### PR TITLE
research(erdos-1064-oq-03): divergent forward margin of the fiveTimes family [VERIFIED]

### DIFF
--- a/proofs/Proofs/EulerTotientOQ04OQ03.lean
+++ b/proofs/Proofs/EulerTotientOQ04OQ03.lean
@@ -3042,4 +3042,80 @@ theorem reversal_gap_primeTriple_ge {m : ℕ} (hm : 1 ≤ m)
   calc 2 ^ (k + 2) = 4 * 2 ^ k := by rw [pow_add]; ring
     _ ≤ (2 * m + 2) * 2 ^ k := by gcongr; omega
 
+-- ----------------------------------------------------------------------------
+-- Quantitative sharpening: a divergent FORWARD margin of the fiveTimes family
+-- ----------------------------------------------------------------------------
+-- `mem_ForwardSet_fiveTimes` shows the family `n = 5·(4m+1)·2^(k+1)` is forward
+-- (`φ(D(n)) < φ(n)`) whenever `4m+1` and `12m+5 = 3q+2` are prime (`m ≥ 3`).  That
+-- is purely qualitative.  The mirror of `reversal_gap_primeTriple` would be an
+-- EXACT gap, but the forward family lands on `14m+3` WITHOUT assuming it prime, so
+-- `φ(D(n)) = φ(14m+3)·2^k` has no closed form.  What the membership proof already
+-- exploits — the uniform bound `φ(14m+3) ≤ 14m+2` — does, however, give a clean
+-- LOWER bound on the margin:  `φ(n) − φ(D(n)) ≥ (2m−2)·2^k`.  This is the exact
+-- forward analogue of `reversal_gap_primeTriple_ge`: the forward margin is not
+-- merely positive but diverges without bound in both `m` and `k`, using no
+-- factorisation of the landing.
+
+/-- **Divergent forward margin of the fiveTimes family.**  For a seed
+    `a = 5·(4m+1)` with `4m+1` and `12m+5` (`= 3q+2`) both prime (`m ≥ 3`), the
+    forward inequality along `n = 5·(4m+1)·2^(k+1)` has margin at least
+    `(2m−2)·2^k`:  `φ(n) − φ(D(n)) ≥ (2m−2)·2^k`.  This sharpens the qualitative
+    membership `mem_ForwardSet_fiveTimes` (`φ(D(n)) < φ(n)`) to a lower bound that
+    grows without bound in both `m` and `k`.  Like the membership proof it needs
+    only the uniform totient bound `φ(14m+3) ≤ 14m+2` — no factorisation of the
+    landing `14m+3` is required. -/
+theorem forward_gap_fiveTimes_ge {m : ℕ} (hm : 3 ≤ m)
+    (hq : (4 * m + 1).Prime) (hb : (12 * m + 5).Prime) (k : ℕ) :
+    (2 * m - 2) * 2 ^ k ≤
+      Nat.totient (5 * (4 * m + 1) * 2 ^ (k + 1))
+        - Nat.totient (dblIter (5 * (4 * m + 1) * 2 ^ (k + 1))) := by
+  have hcop : Nat.Coprime 5 (4 * m + 1) :=
+    (Nat.coprime_primes (by norm_num) hq).mpr (by omega)
+  -- φ(a) = 16m  (a = 5·(4m+1))
+  have hφa : Nat.totient (5 * (4 * m + 1)) = 16 * m := by
+    rw [Nat.totient_mul hcop, show Nat.totient 5 = 4 from by decide,
+        Nat.totient_prime hq]; omega
+  -- φ(b) = 12m+4  (b = 12m+5 prime)
+  have hφb : Nat.totient (12 * m + 5) = 12 * m + 4 := by
+    rw [Nat.totient_prime hb]; omega
+  have ha_odd : Odd (5 * (4 * m + 1)) := Nat.odd_iff.mpr (by omega)
+  have hb_odd : Odd (12 * m + 5) := Nat.odd_iff.mpr (by omega)
+  have hp2 : Nat.totient (2 ^ (k + 1)) = 2 ^ k := by
+    rw [Nat.totient_prime_pow Nat.prime_two (Nat.succ_pos k)]; simp
+  -- φ(n) = φ(5·(4m+1))·2^k = 16m·2^k
+  have copa : Nat.Coprime (5 * (4 * m + 1)) (2 ^ (k + 1)) :=
+    ((Nat.prime_two.coprime_iff_not_dvd).mpr (by omega)).symm.pow_right (k + 1)
+  have hφn : Nat.totient (5 * (4 * m + 1) * 2 ^ (k + 1)) = 16 * m * 2 ^ k := by
+    rw [Nat.totient_mul copa, hp2, hφa]
+  -- transport: D(n) = (2a − φ(b))·2^k = (14m+3)·2^(k+1)
+  have hstep : 2 * (5 * (4 * m + 1)) - Nat.totient (5 * (4 * m + 1)) = 2 * (12 * m + 5) := by
+    rw [hφa]; omega
+  have hD : dblIter (5 * (4 * m + 1) * 2 ^ (k + 1)) = (14 * m + 3) * 2 ^ (k + 1) := by
+    rw [dblIter_transport ha_odd hb_odd hstep k, hφb,
+        show 2 * (5 * (4 * m + 1)) - (12 * m + 4) = (14 * m + 3) * 2 from by omega]
+    ring
+  -- φ(D(n)) = φ(14m+3)·2^k, with the uniform bound φ(14m+3) ≤ 14m+2
+  have cope : Nat.Coprime (14 * m + 3) (2 ^ (k + 1)) :=
+    ((Nat.prime_two.coprime_iff_not_dvd).mpr (by omega)).symm.pow_right (k + 1)
+  have hφD : Nat.totient (dblIter (5 * (4 * m + 1) * 2 ^ (k + 1)))
+      = Nat.totient (14 * m + 3) * 2 ^ k := by
+    rw [hD, Nat.totient_mul cope, hp2]
+  have hple : Nat.totient (14 * m + 3) ≤ 14 * m + 2 := by
+    have := Nat.totient_lt (14 * m + 3) (by omega); omega
+  rw [hφn, hφD, ← Nat.sub_mul]
+  exact mul_le_mul_right' (by omega) (2 ^ k)
+
+/-- **The forward margin is unbounded below by `2^(k+2)`.**  A direct corollary of
+    `forward_gap_fiveTimes_ge`: since `2m−2 ≥ 4` for `m ≥ 3`, the forward margin
+    `φ(n) − φ(D(n)) ≥ (2m−2)·2^k` is at least `2^(k+2)` along every fiveTimes
+    family, and grows with `m` — so the family is forward by an arbitrarily large
+    amount even at fixed `k`.  This mirrors `reversal_gap_primeTriple_ge`. -/
+theorem forward_gap_fiveTimes_ge_pow {m : ℕ} (hm : 3 ≤ m)
+    (hq : (4 * m + 1).Prime) (hb : (12 * m + 5).Prime) (k : ℕ) :
+    2 ^ (k + 2) ≤ Nat.totient (5 * (4 * m + 1) * 2 ^ (k + 1))
+      - Nat.totient (dblIter (5 * (4 * m + 1) * 2 ^ (k + 1))) := by
+  refine le_trans ?_ (forward_gap_fiveTimes_ge hm hq hb k)
+  calc 2 ^ (k + 2) = 4 * 2 ^ k := by rw [pow_add]; ring
+    _ ≤ (2 * m - 2) * 2 ^ k := by gcongr; omega
+
 end Erdos1064OQ03

--- a/src/data/research/problems/erdos-1064-oq-03.json
+++ b/src/data/research/problems/erdos-1064-oq-03.json
@@ -4,7 +4,7 @@
   "phase": "ACT",
   "status": "in-progress",
   "started": "2026-07-08T00:00:00.000Z",
-  "lastUpdate": "2026-07-09",
+  "lastUpdate": "2026-07-10",
   "path": "full",
   "parentId": "erdos-1064",
   "tier": "B",
@@ -35,7 +35,7 @@
     }
   ],
   "knowledge": {
-    "progressSummary": "Sharpened the necessary condition: reversal ⟹ 4∣φ(a) (reversal_seed_four_dvd_totient) is proven NOT sufficient via four_dvd_totient_not_sufficient — the Sophie-Germain equality seed a=15 has 4∣φ(15)=8 yet classifySeed 15=.eq (never reverses). VERIFIED axiom-free (full-file lake env lean exit 0). The elementary structural side (which seeds reverse; reversals confined to seedS=1; 4∣φ necessary-not-sufficient) is COMPLETE; sole open direction is the analytic density-1 forward ψ(x,y) statement (Mathlib gap). [2026-07-10 r3] Added four_dvd_totient_all_regimes: 4∣φ occurs in each of lt/eq/gt (a=21/15/13), the strongest form of necessary-not-sufficient — orthogonal to the trichotomy.",
+    "progressSummary": "Sharpened the necessary condition: reversal ⟹ 4∣φ(a) (reversal_seed_four_dvd_totient) is proven NOT sufficient via four_dvd_totient_not_sufficient — the Sophie-Germain equality seed a=15 has 4∣φ(15)=8 yet classifySeed 15=.eq (never reverses). VERIFIED axiom-free (full-file lake env lean exit 0). The elementary structural side (which seeds reverse; reversals confined to seedS=1; 4∣φ necessary-not-sufficient) is COMPLETE; sole open direction is the analytic density-1 forward ψ(x,y) statement (Mathlib gap). [2026-07-10 r3] Added four_dvd_totient_all_regimes: 4∣φ occurs in each of lt/eq/gt (a=21/15/13), the strongest form of necessary-not-sufficient — orthogonal to the trichotomy. [2026-07-10 r16] Added forward_gap_fiveTimes_ge / _ge_pow: the forward fiveTimes family now carries a divergent margin lower bound φ(n)−φ(D(n)) ≥ (2m−2)·2^k ≥ 2^(k+2), the forward twin of the reversal exact-gap sharpening — completing quantitative margins for both non-equality regimes of the k-free parametric families.",
     "builtItems": [
       "dblIter (EulerTotientOQ04OQ03.lean) — the double cototient iterate D(n) = n − φ(n − φ(n)), the object of OQ-03.",
       "dblIter_prime — collapse lemma: for EVERY prime p, D(p) = p − 1 exactly (φ(p)=p−1 ⟹ p−φ(p)=1 ⟹ φ(1)=1 ⟹ D(p)=p−1).",
@@ -104,7 +104,8 @@
       "classifySeed_175 + mem_ReversalSet_175 (EulerTotientOQ04OQ03.lean): the seed 175=5²·7 classified .lt (reversal) via classifySeed_val s=1,b=115,t=1,e=131; transport 2·175−φ(175)=230=115·2, 2·175−φ(115)=262=131·2, compare φ(175)=120<φ(131)=130. Plus helpers totient_25=20/115=88/175=120/131=130. Completes the four isolated docstring reversal seeds 21,55,129,175 as machine-verified.",
       "four_dvd_totient_not_sufficient : ∃ a, Odd a ∧ 3≤a ∧ 4∣φ(a) ∧ classifySeed a ≠ .lt — proves the necessary condition reversal_seed_four_dvd_totient is NOT sufficient, witnessed by the Sophie-Germain equality seed a=15=3·5 (φ(15)=8 so 4|φ, but classifySeed 15=.eq via classifySeed_sophieGermain_eq q=5). [VERIFIED axiom-free: full-file lake env lean exit 0, #print axioms=propext/Classical.choice/Quot.sound, decide not native_decide]",
       "four_dvd_totient_all_regimes (EulerTotientOQ04OQ03.lean) — capstone sharpening four_dvd_totient_not_sufficient: 4∣φ(a) is realised in ALL THREE trichotomy regimes (a=21 lt, a=15 eq, a=13 gt), so the necessary divisibility is fully orthogonal to the classification within the transport-admissible (seedS=1) regime. UNVERIFIED (docker infra down).",
-      "reversal_gap_primeTriple + reversal_gap_primeTriple_ge in EulerTotientOQ04OQ03.lean: exact gap (2m+2)*2^k and lower bound >= 2^(k+2), sharpening mem_ReversalSet_primeTriple (VERIFIED lean v4.26.0, PR #37463)"
+      "reversal_gap_primeTriple + reversal_gap_primeTriple_ge in EulerTotientOQ04OQ03.lean: exact gap (2m+2)*2^k and lower bound >= 2^(k+2), sharpening mem_ReversalSet_primeTriple (VERIFIED lean v4.26.0, PR #37463)",
+      "forward_gap_fiveTimes_ge + forward_gap_fiveTimes_ge_pow in EulerTotientOQ04OQ03.lean: divergent FORWARD margin of the fiveTimes family — for a=5·(4m+1) with 4m+1, 12m+5 prime (m≥3), φ(n)−φ(D(n)) ≥ (2m−2)·2^k ≥ 2^(k+2) along n=5·(4m+1)·2^(k+1). The forward analogue of reversal_gap_primeTriple_ge: sharpens the qualitative membership mem_ForwardSet_fiveTimes to a lower bound diverging in both m and k, using only the uniform bound φ(14m+3)≤14m+2 (no factorisation of the landing). [VERIFIED local-lean v4.26.0, exit 0]"
     ],
     "insights": [
       "On primes the higher iterate is trivial: D(p) = p − 1 for all primes p, because the first cototient step p − φ(p) = 1 and φ(1) = 1. So φ(D(p)) = φ(p−1), and φ(p−1) < p−1 = φ(p) for every p ≥ 3 (with equality only at p = 2). This gives the forward direction on an infinite explicit family with a one-line reduction to Nat.totient_lt — no density machinery needed.",


### PR DESCRIPTION
## Summary

Adds the **exact forward twin** of the reversal-gap sharpening (PR #37463) to `EulerTotientOQ04OQ03.lean` for Erdős #1064 OQ-03 (`D(n) = n − φ(n − φ(n))`, comparing `φ(n)` vs `φ(D(n))`).

`mem_ForwardSet_fiveTimes` proves the family `n = 5·(4m+1)·2^(k+1)` is **forward** (`φ(D(n)) < φ(n)`) whenever `4m+1` and `12m+5 = 3q+2` are prime (`m ≥ 3`) — but only *qualitatively*. Because the family lands on `14m+3` **without** assuming it prime, `φ(D(n)) = φ(14m+3)·2^k` has no closed form, so an exact gap (the reversal analogue) is unavailable.

The uniform bound `φ(14m+3) ≤ 14m+2` that the membership proof already exploits nonetheless yields a clean **divergent lower bound**:

```
φ(n) − φ(D(n)) ≥ (2m−2)·2^k ≥ 2^(k+2)
```

The margin grows without bound in both `m` and `k`, using **no factorisation** of the landing `14m+3`.

## New theorems

- `forward_gap_fiveTimes_ge` — `φ(n) − φ(D(n)) ≥ (2m−2)·2^k`
- `forward_gap_fiveTimes_ge_pow` — `φ(n) − φ(D(n)) ≥ 2^(k+2)` (corollary)

Together with `reversal_gap_primeTriple_ge`, both non-equality regimes of the *k*-free parametric families now carry quantitative margins (reversal: exact gap; forward: divergent lower bound; equality: exact zero).

## Verification

Local `lean` v4.26.0 typechecks the full 3120-line file: **exit 0, 0 errors** (only pre-existing deprecation warnings). Self-contained (imports only Mathlib). Marked `[VERIFIED]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)