### PR TITLE
research(pythagorean-theorem-oq-01): generalize de Gua to the tetrahedral law of cosines

### DIFF
--- a/proofs/Proofs/PythagoreanTheoremOQ06.lean
+++ b/proofs/Proofs/PythagoreanTheoremOQ06.lean
@@ -43,6 +43,13 @@ What survives is exactly `‖u×v‖² + ‖v×w‖² + ‖w×u‖²`, i.e. the 
 - `deGua_zero`       — apex-at-origin form: `sqArea u v w = sqArea 0 u v + sqArea 0 v w + sqArea 0 w u`.
 - `deGua_scalar`     — the recognisable closed form with axis-aligned edges of lengths
                        `a, b, c`: hypotenuse area² `= (½ab)² + (½bc)² + (½ca)²`.
+- `deGua_general`    — the **tetrahedral law of cosines**: for an arbitrary corner (no
+                       right angle) the hypotenuse-face area² equals the sum of the three
+                       leg-face areas² plus a cross-product correction term.
+- `deGua_general_dot`— the same correction written explicitly in the six edge dot products
+                       via the Binet–Cauchy identity.
+- `deGua_of_general` — de Gua's theorem recovered as the orthogonal special case in which
+                       the correction vanishes.
 
 All results are proved with no `sorry` and no additional axioms.
 -/
@@ -122,6 +129,64 @@ theorem deGua_scalar (a b c : ℝ) :
   simp only [sqArea, cross_apply, vec3_dotProduct, Pi.sub_apply]
   norm_num [Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.head_cons,
     Matrix.cons_val_two, Matrix.tail_cons]
+  ring
+
+/-- **Generalized de Gua identity** (no orthogonality assumed).
+
+For an *arbitrary* corner `O` with three edge vectors `u, v, w` (no right angle
+required), the squared area of the face opposite `O` equals the sum of the three
+squared leg-face areas *plus a correction term* built from the mixed cross products.
+This is the tetrahedral analogue of the plane **law of cosines**: de Gua's theorem is
+the special case where the correction vanishes. -/
+theorem deGua_general (O u v w : Fin 3 → ℝ) :
+    sqArea (O + u) (O + v) (O + w)
+      = sqArea O (O + u) (O + v)
+      + sqArea O (O + v) (O + w)
+      + sqArea O (O + w) (O + u)
+      + (1 / 2) * ((u ⨯₃ v) ⬝ᵥ (v ⨯₃ w)
+          + (v ⨯₃ w) ⬝ᵥ (w ⨯₃ u)
+          + (w ⨯₃ u) ⬝ᵥ (u ⨯₃ v)) := by
+  -- The dot product is symmetric, so the three "reversed" mixed terms coincide with the
+  -- three we keep; identify them before letting `ring` combine the nine expanded pieces.
+  have c1 : (v ⨯₃ w) ⬝ᵥ (u ⨯₃ v) = (u ⨯₃ v) ⬝ᵥ (v ⨯₃ w) := dotProduct_comm _ _
+  have c2 : (w ⨯₃ u) ⬝ᵥ (v ⨯₃ w) = (v ⨯₃ w) ⬝ᵥ (w ⨯₃ u) := dotProduct_comm _ _
+  have c3 : (u ⨯₃ v) ⬝ᵥ (w ⨯₃ u) = (w ⨯₃ u) ⬝ᵥ (u ⨯₃ v) := dotProduct_comm _ _
+  simp only [sqArea, add_sub_cancel_left, add_sub_add_left_eq_sub]
+  rw [hyp_edge_cross]
+  simp only [dotProduct_add, add_dotProduct, c1, c2, c3]
+  ring
+
+/-- **Closed dot-product form of the correction.** Applying the Binet–Cauchy identity
+(`cross_dot_cross`) to each mixed term rewrites the correction of `deGua_general` purely
+in terms of the six edge dot products. Every summand carries a factor that is a dot
+product between two *distinct* edges, so the whole correction collapses to `0` exactly
+when the edges are mutually perpendicular. -/
+theorem deGua_general_dot (O u v w : Fin 3 → ℝ) :
+    sqArea (O + u) (O + v) (O + w)
+      = sqArea O (O + u) (O + v)
+      + sqArea O (O + v) (O + w)
+      + sqArea O (O + w) (O + u)
+      + (1 / 2) * ((u ⬝ᵥ v) * (v ⬝ᵥ w) - (u ⬝ᵥ w) * (v ⬝ᵥ v)
+          + (v ⬝ᵥ w) * (w ⬝ᵥ u) - (v ⬝ᵥ u) * (w ⬝ᵥ w)
+          + (w ⬝ᵥ u) * (u ⬝ᵥ v) - (w ⬝ᵥ v) * (u ⬝ᵥ u)) := by
+  rw [deGua_general]
+  simp only [cross_dot_cross]
+  ring
+
+/-- **de Gua recovered from the general identity.** When the three edges are mutually
+perpendicular, every mixed dot product vanishes, so the correction of `deGua_general_dot`
+is `0` and the general identity collapses to `deGua`. This exhibits de Gua's theorem as a
+strict special case of the tetrahedral law of cosines. -/
+theorem deGua_of_general (O u v w : Fin 3 → ℝ)
+    (huv : u ⬝ᵥ v = 0) (hvw : v ⬝ᵥ w = 0) (hwu : w ⬝ᵥ u = 0) :
+    sqArea (O + u) (O + v) (O + w)
+      = sqArea O (O + u) (O + v)
+      + sqArea O (O + v) (O + w)
+      + sqArea O (O + w) (O + u) := by
+  have huw : u ⬝ᵥ w = 0 := by rw [dotProduct_comm]; exact hwu
+  have hvu : v ⬝ᵥ u = 0 := by rw [dotProduct_comm]; exact huv
+  have hwv : w ⬝ᵥ v = 0 := by rw [dotProduct_comm]; exact hvw
+  rw [deGua_general_dot, huv, hvw, hwu, huw, hvu, hwv]
   ring
 
 end PythagoreanDeGua

--- a/src/data/research/problems/pythagorean-theorem-oq-01.json
+++ b/src/data/research/problems/pythagorean-theorem-oq-01.json
@@ -20,7 +20,8 @@
       "`pythagorean_theorem` proves the main norm-square identity for perpendicular vectors.",
       "`pythagorean_3_4_5`, `pythagorean_5_12_13`, and `pythagorean_8_15_17` verify standard integer triples.",
       "`pythagorean_converse` proves the converse direction from the norm identity to perpendicularity.",
-      "`pythagorean_sum` generalizes the identity to finite mutually perpendicular vector families."
+      "`pythagorean_sum` generalizes the identity to finite mutually perpendicular vector families.",
+      "`deGua_general` proves the tetrahedral law of cosines (arbitrary corner: hypotenuse-face area² = sum of leg-face areas² + cross-product correction), with `deGua_general_dot` giving the explicit Binet–Cauchy dot-product form and `deGua_of_general` recovering de Gua as the orthogonal special case."
     ],
     "open": [],
     "goal": "Use the completed two-dimensional vector proof as a stable geometry example and reference point for richer Euclidean developments."
@@ -39,12 +40,13 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (researcher-1, 2026-07-10): realized Einsteins area-scales-as-square-of-side step concretely on the altitude dissection (nextStep #1) — triArea_sub_A_ratio/_B_ratio (Area of each similar sub-triangle = (leg/hyp)²·whole) + triArea_pieces_sum_whole (the two pieces area-tile the whole). Connects Layer1 triArea/triArea_scale to Layer3 altitude decomposition. Disjoint from open PR #37417 (segment ratio). UNVERIFIED (docker down; local Mathlib field_simp drift breaks even pristine main file verification — new thm #print axioms clean, proofs mirror merged neighbor idiom). meta leanFile 366→429/16→19.",
+    "progressSummary": "PROGRESS (researcher-8, 2026-07-11): strengthened de Gua's theorem (PythagoreanTheoremOQ06.lean 128→192L, 4→7 thm) to the GENERAL tetrahedral law of cosines deGua_general — for an ARBITRARY corner O (no right angle) sqArea(hyp) = leg1+leg2+leg3 + ½·(cyclic sum of mixed cross-dots (u×v)·(v×w)+...). deGua_general_dot gives the explicit six-dot-product closed form via Binet–Cauchy (cross_dot_cross); deGua_of_general recovers de Gua as the orthogonal special case where the correction vanishes. VERIFIED lake env lean 4.26.0 EXIT0, #print axioms = [propext,Classical.choice,Quot.sound] axiom-free. Also fixes stale sorryCount 1→0 (was a docstring 'no `sorry`' false positive).",
     "builtItems": [
       "sin_eq_sinc_mul, tendsto_one_sub_cos_mul_div_sq, tendsto_cos_mul_one, tendsto_one_sub_cos_prod_div_sq, spherical_flat_limit in Proofs/PythagoreanTheoremOQ05.lean (0 sorry, 0 axioms, verified via lake env lean 4.26.0)",
       "Removed 3 unused axioms from Proofs/PythagoreanTriplesOQ01.lean (r2_average_order [false as stated], landau_two_squares, primitive_by_leg_density), reducing 6→3; content retained as documented targets. Updated meta.json axiomCount 6→3 in both stat blocks + assumptions/keyStatements/annotations.",
       "PythagoreanTheoremOQ01.lean: Einstein's similar-triangles proof, verified (0 axioms, 0 sorries, 13 theorems) via docker-build Lean 4.26.0. Three layers: triArea_scale (area-square law), einstein_pythagorean (coordinate-free cancel-the-shape-constant skeleton), and an inner-product altitude decomposition (altitudeFoot, foot_perp, geometric_mean_A/B, segments_sum, pythagorean_via_altitude, einstein_matches_core). Gallery entry src/data/proofs/pythagorean-theorem-oq-01. PR #36241.",
-      "triArea_sub_A_ratio, triArea_sub_B_ratio, triArea_pieces_sum_whole (PythagoreanTheoremOQ01.lean): Einstein area∝side² step realized on the concrete altitude dissection. UNVERIFIED (docker down; file-wide local Mathlib field_simp drift affects even pristine main — #print axioms of new thms clean propext/Classical.choice/Quot.sound, proofs mirror merged triArea_hypotenuse_eq_legs idiom)."
+      "triArea_sub_A_ratio, triArea_sub_B_ratio, triArea_pieces_sum_whole (PythagoreanTheoremOQ01.lean): Einstein area∝side² step realized on the concrete altitude dissection. UNVERIFIED (docker down; file-wide local Mathlib field_simp drift affects even pristine main — #print axioms of new thms clean propext/Classical.choice/Quot.sound, proofs mirror merged triArea_hypotenuse_eq_legs idiom).",
+      "deGua_general, deGua_general_dot, deGua_of_general (PythagoreanTheoremOQ06.lean): the tetrahedral law of cosines generalizing de Gua to an arbitrary (non-right) corner — hypotenuse-face area² = sum of three leg-face areas² + ½·cyclic sum of mixed cross-dots; explicit dot-product form via Binet–Cauchy; de Gua recovered as the orthogonal special case. Verified axiom-free (lake env lean 4.26.0, #print axioms clean)."
     ],
     "insights": [
       "Spherical flat limit: from cos(tc)=cos(ta)cos(tb) ∀t>0, c²=a²+b² follows by the exact identity (1-cos(tx))/t² = (x²/2)·sinc(tx/2)², using half-angle 1-cos(tx)=2sin(tx/2)² and sin u = sinc u · u; sinc continuity (sinc 0 = 1) gives the limit. No range restriction on a,b,c needed.",
@@ -55,7 +57,8 @@
       "The two geometric-mean relations |CA|^2 = |AB|*|AH| and |CB|^2 = |AB|*|HB| (Euclid VI altitude-on-hypotenuse) are the numerical fingerprint of the similar sub-triangles; summing them via betweenness |AH|+|HB|=|AB| rebuilds Pythagoras.",
       "The altitude foot has a closed affine form H = A + (|CA|^2/|AB|^2)*(B-A) whose parameter t is the similar-triangle ratio; the whole decomposition follows by direct inner-product computation, no Mathlib orthogonalProjection needed.",
       "Honesty limit: in a fixed inner-product model the norm already encodes Pythagoras (pythagorean_core is a one-line polarization), so no coordinate proof is foundationally 'simpler' than that line; a genuinely independent 'simplest proof' would require synthetic axiomatic geometry where length is not defined via a coordinate norm.",
-      "Einstein area-ratio realized concretely: the altitude from C cuts A B C into two sub-triangles A H C and H B C, each similar to the whole, with Area(AHC)=(|CA|/|AB|)²·Area(ABC) and Area(HBC)=(|CB|/|AB|)²·Area(ABC) (triArea_sub_A_ratio/_B_ratio via dist_A_foot/dist_foot_B — same altitude height so area ratio = base ratio = squared leg ratio). Their sum = whole (triArea_pieces_sum_whole, area-level companion of segments_sum) because (|CA|²+|CB|²)/|AB|²=1. This closes the Layer1(triArea/triArea_scale)↔Layer3(altitude dissection) loop that nextStep #1 requested."
+      "Einstein area-ratio realized concretely: the altitude from C cuts A B C into two sub-triangles A H C and H B C, each similar to the whole, with Area(AHC)=(|CA|/|AB|)²·Area(ABC) and Area(HBC)=(|CB|/|AB|)²·Area(ABC) (triArea_sub_A_ratio/_B_ratio via dist_A_foot/dist_foot_B — same altitude height so area ratio = base ratio = squared leg ratio). Their sum = whole (triArea_pieces_sum_whole, area-level companion of segments_sum) because (|CA|²+|CB|²)/|AB|²=1. This closes the Layer1(triArea/triArea_scale)↔Layer3(altitude dissection) loop that nextStep #1 requested.",
+      "de Gua's theorem is exactly the vanishing-correction case of a tetrahedral law of cosines: from the edge expansion (v−u)×(w−u)=u×v+v×w+w×u, ‖·‖² produces the three leg cross-norms PLUS three mixed terms 2(u×v)·(v×w)+…; Binet–Cauchy (cross_dot_cross) evaluates each mixed term to (u·v)(v·w)−(u·w)(v·v) etc., every summand carrying a dot product between two DISTINCT edges, so the correction is exactly the obstruction to orthogonality. This makes de Gua a genuine special case rather than a standalone identity."
     ],
     "mathlibGaps": [
       "Mathlib cache drift broke the existing hyperbolic section: le_div_iff→le_div_iff₀, div_le_div_iff→div_le_div_iff₀, Filter.eventually_nhdsWithin_of_forall→eventually_nhdsWithin_of_forall, Tendsto.congr! argument order (eventuallyEq first), pointwise squeeze tendsto_of_tendsto_of_tendsto_of_le_of_le→eventually variant (prime), HasDerivAt.sub of a const now yields x-0 (needs simpa/convert), and let-bound f 0 = 0 no longer closes by bare simp (needs show)."
@@ -88,7 +91,7 @@
     "mathlib": []
   },
   "started": "2026-04-06T06:37:41.264Z",
-  "lastUpdate": "2026-07-09T21:20:00.000Z",
+  "lastUpdate": "2026-07-11T18:30:00.000Z",
   "significance": 7,
   "tractability": 7,
   "leanFiles": [
@@ -194,11 +197,11 @@
     {
       "path": "Proofs/PythagoreanTheoremOQ06.lean",
       "filename": "PythagoreanTheoremOQ06.lean",
-      "lineCount": 128,
-      "theoremCount": 4,
+      "lineCount": 192,
+      "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 1,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/PythagoreanTheoremOQ06.lean"
     }


### PR DESCRIPTION
## Summary

Strengthens `PythagoreanTheoremOQ06.lean` (de Gua's theorem — the 3-D Pythagorean theorem) with the general, **orthogonality-free** identity that de Gua is merely the special case of: a *tetrahedral law of cosines*.

## New results (all axiom-free)

- **`deGua_general`** — for an *arbitrary* corner `O` with edge vectors `u, v, w` (no right angle required):
  ```
  sqArea(hyp face) = sqArea(leg₁) + sqArea(leg₂) + sqArea(leg₃)
                     + ½·((u×v)·(v×w) + (v×w)·(w×u) + (w×u)·(u×v))
  ```
  the tetrahedral analogue of the plane law of cosines.
- **`deGua_general_dot`** — the correction rewritten explicitly in the six edge dot products via the Binet–Cauchy identity (`cross_dot_cross`). Every summand carries a dot product between two *distinct* edges, so the correction is precisely the obstruction to orthogonality.
- **`deGua_of_general`** — de Gua's theorem recovered as the orthogonal special case in which the correction vanishes, exhibiting the classical result as a strict corollary.

## Verification

- `./bin/lake env lean Proofs/PythagoreanTheoremOQ06.lean` → EXIT 0 (Lean 4.26.0, against prebuilt Mathlib oleans).
- `#print axioms` for all three new theorems → `[propext, Classical.choice, Quot.sound]` (no `sorry`, no extra axioms).
- File: 128 → 192 lines, 4 → 7 theorems, 0 sorries.

Also corrects a stale `sorryCount` (1 → 0) in the problem knowledge file — the lone "sorry" was a docstring token (`proved with no \`sorry\``), not a real one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)