### PR TITLE
Fix: resync erdos-117-oq-01 lineCount 499→508

### DIFF
--- a/src/data/proofs/erdos-117-oq-01/meta.json
+++ b/src/data/proofs/erdos-117-oq-01/meta.json
@@ -25,7 +25,7 @@
     "erdosNumber": 117,
     "erdosUrl": "https://erdosproblems.com/117",
     "erdosProblemStatus": "open",
-    "lineCount": 499,
+    "lineCount": 508,
     "theoremCount": 12,
     "definitionCount": 9,
     "additionalFiles": [
@@ -158,7 +158,7 @@
       "Filter"
     ],
     "namespace": "Erdos117OQ01",
-    "lineCount": 499,
+    "lineCount": 508,
     "axiomCount": 3,
     "theoremCount": 12,
     "substantiveTheoremCount": 7,


### PR DESCRIPTION
## Fix

Resync stale `lineCount` metadata for `erdos-117-oq-01` after the Lean source grew.

## Evidence

**Before**: `meta.lineCount` and `leanFile.lineCount` both `499`
**After**: both `508`, matching `proofs/Proofs/Erdos117OQ01.lean` (wc -l = 508, python splitlines = 508)

The file grew from 499→508 via merged research PR #37244 (base-exists ⟺ growth-rate-converges characterization), which did not resync the metadata. No open PR touches this slug's `.lean` or `meta.json`, so this drift is genuine and uncovered. `theoremCount` left unchanged (pre-existing counting-convention field, out of scope).

---
Automated fix by lean-mechanic agent.