### PR TITLE
research(lagrange-theorem-oq-01): Sylow count positivity + subgroup form of Cauchy [UNVERIFIED]

### DIFF
--- a/proofs/Proofs/LagrangeTheoremOQ01.lean
+++ b/proofs/Proofs/LagrangeTheoremOQ01.lean
@@ -189,6 +189,23 @@ theorem cauchy_theorem (p : ℕ) [hp : Fact p.Prime] (h : p ∣ card G) :
     ∃ g : G, orderOf g = p :=
   exists_prime_orderOf_dvd_card p h
 
+/-- **There is always at least one Sylow p-subgroup**: `n_p > 0`.  The positivity
+    underlying every Third-Sylow statement (`n_p ≡ 1 mod p`, `n_p ∣ [G:P]`): the set of
+    Sylow p-subgroups is nonempty (`Sylow.nonempty`, the First Sylow Theorem), hence its
+    cardinality is positive.  Records the base fact that `sylow_count_mod_p` implicitly
+    relies on. -/
+theorem sylow_count_pos (p : ℕ) [hp : Fact p.Prime] : 0 < card (Sylow p G) :=
+  card_pos_iff.mpr Sylow.nonempty
+
+/-- **Subgroup form of Cauchy's theorem**: if `p ∣ |G|` then `G` has a subgroup of order
+    exactly `p`.  This is the `k = 1` case of `partial_converse_lagrange` (`p¹ ∣ |G|`), the
+    subgroup companion to `cauchy_theorem` (which produces an *element* of order `p`; the
+    cyclic group it generates is precisely such a subgroup). -/
+theorem exists_subgroup_card_prime (p : ℕ) [hp : Fact p.Prime] (h : p ∣ card G) :
+    ∃ H : Subgroup G, Fintype.card H = p := by
+  obtain ⟨H, hH⟩ := partial_converse_lagrange p 1 (by rwa [pow_one])
+  exact ⟨H, by rwa [pow_one] at hH⟩
+
 end LagrangeOQ01
 
 /-

--- a/src/data/proofs/lagrange-theorem-oq-01/meta.json
+++ b/src/data/proofs/lagrange-theorem-oq-01/meta.json
@@ -151,9 +151,9 @@
   ],
   "leanFile": {
     "namespace": "LagrangeOQ01",
-    "lineCount": 210,
+    "lineCount": 227,
     "axiomCount": 0,
-    "theoremCount": 16,
+    "theoremCount": 18,
     "definitionCount": 0,
     "path": "Proofs/LagrangeTheoremOQ01.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

Two Mathlib-backed corollaries added to `Proofs/LagrangeTheoremOQ01.lean` (the Sylow theorems as the partial converse of Lagrange).

- **`sylow_count_pos`** — `0 < card (Sylow p G)`. The positivity fact underlying every Third-Sylow statement (`n_p ≡ 1 mod p`, `n_p ∣ [G:P]`): the set of Sylow p-subgroups is nonempty (`Sylow.nonempty`, First Sylow Theorem), so `n_p > 0`. Via `Fintype.card_pos_iff`.
- **`exists_subgroup_card_prime`** — `p ∣ |G| ⟹ ∃ H : Subgroup G, card H = p`. The **subgroup** form of Cauchy's theorem, companion to the file's `cauchy_theorem` (which yields an *element* of order `p`). Immediate as the `k = 1` case of `partial_converse_lagrange` (`p¹ ∣ |G|`).

## Verification
⚠️ **UNVERIFIED** — not machine-checked. Docker image build fails this session (`containerd ... meta.db: input/output error`). Both are one-liners over Mathlib's Sylow API.

Meta `leanFile.lineCount` 210→227, `theoremCount` 16→18.

🤖 Generated with [Claude Code](https://claude.com/claude-code)