### PR TITLE
research(erdos-748): achievability of max sum-free size ⌈n/2⌉

### DIFF
--- a/proofs/Proofs/Erdos748Problem.lean
+++ b/proofs/Proofs/Erdos748Problem.lean
@@ -566,6 +566,34 @@ Green's proof shows type 1 and 2 dominate the count.
 Sum-free sets are related to Schur numbers.
 The maximum size of a sum-free subset of [1,n] is ⌈n/2⌉.
 -/
+
+/--
+**Achievability of the maximum sum-free size `⌈n/2⌉`.**
+There is a sum-free subset of `{1,…,n}` of cardinality exactly `⌈n/2⌉ = (n+1)/2`,
+namely the upper half `U = {⌊n/2⌋+1, …, n}`: it is sum-free by
+`upperHalf_sumFree`, and `Nat.card_Icc` computes `|U| = n − ⌊n/2⌋ = ⌈n/2⌉`.
+
+This formalises the *achievable* direction of the Part VII prose claim that "the
+maximum size of a sum-free subset of `[1,n]` is `⌈n/2⌉`": the extremal size is
+attained. (The matching upper bound — that no sum-free subset can exceed
+`⌈n/2⌉` — is the classical hard direction and is left to the informal discussion.)
+It also witnesses that the exponent in `sharp_lower_bound` comes from a single
+genuine sum-free set of that size, not merely a counting artefact. -/
+theorem exists_sumFree_card_ceil (n : ℕ) :
+    ∃ A ∈ sumFreeSubsets n, A.card = (n + 1) / 2 := by
+  set U : Finset ℕ := Finset.Icc (n / 2 + 1) n with hU
+  refine ⟨U, ?_, ?_⟩
+  · -- `U` is a sum-free subset of `{1,…,n}`.
+    rw [sumFreeSubsets, Finset.mem_filter, Finset.mem_powerset]
+    refine ⟨?_, ?_⟩
+    · rw [hU]; exact Finset.Icc_subset_Icc (by omega) (le_refl n)
+    · apply upperHalf_sumFree n U
+      intro a ha
+      rw [hU, Finset.mem_Icc] at ha
+      exact ha
+  · -- `|U| = n − ⌊n/2⌋ = ⌈n/2⌉ = (n+1)/2`.
+    rw [hU, Nat.card_Icc]; omega
+
 /-
 ## Part VIII: OEIS A007865
 -/

--- a/src/data/proofs/erdos-748/meta.json
+++ b/src/data/proofs/erdos-748/meta.json
@@ -58,7 +58,7 @@
       "erdos_748_summary: combining all results"
     ],
     "axiomCount": 2,
-    "lineCount": 635,
+    "lineCount": 663,
     "assumptions": "2 axiom(s): green_upper_bound (Green 2004), precise_asymptotic (Green/Sapozhenko). Both are deep results from the literature. The lower bound is fully proved (no longer an axiom), and sharpened to f(n) ≥ 2^{⌈n/2⌉} (sharp_lower_bound) — the best the upper-half construction yields. See the Lean source for details.",
     "theoremCount": 21,
     "definitionCount": 5,
@@ -180,7 +180,7 @@
       "Finset"
     ],
     "namespace": "Erdos748",
-    "lineCount": 609,
+    "lineCount": 663,
     "axiomCount": 2,
     "theoremCount": 22,
     "definitionCount": 5,


### PR DESCRIPTION
## Summary

Erdős Problem #748 (Cameron–Erdős conjecture on sum-free sets). This adds one clean, well-motivated theorem to the saturated lower-bound theory in `Erdos748Problem.lean`.

**New theorem `exists_sumFree_card_ceil`:** there is a sum-free subset of `{1,…,n}` of cardinality **exactly** `⌈n/2⌉ = (n+1)/2`, namely the upper half `U = {⌊n/2⌋+1, …, n}`.

## Motivation

Part VII of the file states in prose that "the maximum size of a sum-free subset of `[1,n]` is `⌈n/2⌉`" but never formalizes it. This theorem provides the **achievable** direction: the extremal size is attained. It also witnesses that the exponent in `sharp_lower_bound` comes from a single genuine sum-free set of that size, not merely a counting artefact. (The matching upper bound — no sum-free subset can exceed `⌈n/2⌉` — is the classical hard direction, left informal.)

## Proof

Mirrors `sharp_lower_bound` line-for-line: `upperHalf_sumFree` gives sum-freeness of `U`, and the cardinality step `rw [hU, Nat.card_Icc]; omega` is copied verbatim from the already-verified `sharp_lower_bound` (`|U| = n − ⌊n/2⌋ = (n+1)/2`).

## Verification status

⚠️ **UNVERIFIED** — the Docker Lean image build is down this session (`containerd meta.db input/output error` during image build; host disk healthy at 121Gi free). By-eye verification: the membership block and card computation are copied from the verified sibling `sharp_lower_bound` in the same file. High confidence.

Gallery meta `lineCount` synced 635→663 (both fields). No new axioms; `theoremCount` left unchanged (pre-existing convention drift, mechanic-owned).

🤖 Generated with [Claude Code](https://claude.com/claude-code)