### PR TITLE
research(roth-theorem-oq-01): weighted universal-bound + Erdős contrapositive API, and repair OQ-01 tower (VERIFIED)

### DIFF
--- a/proofs/Proofs/RothTheoremOQ01Weighted.lean
+++ b/proofs/Proofs/RothTheoremOQ01Weighted.lean
@@ -293,8 +293,52 @@ theorem threeAPFree_tsum_log_weighted_reciprocal_le
     exact hA0 (by rw [← hi]; exact i.property)
   exact weighted_finite_sum_le hs0 hs T hTAP hT0
 
+/-- The absolute log-weighted reciprocal-sum constant `weightedRecipBound s` is strictly
+positive for every admissible weight exponent `s < blasiConst` — its `k = 0` term already is.
+The weighted analogue of `RothTheoremOQ01Reciprocal.recipBound_pos`. -/
+theorem weightedRecipBound_pos (hs : s < RothTheoremOQ02.blasiConst) :
+    0 < weightedRecipBound s := by
+  unfold weightedRecipBound
+  have h0 : 0 < weightedMajorant s 0 := by
+    unfold weightedMajorant
+    exact div_pos (by norm_num) (weightedMajorant_denom_pos 0)
+  exact (summable_weightedMajorant hs).tsum_pos weightedMajorant_nonneg 0 h0
+
+/-- **Universal log-weighted reciprocal-sum bound (packaged form).**  For every admissible
+weight exponent `0 ≤ s < blasiConst` there is a single *absolute* constant `B > 0` —
+independent of the set — such that every 3-AP-free `A ⊆ ℕ` with `0 ∉ A` satisfies
+`∑'_{a ∈ A} (log a)^s / a ≤ B`.  The weighted analogue of
+`RothTheoremOQ01Reciprocal.exists_universal_recip_bound`: one common constant simultaneously
+bounds the log-weighted reciprocal sums of all 3-AP-free sets at once.  Rests on the single
+imported Bloom–Sisask assumption; introduces **no new axiom**. -/
+theorem exists_universal_log_weighted_recip_bound
+    (hs0 : 0 ≤ s) (hs : s < RothTheoremOQ02.blasiConst) :
+    ∃ B : ℝ, 0 < B ∧ ∀ (A : Set ℕ), ThreeAPFree A → 0 ∉ A →
+      ∑' a : A, (Real.log (a : ℝ)) ^ s / (a : ℝ) ≤ B :=
+  ⟨weightedRecipBound s, weightedRecipBound_pos hs,
+    fun _A hA hA0 => threeAPFree_tsum_log_weighted_reciprocal_le hs0 hs hA hA0⟩
+
+/-- **Log-weighted Erdős `k = 3` conjecture, contrapositive form.**  For every admissible
+weight exponent `0 ≤ s < blasiConst`, any set `A ⊆ ℕ` (with `0 ∉ A`) whose *log-weighted*
+reciprocal sum `∑_{a ∈ A} (log a)^s / a` diverges is not 3-AP-free.  This is the direct
+contrapositive of `threeAPFree_summable_log_weighted_reciprocal`, and the weighted analogue
+of `RothTheoremOQ01Reciprocal.not_threeAPFree_of_not_summable_reciprocal`.  It is strictly
+sharper than the unweighted `s = 0` form: because the extra `(log a)^s` weight only *inflates*
+the summand, divergence of the weighted sum is an easier certificate to meet, so more sets are
+forced to contain a three-term progression.  Rests on the single imported Bloom–Sisask
+assumption; introduces **no new axiom**. -/
+theorem not_threeAPFree_of_not_summable_log_weighted_reciprocal
+    (hs0 : 0 ≤ s) (hs : s < RothTheoremOQ02.blasiConst)
+    {A : Set ℕ} (hA0 : 0 ∉ A)
+    (hdiv : ¬ Summable (fun a : A => (Real.log (a : ℝ)) ^ s / (a : ℝ))) :
+    ¬ ThreeAPFree A :=
+  fun hAP => hdiv (threeAPFree_summable_log_weighted_reciprocal hs0 hs hAP hA0)
+
 #check @threeAPFree_summable_log_weighted_reciprocal
 #check @threeAPFree_tsum_log_weighted_reciprocal_le
+#check @weightedRecipBound_pos
+#check @exists_universal_log_weighted_recip_bound
+#check @not_threeAPFree_of_not_summable_log_weighted_reciprocal
 #check @weighted_finite_sum_le
 #check @weighted_fiber_sum_le
 #check @summable_weightedMajorant
@@ -304,5 +348,7 @@ theorem threeAPFree_tsum_log_weighted_reciprocal_le
 #print axioms threeAPFree_summable_log_weighted_reciprocal
 #print axioms summable_weightedMajorant
 #print axioms threeAPFree_tsum_log_weighted_reciprocal_le
+#print axioms exists_universal_log_weighted_recip_bound
+#print axioms not_threeAPFree_of_not_summable_log_weighted_reciprocal
 
 end RothTheoremOQ01Weighted

--- a/src/data/research/problems/roth-theorem-oq-01.json
+++ b/src/data/research/problems/roth-theorem-oq-01.json
@@ -69,7 +69,7 @@
     "mathlib": []
   },
   "started": "2026-06-15T02:22:21.995Z",
-  "lastUpdate": "2026-07-09",
+  "lastUpdate": "2026-07-10",
   "significance": 6,
   "tractability": 4,
   "leanFiles": [
@@ -109,8 +109,8 @@
     {
       "path": "Proofs/RothTheoremOQ01Weighted.lean",
       "filename": "RothTheoremOQ01Weighted.lean",
-      "lineCount": 309,
-      "theoremCount": 7,
+      "lineCount": 354,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 2,
       "sorryCount": 0,


### PR DESCRIPTION
## Summary

Two things, both **verified locally** (see Verification):

**1. New API — completes the log-weighted companion `RothTheoremOQ01Weighted.lean`.**
Adds the packaged universal-bound and Erdős contrapositive layer that its verified sibling `RothTheoremOQ01Reciprocal.lean` already carries but the weighted file lacked (it previously stopped at the raw `tsum` bound + `weightedRecipBound` def):

| New (weighted) | Verified sibling (reciprocal) |
|---|---|
| `weightedRecipBound_pos` | `recipBound_pos` |
| `exists_universal_log_weighted_recip_bound` | `exists_universal_recip_bound` |
| `not_threeAPFree_of_not_summable_log_weighted_reciprocal` | `not_threeAPFree_of_not_summable_reciprocal` |

- `weightedRecipBound_pos` — the absolute log-weighted constant `∑'_k weightedMajorant s k` is `> 0`.
- `exists_universal_log_weighted_recip_bound` — one absolute `B > 0`, independent of the set, bounds `∑'_{a∈A} (log a)^s / a` for *every* 3-AP-free `A ⊆ ℕ` (`0 ∉ A`) simultaneously, for admissible `0 ≤ s < blasiConst`.
- `not_threeAPFree_of_not_summable_log_weighted_reciprocal` — Erdős `k=3` contrapositive: any `A` whose log-weighted reciprocal sum diverges is not 3-AP-free (sharper than the `s=0` case).

**2. Tower repair — the OQ-01 files did not compile.**
Verifying locally surfaced that the OQ-01 tower had been shipped **never-compiling** during the long Docker outage (three Mathlib API-drift breaks). Fixed:

- `RothTheoremOQ01.lean`: add missing `import Mathlib.Analysis.SpecialFunctions.Pow.Asymptotics` (home of `tendsto_rpow_atTop`); rename `Tendsto.atTop_mul_atTop` → `Tendsto.atTop_mul_atTop₀` (the reals variant was renamed; the old name now needs `IsOrderedMonoid ℝ` and fails); drop a stray `ring` after `field_simp`.
- `RothTheoremOQ01Weighted.lean`: add the hypothesis `hs : s < blasiConst` to `weighted_fiber_sum_le` (already available at its only call site; the `k=0` block needs `0 ≤ 1+blasiConst−s` for `Real.rpow_le_one`); drop a second stray `ring`.

## Assumptions / axioms

No new axiom. Every result across the chain depends only on `[propext, Classical.choice, Quot.sound, RothTheoremOQ02.rothNumberNat_bloom_sisask]` — the single imported Bloom–Sisask assumption. No `sorryAx`, no `Lean.ofReduceBool`. Status remains `axiomatized` (rests on the Bloom–Sisask bound).

## Verification — VERIFIED

Docker image build is down this session (containerd `meta.db` I/O error), so I verified against the cached Mathlib oleans with the system Lean toolchain (`leanprover/lean4:v4.26.0`). The full dependency chain compiles **clean from scratch with 0 sorries**:

```
OK RothTheoremOQ02
OK RothTheoremOQ01
OK RothTheoremOQ01Reciprocal
OK RothTheoremOQ01Weighted
OK RothTheoremOQ01Primes
sorryAx across chain: 0
```

## Meta

- `RothTheoremOQ01Weighted.lean`: 309 → 355 lines, 7 → 10 theorems (research JSON synced).
- `RothTheoremOQ01.lean`: net line count unchanged (512). Gallery `meta.json` does not track the weighted companion, so no gallery line sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)