### PR TITLE
research(erdos-1064-oq-03): verify EulerTotientOQ04OQ03.lean axiom-free (clear r6 UNVERIFIED backlog)

### DIFF
--- a/research/problems/erdos-1064-oq-03/knowledge.md
+++ b/research/problems/erdos-1064-oq-03/knowledge.md
@@ -1,4 +1,15 @@
 
+## Session 2026-07-11 (researcher-2) — VERIFIED axiom-free (r6 UNVERIFIED backlog cleared)
+
+Re-elaborated the whole `EulerTotientOQ04OQ03.lean` (3121L) Docker-free
+(`bin/lake env lean` vs cached Mathlib oleans). `#print axioms` =
+`[propext, Classical.choice, Quot.sound]` for `prime_landing_family_equality`,
+`prime_landing_family_forward` (both previously UNVERIFIED under r6's Docker
+blackout), plus `excluded_seed_never_reverses` and
+`reversal_mem_implies_transport_regime`. 0 sorry / 0 axiom confirmed; only 4
+cosmetic `mul_le_mul_left'/right'` deprecation warnings. Structural side of OQ-03
+is COMPLETE and now VERIFIED. See sessions/2026-07-11-r2-verify-axiomfree.md.
+
 ## Session 2026-07-08 (researcher-6) — MILESTONE: excluded regime fully closed (structural conjecture proven)
 
 **Mode**: REVISIT (RICH tier; branch dedicated) | **Outcome**: progress (VERIFIED 0 sorry / 0 axiom, Docker `Built (5.6s)`, 3058 jobs; axioms propext/Classical.choice/Quot.sound; no native_decide)

--- a/research/problems/erdos-1064-oq-03/sessions/2026-07-11-r2-verify-axiomfree.md
+++ b/research/problems/erdos-1064-oq-03/sessions/2026-07-11-r2-verify-axiomfree.md
@@ -1,0 +1,35 @@
+# Session 2026-07-11 (researcher-2) — VERIFY: whole file axiom-free (r6 UNVERIFIED backlog cleared)
+
+**Mode**: REVISIT (RICH tier, score 107) | **Outcome**: VERIFIED 0 sorry / 0 axiom (Docker-free path)
+
+## What I did
+Re-elaborated the entire `proofs/Proofs/EulerTotientOQ04OQ03.lean` (3121 lines) via the
+Docker-free path `proofs/bin/lake env lean` against cached Mathlib oleans, and ran
+`#print axioms` on the key theorems — including the two the previous (r6, 2026-07-10)
+session added but had to mark **UNVERIFIED** because Docker was down all that session
+(containerd content-store blob I/O error).
+
+## Findings
+- File elaborates with **no errors** (only 4 pre-existing `mul_le_mul_left'/right'`
+  deprecation warnings at lines 2219/2304/2312/3106 — cosmetic, non-blocking).
+- `#print axioms` = `[propext, Classical.choice, Quot.sound]` (no `sorryAx`, no
+  `Lean.ofReduceBool`) for all of:
+  - `prime_landing_family_equality`  ← previously UNVERIFIED (r6)
+  - `prime_landing_family_forward`    ← previously UNVERIFIED (r6)
+  - `excluded_seed_never_reverses`    (the structural-dichotomy capstone)
+  - `reversal_mem_implies_transport_regime`
+- Confirms the file has 0 `sorry` and 0 `axiom` declarations.
+
+## Status
+The elementary/structural side of OQ-03 is **COMPLETE and now VERIFIED axiom-free**: all
+three regimes of the prime-landing trichotomy are packaged as infinitely-often families
+(`prime_landing_family_{reversal,equality,forward}`) and the excluded-seed dichotomy
+(`excluded_seed_never_reverses` ⟹ every reversal lives in the transport-admissible regime
+`seedS a = 1`) is a theorem. The r6 UNVERIFIED backlog was purely an operator-Docker
+artifact, not a Lean issue.
+
+## Next steps (unchanged)
+The only remaining open direction is the analytically-hard density-1 forward statement
+(smooth-number density ψ(x,y) / Luca–Pomerance) — a genuine Mathlib gap, not
+session-sized. Optional elementary follow-up: characterise *which* transport-admissible
+seeds (`seedS a = 1`) reverse, beyond the least element `a = 21`.


### PR DESCRIPTION
## Summary

Re-elaborated the entire `proofs/Proofs/EulerTotientOQ04OQ03.lean` (3121 lines) via the Docker-free path (`proofs/bin/lake env lean` against cached Mathlib oleans) and ran `#print axioms` on its key theorems.

The previous session (r6, 2026-07-10) added `prime_landing_family_equality` and `prime_landing_family_forward` but had to mark them **UNVERIFIED** because Docker was down all session (containerd content-store I/O error). This confirms they — and the structural capstones — are genuinely sound.

## Results

- File elaborates with **no errors** (only 4 pre-existing cosmetic `mul_le_mul_left'/right'` deprecation warnings).
- `#print axioms` = `[propext, Classical.choice, Quot.sound]` (no `sorryAx`, no `Lean.ofReduceBool`) for:
  - `prime_landing_family_equality` ← was UNVERIFIED
  - `prime_landing_family_forward` ← was UNVERIFIED
  - `excluded_seed_never_reverses`
  - `reversal_mem_implies_transport_regime`
- 0 `sorry`, 0 `axiom` declarations confirmed.

The elementary/structural side of OQ-03 is complete and now verified axiom-free; the only remaining open direction is the analytically-hard density-1 statement (smooth-number density / Luca–Pomerance), a genuine Mathlib gap.

## Change

Documentation only: a session note + knowledge.md entry recording the verification. No Lean changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)