### PR TITLE
Fix: resync stale meta counts (beta-integral-recurrence, euler-polyhedral-oq-02-oq-02)

### DIFF
--- a/src/data/proofs/beta-integral-recurrence-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/beta-integral-recurrence-oq-01-oq-01-oq-01/meta.json
@@ -123,9 +123,9 @@
       "Asymptotics"
     ],
     "namespace": "BetaDiagAsymptotic",
-    "lineCount": 147,
+    "lineCount": 180,
     "axiomCount": 0,
-    "theoremCount": 5,
+    "theoremCount": 7,
     "definitionCount": 1,
     "path": "Proofs/BetaCentralBinomialAsymptotic.lean",
     "sorries": 0
@@ -146,8 +146,8 @@
     ],
     "axiomCount": 0,
     "sorries": 0,
-    "lineCount": 147,
-    "theoremCount": 5,
+    "lineCount": 180,
+    "theoremCount": 7,
     "definitionCount": 1,
     "badge": "original",
     "originalContributions": [

--- a/src/data/proofs/euler-polyhedral-formula-oq-02-oq-02/meta.json
+++ b/src/data/proofs/euler-polyhedral-formula-oq-02-oq-02/meta.json
@@ -43,10 +43,10 @@
     ],
     "historicalContext": "Gauss (1827) and Bonnet (1848) related Gaussian curvature to topology for surfaces: ∫K dA = 2πχ. Allendoerfer-Weil (1943) and then Chern (1944-45) generalized this to all closed oriented even-dimensional Riemannian manifolds, expressing the Euler characteristic as the integral of the Pfaffian of the curvature form: ∫_M Pf(Ω/2π) = χ(M). Chern's intrinsic proof, via the transgression of the Euler form, became a cornerstone of characteristic-class theory. For 2-manifolds (n=1) the Pfaffian of the 2×2 curvature is the Gaussian curvature times the area form, recovering classical Gauss-Bonnet; for polyhedral surfaces the curvature concentrates at vertices as angular deficiency, recovering the discrete theorem Σδ(v)=2πχ.",
     "axiomCount": 2,
-    "lineCount": 512,
+    "lineCount": 612,
     "assumptions": "0 sorries; 0 axiom declarations; 2 structure-encoded assumptions. (1) CGBManifold.chern_gauss_bonnet encodes the Chern-Gauss-Bonnet identity ∫_M Pf(Ω) = (2π)^n·χ(M); Mathlib v4.26.0 has no Pfaffian of a curvature form, no integration of characteristic forms over manifolds, and no manifold Euler characteristic, so the identity is taken as a field rather than derived. (2) ClosedOddManifold.chi_zero encodes the Poincaré-duality fact that closed odd-dimensional manifolds have χ=0. All 54 theorems are then derived; the sphere Euler characteristics, normalization-constant lemmas, and the 2×2 Pfaffian identity are independently verified (depend only on propext/Classical.choice/Quot.sound). #print axioms confirms no sorryAx and no Lean.ofReduceBool.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 54,
+    "theoremCount": 62,
     "definitionCount": 12
   },
   "overview": {


### PR DESCRIPTION
## Fix

Resync two gallery entries whose `meta` count block drifted out of sync with the actual Lean source (no open PR covers either).

## Evidence

**beta-integral-recurrence-oq-01-oq-01-oq-01** — shares `Proofs/BetaCentralBinomialAsymptotic.lean` with two sibling entries. #37453 grew the file (147→180 lines, +2 theorems) and updated the sibling entries' counts but missed this one.
- Both blocks: `lineCount` 147 → 180, `theoremCount` 5 → 7 (matches actual file: 180 lines; matches sibling `beta-central-binomial-asymptotic`).

**euler-polyhedral-formula-oq-02-oq-02** — the `leanFile` block is already correct (612 lines, 62 theorems) but the `meta` block was stale.
- `meta` block: `lineCount` 512 → 612, `theoremCount` 54 → 62 (matches actual file: 612 `\n`).
- `axiomCount`/`sorries` left unchanged (out of scope; `meta.axiomCount=2` reflects structure-encoded assumptions per Axiom Integrity Policy).
- The one open PR touching this meta (#36432) targets vanished context (`lineCount 426`) so its hunk can no longer apply — not a real collision.

Both files validate as JSON.

---
Automated fix by lean-mechanic agent.