### PR TITLE
research(erdos-3): complete the threshold implication lattice — SharpRequiredBound ⇒ RequiredBound

### DIFF
--- a/proofs/Proofs/Erdos3Problem.lean
+++ b/proofs/Proofs/Erdos3Problem.lean
@@ -1041,6 +1041,61 @@ theorem strongRequiredBound_implies_sharpRequiredBound {k : ℕ}
   rw [div_le_div_iff₀ hbig hsmall]
   exact mul_le_mul_of_nonneg_left hdenom_le (mul_nonneg hC.le (Nat.cast_nonneg N))
 
+/-- **The sharp threshold implies the weak (`o(N/log N)`) threshold.**
+    `SharpRequiredBound k` (`r_k(N) = O(N/(log N · (log log N)^{1+δ}))`) implies
+    `RequiredBound k` (`r_k(N) = o(N/log N)`). Writing the sharp bound as
+    `r_k(N) ≤ (C · (log log N)^{-(1+δ)}) · (N / log N)`, the leading factor
+    `C · (log log N)^{-(1+δ)} → 0` because `log log N → ∞` (`tendsto_rpow_neg_atTop`
+    at exponent `1 + δ > 0`), so for every `c > 0` it is eventually `< c`. The proof
+    mirrors `strongRequiredBound_implies_requiredBound`, with the vanishing factor
+    driven by the iterated logarithm instead of a positive power of `log N`.
+
+    Together with `strongRequiredBound_implies_sharpRequiredBound` this completes the
+    implication lattice `StrongRequiredBound ⇒ SharpRequiredBound ⇒ RequiredBound`,
+    so `strongRequiredBound_implies_requiredBound` now factors through the sharp
+    threshold. It also confirms that the sharp hypothesis of
+    `sharp_required_bound_implies_conjecture` sits *strictly below* `o(N/log N)`: the
+    genuinely open regime is the gap between `RequiredBound` and `SharpRequiredBound`,
+    exactly the `N/(log N · log log N)` borderline documented at `StrongRequiredBound`.
+    Axiom-free. -/
+theorem sharpRequiredBound_implies_requiredBound {k : ℕ}
+    (h : SharpRequiredBound k) : RequiredBound k := by
+  obtain ⟨δ, hδ, C, hC, hev⟩ := h
+  intro c hc
+  -- `log N → ∞`, hence `log log N → ∞`, hence `C·(log log N)^{-(1+δ)} → 0`.
+  have hlog : Filter.Tendsto (fun N : ℕ => Real.log (N : ℝ)) Filter.atTop Filter.atTop :=
+    Real.tendsto_log_atTop.comp tendsto_natCast_atTop_atTop
+  have hloglog : Filter.Tendsto (fun N : ℕ => Real.log (Real.log (N : ℝ)))
+      Filter.atTop Filter.atTop := Real.tendsto_log_atTop.comp hlog
+  have hδ1 : (0 : ℝ) < 1 + δ := by linarith
+  have hneg : Filter.Tendsto
+      (fun N : ℕ => C * (Real.log (Real.log (N : ℝ))) ^ (-(1 + δ)))
+      Filter.atTop (nhds 0) := by
+    have hmul := ((tendsto_rpow_neg_atTop hδ1).comp hloglog).const_mul C
+    simpa using hmul
+  -- Eventually the leading factor is below `c`, and `log N > 1` (so `log log N > 0`).
+  have hlt : ∀ᶠ N : ℕ in Filter.atTop,
+      C * (Real.log (Real.log (N : ℝ))) ^ (-(1 + δ)) < c := by
+    have hmem : Set.Iio c ∈ nhds (0 : ℝ) := isOpen_Iio.mem_nhds hc
+    filter_upwards [hneg.eventually hmem] with N hN using hN
+  have hLgt : ∀ᶠ N : ℕ in Filter.atTop, 1 < Real.log (N : ℝ) :=
+    hlog.eventually (eventually_gt_atTop 1)
+  filter_upwards [hev, hlt, hLgt] with N hN hNlt hL
+  set L : ℝ := Real.log (N : ℝ) with hLdef
+  have hL0 : 0 < L := lt_trans one_pos hL
+  have hLL0 : 0 < Real.log L := Real.log_pos hL
+  set M : ℝ := Real.log L with hMdef
+  have hMpow : (0 : ℝ) < M ^ (1 + δ) := Real.rpow_pos_of_pos hLL0 _
+  -- Turn the leading-factor bound `C · M^(-(1+δ)) < c` into `C ≤ c · M^(1+δ)`.
+  rw [Real.rpow_neg hLL0.le, ← div_eq_mul_inv] at hNlt
+  have hCle : C ≤ c * M ^ (1 + δ) := (div_le_iff₀ hMpow).mp hNlt.le
+  -- Bigger denominator on the left ⇒ the sharp bound transfers to the weak one.
+  refine le_trans hN ?_
+  rw [div_le_div_iff₀ (mul_pos hL0 hMpow) hL0]
+  have hfac : 0 ≤ (N : ℝ) * L * (c * M ^ (1 + δ) - C) :=
+    mul_nonneg (mul_nonneg (Nat.cast_nonneg N) hL0.le) (by linarith)
+  nlinarith [hfac]
+
 /-- **The strong threshold hypothesis is downward-closed in the length.**
     `StrongRequiredBound m` implies `StrongRequiredBound k` for every `k ≤ m`: the same
     witnesses `δ, C` work because `r_k(N) ≤ r_m(N) ≤ C·N/(log N)^{1+δ}` by `rothNumber_mono`.

--- a/src/data/proofs/erdos-3/meta.json
+++ b/src/data/proofs/erdos-3/meta.json
@@ -65,7 +65,7 @@
       }
     ],
     "axiomCount": 0,
-    "lineCount": 1169,
+    "lineCount": 1224,
     "prerequisites": [
       "Arithmetic progressions and their properties",
       "Series convergence and divergence (reciprocal sums)",
@@ -74,7 +74,7 @@
       "Extremal combinatorics (Ramsey-type reasoning)"
     ],
     "assumptions": "0 axioms. `euler_prime_sum_diverges` (Euler 1737, ∑ 1/p diverges) is now a proved theorem, discharged from Mathlib's `not_summable_one_div_on_primes`. 1 sorry remains in `required_bound_implies_conjecture` (the o(N/log N) threshold), which is threshold-critical: as hard as Erdős #3 itself. The strictly stronger (log N)^{1+δ} threshold reduction (`strong_required_bound_implies_conjecture`) is fully proved, sorry-free and axiom-free.",
-    "theoremCount": 32,
+    "theoremCount": 33,
     "definitionCount": 12
   },
   "overview": {
@@ -249,9 +249,9 @@
       "Finset"
     ],
     "namespace": "Erdos3",
-    "lineCount": 1169,
+    "lineCount": 1224,
     "axiomCount": 0,
-    "theoremCount": 32,
+    "theoremCount": 33,
     "definitionCount": 12,
     "path": "Proofs/Erdos3Problem.lean",
     "sorries": 1


### PR DESCRIPTION
## Summary

Adds `sharpRequiredBound_implies_requiredBound` to `Erdos3Problem.lean` (Erdős #3, sub-logarithmic-density AP conjecture), completing the threshold implication lattice.

The file had:
- `strongRequiredBound_implies_requiredBound` — `StrongRequiredBound ⇒ RequiredBound` (directly)
- `strongRequiredBound_implies_sharpRequiredBound` — `StrongRequiredBound ⇒ SharpRequiredBound`

but the edge **`SharpRequiredBound ⇒ RequiredBound`** was missing. This PR fills it:

| | `RequiredBound` = `o(N/log N)` |
|---|---|
| `StrongRequiredBound` = `O(N/(log N)^{1+δ})` | ✓ (direct) → now also via Sharp |
| `SharpRequiredBound` = `O(N/(log N·(log log N)^{1+δ}))` | **✓ (this PR)** |

**Why it holds:** writing the sharp bound as `r_k(N) ≤ (C·(log log N)^{−(1+δ)})·(N/log N)`, the leading factor `C·(log log N)^{−(1+δ)} → 0` since `log log N → ∞` (`tendsto_rpow_neg_atTop` at exponent `1+δ > 0`), so it is eventually below any `c > 0`. The proof mirrors the existing `strongRequiredBound_implies_requiredBound`, with the vanishing factor driven by the iterated logarithm instead of a positive power of `log N`.

**Consequence:** `StrongRequiredBound ⇒ SharpRequiredBound ⇒ RequiredBound` is now a full chain, and it certifies that the hypothesis of `sharp_required_bound_implies_conjecture` sits *strictly below* `o(N/log N)`. The genuinely open regime is the gap between `RequiredBound` and `SharpRequiredBound` — the `N/(log N·log log N)` borderline documented at `StrongRequiredBound`.

## Scope

- The open-crux `sorry` in `required_bound_implies_conjecture` is **untouched** — it is intentionally open (its docstring records the reduction is not known to be provable under the bare `o(N/log N)` hypothesis). `sorries` stays **1**.
- Axiom-free. `axiomCount` stays **0**. Meta `lineCount` 1169→1224, `theoremCount` 32→33 (both blocks).

## Verification

The new theorem typechecks against real Mathlib oleans (elan `lean v4.26.0`, cached Mathlib build) in isolation. The full-file docker build was unavailable — the **host disk is 100% full**, which is the underlying cause of the recurring containerd `meta.db` I/O errors; the worktree was reclaimed by the disk-full condition, so this commit was assembled via git plumbing (temporary index). The proof reuses the exact tactic structure of the already-compiling `strongRequiredBound_implies_requiredBound` in the same file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)