### PR TITLE
Enrich urysohns-lemma-oq-01: annotate uncovered abstract-route corollary

### DIFF
--- a/src/data/proofs/urysohns-lemma-oq-01/annotations.json
+++ b/src/data/proofs/urysohns-lemma-oq-01/annotations.json
@@ -53,11 +53,23 @@
     "range": { "startLine": 116, "endLine": 149 },
     "type": "theorem",
     "title": "Boundary Values and Range",
-    "content": "urysohnFn_eq_zero: = 0 on s (infDist_zero_of_mem makes the numerator vanish). urysohnFn_eq_one: = 1 on t (distance to t vanishes; distance to the closed nonempty s is positive off s, so numerator = denominator). urysohnFn_mem_Icc: valued in [0,1] (numerator nonnegative, bounded by the positive denominator). urysohn_metric bundles continuity + these into a C(X,ℝ) separator; urysohn_metric_of_normalSpace notes the abstract lemma also applies since every metric space is normal.",
+    "content": "urysohnFn_eq_zero: = 0 on s (infDist_zero_of_mem makes the numerator vanish). urysohnFn_eq_one: = 1 on t (distance to t vanishes; distance to the closed nonempty s is positive off s, so numerator = denominator). urysohnFn_mem_Icc: valued in [0,1] (numerator nonnegative, bounded by the positive denominator). urysohn_metric bundles continuity + these into a C(X,ℝ) separator.",
     "mathContext": "$f|_s=0$, $f|_t=1$, $f(x)\\in[0,1]$; bundled as $\\exists f\\in C(X,\\mathbb{R})$ separating $s,t$.",
     "significance": "key",
     "relatedConcepts": ["infDist_zero_of_mem", "boundary values", "bundled separator", "metric normality"],
     "prerequisites": ["distance to a set", "continuous maps"]
+  },
+  {
+    "id": "ann-metric-abstract-corollary",
+    "proofId": "urysohns-lemma-oq-01",
+    "range": { "startLine": 151, "endLine": 156 },
+    "type": "theorem",
+    "title": "The Abstract Route: Separation Without Nonemptiness",
+    "content": "urysohn_metric_of_normalSpace records that the abstract Urysohn lemma applies verbatim to any metric space: Mathlib's MetricSpace → NormalSpace instance discharges the normality hypothesis, so exists_continuous_zero_one_of_isClosed separates any two disjoint closed sets. Crucially it carries no nonemptiness hypotheses — unlike the explicit witness urysohn_metric, whose denominator-positivity proof (infDist_add_pos) needs s and t nonempty. This corollary therefore also covers the degenerate cases (either set empty) that the explicit construction cannot, trading the closed-form witness for the nonconstructive abstract one.",
+    "mathContext": "$X$ metric $\\Rightarrow X$ normal, so disjoint closed $s,t$ (either possibly empty) satisfy $\\exists f\\in C(X,\\mathbb{R})$, $f|_s=0,\\ f|_t=1,\\ 0\\le f\\le 1$.",
+    "significance": "supporting",
+    "relatedConcepts": ["MetricSpace normality", "exists_continuous_zero_one_of_isClosed", "hypothesis minimality", "degenerate cases"],
+    "prerequisites": ["normal spaces", "metric spaces"]
   },
   {
     "id": "ann-concrete",


### PR DESCRIPTION
## Summary

Closes an annotation coverage gap on `urysohns-lemma-oq-01` (quality 95, 0 prior passes).

The theorem `urysohn_metric_of_normalSpace` (lines 151–156) was **uncovered** by any annotation: the `ann-boundary-range` block (116–149) mentioned it in passing, but its range ended at 149, leaving the theorem itself outside every annotation range.

## Changes

- **Add** `ann-metric-abstract-corollary` (theorem, range 151–156) making the theorem's genuine mathematical point: the abstract Urysohn lemma applies to any metric space via the `MetricSpace → NormalSpace` instance and — unlike the explicit witness `urysohn_metric` (whose `infDist_add_pos` proof needs `s`, `t` nonempty) — carries **no nonemptiness hypotheses**, so it also covers the degenerate empty-set cases the explicit construction cannot.
- **Trim** the stray out-of-range mention of `urysohn_metric_of_normalSpace` from `ann-boundary-range`, so that annotation's content now matches its range.

Result: full annotation coverage of the file's theorems (only blank/structural lines remain uncovered). Annotation-only change; no meta counts affected. JSON validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)