### PR TITLE
Fix: clear 2 stale audit-tracker issues-found flags

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -400,10 +400,11 @@
       "result": "clean"
     },
     "algebraic-numbers-countable-oq-02": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-07-09T01:43:39Z",
-      "result": "issues-found"
+      "lastAudited": "2026-07-11T05:31:34Z",
+      "result": "clean",
+      "note": "Stale issues-found flag with empty issues[] cleared by mechanic: Lean source matches meta exactly (205L/11thm/0sorry/0axiom), status verified/badge mathlib correct for the Mathlib cardinality bridge, assumptions honestly disclose the bridge. No actionable defect."
     },
     "algebraic-numbers-countable-oq-02-oq-02": {
       "auditCount": 3,
@@ -23882,10 +23883,11 @@
     },
     "prob-method-lovasz-local": {
       "agentId": "auditor-agent",
-      "auditCount": 4,
-      "lastAudited": "2026-07-09T23:00:00Z",
-      "result": "issues-found",
-      "issue": 36397
+      "auditCount": 5,
+      "lastAudited": "2026-07-11T05:31:34Z",
+      "result": "clean",
+      "issue": 36397,
+      "note": "Stale issues-found flag cleared by mechanic: underlying integrity issue gh#36397 was CLOSED/remediated 2026-07-09; title honestly qualified \"Algebraic Core & Threshold Bounds\", 471L/0sorry matches meta. No actionable defect."
     },
     "prob-method-lovasz-local-oq-02": {
       "auditCount": 1,
@@ -29783,5 +29785,5 @@
     }
   },
   "version": 1,
-  "lastUpdated": "2026-07-10T18:20:00Z"
+  "lastUpdated": "2026-07-11T05:31:34Z"
 }


### PR DESCRIPTION
## Fix

Clears the last 2 `issues-found` flags in `audit-tracker.json`. Both point to content that is already clean/remediated — the flags are stale bookkeeping, not open defects.

## Evidence

**Before**: 2 entries with `result: "issues-found"`.

- `algebraic-numbers-countable-oq-02` — empty `issues[]` (no described defect). Lean source matches meta exactly: 205 lines, 11 theorems, 0 sorries, 0 axioms. `status: verified` / `badge: mathlib` is correct for the Mathlib cardinality bridge (`Cardinal.mk_real` / `Cardinal.aleph0_lt_continuum`), and `assumptions` honestly discloses the bridge.
- `prob-method-lovasz-local` — its integrity issue **gh#36397 is CLOSED** (remediated 2026-07-09T23:08:21Z). Title is honestly qualified "Lovasz Local Lemma (Algebraic Core & Threshold Bounds)"; 471 lines / 0 sorries matches meta.

**After**: both `result: "clean"`, `auditCount` bumped, note explaining the clearance. Tracker now has **0 `issues-found`** (4511 clean + 300 issues-fixed).

Minimal diff: only the 2 entries + `lastUpdated` (verified JSON valid).

---
Automated fix by lean-mechanic agent.