### PR TITLE
research(erdos-1038-wip-01): boundedness & finiteness of the faithful sublevel objects

### DIFF
--- a/proofs/Proofs/Erdos1038WIP01.lean
+++ b/proofs/Proofs/Erdos1038WIP01.lean
@@ -679,4 +679,41 @@ theorem sublevelSup'_mem_Icc :
     ENNReal.ofReal (2 * Real.sqrt 2) ≤ sublevelSup' ∧ sublevelSup' ≤ ENNReal.ofReal 4 :=
   ⟨le_sublevelSup', sublevelSup'_le_four⟩
 
+/-! ### Boundedness and finiteness
+
+The `⊆ (−2, 2)` confinement gives more than the numeric `≤ 4` bound: the faithful sublevel
+set is a *bounded* set (complementing `isOpen_sublevelSet`, so it is a bounded open set), each
+faithful sublevel *measure* is finite, and — packaging the `≤ 4` supremum bound as a
+`⊤`-finiteness statement — the extremal supremum `sublevelSup'` is itself finite. The Erdős
+#1038 extremal constant is therefore a genuine real number, not `∞`, with no potential theory. -/
+
+/-- **The faithful sublevel set is bounded.**  It is confined to `(−2, 2)`
+(`sublevelSet_subset_Ioo`), a bounded interval; together with `isOpen_sublevelSet` this
+exhibits it as a bounded open subset of `ℝ`. -/
+theorem isBounded_sublevelSet {f : Polynomial ℝ} (hf : MonicRealRootedIn01' f) :
+    Bornology.IsBounded (sublevelSet f) :=
+  Metric.isBounded_Ioo (-2 : ℝ) 2 |>.subset (sublevelSet_subset_Ioo hf)
+
+/-- **Each faithful sublevel measure is finite** (`< ⊤`), from the uniform `≤ 4` bound. -/
+theorem sublevelMeasure_lt_top {f : Polynomial ℝ} (hf : MonicRealRootedIn01' f) :
+    sublevelMeasure f < ⊤ :=
+  lt_of_le_of_lt (sublevelMeasure_le_four hf) ENNReal.ofReal_lt_top
+
+/-- **Each faithful sublevel measure is finite** (`≠ ⊤`), the `Ne` form of
+`sublevelMeasure_lt_top`. -/
+theorem sublevelMeasure_ne_top {f : Polynomial ℝ} (hf : MonicRealRootedIn01' f) :
+    sublevelMeasure f ≠ ⊤ :=
+  (sublevelMeasure_lt_top hf).ne
+
+/-- **The faithful extremal supremum is finite** (`sublevelSup' < ⊤`).  Packaging
+`sublevelSup' ≤ 4` as a `⊤`-finiteness statement: the open Erdős #1038 extremal constant is a
+genuine finite real number, not `∞`. -/
+theorem sublevelSup'_lt_top : sublevelSup' < ⊤ :=
+  lt_of_le_of_lt sublevelSup'_le_four ENNReal.ofReal_lt_top
+
+/-- **The faithful extremal supremum is finite** (`sublevelSup' ≠ ⊤`), the `Ne` form of
+`sublevelSup'_lt_top`. -/
+theorem sublevelSup'_ne_top : sublevelSup' ≠ ⊤ :=
+  sublevelSup'_lt_top.ne
+
 end Erdos1038WIP01

--- a/research/problems/erdos-1038-wip-01/state.md
+++ b/research/problems/erdos-1038-wip-01/state.md
@@ -37,3 +37,20 @@ Tightening either endpoint to the sharp value requires potential theory beyond M
 - Total attempts: 4
 - Current approach attempts: 1
 - Approaches tried: 4
+
+## Update (2026-07-11, researcher-8 — boundedness & finiteness cluster)
+
+Added a boundedness/finiteness mini-section to `Erdos1038WIP01.lean` (5 theorems,
+0 sorry / 0 axiom, VERIFIED `bin/lake env lean`, all `[propext, Classical.choice,
+Quot.sound]`). The `⊆ (−2,2)` confinement already proved gives more than the numeric
+`≤ 4`:
+- `isBounded_sublevelSet` — the faithful sublevel set is `Bornology.IsBounded`
+  (⊆ Ioo(−2,2)); with `isOpen_sublevelSet` it is a bounded open set.
+- `sublevelMeasure_lt_top` / `_ne_top` — each faithful sublevel measure is finite.
+- `sublevelSup'_lt_top` / `_ne_top` — the extremal supremum is finite: packaging
+  `sublevelSup' ≤ 4` as `< ⊤`, so the open Erdős #1038 constant is a genuine finite
+  real, not `∞`, with no potential theory.
+
+No gallery meta change (the `erdos-1038` entry tracks `Erdos1038Problem.lean`, not this
+WIP file). The sharp constants (`sublevelSup' = 2√2`, exact `sublevelInf'`) remain open,
+needing logarithmic potential theory (Tao 2025) absent from Mathlib.


### PR DESCRIPTION
## Summary

`Erdos1038WIP01.lean` already confines the faithful sublevel set to `(−2, 2)` (`sublevelSet_subset_Ioo`) and bounds each measure by `4`. That confinement gives more than the numeric `≤ 4`: this PR extracts the **boundedness** and **finiteness** content that was missing (5 theorems, axiom-free).

## What's added

- **`isBounded_sublevelSet`** — the faithful sublevel set is `Bornology.IsBounded` (⊆ `Ioo(−2,2)`); combined with the existing `isOpen_sublevelSet` it is exhibited as a **bounded open** subset of `ℝ`.
- **`sublevelMeasure_lt_top`** / **`sublevelMeasure_ne_top`** — each faithful sublevel measure is finite, from the uniform `≤ 4` bound.
- **`sublevelSup'_lt_top`** / **`sublevelSup'_ne_top`** — the faithful extremal supremum is finite: packaging `sublevelSup' ≤ 4` as `< ⊤`, so the open Erdős #1038 extremal constant is a **genuine finite real number, not `∞`**, established with no potential theory.

## Verification

- `bin/lake env lean` compiles the full file, exit 0 (only pre-existing benign warnings).
- `#print axioms` for all five new theorems = `[propext, Classical.choice, Quot.sound]` — **0 sorries, 0 axioms, no `native_decide`**.
- No gallery meta change: the `erdos-1038` gallery entry tracks `Erdos1038Problem.lean`, not this research WIP file.

The sharp constants (`sublevelSup' = 2√2` and the exact `sublevelInf'`) remain open, requiring logarithmic potential theory (Tao 2025) absent from Mathlib.

🤖 Generated with [Claude Code](https://claude.com/claude-code)