### PR TITLE
Enrich Fibonacci Gap-Two Product-Sum: annotate open Finset setup

### DIFF
--- a/src/data/proofs/fibonacci-identities-oq-05-oq-03/annotations.json
+++ b/src/data/proofs/fibonacci-identities-oq-05-oq-03/annotations.json
@@ -20,6 +20,23 @@
     "tags": ["module-header", "framing", "fibonacci"]
   },
   {
+    "id": "ann-fiboq0503-setup",
+    "proofId": "fibonacci-identities-oq-05-oq-03",
+    "range": { "startLine": 32, "endLine": 35 },
+    "type": "context",
+    "title": "Namespace and the open Finset Summation Layer",
+    "content": "**Why `open Finset` matters here.** The single line `open Finset` is the infrastructure the whole entry runs on: it brings `Finset.range` and the `∑ i ∈ Finset.range (n+1), F_i F_{i+2}` big-operator notation into scope, and — critically — makes `Finset.sum_range_succ` available unqualified. That lemma, $\\sum_{i<n+1} f(i) = \\left(\\sum_{i<n} f(i)\\right) + f(n)$, is exactly the *peel-the-last-term* step the main induction uses to expose the fresh product $F_n F_{n+2}$ so that `omega` can combine it with the inductive hypothesis. The `namespace FibonacciIdentitiesOQ05OQ03` wrapper keeps `fib_cassini`, `fib_gap_rel`, and the headline `fib_gap_two_prod_sum` from colliding with the parent `FibonacciIdentitiesOQ05` file's consecutive-product lemmas of the same shape.",
+    "mathContext": "$\\sum_{i \\in \\mathrm{range}(n+1)} f(i) = \\left(\\sum_{i \\in \\mathrm{range}(n)} f(i)\\right) + f(n)$ — `Finset.sum_range_succ`.",
+    "significance": "technical",
+    "relatedConcepts": [
+      "Finset.range and big-operator ∑ notation",
+      "Finset.sum_range_succ (peeling the last term)",
+      "Namespacing to avoid collision with the parent file"
+    ],
+    "prerequisites": ["Finite sums over Finset.range", "Lean namespaces and open"],
+    "tags": ["setup", "finset", "namespace"]
+  },
+  {
     "id": "ann-fiboq0503-2",
     "proofId": "fibonacci-identities-oq-05-oq-03",
     "range": { "startLine": 37, "endLine": 54 },


### PR DESCRIPTION
Enrichment pass for `fibonacci-identities-oq-05-oq-03`.

**Gap addressed:** The entry was well-covered (6 annotations spanning lines 3–144, 6 keyInsights, meta 16.7 KB — comfortably under caps), but the namespace + `open Finset` setup region (lines 32–35) sat uncovered between the module-header annotation (ends line 30) and Cassini (starts line 37).

**Change:** One `context` annotation covering lines 32–35 explaining why `open Finset` is load-bearing for this proof — it brings `Finset.sum_range_succ` ($\sum_{i<n+1} f = \sum_{i<n} f + f(n)$) into scope, which is the *peel-the-last-term* step the main induction uses to expose the fresh $F_n F_{n+2}$ product for `omega`. Also notes the namespace's role in avoiding collision with the parent `FibonacciIdentitiesOQ05` file.

meta.json untouched. JSON validated; annotation ranges remain ordered and non-overlapping.