### PR TITLE
research(roth-theorem-k3-oq-03-oq-01): k-AP count vanishes iff A empty

### DIFF
--- a/proofs/Proofs/RothTheoremOQ03OQ01.lean
+++ b/proofs/Proofs/RothTheoremOQ03OQ01.lean
@@ -662,6 +662,18 @@ theorem kAPCount_count_pos_iff {N : ℕ} [NeZero N] {k : ℕ} (hk : 0 < k)
   rw [Finset.mem_filter] at hp
   exact ⟨p.1, by simpa using hp.2 ⟨0, hk⟩⟩
 
+/-- **Vanishing characterizes emptiness.**  For `k ≥ 1`, the `k`-AP count of `A` is `0` iff
+    `A` is empty: a nonempty set always supplies its diagonal (constant) progressions, so the
+    only way the count can vanish is `A = ∅`.  The vanishing (`δ = 0`) companion of the
+    positivity characterization `kAPCount_count_pos_iff`, and the "iff" strengthening of the
+    empty-set base case `kAPCount_count_empty`. -/
+theorem kAPCount_count_eq_zero_iff {N : ℕ} [NeZero N] {k : ℕ} (hk : 0 < k)
+    {A : Finset (ZMod N)} :
+    (Finset.univ.filter (fun p : ZMod N × ZMod N =>
+        ∀ i : Fin k, p.1 + i.val • p.2 ∈ A)).card = 0 ↔ A = ∅ := by
+  rw [← Finset.not_nonempty_iff_eq_empty, ← kAPCount_count_pos_iff hk]
+  omega
+
 /-- **Exact count for the whole group.**  Every pair `(x, d)` has its length-`k` progression
     inside `univ`, so the `k`-AP count of the full group is exactly `N²` — the combinatorial
     companion of the normalized identity `kAPCount_indicator_univ`

--- a/src/data/proofs/roth-theorem-k3-oq-03-oq-01/meta.json
+++ b/src/data/proofs/roth-theorem-k3-oq-03-oq-01/meta.json
@@ -58,9 +58,9 @@
       "kAPCount_eq_zero_of_zero: a single zero slot annihilates the count — if f j = 0 then Λ_k(f₀,…,f_{k-1}) = 0, since the j-th factor of every product term vanishes"
     ],
     "axiomCount": 0,
-    "lineCount": 719,
+    "lineCount": 731,
     "assumptions": "0 axioms, 0 sorries. Only the foundational axioms propext / Classical.choice / Quot.sound are used; no native_decide, no sorryAx, no Lean.ofReduceBool. The operators are re-declared self-containedly in this file's namespace; the file imports Mathlib.",
-    "theoremCount": 26,
+    "theoremCount": 27,
     "definitionCount": 5
   },
   "overview": {
@@ -142,9 +142,9 @@
       "BigOperators"
     ],
     "namespace": "RothTheoremOQ03OQ01",
-    "lineCount": 719,
+    "lineCount": 731,
     "axiomCount": 0,
-    "theoremCount": 26,
+    "theoremCount": 27,
     "definitionCount": 5,
     "path": "Proofs/RothTheoremOQ03OQ01.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

Adds one foundational identity to the saturated, fully-verified entry **Roth/Szemerédi OQ-03-OQ-01** (`RothTheoremOQ03OQ01.lean`, previously 26 theorems / 0 axioms / 0 sorries):

- **`kAPCount_count_eq_zero_iff`** — for `k ≥ 1`, the `k`-AP count of `A` is `0` iff `A = ∅`:
  ```
  #{(x,d) : ∀ i, x + i·d ∈ A} = 0  ↔  A = ∅.
  ```

This is the **vanishing (`δ = 0`) companion** of the existing positivity characterization `kAPCount_count_pos_iff` (`0 < count ↔ A.Nonempty`), and the **"iff" strengthening** of the empty-set base case `kAPCount_count_empty` (`A = ∅ ⇒ count = 0`). A nonempty set always contributes its diagonal (`d = 0`) constant progressions, so the count vanishes exactly when `A` is empty.

## Proof

Three lines: rewrite `A = ∅` via `Finset.not_nonempty_iff_eq_empty`, rewrite `A.Nonempty` back through `kAPCount_count_pos_iff hk`, reducing the goal to `x = 0 ↔ ¬(0 < x)`, discharged by `omega`. No new axioms or assumptions.

## Verification status

⚠️ **UNVERIFIED** — the Docker Lean build environment is down this session (containerd content-store blob I/O error at image build). The proof is a pure rewrite chain into `omega` reusing lemmas already proved in the same file; confidence is high, but it has not been machine-checked. Meta counts synced: lineCount 719→731, theoremCount 26→27 (both `meta` and `leanFile` copies).

🤖 Generated with [Claude Code](https://claude.com/claude-code)