### PR TITLE
research(minpoly-charpoly-oq-02-incomplete-01): distinct-spectrum commutant is abelian + n-ary product

### DIFF
--- a/proofs/Proofs/MinpolyCharpolyOQ02Incomplete01.lean
+++ b/proofs/Proofs/MinpolyCharpolyOQ02Incomplete01.lean
@@ -461,6 +461,24 @@ theorem IsDiagonalizable.mul_of_commute_distinct {M N P : Matrix n n K}
   have hNdiag := commonDiagonalizer_of_commute_distinct hPdet hMdiag hdist hcomm
   exact IsDiagonalizable.mul_of_commonDiagonalizer hP hMdiag hNdiag
 
+/-- **The commutant of a distinct-spectrum diagonalizable matrix is commutative.**
+    If `P` diagonalizes `M` with pairwise *distinct* eigenvalues, then any two matrices
+    `N₁`, `N₂` that each commute with `M` also commute with **each other**.  Because `M` has
+    distinct eigenvalues, commuting with `M` forces each `Nₖ` to be diagonalized by the same
+    `P` (`commonDiagonalizer_of_commute_distinct`); the two diagonal conjugates `P⁻¹NₖP`
+    commute, so `commute_of_commonDiagonalizer` transports the commutation back to `N₁N₂ =
+    N₂N₁`.  This is the classical fact that the commutant of a matrix with distinct
+    eigenvalues is an abelian algebra (it is exactly the algebra of polynomials in `M`). -/
+theorem commute_of_commute_distinct {M N₁ N₂ P : Matrix n n K}
+    (hP : IsUnit P) (hMdiag : (P⁻¹ * M * P).IsDiag)
+    (hdist : ∀ i j, i ≠ j → (P⁻¹ * M * P) i i ≠ (P⁻¹ * M * P) j j)
+    (hcomm₁ : M * N₁ = N₁ * M) (hcomm₂ : M * N₂ = N₂ * M) :
+    N₁ * N₂ = N₂ * N₁ := by
+  have hPdet : IsUnit P.det := (Matrix.isUnit_iff_isUnit_det P).mp hP
+  have hN₁diag := commonDiagonalizer_of_commute_distinct hPdet hMdiag hdist hcomm₁
+  have hN₂diag := commonDiagonalizer_of_commute_distinct hPdet hMdiag hdist hcomm₂
+  exact commute_of_commonDiagonalizer hP hN₁diag hN₂diag
+
 /-- **The (ordered) product of a list of diagonal matrices is diagonal.**  The
     multiplicative companion of `isDiag_sum`.  Because matrix multiplication is
     *not* commutative, the product must be taken over an ordered `List` rather than
@@ -512,6 +530,27 @@ theorem IsDiagonalizable.prod_of_commonDiagonalizer {P : Matrix n n K} (hP : IsU
   rw [List.mem_map] at hA
   obtain ⟨B, hB, rfl⟩ := hA
   exact hM B hB
+
+/-- **Distinct-eigenvalue simultaneous diagonalization — the (ordered) product of a whole
+    family.**  If `P` diagonalizes `M` with pairwise distinct eigenvalues and *every* matrix
+    in a list `L` commutes with `M`, then the ordered product `L.prod` is diagonalizable.
+    Each `N ∈ L` is forced to share `M`'s diagonalizer `P`
+    (`commonDiagonalizer_of_commute_distinct`), after which the shared-`P` product law
+    `prod_of_commonDiagonalizer` applies.  The list-indexed generalization of
+    `mul_of_commute_distinct`: no independent diagonalizability hypothesis on the members of
+    `L` is needed — commuting with the distinct-spectrum `M` supplies it.  Ordering matters
+    (matrix multiplication is non-commutative), so this is a `List`, not a `Finset`
+    statement; the members themselves need not be assumed to pairwise commute for the
+    *ordered* product to diagonalize, though in fact `commute_of_commute_distinct` shows
+    they do. -/
+theorem IsDiagonalizable.listProd_of_commute_distinct {M P : Matrix n n K}
+    (hP : IsUnit P) (hMdiag : (P⁻¹ * M * P).IsDiag)
+    (hdist : ∀ i j, i ≠ j → (P⁻¹ * M * P) i i ≠ (P⁻¹ * M * P) j j)
+    (L : List (Matrix n n K)) (hL : ∀ N ∈ L, M * N = N * M) :
+    L.prod.IsDiagonalizable := by
+  have hPdet : IsUnit P.det := (Matrix.isUnit_iff_isUnit_det P).mp hP
+  refine IsDiagonalizable.prod_of_commonDiagonalizer hP L (fun N hN => ?_)
+  exact commonDiagonalizer_of_commute_distinct hPdet hMdiag hdist (hL N hN)
 
 /-! ### Necessity of the common-diagonalizer hypothesis
 

--- a/research/problems/minpoly-charpoly-oq-02-incomplete-01/knowledge.md
+++ b/research/problems/minpoly-charpoly-oq-02-incomplete-01/knowledge.md
@@ -141,3 +141,27 @@ So the WHOLE file (all prior UNVERIFIED sessions' work) is now genuinely VERIFIE
 non-trivial fractions (can leave `0 = ![0,0]`); prefer `ext i j; fin_cases … <;> norm_num
 [Matrix.mul_fin_two]`. UNVERIFIED "mirrors verified sibling" claims are NOT reliable — this
 one had a live error. File 537→538.
+
+## Session 2026-07-11 (researcher-10) — distinct-spectrum commutant is abelian + n-ary product
+
+Extended the distinct-eigenvalue simultaneous-diagonalization payoff (PR #37527) with two
+axiom-free theorems (PR #37628):
+- `commute_of_commute_distinct`: the COMMUTANT of a distinct-spectrum diagonalizable M is
+  commutative — N₁, N₂ each commuting with M ⟹ N₁N₂=N₂N₁. Compose: each Nₖ shares M's
+  diagonalizer P (commonDiagonalizer_of_commute_distinct), diagonal conjugates commute,
+  commute_of_commonDiagonalizer transports back. Classical: commutant of distinct-eigenvalue
+  M = abelian algebra ℂ[M].
+- `IsDiagonalizable.listProd_of_commute_distinct`: n-ary (List) generalization of
+  mul_of_commute_distinct — ordered product of a family each commuting with distinct-spectrum
+  M is diagonalizable, via prod_of_commonDiagonalizer.
+Both VERIFIED axiom-free (host lake env lean exit 0; #print axioms = [propext,choice,
+Quot.sound], no sorryAx). File 629→677, 25 thms.
+
+★GOTCHA (cost a rebuild): placed listProd_of_commute_distinct BEFORE prod_of_commonDiagonalizer
+in the file → forward-ref "unknown constant Matrix.IsDiagonalizable.prod_of_commonDiagonalizer".
+Move n-ary payoff AFTER its prod_of_commonDiagonalizer dep. ★GOTCHA: `git checkout -- <file>`
+to strip appended #print-axioms lines ALSO reverted my uncommitted theorems (file is tracked
+at base SHA) — commit BEFORE any checkout, or just truncate the temp lines.
+
+REMAINING (unchanged): repeated-eigenvalue case of the converse (eigenspace decomposition) —
+genuinely hard, not session-sized.


### PR DESCRIPTION
## Summary

Two axiom-free additions to `MinpolyCharpolyOQ02Incomplete01.lean`, extending the recently-landed distinct-eigenvalue simultaneous-diagonalization payoff (#37527).

- **`commute_of_commute_distinct`** — *the commutant of a distinct-spectrum diagonalizable matrix is commutative.* If `P` diagonalizes `M` with pairwise distinct eigenvalues, any two matrices `N₁, N₂` that each commute with `M` also commute with **each other**. Both are forced to share `M`'s diagonalizer `P` (`commonDiagonalizer_of_commute_distinct`), their diagonal conjugates commute, and `commute_of_commonDiagonalizer` transports the commutation back to `N₁N₂ = N₂N₁`. This is the classical fact that the commutant of a distinct-eigenvalue matrix is the abelian algebra of polynomials in `M`.

- **`IsDiagonalizable.listProd_of_commute_distinct`** — the list-indexed generalization of `mul_of_commute_distinct`: the ordered product `L.prod` of a whole family, each member commuting with the distinct-spectrum `M`, is diagonalizable (no separate diagonalizability hypothesis on the members needed). Composes `commonDiagonalizer_of_commute_distinct` per member with the shared-`P` product law `prod_of_commonDiagonalizer`.

## Verification

- Host `lake env lean` (Docker-free), **exit 0**, zero errors.
- `#print axioms` on both new theorems = `[propext, Classical.choice, Quot.sound]` — **axiom-free** (no `sorryAx`, no `Lean.ofReduceBool`).
- File 629 → 677 lines. No new axioms/sorries; the whole file still compiles clean.

No gallery meta on this research file (parent slug tracks canonical `MinpolyCharpolyOQ02`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)