### PR TITLE
Enrich binary-gcd diagonal slice: add annotations (0 → 7)

### DIFF
--- a/src/data/proofs/binary-gcd-oq-01-oq-04-oq-04/annotations.json
+++ b/src/data/proofs/binary-gcd-oq-01-oq-04-oq-04/annotations.json
@@ -1,0 +1,86 @@
+[
+  {
+    "id": "ann-bgcd-diag-overview",
+    "proofId": "binary-gcd-oq-01-oq-04-oq-04",
+    "range": { "startLine": 1, "endLine": 51 },
+    "type": "concept",
+    "title": "The Diagonal Slice a = b and the Valuation Law",
+    "content": "Stein's Binary GCD replaces Euclidean division by shifts and subtractions, and its step count binaryGcdSteps a b defines a two-dimensional surface over the pairs (a, b). The sibling files settled the *axes*: binaryGcdSteps 1 b = Nat.log 2 b + 1 (the binary bit-length). OQ-02 left open whether any *interior* pair a, b > 1 could exceed the axis. This file settles the first and most symmetric interior slice — the diagonal a = b — with the closed form binaryGcdSteps n n = padicValNat 2 n + 1: the cost is the number of trailing binary zeros of n, plus one. The diagonal is thus governed by the 2-adic *valuation* of n rather than by its *size* (logarithm), the exact valuation-analogue of the axis bit-length law.",
+    "mathContext": "$\\texttt{binaryGcdSteps}\\,n\\,n = v_2(n) + 1$, where $v_2(n)$ is the exponent of $2$ in $n$ (trailing binary zeros); compare the axis law $\\texttt{binaryGcdSteps}\\,1\\,n = \\lfloor\\log_2 n\\rfloor + 1$.",
+    "significance": "key",
+    "relatedConcepts": ["binary GCD algorithm", "2-adic valuation", "worst-case complexity", "trailing zeros", "step-count surface"],
+    "prerequisites": ["Stein's binary GCD reduction rules", "p-adic valuation"]
+  },
+  {
+    "id": "ann-bgcd-diag-odd",
+    "proofId": "binary-gcd-oq-01-oq-04-oq-04",
+    "range": { "startLine": 64, "endLine": 76 },
+    "type": "theorem",
+    "title": "Odd Diagonal: One Step to Termination",
+    "content": "binaryGcdSteps_diag_odd: when n is odd, the two equal odd arguments hit Stein's odd/odd branch, which subtracts the smaller from the larger. Here the difference is n − n = 0, so the algorithm terminates in a single step: binaryGcdSteps n n = 1. The proof rewrites via the equation lemma binaryGcdSteps.eq_3 and discharges the three parity/order guards (both arguments odd, and ¬(n > n)) by omega. This is the base case of the whole analysis — every diagonal computation eventually lands on an equal odd pair and stops.",
+    "mathContext": "$n$ odd $\\Rightarrow$ odd/odd rule $\\Rightarrow n - n = 0$ in one step, so $\\texttt{binaryGcdSteps}\\,n\\,n = 1 = v_2(n) + 1$ since $v_2(n) = 0$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Stein odd/odd rule", "equation lemma", "parity", "termination"],
+    "prerequisites": ["binaryGcdSteps recursion", "omega tactic"]
+  },
+  {
+    "id": "ann-bgcd-diag-even",
+    "proofId": "binary-gcd-oq-01-oq-04-oq-04",
+    "range": { "startLine": 77, "endLine": 84 },
+    "type": "theorem",
+    "title": "Even Diagonal: Halve Both Arguments",
+    "content": "binaryGcdSteps_diag_even: when n ≥ 1 is even, both arguments are even, so Stein's even/even branch halves both and recurses: binaryGcdSteps n n = 1 + binaryGcdSteps (n/2) (n/2). A single binaryGcdSteps.eq_3 unfolding with if_pos on the two even-guards closes it. Together with the odd case, these are the *only* two behaviours the diagonal ever exhibits: strip one factor of 2, or terminate. Iterating the halving peels off one binary digit per step until an odd number appears.",
+    "mathContext": "$n$ even $\\Rightarrow$ even/even rule $\\Rightarrow \\texttt{binaryGcdSteps}\\,n\\,n = 1 + \\texttt{binaryGcdSteps}\\,\\tfrac{n}{2}\\,\\tfrac{n}{2}$; each step drops $v_2$ by exactly one.",
+    "significance": "supporting",
+    "relatedConcepts": ["Stein even/even rule", "halving", "recursion", "binary digits"],
+    "prerequisites": ["binaryGcdSteps recursion", "even/odd case split"]
+  },
+  {
+    "id": "ann-bgcd-diag-main",
+    "proofId": "binary-gcd-oq-01-oq-04-oq-04",
+    "range": { "startLine": 89, "endLine": 117 },
+    "type": "theorem",
+    "title": "The Diagonal Closed Form: v₂(n) + 1",
+    "content": "binaryGcdSteps_diag — the headline result: for every n ≥ 1, binaryGcdSteps n n = padicValNat 2 n + 1. Proved by strong induction (Nat.strong_induction_on). The odd case reduces in one step with padicValNat 2 n = 0 (eq_zero_of_not_dvd). The even case applies binaryGcdSteps_diag_even, recurses on n/2, and uses padicValNat.div — which says the valuation drops by *exactly* one when dividing out a factor of 2 — together with one_le_padicValNat_of_dvd, closed by omega. The strong-induction shape is essential because the recursion argument n/2 is smaller but not the immediate predecessor.",
+    "mathContext": "$\\texttt{binaryGcdSteps}\\,n\\,n = v_2(n) + 1$; even branch: $v_2(n/2) = v_2(n) - 1$ (padicValNat.div) with $v_2(n) \\ge 1$, so $1 + (v_2(n/2)+1) = v_2(n)+1$.",
+    "significance": "key",
+    "relatedConcepts": ["strong induction", "padicValNat.div", "2-adic valuation", "closed form", "worst-case analysis"],
+    "prerequisites": ["strong induction", "p-adic valuation API", "Fact (Nat.Prime 2)"]
+  },
+  {
+    "id": "ann-bgcd-diag-constructive",
+    "proofId": "binary-gcd-oq-01-oq-04-oq-04",
+    "range": { "startLine": 122, "endLine": 142 },
+    "type": "theorem",
+    "title": "Constructive Form over n = 2^k · m",
+    "content": "binaryGcdSteps_diag_two_pow_mul: for odd m, binaryGcdSteps (2^k·m) (2^k·m) = k + 1, by a direct induction on k using only the one-step reductions — no valuation machinery. The base case k = 0 is the odd reduction on m; the successor step rewrites 2^(k+1)·m = 2·(2^k·m), applies the even reduction, cancels the halving (2·x/2 = x), and invokes the inductive hypothesis. binaryGcdSteps_diag_two_pow specialises to m = 1: binaryGcdSteps (2^k) (2^k) = k + 1. Because this proof avoids Mathlib's p-adic API entirely, it is an *independent* verification of the same law — the closed form does not hinge on any single piece of the valuation library.",
+    "mathContext": "$n = 2^k m$ ($m$ odd) $\\Rightarrow \\texttt{binaryGcdSteps}\\,n\\,n = k + 1 = v_2(n) + 1$; proved by induction on $k$ with $2^{k+1}m = 2\\cdot(2^k m)$.",
+    "significance": "supporting",
+    "relatedConcepts": ["induction on exponent", "unique factorisation", "independent proof", "powers of two"],
+    "prerequisites": ["induction", "the one-step diagonal reductions"]
+  },
+  {
+    "id": "ann-bgcd-diag-le-axis",
+    "proofId": "binary-gcd-oq-01-oq-04-oq-04",
+    "range": { "startLine": 147, "endLine": 165 },
+    "type": "theorem",
+    "title": "The Diagonal Never Exceeds the Axis (answers OQ-02)",
+    "content": "Two bounds. binaryGcdSteps_diag_le_log: since v₂(n) ≤ log₂ n always (padicValNat_le_nat_log), the diagonal cost is ≤ Nat.log 2 n + 1. binaryGcdSteps_diag_le_axis: rewriting the a = 1 axis slice via sibling OQ-01's closed form (binaryGcdSteps_one_eq_log_succ) gives binaryGcdSteps n n ≤ binaryGcdSteps 1 n for every n ≥ 1. This settles OQ-02's open question for the diagonal: the interior diagonal is *cheaper* than the axis, so the two-argument worst case does not migrate onto it — it stays on the boundary a = 1 or b = 1. The gap is strict except when n is a pure power of two (v₂(n) = log₂ n).",
+    "mathContext": "$v_2(n) \\le \\lfloor\\log_2 n\\rfloor \\Rightarrow \\texttt{binaryGcdSteps}\\,n\\,n \\le \\texttt{binaryGcdSteps}\\,1\\,n$, with equality iff $n = 2^{\\lfloor\\log_2 n\\rfloor}$.",
+    "significance": "key",
+    "relatedConcepts": ["valuation vs logarithm", "worst-case location", "open question OQ-02", "cross-file dependency"],
+    "prerequisites": ["padicValNat_le_nat_log", "sibling axis closed form"]
+  },
+  {
+    "id": "ann-bgcd-diag-crosschecks",
+    "proofId": "binary-gcd-oq-01-oq-04-oq-04",
+    "range": { "startLine": 170, "endLine": 187 },
+    "type": "context",
+    "title": "Symbolic, Axiom-Free Cross-Checks",
+    "content": "Four spot checks exercise the closed form in both presentations without decide / native_decide: binaryGcdSteps 8 8 = 4 (via the power-of-two form, 8 = 2³), binaryGcdSteps 5 5 = 1 (odd), binaryGcdSteps 12 12 = 3 (constructive form, 12 = 2²·3), and binaryGcdSteps 12 12 = padicValNat 2 12 + 1 (valuation form). Deriving these symbolically — rather than by decide — means the checks incur no Lean.ofReduceBool, so the whole file rests only on the foundational axioms propext / Classical.choice / Quot.sound. They also make the non-monotonicity of the diagonal concrete: the cost is 1 at n = 5 but 4 at n = 8.",
+    "mathContext": "$\\texttt{binaryGcdSteps}\\,8\\,8 = 4$, $\\texttt{binaryGcdSteps}\\,5\\,5 = 1$, $\\texttt{binaryGcdSteps}\\,12\\,12 = 3$ — all symbolic, no $\\texttt{native\\_decide}$.",
+    "significance": "context",
+    "relatedConcepts": ["axiom integrity", "no native_decide", "non-monotonicity", "worked examples"],
+    "prerequisites": ["the diagonal closed form", "#print axioms discipline"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `binary-gcd-oq-01-oq-04-oq-04` (Binary GCD, diagonal slice a = b).

## Gap
The entry had **no `annotations.json` at all** — quality was 45 (all annotation/mathContext/significance/crossRef points missing) despite a rich meta.json. No competing open PR.

## Change
Created `annotations.json` with **7 line-anchored annotations** covering the full 187-line Lean file, each carrying `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`:

1. Overview — the diagonal is governed by the 2-adic valuation $v_2(n)$, not the bit-length.
2. Odd reduction (`binaryGcdSteps_diag_odd`) — odd/odd branch terminates in one step.
3. Even reduction (`binaryGcdSteps_diag_even`) — even/even branch halves both.
4. Main closed form (`binaryGcdSteps_diag`) — $v_2(n)+1$ via strong induction + `padicValNat.div`.
5. Constructive form (`binaryGcdSteps_diag_two_pow_mul`) — valuation-free independent proof over $n = 2^k m$.
6. Diagonal ≤ axis (`binaryGcdSteps_diag_le_axis`) — answers OQ-02 for the diagonal.
7. Symbolic, axiom-free cross-checks.

## Verification
- `pnpm annotations:build`: all 7 annotations resolve to the correct Lean constructs, **0 warnings/errors** for this entry.
- Content checked line-by-line against `Proofs/BinaryGcdOQ01OQ04OQ04.lean`.
- Quality 45 → 100. meta.json untouched (already comprehensive). No size-cap concerns.