### PR TITLE
research(erdos-748-incomplete-01): odd-family lower bound f(n) ≥ 2^|O| [UNVERIFIED]

### DIFF
--- a/proofs/Proofs/Erdos748Problem.lean
+++ b/proofs/Proofs/Erdos748Problem.lean
@@ -549,6 +549,43 @@ theorem two_family_bound_gt_upperHalf (n : ℕ) (hn : 3 ≤ n) :
     Nat.pow_lt_pow_right (by norm_num) hcard
   omega
 
+/--
+**The two-family bound also dominates the single *odd-family* bound.**
+Symmetric companion of `two_family_bound_ge_upperHalf`: the right-hand side of
+`two_family_lower_bound`, `2^{|O|} + 2^{|U|} − 2^{|O ∩ U|}`, is always at least
+`2^{|O|}` — the value coming from the odd family alone. Here `O ∩ U ⊆ U`, so
+`2^{|O ∩ U|} ≤ 2^{|U|}` and the surplus `2^{|U|} − 2^{|O ∩ U|}` is nonnegative.
+Together with `two_family_bound_ge_upperHalf` this shows the two-family count
+never loses to *either* single family. -/
+theorem two_family_bound_ge_oddFamily (n : ℕ) :
+    2 ^ ((Finset.range (n + 1)).filter (fun k => k % 2 = 1)).card
+      + 2 ^ (Finset.Icc (n / 2 + 1) n).card
+      - 2 ^ (((Finset.range (n + 1)).filter (fun k => k % 2 = 1))
+              ∩ Finset.Icc (n / 2 + 1) n).card
+    ≥ 2 ^ ((Finset.range (n + 1)).filter (fun k => k % 2 = 1)).card := by
+  have hsub : (((Finset.range (n + 1)).filter (fun k => k % 2 = 1))
+                ∩ Finset.Icc (n / 2 + 1) n).card
+              ≤ (Finset.Icc (n / 2 + 1) n).card :=
+    Finset.card_le_card Finset.inter_subset_right
+  have hpow : 2 ^ (((Finset.range (n + 1)).filter (fun k => k % 2 = 1))
+                ∩ Finset.Icc (n / 2 + 1) n).card
+              ≤ 2 ^ (Finset.Icc (n / 2 + 1) n).card :=
+    Nat.pow_le_pow_right (by norm_num) hsub
+  omega
+
+/--
+**Odd-family lower bound:** `f(n) ≥ 2^{|O|}`, where `O` is the set of odd numbers
+in `[1,n]`. Every subset of `O` is sum-free (odd + odd is even, so no `a = b + c`
+among odds), so the `2^{|O|}` subsets of `O` are all counted by `f n`. This is
+the "type 2" dominant family of Part VII, isolated as a standalone bound: it is
+obtained from `two_family_lower_bound` by discarding the upper-half contribution
+via `two_family_bound_ge_oddFamily`. Since `|O| = ⌈n/2⌉`, it gives the same
+`2^{⌈n/2⌉}` exponent as `sharp_lower_bound` but through the *odd* construction
+rather than the upper half — a genuinely distinct witnessing family. -/
+theorem oddFamily_lower_bound (n : ℕ) :
+    f n ≥ 2 ^ ((Finset.range (n + 1)).filter (fun k => k % 2 = 1)).card :=
+  le_trans (two_family_bound_ge_oddFamily n) (two_family_lower_bound n)
+
 /-
 ## Part VII: Structure of Sum-Free Sets
 -/

--- a/src/data/proofs/erdos-748/meta.json
+++ b/src/data/proofs/erdos-748/meta.json
@@ -58,9 +58,9 @@
       "erdos_748_summary: combining all results"
     ],
     "axiomCount": 2,
-    "lineCount": 663,
+    "lineCount": 700,
     "assumptions": "2 axiom(s): green_upper_bound (Green 2004), precise_asymptotic (Green/Sapozhenko). Both are deep results from the literature. The lower bound is fully proved (no longer an axiom), and sharpened to f(n) ≥ 2^{⌈n/2⌉} (sharp_lower_bound) — the best the upper-half construction yields. See the Lean source for details.",
-    "theoremCount": 21,
+    "theoremCount": 23,
     "definitionCount": 5,
     "additionalFiles": [
       "Proofs/Erdos748Aristotle.lean"
@@ -180,9 +180,9 @@
       "Finset"
     ],
     "namespace": "Erdos748",
-    "lineCount": 663,
+    "lineCount": 700,
     "axiomCount": 2,
-    "theoremCount": 22,
+    "theoremCount": 24,
     "definitionCount": 5,
     "path": "Proofs/Erdos748Problem.lean",
     "sorries": 0,


### PR DESCRIPTION
## Summary

The Cameron–Erdős file already proves that the two-family lower bound dominates the upper-half family (`two_family_bound_ge_upperHalf`: RHS ≥ 2^|U|). It never states the *symmetric* dominance over the **odd** family, nor the standalone odd-family lower bound — the 'type 2' dominant family named in the Part VII prose. This PR adds both:

- `two_family_bound_ge_oddFamily` : `2^|O| + 2^|U| − 2^|O∩U| ≥ 2^|O|` — the mirror of the verified `...ge_upperHalf`, using `O∩U ⊆ U` (so `2^|O∩U| ≤ 2^|U|`, surplus ≥ 0). Together the two lemmas show the two-family count never loses to *either* single family.
- `oddFamily_lower_bound` : `f n ≥ 2^|O|` where `O` = odd numbers in `[1,n]`. Obtained by `le_trans` of the dominance lemma and `two_family_lower_bound`. Since `|O| = ⌈n/2⌉`, this reaches the same `2^⌈n/2⌉` exponent as `sharp_lower_bound` but through the odd construction (type 2) rather than the upper half (type 1) — a genuinely distinct witnessing family.

Both proofs are line-for-line analogues of already-verified siblings (`two_family_bound_ge_upperHalf`, `two_family_lower_bound`). No new axioms or imports; the file's 2 literature axioms (Green/Sapozhenko) are untouched.

## Meta

- `lineCount` 663 → 700 (both copies), `theoremCount` +2 (both copies).

## Collision avoidance

No open PR touches `erdos-748` (`Erdos748Problem.lean`/meta). Zero overlap.

## Verification

⚠️ **UNVERIFIED** — docker build unavailable this session (containerd `meta.db` input/output error). Proofs reuse the exact structure of verified in-file lemmas (`Finset.card_le_card`, `Nat.pow_le_pow_right`, `omega`, `le_trans`); high confidence, but not machine-checked here.