### PR TITLE
research(collatz-structured-oq-02-oq-03): orbit-minimum characterization of reaching 1

### DIFF
--- a/proofs/Proofs/CollatzStructuredOQ02OQ03.lean
+++ b/proofs/Proofs/CollatzStructuredOQ02OQ03.lean
@@ -1154,6 +1154,52 @@ stops. -/
 theorem colMin_one : colMin 1 = 1 :=
   colMin_eq_self_iff.mpr not_attainsBelow_one
 
+/-- The orbit of `0` is constantly `0`: `collatz 0 = 0 / 2 = 0`, so no iterate of `0`
+is ever positive.  This is the degenerate companion of `collatz_iterate_pos` (which keeps
+`0` out of every *positive* orbit) and is exactly what forces a start that reaches `1`
+to be positive. -/
+theorem collatz_iterate_zero (k : ℕ) : collatz^[k] 0 = 0 := by
+  induction k with
+  | zero => rfl
+  | succ k ih => rw [Function.iterate_succ_apply', ih]; simp [collatz]
+
+/-- **The orbit minimum is `1` exactly when the trajectory reaches `1`.**  The Collatz
+conjecture asserts every positive integer eventually reaches `1`; this lemma re-expresses
+that terminal event through the file's central object, the orbit minimum:
+`colMin n = 1 ↔ ∃ k, collatz^[k] n = 1`.  Forward, `1` is the *attained* minimum, so it
+literally occurs on the orbit (`colMin_mem_orbit`).  Backward, an orbit value `1` forces
+the start positive — the orbit of `0` is constantly `0` (`collatz_iterate_zero`) — whence
+`1 ≤ colMin n ≤ 1` by `colMin_pos` and `colMin_le_iterate`.  So `colMin n = 1` is precisely
+the statement "the Collatz conjecture holds for `n`", pinning the conjecture to a single
+value of the orbit minimum. -/
+theorem colMin_eq_one_iff_reaches_one {n : ℕ} :
+    colMin n = 1 ↔ ∃ k, collatz^[k] n = 1 := by
+  constructor
+  · intro h
+    obtain ⟨k, hk⟩ := colMin_mem_orbit n
+    exact ⟨k, by rw [hk, h]⟩
+  · rintro ⟨k, hk⟩
+    have hn : 0 < n := by
+      rcases Nat.eq_zero_or_pos n with h0 | hpos
+      · rw [h0, collatz_iterate_zero k] at hk; omega
+      · exact hpos
+    have hle : colMin n ≤ 1 := by rw [← hk]; exact colMin_le_iterate n k
+    have hpos := colMin_pos hn
+    omega
+
+/-- **Collatz conjecture, orbit-minimum form.**  The Collatz conjecture ("every positive
+integer reaches `1`") is *equivalent* to the assertion that every positive integer has
+orbit minimum exactly `1`:
+`(∀ n, 0 < n → ∃ k, collatz^[k] n = 1) ↔ (∀ n, 0 < n → colMin n = 1)`.  This is the global
+package of the per-`n` characterization `colMin_eq_one_iff_reaches_one`, recasting the whole
+conjecture as a statement purely about `colMin` — the same object whose *strict* drop
+`colMin n < n` this file certifies for `115/128` of the integers. -/
+theorem collatz_conjecture_iff_colMin_eq_one :
+    (∀ n, 0 < n → ∃ k, collatz^[k] n = 1) ↔ (∀ n, 0 < n → colMin n = 1) := by
+  constructor
+  · intro h n hn; exact colMin_eq_one_iff_reaches_one.mpr (h n hn)
+  · intro h n hn; exact colMin_eq_one_iff_reaches_one.mp (h n hn)
+
 /-- Consequently the entire three-quarters family of Part II — the even numbers
 and the odd class `1 + 4ℕ` (`n ≥ 5`) — has orbit minimum strictly below the start,
 unconditionally and without Tao's axiom. -/

--- a/src/data/proofs/collatz-structured-oq-02-oq-03/meta.json
+++ b/src/data/proofs/collatz-structured-oq-02-oq-03/meta.json
@@ -20,7 +20,7 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 1,
-    "lineCount": 2093,
+    "lineCount": 2139,
     "assumptions": "1 axiom: tao_2019 — the precise statement of Tao (2019, Forum Math. Pi), that for every f : ℕ → ℝ with f n → ∞ the set {n : 0 < n ∧ Col_min(n) < f n} has logarithmic density one. This is the deep analytic result the open question asks about; it is recorded, not proved, because its proof (3-adic transport/concentration estimates plus a Fourier-analytic input) is far beyond current Mathlib. No theorem in the file is derived from this axiom — the proven Parts II–III are independently machine-verified and depend only on the standard foundational axioms propext / Classical.choice / Quot.sound.",
     "dateAdded": "2026-06-25",
     "mathlib_version": "4.26.0",
@@ -138,9 +138,9 @@
       "Mathlib"
     ],
     "namespace": "CollatzStructuredOQ02OQ03",
-    "lineCount": 2093,
+    "lineCount": 2139,
     "axiomCount": 1,
-    "theoremCount": 79,
+    "theoremCount": 82,
     "path": "Proofs/CollatzStructuredOQ02OQ03.lean",
     "sorries": 0,
     "definitionCount": 14
@@ -168,6 +168,12 @@
       "type": "theorem",
       "statement": "For all b, N: (#{r < 2^b : autoDropCert b r}) · (N-1) ≤ #{n ∈ [1, 2^b·N] : AttainsBelow n}.",
       "significance": "Unifies the two halves of the file: the general residue-density lemma fed by the fully-auto certificate engine. A new modulus level 2^b now yields a density floor with no new proof — the good-residue count is a single decide and each drop is discharged by autoDropCert_attainsBelow. Axiom-free (decide, not native_decide)."
+    },
+    {
+      "name": "colMin_eq_one_iff_reaches_one",
+      "type": "theorem",
+      "statement": "For all n: colMin n = 1 ↔ ∃ k, collatz^[k] n = 1.",
+      "significance": "Pins the Collatz conjecture to a single value of the orbit minimum: colMin n = 1 is exactly the statement that the trajectory of n reaches 1. Backward direction uses that the orbit of 0 is constantly 0 (collatz_iterate_zero), forcing a reaching start to be positive. Packaged globally as collatz_conjecture_iff_colMin_eq_one: the whole conjecture ⟺ ∀ n>0, colMin n = 1. Axiom-free (foundational axioms only)."
     }
   ]
 }


### PR DESCRIPTION
## Summary

Extends the saturated Collatz almost-all feasibility anchor (`CollatzStructuredOQ02OQ03.lean`) with an axiom-free bridge that ties the file's central object — the **orbit minimum** `colMin` — directly to the Collatz conjecture statement.

The file already certifies the *strict drop* `colMin n < n` for 115/128 of the integers. This PR pins down the *terminal* event `colMin n = 1`:

- **`collatz_iterate_zero`** — the orbit of `0` is constantly `0` (`collatz 0 = 0/2 = 0`); the degenerate companion of `collatz_iterate_pos`, and exactly what forces a start that reaches `1` to be positive.
- **`colMin_eq_one_iff_reaches_one`** — `colMin n = 1 ↔ ∃ k, collatz^[k] n = 1`. The orbit minimum equals `1` **exactly when** the trajectory reaches `1` — so `colMin n = 1` is precisely "the Collatz conjecture holds for `n`". Forward: `1` is the *attained* minimum (`colMin_mem_orbit`). Backward: an orbit value `1` forces `n > 0` (via `collatz_iterate_zero`), whence `1 ≤ colMin n ≤ 1` by `colMin_pos`/`colMin_le_iterate`.
- **`collatz_conjecture_iff_colMin_eq_one`** — global package: the Collatz conjecture (every positive `n` reaches `1`) ⟺ `∀ n > 0, colMin n = 1`. Recasts the whole conjecture as a statement purely about `colMin`.

## Verification

- `lake env lean Proofs/CollatzStructuredOQ02OQ03.lean` → **exit 0**, no errors/sorries.
- `#print axioms` on all three new theorems → `[propext, Classical.choice, Quot.sound]` only (no `tao_2019`, no `Lean.ofReduceBool`, no `sorryAx`).
- Counts: 79→82 theorems, 2093→2139 lines. `axiomCount` unchanged (1: `tao_2019`, untouched by the new content). meta.json updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)