### PR TITLE
research(erdos-744-incomplete-01): fourth corner of max-cut/min-uncut square [VERIFIED]

### DIFF
--- a/proofs/Proofs/Erdos744Problem.lean
+++ b/proofs/Proofs/Erdos744Problem.lean
@@ -376,6 +376,26 @@ theorem maxCut_eq_zero_iff {V : Type*} [Fintype V] [LinearOrder V]
     have hle := maxCut_le_edgeCount G
     omega
 
+/-- **The bipartition number saturates the edge count iff `G` is edgeless.**
+`bipartitionNumber G = edgeCount G ↔ edgeCount G = 0`: every edge is monochromatic under
+*every* coloring (nothing can be cut) exactly when there are no edges at all.  This is the
+fourth and final "corner" of the max-cut / min-uncut square, the exact dual of
+`maxCut_eq_edgeCount_iff` (`maxCut = edgeCount ↔ bipartite`):
+
+| quantity | `= 0` | `= edgeCount` |
+|----------|-------|---------------|
+| `maxCut` | edgeless (`maxCut_eq_zero_iff`) | bipartite (`maxCut_eq_edgeCount_iff`) |
+| `bipartitionNumber` | bipartite (`bipartitionNumber_eq_zero_iff`) | edgeless (*this lemma*) |
+
+Immediate from the complementarity `bipartitionNumber G + maxCut G = edgeCount G` and
+`maxCut_eq_zero_iff`. -/
+theorem bipartitionNumber_eq_edgeCount_iff {V : Type*} [Fintype V] [LinearOrder V]
+    (G : SimpleGraph' V) [DecidableRel G.Adj] :
+    bipartitionNumber G = edgeCount G ↔ edgeCount G = 0 := by
+  rw [← maxCut_eq_zero_iff]
+  have h := bipartitionNumber_add_maxCut G
+  omega
+
 /--
 **The f_k(n) Function**
 

--- a/research/problems/erdos-744-incomplete-01/knowledge.md
+++ b/research/problems/erdos-744-incomplete-01/knowledge.md
@@ -118,3 +118,35 @@ VERIFIED green via direct lean-elab vs pinned Mathlib v4.26.0 (docker containerd
 exit 0, no errors; `#print axioms` on both = `[propext, Classical.choice, Quot.sound]`.
 Gallery meta erdos-744: lineCount 578→614, leanFile.theoremCount 20→22 (top-level curated
 theoremCount 14 left as-is — different convention).
+
+## Session 2026-07-10 (researcher-3) — fourth corner of the max-cut/min-uncut square (VERIFIED)
+
+**Mode**: REVISIT (MODERATE) · **Outcome**: progress (1 theorem, 0 new axioms), **VERIFIED**
+via direct `lake env lean` single-file elaboration against pinned Mathlib v4.26.0 oleans
+(docker image build still hits containerd meta.db I/O error; single-file elab is exit 0, only
+two pre-existing `unused variable` warnings in the untouched `f_*` theorems).
+
+**Contribution.** Added `bipartitionNumber_eq_edgeCount_iff : bipartitionNumber G = edgeCount G ↔ edgeCount G = 0`
+— the fourth and final "corner" of the max-cut / min-uncut characterization square, the exact
+dual of the existing `maxCut_eq_edgeCount_iff`:
+
+| quantity | `= 0` | `= edgeCount` |
+|----------|-------|---------------|
+| `maxCut` | edgeless (`maxCut_eq_zero_iff`) | bipartite (`maxCut_eq_edgeCount_iff`) |
+| `bipartitionNumber` | bipartite (`bipartitionNumber_eq_zero_iff`) | **edgeless (this lemma)** |
+
+Proof mirrors `maxCut_eq_edgeCount_iff` exactly: `rw [← maxCut_eq_zero_iff]; have h := bipartitionNumber_add_maxCut G; omega`.
+`#print axioms` = `[propext, Classical.choice, Quot.sound]` (does NOT touch `rodl_tuza_theorem`).
+
+**File state:** 1 axiom (`rodl_tuza_theorem`, tautological/untouched — converting overclaims,
+prior integrity finding), 0 sorries. 614→634 lines. meta.lineCount synced 614→634; curated
+meta.theoremCount left at 14 (per prior-session convention: curated headline count, not raw).
+
+**No follow-up questions:** engine is saturated (all four extremal corners now present); the
+Erdős #744 conjecture status is unchanged (disproved), remaining directions are the untouched
+tautological axiom and the f_k(n) table.
+
+**Verification path (REUSABLE):** docker down but `cd proofs && ./bin/lake env lean Proofs/<File>.lean`
+works — `lake env` is allowed by the safety wrapper (only `lake build` is blocked), and Mathlib
+oleans are present at `.lake/packages/mathlib/.lake/build/lib/lean/Mathlib.olean`. Single-file
+elaboration does not rebuild Mathlib, so it is safe and fast (~exit 0 in seconds).

--- a/src/data/proofs/erdos-744/meta.json
+++ b/src/data/proofs/erdos-744/meta.json
@@ -59,7 +59,7 @@
       "erdos_744_statement theorem: combined main result"
     ],
     "axiomCount": 1,
-    "lineCount": 614,
+    "lineCount": 634,
     "assumptions": "1 axiom: rodl_tuza_theorem (the deep Rödl–Tuza 1985 result, stated as an assumption since a full formalization of the extremal argument is out of scope). The chromatic number is now defined intrinsically (least number of colors admitting a proper coloring) rather than axiomatized, and is proved well-defined by chromaticNumber_le_card. 0 sorries.",
     "theoremCount": 14,
     "definitionCount": 14

--- a/src/data/research/problems/erdos-744-incomplete-01.json
+++ b/src/data/research/problems/erdos-744-incomplete-01.json
@@ -34,12 +34,14 @@
       "monochromaticEdges G c : ℕ — count of same-colored adjacent pairs u<v (Erdos744Problem.lean:99)",
       "bipartitionNumber G := inf over c:V→Bool of monochromaticEdges G c — total, sorry-free, no chromaticNumber axiom (Erdos744Problem.lean:115)",
       "monochromaticEdges_eq_zero_iff: c has no monochromatic edge ↔ proper 2-coloring (Erdos744Problem.lean:120)",
-      "bipartitionNumber_eq_zero_iff: bipartitionNumber G = 0 ↔ G properly 2-colorable — intrinsic bipartiteness, 0-axiom (Erdos744Problem.lean:136)"
+      "bipartitionNumber_eq_zero_iff: bipartitionNumber G = 0 ↔ G properly 2-colorable — intrinsic bipartiteness, 0-axiom (Erdos744Problem.lean:136)",
+      "bipartitionNumber_eq_edgeCount_iff : bipartitionNumber G = edgeCount G ↔ edgeCount G = 0 — the fourth/final corner of the max-cut/min-uncut square (dual of maxCut_eq_edgeCount_iff), bipartitionNumber saturates edgeCount iff G edgeless. Proof rw[← maxCut_eq_zero_iff]; complementarity; omega [VERIFIED axiom-free, lean-elab exit 0, #print axioms = propext/Classical.choice/Quot.sound]"
     ],
     "insights": [
       "The original bipartitionNumber was Nat.find ⟨witness, sorry⟩ over a metavariable predicate p — ill-formed, not a real definition; the right completion is a redefinition, not discharging the sorry.",
       "Realizing the bipartition number as min monochromatic edges over 2-colorings avoids the chromaticNumber axiom entirely: bipartiteness becomes the intrinsic property bipartitionNumber = 0.",
-      "log_conjecture_false needs only f 4 n = 3 by definition (no Rödl-Tuza axiom): #print axioms shows it depends only on propext/Classical/Quot."
+      "log_conjecture_false needs only f 4 n = 3 by definition (no Rödl-Tuza axiom): #print axioms shows it depends only on propext/Classical/Quot.",
+      "The four extremal characterizations of the bipartitionNumber/maxCut engine form a 2x2 square: maxCut=0⟺edgeless, maxCut=edgeCount⟺bipartite, bipartitionNumber=0⟺bipartite, bipartitionNumber=edgeCount⟺edgeless. All four follow from the single complementarity identity bipartitionNumber+maxCut=edgeCount plus one of the ⟺ endpoints via omega."
     ],
     "mathlibGaps": [],
     "nextSteps": [


### PR DESCRIPTION
## Summary
Research session for `erdos-744-incomplete-01`. The intrinsic `bipartitionNumber` / `maxCut` engine in `Erdos744Problem.lean` is heavily saturated (complementarity, both `≤ edgeCount` bounds, and two of the four extremal `iff` characterizations). This adds the **one missing corner**.

## Progress
Added one axiom-free theorem (mirrors the existing `maxCut_eq_edgeCount_iff` exactly):

- `bipartitionNumber_eq_edgeCount_iff : bipartitionNumber G = edgeCount G ↔ edgeCount G = 0`

This completes the 2×2 square of extremal characterizations built on the single complementarity identity `bipartitionNumber G + maxCut G = edgeCount G`:

| quantity | `= 0` | `= edgeCount` |
|----------|-------|---------------|
| `maxCut` | edgeless (`maxCut_eq_zero_iff`) | bipartite (`maxCut_eq_edgeCount_iff`) |
| `bipartitionNumber` | bipartite (`bipartitionNumber_eq_zero_iff`) | **edgeless (this lemma)** |

`bipartitionNumber` saturates the edge count exactly when *no* edge can be cut under any coloring — i.e. when `G` is edgeless. Proof: `rw [← maxCut_eq_zero_iff]; have h := bipartitionNumber_add_maxCut G; omega`.

## Files modified
- `proofs/Proofs/Erdos744Problem.lean` (614→634 lines, +1 theorem, 0 new axioms)
- `src/data/proofs/erdos-744/meta.json` (lineCount 614→634)
- `src/data/research/problems/erdos-744-incomplete-01.json`, `research/problems/erdos-744-incomplete-01/knowledge.md`

## Verification
**VERIFIED.** Docker image build is down (containerd `meta.db` input/output error), but single-file elaboration against the pinned Mathlib v4.26.0 oleans succeeds:
- `./bin/lake env lean Proofs/Erdos744Problem.lean` → **exit 0**, no errors (only two pre-existing `unused variable` warnings in the untouched `f_*` theorems).
- `#print axioms Erdos744.bipartitionNumber_eq_edgeCount_iff` = `[propext, Classical.choice, Quot.sound]` — does **not** depend on the file's `rodl_tuza_theorem` axiom.

## Status
**Outcome**: completed (axiom-free structural completion of the extremal square; Erdős #744 conjecture status unchanged — disproved).
**Next Steps**: none proposed — the max-cut/min-uncut engine's extremal corners are now all present; the remaining `rodl_tuza_theorem` axiom is tautological and converting it would overclaim (prior integrity finding).

🤖 Generated by researcher-3