### PR TITLE
research(pascals-hexagon-oq-03-incomplete-01): pairwise disjointness of the S₆ census classes [UNVERIFIED]

### DIFF
--- a/proofs/Proofs/PascalsHexagonOQ03Incomplete01.lean
+++ b/proofs/Proofs/PascalsHexagonOQ03Incomplete01.lean
@@ -246,4 +246,47 @@ theorem hexagrammum_total_from_census :
       = 95 := by
   simp only [card_sixCycles, card_doubleThreeCycles, card_tripleTranspositions]
 
+/-! ### Pairwise disjointness of the census classes
+
+`fixedPointFree_census_sum` and `census_cards_sum_eq_fixedPointFree` note in prose that
+the exact count "forces the four classes to be pairwise disjoint", but that disjointness
+is never itself formalized. The two results below supply it: the class predicates are
+pairwise mutually exclusive, so — together with the cover `fixedPointFree_iff_census` —
+the census is a genuine *partition* of the derangements of `Fin 6`. -/
+
+/-- **The four census classes are pairwise mutually exclusive.**  No permutation of `Sym(6)`
+    satisfies two of the fixed-point-free cycle-type predicates at once: `IsSixCycle`,
+    `IsFourTwoCycle`, `IsDoubleThreeCycle`, and `IsTripleTransposition` are pairwise
+    incompatible.  This is the disjointness that `fixedPointFree_census_sum` /
+    `census_cards_sum_eq_fixedPointFree` invoke in prose but do not formalize; with the cover
+    `fixedPointFree_iff_census` it upgrades the census to a partition of `derangements (Fin 6)`. -/
+theorem census_classes_pairwise_exclusive : ∀ σ : Equiv.Perm (Fin 6),
+    ¬(IsSixCycle σ ∧ IsFourTwoCycle σ) ∧
+    ¬(IsSixCycle σ ∧ IsDoubleThreeCycle σ) ∧
+    ¬(IsSixCycle σ ∧ IsTripleTransposition σ) ∧
+    ¬(IsFourTwoCycle σ ∧ IsDoubleThreeCycle σ) ∧
+    ¬(IsFourTwoCycle σ ∧ IsTripleTransposition σ) ∧
+    ¬(IsDoubleThreeCycle σ ∧ IsTripleTransposition σ) := by
+  native_decide
+
+/-- **The three Hexagrammum classes are pairwise disjoint as Finsets.**  Derived from
+    `census_classes_pairwise_exclusive` via `Finset.disjoint_filter`: the six-cycle,
+    double-3-cycle, and triple-transposition filters pairwise share no permutation.  This is
+    the combinatorial fact underlying `census_cards_sum_eq_fixedPointFree` and
+    `hexagrammum_total_from_census`: the `120 / 40 / 15` counts add with no overlap, so the
+    `60 + 20 + 15 = 95` configuration totals are genuine (non-double-counted) sums. -/
+theorem hexagrammum_classes_disjoint :
+    Disjoint (Finset.univ.filter (fun σ : Equiv.Perm (Fin 6) => IsSixCycle σ))
+             (Finset.univ.filter (fun σ : Equiv.Perm (Fin 6) => IsDoubleThreeCycle σ)) ∧
+    Disjoint (Finset.univ.filter (fun σ : Equiv.Perm (Fin 6) => IsSixCycle σ))
+             (Finset.univ.filter (fun σ : Equiv.Perm (Fin 6) => IsTripleTransposition σ)) ∧
+    Disjoint (Finset.univ.filter (fun σ : Equiv.Perm (Fin 6) => IsDoubleThreeCycle σ))
+             (Finset.univ.filter (fun σ : Equiv.Perm (Fin 6) => IsTripleTransposition σ)) :=
+  ⟨Finset.disjoint_filter.mpr
+      (fun σ _ h1 h2 => (census_classes_pairwise_exclusive σ).2.1 ⟨h1, h2⟩),
+   Finset.disjoint_filter.mpr
+      (fun σ _ h1 h2 => (census_classes_pairwise_exclusive σ).2.2.1 ⟨h1, h2⟩),
+   Finset.disjoint_filter.mpr
+      (fun σ _ h1 h2 => (census_classes_pairwise_exclusive σ).2.2.2.2.2 ⟨h1, h2⟩)⟩
+
 end PascalsHexagonOQ03Incomplete01

--- a/src/data/proofs/pascals-hexagon-oq-03-incomplete-01/meta.json
+++ b/src/data/proofs/pascals-hexagon-oq-03-incomplete-01/meta.json
@@ -24,11 +24,11 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 1,
-    "lineCount": 249,
+    "lineCount": 292,
     "assumptions": "0 sorries; 0 literal `axiom` declarations. The three census theorems (card_sixCycles = 120, card_doubleThreeCycles = 40, card_tripleTranspositions = 15) and the anchor card_sym6 = 720 are discharged by `native_decide`, which trusts the Lean compiler and so depends on the `Lean.ofReduceBool` axiom (axiomCount = 1). Under the project axiom-integrity policy this makes the entry `axiomatized`. The geometric bijection from these conjugacy classes to the actual Steiner/Kirkman/Plücker/Salmon points and lines is NOT formalized here — only the combinatorial class sizes are certified; the projective concurrence (the open steiner_count_eq_20 / kirkman_count_eq_60 targets in oq-03) remains future work.",
     "mathlib_version": "4.26.0",
     "dateAdded": "2026-07-04",
-    "theoremCount": 17,
+    "theoremCount": 19,
     "definitionCount": 5,
     "originalContributions": [
       "Identifies the Conway–Ryba (Math. Intelligencer 34 (2012) 4–8) conjugacy-class indexing of the Hexagrammum Mysticum and certifies its three governing class sizes in Lean over the concrete group Equiv.Perm (Fin 6).",
@@ -144,9 +144,9 @@
       "Equiv"
     ],
     "namespace": "PascalsHexagonOQ03Incomplete01",
-    "lineCount": 249,
+    "lineCount": 292,
     "axiomCount": 0,
-    "theoremCount": 17,
+    "theoremCount": 19,
     "definitionCount": 5,
     "path": "Proofs/PascalsHexagonOQ03Incomplete01.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

The S₆ cycle-type census fixes the four fixed-point-free class sizes (`120 / 90 / 40 / 15 = 265 = D₆`) and, via `fixedPointFree_iff_census`, proves they **cover** every derangement. Several docstrings (`fixedPointFree_census_sum`, `census_cards_sum_eq_fixedPointFree`) assert the exact count "forces the four classes to be **pairwise disjoint**" — but that disjointness is never itself formalized. These two additions supply it, upgrading the census from a cover to a genuine partition.

## New results

- **`census_classes_pairwise_exclusive`** — no permutation of `S₆` satisfies two of the four class predicates (`IsSixCycle`, `IsFourTwoCycle`, `IsDoubleThreeCycle`, `IsTripleTransposition`) simultaneously; all six pairwise exclusions, by `native_decide`. Together with the cover `fixedPointFree_iff_census`, this makes the census a genuine partition of `derangements (Fin 6)`.
- **`hexagrammum_classes_disjoint`** — the three geometric-class filters (six-cycles, double-3-cycles, triple-transpositions) are pairwise disjoint as `Finset`s, derived from the predicate exclusivity via `Finset.disjoint_filter` (no extra `native_decide`). This is the combinatorial fact underlying `census_cards_sum_eq_fixedPointFree` and `hexagrammum_total_from_census`: the `120 / 40 / 15` counts add with no overlap, so `60 + 20 + 15 = 95` are genuine sums.

## Verification

⚠️ **UNVERIFIED** — the Docker Lean build is down (the host disk filled up, corrupting `containerd`'s `meta.db` with I/O errors), so `docker-build.sh` could not run. The new `native_decide` theorem uses the identical mechanism as the file's already-verified census theorems (`card_sixCycles`, `fixedPointFree_iff_census`, …); the Finset corollary uses only standard API. Status stays `axiomatized` (`Lean.ofReduceBool`; `axiomCount` unchanged at 1). `meta.json`: `lineCount` 249→292, `theoremCount` 17→19 (both copies). Rebased onto current `origin/main` (baseline 249 matches).

🤖 Generated with [Claude Code](https://claude.com/claude-code)