### PR TITLE
Fix: resync 5 uncovered meta count-block drifts to match leanFile

### DIFF
--- a/src/data/proofs/erdos-1-oq-02-oq-01/meta.json
+++ b/src/data/proofs/erdos-1-oq-02-oq-01/meta.json
@@ -73,10 +73,10 @@
     ],
     "dateAdded": "2026-07-02",
     "axiomCount": 0,
-    "lineCount": 329,
+    "lineCount": 346,
     "mathlib_version": "4.31.0",
     "assumptions": "None beyond Lean/Mathlib's standard foundations. Fully verified with 0 sorries and 0 axiom declarations. #print axioms reports only the ordinary foundational axioms propext / Classical.choice / Quot.sound for every result — no sorryAx, no Lean.ofReduceBool, no native_decide. Self-contained: restates the HasDistinctSubsetSums predicate and imports only Mathlib.",
-    "theoremCount": 18,
+    "theoremCount": 20,
     "definitionCount": 3
   },
   "overview": {

--- a/src/data/proofs/erdos-1-oq-02/meta.json
+++ b/src/data/proofs/erdos-1-oq-02/meta.json
@@ -20,7 +20,7 @@
     "badge": "verified",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 591,
+    "lineCount": 606,
     "assumptions": "0 axioms. The former anticoncentration_bound axiom (2^n ≤ 3√Q + 2 for distinct-subset-sums sets) is now PROVED in-file (theorem anticoncentration_bound) by an elementary, probability-free discharge: the second-moment identity over the powerset, a parity-aware central-interval count, and a discrete Chebyshev tail. dfx_lower_bound and pow2_dss proved; sum_sq_cauchy_schwarz proved. Fully machine-checked, 0 sorries.",
     "dateAdded": "2026-03-30",
     "mathlib_version": "4.26.0",
@@ -55,7 +55,7 @@
       "dfx_improves_counting: DFX bound is asymptotically better than counting bound (n < n² for n ≥ 2)",
       "Concrete cases: f(1)=1 via Finset.subset_singleton_iff, f(2)=2 via simp"
     ],
-    "theoremCount": 18,
+    "theoremCount": 19,
     "definitionCount": 0
   },
   "overview": {

--- a/src/data/proofs/hilbert-17-oq-03-oq-05/meta.json
+++ b/src/data/proofs/hilbert-17-oq-03-oq-05/meta.json
@@ -48,7 +48,7 @@
       "The arithmetic–geometric mean (AM–GM) inequality and sum-of-squares certificates for non-negativity.",
       "Evaluation of multivariate polynomials and the PSD predicate ∀ v, 0 ≤ eval v p."
     ],
-    "lineCount": 430,
+    "lineCount": 450,
     "relatedProblems": [
       {
         "id": "hilbert-17-oq-03-oq-02",
@@ -68,7 +68,7 @@
       }
     ],
     "assumptions": "0 axioms. #print axioms reports only propext, Classical.choice, Quot.sound for motzkinFun_psd_iff, motzkinPoly_psd_iff, three_is_sharp, and motzkin_amgm. No sorryAx, no native_decide / Lean.ofReduceBool. The MvPolynomial PSD predicate IsPSDMv matches the parent entry's IsPositiveSemidefiniteMv definitionally.",
-    "theoremCount": 28,
+    "theoremCount": 30,
     "definitionCount": 3,
     "additionalFiles": []
   },

--- a/src/data/proofs/law-of-cosines-oq-03-oq-03/meta.json
+++ b/src/data/proofs/law-of-cosines-oq-03-oq-03/meta.json
@@ -384,9 +384,9 @@
     ],
     "sorries": 0,
     "axiomCount": 6,
-    "lineCount": 912,
-    "theoremCount": 48,
-    "definitionCount": 2,
+    "lineCount": 937,
+    "theoremCount": 57,
+    "definitionCount": 3,
     "originalContributions": [
       "HyperbolicTriangle structure encoding the three second laws of cosines plus the angular defect",
       "cosh_c_eq / cosh_a_eq / cosh_b_eq: inversion of the second law giving each side as a function of the angles",

--- a/src/data/proofs/roth-theorem-k3-oq-03-oq-01/meta.json
+++ b/src/data/proofs/roth-theorem-k3-oq-03-oq-01/meta.json
@@ -58,9 +58,9 @@
       "kAPCount_eq_zero_of_zero: a single zero slot annihilates the count — if f j = 0 then Λ_k(f₀,…,f_{k-1}) = 0, since the j-th factor of every product term vanishes"
     ],
     "axiomCount": 0,
-    "lineCount": 766,
+    "lineCount": 793,
     "assumptions": "0 axioms, 0 sorries. Only the foundational axioms propext / Classical.choice / Quot.sound are used; no native_decide, no sorryAx, no Lean.ofReduceBool. The operators are re-declared self-containedly in this file's namespace; the file imports Mathlib.",
-    "theoremCount": 29,
+    "theoremCount": 30,
     "definitionCount": 5
   },
   "overview": {


### PR DESCRIPTION
## Fix

Five gallery entries had a stale `meta.*` count block while the sibling `leanFile` block already matched the current `.lean` source. Merged research PRs updated the `leanFile` block but left the `meta` block behind. This resyncs `meta.lineCount` / `theoremCount` / `definitionCount` to the authoritative `leanFile` values.

## Evidence

For each entry, `leanFile.lineCount` exactly equals the actual `.lean` file line count; only the `meta` block was stale:

| slug | lineCount | theoremCount | definitionCount |
|------|-----------|--------------|-----------------|
| roth-theorem-k3-oq-03-oq-01 | 766→793 | 29→30 | — |
| law-of-cosines-oq-03-oq-03 | 912→937 | 48→57 | 2→3 |
| hilbert-17-oq-03-oq-05 | 430→450 | 28→30 | — |
| erdos-1-oq-02-oq-01 | 329→346 | 18→20 | — |
| erdos-1-oq-02 | 591→606 | 18→19 | — |

No `.lean` files touched. `axiomCount` and `sorries` left untouched (per axiom-integrity policy, `meta.axiomCount` may legitimately differ from `leanFile.axiomCount`). All five confirmed uncovered by any open PR.

---
Automated fix by lean-mechanic agent.