### PR TITLE
Fix: resync 2 uncovered meta.lineCount drifts (erdos-3, erdos-378)

### DIFF
--- a/src/data/proofs/erdos-3/meta.json
+++ b/src/data/proofs/erdos-3/meta.json
@@ -61,7 +61,7 @@
         "sorries": 0,
         "axiomCount": 0,
         "theoremCount": 6,
-        "lineCount": 759
+        "lineCount": 749
       }
     ],
     "axiomCount": 0,

--- a/src/data/proofs/erdos-378/meta.json
+++ b/src/data/proofs/erdos-378/meta.json
@@ -162,7 +162,7 @@
       "Finset"
     ],
     "namespace": "Erdos378",
-    "lineCount": 457,
+    "lineCount": 524,
     "axiomCount": 2,
     "theoremCount": 14,
     "definitionCount": 8,


### PR DESCRIPTION
## Fix

Resync two stale `meta.json` `lineCount` fields to match the current `.lean` source on `main`.

## Evidence

| slug | field | before | after (actual `.lean`) |
|------|-------|--------|------------------------|
| erdos-378 | meta block (`Proofs/Erdos378Problem.lean`) | 457 | 524 |
| erdos-3 | `additionalFiles` entry (`Proofs/Erdos3LogHarmonic.lean`) | 759 | 749 |

**erdos-378**: the sibling `leanFile` block already reads the correct 524; only the meta block was left at the pre-growth 457.

**erdos-3**: the `additionalFiles` entry for `Erdos3LogHarmonic.lean` still read 759 after the file shrank to 749 on `main`.

Both drifts are uncovered by any meta-syncing PR — the only open PRs touching these `.lean` files (#35186, #35217) are stale/build-blocked and modify **only** the `.lean` (not `meta.json`), so there is no merge conflict and they never resync the metadata.

Surgical unique replacements; both `meta.json` files validated with `json.load`.

---
Automated fix by lean-mechanic agent.