### PR TITLE
research(erdos-165): formalize main/PGM conjecture mutual exclusion (structural, no Ramsey bound)

### DIFF
--- a/proofs/Proofs/Erdos165Problem.lean
+++ b/proofs/Proofs/Erdos165Problem.lean
@@ -398,6 +398,36 @@ theorem constantConjecture_unique (c₁ c₂ : ℝ)
       (fun ε hε => by obtain ⟨k₀, hk₀⟩ := h₁ ε hε; exact ⟨k₀, fun k hk => (hk₀ k hk).2⟩)
   linarith
 
+/-- **`mainConjecture` is the `constantConjecture` at `c = 1/2`.**  The Erdős main
+    conjecture `R(3,k) ~ (1/2)·k²/log k` (`mainConjecture`) is definitionally the
+    generic exact-constant conjecture instantiated at `c = 1/2`.  This wires the
+    standalone `mainConjecture` def into the general `constantConjecture` machinery
+    (`_unique`, `_forces_bracket`, the refutation lemmas). -/
+theorem mainConjecture_iff_constant : mainConjecture ↔ constantConjecture (1/2) :=
+  Iff.rfl
+
+/-- **`pgmConjecture` is the `constantConjecture` at `c = 1/4`.**  The PGM conjecture
+    `R(3,k) ~ (1/4)·k²/log k` (`pgmConjecture`) is definitionally the generic
+    exact-constant conjecture at `c = 1/4`, connecting it to the general machinery. -/
+theorem pgmConjecture_iff_constant : pgmConjecture ↔ constantConjecture (1/4) :=
+  Iff.rfl
+
+/-- **The main and PGM conjectures are mutually exclusive.**  `mainConjecture`
+    (`c = 1/2`) and `pgmConjecture` (`c = 1/4`) cannot both hold: they assert two
+    different exact asymptotic constants for the *same* sequence `R(3,k)`, and
+    `constantConjecture_unique` forces any two such constants to coincide, whereas
+    `1/2 ≠ 1/4`.  This is the machine-checked form of the "in particular … mutually
+    exclusive" remark in `constantConjecture_unique`'s docstring, and — unlike
+    `pgm_conjecture_refuted` (which invokes the Ramsey bound `hhkp_bound`) — it uses
+    *no* Ramsey input at all: it is a purely structural incompatibility of two
+    exact-constant claims, holding for any sequence whatsoever. -/
+theorem main_pgm_mutually_exclusive : ¬ (mainConjecture ∧ pgmConjecture) := by
+  rintro ⟨hm, hp⟩
+  have h : (1 : ℝ) / 2 = 1 / 4 :=
+    constantConjecture_unique (1/2) (1/4)
+      (mainConjecture_iff_constant.mp hm) (pgmConjecture_iff_constant.mp hp)
+  norm_num at h
+
 /- ## Part VII: Related Problems -/
 
 /-

--- a/src/data/proofs/erdos-165/meta.json
+++ b/src/data/proofs/erdos-165/meta.json
@@ -56,10 +56,10 @@
       "Repaired latent Mathlib-drift breakage in erdos_165 (linarith could not widen 5/4 to 2 without k²/log k ≥ 0)"
     ],
     "axiomCount": 10,
-    "lineCount": 418,
+    "lineCount": 448,
     "assumptions": "10 axioms (unchanged): ramseyNumber, ramseyNumber_symm, ramseyNumber_recurrence, R3_small_values, aks_upper_bound, shearer_upper_bound, kim_lower_bound, bk_pgm_bound, cjms_bound, hhkp_bound. 0 sorries. New theorems add no axioms; asymptotic_constant_le is fully axiom-free; pgm_conjecture_refuted depends only on the existing hhkp_bound.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 11,
+    "theoremCount": 14,
     "definitionCount": 4,
     "additionalFiles": [
       "Proofs/Stubs/Erdos165Aristotle.lean"
@@ -166,9 +166,9 @@
       "Real"
     ],
     "namespace": "Erdos165",
-    "lineCount": 418,
+    "lineCount": 448,
     "axiomCount": 10,
-    "theoremCount": 11,
+    "theoremCount": 14,
     "definitionCount": 4,
     "path": "Proofs/Erdos165Problem.lean",
     "sorries": 0,


### PR DESCRIPTION
## Summary

`Erdos165Problem.lean` (Erdős #165, `R(3,k) ~ c·k²/log k`) has a fully-developed
axiom-free asymptotic-constant obstruction layer — `asymptotic_constant_le`,
`constantConjecture_unique`, `constantConjecture_forces_bracket`, and the
refutation lemmas that pin the exact constant (if it exists) to `[1/2, 1]`. But
the two hand-written conjecture defs `mainConjecture` (`c = 1/2`) and
`pgmConjecture` (`c = 1/4`) floated **disconnected** from that machinery, and the
"in particular … mutually exclusive" claim in `constantConjecture_unique`'s
docstring was **prose only**. This PR closes the gap.

| new theorem | statement |
|---|---|
| `mainConjecture_iff_constant` | `mainConjecture ↔ constantConjecture (1/2)` (`Iff.rfl`) |
| `pgmConjecture_iff_constant` | `pgmConjecture ↔ constantConjecture (1/4)` (`Iff.rfl`) |
| `main_pgm_mutually_exclusive` | `¬ (mainConjecture ∧ pgmConjecture)` |

The mutual-exclusion theorem is the machine-checked form of the docstring remark:
two exact asymptotic constants for the *same* sequence `R(3,k)` must coincide
(`constantConjecture_unique`), but `1/2 ≠ 1/4`. Notably it uses **no Ramsey bound
axiom** (`hhkp_bound`/`shearer_upper_bound` are not invoked) — unlike
`pgm_conjecture_refuted` — confirming it is a purely *structural* incompatibility
of two exact-constant claims, valid for any sequence.

## Verification

Compiles with `bin/lake env lean Proofs/Erdos165Problem.lean` (exit 0).
`#print axioms`:

```
'main_pgm_mutually_exclusive'  depends on axioms: [propext, Classical.choice, Erdos165.ramseyNumber, Quot.sound]
'mainConjecture_iff_constant'  depends on axioms: [propext, Classical.choice, Erdos165.ramseyNumber, Quot.sound]
```

`Erdos165.ramseyNumber` is one of the file's **pre-existing 10 axioms** (the opaque
Ramsey-number definition carried by every `R3` statement); no new axiom is
introduced. Status stays `axiomatized` (Mathlib 4.26 has no Ramsey-number theory,
so the opaque `ramseyNumber` and the research bounds remain genuine axioms).
`axiomCount` unchanged at 10; updated `meta.json` counts (`theoremCount` 11→14,
`lineCount` 418→448).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
