### PR TITLE
Enrich area-of-circle Gaussian-integral trio: add second open questions

### DIFF
--- a/src/data/proofs/area-of-circle-oq-07-oq-04-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/area-of-circle-oq-07-oq-04-oq-01-oq-01-oq-02/meta.json
@@ -128,6 +128,11 @@
       "id": "area-of-circle-oq-07-oq-04-oq-01-oq-01-oq-02-oq-01",
       "question": "Lift the diagonal (anisotropic) result to a general positive-definite quadratic form: prove ∫_{ℝⁿ} e^{-⟨Ax,x⟩} = π^{n/2}/√(det A) for symmetric positive-definite A, by diagonalizing A = Oᵀ D O with O orthogonal (so the linear change of variables x ↦ Oᵀx has unit Jacobian) and applying the diagonal case proved here to D = diag(λ₁,…,λₙ), using det A = ∏ᵢ λᵢ.",
       "significance": "medium"
+    },
+    {
+      "id": "area-of-circle-oq-07-oq-04-oq-01-oq-01-oq-02-oq-02",
+      "question": "Pin down the true convergence domain behind the formal identity: the product form ∏ᵢ √(π/bᵢ) holds as stated via Mathlib's junk-value conventions for every b, but the Lebesgue integral converges only when every bᵢ > 0 and diverges as soon as some bᵢ ≤ 0. Make this gap precise (an Integrable ↔ ∀ i, 0 < bᵢ characterization), and treat the oscillatory continuation bᵢ ↦ i·βᵢ (the anisotropic Fresnel integral) where convergence is only conditional and the value acquires a determinant-of-i phase.",
+      "significance": "medium"
     }
   ],
   "crossReferences": [
@@ -170,7 +175,8 @@
     "summary": "For every weight vector b : Fin n → ℝ the anisotropic (diagonal) Gaussian integral over ℝⁿ = Fin n → ℝ factors as a product of per-axis one-dimensional Gaussians: ∫_{ℝⁿ} e^{-∑ᵢ bᵢ xᵢ²} = ∏ᵢ √(π/bᵢ) (gaussian_anisotropic_eq_prod), valid for every b with no positivity hypothesis. The separable integrand e^{-∑ᵢ bᵢ xᵢ²} is rewritten as the product ∏ᵢ e^{-bᵢ xᵢ²} (Real.exp_sum) and the general n-variable Fubini theorem integral_fintype_prod_volume_eq_prod collapses the product integral to a product of distinct line integrals, each evaluated by Mathlib's integral_gaussian. For positive weights bᵢ > 0 the product re-assembles into the determinant closed form π^{n/2}/√(∏ᵢ bᵢ) (gaussian_anisotropic_closed_form), using Real.sqrt_div to factor √π and Real.finset_prod_rpow to collect ∏ᵢ √bᵢ = √(∏ᵢ bᵢ). The constant weight bᵢ = c recovers the parent's isotropic (π/c)^{n/2} (gaussian_isotropic_recover). 112 lines, 3 theorems, 0 definitions, 0 axioms, 0 sorries. Every Mathlib dependency was checked against the Mathlib v4 source (integral_fintype_prod_volume_eq_prod, integral_gaussian, Real.exp_sum, Real.finset_prod_rpow, Real.sqrt_div, Real.sqrt_eq_rpow, Real.rpow_natCast, Real.rpow_mul, Finset.prod_div_distrib, Finset.sum_neg_distrib, Fintype.card_fin); the file is kernel-verified with `lake env lean` on Mathlib v4.26.0 — all three theorems depend only on the standard foundational axioms [propext, Classical.choice, Quot.sound]. (The product–Fubini step required an explicit beta-reduction (`simp only []`) before `Real.exp_sum` could rewrite the integrand.)",
     "implications": "This upgrades the isotropic n-dimensional Gaussian from a single weight to a diagonal covariance, identifying the normalizing constant π^{n/2}/√(∏ᵢ bᵢ) = π^{n/2}/√(det diag b) as the diagonal case of the general positive-definite quadratic-form value π^{n/2}/√(det A). The engine is the same separable Fubini factorization as the parent, upgraded from a power of one integral to a product of n distinct line integrals; the parent is exactly the constant-weight specialization. The general quadratic-form statement (via orthogonal diagonalization) is left as the open follow-up.",
     "openQuestions": [
-      "Extend to a general positive-definite quadratic form ∫_{ℝⁿ} e^{-⟨Ax,x⟩} = π^{n/2}/√(det A) by orthogonal diagonalization, reducing to the diagonal case proved here."
+      "Extend to a general positive-definite quadratic form ∫_{ℝⁿ} e^{-⟨Ax,x⟩} = π^{n/2}/√(det A) by orthogonal diagonalization, reducing to the diagonal case proved here.",
+      "Characterize the true convergence domain (Integrable ↔ ∀ i, 0 < bᵢ) behind the formal product identity, and treat the oscillatory anisotropic Fresnel continuation bᵢ ↦ i·βᵢ with its determinant-of-i phase."
     ]
   }
 }

--- a/src/data/proofs/area-of-circle-oq-07-oq-04-oq-01-oq-01/meta.json
+++ b/src/data/proofs/area-of-circle-oq-07-oq-04-oq-01-oq-01/meta.json
@@ -128,6 +128,11 @@
       "id": "area-of-circle-oq-07-oq-04-oq-01-oq-01-oq-01",
       "question": "Recover the (n-1)-sphere surface area explicitly: prove ∫_{ℝⁿ} e^{-b‖x‖²} = (π/b)^{n/2} a second time via n-dimensional spherical coordinates (radial r^{n-1} dr times the unit-sphere measure), and equate the two evaluations to read off the surface area ω_{n-1} = 2π^{n/2}/Γ(n/2) of the unit (n-1)-sphere.",
       "significance": "medium"
+    },
+    {
+      "id": "area-of-circle-oq-07-oq-04-oq-01-oq-01-oq-02",
+      "question": "Turn the mass identity into the isotropic multivariate normal: setting b = 1/(2σ²) gives ∫_{ℝⁿ} e^{-‖x‖²/(2σ²)} = (2πσ²)^{n/2}, the normalizing constant of the n-dimensional Gaussian density. From the same separable factorization derive the second-moment (energy) identity E[‖X‖²] = nσ² and the diagonal covariance E[Xᵢ Xⱼ] = σ² δᵢⱼ, so the geometric integral becomes a probabilistic statement about the standard Gaussian on ℝⁿ.",
+      "significance": "medium"
     }
   ],
   "crossReferences": [
@@ -170,7 +175,8 @@
     "summary": "For every natural number n the n-dimensional Gaussian integral over ℝⁿ = Fin n → ℝ factors as the n-th power of the one-dimensional line integral: ∫_{ℝⁿ} e^{-b ∑ᵢ xᵢ²} = (∫_ℝ e^{-b x²})ⁿ (gaussian_pow_eq_integral_pi), valid for every real b with no positivity hypothesis. The separable integrand e^{-b ∑ᵢ xᵢ²} is rewritten as the product ∏ᵢ e^{-b xᵢ²} (Real.exp_sum) and the n-variable Fubini theorem integral_fintype_prod_volume_eq_pow collapses the product integral to a power. Substituting Mathlib's closed form ∫_ℝ e^{-b x²} = √(π/b) gives (√(π/b))ⁿ (integral_pi_gaussian_eq_sqrt_pow), and for b > 0 the rpow algebra delivers the standard form (π/b)^{n/2} (integral_pi_gaussian_eq_rpow). The b = 1 case is π^{n/2} (integral_pi_gaussian_eq_pi). 85 lines, 4 theorems, 0 definitions, 0 axioms, 0 sorries. Every Mathlib dependency was checked against the Mathlib v4 source (integral_fintype_prod_volume_eq_pow, integral_gaussian, Real.exp_sum, Real.sqrt_eq_rpow, Real.rpow_natCast, Real.rpow_mul, Fintype.card_fin, Finset.mul_sum); kernel verification (#print axioms) is gated through the deployer's Docker rebuild because the local Docker daemon was unresponsive during this session.",
     "implications": "This lifts the parent's planar Gaussian identity to all dimensions by the product (separable) route, exhibiting (π/b)^{n/2} as the n-fold Fubini factorization of the radially symmetric Gaussian over ℝⁿ. The n = 1 case is Mathlib's base integral and the n = 2 case is the parent's 2-D area identity, so a single theorem subsumes the whole family. The complementary spherical-coordinate evaluation — which would additionally expose the (n-1)-sphere surface area 2π^{n/2}/Γ(n/2) — is left as the open follow-up.",
     "openQuestions": [
-      "Evaluate ∫_{ℝⁿ} e^{-b‖x‖²} a second time via spherical coordinates to read off the unit (n-1)-sphere surface area ω_{n-1} = 2π^{n/2}/Γ(n/2)."
+      "Evaluate ∫_{ℝⁿ} e^{-b‖x‖²} a second time via spherical coordinates to read off the unit (n-1)-sphere surface area ω_{n-1} = 2π^{n/2}/Γ(n/2).",
+      "Specialize b = 1/(2σ²) to recover the multivariate-normal normalizing constant (2πσ²)^{n/2}, and derive the second-moment identity E[‖X‖²] = nσ² and diagonal covariance E[Xᵢ Xⱼ] = σ² δᵢⱼ for the standard Gaussian on ℝⁿ."
     ]
   }
 }

--- a/src/data/proofs/area-of-circle-oq-07-oq-05-oq-01-oq-02/meta.json
+++ b/src/data/proofs/area-of-circle-oq-07-oq-05-oq-01-oq-02/meta.json
@@ -132,6 +132,11 @@
       "id": "area-of-circle-oq-07-oq-05-oq-01-oq-02-oq-01",
       "question": "Combine the scaled even moments with the (vanishing) scaled odd moments to read off the moment generating function ∫_ℝ e^{t x} e^{-a x²} dx = √(π/a) e^{t²/(4a)}, recovering the full Gaussian Laplace/Fourier transform from the moment sequence.",
       "significance": "medium"
+    },
+    {
+      "id": "area-of-circle-oq-07-oq-05-oq-01-oq-02-oq-02",
+      "question": "Unify the integer even moments with the general fractional/absolute moment via the Gamma function: since (2n-1)‼ = 2ⁿ Γ(n+½)/√π, the identity reads ∫_ℝ x^{2n} e^{-a x²} dx = Γ(n+½)/a^{n+½}, which extends to ∫_ℝ |x|^{s} e^{-a x²} dx = Γ((s+1)/2)/a^{(s+1)/2} for every real s > -1. Prove this continuous-order moment formula and recover the double-factorial case as the even integers s = 2n.",
+      "significance": "medium"
     }
   ],
   "crossReferences": [
@@ -167,7 +172,8 @@
     "summary": "For every n : ℕ and every a > 0 the scaled Gaussian even moment is ∫_ℝ x^{2n} e^{-a x²} dx = (2n-1)‼·√(π/a)/(2a)ⁿ (scaled_gaussian_even_moment). The proof is one linear change of variables x ↦ √a·x: Mathlib's dilation rule MeasureTheory.Measure.integral_comp_mul_left turns the parent entry's unscaled moment ∫ x^{2n} e^{-x²} = (2n-1)‼·√π/2ⁿ into the scaled one, with the dilated integrand g(√a·x) = aⁿ·x^{2n} e^{-a x²} supplying the factor aⁿ and the rule's Jacobian |s⁻¹| = 1/√a supplying the missing half-power, so the integral picks up exactly a^{-(n+1/2)} = √(π/a)/(2a)ⁿ ÷ ((2n-1)‼√π). The second moment specializes to √(π/a)/(2a), twice the half-line sibling value. 119 lines, 4 theorems, 0 definitions, 0 axioms, 0 sorries; depends only on propext, Classical.choice, Quot.sound.",
     "implications": "This parameterizes the gallery's even-moment family by the Gaussian scale a > 0: every ∫ x^{2n} e^{-a x²} now has a machine-checked closed form, obtained for free from the unscaled case by a single dilation rather than re-running the integration-by-parts induction at each scale. It isolates the algebraic content of scaling a Gaussian — the moment of order 2n acquires the factor a^{-(n+1/2)} — and connects the whole-line moments to their half-line counterparts by even symmetry.",
     "openQuestions": [
-      "Assemble the scaled moment generating function ∫_ℝ e^{t x} e^{-a x²} = √(π/a) e^{t²/(4a)} from the full moment sequence."
+      "Assemble the scaled moment generating function ∫_ℝ e^{t x} e^{-a x²} = √(π/a) e^{t²/(4a)} from the full moment sequence.",
+      "Unify the result via the Gamma function as ∫_ℝ x^{2n} e^{-a x²} = Γ(n+½)/a^{n+½}, extending to the continuous-order absolute moment ∫_ℝ |x|^{s} e^{-a x²} = Γ((s+1)/2)/a^{(s+1)/2} for s > -1."
     ]
   }
 }


### PR DESCRIPTION
Enrichment pass for three Gaussian-integral entries in the area-of-circle chain. Each had exactly **one** open question (quality target is ≥2), in both the top-level `openQuestions` (object form) and `conclusion.openQuestions` (string form). Added a second, math-grounded question to each, keeping the two representations in sync.

- **area-of-circle-oq-07-oq-04-oq-01-oq-01** (isotropic n-dim Gaussian $(\pi/b)^{n/2}$): specialize $b=1/(2\sigma^2)$ to the multivariate-normal constant $(2\pi\sigma^2)^{n/2}$ and derive $E[\lVert X\rVert^2]=n\sigma^2$, $E[X_iX_j]=\sigma^2\delta_{ij}$.
- **…-oq-02** (anisotropic $\prod\sqrt{\pi/b_i}$): characterize the true convergence domain (`Integrable ↔ ∀ i, 0<bᵢ`) behind the formal junk-value identity, plus the oscillatory Fresnel continuation with its determinant-of-$i$ phase.
- **area-of-circle-oq-07-oq-05-oq-01-oq-02** (scaled even moment): Gamma-function unification $\int x^{2n}e^{-ax^2}=\Gamma(n+\tfrac12)/a^{n+1/2}$, extended to the continuous-order absolute moment $\Gamma(\tfrac{s+1}2)/a^{(s+1)/2}$.

All three meta.json remain well under the 60 KB cap; openQuestions 1→2. JSON validated; no content deleted.