### PR TITLE
Enrich: The Minimum Collision Number is Exactly 2 (annotate imports region)

### DIFF
--- a/src/data/proofs/dissection-of-cubes-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/dissection-of-cubes-oq-01-oq-02/annotations.json
@@ -1,5 +1,17 @@
 [
   {
+    "id": "diss-oq0102-imports",
+    "proofId": "dissection-of-cubes-oq-01-oq-02",
+    "range": { "startLine": 1, "endLine": 5 },
+    "type": "context",
+    "title": "Imports encode the packaging architecture",
+    "content": "The import list is itself the proof architecture in miniature: this file proves *nothing new about geometry* — it packages two already-proved sibling results into the canonical minimum statement, and the two Proofs.* imports are exactly those two ingredients. `Proofs.DissectionOfCubesOQ01` supplies the lower-bound half (at_least_two_colliding_cubes) together with the collidingCubes definition; `Proofs.DissectionOfCubesOQ01OQ01` supplies the achievability half (the exampleDissection attaining 2, plus the cubeA/cubeB constructions reused to build the third witness). The Mathlib imports are minimal by design: `Mathlib.Tactic` for omega/simp/decide, `Mathlib.Data.Finset.Basic` for the card_insert/card_pair arithmetic used to count the three-cube collision set, and `Mathlib.Data.Real.Basic` for the real-coordinate cube corners. Because the covering constraint lives in the base CubeDissection structure (imported transitively), no covering theory is pulled in here — the single inherited axiom enters through the OQ-01 import, not through anything stated in this file.",
+    "mathContext": "$\\text{OQ01} \\;(\\ge 2) \\;\\wedge\\; \\text{OQ01OQ01} \\;(=2 \\text{ attained}) \\;\\Longrightarrow\\; \\mathrm{IsLeast}\\,\\mathrm{collisionSpectrum}\\,2.$",
+    "significance": "context",
+    "relatedConcepts": ["proof by packaging", "dependency architecture", "Finset cardinality", "transitive axiom inheritance"],
+    "prerequisites": ["Lean import/open mechanics", "the OQ-01 and OQ-01-OQ-01 sibling files"]
+  },
+  {
     "id": "diss-oq0102-header",
     "proofId": "dissection-of-cubes-oq-01-oq-02",
     "range": { "startLine": 7, "endLine": 48 },


### PR DESCRIPTION
Enrichment pass for `dissection-of-cubes-oq-01-oq-02`.

This entry is already saturated (quality 95): 8 full annotations, rich meta.json with 6 keyInsights, 4 sections, 4 crossReferences, and a complete conclusion. The one genuine annotation-coverage gap was the imports/setup region (lines 1–5), which had no annotation.

**Change (annotations-only, meta.json untouched):**
- Added `diss-oq0102-imports` (type `context`, range 1–5) explaining that the import list *is* the proof architecture in miniature: this file proves nothing new geometrically — it packages two already-proved sibling results, and the two `Proofs.*` imports are exactly those ingredients (`DissectionOfCubesOQ01` lower bound + `DissectionOfCubesOQ01OQ01` achievability witness). Also notes why the Mathlib imports are minimal and that the single inherited axiom enters transitively via the OQ-01 import, not from anything stated in this file.

**Guardrails:** annotations.json 11.4 KB, meta.json unchanged at 14.7 KB — both well under the ~60 KB cap. `pnpm annotations:build` passes (exit 0); the new annotation raises no validation warning.