### PR TITLE
audit(erdos-907): remove phantom decomposition_continuous_additive reference

### DIFF
--- a/src/data/proofs/erdos-907/meta.json
+++ b/src/data/proofs/erdos-907/meta.json
@@ -34,7 +34,7 @@
       "Full proof that linear_is_additive, continuous_has_continuous_differences, additive_difference_const, continuous_decomposition, sq_has_continuous_differences (all 0-sorry)",
       "Axiomatization of exactly 2 deep results: continuous_additive_is_linear (Cauchy regularity), de_bruijn_theorem (main decomposition theorem)",
       "Regularity remark: a docstring notes that continuous, measurable, or monotone additive functions are all linear (mathematical context only; only the continuous case is stated, as the axiom continuous_additive_is_linear)",
-      "Connection to erdos-908 via decomposition_continuous_additive characterization",
+      "Cross-reference to erdos-908 as a docstring pointer only (Part 9); no formal declaration links the two problems (there is no `decomposition_continuous_additive` in the source)",
       "Summary theorem packaging de Bruijn + continuous direction + additive constancy as conjunction"
     ],
     "axiomCount": 2,


### PR DESCRIPTION
## Gallery Integrity Audit — erdos-907

**Proof**: erdos-907 (Decomposition of Functions with Continuous Differences, de Bruijn 1951)
**Result**: issues-fixed (1 phantom-declaration overstatement)

### Problem

`meta.json` → `originalContributions` bullet #5 read:

> "Connection to erdos-908 via `decomposition_continuous_additive` characterization"

But `decomposition_continuous_additive` **does not exist** anywhere in `proofs/Proofs/Erdos907Problem.lean`. The source's only link to erdos-908 is a one-line docstring comment (Part 9): *"See also Erdős Problem #908 for related questions."*

The entry was also internally contradictory: the `proofStrategy` field already states *"(`decomposition_continuous_additive` does not exist as an axiom in this file.)"* — so `originalContributions` claimed a contribution that another field explicitly denies.

This is the phantom-declaration failure mode: naming a Lean declaration in the contributions list that was never written.

### Fix

Reworded the bullet to describe the cross-reference honestly:

> "Cross-reference to erdos-908 as a docstring pointer only (Part 9); no formal declaration links the two problems (there is no `decomposition_continuous_additive` in the source)"

### Verification (counts all exact)

| Field | meta.json | source |
|-------|-----------|--------|
| lineCount | 232 | 232 ✓ |
| axiomCount | 2 | 2 (`continuous_additive_is_linear`, `de_bruijn_theorem`) ✓ |
| theoremCount | 12 | 12 ✓ |
| definitionCount | 5 | 5 ✓ |
| sorries | 0 | 0 ✓ |
| native_decide | — | 0 (so no `Lean.ofReduceBool`; axiomCount 2 correct) ✓ |

Status `axiomatized` / badge `axiom` correct (2 disclosed deep-result axioms). No other overclaims found; the recently-merged #37173 cleanup was otherwise accurate.

Also bumps the audit-tracker entry for erdos-907 (the prior audit's tracker write was lost to the shared-checkout race).

---
Discovered during gallery integrity audit.