### PR TITLE
research(erdos-666): hypercube vertex positivity + handshake identity 2|E|=n|V| [UNVERIFIED]

### DIFF
--- a/proofs/Proofs/Erdos666Problem.lean
+++ b/proofs/Proofs/Erdos666Problem.lean
@@ -74,6 +74,24 @@ def hypercubeVertices (n : ℕ) : ℕ := 2^n
 -/
 def hypercubeEdges (n : ℕ) : ℕ := n * 2^(n-1)
 
+/-- **`Qₙ` always has vertices:** `|V(Qₙ)| = 2ⁿ > 0`. -/
+theorem hypercubeVertices_pos (n : ℕ) : 0 < hypercubeVertices n :=
+  pow_pos (by norm_num) n
+
+/-- **Handshake identity for the hypercube:** `2·|E(Qₙ)| = n·|V(Qₙ)|`.  Every one of
+    the `2ⁿ` vertices of `Qₙ` has degree exactly `n` (one neighbour per coordinate
+    flip), so the degree sum is `n·2ⁿ`, which by the handshake lemma is twice the edge
+    count.  Concretely `2·(n·2ⁿ⁻¹) = n·2ⁿ`.  This ties the file's two basic counts
+    `hypercubeVertices` and `hypercubeEdges` together. -/
+theorem two_mul_hypercubeEdges (n : ℕ) :
+    2 * hypercubeEdges n = n * hypercubeVertices n := by
+  cases n with
+  | zero => simp [hypercubeEdges, hypercubeVertices]
+  | succ m =>
+    unfold hypercubeEdges hypercubeVertices
+    rw [Nat.succ_sub_one, pow_succ]
+    ring
+
 /-
 **Degree in Qₙ:** every vertex has degree n.
 -/


### PR DESCRIPTION
## Summary

Two elementary combinatorial facts in `Proofs/Erdos666Problem.lean` tying together the file's basic hypercube counts `hypercubeVertices n = 2ⁿ` and `hypercubeEdges n = n·2ⁿ⁻¹`:

- **`hypercubeVertices_pos`** — `0 < 2ⁿ`: `Qₙ` always has vertices.
- **`two_mul_hypercubeEdges`** — the handshake identity `2·|E(Qₙ)| = n·|V(Qₙ)|`. Every vertex of `Qₙ` has degree exactly `n` (one neighbour per coordinate flip), so the degree sum `n·2ⁿ` is twice the edge count; concretely `2·(n·2ⁿ⁻¹) = n·2ⁿ`. Proof by cases on `n` (`pow_succ` + `ring`).

Both are orthogonal to the file's open axiom `conder_no_threshold`.

## Verification
⚠️ **UNVERIFIED** — not machine-checked. Docker image build fails this session (`containerd ... meta.db: input/output error`). Both proofs are elementary `ℕ`/`pow` manipulations.

Meta `leanFile.lineCount` 472→490, `theoremCount` 13→15.

🤖 Generated with [Claude Code](https://claude.com/claude-code)