### PR TITLE
research(e-transcendental-oq-02-oq-06): single-digit one-sided eventual non-normality criteria [UNVERIFIED]

### DIFF
--- a/proofs/Proofs/ETranscendentalOQ02.lean
+++ b/proofs/Proofs/ETranscendentalOQ02.lean
@@ -911,6 +911,39 @@ theorem not_normal_of_digit_freq_tendsto_ne (b : ℕ) (hb : 2 ≤ b) (x : ℝ)
     exact hlim
   · rwa [Nat.cast_one, zpow_neg_one]
 
+/-- **Single-digit under-representation forbids normality.** If a digit `d` occurs
+    with frequency *eventually* at most some `c < 1/b`, then `x` is not normal in
+    base `b` — no convergence of the frequency is assumed. The `k = 1` case of
+    `not_normal_of_match_freq_eventually_le`, and the one-sided eventual companion of
+    `not_normal_of_digit_freq_tendsto_ne`. -/
+theorem not_normal_of_digit_freq_eventually_le (b : ℕ) (hb : 2 ≤ b) (x : ℝ)
+    (d : Fin b) (c : ℝ)
+    (hc : c < (b : ℝ)⁻¹)
+    (hbound : ∀ᶠ N in atTop,
+        (((Finset.range N).filter (fun n => nthDigit b n x = (d : ℤ))).card : ℝ)
+          / (N : ℝ) ≤ c) :
+    ¬ IsNormalInBase b x := by
+  refine not_normal_of_match_freq_eventually_le b hb x 1 (fun _ => d) c ?_ ?_
+  · rwa [Nat.cast_one, zpow_neg_one]
+  · simp only [Fin.forall_fin_one, Fin.val_zero, add_zero]
+    exact hbound
+
+/-- **Single-digit over-representation forbids normality.** Dual of
+    `not_normal_of_digit_freq_eventually_le`: if a digit `d` occurs with frequency
+    *eventually* at least some `c > 1/b`, then `x` is not normal in base `b`. The
+    `k = 1` case of `not_normal_of_match_freq_eventually_ge`. -/
+theorem not_normal_of_digit_freq_eventually_ge (b : ℕ) (hb : 2 ≤ b) (x : ℝ)
+    (d : Fin b) (c : ℝ)
+    (hc : (b : ℝ)⁻¹ < c)
+    (hbound : ∀ᶠ N in atTop,
+        c ≤ (((Finset.range N).filter (fun n => nthDigit b n x = (d : ℤ))).card : ℝ)
+          / (N : ℝ)) :
+    ¬ IsNormalInBase b x := by
+  refine not_normal_of_match_freq_eventually_ge b hb x 1 (fun _ => d) c ?_ ?_
+  · rwa [Nat.cast_one, zpow_neg_one]
+  · simp only [Fin.forall_fin_one, Fin.val_zero, add_zero]
+    exact hbound
+
 -- ============================================================
 -- PART IV.8: QUANTITATIVE DISJUNCTIVITY
 -- ============================================================

--- a/src/data/research/problems/e-transcendental-oq-02-oq-06.json
+++ b/src/data/research/problems/e-transcendental-oq-02-oq-06.json
@@ -129,8 +129,8 @@
     {
       "path": "Proofs/ETranscendentalOQ02.lean",
       "filename": "ETranscendentalOQ02.lean",
-      "lineCount": 2017,
-      "theoremCount": 66,
+      "lineCount": 2062,
+      "theoremCount": 68,
       "axiomCount": 1,
       "defCount": 5,
       "sorryCount": 0,


### PR DESCRIPTION
## Summary

Completes the **single-digit frequency-criterion family** in `ETranscendentalOQ02.lean`. The parent file already carried:

- k-tuple, one-sided eventual: `not_normal_of_match_freq_eventually_le` / `_ge`
- single-digit, tendsto: `not_normal_of_digit_freq_tendsto_ne`

but was missing the **single-digit, one-sided eventual** forms. This PR adds them:

- `not_normal_of_digit_freq_eventually_le` — a digit `d` occurring with frequency *eventually* `≤ c < 1/b` ⟹ `¬ IsNormalInBase b x`. The `k = 1` case of `not_normal_of_match_freq_eventually_le`.
- `not_normal_of_digit_freq_eventually_ge` — dual: frequency *eventually* `≥ c > 1/b` ⟹ `¬ IsNormalInBase b x`. The `k = 1` case of `not_normal_of_match_freq_eventually_ge`.

No convergence of the frequency is assumed (only one-sided eventual bounds strictly away from `1/b`).

## Proof

Each is a line-for-line mirror of the existing verified `not_normal_of_digit_freq_tendsto_ne`: `refine` the k-tuple version with `s = fun _ => d`, discharge the threshold goal by the `b^{-1} = b⁻¹` bridge (`Nat.cast_one`, `zpow_neg_one`), and normalize the single-digit filter predicate against the `∀ i : Fin 1` tuple predicate via `simp [Fin.forall_fin_one, Fin.val_zero, add_zero]`.

## Assumptions

No new axioms or sorries. The open axiom `e_absolutely_normal` is untouched.

## Verification

⚠️ **UNVERIFIED** — the Docker Lean build is unavailable in this environment (containerd blob input/output error). The proofs are by-eye mirrors of the immediately-adjacent verified siblings and use only Mathlib API already exercised in the same file.

meta `ETranscendentalOQ02.lean` counts synced: lineCount 2017→2062, theoremCount 66→68.

🤖 Generated with [Claude Code](https://claude.com/claude-code)