### PR TITLE
audit(erdos-1019): sync stale sorry counts 1→0 (primary file is 0-sorry)

### DIFF
--- a/src/data/proofs/erdos-1019/meta.json
+++ b/src/data/proofs/erdos-1019/meta.json
@@ -318,7 +318,7 @@
     "theoremCount": 13,
     "definitionCount": 23,
     "path": "Proofs/Erdos1019Problem.lean",
-    "sorries": 1,
+    "sorries": 0,
     "additionalFiles": [
       "Proofs/Erdos1019Aristotle.lean"
     ]
@@ -340,5 +340,5 @@
     "Proof of the 1-edge threshold gap via `omega`",
     "Definition of `completeBipartite` on `Fin m ⊕ Fin n` with adjacency between parts"
   ],
-  "sorries": 1
+  "sorries": 0
 }


### PR DESCRIPTION
## Gallery integrity fix

**Proof**: `erdos-1019`
**Problem**: Stale sorry-count fields contradict the actual source.

## Evidence

The primary proof file `Proofs/Erdos1019Problem.lean` was repaired to **0 sorries** in #37550, and `meta.sorries` (0) plus the `assumptions` prose ("The file is fully machine-checked with 0 sorries") already reflect this. But two count fields were left stale:

| Field | Before | After | Actual source |
|-------|--------|-------|---------------|
| `meta.sorries` | 0 | 0 | 0 ✓ (already correct) |
| `leanFile.sorries` | **1** | 0 | 0 |
| top-level `sorries` | **1** | 0 | 0 |

Comment-stripped grep of `Proofs/Erdos1019Problem.lean` (the `leanFile.path`) confirms **0 sorries**.

The `Erdos1019Aristotle.lean` companion still carries 5 scaffold sorries, but that is a separate supporting file — not the entry's headline result at `leanFile.path`.

## Fix

Set `leanFile.sorries` and top-level `sorries` to `0` so all three sorry fields agree with the source. Status remains `axiomatized`/`axiom` (3 cited-result axioms + `Lean.ofReduceBool` from a supporting `native_decide`, both already disclosed) — no overclaim.

Supersedes #37596, which accidentally staged dozens of unrelated `.claude/` files and is unmergeable.

---
Discovered during gallery integrity audit (batch re-scan of recently-changed Lean files).