### PR TITLE
audit: brouwer defcount fix + binary-gcd clean (tracker bumps)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -29768,8 +29768,14 @@
       "issues": [],
       "lastAudited": "2026-07-09T00:00:00Z",
       "result": "clean"
+    },
+    "brouwer-fixed-point-oq-02-oq-02-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-10T08:00:00Z",
+      "result": "issues-fixed",
+      "issues": []
     }
   },
   "version": 1,
-  "lastUpdated": "2026-07-10T07:43:04Z"
+  "lastUpdated": "2026-07-10T08:00:00Z"
 }

--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -29774,8 +29774,14 @@
       "lastAudited": "2026-07-10T08:00:00Z",
       "result": "issues-fixed",
       "issues": []
+    },
+    "binary-gcd-oq-01-oq-04-oq-04": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-10T08:05:00Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,
-  "lastUpdated": "2026-07-10T08:00:00Z"
+  "lastUpdated": "2026-07-10T08:05:00Z"
 }

--- a/src/data/proofs/brouwer-fixed-point-oq-02-oq-02-oq-01/meta.json
+++ b/src/data/proofs/brouwer-fixed-point-oq-02-oq-02-oq-01/meta.json
@@ -157,7 +157,7 @@
     "axiomCount": 0,
     "theoremCount": 20,
     "substantiveTheoremCount": 20,
-    "definitionCount": 0,
+    "definitionCount": 1,
     "path": "Proofs/BrouwerFixedPointOQ02OQ02OQ01.lean",
     "sorries": 0
   },


### PR DESCRIPTION
## Gallery integrity audit (2 entries)

### 1. brouwer-fixed-point-oq-02-oq-02-oq-01 — issues-fixed
`meta.json` recorded `definitionCount: 0`, but the primary Lean file contains one definition (`def applyAll`, line 137). Counts are scoped to the primary file (theoremCount 20 matched exactly). **Fix: `definitionCount: 0 → 1`.** All other counts exact (20 theorems, 0 axioms, 0 sorries, 422 lines). Badge `original`/`verified` confirmed defensible — the sole substantive Mathlib delegate (`ContractingWith.exists_fixedPoint`, auxiliary existence) is fully disclosed; headline error-estimate/stability content is hand-proved.

### 2. binary-gcd-oq-01-oq-04-oq-04 — clean
Diagonal closed form `binaryGcdSteps n n = padicValNat 2 n + 1` for Stein's Binary GCD. Verified exact: 7 theorems, 0 defs, 0 axioms, 0 sorries, 187 lines; **no `decide`/`native_decide` in code** (axiom-free claim accurate, no `Lean.ofReduceBool`); all 7 named mainTheorems exist with matching leanTypes; badge `original`/`verified` correct (novel result; `padicValNat` lemmas are supporting infrastructure, not a wrapper). No changes needed.

### Tracker
Adds both audit-tracker entries, rebased on current `main` to avoid reverting concurrent auditor entries.

---
Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)