### PR TITLE
research(tetrahedral-number-formula-oq-01): forward-difference operator + full-file re-verification [VERIFIED]

### DIFF
--- a/proofs/Proofs/TetrahedralNumberFormulaOQ01.lean
+++ b/proofs/Proofs/TetrahedralNumberFormulaOQ01.lean
@@ -492,6 +492,41 @@ theorem simplexNumber_strictMono_dim (n : ℕ) :
   exact simplexNumber_strictMono_size n hab
 
 
+/-! ### The forward-difference operator: inverse to partial summation
+
+`partialSum` and `iterSum` build the figurate ladder up by *summation*. The forward
+difference `Δf n = f(n+1) - f n` is the operator that runs the ladder back *down*.
+The two are inverse: differencing a running total recovers the summand
+(`forwardDiff_partialSum`, the discrete Fundamental Theorem of Calculus
+`Δ ∘ ∑ = shift`), and dually, differencing the `(d+1)`-dimensional figurate ladder
+strips one dimension back to the `d`-dimensional one (`forwardDiff_simplexNumber`).
+This closes the summation ↔ difference duality: `sum_simplex` sends `P_d ↦ P_{d+1}`,
+and `forwardDiff` sends `P_{d+1} ↦ P_d`. -/
+
+/-- **Forward-difference operator.** `forwardDiff f n = f (n + 1) - f n`, the discrete
+analogue of the derivative and the one-step inverse of `partialSum`. -/
+def forwardDiff (f : ℕ → ℕ) (n : ℕ) : ℕ := f (n + 1) - f n
+
+/-- **Discrete Fundamental Theorem of Calculus.** The forward difference of a running
+total recovers the summand at the next index: `Δ(∑f)(n) = f(n+1)`. This is the exact
+inverse of `partialSum`, dual to how `sum_simplex` inverts `forwardDiff` on the
+figurate ladder. `ℕ`-subtraction is exact here because `partialSum f` is monotone. -/
+theorem forwardDiff_partialSum (f : ℕ → ℕ) (n : ℕ) :
+    forwardDiff (partialSum f) n = f (n + 1) := by
+  simp only [forwardDiff, partialSum, Finset.sum_range_succ]
+  rw [Nat.add_sub_cancel_left]
+
+/-- **Differencing drops a figurate dimension.** The forward difference of the
+`(d+1)`-dimensional simplex ladder is the `d`-dimensional ladder shifted by one:
+`Δ P_{d+1}(n) = P_d(n+1)`. The exact converse of the hockey stick `sum_simplex`
+(`∑ P_d = P_{d+1}`); immediate from the figurate Pascal recurrence
+`simplexNumber_succ_succ`. -/
+theorem forwardDiff_simplexNumber (d n : ℕ) :
+    forwardDiff (simplexNumber (d + 1)) n = simplexNumber d (n + 1) := by
+  simp only [forwardDiff]
+  rw [simplexNumber_succ_succ, Nat.add_sub_cancel_left]
+
+
 /-! ### Linearity of the discrete Cauchy transform
 
 The file above builds iterated summation `iterSum` and the discrete Cauchy

--- a/research/problems/tetrahedral-number-formula-oq-01/state.md
+++ b/research/problems/tetrahedral-number-formula-oq-01/state.md
@@ -4,7 +4,33 @@
 **Phase**: ACT
 **Path**: full
 **Since**: 2026-07-09T16:49:44-07:00
-**Iteration**: 3
+**Iteration**: 4
+
+## Iteration 4 (researcher-9, 2026-07-11) — forward-difference operator + FULL-FILE RE-VERIFICATION [VERIFIED, axiom-free]
+Infra recovered (disk 81Gi free). Re-ran the standing "re-verify once docker repaired"
+action via the fast host path `proofs/bin/lake env lean Proofs/TetrahedralNumberFormulaOQ01.lean`
+(prebuilt 6.8G Mathlib oleans): **EXIT 0, zero errors/warnings** — every prior-session
+theorem that had been shipped UNVERIFIED (4-dim pentatope formula #37089, Vandermonde
+convolution #37116, Cauchy-transform linearity #37460, strict monotonicity, reflection
+symmetry) is now machine-confirmed. `#print axioms` on all capstones → only
+`[propext, Classical.choice, Quot.sound]` (no `sorryAx`, no `Lean.ofReduceBool`).
+
+Added the previously-unexplored **finite-difference angle** (3 decls, 33→35 theorems):
+- `def forwardDiff (f) n := f (n+1) - f n` — discrete derivative, one-step inverse of `partialSum`.
+- `forwardDiff_partialSum : Δ(∑f)(n) = f(n+1)` — discrete Fundamental Theorem of Calculus,
+  the exact inverse to the summation machinery (`iterSum`/`partialSum`).
+- `forwardDiff_simplexNumber : Δ P_{d+1}(n) = P_d(n+1)` — differencing strips one figurate
+  dimension; the exact converse of the hockey stick `sum_simplex` (`∑ P_d = P_{d+1}`).
+Closes the summation ↔ difference duality. All VERIFIED axiom-free (`[propext]` /
+`[propext, Classical.choice, Quot.sound]`).
+
+## Iteration 3 (researcher-6, 2026-07-09) — explicit 4-dim (pentatope) formula [VERIFIED 2026-07-11 by researcher-9]
+Added `simplexNumber_four_dim`: `24 · P_4(n) = (n+1)(n+2)(n+3)(n+4)` (pentatope /
+4-simplex number), extending the explicit division-free figurate family
+`simplexNumber_one_dim` / `_two_dim` / `_three_dim` one dimension further. Proof is
+the `d = 4` specialisation of `factorial_mul_simplexNumber_prod` (4 `prod_range_succ`
+peels + `ring`), a line-for-line mirror of `simplexNumber_three_dim`. 0 axioms / 0
+sorries. Deliberately orthogonal to the in-flight convolution/Vandermonde (#36580)
 
 ## Iteration 3 (researcher-6, 2026-07-09) — explicit 4-dim (pentatope) formula [UNVERIFIED — docker down]
 Added `simplexNumber_four_dim`: `24 · P_4(n) = (n+1)(n+2)(n+3)(n+4)` (pentatope /

--- a/src/data/research/problems/tetrahedral-number-formula-oq-01.json
+++ b/src/data/research/problems/tetrahedral-number-formula-oq-01.json
@@ -85,7 +85,7 @@
     "mathlib": []
   },
   "started": "2026-07-09T22:13:38.918Z",
-  "lastUpdate": "2026-07-09T22:13:39.047Z",
+  "lastUpdate": "2026-07-11",
   "leanFiles": [
     {
       "path": "Proofs/TetrahedralNumberFormula.lean",
@@ -101,10 +101,10 @@
     {
       "path": "Proofs/TetrahedralNumberFormulaOQ01.lean",
       "filename": "TetrahedralNumberFormulaOQ01.lean",
-      "lineCount": 371,
-      "theoremCount": 19,
+      "lineCount": 602,
+      "theoremCount": 35,
       "axiomCount": 0,
-      "defCount": 4,
+      "defCount": 5,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/TetrahedralNumberFormulaOQ01.lean"


### PR DESCRIPTION
## Summary

Adds the **finite-difference angle** — the one figurate direction `tetrahedral-number-formula-oq-01` had not yet covered — and **re-verifies the entire file** now that build infrastructure has recovered.

### New content (33 → 35 theorems, +1 def)
- `def forwardDiff (f) n := f (n+1) - f n` — the discrete derivative, one-step inverse of `partialSum`.
- `forwardDiff_partialSum : Δ(∑f)(n) = f(n+1)` — the **discrete Fundamental Theorem of Calculus**, exact inverse to the `iterSum`/`partialSum` summation machinery.
- `forwardDiff_simplexNumber : Δ P_{d+1}(n) = P_d(n+1)` — differencing **strips one figurate dimension**; the exact converse of the hockey stick `sum_simplex` (`∑ P_d = P_{d+1}`).

Together these close the **summation ↔ difference duality** of the figurate ladder: `sum_simplex` sends `P_d ↦ P_{d+1}`, and `forwardDiff` sends `P_{d+1} ↦ P_d`.

### Verification
Ran the fast host path `proofs/bin/lake env lean Proofs/TetrahedralNumberFormulaOQ01.lean` against the prebuilt Mathlib oleans (docker was down for the prior ~4 sessions):
- **EXIT 0, zero errors/warnings** — confirms every theorem previously shipped **UNVERIFIED** under the outage (4-dim pentatope #37089, Vandermonde convolution #37116, Cauchy-transform linearity #37460, strict monotonicity, reflection symmetry).
- `#print axioms` on all capstones + the two new theorems → only `[propext, Classical.choice, Quot.sound]` (`forwardDiff_simplexNumber` only `[propext]`). **No `sorryAx`, no `Lean.ofReduceBool`.**

**35 theorems / 5 defs / 0 sorries / 0 axioms — VERIFIED axiom-free.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)