### PR TITLE
research(erdos-1098-oq-01-oq-03): product-multiplicativity capstone boundedCliques_prod_iff [VERIFIED 0-sorry/1-axiom]

### DIFF
--- a/proofs/Proofs/Erdos1098OQ01OQ03.lean
+++ b/proofs/Proofs/Erdos1098OQ01OQ03.lean
@@ -53,6 +53,11 @@ the size of every clique", i.e. ω(Γ(G)) finite) and prove the full equivalence
   and finite-commutator-set (BFC) classes, via the Mathlib Schur endgame
   `Subgroup.finiteIndex_center`. These pin the axiom's residual content to the single
   implication `BoundedCliques G → Finite (commutatorSet G)`.
+* `boundedCliques_prod_iff` — **(fully proved, new)** the multiplicativity capstone:
+  `BoundedCliques (G × K) ↔ BoundedCliques G ∧ BoundedCliques K`, completing the product
+  story of `boundedCliques_of_prod_left` / `boundedCliques_of_prod_right` /
+  `boundedCliques_prod_of_finiteIndex`. (Reverse routes through Neumann's dichotomy, so this
+  equivalence carries the theory's single BFC axiom rather than being axiom-free.)
 
 ## Honesty
 
@@ -622,5 +627,29 @@ theorem boundedCliques_of_prod_left {K : Type*} [Group K]
 theorem boundedCliques_of_prod_right {K : Type*} [Group K]
     (h : BoundedCliques (G × K)) : BoundedCliques K :=
   boundedCliques_of_surjective (MonoidHom.snd G K) (fun k => ⟨(1, k), rfl⟩) h
+
+/-- **The class of `BoundedCliques` groups is exactly closed under finite direct products.**
+    `Γ(G × K)` has finite clique number if and only if *both* `Γ(G)` and `Γ(K)` do:
+
+    > `BoundedCliques (G × K) ↔ BoundedCliques G ∧ BoundedCliques K`.
+
+    This is the capstone the projection lemmas `boundedCliques_of_prod_left` /
+    `boundedCliques_of_prod_right` explicitly advertise: forward is their pair (each factor
+    inherits bounded cliques from the product, via the elementary surjective clique transfer),
+    while the reverse is `boundedCliques_prod_of_finiteIndex` fed by Neumann's dichotomy
+    `neumann_full_theorem` on each factor — turning bounded cliques into finite central index
+    on `G` and `K`, whose product then has finite central index and hence bounded cliques.
+
+    The reverse implication routes through `neumann_hard_direction` (via `neumann_full_theorem`),
+    so — unlike the individual heredity lemmas — this equivalence is *not* axiom-free; it inherits
+    exactly the one BFC assumption of the theory. Combined with `boundedCliques_congr` it says the
+    `BoundedCliques` groups form an isomorphism-closed class that is closed under finite products
+    and factors, i.e. Neumann's finiteness property is genuinely multiplicative. -/
+theorem boundedCliques_prod_iff {K : Type*} [Group K] :
+    BoundedCliques (G × K) ↔ BoundedCliques G ∧ BoundedCliques K := by
+  refine ⟨fun h => ⟨boundedCliques_of_prod_left h, boundedCliques_of_prod_right h⟩, ?_⟩
+  rintro ⟨hG, hK⟩
+  exact boundedCliques_prod_of_finiteIndex
+    (neumann_full_theorem.mp hG) ((neumann_full_theorem (G := K)).mp hK)
 
 end Erdos1098OQ01OQ03

--- a/src/data/proofs/erdos-1098-oq-01-oq-03/meta.json
+++ b/src/data/proofs/erdos-1098-oq-01-oq-03/meta.json
@@ -139,12 +139,12 @@
     }
   ],
   "leanFile": {
-    "lineCount": 626,
+    "lineCount": 655,
     "path": "Proofs/Erdos1098OQ01OQ03.lean",
     "axiomCount": 1,
     "sorries": 0,
     "definitionCount": 3,
-    "theoremCount": 16
+    "theoremCount": 17
   },
   "sorries": 0
 }


### PR DESCRIPTION
## Summary

Adds one new verified theorem to `Erdos1098OQ01OQ03.lean` (Neumann's theorem, ω(Γ(G)) finite ⟺ [G:Z(G)] finite): the **direct-product multiplicativity capstone**

```lean
theorem boundedCliques_prod_iff {K : Type*} [Group K] :
    BoundedCliques (G × K) ↔ BoundedCliques G ∧ BoundedCliques K
```

This is exactly the equivalence the existing projection lemmas `boundedCliques_of_prod_left` / `boundedCliques_of_prod_right` advertise in their docstrings ("together they close the product under both directions, giving the equivalence …") but never stated.

- **Forward** (`G × K` ⇒ each factor): the pair of projection lemmas — axiom-free surjective clique transfer.
- **Reverse** (both factors ⇒ product): Neumann's dichotomy `neumann_full_theorem` turns `BoundedCliques` into finite central index on each factor, then `boundedCliques_prod_of_finiteIndex` rebuilds the product. This routes through the theory's single BFC axiom `neumann_hard_direction`, so the equivalence is not axiom-free (consistent with `neumann_full_theorem`).

Together with `boundedCliques_congr` this shows the `BoundedCliques` groups form an isomorphism-closed class closed under finite products **and** factors.

## Verification

- `lake env lean Proofs/Erdos1098OQ01OQ03.lean` against prebuilt Mathlib → **exit 0, no errors/warnings/sorries**.
- `#print axioms boundedCliques_prod_iff` → `[propext, Classical.choice, Quot.sound, neumann_hard_direction]` — **no new axioms**.
- File remains **0-sorry / 1-axiom**; `theoremCount` 16→17, `lineCount`→655. meta.json updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)