### PR TITLE
Enrich alternating-series-test-oq-01-oq-01: cross-refs to child and Abel-summation sibling

### DIFF
--- a/src/data/proofs/alternating-series-test-oq-01-oq-01/meta.json
+++ b/src/data/proofs/alternating-series-test-oq-01-oq-01/meta.json
@@ -121,6 +121,16 @@
       "targetId": "alternating-series-test-oq-01",
       "relationship": "extends",
       "description": "Parent entry: proves the one-term Leibniz bound |S_N − l| ≤ f N and asks whether it can be sharpened to a two-term estimate. This entry answers that question with the lower bound f N − f (N+1) ≤ |S_N − l|."
+    },
+    {
+      "targetId": "alternating-series-test-oq-01-oq-01-oq-02",
+      "relationship": "extendedBy",
+      "description": "Direct child: shows the two-sided two-term trap f N − f (N+1) ≤ |S_N − l| ≤ f N survives verbatim for every N ≥ M when the coefficients are only eventually antitone (antitone on [M, ∞)), via a shift reduction. Realizes the second open question posed here (do the bounds hold for eventually-antitone coefficients?)."
+    },
+    {
+      "targetId": "alternating-series-test-oq-01-oq-02",
+      "relationship": "related",
+      "description": "The Abel-summation route to the same problem: it drops monotonicity entirely, bounding the truncation error for bounded-variation coefficients via summation by parts (Finset.sum_range_by_parts). This is the other half of the open question raised here — recovering error bounds for coefficients of bounded variation rather than (eventually) antitone."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
Enrichment pass for `alternating-series-test-oq-01-oq-01` (Two-Sided, Two-Term Error Trapping for the Alternating Series Test).

The entry already met all depth targets (5 keyInsights, 5 fully-fielded annotations covering the file, references, conclusion with 2 open questions). The clear gap was **cross-referencing** — it linked only its parent. Added two accurate links (crossReferences 1→3, well under cap 20), both corresponding to this entry's own open question #2:

- **`...-oq-01-oq-02` (extendedBy)** — direct child proving the two-term trap survives for *eventually*-antitone coefficients (antitone on [M,∞)) via a shift reduction.
- **`alternating-series-test-oq-01-oq-02` (related)** — the Abel-summation route that drops monotonicity entirely, bounding the error for bounded-variation coefficients.

Verified each target's content before linking. No other fields touched; meta ~11 KB, within all size caps.