### PR TITLE
Enrich 5 verified entries: fill empty references with classical sources

### DIFF
--- a/src/data/proofs/centered-hexagonal-sum-oq-01-oq-01/meta.json
+++ b/src/data/proofs/centered-hexagonal-sum-oq-01-oq-01/meta.json
@@ -1,4 +1,27 @@
 {
+  "references":   [
+    {
+      "authors": "J. H. Conway and R. K. Guy",
+      "title": "The Book of Numbers",
+      "year": "1996",
+      "venue": "Springer-Verlag",
+      "note": "Accessible account of figurate and centered polygonal numbers and their closed forms and partial sums."
+    },
+    {
+      "authors": "E. Deza and M. M. Deza",
+      "title": "Figurate Numbers",
+      "year": "2012",
+      "venue": "World Scientific",
+      "note": "Comprehensive reference for centered k-gonal numbers, their generating formulas, and the closed forms of their partial sums."
+    },
+    {
+      "authors": "OEIS Foundation Inc.",
+      "title": "The On-Line Encyclopedia of Integer Sequences",
+      "year": "2024",
+      "venue": "https://oeis.org",
+      "note": "Catalogues the centered polygonal number families (e.g. centered hexagonal A003215) and their partial-sum sequences with closed-form references."
+    }
+  ],
   "id": "centered-hexagonal-sum-oq-01-oq-01",
   "title": "Centered Polygonal Partial Sums: a Uniform Closed Form",
   "slug": "centered-hexagonal-sum-oq-01-oq-01",

--- a/src/data/proofs/composition-parts-choose-oq-01/meta.json
+++ b/src/data/proofs/composition-parts-choose-oq-01/meta.json
@@ -1,4 +1,27 @@
 {
+  "references":   [
+    {
+      "authors": "R. P. Stanley",
+      "title": "Enumerative Combinatorics, Volume 1",
+      "year": "2011",
+      "venue": "Cambridge University Press, 2nd ed.",
+      "note": "Standard reference for compositions of an integer: the number of compositions of n into k positive parts is C(n-1, k-1) (stars and bars), summing to 2^{n-1} total."
+    },
+    {
+      "authors": "L. Comtet",
+      "title": "Advanced Combinatorics: The Art of Finite and Infinite Expansions",
+      "year": "1974",
+      "venue": "D. Reidel Publishing Company",
+      "note": "Classical enumeration of compositions and their refinement by number of parts."
+    },
+    {
+      "authors": "P. A. MacMahon",
+      "title": "Combinatory Analysis, Volume 1",
+      "year": "1915",
+      "venue": "Cambridge University Press",
+      "note": "Foundational treatise on the theory of compositions and partitions of integers."
+    }
+  ],
   "id": "composition-parts-choose-oq-01",
   "title": "Composition Parts OQ-01: Compositions of n into k Parts Number C(n−1, k−1)",
   "slug": "composition-parts-choose-oq-01",

--- a/src/data/proofs/cramers-rule-oq-06/meta.json
+++ b/src/data/proofs/cramers-rule-oq-06/meta.json
@@ -1,4 +1,27 @@
 {
+  "references":   [
+    {
+      "authors": "A. Cayley",
+      "title": "A Memoir on the Theory of Matrices",
+      "year": "1858",
+      "venue": "Philosophical Transactions of the Royal Society of London, 148, 17–37",
+      "note": "Founding paper of matrix algebra; introduces the adjugate and the identity A·adj(A) = det(A)·I on which the adjugate's multiplicative structure rests."
+    },
+    {
+      "authors": "R. A. Horn and C. R. Johnson",
+      "title": "Matrix Analysis",
+      "year": "2013",
+      "venue": "Cambridge University Press, 2nd ed.",
+      "note": "Standard reference for adjugate (adjoint) identities: adj(AB) = adj(B)·adj(A), det(adj A) = (det A)^{n-1}, and the interaction of the adjugate with transpose and powers."
+    },
+    {
+      "authors": "F. R. Gantmacher",
+      "title": "The Theory of Matrices, Vol. 1",
+      "year": "1959",
+      "venue": "Chelsea Publishing Company",
+      "note": "Classical treatment of the adjugate as an algebraic operation, including its behaviour under conjugation and multiplication."
+    }
+  ],
   "id": "cramers-rule-oq-06",
   "title": "Cramer's Rule OQ-06: The Adjugate Algebra — Multiplicative and Conjugation Identities",
   "slug": "cramers-rule-oq-06",

--- a/src/data/proofs/det-conjugate-transpose-oq-01/meta.json
+++ b/src/data/proofs/det-conjugate-transpose-oq-01/meta.json
@@ -1,4 +1,27 @@
 {
+  "references":   [
+    {
+      "authors": "R. A. Horn and C. R. Johnson",
+      "title": "Matrix Analysis",
+      "year": "2013",
+      "venue": "Cambridge University Press, 2nd ed.",
+      "note": "Standard reference for the conjugate transpose (Hermitian adjoint) M^H, Hermitian and unitary matrices, and the determinant identities det(M^H) = conj(det M) and |det U| = 1 for unitary U."
+    },
+    {
+      "authors": "P. R. Halmos",
+      "title": "Finite-Dimensional Vector Spaces",
+      "year": "1958",
+      "venue": "Van Nostrand, 2nd ed.",
+      "note": "Coordinate-free development of the adjoint operator and its determinant, the operator-theoretic form of det(M^H) = conj(det M)."
+    },
+    {
+      "authors": "S. Axler",
+      "title": "Linear Algebra Done Right",
+      "year": "2015",
+      "venue": "Springer, 3rd ed.",
+      "note": "Modern account of adjoints, self-adjoint (Hermitian) and unitary operators over ℂ, the setting R = StarRing specializes to."
+    }
+  ],
   "id": "det-conjugate-transpose-oq-01",
   "title": "Determinant of the Conjugate Transpose: det Mᴴ = star (det M), with the Hermitian and Unitary Corollaries",
   "slug": "det-conjugate-transpose-oq-01",

--- a/src/data/proofs/factor-remainder-theorem-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/factor-remainder-theorem-oq-01-oq-01-oq-01/meta.json
@@ -1,4 +1,27 @@
 {
+  "references":   [
+    {
+      "authors": "H. Hasse",
+      "title": "Theorie der höheren Differentiale in einem algebraischen Funktionenkörper mit vollkommenem Konstantenkörper bei beliebiger Charakteristik",
+      "year": "1936",
+      "venue": "Journal für die reine und angewandte Mathematik, 175, 50–54",
+      "note": "Introduces the Hasse (higher/hyper) derivatives, whose vanishing detects root multiplicity in arbitrary characteristic where the ordinary iterated derivative fails."
+    },
+    {
+      "authors": "S. Roman",
+      "title": "Field Theory",
+      "year": "2006",
+      "venue": "Springer, GTM 158, 2nd ed.",
+      "note": "Textbook treatment of the Hasse derivative and its use for multiplicity of polynomial roots over fields of positive characteristic, contrasting it with the ordinary derivative."
+    },
+    {
+      "authors": "S. Lang",
+      "title": "Algebra",
+      "year": "2002",
+      "venue": "Springer, GTM 211, 3rd ed.",
+      "note": "Standard reference for the formal derivative, Taylor expansion of polynomials, and root multiplicity, including the characteristic-p degeneracies such as derivative(X^p) = 0."
+    }
+  ],
   "id": "factor-remainder-theorem-oq-01-oq-01-oq-01",
   "title": "The Sharp Positive-Characteristic Discrepancy: Ordinary vs Hasse/Taylor Multiplicity over 𝔽ₚ",
   "slug": "factor-remainder-theorem-oq-01-oq-01-oq-01",


### PR DESCRIPTION
Enrichment pass addressing the REFS0 defect (no `references` field) on 5 published, verified gallery entries. Added 3 accurate references each, using the gallery schema `{authors, title, year, venue, note}` and grounded in each entry's actual mathematical content (read the Lean docstring / description first; no fabricated citations).

| Entry | Topic | References added |
|-------|-------|------------------|
| cramers-rule-oq-06 | Adjugate algebra (adj(AB)=adj(B)adj(A), det(adj A)=(det A)^{n-1}) | Cayley 1858; Horn & Johnson; Gantmacher |
| det-conjugate-transpose-oq-01 | det Mᴴ = conj(det M), Hermitian/unitary | Horn & Johnson; Halmos; Axler |
| factor-remainder-…-oq-01-oq-01-oq-01 | Hasse derivatives & root multiplicity in char p | Hasse 1936; Roman *Field Theory*; Lang *Algebra* |
| composition-parts-choose-oq-01 | Compositions of n into k parts = C(n−1,k−1) | Stanley EC1; Comtet; MacMahon |
| centered-hexagonal-sum-oq-01-oq-01 | Centered polygonal partial-sum closed forms | Conway & Guy; Deza & Deza; OEIS |

Minimal diffs (+23 lines each, references block only); all meta.json well under the 60 KB cap. JSON validated.