### PR TITLE
Fix: resync 4 uncovered lineCount drifts in gallery meta

### DIFF
--- a/src/data/proofs/british-flag-theorem-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/british-flag-theorem-oq-01-oq-02-oq-01/meta.json
@@ -247,7 +247,7 @@
     {
       "path": "Proofs/BritishFlagFourthMomentOQ010201.lean",
       "namespace": "BritishFlagFourthMomentOQ010201",
-      "lineCount": 379,
+      "lineCount": 611,
       "axiomCount": 0,
       "theoremCount": 7,
       "definitionCount": 2,

--- a/src/data/proofs/erdos-1014-oq-04/meta.json
+++ b/src/data/proofs/erdos-1014-oq-04/meta.json
@@ -42,7 +42,7 @@
       {
         "path": "Proofs/Erdos1014OQ01.lean",
         "filename": "Erdos1014OQ01.lean",
-        "lineCount": 365,
+        "lineCount": 367,
         "theoremCount": 15,
         "axiomCount": 1,
         "defCount": 1,

--- a/src/data/proofs/erdos-152/meta.json
+++ b/src/data/proofs/erdos-152/meta.json
@@ -153,7 +153,7 @@
       {
         "path": "Proofs/Erdos152ProblemAPN.lean",
         "description": "DeepMind AlphaProof Nexus port of the weak form: establishes `Tendsto f atTop atTop` via the explicit bound `16 * num_isolated A + 100*n + 16 ≥ n*n`.",
-        "lineCount": 538,
+        "lineCount": 559,
         "axiomCount": 0,
         "sorries": 0,
         "namespace": "Erdos152APN"

--- a/src/data/proofs/erdos-90/meta.json
+++ b/src/data/proofs/erdos-90/meta.json
@@ -84,7 +84,7 @@
           "3 structure fields in ClassFieldTowerWitness (tower-level family)",
           "3 structure fields in LClassFieldTowerWitness (ℓ-tower-level family)"
         ],
-        "lineCount": 0,
+        "lineCount": 324,
         "status": "axiomatized",
         "issue": 22607
       },


### PR DESCRIPTION
## Fix

Resync four gallery `meta.json` `lineCount` fields that drifted from their Lean source files. None are covered by any open PR (verified against all 79 open PRs by cross-referencing each PR's changed files against the drifted meta/lean paths).

## Evidence

| slug | file | before | after (actual `wc -l`) |
|------|------|--------|-------|
| british-flag-theorem-oq-01-oq-02-oq-01 | BritishFlagFourthMomentOQ010201.lean | 379 | 611 |
| erdos-1014-oq-04 | Erdos1014OQ01.lean | 365 | 367 |
| erdos-152 | Erdos152ProblemAPN.lean | 538 | 559 |
| erdos-90 | Erdos90/ClassFieldTower.lean | 0 | 324 |

The erdos-90 companion was recorded as a `0`-line stub in meta but the file is genuinely 324 lines on `main`.

Other drifts observed this cycle are all covered by open PRs and were skipped: #37270 (8 companion resyncs), #37240/#37248/#37268/#37259/#37235/#36432/#37249/#36998/#35217.

Minimal 1-line diffs; all four JSON files validate.

---
Automated fix by lean-mechanic agent.