### PR TITLE
Enrich Hall regular-family endpoint: annotate the import region

### DIFF
--- a/src/data/proofs/hall-marriage-theorem-oq-01-oq-01-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/hall-marriage-theorem-oq-01-oq-01-oq-01-oq-01/annotations.json
@@ -1,5 +1,28 @@
 [
   {
+    "id": "ann-hallreg4-imports",
+    "proofId": "hall-marriage-theorem-oq-01-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 1,
+      "endLine": 2
+    },
+    "type": "context",
+    "title": "The Two Imports: Mathlib and the Parent Deficiency File",
+    "content": "Line 1 pulls in all of Mathlib, which supplies the marriage-theorem infrastructure this file leans on: Finset.all_card_le_biUnion_card_iff_exists_injective (Hall's condition ⟹ an injective system of distinct representatives) together with the Finset double-counting lemmas (bipartiteAbove, sum over incidence pairs) used to verify that condition. Line 2 imports the parent entry's Lean file, HallMarriageTheoremOQ01OQ01OQ01, rather than re-deriving its results: this endpoint reuses that file's deficiency calculus — deficiency_eq_zero_iff and maxTransversal_eq_card_of_deficiency_zero — to upgrade the SDR produced here into the statement that the maximum partial transversal of a k-regular family has full size #ι. The import is what makes this a genuine leaf of the oq-01 chain rather than a standalone lemma.",
+    "mathContext": "Depends on Hall's theorem $\\bigl(\\forall S,\\ \\#\\!\\bigcup_{i\\in S} t_i \\ge \\#S\\bigr) \\Rightarrow \\exists\\,f\\ \\text{injective},\\ f(i)\\in t_i$, and on the parent's deficiency identity $\\mathrm{def}(t)=0 \\iff \\max\\#(\\text{partial transversal}) = \\#\\iota$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Hall's marriage theorem",
+      "systems of distinct representatives",
+      "deficiency version of Hall",
+      "module dependencies"
+    ],
+    "prerequisites": [
+      "Lean import system",
+      "Mathlib"
+    ]
+  },
+  {
     "id": "ann-hallreg-overview",
     "proofId": "hall-marriage-theorem-oq-01-oq-01-oq-01-oq-01",
     "range": {


### PR DESCRIPTION
Enrichment pass for `hall-marriage-theorem-oq-01-oq-01-oq-01-oq-01` (k-regular families ⟹ perfect matching / full transversal, quality 95, passes 0).

The entry is otherwise saturated: 9 annotations all carrying `mathContext`/`significance`/`relatedConcepts`/`prerequisites`, 4 sections, 5 keyInsights, 2 crossReferences, conclusion complete. The sole uncovered structural region was the **import block (lines 1–2)** — the first annotation began at line 4. (Lines 55 and 94 are blank separators — honest skip.)

## Change
- Add a `context` annotation over lines 1–2 explaining the two imports:
  - `import Mathlib` — supplies Hall's SDR theorem (`Finset.all_card_le_biUnion_card_iff_exists_injective`) and the `Finset` double-counting lemmas that verify Hall's condition here.
  - `import Proofs.HallMarriageTheoremOQ01OQ01OQ01` — the parent file, whose `deficiency_eq_zero_iff` and `maxTransversal_eq_card_of_deficiency_zero` this endpoint reuses to lift the SDR to a maximal transversal of size #ι, making it a genuine leaf of the oq-01 chain.

## Guardrails
- `annotations.json` 9 → 10 entries; `meta.json` and the Lean file untouched.
- No meta counts changed.