### PR TITLE
Enrich algebraic-numbers-countable-oq-01-oq-03: fix cardinality section boundaries

### DIFF
--- a/src/data/proofs/algebraic-numbers-countable-oq-01-oq-03/meta.json
+++ b/src/data/proofs/algebraic-numbers-countable-oq-01-oq-03/meta.json
@@ -117,14 +117,14 @@
       "id": "equiv",
       "title": "§2: Identification with the abstract AlgebraicClosure ℚ",
       "startLine": 90,
-      "endLine": 116,
+      "endLine": 103,
       "summary": "algebraicNumbersEquivAlgebraicClosure : algebraicNumbersField ≃ₐ[ℚ] AlgebraicClosure ℚ from IsAlgClosure.equiv; algebraicNumbersEquivAlgebraicClosure_commutes records that it fixes ℚ pointwise.",
       "mathContext": "Any two algebraic closures of the same field are isomorphic over it (Steinitz uniqueness). Here it bridges the concrete closure inside ℂ and Mathlib's abstract construction from ℚ."
     },
     {
       "id": "cardinality",
       "title": "§3: Cardinality transport — AlgebraicClosure ℚ is countably infinite",
-      "startLine": 118,
+      "startLine": 104,
       "endLine": 140,
       "summary": "cardinalMk_algebraicNumbersField (#= ℵ₀ for the concrete carrier, via Algebraic.cardinalMk_of_countable_of_charZero) is transported across the isomorphism to cardinalMk_algebraicClosure_rat : #(AlgebraicClosure ℚ) = ℵ₀. From that single cardinal equality both countable_algebraicClosure_rat (Cardinal.mk_le_aleph0_iff) and infinite_algebraicClosure_rat (Cardinal.infinite_iff) follow, pinning down 'countably infinite' rather than mere countability.",
       "mathContext": "$\\#(\\mathrm{AlgebraicClosure}\\,\\mathbb{Q}) = \\#\\{z:\\mathbb{C}\\mid \\mathrm{IsAlgebraic}\\,\\mathbb{Q}\\,z\\} = \\aleph_0$, so the type is Countable and Infinite."


### PR DESCRIPTION
Enrichment pass for `algebraic-numbers-countable-oq-01-oq-03` (quality 96, pass 0). This is a **section-boundary correctness fix**.

## Problem
The `equiv` section (90–116) wrongly swallowed the § 3 cardinality header (104–106) and the first cardinality theorem `cardinalMk_algebraicNumbersField` (114), while the `cardinality` section started too late (118) — so its summary described a theorem outside its own line range.

## Fix
- `equiv` → 90–103 (just `algebraicNumbersEquivAlgebraicClosure`).
- `cardinality` → 104–140 (the § 3 header and all four cardinality/countability theorems: `cardinalMk_algebraicNumbersField`, `cardinalMk_algebraicClosure_rat`, `countable_algebraicClosure_rat`, `infinite_algebraicClosure_rat`), matching the existing summary text.

## Note
The entry already meets all quality targets (5 sections, 5 keyInsights, 6 annotations); this pass only realigns the section line ranges to the actual code — no padding, no content added or removed.

## Verification
- Valid JSON; `pnpm build` steps pass with **0 error mentions of this target**; meta.json 21.8 KB, well under caps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)