### PR TITLE
research(erdos-666-incomplete-01): generalized C₂ₖ conjecture at k=3 forces C₆

### DIFF
--- a/proofs/Proofs/Erdos666Problem.lean
+++ b/proofs/Proofs/Erdos666Problem.lean
@@ -427,6 +427,26 @@ theorem hasC2k_three_iff_hasC6 {V : Type*} (H : SimpleGraph V) :
   show HasCycle H (2 * 3) ↔ HasCycle H 6
   rfl
 
+/-- **The generalized conjecture at `k = 3` is a `C₆`-forcing statement.**
+If the generalized `C_{2k}` conjecture holds, its `k = 3` instance forces `C₆`
+(not merely the syntactic `HasC2k H 3`): there is a positive constant `c` and an
+exponent `a ∈ (0,1)` such that every subgraph of `Qₙ` (`n ≥ 10`) with at least
+`c·n^a·2ⁿ` edges contains a `C₆`.  Obtained by specialising `GeneralizedConjecture`
+at `k = 3` and rewriting its conclusion `HasC2k H 3` to `HasC6 H` via
+`hasC2k_three_iff_hasC6`.  This pins down exactly how the generalization meets the
+original problem: same cycle length, but a *sparser* `n^a·2ⁿ` density threshold than
+the `ε·n·2ⁿ⁻¹` of `ConjectureAt`, which is why the `C₆` refutation
+(`conder_no_threshold`) does **not** transfer to it.  No new axioms. -/
+theorem generalizedConjecture_three_forces_c6 (h : GeneralizedConjecture) :
+    ∃ c : ℝ, 0 < c ∧ ∃ a : ℝ, 0 < a ∧ a < 1 ∧
+      ∀ n : ℕ, n ≥ 10 →
+        ∀ H : SimpleGraph (Fin (2^n)),
+          (Nat.card H.edgeSet : ℝ) ≥ c * (n : ℝ)^a * 2^n →
+          HasC6 H := by
+  obtain ⟨c, hc, a, ha0, ha1, hforce⟩ := h 3 (by norm_num)
+  exact ⟨c, hc, a, ha0, ha1,
+    fun n hn H hden => (hasC2k_three_iff_hasC6 H).mp (hforce n hn H hden)⟩
+
 /-
 **This generalization remains open.**
 -/

--- a/src/data/proofs/erdos-666/meta.json
+++ b/src/data/proofs/erdos-666/meta.json
@@ -55,7 +55,7 @@
       "GeneralizedConjecture: open question for C_{2k}"
     ],
     "axiomCount": 1,
-    "lineCount": 472,
+    "lineCount": 492,
     "assumptions": "1 axiom (Chung 1992): chung_no_threshold — no threshold N makes every (1/4)-dense subgraph of Qₙ contain C₆; a consequence of Chung's edge-partition of Qₙ into four C₆-free subgraphs, not available in Mathlib. The companion existence statement chung_c6free (for n ≥ 3, Qₙ has some C₆-free subgraph) was previously axiomatized but is now PROVED outright — it carries no edge-count data, so the empty subgraph ⊥ (no edges, hence no cycle) is an honest witness. The deep density content stays isolated in the single axiom chung_no_threshold.",
     "theoremCount": 15,
     "definitionCount": 13,
@@ -172,7 +172,7 @@
       "SimpleGraph"
     ],
     "namespace": "Erdos666",
-    "lineCount": 472,
+    "lineCount": 492,
     "axiomCount": 1,
     "theoremCount": 13,
     "definitionCount": 13,


### PR DESCRIPTION
## Summary

Adds `generalizedConjecture_three_forces_c6` to `Erdos666Problem.lean`, bridging the (still-open) generalized `C_{2k}` conjecture to the original — and refuted — `C₆` problem at the `k = 3` slice.

If `GeneralizedConjecture` holds, its `k = 3` instance forces genuine `C₆` (not merely the syntactic `HasC2k H 3`): there is `c > 0` and an exponent `a ∈ (0,1)` such that every subgraph of `Qₙ` (`n ≥ 10`) with at least `c·n^a·2ⁿ` edges contains a `C₆`.

## Proof

Specialize `GeneralizedConjecture` at `k = 3` (`h 3 (by norm_num)`) and rewrite the conclusion `HasC2k H 3 → HasC6 H` via the existing `hasC2k_three_iff_hasC6`. One `obtain` + anonymous constructor; 0 new axioms.

## Why this is the right delta

The file's `nextSteps` note that the generalized conjecture is *genuinely distinct* from the C₆ problem and that the C₆ refutation does not specialize to it. This theorem makes that relationship precise: at `k = 3` the **cycle length coincides** (`hasC2k_three_iff_hasC6`), but the density threshold `c·n^a·2ⁿ` is **sparser** than the `ε·n·2ⁿ⁻¹` of `ConjectureAt` — which is exactly why `conder_no_threshold` (`¬ConjectureAt (1/3)`) does not transfer. The theorem cleanly documents the interface between the two formulations without touching the open generalization itself.

## Verification

- 0 sorry / 0 new axioms (uses only the pre-existing `conder_no_threshold` axiom indirectly? — no: this theorem is axiom-free logical glue over `GeneralizedConjecture` as a hypothesis).
- ⚠️ **UNVERIFIED**: Docker build infrastructure is down (containerd `meta.db` input/output error); `docker-build.sh` could not run.
- Synced meta `lineCount` 472 → 492.

🤖 Generated with [Claude Code](https://claude.com/claude-code)