### PR TITLE
research(basel-problem-oq-01-oq-02): weighted finite products of even zeta values are transcendental [UNVERIFIED]

### DIFF
--- a/proofs/Proofs/BaselProblemOQ01OQ02.lean
+++ b/proofs/Proofs/BaselProblemOQ01OQ02.lean
@@ -379,6 +379,56 @@ theorem zeta_even_finset_prod_transcendental {ι : Type*} (f : ι → ℕ) (s : 
   have : 0 < ∑ i ∈ s, f i := Finset.sum_pos hf hs
   omega
 
+/-- **Weighted finite-product structure for even zeta values — axiom-free.**  For arbitrary
+    finite families of positive indices `(f i)` and positive exponents `(g i)` over `s`, the
+    weighted product `∏_{i∈s} ζ(2 f i)^(g i)` is a *single* nonzero-rational multiple of a
+    *single* power of π, whose exponent is the doubled weighted sum:
+    `∏_{i∈s} ζ(2 f i)^(g i) = (∏_{i∈s} q_{f i}^{g i}) · π^(2 ∑_{i∈s} f i · g i)`.
+    This is the common generalisation of *both* `zeta_even_pow_eq_rat_mul_pi_pow` (a single index
+    raised to a power — the case `s = {i}`) and `zeta_even_finset_prod_eq_rat_mul_pi_pow` (a product
+    with all exponents `1`): the class `ℚ∖{0} · π^(even)` is closed under arbitrary finite
+    products of *powers*, i.e. under every monomial in the even zeta values.  Proved by induction
+    on `s`, feeding each factor through the power identity `zeta_even_pow_eq_rat_mul_pi_pow` and
+    collecting the π-powers with `pow_add`.  Uses only Euler's closed form, **no**
+    `hermite_lindemann`. -/
+theorem zeta_even_weighted_prod_eq_rat_mul_pi_pow {ι : Type*} (f g : ι → ℕ) (s : Finset ι)
+    (hf : ∀ i ∈ s, 0 < f i) (hg : ∀ i ∈ s, 0 < g i) :
+    ∃ q : ℚ, q ≠ 0 ∧
+      (∏ i ∈ s, (∑' k : ℕ, 1 / (k : ℝ) ^ (2 * f i)) ^ g i)
+        = (q : ℝ) * π ^ (2 * ∑ i ∈ s, f i * g i) := by
+  classical
+  induction s using Finset.induction_on with
+  | empty => exact ⟨1, one_ne_zero, by simp⟩
+  | @insert a s ha ih =>
+      obtain ⟨q, hq, hqeq⟩ :=
+        ih (fun i hi => hf i (Finset.mem_insert_of_mem hi))
+           (fun i hi => hg i (Finset.mem_insert_of_mem hi))
+      obtain ⟨qa, hqa, hqaeq⟩ :=
+        zeta_even_pow_eq_rat_mul_pi_pow (f a) (g a)
+          (hf a (Finset.mem_insert_self a s)) (hg a (Finset.mem_insert_self a s))
+      refine ⟨qa ^ g a * q, mul_ne_zero (pow_ne_zero _ hqa) hq, ?_⟩
+      rw [Finset.prod_insert ha, Finset.sum_insert ha, hqeq, hqaeq, mul_add, pow_add]
+      push_cast; ring
+
+/-- **Arbitrary finite products of powers of even zeta values are transcendental over ℚ.**
+
+    For nonempty finite families of positive indices `(f i)` and positive exponents `(g i)`, the
+    monomial `∏_{i∈s} ζ(2 f i)^(g i)` is a nonzero rational multiple of a *positive* even power of π
+    (`2 ∑ f i · g i ≥ 2`), hence transcendental over ℚ.  The common companion of
+    `zeta_even_pow_transcendental` and `zeta_even_finset_prod_transcendental`: no finite monomial in
+    the even zeta values can be algebraic.
+
+    **Assumption:** `hermite_lindemann` (transcendence of π). -/
+theorem zeta_even_weighted_prod_transcendental {ι : Type*} (f g : ι → ℕ) (s : Finset ι)
+    (hs : s.Nonempty) (hf : ∀ i ∈ s, 0 < f i) (hg : ∀ i ∈ s, 0 < g i) :
+    Transcendental ℚ (∏ i ∈ s, (∑' k : ℕ, 1 / (k : ℝ) ^ (2 * f i)) ^ g i) := by
+  obtain ⟨q, hq, heq⟩ := zeta_even_weighted_prod_eq_rat_mul_pi_pow f g s hf hg
+  rw [heq]
+  refine transcendental_ratCast_mul (pi_transcendental_over_rationals.pow ?_) hq
+  have hpos : 0 < ∑ i ∈ s, f i * g i :=
+    Finset.sum_pos (fun i hi => Nat.mul_pos (hf i hi) (hg i hi)) hs
+  omega
+
 /-!
 ## The open odd case (documentation only)
 

--- a/src/data/proofs/basel-problem-oq-01-oq-02/meta.json
+++ b/src/data/proofs/basel-problem-oq-01-oq-02/meta.json
@@ -61,10 +61,10 @@
       "zeta_even_finset_prod_transcendental: any finite product ∏_{i∈s} ζ(2 f i) over a nonempty family of positive indices is transcendental over ℚ (its π-exponent 2∑ f i ≥ 2 is positive) — the Finset companion of zeta_even_product_transcendental, showing no finite product of even zeta values can be algebraic"
     ],
     "dateAdded": "2026-07-02",
-    "lineCount": 391,
+    "lineCount": 441,
     "assumptions": "Depends on the axiom hermite_lindemann (Lindemann–Weierstrass theorem, giving transcendence of π), imported via Proofs.PiTranscendental. Mathlib does not yet contain a complete Lindemann–Weierstrass development, and irrationality of π^(2n) provably requires transcendence of π (irrational_pi alone is insufficient, as irrationality does not lift through powers). Everything else is machine-checked with 0 sorries.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 23,
+    "theoremCount": 25,
     "definitionCount": 0
   },
   "overview": {
@@ -162,9 +162,9 @@
       "Real"
     ],
     "namespace": "BaselProblemOQ01OQ02",
-    "lineCount": 391,
+    "lineCount": 441,
     "axiomCount": 0,
-    "theoremCount": 23,
+    "theoremCount": 25,
     "definitionCount": 0,
     "path": "Proofs/BaselProblemOQ01OQ02.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

The file already exhibits the even-zeta transcendence algebra as closed under **pairwise products**, **powers**, **nonzero-rational scaling**, and **unweighted finite products** — each with an axiom-free `… = q·π^(even)` structural identity plus a transcendence corollary. The remaining common generalization is the **weighted finite product** — an arbitrary monomial in the even zeta values.

## New results

- **`zeta_even_weighted_prod_eq_rat_mul_pi_pow`** (axiom-free) —
  `∏_{i∈s} ζ(2 f i)^(g i) = (∏_{i∈s} q_{f i}^{g i}) · π^(2 ∑_{i∈s} f i·g i)`.
  This simultaneously subsumes:
  - `zeta_even_pow_eq_rat_mul_pi_pow` (single index raised to a power — the case `s = {i}`), and
  - `zeta_even_finset_prod_eq_rat_mul_pi_pow` (product with all exponents `1`).

  So the class `ℚ∖{0} · π^(even)` is closed under **every finite monomial** in the even zeta values, not just products or powers separately. Proved by `Finset.induction_on`, feeding each factor through the power identity and collecting π-powers with `pow_add` — uses only Euler's closed form, no `hermite_lindemann`.
- **`zeta_even_weighted_prod_transcendental`** — for nonempty `s` with positive `f`, `g`, the monomial is a nonzero-rational multiple of a *positive* even power of π (`2 ∑ f i·g i ≥ 2`), hence transcendental over ℚ. Common companion of `zeta_even_pow_transcendental` and `zeta_even_finset_prod_transcendental`. **Assumption:** `hermite_lindemann` (transcendence of π).

## Verification

⚠️ **UNVERIFIED** — Docker Lean image-build is down (`containerd meta.db input/output error`); `docker-build.sh` could not run. The proofs mirror the already-verified `zeta_even_finset_prod_eq_rat_mul_pi_pow` induction line-for-line, substituting the power identity `zeta_even_pow_eq_rat_mul_pi_pow` for the single-value `zeta_even_eq_rat_mul_pi_pow`. No new axioms, no `sorry`. Rebased onto current `origin/main` (no drift; baseline lineCount 391 matches). `meta.json`: `lineCount` 391→441, `theoremCount` 23→25 (both copies).

🤖 Generated with [Claude Code](https://claude.com/claude-code)