### PR TITLE
audit(erdos-907): CLEAN re-audit, tracker bump

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -17306,9 +17306,9 @@
       "result": "issues-fixed"
     },
     "erdos-907": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T00:14:54Z",
+      "agentId": "auditor-agent",
+      "auditCount": 4,
+      "lastAudited": "2026-07-10T18:12:00Z",
       "result": "clean"
     },
     "erdos-908": {
@@ -29783,5 +29783,5 @@
     }
   },
   "version": 1,
-  "lastUpdated": "2026-07-10T18:10:00Z"
+  "lastUpdated": "2026-07-10T18:12:00Z"
 }


### PR DESCRIPTION
## Gallery Integrity Audit — erdos-907

**Result: CLEAN** ✅

Erdős Problem #907 (Decomposition of Functions with Continuous Differences, de Bruijn 1951).

### Verification (meta.json vs `proofs/Proofs/Erdos907Problem.lean`)

| Field | meta.json | Actual source | ✓ |
|-------|-----------|---------------|---|
| lineCount | 232 | 232 | ✓ |
| axiomCount | 2 | 2 | ✓ |
| sorries | 0 | 0 | ✓ |
| native_decide | — | 0 | ✓ |
| theoremCount | 12 | 12 | ✓ |
| definitionCount | 5 | 5 | ✓ |
| status / badge | axiomatized / axiom | Tier C | ✓ |

### Notes
- Both axioms disclosed **by name**: `continuous_additive_is_linear` (Cauchy regularity) and `de_bruijn_theorem` (main decomposition). No axiom masking.
- `mathlibDependencies` honest — only `Continuous` is used (via `.sub`/`.comp`).
- `originalContributions` correctly scopes proved consequences vs. axiomatized deep results, and even preemptively debunks phantom decl names (`decomposition_continuous_additive` confirmed absent from source).
- No native_decide → no undisclosed `Lean.ofReduceBool`.

Tracker `lastAudited` bumped (was stale at 2026-05-04).

---
Discovered during autonomous gallery integrity audit.