### PR TITLE
research(puiseux-theorem-wip-01): Part XII — ramification tower at the field level [VERIFIED]

### DIFF
--- a/proofs/Proofs/PuiseuxTheorem.lean
+++ b/proofs/Proofs/PuiseuxTheorem.lean
@@ -1083,6 +1083,115 @@ theorem iSup_puiseuxRamificationSubring {K : Type*} [Ring K] :
 end Filtration
 
 /-! ═══════════════════════════════════════════════════════════════════════════════
+PART XII: THE RAMIFICATION TOWER AT THE FIELD LEVEL
+═══════════════════════════════════════════════════════════════════════════════ -/
+
+/-!
+### The colimit of Laurent *fields*
+
+Part XI built the ramification tower at the **ring** level
+(`puiseuxRamificationSubring`), stopping short of the field structure that the
+running commentary keeps invoking ("the colimit of Laurent *fields* along the
+ramification maps `x ↦ x^{1/n}`"). Over a `Field K` each level is in fact
+**inverse-closed**: the general inverse-closure `isPuiseux_inv` (Part X) preserves
+the ramification index, so `f⁻¹` stays at the *same* level `n` as `f`. Hence each
+floor `puiseuxRamificationSubring K n` is really a `Subfield` — the Laurent field
+`K((x^{1/n}))` — and the tower of these subfields, indexed by divisibility, has the
+full Puiseux subfield `K⦃⦃x⦄⦄` as its directed union. This makes the informal
+colimit-of-Laurent-fields description a machine-checked lattice identity.
+-/
+
+section FieldFiltration
+
+/-- **Level-`n` inverse-closure.** If `f` is a `(1/n)`-Laurent series (`support ⊆
+(1/n)ℤ`) over a field, then so is `f⁻¹`: the inverse-closure argument of `isPuiseux_inv`
+factors `f` through the field homomorphism induced by `ℤ ↪o ℚ, k ↦ k/n`, and `f⁻¹`'s
+support lands back in the range of that *same* embedding — the ramification index does
+not grow. This is the fixed-level refinement of `isPuiseux_inv` (Part X), and it is the
+one field-axiom missing from `puiseuxRamificationSubring`. -/
+theorem isPuiseuxOfRamification_inv {K : Type*} [Field K] {n : ℕ+} {f : HahnSeries ℚ K}
+    (hf : IsPuiseuxOfRamification n f) : IsPuiseuxOfRamification n f⁻¹ := by
+  have hn0 : (0 : ℚ) < (n : ℚ) := by exact_mod_cast n.pos
+  -- the additive hom `ℤ →+ ℚ`, `k ↦ k / n`
+  let φ₀ : ℤ →+ ℚ :=
+    { toFun := fun k => (k : ℚ) / (n : ℚ)
+      map_zero' := by simp
+      map_add' := fun a b => by push_cast; ring }
+  have hmono : ∀ g g' : ℤ, φ₀ g ≤ φ₀ g' ↔ g ≤ g' := by
+    intro g g'
+    show (g : ℚ) / (n : ℚ) ≤ (g' : ℚ) / (n : ℚ) ↔ g ≤ g'
+    rw [div_le_div_iff_of_pos_right hn0, Int.cast_le]
+  have hfi : Function.Injective φ₀ := fun a b hab =>
+    le_antisymm ((hmono a b).1 hab.le) ((hmono b a).1 hab.ge)
+  let emb : ℤ ↪o ℚ := ⟨⟨φ₀, hfi⟩, hmono _ _⟩
+  -- `f` is supported on the range of `emb = (1/n)ℤ`
+  have hfr : f.support ⊆ Set.range emb := by
+    intro q hq
+    obtain ⟨k, hk⟩ := hf q hq
+    exact ⟨k, hk.symm⟩
+  obtain ⟨g, hg⟩ := exists_embDomain_of_support_subset_range emb hfr
+  have key : ∀ x : HahnSeries ℤ K,
+      HahnSeries.embDomainRingHom φ₀ hfi hmono x = HahnSeries.embDomain emb x :=
+    fun _ => rfl
+  have hgf : HahnSeries.embDomainRingHom φ₀ hfi hmono g = f := by rw [key]; exact hg
+  have hinv : f⁻¹ = HahnSeries.embDomain emb g⁻¹ := by
+    rw [← hgf, ← map_inv₀ (HahnSeries.embDomainRingHom φ₀ hfi hmono) g, key]
+  rw [hinv]
+  intro q hq
+  obtain ⟨k, hk⟩ := Set.image_subset_range _ _ (HahnSeries.support_embDomain_subset hq)
+  exact ⟨k, hk.symm⟩
+
+/-- **The level-`n` Puiseux series form a subfield** — the Laurent field `K((x^{1/n}))`
+of `(1/n)`-ramified series. Upgrades `puiseuxRamificationSubring K n` (Part XI) to a
+`Subfield` using the level-preserving inverse-closure `isPuiseuxOfRamification_inv`; its
+carrier is again `{f | IsPuiseuxOfRamification n f}`. -/
+def puiseuxRamificationSubfield (K : Type*) [Field K] (n : ℕ+) : Subfield (HahnSeries ℚ K) where
+  carrier := {f | IsPuiseuxOfRamification n f}
+  zero_mem' := isPuiseuxOfRamification_zero n
+  one_mem' := isPuiseuxOfRamification_one n
+  add_mem' := fun ha hb => isPuiseuxOfRamification_add ha hb
+  mul_mem' := fun ha hb => isPuiseuxOfRamification_mul ha hb
+  neg_mem' := fun ha => isPuiseuxOfRamification_neg ha
+  inv_mem' := fun _ hx => isPuiseuxOfRamification_inv hx
+
+/-- Membership in the level-`n` subfield is definitionally ramification by `n`. -/
+@[simp] theorem mem_puiseuxRamificationSubfield {K : Type*} [Field K] (n : ℕ+)
+    (y : HahnSeries ℚ K) :
+    y ∈ puiseuxRamificationSubfield K n ↔ IsPuiseuxOfRamification n y := Iff.rfl
+
+/-- **The ramification subfields form an increasing tower.** If `n ∣ n'` then every
+`(1/n)`-Laurent series is a `(1/n')`-Laurent series, so
+`puiseuxRamificationSubfield K n ≤ puiseuxRamificationSubfield K n'`. This is the
+field-level refinement of `puiseuxRamificationSubring_mono`. -/
+theorem puiseuxRamificationSubfield_mono {K : Type*} [Field K] {n n' : ℕ+} (hdvd : n ∣ n') :
+    puiseuxRamificationSubfield K n ≤ puiseuxRamificationSubfield K n' :=
+  fun _ hx => IsPuiseuxOfRamification.mono hdvd hx
+
+/-- **Every level sits inside the full Puiseux subfield.** A `(1/n)`-ramified series is
+a fortiori a Puiseux series, so each floor of the field tower is bounded above by
+`puiseuxSubfield K`. -/
+theorem puiseuxRamificationSubfield_le_puiseuxSubfield {K : Type*} [Field K] (n : ℕ+) :
+    puiseuxRamificationSubfield K n ≤ puiseuxSubfield K :=
+  fun _ hx => ⟨n, hx⟩
+
+/-- **The Puiseux field is the colimit of the Laurent fields `K((x^{1/n}))`.** The
+directed union `⨆ n, puiseuxRamificationSubfield K n` of the level-`n` Laurent subfields
+is exactly the full Puiseux subfield: every level embeds
+(`puiseuxRamificationSubfield_le_puiseuxSubfield`) and every Puiseux series lands in
+*some* level (`isPuiseux_iff_exists_ramification`). This is the field-level capstone of
+the ramification filtration — the machine-checked form of
+`K⦃⦃x⦄⦄ = colim_n K((x^{1/n}))`. -/
+theorem iSup_puiseuxRamificationSubfield {K : Type*} [Field K] :
+    (⨆ n : ℕ+, puiseuxRamificationSubfield K n) = puiseuxSubfield K := by
+  refine le_antisymm (iSup_le puiseuxRamificationSubfield_le_puiseuxSubfield) ?_
+  intro x hx
+  rw [mem_puiseuxSubfield] at hx
+  obtain ⟨n, hn⟩ := hx
+  exact (le_iSup (puiseuxRamificationSubfield K) n) hn
+
+end FieldFiltration
+
+/-! ═══════════════════════════════════════════════════════════════════════════════
 SUMMARY
 ═══════════════════════════════════════════════════════════════════════════════ -/
 

--- a/research/problems/puiseux-theorem-wip-01/knowledge.md
+++ b/research/problems/puiseux-theorem-wip-01/knowledge.md
@@ -241,3 +241,51 @@ verified via [[reference-docker-down-lean-elab-verification-path]]:
 **Assessment: file SATURATED + now VERIFIED.** Structure complete through the ramification
 colimit capstone; the algebraic-closure frontier is >1000-line out of scope. No new lemma
 added (would be cosmetic); the value this session is turning UNVERIFIED→VERIFIED + cleanup.
+
+## Session (researcher-2, 2026-07-10): Part XII — ramification tower at the FIELD level
+
+**Mode**: REVISIT (MODERATE, saturated) · **Outcome**: progress (1 thm + 1 def + 3 thms,
+VERIFIED 0-sorry/0-axiom via local lean 4.26.0 — docker image-build down, ENOSPC/meta.db).
+Branch `research/erdos1006-oq0101-decidablepred` (pre-existing worktree branch).
+
+**Gap closed.** Part XI (researcher-1) built the ramification filtration only at the
+**ring** level (`puiseuxRamificationSubring`, `_mono`, `iSup_… = puiseuxSubring`), even
+though every Part-X/XI docstring describes the Puiseux field as "the colimit of Laurent
+**fields** along `x ↦ x^{1/n}`". Over a `Field K` each level is inverse-closed, so each
+floor is genuinely a `Subfield` — that field-level statement was promised in prose but
+never formalized.
+
+**Contribution — Part XII (section `FieldFiltration`):**
+1. `isPuiseuxOfRamification_inv [Field K] {n} {f} : IsPuiseuxOfRamification n f →
+   IsPuiseuxOfRamification n f⁻¹` — the fixed-level refinement of Part X's `isPuiseux_inv`.
+   Proof is `isPuiseux_inv`'s body verbatim but with the level hypothesis `hf` supplied
+   directly (no outer `obtain ⟨n,_⟩`) and the conclusion stated at the *same* `n` (the
+   embedding `ℤ ↪o ℚ, k↦k/n` is unchanged, so `f⁻¹`'s support stays in its range). This is
+   the one field-axiom `puiseuxRamificationSubring` was missing.
+2. `puiseuxRamificationSubfield (K) [Field K] (n) : Subfield (HahnSeries ℚ K)` — the
+   Laurent field `K((x^{1/n}))`; carrier `{f | IsPuiseuxOfRamification n f}`, `inv_mem'`
+   from (1), other fields reuse Part-XI level closure lemmas. `mem_…` `Iff.rfl`.
+3. `puiseuxRamificationSubfield_mono` (`n∣n' → ≤`, via `IsPuiseuxOfRamification.mono`),
+   `_le_puiseuxSubfield` (`fun _ hx => ⟨n, hx⟩`), and the capstone
+   `iSup_puiseuxRamificationSubfield : (⨆ n, puiseuxRamificationSubfield K n) =
+   puiseuxSubfield K` — field-level `K⦃⦃x⦄⦄ = colim_n K((x^{1/n}))`. All three are
+   line-for-line the Part-XI `Subring` versions with `Subring`→`Subfield`.
+
+**Verification (docker down — ENOSPC).** `docker-build.sh` still dies at *image build*
+with the containerd `meta.db: input/output error`; ROOT CAUSE this session confirmed = the
+host `/` volume is at 99% (≈150–180 Mi free), so containerd can't write its metadata store
+(and Edit's atomic-rename tmp write also hit ENOSPC until I freed my own /tmp junk). NOT a
+proof error. Verified via [[reference-docker-down-lean-elab-verification-path]]:
+`~/.elan/toolchains/leanprover--lean4---v4.26.0/bin/lean -R proofs` with
+`LEAN_PATH` = every `proofs/.lake/packages/*/.lake/build/lib/lean`. Full-file elaboration
+**EXIT 0, zero errors** (only the two pre-existing warnings at lines 353/380). `#print axioms`
+on `iSup_puiseuxRamificationSubfield`, `isPuiseuxOfRamification_inv`,
+`puiseuxRamificationSubfield_mono` = `[propext, Classical.choice, Quot.sound]` — no sorryAx,
+no ofReduceBool. Genuinely 0-axiom/0-sorry.
+
+**Files Modified:** proofs/Proofs/PuiseuxTheorem.lean (+Part XII: 4 thms + 1 def;
+1107→1216 lines), src/data/proofs/puiseux-theorem/meta.json (both count blocks synced:
+lineCount 1107→1216, theoremCount 34→39 & 36→41, definitionCount 7→8).
+
+**Assessment.** Structure line is now complete symmetrically at ring AND field level; the
+only remaining frontier is full Newton–Puiseux algebraic closure (>1000-line, out of scope).

--- a/src/data/proofs/puiseux-theorem/meta.json
+++ b/src/data/proofs/puiseux-theorem/meta.json
@@ -55,11 +55,11 @@
     ],
     "dateAdded": "2025-12-29",
     "axiomCount": 0,
-    "lineCount": 1107,
+    "lineCount": 1216,
     "assumptions": "No axiom declarations, no sorries, no native_decide (all theorems depend only on propext/Classical.choice/Quot.sound). The two headline placeholders (puiseux_theorem, puiseux_is_algebraic_closure) were replaced by genuine, fully computed Hahn-series theorems puiseux_binomial_root and puiseux_binomial_ramification, which establish the binomial base case of Puiseux's theorem (every binomial Yⁿ = c·xᵐ has a Puiseux root of ramification n over an algebraically closed field). Four narrative theorems remain as String-literal descriptors carrying no formal content (curve_branches_are_puiseux, newton_polygon_tropicalization, galois_group_is_profinite_integers, char_zero_required); each merely asserts ∃ desc : String, desc = \"…\" and marks an informal application/connection rather than a machine-checked result. This is a rigorously verified FRAGMENT: the full Newton–Puiseux theorem for arbitrary polynomials over the Puiseux field (assembling binomial roots term by term, with its char-0 convergence argument) is not formalized here — the required infrastructure is absent from Mathlib. Badge remains 'wip' to reflect that the headline algebraic-closure theorem is not fully proven.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 34,
-    "definitionCount": 7
+    "theoremCount": 39,
+    "definitionCount": 8
   },
   "overview": {
     "historicalContext": "Newton discovered the algorithm for computing fractional power series roots of polynomials in 1676. Puiseux gave the first rigorous proof in 1850 that these series provide the algebraic closure of the Laurent series field, establishing that allowing fractional exponents suffices to solve all polynomial equations over formal power series (in characteristic 0). The study of algebraic curves via local parametrization goes back to Newton who introduced the Newton polygon method to compute the branches of an algebraic curve at a singular point. The formal algebraic closure result was refined in the 20th century by Hironaka and others in connection with resolution of singularities, and the characteristic-0 hypothesis is essential: in characteristic p, the Artin-Schreier phenomenon means p-th power extensions cannot be captured by Puiseux series.",
@@ -173,10 +173,10 @@
       "Polynomial"
     ],
     "namespace": "PuiseuxTheorem",
-    "lineCount": 1107,
+    "lineCount": 1216,
     "axiomCount": 0,
-    "theoremCount": 36,
-    "definitionCount": 7,
+    "theoremCount": 41,
+    "definitionCount": 8,
     "path": "Proofs/PuiseuxTheorem.lean",
     "sorries": 0
   },


### PR DESCRIPTION
## Summary

Completes the ramification filtration of the Puiseux field **symmetrically at the field level**. Part XI built the tower only as `Subring`s (`puiseuxRamificationSubring`), even though every Part-X/XI docstring describes the Puiseux field as *"the colimit of Laurent **fields** along `x ↦ x^{1/n}`"*. Over a `Field K` each level is inverse-closed, so each floor is genuinely a `Subfield` — that field-level statement was promised in prose but never formalized. This PR closes that gap.

## New declarations (Part XII, `section FieldFiltration`)

- **`isPuiseuxOfRamification_inv`** — level-preserving inverse-closure: `IsPuiseuxOfRamification n f → IsPuiseuxOfRamification n f⁻¹`. The fixed-level refinement of Part X's `isPuiseux_inv` (the embedding `ℤ ↪o ℚ, k ↦ k/n` is unchanged, so `f⁻¹`'s support stays in its range — ramification does not grow). This is the one field-axiom `puiseuxRamificationSubring` was missing.
- **`puiseuxRamificationSubfield (K) [Field K] (n)`** — the Laurent field `K((x^{1/n}))`; upgrades `puiseuxRamificationSubring K n` to a `Subfield` via the new inverse-closure, reusing Part XI's level closure lemmas for the other fields. `mem_…` is `Iff.rfl`.
- **`puiseuxRamificationSubfield_mono`** (`n ∣ n' → ≤`) and **`_le_puiseuxSubfield`** — the subfields form an increasing tower bounded by `puiseuxSubfield K`.
- **`iSup_puiseuxRamificationSubfield`** — capstone: `(⨆ n, puiseuxRamificationSubfield K n) = puiseuxSubfield K`, the machine-checked `K⦃⦃x⦄⦄ = colim_n K((x^{1/n}))` at the field level.

All proofs are line-for-line the Part-XI `Subring` versions with `Subring → Subfield`, plus the fixed-level inverse-closure copied from Part X.

## Verification

**VERIFIED 0-sorry / 0-axiom.** Docker image-build is currently down (host disk at 99%, containerd `meta.db: input/output error`), so verified via local `lean 4.26.0` elaboration against the cached Mathlib oleans:

- Full-file elaboration: **EXIT 0, zero errors** (only the two pre-existing warnings at lines 353/380).
- `#print axioms` on `iSup_puiseuxRamificationSubfield`, `isPuiseuxOfRamification_inv`, `puiseuxRamificationSubfield_mono` = `[propext, Classical.choice, Quot.sound]` — no `sorryAx`, no `ofReduceBool`.

## Files

- `proofs/Proofs/PuiseuxTheorem.lean` (+Part XII: 4 theorems + 1 def; 1107 → 1216 lines)
- `src/data/proofs/puiseux-theorem/meta.json` (both count blocks synced: lineCount 1107→1216, theoremCount 34→39 & 36→41, definitionCount 7→8)
- `research/problems/puiseux-theorem-wip-01/knowledge.md` (session notes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)