### PR TITLE
research(erdos-1014-oq-03): stray-ring drift repair + general-limit & log-gap increment bridges

### DIFF
--- a/proofs/Proofs/Erdos1014OQ03.lean
+++ b/proofs/Proofs/Erdos1014OQ03.lean
@@ -140,7 +140,6 @@ theorem increment_asymptotic_iff_ratioSubOne_asymptotic (R g : ℕ → ℝ)
       =ᶠ[atTop] (fun l => (R (l + 1) - R l) / g l) := by
     filter_upwards [hR, hg] with l hR' hg'
     field_simp
-    ring
   rw [tendsto_congr' heq]
 
 /-- **Logarithmic increment–ratio bridge.** For an eventually-positive sequence
@@ -303,6 +302,53 @@ theorem increment_gap_div_tendsto_zero (R : ℕ → ℝ) (m : ℕ)
     rw [sub_div, div_self (ne_of_gt hl)]
   rw [tendsto_congr' heq]
   have := hgap.sub_const 1
+  simpa using this
+
+/-- **General-limit additive–multiplicative increment equivalence.** For an
+eventually-positive sequence `R` and any `c` with `c + 1 > 0`, the *normalized
+(multiplicative) increment* `(R(l+1) − R(l))/R(l)` tends to `c` **iff** the *additive
+log-increment* `log R(l+1) − log R(l)` tends to `log (c + 1)`.
+
+The `c = 0` case is `increment_div_tendsto_zero_iff_log_increment_tendsto_zero`
+(where `log (0 + 1) = 0`). Both quantities are, by the two general-limit bridges,
+equivalent to the consecutive ratio tending to `c + 1`
+(`increment_div_tendsto_iff_ratio_tendsto` and
+`log_increment_tendsto_log_iff_ratio_tendsto` at `L = c + 1`), hence equivalent to each
+other. This is the `c`-parametrized form of the additive–multiplicative equivalence:
+for a geometrically-growing sequence whose normalized increment tends to `c` (ratio
+`→ c + 1`), the additive log-increment tends to `log (c + 1)`. -/
+theorem increment_div_tendsto_iff_log_increment_tendsto (R : ℕ → ℝ) (c : ℝ)
+    (hc : 0 < c + 1) (hpos : ∀ᶠ l in atTop, 0 < R l) :
+    Tendsto (fun l => (R (l + 1) - R l) / R l) atTop (𝓝 c) ↔
+      Tendsto (fun l => Real.log (R (l + 1)) - Real.log (R l)) atTop
+        (𝓝 (Real.log (c + 1))) := by
+  rw [increment_div_tendsto_iff_ratio_tendsto R c (hpos.mono fun _ hl => ne_of_gt hl),
+    log_increment_tendsto_log_iff_ratio_tendsto R (c + 1) hc hpos]
+
+/-- **Logarithmic bounded-gap increment vanishes.** Under Erdős #1014's ratio
+convergence `R(l+1)/R(l) → 1` (with `R` eventually positive), the *additive
+log-increment over any fixed gap* `m` tends to `0`:
+`log R(l+m) − log R(l) → 0`.
+
+The logarithmic companion of `increment_gap_div_tendsto_zero` (the multiplicative
+bounded-gap increment), and the `m`-fold form of
+`log_increment_tendsto_zero_of_ratio_tendsto_one` (the unit gap `m = 1`). Since
+`log R(l+m) − log R(l) = log (R(l+m)/R(l))` and the gap-ratio `R(l+m)/R(l) → 1`
+(`ratio_gap_tendsto_one`), continuity of `log` at `1` (with `log 1 = 0`) gives the
+claim. So under #1014, Ramsey growth is additively smooth on the log scale over every
+bounded window of the second index. -/
+theorem log_increment_gap_tendsto_zero (R : ℕ → ℝ) (m : ℕ)
+    (hpos : ∀ᶠ l in atTop, 0 < R l)
+    (hratio : Tendsto (fun l => R (l + 1) / R l) atTop (𝓝 1)) :
+    Tendsto (fun l => Real.log (R (l + m)) - Real.log (R l)) atTop (𝓝 0) := by
+  have hgap := ratio_gap_tendsto_one R m hpos hratio
+  have hpos_m : ∀ᶠ l in atTop, 0 < R (l + m) := (tendsto_add_atTop_nat m).eventually hpos
+  have heq : (fun l => Real.log (R (l + m)) - Real.log (R l))
+      =ᶠ[atTop] (fun l => Real.log (R (l + m) / R l)) := by
+    filter_upwards [hpos, hpos_m] with l hl hlm
+    rw [Real.log_div (ne_of_gt hlm) (ne_of_gt hl)]
+  rw [tendsto_congr' heq]
+  have := (Real.continuousAt_log (by norm_num : (1 : ℝ) ≠ 0)).tendsto.comp hgap
   simpa using this
 
 


### PR DESCRIPTION
## Summary

`Erdos1014OQ03.lean` (Erdős #1014 OQ-03, the consecutive off-diagonal Ramsey increment `Δ_l(k) = R(k,l+1)−R(k,l)`) **did not compile** under lean v4.26.0 — merged unverified during the Docker outage. This PR repairs it and adds two results that complete the file's term-for-term family of increment↔ratio bridges. The file imports only Mathlib, so it builds standalone.

## Repair

In `increment_asymptotic_iff_ratioSubOne_asymptotic`, a `field_simp; ring` block now has `field_simp` **fully close** the goal under current Mathlib, so the trailing `ring` errored with `No goals to be solved`. Removed the stray `ring`.

## New content (0 axioms, 0 sorries)

- **`increment_div_tendsto_iff_log_increment_tendsto`** — general-limit additive↔multiplicative equivalence: for `c + 1 > 0`, the normalized increment `(R(l+1)−R(l))/R(l) → c` **iff** the log-increment `log R(l+1) − log R(l) → log(c+1)`. The `c = 0` case is the existing `increment_div_tendsto_zero_iff_log_increment_tendsto_zero`; the proof composes the two existing general-limit bridges (`increment_div_tendsto_iff_ratio_tendsto` + `log_increment_tendsto_log_iff_ratio_tendsto` at `L = c+1`).
- **`log_increment_gap_tendsto_zero`** — logarithmic bounded-gap increment: under #1014's `R(l+1)/R(l) → 1`, `log R(l+m) − log R(l) → 0` for every fixed gap `m`. The log companion of the existing multiplicative `increment_gap_div_tendsto_zero`, via `ratio_gap_tendsto_one` plus continuity of `log` at `1`.

## Verification

**VERIFIED locally** with lean v4.26.0 against cached Mathlib oleans (Docker image build down — containerd `meta.db` I/O error). `Erdos1014OQ03.lean` builds standalone with **0 errors / 0 sorries**. No gallery meta tracks this file (Lean-only PR).

## Out of scope (flagged)

Separate **pre-existing** drift not touched here: the parent `Erdos1014Problem.lean` and sibling `Erdos1014OQ03Obstruction.lean` also fail to compile under v4.26.0 (a `div_le_div_iff` Mathlib rename and related), independent of this file. `Erdos1014OQ03LogIncrement.lean` builds cleanly against the repaired base. These warrant a follow-up repair PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)