### PR TITLE
research(lagrange-four-squares-oq-01-oq-03): even-side structure of Jacobi's four-square count

### DIFF
--- a/proofs/Proofs/LagrangeFourSquaresOQ01OQ03.lean
+++ b/proofs/Proofs/LagrangeFourSquaresOQ01OQ03.lean
@@ -33,6 +33,11 @@ divisor-sum formula reproduces the brute-force lattice count for a range of smal
 2. `jacobiCount n = 8·Σ_{d|n, 4∤d} d` — the right-hand side of Jacobi's formula.
 3. `jacobiCount_odd` (0-axiom, **general**): for odd `n` the `4∤d` filter is vacuous,
    so `jacobiCount n = 8·σ(n)`. This isolates the elementary half of the formula.
+   `jacobiCount_of_not_four_dvd` (0-axiom, **general**) is its common root: whenever
+   `4 ∤ n` the filter is vacuous, so `jacobiCount n = 8·σ(n)`. The doubling relation
+   `jacobiCount_two_mul` (0-axiom, **general**) gives `jacobiCount (2·m) = 3·jacobiCount m`
+   for odd `m`, and `jacobiCount_two_mul_odd_eq` its closed form `24·σ(m)` — the classical
+   `r₄(2m)` value, matching the oracle (`r4 6 = 96 = 24·σ(3)`).
 4. `naive_sigma_fails` (0-axiom): the naive `8·σ(4) = 56` is WRONG; the true count
    is `r4 4 = 24`. The `4∤d` exclusion is load-bearing — this guards the convention.
 5. `jacobi_oracle` : `r4 n = jacobiCount n` for `1 ≤ n ≤ 24`, by `native_decide`
@@ -137,6 +142,53 @@ power of two `2^k` with `k ≥ 1`. -/
 theorem jacobiCount_two_pow_const {j k : ℕ} (hj : 1 ≤ j) (hk : 1 ≤ k) :
     jacobiCount (2 ^ j) = jacobiCount (2 ^ k) := by
   rw [jacobiCount_two_pow hj, jacobiCount_two_pow hk]
+
+/-- **General filter-vacuous lemma (0-axiom).** If `4 ∤ n` then *no* divisor of `n` is
+divisible by `4` (a divisor of `4` in `n` would force `4 ∣ n`), so the `4 ∤ d` exclusion
+is vacuous and `jacobiCount n = 8·σ(n)`. This is the common root of both `jacobiCount_odd`
+(odd `n` ⟹ `4 ∤ n`) and the `n = 2·(odd)` case below: the Jacobi count collapses to
+`8·σ` exactly when the 2-adic valuation of `n` is at most `1`. -/
+theorem jacobiCount_of_not_four_dvd {n : ℕ} (h : ¬ (4 ∣ n)) :
+    jacobiCount n = 8 * ∑ d ∈ n.divisors, d := by
+  unfold jacobiCount
+  congr 1
+  apply Finset.sum_congr _ (fun _ _ => rfl)
+  apply Finset.filter_true_of_mem
+  intro d hd
+  rw [Nat.mem_divisors] at hd
+  intro hdvd
+  exact h (dvd_trans hdvd hd.1)
+
+/-- **First doubling triples the count (0-axiom, general).** For every odd `m`,
+`jacobiCount (2·m) = 3·jacobiCount m`. Since `2·m` has 2-adic valuation `1`, no divisor
+is divisible by `4`, so `jacobiCount (2m) = 8·σ(2m)`; multiplicativity of `σ` on the
+coprime factors `2, m` gives `σ(2m) = σ(2)·σ(m) = 3·σ(m)`, while `jacobiCount m = 8·σ(m)`.
+This is the even-side companion to `jacobiCount_odd`, and its `m = 1` instance
+`jacobiCount 2 = 24` matches `jacobiCount_two_pow`. -/
+theorem jacobiCount_two_mul {m : ℕ} (hm : Odd m) :
+    jacobiCount (2 * m) = 3 * jacobiCount m := by
+  have h4 : ¬ (4 ∣ 2 * m) := by
+    intro hdvd
+    have h2 : (2 : ℕ) * 2 ∣ 2 * m := by simpa using hdvd
+    have : 2 ∣ m := (mul_dvd_mul_iff_left (by norm_num : (2 : ℕ) ≠ 0)).mp h2
+    exact (Nat.not_even_iff_odd.mpr hm) (even_iff_two_dvd.mpr this)
+  have h4m : ¬ (4 ∣ m) := fun hdvd =>
+    (Nat.not_even_iff_odd.mpr hm) (even_iff_two_dvd.mpr (dvd_trans ⟨2, rfl⟩ hdvd))
+  have hcop : Nat.Coprime 2 m := by rw [Nat.coprime_two_left]; exact hm
+  rw [jacobiCount_of_not_four_dvd h4, jacobiCount_of_not_four_dvd h4m,
+      hcop.sum_divisors_mul]
+  have hdiv2 : ∑ d ∈ (2 : ℕ).divisors, d = 3 := by decide
+  rw [hdiv2]; ring
+
+/-- **Closed form for `2·(odd)` (0-axiom, general).** Combining the doubling relation
+with `jacobiCount_odd`, for odd `m` the count is `jacobiCount (2·m) = 24·σ(m)` — the
+classical value of `r₄(2m)` (matching `r4 2 = 24 = 24·σ(1)`, `r4 6 = 96 = 24·σ(3)`, …).
+Together with `jacobiCount_odd` (`8·σ` on the odd part) this exhibits the elementary
+half of Jacobi's formula: on `n = 2^a·m` with `a ≤ 1` the count is a pure multiple of
+`σ` of the odd part. -/
+theorem jacobiCount_two_mul_odd_eq {m : ℕ} (hm : Odd m) :
+    jacobiCount (2 * m) = 24 * ∑ d ∈ m.divisors, d := by
+  rw [jacobiCount_two_mul hm, jacobiCount_odd hm]; ring
 
 /-- **Convention guard (0-axiom).** The naive formula `8·σ(n)` is WRONG for `n = 4`:
 `8·σ(4) = 8·(1+2+4) = 56`, whereas the true count is `r4 4 = 24`. Equivalently the

--- a/src/data/research/problems/lagrange-four-squares-oq-01-oq-03.json
+++ b/src/data/research/problems/lagrange-four-squares-oq-01-oq-03.json
@@ -11,7 +11,9 @@
     "whyMatters": []
   },
   "knownResults": {
-    "proven": [],
+    "proven": [
+      "`jacobiCount_of_not_four_dvd` (0-axiom, general): `4 ∤ n` ⟹ the `4∤d` filter is vacuous ⟹ `jacobiCount n = 8·σ(n)` — the common root of `jacobiCount_odd` and the even case; `jacobiCount_two_mul` (0-axiom, general): `m` odd ⟹ `jacobiCount(2m) = 3·jacobiCount(m)`; `jacobiCount_two_mul_odd_eq`: closed form `24·σ(m)` (classical `r₄(2m)`)."
+    ],
     "open": [],
     "goal": ""
   },
@@ -32,20 +34,22 @@
     }
   },
   "knowledge": {
-    "progressSummary": "SHIPPED tractable increment (PR #32310): computable r4 + Jacobi oracle. General Jacobi theorem confirmed BLOCKED (Mathlib gap: no r4/r2 count; needs Hurwitz-quaternion orders or weight-2 modular forms, each >>1000 LOC). Built LagrangeFourSquaresOQ01OQ03.lean (117L, 0 sorries): r4(n) as computable Finset.card over [-sqrt n,sqrt n]^4 in Z^4; jacobiCount n = 8*sum_{d|n,4!|d}d; jacobiCount_odd (0-axiom, general: odd n => filter vacuous => 8*sigma(n)); naive_sigma_fails (0-axiom guard: 8*sigma(4)=56 wrong, r4(4)=24); jacobi_oracle (native_decide: r4=jacobiCount for 1<=n<=24). Verified via lake env lean v4.26.0; #print axioms confirms jacobiCount_odd 0-axiom and oracles carry Lean.ofReduceBool (entry axiomatized).",
+    "progressSummary": "PROGRESS (researcher-8, 2026-07-11): added 3 elementary 0-axiom GENERAL lemmas to LagrangeFourSquaresOQ01OQ03.lean (118→217L, +3 thm), extending the even-side structure of Jacobi's four-square count. jacobiCount_of_not_four_dvd: whenever 4∤n the 4∤d filter is vacuous so jacobiCount n = 8·σ(n) (common root of jacobiCount_odd and the 2·odd case; v₂(n)≤1). jacobiCount_two_mul: for odd m, jacobiCount(2m)=3·jacobiCount(m) — 'first doubling triples the count' (via v₂(2m)=1 filter-vacuous + σ multiplicativity on coprime {2,m}, ∑_{d|2}d=3). jacobiCount_two_mul_odd_eq: closed form 24·σ(m) = classical r₄(2m) (matches oracle r4 6=96=24·σ(3)). All #print axioms=[propext,Classical.choice,Quot.sound]. General theorem still Mathlib-blocked (no r4/r2 count). SHIPPED tractable increment (PR #32310): computable r4 + Jacobi oracle. General Jacobi theorem confirmed BLOCKED (Mathlib gap: no r4/r2 count; needs Hurwitz-quaternion orders or weight-2 modular forms, each >>1000 LOC). Built LagrangeFourSquaresOQ01OQ03.lean (117L, 0 sorries): r4(n) as computable Finset.card over [-sqrt n,sqrt n]^4 in Z^4; jacobiCount n = 8*sum_{d|n,4!|d}d; jacobiCount_odd (0-axiom, general: odd n => filter vacuous => 8*sigma(n)); naive_sigma_fails (0-axiom guard: 8*sigma(4)=56 wrong, r4(4)=24); jacobi_oracle (native_decide: r4=jacobiCount for 1<=n<=24). Verified via lake env lean v4.26.0; #print axioms confirms jacobiCount_odd 0-axiom and oracles carry Lean.ofReduceBool (entry axiomatized).",
     "builtItems": [
       "r4 : computable Finset.card count of ordered signed four-square reps over box [-sqrt n, sqrt n]^4 in Z^4 (object Mathlib lacks)",
       "jacobiCount : filtered divisor-sum RHS 8*sum_{d|n,4!|d} d",
       "jacobiCount_odd : 0-axiom general lemma, odd n => 4!|d vacuous => jacobiCount n = 8*sigma(n)",
       "naive_sigma_fails : 0-axiom convention guard, 8*sigma(4)=56 != r4(4)=jacobiCount(4)=24",
       "jacobi_oracle : native_decide regression oracle r4(n)=jacobiCount(n) for all 1<=n<=24",
-      "r4_anchor_values : r4(1)=8,r4(2)=24,r4(3)=32,r4(4)=24,r4(5)=48,r4(7)=64"
+      "r4_anchor_values : r4(1)=8,r4(2)=24,r4(3)=32,r4(4)=24,r4(5)=48,r4(7)=64",
+      "jacobiCount_of_not_four_dvd / jacobiCount_two_mul / jacobiCount_two_mul_odd_eq (LagrangeFourSquaresOQ01OQ03.lean): elementary 0-axiom general lemmas for the even side of Jacobi's count — filter vacuous when 4∤n gives 8·σ(n); first doubling of an odd m triples the count (3·jacobiCount m) via σ-multiplicativity on coprime {2,m}; closed form jacobiCount(2m)=24·σ(m)=classical r₄(2m). Verified lake env lean 4.26.0, #print axioms clean."
     ],
     "insights": [
       "The odd half of Jacobi is elementary and 0-axiom: for odd n every divisor is odd so the 4!|d exclusion is vacuous and jacobiCount collapses to 8*sigma(n).",
       "The 4!|d exclusion is load-bearing: at n=4 naive 8*sigma(4)=56 more than doubles the true r4(4)=24; overcount 32 = 8*(excluded divisor 4).",
       "Defining r4 as a computable Finset.card makes native_decide a valid regression oracle (finite box + decidable sum-of-squares test), pinning the ordered/signed convention r4(1)=8,r4(2)=24,r4(4)=24.",
-      "General theorem BLOCKED: r4 = r2 convolution is the one elementary Lean-able reduction but bottoms out on the missing r2 count; full proof needs Hurwitz-quaternion orders or theta^4 in M2(Gamma0(4))."
+      "General theorem BLOCKED: r4 = r2 convolution is the one elementary Lean-able reduction but bottoms out on the missing r2 count; full proof needs Hurwitz-quaternion orders or theta^4 in M2(Gamma0(4)).",
+      "The elementary half of Jacobi's r₄ splits cleanly by 2-adic valuation: when v₂(n)≤1 (i.e. 4∤n) NO divisor is a multiple of 4, so the load-bearing 4∤d filter is vacuous and jacobiCount n = 8·σ(n). Multiplicativity of σ on the coprime factorization 2^a·m (m odd) then gives the whole even side: 8·σ(m) for a=0 (odd), 24·σ(m) for a=1 (jacobiCount_two_mul via ∑_{d|2}d=3). Only a≥2 (4|n) needs the genuine filter and remains the interesting/blocked structure."
     ],
     "mathlibGaps": [
       "No four-square representation count r4 (only existence Nat.sum_four_squares)",
@@ -98,7 +102,7 @@
     "mathlib": []
   },
   "started": "2026-06-16T04:40:01.670Z",
-  "lastUpdate": "2026-06-16T04:40:01.734Z",
+  "lastUpdate": "2026-07-11T19:10:00.000Z",
   "significance": 7,
   "tractability": 5,
   "leanFiles": [
@@ -138,8 +142,8 @@
     {
       "path": "Proofs/LagrangeFourSquaresOQ01OQ03.lean",
       "filename": "LagrangeFourSquaresOQ01OQ03.lean",
-      "lineCount": 118,
-      "theoremCount": 4,
+      "lineCount": 217,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,


### PR DESCRIPTION
## Summary

Three elementary, fully **general**, **0-axiom** lemmas added to `LagrangeFourSquaresOQ01OQ03.lean`, extending the even side of Jacobi's four-square count `jacobiCount n = 8·Σ_{d|n, 4∤d} d`. Previously the file had only `jacobiCount_odd` (odd `n` → `8·σ(n)`) and `jacobiCount_two_pow` (`2^k` → `24`); these new lemmas fill in the `n = 2·(odd)` structure.

## New results

- **`jacobiCount_of_not_four_dvd`** — whenever `4 ∤ n`, no divisor of `n` is a multiple of `4`, so the load-bearing `4∤d` filter is vacuous and `jacobiCount n = 8·σ(n)`. The common root of `jacobiCount_odd` and the doubling case (the count collapses to `8·σ` exactly when `v₂(n) ≤ 1`).
- **`jacobiCount_two_mul`** — for odd `m`, `jacobiCount (2·m) = 3·jacobiCount m` ("the first doubling triples the count"), via `v₂(2m)=1` filter-vacuity plus multiplicativity of `σ` on the coprime factors `{2, m}` (`Σ_{d|2} d = 3`). The `m=1` instance matches `jacobiCount_two_pow`.
- **`jacobiCount_two_mul_odd_eq`** — the closed form `jacobiCount (2·m) = 24·σ(m)`, the classical value of `r₄(2m)`, matching the `native_decide` oracle (`r4 6 = 96 = 24·σ(3)`).

Together with `jacobiCount_odd` these characterize the count on `n = 2^a·m` (`m` odd) for `a ≤ 1` as a pure multiple of `σ` of the odd part. Only `a ≥ 2` (`4 | n`) needs the genuine filter, and the *general* Jacobi theorem remains a Mathlib gap (no `r₄`/`r₂` count).

## Verification

- `./bin/lake env lean Proofs/LagrangeFourSquaresOQ01OQ03.lean` → EXIT 0 (Lean 4.26.0, prebuilt Mathlib oleans).
- `#print axioms` for all three new lemmas → `[propext, Classical.choice, Quot.sound]` (no `sorry`, no extra axioms). The file's existing `native_decide` oracle (`Lean.ofReduceBool`) is unchanged.
- File: 118 → 217 lines, +3 theorems, 0 sorries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)