### PR TITLE
research(descartes-rule-of-signs-oq-01-oq-03): polynomial negation invariance V(-p)=V(p)

### DIFF
--- a/proofs/Proofs/DescartesRuleOfSignsOQ01OQ03.lean
+++ b/proofs/Proofs/DescartesRuleOfSignsOQ01OQ03.lean
@@ -867,4 +867,16 @@ theorem signChangesInCoeffs_C_mul {c : ℝ} (hc : c ≠ 0) (p : ℝ[X]) :
     rw [hcoe]
     exact countSignChanges_const_smul hc _
 
+/-- **Negation invariance for polynomials.**  Negating a polynomial leaves Descartes'
+coefficient sign-change count unchanged: `V(−p) = V(p)`.  This is the `c = −1` case of
+the scaling invariance `signChangesInCoeffs_C_mul` (since `−p = C(−1)·p`), and the
+polynomial-level companion of the sequence lemma `countSignChanges_neg`.  Classically it
+reflects that `p` and `−p` have the *same* roots — in particular the same positive roots —
+so Descartes' bound is identical for both.  Axiom-free. -/
+theorem signChangesInCoeffs_neg (p : ℝ[X]) :
+    DescartesRuleOfSigns.signChangesInCoeffs (-p)
+      = DescartesRuleOfSigns.signChangesInCoeffs p := by
+  have h := signChangesInCoeffs_C_mul (c := -1) (by norm_num) p
+  rwa [show (C (-1 : ℝ)) * p = -p by rw [map_neg, map_one, neg_one_mul]] at h
+
 end DescartesRuleOfSignsOQ01OQ03

--- a/src/data/proofs/descartes-rule-of-signs-oq-01-oq-03/meta.json
+++ b/src/data/proofs/descartes-rule-of-signs-oq-01-oq-03/meta.json
@@ -122,9 +122,9 @@
       "Proofs.DescartesRuleOfSignsOQ02OQ01OQ02"
     ],
     "namespace": "DescartesRuleOfSignsOQ01OQ03",
-    "lineCount": 870,
+    "lineCount": 882,
     "axiomCount": 0,
-    "theoremCount": 30,
+    "theoremCount": 31,
     "definitionCount": 2,
     "path": "Proofs/DescartesRuleOfSignsOQ01OQ03.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

Adds one **axiom-free** corollary to `DescartesRuleOfSignsOQ01OQ03.lean`.

**`signChangesInCoeffs_neg`** — Negating a polynomial leaves Descartes' coefficient sign-change count unchanged: `V(−p) = V(p)`.

## Context

The file has a full invariance family at the **sequence** level (`countSignChanges_neg`, `countSignChanges_const_smul`, `countSignChanges_comp_rev`) but at the **polynomial** level only the scaling invariance `signChangesInCoeffs_C_mul` (`V(c·p) = V(p)` for `c ≠ 0`). This PR adds the missing polynomial-level negation lemma, the natural companion of the sequence-level `countSignChanges_neg`. Classically `p` and `−p` share the same roots (hence the same positive roots), so Descartes' bound is identical for both — this records that invariance directly at `V`.

## Proof

`V(−p) = V(p)` is the `c = −1` instance of `signChangesInCoeffs_C_mul`: apply it with `c := -1` and rewrite `C(−1)·p = −p` via `map_neg`, `map_one`, `neg_one_mul`. One line on top of an existing verified lemma. Axiom-free, 0 sorries.

Gallery `meta.json` synced: `overview.lineCount` 870 → 882, `theoremCount` 30 → 31.

## Verification status

**UNVERIFIED** — the docker Lean image build fails with a `containerd meta.db input/output error` (build infrastructure down this session). The addition is a one-line corollary of the already-verified `signChangesInCoeffs_C_mul` using only standard ring-hom API, so confidence is high.

🤖 Generated with [Claude Code](https://claude.com/claude-code)