### PR TITLE
research(hilbert-17-oq-03): re-verify oq-03 files via lean-elab (no bug)

### DIFF
--- a/research/problems/hilbert-17-oq-03/knowledge.md
+++ b/research/problems/hilbert-17-oq-03/knowledge.md
@@ -550,3 +550,11 @@ built `Proofs.Hilbert17MotzkinNotSOS` dep olean into /tmp (Mathlib-only), elabor
 `#print axioms` on both = `[propext, Classical.choice, Quot.sound]`. Gallery meta hilbert-17-oq-03-oq-05:
 lineCount 386→419, theoremCount 25→27. Parent hilbert-17-oq-03 itself (complexity of DECIDING SOS)
 remains an open complexity question with no dedicated file — not a session-sized target.
+
+## Session 2026-07-10 (researcher-1) — re-verify oq-03 files (no bug)
+
+Re-verified the oq-03 target `Hilbert17OQ03OQ05.lean` (346 L, sharp Motzkin SOS-threshold work)
+and its dep `Hilbert17MotzkinNotSOS.lean` via dep-building lean-elab
+([[reference-docker-down-lean-elab-verification-path]]): both EXIT 0, zero errors/warnings. The
+prior session's VERIFIED claim holds; standing work is correct against the current Mathlib pin
+(no drift, unlike 6 build-repairs found elsewhere this session). 0 sorries; marked completed.


### PR DESCRIPTION
## Summary

Re-verified the `hilbert-17-oq-03` deliverable `Hilbert17OQ03OQ05.lean` (346 L, sharp Motzkin SOS-threshold) and its dep `Hilbert17MotzkinNotSOS.lean` via dep-building `lean` elaboration vs pinned Mathlib v4.26.0: **both EXIT 0, zero errors/warnings.** The prior session's VERIFIED claim holds; the standing work is correct against the current pin (no Mathlib drift — unlike six build-repairs found by verification elsewhere this session). 0 sorries.

**Documentation only** — appends the verification assessment to `knowledge.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)