### PR TITLE
research(bezout-identity-oq-01-oq-02-oq-02): SL₂(ℤ) transitivity on primitive vectors (dim-2 base case) [VERIFIED]

### DIFF
--- a/proofs/Proofs/BezoutIdentityOQ01OQ02OQ02.lean
+++ b/proofs/Proofs/BezoutIdentityOQ01OQ02OQ02.lean
@@ -205,4 +205,45 @@ there is nothing to reduce and no target `e₁` to reach, so the descent is vacu
 theorem not_isPrimitive_fin_zero (v : Fin 0 → ℤ) : ¬ IsPrimitive v :=
   fun h => h.ne_zero (Subsingleton.elim v 0)
 
+/-! ### The first nontrivial case of transitivity: dimension 2 -/
+
+/-- **Transitivity of the `SL₂(ℤ)`-action, base case.**  Every primitive vector
+`v : Fin 2 → ℤ` is carried to `e₁ = (1, 0)` by an *explicit* unimodular matrix.
+Given a dual `w` with `w ⬝ᵥ v = 1`, the matrix
+`![![w 0, w 1], ![-v 1, v 0]]` has determinant `w 0 · v 0 + w 1 · v 1 = 1`,
+so it lies in `SL₂(ℤ)`, and its first row `w` pairs `v` to `1` while its second
+row `(-v 1, v 0)` pairs `v` to `0`.  This is the `n = 2` instance of the
+Euclidean-descent step that `orbit_e_isPrimitive` records as remaining work — here
+the descent is a single Bézout move, so the construction is closed form.  Together
+with the easy half it upgrades to the full characterization
+`isPrimitive_fin_two_iff_orbit`. -/
+theorem isPrimitive_fin_two_orbit {v : Fin 2 → ℤ} (hv : IsPrimitive v) :
+    ∃ A : Matrix.SpecialLinearGroup (Fin 2) ℤ,
+      (A : Matrix (Fin 2) (Fin 2) ℤ) *ᵥ v = Pi.single 0 1 := by
+  obtain ⟨w, hw⟩ := hv
+  have hwv : w 0 * v 0 + w 1 * v 1 = 1 := by
+    simpa [dotProduct, Fin.sum_univ_two] using hw
+  refine ⟨⟨!![w 0, w 1; -v 1, v 0], ?_⟩, ?_⟩
+  · rw [Matrix.det_fin_two_of]
+    linear_combination hwv
+  · funext k
+    fin_cases k <;>
+      simp [Matrix.mulVec, dotProduct, Fin.sum_univ_two] <;>
+      linarith [hwv]
+
+/-- **Full transitivity in dimension 2.**  A vector `v : Fin 2 → ℤ` is primitive
+iff it is `SL₂(ℤ)`-equivalent to `e₁`.  The forward direction is the closed-form
+Bézout reduction `isPrimitive_fin_two_orbit`; the reverse is the invariance
+`isPrimitive_mulVec_iff` applied to the primitive target `e₁`.  This is the
+converse (sufficiency) half of the transitivity characterization, established in
+full for `n = 2`. -/
+theorem isPrimitive_fin_two_iff_orbit (v : Fin 2 → ℤ) :
+    IsPrimitive v ↔ ∃ A : Matrix.SpecialLinearGroup (Fin 2) ℤ,
+      (A : Matrix (Fin 2) (Fin 2) ℤ) *ᵥ v = Pi.single 0 1 := by
+  refine ⟨isPrimitive_fin_two_orbit, ?_⟩
+  rintro ⟨A, hA⟩
+  have h : IsPrimitive ((A : Matrix (Fin 2) (Fin 2) ℤ) *ᵥ v) := by
+    rw [hA]; exact isPrimitive_single 0
+  exact (isPrimitive_mulVec_iff A v).mp h
+
 end BezoutPrimitive

--- a/src/data/proofs/bezout-identity-oq-01-oq-02-oq-02/meta.json
+++ b/src/data/proofs/bezout-identity-oq-01-oq-02-oq-02/meta.json
@@ -23,8 +23,8 @@
     "dateAdded": "2026-07-09",
     "axiomCount": 0,
     "assumptions": "None beyond Mathlib's foundational axioms. Fully machine-checked (0 sorries, 0 axiom declarations, no structure-encoded assumptions, no native_decide). Note: in the local Docker sandbox the file elaborates cleanly across repeated runs but the .olean cache write intermittently aborts with SIGBUS (exit 135), an environment/IO issue independent of the proofs; CI produces the build artifact.",
-    "lineCount": 208,
-    "theoremCount": 12,
+    "lineCount": 249,
+    "theoremCount": 14,
     "definitionCount": 2,
     "originalContributions": [
       "IsPrimitive v := ∃ w, w ⬝ᵥ v = 1 — a coordinate-free, manifestly SLₙ(ℤ)-invariant notion of primitivity for integer vectors (absent from Mathlib)",
@@ -89,9 +89,9 @@
   ],
   "leanFile": {
     "namespace": "BezoutPrimitive",
-    "lineCount": 208,
+    "lineCount": 249,
     "axiomCount": 0,
-    "theoremCount": 12,
+    "theoremCount": 14,
     "definitionCount": 2,
     "path": "Proofs/BezoutIdentityOQ01OQ02OQ02.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

Advances `bezout-identity-oq-01-oq-02-oq-02` (generalizing the Bézout `SL₂(ℤ)` construction to `SLₙ(ℤ)` transitivity on primitive vectors). The existing file builds the invariant-theoretic foundation (primitivity is `SLₙ(ℤ)`-invariant, transvection generators, the `n=1` base case) and explicitly flags the **converse** — every primitive vector lies in the `SLₙ`-orbit of `e₁` — as the remaining Euclidean-descent step.

This PR closes that converse in **dimension 2**, the first nontrivial case:

- `isPrimitive_fin_two_orbit` — every primitive `v : Fin 2 → ℤ` is carried to `e₁` by an **explicit** `SL₂(ℤ)` matrix `![![w 0, w 1], ![-v 1, v 0]]` (with `w ⬝ᵥ v = 1`), whose determinant is `w 0·v 0 + w 1·v 1 = 1`. A single closed-form Bézout move — no descent iteration needed at `n=2`.
- `isPrimitive_fin_two_iff_orbit` — the resulting **full transitivity characterization**: `IsPrimitive v ↔ ∃ A ∈ SL₂(ℤ), A ·ᵥ v = e₁`. Forward = the reduction above; reverse = the existing invariance `isPrimitive_mulVec_iff` applied to the primitive target `e₁`.

Together with `orbit_e_isPrimitive` (the easy/necessity half), the `SL₂(ℤ)`-orbit of `e₁` is now exactly the primitive locus in dimension 2.

## Verification
- **Verified locally** with Lean `v4.26.0` against cached Mathlib oleans: **0 errors, 0 warnings, 0 sorries, 0 axioms** (docker build unavailable this session).
- File imports only Mathlib, so the local compile is a faithful check.

## Meta
- `+2` theorems (12 → 14), `lineCount` 208 → 249, both meta blocks synced. `axiomCount` stays 0; status unchanged.