### PR TITLE
research(cauchy-schwarz-integral-lp-duality-synthesis): seminorm-level restriction monotonicity [VERIFIED]

### DIFF
--- a/proofs/Proofs/CauchySchwarzIntegralLpDualitySynthesis.lean
+++ b/proofs/Proofs/CauchySchwarzIntegralLpDualitySynthesis.lean
@@ -268,6 +268,38 @@ theorem eLpNorm_rpow_restrict_mono {g : α → ℝ} {A B : Set α}
   rw [key]
   exact le_self_add
 
+/-- **Seminorm-level monotonicity of the Lᵠ-seminorm under set inclusion.**
+    For `A ⊆ B`, `eLpNorm g q (μ.restrict A) ≤ eLpNorm g q (μ.restrict B)`.
+
+    This is the *seminorm-level* statement of the monotonicity that
+    `eLpNorm_rpow_restrict_mono` proves only for the `q`-power. The docstrings of the
+    maximality reduction repeatedly assert it verbally ("enlarging the σ-finite support
+    set can only increase the representing function's norm"), yet the additive machinery
+    only delivers it on the `q`-power because the seminorm itself is merely subadditive
+    (Minkowski). It is nevertheless directly monotone in the *measure*, and hence in the
+    restriction set: it follows in one step from `eLpNorm_mono_measure` applied to
+    `μ.restrict A ≤ μ.restrict B` (`Measure.restrict_mono_set`), with **no** finiteness,
+    measurability, or `0 < q < ∞` hypothesis — strictly more general than the `q`-power
+    companion above, which needs `q ≠ 0`, `q ≠ ∞`, and measurability of `A`, `B`. -/
+theorem eLpNorm_restrict_mono {g : α → ℝ} {A B : Set α} (hAB : A ⊆ B) {q : ℝ≥0∞} :
+    eLpNorm g q (μ.restrict A) ≤ eLpNorm g q (μ.restrict B) :=
+  eLpNorm_mono_measure g (Measure.restrict_mono_set μ hAB)
+
+/-- **iUnion specialization** of `eLpNorm_restrict_mono` (step 2 ingredient).
+    Each piece of a countable family is dominated, in Lᵠ-seminorm, by the union:
+
+      `eLpNorm g q (μ.restrict (S n)) ≤ eLpNorm g q (μ.restrict (⋃ k, S k))`.
+
+    This is the exact bound the maximizing-sequence construction consumes: forming the
+    increasing union `T = ⋃ₙ Sₙ` can only *raise* each representer's norm, so replacing a
+    maximizing sequence by its union loses nothing and `‖g_T‖_q` attains the supremum
+    `c = ⨆_S ‖g_S‖_q`. It is the immediate corollary `Set.subset_iUnion S n` of the
+    monotonicity lemma above, and — like it — needs no disjointness, measurability, or
+    exponent hypotheses (unlike the additive `eLpNorm_rpow_restrict_iUnion`). -/
+theorem eLpNorm_restrict_le_iUnion {g : α → ℝ} {S : ℕ → Set α} (n : ℕ) {q : ℝ≥0∞} :
+    eLpNorm g q (μ.restrict (S n)) ≤ eLpNorm g q (μ.restrict (⋃ k, S k)) :=
+  eLpNorm_restrict_mono (Set.subset_iUnion S n)
+
 /-- **Step 1 of the maximality reduction — per-σ-finite-set representer.**
     For any measurable set `S` whose restriction `μ.restrict S` is σ-finite, the
     functional `φ` on `Lp ℝ p μ`, pulled back along the extension-by-zero embedding
@@ -395,6 +427,8 @@ theorem riesz_lp_surjective_general
 #print axioms RieszLpDualitySynthesis.eLpNorm_rpow_restrict_union
 #print axioms RieszLpDualitySynthesis.eLpNorm_rpow_restrict_iUnion
 #print axioms RieszLpDualitySynthesis.eLpNorm_rpow_restrict_mono
+#print axioms RieszLpDualitySynthesis.eLpNorm_restrict_mono
+#print axioms RieszLpDualitySynthesis.eLpNorm_restrict_le_iUnion
 #print axioms RieszLpDualitySynthesis.riesz_representer_on_sigmaFinite_set
 #print axioms RieszLpDualitySynthesis.riesz_lp_surjective_general
 

--- a/src/data/research/problems/cauchy-schwarz-integral-lp-duality-synthesis.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-lp-duality-synthesis.json
@@ -115,8 +115,8 @@
     {
       "path": "Proofs/CauchySchwarzIntegralLpDualitySynthesis.lean",
       "filename": "CauchySchwarzIntegralLpDualitySynthesis.lean",
-      "lineCount": 404,
-      "theoremCount": 8,
+      "lineCount": 437,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 9,
@@ -124,7 +124,7 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CauchySchwarzIntegralLpDualitySynthesis.lean"
     }
   ],
-  "lastUpdate": "2026-07-08",
+  "lastUpdate": "2026-07-10",
   "currentState": {
     "phase": "ACT",
     "since": "2026-07-02",


### PR DESCRIPTION
## Summary

Adds two **verified** theorems to `CauchySchwarzIntegralLpDualitySynthesis.lean`, closing the seminorm-vs-`q`-power gap that the file's own docstrings assert verbally but only formalize at the `q`-power level.

The existing `eLpNorm_rpow_restrict_mono` proves monotonicity of the **`q`-power** of the Lᵠ-seminorm under set inclusion, and several docstrings state the seminorm-level claim in words ("enlarging the σ-finite support set can only increase the representing function's norm"). This PR formalizes that claim directly.

### New theorems

- `eLpNorm_restrict_mono` — `A ⊆ B ⟹ eLpNorm g q (μ.restrict A) ≤ eLpNorm g q (μ.restrict B)`. Proved in one step from `eLpNorm_mono_measure` applied to `Measure.restrict_mono_set μ hAB`. **Strictly more general** than the `q`-power companion: no `q ≠ 0`, `q ≠ ∞`, or measurability hypotheses.
- `eLpNorm_restrict_le_iUnion` — the iUnion specialization (`Set.subset_iUnion`) consumed by the step-2 maximizing-sequence argument: each piece of a countable family is dominated in Lᵠ-seminorm by the union.

### Verification

Both proofs compile clean against **Mathlib v4.26.0** (standalone local-`lean` verification, imports only Mathlib primitives `eLpNorm_mono_measure` / `Measure.restrict_mono_set` / `Set.subset_iUnion`; foundational axioms only). They are inserted between existing kernel-verified theorems and do not touch the resolved `riesz_lp_surjective_general` reduction.

Meta: `lineCount` 404→437, `theoremCount` 8→10 (0 axioms, 0 real sorries — unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)