### PR TITLE
Enrich Fibonacci gap-two product-sum: cross-ref the Gibonacci sibling

### DIFF
--- a/src/data/proofs/fibonacci-identities-oq-05-oq-03/meta.json
+++ b/src/data/proofs/fibonacci-identities-oq-05-oq-03/meta.json
@@ -144,6 +144,11 @@
       "description": "Sibling refinement of the same parent: there the gap is fixed at one and the sum is weighted/alternated; here the gap is widened to two. Both reduce their inductive step to a Cassini-derived product identity."
     },
     {
+      "targetId": "fibonacci-identities-oq-05-oq-02",
+      "relationship": "relatedTo",
+      "description": "The orthogonal sibling refinement of the same parent: rather than widening the gap, it fixes the gap at one and generalizes the sequence, replacing Fₙ by an arbitrary Gibonacci (Horadam) sequence G. There the parent's [n even] toggle is unmasked as [n even]·D with D = G₁² − G₀G₁ − G₀² the recurrence discriminant (D = 1 for Fibonacci); here the same toggle survives sign-intact under the gap widening. Both proofs are powered by a generalized Cassini identity — that entry's seed-free Gₙ₊₁² − Gₙ Gₙ₊₂ = (−1)ⁿ D and this entry's d'Ocagne consequence of Cassini for Nat.fib."
+    },
+    {
       "targetId": "fibonacci-identities",
       "relationship": "relatedTo",
       "description": "The base entry's sum-of-squares identity ∑ Fₖ² = Fₙ Fₙ₊₁ is the gap-zero member of the same family; this entry supplies the gap-two member, landing on Fₙ₊₁ Fₙ₊₂."


### PR DESCRIPTION
Enrichment pass for `fibonacci-identities-oq-05-oq-03` (gap-two Fibonacci product-sum, quality 95, passes 0).

The entry is otherwise saturated — full annotation coverage (lines 1–144, no gaps), all 8 annotations carry `mathContext`/`significance`/`relatedConcepts`/`prerequisites`, 6 sections, 4 keyInsights, conclusion with implications + openQuestions. The one genuine gap was a **missing sibling cross-reference**.

## Change
- Add a `crossReference` to **`fibonacci-identities-oq-05-oq-02`** ("Gibonacci Product-Sum: the Parity Constant is a Discriminant").

This is the *orthogonal* sibling refinement of the shared parent `oq-05`: where this entry widens the gap parameter (1 → 2) over the Fibonacci sequence, oq-05-oq-02 fixes the gap and generalizes the sequence to an arbitrary Gibonacci/Horadam $G$, unmasking the parent's `[n even]` toggle as `[n even]·D` with $D = G_1^2 - G_0G_1 - G_0^2$ the recurrence discriminant ($D=1$ for Fibonacci). The gallery already linked the gap-widening sibling (oq-05-oq-01) and the gap-zero base entry but not this one; both proofs are powered by the same Cassini engine.

## Guardrails
- `crossReferences` 3 → 4 (cap 20)
- `meta.json` 16.8 KB → 17.5 KB (cap ~60 KB)
- meta counts, annotations, Lean file untouched.