### PR TITLE
research(tetrahedral-number-formula-oq-01): central-binomial bridge + exponential lower bounds on the simplex diagonal

### DIFF
--- a/proofs/Proofs/TetrahedralNumberFormulaOQ01Absorption.lean
+++ b/proofs/Proofs/TetrahedralNumberFormulaOQ01Absorption.lean
@@ -95,4 +95,31 @@ theorem simplexNumber_diag_catalan (d : ℕ) :
   rw [simplexNumber_diag d, ← Nat.centralBinom_eq_two_mul_choose]
   exact succ_mul_catalan_eq_centralBinom d
 
+
+/-- **The central simplex diagonal is Mathlib's central binomial coefficient.**  The
+explicit bridge `P_d(d) = Nat.centralBinom d`, making the identification behind
+`simplexNumber_diag` reusable with Mathlib's `Nat.centralBinom` API (growth bounds,
+positivity, Bertrand's postulate, …). -/
+theorem simplexNumber_diag_eq_centralBinom (d : ℕ) :
+    simplexNumber d d = Nat.centralBinom d := by
+  rw [simplexNumber_diag d, ← Nat.centralBinom_eq_two_mul_choose]
+
+/-- **Exponential lower bound on the central simplex diagonal.**  For `d ≥ 4`,
+`4^d < d · P_d(d)`.  Via `simplexNumber_diag_eq_centralBinom` this is exactly Mathlib's
+`Nat.four_pow_lt_mul_centralBinom`, and it makes precise the docstring remark that the
+diagonal drives the `4^d/√(πd)` central-binomial growth. -/
+theorem four_pow_lt_diag {d : ℕ} (hd : 4 ≤ d) :
+    4 ^ d < d * simplexNumber d d := by
+  rw [simplexNumber_diag_eq_centralBinom d]
+  exact Nat.four_pow_lt_mul_centralBinom d hd
+
+/-- **Exponential lower bound valid for every positive dimension.**  `4^d ≤ 2d · P_d(d)`
+for all `d ≥ 1` — the (weaker but hypothesis-light) diagonal reading of
+`Nat.four_pow_le_two_mul_self_mul_centralBinom`, the bound appearing in Erdős's proof of
+Bertrand's postulate. -/
+theorem four_pow_le_two_mul_diag {d : ℕ} (hd : 0 < d) :
+    4 ^ d ≤ 2 * d * simplexNumber d d := by
+  rw [simplexNumber_diag_eq_centralBinom d]
+  exact Nat.four_pow_le_two_mul_self_mul_centralBinom d hd
+
 end TetrahedralNumberFormulaOQ01


### PR DESCRIPTION
## Summary

Extends the central-binomial thread of the Absorption companion `proofs/Proofs/TetrahedralNumberFormulaOQ01Absorption.lean`. The existing `simplexNumber_diag` already identifies the diagonal figurate number `P_d(d)` with the central binomial coefficient `C(2d, d)`; this adds the explicit bridge to Mathlib's `Nat.centralBinom` and ports its exponential lower bounds to the figurate diagonal:

```lean
theorem simplexNumber_diag_eq_centralBinom (d : ℕ) :
    simplexNumber d d = Nat.centralBinom d

theorem four_pow_lt_diag {d : ℕ} (hd : 4 ≤ d) :
    4 ^ d < d * simplexNumber d d

theorem four_pow_le_two_mul_diag {d : ℕ} (hd : 0 < d) :
    4 ^ d ≤ 2 * d * simplexNumber d d
```

These formalize the file's own docstring remark that the diagonal drives the `4^d/√(πd)` central-binomial growth:
- `four_pow_lt_diag` is the figurate reading of `Nat.four_pow_lt_mul_centralBinom`;
- `four_pow_le_two_mul_diag` of the weaker all-`d` bound `Nat.four_pow_le_two_mul_self_mul_centralBinom` (the estimate appearing in Erdős's proof of Bertrand's postulate).

All three are one-line proofs through the bridge lemma. No new axioms or imports.

## Verification

Docker image-build is currently down (containerd `meta.db` I/O error), so verified locally with the pinned toolchain (`lean v4.26.0`) against the cached Mathlib oleans plus a freshly built `TetrahedralNumberFormulaOQ01` dependency:

- **EXIT 0**, 0 sorries, no new warnings (only the file's pre-existing `Nat.succ_mul_choose_eq` deprecation at line 46)

The companion file carries no gallery meta, so this is a Lean-only change — nothing to sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)