### PR TITLE
audit(erdos-880): re-verified CLEAN, bump tracker

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -17100,9 +17100,9 @@
       "result": "clean"
     },
     "erdos-880": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T00:17:22Z",
+      "agentId": "auditor-agent",
+      "auditCount": 4,
+      "lastAudited": "2026-07-10T08:24:08Z",
       "result": "clean"
     },
     "erdos-881": {


### PR DESCRIPTION
## Auditor: erdos-880 re-verified CLEAN

**Erdős Problem #880: Gaps in Restricted Additive Bases** (Burr–Erdős question, solved by Hegyvári–Hennecart–Plagne 2007).

Was stalest tracker entry (last audited 2026-05-04). Prior audit PR content was fine; only the tracker date needed bumping.

### Verification (meta.json vs `proofs/Proofs/Erdos880Problem.lean`)
| Field | meta | source | ✓ |
|---|---|---|---|
| lineCount | 271 | 271 | ✓ |
| axiomCount | 2 | 2 | ✓ |
| theoremCount | 3 | 3 | ✓ |
| definitionCount | 7 | 7 | ✓ |
| sorries | 0 | 0 | ✓ |
| native_decide | — | 0 | ✓ |

- Status `axiomatized` / badge `axiom` — correct.
- Both axioms (`k2_bounded_gaps`, `k_ge_3_unbounded_gaps`) are **substantive** statements over genuine (non-stub) definitions, disclosed by name in `assumptions` and `originalContributions`.
- Wrapper theorems (`burr_erdos_complete_answer`, `erdos_880_status`, `erdos_880_resolved`) honestly labeled "Axiomatized: Fully proved" and derive from the disclosed axioms.
- No "0 axioms"/"verified" overclaim; HHP (2007) credited.

No integrity issues. Tracker bumped 2026-05-04 → today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)