### PR TITLE
Enrich hall-marriage-theorem-oq-01-oq-01-oq-01-oq-01: complete Hall-lineage cross-references

### DIFF
--- a/src/data/proofs/hall-marriage-theorem-oq-01-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/hall-marriage-theorem-oq-01-oq-01-oq-01-oq-01/meta.json
@@ -66,6 +66,16 @@
       "proofId": "hall-marriage-theorem-oq-01",
       "relationship": "related",
       "description": "The root Hall biconditional. exists_sdr_of_regular instantiates its existence direction for the special case of k-regular families, where Hall's condition is automatic."
+    },
+    {
+      "proofId": "hall-marriage-theorem-oq-01-oq-01",
+      "relationship": "related",
+      "description": "The defect (Ore) form of Hall's theorem — the ultimate source of the deficiency calculus this entry consumes. Its deficiency machinery is packaged one level down by the parent hall-marriage-theorem-oq-01-oq-01-oq-01; here the k-regular case is the extreme deficiency-zero instance, where the defect form's matching saturates all of ι."
+    },
+    {
+      "proofId": "hall-marriage-theorem-oq-01-oq-02",
+      "relationship": "related",
+      "description": "König–Egerváry min–max duality (max matching = min vertex cover), a sibling consequence of the same defect-Hall calculus. The perfect matching produced here for a k-regular family is the case where every index is matched, so the minimum vertex cover has size #ι."
     }
   ],
   "sections": [


### PR DESCRIPTION
## Enrichment pass

The k-regular Hall entry was already at quality 95 with 10 fully-populated annotations (all with mathContext/significance/relatedConcepts/prerequisites), 5 keyInsights, a complete conclusion, and 4 sections covering the whole 127-line file. It meets every quality minimum, so per the diminishing-returns rule I did **not** inflate existing fields.

The one genuine gap was navigation: its cross-reference chain linked the direct parent and the root, but skipped two adjacent Hall-lineage entries. This pass adds them:

- **hall-marriage-theorem-oq-01-oq-01** (defect/Ore form) — the ultimate source of the deficiency calculus this entry consumes via its parent. The k-regular case is the deficiency-zero extreme of the defect form.
- **hall-marriage-theorem-oq-01-oq-02** (König–Egerváry min–max) — a sibling consequence of the same defect-Hall calculus.

crossReferences: 2 → 4 (cap 20). All four cross-ref target IDs verified to exist. meta.json stays well under the 60 KB cap (~16.6 KB). JSON validated; gallery data-generation, search-index, and loading-facts build steps all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)