### PR TITLE
fix(burnside-counting): repair Mathlib-v4.26 drift breaking BurnsideCounting.lean [VERIFIED 0/0]

### DIFF
--- a/proofs/Proofs/BurnsideCounting.lean
+++ b/proofs/Proofs/BurnsideCounting.lean
@@ -623,10 +623,9 @@ number of rotation orbits (necklaces) of `Coloring p k` satisfies
 nonzero rotation is a unit of the field `ZMod p` and hence fixes only the `k` constant
 colorings (`fixedBy_card_of_isUnit`).  Summing over the `p` rotations and applying the
 Burnside engine `sum_fixedBy_eq_card_necklaces_mul` gives the identity. -/
-theorem necklaces_prime_length_mul {p : ℕ} (hp : p.Prime) (k : ℕ) :
+theorem necklaces_prime_length_mul {p : ℕ} [NeZero p] (hp : p.Prime) (k : ℕ) :
     @Fintype.card (Quotient (@coloringSetoid p k _)) (coloringQuotientFintype p k) * p
       = k ^ p + (p - 1) * k := by
-  haveI : NeZero p := ⟨hp.pos.ne'⟩
   haveI : Fact p.Prime := ⟨hp⟩
   -- Fixed-point count at each rotation: `kᵖ` at the identity, `k` at every unit.
   have hf : ∀ a : ZMod p,
@@ -637,7 +636,7 @@ theorem necklaces_prime_length_mul {p : ℕ} (hp : p.Prime) (k : ℕ) :
     · subst ha
       rw [if_pos rfl]
       have huniv : ∀ c : Coloring p k, IsFixedByRotation (0 : ZMod p) c :=
-        fun c => zero_vadd c
+        fun c => by simp only [IsFixedByRotation, zero_vadd]
       rw [Fintype.card_congr (Equiv.subtypeUnivEquiv huniv)]
       show Fintype.card (Fin p → Fin k) = k ^ p
       rw [Fintype.card_fun, Fintype.card_fin, Fintype.card_fin]
@@ -660,6 +659,7 @@ rearranges to `kᵖ − k = (kᵖ + (p−1)·k) − ((p−1)·k + k)`, a differe
 of `p`: the `p` cyclic rotations partition the `kᵖ − k` non-constant colorings into
 orbits of size exactly `p`.  No `native_decide`, no `Lean.ofReduceBool`. -/
 theorem prime_dvd_pow_sub_self {p : ℕ} (hp : p.Prime) (k : ℕ) : p ∣ k ^ p - k := by
+  haveI : NeZero p := ⟨hp.pos.ne'⟩
   have h := necklaces_prime_length_mul hp k
   have hdvd1 : p ∣ k ^ p + (p - 1) * k := by rw [← h]; exact dvd_mul_left p _
   have hpk : (p - 1) * k + k = p * k := by
@@ -667,4 +667,4 @@ theorem prime_dvd_pow_sub_self {p : ℕ} (hp : p.Prime) (k : ℕ) : p ∣ k ^ p 
   have hdvd2 : p ∣ (p - 1) * k + k := by rw [hpk]; exact dvd_mul_right p k
   have hrw : k ^ p - k = (k ^ p + (p - 1) * k) - ((p - 1) * k + k) := by omega
   rw [hrw]
-  exact Nat.dvd_sub' hdvd1 hdvd2
+  exact Nat.dvd_sub hdvd1 hdvd2


### PR DESCRIPTION
## Drift repair — `BurnsideCounting.lean` was broken on `main` [VERIFIED 0/0]

PR #36770 (`necklaces_prime_length_mul` + `prime_dvd_pow_sub_self` — Fermat's Little Theorem via Burnside) was shipped **UNVERIFIED** during the docker outage and does **not compile** against Mathlib v4.26 — the entire module fails to build on `main`. Direct `lean` elaboration surfaces three defects:

1. **`failed to synthesize NeZero p`** — the statement of `necklaces_prime_length_mul` uses `coloringSetoid`/`coloringQuotientFintype` (both require `[NeZero p]`), but only `(hp : p.Prime)` is in scope. **Fix:** add a `[NeZero p]` instance binder and drop the now-redundant body `haveI`; the sole caller `prime_dvd_pow_sub_self` supplies it via `haveI : NeZero p := ⟨hp.pos.ne'⟩`.
2. **`zero_vadd c` no longer elaborates** (application type mismatch). **Fix:** `simp only [IsFixedByRotation, zero_vadd]`.
3. **`Nat.dvd_sub'` removed/renamed** in v4.26. **Fix:** `Nat.dvd_sub`.

## Verification — VERIFIED (docker infra down)
Direct `lean` elaboration against pinned Mathlib **v4.26.0** oleans:

- **EXIT 0, 0 errors, 0 sorries.**
- `#print axioms` on `necklaces_prime_length_mul`, `prime_dvd_pow_sub_self`, and `fixed_point_sum_binary_4` ⇒ `[propext, Classical.choice, Quot.sound]` only (**no `sorryAx`, no `Lean.ofReduceBool`**).

## Also closes research slug `burnside-counting-oq-02`
The OQ ("verify `fixed_point_sum_binary_4` via `native_decide`/`decide`") was already satisfied — that theorem is proved by kernel `decide` and is confirmed axiom-clean here.

4 lines changed (2 statement/body edits + 1 caller instance + 2 lemma-name fixes; net 0 lines). `axiomCount` unchanged (0); no meta sync needed.
