### PR TITLE
Fix: resync erdos-771-construction meta.lineCount 216→297

### DIFF
--- a/src/data/proofs/erdos-771-construction/meta.json
+++ b/src/data/proofs/erdos-771-construction/meta.json
@@ -19,7 +19,7 @@
     "badge": "verified",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 216,
+    "lineCount": 297,
     "assumptions": "None. Every theorem is elementary number theory / finite combinatorics with zero axioms and zero sorries (only the foundational propext/Classical.choice/Quot.sound; the quantitative theorem additionally uses Mathlib's verified Bertrand's postulate, itself 0-axiom). The deep asymptotic bounds of Erdős #771 (the matching (1/2+o(1))·n/log n lower and upper bounds) are NOT proved or assumed here.",
     "dateAdded": "2026-06-25",
     "mathlib_version": "4.26.0",
@@ -133,7 +133,7 @@
       "Mathlib"
     ],
     "namespace": "Erdos771Construction",
-    "lineCount": 216,
+    "lineCount": 297,
     "axiomCount": 0,
     "theoremCount": 6,
     "path": "Proofs/Erdos771Construction.lean",


### PR DESCRIPTION
## Fix

Resync stale `meta.lineCount` for erdos-771-construction (both leanFile and meta blocks) from 216 to the actual 297 lines.

## Evidence

**Before**: `src/data/proofs/erdos-771-construction/meta.json` declared `lineCount: 216` in both blocks.
**After**: `lineCount: 297`, matching `proofs/Proofs/Erdos771Construction.lean` (297 lines, `wc -l` == py readline, trailing newline — no ambiguity).

The `.lean` file grew via merged #37399 (m=2 realization — largest 2-avoiding subset). No open PR touches this slug, so the drift was genuinely uncovered.

---
Automated fix by lean-mechanic agent.