### PR TITLE
research(shannon-entropy-oq-03): conditional mutual information as a first-class quantity [UNVERIFIED]

### DIFF
--- a/proofs/Proofs/ShannonEntropySSA.lean
+++ b/proofs/Proofs/ShannonEntropySSA.lean
@@ -107,4 +107,47 @@ theorem conditional_mi_nonneg {pXYZ : α × β × γ → ℝ}
       shannonEntropy pXYZ - shannonEntropy (marginalY pXYZ) ≥ 0 := by
   linarith [InformationTheory.strong_subadditivity hp hsum]
 
+/-! ## Conditional mutual information as a first-class quantity -/
+
+/-- **Conditional mutual information** `I(X ; Z | Y)`, defined directly from the
+    joint distribution as
+
+      `I(X ; Z | Y) = H(X, Y) + H(Y, Z) − H(X, Y, Z) − H(Y)`.
+
+    Packaging the expression bounded by `conditional_mi_nonneg` as a named object
+    lets the two information-theoretic facts below — its non-negativity and its
+    conditional-entropy-reduction identity — be stated about a single reusable
+    quantity rather than an anonymous four-term difference. -/
+noncomputable def conditionalMutualInfo (pXYZ : α × β × γ → ℝ) : ℝ :=
+  shannonEntropy (marginalXY pXYZ) + shannonEntropy (marginalYZ pXYZ) -
+    shannonEntropy pXYZ - shannonEntropy (marginalY pXYZ)
+
+/-- **Conditional mutual information is non-negative**, `0 ≤ I(X ; Z | Y)`. This is
+    strong subadditivity read as a statement about the named quantity
+    `conditionalMutualInfo`; it is definitionally `conditional_mi_nonneg`. -/
+theorem conditionalMutualInfo_nonneg {pXYZ : α × β × γ → ℝ}
+    (hp : ∀ xyz, 0 ≤ pXYZ xyz)
+    (hsum : ∑ xyz : α × β × γ, pXYZ xyz = 1) :
+    0 ≤ conditionalMutualInfo pXYZ := by
+  unfold conditionalMutualInfo
+  linarith [conditional_mi_nonneg hp hsum]
+
+/-- **Conditional mutual information equals the conditioning deficit.** With the
+    conditional entropies `H(X | Y) = H(X, Y) − H(Y)` and
+    `H(X | Y, Z) = H(X, Y, Z) − H(Y, Z)`,
+
+      `I(X ; Z | Y) = H(X | Y) − H(X | Y, Z)`.
+
+    This formalizes the identity asserted in prose in the docstrings of
+    `conditioning_reduces_entropy_general` and `conditional_mi_nonneg` — that the
+    deficit by which the extra variable `Z` reduces the conditional entropy of `X`
+    is *exactly* the conditional mutual information. It is a pure rearrangement of
+    the definition, so it holds unconditionally (no probability hypotheses). -/
+theorem conditionalMutualInfo_eq_conditioning_deficit (pXYZ : α × β × γ → ℝ) :
+    conditionalMutualInfo pXYZ =
+      (shannonEntropy (marginalXY pXYZ) - shannonEntropy (marginalY pXYZ)) -
+        (shannonEntropy pXYZ - shannonEntropy (marginalYZ pXYZ)) := by
+  unfold conditionalMutualInfo
+  ring
+
 end InformationTheory.SSA

--- a/src/data/proofs/shannon-entropy-oq-03/meta.json
+++ b/src/data/proofs/shannon-entropy-oq-03/meta.json
@@ -39,12 +39,13 @@
     ],
     "originalContributions": [
       "Three-variable 'conditioning reduces entropy' H(X|Y,Z) ≤ H(X|Y) as a corollary of SSA",
-      "Non-negativity of conditional mutual information I(X;Z|Y) ≥ 0"
+      "Non-negativity of conditional mutual information I(X;Z|Y) ≥ 0",
+      "Conditional mutual information as a first-class definition (conditionalMutualInfo), with the deficit identity I(X;Z|Y) = H(X|Y) − H(X|Y,Z) formalizing the prose claim of the conditioning corollaries"
     ],
     "dateAdded": "2026-03-30",
-    "lineCount": 110,
-    "theoremCount": 4,
-    "definitionCount": 0,
+    "lineCount": 153,
+    "theoremCount": 6,
+    "definitionCount": 1,
     "additionalFiles": [],
     "mathlib_version": "4.26.0",
     "verifiedAt": "2026-07-07"
@@ -96,6 +97,14 @@
       "endLine": 92,
       "summary": "Three three-variable corollaries derived from strong subadditivity by linear rearrangement (linarith), not present in the parent file: conditioning_reduces_entropy_general (H(X|Y,Z) ≤ H(X|Y), extra conditioning cannot increase entropy), conditioning_reduces_entropy_general′ (H(Z|X,Y) ≤ H(Z|Y), the X↔Z dual), and conditional_mi_nonneg (I(X;Z|Y) ≥ 0, the conditional mutual information is non-negative).",
       "mathContext": "SSA implies (1) $H(X|Y,Z) \\leq H(X|Y)$ and (2) $I(X;Z|Y) = H(X,Y) + H(Y,Z) - H(X,Y,Z) - H(Y) \\geq 0$."
+    },
+    {
+      "title": "Conditional mutual information as a first-class quantity",
+      "id": "conditional-mutual-info",
+      "startLine": 111,
+      "endLine": 153,
+      "summary": "Packages the SSA deficit as a named definition conditionalMutualInfo pXYZ = H(X,Y) + H(Y,Z) − H(X,Y,Z) − H(Y), and proves two facts about it: conditionalMutualInfo_nonneg (0 ≤ I(X;Z|Y), reusing conditional_mi_nonneg) and conditionalMutualInfo_eq_conditioning_deficit (I(X;Z|Y) = H(X|Y) − H(X|Y,Z), a hypothesis-free ring rearrangement that formalizes the prose claim of the conditioning corollaries).",
+      "mathContext": "Defines $I(X;Z|Y)$ and proves the identity $I(X;Z|Y) = H(X|Y) - H(X|Y,Z)$, i.e. the deficit by which conditioning additionally on $Z$ reduces the entropy of $X$ equals the conditional mutual information."
     }
   ],
   "conclusion": {
@@ -163,10 +172,10 @@
       "Finset"
     ],
     "namespace": "InformationTheory.SSA",
-    "lineCount": 110,
+    "lineCount": 153,
     "axiomCount": 0,
-    "theoremCount": 4,
-    "definitionCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 1,
     "path": "Proofs/ShannonEntropySSA.lean",
     "sorries": 0,
     "additionalFiles": []


### PR DESCRIPTION
## Summary

Extends the **verified** strong-subadditivity companion `Proofs/ShannonEntropySSA.lean` with a first-class definition of **conditional mutual information** and the deficit identity that the existing corollaries currently assert only in prose.

The file already proves the SSA inequality (re-exported from the parent) and three linear corollaries, and its docstrings claim "the deficit [by which conditioning on `Z` reduces the entropy of `X`] is exactly the conditional mutual information `I(X;Z|Y)`" — but that identity was never formalized. This PR turns the prose into a theorem.

### New declarations

- `conditionalMutualInfo` (def) — `I(X;Z|Y) = H(X,Y) + H(Y,Z) − H(X,Y,Z) − H(Y)`, packaging the quantity bounded by the existing `conditional_mi_nonneg`.
- `conditionalMutualInfo_nonneg` — `0 ≤ I(X;Z|Y)`, reusing the verified `conditional_mi_nonneg` (`unfold; linarith`).
- `conditionalMutualInfo_eq_conditioning_deficit` — `I(X;Z|Y) = H(X|Y) − H(X|Y,Z)`, where `H(X|Y) = H(X,Y) − H(Y)` and `H(X|Y,Z) = H(X,Y,Z) − H(Y,Z)`. A hypothesis-free `ring` rearrangement.

## Verification status

**UNVERIFIED**: the Docker Lean image build is down this session (`containerd meta.db` input/output error), so `lake build` could not run. Both new proofs are `unfold` + `ring` / `unfold` + `linarith` over an already-verified inequality — structurally identical to the file's existing verified `linarith` corollaries — and were checked by eye against the parent's `marginalXY`/`marginalYZ`/`marginalY` and `shannonEntropy` signatures.

The entry's `status` is left `verified` (the SSA core and prior corollaries are unchanged and machine-checked) and `verifiedAt` is **not** bumped, pending a clean build of the new declarations.

## Gallery impact

`src/data/proofs/shannon-entropy-oq-03/meta.json` synced: `lineCount` 110→153, `theoremCount` 4→6, `definitionCount` 0→1 (both `leanFile` and `meta` copies); one new section entry and one `originalContribution` added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)