### PR TITLE
research(cauchy-interlacing-oq-02-oq-01): per-eigenvalue algebraic multiplicity additivity over a reducing subspace

### DIFF
--- a/proofs/Proofs/CauchyInterlacingPoincareCompression.lean
+++ b/proofs/Proofs/CauchyInterlacingPoincareCompression.lean
@@ -1130,6 +1130,57 @@ theorem roots_charpoly_orthogonal_compress_le_of_reducing {T : V →ₗ[𝕜] V}
   rw [roots_charpoly_eq_add_compress_of_reducing H hH hHp]
   exact Multiset.le_add_left _ _
 
+/-- **Per-eigenvalue algebraic-multiplicity additivity over a reducing subspace.**
+
+The pointwise, single-eigenvalue refinement of the eigenvalue-multiset additivity
+`roots_charpoly_eq_add_compress_of_reducing`: for *each* scalar `μ`, the algebraic
+multiplicity of `μ` as a root of `charpoly T` splits as the sum of its algebraic
+multiplicities over the two reducing blocks,
+
+  `(charpoly T).rootMultiplicity μ
+      = (charpoly (compress T H)).rootMultiplicity μ
+          + (charpoly (compress T Hᗮ)).rootMultiplicity μ`.
+
+This is the *algebraic*-multiplicity companion of the *geometric*-multiplicity
+additivity `finrank_eigenspace_eq_add_of_reducing`
+(`dim (eigenspace T μ) = dim (eigenspace T μ ⊓ H) + dim (eigenspace T μ ⊓ Hᗮ)`); for a
+symmetric `T` the two coincide, but the algebraic statement needs no symmetry.  Proof:
+apply the master factorisation `charpoly_eq_mul_compress_of_reducing` and read off
+`Polynomial.rootMultiplicity_mul` (valid since `charpoly T`, monic, is nonzero).  Unlike
+the `Multiset.count` form this uses `rootMultiplicity`, so it needs no `DecidableEq 𝕜`.
+Symmetry-free. -/
+theorem rootMultiplicity_charpoly_eq_add_compress_of_reducing {T : V →ₗ[𝕜] V}
+    (H : Submodule 𝕜 V) (hH : ∀ y ∈ H, T y ∈ H) (hHp : ∀ y ∈ Hᗮ, T y ∈ Hᗮ) (μ : 𝕜) :
+    (LinearMap.charpoly T).rootMultiplicity μ =
+      (LinearMap.charpoly (compress T H)).rootMultiplicity μ
+        + (LinearMap.charpoly (compress T Hᗮ)).rootMultiplicity μ := by
+  rw [charpoly_eq_mul_compress_of_reducing H hH hHp]
+  refine Polynomial.rootMultiplicity_mul ?_
+  rw [← charpoly_eq_mul_compress_of_reducing H hH hHp]
+  exact (LinearMap.charpoly_monic T).ne_zero
+
+/-- The `H`-block algebraic-multiplicity bound: for every eigenvalue `μ`, its algebraic
+multiplicity in the `H`-compression is at most its algebraic multiplicity in the ambient
+`T`.  The single-eigenvalue shadow of the sub-multiset containment
+`roots_charpoly_compress_le_of_reducing`, read off the additivity
+`rootMultiplicity_charpoly_eq_add_compress_of_reducing` via `Nat.le_add_right`. -/
+theorem rootMultiplicity_charpoly_compress_le_of_reducing {T : V →ₗ[𝕜] V}
+    (H : Submodule 𝕜 V) (hH : ∀ y ∈ H, T y ∈ H) (hHp : ∀ y ∈ Hᗮ, T y ∈ Hᗮ) (μ : 𝕜) :
+    (LinearMap.charpoly (compress T H)).rootMultiplicity μ ≤
+      (LinearMap.charpoly T).rootMultiplicity μ := by
+  rw [rootMultiplicity_charpoly_eq_add_compress_of_reducing H hH hHp]
+  exact Nat.le_add_right _ _
+
+/-- The `Hᗮ`-block companion of `rootMultiplicity_charpoly_compress_le_of_reducing`:
+each eigenvalue's algebraic multiplicity in the orthogonal compression is bounded by its
+algebraic multiplicity in the ambient `T`, via `Nat.le_add_left`. -/
+theorem rootMultiplicity_charpoly_orthogonal_compress_le_of_reducing {T : V →ₗ[𝕜] V}
+    (H : Submodule 𝕜 V) (hH : ∀ y ∈ H, T y ∈ H) (hHp : ∀ y ∈ Hᗮ, T y ∈ Hᗮ) (μ : 𝕜) :
+    (LinearMap.charpoly (compress T Hᗮ)).rootMultiplicity μ ≤
+      (LinearMap.charpoly T).rootMultiplicity μ := by
+  rw [rootMultiplicity_charpoly_eq_add_compress_of_reducing H hH hHp]
+  exact Nat.le_add_left _ _
+
 /-! ### Upgrading eigenvalue-count additivity to a genuine `finrank` identity
 
 The multiset additivity `card_roots_charpoly_eq_add_compress_of_reducing` is

--- a/src/data/proofs/cauchy-interlacing-theorem-oq-01-oq-02/meta.json
+++ b/src/data/proofs/cauchy-interlacing-theorem-oq-01-oq-02/meta.json
@@ -12,7 +12,7 @@
     "sorries": 0,
     "dateAdded": "2026-06-23",
     "mathlib_version": "4.26.0",
-    "lineCount": 1524,
+    "lineCount": 1575,
     "theoremCount": 40,
     "definitionCount": 0,
     "difficulty": "advanced",
@@ -62,7 +62,7 @@
       "CauchyInterlacing.Poincare"
     ],
     "namespace": "CauchyInterlacing.PoincareCompression",
-    "lineCount": 1524,
+    "lineCount": 1575,
     "axiomCount": 0,
     "theoremCount": 40,
     "definitionCount": 0,


### PR DESCRIPTION
## Summary

Adds the **algebraic-multiplicity** refinement of the block-diagonal eigenvalue decomposition to `CauchyInterlacingPoincareCompression.lean`, complementing the existing geometric-multiplicity additivity.

For each scalar `μ`, the algebraic multiplicity of `μ` as a root of `charpoly T` splits across the two reducing blocks:

```
(charpoly T).rootMultiplicity μ
  = (charpoly (compress T H)).rootMultiplicity μ
      + (charpoly (compress T Hᗮ)).rootMultiplicity μ
```

## New theorems (3)

- `rootMultiplicity_charpoly_eq_add_compress_of_reducing` — per-eigenvalue algebraic multiplicity additivity.
- `rootMultiplicity_charpoly_compress_le_of_reducing` — `H`-block multiplicity ≤ ambient.
- `rootMultiplicity_charpoly_orthogonal_compress_le_of_reducing` — `Hᗮ`-block multiplicity ≤ ambient.

## Context

The file already carries:
- **geometric** multiplicity additivity `finrank_eigenspace_eq_add_of_reducing` (`dim eigenspace T μ = dim(·⊓H) + dim(·⊓Hᗮ)`), and
- eigenvalue-**multiset** additivity `roots_charpoly_eq_add_compress_of_reducing`.

Missing was the per-eigenvalue *algebraic* multiplicity statement. For a symmetric `T` algebraic and geometric multiplicities coincide, but the `rootMultiplicity` form here is **symmetry-free**.

## Proof

Mirrors the verified `roots_charpoly_eq_add_compress_of_reducing`: apply the master factorization `charpoly_eq_mul_compress_of_reducing` then `Polynomial.rootMultiplicity_mul` (valid since `charpoly T` is monic, hence nonzero). The two block bounds read off via `Nat.le_add_{right,left}`. Uses `rootMultiplicity` (not `Multiset.count`), so no `DecidableEq 𝕜` is needed.

## Verification

- 0 sorry / 0 new axioms.
- ⚠️ **UNVERIFIED**: Docker build infrastructure is currently down (containerd `meta.db` input/output error), so `docker-build.sh` could not run. Proofs are one-to-one analogues of already-verified declarations in the same file.
- `Polynomial.rootMultiplicity_mul` confirmed present in the pinned Mathlib (`Mathlib/Algebra/Polynomial/RingDivision.lean:244`).
- Synced meta `lineCount` 1524 → 1575.

🤖 Generated with [Claude Code](https://claude.com/claude-code)