### PR TITLE
research(cauchy-schwarz-integral-oq-04): literal Δx·Δp ≥ ℏ/2 standard-deviation form [VERIFIED axiom-free]

### DIFF
--- a/proofs/Proofs/CauchySchwarzIntegralOQ04.lean
+++ b/proofs/Proofs/CauchySchwarzIntegralOQ04.lean
@@ -30,6 +30,9 @@
     `¼‖⟪ψ,[A,B]ψ⟫‖² + (Re⟪u,v⟫)² ≤ ‖(A−a)ψ‖²·‖(B−b)ψ‖²` (via the Gram form).
   * `robertson_of_schrodinger` — Robertson recovered by dropping the covariance term.
   * `heisenberg_variance_form` — the same at `a = ⟨A⟩`, `b = ⟨B⟩` (variance form).
+  * `robertson_std_form` / `heisenberg_std_form` / `heisenberg_canonical_std` — the
+    literal *standard-deviation* form `Δx·Δp ≥ ½‖⟪[A,B]⟫‖`, i.e. `Δx·Δp ≥ ℏ/2`,
+    obtained by taking square roots of the (squared) variance bounds above.
 
   All results are fully machine-checked (0 axioms, 0 sorries).
 
@@ -529,6 +532,80 @@ theorem heisenberg_canonical {A B : E →ₗ[𝕜] E} (hA : A.IsSymmetric)
   have h := robertson_canonical hA hB ψ (RCLike.re (inner 𝕜 ψ (A ψ)))
     (RCLike.re (inner 𝕜 ψ (B ψ))) c hc
   rwa [hψ, one_pow, mul_one] at h
+
+/-! ## The literal `Δx·Δp ≥ ℏ/2` (product-of-standard-deviations form)
+
+All the results above are stated in the **squared / variance** form
+`Var(A)·Var(B) ≥ ¼‖⟪ψ,[A,B]ψ⟫‖²`.  The Heisenberg principle is more often written in
+its **standard-deviation** form `Δx·Δp ≥ ℏ/2`, i.e. with the square roots taken:
+
+  `‖(A−a)ψ‖·‖(B−b)ψ‖ ≥ ½·‖⟪ψ,[A,B]ψ⟫‖`.
+
+Since both sides are nonnegative, this is *equivalent* to `robertson_uncertainty`,
+obtained by taking `Real.sqrt` of both sides (`Real.sqrt_sq` on the nonnegative
+squared quantities).  We record it explicitly because it is the form that appears
+in physics texts and that the OQ-04 prompt literally asks for. -/
+
+/-- **Robertson uncertainty relation, standard-deviation form.**  The un-squared
+`Δx·Δp ≥ ½|⟪[A,B]⟫|`: for symmetric `A, B`, any state `ψ` and any real shifts `a, b`,
+
+  `½·‖⟪ψ, (AB−BA)ψ⟫‖ ≤ ‖(A−a)ψ‖·‖(B−b)ψ‖`.
+
+This is `robertson_uncertainty` with the square roots taken (both sides are
+nonnegative), the physically standard `Δx·Δp ≥ ℏ/2` shape. -/
+theorem robertson_std_form {A B : E →ₗ[𝕜] E} (hA : A.IsSymmetric)
+    (hB : B.IsSymmetric) (ψ : E) (a b : ℝ) :
+    (1 / 2 : ℝ) * ‖inner 𝕜 ψ (A (B ψ) - B (A ψ))‖
+      ≤ ‖A ψ - (a : 𝕜) • ψ‖ * ‖B ψ - (b : 𝕜) • ψ‖ := by
+  have hrob := robertson_uncertainty hA hB ψ a b
+  have hl : (0 : ℝ) ≤ (1 / 2 : ℝ) * ‖inner 𝕜 ψ (A (B ψ) - B (A ψ))‖ := by positivity
+  have hr : (0 : ℝ) ≤ ‖A ψ - (a : 𝕜) • ψ‖ * ‖B ψ - (b : 𝕜) • ψ‖ :=
+    mul_nonneg (norm_nonneg _) (norm_nonneg _)
+  have key : ((1 / 2 : ℝ) * ‖inner 𝕜 ψ (A (B ψ) - B (A ψ))‖) ^ 2
+      ≤ (‖A ψ - (a : 𝕜) • ψ‖ * ‖B ψ - (b : 𝕜) • ψ‖) ^ 2 := by
+    nlinarith [hrob]
+  calc (1 / 2 : ℝ) * ‖inner 𝕜 ψ (A (B ψ) - B (A ψ))‖
+      = Real.sqrt (((1 / 2 : ℝ) * ‖inner 𝕜 ψ (A (B ψ) - B (A ψ))‖) ^ 2) :=
+        (Real.sqrt_sq hl).symm
+    _ ≤ Real.sqrt ((‖A ψ - (a : 𝕜) • ψ‖ * ‖B ψ - (b : 𝕜) • ψ‖) ^ 2) :=
+        Real.sqrt_le_sqrt key
+    _ = ‖A ψ - (a : 𝕜) • ψ‖ * ‖B ψ - (b : 𝕜) • ψ‖ := Real.sqrt_sq hr
+
+/-- **Heisenberg uncertainty principle, standard-deviation form.**  Instantiating
+`robertson_std_form` at the expectation values `⟨A⟩ = Re⟪ψ,Aψ⟫`, `⟨B⟩ = Re⟪ψ,Bψ⟫`
+makes each factor the standard deviation `Δ_ψ A = ‖(A−⟨A⟩)ψ‖`, `Δ_ψ B = ‖(B−⟨B⟩)ψ‖`,
+giving the physically standard
+
+  `Δ_ψ(A)·Δ_ψ(B) ≥ ½·‖⟪ψ, (AB−BA)ψ⟫‖`. -/
+theorem heisenberg_std_form {A B : E →ₗ[𝕜] E} (hA : A.IsSymmetric)
+    (hB : B.IsSymmetric) (ψ : E) :
+    (1 / 2 : ℝ) * ‖inner 𝕜 ψ (A (B ψ) - B (A ψ))‖
+      ≤ ‖A ψ - ((RCLike.re (inner 𝕜 ψ (A ψ)) : ℝ) : 𝕜) • ψ‖
+        * ‖B ψ - ((RCLike.re (inner 𝕜 ψ (B ψ)) : ℝ) : 𝕜) • ψ‖ :=
+  robertson_std_form hA hB ψ (RCLike.re (inner 𝕜 ψ (A ψ)))
+    (RCLike.re (inner 𝕜 ψ (B ψ)))
+
+/-- **The literal `Δx·Δp ≥ ℏ/2`.**  For a normalized state `‖ψ‖ = 1` obeying a canonical
+commutation relation `(AB − BA)ψ = c • ψ` (abstractly `[x, p] = iℏ`, so `‖c‖ = ℏ`), the
+product of standard deviations is bounded below by `½‖c‖`:
+
+  `Δ_ψ(A)·Δ_ψ(B) ≥ ½‖c‖`.
+
+For `‖c‖ = ℏ` this is exactly Heisenberg's `Δx·Δp ≥ ℏ/2` — the un-squared form of
+`heisenberg_canonical`, obtained from `robertson_std_form` since the commutator
+expectation is `⟪ψ, (AB−BA)ψ⟫ = c‖ψ‖² = c`. -/
+theorem heisenberg_canonical_std {A B : E →ₗ[𝕜] E} (hA : A.IsSymmetric)
+    (hB : B.IsSymmetric) (ψ : E) (hψ : ‖ψ‖ = 1) (c : 𝕜)
+    (hc : A (B ψ) - B (A ψ) = c • ψ) :
+    ‖c‖ / 2
+      ≤ ‖A ψ - ((RCLike.re (inner 𝕜 ψ (A ψ)) : ℝ) : 𝕜) • ψ‖
+        * ‖B ψ - ((RCLike.re (inner 𝕜 ψ (B ψ)) : ℝ) : 𝕜) • ψ‖ := by
+  have h := heisenberg_std_form hA hB ψ
+  have hnorm : ‖inner 𝕜 ψ (A (B ψ) - B (A ψ))‖ = ‖c‖ := by
+    rw [hc, inner_smul_right, norm_mul, inner_self_eq_norm_sq_to_K, norm_pow,
+      RCLike.norm_ofReal, abs_of_nonneg (norm_nonneg ψ), hψ, one_pow, mul_one]
+  rw [hnorm] at h
+  linarith [h]
 
 end CauchySchwarzIntegralOQ04
 

--- a/research/problems/cauchy-schwarz-integral-oq-04/knowledge.md
+++ b/research/problems/cauchy-schwarz-integral-oq-04/knowledge.md
@@ -1,3 +1,36 @@
+## Session 2026-07-11 (researcher-2) — VERIFIED axiom-free + literal Δx·Δp ≥ ℏ/2 (standard-deviation form)
+
+Two developments this session on `CauchySchwarzIntegralOQ04.lean`:
+
+**(1) BUILD VERIFIED (finally).** Every prior OQ04 session (researcher-1/3/4) marked the
+file BUILD: UNVERIFIED because the Docker image build died at a containerd metadata I/O
+error. This session confirmed the file elaborates **axiom-free** via the Docker-free path
+`proofs/bin/lake env lean File.lean` against the prebuilt Mathlib oleans (5.3G .lake). All
+key theorems (`robertson_uncertainty`, `heisenberg_canonical`, `gram_eq_iff_parallel`,
+`exists_im_inner_sq_saturated`, `im_inner_smul_saturated_iff`, ...) depend only on
+`[propext, Classical.choice, Quot.sound]`. The 22 pre-existing theorems are all genuinely
+verified — the accumulated UNVERIFIED backlog was purely an operator-docker artifact.
+
+**(2) New content — the literal standard-deviation form.** The whole file stated only the
+*squared* (variance) bound `Var(A)·Var(B) ≥ ¼‖⟪[A,B]⟫‖²`; the OQ-04 prompt literally asks
+for `Δx·Δp ≥ ℏ/2` (product of standard deviations). Added three theorems, 535→~600 lines:
+- `robertson_std_form`: `½‖⟪ψ,(AB−BA)ψ⟫‖ ≤ ‖(A−a)ψ‖·‖(B−b)ψ‖` — the un-squared Robertson
+  bound. Proof: `Real.sqrt` of both sides of `robertson_uncertainty`; `key : lhs² ≤ rhs²`
+  closes by `nlinarith [hrob]` (ring-normalizes `(½x)²=¼x²` and `(‖u‖‖v‖)²=‖u‖²‖v‖²`), then
+  a `calc` chain `x = √(x²) ≤ √(y²) = y` via `Real.sqrt_sq` (nonneg) + `Real.sqrt_le_sqrt`.
+- `heisenberg_std_form`: same at `a=⟨A⟩=Re⟪ψ,Aψ⟫`, `b=⟨B⟩` → `Δ_ψ(A)·Δ_ψ(B) ≥ ½‖⟪[A,B]⟫‖`.
+- `heisenberg_canonical_std`: for unit `ψ` with `(AB−BA)ψ = c•ψ`, the literal
+  `Δ_ψ(A)·Δ_ψ(B) ≥ ‖c‖/2` (= `Δx·Δp ≥ ℏ/2` at `‖c‖=ℏ`). `hnorm : ‖⟪ψ,[A,B]ψ⟫‖ = ‖c‖` via
+  `inner_smul_right`, `inner_self_eq_norm_sq_to_K`, `RCLike.norm_ofReal`, `hψ`.
+All three VERIFIED axiom-free (bin/lake env lean, `#print axioms` = foundational only).
+
+Note: gallery slug `cauchy-schwarz-integral` tracks the PARENT file, not this OQ04 research
+file (confirmed: no src/data/proofs meta references CauchySchwarzIntegralOQ04.lean), so no
+gallery resync needed. The file is now essentially at TERMINUS: squared + std forms,
+Robertson + Schrödinger + canonical, saturation characterization + attainability witness.
+
+---
+
 ## Session 2026-07-10 (researcher-4) — ATTAINABILITY: the Heisenberg bound is sharp (nonempty saturating set)
 
 Added `im_inner_I_smul_saturated` and `exists_im_inner_sq_saturated` to


### PR DESCRIPTION
## Summary

Adds the **literal `Δx·Δp ≥ ℏ/2`** (product-of-standard-deviations) form of the Heisenberg uncertainty principle to `CauchySchwarzIntegralOQ04.lean`, and confirms the whole file is **verified axiom-free**.

The file already proved the uncertainty principle in **squared / variance** form (`Var(A)·Var(B) ≥ ¼‖⟪[A,B]⟫‖²`). But the OQ-04 prompt literally asks to formalize `Δx·Δp ≥ ℏ/2` — the *un-squared* product of standard deviations — which was absent. This PR fills that gap.

## New theorems (all axiom-free)

- **`robertson_std_form`** — `½‖⟪ψ,(AB−BA)ψ⟫‖ ≤ ‖(A−a)ψ‖·‖(B−b)ψ‖`, the un-squared Robertson bound for symmetric `A,B` and any real shifts `a,b`.
- **`heisenberg_std_form`** — at the expectation values `a=⟨A⟩=Re⟪ψ,Aψ⟫`, `b=⟨B⟩`: `Δ_ψ(A)·Δ_ψ(B) ≥ ½‖⟪[A,B]⟫‖`.
- **`heisenberg_canonical_std`** — for a unit state `‖ψ‖=1` with a canonical commutation relation `(AB−BA)ψ = c•ψ`: the literal `Δ_ψ(A)·Δ_ψ(B) ≥ ‖c‖/2` (i.e. `Δx·Δp ≥ ℏ/2` at `‖c‖=ℏ`).

Proof: take `Real.sqrt` of the already-verified squared bounds (`robertson_uncertainty`, etc.); both sides are nonnegative so `Real.sqrt_sq` + `Real.sqrt_le_sqrt` recover the un-squared inequality.

## Verification

Elaborated via the Docker-free path `proofs/bin/lake env lean` against the prebuilt Mathlib oleans. `#print axioms` on all three new theorems (and spot-checks across the pre-existing 22) shows only the foundational `[propext, Classical.choice, Quot.sound]` — **no `sorry`, no `axiom`**.

This also resolves the accumulated **UNVERIFIED** backlog on this file: prior sessions could not build it because of an operator-level containerd I/O error (not a Lean error). The file is confirmed sound.

## Notes

- Gallery slug `cauchy-schwarz-integral` tracks the parent `CauchySchwarzIntegral.lean`, not this research file — no gallery resync needed.
- File `535 → ~600` lines, `22 → 25` theorems.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
