### PR TITLE
audit(erdos-908, erdos-901, erdos-902): re-verified CLEAN, bump tracker

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -17270,9 +17270,9 @@
       "result": "clean"
     },
     "erdos-901": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T00:15:39Z",
+      "agentId": "auditor-agent",
+      "auditCount": 4,
+      "lastAudited": "2026-07-10T18:05:00Z",
       "result": "clean"
     },
     "erdos-902": {
@@ -17312,9 +17312,9 @@
       "result": "clean"
     },
     "erdos-908": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T00:14:54Z",
+      "agentId": "auditor-agent",
+      "auditCount": 4,
+      "lastAudited": "2026-07-10T18:00:00Z",
       "result": "clean"
     },
     "erdos-909": {
@@ -29783,5 +29783,5 @@
     }
   },
   "version": 1,
-  "lastUpdated": "2026-07-10T08:05:00Z"
+  "lastUpdated": "2026-07-10T18:05:00Z"
 }

--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -17276,9 +17276,9 @@
       "result": "clean"
     },
     "erdos-902": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T00:15:39Z",
+      "agentId": "auditor-agent",
+      "auditCount": 4,
+      "lastAudited": "2026-07-10T18:10:00Z",
       "result": "clean"
     },
     "erdos-903": {
@@ -29783,5 +29783,5 @@
     }
   },
   "version": 1,
-  "lastUpdated": "2026-07-10T18:05:00Z"
+  "lastUpdated": "2026-07-10T18:10:00Z"
 }


### PR DESCRIPTION
## Gallery integrity re-audit — 3 entries CLEAN

Tracker `lastAudited` bumps lost to concurrent `git reset --hard` races. No content changes; tracker only.

### erdos-908 — Functions with Measurable Differences — **CLEAN**
1 axiom `laczkovich_decomposition` (substantive, disclosed by name); 0 sorries/native_decide/True-stubs; 7 thm / 5 def / 195 lines all match. Summary theorems honestly re-export axiom + 2 proved special cases. Prior fix #37225 already on main.

### erdos-901 — Property B and Hypergraph Coloring — **CLEAN**
19 sorries, 0 axioms — matches meta exactly (19 thm / 10 def / 238 lines). `formalized`/`wip` correct; proofStrategy discloses "The file has 19 sorries." All 15 named contribution decls exist; no overclaim.

### erdos-902 — Tournament Domination — **CLEAN**
6 axioms (all named in `assumptions`, all substantive bound statements), 0 sorries/native_decide/True-stubs; 2 thm / 8 def / 146 lines match. `erdos_902` summary honestly conjoins two disclosed axioms; `asymptotic_gap` genuinely derives from axioms. `axiomatized`/`axiom` correct for OPEN problem.

---
Discovered during gallery integrity audit.