### PR TITLE
research(erdos-1014-oq-03): repair Mathlib drift in Obstruction.lean [VERIFIED axiom-free]

### DIFF
--- a/proofs/Proofs/Erdos1014OQ03Obstruction.lean
+++ b/proofs/Proofs/Erdos1014OQ03Obstruction.lean
@@ -176,7 +176,7 @@ theorem v_normalizedIncrement_tendsto_zero :
   have hden : (l : ℝ) / 2 ≤ v l := by simp only [v, ← ha_def]; linarith
   -- Squeeze: `|(v(l+1) − v l)/v l| ≤ 6/l`.
   simp only [Real.norm_eq_abs, abs_div, abs_of_pos hvpos]
-  rw [div_le_div_iff hvpos hlpos]
+  rw [div_le_div_iff₀ hvpos hlpos]
   nlinarith [mul_le_mul_of_nonneg_right hnum hlpos.le, hden, hlpos]
 
 /-- **Increment not determined by the asymptotic class (packaged existential).**

--- a/src/data/research/problems/erdos-1014-oq-03.json
+++ b/src/data/research/problems/erdos-1014-oq-03.json
@@ -42,7 +42,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (UNVERIFIED, docker image-build infra down): formalized the previously-prose negative meta-result that the increment asymptotic is not determined by the ~-class of R(k,.) (Erdos1014OQ03Obstruction.lean). Elementary explicit witness u l=l, v l=l+(-1)^l. This closes the justification gap for rejecting the naive power-law Approach A; the honest increment-ratio bridge (prior sessions) remains the correct route. Full increment asymptotic for k=3 remains OPEN (constant-matching obstruction).",
+    "progressSummary": "PROGRESS (VERIFIED 2026-07-11): repaired Mathlib API drift in Erdos1014OQ03Obstruction.lean (div_le_div_iff -> div_le_div_iff0) so it elaborates cleanly against current Mathlib; confirmed axiom-free via #print axioms on all three capstones (increment_ratio_not_tendsto_one, increment_asymptotic_not_determined_by_asymptotic_class, increment_asymptotic_not_determined_under_normalized_regularity -> [propext, Classical.choice, Quot.sound] only, no sorryAx/ofReduceBool). This formalizes the previously-prose negative meta-result that the increment asymptotic is not determined by the ~-class of R(k,.) via the explicit witness u l=l, v l=l+(-1)^l; the honest increment-ratio bridge (Erdos1014OQ03.lean + LogIncrement.lean, both verify clean) remains the correct route. Full increment asymptotic for k=3 remains OPEN (constant-matching obstruction). KNOWN DRIFT (needs separate repair, out of OQ03 scope): Erdos1014Problem.lean (general problem file, 9 axioms) does NOT compile against current Mathlib -- ~17 errors: Mathlib renames (div_le_div_iff, Real.isLittleO_log_rpow_atTop), a genuine unsolved-goals hole in ramsey_mono_left_ge2 (line ~66, subst with no closing tactic), and fragile nlinarith steps in the general-k asymptotic argument. Erdos1014OQ03Concrete.lean imports Erdos1014Problem and is transitively blocked until that file is repaired.",
     "builtItems": [
       "increment_div_eq_ratio_sub_one — (R(l+1)-R(l))/R(l) = R(l+1)/R(l)-1 (algebraic engine).",
       "increment_div_tendsto_zero_iff_ratio_tendsto_one — normalized increment ->0 IFF consecutive ratio ->1; converts #1014's ratio convergence into Delta_l(k)=o(R(k,l)).",
@@ -56,6 +56,7 @@
     ],
     "mathlibGaps": [],
     "nextSteps": [
+      "Repair Erdos1014Problem.lean Mathlib drift (17 errors incl. ramsey_mono_left_ge2 unsolved-goals hole) to unblock Erdos1014OQ03Concrete.lean verification.",
       "Formalize the real-analysis lemma: g ~ c·l^a/(log l)^b implies g(l+1) - g(l) ~ a·c·l^{a-1}/(log l)^b.",
       "Prove the conditional increment asymptotic Δ_l(k) ~ (k-1)·c_k·l^{k-2}/(log l)^{k-2} from the power-law hypothesis on R(k,l).",
       "Relate the increment asymptotic to ratio_equiv_difference and ratio_from_asymptotics in the parent file.",


### PR DESCRIPTION
## Summary

`Erdos1014OQ03Obstruction.lean` (the OQ-03 negative meta-result: the increment asymptotic of `R(k,·)` is **not** determined by its `~`-equivalence class) was authored during the docker-infra outage and landed **unverified**. Against current Mathlib it fails to elaborate: `div_le_div_iff` was renamed to `div_le_div_iff₀`.

This one-line rename restores it.

## Verification

Single-file elaboration against prebuilt Mathlib oleans (`lake env lean`): **0 errors**.

`#print axioms` on all three capstones —
`increment_ratio_not_tendsto_one`,
`increment_asymptotic_not_determined_by_asymptotic_class`,
`increment_asymptotic_not_determined_under_normalized_regularity` —
reports only `[propext, Classical.choice, Quot.sound]`. Genuinely **axiom-free** (no `sorryAx`, no `Lean.ofReduceBool`).

The sibling OQ-03 deliverables `Erdos1014OQ03.lean` and `Erdos1014OQ03LogIncrement.lean` also verify clean.

## Out of scope (documented in knowledge.json)

`Erdos1014Problem.lean` (the general problem file, 9 axioms) does **not** compile against current Mathlib — ~17 errors: additional renames (`div_le_div_iff`, `Real.isLittleO_log_rpow_atTop`), a genuine unsolved-goals hole in `ramsey_mono_left_ge2` (`subst` with no closing tactic), and fragile `nlinarith` steps in the general-k argument. `Erdos1014OQ03Concrete.lean` imports it and is transitively blocked. Flagged in `nextSteps` for a dedicated repair pass; kept out of this focused, verified PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)