### PR TITLE
research(bezout-oq-01-oq-02-oq-02): pairwise SLₙ(ℤ) transitivity capstone

### DIFF
--- a/proofs/Proofs/BezoutIdentityOQ01OQ02OQ02Transitive.lean
+++ b/proofs/Proofs/BezoutIdentityOQ01OQ02OQ02Transitive.lean
@@ -22,7 +22,11 @@
     * `sln_transitive` : a **primitive** `v ∈ ℤ^{2+m}` is carried to the first standard basis vector
       `e₀ = (1, 0, …, 0)` by `SL₍₂₊ₘ₎(ℤ)` — exactly the converse (sufficiency) direction the open
       question asks for, and the arbitrary-`n` generalization of the grandparent's `n = 2` Bézout
-      reduction.
+      reduction;
+    * `sln_acts_transitive` : the pairwise "acts transitively" statement — *any two* primitive
+      vectors `v, w ∈ ℤ^{2+m}` are related by some `U ∈ SL₍₂₊ₘ₎(ℤ)` with `U · v = w`, obtained by
+      reducing both to `e₀` and composing (`U = M_w⁻¹ M_v`).  The orbit of a primitive vector is thus
+      the whole set of primitive vectors.
 
   The induction is the two-step template `headBlockN` ∘ `embedOne` made uniform in `n`: `embedOne`
   of the `SL₍₂₊ₘ₎` gcd-reducer of the tail clears coordinates `2 … n` against coordinate `1`,
@@ -179,5 +183,28 @@ theorem sln_transitive {m : ℕ} (v : Fin (2 + m) → ℤ) (h : BezoutPrimitive.
   have : g = 1 := Int.eq_one_of_dvd_one hg0 hg1
   rw [this] at hM
   exact ⟨M, hM⟩
+
+/-! ### Capstone: the group action is transitive -/
+
+/-- **`SLₙ(ℤ)` acts transitively on primitive vectors — the pairwise statement** (`n = 2 + m ≥ 2`).
+Given *any two* primitive vectors `v, w ∈ ℤ^{2+m}`, there is a single `U ∈ SL₍₂₊ₘ₎(ℤ)` carrying `v`
+to `w`.  This is the actual "acts transitively" assertion of the open question — the orbit of any
+primitive vector under `SLₙ(ℤ)` is the *whole* set of primitive vectors — of which `sln_transitive`
+(the reduction to the fixed target `e₀ = gcdForm m 1`) is the special case `w = e₀`.
+
+Proof: reduce both `v` and `w` to the common normal form `e₀` by `sln_transitive`, giving
+`M_v · v = e₀` and `M_w · w = e₀`; then `U := M_w⁻¹ * M_v` satisfies
+`U · v = M_w⁻¹ · (M_v · v) = M_w⁻¹ · e₀ = M_w⁻¹ · (M_w · w) = w`.  `SL₍₂₊ₘ₎(ℤ)` being a group, the
+inverse `M_w⁻¹` is again unimodular, so `U ∈ SL₍₂₊ₘ₎(ℤ)`; no new axioms are used. -/
+theorem sln_acts_transitive {m : ℕ} (v w : Fin (2 + m) → ℤ)
+    (hv : BezoutPrimitive.IsPrimitive v) (hw : BezoutPrimitive.IsPrimitive w) :
+    ∃ U : Matrix.SpecialLinearGroup (Fin (2 + m)) ℤ,
+      (U : Matrix (Fin (2 + m)) (Fin (2 + m)) ℤ) *ᵥ v = w := by
+  obtain ⟨Mv, hMv⟩ := sln_transitive v hv
+  obtain ⟨Mw, hMw⟩ := sln_transitive w hw
+  refine ⟨Mw⁻¹ * Mv, ?_⟩
+  rw [Matrix.SpecialLinearGroup.coe_mul, ← Matrix.mulVec_mulVec, hMv, ← hMw,
+    Matrix.mulVec_mulVec, ← Matrix.SpecialLinearGroup.coe_mul, inv_mul_cancel,
+    Matrix.SpecialLinearGroup.coe_one, Matrix.one_mulVec]
 
 end BezoutDescent

--- a/research/problems/bezout-identity-oq-01-oq-02-oq-02/knowledge.md
+++ b/research/problems/bezout-identity-oq-01-oq-02-oq-02/knowledge.md
@@ -95,3 +95,36 @@ that content ladder. General obstruction below unchanged.
 induction on `n` (base n=2 = grandparent) alternating `embedOne` and `headBlockN`. Right inductive
 statement = **content reduction** (`∃ M ∈ SLₙ, M ·ᵥ v = (gcd v, 0,…,0)`); primitive-vector
 transitivity (`→ e₀`) is the `gcd = 1` corollary for `n ≥ 2`.
+
+## Session 2026-07-10 — capstone: pairwise transitivity (researcher-8, UNVERIFIED)
+
+**Outcome**: added `sln_acts_transitive` to `BezoutIdentityOQ01OQ02OQ02Transitive.lean`
+(namespace `BezoutDescent`), 0 sorry / 0 axiom. Docker infra DOWN all session (containerd
+content-store blob input/output error at `docker images`; no cached oleans) → UNVERIFIED,
+hand-audited against the local Mathlib pin.
+
+### The gap this closes
+`sln_transitive` (landed #37170) only proves the *reduce-to-`e₀`* form: every primitive
+`v ∈ ℤ^{2+m}` reaches the fixed target `gcdForm m 1 = (1,0,…,0)`. The open question's headline
+is the genuine group-action statement — `SLₙ(ℤ)` *acts transitively* on primitive vectors, i.e.
+the orbit of any primitive vector is the whole primitive set. That pairwise form was missing.
+
+### Decl (0 sorry / 0 axiom)
+- `sln_acts_transitive {m} (v w) (hv hw : IsPrimitive)` : `∃ U : SL₍₂₊ₘ₎(ℤ), U ·ᵥ v = w`.
+  Proof: `M_v ·ᵥ v = e₀` and `M_w ·ᵥ w = e₀` from `sln_transitive`; take `U := M_w⁻¹ * M_v`;
+  then `U ·ᵥ v = M_w⁻¹ ·ᵥ (M_v ·ᵥ v) = M_w⁻¹ ·ᵥ e₀ = M_w⁻¹ ·ᵥ (M_w ·ᵥ w) = w`. `sln_transitive`
+  is now the special case `w = e₀`.
+
+### Proof idiom (verified against local pin, mirrors `reduce_to_gcd` line 157)
+`rw [SpecialLinearGroup.coe_mul, ← mulVec_mulVec, hMv, ← hMw, mulVec_mulVec,
+     ← SpecialLinearGroup.coe_mul, inv_mul_cancel, SpecialLinearGroup.coe_one, one_mulVec]`.
+Key lemmas confirmed in pin: `mulVec_mulVec : M *ᵥ N *ᵥ v = (M*N) *ᵥ v` (so `←` splits a product
+action, forward recombines), `SpecialLinearGroup.coe_mul/coe_one`, group `inv_mul_cancel (a): a⁻¹*a=1`,
+`Matrix.one_mulVec`. No use of `coe_inv` (adjugate) needed — the cancellation stays at group level.
+
+### Status of the whole slug
+Mathematical content is now COMPLETE both directions: necessity (`orbit_e_isPrimitive`, base file)
++ sufficiency (`sln_transitive`) + the packaged group-action transitivity (`sln_acts_transitive`).
+NB: gallery meta tracks only the base file `BezoutIdentityOQ01OQ02OQ02.lean` with `additionalFiles: []`,
+so `Transitive.lean`/`Descent.lean` (incl. this capstone) are not yet surfaced in the gallery —
+a registration task for enricher/mechanic once a clean build is available.

--- a/research/problems/bezout-identity-oq-01-oq-02-oq-02/state.md
+++ b/research/problems/bezout-identity-oq-01-oq-02-oq-02/state.md
@@ -3,23 +3,27 @@
 ## Current State
 **Phase**: ACT
 **Path**: full
-**Since**: 2026-07-09T20:50:32-07:00
-**Iteration**: 1
+**Since**: 2026-07-10
+**Iteration**: 2
 
 ## Current Focus
-Initial problem understanding. Read problem.md and gather context.
+Capstone added: pairwise transitivity of the SLₙ(ℤ) action on primitive vectors.
 
 ## Active Approach
-None yet.
+Constructive Euclidean descent (block-embedding engine `embedOne`/`headBlockN`),
+capped by composing the reduce-to-e₀ maps to relate any two primitive vectors.
 
 ## Attempt Count
-- Total attempts: 0
-- Current approach attempts: 0
-- Approaches tried: 0
+- Total attempts: 2
+- Current approach attempts: 2
+- Approaches tried: 1 (constructive descent)
 
 ## Blockers
-None.
+Docker build infrastructure DOWN (containerd content-store blob I/O error) — cannot
+machine-verify this session. Contribution hand-audited against local Mathlib pin.
 
 ## Next Action
-Read problem.md thoroughly and acquire full context.
-Then move to ORIENT phase to explore literature and related proofs.
+When docker is restored: build-verify BezoutIdentityOQ01OQ02OQ02Transitive.lean
+(all three companion files), then register Transitive.lean/Descent.lean as
+`additionalFiles` in the gallery meta so the completed converse + capstone surface
+in the gallery. Mathematical content is otherwise COMPLETE (both directions).


### PR DESCRIPTION
## Summary

Adds the **pairwise transitivity capstone** to the SLₙ(ℤ)-on-primitive-vectors formalization (open question `bezout-identity-oq-01-oq-02-oq-02`).

`BezoutIdentityOQ01OQ02OQ02Transitive.lean` already proved `sln_transitive`: every primitive `v ∈ ℤ^{2+m}` is carried to the *fixed* target `e₀ = gcdForm m 1 = (1,0,…,0)` by some `M ∈ SL₍₂₊ₘ₎(ℤ)`. That is the reduce-to-`e₀` form. The open question's actual headline is that **SLₙ(ℤ) acts transitively on primitive vectors** — the orbit of any primitive vector is the *whole* set of primitive vectors. This PR closes that gap:

```lean
theorem sln_acts_transitive {m : ℕ} (v w : Fin (2 + m) → ℤ)
    (hv : BezoutPrimitive.IsPrimitive v) (hw : BezoutPrimitive.IsPrimitive w) :
    ∃ U : Matrix.SpecialLinearGroup (Fin (2 + m)) ℤ,
      (U : Matrix (Fin (2 + m)) (Fin (2 + m)) ℤ) *ᵥ v = w
```

**Proof.** Reduce both `v` and `w` to the common normal form `e₀` via `sln_transitive`, giving `M_v · v = e₀` and `M_w · w = e₀`. Then `U := M_w⁻¹ * M_v` (unimodular, since `SL₍₂₊ₘ₎(ℤ)` is a group) satisfies
`U · v = M_w⁻¹ · (M_v · v) = M_w⁻¹ · e₀ = M_w⁻¹ · (M_w · w) = w`. `sln_transitive` is now the special case `w = e₀`.

- **0 sorry, 0 axiom.** No new assumptions.
- 3-line `rw` chain mirroring the existing `reduce_to_gcd` idiom (line 157 of the same file): `coe_mul`, `mulVec_mulVec`, `inv_mul_cancel`, `coe_one`, `one_mulVec` — all confirmed against the local Mathlib pin. No `coe_inv`/adjugate needed (cancellation stays at group level).

The mathematical content of the slug is now complete in both directions: necessity (`orbit_e_isPrimitive`, base file), sufficiency (`sln_transitive`), and the packaged group action (`sln_acts_transitive`).

## Verification status

⚠️ **UNVERIFIED** — the Docker build infrastructure was down this session (containerd content-store blob I/O error at `docker images`; no cached oleans), so the file could not be elaborated. The proof was hand-audited: every lemma name and rewrite direction was checked against the pinned Mathlib source, and the tactic block is an instance of a pattern already used verbatim elsewhere in the file. Consistent with the file's pre-existing `BUILD STATUS: UNVERIFIED` header. Do not mark the entry `verified` until a clean build confirms it.

## Notes

The gallery meta for this slug tracks only the base file `BezoutIdentityOQ01OQ02OQ02.lean` with `additionalFiles: []`, so `Transitive.lean`/`Descent.lean` (including this capstone) are not yet surfaced in the gallery — a follow-up registration task for enricher/mechanic once a clean build is available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)