### PR TITLE
research(erdos-729-oq-02): exact zero-locus v_p(n!)=0 ⟺ n<p [VERIFIED]

### DIFF
--- a/proofs/Proofs/Erdos729LegendreGeneral.lean
+++ b/proofs/Proofs/Erdos729LegendreGeneral.lean
@@ -128,6 +128,43 @@ theorem padicValNat_factorial_le_div (p n : ℕ) (hp : p.Prime) :
   rw [padicValNat_factorial_eq_div p n hp]
   exact Nat.div_le_div_right (Nat.sub_le n ((p.digits n).sum))
 
+/-- **The exact zero-locus of `v_p(n!)`.**  For every prime `p`,
+
+  `v_p(n!) = 0  ↔  n < p`.
+
+The upper-bound lemmas above (`padicValNat_factorial_le_div` etc.) pin the growth of
+`v_p(n!)` from above; this identifies exactly where the valuation *vanishes*.  A prime `p`
+first appears as a factor of `n!` precisely at `n = p`, so `n! ` is coprime to `p` iff
+`n < p`.  Proven directly from `Nat.Prime.dvd_factorial` (`p ∣ n! ↔ p ≤ n`) together with
+the standard positivity/vanishing lemmas for `padicValNat`, independently of the
+digit-sum machinery — and it is the natural base case for the sandwich
+`0 ≤ v_p(n!) ≤ n/(p-1)`. -/
+theorem padicValNat_factorial_eq_zero_iff (p n : ℕ) (hp : p.Prime) :
+    padicValNat p n.factorial = 0 ↔ n < p := by
+  haveI : Fact p.Prime := ⟨hp⟩
+  constructor
+  · intro h
+    by_contra hle
+    push_neg at hle
+    have hdvd : p ∣ n.factorial := hp.dvd_factorial.mpr hle
+    have : 1 ≤ padicValNat p n.factorial :=
+      one_le_padicValNat_of_dvd (Nat.factorial_ne_zero n) hdvd
+    omega
+  · intro hlt
+    exact padicValNat.eq_zero_of_not_dvd
+      (fun hdvd => absurd (hp.dvd_factorial.mp hdvd) (Nat.not_le.mpr hlt))
+
+/-- **The valuation `v_p(n!)` is positive exactly once `n` reaches `p`.**  The
+complement of `padicValNat_factorial_eq_zero_iff`: for every prime `p`,
+
+  `0 < v_p(n!)  ↔  p ≤ n`,
+
+i.e. `p` divides `n!` iff `n ≥ p`.  Together with the zero-locus statement this gives the
+sharp dichotomy governing the lowest step of Legendre's staircase. -/
+theorem padicValNat_factorial_pos_iff (p n : ℕ) (hp : p.Prime) :
+    0 < padicValNat p n.factorial ↔ p ≤ n := by
+  rw [Nat.pos_iff_ne_zero, ne_eq, padicValNat_factorial_eq_zero_iff p n hp, Nat.not_lt]
+
 -- The numerical content (v_p(n!) = (n - s_p(n))/(p-1) for many p, n) is certified
 -- independently in `research/problems/erdos-729-oq-02/verify_legendre_general.py`
 -- (no Lean `decide` on `Nat.digits`, which is well-founded and does not reduce
@@ -140,5 +177,7 @@ theorem padicValNat_factorial_le_div (p n : ℕ) (hp : p.Prime) :
 #check @sub_one_mul_padicValNat_factorial_le
 #check @padicValNat_factorial_le_div
 #check @modEq_digitSum
+#check @padicValNat_factorial_eq_zero_iff
+#check @padicValNat_factorial_pos_iff
 
 end Erdos729Legendre

--- a/src/data/research/problems/erdos-729-oq-02.json
+++ b/src/data/research/problems/erdos-729-oq-02.json
@@ -105,8 +105,8 @@
     {
       "path": "Proofs/Erdos729LegendreGeneral.lean",
       "filename": "Erdos729LegendreGeneral.lean",
-      "lineCount": 93,
-      "theoremCount": 3,
+      "lineCount": 183,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,


### PR DESCRIPTION
## Summary

Adds two **axiom-free, locally-verified** theorems to `proofs/Proofs/Erdos729LegendreGeneral.lean`, the general-$p$ Legendre companion for Erdős #729 (OQ-02). The file already proves the classical division identity $v_p(n!)=(n-s_p(n))/(p-1)$ and the sharp **upper** bounds $v_p(n!)\le n/(p-1)$. This PR pins the **base of the staircase** — exactly where the valuation vanishes:

- `padicValNat_factorial_eq_zero_iff (p n) (hp : p.Prime) : padicValNat p n! = 0 ↔ n < p`
- `padicValNat_factorial_pos_iff  (p n) (hp : p.Prime) : 0 < padicValNat p n! ↔ p ≤ n`

A prime $p$ first appears as a factor of $n!$ precisely at $n=p$, so $n!$ is coprime to $p$ iff $n<p$. Together with the file's upper bounds this completes the dichotomy governing the lowest step of Legendre's staircase, $0\le v_p(n!)\le n/(p-1)$.

## Proof

Direct, independent of the digit-sum machinery:
- `Nat.Prime.dvd_factorial : p ∣ n! ↔ p ≤ n`
- `one_le_padicValNat_of_dvd` (positivity when $p\mid n!$) and `padicValNat.eq_zero_of_not_dvd` (vanishing otherwise)
- `pos_iff` is the `Nat.pos_iff_ne_zero` complement of `eq_zero_iff`

## Verification

Docker image build is down (containerd meta.db I/O). Verified locally with **lean v4.26.0** against the pinned Mathlib oleans:
- File typechecks with **0 errors / 0 sorries**.
- `#print axioms` for both new theorems lists only `[propext, Classical.choice, Quot.sound]` — no `sorryAx`, no `Lean.ofReduceBool`. Genuinely axiom-free.

## Metadata

Synced the research-problem json `leanFile` entry for this file, correcting its stale `93/3` (predating merged PR #37365) to the true post-edit `183/10`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)