### PR TITLE
research(erdos-490-incomplete-01): product-set monotonicity + distinct-products subset closure

### DIFF
--- a/proofs/Proofs/Erdos490Problem.lean
+++ b/proofs/Proofs/Erdos490Problem.lean
@@ -118,6 +118,26 @@ theorem hasDistinctProducts_comm (A B : Finset ℕ) :
   rw [HasDistinctProducts, HasDistinctProducts, productSet_comm A B,
     Nat.mul_comm A.card B.card]
 
+/-- **The product set is monotone in both factors**: enlarging either `A` or `B`
+can only enlarge `A·B`.  Immediate from `productSet_eq_image` and monotonicity of
+`Finset.image` along `A' ×ˢ B' ⊆ A ×ˢ B`. -/
+theorem productSet_mono {A A' B B' : Finset ℕ} (hA : A' ⊆ A) (hB : B' ⊆ B) :
+    productSet A' B' ⊆ productSet A B := by
+  rw [productSet_eq_image, productSet_eq_image]
+  exact image_subset_image (product_subset_product hA hB)
+
+/-- **Distinct products is inherited by subsets**: if every product `a·b` over
+`A × B` is distinct, then so are the products over any subsets `A' ⊆ A`, `B' ⊆ B`.
+Distinctness is a downward-closed property — a subpair of a "good" pair is again
+"good" — so in the extremal problem one may always pass to subsets freely.  Proved
+through the elementwise `ProductMapInjective` characterization. -/
+theorem HasDistinctProducts.subset {A A' B B' : Finset ℕ}
+    (h : HasDistinctProducts A B) (hA : A' ⊆ A) (hB : B' ⊆ B) :
+    HasDistinctProducts A' B' := by
+  rw [← productMapInjective_iff_hasDistinctProducts] at h ⊢
+  intro a₁ a₂ b₁ b₂ ha₁ ha₂ hb₁ hb₂ heq
+  exact h a₁ a₂ b₁ b₂ (hA ha₁) (hA ha₂) (hB hb₁) (hB hb₂) heq
+
 /-
 ## Part II: The Erdős Question
 -/

--- a/src/data/proofs/erdos-490/meta.json
+++ b/src/data/proofs/erdos-490/meta.json
@@ -82,9 +82,9 @@
       "erdos490_analytic_tail (in Erdos490Chebyshev.lean, 0-axiom): ∃c>0,∃N₀,∀n≥N₀, the elementary θ-gap lower bound (n/3)·log4 − log n − √(2n)·log(2n) ≥ c·n, proved from Real.isLittleO_log_id_atTop and isLittleO_log_rpow_atTop (exponent 1/2). This is the single analytic input that converted the Chebyshev θ-gap axiom into a theorem."
     ],
     "axiomCount": 1,
-    "lineCount": 937,
+    "lineCount": 979,
     "assumptions": "1 axiom, 0 sorries. Axiom: szemeredi_theorem (Szemerédi 1976 N²/log N upper bound, deep — the hard analytic input of the problem). The former second axiom chebyshev_theta_upper_half_lower_bound (the classical Chebyshev θ-gap lower bound θ(N)−θ(N/2) ≥ c·N) is NOW A THEOREM (0-axiom), proved by combining the verified central-binomial estimate Erdos490Cheb.theta_gap_lower_bound with the analytic tail Erdos490Cheb.erdos490_analytic_tail (log n and √(2n)·log(2n) are o(n)) and a Bertrand-based θ(N)−θ(N/2) ≥ log 2 for the finitely many small N. Only the deep Szemerédi upper bound remains axiomatized; status stays 'axiomatized'.",
-    "theoremCount": 29,
+    "theoremCount": 33,
     "definitionCount": 15,
     "additionalFiles": [
       "Proofs/Erdos490ProblemAristotle.lean",
@@ -217,9 +217,9 @@
       "Real"
     ],
     "namespace": "Erdos490",
-    "lineCount": 959,
+    "lineCount": 979,
     "axiomCount": 1,
-    "theoremCount": 31,
+    "theoremCount": 33,
     "definitionCount": 15,
     "path": "Proofs/Erdos490Problem.lean",
     "sorries": 0,


### PR DESCRIPTION
## Summary

Adds two structural API lemmas to `proofs/Proofs/Erdos490Problem.lean` (Erdős #490, distinct products of two sets), completing the basic theory of the product set alongside the existing symmetry lemmas `productSet_comm` / `hasDistinctProducts_comm`:

```lean
theorem productSet_mono {A A' B B' : Finset ℕ} (hA : A' ⊆ A) (hB : B' ⊆ B) :
    productSet A' B' ⊆ productSet A B

theorem HasDistinctProducts.subset {A A' B B' : Finset ℕ}
    (h : HasDistinctProducts A B) (hA : A' ⊆ A) (hB : B' ⊆ B) :
    HasDistinctProducts A' B'
```

- **Monotonicity** is immediate from `productSet_eq_image` and `Finset.image_subset_image` along `product_subset_product`.
- **Downward closure** of the distinctness property is proved through the elementwise `ProductMapInjective` characterization: a subpair of a pair whose products are all distinct again has all-distinct products. This records that the extremal problem may freely restrict to subsets — a fact used implicitly throughout the file's extremal arguments.

No new axioms, no new imports.

## Verification

Docker image-build is currently down (containerd `meta.db` I/O error), so verified locally with the pinned toolchain (`lean v4.26.0`) against the cached Mathlib oleans plus a freshly built `Erdos490Chebyshev` dependency:

- **EXIT 0**, 0 sorries, no new warnings (only the file's pre-existing `unusedVariables` lint)
- The single `szemeredi_theorem` axiom is untouched — status remains `axiomatized` (1 axiom)

## Gallery meta

`src/data/proofs/erdos-490/meta.json` synced to the current file: `979` lines / `33` theorems in **both** the `meta` and `leanFile` blocks. (The two blocks were also previously out of sync — `937/29` vs `959/31` after the earlier symmetry-lemma merge — and are now reconciled.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)