### PR TITLE
research(erdos-1008-oq-02-oq-02): KST edge bound is monotone in t [UNVERIFIED]

### DIFF
--- a/proofs/Proofs/Erdos1008OQ02OQ02.lean
+++ b/proofs/Proofs/Erdos1008OQ02OQ02.lean
@@ -419,6 +419,48 @@ theorem kst_edge_bound_of_free (G : SimpleGraph V) [DecidableRel G.Adj] [Nonempt
     rw [Nat.cast_sub ht, Nat.cast_one]
   rwa [hcast] at h
 
+/-- **Monotonicity of the exact KST bound in `t`.**  For `t ≤ t'` and `n ≥ 1` the
+Reiman/KST right-hand side is non-decreasing in the parameter `t`:
+
+      n · (1 + √(1 + 4(t-1)(n-1)))  ≤  n · (1 + √(1 + 4(t'-1)(n-1))).
+
+The radicand is monotone because `(n-1) ≥ 0`, so the larger `t' - 1 ≥ t - 1` only
+increases `4(t-1)(n-1)`; `√` and the nonnegative factor `n` preserve the order.  This
+is the algebraic reason the extremal count `ex(n ; K_{2,t})` is non-decreasing in `t`:
+forbidding the *larger* complete bipartite graph `K_{2,t'}` is a *weaker* constraint. -/
+theorem kst_exact_bound_mono_t (t t' : ℕ) (htt' : t ≤ t') (n : ℝ) (hn : 1 ≤ n) :
+    n * (1 + Real.sqrt (1 + 4 * ((t : ℝ) - 1) * (n - 1))) ≤
+      n * (1 + Real.sqrt (1 + 4 * ((t' : ℝ) - 1) * (n - 1))) := by
+  have hcast : (t : ℝ) ≤ (t' : ℝ) := by exact_mod_cast htt'
+  have hn1 : (0 : ℝ) ≤ n - 1 := by linarith
+  have hdiff : (0 : ℝ) ≤ (((t' : ℝ) - 1) - ((t : ℝ) - 1)) * (n - 1) :=
+    mul_nonneg (by linarith) hn1
+  have harg : 1 + 4 * ((t : ℝ) - 1) * (n - 1) ≤ 1 + 4 * ((t' : ℝ) - 1) * (n - 1) := by
+    nlinarith [hdiff]
+  have hsqrt := Real.sqrt_le_sqrt harg
+  exact mul_le_mul_of_nonneg_left (by linarith) (by linarith)
+
+/-- **Monotone (weaker-forbidden) KST bound.**  A `K_{2,t}`-free nonempty graph
+(`t ≥ 1`) also satisfies the KST edge bound for every *larger* forbidden parameter
+`t' ≥ t`:
+
+      4 m ≤ n · (1 + √(1 + 4(t'-1)(n-1))).
+
+Immediate from `kst_edge_bound_of_free` at `t` composed with the parameter
+monotonicity `kst_exact_bound_mono_t`.  It records that the `t`-bound is the sharpest
+of the family: a graph avoiding `K_{2,t}` a fortiori respects every looser
+`K_{2,t'}` estimate. -/
+theorem kst_edge_bound_of_free_mono_t (G : SimpleGraph V) [DecidableRel G.Adj]
+    [Nonempty V] (t t' : ℕ) (ht : 1 ≤ t) (htt' : t ≤ t') (hfree : ¬ HasK2t G t) :
+    4 * (G.edgeFinset.card : ℝ) ≤
+      (Fintype.card V : ℝ) *
+        (1 + Real.sqrt (1 + 4 * ((t' : ℝ) - 1) * ((Fintype.card V : ℝ) - 1))) := by
+  have hn : (1 : ℝ) ≤ (Fintype.card V : ℝ) := by
+    have : 1 ≤ Fintype.card V := Fintype.card_pos
+    exact_mod_cast this
+  exact le_trans (kst_edge_bound_of_free G t ht hfree)
+    (kst_exact_bound_mono_t t t' htt' (Fintype.card V : ℝ) hn)
+
 /-- **Nested-radical envelope.**  For `t ≥ 1` and any `n ≥ 0` the Reiman/KST radical
 is dominated by a sum of *separated* radicals:
 


### PR DESCRIPTION
## Summary

Adds two theorems to `proofs/Proofs/Erdos1008OQ02OQ02.lean` (explicit closed-form `ex(n; K_{2,t})` from the Kővári–Sós–Turán quadratic), formalizing the **parameter-monotonicity** of the KST bound — the structural reason the extremal count is non-decreasing in `t`.

### Added theorems
1. **`kst_exact_bound_mono_t`** — for `t ≤ t'` and `n ≥ 1`:
   ```
   n·(1 + √(1 + 4(t−1)(n−1)))  ≤  n·(1 + √(1 + 4(t'−1)(n−1)))
   ```
   The radicand is monotone because `n−1 ≥ 0`; `√` and the nonnegative factor `n` preserve the order.
2. **`kst_edge_bound_of_free_mono_t`** — a `K_{2,t}`-free nonempty graph (`t ≥ 1`) a fortiori satisfies the looser `K_{2,t'}` edge bound for every `t' ≥ t`:
   ```
   4m ≤ n·(1 + √(1 + 4(t'−1)(n−1)))
   ```
   Obtained by composing the verified `kst_edge_bound_of_free` (at `t`) with the parameter monotonicity.

Together these record that forbidding the *larger* `K_{2,t'}` is a *weaker* constraint, so the `t`-bound is the sharpest of the family.

### Notes
- Both proofs reuse existing verified lemmas plus standard `Real.sqrt` monotonicity. **No new axioms, no sorries.**
- The file is standalone (not referenced by any gallery `meta.json`), so no meta sync is required.

### Verification status
⚠️ **UNVERIFIED** — the local Docker Lean image build is down this session (`containerd meta.db input/output error`), so `lake build` could not run. Proofs reviewed by eye against the file's existing verified lemmas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)