### PR TITLE
research(erdos-214-incomplete-01-oq-01): minimal positive distance of √2·ℤ² is exactly √2 [UNVERIFIED]

### DIFF
--- a/proofs/Proofs/Erdos214Incomplete01OQ01.lean
+++ b/proofs/Proofs/Erdos214Incomplete01OQ01.lean
@@ -450,4 +450,75 @@ theorem scaledLattice_realizes_sqrt_eight :
   refine ⟨p, q, hp, hq, ?_⟩
   rw [h]; congr 1; norm_num
 
+/-!
+## The minimal positive distance of `√2·ℤ²` is exactly `√2`
+
+Every result above describes *which* distances the lattice avoids or realizes,
+but none pins down its **smallest positive** distance.  The exact
+characterization `dist² = 2·(u² + v²)` supplies it at once: the radicand is either
+`0` (coincident points) or `≥ 2` (any nonzero integer combination), so the lattice
+has **no** distance in the open interval `(0, √2)`.  This "gap" bound is *sharp* —
+`√2` itself is attained (`latticePoint 1 0` and the origin) — so the minimal
+positive distance is exactly `√2`, the nearest-neighbour spacing of the lattice.
+-/
+
+/-- **Distance gap.**  Any two points of `ScaledLattice` are either *coincident*
+(distance `0`) or at least `√2` apart: the squared distance `2·((a-a')² + (b-b')²)`
+is either `0` or `≥ 2`, since `(a-a')² + (b-b')²` is a nonnegative integer that,
+when nonzero, is `≥ 1`.  Hence the lattice realizes **no** distance in the open
+interval `(0, √2)`. -/
+theorem scaledLattice_dist_eq_zero_or_ge_sqrt_two {p q : Plane}
+    (hp : p ∈ ScaledLattice) (hq : q ∈ ScaledLattice) :
+    dist p q = 0 ∨ Real.sqrt 2 ≤ dist p q := by
+  obtain ⟨a, b, hpa, hpb⟩ := hp
+  obtain ⟨a', b', hqa, hqb⟩ := hq
+  have hs : Real.sqrt 2 ^ 2 = 2 := Real.sq_sqrt (by norm_num)
+  have hx : (p 0 - q 0) ^ 2 = 2 * ((a : ℝ) - a') ^ 2 := by
+    rw [hpa, hqa]
+    have e : (Real.sqrt 2 * (a : ℝ) - Real.sqrt 2 * a') ^ 2
+        = Real.sqrt 2 ^ 2 * ((a : ℝ) - a') ^ 2 := by ring
+    rw [e, hs]
+  have hy : (p 1 - q 1) ^ 2 = 2 * ((b : ℝ) - b') ^ 2 := by
+    rw [hpb, hqb]
+    have e : (Real.sqrt 2 * (b : ℝ) - Real.sqrt 2 * b') ^ 2
+        = Real.sqrt 2 ^ 2 * ((b : ℝ) - b') ^ 2 := by ring
+    rw [e, hs]
+  rw [dist_eq_coords, hx, hy]
+  rcases eq_or_ne ((a - a') ^ 2 + (b - b') ^ 2) 0 with h0 | h0
+  · left
+    have hc : ((a : ℝ) - a') ^ 2 + ((b : ℝ) - b') ^ 2 = 0 := by exact_mod_cast h0
+    have hz : 2 * ((a : ℝ) - a') ^ 2 + 2 * ((b : ℝ) - b') ^ 2 = 0 := by linarith
+    rw [hz, Real.sqrt_zero]
+  · right
+    have hnn : (0 : ℤ) ≤ (a - a') ^ 2 + (b - b') ^ 2 := by positivity
+    have hM : (1 : ℤ) ≤ (a - a') ^ 2 + (b - b') ^ 2 := by omega
+    have hM' : (1 : ℝ) ≤ ((a : ℝ) - a') ^ 2 + ((b : ℝ) - b') ^ 2 := by exact_mod_cast hM
+    have hR : (2 : ℝ) ≤ 2 * ((a : ℝ) - a') ^ 2 + 2 * ((b : ℝ) - b') ^ 2 := by linarith
+    exact Real.sqrt_le_sqrt hR
+
+/-- **Minimal positive distance.**  Any two *distinct* points of `ScaledLattice`
+are at distance at least `√2`.  Immediate from the distance-gap dichotomy: the
+`distance 0` branch forces `p = q` (via `‖p - q‖ = 0`), contradicting `p ≠ q`. -/
+theorem scaledLattice_dist_ge_sqrt_two {p q : Plane}
+    (hp : p ∈ ScaledLattice) (hq : q ∈ ScaledLattice) (hpq : p ≠ q) :
+    Real.sqrt 2 ≤ dist p q := by
+  rcases scaledLattice_dist_eq_zero_or_ge_sqrt_two hp hq with h0 | h
+  · exfalso
+    apply hpq
+    have hsub : p - q = 0 := by
+      unfold dist at h0
+      exact norm_eq_zero.mp h0
+    exact sub_eq_zero.mp hsub
+  · exact h
+
+/-- **Sharpness of the gap.**  The bound `√2` is attained: `latticePoint 1 0` and the
+origin `0` are distinct lattice points exactly `√2` apart (`n = 2 = 2·(1² + 0²)`).
+Together with `scaledLattice_dist_ge_sqrt_two` this shows the minimal positive
+distance of `√2·ℤ²` is **exactly** `√2` — its nearest-neighbour spacing. -/
+theorem scaledLattice_realizes_sqrt_two :
+    ∃ p q : Plane, p ∈ ScaledLattice ∧ q ∈ ScaledLattice ∧ dist p q = Real.sqrt 2 := by
+  obtain ⟨p, q, hp, hq, h⟩ := scaledLattice_realizes 1 0
+  refine ⟨p, q, hp, hq, ?_⟩
+  rw [h]; congr 1; norm_num
+
 end Erdos214Incomplete01OQ01

--- a/src/data/proofs/erdos-214-incomplete-01-oq-01/meta.json
+++ b/src/data/proofs/erdos-214-incomplete-01-oq-01/meta.json
@@ -38,7 +38,10 @@
       "two_mul_sq_add_sq_ne_one: 2·(m² + k²) ≠ 1 for integers m,k — the parity/arithmetic core (omega after casting to ℤ)",
       "scaledLattice_dist_ne_one: any two points of ScaledLattice are at distance ≠ 1 (no p ≠ q hypothesis needed; the squared distance is an even integer)",
       "scaledLattice_unitDistanceFree: the √2-scaled integer lattice is unit-distance-free — the hypothesis of Erdős #214 is non-vacuous",
-      "scaledLattice_nonempty: the origin lies in ScaledLattice (the set is inhabited)"
+      "scaledLattice_nonempty: the origin lies in ScaledLattice (the set is inhabited)",
+      "scaledLattice_dist_eq_zero_or_ge_sqrt_two: distance-gap dichotomy — any two lattice points are either coincident (distance 0) or at least √2 apart; the lattice realizes no distance in the open interval (0, √2)",
+      "scaledLattice_dist_ge_sqrt_two: the minimal positive distance — any two distinct lattice points are at distance ≥ √2 (the coincidence branch is ruled out via ‖p − q‖ = 0 ⇒ p = q)",
+      "scaledLattice_realizes_sqrt_two: sharpness — √2 is attained by latticePoint 1 0 and the origin, so the minimal positive (nearest-neighbour) distance of √2·ℤ² is exactly √2"
     ],
     "references": [
       {
@@ -63,10 +66,10 @@
     ],
     "dateAdded": "2026-06-28",
     "axiomCount": 0,
-    "lineCount": 453,
+    "lineCount": 524,
     "mathlib_version": "4.26.0",
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries (only the foundational propext / Classical.choice / Quot.sound). In particular this result does NOT use the parent entry's axiomatized juhasz_1979 / juhasz_stronger.",
-    "theoremCount": 15,
+    "theoremCount": 18,
     "definitionCount": 5
   },
   "overview": {
@@ -160,9 +163,9 @@
     ],
     "opens": [],
     "namespace": "Erdos214Incomplete01OQ01",
-    "lineCount": 453,
+    "lineCount": 524,
     "axiomCount": 0,
-    "theoremCount": 15,
+    "theoremCount": 18,
     "definitionCount": 5,
     "sorries": 0,
     "path": "Proofs/Erdos214Incomplete01OQ01.lean"


### PR DESCRIPTION
## Summary

The gallery entry **erdos-214-incomplete-01-oq-01** (`√2·ℤ²` is unit-distance-free) already contains the full *exact characterization* of achievable square-distances — `dist p q ² = 2·(u² + v²)`, i.e. `√n` is realized ⟺ `n/2` is a sum of two squares — but it never identifies the lattice's **smallest positive distance**. These three coherent additions close that gap and complete the distance-spectrum narrative.

## New results

- **`scaledLattice_dist_eq_zero_or_ge_sqrt_two`** — *distance-gap dichotomy.* Any two lattice points are either coincident (distance `0`) or at least `√2` apart: the radicand `2·((a-a')² + (b-b')²)` is either `0` or `≥ 2`, since `(a-a')² + (b-b')²` is a nonnegative integer that, when nonzero, is `≥ 1`. Hence the lattice realizes **no** distance in the open interval `(0, √2)`.
- **`scaledLattice_dist_ge_sqrt_two`** — *minimal positive distance.* Any two **distinct** lattice points are at distance `≥ √2`. The coincidence branch is discharged via `‖p − q‖ = 0 ⇒ p = q` (`norm_eq_zero` + `sub_eq_zero`), needing no coordinate `ext`.
- **`scaledLattice_realizes_sqrt_two`** — *sharpness.* `√2` is attained by `latticePoint 1 0` and the origin (`n = 2 = 2·(1² + 0²)`), so the minimal positive (nearest-neighbour) distance of `√2·ℤ²` is **exactly** `√2`.

Each proof reuses the file's already-verified `dist_eq_coords`, `Real.sq_sqrt`, and `scaledLattice_realizes` idioms; no new axioms, no `sorry`.

## Verification

⚠️ **UNVERIFIED** — the Docker Lean image-build is currently down (`containerd meta.db input/output error`), so `docker-build.sh` could not run. The proofs are by-eye checked and mirror the file's existing verified lemmas line-for-line. `meta.json`: `lineCount` 453→524, `theoremCount` 15→18 (both copies), plus three `originalContributions` entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)