### PR TITLE
Enrich Joint Typicality Lemma (Combinatorial Core): annotate closing remark

### DIFF
--- a/src/data/proofs/shannon-channel-coding-oq-02-oq-02/annotations.json
+++ b/src/data/proofs/shannon-channel-coding-oq-02-oq-02/annotations.json
@@ -86,5 +86,27 @@
       "prob_le_card_mul",
       "jointlyTypicalSet_card_le"
     ]
+  },
+  {
+    "id": "ann-proved-vs-deferred",
+    "proofId": "shannon-channel-coding-oq-02-oq-02",
+    "range": {
+      "startLine": 125,
+      "endLine": 146
+    },
+    "type": "context",
+    "title": "Proved vs. Deferred: Why the Assumption Count Stays 0",
+    "content": "The closing remark draws an honest boundary around what this file establishes. It formalizes the non-asymptotic, combinatorial core — Properties (2) and (3) — by taking the per-sequence probability bounds that *define* the jointly ε-typical set as hypotheses (`hpmem`, `hqmem`). This is faithful rather than circular: those bounds are definitional (a sequence lies in A_ε^{(n)} precisely when its empirical entropies in X, Y, and (X,Y) are all within ε of the true values), so the size and independence bounds are then exact finite-sum inequalities with no hidden analysis. The analytic half — Property (1), P((Xⁿ,Yⁿ) ∈ A_ε) → 1 — is the weak law of large numbers applied to the empirical information density -(1/n)·log p(Xⁿ,Yⁿ), and is deliberately NOT axiomatized: no `axiom` is introduced, so the assumption count stays 0 (consistent with the meta status `verified` and axiomCount 0). Formalizing (1) would require the i.i.d.-product construction plus an L²/Chebyshev concentration argument atop Mathlib's `ProbabilityTheory` law-of-large-numbers infrastructure — the natural next target. The trailing `#check` commands are a lightweight regression guard pinning the four exported names.",
+    "mathContext": "$-\\tfrac{1}{n}\\log p(X^n,Y^n) \\xrightarrow{\\;P\\;} H(X,Y) \\;\\Rightarrow\\; P\\big((X^n,Y^n)\\in A_\\varepsilon\\big)\\to 1\\quad\\text{(Property (1), deferred to the WLLN).}$",
+    "significance": "context",
+    "relatedConcepts": [
+      "weak law of large numbers",
+      "asymptotic equipartition property",
+      "axiom integrity"
+    ],
+    "prerequisites": [
+      "empirical information density",
+      "Chebyshev's inequality"
+    ]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `shannon-channel-coding-oq-02-oq-02` (Joint Typicality Lemma — Combinatorial Core).

## Gap addressed
The final section of the Lean file (lines 125–146, "Closing remark: what is proved and what is deferred") had **no annotation**, and the entry sat at 4 annotations — below the 5-annotation minimum. This adds one accurate, bounded annotation completing full-file coverage.

## Change
- **New annotation `ann-proved-vs-deferred`** (lines 125–146, type `context`):
  - Explains the honest boundary: Properties (2) size bound and (3) independence bound are proved as exact finite-sum inequalities by taking the *definitional* per-sequence typicality bounds as hypotheses (faithful, not circular).
  - Documents that Property (1) — $P((X^n,Y^n)\in A_\varepsilon)\to 1$, the weak law of large numbers on the empirical information density — is **deliberately not axiomatized**, so the assumption count stays 0 (consistent with meta `status: verified`, `axiomCount: 0`).
  - Notes the natural next target (i.i.d.-product + L²/Chebyshev atop Mathlib `ProbabilityTheory`).
  - Includes `mathContext`, `significance`, 3 `relatedConcepts`, 2 `prerequisites`.

## Verification
- JSON validated (parses, schema fields present); annotation ranges now cover through line 146 (full file).
- `meta.json` untouched (no size-cap impact; entry remains well under caps).
- No axiom-integrity discrepancy found: status `verified` / axiomCount 0 accurately reflects the Lean source (no `axiom` declarations, Property (1) deferred rather than assumed).