### PR TITLE
research(cauchy-schwarz-oq-02-oq-04): seminorm axioms for the positive-operator Cauchy–Schwarz form

### DIFF
--- a/proofs/Proofs/CauchySchwarzOQ02OQ04.lean
+++ b/proofs/Proofs/CauchySchwarzOQ02OQ04.lean
@@ -30,7 +30,7 @@ symmetric operator (a Kadison–Schwarz-type inequality),
 proved from the nonnegativity of the quadratic `t ↦ ⟪T(x + t•y), x + t•y⟫` via the
 discriminant criterion `discrim_le_zero`.
 
-## Main Results (11 theorems, 0 definitions, 0 sorries)
+## Main Results (13 theorems, 0 definitions, 0 sorries)
 
 1. `operator_cauchy_schwarz`        — ‖⟪T x, y⟫‖ ≤ ‖T‖ * ‖x‖ * ‖y‖
 2. `operator_cauchy_schwarz_right`  — same with the operator in the right slot
@@ -195,6 +195,50 @@ theorem positive_operator_cs_abs (T : F →L[ℝ] F)
   apply Real.sqrt_le_sqrt
   rw [abs_mul_abs_self]
   nlinarith [hcs]
+
+/-- **Absolute homogeneity of the induced seminorm.**  For *any* operator `T`, the
+functional `p(x) = √⟪T x, x⟫` scales absolutely: `p(c • x) = |c| · p(x)`.  This is the
+homogeneity axiom of a seminorm and needs neither symmetry nor positivity of `T`. -/
+theorem positive_operator_seminorm_smul (T : F →L[ℝ] F) (c : ℝ) (x : F) :
+    Real.sqrt ⟪T (c • x), c • x⟫ = |c| * Real.sqrt ⟪T x, x⟫ := by
+  have h : ⟪T (c • x), c • x⟫ = c ^ 2 * ⟪T x, x⟫ := by
+    rw [map_smul, real_inner_smul_left, real_inner_smul_right]; ring
+  rw [h, Real.sqrt_mul (by positivity), Real.sqrt_sq_eq_abs]
+
+/-- **Triangle inequality for the induced seminorm** (Minkowski form).  For a positive
+symmetric operator `T`, the functional `p(x) = √⟪T x, x⟫` is subadditive:
+
+      √⟪T (x + y), x + y⟫ ≤ √⟪T x, x⟫ + √⟪T y, y⟫.
+
+Together with `positive_operator_seminorm_smul` (absolute homogeneity) and the
+nonnegativity `hpos`, this shows the sesquilinear form of a positive symmetric operator
+induces a genuine **seminorm** on `F`.  The proof expands the diagonal
+`⟪T (x + y), x + y⟫ = ⟪T x, x⟫ + 2⟪T x, y⟫ + ⟪T y, y⟫` and bounds the cross term via the
+Kadison–Schwarz inequality `positive_operator_cs_abs`. -/
+theorem positive_operator_seminorm_triangle (T : F →L[ℝ] F)
+    (hsymm : ∀ a b : F, ⟪T a, b⟫ = ⟪a, T b⟫)
+    (hpos : ∀ a : F, 0 ≤ ⟪T a, a⟫) (x y : F) :
+    Real.sqrt ⟪T (x + y), x + y⟫ ≤ Real.sqrt ⟪T x, x⟫ + Real.sqrt ⟪T y, y⟫ := by
+  -- symmetry of the form
+  have hsy : ⟪T y, x⟫ = ⟪T x, y⟫ := by rw [hsymm y x, real_inner_comm]
+  -- expand the diagonal at `x + y`
+  have hexp : ⟪T (x + y), x + y⟫ = ⟪T x, x⟫ + 2 * ⟪T x, y⟫ + ⟪T y, y⟫ := by
+    rw [map_add]
+    simp only [inner_add_left, inner_add_right]
+    rw [hsy]; ring
+  -- bound the cross term by the Kadison–Schwarz inequality
+  have hcs := positive_operator_cs_abs T hsymm hpos x y
+  have hle : ⟪T x, y⟫ ≤ Real.sqrt ⟪T x, x⟫ * Real.sqrt ⟪T y, y⟫ :=
+    (le_abs_self _).trans hcs
+  have e1 : Real.sqrt ⟪T x, x⟫ ^ 2 = ⟪T x, x⟫ := Real.sq_sqrt (hpos x)
+  have e2 : Real.sqrt ⟪T y, y⟫ ^ 2 = ⟪T y, y⟫ := Real.sq_sqrt (hpos y)
+  have hbound : ⟪T (x + y), x + y⟫ ≤
+      (Real.sqrt ⟪T x, x⟫ + Real.sqrt ⟪T y, y⟫) ^ 2 := by
+    rw [hexp]; nlinarith [hle, e1, e2]
+  calc Real.sqrt ⟪T (x + y), x + y⟫
+      ≤ Real.sqrt ((Real.sqrt ⟪T x, x⟫ + Real.sqrt ⟪T y, y⟫) ^ 2) :=
+        Real.sqrt_le_sqrt hbound
+    _ = Real.sqrt ⟪T x, x⟫ + Real.sqrt ⟪T y, y⟫ := Real.sqrt_sq (by positivity)
 
 end PositiveOperator
 

--- a/src/data/proofs/cauchy-schwarz-oq-02-oq-04/meta.json
+++ b/src/data/proofs/cauchy-schwarz-oq-02-oq-04/meta.json
@@ -21,8 +21,8 @@
     "dateAdded": "2026-06-21",
     "axiomCount": 0,
     "assumptions": "None. Fully machine-verified. The operator-norm bounds assemble Mathlib's norm_inner_le_norm (scalar Cauchy-Schwarz) and ContinuousLinearMap.le_opNorm; the positive-operator (Kadison–Schwarz) inequality is an original derivation from the nonnegativity of the quadratic t ↦ ⟪T(x+t·y), x+t·y⟫ via discrim_le_zero, with positivity and symmetry of T carried as explicit hypotheses (no structure-encoded assumptions).",
-    "lineCount": 201,
-    "theoremCount": 11,
+    "lineCount": 245,
+    "theoremCount": 13,
     "definitionCount": 0,
     "mathlibDependencies": [
       {
@@ -86,9 +86,9 @@
   },
   "leanFile": {
     "namespace": "CauchySchwarzOperatorNorm",
-    "lineCount": 201,
+    "lineCount": 245,
     "axiomCount": 0,
-    "theoremCount": 11,
+    "theoremCount": 13,
     "definitionCount": 0,
     "path": "Proofs/CauchySchwarzOQ02OQ04.lean",
     "sorries": 0,


### PR DESCRIPTION
## Summary

Adds two theorems to `CauchySchwarzOQ02OQ04.lean` completing the *"a positive symmetric operator induces a seminorm"* story that the file's Kadison–Schwarz inequality (`positive_operator_cs_abs`) sets up but does not finish.

For a positive symmetric operator `T` on a real inner product space, the functional `p(x) = √⟪T x, x⟫` is a genuine **seminorm**. The file already had nonnegativity (`hpos`) and the Cauchy–Schwarz bound on the cross term; the two missing seminorm axioms are supplied here:

1. **`positive_operator_seminorm_smul`** — absolute homogeneity
   `p(c • x) = |c| · p(x)`. Holds for *any* operator `T` (needs neither symmetry nor positivity); pure homogeneity of the diagonal form.
2. **`positive_operator_seminorm_triangle`** — Minkowski subadditivity
   `√⟪T(x+y),x+y⟫ ≤ √⟪T x,x⟫ + √⟪T y,y⟫`, proved by expanding the diagonal and bounding the cross term `⟪T x, y⟫` via the existing Kadison–Schwarz inequality.

Together with `hpos` these three facts establish that `⟪T·,·⟫` induces a seminorm — a genuine structural consequence, not a cosmetic variant.

## Verification

Verified locally with Lean **v4.26.0** (the pinned toolchain) against the cached Mathlib oleans; the file imports only Mathlib. Both new theorems elaborate with the exact intended statements (confirmed via `#check`). Docker image build was unavailable this session (containerd `meta.db` I/O error), hence local verification.

## Gallery meta
- `theoremCount`: 11 → 13 (both count blocks)
- `lineCount`: 201 → 245 (both count blocks)
- 0 sorries, 0 axioms — status unchanged (`verified`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)