### PR TITLE
research(erdos-378): elementary two-sided bounds on natural density + (0,1] localisation

### DIFF
--- a/proofs/Proofs/Erdos378Problem.lean
+++ b/proofs/Proofs/Erdos378Problem.lean
@@ -470,4 +470,55 @@ theorem erdos_378_answer (r : ℕ) :
   obtain ⟨d, hd_pos, hd_density⟩ := erdos_378_density_positive r
   exact ⟨d, hd_pos, ⟨d, hd_density⟩, hd_density⟩
 
+/-
+## Part VII: Elementary two-sided bounds on the natural density
+-/
+
+/-- **A natural density is nonnegative.**  The counting ratio
+`|S ∩ [0,N)| / N` is a ratio of nonnegative reals, so its limit `d` cannot be
+negative: were `d < 0`, taking `ε = −d > 0` past the convergence threshold would
+force the (nonnegative) ratio strictly below `0`.  Elementary, uses no axioms. -/
+theorem natDensity_nonneg {S : Set ℕ} {d : ℝ} (h : NaturalDensity S d) : 0 ≤ d := by
+  by_contra hd
+  push_neg at hd
+  obtain ⟨N₀, hN₀⟩ := h (-d) (by linarith)
+  set N := max N₀ 1 with hNdef
+  have hb := hN₀ N (le_max_left _ _)
+  have hratio : 0 ≤ ((S ∩ Set.Iio N).ncard : ℝ) / (N : ℝ) :=
+    div_nonneg (Nat.cast_nonneg _) (Nat.cast_nonneg _)
+  rw [abs_lt] at hb
+  linarith [hb.2, hratio]
+
+/-- **A natural density is at most one.**  Since `S ∩ [0,N) ⊆ [0,N)` has at most
+`N` elements, the counting ratio is `≤ 1`, so its limit `d` cannot exceed `1`:
+were `1 < d`, taking `ε = d − 1 > 0` past the threshold would force the ratio
+strictly above `1`.  Elementary, uses no axioms. -/
+theorem natDensity_le_one {S : Set ℕ} {d : ℝ} (h : NaturalDensity S d) : d ≤ 1 := by
+  by_contra hd
+  push_neg at hd
+  obtain ⟨N₀, hN₀⟩ := h (d - 1) (by linarith)
+  set N := max N₀ 1 with hNdef
+  have hNpos : 0 < N := lt_of_lt_of_le Nat.zero_lt_one (le_max_right _ _)
+  have hNR : (0 : ℝ) < N := by exact_mod_cast hNpos
+  have hb := hN₀ N (le_max_left _ _)
+  have hcard : (S ∩ Set.Iio N).ncard ≤ N := by
+    calc (S ∩ Set.Iio N).ncard
+        ≤ (Set.Iio N).ncard :=
+          Set.ncard_le_ncard Set.inter_subset_right (Set.finite_Iio N)
+      _ = N := by rw [← Finset.coe_range, Set.ncard_coe_finset, Finset.card_range]
+  have hle : ((S ∩ Set.Iio N).ncard : ℝ) ≤ (N : ℝ) := by exact_mod_cast hcard
+  have hratio : ((S ∩ Set.Iio N).ncard : ℝ) / (N : ℝ) ≤ 1 := (div_le_one hNR).mpr hle
+  rw [abs_lt] at hb
+  linarith [hb.1, hratio]
+
+/-- **The Erdős #378 density lies in `(0, 1]`.**  Combining the positivity
+`erdos_378_density_positive` with the universal upper bound `natDensity_le_one`:
+for every threshold `r`, the density of the integers with at least `r` squarefree
+interior binomials exists and lies strictly above `0` and at most `1` — the sharp
+two-sided localisation of the answer to Erdős #378. -/
+theorem erdos_378_density_mem_Ioc (r : ℕ) :
+    ∃ d : ℝ, d ∈ Set.Ioc (0 : ℝ) 1 ∧ NaturalDensity (atLeastSquarefree r) d := by
+  obtain ⟨d, hd_pos, hd_density⟩ := erdos_378_density_positive r
+  exact ⟨d, ⟨hd_pos, natDensity_le_one hd_density⟩, hd_density⟩
+
 end Erdos378

--- a/src/data/proofs/erdos-378/meta.json
+++ b/src/data/proofs/erdos-378/meta.json
@@ -64,7 +64,7 @@
       "erdos_378, erdos_378_answer (no sorries): combined resolution of both questions"
     ],
     "axiomCount": 2,
-    "lineCount": 473,
+    "lineCount": 524,
     "assumptions": "2 axioms, both isolating the deep analytic content of Granville-Ramaré (1996): granville_ramare_density_exists (the density η_m of n with exactly 2m+2 squarefree binomials exists) and complement_density (the set of n with fewer than r squarefree binomials has density Σ_{0≤m≤(r-1)/2} η_m, which is < 1). 0 sorries. All other results, including the resolution of both questions and the parity theorems squarefreeCount_even_of_odd (odd rows have an even count) and squarefreeCount_odd_iff_central_squarefree (an even row has an odd count iff its central binomial C(n,n/2) is squarefree), are fully machine-checked (depend only on propext/Classical.choice/Quot.sound).",
     "theoremCount": 17,
     "definitionCount": 8,


### PR DESCRIPTION
## Summary

Adds the missing **foundational bounds** to the natural-density framework in `Erdos378Problem.lean` (new Part VII), plus a capstone that sharpens the Erdős #378 answer.

## New theorems (3)

- **`natDensity_nonneg`** — any `NaturalDensity S d` has `0 ≤ d`. The counting ratio `|S ∩ [0,N)|/N` is nonnegative, so its limit cannot be negative (`ε = −d` contradiction). Axiom-free.
- **`natDensity_le_one`** — any `NaturalDensity S d` has `d ≤ 1`. Since `S ∩ [0,N) ⊆ [0,N)` gives `ncard ≤ N`, the ratio is `≤ 1`, so the limit cannot exceed `1` (`ε = d−1` contradiction). Axiom-free.
- **`erdos_378_density_mem_Ioc`** — the Erdős #378 density lies in `(0, 1]`, combining `erdos_378_density_positive` with the new `natDensity_le_one`: the sharp two-sided localisation of the answer.

## Context

The density framework previously had only `natDensity_compl` and `naturalDensity_unique` — no bounds lemma. These two universal bounds (`0 ≤ d ≤ 1`) are the standard sanity facts about natural density and complete the elementary toolkit; the capstone applies them to the resolved problem.

## Verification

- 0 sorry / 0 new axioms. Standard Mathlib API confirmed in the pin: `div_le_one` (`Algebra/Order/Field/Basic.lean:50`), `Set.ncard_le_ncard` (`Data/Set/Card.lean:599`).
- ⚠️ **UNVERIFIED**: Docker build infrastructure is down (containerd `meta.db` input/output error); `docker-build.sh` could not run.
- Placed at the **end of the file**, disjoint from the open PR #35186 (parity section) hunk — the 3-way merge stays clean.
- Synced the `wc -l` meta `lineCount` 473 → 524; left the already-drifted secondary count (457, a known py-vs-wc counter mismatch on this file) for the mechanic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)