### PR TITLE
research(cantor-diagonalization-oq-06-oq-01): Uncountable ℝ + no countable surjection, from the explicit diagonal

### DIFF
--- a/proofs/Proofs/CantorDiagonalizationOQ06OQ01.lean
+++ b/proofs/Proofs/CantorDiagonalizationOQ06OQ01.lean
@@ -206,4 +206,34 @@ theorem not_surjective_nat_real (f : ℕ → ℝ) : ¬ Function.Surjective f := 
 theorem not_exists_surjective_nat_real : ¬ ∃ f : ℕ → ℝ, Function.Surjective f :=
   fun ⟨f, hf⟩ => not_surjective_nat_real f hf
 
+/-! ## Standard consequences, derived from the explicit diagonal
+
+The two headline statements below are the textbook corollaries of Cantor's
+diagonal argument.  We obtain them *from the bespoke construction above* — the
+only input is `not_surjective_nat_real`, never `Cardinal.not_countable_real` —
+so the entry's originality is preserved while it still delivers the expected
+`Uncountable ℝ` conclusion in Mathlib's own vocabulary. -/
+
+/-- **`ℝ` is uncountable** (`Uncountable` instance), obtained purely from the explicit
+diagonal `diagonalReal`.  Were `ℝ` countable, `exists_surjective_nat` would supply a
+surjection `ℕ → ℝ`, which `not_exists_surjective_nat_real` forbids.  No appeal to
+`Cardinal.not_countable_real`. -/
+theorem uncountable_real : Uncountable ℝ := by
+  rw [← not_countable_iff]
+  exact fun _ => not_exists_surjective_nat_real (exists_surjective_nat ℝ)
+
+/-- **No countable type surjects onto `ℝ`.**  The diagonal argument scales from `ℕ`
+to any countable index type `α`: a surjection `g : α → ℝ` with `α` countable would,
+composed with a surjection `ℕ → α` (from `exists_surjective_nat`), yield a surjection
+`ℕ → ℝ`; and if `α` is empty there is no surjection onto the non-empty `ℝ` at all.
+Either way `not_surjective_nat_real` closes it.  So `ℝ` is not the surjective image of
+any countable set — the general form of the uncountability statement. -/
+theorem not_surjective_of_countable {α : Type*} [Countable α] (g : α → ℝ) :
+    ¬ Function.Surjective g := by
+  intro hg
+  rcases isEmpty_or_nonempty α with hα | hα
+  · exact (hg 0).elim (fun a _ => (IsEmpty.false a))
+  · obtain ⟨e, he⟩ := exists_surjective_nat α
+    exact not_surjective_nat_real (g ∘ e) (hg.comp he)
+
 end CantorDiagonalizationOQ06OQ01

--- a/src/data/proofs/cantor-diagonalization-oq-06-oq-01/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-06-oq-01/meta.json
@@ -51,13 +51,15 @@
       "diagonalReal f := ∑' n, (db f n)/10^(n+1): the explicit, definable diagonal real witness",
       "digit_diagonalReal: the crux lemma digit (diagonalReal f) n = db f n, proved by a head/tail split with an integer head and a geometric tail 0 ≤ T ≤ 2/9 < 1",
       "diagonalReal_ne: diagonalReal f ≠ f n for every n, by direct digit disagreement",
-      "not_surjective_nat_real / not_exists_surjective_nat_real: Cantor's theorem in enumeration form, witnessed constructively rather than via cardinality"
+      "not_surjective_nat_real / not_exists_surjective_nat_real: Cantor's theorem in enumeration form, witnessed constructively rather than via cardinality",
+      "uncountable_real: ℝ is uncountable (Uncountable instance), derived purely from the explicit diagonalReal witness via exists_surjective_nat — NO appeal to Cardinal.not_countable_real",
+      "not_surjective_of_countable: no countable type α surjects onto ℝ (the general form of uncountability), obtained by composing an α-surjection ℕ→α with the diagonal argument"
     ],
     "dateAdded": "2026-07-11",
-    "lineCount": 209,
+    "lineCount": 239,
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries; #print axioms reports only [propext, Classical.choice, Quot.sound]. No use of Cardinal.not_countable_real.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 14,
+    "theoremCount": 16,
     "definitionCount": 4
   },
   "overview": {


### PR DESCRIPTION
## Summary

The entry's bespoke constructive diagonal (`diagonalReal`, digit-disagreement crux) already proves `not_surjective_nat_real` — no `f : ℕ → ℝ` is surjective — and deliberately avoids `Cardinal.not_countable_real` to keep the argument original. This PR adds the two standard textbook corollaries, **derived only from that construction**, so the Tier-A originality is preserved while the entry now delivers the expected conclusions in Mathlib's own vocabulary.

## New theorems (axiom-free: `[propext, Classical.choice, Quot.sound]`)

- **`uncountable_real`** : `Uncountable ℝ` — via `not_countable_iff` + `exists_surjective_nat` (a countable `ℝ` would give a surjection `ℕ → ℝ`, forbidden by `not_exists_surjective_nat_real`). No appeal to `Cardinal.not_countable_real`.
- **`not_surjective_of_countable`** : for any countable `α`, no `g : α → ℝ` is surjective. Empty `α`: no surjection onto the non-empty `ℝ`; non-empty `α`: compose an `ℕ → α` surjection with the diagonal argument. The general form of the uncountability statement.

## Verification

- `./bin/lake env lean Proofs/CantorDiagonalizationOQ06OQ01.lean` → exit 0 (only one pre-existing style warning at line 54).
- `#print axioms` on both: foundational only. Entry remains **0 sorry, 0 axiom**. `theoremCount` 14→16, `lineCount` 209→239.

🤖 Generated with [Claude Code](https://claude.com/claude-code)