### PR TITLE
research(erdos-1008-oq-02-oq-02): commonNbrs API — symmetry, membership, self

### DIFF
--- a/proofs/Proofs/Erdos1008OQ02OQ02.lean
+++ b/proofs/Proofs/Erdos1008OQ02OQ02.lean
@@ -185,6 +185,32 @@ variable {V : Type*} [Fintype V] [DecidableEq V]
 def commonNbrs (G : SimpleGraph V) [DecidableRel G.Adj] (a b : V) : Finset V :=
   G.neighborFinset a ∩ G.neighborFinset b
 
+/-- Membership in `commonNbrs`: `v` is a common neighbour of `a` and `b` iff it is
+    adjacent to both. -/
+theorem mem_commonNbrs (G : SimpleGraph V) [DecidableRel G.Adj] {a b v : V} :
+    v ∈ commonNbrs G a b ↔ G.Adj a v ∧ G.Adj b v := by
+  simp only [commonNbrs, Finset.mem_inter, SimpleGraph.mem_neighborFinset]
+
+/-- **Symmetry of common neighbours.** `commonNbrs G a b = commonNbrs G b a`:
+    the set of common neighbours does not depend on the order of the pair, since
+    it is the (commutative) intersection of the two neighbour sets.  The `K_{2,t}`
+    codegree hypothesis `(commonNbrs G a b).card ≤ κ` is therefore symmetric in
+    `a, b`, matching the unordered nature of the `K_{2,t}` obstruction. -/
+theorem commonNbrs_comm (G : SimpleGraph V) [DecidableRel G.Adj] (a b : V) :
+    commonNbrs G a b = commonNbrs G b a := by
+  simp only [commonNbrs, Finset.inter_comm]
+
+/-- The common-neighbour count is symmetric in the two vertices. -/
+theorem commonNbrs_card_comm (G : SimpleGraph V) [DecidableRel G.Adj] (a b : V) :
+    (commonNbrs G a b).card = (commonNbrs G b a).card := by
+  rw [commonNbrs_comm]
+
+/-- A vertex's common neighbours with itself are exactly its neighbours:
+    `commonNbrs G a a = G.neighborFinset a`. -/
+theorem commonNbrs_self (G : SimpleGraph V) [DecidableRel G.Adj] (a : V) :
+    commonNbrs G a a = G.neighborFinset a := by
+  simp only [commonNbrs, Finset.inter_self]
+
 /-- `s.offDiag.card = s.card·(s.card-1)` (self-contained port). -/
 private theorem finset_card_offDiag {α : Type*} [DecidableEq α] (s : Finset α) :
     s.offDiag.card = s.card * (s.card - 1) := by


### PR DESCRIPTION
## Summary

The `K_{2,t}`/KST file defines `commonNbrs G a b := N(a) ∩ N(b)` and uses it throughout the codegree / cherry-counting argument, but never establishes basic API for it. This adds the missing structural lemmas:

- `mem_commonNbrs` — `v ∈ commonNbrs G a b ↔ G.Adj a v ∧ G.Adj b v`.
- `commonNbrs_comm` — `commonNbrs G a b = commonNbrs G b a` (the codegree hypothesis `(commonNbrs G a b).card ≤ κ` is symmetric in `a,b`, matching the unordered nature of the `K_{2,t}` obstruction).
- `commonNbrs_card_comm` — symmetry of the common-neighbour count.
- `commonNbrs_self` — `commonNbrs G a a = G.neighborFinset a`.

Purely definitional graph API; the `simp` sets mirror usage already present in the file.

## Collision-avoidance

Two open PRs (#37052, #37025) work the **leading-order `n^{3/2}` analytic edge bounds**; these lemmas are disjoint **graph-theoretic** API. The file's `research-json` `leanFiles` lineCount is stale and already being modified by those PRs, so it is **deliberately left untouched** here to avoid merge conflicts — this is a Lean-only change (no gallery dir for this slug).

## Verification

⚠️ **UNVERIFIED** — Docker build unavailable this session (containerd `meta.db` I/O error). Proof checked by inspection; the `simp` lemmas (`Finset.mem_inter`/`inter_comm`/`inter_self`, `SimpleGraph.mem_neighborFinset`) are used identically elsewhere in the same file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)