### PR TITLE
audit(erdos-910): reconcile assumptions prose with axiomCount=2

### DIFF
--- a/src/data/proofs/erdos-910/meta.json
+++ b/src/data/proofs/erdos-910/meta.json
@@ -57,7 +57,7 @@
       "erdos_910_both_false: combined result disproving both conjectures"
     ],
     "lineCount": 155,
-    "assumptions": "1 axiom: rudin_theorem_ch. See Lean source for the complete statement.",
+    "assumptions": "2 axiom declarations, both encoding the same result — Rudin's 1958 construction under CH: `rudin_theorem_ch` in Erdos910OQ01.lean and `rudin_theorem` in the companion Erdos910Problem.lean. Each asserts that under CH there exists a connected planar Rudin set with exactly continuum-many connected subsets. See Lean source for the complete statements.",
     "mathlib_version": "4.26.0",
     "theoremCount": 6,
     "definitionCount": 7,


### PR DESCRIPTION
## Integrity Audit: erdos-910 (Connected Subsets of Euclidean Space, Rudin 1958)

Re-audit of a stale entry (last audited 2026-05-04, 3×). Verified against both Lean sources.

### Verified correct
- **Main file `Erdos910OQ01.lean`**: 1 axiom (`rudin_theorem_ch`), 0 sorries, 7 defs, 6 theorems — matches `leanFile` block.
- **Companion `Erdos910Problem.lean`**: 1 axiom (`rudin_theorem`) encoding the same Rudin construction.
- **Aggregate axiomCount = 2** matches `meta.axiomCount`. `status: axiomatized`, `badge: axiom` correct (Tier C — Rudin's deep construction honestly axiomatized).
- No True stubs, no `native_decide`. The main theorems (`erdos_first_conjecture_false`, `erdos_second_conjecture_false`, `erdos_910_both_false`) genuinely prove the negations modulo the axiom. Disclosure thorough in `proofStrategy` and the `rudin-axiom` section.

### One nit fixed
The `assumptions` field read **"1 axiom: rudin_theorem_ch"** while the visible `meta.axiomCount` is **2**. Both axioms encode the same Rudin 1958 theorem across the two files. Reconciled the prose so disclosure matches the headline count. No mathematical change.

Also bumps the audit-tracker entry.

---
Discovered during gallery integrity audit.