### PR TITLE
Enrich algebraic-numbers-countable-oq-02-oq-03-oq-02-oq-01: cross-refs to concrete instances and Baire foundation

### DIFF
--- a/src/data/proofs/algebraic-numbers-countable-oq-02-oq-03-oq-02-oq-01/meta.json
+++ b/src/data/proofs/algebraic-numbers-countable-oq-02-oq-03-oq-02-oq-01/meta.json
@@ -142,6 +142,21 @@
       "targetId": "algebraic-numbers-countable-oq-02-oq-03-oq-02",
       "relationship": "extends",
       "description": "Parent: proves the concrete ℝ dichotomy (algebraic reals Fσ-not-Gδ, transcendentals dense Gδ). This entry abstracts the Baire-category engine of the 'not Gδ' half to arbitrary perfect T1 Baire spaces and recovers ℚ ⊆ ℝ as a corollary."
+    },
+    {
+      "targetId": "algebraic-reals-meager-dense-gdelta-oq-01",
+      "relationship": "related",
+      "description": "A concrete instance of the abstract theorem here: the algebraic reals are an explicit Fσ, completing the Gδ/Fσ dichotomy on ℝ. This entry's 'dense countable ⇒ Fσ-but-not-Gδ' specialises to exactly that statement (with density supplied by ℚ ⊆ algebraic reals)."
+    },
+    {
+      "targetId": "algebraic-reals-meager-dense-gdelta",
+      "relationship": "related",
+      "description": "The complement side of the same concrete instance: the transcendental reals as an explicit dense Gδ. Here it is the abstract 'complement of a countable set is a dense Gδ' half, applied to the countable algebraic reals in ℝ."
+    },
+    {
+      "targetId": "baire-category-theorem-oq-01",
+      "relationship": "related",
+      "description": "Foundational input: the BaireSpace hypothesis driving the 'not Gδ' obstruction is the Baire category theorem. That entry establishes it (and derives the uncountability of ℝ); this entry consumes it abstractly via the four typeclass hypotheses (T1, perfect, Baire, nonempty)."
     }
   ],
   "references": [


### PR DESCRIPTION
Enrichment pass for `algebraic-numbers-countable-oq-02-oq-03-oq-02-oq-01` (Dense Countable Sets are Fσ but not Gδ in Perfect Polish Spaces).

The entry already met all depth targets (5 keyInsights, 7 fully-fielded annotations, conclusion with 2 open questions) but had only its parent as a cross-reference. Added three accurate links (crossReferences 1→4, under cap 20):

- **`algebraic-reals-meager-dense-gdelta-oq-01` (related)** — the algebraic reals as an explicit Fσ, a concrete instance of this abstract theorem.
- **`algebraic-reals-meager-dense-gdelta` (related)** — the transcendentals as a dense Gδ, the complement side.
- **`baire-category-theorem-oq-01` (related)** — the Baire category theorem, the foundational input behind the 'not Gδ' obstruction.

Verified each target's content/title before linking. No other fields touched; meta ~13 KB, within all size caps.