### PR TITLE
research(pythagorean-theorem-oq-01): the inverse (reciprocal) Pythagorean theorem [UNVERIFIED]

### DIFF
--- a/proofs/Proofs/PythagoreanTheoremOQ01.lean
+++ b/proofs/Proofs/PythagoreanTheoremOQ01.lean
@@ -312,6 +312,38 @@ theorem triArea_hypotenuse_eq_legs (hperp : ⟪A - C, B - C⟫ = (0 : ℝ)) :
   field_simp
   ring
 
+include hAB in
+/-- **The inverse (reciprocal) Pythagorean theorem.**  For a right angle at `C` with
+non-degenerate legs (`A ≠ C`, `B ≠ C`), the *reciprocals of the squares* of the two legs
+sum to the reciprocal of the square of the altitude `|CH|` dropped onto the hypotenuse:
+
+  `1 / |CH|²  =  1 / |CA|²  +  1 / |CB|²`.
+
+This is the elegant "upside-down" companion of Pythagoras `|CA|² + |CB|² = |CB'|²`: whereas
+Pythagoras adds the leg squares to the hypotenuse square, the inverse theorem adds their
+*reciprocal* squares to the reciprocal altitude square.  It follows immediately from the two
+altitude facts already proved here: `altitude_length` gives `|CH| = |CA|·|CB| / |AB|`, so
+`1/|CH|² = |AB|² / (|CA|²·|CB|²)`, and `pythagorean_via_altitude` rewrites the numerator
+`|AB|² = |CA|² + |CB|²`, splitting the single fraction into `1/|CB|² + 1/|CA|²`. -/
+theorem inverse_pythagorean (hAC : A ≠ C) (hBC : B ≠ C)
+    (hperp : ⟪A - C, B - C⟫ = (0 : ℝ)) :
+    1 / ‖C - altitudeFoot A B C‖ ^ 2
+      = 1 / ‖A - C‖ ^ 2 + 1 / ‖B - C‖ ^ 2 := by
+  have hcA : ‖A - C‖ ≠ 0 := by
+    have : A - C ≠ 0 := sub_ne_zero.mpr hAC
+    simpa using norm_ne_zero_iff.mpr this
+  have hcB : ‖B - C‖ ≠ 0 := by
+    have : B - C ≠ 0 := sub_ne_zero.mpr hBC
+    simpa using norm_ne_zero_iff.mpr this
+  have hlen := altitude_length A B C hAB hperp
+  have hpy := pythagorean_via_altitude A B C hAB hperp
+  have hCH2 : ‖C - altitudeFoot A B C‖ ^ 2
+      = ‖A - C‖ ^ 2 * ‖B - C‖ ^ 2 / ‖A - B‖ ^ 2 := by
+    rw [hlen, div_pow, mul_pow]
+  rw [hCH2, ← hpy, one_div_div]
+  field_simp
+  ring
+
 end Geometric
 
 -- ============================================================

--- a/src/data/proofs/pythagorean-theorem-oq-01/meta.json
+++ b/src/data/proofs/pythagorean-theorem-oq-01/meta.json
@@ -26,8 +26,8 @@
     "dateAdded": "2026-07-09",
     "axiomCount": 0,
     "assumptions": "None. All theorems are fully machine-checked, depending only on propext, Classical.choice, and Quot.sound. Layer 3 works in a general real inner-product space; the right angle is supplied as the explicit hypothesis ⟪A − C, B − C⟫ = 0 and non-degeneracy as A ≠ B. Honesty note: once a Euclidean/inner-product model is fixed, the norm already encodes distance, so the one-line identity pythagorean_core (‖A−B‖² = ‖A−C‖² + ‖B−C‖²) is itself Pythagoras; Layer 3 does not claim foundational independence from it — its content is the verified geometric-mean/altitude decomposition. Layers 1 and 2 capture the parts of Einstein's reasoning genuinely independent of coordinates.",
-    "lineCount": 334,
-    "theoremCount": 13,
+    "lineCount": 366,
+    "theoremCount": 14,
     "definitionCount": 2,
     "originalContributions": [
       "einstein_pythagorean: the coordinate-free algebraic core of Einstein's proof — from areaWhole = k·h², areaA = k·cA², areaB = k·cB² and areaWhole = areaA + areaB with k ≠ 0, cancelling k gives cA² + cB² = h². This is the 'cancel the shape constant' step, verified with no geometry.",
@@ -74,9 +74,9 @@
   },
   "leanFile": {
     "namespace": "PythagoreanEinstein",
-    "lineCount": 334,
+    "lineCount": 366,
     "axiomCount": 0,
-    "theoremCount": 15,
+    "theoremCount": 16,
     "definitionCount": 2,
     "path": "Proofs/PythagoreanTheoremOQ01.lean",
     "imports": [


### PR DESCRIPTION
## Summary

Adds the **inverse (reciprocal) Pythagorean theorem** to the Einstein similar-triangles showcase (`PythagoreanTheoremOQ01.lean`). For a right angle at `C` with non-degenerate legs (`A ≠ C`, `B ≠ C`):

    1/|CH|² = 1/|CA|² + 1/|CB|²

where `|CH|` is the altitude dropped from the right-angle vertex `C` onto the hypotenuse `AB`. This is the elegant "upside-down" companion of Pythagoras: whereas Pythagoras sums the *leg squares* to the *hypotenuse square*, the inverse theorem sums the *reciprocal* leg squares to the *reciprocal altitude square*.

## Proof

Reuses the file's own altitude lemmas:
- `altitude_length` : `|CH| = |CA|·|CB| / |AB|`, so `1/|CH|² = |AB|² / (|CA|²·|CB|²)`;
- `pythagorean_via_altitude` : `|AB|² = |CA|² + |CB|²`, which splits the single fraction into `1/|CB|² + 1/|CA|²`.

Non-degeneracy `A ≠ C`, `B ≠ C` supplies the nonzero legs for the reciprocals. Axiom-free, no sorries.

## Meta sync

`lineCount` 334→366 (both the `meta` and `leanFile` blocks), `theoremCount` 13→14 (curated) / 15→16 (`leanFile` raw). `axiomCount` unchanged (0).

## Verification status

**UNVERIFIED.** The Lean docker image build is unavailable in this environment (containerd `meta.db` input/output error at image build). The proof was checked by hand against `altitude_length` / `pythagorean_via_altitude` and standard field arithmetic (`div_pow`, `mul_pow`, `one_div_div`, `field_simp`, `ring`). No new axioms or `sorry`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)