### PR TITLE
research(feuerbachs-theorem-oq-04): bundle spherical model as a MetricSpace instance [VERIFIED axiom-free]

### DIFF
--- a/proofs/Proofs/FeuerbachsTheoremOQ04Metric.lean
+++ b/proofs/Proofs/FeuerbachsTheoremOQ04Metric.lean
@@ -1,0 +1,68 @@
+import Proofs.FeuerbachsTheoremOQ04
+
+/-
+# The spherical model as a bundled `MetricSpace`  (Feuerbach OQ-04, continued)
+
+`FeuerbachsTheoremOQ04.lean` proves `sdist_isMetric`: the spherical distance
+`sdist P Q = arccos ⟪P, Q⟫` satisfies all four metric-space axioms on model points
+(unit vectors).  Its docstring notes that "packaging this as a bundled `MetricSpace`
+instance would only additionally require carving the sphere out as a subtype".
+
+This file does exactly that.  It defines the spherical model `SphereModel E` as the
+subtype of unit vectors and registers a genuine `MetricSpace (SphereModel E)`
+instance whose `dist` is `sdist`, drawing each field from the corresponding lemma of
+`FeuerbachsTheoremOQ04` (`sdist_self`, `sdist_comm`, `sdist_triangle`,
+`sdist_eq_zero_iff`).  This turns the four-axiom conjunction into an actual typeclass
+instance, so the spherical model can be used with Mathlib's entire metric-space API
+(balls, `Metric.sphere`, continuity, `Bornology`, uniformity, …) rather than only the
+bare `sdist` lemmas.
+
+Two immediate consequences are recorded: the distance formula `dist P Q =
+arccos ⟪P, Q⟫` (definitional, `rfl`) and the diameter bound `dist P Q ≤ π` (the
+spherical model has diameter `π`, attained at antipodal points).
+
+Axiom-free (`propext`/`Classical.choice`/`Quot.sound` only): no `native_decide`, no
+`sorry`, no `axiom`.
+-/
+
+namespace FeuerbachsTheoremOQ04
+
+open scoped RealInnerProductSpace
+
+variable {E : Type*} [NormedAddCommGroup E] [InnerProductSpace ℝ E]
+
+/-- The **spherical model**: the subtype of unit vectors of `E` (`OnSphere P : ‖P‖ = 1`).
+This is the carrier on which `sdist` is a genuine metric. -/
+def SphereModel (E : Type*) [NormedAddCommGroup E] [InnerProductSpace ℝ E] : Type _ :=
+  {P : E // OnSphere P}
+
+namespace SphereModel
+
+instance : CoeOut (SphereModel E) E := ⟨Subtype.val⟩
+
+/-- **The spherical model is a metric space** with `dist = sdist`.  Each axiom is
+supplied by the corresponding `sdist_*` lemma of `FeuerbachsTheoremOQ04`; the
+`edist`/uniformity/bornology fields take their canonical defaults derived from `dist`. -/
+noncomputable instance instMetricSpace : MetricSpace (SphereModel E) where
+  dist P Q := sdist P.1 Q.1
+  dist_self P := sdist_self P.1 P.2
+  dist_comm P Q := sdist_comm P.1 Q.1
+  dist_triangle P Q R := sdist_triangle P.2 Q.2 R.2
+  eq_of_dist_eq_zero {P Q} h := Subtype.ext ((sdist_eq_zero_iff P.2 Q.2).mp h)
+
+/-- The metric-space `dist` on the spherical model is definitionally `sdist`. -/
+@[simp] theorem dist_eq (P Q : SphereModel E) : dist P Q = sdist P.1 Q.1 := rfl
+
+/-- Unfolded distance formula: `dist P Q = arccos ⟪P, Q⟫`. -/
+theorem dist_eq_arccos (P Q : SphereModel E) :
+    dist P Q = Real.arccos ⟪(P : E), (Q : E)⟫ := rfl
+
+/-- **Diameter bound.**  Every spherical distance is at most `π`; the spherical model
+has diameter `π` (attained at antipodal points).  Immediate from `arccos ≤ π`. -/
+theorem dist_le_pi (P Q : SphereModel E) : dist P Q ≤ Real.pi := by
+  rw [dist_eq_arccos]
+  exact Real.arccos_le_pi _
+
+end SphereModel
+
+end FeuerbachsTheoremOQ04

--- a/src/data/research/problems/feuerbachs-theorem-oq-04.json
+++ b/src/data/research/problems/feuerbachs-theorem-oq-04.json
@@ -21,7 +21,7 @@
   "currentState": {
     "phase": "ACT",
     "since": "2026-06-28T10:40:00.000Z",
-    "iteration": 3,
+    "iteration": 4,
     "focus": "Spherical circles (level sets of scos) + internal/external tangency relations formalized on top of the metric layer; level-set circle identified with the metric circle (mem_sCircle_iff_sdist).",
     "blockers": [],
     "nextAction": "Tangent-point existence: exhibit the unique common point on the geodesic between centres for tangent circles (spherical slerp) and verify it lies on both sCircles; then build spherical incircle / nine-point circle and attempt the spherical Feuerbach tangency.",
@@ -32,7 +32,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: side-midpoint API rounded out with geodesic-membership (span{A,B}) and self-midpoint lemmas; frontier remains the Feuerbach tangency (nine-point circle ↔ incircle/excircles).",
+    "progressSummary": "SHIPPED bundled MetricSpace instance (researcher-11, 2026-07-11, VERIFIED axiom-free): new FeuerbachsTheoremOQ04Metric.lean turns sdist_isMetric's four-axiom conjunction into an actual typeclass instance. Defines SphereModel E := {P : E // OnSphere P} (unit-vector subtype) and registers `noncomputable instance MetricSpace (SphereModel E)` with dist = sdist (arccos of inner product), each field drawn from sdist_self/sdist_comm/sdist_triangle/sdist_eq_zero_iff; edist/uniformity/bornology take canonical dist-derived defaults. So the spherical model now plugs into Mathlib's full metric-space API (balls, Metric.sphere, continuity, bornology, uniformity). Records dist_eq (rfl to sdist), dist_eq_arccos, and diameter bound dist_le_pi (dist P Q <= pi via Real.arccos_le_pi). #print axioms: instance + dist_le_pi [propext,Classical.choice,Quot.sound] only. Closes nextStep #1 (bundle S^n as a MetricSpace instance). || PRIOR: PROGRESS: side-midpoint API rounded out with geodesic-membership (span{A,B}) and self-midpoint lemmas; frontier remains the Feuerbach tangency (nine-point circle ↔ incircle/excircles).",
     "builtItems": [
       "FeuerbachsTheoremOQ04.chord_sq (Proofs/FeuerbachsTheoremOQ04.lean) — chord-cosine bridge: for unit vectors, ||P-Q||^2 = 2 - 2*scos P Q; turns spherical tangency into an inner-product equation. 0-axiom.",
       "FeuerbachsTheoremOQ04.abs_scos_le_one/scos_le_one/neg_one_le_scos — spherical cosine in [-1,1] (Cauchy-Schwarz on unit vectors)",
@@ -56,7 +56,8 @@
       "sphericalIncircle_contact_points — incircle meets each of the 3 sides in exactly one point (explicit feet)",
       "sphericalCircumcircle_exists in FeuerbachsTheoremOQ04Circumcircle.lean: any three model points lie on a common sCircle O rho (circumcircle), via greatCircles_inter on poles A-B, B-C. [VERIFIED, 0-axiom]",
       "sphericalCircumcircle_equidistant + inner_sub_eq_zero_iff_scos_eq in FeuerbachsTheoremOQ04Circumcircle.lean: circumcentre is spherically equidistant sdist A O = sdist B O = sdist C O. [VERIFIED, 0-axiom]",
-      "sMidpoint_self (degenerate midpoint sMidpoint A A = A) + sMidpoint_mem_span (midpoint lies in span{A,B}, i.e. on the geodesic through A,B) in FeuerbachsTheoremOQ04Midpoint.lean"
+      "sMidpoint_self (degenerate midpoint sMidpoint A A = A) + sMidpoint_mem_span (midpoint lies in span{A,B}, i.e. on the geodesic through A,B) in FeuerbachsTheoremOQ04Midpoint.lean",
+      "FeuerbachsTheoremOQ04Metric.lean: SphereModel E subtype + noncomputable MetricSpace instance (dist=sdist) from sdist_isMetric components + dist_eq/dist_eq_arccos/dist_le_pi. 0-axiom VERIFIED."
     ],
     "insights": [
       "Mathlib has clean spherical geometry for free (unit vectors of any InnerProductSpace R E; geodesic distance = arccos of inner product) but essentially no hyperbolic metric, so the spherical model is the tractable non-Euclidean route for Feuerbach.",
@@ -73,7 +74,6 @@
       "No spherical-triangle incircle / nine-point-circle construction in Mathlib; must be built on scos/sdist."
     ],
     "nextSteps": [
-      "Bundle (S^n, sdist) as an actual Mathlib MetricSpace instance on the sphere subtype (sdist_isMetric supplies all four axioms; the remaining work is the subtype packaging).",
       "Tangent-point existence for tangent spherical circles (slerp midpoint on the geodesic between centres), using sdist_triangle for the betweenness/uniqueness argument.",
       "Construct the spherical incircle and nine-point circle for a spherical triangle, then attempt the tangency conclusion.",
       "Relate the common tangent direction to a spherical Feuerbach configuration (incircle/nine-point-analogue tangency) building on the contact-point tangent structure.",


### PR DESCRIPTION
## Summary

Adds **`FeuerbachsTheoremOQ04Metric.lean`** (0 sorry, 0 axiom, verified) to open question OQ-04 (Feuerbach's theorem in spherical geometry). `FeuerbachsTheoremOQ04.lean` proves `sdist_isMetric` — that `sdist P Q = arccos ⟪P, Q⟫` satisfies all four metric-space axioms on unit vectors — and its docstring notes that bundling this "would only additionally require carving the sphere out as a subtype." This PR does exactly that (closing next-step #1).

## Contents

- **`SphereModel E := {P : E // OnSphere P}`** — the spherical model as the unit-vector subtype.
- **`instance MetricSpace (SphereModel E)`** with `dist = sdist`, each field supplied by the corresponding lemma (`sdist_self`, `sdist_comm`, `sdist_triangle`, `sdist_eq_zero_iff`); `edist`/uniformity/bornology take the canonical `dist`-derived defaults. The spherical model now plugs into Mathlib's entire metric-space API (balls, `Metric.sphere`, continuity, `Bornology`, uniformity) rather than the bare `sdist` lemmas.
- **`dist_eq`** (`rfl` to `sdist`), **`dist_eq_arccos`**, and the diameter bound **`dist_le_pi`** (`dist P Q ≤ π`, via `Real.arccos_le_pi`).

## Verification

`#print axioms` confirms the instance and `dist_le_pi` depend only on `[propext, Classical.choice, Quot.sound]`. Verified with `lake env lean` against prebuilt Mathlib oleans; 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)