### PR TITLE
Enrich abel-ruffini-obstruction-oq-06: finer section coverage (3->5)

### DIFF
--- a/src/data/proofs/abel-ruffini-obstruction-oq-06/meta.json
+++ b/src/data/proofs/abel-ruffini-obstruction-oq-06/meta.json
@@ -79,12 +79,28 @@
       "mathContext": "solvable by radicals $\\iff$ $\\mathrm{Gal}$ solvable; $S_n$ solvable $\\iff n \\le 4$."
     },
     {
-      "id": "part-i-symmetric-obstruction",
-      "title": "Part I: The Symmetric-Group Obstruction",
+      "id": "part-i-obstruction",
+      "title": "Part I(a): Sₙ is not solvable for n ≥ 5",
       "startLine": 42,
+      "endLine": 67,
+      "summary": "symmetricGroup_not_solvable: the symmetric group on n symbols is not solvable once n ≥ 5, generalizing Mathlib's Fin 5 case (Equiv.Perm.fin_5_not_solvable) to every n ≥ 5 — any such Sₙ contains a copy of S₅, whose derived series never reaches the trivial subgroup because A₅ is perfect (its own commutator subgroup) and nonabelian simple. This is the obstruction itself.",
+      "mathContext": "$A_5$ perfect nonabelian simple $\\Rightarrow$ $S_n$ not solvable for all $n \\ge 5$."
+    },
+    {
+      "id": "part-i-small-groups",
+      "title": "Part I(b): S₂, S₃, S₄, A₄ are solvable",
+      "startLine": 68,
+      "endLine": 144,
+      "summary": "The solvable side, each built as a one-step (or two-step) extension closed by solvable_of_ker_le_range: perm_fin_two_solvable (S₂ abelian), perm_fin_three_solvable (A₃ cyclic of prime order 3, quotient via the sign map), alt_fin_four_solvable (A₄ ⊳ V₄ ⊳ 1 with Klein-four kernel of exponent 2 and cyclic order-3 quotient), and perm_fin_four_solvable (S₄ over the sign sequence with A₄ as kernel). These are the concrete low-degree witnesses making the threshold sharp.",
+      "mathContext": "$S_2$ abelian; $A_3 \\cong C_3$; $A_4 \\rhd V_4 \\rhd 1$; $S_4 \\rhd A_4 \\rhd V_4 \\rhd 1$ — all solvable."
+    },
+    {
+      "id": "part-i-threshold",
+      "title": "Part I(c): the sharp threshold Sₙ solvable ⟺ n ≤ 4",
+      "startLine": 145,
       "endLine": 176,
-      "summary": "The full group-theoretic threshold. symmetricGroup_not_solvable: Sₙ is not solvable for every n ≥ 5 (via Equiv.Perm.not_solvable, generalizing Mathlib's Fin 5 case). The solvable side, each built as a one-step extension closed by solvable_of_ker_le_range: perm_fin_two_solvable (S₂ abelian), perm_fin_three_solvable (A₃ cyclic of prime order 3, quotient via sign), alt_fin_four_solvable (A₄ ⊳ V₄ ⊳ 1 with Klein-four kernel of exponent 2 and cyclic order-3 quotient), and perm_fin_four_solvable (S₄ over the sign sequence with A₄ kernel). symmetric_threshold and symmetric_threshold_full package the dividing line Sₙ solvable ⟺ n ≤ 4.",
-      "mathContext": "$A_5$ perfect simple $\\Rightarrow S_n$ unsolvable for $n\\ge5$; $S_2,S_3,S_4$ solvable via derived series $A_4 \\rhd V_4 \\rhd 1$."
+      "summary": "symmetric_threshold and symmetric_threshold_full package the two sides into a single dividing line: S₂, S₃ (and S₄, in the full form) are solvable while Sₙ is not solvable for any n ≥ 5. This is the group-theoretic skeleton of Abel–Ruffini — solvability of the symmetric group is exactly what separates the radically-solvable low degrees from the radically-unsolvable high ones.",
+      "mathContext": "$S_n$ solvable $\\iff n \\le 4$ — the sharp group-theoretic dividing line behind Abel–Ruffini."
     },
     {
       "id": "part-ii-radical-criterion",


### PR DESCRIPTION
Enrichment pass for `abel-ruffini-obstruction-oq-06` (quality 96, pass 0).

## Changes
- **Sections 3 → 5.** The former Part I section spanned 134 lines (42–176) and lumped 7 theorems into one summary. Split it into three conceptually distinct theorem-level sections at genuine Lean boundaries:
  - **Part I(a)** — the obstruction `symmetricGroup_not_solvable`: Sₙ not solvable for n ≥ 5 (42–67).
  - **Part I(b)** — the small solvable groups `perm_fin_two/three/four_solvable`, `alt_fin_four_solvable` (68–144).
  - **Part I(c)** — the sharp threshold `symmetric_threshold`/`symmetric_threshold_full`: Sₙ solvable ⟺ n ≤ 4 (145–176).
  - Each new section has its own summary + LaTeX mathContext; the 5 sections cover the file at a readable granularity (no padding).

## Verification
- `meta.json`/`annotations.json` valid JSON; `pnpm build` `check-meta-size`, annotations, search-index, loading-facts steps pass with **0 error mentions of this target** (only routine 'Generating/Enriched' info lines for child entries `-oq-06-oq-01/-oq-02`; the unrelated `tsc: command not found` post-step fails due to node_modules not installed).
- meta.json 19.0 → 20.2 KB, well under the 60 KB cap; keyInsights already at 5 (unchanged); no content deleted; status/badge/axiomCount untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)