### PR TITLE
Enrich algebraic-numbers-countable-oq-02-oq-02-oq-03 (R uncountable via perfect sets): sections 4->5, keyInsights 4->5

### DIFF
--- a/src/data/proofs/algebraic-numbers-countable-oq-02-oq-02-oq-03/annotations.json
+++ b/src/data/proofs/algebraic-numbers-countable-oq-02-oq-02-oq-03/annotations.json
@@ -2,7 +2,10 @@
   {
     "id": "ann-algcount-oq020203-01",
     "proofId": "algebraic-numbers-countable-oq-02-oq-02-oq-03",
-    "range": { "startLine": 1, "endLine": 56 },
+    "range": {
+      "startLine": 1,
+      "endLine": 56
+    },
     "type": "concept",
     "title": "The Right Generality: Uncountability is Topological, not Arithmetic",
     "content": "The sibling entries prove ℝ uncountable using features of the real line (nested intervals, the diagonal argument, cardinal arithmetic on 2^ℵ₀). This file asks what those proofs are really about. The answer belongs to topology: any nonempty complete metric space with no isolated points — a perfect space — is uncountable. ℝ inherits uncountability only because it is complete, connected, and has more than one point. The general theorem never mentions the order or field structure of ℝ; the real line appears only in the final one-line application `real_uncountable`.",
@@ -23,7 +26,10 @@
   {
     "id": "ann-algcount-oq020203-02",
     "proofId": "algebraic-numbers-countable-oq-02-oq-02-oq-03",
-    "range": { "startLine": 58, "endLine": 66 },
+    "range": {
+      "startLine": 58,
+      "endLine": 66
+    },
     "type": "theorem",
     "title": "The Cantor Space ℕ → Bool Has Cardinality 𝔠",
     "content": "`card_nat_bool` computes #(ℕ → Bool) = 𝔠 by rewriting through Mathlib's cardinal-arithmetic lemmas: mk_arrow reduces the function space to #Bool ^ #ℕ, mk_bool and mk_nat give 2 and ℵ₀, the lift lemmas normalize universes, and two_power_aleph0 collapses 2^ℵ₀ to 𝔠. `nat_bool_uncountable` then converts this cardinal equation into the `Uncountable (ℕ → Bool)` typeclass instance via aleph0_lt_mk_iff and aleph0_lt_continuum. The Cantor space is the universal uncountable witness that the rest of the proof injects into its target.",
@@ -42,7 +48,10 @@
   {
     "id": "ann-algcount-oq020203-03",
     "proofId": "algebraic-numbers-countable-oq-02-oq-02-oq-03",
-    "range": { "startLine": 68, "endLine": 80 },
+    "range": {
+      "startLine": 68,
+      "endLine": 80
+    },
     "type": "theorem",
     "title": "Core Theorem: Nonempty Perfect Sets are Uncountable",
     "content": "`perfect_nonempty_uncountable` is the mathematical heart. Mathlib's `Perfect.exists_nat_bool_injection` supplies a continuous injection f : (ℕ → Bool) → X whose range lies inside the perfect set C — this is the Cantor scheme, which recursively splits C into two disjoint nonempty perfect pieces of shrinking diameter and reads off the unique nested-intersection point for each binary address. Because the domain ℕ → Bool is uncountable, the codomain of any injection out of it is uncountable too. The one subtlety is landing in the subtype: f maps into X, so it is lifted to g : (ℕ → Bool) → ↥C using the range hypothesis, and `Function.Injective.uncountable` yields `Uncountable ↥C`.",
@@ -62,7 +71,10 @@
   {
     "id": "ann-algcount-oq020203-04",
     "proofId": "algebraic-numbers-countable-oq-02-oq-02-oq-03",
-    "range": { "startLine": 81, "endLine": 88 },
+    "range": {
+      "startLine": 81,
+      "endLine": 88
+    },
     "type": "theorem",
     "title": "Main Theorem: Perfect Complete Metric Spaces are Uncountable",
     "content": "`perfectSpace_uncountable` promotes the core set-level result to the whole space. It specializes C := univ, whose perfectness is exactly the `PerfectSpace` typeclass repackaged by `PerfectSpace.univ_perfect`, and univ is nonempty from the `Nonempty X` instance. The core theorem then hands back `Uncountable ↥(univ)`, which is definitionally `Uncountable X`. The proof is four lines: register the Cantor space's uncountability, extract the injection out of `(PerfectSpace.univ_perfect).exists_nat_bool_injection Set.univ_nonempty`, and close with `hinj.uncountable`. This is the headline statement of the entry — the point at which 'no isolated points' becomes 'uncountable' with no mention of ℝ.",
@@ -82,7 +94,10 @@
   {
     "id": "ann-algcount-oq020203-05",
     "proofId": "algebraic-numbers-countable-oq-02-oq-02-oq-03",
-    "range": { "startLine": 89, "endLine": 103 },
+    "range": {
+      "startLine": 90,
+      "endLine": 103
+    },
     "type": "theorem",
     "title": "Connected Corollary and ℝ Recovered in One Line",
     "content": "The two payoff results need no new mathematics. `uncountable_of_connected` is literally `perfectSpace_uncountable` with a different hypothesis bundle: Mathlib supplies the instance that a connected `T1` space with at least two distinct points has no isolated points (an isolated point would be clopen, splitting the space), so `[ConnectedSpace X] [Nontrivial X]` already synthesizes `[PerfectSpace X]` and the corollary is a bare term-mode reference to the main theorem. `real_uncountable` is then a one-liner: ℝ is a complete, connected, nontrivial metric space, so all instances fire and `uncountable_of_connected` closes it — recovering the classical theorem of the sibling entries with no property of the real line beyond these three used anywhere.",

--- a/src/data/proofs/algebraic-numbers-countable-oq-02-oq-02-oq-03/meta.json
+++ b/src/data/proofs/algebraic-numbers-countable-oq-02-oq-02-oq-03/meta.json
@@ -156,7 +156,8 @@
       "**Uncountability of ℝ is topological, not arithmetic.** The reals are uncountable purely because they are complete, connected, and have more than one point. No feature of the real line — its order, its field structure, its specific construction — is used in the general theorem; ℝ appears only in the final one-line application.",
       "**The Cantor space is the universal witness.** Every nonempty perfect complete metric space contains an injective image of ℕ → Bool. Since #(ℕ → Bool) = 𝔠, this single embedding simultaneously bounds the cardinality of ℝ, of Cantor's middle-thirds set, of [0,1], and of any perfect Polish space from below by the continuum.",
       "**Subtype uncountability vs. set uncountability.** This Mathlib version has no Set.Uncountable predicate; the natural statement of the core theorem is Uncountable ↥C for the coercion subtype, which is definitionally ¬ C.Countable. Lifting the ambient injection f : (ℕ → Bool) → X to g : (ℕ → Bool) → ↥C keeps the argument entirely at the typeclass level.",
-      "**Connectedness implies perfect.** A connected T1 space with at least two points has no isolated points: an isolated point would be clopen, contradicting connectedness. Mathlib packages this as an instance, so the connected corollary needs no separate topological argument — it is definitionally the main theorem."
+      "**Connectedness implies perfect.** A connected T1 space with at least two points has no isolated points: an isolated point would be clopen, contradicting connectedness. Mathlib packages this as an instance, so the connected corollary needs no separate topological argument — it is definitionally the main theorem.",
+      "**A third, most-general route to uncountability of ℝ.** Alongside Cantor's digit diagonalization and the cardinal-arithmetic identity #ℝ = 𝔠, this gives a purely topological proof: ℝ is uncountable because it is a perfect Polish space. Its advantage is generality — the same perfectSpace_uncountable theorem, instantiated at different spaces, immediately yields the uncountability of the Cantor middle-thirds set, of [0,1], of the irrationals, and of any nonempty complete metric space without isolated points, each in one line. The perfect-set method is also the entry point to the Cantor–Bendixson analysis of closed subsets of Polish spaces."
     ],
     "prerequisites": [
       "Perfect sets and the Cantor scheme in complete metric spaces",
@@ -190,11 +191,19 @@
     },
     {
       "id": "main-and-corollaries",
-      "title": "Main Theorem, Connected Corollary, and ℝ",
+      "title": "Whole-Space Theorem and the Connected Corollary",
       "startLine": 81,
+      "endLine": 96,
+      "summary": "perfectSpace_uncountable specializes the core theorem to C := univ via PerfectSpace.univ_perfect: a nonempty complete metric space with no isolated points is uncountable. uncountable_of_connected then derives the connected/nontrivial case from it — a connected T1 space with two distinct points is automatically perfect, so no separate argument is needed.",
+      "mathContext": "$X$ complete, nonempty, no isolated points $\\Rightarrow X$ uncountable; and connected + $|X|>1$ $\\Rightarrow X$ perfect $\\Rightarrow$ uncountable."
+    },
+    {
+      "id": "real-application",
+      "title": "ℝ is Uncountable (application)",
+      "startLine": 97,
       "endLine": 103,
-      "summary": "perfectSpace_uncountable specializes the core theorem to C := univ via PerfectSpace.univ_perfect; uncountable_of_connected derives the connected/nontrivial case from Mathlib's perfect-space instance; real_uncountable recovers ℝ uncountable as a one-line application.",
-      "mathContext": "$\\mathbb{R}$ is a complete, connected, nontrivial metric space, hence perfect, hence uncountable — no property of the real line beyond these three is used."
+      "summary": "real_uncountable recovers the classical fact that ℝ is uncountable as a one-line instance of uncountable_of_connected: ℝ is a complete, connected, nontrivial metric space, so no property of the real line beyond those three abstract hypotheses is invoked. This is the Baire-category / perfect-set route to uncountability, independent of the diagonal and cardinal-arithmetic proofs.",
+      "mathContext": "$\\mathbb{R}$ complete + connected + nontrivial $\\Rightarrow \\mathrm{Uncountable}\\,\\mathbb{R}$ — the topological (perfect-set) proof, distinct from Cantor diagonalization and $\\#\\mathbb{R} = \\mathfrak{c}$."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
Enrichment pass for `algebraic-numbers-countable-oq-02-oq-02-oq-03` (ℝ uncountable via the perfect-set / Baire route, quality 96, pass 0). Includes an **annotation bug fix**.

## Changes
- **Sections 4 → 5.** Split the `main-and-corollaries` section (81–103, three theorems) at the genuine boundary (96/97):
  - **Whole-space theorem + connected corollary** `perfectSpace_uncountable`, `uncountable_of_connected` (81–96).
  - **ℝ application** `real_uncountable` (97–103).
- **keyInsights 4 → 5.** Added: this is a third, most-general route to ℝ uncountable (vs. Cantor diagonalization and #ℝ = 𝔠), instantiating to the Cantor set, [0,1], the irrationals, and any perfect Polish space in one line each — the entry point to Cantor–Bendixson.
- **Bug fix.** Annotation `ann-algcount-oq020203-05` was anchored to blank line 89 (`annotations:build` 'No Lean construct found'); repointed to `uncountable_of_connected` (90).

## Verification
- Valid JSON; `pnpm build` steps pass with **0 error mentions of this target** (the previously-flagged annotation warning is gone); meta.json 18.5 KB, well under caps; no content deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)