### PR TITLE
research(erdos-703): sharpen T(n,r) upper bound to 2^n − C(n,r)

### DIFF
--- a/proofs/Proofs/Erdos703Problem.lean
+++ b/proofs/Proofs/Erdos703Problem.lean
@@ -408,6 +408,50 @@ theorem T_le_pow (n r : ℕ) : T n r ≤ 2 ^ n := by
     _ = 2 ^ n := by rw [Finset.card_powerset, Finset.card_range]
 
 /--
+**Sharpened upper bound `T(n,r) ≤ 2ⁿ − C(n,r)`.**
+An `r`-avoiding family cannot contain *any* set `A` of size exactly `r`: the
+self-pair `A, A` meets in `|A ∩ A| = |A| = r`, which `avoidsRIntersection r`
+forbids. Hence every `r`-avoiding family embeds in the powerset with all
+`C(n,r)` sets of size `r` removed, of size `2ⁿ − C(n,r)`. This strictly sharpens
+`T_le_pow` and is tight at the diagonal `r = n`, where `C(n,n) = 1` recovers the
+exact value `T(n,n) = 2ⁿ − 1` (`T_n_n`).
+-/
+theorem T_le_pow_sub_choose (n r : ℕ) : T n r ≤ 2 ^ n - n.choose r := by
+  unfold T
+  apply Finset.sup_le
+  intro F hF
+  rw [Finset.mem_filter, Finset.mem_powerset] at hF
+  obtain ⟨hFsub, hFavoid⟩ := hF
+  -- No set of size `r` can belong to an `r`-avoiding family (self-intersection).
+  have hsub : F ⊆ (Finset.range n).powerset.filter (fun A => ¬ A.card = r) := by
+    intro A hA
+    rw [Finset.mem_filter]
+    refine ⟨hFsub hA, ?_⟩
+    intro hcard
+    exact hFavoid A A hA hA (by rw [Finset.inter_self]; exact hcard)
+  -- Count the complement of the `r`-element subsets inside the powerset.
+  have hcount : ((Finset.range n).powerset.filter (fun A => ¬ A.card = r)).card
+      = 2 ^ n - n.choose r := by
+    rw [Finset.filter_not, Finset.card_sdiff_of_subset (Finset.filter_subset _ _),
+      Finset.card_powerset, ← Finset.powersetCard_eq_filter, Finset.card_powersetCard]
+    simp [Finset.card_range]
+  calc F.card ≤ ((Finset.range n).powerset.filter (fun A => ¬ A.card = r)).card :=
+        Finset.card_le_card hsub
+    _ = 2 ^ n - n.choose r := hcount
+
+/--
+**Uniform strict-improvement `T(n,r) ≤ 2ⁿ − 1` for `r ≤ n`.**
+Whenever `r ≤ n` there is at least one `r`-element subset of `[n]`
+(`C(n,r) ≥ 1`), so the sharpened bound `T_le_pow_sub_choose` already strictly
+beats the trivial ceiling `2ⁿ`: no `r`-avoiding family can be the full powerset.
+This holds across the entire non-degenerate range `0 ≤ r ≤ n`, and is attained
+at the diagonal `r = n`. -/
+theorem T_le_pow_sub_one {n r : ℕ} (h : r ≤ n) : T n r ≤ 2 ^ n - 1 := by
+  have hchoose : 1 ≤ n.choose r := Nat.choose_pos h
+  have hbound := T_le_pow_sub_choose n r
+  omega
+
+/--
 **`T` is monotone in the ground set.**
 If `m ≤ n` then any `r`-avoiding family of subsets of `[m]` is also an
 `r`-avoiding family of subsets of `[n]` (the predicate `avoidsRIntersection r`

--- a/src/data/proofs/erdos-703/meta.json
+++ b/src/data/proofs/erdos-703/meta.json
@@ -49,13 +49,14 @@
       "largeSetsFamily / largeSetsFamily_avoids_1 / largeSetsFamily_card_le_T: Frankl's (1977) r=1 lower-bound construction — the family of sets larger than (n+1)/2 is a valid 1-avoiding family, giving a verified lower bound |largeSetsFamily n| ≤ T(n,1)",
       "T_n_n: fully machine-checked exact diagonal value T(n,n) = 2^n − 1 — the maximal n-avoiding family is the powerset of [n] minus the single full set [n], since [n] with itself is the only pair of subsets meeting in exactly n elements. This is the third exactly-known boundary of T, alongside T(n,0) = 2^{n-1} and T(n,r) = 2^n for n < r.",
       "inter_card_eq_n_iff: the supporting characterization that for A, B ⊆ [n], |A ∩ B| = n iff A = B = [n]; the combinatorial core of the diagonal value.",
-      "Structural lemmas on T: T_le_pow (T(n,r) ≤ 2^n), T_mono_ground (monotone in the ground-set size n), one_le_T (positivity), and full_powerset_avoids_r_of_lt / T_eq_pow_of_lt (T(n,r) = 2^n whenever n < r); plus largeSetsFamily_subset_franklFurediOdd_one linking Frankl's r=1 family into the general Frankl-Füredi construction."
+      "Structural lemmas on T: T_le_pow (T(n,r) ≤ 2^n), T_mono_ground (monotone in the ground-set size n), one_le_T (positivity), and full_powerset_avoids_r_of_lt / T_eq_pow_of_lt (T(n,r) = 2^n whenever n < r); plus largeSetsFamily_subset_franklFurediOdd_one linking Frankl's r=1 family into the general Frankl-Füredi construction.",
+      "T_le_pow_sub_choose / T_le_pow_sub_one: sharpened upper bound T(n,r) ≤ 2^n − C(n,r), machine-checked. An r-avoiding family can contain no set of size exactly r (its self-pair A,A meets in |A| = r), so the family omits all C(n,r) subsets of size r, giving T(n,r) ≤ 2^n − C(n,r); for r ≤ n this yields the uniform strict improvement T(n,r) ≤ 2^n − 1 over the trivial ceiling, and it is tight at the diagonal r = n (C(n,n) = 1 recovers T(n,n) = 2^n − 1)."
     ],
     "axiomCount": 1,
-    "lineCount": 721,
+    "lineCount": 765,
     "assumptions": "1 axiom: frankl_rodl_1987 (the deep Frankl–Rödl 1987 exponential bound — the affirmative answer to the main question). 0 sorries: the trivial case T(n,0)=2^{n-1} is fully machine-checked (#print axioms T_n_0 = [propext, Classical.choice, Quot.sound]) via a complement-pairing upper bound and a star-family witness. The unused opaque chromaticNumber axiom was removed; the geometric chromatic-number consequence is recorded as prose only since infinite unit-distance chromatic numbers are not yet in Mathlib.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 29,
+    "theoremCount": 31,
     "definitionCount": 8
   },
   "crossReferences": [
@@ -182,9 +183,9 @@
       "Finset"
     ],
     "namespace": "Erdos703",
-    "lineCount": 721,
+    "lineCount": 765,
     "axiomCount": 1,
-    "theoremCount": 29,
+    "theoremCount": 31,
     "definitionCount": 8,
     "path": "Proofs/Erdos703Problem.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

Erdős #703 (Forbidden r-Intersection Families) is a saturated, verified gallery entry: 29 theorems, 1 axiom (`frankl_rodl_1987`, the deep open bound). This PR adds a clean, fully machine-checked **sharpening of the trivial upper bound** `T(n,r) ≤ 2ⁿ`.

## What's new

- **`T_le_pow_sub_choose : T n r ≤ 2 ^ n - n.choose r`** — an `r`-avoiding family cannot contain *any* set `A` of size exactly `r`, because the self-pair `A, A` meets in `|A ∩ A| = |A| = r`, which `avoidsRIntersection r` forbids. So every avoiding family omits all `C(n,r)` subsets of size `r`, embedding in `powerset \ {size-r sets}` of cardinality `2ⁿ − C(n,r)`.
- **`T_le_pow_sub_one : r ≤ n → T n r ≤ 2 ^ n - 1`** — since `C(n,r) ≥ 1` for `r ≤ n`, no `r`-avoiding family can be the full powerset; a uniform strict improvement over `2ⁿ` across the whole non-degenerate range.

The bound is **tight at the diagonal** `r = n`: `C(n,n) = 1` recovers the exact value `T(n,n) = 2ⁿ − 1` already proved in `T_n_n`. This addresses the entry's open question on further machine-checkable structural bounds for `T`.

## Verification

Both theorems are fully machine-checked:

```
#print axioms Erdos703.T_le_pow_sub_choose
  -- [propext, Classical.choice, Quot.sound]
#print axioms Erdos703.T_le_pow_sub_one
  -- [propext, Classical.choice, Quot.sound]
```

No dependence on `frankl_rodl_1987`, no `sorry`. Proof uses `Finset.powersetCard_eq_filter`, `Finset.card_powersetCard`, `Finset.filter_not`, `Finset.card_sdiff_of_subset`, `Nat.choose_pos`.

Docker build is down (containerd `meta.db` I/O error), so verified locally against cached Mathlib v4.26.0 oleans (`lean` on the pinned toolchain, exit 0, no errors).

## Meta

- `lineCount` 721 → 765, `theoremCount` 29 → 31 (both blocks synced).
- `axiomCount` unchanged (1 — the entry's status remains `axiomatized`).
- Added an `originalContributions` entry documenting the new bound.

🤖 Generated with [Claude Code](https://claude.com/claude-code)