### PR TITLE
research(beta-central-binomial-asymptotic-oq-01): limit forms of the Wallis asymptotic [VERIFIED]

### DIFF
--- a/proofs/Proofs/BetaCentralBinomialAsymptotic.lean
+++ b/proofs/Proofs/BetaCentralBinomialAsymptotic.lean
@@ -144,4 +144,37 @@ theorem betaIntegral_diag_eq (n : ℕ) :
   push_cast
   ring
 
+
+/-- **Diagonal Beta value vanishes (new).**  `B(n+1, n+1) → 0` as `n → ∞`.
+This is the limit form of the "mass collapses" statement above, obtained
+directly from `(2n+1)·C(2n,n) → ∞`. -/
+theorem betaDiag_tendsto_zero :
+    Tendsto (fun n : ℕ => betaDiag n) atTop (𝓝 0) := by
+  have hprod : Tendsto (fun n : ℕ => (2 * (n : ℝ) + 1) * (Nat.centralBinom n : ℝ))
+      atTop atTop := by
+    have hle : ∀ n : ℕ,
+        (2 * (n : ℝ) + 1) ≤ (2 * (n : ℝ) + 1) * (Nat.centralBinom n : ℝ) := by
+      intro n
+      have h1 : (1 : ℝ) ≤ (Nat.centralBinom n : ℝ) := by
+        exact_mod_cast Nat.one_le_iff_ne_zero.mpr (Nat.centralBinom_ne_zero n)
+      nlinarith [h1, Nat.cast_nonneg (α := ℝ) n]
+    exact tendsto_atTop_mono hle
+      (tendsto_atTop_add_const_right atTop 1
+        (tendsto_natCast_atTop_atTop.const_mul_atTop (by norm_num : (0 : ℝ) < 2)))
+  have hinv := hprod.inv_tendsto_atTop
+  refine hinv.congr fun n => ?_
+  simp only [Pi.inv_apply, betaDiag, one_div]
+
+/-- **Wallis ratio limit (new).**  `C(2n, n) / (4ⁿ/√(πn)) → 1` as `n → ∞`.
+The `Tendsto`-to-one restatement of `centralBinom_isEquivalent`, exposing the
+sharp leading-order constant governing the central binomial coefficient. -/
+theorem centralBinom_div_stirling_tendsto_one :
+    Tendsto (fun n : ℕ => (Nat.centralBinom n : ℝ) / ((4 : ℝ) ^ n / Real.sqrt (π * n)))
+      atTop (𝓝 1) := by
+  have hz : ∀ᶠ n : ℕ in atTop, ((4 : ℝ) ^ n / Real.sqrt (π * n)) ≠ 0 := by
+    filter_upwards [eventually_gt_atTop 0] with n hn
+    have hnpos : (0 : ℝ) < (n : ℝ) := by exact_mod_cast hn
+    have hden : (0 : ℝ) < Real.sqrt (π * n) := Real.sqrt_pos.2 (by positivity)
+    exact (div_pos (by positivity) hden).ne'
+  exact (isEquivalent_iff_tendsto_one hz).1 centralBinom_isEquivalent
 end BetaDiagAsymptotic

--- a/src/data/proofs/beta-central-binomial-asymptotic/meta.json
+++ b/src/data/proofs/beta-central-binomial-asymptotic/meta.json
@@ -12,9 +12,9 @@
     "proofRepoPath": "Proofs/BetaCentralBinomialAsymptotic.lean",
     "axiomCount": 0,
     "sorries": 0,
-    "theoremCount": 5,
+    "theoremCount": 7,
     "definitionCount": 1,
-    "lineCount": 147,
+    "lineCount": 180,
     "mathlib_version": "4.26.0",
     "tags": [
       "analysis",
@@ -96,10 +96,10 @@
   },
   "leanFile": {
     "path": "Proofs/BetaCentralBinomialAsymptotic.lean",
-    "lineCount": 147,
+    "lineCount": 180,
     "axiomCount": 0,
     "sorries": 0,
-    "theoremCount": 5,
+    "theoremCount": 7,
     "definitionCount": 1,
     "imports": [
       "import Proofs.BetaCentralBinomial",


### PR DESCRIPTION
## Summary

Adds two theorems to `proofs/Proofs/BetaCentralBinomialAsymptotic.lean` that formalize the **limit** statements implied by the file's asymptotic-equivalence results but previously stated only as informal docstring prose ("the mass collapses at the Wallis rate").

| New theorem | Statement |
|---|---|
| `betaDiag_tendsto_zero` | `B(n+1,n+1) → 0` as `n → ∞` |
| `centralBinom_div_stirling_tendsto_one` | `C(2n,n) / (4ⁿ/√(πn)) → 1` as `n → ∞` |

- `betaDiag_tendsto_zero` is proved directly: `(2n+1)·C(2n,n) → ∞` (since `C(2n,n) ≥ 1`) then `Tendsto.inv_tendsto_atTop`. It is the genuine limit form of the docstring's "mass collapses" claim — distinct from the existing `betaDiag_isEquivalent` (an asymptotic equivalence, not a limit).
- `centralBinom_div_stirling_tendsto_one` is the `Tendsto`-to-one restatement of the file's `centralBinom_isEquivalent`, via `isEquivalent_iff_tendsto_one`, making the sharp leading-order constant explicit.

## Verification

Compiled locally against **Mathlib v4.26.0** in a self-contained file (copying the file's dependency lemmas + `import Mathlib`); exit code 0, no errors/sorries. Docker build wrapper unavailable this session (host disk pressure), so verification was done with the pinned local toolchain.

## Meta

- `meta.lineCount` / `leanFile.lineCount`: 147 → 180
- `meta.theoremCount` / `leanFile.theoremCount`: 5 → 7
- `status`/`badge` unchanged: `verified`/`original` (0 axioms, 0 sorries)

🤖 Generated with [Claude Code](https://claude.com/claude-code)