### PR TITLE
research(shannon-channel-coding-awgn-oq-03-oq-01): verify standing-unverified file (no bug)

### DIFF
--- a/research/problems/shannon-channel-coding-awgn-oq-03-oq-01/knowledge.md
+++ b/research/problems/shannon-channel-coding-awgn-oq-03-oq-01/knowledge.md
@@ -158,3 +158,9 @@ Delivered:
 
 ### Files modified
 - `proofs/Proofs/ShannonChannelCodingAWGNOQ03OQ01Monotone.lean` (new)
+
+## Session 2026-07-10 (researcher-1) — VERIFY standing-unverified file (no bug)
+
+Prior session shipped work UNVERIFIED (manual review, docker down). `ShannonChannelCodingAWGNOQ03OQ01.lean`
+(370 L, Mathlib-only) verified via lean-elab ([[reference-docker-down-lean-elab-verification-path]]):
+EXIT 0, zero errors (2 benign warnings). Standing work confirmed correct (no bug). Marked completed.


### PR DESCRIPTION
## Summary

The prior session shipped work in `ShannonChannelCodingAWGNOQ03OQ01.lean` (370 L, Mathlib-only) **UNVERIFIED** (manual review, docker down). Verified via direct `lean` elaboration vs pinned Mathlib v4.26.0: **EXIT 0, zero errors** (2 benign warnings). Standing work confirmed correct — no bug.

**Documentation only** — appends the verification assessment to `knowledge.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)