### PR TITLE
Fix: resync 2 uncovered meta.lineCount drifts (erdos-771-construction, erdos-1006-oq-01)

### DIFF
--- a/src/data/proofs/erdos-1006-oq-01/meta.json
+++ b/src/data/proofs/erdos-1006-oq-01/meta.json
@@ -21,7 +21,7 @@
     "dateAdded": "2026-04-02",
     "axiomCount": 2,
     "assumptions": "2 axioms: chromatic_lt_girth_implies_robust (Fisher-Fraughnaugh-Langley-West 1997: χ(G) < girth(G) → G has robust orientation), nesetril_rodl_counterexample (Nešetřil-Rödl 1978: for every girth g≥3, there exists a graph with girth g that does NOT have a robust orientation). The Pretzel-Brightwell characterization (cover_graph_characterization) is now a proved theorem, not an axiom.",
-    "lineCount": 691,
+    "lineCount": 689,
     "theoremCount": 18,
     "definitionCount": 14,
     "originalContributions": [
@@ -114,7 +114,7 @@
   },
   "leanFile": {
     "namespace": "Erdos1006OQ01",
-    "lineCount": 691,
+    "lineCount": 689,
     "axiomCount": 2,
     "theoremCount": 18,
     "definitionCount": 14,

--- a/src/data/proofs/erdos-771-construction/meta.json
+++ b/src/data/proofs/erdos-771-construction/meta.json
@@ -19,7 +19,7 @@
     "badge": "verified",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 183,
+    "lineCount": 216,
     "assumptions": "None. Every theorem is elementary number theory / finite combinatorics with zero axioms and zero sorries (only the foundational propext/Classical.choice/Quot.sound; the quantitative theorem additionally uses Mathlib's verified Bertrand's postulate, itself 0-axiom). The deep asymptotic bounds of Erdős #771 (the matching (1/2+o(1))·n/log n lower and upper bounds) are NOT proved or assumed here.",
     "dateAdded": "2026-06-25",
     "mathlib_version": "4.26.0",
@@ -133,7 +133,7 @@
       "Mathlib"
     ],
     "namespace": "Erdos771Construction",
-    "lineCount": 183,
+    "lineCount": 216,
     "axiomCount": 0,
     "theoremCount": 6,
     "path": "Proofs/Erdos771Construction.lean",


### PR DESCRIPTION
## Fix

Resync two stale `meta.json` `lineCount` fields to match their Lean source files. Both drifts are genuine and uncovered by any open PR.

## Evidence

| slug | file | meta declared | actual `.lean` | cause |
|------|------|--------------|----------------|-------|
| erdos-771-construction | Erdos771Construction.lean | 183 | 216 | grew via merged Lean-only PR #37364 (meta not resynced) |
| erdos-1006-oq-01 | Erdos1006OQ01.lean | 691 | 689 | `.lean` shrank; meta not resynced |

Each `meta.json` carries two `lineCount` occurrences (leanFile block + files block); both updated in each file. Verified against live remote main (`gh api`): meta still read 183/691 while the source files are 216/689 lines. No open PR touches either `.lean` or `meta.json`, so these will not re-drift on merge.

Diff is exactly 2 files, 4 insertions / 4 deletions.

---
Automated fix by lean-mechanic agent.