### PR TITLE
Enrich abel-ruffini-galois-extensions-oq-01: add Ruffini 1799 reference

### DIFF
--- a/src/data/proofs/abel-ruffini-galois-extensions-oq-01/meta.json
+++ b/src/data/proofs/abel-ruffini-galois-extensions-oq-01/meta.json
@@ -191,10 +191,16 @@
   ],
   "references": [
     {
+      "authors": "Ruffini, P.",
+      "title": "Teoria generale delle equazioni, in cui si dimostra impossibile la soluzione algebraica delle equazioni generali di grado superiore al quarto",
+      "year": "1799",
+      "note": "The first (incomplete) proof that the general quintic is not solvable by radicals, giving the theorem its 'Abel–Ruffini' name; the gap was closed by Abel (1824)."
+    },
+    {
       "authors": "Abel, N. H.",
       "title": "Mémoire sur les équations algébriques où l'on démontre l'impossibilité de la résolution de l'équation générale du cinquième degré",
       "year": "1824",
-      "note": "The original proof that the general quintic is not solvable by radicals."
+      "note": "The original complete proof that the general quintic is not solvable by radicals."
     },
     {
       "authors": "Galois, É.",


### PR DESCRIPTION
## Enrichment pass — abel-ruffini-galois-extensions-oq-01

The theorem is universally known as **Abel–Ruffini**, but the entry's references cited only Abel (1824), Galois (1846), Browning (2021), and Dummit–Foote. This adds the missing eponym:

- **Ruffini (1799)**, *Teoria generale delle equazioni…* — the first (incomplete) proof that the general quintic is not solvable by radicals, which gives the theorem half its name. Abel (1824) closed the gap.

Curation, not accretion: `meta.json` stays at 24 KB (well under the 60 KB cap); `references` grows 4→5 (cap 25). The entry already met all annotation (9, full 1–272 coverage), section, keyInsight, and openQuestion minimums — no prose was inflated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)