### PR TITLE
research(erdos-703-incomplete-01): add T_L, the L-avoiding analogue of T [VERIFIED axiom-free]

### DIFF
--- a/proofs/Proofs/Erdos703Problem.lean
+++ b/proofs/Proofs/Erdos703Problem.lean
@@ -843,6 +843,65 @@ theorem avoidsLIntersections_insert {r : ℕ} {L : Finset ℕ} {F : Finset (Fins
   rw [Finset.insert_eq, avoidsLIntersections_union,
       avoidsRIntersection_iff_avoidsLIntersections_singleton]
 
+/--
+**T_L(n, L):** the maximum size of a family `F ⊆ 2^{[n]}` avoiding *every* intersection
+size in `L` — the Frankl–Wilson `L`-avoiding analogue of `T(n,r)`. The maximisation ranges
+over the same families as `T` (`F ∈ (range n).powerset.powerset`) but under the stronger
+`avoidsLIntersections L` constraint, so `T_L` interpolates the whole `T`-theory across the
+hierarchy: `T_L n {r} = T n r`, and forbidding more sizes can only shrink the maximum.
+-/
+noncomputable def T_L (n : ℕ) (L : Finset ℕ) : ℕ :=
+  (((Finset.range n).powerset.powerset).filter (avoidsLIntersections L)).sup
+    (fun F => F.card)
+
+/--
+**`T_L` specializes to `T` at a singleton.** Forbidding the single intersection size `r`
+recovers exactly `T(n,r)`, since `avoidsLIntersections {r}` and `avoidsRIntersection r` cut
+out the same families (`avoidsRIntersection_iff_avoidsLIntersections_singleton`). This is the
+statement that `T_L` genuinely generalizes the extremal quantity `T`.
+-/
+theorem T_L_singleton (n r : ℕ) : T_L n {r} = T n r := by
+  have hfilt :
+      ((Finset.range n).powerset.powerset).filter (avoidsLIntersections {r})
+        = ((Finset.range n).powerset.powerset).filter (avoidsRIntersection r) := by
+    apply Finset.ext
+    intro F
+    simp only [Finset.mem_filter, and_congr_right_iff]
+    intro _
+    exact (avoidsRIntersection_iff_avoidsLIntersections_singleton r F).symm
+  unfold T_L T
+  rw [hfilt]
+
+/--
+**`T_L` is antitone in the forbidden-size set.** Forbidding a *larger* set of intersection
+sizes is a stronger constraint, so it can only shrink the extremal family: `L ⊆ L'` gives
+`T_L n L' ≤ T_L n L`. Proved from `avoidsLIntersections_of_subset_forbidden` — every family
+counted by `T_L n L'` is also counted by `T_L n L` — via `Finset.sup_mono`.
+-/
+theorem T_L_antitone_forbidden {n : ℕ} {L L' : Finset ℕ} (hL : L ⊆ L') :
+    T_L n L' ≤ T_L n L := by
+  unfold T_L
+  apply Finset.sup_mono
+  intro F hF
+  rw [Finset.mem_filter] at hF ⊢
+  exact ⟨hF.1, avoidsLIntersections_of_subset_forbidden hL hF.2⟩
+
+/--
+**Adding a forbidden size cannot increase `T_L`.** The `insert` corollary of antitonicity:
+`T_L n (insert r L) ≤ T_L n L`. Assembling the forbidden set one size at a time (cf.
+`avoidsLIntersections_insert`) only tightens the bound. -/
+theorem T_L_insert_le {n r : ℕ} {L : Finset ℕ} : T_L n (insert r L) ≤ T_L n L :=
+  T_L_antitone_forbidden (Finset.subset_insert r L)
+
+/--
+**An `L`-avoiding maximum is bounded by the `r`-avoiding maximum for any forbidden `r ∈ L`.**
+If `r ∈ L` then `T_L n L ≤ T n r`: an `L`-avoiding family is in particular `r`-avoiding, so it
+cannot beat the single-size extremal `T(n,r)`. Ties the `L`-avoiding hierarchy back to the
+concrete quantities `T(n,r)` computed in Parts II–VI. -/
+theorem T_L_le_T_of_mem {n r : ℕ} {L : Finset ℕ} (hr : r ∈ L) : T_L n L ≤ T n r := by
+  rw [← T_L_singleton]
+  exact T_L_antitone_forbidden (Finset.singleton_subset_iff.mpr hr)
+
 /-
 ## Part VIII: Summary
 -/

--- a/research/problems/erdos-703-incomplete-01/state.md
+++ b/research/problems/erdos-703-incomplete-01/state.md
@@ -4,7 +4,7 @@
 
 **Phase**: ACT
 **Status**: Active
-**Last Updated**: 2026-07-09
+**Last Updated**: 2026-07-11
 
 ## Progress Summary
 
@@ -23,16 +23,27 @@ but zero lemmas):
 - `avoidsLIntersections_of_subset_forbidden` — antitone in the forbidden-size set.
 - `avoidsLIntersections_empty` — vacuous base case.
 
+**Follow-up (2026-07-11, researcher-3):** RE-VERIFIED the whole file axiom-free
+via `lake env lean` (toolchain v4.26.0, Docker not needed), EXIT 0 — the prior
+session's `L`-avoiding lemmas (incl. `_union` / `_insert` added since) are now
+confirmed, not just "correct by inspection". Then took the documented next step
+and added the **`avoidsLIntersections`-indexed analogue of `T`**:
+
+- `T_L (n : ℕ) (L : Finset ℕ)` — max family size avoiding every size in `L`.
+- `T_L_singleton` : `T_L n {r} = T n r` (the generalization is faithful).
+- `T_L_antitone_forbidden` : `L ⊆ L' ⟹ T_L n L' ≤ T_L n L` (via `Finset.sup_mono`).
+- `T_L_insert_le` : `T_L n (insert r L) ≤ T_L n L`.
+- `T_L_le_T_of_mem` : `r ∈ L ⟹ T_L n L ≤ T n r` (ties the hierarchy to concrete `T`).
+
+All four `#print axioms`-clean (`propext, Classical.choice, Quot.sound`). File 879→938L, 37→41 thm, 9→10 def.
+
 ## Blockers
 
 `mainQuestion` / `frankl_rodl_1987` is the deep 1987 exponential bound with no
-Mathlib pathway; it remains an axiom, untouched. Docker daemon corrupted this
-session (containerd `meta.db` I/O error at image build) → shipped UNVERIFIED;
-the four new lemmas are trivial Finset-membership facts, correct by inspection.
+Mathlib pathway; it remains the sole axiom, untouched.
 
 ## Next Action
 
-Re-verify once docker repaired:
-`./proofs/scripts/docker-build.sh Proofs.Erdos703Problem`. Further `L`-avoiding
-API (e.g. an `avoidsLIntersections`-indexed analogue of `T`) is possible but the
-core problem is otherwise mature around the standing axiom.
+Core problem is mature around the standing axiom. The `T_L` extremal quantity is
+now available for any further Frankl–Wilson `L`-avoiding development, but a
+numeric bound on `T_L` / `T` requires the still-missing Frankl–Rödl machinery.

--- a/src/data/proofs/erdos-703/meta.json
+++ b/src/data/proofs/erdos-703/meta.json
@@ -51,14 +51,15 @@
       "inter_card_eq_n_iff: the supporting characterization that for A, B ⊆ [n], |A ∩ B| = n iff A = B = [n]; the combinatorial core of the diagonal value.",
       "Structural lemmas on T: T_le_pow (T(n,r) ≤ 2^n), T_mono_ground (monotone in the ground-set size n), one_le_T (positivity), and full_powerset_avoids_r_of_lt / T_eq_pow_of_lt (T(n,r) = 2^n whenever n < r); plus largeSetsFamily_subset_franklFurediOdd_one linking Frankl's r=1 family into the general Frankl-Füredi construction.",
       "T_le_pow_sub_choose / T_le_pow_sub_one: sharpened upper bound T(n,r) ≤ 2^n − C(n,r), machine-checked. An r-avoiding family can contain no set of size exactly r (its self-pair A,A meets in |A| = r), so the family omits all C(n,r) subsets of size r, giving T(n,r) ≤ 2^n − C(n,r); for r ≤ n this yields the uniform strict improvement T(n,r) ≤ 2^n − 1 over the trivial ceiling, and it is tight at the diagonal r = n (C(n,n) = 1 recovers T(n,n) = 2^n − 1).",
-      "smallSetsFamily / smallSetsFamily_avoids_r / smallSetsFamily_card / sum_choose_le_T / n_add_one_le_T_n_2: the 'small' disjunct {A ⊆ [n] : |A| < r} of the Frankl–Füredi families, isolated as its own r-avoiding family (|A ∩ B| ≤ |A| < r). It admits an EXACT binomial-sum cardinality ∑_{k<r} C(n,k) (proved by partitioning into powersetCard k layers), giving the first certified POLYNOMIAL lower bound T(n,r) ≥ ∑_{k<r} C(n,k) for all n,r — specialising to T(n,2) ≥ n+1, a nontrivial bound on the r=2 line at the start of the middle range the Frankl–Rödl question concerns. Axiom-free ([propext, Classical.choice, Quot.sound])."
+      "smallSetsFamily / smallSetsFamily_avoids_r / smallSetsFamily_card / sum_choose_le_T / n_add_one_le_T_n_2: the 'small' disjunct {A ⊆ [n] : |A| < r} of the Frankl–Füredi families, isolated as its own r-avoiding family (|A ∩ B| ≤ |A| < r). It admits an EXACT binomial-sum cardinality ∑_{k<r} C(n,k) (proved by partitioning into powersetCard k layers), giving the first certified POLYNOMIAL lower bound T(n,r) ≥ ∑_{k<r} C(n,k) for all n,r — specialising to T(n,2) ≥ n+1, a nontrivial bound on the r=2 line at the start of the middle range the Frankl–Rödl question concerns. Axiom-free ([propext, Classical.choice, Quot.sound]).",
+      "T_L(n,L) + T_L_singleton / T_L_antitone_forbidden / T_L_insert_le / T_L_le_T_of_mem: the Frankl–Wilson L-avoiding analogue of the extremal quantity T — T_L(n,L) is the max size of a family avoiding EVERY intersection size in L. It faithfully generalizes T (T_L n {r} = T n r), is antitone in the forbidden-size set (L ⊆ L' ⟹ T_L n L' ≤ T_L n L, via Finset.sup_mono), and is bounded by any single-size extremal it forbids (r ∈ L ⟹ T_L n L ≤ T n r), tying the L-avoiding hierarchy back to the concrete T(n,r) values. Axiom-free ([propext, Classical.choice, Quot.sound])."
     ],
     "axiomCount": 1,
-    "lineCount": 879,
+    "lineCount": 938,
     "assumptions": "1 axiom: frankl_rodl_1987 (the deep Frankl–Rödl 1987 exponential bound — the affirmative answer to the main question). 0 sorries: the trivial case T(n,0)=2^{n-1} is fully machine-checked (#print axioms T_n_0 = [propext, Classical.choice, Quot.sound]) via a complement-pairing upper bound and a star-family witness. The unused opaque chromaticNumber axiom was removed; the geometric chromatic-number consequence is recorded as prose only since infinite unit-distance chromatic numbers are not yet in Mathlib.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 37,
-    "definitionCount": 9
+    "theoremCount": 41,
+    "definitionCount": 10
   },
   "crossReferences": [
     {
@@ -184,10 +185,10 @@
       "Finset"
     ],
     "namespace": "Erdos703",
-    "lineCount": 879,
+    "lineCount": 938,
     "axiomCount": 1,
-    "theoremCount": 37,
-    "definitionCount": 9,
+    "theoremCount": 41,
+    "definitionCount": 10,
     "path": "Proofs/Erdos703Problem.lean",
     "sorries": 0
   },

--- a/src/data/research/problems/erdos-703-incomplete-01.json
+++ b/src/data/research/problems/erdos-703-incomplete-01.json
@@ -15,7 +15,7 @@
     "open": [],
     "goal": ""
   },
-  "currentState": "T(n,0)=2^{n-1} is fully machine-checked, and BOTH parities of the Frankl-Füredi extremal construction are now proved r-avoiding with matching T(n,r) lower bounds: franklFurediOdd_avoids_r / _card_le_T (all n,r) and the new even-parity companions franklFurediEven_avoids_r / _card_le_T (n+r even, n≥1). The deep Frankl-Rödl exponential bound (frankl_rodl_1987) remains the sole axiom. Entry status: axiomatized, 1 axiom, 0 sorries.",
+  "currentState": "T(n,0)=2^{n-1} is fully machine-checked, and BOTH parities of the Frankl-Füredi extremal construction are now proved r-avoiding with matching T(n,r) lower bounds: franklFurediOdd_avoids_r / _card_le_T (all n,r) and the new even-parity companions franklFurediEven_avoids_r / _card_le_T (n+r even, n≥1). The deep Frankl-Rödl exponential bound (frankl_rodl_1987) remains the sole axiom. Entry status: axiomatized, 1 axiom, 0 sorries. | Follow-up (researcher-3, 2026-07-11): re-verified the whole file axiom-free via `lake env lean` (v4.26.0), EXIT 0 — confirming the previously UNVERIFIED (docker-down) L-avoiding lemmas. Added the `T_L(n,L)` extremal quantity generalizing `T` to the Frankl-Wilson L-avoiding hierarchy: T_L_singleton (T_L n {r} = T n r), T_L_antitone_forbidden (L ⊆ L' ⟹ T_L n L' ≤ T_L n L), T_L_insert_le, and T_L_le_T_of_mem (r∈L ⟹ T_L n L ≤ T n r, tying the hierarchy back to concrete T). All 4 axiom-free [propext,choice,Quot.sound]. File 879→938L, 37→41 thm, 9→10 def; frankl_rodl_1987 remains the sole axiom.",
   "knowledge": {
     "progressSummary": "PROGRESS (researcher-2, 2026-07-09, VERIFIED green build): proved the exact diagonal value T(n,n)=2^n-1, the third exactly-known boundary value of T(n,r) alongside T(n,0)=2^{n-1} and T(n,r)=2^n (n<r). A family avoids n-intersection iff it omits the full ground set [n] (the unique n-meeting pair among subsets of [n] is [n] with itself, forbidden as a self-pair by avoidsRIntersection). Deep frankl_rodl_1987 axiom and exact T(n,1) (Frankl 1977 upper bound) remain open.",
     "builtItems": [
@@ -57,7 +57,7 @@
     "mathlib": []
   },
   "started": "2026-04-03T12:23:52.517Z",
-  "lastUpdate": "2026-07-08",
+  "lastUpdate": "2026-07-11",
   "significance": 7,
   "tractability": 5
 }


### PR DESCRIPTION
## Summary

`Erdos703Problem.lean` (Forbidden r-Intersection Families, Erdős #703) already develops the Frankl–Wilson `avoidsLIntersections L` predicate in Part VII, but had **no extremal quantity** attached to it. This PR adds the `avoidsLIntersections`-indexed analogue of `T(n,r)` — the documented next step in the research state — lifting the whole `T`-theory into the L-avoiding hierarchy:

```lean
noncomputable def T_L (n : ℕ) (L : Finset ℕ) : ℕ   -- max |F|, F ⊆ 2^[n], avoiding every intersection size in L

theorem T_L_singleton          (n r) : T_L n {r} = T n r                  -- faithful generalization of T
theorem T_L_antitone_forbidden (hL : L ⊆ L') : T_L n L' ≤ T_L n L         -- via Finset.sup_mono
theorem T_L_insert_le          : T_L n (insert r L) ≤ T_L n L
theorem T_L_le_T_of_mem        (hr : r ∈ L) : T_L n L ≤ T n r             -- ties the hierarchy back to concrete T(n,r)
```

`T_L n {r} = T n r` shows the generalization is faithful (via the existing `avoidsRIntersection_iff_avoidsLIntersections_singleton` bridge); antitonicity captures that forbidding more intersection sizes only shrinks the maximum; and `T_L_le_T_of_mem` connects the L-avoiding maxima back to the concrete `T(n,r)` values computed in Parts II–VI.

## Verification

- `lake env lean Proofs/Erdos703Problem.lean` (toolchain v4.26.0) — elaborates clean, EXIT 0, no new warnings.
- `#print axioms` of all four new theorems = `[propext, Classical.choice, Quot.sound]` — **axiom-free**.
- This session also **re-verified the whole file axiom-free**: the prior session's `avoidsLIntersections` lemmas had shipped UNVERIFIED (Docker daemon corrupted). They are now machine-confirmed.
- File 879 → 938 lines, 37 → 41 theorem/lemma, 9 → 10 def; still **0 sorries, 1 axiom** (`frankl_rodl_1987`, the deep open-literature Frankl–Rödl exponential bound — untouched). Entry remains honestly `axiomatized`.
- Gallery `meta.json` counts and `originalContributions` refreshed; research `state.md` / problem json updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)