### PR TITLE
docs(research): adopt CDC prompt statement-pinning + artifact-only reporting (part of #37505)

### DIFF
--- a/.claude/commands/lean-research.md
+++ b/.claude/commands/lean-research.md
@@ -27,6 +27,26 @@ You are a Lean theorem proving researcher. Run one research iteration on the lea
 - A lemma that filled a gap 3 months ago may be trivial now if stronger results exist
 - When uncertain about significance, default to understating rather than overstating
 
+### Artifact-only reporting (MANDATORY)
+
+A session report must be an **artifact, not a status update**. For any step that
+is not yet machine-checked:
+
+- **Do NOT** call an unproved step "routine", "should follow", "straightforward",
+  "standard", or "clearly true" and count it as done. These words claim progress
+  without evidence.
+- A step counts as done only with a **complete audited artifact** (the lemma
+  elaborates with 0 sorries) — or, if it is not done, report the **strongest
+  rigorously proved derivation plus the exact remaining gap**: the precise lemma
+  statement still to prove, or a documented counterexample/obstruction.
+- "The rest is routine" is acceptable *only* when accompanied by the exact
+  statement of what remains, so the next iteration can pick it up cold.
+
+This mirrors the artifact-only reporting requirement in
+[`research/SORRY-CLASSIFICATION.md`](../../research/SORRY-CLASSIFICATION.md) and
+is adopted from the OpenAI CDC prompt (see issue #37505 and
+<https://cdn.openai.com/pdf/04d1d1e4-bc75-476a-97cf-49055cd98d31/cdc_prompt.pdf>).
+
 ---
 
 ## Quick Reference: Modes
@@ -155,6 +175,26 @@ Invalid: "Verify n=7, 9, 11... and keep going" or "extend to n ≤ 1000".
 3. **Lemma on critical path** - actual progress toward goal
 4. **3-5 examples** - demonstrates pattern works
 5. **More examples** - ZERO additional value after 5
+
+### Pin the Statement Before Attacking (MANDATORY)
+
+Before search begins, confirm the target's `research/problems/<slug>/problem.md`
+has a **"Must prove exactly / does not count"** section (element 5 in
+[`research/PROBLEMS-STRUCTURE.md`](../../research/PROBLEMS-STRUCTURE.md)). If it
+is missing, write it first:
+
+- **Definitional pinning** — resolve every edge case of the formal statement
+  (quantification, boundary/degenerate cases, multiplicity/exactness,
+  connectivity/regularity hypotheses) as one-line assertions the final theorem
+  must satisfy.
+- **Near-misses that do NOT count** — name the partial results and restatements
+  that fail to prove the target (wrong multiplicity, restricted subclass,
+  reduction to another open problem, bounded/finite verification, equivalent
+  same-strength restatement, plus problem-specific traps).
+
+This blocks the most common way a "proof" drifts into a weaker theorem. Adopted
+from the OpenAI CDC prompt (see issue #37505 and
+<https://cdn.openai.com/pdf/04d1d1e4-bc75-476a-97cf-49055cd98d31/cdc_prompt.pdf>).
 
 ### Solved/Unsolved Strategy (MANDATORY)
 

--- a/research/PROBLEMS-STRUCTURE.md
+++ b/research/PROBLEMS-STRUCTURE.md
@@ -43,6 +43,25 @@ The top-level file is a working brief. It must contain at minimum:
    `other`) so claim files can reference it.
 4. **Connections** — neighboring problems, both in the gallery and in the
    literature.
+5. **Must prove exactly / does not count** — pin the target so a proof cannot
+   drift into a weaker statement. This section has two parts:
+   - **Definitional pinning.** Resolve every edge case of the formal statement
+     *before* search begins: which objects are quantified over, boundary and
+     degenerate cases, multiplicity/exactness conditions, connectivity or
+     regularity hypotheses — anything a proof could silently weaken. State each
+     as a one-line assertion the final theorem must satisfy.
+   - **Near-misses that do NOT count.** List, by name, the known partial results
+     and restatements that fail to prove the target, so the next iteration does
+     not mistake one for a win. Cover the standard failure families where they
+     apply: wrong multiplicity/exactness, a restricted subclass, reduction to
+     another open problem, bounded/finite verification, and equivalent
+     restatement of the same-strength claim. Add problem-specific traps.
+
+   This convention is adopted from the OpenAI CDC research prompt's "pin the
+   statement + fence off near-misses" technique (see issue #37505 and
+   <https://cdn.openai.com/pdf/04d1d1e4-bc75-476a-97cf-49055cd98d31/cdc_prompt.pdf>).
+   It applies to problem.md files created going forward; existing files are not
+   retroactively required to add it.
 
 Style is functional; this is a working file, not a publication artifact.
 

--- a/research/SORRY-CLASSIFICATION.md
+++ b/research/SORRY-CLASSIFICATION.md
@@ -778,6 +778,27 @@ When the Aristotle wrapper completes a Tier-3 run, `write-run-artifact.sh`
 drops a stub claim file in `research/problems/<slug>/claims/` so that the
 Aristotle agent and the Researcher agent share the same memory.
 
+### Artifact-only session reports
+
+A `summary.md` or claim file is an **artifact, not a status update**. It must
+let the next iteration pick the work up cold, which rules out vague optimism
+about unproved steps.
+
+- **Reject "routine", "should follow", "straightforward", "standard", "clearly
+  true"** as a way of marking an unproved step done. These phrases claim
+  progress without evidence.
+- A step is done only with a **complete audited artifact** — the lemma
+  elaborates with 0 sorries. Otherwise report the **strongest rigorously proved
+  derivation plus the exact remaining gap**: the precise statement of the lemma
+  still to prove, or a documented counterexample / obstruction.
+- "The rest is routine" is allowed *only* alongside the exact statement of what
+  remains, so no reader has to reconstruct the missing step from optimism.
+
+This is the same rule stated for researcher session output in
+[`.claude/commands/lean-research.md`](../.claude/commands/lean-research.md)
+(`## Honesty Standards`), adopted from the OpenAI CDC prompt (see issue #37505
+and <https://cdn.openai.com/pdf/04d1d1e4-bc75-476a-97cf-49055cd98d31/cdc_prompt.pdf>).
+
 ## Open conjectures: when to use Tier 3 vs `axiom`
 
 > **Policy reversal (2026-06-09, issue #22628).**


### PR DESCRIPTION
Part of #37505 — implements the curated **first-PR scope (checkboxes 1 + 6 only)**. Both are pure documentation/convention changes; no data migration, no code paths touched.

## Checkbox 1 — problem.md "Must prove exactly / does not count"

- `research/PROBLEMS-STRUCTURE.md` `## problem.md`: adds a required 5th element after Statement/Current state/Attack vectors/Connections, with two parts:
  - **Definitional pinning** — resolve every formal-statement edge case (quantification, boundary/degenerate cases, multiplicity/exactness, connectivity/regularity) as one-line assertions the final theorem must satisfy.
  - **Near-misses that do NOT count** — name the partial results/restatements that fail to prove the target (wrong multiplicity, restricted subclass, reduction to another open problem, bounded/finite verification, equivalent same-strength restatement, plus problem-specific traps).
  - Marked as applying to problem.md files created going forward (no retroactive requirement), consistent with the doc's existing "optional additions" stance.
- `.claude/commands/lean-research.md`: new **"Pin the Statement Before Attacking (MANDATORY)"** step ahead of the Solved/Unsolved Strategy, requiring the researcher to confirm/write that section before search begins, and referencing `PROBLEMS-STRUCTURE.md`.

## Checkbox 6 — artifact-only session reports

- `.claude/commands/lean-research.md` `## Honesty Standards`: new **"Artifact-only reporting (MANDATORY)"** rule rejecting "routine"/"should follow"/"straightforward"/"standard"/"clearly true" as a way to mark an unproved step done. A step counts only with a complete audited artifact (0 sorries) or the strongest rigorously proved derivation plus the exact remaining gap (precise lemma statement or documented counterexample/obstruction).
- `research/SORRY-CLASSIFICATION.md`: parallel **"Artifact-only session reports"** subsection under the OODA-loop substrate (the honesty-rules / end-of-session-report sections referenced in the issue no longer exist in the current file; this is their current natural home). Cross-linked to `lean-research.md`.

Every added block cites issue #37505 and the CDC prompt PDF for provenance.

## Deferred (NOT in this PR)

Checkboxes 2 (equivalent-strength OQ-spawn check), 3 (blocked-route registry — schema migration), 4 (per-problem adversarial checklists — scoping decision), 5 (independence preservation — new orchestration design). No `src/data/research/problems/*.json`, `lean-auditor.md`, `peer-review.md`, or multi-researcher orchestration files touched.

## Notes on stale line numbers

The issue body's line references (~801 in lean-research.md; 479-503/498-503 in SORRY-CLASSIFICATION.md) predate recent doc evolution — those exact sections have moved/been removed. Edits were placed in the current equivalent homes and all three cross-links were verified to resolve.

## Test plan

- Docs-only; no code path exercises these files. Relative markdown links verified to resolve on disk.
- Manual read confirms each new rule gives an unambiguous bar (named failure families / required artifact), not a restatement of "be honest".

🤖 Generated with [Claude Code](https://claude.com/claude-code)