### PR TITLE
research(inverse-galois-oq-03): field-side degree corollaries for the Monster-realizing field

### DIFF
--- a/proofs/Proofs/InverseGaloisOQ03.lean
+++ b/proofs/Proofs/InverseGaloisOQ03.lean
@@ -306,7 +306,46 @@ theorem Monster_realizing_field_not_solvable :
     (solvable_of_solvable_injective (f := e.toMonoidHom) e.injective)
 
 -- ============================================================================
--- Part VI: The Sporadic Realizability Census
+-- Part VI: Field-Side Consequences of the Realizing Degree
+-- ============================================================================
+
+/-
+The realizability input pins `[K : ℚ] = |𝕄|` exactly (`Monster_realizing_field_finrank`).
+Every arithmetic fact we proved about `|𝕄|` in Part II therefore transports to the
+degree of Thompson's field. Two are recorded here as the field-side analogues of
+`Monster_card_factored` and `Monster_card_not_prime`.
+-/
+
+/-- Field-side analogue of `Monster_card_factored`: the Monster-realizing field's
+    degree over ℚ is the full 15-prime factorization of |𝕄|. -/
+theorem Monster_realizing_field_finrank_factored :
+    ∃ (K : Type) (_ : Field K) (_ : Algebra ℚ K) (_ : FiniteDimensional ℚ K)
+      (_ : IsGalois ℚ K),
+      Module.finrank ℚ K =
+        2 ^ 46 * 3 ^ 20 * 5 ^ 9 * 7 ^ 6 * 11 ^ 2 * 13 ^ 3 * 17 * 19 * 23 * 29 * 31 *
+          41 * 47 * 59 * 71 := by
+  obtain ⟨K, fK, aK, fdK, gK, hfr⟩ := Monster_realizing_field_finrank
+  refine ⟨K, fK, aK, fdK, gK, ?_⟩
+  rw [hfr]; norm_num
+
+/-- Field-side analogue of `Monster_card_not_prime`: the degree `[K : ℚ]` of the
+    Monster-realizing field is composite. In particular K/ℚ is not a prime-degree
+    (hence not a cyclic prime) extension — its Galois group is the non-abelian
+    simple 𝕄, consistent with `Monster_realizing_field_not_solvable`. -/
+theorem Monster_realizing_field_finrank_not_prime :
+    ∃ (K : Type) (_ : Field K) (_ : Algebra ℚ K) (_ : FiniteDimensional ℚ K)
+      (_ : IsGalois ℚ K), ¬ Nat.Prime (Module.finrank ℚ K) := by
+  obtain ⟨K, fK, aK, fdK, gK, hfr⟩ := Monster_realizing_field_finrank
+  refine ⟨K, fK, aK, fdK, gK, ?_⟩
+  rw [hfr]
+  intro h
+  have hdvd : 2 ∣ (808017424794512875886459904961710757005754368000000000 : ℕ) :=
+    ⟨404008712397256437943229952480855378502877184000000000, by norm_num⟩
+  have := h.eq_one_or_self_of_dvd 2 hdvd
+  omega
+
+-- ============================================================================
+-- Part VII: The Sporadic Realizability Census
 -- ============================================================================
 
 /-

--- a/src/data/proofs/inverse-galois-oq-03/meta.json
+++ b/src/data/proofs/inverse-galois-oq-03/meta.json
@@ -39,9 +39,9 @@
         "relationship": "Sister entry on the non-solvable frontier and the solvability divide"
       }
     ],
-    "lineCount": 322,
+    "lineCount": 361,
     "mathlib_version": "4.26.0",
-    "theoremCount": 16,
+    "theoremCount": 18,
     "definitionCount": 0,
     "additionalFiles": []
   },
@@ -145,10 +145,10 @@
   "sorries": 0,
   "leanFile": {
     "path": "Proofs/InverseGaloisOQ03.lean",
-    "lineCount": 322,
+    "lineCount": 361,
     "axiomCount": 6,
     "sorries": 0,
-    "theoremCount": 17,
+    "theoremCount": 19,
     "definitionCount": 0,
     "imports": [
       "Mathlib",


### PR DESCRIPTION
## Summary

Adds two field-side corollaries to `InverseGaloisOQ03.lean` (the Monster 𝕄 as a resolved sporadic case of the Inverse Galois Problem), forming a new **Part VI**.

The entry already proved:
- **Part II** — order facts about |𝕄|: the 15-prime factorization (`Monster_card_factored`) and non-primality (`Monster_card_not_prime`).
- **Part V** — Thompson's realizability, and that the realizing field satisfies `[K:ℚ] = |𝕄|` exactly (`Monster_realizing_field_finrank`).

But it never transported the Part II arithmetic to the field degree. These two theorems bridge Part II ↔ Part V at the field level:

| Theorem | Statement |
|---|---|
| `Monster_realizing_field_finrank_factored` | `∃ K, [K:ℚ] = 2⁴⁶·3²⁰·5⁹·7⁶·11²·13³·17·19·23·29·31·41·47·59·71` |
| `Monster_realizing_field_finrank_not_prime` | `∃ K, ¬ Nat.Prime [K:ℚ]` — the degree is composite (field-side analogue of `Monster_card_not_prime`) |

Both derive from the existing `Monster_realizing_field_finrank` by `rw` + `norm_num` / `omega`, reusing the exact tactic blocks already used for `Monster_card_factored` and `Monster_card_not_prime`.

## Assumptions

No new axioms — `axiomCount` stays **6** (the Monster axiomatization + Thompson's realizability). Status remains `axiomatized`.

## Verification

Both new theorems typecheck against real Mathlib oleans (elan `lean v4.26.0`, cached Mathlib build) in isolation. Full-file docker build was unavailable (containerd `meta.db` I/O error); the upstream `Monster_realizing_field_finrank` they depend on is pre-existing and unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)