### PR TITLE
research(szemeredi-regularity-oq-01): empty parts are trivially ε-regular [UNVERIFIED]

### DIFF
--- a/proofs/Proofs/SzemerediRegularityOQ01.lean
+++ b/proofs/Proofs/SzemerediRegularityOQ01.lean
@@ -444,4 +444,27 @@ theorem card_irregularOrderedPairs_eq_zero_of_one_le (G : SimpleGraph V) [Decida
     (irregularOrderedPairs G eps parts).card = 0 := by
   rw [irregularOrderedPairs_eq_empty_of_one_le G heps parts, Finset.card_empty]
 
+/-- **An empty part is trivially ε-regular (left).**  For any `eps ≥ 0` the pair
+    `(∅, B)` is ε-regular: the only admissible witness `A' ⊆ ∅` is `∅`, and both
+    densities `d(∅, B')`, `d(∅, B)` vanish (`edgeDensity_empty_left`), so the gap is
+    `0 ≤ eps`.  This lifts the density fact `edgeDensity_empty_left` to the regularity
+    predicate — the degenerate base case underlying every partition induction, where a
+    part may be empty. -/
+theorem isEpsilonRegular_empty_left (G : SimpleGraph V) [DecidableRel G.Adj]
+    {eps : ℚ} (heps : 0 ≤ eps) (B : Finset V) :
+    IsEpsilonRegular G eps ∅ B := by
+  intro A' B' hA' _ _ _
+  rw [Finset.subset_empty] at hA'
+  subst hA'
+  rw [edgeDensity_empty_left, edgeDensity_empty_left]
+  simpa using heps
+
+/-- **An empty part is trivially ε-regular (right).**  The `(A, ∅)` companion of
+    `isEpsilonRegular_empty_left`, obtained by symmetry (`isEpsilonRegular_comm`); it lifts
+    `edgeDensity_empty_right` to the regularity predicate. -/
+theorem isEpsilonRegular_empty_right (G : SimpleGraph V) [DecidableRel G.Adj]
+    {eps : ℚ} (heps : 0 ≤ eps) (A : Finset V) :
+    IsEpsilonRegular G eps A ∅ :=
+  (isEpsilonRegular_comm G eps A ∅).mpr (isEpsilonRegular_empty_left G heps A)
+
 end Szemeredi.Regularity.OQ01


### PR DESCRIPTION
## Summary

Lifts the file's edge-density empty lemmas to the **ε-regularity predicate** in `Proofs/SzemerediRegularityOQ01.lean`.

- **`isEpsilonRegular_empty_left`** — for `eps ≥ 0`, the pair `(∅, B)` is ε-regular. The only admissible witness `A' ⊆ ∅` is `∅`, and both densities `d(∅, B')`, `d(∅, B)` vanish (`edgeDensity_empty_left`), so the gap is `0 ≤ eps`.
- **`isEpsilonRegular_empty_right`** — the `(A, ∅)` companion, by `isEpsilonRegular_comm`.

The file already had `edgeDensity_empty_left/right` but not the regularity-predicate form; these are the degenerate base case underlying any partition induction where a part may be empty. Proofs reuse existing same-file lemmas.

## Verification
⚠️ **UNVERIFIED** — not machine-checked. Docker image build fails this session (`containerd ... meta.db: input/output error`). Both proofs are short reductions over the file's own `edgeDensity_empty_*` and `isEpsilonRegular_comm`.

No gallery `meta.json` references this companion Lean file, so no meta sync is required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)