### PR TITLE
research(erdos-1138-oq-03-oq-01): explicit decay rate of the normalised prime gap

### DIFF
--- a/proofs/Proofs/Erdos1138OQ03OQ01.lean
+++ b/proofs/Proofs/Erdos1138OQ03OQ01.lean
@@ -97,6 +97,24 @@ theorem gap_isBigO_rpow :
     abs_of_nonneg (Nat.cast_nonneg (maxPrimeGap x)), abs_of_nonneg hnn]
   exact baker_harman_pintz x hx
 
+/-- **Explicit decay rate of the normalised gap.** The normalised maximal prime gap not only
+    tends to `0` (`bhp_implies_gap_littleo`) but does so at a concrete polynomial rate:
+    `maxPrimeGap x / x = O(x^(-0.475))`. This sharpens the qualitative `Tendsto … (𝓝 0)` to a
+    quantitative envelope with an explicit exponent `-(1 - 0.525) = -0.475`, packaged in Mathlib's
+    asymptotics idiom (constant `1`, valid for `x ≥ 25`). It is the normalised counterpart of
+    `gap_isBigO_rpow` (`maxPrimeGap = O(x^0.525)`), obtained by dividing that envelope by `x`. -/
+theorem gap_div_isBigO_rpow_neg :
+    (fun x : ℕ => (maxPrimeGap x : ℝ) / x) =O[atTop]
+      (fun x : ℕ => (x : ℝ) ^ (-(0.475 : ℝ))) := by
+  rw [isBigO_iff]
+  refine ⟨1, ?_⟩
+  filter_upwards [eventually_ge_atTop 25] with x hx
+  have hnn : (0 : ℝ) ≤ (x : ℝ) ^ (-(0.475 : ℝ)) := Real.rpow_nonneg (Nat.cast_nonneg x) _
+  have hlo : (0 : ℝ) ≤ (maxPrimeGap x : ℝ) / x :=
+    div_nonneg (Nat.cast_nonneg _) (Nat.cast_nonneg _)
+  rw [one_mul, Real.norm_eq_abs, Real.norm_eq_abs, abs_of_nonneg hlo, abs_of_nonneg hnn]
+  exact gap_div_le_rpow_neg x hx
+
 /-- **Generalised sublinearity.** For every exponent `a > 0.525`, the normalised gap
     `maxPrimeGap x / x^a` tends to `0`. This uses the full strength of the BHP exponent:
     `bhp_implies_gap_littleo` is the `a = 1` case, but sublinearity in fact holds for any
@@ -209,7 +227,7 @@ theorem gap_littleo_of_rpow_bound {θ : ℝ} (hθ : θ < 1)
     have hdiv : (x : ℝ) ^ θ / x = (x : ℝ) ^ (-(1 - θ)) := by
       rw [show (-(1 - θ)) = θ - 1 by ring, Real.rpow_sub hx_pos, Real.rpow_one]
     calc (maxPrimeGap x : ℝ) / x
-        ≤ (x : ℝ) ^ θ / x := by gcongr <;> exact hx
+        ≤ (x : ℝ) ^ θ / x := by gcongr
       _ = (x : ℝ) ^ (-(1 - θ)) := hdiv
   exact squeeze_zero' (Eventually.of_forall h_lo) h_hi h_env
 
@@ -241,7 +259,7 @@ theorem gap_div_rpow_littleo_of_rpow_bound {θ a : ℝ} (hθa : θ < a)
     have hdiv : (x : ℝ) ^ θ / (x : ℝ) ^ a = (x : ℝ) ^ (-(a - θ)) := by
       rw [← Real.rpow_sub hx_pos]; congr 1; ring
     calc (maxPrimeGap x : ℝ) / (x : ℝ) ^ a
-        ≤ (x : ℝ) ^ θ / (x : ℝ) ^ a := by gcongr <;> exact hx
+        ≤ (x : ℝ) ^ θ / (x : ℝ) ^ a := by gcongr
       _ = (x : ℝ) ^ (-(a - θ)) := hdiv
   exact squeeze_zero' (Eventually.of_forall h_lo) h_hi h_env
 
@@ -275,6 +293,30 @@ theorem gap_isBigO_rpow_of_rpow_bound {θ : ℝ}
   rw [one_mul, Real.norm_eq_abs, Real.norm_eq_abs,
     abs_of_nonneg (Nat.cast_nonneg (maxPrimeGap x)), abs_of_nonneg hnn]
   exact hx
+
+/-- **Master engine, normalised decay rate.** From *any* eventual power envelope
+`maxPrimeGap x ≤ x^θ`, the normalised gap decays at the explicit rate
+`maxPrimeGap x / x = O(x^(θ - 1))` — the envelope divided by `x`. This is the abstract counterpart
+of the concrete `gap_div_isBigO_rpow_neg` (the BHP instance `θ = 0.525`, giving `O(x^(-0.475))`),
+and the big-O sharpening of the `Tendsto (·/x) → 0` engine `gap_littleo_of_rpow_bound`: no
+sub-linearity of `θ` is needed for the big-O (the rate is negative exactly when `θ < 1`, which is
+when it also gives sublinearity). -/
+theorem gap_div_isBigO_rpow_sub_one_of_rpow_bound {θ : ℝ}
+    (H : ∀ᶠ x : ℕ in atTop, (maxPrimeGap x : ℝ) ≤ (x : ℝ) ^ θ) :
+    (fun x : ℕ => (maxPrimeGap x : ℝ) / x) =O[atTop] (fun x : ℕ => (x : ℝ) ^ (θ - 1)) := by
+  rw [isBigO_iff]
+  refine ⟨1, ?_⟩
+  filter_upwards [H, eventually_ge_atTop 1] with x hx hx1
+  have hx_pos : (0 : ℝ) < (x : ℝ) := by exact_mod_cast (lt_of_lt_of_le Nat.zero_lt_one hx1)
+  have hnn : (0 : ℝ) ≤ (x : ℝ) ^ (θ - 1) := Real.rpow_nonneg (Nat.cast_nonneg x) _
+  have hlo : (0 : ℝ) ≤ (maxPrimeGap x : ℝ) / x :=
+    div_nonneg (Nat.cast_nonneg _) (Nat.cast_nonneg _)
+  rw [one_mul, Real.norm_eq_abs, Real.norm_eq_abs, abs_of_nonneg hlo, abs_of_nonneg hnn]
+  have hdiv : (x : ℝ) ^ θ / x = (x : ℝ) ^ (θ - 1) := by
+    rw [Real.rpow_sub hx_pos, Real.rpow_one]
+  calc (maxPrimeGap x : ℝ) / x
+      ≤ (x : ℝ) ^ θ / x := by gcongr
+    _ = (x : ℝ) ^ (θ - 1) := hdiv
 
 /-- **Master engine, little-o against `id`.** From *any* eventual power envelope
 `maxPrimeGap x ≤ x^θ` with sub-linear exponent `θ < 1`, `maxPrimeGap =o[atTop] id`. This is the

--- a/src/data/proofs/erdos-1138-oq-03-oq-01/meta.json
+++ b/src/data/proofs/erdos-1138-oq-03-oq-01/meta.json
@@ -45,14 +45,16 @@
       "gap_div_le_rpow_neg: pointwise upper envelope maxPrimeGap x / x <= x^(-0.475) for x >= 25, via BHP divided by x and the identity x^0.525 / x = x^(0.525 - 1)",
       "bhp_implies_gap_littleo: unconditional maxPrimeGap x / x -> 0, squeezing between 0 and the envelope x^(-0.475) -> 0 (unconditional twin of cramer_implies_gap_sublinear)",
       "bhp_gap_eventually_le_eps: epsilon-form, for every epsilon > 0 eventually maxPrimeGap x <= epsilon * x",
-      "gap_eventually_le_eps_of_rpow_bound: abstract epsilon-form engine, from any eventual envelope maxPrimeGap x <= x^theta with theta < 1, for every epsilon > 0 eventually maxPrimeGap x <= epsilon * x (the abstract counterpart of bhp_gap_eventually_le_eps, completing the engine family's term-for-term match with the concrete BHP family)"
+      "gap_eventually_le_eps_of_rpow_bound: abstract epsilon-form engine, from any eventual envelope maxPrimeGap x <= x^theta with theta < 1, for every epsilon > 0 eventually maxPrimeGap x <= epsilon * x (the abstract counterpart of bhp_gap_eventually_le_eps, completing the engine family's term-for-term match with the concrete BHP family)",
+      "gap_div_isBigO_rpow_neg: explicit decay RATE of the normalised gap, maxPrimeGap x / x = O(x^(-0.475)) (Landau big-O idiom, constant 1, x>=25) — sharpens bhp_implies_gap_littleo's qualitative Tendsto to 0 into a quantitative polynomial-rate envelope; the normalised counterpart of gap_isBigO_rpow.",
+      "gap_div_isBigO_rpow_sub_one_of_rpow_bound: abstract normalised-decay-rate engine — from any eventual envelope maxPrimeGap x <= x^theta, maxPrimeGap x / x = O(x^(theta-1)); the source-parametric, axiom-free ([propext,choice,Quot.sound]) twin of the concrete gap_div_isBigO_rpow_neg."
     ],
     "dateAdded": "2026-07-05",
     "mathlib_version": "4.26.0",
     "axiomCount": 1,
-    "lineCount": 376,
+    "lineCount": 418,
     "assumptions": "1 axiom, inherited from the parent Erdos1138OQ03: baker_harman_pintz (maxPrimeGap x <= x^0.525 for x >= 25). No axiom is declared in this file (leanFile.axiomCount = 0); the assumption is imported. #print axioms confirms the results depend only on {propext, Classical.choice, Quot.sound, Erdos1138OQ03.baker_harman_pintz}. No sorries, no native_decide.",
-    "theoremCount": 14,
+    "theoremCount": 16,
     "definitionCount": 0
   },
   "overview": {
@@ -141,9 +143,9 @@
       "Topology"
     ],
     "namespace": "Erdos1138OQ03",
-    "lineCount": 376,
+    "lineCount": 418,
     "axiomCount": 0,
-    "theoremCount": 17,
+    "theoremCount": 20,
     "definitionCount": 0,
     "path": "Proofs/Erdos1138OQ03OQ01.lean",
     "sorries": 0

--- a/src/data/research/problems/erdos-1138-oq-03-oq-01.json
+++ b/src/data/research/problems/erdos-1138-oq-03-oq-01.json
@@ -16,14 +16,12 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "SURVEYED",
-    "since": "2026-07-02",
-    "iteration": 1,
-    "focus": "Scoped a tractable oq-01 for the fresh (previously EMPTY, no problem.md) candidate:",
+    "phase": "PROGRESS",
+    "since": "2026-07-11",
+    "iteration": 2,
+    "focus": "Verified the file builds (built parent Erdos1138OQ03 olean, then OQ01 via lake env lean, EXIT 0). Added normalised-gap decay-rate results gap_div_isBigO_rpow_neg (O(x^(-0.475))) + abstract engine gap_div_isBigO_rpow_sub_one_of_rpow_bound (O(x^(θ-1))); cleaned 2 dead-tactic warnings. 20 theorems, 0 sorry, inherits only the BHP axiom.",
     "activeApproach": "Real-analysis squeeze: `maxPrimeGap x / x ≤ x^(-0.475) → 0`. Envelope limit from",
-    "blockers": [
-      "Build-blocked this session (Docker down; disk ~97%; 0 oleans on disk, #33336). No Lean"
-    ],
+    "blockers": [],
     "nextAction": "Build-capable session: create `proofs/Proofs/Erdos1138OQ03OQ01.lean` (import",
     "attemptCounts": {
       "total": 1,
@@ -37,13 +35,16 @@
       "gap_div_le_rpow_neg (Erdos1138OQ03OQ01.lean:37): maxPrimeGap x / x <= x^(-0.475) for x >= 25",
       "bhp_implies_gap_littleo (Erdos1138OQ03OQ01.lean:57): Tendsto (maxPrimeGap x / x) atTop (nhds 0)",
       "bhp_gap_eventually_le_eps (Erdos1138OQ03OQ01.lean:74): forall eps>0, eventually maxPrimeGap x <= eps*x",
-      "Erdos1138OQ03OQ01.lean:186 gap_littleo_of_rpow_bound (source-exponent-parametric sublinearity engine). Elaboration-clean; olean-write blocked by fleet SIGBUS storm."
+      "Erdos1138OQ03OQ01.lean:186 gap_littleo_of_rpow_bound (source-exponent-parametric sublinearity engine). Elaboration-clean; olean-write blocked by fleet SIGBUS storm.",
+      "gap_div_isBigO_rpow_neg (Erdos1138OQ03OQ01.lean, VERIFIED [propext,choice,Quot.sound,baker_harman_pintz]): explicit decay RATE of the normalised gap, maxPrimeGap x / x = O(x^(-0.475)) — sharpens bhp_implies_gap_littleo (Tendsto→0) to a quantitative polynomial-rate big-O; normalised counterpart of gap_isBigO_rpow.",
+      "gap_div_isBigO_rpow_sub_one_of_rpow_bound (Erdos1138OQ03OQ01.lean, VERIFIED axiom-free [propext,choice,Quot.sound]): abstract normalised-decay-rate engine, any eventual envelope maxPrimeGap x≤x^θ ⟹ maxPrimeGap x/x = O(x^(θ-1)); source-parametric twin of the concrete decay-rate result."
     ],
     "insights": [
       "BHP exponent 0.525 < 1: one division by x yields a negative power x^(-0.475) that vanishes at infinity - no finer analysis needed",
       "x^0.525 / x must be rewritten via Real.rpow_sub on x^(0.525-1); rewriting x as x^1 via rpow_one hits the numerator base and fails",
       "tendsto_rpow_neg_atTop is root-namespace (not Real.); the earlier survey mis-quoted it",
-      "Abstract sublinearity engine: the specific BHP exponent 0.525 is inessential — ANY eventual power envelope maxPrimeGap x ≤ x^θ with θ<1 forces maxPrimeGap x / x → 0 (envelope x^θ/x = x^(θ-1) = x^(-(1-θ)) → 0 since 1-θ>0). gap_littleo_of_rpow_bound {θ} (hθ:θ<1) (H: ∀ᶠ x, gap ≤ x^θ). bhp_implies_gap_littleo is the θ=0.525 instance; future BHP tightenings (0.5+ε) plug in with no re-proof."
+      "Abstract sublinearity engine: the specific BHP exponent 0.525 is inessential — ANY eventual power envelope maxPrimeGap x ≤ x^θ with θ<1 forces maxPrimeGap x / x → 0 (envelope x^θ/x = x^(θ-1) = x^(-(1-θ)) → 0 since 1-θ>0). gap_littleo_of_rpow_bound {θ} (hθ:θ<1) (H: ∀ᶠ x, gap ≤ x^θ). bhp_implies_gap_littleo is the θ=0.525 instance; future BHP tightenings (0.5+ε) plug in with no re-proof.",
+      "Added the explicit decay RATE of the normalised gap (previously only the qualitative Tendsto→0 was recorded): concrete gap_div_isBigO_rpow_neg = O(x^(-0.475)) and abstract gap_div_isBigO_rpow_sub_one_of_rpow_bound = O(x^(θ-1)). Also cleaned two dead `gcongr <;> exact hx` linter warnings. File VERIFIED via lake env lean (built parent olean first), EXIT 0, 0 warnings; 18→20 theorems."
     ],
     "mathlibGaps": [],
     "nextSteps": [],
@@ -70,7 +71,7 @@
     "mathlib": []
   },
   "started": "2026-04-05T12:58:50.791Z",
-  "lastUpdate": "2026-06-27T00:25:01.703Z",
+  "lastUpdate": "2026-07-11T00:00:00.000Z",
   "significance": 5,
   "tractability": 8,
   "leanFiles": [


### PR DESCRIPTION
## Summary

Adds the explicit polynomial **decay rate** of the normalised maximal prime gap to `proofs/Proofs/Erdos1138OQ03OQ01.lean`. The file already proved sublinearity qualitatively (`bhp_implies_gap_littleo : Tendsto (maxPrimeGap x / x) atTop (𝓝 0)`) but never recorded *how fast* the ratio decays. These two theorems supply the rate:

```lean
theorem gap_div_isBigO_rpow_neg :
    (fun x : ℕ => (maxPrimeGap x : ℝ) / x) =O[atTop]
      (fun x : ℕ => (x : ℝ) ^ (-(0.475 : ℝ)))

theorem gap_div_isBigO_rpow_sub_one_of_rpow_bound {θ : ℝ}
    (H : ∀ᶠ x : ℕ in atTop, (maxPrimeGap x : ℝ) ≤ (x : ℝ) ^ θ) :
    (fun x : ℕ => (maxPrimeGap x : ℝ) / x) =O[atTop] (fun x : ℕ => (x : ℝ) ^ (θ - 1))
```

- The **concrete** result is the normalised counterpart of `gap_isBigO_rpow` (`maxPrimeGap = O(x^0.525)`), obtained by dividing that envelope by `x`; it sharpens the qualitative `Tendsto … 0` into a quantitative `O(x^(-0.475))`.
- The **abstract** engine is its source-parametric, axiom-free twin, matching the file's concrete/abstract family pattern term-for-term.

Also removes two dead `gcongr <;> exact hx` tactic sequences (`gcongr`'s discharger already closes the envelope side-goal by assumption), eliminating the file's only two linter warnings.

## Verification

- `lake env lean` (toolchain `v4.26.0`): built the parent `Proofs.Erdos1138OQ03` olean, then the OQ01 file — **EXIT 0, no warnings**.
- `#print axioms`:
  - `gap_div_isBigO_rpow_neg` = `[propext, Classical.choice, baker_harman_pintz, Quot.sound]` — inherits only the parent's Baker–Harman–Pintz axiom, as intended.
  - `gap_div_isBigO_rpow_sub_one_of_rpow_bound` = `[propext, Classical.choice, Quot.sound]` — **axiom-free**.
- File: 18 → 20 theorems, still **0 sorry**. Entry remains **axiomatized** (`axiomCount = 1`, the BHP bound). Gallery meta counts refreshed (`lineCount` 376→418, `leanFile.theoremCount` 17→20).

🤖 Generated with [Claude Code](https://claude.com/claude-code)