### PR TITLE
research(elem-quad-recip-oq-03-oq-02): square-numerator Kronecker value = coprimality indicator [UNVERIFIED]

### DIFF
--- a/proofs/Proofs/ElementaryQuadraticReciprocityOQ03OQ02.lean
+++ b/proofs/Proofs/ElementaryQuadraticReciprocityOQ03OQ02.lean
@@ -937,6 +937,42 @@ theorem kronecker_sq_right_eq_one_of_coprime (a : ℤ) (n : ℕ) (hn : 0 < n) (h
   rw [kronecker_sq_right a (n : ℤ) (by exact_mod_cast hn.ne')]
   exact kronecker_sq_eq_one_of_coprime a n hn hno h
 
+/-- **A square numerator is a residue or a non-unit — never a non-residue.**
+For nonzero `a`, `(a²/n) ∈ {0, 1}`: by `kronecker_sq_left` the value is `(a/n)²`,
+which is `{0,1}`-valued (`kronecker_sq_mem`).  Sharpens `kronecker_sq_left_nonneg`
+(`0 ≤ (a²/n)`) with the matching upper bound, pinning the square-numerator value
+to exactly the two residue possibilities. -/
+theorem kronecker_sq_left_eq_zero_or_one (a n : ℤ) (ha : a ≠ 0) :
+    kronecker (a ^ 2) n = 0 ∨ kronecker (a ^ 2) n = 1 := by
+  rw [kronecker_sq_left a n ha]; exact kronecker_sq_mem a n
+
+/-- **A square numerator vanishes exactly when its base does.**  `(a²/n) = 0 ↔
+(a/n) = 0` for nonzero `a`: the value `(a/n)²` is zero iff `(a/n)` is
+(`sq_eq_zero_iff`, `ℤ` having no zero divisors).  So `(a²/n)` is the same
+non-coprimality indicator as `(a/n)` — squaring the numerator never creates or
+destroys a common factor with `n`. -/
+theorem kronecker_sq_left_eq_zero_iff (a n : ℤ) (ha : a ≠ 0) :
+    kronecker (a ^ 2) n = 0 ↔ kronecker a n = 0 := by
+  rw [kronecker_sq_left a n ha, sq_eq_zero_iff]
+
+/-- **A square numerator is a residue exactly when its base is nonzero.**  `(a²/n)
+= 1 ↔ (a/n) ≠ 0` for nonzero `a`.  Since `(a²/n) ∈ {0, 1}`
+(`kronecker_sq_left_eq_zero_or_one`) and vanishes iff `(a/n)` does
+(`kronecker_sq_left_eq_zero_iff`), the value is `1` precisely on the nonvanishing
+locus.  This is the general-modulus refinement of `kronecker_sq_left_eq_one_of_coprime`
+(which needs `n` odd positive and coprimality): here the criterion is simply
+`(a/n) ≠ 0`, valid for *every* modulus. -/
+theorem kronecker_sq_left_eq_one_iff (a n : ℤ) (ha : a ≠ 0) :
+    kronecker (a ^ 2) n = 1 ↔ kronecker a n ≠ 0 := by
+  constructor
+  · intro h hz
+    have h0 : kronecker (a ^ 2) n = 0 := (kronecker_sq_left_eq_zero_iff a n ha).mpr hz
+    rw [h] at h0; exact one_ne_zero h0
+  · intro h
+    rcases kronecker_sq_left_eq_zero_or_one a n ha with h0 | h1
+    · exact absurd ((kronecker_sq_left_eq_zero_iff a n ha).mp h0) h
+    · exact h1
+
 /-!
 ## Module note: what remains open
 

--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-03-oq-02/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-03-oq-02/meta.json
@@ -18,9 +18,9 @@
     "badge": "wip",
     "sorries": 0,
     "axiomCount": 0,
-    "theoremCount": 56,
+    "theoremCount": 59,
     "defCount": 4,
-    "lineCount": 956,
+    "lineCount": 1023,
     "dateAdded": "2026-03-28",
     "assumptions": "0 axioms, 0 sorries — the file is fully machine-verified (no axiom or sorry is used). Complete multiplicativity is now proven in BOTH arguments over all nonzero moduli: kronecker_mul_left and kronecker_mul_right, alongside agreement with the Jacobi symbol and odd-modulus quadratic reciprocity. Status is kept 'wip' because the FORMALIZATION of the classical symbol is still partial, not because anything is assumed: (1) the definition routes even moduli through jacobiSym |n| rather than the classical mod-8 character kronecker2, so kronecker_mul_right is multiplicativity of the symbol as defined (which matches the classical Kronecker symbol at all odd moduli and at n = plus/minus 1); and (2) generalized quadratic reciprocity for arbitrary fundamental discriminants remains open. Both are documented as open work in the source module note; neither is axiomatized. Toward (2), the denominator-side supplementary characters are now shown periodic: kronecker_neg_one_periodic ((-1/.) is periodic mod 4) and kronecker_two_periodic ((2/.) is periodic mod 8), the structural complement of kronecker2_periodic (the numerator character (./2) is a Dirichlet character mod 8) and a Gauss-sum-route input.",
     "mathlib_version": "4.26.0",
@@ -97,9 +97,9 @@
       "Mathlib.NumberTheory.LegendreSymbol.JacobiSymbol"
     ],
     "namespace": "KroneckerSymbol",
-    "lineCount": 956,
+    "lineCount": 1023,
     "axiomCount": 0,
-    "theoremCount": 56,
+    "theoremCount": 59,
     "definitionCount": 4,
     "path": "Proofs/ElementaryQuadraticReciprocityOQ03OQ02.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

Section 13 of the Kronecker-symbol file establishes `(a²/n) = (a/n)²` and `0 ≤ (a²/n)`, but never pins the **value** of the symbol at a square numerator. These three certain lemmas identify it as the non-vanishing / coprimality indicator, completing the square-numerator picture.

## New results (Section 13)

- **`kronecker_sq_left_eq_zero_or_one`** — `(a²/n) ∈ {0, 1}` for nonzero `a`. The matching upper bound to `kronecker_sq_left_nonneg`: a square numerator is *never* a quadratic non-residue. (From `kronecker_sq_left` + `kronecker_sq_mem`.)
- **`kronecker_sq_left_eq_zero_iff`** — `(a²/n) = 0 ↔ (a/n) = 0` (via `sq_eq_zero_iff`, `ℤ` having no zero divisors): squaring the numerator neither creates nor destroys a common factor with `n`.
- **`kronecker_sq_left_eq_one_iff`** — `(a²/n) = 1 ↔ (a/n) ≠ 0`. The **general-modulus** refinement of `kronecker_sq_left_eq_one_of_coprime` (which needs `n` odd positive and coprimality): here the criterion is simply `(a/n) ≠ 0`, valid for every modulus.

Each proof combines already-verified idioms only — no new axioms, no `sorry`.

## Orthogonality / collisions

- Open PR #36458 (numerator multiplicativity + `MonoidHom` + `kronecker_pow_left_odd`) inserts at **Section 11** (line ~708); these lemmas go in **Section 13** (line ~940). No overlap.
- Rebased onto current `origin/main`, which already merged the denominator-square trio (`kronecker_sq_right*`); those are preserved.

## Verification

⚠️ **UNVERIFIED** — Docker Lean image-build is down (`containerd meta.db input/output error`); `docker-build.sh` could not run. Proofs are by-eye checked and reuse the file's verified lemmas. `meta.json`: `lineCount` 956→1023 (also absorbs a pre-existing +31-line mechanic drift from the merged `_sq_right` trio), `theoremCount` 56→59 (both copies).

🤖 Generated with [Claude Code](https://claude.com/claude-code)