### PR TITLE
Enrich Fibonacci Prime-Index: annotate namespace + open Nat setup

### DIFF
--- a/src/data/proofs/fibonacci-identities-oq-02-oq-02-prime-index/annotations.json
+++ b/src/data/proofs/fibonacci-identities-oq-02-oq-02-prime-index/annotations.json
@@ -28,6 +28,33 @@
     ]
   },
   {
+    "id": "ann-fiboq0202-setup",
+    "proofId": "fibonacci-identities-oq-02-oq-02-prime-index",
+    "range": {
+      "startLine": 33,
+      "endLine": 37
+    },
+    "type": "context",
+    "title": "Namespace and the open Nat Number-Theory Layer",
+    "content": "The `namespace FibonacciIdentitiesOQ02OQ02PrimeIndex` wrapper isolates this child file's lemmas from the parent `FibonacciIdentitiesOQ02.lean`, whose index-divisibility law $F_m \\mid F_n \\iff m \\mid n$ this entry consumes. `open Nat` is what lets the proof name `Nat.Prime`, `Nat.fib`, and the divisor-existence lemmas (`exists_dvd_of_not_prime2`) unqualified — the entire argument lives in $\\mathbb{N}$, reasoning about prime versus composite *indices*, so pulling the `Nat` namespace into scope keeps the primality and divisibility statements readable.",
+    "mathContext": "Scope for $\\mathbb{N}$-level reasoning: `Nat.Prime`, `Nat.fib`, and `Nat.exists_dvd_of_not_prime2` become available unqualified.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Lean namespaces",
+      "open Nat",
+      "parent index-divisibility law"
+    ],
+    "prerequisites": [
+      "Lean namespaces and open",
+      "natural-number primality"
+    ],
+    "tags": [
+      "setup",
+      "namespace",
+      "nat"
+    ]
+  },
+  {
     "id": "ann-fiboq0202-2",
     "proofId": "fibonacci-identities-oq-02-oq-02-prime-index",
     "range": {


### PR DESCRIPTION
Enrichment pass for `fibonacci-identities-oq-02-oq-02-prime-index`.

**Gap addressed:** The `namespace` + `open Nat` setup region (lines 33–37) sat uncovered between the module-header annotation (ends line 32) and the first lemma (starts line 38). Added one `context` annotation explaining the parent-file isolation (this child consumes `FibonacciIdentitiesOQ02`'s index-divisibility law) and why `open Nat` is in scope (`Nat.Prime` / `Nat.fib` / `Nat.exists_dvd_of_not_prime2` used unqualified throughout an all-ℕ argument).

The other interior gap (lines 95–99) is a decorative section divider already described by the adjacent "Sharpness and One-Directionality" annotation, so it was intentionally left alone.

meta.json untouched. JSON validated; ranges remain ordered and non-overlapping.