### PR TITLE
research(algebraic-numbers-countable-oq-07): internalize the Baire-category pillar (transcendentals dense Gδ ⇒ comeagre)

### DIFF
--- a/proofs/Proofs/AlgebraicRealsNull.lean
+++ b/proofs/Proofs/AlgebraicRealsNull.lean
@@ -484,4 +484,67 @@ theorem algebraic_complex_no_perfect_subset {P : Set ℂ}
   exact perfect_not_countable hP (Set.nonempty_iff_ne_empty.mpr hne)
     (AlgebraicNumbersCountable.algebraic_complex_countable.mono hsub)
 
+/-!
+## Baire category: the algebraic reals are meagre, the transcendentals comeagre
+
+The measure pillar above shows the transcendentals are *conull* (measure-large) and the
+algebraic reals *null* (measure-small). This section supplies the parallel **Baire-category**
+pillar with its topological structure explicit. Because the algebraic reals are countable,
+they are a countable union of singletons, so their complement — the transcendentals — is a
+**Gδ** set (`Set.Countable.isGδ_compl`, using that `ℝ`/`ℂ` are `T1`). A *dense* Gδ set is
+**residual** (comeagre) (`residual_of_dense_Gδ`), and the transcendentals are dense
+(`transcendental_reals_dense`), so they are comeagre and the algebraic reals are
+**meagre** (`IsMeagre`). This is the category-largeness dual of `transcendental_reals_conull`,
+completing the smallness picture: the algebraic reals are simultaneously null (measure),
+meagre (category), dimension-zero (Hausdorff), countable (cardinality) and perfect-kernel-free
+(descriptive), while the transcendentals are conull, comeagre, full-dimensional and continuum.
+-/
+
+/-- **The transcendental reals form a Gδ set.** The algebraic reals are countable, hence
+(as `ℝ` is `T1`) their complement is a countable intersection of open sets. -/
+theorem transcendental_reals_isGδ : IsGδ {x : ℝ | Transcendental ℚ x} := by
+  have hcompl : {x : ℝ | Transcendental ℚ x} = {x : ℝ | IsAlgebraic ℚ x}ᶜ := by
+    ext x; simp only [mem_setOf_eq, mem_compl_iff, Transcendental]
+  rw [hcompl]
+  exact AlgebraicNumbersCountable.algebraic_reals_countable.isGδ_compl
+
+/-- **The transcendental reals are comeagre (residual).** A dense Gδ set is residual
+(`residual_of_dense_Gδ`); the transcendentals are a Gδ (`transcendental_reals_isGδ`) and
+dense (`transcendental_reals_dense`). This is the Baire-category largeness of the
+transcendentals, dual to their conull measure largeness. -/
+theorem transcendental_reals_residual :
+    {x : ℝ | Transcendental ℚ x} ∈ residual ℝ :=
+  residual_of_dense_Gδ transcendental_reals_isGδ transcendental_reals_dense
+
+/-- **The algebraic reals are meagre.** Their complement (the transcendentals) is residual,
+which is exactly the definition of `IsMeagre`. The category-theoretic smallness pillar,
+sitting alongside `algebraic_reals_null` (measure) and `algebraic_reals_dimH_zero` (dimension). -/
+theorem algebraic_reals_meagre : IsMeagre {x : ℝ | IsAlgebraic ℚ x} := by
+  have hcompl : {x : ℝ | IsAlgebraic ℚ x}ᶜ = {x : ℝ | Transcendental ℚ x} := by
+    ext x; simp only [mem_compl_iff, mem_setOf_eq, Transcendental]
+  rw [IsMeagre, hcompl]
+  exact transcendental_reals_residual
+
+/-- **The transcendental complex numbers form a Gδ set**, by the same argument with the
+countable complex algebraic numbers and `ℂ` being `T1`. -/
+theorem transcendental_complex_isGδ : IsGδ {z : ℂ | Transcendental ℚ z} := by
+  have hcompl : {z : ℂ | Transcendental ℚ z} = {z : ℂ | IsAlgebraic ℚ z}ᶜ := by
+    ext z; simp only [mem_setOf_eq, mem_compl_iff, Transcendental]
+  rw [hcompl]
+  exact AlgebraicNumbersCountable.algebraic_complex_countable.isGδ_compl
+
+/-- **The transcendental complex numbers are comeagre (residual)**: a dense Gδ set, the
+complex analogue of `transcendental_reals_residual`. -/
+theorem transcendental_complex_residual :
+    {z : ℂ | Transcendental ℚ z} ∈ residual ℂ :=
+  residual_of_dense_Gδ transcendental_complex_isGδ transcendental_complex_dense
+
+/-- **The complex algebraic numbers are meagre**, the complex analogue of
+`algebraic_reals_meagre`. -/
+theorem algebraic_complex_meagre : IsMeagre {z : ℂ | IsAlgebraic ℚ z} := by
+  have hcompl : {z : ℂ | IsAlgebraic ℚ z}ᶜ = {z : ℂ | Transcendental ℚ z} := by
+    ext z; simp only [mem_compl_iff, mem_setOf_eq, Transcendental]
+  rw [IsMeagre, hcompl]
+  exact transcendental_complex_residual
+
 end AlgebraicRealsNull

--- a/src/data/proofs/algebraic-numbers-countable-oq-07/meta.json
+++ b/src/data/proofs/algebraic-numbers-countable-oq-07/meta.json
@@ -20,8 +20,8 @@
     "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 487,
-    "theoremCount": 30,
+    "lineCount": 550,
+    "theoremCount": 36,
     "definitionCount": 0,
     "dateAdded": "2026-06-21",
     "mathlibDependencies": [
@@ -147,7 +147,7 @@
     }
   ],
   "conclusion": {
-    "summary": "This entry completes the smallness trichotomy for the algebraic numbers by supplying its measure-theoretic pillar: the algebraic reals (and complex algebraic numbers) have Lebesgue measure zero, so almost every real (and complex) number is transcendental. The proof is short — a countable set is null because Lebesgue measure is atomless — but it records the one of the three independent smallness notions (cardinality, Baire category, measure) that was missing from the gallery. A fourth, order-topological, pillar is also recorded: since a nonempty perfect set in a complete metric space is uncountable (it injects Cantor space ℕ → Bool, of cardinality 2^ℵ₀ > ℵ₀), the countable algebraic reals contain no nonempty perfect subset, so their Cantor–Bendixson kernel is empty. All 30 theorems are proved with 0 sorries and 0 axioms.",
+    "summary": "This entry completes the smallness trichotomy for the algebraic numbers by supplying its measure-theoretic pillar: the algebraic reals (and complex algebraic numbers) have Lebesgue measure zero, so almost every real (and complex) number is transcendental. The proof is short — a countable set is null because Lebesgue measure is atomless — but it records the one of the three independent smallness notions (cardinality, Baire category, measure) that was missing from the gallery. A fourth, order-topological, pillar is also recorded: since a nonempty perfect set in a complete metric space is uncountable (it injects Cantor space ℕ → Bool, of cardinality 2^ℵ₀ > ℵ₀), the countable algebraic reals contain no nonempty perfect subset, so their Cantor–Bendixson kernel is empty. The Baire-category pillar is also internalized here with its topological structure explicit: because the algebraic reals are countable they are meagre, and dually the transcendentals are a dense Gδ, hence comeagre (residual) — the category-largeness dual of the conull measure-largeness proved in this same file. All 36 theorems are proved with 0 sorries and 0 axioms.",
     "implications": "With this entry, the gallery records all three senses in which 'almost every real is transcendental': cardinality (ℵ₀ < 𝔠, parent entry), Baire category (the transcendentals are comeagre, `algebraic-reals-meager`), and measure (the transcendentals are conull, this entry). Because the three notions are logically independent, each is a genuinely separate theorem, and only by proving all three is the statement 'the algebraic reals are negligible' established in every standard sense.\n\nThe measure-theoretic existence corollary adds a third route to the existence of transcendentals — any positive-measure set contains one — complementing Cantor's counting proof and Liouville's explicit construction. This is the prototype of a probabilistic/measure-theoretic existence argument: a randomly chosen real (uniform on any interval) is transcendental with probability one.",
     "openQuestions": [
       "Refine 'measure zero' to 'Hausdorff dimension zero': a countable set has Hausdorff dimension 0, which is strictly stronger than Lebesgue-null. Formalizing $\\dim_H\\{x : \\mathrm{IsAlgebraic}_\\mathbb{Q}\\,x\\} = 0$ would sharpen this entry and connect to the fractal-geometry hierarchy of negligible sets.",
@@ -185,8 +185,8 @@
   ],
   "leanFile": {
     "path": "Proofs/AlgebraicRealsNull.lean",
-    "lineCount": 487,
-    "theoremCount": 30,
+    "lineCount": 550,
+    "theoremCount": 36,
     "axiomCount": 0,
     "definitionCount": 0,
     "sorries": 0


### PR DESCRIPTION
## Summary

`AlgebraicRealsNull.lean` (the measure pillar of the algebraic-numbers "smallness" showcase) already proves the measure, Hausdorff-dimension, cardinality, and Cantor–Bendixson (perfect-kernel) pillars. Its own docstrings *assert* that the transcendentals are "comeagre" and the algebraic reals "meagre" — but that Baire-category content was only proved in a companion entry. This PR **internalizes the Baire pillar directly**, with its topological structure explicit.

## What's added (6 theorems, axiom-free)

- **`transcendental_reals_isGδ`** / **`transcendental_complex_isGδ`** — the transcendentals are a **Gδ** set: the algebraic reals are countable, so (as `ℝ`/`ℂ` are `T1`) their complement is a countable intersection of opens (`Set.Countable.isGδ_compl`).
- **`transcendental_reals_residual`** / **`transcendental_complex_residual`** — a dense Gδ is **residual/comeagre** (`residual_of_dense_Gδ`) and the transcendentals are dense (`transcendental_reals_dense`). This is the Baire-category *largeness* dual of the file's existing conull measure-largeness (`transcendental_reals_conull`).
- **`algebraic_reals_meagre`** / **`algebraic_complex_meagre`** — the algebraic numbers are **meagre** (`IsMeagre s := sᶜ ∈ residual`), the category-smallness pillar sitting alongside `algebraic_reals_null` (measure) and `algebraic_reals_dimH_zero` (dimension).

The algebraic reals are now shown, all within one file, to be simultaneously null (measure), meagre (category), dimension-zero (Hausdorff), countable (cardinality) and perfect-kernel-free (descriptive); the transcendentals dually conull, comeagre, full-dimensional and continuum.

## Verification

- `bin/lake env lean` compiles the full file, exit 0 (only pre-existing benign linter warnings).
- `#print axioms` for all six new theorems = `[propext, Classical.choice, Quot.sound]` — **0 sorries, 0 axioms, no `native_decide`**. Entry stays `verified` / `axiomCount: 0`.
- Gallery meta updated: `theoremCount` 30→36, `lineCount` 487→550, summary notes the internalized category pillar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)