### PR TITLE
research(erdos-378): r=0 boundary — answer-set density is exactly 1 [VERIFIED]

### DIFF
--- a/proofs/Proofs/Erdos378Problem.lean
+++ b/proofs/Proofs/Erdos378Problem.lean
@@ -521,4 +521,45 @@ theorem erdos_378_density_mem_Ioc (r : ℕ) :
   obtain ⟨d, hd_pos, hd_density⟩ := erdos_378_density_positive r
   exact ⟨d, ⟨hd_pos, natDensity_le_one hd_density⟩, hd_density⟩
 
+/-
+## Part VIII: The threshold-`0` boundary — density exactly `1`
+
+The universal upper bound `natDensity_le_one` says every density is `≤ 1`. Here we
+exhibit the extreme case where it is *attained*: at threshold `r = 0` the answer set
+is all of `ℕ` (every `n` has at least `0` squarefree interior binomials), so its
+density is exactly `1`. This pins the top endpoint of the interval
+`erdos_378_density_mem_Ioc` and needs none of the Granville–Ramaré axioms.
+-/
+
+/-- **The full set `ℕ` has natural density `1`.**  For every `N ≥ 1` the counting
+ratio is `|univ ∩ [0,N)| / N = N / N = 1`, so the limit is `1`.  Elementary, uses no
+axioms. -/
+theorem natDensity_univ : NaturalDensity Set.univ 1 := by
+  intro ε hε
+  refine ⟨1, fun N hN => ?_⟩
+  have hNR : (N : ℝ) ≠ 0 := by
+    have : 0 < N := hN
+    exact_mod_cast this.ne'
+  have hcard : (Set.univ ∩ Set.Iio N).ncard = N := by
+    rw [Set.univ_inter, ← Finset.coe_range, Set.ncard_coe_finset, Finset.card_range]
+  rw [hcard, div_self hNR, sub_self, abs_zero]
+  exact hε
+
+/-- **At threshold `0` the answer set is everything.**  `hasAtLeastSquarefree n 0`
+holds for every `n` (the count is always `≥ 0`), so `atLeastSquarefree 0 = ℕ`. -/
+theorem atLeastSquarefree_zero_eq_univ : atLeastSquarefree 0 = Set.univ := by
+  ext n
+  simp only [atLeastSquarefree, hasAtLeastSquarefree, Set.mem_setOf_eq, Set.mem_univ,
+    iff_true]
+  exact Nat.zero_le _
+
+/-- **The Erdős #378 density at threshold `0` is exactly `1`.**  Since
+`atLeastSquarefree 0 = ℕ`, the density equals that of the full set, namely `1` — the
+maximal value permitted by `natDensity_le_one` and the top endpoint of the interval in
+`erdos_378_density_mem_Ioc`.  So the universal upper bound `d ≤ 1` is sharp, attained
+precisely at the (vacuous) threshold `r = 0`. -/
+theorem erdos_378_density_zero : NaturalDensity (atLeastSquarefree 0) 1 := by
+  rw [atLeastSquarefree_zero_eq_univ]
+  exact natDensity_univ
+
 end Erdos378

--- a/src/data/proofs/erdos-378/meta.json
+++ b/src/data/proofs/erdos-378/meta.json
@@ -64,9 +64,9 @@
       "erdos_378, erdos_378_answer (no sorries): combined resolution of both questions"
     ],
     "axiomCount": 2,
-    "lineCount": 524,
+    "lineCount": 565,
     "assumptions": "2 axioms, both isolating the deep analytic content of Granville-Ramaré (1996): granville_ramare_density_exists (the density η_m of n with exactly 2m+2 squarefree binomials exists) and complement_density (the set of n with fewer than r squarefree binomials has density Σ_{0≤m≤(r-1)/2} η_m, which is < 1). 0 sorries. All other results, including the resolution of both questions and the parity theorems squarefreeCount_even_of_odd (odd rows have an even count) and squarefreeCount_odd_iff_central_squarefree (an even row has an odd count iff its central binomial C(n,n/2) is squarefree), are fully machine-checked (depend only on propext/Classical.choice/Quot.sound).",
-    "theoremCount": 17,
+    "theoremCount": 20,
     "definitionCount": 8,
     "additionalFiles": [
       "Proofs/Erdos378Aristotle.lean"
@@ -162,9 +162,9 @@
       "Finset"
     ],
     "namespace": "Erdos378",
-    "lineCount": 524,
+    "lineCount": 565,
     "axiomCount": 2,
-    "theoremCount": 14,
+    "theoremCount": 17,
     "definitionCount": 8,
     "path": "Proofs/Erdos378Problem.lean",
     "sorries": 0,

--- a/src/data/research/problems/erdos-378.json
+++ b/src/data/research/problems/erdos-378.json
@@ -32,7 +32,7 @@
     "focus": "Verified deliverable: Proofs/Erdos378Problem.lean and gallery entry erdos-378 are complete in main (status axiomatized, badge axiom, 2 axioms = Granville–Ramaré inputs, 0 sorries)."
   },
   "knowledge": {
-    "progressSummary": "COMPLETED (axiomatized) in main. Proofs/Erdos378Problem.lean (311 lines, 11 theorems, 8 definitions, 0 sorries, axiomCount 2) resolves Erdős #378: the set of n with C(n,k) squarefree for at least r values has a natural density, and it is positive. The two assumptions are exactly the deep Granville–Ramaré (1996) inputs (existence of the exact-count densities η_m, and complement density d < 1), stated as axioms; everything else — complementation, density-of-complement, positivity via 1 − d > 0 — is elementary and fully checked. Gallery entry present (meta.json + annotations.json), status 'axiomatized', badge 'axiom', axiomCount 2. Correct under the axiom-integrity policy: open/deep number-theory inputs are isolated as named axioms rather than overclaimed as verified.",
+    "progressSummary": "COMPLETED (axiomatized) in main. Added Part VIII: the r=0 boundary case, proving the answer-set density is exactly 1 there (natDensity_univ + atLeastSquarefree_zero_eq_univ + erdos_378_density_zero), showing natDensity_le_one is sharp. 565 lines, 20 theorems, axiomCount 2, 0 sorries. Verified locally (Lean v4.26.0, cached Mathlib oleans; docker image build down).",
     "builtItems": [
       "erdos_378_density_exists: density of atLeastSquarefree r exists, by complementing the Granville–Ramaré tail-density input (natDensity_compl).",
       "erdos_378_density_positive: the density equals 1 − d with d < 1, hence > 0 (linarith).",
@@ -41,14 +41,18 @@
       "Definitions squarefreeCount, hasAtLeastSquarefree, exactlySquarefree, atLeastSquarefree, eta, HasDensity/NaturalDensity scaffolding (8 definitions) framing the density formulation.",
       "Two named axioms granville_ramare_density_exists and complement_density isolating the deep analytic input; gallery entry src/data/proofs/erdos-378 (meta.json + annotations.json).",
       "REPAIRED broken build (Mathlib drift): Nat.even_iff_not_odd/Nat.odd_iff_not_even (nonexistent in pinned Mathlib rev 2df2f0150c) → not_odd_iff_even.mpr/not_even_iff_odd.mpr; lt_or_le → lt_or_ge deprecation. File now elaborates CLEAN (0 errors 0 warnings). The break was introduced by #36995 and fast-merged unbuilt (math PRs skip build).",
-      "hasAtLeastSquarefree_antitone / atLeastSquarefree_antitone : the Erdős #378 answer sets form a decreasing filtration atLeastSquarefree 0 ⊇ atLeastSquarefree 1 ⊇ ⋯ (antitone in threshold r via le_trans). [VERIFIED axiom-free]"
+      "hasAtLeastSquarefree_antitone / atLeastSquarefree_antitone : the Erdős #378 answer sets form a decreasing filtration atLeastSquarefree 0 ⊇ atLeastSquarefree 1 ⊇ ⋯ (antitone in threshold r via le_trans). [VERIFIED axiom-free]",
+      "natDensity_univ (Erdos378Problem.lean): the full set N has natural density 1 (verified, 0-axiom)",
+      "atLeastSquarefree_zero_eq_univ (Erdos378Problem.lean): at threshold 0 the answer set is all of N",
+      "erdos_378_density_zero (Erdos378Problem.lean): NaturalDensity (atLeastSquarefree 0) 1 — density exactly 1 at r=0 (verified, 0-axiom)"
     ],
     "insights": [
       "The whole resolution is complementation: 'at least r squarefree' is the complement of 'fewer than r squarefree', so its density is 1 − d, and positivity is exactly the d < 1 clause of the Granville–Ramaré tail estimate.",
       "The deep content is purely the two density facts of Granville–Ramaré (1996); once granted, the Erdős #378 answer follows by elementary, fully-checked Lean arguments — so axiomatizing those two inputs is the honest and efficient architecture.",
       "Positivity is the substantive 'yes': existence of a density is the easy half; that the density is strictly positive (the excluded tail does not have full density) is what makes the answer affirmative.",
       "Mathlib lacks the Granville–Ramaré machinery, so these inputs cannot currently be discharged; the entry is correctly badged 'axiomatized' (axiomCount 2) rather than 'verified'.",
-      "Erdos378Problem.lean was BROKEN on main against the pinned Mathlib: Nat.even_iff_not_odd and Nat.odd_iff_not_even do not exist there (the general not_odd_iff_even/not_even_iff_odd in Algebra/Ring/Parity are the correct names). Math PRs fast-merge WITHOUT building (deployer policy), so drift-breaking edits land unverified — always full-file lake env lean before adding to a gallery file."
+      "Erdos378Problem.lean was BROKEN on main against the pinned Mathlib: Nat.even_iff_not_odd and Nat.odd_iff_not_even do not exist there (the general not_odd_iff_even/not_even_iff_odd in Algebra/Ring/Parity are the correct names). Math PRs fast-merge WITHOUT building (deployer policy), so drift-breaking edits land unverified — always full-file lake env lean before adding to a gallery file.",
+      "Threshold r=0 boundary: atLeastSquarefree 0 = Set.univ, so the Erdos #378 density there is exactly 1, showing the universal upper bound natDensity_le_one (d <= 1) is sharp/attained — the top endpoint of the interval (0,1] in erdos_378_density_mem_Ioc."
     ],
     "mathlibGaps": [
       "Granville–Ramaré (1996) density results for squarefree-binomial counts are not in Mathlib; discharging granville_ramare_density_exists and complement_density would require formalizing substantial analytic number theory."


### PR DESCRIPTION
## Summary

Adds **Part VIII** to `Erdos378Problem.lean`: the threshold-`0` boundary case of Erdős #378. The file already resolves the problem (density exists and is positive for all `r`, axiomatized on the two Granville–Ramaré inputs) and proves the universal bounds `0 ≤ d ≤ 1`. This PR pins the sharpness of the upper bound.

## New theorems (all verified, 0-axiom)

- `natDensity_univ` — the full set `ℕ` has natural density `1` (elementary: ratio `N/N = 1`).
- `atLeastSquarefree_zero_eq_univ` — at threshold `r = 0` the answer set is all of `ℕ` (every `n` trivially has `≥ 0` squarefree interior binomials).
- `erdos_378_density_zero` — `NaturalDensity (atLeastSquarefree 0) 1`: the Erdős #378 density at `r = 0` is exactly `1`.

## Why it matters

`natDensity_le_one` gives `d ≤ 1` for every density; `erdos_378_density_mem_Ioc` localises the answer to `(0, 1]`. This PR shows that upper endpoint is **attained** — precisely at the vacuous threshold `r = 0` — so the bound is sharp. Uses none of the Granville–Ramaré axioms (`axiomCount` unchanged at 2, 0 sorries).

## Verification

Compiled cleanly with Lean **v4.26.0** against cached Mathlib oleans (exit 0, no errors). The docker image build was unavailable this session (containerd `meta.db` input/output error), so the standard `docker-build.sh` path could not run; local `lean` typecheck stands in.

Synced `meta.json` count blocks to the current file: `lineCount` 524/457 → 565, `theoremCount` 17 → 20 (meta) and 14 → 17 (leanFile).

🤖 Generated with [Claude Code](https://claude.com/claude-code)