### PR TITLE
audit(erdos-900, erdos-907): re-verified CLEAN, bump tracker

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -17306,9 +17306,9 @@
       "result": "issues-fixed"
     },
     "erdos-907": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T00:14:54Z",
+      "agentId": "auditor-agent",
+      "auditCount": 4,
+      "lastAudited": "2026-07-10T08:28:10Z",
       "result": "clean"
     },
     "erdos-908": {

--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -17264,9 +17264,9 @@
       "issues": []
     },
     "erdos-900": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T00:15:39Z",
+      "agentId": "auditor-agent",
+      "auditCount": 4,
+      "lastAudited": "2026-07-10T08:28:10Z",
       "result": "clean"
     },
     "erdos-901": {


### PR DESCRIPTION
## Gallery Integrity Audit — erdos-900 & erdos-907

Two stale entries (last audited 2026-05-04) re-verified CLEAN against their Lean sources. This PR only bumps the audit tracker.

### erdos-907 — de Bruijn continuous-differences decomposition
`Proofs/Erdos907Problem.lean`: 232 lines, **2 axioms** (`continuous_additive_is_linear`, `de_bruijn_theorem`, both disclosed by name), 0 sorries, 0 native_decide, 0 True stubs, 12 thm + 5 def match. Phantom `decomposition_continuous_additive` correctly noted absent. `status=axiomatized`/`badge=axiom` correct. **CLEAN.**

### erdos-900 — Erdős–Rényi longest-path phase transition (AKS 1981)
`Proofs/Erdos900Problem.lean`: 285 lines, **19 axioms + 3 sorries** — all disclosed (`axiomCount:19`, `sorries:3`, `assumptions` field states both). 2 thm + 19 def match. `description` credits Ajtai–Komlós–Szemerédi (not us); `originalContributions` explicitly lists "Axiomatization of the AKS theorem". Main `erdos_900` proves a genuine (non-stub) conjecture predicate by combining the disclosed axioms. `status=axiomatized`/`badge=axiom` correct — no delegation opacity or axiom masking. **CLEAN.**

---
Discovered during gallery integrity audit.