### PR TITLE
Enrich Gerretsen's Inequality: annotate import/namespace region

### DIFF
--- a/src/data/proofs/herons-formula-oq-06-oq-02/annotations.json
+++ b/src/data/proofs/herons-formula-oq-06-oq-02/annotations.json
@@ -25,6 +25,28 @@
     ]
   },
   {
+    "id": "ann-imports-namespace",
+    "proofId": "herons-formula-oq-06-oq-02",
+    "range": {
+      "startLine": 45,
+      "endLine": 51
+    },
+    "type": "context",
+    "title": "Building on the Parent: Imports and the Opened Namespace",
+    "content": "The two imports mark this file as a genuine *child* of the Euler-inequality entry rather than a standalone proof. `import Proofs.HeronsFormulaOQ06` pulls in the verified parent, and `open EulerInequalityHeronOQ06` brings its triangle infrastructure — `semiperimeter`, `area`, `circumradius`, `inradius`, and the key lemma `area_sq` (Area² = s·xyz after Ravi substitution) — into scope unqualified, so Gerretsen's inequality is derived by *reusing* the parent's data rather than re-deriving R, r, and the area from scratch. Only `import Mathlib.Tactic` is added on top (for `nlinarith`/`polyrith`/`ring`), a lighter dependency than a blanket `import Mathlib`. `open Real` supplies the real-number scope for `Real.sqrt` and friends, and the `namespace GerretsenHeronOQ06OQ02` wrapper keeps `gerretsenPoly` and the core lemmas from colliding with the parent's identically-shaped definitions.",
+    "mathContext": "Reused parent data: $\\mathrm{Area}^2 = s\\,xyz$, $R = \\frac{abc}{4\\,\\mathrm{Area}}$, $r = \\frac{\\mathrm{Area}}{s}$ with $x=s-a,\\ y=s-b,\\ z=s-c$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "namespace and open (Lean modules)",
+      "reuse of a verified parent proof",
+      "Ravi triangle data (semiperimeter, area, circumradius, inradius)"
+    ],
+    "prerequisites": [
+      "Lean 4 imports and namespaces",
+      "the parent Euler-inequality entry HeronsFormulaOQ06"
+    ]
+  },
+  {
     "id": "ann-gerretsen-poly",
     "proofId": "herons-formula-oq-06-oq-02",
     "range": {


### PR DESCRIPTION
Enrichment pass for `herons-formula-oq-06-oq-02` (Gerretsen's Inequality $s^2 \le 4R^2 + 4Rr + 3r^2$; quality 95, passes 0 — saturated).

## Gap addressed
The 7 existing annotations covered lines 1–44 (header) and 52–183, leaving **lines 45–51 uncovered** — the import / namespace / open region. On a saturated entry that non-theorem region is the remaining real gap.

## Change
Adds one `context` annotation (`ann-imports-namespace`, lines 45–51) explaining that this file is a genuine *child* of the parent Euler-inequality entry:
- `import Proofs.HeronsFormulaOQ06` + `open EulerInequalityHeronOQ06` reuse the parent's verified triangle data (`semiperimeter`, `area`, `circumradius`, `inradius`, `area_sq`) rather than re-deriving $R, r,$ Area.
- Notes the lighter `import Mathlib.Tactic` (vs blanket `import Mathlib`), `open Real`, and the namespace's collision-avoidance role.

Includes `mathContext`, `significance`, `relatedConcepts`, `prerequisites`. Annotation coverage is now contiguous from line 1 through the imports into the body.

## Scope
- `meta.json` untouched (already saturated, 15.5 KB — under caps).
- No status/badge/axiom claims changed (entry remains verified, 0 axioms, 0 sorries).
- Validated JSON structure and id uniqueness.