### PR TITLE
research(erdos-1018): isolate K5/K33-subdivision sufficient conditions for non-planarity [UNVERIFIED]

### DIFF
--- a/proofs/Proofs/Erdos1018Problem.lean
+++ b/proofs/Proofs/Erdos1018Problem.lean
@@ -162,6 +162,24 @@ theorem K5_nonplanar : isNonPlanar (completeGraph 5) :=
 theorem K33_nonplanar : isNonPlanar (completeBipartite 3 3) :=
   (kuratowski_theorem _).mpr (Or.inr (self_containsSubdivision _))
 
+omit [Fintype V] [DecidableEq V] in
+/-- **Sufficient condition for non-planarity (K₅ branch).** A graph that contains a
+    subdivision of `K₅` is non-planar. This is the forward half of Kuratowski's
+    criterion, isolated as a reusable lemma — the pattern used inline in
+    `K5_nonplanar`. -/
+theorem nonPlanar_of_containsK5Subdivision {G : SimpleGraph V}
+    (h : containsSubdivision G (completeGraph 5)) : isNonPlanar G :=
+  (kuratowski_theorem G).mpr (Or.inl h)
+
+omit [Fintype V] [DecidableEq V] in
+/-- **Sufficient condition for non-planarity (K₃,₃ branch).** A graph that contains a
+    subdivision of `K₃,₃` is non-planar. The `K₃,₃` companion of
+    `nonPlanar_of_containsK5Subdivision` and the reusable form of the argument in
+    `K33_nonplanar`. -/
+theorem nonPlanar_of_containsK33Subdivision {G : SimpleGraph V}
+    (h : containsSubdivision G (completeBipartite 3 3)) : isNonPlanar G :=
+  (kuratowski_theorem G).mpr (Or.inr h)
+
 /-
 ## Induced Subgraphs
 

--- a/src/data/proofs/erdos-1018/meta.json
+++ b/src/data/proofs/erdos-1018/meta.json
@@ -244,9 +244,9 @@
       "SimpleGraph"
     ],
     "namespace": "Erdos1018",
-    "lineCount": 530,
+    "lineCount": 548,
     "axiomCount": 3,
-    "theoremCount": 15,
+    "theoremCount": 17,
     "definitionCount": 15,
     "path": "Proofs/Erdos1018Problem.lean",
     "sorries": 0,


### PR DESCRIPTION
## Summary

Extracts the forward half of Kuratowski's criterion as two reusable lemmas in `Proofs/Erdos1018Problem.lean`:

- **`nonPlanar_of_containsK5Subdivision`** — `containsSubdivision G K₅ → isNonPlanar G`.
- **`nonPlanar_of_containsK33Subdivision`** — `containsSubdivision G K₃,₃ → isNonPlanar G`.

Both are one-liners over the file's `kuratowski_theorem` (`.mpr ∘ Or.inl/Or.inr`), abstracting the argument currently inlined in `K5_nonplanar` / `K33_nonplanar` so downstream code can conclude non-planarity from either forbidden subdivision directly. Marked `omit [Fintype V] [DecidableEq V]` to match `kuratowski_theorem`.

## Verification
⚠️ **UNVERIFIED** — not machine-checked. Docker image build fails this session (`containerd ... meta.db: input/output error`). Both are direct rewrites of the existing `kuratowski_theorem` biconditional.

Meta `leanFile.lineCount` 530→548, `theoremCount` 15→17.

🤖 Generated with [Claude Code](https://claude.com/claude-code)