### PR TITLE
research(erdos-1059-oq-01-oq-01): strict surplus dual of the deficit bound [UNVERIFIED]

### DIFF
--- a/proofs/Proofs/Erdos1059OQ01OQ01.lean
+++ b/proofs/Proofs/Erdos1059OQ01OQ01.lean
@@ -320,6 +320,40 @@ theorem nonqualifying_le_qualifying_div_level (l : ℕ) (hl : l ≥ 3) :
     rw [← Nat.add_mul]; congr 1; omega
   omega
 
+/-- **Strict level-wise deficit bound (the surplus dual of `levelwise_deficit_le`).**
+    At a *surplus* level `l ≥ k + 2` the non-qualifying primes miss the `1/(k+1)`
+    fraction budget by at least one prime:
+
+      `(p(l) − q(l)) · (k+1) ≤ p(l) − 1`.
+
+    Where `levelwise_deficit_le` (from the non-strict `levelwise_density_bound`) only
+    gives `(p(l) − q(l))·(k+1) ≤ p(l)`, the strict surplus `levelwise_strict_surplus`
+    (`q(l)·(k+1) ≥ p(l)·k + 1`) tightens the right-hand side to `p(l) − 1` via the same
+    truncated-subtraction identity `(p−q)·(k+1) = p·(k+1) − q·(k+1)` and
+    `p·(k+1) = p·k + p`.  It records that once the level index exceeds the threshold by
+    at least two, at least one prime beyond the `k/(k+1)` density line is qualifying. -/
+theorem levelwise_strict_deficit_lt (l k : ℕ) (hl : l ≥ 3) (hlk : l ≥ k + 2) :
+    (primesInLevel l - qualifyingInLevel l) * (k + 1) ≤ primesInLevel l - 1 := by
+  have hs := levelwise_strict_surplus l k hl hlk
+  have e1 : (primesInLevel l - qualifyingInLevel l) * (k + 1)
+      = primesInLevel l * (k + 1) - qualifyingInLevel l * (k + 1) := Nat.sub_mul _ _ _
+  have e2 : primesInLevel l * (k + 1) = primesInLevel l * k + primesInLevel l := by ring
+  omega
+
+/-- **Sharpest strict per-level deficit.**  Taking `k = l − 2` (the largest threshold
+    for which `levelwise_strict_deficit_lt` applies) yields, for every `l ≥ 3`,
+
+      `(p(l) − q(l)) · (l − 1) ≤ p(l) − 1`,
+
+    the finest surplus reading of the strong Selberg density axiom at level `l`: the
+    non-qualifying primes occupy at most a `(p(l)−1)/(l−1)` share, strictly inside the
+    `1/(l−1)` budget the non-strict bound would permit. -/
+theorem nonqualifying_strict_fraction_sharp (l : ℕ) (hl : l ≥ 3) :
+    (primesInLevel l - qualifyingInLevel l) * (l - 1) ≤ primesInLevel l - 1 := by
+  have h := levelwise_strict_deficit_lt l (l - 2) hl (by omega)
+  have e : l - 2 + 1 = l - 1 := by omega
+  rwa [e] at h
+
 /-
 ## Part V: Gap Analysis — Why General x Fails
 

--- a/src/data/proofs/erdos-1059-oq-01-oq-01/meta.json
+++ b/src/data/proofs/erdos-1059-oq-01-oq-01/meta.json
@@ -69,7 +69,7 @@
       "Sieve theory: Selberg sieve, Brun-Titchmarsh inequality (motivational)",
       "Finset operations: filter, card, sum, sum splitting"
     ],
-    "lineCount": 682,
+    "lineCount": 807,
     "relatedProblems": [
       {
         "id": "erdos-1059-oq-01",
@@ -85,7 +85,7 @@
       }
     ],
     "assumptions": "One explicit sieve axiom: strong_selberg_density (the Selberg sieve's quantitative prediction q(l)·(l+1) ≥ p(l)·l for l ≥ 3). The former second axiom primes_growth_in_levels (p(l) ≥ l) is now the PROVED theorem primesInLevel_pos (p(l) ≥ 1, via Bertrand's postulate); the downstream results only ever used positivity of the level prime count, so the axiom count drops from 2 to 1. The file is SORRY-FREE: the two interval-decomposition lemmas (π(n!) and C(n!) as sums over primorial levels) are proved via the generic count_decomp by induction. Hence density_one_at_factorials is fully derived modulo the single disclosed axiom.",
-    "theoremCount": 14,
+    "theoremCount": 16,
     "definitionCount": 3
   },
   "overview": {
@@ -190,14 +190,14 @@
     }
   ],
   "leanFile": {
-    "lineCount": 714,
+    "lineCount": 807,
     "namespace": "Erdos1059OQ01OQ01",
     "opens": [
       "Nat"
     ],
     "structureCount": 0,
     "axiomCount": 1,
-    "theoremCount": 16,
+    "theoremCount": 18,
     "substantiveTheoremCount": 10,
     "computationalVerifications": 0,
     "lemmaCount": 0,


### PR DESCRIPTION
## Summary

Adds two corollaries to `proofs/Proofs/Erdos1059OQ01OQ01.lean` (Strong Selberg Density Axiom, Erdős 1059 OQ-01-01) — the **strict/surplus duals** of the existing non-strict deficit bounds `levelwise_deficit_le` and `nonqualifying_fraction_bound`.

### Added theorems
1. **`levelwise_strict_deficit_lt`** — at a *surplus* level `l ≥ k+2`, the non-qualifying primes miss the `1/(k+1)` budget by at least one prime:
   ```
   (p(l) − q(l)) · (k+1) ≤ p(l) − 1
   ```
   Tightens `levelwise_deficit_le`'s RHS from `p(l)` to `p(l)−1`, using the already-proved `levelwise_strict_surplus` (`q(l)·(k+1) ≥ p(l)·k + 1`) and the truncated-subtraction identity `(p−q)·(k+1) = p·(k+1) − q·(k+1)`.
2. **`nonqualifying_strict_fraction_sharp`** — the `k = l−2` specialization (largest admissible threshold):
   ```
   (p(l) − q(l)) · (l−1) ≤ p(l) − 1
   ```
   the sharpest per-level strict reading of the density axiom.

### Notes
- Both proofs are `omega`-driven from already-verified in-file lemmas. **No new axioms, no sorries.** The single sieve axiom `strong_selberg_density` is unchanged (`axiomCount` stays 1).
- Synced gallery `meta.json` line/theorem counts to the current file (both `lineCount` → 807, both `theoremCount` +2). The recorded baseline (682/714) lagged the actual 773-line file after research PR #37102; note the file's `sorryCount` metadata was also stale — the file is in fact sorry-free.

### Verification status
⚠️ **UNVERIFIED** — the local Docker Lean image build is down this session (`containerd meta.db input/output error`), so `lake build` could not run. Proofs reviewed by eye; each reduces to `omega` over the verified `levelwise_strict_surplus`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)