### PR TITLE
Fix references dict-wrapper in 9 mathlib-carrying gallery entries

### DIFF
--- a/src/data/proofs/ballot-problem-oq-01-oq-03/meta.json
+++ b/src/data/proofs/ballot-problem-oq-01-oq-03/meta.json
@@ -155,25 +155,34 @@
       "description": "Sibling open question under ballot-problem-oq-01 in the same reflection/Catalan circle of ideas."
     }
   ],
-  "references": {
-    "papers": [
-      {
-        "title": "Solution directe du problème résolu par M. Bertrand",
-        "author": "D. André",
-        "year": 1887,
-        "url": "https://en.wikipedia.org/wiki/Bertrand%27s_ballot_problem"
-      }
-    ],
-    "urls": [
-      "https://en.wikipedia.org/wiki/Catalan_number",
-      "https://en.wikipedia.org/wiki/Bertrand%27s_ballot_problem"
-    ],
-    "mathlib": [
-      "Mathlib.Combinatorics.Catalan",
-      "Mathlib.Combinatorics.Choose.Central",
-      "Mathlib.Data.Nat.Choose.Basic"
-    ]
-  },
+  "references": [
+    {
+      "title": "Solution directe du problème résolu par M. Bertrand",
+      "author": "D. André",
+      "year": 1887,
+      "url": "https://en.wikipedia.org/wiki/Bertrand%27s_ballot_problem"
+    },
+    {
+      "text": "https://en.wikipedia.org/wiki/Catalan_number",
+      "url": "https://en.wikipedia.org/wiki/Catalan_number"
+    },
+    {
+      "text": "https://en.wikipedia.org/wiki/Bertrand%27s_ballot_problem",
+      "url": "https://en.wikipedia.org/wiki/Bertrand%27s_ballot_problem"
+    },
+    {
+      "text": "Mathlib: Mathlib.Combinatorics.Catalan",
+      "url": "https://leanprover-community.github.io/mathlib4_docs/Mathlib/Combinatorics/Catalan.html"
+    },
+    {
+      "text": "Mathlib: Mathlib.Combinatorics.Choose.Central",
+      "url": "https://leanprover-community.github.io/mathlib4_docs/Mathlib/Combinatorics/Choose/Central.html"
+    },
+    {
+      "text": "Mathlib: Mathlib.Data.Nat.Choose.Basic",
+      "url": "https://leanprover-community.github.io/mathlib4_docs/Mathlib/Data/Nat/Choose/Basic.html"
+    }
+  ],
   "leanFile": {
     "namespace": "BallotProblemOQ01OQ03",
     "lineCount": 92,

--- a/src/data/proofs/euler-identity-oq-01-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/euler-identity-oq-01-oq-01-oq-01-oq-01/meta.json
@@ -171,34 +171,41 @@
       "Can the kernel description 2π·ℤ from the parent be combined with the smooth structure to formalize the covering map exp : ℝ → S¹ as a smooth covering (IsCoveringMap), the next step toward π₁(S¹) ≅ ℤ in the smooth category?"
     ]
   },
-  "references": {
-    "papers": [
-      {
-        "title": "Introductio in analysin infinitorum, Vol. 1, Ch. 8",
-        "authors": [
-          "Leonhard Euler"
-        ],
-        "year": 1748,
-        "description": "Original derivation of e^(ix) = cos x + i sin x via Taylor series."
-      },
-      {
-        "title": "Theorie der Transformationsgruppen",
-        "authors": [
-          "Sophus Lie",
-          "Friedrich Engel"
-        ],
-        "year": 1888,
-        "description": "Foundational text on continuous transformation groups; introduces the exponential map and the Lie algebra as the tangent space at the identity."
-      }
-    ],
-    "urls": [],
-    "mathlib": [
-      "Mathlib.Geometry.Manifold.Instances.Sphere",
-      "Mathlib.Analysis.Complex.Circle",
-      "Mathlib.Analysis.Complex.RealDeriv",
-      "Mathlib.Analysis.SpecialFunctions.ExpDeriv"
-    ]
-  },
+  "references": [
+    {
+      "title": "Introductio in analysin infinitorum, Vol. 1, Ch. 8",
+      "authors": [
+        "Leonhard Euler"
+      ],
+      "year": 1748,
+      "description": "Original derivation of e^(ix) = cos x + i sin x via Taylor series."
+    },
+    {
+      "title": "Theorie der Transformationsgruppen",
+      "authors": [
+        "Sophus Lie",
+        "Friedrich Engel"
+      ],
+      "year": 1888,
+      "description": "Foundational text on continuous transformation groups; introduces the exponential map and the Lie algebra as the tangent space at the identity."
+    },
+    {
+      "text": "Mathlib: Mathlib.Geometry.Manifold.Instances.Sphere",
+      "url": "https://leanprover-community.github.io/mathlib4_docs/Mathlib/Geometry/Manifold/Instances/Sphere.html"
+    },
+    {
+      "text": "Mathlib: Mathlib.Analysis.Complex.Circle",
+      "url": "https://leanprover-community.github.io/mathlib4_docs/Mathlib/Analysis/Complex/Circle.html"
+    },
+    {
+      "text": "Mathlib: Mathlib.Analysis.Complex.RealDeriv",
+      "url": "https://leanprover-community.github.io/mathlib4_docs/Mathlib/Analysis/Complex/RealDeriv.html"
+    },
+    {
+      "text": "Mathlib: Mathlib.Analysis.SpecialFunctions.ExpDeriv",
+      "url": "https://leanprover-community.github.io/mathlib4_docs/Mathlib/Analysis/SpecialFunctions/ExpDeriv.html"
+    }
+  ],
   "crossReferences": [
     {
       "type": "extends",

--- a/src/data/proofs/euler-identity-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/euler-identity-oq-01-oq-01-oq-01/meta.json
@@ -208,34 +208,41 @@
       "Does this construction lift to a similar homomorphism description for the Lie group exponential on $SU(2)$ or other compact Lie groups, where Mathlib's representation theory is still developing?"
     ]
   },
-  "references": {
-    "papers": [
-      {
-        "title": "Introductio in analysin infinitorum, Vol. 1, Ch. 8",
-        "authors": [
-          "Leonhard Euler"
-        ],
-        "year": 1748,
-        "description": "Original derivation of e^(ix) = cos x + i sin x via Taylor series."
-      },
-      {
-        "title": "Theorie der Transformationsgruppen",
-        "authors": [
-          "Sophus Lie",
-          "Friedrich Engel"
-        ],
-        "year": 1888,
-        "description": "Foundational text on continuous transformation groups; introduces exponential map for Lie groups."
-      }
-    ],
-    "urls": [],
-    "mathlib": [
-      "Mathlib.Analysis.SpecialFunctions.Complex.Circle",
-      "Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic",
-      "Mathlib.Analysis.SpecialFunctions.Complex.Log",
-      "Mathlib.Topology.Algebra.Group.Basic"
-    ]
-  },
+  "references": [
+    {
+      "title": "Introductio in analysin infinitorum, Vol. 1, Ch. 8",
+      "authors": [
+        "Leonhard Euler"
+      ],
+      "year": 1748,
+      "description": "Original derivation of e^(ix) = cos x + i sin x via Taylor series."
+    },
+    {
+      "title": "Theorie der Transformationsgruppen",
+      "authors": [
+        "Sophus Lie",
+        "Friedrich Engel"
+      ],
+      "year": 1888,
+      "description": "Foundational text on continuous transformation groups; introduces exponential map for Lie groups."
+    },
+    {
+      "text": "Mathlib: Mathlib.Analysis.SpecialFunctions.Complex.Circle",
+      "url": "https://leanprover-community.github.io/mathlib4_docs/Mathlib/Analysis/SpecialFunctions/Complex/Circle.html"
+    },
+    {
+      "text": "Mathlib: Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic",
+      "url": "https://leanprover-community.github.io/mathlib4_docs/Mathlib/Analysis/SpecialFunctions/Trigonometric/Basic.html"
+    },
+    {
+      "text": "Mathlib: Mathlib.Analysis.SpecialFunctions.Complex.Log",
+      "url": "https://leanprover-community.github.io/mathlib4_docs/Mathlib/Analysis/SpecialFunctions/Complex/Log.html"
+    },
+    {
+      "text": "Mathlib: Mathlib.Topology.Algebra.Group.Basic",
+      "url": "https://leanprover-community.github.io/mathlib4_docs/Mathlib/Topology/Algebra/Group/Basic.html"
+    }
+  ],
   "crossReferences": [
     {
       "type": "extends",

--- a/src/data/proofs/euler-identity-oq-01-oq-03/meta.json
+++ b/src/data/proofs/euler-identity-oq-01-oq-03/meta.json
@@ -160,32 +160,36 @@
     "theoremCount": 7,
     "definitionCount": 1
   },
-  "references": {
-    "papers": [
-      {
-        "title": "Miscellanea Analytica de Seriebus et Quadraturis",
-        "authors": [
-          "Abraham de Moivre"
-        ],
-        "year": 1730,
-        "description": "Source of the power law (cos θ + i sin θ)^n = cos nθ + i sin nθ that bears de Moivre's name."
-      },
-      {
-        "title": "Introductio in analysin infinitorum, Vol. 1, Ch. 8",
-        "authors": [
-          "Leonhard Euler"
-        ],
-        "year": 1748,
-        "description": "Euler's formula e^{ix} = cos x + i sin x, the identity that turns De Moivre's power law into the exponent law."
-      }
-    ],
-    "urls": [],
-    "mathlib": [
-      "Mathlib.Analysis.Complex.Trigonometric",
-      "Mathlib.Analysis.Complex.Exponential",
-      "Mathlib.Algebra.Field.GeomSum"
-    ]
-  },
+  "references": [
+    {
+      "title": "Miscellanea Analytica de Seriebus et Quadraturis",
+      "authors": [
+        "Abraham de Moivre"
+      ],
+      "year": 1730,
+      "description": "Source of the power law (cos θ + i sin θ)^n = cos nθ + i sin nθ that bears de Moivre's name."
+    },
+    {
+      "title": "Introductio in analysin infinitorum, Vol. 1, Ch. 8",
+      "authors": [
+        "Leonhard Euler"
+      ],
+      "year": 1748,
+      "description": "Euler's formula e^{ix} = cos x + i sin x, the identity that turns De Moivre's power law into the exponent law."
+    },
+    {
+      "text": "Mathlib: Mathlib.Analysis.Complex.Trigonometric",
+      "url": "https://leanprover-community.github.io/mathlib4_docs/Mathlib/Analysis/Complex/Trigonometric.html"
+    },
+    {
+      "text": "Mathlib: Mathlib.Analysis.Complex.Exponential",
+      "url": "https://leanprover-community.github.io/mathlib4_docs/Mathlib/Analysis/Complex/Exponential.html"
+    },
+    {
+      "text": "Mathlib: Mathlib.Algebra.Field.GeomSum",
+      "url": "https://leanprover-community.github.io/mathlib4_docs/Mathlib/Algebra/Field/GeomSum.html"
+    }
+  ],
   "crossReferences": [
     {
       "type": "extends",

--- a/src/data/proofs/euler-identity-oq-01-oq-04/meta.json
+++ b/src/data/proofs/euler-identity-oq-01-oq-04/meta.json
@@ -177,32 +177,33 @@
       "**The dual character lattice $\\widehat{S^1} \\cong \\mathbb{Z}$ via Pontryagin duality applied to this `≃+`.** A foundational Fourier-analytic identity that does *not* follow purely formally from the present packaging — it requires three additional ingredients, each clearly tractable but cumulatively a sub-project. **The structural chain.** Pontryagin duality (Pontryagin 1934, *Topological groups*; Mathlib's `PontryaginDual G := ContinuousMonoidHom G circle`) is a contravariant functor sending $\\mathbb{R}/2\\pi\\mathbb{Z}$ to $\\widehat{\\mathbb{R}/2\\pi\\mathbb{Z}}$. The classical computation proceeds in three steps: (i) $\\widehat{\\mathbb{R}/2\\pi\\mathbb{Z}}$ is the kernel of restriction $\\widehat{\\mathbb{R}} \\to \\widehat{2\\pi\\mathbb{Z}}$ via the exact sequence $0 \\to 2\\pi\\mathbb{Z} \\to \\mathbb{R} \\to \\mathbb{R}/2\\pi\\mathbb{Z} \\to 0$ and Pontryagin's functoriality on short exact sequences; (ii) $\\widehat{\\mathbb{R}} \\cong \\mathbb{R}$ self-duality with characters $\\chi_\\xi(t) = e^{i\\xi t}$ (Plancherel's theorem, Mathlib's `Real.continuousMonoidHomEquivReal`); (iii) the kernel condition $\\chi_\\xi|_{2\\pi\\mathbb{Z}} = 1$ forces $\\xi \\cdot 2\\pi \\in 2\\pi\\mathbb{Z}$, i.e. $\\xi \\in \\mathbb{Z}$, giving $\\widehat{\\mathbb{R}/2\\pi\\mathbb{Z}} \\cong \\mathbb{Z}$ with the character-by-integer indexing $\\chi_n(\\theta) = e^{in\\theta}$. Composing with this file's `addCircleEquivAdditiveCircle.symm` then yields $\\widehat{S^1} \\cong \\mathbb{Z}$, the form used throughout harmonic analysis (Fourier series $f(\\theta) = \\sum_{n \\in \\mathbb{Z}} \\hat{f}(n) e^{in\\theta}$). **Formalization status (2026).** Mathlib v4.26.0 has `PontryaginDual` as a typeclass but does *not* yet have $\\widehat{\\mathbb{R}} \\cong \\mathbb{R}$ as a named `AddEquiv` (it has the underlying characters but not the duality `AddEquiv` itself — the proof requires the Plancherel theorem on $\\mathbb{R}$, partially formalized via `Real.fourierIntegral` in `Mathlib.Analysis.Fourier.FourierTransform` but the full $L^2$-isometry is still under construction in `Mathlib.Analysis.Fourier.Inversion`). Step (iii) — the kernel calculation $\\widehat{S^1} = \\ker(\\widehat{\\mathbb{R}} \\to \\widehat{2\\pi\\mathbb{Z}}) \\cong \\mathbb{Z}$ — would chain cleanly once $\\widehat{\\mathbb{R}} \\cong \\mathbb{R}$ is named. Estimated formalization cost: $\\sim$200 LOC once the `Real.continuousMonoidHomEquivReal` packaging lands (currently *the* missing Mathlib piece blocking this follow-up). **Why downstream users care.** Three Fourier-analytic theorems sit one step beyond the `$\\widehat{S^1} \\cong \\mathbb{Z}$` packaging: (a) the **Fourier series isomorphism** $L^2(S^1) \\cong \\ell^2(\\mathbb{Z})$ via the orthonormal basis $\\{e^{in\\theta}\\}_{n \\in \\mathbb{Z}}$ (Plancherel for the circle, Mathlib's `Real.Fourier.fourierSeries` infrastructure); (b) the **Poisson summation formula** $\\sum_{n \\in \\mathbb{Z}} f(n) = \\sum_{k \\in \\mathbb{Z}} \\hat{f}(k)$ for $f \\in \\mathcal{S}(\\mathbb{R})$ (a special case of the Pontryagin self-dual lattice formula $\\mathbb{Z}^\\vee \\cong \\mathbb{Z}$ inside $\\mathbb{R}^\\vee \\cong \\mathbb{R}$); (c) the **Pontryagin double-dual reflection** $S^1 \\cong \\widehat{\\widehat{S^1}} = \\widehat{\\mathbb{Z}}$, which composed with the present `≃+` would express $\\widehat{\\mathbb{Z}}$ explicitly as `AddCircle (2π)`, anchoring discrete-time Fourier transforms in the gallery. **Cross-references.** The character lattice connects directly to `dirichlets-theorem` (where $\\widehat{(\\mathbb{Z}/n\\mathbb{Z})^\\times}$ is the finite analog used in Dirichlet $L$-series), to `primitive-roots` (the cyclic group $(\\mathbb{Z}/p\\mathbb{Z})^\\times$ has $\\widehat{(\\mathbb{Z}/p\\mathbb{Z})^\\times} \\cong \\mathbb{Z}/(p-1)\\mathbb{Z}$), and to the broader `inverse-galois` / abelian Galois theory cluster via Kronecker-Weber's identification of abelian extensions of $\\mathbb{Q}$ with finite quotients of the idèle class character group $\\widehat{C_\\mathbb{Q}}$. The $\\widehat{S^1} \\cong \\mathbb{Z}$ packaging is the gateway theorem — the simplest non-finite Pontryagin pair, and the model for every richer character-theoretic identity downstream."
     ]
   },
-  "references": {
-    "papers": [
-      {
-        "title": "Introductio in analysin infinitorum, Vol. 1, Ch. 8",
-        "authors": [
-          "Leonhard Euler"
-        ],
-        "year": 1748,
-        "description": "Original derivation of e^(ix) = cos x + i sin x, the analytic identification underlying the additive-group structure on S¹."
-      },
-      {
-        "title": "Theorie der Transformationsgruppen",
-        "authors": [
-          "Sophus Lie",
-          "Friedrich Engel"
-        ],
-        "year": 1888,
-        "description": "Foundational text on continuous transformation groups; the prototype Lie group exponential ℝ → S¹ is the model for the construction here."
-      }
-    ],
-    "urls": [],
-    "mathlib": [
-      "Mathlib.Analysis.SpecialFunctions.Complex.Circle",
-      "Mathlib.Topology.Instances.AddCircle"
-    ]
-  },
+  "references": [
+    {
+      "title": "Introductio in analysin infinitorum, Vol. 1, Ch. 8",
+      "authors": [
+        "Leonhard Euler"
+      ],
+      "year": 1748,
+      "description": "Original derivation of e^(ix) = cos x + i sin x, the analytic identification underlying the additive-group structure on S¹."
+    },
+    {
+      "title": "Theorie der Transformationsgruppen",
+      "authors": [
+        "Sophus Lie",
+        "Friedrich Engel"
+      ],
+      "year": 1888,
+      "description": "Foundational text on continuous transformation groups; the prototype Lie group exponential ℝ → S¹ is the model for the construction here."
+    },
+    {
+      "text": "Mathlib: Mathlib.Analysis.SpecialFunctions.Complex.Circle",
+      "url": "https://leanprover-community.github.io/mathlib4_docs/Mathlib/Analysis/SpecialFunctions/Complex/Circle.html"
+    },
+    {
+      "text": "Mathlib: Mathlib.Topology.Instances.AddCircle",
+      "url": "https://leanprover-community.github.io/mathlib4_docs/Mathlib/Topology/Instances/AddCircle.html"
+    }
+  ],
   "crossReferences": [
     {
       "type": "extends",

--- a/src/data/proofs/quadratic-reciprocity-oq-03-oq-01/meta.json
+++ b/src/data/proofs/quadratic-reciprocity-oq-03-oq-01/meta.json
@@ -158,24 +158,30 @@
       "description": "An elementary proof of QR via Gauss sums; provides the theoretical foundation that this algorithmic packaging makes computational."
     }
   ],
-  "references": {
-    "papers": [
-      {
-        "title": "Disquisitiones Arithmeticae",
-        "author": "C. F. Gauss",
-        "year": 1801,
-        "url": "https://en.wikipedia.org/wiki/Disquisitiones_Arithmeticae"
-      }
-    ],
-    "urls": [
-      "https://en.wikipedia.org/wiki/Quadratic_reciprocity",
-      "https://en.wikipedia.org/wiki/Legendre_symbol"
-    ],
-    "mathlib": [
-      "Mathlib.NumberTheory.LegendreSymbol.QuadraticReciprocity",
-      "Mathlib.NumberTheory.LegendreSymbol.Basic"
-    ]
-  },
+  "references": [
+    {
+      "title": "Disquisitiones Arithmeticae",
+      "author": "C. F. Gauss",
+      "year": 1801,
+      "url": "https://en.wikipedia.org/wiki/Disquisitiones_Arithmeticae"
+    },
+    {
+      "text": "https://en.wikipedia.org/wiki/Quadratic_reciprocity",
+      "url": "https://en.wikipedia.org/wiki/Quadratic_reciprocity"
+    },
+    {
+      "text": "https://en.wikipedia.org/wiki/Legendre_symbol",
+      "url": "https://en.wikipedia.org/wiki/Legendre_symbol"
+    },
+    {
+      "text": "Mathlib: Mathlib.NumberTheory.LegendreSymbol.QuadraticReciprocity",
+      "url": "https://leanprover-community.github.io/mathlib4_docs/Mathlib/NumberTheory/LegendreSymbol/QuadraticReciprocity.html"
+    },
+    {
+      "text": "Mathlib: Mathlib.NumberTheory.LegendreSymbol.Basic",
+      "url": "https://leanprover-community.github.io/mathlib4_docs/Mathlib/NumberTheory/LegendreSymbol/Basic.html"
+    }
+  ],
   "leanFile": {
     "namespace": "QRAlgorithmTwo",
     "lineCount": 143,

--- a/src/data/proofs/quadratic-reciprocity-oq-03-oq-02/meta.json
+++ b/src/data/proofs/quadratic-reciprocity-oq-03-oq-02/meta.json
@@ -159,24 +159,30 @@
       "description": "The underlying Law of Quadratic Reciprocity, whose sign this entry turns into a residue decision rule."
     }
   ],
-  "references": {
-    "papers": [
-      {
-        "title": "Disquisitiones Arithmeticae",
-        "author": "C. F. Gauss",
-        "year": 1801,
-        "url": "https://en.wikipedia.org/wiki/Disquisitiones_Arithmeticae"
-      }
-    ],
-    "urls": [
-      "https://en.wikipedia.org/wiki/Quadratic_reciprocity",
-      "https://en.wikipedia.org/wiki/Legendre_symbol"
-    ],
-    "mathlib": [
-      "Mathlib.NumberTheory.LegendreSymbol.QuadraticReciprocity",
-      "Mathlib.NumberTheory.LegendreSymbol.Basic"
-    ]
-  },
+  "references": [
+    {
+      "title": "Disquisitiones Arithmeticae",
+      "author": "C. F. Gauss",
+      "year": 1801,
+      "url": "https://en.wikipedia.org/wiki/Disquisitiones_Arithmeticae"
+    },
+    {
+      "text": "https://en.wikipedia.org/wiki/Quadratic_reciprocity",
+      "url": "https://en.wikipedia.org/wiki/Quadratic_reciprocity"
+    },
+    {
+      "text": "https://en.wikipedia.org/wiki/Legendre_symbol",
+      "url": "https://en.wikipedia.org/wiki/Legendre_symbol"
+    },
+    {
+      "text": "Mathlib: Mathlib.NumberTheory.LegendreSymbol.QuadraticReciprocity",
+      "url": "https://leanprover-community.github.io/mathlib4_docs/Mathlib/NumberTheory/LegendreSymbol/QuadraticReciprocity.html"
+    },
+    {
+      "text": "Mathlib: Mathlib.NumberTheory.LegendreSymbol.Basic",
+      "url": "https://leanprover-community.github.io/mathlib4_docs/Mathlib/NumberTheory/LegendreSymbol/Basic.html"
+    }
+  ],
   "leanFile": {
     "namespace": "QRMod4Sign",
     "lineCount": 235,

--- a/src/data/proofs/quadratic-reciprocity-oq-03-oq-03/meta.json
+++ b/src/data/proofs/quadratic-reciprocity-oq-03-oq-03/meta.json
@@ -98,7 +98,11 @@
       "endLine": 54,
       "summary": "jacobi_eq_legendre: at an odd prime p, J(a|p) = legendreSym p a, so every Legendre computation from the parent entry is the prime case of the Jacobi algorithm.",
       "mathContext": "At a prime $p$, $\\left(\\tfrac{a}{p}\\right)_{\\text{Jacobi}} = \\left(\\tfrac{a}{p}\\right)_{\\text{Legendre}}$ — the Jacobi symbol is a conservative extension.",
-      "relatedConcepts": ["Jacobi symbol", "Legendre symbol", "conservative extension"]
+      "relatedConcepts": [
+        "Jacobi symbol",
+        "Legendre symbol",
+        "conservative extension"
+      ]
     },
     {
       "id": "reduction-toolkit",
@@ -107,7 +111,12 @@
       "endLine": 82,
       "summary": "Numerator multiplicativity (jacobiSym_mul_left), denominator multiplicativity (jacobiSym_mul_right, the new phenomenon for composite moduli), numerator reduction (jacobiSym_mod_left), and powers (jacobiSym_pow_left). Each is the Jacobi analogue of a Legendre descent step.",
       "mathContext": "$\\left(\\tfrac{a_1 a_2}{n}\\right) = \\left(\\tfrac{a_1}{n}\\right)\\left(\\tfrac{a_2}{n}\\right)$; $\\left(\\tfrac{a}{mn}\\right) = \\left(\\tfrac{a}{m}\\right)\\left(\\tfrac{a}{n}\\right)$; $\\left(\\tfrac{a}{n}\\right) = \\left(\\tfrac{a \\bmod n}{n}\\right)$; $\\left(\\tfrac{a^e}{n}\\right) = \\left(\\tfrac{a}{n}\\right)^e$.",
-      "relatedConcepts": ["multiplicativity", "modular reduction", "Euclidean descent", "composite modulus"]
+      "relatedConcepts": [
+        "multiplicativity",
+        "modular reduction",
+        "Euclidean descent",
+        "composite modulus"
+      ]
     },
     {
       "id": "supplementary-reciprocity",
@@ -116,7 +125,12 @@
       "endLine": 104,
       "summary": "First supplementary law J(-1|n)=χ₄(n), second supplementary law J(2|n)=χ₈(n), and full quadratic reciprocity J(a|b) = (-1)^((a/2)·(b/2))·J(b|a) for odd a, b — the engine that flips the symbol and enables descent without factoring either argument.",
       "mathContext": "$\\left(\\tfrac{-1}{n}\\right) = \\chi_4(n)$, $\\left(\\tfrac{2}{n}\\right) = \\chi_8(n)$, and $\\left(\\tfrac{a}{b}\\right) = (-1)^{\\frac{a-1}{2}\\frac{b-1}{2}}\\left(\\tfrac{b}{a}\\right)$ for odd $a,b$.",
-      "relatedConcepts": ["supplementary laws", "quadratic reciprocity", "χ₄", "χ₈"]
+      "relatedConcepts": [
+        "supplementary laws",
+        "quadratic reciprocity",
+        "χ₄",
+        "χ₈"
+      ]
     },
     {
       "id": "residue-test",
@@ -125,7 +139,12 @@
       "endLine": 121,
       "summary": "nonresidue_of_jacobi_eq_neg_one: J=-1 certifies a non-residue (valid for every modulus). residue_of_jacobi_eq_one_prime: J=1 recovers a residue only when the modulus is prime. The asymmetry between these two is the heart of the entry.",
       "mathContext": "For all $n$: $\\left(\\tfrac{a}{n}\\right) = -1 \\Rightarrow a$ is not a square mod $n$. For prime $p$: $\\left(\\tfrac{a}{p}\\right) = 1 \\Rightarrow a$ is a square mod $p$.",
-      "relatedConcepts": ["quadratic residue", "Solovay–Strassen test", "Euler liar", "primality testing"]
+      "relatedConcepts": [
+        "quadratic residue",
+        "Solovay–Strassen test",
+        "Euler liar",
+        "primality testing"
+      ]
     },
     {
       "id": "computations",
@@ -134,7 +153,11 @@
       "endLine": 139,
       "summary": "Three values evaluated by Mathlib's kernel-checked norm_num Jacobi-symbol extension: J(2|15)=1, J(7|15)=-1, J(3|15)=0. The extension runs the reciprocity descent at elaboration time and emits an ordinary proof term — no native_decide, so these stay 0-axiom.",
       "mathContext": "$J(2|15) = J(2|3)\\,J(2|5) = (-1)(-1) = 1$; $J(7|15) = J(7|3)\\,J(7|5) = (1)(-1) = -1$; $J(3|15) = 0$ since $\\gcd(3,15) \\ne 1$.",
-      "relatedConcepts": ["norm_num", "kernel-checked computation", "Jacobi symbol evaluation"]
+      "relatedConcepts": [
+        "norm_num",
+        "kernel-checked computation",
+        "Jacobi symbol evaluation"
+      ]
     },
     {
       "id": "converse-fails",
@@ -143,7 +166,12 @@
       "endLine": 161,
       "summary": "two_not_square_mod_fifteen establishes ¬IsSquare (2 : ZMod 15) by decide. jacobi_one_not_residue_test combines it with J(2|15)=1 to prove ∃ a n, J(a|n)=1 ∧ ¬IsSquare a — the Legendre characterization is genuinely false for composite moduli. seven_not_square_mod_fifteen shows the valid direction: J(7|15)=-1 certifies 7 is a non-residue.",
       "mathContext": "Squares mod 15 are $\\{0,1,4,6,9,10\\}$, so $2 \\notin$ them despite $J(2|15)=1$. This false positive is an Euler liar — the obstruction making Solovay–Strassen probabilistic rather than exact.",
-      "relatedConcepts": ["Euler liar", "false positive", "ZMod decidability", "counterexample"]
+      "relatedConcepts": [
+        "Euler liar",
+        "false positive",
+        "ZMod decidability",
+        "counterexample"
+      ]
     },
     {
       "id": "descent",
@@ -152,7 +180,11 @@
       "endLine": 173,
       "summary": "algorithm_descent: under a < b with both odd, reciprocity rewrites J(a|b) in terms of J(b|a), which then reduces mod a < b — the strictly decreasing measure that justifies termination, exactly as in Euclid's algorithm.",
       "mathContext": "Each reciprocity swap maps $\\left(\\tfrac{a}{b}\\right)$ to a problem of strictly smaller modulus after $b \\bmod a$, giving a well-founded descent on the modulus.",
-      "relatedConcepts": ["well-founded recursion", "Euclidean algorithm analogy", "termination"]
+      "relatedConcepts": [
+        "well-founded recursion",
+        "Euclidean algorithm analogy",
+        "termination"
+      ]
     },
     {
       "id": "exports",
@@ -188,23 +220,26 @@
       "description": "The underlying Law of Quadratic Reciprocity, which the Jacobi symbol inherits and which drives the descent."
     }
   ],
-  "references": {
-    "papers": [
-      {
-        "title": "A Fast Monte-Carlo Test for Primality",
-        "author": "R. Solovay and V. Strassen",
-        "year": 1977,
-        "url": "https://en.wikipedia.org/wiki/Solovay%E2%80%93Strassen_primality_test"
-      }
-    ],
-    "urls": [
-      "https://en.wikipedia.org/wiki/Jacobi_symbol",
-      "https://en.wikipedia.org/wiki/Solovay%E2%80%93Strassen_primality_test"
-    ],
-    "mathlib": [
-      "Mathlib.NumberTheory.LegendreSymbol.JacobiSymbol"
-    ]
-  },
+  "references": [
+    {
+      "title": "A Fast Monte-Carlo Test for Primality",
+      "author": "R. Solovay and V. Strassen",
+      "year": 1977,
+      "url": "https://en.wikipedia.org/wiki/Solovay%E2%80%93Strassen_primality_test"
+    },
+    {
+      "text": "https://en.wikipedia.org/wiki/Jacobi_symbol",
+      "url": "https://en.wikipedia.org/wiki/Jacobi_symbol"
+    },
+    {
+      "text": "https://en.wikipedia.org/wiki/Solovay%E2%80%93Strassen_primality_test",
+      "url": "https://en.wikipedia.org/wiki/Solovay%E2%80%93Strassen_primality_test"
+    },
+    {
+      "text": "Mathlib: Mathlib.NumberTheory.LegendreSymbol.JacobiSymbol",
+      "url": "https://leanprover-community.github.io/mathlib4_docs/Mathlib/NumberTheory/LegendreSymbol/JacobiSymbol.html"
+    }
+  ],
   "leanFile": {
     "namespace": "JacobiAlgorithm",
     "lineCount": 186,

--- a/src/data/proofs/quadratic-reciprocity-oq-03/meta.json
+++ b/src/data/proofs/quadratic-reciprocity-oq-03/meta.json
@@ -156,24 +156,30 @@
       "description": "An elementary proof of QR via Gauss sums; provides the theoretical foundation that this algorithmic packaging makes computational."
     }
   ],
-  "references": {
-    "papers": [
-      {
-        "title": "Disquisitiones Arithmeticae",
-        "author": "C. F. Gauss",
-        "year": 1801,
-        "url": "https://en.wikipedia.org/wiki/Disquisitiones_Arithmeticae"
-      }
-    ],
-    "urls": [
-      "https://en.wikipedia.org/wiki/Quadratic_reciprocity",
-      "https://en.wikipedia.org/wiki/Legendre_symbol"
-    ],
-    "mathlib": [
-      "Mathlib.NumberTheory.LegendreSymbol.QuadraticReciprocity",
-      "Mathlib.NumberTheory.LegendreSymbol.Basic"
-    ]
-  },
+  "references": [
+    {
+      "title": "Disquisitiones Arithmeticae",
+      "author": "C. F. Gauss",
+      "year": 1801,
+      "url": "https://en.wikipedia.org/wiki/Disquisitiones_Arithmeticae"
+    },
+    {
+      "text": "https://en.wikipedia.org/wiki/Quadratic_reciprocity",
+      "url": "https://en.wikipedia.org/wiki/Quadratic_reciprocity"
+    },
+    {
+      "text": "https://en.wikipedia.org/wiki/Legendre_symbol",
+      "url": "https://en.wikipedia.org/wiki/Legendre_symbol"
+    },
+    {
+      "text": "Mathlib: Mathlib.NumberTheory.LegendreSymbol.QuadraticReciprocity",
+      "url": "https://leanprover-community.github.io/mathlib4_docs/Mathlib/NumberTheory/LegendreSymbol/QuadraticReciprocity.html"
+    },
+    {
+      "text": "Mathlib: Mathlib.NumberTheory.LegendreSymbol.Basic",
+      "url": "https://leanprover-community.github.io/mathlib4_docs/Mathlib/NumberTheory/LegendreSymbol/Basic.html"
+    }
+  ],
   "leanFile": {
     "namespace": "QRAlgorithm",
     "lineCount": 118,


### PR DESCRIPTION
Companion to #37532. Fixes the remaining `{papers, urls, mathlib}` dict-wrapper entries whose references rendered nothing (`ProofReferences.tsx` expects a `ProofReference[]`; the loader at `src/data/proofs/index.ts:238` passes `meta.references` through unnormalized, so `references.length`/`.map` fail on the dict).

**Entries:** `ballot-problem-oq-01-oq-03`, `euler-identity-oq-01-oq-01-oq-01`, `euler-identity-oq-01-oq-01-oq-01-oq-01`, `euler-identity-oq-01-oq-03`, `euler-identity-oq-01-oq-04`, `quadratic-reciprocity-oq-03` (+ `-oq-01`/`-oq-02`/`-oq-03`).

**Lossless conversion** to flat `ProofReference[]`:
- `papers` dict items kept as-is (`journal` → schema's `venue`); string items → `{ citation }`
- `urls` → `{ text, url }`
- `mathlib` module paths → `{ text: 'Mathlib: <mod>', url: <mathlib4_docs link> }` — previously rendered nowhere; now clickable formal-dependency links in the References section.

Every field preserved and now **displayed**; only the `references` block changes per file; all under size/count caps. Together with #37532 (8 non-mathlib entries) and #37524 (cycle-double-cover), this clears all 18 dict-wrapper entries in the gallery.