### PR TITLE
research(szemeredi-regularity-oq-04): multi-cell variance atom bound

### DIFF
--- a/proofs/Proofs/SzemerediRegularityOQ04.lean
+++ b/proofs/Proofs/SzemerediRegularityOQ04.lean
@@ -544,4 +544,31 @@ theorem weighted_variance_atom_bound {ι : Type*} (s : Finset ι) (w x : ι → 
     mul_le_mul_of_nonneg_left hd (hw j hj)
   linarith [hle_sum, hatom]
 
+/-- **The variance atom over many deviating cells.**  Strengthening of
+    `weighted_variance_atom_bound` from a single index to an arbitrary sub-family
+    `J ⊆ s`: if *every* index `j ∈ J` deviates from the weighted mean `μ` by at
+    least `d` (`d² ≤ (xⱼ − μ)²`), then the pooled weight of `J` scales the floor,
+    `(∑_{j∈J} wⱼ)·d² ≤ (∑ wᵢxᵢ²) − (∑ wᵢ)·μ²`.
+
+    This is the form the AFKS energy-increment step actually consumes: refining a
+    part into sub-cells whose densities all deviate from the parent mean by `d`
+    raises the partition energy by at least the *total* sub-cell weight times `d²`,
+    not just one cell's — the honest four-cell (`ε⁴`) increment rather than the
+    single-cell (`ε²`) one.  The single-index bound is the case `J = {j}`. -/
+theorem weighted_variance_subset_bound {ι : Type*} (s : Finset ι) (w x : ι → ℚ)
+    (μ d : ℚ) (hw : ∀ i ∈ s, 0 ≤ w i)
+    (hmean : ∑ i ∈ s, w i * x i = (∑ i ∈ s, w i) * μ)
+    {J : Finset ι} (hJ : J ⊆ s) (hdev : ∀ j ∈ J, d ^ 2 ≤ (x j - μ) ^ 2) :
+    (∑ j ∈ J, w j) * d ^ 2 ≤ (∑ i ∈ s, w i * x i ^ 2) - (∑ i ∈ s, w i) * μ ^ 2 := by
+  rw [← weighted_variance_eq s w x μ hmean]
+  have hterm_nonneg : ∀ i ∈ s, 0 ≤ w i * (x i - μ) ^ 2 :=
+    fun i hi => mul_nonneg (hw i hi) (sq_nonneg _)
+  have hsubset : ∑ i ∈ J, w i * (x i - μ) ^ 2 ≤ ∑ i ∈ s, w i * (x i - μ) ^ 2 :=
+    Finset.sum_le_sum_of_subset_of_nonneg hJ (fun i hi _ => hterm_nonneg i hi)
+  have hfloor : ∑ j ∈ J, w j * d ^ 2 ≤ ∑ j ∈ J, w j * (x j - μ) ^ 2 :=
+    Finset.sum_le_sum (fun j hj =>
+      mul_le_mul_of_nonneg_left (hdev j hj) (hw j (hJ hj)))
+  rw [Finset.sum_mul]
+  linarith [hsubset, hfloor]
+
 end Szemeredi.RegularityOQ04


### PR DESCRIPTION
## Summary

Erdős-adjacent strong (AFKS) regularity work in `SzemerediRegularityOQ04.lean`. The energy-increment engine already proves a **single-index** variance floor (`weighted_variance_atom_bound`): one deviating sub-cell forces a positive second moment. This PR adds the **multi-cell** strengthening the four-cell refinement actually needs.

## Added theorem (1)

`weighted_variance_subset_bound`: for nonneg weights `w` with weighted mean `μ`, if *every* index in a sub-family `J ⊆ s` deviates by at least `d` (`d² ≤ (xⱼ−μ)²`), then the pooled weight scales the floor:
```
(∑_{j∈J} wⱼ)·d² ≤ (∑ wᵢxᵢ²) − (∑ wᵢ)·μ²
```

This is the honest **ε⁴** energy increment (total deviating-cell weight × d²) rather than the single-cell ε² one. The existing single-index bound is the special case `J = {j}`.

**Proof:** rewrite the RHS via `weighted_variance_eq` to `∑ wᵢ(xᵢ−μ)²`; drop cells outside `J` (`Finset.sum_le_sum_of_subset_of_nonneg`); apply the termwise floor `wⱼd² ≤ wⱼ(xⱼ−μ)²` on `J` (`Finset.sum_le_sum` + `mul_le_mul_of_nonneg_left`); distribute the pooled weight (`Finset.sum_mul`); `linarith`. Pure `Finset` algebra, no new axioms or sorries.

## Verification status

⚠️ **UNVERIFIED** — docker build infrastructure is down this session (host disk full → containerd `meta.db` I/O error). All four Mathlib lemmas were confirmed present in the current pin by grepping existing proofs, and the proof mirrors the adjacent verified `weighted_variance_atom_bound`. Lean-only change: `SzemerediRegularityOQ04.lean` carries no gallery `meta.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)