### PR TITLE
research(sylow-theorem-oq-04-oq-03): PSL(2,p) is not solvable for p≥5

### DIFF
--- a/proofs/Proofs/SylowTheoremOQ04OQ03.lean
+++ b/proofs/Proofs/SylowTheoremOQ04OQ03.lean
@@ -914,4 +914,31 @@ theorem not_isSolvable (hp : 5 ≤ p) :
   rw [commutator_eq_top hp] at hlt
   exact lt_irrefl _ hlt
 
+/-- **`PSL(2, p)` is not solvable for `p ≥ 5`.**  Non-solvability descends from the
+cover `SL(2, p)` to the projective quotient through the central extension
+
+    `1 → Z → SL(2, p) → PSL(2, p) → 1`.
+
+The kernel `Z = Z(SL(2, p))` is abelian, hence solvable, and if `PSL(2, p)` were
+solvable then — with a solvable kernel *and* a solvable quotient — the middle group
+`SL(2, p)` would be solvable too (`solvable_of_ker_le_range`).  That contradicts
+`not_isSolvable`, so `PSL(2, p)` is not solvable.
+
+This is the non-solvability of the target group itself, one step past the
+non-solvability of its cover; together with `commutator_PSL_eq_top` (perfectness of
+`PSL(2, p)`) it records that `PSL(2, p)` escapes the entire solvable hierarchy exactly
+on the range `p ≥ 5` where the simplicity theorem turns on. -/
+theorem not_isSolvable_PSL (hp : 5 ≤ p) :
+    ¬ IsSolvable (Matrix.ProjectiveSpecialLinearGroup (Fin 2) (ZMod p)) := by
+  intro hsolv
+  haveI := hsolv
+  -- A solvable quotient and (automatically) solvable central kernel force the middle
+  -- group `SL(2, p)` to be solvable via the central extension.
+  haveI : IsSolvable (Matrix.SpecialLinearGroup (Fin 2) (ZMod p)) :=
+    solvable_of_ker_le_range
+      (Subgroup.center (Matrix.SpecialLinearGroup (Fin 2) (ZMod p))).subtype
+      (QuotientGroup.mk' (Subgroup.center (Matrix.SpecialLinearGroup (Fin 2) (ZMod p))))
+      (by rw [QuotientGroup.ker_mk']; exact (Subgroup.range_subtype _).ge)
+  exact not_isSolvable hp this
+
 end SylowOQ04OQ03

--- a/src/data/proofs/sylow-theorem-oq-04-oq-03/meta.json
+++ b/src/data/proofs/sylow-theorem-oq-04-oq-03/meta.json
@@ -254,12 +254,12 @@
     }
   ],
   "leanFile": {
-    "lineCount": 887,
+    "lineCount": 944,
     "path": "Proofs/SylowTheoremOQ04OQ03.lean",
     "axiomCount": 0,
     "sorries": 0,
     "definitionCount": 8,
-    "theoremCount": 45
+    "theoremCount": 46
   },
   "sorries": 0
 }


### PR DESCRIPTION
## Summary

Adds `not_isSolvable_PSL` to `SylowTheoremOQ04OQ03.lean` — the projective-quotient analogue of the file's existing `not_isSolvable` (non-solvability of the cover `SL(2,p)`).

Non-solvability descends from the cover to `PSL(2,p)` through the central extension
```
1 → Z → SL(2,p) → PSL(2,p) → 1.
```
The kernel `Z = Z(SL(2,p))` is abelian, hence solvable; if `PSL(2,p)` were solvable then — with a solvable kernel *and* solvable quotient — `solvable_of_ker_le_range` would force `SL(2,p)` solvable, contradicting `not_isSolvable`. So `PSL(2,p)` is not solvable.

Together with `commutator_PSL_eq_top` (perfectness of `PSL(2,p)`), this records that `PSL(2,p)` escapes the entire solvable hierarchy on the same range `p ≥ 5` where the simplicity theorem turns on — the group-theoretic heart of the target open question.

## Proof ingredients (mathlib, API-checked against local pin)
- `solvable_of_ker_le_range` — extension with solvable kernel + quotient ⟹ middle solvable
- `QuotientGroup.ker_mk'`, `Subgroup.range_subtype` — the kernel/range bookkeeping `ker(mk') = Z = range(Z.subtype)`
- `CommGroup.ofIsMulCommutative` + `CommGroup.isSolvable` — solvability of the abelian center (via `center.isMulCommutative`)

## Verification status
**UNVERIFIED.** The Docker Lean build fails at the containerd image layer (`meta.db` input/output error), an operator-level infra failure independent of this change (host disk healthy, 120Gi free). The proof was checked line-by-line against the local mathlib pin; it is a 5-line assembly mirroring the verified `not_isSolvable` in the same file. Meta `lineCount`/`theoremCount` synced (887→944, 45→46).

No new axioms; `sorry`-free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)