### PR TITLE
research(szemeredi-regularity-oq-04): energy monotonicity (Jensen: mean² ≤ mean-of-squares) [VERIFIED]

### DIFF
--- a/proofs/Proofs/SzemerediRegularityOQ04.lean
+++ b/proofs/Proofs/SzemerediRegularityOQ04.lean
@@ -571,4 +571,25 @@ theorem weighted_variance_subset_bound {ι : Type*} (s : Finset ι) (w x : ι �
   rw [Finset.sum_mul]
   linarith [hsubset, hfloor]
 
+/-- **Energy monotonicity: square of the mean ≤ weighted mean of squares (Jensen).**
+    With nonnegative weights `w` and weighted mean `μ` (`∑ wᵢxᵢ = (∑ wᵢ)·μ`), the total
+    weighted second moment about `0` dominates the mean scaled by the total weight:
+    `(∑ wᵢ)·μ² ≤ ∑ wᵢxᵢ²`.  Immediate from `weighted_variance_eq`, since the variance
+    `∑ wᵢ(xᵢ − μ)²` is a sum of nonnegative terms.
+
+    This is the coarse-to-fine inequality the atom bounds sharpen: it says the
+    mean-square edge density (partition energy) of a *refined* partition is at least
+    that of its parent — refining can only raise energy, never lower it.  The
+    variance-atom lemmas above quantify *how much* it rises; this records that the
+    rise is nonnegative unconditionally, the monotonicity underlying the `[0,1]`
+    energy trap that makes the AFKS iteration terminate. -/
+theorem weighted_sq_mean_le {ι : Type*} (s : Finset ι) (w x : ι → ℚ) (μ : ℚ)
+    (hw : ∀ i ∈ s, 0 ≤ w i)
+    (hmean : ∑ i ∈ s, w i * x i = (∑ i ∈ s, w i) * μ) :
+    (∑ i ∈ s, w i) * μ ^ 2 ≤ ∑ i ∈ s, w i * x i ^ 2 := by
+  have hvar : 0 ≤ ∑ i ∈ s, w i * (x i - μ) ^ 2 :=
+    Finset.sum_nonneg (fun i hi => mul_nonneg (hw i hi) (sq_nonneg _))
+  rw [weighted_variance_eq s w x μ hmean] at hvar
+  linarith
+
 end Szemeredi.RegularityOQ04


### PR DESCRIPTION
## Summary

The variance-atom section of `SzemerediRegularityOQ04.lean` proves *lower* bounds on the energy increment (`weighted_variance_atom_bound`, `weighted_variance_subset_bound`) and its docstrings repeatedly invoke the qualitative fact that *refining a partition can only raise the mean-square edge density (partition energy), never lower it* — but that coarse-to-fine inequality was never stated as a standalone lemma. This PR adds it:

- **`weighted_sq_mean_le`** — for nonnegative weights `w` with weighted mean `μ` (`∑ wᵢxᵢ = (∑ wᵢ)·μ`): `(∑ wᵢ)·μ² ≤ ∑ wᵢxᵢ²`. The Jensen / square-of-mean ≤ mean-of-squares inequality, immediate from the existing `weighted_variance_eq` since the variance `∑ wᵢ(xᵢ − μ)²` is a sum of nonnegative terms.

The variance-atom lemmas quantify *how much* the energy rises when cells deviate; this records that the rise is **nonnegative unconditionally** — the monotonicity underlying the `[0,1]` energy trap that makes the AFKS iteration terminate.

## Verification

Compiled locally with `lean v4.26.0` against cached Mathlib + Proofs oleans (docker image-build currently down). Builds with **0 errors**; `#print axioms weighted_sq_mean_le` reports only `propext, Classical.choice, Quot.sound` — **0 sorries**.

Appended at the file end, disjoint from the open PR #35998 (which touches the Bridge/Energy files, not this one). No gallery dir tracks this file, so no meta sync is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)