### PR TITLE
research(erdos-1090): complete colored Ramsey realizable-cardinality API [VERIFIED]

### DIFF
--- a/proofs/Proofs/Erdos1090Problem.lean
+++ b/proofs/Proofs/Erdos1090Problem.lean
@@ -803,6 +803,62 @@ theorem ramseyNumberColored_mono {C : Type*} [Finite C] {k k' : ℕ} (hk' : 3 �
   refine Nat.sInf_le ⟨A, ?_, hasRamseyPropertyColored_antitone hkk hA⟩
   simpa [ramseyNumberColored] using hcard
 
+/--
+**The colored Ramsey number is an attained minimum.**  For a finite palette `C` and `k ≥ 3` the
+defining set is nonempty (`hasRamseyPropertyColored_construction` supplies a witness), so the
+infimum `R_C(k)` is *realized* by an actual optimal configuration: there is a finite `A` with
+`|A| = R_C(k)` that already has the `C`-colored Ramsey property.  Together with
+`ramseyNumberColored_lower_bound` (`k ≤ R_C(k)`) this pins `R_C(k)` down as a genuine minimum
+rather than a mere infimum.  The colored analogue of
+`exists_hasRamseyProperty_card_eq_ramseyNumber`. -/
+theorem exists_hasRamseyPropertyColored_card_eq_ramseyNumberColored
+    (C : Type*) [Finite C] (k : ℕ) (hk : k ≥ 3) :
+    ∃ A : Finset Point, A.card = ramseyNumberColored C k ∧ HasRamseyPropertyColored C A k := by
+  have hne : {n : ℕ | ∃ A : Finset Point, A.card = n ∧ HasRamseyPropertyColored C A k}.Nonempty := by
+    obtain ⟨A, hA⟩ := hasRamseyPropertyColored_construction C k hk
+    exact ⟨A.card, A, rfl, hA⟩
+  obtain ⟨A, hcard, hA⟩ := Nat.sInf_mem hne
+  exact ⟨A, hcard, hA⟩
+
+/--
+**Every size above `R_C(k)` is realizable (colored).**  For a finite palette `C`, `k ≥ 3` and any
+`n ≥ R_C(k)` there is a configuration of *exactly* `n` points with the `C`-colored Ramsey property.
+Take the extremal witness of size `R_C(k)`
+(`exists_hasRamseyPropertyColored_card_eq_ramseyNumberColored`) and pad it with fresh plane points,
+one at a time: the plane is infinite, so a point outside the current set always exists, and
+enlarging preserves the colored property (`hasRamseyPropertyColored_mono`).  The colored analogue
+of `exists_hasRamseyProperty_card_eq`. -/
+theorem exists_hasRamseyPropertyColored_card_eq {C : Type*} [Finite C] {k : ℕ} (hk : k ≥ 3)
+    {n : ℕ} (hn : ramseyNumberColored C k ≤ n) :
+    ∃ A : Finset Point, A.card = n ∧ HasRamseyPropertyColored C A k := by
+  obtain ⟨A, hAcard, hA⟩ := exists_hasRamseyPropertyColored_card_eq_ramseyNumberColored C k hk
+  have hAn : A.card ≤ n := hAcard ▸ hn
+  clear hAcard hn
+  induction n, hAn using Nat.le_induction with
+  | base => exact ⟨A, rfl, hA⟩
+  | succ m _ ih =>
+    obtain ⟨B, hBcard, hB⟩ := ih
+    obtain ⟨p, hp⟩ := Infinite.exists_notMem_finset B
+    exact ⟨insert p B, by rw [Finset.card_insert_of_notMem hp, hBcard],
+      hasRamseyPropertyColored_mono (Finset.subset_insert p B) hB⟩
+
+/--
+**Realizable cardinalities are exactly the ray `[R_C(k), ∞)` (colored).**  For a finite palette `C`
+and `k ≥ 3`, a finite point set of size `n` with the `C`-colored Ramsey property exists *iff*
+`R_C(k) ≤ n`.  The forward direction is `ramseyNumberColored_le_of_hasRamseyProperty` (any witness
+bounds the infimum from above); the reverse is the padding argument
+`exists_hasRamseyPropertyColored_card_eq`.  This pins down the realizable-size set completely as the
+full up-set above the threshold, with no gaps — the colored analogue of
+`hasRamseyProperty_realizable_card_iff`. -/
+theorem hasRamseyPropertyColored_realizable_card_iff {C : Type*} [Finite C] {k : ℕ} (hk : k ≥ 3)
+    (n : ℕ) :
+    (∃ A : Finset Point, A.card = n ∧ HasRamseyPropertyColored C A k) ↔
+      ramseyNumberColored C k ≤ n := by
+  constructor
+  · rintro ⟨A, hcard, hA⟩
+    exact hcard ▸ ramseyNumberColored_le_of_hasRamseyProperty hA
+  · exact exists_hasRamseyPropertyColored_card_eq hk
+
 /-
 **R(3) is Small:**
 The k = 3 case can be achieved with a small set of points.

--- a/src/data/proofs/erdos-1090/meta.json
+++ b/src/data/proofs/erdos-1090/meta.json
@@ -74,9 +74,9 @@
       "ramseyNumberColored_mono_colors (0-axiom): palette monotonicity — if C ↪ C' then R_C(k) ≤ R_{C'}(k); more colors cannot lower the threshold. Proved via hasRamseyPropertyColored_of_embedding (a C-coloring pushes forward along e, and injectivity of e pulls monochromaticity back). ramseyNumberColored_congr gives recoloring invariance (C ≃ C' ⟹ equal), ramseyNumberColored_mono_fin the monotone chain R_{Fin r} ≤ R_{Fin r'} for r ≤ r', and ramseyNumber_le_ramseyNumberColored_fin the bound R(k) ≤ R_{Fin r}(k) for r ≥ 2 (via finTwoEquiv)"
     ],
     "axiomCount": 0,
-    "lineCount": 1123,
+    "lineCount": 1179,
     "assumptions": "None. 0 axiom declarations, 0 sorries. Both former axioms (graham_selfridge, hunter_observation) are now theorems proved from Mathlib's Hales-Jewett theorem. #print axioms reports only the standard foundational axioms [propext, Classical.choice, Quot.sound]; no sorryAx, no Lean.ofReduceBool. The Line structure's `nonzero` field is constructive data (a witnessed direction), not an assumption.",
-    "theoremCount": 37,
+    "theoremCount": 40,
     "definitionCount": 20
   },
   "overview": {
@@ -113,9 +113,9 @@
       "Finset"
     ],
     "namespace": "Erdos1090",
-    "lineCount": 1123,
+    "lineCount": 1179,
     "axiomCount": 0,
-    "theoremCount": 37,
+    "theoremCount": 40,
     "definitionCount": 20,
     "path": "Proofs/Erdos1090Problem.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

Erdős #1090 (monochromatic collinear points) is fully verified in `Erdos1090Problem.lean`. The file develops both an **uncolored** `ramseyNumber` API (2-colorings) and a **colored** `ramseyNumberColored C` API (arbitrary finite palette). The uncolored side has a complete *realizable-cardinality* trio — attained minimum, padding above threshold, and a realizable-iff characterization (lines 556–607). The colored side previously had only monotonicity/embedding lemmas. This PR closes that symmetry gap.

## New theorems (3)

1. **`exists_hasRamseyPropertyColored_card_eq_ramseyNumberColored`** — for finite `C`, `k ≥ 3`, the colored Ramsey number `R_C(k)` is an *attained* minimum: there is a set of exactly `R_C(k)` points with the colored property. (Defining set nonempty via `hasRamseyPropertyColored_construction`.)
2. **`exists_hasRamseyPropertyColored_card_eq`** — every `n ≥ R_C(k)` is realizable: pad the extremal witness with fresh plane points (`Infinite Point` + `hasRamseyPropertyColored_mono`).
3. **`hasRamseyPropertyColored_realizable_card_iff`** — realizable cardinalities are exactly the ray `[R_C(k), ∞)`.

Each mirrors the corresponding verified uncolored proof (`exists_hasRamseyProperty_card_eq_ramseyNumber`, `exists_hasRamseyProperty_card_eq`, `hasRamseyProperty_realizable_card_iff`). All reuse existing verified lemmas; **no new axioms or sorries**.

## Verification

Compiled locally with **lean v4.26.0** (the pinned toolchain from `lean-toolchain`) against cached Mathlib oleans — **0 errors**, only pre-existing warnings (lines 66, 424, 880, none introduced here). The Docker image build is currently down (containerd `meta.db` input/output error), so CI-parity was not run in Docker.

## meta.json

`lineCount` 1123→1179, `theoremCount` 37→40 (both `meta` and `leanFile` blocks). Status remains `verified` / 0 axioms / 0 sorries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)