### PR TITLE
research(sylow-theorem-oq-04-oq-03): trivial abelianizations of SL(2,p) and PSL(2,p) for p≥5 [UNVERIFIED]

### DIFF
--- a/proofs/Proofs/SylowTheoremOQ04OQ03.lean
+++ b/proofs/Proofs/SylowTheoremOQ04OQ03.lean
@@ -941,4 +941,38 @@ theorem not_isSolvable_PSL (hp : 5 ≤ p) :
       (by rw [QuotientGroup.ker_mk']; exact (Subgroup.range_subtype _).ge)
   exact not_isSolvable hp this
 
+/-!
+## Triviality of the abelianizations for `p ≥ 5`
+
+Perfectness (`commutator_eq_top`, `commutator_PSL_eq_top`) says the derived subgroup is
+the whole group.  In the standard `G^{ab} = 1` language this is the statement that the
+*abelianization* — the universal abelian quotient `G ⧸ ⁅G, G⁆` — is trivial.  Recording
+it in this form makes the perfectness of both the cover `SL(2, p)` and the target
+`PSL(2, p)` available as `Subsingleton (Abelianization …)`, the shape most facts about
+abelian quotients consume: every homomorphism from a perfect group to an abelian group is
+trivial, and the first integral homology `H₁(G; ℤ) ≅ G^{ab}` vanishes.
+-/
+
+/-- **The abelianization of `SL(2, p)` is trivial for `p ≥ 5`.**  Since
+`Abelianization G = G ⧸ commutator G` and `SL(2, p)` is perfect (`commutator_eq_top`), the
+abelianization is a quotient by the whole group, hence a subsingleton.  Equivalently, every
+group homomorphism from `SL(2, p)` into an abelian group is trivial. -/
+theorem subsingleton_abelianization (hp : 5 ≤ p) :
+    Subsingleton (Abelianization (Matrix.SpecialLinearGroup (Fin 2) (ZMod p))) := by
+  show Subsingleton (_ ⧸ commutator (Matrix.SpecialLinearGroup (Fin 2) (ZMod p)))
+  rw [commutator_eq_top hp]
+  exact QuotientGroup.subsingleton_quotient_top
+
+/-- **The abelianization of `PSL(2, p)` is trivial for `p ≥ 5`.**  The target group is
+perfect (`commutator_PSL_eq_top`), so its abelianization `PSL(2, p) ⧸ commutator` is a
+quotient by the whole group and therefore a subsingleton.  This is the `G^{ab} = 1` form of
+perfectness for the simple-group candidate itself. -/
+theorem subsingleton_abelianization_PSL (hp : 5 ≤ p) :
+    Subsingleton
+      (Abelianization (Matrix.ProjectiveSpecialLinearGroup (Fin 2) (ZMod p))) := by
+  show Subsingleton
+    (_ ⧸ commutator (Matrix.ProjectiveSpecialLinearGroup (Fin 2) (ZMod p)))
+  rw [commutator_PSL_eq_top hp]
+  exact QuotientGroup.subsingleton_quotient_top
+
 end SylowOQ04OQ03

--- a/src/data/proofs/sylow-theorem-oq-04-oq-03/meta.json
+++ b/src/data/proofs/sylow-theorem-oq-04-oq-03/meta.json
@@ -254,12 +254,12 @@
     }
   ],
   "leanFile": {
-    "lineCount": 944,
+    "lineCount": 978,
     "path": "Proofs/SylowTheoremOQ04OQ03.lean",
     "axiomCount": 0,
     "sorries": 0,
     "definitionCount": 8,
-    "theoremCount": 46
+    "theoremCount": 48
   },
   "sorries": 0
 }

--- a/src/data/research/problems/sylow-theorem-oq-04-oq-03.json
+++ b/src/data/research/problems/sylow-theorem-oq-04-oq-03.json
@@ -86,7 +86,8 @@
       "unipotent_isCommutator_of_isUnit (SylowTheoremOQ04OQ03.lean): a²−1 a unit ⟹ every u(s) is a T–U commutator, VERIFIED 0/0",
       "exists_unipotent_isCommutator (SylowTheoremOQ04OQ03.lean): p≥5 ⟹ every u(s) is a commutator [diag(2),u(t)] (perfectness input), VERIFIED 0/0",
       "unipotentUpper_inv (SylowTheoremOQ04OQ03.lean): (u(t))⁻¹ = u(−t) helper, VERIFIED 0/0",
-      "closure_rootGroups_eq_top + weylW_eq_root_word + torusDiag_eq_root_word + mem_closure_of_lowerLeft_ne_zero + rootGroups + membership lemmas + lowerUnipotent_mul/_zero (SylowTheoremOQ04OQ03.lean, +~194 lines): Bruhat generation ⟨U,U⁻⟩ = SL(2,p). [UNVERIFIED — Docker daemon I/O corruption blocked the build; mathematically hand-checked, tactics mirror the file's verified matrix-identity idiom.]"
+      "closure_rootGroups_eq_top + weylW_eq_root_word + torusDiag_eq_root_word + mem_closure_of_lowerLeft_ne_zero + rootGroups + membership lemmas + lowerUnipotent_mul/_zero (SylowTheoremOQ04OQ03.lean, +~194 lines): Bruhat generation ⟨U,U⁻⟩ = SL(2,p). [UNVERIFIED — Docker daemon I/O corruption blocked the build; mathematically hand-checked, tactics mirror the file's verified matrix-identity idiom.]",
+      "subsingleton_abelianization + subsingleton_abelianization_PSL (SylowTheoremOQ04OQ03.lean): the G^{ab}=1 form of perfectness — Abelianization of SL(2,p) and of PSL(2,p) is a Subsingleton for p≥5, via commutator_eq_top / commutator_PSL_eq_top + QuotientGroup.subsingleton_quotient_top. [UNVERIFIED — Docker daemon down (containerd blob I/O); the 3-line proof pattern was independently confirmed to elaborate against the local pinned Mathlib on a generic perfect group.]"
     ]
   },
   "leanFiles": [
@@ -236,8 +237,8 @@
     {
       "path": "Proofs/SylowTheoremOQ04OQ03.lean",
       "filename": "SylowTheoremOQ04OQ03.lean",
-      "lineCount": 885,
-      "theoremCount": 36,
+      "lineCount": 978,
+      "theoremCount": 48,
       "axiomCount": 0,
       "defCount": 8,
       "sorryCount": 0,


### PR DESCRIPTION
## Summary

Adds the standard **`G^ab = 1`** form of the already-verified perfectness results in `SylowTheoremOQ04OQ03.lean`, for both the cover and the target simple-group candidate:

- `subsingleton_abelianization` — `Subsingleton (Abelianization (SL(2,p)))` for `p ≥ 5`
- `subsingleton_abelianization_PSL` — `Subsingleton (Abelianization (PSL(2,p)))` for `p ≥ 5`

Since `Abelianization G = G ⧸ commutator G`, each is a one-line consequence of the file's existing verified perfectness lemmas (`commutator_eq_top`, `commutator_PSL_eq_top`) via `QuotientGroup.subsingleton_quotient_top`:

```lean
theorem subsingleton_abelianization (hp : 5 ≤ p) :
    Subsingleton (Abelianization (Matrix.SpecialLinearGroup (Fin 2) (ZMod p))) := by
  show Subsingleton (_ ⧸ commutator (Matrix.SpecialLinearGroup (Fin 2) (ZMod p)))
  rw [commutator_eq_top hp]
  exact QuotientGroup.subsingleton_quotient_top
```

## Why it matters

This records perfectness in the universal-abelian-quotient language most facts about abelian quotients consume: every homomorphism from a perfect group into an abelian group is trivial, and `H₁(G; ℤ) ≅ G^ab` vanishes. It extends the existing `not_isSolvable` / `not_isSolvable_PSL` "escapes the solvable hierarchy" cluster on the `p ≥ 5` range where the PSL(2,p) simplicity theorem turns on.

## Verification

**UNVERIFIED**: the canonical Docker build is down (containerd blob input/output error at image build; `docker info` succeeds but `docker images`/build fail). The 3-line proof **pattern** was independently confirmed to elaborate (`lean` exit 0) against the local pinned Mathlib on a generic perfect group; the reused perfectness lemmas are already verified on `main`. No new axioms, no `sorry`.

## Files
- `proofs/Proofs/SylowTheoremOQ04OQ03.lean` (+34 lines, +2 theorems → 978 L)
- gallery `meta.json` + research problem JSON: `leanFile` counts synced to 978 L / 48 thm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)