### PR TITLE
research(bezout-identity-oq-01-oq-02-oq-02): repair Mathlib drift (restore 'verified') + empty-dimension edge case

### DIFF
--- a/proofs/Proofs/BezoutIdentityOQ01OQ02OQ02.lean
+++ b/proofs/Proofs/BezoutIdentityOQ01OQ02OQ02.lean
@@ -63,7 +63,7 @@ def IsPrimitive (v : Fin n → ℤ) : Prop := ∃ w : Fin n → ℤ, w ⬝ᵥ v 
 pairing to `1`.  This is the target of the transitivity reduction. -/
 theorem isPrimitive_single (i : Fin n) : IsPrimitive (Pi.single i (1 : ℤ)) := by
   refine ⟨Pi.single i 1, ?_⟩
-  simp [dotProduct, Pi.single_apply, Finset.sum_ite_eq]
+  simp [dotProduct, Pi.single_apply]
 
 /-- **Bridge to the classical notion.**  `v` is primitive iff its entries
 generate the unit ideal of `ℤ`, i.e. `Ideal.span (range v) = ⊤`.  Over `ℤ` the
@@ -106,7 +106,7 @@ theorem isPrimitive_mulVec_iff (A : Matrix.SpecialLinearGroup (Fin n) ℤ)
 proves transitivity; each has determinant `1`. -/
 def transvectionSL (i j : Fin n) (h : i ≠ j) (c : ℤ) :
     Matrix.SpecialLinearGroup (Fin n) ℤ :=
-  ⟨Matrix.transvection i j c, Matrix.det_transvection_of_ne h c⟩
+  ⟨Matrix.transvection i j c, Matrix.det_transvection_of_ne i j h c⟩
 
 /-- **Action of a transvection on a vector.**  `transvectionSL i j h c` adds
 `c · vⱼ` to the `i`-th coordinate of `v` and leaves the others fixed — one
@@ -186,16 +186,23 @@ of the `SLₙ(ℤ)`-action. -/
 theorem isPrimitive_fin_one_iff (v : Fin 1 → ℤ) :
     IsPrimitive v ↔ v 0 = 1 ∨ v 0 = -1 := by
   have hdot : ∀ x y : Fin 1 → ℤ, x ⬝ᵥ y = x 0 * y 0 := fun x y => by
-    simp [dotProduct, Fin.sum_univ_one]
+    simp [dotProduct]
   constructor
   · rintro ⟨w, hw⟩
     rw [hdot] at hw
     have hu : IsUnit (v 0) :=
-      isUnit_of_mul_eq_one (v 0) (w 0) (by rw [mul_comm]; exact hw)
+      IsUnit.of_mul_eq_one (w 0) (by rw [mul_comm]; exact hw)
     rwa [Int.isUnit_iff] at hu
   · intro h
     refine ⟨v, ?_⟩
     rw [hdot]
     rcases h with h | h <;> rw [h] <;> norm_num
+
+/-- **The empty dimension has no primitive vectors.**  When `n = 0` every vector is
+`0` (there are no coordinates to distinguish), and `0` is never primitive
+(`IsPrimitive.ne_zero`).  This is the degenerate floor below the `Fin 1` base case:
+there is nothing to reduce and no target `e₁` to reach, so the descent is vacuous. -/
+theorem not_isPrimitive_fin_zero (v : Fin 0 → ℤ) : ¬ IsPrimitive v :=
+  fun h => h.ne_zero (Subsingleton.elim v 0)
 
 end BezoutPrimitive

--- a/src/data/proofs/bezout-identity-oq-01-oq-02-oq-02/meta.json
+++ b/src/data/proofs/bezout-identity-oq-01-oq-02-oq-02/meta.json
@@ -23,8 +23,8 @@
     "dateAdded": "2026-07-09",
     "axiomCount": 0,
     "assumptions": "None beyond Mathlib's foundational axioms. Fully machine-checked (0 sorries, 0 axiom declarations, no structure-encoded assumptions, no native_decide). Note: in the local Docker sandbox the file elaborates cleanly across repeated runs but the .olean cache write intermittently aborts with SIGBUS (exit 135), an environment/IO issue independent of the proofs; CI produces the build artifact.",
-    "lineCount": 201,
-    "theoremCount": 11,
+    "lineCount": 208,
+    "theoremCount": 12,
     "definitionCount": 2,
     "originalContributions": [
       "IsPrimitive v := ∃ w, w ⬝ᵥ v = 1 — a coordinate-free, manifestly SLₙ(ℤ)-invariant notion of primitivity for integer vectors (absent from Mathlib)",
@@ -89,9 +89,9 @@
   ],
   "leanFile": {
     "namespace": "BezoutPrimitive",
-    "lineCount": 201,
+    "lineCount": 208,
     "axiomCount": 0,
-    "theoremCount": 11,
+    "theoremCount": 12,
     "definitionCount": 2,
     "path": "Proofs/BezoutIdentityOQ01OQ02OQ02.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

The gallery entry `bezout-identity-oq-01-oq-02-oq-02` (primitive integer vectors and the `SLₙ(ℤ)` action) is marked **status "verified"**, but its Lean file no longer compiled against the repo's **pinned** Mathlib (`v4.26.0`, rev `2df2f015`). It had drifted (shipped during the Docker outage). This PR restores it to actually compiling.

### Drift repairs
- `Matrix.det_transvection_of_ne` now takes `i j` **explicitly** → `det_transvection_of_ne i j h c` (was failing with `failed to synthesize Fintype ℤ` / arg-type mismatch, cascading into `transvectionSL` and `transvectionSL_mulVec`).
- `isUnit_of_mul_eq_one` deprecated and resignatured (the element is now implicit) → `IsUnit.of_mul_eq_one (w 0) h`.
- Removed two now-unused `simp` args (`Finset.sum_ite_eq`, `Fin.sum_univ_one`).

With these the whole file elaborates with **0 errors and 0 warnings**, making the "verified" badge truthful again.

### New content
- `not_isPrimitive_fin_zero`: the empty dimension (`n = 0`) has no primitive vectors — every `Fin 0 → ℤ` vector is `0`, which is never primitive (`IsPrimitive.ne_zero`). The degenerate floor below the `Fin 1` base case (`isPrimitive_fin_one_iff`).

## Verification

Verified locally against the pinned Mathlib olean set (lean v4.26.0; Docker image build down — containerd blob I/O). No axioms. Meta synced: `lineCount` 201→208, `theoremCount` 11→12 (both blocks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)