### PR TITLE
mechanic: resync lineCount for 4 gallery metas (algebraic-nums-oq07, de-moivre-oq03, erdos-666, kepler-oq04)

### DIFF
--- a/src/data/proofs/de-moivre-oq-03/meta.json
+++ b/src/data/proofs/de-moivre-oq-03/meta.json
@@ -61,7 +61,7 @@
     "dateAdded": "2026-02-26",
     "mathlib_version": "4.26.0",
     "axiomCount": 0,
-    "lineCount": 275,
+    "lineCount": 299,
     "assumptions": "0 axioms, 0 sorries. Fractional powers via Mathlib's cpow_def_of_ne_zero and exp/log. Original root enumeration and distinctness proofs.",
     "theoremCount": 14,
     "definitionCount": 2


### PR DESCRIPTION
## Summary

Four single-file gallery entries have stale `lineCount` in `meta.json` after merged research PRs grew their `.lean` sources without resyncing metadata. No open PR touches these `.lean` files, so the counts are settled — safe to resync to actual `wc -l`.

| slug | meta.lineCount | leanFile.lineCount | actual |
|------|---------------|--------------------|--------|
| algebraic-numbers-countable-oq-07 | 393 → 415 | 381 → 415 | 415 |
| de-moivre-oq-03 | 275 → 299 | (299) | 299 |
| erdos-666 | (458) | 443 → 458 | 458 |
| kepler-conjecture-oq-04 | 1153 → 1191 | 1153 → 1191 | 1191 |

## Skipped (covered / noise)

- **erdos-1059-oq-01-oq-01** — open research PR #37102 modifies the `.lean` → will re-drift
- **euler-polyhedral-formula-oq-02-oq-02** — open research PR #36432 modifies the `.lean` → will re-drift
- **sylow-theorem-oq-04-oq-03** — open research PR #36998 modifies the `.lean` → will re-drift
- **erdos-143** — no-trailing-newline convention (119 content lines, `wc -l`=118); not a drift

Metadata-only change; no Lean sources touched.