### PR TITLE
research(erdos-744-incomplete-01): cut-side monotonicity trio under edge addition [VERIFIED axiom-free]

### DIFF
--- a/proofs/Proofs/Erdos744Problem.lean
+++ b/proofs/Proofs/Erdos744Problem.lean
@@ -396,6 +396,65 @@ theorem bipartitionNumber_eq_edgeCount_iff {V : Type*} [Fintype V] [LinearOrder 
   have h := bipartitionNumber_add_maxCut G
   omega
 
+/-
+# Part 3c: Monotonicity of the cut quantities under edge addition
+
+The dual side of `monochromaticEdges_mono` / `bipartitionNumber_mono`: the
+*cut* quantities (`edgeCount`, `bichromaticEdges`, `maxCut`) are likewise
+monotone when edges are added. Together the two groups say that adding an edge
+can only push a colouring's monochromatic and bichromatic counts *up*, and
+hence both extremal invariants `bipartitionNumber` and `maxCut` grow with the
+graph — the "quantities increase with the graph" intuition behind Erdős #744.
+All axiom-free.
+-/
+
+/-- **The edge count is monotone under edge addition.** If every edge of `G` is
+    an edge of `H` then `edgeCount G ≤ edgeCount H`: a supergraph has at least as
+    many edges. -/
+theorem edgeCount_mono {V : Type*} [Fintype V] [LinearOrder V]
+    (G H : SimpleGraph' V) [DecidableRel G.Adj] [DecidableRel H.Adj]
+    (hsub : ∀ u v, G.Adj u v → H.Adj u v) :
+    edgeCount G ≤ edgeCount H := by
+  unfold edgeCount
+  apply Finset.card_le_card
+  intro p hp
+  simp only [Finset.mem_filter, Finset.mem_univ, true_and] at hp ⊢
+  exact ⟨hp.1, hsub p.1 p.2 hp.2⟩
+
+/-- **Bichromatic edges are monotone under edge addition.** Dual to
+    `monochromaticEdges_mono`: if every edge of `G` is an edge of `H`, then for a
+    *fixed* 2-colouring the supergraph `H` cuts at least as many edges as `G`.
+    A newly added edge either is or is not separated by `c`, but it can never
+    remove one of `G`'s already-separated edges. -/
+theorem bichromaticEdges_mono {V : Type*} [Fintype V] [LinearOrder V]
+    (G H : SimpleGraph' V) [DecidableRel G.Adj] [DecidableRel H.Adj]
+    (hsub : ∀ u v, G.Adj u v → H.Adj u v) (c : V → Bool) :
+    bichromaticEdges G c ≤ bichromaticEdges H c := by
+  unfold bichromaticEdges
+  apply Finset.card_le_card
+  intro p hp
+  simp only [Finset.mem_filter, Finset.mem_univ, true_and] at hp ⊢
+  exact ⟨hp.1, hsub p.1 p.2 hp.2.1, hp.2.2⟩
+
+/-- **The max-cut is monotone under edge addition.** If every edge of `G` is an
+    edge of `H` then `maxCut G ≤ maxCut H`: a supergraph can be cut at least as
+    deeply. The exact dual of `bipartitionNumber_mono`, and the max-cut side of
+    the "both invariants grow with the graph" phenomenon. The optimal cut of `G`
+    already separates `maxCut G` edges of `H` (`bichromaticEdges_mono`), so the
+    best cut of `H` does at least that well. -/
+theorem maxCut_mono {V : Type*} [Fintype V] [LinearOrder V]
+    (G H : SimpleGraph' V) [DecidableRel G.Adj] [DecidableRel H.Adj]
+    (hsub : ∀ u v, G.Adj u v → H.Adj u v) :
+    maxCut G ≤ maxCut H := by
+  unfold maxCut
+  obtain ⟨c, -, hc⟩ :=
+    Finset.exists_mem_eq_sup' (Finset.univ_nonempty (α := V → Bool)) (bichromaticEdges G)
+  rw [hc]
+  calc bichromaticEdges G c
+      ≤ bichromaticEdges H c := bichromaticEdges_mono G H hsub c
+    _ ≤ (Finset.univ : Finset (V → Bool)).sup' Finset.univ_nonempty (bichromaticEdges H) :=
+        Finset.le_sup' (bichromaticEdges H) (Finset.mem_univ c)
+
 /--
 **The f_k(n) Function**
 

--- a/src/data/research/problems/erdos-744-incomplete-01.json
+++ b/src/data/research/problems/erdos-744-incomplete-01.json
@@ -29,19 +29,21 @@
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETE: replaced ill-formed bipartitionNumber (Nat.find over an undetermined predicate, with a sorry) with a correct, constructive, axiom-free definition; un-bit-rotted the whole file so it builds on Lean v4.26.0. 0 sorries; 2 legitimate axioms remain (chromaticNumber, rodl_tuza_theorem).",
+    "progressSummary": "COMPLETE + extended: correct axiom-free bipartitionNumber engine (0 sorries; 2 legitimate axioms chromaticNumber, rodl_tuza_theorem). Now includes the full monotonicity-under-edge-addition picture on BOTH sides: monochromaticEdges/bipartitionNumber (min-uncut) and edgeCount/bichromaticEdges/maxCut (max-cut), all verified axiom-free.",
     "builtItems": [
       "monochromaticEdges G c : ℕ — count of same-colored adjacent pairs u<v (Erdos744Problem.lean:99)",
       "bipartitionNumber G := inf over c:V→Bool of monochromaticEdges G c — total, sorry-free, no chromaticNumber axiom (Erdos744Problem.lean:115)",
       "monochromaticEdges_eq_zero_iff: c has no monochromatic edge ↔ proper 2-coloring (Erdos744Problem.lean:120)",
       "bipartitionNumber_eq_zero_iff: bipartitionNumber G = 0 ↔ G properly 2-colorable — intrinsic bipartiteness, 0-axiom (Erdos744Problem.lean:136)",
-      "bipartitionNumber_eq_edgeCount_iff : bipartitionNumber G = edgeCount G ↔ edgeCount G = 0 — the fourth/final corner of the max-cut/min-uncut square (dual of maxCut_eq_edgeCount_iff), bipartitionNumber saturates edgeCount iff G edgeless. Proof rw[← maxCut_eq_zero_iff]; complementarity; omega [VERIFIED axiom-free, lean-elab exit 0, #print axioms = propext/Classical.choice/Quot.sound]"
+      "bipartitionNumber_eq_edgeCount_iff : bipartitionNumber G = edgeCount G ↔ edgeCount G = 0 — the fourth/final corner of the max-cut/min-uncut square (dual of maxCut_eq_edgeCount_iff), bipartitionNumber saturates edgeCount iff G edgeless. Proof rw[← maxCut_eq_zero_iff]; complementarity; omega [VERIFIED axiom-free, lean-elab exit 0, #print axioms = propext/Classical.choice/Quot.sound]",
+      "edgeCount_mono / bichromaticEdges_mono / maxCut_mono: the cut-side monotonicity trio under edge addition (G⊆H ⇒ edgeCount, bichromaticEdges c, and maxCut all non-decreasing), dual to monochromaticEdges_mono/bipartitionNumber_mono. maxCut_mono via the optimal cut of G already separating maxCut G edges of H (Erdos744Problem.lean, Part 3c) [VERIFIED axiom-free: propext/Classical.choice/Quot.sound, lake env lean exit 0]"
     ],
     "insights": [
       "The original bipartitionNumber was Nat.find ⟨witness, sorry⟩ over a metavariable predicate p — ill-formed, not a real definition; the right completion is a redefinition, not discharging the sorry.",
       "Realizing the bipartition number as min monochromatic edges over 2-colorings avoids the chromaticNumber axiom entirely: bipartiteness becomes the intrinsic property bipartitionNumber = 0.",
       "log_conjecture_false needs only f 4 n = 3 by definition (no Rödl-Tuza axiom): #print axioms shows it depends only on propext/Classical/Quot.",
-      "The four extremal characterizations of the bipartitionNumber/maxCut engine form a 2x2 square: maxCut=0⟺edgeless, maxCut=edgeCount⟺bipartite, bipartitionNumber=0⟺bipartite, bipartitionNumber=edgeCount⟺edgeless. All four follow from the single complementarity identity bipartitionNumber+maxCut=edgeCount plus one of the ⟺ endpoints via omega."
+      "The four extremal characterizations of the bipartitionNumber/maxCut engine form a 2x2 square: maxCut=0⟺edgeless, maxCut=edgeCount⟺bipartite, bipartitionNumber=0⟺bipartite, bipartitionNumber=edgeCount⟺edgeless. All four follow from the single complementarity identity bipartitionNumber+maxCut=edgeCount plus one of the ⟺ endpoints via omega.",
+      "Both extremal invariants grow with the graph: bipartitionNumber_mono (min-uncut side) and maxCut_mono (max-cut side) are duals, each reducing to per-colouring monotonicity of monochromatic/bichromatic edge counts. This is the formal content of Erdős's original growth intuition for f_k, cleanly separated from the (false) asymptotic-divergence claim."
     ],
     "mathlibGaps": [],
     "nextSteps": [


### PR DESCRIPTION
## Summary

Extends the completed `erdos-744-incomplete-01` bipartition engine with the **cut-side monotonicity trio** under edge addition, the exact dual of the existing `monochromaticEdges_mono` / `bipartitionNumber_mono`. This completes the "both extremal invariants grow with the graph" picture — the formal content of Erdős's original growth intuition behind #744.

## New theorems (all axiom-free)

| theorem | statement |
|---------|-----------|
| `edgeCount_mono` | `G ⊆ H ⇒ edgeCount G ≤ edgeCount H` |
| `bichromaticEdges_mono` | `G ⊆ H ⇒ bichromaticEdges G c ≤ bichromaticEdges H c` (dual of `monochromaticEdges_mono`) |
| `maxCut_mono` | `G ⊆ H ⇒ maxCut G ≤ maxCut H` (dual of `bipartitionNumber_mono`) |

`maxCut_mono` reduces to per-colouring bichromatic monotonicity: the optimal cut of `G` already separates `maxCut G` edges of the supergraph `H`, so `H`'s best cut does at least as well.

## Verification

- `lake env lean Proofs/Erdos744Problem.lean` → exit 0, 0 sorries.
- `#print axioms` for all three new theorems: `[propext, Classical.choice, Quot.sound]` (axiom-free by project standards).
- The file's 2 pre-existing legitimate axioms (`chromaticNumber`, `rodl_tuza_theorem`) are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
