### PR TITLE
research(descartes-rule-of-signs-oq-01-oq-03): •-form + monic-normalisation invariance of V [UNVERIFIED]

### DIFF
--- a/proofs/Proofs/DescartesRuleOfSignsOQ01OQ03.lean
+++ b/proofs/Proofs/DescartesRuleOfSignsOQ01OQ03.lean
@@ -879,4 +879,26 @@ theorem signChangesInCoeffs_neg (p : ℝ[X]) :
   have h := signChangesInCoeffs_C_mul (c := -1) (by norm_num) p
   rwa [show (C (-1 : ℝ)) * p = -p by rw [map_neg, map_one, neg_one_mul]] at h
 
+/-- **Scaling invariance, `•`-form.**  The `smul` counterpart of
+`signChangesInCoeffs_C_mul`: scaling a polynomial by a nonzero real `c` via the
+module action leaves Descartes' coefficient sign-change count unchanged,
+`V(c • p) = V(p)`.  Immediate from `smul_eq_C_mul` and `signChangesInCoeffs_C_mul`.
+Axiom-free. -/
+theorem signChangesInCoeffs_smul {c : ℝ} (hc : c ≠ 0) (p : ℝ[X]) :
+    DescartesRuleOfSigns.signChangesInCoeffs (c • p)
+      = DescartesRuleOfSigns.signChangesInCoeffs p := by
+  rw [smul_eq_C_mul]
+  exact signChangesInCoeffs_C_mul hc p
+
+/-- **Descartes' bound is invariant under monic normalisation.**  For `p ≠ 0`,
+rescaling by the inverse leading coefficient — which produces a *monic* polynomial
+with the same roots — leaves the sign-change count unchanged:
+`V(leadingCoeff(p)⁻¹ • p) = V(p)`.  Thus Descartes' rule may be applied to the monic
+normalisation of any polynomial without affecting the bound.  The `c = leadingCoeff⁻¹`
+case of `signChangesInCoeffs_smul` (`leadingCoeff p ≠ 0` since `p ≠ 0`).  Axiom-free. -/
+theorem signChangesInCoeffs_leadingCoeff_inv_smul {p : ℝ[X]} (hp : p ≠ 0) :
+    DescartesRuleOfSigns.signChangesInCoeffs (p.leadingCoeff⁻¹ • p)
+      = DescartesRuleOfSigns.signChangesInCoeffs p :=
+  signChangesInCoeffs_smul (inv_ne_zero (leadingCoeff_ne_zero.mpr hp)) p
+
 end DescartesRuleOfSignsOQ01OQ03

--- a/src/data/proofs/descartes-rule-of-signs-oq-01-oq-03/meta.json
+++ b/src/data/proofs/descartes-rule-of-signs-oq-01-oq-03/meta.json
@@ -49,9 +49,9 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 1,
-    "lineCount": 870,
+    "lineCount": 904,
     "assumptions": "The general direction (Sturm ⟹ Descartes for an arbitrary polynomial) is a reduction: it is conditional on a `SturmReduction p` bridge structure whose five fields package Sturm's exact positive-root count on (0, B] together with the three classical coefficient-comparison facts σ_p(0) ≤ V(p), Even(V(p) − σ_p(0)), and Even(σ_p(B)). Per the project's axiom-integrity policy these structure fields are mathematical assumptions (counted here as axiomCount 1; obtaining the data for a general p requires Sturm's theorem, axiomatized in the parent entry as sturm_exact_count_axiom, plus standard Sturm/Descartes comparison theory). No `axiom` declarations and no sorries appear in the file (leanFile.axiomCount = 0). The reduction theorems (upper_bound_core, parity_core, descartes_upper_bound_via_sturm, descartes_parity_via_sturm, descartes_rule_via_sturm) are fully machine-checked implications, and the Sturm half is validated UNCONDITIONALLY and axiom-free on linear polynomials X − c (c > 0), reusing the gallery's axiom-free Sturm computations. The linear-polynomial validation (X − c, c > 0) is now fully unconditional and axiom-free: the coefficient sign-change count V(X − c) = 1 is computed directly (linear_signChanges, via the new axiom-free countSignChanges_two), so the previously-assumed hypothesis hV has been discharged and linearReduction/linear_descartes_bound carry no standing assumption for the linear case.",
-    "theoremCount": 26,
+    "theoremCount": 28,
     "mathlib_version": "4.26.0",
     "definitionCount": 2
   },
@@ -122,9 +122,9 @@
       "Proofs.DescartesRuleOfSignsOQ02OQ01OQ02"
     ],
     "namespace": "DescartesRuleOfSignsOQ01OQ03",
-    "lineCount": 882,
+    "lineCount": 904,
     "axiomCount": 0,
-    "theoremCount": 31,
+    "theoremCount": 33,
     "definitionCount": 2,
     "path": "Proofs/DescartesRuleOfSignsOQ01OQ03.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

Completes the scaling-invariance API for Descartes' coefficient sign-change count `V(p) = signChangesInCoeffs p` in `DescartesRuleOfSignsOQ01OQ03.lean`. The file already proved `V(c·p) = V(p)` via `C`-multiplication (`signChangesInCoeffs_C_mul`) and `V(−p) = V(p)`; this adds the Mathlib-idiomatic `•`-form and the classically-meaningful monic-normalisation corollary:

- `signChangesInCoeffs_smul : V(c • p) = V(p)`  (`c ≠ 0`)
- `signChangesInCoeffs_leadingCoeff_inv_smul : V(leadingCoeff(p)⁻¹ • p) = V(p)`  (`p ≠ 0`)

The first follows from `smul_eq_C_mul` + `signChangesInCoeffs_C_mul`. The second — **Descartes' bound is invariant under monic normalisation** — is the `c = leadingCoeff⁻¹` instance (`leadingCoeff p ≠ 0` iff `p ≠ 0`); it records that one may always apply Descartes' rule to the monic normalisation of a polynomial without changing the bound.

Both are axiom-free two-line corollaries; no new assumptions.

## Meta sync

Both count blocks synced to the two added theorems and the current file length: `meta.lineCount` 870→904, `meta.theoremCount` 26→28, `leanFile.lineCount` 882→904, `leanFile.theoremCount` 31→33 (this also absorbs a pre-existing 870-vs-882 `lineCount` drift). `axiomCount` unchanged (the entry's single assumption is the `SturmReduction` bridge structure; no `axiom` declarations added).

## Verification status

**UNVERIFIED.** The Lean docker image build is unavailable in this environment (containerd `meta.db` input/output error at image build). The two proofs were checked by hand against `signChangesInCoeffs_C_mul` and standard Mathlib (`smul_eq_C_mul`, `leadingCoeff_ne_zero`, `inv_ne_zero`). No new axioms or `sorry`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)