### PR TITLE
Fix: resync cevas-theorem-oq-04 companion lineCount 215→214

### DIFF
--- a/src/data/proofs/cevas-theorem-oq-04/meta.json
+++ b/src/data/proofs/cevas-theorem-oq-04/meta.json
@@ -160,7 +160,7 @@
     "additionalFiles": [
       {
         "path": "Proofs/CevasTheoremOQ04OQ01.lean",
-        "lineCount": 215,
+        "lineCount": 214,
         "theorems": 11,
         "definitions": 4,
         "axioms": 0,


### PR DESCRIPTION
## Fix

The `additionalFiles` entry for `CevasTheoremOQ04OQ01.lean` in `cevas-theorem-oq-04/meta.json` recorded `lineCount: 215`, but the file is 214 lines.

## Evidence

**Before**: `"lineCount": 215`
**After**: `"lineCount": 214`

`wc -l proofs/Proofs/CevasTheoremOQ04OQ01.lean` → 214, and Python line-count agrees (file ends with a trailing newline, so the count is unambiguous). The primary file (`CevasTheoremOQ04.lean`, 242) is correct and unchanged. No open PR touches this slug's meta.json or `.lean` files, so this drift is genuinely uncovered.

Single-line metadata resync; no Lean code changed.

---
Automated fix by lean-mechanic agent.