### PR TITLE
research(erdos-3): repair broken chain + SuperSharp reduction (Erdős #3 at N/(log N·log log N·log log log N))

### DIFF
--- a/proofs/Proofs/Erdos3LogHarmonic.lean
+++ b/proofs/Proofs/Erdos3LogHarmonic.lean
@@ -277,13 +277,17 @@ theorem summable_one_div_nat_mul_log_mul_const {c δ : ℝ} (hc : 0 < c) (hδ : 
   have hc2 : (0 : ℝ) < c ^ 2 := by positivity
   -- threshold `N₀` above `2`, `2/c` and `1/c²` (so `m·c ≥ 2` and `m·c² ≥ 1` on the tail)
   set N₀ : ℕ := max 2 (⌈2 / c⌉₊ + ⌈1 / c ^ 2⌉₊) with hN₀def
-  have hN₀2 : (2 : ℝ) ≤ (N₀ : ℝ) := by exact_mod_cast le_max_left 2 (⌈2 / c⌉₊ + ⌈1 / c ^ 2⌉₊)
-  have hN₀2c : 2 / c ≤ (N₀ : ℝ) :=
-    le_trans (Nat.le_ceil _) (by exact_mod_cast le_trans (Nat.le_add_right _ _)
-      (le_max_right 2 (⌈2 / c⌉₊ + ⌈1 / c ^ 2⌉₊)))
-  have hN₀c2 : 1 / c ^ 2 ≤ (N₀ : ℝ) :=
-    le_trans (Nat.le_ceil _) (by exact_mod_cast le_trans (Nat.le_add_left _ _)
-      (le_max_right 2 (⌈2 / c⌉₊ + ⌈1 / c ^ 2⌉₊)))
+  have hN₀2 : (2 : ℝ) ≤ (N₀ : ℝ) := by
+    have h : (2 : ℕ) ≤ N₀ := le_max_left _ _
+    exact_mod_cast h
+  have hN₀2c : 2 / c ≤ (N₀ : ℝ) := by
+    refine (Nat.le_ceil _).trans ?_
+    have h : ⌈2 / c⌉₊ ≤ N₀ := (Nat.le_add_right _ _).trans (le_max_right _ _)
+    exact_mod_cast h
+  have hN₀c2 : 1 / c ^ 2 ≤ (N₀ : ℝ) := by
+    refine (Nat.le_ceil _).trans ?_
+    have h : ⌈1 / c ^ 2⌉₊ ≤ N₀ := (Nat.le_add_left _ _).trans (le_max_right _ _)
+    exact_mod_cast h
   -- dominating series: the constant-free convergent series, shifted and scaled by `2^{1+δ}`
   have hbase : Summable (fun n : ℕ => 1 / ((n : ℝ) * (Real.log n) ^ (1 + δ))) :=
     summable_one_div_nat_mul_log_rpow hδ
@@ -348,13 +352,17 @@ theorem not_summable_one_div_nat_mul_log_mul_const {c : ℝ} (hc : 0 < c) :
   intro hsum
   -- threshold `N₀ ≥ 2`, `≥ c`, `≥ 2/c` (so `m ≥ 2`, `c ≤ m`, `m·c ≥ 2` on the tail)
   set N₀ : ℕ := max 2 (⌈c⌉₊ + ⌈2 / c⌉₊) with hN₀def
-  have hN₀2 : (2 : ℝ) ≤ (N₀ : ℝ) := by exact_mod_cast le_max_left 2 (⌈c⌉₊ + ⌈2 / c⌉₊)
-  have hN₀c : c ≤ (N₀ : ℝ) :=
-    le_trans (Nat.le_ceil _) (by exact_mod_cast le_trans (Nat.le_add_right _ _)
-      (le_max_right 2 (⌈c⌉₊ + ⌈2 / c⌉₊)))
-  have hN₀2c : 2 / c ≤ (N₀ : ℝ) :=
-    le_trans (Nat.le_ceil _) (by exact_mod_cast le_trans (Nat.le_add_left _ _)
-      (le_max_right 2 (⌈c⌉₊ + ⌈2 / c⌉₊)))
+  have hN₀2 : (2 : ℝ) ≤ (N₀ : ℝ) := by
+    have h : (2 : ℕ) ≤ N₀ := le_max_left _ _
+    exact_mod_cast h
+  have hN₀c : c ≤ (N₀ : ℝ) := by
+    refine (Nat.le_ceil _).trans ?_
+    have h : ⌈c⌉₊ ≤ N₀ := (Nat.le_add_right _ _).trans (le_max_right _ _)
+    exact_mod_cast h
+  have hN₀2c : 2 / c ≤ (N₀ : ℝ) := by
+    refine (Nat.le_ceil _).trans ?_
+    have h : ⌈2 / c⌉₊ ≤ N₀ := (Nat.le_add_left _ _).trans (le_max_right _ _)
+    exact_mod_cast h
   -- the given series, shifted past the threshold and scaled by `2`, dominates `1/(n·log n)`
   have hdom : Summable (fun n : ℕ => (2 : ℝ) *
       (1 / (((n + N₀ : ℕ) : ℝ) * Real.log (((n + N₀ : ℕ) : ℝ) * c)))) :=
@@ -745,5 +753,156 @@ theorem summable_one_div_nat_mul_log_mul_loglog_rpow {δ : ℝ} (hδ : 0 < δ) :
   unfold h₄; push_cast; ring
 
 end LoglogConvergent
+
+/-!
+### Constant-in-log second-axis (iterated-log) convergent Bertrand series
+
+`summable_one_div_nat_mul_log_mul_loglog_rpow` (`∑ 1/(n·log n·(log log n)^{1+δ}) < ∞`)
+is the *constant-free* second-axis convergent series.  The Erdős #3 dyadic-blocking
+argument, however, feeds a *multiplicative constant* `c = log 2` into every logarithm
+(because `log 2^{j+1} = (j+1)·log 2`), so the block masses of a hypothetical
+`N/(log N · log log N · (log log log N)^{1+δ})` threshold reduction form the
+**constant-in-log** second-axis series
+
+    ∑ₙ  1 / (n · log (n·c) · (log log (n·c))^{1+δ}).
+
+This lemma supplies its convergence for every `c > 0`, `δ > 0`.  It is the exact
+second-axis analogue of `summable_one_div_nat_mul_log_mul_const` (the *first*-axis
+constant-in-log series that powers `summable_of_sharpBound`), and is precisely the
+analytic input a `SuperSharpRequiredBound` reduction — one iterated logarithm below the
+sharp threshold — would consume.
+
+**Proof.**  A tail comparison against the constant-free
+`summable_one_div_nat_mul_log_mul_loglog_rpow`.  On the tail `n ≥ 64`, `n·c ≥ 3`,
+`n·c² ≥ 1` one has both
+`log n ≤ 2·log(n·c)` (first axis, as in `summable_one_div_nat_mul_log_mul_const`) and
+`log log n ≤ 2·log log(n·c)` (because `log(n·c) ≥ ½·log n` gives
+`log log(n·c) ≥ log log n − log 2`, and `log log n ≥ 2·log 2` on the tail).  Multiplying,
+each term is at most `2·2^{1+δ} = 2^{2+δ}` times the corresponding constant-free term,
+which is summable.
+-/
+
+/-- **Constant-in-log second-axis (iterated-log) convergent Bertrand series.**
+    For every `c > 0` and `δ > 0`, `∑ 1/(n·log(n·c)·(log log(n·c))^{1+δ})` converges.
+    This is the constant-carrying generalisation of
+    `summable_one_div_nat_mul_log_mul_loglog_rpow` (`c = 1`) — the exact second-axis
+    analogue of `summable_one_div_nat_mul_log_mul_const`, and the analytic input the
+    Erdős #3 dyadic-blocking argument needs at the sharper
+    `N/(log N · log log N · (log log log N)^{1+δ})` threshold (with `c = log 2`).
+    Proof: on the tail `n ≥ 64`, `n·c ≥ 3`, `n·c² ≥ 1` each term is `≤ 2^{2+δ}` times the
+    constant-free term (`log n ≤ 2·log(n·c)` and `log log n ≤ 2·log log(n·c)`). -/
+theorem summable_one_div_nat_mul_log_mul_loglog_rpow_const {c δ : ℝ}
+    (hc : 0 < c) (hδ : 0 < δ) :
+    Summable (fun n : ℕ =>
+      1 / ((n : ℝ) * Real.log ((n : ℝ) * c) *
+        (Real.log (Real.log ((n : ℝ) * c))) ^ (1 + δ))) := by
+  have hc2 : (0 : ℝ) < c ^ 2 := by positivity
+  -- threshold `N₀` above `64`, `3/c` and `1/c²`
+  set N₀ : ℕ := max 64 (⌈3 / c⌉₊ + ⌈1 / c ^ 2⌉₊) with hN₀def
+  have hN₀64 : (64 : ℝ) ≤ (N₀ : ℝ) := by
+    have h : (64 : ℕ) ≤ N₀ := le_max_left _ _
+    exact_mod_cast h
+  have hN₀3c : 3 / c ≤ (N₀ : ℝ) := by
+    refine (Nat.le_ceil _).trans ?_
+    have h : ⌈3 / c⌉₊ ≤ N₀ := (Nat.le_add_right _ _).trans (le_max_right _ _)
+    exact_mod_cast h
+  have hN₀c2 : 1 / c ^ 2 ≤ (N₀ : ℝ) := by
+    refine (Nat.le_ceil _).trans ?_
+    have h : ⌈1 / c ^ 2⌉₊ ≤ N₀ := (Nat.le_add_left _ _).trans (le_max_right _ _)
+    exact_mod_cast h
+  -- dominating series: the constant-free second-axis series, shifted and scaled by `2^{2+δ}`
+  have hbase : Summable (fun n : ℕ =>
+      1 / ((n : ℝ) * Real.log n * (Real.log (Real.log n)) ^ (1 + δ))) :=
+    summable_one_div_nat_mul_log_mul_loglog_rpow hδ
+  have hdom : Summable (fun n : ℕ => (2 * (2 : ℝ) ^ (1 + δ)) *
+      (1 / (((n + N₀ : ℕ) : ℝ) * Real.log ((n + N₀ : ℕ) : ℝ) *
+        (Real.log (Real.log ((n + N₀ : ℕ) : ℝ))) ^ (1 + δ)))) :=
+    ((summable_nat_add_iff N₀).mpr hbase).mul_left _
+  apply (summable_nat_add_iff N₀).mp
+  refine Summable.of_nonneg_of_le (fun n => ?_) (fun n => ?_) hdom
+  · -- nonnegativity of the shifted target term
+    set m : ℝ := ((n + N₀ : ℕ) : ℝ) with hm
+    have hmN : (N₀ : ℝ) ≤ m := by rw [hm]; exact_mod_cast Nat.le_add_left N₀ n
+    have hm_pos : 0 < m := by linarith [hN₀64, hmN]
+    have hmc3 : (3 : ℝ) ≤ m * c := (div_le_iff₀ hc).mp (le_trans hN₀3c hmN)
+    have hlogmc1 : 1 < Real.log (m * c) := by
+      rw [Real.lt_log_iff_exp_lt (by linarith : (0 : ℝ) < m * c)]
+      calc Real.exp 1 < 2.7182818286 := Real.exp_one_lt_d9
+        _ ≤ m * c := by linarith
+    have hllmc_nonneg : 0 ≤ Real.log (Real.log (m * c)) := Real.log_nonneg hlogmc1.le
+    have hpow_nonneg : 0 ≤ (Real.log (Real.log (m * c))) ^ (1 + δ) :=
+      Real.rpow_nonneg hllmc_nonneg _
+    have hDt_nonneg : 0 ≤ m * Real.log (m * c) * (Real.log (Real.log (m * c))) ^ (1 + δ) :=
+      mul_nonneg (mul_nonneg hm_pos.le (by linarith [hlogmc1])) hpow_nonneg
+    exact div_nonneg zero_le_one hDt_nonneg
+  · -- termwise domination
+    set m : ℝ := ((n + N₀ : ℕ) : ℝ) with hm
+    have hmN : (N₀ : ℝ) ≤ m := by rw [hm]; exact_mod_cast Nat.le_add_left N₀ n
+    have hm_pos : 0 < m := by linarith [hN₀64, hmN]
+    have hmc3 : (3 : ℝ) ≤ m * c := (div_le_iff₀ hc).mp (le_trans hN₀3c hmN)
+    have hmc2 : (1 : ℝ) ≤ m * c ^ 2 := (div_le_iff₀ hc2).mp (le_trans hN₀c2 hmN)
+    -- first axis: `log m ≤ 2·log(m·c)`
+    have hmc_eq : Real.log (m * c) = Real.log m + Real.log c :=
+      Real.log_mul (ne_of_gt hm_pos) (ne_of_gt hc)
+    have hmc2_eq : Real.log (m * c ^ 2) = Real.log m + 2 * Real.log c := by
+      rw [Real.log_mul (ne_of_gt hm_pos) (by positivity), Real.log_pow]; push_cast; ring
+    have hmc2_nonneg : 0 ≤ Real.log m + 2 * Real.log c := hmc2_eq ▸ Real.log_nonneg hmc2
+    have hcrux : Real.log m ≤ 2 * Real.log (m * c) := by rw [hmc_eq]; linarith
+    -- `log m ≥ 4` on the tail `m ≥ 64` (via `log 64 = 6·log 2`)
+    have hlogm4 : (4 : ℝ) ≤ Real.log m := by
+      have h64m : (64 : ℝ) ≤ m := le_trans hN₀64 hmN
+      have hmono : Real.log 64 ≤ Real.log m := Real.log_le_log (by norm_num) h64m
+      have hlog64 : Real.log 64 = 6 * Real.log 2 := by
+        rw [show (64 : ℝ) = 2 ^ (6 : ℕ) by norm_num, Real.log_pow]; push_cast; ring
+      have hlog2 : (0.6931471803 : ℝ) < Real.log 2 := Real.log_two_gt_d9
+      linarith [hmono, hlog64, hlog2]
+    have hlogm_pos : 0 < Real.log m := by linarith [hlogm4]
+    -- second axis: `log log m ≥ 2·log 2` on the tail
+    have hllm_ge : 2 * Real.log 2 ≤ Real.log (Real.log m) := by
+      have h4log : Real.log 4 ≤ Real.log (Real.log m) := Real.log_le_log (by norm_num) hlogm4
+      have hlog4 : Real.log 4 = 2 * Real.log 2 := by
+        rw [show (4 : ℝ) = 2 ^ (2 : ℕ) by norm_num, Real.log_pow]; push_cast; ring
+      linarith [h4log, hlog4]
+    have hllm_pos : 0 < Real.log (Real.log m) := by
+      have h2 : 0 < Real.log 2 := Real.log_pos (by norm_num)
+      linarith [hllm_ge, h2]
+    have hlogmc_pos : 0 < Real.log (m * c) := by linarith [hcrux, hlogm_pos]
+    -- `log log m ≤ 2·log log(m·c)` from `log(m·c) ≥ ½·log m`
+    have hlogmc_ge : Real.log m / 2 ≤ Real.log (m * c) := by linarith [hcrux]
+    have hlogmhalf_pos : 0 < Real.log m / 2 := by linarith [hlogm_pos]
+    have hllmc_ge : Real.log (Real.log m) - Real.log 2 ≤ Real.log (Real.log (m * c)) := by
+      have hmono : Real.log (Real.log m / 2) ≤ Real.log (Real.log (m * c)) :=
+        Real.log_le_log hlogmhalf_pos hlogmc_ge
+      have hdiv : Real.log (Real.log m / 2) = Real.log (Real.log m) - Real.log 2 :=
+        Real.log_div (ne_of_gt hlogm_pos) (by norm_num)
+      linarith [hmono, hdiv]
+    have hll_double : Real.log (Real.log m) ≤ 2 * Real.log (Real.log (m * c)) := by
+      linarith [hllmc_ge, hllm_ge]
+    have hllmc_pos : 0 < Real.log (Real.log (m * c)) := by linarith [hll_double, hllm_pos]
+    -- lift the second-axis comparison through `(·)^{1+δ}`
+    have hLLpow : (Real.log (Real.log m)) ^ (1 + δ)
+        ≤ (2 : ℝ) ^ (1 + δ) * (Real.log (Real.log (m * c))) ^ (1 + δ) := by
+      calc (Real.log (Real.log m)) ^ (1 + δ)
+          ≤ (2 * Real.log (Real.log (m * c))) ^ (1 + δ) :=
+            Real.rpow_le_rpow hllm_pos.le hll_double (by linarith)
+        _ = (2 : ℝ) ^ (1 + δ) * (Real.log (Real.log (m * c))) ^ (1 + δ) :=
+            Real.mul_rpow (by norm_num) hllmc_pos.le
+    -- positivity of the two composite denominators
+    have hDt_pos : 0 < m * Real.log (m * c) * (Real.log (Real.log (m * c))) ^ (1 + δ) :=
+      mul_pos (mul_pos hm_pos hlogmc_pos) (Real.rpow_pos_of_pos hllmc_pos _)
+    have hDd_pos : 0 < m * Real.log m * (Real.log (Real.log m)) ^ (1 + δ) :=
+      mul_pos (mul_pos hm_pos hlogm_pos) (Real.rpow_pos_of_pos hllm_pos _)
+    rw [mul_one_div, div_le_div_iff₀ hDt_pos hDd_pos, one_mul]
+    have hstep : Real.log m * (Real.log (Real.log m)) ^ (1 + δ)
+        ≤ (2 * Real.log (m * c)) *
+            ((2 : ℝ) ^ (1 + δ) * (Real.log (Real.log (m * c))) ^ (1 + δ)) :=
+      mul_le_mul hcrux hLLpow (Real.rpow_nonneg hllm_pos.le _) (by linarith [hlogmc_pos])
+    calc m * Real.log m * (Real.log (Real.log m)) ^ (1 + δ)
+        = m * (Real.log m * (Real.log (Real.log m)) ^ (1 + δ)) := by ring
+      _ ≤ m * ((2 * Real.log (m * c)) *
+            ((2 : ℝ) ^ (1 + δ) * (Real.log (Real.log (m * c))) ^ (1 + δ))) :=
+          mul_le_mul_of_nonneg_left hstep hm_pos.le
+      _ = (2 * (2 : ℝ) ^ (1 + δ)) *
+            (m * Real.log (m * c) * (Real.log (Real.log (m * c))) ^ (1 + δ)) := by ring
 
 end Erdos3Bertrand

--- a/proofs/Proofs/Erdos3Problem.lean
+++ b/proofs/Proofs/Erdos3Problem.lean
@@ -168,6 +168,25 @@ def SharpRequiredBound (k : ℕ) : Prop :=
   ∃ δ : ℝ, δ > 0 ∧ ∃ C : ℝ, C > 0 ∧ ∀ᶠ N in atTop,
     (rothNumber k N : ℝ) ≤ C * N / (Real.log N * (Real.log (Real.log N)) ^ (1 + δ))
 
+/-- **Super-sharp (double-iterated-log) threshold hypothesis.**
+    `r_k(N) = O(N / (log N · log log N · (log log log N)^{1+δ}))` for some `δ > 0`.
+
+    This sits an *entire iterated logarithm below* `SharpRequiredBound`: for large `N`
+    the denominator `log N · log log N · (log log log N)^{1+δ}` is dominated by
+    `log N · (log log N)^{1+δ'}` (any `δ' > 0`), so
+    `SharpRequiredBound ⇒ SuperSharpRequiredBound` while the converse fails. Yet — as with
+    the sharp bound — this even weaker hypothesis *still* forces a convergent reciprocal sum
+    (`summable_of_superSharpBound`), so it *still* implies Erdős #3
+    (`superSharp_required_bound_implies_conjecture`), pushing the provable sufficient
+    threshold down to `N / (log N · log log N · log log log N)` — one more iterated
+    logarithm toward the open divergence borderline. The analytic engine is the
+    constant-in-log *second-axis* Bertrand series
+    `Erdos3Bertrand.summable_one_div_nat_mul_log_mul_loglog_rpow_const` (with `c = log 2`). -/
+def SuperSharpRequiredBound (k : ℕ) : Prop :=
+  ∃ δ : ℝ, δ > 0 ∧ ∃ C : ℝ, C > 0 ∧ ∀ᶠ N in atTop,
+    (rothNumber k N : ℝ) ≤ C * N /
+      (Real.log N * Real.log (Real.log N) * (Real.log (Real.log (Real.log N))) ^ (1 + δ))
+
 /-- If r_k(N) = o(N / log N) for all k, then the conjecture holds.
 
     OPEN CRUX. See `countingFunction_le_rothNumber` (proved) for the first step and
@@ -920,6 +939,253 @@ theorem sharp_required_bound_implies_conjecture :
           exact_mod_cast countingFunction_le_rothNumber A (max k 3) N hApf
       _ ≤ C * (N : ℝ) / (Real.log N * (Real.log (Real.log N)) ^ (1 + δ)) := hN
   exact hdiv (summable_of_sharpBound hδ hC hcount)
+
+/-- **Super-sharp analytic core of the reduction (double-iterated-log threshold).**
+    If the counting function of `A` obeys
+    `f_A(N) ≤ C · N / (log N · log log N · (log log log N)^{1+δ})` for all large `N`
+    (`δ > 0`), then `∑_{a ∈ A} 1/a` converges. This strengthens `summable_of_sharpBound`:
+    the hypothesis is *weaker* still (its denominator carries an extra `log log N` factor),
+    so the same convergence conclusion says even more.
+
+    Proof by dyadic blocking, exactly as `summable_of_sharpBound`, but the block masses now
+    form the *constant-in-log second-axis* Bertrand series: the reciprocal mass of the block
+    `A ∩ [2^j, 2^{j+1})` is at most
+    `f_A(2^{j+1}) / 2^j ≤ 2C / ((j+1)·log 2 · log((j+1)·log 2) · (log log((j+1)·log 2))^{1+δ})`,
+    the general term of the convergent series
+    `Erdos3Bertrand.summable_one_div_nat_mul_log_mul_loglog_rpow_const` (with `c = log 2`),
+    whose convergence is exactly what makes this even sharper threshold go through. -/
+theorem summable_of_superSharpBound {A : Set ℕ} {C δ : ℝ} (hδ : 0 < δ) (hC : 0 < C)
+    (hbound : ∀ᶠ N in atTop,
+      (countingFunction A N : ℝ)
+        ≤ C * (N : ℝ) / (Real.log N * Real.log (Real.log N) *
+            (Real.log (Real.log (Real.log N))) ^ (1 + δ))) :
+    Summable (fun n : A => (1 : ℝ) / (n : ℝ)) := by
+  classical
+  set F : ℕ → ℝ := fun n => (1 : ℝ) / (n : ℝ) with hF
+  have hlog2 : (0 : ℝ) < Real.log 2 := Real.log_pos (by norm_num)
+  have hlog2gt : (0.6931471803 : ℝ) < Real.log 2 := Real.log_two_gt_d9
+  set K : ℝ := 2 * C / Real.log 2 with hKdef
+  have hKpos : 0 < K := by rw [hKdef]; positivity
+  obtain ⟨N0, hN0⟩ := eventually_atTop.1 hbound
+  -- Effective dyadic threshold: also forces `(j+1)·log 2 > e`, so the inner `log log` is > 0.
+  set Nthr : ℕ := max N0 5 with hNthrdef
+  have hlogpos : ∀ j : ℕ, Nthr ≤ j → 1 < Real.log (((j : ℝ) + 1) * Real.log 2) := by
+    intro j hj
+    have hj5 : (5 : ℕ) ≤ j := le_trans (le_max_right N0 5) hj
+    have hjr : (6 : ℝ) ≤ (j : ℝ) + 1 := by
+      have : (6 : ℕ) ≤ j + 1 := by omega
+      exact_mod_cast this
+    have hxpos : 0 < ((j : ℝ) + 1) * Real.log 2 := mul_pos (by positivity) hlog2
+    rw [Real.lt_log_iff_exp_lt hxpos]
+    have hle : (6 : ℝ) * Real.log 2 ≤ ((j : ℝ) + 1) * Real.log 2 :=
+      mul_le_mul_of_nonneg_right hjr hlog2.le
+    have hexp : Real.exp 1 < 2.7182818286 := Real.exp_one_lt_d9
+    calc Real.exp 1 < 6 * Real.log 2 := by linarith [hlog2gt, hexp]
+      _ ≤ ((j : ℝ) + 1) * Real.log 2 := hle
+  -- The block-mass envelope: the const-in-log second-axis Bertrand term above threshold.
+  set full : ℕ → ℝ :=
+    fun j => K / (((j : ℝ) + 1) * Real.log (((j : ℝ) + 1) * Real.log 2) *
+      (Real.log (Real.log (((j : ℝ) + 1) * Real.log 2))) ^ (1 + δ))
+    with hfulldef
+  have hfullpos : ∀ j : ℕ, Nthr ≤ j → 0 < full j := by
+    intro j hj
+    rw [hfulldef]
+    have hlp : 1 < Real.log (((j : ℝ) + 1) * Real.log 2) := hlogpos j hj
+    have hllp : 0 < Real.log (Real.log (((j : ℝ) + 1) * Real.log 2)) := Real.log_pos hlp
+    have hden : 0 < ((j : ℝ) + 1) * Real.log (((j : ℝ) + 1) * Real.log 2) *
+        (Real.log (Real.log (((j : ℝ) + 1) * Real.log 2))) ^ (1 + δ) :=
+      mul_pos (mul_pos (by positivity) (lt_trans one_pos hlp)) (Real.rpow_pos_of_pos hllp _)
+    exact div_pos hKpos hden
+  set g : ℕ → ℝ := {j : ℕ | Nthr ≤ j}.indicator full with hgdef
+  have hg_nonneg : ∀ j, 0 ≤ g j := by
+    intro j
+    rw [hgdef, Set.indicator_apply]
+    split_ifs with hj
+    · exact (hfullpos j hj).le
+    · exact le_refl 0
+  -- g is summable: `full` is a constant multiple of the convergent second-axis series.
+  have hfull_summable : Summable full := by
+    have hbase := Erdos3Bertrand.summable_one_div_nat_mul_log_mul_loglog_rpow_const
+      (c := Real.log 2) hlog2 hδ
+    have hshift := (summable_nat_add_iff 1).mpr hbase
+    rw [hfulldef]
+    refine (hshift.mul_left K).congr (fun j => ?_)
+    push_cast
+    rw [mul_one_div]
+  have hg_summable : Summable g := by
+    rw [hgdef]
+    refine (summable_nat_add_iff Nthr).mp ?_
+    refine ((summable_nat_add_iff Nthr).mpr hfull_summable).congr (fun n => ?_)
+    exact (Set.indicator_of_mem (Nat.le_add_left Nthr n) full).symm
+  -- Dyadic block masses.
+  set block : ℕ → ℝ := fun j => ∑ i ∈ Finset.Ico (2 ^ j) (2 ^ (j + 1)), A.indicator F i
+    with hblockdef
+  have hterm_le : ∀ j, ∀ i ∈ Finset.Ico (2 ^ j) (2 ^ (j + 1)),
+      A.indicator F i ≤ 1 / (2 : ℝ) ^ j := by
+    intro j i hi
+    rw [Finset.mem_Ico] at hi
+    have h2j : (2 : ℝ) ^ j ≤ (i : ℝ) := by exact_mod_cast hi.1
+    by_cases hmem : i ∈ A
+    · rw [Set.indicator_of_mem hmem, hF]
+      exact one_div_le_one_div_of_le (by positivity) h2j
+    · rw [Set.indicator_of_notMem hmem]; positivity
+  have hcrude : ∀ j, block j ≤ 1 := by
+    intro j
+    simp only [hblockdef]
+    calc ∑ i ∈ Finset.Ico (2 ^ j) (2 ^ (j + 1)), A.indicator F i
+        ≤ ∑ _i ∈ Finset.Ico (2 ^ j) (2 ^ (j + 1)), (1 / (2 : ℝ) ^ j) :=
+          Finset.sum_le_sum (hterm_le j)
+      _ = (Finset.Ico (2 ^ j) (2 ^ (j + 1))).card • (1 / (2 : ℝ) ^ j) := by
+          rw [Finset.sum_const]
+      _ = 1 := by
+          rw [Nat.card_Ico, nsmul_eq_mul]
+          have hsub : 2 ^ (j + 1) - 2 ^ j = 2 ^ j := by rw [pow_succ]; omega
+          rw [hsub, Nat.cast_pow, Nat.cast_ofNat, mul_one_div,
+            div_self (by positivity)]
+  -- Strong bound: for j ≥ Nthr, block mass ≤ g j.
+  have hstrong : ∀ j, Nthr ≤ j → block j ≤ g j := by
+    intro j hj
+    have hgj : g j = full j := by rw [hgdef]; exact Set.indicator_of_mem hj full
+    rw [hgj]
+    have hbe : block j
+        = ∑ i ∈ (Finset.Ico (2 ^ j) (2 ^ (j + 1))).filter (· ∈ A), F i := by
+      simp only [hblockdef, Set.indicator_apply]
+      rw [← Finset.sum_filter]
+    have hN0le : N0 ≤ 2 ^ (j + 1) :=
+      le_trans (le_trans (le_max_left N0 5) hj)
+        (le_trans (Nat.le_succ j) (Nat.le_of_lt Nat.lt_two_pow_self))
+    have hcb := hN0 (2 ^ (j + 1)) hN0le
+    have hcard : ((Finset.Ico (2 ^ j) (2 ^ (j + 1))).filter (· ∈ A)).card
+        ≤ countingFunction A (2 ^ (j + 1)) := by
+      rw [countingFunction]
+      apply Finset.card_le_card
+      intro x hx
+      rw [Finset.mem_filter, Finset.mem_Ico] at hx
+      rw [Finset.mem_filter, Finset.mem_range]
+      exact ⟨by omega, hx.2⟩
+    have hlogval : Real.log ((2 ^ (j + 1) : ℕ) : ℝ) = ((j : ℝ) + 1) * Real.log 2 := by
+      rw [Nat.cast_pow, Nat.cast_ofNat, Real.log_pow]; push_cast; ring
+    have hloglogval : Real.log (Real.log ((2 ^ (j + 1) : ℕ) : ℝ))
+        = Real.log (((j : ℝ) + 1) * Real.log 2) := by rw [hlogval]
+    have hnum : ((2 ^ (j + 1) : ℕ) : ℝ) = (2 : ℝ) ^ j * 2 := by
+      rw [Nat.cast_pow, Nat.cast_ofNat, pow_succ]
+    rw [hbe]
+    calc ∑ i ∈ (Finset.Ico (2 ^ j) (2 ^ (j + 1))).filter (· ∈ A), F i
+        ≤ ∑ _i ∈ (Finset.Ico (2 ^ j) (2 ^ (j + 1))).filter (· ∈ A), (1 / (2 : ℝ) ^ j) := by
+          apply Finset.sum_le_sum
+          intro i hi
+          rw [Finset.mem_filter, Finset.mem_Ico] at hi
+          rw [hF]
+          exact one_div_le_one_div_of_le (by positivity) (by exact_mod_cast hi.1.1)
+      _ = (((Finset.Ico (2 ^ j) (2 ^ (j + 1))).filter (· ∈ A)).card : ℝ) * (1 / (2 : ℝ) ^ j) := by
+          rw [Finset.sum_const, nsmul_eq_mul]
+      _ ≤ (countingFunction A (2 ^ (j + 1)) : ℝ) * (1 / (2 : ℝ) ^ j) := by
+          apply mul_le_mul_of_nonneg_right _ (by positivity)
+          exact_mod_cast hcard
+      _ ≤ (C * ((2 ^ (j + 1) : ℕ) : ℝ)
+            / (Real.log ((2 ^ (j + 1) : ℕ) : ℝ)
+              * Real.log (Real.log ((2 ^ (j + 1) : ℕ) : ℝ))
+              * (Real.log (Real.log (Real.log ((2 ^ (j + 1) : ℕ) : ℝ)))) ^ (1 + δ)))
+            * (1 / (2 : ℝ) ^ j) := by
+          apply mul_le_mul_of_nonneg_right _ (by positivity)
+          exact hcb
+      _ = full j := by
+          rw [hfulldef, hloglogval, hlogval, hnum, hKdef]
+          have ha : (2 : ℝ) ^ j ≠ 0 := by positivity
+          have hb : ((j : ℝ) + 1) ≠ 0 := by positivity
+          have hln2 : Real.log 2 ≠ 0 := ne_of_gt hlog2
+          have hlp : 1 < Real.log (((j : ℝ) + 1) * Real.log 2) := hlogpos j hj
+          have hlp0 : Real.log (((j : ℝ) + 1) * Real.log 2) ≠ 0 :=
+            ne_of_gt (lt_trans one_pos hlp)
+          have hllp : 0 < Real.log (Real.log (((j : ℝ) + 1) * Real.log 2)) := Real.log_pos hlp
+          have hpw : (Real.log (Real.log (((j : ℝ) + 1) * Real.log 2))) ^ (1 + δ) ≠ 0 :=
+            ne_of_gt (Real.rpow_pos_of_pos hllp _)
+          field_simp
+  have hcombine : ∀ j, block j ≤ (if j < Nthr then (1 : ℝ) else 0) + g j := by
+    intro j
+    by_cases hjN : j < Nthr
+    · simp only [hjN, if_true]
+      linarith [hcrude j, hg_nonneg j]
+    · simp only [hjN, if_false, zero_add]
+      exact hstrong j (Nat.le_of_not_lt hjN)
+  have hind0 : A.indicator F 0 = 0 := by simp [Set.indicator_apply, hF]
+  have hdyadic : ∀ J : ℕ, ∑ i ∈ Finset.Ico 1 (2 ^ J), A.indicator F i
+      = ∑ j ∈ Finset.range J, block j := by
+    intro J
+    induction J with
+    | zero => simp
+    | succ J ih =>
+      rw [Finset.sum_range_succ, ← ih]
+      simp only [hblockdef]
+      exact (Finset.sum_Ico_consecutive (A.indicator F)
+        (Nat.one_le_pow J 2 (by norm_num))
+        (Nat.pow_le_pow_right (by norm_num) (Nat.le_succ J))).symm
+  suffices hind : Summable (A.indicator F) by
+    exact summable_subtype_iff_indicator.mpr hind
+  apply summable_of_sum_range_le (c := (Nthr : ℝ) + ∑' j, g j)
+  · intro n
+    exact Set.indicator_nonneg (fun i _ => by rw [hF]; positivity) n
+  · intro M
+    have hsubM : Finset.range M ⊆ Finset.range (2 ^ M) := by
+      intro x hx
+      rw [Finset.mem_range] at hx ⊢
+      exact lt_of_lt_of_le hx (Nat.le_of_lt Nat.lt_two_pow_self)
+    have hle1 : ∑ i ∈ Finset.range M, A.indicator F i
+        ≤ ∑ i ∈ Finset.range (2 ^ M), A.indicator F i := by
+      apply Finset.sum_le_sum_of_subset_of_nonneg hsubM
+      intro i _ _
+      exact Set.indicator_nonneg (fun a _ => by rw [hF]; positivity) i
+    have hsplit : ∑ i ∈ Finset.range (2 ^ M), A.indicator F i
+        = ∑ i ∈ Finset.Ico 1 (2 ^ M), A.indicator F i := by
+      rw [Finset.range_eq_Ico,
+        ← Finset.sum_Ico_consecutive (A.indicator F) (Nat.zero_le 1)
+          (Nat.one_le_pow M 2 (by norm_num)),
+        ← Finset.range_eq_Ico, Finset.sum_range_one, hind0, zero_add]
+    calc ∑ i ∈ Finset.range M, A.indicator F i
+        ≤ ∑ j ∈ Finset.range M, block j := by rw [← hdyadic M, ← hsplit]; exact hle1
+      _ ≤ ∑ j ∈ Finset.range M, ((if j < Nthr then (1 : ℝ) else 0) + g j) :=
+          Finset.sum_le_sum (fun j _ => hcombine j)
+      _ = (∑ j ∈ Finset.range M, (if j < Nthr then (1 : ℝ) else 0))
+            + ∑ j ∈ Finset.range M, g j := by rw [Finset.sum_add_distrib]
+      _ ≤ (Nthr : ℝ) + ∑' j, g j := by
+          apply _root_.add_le_add
+          · rw [Finset.sum_boole]
+            have hsub2 : (Finset.range M).filter (· < Nthr) ⊆ Finset.range Nthr := by
+              intro x hx
+              rw [Finset.mem_filter] at hx
+              exact Finset.mem_range.2 hx.2
+            calc (((Finset.range M).filter (· < Nthr)).card : ℝ)
+                ≤ ((Finset.range Nthr).card : ℝ) := by exact_mod_cast Finset.card_le_card hsub2
+              _ = (Nthr : ℝ) := by rw [Finset.card_range]
+          · exact Summable.sum_le_tsum _ (fun j _ => hg_nonneg j) hg_summable
+
+/-- **The super-sharp reduction goes through at the double-iterated-log threshold.**
+    If `r_k(N) = O(N / (log N · log log N · (log log log N)^{1+δ}))` for some `δ > 0` and
+    every `k ≥ 3` (`SuperSharpRequiredBound`), then Erdős #3 holds. This strictly sharpens
+    `sharp_required_bound_implies_conjecture`: the hypothesis is one further *iterated
+    logarithm* weaker (see `SuperSharpRequiredBound`), yet it still forces a convergent
+    reciprocal sum (`summable_of_superSharpBound`) and hence still implies the conjecture.
+
+    Fully machine-checked, `sorry`-free, axiom-free (it only depends on the verified
+    constant-in-log second-axis Bertrand series
+    `Erdos3Bertrand.summable_one_div_nat_mul_log_mul_loglog_rpow_const`). -/
+theorem superSharp_required_bound_implies_conjecture :
+    (∀ k : ℕ, k ≥ 3 → SuperSharpRequiredBound k) → Erdos3Conjecture := by
+  intro hbound A hdiv k
+  apply containsAP_of_le (le_max_left k 3)
+  by_contra hAPfree
+  have hApf : IsAPFree A (max k 3) := hAPfree
+  obtain ⟨δ, hδ, C, hC, hev⟩ := hbound (max k 3) (le_max_right k 3)
+  have hcount : ∀ᶠ N in atTop,
+      (countingFunction A N : ℝ)
+        ≤ C * (N : ℝ) / (Real.log N * Real.log (Real.log N) *
+            (Real.log (Real.log (Real.log N))) ^ (1 + δ)) := by
+    filter_upwards [hev] with N hN
+    calc (countingFunction A N : ℝ) ≤ (rothNumber (max k 3) N : ℝ) := by
+          exact_mod_cast countingFunction_le_rothNumber A (max k 3) N hApf
+      _ ≤ C * (N : ℝ) / (Real.log N * Real.log (Real.log N) *
+            (Real.log (Real.log (Real.log N))) ^ (1 + δ)) := hN
+  exact hdiv (summable_of_superSharpBound hδ hC hcount)
 
 /-- **Divergent reciprocal sum forces super-`(log)^{1+δ}` density infinitely often.**
     The contrapositive of `summable_of_strongBound`, packaged as a positive density

--- a/proofs/Proofs/Erdos3Problem.lean
+++ b/proofs/Proofs/Erdos3Problem.lean
@@ -785,7 +785,7 @@ theorem summable_of_sharpBound {A : Set ℕ} {C δ : ℝ} (hδ : 0 < δ) (hC : 0
   -- Strong bound: for j ≥ Nthr, block mass ≤ g j.
   have hstrong : ∀ j, Nthr ≤ j → block j ≤ g j := by
     intro j hj
-    have hgj : g j = full j := by rw [hgdef]; exact Set.indicator_of_mem hj
+    have hgj : g j = full j := by rw [hgdef]; exact Set.indicator_of_mem hj full
     rw [hgj]
     have hbe : block j
         = ∑ i ∈ (Finset.Ico (2 ^ j) (2 ^ (j + 1))).filter (· ∈ A), F i := by
@@ -837,7 +837,6 @@ theorem summable_of_sharpBound {A : Set ℕ} {C δ : ℝ} (hδ : 0 < δ) (hC : 0
           have hpw : (Real.log (((j : ℝ) + 1) * Real.log 2)) ^ (1 + δ) ≠ 0 :=
             ne_of_gt (Real.rpow_pos_of_pos hlp _)
           field_simp
-          ring
   -- Combine into a uniform partial-sum bound and conclude summability.
   have hcombine : ∀ j, block j ≤ (if j < Nthr then (1 : ℝ) else 0) + g j := by
     intro j
@@ -921,8 +920,6 @@ theorem sharp_required_bound_implies_conjecture :
           exact_mod_cast countingFunction_le_rothNumber A (max k 3) N hApf
       _ ≤ C * (N : ℝ) / (Real.log N * (Real.log (Real.log N)) ^ (1 + δ)) := hN
   exact hdiv (summable_of_sharpBound hδ hC hcount)
-
-/-- **Divergent reciprocal sum forces super-`(log)^{1+δ}` density infinitely often.**
 
 /-- **Divergent reciprocal sum forces super-`(log)^{1+δ}` density infinitely often.**
     The contrapositive of `summable_of_strongBound`, packaged as a positive density
@@ -1010,7 +1007,7 @@ theorem strongRequiredBound_implies_sharpRequiredBound {k : ℕ}
   have hlog : Filter.Tendsto (fun N : ℕ => Real.log (N : ℝ)) Filter.atTop Filter.atTop :=
     Real.tendsto_log_atTop.comp tendsto_natCast_atTop_atTop
   have hr : (0 : ℝ) < δ / 2 := by linarith
-  have hlittle := (Real.isLittleO_log_rpow_atTop hr).comp_tendsto hlog
+  have hlittle := (isLittleO_log_rpow_atTop hr).comp_tendsto hlog
   have hbound := Asymptotics.isLittleO_iff.mp hlittle (one_pos)
   simp only [Function.comp_apply] at hbound
   have hLgt : ∀ᶠ N : ℕ in Filter.atTop, 1 < Real.log (N : ℝ) :=

--- a/src/data/proofs/erdos-3/meta.json
+++ b/src/data/proofs/erdos-3/meta.json
@@ -249,10 +249,10 @@
       "Finset"
     ],
     "namespace": "Erdos3",
-    "lineCount": 1224,
+    "lineCount": 1487,
     "axiomCount": 0,
-    "theoremCount": 33,
-    "definitionCount": 12,
+    "theoremCount": 35,
+    "definitionCount": 13,
     "path": "Proofs/Erdos3Problem.lean",
     "sorries": 1
   },

--- a/src/data/research/problems/erdos-3-incomplete-01.json
+++ b/src/data/research/problems/erdos-3-incomplete-01.json
@@ -47,7 +47,10 @@
       "SharpRequiredBound + summable_of_sharpBound + sharp_required_bound_implies_conjecture (Erdos3Problem.lean, researcher-1 2026-07-09): strictly-sharper iterated-log conditional reduction at the O(N/(log N·(log log N)^{1+δ})) threshold, one whole iterated log below strong_required_bound_implies_conjecture. Consumes verified Erdos3Bertrand.summable_one_div_nat_mul_log_mul_const (c=log2). Envelope g={j|Nthr≤j}.indicator full handles full's negative small-j terms; Summable g via summable_nat_add_iff tail-shift (Summable.indicator is NNReal-only). Elaboration-mirrors summable_of_strongBound; UNVERIFIED (dep olean-write SIGBUS storm).",
       "REPAIR Erdos3LogHarmonic.lean (researcher-1 2026-07-09): Mathlib drift div_le_div_iff→div_le_div_iff₀, div_le_iff→div_le_iff₀ (lines 299/308/309/329/456). CONFIRMED — Unknown-identifier error eliminated. File had bitrotted; blocks the sharp reduction otherwise.",
       "strongRequiredBound_implies_sharpRequiredBound (Erdos3Problem.lean): StrongRequiredBound k ⇒ SharpRequiredBound k, formalizing the docstring-asserted ordering. Witness δ*=1; denominator comparison L·(log L)^2 ≤ L^{1+δ} reduces to (log log N)^2 ≤ (log N)^δ, proved via Real.isLittleO_log_rpow_atTop at exponent δ/2 then squaring.",
-      "sharpRequiredBound_mono (Erdos3Problem.lean): SharpRequiredBound downward-closed in AP length k, mirroring strongRequiredBound_mono/requiredBound_mono via rothNumber_mono."
+      "sharpRequiredBound_mono (Erdos3Problem.lean): SharpRequiredBound downward-closed in AP length k, mirroring strongRequiredBound_mono/requiredBound_mono via rothNumber_mono.",
+      "summable_one_div_nat_mul_log_mul_loglog_rpow_const (Erdos3LogHarmonic.lean, researcher-7 2026-07-11): const-in-log second-axis convergent Bertrand series ∑1/(n·log(nc)·(loglog(nc))^{1+δ}), c,δ>0. Second-axis analogue of summable_one_div_nat_mul_log_mul_const. Tail comparison vs constant-free summable_one_div_nat_mul_log_mul_loglog_rpow: on n≥64,nc≥3,nc²≥1 use log n≤2log(nc) AND loglog n≤2 loglog(nc) (from log(nc)≥½log n ⇒ loglog(nc)≥loglog n−log2, plus loglog n≥2log2) ⇒ term ≤2^{2+δ}×. 0-sorry, 0-ax.",
+      "SuperSharpRequiredBound + summable_of_superSharpBound + superSharp_required_bound_implies_conjecture (Erdos3Problem.lean, researcher-7 2026-07-11): threshold r_k(N)=O(N/(logN·loglogN·(logloglogN)^{1+δ})) STILL implies Erdős #3, one iterated log below sharp. Dyadic blocking mirrors summable_of_sharpBound; block masses = const-in-log second-axis series (c=log2). VERIFIED axiom-free.",
+      "REPAIR erdos-3 chain (researcher-7 2026-07-11): whole formalization had bitrotted on Mathlib bump — Erdos3LogHarmonic (4 threshold bounds: parse/mod_cast drift) + Erdos3Problem (indicator Zero-mvar, redundant ring, doubled docstring→unterminated comment, isLittleO_log_rpow_atTop root-namespace rename). Both files now compile (only intended open sorry)."
     ],
     "insights": [
       "File did not compile on main (enrichment merged without build): ArithProg map/omega injectivity false for d=0, missing Decidable for Set-membership filters, orphaned /-- docstrings.",
@@ -64,7 +67,8 @@
       "SHARP threshold (researcher-1, 2026-07-09): SharpRequiredBound (r_k=O(N/(log N·(log log N)^{1+δ}))) is STRICTLY WEAKER than StrongRequiredBound yet STILL implies Erdős #3 (summable_of_sharpBound + sharp_required_bound_implies_conjecture). The ordering of sufficient thresholds is Required(o(N/logN), open) ⊋ Sharp(O(N/(logN·(loglogN)^{1+δ})), NEW) ⊋ Strong(O(N/(logN)^{1+δ})); Sharp sits one iterated log below Strong, right at the divergence borderline N/(logN·loglogN). The const-in-log Bertrand series summable_one_div_nat_mul_log_mul_const (c=log2) is precisely the analytic input that makes the sharper dyadic-block masses termwise summable.",
       "GOTCHA (researcher-1): Erdos3LogHarmonic.lean bitrotted on Mathlib drift — div_le_div_iff & div_le_iff were REMOVED (Unknown identifier), replaced by div_le_div_iff₀/div_le_iff₀ (already used elsewhere in the same file). Also: Summable.indicator is NNReal-only; for a general-ℝ indicator with finite complement use (summable_nat_add_iff Nthr).mp to shift past the window onto the summable tail. rpow of a negative base can be negative, so full=K/((j+1)·(log((j+1)log2))^{1+δ}) has negative small-j terms → wrap in {j|Nthr≤j}.indicator.",
       "The three threshold hypotheses are now fully ordered: StrongRequiredBound ⇒ SharpRequiredBound (new) and StrongRequiredBound ⇒ RequiredBound (existing). This certifies sharp_required_bound_implies_conjecture is a genuine sharpening of strong_required_bound_implies_conjecture — its hypothesis is weaker (implied by the strong one), so the sharp reduction applies to strictly more sets.",
-      "Key analytic input for Strong⇒Sharp: (log log N) grows slower than any positive power of log N; formalized by composing Real.isLittleO_log_rpow_atTop (exponent δ/2) with log→∞, extracting the c=1 eventual bound, and raising to the 2nd rpow power (collapse (δ/2)*2=δ by ring)."
+      "Key analytic input for Strong⇒Sharp: (log log N) grows slower than any positive power of log N; formalized by composing Real.isLittleO_log_rpow_atTop (exponent δ/2) with log→∞, extracting the c=1 eventual bound, and raising to the 2nd rpow power (collapse (δ/2)*2=δ by ring).",
+      "The sufficient-threshold ladder now has FOUR rungs: Strong (O(N/(logN)^{1+δ})) ⊋ Sharp (O(N/(logN·(loglogN)^{1+δ}))) ⊋ SuperSharp (O(N/(logN·loglogN·(logloglogN)^{1+δ}))) ⊋ Required (o(N/logN), OPEN). Each rung is a strictly weaker hypothesis that STILL forces a convergent reciprocal sum, hence still implies Erdős #3; the analytic engine drops one iterated logarithm per rung, tracked by the const-in-log Bertrand series on successive log-axes."
     ],
     "mathlibGaps": [],
     "nextSteps": [
@@ -87,15 +91,15 @@
     "mathlib": []
   },
   "started": "2026-04-03T08:27:10.083Z",
-  "lastUpdate": "2026-07-09",
+  "lastUpdate": "2026-07-11",
   "significance": 8,
   "tractability": 4,
   "leanFiles": [
     {
       "path": "Proofs/Erdos3LogHarmonic.lean",
       "filename": "Erdos3LogHarmonic.lean",
-      "lineCount": 501,
-      "theoremCount": 4,
+      "lineCount": 908,
+      "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,
@@ -103,7 +107,7 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos3LogHarmonic.lean"
     }
   ],
-  "progressSummary": "PROGRESS (researcher-1, 2026-07-09): delivered the SHARP iterated-log threshold reduction — SharpRequiredBound k (r_k(N)=O(N/(log N·(log log N)^{1+δ}))), its analytic core summable_of_sharpBound (dyadic blocking whose block masses form the convergent const-in-log Bertrand series Erdos3Bertrand.summable_one_div_nat_mul_log_mul_const, c=log2), and sharp_required_bound_implies_conjecture. This STRICTLY sharpens strong_required_bound_implies_conjecture: the hypothesis is an entire iterated logarithm weaker (log N·(log log N)^{1+δ} vs (log N)^{1+δ}) yet still forces a convergent reciprocal sum, pushing the provable sufficient threshold right up to the divergence borderline N/(log N·log log N). Also repaired Mathlib drift in the dependency Erdos3LogHarmonic.lean (div_le_div_iff/div_le_iff → *₀; CONFIRMED — the Unknown-identifier error disappeared). Build UNVERIFIED end-to-end: both files elaborate cleanly but the Erdos3LogHarmonic olean-write SIGBUS-135'd 15/15 attempts (persistent host storm), so the import olean never wrote and Erdos3Problem never built. All load-bearing lemma names verified vs Mathlib source; proof mirrors the verified summable_of_strongBound.",
+  "progressSummary": "PROGRESS (researcher-7, 2026-07-11): (1) REPAIRED Mathlib drift that had broken the ENTIRE erdos-3 chain (both Erdos3LogHarmonic.lean and Erdos3Problem.lean stopped compiling): multi-line `by exact_mod_cast le_trans(..)\\n(..)` no longer parses + exact_mod_cast no longer folds `max` into `set` var (restructured 4 N0-threshold bounds); `Set.indicator_of_mem` Zero-mvar (supply `full`); redundant `ring` after field_simp; doubled `/--` docstring (unterminated comment); `Real.isLittleO_log_rpow_atTop`->root `isLittleO_log_rpow_atTop`. Chain now compiles (only the intended threshold-critical open sorry). (2) NEW axiom-free lemma `summable_one_div_nat_mul_log_mul_loglog_rpow_const`: const-in-log SECOND-axis convergent Bertrand series ∑1/(n·log(nc)·(loglog(nc))^{1+δ}) (tail comparison, n≥64/nc≥3/nc²≥1 ⇒ ≤2^{2+δ}× const-free). (3) NEW SuperSharpRequiredBound reduction consuming it: def + summable_of_superSharpBound (dyadic blocking) + superSharp_required_bound_implies_conjecture, all VERIFIED axiom-free — pushes the provable sufficient threshold to N/(logN·loglogN·logloglogN), one iterated log below Sharp. Ladder now Strong⊋Sharp⊋SuperSharp(⊋Required, open). VERIFIED lake env lean 0-error, #print axioms=[propext,Classical.choice,Quot.sound].",
   "builtItems": [
     "SharpRequiredBound + summable_of_sharpBound + sharp_required_bound_implies_conjecture (Erdos3Problem.lean, researcher-1 2026-07-09): strictly-sharper iterated-log conditional reduction at the O(N/(log N·(log log N)^{1+δ})) threshold, one whole iterated log below strong_required_bound_implies_conjecture. Consumes verified Erdos3Bertrand.summable_one_div_nat_mul_log_mul_const (c=log2). Envelope g={j|Nthr≤j}.indicator full handles full's negative small-j terms; Summable g via summable_nat_add_iff tail-shift (Summable.indicator is NNReal-only). Elaboration-mirrors summable_of_strongBound; UNVERIFIED (dep olean-write SIGBUS storm).",
     "REPAIR Erdos3LogHarmonic.lean (researcher-1 2026-07-09): Mathlib drift div_le_div_iff→div_le_div_iff₀, div_le_iff→div_le_iff₀ (lines 299/308/309/329/456). CONFIRMED — Unknown-identifier error eliminated. File had bitrotted; blocks the sharp reduction otherwise."


### PR DESCRIPTION
## Summary

Work on **erdos-3-incomplete-01** (Erdős Problem #3, AP-free sets). Two things:

### 1. Repaired the entire (broken) erdos-3 formalization
On a Mathlib bump the whole chain had bitrotted and **no longer compiled**:

- **`Erdos3LogHarmonic.lean`** (4 `N₀`-threshold lemmas): the multi-line
  `by exact_mod_cast le_trans (…) ⏎ (…)` no longer parses (the continuation
  orphans `le_trans`'s 2nd argument → partial application), and `exact_mod_cast`
  no longer folds `max 2 (…)` back into the `set` variable. Restructured all four
  bounds to bind ℕ-level inequalities to `have`s whose expected type pins the
  `set` variable.
- **`Erdos3Problem.lean`**: (i) `Set.indicator_of_mem hj` left the codomain `Zero`
  a metavariable → supply `full`; (ii) `field_simp` now closes the block-mass goal
  so a trailing `ring` had no goals → removed; (iii) a doubled `/--` docstring
  nested an unclosed doc-comment (unterminated comment at EOF) → removed the copy;
  (iv) `Real.isLittleO_log_rpow_atTop` moved to root namespace.

Both files now compile with **only the intended threshold-critical open sorry**
(`required_bound_implies_conjecture`, as hard as Erdős #3 itself).

### 2. New math: the SuperSharp threshold reduction
- **`summable_one_div_nat_mul_log_mul_loglog_rpow_const`** (LogHarmonic): for
  `c, δ > 0`, `∑ 1/(n·log(n·c)·(log log(n·c))^{1+δ})` converges — the
  constant-in-log **second-axis** Bertrand series (the `c=log 2` engine the dyadic
  argument needs). Tail comparison: on `n≥64`, `n·c≥3`, `n·c²≥1` each term is
  `≤ 2^{2+δ}×` the constant-free term.
- **`SuperSharpRequiredBound`** + **`summable_of_superSharpBound`** +
  **`superSharp_required_bound_implies_conjecture`** (Problem): the threshold
  `r_k(N) = O(N/(log N·log log N·(log log log N)^{1+δ}))` — **one whole iterated
  logarithm below the sharp threshold** — *still* forces a convergent reciprocal
  sum and hence *still* implies Erdős #3.

The provable sufficient-threshold ladder now reads
**Strong ⊋ Sharp ⊋ SuperSharp** (⊋ Required, open), each rung one iterated log
closer to the open divergence borderline `N/(log N·log log N)`.

## Verification
- `lake env lean` on both files: **0 errors** (only the documented open sorry).
- `#print axioms` on every new theorem = `[propext, Classical.choice, Quot.sound]`
  (**axiom-free**).

Verified locally (`bin/lake env lean`) against the pinned Mathlib oleans.