### PR TITLE
Enrich Finite p-Groups Have Nontrivial Center (Class Equation)

### DIFF
--- a/src/data/proofs/conjugacy-class-equation-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/conjugacy-class-equation-oq-01-oq-02/annotations.json
@@ -1,5 +1,17 @@
 [
   {
+    "id": "imports-parent-classequation",
+    "proofId": "conjugacy-class-equation-oq-01-oq-02",
+    "range": { "startLine": 1, "endLine": 2 },
+    "type": "context",
+    "title": "Imports: the parent divisibility lemma and Mathlib's class equation",
+    "content": "The derivation stands on two imported pillars. `import Proofs.ConjugacyClassEquationOQ01` (the parent entry) supplies the sorry-free per-class divisibility lemma conjClass_card_dvd_card, |class(g)| ∣ |G|, which this file lifts from a chosen representative to an arbitrary class over the quotient ConjClasses G. `import Mathlib` brings in the numeric class equation Group.nat_card_center_add_sum_card_noncenter_eq_card (module Mathlib.GroupTheory.ClassEquation) — the identity |Z(G)| + Σ|class| = |G| that the whole modular argument reads off — together with the p-group cardinality lemmas IsPGroup.iff_card and Nat.dvd_prime_pow. The proof deliberately routes through this explicit numeric class equation rather than Mathlib's own fixed-point proof of the same theorem (IsPGroup.center_nontrivial), which is exactly the alternative derivation the parent's open question asked for.",
+    "mathContext": "Parent: $|\\mathrm{class}(g)| \\mid |G|$. Mathlib: $|Z(G)| + \\sum_{\\text{noncentral}} |x| = |G|$.",
+    "significance": "supporting",
+    "relatedConcepts": ["module dependency", "class equation", "per-class divisibility", "ConjClasses quotient", "IsPGroup.center_nontrivial"],
+    "prerequisites": ["Lean imports and namespaces", "the parent's per-class divisibility lemma"]
+  },
+  {
     "id": "pgroup-center-overview",
     "proofId": "conjugacy-class-equation-oq-01-oq-02",
     "range": { "startLine": 3, "endLine": 45 },


### PR DESCRIPTION
Enrichment pass for `conjugacy-class-equation-oq-01-oq-02` (quality 95, passes 0).

## Assessment
The entry already **exceeded every minimum quality target**: 5 fully-populated annotations covering lines 3–123, 4 keyInsights, a rich `historicalContext`/`proofStrategy`, 5 sections spanning the whole 123-line file, a conclusion with implications + 2 open questions, documented `mathlibDependencies`, and 2 references. Meta.json is 15 KB — well under the 60 KB cap. Per the size guardrails I did **not** inflate existing fields.

## Change
The one genuine coverage gap was the import region (lines 1–2), where the two load-bearing dependencies enter.

- Added `imports-parent-classequation`: explains that `Proofs.ConjugacyClassEquationOQ01` (the parent) supplies the per-class divisibility lemma `conjClass_card_dvd_card`, and that `Mathlib` supplies the numeric class equation `Group.nat_card_center_add_sum_card_noncenter_eq_card` — clarifying why this proof routes through the explicit class equation rather than Mathlib's fixed-point proof `IsPGroup.center_nontrivial` (the alternative derivation the parent's open question asked for).
- Verified all 3 cross-reference targets resolve to existing gallery entries.

annotations.json: 5 → 6 annotations (5.0 KB → 6.6 KB). meta.json unchanged.

## Validation
- JSON parses; `gallery/check-meta-size` passes (within caps); `annotations:build` processes the entry with no new warnings (the two warnings on `pgroup-center-overview`/`noncentral-prime-power` are pre-existing and non-blocking).
- Both files remain well under size caps.