### PR TITLE
research(erdos-378): Part IX monotonicity of natural density [VERIFIED axiom-free]

### DIFF
--- a/proofs/Proofs/Erdos378Problem.lean
+++ b/proofs/Proofs/Erdos378Problem.lean
@@ -562,4 +562,59 @@ theorem erdos_378_density_zero : NaturalDensity (atLeastSquarefree 0) 1 := by
   rw [atLeastSquarefree_zero_eq_univ]
   exact natDensity_univ
 
+/-
+## Part IX: Monotonicity of natural density — the density is order-preserving
+
+The framework already records the two extreme bounds `natDensity_nonneg` (density `≥ 0`)
+and `natDensity_le_one` (density `≤ 1`). Both are instances of a single structural fact:
+natural density is *monotone* under set inclusion. Below we prove that general law and
+apply it to the decreasing filtration `atLeastSquarefree_antitone`, obtaining that the
+Erdős #378 densities are **antitone in the threshold** — a larger demand `r` on the number
+of squarefree interior binomials cannot increase the density of qualifying integers. All
+axiom-free (independent of the Granville–Ramaré inputs).
+-/
+
+/-- **Natural density is monotone under inclusion.**  If `S ⊆ T` and both have natural
+densities `d` and `d'`, then `d ≤ d'`.  For every `N` the counting cardinalities satisfy
+`|S ∩ [0,N)| ≤ |T ∩ [0,N)|`, so the ratios are ordered; taking `N` past both convergence
+thresholds forces the limits to be ordered too.  This subsumes both `natDensity_nonneg`
+(the case `S = ∅`, `d = 0`) and `natDensity_le_one` (the case `T = univ`, `d' = 1`).
+Elementary ε-argument, uses none of the axioms. -/
+theorem natDensity_mono {S T : Set ℕ} {d d' : ℝ} (hst : S ⊆ T)
+    (hS : NaturalDensity S d) (hT : NaturalDensity T d') : d ≤ d' := by
+  by_contra hlt
+  push_neg at hlt  -- `d' < d`
+  set ε : ℝ := (d - d') / 2 with hεdef
+  have hε : 0 < ε := by rw [hεdef]; linarith
+  obtain ⟨N₁, hN₁⟩ := hS ε hε
+  obtain ⟨N₂, hN₂⟩ := hT ε hε
+  set N := max (max N₁ N₂) 1 with hNdef
+  have hNpos : 0 < N := lt_of_lt_of_le Nat.zero_lt_one (le_max_right _ _)
+  have hNR : (0 : ℝ) < N := by exact_mod_cast hNpos
+  have hb1 := hN₁ N (le_trans (le_max_left _ _) (le_max_left _ _))
+  have hb2 := hN₂ N (le_trans (le_max_right _ _) (le_max_left _ _))
+  -- counting-ratio monotonicity from the cardinality inclusion
+  have hsub : (S ∩ Set.Iio N) ⊆ (T ∩ Set.Iio N) :=
+    Set.inter_subset_inter_left _ hst
+  have hfinT : (T ∩ Set.Iio N).Finite := (Set.finite_Iio N).inter_of_right T
+  have hcardR : ((S ∩ Set.Iio N).ncard : ℝ) ≤ ((T ∩ Set.Iio N).ncard : ℝ) := by
+    exact_mod_cast Set.ncard_le_ncard hsub hfinT
+  have hratio : ((S ∩ Set.Iio N).ncard : ℝ) / (N : ℝ)
+      ≤ ((T ∩ Set.Iio N).ncard : ℝ) / (N : ℝ) :=
+    div_le_div_of_nonneg_right hcardR (le_of_lt hNR)
+  rw [abs_lt] at hb1 hb2
+  linarith [hb1.1, hb2.2, hratio]
+
+/-- **The Erdős #378 densities are antitone in the threshold.**  For thresholds `r ≤ r'`,
+if the answer sets at both thresholds have natural densities `d` and `d'`, then `d' ≤ d`:
+raising the required number of squarefree interior binomials shrinks the qualifying set
+(`atLeastSquarefree_antitone`), so by `natDensity_mono` its density cannot increase.  This
+is the monotone structure of the density profile `r ↦ d(r)` descending from `d(0) = 1`
+(`erdos_378_density_zero`).  Axiom-free (the densities are supplied as hypotheses, so the
+Granville–Ramaré existence input is not invoked). -/
+theorem erdos_378_density_antitone {r r' : ℕ} {d d' : ℝ} (hr : r ≤ r')
+    (hd : NaturalDensity (atLeastSquarefree r) d)
+    (hd' : NaturalDensity (atLeastSquarefree r') d') : d' ≤ d :=
+  natDensity_mono (atLeastSquarefree_antitone hr) hd' hd
+
 end Erdos378

--- a/research/problems/erdos-378/state.md
+++ b/research/problems/erdos-378/state.md
@@ -2,7 +2,26 @@
 
 **Phase**: COMPLETED
 **Since**: 2026-07-08
-**Iteration**: 1
+**Iteration**: 3
+
+## Iteration 3 (researcher-9, 2026-07-11, VERIFIED via offline Mathlib elaboration)
+Added **Part IX: monotonicity of natural density** — 2 axiom-free theorems generalizing
+the density framework (independent of the 2 Granville–Ramaré axioms):
+- `natDensity_mono` : `S ⊆ T` + both have densities `d, d'` ⟹ `d ≤ d'`. The single
+  structural law subsuming both `natDensity_nonneg` (`S = ∅`) and `natDensity_le_one`
+  (`T = univ`). by_contra ε-argument mirroring `naturalDensity_unique`: cardinality
+  inclusion `|S ∩ Iio N| ≤ |T ∩ Iio N|` (`Set.ncard_le_ncard`) → ratio order
+  (`div_le_div_of_nonneg_right`) → limit order via `linarith`.
+- `erdos_378_density_antitone` : for thresholds `r ≤ r'`, if both answer-set densities
+  exist (`d`, `d'`) then `d' ≤ d` — the density profile `r ↦ d(r)` is antitone descending
+  from `d(0) = 1`. Composes `natDensity_mono` with the existing `atLeastSquarefree_antitone`
+  filtration. Densities passed as hypotheses so the GR existence axiom is NOT invoked.
+
+File 565→620 lines, 17→19 theorems (meta count), 0 sorries, 2 axioms (Granville–Ramaré)
+unchanged. Both new theorems depend only on `[propext, Classical.choice, Quot.sound]`
+(foundational) — confirmed by `#print axioms`, NOT on the GR axioms. Verified by full
+offline elaboration (`bin/lake env lean Proofs/Erdos378Problem.lean`, EXIT 0). The two
+density axioms remain the analytic frontier (out of scope).
 
 ## Current Focus
 

--- a/src/data/proofs/erdos-378/meta.json
+++ b/src/data/proofs/erdos-378/meta.json
@@ -162,9 +162,9 @@
       "Finset"
     ],
     "namespace": "Erdos378",
-    "lineCount": 565,
+    "lineCount": 620,
     "axiomCount": 2,
-    "theoremCount": 17,
+    "theoremCount": 19,
     "definitionCount": 8,
     "path": "Proofs/Erdos378Problem.lean",
     "sorries": 0,


### PR DESCRIPTION
## Summary

Adds **Part IX: monotonicity of natural density** to `Erdos378Problem.lean` — the single structural law behind the framework's two extreme bounds (`natDensity_nonneg`, `natDensity_le_one`), plus its threshold-antitonicity payoff. Both new theorems are independent of the two Granville–Ramaré density axioms.

## New theorems (axiom-free)

- **`natDensity_mono`** — if `S ⊆ T` and both have natural densities `d`, `d'`, then `d ≤ d'`. The general law subsuming both `natDensity_nonneg` (case `S = ∅`, `d = 0`) and `natDensity_le_one` (case `T = univ`, `d' = 1`). Proof: cardinality inclusion `|S ∩ [0,N)| ≤ |T ∩ [0,N)|` → ratio order → limit order (by_contra ε-argument mirroring `naturalDensity_unique`).
- **`erdos_378_density_antitone`** — for thresholds `r ≤ r'`, if both answer-set densities exist, then `d' ≤ d`: the Erdős #378 density profile `r ↦ d(r)` is antitone, descending from `d(0) = 1` (`erdos_378_density_zero`). Composes `natDensity_mono` with the existing `atLeastSquarefree_antitone` filtration. Densities are supplied as hypotheses, so the Granville–Ramaré existence axiom is not invoked.

## Verification

- File `565 → 620` lines, `17 → 19` theorems, **0 sorries**, **2 axioms** (Granville–Ramaré, unchanged and uninvolved).
- `#print axioms`: both new theorems depend only on `[propext, Classical.choice, Quot.sound]` — **not** on `granville_ramare_density_exists` / `complement_density`.
- Verified by full offline Mathlib elaboration (`bin/lake env lean Proofs/Erdos378Problem.lean`, EXIT 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)