### PR TITLE
research(roth-theorem-k3-oq-03-oq-01): nondegenerate k-AP count boundary values [UNVERIFIED]

### DIFF
--- a/proofs/Proofs/RothTheoremOQ03OQ01.lean
+++ b/proofs/Proofs/RothTheoremOQ03OQ01.lean
@@ -728,4 +728,39 @@ theorem kAPCount_indicator_empty {N : ℕ} [NeZero N] {k : ℕ} (hk : 0 < k) :
   funext x
   simp [indicatorZMod]
 
+-- ============================================================
+-- Nondegenerate-count boundary values
+--
+-- `kAPCount_count_empty` / `kAPCount_count_univ` pin the *total* `k`-AP count at
+-- the two ends of the density scale (`0` and `N²`). The genuine content of Roth's
+-- theorem, however, lives in the *nondegenerate* (`d ≠ 0`) count split off by
+-- `kAPCount_count_split`. The two lemmas below pin that nondegenerate count at the
+-- same two ends: it vanishes for `A = ∅` and saturates at `N·(N − 1) = N² − N` for
+-- `A = univ` (every ordered pair `(x, d)` with `d ≠ 0`).
+-- ============================================================
+
+/-- **No nondegenerate progressions in the empty set.**  For `k ≥ 1`, no pair `(x, d)`
+    with `d ≠ 0` has its length-`k` progression inside `∅`, so the nondegenerate count is
+    `0`.  Immediate from the nondegenerate upper bound `kAPCount_nondeg_le`
+    (`≤ #∅ · (N − 1) = 0`); the `d ≠ 0` companion of `kAPCount_count_empty`. -/
+theorem kAPCount_nondeg_empty {N : ℕ} [NeZero N] {k : ℕ} (hk : 0 < k) :
+    (Finset.univ.filter (fun p : ZMod N × ZMod N =>
+        (∀ i : Fin k, p.1 + i.val • p.2 ∈ (∅ : Finset (ZMod N))) ∧ p.2 ≠ 0)).card = 0 := by
+  simpa using kAPCount_nondeg_le hk (∅ : Finset (ZMod N))
+
+/-- **Every nonzero difference gives a nondegenerate progression in the whole group.**
+    For `k ≥ 1`, the nondegenerate (`d ≠ 0`) `k`-AP count of `univ` is exactly
+    `N·(N − 1) = N² − N`: every one of the `N²` pairs `(x, d)` lies inside `univ`, and
+    removing the `N` diagonal pairs with `d = 0` leaves the nonzero-difference count.
+    This saturates the `kAPCount_nondeg_le` bound (`≤ #univ · (N − 1) = N·(N − 1)`) and is
+    the `A = univ` companion of `kAPCount_count_univ`.  Obtained from the diagonal split
+    `kAPCount_count_split` at `A = univ` together with `kAPCount_count_univ`. -/
+theorem kAPCount_nondeg_univ {N : ℕ} [NeZero N] {k : ℕ} (hk : 0 < k) :
+    (Finset.univ.filter (fun p : ZMod N × ZMod N =>
+        (∀ i : Fin k, p.1 + i.val • p.2 ∈ (Finset.univ : Finset (ZMod N))) ∧ p.2 ≠ 0)).card
+      = N ^ 2 - N := by
+  have hsplit := kAPCount_count_split hk (Finset.univ : Finset (ZMod N))
+  rw [kAPCount_count_univ, Finset.card_univ, ZMod.card] at hsplit
+  omega
+
 end RothTheoremOQ03OQ01

--- a/src/data/proofs/roth-theorem-k3-oq-03-oq-01/meta.json
+++ b/src/data/proofs/roth-theorem-k3-oq-03-oq-01/meta.json
@@ -58,9 +58,9 @@
       "kAPCount_eq_zero_of_zero: a single zero slot annihilates the count — if f j = 0 then Λ_k(f₀,…,f_{k-1}) = 0, since the j-th factor of every product term vanishes"
     ],
     "axiomCount": 0,
-    "lineCount": 731,
+    "lineCount": 766,
     "assumptions": "0 axioms, 0 sorries. Only the foundational axioms propext / Classical.choice / Quot.sound are used; no native_decide, no sorryAx, no Lean.ofReduceBool. The operators are re-declared self-containedly in this file's namespace; the file imports Mathlib.",
-    "theoremCount": 27,
+    "theoremCount": 29,
     "definitionCount": 5
   },
   "overview": {
@@ -142,9 +142,9 @@
       "BigOperators"
     ],
     "namespace": "RothTheoremOQ03OQ01",
-    "lineCount": 731,
+    "lineCount": 766,
     "axiomCount": 0,
-    "theoremCount": 27,
+    "theoremCount": 29,
     "definitionCount": 5,
     "path": "Proofs/RothTheoremOQ03OQ01.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

The file pins the **total** `k`-AP count at both ends of the density scale (`kAPCount_count_empty = 0`, `kAPCount_count_univ = N²`), but leaves the **nondegenerate** (`d ≠ 0`) count — the quantity Roth's theorem actually controls, split off by `kAPCount_count_split` — unpinned at the endpoints. This adds the two matching boundary values:

- `kAPCount_nondeg_empty : nondeg-count ∅ = 0`
- `kAPCount_nondeg_univ  : nondeg-count univ = N² − N` (= `N·(N−1)`)

## Proofs

- `nondeg_empty`: immediate from the nondegenerate upper bound `kAPCount_nondeg_le` (`≤ #∅·(N−1) = 0`), mirroring the existing `kAPCount_count_empty`.
- `nondeg_univ`: the diagonal split `kAPCount_count_split` at `A = univ` gives `N² = N + nondeg`, so `nondeg = N² − N`; this saturates the `kAPCount_nondeg_le` bound and is the `A = univ` companion of `kAPCount_count_univ`.

Both use only in-file lemmas; 0 axioms, 0 sorries.

## Meta sync

`lineCount` 731→766, `theoremCount` 27→29 (both the `meta` and `leanFile` blocks). `axiomCount` unchanged (0).

## Verification status

**UNVERIFIED.** The Lean docker image build is unavailable in this environment (containerd `meta.db` input/output error at image build). The proofs were checked by hand against `kAPCount_nondeg_le`, `kAPCount_count_split`, `kAPCount_count_univ`, and standard `Finset`/`ZMod` cardinality API. No new axioms or `sorry`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)