### PR TITLE
audit(erdos-893): disclose Lean.ofReduceBool from native_decide

### DIFF
--- a/src/data/proofs/erdos-893/meta.json
+++ b/src/data/proofs/erdos-893/meta.json
@@ -64,9 +64,9 @@
       "Proved tau_mersenne_ge_tau: tau(2^k - 1) >= tau(k) via divisor injection d -> 2^d - 1",
       "Proved f_divisor_sum_lower: f(n) >= sum_{k=1}^n tau(k), connecting f to the divisor summatory function"
     ],
-    "axiomCount": 1,
+    "axiomCount": 2,
     "lineCount": 332,
-    "assumptions": "1 axiom: kovac_luca_limsup_infinite. See Lean source for the complete statement.",
+    "assumptions": "2 assumptions: (1) axiom kovac_luca_limsup_infinite (see Lean source for the complete statement); (2) Lean.ofReduceBool, on which the 16 native_decide computations that verify tau(2^k-1) and f(k) for k = 1, ..., 8 depend. The file has 1 literal axiom declaration, so leanFile.axiomCount = 1 counts only that literal axiom while meta.axiomCount = 2 counts all trust assumptions.",
     "mathlib_version": "4.26.0",
     "theoremCount": 35,
     "leanFiles": [


### PR DESCRIPTION
## Gallery Integrity Fix

**Proof**: erdos-893 (Erdős Problem #893: Divisor Sum of Mersenne Numbers)
**Severity**: LOW (disclosure gap — no status overclaim)

## Problem

`proofs/Proofs/Erdos893Problem.lean` uses `native_decide` in **16 top-level theorems** (`tau_1`…`tau_255`, `f_one`…`f_eight`) to verify τ(2^k−1) and f(k) for k = 1,…,8. These are explicitly enumerated in `originalContributions` as verified results.

Per the project **Axiom Integrity Policy**, `native_decide` trusts the Lean compiler's kernel reduction and depends on the `Lean.ofReduceBool` axiom (`#print axioms` lists it). The entry disclosed only the `kovac_luca_limsup_infinite` axiom and omitted `Lean.ofReduceBool`.

## Evidence

- **meta.json claimed**: `axiomCount: 1`, `assumptions: "1 axiom: kovac_luca_limsup_infinite…"` — no mention of `native_decide` / `Lean.ofReduceBool`.
- **Lean file shows**: 1 literal `axiom` (`kovac_luca_limsup_infinite`, line 292) **plus** 16 `native_decide` invocations discharging claimed-verified computations.

## Fix

- `meta.axiomCount`: 1 → **2** (kovac_luca_limsup_infinite + Lean.ofReduceBool)
- `assumptions`: now discloses the `native_decide` / `Lean.ofReduceBool` dependency
- `leanFile.axiomCount` / `leanFiles[0].axiomCount`: unchanged at **1** (literal `axiom` declarations only, per policy)
- `status`/`badge`: unchanged (`axiomatized`/`axiom` — already correct, no overclaim)

Counts otherwise verified against source: lineCount 332 ✓, sorries 0 ✓, definitionCount 4 ✓, theoremCount 35 ✓ (34 theorems + 1 axiom), 0 True stubs.

---
Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)