### PR TITLE
research(law-of-cosines-oq-03-oq-03): explicit equilateral side length via arcosh [UNVERIFIED]

### DIFF
--- a/proofs/Proofs/LawOfCosinesOQ03OQ03.lean
+++ b/proofs/Proofs/LawOfCosinesOQ03OQ03.lean
@@ -884,4 +884,29 @@ theorem exists_equilateral (θ : ℝ) (hθ : 0 < θ) (hθ3 : θ < Real.pi / 3) :
   have hθpi : θ < Real.pi := by linarith [Real.pi_pos]
   exact exists_triangle_of_defect θ θ θ hθ hθ hθ hθpi hθpi hθpi (by linarith)
 
+-- ============================================================
+-- PART 11: Equilateral side lengths in closed form (explicit arcosh)
+-- ============================================================
+
+/-- **The equilateral side length in closed form.** Upgrading `equilateral_cosh` from the
+    `cosh` of the side to the side itself: an equilateral hyperbolic triangle with common
+    angle `θ` has every side equal to `arcosh(cos θ / (1 - cos θ))`. Because the side is
+    nonnegative, `arcosh` inverts `cosh` (`Real.arcosh_cosh`), turning the implicit length of
+    PART 5 into an explicit formula and confirming that the closed form of PART 5 really is
+    the metric length of the side (not merely its hyperbolic cosine). -/
+theorem equilateral_side (t : HyperbolicTriangle)
+    (hAB : t.A = t.B) (hBC : t.B = t.C) :
+    t.c = Real.arcosh (Real.cos t.C / (1 - Real.cos t.C)) := by
+  rw [← equilateral_cosh t hAB hBC, Real.arcosh_cosh t.hc.le]
+
+/-- **The concrete equilateral side length.** The hyperbolic equilateral triangle with all
+    three angles `π/4` has every side exactly `arcosh(1 + √2)` — the explicit length promised
+    by the docstring of `equilateral_pi_four_cosh`, which only established the `cosh` value.
+    Immediate from `equilateral_pi_four_cosh` and `Real.arcosh_cosh` (the side is
+    nonnegative). -/
+theorem equilateral_pi_four_side (t : HyperbolicTriangle)
+    (hAB : t.A = t.B) (hBC : t.B = t.C) (hC4 : t.C = Real.pi / 4) :
+    t.c = Real.arcosh (1 + Real.sqrt 2) := by
+  rw [← equilateral_pi_four_cosh t hAB hBC hC4, Real.arcosh_cosh t.hc.le]
+
 end HyperbolicAAA

--- a/src/data/proofs/law-of-cosines-oq-03-oq-03/meta.json
+++ b/src/data/proofs/law-of-cosines-oq-03-oq-03/meta.json
@@ -17,8 +17,8 @@
     ],
     "axiomCount": 0,
     "sorries": 0,
-    "lineCount": 887,
-    "theoremCount": 53,
+    "lineCount": 912,
+    "theoremCount": 55,
     "definitionCount": 3
   },
   "openQuestion": {
@@ -384,8 +384,8 @@
     ],
     "sorries": 0,
     "axiomCount": 6,
-    "lineCount": 887,
-    "theoremCount": 46,
+    "lineCount": 912,
+    "theoremCount": 48,
     "definitionCount": 2,
     "originalContributions": [
       "HyperbolicTriangle structure encoding the three second laws of cosines plus the angular defect",


### PR DESCRIPTION
## Summary

Fills a documented gap in the saturated, verified **Hyperbolic AAA Congruence** entry (`law-of-cosines-oq-03-oq-03`). The equilateral results in PARTS 5 & 7 compute `cosh(side)` and their docstrings promise the *side length* as `arcosh(...)`, but that side length was never actually formalized. This PR adds the two one-line corollaries that complete the claim.

## New theorems (2)

- **`equilateral_side`** — for common angle `θ`, `t.c = arcosh(cos θ / (1 - cos θ))`. Upgrades `equilateral_cosh` from the hyperbolic cosine to the metric side length.
- **`equilateral_pi_four_side`** — the `θ = π/4` triangle has every side exactly `arcosh(1 + √2)`, the explicit value already stated in the `equilateral_pi_four_cosh` docstring.

## Proof

Each is a single `rw`: rewrite the target back through the existing `*_cosh` theorem, then apply `Real.arcosh_cosh (0 ≤ x)` (side is nonnegative via `t.hc.le`). `Real.arcosh_cosh` is confirmed present in the Mathlib pin and the `Mathlib.Analysis.SpecialFunctions.Arcosh` import is already in the file.

## Assumptions

No new axioms or sorries. Reuses the existing 6 structure-encoded geometric assumptions of `HyperbolicTriangle`.

## Verification

⚠️ **UNVERIFIED** — the Docker Lean image build is currently down (`containerd meta.db` input/output error at image build; `docker info` reports healthy but image build fails). Both proofs are one-line rewrites of already-proven theorems in the same file using a confirmed pin lemma, checkable by inspection. meta.json `lineCount` 887→912 and `theoremCount` synced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)