### PR TITLE
research(angle-trisection-oq-02-oq-01-oq-03): degree coprimality + p ≤ degree bound [+2 thm]

### DIFF
--- a/proofs/Proofs/AngleTrisectionOQ02OQ01OQ03.lean
+++ b/proofs/Proofs/AngleTrisectionOQ02OQ01OQ03.lean
@@ -288,4 +288,28 @@ theorem pgroup_prime_eq_minFac (α : ℝ) (hα : IsIntegral ℚ α)
   rw [hpf, Finset.mem_singleton] at hmem
   exact hmem.symm
 
+/-- **The degree is coprime to every prime other than `p`.**
+    Companion to `pgroup_primeFactors_eq`: since a `p`-group Galois group makes the
+    degree a power of `p`, the degree shares no prime factor with any other prime `q`.
+    Equivalently, `q ∤ natDegree(minpoly ℚ α)` for `q ≠ p` — the positive coprimality
+    form of the prime-factor obstruction `not_pgroup_of_prime_dvd_degree_ne`. -/
+theorem pgroup_degree_coprime_of_prime_ne (α : ℝ) (hα : IsIntegral ℚ α)
+    {p q : ℕ} (hp : p.Prime) (hq : q.Prime) (hne : q ≠ p)
+    (hP : IsPGroup p (minpoly ℚ α).Gal) :
+    Nat.Coprime q (minpoly ℚ α).natDegree := by
+  obtain ⟨k, hk⟩ := galois_pgroup_implies_degree_is_pow_p α hα hp hP
+  rw [hk]
+  exact ((Nat.coprime_primes hq hp).mpr hne).pow_right k
+
+/-- **A nontrivial p-group Galois extension has degree at least `p`.**
+    The cleanest size bound: a `p`-group Galois group forces `p ∣ degree`
+    (`prime_dvd_degree_of_pgroup`), and a positive multiple of `p` is at least `p`.
+    So the minimal-polynomial degree of a nontrivial `p`-group extension can never be
+    smaller than the prime itself. -/
+theorem p_le_degree_of_pgroup (α : ℝ) (hα : IsIntegral ℚ α)
+    {p : ℕ} (hp : p.Prime) (hgt : 1 < (minpoly ℚ α).natDegree)
+    (hP : IsPGroup p (minpoly ℚ α).Gal) :
+    p ≤ (minpoly ℚ α).natDegree :=
+  Nat.le_of_dvd (by omega) (prime_dvd_degree_of_pgroup α hα hp hgt hP)
+
 end AngleTrisectionOQ02OQ01OQ03


### PR DESCRIPTION
## Summary

Two new corollaries to the p-group Galois → prime-power degree suite in `AngleTrisectionOQ02OQ01OQ03.lean`, the algebraic core behind angle-trisection impossibility.

- **`pgroup_degree_coprime_of_prime_ne`** — a `p`-group Galois group makes the minimal-polynomial degree a power of `p`, hence `Nat.Coprime q (natDegree)` for every prime `q ≠ p`. This is the positive coprimality form complementing `pgroup_primeFactors_eq` (which pins the prime-factor set to `{p}`) and `not_pgroup_of_prime_dvd_degree_ne`.
- **`p_le_degree_of_pgroup`** — the clean size bound: since `p ∣ natDegree` (`prime_dvd_degree_of_pgroup`) and the extension is nontrivial, `p ≤ natDegree`. A nontrivial `p`-group extension's degree is never below the prime itself.

Both reuse existing lemmas in the file (`galois_pgroup_implies_degree_is_pow_p`, `prime_dvd_degree_of_pgroup`); proofs are 2–3 lines each.

## Verification

Docker image build is down and disk is full, so verified locally with lean v4.26.0 (matching `lean-toolchain`) against the cached Mathlib oleans and the parent `AngleTrisectionOQ02OQ01.olean`: **0 errors, 0 sorries, 0 new axioms**.

No gallery meta.json tracks this file — Lean-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)