### PR TITLE
research(erdos-101-oq-04): state L₄ unboundedness as a k-free theorem [UNVERIFIED]

### DIFF
--- a/proofs/Proofs/Erdos101OQ04.lean
+++ b/proofs/Proofs/Erdos101OQ04.lean
@@ -2793,6 +2793,19 @@ theorem exists_fourPointLineCount_ge_card_div_four_real (k : ℕ) (hk : 0 < k) :
       ≤ ((4 * fourPointLineCount P : ℕ) : ℝ) := by exact_mod_cast hdens
     _ = (fourPointLineCount P : ℝ) * 4 := by push_cast; ring
 
+/-- **Unboundedness of the four-point-line count.**  For every target `N` there is a
+no-five-collinear planar point set `P` with `N ≤ fourPointLineCount P`.  This is the
+qualitative core of the linear lower bound `quartic_linear_lower_bound`, stated without the
+auxiliary level-parameter `k`: the maximum number of four-point lines over no-five-collinear
+sets is bounded by *no* constant, so the constant witnesses `crossSet`/`asteriskSet`/`gridSet`
+(fixed floors `≤ 10`) cannot be maximal.  The prose remarks scattered through the file
+("`fourPointLineCount` is unbounded", "grows without bound") are exactly this statement;
+it follows in one step from the quartic-chord family at level parameter `k = max N 1`. -/
+theorem exists_fourPointLineCount_ge (N : ℕ) :
+    ∃ P : PlanarPointSet, NoFiveCollinear P ∧ N ≤ fourPointLineCount P := by
+  obtain ⟨P, _, hno5, hcount⟩ := quartic_linear_lower_bound (max N 1) (by omega)
+  exact ⟨P, hno5, le_trans (le_max_left N 1) hcount⟩
+
 /-! ### Exact collinearity criteria on the quartic (arithmetization)
 
 The `noFiveCollinear_of_onQuartic` engine says the quartic graph *forbids* five


### PR DESCRIPTION
## Summary

Erdős 101 OQ-04 (higher-dimensional / four-point-line count) is a saturated, graduated slug: `Erdos101OQ04.lean` builds the whole framework up to the unconditional linear lower bound `L₄(n) = Ω(n)` via the quartic-chord family `quartic_linear_lower_bound`. The file's prose asserts **five** times that `fourPointLineCount` is *unbounded* / *grows without bound* over no-five-collinear sets, but that qualitative statement was never recorded as a theorem — every existing statement carries the auxiliary level-parameter `k`.

This PR adds the single missing `k`-free corollary:

```lean
theorem exists_fourPointLineCount_ge (N : ℕ) :
    ∃ P : PlanarPointSet, NoFiveCollinear P ∧ N ≤ fourPointLineCount P
```

**Proof** (one step): instantiate `quartic_linear_lower_bound (max N 1)` — it yields a no-five-collinear `P` with `max N 1 ≤ fourPointLineCount P`; combine with `N ≤ max N 1` (`le_max_left`) via `le_trans`. The positivity side-goal `0 < max N 1` is `omega`. No new definitions, no new axioms.

Why it matters: this is the cleanest phrasing of the growth result (no auxiliary `k`) and makes precise that the constant witnesses `crossSet`/`asteriskSet`/`gridSet` (fixed floors ≤ 10) cannot be maximal — the file's recurring prose claim, now a checked theorem.

## Placement / collision-avoidance

Inserted **mid-file**, right after the density corollaries (`exists_fourPointLineCount_ge_card_div_four_real`) and before the arithmetization section — deliberately orthogonal to the two open ternary-conic PRs (#37106 inserts after line ~3088; #37271 inserts at EOF).

## Verification

⚠️ **UNVERIFIED**: the Lean Docker image build is currently unavailable on this host (containerd `meta.db` input/output error at image-build time), so a full `docker-build.sh` run could not machine-check the file. The added proof is a one-line reuse of the already-verified `quartic_linear_lower_bound` through `le_max_left` / `le_trans` / `omega`, so the logic is checkable by inspection.

Gallery `erdos-101` tracks this file only as a bare `additionalFiles` path (no `lineCount` field), so no meta sync is required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)