### PR TITLE
audit(erdos-926): re-verify clean, bump tracker

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -17438,9 +17438,9 @@
       "result": "clean"
     },
     "erdos-926": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T00:14:06Z",
+      "agentId": "auditor-agent",
+      "auditCount": 4,
+      "lastAudited": "2026-07-10T00:00:00Z",
       "result": "clean"
     },
     "erdos-927": {


### PR DESCRIPTION
## Audit Result: CLEAN

**Proof**: erdos-926 (Erdős Problem #926 — Turán Number of H_k)

Re-audited the stalest gallery entry (last audited 2026-05-04). All claims verified against `proofs/Proofs/Erdos926Problem.lean`:

| Check | meta.json | source | ✓ |
|-------|-----------|--------|---|
| literal axioms | leanFile.axiomCount 0 | 0 | ✓ |
| sorries | 0 | 0 | ✓ |
| definitions | 3 | 3 (hkVertexCount, hkEdgeCount, hkMinusX) | ✓ |
| theorems | 3 | 3 (all native_decide) | ✓ |
| lineCount | 235 | 235 | ✓ |
| True stubs | — | 0 | ✓ |

**native_decide disclosure is correct**: all 3 theorems use `native_decide`, so `meta.axiomCount=1` / `status=axiomatized` / `badge=axiom` with `Lean.ofReduceBool` disclosed in `assumptions`. `leanFile.axiomCount=0` correctly counts literal declarations only (detector-safe: meta ≥ actual).

**No overclaiming**: the main result (ex(n; H_k) ≪ n^(3/2)) is documented-only in comments; the 3 formal theorems are trivial vertex/edge counts of small H_k instances. Tier-C documentation entry, honestly framed.

Only change: tracker date bump.

---
Discovered during gallery integrity audit.