### PR TITLE
research(erdos-748-incomplete-01): Part VI unconditional lower half of log-asymptotic [VERIFIED axiom-free]

### DIFF
--- a/proofs/Proofs/Erdos748Problem.lean
+++ b/proofs/Proofs/Erdos748Problem.lean
@@ -764,6 +764,59 @@ theorem erdos_748_summary :
   · obtain ⟨ce, co, hce, hco, _⟩ := precise_asymptotic
     exact ⟨ce, co, hce, hco⟩
 
+/-!
+## Part VI: The lower half of the log-asymptotic is unconditional
+
+The Cameron–Erdős conjecture `cameronErdosConjecture` is a two-sided estimate on
+`log₂ (f n) = Real.log (f n) / Real.log 2`. Its upper half needs the deep Green/Sapozhenko
+input (the axiom `green_upper_bound`). Its **lower** half, however, is elementary: the
+sharp counting bound `sharp_lower_bound` (`f n ≥ 2^⌈n/2⌉`) gives `log₂ (f n) ≥ ⌈n/2⌉ ≥ n/2`
+with no axiom at all — and it holds for *every* `n`, not merely eventually. The theorems
+below isolate this axiom-free lower half.
+-/
+
+/-- **Unconditional log₂ lower bound.**  For every `n`, `log₂ (f n) ≥ n/2`.  Taking the
+base-2 logarithm of the sharp counting bound `f n ≥ 2^⌈n/2⌉` (`sharp_lower_bound`) and
+using `⌈n/2⌉ = (n+1)/2 ≥ n/2`.  Axiom-free: the lower half of the Cameron–Erdős asymptotic
+needs none of the Green/Sapozhenko machinery. -/
+theorem logDiv_log_two_f_ge (n : ℕ) :
+    (n : ℝ) / 2 ≤ Real.log (f n) / Real.log 2 := by
+  have hlog2 : 0 < Real.log 2 := Real.log_pos (by norm_num)
+  -- real-cast lower bound on `f n`
+  have hfge : (2 : ℝ) ^ ((n + 1) / 2) ≤ (f n : ℝ) := by
+    have h := sharp_lower_bound n
+    calc (2 : ℝ) ^ ((n + 1) / 2) = ((2 ^ ((n + 1) / 2) : ℕ) : ℝ) := by push_cast; ring
+      _ ≤ (f n : ℝ) := by exact_mod_cast h
+  have hfpos : (0 : ℝ) < f n := lt_of_lt_of_le (by positivity) hfge
+  -- log of the power bound
+  have hloglb : ((n + 1) / 2 : ℕ) * Real.log 2 ≤ Real.log (f n) := by
+    calc ((n + 1) / 2 : ℕ) * Real.log 2
+          = Real.log ((2 : ℝ) ^ ((n + 1) / 2)) := by rw [Real.log_pow]
+      _ ≤ Real.log (f n) := Real.log_le_log (by positivity) hfge
+  -- `n/2 ≤ ⌈n/2⌉ = (n+1)/2` as reals
+  have hceil : (n : ℝ) / 2 ≤ ((n + 1) / 2 : ℕ) := by
+    have h2 : n ≤ 2 * ((n + 1) / 2) := by omega
+    have : (n : ℝ) ≤ 2 * (((n + 1) / 2 : ℕ) : ℝ) := by exact_mod_cast h2
+    linarith
+  rw [le_div_iff₀ hlog2]
+  calc (n : ℝ) / 2 * Real.log 2
+        ≤ ((n + 1) / 2 : ℕ) * Real.log 2 :=
+          mul_le_mul_of_nonneg_right hceil (le_of_lt hlog2)
+    _ ≤ Real.log (f n) := hloglb
+
+/-- **The Cameron–Erdős lower bound, unconditionally and for all `n`.**  The lower conjunct
+of `cameronErdosConjecture` — `(1 − ε)·(n/2) ≤ log₂ (f n)` — holds for *every* `ε > 0` and
+*every* `n`, with no threshold `N` and no axiom.  It follows from the exact bound
+`log₂ (f n) ≥ n/2` (`logDiv_log_two_f_ge`) since `(1 − ε)·(n/2) ≤ n/2`.  So only the upper
+half of the conjecture carries the Green/Sapozhenko content. -/
+theorem cameronErdos_lower_unconditional {ε : ℝ} (hε : 0 < ε) (n : ℕ) :
+    (1 - ε) * (n / 2 : ℝ) ≤ Real.log (f n) / Real.log 2 := by
+  have hhalf : (0 : ℝ) ≤ (n / 2 : ℝ) := by positivity
+  calc (1 - ε) * (n / 2 : ℝ)
+        ≤ 1 * (n / 2 : ℝ) := mul_le_mul_of_nonneg_right (by linarith) hhalf
+    _ = (n / 2 : ℝ) := one_mul _
+    _ ≤ Real.log (f n) / Real.log 2 := logDiv_log_two_f_ge n
+
 /--
 **Erdős Problem #748: PROVED**
 -/

--- a/research/problems/erdos-748-incomplete-01/state.md
+++ b/research/problems/erdos-748-incomplete-01/state.md
@@ -2,8 +2,20 @@
 
 **Phase**: ACT
 **Since**: 2026-06-25T00:00:00Z
-**Attempts**: 2
+**Attempts**: 3
 **Status**: in-progress
+
+Attempt 3 (researcher-9, 2026-07-11, VERIFIED offline): added **Part VI — the lower half
+of the log-asymptotic is unconditional** (2 axiom-free theorems):
+- `logDiv_log_two_f_ge (n) : (n:ℝ)/2 ≤ Real.log (f n) / Real.log 2` — taking log₂ of
+  `sharp_lower_bound` (`f n ≥ 2^⌈n/2⌉`) gives `log₂(f n) ≥ ⌈n/2⌉ ≥ n/2`. `Real.log_pow`,
+  `Real.log_le_log`, `le_div_iff₀`; `⌈n/2⌉=(n+1)/2≥n/2` via omega+cast.
+- `cameronErdos_lower_unconditional (hε) (n) : (1-ε)*(n/2) ≤ log₂(f n)` — the LOWER conjunct
+  of `cameronErdosConjecture` holds for EVERY ε>0 and EVERY n (no threshold N, no axiom),
+  since `(1-ε)(n/2) ≤ n/2 ≤ log₂(f n)`. Only the UPPER half carries the Green/Sapozhenko axioms.
+Both depend only on `[propext, Classical.choice, Quot.sound]` (confirmed `#print axioms`),
+NOT `green_upper_bound`/`precise_asymptotic`. File 772→825 lines, theoremCount 27→29, 0 sorries,
+2 axioms unchanged. Verified `bin/lake env lean` EXIT 0.
 
 Attempt 2 (researcher-9): added `sharp_lower_bound : f n ≥ 2^⌈n/2⌉` (0 axioms),
 sharpening `trivial_lower_bound` (which only used `2^⌊n/2⌋`). The upper half

--- a/src/data/proofs/erdos-748/meta.json
+++ b/src/data/proofs/erdos-748/meta.json
@@ -182,9 +182,9 @@
       "Finset"
     ],
     "namespace": "Erdos748",
-    "lineCount": 772,
+    "lineCount": 825,
     "axiomCount": 2,
-    "theoremCount": 27,
+    "theoremCount": 29,
     "definitionCount": 5,
     "path": "Proofs/Erdos748Problem.lean",
     "sorries": 0,


### PR DESCRIPTION
## Summary

Adds **Part VI** to `Erdos748Problem.lean` (Cameron–Erdős conjecture on sum-free sets). The conjecture `cameronErdosConjecture` is a two-sided estimate on `log₂ (f n)`; its upper half needs the deep Green/Sapozhenko input (the axioms `green_upper_bound` / `precise_asymptotic`), but its **lower half is elementary and unconditional**. Two axiom-free theorems isolate that.

## New theorems (axiom-free)

- **`logDiv_log_two_f_ge`** — for every `n`, `n/2 ≤ log₂ (f n)`. Take the base-2 logarithm of the sharp counting bound `f n ≥ 2^⌈n/2⌉` (`sharp_lower_bound`) and use `⌈n/2⌉ = (n+1)/2 ≥ n/2`.
- **`cameronErdos_lower_unconditional`** — the lower conjunct `(1 − ε)·(n/2) ≤ log₂ (f n)` of `cameronErdosConjecture` holds for *every* `ε > 0` and *every* `n` (no threshold `N`, no axiom), since `(1 − ε)·(n/2) ≤ n/2 ≤ log₂ (f n)`. Only the upper half carries the Green/Sapozhenko content.

## Verification

- File `772 → 825` lines, `27 → 29` theorems, **0 sorries**, **2 axioms** (Green/Sapozhenko, unchanged and uninvolved).
- `#print axioms`: both new theorems depend only on `[propext, Classical.choice, Quot.sound]` — **not** on `green_upper_bound` / `precise_asymptotic`.
- Verified by full offline Mathlib elaboration (`bin/lake env lean Proofs/Erdos748Problem.lean`, EXIT 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)