### PR TITLE
research(hilbert-17-oq-03): univariate PSD ⟺ SOS equivalence

### DIFF
--- a/proofs/Proofs/Hilbert17UnivariatePSDSOS.lean
+++ b/proofs/Proofs/Hilbert17UnivariatePSDSOS.lean
@@ -205,4 +205,52 @@ theorem univariate_psd_is_sos (p : ℝ[X]) (h : IsPSD p) :
   rw [huv, Fin.sum_univ_two]
   simp
 
+/-! ## The converse and the univariate PSD ⟺ SOS equivalence
+
+Hilbert's theorem gives PSD ⟹ SOS in one variable; the reverse implication —
+a sum of squares is non-negative — is trivial and holds in every dimension.
+Recording it upgrades the one-directional theorem to a genuine *characterization*
+`IsPSD p ↔ p is SOS`, which is exactly the statement that in a single variable
+PSD-membership is *decidable by a sum-of-squares certificate*.  This is the
+tractable end of the complexity spectrum of Hilbert's 17th problem: in two or
+more variables PSD ⊋ (polynomial-)SOS (the Motzkin / Robinson witnesses in the
+sibling files), and the analogous decision problem is NP-hard. -/
+
+/-- **The converse (all dimensions).**  A sum of squares of polynomials is PSD:
+non-negativity of `∑ qᵢ²` is immediate since each `qᵢ(x)²  ≥ 0`. -/
+theorem sos_is_psd {m : ℕ} (q : Fin m → ℝ[X]) : IsPSD (∑ i, q i ^ 2) := by
+  intro x
+  rw [eval_finset_sum]
+  refine Finset.sum_nonneg (fun i _ => ?_)
+  rw [eval_pow]
+  exact sq_nonneg _
+
+/-- A sum of *two* squares is PSD (the shape actually produced by
+`psd_eq_sq_add_sq_aux`). -/
+theorem two_sq_is_psd (u v : ℝ[X]) : IsPSD (u ^ 2 + v ^ 2) := by
+  intro x
+  simp only [eval_add, eval_pow]
+  positivity
+
+/-- **Sharp univariate characterization: PSD ⟺ a sum of two squares.**  Combining
+Hilbert's theorem (which in fact yields *two* squares) with the trivial converse,
+a univariate real polynomial is non-negative on all of `ℝ` iff it is `u² + v²`
+for some polynomials `u, v`.  Two squares always suffice. -/
+theorem univariate_psd_iff_two_sq (p : ℝ[X]) :
+    IsPSD p ↔ ∃ u v : ℝ[X], p = u ^ 2 + v ^ 2 := by
+  refine ⟨fun h => psd_eq_sq_add_sq_aux p.natDegree p rfl h, ?_⟩
+  rintro ⟨u, v, rfl⟩
+  exact two_sq_is_psd u v
+
+/-- **Univariate PSD ⟺ SOS.**  A univariate real polynomial is positive
+semidefinite iff it is a sum of squares.  The forward direction is Hilbert's
+1888 theorem (`univariate_psd_is_sos`); the reverse is `sos_is_psd`.  This
+biconditional is the decidability statement for the univariate instance of
+Hilbert's 17th problem. -/
+theorem univariate_psd_iff_sos (p : ℝ[X]) :
+    IsPSD p ↔ ∃ (m : ℕ) (q : Fin m → ℝ[X]), p = ∑ i, q i ^ 2 := by
+  refine ⟨univariate_psd_is_sos p, ?_⟩
+  rintro ⟨m, q, rfl⟩
+  exact sos_is_psd q
+
 end Hilbert17UnivariatePSDSOS

--- a/src/data/proofs/hilbert-17-oq-03-oq-04/meta.json
+++ b/src/data/proofs/hilbert-17-oq-03-oq-04/meta.json
@@ -58,7 +58,7 @@
       "Root multiplicity and the factorization p = (X − C r)^m · g with g(r) ≠ 0.",
       "The Brahmagupta–Fibonacci two-square identity (a²+b²)(c²+d²) = (ac−bd)²+(ad+bc)²."
     ],
-    "lineCount": 208,
+    "lineCount": 256,
     "relatedProblems": [
       {
         "id": "hilbert-17",
@@ -74,12 +74,12 @@
       }
     ],
     "assumptions": "0 axioms. #print axioms Hilbert17UnivariatePSDSOS.univariate_psd_is_sos reports only propext, Classical.choice, Quot.sound. No sorryAx, no native_decide / Lean.ofReduceBool. The PSD predicate and the SOS predicate are definitionally equal to the parent entry's IsPositiveSemidefinite / IsSumOfSquaresPolynomial, so the parent axiom univariate_psd_is_sos_aux is discharged by exact reference.",
-    "theoremCount": 5,
+    "theoremCount": 9,
     "definitionCount": 1,
     "additionalFiles": []
   },
   "leanFile": {
-    "lineCount": 208,
+    "lineCount": 256,
     "namespace": "Hilbert17UnivariatePSDSOS",
     "opens": [
       "Polynomial",
@@ -88,8 +88,8 @@
     ],
     "structureCount": 0,
     "axiomCount": 0,
-    "theoremCount": 5,
-    "substantiveTheoremCount": 3,
+    "theoremCount": 9,
+    "substantiveTheoremCount": 6,
     "computationalVerifications": 0,
     "lemmaCount": 0,
     "imports": [


### PR DESCRIPTION
## Summary

`hilbert-17-oq-03` asks about the **computational complexity** of deciding whether a PSD polynomial is a (polynomial) sum of squares — NP-hard in general. `Hilbert17UnivariatePSDSOS.lean` establishes the *tractable* end of that spectrum: Hilbert's 1888 theorem that in **one variable** every PSD polynomial is SOS (`univariate_psd_is_sos`). But the file only has the forward direction. This adds the converse and the resulting characterization:

- `sos_is_psd` — a sum of squares `∑ qᵢ²` is PSD (holds in all dimensions).
- `two_sq_is_psd` — `u² + v²` is PSD.
- `univariate_psd_iff_two_sq` — `IsPSD p ↔ ∃ u v, p = u² + v²` (two squares always suffice in one variable).
- `univariate_psd_iff_sos` — `IsPSD p ↔ ∃ m q, p = ∑ qᵢ²`.

The biconditional is precisely the **decidability** statement for the univariate instance: PSD-membership is certified by a sum-of-squares decomposition. This contrasts with the multivariate case, where PSD ⊋ SOS (the Motzkin/Robinson witnesses in the sibling `oq-03-oq-02`/`oq-03-oq-03` files) and the analogous decision problem is NP-hard.

## Proofs

Short corollaries of the existing verified `psd_eq_sq_add_sq_aux`/`univariate_psd_is_sos` plus `Polynomial.eval_finset_sum`, `sq_nonneg`, `positivity`. No new axioms or assumptions.

## Collision-avoidance

Sibling open PR #37321 edits `Hilbert17OQ03OQ05.lean`; this PR touches only `Hilbert17UnivariatePSDSOS.lean` (`oq-03-oq-04`) — disjoint.

## Verification

⚠️ **UNVERIFIED** — Docker build unavailable this session (containerd `meta.db` I/O error). Proof checked by inspection; `Polynomial.eval_finset_sum`/`eval_pow` confirmed in the pin and identical repo usage (`EhrhartCubeProvenOQ04.lean:742`, `AngleTrisectionCos20GalOQ01OQ03.lean:1054`).

Gallery meta synced: lineCount 208→256, theoremCount 5→9, substantiveTheoremCount 3→6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)