### PR TITLE
Enrich algebraic-numbers-countable-oq-02-oq-03-oq-02: cross-refs to child, measure pillar, parallel derivation

### DIFF
--- a/src/data/proofs/algebraic-numbers-countable-oq-02-oq-03-oq-02/meta.json
+++ b/src/data/proofs/algebraic-numbers-countable-oq-02-oq-03-oq-02/meta.json
@@ -220,6 +220,21 @@
       "targetId": "algebraic-numbers-countable",
       "relationship": "related",
       "description": "Ancestor: the algebraic reals are countable. That countability is the Fσ input reused here — a countable set is Fσ, so its complement (the transcendentals) is Gδ."
+    },
+    {
+      "targetId": "algebraic-numbers-countable-oq-02-oq-03-oq-02-oq-01",
+      "relationship": "extendedBy",
+      "description": "Direct child: abstracts this entry's concrete ℝ dichotomy into the space-agnostic theorem that any dense countable set is Fσ-but-not-Gδ in a nonempty perfect T1 Baire (Polish) space, recovering ℚ ⊆ ℝ as a one-line corollary. This realizes open question #1 posed here (a generic 'dense countable ⇒ Fσ ∖ Gδ' theorem)."
+    },
+    {
+      "targetId": "algebraic-numbers-countable-oq-07",
+      "relationship": "complements",
+      "description": "The measure-theoretic pillar of the smallness trichotomy: the algebraic reals are Lebesgue-null (measure zero), dually the transcendentals have full measure. Together with the Gδ/Fσ classification here this answers open question #2 — pairing category-smallness (this entry) with measure-smallness on ℝ."
+    },
+    {
+      "targetId": "algebraic-reals-meager-dense-gdelta",
+      "relationship": "related",
+      "description": "Parallel derivation of the same headline: the transcendental reals {x : ℝ | ¬ IsAlgebraic ℚ x} are an explicit dense Gδ, obtained from the meagre parent via the countable-complement-is-Gδ lemma. This entry additionally pins the algebraic reals as Fσ-but-not-Gδ via the disjoint-dense-Gδ obstruction."
     }
   ]
 }


### PR DESCRIPTION
Enrichment pass for `algebraic-numbers-countable-oq-02-oq-03-oq-02` (The Transcendental Reals are a Dense Gδ — and the Algebraic Reals are not Gδ).

The entry already met all depth targets (5 keyInsights, 7 fully-fielded annotations covering the file, references, conclusion with 2 open questions). The genuine gap was **cross-referencing**: it linked its ancestors but not the descendants/siblings that directly answer its own open questions. Added three accurate links (crossReferences 3→6, well under cap 20):

- **`...-oq-02-oq-01` (extendedBy)** — direct child abstracting this ℝ dichotomy to perfect Polish spaces; realizes **open question #1**.
- **`algebraic-numbers-countable-oq-07` (complements)** — algebraic reals Lebesgue-null; the measure pillar answering **open question #2** (category vs measure smallness).
- **`algebraic-reals-meager-dense-gdelta` (related)** — parallel dense-Gδ derivation of the same headline.

Verified each target's content before linking. No other fields touched; meta ~17 KB, within all size caps.