### PR TITLE
research(erdos-748): sharp lower bound via the odd family [VERIFIED axiom-free]

### DIFF
--- a/proofs/Proofs/Erdos748Problem.lean
+++ b/proofs/Proofs/Erdos748Problem.lean
@@ -625,6 +625,39 @@ theorem oddFamily_lower_bound (n : ℕ) :
     f n ≥ 2 ^ ((Finset.range (n + 1)).filter (fun k => k % 2 = 1)).card :=
   le_trans (two_family_bound_ge_oddFamily n) (two_family_lower_bound n)
 
+/--
+**The odd family has size exactly `⌈n/2⌉`.**
+`|O| = (n+1)/2`, where `O` is the set of odd numbers in `[1,n]` (the odd elements
+of `{0,…,n}`, since `0` is even). This discharges the previously prose-only claim
+in `oddFamily_lower_bound` that "`|O| = ⌈n/2⌉`". The proof is a direct induction on
+`n`: passing from `{0,…,n}` to `{0,…,n+1}` adds the new top element `n+1`, which is
+counted iff it is odd, and `omega` checks that this matches the increment of the
+ceiling `(n+1)/2 ↦ (n+2)/2`. In `ℕ` the ceiling `⌈n/2⌉` is written `(n+1)/2`. -/
+theorem oddNumbers_card (n : ℕ) :
+    ((Finset.range (n + 1)).filter (fun k => k % 2 = 1)).card = (n + 1) / 2 := by
+  induction n with
+  | zero => decide
+  | succ m ih =>
+    rw [Finset.range_add_one, Finset.filter_insert]
+    by_cases h : (m + 1) % 2 = 1
+    · rw [if_pos h, Finset.card_insert_of_notMem (by simp), ih]
+      omega
+    · rw [if_neg h, ih]
+      omega
+
+/--
+**Sharp lower bound via the *odd* family:** `f(n) ≥ 2^{⌈n/2⌉}`.
+This re-derives the exponent of `sharp_lower_bound` through a genuinely different
+witnessing construction: instead of the upper half `U = {⌊n/2⌋+1,…,n}`, it uses the
+`⌈n/2⌉` odd numbers in `[1,n]`, all of whose `2^{⌈n/2⌉}` subsets are sum-free
+(`oddFamily_lower_bound`). Combining `oddFamily_lower_bound` with the exact count
+`oddNumbers_card` (`|O| = (n+1)/2`) yields the same `2^{⌈n/2⌉}` bound as
+`sharp_lower_bound`, confirming that the odd family alone already attains the sharp
+trivial exponent — the "type 2" dominant family of Part VII carries full weight. -/
+theorem oddFamily_lower_bound_ceil (n : ℕ) : f n ≥ 2 ^ ((n + 1) / 2) := by
+  have h := oddFamily_lower_bound n
+  rwa [oddNumbers_card] at h
+
 /-
 ## Part VII: Structure of Sum-Free Sets
 -/

--- a/src/data/proofs/erdos-748/meta.json
+++ b/src/data/proofs/erdos-748/meta.json
@@ -55,12 +55,14 @@
       "green_upper_bound axiom: f(n) ≪ 2^{n/2}",
       "precise_asymptotic axiom: f(n) ~ c_n · 2^{n/2}",
       "oddNumbers_sumFree theorem: odds form sum-free set",
+      "oddNumbers_card theorem (PROVED, 0 axioms): |O| = ⌈n/2⌉ = (n+1)/2, the exact size of the odd family in [1,n] — discharges the previously prose-only claim in oddFamily_lower_bound by induction on n",
+      "oddFamily_lower_bound_ceil theorem (PROVED, 0 axioms): f(n) ≥ 2^{⌈n/2⌉} re-derived through the ODD family (a genuinely distinct witnessing construction from sharp_lower_bound's upper half), combining oddFamily_lower_bound with the exact count oddNumbers_card",
       "erdos_748_summary: combining all results"
     ],
     "axiomCount": 2,
-    "lineCount": 739,
+    "lineCount": 772,
     "assumptions": "2 axiom(s): green_upper_bound (Green 2004), precise_asymptotic (Green/Sapozhenko). Both are deep results from the literature. The lower bound is fully proved (no longer an axiom), and sharpened to f(n) ≥ 2^{⌈n/2⌉} (sharp_lower_bound) — the best the upper-half construction yields. See the Lean source for details.",
-    "theoremCount": 24,
+    "theoremCount": 26,
     "definitionCount": 5,
     "additionalFiles": [
       "Proofs/Erdos748Aristotle.lean"
@@ -180,9 +182,9 @@
       "Finset"
     ],
     "namespace": "Erdos748",
-    "lineCount": 739,
+    "lineCount": 772,
     "axiomCount": 2,
-    "theoremCount": 25,
+    "theoremCount": 27,
     "definitionCount": 5,
     "path": "Proofs/Erdos748Problem.lean",
     "sorries": 0,

--- a/src/data/research/problems/erdos-748-incomplete-01.json
+++ b/src/data/research/problems/erdos-748-incomplete-01.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "Saturated RICH file (0 sorries, 2 deep BLOCKED axioms Green/Sapozhenko). Session (researcher-2, 2026-07-09): added two_family_bound_gt_upperHalf — the STRICT (>) sharpening of two_family_bound_ge_upperHalf for n≥3, formalizing the previously prose-only strictness claim. 0 new axioms. UNVERIFIED (docker down, no local oleans) but every lemma name/signature checked against pinned mathlib and proof is line-for-line analogue of verified sibling.",
+    "progressSummary": "Saturated RICH file (0 sorries, 2 deep BLOCKED axioms Green/Sapozhenko). Session (researcher-3, 2026-07-11): added oddNumbers_card (|O| = (n+1)/2 = ⌈n/2⌉, by induction) and oddFamily_lower_bound_ceil (f(n) ≥ 2^{⌈n/2⌉} via the ODD family, distinct construction from sharp_lower_bound). Together they discharge the prose-only '|O| = ⌈n/2⌉' claim in oddFamily_lower_bound. 0 new axioms. VERIFIED axiom-free ([propext,Classical.choice,Quot.sound]) via `lake env lean` against prebuilt mathlib oleans, exit 0. Prior session (researcher-2, 2026-07-09): two_family_bound_gt_upperHalf.",
     "builtItems": [
       "Proved trivial_lower_bound in Erdos748Problem.lean: U.powerset ⊆ sumFreeSubsets n ⇒ f n ≥ 2^|U| ≥ 2^{⌊n/2⌋}",
       "Added decidableIsSumFree instance (sum-free predicate is decidable via bounded ∀∈A form)",
@@ -37,7 +37,9 @@
       "f_2 : f 2 = 3 (decide, axiom-free) in Erdos748Aristotle.lean:38",
       "f_3 : f 3 = 6 (decide, axiom-free) in Erdos748Aristotle.lean:44",
       "two_family_bound_ge_upperHalf: the two-family lower bound 2^|O|+2^|U|-2^|O∩U| ≥ 2^|U| (dominates sharp_lower_bound), formalising the prose domination claim. Erdos748Problem.lean.",
-      "two_family_bound_gt_upperHalf (Erdos748Problem.lean): strict version of two_family_bound_ge_upperHalf for n≥3 — formalizes the prose strictness claim in two_family_lower_bound. Witness 1∈O\\U ⇒ O∩U⊊O ⇒ 2^|O∩U|<2^|O| ⇒ RHS > 2^⌈n/2⌉."
+      "two_family_bound_gt_upperHalf (Erdos748Problem.lean): strict version of two_family_bound_ge_upperHalf for n≥3 — formalizes the prose strictness claim in two_family_lower_bound. Witness 1∈O\\U ⇒ O∩U⊊O ⇒ 2^|O∩U|<2^|O| ⇒ RHS > 2^⌈n/2⌉.",
+      "oddNumbers_card (Erdos748Problem.lean, VERIFIED axiom-free): |O| = (n+1)/2 = ⌈n/2⌉ — exact size of the odd family in [1,n], by induction on n (Finset.range_add_one + filter_insert + card_insert_of_notMem, omega on the ⌈·⌉ increment). Discharges the previously prose-only '|O| = ⌈n/2⌉' claim in oddFamily_lower_bound.",
+      "oddFamily_lower_bound_ceil (Erdos748Problem.lean, VERIFIED axiom-free): f(n) ≥ 2^{⌈n/2⌉} via the ODD family, a genuinely distinct witnessing construction from sharp_lower_bound's upper half. Follows by rewriting oddFamily_lower_bound with oddNumbers_card."
     ],
     "insights": [
       "The trivial lower bound needs no analysis: every subset of the upper half {⌊n/2⌋+1,…,n} is sum-free (upperHalf_sumFree), giving 2^{n-⌊n/2⌋} ≥ 2^{⌊n/2⌋} distinct sum-free sets",


### PR DESCRIPTION
## Erdős #748 (Cameron–Erdős sum-free counting): sharp lower bound via the odd family

Two axiom-free additions to `proofs/Proofs/Erdos748Problem.lean` that discharge a
previously **prose-only** claim in the file.

The docstring of the existing `oddFamily_lower_bound` asserts "Since |O| = ⌈n/2⌉, it
gives the same 2^{⌈n/2⌉} exponent as `sharp_lower_bound`" — but the count `|O| = ⌈n/2⌉`
was never formalized. This PR proves it and wires it into a sharp bound.

### New theorems
- **`oddNumbers_card`** — `|O| = (n+1)/2 = ⌈n/2⌉`, the exact number of odd elements
  of `[1,n]`. Proved by induction on `n` (`Finset.range_add_one` + `filter_insert` +
  `card_insert_of_notMem`; `omega` verifies the ceiling increment `(n+1)/2 ↦ (n+2)/2`).
- **`oddFamily_lower_bound_ceil`** — `f(n) ≥ 2^{⌈n/2⌉}`, re-deriving the exponent of
  `sharp_lower_bound` through a **genuinely distinct** witnessing construction: the
  `⌈n/2⌉` odd numbers (the "type 2" dominant family of Part VII) rather than the upper
  half `{⌊n/2⌋+1,…,n}`. Follows by rewriting `oddFamily_lower_bound` with `oddNumbers_card`.

### Verification
- `proofs/bin/lake env lean Proofs/Erdos748Problem.lean` → **exit 0, no warnings**, against pinned Mathlib v4.26.0 oleans.
- `#print axioms` on both new theorems → `[propext, Classical.choice, Quot.sound]` only. **0 new axioms, 0 sorries.**
- The file's 2 existing axioms (Green 2004 / Sapozhenko 2003 — the deep upper-bound results) are untouched; `axiomCount` stays 2.

meta.json updated: `theoremCount` +2, `lineCount` 739→772, two `originalContributions` entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
