### PR TITLE
research(erdos-1-oq-02): f(3)=4 small-case witness {1,2,4} [UNVERIFIED]

### DIFF
--- a/proofs/Proofs/Erdos1OQ02.lean
+++ b/proofs/Proofs/Erdos1OQ02.lean
@@ -563,6 +563,21 @@ theorem f_two_max :
   have hT' : T ∈ ({1, 2} : Finset ℕ).powerset := Finset.mem_powerset.mpr hT
   fin_cases hS' <;> fin_cases hT' <;> revert heq <;> decide
 
+/-- f(3) = 4: the set `{1, 2, 4}` has `2³ = 8` distinct subset sums (`0..7`, the
+    binary representations) with maximum element `4`.  This is the `n = 3` entry of
+    OEIS A005318, continuing the `f_zero`/`f_one`/`f_two_max` sequence: powers of two
+    are the simplest distinct-subset-sums witness, and `{1,2,4}` attains the known
+    minimal maximum `f(3) = 4`.  The `hasDistinctSubsetSums {1,2,4}` obligation is
+    discharged by enumerating the eight subsets (`fin_cases` over the powerset) and
+    deciding each subset-pair sum comparison, exactly as in `f_two_max`. -/
+theorem f_three :
+    ∃ (A : Finset ℕ), A.card = 3 ∧ hasDistinctSubsetSums A ∧ A.sup id = 4 := by
+  refine ⟨{1, 2, 4}, by decide, ?_, by decide⟩
+  intro S T hS hT heq
+  have hS' : S ∈ ({1, 2, 4} : Finset ℕ).powerset := Finset.mem_powerset.mpr hS
+  have hT' : T ∈ ({1, 2, 4} : Finset ℕ).powerset := Finset.mem_powerset.mpr hT
+  fin_cases hS' <;> fin_cases hT' <;> revert heq <;> decide
+
 /-! ## Conclusion
 
 The DFX framework is formalized with:

--- a/src/data/proofs/erdos-1-oq-02/meta.json
+++ b/src/data/proofs/erdos-1-oq-02/meta.json
@@ -211,9 +211,9 @@
       "Mathlib"
     ],
     "namespace": "Erdos1OQ02",
-    "lineCount": 591,
+    "lineCount": 606,
     "axiomCount": 0,
-    "theoremCount": 18,
+    "theoremCount": 19,
     "definitionCount": 0,
     "path": "Proofs/Erdos1OQ02.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

Extends the documented OEIS A005318 small-case sequence (`f_zero`, `f_one`, `f_two_max`) in `Proofs/Erdos1OQ02.lean` (Dubroff–Fox–Xu subset-sum lower bound) with the next entry:

- **`f_three`** — the set `{1, 2, 4}` has `card = 3`, distinct subset sums (`0..7`, the binary representations), and maximum element `4`, the known minimal maximum `f(3) = 4`.

Powers of two are the canonical distinct-subset-sums witness. The `hasDistinctSubsetSums {1,2,4}` obligation is discharged by enumerating the eight subsets (`fin_cases` over the powerset) and `decide`-ing each subset-pair sum comparison — the same proof structure the file already uses for `f_two_max`.

## Verification
⚠️ **UNVERIFIED** — not machine-checked. Docker image build fails this session (`containerd ... meta.db: input/output error`). The proof is a finite `decide` enumeration structurally identical to the existing `f_two_max`; the mathematical claim (binary set `{1,2,4}` has distinct subset sums) is elementary.

Meta `leanFile.lineCount` 591→606, `theoremCount` 18→19.

🤖 Generated with [Claude Code](https://claude.com/claude-code)