### PR TITLE
research(burnside-counting-oq-02): Fermat's little theorem in modular form [VERIFIED]

### DIFF
--- a/proofs/Proofs/BurnsideCounting.lean
+++ b/proofs/Proofs/BurnsideCounting.lean
@@ -668,3 +668,25 @@ theorem prime_dvd_pow_sub_self {p : ℕ} (hp : p.Prime) (k : ℕ) : p ∣ k ^ p 
   have hrw : k ^ p - k = (k ^ p + (p - 1) * k) - ((p - 1) * k + k) := by omega
   rw [hrw]
   exact Nat.dvd_sub hdvd1 hdvd2
+
+/-- **Fermat's little theorem, congruence form.**  The divisibility `p ∣ kᵖ − k` proved
+    combinatorially above (`prime_dvd_pow_sub_self`) is exactly the modular statement
+    `kᵖ ≡ k [MOD p]`.  We transfer it via `Nat.modEq_iff_dvd'`, using `k ≤ kᵖ` (`p ≠ 0`).
+    Thus the necklace-orbit count *is* Fermat's little theorem — no `ZMod.pow_card`. -/
+theorem pow_prime_modEq_self {p : ℕ} (hp : p.Prime) (k : ℕ) : k ^ p ≡ k [MOD p] := by
+  have hdvd : p ∣ k ^ p - k := prime_dvd_pow_sub_self hp k
+  have hle : k ≤ k ^ p := Nat.le_self_pow hp.pos.ne' k
+  exact ((Nat.modEq_iff_dvd' hle).mpr hdvd).symm
+
+/-- **Fermat's little theorem, coprime form.**  For a prime `p` and a base `k` not divisible
+    by `p`, `k^(p−1) ≡ 1 [MOD p]`.  Cancel a factor of `k` (coprime to `p`) from the
+    self-congruence `kᵖ ≡ k` of `pow_prime_modEq_self`, writing `kᵖ = k · k^(p−1)`. -/
+theorem pow_prime_sub_one_modEq_one {p : ℕ} (hp : p.Prime) {k : ℕ} (hk : ¬ p ∣ k) :
+    k ^ (p - 1) ≡ 1 [MOD p] := by
+  have hcop : Nat.Coprime p k := hp.coprime_iff_not_dvd.mpr hk
+  have hrw : k * k ^ (p - 1) = k ^ p := by
+    conv_rhs => rw [← Nat.sub_add_cancel hp.pos]
+    rw [pow_succ]; ring
+  have hstep : k * k ^ (p - 1) ≡ k * 1 [MOD p] := by
+    rw [mul_one, hrw]; exact pow_prime_modEq_self hp k
+  exact Nat.ModEq.cancel_left_of_coprime hcop hstep

--- a/src/data/proofs/burnside-counting/meta.json
+++ b/src/data/proofs/burnside-counting/meta.json
@@ -22,8 +22,8 @@
     "dateAdded": "2026-04-02",
     "axiomCount": 0,
     "assumptions": "None. The S5 drift repair (Mathlib v4.26) replaces every `native_decide` with kernel `decide` plus a genuine application of Mathlib's additive Burnside lemma `AddAction.sum_card_fixedBy_eq_card_orbits_mul_card_addGroup`, so the file no longer depends on `Lean.ofReduceBool`. `#print axioms fixed_point_sum_binary_4` and `#print axioms binary_necklaces_4` report only the foundational trio [propext, Classical.choice, Quot.sound]. 0 literal `axiom` declarations, 0 sorries, no assumption-carrying structures.",
-    "lineCount": 670,
-    "theoremCount": 21,
+    "lineCount": 692,
+    "theoremCount": 23,
     "definitionCount": 9,
     "originalContributions": [
       "burnside_lemma: Burnside orbit-counting theorem from Mathlib (MulAction.sum_card_fixedBy_eq_card_orbits_mul_card_group)",
@@ -72,9 +72,9 @@
   },
   "leanFile": {
     "namespace": "BurnsideCounting",
-    "lineCount": 670,
+    "lineCount": 692,
     "axiomCount": 0,
-    "theoremCount": 21,
+    "theoremCount": 23,
     "definitionCount": 9,
     "path": "Proofs/BurnsideCounting.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

`BurnsideCounting.lean` derives **Fermat's little theorem combinatorially** — the necklace-orbit argument shows the `p` cyclic rotations partition the `kᵖ − k` non-constant colorings into orbits of size `p`, giving `prime_dvd_pow_sub_self : p ∣ kᵖ − k`. But the file stops at the divisibility form. This PR adds the two standard **congruence** formulations, derived directly from that result (no `ZMod.pow_card`):

- **`pow_prime_modEq_self`** — `kᵖ ≡ k [MOD p]`, via `Nat.modEq_iff_dvd'` and `k ≤ kᵖ` (`p ≠ 0`).
- **`pow_prime_sub_one_modEq_one`** — for `p ∤ k`, `k^(p−1) ≡ 1 [MOD p]`, cancelling a factor of `k` (coprime to `p`) from the self-congruence `kᵖ ≡ k`.

Together these promote the file's combinatorial Fermat proof to the two forms it is usually stated in, keeping the derivation grounded in the necklace count rather than Mathlib's `ZMod` machinery.

## Verification

Compiled locally with `lean v4.26.0` against the cached Mathlib oleans (docker image-build currently down). The full file builds with **0 errors**; `#print axioms` on both new theorems reports only `propext, Classical.choice, Quot.sound` — **0 sorries**.

## Collision note

Both theorems are **appended at the file end** (after line 670), disjoint from the open build-repair PR #37311 which edits lines 623–670 and does not touch `meta.json`. Gallery `meta.json` synced: lineCount 670→692, theoremCount 21→23 (axiomCount 0 unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)