### PR TITLE
research(bezout-identity-oq-01-oq-02-oq-02): n=2 primitivity ⟺ coprime/gcd=1 bridge [VERIFIED]

### DIFF
--- a/proofs/Proofs/BezoutIdentityOQ01OQ02OQ02.lean
+++ b/proofs/Proofs/BezoutIdentityOQ01OQ02OQ02.lean
@@ -205,4 +205,30 @@ there is nothing to reduce and no target `e₁` to reach, so the descent is vacu
 theorem not_isPrimitive_fin_zero (v : Fin 0 → ℤ) : ¬ IsPrimitive v :=
   fun h => h.ne_zero (Subsingleton.elim v 0)
 
+/-! ### Reconciliation with the parent proof (`n = 2`) -/
+
+/-- **Two-dimensional case: primitivity is coprimality of the entries.**  A vector
+`v : Fin 2 → ℤ` is primitive iff `v 0` and `v 1` are coprime.  This is precisely the
+hypothesis under which the parent proof `bezout-identity-oq-01-oq-02` builds its
+explicit `SL₂(ℤ)` matrix, so it identifies the coordinate-free `IsPrimitive` with the
+classical Bézout notion at the base dimension of the descent.  Indeed `IsPrimitive v`
+unfolds to the existence of `w` with `w 0 · v 0 + w 1 · v 1 = 1`, which is exactly the
+definition of `IsCoprime (v 0) (v 1)`. -/
+theorem isPrimitive_fin_two_iff_isCoprime (v : Fin 2 → ℤ) :
+    IsPrimitive v ↔ IsCoprime (v 0) (v 1) := by
+  constructor
+  · rintro ⟨w, hw⟩
+    exact ⟨w 0, w 1, by simpa [dotProduct, Fin.sum_univ_two] using hw⟩
+  · rintro ⟨a, b, hab⟩
+    exact ⟨![a, b], by simpa [dotProduct, Fin.sum_univ_two] using hab⟩
+
+/-- **The classical "gcd of the entries is `1`" characterization, base case.**  For
+`v : Fin 2 → ℤ`, primitivity is equivalent to `Int.gcd (v 0) (v 1) = 1`.  This is the
+literal gcd form promised for the general `isPrimitive_iff_span_eq_top`, made concrete
+in the two-coordinate case handled by the parent proof: the entries generate the unit
+ideal exactly when their gcd is a unit, i.e. `1`. -/
+theorem isPrimitive_fin_two_iff_gcd (v : Fin 2 → ℤ) :
+    IsPrimitive v ↔ Int.gcd (v 0) (v 1) = 1 := by
+  rw [isPrimitive_fin_two_iff_isCoprime, Int.isCoprime_iff_gcd_eq_one]
+
 end BezoutPrimitive

--- a/src/data/proofs/bezout-identity-oq-01-oq-02-oq-02/meta.json
+++ b/src/data/proofs/bezout-identity-oq-01-oq-02-oq-02/meta.json
@@ -23,8 +23,8 @@
     "dateAdded": "2026-07-09",
     "axiomCount": 0,
     "assumptions": "None beyond Mathlib's foundational axioms. Fully machine-checked (0 sorries, 0 axiom declarations, no structure-encoded assumptions, no native_decide). Note: in the local Docker sandbox the file elaborates cleanly across repeated runs but the .olean cache write intermittently aborts with SIGBUS (exit 135), an environment/IO issue independent of the proofs; CI produces the build artifact.",
-    "lineCount": 208,
-    "theoremCount": 12,
+    "lineCount": 234,
+    "theoremCount": 14,
     "definitionCount": 2,
     "originalContributions": [
       "IsPrimitive v := ∃ w, w ⬝ᵥ v = 1 — a coordinate-free, manifestly SLₙ(ℤ)-invariant notion of primitivity for integer vectors (absent from Mathlib)",
@@ -89,9 +89,9 @@
   ],
   "leanFile": {
     "namespace": "BezoutPrimitive",
-    "lineCount": 208,
+    "lineCount": 234,
     "axiomCount": 0,
-    "theoremCount": 12,
+    "theoremCount": 14,
     "definitionCount": 2,
     "path": "Proofs/BezoutIdentityOQ01OQ02OQ02.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

Adds two verified theorems to `BezoutIdentityOQ01OQ02OQ02.lean` (primitive integer vectors under the SLₙ(ℤ)-action) that realize the **docstring-promised** classical gcd characterization of primitivity — previously only the *ideal* form (`isPrimitive_iff_span_eq_top`) was formalized, never the "gcd of the entries is 1" claim the docstring states twice.

The additions are anchored at the parent proof's base dimension `n = 2` (`bezout-identity-oq-01-oq-02` builds an explicit SL₂(ℤ) matrix for a **coprime pair**), tying the generalized coordinate-free `IsPrimitive` back to the classical notion.

## New theorems

- **`isPrimitive_fin_two_iff_isCoprime`** — `IsPrimitive v ↔ IsCoprime (v 0) (v 1)`. `IsPrimitive v` unfolds to `∃ w, w 0 · v 0 + w 1 · v 1 = 1`, which is definitionally `IsCoprime (v 0) (v 1)`; proved via `Fin.sum_univ_two` on the dot product.
- **`isPrimitive_fin_two_iff_gcd`** — `IsPrimitive v ↔ Int.gcd (v 0) (v 1) = 1`, the literal gcd form, via `Int.isCoprime_iff_gcd_eq_one`.

## Verification

Compiled locally with lean v4.26.0 against the pinned Mathlib: **0 errors, 0 sorries, 0 new axioms**. Meta synced: `lineCount` 208→234, `theoremCount` 12→14 (both `meta` and `leanFile` blocks).