### PR TITLE
research(lagrange-four-squares-oq-01-oq-03): power-of-two closed form jacobiCount(2^k)=24 + constancy [VERIFIED]

### DIFF
--- a/proofs/Proofs/LagrangeFourSquaresOQ01OQ03.lean
+++ b/proofs/Proofs/LagrangeFourSquaresOQ01OQ03.lean
@@ -99,6 +99,45 @@ theorem jacobiCount_prime {p : ℕ} (hp : p.Prime) (hodd : Odd p) :
   rw [jacobiCount_odd hodd, hp.divisors, Finset.sum_pair hp.one_lt.ne]
   ring
 
+/-- **Power-of-two closed form (0-axiom, general).** For every `k ≥ 1` the divisors
+of `2^k` are `1, 2, 4, …, 2^k`, and the `4 ∤ d` filter keeps exactly `d = 1` and
+`d = 2` (all higher powers are divisible by `4 = 2²`). Hence Jacobi's count is the
+constant `jacobiCount (2^k) = 8·(1+2) = 24`, *independent of `k`*. Combined with
+`jacobi_oracle` this pins `r₄(2^k) = 24` for the powers of two in range
+(`r₄(2)=r₄(4)=r₄(8)=r₄(16)=24`), matching the classical fact that `r₄` is constant
+on powers of two. This is the elementary even-side companion to `jacobiCount_odd`. -/
+theorem jacobiCount_two_pow {k : ℕ} (hk : 1 ≤ k) : jacobiCount (2 ^ k) = 24 := by
+  have hset : (2 ^ k).divisors.filter (fun d => ¬ 4 ∣ d) = {1, 2} := by
+    ext d
+    simp only [Finset.mem_filter, Nat.mem_divisors, Finset.mem_insert, Finset.mem_singleton]
+    constructor
+    · rintro ⟨⟨hdvd, _hne⟩, h4⟩
+      rw [Nat.dvd_prime_pow Nat.prime_two] at hdvd
+      obtain ⟨i, _hik, rfl⟩ := hdvd
+      have hi2 : i < 2 := by
+        by_contra h
+        push_neg at h
+        exact h4 (by
+          have h4eq : (4 : ℕ) = 2 ^ 2 := rfl
+          rw [h4eq]; exact pow_dvd_pow 2 h)
+      interval_cases i
+      · left; rfl
+      · right; rfl
+    · rintro (rfl | rfl)
+      · exact ⟨⟨one_dvd _, pow_ne_zero k (by norm_num)⟩, by decide⟩
+      · exact ⟨⟨dvd_pow_self 2 (Nat.one_le_iff_ne_zero.mp hk),
+          pow_ne_zero k (by norm_num)⟩, by decide⟩
+  unfold jacobiCount
+  rw [hset, Finset.sum_pair (by decide : (1 : ℕ) ≠ 2)]
+  norm_num
+
+/-- **Constancy on powers of two (0-axiom).** An immediate corollary of
+`jacobiCount_two_pow`: Jacobi's four-square count takes the same value on every
+power of two `2^k` with `k ≥ 1`. -/
+theorem jacobiCount_two_pow_const {j k : ℕ} (hj : 1 ≤ j) (hk : 1 ≤ k) :
+    jacobiCount (2 ^ j) = jacobiCount (2 ^ k) := by
+  rw [jacobiCount_two_pow hj, jacobiCount_two_pow hk]
+
 /-- **Convention guard (0-axiom).** The naive formula `8·σ(n)` is WRONG for `n = 4`:
 `8·σ(4) = 8·(1+2+4) = 56`, whereas the true count is `r4 4 = 24`. Equivalently the
 `4 ∤ d` exclusion drops the divisor `d = 4`. This is exactly why the general formula

--- a/src/data/proofs/lagrange-four-squares-oq-01-oq-03/meta.json
+++ b/src/data/proofs/lagrange-four-squares-oq-01-oq-03/meta.json
@@ -35,8 +35,8 @@
       }
     ],
     "assumptions": "The general Jacobi four-square theorem is NOT proved — it is a genuine Mathlib gap requiring either Hurwitz-quaternion order arithmetic or weight-2 modular forms (θ⁴∈M₂(Γ₀(4))), each ≫1000 LOC of absent number theory. This entry proves (a) a 0-axiom general lemma jacobiCount_odd (for odd n the 4∤d filter is vacuous, so jacobiCount n = 8·σ(n)), and (b) a machine-checked oracle jacobi_oracle : ∀ n∈[1,24], r₄ n = jacobiCount n, discharged by native_decide. native_decide trusts the Lean compiler and depends on the Lean.ofReduceBool axiom (#print axioms lists it, together with Lean.trustCompiler); naive_sigma_fails and r4_anchor_values also use native_decide. The entry is therefore axiomatized, not axiom-free. The literal `axiom` declaration count in the Lean file is 0; the single counted assumption is Lean.ofReduceBool introduced via native_decide.",
-    "lineCount": 126,
-    "theoremCount": 5,
+    "lineCount": 165,
+    "theoremCount": 7,
     "definitionCount": 3,
     "originalContributions": [
       "r4: the ordered, signed four-square representation count r₄(n), defined as a computable Finset.card over the integer box [-√n,√n]⁴ — an object Mathlib lacks entirely",
@@ -44,7 +44,9 @@
       "jacobiCount_odd: 0-axiom general lemma isolating the elementary half — for odd n the 4∤d exclusion is vacuous, so jacobiCount collapses to 8·σ(n)",
       "naive_sigma_fails: 0-axiom convention guard proving the naive 8·σ(4)=56 is wrong while r₄(4)=jacobiCount(4)=24 — the 4∤d exclusion is load-bearing",
       "jacobi_oracle: native_decide regression oracle r₄(n)=jacobiCount(n) for all 1≤n≤24, pinning the convention (r₄(1)=8, r₄(2)=24, r₄(4)=24, ...)",
-      "r4_anchor_values: explicit spot anchors r₄(1)=8, r₄(2)=24, r₄(3)=32, r₄(4)=24, r₄(5)=48, r₄(7)=64"
+      "r4_anchor_values: explicit spot anchors r₄(1)=8, r₄(2)=24, r₄(3)=32, r₄(4)=24, r₄(5)=48, r₄(7)=64",
+      "jacobiCount_two_pow: 0-axiom general closed form — for every k≥1, jacobiCount(2^k)=24 (the 4∤d filter keeps only divisors 1 and 2), the elementary even-side companion to jacobiCount_odd, revealing r₄ is constant on powers of two",
+      "jacobiCount_two_pow_const: 0-axiom corollary — Jacobi's count is independent of the exponent, jacobiCount(2^j)=jacobiCount(2^k) for all j,k≥1"
     ]
   },
   "overview": {
@@ -123,12 +125,12 @@
     }
   ],
   "leanFile": {
-    "lineCount": 126,
+    "lineCount": 165,
     "path": "Proofs/LagrangeFourSquaresOQ01OQ03.lean",
     "axiomCount": 0,
     "sorries": 0,
     "definitionCount": 3,
-    "theoremCount": 5
+    "theoremCount": 7
   },
   "sorries": 0
 }


### PR DESCRIPTION
Adds two **0-axiom, general** theorems to the Jacobi four-square oracle file `LagrangeFourSquaresOQ01OQ03.lean` — the elementary **even-side companion** to the existing `jacobiCount_odd`.

## What is proved

- **`jacobiCount_two_pow`** `{k : ℕ} (hk : 1 ≤ k) : jacobiCount (2 ^ k) = 24`
  The divisors of `2^k` are `1, 2, 4, …, 2^k`; the load-bearing `4 ∤ d` filter keeps exactly `d = 1` and `d = 2` (every higher power is divisible by `4 = 2²`), so Jacobi's count collapses to `8·(1+2) = 24`, **independent of `k`**. This is the classical fact that `r₄` is constant on powers of two; the existing `jacobi_oracle` confirms `r₄(2)=r₄(4)=r₄(8)=r₄(16)=24`.
- **`jacobiCount_two_pow_const`** — immediate corollary: `jacobiCount (2^j) = jacobiCount (2^k)` for all `j,k ≥ 1`.

## Why this is a genuine increment

The file previously isolated the **odd** half of Jacobi's formula (`jacobiCount_odd`: for odd `n`, the filter is vacuous so `jacobiCount n = 8·σ(n)`) plus a `native_decide` regression oracle. The **prime-power-of-two** case is the natural elementary complement and is not covered by any existing lemma or open PR. Both proofs use only `Nat.dvd_prime_pow` / `pow_dvd_pow` — **no `native_decide`**, so they are genuinely 0-axiom (unlike the oracle).

## Verification

Verified locally with **Lean v4.26.0** (docker build unavailable this session): the full file — including the `native_decide` oracle — compiles clean (`EXIT=0`). The two new theorems also compile in isolation.

## Meta

`meta.json` count blocks synced to match the Lean file: `lineCount 126→165`, `theoremCount 5→7` (both `leanFile` and `meta` blocks); two `originalContributions` entries added. Status unchanged (`axiomatized` — the file's oracle still depends on `Lean.ofReduceBool`; the new lemmas themselves are 0-axiom).