### PR TITLE
research(lagrange-theorem-oq-01): Sylow count/index coprimality to p [UNVERIFIED]

### DIFF
--- a/proofs/Proofs/LagrangeTheoremOQ01.lean
+++ b/proofs/Proofs/LagrangeTheoremOQ01.lean
@@ -110,6 +110,26 @@ theorem sylow_count_mod_p (p : ℕ) [hp : Fact p.Prime] :
     card (Sylow p G) % p = 1 := by
   exact Sylow.card_sylow_modEq_one p G |>.out
 
+/-- The Sylow count `n_p` is **not** divisible by `p` — equivalently, `n_p` is coprime
+    to `p`.  Immediate from `sylow_count_mod_p`: a multiple of `p` would have residue `0`,
+    but `n_p ≡ 1 (mod p)`.  This is the residue-form companion to `sylow_count_mod_p`
+    used, e.g., to rule out `n_p = p` in the classification of groups of small order. -/
+theorem sylow_count_not_dvd_p (p : ℕ) [hp : Fact p.Prime] :
+    ¬ p ∣ card (Sylow p G) := by
+  rw [Nat.dvd_iff_mod_eq_zero, sylow_count_mod_p]
+  exact one_ne_zero
+
+/-- **Hall property of Sylow subgroups**: the index `[G : P]` of a Sylow p-subgroup is
+    prime to `p`.  Since `|P| = p^(vₚ(|G|))` is the *full* p-power in `|G|`
+    (`sylow_card_eq`), the complementary index carries no factor of `p`.  This is exactly
+    what makes a Sylow subgroup a *Hall* subgroup (`|P|` and `[G:P]` coprime) and the
+    defining maximality property behind the First Sylow Theorem.  From
+    `Sylow.not_dvd_index` (the `[P.FiniteIndex]` and `Finite (Sylow p G)` instances are
+    supplied automatically by `[Fintype G]`). -/
+theorem sylow_index_not_dvd_p (p : ℕ) [hp : Fact p.Prime] (P : Sylow p G) :
+    ¬ p ∣ P.toSubgroup.index :=
+  P.not_dvd_index
+
 /-
 ═══════════════════════════════════════════════════════════════════════════════
 PART IV-B: THE NORMALITY CRITERION (STRUCTURAL COROLLARY OF SYLOW III)
@@ -181,6 +201,7 @@ end LagrangeOQ01
   - Sylow existence (First Sylow Theorem)
   - Sylow conjugacy (Second Sylow Theorem)
   - Sylow counting (Third Sylow Theorem): n_p ≡ 1 mod p, n_p | [G:P]
+  - Coprimality: p ∤ n_p, and the Hall property p ∤ [G:P] (index prime to p)
   - Normality criterion: P normal ⟺ n_p = 1; a normal Sylow is characteristic
   - Partial converse: p^k | |G| implies ∃ subgroup of order p^k
   - Cauchy's theorem: p | |G| implies ∃ element of order p

--- a/src/data/proofs/lagrange-theorem-oq-01/meta.json
+++ b/src/data/proofs/lagrange-theorem-oq-01/meta.json
@@ -20,8 +20,8 @@
     "sorries": 0,
     "dateAdded": "2026-04-04",
     "axiomCount": 0,
-    "lineCount": 189,
-    "theoremCount": 11,
+    "lineCount": 210,
+    "theoremCount": 16,
     "definitionCount": 0,
     "assumptions": "None.",
     "originalContributions": [
@@ -151,9 +151,9 @@
   ],
   "leanFile": {
     "namespace": "LagrangeOQ01",
-    "lineCount": 189,
+    "lineCount": 210,
     "axiomCount": 0,
-    "theoremCount": 12,
+    "theoremCount": 16,
     "definitionCount": 0,
     "path": "Proofs/LagrangeTheoremOQ01.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

Adds two classical coprimality corollaries to the Sylow-theorems entry `LagrangeTheoremOQ01.lean` (partial converse of Lagrange). Both fill genuine gaps in the counting/index section of an otherwise saturated verified file.

- **`sylow_count_not_dvd_p`**: `¬ p ∣ n_p` — the residue-form companion of the file's own `sylow_count_mod_p` (`n_p ≡ 1 mod p ⟹ p ∤ n_p`). Proof: `rw [Nat.dvd_iff_mod_eq_zero, sylow_count_mod_p]; exact one_ne_zero`.
- **`sylow_index_not_dvd_p`**: the **Hall property** `¬ p ∣ [G:P]` — a Sylow p-subgroup's index is prime to `p`, the defining maximality feature behind the First Sylow Theorem. Proof: `P.not_dvd_index`; the `[P.FiniteIndex]` and `[Finite (Sylow p G)]` instances are supplied automatically by `[Fintype G]` (mirrors the verified `sylow_count_dvd_index`, which already uses `P.toSubgroup.index`).

Together with the existing `sylow_card_eq` (`|P| = p^(vₚ|G|)`) these express that a Sylow subgroup is a Hall subgroup: `|P|` and `[G:P]` are coprime.

## Meta
- `lineCount` 189 → 210
- `theoremCount` (both fields were stale, 11/12) → 16 (matches `grep -c '^theorem '`)

## Verification status
**UNVERIFIED** — the Docker Lean image build fails with the recurring `containerd .../meta.db: input/output error`, so `docker-build.sh` could not run. Both proofs are one-line applications of Mathlib API (`Sylow.not_dvd_index`, `Nat.dvd_iff_mod_eq_zero`) following verified sibling patterns already in the file. No new axioms or sorries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)