### PR TITLE
research(bezout-identity-oq-01-oq-02-oq-02): gcd characterization + unit-pivot termination [VERIFIED-local]

### DIFF
--- a/proofs/Proofs/BezoutIdentityOQ01OQ02OQ02.lean
+++ b/proofs/Proofs/BezoutIdentityOQ01OQ02OQ02.lean
@@ -39,6 +39,7 @@ import Mathlib.LinearAlgebra.Matrix.SpecialLinearGroup
 import Mathlib.LinearAlgebra.Matrix.Transvection
 import Mathlib.RingTheory.Ideal.Span
 import Mathlib.RingTheory.Ideal.Operations
+import Mathlib.RingTheory.PrincipalIdealDomain
 import Mathlib.Tactic
 
 namespace BezoutPrimitive
@@ -76,6 +77,39 @@ theorem isPrimitive_iff_span_eq_top (v : Fin n → ℤ) :
     exact ⟨w, by simpa [dotProduct, smul_eq_mul, mul_comm] using hw⟩
   · rintro ⟨c, hc⟩
     exact ⟨c, by simpa [dotProduct, smul_eq_mul, mul_comm] using hc⟩
+
+/-- **The gcd characterization of primitivity.**  A vector `v` is primitive iff
+every common divisor of its entries is a unit — i.e. `gcd(v₁, …, vₙ) = 1`, the
+classical definition.  Forward: a dual `w` with `w ⬝ᵥ v = 1` divides `1` by any
+common divisor `d` of the entries (`d ∣ ∑ wᵢvᵢ = 1`), so `d` is a unit.  Reverse
+(over `ℤ`, a principal ideal ring): the generator `g` of `Ideal.span (range v)`
+divides every entry, hence is a unit by hypothesis, so the ideal is `⊤` and
+`isPrimitive_iff_span_eq_top` closes it.  This is the entry-level statement the
+opening docstring names ("gcd of the entries is `1`"), complementing the ideal
+form. -/
+theorem isPrimitive_iff_forall_isUnit_of_dvd (v : Fin n → ℤ) :
+    IsPrimitive v ↔ ∀ d : ℤ, (∀ i, d ∣ v i) → IsUnit d := by
+  constructor
+  · rintro ⟨w, hw⟩ d hd
+    apply isUnit_of_dvd_one
+    rw [← hw, dotProduct]
+    exact Finset.dvd_sum fun i _ => (hd i).mul_left (w i)
+  · intro h
+    rw [isPrimitive_iff_span_eq_top]
+    haveI hP : (Ideal.span (Set.range v)).IsPrincipal :=
+      IsPrincipalIdealRing.principal _
+    set I := Ideal.span (Set.range v) with hI
+    have hgen : Ideal.span {Submodule.IsPrincipal.generator I} = I :=
+      Submodule.IsPrincipal.span_singleton_generator I
+    set g := Submodule.IsPrincipal.generator I with hg
+    have hdvd : ∀ i, g ∣ v i := by
+      intro i
+      have hmem : v i ∈ I := Ideal.subset_span (Set.mem_range_self i)
+      rw [← hgen] at hmem
+      exact Ideal.mem_span_singleton.mp hmem
+    have hu : IsUnit g := h g hdvd
+    rw [← hgen]
+    exact Ideal.span_singleton_eq_top.mpr hu
 
 /-! ### `SLₙ(ℤ)` preserves primitivity -/
 
@@ -150,6 +184,24 @@ theorem IsPrimitive.ne_zero {v : Fin n → ℤ} (h : IsPrimitive v) : v ≠ 0 :=
   obtain ⟨w, hw⟩ := h
   rw [dotProduct_zero] at hw
   exact one_ne_zero hw.symm
+
+/-- **A unit coordinate makes the whole vector primitive.**  If some entry `vᵢ` is
+a unit (over `ℤ`, `vᵢ = ±1`) then `v` is primitive: the single dual
+`w = (vᵢ)⁻¹ · eᵢ` pairs `v` to `1`.  This is the *termination test* of the
+Euclidean descent — the moment a Bézout reduction drives one coordinate down to a
+unit, primitivity (hence reachability of `e₁`) is already certified, no further
+reduction required.  It is the sufficient-condition companion to
+`IsPrimitive.ne_zero`. -/
+theorem isPrimitive_of_isUnit_apply {v : Fin n → ℤ} {i : Fin n}
+    (hi : IsUnit (v i)) : IsPrimitive v := by
+  obtain ⟨u, hu⟩ := hi
+  refine ⟨Pi.single i ((u⁻¹ : ℤˣ) : ℤ), ?_⟩
+  rw [dotProduct, Finset.sum_eq_single i]
+  · rw [Pi.single_eq_same, ← hu, ← Units.val_mul, inv_mul_cancel, Units.val_one]
+  · intro j _ hj
+    rw [Pi.single_eq_of_ne hj, zero_mul]
+  · intro h
+    exact absurd (Finset.mem_univ i) h
 
 /-- **Primitivity is preserved under negation.**  If `w ⬝ᵥ v = 1` then
 `(-w) ⬝ᵥ (-v) = 1`, so `-v` is primitive with dual `-w`.  A sign flip is an

--- a/src/data/proofs/bezout-identity-oq-01-oq-02-oq-02/meta.json
+++ b/src/data/proofs/bezout-identity-oq-01-oq-02-oq-02/meta.json
@@ -23,8 +23,8 @@
     "dateAdded": "2026-07-09",
     "axiomCount": 0,
     "assumptions": "None beyond Mathlib's foundational axioms. Fully machine-checked (0 sorries, 0 axiom declarations, no structure-encoded assumptions, no native_decide). Note: in the local Docker sandbox the file elaborates cleanly across repeated runs but the .olean cache write intermittently aborts with SIGBUS (exit 135), an environment/IO issue independent of the proofs; CI produces the build artifact.",
-    "lineCount": 249,
-    "theoremCount": 14,
+    "lineCount": 301,
+    "theoremCount": 16,
     "definitionCount": 2,
     "originalContributions": [
       "IsPrimitive v := ∃ w, w ⬝ᵥ v = 1 — a coordinate-free, manifestly SLₙ(ℤ)-invariant notion of primitivity for integer vectors (absent from Mathlib)",
@@ -89,9 +89,9 @@
   ],
   "leanFile": {
     "namespace": "BezoutPrimitive",
-    "lineCount": 249,
+    "lineCount": 301,
     "axiomCount": 0,
-    "theoremCount": 14,
+    "theoremCount": 16,
     "definitionCount": 2,
     "path": "Proofs/BezoutIdentityOQ01OQ02OQ02.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

Extends the SLₙ(ℤ)-transitivity-on-primitive-vectors formalization in `BezoutIdentityOQ01OQ02OQ02.lean` with two machine-checked theorems that fill genuine gaps named in the file's own docstring.

### `isPrimitive_iff_forall_isUnit_of_dvd`
The **classical gcd characterization** of primitivity: `v` is primitive iff every common divisor of its entries is a unit (equivalently `gcd(v₁,…,vₙ) = 1`). The opening docstring explicitly names this notion ("gcd of the entries is 1") but the file only had the ideal form `isPrimitive_iff_span_eq_top`. 
- Forward: any common divisor `d` divides `∑ wᵢvᵢ = 1`, so `d` is a unit.
- Reverse: over ℤ (a principal ideal ring) the generator `g` of `Ideal.span (range v)` divides every entry, hence is a unit by hypothesis, forcing the ideal to be ⊤.

### `isPrimitive_of_isUnit_apply`
A **unit coordinate certifies primitivity**: if some `vᵢ = ±1` then `v` is primitive via the single dual `(vᵢ)⁻¹·eᵢ`. This is the *termination test* of the Euclidean descent — once a Bézout reduction drives one coordinate to a unit, reachability of `e₁` is already guaranteed. Sufficient-condition companion to `IsPrimitive.ne_zero`.

## Verification
Compiled with local `lean v4.26.0` against the pinned Mathlib oleans: **EXIT=0, no errors, no sorries, no new axioms**.

- File: 249 → 301 lines, 14 → 16 theorems, 0 axioms (unchanged)
- meta.json `leanFile` and `meta` blocks resynced

🤖 Generated with [Claude Code](https://claude.com/claude-code)