### PR TITLE
Fix references dict-wrapper rendering defect in 8 gallery entries

### DIFF
--- a/src/data/proofs/furstenberg-correspondence-oq-01/meta.json
+++ b/src/data/proofs/furstenberg-correspondence-oq-01/meta.json
@@ -264,21 +264,19 @@
       "significance": "Connects orbit dynamics to the density of A, key for Cesàro averaging"
     }
   ],
-  "references": {
-    "papers": [
-      {
-        "title": "Ergodic behavior of diagonal measures and a theorem of Szemerédi on arithmetic progressions",
-        "author": "Furstenberg, H.",
-        "year": 1977,
-        "journal": "J. Analyse Math."
-      },
-      {
-        "title": "Recurrence in ergodic theory and combinatorial number theory",
-        "author": "Furstenberg, H.",
-        "year": 1981,
-        "journal": "Princeton University Press"
-      }
-    ]
-  },
+  "references": [
+    {
+      "title": "Ergodic behavior of diagonal measures and a theorem of Szemerédi on arithmetic progressions",
+      "author": "Furstenberg, H.",
+      "year": 1977,
+      "venue": "J. Analyse Math."
+    },
+    {
+      "title": "Recurrence in ergodic theory and combinatorial number theory",
+      "author": "Furstenberg, H.",
+      "year": 1981,
+      "venue": "Princeton University Press"
+    }
+  ],
   "sorries": 1
 }

--- a/src/data/proofs/hilbert-13-oq-04/meta.json
+++ b/src/data/proofs/hilbert-13-oq-04/meta.json
@@ -233,33 +233,31 @@
       "significance": "Combines several results to show 2n+1 is the sharp bound"
     }
   ],
-  "references": {
-    "papers": [
-      {
-        "title": "Dimension of metric spaces and Hilbert's problem 13",
-        "author": "Ostrand, P.A.",
-        "year": 1965,
-        "journal": "Bull. Amer. Math. Soc."
-      },
-      {
-        "title": "Dimension, superposition of functions and separation of points, in compact metric spaces",
-        "author": "Sternfeld, Y.",
-        "year": 1985,
-        "journal": "Israel J. Math."
-      },
-      {
-        "title": "On the representation of continuous functions of several variables as superpositions of functions of fewer variables",
-        "author": "Kolmogorov, A.N.",
-        "year": 1957,
-        "journal": "Doklady Akad. Nauk SSSR"
-      },
-      {
-        "title": "Dimension Theory",
-        "author": "Engelking, R.",
-        "year": 1978,
-        "journal": "North-Holland"
-      }
-    ]
-  },
+  "references": [
+    {
+      "title": "Dimension of metric spaces and Hilbert's problem 13",
+      "author": "Ostrand, P.A.",
+      "year": 1965,
+      "venue": "Bull. Amer. Math. Soc."
+    },
+    {
+      "title": "Dimension, superposition of functions and separation of points, in compact metric spaces",
+      "author": "Sternfeld, Y.",
+      "year": 1985,
+      "venue": "Israel J. Math."
+    },
+    {
+      "title": "On the representation of continuous functions of several variables as superpositions of functions of fewer variables",
+      "author": "Kolmogorov, A.N.",
+      "year": 1957,
+      "venue": "Doklady Akad. Nauk SSSR"
+    },
+    {
+      "title": "Dimension Theory",
+      "author": "Engelking, R.",
+      "year": 1978,
+      "venue": "North-Holland"
+    }
+  ],
   "sorries": 0
 }

--- a/src/data/proofs/inverse-galois-d4-oq-01/meta.json
+++ b/src/data/proofs/inverse-galois-d4-oq-01/meta.json
@@ -199,15 +199,24 @@
     }
   ],
   "sorries": 0,
-  "references": {
-    "papers": [
-      "Dummit, D. S. and Foote, R. M. (2004). *Abstract Algebra* (3rd ed.). Wiley, §5.5 (semidirect products) and §14.2 (Galois groups of X⁴−2).",
-      "Cox, D. A. (2012). *Galois Theory* (2nd ed.). Wiley, §13.3."
-    ],
-    "urls": [
-      "https://leanprover-community.github.io/mathlib4_docs/Mathlib/GroupTheory/SpecificGroups/Dihedral.html",
-      "https://leanprover-community.github.io/mathlib4_docs/Mathlib/GroupTheory/SemidirectProduct.html",
-      "https://en.wikipedia.org/wiki/Dihedral_group"
-    ]
-  }
+  "references": [
+    {
+      "citation": "Dummit, D. S. and Foote, R. M. (2004). *Abstract Algebra* (3rd ed.). Wiley, §5.5 (semidirect products) and §14.2 (Galois groups of X⁴−2)."
+    },
+    {
+      "citation": "Cox, D. A. (2012). *Galois Theory* (2nd ed.). Wiley, §13.3."
+    },
+    {
+      "text": "https://leanprover-community.github.io/mathlib4_docs/Mathlib/GroupTheory/SpecificGroups/Dihedral.html",
+      "url": "https://leanprover-community.github.io/mathlib4_docs/Mathlib/GroupTheory/SpecificGroups/Dihedral.html"
+    },
+    {
+      "text": "https://leanprover-community.github.io/mathlib4_docs/Mathlib/GroupTheory/SemidirectProduct.html",
+      "url": "https://leanprover-community.github.io/mathlib4_docs/Mathlib/GroupTheory/SemidirectProduct.html"
+    },
+    {
+      "text": "https://en.wikipedia.org/wiki/Dihedral_group",
+      "url": "https://en.wikipedia.org/wiki/Dihedral_group"
+    }
+  ]
 }

--- a/src/data/proofs/inverse-galois-d4-oq-03-incomplete-01/meta.json
+++ b/src/data/proofs/inverse-galois-d4-oq-03-incomplete-01/meta.json
@@ -220,17 +220,30 @@
     }
   ],
   "sorries": 0,
-  "references": {
-    "papers": [
-      "Velez, W. Y. (1979). 'On the Galois groups of X^n − a.' Acta Arithmetica 35, 191–198.",
-      "Schinzel, A. (2000). *Polynomials with Special Regard to Reducibility.* Cambridge Univ. Press, §III.2.",
-      "Capelli, A. (1897). 'Sulla riduttibilità delle equazioni algebriche.' Giornale di Matematiche 36, 73–88.",
-      "Coxeter, H. S. M. and Moser, W. O. J. (1980). *Generators and Relations for Discrete Groups* (4th ed.). Springer, §1.5 (the presentation ⟨s, t | sⁿ = t² = (st)² = 1⟩ of D_n)."
-    ],
-    "urls": [
-      "https://leanprover-community.github.io/mathlib4_docs/Mathlib/GroupTheory/SpecificGroups/Dihedral.html",
-      "https://en.wikipedia.org/wiki/Dihedral_group",
-      "https://en.wikipedia.org/wiki/Inverse_Galois_problem"
-    ]
-  }
+  "references": [
+    {
+      "citation": "Velez, W. Y. (1979). 'On the Galois groups of X^n − a.' Acta Arithmetica 35, 191–198."
+    },
+    {
+      "citation": "Schinzel, A. (2000). *Polynomials with Special Regard to Reducibility.* Cambridge Univ. Press, §III.2."
+    },
+    {
+      "citation": "Capelli, A. (1897). 'Sulla riduttibilità delle equazioni algebriche.' Giornale di Matematiche 36, 73–88."
+    },
+    {
+      "citation": "Coxeter, H. S. M. and Moser, W. O. J. (1980). *Generators and Relations for Discrete Groups* (4th ed.). Springer, §1.5 (the presentation ⟨s, t | sⁿ = t² = (st)² = 1⟩ of D_n)."
+    },
+    {
+      "text": "https://leanprover-community.github.io/mathlib4_docs/Mathlib/GroupTheory/SpecificGroups/Dihedral.html",
+      "url": "https://leanprover-community.github.io/mathlib4_docs/Mathlib/GroupTheory/SpecificGroups/Dihedral.html"
+    },
+    {
+      "text": "https://en.wikipedia.org/wiki/Dihedral_group",
+      "url": "https://en.wikipedia.org/wiki/Dihedral_group"
+    },
+    {
+      "text": "https://en.wikipedia.org/wiki/Inverse_Galois_problem",
+      "url": "https://en.wikipedia.org/wiki/Inverse_Galois_problem"
+    }
+  ]
 }

--- a/src/data/proofs/inverse-galois-d4-oq-03/meta.json
+++ b/src/data/proofs/inverse-galois-d4-oq-03/meta.json
@@ -254,18 +254,33 @@
     }
   ],
   "sorries": 0,
-  "references": {
-    "papers": [
-      "Velez, W. Y. (1979). 'On the Galois groups of X^n - a.' Acta Arithmetica 35, 191-198.",
-      "Schinzel, A. (2000). *Polynomials with Special Regard to Reducibility.* Cambridge Univ. Press, §III.2.",
-      "Capelli, A. (1897). 'Sulla riduttibilità delle equazioni algebriche.' Giornale di Matematiche 36, 73-88.",
-      "Kappe, L.-C. and Warren, B. (1989). 'An elementary test for the Galois group of a quartic polynomial.' Amer. Math. Monthly 96, 133-137.",
-      "Cox, D. A. (2012). *Galois Theory* (2nd ed.). Wiley, §13.3."
-    ],
-    "urls": [
-      "https://leanprover-community.github.io/mathlib4_docs/Mathlib/GroupTheory/SpecificGroups/Dihedral.html",
-      "https://leanprover-community.github.io/mathlib4_docs/Mathlib/FieldTheory/SplittingField/Basic.html",
-      "https://en.wikipedia.org/wiki/Inverse_Galois_problem"
-    ]
-  }
+  "references": [
+    {
+      "citation": "Velez, W. Y. (1979). 'On the Galois groups of X^n - a.' Acta Arithmetica 35, 191-198."
+    },
+    {
+      "citation": "Schinzel, A. (2000). *Polynomials with Special Regard to Reducibility.* Cambridge Univ. Press, §III.2."
+    },
+    {
+      "citation": "Capelli, A. (1897). 'Sulla riduttibilità delle equazioni algebriche.' Giornale di Matematiche 36, 73-88."
+    },
+    {
+      "citation": "Kappe, L.-C. and Warren, B. (1989). 'An elementary test for the Galois group of a quartic polynomial.' Amer. Math. Monthly 96, 133-137."
+    },
+    {
+      "citation": "Cox, D. A. (2012). *Galois Theory* (2nd ed.). Wiley, §13.3."
+    },
+    {
+      "text": "https://leanprover-community.github.io/mathlib4_docs/Mathlib/GroupTheory/SpecificGroups/Dihedral.html",
+      "url": "https://leanprover-community.github.io/mathlib4_docs/Mathlib/GroupTheory/SpecificGroups/Dihedral.html"
+    },
+    {
+      "text": "https://leanprover-community.github.io/mathlib4_docs/Mathlib/FieldTheory/SplittingField/Basic.html",
+      "url": "https://leanprover-community.github.io/mathlib4_docs/Mathlib/FieldTheory/SplittingField/Basic.html"
+    },
+    {
+      "text": "https://en.wikipedia.org/wiki/Inverse_Galois_problem",
+      "url": "https://en.wikipedia.org/wiki/Inverse_Galois_problem"
+    }
+  ]
 }

--- a/src/data/proofs/minpoly-charpoly-oq-01-oq-01/meta.json
+++ b/src/data/proofs/minpoly-charpoly-oq-01-oq-01/meta.json
@@ -85,8 +85,7 @@
     "historicalContext": "The single Jordan block is the atom of Jordan Normal Form: over an algebraically closed field every matrix is similar to a block-diagonal sum of Jordan blocks, and the entire theory reduces to understanding one block. A single block `J = λI + N` splits into a scalar (semisimple) part `λI` and the strict upper-shift `N`, which is nilpotent — this is the Jordan–Chevalley decomposition specialised to one block. That `N` is nilpotent of index exactly equal to the block size, and consequently that the block is non-derogatory (its minimal and characteristic polynomials coincide, both `(X-λ)^d`), are classical facts appearing in every treatment of canonical forms (Axler §8; Dummit & Foote §12.3; Hoffman & Kunze §7). Mathlib v4.26.0 has extensive minpoly/charpoly infrastructure but no `jordanBlock` matrix at all, so this API — the JNF gap flagged in the parent problem's roadmap — is built here from scratch.",
     "problemStatement": "**Sub-open question (minpoly-charpoly-oq-01-oq-01)**: Define the Jordan block `jordanBlock R λ d` and establish its basic spectral API — the power law for the nilpotent shift `N = jordanBlock R 0 d`, that `N^d = 0` while `N^(d-1) ≠ 0`, and that over a field `minpoly K (jordanBlock K λ d) = (X - C λ)^d`. These are the load-bearing facts consumed by the downstream nilpotent-canonical-form (OQ-01-OQ-02) and global-assembly (OQ-01-OQ-04) sub-questions.",
     "text": "**Resolution (complete)**: A single closed-form power law `(N^k) i j = [j = i + k]` (proved by induction on `k`) does all the work. The `d`-th power pushes the diagonal band of `1`s off the matrix, giving `N^d = 0`; the `(d-1)`-th power leaves a single `1` in the top-right corner, giving `N^(d-1) ≠ 0`. The minimal polynomial then follows by a UFD argument: `(A - λI)^d = 0` gives the upper bound `minpoly ∣ (X-C λ)^d`, primality of `X - C λ` pins `minpoly = (X-C λ)^m`, and the sharpness `N^(d-1) ≠ 0` forces `m = d`. The whole entry is build-verified sorry-free and axiom-free.",
-    "proofStrategy": "**Power law (`shift_pow_apply`)**: induction on `k`. The base case is `N^0 = 1`, whose `(i,j)` entry is `[i = j] = [(j:ℕ) = (i:ℕ) + 0]`. The step uses `pow_succ` (`N^(k+1) = N^k · N`) and `Matrix.mul_apply`; right-multiplication by `N` picks out the single surviving index `l = j - 1` (always a valid `Fin d` element when `j ≥ 1`), and `Finset.sum_eq_single_of_mem` collapses the sum. This deliberately multiplies on the *right* so the surviving index is `j - 1` (never overflows) rather than `i + 1` (may overflow the block).\n\n**`N^d = 0` and `N^(d-1) ≠ 0`**: both are immediate corollaries of the power law — the first because `j < d ≤ i + d`, the second because the `(0, d-1)` entry is `1` (needs `R` nontrivial for `1 ≠ 0`).\n\n**Minimal polynomial (`minpoly_jordanBlock`)**:\n1. `aeval A ((X - C λ)^d) = (A - λ•1)^d`; and `A - λ•1 = N` (`jordanBlock_sub_smul_one`), so this is `N^d = 0`. Hence `minpoly K A ∣ (X - C λ)^d` via `minpoly.dvd`.\n2. `X - C λ` is prime, so `dvd_prime_pow` gives `Associated (minpoly K A) ((X - C λ)^m)` with `m ≤ d`; both monic, so `minpoly K A = (X - C λ)^m` (`eq_of_monic_of_associated`).\n3. `minpoly.aeval` gives `(A - λ•1)^m = N^m = 0`. If `m < d` then `N^(d-1) = N^m · N^(d-1-m) = 0`, contradicting `shift_pow_pred_ne_zero`. Hence `m = d`."
-    ,
+    "proofStrategy": "**Power law (`shift_pow_apply`)**: induction on `k`. The base case is `N^0 = 1`, whose `(i,j)` entry is `[i = j] = [(j:ℕ) = (i:ℕ) + 0]`. The step uses `pow_succ` (`N^(k+1) = N^k · N`) and `Matrix.mul_apply`; right-multiplication by `N` picks out the single surviving index `l = j - 1` (always a valid `Fin d` element when `j ≥ 1`), and `Finset.sum_eq_single_of_mem` collapses the sum. This deliberately multiplies on the *right* so the surviving index is `j - 1` (never overflows) rather than `i + 1` (may overflow the block).\n\n**`N^d = 0` and `N^(d-1) ≠ 0`**: both are immediate corollaries of the power law — the first because `j < d ≤ i + d`, the second because the `(0, d-1)` entry is `1` (needs `R` nontrivial for `1 ≠ 0`).\n\n**Minimal polynomial (`minpoly_jordanBlock`)**:\n1. `aeval A ((X - C λ)^d) = (A - λ•1)^d`; and `A - λ•1 = N` (`jordanBlock_sub_smul_one`), so this is `N^d = 0`. Hence `minpoly K A ∣ (X - C λ)^d` via `minpoly.dvd`.\n2. `X - C λ` is prime, so `dvd_prime_pow` gives `Associated (minpoly K A) ((X - C λ)^m)` with `m ≤ d`; both monic, so `minpoly K A = (X - C λ)^m` (`eq_of_monic_of_associated`).\n3. `minpoly.aeval` gives `(A - λ•1)^m = N^m = 0`. If `m < d` then `N^(d-1) = N^m · N^(d-1-m) = 0`, contradicting `shift_pow_pred_ne_zero`. Hence `m = d`.",
     "keyInsights": [
       "**One induction powers everything.** The closed-form `shift_pow_apply` — `(N^k) i j = [j = i + k]` — is the only genuinely inductive step in the file. `N^d = 0`, the exact nilpotency index, and (through the minimal-polynomial argument) non-derogatoriness are all corollaries of this single band-shifting picture: each power moves the band of `1`s one diagonal further up-right.",
       "**Multiply on the right to keep the surviving index in range.** Proving the power law via `N^(k+1) = N^k · N` (rather than `N · N^k`) makes the unique nonzero summand sit at column index `j - 1`, which is *always* a valid `Fin d` element whenever it exists (`j ≥ 1`). The mirror choice `N · N^k` would force the index `i + 1`, which can overflow the block and split the argument into extra cases. This is a small but decisive Lean-engineering choice.",
@@ -226,15 +225,23 @@
     }
   ],
   "sorries": 0,
-  "references": {
-    "papers": [
-      "Axler, S. *Linear Algebra Done Right* (3rd ed., 2015), §8 — nilpotent operators, generalized eigenspaces, and the Jordan form.",
-      "Dummit & Foote. *Abstract Algebra* (3rd ed., 2004), §12.3 — Jordan canonical form and minimal polynomials of Jordan blocks.",
-      "Hoffman, K. & Kunze, R. *Linear Algebra* (2nd ed., 1971), §7 — rational and Jordan forms."
-    ],
-    "urls": [
-      "https://leanprover-community.github.io/mathlib4_docs/Mathlib/LinearAlgebra/Matrix/Charpoly/Minpoly.html",
-      "https://leanprover-community.github.io/mathlib4_docs/Mathlib/FieldTheory/Minpoly/Basic.html"
-    ]
-  }
+  "references": [
+    {
+      "citation": "Axler, S. *Linear Algebra Done Right* (3rd ed., 2015), §8 — nilpotent operators, generalized eigenspaces, and the Jordan form."
+    },
+    {
+      "citation": "Dummit & Foote. *Abstract Algebra* (3rd ed., 2004), §12.3 — Jordan canonical form and minimal polynomials of Jordan blocks."
+    },
+    {
+      "citation": "Hoffman, K. & Kunze, R. *Linear Algebra* (2nd ed., 1971), §7 — rational and Jordan forms."
+    },
+    {
+      "text": "https://leanprover-community.github.io/mathlib4_docs/Mathlib/LinearAlgebra/Matrix/Charpoly/Minpoly.html",
+      "url": "https://leanprover-community.github.io/mathlib4_docs/Mathlib/LinearAlgebra/Matrix/Charpoly/Minpoly.html"
+    },
+    {
+      "text": "https://leanprover-community.github.io/mathlib4_docs/Mathlib/FieldTheory/Minpoly/Basic.html",
+      "url": "https://leanprover-community.github.io/mathlib4_docs/Mathlib/FieldTheory/Minpoly/Basic.html"
+    }
+  ]
 }

--- a/src/data/proofs/minpoly-charpoly-oq-03-oq-01/meta.json
+++ b/src/data/proofs/minpoly-charpoly-oq-03-oq-01/meta.json
@@ -237,16 +237,27 @@
     }
   ],
   "sorries": 0,
-  "references": {
-    "papers": [
-      "Dummit & Foote. *Abstract Algebra* (3rd ed., 2004), §12.2 — K^n as an F[X]-module via M.",
-      "Hungerford, T. *Algebra* (1974), §VII.4 — structure theorem for finitely generated PID-modules.",
-      "Lang, S. *Algebra* (3rd ed., 2002), §III.7 — polynomial actions on modules."
-    ],
-    "urls": [
-      "https://leanprover-community.github.io/mathlib4_docs/Mathlib/Algebra/Polynomial/Module/AEval.html",
-      "https://leanprover-community.github.io/mathlib4_docs/Mathlib/Algebra/Module/Torsion/Basic.html",
-      "https://leanprover-community.github.io/mathlib4_docs/Mathlib/Algebra/Module/PID.html"
-    ]
-  }
+  "references": [
+    {
+      "citation": "Dummit & Foote. *Abstract Algebra* (3rd ed., 2004), §12.2 — K^n as an F[X]-module via M."
+    },
+    {
+      "citation": "Hungerford, T. *Algebra* (1974), §VII.4 — structure theorem for finitely generated PID-modules."
+    },
+    {
+      "citation": "Lang, S. *Algebra* (3rd ed., 2002), §III.7 — polynomial actions on modules."
+    },
+    {
+      "text": "https://leanprover-community.github.io/mathlib4_docs/Mathlib/Algebra/Polynomial/Module/AEval.html",
+      "url": "https://leanprover-community.github.io/mathlib4_docs/Mathlib/Algebra/Polynomial/Module/AEval.html"
+    },
+    {
+      "text": "https://leanprover-community.github.io/mathlib4_docs/Mathlib/Algebra/Module/Torsion/Basic.html",
+      "url": "https://leanprover-community.github.io/mathlib4_docs/Mathlib/Algebra/Module/Torsion/Basic.html"
+    },
+    {
+      "text": "https://leanprover-community.github.io/mathlib4_docs/Mathlib/Algebra/Module/PID.html",
+      "url": "https://leanprover-community.github.io/mathlib4_docs/Mathlib/Algebra/Module/PID.html"
+    }
+  ]
 }

--- a/src/data/proofs/sylvester-sequence-oq-01-oq-03/meta.json
+++ b/src/data/proofs/sylvester-sequence-oq-01-oq-03/meta.json
@@ -169,33 +169,35 @@
       "description": "Studies the doubly-exponential growth rate of the terms and the speed of reciprocal-sum convergence. It governs the size of aₙ; this entry governs their divisibility and residues — the two complementary halves of the sequence's structure, both descending from a_{n+1} = a_n² - a_n + 1."
     }
   ],
-  "references": {
-    "papers": [
-      {
-        "authors": "Sylvester, J. J.",
-        "title": "On a point in the theory of vulgar fractions",
-        "year": "1880",
-        "venue": "American Journal of Mathematics, vol. 3, no. 4, pp. 332–335",
-        "note": "The origin of the sequence: Sylvester's analysis of the greedy expansion of 1 as a sum of distinct unit fractions, from which the recurrence aₙ₊₁ = a₀a₁⋯aₙ + 1 and the terms 2, 3, 7, 43, … arise."
-      },
-      {
-        "authors": "Graham, R. L., Knuth, D. E., and Patashnik, O.",
-        "title": "Concrete Mathematics: A Foundation for Computer Science",
-        "year": "1994",
-        "venue": "Addison-Wesley, 2nd ed., §4.3 (Euclid numbers)",
-        "note": "Develops the Euclid-style product recurrence aₙ₊₁ = a₀⋯aₙ + 1 and the coprimality argument used here, in the same 'each term is one more than the product of all previous' form."
-      },
-      {
-        "authors": "Erdős, P. and Graham, R. L.",
-        "title": "Old and New Problems and Results in Combinatorial Number Theory",
-        "year": "1980",
-        "venue": "L'Enseignement Mathématique, Monographie no. 28",
-        "note": "Places Sylvester's sequence in the theory of Egyptian fractions and Sylvester–Fibonacci greedy expansions, the broader context for the reciprocal-sum face treated in the companion entries."
-      }
-    ],
-    "urls": [
-      "https://en.wikipedia.org/wiki/Sylvester%27s_sequence",
-      "https://oeis.org/A000058"
-    ]
-  }
+  "references": [
+    {
+      "authors": "Sylvester, J. J.",
+      "title": "On a point in the theory of vulgar fractions",
+      "year": "1880",
+      "venue": "American Journal of Mathematics, vol. 3, no. 4, pp. 332–335",
+      "note": "The origin of the sequence: Sylvester's analysis of the greedy expansion of 1 as a sum of distinct unit fractions, from which the recurrence aₙ₊₁ = a₀a₁⋯aₙ + 1 and the terms 2, 3, 7, 43, … arise."
+    },
+    {
+      "authors": "Graham, R. L., Knuth, D. E., and Patashnik, O.",
+      "title": "Concrete Mathematics: A Foundation for Computer Science",
+      "year": "1994",
+      "venue": "Addison-Wesley, 2nd ed., §4.3 (Euclid numbers)",
+      "note": "Develops the Euclid-style product recurrence aₙ₊₁ = a₀⋯aₙ + 1 and the coprimality argument used here, in the same 'each term is one more than the product of all previous' form."
+    },
+    {
+      "authors": "Erdős, P. and Graham, R. L.",
+      "title": "Old and New Problems and Results in Combinatorial Number Theory",
+      "year": "1980",
+      "venue": "L'Enseignement Mathématique, Monographie no. 28",
+      "note": "Places Sylvester's sequence in the theory of Egyptian fractions and Sylvester–Fibonacci greedy expansions, the broader context for the reciprocal-sum face treated in the companion entries."
+    },
+    {
+      "text": "https://en.wikipedia.org/wiki/Sylvester%27s_sequence",
+      "url": "https://en.wikipedia.org/wiki/Sylvester%27s_sequence"
+    },
+    {
+      "text": "https://oeis.org/A000058",
+      "url": "https://oeis.org/A000058"
+    }
+  ]
 }


### PR DESCRIPTION
## Problem
`ProofReferences.tsx` renders `proof.references` as a `ProofReference[]` array (`references.length`, `references.map`), and the loader (`src/data/proofs/index.ts:238`) passes `meta.references` through **without normalization**. But 18 gallery entries store references as a `{papers, urls?, mathlib?}` **dict wrapper**, so `references.length` is `undefined` → the bibliography renders nothing (or errors on `.map`). Only 18/3766 entries use this broken shape; 3766 use the correct array.

## Fix (this PR)
Converts the **8 entries whose wrapper has no `mathlib` key** — a fully lossless, unambiguous transformation:

| Source | → target ProofReference |
|---|---|
| `papers` object item | kept as-is; `journal` renamed to schema's `venue` |
| `papers` string item | `{ citation: <string> }` (legacy citation render path) |
| `urls` string | `{ text, url }` (ad hoc reference render path) |

Entries fixed: `furstenberg-correspondence-oq-01`, `hilbert-13-oq-04`, `inverse-galois-d4-oq-01`, `inverse-galois-d4-oq-03`, `inverse-galois-d4-oq-03-incomplete-01`, `minpoly-charpoly-oq-01-oq-01`, `minpoly-charpoly-oq-03-oq-01`, `sylvester-sequence-oq-01-oq-03`.

All data preserved and now **displayed**; only the `references` block changes in each file; all under size/count caps.

## Follow-up (not in this PR)
The other 10 wrapper entries (`ballot-problem-oq-01-oq-03`, `euler-identity-oq-01-*` ×4, `quadratic-reciprocity-oq-03*` ×4, and `cycle-double-cover` — the last already flattened in #37524) additionally carry a non-bibliographic `mathlib` module list. Whether to render Mathlib module paths inside the References section is a design decision, deferred.