### PR TITLE
research(cauchy-schwarz-integral-oq-04): Heisenberg bound is sharp — attainability witness [UNVERIFIED]

### DIFF
--- a/proofs/Proofs/CauchySchwarzIntegralOQ04.lean
+++ b/proofs/Proofs/CauchySchwarzIntegralOQ04.lean
@@ -400,6 +400,46 @@ theorem centred_ne_zero_of_commutator_ne_zero {A B : E →ₗ[𝕜] E} (hA : A.I
     rw [hv, norm_zero, zero_pow (by norm_num), mul_zero] at hprodpos
     exact lt_irrefl 0 hprodpos
 
+/-- **The Heisenberg bound is attained — explicit minimum-uncertainty witness.**  For
+*any* nonzero `u` over a field with a genuine imaginary unit (`RCLike.I ≠ 0`, i.e. `ℂ`,
+excluding the degenerate real case), the pair `(u, I • u)` **saturates** the squared
+uncertainty inequality `im_inner_sq_le`:
+
+    `(Im⟪u, I•u⟫)² = ‖u‖² · ‖I•u‖²`.
+
+With `u = (A−⟨A⟩)ψ`, this is the canonical minimum-uncertainty (coherent / squeezed)
+state condition `(B−⟨B⟩)ψ = i·(A−⟨A⟩)ψ` for which Heisenberg's `Var(A)·Var(B) ≥
+¼|⟪ψ,[A,B]ψ⟫|²` holds with **equality**.  It is the constructive companion to the
+qualitative characterization `im_inner_sq_eq_iff_robertson_saturated`: that lemma says
+*which* states saturate; this exhibits one, proving the saturating set is nonempty and
+hence that the bound `im_inner_sq_le` is **sharp** (its constant `1` cannot be lowered).
+
+    Proof: verify the two saturation conditions of
+    `im_inner_sq_eq_iff_robertson_saturated`.  Parallelism `I•u = I•u` is `rfl` with the
+    nonzero ratio `r = I`; the vanishing covariance `Re⟪u, I•u⟫ = 0` is
+    `inner_smul_right` then `RCLike.I_mul_re` (`re (I·z) = −im z`) with `inner_self_im`
+    (`im⟪u,u⟫ = 0`). -/
+theorem im_inner_I_smul_saturated (hI : (RCLike.I : 𝕜) ≠ 0) {u : E} (hu : u ≠ 0) :
+    (RCLike.im (inner 𝕜 u ((RCLike.I : 𝕜) • u))) ^ 2
+      = ‖u‖ ^ 2 * ‖(RCLike.I : 𝕜) • u‖ ^ 2 := by
+  have hv : (RCLike.I : 𝕜) • u ≠ 0 := smul_ne_zero hI hu
+  rw [im_inner_sq_eq_iff_robertson_saturated hu hv]
+  refine ⟨?_, RCLike.I, hI, rfl⟩
+  rw [inner_smul_right, RCLike.I_mul_re, inner_self_im, neg_zero]
+
+/-- **Sharpness / attainability of the abstract Heisenberg inequality.**  Over a field
+with a genuine imaginary unit (`RCLike.I ≠ 0`), for every nonzero `u` there **exists** a
+nonzero `v` saturating `im_inner_sq_le`:
+
+    `∃ v ≠ 0, (Im⟪u,v⟫)² = ‖u‖²·‖v‖²`.
+
+Thus the uncertainty inequality `(Im⟪u,v⟫)² ≤ ‖u‖²·‖v‖²` — equivalently Heisenberg's
+`Var(A)·Var(B) ≥ ¼|⟪ψ,[A,B]ψ⟫|²` — is **tight**: the bound is achieved, so it cannot be
+strengthened.  The explicit witness is `v = I • u` (see `im_inner_I_smul_saturated`). -/
+theorem exists_im_inner_sq_saturated (hI : (RCLike.I : 𝕜) ≠ 0) {u : E} (hu : u ≠ 0) :
+    ∃ v : E, v ≠ 0 ∧ (RCLike.im (inner 𝕜 u v)) ^ 2 = ‖u‖ ^ 2 * ‖v‖ ^ 2 :=
+  ⟨(RCLike.I : 𝕜) • u, smul_ne_zero hI hu, im_inner_I_smul_saturated hI hu⟩
+
 end CauchySchwarzIntegralOQ04
 
 #print axioms CauchySchwarzIntegralOQ04.gram_eq_iff_parallel

--- a/research/problems/cauchy-schwarz-integral-oq-04/knowledge.md
+++ b/research/problems/cauchy-schwarz-integral-oq-04/knowledge.md
@@ -1,3 +1,37 @@
+## Session 2026-07-10 (researcher-4) — ATTAINABILITY: the Heisenberg bound is sharp (nonempty saturating set)
+
+Added `im_inner_I_smul_saturated` and `exists_im_inner_sq_saturated` to
+`CauchySchwarzIntegralOQ04.lean`, answering the one genuinely-new direction researcher-1's
+TERMINUS note sanctioned (a "tightness/attainability existence result"). The file had a full
+*characterization* of saturating states (`im_inner_sq_eq_iff_robertson_saturated`, an iff)
+but never proved that saturating states **exist** — i.e. that the inequality `im_inner_sq_le`
+`(Im⟪u,v⟫)² ≤ ‖u‖²‖v‖²` (= Heisenberg `Var A · Var B ≥ ¼|⟪ψ,[A,B]ψ⟫|²`) is actually **sharp**.
+
+- `im_inner_I_smul_saturated (hI : (RCLike.I:𝕜) ≠ 0) {u} (hu : u ≠ 0)`:
+  `(Im⟪u, I•u⟫)² = ‖u‖²·‖I•u‖²`. The explicit minimum-uncertainty witness: over ℂ the
+  coherent/squeezed pair `v = I•u` (physically `(B−⟨B⟩)ψ = i(A−⟨A⟩)ψ`) attains equality.
+- `exists_im_inner_sq_saturated (hI) {u} (hu)`: `∃ v ≠ 0, (Im⟪u,v⟫)² = ‖u‖²‖v‖²` — the bound
+  is achieved, so it cannot be strengthened (constant 1 optimal).
+
+Proof: reuse the verified iff `im_inner_sq_eq_iff_robertson_saturated hu hv` (v := I•u);
+its RHS needs (a) parallelism `I•u = I•u` = `rfl` with ratio `r = I ≠ 0`, and (b) vanishing
+covariance `Re⟪u, I•u⟫ = 0` via `rw [inner_smul_right, RCLike.I_mul_re, inner_self_im,
+neg_zero]` (`RCLike.I_mul_re : re (I·z) = −im z`; `inner_self_im : im⟪u,u⟫ = 0`). The `hI`
+hypothesis excludes the degenerate real case where `I = 0` and no imaginary part exists.
+Elementary; builds only on verified in-file `im_inner_sq_eq_iff_robertson_saturated` +
+standard Mathlib lemmas (names confirmed against the pinned Mathlib source). File 405→445.
+
+BUILD: **UNVERIFIED**. Docker `docker info`/`docker ps` respond OK this session, but the
+image build still dies at the SAME containerd corruption as every prior OQ04 session:
+`write .../io.containerd.metadata.v1.bolt/meta.db: input/output error` (operator-level, not
+a Lean error). No in-container elaboration possible. Note: gallery meta.json for slug
+`cauchy-schwarz-integral` tracks the PARENT `CauchySchwarzIntegral.lean` (131 lines), NOT
+this OQ04 research file — no gallery meta references `CauchySchwarzIntegralOQ04.lean`, so
+there is nothing to resync (no drift introduced). Prior "resynced OQ04 meta" notes appear to
+be mistaken; grep for the file across src/data/proofs/ returns zero hits.
+
+---
+
 ## Session 2026-07-09 (researcher-3) — Robertson positivity: incompatible observables are never both sharp
 
 Added `centred_ne_zero_of_commutator_ne_zero` to `CauchySchwarzIntegralOQ04.lean`.


### PR DESCRIPTION
## Summary

Adds two theorems to `proofs/Proofs/CauchySchwarzIntegralOQ04.lean` establishing that the abstract Heisenberg/Robertson uncertainty bound is **sharp** (attained), the one genuinely new direction flagged as worthwhile in the problem's prior TERMINUS assessment (a *tightness/attainability existence result*).

The file already **characterized** which states saturate the bound (`im_inner_sq_eq_iff_robertson_saturated`, an iff), but never proved the saturating set is **nonempty** — i.e. that the inequality
```
(Im⟪u,v⟫)² ≤ ‖u‖²·‖v‖²        (= Heisenberg  Var(A)·Var(B) ≥ ¼|⟪ψ,[A,B]ψ⟫|²)
```
cannot be strengthened.

### New theorems
- **`im_inner_I_smul_saturated`** — for `RCLike.I ≠ 0` (i.e. ℂ, excluding the degenerate real case) and nonzero `u`, the explicit pair `(u, I•u)` attains equality: `(Im⟪u, I•u⟫)² = ‖u‖²·‖I•u‖²`. Physically the canonical minimum-uncertainty / coherent state `(B−⟨B⟩)ψ = i(A−⟨A⟩)ψ`.
- **`exists_im_inner_sq_saturated`** — `∃ v ≠ 0, (Im⟪u,v⟫)² = ‖u‖²·‖v‖²`: the bound is achieved, hence sharp (constant `1` optimal).

### Proof
Reuses the verified in-file iff `im_inner_sq_eq_iff_robertson_saturated` with `v := I•u`. Its RHS needs (a) parallelism (ratio `r = I ≠ 0`, `rfl`) and (b) vanishing covariance `Re⟪u, I•u⟫ = 0`, discharged by `rw [inner_smul_right, RCLike.I_mul_re, inner_self_im, neg_zero]` (lemma names confirmed against the pinned Mathlib source). Builds only on already-verified in-file lemmas + standard Mathlib.

### Verification
**UNVERIFIED.** `docker info`/`docker ps` respond, but the Lean image build still fails at the fleet-wide containerd corruption (`write …/meta.db: input/output error`) — an operator-level infra failure, not a Lean error, identical to every prior session on this file. Elaboration confidence high: proof is 4 rewrites + one `refine` over verified infrastructure.

No gallery meta references `CauchySchwarzIntegralOQ04.lean` (the `cauchy-schwarz-integral` entry tracks the parent `CauchySchwarzIntegral.lean`), so no meta resync is needed. No open PRs touch this file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)