### PR TITLE
research(erdos-1204): slope-3 general lower bound A(k) ≥ 3(k−2)

### DIFF
--- a/proofs/Proofs/Erdos1204C.lean
+++ b/proofs/Proofs/Erdos1204C.lean
@@ -1,0 +1,176 @@
+import Proofs.Erdos1204Problem
+
+/-
+# Erdős #1204 — a slope-`3` general lower bound `A(k) ≥ 3(k − 2)`
+
+`Erdos1204Problem.lean` records two *general* lower bounds on the minimal diameter
+`A(k)`:
+
+* `sub_one_le_A`      : `A(k) ≥ k − 1`   (the trivial packing bound), and
+* `two_mul_sub_one_le_A` : `A(k) ≥ 2(k − 1)`  (the prime `2` forces a single parity).
+
+Here we sharpen the *slope* from `2` to `3` by using the primes `2` **and** `3`
+simultaneously. An admissible set misses a residue class modulo `2` (so it occupies
+at most one class mod `2`) and misses a class modulo `3` (at most two classes mod `3`);
+by CRT its elements therefore occupy at most `1 · 2 = 2` residue classes modulo `6`.
+Pigeonholing, one of those two classes holds at least `⌈k/2⌉` of the `k` elements, and
+those elements — all congruent mod `6` — are `6`-separated, spanning a diameter of at
+least `6(⌈k/2⌉ − 1) ≥ 3(k − 2)`.
+
+The result:
+
+* `admissible_three_sub_two_le_sup` : any admissible set has `sup ≥ 3(card − 2)`;
+* `three_mul_sub_two_le_A`          : `A(k) ≥ 3(k − 2)`.
+
+For `k ≥ 5` this strictly improves `2(k − 1)` (since `3(k − 2) > 2(k − 1) ⇔ k > 4`),
+i.e. it is the leading joint prime-`{2,3}` contribution toward the conjectured
+`A(k) ∼ k log k`. It remains far below the truth (which grows super-linearly), and the
+sharp small values `A(5) = 12, A(6) = 16, …` are established separately; this is a clean
+*asymptotic slope* improvement provable uniformly in `k`.
+
+Everything is axiom-free (`propext`, `Classical.choice`, `Quot.sound` only).
+-/
+
+namespace Erdos1204
+
+open Finset
+
+/- ## A spacing lemma for a single residue class
+
+If every element of a finite set of naturals is congruent modulo `d`, the `card`
+distinct elements are `d`-separated, so the maximum is at least `d(card − 1)`. This is
+the exact generalization of `admissible_diam_ge` (the `d = 2` parity case) to an
+arbitrary modulus. -/
+
+/-- **Spacing in one residue class.** If all elements of `b` are congruent modulo
+`d > 0`, then `b.sup id ≥ d · (card − 1)`: the map `x ↦ (x − min)/d` injects `b` into
+`{0, …, (sup − min)/d}`, so `card ≤ (sup − min)/d + 1`, whence `d(card − 1) ≤ sup`. -/
+theorem same_mod_sup_ge {b : Finset ℕ} {d : ℕ} (hd : 0 < d)
+    (hmod : ∀ x ∈ b, ∀ y ∈ b, (x : ZMod d) = (y : ZMod d)) :
+    d * (b.card - 1) ≤ b.sup id := by
+  classical
+  rcases b.eq_empty_or_nonempty with rfl | hne
+  · simp
+  · -- every element is `≥ min` and `≡ min (mod d)`, hence `d ∣ x - min`
+    have hdvd : ∀ x ∈ b, d ∣ (x - b.min' hne) := by
+      intro x hx
+      have hmx : b.min' hne ≤ x := b.min'_le x hx
+      have hpar : ((b.min' hne : ℕ) : ZMod d) = (x : ZMod d) :=
+        hmod _ (b.min'_mem hne) _ hx
+      rw [ZMod.natCast_eq_natCast_iff] at hpar
+      exact (Nat.modEq_iff_dvd' hmx).mp hpar
+    -- `x ↦ (x - min)/d` maps `b` into `range ((sup - min)/d + 1)` ...
+    have hmono : ∀ x ∈ b, (x - b.min' hne) / d ∈
+        Finset.range ((b.sup id - b.min' hne) / d + 1) := by
+      intro x hx
+      rw [Finset.mem_range]
+      have hxM : x ≤ b.sup id := Finset.le_sup (f := id) hx
+      have hmx : b.min' hne ≤ x := b.min'_le x hx
+      have hd2 : (x - b.min' hne) / d ≤ (b.sup id - b.min' hne) / d :=
+        Nat.div_le_div_right (by omega)
+      exact Nat.lt_succ_of_le hd2
+    -- ... and is injective (distinct multiples of `d` give distinct quotients)
+    have hinj : Set.InjOn (fun x => (x - b.min' hne) / d) b := by
+      intro x hx y hy hxy
+      simp only at hxy
+      have hmx : b.min' hne ≤ x := b.min'_le x hx
+      have hmy : b.min' hne ≤ y := b.min'_le y hy
+      obtain ⟨u, hu⟩ := hdvd x hx
+      obtain ⟨v, hv⟩ := hdvd y hy
+      rw [hu, hv, Nat.mul_div_cancel_left _ hd, Nat.mul_div_cancel_left _ hd] at hxy
+      have hxeq : x - b.min' hne = y - b.min' hne := by rw [hu, hv, hxy]
+      omega
+    have hcard : b.card ≤ (b.sup id - b.min' hne) / d + 1 := by
+      have h := Finset.card_le_card_of_injOn
+        (f := fun x => (x - b.min' hne) / d)
+        (t := Finset.range ((b.sup id - b.min' hne) / d + 1)) hmono hinj
+      simpa using h
+    calc d * (b.card - 1)
+        ≤ d * ((b.sup id - b.min' hne) / d) :=
+          Nat.mul_le_mul (le_refl d) (tsub_le_iff_right.mpr hcard)
+      _ ≤ b.sup id - b.min' hne := by rw [Nat.mul_comm]; exact Nat.div_mul_le_self _ _
+      _ ≤ b.sup id := Nat.sub_le _ _
+
+/- ## The joint prime-`{2, 3}` count
+
+An admissible set misses one class mod `2` and one class mod `3`; via the residue pair
+`x ↦ (x mod 2, x mod 3)` it lands in a fixed `2`-element subset of `ZMod 2 × ZMod 3`
+(one surviving class mod `2`, two mod `3`). This is a finite check. -/
+
+/-- Missing one class mod `2` and one class mod `3` leaves exactly `1 · 2 = 2` residue
+pairs in `ZMod 2 × ZMod 3`. -/
+theorem two_classes_prod :
+    ∀ (s : ZMod 2) (u : ZMod 3),
+      (Finset.univ.filter (fun q : ZMod 2 × ZMod 3 => q.1 ≠ s ∧ q.2 ≠ u)).card = 2 := by
+  decide
+
+/- ## The joint prime-`{2, 3}` lower bound -/
+
+/-- **Slope-`3` lower bound on the diameter.** Every admissible set satisfies
+`sup ≥ 3(card − 2)`. Missing a class mod `2` and mod `3`, its elements occupy at most
+two residue classes modulo `6`; the larger class holds `≥ ⌈card/2⌉` elements, `6`-spaced,
+so `sup ≥ 6(⌈card/2⌉ − 1) ≥ 3(card − 2)`. -/
+theorem admissible_three_sub_two_le_sup {a : Finset ℕ} (ha : Admissible a) :
+    3 * (a.card - 2) ≤ a.sup id := by
+  classical
+  rcases Nat.lt_or_ge a.card 3 with hsmall | hbig
+  · -- `card ≤ 2` ⇒ `3(card − 2) = 0`
+    have : 3 * (a.card - 2) = 0 := by omega
+    rw [this]; exact Nat.zero_le _
+  · -- pull out the missed classes mod 2 and mod 3
+    obtain ⟨r2, hr2⟩ := ha 2 (by norm_num)
+    obtain ⟨r3, hr3⟩ := ha 3 (by norm_num)
+    -- the residue-pair map and its 2-element target
+    set f : ℕ → ZMod 2 × ZMod 3 := fun x => ((x : ZMod 2), (x : ZMod 3)) with hf_def
+    set T : Finset (ZMod 2 × ZMod 3) :=
+      Finset.univ.filter (fun q => q.1 ≠ r2 ∧ q.2 ≠ r3) with hT
+    -- admissible elements map into `T`
+    have hf : ∀ x ∈ a, f x ∈ T := by
+      intro x hx
+      rw [hf_def, hT]
+      simp only [Finset.mem_filter, Finset.mem_univ, true_and]
+      exact ⟨hr2 x hx, hr3 x hx⟩
+    -- pigeonhole: some pair `p` has a fiber larger than `(card − 1)/2`
+    have hlt : T.card * ((a.card - 1) / 2) < a.card := by
+      rw [hT, two_classes_prod r2 r3]; omega
+    obtain ⟨p, _, hp⟩ :=
+      Finset.exists_lt_card_fiber_of_mul_lt_card_of_maps_to (f := f) hf hlt
+    -- every element of that fiber shares the pair `p`
+    have hpairmem : ∀ x ∈ a.filter (fun x => f x = p), f x = p :=
+      fun x hx => (Finset.mem_filter.mp hx).2
+    -- hence any two are congruent mod 2 and mod 3, so (CRT) congruent mod 6
+    have hmod6 : ∀ x ∈ a.filter (fun x => f x = p), ∀ y ∈ a.filter (fun x => f x = p),
+        (x : ZMod 6) = (y : ZMod 6) := by
+      intro x hx y hy
+      have hxy : f x = f y := (hpairmem x hx).trans (hpairmem y hy).symm
+      rw [hf_def] at hxy
+      simp only [Prod.mk.injEq] at hxy
+      obtain ⟨e2, e3⟩ := hxy
+      rw [ZMod.natCast_eq_natCast_iff] at e2 e3
+      rw [ZMod.natCast_eq_natCast_iff]
+      have hcomb :=
+        (Nat.modEq_and_modEq_iff_modEq_mul (show Nat.Coprime 2 3 by decide)).mp ⟨e2, e3⟩
+      simpa using hcomb
+    -- spacing within that class, transported back to `a`
+    have hspace := same_mod_sup_ge (show (0 : ℕ) < 6 by norm_num) hmod6
+    have hsub : a.filter (fun x => f x = p) ⊆ a := Finset.filter_subset _ _
+    have hsuple : (a.filter (fun x => f x = p)).sup id ≤ a.sup id := Finset.sup_mono hsub
+    omega
+
+/-- **Slope-`3` lower bound on `A(k)`: `A(k) ≥ 3(k − 2)`.** The joint action of the
+primes `2` and `3` forces every admissible `k`-set to occupy at most two residue classes
+mod `6`, so its `k` elements are packed at density `≤ 2/6 = 1/3` and must span at least
+`3(k − 2)`. This sharpens `two_mul_sub_one_le_A` (`A(k) ≥ 2(k − 1)`) for all `k ≥ 5`. -/
+theorem three_mul_sub_two_le_A (k : ℕ) : 3 * (k - 2) ≤ A k := by
+  obtain ⟨a, hcard, ha, hsup⟩ := A_mem k
+  have h := admissible_three_sub_two_le_sup ha
+  rw [hcard, hsup] at h
+  exact h
+
+/-- **The slope-`3` bound beats the parity bound past `k = 4`.** For every `k ≥ 5`,
+`3(k − 2) > 2(k − 1)`, so `three_mul_sub_two_le_A` is a strict improvement on
+`two_mul_sub_one_le_A`. -/
+theorem three_bound_gt_two_bound {k : ℕ} (hk : 5 ≤ k) :
+    2 * (k - 1) < 3 * (k - 2) := by omega
+
+end Erdos1204

--- a/src/data/proofs/erdos-1204/meta.json
+++ b/src/data/proofs/erdos-1204/meta.json
@@ -45,6 +45,16 @@
         "theorem": "Nat.Prime",
         "description": "Prime number predicate",
         "module": "Mathlib.Data.Nat.Prime.Basic"
+      },
+      {
+        "theorem": "Finset.exists_lt_card_fiber_of_mul_lt_card_of_maps_to",
+        "description": "pigeonhole: if t.card * n < s.card and f maps s into t, some fiber exceeds n",
+        "module": "Mathlib.Combinatorics.Pigeonhole"
+      },
+      {
+        "theorem": "Nat.modEq_and_modEq_iff_modEq_mul",
+        "description": "CRT: for coprime m,n, a≡b [MOD m] ∧ a≡b [MOD n] ↔ a≡b [MOD m*n]",
+        "module": "Mathlib.Data.Nat.ModEq"
       }
     ],
     "originalContributions": [
@@ -67,7 +77,9 @@
       "A_seven: the exact value A(7)=20 (= Hardy–Littlewood minimal diameter H(7)) in companion file Erdos1204A7.lean. Upper bound from the admissible witness {0,2,6,8,12,18,20} (even, residues miss class 1 mod 3, class 4 mod 5, class 3 mod 7); lower bound (admissible_seven_sup_ge) — any admissible 7-set with max ≤ 19 is single-parity, hence sits among the ten evens {0,2,4,6,8,10,12,14,16,18} or ten odds {1,3,5,7,9,11,13,15,17,19}; within each window the mod-3 classes have sizes 4,3,3, so missing the size-4 class leaves only six slots (too few for a 7-set) while missing either size-3 class leaves a forced 7-set — for evens {0,2,6,8,12,14,18} / {0,4,6,10,12,16,18}, for odds {1,5,7,11,13,17,19} / {1,3,7,9,13,15,19} — and all four forced sets cover EVERY residue class mod 5, failing admissibility at p=5. Unlike a naive 'one further prime per value' extrapolation, A(7)=20 does NOT need the prime 7 in its lower bound: the two size-3 mod-3 classes yield two forced 7-sets per parity (vs one at A(6)), but p=5 still kills all four (Proofs/Erdos1204A7.lean)",
       "S(k) / B(k): the SECOND extremal quantity of Problem #1204 — the minimal average B(k)=min(a1+...+ak)/k, carried by the minimal sum S(k)=sInf of admissible k-set sums — is now defined in Lean (companion file Erdos1204B.lean). Every prior session worked only on A(k); B(k) was untouched. Includes S_set_nonempty/S_mem (the defining infimum is attained) and S_le (S(k) lower-bounds every admissible k-set sum) (Proofs/Erdos1204B.lean)",
       "admissible_sum_ge / sub_mul_le_S / sub_one_le_B: general lower bound k*(k-1) <= S(k), equivalently B(k) >= k-1 — the average analogue of the diameter bound A(k) >= 2(k-1). The prime 2 forces every admissible set to be single-parity, so its k distinct elements, translated to start at 0, are >= 0,2,4,...,2(k-1), whose sum is k(k-1). Proved by strong induction removing the maximum (which is >= 2(card-1) by admissible_two_mul_card_sub_one_le_sup) and applying the inductive hypothesis to the still-admissible remainder; the identity 2(k-1)+(k-1)(k-2)=k(k-1) closes the step. Sharp at k=2 (Proofs/Erdos1204B.lean)",
-      "S(2)=2 and S(3)=8 exact, giving the first exact averages B(2)=1 and B(3)=8/3. B(2)=1 attains the parity floor k-1=1 (the general bound is tight); B(3)=8/3 > 2 is the first place the mod-3 obstruction — the same one that makes A(3)=6 — forces the average strictly above the floor. The S(3) >= 8 lower bound combines the A(3) fact sup >= 6 (admissible_three_sup_ge) with admissible_sum_ge on the erased admissible 2-set: 6+2=8 (Proofs/Erdos1204B.lean)"
+      "S(2)=2 and S(3)=8 exact, giving the first exact averages B(2)=1 and B(3)=8/3. B(2)=1 attains the parity floor k-1=1 (the general bound is tight); B(3)=8/3 > 2 is the first place the mod-3 obstruction — the same one that makes A(3)=6 — forces the average strictly above the floor. The S(3) >= 8 lower bound combines the A(3) fact sup >= 6 (admissible_three_sup_ge) with admissible_sum_ge on the erased admissible 2-set: 6+2=8 (Proofs/Erdos1204B.lean)",
+      "same_mod_sup_ge: a general spacing lemma — a finite set of naturals all congruent modulo d has largest element ≥ d·(card−1) (the exact d-modulus generalization of the parity diameter bound admissible_diam_ge)",
+      "three_mul_sub_two_le_A / admissible_three_sub_two_le_sup (Erdos1204C.lean): the joint prime-{2,3} lower bound A(k) ≥ 3(k−2), sharpening the slope of the general lower bound from 2 to 3 — an admissible set occupies ≤ 2 residue classes mod 6 (CRT: one class mod 2, two mod 3), so a pigeonholed class of ≥ ⌈k/2⌉ elements is 6-separated. Strictly beats 2(k−1) for all k ≥ 5; axiom-free"
     ],
     "axiomCount": 0,
     "lineCount": 632,
@@ -86,7 +98,8 @@
       "**Only small primes matter:** for p > k there are more classes than elements, so a class is always free — admissibility reduces to primes p ≤ k.",
       "**Minimal example:** {0,2} is admissible but {0,1} is not, because {0,1} hits both classes mod 2 (this is why twin-prime-like patterns must avoid such coverage).",
       "**Connection:** this is exactly the admissible-tuple notion underlying bounded gaps between primes (Zhang, Maynard).",
-      "**A(k) is now defined and computed for small k:** k-1 ≤ A(k), with A(0)=A(1)=0, A(2)=2, A(3)=6, A(4)=8, A(5)=12, A(6)=16, and A(7)=20 — each equal to the Hardy–Littlewood minimal diameter H(k), proved by a finite parity-then-mod-p slot-counting argument (no admissible k-set fits below the stated value). At A(5)=12 the mod-3 constraint beyond parity is binding (12 > 8 = 2(k−1)); at A(6)=16 the prime 5 first becomes binding; A(7)=20 still closes with primes 2,3,5 (the prime 7 is not yet needed)."
+      "**A(k) is now defined and computed for small k:** k-1 ≤ A(k), with A(0)=A(1)=0, A(2)=2, A(3)=6, A(4)=8, A(5)=12, A(6)=16, and A(7)=20 — each equal to the Hardy–Littlewood minimal diameter H(k), proved by a finite parity-then-mod-p slot-counting argument (no admissible k-set fits below the stated value). At A(5)=12 the mod-3 constraint beyond parity is binding (12 > 8 = 2(k−1)); at A(6)=16 the prime 5 first becomes binding; A(7)=20 still closes with primes 2,3,5 (the prime 7 is not yet needed).",
+      "**Joint {2,3} sieve raises the slope:** using primes 2 and 3 together confines an admissible set to ≤ 2 residue classes mod 6, forcing A(k) ≥ 3(k−2) — a slope-3 lower bound, strictly stronger than the parity bound 2(k−1) once k ≥ 5."
     ],
     "prerequisites": [
       "Number theory",
@@ -175,11 +188,19 @@
       "endLine": 561,
       "mathContext": "$2(k-1) \\le A(k) \\le (k-1)\\cdot\\!\\!\\prod_{p \\le k}\\! p$; the primorial spacing $N=\\prod_{p\\le k}p$ gives the admissible set $\\{0,N,\\dots,(k-1)N\\}$.",
       "summary": "primorialUpTo k = ∏_{p ≤ k} p (product of primes ≤ k) and A_le_primorial: A(k) ≤ (k−1)·primorialUpTo k. The arithmetic progression {0, N, …, (k−1)N} with N = primorialUpTo k is admissible (every element ≡ 0 mod each prime p ≤ k, so class 1 is missed), has k elements, and largest element (k−1)N; feeding it to A_le gives the bound. Together with two_mul_sub_one_le_A this sandwiches A(k) between 2(k−1) and (k−1)·∏_{p≤k}p — an elementary two-sided companion far from the conjectured A(k) ∼ k log k, since N grows like e^{(1+o(1))k}."
+    },
+    {
+      "id": "joint-2-3-lower-bound",
+      "title": "A Slope-3 Lower Bound A(k) ≥ 3(k−2) (companion Erdos1204C.lean)",
+      "startLine": 1,
+      "endLine": 213,
+      "mathContext": "Erdos1204C.lean. Sharpens the general lower bound on A(k) from slope 2 to slope 3 by combining the mod-2 and mod-3 obstructions.",
+      "summary": "An admissible set misses a class mod 2 (one surviving class) and mod 3 (two surviving classes), so by CRT it occupies at most 1·2 = 2 residue classes mod 6 (two_classes_prod, a finite decide-check). Pigeonholing the k elements into those ≤ 2 classes (Finset.exists_lt_card_fiber_of_mul_lt_card_of_maps_to) yields a class with ≥ ⌈k/2⌉ elements; being pairwise congruent mod 6 they are 6-separated (same_mod_sup_ge, the general d-modulus spacing lemma), so the diameter is ≥ 6(⌈k/2⌉−1) ≥ 3(k−2). Hence three_mul_sub_two_le_A: A(k) ≥ 3(k−2), strictly stronger than 2(k−1) for k ≥ 5 (three_bound_gt_two_bound). Axiom-free."
     }
   ],
   "conclusion": {
-    "summary": "Erdős Problem #1204 asks for the asymptotics of the minimal diameter A(k) and minimal average B(k) of admissible k-tuples, conjecturally A(k) ∼ k log k. This entry formalizes the admissibility framework: the definition, the reduction showing only primes p ≤ k impose constraints, the extremal quantity A(k) itself (as an attained infimum), exact values A(0)=A(1)=0, A(2)=2, A(3)=6, A(4)=8, A(5)=12 (the last two in companion files), and a verified parity-sharpened lower bound A(k) ≥ 2(k−1) — the prime 2 forces all elements to share parity, doubling the trivial packing bound k−1 (sharp at k=2). Each exact value matches the Hardy–Littlewood minimal diameter H(k); at A(5)=12 the mod-3 constraint beyond parity first pushes the value strictly above 2(k−1). The full asymptotic questions remain open and are not asserted.",
-    "implications": "Gives a fully verified elementary foundation for the admissible-tuple constant A(k) — the same admissibility notion underlying the Hardy–Littlewood prime k-tuples conjecture and the bounded-gaps program (Zhang, Maynard–Tao). The parity-sharpened bound A(k) ≥ 2(k−1) isolates the leading prime-2 contribution to the conjectural k log k growth, and the attained-infimum framing makes A(k) a well-defined target for future sieve-theoretic asymptotics rather than an informal quantity.",
+    "summary": "Erdős Problem #1204 asks for the asymptotics of the minimal diameter A(k) and minimal average B(k) of admissible k-tuples, conjecturally A(k) ∼ k log k. This entry formalizes the admissibility framework: the definition, the reduction showing only primes p ≤ k impose constraints, the extremal quantity A(k) itself (as an attained infimum), exact values A(0)=A(1)=0, A(2)=2, A(3)=6, A(4)=8, A(5)=12 (the last two in companion files), and a verified parity-sharpened lower bound A(k) ≥ 2(k−1) — the prime 2 forces all elements to share parity, doubling the trivial packing bound k−1 (sharp at k=2). Each exact value matches the Hardy–Littlewood minimal diameter H(k); at A(5)=12 the mod-3 constraint beyond parity first pushes the value strictly above 2(k−1). The full asymptotic questions remain open and are not asserted. A companion file (Erdos1204C.lean) further sharpens the general lower bound to A(k) ≥ 3(k−2): the primes 2 and 3 acting jointly confine any admissible set to at most two residue classes mod 6, raising the provable slope from 2 to 3 (strictly better than 2(k−1) for k ≥ 5).",
+    "implications": "Gives a fully verified elementary foundation for the admissible-tuple constant A(k) — the same admissibility notion underlying the Hardy–Littlewood prime k-tuples conjecture and the bounded-gaps program (Zhang, Maynard–Tao). The parity-sharpened bound A(k) ≥ 2(k−1) isolates the leading prime-2 contribution to the conjectural k log k growth, and the attained-infimum framing makes A(k) a well-defined target for future sieve-theoretic asymptotics rather than an informal quantity. Extending the prime-2 parity bound, the joint prime-{2,3} bound A(k) ≥ 3(k−2) shows how successive small primes each lift the linear slope toward the conjectural k log k growth — a template that a full sieve makes quantitative.",
     "openQuestions": [
       "Is A(k) ∼ k log k?",
       "What is the correct order of B(k) = min (a₁+⋯+a_k)/k?"


### PR DESCRIPTION
## Summary

Sharpens the **general** lower bound on the minimal admissible-tuple diameter `A(k)` (Erdős #1204) from **slope 2** to **slope 3**, using the primes `2` and `3` jointly.

`Erdos1204Problem.lean` already proves two general lower bounds:
- `sub_one_le_A` : `A(k) ≥ k − 1` (trivial packing)
- `two_mul_sub_one_le_A` : `A(k) ≥ 2(k − 1)` (prime `2` ⇒ single parity)

This PR adds a new companion file **`proofs/Proofs/Erdos1204C.lean`** proving `A(k) ≥ 3(k − 2)`.

## Mathematical content

An admissible set misses a residue class mod `2` (so it occupies ≤ 1 class mod `2`) **and** a class mod `3` (≤ 2 classes mod `3`). By CRT its elements therefore occupy **at most `1·2 = 2` residue classes mod `6`**. Pigeonholing the `k` elements into those two classes yields one class holding `≥ ⌈k/2⌉` elements; being pairwise congruent mod `6` they are `6`-separated, so the diameter is `≥ 6(⌈k/2⌉ − 1) ≥ 3(k − 2)`.

For `k ≥ 5`, `3(k − 2) > 2(k − 1)`, so this strictly improves the parity bound — the leading joint prime-`{2,3}` contribution toward the conjectured `A(k) ∼ k log k`.

## New theorems (all axiom-free)

- `same_mod_sup_ge` — general `d`-modulus spacing lemma: a finite set of naturals all congruent mod `d` has `sup ≥ d·(card − 1)` (exact generalization of `admissible_diam_ge`).
- `two_classes_prod` — `decide`-check that missing one class mod `2` and one mod `3` leaves exactly `2` residue pairs.
- `admissible_three_sub_two_le_sup` — any admissible set has `sup ≥ 3(card − 2)`.
- `three_mul_sub_two_le_A` — `A(k) ≥ 3(k − 2)`.
- `three_bound_gt_two_bound` — `3(k − 2) > 2(k − 1)` for `k ≥ 5`.

## Verification

- `lake env lean Proofs/Erdos1204C.lean` → exit 0 against current `main`.
- `#print axioms` for every new theorem → `[propext, Classical.choice, Quot.sound]` only (uses `decide`, **not** `native_decide`; no `sorryAx`, no `Lean.ofReduceBool`).

Gallery `meta.json` updated: new section, `originalContributions`, key insight, conclusion, and mathlib dependencies (pigeonhole + CRT).