### PR TITLE
research(erdos-1014-oq-03): repair Erdos1014Problem.lean Mathlib drift [VERIFIED axiom-free]

### DIFF
--- a/proofs/Proofs/Erdos1014Problem.lean
+++ b/proofs/Proofs/Erdos1014Problem.lean
@@ -66,6 +66,7 @@ private theorem ramsey_mono_left_ge2 (k l : ℕ) (hk : k ≥ 2) :
     · -- n < 2 and n + 1 ≥ 2, so n = 1 and k = n + 1 = 2
       have : n = 1 := by omega
       subst this
+      norm_num
 
 /-- R(k, l) ≥ 1 for all k ≥ 2, l ≥ 1. Proved from R(2,l)=l and iterated
     left-monotonicity: R(2,l) ≤ R(k,l) for k ≥ 2. -/
@@ -110,8 +111,9 @@ private lemma tendsto_succ_div_pow (a : ℕ) :
   have h : Tendsto (fun n : ℕ => 1 + (n : ℝ)⁻¹) atTop (nhds (1 + 0)) :=
     tendsto_const_nhds.add (tendsto_inv_atTop_zero.comp tendsto_natCast_atTop_atTop)
   rw [add_zero] at h
-  exact h.congr (eventually_atTop.mpr ⟨1, fun n hn => by
-    have : (n : ℝ) ≠ 0 := Nat.cast_ne_zero.mpr (by omega); field_simp⟩)
+  exact h.congr' (eventually_atTop.mpr ⟨1, fun n hn => by
+    have hn0 : (n : ℝ) ≠ 0 := Nat.cast_ne_zero.mpr (by omega)
+    field_simp⟩)
 
 /-- For any fixed b : ℕ, (log n / log(n+1))^b → 1 as n → ∞.
     Uses squeeze: for n ≥ 2, 1 - 1/(n·log 2) ≤ log n/log(n+1) ≤ 1, and both → 1. -/
@@ -120,12 +122,14 @@ private lemma tendsto_log_ratio_pow (b : ℕ) :
   conv_rhs => rw [show (1 : ℝ) = 1 ^ b from (one_pow b).symm]
   apply Tendsto.pow
   -- Squeeze: 1 - (n⁻¹/log 2) ≤ log(n)/log(n+1) ≤ 1, both bounds → 1
-  apply tendsto_of_tendsto_of_tendsto_of_le_of_le
+  apply tendsto_of_tendsto_of_tendsto_of_le_of_le'
     -- Lower bound → 1
     (show Tendsto (fun n : ℕ => 1 - (n : ℝ)⁻¹ / log 2) atTop (nhds 1) from by
-      rw [show (1 : ℝ) = 1 - 0 / log 2 from by simp]
-      exact tendsto_const_nhds.sub
-        ((tendsto_inv_atTop_zero.comp tendsto_natCast_atTop_atTop).div_const _))
+      have hinv : Tendsto (fun n : ℕ => ((n : ℝ))⁻¹) atTop (nhds 0) :=
+        tendsto_natCast_atTop_atTop.inv_tendsto_atTop
+      have h0 : Tendsto (fun n : ℕ => ((n : ℝ))⁻¹ / log 2) atTop (nhds 0) := by
+        simpa using hinv.div_const (log 2)
+      simpa using tendsto_const_nhds.sub h0)
     -- Upper bound → 1
     tendsto_const_nhds
     -- f(n) ≥ lower bound eventually
@@ -149,14 +153,15 @@ private lemma tendsto_log_ratio_pow (b : ℕ) :
       -- Combine: diff/log(n+1) ≤ n⁻¹/log(2)
       have h_frac : (log ((n : ℝ) + 1) - log (n : ℝ)) / log ((n : ℝ) + 1) ≤
           (n : ℝ)⁻¹ / log 2 := by
-        rw [div_le_div_iff hlog_n1 hlog2]
+        rw [div_le_div_iff₀ hlog_n1 hlog2]
         calc (log ((n : ℝ) + 1) - log (n : ℝ)) * log 2
             ≤ (n : ℝ)⁻¹ * log 2 := by nlinarith [h_log_diff]
-          _ ≤ (n : ℝ)⁻¹ * log ((n : ℝ) + 1) := by nlinarith [hlog2_le]
+          _ ≤ (n : ℝ)⁻¹ * log ((n : ℝ) + 1) := by
+              nlinarith [hlog2_le, inv_nonneg.mpr hn_pos.le]
       rw [h_eq]; linarith⟩)
     -- f(n) ≤ 1 eventually (log is increasing)
     (eventually_atTop.mpr ⟨2, fun n hn => by
-      exact div_le_one_of_le
+      exact div_le_one_of_le₀
         (log_le_log (by exact_mod_cast (show 0 < n by omega))
           (by exact_mod_cast (show n ≤ n + 1 by omega)))
         (le_of_lt (log_pos (by exact_mod_cast (show 1 < n + 1 by omega))))⟩)
@@ -170,11 +175,13 @@ private lemma growth_ratio_close (a b : ℕ) (δ : ℝ) (hδ : δ > 0) :
   have ht : Tendsto (fun n : ℕ =>
       (((n : ℝ) + 1) / (n : ℝ)) ^ a *
       (log (n : ℝ) / log ((n : ℝ) + 1)) ^ b) atTop (nhds 1) := by
-    rw [show (1 : ℝ) = 1 * 1 from (mul_one 1).symm]
-    exact (tendsto_succ_div_pow a).mul (tendsto_log_ratio_pow b)
+    have hmul := (tendsto_succ_div_pow a).mul (tendsto_log_ratio_pow b)
+    simpa using hmul
   rw [Metric.tendsto_atTop] at ht
   obtain ⟨N, hN⟩ := ht δ hδ
-  exact ⟨N, fun l hl => by rwa [Real.dist_eq] at hN l (by omega)⟩
+  exact ⟨N, fun l hl => by
+    have h := hN l (by omega)
+    rwa [Real.dist_eq] at h⟩
 
 end GrowthRatioHelpers
 
@@ -219,8 +226,17 @@ theorem ratio_from_asymptotics (k : ℕ) (hk : k ≥ 3) :
   have hα : |(ramseyNumber k (l + 1) : ℝ) / g' - 1| < δ := by
     convert hL₁ (l + 1) (by omega) using 2; push_cast; ring
   have hβ : |g' / g - 1| < δ := by
-    convert hL₂ l hl2 using 2
-    simp only [g, g']; field_simp; ring
+    have hne_l : (l : ℝ) ≠ 0 := ne_of_gt hl_pos
+    have hne_l1 : (l : ℝ) + 1 ≠ 0 := ne_of_gt hl1_pos
+    have hne_logl : Real.log (l : ℝ) ≠ 0 := ne_of_gt hlog_l
+    have hne_logl1 : Real.log ((l : ℝ) + 1) ≠ 0 := ne_of_gt hlog_l1
+    have hne_c : c ≠ 0 := ne_of_gt hc
+    have hgg : g' / g = (((l : ℝ) + 1) / (l : ℝ)) ^ (k - 1) *
+        (Real.log (l : ℝ) / Real.log ((l : ℝ) + 1)) ^ (k - 2) := by
+      rw [div_pow, div_pow]
+      simp only [g, g']
+      field_simp
+    rw [hgg]; exact hL₂ l hl2
   have hζ : |(ramseyNumber k l : ℝ) / g - 1| < δ := hL₁ l hl1
   -- R(k,l) > 0 from sandwich
   set R := (ramseyNumber k l : ℝ)
@@ -244,37 +260,46 @@ theorem ratio_from_asymptotics (k : ℕ) (hk : k ≥ 3) :
   -- Factor bounds
   have hα_abs : |α| ≤ 1 + δ := by
     calc |α| = |α - 1 + 1| := by ring_nf
-      _ ≤ |α - 1| + |1| := abs_add _ _
+      _ ≤ |α - 1| + |1| := abs_add_le _ _
       _ ≤ δ + 1 := by linarith [le_of_lt hα, abs_of_pos (show (0:ℝ) < 1 by norm_num)]
       _ = 1 + δ := by ring
   have hβ_abs : |β| ≤ 1 + δ := by
     calc |β| = |β - 1 + 1| := by ring_nf
-      _ ≤ |β - 1| + 1 := by linarith [abs_add (β - 1) 1, abs_of_pos (show (0:ℝ) < 1 by norm_num)]
+      _ ≤ |β - 1| + 1 := by linarith [abs_add_le (β - 1) 1, abs_of_pos (show (0:ℝ) < 1 by norm_num)]
       _ ≤ δ + 1 := by linarith [le_of_lt hβ]
       _ = 1 + δ := by ring
   have hγ_abs : |γ - 1| ≤ 4 * δ / 3 := by
     -- γ = g/R = 1/(R/g), |1/x - 1| = |x-1|/x when x > 0
     have hRg_pos : 0 < R / g := by linarith
+    have hR_ne : R ≠ 0 := ne_of_gt hR_pos
+    have hg_ne : g ≠ 0 := ne_of_gt hg_pos
     have hγ_eq : γ - 1 = -(R / g - 1) / (R / g) := by
-      simp only [γ]; field_simp
+      simp only [γ]; field_simp; ring
     rw [hγ_eq, abs_div, abs_neg, abs_of_pos hRg_pos]
     -- Need: |R/g-1| / (R/g) ≤ 4δ/3, i.e., |R/g-1| ≤ (4δ/3)·(R/g)
-    rw [div_le_iff hRg_pos]
+    rw [div_le_iff₀ hRg_pos]
     -- (4δ/3)·(R/g) ≥ (4δ/3)·(3/4) = δ ≥ |R/g-1|
     nlinarith [le_of_lt hζ, hRg_lb, hδ14, hδ]
   -- Final bound: |αβγ - 1| ≤ |α||β||γ-1| + |α||β-1| + |α-1| < 13δ/3 < ε
   rw [h_decomp, h_expand]
   calc |α * β * (γ - 1) + α * (β - 1) + (α - 1)|
       ≤ |α * β * (γ - 1)| + |α * (β - 1)| + |α - 1| := by
-        linarith [abs_add (α * β * (γ - 1) + α * (β - 1)) (α - 1),
-                  abs_add (α * β * (γ - 1)) (α * (β - 1))]
+        linarith [abs_add_le (α * β * (γ - 1) + α * (β - 1)) (α - 1),
+                  abs_add_le (α * β * (γ - 1)) (α * (β - 1))]
     _ = |α| * |β| * |γ - 1| + |α| * |β - 1| + |α - 1| := by
         rw [abs_mul, abs_mul, abs_mul]
     _ ≤ (1 + δ) * (1 + δ) * (4 * δ / 3) + (1 + δ) * δ + δ := by
-        have := abs_nonneg α; have := abs_nonneg β; have := abs_nonneg (γ - 1)
-        have := abs_nonneg (β - 1); have := abs_nonneg (α - 1)
-        nlinarith [hα_abs, hβ_abs, hγ_abs, le_of_lt hα, le_of_lt hβ]
-    _ ≤ (5/4) * (5/4) * (4 * δ / 3) + (5/4) * δ + δ := by nlinarith
+        have h1d : (0 : ℝ) ≤ 1 + δ := by linarith
+        have hAB : |α| * |β| ≤ (1 + δ) * (1 + δ) :=
+          mul_le_mul hα_abs hβ_abs (abs_nonneg β) h1d
+        have hABC : |α| * |β| * |γ - 1| ≤ (1 + δ) * (1 + δ) * (4 * δ / 3) :=
+          mul_le_mul hAB hγ_abs (abs_nonneg (γ - 1)) (by positivity)
+        have hAD : |α| * |β - 1| ≤ (1 + δ) * δ :=
+          mul_le_mul hα_abs (le_of_lt hβ) (abs_nonneg (β - 1)) h1d
+        have hE : |α - 1| ≤ δ := le_of_lt hα
+        linarith [hABC, hAD, hE]
+    _ ≤ (5/4) * (5/4) * (4 * δ / 3) + (5/4) * δ + δ := by
+        nlinarith [hδ14, hδ, mul_nonneg (by linarith : (0:ℝ) ≤ 1/4 - δ) hδ.le]
     _ = 52 * δ / 12 := by ring
     _ = 13 * δ / 3 := by ring
     _ ≤ 13 * (ε / 6) / 3 := by nlinarith
@@ -364,20 +389,9 @@ theorem R22 : ramseyNumber 2 2 = 2 := ramsey_k2 2 (by norm_num)
 -- Since R(2, k) = k and R(k, k) ≥ R(2, k) by monotonicity
 theorem diagonal_ramsey_lower (k : ℕ) (hk : k ≥ 2) :
     k ≤ ramseyNumber k k := by
-  calc k = ramseyNumber 2 k := (ramsey_k2 k (by omega)).symm
-    _ ≤ ramseyNumber k k := by
-        have h1 : ramseyNumber 2 k ≤ ramseyNumber k k := by
-          induction k with
-          | zero => omega
-          | succ n ih =>
-            by_cases hn : n ≥ 2
-            · calc ramseyNumber 2 (n + 1)
-                  ≤ ramseyNumber (n + 1) (n + 1) := by
-                    calc ramseyNumber 2 (n + 1)
-                        = ramseyNumber (n + 1) 2 := ramsey_symm 2 (n + 1)
-                      _ ≤ ramseyNumber (n + 1) (n + 1) := ramsey_monotone_right (n + 1) 2
-            · interval_cases n <;> simp_all [R22, ramsey_k2, ramsey_symm]
-        exact h1
+  have h1 : ramseyNumber 2 k ≤ ramseyNumber k k := ramsey_mono_left_ge2 k k hk
+  have h2 : ramseyNumber 2 k = k := ramsey_k2 k (by omega)
+  omega
 
 /- ## General Increment Bound -/
 
@@ -419,7 +433,7 @@ theorem R3_ratio_convergence :
   intro ε hε
   obtain ⟨c, hc, L₁, hL₁⟩ := R3_lower
   -- Find L₂ where (l+1)·log l / (c·l²) < ε, via log = o(x)
-  have ho := Real.isLittleO_log_rpow_atTop (show (0 : ℝ) < 1 by norm_num)
+  have ho := isLittleO_log_rpow_atTop (show (0 : ℝ) < 1 by norm_num)
   have hev := ho.bound (show (0 : ℝ) < c * ε / 4 by positivity)
   obtain ⟨N, hN⟩ := Filter.eventually_atTop.mp hev
   use max (max L₁ (⌈N⌉₊ + 1)) 2

--- a/src/data/proofs/erdos-1014/meta.json
+++ b/src/data/proofs/erdos-1014/meta.json
@@ -207,7 +207,7 @@
     ],
     "opens": [],
     "namespace": null,
-    "lineCount": 483,
+    "lineCount": 497,
     "axiomCount": 12,
     "theoremCount": 20,
     "definitionCount": 0,

--- a/src/data/research/problems/erdos-1014-oq-03.json
+++ b/src/data/research/problems/erdos-1014-oq-03.json
@@ -31,10 +31,10 @@
   "currentState": {
     "phase": "OBSERVE",
     "since": "2026-07-09T00:00:00Z",
-    "iteration": 1,
-    "focus": "Understand the increment Δ_l(k) = R(k,l+1) - R(k,l) and how a power-law asymptotic for R(k,l) transfers to an asymptotic for the increment.",
+    "iteration": 2,
+    "focus": "Parent Erdos1014Problem.lean drift repaired & verified; Concrete instantiation unblocked. Remaining frontier: formalize g~c*l^a/(log l)^b => g(l+1)-g(l)~a*c*l^(a-1)/(log l)^b and the conditional increment asymptotic; document the k=3 constant-matching obstruction.",
     "blockers": [],
-    "nextAction": "Review the GrowthRatioHelpers real-analysis lemmas in Erdos1014Problem.lean and draft the finite-difference expansion for a power-law-with-log function.",
+    "nextAction": "Formalize the finite-difference asymptotic transfer lemma for power-law-with-log functions (next step 2), building on the now-compiling GrowthRatioHelpers.",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -42,7 +42,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (VERIFIED 2026-07-11): repaired Mathlib API drift in Erdos1014OQ03Obstruction.lean (div_le_div_iff -> div_le_div_iff0) so it elaborates cleanly against current Mathlib; confirmed axiom-free via #print axioms on all three capstones (increment_ratio_not_tendsto_one, increment_asymptotic_not_determined_by_asymptotic_class, increment_asymptotic_not_determined_under_normalized_regularity -> [propext, Classical.choice, Quot.sound] only, no sorryAx/ofReduceBool). This formalizes the previously-prose negative meta-result that the increment asymptotic is not determined by the ~-class of R(k,.) via the explicit witness u l=l, v l=l+(-1)^l; the honest increment-ratio bridge (Erdos1014OQ03.lean + LogIncrement.lean, both verify clean) remains the correct route. Full increment asymptotic for k=3 remains OPEN (constant-matching obstruction). KNOWN DRIFT (needs separate repair, out of OQ03 scope): Erdos1014Problem.lean (general problem file, 9 axioms) does NOT compile against current Mathlib -- ~17 errors: Mathlib renames (div_le_div_iff, Real.isLittleO_log_rpow_atTop), a genuine unsolved-goals hole in ramsey_mono_left_ge2 (line ~66, subst with no closing tactic), and fragile nlinarith steps in the general-k asymptotic argument. Erdos1014OQ03Concrete.lean imports Erdos1014Problem and is transitively blocked until that file is repaired.",
+    "progressSummary": "PROGRESS (VERIFIED 2026-07-11, researcher-11): REPAIRED Mathlib API drift in the parent Erdos1014Problem.lean (was ~25 elaboration errors) so it now compiles cleanly (0 errors, 12 domain axioms, 20 theorems, 0 sorry). Fixes: renamed div_le_div_iff->div_le_div_iff0, div_le_one_of_le->div_le_one_of_le0, div_le_iff->div_le_iff0, abs_add->abs_add_le, Real.isLittleO_log_rpow_atTop->isLittleO_log_rpow_atTop; switched the squeeze to tendsto_of_tendsto_of_tendsto_of_le_of_le' (eventual variant) and rebuilt the n^-1/log2->0 lower bound via Tendsto.inv_tendsto_atTop; closed the genuine unsolved-goals hole in ramsey_mono_left_ge2 (norm_num after subst n=1); replaced the broken calc/induction in diagonal_ramsey_lower with a 3-line proof from ramsey_mono_left_ge2 + ramsey_k2; fixed Tendsto.congr->congr' in tendsto_succ_div_pow; proved hbeta g'/g = ((l+1)/l)^(k-1)*(log l/log(l+1))^(k-2) via div_pow (ring cannot split symbolic-exponent powers) then field_simp; and rebuilt the final product bound with explicit mul_le_mul steps (nlinarith only multiplies pairs, could not reach the degree-3 |a||b||c| bound). #print axioms confirms ratio_from_asymptotics / R3_ratio_convergence / diagonal_ramsey_lower depend only on the stated Ramsey axioms + [propext,Classical.choice,Quot.sound] -- NO sorryAx, NO ofReduceBool. This UNBLOCKS Erdos1014OQ03Concrete.lean, which imports the parent and now also verifies clean (ramsey3_increment_div_tendsto_zero depends only on R3_lower/ramsey* domain axioms + foundational). The abstract increment-ratio bridge (Erdos1014OQ03.lean + LogIncrement.lean) and the negative meta-result (Erdos1014OQ03Obstruction.lean) remain clean. Full increment asymptotic for k=3 (Delta_l(3) ~ c*l/log l) still OPEN (constant-matching obstruction).",
     "builtItems": [
       "increment_div_eq_ratio_sub_one — (R(l+1)-R(l))/R(l) = R(l+1)/R(l)-1 (algebraic engine).",
       "increment_div_tendsto_zero_iff_ratio_tendsto_one — normalized increment ->0 IFF consecutive ratio ->1; converts #1014's ratio convergence into Delta_l(k)=o(R(k,l)).",
@@ -56,7 +56,6 @@
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "Repair Erdos1014Problem.lean Mathlib drift (17 errors incl. ramsey_mono_left_ge2 unsolved-goals hole) to unblock Erdos1014OQ03Concrete.lean verification.",
       "Formalize the real-analysis lemma: g ~ c·l^a/(log l)^b implies g(l+1) - g(l) ~ a·c·l^{a-1}/(log l)^b.",
       "Prove the conditional increment asymptotic Δ_l(k) ~ (k-1)·c_k·l^{k-2}/(log l)^{k-2} from the power-law hypothesis on R(k,l).",
       "Relate the increment asymptotic to ratio_equiv_difference and ratio_from_asymptotics in the parent file.",


### PR DESCRIPTION
## Summary

Repairs ~25 Mathlib-drift elaboration errors in the parent **`Erdos1014Problem.lean`** (Erdős #1014, Ramsey-number ratio convergence) so it compiles cleanly again: **0 errors, 12 domain axioms, 20 theorems, 0 sorry**. This transitively **unblocks `Erdos1014OQ03Concrete.lean`** — the concrete `k=3` increment instantiation for open question OQ-03 — which imports the parent and now also verifies clean.

## What was broken

The file had drifted against current Mathlib (renamed lemmas, an eventual-vs-global squeeze API change, a `Tendsto.congr` split, plus a genuine unsolved-goals hole in `ramsey_mono_left_ge2` and a malformed calc/induction in `diagonal_ramsey_lower`).

## Fixes

- **Renames**: `div_le_div_iff → div_le_div_iff₀`, `div_le_one_of_le → div_le_one_of_le₀`, `div_le_iff → div_le_iff₀`, `abs_add → abs_add_le`, `Real.isLittleO_log_rpow_atTop → isLittleO_log_rpow_atTop`.
- **`tendsto_succ_div_pow`**: `Tendsto.congr → Tendsto.congr'` (eventual-eq).
- **`tendsto_log_ratio_pow` squeeze**: `tendsto_of_tendsto_of_tendsto_of_le_of_le'` (eventual bounds); rebuild the `n⁻¹/log 2 → 0` lower bound via `Tendsto.inv_tendsto_atTop`; `nlinarith` hint `0 ≤ n⁻¹`.
- **`growth_ratio_close`**: derive `nhds 1` via `simpa` (the old `rw [show (1:ℝ)=1*1]` was rewriting the `1` inside `n+1`); fix the dist-unpacking chain.
- **`ramsey_mono_left_ge2`**: close the unsolved-goals hole with `norm_num` after `subst n = 1`.
- **`diagonal_ramsey_lower`**: replace the broken calc/induction with a 3-line proof from `ramsey_mono_left_ge2` + `ramsey_k2`.
- **`ratio_from_asymptotics`**: prove `g'/g = ((l+1)/l)^(k-1)·(log l/log(l+1))^(k-2)` via `div_pow` (ring cannot split symbolic-exponent powers) then `field_simp`; rebuild the final product bound with explicit `mul_le_mul` steps (nlinarith only multiplies pairs, so it could not reach the degree-3 `|α||β||γ-1|` bound); add a `δ ≤ 1/4` hint.

## Verification

`#print axioms` confirms `ratio_from_asymptotics`, `R3_ratio_convergence`, `diagonal_ramsey_lower`, and the concrete `ramsey3_increment_div_tendsto_zero` depend only on the stated Ramsey axioms (`ramseyNumber`, `ramsey_symm`, `ramsey_k2`, `ramsey_monotone_right`, `ramsey_recurrence`, `R3_lower`) plus `[propext, Classical.choice, Quot.sound]` — **no `sorryAx`, no `Lean.ofReduceBool`**. Verified with `lake env lean` against prebuilt Mathlib oleans; both files return 0 errors.

## Also

- Correct gallery meta `lineCount` 483 → 497 for `erdos-1014`.
- Update `erdos-1014-oq-03` problem knowledge to record the repair and drop the resolved drift blocker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)