### PR TITLE
research(erdos-1014-oq-03): bounded-gap ratio convergence strengthens #1014

### DIFF
--- a/proofs/Proofs/Erdos1014OQ03.lean
+++ b/proofs/Proofs/Erdos1014OQ03.lean
@@ -254,5 +254,56 @@ theorem increment_div_tendsto_zero_iff_log_increment_tendsto_zero (R : ℕ → �
   rw [increment_div_tendsto_zero_iff_ratio_tendsto_one R (hpos.mono fun _ hl => ne_of_gt hl),
     log_increment_tendsto_zero_iff_ratio_tendsto_one R hpos]
 
+/-- **Bounded-gap ratio convergence.** If the consecutive ratio `R(l+1)/R(l)` tends to
+`1` (Erdős #1014) and `R` is eventually positive, then for *every fixed gap* `m` the
+gap-ratio `R(l+m)/R(l)` also tends to `1`.
+
+Telescoping `R(l+m)/R(l) = ∏_{i<m} R(l+i+1)/R(l+i)` into `m` consecutive ratios — each
+`→ 1` (the `i`-th being the unit-gap ratio shifted by `i`) — the product of finitely many
+null-ratios is `1`; formally by induction on `m`, splitting off one factor with
+`div_mul_div_cancel₀`. Applied to `R(k, ·)`, #1014's unit-gap convergence self-strengthens
+to `R(k,l+m)/R(k,l) → 1` for every fixed `m`: Ramsey growth is smooth over any bounded
+window of the second index, not merely between neighbours. -/
+theorem ratio_gap_tendsto_one (R : ℕ → ℝ) (m : ℕ)
+    (hpos : ∀ᶠ l in atTop, 0 < R l)
+    (hratio : Tendsto (fun l => R (l + 1) / R l) atTop (𝓝 1)) :
+    Tendsto (fun l => R (l + m) / R l) atTop (𝓝 1) := by
+  induction m with
+  | zero =>
+      have heq : (fun l => R (l + 0) / R l) =ᶠ[atTop] (fun _ => (1 : ℝ)) := by
+        filter_upwards [hpos] with l hl
+        simp [div_self (ne_of_gt hl)]
+      rw [tendsto_congr' heq]
+      exact tendsto_const_nhds
+  | succ m ih =>
+      have hpos_m : ∀ᶠ l in atTop, 0 < R (l + m) :=
+        (tendsto_add_atTop_nat m).eventually hpos
+      have hmul : Tendsto
+          (fun l => R (l + m + 1) / R (l + m) * (R (l + m) / R l)) atTop (𝓝 1) := by
+        have hshift := hratio.comp (tendsto_add_atTop_nat m)
+        simpa using hshift.mul ih
+      refine hmul.congr' ?_
+      filter_upwards [hpos_m] with l hlm
+      show R (l + m + 1) / R (l + m) * (R (l + m) / R l) = R (l + m + 1) / R l
+      exact div_mul_div_cancel₀ (ne_of_gt hlm)
+
+/-- **Corollary (bounded-gap increment is `o(R)`).** Under #1014's ratio convergence,
+the increment `R(l+m) − R(l)` over any fixed gap `m` is `o(R(l))`:
+`(R(l+m) − R(l))/R(l) → 0`. Immediate from `ratio_gap_tendsto_one`, since
+`(R(l+m) − R(l))/R(l) = R(l+m)/R(l) − 1`; the `m = 1` case is
+`increment_div_tendsto_zero_of_ratio_tendsto_one`. -/
+theorem increment_gap_div_tendsto_zero (R : ℕ → ℝ) (m : ℕ)
+    (hpos : ∀ᶠ l in atTop, 0 < R l)
+    (hratio : Tendsto (fun l => R (l + 1) / R l) atTop (𝓝 1)) :
+    Tendsto (fun l => (R (l + m) - R l) / R l) atTop (𝓝 0) := by
+  have hgap := ratio_gap_tendsto_one R m hpos hratio
+  have heq : (fun l => (R (l + m) - R l) / R l)
+      =ᶠ[atTop] (fun l => R (l + m) / R l - 1) := by
+    filter_upwards [hpos] with l hl
+    rw [sub_div, div_self (ne_of_gt hl)]
+  rw [tendsto_congr' heq]
+  have := hgap.sub_const 1
+  simpa using this
+
 
 end Erdos1014OQ03


### PR DESCRIPTION
## Summary

Two new bridge lemmas in `proofs/Proofs/Erdos1014OQ03.lean` extending the unit-gap increment/ratio family to **arbitrary fixed gaps**:

- **`ratio_gap_tendsto_one`** — if the consecutive ratio `R(l+1)/R(l) → 1` (Erdős #1014) and `R` is eventually positive, then for *every fixed gap* `m` the gap-ratio `R(l+m)/R(l) → 1`. Proved by induction on `m`, splitting off one factor with `div_mul_div_cancel₀` (telescoping `m` consecutive null-ratios). Self-strengthens #1014: Ramsey growth is smooth over any bounded window of the second index, not just between neighbours.
- **`increment_gap_div_tendsto_zero`** — corollary that the bounded-gap increment `R(l+m) − R(l)` is `o(R(l))`; the `m = 1` case recovers the existing `increment_div_tendsto_zero_of_ratio_tendsto_one`.

No new axioms. No gallery meta references this file (no lineCount sync needed).

## Verification

⚠️ **UNVERIFIED** — docker build infra is down this session (containerd content-store blob input/output error at image build; `docker info` misreports OK). All APIs used (`div_mul_div_cancel₀`, `Tendsto.congr'`/`.comp`/`.mul`/`.sub_const`/`.eventually`, `tendsto_add_atTop_nat`) were checked against the local Mathlib pin and mirror idioms already used verbatim in this same file (lines 75, 82, 213).

🤖 Generated with [Claude Code](https://claude.com/claude-code)