### PR TITLE
research(szemeredi-regularity-oq-04): count-form variance atom [VERIFIED axiom-free]

### DIFF
--- a/proofs/Proofs/SzemerediRegularityOQ04.lean
+++ b/proofs/Proofs/SzemerediRegularityOQ04.lean
@@ -571,6 +571,34 @@ theorem weighted_variance_subset_bound {ι : Type*} (s : Finset ι) (w x : ι �
   rw [Finset.sum_mul]
   linarith [hsubset, hfloor]
 
+/-- **The variance atom in count form.**  Specialising `weighted_variance_subset_bound`
+    to a *uniform weight floor*: if every deviating cell `j ∈ J` carries weight at least
+    `w₀` (`w₀ ≤ wⱼ`) and deviates from the mean by at least `d`, then the energy floor
+    scales with the *number* of deviating cells,
+
+      `(|J| : ℚ)·w₀·d² ≤ (∑ wᵢxᵢ²) − (∑ wᵢ)·μ²`.
+
+    This is the shape the AFKS energy-increment step needs when it counts irregular
+    sub-cells: "`≥ N` cells of weight `≥ w₀` each deviating by `≥ d`" raises the
+    partition energy by a fixed `δ = N·w₀·d²`, exactly the per-step jump that
+    `energy_steps_bounded` / `energy_iteration_count_le` cap in number (giving an
+    iteration bound `≤ 1/(N·w₀·d²)`).  The pooled-weight bound
+    `weighted_variance_subset_bound` is recovered when the weights are not assumed
+    uniform; this trades that generality for a floor that depends only on `|J|`. -/
+theorem weighted_variance_card_bound {ι : Type*} (s : Finset ι) (w x : ι → ℚ)
+    (μ d w₀ : ℚ) (hw : ∀ i ∈ s, 0 ≤ w i)
+    (hmean : ∑ i ∈ s, w i * x i = (∑ i ∈ s, w i) * μ)
+    {J : Finset ι} (hJ : J ⊆ s) (hdev : ∀ j ∈ J, d ^ 2 ≤ (x j - μ) ^ 2)
+    (hw0 : ∀ j ∈ J, w₀ ≤ w j) :
+    (J.card : ℚ) * w₀ * d ^ 2 ≤ (∑ i ∈ s, w i * x i ^ 2) - (∑ i ∈ s, w i) * μ ^ 2 := by
+  have hsub := weighted_variance_subset_bound s w x μ d hw hmean hJ hdev
+  have hcard : (J.card : ℚ) * w₀ ≤ ∑ j ∈ J, w j := by
+    have h : ∑ _j ∈ J, w₀ ≤ ∑ j ∈ J, w j := Finset.sum_le_sum (fun j hj => hw0 j hj)
+    simpa [Finset.sum_const, nsmul_eq_mul] using h
+  have hstep : (J.card : ℚ) * w₀ * d ^ 2 ≤ (∑ j ∈ J, w j) * d ^ 2 :=
+    mul_le_mul_of_nonneg_right hcard (sq_nonneg d)
+  linarith [hstep, hsub]
+
 /-- **Energy monotonicity: square of the mean ≤ weighted mean of squares (Jensen).**
     With nonnegative weights `w` and weighted mean `μ` (`∑ wᵢxᵢ = (∑ wᵢ)·μ`), the total
     weighted second moment about `0` dominates the mean scaled by the total weight:

--- a/research/problems/szemeredi-regularity-oq-04/state.md
+++ b/research/problems/szemeredi-regularity-oq-04/state.md
@@ -6,6 +6,24 @@
 **Since**: 2026-07-08T19:18:01-07:00
 **Iteration**: 3
 
+## Status (S7, researcher-2, 2026-07-11) — VERIFIED PART III + count-form variance atom
+
+Verified the whole `SzemerediRegularityOQ04.lean` axiom-free via the Docker-free path
+(`bin/lake env lean`, prebuilt oleans): S6's variance-atom additions
+(`weighted_variance_eq`, `weighted_variance_atom_bound`, `weighted_variance_subset_bound`,
+`weighted_sq_mean_le`) — previously UNVERIFIED under a Docker blackout — all report
+`#print axioms = [propext, Classical.choice, Quot.sound]`.
+
+Added `weighted_variance_card_bound`: the **count form** of the variance atom. With a
+uniform weight floor `w₀ ≤ wⱼ` on the deviating cells `J`, the energy floor becomes
+`(|J| : ℚ)·w₀·d² ≤ (∑ wᵢxᵢ²) − (∑ wᵢ)·μ²` — i.e. "`≥ N` cells of weight `≥ w₀`, each
+deviating by `≥ d`" raises partition energy by a fixed `δ = N·w₀·d²`, exactly the
+per-step jump that `energy_steps_bounded`/`energy_iteration_count_le` cap (iteration
+count `≤ 1/(N·w₀·d²)`). Proof: `weighted_variance_subset_bound` + `Finset.sum_const`
+pooling of the weight floor. VERIFIED axiom-free. This closes the abstract gap between
+the pooled-weight atom and the AFKS irregular-pair *count*; the remaining open piece is
+still the quantitative `d = d(ε)` from ε-irregularity (item 1 analytic input).
+
 ## Status (S6, researcher-6, 2026-07-09) — the variance atom (remaining item 1), UNVERIFIED docker-down
 
 Discharged the abstract half of "Next Action" item 1 (the variance atom bound


### PR DESCRIPTION
## Summary

Adds `weighted_variance_card_bound` — the **count form** of the AFKS energy-increment variance atom — and re-verifies the whole `SzemerediRegularityOQ04.lean` axiom-free.

## New lemma

```
weighted_variance_card_bound (w₀ : ℚ) (hw0 : ∀ j ∈ J, w₀ ≤ w j) :
  (|J| : ℚ) * w₀ * d² ≤ (∑ wᵢxᵢ²) − (∑ wᵢ)·μ²
```

With a **uniform weight floor** `w₀` on the deviating cells `J`, the energy floor scales with the *number* of deviating cells. This is the shape the AFKS energy-increment step consumes when it counts irregular sub-cells: "$\ge N$ cells of weight $\ge w_0$, each deviating from the mean by $\ge d$" raises the partition energy by a fixed $\delta = N w_0 d^2$ — exactly the per-step jump that the file's `energy_steps_bounded` / `energy_iteration_count_le` cap in number (iteration bound $\le 1/(N w_0 d^2)$). It bridges the pooled-weight atom (`weighted_variance_subset_bound`) and the irregular-pair count.

Proof: `weighted_variance_subset_bound` for the pooled-weight floor, then `Finset.sum_const` to replace the pooled weight by `|J| · w₀`.

## Verification

Elaborated via `proofs/bin/lake env lean` (Docker-free, prebuilt oleans). `#print axioms weighted_variance_card_bound` = `[propext, Classical.choice, Quot.sound]`.

This also clears the **UNVERIFIED** backlog on PART III: S6 (2026-07-09) added `weighted_variance_eq`, `weighted_variance_atom_bound`, `weighted_variance_subset_bound`, `weighted_sq_mean_le` under a Docker blackout — all now confirmed axiom-free. File remains 0-sorry / 0-axiom.

The remaining open piece is unchanged: the quantitative $d = d(\varepsilon)$ from $\varepsilon$-irregularity (the analytic input to the energy-increment step).

🤖 Generated with [Claude Code](https://claude.com/claude-code)