### PR TITLE
audit(erdos-893): re-verified CLEAN, bump tracker

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -17188,8 +17188,8 @@
     },
     "erdos-893": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T00:17:22Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-10T10:31:26Z",
       "result": "clean"
     },
     "erdos-894": {


### PR DESCRIPTION
## Gallery Integrity Audit — erdos-893

Re-audit of **Erdős Problem #893: Divisor Sum of Mersenne Numbers**.

### Verification against `proofs/Proofs/Erdos893Problem.lean`

| Check | meta.json | Lean source | ✓ |
|-------|-----------|-------------|---|
| lineCount | 332 | 332 | ✓ |
| sorries | 0 | 0 | ✓ |
| True stubs | — | 0 | ✓ |
| literal axioms | leanFile 1 | 1 (`kovac_luca_limsup_infinite`) | ✓ |
| axiomCount (all assumptions) | 2 | 1 axiom + `Lean.ofReduceBool` (16 native_decide) | ✓ |
| theoremCount | 35 | 35 (incl. `private theorem mersenne_injective`) | ✓ |
| defCount | 4 | 4 | ✓ |

### Narrative / claim risk
- `status: axiomatized` / `badge: axiom` — correct for an open problem whose core (Kovac–Luca 2025 limsup) is axiomatized.
- Not a Mathlib wrapper: main result comes from an explicit `axiom`, not a deep Mathlib theorem.
- Title/description correctly flag "Full divergence remains open"; no overclaiming.
- `assumptions` field correctly discloses both the literal axiom and `Lean.ofReduceBool` per the axiom-integrity policy.

**Result: CLEAN.** Only change is the tracker bump (auditCount 3→4, lastAudited).

---
Discovered during gallery integrity audit. No `loom:review-requested` (math-agent PR, merged directly by deployer).