### PR TITLE
research(arithmetic-series): eliminate Lean.ofReduceBool → verified [VERIFIED]

### DIFF
--- a/proofs/Proofs/ArithmeticSeries.lean
+++ b/proofs/Proofs/ArithmeticSeries.lean
@@ -109,11 +109,19 @@ theorem arithmetic_series_sum (a d n : ℕ) :
 
 /-! ## Famous Special Cases -/
 
-/-- Sum of first 100 natural numbers (Gauss's original problem) -/
-theorem gauss_100 : ∑ i ∈ range 101, i = 5050 := by native_decide
+/-- Sum of first 100 natural numbers (Gauss's original problem).
 
-/-- Sum of first 10 natural numbers: 0 + 1 + 2 + ... + 10 = 55 -/
-theorem sum_0_to_10 : ∑ i ∈ range 11, i = 55 := by native_decide
+    Discharged from the kernel-checked `gauss_sum` (no `native_decide`), so the
+    entry carries no `Lean.ofReduceBool` assumption. -/
+theorem gauss_100 : ∑ i ∈ range 101, i = 5050 := by
+  rw [show (101 : ℕ) = 100 + 1 from rfl, gauss_sum]
+
+/-- Sum of first 10 natural numbers: 0 + 1 + 2 + ... + 10 = 55.
+
+    Also derived from `gauss_sum`, keeping the presented corollaries fully
+    kernel-checked. -/
+theorem sum_0_to_10 : ∑ i ∈ range 11, i = 55 := by
+  rw [show (11 : ℕ) = 10 + 1 from rfl, gauss_sum]
 
 /-- Sum of odd numbers: 1 + 3 + 5 + ... + (2n-1) = n²
 

--- a/src/data/proofs/arithmetic-series/meta.json
+++ b/src/data/proofs/arithmetic-series/meta.json
@@ -7,7 +7,7 @@
     "author": "Carl Friedrich Gauss (formalized via Mathlib)",
     "sourceUrl": "https://leanprover-community.github.io/mathlib4_docs/Mathlib/Algebra/BigOperators/Intervals.html",
     "date": "~1785",
-    "status": "axiomatized",
+    "status": "verified",
     "proofRepoPath": "Proofs/ArithmeticSeries.lean",
     "tags": [
       "number-theory",
@@ -17,7 +17,7 @@
       "classic",
       "gauss"
     ],
-    "badge": "axiom",
+    "badge": "verified",
     "sorries": 0,
     "mathlibDependencies": [
       {
@@ -40,8 +40,8 @@
     ],
     "dateAdded": "2025-12-26",
     "wiedijkNumber": 68,
-    "axiomCount": 1,
-    "lineCount": 180,
+    "axiomCount": 0,
+    "lineCount": 188,
     "relatedProblems": [
       {
         "id": "arithmetic-series-oq-02",
@@ -52,7 +52,7 @@
         "relationship": "Further extensions of simplicial number theory"
       }
     ],
-    "assumptions": "One assumption: `Lean.ofReduceBool`. 0 `axiom` declarations, 0 sorries. The general Gauss/arithmetic-series formulas are kernel-checked, but the presented concrete corollary `gauss_100` (∑_{i<101} i = 5050) is discharged by `native_decide`, which the kernel accepts via `Lean.ofReduceBool` (compiler trust). Under the gallery convention (CLAUDE.md), native_decide on a presented result makes the entry `axiomatized` (axiomCount 1); `leanFile.axiomCount` stays 0 (no literal `axiom` declarations).",
+    "assumptions": "No assumptions: 0 `axiom` declarations, 0 sorries, and no `Lean.ofReduceBool`. The two concrete corollaries `gauss_100` (∑_{i<101} i = 5050) and `sum_0_to_10` (∑_{i<11} i = 55) are now derived from the kernel-checked `gauss_sum` by index shifting (`rw [show (101:ℕ) = 100 + 1 from rfl, gauss_sum]`) instead of `native_decide`, so `#print axioms` lists only `propext`, `Classical.choice`, `Quot.sound`. The entry is fully machine-checked (`verified`).",
     "mathlib_version": "4.26.0",
     "theoremCount": 11,
     "definitionCount": 1
@@ -60,7 +60,7 @@
   "overview": {
     "historicalContext": "The formula for 1 + 2 + ... + n = n(n+1)/2 is famously attributed to Carl Friedrich Gauss, who allegedly discovered it as a schoolboy around 1785. The story goes that when his teacher J.G. Büttner asked the class to sum the numbers 1 to 100 (hoping for a quiet classroom), young Gauss immediately answered 5050. The earliest known source for this anecdote is Wolfgang Sartorius von Waltershausen's 1856 biography of Gauss, written decades after the alleged event — the story has been embellished in many retellings.\n\nGauss realized that pairing 1+100, 2+99, 3+98, etc. gives 50 pairs, each summing to 101, yielding 50 × 101 = 5050. This pairing argument is the essence of the proof and illustrates a fundamental principle: algebraic insight (symmetry) defeats brute-force computation.\n\nThe formula was known long before Gauss. It appears in Archimedes' work (c. 250 BCE), in Aryabhata's *Aryabhatiya* (499 CE, India) as the formula for *saṅkalita*, and in Babylonian mathematics. The Pythagoreans studied triangular numbers T(n) = n(n+1)/2 as figurate numbers — dots arranged in triangular patterns — connecting arithmetic to geometry. In China, the formula appears in the *Jiuzhang Suanshu* (Nine Chapters on the Mathematical Art, c. 200 BCE).",
     "problemStatement": "**Theorem (Gauss, ~1785)**: The sum of the first n natural numbers:\n\n$$\\sum_{k=1}^{n} k = \\frac{n(n+1)}{2}$$\n\nMore generally, for an arithmetic series with first term a and common difference d:\n\n$$\\sum_{k=0}^{n-1} (a + kd) = na + \\frac{dn(n-1)}{2}$$\n\nThis is Wiedijk's 100 Theorems #68.",
-    "text": "A 187-line formalization of Gauss's summation formula (Wiedijk #68) with 12 declarations, 0 sorries, 0 axiom declarations (native_decide relies on Lean.ofReduceBool). Bridges Mathlib's `Finset.sum_range_id` ($\\sum_{i<n} i = n(n-1)/2$, 0-indexed) to the classical 1-indexed form `gauss_sum` ($\\sum_{k=1}^n k = n(n+1)/2$) via index shifting and `omega`. Extends to a general arithmetic series formula `arith_series_sum` ($\\sum_{k=0}^{n-1} (a + kd) = na + dn(n-1)/2$) using `Finset.sum_add_const` and `Finset.sum_mul_distrib`. Includes Gauss's pairing argument as a separate pedagogical proof `gauss_pairing` using a bijective sum reversal, and concrete verifications via `norm_num` (e.g., $1+2+\\cdots+100 = 5050$).",
+    "text": "A 188-line formalization of Gauss's summation formula (Wiedijk #68) with 12 declarations, 0 sorries, 0 axiom declarations, and no `Lean.ofReduceBool` (fully kernel-checked). Bridges Mathlib's `Finset.sum_range_id` ($\\sum_{i<n} i = n(n-1)/2$, 0-indexed) to the classical 1-indexed form `gauss_sum` ($\\sum_{k=1}^n k = n(n+1)/2$) via index shifting and `omega`. Extends to a general arithmetic series formula `arith_series_sum` ($\\sum_{k=0}^{n-1} (a + kd) = na + dn(n-1)/2$) using `Finset.sum_add_const` and `Finset.sum_mul_distrib`. Includes Gauss's pairing argument as a separate pedagogical proof `gauss_pairing` using a bijective sum reversal, and concrete verifications derived from `gauss_sum` by index shifting (e.g., $1+2+\\cdots+100 = 5050$), keeping the presented corollaries fully kernel-checked.",
     "proofStrategy": "**The Pairing Argument (Gauss's Method):**\n\nWrite the sum S twice, forwards and backwards:\n\n```\n  S = 1   +   2   +   3   + ... + (n-1) +   n\n  S = n   + (n-1) + (n-2) + ... +   2   +   1\n ─────────────────────────────────────────────\n 2S = (n+1) + (n+1) + (n+1) + ... + (n+1) + (n+1)\n    = n x (n+1)\n```\n\nTherefore S = n(n+1)/2.\n\nThe formalization uses Mathlib's `Finset.sum_range_id` and derives the classical formula by adjusting indices.",
     "keyInsights": [
       "**Gauss's Pairing Trick:** Writing $S = 0 + 1 + \\cdots + n$ and $S = n + (n-1) + \\cdots + 0$, each column sums to $n$, giving $2S = n \\cdot (n+1)$, hence $S = n(n+1)/2$. Mathlib proves this as `Finset.sum_range_id_eq_sum_range_succ`.",
@@ -146,7 +146,7 @@
       "BigOperators"
     ],
     "namespace": "ArithmeticSeries",
-    "lineCount": 180,
+    "lineCount": 188,
     "axiomCount": 0,
     "theoremCount": 11,
     "definitionCount": 1,


### PR DESCRIPTION
## Summary

The **arithmetic-series** gallery entry (Gauss's summation formula, Wiedijk #68) was marked `axiomatized` for a single, avoidable reason: two concrete corollaries were discharged by `native_decide`, which pulls in the `Lean.ofReduceBool` compiler-trust axiom. This PR eliminates that assumption, upgrading the entry to fully `verified`.

## Change

Both corollaries follow in O(1) from the already-kernel-checked `gauss_sum` (`∑ i ∈ range (n+1), i = n(n+1)/2`) by a simple index shift:

```lean
theorem gauss_100 : ∑ i ∈ range 101, i = 5050 := by
  rw [show (101 : ℕ) = 100 + 1 from rfl, gauss_sum]

theorem sum_0_to_10 : ∑ i ∈ range 11, i = 55 := by
  rw [show (11 : ℕ) = 10 + 1 from rfl, gauss_sum]
```

No `native_decide`, so no `Lean.ofReduceBool`.

## Verification

Built locally with Lean `v4.26.0` (docker unavailable this session): **0 errors**. Axiom check:

```
'ArithmeticSeries.gauss_100'  depends on axioms: [propext, Classical.choice, Quot.sound]
'ArithmeticSeries.sum_0_to_10' depends on axioms: [propext, Classical.choice, Quot.sound]
```

Only the foundational axioms remain (which do not count under the Axiom Integrity Policy).

## Meta updates

- `status`: `axiomatized` → `verified`
- `badge`: `axiom` → `verified`
- `axiomCount`: `1` → `0`
- `lineCount` (meta + leanFile): `180` → `188` (added explanatory docstrings)
- `assumptions` / `overview.text`: rewritten to reflect the fully kernel-checked status

🤖 Generated with [Claude Code](https://claude.com/claude-code)