### PR TITLE
research(euler-polyhedral-formula-oq-02-oq-02): Gauss-Bonnet sign trichotomy for genus surfaces

### DIFF
--- a/proofs/Proofs/EulerPolyhedralOQ02OQ02.lean
+++ b/proofs/Proofs/EulerPolyhedralOQ02OQ02.lean
@@ -551,6 +551,62 @@ theorem genusSurfaceCGB_genus_of_chi (g : ℕ) :
     2 * (g : ℤ) = 2 - (genusSurfaceCGB g).chi := by
   rw [genusSurfaceCGB_chi]; ring
 
+-- ============================================================================
+-- Part XIV: The Gauss-Bonnet sign trichotomy — total curvature detects the
+--           uniformization regime (spherical / flat / hyperbolic) from the genus
+-- ============================================================================
+
+/-- **Positive total curvature ⇔ the sphere (`g = 0`).**  Since `∫Pf(Σ_g) = 4π(1 − g)`
+    and `2π > 0`, the total Gauss-Bonnet curvature is *positive* exactly for genus `0` —
+    the spherical (positively-curved) case.  This is the `χ > 0` corner of the
+    uniformization trichotomy, read off directly from the genus. -/
+theorem genusSurfaceCGB_totalPfaffian_pos_iff (g : ℕ) :
+    0 < (genusSurfaceCGB g).totalPfaffian ↔ g = 0 := by
+  have hpi : (0 : ℝ) < 2 * π := by positivity
+  rw [genusSurfaceCGB_totalPfaffian, mul_pos_iff]
+  constructor
+  · rintro (⟨h, -⟩ | ⟨-, h⟩)
+    · have h1 : (g : ℝ) < 1 := by linarith
+      have : g < 1 := by exact_mod_cast h1
+      omega
+    · exact absurd h (lt_asymm hpi)
+  · intro hg; subst hg; exact Or.inl ⟨by push_cast; norm_num, hpi⟩
+
+/-- **Zero total curvature ⇔ the torus (`g = 1`).**  The total Gauss-Bonnet curvature
+    `4π(1 − g)` vanishes exactly for genus `1` — the flat (Euclidean) case.  This is the
+    `χ = 0` corner of the uniformization trichotomy. -/
+theorem genusSurfaceCGB_totalPfaffian_eq_zero_iff (g : ℕ) :
+    (genusSurfaceCGB g).totalPfaffian = 0 ↔ g = 1 := by
+  have hpi : (2 * π : ℝ) ≠ 0 := by positivity
+  rw [genusSurfaceCGB_totalPfaffian, mul_eq_zero]
+  constructor
+  · rintro (h | h)
+    · have : (g : ℝ) = 1 := by linarith
+      exact_mod_cast this
+    · exact absurd h hpi
+  · intro hg; subst hg; exact Or.inl (by push_cast; ring)
+
+/-- **Negative total curvature ⇔ higher genus (`g ≥ 2`).**  The total Gauss-Bonnet
+    curvature `4π(1 − g)` is *negative* exactly for genus `≥ 2` — the hyperbolic
+    (negatively-curved) case.  Together with `genusSurfaceCGB_totalPfaffian_pos_iff` and
+    `..._eq_zero_iff` this is the full **Gauss-Bonnet sign trichotomy**: the sign of the
+    total curvature of a closed orientable surface reads off its uniformization type
+    (spherical `g = 0`, flat `g = 1`, hyperbolic `g ≥ 2`) directly from the genus. -/
+theorem genusSurfaceCGB_totalPfaffian_neg_iff (g : ℕ) :
+    (genusSurfaceCGB g).totalPfaffian < 0 ↔ 2 ≤ g := by
+  have hpi : (0 : ℝ) < 2 * π := by positivity
+  rw [genusSurfaceCGB_totalPfaffian, mul_neg_iff]
+  constructor
+  · rintro (⟨-, h⟩ | ⟨h, -⟩)
+    · exact absurd h (lt_asymm hpi)
+    · have h1 : (1 : ℝ) < (g : ℝ) := by linarith
+      have : 1 < g := by exact_mod_cast h1
+      omega
+  · intro hg
+    refine Or.inr ⟨?_, hpi⟩
+    have : (2 : ℝ) ≤ (g : ℝ) := by exact_mod_cast hg
+    linarith
+
 end ChernGaussBonnet
 
 end

--- a/src/data/proofs/euler-polyhedral-formula-oq-02-oq-02/meta.json
+++ b/src/data/proofs/euler-polyhedral-formula-oq-02-oq-02/meta.json
@@ -154,9 +154,9 @@
       "Real"
     ],
     "namespace": "ChernGaussBonnet",
-    "lineCount": 556,
+    "lineCount": 612,
     "axiomCount": 0,
-    "theoremCount": 59,
+    "theoremCount": 62,
     "definitionCount": 12,
     "path": "Proofs/EulerPolyhedralOQ02OQ02.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

Adds the **Gauss-Bonnet sign trichotomy** to `EulerPolyhedralOQ02OQ02.lean` (Chern-Gauss-Bonnet formalization): the sign of the total curvature `∫Pf(Σ_g) = 4π(1 − g)` detects the uniformization regime of a closed orientable surface directly from its genus `g`.

| Theorem | Statement | Geometry |
|---|---|---|
| `genusSurfaceCGB_totalPfaffian_pos_iff` | `0 < ∫Pf ↔ g = 0` | spherical (positive curvature) |
| `genusSurfaceCGB_totalPfaffian_eq_zero_iff` | `∫Pf = 0 ↔ g = 1` | flat (torus) |
| `genusSurfaceCGB_totalPfaffian_neg_iff` | `∫Pf < 0 ↔ 2 ≤ g` | hyperbolic (negative curvature) |

## Context

The file already contains a *generic* `CGBManifold.totalPfaffian_pos_iff` phrased in terms of the abstract Euler characteristic `M.chi`. This PR specializes the **full three-way** sign law to the concrete genus surfaces `Σ_g`, pinning each sign regime to an explicit condition on the integer genus `g`. It rounds out the genus-surface classification (χ formula, additivity, injectivity, genus recovery) with its geometric/uniformization content: the sign of total Gauss-Bonnet curvature = the surface's uniformization type.

## Proof

Each proof rewrites `genusSurfaceCGB_totalPfaffian` to `(2 − 2g)·(2π)` and applies `mul_pos_iff` / `mul_eq_zero` / `mul_neg_iff` against `2π > 0` (`positivity`), then closes the integer side with a cast + `omega`/`linarith`. 0 axiom declarations, 0 sorries, no `native_decide`.

Gallery `meta.json` synced: `overview.lineCount` 556 → 612, `theoremCount` 59 → 62.

## Verification status

**UNVERIFIED** — the docker Lean image build fails with a `containerd meta.db input/output error` (build infrastructure down this session). The proofs use only standard ordered-field API (`mul_pos_iff`, `mul_neg_iff`, `mul_eq_zero`, `positivity`, `omega`) on top of existing verified lemmas in the file, so confidence is high.

🤖 Generated with [Claude Code](https://claude.com/claude-code)