### PR TITLE
Enrich pac-learning-bounds-wip-01: add cross-references to combinatorial foundations

### DIFF
--- a/src/data/proofs/pac-learning-bounds-wip-01/meta.json
+++ b/src/data/proofs/pac-learning-bounds-wip-01/meta.json
@@ -143,6 +143,21 @@
       "targetId": "pac-learning-bounds",
       "relationship": "extends",
       "description": "Replaces the parent's placeholder growthFunction := 0 with proper trace/shattering definitions and proves genuine VC-dimension foundations, advancing its open question on formalizing the learning-theoretic notions as real Lean types."
+    },
+    {
+      "targetId": "binomial-theorem",
+      "relationship": "foundational",
+      "description": "The growth ceiling |Π_H(S)| ≤ 2^|S| proved here (trace_card_le_pow) is exactly the total subset count ∑_{k=0}^{|S|} C(|S|,k) = 2^|S| — the coefficient-sum identity that entry derives from the Binomial Theorem. The powerset that bounds the trace is the disjoint union of the C(|S|,k)-sized layers the binomial coefficients count."
+    },
+    {
+      "targetId": "combinations-formula",
+      "relationship": "foundational",
+      "description": "The binomial coefficient C(n,k) counting k-element subsets is the elementary object behind the open Sauer–Shelah question: |Π_H(S)| ≤ Σ_{i≤d} C(|S|,i) refines the 2^|S| bound proved here to a polynomial in the VC dimension d. This entry establishes the trivial C(|S|,·)-summed ceiling; the sub-2^|S| improvement is the deeper result that formula supplies the counting for."
+    },
+    {
+      "targetId": "lovasz-local-lemma",
+      "relationship": "thematic",
+      "description": "A companion pillar of probabilistic combinatorics. VC dimension controls uniform convergence and PAC sample complexity — the analytic payoff of the |S| ≤ log₂|H| bound proved here — while the Lovász Local Lemma supplies existence guarantees under sparse dependence; both are core tools of the extremal/probabilistic method underlying learning theory."
     }
   ],
   "references": [


### PR DESCRIPTION
## Enrichment pass — pac-learning-bounds-wip-01

This VC-dimension foundations entry was already deep in annotations (12, all with mathContext/significance/relatedConcepts), overview, sections, and conclusion, but had only a single crossReference (to its parent). This pass adds three genuine, tightly-motivated cross-links so a reader can reach the combinatorial machinery the entry rests on:

- **binomial-theorem** (`foundational`) — the growth ceiling |Π_H(S)| ≤ 2^|S| (`trace_card_le_pow`) *is* the coefficient-sum identity ∑ C(|S|,k) = 2^|S|.
- **combinations-formula** (`foundational`) — binomial coefficients C(n,k) are the counting object behind the open Sauer–Shelah question |Π_H(S)| ≤ Σ_{i≤d} C(|S|,i) listed in the entry's own open questions.
- **lovasz-local-lemma** (`thematic`) — a companion pillar of the probabilistic/extremal method underlying PAC sample-complexity and uniform convergence.

crossReferences: 1 → 4 (well under the 20 cap). meta.json 13.2 KB → 14.6 KB (under the 60 KB cap). No existing content removed.

### Verification
- All three targetIds verified to exist in the gallery.
- JSON validated; `pnpm build` passes (bundle budget OK).