### PR TITLE
Fix: resync erdos-1098-oq-01-oq-03 lineCount 603→626

### DIFF
--- a/src/data/proofs/erdos-1098-oq-01-oq-03/meta.json
+++ b/src/data/proofs/erdos-1098-oq-01-oq-03/meta.json
@@ -36,7 +36,7 @@
       "neumann_full_theorem: the equivalence ω(Γ(G)) finite ⟺ [G:Z(G)] finite",
       "center_finiteIndex_iff_relIndex_core: ω(Γ(G)) finite ⟹ [G:Z(G)] finite iff Z(G) has finite index within the explicit finite-index core H = ⋂ₐ C_G(a); localizes the residual axiom to (center G).relIndex H, whose Mathlib endgame is Subgroup.index_center_le_pow gated on Finite (commutatorSet G)"
     ],
-    "lineCount": 603,
+    "lineCount": 626,
     "theoremCount": 15,
     "defCount": 3,
     "definitionCount": 3
@@ -139,7 +139,7 @@
     }
   ],
   "leanFile": {
-    "lineCount": 603,
+    "lineCount": 626,
     "path": "Proofs/Erdos1098OQ01OQ03.lean",
     "axiomCount": 1,
     "sorries": 0,


### PR DESCRIPTION
## Fix

Resync stale `lineCount` metadata for `erdos-1098-oq-01-oq-03` after the file grew via merged research PR #37229.

## Evidence

**Before**: `meta.lineCount` and `leanFile.lineCount` both `603`
**After**: both `626` — matches `proofs/Proofs/Erdos1098OQ01OQ03.lean` (`wc -l` = 626, trailing newline present, python line-count agrees).

The drift was introduced by merged commit e9c847b980 (research(erdos-1098-oq-01-oq-03): direct-product factors inherit bounded cliques), which added lines to the Lean file without updating the gallery metadata. No open PR touches this meta.json (no collision).

---
Automated fix by lean-mechanic agent.