### PR TITLE
Fix: trim erdos-885 originalContributions to formalized items

### DIFF
--- a/src/data/proofs/erdos-885/meta.json
+++ b/src/data/proofs/erdos-885/meta.json
@@ -43,10 +43,7 @@
     "originalContributions": [
       "Definition of factor difference sets D(n)",
       "Definition of k-common sets",
-      "Axiomatization of the Erdős-Rosenfeld conjecture",
-      "Solved cases: k = 2, 3, 4",
       "Open case: k ≥ 5",
-      "Connection to divisor structure",
       "Verified examples for D(6) and D(12)"
     ],
     "axiomCount": 0,


### PR DESCRIPTION
## Fix

Trim `erdos-885` `meta.json` `originalContributions` to items actually backed by declarations in `Erdos885Problem.lean`.

## Evidence

`proofs/Proofs/Erdos885Problem.lean` (165 lines) declares exactly: 2 `def`s (`factorDifferenceSet`, `IsKCommonSet`) and 6 concrete membership `theorem`s; **0 axioms, 0 sorries**.

**Before**: `originalContributions` listed 3 items with no backing declaration —
- "Axiomatization of the Erdős-Rosenfeld conjecture" (axiomCount=0, no axiom exists — internally contradictory)
- "Solved cases: k = 2, 3, 4" (prose/docstring only)
- "Connection to divisor structure" (prose/docstring only)

**After**: retained the 4 items that reflect the Lean source — definition of D(n), definition of k-common sets, open case k ≥ 5, verified examples for D(6)/D(12).

Headline `status`/`axiomCount`/`sorries`/`assumptions` were already accurate and are unchanged. Metadata-only change; gallery data pipeline (enrichment + search-index + loading-facts) passes.

Closes #37489

---
Automated fix by lean-mechanic agent.