### PR TITLE
Enrich pac-learning-bounds-wip-01: add Shelah 1972 and BEHW 1989 references

### DIFF
--- a/src/data/proofs/pac-learning-bounds-wip-01/meta.json
+++ b/src/data/proofs/pac-learning-bounds-wip-01/meta.json
@@ -174,6 +174,20 @@
       "year": "1972",
       "venue": "J. Combin. Theory Ser. A",
       "note": "The Sauer–Shelah growth bound (polynomial in the VC dimension) — the deeper result this entry's foundations support"
+    },
+    {
+      "authors": "S. Shelah",
+      "title": "A combinatorial problem; stability and order for models and theories in infinitary languages",
+      "year": "1972",
+      "venue": "Pacific J. Math.",
+      "note": "The independent second half of the Sauer–Shelah lemma, arising from model-theoretic stability; the growth-bound counterpart to Sauer (1972) that the entry's open question targets"
+    },
+    {
+      "authors": "A. Blumer, A. Ehrenfeucht, D. Haussler, M. K. Warmuth",
+      "title": "Learnability and the Vapnik–Chervonenkis dimension",
+      "year": "1989",
+      "venue": "J. ACM",
+      "note": "Established that finite VC dimension characterises PAC-learnability via the Sauer–Shelah growth bound — the learning-theoretic payoff the parent entry axiomatizes and the |S| ≤ log₂|H| bound here anticipates"
     }
   ],
   "sorries": [],


### PR DESCRIPTION
## Enrichment pass — pac-learning-bounds-wip-01

The VC-dimension foundations entry named the "Sauer–Shelah" lemma and discussed PAC-learnability but cited only Vapnik–Chervonenkis (1971) and Sauer (1972). This adds the two canonical missing references:

- **Shelah (1972)**, *A combinatorial problem; stability and order…* (Pacific J. Math.) — the independent model-theoretic half of the Sauer–Shelah lemma.
- **Blumer, Ehrenfeucht, Haussler, Warmuth (1989)**, *Learnability and the VC dimension* (J. ACM) — established that finite VC dimension characterises PAC-learnability, the learning-theoretic payoff the parent entry axiomatizes.

Curation, not accretion: `meta.json` stays at 15.4 KB (well under the 60 KB cap); `references` grows 2→4 (cap 25). No prose inflation; the entry already met all annotation/section/insight minimums.

🤖 Generated with [Claude Code](https://claude.com/claude-code)