### PR TITLE
research(tetrahedral-number-formula-oq-01): iterated forward difference = two-sided inverse of iterated summation [VERIFIED]

### DIFF
--- a/proofs/Proofs/TetrahedralNumberFormulaOQ01.lean
+++ b/proofs/Proofs/TetrahedralNumberFormulaOQ01.lean
@@ -599,4 +599,92 @@ theorem simplexConv_const (d c n : ℕ) :
     simpa using this
   rw [← iterSum_eq_simplexConv, h, iterSum_one]
 
+
+/-! ### The iterated forward difference: two-sided inverse of iterated summation
+
+The single-step forward difference `forwardDiff` inverts a single `partialSum`
+(`forwardDiff_partialSum`) and strips one figurate dimension (`forwardDiff_simplexNumber`).
+Iterating it `a` times gives the operator `iterForwardDiff a = Δ^a`, and the two
+constructions become *two-sided* inverses: `iterSum a` raises the figurate ladder by
+`a` dimensions (`iterSum_simplexNumber`), and `Δ^a` runs it back down.
+
+The headline is the **general discrete Fundamental Theorem of Calculus**
+`iterForwardDiff_iterSum`: for *any* sequence `f`, differencing an `a`-fold running
+total `a` times recovers the original summand up to the intrinsic shift,
+`Δ^a (∑^a f)(n) = f(n + a)` — the exact discrete analogue of
+`(d/dx)^a ∫^a f = f`. Everything below is a corollary: `iterSum_simplexNumber`
+turns the figurate case `Δ^a P_{a+b} = P_b(· + a)` into a one-line consequence, and
+the `b = 0` slice is the dual of `iterSum_one` (the `a`-fold sum of `1` is `P_a`):
+the `a`-th forward difference of the `a`-dimensional ladder is the constant `1`.
+-/
+
+/-- **Iterated forward-difference operator.** `iterForwardDiff a` applies the forward
+difference `Δ` a total of `a` times: `Δ⁰ = id`, `Δ^{a+1} = Δ ∘ Δ^a`. It is the
+downward-running operator on the figurate ladder, dual to `iterSum`. -/
+def iterForwardDiff : ℕ → (ℕ → ℕ) → (ℕ → ℕ)
+  | 0,     f => f
+  | a + 1, f => forwardDiff (iterForwardDiff a f)
+
+/-- **General discrete Fundamental Theorem of Calculus.** Differencing an `a`-fold
+iterated partial sum `a` times returns the original summand, shifted by `a`:
+
+`Δ^a (∑^a f)(n) = f(n + a)`.
+
+This is the two-sided companion of the single-step `forwardDiff_partialSum`
+(`Δ ∘ ∑ = shift`) and the exact discrete analogue of `(d/dx)^a ∘ ∫^a = id`.
+The shift is intrinsic: each `Δ` reads a running total one index ahead, so `a`
+differences advance the argument by `a`. Proved by induction on `a`, peeling one
+summation layer to `partialSum` via the semigroup law `iterSum_add` and collapsing it
+with `forwardDiff_partialSum`. -/
+theorem iterForwardDiff_iterSum (a : ℕ) (f : ℕ → ℕ) (n : ℕ) :
+    iterForwardDiff a (iterSum a f) n = f (n + a) := by
+  induction a generalizing f n with
+  | zero => rfl
+  | succ a ih =>
+    have hstep : iterSum (a + 1) f = iterSum a (partialSum f) := (iterSum_add a 1 f).symm
+    show forwardDiff (iterForwardDiff a (iterSum (a + 1) f)) n = f (n + (a + 1))
+    rw [hstep]
+    simp only [forwardDiff]
+    rw [ih (partialSum f) (n + 1), ih (partialSum f) n]
+    have hfd := forwardDiff_partialSum f (n + a)
+    simp only [forwardDiff] at hfd
+    have e1 : n + 1 + a = n + a + 1 := by omega
+    have e2 : n + (a + 1) = n + a + 1 := by omega
+    rw [e1, e2, hfd]
+
+/-- **Iterated differencing strips figurate dimensions** — the inverse of the
+dimension-additivity law `iterSum_simplexNumber` (`iterSum a P_b = P_{a+b}`).
+Applying the forward difference `a` times to the `(a+b)`-dimensional simplex sequence
+recovers the `b`-dimensional one, shifted by `a`:
+
+`Δ^a P_{a+b}(n) = P_b(n + a)`.
+
+Immediate from the discrete FTC `iterForwardDiff_iterSum` once `P_{a+b}` is written as
+`iterSum a P_b`. The single-step `forwardDiff_simplexNumber` (`Δ P_{d+1} = P_d(· + 1)`)
+is the case `a = 1`. -/
+theorem iterForwardDiff_simplexNumber (a b n : ℕ) :
+    iterForwardDiff a (simplexNumber (a + b)) n = simplexNumber b (n + a) := by
+  have hfun : (simplexNumber (a + b) : ℕ → ℕ) = iterSum a (simplexNumber b) := by
+    funext m; rw [iterSum_simplexNumber]
+  rw [hfun, iterForwardDiff_iterSum]
+
+/-- **The `a`-th forward difference of the `a`-dimensional ladder is constant `1`** —
+the exact dual of the ladder characterisation `iterSum_one` (the `a`-fold *sum* of the
+constant `1` is `P_a`). Differencing the `a`-dimensional figurate sequence `a` times
+brings it all the way back down to the constant sequence `P_0 ≡ 1`:
+
+`Δ^a P_a(n) = 1`.
+
+The `b = 0` slice of `iterForwardDiff_simplexNumber`, since `P_0 ≡ 1`. Together with
+`iterSum_one` this closes the loop: summation `1 → n → triangular → tetrahedral → …`
+and differencing `… → tetrahedral → triangular → n → 1` are mutually inverse ladders. -/
+theorem iterForwardDiff_self_simplexNumber (a n : ℕ) :
+    iterForwardDiff a (simplexNumber a) n = 1 := by
+  have h : iterForwardDiff a (simplexNumber (a + 0)) n = simplexNumber 0 (n + a) :=
+    iterForwardDiff_simplexNumber a 0 n
+  rw [Nat.add_zero] at h
+  rw [h]
+  simp [simplexNumber]
+
 end TetrahedralNumberFormulaOQ01
+

--- a/research/problems/tetrahedral-number-formula-oq-01/knowledge.md
+++ b/research/problems/tetrahedral-number-formula-oq-01/knowledge.md
@@ -1,5 +1,41 @@
 # Knowledge: tetrahedral-number-formula-oq-01
 
+## Session 2026-07-11 (researcher-9) — Iterated forward difference: two-sided inverse of iterated summation [VERIFIED]
+
+**Mode:** REVISIT (RICH; base solved). **Outcome:** progress — 1 def + 3 theorems,
+**VERIFIED 0 sorry / 0 axiom** (`lake env lean`, EXIT 0; `#print axioms` = [propext, Classical.choice, Quot.sound] only).
+
+### What I did — the iterated inverse operator (602→690 lines, 35→38 theorems)
+Completed the summation↔difference duality at the ITERATED level. The file already had the
+single-step `forwardDiff` (`Δ ∘ ∑ = shift`, `Δ P_{d+1} = P_d(·+1)`); I added its `a`-fold iterate
+and proved it is the two-sided inverse of `iterSum a`:
+- `iterForwardDiff` — `Δ^a`, defined by `Δ⁰=id`, `Δ^{a+1}=Δ∘Δ^a` (outside peel, mirroring `iterSum`).
+- `iterForwardDiff_iterSum` — **general discrete FTC**: `Δ^a(∑^a f)(n) = f(n+a)` for *arbitrary* `f`.
+  Induction on `a`, peeling `iterSum (a+1) f = iterSum a (partialSum f)` via `iterSum_add a 1 f`, then
+  collapsing the outer `Δ` with `forwardDiff_partialSum`. The discrete analogue of `(d/dx)^a ∘ ∫^a = id`.
+- `iterForwardDiff_simplexNumber` — `Δ^a P_{a+b}(n) = P_b(n+a)`, the exact inverse of the
+  dimension-additivity law `iterSum_simplexNumber` (`iterSum a P_b = P_{a+b}`). One-line corollary of
+  the FTC after `funext` rewriting `P_{a+b} = iterSum a P_b`.
+- `iterForwardDiff_self_simplexNumber` — `Δ^a P_a = 1`, the dual of `iterSum_one` (`a`-fold sum of `1`
+  is `P_a`). Closes the loop: the summation ladder `1→n→triangular→…` and the differencing ladder
+  `…→triangular→n→1` are mutually inverse.
+
+### Key Lean notes (reusable)
+- The shift is intrinsic and unavoidable (`Δ^a` advances the argument by `a`) because
+  `forwardDiff_partialSum` reads the total one index ahead. State theorems with the `(·+a)` shift
+  rather than fighting it — keeps `ℕ`-subtraction exact (all sequences here are monotone).
+- `iterSum (a+1) f = iterSum a (partialSum f)` is `(iterSum_add a 1 f).symm` (uses `iterSum 1 f ≡ partialSum f`
+  definitionally); lets an outside-peel induction reuse the IH on `partialSum f`.
+- Corollaries via `funext m; rw [iterSum_simplexNumber]` to swap `simplexNumber (a+b)` for `iterSum a (simplexNumber b)`
+  as *functions* before applying the FTC — avoids re-running the induction.
+
+### Files Modified
+- `proofs/Proofs/TetrahedralNumberFormulaOQ01.lean` (+`iterForwardDiff`, +3 theorems; 602→690 lines, 35→38 thm)
+- `src/data/research/problems/tetrahedral-number-formula-oq-01.json` (leanFile counts 602/35/5 → 690/38/6 + knowledge)
+
+---
+
+
 ## Session 2026-07-09 (researcher-8) — Semigroup law of iterated summation + dimension-additivity [VERIFIED]
 
 **Mode:** REVISIT (RICH; base already solved by my PR #36499). **Outcome:** progress —

--- a/src/data/research/problems/tetrahedral-number-formula-oq-01.json
+++ b/src/data/research/problems/tetrahedral-number-formula-oq-01.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: completed the linear-operator structure of the figurate calculus (5 verified theorems: additivity + homogeneity of iterSum and simplexConv, plus constant-kernel convolution). File remains 0 sorries, 0 axioms; verified locally against Mathlib v4.26.0.",
+    "progressSummary": "SOLVED/RICH: general figurate theory (38 thm, 0 sorry, 0 axiom) now includes the iterated forward-difference operator and general discrete FTC (Δ^a inverts ∑^a), completing the summation↔difference duality at the iterated level.",
     "builtItems": [
       "simplexNumber d n := (n+d).choose d - the d-dimensional hyper-tetrahedral number (TetrahedralNumberFormulaOQ01.lean)",
       "sum_simplex: sum_{k<=n} simplexNumber d k = simplexNumber (d+1) n - general hockey stick, any dimension d (via Nat.sum_range_add_choose)",
@@ -47,7 +47,11 @@
       "iterSum_add_fn: additivity of d-fold summation (induction + Finset.sum_add_distrib) — TetrahedralNumberFormulaOQ01.lean",
       "iterSum_smul_fn: ℕ-homogeneity of d-fold summation (induction + Finset.mul_sum) — TetrahedralNumberFormulaOQ01.lean",
       "simplexConv_add_fn / simplexConv_smul_fn: convolution linear in f (Nat.mul_add / Finset.mul_sum) — TetrahedralNumberFormulaOQ01.lean",
-      "simplexConv_const: constant-kernel convolution = c·P_{d+1}(n), generalizing the c=1 example — TetrahedralNumberFormulaOQ01.lean"
+      "simplexConv_const: constant-kernel convolution = c·P_{d+1}(n), generalizing the c=1 example — TetrahedralNumberFormulaOQ01.lean",
+      "iterForwardDiff (TetrahedralNumberFormulaOQ01.lean:624) — iterated forward-difference operator Δ^a",
+      "iterForwardDiff_iterSum (:639) — general discrete FTC: Δ^a(∑^a f)(n) = f(n+a), two-sided inverse of iterSum",
+      "iterForwardDiff_simplexNumber (:665) — Δ^a P_{a+b}(n) = P_b(n+a), inverse of iterSum_simplexNumber",
+      "iterForwardDiff_self_simplexNumber (:681) — Δ^a P_a = 1, dual of iterSum_one"
     ],
     "insights": [
       "The hyper-tetrahedral / d-simplex number is exactly Mathlib Nat.multichoose (n+1) d = C(n+d,d); Mathlib gives the one-step hockey stick Nat.sum_range_add_choose : sum i in range(n+1),(i+d).choose d = (n+d+1).choose(d+1)",
@@ -56,7 +60,8 @@
       "The figurate numbers P_d are exactly the KERNEL of repeated discrete summation: iterating partialSum d+1 times against any f convolves f with P_d(n-k). Discrete analogue of Cauchy repeated integration (kernel (n-t)^d/d!).",
       "Finset.sum_Ico_Ico_comm (a<=i<=j<b triangular swap) + Finset.sum_Ico_eq_sum_range cleanly reduce a nested partial-sum-of-convolution to a single hockey-stick collapse.",
       "VERIFIED (researcher-2, 2026-07-09, GREEN build): the order facts of the figurate ladder P_d(n)=C(n+d,d), absent from the file. simplexNumber_pos (0<P_d(n), Nat.choose_pos on d≤n+d), simplexNumber_mono_size (m≤n⟹P_d(m)≤P_d(n), Nat.choose_le_choose on m+d≤n+d), simplexNumber_mono_dim (a≤b⟹P_a(n)≤P_b(n), reduced to mono_size through the reflection symmetry simplexNumber_symm P_d(n)=P_n(d)). Monotone in BOTH arguments + positive. Complements the exact-value/summation theory with the growth/order structure.",
-      "The figurate calculus is ℕ-linear: both iterated summation (iterSum) and simplex convolution (simplexConv) are additive and ℕ-homogeneous in the summand — the summand-side companion to the dimension-side semigroup laws iterSum_add / simplexConv_comp."
+      "The figurate calculus is ℕ-linear: both iterated summation (iterSum) and simplex convolution (simplexConv) are additive and ℕ-homogeneous in the summand — the summand-side companion to the dimension-side semigroup laws iterSum_add / simplexConv_comp.",
+      "The summation↔difference duality closes at the ITERATED level: iterSum a (raise a dims) and iterForwardDiff a = Δ^a (lower a dims) are two-sided inverses up to the intrinsic shift Δ^a∘∑^a = shift^a; the shift is forced because each Δ reads a running total one index ahead."
     ],
     "mathlibGaps": [
       "Mathlib has the one-step hockey stick and multichoose but no dimension-indexed figurate theory: no iterated-partial-sum characterization of simplex numbers, no figurate recurrence/closed form stated uniformly in the dimension d."
@@ -101,10 +106,10 @@
     {
       "path": "Proofs/TetrahedralNumberFormulaOQ01.lean",
       "filename": "TetrahedralNumberFormulaOQ01.lean",
-      "lineCount": 602,
-      "theoremCount": 35,
+      "lineCount": 690,
+      "theoremCount": 38,
       "axiomCount": 0,
-      "defCount": 5,
+      "defCount": 6,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/TetrahedralNumberFormulaOQ01.lean"


### PR DESCRIPTION
## Summary

Extends the general figurate/simplex theory in `TetrahedralNumberFormulaOQ01.lean` with the **iterated forward-difference operator** `Δ^a` and proves it is the two-sided inverse of the iterated-summation operator `iterSum`, completing the summation↔difference duality at the *iterated* level (the file previously had only the single-step `forwardDiff`).

## New results (1 def + 3 theorems)

- `iterForwardDiff` — `Δ^a`, defined by `Δ⁰ = id`, `Δ^{a+1} = Δ ∘ Δ^a`.
- `iterForwardDiff_iterSum` — **general discrete Fundamental Theorem of Calculus**: for any sequence `f`, `Δ^a(∑^a f)(n) = f(n + a)`. The discrete analogue of `(d/dx)^a ∘ ∫^a = id`; the shift is intrinsic since each `Δ` reads a running total one index ahead.
- `iterForwardDiff_simplexNumber` — `Δ^a P_{a+b}(n) = P_b(n + a)`, the exact inverse of the dimension-additivity law `iterSum_simplexNumber` (`iterSum a P_b = P_{a+b}`).
- `iterForwardDiff_self_simplexNumber` — `Δ^a P_a = 1`, dual to `iterSum_one` (the `a`-fold sum of `1` is `P_a`): the summation ladder `1→n→triangular→…` and the differencing ladder `…→triangular→n→1` are mutually inverse.

## Verification

- `lake env lean Proofs/TetrahedralNumberFormulaOQ01.lean` → EXIT 0, 0 sorries.
- `#print axioms` on all three new theorems = `[propext, Classical.choice, Quot.sound]` only — **axiom-free** (no `sorryAx`, no `Lean.ofReduceBool`).
- File: 602→690 lines, 35→38 theorems, 0 sorry / 0 axiom throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)