### PR TITLE
research(erdos-703): L-avoiding union/insert decomposition (Frankl–Wilson API)

### DIFF
--- a/proofs/Proofs/Erdos703Problem.lean
+++ b/proofs/Proofs/Erdos703Problem.lean
@@ -729,6 +729,36 @@ theorem avoidsLIntersections_empty (F : Finset (Finset ℕ)) :
   intro A B _ _
   simp
 
+/--
+**Union of forbidden sizes decomposes.** Avoiding the union `L ∪ L'` of two forbidden-size
+sets is exactly avoiding each of them: a pair's intersection size lies in `L ∪ L'` iff it lies
+in `L` or in `L'`, so forbidding the union is the conjunction of the two constraints. This is
+the multiplicative/AND structure of the `L`-avoiding hierarchy, complementing the antitone
+`avoidsLIntersections_of_subset_forbidden`. -/
+theorem avoidsLIntersections_union {L L' : Finset ℕ} {F : Finset (Finset ℕ)} :
+    avoidsLIntersections (L ∪ L') F ↔
+      avoidsLIntersections L F ∧ avoidsLIntersections L' F := by
+  constructor
+  · intro h
+    exact ⟨avoidsLIntersections_of_subset_forbidden Finset.subset_union_left h,
+           avoidsLIntersections_of_subset_forbidden Finset.subset_union_right h⟩
+  · rintro ⟨h1, h2⟩ A B hA hB hmem
+    rw [Finset.mem_union] at hmem
+    rcases hmem with hL | hL'
+    · exact h1 A B hA hB hL
+    · exact h2 A B hA hB hL'
+
+/--
+**Adding one forbidden size.** Avoiding `insert r L` is avoiding the single size `r`
+(equivalently `avoidsRIntersection r`) *and* avoiding `L`. Via the singleton bridge
+`avoidsRIntersection_iff_avoidsLIntersections_singleton`, this lets the `T(n,r)` `r`-avoidance
+theory be assembled one forbidden size at a time inside the Frankl–Wilson hierarchy. -/
+theorem avoidsLIntersections_insert {r : ℕ} {L : Finset ℕ} {F : Finset (Finset ℕ)} :
+    avoidsLIntersections (insert r L) F ↔
+      avoidsRIntersection r F ∧ avoidsLIntersections L F := by
+  rw [Finset.insert_eq, avoidsLIntersections_union,
+      avoidsRIntersection_iff_avoidsLIntersections_singleton]
+
 /-
 ## Part VIII: Summary
 -/

--- a/research/problems/erdos-703-incomplete-01/knowledge.md
+++ b/research/problems/erdos-703-incomplete-01/knowledge.md
@@ -42,3 +42,31 @@ axiomCount stays 1 (`frankl_rodl_1987` untouched).
 
 **BLOCKER:** docker corrupted fleet-wide (containerd `meta.db` I/O error at image
 build). UNVERIFIED; proofs are trivial membership facts, correct by inspection.
+
+## Session 2026-07-10 (researcher-3) — L-avoiding union/insert decomposition (VERIFIED)
+
+**Mode**: REVISIT (Part VII API). **Outcome**: progress (2 theorems, axiom-free), **VERIFIED-local**.
+
+Part VII's `avoidsLIntersections` API had subset-family / antitone-forbidden / empty lemmas but
+no union rule. Added the AND-structure of the Frankl–Wilson hierarchy:
+- `avoidsLIntersections_union {L L' F}`: `avoidsLIntersections (L ∪ L') F ↔ avoidsLIntersections L F
+  ∧ avoidsLIntersections L' F`. Forward = two applications of `avoidsLIntersections_of_subset_forbidden`
+  with `Finset.subset_union_left/right`; backward = `rw [Finset.mem_union]; rcases`.
+- `avoidsLIntersections_insert {r L F}`: `avoidsLIntersections (insert r L) F ↔ avoidsRIntersection r F
+  ∧ avoidsLIntersections L F`. One-liner: `rw [Finset.insert_eq, avoidsLIntersections_union,
+  avoidsRIntersection_iff_avoidsLIntersections_singleton]` (uses the singleton bridge). Lets the
+  `T(n,r)` r-avoidance theory be built one forbidden size at a time.
+
+Both pure logic → **axiom-free** (file keeps its 1 deep `frankl_rodl_1987` axiom, un-eliminable).
+
+**Verification.** docker image layer down (containerd meta.db I/O). elan lean v4.26.0 vs main-checkout
+Mathlib oleans → exit 0, no warnings. File 765→795 lines, 31→33 theorems; meta.{meta,leanFile}
+lineCount/theoremCount synced, axiomCount stays 1.
+
+★★INFRA: worktree `.loom/worktrees/researcher-3` deleted TWICE this session (env eater) —
+uncommitted edits lost each time (branch at origin/main). Recovery: `git worktree prune` +
+`git worktree add <path> <existing-branch>` (no -b) + re-apply from context + **commit as soon as
+build passes**. Committed the .lean before touching meta this time.
+
+### Still open (unchanged)
+`frankl_rodl_1987` (deep 1987 exponential bound, no Mathlib pathway) — BLOCKED.

--- a/src/data/proofs/erdos-703/meta.json
+++ b/src/data/proofs/erdos-703/meta.json
@@ -53,10 +53,10 @@
       "T_le_pow_sub_choose / T_le_pow_sub_one: sharpened upper bound T(n,r) ≤ 2^n − C(n,r), machine-checked. An r-avoiding family can contain no set of size exactly r (its self-pair A,A meets in |A| = r), so the family omits all C(n,r) subsets of size r, giving T(n,r) ≤ 2^n − C(n,r); for r ≤ n this yields the uniform strict improvement T(n,r) ≤ 2^n − 1 over the trivial ceiling, and it is tight at the diagonal r = n (C(n,n) = 1 recovers T(n,n) = 2^n − 1)."
     ],
     "axiomCount": 1,
-    "lineCount": 765,
+    "lineCount": 795,
     "assumptions": "1 axiom: frankl_rodl_1987 (the deep Frankl–Rödl 1987 exponential bound — the affirmative answer to the main question). 0 sorries: the trivial case T(n,0)=2^{n-1} is fully machine-checked (#print axioms T_n_0 = [propext, Classical.choice, Quot.sound]) via a complement-pairing upper bound and a star-family witness. The unused opaque chromaticNumber axiom was removed; the geometric chromatic-number consequence is recorded as prose only since infinite unit-distance chromatic numbers are not yet in Mathlib.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 31,
+    "theoremCount": 33,
     "definitionCount": 8
   },
   "crossReferences": [
@@ -183,9 +183,9 @@
       "Finset"
     ],
     "namespace": "Erdos703",
-    "lineCount": 765,
+    "lineCount": 795,
     "axiomCount": 1,
-    "theoremCount": 31,
+    "theoremCount": 33,
     "definitionCount": 8,
     "path": "Proofs/Erdos703Problem.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

Part VII of `Erdos703Problem.lean` develops the Frankl–Wilson `L`-avoiding hierarchy
(`avoidsLIntersections L F`: no two sets in `F` intersect in a size lying in `L`). It had the
subset-family, antitone-forbidden, and empty-base lemmas but **no union rule**. This PR adds the
AND-structure that was missing:

- **`avoidsLIntersections_union`**: `avoidsLIntersections (L ∪ L') F ↔ avoidsLIntersections L F ∧
  avoidsLIntersections L' F`. A pair's intersection size lies in `L ∪ L'` iff it lies in `L` or in
  `L'`, so forbidding a union of sizes is exactly the conjunction of the two constraints —
  complementing the existing antitone `avoidsLIntersections_of_subset_forbidden`.
- **`avoidsLIntersections_insert`**: `avoidsLIntersections (insert r L) F ↔ avoidsRIntersection r F
  ∧ avoidsLIntersections L F`. Via the singleton bridge
  `avoidsRIntersection_iff_avoidsLIntersections_singleton`, this lets the `T(n,r)` `r`-avoidance
  theory be assembled one forbidden intersection size at a time inside the hierarchy.

Both lemmas are pure logic — **no new axioms**; the file keeps its single deep
`frankl_rodl_1987` axiom (the 1987 exponential bound, no Mathlib pathway, un-eliminable).

## Verification

**VERIFIED locally** (Docker image layer down — containerd metadata.db I/O error at image build).
Offline typecheck with pinned `elan lean v4.26.0` against the main checkout's Mathlib oleans →
**exit 0, no warnings**.

## Changes

- `Erdos703Problem.lean`: +2 theorems in Part VII. 765→795 lines, 31→33 theorems, axiomCount
  unchanged (1).
- `meta.json`: lineCount 765→795, theoremCount 31→33 synced (both `meta` and `leanFile` blocks).