### PR TITLE
audit(erdos-899): re-verified CLEAN, bump tracker

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -17245,9 +17245,9 @@
       "result": "clean"
     },
     "erdos-899": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T00:16:40Z",
+      "agentId": "auditor-agent",
+      "auditCount": 4,
+      "lastAudited": "2026-07-10T18:20:00Z",
       "result": "clean"
     },
     "erdos-9": {
@@ -29783,5 +29783,5 @@
     }
   },
   "version": 1,
-  "lastUpdated": "2026-07-10T18:10:00Z"
+  "lastUpdated": "2026-07-10T18:20:00Z"
 }


### PR DESCRIPTION
## Gallery Integrity Audit — erdos-899

**Result: CLEAN** ✅

Erdős Problem #899 (Growth of Difference Sets; Ruzsa 1978).

### Verification (meta.json vs `proofs/Proofs/Erdos899Problem.lean`)

| Field | meta.json | Actual | ✓ |
|-------|-----------|--------|---|
| lineCount | 140 | 140 | ✓ |
| axiomCount | 1 | 1 | ✓ |
| sorries | 0 | 0 | ✓ |
| native_decide | — | 0 | ✓ |
| theoremCount | 3 | 3 | ✓ |
| definitionCount | 6 | 6 | ✓ |
| status / badge | axiomatized / axiom | Tier C | ✓ |

### Notes
- Single axiom `ruzsa_difference_growth` disclosed by name in `assumptions`. It is a genuine non-vacuous statement (`Tendsto (fun N => diffCountingFn/countingFn) atTop atTop`), **not** a `True`-stub. No axiom masking.
- `erdos_899` is a one-line application of the axiom (disclosed).
- `originalContributions` are honestly scoped (statement + definitions + powers-of-2 examples + additive-combinatorics context); no phantom decls named.
- No native_decide → no undisclosed `Lean.ofReduceBool`.

Tracker `lastAudited` bumped (was stale at 2026-05-04).

---
Discovered during autonomous gallery integrity audit.