### PR TITLE
Add gallery entry: Cycle Double Cover Conjecture (resolved 2026, external result)

### DIFF
--- a/proofs/Proofs/CycleDoubleCover.lean
+++ b/proofs/Proofs/CycleDoubleCover.lean
@@ -1,0 +1,157 @@
+import Mathlib.Data.ZMod.Basic
+import Mathlib.Data.Fintype.Card
+import Mathlib.Tactic
+
+/-
+# The Cycle Double Cover Conjecture (Szekeres 1973 / Seymour 1979)
+
+## Statement
+
+Every finite bridgeless loopless multigraph has a cycle double cover: a finite
+multiset of cycles such that every edge lies in exactly two members, counted
+with multiplicity.
+
+## Status: RESOLVED (2026), axiomatized here pending port
+
+On 2026-07-10 OpenAI announced a proof produced by GPT-5.6 Sol Ultra, together
+with a complete Lean 4 formalization:
+
+- Proof PDF: https://cdn.openai.com/pdf/04d1d1e4-bc75-476a-97cf-49055cd98d31/cdc_proof.pdf
+- Lean source: https://github.com/openai/cdc-lean (Lean v4.31.0, Mathlib 9a9483a9)
+
+The upstream Lean proof was INDEPENDENTLY VERIFIED for this gallery on
+2026-07-11 (see issue #37504): `lake build` succeeded (1727 jobs) on the pinned
+toolchain, and `#print axioms` on the final theorem
+`CDCLean.cycleDoubleCover_of_bridgeless` reports exactly
+`[propext, Classical.choice, Quot.sound]` — no sorries, no custom axioms, no
+`native_decide`. The statement was checked to be the genuine, unconditional
+conjecture (this file mirrors those definitions).
+
+The proof route: Jaeger–Kilpatrick's eight-flow theorem produces a nowhere-zero
+`(ZMod 2)³`-flow on a cubic expansion; a new labeling/linear-algebra argument
+converts that flow into an exact even double cover, which projects back and
+decomposes into cycles. Classically an 8-flow was only known to yield a cycle
+QUADRUPLE cover; the 8-flow → double-cover conversion is the new content.
+
+This file ports the *statement* (definitions follow upstream `CDCLean` exactly,
+modulo naming) and axiomatizes the theorem until the 7,134-line proof is ported
+to our Mathlib pin. The axiom is the upstream kernel-checked theorem.
+
+## Definitions (mirroring openai/cdc-lean)
+
+- `FiniteGraph V E`: finite loopless multigraph — edges are primitive objects
+  with two distinct ends; parallel edges are distinct.
+- `Bridgeless`: no vertex subset has an edge cut of cardinality exactly one.
+- `Cycle`: a nonempty inclusion-minimal even edge set — the graphic-matroid
+  characterization of a circuit (two parallel edges form a 2-cycle).
+- `CycleDoubleCover`: a list (multiset) of cycles with every edge in exactly
+  two members.
+-/
+
+namespace CycleDoubleCover
+
+open Finset
+
+/-- The field with two elements, used for parity bookkeeping. -/
+abbrev F₂ := ZMod 2
+
+/-- A finite loopless multigraph: each edge is a primitive object with two
+numbered, distinct ends. Parallel edges are allowed and distinct. -/
+structure FiniteGraph (V E : Type*) [Fintype V] [Fintype E] where
+  endAt : E → Fin 2 → V
+  loopless : ∀ e, endAt e 0 ≠ endAt e 1
+
+namespace FiniteGraph
+
+variable {V E : Type*} [Fintype V] [Fintype E] [DecidableEq V] [DecidableEq E]
+  (G : FiniteGraph V E)
+
+/-- Whether edge `e` crosses the vertex subset `S`. -/
+def Crosses (S : Finset V) (e : E) : Prop :=
+  (G.endAt e 0 ∈ S) ≠ (G.endAt e 1 ∈ S)
+
+/-- The cut of a vertex subset: the edges crossing it. -/
+noncomputable def cut (S : Finset V) : Finset E := by
+  classical
+  exact Finset.univ.filter (G.Crosses S)
+
+/-- Bridgeless, by the cut characterization: no cut consists of exactly one
+edge. Connectivity is NOT assumed; disconnected graphs are permitted. -/
+def Bridgeless : Prop := ∀ S : Finset V, (G.cut S).card ≠ 1
+
+/-- The incidence indicator of an edge at a vertex over `F₂`, counting both
+edge ends. -/
+def edgeIncidence (v : V) (e : E) : F₂ :=
+  (if G.endAt e 0 = v then 1 else 0) + (if G.endAt e 1 = v then 1 else 0)
+
+/-- An edge set is even when every vertex meets it an even number of times. -/
+def IsEvenEdgeSet (F : Finset E) : Prop :=
+  ∀ v : V, ∑ e ∈ F, G.edgeIncidence v e = 0
+
+/-- A multigraph cycle: a nonempty inclusion-minimal even edge set. For
+loopless multigraphs these are exactly the circuits (connected 2-regular
+submultigraphs); two distinct parallel edges form a legitimate 2-cycle. -/
+structure Cycle where
+  edges : Finset E
+  nonempty : edges.Nonempty
+  even : G.IsEvenEdgeSet edges
+  minimal : ∀ D : Finset E, D.Nonempty → D ⊆ edges → G.IsEvenEdgeSet D → D = edges
+
+/-- A cycle double cover: a finite multiset of cycles (a list, so repeated
+cycles are retained) in which every edge occurs in exactly two members. -/
+structure CycleDoubleCover where
+  cycles : List G.Cycle
+  coveredTwice : ∀ e : E, (cycles.filter fun C => e ∈ C.edges).length = 2
+
+end FiniteGraph
+
+-- ============================================================
+-- The theorem (axiomatized; kernel-checked upstream, see header)
+-- ============================================================
+
+/-- **The Cycle Double Cover theorem** (Szekeres–Seymour conjecture, resolved
+2026): every finite bridgeless loopless multigraph has a cycle double cover.
+
+Axiomatized pending a port of the upstream proof. The upstream artifact
+(`CDCLean.cycleDoubleCover_of_bridgeless` in openai/cdc-lean) was independently
+rebuilt and kernel-audited for this gallery on 2026-07-11; it depends only on
+`propext`, `Classical.choice`, and `Quot.sound`. -/
+axiom cycleDoubleCover_of_bridgeless
+    {V E : Type*} [Fintype V] [Fintype E] [DecidableEq V] [DecidableEq E]
+    (G : FiniteGraph V E) (hb : G.Bridgeless) :
+    Nonempty G.CycleDoubleCover
+
+-- ============================================================
+-- Elementary facts proved directly (no axiom dependence)
+-- ============================================================
+
+section Elementary
+
+variable {V E : Type*} [Fintype V] [Fintype E] [DecidableEq V] [DecidableEq E]
+  (G : FiniteGraph V E)
+
+/-- An edgeless graph has the empty cycle double cover, directly. -/
+theorem edgeless_cdc [IsEmpty E] : Nonempty G.CycleDoubleCover :=
+  ⟨⟨[], fun e => isEmptyElim e⟩⟩
+
+/-- A single edge is never an even edge set: its two ends are distinct, so it
+meets each of them exactly once. Hence no cycle is a singleton — the smallest
+cycles are parallel-edge 2-cycles. -/
+theorem singleton_not_even (e : E) : ¬ G.IsEvenEdgeSet {e} := by
+  intro h
+  have he := h (G.endAt e 0)
+  have hne : G.endAt e 1 ≠ G.endAt e 0 := (G.loopless e).symm
+  simp [FiniteGraph.edgeIncidence, hne] at he
+
+/-- Every cycle has at least two edges. -/
+theorem cycle_card_ge_two (C : G.Cycle) : 2 ≤ C.edges.card := by
+  by_contra hlt
+  push_neg at hlt
+  interval_cases h : C.edges.card
+  · exact absurd (Finset.card_eq_zero.mp h) C.nonempty.ne_empty
+  · obtain ⟨e, he⟩ := Finset.card_eq_one.mp h
+    exact singleton_not_even G e (he ▸ C.even)
+
+end Elementary
+
+end CycleDoubleCover

--- a/src/data/proofs/cycle-double-cover/annotations.json
+++ b/src/data/proofs/cycle-double-cover/annotations.json
@@ -1,0 +1,65 @@
+[
+  {
+    "id": "ann-cdc-header",
+    "proofId": "cycle-double-cover",
+    "range": { "startLine": 1, "endLine": 49 },
+    "type": "concept",
+    "title": "A 50-Year Conjecture, Resolved and Kernel-Checked",
+    "content": "Header documenting the Cycle Double Cover Conjecture (Szekeres 1973, Seymour 1979) and its 2026 resolution. OpenAI's GPT-5.6 Sol Ultra produced both an informal proof and a complete Lean 4 formalization (openai/cdc-lean). The upstream artifact was independently rebuilt and audited for this gallery on 2026-07-11: the pinned-toolchain build succeeds (1,727 jobs) and `#print axioms` on the final theorem reports only `propext`, `Classical.choice`, `Quot.sound` — Lean's three standard foundational axioms. Verification trail: issue #37504.",
+    "mathContext": "A cycle double cover of a graph $G$ is a multiset $\\mathcal{C}$ of cycles of $G$ such that every edge of $G$ lies in exactly two members of $\\mathcal{C}$. The conjecture asserts every finite bridgeless (loopless, multi-)graph has one. Bridgelessness is necessary: a bridge lies on no cycle at all."
+  },
+  {
+    "id": "ann-cdc-finitegraph",
+    "proofId": "cycle-double-cover",
+    "range": { "startLine": 56, "endLine": 62 },
+    "type": "definition",
+    "title": "Finite Loopless Multigraph",
+    "content": "Edges are primitive objects: `endAt e : Fin 2 → V` gives the two ends of edge `e`, and `loopless` requires them to be distinct. Because edges are objects rather than vertex pairs, parallel edges are automatically distinct — the correct setting for CDC, where two parallel edges form a legitimate cycle of length two. This mirrors upstream `CDCLean.FiniteGraph` exactly.",
+    "mathContext": "Looplessness is the standard WLOG convention: a loop is never a bridge, and loops can be handled trivially, so the substantive statement is for loopless multigraphs."
+  },
+  {
+    "id": "ann-cdc-bridgeless",
+    "proofId": "cycle-double-cover",
+    "range": { "startLine": 68, "endLine": 80 },
+    "type": "definition",
+    "title": "Bridgelessness via Edge Cuts",
+    "content": "A bridge is characterized cut-theoretically: `Bridgeless` says no vertex subset $S$ has exactly one edge crossing it. This is equivalent to the usual definition (an edge whose deletion disconnects its component) but is stated without any connectivity apparatus — disconnected graphs are covered by the theorem, as required by the conjecture's strongest form.",
+    "mathContext": "For $S \\subseteq V$, the cut $\\delta(S)$ is the set of edges with exactly one end in $S$. An edge $e$ is a bridge iff $\\{e\\} = \\delta(S)$ for some $S$."
+  },
+  {
+    "id": "ann-cdc-cycle",
+    "proofId": "cycle-double-cover",
+    "range": { "startLine": 84, "endLine": 100 },
+    "type": "definition",
+    "title": "Cycles as Minimal Even Edge Sets",
+    "content": "A cycle is a nonempty inclusion-minimal even edge set, where 'even' means every vertex has even degree in the set (parity tracked in $\\mathbb{F}_2$ via `edgeIncidence`). This is the graphic-matroid characterization of a circuit: for loopless multigraphs, minimal nonempty even sets are exactly the connected 2-regular submultigraphs. This is the strong, standard reading of 'cycle' — not the weaker 'even subgraph' reading, so the theorem statement is not diluted.",
+    "mathContext": "The even edge sets form the cycle space $\\mathcal{Z}(G) \\le \\mathbb{F}_2^E$; its minimal nonzero elements (circuits) generate it, and every even set decomposes into edge-disjoint circuits."
+  },
+  {
+    "id": "ann-cdc-cover",
+    "proofId": "cycle-double-cover",
+    "range": { "startLine": 102, "endLine": 105 },
+    "type": "definition",
+    "title": "Cycle Double Cover as a Multiset",
+    "content": "The cover is a `List` of cycles, so repeated cycles are retained (a multiset), and `coveredTwice` demands each edge occur in exactly two members counted with multiplicity. Cycles need not be edge-disjoint from one another; the requirement is exactly two total occurrences per edge.",
+    "mathContext": "The multiset convention matters: for example, a single cycle graph is double-covered by taking its unique cycle twice."
+  },
+  {
+    "id": "ann-cdc-axiom",
+    "proofId": "cycle-double-cover",
+    "range": { "startLine": 108, "endLine": 122 },
+    "type": "concept",
+    "title": "The Theorem, Axiomatized with Full Disclosure",
+    "content": "The main theorem is declared as an axiom in this file — the honest representation while the 7,134-line upstream proof awaits porting from Lean v4.31.0/Mathlib 9a9483a9 to this repository's pin. The axiom is not a conjecture: the exact statement (same definitions, checked line-by-line) is a kernel-verified theorem in openai/cdc-lean, rebuilt independently for this gallery. The proof route: the Jaeger–Kilpatrick 8-flow theorem (proved internally upstream — no Seymour 6-flow needed) gives a nowhere-zero $(\\mathbb{Z}/2)^3$-flow on a cubic expansion; a new labeling argument with a linear-algebra solvability core converts the flow into an exact even double cover, which projects back and decomposes into circuits.",
+    "mathContext": "Classically, a nowhere-zero 8-flow yields only an even-subgraph 4-cover (Bermond–Jackson–Jaeger 1983), and CDC was known to follow from a nowhere-zero 4-flow. The 8-flow $\\Rightarrow$ exact double cover conversion is the genuinely new mathematics."
+  },
+  {
+    "id": "ann-cdc-elementary",
+    "proofId": "cycle-double-cover",
+    "range": { "startLine": 124, "endLine": 155 },
+    "type": "concept",
+    "title": "Elementary Sanity Lemmas (Axiom-Free)",
+    "content": "Three facts proved directly, with no dependence on the axiom: the edgeless graph has the empty double cover (the conjecture's trivial base case); a single edge is never an even set (its two distinct ends each meet it once); hence every cycle has at least two edges — the minimum is realized by parallel-edge 2-cycles. These pin down the definitional edge cases that adversarial review of any CDC claim must check.",
+    "mathContext": "The singleton argument is pure parity: if $F = \\{e\\}$ with ends $u \\neq v$, then $\\sum_{f \\in F} \\iota_u(f) = 1 \\neq 0$ in $\\mathbb{F}_2$."
+  }
+]

--- a/src/data/proofs/cycle-double-cover/meta.json
+++ b/src/data/proofs/cycle-double-cover/meta.json
@@ -1,0 +1,79 @@
+{
+  "id": "cycle-double-cover",
+  "title": "The Cycle Double Cover Conjecture (Resolved 2026)",
+  "slug": "cycle-double-cover",
+  "description": "Every finite bridgeless loopless multigraph has a cycle double cover — a multiset of cycles covering every edge exactly twice. Conjectured by Szekeres (1973) and Seymour (1979), resolved in 2026 by OpenAI's GPT-5.6 Sol Ultra with a complete Lean 4 formalization, independently kernel-verified for this gallery. This entry ports the statement and axiomatizes the theorem pending a full port of the 7,134-line upstream proof.",
+  "meta": {
+    "author": "Szekeres (1973), Seymour (1979); proof by GPT-5.6 Sol Ultra (OpenAI, 2026)",
+    "sourceUrl": "https://github.com/openai/cdc-lean",
+    "status": "axiomatized",
+    "proofRepoPath": "Proofs/CycleDoubleCover.lean",
+    "tags": [
+      "graph theory",
+      "cycle double cover",
+      "nowhere-zero flows",
+      "external result",
+      "ai-generated proof"
+    ],
+    "badge": "axiom",
+    "sorries": 0,
+    "axiomCount": 1,
+    "assumptions": "1 axiom: cycleDoubleCover_of_bridgeless, the CDC theorem itself. The axiom mirrors the upstream kernel-checked theorem CDCLean.cycleDoubleCover_of_bridgeless in openai/cdc-lean (Lean v4.31.0, Mathlib 9a9483a9), which was independently rebuilt and audited for this gallery on 2026-07-11: lake build clean (1727 jobs), #print axioms = [propext, Classical.choice, Quot.sound] only — no sorries, no custom axioms, no native_decide (issue #37504). Statement definitions in this file were checked to match upstream exactly. The entry remains 'axiomatized' until the 7,134-line proof is ported to our Mathlib pin.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 3,
+    "definitionCount": 7
+  },
+  "overview": {
+    "historicalContext": "The Cycle Double Cover Conjecture was posed independently by George Szekeres (1973) and Paul Seymour (1979): every bridgeless graph admits a collection of cycles covering each edge exactly twice. It became one of the central open problems of graph theory, tightly linked to nowhere-zero flows, snarks, and graph embeddings. The classical reduction shows a minimal counterexample must be a snark, and Jaeger's 8-flow theorem (1976) yields a cycle quadruple cover for every bridgeless graph — but closing the gap from four to two resisted five decades of effort. On 2026-07-10, OpenAI announced a proof produced by its GPT-5.6 Sol Ultra model orchestrating up to 64 subagents, accompanied by a complete Lean 4 formalization (openai/cdc-lean). The formal artifact was independently verified for this gallery on 2026-07-11: the pinned-toolchain build succeeds and the final theorem depends only on Lean's three standard foundational axioms.",
+    "keyInsight": "The new mathematical content is a conversion of Jaeger's 8-flow into an exact double cover. A nowhere-zero (ZMod 2)^3-flow on a cubic expansion of the graph classically yields only an even-subgraph 4-cover; the upstream proof constructs a labeling of edges (the CubicLabeling machinery) whose compatibility system is solvable by a linear-algebra argument, forcing each edge into exactly two even subgraphs. Projecting back from the cubic expansion and decomposing even sets into circuits gives the cycle double cover — unconditionally, since the 8-flow theorem is proved internally.",
+    "approachRationale": "This entry follows the gallery's external-result integration pattern (cf. AlphaProof Nexus, #20732): the statement is ported exactly — finite loopless multigraph with primitive edge objects, cut-characterized bridgelessness, cycles as inclusion-minimal even edge sets, covers as multisets with exact multiplicity two — and the theorem is axiomatized with full disclosure while the upstream proof (7,134 lines, Lean v4.31.0) awaits porting to our Mathlib pin. Elementary sanity lemmas (edgeless graphs, no singleton cycles, cycles have ≥ 2 edges) are proved directly without the axiom.",
+    "prerequisites": [
+      "Multigraphs, bridges, and edge cuts",
+      "Cycle space over GF(2): even subgraphs and their circuit decompositions",
+      "Nowhere-zero flows and Jaeger's 8-flow theorem (background for the proof route)"
+    ]
+  },
+  "conclusion": {
+    "summary": "The Cycle Double Cover Conjecture is resolved: every finite bridgeless loopless multigraph has a cycle double cover. The proof, produced by an AI system and formalized in Lean 4, was independently kernel-verified for this gallery — the strongest form of assurance available for a mathematical claim. This entry records the exact statement and the verification trail, and axiomatizes the result pending a full port.",
+    "significance": "A 50-year-old central conjecture of graph theory is closed, and notably the artifact of record is a machine-checked formal proof rather than a refereed paper — community peer review of the informal write-up was still in progress when the Lean proof already kernel-checked. For this project it is a landmark precedent: formal verification let us confirm an extraordinary claim within a day of its announcement.",
+    "openQuestions": [
+      "Port the full 7,134-line upstream proof to this repository's Mathlib pin so the axiom can be discharged (tracked in #37504).",
+      "Does the 8-flow-to-double-cover labeling technique extend to the stronger 5-cycle-double-cover conjecture or to the oriented cycle double cover conjecture?",
+      "Can the CubicLabeling compatibility argument be simplified or upstreamed into Mathlib's flow/matroid libraries?"
+    ]
+  },
+  "references": {
+    "papers": [
+      {
+        "title": "A Proof of the Cycle Double Cover Conjecture",
+        "authors": "GPT-5.6 Sol Ultra (OpenAI)",
+        "year": 2026,
+        "url": "https://cdn.openai.com/pdf/04d1d1e4-bc75-476a-97cf-49055cd98d31/cdc_proof.pdf"
+      },
+      {
+        "title": "Prompt used for 'A Proof of the Cycle Double Cover Conjecture'",
+        "authors": "OpenAI",
+        "year": 2026,
+        "url": "https://cdn.openai.com/pdf/04d1d1e4-bc75-476a-97cf-49055cd98d31/cdc_prompt.pdf"
+      },
+      {
+        "title": "cdc-lean: Lean 4 formalization of the Cycle Double Cover theorem",
+        "authors": "OpenAI",
+        "year": 2026,
+        "url": "https://github.com/openai/cdc-lean"
+      },
+      {
+        "title": "Sums of circuits (origin of the conjecture)",
+        "authors": "George Szekeres",
+        "year": 1973,
+        "url": "https://doi.org/10.1017/S0004972700045895"
+      },
+      {
+        "title": "Flows and generalized coloring theorems in graphs (8-flow theorem)",
+        "authors": "François Jaeger",
+        "year": 1979,
+        "url": "https://doi.org/10.1016/0095-8956(79)90057-1"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Adds a gallery entry for the **Cycle Double Cover Conjecture** (Szekeres 1973 / Seymour 1979), resolved 2026-07-10 by OpenAI's GPT-5.6 Sol Ultra with a complete Lean 4 formalization. Follows the external-result pattern (cf. AlphaProof Nexus #20732): statement ported exactly, theorem axiomatized with full disclosure pending a port of the 7,134-line upstream proof across the Mathlib gap (upstream v4.31.0 vs our v4.26.0).

**Verification trail** (#37504): upstream `openai/cdc-lean` was independently rebuilt on its pinned toolchain — clean 1,727-job build, `#print axioms` on the final theorem = `[propext, Classical.choice, Quot.sound]` only. Statement definitions checked line-by-line to match.

## This PR

- `proofs/Proofs/CycleDoubleCover.lean` — definitions mirroring upstream `CDCLean` (loopless multigraph with primitive edge objects, cut-characterized bridgelessness, cycles as inclusion-minimal even edge sets, multiset double cover); **1 axiom** (the theorem, disclosed), **3 proven lemmas**, **0 sorries**.
- `src/data/proofs/cycle-double-cover/` — meta.json (status `axiomatized`, badge `axiom`, axiomCount 1) + 7 annotations.

## Verification done

- File elaborates cleanly against our exact Mathlib pin (`2df2f015`, Lean v4.26.0) in a memory-capped podman container (Docker Desktop currently blocked on a host GUI prompt).
- `#print axioms` on all three proven lemmas: `[propext, Classical.choice, Quot.sound]` — no dependence on the CDC axiom.
- `check-meta-size`: entry within cap (8KB / 60KB).

Axiom Integrity Policy compliance: axiomCount 1 reflects the single `axiom` declaration; no structure-encoded assumptions (all structures are definitions); no `native_decide`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)