### PR TITLE
research(erdos-1008-oq-02-oq-02): K_{2,t} monotonicity in t [VERIFIED]

### DIFF
--- a/proofs/Proofs/Erdos1008OQ02OQ02.lean
+++ b/proofs/Proofs/Erdos1008OQ02OQ02.lean
@@ -400,6 +400,24 @@ theorem commonNbrs_card_lt_of_free (G : SimpleGraph V) [DecidableRel G.Adj]
     simp only [commonNbrs, Finset.mem_inter, SimpleGraph.mem_neighborFinset] at hy
     exact hy⟩
 
+/-- **`K_{2,t}`-containment is antitone in `t`.**  If `G` contains a `K_{2,t}` then it
+also contains a `K_{2,s}` for every `s ≤ t`: the very same pair of vertices, together
+with its `≥ t ≥ s` common neighbours, already witnesses the smaller complete bipartite
+graph.  (The witness `T` is reused verbatim; only its cardinality lower bound is
+weakened `t ↦ s`.) -/
+theorem hasK2t_mono (G : SimpleGraph V) {s t : ℕ} (hst : s ≤ t) (h : HasK2t G t) :
+    HasK2t G s := by
+  obtain ⟨a, b, T, hab, htc, hadj⟩ := h
+  exact ⟨a, b, T, hab, le_trans hst htc, hadj⟩
+
+/-- **`K_{2,t}`-freeness is monotone in `t`.**  Dual to `hasK2t_mono`: a graph with no
+`K_{2,s}` also has no `K_{2,t}` for any `t ≥ s`, since a `K_{2,t}` would contain a
+`K_{2,s}`.  So the forbidden-subgraph hypothesis only *strengthens* as `t` grows — the
+`t`-indexed family of K_{2,t}-free classes is nested `⋯ ⊇ Free(s) ⊇ Free(t) ⊇ ⋯`. -/
+theorem not_hasK2t_mono (G : SimpleGraph V) {s t : ℕ} (hst : s ≤ t)
+    (h : ¬ HasK2t G s) : ¬ HasK2t G t :=
+  fun hcon => h (hasK2t_mono G hst hcon)
+
 /-- **K_{2,t}-free edge bound.**  A genuinely K_{2,t}-free nonempty graph
 (`t ≥ 1`) satisfies the classical Kővári–Sós–Turán bound
 

--- a/research/problems/erdos-1008-oq-02-oq-02/knowledge.md
+++ b/research/problems/erdos-1008-oq-02-oq-02/knowledge.md
@@ -81,3 +81,28 @@ new `docker run` blocked). Used the direct-`lean`-elab-vs-pinned-Mathlib path
 (only the pre-existing unused `[DecidableEq V]` section-var warning on `sq_sum_le_card`
 at line 218), and `#print axioms reiman_edge_bound_leading_order` =
 `[propext, Classical.choice, Quot.sound]` — no `sorryAx`, genuinely axiom-free.
+
+## Session 2026-07-10 (researcher-3) — K_{2,t} monotonicity in t (VERIFIED, orthogonal to open leading-order PRs)
+
+**Mode**: REVISIT (MODERATE) · **Outcome**: progress (2 theorems, 0 axioms), **VERIFIED**.
+
+The K_{2,t} KST engine is fully saturated (both directions: `kst_edge_bound(_of_free)` +
+forcing converses `hasK2t_of_edge_bound_lt`; exact + leading-order + Reiman t=2 specialisations)
+and had **two open PRs** in the leading-order zone (#37052, #37025). To avoid an add/add race
+(this slug is a known concurrent-agent magnet — see prior sessions), I added a **structurally
+orthogonal** pair placed right after the `HasK2t` def, far from the collision zone:
+
+- `hasK2t_mono (G) {s t} (hst : s ≤ t) : HasK2t G t → HasK2t G s` — containment antitone in `t`:
+  the very same witness `⟨a,b,T⟩` works, only its cardinality bound is weakened `t ↦ s`
+  (`le_trans hst htc`).
+- `not_hasK2t_mono : s ≤ t → ¬HasK2t G s → ¬HasK2t G t` — the dual freeness monotonicity
+  (K_{2,t}-free classes are nested `⋯ ⊇ Free(s) ⊇ Free(t) ⊇ ⋯`).
+
+Proofs are one-liners on the `HasK2t` existential. **VERIFIED** via `./bin/lake env lean`
+single-file elab (docker image build still down, containerd meta.db I/O): exit 0, no errors
+(only the pre-existing `sq_sum_le_card` unused-section-var warning + the analogous benign
+warning on `hasK2t_mono`, which does not use `[Fintype V]`). `#print axioms` on both =
+`[propext, Quot.sound]` — genuinely axiom-free.
+
+File `Erdos1008OQ02OQ02.lean` is research-only (no `src/data/proofs/erdos-1008-oq-02-oq-02/`
+gallery meta), so no meta lineCount sync. 536→554 lines.

--- a/src/data/research/problems/erdos-1008-oq-02-oq-02.json
+++ b/src/data/research/problems/erdos-1008-oq-02-oq-02.json
@@ -46,12 +46,14 @@
       "kst_graph_quadratic (Erdos1008OQ02OQ02.lean): assembles cherry count + handshaking + CS (sq_sum_le_card) into 4m² ≤ κ·n²(n-1)+2nm — the graph-theoretic input kst_quadratic_solve needed",
       "kst_edge_bound (Erdos1008OQ02OQ02.lean): graph-level closed form 4m ≤ n(1+√(1+4κ(n-1))) via kst_quadratic_solve with t=κ+1",
       "HasK2t + commonNbrs_card_lt_of_free + kst_edge_bound_of_free: connects the common-neighbour-bound hypothesis to the genuine forbidden-subgraph definition of K_{2,t}-freeness",
-      "hasK2t_of_edge_bound_lt / hasK2t_of_edge_bound_leading_order_lt / hasK2t_two_of_edge_bound_leading_order_lt in Erdos1008OQ02OQ02.lean (GraphLevel): the KST forcing/existence direction — edges above the exact / leading-order / Reiman-C4 threshold force HasK2t; one-line contrapositives of the corresponding upper bounds (PR #37195, UNVERIFIED docker-down)"
+      "hasK2t_of_edge_bound_lt / hasK2t_of_edge_bound_leading_order_lt / hasK2t_two_of_edge_bound_leading_order_lt in Erdos1008OQ02OQ02.lean (GraphLevel): the KST forcing/existence direction — edges above the exact / leading-order / Reiman-C4 threshold force HasK2t; one-line contrapositives of the corresponding upper bounds (PR #37195, UNVERIFIED docker-down)",
+      "hasK2t_mono / not_hasK2t_mono : K_{2,t}-containment is antitone in t (HasK2t G t → HasK2t G s for s≤t, same witness T reused) and dually K_{2,t}-freeness is monotone (¬HasK2t G s → ¬HasK2t G t) — the nested lattice ⋯⊇Free(s)⊇Free(t)⊇⋯. [VERIFIED axiom-free, lean-elab exit 0, #print axioms=propext/Quot.sound]"
     ],
     "insights": [
       "The C4 algebraic core generalises to K_{2,t} with zero structural change: replace the single-common-neighbour bound by (t-1), so s^2=4n-3 becomes s^2=1+4(t-1)(n-1) and the KST quadratic gains a (t-1) factor on the n^2(n-1) term. Same nlinarith case-split proof works.",
       "Leading-order closed form is ex(n;K_{2,t}) <= (1/2)(sqrt(t-1)*n^{3/2}+n), matching the classical Kovari-Sos-Turan asymptotic.",
-      "The graph-level file only had the K_{2,t}-free upper bounds; the forcing converse (too many edges ⟹ K_{2,t}) is what makes KST an extremal theorem and was missing. Trivial via by_contra + absurd (bound) (not_le.2 hm)."
+      "The graph-level file only had the K_{2,t}-free upper bounds; the forcing converse (too many edges ⟹ K_{2,t}) is what makes KST an extremal theorem and was missing. Trivial via by_contra + absurd (bound) (not_le.2 hm).",
+      "HasK2t (∃ a≠b, T with t≤|T|, all of T common-adjacent to a,b) is antitone in t by reusing the SAME witness T and only weakening its cardinality bound t↦s (le_trans). This gives the K_{2,t}-free-class monotonicity for free — orthogonal to the edge-bound/KST machinery, a pure structural fact about the forbidden-subgraph predicate."
     ],
     "mathlibGaps": [
       "No graph-level general cherry-count sum_v C(d_v,2) <= (t-1)*C(n,2) for K_{2,t}-free graphs in the gallery; parent Erdos1008Problem only proves the t=2 (C4) case kovari_sos_turan."


### PR DESCRIPTION
## Summary
Research session for `erdos-1008-oq-02-oq-02` (graph-level Kővári–Sós–Turán K_{2,t} development). The KST engine in `Erdos1008OQ02OQ02.lean` is fully saturated — both the K_{2,t}-free edge bounds and their forcing converses, in exact, leading-order, and Reiman (t=2) forms — and has two open PRs in the leading-order zone (#37052, #37025). This adds a **structurally orthogonal** pair, placed right after the `HasK2t` definition (far from the collision zone).

## Progress
Two axiom-free structural lemmas on the forbidden-subgraph predicate `HasK2t`:

- `hasK2t_mono : s ≤ t → HasK2t G t → HasK2t G s` — **K_{2,t}-containment is antitone in `t`**: the same witnessing pair `⟨a, b, T⟩` works for the smaller graph, only its cardinality lower bound is weakened `t ↦ s`.
- `not_hasK2t_mono : s ≤ t → ¬HasK2t G s → ¬HasK2t G t` — the **dual freeness monotonicity**: the K_{2,t}-free classes are nested `⋯ ⊇ Free(s) ⊇ Free(t) ⊇ ⋯`, so the forbidden-subgraph hypothesis only strengthens as `t` grows.

These are the basic order-theoretic facts underpinning the whole K_{2,t} family (why K_{2,t}-freeness for one `t` transfers to larger `t`), and are orthogonal to the edge-counting/KST machinery.

## Files modified
- `proofs/Proofs/Erdos1008OQ02OQ02.lean` (536→554 lines, +2 theorems, 0 axioms)
- `src/data/research/problems/erdos-1008-oq-02-oq-02.json`, `research/problems/erdos-1008-oq-02-oq-02/knowledge.md`

(Research-only file — no gallery `meta.json` tracks it, so no lineCount sync.)

## Verification
**VERIFIED.** Docker image build is down (containerd `meta.db` I/O error), but single-file elaboration against pinned Mathlib v4.26.0 oleans succeeds:
- `./bin/lake env lean Proofs/Erdos1008OQ02OQ02.lean` → **exit 0**, no errors (only benign pre-existing unused-section-variable warnings).
- `#print axioms` on both lemmas = `[propext, Quot.sound]` — genuinely axiom-free.

## Status
**Outcome**: completed (small orthogonal structural completion; the K_{2,t} extremal results are otherwise saturated).
**Next Steps**: none — engine is complete; remaining directions belong to the open leading-order PRs.

🤖 Generated by researcher-3