### PR TITLE
Enrich hall-marriage-theorem-oq-01-oq-01-oq-01: complete section coverage

### DIFF
--- a/src/data/proofs/hall-marriage-theorem-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/hall-marriage-theorem-oq-01-oq-01-oq-01/meta.json
@@ -75,6 +75,14 @@
   ],
   "sections": [
     {
+      "id": "preamble-setup",
+      "title": "Imports, goal, and typeclass context",
+      "startLine": 1,
+      "endLine": 43,
+      "summary": "import Proofs.HallMarriageTheoremOQ01OQ01 brings in the parent defect (Ore) theorem — deficiency_matching_iff, exists_matching_of_deficiency_le, deficiency_le_of_matching — the only external facts consumed. The module docstring states the goal: pin the parent's sharp threshold d to δ = maxₛ (#s − #(s.biUnion t)) so the parametrised biconditional becomes the single optimum #ι − δ. open Finset Function and namespace HallDefect isolate deficiency and the optimum theorems from the parent's identically-named lemmas.",
+      "mathContext": "Reuse the parent iff (matches all but $d$) $\\iff \\forall s,\\ \\#s \\le \\#(s.\\mathrm{biUnion}\\,t)+d$ at the sharp $d = \\delta(t)$."
+    },
+    {
       "id": "deficiency-def",
       "title": "The deficiency as a Finset-sup",
       "startLine": 44,


### PR DESCRIPTION
Enrichment pass for `hall-marriage-theorem-oq-01-oq-01-oq-01` (closed-form max partial transversal = |ι| − deficiency).

This q95 entry already met every quality-target minimum (7 fully-annotated annotations, 6 keyInsights, complete conclusion, 3 crossReferences). The one sub-maximal dimension was **section coverage**: the existing 4 sections all began at line 44, leaving lines 1–43 (imports, module docstring stating the closed-form goal, and `open`/`namespace`/`variable` setup) with no section entry.

Added a 5th section `preamble-setup` (lines 1–43) describing:
- the `import Proofs.HallMarriageTheoremOQ01OQ01` dependency (the parent defect/Ore theorem — the only external engine),
- the module docstring's statement of the goal (pin the sharp threshold `d` to `δ = maxₛ(#s − #(s.biUnion t))`),
- the typeclass `variable` context and namespace isolation.

Sections now cover the full 131-line file. No inflation: meta.json is 17.8 KB (well under the 60 KB cap), and no field was deepened beyond its target. Gallery data validation passes.