### PR TITLE
Enrich Coprime Companion Blocks are Nonderogatory (Matrix CRT)

### DIFF
--- a/src/data/proofs/cayley-hamilton-cyclic-vector-all-fields-oq-01-oq-02-oq-05/annotations.json
+++ b/src/data/proofs/cayley-hamilton-cyclic-vector-all-fields-oq-01-oq-02-oq-05/annotations.json
@@ -1,5 +1,17 @@
 [
   {
+    "id": "ann-import-scaffold",
+    "proofId": "cayley-hamilton-cyclic-vector-all-fields-oq-01-oq-02-oq-05",
+    "range": { "startLine": 1, "endLine": 2 },
+    "type": "context",
+    "title": "Two-file architecture: importing the parent scaffold",
+    "content": "The proof is deliberately split across two files. `import Proofs.CayleyHamiltonReductionOQ02OQ01WIP01` (recorded as this entry's `additionalFiles` dependency) pulls in the two heavy, sorry-free block-matrix theorems `charpoly_companion_block` (charpoly = p·q) and `minpoly_companion_block` (minpoly = lcm p q), whose proofs manipulate the `fromBlocks` structure directly. Once imported, this file never touches the block-matrix structure again: the entire coprime-merge result is obtained by feeding one scalar polynomial identity (lcm = product) into those imported readouts. The `import Mathlib` line brings in the `GCDMonoid F[X]` machinery — `lcm`, `IsCoprime.mul_dvd`, `lcm_dvd`, and the monic-divisibility lemmas — that the new arithmetic lemma rests on. Splitting the derivation this way keeps the derogatory-vs-nonderogatory story (matrix side) cleanly separated from the coprimality arithmetic (scalar side).",
+    "mathContext": "Imported facts: $\\chi_{C(p)\\oplus C(q)} = pq$ and $\\mu_{C(p)\\oplus C(q)} = \\operatorname{lcm}(p,q)$; the only new input is the scalar identity $\\operatorname{lcm}(p,q) = pq$ for coprime monic $p,q$.",
+    "significance": "supporting",
+    "relatedConcepts": ["module dependency", "companion block matrix", "separation of concerns", "GCDMonoid instance", "block-matrix charpoly/minpoly"],
+    "prerequisites": ["Lean imports and namespaces", "companion matrices"]
+  },
+  {
     "id": "ann-crt-context",
     "proofId": "cayley-hamilton-cyclic-vector-all-fields-oq-01-oq-02-oq-05",
     "range": { "startLine": 4, "endLine": 45 },


### PR DESCRIPTION
Enrichment pass for `cayley-hamilton-cyclic-vector-all-fields-oq-01-oq-02-oq-05` (quality 95, passes 0).

## Assessment
The entry already **exceeded every minimum quality target**: 5 fully-populated annotations, 6 keyInsights, rich `historicalContext`, a conclusion with implications + 3 open questions, 4 sections covering the whole 106-line file, 7 cross-references, and 3 references. Meta.json is 15 KB — well under the 60 KB cap. Per the size guardrails I did **not** inflate existing fields.

## Change
The one genuine gap was annotation coverage: the import/parent-scaffold region (lines 1–2) — the crux of the two-file architecture — was unannotated.

- Added `ann-import-scaffold`: explains the `additionalFiles` dependency on `CayleyHamiltonReductionOQ02OQ01WIP01` (supplies the sorry-free `charpoly_companion_block`/`minpoly_companion_block` readouts) and the deliberate matrix-side vs. scalar-side separation of concerns, plus why `import Mathlib` is needed for the `GCDMonoid F[X]` machinery.
- Verified all 7 cross-reference targets resolve to existing gallery entries.

annotations.json: 5 → 6 annotations (6.5 KB → 8.2 KB). meta.json unchanged.

## Validation
- JSON parses; `pnpm gallery:check-size`, `annotations:build`, `check-search-index`, `loading-facts` all pass.
- `tsc -b` passes (exit 0).
- Both files remain well under size caps.