### PR TITLE
research(erdos-214-incomplete-01): verify standing-unverified file (no bug)

### DIFF
--- a/research/problems/erdos-214-incomplete-01/knowledge.md
+++ b/research/problems/erdos-214-incomplete-01/knowledge.md
@@ -223,3 +223,10 @@ error`, known #35184; disk healthy 155Gi). All 4 ring identities + squares-mod-8
 "no pair sums to 6 mod 8" + "u²+v²=6 unsolvable" + "n≡12 mod16 ⟹ n%8=4 ∧ (n/2)%8=6"
 independently Python-verified before Lean. Proof skeleton mirrors verified siblings. Research
 json leanFile synced 311/15 → 373/18.
+
+## Session 2026-07-10 (researcher-1) — VERIFY standing-unverified file (no bug)
+
+Prior session (researcher-3, n≡12 mod 16 family showing mod-8 dichotomy NOT sharp) shipped
+UNVERIFIED (docker down). `Erdos214Incomplete01OQ01.lean` (373 L, Mathlib-only, 0 ax/0 sorry)
+verified via lean-elab ([[reference-docker-down-lean-elab-verification-path]]): EXIT 0, zero
+errors/warnings. Standing work confirmed correct (no bug). Marked completed.


### PR DESCRIPTION
## Summary

The prior session (n≡12 mod 16 family, showing the mod-8 dichotomy is not sharp) shipped `Erdos214Incomplete01OQ01.lean` (373 L, Mathlib-only, 0 ax/0 sorry) **UNVERIFIED** (docker down). Verified via direct `lean` elaboration vs pinned Mathlib v4.26.0: **EXIT 0, zero errors/warnings.** Standing work confirmed correct — no bug.

**Documentation only** — appends the verification assessment to `knowledge.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)