### PR TITLE
research(erdos-771): exact maxAvoidingSize n m = n for m > n² [UNVERIFIED]

### DIFF
--- a/proofs/Proofs/Erdos771Problem.lean
+++ b/proofs/Proofs/Erdos771Problem.lean
@@ -192,6 +192,26 @@ theorem maxAvoidingSize_ge_iff (n m k : ℕ) :
       rw [Finset.mem_filter, Finset.mem_powerset] at hSmem
       exact ⟨S, hSmem.1, hScard, hSmem.2⟩
 
+/-- **The full box is a large-target witness.** For `m > n²` the whole set
+`{1,…,n}` avoids `m` (`avoid_full`) and has size `n`, so the maximum avoiding
+size is at least `n`: `n ≤ maxAvoidingSize n m`. Packaged from `avoid_full` via
+the bridge `maxAvoidingSize_ge_iff`. -/
+theorem le_maxAvoidingSize_of_lt (n m : ℕ) (h : n * n < m) :
+    n ≤ maxAvoidingSize n m :=
+  (maxAvoidingSize_ge_iff n m n).mp
+    ⟨Icc_n n, Finset.Subset.refl _, by rw [Icc_n, Nat.card_Icc]; omega,
+      avoid_full n m h⟩
+
+/-- **Exact value for large targets.** Once `m > n²` no subset sum of `{1,…,n}`
+can reach `m` (`avoid_full`), so the maximum avoiding size attains its ceiling:
+`maxAvoidingSize n m = n`. Combines the universal upper bound
+`maxAvoidingSize_le` with the full-box lower bound `le_maxAvoidingSize_of_lt`.
+This pins down `maxAvoidingSize` completely in the large-`m` regime and is the
+fact behind the `m > n²` branch of `f_characterization`. -/
+theorem maxAvoidingSize_eq_of_lt (n m : ℕ) (h : n * n < m) :
+    maxAvoidingSize n m = n :=
+  le_antisymm (maxAvoidingSize_le n m) (le_maxAvoidingSize_of_lt n m h)
+
 /-- f(n) is the largest k satisfying f_property. -/
 theorem f_characterization (n : ℕ) (hn : n ≥ 1) :
     f_property n (f n) ∧ ∀ k > f n, ¬f_property n k := by

--- a/src/data/proofs/erdos-771/meta.json
+++ b/src/data/proofs/erdos-771/meta.json
@@ -79,9 +79,9 @@
       "erdos_771, erdos_771_main, erdos_771_solved: main theorem statements"
     ],
     "axiomCount": 2,
-    "lineCount": 555,
+    "lineCount": 575,
     "assumptions": "2 axioms: erdos_graham_lower_bound, alon_freiman_upper_bound. 0 sorries.",
-    "theoremCount": 21,
+    "theoremCount": 23,
     "definitionCount": 16,
     "additionalFiles": [
       "Proofs/Erdos771Aristotle.lean",
@@ -214,9 +214,9 @@
       "Nat"
     ],
     "namespace": "Erdos771",
-    "lineCount": 555,
+    "lineCount": 575,
     "axiomCount": 2,
-    "theoremCount": 21,
+    "theoremCount": 23,
     "definitionCount": 16,
     "sorries": 0,
     "path": "Proofs/Erdos771Problem.lean",


### PR DESCRIPTION
## Summary

The Erdős #771 file (subsets avoiding a given sum) already proves two halves of the large-target behaviour of `maxAvoidingSize` — `avoid_full` (for `m > n²` the whole box `{1,…,n}` avoids `m`) and `maxAvoidingSize_le` (`maxAvoidingSize n m ≤ n`) — and even reassembles the `n ≤ maxAvoidingSize n m` argument *inline* inside `f_characterization`. It never states the resulting exact value as a reusable theorem. This PR extracts it:

- `le_maxAvoidingSize_of_lt` : `n * n < m → n ≤ maxAvoidingSize n m` — the full box is an `m`-avoiding witness of size `n`, packaged from `avoid_full` through the bridge `maxAvoidingSize_ge_iff`.
- `maxAvoidingSize_eq_of_lt` : `n * n < m → maxAvoidingSize n m = n` — `le_antisymm` of `maxAvoidingSize_le` and the new lower bound.

This pins down `maxAvoidingSize` completely in the large-`m` regime (the regime where every subset sum `≤ n²` falls short of `m`), factoring out the reasoning currently duplicated in `f_characterization`'s `m > n²` branch. No new axioms or imports; both proofs are short compositions of already-verified lemmas.

## Meta

- `lineCount` 555 → 575, `theoremCount` 21 → 23 (both copies). The file's 2 literature axioms (Erdős–Graham, Alon–Freiman) are untouched.

## Collision avoidance

No open PR touches `erdos-771`. The edit is confined to the primary `Erdos771Problem.lean` and the `erdos-771` meta — the sibling `erdos-771-construction` slug (`Erdos771Construction.lean`) is untouched.

## Verification

⚠️ **UNVERIFIED** — docker build unavailable this session (containerd `meta.db` input/output error). Both theorems are one-line compositions of `maxAvoidingSize_ge_iff`, `avoid_full`, `maxAvoidingSize_le`, and `le_antisymm`; high confidence, but not machine-checked here.