### PR TITLE
research(hilbert-17-oq-03): name the classical Motzkin polynomial PSD-not-SOS witness [VERIFIED]

### DIFF
--- a/proofs/Proofs/Hilbert17OQ03OQ05.lean
+++ b/proofs/Proofs/Hilbert17OQ03OQ05.lean
@@ -339,6 +339,17 @@ theorem motzkinPoly_psd_not_sos {c : ℝ} (hc0 : 0 < c) (hc3 : c ≤ 3) :
     IsPSDMv (motzkinPoly c) ∧ ¬ Hilbert17MotzkinNotSOS.IsSOS (motzkinPoly c) :=
   ⟨(motzkinPoly_psd_iff c).2 hc3, motzkinPoly_not_sos hc0⟩
 
+/-- **The classical Motzkin polynomial is PSD but not a sum of squares.**
+    `motzkinPoly 3 = X₀⁴X₁² + X₀²X₁⁴ + 1 − 3·X₀²X₁²` is Motzkin's (1967) first *explicit*
+    example of a positive-semidefinite polynomial that is not a sum of squares of
+    polynomials — the concrete witness that Hilbert's 17th problem genuinely requires
+    rational functions (denominators), not just polynomials.  It is the `c = 3`
+    PSD-boundary member of the family `motzkinPoly_psd_not_sos`, singled out here as the
+    headline instance the whole file is built around. -/
+theorem motzkin_classical_psd_not_sos :
+    IsPSDMv (motzkinPoly 3) ∧ ¬ Hilbert17MotzkinNotSOS.IsSOS (motzkinPoly 3) :=
+  motzkinPoly_psd_not_sos (by norm_num) (by norm_num)
+
 /-- **SOS membership at `c ≤ 0`.** For a nonpositive coefficient the `−c·x²y²` term has a
     nonnegative sign, so `motzkinPoly c` is a genuine sum of four squares,
 

--- a/src/data/proofs/hilbert-17-oq-03-oq-05/meta.json
+++ b/src/data/proofs/hilbert-17-oq-03-oq-05/meta.json
@@ -48,7 +48,7 @@
       "The arithmetic–geometric mean (AM–GM) inequality and sum-of-squares certificates for non-negativity.",
       "Evaluation of multivariate polynomials and the PSD predicate ∀ v, 0 ≤ eval v p."
     ],
-    "lineCount": 419,
+    "lineCount": 430,
     "relatedProblems": [
       {
         "id": "hilbert-17-oq-03-oq-02",
@@ -68,19 +68,19 @@
       }
     ],
     "assumptions": "0 axioms. #print axioms reports only propext, Classical.choice, Quot.sound for motzkinFun_psd_iff, motzkinPoly_psd_iff, three_is_sharp, and motzkin_amgm. No sorryAx, no native_decide / Lean.ofReduceBool. The MvPolynomial PSD predicate IsPSDMv matches the parent entry's IsPositiveSemidefiniteMv definitionally.",
-    "theoremCount": 27,
+    "theoremCount": 28,
     "definitionCount": 3,
     "additionalFiles": []
   },
   "leanFile": {
-    "lineCount": 419,
+    "lineCount": 430,
     "namespace": "Hilbert17OQ03OQ05",
     "opens": [
       "MvPolynomial"
     ],
     "structureCount": 0,
     "axiomCount": 0,
-    "theoremCount": 27,
+    "theoremCount": 28,
     "substantiveTheoremCount": 9,
     "computationalVerifications": 0,
     "lemmaCount": 0,


### PR DESCRIPTION
## Summary
`Hilbert17OQ03OQ05.lean` proves the entire one-parameter Motzkin family `M_c` is PSD-but-not-SOS for `0 < c ≤ 3` (`motzkinPoly_psd_not_sos`), but never singles out the canonical member. This PR names it:

`motzkin_classical_psd_not_sos : IsPSDMv (motzkinPoly 3) ∧ ¬ IsSOS (motzkinPoly 3)`

The **classical Motzkin polynomial** `M(x,y) = x⁴y² + x²y⁴ + 1 − 3x²y²` (c = 3) is Motzkin's (1967) first **explicit** example of a positive-semidefinite polynomial that is not a sum of squares of polynomials — the concrete witness that Hilbert's 17th problem genuinely requires rational functions (denominators), not just polynomials. It is the `c = 3` PSD-boundary member of the family, and the headline example the whole file is built around.

## Proof
The `c = 3` instance of the verified family theorem `motzkinPoly_psd_not_sos`; the two side conditions (`0 < 3`, `3 ≤ 3`) are `norm_num`. 0 axioms, 0 sorries.

## Verification — VERIFIED (docker infra down)
Direct `lean` elaboration against pinned Mathlib **v4.26.0** (built the sibling dep `Hilbert17MotzkinNotSOS` olean first): **EXIT 0, 0 errors, 0 sorries**. Axiom-clean by composition (`motzkinPoly_psd_not_sos` is verified 0/0).

Meta synced (`lineCount` 419→430, `theoremCount` 27→28).
