### PR TITLE
research(elem-quad-recip-oq-03-oq-02): denominator power law for the Kronecker symbol

### DIFF
--- a/proofs/Proofs/ElementaryQuadraticReciprocityOQ03OQ02.lean
+++ b/proofs/Proofs/ElementaryQuadraticReciprocityOQ03OQ02.lean
@@ -383,6 +383,32 @@ theorem kronecker_mul_right_odd (a : ℤ) (m n : ℕ)
     kronecker_eq_jacobi a m hm hmo, kronecker_eq_jacobi a n hn hno,
     jacobiSym.mul_right' a (by omega) (by omega)]
 
+/-- **The symbol at a prime-power modulus is the power of the symbol.**
+    For any nonzero modulus `n` and exponent `k`, `(a / nᵏ) = (a/n)ᵏ`.
+
+    This is the denominator-side companion of `kronecker_sq_left`
+    `(a²/n) = (a/n)²` (which powers the *numerator*): here the modulus is
+    raised to a power. It follows by induction from second-argument
+    multiplicativity `kronecker_mul_right` on `nᵏ⁺¹ = nᵏ · n` (a nonzero
+    product for `n ≠ 0`), with the base case `(a/n⁰) = (a/1) = 1 = (a/n)⁰`
+    supplied by `kronecker_one_right`. It generalizes the square case
+    `(a/n²) = (a/n)²` to every exponent. -/
+theorem kronecker_pow_right (a n : ℤ) (k : ℕ) (hn : n ≠ 0) :
+    kronecker a (n ^ k) = kronecker a n ^ k := by
+  induction k with
+  | zero => simp only [pow_zero, kronecker_one_right]
+  | succ k ih =>
+    have hnk : n ^ k ≠ 0 := pow_ne_zero k hn
+    rw [pow_succ, kronecker_mul_right a (n ^ k) n (mul_ne_zero hnk hn), ih, pow_succ]
+
+/-- **The symbol is non-negative at even-power moduli.**  For nonzero `n`,
+    `0 ≤ (a / n^(2j))`: the value is `(a/n)^(2j) = ((a/n)^j)²`, a perfect
+    square. Denominator-side companion of `kronecker_sq_left_nonneg`. -/
+theorem kronecker_even_pow_right_nonneg (a n : ℤ) (j : ℕ) (hn : n ≠ 0) :
+    0 ≤ kronecker a (n ^ (2 * j)) := by
+  rw [kronecker_pow_right a n (2 * j) hn, mul_comm 2 j, pow_mul]
+  exact sq_nonneg _
+
 /-- **Quadratic reciprocity for the Kronecker symbol, odd positive case.**
     For odd positive m, n:
     (m/n) = (-1)^{((m-1)/2)·((n-1)/2)} · (n/m).

--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-03-oq-02/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-03-oq-02/meta.json
@@ -20,7 +20,7 @@
     "axiomCount": 0,
     "theoremCount": 56,
     "defCount": 4,
-    "lineCount": 930,
+    "lineCount": 956,
     "dateAdded": "2026-03-28",
     "assumptions": "0 axioms, 0 sorries — the file is fully machine-verified (no axiom or sorry is used). Complete multiplicativity is now proven in BOTH arguments over all nonzero moduli: kronecker_mul_left and kronecker_mul_right, alongside agreement with the Jacobi symbol and odd-modulus quadratic reciprocity. Status is kept 'wip' because the FORMALIZATION of the classical symbol is still partial, not because anything is assumed: (1) the definition routes even moduli through jacobiSym |n| rather than the classical mod-8 character kronecker2, so kronecker_mul_right is multiplicativity of the symbol as defined (which matches the classical Kronecker symbol at all odd moduli and at n = plus/minus 1); and (2) generalized quadratic reciprocity for arbitrary fundamental discriminants remains open. Both are documented as open work in the source module note; neither is axiomatized. Toward (2), the denominator-side supplementary characters are now shown periodic: kronecker_neg_one_periodic ((-1/.) is periodic mod 4) and kronecker_two_periodic ((2/.) is periodic mod 8), the structural complement of kronecker2_periodic (the numerator character (./2) is a Dirichlet character mod 8) and a Gauss-sum-route input.",
     "mathlib_version": "4.26.0",
@@ -97,7 +97,7 @@
       "Mathlib.NumberTheory.LegendreSymbol.JacobiSymbol"
     ],
     "namespace": "KroneckerSymbol",
-    "lineCount": 930,
+    "lineCount": 956,
     "axiomCount": 0,
     "theoremCount": 56,
     "definitionCount": 4,


### PR DESCRIPTION
## Summary

Adds the **denominator power law** for the Kronecker symbol to
`ElementaryQuadraticReciprocityOQ03OQ02.lean` — the denominator-side dual of the
existing numerator power/square laws. Two theorems:

- **`kronecker_pow_right`** — `(a / nᵏ) = (a/n)ᵏ` for every nonzero modulus `n`
  and exponent `k`. Induction from second-argument multiplicativity
  `kronecker_mul_right` on `nᵏ⁺¹ = nᵏ · n` (a nonzero product), base case
  `(a/n⁰) = (a/1) = 1` via `kronecker_one_right`. Generalizes the square case
  `(a/n²) = (a/n)²` to all exponents; the denominator analogue of the numerator
  law `kronecker_sq_left`.
- **`kronecker_even_pow_right_nonneg`** — `0 ≤ (a / n^(2j))`, since the value is
  a perfect square `((a/n)ʲ)²`. Denominator companion of
  `kronecker_sq_left_nonneg`.

Both are one-line proofs off existing multiplicativity plus standard
`pow_succ`/`pow_mul`/`sq_nonneg` Mathlib API. **No new axioms or sorries.**

## Context

Complements the numerator-side laws already in the file (`kronecker_sq_left`
et al.) and does not overlap with in-flight PRs #37258 (denominator *square*
trio, Section 13) or #36458 (numerator MonoidHom / `kronecker_pow_left_odd`):
those add square/odd-modulus results; this adds the general **denominator**
power law near the `kronecker_mul_right` block.

Synced gallery `meta.json` `lineCount` 930 → 956.

## Verification status

⚠️ **UNVERIFIED** — the Docker Lean build is currently unavailable (containerd
content-store blob `input/output error`; `docker info` reports OK but image
operations fail). The proofs elaborate by inspection:

- `kronecker_pow_right` zero case: `pow_zero` + `kronecker_one_right` ⇒ `1 = 1`.
- succ case: `pow_succ` ⇒ `nᵏ·n`; `kronecker_mul_right a (nᵏ) n (mul_ne_zero …)`;
  `ih`; `pow_succ` on RHS — both sides reduce to `(a/n)ᵏ · (a/n)`.
- `kronecker_even_pow_right_nonneg`: `kronecker_pow_right` then
  `mul_comm 2 j` + `pow_mul` ⇒ `((a/n)ʲ)²`; closed by `sq_nonneg`.

A follow-up build should be run once Docker is restored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)