### PR TITLE
research(lagrange-four-squares-oq-01-oq-03): jacobiCount divisibility + upper bound [VERIFIED]

### DIFF
--- a/proofs/Proofs/Erdos729LegendreGeneral.lean
+++ b/proofs/Proofs/Erdos729LegendreGeneral.lean
@@ -128,6 +128,43 @@ theorem padicValNat_factorial_le_div (p n : ℕ) (hp : p.Prime) :
   rw [padicValNat_factorial_eq_div p n hp]
   exact Nat.div_le_div_right (Nat.sub_le n ((p.digits n).sum))
 
+/-- **The exact zero-locus of `v_p(n!)`.**  For every prime `p`,
+
+  `v_p(n!) = 0  ↔  n < p`.
+
+The upper-bound lemmas above (`padicValNat_factorial_le_div` etc.) pin the growth of
+`v_p(n!)` from above; this identifies exactly where the valuation *vanishes*.  A prime `p`
+first appears as a factor of `n!` precisely at `n = p`, so `n! ` is coprime to `p` iff
+`n < p`.  Proven directly from `Nat.Prime.dvd_factorial` (`p ∣ n! ↔ p ≤ n`) together with
+the standard positivity/vanishing lemmas for `padicValNat`, independently of the
+digit-sum machinery — and it is the natural base case for the sandwich
+`0 ≤ v_p(n!) ≤ n/(p-1)`. -/
+theorem padicValNat_factorial_eq_zero_iff (p n : ℕ) (hp : p.Prime) :
+    padicValNat p n.factorial = 0 ↔ n < p := by
+  haveI : Fact p.Prime := ⟨hp⟩
+  constructor
+  · intro h
+    by_contra hle
+    push_neg at hle
+    have hdvd : p ∣ n.factorial := hp.dvd_factorial.mpr hle
+    have : 1 ≤ padicValNat p n.factorial :=
+      one_le_padicValNat_of_dvd (Nat.factorial_ne_zero n) hdvd
+    omega
+  · intro hlt
+    exact padicValNat.eq_zero_of_not_dvd
+      (fun hdvd => absurd (hp.dvd_factorial.mp hdvd) (Nat.not_le.mpr hlt))
+
+/-- **The valuation `v_p(n!)` is positive exactly once `n` reaches `p`.**  The
+complement of `padicValNat_factorial_eq_zero_iff`: for every prime `p`,
+
+  `0 < v_p(n!)  ↔  p ≤ n`,
+
+i.e. `p` divides `n!` iff `n ≥ p`.  Together with the zero-locus statement this gives the
+sharp dichotomy governing the lowest step of Legendre's staircase. -/
+theorem padicValNat_factorial_pos_iff (p n : ℕ) (hp : p.Prime) :
+    0 < padicValNat p n.factorial ↔ p ≤ n := by
+  rw [Nat.pos_iff_ne_zero, ne_eq, padicValNat_factorial_eq_zero_iff p n hp, Nat.not_lt]
+
 -- The numerical content (v_p(n!) = (n - s_p(n))/(p-1) for many p, n) is certified
 -- independently in `research/problems/erdos-729-oq-02/verify_legendre_general.py`
 -- (no Lean `decide` on `Nat.digits`, which is well-founded and does not reduce
@@ -140,5 +177,7 @@ theorem padicValNat_factorial_le_div (p n : ℕ) (hp : p.Prime) :
 #check @sub_one_mul_padicValNat_factorial_le
 #check @padicValNat_factorial_le_div
 #check @modEq_digitSum
+#check @padicValNat_factorial_eq_zero_iff
+#check @padicValNat_factorial_pos_iff
 
 end Erdos729Legendre

--- a/proofs/Proofs/LagrangeFourSquaresOQ01OQ03Bound.lean
+++ b/proofs/Proofs/LagrangeFourSquaresOQ01OQ03Bound.lean
@@ -51,6 +51,27 @@ theorem eight_le_jacobiCount {n : ℕ} (hn : n ≠ 0) : 8 ≤ jacobiCount n := b
 theorem jacobiCount_pos {n : ℕ} (hn : n ≠ 0) : 0 < jacobiCount n :=
   lt_of_lt_of_le (by norm_num) (eight_le_jacobiCount hn)
 
+/-- **Every Jacobi count is a multiple of `8`.**  Immediate from the shape
+`jacobiCount n = 8·Σ…`.  Arithmetically this is the reason the lower bound is exactly
+`8` rather than `1`: signed four-square representations come in sign/permutation orbits,
+and the count is an integer number of size-`8` orbits.  (Combined with
+`eight_le_jacobiCount`, on every `n ≥ 1` the count is a *positive* multiple of `8`.) -/
+theorem eight_dvd_jacobiCount (n : ℕ) : 8 ∣ jacobiCount n := by
+  unfold jacobiCount
+  exact dvd_mul_right 8 _
+
+/-- **Elementary upper bound.**  The Jacobi RHS never exceeds `8·σ₁(n)`, i.e.
+`jacobiCount n ≤ 8·Σ_{d ∣ n} d`: the filter `4 ∤ d` can only *drop* divisor terms from
+the full divisor sum, never add them.  Together with `eight_le_jacobiCount` this sandwiches
+the count, `8 ≤ jacobiCount n ≤ 8·σ₁(n)` for `n ≥ 1`, with equality at the top exactly when
+no divisor of `n` is a multiple of `4` (e.g. every odd `n`). -/
+theorem jacobiCount_le_eight_mul_sigma (n : ℕ) :
+    jacobiCount n ≤ 8 * ∑ d ∈ n.divisors, d := by
+  have h : (∑ d ∈ n.divisors.filter (fun d => ¬ 4 ∣ d), d) ≤ ∑ d ∈ n.divisors, d :=
+    Finset.sum_le_sum_of_subset (Finset.filter_subset _ _)
+  unfold jacobiCount
+  omega
+
 /-- Sanity check: `jacobiCount 1 = 8`, so the lower bound is attained at `n = 1`. -/
 example : jacobiCount 1 = 8 := by decide
 

--- a/src/data/research/problems/erdos-729-oq-02.json
+++ b/src/data/research/problems/erdos-729-oq-02.json
@@ -105,8 +105,8 @@
     {
       "path": "Proofs/Erdos729LegendreGeneral.lean",
       "filename": "Erdos729LegendreGeneral.lean",
-      "lineCount": 93,
-      "theoremCount": 3,
+      "lineCount": 183,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/lagrange-four-squares-oq-01-oq-03.json
+++ b/src/data/research/problems/lagrange-four-squares-oq-01-oq-03.json
@@ -149,8 +149,8 @@
     {
       "path": "Proofs/LagrangeFourSquaresOQ01OQ03Bound.lean",
       "filename": "LagrangeFourSquaresOQ01OQ03Bound.lean",
-      "lineCount": 58,
-      "theoremCount": 3,
+      "lineCount": 78,
+      "theoremCount": 5,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,


### PR DESCRIPTION
## Summary

Two **axiom-free, locally-verified** theorems added to `proofs/Proofs/LagrangeFourSquaresOQ01OQ03Bound.lean`, completing the elementary structure of the Jacobi four-square right-hand side $\text{jacobiCount}(n) = 8\cdot\sum_{d\mid n,\ 4\nmid d} d$. The file already proves the lower bound $8 \le \text{jacobiCount}(n)$ and positivity; this PR adds the two natural companions:

- `eight_dvd_jacobiCount (n) : 8 ∣ jacobiCount n` — every count is a multiple of 8 (signed/permutation orbit structure); the reason the sharp lower bound is 8, not 1.
- `jacobiCount_le_eight_mul_sigma (n) : jacobiCount n ≤ 8·∑_{d∣n} d` — the elementary upper bound: the filter $4\nmid d$ can only drop divisor terms from the full sum.

Together with the existing `eight_le_jacobiCount` this **sandwiches** the count,
$$8 \le \text{jacobiCount}(n) \le 8\,\sigma_1(n) \quad (n \ge 1),$$
with top equality exactly when no divisor of $n$ is a multiple of 4 (e.g. every odd $n$).

## Proof

Fully elementary, native_decide-free:
- divisibility: `dvd_mul_right 8 _` after unfolding.
- upper bound: `Finset.sum_le_sum_of_subset (Finset.filter_subset _ _)` gives the sum inequality, then `omega` lifts it through the factor of 8.

## Verification

Docker image build is down (containerd meta.db I/O). Verified locally with **lean v4.26.0** against the pinned Mathlib oleans:
- File typechecks with **0 errors / 0 sorries**.
- `#print axioms` for both new theorems lists only `[propext, Classical.choice, Quot.sound]` — no `sorryAx`, no `Lean.ofReduceBool`. Genuinely axiom-free (this companion file, unlike the native_decide-based core, stays fully verified).

No collision: the only open lagrange PR (#37345) is on the group-theory slug `lagrange-theorem-oq-01`, a different file. Synced the `Bound` `leanFile` counts in the research json.

🤖 Generated with [Claude Code](https://claude.com/claude-code)