### PR TITLE
Enrich Nakayama Minimal Generators: annotate imports + typeclass setup

### DIFF
--- a/src/data/proofs/nakayama-lemma-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/nakayama-lemma-oq-01-oq-01/annotations.json
@@ -1,5 +1,17 @@
 [
   {
+    "id": "ann-imports",
+    "proofId": "nakayama-lemma-oq-01-oq-01",
+    "range": { "startLine": 1, "endLine": 9 },
+    "type": "context",
+    "title": "Imports Encode the Proof Architecture",
+    "content": "The import block reads as a table of contents for the argument. `Mathlib.RingTheory.Nakayama` supplies the lemma that powers the upper bound (a generating set of size exactly the dimension exists); `Mathlib.RingTheory.LocalRing.MaximalIdeal.Basic` and `Mathlib.RingTheory.Ideal.Cotangent` give the local ring, its residue field k = R/𝔪, and the 𝔪/𝔪² cotangent machinery; `Mathlib.Algebra.Module.Torsion.Basic` provides the annihilator/torsion facts that make M/𝔪M a k-module; and the two `LinearAlgebra.Dimension.*` modules furnish `finrank` and the span↔dimension inequalities used on both sides of the count. The final `import Proofs.NakayamaLemmaOQ01` pulls in the parent entry's lifting lemma — this file is the `-oq-01-oq-01` child that assembles the two-sided count on top of it.",
+    "mathContext": "Dependency layers: Nakayama (upper bound) · residue field $k = R/\\mathfrak{m}$ + cotangent $\\mathfrak{m}/\\mathfrak{m}^2$ · torsion/annihilator ($M/\\mathfrak{m}M$ is a $k$-module) · $\\operatorname{finrank}$ and span–dimension bounds.",
+    "significance": "context",
+    "relatedConcepts": ["Nakayama's lemma", "residue field", "cotangent space", "finrank", "parent lifting lemma"],
+    "prerequisites": ["Mathlib module organization", "local ring theory"]
+  },
+  {
     "id": "ann-overview",
     "proofId": "nakayama-lemma-oq-01-oq-01",
     "range": { "startLine": 10, "endLine": 62 },
@@ -10,6 +22,18 @@
     "significance": "supporting",
     "relatedConcepts": ["Nakayama's lemma", "local ring", "residue field", "minimal generators", "cotangent space"],
     "prerequisites": ["local rings", "modules over a ring", "vector space dimension"]
+  },
+  {
+    "id": "ann-setup",
+    "proofId": "nakayama-lemma-oq-01-oq-01",
+    "range": { "startLine": 64, "endLine": 70 },
+    "type": "context",
+    "title": "The Local-Ring / Module Ambient Context",
+    "content": "The `variable` block fixes the ambient setting for every lemma below. `[CommRing R] [IsLocalRing R]` is the crucial hypothesis: `IsLocalRing R` is what gives a unique maximal ideal 𝔪, a residue field k = R/𝔪, and makes Nakayama's lemma applicable — none of the count survives if R is merely a commutative ring. `M` is an arbitrary R-module (`[AddCommGroup M] [Module R M]`); finiteness is added lemma-by-lemma rather than globally, so the definitions (the residue space, the generator count) are stated in full generality and only the dimension bounds assume `Module.Finite`. `open Submodule IsLocalRing Module` is what lets the source write `maximalIdeal R`, `𝔪 • ⊤`, and `finrank` without qualification.",
+    "mathContext": "Fixed context: $(R,\\mathfrak{m})$ a local commutative ring with residue field $k = R/\\mathfrak{m}$, and $M$ an $R$-module; $R$-finiteness assumed only where dimension bounds require it.",
+    "significance": "technical",
+    "relatedConcepts": ["IsLocalRing", "maximal ideal", "Module.Finite", "variable/typeclass context", "open namespaces"],
+    "prerequisites": ["Lean typeclass variables", "local rings", "modules over a ring"]
   },
   {
     "id": "ann-residue-space",


### PR DESCRIPTION
Enrichment pass for `nakayama-lemma-oq-01-oq-01`.

**Gaps addressed:** Two genuine uncovered code regions (annotations previously started at line 10):
- **Imports (lines 1–9):** a `context` annotation reading the specific `RingTheory`/`LinearAlgebra` modules as the proof's architecture — Nakayama for the upper bound, LocalRing/Cotangent for the residue field and 𝔪/𝔪², Torsion for the k-module structure, Dimension.* for `finrank` — and flagging the `import Proofs.NakayamaLemmaOQ01` parent-file dependency (this is the `-oq-01-oq-01` child).
- **Namespace/variable setup (lines 64–70):** a `technical` annotation explaining why `[IsLocalRing R]` is the load-bearing hypothesis (unique 𝔪, residue field, Nakayama applicability) and why `Module.Finite` is added per-lemma rather than globally.

meta.json untouched. JSON validated; annotation ranges remain ordered and non-overlapping.