### PR TITLE
research(erdos-659): B2 counting function upper bound B2(N) ≤ N [UNVERIFIED]

### DIFF
--- a/proofs/Proofs/Erdos659Problem.lean
+++ b/proofs/Proofs/Erdos659Problem.lean
@@ -392,6 +392,21 @@ theorem one_le_B2 {N : ℕ} (hN : 1 ≤ N) : 1 ≤ B2 N := by
     (Set.ncard_pos hfin).mpr ⟨1, hmem⟩
   omega
 
+/-- **`B₂(N) ≤ N`.** The counted set `representable ∩ Icc 1 N` is a subset of the window
+    `Icc 1 N`, which has exactly `N` elements, so the counting function never exceeds `N`.
+    Together with `one_le_B2` this sandwiches `B₂` as `1 ≤ B₂(N) ≤ N` for `N ≥ 1`; the
+    *rate* at which `B₂(N)` approaches its Landau asymptotic `∼ c·N/√(log N)` inside this
+    window is exactly the deep content isolated in `moreeOsburnWorks`. Elementary finiteness
+    bookkeeping, independent of the deep analytic input. -/
+theorem B2_le (N : ℕ) : B2 N ≤ N := by
+  unfold B2
+  have hle := Set.ncard_le_ncard
+    (Set.inter_subset_right : representable_x2_2y2 ∩ Set.Icc 1 N ⊆ Set.Icc (1 : ℕ) N)
+    (Set.finite_Icc 1 N)
+  have hcard : (Set.Icc (1 : ℕ) N).ncard = N := by
+    rw [← Finset.coe_Icc, Set.ncard_coe_finset, Nat.card_Icc]; omega
+  omega
+
 /-! ### The mod-8 obstruction (necessity side of the characterization)
 
 The lemmas above are all *positivity* results — they exhibit integers that **are**

--- a/src/data/proofs/erdos-659/meta.json
+++ b/src/data/proofs/erdos-659/meta.json
@@ -49,7 +49,7 @@
       "Verified the necessity side (mod-8 obstruction) of the arithmetic characterization: not_representable_of_mod8 proves no integer ≡ 5 or 7 (mod 8) is a value of x²+2y² (finite decide over ZMod 8), with five_not_representable / seven_not_representable as the smallest concrete witnesses — the first non-representability results in the file, showing the form is not universal (5, 7 are inert in ℤ[√-2])"
     ],
     "axiomCount": 1,
-    "lineCount": 535,
+    "lineCount": 550,
     "assumptions": "1 axiom: moreeOsburnWorks (the two deep geometric facts about the box-truncated lattice — the 4-point property and the Landau/x²+2y² distinct-distance bound m/√(log m); not available in Mathlib 4.26). The cardinality (2k+1)² is now a verified theorem (moreeOsburnLattice_card), not an assumption. 0 sorries.",
     "theoremCount": 18,
     "definitionCount": 9
@@ -140,9 +140,9 @@
       "Real"
     ],
     "namespace": "Erdos659",
-    "lineCount": 535,
+    "lineCount": 550,
     "axiomCount": 1,
-    "theoremCount": 25,
+    "theoremCount": 26,
     "definitionCount": 9,
     "path": "Proofs/Erdos659Problem.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

Adds `B2_le` to `Erdos659Problem.lean`: the upper bound **B₂(N) ≤ N** for the counting function of positive integers ≤ N representable as `x² + 2y²`.

This **completes the sandwich `1 ≤ B₂(N) ≤ N`** (for N ≥ 1), pairing with the file's existing:
- `B2_mono` — monotonicity
- `one_le_B2` — positivity lower bound

## Mathematical content

The counted set `representable_x2_2y2 ∩ Icc 1 N` is a subset of the window `Icc 1 N`, which has exactly N elements, so B₂ never exceeds N. Elementary finiteness bookkeeping via `Set.ncard_le_ncard` + `Set.ncard_coe_finset` + `Nat.card_Icc`.

The *rate* at which B₂(N) approaches its Landau asymptotic `~ c·N/√(log N)` inside this window is exactly the deep content isolated in the `moreeOsburnWorks` axiom — this lemma is honest that the trivial envelope is all that's provable without the deep analytic input.

## Assumptions

No new axioms, no sorries. The entry retains its single existing axiom `moreeOsburnWorks` (the deep Moree–Osburn/Landau geometric input). Status remains `axiomatized`.

## Verification

⚠️ **UNVERIFIED** — the Docker Lean image build is currently down (containerd `meta.db` input/output error), so `docker-build.sh` could not run. All Mathlib API used was confirmed against the local mathlib pin (`Set.ncard_le_ncard`, `Set.ncard_coe_finset`, `Nat.card_Icc`, `Finset.coe_Icc`). The proof mirrors the elaboration idiom of the sibling `B2_mono`/`one_le_B2` lemmas.

Meta synced: leanFile.lineCount 535→550, theoremCount 25→26.

🤖 Generated with [Claude Code](https://claude.com/claude-code)