### PR TITLE
research(erdos-18-oq-01): unconditional infinitude + unboundedness of practical numbers

### DIFF
--- a/proofs/Proofs/Erdos18OQ01.lean
+++ b/proofs/Proofs/Erdos18OQ01.lean
@@ -474,4 +474,27 @@ theorem practical_pow {m : ℕ} (hp : IsPractical m) (k : ℕ) : IsPractical (m 
 theorem six_pow_practical (k : ℕ) : IsPractical (6 ^ k) :=
   practical_pow six_practical k
 
+/-! ## Infinitude of practical numbers
+
+The parent's `conjecture_part1` asks whether *infinitely many* practical numbers
+enjoy a doubly-logarithmic bound on `h`; that conditional statement is open.  The
+*unconditional* fact — that there are infinitely many practical numbers at all —
+is elementary: the powers of two `2^k` are all practical (`two_pow_practical`)
+and pairwise distinct, so `k ↦ 2^k` injects `ℕ` into the practical numbers. -/
+
+/-- **There are infinitely many practical numbers.**  The set `{m | IsPractical m}`
+    (the parent's `Erdos18.PracticalNumbers`) is infinite, witnessed by the
+    injective family `k ↦ 2^k` of powers of two, each practical by
+    `two_pow_practical`. -/
+theorem practical_infinite : {m : ℕ | IsPractical m}.Infinite :=
+  Set.infinite_of_injective_forall_mem
+    (Nat.pow_right_injective (le_refl 2))
+    (fun k => two_pow_practical k)
+
+/-- **Practical numbers are unbounded.**  For every bound `N` there is a practical
+    number exceeding `N`, realised by the power of two `2^(N+1)`. -/
+theorem practical_unbounded (N : ℕ) : ∃ m, N < m ∧ IsPractical m :=
+  ⟨2 ^ (N + 1), (Nat.lt_succ_self N).trans Nat.lt_two_pow_self,
+    two_pow_practical (N + 1)⟩
+
 end Erdos18OQ01


### PR DESCRIPTION
## Summary

Erdős Problem #18 ($250, OPEN) concerns practical numbers. The gallery entry `Erdos18OQ01.lean` develops the elementary structural theory (representability algebra, evenness, multiplicative/power closure). This PR fills a clean gap: the **unconditional infinitude** of the practical numbers.

The parent `Erdos18Problem.lean` only states `Set.Infinite` *inside* the open `conjecture_part1` (infinitely many practicals with a doubly-logarithmic `h`-bound). The plain fact — there are infinitely many practical numbers at all — was never proved.

## Added theorems (2)

- `practical_infinite : {m : ℕ | IsPractical m}.Infinite` — the set of practical numbers is infinite, witnessed by the injective family `k ↦ 2^k` (all practical by `two_pow_practical`), via `Set.infinite_of_injective_forall_mem` + `Nat.pow_right_injective`.
- `practical_unbounded (N) : ∃ m, N < m ∧ IsPractical m` — concrete unbounded form, witnessed by `2^(N+1)`.

Both are 1–2 line term-mode assemblies mirroring verified precedents (`AbundantOddInfiniteOQ03`, `Erdos1100OQ02`). No new axioms, no sorries.

## Verification status

⚠️ **UNVERIFIED** — docker build infrastructure is down this session (containerd `meta.db` I/O error). All lemma names were confirmed present in the current Mathlib pin by grepping existing proofs; the proof shapes copy working code. Lean-only change: `Erdos18OQ01.lean` carries no gallery `meta.json`, so no metadata sync is required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)