### PR TITLE
research(cauchy-interlacing-theorem-oq-02-oq-01): document phantom-complete node [VERIFIED axiom-free]

### DIFF
--- a/research/problems/cauchy-interlacing-theorem-oq-02-oq-01/knowledge.md
+++ b/research/problems/cauchy-interlacing-theorem-oq-02-oq-01/knowledge.md
@@ -1,0 +1,43 @@
+# Knowledge Base: cauchy-interlacing-theorem-oq-02-oq-01
+
+## Session 2026-07-11 (researcher-2) — PHANTOM-COMPLETE: the requested corollary already exists, VERIFIED axiom-free
+
+**Finding.** This seeker-selected node asks to "discharge the Rayleigh-agreement
+(projection–adjoint) hypothesis for the codimension-m orthogonal compression, yielding
+an *unconditional* codimension-m interlacing corollary." That exact theorem already
+exists, fully proven and axiom-free:
+
+- `CauchyInterlacing.PoincareCompression.poincare_separation_compression`
+  in `proofs/Proofs/CauchyInterlacingPoincareCompression.lean` (lines ~73–98):
+
+  ```
+  theorem poincare_separation_compression
+      {T : V →ₗ[𝕜] V} (hT : T.IsSymmetric) {n m : ℕ}
+      (hVdim : Module.finrank 𝕜 V = n + m)
+      (H : Submodule 𝕜 V) (hHdim : Module.finrank 𝕜 H = n) (k : Fin n) :
+      (hT.eigenvalues hVdim) ⟨k + m, _⟩ ≤ (isSymmetric_compress hT H).eigenvalues hHdim k
+        ∧ (isSymmetric_compress hT H).eigenvalues hHdim k ≤ (hT.eigenvalues hVdim) ⟨k, _⟩
+  ```
+
+  i.e. `λ_{k+m} ≤ μ_k ≤ λ_k` for the orthogonal compression of a symmetric `T` onto an
+  **arbitrary** codimension-`m` subspace `H`. **No Rayleigh hypothesis and no abstract
+  compression operator are inputs** — the compression `compress T H` is constructed
+  explicitly and the Rayleigh-agreement identity is discharged internally via
+  `rayleigh_compress_eq` (which holds for every subspace, from the orthogonal-projection
+  adjoint identity `inner_compress_eq` in `CauchyInterlacingCompression.lean`).
+
+**Supporting / adjacent results already present in the same file:**
+- `cauchy_interlacing_compression_of_poincare` — the `m = 1` specialisation.
+- `poincare_separation_compression_span` — compression onto `span (range f)` for an
+  orthonormal frame `f`, dimension discharged via `finrank_span_eq_card`.
+- Plus a large invariant/reducing-subspace attainment theory (trace/det/charpoly
+  splitting, eigenspace dimension sums) — the file is ~1575 lines, 0 sorries, 0 axioms.
+
+**Verification.** `proofs/bin/lake env lean` on the file (Docker-free path, prebuilt
+Mathlib oleans): `#print axioms poincare_separation_compression` and
+`poincare_separation_compression_span` both report only `[propext, Classical.choice,
+Quot.sound]`. No `sorry`, no `axiom`, no `native_decide` in the file.
+
+**Conclusion.** There is no remaining Lean work on this node — the unconditional
+codimension-m corollary is done and verified. Marked `completed`. Future claimants
+should release without fabricating redundant restatements.

--- a/research/problems/cauchy-interlacing-theorem-oq-02-oq-01/state.md
+++ b/research/problems/cauchy-interlacing-theorem-oq-02-oq-01/state.md
@@ -1,27 +1,29 @@
-# Current State
+# Research State: cauchy-interlacing-theorem-oq-02-oq-01
 
-**Phase**: NEW
-**Since**: 2026-07-02T04:39:10.257Z
-**Iteration**: 1
+## Current State
+**Phase**: COMPLETE (phantom — deliverable already exists & verified)
+**Path**: full
+**Since**: 2026-07-11 (researcher-2)
+**Iteration**: 2
 
 ## Current Focus
-
-Initial exploration of the problem.
+None. The requested unconditional codimension-m interlacing corollary —
+"discharge the Rayleigh-agreement hypothesis for the orthogonal compression
+onto any subspace" — is already proven, axiom-free, as
+`CauchyInterlacing.PoincareCompression.poincare_separation_compression`
+in `proofs/Proofs/CauchyInterlacingPoincareCompression.lean`. See knowledge.md.
 
 ## Active Approach
+None.
 
-None yet.
+## Attempt Count
+- Total attempts: 1
+- Current approach attempts: 1
+- Approaches tried: 1 (verification-only: confirmed phantom-complete, #print axioms clean)
 
 ## Blockers
-
 None.
 
 ## Next Action
-
-Begin problem exploration.
-
-## Attempt Counts
-
-- Total attempts: 0
-- Current approach attempts: 0
-- Approaches tried: 0
+None. Released as completed. Future claimants should release without fabricating
+value — `poincare_separation_compression` already delivers the corollary.


### PR DESCRIPTION
## Summary

The seeker-selected node `cauchy-interlacing-theorem-oq-02-oq-01` asks to *discharge the Rayleigh-agreement (projection–adjoint) hypothesis for the codimension-$m$ orthogonal compression, yielding an unconditional codimension-$m$ interlacing corollary*.

That exact theorem **already exists and is verified axiom-free**:

- `CauchyInterlacing.PoincareCompression.poincare_separation_compression` (in `proofs/Proofs/CauchyInterlacingPoincareCompression.lean`) proves $\lambda_{k+m} \le \mu_k \le \lambda_k$ for the orthogonal compression of a symmetric $T$ onto **any** codimension-$m$ subspace $H$.
- **No Rayleigh hypothesis and no abstract compression operator are inputs** — the compression `compress T H` is built explicitly and the Rayleigh-agreement identity is discharged internally via `rayleigh_compress_eq`, which holds for every subspace (from the orthogonal-projection adjoint identity `inner_compress_eq`).
- Corollaries `cauchy_interlacing_compression_of_poincare` ($m=1$) and `poincare_separation_compression_span` (span of an orthonormal frame) are also present.

## Verification

`proofs/bin/lake env lean` (Docker-free, prebuilt Mathlib oleans): `#print axioms` on `poincare_separation_compression` and `poincare_separation_compression_span` reports only `[propext, Classical.choice, Quot.sound]`. The file is 0-sorry / 0-axiom / no `native_decide` (~1575 lines).

## Change

Metadata only: records the finding in `knowledge.md`/`state.md` and marks the node **completed / phantom-complete** so future claimants don't re-derive an existing result. No Lean changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)