### PR TITLE
research(erdos-703-incomplete-01): uniform T(n,1) lower bounds via ground-set monotonicity [UNVERIFIED]

### DIFF
--- a/proofs/Proofs/Erdos703Problem.lean
+++ b/proofs/Proofs/Erdos703Problem.lean
@@ -582,6 +582,21 @@ theorem seven_le_T_5_1 : 7 ≤ T 5 1 := by
   have hle := franklFurediOdd_card_le_T 5 1
   omega
 
+/-- **Uniform lower bound `T(n,1) ≥ 6` for every ground set of size `n ≥ 4`.** The
+    concrete `n = 4` anchor `six_le_T_4_1` propagates to all larger `n` by monotonicity
+    of `T` in the ground-set size (`T_mono_ground`): a `1`-avoiding family on `[4]` is
+    still `1`-avoiding when the ground set is enlarged to `[n]`, so the extremal size can
+    only grow.  This turns the isolated decidable anchor into an infinite family of
+    certified lower bounds without any further `decide`. -/
+theorem six_le_T_n_1 (n : ℕ) (hn : 4 ≤ n) : 6 ≤ T n 1 :=
+  le_trans six_le_T_4_1 (T_mono_ground (r := 1) hn)
+
+/-- **Uniform lower bound `T(n,1) ≥ 7` for every ground set of size `n ≥ 5`.** The same
+    monotone propagation (`T_mono_ground`) of the `n = 5` anchor `seven_le_T_5_1`,
+    sharpening `six_le_T_n_1` on the range `n ≥ 5`. -/
+theorem seven_le_T_n_1 (n : ℕ) (hn : 5 ≤ n) : 7 ≤ T n 1 :=
+  le_trans seven_le_T_5_1 (T_mono_ground (r := 1) hn)
+
 /-
 ## Part V: The Main Question - Exponential Bound
 

--- a/src/data/proofs/erdos-703/meta.json
+++ b/src/data/proofs/erdos-703/meta.json
@@ -52,10 +52,10 @@
       "Structural lemmas on T: T_le_pow (T(n,r) ≤ 2^n), T_mono_ground (monotone in the ground-set size n), one_le_T (positivity), and full_powerset_avoids_r_of_lt / T_eq_pow_of_lt (T(n,r) = 2^n whenever n < r); plus largeSetsFamily_subset_franklFurediOdd_one linking Frankl's r=1 family into the general Frankl-Füredi construction."
     ],
     "axiomCount": 1,
-    "lineCount": 706,
+    "lineCount": 721,
     "assumptions": "1 axiom: frankl_rodl_1987 (the deep Frankl–Rödl 1987 exponential bound — the affirmative answer to the main question). 0 sorries: the trivial case T(n,0)=2^{n-1} is fully machine-checked (#print axioms T_n_0 = [propext, Classical.choice, Quot.sound]) via a complement-pairing upper bound and a star-family witness. The unused opaque chromaticNumber axiom was removed; the geometric chromatic-number consequence is recorded as prose only since infinite unit-distance chromatic numbers are not yet in Mathlib.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 27,
+    "theoremCount": 29,
     "definitionCount": 8
   },
   "crossReferences": [
@@ -182,9 +182,9 @@
       "Finset"
     ],
     "namespace": "Erdos703",
-    "lineCount": 706,
+    "lineCount": 721,
     "axiomCount": 1,
-    "theoremCount": 27,
+    "theoremCount": 29,
     "definitionCount": 8,
     "path": "Proofs/Erdos703Problem.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

Adds two theorems to `proofs/Proofs/Erdos703Problem.lean` (Erdős #703, forbidden `r`-intersection families) that turn the isolated decidable anchors into infinite families of certified lower bounds.

### Added theorems
- **`six_le_T_n_1`** (`n ≥ 4`): `6 ≤ T n 1`
- **`seven_le_T_n_1`** (`n ≥ 5`): `7 ≤ T n 1`

Each is `le_trans` of the concrete anchor (`six_le_T_4_1`, `seven_le_T_5_1`) through the verified monotonicity `T_mono_ground`: a `1`-avoiding family on `[m]` remains `1`-avoiding on the larger ground set `[n]` for `m ≤ n`, so the extremal size only grows. No further `decide`.

### Notes
- No new axioms, no sorries — the single open axiom `frankl_rodl_1987` is unchanged.
- Synced gallery `meta.json`: `lineCount` 706 → 721, `theoremCount` 27 → 29 (both fields).
- The problem title ("…(1 sorry)") is stale: the file has no code `sorry` (the grep hit is docstring text).

### Verification status
⚠️ **UNVERIFIED** — the local Docker Lean image build is down this session (`containerd meta.db input/output error`). The two additions are one-line `le_trans` of already-verified lemmas, reviewed by eye.

🤖 Generated with [Claude Code](https://claude.com/claude-code)