### PR TITLE
research(szemeredi-regularity-oq-04): fix Mathlib-drift break in energy_steps_bounded_sharp + verify engine

### DIFF
--- a/proofs/Proofs/SzemerediRegularityOQ04.lean
+++ b/proofs/Proofs/SzemerediRegularityOQ04.lean
@@ -101,13 +101,10 @@ theorem energy_steps_bounded_sharp (N : ℕ) (hN : 0 < N) :
   · -- exact `δ`-increment on each of the first `N` steps
     intro n hn
     refine le_of_eq ?_
-    have h1 : (min n N : ℚ) = (n : ℚ) := by
-      exact_mod_cast Nat.min_eq_left (Nat.le_of_lt hn)
-    have h2 : (min (n + 1) N : ℚ) = (n : ℚ) + 1 := by
-      have hmin : min (n + 1) N = n + 1 := Nat.min_eq_left hn
-      rw [hmin]; push_cast; ring
-    show (min n N : ℚ) / (N : ℚ) + 1 / (N : ℚ) = (min (n + 1) N : ℚ) / (N : ℚ)
-    rw [h1, h2, div_add_div_same]
+    push_cast
+    rw [min_eq_left (show (n : ℚ) ≤ (N : ℚ) by exact_mod_cast hn.le),
+        min_eq_left (show (n : ℚ) + 1 ≤ (N : ℚ) by exact_mod_cast hn)]
+    ring
   · -- equality `N • δ = 1`
     rw [mul_one_div, div_self hNQ.ne']
 

--- a/research/problems/szemeredi-regularity-oq-04/knowledge.md
+++ b/research/problems/szemeredi-regularity-oq-04/knowledge.md
@@ -632,3 +632,26 @@ count ≤ ⌊1/δ⌋₊, regular-steps majority, and now chain-depth ≤ ⌊1/δ
 SATURATED — further floor-variants would be cosmetic. Genuine remaining work is the
 two-level exceptional-pair Bridge/Energy terminus (hard, blocked, >1000 lines). Do
 not churn the abstract engine further; next real progress must attack the Bridge.
+
+## Session 2026-07-10 (researcher-1) — VERIFY standing-unverified engine → found & FIXED a Mathlib-drift break
+
+Several recent sessions on `SzemerediRegularityOQ04.lean` shipped UNVERIFIED (SIGBUS-135/139
+olean-write + docker down). Verified via dep-building lean-elab (SzemerediCore →
+SzemerediRegularity → OQ04; [[reference-docker-down-lean-elab-verification-path]]).
+
+★★FOUND A REAL BUG (harder than a typo — genuine Mathlib-drift elaboration break):
+`energy_steps_bounded_sharp` (the ⌊1/δ⌋-tightness witness) FAILED — `rw`/`show` "did not find
+pattern" at the increment bullet. ROOT CAUSE: `(min n N : ℚ)` elaborates to **ℚ-min of casts**
+`@Min.min ℚ _ ↑n ↑N` (NOT `↑(Nat.min n N)`), so the helper `hmin : min (n+1) N = n+1` (ℕ-min)
+was invisible to `rw`. Worse, `f`'s substitution gives `↑(n+1)` (unpushed) while a fresh `show`
+writes `↑n+1` (pushed) — defeq but not syntactic, so `show` also failed. FIX: drop the fragile
+`show`/`rw [hmin]`; `push_cast` to normalize all casts, then `min_eq_left` on the ℚ values
+directly (`min_eq_left (show (n:ℚ) ≤ N by exact_mod_cast hn.le)` etc.), close with `ring`.
+Re-elaborated: whole file EXIT 0, 0 errors/warnings. `#print axioms energy_steps_bounded_sharp`
+/ `energy_all_increment_length_le` = [propext, Classical.choice, Quot.sound] — no sorryAx.
+
+★LESSON: `(min a b : ℚ)` for `a b : ℕ` is ℚ-min-of-casts, NOT `↑(ℕ-min)` — ℕ-min rewrites
+won't fire; use `min_eq_left`/`min_eq_right` on the ℚ side after `push_cast`, or `exact_mod_cast`
+against `Nat.min_eq_left` (works because norm_cast knows `Nat.cast_min`). This is the THIRD
+verification-found bug this session (cf. minpoly `0=![0,0]`, erdos-659 spurious `.symm`) — the
+docker-down era left multiple live errors in "UNVERIFIED, high-confidence" files. File 509→506.


### PR DESCRIPTION
## Summary

Verifying the standing-**UNVERIFIED** abstract engine `SzemerediRegularityOQ04.lean` (accumulated across several docker-down / SIGBUS sessions) via dep-building lean-elaboration (`SzemerediCore` → `SzemerediRegularity` → OQ04) surfaced a **real break** — and a subtle one, not a typo.

`energy_steps_bounded_sharp` (the ⌊1/δ⌋-tightness witness) failed with `rw`/`show` "did not find pattern". **Root cause:** `(min n N : ℚ)` for `n N : ℕ` elaborates to the **ℚ-min of casts** `@Min.min ℚ _ ↑n ↑N`, *not* `↑(Nat.min n N)` — so the helper `hmin : min (n+1) N = n+1` (an ℕ-min fact) was invisible to `rw`. Compounding it, `f`'s substitution produces `↑(n+1)` (unpushed) while a fresh `show` writes `↑n+1` (pushed) — defeq but not syntactic, so the `show` also failed.

**Fix:** drop the fragile `show`/`rw [hmin]`; `push_cast` to normalize all casts, then apply `min_eq_left` on the ℚ values directly and close with `ring`.

## Verification

Whole file re-elaborated vs pinned Mathlib v4.26.0: **EXIT 0, zero errors, zero warnings** (was EXIT 1). `#print axioms energy_steps_bounded_sharp` / `energy_all_increment_length_le` = `[propext, Classical.choice, Quot.sound]` — no `sorryAx`. The whole standing-unverified engine is now verified.

**Takeaway:** `(min a b : ℚ)` with `a b : ℕ` is ℚ-min-of-casts, not `↑(ℕ-min)`; ℕ-min rewrites won't fire — use `min_eq_left`/`min_eq_right` on the ℚ side after `push_cast`. This is the **third** verification-found bug this session (cf. the minpoly `0 = ![0,0]` and erdos-659 spurious-`.symm` fixes) — the docker-down era left multiple live errors in "UNVERIFIED, high-confidence" files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)