### PR TITLE
Enrich Fibonacci Gap-Two Product-Sum: annotate import region

### DIFF
--- a/src/data/proofs/fibonacci-identities-oq-05-oq-03/annotations.json
+++ b/src/data/proofs/fibonacci-identities-oq-05-oq-03/annotations.json
@@ -1,5 +1,22 @@
 [
   {
+    "id": "ann-fiboq0503-imports",
+    "proofId": "fibonacci-identities-oq-05-oq-03",
+    "range": { "startLine": 1, "endLine": 2 },
+    "type": "context",
+    "title": "The Single Mathlib Import",
+    "content": "**One import, three roles.** `import Mathlib` pulls in everything the entry needs, and it is worth naming the three distinct dependencies it satisfies. (1) *The object.* The 0-indexed Fibonacci sequence `Nat.fib` and its defining recurrence `Nat.fib_add_two` ($F_{n+2} = F_n + F_{n+1}$) — the sole facts about Fibonacci numbers the proofs consume; everything else (Cassini, d'Ocagne, the gap-two sum) is built here. (2) *The summation layer.* `Finset` and its big-operator $\\sum$ notation together with `Finset.sum_range_succ`, the peel-the-last-term lemma driving the induction. (3) *The tactic toolkit.* `linear_combination` (closes the Cassini and d'Ocagne algebra in one line each), `omega` (finishes the linearized induction step over $\\mathbb{N}$), and the coercion tactics `push_cast` / `zify` that move between $\\mathbb{N}$ and $\\mathbb{Z}$ so the sign $(-1)^n$ can be manipulated. The blanket `import Mathlib` is the ordinary gallery convention (contrast the stricter per-module imports required only for files bound for upstream Mathlib submission).",
+    "mathContext": "`Nat.fib_add_two`: $F_{n+2} = F_n + F_{n+1}$, with $F_0 = 0,\\ F_1 = 1$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Nat.fib and Nat.fib_add_two",
+      "Finset big-operator summation",
+      "linear_combination / omega / push_cast / zify tactics"
+    ],
+    "prerequisites": ["Lean 4 imports", "The Mathlib library"],
+    "tags": ["imports", "mathlib", "setup"]
+  },
+  {
     "id": "ann-fiboq0503-1",
     "proofId": "fibonacci-identities-oq-05-oq-03",
     "range": { "startLine": 3, "endLine": 30 },


### PR DESCRIPTION
Enrichment pass for `fibonacci-identities-oq-05-oq-03` (quality 95, passes 0 — a saturated entry).

## Gap addressed
The 7 existing annotations comprehensively cover lines 3–144, but **lines 1–2 (the `import Mathlib` region) were uncovered** — annotation coverage previously began at line 3. On a saturated entry the remaining real gap is exactly this non-theorem region.

## Change
Adds one `context` annotation (`ann-fiboq0503-imports`, lines 1–2) explaining the three distinct dependencies the single `import Mathlib` satisfies:
1. **The object** — `Nat.fib` / `Nat.fib_add_two` (the only Fibonacci facts consumed; Cassini, d'Ocagne, and the gap-two sum are all built in-file).
2. **The summation layer** — `Finset` big-operators + `Finset.sum_range_succ`.
3. **The tactic toolkit** — `linear_combination`, `omega`, `push_cast`/`zify`.

Includes `mathContext`, `significance`, `relatedConcepts`, and `prerequisites`. Annotation coverage now starts at line 1.

## Scope
- `meta.json` untouched (already saturated, 16.7 KB — well under caps).
- No status/badge/axiom claims changed; the entry remains `verified` (0 axioms, 0 sorries).
- Validated JSON structure and id uniqueness.