### PR TITLE
research(erdos-3): repair Mathlib drift — restore Erdos3Problem + Erdos3LogHarmonic to verified

### DIFF
--- a/proofs/Proofs/Erdos3LogHarmonic.lean
+++ b/proofs/Proofs/Erdos3LogHarmonic.lean
@@ -277,13 +277,15 @@ theorem summable_one_div_nat_mul_log_mul_const {c δ : ℝ} (hc : 0 < c) (hδ : 
   have hc2 : (0 : ℝ) < c ^ 2 := by positivity
   -- threshold `N₀` above `2`, `2/c` and `1/c²` (so `m·c ≥ 2` and `m·c² ≥ 1` on the tail)
   set N₀ : ℕ := max 2 (⌈2 / c⌉₊ + ⌈1 / c ^ 2⌉₊) with hN₀def
-  have hN₀2 : (2 : ℝ) ≤ (N₀ : ℝ) := by exact_mod_cast le_max_left 2 (⌈2 / c⌉₊ + ⌈1 / c ^ 2⌉₊)
-  have hN₀2c : 2 / c ≤ (N₀ : ℝ) :=
-    le_trans (Nat.le_ceil _) (by exact_mod_cast le_trans (Nat.le_add_right _ _)
-      (le_max_right 2 (⌈2 / c⌉₊ + ⌈1 / c ^ 2⌉₊)))
-  have hN₀c2 : 1 / c ^ 2 ≤ (N₀ : ℝ) :=
-    le_trans (Nat.le_ceil _) (by exact_mod_cast le_trans (Nat.le_add_left _ _)
-      (le_max_right 2 (⌈2 / c⌉₊ + ⌈1 / c ^ 2⌉₊)))
+  have hN₀2 : (2 : ℝ) ≤ (N₀ : ℝ) := by
+    have h : (2 : ℕ) ≤ N₀ := le_max_left _ _
+    exact_mod_cast h
+  have hN₀2c : 2 / c ≤ (N₀ : ℝ) := by
+    have h : ⌈2 / c⌉₊ ≤ N₀ := le_trans (Nat.le_add_right _ _) (le_max_right _ _)
+    exact le_trans (Nat.le_ceil _) (by exact_mod_cast h)
+  have hN₀c2 : 1 / c ^ 2 ≤ (N₀ : ℝ) := by
+    have h : ⌈1 / c ^ 2⌉₊ ≤ N₀ := le_trans (Nat.le_add_left _ _) (le_max_right _ _)
+    exact le_trans (Nat.le_ceil _) (by exact_mod_cast h)
   -- dominating series: the constant-free convergent series, shifted and scaled by `2^{1+δ}`
   have hbase : Summable (fun n : ℕ => 1 / ((n : ℝ) * (Real.log n) ^ (1 + δ))) :=
     summable_one_div_nat_mul_log_rpow hδ
@@ -350,11 +352,9 @@ theorem not_summable_one_div_nat_mul_log_mul_const {c : ℝ} (hc : 0 < c) :
   set N₀ : ℕ := max 2 (⌈c⌉₊ + ⌈2 / c⌉₊) with hN₀def
   have hN₀2 : (2 : ℝ) ≤ (N₀ : ℝ) := by exact_mod_cast le_max_left 2 (⌈c⌉₊ + ⌈2 / c⌉₊)
   have hN₀c : c ≤ (N₀ : ℝ) :=
-    le_trans (Nat.le_ceil _) (by exact_mod_cast le_trans (Nat.le_add_right _ _)
-      (le_max_right 2 (⌈c⌉₊ + ⌈2 / c⌉₊)))
+    le_trans (Nat.le_ceil _) (by exact_mod_cast le_trans (Nat.le_add_right _ _) (le_max_right 2 (⌈c⌉₊ + ⌈2 / c⌉₊)))
   have hN₀2c : 2 / c ≤ (N₀ : ℝ) :=
-    le_trans (Nat.le_ceil _) (by exact_mod_cast le_trans (Nat.le_add_left _ _)
-      (le_max_right 2 (⌈c⌉₊ + ⌈2 / c⌉₊)))
+    le_trans (Nat.le_ceil _) (by exact_mod_cast le_trans (Nat.le_add_left _ _) (le_max_right 2 (⌈c⌉₊ + ⌈2 / c⌉₊)))
   -- the given series, shifted past the threshold and scaled by `2`, dominates `1/(n·log n)`
   have hdom : Summable (fun n : ℕ => (2 : ℝ) *
       (1 / (((n + N₀ : ℕ) : ℝ) * Real.log (((n + N₀ : ℕ) : ℝ) * c)))) :=

--- a/proofs/Proofs/Erdos3Problem.lean
+++ b/proofs/Proofs/Erdos3Problem.lean
@@ -785,7 +785,7 @@ theorem summable_of_sharpBound {A : Set ℕ} {C δ : ℝ} (hδ : 0 < δ) (hC : 0
   -- Strong bound: for j ≥ Nthr, block mass ≤ g j.
   have hstrong : ∀ j, Nthr ≤ j → block j ≤ g j := by
     intro j hj
-    have hgj : g j = full j := by rw [hgdef]; exact Set.indicator_of_mem hj
+    have hgj : g j = full j := by rw [hgdef]; exact Set.indicator_of_mem hj full
     rw [hgj]
     have hbe : block j
         = ∑ i ∈ (Finset.Ico (2 ^ j) (2 ^ (j + 1))).filter (· ∈ A), F i := by
@@ -837,7 +837,6 @@ theorem summable_of_sharpBound {A : Set ℕ} {C δ : ℝ} (hδ : 0 < δ) (hC : 0
           have hpw : (Real.log (((j : ℝ) + 1) * Real.log 2)) ^ (1 + δ) ≠ 0 :=
             ne_of_gt (Real.rpow_pos_of_pos hlp _)
           field_simp
-          ring
   -- Combine into a uniform partial-sum bound and conclude summability.
   have hcombine : ∀ j, block j ≤ (if j < Nthr then (1 : ℝ) else 0) + g j := by
     intro j
@@ -921,8 +920,6 @@ theorem sharp_required_bound_implies_conjecture :
           exact_mod_cast countingFunction_le_rothNumber A (max k 3) N hApf
       _ ≤ C * (N : ℝ) / (Real.log N * (Real.log (Real.log N)) ^ (1 + δ)) := hN
   exact hdiv (summable_of_sharpBound hδ hC hcount)
-
-/-- **Divergent reciprocal sum forces super-`(log)^{1+δ}` density infinitely often.**
 
 /-- **Divergent reciprocal sum forces super-`(log)^{1+δ}` density infinitely often.**
     The contrapositive of `summable_of_strongBound`, packaged as a positive density
@@ -1010,7 +1007,7 @@ theorem strongRequiredBound_implies_sharpRequiredBound {k : ℕ}
   have hlog : Filter.Tendsto (fun N : ℕ => Real.log (N : ℝ)) Filter.atTop Filter.atTop :=
     Real.tendsto_log_atTop.comp tendsto_natCast_atTop_atTop
   have hr : (0 : ℝ) < δ / 2 := by linarith
-  have hlittle := (Real.isLittleO_log_rpow_atTop hr).comp_tendsto hlog
+  have hlittle := (isLittleO_log_rpow_atTop hr).comp_tendsto hlog
   have hbound := Asymptotics.isLittleO_iff.mp hlittle (one_pos)
   simp only [Function.comp_apply] at hbound
   have hLgt : ∀ᶠ N : ℕ in Filter.atTop, 1 < Real.log (N : ℝ) :=

--- a/src/data/proofs/erdos-3/meta.json
+++ b/src/data/proofs/erdos-3/meta.json
@@ -65,7 +65,7 @@
       }
     ],
     "axiomCount": 0,
-    "lineCount": 1224,
+    "lineCount": 1221,
     "prerequisites": [
       "Arithmetic progressions and their properties",
       "Series convergence and divergence (reciprocal sums)",

--- a/src/data/research/problems/erdos-3-incomplete-01.json
+++ b/src/data/research/problems/erdos-3-incomplete-01.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (researcher-4, 2026-07-10): formalized StrongRequiredBound ⇒ SharpRequiredBound (strongRequiredBound_implies_sharpRequiredBound) + sharpRequiredBound_mono, completing the ordering of the three conditional-threshold hypotheses. The Strong⇒Sharp implication certifies that the sharp reduction (sharp_required_bound_implies_conjecture) genuinely sharpens the strong one. Build UNVERIFIED: docker containerd corrupted (blob/meta.db I/O errors, operator-level), no local/host mathlib oleans; all lemma signatures checked against v4.26.0 pin (isLittleO_log_rpow_atTop, IsLittleO.comp_tendsto, isLittleO_iff, rpow_mul, div_le_div_iff₀). Threshold-critical sorry required_bound_implies_conjecture untouched (as hard as Erdős #3).",
+    "progressSummary": "BUILD REPAIR (researcher-5, 2026-07-11): both Erdos3LogHarmonic.lean and Erdos3Problem.lean were UNVERIFIED and NON-COMPILING on main (Mathlib drift accumulated while docker was down). Repaired end-to-end: (LogHarmonic) multi-line `exact_mod_cast` term no longer continues onto the next line inside a parenthesised `by` → joined; `set`-fold + c^2 ℝ/ℕ exponent mismatch in the two threshold lemmas → rewrote as ℕ inequalities then cast. (Problem) a stray DUPLICATE `/--` docstring at line 925 opened an unterminated comment that swallowed the entire second half of the file (all ordering-lattice + green-tao theorems silently undefined) → removed; `Real.isLittleO_log_rpow_atTop` moved to root namespace → dropped `Real.`; `Set.indicator_of_mem hj` needs the explicit function arg `full`; redundant `ring` after `field_simp` removed. Both files now compile 0 errors; all repaired sorry-free theorems axiom-free [propext,choice,Quot.sound]. The single remaining sorry is the off-limits threshold-critical required_bound_implies_conjecture (as hard as Erdős #3). PROGRESS (researcher-4, 2026-07-10): formalized StrongRequiredBound ⇒ SharpRequiredBound (strongRequiredBound_implies_sharpRequiredBound) + sharpRequiredBound_mono, completing the ordering of the three conditional-threshold hypotheses. The Strong⇒Sharp implication certifies that the sharp reduction (sharp_required_bound_implies_conjecture) genuinely sharpens the strong one. Build UNVERIFIED: docker containerd corrupted (blob/meta.db I/O errors, operator-level), no local/host mathlib oleans; all lemma signatures checked against v4.26.0 pin (isLittleO_log_rpow_atTop, IsLittleO.comp_tendsto, isLittleO_iff, rpow_mul, div_le_div_iff₀). Threshold-critical sorry required_bound_implies_conjecture untouched (as hard as Erdős #3).",
     "builtItems": [
       "containsAP_of_le",
       "summable_of_strongBound",
@@ -87,7 +87,7 @@
     "mathlib": []
   },
   "started": "2026-04-03T08:27:10.083Z",
-  "lastUpdate": "2026-07-09",
+  "lastUpdate": "2026-07-11",
   "significance": 8,
   "tractability": 4,
   "leanFiles": [


### PR DESCRIPTION
## Summary

**Both erdos-3 files were `[UNVERIFIED]` and did not compile on `main`.** The drift accumulated across several commits landed while docker was down; the prebuilt oleans were stale-but-valid, masking the breakage from CI. This PR repairs the full dependency chain so the flagship builds again end-to-end.

## `Erdos3Problem.lean`

- **Unterminated comment** — a stray *duplicate* `/--` docstring at line 925 opened a nested comment that was never closed, **silently swallowing the entire second half of the file** (every ordering-lattice lemma, the Green–Tao bridge, `erdos_3_open`, …). Removed the duplicate.
- `Real.isLittleO_log_rpow_atTop` → `isLittleO_log_rpow_atTop` (the lemma now lives in the root namespace).
- `Set.indicator_of_mem hj` → `Set.indicator_of_mem hj full` — the function argument could not be inferred ("typeclass instance problem is stuck").
- Removed a redundant `ring` after a `field_simp` that already closes the goal ("no goals to be solved").

## `Erdos3LogHarmonic.lean`

- **Parse errors** (`unexpected token '('`): a multi-line `exact_mod_cast <term>` where the term continued onto the next line inside a parenthesised `by` — the term parser stopped at the line break. Joined onto one line.
- The two threshold lemmas' `have`s failed with `set`-fold and a `c ^ 2` ℝ/ℕ exponent mismatch; rewrote them as `ℕ` inequalities (`le_max_*`, `Nat.le_add_*`) then cast.

## Verification

- `./bin/lake env lean Proofs/Erdos3LogHarmonic.lean` → **0 errors**.
- `./bin/lake env lean Proofs/Erdos3Problem.lean` (against a freshly-built LogHarmonic olean) → **0 errors**, only the expected off-limits `sorry` warning.
- `#print axioms` on all repaired sorry-free theorems (ordering lattice, `sharp_required_bound_implies_conjecture`, both LogHarmonic summability lemmas): foundational only `[propext, Classical.choice, Quot.sound]`.

The single remaining `sorry` is the threshold-critical `required_bound_implies_conjecture` — as hard as Erdős #3 itself, deliberately left open. `meta.lineCount` 1224→1221; `status`/`sorries`/`axiomCount` unchanged (now actually accurate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)