### PR TITLE
research(erdos-1215-oq-02): the cyclotomic level set is open

### DIFF
--- a/proofs/Proofs/CyclotomicPolynomialsOQ02OQ01.lean
+++ b/proofs/Proofs/CyclotomicPolynomialsOQ02OQ01.lean
@@ -96,6 +96,23 @@ theorem isBounded_levelSet_cyclotomic (n : ℕ) (hn : n ≠ 0) (C : ℝ) :
     exact le_of_lt (cyclotomic_sublevel_norm_lt n hn C z hz)
   exact Metric.isBounded_closedBall.subset hsub
 
+/-- **The cyclotomic level set is open.**
+`{z : |Φ_n(z)| < C}` is the preimage of the open ray `(-∞, C)` under the continuous
+map `z ↦ |Φ_n(z)|` (a polynomial evaluation composed with the norm), hence open.
+Together with `isBounded_levelSet_cyclotomic` this exhibits the cyclotomic lemniscate
+interior as a *bounded open* subset of `ℂ` — the natural topological shape of an
+Erdős #1215 sublevel set. -/
+theorem isOpen_levelSet_cyclotomic (n : ℕ) (C : ℝ) :
+    IsOpen (Erdos1215.levelSet (cyclotomic n ℂ) C) := by
+  have hcont : Continuous fun z : ℂ => ‖(cyclotomic n ℂ).eval z‖ :=
+    (Polynomial.continuous (cyclotomic n ℂ)).norm
+  have hset : Erdos1215.levelSet (cyclotomic n ℂ) C
+      = (fun z : ℂ => ‖(cyclotomic n ℂ).eval z‖) ⁻¹' Set.Iio C := by
+    ext z
+    simp only [Erdos1215.levelSet, Set.mem_setOf_eq, Set.mem_preimage, Set.mem_Iio]
+  rw [hset]
+  exact isOpen_Iio.preimage hcont
+
 /-- **No escape-to-infinity path for cyclotomic polynomials.**
 Because the level set is bounded, no continuous path from `0` with `‖γ t‖ → ∞`
 can stay inside `{z : |Φ_n(z)| < C}`.  This is the cyclotomic specialisation of the


### PR DESCRIPTION
## Summary

Adds one **axiom-free** theorem to `CyclotomicPolynomialsOQ02OQ01.lean` (Erdős #1215, cyclotomic sublevel sets).

**`isOpen_levelSet_cyclotomic`** — The cyclotomic level set `{z : |Φ_n(z)| < C}` is open.

## Context

The file already proves this set is **bounded** (`isBounded_levelSet_cyclotomic`, contained in `closedBall 0 (max 2 (C+1))`) and derives the no-escape-to-∞ path obstruction from that. But it never records that the set is **open**. This PR supplies exactly that: together with boundedness it exhibits the cyclotomic lemniscate interior as a *bounded open* subset of ℂ — the natural topological shape of an Erdős #1215 sublevel set.

## Proof

`levelSet (cyclotomic n ℂ) C = (fun z => ‖(cyclotomic n ℂ).eval z‖) ⁻¹' Set.Iio C`; the map `z ↦ |Φ_n(z)|` is continuous (`(Polynomial.continuous _).norm`), and `Set.Iio C` is open, so the preimage is open (`isOpen_Iio.preimage`). Axiom-free, 0 sorries.

No gallery `meta.json` references this companion file, so no metadata sync is required.

## Verification status

**UNVERIFIED** — the docker Lean image build fails with a `containerd meta.db input/output error` (build infrastructure down this session). The proof uses only standard continuity/topology API (`Polynomial.continuous`, `Continuous.norm`, `isOpen_Iio`, `IsOpen.preimage`), so confidence is high.

🤖 Generated with [Claude Code](https://claude.com/claude-code)