### PR TITLE
research(erdos-1093-oq-02): location bound closes k=26 [VERIFIED 0-sorry/0-new-axiom]

### DIFF
--- a/proofs/Proofs/Erdos1093ProblemOQ02.lean
+++ b/proofs/Proofs/Erdos1093ProblemOQ02.lean
@@ -2084,3 +2084,96 @@ theorem maximalDeficiencyIs_nine_iff_kGe26 :
     by_cases hk : k ≤ 25
     · exact deficiency_le_nine_of_k_le_25 hv.1 hv.2 hk
     · exact h n k (by omega) hv
+
+/-
+## Section XXVII: The location bound closes `k = 26` — frontier `k ≥ 26` → `k ≥ 27`
+
+Section XXVI cashed out the effective, ELS-free location bound at the open frontier
+`k = 25`.  The same mechanism advances one further step, to `k = 26`.  A deficiency
+`≥ 10` forces the window-floor power bound `(n - 25)^{10} ≤ 26!`, and `26! < 458^{10}`
+(`factorial_26_lt_458_pow_ten`), so `n - 25 < 458`, i.e. `n ≤ 482`.  With the admissibility
+floor `n ≥ 52` (`= 2·26`) this leaves the finite window `n ∈ {52, 51, …, 482}` (four
+hundred and thirty-one values).
+
+As at `k = 18, …, 25`, `C(n,26)` is **not** uniformly even on this window: by
+Kummer/Lucas `C(n,26)` is odd exactly when the binary digits of `26 = 11010₂` sit inside
+those of `n`, so the single prime `2` no longer certifies inadmissibility.  It remains
+true — and this is what closes the slice — that *some* prime `≤ 26` divides `C(n,26)` for
+every one of the four hundred and thirty-one values.  Here the two-prime economy of the
+earliest slices very nearly returns: `2` divides the even binomials, `3` divides all of the
+odd ones save the single exception `n = 350`, and that lone odd non-multiple of `3` is
+caught by `5` (`5 ∣ C(350,26)`).  So already the three-prime disjunction
+`2 ∣ C(n,26) ∨ 3 ∣ C(n,26) ∨ 5 ∣ C(n,26)` holds throughout the window — no pair is
+admissible and no admissible pair at `k = 26` has deficiency exceeding `9`.
+
+As before the `(k!)²` factorial method is powerless here
+(`sharp_bound_permits_deficiency_ten` permits deficiency `10` for every `k ≥ 16`); only
+the *location* bound closes the slice, through the uniform engine
+`deficiency_le_nine_of_location` (Section XVIIB).  The elementary resolution of OQ-02 now
+covers **all `k ≤ 26`**, moving the open frontier to `k ≥ 27`.  The structural results
+remain `ofReduceBool`-free; only the concrete divisibility facts use `native_decide`. -/
+
+/-- `26! < 458^10`, the numeric input that pins the `k = 26` window: `(n-25)^{10} ≤ 26!`
+forces `n - 25 < 458`.  `ofReduceBool`-free (`Nat.factorial` and `Nat.pow` on literals
+reduce under kernel `decide`; `26! = 403291461126605635584000000 <
+406120376413199518554317824 = 458^{10}`). -/
+theorem factorial_26_lt_458_pow_ten : Nat.factorial 26 < 458 ^ 10 := by decide
+
+/-- For `52 ≤ n ≤ 482` some prime `≤ 26` divides `C(n,26)`: `2` for the even values, `3`
+for all but one of the odd binomials, and `5` for the single odd exception `n = 350`.
+Stated as the disjunction `2 ∣ · ∨ 3 ∣ · ∨ 5 ∣ ·`, which holds across the whole window.
+Uses `native_decide` (⇒ `Lean.ofReduceBool`) because the naive `Nat.choose` recursion is
+infeasible for kernel `decide`. -/
+theorem smallPrime_dvd_choose_26_of_range {n : ℕ} (hlo : 52 ≤ n) (hhi : n ≤ 482) :
+    2 ∣ Nat.choose n 26 ∨ 3 ∣ Nat.choose n 26 ∨ 5 ∣ Nat.choose n 26 := by
+  interval_cases n <;> native_decide
+
+/-- The four hundred and thirty-one small pairs left by the `k = 26` location window are all
+inadmissible: some prime `p ∈ {2, 3, 5}` (each `≤ 26`) divides `C(n,26)`, contradicting
+`NoSmallPrimeFactors n 26` (which would force `26 < p`). -/
+theorem not_admissible_k26_of_range {n : ℕ} (hlo : 52 ≤ n) (hhi : n ≤ 482) :
+    ¬ NoSmallPrimeFactors n 26 := by
+  intro h
+  rcases smallPrime_dvd_choose_26_of_range hlo hhi with hd | hd | hd
+  · have := h 2 Nat.prime_two hd; omega
+  · have := h 3 Nat.prime_three hd; omega
+  · have := h 5 (by norm_num) hd; omega
+
+/-- **The location bound closes `k = 26`.**  For an admissible pair with `k = 26` the
+deficiency never exceeds `9`.  A deficiency `≥ 10` would force, via the window-floor
+bound, `(n - 25)^{10} ≤ 26! < 458^{10}`, hence `n ≤ 482`; with the admissibility floor
+`n ≥ 52` this leaves only `n ∈ {52,…,482}`, none admissible (some prime `≤ 26` divides
+`C(n,26)`, even where `C(n,26)` is odd).  A one-line instantiation of the uniform engine
+`deficiency_le_nine_of_location` at `k = 26, M = 458`. -/
+theorem deficiency_le_nine_of_k_eq_26 {n : ℕ} (hn : 52 ≤ n)
+    (h : NoSmallPrimeFactors n 26) : deficiency n 26 ≤ 9 :=
+  deficiency_le_nine_of_location (k := 26) (M := 458) (by omega) h
+    factorial_26_lt_458_pow_ten
+    (fun m hlo hhi => not_admissible_k26_of_range (by omega) (by omega))
+
+/-- **Elementary resolution of OQ-02 for all `k ≤ 26`.**  Combines the location bound at
+`k ≤ 25` (`deficiency_le_nine_of_k_le_25`) with the location bound at `k = 26`
+(`deficiency_le_nine_of_k_eq_26`).  Strictly extends the `k ≤ 25` reach of Section XXVI. -/
+theorem deficiency_le_nine_of_k_le_26 {n k : ℕ} (hn : 2 * k ≤ n)
+    (h : NoSmallPrimeFactors n k) (hk : k ≤ 26) : deficiency n k ≤ 9 := by
+  by_cases hk25 : k ≤ 25
+  · exact deficiency_le_nine_of_k_le_25 hn h hk25
+  · have hk26 : k = 26 := by omega
+    subst hk26
+    exact deficiency_le_nine_of_k_eq_26 (by omega) h
+
+/-- **Sharpened reduction to `k ≥ 27`.**  `MaximalDeficiencyIs 9` is equivalent to the
+open universal bound restricted to `k ≥ 27`: the cases `k ≤ 25` are discharged by the
+sharp/location bounds and `k = 26` by the location bound (`deficiency_le_nine_of_k_le_26`).
+Strictly sharper than `maximalDeficiencyIs_nine_iff_kGe26`; the entire remaining open
+content of OQ-02 now lives at `k ≥ 27`. -/
+theorem maximalDeficiencyIs_nine_iff_kGe27 :
+    MaximalDeficiencyIs 9 ↔
+      ∀ n k, 27 ≤ k → ValidDeficiencyExample n k → deficiency n k ≤ 9 := by
+  rw [maximalDeficiencyIs_nine_iff_upperBound]
+  constructor
+  · intro h n k _ hv; exact h n k hv
+  · intro h n k hv
+    by_cases hk : k ≤ 26
+    · exact deficiency_le_nine_of_k_le_26 hv.1 hv.2 hk
+    · exact h n k (by omega) hv

--- a/src/data/research/problems/erdos-1093-oq-02.json
+++ b/src/data/research/problems/erdos-1093-oq-02.json
@@ -4,7 +4,7 @@
   "phase": "ACT",
   "status": "in-progress",
   "started": "2026-07-08T00:00:00.000Z",
-  "lastUpdate": "2026-07-09",
+  "lastUpdate": "2026-07-11",
   "path": "full",
   "parentId": "erdos-1093",
   "tier": "C",
@@ -34,17 +34,17 @@
     {
       "path": "Proofs/Erdos1093ProblemOQ02.lean",
       "filename": "Erdos1093ProblemOQ02.lean",
-      "lineCount": 1591,
-      "theoremCount": 77,
+      "lineCount": 2179,
+      "theoremCount": 83,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1093ProblemOQ02.lean"
     }
   ],
   "knowledge": {
-    "progressSummary": "PROGRESS (VERIFIED axiom-free, local lean): added the factorial-growth meta-theorem exists_factorial_add_le_sq establishing that the sharp bound (k+D)!≤(k!)² holds for all fixed D (k≥3D) — hence the sharp bound alone cannot certify a finite maximal deficiency. Structural k-slice engine + this negative meta-result now bracket the problem; only genuinely analytic ELS density input remains open.",
+    "progressSummary": "PROGRESS (VERIFIED 0-sorry, single-file lean elab; PR #37514): the ELS-free location-bound sweep now closes every slice k<=26. Section XXVII adds k=26 (deficiency>=10 forces (n-25)^10<=26!<458^10 => n<=482; the finite window n in {52..482} is uniformly inadmissible via 2|C(n,26) OR 3|C(n,26) OR 5|C(n,26)), advancing the elementary open frontier from k>=26 to k>=27 (maximalDeficiencyIs_nine_iff_kGe27). The (k!)^2 factorial method is provably powerless for all k>=16 (sharp_bound_permits_deficiency_ten), so each further slice needs one location-bound section: pick M=ceil((k!)^(1/10)), pin k!<M^10 by kernel decide, then certify 2k<=n<=k+M-2 inadmissible via a small-prime disjunction (interval_cases <;> native_decide). Only genuinely analytic short-interval smooth-count (Dickman/ELS) input remains for the k->infinity tail.",
     "builtItems": [
       "noSmallPrimeFactors_iff (Erdos1093ProblemOQ02.lean) — decidable reduction of the admissibility side-condition (unbounded ∀ prime) to a bounded check over primes p ≤ k; ofReduceBool-free.",
       "noSmallPrimeFactors_284_28 — the record pair (284,28) is admissible: no prime ≤ 28 divides C(284,28) (parent verified only the count = 9, never admissibility).",
@@ -79,7 +79,8 @@
       "not_admissible_k21_of_range / deficiency_le_nine_of_k_eq_21 / deficiency_le_nine_of_k_le_21",
       "maximalDeficiencyIs_nine_iff_kGe22: reduces open content of OQ-02 to k>=22",
       "deficiency_le_of_sq_factorial_lt (Erdos1093ProblemOQ02.lean:753): uniform transfer principle — for all k, (k!)²<(k+D+1)! ⟹ deficiency n k ≤ D; subsumes the infinite family of per-k sharp ceilings into one theorem. deficiency_record_le_18 refactored to a 1-line corollary (k=28,D=18).",
-      "Erdos1093OQ02FactorialGrowth.lean: exists_factorial_add_le_sq — ∀ D, ∃ k₀, ∀ k≥k₀, (k+D)!≤(k!)² (any k₀=3D works); elementary chain via factorial_mul_ascFactorial + factorial_mul_pow_le_factorial + two_pow_le_succ_factorial helper. VERIFIED axiom-free (local lean v4.26.0, exit 0, deps: propext/Classical.choice/Quot.sound only)."
+      "Erdos1093OQ02FactorialGrowth.lean: exists_factorial_add_le_sq — ∀ D, ∃ k₀, ∀ k≥k₀, (k+D)!≤(k!)² (any k₀=3D works); elementary chain via factorial_mul_ascFactorial + factorial_mul_pow_le_factorial + two_pow_le_succ_factorial helper. VERIFIED axiom-free (local lean v4.26.0, exit 0, deps: propext/Classical.choice/Quot.sound only).",
+      "Section XXVII (researcher-3, 2026-07-11): location bound CLOSES k=26, frontier k>=26 -> k>=27. factorial_26_lt_458_pow_ten (26!=403291461126605635584000000 < 458^10, kernel decide, ofReduceBool-free); smallPrime_dvd_choose_26_of_range (three-prime disjunction 2|C(n,26) OR 3|C(n,26) OR 5|C(n,26) over 52<=n<=482 — 2 on evens, 3 on all odds but n=350, 5 on that lone exception; interval_cases n <;> native_decide); not_admissible_k26_of_range / deficiency_le_nine_of_k_eq_26 / deficiency_le_nine_of_k_le_26 (elementary OQ-02 now covers all k<=26) / maximalDeficiencyIs_nine_iff_kGe27. 6 theorems, 0 sorry, 0 new axiom decls; native_decide=>Lean.ofReduceBool only on the divisibility fact. VERIFIED 0-sorry via single-file lean elab against prebuilt Mathlib oleans (PR #37514)."
     ],
     "insights": [
       "The parent's deficiency_284_28 = 9 alone does NOT exhibit a valid deficiency example: the deficiency count is defined unconditionally, but the ELS problem requires C(n,k) to have no prime factor ≤ k. Checking admissibility only needs primes ≤ k (Kummer is unnecessary): C(284,28) is a ~110-bit bignum, so native_decide computes it and tests divisibility by primes ≤ 28 instantly.",


### PR DESCRIPTION
## Summary

Extends the ELS-free **location-bound** sweep on Erdős #1093 OQ-02 ("is $d(284,28)=9$ the maximal deficiency?") one further step, closing the slice $k=26$ and moving the elementary open frontier from $k\ge 26$ to $k\ge 27$.

## Mathematical content (Section XXVII)

A deficiency $\ge 10$ at $k=26$ forces the window-floor power bound $(n-25)^{10}\le 26!$. Since $26! = 403291461126605635584000000 < 406120376413199518554317824 = 458^{10}$ (`factorial_26_lt_458_pow_ten`, kernel `decide`, ofReduceBool-free), this gives $n-25 < 458$, i.e. $n\le 482$. With the admissibility floor $n\ge 52\ (=2\cdot 26)$ the open window is the finite set $n\in\{52,\dots,482\}$ (431 values).

Every pair in the window is inadmissible via the three-prime disjunction
`2 ∣ C(n,26) ∨ 3 ∣ C(n,26) ∨ 5 ∣ C(n,26)`: `2` covers the even binomials, `3` covers all odd ones except $n=350$, and `5` catches that lone exception ($5\mid C(350,26)$). So `not_admissible_k26_of_range` closes the slice through the uniform engine `deficiency_le_nine_of_location` (Section XVIIB). The $(k!)^2$ factorial method is provably powerless here (`sharp_bound_permits_deficiency_ten` permits deficiency 10 for every $k\ge 16$); only the location bound closes it.

## New theorems (6, +93 lines, 0 sorry)
- `factorial_26_lt_458_pow_ten`
- `smallPrime_dvd_choose_26_of_range`
- `not_admissible_k26_of_range`
- `deficiency_le_nine_of_k_eq_26`
- `deficiency_le_nine_of_k_le_26` — elementary OQ-02 now covers all $k\le 26$
- `maximalDeficiencyIs_nine_iff_kGe27` — remaining open content lives at $k\ge 27$

## Verification
- Single-file elaboration `lake env lean Proofs/Erdos1093ProblemOQ02.lean` against prebuilt Mathlib oleans: **EXIT 0, 0 sorry, 0 errors**.
- Axiom footprint of the new closure theorems: `[propext, Classical.choice, Lean.ofReduceBool, Lean.trustCompiler, Quot.sound]` — identical to the sibling Section XXVI `deficiency_le_nine_of_k_eq_25`. No new literal `axiom` declarations; `native_decide` (⇒ `Lean.ofReduceBool`) is used only on the concrete divisibility fact, exactly as in Sections XVII–XXVI.
- Covering disjunction independently confirmed by direct computation of $C(n,26)\bmod\{2,3,5\}$ over the whole window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)