### PR TITLE
Enrich arsinh-log-formula-oq-01-oq-01-oq-02: annotate the two FTC integrability side-conditions

### DIFF
--- a/src/data/proofs/arsinh-log-formula-oq-01-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/arsinh-log-formula-oq-01-oq-01-oq-02/annotations.json
@@ -70,6 +70,27 @@
     "mathContext": "$F(t)=\\tfrac12\\bigl(t\\sqrt{1+t^2}+\\operatorname{arsinh} t\\bigr)$ satisfies $F'(t)=\\sqrt{1+t^2}$; the algebra collapses via $\\dfrac{t^2+1}{\\sqrt{1+t^2}}=\\sqrt{1+t^2}$."
   },
   {
+    "id": "ann-intervalintegrable-sqrt",
+    "proofId": "arsinh-log-formula-oq-01-oq-01-oq-02",
+    "range": {
+      "startLine": 78,
+      "endLine": 81
+    },
+    "type": "tactic",
+    "title": "Interval-integrability of √(1+t²)",
+    "content": "intervalIntegral.integral_eq_sub_of_hasDerivAt has TWO hypotheses: the antiderivative relation (above) and that the integrand is interval-integrable on [0, b]. This lemma supplies the second: t ↦ √(1+t²) is continuous (dispatched by fun_prop), and continuous functions are interval-integrable on every [a, b] via Continuous.intervalIntegrable. Without it the FTC evaluation below cannot be invoked.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "IntervalIntegrable",
+      "Continuous.intervalIntegrable",
+      "fun_prop"
+    ],
+    "prerequisites": [
+      "continuity implies interval integrability"
+    ],
+    "mathContext": "$t\\mapsto\\sqrt{1+t^2}$ is continuous, hence interval-integrable on every $[a,b]$ — the side condition FTC needs alongside the antiderivative."
+  },
+  {
     "id": "ann-integral-arsinh-form",
     "proofId": "arsinh-log-formula-oq-01-oq-01-oq-02",
     "range": {
@@ -170,6 +191,27 @@
       "HasDerivAt in Mathlib"
     ],
     "mathContext": "$G(x)=\\tfrac12\\bigl(x+\\sinh x\\cosh x\\bigr)$ satisfies $G'(x)=\\cosh^2 x$; uses $(\\sinh x\\cosh x)'=\\cosh^2 x+\\sinh^2 x$ and $\\cosh^2 x=1+\\sinh^2 x$."
+  },
+  {
+    "id": "ann-intervalintegrable-coshsq",
+    "proofId": "arsinh-log-formula-oq-01-oq-01-oq-02",
+    "range": {
+      "startLine": 134,
+      "endLine": 137
+    },
+    "type": "tactic",
+    "title": "Interval-integrability of cosh²",
+    "content": "The companion integrability side-condition for the cosh² integral: x ↦ cosh²x is continuous (fun_prop), so Continuous.intervalIntegrable makes it interval-integrable on every [a, b]. This is the second hypothesis integral_eq_sub_of_hasDerivAt requires before the cosh² antiderivative can be turned into the definite integral below.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "IntervalIntegrable",
+      "Continuous.intervalIntegrable",
+      "fun_prop"
+    ],
+    "prerequisites": [
+      "continuity implies interval integrability"
+    ],
+    "mathContext": "$x\\mapsto\\cosh^2 x$ is continuous, hence interval-integrable on every $[a,b]$ — the side condition needed to apply FTC to the $\\cosh^2$ antiderivative."
   },
   {
     "id": "ann-integral-coshsq",


### PR DESCRIPTION
## Summary

On this saturated q96 catenary/catenoid entry the coverage scan flagged two **substantive theorems with no annotation** — the interval-integrability side-conditions each FTC evaluation depends on. They sat in the gaps *between* the "antiderivative" annotation and the "FTC evaluation" annotation on both the √(1+t²) and cosh² chains.

## The gap

`intervalIntegral.integral_eq_sub_of_hasDerivAt` needs **two** hypotheses: the antiderivative relation *and* that the integrand is interval-integrable on `[0, b]`. The file annotated the antiderivatives and the FTC evaluations but skipped the integrability bridges:

| lemma | lines | now annotated |
|-------|-------|---------------|
| `intervalIntegrable_sqrt_integrand` | L78-81 | `ann-intervalintegrable-sqrt` |
| `intervalIntegrable_cosh_sq` | L134-137 | `ann-intervalintegrable-coshsq` |

Both are `tactic`-type / `supporting` annotations explaining that the integrand is continuous (`fun_prop`) hence interval-integrable (`Continuous.intervalIntegrable`) — the missing FTC hypothesis.

## Change

- Annotation count **11 → 13**; the two previously-uncovered theorems now have accurate line ranges.
- Annotations-only; no Lean source, meta counts, or other files touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)