### PR TITLE
research(e-transcendental-oq-02-oq-06): contrapositive of normal_imp_irrational — rationals are never normal [UNVERIFIED]

### DIFF
--- a/proofs/Proofs/ETranscendentalOQ02OQ06.lean
+++ b/proofs/Proofs/ETranscendentalOQ02OQ06.lean
@@ -1,0 +1,84 @@
+import Mathlib.Tactic
+import Proofs.ETranscendentalOQ02
+
+/-
+# The contrapositive of `normal_imp_irrational`: rationals are never normal
+
+## Context
+
+The parent entry `ETranscendentalOQ02` ("Is e a Normal Number?") proves the
+positive implication
+
+  `normal_imp_irrational : IsNormalInBase b x → Irrational x`   (base `b ≥ 2`),
+
+using that a rational's base-`b` expansion is eventually periodic and hence has a
+missing digit block, so some block frequency tends to `0` rather than to the
+positive normal value `b^(-k)`.
+
+The open-question child `e-transcendental-oq-02-oq-06` asks to package the
+*contrapositive* as a reusable standalone lemma:
+
+  `x ∈ ℚ  ⇒  ¬ IsNormalInBase b x`.
+
+That is exactly what a downstream user needs to rule out normality of a concrete
+number once it is known to be rational. This file records the contrapositive and
+its immediate specializations (rational / integer / natural casts, and the
+absolute-normality level), each obtained from `normal_imp_irrational` and the
+Mathlib facts `Rat.not_irrational` / `Int.not_irrational` / `Nat.not_irrational`.
+
+None of these introduce assumptions: they are corollaries of a theorem already
+machine-checked in the parent file. The only `axiom` in the parent
+(`e_absolutely_normal`, the genuinely open conjecture that `e` is normal) is not
+used here.
+
+## Results
+
+- `rational_not_normal`      : `¬ IsNormalInBase b (q : ℝ)` for `q : ℚ`.
+- `intCast_not_normal`       : `¬ IsNormalInBase b (n : ℝ)` for `n : ℤ`.
+- `natCast_not_normal`       : `¬ IsNormalInBase b (n : ℝ)` for `n : ℕ`.
+- `normal_ne_ratCast`        : a normal number differs from every rational.
+- `rational_not_absolutely_normal` : `¬ IsAbsolutelyNormal (q : ℝ)`.
+-/
+
+open ETranscendentalOQ02
+
+namespace ETranscendentalOQ02OQ06
+
+/-- **Rationals are never normal (the contrapositive of `normal_imp_irrational`).**
+    If `q : ℚ`, then `(q : ℝ)` is not normal in any base `b ≥ 2`: normality would
+    force irrationality by `normal_imp_irrational`, contradicting
+    `Rat.not_irrational`. This is the standalone contrapositive requested by the
+    `e-transcendental-oq-02-oq-06` open question. -/
+theorem rational_not_normal (b : ℕ) (hb : 2 ≤ b) (q : ℚ) :
+    ¬ IsNormalInBase b (q : ℝ) :=
+  fun hn => q.not_irrational (normal_imp_irrational b hb (q : ℝ) hn)
+
+/-- **Integers are never normal.**  Specialization of `rational_not_normal` to
+    integer casts, via `Int.not_irrational`. -/
+theorem intCast_not_normal (b : ℕ) (hb : 2 ≤ b) (n : ℤ) :
+    ¬ IsNormalInBase b (n : ℝ) :=
+  fun hn => (Int.not_irrational n) (normal_imp_irrational b hb (n : ℝ) hn)
+
+/-- **Naturals are never normal.**  Specialization of `rational_not_normal` to
+    natural-number casts, via `Nat.not_irrational`. -/
+theorem natCast_not_normal (b : ℕ) (hb : 2 ≤ b) (n : ℕ) :
+    ¬ IsNormalInBase b (n : ℝ) :=
+  fun hn => (Nat.not_irrational n) (normal_imp_irrational b hb (n : ℝ) hn)
+
+/-- **A normal number is distinct from every rational.**  The pointwise form of
+    the contrapositive: if `x` is normal in base `b ≥ 2`, then `x ≠ (q : ℝ)` for
+    every `q : ℚ`. Immediate from `rational_not_normal` (substituting a purported
+    equality would make a rational normal). -/
+theorem normal_ne_ratCast (b : ℕ) (hb : 2 ≤ b) (x : ℝ) (hx : IsNormalInBase b x)
+    (q : ℚ) : x ≠ (q : ℝ) := by
+  rintro rfl
+  exact rational_not_normal b hb q hx
+
+/-- **Rationals are not absolutely normal.**  A rational cannot be normal in even
+    a single base, so in particular it is not normal in *every* base. Uses
+    `IsAbsolutelyNormal` at the concrete base `2`. -/
+theorem rational_not_absolutely_normal (q : ℚ) :
+    ¬ IsAbsolutelyNormal (q : ℝ) :=
+  fun hn => rational_not_normal 2 (le_refl 2) q (hn 2 (le_refl 2))
+
+end ETranscendentalOQ02OQ06

--- a/research/problems/e-transcendental-oq-02-oq-06/state.md
+++ b/research/problems/e-transcendental-oq-02-oq-06/state.md
@@ -1,25 +1,46 @@
 # Research State: e-transcendental-oq-02-oq-06
 
 ## Current State
-**Phase**: OBSERVE
+**Phase**: ACT
 **Path**: full
 **Since**: 2026-07-04T12:34:40-07:00
-**Iteration**: 1
+**Iteration**: 2
 
 ## Current Focus
-Initial problem understanding. Read problem.md and gather context.
+Package the contrapositive `x ∈ ℚ ⇒ ¬ IsNormalInBase b x` as a reusable
+standalone lemma, per the open-question goal.
+
+## Key Finding
+The positive implication `normal_imp_irrational : IsNormalInBase b x → Irrational x`
+is **already a fully machine-checked theorem** in the parent file
+`ETranscendentalOQ02.lean` (line 663) — it is NOT an axiom. The only remaining
+`axiom` in the parent is `e_absolutely_normal` (the genuinely open conjecture that
+`e` is normal, which cannot be discharged). So the axiom-discharge framing in
+`problem.md` was already satisfied by the parent; the productive increment is to
+expose the explicitly-requested contrapositive form.
 
 ## Active Approach
-None yet.
+Companion file `ETranscendentalOQ02OQ06.lean` deriving, from `normal_imp_irrational`
+and Mathlib's `Rat.not_irrational` / `Int.not_irrational` / `Nat.not_irrational`:
+- `rational_not_normal` : `¬ IsNormalInBase b (q : ℝ)` (the requested contrapositive)
+- `intCast_not_normal`, `natCast_not_normal` : integer / natural specializations
+- `normal_ne_ratCast` : a normal number differs from every rational
+- `rational_not_absolutely_normal` : `¬ IsAbsolutelyNormal (q : ℝ)`
+
+All are term-mode corollaries introducing no new assumptions.
 
 ## Attempt Count
-- Total attempts: 0
-- Current approach attempts: 0
-- Approaches tried: 0
+- Total attempts: 1
+- Current approach attempts: 1
+- Approaches tried: 1
 
 ## Blockers
-None.
+Docker build infrastructure DOWN this session (containerd `meta.db` / content-blob
+input/output errors at the image-build step; host disk healthy, ~120 GiB free).
+Verification not possible — shipped UNVERIFIED. Proofs are one-line corollaries of
+an already-verified theorem using confirmed-present Mathlib API, so confidence is high.
 
 ## Next Action
-Read problem.md thoroughly and acquire full context.
-Then move to ORIENT phase to explore literature and related proofs.
+Re-run `./proofs/scripts/docker-build.sh Proofs.ETranscendentalOQ02OQ06` once docker
+infra is restored; then consider a concrete instance (e.g. an explicit non-normal
+rational such as `1/3` in base 10).


### PR DESCRIPTION
## Summary

Open question `e-transcendental-oq-02-oq-06` asks to package the **contrapositive** of the parent's normality lemma as a reusable standalone result:
```
x ∈ ℚ  ⇒  ¬ IsNormalInBase b x   (base b ≥ 2)
```

**Key finding:** the positive direction `normal_imp_irrational : IsNormalInBase b x → Irrational x` is *already a fully machine-checked theorem* in the parent `ETranscendentalOQ02.lean` (line 663), not an axiom. The only remaining `axiom` in the parent is `e_absolutely_normal` (the genuinely open conjecture that *e* is normal). So the axiom-discharge framing in problem.md was already met by the parent; the productive increment is exposing the requested contrapositive.

## New file: `proofs/Proofs/ETranscendentalOQ02OQ06.lean`

Five term-mode corollaries of `normal_imp_irrational` + Mathlib's `Rat/Int/Nat.not_irrational`, introducing **no new assumptions**:

| Lemma | Statement |
|-------|-----------|
| `rational_not_normal` | `¬ IsNormalInBase b (q : ℝ)` for `q : ℚ` (the requested contrapositive) |
| `intCast_not_normal` | `¬ IsNormalInBase b (n : ℝ)` for `n : ℤ` |
| `natCast_not_normal` | `¬ IsNormalInBase b (n : ℝ)` for `n : ℕ` |
| `normal_ne_ratCast` | a normal number differs from every rational: `x ≠ (q : ℝ)` |
| `rational_not_absolutely_normal` | `¬ IsAbsolutelyNormal (q : ℝ)` |

## Verification status

⚠️ **UNVERIFIED.** Docker build infrastructure is down this session (containerd `meta.db` / content-blob input/output errors at the image-build step; host disk healthy, ~120 GiB free). Verification not possible.

Confidence is high: every proof is a one-line corollary of an already-verified theorem, and the Mathlib API used (`Rat.not_irrational`, `Int.not_irrational`, `Nat.not_irrational`) was confirmed present in the pinned Mathlib. Should be re-run once docker is restored.

No gallery meta change: the parent slug `e-transcendental-oq-02` lists no `additionalFiles`, so this companion needs no meta sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)