### PR TITLE
research(shannon-entropy-oq-03): dual conditioning-deficit identity + deficit symmetry [VERIFIED]

### DIFF
--- a/proofs/Proofs/ShannonEntropySSA.lean
+++ b/proofs/Proofs/ShannonEntropySSA.lean
@@ -150,4 +150,42 @@ theorem conditionalMutualInfo_eq_conditioning_deficit (pXYZ : α × β × γ →
   unfold conditionalMutualInfo
   ring
 
+/-- **Conditional mutual information equals the conditioning deficit — `X ↔ Z`
+    dual.** With the conditional entropies `H(Z | Y) = H(Y, Z) − H(Y)` and
+    `H(Z | X, Y) = H(X, Y, Z) − H(X, Y)`,
+
+      `I(X ; Z | Y) = H(Z | Y) − H(Z | X, Y)`.
+
+    This is the `X ↔ Z` dual of `conditionalMutualInfo_eq_conditioning_deficit`,
+    formalizing the identity asserted in prose in the docstring of
+    `conditioning_reduces_entropy_general'` — that the deficit by which the extra
+    variable `X` reduces the conditional entropy of `Z` is *exactly* the same
+    conditional mutual information.  Together with the primal deficit identity it
+    completes the symmetric pair, matching the symmetric conditioning bounds
+    `conditioning_reduces_entropy_general` / `…'`.  Like its dual it is a pure
+    rearrangement of the definition, holding with no probability hypotheses. -/
+theorem conditionalMutualInfo_eq_conditioning_deficit' (pXYZ : α × β × γ → ℝ) :
+    conditionalMutualInfo pXYZ =
+      (shannonEntropy (marginalYZ pXYZ) - shannonEntropy (marginalY pXYZ)) -
+        (shannonEntropy pXYZ - shannonEntropy (marginalXY pXYZ)) := by
+  unfold conditionalMutualInfo
+  ring
+
+/-- **The two conditioning deficits are equal.**
+
+      `H(X | Y) − H(X | Y, Z) = H(Z | Y) − H(Z | X, Y)`,
+
+    i.e. the amount by which learning `Z` reduces the conditional entropy of `X`
+    equals the amount by which learning `X` reduces the conditional entropy of
+    `Z`.  Both sides equal the conditional mutual information `I(X ; Z | Y)`
+    (`conditionalMutualInfo_eq_conditioning_deficit` and its `'` dual), so this is
+    the symmetry `I(X ; Z | Y) = I(Z ; X | Y)` read at the level of conditional
+    entropies.  A pure rearrangement, valid with no probability hypotheses. -/
+theorem conditioning_deficit_symm (pXYZ : α × β × γ → ℝ) :
+    (shannonEntropy (marginalXY pXYZ) - shannonEntropy (marginalY pXYZ)) -
+        (shannonEntropy pXYZ - shannonEntropy (marginalYZ pXYZ)) =
+      (shannonEntropy (marginalYZ pXYZ) - shannonEntropy (marginalY pXYZ)) -
+        (shannonEntropy pXYZ - shannonEntropy (marginalXY pXYZ)) := by
+  ring
+
 end InformationTheory.SSA

--- a/src/data/proofs/shannon-entropy-oq-03/meta.json
+++ b/src/data/proofs/shannon-entropy-oq-03/meta.json
@@ -43,8 +43,8 @@
       "Conditional mutual information as a first-class definition (conditionalMutualInfo), with the deficit identity I(X;Z|Y) = H(X|Y) − H(X|Y,Z) formalizing the prose claim of the conditioning corollaries"
     ],
     "dateAdded": "2026-03-30",
-    "lineCount": 153,
-    "theoremCount": 6,
+    "lineCount": 191,
+    "theoremCount": 8,
     "definitionCount": 1,
     "additionalFiles": [],
     "mathlib_version": "4.26.0",
@@ -172,9 +172,9 @@
       "Finset"
     ],
     "namespace": "InformationTheory.SSA",
-    "lineCount": 153,
+    "lineCount": 191,
     "axiomCount": 0,
-    "theoremCount": 6,
+    "theoremCount": 8,
     "definitionCount": 1,
     "path": "Proofs/ShannonEntropySSA.lean",
     "sorries": 0,


### PR DESCRIPTION
## Summary

The claimed slug `shannon-entropy-oq-03-incomplete-01` is a **saturated** target: strong subadditivity (SSA) is already fully proven (0-sorry, 0-axiom) in `ShannonEntropy.lean` and re-exported through the gallery file `ShannonEntropySSA.lean`, which also packages the conditional-mutual-information quantity `conditionalMutualInfo` with its non-negativity and the *primal* conditioning-deficit identity.

The one real gap in that API: the file carries the **symmetric conditioning-reduction pair** (`conditioning_reduces_entropy_general` and its `X↔Z` dual `'`) but only **one** deficit-identity. This PR completes the pair.

## What's added (`Proofs/ShannonEntropySSA.lean`)

- **`conditionalMutualInfo_eq_conditioning_deficit'`** — the `X↔Z` dual
  `I(X;Z|Y) = H(Z|Y) − H(Z|X,Y)`, formalizing the identity stated in prose in the docstring of `conditioning_reduces_entropy_general'`.
- **`conditioning_deficit_symm`** — the two conditioning deficits are equal:
  `H(X|Y) − H(X|Y,Z) = H(Z|Y) − H(Z|X,Y)`, i.e. `I(X;Z|Y) = I(Z;X|Y)` read at the level of conditional entropies.

Both are unconditional pure rearrangements (`unfold; ring` / `ring`) of the existing verified `conditionalMutualInfo` definition. No probability hypotheses, no new axioms, 0 sorries.

## Verification

Docker image build is currently down (containerd `meta.db` input/output error), so verified locally with `lean v4.26.0`: built `ShannonEntropy.olean` to a temp output dir, then compiled the target file — **0 errors, 0 warnings**, olean produced. Additions use only `ring`/`unfold`, so the file stays axiom-free.

## Gallery sync

`src/data/proofs/shannon-entropy-oq-03/meta.json` (both count blocks): `lineCount` 153→191, `theoremCount` 6→8.