### PR TITLE
audit(cycle-double-cover): mark clean — drains last unaudited gallery entry

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -29782,6 +29782,12 @@
       "lastAudited": "2026-07-10T08:05:00Z",
       "result": "clean",
       "issues": []
+    },
+    "cycle-double-cover": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-11T21:56:02Z",
+      "result": "clean",
+      "notes": "External-result axiomatized entry (CDC, resolved 2026). Verified: 1 axiom decl (cycleDoubleCover_of_bridgeless = the CDC theorem, fully disclosed), 0 sorries, native_decide only in comments, 3 theorems (elementary facts proved without the axiom). status=axiomatized/badge=axiom/axiomCount=1/theoremCount=3 all match. Minor: definitionCount=7 vs 8 actual (trivial abbrev F2), cosmetic."
     }
   },
   "version": 1,


### PR DESCRIPTION
## Gallery Integrity Audit

**Proof**: cycle-double-cover (The Cycle Double Cover Conjecture, resolved 2026)
**Result**: CLEAN — no integrity issues.

This was the single remaining unaudited gallery entry. Marking it clean brings the gallery to **4799/4799 audited, 0 issues**.

## Verification (meta.json vs proofs/Proofs/CycleDoubleCover.lean)

| Field | meta.json | Lean source | Match |
|-------|-----------|-------------|-------|
| status | axiomatized | — | ✓ (Tier C external result) |
| badge | axiom | — | ✓ |
| axiomCount | 1 | 1 axiom decl (`cycleDoubleCover_of_bridgeless`) | ✓ |
| sorries | 0 | 0 (only comment mentions) | ✓ |
| theoremCount | 3 | 3 (all elementary, proved without the axiom) | ✓ |
| native_decide | disclosed absent | only in comments | ✓ |

The single axiom **is** the CDC theorem itself, fully disclosed in both the Lean docstring and meta's `assumptions` field, with the honest upstream kernel-verification trail (propext/Classical.choice/Quot.sound only). The 3 theorems (`edgeless_cdc`, `singleton_not_even`, `cycle_card_ge_two`) are elementary facts proved directly, not the conjecture. A model of honest external-result disclosure.

**Minor (non-blocking, cosmetic)**: `definitionCount: 7` vs 8 actual (the trivial `abbrev F₂ := ZMod 2`). Not a claim-risk field; noted in tracker.

---
Discovered during gallery integrity audit.