### PR TITLE
research(hilbert-17-oq-03): Motzkin family reflection symmetry + boundary member is PSD-not-positive-definite [UNVERIFIED]

### DIFF
--- a/proofs/Proofs/Hilbert17OQ03OQ05.lean
+++ b/proofs/Proofs/Hilbert17OQ03OQ05.lean
@@ -424,6 +424,26 @@ theorem motzkinFun_antitone_in_coeff {c₁ c₂ : ℝ} (h : c₁ ≤ c₂) (x y 
   unfold motzkinFun
   nlinarith [mul_nonneg (sub_nonneg.mpr h) (mul_nonneg (sq_nonneg x) (sq_nonneg y))]
 
+/-- **Reflection symmetry of the family.** The Motzkin function is invariant under
+    swapping the two variables: `Mₐ(x,y) = Mₐ(y,x)`.  Both the AM–GM core `x⁴y²+x²y⁴+1`
+    and the `−c·x²y²` term are symmetric in `x, y`, so the whole family inherits the
+    diagonal reflection symmetry of the plane — which is why the sharp threshold is
+    detected on the diagonal `x = y` (indeed at `(1,1)`, via `motzkinFun_at_one_one`). -/
+theorem motzkinFun_symm (c x y : ℝ) : motzkinFun c x y = motzkinFun c y x := by
+  unfold motzkinFun; ring
+
+/-- **The boundary member is PSD but not positive definite.** At the sharp threshold
+    `c = 3` the family is non-negative (`motzkin_nonneg`) yet fails *strict* positivity:
+    it cannot be everywhere `> 0`, because it vanishes at `(1,1)`
+    (`motzkinFun_three_zero_at_one_one`).  This is the formal content of "`M₃` sits on the
+    PSD-cone boundary": PSD but with a genuine real zero, hence not in the cone's interior.
+    It is exactly the property that makes `c = 3` extremal rather than interior. -/
+theorem motzkinFun_three_not_posDef : ¬ ∀ x y : ℝ, 0 < motzkinFun 3 x y := by
+  intro h
+  have h11 := h 1 1
+  rw [motzkinFun_three_zero_at_one_one] at h11
+  exact lt_irrefl 0 h11
+
 end Hilbert17OQ03OQ05
 
 -- Axiom audit: should list only propext, Classical.choice, Quot.sound.

--- a/src/data/proofs/hilbert-17-oq-03-oq-05/meta.json
+++ b/src/data/proofs/hilbert-17-oq-03-oq-05/meta.json
@@ -73,14 +73,14 @@
     "additionalFiles": []
   },
   "leanFile": {
-    "lineCount": 430,
+    "lineCount": 450,
     "namespace": "Hilbert17OQ03OQ05",
     "opens": [
       "MvPolynomial"
     ],
     "structureCount": 0,
     "axiomCount": 0,
-    "theoremCount": 28,
+    "theoremCount": 30,
     "substantiveTheoremCount": 9,
     "computationalVerifications": 0,
     "lemmaCount": 0,


### PR DESCRIPTION
## Summary

Two structural gap-fills for the Motzkin family `motzkinFun c x y = x⁴y² + x²y⁴ + 1 − c·x²y²` in `Proofs/Hilbert17OQ03OQ05.lean` (the PSD-not-SOS witness family behind Hilbert's 17th problem). Both formalize facts the file's docstrings describe only in prose.

- **`motzkinFun_symm`** — reflection symmetry `Mₐ(x,y) = Mₐ(y,x)`. Both the AM–GM core and the `−c·x²y²` term are symmetric in the two variables, so the family is invariant under `x ↔ y`; this is why the sharp threshold is detected on the diagonal (at `(1,1)`, cf. `motzkinFun_at_one_one`). Proof: `unfold; ring`.
- **`motzkinFun_three_not_posDef`** — the boundary member `c = 3` is **not** everywhere strictly positive: it vanishes at `(1,1)` (`motzkinFun_three_zero_at_one_one`). Combined with `motzkin_nonneg` (`M₃ ≥ 0`) this is the formal content of the docstring claim that `M₃` sits *on* the PSD-cone boundary — PSD but not positive definite, hence `c = 3` is extremal, not interior. Proof: `intro h; specialize (1,1); rw zero; lt_irrefl`.

## Verification
⚠️ **UNVERIFIED** — not machine-checked. Docker image build fails this session (`containerd ... meta.db: input/output error`). Both proofs are trivial one-liners off existing same-file lemmas.

Meta `leanFile.lineCount` 430→450, `theoremCount` 28→30 (matching the author's field convention).

🤖 Generated with [Claude Code](https://claude.com/claude-code)