### PR TITLE
research(erdos-1204): explicit A(k) sandwich + divergence A(k)→∞

### DIFF
--- a/proofs/Proofs/Erdos1204Problem.lean
+++ b/proofs/Proofs/Erdos1204Problem.lean
@@ -601,4 +601,32 @@ theorem A_le_primorial (k : ℕ) : A k ≤ (k - 1) * primorialUpTo k := by
     exact mul_le_mul_right' (by omega) N
   exact le_trans (A_le hcard hadm) hsup
 
+/- ## The two-sided sandwich and the divergence of `A(k)`
+
+The lower bound `two_mul_sub_one_le_A` and the upper bound `A_le_primorial`
+promised (in prose) to *sandwich* `A(k)`; we record that sandwich as a single
+statement, and read off its qualitative consequence: `A(k) → ∞`.  While the
+sharp rate `A(k) ∼ k log k` is open, the fact that the extremal quantity is
+*unbounded* is already forced by the prime-`2` lower bound alone. -/
+
+/-- **Two-sided sandwich for `A(k)`.**  Packaging the prime-`2` lower bound
+`two_mul_sub_one_le_A` with the primorial upper bound `A_le_primorial`:
+`2(k-1) ≤ A(k) ≤ (k-1)·∏_{p ≤ k} p`.  This is the explicit bracket promised in
+the file header; the conjectured truth `A(k) ∼ k log k` lies strictly inside
+it. -/
+theorem A_sandwich (k : ℕ) :
+    2 * (k - 1) ≤ A k ∧ A k ≤ (k - 1) * primorialUpTo k :=
+  ⟨two_mul_sub_one_le_A k, A_le_primorial k⟩
+
+/-- **`A(k)` diverges.**  The minimal-largest-element function tends to infinity:
+`A(k) → ∞` as `k → ∞`.  This is immediate from the trivial packing bound
+`k - 1 ≤ A(k)` (`sub_one_le_A`), and is the unconditional qualitative core of
+the growth-rate question of Problem #1204 — no admissible `k`-tuple can be kept
+in a bounded window once `k` is large. -/
+theorem A_tendsto_atTop : Filter.Tendsto A Filter.atTop Filter.atTop := by
+  have hsub : Filter.Tendsto (fun k : ℕ => k - 1) Filter.atTop Filter.atTop := by
+    rw [Filter.tendsto_atTop_atTop]
+    exact fun b => ⟨b + 1, fun k hk => by omega⟩
+  exact Filter.tendsto_atTop_mono (f := fun k : ℕ => k - 1) sub_one_le_A hsub
+
 end Erdos1204

--- a/src/data/proofs/erdos-1204/meta.json
+++ b/src/data/proofs/erdos-1204/meta.json
@@ -70,9 +70,9 @@
       "S(2)=2 and S(3)=8 exact, giving the first exact averages B(2)=1 and B(3)=8/3. B(2)=1 attains the parity floor k-1=1 (the general bound is tight); B(3)=8/3 > 2 is the first place the mod-3 obstruction — the same one that makes A(3)=6 — forces the average strictly above the floor. The S(3) >= 8 lower bound combines the A(3) fact sup >= 6 (admissible_three_sup_ge) with admissible_sum_ge on the erased admissible 2-set: 6+2=8 (Proofs/Erdos1204B.lean)"
     ],
     "axiomCount": 0,
-    "lineCount": 604,
+    "lineCount": 632,
     "assumptions": "0 axiom declarations and 0 sorries; every stated lemma is fully proved. Proofs use only kernel `decide` (no `native_decide`) and `Nat.sInf`; #print axioms (incl. admissible_same_parity, admissible_diam_ge, two_mul_sub_one_le_A) shows only propext/Classical.choice/Quot.sound — no Lean.ofReduceBool, no sorryAx. Status is 'axiomatized' because the headline asymptotic questions of Problem #1204 — whether A(k) ∼ k log k and the estimate for B(k) — remain OPEN and are documented but not formalized as theorems. Formalized here: the admissibility framework, the reduction to small primes, existence/well-definedness of A(k), the parity-sharpened two-sided bounds 2(k-1) ≤ A(k) ≤ (k-1)·primorial (doubling the trivial k-1 lower bound for all k), and the exact values A(0)=A(1)=0, A(2)=2, A(3)=6, A(4)=8, A(5)=12, A(6)=16, A(7)=20 (the last four in companion files Erdos1204A4.lean, Erdos1204A5.lean, Erdos1204A6.lean and Erdos1204A7.lean, each verified and axiom-free; A(6)=16 is the first exact value whose lower bound needs three primes 2,3,5, and A(7)=20 shows the prime 7 is not yet binding — two forced 7-sets per parity are all killed at p=5). The companion Erdos1204B.lean (B(k) theory: S/B definitions, the bound k(k-1) <= S(k), and exact S(2)=2/S(3)=8, B(2)=1/B(3)=8/3) is likewise 0 axioms / 0 sorries, kernel decide only (no native_decide), depending only on propext/Classical.choice/Quot.sound.",
-    "theoremCount": 32,
+    "theoremCount": 34,
     "definitionCount": 3,
     "summary": " A companion file (Erdos1204B.lean) now also introduces the SECOND extremal quantity B(k)=min(a1+...+ak)/k (the minimal average, carried by the minimal sum S(k)), previously untouched: it is defined as an attained infimum, satisfies the parity lower bound B(k) >= k-1 (average analogue of A(k) >= 2(k-1)), with first exact values B(2)=1 (tight) and B(3)=8/3 (mod-3 forces the average above the floor). The asymptotics of B(k) remain OPEN."
   },
@@ -223,9 +223,9 @@
       "Finset"
     ],
     "namespace": "Erdos1204",
-    "lineCount": 604,
+    "lineCount": 632,
     "axiomCount": 0,
-    "theoremCount": 32,
+    "theoremCount": 34,
     "definitionCount": 3,
     "path": "Proofs/Erdos1204Problem.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

Erdős #1204 concerns the extremal quantity `A(k) = min aₖ` over admissible `k`-element sequences and asks for its growth rate (`A(k) ∼ k log k`?). `Erdos1204Problem.lean` establishes the lower bound `2(k-1) ≤ A(k)` and the upper bound `A(k) ≤ (k-1)·∏_{p≤k} p`, and its header states these *sandwich* `A(k)` — but the sandwich is never recorded as a theorem, and the file has no divergence statement. This adds both:

- `A_sandwich` — `2(k-1) ≤ A(k) ≤ (k-1)·∏_{p≤k} p`, packaging `two_mul_sub_one_le_A` and `A_le_primorial`.
- `A_tendsto_atTop` — **`A(k) → ∞`** as `k → ∞`, from the trivial packing bound `sub_one_le_A` (`k-1 ≤ A k`) via `Filter.tendsto_atTop_mono`.

`A_tendsto_atTop` is the unconditional qualitative core of the growth-rate question: even without the sharp asymptotic (open), the extremal quantity is provably unbounded — no admissible `k`-tuple stays in a fixed window as `k → ∞`.

## Proofs

Both are short corollaries of existing verified lemmas; no new axioms or assumptions.

## Verification

⚠️ **UNVERIFIED** — Docker build unavailable this session (containerd `meta.db` I/O error). Proof checked by inspection; `Filter.tendsto_atTop_mono` signature and identical usage confirmed in `Erdos138Problem.lean:801`.

Gallery meta synced: lineCount 604→632, theoremCount 32→34.

🤖 Generated with [Claude Code](https://claude.com/claude-code)