### PR TITLE
Research: cantor-diagonalization-oq-06-oq-01 — ORIENT (verifiable diagonalReal construction plan)

### DIFF
--- a/src/data/research/problems/cantor-diagonalization-oq-06-oq-01.json
+++ b/src/data/research/problems/cantor-diagonalization-oq-06-oq-01.json
@@ -1,7 +1,7 @@
 {
   "slug": "cantor-diagonalization-oq-06-oq-01",
   "title": "Explicit Diagonal Real Missing From Any Listed Enumeration",
-  "phase": "OBSERVE",
+  "phase": "ORIENT",
   "status": "available",
   "tier": "B",
   "path": "full",
@@ -23,12 +23,14 @@
     "goal": "Define the witness x as an explicit function of the enumeration f (e.g. a bit sequence b n = if nthDigit (f n) n = 0 then 1 else 0 summed into [0,1]) and prove x ≠ f n for every n by exhibiting the differing digit, with no appeal to Cardinal.not_countable_real or #ℝ = 𝔠."
   },
   "currentState": {
-    "phase": "OBSERVE",
+    "phase": "ORIENT",
     "since": "2026-07-09T16:43:20-07:00",
-    "iteration": 1,
-    "focus": "Initial problem understanding. Read problem.md and gather context.",
-    "blockers": [],
-    "nextAction": "Read problem.md thoroughly and acquire full context.",
+    "iteration": 2,
+    "focus": "Approach identified: explicit diagonalReal via floor/emod decimal digits (in {1,2}) with geometric tail bound. Verifiable BUILD plan recorded; ~150-250 lines.",
+    "blockers": [
+      "Verification environment: docker lean image absent (docker system df shows 0 images) and disk ~121Mi; no build/verify path this session."
+    ],
+    "nextAction": "Execute the BUILD in a working docker env per knowledge.nextSteps: define digit/db/diagonalReal, prove crux digit(diagonalReal f) n = db f n, then diagonalReal_ne.",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -36,11 +38,22 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
+    "progressSummary": "ORIENT (researcher-11, 2026-07-10): Designed a COMPLETE verifiable construction for the explicit diagonalReal:(N->R)->R with x!=f n by decimal-digit comparison — no cardinality, no Cardinal.not_countable. Digits restricted to {1,2} sidestep the 0.999...=1.000... expansion-uniqueness obstruction; digit defined via floor/emod; disagreement proven through a geometric 2/9<1 tail bound. NO Lean written or verified this session — environment hard-blocked (docker lean image absent [docker system df: 0 images], disk 121Mi, worktree reaped). Ready-to-execute BUILD plan with exact Mathlib lemma names recorded in nextSteps. NOT yet proven.",
     "builtItems": [],
-    "insights": [],
-    "mathlibGaps": [],
-    "nextSteps": []
+    "insights": [
+      "Parent CantorDiagonalization.lean (176L, 0 sorry) proves the diagonal only over BinarySeq = N->Bool via fun n => !(f n n); it never touches actual reals. Its remark (lines 102-107) that binary sequences correspond to reals in [0,1] is exactly the UNPROVEN bridge — supplying it is the genuine open content of this OQ.",
+      "Complete construction designed: digit r n := floor(r*10^(n+1)) % 10 (Z, in [0,10) by Int.emod_nonneg / Int.emod_lt_of_pos); db f n := if digit (f n) n = 1 then 2 else 1 (in {1,2}, and db f n != digit (f n) n by the two-case check); diagonalReal f := tsum n, (db f n : R)/10^(n+1). Restricting produced digits to {1,2} makes the expansion unambiguous, killing the 0.999...=1.000... non-uniqueness problem that makes a naive digit argument false.",
+      "Crux lemma digit (diagonalReal f) n = db f n via head/tail split of x*10^(n+1) = A + T: A := sum_{k<=n} db_k*10^(n-k) in Z; tail T := sum_{k>n} db_k*10^(n-k) has 0 <= T <= 2*sum_{j>=1}10^(-j) = 2/9 < 1, so floor(x*10^(n+1)) = A; and A % 10 = db_n because A = db_n + 10*B with Int.add_mul_emod_self_left. Then x = f n => digit x n = digit (f n) n, contradicting digit x n = db_n != digit (f n) n. Construction is self-consistent and cardinality-free."
+    ],
+    "mathlibGaps": [
+      "Mathlib has no ready-made n-th decimal digit of a real number API (Nat.digits is naturals-only). Must define digit r n := floor(r*10^(n+1)) % 10 locally from Int.floor + Int.emod. This is a ~5-line local definition, not a blocker."
+    ],
+    "nextSteps": [
+      "Summability: db f bounded by 2 => sum (db_k)*10^(-(k+1)) summable by comparison with summable_geometric_of_lt_one (ratio 1/10) via Summable.of_nonneg_of_le. Import Mathlib.Analysis.SpecificLimits.Basic.",
+      "Head/tail split: sum_add_tsum_nat_add (k:=n+1) writes diagonalReal f = sum_{i<n+1} + tail; multiply by (10:R)^(n+1) using tsum_mul_left; head -> integer A, tail T bounded above via tsum_geometric_of_lt_one (=2/9<1).",
+      "Floor step: Int.floor_add_int (or Int.floor_intCast_add) plus Int.floor_eq_zero_iff (0<=T<1 => floor T=0) give floor(x*10^(n+1)) = A. Digit-mod step: Int.add_mul_emod_self_left gives (db_n + 10*B) % 10 = db_n % 10 = db_n for db_n in {1,2}.",
+      "Final assembly: diagonalReal_ne (f) (n): x = f n => congrArg (fun r => digit r n) yields digit x n = digit (f n) n, contradicting the crux lemma (digit x n = db_n) and db_n != digit (f n) n. Then cantor_via_diagonalReal: not (Surjective f) follows. Est. 150-250 lines, self-contained; classified BUILD (<500 lines). Execute in a WORKING docker env — this session was verification-blocked."
+    ]
   },
   "tags": [
     "set-theory",


### PR DESCRIPTION
## Summary

Advances **cantor-diagonalization-oq-06-oq-01** ("Explicit Diagonal Real Missing From Any Listed Enumeration") from OBSERVE to **ORIENT** with a complete, verifiable proof design.

The parent `CantorDiagonalization.lean` proves the diagonal only over `BinarySeq = ℕ→Bool` (flip-the-bit); it never constructs an actual real. Its remark that "binary sequences correspond to reals in [0,1]" (lines 102–107) is precisely the unproven bridge this OQ must supply.

## The designed construction (cardinality-free)

- `digit r n := ⌊r * 10^(n+1)⌋ % 10`  (ℤ, in [0,10))
- `db f n := if digit (f n) n = 1 then 2 else 1`  (∈ {1,2}, and `≠ digit (f n) n`)
- `diagonalReal f := ∑' n, (db f n : ℝ) / 10^(n+1)`

Restricting produced digits to **{1,2}** makes the expansion unambiguous, sidestepping the `0.999… = 1.000…` non-uniqueness that makes a naïve digit argument false.

**Crux:** `digit (diagonalReal f) n = db f n` via a head/tail split of `x·10^(n+1) = A + T`, where `A ∈ ℤ` and the tail satisfies `0 ≤ T ≤ 2·∑_{j≥1}10^(-j) = 2/9 < 1`, so `⌊x·10^(n+1)⌋ = A` and `A % 10 = db_n` (`Int.add_mul_emod_self_left`). Then `x = f n ⇒ digit x n = digit (f n) n`, contradicting `db_n ≠ digit (f n) n`.

Exact Mathlib lemma toolkit (summability, `sum_add_tsum_nat_add`, `tsum_mul_left`, `tsum_geometric_of_lt_one`, `Int.floor_add_int`, `Int.floor_eq_zero_iff`) is recorded in `knowledge.nextSteps`. Classified **BUILD** (~150–250 lines, <500).

## Honesty note

Data-only change (problem knowledge JSON). **No Lean was written or verified** this session — the environment was hard-blocked (docker lean image absent per `docker system df` showing 0 images; disk ~121Mi; worktree reaped mid-commit). This PR records the ready-to-execute plan so the BUILD can be done directly in a working docker env.

🤖 Generated with [Claude Code](https://claude.com/claude-code)