### PR TITLE
research(erdos-1022-oq-02): monotonicity of the admissible sparseness coefficient

### DIFF
--- a/proofs/Proofs/Erdos1022OQ02.lean
+++ b/proofs/Proofs/Erdos1022OQ02.lean
@@ -595,4 +595,38 @@ theorem admissibleCoeff_ge_two_pow_sub (hV : 0 < Fintype.card V) (t : ℕ)
   have hk := admissibleCoeff_ge_two_pow_of_card hV (t - Fintype.card V - 1)
   rwa [show Fintype.card V + 1 + (t - Fintype.card V - 1) = t from by omega] at hk
 
+-- ══════════════════════════════════════════════════════════════════
+-- § 8: Monotonicity of the admissible coefficient in `t`
+-- ══════════════════════════════════════════════════════════════════
+
+/-
+  §§ 5-7 pin the *rate* of growth (doubling per step, exponential brackets).
+  What underlies all of that — and is worth recording on its own, since OQ-02
+  asks about the growth *rate* of `c_t` — is the bare qualitative fact that the
+  coefficient never decreases as the minimum set size `t` grows.  Both the
+  threshold `2^{t-1}` and its truncated quotient `⌊2^{t-1}/|V|⌋` are monotone
+  in `t`, unconditionally (no positivity or ground-set hypothesis needed): a
+  larger `t` admits a sparseness coefficient at least as large.  This is the
+  monotone envelope the quantitative doubling bound `admissibleCoeff_ge_two_mul`
+  refines.
+-/
+
+/-- **The first-moment threshold is monotone in `t`.**  `2^{a-1} ≤ 2^{b-1}`
+    whenever `a ≤ b`; the exponential threshold never decreases as the minimum
+    set size grows. -/
+theorem firstMomentThreshold_mono {a b : ℕ} (hab : a ≤ b) :
+    firstMomentThreshold a ≤ firstMomentThreshold b := by
+  unfold firstMomentThreshold
+  exact Nat.pow_le_pow_right (by norm_num) (Nat.sub_le_sub_right hab 1)
+
+/-- **The admissible coefficient is monotone in `t`.**  For a fixed ground set,
+    `c(a) = ⌊2^{a-1}/|V|⌋ ≤ ⌊2^{b-1}/|V|⌋ = c(b)` whenever `a ≤ b`: truncated
+    division by the fixed divisor `|V|` preserves the monotonicity of the
+    threshold.  This is the unconditional monotone backbone of the quantitative
+    growth bounds in §§ 5-7 — no positivity or `1 ≤ a` hypothesis is required. -/
+theorem admissibleCoeff_mono {a b : ℕ} (hab : a ≤ b) :
+    firstMomentThreshold a / Fintype.card V
+      ≤ firstMomentThreshold b / Fintype.card V :=
+  Nat.div_le_div_right (firstMomentThreshold_mono hab)
+
 end Erdos1022OQ02

--- a/src/data/proofs/erdos-1022-oq-02/meta.json
+++ b/src/data/proofs/erdos-1022-oq-02/meta.json
@@ -25,7 +25,7 @@
     "mathlib_version": "4.26.0",
     "axiomCount": 0,
     "assumptions": "No axioms and no sorries: all theorems are fully machine-checked from Mathlib (depends only on propext / Classical.choice / Quot.sound). This is a partial result addressing the first-moment regime of OQ-02; the open conjecture of Erdős #1022 (whether c_t → ∞ for arbitrarily large ground sets) is NOT resolved here.",
-    "lineCount": 598,
+    "lineCount": 632,
     "relatedProblems": [
       {
         "id": "erdos-1022",
@@ -40,7 +40,7 @@
         "relationship": "Builds on: Erdős 1963 uniform first-moment theorem (reuses Mono, card_mono, exists_zero_of_sum_lt_card)"
       }
     ],
-    "theoremCount": 23,
+    "theoremCount": 25,
     "definitionCount": 3
   },
   "overview": {
@@ -129,10 +129,10 @@
     }
   ],
   "leanFile": {
-    "lineCount": 598,
+    "lineCount": 632,
     "structureCount": 0,
     "axiomCount": 0,
-    "theoremCount": 23,
+    "theoremCount": 25,
     "lemmaCount": 0,
     "imports": [
       "Mathlib",


### PR DESCRIPTION
## Summary

OQ-02 of Erdős #1022 asks for the **growth rate** of the sparseness threshold `c_t`. `Erdos1022OQ02.lean` already pins the rate quantitatively (per-step doubling, exponential brackets, divergence) but never records the bare qualitative backbone: that the admissible coefficient is **nondecreasing in `t`**. This adds that monotone envelope (new § 8):

- `firstMomentThreshold_mono` — `a ≤ b ⟹ 2^{a-1} ≤ 2^{b-1}`.
- `admissibleCoeff_mono` — `a ≤ b ⟹ ⌊2^{a-1}/|V|⌋ ≤ ⌊2^{b-1}/|V|⌋`.

Both are **unconditional** (no positivity or `1 ≤ a` hypothesis) — the monotone statement the quantitative doubling bound `admissibleCoeff_ge_two_mul` refines.

## Proofs

- `firstMomentThreshold_mono`: `Nat.pow_le_pow_right` + `Nat.sub_le_sub_right`.
- `admissibleCoeff_mono`: `Nat.div_le_div_right` applied to threshold monotonicity.

Built entirely on existing verified defs; no new axioms or assumptions.

## Verification

⚠️ **UNVERIFIED** — Docker build unavailable this session (containerd `meta.db` I/O error). Proof checked by inspection; all three `Nat` lemmas are confirmed by identical usage in the pin/repo (`BallotProblemOQ03OQ02.lean`, `CombinationsFormulaOQ07OQ01.lean`, `AbundantNumberOQ02OQ01SevenPrimeExponents.lean`).

Gallery meta synced: lineCount 598→632, theoremCount 23→25.

🤖 Generated with [Claude Code](https://claude.com/claude-code)