### PR TITLE
Fix: resync 2 uncovered meta.lineCount drifts (algebraic-oq-07, erdos-659)

### DIFF
--- a/src/data/proofs/algebraic-numbers-countable-oq-07/meta.json
+++ b/src/data/proofs/algebraic-numbers-countable-oq-07/meta.json
@@ -20,7 +20,7 @@
     "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 393,
+    "lineCount": 438,
     "theoremCount": 16,
     "definitionCount": 0,
     "dateAdded": "2026-06-21",

--- a/src/data/proofs/erdos-659/meta.json
+++ b/src/data/proofs/erdos-659/meta.json
@@ -49,7 +49,7 @@
       "Verified the necessity side (mod-8 obstruction) of the arithmetic characterization: not_representable_of_mod8 proves no integer ≡ 5 or 7 (mod 8) is a value of x²+2y² (finite decide over ZMod 8), with five_not_representable / seven_not_representable as the smallest concrete witnesses — the first non-representability results in the file, showing the form is not universal (5, 7 are inert in ℤ[√-2])"
     ],
     "axiomCount": 1,
-    "lineCount": 550,
+    "lineCount": 575,
     "assumptions": "1 axiom: moreeOsburnWorks (the two deep geometric facts about the box-truncated lattice — the 4-point property and the Landau/x²+2y² distinct-distance bound m/√(log m); not available in Mathlib 4.26). The cardinality (2k+1)² is now a verified theorem (moreeOsburnLattice_card), not an assumption. 0 sorries.",
     "theoremCount": 18,
     "definitionCount": 9


### PR DESCRIPTION
## Fix

Resync two stale `meta.lineCount` fields to match their Lean sources. In both entries the `leanFile.lineCount` was already correct — only the sibling `meta.lineCount` was left stale by merged research PRs.

## Evidence

| slug | file | meta.lineCount | leanFile.lineCount | actual `wc -l` | grew via |
|------|------|---------------|--------------------|----------------|----------|
| algebraic-numbers-countable-oq-07 | `AlgebraicRealsNull.lean` | 393 → **438** | 438 (already) | 438 | merged #37248 |
| erdos-659 | `Erdos659Problem.lean` | 550 → **575** | 575 (already) | 575 | merged #37338 |

**Before**: `meta.lineCount` understated the file size; `leanFile.lineCount` and the actual file disagreed with it.
**After**: `meta.lineCount` matches `leanFile.lineCount` and the actual line count.

No open PR touches either `.lean` or `meta.json`, so these drifts are genuine and uncovered (verified against all 71 open PRs). Only the two `meta.lineCount` values change; no Lean code touched.

---
Automated fix by lean-mechanic agent.