### PR TITLE
research(cauchy-schwarz-integral-oq-04): canonical-commutation Robertson bound + Heisenberg Δx·Δp≥ℏ/2 [VERIFIED]

### DIFF
--- a/proofs/Proofs/CauchySchwarzIntegralOQ04.lean
+++ b/proofs/Proofs/CauchySchwarzIntegralOQ04.lean
@@ -484,6 +484,52 @@ theorem im_inner_smul_saturated_iff {u : E} (hu : u ≠ 0) {r : 𝕜} (hr : r �
   · intro hre
     exact ⟨by rw [re_inner_smul_self, hre, zero_mul], r, hr, rfl⟩
 
+/-- **Robertson relation under a canonical commutation relation.**  Suppose the
+commutator acts on the state `ψ` as a scalar, `(AB − BA)ψ = c • ψ` for some
+`c ∈ 𝕜` — the abstract form of the canonical commutation relation `[x, p] = iℏ`.
+Then the commutator expectation is `⟪ψ, (AB−BA)ψ⟫ = c‖ψ‖²`, so `robertson_uncertainty`
+becomes the *scalar* lower bound
+
+    `¼‖c‖²·‖ψ‖⁴ ≤ ‖(A−a)ψ‖²·‖(B−b)ψ‖²`,
+
+independent of the operators' finer structure: the product of the (uncentred, then
+centred) fluctuations is bounded below purely by the size of the commutator scalar.
+This is the step that turns the operator inequality into the physical Heisenberg
+bound `Δx·Δp ≥ ℏ/2`. -/
+theorem robertson_canonical {A B : E →ₗ[𝕜] E} (hA : A.IsSymmetric)
+    (hB : B.IsSymmetric) (ψ : E) (a b : ℝ) (c : 𝕜)
+    (hc : A (B ψ) - B (A ψ) = c • ψ) :
+    ‖c‖ ^ 2 / 4 * ‖ψ‖ ^ 4
+      ≤ ‖A ψ - (a : 𝕜) • ψ‖ ^ 2 * ‖B ψ - (b : 𝕜) • ψ‖ ^ 2 := by
+  have hnorm : ‖inner 𝕜 ψ (A (B ψ) - B (A ψ))‖ = ‖c‖ * ‖ψ‖ ^ 2 := by
+    rw [hc, inner_smul_right, norm_mul, inner_self_eq_norm_sq_to_K, norm_pow,
+      RCLike.norm_ofReal, abs_of_nonneg (norm_nonneg ψ)]
+  have hrob := robertson_uncertainty hA hB ψ a b
+  rw [hnorm] at hrob
+  have hgoal : ‖c‖ ^ 2 / 4 * ‖ψ‖ ^ 4 = (1 / 4 : ℝ) * (‖c‖ * ‖ψ‖ ^ 2) ^ 2 := by ring
+  rw [hgoal]
+  exact hrob
+
+/-- **Heisenberg uncertainty principle for a unit state under a canonical commutation
+relation.**  Specializing `robertson_canonical` to a normalized state `‖ψ‖ = 1` and
+the expectation-value shifts `a = ⟨A⟩ = Re⟪ψ,Aψ⟫`, `b = ⟨B⟩ = Re⟪ψ,Bψ⟫` makes the
+right-hand side the product of variances `Var_ψ(A)·Var_ψ(B)` and collapses the
+`‖ψ‖⁴` factor to `1`, giving the sharp scalar bound
+
+    `¼‖c‖² ≤ Var_ψ(A)·Var_ψ(B)`.
+
+For the canonical pair `[A, B]ψ = iℏ ψ` (so `‖c‖ = ℏ`) this is exactly
+`Var_ψ(A)·Var_ψ(B) ≥ ℏ²/4`, i.e. `Δx·Δp ≥ ℏ/2`. -/
+theorem heisenberg_canonical {A B : E →ₗ[𝕜] E} (hA : A.IsSymmetric)
+    (hB : B.IsSymmetric) (ψ : E) (hψ : ‖ψ‖ = 1) (c : 𝕜)
+    (hc : A (B ψ) - B (A ψ) = c • ψ) :
+    ‖c‖ ^ 2 / 4
+      ≤ ‖A ψ - ((RCLike.re (inner 𝕜 ψ (A ψ)) : ℝ) : 𝕜) • ψ‖ ^ 2
+        * ‖B ψ - ((RCLike.re (inner 𝕜 ψ (B ψ)) : ℝ) : 𝕜) • ψ‖ ^ 2 := by
+  have h := robertson_canonical hA hB ψ (RCLike.re (inner 𝕜 ψ (A ψ)))
+    (RCLike.re (inner 𝕜 ψ (B ψ))) c hc
+  rwa [hψ, one_pow, mul_one] at h
+
 end CauchySchwarzIntegralOQ04
 
 #print axioms CauchySchwarzIntegralOQ04.gram_eq_iff_parallel


### PR DESCRIPTION
## Summary

`cauchy-schwarz-integral-oq-04` (Heisenberg uncertainty) is a RICH, `completed` file: it already proves the operator **Robertson** and **Schrödinger** uncertainty relations, the Gram bound, and the full saturation characterization. The one missing piece is the **physical punchline** — the bound stated in terms of the *commutator scalar*, i.e. the actual `Δx·Δp ≥ ℏ/2`. The existing `robertson_uncertainty` is phrased via the commutator *expectation* `⟪ψ,(AB−BA)ψ⟫`; nothing specializes it to a canonical commutation relation.

## What's added (`Proofs/CauchySchwarzIntegralOQ04.lean`, +46 lines, 2 theorems)

- **`robertson_canonical`** — under a canonical commutation relation `(AB − BA)ψ = c • ψ` (the abstract `[x,p] = iℏ`), the commutator expectation is `⟪ψ,(AB−BA)ψ⟫ = c‖ψ‖²`, so Robertson collapses to the scalar lower bound
  `¼‖c‖²·‖ψ‖⁴ ≤ ‖(A−a)ψ‖²·‖(B−b)ψ‖²`.
- **`heisenberg_canonical`** — specializing to a unit state `‖ψ‖ = 1` at the expectation-value shifts `a = ⟨A⟩`, `b = ⟨B⟩` gives
  `¼‖c‖² ≤ Var(A)·Var(B)`, i.e. exactly `Δx·Δp ≥ ℏ/2` for the canonical pair `‖c‖ = ℏ`.

Both are derived from the existing verified `robertson_uncertainty` via `inner_smul_right` + `inner_self_eq_norm_sq_to_K` (the commutator-norm computation) and a `ring` rearrangement. No probability/finer-structure hypotheses, no new axioms.

## Verification

Docker image build is currently down (containerd `meta.db` input/output error), so verified locally with `lean v4.26.0`. The file imports only Mathlib (self-contained), compiles with **0 errors**, and `#print axioms` on **both** new theorems reports only `[propext, Classical.choice, Quot.sound]` — no `sorryAx`, no added axioms.

## Gallery

No gallery dir exists for `cauchy-schwarz-integral-oq-04` (parent tracks a different entry); Lean-only change, no meta to sync.