### PR TITLE
Enrich pac-learning-bounds-wip-01: annotate ambient DecidableEq α context

### DIFF
--- a/src/data/proofs/pac-learning-bounds-wip-01/annotations.json
+++ b/src/data/proofs/pac-learning-bounds-wip-01/annotations.json
@@ -24,6 +24,30 @@
     ]
   },
   {
+    "id": "ann-pac-wip01-01b-ambient",
+    "proofId": "pac-learning-bounds-wip-01",
+    "range": {
+      "startLine": 41,
+      "endLine": 42
+    },
+    "type": "context",
+    "title": "Ambient Context: DecidableEq α Powers the Whole Combinatorics",
+    "content": "Before any definition, the file fixes a single ambient hypothesis: `variable {α : Type*} [DecidableEq α]`. The type `α` of feature points is left completely general — no finiteness, no order, no cardinality assumption — because every finiteness fact the theory needs is carried by the `Finset` structure itself, not by `α`. The one instance that is load-bearing is `[DecidableEq α]`: it is exactly what makes the core operations computable as finite sets. Intersection `h ∩ S` needs `DecidableEq α`; `H.image (· ∩ S)` (the definition of `trace`) needs a `DecidableEq` on its codomain `Finset α`, which is *derived* from `DecidableEq α`; and `S.powerset` together with the equality `trace H S = S.powerset` that defines `Shatters` again relies on decidable membership in `Finset α`. Drop this instance and none of `trace`, `Shatters`, or a single cardinality bound below would typecheck.",
+    "mathContext": "`DecidableEq α ⟹ DecidableEq (Finset α)`, which is what `Finset.image`, `∩`, `Finset.powerset`, and Finset equality require. Generality of `α` (no `Fintype`) is deliberate: the growth quantity $\\Pi_H(S)$ and the shattering relation are statements about *finite subsets*, so finiteness lives in the `Finset (Finset α)` model, not in the ground type.",
+    "significance": "context",
+    "relatedConcepts": [
+      "DecidableEq typeclass",
+      "Finset.image",
+      "Finset.powerset",
+      "hypothesis class as Finset (Finset α)",
+      "computable finite intersection"
+    ],
+    "prerequisites": [
+      "Lean typeclass resolution",
+      "Finset operations and decidability"
+    ]
+  },
+  {
     "id": "ann-pac-wip01-02-defs",
     "proofId": "pac-learning-bounds-wip-01",
     "range": {


### PR DESCRIPTION
## Summary
Adds a single `context` annotation (lines 41–42) on `variable {α : Type*} [DecidableEq α]` — the previously **uncovered** ambient-setup line on this otherwise-saturated (quality 95) entry.

## Why this is the real gap
Coverage already tiled lines 1–40 (header/concept) and 43–185 (defs + theorems). The one content-bearing declaration left uncovered was the ambient `variable`. `[DecidableEq α]` is load-bearing: it is what makes `h ∩ S`, `H.image (· ∩ S)` (the definition of `trace`), `S.powerset`, and Finset equality computable — drop it and nothing below typechecks. `{α : Type*}` is deliberately general (no `Fintype`): all finiteness is carried by the `Finset (Finset α)` model.

## Guardrails
- **annotations.json only**; `meta.json` untouched (no status/badge/count/axiom claims changed).
- New range 41–42 is **non-overlapping** with existing 1–40 and 43–53; ids unique; JSON validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)