### PR TITLE
Fix: resync erdos-1039 meta.lineCount drift (700→727)

### DIFF
--- a/src/data/proofs/erdos-1039/meta.json
+++ b/src/data/proofs/erdos-1039/meta.json
@@ -23,7 +23,7 @@
     "erdosProblemStatus": "open",
     "relatedProblems": [],
     "axiomCount": 4,
-    "lineCount": 700,
+    "lineCount": 727,
     "assumptions": "4 axioms, all genuine published research results the proof correctly leaves unformalized (not overclaimed): benchmark_upper (Erdos-Herzog-Piranian benchmark rho(z^n-1) <= pi/(2n)), pommerenke_lower (Pommerenke 1961, rho >= 1/(2en^2)), and klr_lower + klr_area_bound (Krishnapur-Lundberg-Ramachandran 2025, rho >> 1/(n*sqrt(log n))). Formalizing any of these would require reproducing the source papers, so they are stated as axioms. The three elementary-geometry lemmas (area_implies_disc_bound, degree_one_optimal, clustered_implies_large_disc) were completed in PR #33815 and the main file Proofs/Erdos1039Problem.lean has 0 sorries (543 lines). UPDATE: the former 5th axiom random_polynomial_expected was DEGENERATE — its intended Expected[rho] middle term was only a comment, so the Lean proposition collapsed to the trivially-true c1/sqrt(n) <= c2/sqrt(n); it has been converted to a proved theorem (witness c1=c2=1), removing a spurious entry from the axiom list (5 -> 4). The real Theta(1/sqrt n) expected-order claim needs an Expected functional and remains unformalized. The deprecated stub Proofs/Stubs/Erdos1039Problem.lean still holds the pre-#33815 state (3 sorries, the original 5 axioms) and is not the presented proof (proofRepoPath is the main file); it adds no distinct assumptions.",
     "mathlib_version": "4.29.0",
     "mathlibDependencies": [
@@ -242,7 +242,7 @@
     ],
     "opens": [],
     "namespace": "Erdos1039",
-    "lineCount": 700,
+    "lineCount": 727,
     "axiomCount": 4,
     "theoremCount": 20,
     "definitionCount": 17,


### PR DESCRIPTION
## Fix

Resync stale `lineCount` in `src/data/proofs/erdos-1039/meta.json` to match the actual `proofs/Proofs/Erdos1039Problem.lean` (727 lines).

## Evidence

**Before**: both `meta.lineCount` blocks declared `700`.
**After**: both blocks declare `727` (verified via newline-aware count; `wc -l` = 727, file ends with newline).

The file grew from 700→727 via merged research PRs. The only open PR touching this file (#36432) branches from a stale base (543) and does not apply against current main, so this drift was genuinely uncovered.

---
Automated fix by lean-mechanic agent.