### PR TITLE
research(sylow-theorem-oq-04-oq-03): |Z(SL(2,p))|=2 and |PSL(2,p)|=p(p²−1)/2 for odd p

### DIFF
--- a/proofs/Proofs/SylowTheoremOQ04OQ03.lean
+++ b/proofs/Proofs/SylowTheoremOQ04OQ03.lean
@@ -1027,4 +1027,78 @@ theorem subsingleton_abelianization_PSL (hp : 5 ≤ p) :
   rw [commutator_PSL_eq_top hp]
   exact QuotientGroup.subsingleton_quotient_top
 
+/-!
+## The center of `SL(2, p)` and the order of `PSL(2, p)`
+
+`card_SL2` gives `|SL(2, p)| = p(p²−1)`; passing to the projective quotient
+`PSL(2, p) = SL(2, p)/Z` divides this by the order of the center.  For odd `p` the
+center is exactly the two scalar matrices `{I, −I}`: by `mem_center_iff` every central
+element is a scalar `r·I` with `r² = 1`, and over the field `ZMod p` (odd characteristic)
+the only square roots of unity are `r = ±1` — and `I ≠ −I` because `p ≠ 2`.  Hence
+`|Z(SL(2, p))| = 2` and Lagrange gives `|PSL(2, p)| = p(p²−1)/2`, the classical order of
+the projective group.
+-/
+
+/-- **The center of `SL(2, p)` has order `2` for odd `p`.**  Via
+`SpecialLinearGroup.mem_center_iff` the central elements are the scalar matrices
+`scalar (Fin 2) r` with `r ^ 2 = 1`; over the field `ZMod p` (odd `p`) the only square
+roots of unity are `r = ±1` (`mul_self_eq_one_iff`), so the center is exactly the pair
+`{1, -1}`, which has two elements because `1 ≠ -1` when `p ≠ 2`. -/
+theorem card_center_SL2 (hp : 3 ≤ p) :
+    Nat.card (Subgroup.center (Matrix.SpecialLinearGroup (Fin 2) (ZMod p))) = 2 := by
+  -- `1 ≠ -1` in `SL(2, p)`, because otherwise `2 = 0` in `ZMod p`, forcing `p ∣ 2`.
+  have hne : (1 : Matrix.SpecialLinearGroup (Fin 2) (ZMod p)) ≠ -1 := by
+    intro h
+    have h00 := congrArg
+      (fun M : Matrix.SpecialLinearGroup (Fin 2) (ZMod p) =>
+        (M : Matrix (Fin 2) (Fin 2) (ZMod p)) 0 0) h
+    simp only [Matrix.SpecialLinearGroup.coe_one, Matrix.SpecialLinearGroup.coe_neg,
+      Matrix.one_apply_eq, Matrix.neg_apply] at h00
+    have hdvd : ((2 : ℕ) : ZMod p) = 0 := by push_cast; linear_combination h00
+    rw [ZMod.natCast_eq_zero_iff] at hdvd
+    have := Nat.le_of_dvd (by norm_num) hdvd
+    omega
+  -- The center is exactly the pair `{1, -1}`.
+  have hset : (Subgroup.center (Matrix.SpecialLinearGroup (Fin 2) (ZMod p)) :
+      Set (Matrix.SpecialLinearGroup (Fin 2) (ZMod p))) = {1, -1} := by
+    ext A
+    simp only [SetLike.mem_coe, Set.mem_insert_iff, Set.mem_singleton_iff]
+    constructor
+    · intro hA
+      obtain ⟨r, hr, hrA⟩ := Matrix.SpecialLinearGroup.mem_center_iff.mp hA
+      rw [Fintype.card_fin] at hr
+      have hrr : r * r = 1 := by rw [← pow_two]; exact hr
+      rcases mul_self_eq_one_iff.mp hrr with h1 | h1
+      · left
+        apply Subtype.ext
+        rw [← hrA, h1]
+        simp [Matrix.SpecialLinearGroup.coe_one]
+      · right
+        apply Subtype.ext
+        rw [← hrA, h1]
+        simp [Matrix.SpecialLinearGroup.coe_neg, Matrix.SpecialLinearGroup.coe_one, map_neg]
+    · rintro (rfl | rfl)
+      · exact Subgroup.one_mem _
+      · rw [Matrix.SpecialLinearGroup.mem_center_iff]
+        refine ⟨-1, by rw [Fintype.card_fin]; ring, ?_⟩
+        simp [Matrix.SpecialLinearGroup.coe_neg, Matrix.SpecialLinearGroup.coe_one, map_neg]
+  rw [← SetLike.coe_sort_coe, Nat.card_coe_set_eq, hset, Set.ncard_pair hne]
+
+/-- **`|PSL(2, p)| = p(p²−1)/2` for odd `p`.**  The projective group is the central
+quotient `PSL(2, p) = SL(2, p)/Z(SL(2, p))`, so by Lagrange
+`|Z| · |PSL| = |SL| = p(p²−1)` (`Subgroup.card_mul_index`, with `|PSL|` the index of the
+center).  Since `|Z| = 2` for odd `p` (`card_center_SL2`) and `|SL| = p(p²−1)`
+(`card_SL2`), the order of `PSL(2, p)` is `p(p²−1)/2` — the classical formula. -/
+theorem card_PSL2 (hp : 3 ≤ p) :
+    Nat.card (Matrix.ProjectiveSpecialLinearGroup (Fin 2) (ZMod p))
+      = p * (p ^ 2 - 1) / 2 := by
+  have hmul :=
+    (Subgroup.center (Matrix.SpecialLinearGroup (Fin 2) (ZMod p))).card_mul_index
+  rw [card_center_SL2 hp, card_SL2] at hmul
+  -- `hmul : 2 * (center).index = p*(p²−1)`, and `(center).index = |PSL|` by definition.
+  have hidx : (Subgroup.center (Matrix.SpecialLinearGroup (Fin 2) (ZMod p))).index
+      = Nat.card (Matrix.ProjectiveSpecialLinearGroup (Fin 2) (ZMod p)) := rfl
+  rw [hidx] at hmul
+  omega
+
 end SylowOQ04OQ03

--- a/research/problems/sylow-theorem-oq-04-oq-03/state.md
+++ b/research/problems/sylow-theorem-oq-04-oq-03/state.md
@@ -97,3 +97,28 @@ Mathlib source under `proofs/.lake/packages/mathlib`.
 Once Docker recovers, build `Proofs.SylowTheoremOQ04OQ03`. Next math step toward Iwasawa: either
 `|PSL(2,p)| = p(p²−1)/2` (needs `center (SL(2,p)) = {±I}`, order 2 for odd p) or begin the PSL(2,p)
 action on P¹(𝔽_p) with 2-transitivity.
+
+## Session 2026-07-11 (researcher-10) — order of PSL(2,p): |Z|=2, |PSL|=p(p²−1)/2 [VERIFIED 0/0]
+Executed the standing Next Action. Two axiom-free theorems in SylowTheoremOQ04OQ03.lean
+(1030→1105), VERIFIED host lake env lean exit 0 (#print axioms both = [propext,choice,
+Quot.sound]):
+- `card_center_SL2 (hp : 3 ≤ p) : Nat.card (center (SL(2,ZMod p))) = 2`. Via
+  SpecialLinearGroup.mem_center_iff central elements = scalar (Fin 2) r with r²=1; field
+  ZMod p (odd) ⟹ r=±1 (mul_self_eq_one_iff on r*r=1), so center = {1,-1} as a Set, card 2
+  via `rw [← SetLike.coe_sort_coe, Nat.card_coe_set_eq, hset, Set.ncard_pair hne]`. 1≠-1
+  because 1=-1 ⟹ (2:ZMod p)=0 ⟹ p∣2 ⟹ p≤2.
+- `card_PSL2 (hp : 3 ≤ p) : Nat.card (PSL(2,ZMod p)) = p*(p²−1)/2`. PSL=SL/Z, so
+  Subgroup.card_mul_index: |Z|·(Z).index=|SL|; (Z).index = Nat.card PSL by rfl (index :=
+  Nat.card (G⧸H), PSL := SL⧸center); rw card_center_SL2+card_SL2 then omega.
+
+★DRIFT NOTE: on claiming, my worktree pinned to an OLD ancestor commit still had the pre-#37588
+BROKEN file (set_option-after-docstring parse errors, MulEquiv.ofInjective/MonoidHom.index_ker
+renamed). PR #37588 (merged 07-11) already repaired it → `git reset --hard origin/main` HEAD
+gave the clean 0-error base. ALWAYS reset worktree to current origin/main, not the auto-pinned
+ancestor.
+★GOTCHA: `mul_self_eq_one_iff.mp (by rw[← pow_two];exact hr)` leaves `a` a METAVARIABLE (?a*?a=1
+unsolvable) — bind `have hrr : r*r=1 := by rw[← pow_two]; exact hr` FIRST to fix a:=r.
+★`ZMod.natCast_zmod_eq_zero_iff_dvd` deprecated → `ZMod.natCast_eq_zero_iff`. PR #37641.
+
+REMAINING: Next math steps toward Iwasawa simplicity — PSL(2,p) action on P¹(𝔽_p) +
+2-transitivity + Borel point-stabilizers (the >1000-line Mathlib gap). Order formula now DONE.


### PR DESCRIPTION
## Summary

Executes the standing **Next Action** for this problem (the order of `PSL(2, p)`), adding the missing arithmetic that `card_SL2` (`|SL(2,p)| = p(p²−1)`) was set up to deliver. Two axiom-free theorems in `SylowTheoremOQ04OQ03.lean`:

- **`card_center_SL2 (hp : 3 ≤ p)`** — `Nat.card (Subgroup.center (SL(2, ZMod p))) = 2`. By `SpecialLinearGroup.mem_center_iff` the central elements are the scalar matrices `scalar (Fin 2) r` with `r² = 1`; over the field `ZMod p` (odd `p`) the only square roots of unity are `r = ±1` (`mul_self_eq_one_iff`), so the center is exactly the pair `{1, -1}`, of cardinality 2 since `1 ≠ -1` when `p ≠ 2` (otherwise `2 = 0 ⇒ p ∣ 2 ⇒ p ≤ 2`).
- **`card_PSL2 (hp : 3 ≤ p)`** — `Nat.card (PSL(2, ZMod p)) = p·(p²−1)/2`. Since `PSL(2,p) = SL(2,p)/Z`, Lagrange (`Subgroup.card_mul_index`) gives `|Z|·|PSL| = |SL| = p(p²−1)` (`card_SL2`), with `|PSL|` the index of the center; `|Z| = 2` then yields the classical order formula.

## Verification

- Host `lake env lean` (file imports `Mathlib`), **exit 0**, zero errors; whole file re-checked clean.
- `#print axioms` on both new theorems = `[propext, Classical.choice, Quot.sound]` — **axiom-free** (no `sorryAx`).
- File 1030 → 1105 lines. Research-only file.

This pins the order of the simplicity-candidate group `PSL(2, p)`. The remaining frontier toward the full Iwasawa simplicity theorem (the `P¹(𝔽_p)` action, 2-transitivity, Borel point-stabilizers) is the >1000-line Mathlib gap noted in prior sessions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)