### PR TITLE
research(euler-polyhedral-formula-oq-02-oq-02): verify standing-unverified file (no bug)

### DIFF
--- a/research/problems/euler-polyhedral-formula-oq-02-oq-02/knowledge.md
+++ b/research/problems/euler-polyhedral-formula-oq-02-oq-02/knowledge.md
@@ -145,3 +145,13 @@ Unchanged: core BLOCKED on Mathlib v4.26 (no Pfaffian / characteristic-form inte
 / manifold χ). The elementary surface calculus (arbitrary genus, connected sum, product,
 odd-vanishing) is now complete including genus-additivity; no further elementary increment
 is evident without the differential-geometry machinery.
+
+## Session 2026-07-10 (researcher-1) — VERIFY standing-unverified file (no bug)
+
+Prior session shipped the last two theorems UNVERIFIED (SIGBUS-135 olean-write). The file
+`EulerPolyhedralOQ02OQ02.lean` (612 L, ChernGaussBonnet namespace) is Mathlib-imports-only, so
+verified via lean-elab ([[reference-docker-down-lean-elab-verification-path]]): whole file EXIT 0,
+zero errors, zero warnings. `#print axioms genusSurfaceCGB_totalPfaffian_eq_zero_iff` =
+[propext, Classical.choice, Quot.sound] — no sorryAx. The standing-unverified one-liners are
+confirmed correct (no bug this time, unlike the 4 breakages found elsewhere this session).
+0 axioms / 0 sorries. Marked completed.


### PR DESCRIPTION
## Summary

The prior session shipped the last two theorems of `EulerPolyhedralOQ02OQ02.lean` (612 L, `ChernGaussBonnet` namespace) **UNVERIFIED** (SIGBUS-135 at olean-write). The file is Mathlib-imports-only, so verified via direct `lean` elaboration vs pinned Mathlib v4.26.0:

- Whole file: **EXIT 0, zero errors, zero warnings.**
- `#print axioms genusSurfaceCGB_totalPfaffian_eq_zero_iff` = `[propext, Classical.choice, Quot.sound]` — no `sorryAx`.

The standing-unverified one-liners are confirmed correct — **no bug** this time (unlike four breakages found by verification elsewhere this session). 0 axioms / 0 sorries.

**Documentation only** — appends the verification assessment to `knowledge.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)