### PR TITLE
Fix: resync meta.theoremCount to canonical count (7 gallery entries)

### DIFF
--- a/src/data/proofs/de-moivre-oq-03/meta.json
+++ b/src/data/proofs/de-moivre-oq-03/meta.json
@@ -63,7 +63,7 @@
     "axiomCount": 0,
     "lineCount": 299,
     "assumptions": "0 axioms, 0 sorries. Fractional powers via Mathlib's cpow_def_of_ne_zero and exp/log. Original root enumeration and distinctness proofs.",
-    "theoremCount": 14,
+    "theoremCount": 15,
     "definitionCount": 2
   },
   "overview": {

--- a/src/data/proofs/descartes-rule-of-signs-oq-01-oq-03/meta.json
+++ b/src/data/proofs/descartes-rule-of-signs-oq-01-oq-03/meta.json
@@ -51,7 +51,7 @@
     "axiomCount": 1,
     "lineCount": 904,
     "assumptions": "The general direction (Sturm ⟹ Descartes for an arbitrary polynomial) is a reduction: it is conditional on a `SturmReduction p` bridge structure whose five fields package Sturm's exact positive-root count on (0, B] together with the three classical coefficient-comparison facts σ_p(0) ≤ V(p), Even(V(p) − σ_p(0)), and Even(σ_p(B)). Per the project's axiom-integrity policy these structure fields are mathematical assumptions (counted here as axiomCount 1; obtaining the data for a general p requires Sturm's theorem, axiomatized in the parent entry as sturm_exact_count_axiom, plus standard Sturm/Descartes comparison theory). No `axiom` declarations and no sorries appear in the file (leanFile.axiomCount = 0). The reduction theorems (upper_bound_core, parity_core, descartes_upper_bound_via_sturm, descartes_parity_via_sturm, descartes_rule_via_sturm) are fully machine-checked implications, and the Sturm half is validated UNCONDITIONALLY and axiom-free on linear polynomials X − c (c > 0), reusing the gallery's axiom-free Sturm computations. The linear-polynomial validation (X − c, c > 0) is now fully unconditional and axiom-free: the coefficient sign-change count V(X − c) = 1 is computed directly (linear_signChanges, via the new axiom-free countSignChanges_two), so the previously-assumed hypothesis hV has been discharged and linearReduction/linear_descartes_bound carry no standing assumption for the linear case.",
-    "theoremCount": 28,
+    "theoremCount": 33,
     "mathlib_version": "4.26.0",
     "definitionCount": 2
   },

--- a/src/data/proofs/erdos-490-oq-01/meta.json
+++ b/src/data/proofs/erdos-490-oq-01/meta.json
@@ -48,7 +48,7 @@
     "lineCount": 371,
     "assumptions": "1 axiom (a deep number-theoretic result): the Szemerédi upper bound maxProd(N) ≤ C·N²/log N. The optimal-example lower bound maxProd(N) ≥ c·N²/log N is now a proved theorem (`optimal_lower`, 0-axiom): it is transferred from the sibling file's verified `Erdos490.bound_is_optimal` via `maxProd_is_upper` (the maximum dominates the optimal example's product), with small cases N ∈ {2,3} handled by `maxProd_ge_self`. The existence/achievability of the maximum (`maxProd_exists`) is likewise a proved theorem — the optimization ranges over subsets of the finite set {1,...,N}, so the achievable-value set is a nonempty finite Finset of naturals and the maximum is its Finset.max'. Fully machine-checked apart from the single stated axiom (#print axioms of optimal_lower lists only propext/Classical.choice/Quot.sound — no sorryAx, no Lean.ofReduceBool).",
     "mathlib_version": "4.26.0",
-    "theoremCount": 13,
+    "theoremCount": 14,
     "definitionCount": 5
   },
   "sections": [

--- a/src/data/proofs/erdos-659/meta.json
+++ b/src/data/proofs/erdos-659/meta.json
@@ -51,7 +51,7 @@
     "axiomCount": 1,
     "lineCount": 575,
     "assumptions": "1 axiom: moreeOsburnWorks (the two deep geometric facts about the box-truncated lattice — the 4-point property and the Landau/x²+2y² distinct-distance bound m/√(log m); not available in Mathlib 4.26). The cardinality (2k+1)² is now a verified theorem (moreeOsburnLattice_card), not an assumption. 0 sorries.",
-    "theoremCount": 18,
+    "theoremCount": 28,
     "definitionCount": 9
   },
   "overview": {

--- a/src/data/proofs/erdos-729-oq-04/meta.json
+++ b/src/data/proofs/erdos-729-oq-04/meta.json
@@ -92,7 +92,7 @@
     "lineCount": 236,
     "assumptions": "0 axioms, 0 sorries. #print axioms reports only [propext, Classical.choice, Quot.sound] for sub_one_mul_padicValNat_multinomial, padicValNat_multinomial_eq_div, prime_dvd_multinomial_iff, and sub_one_mul_padicValNat_multinomial_fin — no sorryAx and no Lean.ofReduceBool. The identity holds for every prime p and an arbitrary finite index set (any k). Verified with Lean toolchain 4.26.0 against the pinned Mathlib.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 8,
+    "theoremCount": 10,
     "definitionCount": 0
   },
   "overview": {

--- a/src/data/proofs/inverse-galois-oq-03/meta.json
+++ b/src/data/proofs/inverse-galois-oq-03/meta.json
@@ -41,7 +41,7 @@
     ],
     "lineCount": 361,
     "mathlib_version": "4.26.0",
-    "theoremCount": 18,
+    "theoremCount": 19,
     "definitionCount": 0,
     "additionalFiles": []
   },

--- a/src/data/proofs/strong-goldbach-symmetric/meta.json
+++ b/src/data/proofs/strong-goldbach-symmetric/meta.json
@@ -21,7 +21,7 @@
     "axiomCount": 0,
     "assumptions": "None. The file is axiom-free (only the ordinary foundational axioms of Lean/Mathlib are used; `#print axioms` shows no `sorryAx`, no `Lean.ofReduceBool`). All examples use kernel `decide`, not `native_decide`. Note: this file does NOT prove the Strong Goldbach Conjecture, which remains open; it proves only that the conjecture is equivalent to its symmetric-prime-pair form.",
     "lineCount": 997,
-    "theoremCount": 30,
+    "theoremCount": 34,
     "definitionCount": 5,
     "originalContributions": [
       "sumTwoPrimes_iff_symmetric: for every m, IsSumOfTwoPrimes (2m) ↔ ∃ k < m, Prime (m−k) ∧ Prime (m+k) — the midpoint-symmetry equivalence, valid without any lower bound on m",


### PR DESCRIPTION
## Fix

Resync the stale `meta.theoremCount` field to the canonical theorem count for 7 gallery entries. In each case `leanFile.theoremCount` already equals the auditor's canonical count (`grep -c '^theorem \|^lemma '` on the source file), but the sibling `meta` block's `theoremCount` was left behind by prior research PRs that updated only the `leanFile` block.

| slug | meta.theoremCount | canonical (leanFile) |
|------|------|------|
| de-moivre-oq-03 | 14 → | 15 |
| descartes-rule-of-signs-oq-01-oq-03 | 28 → | 33 |
| erdos-490-oq-01 | 13 → | 14 |
| erdos-659 | 18 → | 28 |
| erdos-729-oq-04 | 8 → | 10 |
| inverse-galois-oq-03 | 18 → | 19 |
| strong-goldbach-symmetric | 30 → | 34 |

## Evidence

**Before**: `meta.theoremCount` disagreed with `leanFile.theoremCount`; the leanFile value matched a direct grep of the current `.lean` source.
**After**: both blocks agree and match the canonical count.

`lineCount` already agreed in both blocks for all 7 entries; only `theoremCount` had drifted. No open PR touches any of these Lean files or meta.json (verified), so the drift is genuinely uncovered. One-line diff per file.

---
Automated fix by lean-mechanic agent.