### PR TITLE
research(erdos-490-incomplete-01): product-set / distinct-products symmetry corollaries [VERIFIED]

### DIFF
--- a/proofs/Proofs/Erdos490Problem.lean
+++ b/proofs/Proofs/Erdos490Problem.lean
@@ -96,6 +96,28 @@ theorem productMapInjective_iff_hasDistinctProducts (A B : Finset ℕ) :
     have hy : ((a₂, b₂) : ℕ × ℕ) ∈ A ×ˢ B := Finset.mem_product.mpr ⟨ha₂, hb₂⟩
     have := h (Finset.mem_coe.mpr hx) (Finset.mem_coe.mpr hy) heq
     rw [Prod.mk.injEq] at this; exact this
+
+/-- **The product set is symmetric**: `A·B = B·A` as finsets.  Commutativity of
+multiplication (`a·b = b·a`) means the two product sets contain exactly the same
+elements, so they are literally equal (not merely equinumerous). -/
+theorem productSet_comm (A B : Finset ℕ) :
+    productSet A B = productSet B A := by
+  ext n
+  simp only [productSet, Finset.mem_biUnion, Finset.mem_image]
+  constructor
+  · rintro ⟨a, ha, b, hb, rfl⟩; exact ⟨b, hb, a, ha, by rw [mul_comm]⟩
+  · rintro ⟨b, hb, a, ha, rfl⟩; exact ⟨a, ha, b, hb, by rw [mul_comm]⟩
+
+/-- **Distinct products is symmetric in the two factors**: `HasDistinctProducts A B ↔
+HasDistinctProducts B A`.  Since `A·B = B·A` (`productSet_comm`) and `|A||B| = |B||A|`,
+the cardinality condition `|A·B| = |A||B|` is unchanged by swapping `A` and `B`.  This
+records that the whole distinctness/energy theory is symmetric — one need only study
+`|A| ≤ |B|`. -/
+theorem hasDistinctProducts_comm (A B : Finset ℕ) :
+    HasDistinctProducts A B ↔ HasDistinctProducts B A := by
+  rw [HasDistinctProducts, HasDistinctProducts, productSet_comm A B,
+    Nat.mul_comm A.card B.card]
+
 /-
 ## Part II: The Erdős Question
 -/

--- a/src/data/proofs/erdos-490/meta.json
+++ b/src/data/proofs/erdos-490/meta.json
@@ -217,9 +217,9 @@
       "Real"
     ],
     "namespace": "Erdos490",
-    "lineCount": 937,
+    "lineCount": 959,
     "axiomCount": 1,
-    "theoremCount": 29,
+    "theoremCount": 31,
     "definitionCount": 15,
     "path": "Proofs/Erdos490Problem.lean",
     "sorries": 0,


### PR DESCRIPTION
## Summary

Adds two **0-axiom** symmetry lemmas to `proofs/Proofs/Erdos490Problem.lean` (Erdős #490, distinct products of two sets), completing the factor-swap symmetry of the distinct-products / multiplicative-energy theory.

- `productSet_comm : productSet A B = productSet B A` — the product set `A·B = B·A` as finsets (literally equal, not merely equinumerous), via `mul_comm`.
- `hasDistinctProducts_comm : HasDistinctProducts A B ↔ HasDistinctProducts B A` — follows from `productSet_comm` + `Nat.mul_comm` on the cardinalities.

These complement the file's existing `multiplicativeEnergy_comm` (energy symmetry): the whole distinctness/energy theory is symmetric in `A, B`, so in the extremal analysis one may WLOG assume `|A| ≤ |B|`. Both proofs reuse only existing verified definitions — no new axioms or sorries.

## Verification

Full-file elaboration is clean under Lean 4.26.0 against the cached Mathlib oleans (host `lean`, `LEAN_PATH` = pinned package oleans): **zero errors**, only pre-existing unused-variable warnings. The Docker build wrapper is currently unavailable (host disk full), so this is verified via the local toolchain rather than the Docker path.

Gallery meta `src/data/proofs/erdos-490/meta.json`: `leanFile.lineCount` 937→959, `leanFile.theoremCount` 29→31.

🤖 Generated with [Claude Code](https://claude.com/claude-code)