### PR TITLE
research(bezout-identity-oq-01-oq-02-oq-02): unimodular column completion (n≥2)

### DIFF
--- a/proofs/Proofs/BezoutIdentityOQ01OQ02OQ02.lean
+++ b/proofs/Proofs/BezoutIdentityOQ01OQ02OQ02.lean
@@ -521,4 +521,28 @@ theorem exists_sl_mulVec_basis_of_isPrimitive (hn : 1 < n) {v : Fin n → ℤ}
     ∃ A : Matrix.SpecialLinearGroup (Fin n) ℤ, ↑ₘA *ᵥ v = Pi.single t (1 : ℤ) :=
   exists_sl_mulVec_eq_of_isPrimitive hn hv (isPrimitive_single t)
 
+/-- **Unimodular column completion (`n ≥ 2`).**  A vector is primitive **iff** it is a
+column of some matrix in `SLₙ(ℤ)`: `IsPrimitive v ↔ ∃ A k, ↑ₘA *ᵥ eₖ = v` — the right side
+says `v` is the `k`-th column of `A` (`↑ₘA *ᵥ Pi.single k 1` extracts that column).  The
+backward direction is `orbit_e_isPrimitive` (any column of a unimodular matrix is
+primitive); the forward direction inverts `exists_sl_mulVec_basis_of_isPrimitive` — the `U`
+carrying `v` onto `e₀` has `U⁻¹` with `v` as its `0`-th column.  This is the classical
+statement that a primitive integer vector **extends to a `ℤ`-basis** (unimodular
+completion): the columns of `SLₙ(ℤ)` are *exactly* the primitive vectors.
+
+The dimension hypothesis `1 < n` is essential and not an artefact: for `n = 1` the only
+unimodular matrix is the identity, whose sole column is `e₀ = (1)`, so the primitive vector
+`(-1)` is *not* a column of any `SL₁(ℤ)` matrix — the same sign obstruction that keeps the
+uniform `c · eₖ` normal form (`isPrimitive_iff_exists_sl_single`) from sharpening at `n = 1`. -/
+theorem isPrimitive_iff_exists_sl_column (hn : 1 < n) (v : Fin n → ℤ) :
+    IsPrimitive v ↔ ∃ (A : Matrix.SpecialLinearGroup (Fin n) ℤ) (k : Fin n),
+      ↑ₘA *ᵥ Pi.single k (1 : ℤ) = v := by
+  refine ⟨fun hv => ?_, ?_⟩
+  · obtain ⟨A, hA⟩ := exists_sl_mulVec_basis_of_isPrimitive hn hv ⟨0, by omega⟩
+    refine ⟨A⁻¹, ⟨0, by omega⟩, ?_⟩
+    rw [← hA, Matrix.mulVec_mulVec, ← SpecialLinearGroup.coe_mul, inv_mul_cancel,
+      SpecialLinearGroup.coe_one, one_mulVec]
+  · rintro ⟨A, k, rfl⟩
+    exact orbit_e_isPrimitive A k
+
 end BezoutPrimitive

--- a/src/data/proofs/bezout-identity-oq-01-oq-02-oq-02/meta.json
+++ b/src/data/proofs/bezout-identity-oq-01-oq-02-oq-02/meta.json
@@ -23,7 +23,7 @@
     "dateAdded": "2026-07-09",
     "axiomCount": 0,
     "assumptions": "None beyond Mathlib's foundational axioms. Fully machine-checked (0 sorries, 0 axiom declarations, no structure-encoded assumptions, no native_decide). Note: in the local Docker sandbox the file elaborates cleanly across repeated runs but the .olean cache write intermittently aborts with SIGBUS (exit 135), an environment/IO issue independent of the proofs; CI produces the build artifact.",
-    "lineCount": 301,
+    "lineCount": 548,
     "theoremCount": 16,
     "definitionCount": 2,
     "originalContributions": [
@@ -85,13 +85,18 @@
       "name": "isPrimitive_single",
       "type": "supporting",
       "description": "The standard basis vector eᵢ (Pi.single i 1) is primitive, witnessed by its own indicator as the dual. The target of the transitivity reduction."
+    },
+    {
+      "name": "isPrimitive_iff_exists_sl_column",
+      "type": "theorem",
+      "description": "Unimodular column completion (n ≥ 2): a vector is primitive iff it is a column of some matrix in SLₙ(ℤ) (IsPrimitive v ↔ ∃ A k, ↑ₘA *ᵥ eₖ = v). The classical statement that a primitive integer vector extends to a ℤ-basis — the columns of SLₙ(ℤ) are exactly the primitive vectors. Backward is orbit_e_isPrimitive; forward inverts exists_sl_mulVec_basis_of_isPrimitive. The 1<n hypothesis is essential: at n=1 the primitive vector (-1) is no column of SL₁(ℤ)={1}."
     }
   ],
   "leanFile": {
     "namespace": "BezoutPrimitive",
-    "lineCount": 301,
+    "lineCount": 548,
     "axiomCount": 0,
-    "theoremCount": 16,
+    "theoremCount": 24,
     "definitionCount": 2,
     "path": "Proofs/BezoutIdentityOQ01OQ02OQ02.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

Adds the classical capstone to the SL_n(ℤ)-transitivity development in `BezoutIdentityOQ01OQ02OQ02.lean`. The file already proves that SL_n(ℤ) acts transitively on primitive vectors (`exists_sl_mulVec_eq_of_isPrimitive`, `exists_sl_mulVec_basis_of_isPrimitive`); this PR closes the orbit description into the standard **unimodular column completion** characterization:

- **`isPrimitive_iff_exists_sl_column`** (`1 < n`): `IsPrimitive v ↔ ∃ A k, ↑ₘA *ᵥ eₖ = v`. The right side says `v` is the `k`-th column of `A ∈ SL_n(ℤ)` (`↑ₘA *ᵥ Pi.single k 1` extracts that column). So **the columns of SL_n(ℤ) are exactly the primitive vectors** — equivalently, a primitive integer vector extends to a ℤ-basis (unimodular completion).
  - Backward: `orbit_e_isPrimitive` (any column of a unimodular matrix is primitive).
  - Forward: inverts `exists_sl_mulVec_basis_of_isPrimitive` — the `U` carrying `v` onto `e₀` has `U⁻¹` with `v` as its `0`-th column.
  - The `1 < n` hypothesis is essential (not an artefact): at `n = 1` the primitive vector `(-1)` is no column of any `SL₁(ℤ) = {1}` matrix — the same sign obstruction that keeps the uniform `c·eₖ` normal form (`isPrimitive_iff_exists_sl_single`) from sharpening at `n = 1`.

## Verification

- `lake env lean Proofs/BezoutIdentityOQ01OQ02OQ02.lean` → **exit 0**, no errors/sorries.
- `#print axioms isPrimitive_iff_exists_sl_column` → `[propext, Classical.choice, Quot.sound]` only.
- meta.json refreshed to current file state (it was stale: `301`L/`16` thm from before the general-n expansion → now `548`L/`24` thm; `axiomCount` stays `0`, status `verified`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)