### PR TITLE
research(erdos-897-oq-01): unboundedness on prime powers survives bounded-below perturbation

### DIFF
--- a/proofs/Proofs/Erdos897OQ01.lean
+++ b/proofs/Proofs/Erdos897OQ01.lean
@@ -214,6 +214,38 @@ theorem unboundedOnPrimePowers_add_nonneg {f g : ℕ → ℝ}
   have hgnn := hg p k hp hk
   linarith
 
+/-- **Closure under bounded-below perturbation on prime powers.**  If `f` is unbounded on
+prime powers and `g` has a floor at every prime power (`g(p^k) ≥ -C` for some constant
+`C ≥ 0`), then `f + g` is still unbounded on prime powers.  A constant additive shift, or
+any perturbation bounded from below, cannot spoil the unbounded ratio: the deficit `C` is
+absorbed by demanding `f(p^k)/log(p^k)` exceed the larger threshold `M + C/log 2`, which is
+legitimate because `log(p^k) ≥ log 2 > 0` on every prime power (`p ≥ 2`, `k ≥ 1`).  This
+generalizes `unboundedOnPrimePowers_add_nonneg` (the case `C = 0`): unboundedness on prime
+powers is a tail property, insensitive to any bounded-below correction term. -/
+theorem unboundedOnPrimePowers_add_bddBelow {f g : ℕ → ℝ} {C : ℝ} (hC : 0 ≤ C)
+    (hf : UnboundedOnPrimePowers f)
+    (hg : ∀ p k : ℕ, p.Prime → 1 ≤ k → -C ≤ g (p ^ k)) :
+    UnboundedOnPrimePowers (fun n => f n + g n) := by
+  intro M
+  obtain ⟨p, k, hp, hk, hgt⟩ := hf (M + C / Real.log 2)
+  refine ⟨p, k, hp, hk, ?_⟩
+  show f (p ^ k) + g (p ^ k) > M * Real.log (p ^ k)
+  have hgb := hg p k hp hk
+  have hlog2 : (0 : ℝ) < Real.log 2 := Real.log_pos (by norm_num)
+  have hL : Real.log 2 ≤ Real.log (p ^ k) := by
+    apply Real.log_le_log (by norm_num)
+    have h2pk : 2 ≤ p ^ k := le_trans hp.two_le (Nat.le_self_pow (by omega) p)
+    exact_mod_cast h2pk
+  have hdiv_nn : 0 ≤ C / Real.log 2 := div_nonneg hC hlog2.le
+  have key : C ≤ C / Real.log 2 * Real.log (p ^ k) := by
+    have h1 : C / Real.log 2 * Real.log 2 ≤
+        C / Real.log 2 * Real.log (p ^ k) :=
+      mul_le_mul_of_nonneg_left hL hdiv_nn
+    rwa [div_mul_cancel₀ C hlog2.ne'] at h1
+  have hexp : (M + C / Real.log 2) * Real.log (p ^ k) =
+      M * Real.log (p ^ k) + C / Real.log 2 * Real.log (p ^ k) := by ring
+  linarith [hgt, hgb, key, hexp]
+
 /-
 ## (4) A strongly-additive reduction
 

--- a/src/data/proofs/erdos-897-oq-01/meta.json
+++ b/src/data/proofs/erdos-897-oq-01/meta.json
@@ -54,7 +54,7 @@
       "unboundedOnPrimePowers_max_left / _max_right / not_unboundedOnPrimePowers_max: PROVED the JOIN (sup) closure completing the file's prime-power domination order into a lattice — the Erdős #897 hypothesis functions form a sup-closed filter (closed under pointwise max with any function), and the failing O(log)-on-prime-powers functions form a sup-closed ideal (closed under max of two, merging the two O(log) constants via log(p^k) ≥ 0)."
     ],
     "axiomCount": 0,
-    "lineCount": 545,
+    "lineCount": 575,
     "assumptions": "None. Fully machine-checked with 0 axioms and 0 sorries; proofs use no native_decide (so #print axioms shows only propext/Classical.choice/Quot.sound). Part I of Erdős #897 — whether the prime-power growth hypothesis forces limsup_n (f(n+1)-f(n))/log n = ∞ — remains OPEN and is NOT asserted; this entry proves only the verified surrounding theory (non-vacuity, selectivity, plain unboundedness, and the strongly-additive reduction).",
     "theoremCount": 26,
     "definitionCount": 1
@@ -130,11 +130,11 @@
       "Finset"
     ],
     "namespace": "Erdos897",
-    "lineCount": 545,
+    "lineCount": 575,
     "axiomCount": 0,
     "sorries": 0,
     "definitionCount": 1,
-    "theoremCount": 27
+    "theoremCount": 28
   },
   "crossReferences": [
     {


### PR DESCRIPTION
## Summary

Extends the verified surrounding theory for Erdős #897 Part I (`Erdos897OQ01.lean`) with a new closure property of the `UnboundedOnPrimePowers` predicate:

- **`unboundedOnPrimePowers_add_bddBelow`** — if `f` is `UnboundedOnPrimePowers` and `g` has a floor at every prime power (`g(p^k) ≥ -C` for some `C ≥ 0`), then `f + g` is `UnboundedOnPrimePowers`. This generalizes the existing `unboundedOnPrimePowers_add_nonneg` (its `C = 0` case).

The content: unboundedness of `f(p^k)/log(p^k)` is a *tail* property, insensitive to any correction term with a lower bound (a constant additive shift, a bounded-below additive perturbation, …). The deficit `C` is absorbed by asking `f/log` to exceed the raised threshold `M + C/log 2` — legitimate because `log(p^k) ≥ log 2 > 0` on every prime power (`p ≥ 2`, `k ≥ 1`). The `log 2` floor gives `C·1 ≤ (C/log 2)·log(p^k)`, so the witness for the raised threshold still clears `M·log(p^k)` after subtracting `C`.

## Verification

- `lake env lean Proofs/Erdos897OQ01.lean` → **exit 0**, no errors/sorries.
- `#print axioms unboundedOnPrimePowers_add_bddBelow` → `[propext, Classical.choice, Quot.sound]` only.
- Counts: 27→28 theorems, 543→575 lines; `axiomCount` stays 0, status `verified`. meta.json refreshed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)