### PR TITLE
research(erdos-378): repair broken build (Mathlib drift) + antitone filtration [VERIFIED]

### DIFF
--- a/proofs/Proofs/Erdos378Problem.lean
+++ b/proofs/Proofs/Erdos378Problem.lean
@@ -279,7 +279,7 @@ theorem odd_squarefreeCount_iff {n : ℕ} :
     Odd (squarefreeCount n) ↔ (Even n ∧ 2 ≤ n ∧ Squarefree (n.choose (n / 2))) := by
   rcases Nat.even_or_odd n with he | ho
   · -- even `n`: split on the degenerate `n = 0` versus the genuine `n ≥ 2` rows
-    rcases lt_or_le n 2 with hlt | hge
+    rcases lt_or_ge n 2 with hlt | hge
     · have hn0 : n = 0 := by have := Nat.even_iff.mp he; omega
       subst hn0
       have h0 : squarefreeCount 0 = 0 := by simp [squarefreeCount]
@@ -289,8 +289,8 @@ theorem odd_squarefreeCount_iff {n : ℕ} :
       exact ⟨fun h => ⟨he, hge, h⟩, fun h => h.2.2⟩
   · -- odd `n`: the count is even, and the right side fails because `n` is not even
     have heven : Even (squarefreeCount n) := squarefreeCount_even_of_odd ho
-    exact ⟨fun h => absurd h (Nat.even_iff_not_odd.mp heven),
-           fun h => absurd h.1 (Nat.odd_iff_not_even.mp ho)⟩
+    exact ⟨fun h => absurd h (not_odd_iff_even.mpr heven),
+           fun h => absurd h.1 (not_even_iff_odd.mpr ho)⟩
 
 /-
 ## Part IV: Natural density
@@ -414,6 +414,22 @@ theorem atLeastSquarefree_eq_compl (r : ℕ) :
   ext n
   simp only [atLeastSquarefree, hasAtLeastSquarefree, Set.mem_setOf_eq,
     Set.mem_compl_iff, not_lt]
+
+/-- **`hasAtLeastSquarefree` is antitone in the threshold `r`.**  If `n` has at least `r`
+values of `k` with `C(n,k)` squarefree, then it has at least `r'` for every `r' ≤ r`: the
+requirement only weakens as the threshold drops (`r' ≤ r ≤ squarefreeCount n`). -/
+theorem hasAtLeastSquarefree_antitone {n r r' : ℕ} (hr : r' ≤ r)
+    (h : hasAtLeastSquarefree n r) : hasAtLeastSquarefree n r' :=
+  le_trans hr h
+
+/-- **The `atLeastSquarefree r` sets form a decreasing filtration.**  A larger threshold `r`
+carves out a smaller set: `atLeastSquarefree r ⊆ atLeastSquarefree r'` whenever `r' ≤ r`.  So
+the Erdős #378 answer sets are nested `atLeastSquarefree 0 ⊇ atLeastSquarefree 1 ⊇ ⋯`, and the
+positive-density statement `erdos_378_density_positive` at threshold `r` propagates down to every
+smaller threshold `r' ≤ r`. -/
+theorem atLeastSquarefree_antitone {r r' : ℕ} (hr : r' ≤ r) :
+    atLeastSquarefree r ⊆ atLeastSquarefree r' :=
+  fun _ hn => hasAtLeastSquarefree_antitone hr hn
 
 /-- **Main Theorem, Part 1 — the density exists.**
 

--- a/research/problems/erdos-378/knowledge.md
+++ b/research/problems/erdos-378/knowledge.md
@@ -69,3 +69,31 @@ theoremCount 11→12, lineCount 311→403.
   theory is now complete.
 - The two Granville–Ramaré axioms are the frontier; formalizing either needs the
   full exponential-sum machinery (>>1000 lines, BLOCKED).
+
+## Session 2026-07-10 (researcher-3) — REPAIRED broken build + antitone filtration (VERIFIED)
+
+**Mode**: REVISIT (MODERATE, COMPLETED slug) · **Outcome**: build repair + 2 theorems, **VERIFIED**.
+
+**★ Found the gallery file broken on main.** `Erdos378Problem.lean` did not elaborate against the
+pinned Mathlib (rev 2df2f0150c): `Nat.even_iff_not_odd` and `Nat.odd_iff_not_even` (used at lines
+292–293, introduced by #36995) **do not exist** there. Math PRs fast-merge without building
+(deployer policy), so the drift-break landed unverified. Repaired:
+- `Nat.even_iff_not_odd.mp heven` → `not_odd_iff_even.mpr heven`
+- `Nat.odd_iff_not_even.mp ho` → `not_even_iff_odd.mpr ho`
+  (`not_odd_iff_even : ¬Odd n ↔ Even n`, `not_even_iff_odd : ¬Even n ↔ Odd n` — the general
+  `Algebra/Ring/Parity` lemmas, which apply to ℕ).
+- `lt_or_le` → `lt_or_ge` (deprecation).
+File now elaborates **completely clean** (exit 0, 0 errors, 0 warnings).
+
+**Added** (orthogonal to the parity work / open PR #35186):
+- `hasAtLeastSquarefree_antitone {n r r'} (hr : r' ≤ r) : hasAtLeastSquarefree n r → hasAtLeastSquarefree n r'`
+- `atLeastSquarefree_antitone {r r'} (hr : r' ≤ r) : atLeastSquarefree r ⊆ atLeastSquarefree r'`
+
+The Erdős #378 answer sets form a decreasing filtration `atLeastSquarefree 0 ⊇ atLeastSquarefree 1 ⊇ ⋯`
+(`hasAtLeastSquarefree n r := squarefreeCount n ≥ r`, antitone in `r` by `le_trans`), so the
+positive-density result at threshold `r` propagates to every smaller threshold. Axiom count
+unchanged (2 deep Granville–Ramaré axioms, un-eliminable). File 457→473 lines; gallery
+meta.lineCount 432→473 (also drifted), theoremCount →17.
+
+**Verification.** Full-file `./bin/lake env lean` from the main repo (self-contained, imports only
+Mathlib): exit 0, clean. Both new lemmas are `le_trans`-only, axiom-free.

--- a/src/data/proofs/erdos-378/meta.json
+++ b/src/data/proofs/erdos-378/meta.json
@@ -64,9 +64,9 @@
       "erdos_378, erdos_378_answer (no sorries): combined resolution of both questions"
     ],
     "axiomCount": 2,
-    "lineCount": 432,
+    "lineCount": 473,
     "assumptions": "2 axioms, both isolating the deep analytic content of Granville-Ramaré (1996): granville_ramare_density_exists (the density η_m of n with exactly 2m+2 squarefree binomials exists) and complement_density (the set of n with fewer than r squarefree binomials has density Σ_{0≤m≤(r-1)/2} η_m, which is < 1). 0 sorries. All other results, including the resolution of both questions and the parity theorems squarefreeCount_even_of_odd (odd rows have an even count) and squarefreeCount_odd_iff_central_squarefree (an even row has an odd count iff its central binomial C(n,n/2) is squarefree), are fully machine-checked (depend only on propext/Classical.choice/Quot.sound).",
-    "theoremCount": 12,
+    "theoremCount": 17,
     "definitionCount": 8,
     "additionalFiles": [
       "Proofs/Erdos378Aristotle.lean"

--- a/src/data/research/problems/erdos-378.json
+++ b/src/data/research/problems/erdos-378.json
@@ -39,13 +39,16 @@
       "erdos_378 / erdos_378_answer: packaged full resolution combining existence and positivity for all r.",
       "atLeastSquarefree_eq_compl: atLeastSquarefree r is the set-complement of {n | squarefreeCount n < r} (elementary, 0 sorries).",
       "Definitions squarefreeCount, hasAtLeastSquarefree, exactlySquarefree, atLeastSquarefree, eta, HasDensity/NaturalDensity scaffolding (8 definitions) framing the density formulation.",
-      "Two named axioms granville_ramare_density_exists and complement_density isolating the deep analytic input; gallery entry src/data/proofs/erdos-378 (meta.json + annotations.json)."
+      "Two named axioms granville_ramare_density_exists and complement_density isolating the deep analytic input; gallery entry src/data/proofs/erdos-378 (meta.json + annotations.json).",
+      "REPAIRED broken build (Mathlib drift): Nat.even_iff_not_odd/Nat.odd_iff_not_even (nonexistent in pinned Mathlib rev 2df2f0150c) → not_odd_iff_even.mpr/not_even_iff_odd.mpr; lt_or_le → lt_or_ge deprecation. File now elaborates CLEAN (0 errors 0 warnings). The break was introduced by #36995 and fast-merged unbuilt (math PRs skip build).",
+      "hasAtLeastSquarefree_antitone / atLeastSquarefree_antitone : the Erdős #378 answer sets form a decreasing filtration atLeastSquarefree 0 ⊇ atLeastSquarefree 1 ⊇ ⋯ (antitone in threshold r via le_trans). [VERIFIED axiom-free]"
     ],
     "insights": [
       "The whole resolution is complementation: 'at least r squarefree' is the complement of 'fewer than r squarefree', so its density is 1 − d, and positivity is exactly the d < 1 clause of the Granville–Ramaré tail estimate.",
       "The deep content is purely the two density facts of Granville–Ramaré (1996); once granted, the Erdős #378 answer follows by elementary, fully-checked Lean arguments — so axiomatizing those two inputs is the honest and efficient architecture.",
       "Positivity is the substantive 'yes': existence of a density is the easy half; that the density is strictly positive (the excluded tail does not have full density) is what makes the answer affirmative.",
-      "Mathlib lacks the Granville–Ramaré machinery, so these inputs cannot currently be discharged; the entry is correctly badged 'axiomatized' (axiomCount 2) rather than 'verified'."
+      "Mathlib lacks the Granville–Ramaré machinery, so these inputs cannot currently be discharged; the entry is correctly badged 'axiomatized' (axiomCount 2) rather than 'verified'.",
+      "Erdos378Problem.lean was BROKEN on main against the pinned Mathlib: Nat.even_iff_not_odd and Nat.odd_iff_not_even do not exist there (the general not_odd_iff_even/not_even_iff_odd in Algebra/Ring/Parity are the correct names). Math PRs fast-merge WITHOUT building (deployer policy), so drift-breaking edits land unverified — always full-file lake env lean before adding to a gallery file."
     ],
     "mathlibGaps": [
       "Granville–Ramaré (1996) density results for squarefree-binomial counts are not in Mathlib; discharging granville_ramare_density_exists and complement_density would require formalizing substantial analytic number theory."


### PR DESCRIPTION
## Summary
Research session for `erdos-378` (density of `n` with `C(n,k)` squarefree for ≥ r values). While verifying, I found the gallery file **broken on `main`** and repaired it, then added a structural lemma.

## ⚠️ Build repair (primary contribution)
`Proofs/Erdos378Problem.lean` did **not** elaborate against the pinned Mathlib (rev `2df2f0150c`): `Nat.even_iff_not_odd` and `Nat.odd_iff_not_even` (used at lines 292–293, introduced by #36995) **do not exist** in it. Because math PRs fast-merge without building (deployer policy), this drift-break landed on `main` unverified. Fixed:
- `Nat.even_iff_not_odd.mp heven` → `not_odd_iff_even.mpr heven`
- `Nat.odd_iff_not_even.mp ho` → `not_even_iff_odd.mpr ho`
  (`not_odd_iff_even : ¬Odd n ↔ Even n` and `not_even_iff_odd : ¬Even n ↔ Odd n` — the general `Algebra/Ring/Parity` lemmas, which apply to `ℕ`.)
- `lt_or_le` → `lt_or_ge` (deprecation).

The file now elaborates **completely clean** (exit 0, **0 errors, 0 warnings**).

## New content (orthogonal to open parity PR #35186)
- `hasAtLeastSquarefree_antitone {n r r'} (hr : r' ≤ r) : hasAtLeastSquarefree n r → hasAtLeastSquarefree n r'`
- `atLeastSquarefree_antitone {r r'} (hr : r' ≤ r) : atLeastSquarefree r ⊆ atLeastSquarefree r'`

The Erdős #378 answer sets form a decreasing filtration `atLeastSquarefree 0 ⊇ atLeastSquarefree 1 ⊇ ⋯` (since `hasAtLeastSquarefree n r := squarefreeCount n ≥ r`, antitone in `r`), so the positive-density result at threshold `r` propagates down to every smaller threshold.

## Files modified
- `proofs/Proofs/Erdos378Problem.lean` (457→473; drift repair + 2 theorems; axiom count unchanged at 2)
- `src/data/proofs/erdos-378/meta.json` (lineCount 432→473 — also drifted; theoremCount →17)
- `src/data/research/problems/erdos-378.json`, `research/problems/erdos-378/knowledge.md`

## Verification
**VERIFIED.** The file imports only Mathlib, so it was elaborated in full via `./bin/lake env lean` against the pinned Mathlib v4.26.0 oleans (Docker image build is down): **exit 0, no errors, no warnings**. The two deep Granville–Ramaré axioms are unchanged (status stays `axiomatized`); both new lemmas are `le_trans`-only, axiom-free.

## Status
**Outcome**: build repair (was broken on main) + orthogonal structural lemma.
**Next Steps**: none beyond the standing deep axioms.

🤖 Generated by researcher-3