### PR TITLE
research(erdos-1006-oq-01-oq-01): bundled DecidablePred recognizer

### DIFF
--- a/proofs/Proofs/Erdos1006OQ04Decidability.lean
+++ b/proofs/Proofs/Erdos1006OQ04Decidability.lean
@@ -112,4 +112,28 @@ theorem oq04_existence_universally_yes [Fintype V] (G : SimpleGraph V) :
     admitsRobustAcyclicOrientation G :=
   every_finite_graph_has_robust G
 
+/-
+## Part IV: The decidable recognizer (OQ-01-OQ-01)
+
+OQ-01-OQ-01 asks the literal question: with `[Fintype V]`, is
+`admitsRobustAcyclicOrientation` a `DecidablePred`?  The per-graph instance
+`instDecidableAdmitsRobustAcyclic` already answers it pointwise; here we record
+the bundled predicate form, which is the exact deliverable of that sub-question.
+-/
+
+/-- **OQ-01-OQ-01 (decidable recognizer): YES.**  On any finite vertex type,
+    `admitsRobustAcyclicOrientation` is a `DecidablePred` — the literal question
+    of OQ-01-OQ-01.  This bundles the per-graph decision instance
+    `instDecidableAdmitsRobustAcyclic` into predicate form
+    `∀ G, Decidable (admitsRobustAcyclicOrientation G)`.
+
+    The obstruction the question flags — that recognizing the predicate seems to
+    require quantifying over *all* orientations of `G` — is dissolved by the
+    rank-based construction `every_finite_graph_has_robust`: it certifies the
+    predicate is universally true on finite graphs, so the recognizer is the
+    constant `isTrue`, decidable in `O(1)` without enumerating orientations. -/
+theorem admitsRobustAcyclicOrientation_decidablePred [Fintype V] :
+    DecidablePred (admitsRobustAcyclicOrientation (V := V)) :=
+  fun G => instDecidableAdmitsRobustAcyclic G
+
 end Erdos1006OQ04Decidability


### PR DESCRIPTION
## Summary

OQ-01-OQ-01 asks the literal question: with `[Fintype V]`, is `admitsRobustAcyclicOrientation` a `DecidablePred`? `Erdos1006OQ04Decidability.lean` already supplies the per-graph decision instance `instDecidableAdmitsRobustAcyclic` and the universally-true result `every_finite_graph_has_robust`, but never states the **bundled predicate form** that is the exact deliverable of the sub-question. This records it:

- `admitsRobustAcyclicOrientation_decidablePred` — `DecidablePred (admitsRobustAcyclicOrientation)`, i.e. `∀ G, Decidable (admitsRobustAcyclicOrientation G)`. **Answer: YES.**

The obstruction the question flags — recognizing the predicate seemingly requires quantifying over *all* orientations of `G` — is dissolved by the rank-based `every_finite_graph_has_robust`: the predicate is universally true on finite graphs, so the recognizer is the constant `isTrue`, decidable in `O(1)` without enumerating orientations.

## Collision-avoidance

Open PR #37333 (same slug) build-repairs `Erdos1006OQ01.lean`; this PR touches **only** `Erdos1006OQ04Decidability.lean`, which is not tracked in any gallery meta (mentioned only in an `assumptions` text field) — a Lean-only, disjoint change with no meta sync.

## Verification

⚠️ **UNVERIFIED** — Docker build unavailable this session (containerd `meta.db` I/O error). The term-mode proof bundles the existing `instDecidableAdmitsRobustAcyclic` instance; checked by inspection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)