### PR TITLE
research(roth-theorem-oq-01): repair OQ-01 tower so it compiles (VERIFIED)

### DIFF
--- a/proofs/Proofs/RothTheoremOQ01.lean
+++ b/proofs/Proofs/RothTheoremOQ01.lean
@@ -2,6 +2,7 @@ import Mathlib.Combinatorics.Additive.Corner.Roth
 import Mathlib.Combinatorics.Additive.AP.Three.Behrend
 import Mathlib.Analysis.SpecialFunctions.Log.Basic
 import Mathlib.Analysis.SpecialFunctions.Pow.Real
+import Mathlib.Analysis.SpecialFunctions.Pow.Asymptotics
 import Mathlib.Analysis.Complex.ExponentialBounds
 import Proofs.RothTheoremOQ02
 
@@ -415,7 +416,7 @@ theorem blasi_factor_isLittleO_bourgain_factor :
     have hD : Filter.Tendsto
         (fun N : ℕ => Real.log N ^ ((1:ℝ)/2 + c) * Real.log (Real.log N) ^ ((1:ℝ)/2))
         Filter.atTop Filter.atTop := by
-      have := ((tendsto_rpow_atTop (show (0:ℝ) < 1/2 + c by positivity)).comp hlogN).atTop_mul_atTop
+      have := ((tendsto_rpow_atTop (show (0:ℝ) < 1/2 + c by positivity)).comp hlogN).atTop_mul_atTop₀
         ((tendsto_rpow_atTop (show (0:ℝ) < 1/2 by norm_num)).comp hloglogN)
       simpa [Function.comp] using this
     refine (hD.inv_tendsto_atTop).congr' ?_
@@ -431,7 +432,6 @@ theorem blasi_factor_isLittleO_bourgain_factor :
     have hM12 : Real.log (Real.log N) ^ ((1:ℝ)/2) ≠ 0 := ne_of_gt (Real.rpow_pos_of_pos hLL _)
     rw [Real.div_rpow hLL.le hL.le, hLsplit]
     field_simp
-    ring
 
 /-- **Bloom–Sisask density bound for an arbitrary 3-AP-free set.**
 

--- a/proofs/Proofs/RothTheoremOQ01Weighted.lean
+++ b/proofs/Proofs/RothTheoremOQ01Weighted.lean
@@ -88,9 +88,11 @@ theorem summable_weightedMajorant (hs : s < RothTheoremOQ02.blasiConst) :
   exact hbase.mul_left _
 
 /-- **Per-block weighted reciprocal bound.**  For any finite 3-AP-free `T` with `0 ∉ T` and
-weight exponent `0 ≤ s`, the `(log a)^s`-weighted reciprocal sum over the `k`-th dyadic
-fiber `{a ∈ T : ⌊log₂ a⌋ = k}` is at most `weightedMajorant s k`. -/
-theorem weighted_fiber_sum_le (hs0 : 0 ≤ s)
+weight exponent `0 ≤ s < blasiConst`, the `(log a)^s`-weighted reciprocal sum over the `k`-th
+dyadic fiber `{a ∈ T : ⌊log₂ a⌋ = k}` is at most `weightedMajorant s k`.  The upper bound
+`s < blasiConst` guarantees the majorant exponent `1 + blasiConst − s` stays positive (needed
+for the `k = 0` block, where `Real.rpow_le_one` requires a nonnegative exponent). -/
+theorem weighted_fiber_sum_le (hs0 : 0 ≤ s) (hs : s < RothTheoremOQ02.blasiConst)
     (T : Finset ℕ) (hT : ThreeAPFree (T : Set ℕ)) (hT0 : 0 ∉ T) (k : ℕ) :
     ∑ a ∈ T.filter (fun a => Nat.log 2 a = k), (Real.log a) ^ s / (a : ℝ)
       ≤ weightedMajorant s k := by
@@ -196,7 +198,6 @@ theorem weighted_fiber_sum_le (hs0 : 0 ≤ s)
             unfold weightedMajorant
             rw [pow_succ, Real.rpow_sub hbpos]
             field_simp
-            ring
 
 /-- **Uniform bound on finite weighted reciprocal sums.**  For every finite 3-AP-free `T`
 (`0 ∉ T`) and `0 ≤ s < blasiConst`, the `(log a)^s`-weighted reciprocal sum is bounded by
@@ -211,7 +212,7 @@ theorem weighted_finite_sum_le (hs0 : 0 ≤ s) (hs : s < RothTheoremOQ02.blasiCo
   calc ∑ k ∈ T.image (Nat.log 2), ∑ a ∈ T.filter (fun a => Nat.log 2 a = k),
           (Real.log a) ^ s / (a : ℝ)
       ≤ ∑ k ∈ T.image (Nat.log 2), weightedMajorant s k :=
-        Finset.sum_le_sum (fun k _ => weighted_fiber_sum_le hs0 T hT hT0 k)
+        Finset.sum_le_sum (fun k _ => weighted_fiber_sum_le hs0 hs T hT hT0 k)
     _ ≤ ∑' k, weightedMajorant s k :=
         Summable.sum_le_tsum _ (fun k _ => weightedMajorant_nonneg k)
           (summable_weightedMajorant hs)

--- a/src/data/research/problems/roth-theorem-oq-01.json
+++ b/src/data/research/problems/roth-theorem-oq-01.json
@@ -109,7 +109,7 @@
     {
       "path": "Proofs/RothTheoremOQ01Weighted.lean",
       "filename": "RothTheoremOQ01Weighted.lean",
-      "lineCount": 354,
+      "lineCount": 355,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 2,


### PR DESCRIPTION
## Problem

The `roth-theorem-oq-01` tower on `main` **does not compile**. It was merged during the long Docker-build outage and never machine-checked. Three latent Mathlib API-drift breaks:

- `RothTheoremOQ01.lean:418` uses `Tendsto.atTop_mul_atTop`, which in current Mathlib denotes the *ordered-monoid* lemma (fails to synthesize `IsOrderedMonoid ℝ`); the reals/semiring variant was renamed to `atTop_mul_atTop₀`.
- `RothTheoremOQ01.lean` never imports `Mathlib.Analysis.SpecialFunctions.Pow.Asymptotics`, so `tendsto_rpow_atTop` is an unknown identifier.
- `RothTheoremOQ01Weighted.lean`'s `weighted_fiber_sum_le` is missing the hypothesis `s < blasiConst`; its `k = 0` block needs `0 ≤ 1 + blasiConst − s` for `Real.rpow_le_one`, and `linarith` fails without it.
- Two stray `ring` tactics after `field_simp` calls that now close their goals ("No goals to be solved").

(Sibling PR #37336 merged the new weighted-bound API but the deployer squash-merged it before this repair commit landed, so the fix was stranded.)

## Fix

- `RothTheoremOQ01.lean`: add the `Pow.Asymptotics` import; `atTop_mul_atTop` → `atTop_mul_atTop₀`; drop the stray `ring`.
- `RothTheoremOQ01Weighted.lean`: thread `hs : s < blasiConst` into `weighted_fiber_sum_le` (already available at its only call site `weighted_finite_sum_le`); drop the stray `ring`.

## Verification — VERIFIED

Docker image build is down (containerd `meta.db` I/O error), so verified against cached Mathlib oleans with the system Lean toolchain (`leanprover/lean4:v4.26.0`). The full chain compiles **clean from scratch, 0 sorries**:

```
OK RothTheoremOQ02
OK RothTheoremOQ01
OK RothTheoremOQ01Reciprocal
OK RothTheoremOQ01Weighted
OK RothTheoremOQ01Primes
sorryAx: 0
```

`#print axioms` confirms every result depends only on `[propext, Classical.choice, Quot.sound, RothTheoremOQ02.rothNumberNat_bloom_sisask]` — no new axiom, no `sorryAx`, no `Lean.ofReduceBool`. Status stays `axiomatized` (rests on the Bloom–Sisask bound).

## Meta

`RothTheoremOQ01Weighted.lean` 354 → 355 lines (research JSON synced). `RothTheoremOQ01.lean` net line count unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)