### PR TITLE
research(erdos-1093-oq-02): close k=26 rung of ELS-free location ladder

### DIFF
--- a/proofs/Proofs/Erdos1093ProblemOQ02.lean
+++ b/proofs/Proofs/Erdos1093ProblemOQ02.lean
@@ -2084,3 +2084,99 @@ theorem maximalDeficiencyIs_nine_iff_kGe26 :
     by_cases hk : k ≤ 25
     · exact deficiency_le_nine_of_k_le_25 hv.1 hv.2 hk
     · exact h n k (by omega) hv
+
+/-
+## Section XXVII: The location bound closes `k = 26` — frontier `k ≥ 26` → `k ≥ 27`
+
+Section XXVI cashed out the effective, ELS-free location bound at the open frontier
+`k = 25`.  The same mechanism advances one further step, to `k = 26`.  A deficiency
+`≥ 10` forces the window-floor power bound `(n - 25)^{10} ≤ 26!`, and `26! < 458^{10}`
+(`factorial_26_lt_458_pow_ten`), so `n - 25 < 458`, i.e. `n ≤ 482`.  With the admissibility
+floor `n ≥ 52` (`= 2·26`) this leaves the finite window `n ∈ {52, 53, …, 482}` (four
+hundred and thirty-one values).
+
+As at `k = 18, …, 25`, `C(n,26)` is **not** uniformly even on this window: by
+Kummer/Lucas `C(n,26)` is odd exactly when the binary digits of `26 = 11010₂` sit inside
+those of `n`, which happens for fifty-six values of `n` in the window, so the single prime
+`2` no longer certifies inadmissibility.  It remains true — and this is what closes the
+slice — that *some* prime `≤ 26` divides `C(n,26)` for every one of the four hundred and
+thirty-one values: `2` for the three hundred and seventy-five even ones, `3` for all but one
+of the fifty-six odd ones, and `5` for the single odd exception `n = 350` (which no prime
+`≤ 3` reaches).  So already the three-prime disjunction
+`2 ∣ C(n,26) ∨ 3 ∣ C(n,26) ∨ 5 ∣ C(n,26)` holds throughout the window — a tighter
+certificate than the `k = 25` slice needed (there a prime as large as `11` was required),
+the wider window at `k = 26` nonetheless yielding the fewest exceptional residues yet — so no
+pair is admissible and no admissible pair at `k = 26` has deficiency exceeding `9`.
+
+As before the `(k!)²` factorial method is powerless here
+(`sharp_bound_permits_deficiency_ten` permits deficiency `10` for every `k ≥ 16`); only
+the *location* bound closes the slice, through the uniform engine
+`deficiency_le_nine_of_location` (Section XVIIB).  The elementary resolution of OQ-02 now
+covers **all `k ≤ 26`**, moving the open frontier to `k ≥ 27`.  The structural results
+remain `ofReduceBool`-free; only the concrete divisibility facts use `native_decide`. -/
+
+/-- `26! < 458^10`, the numeric input that pins the `k = 26` window: `(n-25)^{10} ≤ 26!`
+forces `n - 25 < 458`.  `ofReduceBool`-free (`Nat.factorial` and `Nat.pow` on literals
+reduce under kernel `decide`; `26! = 403291461126605635584000000 <
+406120376413199518554317824 = 458^{10}`; and `458` is sharp: `457^{10} =
+397339737654378065640319249 ≤ 26!`). -/
+theorem factorial_26_lt_458_pow_ten : Nat.factorial 26 < 458 ^ 10 := by decide
+
+/-- For `52 ≤ n ≤ 482` some prime `≤ 26` divides `C(n,26)`: `2` for the even values, `3`
+for all but one of the odd binomials, and `5` for the odd exception `n = 350`.  Stated as
+the disjunction `2 ∣ · ∨ 3 ∣ · ∨ 5 ∣ ·`, which holds across the whole window.  Uses
+`native_decide` (⇒ `Lean.ofReduceBool`) because the naive `Nat.choose` recursion is
+infeasible for kernel `decide`. -/
+theorem smallPrime_dvd_choose_26_of_range {n : ℕ} (hlo : 52 ≤ n) (hhi : n ≤ 482) :
+    2 ∣ Nat.choose n 26 ∨ 3 ∣ Nat.choose n 26 ∨ 5 ∣ Nat.choose n 26 := by
+  interval_cases n <;> native_decide
+
+/-- The four hundred and thirty-one small pairs left by the `k = 26` location window are all
+inadmissible: some prime `p ∈ {2, 3, 5}` (each `≤ 26`) divides `C(n,26)`, contradicting
+`NoSmallPrimeFactors n 26` (which would force `26 < p`). -/
+theorem not_admissible_k26_of_range {n : ℕ} (hlo : 52 ≤ n) (hhi : n ≤ 482) :
+    ¬ NoSmallPrimeFactors n 26 := by
+  intro h
+  rcases smallPrime_dvd_choose_26_of_range hlo hhi with hd | hd | hd
+  · have := h 2 Nat.prime_two hd; omega
+  · have := h 3 Nat.prime_three hd; omega
+  · have := h 5 (by norm_num) hd; omega
+
+/-- **The location bound closes `k = 26`.**  For an admissible pair with `k = 26` the
+deficiency never exceeds `9`.  A deficiency `≥ 10` would force, via the window-floor
+bound, `(n - 25)^{10} ≤ 26! < 458^{10}`, hence `n ≤ 482`; with the admissibility floor
+`n ≥ 52` this leaves only `n ∈ {52,…,482}`, none admissible (some prime `≤ 26` divides
+`C(n,26)`, even where `C(n,26)` is odd).  A one-line instantiation of the uniform engine
+`deficiency_le_nine_of_location` at `k = 26, M = 458`. -/
+theorem deficiency_le_nine_of_k_eq_26 {n : ℕ} (hn : 52 ≤ n)
+    (h : NoSmallPrimeFactors n 26) : deficiency n 26 ≤ 9 :=
+  deficiency_le_nine_of_location (k := 26) (M := 458) (by omega) h
+    factorial_26_lt_458_pow_ten
+    (fun m hlo hhi => not_admissible_k26_of_range (by omega) (by omega))
+
+/-- **Elementary resolution of OQ-02 for all `k ≤ 26`.**  Combines the location bound at
+`k ≤ 25` (`deficiency_le_nine_of_k_le_25`) with the location bound at `k = 26`
+(`deficiency_le_nine_of_k_eq_26`).  Strictly extends the `k ≤ 25` reach of Section XXVI. -/
+theorem deficiency_le_nine_of_k_le_26 {n k : ℕ} (hn : 2 * k ≤ n)
+    (h : NoSmallPrimeFactors n k) (hk : k ≤ 26) : deficiency n k ≤ 9 := by
+  by_cases hk25 : k ≤ 25
+  · exact deficiency_le_nine_of_k_le_25 hn h hk25
+  · have hk26 : k = 26 := by omega
+    subst hk26
+    exact deficiency_le_nine_of_k_eq_26 (by omega) h
+
+/-- **Sharpened reduction to `k ≥ 27`.**  `MaximalDeficiencyIs 9` is equivalent to the
+open universal bound restricted to `k ≥ 27`: the cases `k ≤ 25` are discharged by the
+sharp/location bounds and `k = 26` by the location bound (`deficiency_le_nine_of_k_le_26`).
+Strictly sharper than `maximalDeficiencyIs_nine_iff_kGe26`; the entire remaining open
+content of OQ-02 now lives at `k ≥ 27`. -/
+theorem maximalDeficiencyIs_nine_iff_kGe27 :
+    MaximalDeficiencyIs 9 ↔
+      ∀ n k, 27 ≤ k → ValidDeficiencyExample n k → deficiency n k ≤ 9 := by
+  rw [maximalDeficiencyIs_nine_iff_upperBound]
+  constructor
+  · intro h n k _ hv; exact h n k hv
+  · intro h n k hv
+    by_cases hk : k ≤ 26
+    · exact deficiency_le_nine_of_k_le_26 hv.1 hv.2 hk
+    · exact h n k (by omega) hv

--- a/src/data/research/problems/erdos-1093-oq-02.json
+++ b/src/data/research/problems/erdos-1093-oq-02.json
@@ -4,7 +4,7 @@
   "phase": "ACT",
   "status": "in-progress",
   "started": "2026-07-08T00:00:00.000Z",
-  "lastUpdate": "2026-07-09",
+  "lastUpdate": "2026-07-11T22:07:16Z",
   "path": "full",
   "parentId": "erdos-1093",
   "tier": "C",
@@ -34,17 +34,17 @@
     {
       "path": "Proofs/Erdos1093ProblemOQ02.lean",
       "filename": "Erdos1093ProblemOQ02.lean",
-      "lineCount": 1591,
-      "theoremCount": 77,
+      "lineCount": 2182,
+      "theoremCount": 112,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1093ProblemOQ02.lean"
     }
   ],
   "knowledge": {
-    "progressSummary": "PROGRESS (VERIFIED axiom-free, local lean): added the factorial-growth meta-theorem exists_factorial_add_le_sq establishing that the sharp bound (k+D)!≤(k!)² holds for all fixed D (k≥3D) — hence the sharp bound alone cannot certify a finite maximal deficiency. Structural k-slice engine + this negative meta-result now bracket the problem; only genuinely analytic ELS density input remains open.",
+    "progressSummary": "PROGRESS (VERIFIED axiom-free of new axiom declarations, local `lake env lean`): Section XXVII extends the ELS-free location ladder to close k=26 (factorial_26_lt_458_pow_ten, smallPrime_dvd_choose_26_of_range, not_admissible_k26_of_range, deficiency_le_nine_of_k_eq_26 / _le_26 / maximalDeficiencyIs_nine_iff_kGe27). A deficiency >=10 at k=26 forces (n-25)^10 <= 26! < 458^10, pinning the finite window n in {52,...,482}; the three-prime disjunction 2|C(n,26) v 3|C(n,26) v 5|C(n,26) certifies every one of the 431 values inadmissible (375 even, 55 odd divisible by 3, and n=350 caught by 5). The elementary open frontier now moves to k>=27; only concrete divisibility facts use native_decide (Lean.ofReduceBool), the structural results stay ofReduceBool-free. Remaining universal open content (the record pair (284,28) lives at k=28) requires the ELS analytic short-interval smooth-count bound (multi-month, absent from Mathlib).",
     "builtItems": [
       "noSmallPrimeFactors_iff (Erdos1093ProblemOQ02.lean) — decidable reduction of the admissibility side-condition (unbounded ∀ prime) to a bounded check over primes p ≤ k; ofReduceBool-free.",
       "noSmallPrimeFactors_284_28 — the record pair (284,28) is admissible: no prime ≤ 28 divides C(284,28) (parent verified only the count = 9, never admissibility).",
@@ -120,6 +120,6 @@
     "erdos-1093"
   ],
   "currentState": {
-    "nextAction": "Section XXVI (this cycle) extended the ELS-free location ladder to close k=25 (deficiency_le_nine_of_k_eq_25 / _le_25 / maximalDeficiencyIs_nine_iff_kGe26), moving the elementary open frontier to k>=26. The ladder mechanically continues one rung at a time (k=26,27) until it meets the record pair (284,28) at k=28, where an admissible deficiency-9 example lives in the location window and the window-inadmissibility disjunction genuinely fails. Remaining universal open content (k>=28) requires the ELS analytic upper bound (multi-month). UNVERIFIED: docker image build down (containerd blob I/O)."
+    "nextAction": "Section XXVII (this cycle) closed k=26 (deficiency_le_nine_of_k_eq_26 / _le_26 / maximalDeficiencyIs_nine_iff_kGe27), VERIFIED via `lake env lean` (exit 0). The mechanical ladder continues one rung at a time (k=27) until it meets the record pair (284,28) at k=28, where an admissible deficiency-9 example lives in the location window and the window-inadmissibility disjunction genuinely fails. Remaining universal open content (k>=28) requires the ELS analytic upper bound (multi-month). Next elementary rung: replicate for k=27 (M with 27!<M^10, covering primes <=27 over window n in {54,...,25+M})."
   }
 }


### PR DESCRIPTION
## Summary

Extends the elementary, ELS-free **location-bound ladder** for Erdős #1093 OQ-02
(*Is d(284,28)=9 the maximal deficiency?*) one further rung, from `k=25` to `k=26`.
The elementary resolution of OQ-02 now covers **all `k ≤ 26`**; the open frontier moves to `k ≥ 27`.

## Section XXVII — closing `k = 26`

A deficiency `≥ 10` at `k = 26` forces the window-floor power bound
`(n-25)^10 ≤ 26!`, and `26! < 458^10` (`factorial_26_lt_458_pow_ten`; `458` is sharp,
`457^10 ≤ 26!`), so `n ≤ 482`. With the admissibility floor `n ≥ 52` this leaves the
finite window `n ∈ {52,…,482}` (431 values).

The three-prime disjunction `2 ∣ C(n,26) ∨ 3 ∣ C(n,26) ∨ 5 ∣ C(n,26)` holds across the
whole window — tighter than the `k=25` slice, which needed a prime as large as `11`:
- `2` divides the 375 even binomials,
- `3` divides all but one of the 56 odd ones,
- `5` catches the single odd exception `n = 350`.

Hence every pair in the window is inadmissible and no admissible `k = 26` pair exceeds
deficiency `9`.

## New theorems
- `factorial_26_lt_458_pow_ten` (kernel `decide`, `ofReduceBool`-free)
- `smallPrime_dvd_choose_26_of_range`
- `not_admissible_k26_of_range`
- `deficiency_le_nine_of_k_eq_26`
- `deficiency_le_nine_of_k_le_26`
- `maximalDeficiencyIs_nine_iff_kGe27`

## Verification
`lake env lean Proofs/Erdos1093ProblemOQ02.lean` → exit 0 (full elaboration; a
deliberately-broken copy was confirmed to error, so exit 0 is genuine). No new `axiom`
declarations; concrete divisibility facts use `native_decide` (`Lean.ofReduceBool`),
structural results remain `ofReduceBool`-free — the same axiom footprint as the existing
Sections XVII–XXVI.

## Status
OQ-02 remains **open**: the mechanical ladder continues one rung at a time until it meets
the record pair `(284,28)` at `k = 28`, where an admissible deficiency-9 example lives in
the location window. The universal open tail (`k ≥ 28`) requires the analytic
Erdős–Lacampagne–Selfridge short-interval smooth-count bound, absent from Mathlib.

🤖 Generated with [Claude Code](https://claude.com/claude-code)