### PR TITLE
research(burnside-counting-oq-03): necklace formulas from Burnside's lemma alone [UNVERIFIED]

### DIFF
--- a/proofs/Proofs/BurnsideCountingOQ03.lean
+++ b/proofs/Proofs/BurnsideCountingOQ03.lean
@@ -413,6 +413,31 @@ theorem polya_necklace_divisor_formula (n k : ℕ) [NeZero n]
   rw [polya_necklace_formula_statement n k necklace_count h_burnside h_fixed]
   exact polya_sum_identity n k (Nat.pos_of_ne_zero (NeZero.ne n))
 
+/-- **Necklace formula requiring only Burnside's lemma.**
+    The fixed-point hypothesis `h_fixed` of `polya_necklace_formula_statement` is exactly
+    the content of `polya_cyclic_fixed_count`, which this file proves in full generality
+    (`|Fix(r)| = k^gcd(r,n)` for arbitrary `n, k`). Discharging it internally, the necklace
+    identity `n · necklace_count = Σ_r k^gcd(r,n)` follows from Burnside's lemma alone. -/
+theorem polya_necklace_formula_of_burnside (n k : ℕ) [NeZero n]
+    (necklace_count : ℕ)
+    (h_burnside : n * necklace_count =
+      ∑ r : Fin n, Fintype.card {c : Fin n → Fin k // IsFixed n k r c}) :
+    n * necklace_count = ∑ r : Fin n, k ^ Nat.gcd r.val n :=
+  polya_necklace_formula_statement n k necklace_count h_burnside
+    (fun r => polya_cyclic_fixed_count n k r)
+
+/-- **Divisor-sum necklace formula requiring only Burnside's lemma.** As with
+    `polya_necklace_formula_of_burnside`, the fixed-point count is supplied internally by
+    `polya_cyclic_fixed_count`, so Burnside's lemma alone yields the classical divisor-sum
+    formula `n · necklace_count = Σ_{d | n} φ(n/d) · k^d`. -/
+theorem polya_necklace_divisor_formula_of_burnside (n k : ℕ) [NeZero n]
+    (necklace_count : ℕ)
+    (h_burnside : n * necklace_count =
+      ∑ r : Fin n, Fintype.card {c : Fin n → Fin k // IsFixed n k r c}) :
+    n * necklace_count = ∑ d ∈ Nat.divisors n, Nat.totient (n / d) * k ^ d :=
+  polya_necklace_divisor_formula n k necklace_count h_burnside
+    (fun r => polya_cyclic_fixed_count n k r)
+
 #check @MulAction.sum_card_fixedBy_eq_card_orbits_mul_card_group
 #check ZMod.addOrderOf_coe
 #check ZMod.natCast_zmod_val

--- a/src/data/proofs/burnside-counting-oq-03/meta.json
+++ b/src/data/proofs/burnside-counting-oq-03/meta.json
@@ -25,8 +25,8 @@
     "axiomCount": 1,
     "assumptions": "0 sorries, 0 literal `axiom` declarations. Uses Mathlib's ZMod.addOrderOf_coe for the orbit size formula (addOrderOf r = n / gcd(n, r.val)) and references MulAction.sum_card_fixedBy_eq_card_orbits_mul_card_group (Burnside's lemma). The core theorem polya_cyclic_fixed_count is independently proved via explicit bijection; the general necklace formula is stated conditionally with Burnside as a hypothesis. However, the concrete §4/§5 verification theorems (fp_count_rot0_4_2, fp_count_rot1_4_2, fp_count_rot2_4_2, fp_count_rot3_4_2, fp_sum_binary4, polya_sum_Z4_binary) discharge their finite Fintype.card computations using `native_decide`, which depends on the `Lean.ofReduceBool` axiom (Lean compiler kernel reduction); those named theorems are therefore not axiom-free. Hence axiomCount = 1; leanFile.axiomCount remains 0 since there are no literal `axiom` declarations.",
     "dateAdded": "2026-04-04",
-    "lineCount": 420,
-    "theoremCount": 19,
+    "lineCount": 445,
+    "theoremCount": 21,
     "definitionCount": 1,
     "additionalFiles": [
       "Proofs/BurnsideCountingOQ03Aristotle.lean",
@@ -206,12 +206,12 @@
     }
   ],
   "leanFile": {
-    "lineCount": 420,
+    "lineCount": 445,
     "path": "Proofs/BurnsideCountingOQ03.lean",
     "axiomCount": 0,
     "sorries": 0,
     "definitionCount": 1,
-    "theoremCount": 18,
+    "theoremCount": 20,
     "additionalFiles": [
       "Proofs/BurnsideCountingOQ03Aristotle.lean",
       {


### PR DESCRIPTION
## Summary

Adds two theorems to `proofs/Proofs/BurnsideCountingOQ03.lean` that make the file's Pólya necklace formulas usable from **Burnside's lemma alone**.

The existing headline theorems `polya_necklace_formula_statement` and `polya_necklace_divisor_formula` both take the fixed-point count `|Fix(r)| = k^gcd(r,n)` as an *unfilled* hypothesis (`h_fixed`) — even though this same file already proves that fact in **full generality** via `polya_cyclic_fixed_count` (an explicit bijection to `Fin d → Fin k`, no `n = 4` restriction). The gap: a user still had to re-prove `h_fixed` to apply the necklace formula.

Two new theorems close that gap by supplying the file's own lemma:

```lean
theorem polya_necklace_formula_of_burnside (n k : ℕ) [NeZero n]
    (necklace_count : ℕ)
    (h_burnside : n * necklace_count =
      ∑ r : Fin n, Fintype.card {c : Fin n → Fin k // IsFixed n k r c}) :
    n * necklace_count = ∑ r : Fin n, k ^ Nat.gcd r.val n

theorem polya_necklace_divisor_formula_of_burnside (n k : ℕ) [NeZero n]
    (necklace_count : ℕ)
    (h_burnside : ...) :
    n * necklace_count = ∑ d ∈ Nat.divisors n, Nat.totient (n / d) * k ^ d
```

Both are trivial partial applications: `fun r => polya_cyclic_fixed_count n k r` has exactly the type of the `h_fixed` argument, and the divisor-sum version additionally invokes the file's `polya_sum_identity` reindexing (already used by `polya_necklace_divisor_formula`).

## Verification

**UNVERIFIED.** Docker image build is down in this environment (containerd `meta.db` input/output error at image build; `docker info` reports OK but `docker-build.sh` cannot build the Lean image). A full `lake build` could not run. The additions are trivial term-mode partial applications of existing verified theorems and type-check by inspection — no new tactics, no new axioms.

## Metadata

- No new axioms or sorries (both proofs are term-mode, hypothesis-parameterized).
- Synced `burnside-counting-oq-03` meta: lineCount 420→445, theoremCount 19→21 (leanFile 18→20).

🤖 Generated with [Claude Code](https://claude.com/claude-code)