### PR TITLE
research(erdos-1019): repair Mathlib API drift, eliminate sorry (file now compiles)

### DIFF
--- a/proofs/Proofs/Erdos1019Problem.lean
+++ b/proofs/Proofs/Erdos1019Problem.lean
@@ -64,10 +64,10 @@ def HasMinor {α : Type*} {β : Type*} (G : SimpleGraph α) (H : SimpleGraph β)
   Nonempty (GraphMinorWitness G H)
 
 /-- K₅: the complete graph on 5 vertices. -/
-abbrev K5 : SimpleGraph (Fin 5) := completeGraph 5
+abbrev K5 : SimpleGraph (Fin 5) := completeGraph (Fin 5)
 
 /-- K₃,₃: the complete bipartite graph on 3+3 vertices. -/
-abbrev K33 : SimpleGraph (Fin 3 ⊕ Fin 3) := completeBipartite 3 3
+abbrev K33 : SimpleGraph (Fin 3 ⊕ Fin 3) := completeBipartiteGraph (Fin 3) (Fin 3)
 
 /-- No graph on fewer vertices than H can contain H as a minor.
     Pigeonhole: injecting branch set representatives requires |V| ≥ |W|. -/
@@ -80,9 +80,11 @@ private theorem no_minor_of_card_lt {α : Type*} {β : Type*}
   let f : β → α := fun i => (w.nonempty i).choose
   have hf : Function.Injective f := by
     intro i j heq
+    simp only [f] at heq
     by_contra hij
-    exact Set.disjoint_left.mp (w.disjoint hij)
-      (w.nonempty i).choose_spec (heq ▸ (w.nonempty j).choose_spec)
+    have hj := (w.nonempty j).choose_spec
+    rw [← heq] at hj
+    exact Set.disjoint_left.mp (w.disjoint hij) (w.nonempty i).choose_spec hj
   exact absurd (Fintype.card_le_of_injective f hf) (by omega)
 
 /-
@@ -96,7 +98,7 @@ A graph is planar iff it has no K₅ or K₃,₃ minor (Wagner's theorem, 1937).
 def isPlanar (G : SimpleGraph V) : Prop :=
   ¬HasMinor G K5 ∧ ¬HasMinor G K33
 
-/-- Euler's formula bound: planar graphs have ≤ 3n - 6 edges. -/
+-- Euler's formula bound: planar graphs have ≤ 3n - 6 edges.
 /-
 ## Saturated Planar Graphs
 
@@ -188,8 +190,11 @@ theorem turan_triangle (G : SimpleGraph V) [DecidableRel G.Adj] :
   unfold edgeCount turanEdges at hedge
   have hbound := hcf.card_edgeFinset_le
   set n := Fintype.card V
-  have hmod : n % 2 = 0 ∨ n % 2 = 1 := Nat.mod_two_eq_zero_or_one n
-  rcases hmod with hm | hm <;> simp only [hm] at hbound <;> omega
+  -- Mathlib's Turán bound for r = 2: #E ≤ (n² - (n%2)²)/4 + (n%2).choose 2 ≤ n²/4
+  have hkey : (n ^ 2 - (n % 2) ^ 2) * (2 - 1) / (2 * 2) + (n % 2).choose 2 ≤ n ^ 2 / 4 := by
+    rcases Nat.mod_two_eq_zero_or_one n with hm | hm <;> rw [hm] <;>
+      norm_num [Nat.choose] <;> omega
+  omega
 
 /-
 ## The Induced Subgraph
@@ -242,8 +247,10 @@ theorem K4_saturated_planar (G : SimpleGraph V) [DecidableRel G.Adj]
     constructor
     · -- G.Adj u v → u ≠ v (as subtypes)
       intro hadj heq
-      -- heq : ⟨u,hu⟩ = ⟨v,hv⟩, so v = u
-      exact G.loopless u ((congr_arg Subtype.val heq).symm ▸ hadj)
+      -- heq : ⟨u,hu⟩ = ⟨v,hv⟩, so u = v
+      have huv : u = v := congr_arg Subtype.val heq
+      rw [huv] at hadj
+      exact G.loopless v hadj
     · -- ⟨u,hu⟩ ≠ ⟨v,hv⟩ → G.Adj u v
       intro hne
       exact hClique u hu v hv (fun h => hne (Subtype.ext h))
@@ -253,18 +260,20 @@ theorem K4_saturated_planar (G : SimpleGraph V) [DecidableRel G.Adj]
       rw [hScard, Fintype.card_fin]; norm_num)
   · -- No K₃,₃ minor: |↥S| = 4 < 6 = |Fin 3 ⊕ Fin 3|
     exact no_minor_of_card_lt _ K33 (by
-      rw [hScard, Fintype.card_sum, Fintype.card_fin, Fintype.card_fin]; norm_num)
+      rw [hScard, Fintype.card_sum, Fintype.card_fin]; norm_num)
   · -- |↥S| ≥ 3
     omega
   · -- edgeCount = 3 * 4 - 6 = 6
     -- (⊤ : SimpleGraph ↥S).edgeFinset.card = C(4,2) = 6
     unfold edgeCount
-    rw [heq, hScard]
-    have h6 : (3 : ℕ) * 4 - 6 = 6 := by norm_num
-    rw [h6]
-    -- Routine: complete graph on a 4-element type has C(4,2) = 6 edges
-    -- Mathlib hint: card_edgeFinset_top or equivFin + native_decide
-    sorry
+    -- Route the graph equality through `edgeSet` (instance-free) to avoid the
+    -- DecidableRel/Fintype dependency that blocks a direct `rw [heq]`.
+    have key : (inducedSubgraph G S).edgeFinset.card = (⊤ : SimpleGraph ↥S).edgeFinset.card := by
+      rw [← Set.ncard_coe_finset, ← Set.ncard_coe_finset,
+          coe_edgeFinset, coe_edgeFinset, heq]
+    rw [key, card_edgeFinset_top_eq_card_choose_two, hScard]
+    -- `Nat.choose 4 2 = 3 * 4 - 6`, i.e. `6 = 6`
+    decide
 
 /-- K₄ gives a saturated planar subgraph on 4 vertices. -/
 theorem K4_gives_large_saturated (G : SimpleGraph V) [DecidableRel G.Adj] :
@@ -363,7 +372,7 @@ Erdős also proved a quantitative lower bound on the size of saturated planar su
 /-- The lower bound on saturated planar subgraph size. -/
 def saturatedPlanarSize (n k : ℕ) : ℕ := k / n
 
-/-- Erdős (1969): Graphs with n²/4 + k edges have saturated planar subgraphs on ≫ k/n vertices. -/
+-- Erdős (1969): Graphs with n²/4 + k edges have saturated planar subgraphs on ≫ k/n vertices.
 /-
 ## Connection to Turán Theory
 

--- a/src/data/proofs/erdos-1019/meta.json
+++ b/src/data/proofs/erdos-1019/meta.json
@@ -318,7 +318,7 @@
     "theoremCount": 13,
     "definitionCount": 23,
     "path": "Proofs/Erdos1019Problem.lean",
-    "sorries": 1,
+    "sorries": 0,
     "additionalFiles": [
       "Proofs/Erdos1019Aristotle.lean"
     ]


### PR DESCRIPTION
## Summary

`proofs/Proofs/Erdos1019Problem.lean` (Erdős #1019, saturated planar subgraphs) **no longer compiled** against the current Mathlib pin. It had **9 parse/elaboration errors plus 1 `sorry`**, even though `meta.json` recorded only `sorries: 1`. This PR restores a clean build.

Verified with `./proofs/bin/lake env lean Proofs/Erdos1019Problem.lean` against the prebuilt Mathlib oleans — **0 errors, 0 sorries**.

## Root causes & fixes

| Site | Problem | Fix |
|------|---------|-----|
| `K5`, `K33` | `completeGraph 5` / `completeBipartite 3 3` used stale API; `completeBipartite` was a **forward reference** → `K33` elaborated to `sorry` | `completeGraph (Fin 5)` / `completeBipartiteGraph (Fin 3) (Fin 3)` (Mathlib built-ins) |
| lines 99, 373 | two floating `/--` doc-comments before block comments (hard parse errors) | convert to `--` line comments |
| `no_minor_of_card_lt` | fragile `▸` cast failed motive inference | explicit `rw` |
| `turan_triangle` | Mathlib's `CliqueFree.card_edgeFinset_le` bound changed shape to `(n²-(n%2)²)/4 + (n%2).choose 2` | prove that bound `≤ n²/4` so `omega` closes |
| `K4_saturated_planar` loopless | `▸` cast motive failure | explicit `rw` |
| K₃,₃ card bullet | duplicate `Fintype.card_fin` rewrite (first already rewrites both `Fin 3`) | drop the duplicate |
| edge-count `sorry` | `(inducedSubgraph G S).edgeFinset.card`: direct `rw [heq]`/`simp` blocked by the `DecidableRel`/`Fintype` instance in `edgeFinset` | route through `edgeSet` (instance-free) via `ncard_coe_finset` + `coe_edgeFinset`, then `card_edgeFinset_top_eq_card_choose_two` |

## Status

Remains **axiomatized** — the file legitimately depends on 3 external-result axioms (`simonovits_theorem`, `erdos_construction_exists`, `cyclePlus2K1_saturated_planar`) and one pre-existing `native_decide`. This PR does not change that; it repairs the mechanical Mathlib drift and discharges the one remaining supporting `sorry`.

`meta.json` `leanFile.sorries` corrected `1 → 0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)