### PR TITLE
research(erdos-1014-oq-03): bounded-gap log-flatness of Ramsey increment [UNVERIFIED]

### DIFF
--- a/proofs/Proofs/Erdos1014OQ03LogIncrement.lean
+++ b/proofs/Proofs/Erdos1014OQ03LogIncrement.lean
@@ -100,4 +100,39 @@ theorem logIncrement_tendsto_zero_of_ratio_tendsto_one (R : ℕ → ℝ)
     Tendsto (fun l => Real.log (R (l + 1)) - Real.log (R l)) atTop (𝓝 0) :=
   (logIncrement_tendsto_zero_iff_ratio_tendsto_one R hpos).mpr hratio
 
+/-- **Gap log-increment equals log of the gap-ratio.** For an eventually-positive
+sequence `R` and any fixed gap `m`, eventually
+`log R(l+m) − log R(l) = log ( R(l+m) / R(l) )`. The unit-gap case (`m = 1`) is
+`log_increment_eventuallyEq_log_ratio`. -/
+theorem logIncrement_gap_eventuallyEq_log_ratio_gap (R : ℕ → ℝ) (m : ℕ)
+    (hpos : ∀ᶠ l in atTop, 0 < R l) :
+    (fun l => Real.log (R (l + m)) - Real.log (R l))
+      =ᶠ[atTop] (fun l => Real.log (R (l + m) / R l)) := by
+  have hpos_m : ∀ᶠ l in atTop, 0 < R (l + m) :=
+    (tendsto_add_atTop_nat m).eventually hpos
+  filter_upwards [hpos, hpos_m] with l h0 hm
+  rw [Real.log_div hm.ne' h0.ne']
+
+/-- **Bounded-gap log-flatness.** Under Erdős #1014's ratio convergence
+`R(l+1)/R(l) → 1`, for *every fixed gap* `m` the gap log-increment
+`log R(l+m) − log R(l)` tends to `0`.
+
+The gap-ratio `R(l+m)/R(l) → 1` (parent's `ratio_gap_tendsto_one`), and eventually
+the gap log-increment equals `log ( R(l+m)/R(l) )`, so continuity of `log` at `1`
+sends it to `log 1 = 0`. This completes the gap-level trio alongside the parent's
+`ratio_gap_tendsto_one` (ratio → 1) and `increment_gap_div_tendsto_zero`
+(normalized increment → 0): applied to `R(k, ·)`, Ramsey growth is log-flat over
+*any* bounded window of the second index, not merely between neighbours. The
+unit-gap case (`m = 1`) is `logIncrement_tendsto_zero_of_ratio_tendsto_one`. -/
+theorem logIncrement_gap_tendsto_zero (R : ℕ → ℝ) (m : ℕ)
+    (hpos : ∀ᶠ l in atTop, 0 < R l)
+    (hratio : Tendsto (fun l => R (l + 1) / R l) atTop (𝓝 1)) :
+    Tendsto (fun l => Real.log (R (l + m)) - Real.log (R l)) atTop (𝓝 0) := by
+  rw [tendsto_congr' (logIncrement_gap_eventuallyEq_log_ratio_gap R m hpos)]
+  have hgap := ratio_gap_tendsto_one R m hpos hratio
+  have hlog : Tendsto Real.log (𝓝 1) (𝓝 (Real.log 1)) :=
+    (Real.continuousAt_log (by norm_num)).tendsto
+  have := hlog.comp hgap
+  simpa using this
+
 end Erdos1014OQ03Log

--- a/src/data/research/problems/erdos-1014-oq-03.json
+++ b/src/data/research/problems/erdos-1014-oq-03.json
@@ -129,8 +129,8 @@
     {
       "path": "Proofs/Erdos1014OQ03LogIncrement.lean",
       "filename": "Erdos1014OQ03LogIncrement.lean",
-      "lineCount": 104,
-      "theoremCount": 4,
+      "lineCount": 138,
+      "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,


### PR DESCRIPTION
## Summary

Completes the **gap-level trio** for the off-diagonal Ramsey increment on the saturated slug `erdos-1014-oq-03`. The parent `Erdos1014OQ03.lean` already proved the bounded-gap versions for two of the three equivalent smoothness measures:

- `ratio_gap_tendsto_one`: `R(l+m)/R(l) → 1` for every fixed gap `m`
- `increment_gap_div_tendsto_zero`: `(R(l+m) − R(l))/R(l) → 0`

but the log-increment companion `Erdos1014OQ03LogIncrement.lean` only carried the **unit-gap** log-flatness. This PR adds the missing **gap-level** log version, closing the parallel:

- `logIncrement_gap_eventuallyEq_log_ratio_gap`: eventually `log R(l+m) − log R(l) = log(R(l+m)/R(l))`
- `logIncrement_gap_tendsto_zero`: under Erdős #1014's ratio convergence `R(l+1)/R(l) → 1`, the gap log-increment `log R(l+m) − log R(l) → 0` for **every fixed gap** `m`.

Applied to `R(k, ·)`, this says Ramsey growth is asymptotically log-flat over *any bounded window* of the second index, not just between neighbours — the honest structural consequence of #1014's ratio-convergence. The full asymptotic for `Δ_l(k)` remains OPEN and is not asserted.

### Proof sketch
The gap-ratio `→ 1` (parent's `ratio_gap_tendsto_one`); eventually the gap log-increment equals `log` of the gap-ratio (positivity + `Real.log_div`); continuity of `log` at `1` sends it to `log 1 = 0`. Mirrors the existing unit-gap proofs in the same file.

## Verification
- **UNVERIFIED**: docker Lean build unavailable this session. Proofs reuse the file's own established idioms (`Real.log_div`, `Real.continuousAt_log`, `tendsto_add_atTop_nat`, `ratio_gap_tendsto_one`) and are by-eye checkable.
- No new axioms, no `sorry`, no `native_decide`.

## Collision avoidance
Open PR #37224 on this slug touches only `Erdos1014OQ03.lean`; this PR touches only the companion `Erdos1014OQ03LogIncrement.lean` (+ json count sync) — no overlap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)