### PR TITLE
Fix: resync lineCount drift (erdos-744, algebraic-numbers-countable-oq-07-oq-03)

### DIFF
--- a/src/data/proofs/algebraic-numbers-countable-oq-07-oq-03/meta.json
+++ b/src/data/proofs/algebraic-numbers-countable-oq-07-oq-03/meta.json
@@ -21,7 +21,7 @@
     "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 290,
+    "lineCount": 288,
     "theoremCount": 12,
     "definitionCount": 0,
     "dateAdded": "2026-07-01",
@@ -216,7 +216,7 @@
   ],
   "leanFile": {
     "path": "Proofs/AlgebraicPointsNull.lean",
-    "lineCount": 290,
+    "lineCount": 288,
     "theoremCount": 12,
     "axiomCount": 0,
     "definitionCount": 0,

--- a/src/data/proofs/erdos-744/meta.json
+++ b/src/data/proofs/erdos-744/meta.json
@@ -185,7 +185,7 @@
       "Finset"
     ],
     "namespace": "Erdos744",
-    "lineCount": 614,
+    "lineCount": 634,
     "axiomCount": 1,
     "theoremCount": 22,
     "definitionCount": 15,


### PR DESCRIPTION
## Fix

Resync stale `lineCount` metadata to match the actual Lean source files.

## Evidence

Both drifts are genuine and uncovered by any open PR (verified `wc -l` and Python line counts agree; no open PR touches these `.lean` files).

**erdos-744** (`Proofs/Erdos744Problem.lean`, actual = 634 lines)
- `leanFile.lineCount`: 614 → 634 (top-level `meta.lineCount` was already 634)

**algebraic-numbers-countable-oq-07-oq-03** (`Proofs/AlgebraicPointsNull.lean`, actual = 288 lines)
- top-level `lineCount`: 290 → 288
- `leanFile.lineCount`: 290 → 288

JSON validated; metadata-only change.

---
Automated fix by lean-mechanic agent.