### PR TITLE
research(erdos-1039): universal ceiling ρ(f) ≤ 2 + boundedness of the sublevel set

### DIFF
--- a/proofs/Proofs/Erdos1039Problem.lean
+++ b/proofs/Proofs/Erdos1039Problem.lean
@@ -666,6 +666,41 @@ theorem rho_pos (hf : 0 < f.degree) : 0 < rho f := by
     _ ≤ sSup {r : ℝ | ∃ c : ℂ, isInscribedDisc (sublevelSet f) c r} :=
         le_csSup (bddAbove_inscribed_radii f hf) ⟨z0, hins⟩
 
+/-- **The sublevel set is bounded.** For a polynomial of positive degree, the
+    lemniscate sublevel set `{z : |f(z)| < 1}` sits inside the ball of radius `2`
+    (`sublevelSet_subset_ball`), hence is a bounded subset of `ℂ`. Together with
+    `sublevelSet_isOpen` and `sublevelSet_nonempty` this pins down its basic
+    topology: a nonempty, open, bounded region whose largest inscribed disc is
+    the object of study. -/
+theorem sublevelSet_isBounded (hf : 0 < f.degree) :
+    Bornology.IsBounded (sublevelSet f) :=
+  Metric.isBounded_ball.subset (sublevelSet_subset_ball f hf)
+
+/-- **Universal ceiling `ρ(f) ≤ 2`.** Every inscribed disc `B(c, r)` of the
+    sublevel set is contained in the sublevel set, which itself lies in `B(0, 2)`
+    (`sublevelSet_subset_ball`); comparing the two balls with `inscribed_radius_le`
+    forces `r ≤ 2`, so the supremum `ρ(f)` of all inscribed radii is at most `2`.
+    Combined with `rho_pos`, this bounds `ρ(f) ∈ (0, 2]` for every positive-degree
+    polynomial — a crude but assumption-free ceiling framing the deep lower-bound
+    axioms (`pommerenke_lower`, `klr_lower`), which sharpen the *floor* while this
+    caps the *height*. -/
+theorem rho_le_two (hf : 0 < f.degree) : rho f ≤ 2 := by
+  unfold rho inscribedDiscRadius
+  refine Real.sSup_le ?_ (by norm_num)
+  rintro r ⟨c, hrpos, hsub⟩
+  refine inscribed_radius_le (c := c) (z0 := 0) hrpos (by norm_num : (0 : ℝ) < 2) ?_
+  intro z hz
+  have hzc : z ∈ sublevelSet f := hsub z hz
+  have hb := sublevelSet_subset_ball f hf hzc
+  rw [Metric.mem_ball, dist_zero_right] at hb
+  simpa using hb
+
+/-- **`ρ(f) ∈ (0, 2]`.** Packaging `rho_pos` and `rho_le_two`: for every
+    positive-degree polynomial the inscribed-disc radius is strictly positive and
+    at most `2`. -/
+theorem rho_mem_Ioc (hf : 0 < f.degree) : rho f ∈ Set.Ioc (0 : ℝ) 2 :=
+  ⟨rho_pos f hf, rho_le_two f hf⟩
+
 /-
 ## Random Polynomials
 -/

--- a/proofs/Proofs/Erdos703Problem.lean
+++ b/proofs/Proofs/Erdos703Problem.lean
@@ -385,6 +385,90 @@ theorem franklFurediEven_card_le_T (n r : ℕ) (hn : 1 ≤ n) (hpar : (n + r) % 
   exact Finset.le_sup hmem
 
 /-
+## Part IV.a: The Small-Sets Family and a Polynomial Lower Bound
+
+The "small" disjunct `{A ⊆ [n] : |A| < r}` of the Frankl–Füredi families is itself
+an `r`-avoiding family, for the trivial reason that two sets of size `< r` cannot
+meet in `r` points. Unlike the large-set part it admits an *exact* closed-form count
+`∑_{k<r} C(n,k)`, yielding the first certified **polynomial** lower bound on `T(n,r)`
+across the whole middle range `r ≥ 2` that the Frankl–Rödl question concerns.
+-/
+
+/--
+**The small-sets family.**
+`F = {A ⊆ [n] : |A| < r}` — all subsets of `[n]` of size strictly below the
+forbidden size `r`. It is the "small" disjunct of `franklFurediOdd`/`franklFurediEven`
+isolated on its own.
+-/
+def smallSetsFamily (n r : ℕ) : Finset (Finset ℕ) :=
+  (Finset.range n).powerset.filter (fun A => A.card < r)
+
+/--
+**The small-sets family avoids `r`-intersection.**
+Any two sets of size `< r` meet in fewer than `r` points, since
+`|A ∩ B| ≤ |A| < r`. Holds for every `n, r` with no parity or size hypothesis. -/
+theorem smallSetsFamily_avoids_r (n r : ℕ) :
+    avoidsRIntersection r (smallSetsFamily n r) := by
+  intro A B hA hB
+  rw [smallSetsFamily, Finset.mem_filter, Finset.mem_powerset] at hA hB
+  have hle : (A ∩ B).card ≤ A.card := Finset.card_le_card Finset.inter_subset_left
+  omega
+
+/--
+**Exact cardinality of the small-sets family: `∑_{k<r} C(n,k)`.**
+Partitioning `{A ⊆ [n] : |A| < r}` by exact size `k ∈ {0,…,r−1}` gives a disjoint
+union of the `powersetCard k` layers of `[n]`, each of size `C(n,k)`. -/
+theorem smallSetsFamily_card (n r : ℕ) :
+    (smallSetsFamily n r).card = ∑ k ∈ Finset.range r, n.choose k := by
+  have hbi : smallSetsFamily n r
+      = (Finset.range r).biUnion (fun k => (Finset.range n).powersetCard k) := by
+    ext A
+    simp only [smallSetsFamily, Finset.mem_filter, Finset.mem_powerset, Finset.mem_biUnion,
+      Finset.mem_range, Finset.mem_powersetCard]
+    constructor
+    · rintro ⟨hsub, hlt⟩
+      exact ⟨A.card, hlt, hsub, rfl⟩
+    · rintro ⟨k, hk, hsub, hcard⟩
+      exact ⟨hsub, by omega⟩
+  have hdisj : (↑(Finset.range r) : Set ℕ).PairwiseDisjoint
+      (fun k => (Finset.range n).powersetCard k) := by
+    intro i _ j _ hij
+    apply Finset.disjoint_left.mpr
+    intro A hAi hAj
+    rw [Finset.mem_powersetCard] at hAi hAj
+    apply hij
+    rw [← hAi.2, hAj.2]
+  rw [hbi, Finset.card_biUnion hdisj]
+  apply Finset.sum_congr rfl
+  intro k _
+  rw [Finset.card_powersetCard, Finset.card_range]
+
+/--
+**Polynomial lower bound `T(n,r) ≥ ∑_{k<r} C(n,k)`.**
+The small-sets family is a valid `r`-avoiding subfamily of `2^{[n]}`, so its exact
+binomial-sum cardinality bounds `T(n,r)` from below. Unlike the exponential-order
+large-set constructions this bound is fully explicit and holds for every `n, r`. -/
+theorem sum_choose_le_T (n r : ℕ) : (∑ k ∈ Finset.range r, n.choose k) ≤ T n r := by
+  rw [← smallSetsFamily_card n r]
+  have hmem : smallSetsFamily n r ∈
+      ((Finset.range n).powerset.powerset).filter (avoidsRIntersection r) := by
+    rw [Finset.mem_filter]
+    exact ⟨Finset.mem_powerset.mpr (Finset.filter_subset _ _), smallSetsFamily_avoids_r n r⟩
+  exact Finset.le_sup hmem
+
+/--
+**`T(n,2) ≥ n + 1`.** Specialising `sum_choose_le_T` at `r = 2`:
+`∑_{k<2} C(n,k) = C(n,0) + C(n,1) = 1 + n`. This is a certified *polynomial* lower
+bound on the `r = 2` line — the smallest forbidden size in the middle range that the
+Frankl–Rödl question actually concerns (`r ≥ 2`) — complementing the exact boundary
+values `T(n,0) = 2^{n-1}`, `T(n,n) = 2^n − 1`, and `T(n,r) = 2^n` for `n < r`. -/
+theorem n_add_one_le_T_n_2 (n : ℕ) : n + 1 ≤ T n 2 := by
+  have h := sum_choose_le_T n 2
+  simp only [Finset.sum_range_succ, Finset.sum_range_zero, Nat.choose_zero_right,
+    Nat.choose_one_right] at h
+  omega
+
+/-
 ## Part IV.b: Structural Properties of `T`
 
 Elementary structural facts about the extremal function `T(n,r)` that hold for

--- a/research/problems/cauchy-schwarz-integral-lp-duality-synthesis/state.md
+++ b/research/problems/cauchy-schwarz-integral-lp-duality-synthesis/state.md
@@ -1,8 +1,40 @@
 # Research State: cauchy-schwarz-integral-lp-duality-synthesis
 
 ## Current State
-**Phase**: ACT (wiring RESOLVED end-to-end; one Docker build from discharging the Synthesis sorry)
+**Phase**: DONE — axiom DISCHARGED and independently KERNEL-VERIFIED on `main`
 **Path**: full
+**Since**: 2026-07-08
+**Iteration**: 27
+
+## RESOLUTION (S27, researcher-5, 2026-07-11) — VERIFIED COMPLETE
+The S26 wiring patch was **landed on `main`** (commit a5a3f9e917, 2026-07-10) and the
+`riesz_lp_surjective_general` `sorry` is **gone**. This session **independently
+kernel-verified the entire discharge chain** (the prior sessions' status was only
+"verified-by-analogy, not kernel-checked"; the Session-10 "58-error Mathlib-drift"
+caveat is also stale — the foundation now compiles clean).
+
+Built all 12 chain files bottom-up with the host toolchain (`lean` v4.26.0 against the
+prebuilt Mathlib oleans, isolated olean output dir, no Docker needed):
+`…OQ01OQ01OQ02OQ01` → Ingredients/Consistency/Extension → Gluing → Incomplete01Infra
+(with the added `extByZeroCLM_coeFn`) → Norm → Loc → Incomplete01 → LpDualityMaximal →
+LpDualitySynthesis → **`…OQ01OQ01OQ02` (gallery file)**. All 12 compile (warnings only).
+
+`#print axioms` results (kernel, host build):
+- `RieszLpDualitySynthesis.riesz_lp_surjective_general` → `[propext, Classical.choice, Quot.sound]`
+- `RieszLp.riesz_lp_surjective` (gallery re-export) → `[propext, Classical.choice, Quot.sound]`
+
+No `sorryAx`, no `Lean.ofReduceBool`. The gallery entry
+`src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-02/meta.json`
+(`status: verified`, `badge: verified`, `axiomCount: 0`, `sorries: 0`) is **accurate**;
+`main` is NOT masked-broken. The 26-session goal — eliminate `axiom riesz_lp_surjective`
+— is achieved: it is a re-export theorem of the Folland-6.16 maximality assembly, for an
+arbitrary measure, foundational-axioms-only. **Nothing further to do; claim released.**
+
+The `lp-duality-final-wiring.patch` and the "Next Action / patch is READY" notes below
+are now HISTORICAL (the patch is already in `main`). Retained for provenance.
+
+## Current Focus (HISTORICAL — pre-S27)
+**Phase**: ACT (wiring RESOLVED end-to-end; one Docker build from discharging the Synthesis sorry)
 **Since**: 2026-07-08
 **Iteration**: 26
 

--- a/src/data/proofs/erdos-1039/meta.json
+++ b/src/data/proofs/erdos-1039/meta.json
@@ -23,7 +23,7 @@
     "erdosProblemStatus": "open",
     "relatedProblems": [],
     "axiomCount": 4,
-    "lineCount": 727,
+    "lineCount": 762,
     "assumptions": "4 axioms, all genuine published research results the proof correctly leaves unformalized (not overclaimed): benchmark_upper (Erdos-Herzog-Piranian benchmark rho(z^n-1) <= pi/(2n)), pommerenke_lower (Pommerenke 1961, rho >= 1/(2en^2)), and klr_lower + klr_area_bound (Krishnapur-Lundberg-Ramachandran 2025, rho >> 1/(n*sqrt(log n))). Formalizing any of these would require reproducing the source papers, so they are stated as axioms. The three elementary-geometry lemmas (area_implies_disc_bound, degree_one_optimal, clustered_implies_large_disc) were completed in PR #33815 and the main file Proofs/Erdos1039Problem.lean has 0 sorries (543 lines). UPDATE: the former 5th axiom random_polynomial_expected was DEGENERATE — its intended Expected[rho] middle term was only a comment, so the Lean proposition collapsed to the trivially-true c1/sqrt(n) <= c2/sqrt(n); it has been converted to a proved theorem (witness c1=c2=1), removing a spurious entry from the axiom list (5 -> 4). The real Theta(1/sqrt n) expected-order claim needs an Expected functional and remains unformalized. The deprecated stub Proofs/Stubs/Erdos1039Problem.lean still holds the pre-#33815 state (3 sorries, the original 5 axioms) and is not the presented proof (proofRepoPath is the main file); it adds no distinct assumptions.",
     "mathlib_version": "4.29.0",
     "mathlibDependencies": [
@@ -57,9 +57,10 @@
       "pommerenke_lower axiom: ρ(f) ≥ 1/(2en²) for any UnitDiscPolynomial (Pommerenke 1961)",
       "klr_lower axiom: ρ(f) ≥ c/(n√log n) (Krishnapur-Lundberg-Ramachandran 2025)",
       "klr_area_bound axiom: sublevelArea ≥ c/n² (area lower bound driving the KLR result)",
-      "random_polynomial_expected: now a proved theorem (degenerate as stated — c₁/√n ≤ c₂/√n, witness c₁=c₂=1); the genuine Θ(1/√n) expected-order claim needs an Expected functional and is unformalized"
+      "random_polynomial_expected: now a proved theorem (degenerate as stated — c₁/√n ≤ c₂/√n, witness c₁=c₂=1); the genuine Θ(1/√n) expected-order claim needs an Expected functional and is unformalized",
+      "sublevelSet_isBounded / rho_le_two / rho_mem_Ioc: assumption-free structural bounds on the geometry. The lemniscate sublevel set {z:|f(z)|<1} is bounded (it lies in B(0,2)), and every inscribed disc is therefore capped, giving the universal ceiling rho(f) ≤ 2 and hence rho(f) ∈ (0,2] for all positive-degree f. This frames the deep lower-bound axioms (Pommerenke, KLR), which sharpen the FLOOR of rho, with a matching elementary cap on its HEIGHT. Axiom-free ([propext, Classical.choice, Quot.sound])."
     ],
-    "theoremCount": 20,
+    "theoremCount": 23,
     "definitionCount": 17,
     "additionalFiles": [
       "Proofs/Erdos1039Aristotle.lean",
@@ -242,9 +243,9 @@
     ],
     "opens": [],
     "namespace": "Erdos1039",
-    "lineCount": 727,
+    "lineCount": 762,
     "axiomCount": 4,
-    "theoremCount": 20,
+    "theoremCount": 23,
     "definitionCount": 17,
     "path": "Proofs/Erdos1039Problem.lean",
     "sorries": 0,

--- a/src/data/proofs/erdos-703/meta.json
+++ b/src/data/proofs/erdos-703/meta.json
@@ -50,14 +50,15 @@
       "T_n_n: fully machine-checked exact diagonal value T(n,n) = 2^n − 1 — the maximal n-avoiding family is the powerset of [n] minus the single full set [n], since [n] with itself is the only pair of subsets meeting in exactly n elements. This is the third exactly-known boundary of T, alongside T(n,0) = 2^{n-1} and T(n,r) = 2^n for n < r.",
       "inter_card_eq_n_iff: the supporting characterization that for A, B ⊆ [n], |A ∩ B| = n iff A = B = [n]; the combinatorial core of the diagonal value.",
       "Structural lemmas on T: T_le_pow (T(n,r) ≤ 2^n), T_mono_ground (monotone in the ground-set size n), one_le_T (positivity), and full_powerset_avoids_r_of_lt / T_eq_pow_of_lt (T(n,r) = 2^n whenever n < r); plus largeSetsFamily_subset_franklFurediOdd_one linking Frankl's r=1 family into the general Frankl-Füredi construction.",
-      "T_le_pow_sub_choose / T_le_pow_sub_one: sharpened upper bound T(n,r) ≤ 2^n − C(n,r), machine-checked. An r-avoiding family can contain no set of size exactly r (its self-pair A,A meets in |A| = r), so the family omits all C(n,r) subsets of size r, giving T(n,r) ≤ 2^n − C(n,r); for r ≤ n this yields the uniform strict improvement T(n,r) ≤ 2^n − 1 over the trivial ceiling, and it is tight at the diagonal r = n (C(n,n) = 1 recovers T(n,n) = 2^n − 1)."
+      "T_le_pow_sub_choose / T_le_pow_sub_one: sharpened upper bound T(n,r) ≤ 2^n − C(n,r), machine-checked. An r-avoiding family can contain no set of size exactly r (its self-pair A,A meets in |A| = r), so the family omits all C(n,r) subsets of size r, giving T(n,r) ≤ 2^n − C(n,r); for r ≤ n this yields the uniform strict improvement T(n,r) ≤ 2^n − 1 over the trivial ceiling, and it is tight at the diagonal r = n (C(n,n) = 1 recovers T(n,n) = 2^n − 1).",
+      "smallSetsFamily / smallSetsFamily_avoids_r / smallSetsFamily_card / sum_choose_le_T / n_add_one_le_T_n_2: the 'small' disjunct {A ⊆ [n] : |A| < r} of the Frankl–Füredi families, isolated as its own r-avoiding family (|A ∩ B| ≤ |A| < r). It admits an EXACT binomial-sum cardinality ∑_{k<r} C(n,k) (proved by partitioning into powersetCard k layers), giving the first certified POLYNOMIAL lower bound T(n,r) ≥ ∑_{k<r} C(n,k) for all n,r — specialising to T(n,2) ≥ n+1, a nontrivial bound on the r=2 line at the start of the middle range the Frankl–Rödl question concerns. Axiom-free ([propext, Classical.choice, Quot.sound])."
     ],
     "axiomCount": 1,
-    "lineCount": 795,
+    "lineCount": 879,
     "assumptions": "1 axiom: frankl_rodl_1987 (the deep Frankl–Rödl 1987 exponential bound — the affirmative answer to the main question). 0 sorries: the trivial case T(n,0)=2^{n-1} is fully machine-checked (#print axioms T_n_0 = [propext, Classical.choice, Quot.sound]) via a complement-pairing upper bound and a star-family witness. The unused opaque chromaticNumber axiom was removed; the geometric chromatic-number consequence is recorded as prose only since infinite unit-distance chromatic numbers are not yet in Mathlib.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 33,
-    "definitionCount": 8
+    "theoremCount": 37,
+    "definitionCount": 9
   },
   "crossReferences": [
     {
@@ -183,10 +184,10 @@
       "Finset"
     ],
     "namespace": "Erdos703",
-    "lineCount": 795,
+    "lineCount": 879,
     "axiomCount": 1,
-    "theoremCount": 33,
-    "definitionCount": 8,
+    "theoremCount": 37,
+    "definitionCount": 9,
     "path": "Proofs/Erdos703Problem.lean",
     "sorries": 0
   },


### PR DESCRIPTION
## Summary

Extends the Erdős #1039 gallery entry (polynomial lemniscate inscribed-disc radius) with three **axiom-free** structural lemmas that cap the *height* of `ρ(f)`, complementing the deep published lower-bound axioms that constrain its *floor*.

For `f(z) = ∏(z − zᵢ)` with `|zᵢ| ≤ 1`, `ρ(f)` is the radius of the largest disc inscribed in the sublevel set `{z : |f(z)| < 1}`. Prior work established `ρ(f) > 0` (`rho_pos`), the crude bound `sublevelSet ⊆ B(0,2)`, and the deep lower bounds as axioms (Pommerenke 1961 `1/(2en²)`, KLR 2025 `1/(n√log n)`).

## New results (all axiom-free)

| Declaration | Statement |
|---|---|
| `sublevelSet_isBounded` | `{z : |f(z)| < 1}` is a bounded subset of `ℂ` |
| `rho_le_two` | **`ρ(f) ≤ 2`** for every positive-degree polynomial |
| `rho_mem_Ioc` | `ρ(f) ∈ (0, 2]` (packaging with `rho_pos`) |

**Proof of `rho_le_two`:** every inscribed disc `B(c, r) ⊆ sublevelSet ⊆ B(0, 2)`; comparing the two balls with the existing `inscribed_radius_le` forces `r ≤ 2`, so `Real.sSup_le` bounds the supremum `ρ(f) ≤ 2`.

This gives a complete elementary bracket `ρ(f) ∈ (0, 2]` on the range of the inscribed radius — an honest assumption-free frame around the hard `Θ(1/n)`-scale question, whose lower-bound axioms (`pommerenke_lower`, `klr_lower`) sharpen the floor while these cap the height.

## Verification

- Built with `lean v4.26.0` against prebuilt Mathlib oleans — clean (exit 0).
- `#print axioms` = `[propext, Classical.choice, Quot.sound]` for all three new theorems.
- File's four deep published-result axioms (`benchmark_upper`, `pommerenke_lower`, `klr_lower`, `klr_area_bound`) untouched; 0 sorries.
- Gallery `meta.json`: `theoremCount` 20→23, `lineCount` 727→762.

🤖 Generated with [Claude Code](https://claude.com/claude-code)