### PR TITLE
research(erdos-666): unbounded C6-free counterexamples across the interval ε ≤ 1/3 [UNVERIFIED]

### DIFF
--- a/proofs/Proofs/Erdos666Problem.lean
+++ b/proofs/Proofs/Erdos666Problem.lean
@@ -320,6 +320,20 @@ theorem conder_counterexamples_unbounded :
   obtain ⟨N, hN⟩ := h
   exact conder_no_threshold ⟨N, hN⟩
 
+/-- **The unbounded counterexamples persist across the whole interval `ε ≤ 1/3`.**
+The interval-level strengthening of `conder_counterexamples_unbounded`, standing to it
+exactly as `conder_no_threshold_le` stands to `conder_no_threshold`.  For *every* density
+`ε ≤ 1/3` and *every* candidate threshold `N`, some `n ≥ N` fails to force `C₆` at density
+`ε`: a `C₆`-free subgraph that is already `(1/3)`-dense is a fortiori `ε`-dense, so the
+Conder counterexamples witnessing `¬ DenseForcesC6 n (1/3)` witness `¬ DenseForcesC6 n ε`
+too (contrapositive of `denseForcesC6_mono`).  No new axioms — pure monotonicity applied to
+the single `conder_no_threshold`. -/
+theorem conder_counterexamples_unbounded_le {ε : ℝ} (hε : ε ≤ 1/3) :
+    ∀ N : ℕ, ∃ n, N ≤ n ∧ ¬ DenseForcesC6 n ε := by
+  intro N
+  obtain ⟨n, hn, hnd⟩ := conder_counterexamples_unbounded N
+  exact ⟨n, hn, fun h => hnd (denseForcesC6_mono hε h)⟩
+
 /-
 ## Part V: Chung's Result (1992)
 

--- a/src/data/proofs/erdos-666/meta.json
+++ b/src/data/proofs/erdos-666/meta.json
@@ -55,9 +55,9 @@
       "GeneralizedConjecture: open question for C_{2k}"
     ],
     "axiomCount": 1,
-    "lineCount": 458,
+    "lineCount": 472,
     "assumptions": "1 axiom (Chung 1992): chung_no_threshold — no threshold N makes every (1/4)-dense subgraph of Qₙ contain C₆; a consequence of Chung's edge-partition of Qₙ into four C₆-free subgraphs, not available in Mathlib. The companion existence statement chung_c6free (for n ≥ 3, Qₙ has some C₆-free subgraph) was previously axiomatized but is now PROVED outright — it carries no edge-count data, so the empty subgraph ⊥ (no edges, hence no cycle) is an honest witness. The deep density content stays isolated in the single axiom chung_no_threshold.",
-    "theoremCount": 14,
+    "theoremCount": 15,
     "definitionCount": 13,
     "proofStrategy": "**Formalization Approach**\\n\\n1. **Hypercube Definition:** Qₙ defined on Fin(2ⁿ) - vertices x, y are adjacent iff their bitwise XOR is a power of two (exactly one differing bit, i.e. Hamming distance 1). Symmetry and looplessness are discharged from Nat.xor_comm and Nat.xor_self.\\n\\n2. **Cycle Definitions:**\\n   - HasCycle G k: injective k-sequence with cyclic adjacency\\n   - HasC4, HasC6, HasC2k: specific even cycle predicates\\n\\n3. **Density:**\\n   - EpsilonDenseSubgraph: at least ε·n·2ⁿ⁻¹ edges\\n\\n4. **Main Results:**\\n   - ErdosConjecture: the (false) original conjecture\\n   - erdos_conjecture_false: theorem showing it is false, fully proved (no sorry) from chung_no_threshold\\n   - conder_no_threshold axiom (ε = 1/3): no threshold N forces C₆ in every (1/3)-dense subgraph of Qₙ — the pigeonhole consequence of Conder 1993's 3-edge-colouring, the sharpest known refutation and the single deep input\\n   - chung_no_threshold theorem (ε = 1/4): now DERIVED from conder_no_threshold via monotonicity of ConjectureAt (1/4 ≤ 1/3), so no separate Chung axiom is needed; still consumed by erdos_conjecture_false\\n   - conjectureAt_mono / epsilonDense_antitone / denseForcesC6_mono: axiom-free monotonicity bookkeeping used to derive Chung from Conder and to spread each refutation across an interval\\n   - chung_no_threshold_le / conder_no_threshold_le: the refutation holds on the whole intervals ε ≤ 1/4 and (sharpest) ε ≤ 1/3\\n   - chung_c6free theorem (de-axiomatized): for n ≥ 3, Qₙ has a C₆-free subgraph — proved via the empty subgraph ⊥ (no edges ⇒ no C₆)\\n   - chung_counterexample / conder_counterexample: ε = 1/4 and ε = 1/3 C₆-free existence witnesses, both derived from chung_c6free\\n\\n5. **Why axioms:** Conder's explicit 3-edge-colouring construction is combinatorial and not available in Mathlib. It is captured by a single density axiom conder_no_threshold, whose ¬ ConjectureAt (1/3) arrow form avoids a Mathlib v4.26 elaborator stack overflow triggered by the bundled ∃ H, (edge bound) ∧ ¬ HasC6 H form. Definitions HasCycle/HasC6/EpsilonDenseSubgraph are marked @[irreducible] for the same reason (1 axiom, 0 sorries)."
   },
@@ -172,9 +172,9 @@
       "SimpleGraph"
     ],
     "namespace": "Erdos666",
-    "lineCount": 443,
+    "lineCount": 472,
     "axiomCount": 1,
-    "theoremCount": 12,
+    "theoremCount": 13,
     "definitionCount": 13,
     "path": "Proofs/Erdos666Problem.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

Adds `conder_counterexamples_unbounded_le` to `proofs/Proofs/Erdos666Problem.lean`, the interval-level strengthening of the file's existing `conder_counterexamples_unbounded`.

The file already proves (Part IV.5) that each refutation of Erdős's C₆ conjecture spreads across an interval of densities — `conder_no_threshold_le` extends `conder_no_threshold` (`¬ ConjectureAt (1/3)`) to all `ε ≤ 1/3`. It separately proves `conder_counterexamples_unbounded`: the positive/unbounded form at the fixed density `ε = 1/3` (for every threshold `N`, some `n ≥ N` has `¬ DenseForcesC6 n (1/3)`).

The missing companion — the **unbounded form across the whole interval** — is added here:

```lean
theorem conder_counterexamples_unbounded_le {ε : ℝ} (hε : ε ≤ 1/3) :
    ∀ N : ℕ, ∃ n, N ≤ n ∧ ¬ DenseForcesC6 n ε
```

**Proof (pure monotonicity, no new axioms):** a `C₆`-free subgraph that is already `(1/3)`-dense is a fortiori `ε`-dense for `ε ≤ 1/3`, so the same Conder counterexamples witnessing `¬ DenseForcesC6 n (1/3)` witness `¬ DenseForcesC6 n ε`. Formally this is the contrapositive of the file's `denseForcesC6_mono`: `denseForcesC6_mono hε h` lifts `DenseForcesC6 n ε` to `DenseForcesC6 n (1/3)`, contradicting the `ε = 1/3` counterexample. Rests on the single deep axiom `conder_no_threshold`.

## Verification

**UNVERIFIED.** Docker image build is down in this environment (containerd `meta.db` input/output error at image build; `docker info` reports healthy but `docker-build.sh` cannot build the Lean image). A full `lake build` could not run. The addition is a two-line term-mode proof over the file's own verified `denseForcesC6_mono` / `conder_counterexamples_unbounded`; it type-checks by inspection and introduces no new axioms.

## Metadata

- No new axioms or sorries (axiom count stays at 1: `conder_no_threshold`).
- Synced `erdos-666` meta: lineCount 458→472, theoremCount 14→15 (leanFile 443→472 — also resyncing a pre-existing lineCount drift — and 12→13).

🤖 Generated with [Claude Code](https://claude.com/claude-code)