### PR TITLE
research(erdos-1008-oq-02-oq-02): n-direction monotonicity of exact K_{2,t} KST bound [VERIFIED axiom-free]

### DIFF
--- a/proofs/Proofs/Erdos1008OQ02OQ02.lean
+++ b/proofs/Proofs/Erdos1008OQ02OQ02.lean
@@ -527,6 +527,43 @@ theorem kst_exact_bound_mono_t (t t' : ℕ) (htt' : t ≤ t') (n : ℝ) (hn : 1 
   have hsqrt := Real.sqrt_le_sqrt harg
   exact mul_le_mul_of_nonneg_left (by linarith) (by linarith)
 
+/-- **Monotonicity of the exact KST bound in `n`.**  For fixed `t ≥ 1` and `1 ≤ n ≤ n'`
+the Reiman/KST right-hand side is non-decreasing in the vertex count `n`:
+
+      n · (1 + √(1 + 4(t-1)(n-1)))  ≤  n' · (1 + √(1 + 4(t-1)(n'-1))).
+
+Both factors grow: the leading `n ≤ n'`, and the radicand `1 + 4(t-1)(n-1)` increases
+with `n` because `(t-1) ≥ 0`, so its `√` increases; the product of two nonnegative
+non-decreasing factors is non-decreasing.  This is the `n`-companion of
+`kst_exact_bound_mono_t`, recording that the extremal count `ex(n ; K_{2,t})` grows with
+the number of vertices. -/
+theorem kst_exact_bound_mono_n (t : ℕ) (ht : 1 ≤ t) {n n' : ℝ} (hn : 1 ≤ n)
+    (hnn' : n ≤ n') :
+    n * (1 + Real.sqrt (1 + 4 * ((t : ℝ) - 1) * (n - 1))) ≤
+      n' * (1 + Real.sqrt (1 + 4 * ((t : ℝ) - 1) * (n' - 1))) := by
+  have htm1 : (0 : ℝ) ≤ (t : ℝ) - 1 := by
+    have : (1 : ℝ) ≤ (t : ℝ) := by exact_mod_cast ht
+    linarith
+  have hstep : (0 : ℝ) ≤ 4 * ((t : ℝ) - 1) * (n' - n) :=
+    mul_nonneg (mul_nonneg (by norm_num) htm1) (by linarith)
+  have harg : 1 + 4 * ((t : ℝ) - 1) * (n - 1) ≤ 1 + 4 * ((t : ℝ) - 1) * (n' - 1) := by
+    nlinarith [hstep]
+  have hsqrt := Real.sqrt_le_sqrt harg
+  have hc : (0 : ℝ) ≤ 1 + Real.sqrt (1 + 4 * ((t : ℝ) - 1) * (n - 1)) := by positivity
+  exact mul_le_mul hnn' (by linarith) hc (by linarith)
+
+/-- **Joint monotonicity of the exact KST bound.**  Combining the `t`- and `n`-directions:
+for `t ≤ t'` (with `t ≥ 1`) and `1 ≤ n ≤ n'`, the Reiman/KST bound at `(t, n)` is dominated
+by the one at `(t', n')`.  A single order statement folding `kst_exact_bound_mono_t` and
+`kst_exact_bound_mono_n`: forbidding a larger `K_{2,t'}` on more vertices only loosens the
+edge bound. -/
+theorem kst_exact_bound_mono (t t' : ℕ) (ht : 1 ≤ t) (htt' : t ≤ t')
+    {n n' : ℝ} (hn : 1 ≤ n) (hnn' : n ≤ n') :
+    n * (1 + Real.sqrt (1 + 4 * ((t : ℝ) - 1) * (n - 1))) ≤
+      n' * (1 + Real.sqrt (1 + 4 * ((t' : ℝ) - 1) * (n' - 1))) :=
+  le_trans (kst_exact_bound_mono_n t ht hn hnn')
+    (kst_exact_bound_mono_t t t' htt' n' (le_trans hn hnn'))
+
 /-- **Monotone (weaker-forbidden) KST bound.**  A `K_{2,t}`-free nonempty graph
 (`t ≥ 1`) also satisfies the KST edge bound for every *larger* forbidden parameter
 `t' ≥ t`:

--- a/research/problems/erdos-1008-oq-02-oq-02/state.md
+++ b/research/problems/erdos-1008-oq-02-oq-02/state.md
@@ -1,10 +1,23 @@
 # Research State: erdos-1008-oq-02-oq-02
 
 ## Current State
-**Phase**: OBSERVE
+**Phase**: ACT
 **Path**: full
 **Since**: 2026-07-09T16:43:20-07:00
-**Iteration**: 1
+**Iteration**: 2
+
+## Iteration 2 (researcher-9, 2026-07-11, VERIFIED offline)
+The parametric K_{2,t} KST machinery in `Proofs/Erdos1008OQ02OQ02.lean` was already
+saturated (699L, 0 sorries, 0 axioms, exact nested-radical bound + graph-level +
+leading-order + `kst_exact_bound_mono_t`). Added the missing **`n`-direction monotonicity**
+of the exact bound (2 axiom-free theorems), the companion to the existing `t`-monotonicity:
+- `kst_exact_bound_mono_n (t) (ht:1≤t) {n n'} (hn:1≤n) (hnn':n≤n')`: the Reiman/KST RHS
+  `n·(1+√(1+4(t-1)(n-1)))` is non-decreasing in `n` — both leading factor and radicand grow
+  (radicand via `(t-1)≥0`), product of nonneg non-decreasing factors. `mul_le_mul`+`Real.sqrt_le_sqrt`+nlinarith.
+- `kst_exact_bound_mono (t t') (ht) (htt') {n n'} (hn) (hnn')`: joint monotonicity in both
+  `t` and `n`, `le_trans` of mono_n then mono_t.
+Both depend only on `[propext, Classical.choice, Quot.sound]` (confirmed `#print axioms`).
+File 699→736 lines, +2 theorems, 0 sorries/0 axioms unchanged. Verified `bin/lake env lean` EXIT 0.
 
 ## Current Focus
 Initial problem understanding. Read problem.md and gather context.


### PR DESCRIPTION
## Summary

The parametric $K_{2,t}$ Kővári–Sós–Turán file `Erdos1008OQ02OQ02.lean` already carries the exact nested-radical edge bound, its graph-level form, the leading-order form, and $t$-monotonicity (`kst_exact_bound_mono_t`). This adds the missing **$n$-direction companion** — 2 axiom-free theorems.

## New theorems (axiom-free)

- **`kst_exact_bound_mono_n`** — for fixed $t \ge 1$ and $1 \le n \le n'$, the Reiman/KST bound $n\,(1 + \sqrt{1 + 4(t-1)(n-1)})$ is non-decreasing in $n$: both the leading factor and the radicand grow (radicand since $t-1 \ge 0$), and the product of nonnegative non-decreasing factors is non-decreasing.
- **`kst_exact_bound_mono`** — joint monotonicity in both $t$ and $n$ (`le_trans` of the two directions).

Records that $\mathrm{ex}(n; K_{2,t})$ grows with the vertex count — the $n$-analogue of the existing $t$-monotonicity.

## Verification

- File `699 → 736` lines, `+2` theorems, **0 sorries / 0 axioms** (unchanged).
- `#print axioms`: both new theorems depend only on `[propext, Classical.choice, Quot.sound]`.
- Verified by full offline Mathlib elaboration (`bin/lake env lean Proofs/Erdos1008OQ02OQ02.lean`, EXIT 0; only pre-existing unused-section-variable linter warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)