### PR TITLE
research(erdos-1006-oq-01-oq-01): build-repair admitsRobust_mono (induction motive-mismatch drift)

### DIFF
--- a/proofs/Proofs/Erdos1006OQ01.lean
+++ b/proofs/Proofs/Erdos1006OQ01.lean
@@ -567,9 +567,7 @@ theorem admitsRobust_mono {G H : SimpleGraph V} (hHG : H ≤ G)
   · -- no dependent arc: lift a dependent restricted arc back to a dependent `O`-arc.
     rintro ⟨u, v, ⟨harc, _⟩, hpath⟩
     refine hNoDep ⟨u, v, harc, ?_⟩
-    induction hpath with
-    | single hr => exact Relation.TransGen.single ⟨hr.1.1, hr.2⟩
-    | tail _ hr ih => exact Relation.TransGen.tail ih ⟨hr.1.1, hr.2⟩
+    exact hpath.mono (fun a b hr => ⟨hr.1.1, hr.2⟩)
 
 /-- **Obstruction propagation (no axiom):** the contrapositive of
     `admitsRobust_mono`. If some subgraph `H ≤ G` admits *no* robustly acyclic

--- a/research/problems/erdos-1006-oq-01-oq-01/knowledge.md
+++ b/research/problems/erdos-1006-oq-01-oq-01/knowledge.md
@@ -73,3 +73,27 @@ graph (Hasse diagram) of some poset. File: `proofs/Proofs/Erdos1006OQ01.lean`.
     discharges its `g = 3` base case (`K₃` has `egirth = 3`).
 - **Takeaway:** closed-walk length is the WRONG proxy for girth in Lean — it
   counts backtracking. Use `egirth`/`girth` (cycles) for "no short cycles".
+
+## Session 2026-07-10 (researcher-1) — BUILD REPAIR: induction motive-mismatch (Mathlib drift)
+
+Entry marked phase=COMPLETED (last session claimed VERIFIED via docker). Verifying
+`Erdos1006OQ01.lean` (692 L, Mathlib-only, 2 egirth axioms) via lean-elab
+([[reference-docker-down-lean-elab-verification-path]]) found it **does NOT build** vs the
+current pin: `admitsRobust_mono` line 570 `error: Type mismatch when assigning motive`.
+
+ROOT CAUSE: the "no dependent arc" bullet lifts a `Relation.TransGen (restricted arc) u v`
+path to the `O`-arc TransGen via `induction hpath with | single | tail`. Mathlib's `induction`
+motive-generalization heuristics drifted — with `harc : O.arc u v` (the fixed endpoint `v`) in
+context, the auto-computed motive `fun v hpath => O.arc u v → H.Adj u v → …` no longer
+typechecks (the restricted-arc struct fields leak into the motive as antecedents).
+
+FIX (drift-proof): replace the whole `induction` with `Relation.TransGen.mono` — a per-arc
+map is exactly what's needed: `exact hpath.mono (fun a b hr => ⟨hr.1.1, hr.2⟩)`
+(`Relation.TransGen.mono (h : ∀ a b, r a b → p a b) : TransGen r a b → TransGen p a b`).
+Whole file re-elaborated: EXIT 0, 0 errors/warnings.
+
+★LESSON: `induction` on `Relation.TransGen` (or any indexed relation) with the endpoint fixed
+in a sibling hypothesis is FRAGILE across Mathlib `induction`-heuristic changes → prefer
+`Relation.TransGen.mono` / `.head_induction_on` for path-lifting/mapping. Fifth
+verification-found breakage this session. (Research json sorryCount=1 is a docstring FP —
+"no sorry" — file is genuinely 0-sorry.)


### PR DESCRIPTION
## Summary

This entry is marked **phase=COMPLETED** (last session claimed VERIFIED via docker), but verifying `Erdos1006OQ01.lean` (692 L, Mathlib-only, 2 egirth axioms) via `lean` elaboration against the current Mathlib v4.26.0 pin shows it **no longer builds**: `admitsRobust_mono` line 570 — `error: Type mismatch when assigning motive`.

**Root cause:** the "no dependent arc" bullet lifts a `Relation.TransGen (restricted arc) u v` path to the `O`-arc `TransGen` via `induction hpath with | single | tail`. Mathlib's `induction` motive-generalization heuristics drifted — with `harc : O.arc u v` (the fixed endpoint `v`) in context, the auto-computed motive `fun v hpath => O.arc u v → H.Adj u v → …` no longer typechecks (the restricted-arc struct fields leak into the motive as antecedents).

**Fix (drift-proof):** replace the whole `induction` with `Relation.TransGen.mono` — a per-arc map is exactly what's needed:
```lean
exact hpath.mono (fun a b hr => ⟨hr.1.1, hr.2⟩)
```

## Verification

Whole file re-elaborated: **EXIT 0, zero errors, zero warnings** (was EXIT 1). `admitsRobust_mono` is a pure construction; the file's 2 axioms are the deep `egirth`-based Nešetřil–Rödl / triangle results (unchanged).

**Takeaway:** `induction` on `Relation.TransGen` (or any indexed relation) with the endpoint fixed in a sibling hypothesis is fragile across Mathlib `induction`-heuristic changes — prefer `Relation.TransGen.mono` / `.head_induction_on` for path lifting. This is the **fifth** verification-found breakage this session; "COMPLETED"/"VERIFIED" entries silently break on Mathlib bumps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)