### PR TITLE
research(tetrahedral-number-formula-oq-01): Catalan numbers on the simplex diagonal

### DIFF
--- a/proofs/Proofs/TetrahedralNumberFormulaOQ01Absorption.lean
+++ b/proofs/Proofs/TetrahedralNumberFormulaOQ01Absorption.lean
@@ -82,4 +82,17 @@ theorem simplexNumber_diag_succ (d : ℕ) :
   rw [simplexNumber_diag (d + 1), simplexNumber_diag d]
   exact Nat.succ_mul_centralBinom_succ d
 
+/-- **Catalan numbers on the diagonal.**  The `d`-th Catalan number is the central simplex
+number `P_d(d) = C(2d, d)` divided by `d+1`; multiplicatively,
+`(d+1) · catalan d = P_d(d)`.  Since `simplexNumber_diag` identifies the diagonal of
+Pascal's simplex with the central binomial coefficient `Nat.centralBinom`, this is just
+Mathlib's `Nat.succ_mul_catalan_eq_centralBinom` read through that identification.  It
+places the Catalan numbers `catalan d = C(2d,d)/(d+1)` inside the figurate ladder as the
+`(d+1)`-quotient of the central simplex diagonal, complementing the diagonal doubling
+recurrence `simplexNumber_diag_succ`. -/
+theorem simplexNumber_diag_catalan (d : ℕ) :
+    (d + 1) * catalan d = simplexNumber d d := by
+  rw [simplexNumber_diag d, ← Nat.centralBinom_eq_two_mul_choose]
+  exact succ_mul_catalan_eq_centralBinom d
+
 end TetrahedralNumberFormulaOQ01


### PR DESCRIPTION
## Summary

Adds one theorem to the OQ-01 absorption companion (`TetrahedralNumberFormulaOQ01Absorption.lean`), connecting the figurate/simplex ladder to the **Catalan numbers**:

```lean
theorem simplexNumber_diag_catalan (d : ℕ) :
    (d + 1) * catalan d = simplexNumber d d
```

The `d`-th Catalan number is the central simplex number `P_d(d) = C(2d, d)` divided by `d+1`; multiplicatively, `(d+1)·catalan d = P_d(d)`. This places `catalan d = C(2d,d)/(d+1)` inside the figurate ladder as the `(d+1)`-quotient of the central simplex diagonal.

## Proof

Three-step rewrite:
- `simplexNumber_diag d` : `simplexNumber d d = (2*d).choose d` (existing verified diagonal = central binomial)
- `← Nat.centralBinom_eq_two_mul_choose` folds `(2*d).choose d → Nat.centralBinom d`
- `succ_mul_catalan_eq_centralBinom d` : `(d+1) * catalan d = Nat.centralBinom d` — exact match

Complements the diagonal doubling recurrence `simplexNumber_diag_succ`. No new axioms or sorries.

## Verification status

**UNVERIFIED** — the Docker Lean image build is currently unavailable in this environment (containerd `meta.db` input/output error at image build). The proof is a short rewrite verified by eye against the pinned Mathlib (`Mathlib/Combinatorics/Enumerative/Catalan.lean`, `Mathlib/Data/Nat/Choose/Central.lean`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)