### PR TITLE
Fix stale sorryCount (9→0) for cauchy-schwarz-integral-lp-duality-synthesis

### DIFF
--- a/src/data/research/problems/cauchy-schwarz-integral-lp-duality-synthesis.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-lp-duality-synthesis.json
@@ -119,7 +119,7 @@
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 9,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CauchySchwarzIntegralLpDualitySynthesis.lean"
     }


### PR DESCRIPTION
## Summary

`cauchy-schwarz-integral-lp-duality-synthesis` is `status: completed` — S28 eliminated the parent `riesz_lp_surjective` axiom by re-exporting `riesz_lp_surjective_general`, making the full Lᵖ-duality chain 0-axiom end to end.

But the problem JSON reported `leanFiles.sorryCount: 9`, which is wrong. A comment/docstring-aware scan of `proofs/Proofs/CauchySchwarzIntegralLpDualitySynthesis.lean` (437 lines, 10 theorems, 0 axioms) finds **0 real `sorry` tactics**. All 9 matches were 'sorry' tokens inside docstrings/comments (e.g. "sorry-free", "the maximality `sorry` is gone") — the naive grep -c overcount the problem's own `insights` explicitly warns against.

This PR corrects `sorryCount` 9 → 0 so the metadata matches the source.

## Verification
- Comment-aware state-machine scan of the .lean file: 0 `sorry` tactics outside block/line comments.
- `grep -cE '^(theorem|lemma) '` = 10 (matches `theoremCount`); `grep -c '^axiom '` = 0 (matches `axiomCount`); `wc -l` = 437 (matches `lineCount`).
- Local Lean rebuild not attempted: the Synthesis dependency (`Incomplete01`) is the documented >32GB over-envelope file (SIGBUS/host-crash risk); the file is kernel-verified 0-axiom on main per S28.

## Labels
research (metadata-only; no Lean changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)