### PR TITLE
research(kepler-conjecture-oq-04): Ulam interval [fcc,1] for symmetric convex bodies [UNVERIFIED]

### DIFF
--- a/proofs/Proofs/KeplerConjectureOQ04Interval.lean
+++ b/proofs/Proofs/KeplerConjectureOQ04Interval.lean
@@ -41,4 +41,32 @@ theorem packingDensity_mem_Icc_rhombicDodecahedron (d : PackingDensity) :
     d.density ∈ Set.Icc (0 : ℝ) rhombicDodecahedronPackingDensity :=
   ⟨d.nonneg, packingDensity_le_rhombicDodecahedron d⟩
 
+/-!
+## The Ulam interval `[fcc, 1]` for centrally symmetric convex bodies
+
+For a *general* packing density the only interval available is `[0, 1]` above.  The
+one class where the lower endpoint sharpens is the centrally symmetric convex bodies:
+Ulam's conjecture (the file's `ulam_conjecture` axiom) asserts each of them packs at
+density at least the sphere/FCC value `fccDensity = π/(3√2)`, and the structural ceiling
+`le_one` still caps it at `1`.  Packaging the two as a single interval membership gives
+the sharpest two-sided bound the file supports for this class, conditional on Ulam.
+-/
+
+/-- **Symmetric-convex-body densities lie in `[fccDensity, 1]`.**  The Ulam-conditional
+sharpening of `packingDensity_mem_Icc`: for a centrally symmetric convex body packing the
+lower endpoint rises from `0` to the sphere/FCC value `fccDensity` (`ulam_conjecture`),
+while `le_one` keeps the upper endpoint at `1`.  Depends on the `ulam_conjecture` axiom
+(an open conjecture), so this interval is conditional. -/
+theorem symmetricConvexBody_density_mem_Icc_fcc (p : SymmetricConvexBody3DPacking) :
+    p.density ∈ Set.Icc fccDensity 1 :=
+  ⟨ulam_conjecture p, p.le_one⟩
+
+/-- **Same interval stated against the named `fccPacking` instance.**  The interval
+`[fccPacking.density, 1]` form, tying the lower endpoint to the concrete FCC packing
+instance from the parent file via `ulam_le_fccPacking_density`. -/
+theorem symmetricConvexBody_density_mem_Icc_fccPacking
+    (p : SymmetricConvexBody3DPacking) :
+    p.density ∈ Set.Icc fccPacking.density 1 :=
+  ⟨ulam_le_fccPacking_density p, p.le_one⟩
+
 end KeplerConjectureOQ04

--- a/src/data/research/problems/kepler-conjecture-oq-04.json
+++ b/src/data/research/problems/kepler-conjecture-oq-04.json
@@ -57,7 +57,8 @@
       "Realigned 6 drifted annotations (ranges pinned to the pre-S3 ~118-line file) to the current 456-line source + added 5 new annotations covering S3-S7 (refutation, PackingDensity instance/existential, Bezdek-Kuperberg axiom, Ulam axiom, density_hierarchy_3d aggregation); annotations now 11, matching the 11 meta.json sections, in src/data/proofs/kepler-conjecture-oq-04/annotations.json",
       "Backfilled missing S5/S6/S7 session entries in research/problems/kepler-conjecture-oq-04/knowledge.md (previously only S1 + S3+S4 were recorded; S5/S6/S7 had been deferred to a post-build doc update)",
       "S15/S8 (researcher-7, 2026-07-08): BUILD-VERIFIED the S14 opaque-predicate soundness fix. Both KeplerConjecture.lean (opaque IsDiskPacking/IsSpherePacking/IsSpherePacking8D) and KeplerConjectureOQ04.lean (opaque IsEllipsoidLatticePacking/IsSymmetricConvexBody3DPacking, gated marker structures) compile clean against Mathlib v4.26 (docker-build 7744 jobs), confirming the fix that was 'build-pending under Docker blackout' at S14. Added S8: two theorems proving the shape gates are NON-VACUOUS.",
-      "S9 octahedron benchmark: octahedronPackingDensity (18/19) + pos/lt_one, tetrahedronDimerDensity_lt_octahedron, octahedronPackingDensity_gt_fccDensity, octahedronPacking instance, exists_packingDensity_gt_tetrahedronDimer, octahedron_not_ellipsoidLattice, fcc_lt_tetrahedron_lt_octahedron. 7 theorems, 1 def, 0 NEW axioms (still 2 total)."
+      "S9 octahedron benchmark: octahedronPackingDensity (18/19) + pos/lt_one, tetrahedronDimerDensity_lt_octahedron, octahedronPackingDensity_gt_fccDensity, octahedronPacking instance, exists_packingDensity_gt_tetrahedronDimer, octahedron_not_ellipsoidLattice, fcc_lt_tetrahedron_lt_octahedron. 7 theorems, 1 def, 0 NEW axioms (still 2 total).",
+      "symmetricConvexBody_density_mem_Icc_fcc + _fccPacking (KeplerConjectureOQ04Interval.lean): the Ulam interval [fccDensity,1] for centrally symmetric convex body packings — the sharpest two-sided density bound the file supports for that class (lower endpoint from ulam_conjecture, upper from le_one), packaged as Set.Icc membership. Conditional on the ulam_conjecture axiom. [UNVERIFIED — Docker down; the Set.Icc anonymous-constructor + extends-field-access proof pattern was confirmed to elaborate against local Mathlib.]"
     ],
     "insights": [
       "The tetrahedral refutation 4000/4671 > pi/(3*sqrt(2)) is AXIOM-FREE in Lean: pure real-number arithmetic provable via Real.pi_sq_lt (pi^2 < 9.8696). Squared form: 288_000_000 > 21_818_241 * pi^2, margin ~ 25% even with the loosest Mathlib pi bound.",
@@ -156,11 +157,11 @@
     {
       "path": "Proofs/KeplerConjectureOQ04Interval.lean",
       "filename": "KeplerConjectureOQ04Interval.lean",
-      "lineCount": 45,
-      "theoremCount": 2,
+      "lineCount": 72,
+      "theoremCount": 4,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/KeplerConjectureOQ04Interval.lean"
     }


### PR DESCRIPTION
## Summary

Extends the packing-density **interval-API companion** (`KeplerConjectureOQ04Interval.lean`) with the one interval it did not yet package — the Ulam-conditional two-sided bound for centrally symmetric convex body packings:

- `symmetricConvexBody_density_mem_Icc_fcc` — `p.density ∈ Set.Icc fccDensity 1`
- `symmetricConvexBody_density_mem_Icc_fccPacking` — same against the named `fccPacking` instance

## Why it matters

For a *general* packing density the only interval available is `[0, 1]` (`packingDensity_mem_Icc`). The centrally symmetric convex bodies are the one class where the lower endpoint sharpens: **Ulam's conjecture** (the parent file's `ulam_conjecture` axiom) asserts each packs at density at least the sphere/FCC value `fccDensity = π/(3√2)`, while the structural ceiling `le_one` caps it at `1`. Packaging the two as a single `Set.Icc` membership gives the sharpest two-sided bound the file supports for this class.

Each proof is a one-line anonymous constructor:

```lean
theorem symmetricConvexBody_density_mem_Icc_fcc (p : SymmetricConvexBody3DPacking) :
    p.density ∈ Set.Icc fccDensity 1 :=
  ⟨ulam_conjecture p, p.le_one⟩
```

## Assumptions

Conditional on the `ulam_conjecture` axiom (an open conjecture, already present in the parent file). **No new axiom is declared** in this file. The companion remains `0`-sorry.

## Verification

**UNVERIFIED**: the canonical Docker build is down (containerd blob input/output error at image build). The `Set.Icc` anonymous-constructor + `extends`-field-access proof pattern was independently confirmed to elaborate (`lean` exit 0) against the local pinned Mathlib; the reused `ulam_conjecture` / `ulam_le_fccPacking_density` / `le_one` are already on `main`.

## Files
- `proofs/Proofs/KeplerConjectureOQ04Interval.lean` (+28 lines, +2 theorems → 72 L)
- research problem JSON: companion `leanFiles` entry synced to 72 L / 4 thm (also corrects a stale `sorryCount: 1` → `0`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)