### PR TITLE
research(cayley-hamilton-cyclic-vector-oq-02-oq-01/02): fix stray -/ in docstring blocking compilation

### DIFF
--- a/proofs/Proofs/CayleyHamiltonCyclicVectorAllFieldsOQ02OQ01.lean
+++ b/proofs/Proofs/CayleyHamiltonCyclicVectorAllFieldsOQ02OQ01.lean
@@ -56,7 +56,7 @@
   module.  Combined with the dimension bookkeeping (`dim K[M] = deg minpoly`),
   the degree squeeze, and the descent to a cyclic vector, the whole converse edge
   is verified.  The three supporting lemmas (`lmul_finrank_bound`,
-  `aeval_end_bound`, `endK_centralizer_bound`) are field-/module-general and
+  `aeval_end_bound`, `endK_centralizer_bound`) are field- and module-general and
   reusable.  `#print axioms finrank_centralizer_ge` reports only
   `propext, Classical.choice, Quot.sound`.
 -/


### PR DESCRIPTION
## Summary

`CayleyHamiltonCyclicVectorAllFieldsOQ02OQ01.lean` **never compiled**. Its opening `/- … -/` block comment contained the sequence `field-/module-general`; the embedded `-/` closed the block comment early, so the docstring word "module" (and the remainder of the header) was parsed as source, giving:

```
<input>:1:0: error: `module` keyword is experimental and not enabled here
```

This blocked machine verification of the whole OQ-02-OQ-01 / OQ-02-OQ-02 chain, and had been misdiagnosed as "isModule shared-cache poisoning" (no `setup.json` / `isModule` marker actually exists in the current build tree — the cause was purely this one comment).

## Fix

Reword `field-/module-general` → `field- and module-general` (removes the stray `-/`). Documentation-only change; no proof term touched.

## Verification (with the fix)

- `lake env lean Proofs/CayleyHamiltonCyclicVectorAllFieldsOQ02OQ01.lean` → exit 0, 0 errors
- `lake env lean Proofs/CayleyHamiltonCyclicVectorAllFieldsOQ02OQ02.lean` → exit 0, 0 errors, 0 sorries
- `#print axioms` on `finrank_centralizer_eq_of_nonderogatory`, `centralizer_eq_adjoin_iff_nonderogatory`, `cayley_hamilton_oq02_oq02_summary`, `finrank_centralizer_ge`, `centralizer_eq_adjoin_implies_nonderogatory` → all `[propext, Classical.choice, Quot.sound]` (axiom-free)

The headline result `dim_K C(M) = n` for nonderogatory `M` is now machine-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)