### PR TITLE
Enrich abel-ruffini-oq-04-oq-02-oq-04-oq-03: annotate headline metabelian theorem

### DIFF
--- a/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-04-oq-03/annotations.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-04-oq-03/annotations.json
@@ -11,9 +11,24 @@
     "content": "**Module framing.** The parent entry proved each dihedral group $D_n$ solvable by *building* the short exact sequence $1 \\to \\langle r\\rangle \\to D_n \\to \\mathbb{Z}/2 \\to 1$ and invoking `solvable_of_ker_le_range`. Its open question OQ-03 asked what that argument *really* proves. This file answers: the concrete construction is a special case of a purely structural fact about **metabelian** groups (an abelian normal subgroup with abelian quotient), and the honest conclusion is not merely 'solvable' but the sharp derived-length bound `derivedSeries G 2 = ⊥`. The logical spine is the hierarchy **cyclic ⟹ metabelian ⟹ solvable of class ≤ 2**: `comm_of_isCyclic` turns a cyclic-by-cyclic (metacyclic) hypothesis into the two abelian hypotheses the metabelian theorem needs, so metacyclic solvability drops out as a one-line corollary. Dihedral, dicyclic, order-$pq$, and the solvable symmetric groups $S_2, S_3, S_4$ are all instances of the same theorem.",
     "mathContext": "Metabelian $\\iff G^{(2)} = [[G,G],[G,G]] = 1 \\iff$ derived length $\\le 2$; metacyclic (cyclic-by-cyclic) $\\subsetneq$ metabelian.",
     "significance": "supporting",
-    "relatedConcepts": ["metabelian group", "metacyclic group", "solvable derived length", "short exact sequence", "Abel–Ruffini / Galois solvability"],
-    "prerequisites": ["solvable groups and the derived series", "the parent dihedral solvability proof", "group extensions"],
-    "tags": ["module-header", "framing", "group-theory", "abel-ruffini"]
+    "relatedConcepts": [
+      "metabelian group",
+      "metacyclic group",
+      "solvable derived length",
+      "short exact sequence",
+      "Abel–Ruffini / Galois solvability"
+    ],
+    "prerequisites": [
+      "solvable groups and the derived series",
+      "the parent dihedral solvability proof",
+      "group extensions"
+    ],
+    "tags": [
+      "module-header",
+      "framing",
+      "group-theory",
+      "abel-ruffini"
+    ]
   },
   {
     "id": "ann-comm-of-cyclic",
@@ -36,6 +51,32 @@
     "prerequisites": [
       "cyclic groups",
       "group homomorphisms"
+    ]
+  },
+  {
+    "id": "ann-metabelian-derived-two",
+    "proofId": "abel-ruffini-oq-04-oq-02-oq-04-oq-03",
+    "range": {
+      "startLine": 65,
+      "endLine": 73
+    },
+    "type": "theorem",
+    "title": "Metabelian ⟹ derived length ≤ 2 (the sharp statement)",
+    "content": "derivedSeries_two_eq_bot_of_metabelian is the entry's headline theorem, stated in fully abstract form: for any group G with an abelian normal subgroup N whose quotient G ⧸ N is also abelian, the second term of the derived series is already trivial, derivedSeries G 2 = ⊥. This is strictly sharper than the usual textbook conclusion 'metabelian ⟹ solvable': it pins the exact derived length at ≤ 2 rather than merely asserting the series terminates eventually. The proof is a clean two-step descent — first pushing derivedSeries G 1 ≤ N through the abelian quotient (Step 1), then killing ⁅N, N⁆ = ⊥ because N is abelian (Step 2) — and everything downstream (solvability packaging, the metacyclic corollary) is a specialization of this one bound.",
+    "mathContext": "A group $G$ is *metabelian* when it has an abelian normal subgroup $N \\trianglelefteq G$ with $G/N$ abelian. Equivalently $G'' = 1$: the derived length is $\\le 2$. The theorem states $G^{(2)} = \\mathrm{derivedSeries}\\,G\\,2 = \\bot$ under the two abelianness hypotheses, via $G' = \\mathrm{derivedSeries}\\,G\\,1 \\le N$ (from $(G/N)' = 1$) and then $G'' = [G',G'] \\le [N,N] = 1$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "metabelian group",
+      "derived series",
+      "derived length",
+      "commutator subgroup",
+      "solvable group"
+    ],
+    "prerequisites": [
+      "derived series",
+      "commutator subgroups",
+      "normal subgroups and quotients",
+      "abelian groups"
     ]
   },
   {


### PR DESCRIPTION
## Enrichment pass — coverage gap

**Target:** `abel-ruffini-oq-04-oq-02-oq-04-oq-03` (quality 95, 0 prior passes)

**Gap addressed:** The file's central theorem `derivedSeries_two_eq_bot_of_metabelian` (metabelian ⟹ derived length ≤ 2, i.e. `G'' = 1` — sharper than the usual 'metabelian ⟹ solvable') had **no annotation on its statement** (lines 65–73), even though both of its proof steps were annotated. The headline result was uncovered.

**Change:** Added one `theorem`-type annotation (`ann-metabelian-derived-two`, range 65–73) framing the sharp derived-length bound and how the downstream solvability packaging and metacyclic corollary specialize it. Includes `mathContext`, `significance`, `relatedConcepts`, `prerequisites` matching existing style.

- annotations.json only; **meta.json untouched** (already within all size caps).
- No range overlaps; JSON validated.
- Single sharp addition per curation guardrails.