### PR TITLE
research(elem-quad-recip-oq-03-oq-02): denominator-side square trio for the Kronecker symbol

### DIFF
--- a/proofs/Proofs/ElementaryQuadraticReciprocityOQ03OQ02.lean
+++ b/proofs/Proofs/ElementaryQuadraticReciprocityOQ03OQ02.lean
@@ -906,6 +906,37 @@ theorem kronecker_sq_left_eq_one_of_coprime (a : ℤ) (n : ℕ) (hn : 0 < n) (hn
   rw [kronecker_sq_left a (n : ℤ) ha]
   exact kronecker_sq_eq_one_of_coprime a n hn hno h
 
+/-! The three results above square the *numerator*.  Their denominator-side duals
+follow the same way from second-argument multiplicativity `kronecker_mul_right`:
+the symbol at a *square modulus* `n²` is a perfect square, hence `≥ 0`, and equals
+`1` on units.  This completes the "squares are residues" picture in both arguments. -/
+
+/-- **The symbol at a square modulus is the square of the symbol.**  For nonzero
+`n`, `(a/n²) = (a/n)²` — the denominator-side dual of `kronecker_sq_left`, a direct
+instance of second-argument multiplicativity `kronecker_mul_right` on the nonzero
+product `n² = n·n`. -/
+theorem kronecker_sq_right (a n : ℤ) (hn : n ≠ 0) :
+    kronecker a (n ^ 2) = kronecker a n ^ 2 := by
+  rw [pow_two, kronecker_mul_right a n n (mul_ne_zero hn hn), pow_two]
+
+/-- **The symbol is non-negative at square moduli.**  `0 ≤ (a/n²)` for nonzero `n`:
+by `kronecker_sq_right` the value is a perfect square.  So a square modulus never
+records `a` as a quadratic *non*-residue — the value is `0` (non-coprime) or `1`. -/
+theorem kronecker_sq_right_nonneg (a n : ℤ) (hn : n ≠ 0) :
+    0 ≤ kronecker a (n ^ 2) := by
+  rw [kronecker_sq_right a n hn]; exact sq_nonneg _
+
+/-- **Square moduli coprime to the numerator give the trivial value.**  For odd
+positive `n` coprime to `a`, `(a/n²) = 1`: at a square modulus the character is
+principal on units.  The denominator-side companion of
+`kronecker_sq_left_eq_one_of_coprime`, combining `kronecker_sq_right` with
+`kronecker_sq_eq_one_of_coprime`. -/
+theorem kronecker_sq_right_eq_one_of_coprime (a : ℤ) (n : ℕ) (hn : 0 < n) (hno : n % 2 = 1)
+    (h : Int.gcd a n = 1) :
+    kronecker a ((n : ℤ) ^ 2) = 1 := by
+  rw [kronecker_sq_right a (n : ℤ) (by exact_mod_cast hn.ne')]
+  exact kronecker_sq_eq_one_of_coprime a n hn hno h
+
 /-!
 ## Module note: what remains open
 

--- a/research/problems/elementary-quadratic-reciprocity-oq-03-oq-02-wip-01/state.md
+++ b/research/problems/elementary-quadratic-reciprocity-oq-03-oq-02-wip-01/state.md
@@ -44,6 +44,16 @@ supplementary laws are done. Or refinement (1): redefine `kronecker` to use
 
 ## Progress log
 
+- 2026-07-10 (iter 5): Added the **denominator-side square trio** completing
+  Section 13's numerator/denominator symmetry — `kronecker_sq_right`
+  ((a/n²) = (a/n)², via `kronecker_mul_right` on n²=n·n), `kronecker_sq_right_nonneg`
+  (0 ≤ (a/n²), a perfect square), and `kronecker_sq_right_eq_one_of_coprime`
+  ((a/n²)=1 for odd positive n coprime to a). Exact denominator duals of the
+  verified `kronecker_sq_left`/`_nonneg`/`_eq_one_of_coprime`; one-line proofs off
+  second-arg multiplicativity + `kronecker_sq_eq_one_of_coprime`. Docker infra DOWN
+  (containerd meta.db I/O error) — shipped UNVERIFIED, proofs mirror verified
+  siblings. Refinements (1) def-rewiring and (2) Gauss-sum reciprocity core remain open.
+
 - 2026-07-08 (iter 4): Added the numerator-side structural law
   `kronecker_mod_numerator` — for odd positive `n`, `(a/n) = (a % n / n)`, i.e.
   the symbol at a fixed odd modulus factors through `ℤ/nℤ` in the numerator — and


### PR DESCRIPTION
## Summary

Completes the numerator/denominator symmetry of **Section 13** in
`ElementaryQuadraticReciprocityOQ03OQ02.lean` by adding the three
denominator-side (second-argument) duals of the existing verified
numerator-square lemmas. Together they say: **at a square modulus `n²` the
Kronecker symbol is a perfect square, hence non-negative, and equals `1` on
units** — the "squares are quadratic residues" statement, now in both arguments.

New theorems:
- `kronecker_sq_right (a n : ℤ) (hn : n ≠ 0)` — `(a/n²) = (a/n)²`, a direct
  instance of second-argument multiplicativity `kronecker_mul_right` on the
  nonzero product `n² = n·n`. Dual of `kronecker_sq_left`.
- `kronecker_sq_right_nonneg (a n : ℤ) (hn : n ≠ 0)` — `0 ≤ (a/n²)` (a perfect
  square). Dual of `kronecker_sq_left_nonneg`.
- `kronecker_sq_right_eq_one_of_coprime (a : ℤ) (n : ℕ) …` — `(a/n²) = 1` for
  odd positive `n` coprime to `a`. Dual of `kronecker_sq_left_eq_one_of_coprime`,
  reusing `kronecker_sq_eq_one_of_coprime`.

Proofs are one line each, mirroring the verified numerator-side trio. No new
axioms or sorries. Gallery meta `lineCount` synced 930→961.

## Verification status

**UNVERIFIED.** Docker build infrastructure is down this session (containerd
`meta.db` input/output error at image build, disk healthy). The three proofs
are line-for-line duals of build-verified siblings (`kronecker_sq_left` &c.)
and use only established local API (`kronecker_mul_right`, `pow_two`,
`mul_ne_zero`, `sq_nonneg`, `kronecker_sq_eq_one_of_coprime`), so confidence is
high; flagging as unverified per policy since no local build confirmed it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)