### PR TITLE
research(cayley-hamilton-cyclic-vector-all-fields-oq-02-oq-02): always-true commutant lower bound deg(minpoly) ≤ dim C(M) [UNVERIFIED]

### DIFF
--- a/proofs/Proofs/CayleyHamiltonCyclicVectorAllFieldsOQ02OQ02.lean
+++ b/proofs/Proofs/CayleyHamiltonCyclicVectorAllFieldsOQ02OQ02.lean
@@ -226,6 +226,29 @@ theorem finrank_centralizer_eq_natDegree_minpoly_iff_nonderogatory
   (centralizer_eq_adjoin_iff_finrank_eq_natDegree_minpoly M).symm.trans
     (centralizer_eq_adjoin_iff_nonderogatory M)
 
+/-- **The always-true commutant lower bound** `deg(minpoly K M) ≤ dim_K C(M)`.  Since
+    `K[M] ⊆ C(M)` (`adjoin_le_centralizer`) as `K`-submodules and `dim_K K[M] =
+    deg(minpoly K M)` (`finrank_adjoin_eq_natDegree_minpoly`), `Submodule.finrank_mono`
+    gives the inequality for *every* `M` — derogatory or not.  This is the elementary
+    lower half of the Frobenius commutant bound; equality `dim_K C(M) = deg(minpoly K M)`
+    is the nonderogatory case (`finrank_centralizer_eq_natDegree_minpoly_iff_nonderogatory`),
+    while the file's other bound `dim_K C(M) ≥ n` (Frobenius) is the sharper form available
+    only through the invariant-factor formula. -/
+theorem natDegree_minpoly_le_finrank_centralizer
+    (M : Matrix (Fin n) (Fin n) K) :
+    (minpoly K M).natDegree
+      ≤ Module.finrank K
+          ↥(Subalgebra.centralizer K ({M} : Set (Matrix (Fin n) (Fin n) K))) := by
+  have hlesub :
+      (Algebra.adjoin K ({M} : Set (Matrix (Fin n) (Fin n) K))).toSubmodule
+        ≤ (Subalgebra.centralizer K ({M} : Set (Matrix (Fin n) (Fin n) K))).toSubmodule := by
+    intro x hx
+    rw [Subalgebra.mem_toSubmodule] at hx ⊢
+    exact adjoin_le_centralizer M hx
+  have hmono := Submodule.finrank_mono hlesub
+  rwa [Subalgebra.finrank_toSubmodule, Subalgebra.finrank_toSubmodule,
+    CyclicCommutantConverse.finrank_adjoin_eq_natDegree_minpoly M] at hmono
+
 /-! ### Summary -/
 
 /-- **De Moivre / Cayley–Hamilton OQ-02-OQ-02 summary.**  For an `n × n` matrix


### PR DESCRIPTION
## Summary

Adds `natDegree_minpoly_le_finrank_centralizer` to `Proofs/CayleyHamiltonCyclicVectorAllFieldsOQ02OQ02.lean`: for **every** `n×n` matrix `M` over a field `K`,

```
deg(minpoly K M) ≤ dim_K C(M)
```

where `C(M)` is the centralizer. Since `K[M] ⊆ C(M)` (`adjoin_le_centralizer`) as `K`-submodules and `dim_K K[M] = deg(minpoly K M)` (`finrank_adjoin_eq_natDegree_minpoly`), `Submodule.finrank_mono` yields the bound — derogatory or not.

This is the elementary lower half of the Frobenius commutant bound, stated standalone. The file previously recorded only the inclusion `K[M] ⊆ C(M)` and the equality case (`dim C(M) = deg minpoly ⟺ nonderogatory`); the unconditional inequality was missing. The proof mirrors the file's existing `toSubmodule`/`finrank` plumbing.

## Verification
⚠️ **UNVERIFIED** — not machine-checked. Docker image build fails this session (`containerd ... meta.db: input/output error`). Proof reuses the exact submodule-inclusion + `Submodule.finrank_mono` + `Subalgebra.finrank_toSubmodule` idiom already present in the file.

No gallery `meta.json` references this companion Lean file, so no meta sync is required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)