### PR TITLE
research(algebraic-numbers-countable-oq-07): Cantor–Bendixson pillar — empty perfect kernel

### DIFF
--- a/proofs/Proofs/AlgebraicRealsNull.lean
+++ b/proofs/Proofs/AlgebraicRealsNull.lean
@@ -3,6 +3,7 @@ import Mathlib.MeasureTheory.Measure.Lebesgue.Complex
 import Mathlib.MeasureTheory.Measure.Haar.NormedSpace
 import Mathlib.MeasureTheory.Measure.Typeclasses.NoAtoms
 import Mathlib.Topology.MetricSpace.HausdorffDimension
+import Mathlib.Topology.MetricSpace.Perfect
 import Mathlib.Analysis.Real.Cardinality
 import Mathlib.Tactic
 import Proofs.AlgebraicNumbersCountable
@@ -434,5 +435,53 @@ theorem exists_transcendental_of_pos_measure_noAtoms_complex {μ : Measure ℂ} 
   have hz : μ s = 0 := measure_mono_null hsub (algebraic_complex_null_of_noAtoms μ)
   rw [hz] at hs
   exact lt_irrefl 0 hs
+
+/-!
+## Cantor–Bendixson: the algebraic reals have an empty perfect kernel
+
+Alongside the measure-, category-, and cardinality-smallness above sits a fourth,
+order-topological, notion from descriptive set theory. The **Cantor–Bendixson kernel**
+of a set is what remains after transfinitely iterating the removal of isolated points;
+for a *countable* closed set it is empty. The engine is the fact that a nonempty perfect
+set in a complete metric space is uncountable — it admits a continuous injection from
+Cantor space `ℕ → Bool`, whose cardinality is the continuum `𝔠 = 2 ^ ℵ₀ > ℵ₀`
+(`Perfect.exists_nat_bool_injection`). Hence the countable algebraic reals — and complex
+algebraic numbers — contain no nonempty perfect subset, so their Cantor–Bendixson
+derivative process terminates at `∅`.
+-/
+
+/-- A nonempty `Perfect` set in a complete metric space is uncountable: it admits a
+continuous injection from Cantor space `ℕ → Bool` (`Perfect.exists_nat_bool_injection`),
+whose cardinality is the continuum `2 ^ ℵ₀ > ℵ₀`. -/
+theorem perfect_not_countable {α : Type*} [MetricSpace α] [CompleteSpace α]
+    {C : Set α} (hC : Perfect C) (hne : C.Nonempty) : ¬ C.Countable := by
+  obtain ⟨f, hrange, -, hinj⟩ := hC.exists_nat_bool_injection hne
+  intro hcount
+  have hrc : (Set.range f).Countable := hcount.mono hrange
+  have hcb : Countable (ℕ → Bool) :=
+    (Equiv.ofInjective f hinj).countable_iff.mpr hrc.to_subtype
+  have hle : #(ℕ → Bool) ≤ ℵ₀ := Cardinal.mk_le_aleph0
+  have hlt : ℵ₀ < #(ℕ → Bool) := by
+    calc ℵ₀ < 2 ^ ℵ₀ := by exact_mod_cast Cardinal.cantor ℵ₀
+      _ = #(ℕ → Bool) := by rw [Cardinal.mk_arrow]; simp
+  exact absurd hle (not_le.mpr hlt)
+
+/-- **The Cantor–Bendixson kernel of the algebraic reals is empty.** Since the algebraic
+reals are countable (`AlgebraicNumbersCountable.algebraic_reals_countable`) they contain
+no nonempty perfect subset: any `Perfect P` with `P ⊆ {x | IsAlgebraic ℚ x}` is `∅`. -/
+theorem algebraic_reals_no_perfect_subset {P : Set ℝ}
+    (hP : Perfect P) (hsub : P ⊆ {x : ℝ | IsAlgebraic ℚ x}) : P = ∅ := by
+  by_contra hne
+  exact perfect_not_countable hP (Set.nonempty_iff_ne_empty.mpr hne)
+    (AlgebraicNumbersCountable.algebraic_reals_countable.mono hsub)
+
+/-- **The Cantor–Bendixson kernel of the complex algebraic numbers is empty.** The
+complex analogue of `algebraic_reals_no_perfect_subset`: the countable set
+`{z : ℂ | IsAlgebraic ℚ z}` contains no nonempty perfect subset. -/
+theorem algebraic_complex_no_perfect_subset {P : Set ℂ}
+    (hP : Perfect P) (hsub : P ⊆ {z : ℂ | IsAlgebraic ℚ z}) : P = ∅ := by
+  by_contra hne
+  exact perfect_not_countable hP (Set.nonempty_iff_ne_empty.mpr hne)
+    (AlgebraicNumbersCountable.algebraic_complex_countable.mono hsub)
 
 end AlgebraicRealsNull

--- a/src/data/proofs/algebraic-numbers-countable-oq-07/meta.json
+++ b/src/data/proofs/algebraic-numbers-countable-oq-07/meta.json
@@ -20,8 +20,8 @@
     "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 438,
-    "theoremCount": 16,
+    "lineCount": 487,
+    "theoremCount": 30,
     "definitionCount": 0,
     "dateAdded": "2026-06-21",
     "mathlibDependencies": [
@@ -136,10 +136,18 @@
       "endLine": 205,
       "summary": "Local instance `NoAtoms (volume : Measure ℂ)` by transporting singletons through ℂ ≃ᵐ ℝ × ℝ. `algebraic_complex_null`: complex algebraic numbers have planar measure zero. `ae_transcendental_complex`: almost every complex number is transcendental.",
       "mathContext": "$\\mathrm{vol}\\{z : \\mathbb{C} \\mid \\mathrm{IsAlgebraic}_\\mathbb{Q}\\,z\\} = 0$ via the atomless planar Lebesgue measure."
+    },
+    {
+      "id": "section-6-cantor-bendixson",
+      "title": "§6. Cantor–Bendixson: Empty Perfect Kernel",
+      "startLine": 438,
+      "endLine": 487,
+      "summary": "A fourth, order-topological smallness notion. `perfect_not_countable`: a nonempty perfect set in a complete metric space is uncountable, via the injection from Cantor space ℕ → Bool (`Perfect.exists_nat_bool_injection`) whose cardinality is the continuum 2^ℵ₀ > ℵ₀. `algebraic_reals_no_perfect_subset` and `algebraic_complex_no_perfect_subset`: the countable algebraic reals (resp. complex algebraic numbers) contain no nonempty perfect subset, so their Cantor–Bendixson kernel is empty.",
+      "mathContext": "A nonempty perfect $P\\subseteq\\mathbb{R}$ satisfies $|P|\\ge 2^{\\aleph_0}>\\aleph_0$, so $P\\subseteq\\{x\\mid\\mathrm{IsAlgebraic}_\\mathbb{Q}\\,x\\}$ (a countable set) forces $P=\\varnothing$."
     }
   ],
   "conclusion": {
-    "summary": "This entry completes the smallness trichotomy for the algebraic numbers by supplying its measure-theoretic pillar: the algebraic reals (and complex algebraic numbers) have Lebesgue measure zero, so almost every real (and complex) number is transcendental. The proof is short — a countable set is null because Lebesgue measure is atomless — but it records the one of the three independent smallness notions (cardinality, Baire category, measure) that was missing from the gallery. All 11 theorems are proved with 0 sorries and 0 axioms.",
+    "summary": "This entry completes the smallness trichotomy for the algebraic numbers by supplying its measure-theoretic pillar: the algebraic reals (and complex algebraic numbers) have Lebesgue measure zero, so almost every real (and complex) number is transcendental. The proof is short — a countable set is null because Lebesgue measure is atomless — but it records the one of the three independent smallness notions (cardinality, Baire category, measure) that was missing from the gallery. A fourth, order-topological, pillar is also recorded: since a nonempty perfect set in a complete metric space is uncountable (it injects Cantor space ℕ → Bool, of cardinality 2^ℵ₀ > ℵ₀), the countable algebraic reals contain no nonempty perfect subset, so their Cantor–Bendixson kernel is empty. All 30 theorems are proved with 0 sorries and 0 axioms.",
     "implications": "With this entry, the gallery records all three senses in which 'almost every real is transcendental': cardinality (ℵ₀ < 𝔠, parent entry), Baire category (the transcendentals are comeagre, `algebraic-reals-meager`), and measure (the transcendentals are conull, this entry). Because the three notions are logically independent, each is a genuinely separate theorem, and only by proving all three is the statement 'the algebraic reals are negligible' established in every standard sense.\n\nThe measure-theoretic existence corollary adds a third route to the existence of transcendentals — any positive-measure set contains one — complementing Cantor's counting proof and Liouville's explicit construction. This is the prototype of a probabilistic/measure-theoretic existence argument: a randomly chosen real (uniform on any interval) is transcendental with probability one.",
     "openQuestions": [
       "Refine 'measure zero' to 'Hausdorff dimension zero': a countable set has Hausdorff dimension 0, which is strictly stronger than Lebesgue-null. Formalizing $\\dim_H\\{x : \\mathrm{IsAlgebraic}_\\mathbb{Q}\\,x\\} = 0$ would sharpen this entry and connect to the fractal-geometry hierarchy of negligible sets.",
@@ -177,8 +185,8 @@
   ],
   "leanFile": {
     "path": "Proofs/AlgebraicRealsNull.lean",
-    "lineCount": 438,
-    "theoremCount": 28,
+    "lineCount": 487,
+    "theoremCount": 30,
     "axiomCount": 0,
     "definitionCount": 0,
     "sorries": 0


### PR DESCRIPTION
## Summary

Adds a **fourth, order-topological smallness pillar** to the `algebraic-numbers-countable-oq-07` gallery entry ("The Algebraic Reals are Lebesgue-Null"). The entry already records that the algebraic reals are small in the senses of **measure** (Lebesgue-null), **category** (meagre), and **cardinality** (countable). This PR adds the **Cantor–Bendixson** pillar from descriptive set theory: the algebraic reals have an **empty perfect kernel**.

## New theorems (`Proofs/AlgebraicRealsNull.lean`, §6)

- **`perfect_not_countable`** — a nonempty `Perfect` set in a complete metric space is uncountable. Proof: it admits a continuous injection from Cantor space `ℕ → Bool` (`Perfect.exists_nat_bool_injection`), whose cardinality is the continuum `2 ^ ℵ₀ > ℵ₀` (`Cardinal.cantor` + `Cardinal.mk_arrow`).
- **`algebraic_reals_no_perfect_subset`** — since the algebraic reals are countable, any `Perfect P ⊆ {x : ℝ | IsAlgebraic ℚ x}` is `∅`. The Cantor–Bendixson derivative process on the algebraic reals terminates at `∅`.
- **`algebraic_complex_no_perfect_subset`** — complex analogue.

## Verification

- Single-file `lake env lean Proofs/AlgebraicRealsNull.lean` against prebuilt Mathlib oleans: **EXIT 0, zero output** (0 sorry, 0 errors).
- `#print axioms` on all three new theorems: `[propext, Classical.choice, Quot.sound]` — the foundational three only. **No `sorry`, no `native_decide`, no `Lean.ofReduceBool`.** The entry remains genuinely axiom-free.
- File now **487 lines / 30 theorems**, still **0 sorry / 0 axiom**. `meta.json` updated (counts, new §6 section, conclusion text).

This advances the open question one genuine, machine-checked step (the pool named this angle "Cantor–Bendixson Decomposition of Algebraic Reals").

🤖 Generated with [Claude Code](https://claude.com/claude-code)
