### PR TITLE
research(bezout-identity-oq-01-oq-02-oq-02): Fin 2 full transitivity of SLₙ(ℤ) action [VERIFIED]

### DIFF
--- a/proofs/Proofs/BezoutIdentityOQ01OQ02OQ02.lean
+++ b/proofs/Proofs/BezoutIdentityOQ01OQ02OQ02.lean
@@ -234,7 +234,8 @@ second row is `v` rotated a quarter turn and pairs to `0`.  Together with
 case of the open question, recovering the parent proof's `bezoutSL`. -/
 theorem exists_special_mulVec_eq_single_fin_two (v : Fin 2 → ℤ)
     (h : IsPrimitive v) :
-    ∃ A : Matrix.SpecialLinearGroup (Fin 2) ℤ, ↑ₘA *ᵥ v = Pi.single 0 1 := by
+    ∃ A : Matrix.SpecialLinearGroup (Fin 2) ℤ,
+      (A : Matrix (Fin 2) (Fin 2) ℤ) *ᵥ v = Pi.single 0 1 := by
   obtain ⟨w, hw⟩ := h
   have hw2 : w 0 * v 0 + w 1 * v 1 = 1 := by
     simpa [dotProduct, Fin.sum_univ_two] using hw
@@ -244,12 +245,11 @@ theorem exists_special_mulVec_eq_single_fin_two (v : Fin 2 → ℤ)
   refine ⟨⟨!![w 0, w 1; -v 1, v 0], hdet⟩, ?_⟩
   funext k
   fin_cases k
-  · simp only [SpecialLinearGroup.coe_mk, mulVec, dotProduct, Fin.sum_univ_two,
-      Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.head_cons, Pi.single_eq_same,
-      Fin.isValue]
+  · simp only [Fin.mk_zero, Fin.isValue, Matrix.mulVec, Matrix.of_apply, dotProduct,
+      Fin.sum_univ_two, Matrix.cons_val_zero, Matrix.cons_val_one, Pi.single_eq_same]
     linear_combination hw2
-  · simp only [SpecialLinearGroup.coe_mk, mulVec, dotProduct, Fin.sum_univ_two,
-      Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.head_cons, Fin.isValue]
+  · simp only [Fin.mk_one, Fin.isValue, Matrix.mulVec, Matrix.of_apply, dotProduct,
+      Fin.sum_univ_two, Matrix.cons_val_zero, Matrix.cons_val_one]
     rw [Pi.single_eq_of_ne (by decide : (1 : Fin 2) ≠ 0)]
     ring
 

--- a/proofs/Proofs/BezoutIdentityOQ01OQ02OQ02.lean
+++ b/proofs/Proofs/BezoutIdentityOQ01OQ02OQ02.lean
@@ -205,4 +205,52 @@ there is nothing to reduce and no target `e₁` to reach, so the descent is vacu
 theorem not_isPrimitive_fin_zero (v : Fin 0 → ℤ) : ¬ IsPrimitive v :=
   fun h => h.ne_zero (Subsingleton.elim v 0)
 
+/-! ### Full transitivity in dimension two -/
+
+/-- **Primitivity in dimension `2` is Bézout coprimality.**  A vector
+`v : Fin 2 → ℤ` is primitive iff its two entries are coprime, `IsCoprime (v 0) (v 1)`.
+Both sides unfold to the existence of integers `a, b` with `a * v 0 + b * v 1 = 1`,
+the classical Bézout identity — this is exactly the hypothesis a two-coordinate
+descent step consumes, and it links the coordinate-free `IsPrimitive` back to the
+parent proof's coprime pair `(a, b)`. -/
+theorem isPrimitive_fin_two_iff (v : Fin 2 → ℤ) :
+    IsPrimitive v ↔ IsCoprime (v 0) (v 1) := by
+  constructor
+  · rintro ⟨w, hw⟩
+    refine ⟨w 0, w 1, ?_⟩
+    simpa [dotProduct, Fin.sum_univ_two] using hw
+  · rintro ⟨a, b, hab⟩
+    refine ⟨![a, b], ?_⟩
+    simpa [dotProduct, Fin.sum_univ_two] using hab
+
+/-- **Transitivity of the `SL₂(ℤ)`-action — the base case of the descent.**
+Every primitive vector `v : Fin 2 → ℤ` is carried onto the basis vector `e₁ = (1, 0)`
+by an explicit element of `SL₂(ℤ)`.  Taking a Bézout dual `w ⬝ᵥ v = 1`, the matrix
+`!![w 0, w 1; -v 1, v 0]` has determinant `w 0 * v 0 + w 1 * v 1 = 1`, so it lies in
+`SL₂(ℤ)`, and it sends `v` to `(1, 0)`: the first row pairs `w` against `v`, the
+second row is `v` rotated a quarter turn and pairs to `0`.  Together with
+`orbit_e_isPrimitive` (necessity) this settles *full* transitivity in dimension two —
+`v` is `SL₂(ℤ)`-equivalent to `e₁` **iff** it is primitive — the first nontrivial
+case of the open question, recovering the parent proof's `bezoutSL`. -/
+theorem exists_special_mulVec_eq_single_fin_two (v : Fin 2 → ℤ)
+    (h : IsPrimitive v) :
+    ∃ A : Matrix.SpecialLinearGroup (Fin 2) ℤ, ↑ₘA *ᵥ v = Pi.single 0 1 := by
+  obtain ⟨w, hw⟩ := h
+  have hw2 : w 0 * v 0 + w 1 * v 1 = 1 := by
+    simpa [dotProduct, Fin.sum_univ_two] using hw
+  have hdet : (!![w 0, w 1; -v 1, v 0] : Matrix (Fin 2) (Fin 2) ℤ).det = 1 := by
+    rw [Matrix.det_fin_two_of]
+    linear_combination hw2
+  refine ⟨⟨!![w 0, w 1; -v 1, v 0], hdet⟩, ?_⟩
+  funext k
+  fin_cases k
+  · simp only [SpecialLinearGroup.coe_mk, mulVec, dotProduct, Fin.sum_univ_two,
+      Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.head_cons, Pi.single_eq_same,
+      Fin.isValue]
+    linear_combination hw2
+  · simp only [SpecialLinearGroup.coe_mk, mulVec, dotProduct, Fin.sum_univ_two,
+      Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.head_cons, Fin.isValue]
+    rw [Pi.single_eq_of_ne (by decide : (1 : Fin 2) ≠ 0)]
+    ring
+
 end BezoutPrimitive

--- a/src/data/proofs/bezout-identity-oq-01-oq-02-oq-02/meta.json
+++ b/src/data/proofs/bezout-identity-oq-01-oq-02-oq-02/meta.json
@@ -2,7 +2,7 @@
   "id": "bezout-identity-oq-01-oq-02-oq-02",
   "title": "Primitive Integer Vectors and the SLₙ(ℤ) Action: the Invariance Foundation",
   "slug": "bezout-identity-oq-01-oq-02-oq-02",
-  "description": "Builds the SLₙ(ℤ)-invariant foundation for the parent entry's open question — transitivity of SLₙ(ℤ) on primitive integer vectors, generalizing the n=2 bezoutSL. Introduces a coordinate-free notion of primitivity, IsPrimitive v := ∃ w, w ⬝ᵥ v = 1 (v has an integer dual pairing to 1), proves it agrees with the classical 'entries generate the unit ideal' (isPrimitive_iff_span_eq_top), and — the crux — proves SLₙ(ℤ) preserves primitivity in both directions (isPrimitive_mulVec_iff), since ↑ₘA⁻¹ * ↑ₘA = 1. Packages the Euclidean-descent generators as SLₙ(ℤ) elements (transvectionSL, with explicit vector action transvectionSL_mulVec) and assembles the necessity half of transitivity: every vector in the orbit of eᵢ is primitive (orbit_e_isPrimitive). The sufficiency converse (every primitive vector reaches eᵢ via Euclidean descent) is left as the documented next step. 10 theorems, 2 definitions, 0 sorries, 0 axioms.",
+  "description": "Builds the SLₙ(ℤ)-invariant foundation for the parent entry's open question — transitivity of SLₙ(ℤ) on primitive integer vectors, generalizing the n=2 bezoutSL. Introduces a coordinate-free notion of primitivity, IsPrimitive v := ∃ w, w ⬝ᵥ v = 1 (v has an integer dual pairing to 1), proves it agrees with the classical 'entries generate the unit ideal' (isPrimitive_iff_span_eq_top), and — the crux — proves SLₙ(ℤ) preserves primitivity in both directions (isPrimitive_mulVec_iff), since ↑ₘA⁻¹ * ↑ₘA = 1. Packages the Euclidean-descent generators as SLₙ(ℤ) elements (transvectionSL, with explicit vector action transvectionSL_mulVec) and assembles the necessity half of transitivity: every vector in the orbit of eᵢ is primitive (orbit_e_isPrimitive). The sufficiency converse (every primitive vector reaches eᵢ via Euclidean descent) is left as the documented next step. 14 theorems, 2 definitions, 0 sorries, 0 axioms.",
   "meta": {
     "author": "Lean Genius",
     "date": "2026-07-09",
@@ -23,14 +23,16 @@
     "dateAdded": "2026-07-09",
     "axiomCount": 0,
     "assumptions": "None beyond Mathlib's foundational axioms. Fully machine-checked (0 sorries, 0 axiom declarations, no structure-encoded assumptions, no native_decide). Note: in the local Docker sandbox the file elaborates cleanly across repeated runs but the .olean cache write intermittently aborts with SIGBUS (exit 135), an environment/IO issue independent of the proofs; CI produces the build artifact.",
-    "lineCount": 208,
-    "theoremCount": 12,
+    "lineCount": 256,
+    "theoremCount": 14,
     "definitionCount": 2,
     "originalContributions": [
       "IsPrimitive v := ∃ w, w ⬝ᵥ v = 1 — a coordinate-free, manifestly SLₙ(ℤ)-invariant notion of primitivity for integer vectors (absent from Mathlib)",
       "isPrimitive_mulVec_iff: SLₙ(ℤ) preserves primitivity in both directions — the exact invariant transitivity must respect",
       "transvectionSL / transvectionSL_mulVec: the elementary Euclidean-descent generators packaged in SLₙ(ℤ) with their explicit action v ↦ update v i (vᵢ + c·vⱼ)",
-      "orbit_e_isPrimitive: the necessity half of transitivity — every SLₙ(ℤ)-orbit of a basis vector consists of primitive vectors"
+      "orbit_e_isPrimitive: the necessity half of transitivity — every SLₙ(ℤ)-orbit of a basis vector consists of primitive vectors",
+      "exists_special_mulVec_eq_single_fin_two: the n=2 case of full transitivity — every primitive v : Fin 2 → ℤ is carried to e₁ by the explicit SL₂(ℤ) matrix !![w 0, w 1; -v 1, v 0], the first nontrivial instance of the parent open question and the sufficiency converse in dimension two",
+      "isPrimitive_fin_two_iff: primitivity in dimension 2 is exactly IsCoprime (v 0) (v 1), bridging the coordinate-free predicate to the parent proof’s Bézout coprime pair"
     ]
   },
   "overview": {
@@ -52,12 +54,11 @@
     ]
   },
   "conclusion": {
-    "summary": "Establishes the SLₙ(ℤ)-invariant foundation for transitivity on primitive vectors: a coordinate-free primitivity predicate (dot-product dual) equivalent to the classical unit-ideal condition, its SLₙ(ℤ)-invariance in both directions, the transvection generators of the Euclidean descent with explicit action, and the necessity half of transitivity (the orbit of a basis vector is primitive), plus the permutation-invariance of primitivity in every dimension. 11 theorems, 2 definitions, 0 sorries, 0 axioms, 201 lines.",
+    "summary": "Establishes the SLₙ(ℤ)-invariant foundation for transitivity on primitive vectors: a coordinate-free primitivity predicate (dot-product dual) equivalent to the classical unit-ideal condition, its SLₙ(ℤ)-invariance in both directions, the transvection generators of the Euclidean descent with explicit action, and the necessity half of transitivity (the orbit of a basis vector is primitive), plus the permutation-invariance of primitivity in every dimension. 14 theorems, 2 definitions, 0 sorries, 0 axioms, 256 lines.",
     "implications": "Reduces the parent's open question to a single remaining step: the sufficiency converse — every primitive vector is SLₙ(ℤ)-equivalent to e₀ — for which the transvection generators and the invariance guarantee here are exactly the tools. Because primitivity is now an SLₙ(ℤ)-invariant, the transitivity theorem takes the sharp form 'the SLₙ(ℤ)-orbit of e₀ is precisely the set of primitive vectors', of which the ⊆ direction is proved here.",
     "openQuestions": [
-      "Prove sufficiency: every primitive v ∈ ℤⁿ is SLₙ(ℤ)-equivalent to e₀, by strong induction on ∑ᵢ|vᵢ| applying transvectionSL (the Euclidean algorithm across coordinates) and accumulating the transvection product.",
-      "Add the determinant-one coordinate swap (a rotation built from three transvections) needed to normalize the surviving coordinate to position 0.",
-      "Relate IsPrimitive to Finset.univ.gcd of the entries being 1, bridging explicitly to the parent's n=2 IsCoprime phrasing."
+      "Prove sufficiency in general n: every primitive v ∈ ℤⁿ is SLₙ(ℤ)-equivalent to e₀, by strong induction on ∑ᵢ|vᵢ| applying transvectionSL (the Euclidean algorithm across coordinates) and accumulating the transvection product. The n=2 base case is now settled (exists_special_mulVec_eq_single_fin_two).",
+      "Add the determinant-one coordinate swap (a rotation built from three transvections) needed to normalize the surviving coordinate to position 0."
     ]
   },
   "mainTheorems": [
@@ -85,13 +86,23 @@
       "name": "isPrimitive_single",
       "type": "supporting",
       "description": "The standard basis vector eᵢ (Pi.single i 1) is primitive, witnessed by its own indicator as the dual. The target of the transitivity reduction."
+    },
+    {
+      "name": "exists_special_mulVec_eq_single_fin_two",
+      "type": "core",
+      "description": "Full transitivity in dimension two: every primitive v : Fin 2 → ℤ is SL₂(ℤ)-equivalent to e₁, via the explicit matrix !![w 0, w 1; -v 1, v 0] built from a Bézout dual w (det = w 0·v 0 + w 1·v 1 = 1). Together with orbit_e_isPrimitive this gives the sharp biconditional in n=2 and recovers the parent proof’s bezoutSL."
+    },
+    {
+      "name": "isPrimitive_fin_two_iff",
+      "type": "supporting",
+      "description": "In dimension 2, IsPrimitive v ↔ IsCoprime (v 0) (v 1): both sides are the Bézout identity ∃ a b, a·v 0 + b·v 1 = 1. Links the coordinate-free primitivity predicate to the parent entry’s coprime-pair phrasing."
     }
   ],
   "leanFile": {
     "namespace": "BezoutPrimitive",
-    "lineCount": 208,
+    "lineCount": 256,
     "axiomCount": 0,
-    "theoremCount": 12,
+    "theoremCount": 14,
     "definitionCount": 2,
     "path": "Proofs/BezoutIdentityOQ01OQ02OQ02.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

Advances **bezout-identity-oq-01-oq-02-oq-02** (SLₙ(ℤ)-invariant foundation for transitivity on primitive integer vectors) by proving the **first nontrivial case of the open transitivity question** — dimension `n = 2` — in closed form.

The entry previously proved only the *necessity* half (`orbit_e_isPrimitive`: everything in the SLₙ(ℤ)-orbit of a basis vector is primitive) and left *sufficiency* (every primitive vector reaches e₁) as the documented next step. This PR settles sufficiency in `n = 2`, giving the sharp biconditional there.

## New theorems (2)

- **`exists_special_mulVec_eq_single_fin_two`** — every primitive `v : Fin 2 → ℤ` is carried to `e₁ = (1,0)` by an explicit element of `SL₂(ℤ)`. Given a Bézout dual `w ⬝ᵥ v = 1`, the matrix `!![w 0, w 1; -v 1, v 0]` has determinant `w 0·v 0 + w 1·v 1 = 1` and sends `v ↦ (1, 0)`. Together with `orbit_e_isPrimitive` this is *full* transitivity in dimension two (`v` is `SL₂(ℤ)`-equivalent to `e₁` **iff** it is primitive), recovering the parent proof's `bezoutSL`.
- **`isPrimitive_fin_two_iff`** — in dimension 2, `IsPrimitive v ↔ IsCoprime (v 0) (v 1)`; both sides unfold to `∃ a b, a·v 0 + b·v 1 = 1`. This bridges the coordinate-free primitivity predicate to the parent entry's coprime-pair phrasing (previously listed as an open question).

## Verification

**VERIFIED** locally against the pinned toolchain (`lean v4.26.0`) with cached Mathlib oleans: the file compiles with **0 errors, 0 warnings, 0 sorries, 0 axioms**. The file imports only Mathlib, so there is no olean-drift ambiguity. (Docker olean-cache writes remain intermittently flaky in the sandbox, unrelated to the proofs.)

## Meta

- `lineCount` 208 → 256, `theoremCount` 12 → 14 (both `.meta` and `.leanFile` blocks)
- Added both theorems to `mainTheorems` / `originalContributions`
- Updated `openQuestions`: the IsCoprime bridge and the n=2 base case are now resolved; the remaining open item is general-n sufficiency by Euclidean descent

🤖 Generated with [Claude Code](https://claude.com/claude-code)