### PR TITLE
research(erdos-1-oq-02-oq-01): geomSet counting-bound tightness + superincreasing 0∉A [UNVERIFIED]

### DIFF
--- a/proofs/Proofs/Erdos1OQ02OQ01.lean
+++ b/proofs/Proofs/Erdos1OQ02OQ01.lean
@@ -179,6 +179,16 @@ theorem sum_geomSet (n : ℕ) : (geomSet n).sum id = 2 ^ n - 1 := by
   have := geomSum_two_succ n
   omega
 
+/-- The geometric set makes the Section 2 counting bound `two_pow_card_le_sum_succ`
+    (`2^{|A|} ≤ Σ A + 1`) an **equality** for every `n`: with `|A| = n` and
+    `Σ A = 2ⁿ − 1`, we get `2^{|A|} = 2ⁿ = Σ A + 1`. This is the explicit witness
+    that the counting lower bound cannot be improved as stated. -/
+theorem two_pow_card_geomSet_eq_sum_succ (n : ℕ) :
+    2 ^ (geomSet n).card = (geomSet n).sum id + 1 := by
+  rw [card_geomSet, sum_geomSet]
+  have h : 1 ≤ 2 ^ n := Nat.one_le_pow n 2 (by norm_num)
+  omega
+
 /-- The largest element of the geometric set is `2^{n-1}` (for `n ≥ 1`). -/
 theorem max'_geomSet {n : ℕ} (hn : 1 ≤ n) (hne : (geomSet n).Nonempty) :
     (geomSet n).max' hne = 2 ^ (n - 1) := by
@@ -239,6 +249,13 @@ theorem Superincreasing.erase {A : Finset ℕ} (h : Superincreasing A) (m : ℕ)
   have hsub : (A.erase m).filter (· < a) ⊆ A.filter (· < a) :=
     filter_subset_filter _ (erase_subset _ _)
   exact lt_of_le_of_lt (sum_le_sum_of_subset hsub) (h a haA)
+
+/-- A superincreasing set cannot contain `0` (the structural analogue of
+    `zero_not_mem` for distinct-subset-sums sets): applying the superincreasing
+    inequality at `a = 0` would give `(A.filter (· < 0)).sum id < 0`, impossible
+    in `ℕ`. -/
+theorem Superincreasing.zero_not_mem {A : Finset ℕ} (h : Superincreasing A) :
+    0 ∉ A := fun h0 => absurd (h 0 h0) (Nat.not_lt_zero _)
 
 /-- **Superincreasing ⟹ distinct subset sums.** The key structural principle: because
     each element dominates the sum of everything below it, a subset is determined by

--- a/src/data/proofs/erdos-1-oq-02-oq-01/meta.json
+++ b/src/data/proofs/erdos-1-oq-02-oq-01/meta.json
@@ -11,10 +11,10 @@
       "Finset"
     ],
     "namespace": "Erdos1OQ02OQ01",
-    "lineCount": 329,
+    "lineCount": 346,
     "axiomCount": 0,
-    "theoremCount": 18,
-    "substantiveTheoremCount": 14,
+    "theoremCount": 20,
+    "substantiveTheoremCount": 16,
     "definitionCount": 3,
     "path": "Proofs/Erdos1OQ02OQ01.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

Two clean gap-fill theorems on the **saturated, 0-axiom** elementary distinct-subset-sums entry `erdos-1-oq-02-oq-01` (`Proofs/Erdos1OQ02OQ01.lean`). Both fill genuine gaps left by the existing docstrings/structure.

### `two_pow_card_geomSet_eq_sum_succ`
The powers-of-two set `{2⁰,…,2^{n-1}}` attains **equality** `2^{|A|} = ΣA + 1` in the Section-2 counting bound `two_pow_card_le_sum_succ`. The Section-4 docstrings repeatedly claim the geomSet "attains equality in the counting bound", but no theorem stated it directly — the file only had the arithmetic identity `geomSum_two_succ` and `sum_geomSet` (ΣA = 2ⁿ−1). This combines `card_geomSet` + `sum_geomSet` into the explicit tightness witness proving the elementary lower bound cannot be improved as stated.

### `Superincreasing.zero_not_mem`
A superincreasing set cannot contain `0` — the structural analogue of the existing `zero_not_mem` (distinct-subset-sums ⟹ 0∉A). Section 5 introduced the `Superincreasing` predicate but lacked this basic membership fact; it follows in one line since the superincreasing inequality at `a=0` would assert `… < 0` in ℕ.

## Proofs
- `two_pow_card_geomSet_eq_sum_succ`: `rw [card_geomSet, sum_geomSet]` then `omega` with `1 ≤ 2^n` (`Nat.one_le_pow`).
- `Superincreasing.zero_not_mem`: term-mode `absurd (h 0 h0) (Nat.not_lt_zero _)`.

No new axioms, no sorries. Reuses only existing file lemmas + standard Mathlib.

## Meta
`Erdos1OQ02OQ01.lean` leanFile: lineCount 329→346, theoremCount 18→20, substantiveTheoremCount 14→16. Entry stays `verified` / 0-axiom.

## Verification
⚠️ **UNVERIFIED** — the Docker build environment was unavailable this session. Both proofs are short and checked by inspection against the surrounding file idioms; no collisions (no open PR touches this file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)