### PR TITLE
research(hilbert-10-oq-01-oq-02): affine invariance at level 2 (Σ₂/Π₂) [UNVERIFIED]

### DIFF
--- a/proofs/Proofs/Hilbert10OQ01OQ02.lean
+++ b/proofs/Proofs/Hilbert10OQ01OQ02.lean
@@ -3124,6 +3124,59 @@ theorem int_diophantine_iff_affinePullback_diophantine
     have hpq := hP q
     simpa only [affinePullback, hq] using hpq
 
+/-- **Affine invariance of the level-2 OPEN question (Σ₂).** For `a ≠ 0`, the
+    map `q ↦ a·q + b` is a bijection of `ℚ`, so ℤ is Σ₂-definable over ℚ iff
+    its affine pullback `{ q | a·q + b ∈ ℤ }` is. This is the level-2
+    (existential-universal) analog of
+    `int_diophantine_iff_affinePullback_diophantine`: the OPEN Σ₂(ℤ) question
+    `IntegersAreExistentialUniversalOverQ` is invariant under affine
+    reparametrization, exactly as its level-1 Σ₁ counterpart is. The forward
+    direction is the closure theorem
+    `affinePullback_isExistentialUniversalDefinition`; the converse pulls back
+    along the inverse map `q ↦ a⁻¹·q − a⁻¹·b`. -/
+theorem int_existentialUniversal_iff_affinePullback_existentialUniversal
+    (a b : Rat) (ha : a ≠ 0) :
+    IsExistentialUniversalDefinition IntSubset ↔
+      IsExistentialUniversalDefinition (affinePullback a b IntSubset) := by
+  constructor
+  · intro h
+    exact affinePullback_isExistentialUniversalDefinition a b h
+  · intro h
+    -- pull the pullback back along the inverse map `q ↦ a⁻¹·q − a⁻¹·b`
+    have hback := affinePullback_isExistentialUniversalDefinition a⁻¹ (-(a⁻¹ * b)) h
+    obtain ⟨P, hP⟩ := hback
+    refine ⟨P, fun q => ?_⟩
+    have hinv : a * a⁻¹ = 1 := mul_inv_cancel₀ ha
+    have hq : a * (a⁻¹ * q + -(a⁻¹ * b)) + b = q := by
+      linear_combination (q - b) * hinv
+    have hpq := hP q
+    simpa only [affinePullback, hq] using hpq
+
+/-- **Affine invariance of the settled level-2 (Π₂) statement.** For `a ≠ 0`,
+    ℤ is Π₂-definable over ℚ iff its affine pullback `{ q | a·q + b ∈ ℤ }` is.
+    Unlike the Σ₁/Σ₂ versions this iff has BOTH sides true (Koenigsmann 2016
+    settles the Π₂ level, and `affinePullback_int_isUniversalExistentialDefinition`
+    gives the pullback directly), but recording the reparametrization
+    invariance completes the level-2 pair alongside
+    `int_existentialUniversal_iff_affinePullback_existentialUniversal`. Same
+    inverse-map argument as the Σ₂ case. -/
+theorem int_universalExistential_iff_affinePullback_universalExistential
+    (a b : Rat) (ha : a ≠ 0) :
+    IsUniversalExistentialDefinition IntSubset ↔
+      IsUniversalExistentialDefinition (affinePullback a b IntSubset) := by
+  constructor
+  · intro h
+    exact affinePullback_isUniversalExistentialDefinition a b h
+  · intro h
+    have hback := affinePullback_isUniversalExistentialDefinition a⁻¹ (-(a⁻¹ * b)) h
+    obtain ⟨P, hP⟩ := hback
+    refine ⟨P, fun q => ?_⟩
+    have hinv : a * a⁻¹ = 1 := mul_inv_cancel₀ ha
+    have hq : a * (a⁻¹ * q + -(a⁻¹ * b)) + b = q := by
+      linear_combination (q - b) * hinv
+    have hpq := hP q
+    simpa only [affinePullback, hq] using hpq
+
 -- ============================================================
 -- Part IX: The landscape, sharpened
 -- ============================================================
@@ -3352,6 +3405,8 @@ consequences of the OQ-01 axioms together with the Σ₁ ↔ existing-formulatio
   - `sdiff_codiophantine_diophantine_isCoDiophantineDefinition` (Π₁ \ Σ₁ ⊆ Π₁, dual at level 1, iter 28)
   - `sdiff_sigma2_pi2_isExistentialUniversalDefinition` (Σ₂ \ Π₂ ⊆ Σ₂, level-2 analog, iter 28)
   - `sdiff_pi2_sigma2_isUniversalExistentialDefinition` (Π₂ \ Σ₂ ⊆ Π₂, level-2 dual — Boolean algebra of all four levels complete, iter 28)
+  - `int_existentialUniversal_iff_affinePullback_existentialUniversal` (affine invariance of the level-2 OPEN Σ₂(ℤ) question, a ≠ 0 — level-2 analog of the Σ₁ affine invariance, iter 30)
+  - `int_universalExistential_iff_affinePullback_universalExistential` (affine invariance of the settled Π₂(ℤ) statement, a ≠ 0 — completes the level-2 pair, iter 30)
 -/
 
 #check @IsDiophantineDefinition
@@ -3441,5 +3496,7 @@ consequences of the OQ-01 axioms together with the Σ₁ ↔ existing-formulatio
 #check @sdiff_codiophantine_diophantine_isCoDiophantineDefinition
 #check @sdiff_sigma2_pi2_isExistentialUniversalDefinition
 #check @sdiff_pi2_sigma2_isUniversalExistentialDefinition
+#check @int_existentialUniversal_iff_affinePullback_existentialUniversal
+#check @int_universalExistential_iff_affinePullback_universalExistential
 
 end Hilbert10Rationals

--- a/src/data/proofs/hilbert-10-oq-01-oq-02/meta.json
+++ b/src/data/proofs/hilbert-10-oq-01-oq-02/meta.json
@@ -146,7 +146,7 @@
     ],
     "dateAdded": "2026-05-08",
     "axiomCount": 1,
-    "lineCount": 3445,
+    "lineCount": 3502,
     "prerequisites": [
       "Hilbert's 10th problem over ℚ (companion file Hilbert10OQ01.lean)",
       "Arithmetic hierarchy (Σ_n / Π_n) at the level of polynomial formulas",
@@ -154,7 +154,7 @@
     ],
     "assumptions": "One axiom: `koenigsmann_2016_universal` — ℤ is Π₂-definable in ℚ. This is PROVED in Koenigsmann (Annals 2016) via an explicit polynomial built from Hilbert symbols and quaternion algebras over ℚ; axiomatized here pending a Lean formalization of that construction. All other results in this file (Σ₁ → ¬H10/ℚ-decidable, Mazur → ¬Σ₁, the Σ₁/Π₁ and Σ₂/Π₂ dualities and their specializations to ℤ ⊂ ℚ, the Π₁(ℚ\\ℤ) re-exports, the Π₁ ⊆ Σ₂ containment, and the Σ₂(ℚ\\ℤ) corollary of Koenigsmann) are NOT new axioms — they are logical consequences of the OQ-01 axioms together with the Σ₁/Π₁ and Σ₂/Π₂ equivalences proved here. Both duality theorems use classical excluded middle (`Classical.byContradiction`) to convert ¬¬p to p; the Σ₂/Π₂ duality and the Σ₂(ℚ\\ℤ) corollary use it twice, the Σ₁/Π₁ duality once.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 108,
+    "theoremCount": 110,
     "definitionCount": 17
   },
   "overview": {
@@ -302,9 +302,9 @@
     ],
     "opens": [],
     "namespace": "Hilbert10Rationals",
-    "lineCount": 3445,
+    "lineCount": 3502,
     "axiomCount": 1,
-    "theoremCount": 108,
+    "theoremCount": 110,
     "definitionCount": 17,
     "path": "Proofs/Hilbert10OQ01OQ02.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

Extends the affine-reparametrization invariance of the ℤ-over-ℚ definability question from **level 1 (Σ₁)** to **level 2 (Σ₂/Π₂)**, adding the level-2 twin of the existing `int_diophantine_iff_affinePullback_diophantine`.

The file's `affinePullback` section (iter 29) already proves closure of all four classes (Σ₁/Π₁/Σ₂/Π₂) under affine pullback `q ↦ a·q + b`, but the *invariance iff* (definability of ℤ ⟺ definability of its pullback, for `a ≠ 0`) existed only at level 1. This PR completes the pair at level 2.

## New theorems (2)

- **`int_existentialUniversal_iff_affinePullback_existentialUniversal`** — for `a ≠ 0`, ℤ is Σ₂-definable over ℚ iff `{q | a·q+b ∈ ℤ}` is. The OPEN `Σ₂(ℤ)` question (`IntegersAreExistentialUniversalOverQ`) is invariant under affine change of variables — the level-2 analog of the Σ₁ result.
- **`int_universalExistential_iff_affinePullback_universalExistential`** — the same for the *settled* `Π₂(ℤ)` statement (Koenigsmann 2016), completing the level-2 pair.

## Proof

Both are structural copies of the verified level-1 iff:
- **forward**: the existing `affinePullback_is{ExistentialUniversal,UniversalExistential}Definition` closure theorems;
- **converse**: pull back along the inverse map `q ↦ a⁻¹·q − a⁻¹·b` via `mul_inv_cancel₀` + `linear_combination` — the identical pattern used by the level-1 twin in the same file.

No new axioms, no new imports.

## Meta

- `lineCount` 3445 → 3502, `theoremCount` 108 → 110 (both meta blocks); `axiomCount` unchanged (1 = `koenigsmann_2016_universal`).

## Verification

⚠️ **UNVERIFIED** — the Docker build system is down (containerd meta.db I/O) and the host disk is at 100%, so this was not machine-checked this session. The proof reuses only lemmas already exercised identically by the verified level-1 twin (`int_diophantine_iff_affinePullback_diophantine`) in the same file; high confidence, pending a build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)