### PR TITLE
research(erdos-1059-oq-01-oq-01): absolute lower bound C(n!) ≥ n−3 + infinitude at factorial points

### DIFF
--- a/proofs/Proofs/Erdos1059OQ01OQ01.lean
+++ b/proofs/Proofs/Erdos1059OQ01OQ01.lean
@@ -761,6 +761,62 @@ theorem nonqualifying_deficit_surplus_at_factorials (k M : ℕ) : ∃ N : ℕ, �
   exact ⟨N, fun n hn => (deficit_add_le_iff_density_surplus _ k M).mpr (hN n hn)⟩
 
 /-
+## Part XI: Absolute Growth of the Qualifying Count at Factorial Points
+
+All of the results above are *relative* (ratio / deficit) statements: they compare
+`C(n!)` to `π(n!)`. They leave open the crude but basic question of how large
+`C(n!)` is in absolute terms. Here we record the direct absolute lower bound.
+
+Every level `l ≥ 3` contributes at least one qualifying prime
+(`qualifyingInLevel_pos`), and `C(n!) = Σ_{l<n} q(l)` (`qualifyingCount_decomposition`),
+so summing the `≥ 1` contributions over the `n − 3` levels `3 ≤ l < n` gives the
+explicit linear lower bound `C(n!) ≥ n − 3`. In particular the qualifying primes are
+*infinite*: `C(n!) → ∞`. This is exactly the (weak-axiom-level) infinitude conclusion
+for Erdős 1059 read at factorial evaluation points, now stated as an absolute count
+rather than a density ratio.
+-/
+
+/-- **Absolute lower bound on the qualifying count at factorial points.**
+    For `n ≥ 3`,
+
+      `C(n!) ≥ n − 3`.
+
+    Since `C(n!) = Σ_{l<n} q(l)` (`qualifyingCount_decomposition`) and every level
+    `l ≥ 3` contributes at least one qualifying prime (`qualifyingInLevel_pos`), the
+    `n − 3` levels `3 ≤ l < n` each contribute `≥ 1`, giving the explicit linear
+    lower bound. This is the absolute (non-ratio) counterpart of the density results:
+    it shows the qualifying primes genuinely accumulate, not merely keep pace with a
+    shrinking fraction. -/
+theorem qualifyingCount_factorial_ge (n : ℕ) (hn : n ≥ 3) :
+    Erdos1059OQ01.qualifyingPrimeCount (Nat.factorial n) ≥ n - 3 := by
+  rw [qualifyingCount_decomposition n (by omega)]
+  -- Split range n = range 3 ∪ Ico 3 n and bound the high part by its cardinality.
+  have h3n : 3 ≤ n := hn
+  have hsplit : (Finset.range n).sum qualifyingInLevel
+      = (Finset.range 3).sum qualifyingInLevel
+        + (Finset.Ico 3 n).sum qualifyingInLevel := by
+    rw [← Finset.sum_range_add_sum_Ico _ h3n]
+  have hle : (Finset.Ico 3 n).sum (fun _ => (1 : ℕ)) ≤
+      (Finset.Ico 3 n).sum qualifyingInLevel := by
+    apply Finset.sum_le_sum
+    intro l hl
+    simp only [Finset.mem_Ico] at hl
+    exact qualifyingInLevel_pos l (by omega)
+  have hone : (Finset.Ico 3 n).sum (fun _ => (1 : ℕ)) = n - 3 := by
+    simp [Finset.sum_const, Nat.card_Ico]
+  omega
+
+/-- **The qualifying count is unbounded at factorial points** (infinitude of
+    qualifying primes, factorial-point form). For every `M` there is an `N` such
+    that `C(n!) ≥ M` for all `n ≥ N`; hence `C(n!) → ∞`. Immediate from the linear
+    lower bound `qualifyingCount_factorial_ge`. -/
+theorem qualifyingCount_factorial_unbounded (M : ℕ) : ∃ N : ℕ, ∀ n : ℕ, n ≥ N →
+    Erdos1059OQ01.qualifyingPrimeCount (Nat.factorial n) ≥ M := by
+  refine ⟨M + 3, fun n hn => ?_⟩
+  have hge := qualifyingCount_factorial_ge n (by omega)
+  omega
+
+/-
 ## Summary
 
 **Proved from first principles** (no sorry):
@@ -789,6 +845,11 @@ theorem nonqualifying_deficit_surplus_at_factorials (k M : ℕ) : ∃ N : ℕ, �
     (needs the subset bound C(x) ≤ π(x); the M=0 case is deficit_le_iff_density)
 17. nonqualifying_deficit_surplus_at_factorials — sharp deficit form of the unbounded
     surplus: (π(n!)−C(n!))·(k+1) + M ≤ π(n!) eventually, for every margin M
+18. qualifyingCount_factorial_ge — absolute linear lower bound C(n!) ≥ n − 3 (each
+    level l ≥ 3 contributes ≥1 qualifying prime), the non-ratio counterpart of the
+    density results
+19. qualifyingCount_factorial_unbounded — infinitude at factorial points: C(n!) → ∞
+    (for every M eventually C(n!) ≥ M), immediate from qualifyingCount_factorial_ge
 
 **This file is now sorry-free** — the previous two `sorry`s (the interval
 decompositions) are discharged by `count_decomp`.

--- a/src/data/proofs/erdos-1059-oq-01-oq-01/meta.json
+++ b/src/data/proofs/erdos-1059-oq-01-oq-01/meta.json
@@ -61,7 +61,8 @@
       "levelwise_density_bound: PROVED l/(l+1) ≥ k/(k+1) monotonicity for interval counts",
       "levelwise_strict_surplus: PROVED per-level surplus ≥ 1 for l ≥ max(3, k+2)",
       "density_at_levels: PROVED (main theorem) — level-sum density bound via sum splitting and surplus accumulation",
-      "Gap analysis: factorial growth of interval sizes prevents extending from factorial points to general x"
+      "Gap analysis: factorial growth of interval sizes prevents extending from factorial points to general x",
+      "qualifyingCount_factorial_ge / qualifyingCount_factorial_unbounded: PROVED the absolute (non-ratio) lower bound C(n!) ≥ n−3 by summing the per-level positivity qualifyingInLevel_pos over levels 3 ≤ l < n via qualifyingCount_decomposition, yielding infinitude of qualifying primes at factorial points (C(n!) → ∞) — the absolute counterpart of the density/deficit results"
     ],
     "axiomCount": 1,
     "prerequisites": [
@@ -69,7 +70,7 @@
       "Sieve theory: Selberg sieve, Brun-Titchmarsh inequality (motivational)",
       "Finset operations: filter, card, sum, sum splitting"
     ],
-    "lineCount": 807,
+    "lineCount": 868,
     "relatedProblems": [
       {
         "id": "erdos-1059-oq-01",
@@ -85,7 +86,7 @@
       }
     ],
     "assumptions": "One explicit sieve axiom: strong_selberg_density (the Selberg sieve's quantitative prediction q(l)·(l+1) ≥ p(l)·l for l ≥ 3). The former second axiom primes_growth_in_levels (p(l) ≥ l) is now the PROVED theorem primesInLevel_pos (p(l) ≥ 1, via Bertrand's postulate); the downstream results only ever used positivity of the level prime count, so the axiom count drops from 2 to 1. The file is SORRY-FREE: the two interval-decomposition lemmas (π(n!) and C(n!) as sums over primorial levels) are proved via the generic count_decomp by induction. Hence density_one_at_factorials is fully derived modulo the single disclosed axiom.",
-    "theoremCount": 16,
+    "theoremCount": 18,
     "definitionCount": 3
   },
   "overview": {
@@ -190,15 +191,15 @@
     }
   ],
   "leanFile": {
-    "lineCount": 807,
+    "lineCount": 868,
     "namespace": "Erdos1059OQ01OQ01",
     "opens": [
       "Nat"
     ],
     "structureCount": 0,
     "axiomCount": 1,
-    "theoremCount": 18,
-    "substantiveTheoremCount": 10,
+    "theoremCount": 20,
+    "substantiveTheoremCount": 12,
     "computationalVerifications": 0,
     "lemmaCount": 0,
     "imports": [


### PR DESCRIPTION
## Summary

Extends the saturated Erdős 1059 Selberg-density file `Erdos1059OQ01OQ01.lean` with two new theorems that fill the one gap the existing results left open: an **absolute** (non-ratio) statement about the qualifying prime count `C(n!)`.

All 18 prior theorems are *relative* — they compare `C(n!)` to `π(n!)` (density ratio and non-qualifying deficit, both in level-sum and factorial-point form, with unbounded margins). None bounds `C(n!)` in absolute terms.

## New theorems

- **`qualifyingCount_factorial_ge`**: `C(n!) ≥ n − 3` for `n ≥ 3`. Every primorial level `l ≥ 3` contributes at least one qualifying prime (`qualifyingInLevel_pos`), and `C(n!) = Σ_{l<n} q(l)` (`qualifyingCount_decomposition`); summing the `≥ 1` contributions over the `n − 3` levels `3 ≤ l < n` gives the explicit linear lower bound.
- **`qualifyingCount_factorial_unbounded`**: `C(n!) → ∞` (for every `M`, eventually `C(n!) ≥ M`) — the factorial-point form of infinitude of qualifying primes for Erdős 1059.

## Verification

- `lake env lean Proofs/Erdos1059OQ01OQ01.lean` → exit 0 (only pre-existing unused-variable warnings).
- `#print axioms` of both new theorems: `[propext, Classical.choice, Quot.sound, strong_selberg_density]` — **no new axiom** introduced; `axiomCount` stays **1** (the single disclosed sieve axiom).
- meta.json updated: `theoremCount` 16→18, `leanFile.theoremCount` 18→20, `substantiveTheoremCount` 10→12, `lineCount` 807→868, plus an `originalContributions` entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
