### PR TITLE
research(erdos-1138-oq-03-oq-01): abstract ε-form sublinearity engine

### DIFF
--- a/proofs/Proofs/Erdos1138OQ03OQ01.lean
+++ b/proofs/Proofs/Erdos1138OQ03OQ01.lean
@@ -290,6 +290,24 @@ theorem gap_isLittleO_id_of_rpow_bound {θ : ℝ} (hθ : θ < 1)
   rw [h0] at hxpos
   exact absurd hxpos (lt_irrefl 0)
 
+/-- **Master engine, ε-form.** From *any* eventual power envelope `maxPrimeGap x ≤ x^θ` with
+sub-linear exponent `θ < 1`, for every `ε > 0` eventually `maxPrimeGap x ≤ ε · x`. This is the
+abstract counterpart of the concrete `bhp_gap_eventually_le_eps` (the BHP instance `θ = 0.525`):
+the ε-form was the sole concrete BHP term without an engine twin, so this completes the abstract
+family's term-for-term match. Like the other engines it takes the envelope in `atTop`-eventual
+form, and it factors through the `Tendsto` engine `gap_littleo_of_rpow_bound` exactly as the
+concrete `bhp_gap_eventually_le_eps` factors through `bhp_implies_gap_littleo`. -/
+theorem gap_eventually_le_eps_of_rpow_bound {θ : ℝ} (hθ : θ < 1)
+    (H : ∀ᶠ x : ℕ in atTop, (maxPrimeGap x : ℝ) ≤ (x : ℝ) ^ θ) (ε : ℝ) (hε : 0 < ε) :
+    ∀ᶠ x : ℕ in atTop, (maxPrimeGap x : ℝ) ≤ ε * x := by
+  -- From the engine limit, `maxPrimeGap x / x < ε` eventually; clear the denominator.
+  have hev : ∀ᶠ x : ℕ in atTop, (maxPrimeGap x : ℝ) / x < ε :=
+    (gap_littleo_of_rpow_bound hθ H).eventually (eventually_lt_nhds hε)
+  filter_upwards [hev, eventually_ge_atTop 1] with x hxlt hx1
+  have hx_pos : (0 : ℝ) < (x : ℝ) := by exact_mod_cast (lt_of_lt_of_le Nat.zero_lt_one hx1)
+  rw [div_lt_iff₀ hx_pos] at hxlt
+  exact le_of_lt hxlt
+
 -- ============================================================================
 -- Individual-gap bridge: from the maximal gap `sSup` back to actual gaps
 -- ============================================================================

--- a/src/data/proofs/erdos-1138-oq-03-oq-01/meta.json
+++ b/src/data/proofs/erdos-1138-oq-03-oq-01/meta.json
@@ -44,14 +44,15 @@
     "originalContributions": [
       "gap_div_le_rpow_neg: pointwise upper envelope maxPrimeGap x / x <= x^(-0.475) for x >= 25, via BHP divided by x and the identity x^0.525 / x = x^(0.525 - 1)",
       "bhp_implies_gap_littleo: unconditional maxPrimeGap x / x -> 0, squeezing between 0 and the envelope x^(-0.475) -> 0 (unconditional twin of cramer_implies_gap_sublinear)",
-      "bhp_gap_eventually_le_eps: epsilon-form, for every epsilon > 0 eventually maxPrimeGap x <= epsilon * x"
+      "bhp_gap_eventually_le_eps: epsilon-form, for every epsilon > 0 eventually maxPrimeGap x <= epsilon * x",
+      "gap_eventually_le_eps_of_rpow_bound: abstract epsilon-form engine, from any eventual envelope maxPrimeGap x <= x^theta with theta < 1, for every epsilon > 0 eventually maxPrimeGap x <= epsilon * x (the abstract counterpart of bhp_gap_eventually_le_eps, completing the engine family's term-for-term match with the concrete BHP family)"
     ],
     "dateAdded": "2026-07-05",
     "mathlib_version": "4.26.0",
     "axiomCount": 1,
-    "lineCount": 358,
+    "lineCount": 376,
     "assumptions": "1 axiom, inherited from the parent Erdos1138OQ03: baker_harman_pintz (maxPrimeGap x <= x^0.525 for x >= 25). No axiom is declared in this file (leanFile.axiomCount = 0); the assumption is imported. #print axioms confirms the results depend only on {propext, Classical.choice, Quot.sound, Erdos1138OQ03.baker_harman_pintz}. No sorries, no native_decide.",
-    "theoremCount": 13,
+    "theoremCount": 14,
     "definitionCount": 0
   },
   "overview": {
@@ -140,9 +141,9 @@
       "Topology"
     ],
     "namespace": "Erdos1138OQ03",
-    "lineCount": 358,
+    "lineCount": 376,
     "axiomCount": 0,
-    "theoremCount": 16,
+    "theoremCount": 17,
     "definitionCount": 0,
     "path": "Proofs/Erdos1138OQ03OQ01.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

Adds one theorem to the saturated `Erdos1138OQ03OQ01.lean` (BHP unconditional prime-gap sublinearity), completing the abstract sublinearity-engine family.

**`gap_eventually_le_eps_of_rpow_bound`** — from *any* eventual power envelope `maxPrimeGap x ≤ x^θ` with sub-linear exponent `θ < 1`, for every `ε > 0` eventually `maxPrimeGap x ≤ ε·x`.

## Why this is the genuine gap

The file's abstract engine family (parametrised over an arbitrary envelope exponent `θ`) explicitly claims to match the concrete BHP family (fixed `θ = 0.525`) "term for term":

| concrete BHP term | abstract engine twin |
|---|---|
| `bhp_implies_gap_littleo` (Tendsto ·/x) | `gap_littleo_of_rpow_bound` ✓ |
| `bhp_gap_div_rpow_littleo` (Tendsto ·/x^a) | `gap_div_rpow_littleo_of_rpow_bound` ✓ |
| `bhp_gap_isLittleO_id` (=o id) | `gap_isLittleO_id_of_rpow_bound` ✓ |
| `bhp_gap_isLittleO_rpow` (=o x^a) | `gap_isLittleO_rpow_of_rpow_bound` ✓ |
| `gap_isBigO_rpow` (=O x^θ) | `gap_isBigO_rpow_of_rpow_bound` ✓ |
| **`bhp_gap_eventually_le_eps` (ε-form)** | **(missing → this PR)** |

The ε-form was the sole concrete term without an engine twin. This closes it: the proof factors through `gap_littleo_of_rpow_bound` exactly as `bhp_gap_eventually_le_eps` factors through `bhp_implies_gap_littleo`.

## Verification

**VERIFIED locally** with `lean v4.26.0` against cached Mathlib oleans (Docker image build is down — containerd `meta.db` I/O error). Parent `Erdos1138OQ03` and the edited target both compile with **0 errors, 0 sorries**; only pre-existing linter warnings on unrelated lines 212/244. No new axioms — inherits only the parent's `baker_harman_pintz`.

## Meta

`lineCount` 358→376 (both blocks), `theoremCount` 13→14 / 16→17, new `originalContributions` entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)