### PR TITLE
research(liouville-theorem-oq-03): well-approximable fractals are uncountable

### DIFF
--- a/proofs/Proofs/LiouvilleTheoremOQ03.lean
+++ b/proofs/Proofs/LiouvilleTheoremOQ03.lean
@@ -411,4 +411,37 @@ theorem dimH_setOf_exists_liouvilleWith_gt_two_eq_one :
       simpa using this
     exact le_of_tendsto' htend hge
 
+/-! ## Part VIII: Cardinality — the fractals are uncountable
+
+The measure and dimension results above all say the well-approximable sets are
+*small*: for `τ > 2` they have Hausdorff dimension `< 1` (`dimH_wellApprox_lt_one`)
+and Lebesgue measure `0` (`volume_wellApprox_eq_zero`). The cardinality side is the
+opposite: they are *uncountable*. The mechanism is the contrapositive of
+`Set.Countable.dimH_zero` (a countable set has Hausdorff dimension `0`): since
+`dimH (W τ) = 2/τ > 0` for `τ ≥ 2` (`dimH_wellApprox_pos`), the set cannot be
+countable. This makes each `W τ` a genuine *fractal* in the strong sense —
+uncountably many points packed into a Lebesgue-null, sub-dimensional set. -/
+
+/-- **The well-approximable set is uncountable.** For `τ ≥ 2`, `W τ` cannot be
+countable: a countable set has Hausdorff dimension `0` (`Set.Countable.dimH_zero`),
+but `dimH (W τ) = 2/τ > 0` by `dimH_wellApprox_pos`. So although `W τ` is Lebesgue
+null and (for `τ > 2`) has dimension below the line, it still contains uncountably
+many reals. -/
+theorem not_countable_wellApprox {τ : ℝ} (hτ : 2 ≤ τ) : ¬ (wellApprox τ).Countable :=
+  fun hc => (dimH_wellApprox_pos hτ).ne' hc.dimH_zero
+
+/-- **The very-well-approximable reals are uncountable.** The set of `x` that are
+`τ`-well-approximable for *some* `τ > 2` — already shown to be Lebesgue-null
+(`volume_setOf_exists_liouvilleWith_gt_two_eq_zero`) yet of full Hausdorff
+dimension `1` (`dimH_setOf_exists_liouvilleWith_gt_two_eq_one`) — is in particular
+uncountable, since its dimension `1 ≠ 0`. The sharpest form of the "large yet
+measure-zero" phenomenon: a null set of maximal dimension carrying uncountably
+many points. -/
+theorem not_countable_setOf_exists_liouvilleWith_gt_two :
+    ¬ {x : ℝ | ∃ τ : ℝ, 2 < τ ∧ LiouvilleWith τ x}.Countable := by
+  intro hc
+  have h := hc.dimH_zero
+  rw [dimH_setOf_exists_liouvilleWith_gt_two_eq_one] at h
+  exact one_ne_zero h
+
 end LiouvilleTheoremOQ03

--- a/src/data/proofs/liouville-theorem-oq-03/meta.json
+++ b/src/data/proofs/liouville-theorem-oq-03/meta.json
@@ -23,8 +23,8 @@
     "dateAdded": "2026-06-24",
     "axiomCount": 1,
     "assumptions": "One axiom: `dimH_wellApprox` — the Jarník–Besicovitch dimension formula dimH(W τ) = ENNReal.ofReal(2/τ) for τ ≥ 2. This is the deep theorem of metric Diophantine approximation (Jarník 1931, Besicovitch 1934) and is not yet available in Mathlib (the upper bound requires a covering/Borel–Cantelli Hausdorff-measure estimate; the lower bound a mass-distribution principle / Frostman construction on a Cantor subset). `#print axioms` confirms: the structural lemmas (wellApprox_antitone, liouville_subset_wellApprox, dimH_liouville_le_wellApprox, and the jbDim exponent facts) depend on no axioms beyond the standard foundational trio; only the formula-dependent results (dimH_wellApprox_two, dimH_liouville_le, dimH_liouville_eq_zero, the summary) carry dimH_wellApprox.",
-    "lineCount": 414,
-    "theoremCount": 26,
+    "lineCount": 447,
+    "theoremCount": 28,
     "definitionCount": 2,
     "originalContributions": [
       "wellApprox τ := {x | LiouvilleWith τ x}: the τ-well-approximable sets, packaged on top of Mathlib's LiouvilleWith with the JB exponent in mind",
@@ -134,9 +134,9 @@
     "path": "Proofs/LiouvilleTheoremOQ03.lean",
     "sorries": 0,
     "axiomCount": 1,
-    "theoremCount": 26,
+    "theoremCount": 28,
     "definitionCount": 2,
-    "lineCount": 414
+    "lineCount": 447
   },
   "sorries": 0
 }


### PR DESCRIPTION
## Summary

Extends the Jarník–Besicovitch entry (`liouville-theorem-oq-03`, *Hausdorff Dimension of Well-Approximable Sets*) with a new **Part VIII: Cardinality**. The existing file establishes that the τ-well-approximable sets `W τ` are *small* — Hausdorff dimension `< 1` for `τ > 2` and Lebesgue measure zero. This PR adds the complementary *size* fact: they are **uncountable**.

## New theorems (2)

- `not_countable_wellApprox {τ} (hτ : 2 ≤ τ) : ¬ (wellApprox τ).Countable` — via the contrapositive of `Set.Countable.dimH_zero` (countable ⟹ Hausdorff dimension 0) applied to the file's `dimH_wellApprox_pos` (`dimH (W τ) = 2/τ > 0`).
- `not_countable_setOf_exists_liouvilleWith_gt_two` — the very-well-approximable reals (already shown Lebesgue-null yet of full dimension 1) are uncountable, since `1 ≠ 0`.

Together these complete the size trichotomy for these fractals: **measure-zero, sub-line-dimensional, yet uncountable** — the strong form of the measure-zero-but-large phenomenon.

## Verification

Compiled locally against the cached Mathlib olean set (lean v4.26.0, Docker image build is down): the file elaborates with **no errors** (only a pre-existing `le_or_lt` deprecation warning on base line 200). Proofs reuse only existing verified lemmas from the file plus `Set.Countable.dimH_zero`; no new axioms (`axiomCount` unchanged at 1, the Jarník–Besicovitch formula).

Meta synced: `lineCount` 414→447, `theoremCount` 26→28 (both `leanFile` and `meta` blocks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)