### PR TITLE
research(cantor-diagonalization-oq-06-oq-01): explicit constructive diagonal real [VERIFIED 0 sorry / 0 axiom]

### DIFF
--- a/proofs/Proofs/CantorDiagonalizationOQ06OQ01.lean
+++ b/proofs/Proofs/CantorDiagonalizationOQ06OQ01.lean
@@ -1,0 +1,209 @@
+/-
+# Cantor Diagonalization OQ-06-OQ-01: the explicit diagonal real
+
+## Open Question
+The parent entry `CantorDiagonalizationOQ06` proves `¬ Countable ℝ` abstractly, through
+the cardinal inequality `ℵ₀ < #ℝ` (Mathlib's `Cardinal.not_countable_real`). This entry
+supplies Cantor's *constructive* 1891 diagonal argument at the level of decimal digits:
+given any enumeration `f : ℕ → ℝ` it builds an **explicit, definable** real
+`diagonalReal f` and proves directly, digit by digit, that `diagonalReal f ≠ f n` for
+every `n` — with no appeal to `Cardinal.not_countable_real` or `#ℝ = 𝔠`.
+
+## Construction
+* `digit r n := ⌊r * 10^(n+1)⌋ % 10` is the `n`-th decimal digit of `r` (an integer in
+  `[0,10)`).
+* `db f n := if digit (f n) n = 1 then 2 else 1` is a digit in `{1,2}` that *disagrees*
+  with the `n`-th digit of `f n`.  Restricting the produced digits to `{1,2}` sidesteps
+  the `0.999… = 1.000…` non-uniqueness that would make a naive digit argument false.
+* `diagonalReal f := ∑' n, (db f n : ℝ) / 10^(n+1)` assembles the disagreeing digits into
+  a real in `[0,1]`.
+
+The crux lemma `digit_diagonalReal : digit (diagonalReal f) n = db f n` is proved by a
+head/tail split of `diagonalReal f * 10^(n+1) = A + T`, where `A : ℤ` is the integer head
+and `0 ≤ T ≤ 2/9 < 1` is a geometric tail, so `⌊diagonalReal f * 10^(n+1)⌋ = A` and
+`A % 10 = db f n`.  Then `diagonalReal f = f n` would force
+`digit (diagonalReal f) n = digit (f n) n`, contradicting `db f n ≠ digit (f n) n`.
+
+Sorry-free and axiom-free.  Uses only foundational axioms
+`[propext, Classical.choice, Quot.sound]`.
+-/
+import Mathlib
+
+namespace CantorDiagonalizationOQ06OQ01
+
+/-- The `n`-th decimal digit of a real number `r`, as an integer in `[0,10)`. -/
+noncomputable def digit (r : ℝ) (n : ℕ) : ℤ := ⌊r * 10 ^ (n + 1)⌋ % 10
+
+/-- The diagonal digit at position `n`: a value in `{1,2}` chosen to differ from the
+`n`-th digit of `f n`. -/
+noncomputable def db (f : ℕ → ℝ) (n : ℕ) : ℤ := if digit (f n) n = 1 then 2 else 1
+
+/-- **Cantor's explicit diagonal real.**  Given an enumeration `f : ℕ → ℝ`, the digits
+`db f n ∈ {1,2}` assemble into a real number in `[0,1]`. -/
+noncomputable def diagonalReal (f : ℕ → ℝ) : ℝ := ∑' n, (db f n : ℝ) / 10 ^ (n + 1)
+
+/-! ## Elementary facts about the diagonal digits -/
+
+theorem db_eq (f : ℕ → ℝ) (n : ℕ) : db f n = 1 ∨ db f n = 2 := by
+  unfold db; split_ifs <;> simp
+
+theorem db_pos (f : ℕ → ℝ) (n : ℕ) : 0 < db f n := by
+  rcases db_eq f n with h | h <;> rw [h] <;> norm_num
+
+theorem db_le_two (f : ℕ → ℝ) (n : ℕ) : db f n ≤ 2 := by
+  rcases db_eq f n with h | h <;> rw [h] <;> norm_num
+
+/-- The diagonal digit differs from the `n`-th digit of `f n` — the heart of the
+disagreement. -/
+theorem db_ne_digit (f : ℕ → ℝ) (n : ℕ) : db f n ≠ digit (f n) n := by
+  unfold db
+  split_ifs with h
+  · rw [h]; norm_num
+  · exact fun hc => h hc.symm
+
+/-! ## Summability -/
+
+/-- A generic term bound: `db f m / 10^(i+1) ≤ 2 * (1/10)^(i+1)`, valid for any index `m`
+appearing in the numerator. -/
+theorem term_le' (f : ℕ → ℝ) (m i : ℕ) :
+    (db f m : ℝ) / 10 ^ (i + 1) ≤ 2 * (1 / 10) ^ (i + 1) := by
+  rw [div_pow, one_pow, mul_one_div]
+  gcongr
+  exact_mod_cast db_le_two f m
+
+/-- Each term of the defining series is nonnegative. -/
+theorem term_nonneg (f : ℕ → ℝ) (m i : ℕ) : 0 ≤ (db f m : ℝ) / 10 ^ (i + 1) := by
+  apply div_nonneg
+  · exact_mod_cast (db_pos f m).le
+  · positivity
+
+/-- The shifted geometric series `∑' i, 2 * (1/10)^(i+1)` is summable. -/
+theorem summable_geo_shift : Summable (fun i : ℕ => 2 * (1 / 10 : ℝ) ^ (i + 1)) := by
+  apply Summable.mul_left
+  exact (summable_nat_add_iff 1).mpr
+    (summable_geometric_of_lt_one (by norm_num) (by norm_num))
+
+/-- The defining series of `diagonalReal` is summable. -/
+theorem summable_term (f : ℕ → ℝ) :
+    Summable (fun k => (db f k : ℝ) / 10 ^ (k + 1)) := by
+  apply Summable.of_nonneg_of_le (fun k => term_nonneg f k k) (fun k => term_le' f k k)
+  exact summable_geo_shift
+
+/-! ## The head/tail decomposition -/
+
+/-- The integer head: `A f n = ∑_{i≤n} db f i * 10^(n-i)`.  This is an integer whose last
+decimal digit is `db f n`. -/
+noncomputable def headInt (f : ℕ → ℝ) (n : ℕ) : ℤ :=
+  ∑ i ∈ Finset.range (n + 1), db f i * 10 ^ (n - i)
+
+/-- The head sum over reals equals `(headInt f n : ℝ)`. -/
+theorem head_real_eq (f : ℕ → ℝ) (n : ℕ) :
+    (∑ i ∈ Finset.range (n + 1), (db f i : ℝ) / 10 ^ (i + 1)) * 10 ^ (n + 1)
+      = (headInt f n : ℝ) := by
+  rw [Finset.sum_mul, headInt]
+  push_cast
+  apply Finset.sum_congr rfl
+  intro i hi
+  have hin : i ≤ n := by simp only [Finset.mem_range] at hi; omega
+  have hpow : (10 : ℝ) ^ (n + 1) / 10 ^ (i + 1) = 10 ^ (n - i) := by
+    rw [eq_comm, eq_div_iff (by positivity), ← pow_add]
+    congr 1; omega
+  rw [div_mul_eq_mul_div, mul_div_assoc, hpow]
+
+/-- The `A % 10 = db f n` step: the last decimal digit of the head is `db f n`. -/
+theorem headInt_emod (f : ℕ → ℝ) (n : ℕ) : headInt f n % 10 = db f n := by
+  rw [headInt, Finset.sum_range_succ]
+  simp only [Nat.sub_self, pow_zero, mul_one]
+  set S := ∑ i ∈ Finset.range n, db f i * 10 ^ (n - i) with hS
+  have hdvd : (10 : ℤ) ∣ S := by
+    rw [hS]
+    apply Finset.dvd_sum
+    intro i hi
+    have hin : i < n := by simpa only [Finset.mem_range] using hi
+    have he : n - i = (n - 1 - i) + 1 := by omega
+    rw [he, pow_succ, ← mul_assoc]
+    exact dvd_mul_left 10 (db f i * 10 ^ (n - 1 - i))
+  obtain ⟨B, hB⟩ := hdvd
+  rw [hB, add_comm, Int.add_mul_emod_self_left]
+  exact Int.emod_eq_of_lt (db_pos f n).le (by have := db_le_two f n; omega)
+
+/-! ## The crux lemma -/
+
+/-- **Crux:** the `n`-th digit of the diagonal real is exactly `db f n`. -/
+theorem digit_diagonalReal (f : ℕ → ℝ) (n : ℕ) :
+    digit (diagonalReal f) n = db f n := by
+  have hsum := summable_term f
+  -- Split the series at n+1: diagonalReal f = head + tail.
+  have hsplit := Summable.sum_add_tsum_nat_add (f := fun k => (db f k : ℝ) / 10 ^ (k + 1))
+    (n + 1) hsum
+  set tail := ∑' i, (db f (i + (n + 1)) : ℝ) / 10 ^ (i + (n + 1) + 1) with htail_def
+  have hx : diagonalReal f =
+      (∑ i ∈ Finset.range (n + 1), (db f i : ℝ) / 10 ^ (i + 1)) + tail := by
+    rw [diagonalReal, htail_def]; exact hsplit.symm
+  -- Multiply through by 10^(n+1).
+  have hxmul : diagonalReal f * 10 ^ (n + 1)
+      = (headInt f n : ℝ) + tail * 10 ^ (n + 1) := by
+    rw [hx, add_mul, head_real_eq]
+  set T := tail * 10 ^ (n + 1) with hT_def
+  -- The scaled tail equals ∑' i, db f (i+n+1) / 10^(i+1).
+  have hT_eq : T = ∑' i, (db f (i + (n + 1)) : ℝ) / 10 ^ (i + 1) := by
+    rw [hT_def, htail_def, ← tsum_mul_right]
+    apply tsum_congr
+    intro i
+    have hp : (10 : ℝ) ^ (i + (n + 1) + 1) = 10 ^ (i + 1) * 10 ^ (n + 1) := by
+      rw [← pow_add]; congr 1; omega
+    have h1 : (10 : ℝ) ^ (i + 1) ≠ 0 := by positivity
+    have h2 : (10 : ℝ) ^ (n + 1) ≠ 0 := by positivity
+    rw [hp]; field_simp
+  -- Tail is nonnegative.
+  have hT_nonneg : 0 ≤ T := by
+    rw [hT_eq]
+    exact tsum_nonneg fun i => term_nonneg f (i + (n + 1)) i
+  -- Tail is summable (comparison with geometric).
+  have hT_summ : Summable (fun i => (db f (i + (n + 1)) : ℝ) / 10 ^ (i + 1)) :=
+    Summable.of_nonneg_of_le (fun i => term_nonneg f (i + (n + 1)) i)
+      (fun i => term_le' f (i + (n + 1)) i) summable_geo_shift
+  -- Tail < 1.
+  have hT_lt : T < 1 := by
+    rw [hT_eq]
+    calc ∑' i, (db f (i + (n + 1)) : ℝ) / 10 ^ (i + 1)
+        ≤ ∑' i, 2 * (1 / 10 : ℝ) ^ (i + 1) :=
+          Summable.tsum_le_tsum (fun i => term_le' f (i + (n + 1)) i) hT_summ summable_geo_shift
+      _ = 2 * ∑' i, (1 / 10 : ℝ) ^ (i + 1) := by rw [tsum_mul_left]
+      _ = 2 * ((∑' i, (1 / 10 : ℝ) ^ i) * (1 / 10)) := by
+            congr 1
+            rw [← tsum_mul_right]
+            apply tsum_congr; intro i; rw [pow_succ]
+      _ = 2 * ((1 - 1 / 10 : ℝ)⁻¹ * (1 / 10)) := by
+            rw [tsum_geometric_of_lt_one (by norm_num) (by norm_num)]
+      _ < 1 := by norm_num
+  -- Floor of x * 10^(n+1) is headInt f n.
+  have hfloor : ⌊diagonalReal f * 10 ^ (n + 1)⌋ = headInt f n := by
+    have hTfloor : ⌊T⌋ = 0 := by
+      rw [Int.floor_eq_zero_iff]; exact ⟨hT_nonneg, hT_lt⟩
+    rw [hxmul, Int.floor_intCast_add, hTfloor, add_zero]
+  rw [digit, hfloor, headInt_emod]
+
+/-! ## The diagonal real differs from every listed real -/
+
+/-- **Diagonal disagreement.**  The explicit real `diagonalReal f` is different from every
+term `f n` of the enumeration, because their `n`-th decimal digits differ. -/
+theorem diagonalReal_ne (f : ℕ → ℝ) (n : ℕ) : diagonalReal f ≠ f n := by
+  intro hEq
+  have hdig : digit (diagonalReal f) n = digit (f n) n := by rw [hEq]
+  rw [digit_diagonalReal] at hdig
+  exact db_ne_digit f n hdig
+
+/-- **Cantor's constructive theorem:** no `f : ℕ → ℝ` is surjective, witnessed explicitly
+by `diagonalReal f`. -/
+theorem not_surjective_nat_real (f : ℕ → ℝ) : ¬ Function.Surjective f := by
+  intro hf
+  obtain ⟨n, hn⟩ := hf (diagonalReal f)
+  exact diagonalReal_ne f n hn.symm
+
+/-- The reals are uncountable, proved via the explicit diagonal witness (no appeal to
+`Cardinal.not_countable_real`). -/
+theorem not_exists_surjective_nat_real : ¬ ∃ f : ℕ → ℝ, Function.Surjective f :=
+  fun ⟨f, hf⟩ => not_surjective_nat_real f hf
+
+end CantorDiagonalizationOQ06OQ01

--- a/src/data/proofs/cantor-diagonalization-oq-06-oq-01/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-06-oq-01/meta.json
@@ -1,0 +1,186 @@
+{
+  "id": "cantor-diagonalization-oq-06-oq-01",
+  "title": "Cantor's Explicit Diagonal Real",
+  "slug": "cantor-diagonalization-oq-06-oq-01",
+  "description": "A constructive, digit-level form of Cantor's 1891 diagonal argument: for any enumeration f : ℕ → ℝ, an explicit definable real diagonalReal f is built whose n-th decimal digit differs from that of f n, giving diagonalReal f ≠ f n directly — with no appeal to Cardinal.not_countable_real or #ℝ = 𝔠.",
+  "meta": {
+    "author": "Cantor (formalized in Lean 4 with Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Cantor%27s_diagonal_argument",
+    "date": "1891",
+    "status": "verified",
+    "tags": [
+      "set-theory",
+      "cardinality",
+      "cantor",
+      "uncountability",
+      "real-numbers",
+      "constructive",
+      "diagonal-argument",
+      "extension",
+      "research"
+    ],
+    "proofRepoPath": "Proofs/CantorDiagonalizationOQ06OQ01.lean",
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Summable.sum_add_tsum_nat_add",
+        "description": "Splits an infinite sum into a finite head ∑_{i<k} f i and a tail ∑' i, f (i+k) — the head/tail decomposition of the diagonal real times 10^(n+1)",
+        "module": "Mathlib.Topology.Algebra.InfiniteSum.NatInt"
+      },
+      {
+        "theorem": "tsum_geometric_of_lt_one",
+        "description": "∑' n, r^n = (1-r)⁻¹ for 0 ≤ r < 1 — used to bound the geometric tail by 2/9 < 1",
+        "module": "Mathlib.Analysis.SpecificLimits.Basic"
+      },
+      {
+        "theorem": "Int.floor_eq_zero_iff",
+        "description": "⌊r⌋ = 0 ↔ r ∈ [0,1) — pins the floor of the fractional tail to 0",
+        "module": "Mathlib.Algebra.Order.Floor.Ring"
+      },
+      {
+        "theorem": "Int.add_mul_emod_self_left",
+        "description": "(a + b*c) % b = a % b — extracts the last decimal digit db f n from the integer head A = db f n + 10*B",
+        "module": "Mathlib.Data.Int.Order"
+      }
+    ],
+    "originalContributions": [
+      "digit r n := ⌊r * 10^(n+1)⌋ % 10: an explicit n-th decimal digit function on ℝ",
+      "db f n := if digit (f n) n = 1 then 2 else 1: a disagreeing digit valued in {1,2}, dodging the 0.999…=1.000… non-uniqueness obstruction",
+      "diagonalReal f := ∑' n, (db f n)/10^(n+1): the explicit, definable diagonal real witness",
+      "digit_diagonalReal: the crux lemma digit (diagonalReal f) n = db f n, proved by a head/tail split with an integer head and a geometric tail 0 ≤ T ≤ 2/9 < 1",
+      "diagonalReal_ne: diagonalReal f ≠ f n for every n, by direct digit disagreement",
+      "not_surjective_nat_real / not_exists_surjective_nat_real: Cantor's theorem in enumeration form, witnessed constructively rather than via cardinality"
+    ],
+    "dateAdded": "2026-07-11",
+    "lineCount": 209,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries; #print axioms reports only [propext, Classical.choice, Quot.sound]. No use of Cardinal.not_countable_real.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 14,
+    "definitionCount": 4
+  },
+  "overview": {
+    "historicalContext": "Cantor's 1874 proof that the reals are uncountable was recast in 1891 as the diagonal argument: given any list r₀, r₁, r₂, … of reals, build a new real x whose n-th digit differs from the n-th digit of rₙ, so x cannot equal any rₙ and the list is incomplete. This constructive form — an actual witness x, defined explicitly from the list — is strictly stronger than the non-constructive cardinal inequality ℵ₀ < #ℝ, and it is the version taught in every first course. The parent gallery entry cantor-diagonalization-oq-06 proves ¬ Countable ℝ through Mathlib's Cardinal.not_countable_real; its stated open question asks precisely for the self-contained diagonal construction supplied here. The same diagonal mechanism underlies Cantor's theorem #A < #𝒫(A), Turing's halting problem, Gödel's incompleteness, and Russell's paradox.",
+    "problemStatement": "**Open Question (cantor-diagonalization-oq-06-oq-01)**: Define an explicit, definable map diagonalReal : (ℕ → ℝ) → ℝ producing, for any enumeration f, a witness with diagonalReal f ≠ f n for all n, proved by direct digit comparison rather than via Cardinal.not_countable_real or #ℝ = 𝔠.\n\n**Result**: diagonalReal f := ∑' n, (db f n)/10^(n+1) with db f n ∈ {1,2}, and the theorems digit_diagonalReal (its n-th digit is db f n), diagonalReal_ne (it differs from every f n), and the enumeration form not_surjective_nat_real.",
+    "text": "An explicit real diagonalReal f, defined from the list f, whose n-th decimal digit differs from that of f n — so diagonalReal f ≠ f n for every n, and no f : ℕ → ℝ is surjective.",
+    "proofStrategy": "**Proof Strategy.**\n\n1. **Digit extraction.** digit r n := ⌊r · 10^(n+1)⌋ % 10 reads off the n-th decimal digit of r as an integer in [0,10).\n2. **Disagreeing digit.** db f n := if digit (f n) n = 1 then 2 else 1 always differs from digit (f n) n and lies in {1,2}. Restricting the produced digits to {1,2} avoids the 0.999…=1.000… non-uniqueness that would break a naive argument.\n3. **The witness.** diagonalReal f := ∑' n, (db f n)/10^(n+1) is summable by comparison with a geometric series and lies in [0,1].\n4. **Crux lemma.** digit (diagonalReal f) n = db f n: multiply by 10^(n+1) and split the sum at n+1 into an integer head A = ∑_{i≤n} db f i · 10^(n-i) and a tail T with 0 ≤ T ≤ 2·(1/9) = 2/9 < 1. Then ⌊diagonalReal f · 10^(n+1)⌋ = A, and A % 10 = db f n because A = db f n + 10·B.\n5. **Disagreement.** If diagonalReal f = f n, then digit (diagonalReal f) n = digit (f n) n, contradicting digit (diagonalReal f) n = db f n ≠ digit (f n) n. Hence diagonalReal f ≠ f n, so f is not surjective.",
+    "keyInsights": [
+      "**A constructive witness, not a cardinal inequality.** Unlike the parent entry's route through ℵ₀ < #ℝ, diagonalReal f is an explicit definable real; the disagreement diagonalReal f ≠ f n is proved by exhibiting the differing digit, so the argument carries a witness rather than a mere existence claim.",
+      "**Digits in {1,2} defuse expansion non-uniqueness.** The naive 'flip the n-th digit' argument is subtly false because e.g. 0.4999… = 0.5000…. Forcing every produced digit into {1,2} makes the decimal expansion of diagonalReal f unambiguous at the compared position, so digit reads back exactly db f n.",
+      "**Head/tail split turns an analytic identity into integer arithmetic.** Multiplying by 10^(n+1) and splitting the series at index n+1 isolates an integer head A whose last decimal digit is db f n; the fractional tail is a geometric series bounded by 2/9 < 1, so the floor sees exactly A. This reduces the digit computation to (db f n + 10·B) % 10 = db f n.",
+      "**Answers the parent's open question.** cantor-diagonalization-oq-06 explicitly asks to 'formalize a self-contained diagonal construction (an explicit real missing from a given list) rather than routing through cardinality' — this entry is that construction, verified with 0 axioms and no appeal to Cardinal.not_countable_real.",
+      "**The diagonal template is reusable.** digit / db / the head-tail floor computation form a self-contained mechanism for building a real disagreeing with a prescribed sequence, transplantable to other diagonalizations in the gallery."
+    ],
+    "prerequisites": [
+      "Infinite sums (tsum) and summability by geometric comparison in Mathlib",
+      "The floor function ⌊·⌋ : ℝ → ℤ and integer modular arithmetic",
+      "Decimal digit extraction and the 0.999…=1.000… expansion non-uniqueness"
+    ]
+  },
+  "sections": [
+    {
+      "id": "definitions",
+      "title": "Digit, Disagreeing Digit, and the Diagonal Real",
+      "startLine": 36,
+      "endLine": 47,
+      "summary": "digit r n extracts the n-th decimal digit; db f n picks a value in {1,2} disagreeing with digit (f n) n; diagonalReal f assembles the db f n into a real in [0,1].",
+      "mathContext": "$\\mathrm{digit}\\,r\\,n = \\lfloor r\\cdot 10^{n+1}\\rfloor \\bmod 10$, $\\mathrm{db}\\,f\\,n \\in \\{1,2\\}$, $\\mathrm{diagonalReal}\\,f = \\sum_n \\mathrm{db}\\,f\\,n / 10^{n+1}$."
+    },
+    {
+      "id": "digit-facts",
+      "title": "Elementary Facts About the Diagonal Digits",
+      "startLine": 49,
+      "endLine": 71,
+      "summary": "db_eq / db_pos / db_le_two bound db f n in {1,2}; db_ne_digit is the key disagreement db f n ≠ digit (f n) n.",
+      "mathContext": "$\\mathrm{db}\\,f\\,n \\in \\{1,2\\}$ and $\\mathrm{db}\\,f\\,n \\neq \\mathrm{digit}\\,(f\\,n)\\,n$."
+    },
+    {
+      "id": "summability",
+      "title": "Summability of the Defining Series",
+      "startLine": 73,
+      "endLine": 103,
+      "summary": "term_le' / term_nonneg bound each term by a geometric term; summable_geo_shift and summable_term establish that ∑' n, db f n / 10^(n+1) converges.",
+      "mathContext": "$0 \\le \\mathrm{db}\\,f\\,k/10^{k+1} \\le 2\\,(1/10)^{k+1}$, a convergent geometric bound."
+    },
+    {
+      "id": "head-tail",
+      "title": "The Head/Tail Decomposition",
+      "startLine": 105,
+      "endLine": 147,
+      "summary": "headInt f n is the integer head ∑_{i≤n} db f i · 10^(n-i); head_real_eq identifies the real head sum with it, and headInt_emod proves headInt f n % 10 = db f n.",
+      "mathContext": "$A = \\sum_{i\\le n} \\mathrm{db}\\,f\\,i\\cdot 10^{n-i}$, $A \\bmod 10 = \\mathrm{db}\\,f\\,n$."
+    },
+    {
+      "id": "crux",
+      "title": "Crux: the n-th Digit of the Diagonal Real",
+      "startLine": 149,
+      "endLine": 194,
+      "summary": "digit_diagonalReal splits diagonalReal f · 10^(n+1) into the integer head and a geometric tail 0 ≤ T ≤ 2/9 < 1, so the floor equals headInt f n and its last digit is db f n.",
+      "mathContext": "$\\mathrm{digit}\\,(\\mathrm{diagonalReal}\\,f)\\,n = \\mathrm{db}\\,f\\,n$."
+    },
+    {
+      "id": "disagreement",
+      "title": "Diagonal Disagreement and Uncountability",
+      "startLine": 196,
+      "endLine": 209,
+      "summary": "diagonalReal_ne (diagonalReal f ≠ f n for all n), not_surjective_nat_real, and not_exists_surjective_nat_real — Cantor's theorem in constructive enumeration form.",
+      "mathContext": "For every $f:\\mathbb{N}\\to\\mathbb{R}$, $\\mathrm{diagonalReal}\\,f \\neq f\\,n$ for all $n$, so $f$ is not surjective."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "cantor-diagonalization-oq-06",
+      "relationship": "extends",
+      "description": "Supplies the self-contained diagonal construction that the parent entry's open question asks for, replacing its route through Cardinal.not_countable_real"
+    },
+    {
+      "targetId": "cantor-diagonalization",
+      "relationship": "related",
+      "description": "The binary-sequence diagonal (flip the n-th bit) recast for actual real numbers via decimal digits"
+    },
+    {
+      "targetId": "cantors-theorem",
+      "relationship": "related",
+      "description": "The digit-level diagonal is the A = ℕ instance of Cantor's theorem #A < #𝒫(A)"
+    }
+  ],
+  "conclusion": {
+    "summary": "A complete, fully verified (0 sorries, 0 axioms) constructive form of Cantor's diagonal argument: an explicit definable real diagonalReal f whose n-th decimal digit differs from that of f n, giving diagonalReal f ≠ f n directly and hence that no f : ℕ → ℝ is surjective — without invoking Cardinal.not_countable_real or #ℝ = 𝔠.",
+    "implications": "Turns the parent entry's cardinality-based uncountability of ℝ into an explicit witness, matching how the diagonal argument is taught and providing a reusable digit-level template for downstream diagonalizations. The floor/head-tail computation is a self-contained way to force a real to disagree with a prescribed sequence.",
+    "openQuestions": [
+      "Show diagonalReal f ∈ [0,1] and package the result as an explicit injection {sequences} ↪ ℝ.",
+      "Prove the constructive form implies ¬ Countable ℝ directly, connecting back to cantor-diagonalization-oq-06 without Mathlib's cardinality lemmas."
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [],
+    "namespace": "CantorDiagonalizationOQ06OQ01",
+    "lineCount": 209,
+    "axiomCount": 0,
+    "theoremCount": 14,
+    "definitionCount": 4,
+    "path": "Proofs/CantorDiagonalizationOQ06OQ01.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "Cantor, Georg",
+      "title": "Über eine elementare Frage der Mannigfaltigkeitslehre",
+      "year": "1891",
+      "venue": "Jahresbericht der Deutschen Mathematiker-Vereinigung, vol. 1, pp. 75–78",
+      "note": "Introduces the diagonal argument in its now-standard form"
+    },
+    {
+      "authors": "Cantor, Georg",
+      "title": "Über eine Eigenschaft des Inbegriffes aller reellen algebraischen Zahlen",
+      "year": "1874",
+      "venue": "Journal für die reine und angewandte Mathematik, vol. 77, pp. 258–262",
+      "note": "The first proof that the reals are uncountable"
+    }
+  ],
+  "sorries": 0
+}

--- a/src/data/research/problems/cantor-diagonalization-oq-06-oq-01.json
+++ b/src/data/research/problems/cantor-diagonalization-oq-06-oq-01.json
@@ -1,8 +1,8 @@
 {
   "slug": "cantor-diagonalization-oq-06-oq-01",
   "title": "Explicit Diagonal Real Missing From Any Listed Enumeration",
-  "phase": "ORIENT",
-  "status": "available",
+  "phase": "COMPLETED",
+  "status": "completed",
   "tier": "B",
   "path": "full",
   "problemStatement": {
@@ -23,14 +23,12 @@
     "goal": "Define the witness x as an explicit function of the enumeration f (e.g. a bit sequence b n = if nthDigit (f n) n = 0 then 1 else 0 summed into [0,1]) and prove x ≠ f n for every n by exhibiting the differing digit, with no appeal to Cardinal.not_countable_real or #ℝ = 𝔠."
   },
   "currentState": {
-    "phase": "ORIENT",
-    "since": "2026-07-09T16:43:20-07:00",
+    "phase": "COMPLETED",
+    "since": "2026-07-11",
     "iteration": 2,
-    "focus": "Approach identified: explicit diagonalReal via floor/emod decimal digits (in {1,2}) with geometric tail bound. Verifiable BUILD plan recorded; ~150-250 lines.",
-    "blockers": [
-      "Verification environment: docker lean image absent (docker system df shows 0 images) and disk ~121Mi; no build/verify path this session."
-    ],
-    "nextAction": "Execute the BUILD in a working docker env per knowledge.nextSteps: define digit/db/diagonalReal, prove crux digit(diagonalReal f) n = db f n, then diagonalReal_ne.",
+    "focus": "SOLVED & VERIFIED (researcher-1, 2026-07-11). Explicit constructive diagonal real implemented and machine-checked: proofs/Proofs/CantorDiagonalizationOQ06OQ01.lean, 209 lines, 14 theorems / 4 defs, 0 sorry / 0 axiom. #print axioms reports only [propext, Classical.choice, Quot.sound]. digit r n = ⌊r·10^(n+1)⌋%10; db f n ∈ {1,2} disagrees with digit(f n) n; diagonalReal f = ∑ n, db f n/10^(n+1); crux digit_diagonalReal via head/tail split (integer head A, geometric tail 0≤T≤2/9<1) ⟹ diagonalReal_ne and not_surjective_nat_real. No Cardinal.not_countable_real.",
+    "blockers": [],
+    "nextAction": "Done — gallery entry src/data/proofs/cantor-diagonalization-oq-06-oq-01/meta.json created.",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -38,7 +36,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "ORIENT (researcher-11, 2026-07-10): Designed a COMPLETE verifiable construction for the explicit diagonalReal:(N->R)->R with x!=f n by decimal-digit comparison — no cardinality, no Cardinal.not_countable. Digits restricted to {1,2} sidestep the 0.999...=1.000... expansion-uniqueness obstruction; digit defined via floor/emod; disagreement proven through a geometric 2/9<1 tail bound. NO Lean written or verified this session — environment hard-blocked (docker lean image absent [docker system df: 0 images], disk 121Mi, worktree reaped). Ready-to-execute BUILD plan with exact Mathlib lemma names recorded in nextSteps. NOT yet proven.",
+    "progressSummary": "COMPLETED (researcher-1, 2026-07-11): the BUILD designed in the ORIENT phase was executed and verified. CantorDiagonalizationOQ06OQ01.lean (0 sorry / 0 axiom, foundational axioms only) gives an explicit definable diagonalReal:(ℕ→ℝ)→ℝ with diagonalReal f ≠ f n for all n by digit disagreement (digits in {1,2}, floor/emod digit extraction, geometric 2/9<1 tail bound), answering the parent OQ06 open question with no appeal to cardinality.",
     "builtItems": [],
     "insights": [
       "Parent CantorDiagonalization.lean (176L, 0 sorry) proves the diagonal only over BinarySeq = N->Bool via fun n => !(f n n); it never touches actual reals. Its remark (lines 102-107) that binary sequences correspond to reals in [0,1] is exactly the UNPROVEN bridge — supplying it is the genuine open content of this OQ.",
@@ -522,5 +520,6 @@
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CantorDiagonalizationOQ07OQ01.lean"
     }
-  ]
+  ],
+  "completed": "2026-07-11"
 }


### PR DESCRIPTION
## Summary

Formalizes **Cantor's constructive 1891 diagonal argument at the level of decimal digits**, answering the open question posed by the parent gallery entry `cantor-diagonalization-oq-06` — *"formalize a self-contained diagonal construction (an explicit real missing from a given list) rather than routing through cardinality."*

Given any enumeration `f : ℕ → ℝ`, this builds an **explicit, definable** real `diagonalReal f` and proves directly, digit by digit, that `diagonalReal f ≠ f n` for every `n`, with **no appeal to `Cardinal.not_countable_real` or `#ℝ = 𝔠`**.

## Construction

```lean
digit r n := ⌊r * 10^(n+1)⌋ % 10                  -- n-th decimal digit (ℤ, in [0,10))
db f n    := if digit (f n) n = 1 then 2 else 1   -- disagreeing digit, in {1,2}
diagonalReal f := ∑' n, (db f n : ℝ) / 10^(n+1)   -- explicit witness in [0,1]
```

Restricting the produced digits to `{1,2}` defuses the `0.999… = 1.000…` expansion-uniqueness obstruction that makes a naive digit argument false.

## Proof of the crux `digit (diagonalReal f) n = db f n`

Multiply by `10^(n+1)` and split the series at index `n+1`:
`diagonalReal f * 10^(n+1) = A + T`, where
- `A = ∑_{i≤n} db f i · 10^(n-i) : ℤ` is an integer head with `A % 10 = db f n` (since `A = db f n + 10·B`), and
- `0 ≤ T ≤ 2·(1/9) = 2/9 < 1` is a geometric tail.

Hence `⌊diagonalReal f · 10^(n+1)⌋ = A` and `digit (diagonalReal f) n = A % 10 = db f n`. Then `diagonalReal f = f n` would force `digit (diagonalReal f) n = digit (f n) n`, contradicting `db f n ≠ digit (f n) n`. So `diagonalReal_ne` and `not_surjective_nat_real` follow.

## Verification

- `proofs/Proofs/CantorDiagonalizationOQ06OQ01.lean` — 209 lines, 14 theorems, 4 definitions, **0 sorries, 0 axiom declarations**.
- Verified by single-file elaboration against prebuilt Mathlib oleans (`lake env lean`).
- `#print axioms` on `not_exists_surjective_nat_real`, `diagonalReal_ne`, and `digit_diagonalReal` reports **only** `[propext, Classical.choice, Quot.sound]` — no `sorryAx`, no `Lean.ofReduceBool`.

## Gallery

- New entry `src/data/proofs/cantor-diagonalization-oq-06-oq-01/meta.json` (status `verified`, badge `original`, 0 axioms / 0 sorries), cross-referenced to the parent `cantor-diagonalization-oq-06`.
- Research problem `cantor-diagonalization-oq-06-oq-01` marked `completed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)