### PR TITLE
Enrich abel-ruffini-oq-06-oq-01: annotate pivotal A₄-solvable theorem

### DIFF
--- a/src/data/proofs/abel-ruffini-oq-06-oq-01/annotations.json
+++ b/src/data/proofs/abel-ruffini-oq-06-oq-01/annotations.json
@@ -2,7 +2,10 @@
   {
     "id": "ann-overview",
     "proofId": "abel-ruffini-oq-06-oq-01",
-    "range": { "startLine": 1, "endLine": 50 },
+    "range": {
+      "startLine": 1,
+      "endLine": 50
+    },
     "type": "concept",
     "title": "Closing the threshold at the last open case S₄",
     "content": "The Abel–Ruffini dichotomy 'Sₙ solvable ⟺ n ≤ 4' has its negative half (n ≥ 5) in Mathlib, via the simplicity of A₅. The parent entry supplied the easy solvable cases S₂, S₃ (their alternating groups A₂, A₃ have prime order, so are cyclic and abelian). The hard remaining case is S₄: its alternating group A₄ has order 12 — neither prime-order nor simple — so a new argument is needed. This file proves A₄ solvable via its metabelian structure, lifts that to S₄, and packages the complete equivalence.",
@@ -22,9 +25,38 @@
     ]
   },
   {
+    "id": "ann-a4-solvable",
+    "proofId": "abel-ruffini-oq-06-oq-01",
+    "range": {
+      "startLine": 51,
+      "endLine": 57
+    },
+    "type": "theorem",
+    "title": "A₄ is solvable — the one case beyond prime order",
+    "content": "alternatingFinFour_isSolvable is the pivotal result of the entry: it settles the single case the parent's prime-order argument cannot reach. For n ∈ {2, 3} the alternating group Aₙ has prime order (1, 3) and is trivially abelian, hence solvable; for n ≥ 5, Aₙ is non-abelian simple and Sₙ fails to be solvable. Only |A₄| = 12 falls between — neither prime-order nor simple — so it demands a genuine structural argument. The proof exhibits A₄ as metabelian: it sets N = V₄ = alternatingGroup.kleinFour (Fin 4), proves N solvable (exponent two ⟹ abelian), and A₄/N abelian (N is exactly the commutator subgroup), then assembles the two through the extension 1 → V₄ → A₄ → A₄/V₄ → 1. This is the load-bearing step everything downstream (S₄ solvable, the packaged equivalence) lifts from.",
+    "mathContext": "$A_4$ is solvable with derived series $A_4 \\rhd V_4 \\rhd 1$ of length $2$ (metabelian). Concretely $A_4' = V_4 \\cong \\mathbb{Z}/2 \\times \\mathbb{Z}/2$ and $A_4'' = V_4' = 1$, so the series reaches the trivial group. Contrast $A_5$, where $A_5' = A_5$ (perfect) and the derived series never descends — the structural reason $S_n$ is non-solvable for $n \\ge 5$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "solvable group",
+      "metabelian group",
+      "derived series",
+      "alternating group A₄",
+      "extension of solvable groups"
+    ],
+    "prerequisites": [
+      "solvable groups",
+      "derived series",
+      "commutator subgroup",
+      "group extensions"
+    ]
+  },
+  {
     "id": "ann-v4-solvable",
     "proofId": "abel-ruffini-oq-06-oq-01",
-    "range": { "startLine": 58, "endLine": 67 },
+    "range": {
+      "startLine": 58,
+      "endLine": 67
+    },
     "type": "insight",
     "title": "The Klein-four commutator subgroup V₄ is abelian, hence solvable",
     "content": "The commutator subgroup of A₄ is the Klein-four group V₄ = alternatingGroup.kleinFour (Fin 4). Its defining feature is exponent two — every non-identity element is an involution — so for any a, b: ab = (ab)⁻¹ = b⁻¹a⁻¹ = ba. Mathlib packages this as mul_comm_of_exponent_two, turning Monoid.exponent V₄ = 2 into commutativity, and isSolvable_of_comm then makes V₄ solvable. This is the bottom step of the derived series A₄ ⊳ V₄ ⊳ 1.",
@@ -45,7 +77,10 @@
   {
     "id": "ann-quotient-abelian",
     "proofId": "abel-ruffini-oq-06-oq-01",
-    "range": { "startLine": 68, "endLine": 76 },
+    "range": {
+      "startLine": 68,
+      "endLine": 76
+    },
     "type": "insight",
     "title": "A₄/V₄ is abelian because V₄ IS the commutator subgroup",
     "content": "The same subgroup that serves as the solvable kernel also certifies the quotient is abelian: since V₄ = commutator A₄ (kleinFour_eq_commutator), the criterion quotient_commutative_iff_commutator_le gives that A₄/V₄ (≅ ℤ/3) is commutative, hence solvable. The short exact sequence 1 → V₄ → A₄ → A₄/V₄ → 1 — with ker(quotient map) = V₄ = range(inclusion) — then yields IsSolvable A₄ through solvable_of_ker_le_range. This is the metabelian core: solvable kernel + solvable quotient ⟹ solvable extension.",
@@ -67,7 +102,10 @@
   {
     "id": "ann-s4",
     "proofId": "abel-ruffini-oq-06-oq-01",
-    "range": { "startLine": 82, "endLine": 89 },
+    "range": {
+      "startLine": 82,
+      "endLine": 89
+    },
     "type": "theorem",
     "title": "S₄ is solvable",
     "content": "Feeding the new IsSolvable A₄ instance into the parent reduction permSolvable_of_alternatingSolvable 4 (the short exact sequence 1 → A₄ → S₄ → ℤˣ with abelian quotient ℤˣ ≅ ℤ/2) yields permFinFour_isSolvable: IsSolvable (Equiv.Perm (Fin 4)). This closes the final open case of the solvable side of the threshold.",
@@ -87,7 +125,10 @@
   {
     "id": "ann-equivalence",
     "proofId": "abel-ruffini-oq-06-oq-01",
-    "range": { "startLine": 90, "endLine": 105 },
+    "range": {
+      "startLine": 90,
+      "endLine": 105
+    },
     "type": "theorem",
     "title": "The packaged threshold: Sₙ solvable ⟺ n ≤ 4",
     "content": "isSolvable_perm_fin_iff packages the whole Abel–Ruffini dichotomy. Forward (solvable ⟹ n ≤ 4): contraposition — for n ≥ 5, Equiv.Perm.not_solvable (using #(Fin n) = n ≥ 5) shows Sₙ is non-solvable. Backward (n ≤ 4 ⟹ solvable): interval_cases on n discharges S₀, S₁ as subsingletons (infer_instance), S₂, S₃ from the parent theorems, and S₄ from permFinFour_isSolvable. This single biconditional is the exact group-theoretic boundary between radical-solvable degrees (n ≤ 4) and the rest.",


### PR DESCRIPTION
## Enrichment pass — coverage gap

**Target:** `abel-ruffini-oq-06-oq-01` (quality 95, 0 prior passes)

**Gap addressed:** The file's load-bearing theorem `alternatingFinFour_isSolvable` (A₄ solvable — the single case beyond prime order that the parent's argument cannot reach) had **no annotation on its statement** (lines 51–57), even though its two proof steps (V₄ abelian, A₄/V₄ abelian) were annotated. The headline result was uncovered.

**Change:** Added one `theorem`-type annotation (`ann-a4-solvable`, range 51–57) framing A₄'s metabelian structure and its derived series `A₄ ⊳ V₄ ⊳ 1`, contrasting with the perfect `A₅` that makes `Sₙ` non-solvable for `n ≥ 5`. Includes `mathContext`, `significance`, `relatedConcepts`, `prerequisites` matching existing style.

- annotations.json only; **meta.json untouched** (already within all size caps).
- No range overlaps introduced; JSON validated.
- Single sharp addition per curation guardrails — no accretion.