### PR TITLE
research(erdos-1215-oq-02): general degree obstruction — no escape path for any non-constant polynomial

### DIFF
--- a/proofs/Proofs/Erdos1215Problem.lean
+++ b/proofs/Proofs/Erdos1215Problem.lean
@@ -19,6 +19,7 @@ Reference:
 import Mathlib.Analysis.SpecialFunctions.Complex.Circle
 import Mathlib.RingTheory.Polynomial.Basic
 import Mathlib.Analysis.Complex.Basic
+import Mathlib.Topology.Algebra.Polynomial
 
 open Complex Polynomial
 
@@ -39,43 +40,55 @@ def HasBoundedLevelPath (P : ℂ[X]) (C : ℝ) : Prop :=
     ∀ t ≥ 0, γ t ∈ levelSet P C
 
 /--
+**The escape-to-∞ obstruction is trivial for degree reasons.**
+For *any* polynomial `P` of positive degree, `‖P(z)‖ → ∞` as `‖z‖ → ∞`
+(`Polynomial.tendsto_norm_atTop`), so its level set `{z : ‖P(z)‖ < C}` is *bounded* and
+admits no path escaping to `∞`: a path `γ` with `‖γ t‖ → ∞` would force
+`‖P(γ t)‖ → ∞`, contradicting `‖P(γ t)‖ < C` on `t ≥ 0`.
+
+This isolates exactly *why* the literal escape-to-∞ question (Erdős #1215) is easy: it is
+refuted by the growth of any single non-constant polynomial and needs nothing about roots,
+the unit circle, or Mac Lane's argument.  All of Mac Lane's genuine depth — paths forced
+through neighbourhoods of `0` in the `C > 1` regime — lives in the strictly stronger
+`maclane_labyrinth` below, which remains axiomatized. -/
+theorem no_bounded_level_path_of_degree_pos {P : ℂ[X]} (hP : 0 < P.degree) (C : ℝ) :
+    ¬ HasBoundedLevelPath P C := by
+  rintro ⟨γ, _hcont, _hγ0, htend, hpath⟩
+  -- growth of `P` transports `‖γ t‖ → ∞` into `‖P(γ t)‖ → ∞`
+  have hPtend : Filter.Tendsto (fun t => ‖P.eval (γ t)‖) Filter.atTop Filter.atTop :=
+    P.tendsto_norm_atTop hP htend
+  have h1 : ∀ᶠ t in Filter.atTop, C < ‖P.eval (γ t)‖ := hPtend.eventually_gt_atTop C
+  have h2 : ∀ᶠ t in Filter.atTop, (0 : ℝ) ≤ t := Filter.eventually_ge_atTop 0
+  obtain ⟨t, ht1, ht2⟩ := (h1.and h2).exists
+  have hmem := hpath t ht2
+  simp only [levelSet, Set.mem_setOf_eq] at hmem
+  linarith
+
+/--
 **The literal escape-to-∞ answer is NO — and it is *elementary*.**
 For any `C`, there is a unit-circle polynomial with no bounded-level path from
 `0` to `∞` inside `{|P| < C}`.  The witness is the degree-one cyclotomic
-`P = X + 1` (`P(0) = 1`, sole root `-1` on the unit circle): its level set
-`{z : ‖z + 1‖ < C}` is a *bounded* disc, so `‖z‖ ≤ ‖z + 1‖ + 1 < C + 1` there,
-and no path can escape to `∞` while staying inside it.
+`P = X + 1` (`P(0) = 1`, sole root `-1` on the unit circle); its level set is bounded
+because `X + 1` has positive degree, so `no_bounded_level_path_of_degree_pos` applies.
 
-This was formerly an `axiom` labelled "Mac Lane 1953", but the escape-to-∞
-formulation does **not** require Mac Lane's deep argument — it is refuted by mere
-compactness of the level set of a single explicit polynomial.  Mac Lane's genuine
-content (the labyrinth forcing paths through neighbourhoods of `0` in the `C > 1`
-regime) is the strictly stronger phenomenon recorded below in `maclane_labyrinth`,
-which remains axiomatized.  Cf. the cyclotomic re-derivation in
+This was formerly an `axiom` labelled "Mac Lane 1953", but the escape-to-∞ formulation does
+**not** require Mac Lane's deep argument — it now follows from the general degree obstruction
+`no_bounded_level_path_of_degree_pos` applied to a single explicit polynomial.  Mac Lane's
+genuine content (the labyrinth forcing paths through neighbourhoods of `0` in the `C > 1`
+regime) is the strictly stronger phenomenon recorded below in `maclane_labyrinth`, which
+remains axiomatized.  Cf. the cyclotomic re-derivation in
 `CyclotomicPolynomialsOQ02OQ05.erdos_1215_via_cyclotomic`. -/
 theorem maclane_1953 (C : ℝ) (_hC : C > 1) :
     ∃ P : ℂ[X], IsUnitCirclePolynomial P ∧ ¬HasBoundedLevelPath P C := by
-  refine ⟨X + 1, ⟨by simp, ?_⟩, ?_⟩
+  refine ⟨X + 1, ⟨by simp, ?_⟩, no_bounded_level_path_of_degree_pos ?_ C⟩
   · -- the sole root of `X + 1` is `-1`, which lies on the unit circle
     intro z hz
     rw [IsRoot.def, eval_add, eval_X, eval_one] at hz
     rw [eq_neg_of_add_eq_zero_left hz]
     simp
-  · -- no path can escape to ∞ while `‖γ t + 1‖ < C` keeps `‖γ t‖` below `C + 1`
-    rintro ⟨γ, _hcont, _hγ0, htend, hpath⟩
-    have hbound : ∀ t ≥ (0 : ℝ), ‖γ t‖ < C + 1 := by
-      intro t ht
-      have hmem := hpath t ht
-      simp only [levelSet, Set.mem_setOf_eq, eval_add, eval_X, eval_one] at hmem
-      have hkey := norm_sub_norm_le (γ t) (γ t + 1)
-      have hgeq : γ t - (γ t + 1) = -1 := by ring
-      rw [hgeq] at hkey
-      simp only [norm_neg, norm_one] at hkey
-      linarith
-    have h1 : ∀ᶠ t in Filter.atTop, C + 1 < ‖γ t‖ := htend.eventually_gt_atTop (C + 1)
-    have h2 : ∀ᶠ t in Filter.atTop, (0 : ℝ) ≤ t := Filter.eventually_ge_atTop 0
-    obtain ⟨t, ht1, ht2⟩ := (h1.and h2).exists
-    exact absurd (hbound t ht2) (by linarith)
+  · -- `X + 1 = X + C 1` has degree `1 > 0`
+    rw [← C_1, degree_X_add_C]
+    exact WithBot.coe_lt_coe.mpr Nat.one_pos
 
 /--
 **Stronger form:** For any C, there exist labyrinth blocks forcing the path

--- a/research/problems/erdos-1215-oq-02/knowledge.md
+++ b/research/problems/erdos-1215-oq-02/knowledge.md
@@ -208,3 +208,40 @@ on C) → binder renamed `_hC`.
 v4.26.0 oleans (see [[reference-docker-down-lean-elab-verification-path]]): exit 0, `#print axioms`
 clean. Metas synced: src/data/proofs/erdos-1215/meta.json (axiomCount 2→1, 70→100 lines, 1→2 thm,
 assumptions text) + research json leanFiles.
+
+## Session 2026-07-10 (researcher-3) — general degree obstruction (maclane_1953 becomes a corollary)
+
+**Mode**: REVISIT. **Outcome**: progress (1 theorem, axiom-free), **VERIFIED-local**.
+
+Generalized the escape-to-∞ half of `maclane_1953` from the single witness `X + 1` to *every*
+positive-degree polynomial, isolating why the literal Erdős #1215 question is trivial:
+
+- `no_bounded_level_path_of_degree_pos {P : ℂ[X]} (hP : 0 < P.degree) (C) : ¬ HasBoundedLevelPath P C`.
+  For any non-constant `P`, `‖P(z)‖ → ∞` as `‖z‖ → ∞` (`Polynomial.tendsto_norm_atTop`), so a path
+  `γ` with `‖γ t‖ → ∞` forces `‖P(γ t)‖ → ∞`, contradicting `‖P(γ t)‖ < C` on `t ≥ 0`. Proof:
+  `P.tendsto_norm_atTop hP htend` then `eventually_gt_atTop C` ∧ `eventually_ge_atTop 0`, `.exists`,
+  `linarith` against the level-set membership.
+
+`maclane_1953` is now a corollary: witness `X + 1`, root on the circle as before, and the escape
+clause is `no_bounded_level_path_of_degree_pos` with `0 < degree (X+1)` via
+`rw [← C_1, degree_X_add_C]; exact WithBot.coe_lt_coe.mpr Nat.one_pos`. This removes the duplicated
+13-line escape argument and demonstrates the new lemma strictly subsumes it.
+
+### Key facts / gotchas
+- `Polynomial.tendsto_norm_atTop (p) (h : 0 < degree p) (hz : Tendsto (‖z ·‖) l atTop) :
+  Tendsto (‖p.eval (z ·)‖) l atTop` — the **norm** form (no cocompact/cobounded plumbing needed);
+  lives in `Mathlib.Topology.Algebra.Polynomial` → **added that import** (the file's 3 specific
+  imports did not transitively pull it; dot-notation errored "environment does not contain").
+- `degree (X + 1) = 1`: `rw [← Polynomial.C_1, degree_X_add_C]`; then `0 < (1 : WithBot ℕ)` via
+  `WithBot.coe_lt_coe.mpr Nat.one_pos`.
+
+### Verification
+VERIFIED-local (docker image layer down): elan lean v4.26.0 vs main-checkout Mathlib oleans →
+exit 0, no warnings. `#print axioms no_bounded_level_path_of_degree_pos` and `#print axioms
+erdos_1215` = `[propext, Classical.choice, Quot.sound]` — axiom-free (no `native_decide`, does NOT
+touch `maclane_labyrinth`). File 100→113 lines, 2→3 theorems, axiomCount stays 1 (the deep
+`maclane_labyrinth` labyrinth axiom, unused by the headline). Meta + research json synced.
+
+### Still open (unchanged)
+The genuinely deep Mac Lane labyrinth (`maclane_labyrinth` axiom): paths forced through
+neighbourhoods of `0` in the `C > 1` regime — needs polynomial-lemniscate topology Mathlib lacks.

--- a/src/data/proofs/erdos-1215/meta.json
+++ b/src/data/proofs/erdos-1215/meta.json
@@ -16,7 +16,7 @@
       "topology",
       "unit-circle"
     ],
-    "lineCount": 100,
+    "lineCount": 113,
     "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 1215,
@@ -24,7 +24,7 @@
     "erdosProblemStatus": "solved",
     "axiomCount": 1,
     "assumptions": "1 axiom(s) and 0 sorry(s). The remaining axiom `maclane_labyrinth` encodes Mac Lane's deep labyrinth phenomenon; the escape-to-∞ negative answer (`maclane_1953`, `erdos_1215`) is now proved axiom-free via the compact witness P = X + 1.",
-    "theoremCount": 2,
+    "theoremCount": 3,
     "definitionCount": 3
   },
   "overview": {
@@ -109,9 +109,9 @@
     ],
     "opens": [],
     "namespace": null,
-    "lineCount": 100,
+    "lineCount": 113,
     "axiomCount": 1,
-    "theoremCount": 2,
+    "theoremCount": 3,
     "definitionCount": 3,
     "sorries": 0,
     "path": "Proofs/Erdos1215Problem.lean"

--- a/src/data/research/problems/erdos-1215-oq-02.json
+++ b/src/data/research/problems/erdos-1215-oq-02.json
@@ -94,8 +94,8 @@
     {
       "path": "Proofs/Erdos1215Problem.lean",
       "filename": "Erdos1215Problem.lean",
-      "lineCount": 100,
-      "theoremCount": 2,
+      "lineCount": 113,
+      "theoremCount": 3,
       "axiomCount": 1,
       "defCount": 3,
       "sorryCount": 0,


### PR DESCRIPTION
## Summary

The headline `erdos_1215` (Erdős #1215 resolved negatively) rested on `maclane_1953`, whose
escape-to-∞ clause was proved only for the single witness `X + 1` via an explicit disc bound.
This PR generalizes that clause to **every** positive-degree polynomial, isolating exactly *why*
the literal escape-to-∞ question is trivial:

- **`no_bounded_level_path_of_degree_pos {P : ℂ[X]} (hP : 0 < P.degree) (C : ℝ)`**:
  `¬ HasBoundedLevelPath P C`. For any non-constant `P`, `‖P(z)‖ → ∞` as `‖z‖ → ∞`
  (`Polynomial.tendsto_norm_atTop`), so a path `γ` with `‖γ t‖ → ∞` would force `‖P(γ t)‖ → ∞`,
  contradicting `‖P(γ t)‖ < C` on `t ≥ 0`. Hence the level set `{‖P‖ < C}` is bounded and admits
  no escape-to-∞ path.

`maclane_1953` becomes a one-line corollary (witness `X + 1`, `degree (X+1) = 1 > 0`), removing the
duplicated 13-line escape argument.

## Why this matters

It pinpoints that the literal Erdős #1215 escape-to-∞ obstruction is refuted by the growth of *any*
single non-constant polynomial — it needs nothing about roots, the unit circle, or Mac Lane's
argument. All of Mac Lane's genuine depth (paths forced through neighbourhoods of `0` in the
`C > 1` regime) remains in the strictly stronger `maclane_labyrinth` axiom, which stays
axiomatized. No overclaim: the entry keeps `status: axiomatized`, `axiomCount: 1`.

## Verification

**VERIFIED locally** (Docker image layer down — containerd metadata.db I/O error at image build,
`docker info` OK). Offline typecheck with pinned `elan lean v4.26.0` against the main checkout's
Mathlib oleans → **exit 0, no warnings**. `#print axioms` of both `no_bounded_level_path_of_degree_pos`
and `erdos_1215` = `[propext, Classical.choice, Quot.sound]` — **axiom-free** (no `native_decide`;
does not touch `maclane_labyrinth`).

## Changes

- `Erdos1215Problem.lean`: +`no_bounded_level_path_of_degree_pos`, `maclane_1953` refactored to use
  it; `+import Mathlib.Topology.Algebra.Polynomial` (for `tendsto_norm_atTop`). 100→113 lines,
  2→3 theorems, axiomCount unchanged (1).
- `meta.json` + research json: lineCount 100→113, theoremCount 2→3 synced.