### PR TITLE
research(elementary-quadratic-reciprocity): remove native_decide from OQ04 shared file — keeps 0-axiom claim honest [VERIFIED]

### DIFF
--- a/proofs/Proofs/ElementaryQuadraticReciprocityOQ03OQ01OQ01OQ04.lean
+++ b/proofs/Proofs/ElementaryQuadraticReciprocityOQ03OQ01OQ01OQ04.lean
@@ -60,27 +60,30 @@ theorem kroneckerTwoFixed_values (a : ℤ) :
 
 /-! ## Part III: Concrete Verification Against χ₈ -/
 
--- All four odd residue classes mod 8, verified by computation
-example : kroneckerTwoFixed 1 = χ₈ 1 := by native_decide
-example : kroneckerTwoFixed 3 = χ₈ 3 := by native_decide
-example : kroneckerTwoFixed 5 = χ₈ 5 := by native_decide
-example : kroneckerTwoFixed 7 = χ₈ 7 := by native_decide
+-- All four odd residue classes mod 8, verified by kernel computation (`decide`)
+example : kroneckerTwoFixed 1 = χ₈ 1 := by decide
+example : kroneckerTwoFixed 3 = χ₈ 3 := by decide
+example : kroneckerTwoFixed 5 = χ₈ 5 := by decide
+example : kroneckerTwoFixed 7 = χ₈ 7 := by decide
 
 -- The key discrepancy: gallery's kroneckerTwo 7 = -1 (WRONG)
 -- Our fix: kroneckerTwoFixed 7 = 1 (CORRECT)
 theorem kroneckerTwoFixed_seven : kroneckerTwoFixed 7 = 1 := by
   norm_num [kroneckerTwoFixed]
 
--- Mathlib confirms χ₈ 7 = 1 via Jacobi symbol
-theorem chi8_seven : χ₈ 7 = 1 := by native_decide
+-- Mathlib confirms χ₈ 7 = 1 (kernel `decide`, no `Lean.ofReduceBool`)
+theorem chi8_seven : χ₈ 7 = 1 := by decide
 
-theorem jacobiSym_two_seven : jacobiSym 2 7 = 1 := by native_decide
+-- `jacobiSym 2 7 = χ₈ 7 = 1` via the second supplement (`jacobiSym.at_two`),
+-- keeping the proof kernel-checked rather than relying on `native_decide`.
+theorem jacobiSym_two_seven : jacobiSym 2 7 = 1 := by
+  rw [jacobiSym.at_two (by decide)]; decide
 
 /-- `kroneckerTwoFixed` agrees with `χ₈` on small examples. -/
 theorem kroneckerTwoFixed_eq_chi8_small :
     (kroneckerTwoFixed 1 = χ₈ 1) ∧ (kroneckerTwoFixed 3 = χ₈ 3) ∧
     (kroneckerTwoFixed 5 = χ₈ 5) ∧ (kroneckerTwoFixed 7 = χ₈ 7) :=
-  ⟨by native_decide, by native_decide, by native_decide, by native_decide⟩
+  ⟨by decide, by decide, by decide, by decide⟩
 
 /-! ## Part IV: Multiplicativity -/
 
@@ -125,11 +128,13 @@ theorem kroneckerTwoFixed_mul (a b : ℤ) :
 theorem jacobi_two_eq_chi8 (n : ℕ) (hn : Odd n) : jacobiSym 2 n = χ₈ n :=
   jacobiSym.at_two hn
 
-/-- `kroneckerTwoFixed` agrees with `jacobiSym 2` on {1, 3, 5, 7, 9, 11, 13, 15}. -/
+/-- `kroneckerTwoFixed` agrees with `jacobiSym 2` on {1, 3, 5, 7, 9, 11, 13, 15}.
+    Proven case-by-case via `jacobiSym.at_two` + kernel `decide` (no `native_decide`). -/
 theorem kroneckerTwoFixed_agrees_jacobi :
     ∀ n ∈ ([1, 3, 5, 7, 9, 11, 13, 15] : List ℕ),
       (kroneckerTwoFixed n : ℤ) = jacobiSym 2 n := by
-  native_decide
+  intro n hn
+  fin_cases hn <;> (rw [jacobiSym.at_two (by decide)]; decide)
 
 /-! ## Part VI: Summary -/
 


### PR DESCRIPTION
## Fixes gallery-integrity issue #37554

Both `elementary-quadratic-reciprocity` and `elementary-quadratic-reciprocity-oq-03-oq-01-oq-01` are `status: verified`, `badge: mathlib`, `axiomCount: 0`, and assert *"0 axioms, fully verified"*. Both list the shared file `proofs/Proofs/ElementaryQuadraticReciprocityOQ03OQ01OQ01OQ04.lean` in `leanFile.additionalFiles`, and that file proved several **named theorems** with `native_decide`. Per the Axiom Integrity Policy, `native_decide` depends on `Lean.ofReduceBool`, so those results were **not** axiom-free — contradicting the entries' claim (axiom masking).

## Fix (Option A — auditor-preferred)

Replaced every `native_decide` with kernel `decide`:

- **χ₈ facts** (`chi8_seven`, `kroneckerTwoFixed_eq_chi8_small`, the four `example` checks) reduce directly under `decide`.
- **jacobiSym facts** (`jacobiSym_two_seven`, `kroneckerTwoFixed_agrees_jacobi`) do *not* kernel-reduce, so they are rewritten through Mathlib's second supplement `jacobiSym.at_two` (`jacobiSym 2 n = χ₈ n` for odd `n`) and then closed by `decide` on the χ₈ side. `kroneckerTwoFixed_agrees_jacobi` is discharged case-by-case via `fin_cases`.

## Verification

`lake env lean` (host toolchain, prebuilt Mathlib oleans): file elaborates clean and `#print axioms` reports **only `[propext, Classical.choice, Quot.sound]`** — no `Lean.ofReduceBool` — for:

- `summary` (the presented headline)
- `jacobiSym_two_seven`
- `chi8_seven`
- `kroneckerTwoFixed_eq_chi8_small`
- `kroneckerTwoFixed_agrees_jacobi`

The "verified / mathlib / 0 axioms" claim is now accurate. No metadata change required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)