### PR TITLE
Enrich: Hall's marriage theorem OQ-01 (annotate the typeclass setup)

### DIFF
--- a/src/data/proofs/hall-marriage-theorem-oq-01/annotations.json
+++ b/src/data/proofs/hall-marriage-theorem-oq-01/annotations.json
@@ -12,6 +12,18 @@
     "prerequisites": ["combinatorics", "finite sets", "injections"]
   },
   {
+    "id": "ann-variable-setup",
+    "proofId": "hall-marriage-theorem-oq-01",
+    "range": { "startLine": 53, "endLine": 56 },
+    "type": "technique",
+    "title": "The Typeclass Setup Encodes the Generality",
+    "content": "The `variable {ι α : Type*} [DecidableEq α]` line is doing real mathematical work by what it *omits*. The index type $\\iota$ carries **no** `Fintype` or `Finite` instance, and the value type $\\alpha$ carries only `DecidableEq` (needed so that `Finset α`, `biUnion`, and `image` are well-defined). In particular there is no finiteness assumption on the family's index set. This is precisely why the necessity direction (`hall_condition_of_sdr`) generalizes to an arbitrary — possibly infinite — index type: its proof touches only a single finite sub-family $s : \\mathrm{Finset}\\,\\iota$ at a time and never quantifies over all of $\\iota$. The sufficiency direction, by contrast, silently requires the finiteness that Mathlib's `all_card_le_biUnion_card_iff_exists_injective` supplies through Rado's compactness argument. So the section-level split between the cheap and the deep half of Hall's theorem is already visible in which typeclasses each result actually needs — and this shared `variable` block is the widest hypothesis under which any of them holds.",
+    "mathContext": "$\\iota, \\alpha : \\mathrm{Type}^*$, only $[\\mathrm{DecidableEq}\\,\\alpha]$ — no $\\mathrm{Fintype}\\,\\iota$; necessity holds for infinite $\\iota$.",
+    "significance": "technical",
+    "relatedConcepts": ["DecidableEq", "typeclass hypotheses", "infinite index type", "Rado compactness", "variable declarations"],
+    "prerequisites": ["Lean typeclass inference", "Finset requires DecidableEq"]
+  },
+  {
     "id": "ann-biconditional",
     "proofId": "hall-marriage-theorem-oq-01",
     "range": { "startLine": 57, "endLine": 73 },


### PR DESCRIPTION
Enrichment pass for `hall-marriage-theorem-oq-01`.

This entry is already well-developed (17 KB meta.json: 4 keyInsights, 5 sections, mainTheorems, 3 references, 3 crossReferences; 5 rich annotations). The one genuine annotation-coverage gap was the `namespace` + `variable` region (lines 53–56), which had no annotation.

**Change (annotations-only, meta.json untouched):**
- Added `ann-variable-setup` (type `technique`, range 53–56) explaining that `variable {ι α : Type*} [DecidableEq α]` does real mathematical work *by omission*: the index type `ι` carries no `Fintype`/`Finite` instance. That absence is exactly why the necessity direction (`hall_condition_of_sdr`) generalizes to an arbitrary, possibly infinite index type — its proof touches only one finite sub-family at a time — whereas sufficiency needs the finiteness Mathlib supplies via Rado's compactness. The cheap-vs-deep split of Hall's theorem is thus already visible in which typeclasses each half requires.

**Guardrails:** annotations.json 7.7 KB, meta.json unchanged at 17.1 KB — both well under the ~60 KB cap. `pnpm annotations:build` passes (exit 0); the new annotation raises no validation warning.

_Note: pushed on a dedicated branch `feature/enricher-3-hall-marriage` to avoid disturbing PR #37398 on `feature/enricher-3`._