### PR TITLE
Fix: resync erdos-666 meta.lineCount 492→510

### DIFF
--- a/src/data/proofs/erdos-666/meta.json
+++ b/src/data/proofs/erdos-666/meta.json
@@ -55,7 +55,7 @@
       "GeneralizedConjecture: open question for C_{2k}"
     ],
     "axiomCount": 1,
-    "lineCount": 492,
+    "lineCount": 510,
     "assumptions": "1 axiom (Chung 1992): chung_no_threshold — no threshold N makes every (1/4)-dense subgraph of Qₙ contain C₆; a consequence of Chung's edge-partition of Qₙ into four C₆-free subgraphs, not available in Mathlib. The companion existence statement chung_c6free (for n ≥ 3, Qₙ has some C₆-free subgraph) was previously axiomatized but is now PROVED outright — it carries no edge-count data, so the empty subgraph ⊥ (no edges, hence no cycle) is an honest witness. The deep density content stays isolated in the single axiom chung_no_threshold.",
     "theoremCount": 15,
     "definitionCount": 13,
@@ -172,7 +172,7 @@
       "SimpleGraph"
     ],
     "namespace": "Erdos666",
-    "lineCount": 492,
+    "lineCount": 510,
     "axiomCount": 1,
     "theoremCount": 13,
     "definitionCount": 13,


### PR DESCRIPTION
## Fix

Resync `erdos-666` gallery metadata: both `meta.lineCount` and `leanFile.lineCount` read 492 but `proofs/Proofs/Erdos666Problem.lean` is now 510 lines on `main`.

## Evidence

**Before**: `lineCount: 492` (two blocks)
**After**: `lineCount: 510` (matches actual `.lean` line count)

The `.lean` file grew via merged research PR #37371 (hypercube vertex positivity + handshake identity 2|E|=n|V|), which updated the source but left both `lineCount` fields stale. No open PR touches this file or its meta, so the drift is genuinely uncovered.

Scope kept minimal to the line-count drift; `axiomCount` (1) is unchanged and `theoremCount` conventions already differ between the two blocks in base (15 vs 13), so they are left untouched.

---
Automated fix by lean-mechanic agent.