### PR TITLE
research(elementary-quadratic-reciprocity-oq-03-oq-02): denominator sign law (n ↦ -n dual)

### DIFF
--- a/proofs/Proofs/ElementaryQuadraticReciprocityOQ03OQ02.lean
+++ b/proofs/Proofs/ElementaryQuadraticReciprocityOQ03OQ02.lean
@@ -1074,6 +1074,54 @@ theorem kronecker_even_pow_right_eq_one_of_coprime (a : ℤ) (n k : ℕ)
   rw [kronecker_pow_right (a : ℤ) (n : ℤ) (2 * k) (by exact_mod_cast hn.ne'), pow_mul,
     kronecker_sq_eq_one_of_coprime a n hn hno h, one_pow]
 
+-- ============================================================
+-- Section 14: Denominator sign law (behaviour under n ↦ -n)
+-- ============================================================
+
+/-! The numerator-negation family of Section 10 records how the symbol twists when the
+*numerator* changes sign: `(-a/n) = (-1/n)·(a/n)`. Its exact dual — how the symbol behaves
+when the *denominator* changes sign — is the following. Because `kronecker` is multiplicative
+in the second argument (`kronecker_mul_right`) and `-n = (-1)·n`, negating the modulus twists
+the symbol by the value `(a/(-1)) = kroneckerNeg1 a`, the sign character of the *numerator*.
+Concretely the symbol is even in the modulus sign for `a ≥ 0` and odd for `a < 0` — the
+reflection of how the numerator law depends on `n mod 4`, here depending instead on the sign of
+`a` (which is exactly what `(a/(-1))` measures). All proofs are one line off second-argument
+multiplicativity and hold for the symbol exactly as defined. -/
+
+/-- **Denominator negation, general modulus.** For any numerator `a` and any nonzero modulus
+`n`, `(a/(-n)) = (a/(-1))·(a/n)`. The second-argument dual of `kronecker_neg_numerator`; an
+instance of `kronecker_mul_right` applied to `-n = (-1)·n`. -/
+theorem kronecker_neg_denominator (a n : ℤ) (hn : n ≠ 0) :
+    kronecker a (-n) = kronecker a (-1) * kronecker a n := by
+  rw [show (-n : ℤ) = (-1) * n by ring]
+  exact kronecker_mul_right a (-1) n (mul_ne_zero (by norm_num) hn)
+
+/-- **The symbol at modulus `-1` is the numerator sign character.** `(a/(-1)) = kroneckerNeg1 a`
+(namely `1` for `a ≥ 0` and `-1` for `a < 0`). Via `kronecker_eq_sign_jacobi` at `n = -1`,
+where `|n| = 1` and `jacobiSym a 1 = 1`. -/
+theorem kronecker_neg_one_denominator (a : ℤ) :
+    kronecker a (-1) = kroneckerNeg1 a := by
+  rw [kronecker_eq_sign_jacobi a (-1) (by norm_num)]
+  norm_num [jacobiSym.one_right]
+
+/-- **Denominator negation via the sign character.** `(a/(-n)) = kroneckerNeg1 a · (a/n)`:
+the explicit form of `kronecker_neg_denominator` with `(a/(-1))` evaluated. -/
+theorem kronecker_neg_denominator_eq_kroneckerNeg1 (a n : ℤ) (hn : n ≠ 0) :
+    kronecker a (-n) = kroneckerNeg1 a * kronecker a n := by
+  rw [kronecker_neg_denominator a n hn, kronecker_neg_one_denominator]
+
+/-- **The symbol is even in the modulus sign for a nonnegative numerator.** For `0 ≤ a` and
+`n ≠ 0`, `(a/(-n)) = (a/n)`, since the sign character `kroneckerNeg1 a = 1`. -/
+theorem kronecker_neg_denominator_nonneg (a n : ℤ) (ha : 0 ≤ a) (hn : n ≠ 0) :
+    kronecker a (-n) = kronecker a n := by
+  rw [kronecker_neg_denominator_eq_kroneckerNeg1 a n hn, kroneckerNeg1_nonneg a ha, one_mul]
+
+/-- **The symbol is odd in the modulus sign for a negative numerator.** For `a < 0` and
+`n ≠ 0`, `(a/(-n)) = -(a/n)`, since the sign character `kroneckerNeg1 a = -1`. -/
+theorem kronecker_neg_denominator_neg (a n : ℤ) (ha : a < 0) (hn : n ≠ 0) :
+    kronecker a (-n) = - kronecker a n := by
+  rw [kronecker_neg_denominator_eq_kroneckerNeg1 a n hn, kroneckerNeg1_neg a ha, neg_one_mul]
+
 /-!
 ## Module note: what remains open
 

--- a/research/problems/elementary-quadratic-reciprocity-oq-03-oq-02-wip-01/state.md
+++ b/research/problems/elementary-quadratic-reciprocity-oq-03-oq-02-wip-01/state.md
@@ -68,3 +68,19 @@ supplementary laws are done. Or refinement (1): redefine `kronecker` to use
   `kronecker_two_periodic` ((2/·) periodic mod 8). Structural complement of
   `kronecker2_periodic`; feeds the Gauss-sum route (refinement 2). The Gauss-sum
   reciprocity core and refinement (1) definition rewiring both remain open.
+
+## Update (2026-07-11, researcher-8 — denominator sign law)
+
+Added **Section 14: Denominator sign law** (behaviour under `n ↦ -n`), the exact
+second-argument dual of Section 10's numerator-negation family (5 theorems, 0 sorry /
+0 axiom, VERIFIED `bin/lake env lean`, all `[propext, Classical.choice, Quot.sound]`):
+- `kronecker_neg_denominator` — `(a/(-n)) = (a/(-1))·(a/n)` for `n ≠ 0`, instance of
+  `kronecker_mul_right` on `-n = (-1)·n`.
+- `kronecker_neg_one_denominator` — `(a/(-1)) = kroneckerNeg1 a` (the numerator sign
+  character), via `kronecker_eq_sign_jacobi` at `n = -1`.
+- `kronecker_neg_denominator_eq_kroneckerNeg1` — `(a/(-n)) = kroneckerNeg1 a · (a/n)`.
+- `kronecker_neg_denominator_nonneg` / `_neg` — even/odd in the modulus sign for
+  `a ≥ 0` / `a < 0` (dual of the numerator law's `n mod 4` dependence, here on `sign a`).
+
+Meta counts updated (theoremCount 76→81, lineCount 1124→1172). The two genuinely-open
+refinements (kronecker2 def-rewiring; Gauss-sum generalized-reciprocity core) remain.

--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-03-oq-02/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-03-oq-02/meta.json
@@ -18,9 +18,9 @@
     "badge": "wip",
     "sorries": 0,
     "axiomCount": 0,
-    "theoremCount": 76,
+    "theoremCount": 81,
     "defCount": 6,
-    "lineCount": 1124,
+    "lineCount": 1172,
     "dateAdded": "2026-03-28",
     "assumptions": "0 axioms, 0 sorries — the file is fully machine-verified (no axiom or sorry is used). Complete multiplicativity is now proven in BOTH arguments over all nonzero moduli: kronecker_mul_left and kronecker_mul_right, alongside agreement with the Jacobi symbol and odd-modulus quadratic reciprocity. Status is kept 'wip' because the FORMALIZATION of the classical symbol is still partial, not because anything is assumed: (1) the definition routes even moduli through jacobiSym |n| rather than the classical mod-8 character kronecker2, so kronecker_mul_right is multiplicativity of the symbol as defined (which matches the classical Kronecker symbol at all odd moduli and at n = plus/minus 1); and (2) generalized quadratic reciprocity for arbitrary fundamental discriminants remains open. Both are documented as open work in the source module note; neither is axiomatized. Toward (2), the denominator-side supplementary characters are now shown periodic: kronecker_neg_one_periodic ((-1/.) is periodic mod 4) and kronecker_two_periodic ((2/.) is periodic mod 8), the structural complement of kronecker2_periodic (the numerator character (./2) is a Dirichlet character mod 8) and a Gauss-sum-route input.",
     "mathlib_version": "4.26.0",
@@ -97,9 +97,9 @@
       "Mathlib.NumberTheory.LegendreSymbol.JacobiSymbol"
     ],
     "namespace": "KroneckerSymbol",
-    "lineCount": 1124,
+    "lineCount": 1172,
     "axiomCount": 0,
-    "theoremCount": 76,
+    "theoremCount": 81,
     "definitionCount": 6,
     "path": "Proofs/ElementaryQuadraticReciprocityOQ03OQ02.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

Adds **Section 14: Denominator sign law** to the Kronecker-symbol file — the exact second-argument dual of Section 10's numerator-negation family. Section 10 records how the symbol twists when the *numerator* changes sign (`(-a/n) = (-1/n)·(a/n)`); this PR supplies the missing companion for when the *modulus* changes sign.

## What's added (5 theorems, axiom-free)

- **`kronecker_neg_denominator`** — `(a/(-n)) = (a/(-1))·(a/n)` for `n ≠ 0`, an instance of second-argument multiplicativity `kronecker_mul_right` on `-n = (-1)·n`.
- **`kronecker_neg_one_denominator`** — `(a/(-1)) = kroneckerNeg1 a` (the numerator sign character), via `kronecker_eq_sign_jacobi` at `n = -1` where `|n| = 1`.
- **`kronecker_neg_denominator_eq_kroneckerNeg1`** — `(a/(-n)) = kroneckerNeg1 a · (a/n)`.
- **`kronecker_neg_denominator_nonneg`** / **`kronecker_neg_denominator_neg`** — the symbol is **even** in the modulus sign for `a ≥ 0` and **odd** for `a < 0`. This is the reflection of the numerator law's `n mod 4` dependence, here depending instead on `sign a` — which is exactly what `(a/(-1))` measures.

Together with the existing numerator-negation family this completes the symbol's behaviour under sign changes in *both* arguments.

## Verification

- `bin/lake env lean` compiles the full file, exit 0 (only a pre-existing benign `done`-no-op warning).
- `#print axioms` for all five new theorems = `[propext, Classical.choice, Quot.sound]` — **0 sorries, 0 axioms, no `native_decide`**.
- Gallery meta updated: `theoremCount` 76→81, `lineCount` 1124→1172. The open refinements (`kronecker2` def-rewiring; Gauss-sum generalized reciprocity) are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)