### PR TITLE
Fix: resync 8 companion-file lineCount drifts (gallery metadata)

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-04/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-04/meta.json
@@ -177,7 +177,7 @@
       },
       {
         "path": "Proofs/AmgmInequalityOQ04OQ03.lean",
-        "lineCount": 224,
+        "lineCount": 315,
         "theorems": 10,
         "definitions": 2,
         "axioms": 1,

--- a/src/data/proofs/area-of-circle-oq-05/meta.json
+++ b/src/data/proofs/area-of-circle-oq-05/meta.json
@@ -191,7 +191,7 @@
     "additionalFiles": [
       {
         "path": "Proofs/AreaOfCircleOQ05OQ04.lean",
-        "lineCount": 854,
+        "lineCount": 1114,
         "theorems": 25,
         "definitions": 0,
         "axioms": 0,

--- a/src/data/proofs/ballot-problem-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/ballot-problem-oq-01-oq-01-oq-02/meta.json
@@ -141,7 +141,7 @@
     "additionalFiles": [
       {
         "path": "Proofs/BallotProblemOQ01OQ01OQ02OQ01.lean",
-        "lineCount": 626,
+        "lineCount": 640,
         "theorems": 12,
         "definitions": 0,
         "axioms": 0,

--- a/src/data/proofs/birthday-problem-oq-01/meta.json
+++ b/src/data/proofs/birthday-problem-oq-01/meta.json
@@ -250,7 +250,7 @@
     "additionalFiles": [
       {
         "path": "Proofs/BirthdayProblemOQ01OQ02.lean",
-        "lineCount": 235,
+        "lineCount": 263,
         "theorems": 4,
         "definitions": 0,
         "axioms": 0,

--- a/src/data/proofs/bounded-prime-gaps-oq-03/meta.json
+++ b/src/data/proofs/bounded-prime-gaps-oq-03/meta.json
@@ -243,7 +243,7 @@
     "additionalFiles": [
       {
         "path": "Proofs/BoundedPrimeGapsOQ03OQ02.lean",
-        "lineCount": 953,
+        "lineCount": 997,
         "theorems": 29,
         "definitions": 7,
         "axioms": 0,

--- a/src/data/proofs/brouwer-fixed-point-oq-04/meta.json
+++ b/src/data/proofs/brouwer-fixed-point-oq-04/meta.json
@@ -231,7 +231,7 @@
     "additionalFiles": [
       {
         "path": "Proofs/BrouwerFixedPointOQ04OQ01.lean",
-        "lineCount": 296,
+        "lineCount": 305,
         "theorems": 8,
         "definitions": 6,
         "axioms": 2,

--- a/src/data/proofs/cayley-hamilton-minpoly-oq-03/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-03/meta.json
@@ -100,7 +100,7 @@
       "Proofs/CayleyHamiltonMinpolyOQ03Aristotle.lean",
       {
         "path": "Proofs/CayleyHamiltonMinpolyOQ03OQ02.lean",
-        "lineCount": 333,
+        "lineCount": 383,
         "theorems": 11,
         "definitions": 2,
         "axioms": 3,

--- a/src/data/proofs/tractatus-ontology/meta.json
+++ b/src/data/proofs/tractatus-ontology/meta.json
@@ -306,7 +306,7 @@
       },
       {
         "path": "Proofs/TractatusOntologySpectrum.lean",
-        "lineCount": 307,
+        "lineCount": 459,
         "theorems": 19,
         "definitions": 4,
         "axioms": 0,


### PR DESCRIPTION
## Fix

Resync `additionalFiles[].lineCount` for 8 gallery entries whose companion `.lean` files grew (via merged research/enrichment) but whose metadata was never updated. Metadata-only; no Lean code touched.

## Evidence

| slug | companion file | before | after (actual `wc -l`) |
|------|----------------|--------|-------|
| amgm-inequality-oq-04 | AmgmInequalityOQ04OQ03.lean | 224 | 315 |
| area-of-circle-oq-05 | AreaOfCircleOQ05OQ04.lean | 854 | 1114 |
| ballot-problem-oq-01-oq-01-oq-02 | BallotProblemOQ01OQ01OQ02OQ01.lean | 626 | 640 |
| birthday-problem-oq-01 | BirthdayProblemOQ01OQ02.lean | 235 | 263 |
| bounded-prime-gaps-oq-03 | BoundedPrimeGapsOQ03OQ02.lean | 953 | 997 |
| brouwer-fixed-point-oq-04 | BrouwerFixedPointOQ04OQ01.lean | 296 | 305 |
| cayley-hamilton-minpoly-oq-03 | CayleyHamiltonMinpolyOQ03OQ02.lean | 333 | 383 |
| tractatus-ontology | TractatusOntologySpectrum.lean | 307 | 459 |

Each is a genuine, uncovered drift: no open PR touches these companion files or their metas. All 8 companion files end with a trailing newline, so `wc -l` equals the content-line count. Diff is 8 one-line changes; JSON remains valid.

---
Automated fix by lean-mechanic agent.