### PR TITLE
research(erdos-1204): S(k)→∞ and B(k)→∞ — divergence of all three extremal quantities [VERIFIED]

### DIFF
--- a/proofs/Proofs/Erdos1204B.lean
+++ b/proofs/Proofs/Erdos1204B.lean
@@ -382,6 +382,34 @@ theorem A_add_S_le_S_succ (k : ℕ) : A (k + 1) + S k ≤ S (k + 1) := by
   rw [← hsum, hsplit]
   omega
 
+/- ## Divergence of the sum and average extremal quantities
+
+The diameter `A(k)` diverges (`A_tendsto_atTop` in `Erdos1204Problem`). Since the
+minimal sum dominates the minimal diameter (`A_le_S`) and the minimal average is
+bounded below by `k - 1` (`sub_one_le_B`), both `S(k)` and `B(k)` diverge too. The
+sharp rates (`A(k) ∼ k log k`, and the analogous unknown rates for `S` and `B`)
+remain OPEN; only the qualitative unboundedness is recorded here. -/
+
+/-- **`S(k)` diverges.** The minimal admissible sum tends to infinity as `k → ∞`.
+Immediate from `A(k) ≤ S(k)` (`A_le_S`) and the divergence of the diameter
+`A(k) → ∞` (`A_tendsto_atTop`), by domination — no admissible `k`-tuple can keep
+its total bounded once `k` is large. -/
+theorem S_tendsto_atTop : Filter.Tendsto S Filter.atTop Filter.atTop :=
+  Filter.tendsto_atTop_mono A_le_S A_tendsto_atTop
+
+/-- **`B(k)` diverges.** The minimal admissible average tends to infinity as
+`k → ∞`. Immediate from the general lower bound `k - 1 ≤ B(k)` (`sub_one_le_B`,
+valid for `k ≥ 1`) and `(k : ℚ) - 1 → ∞`, by eventual domination. In particular the
+average — like the diameter and the sum — cannot be kept bounded, even though its
+sharp growth rate is OPEN. -/
+theorem B_tendsto_atTop : Filter.Tendsto B Filter.atTop Filter.atTop := by
+  have hsub : Filter.Tendsto (fun k : ℕ => (k : ℚ) - 1) Filter.atTop Filter.atTop := by
+    simpa [sub_eq_add_neg] using
+      Filter.tendsto_atTop_add_const_right Filter.atTop (-1 : ℚ) tendsto_natCast_atTop_atTop
+  refine Filter.tendsto_atTop_mono' _ ?_ hsub
+  filter_upwards [Filter.eventually_ge_atTop 1] with k hk
+  exact sub_one_le_B k hk
+
 /- ## Open Problem
 
 The asymptotic behaviour of `B(k) = min (a₁ + ⋯ + a_k)/k` over admissible
@@ -403,3 +431,5 @@ end Erdos1204
 #print axioms Erdos1204.A_le_sum
 #print axioms Erdos1204.A_le_S
 #print axioms Erdos1204.A_add_S_le_S_succ
+#print axioms Erdos1204.S_tendsto_atTop
+#print axioms Erdos1204.B_tendsto_atTop

--- a/src/data/research/problems/erdos-1204.json
+++ b/src/data/research/problems/erdos-1204.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (researcher-2, 2026-07-09): formalized the explicit weak upper bound A(k) ≤ (k-1)·primorialUpTo k (A_le_primorial) — the two-sided companion of the parity lower bound 2(k-1), previously only stated in a docstring. A(k) now provably sandwiched between 2(k-1) and (k-1)·∏_{p≤k}p. Exact small values A(0..7) and structural layer (admissibility, monotonicity, parity) already complete. Headline A(k)∼k log k and B(k) remain OPEN (sieve theory). Elaboration-clean; olean-write blocked by fleet SIGBUS-135.",
+    "progressSummary": "PROGRESS (researcher-1, 2026-07-10): completed the divergence trilogy — added S_tendsto_atTop and B_tendsto_atTop to Erdos1204B.lean, the sum/average companions of the already-merged A_tendsto_atTop. All three extremal quantities of #1204 (min diameter A, min sum S, min average B) now provably →∞. S→∞ by domination A≤S; B→∞ by the k-1 lower bound. Sharp rates (A~k log k) remain OPEN. Verified local Lean v4.26.0 (B.lean untracked in meta → Lean-only).",
     "builtItems": [
       "Erdos1204.Admissible (def) in Proofs/Erdos1204Problem.lean",
       "Erdos1204.missing_class_of_card_lt",
@@ -43,7 +43,8 @@
       "A_three: A(3)=6 proved exactly (Erdos1204Problem.lean), with witness {0,2,6} and finite lower-bound argument",
       "admissible_three_sup_ge: every admissible 3-set has max ≥ 6 (parity forces {0,2,4} or {1,3,5}, both inadmissible mod 3)",
       "not_admissible_zero_two_four / not_admissible_one_three_five / admissible_zero_two_six: supporting examples for A(3)",
-      "Erdos1204Problem.lean: primorialUpTo k := ((range(k+1)).filter Nat.Prime).prod id + A_le_primorial (A k ≤ (k-1)*primorialUpTo k). Reuses the exists_admissible_card construction, adding the sup bound. 0 new axioms/sorries. Elaboration-clean; olean-write blocked by fleet SIGBUS-135."
+      "Erdos1204Problem.lean: primorialUpTo k := ((range(k+1)).filter Nat.Prime).prod id + A_le_primorial (A k ≤ (k-1)*primorialUpTo k). Reuses the exists_admissible_card construction, adding the sup bound. 0 new axioms/sorries. Elaboration-clean; olean-write blocked by fleet SIGBUS-135.",
+      "Erdos1204B.lean: S_tendsto_atTop (Filter.tendsto_atTop_mono A_le_S A_tendsto_atTop) + B_tendsto_atTop (tendsto_atTop_mono` off sub_one_le_B eventual bound). 0 axioms/0 sorries; verified local Lean v4.26.0 (docker image build down, containerd meta.db I/O)."
     ],
     "insights": [
       "Admissibility is purely local: only the residue pattern mod each prime matters.",
@@ -54,7 +55,8 @@
       "A(k) defined as sInf of max over admissible k-sets; infimum attained (nonempty family); k-1 ≤ A(k) ≤ (k-1)·primorial; A(0)=A(1)=0, A(2)=2 (admissibility first binding at k=2).",
       "A(k) equals the Hardy–Littlewood minimal diameter H(k) (by translation invariance min a_k = min diameter); so A(3)=H(3)=6, A(4)=H(4)=8, etc. — the exact-value frontier is computing successive H(k).",
       "Lower bound for A(3): the mod-2 admissibility constraint forces all three elements to share a parity, so within {0,..,5} the only candidates are {0,2,4} and {1,3,5}, both of which cover every class mod 3. This parity-then-residue pruning is the model for larger exact values.",
-      "Formalized the explicit weak UPPER bound A(k) ≤ (k-1)·∏_{p≤k prime}p (A_le_primorial), previously only asserted in a docstring. Uses the arithmetic progression {0,N,2N,…,(k-1)N} with N=primorialUpTo k (product of primes ≤k): admissible because every element ≡0 mod each prime p≤k so class 1 is missed (larger primes automatic via missing_class_of_card_lt), k elements (injective ·*N since N>0), largest element (k-1)·N (Finset.sup_le, i*N≤(k-1)*N via mul_le_mul_right'), fed to A_le. This SANDWICHES A(k) between the parity lower bound 2(k-1) (two_mul_sub_one_le_A) and (k-1)·primorial — the elementary two-sided companion, far from the conjectured A(k)∼k log k (primorial grows like e^{(1+o(1))k}). Elaboration-clean [7743/7743] (olean-write SIGBUS-135)."
+      "Formalized the explicit weak UPPER bound A(k) ≤ (k-1)·∏_{p≤k prime}p (A_le_primorial), previously only asserted in a docstring. Uses the arithmetic progression {0,N,2N,…,(k-1)N} with N=primorialUpTo k (product of primes ≤k): admissible because every element ≡0 mod each prime p≤k so class 1 is missed (larger primes automatic via missing_class_of_card_lt), k elements (injective ·*N since N>0), largest element (k-1)·N (Finset.sup_le, i*N≤(k-1)*N via mul_le_mul_right'), fed to A_le. This SANDWICHES A(k) between the parity lower bound 2(k-1) (two_mul_sub_one_le_A) and (k-1)·primorial — the elementary two-sided companion, far from the conjectured A(k)∼k log k (primorial grows like e^{(1+o(1))k}). Elaboration-clean [7743/7743] (olean-write SIGBUS-135).",
+      "Divergence extends from A to all three extremal quantities: S(k)→∞ (via A(k)≤S(k), A_le_S + A_tendsto_atTop domination) and B(k)→∞ (via k-1≤B(k), sub_one_le_B + (k:ℚ)-1→∞ eventual domination). No admissible k-tuple can keep its diameter, sum, OR average bounded as k→∞; the sharp rates all remain OPEN (sieve theory)."
     ],
     "mathlibGaps": [],
     "nextSteps": [


### PR DESCRIPTION
## Summary
Research session for **erdos-1204** (admissible tuples; estimate A(k)=min a_k, and B(k)=min average). Adds the two remaining divergence corollaries so that **all three** extremal quantities of the problem provably tend to infinity.

## Progress
Added to `proofs/Proofs/Erdos1204B.lean` (0 axioms / 0 sorries):

- **`S_tendsto_atTop`** — the minimal admissible sum `S(k) → ∞`. Immediate from `A(k) ≤ S(k)` (`A_le_S`, already in the file) and the merged `A_tendsto_atTop`, by domination (`Filter.tendsto_atTop_mono`).
- **`B_tendsto_atTop`** — the minimal admissible average `B(k) → ∞`. From the general lower bound `k-1 ≤ B(k)` (`sub_one_le_B`) and `(k:ℚ)-1 → ∞`, by eventual domination (`Filter.tendsto_atTop_mono'`).

These complete the divergence trilogy: the diameter `A(k)` (via the previously-merged `A_tendsto_atTop`), the sum `S(k)`, and the average `B(k)` are now each proven unbounded.

## Findings
- The unboundedness of *all three* quantities is forced already by the elementary prime-2 (parity) bounds — no sieve theory needed.
- The sharp growth rates (`A(k) ∼ k log k`, and the analogous rates for `S`, `B`) remain **OPEN**.

## Verification
- Verified locally with **Lean v4.26.0** (`#print axioms`: both new theorems depend only on `propext, Classical.choice, Quot.sound` — no `sorryAx`, no new axioms).
- Docker image build is currently down (containerd `meta.db` I/O error), so the standard `docker-build.sh` could not run; local `lean` compile against the pinned toolchain + cached Mathlib oleans succeeds.
- `Erdos1204B.lean` is **not tracked** in `meta.json` (`additionalFiles: null`, `leanFile.path` = `Erdos1204Problem.lean`), so this is a Lean-only change; no meta counts require syncing.

## Status
**Outcome**: progress (verified)
**Next Steps**: sharp lower bound toward `A(k) ≳ k log k` (sieve theory); exact `A(8)=26` lower half (mod-2,3,5,7 pruning). Both remain OPEN.

🤖 Generated by researcher-1