### PR TITLE
research(binary-gcd-oq-01-oq-04): two-sided Θ(log b) sandwich for worst-case family

### DIFF
--- a/proofs/Proofs/BinaryGcdOQ01OQ04.lean
+++ b/proofs/Proofs/BinaryGcdOQ01OQ04.lean
@@ -139,6 +139,42 @@ theorem binaryGcdSteps_exceeds_log_by_one (n : ℕ) (hn : 2 ≤ n) :
   omega
 
 -- ═══════════════════════════════════════════════════════════════════
+-- PART IV.5: MATCHING UPPER BOUND AND THE TWO-SIDED SANDWICH
+-- ═══════════════════════════════════════════════════════════════════
+
+/-- **Matching upper bound** for the worst-case family, specialised from the
+    general Binary GCD bound `binaryGcdSteps_le_log` in `BinaryGcdOQ01`.
+
+    Since the first argument is `1` and `Nat.log 2 1 = 0`, the two-variable
+    bound `binaryGcdSteps a b ≤ 2·(log₂ a + log₂ b) + 2` collapses to
+      binaryGcdSteps 1 (2^n - 1) ≤ 2·log₂(2^n - 1) + 2. -/
+theorem binaryGcdSteps_family_upper_bound (n : ℕ) (hn : 1 ≤ n) :
+    binaryGcdSteps 1 (2 ^ n - 1) ≤ 2 * Nat.log 2 (2 ^ n - 1) + 2 := by
+  have hb : 0 < 2 ^ n - 1 := by
+    have h2n : 2 ≤ 2 ^ n := by
+      calc 2 = 2 ^ 1 := by norm_num
+        _ ≤ 2 ^ n := Nat.pow_le_pow_right (by norm_num) hn
+    omega
+  have h := binaryGcdSteps_le_log 1 (2 ^ n - 1) (by norm_num) hb
+  rw [Nat.log_one_right] at h
+  omega
+
+/-- **Two-sided tight bound (Θ(log b))** for the worst-case family `(1, 2^n - 1)`.
+
+    This formalizes the claim stated in prose in the file header and in the
+    docstring of `binaryGcdSteps_log_lower_bound`: with `L = log₂(2^n - 1)`,
+      L + 1 ≤ binaryGcdSteps 1 (2^n - 1) ≤ 2·L + 2.
+
+    The lower bound comes from the exact step count `= n` (which exceeds `L`),
+    and the upper bound is the specialised general bound. Together they pin the
+    step count to a factor-2 window around `log₂ b`, proving the worst-case
+    Binary GCD complexity is `Θ(log b)`. -/
+theorem binaryGcdSteps_family_sandwich (n : ℕ) (hn : 1 ≤ n) :
+    Nat.log 2 (2 ^ n - 1) + 1 ≤ binaryGcdSteps 1 (2 ^ n - 1) ∧
+      binaryGcdSteps 1 (2 ^ n - 1) ≤ 2 * Nat.log 2 (2 ^ n - 1) + 2 :=
+  ⟨binaryGcdSteps_log_lower_bound n hn, binaryGcdSteps_family_upper_bound n hn⟩
+
+-- ═══════════════════════════════════════════════════════════════════
 -- PART V: CONCRETE VERIFICATIONS
 -- ═══════════════════════════════════════════════════════════════════
 

--- a/src/data/proofs/binary-gcd-oq-01-oq-04/meta.json
+++ b/src/data/proofs/binary-gcd-oq-01-oq-04/meta.json
@@ -20,7 +20,7 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 1,
-    "lineCount": 157,
+    "lineCount": 193,
     "dateAdded": "2026-04-04",
     "mathlibDependencies": [
       {
@@ -59,7 +59,7 @@
       "Computational verification for n = 1,2,3,4,6,8 via native_decide"
     ],
     "assumptions": "Depends on Lean.ofReduceBool. The symbolic results — binaryGcdSteps_one_pow2_sub_one (exact step count = n), binaryGcdSteps_log_lower_bound, and binaryGcdSteps_exceeds_log_by_one — are proved symbolically and are axiom-free. The advertised 'Computational verification for n = 1,2,3,4,6,8 via native_decide' contribution is discharged by native_decide, which trusts the Lean compiler's kernel reduction and adds the Lean.ofReduceBool axiom. 0 sorries. leanFile.axiomCount remains 0 (no literal axiom declarations).",
-    "theoremCount": 6,
+    "theoremCount": 8,
     "definitionCount": 0
   },
   "overview": {
@@ -171,10 +171,10 @@
       "Nat"
     ],
     "namespace": "BinaryGcdOQ01OQ04",
-    "lineCount": 157,
+    "lineCount": 193,
     "axiomCount": 0,
-    "theoremCount": 6,
-    "substantiveTheoremCount": 5,
+    "theoremCount": 8,
+    "substantiveTheoremCount": 7,
     "definitionCount": 0,
     "path": "Proofs/BinaryGcdOQ01OQ04.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

Formalizes the **two-sided tight bound** that `BinaryGcdOQ01OQ04.lean` states only in prose (file header + `binaryGcdSteps_log_lower_bound` docstring). With `L = log₂(2^n − 1)`, for `n ≥ 1`:

```
L + 1  ≤  binaryGcdSteps 1 (2^n − 1)  ≤  2·L + 2
```

pinning the worst-case Binary-GCD step count to a factor-2 window around `log₂ b` — i.e. **Θ(log b)**.

## What's new

- `binaryGcdSteps_family_upper_bound` — specialises the parent's general bound `binaryGcdSteps_le_log` (a=1 ⇒ `Nat.log 2 1 = 0`) to `2·log₂(2^n−1) + 2`.
- `binaryGcdSteps_family_sandwich` — pairs the new upper bound with the existing `binaryGcdSteps_log_lower_bound` for the complete two-sided statement.

Both are short corollaries built entirely on existing, verified lemmas; no new axioms or assumptions.

## Context

The claimed problem `binary-gcd-oq-01-oq-04-oq-03` (Brent's average-case constant ≈0.7050, requiring measure-theoretic probabilistic analysis) is out of reach for a single increment. This PR instead closes a concrete, promised-but-unformalized gap on the same worst-case family.

## Verification

⚠️ **UNVERIFIED** — Docker build unavailable this session (containerd `meta.db` I/O error). Proof checked by inspection:
- `Nat.log_one_right : log b 1 = 0` confirmed in the Mathlib pin (`Mathlib/Data/Nat/Log.lean:153`) and used identically in `BezoutIdentityOQ01OQ01OQ01OQ04.lean:210`.
- `binaryGcdSteps_le_log` is public in `BinaryGcdOQ01` (opened in this file).
- Final `omega` closes linear goals over opaque `binaryGcdSteps`/`Nat.log` atoms.

Gallery meta synced: lineCount 157→193, theoremCount 6→8, substantiveTheoremCount 5→7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)