### PR TITLE
Enrich amgm-inequality-oq-02-oq-01-oq-05-oq-01: link the Newton's-inequality entries it strengthens

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-02-oq-01-oq-05-oq-01/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-02-oq-01-oq-05-oq-01/meta.json
@@ -109,6 +109,16 @@
       "targetId": "amgm-inequality-oq-02",
       "relationship": "parent-problem",
       "description": "Maclaurin's inequalities via elementary symmetric polynomials; S₂² ≥ S₁S₃ is the second rung of that chain and the first instance of Newton's log-concavity."
+    },
+    {
+      "targetId": "newton-inductive-step-oq-01",
+      "relationship": "complements",
+      "description": "The general nonnegative-reals Newton's inequality eₖ² ≥ eₖ₋₁·eₖ₊₁ (the gallery's NewtonLC.newton_ineq that this entry cites). This SOS entry strengthens its k=2 rung by removing the eₖ ≥ 0 hypothesis for n = 3 — Newton's inequalities are really facts about real-rooted polynomials, not signs."
+    },
+    {
+      "targetId": "newton-inductive-step",
+      "relationship": "related",
+      "description": "The binomial-coefficient log-concavity inductive step (bc³ + adc² + ac³ ≥ 2b²cd + b³d for consecutive binomials) underpinning the general Newton log-concavity theorem; here the cleared constant 3(n−1)/(2(n−2)) is the same binomial ratio C(n,2)²/(C(n,1)C(n,3))."
     }
   ],
   "references": [


### PR DESCRIPTION
Enrichment pass for `amgm-inequality-oq-02-oq-01-oq-05-oq-01` (Newton's Rung S₂² ≥ S₁S₃ via an explicit SOS certificate).

The entry already met depth targets (7 annotations, references, conclusion with 3 open questions) but had only 2 cross-references and explicitly cited 'the gallery's NewtonLC.newton_ineq' without linking it. Added two accurate links (crossReferences 2→4, under cap 20):

- **`newton-inductive-step-oq-01` (complements)** — the general nonnegative-reals Newton's inequality eₖ² ≥ eₖ₋₁·eₖ₊₁ (exactly the NewtonLC.newton_ineq this entry cites); the SOS proof here strengthens its k=2 rung by dropping the eₖ ≥ 0 hypothesis for n = 3.
- **`newton-inductive-step` (related)** — the binomial log-concavity inductive step whose ratio equals the cleared constant 3(n−1)/(2(n−2)).

Verified each target's content before linking. No other fields touched; meta ~12 KB, within all size caps.