### PR TITLE
Enrich amgm-inequality-oq-02-oq-03-oq-03-oq-01: link the SOS order-proof and Newton-Girard identity it discusses

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-02-oq-03-oq-03-oq-01/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-02-oq-03-oq-03-oq-01/meta.json
@@ -128,6 +128,16 @@
       "targetId": "amgm-inequality-oq-02",
       "relationship": "derives-from",
       "description": "Grandparent providing elemSymm, maclaurinMean, the maclaurin_step axiom, and the proved maclaurin_sq_m1_ge_m2_general used by newton_inequality_k1."
+    },
+    {
+      "targetId": "amgm-inequality-oq-02-oq-01-oq-05-oq-01",
+      "relationship": "complements",
+      "description": "The order proof this entry says the identities cannot supply: it proves the k=2 Newton rung e₂² ≥ 3e₁e₃ for all reals via an explicit SOS certificate. Together they make the point precisely — Newton's inequalities need an order argument (Cauchy-Schwarz here, sum-of-squares there), never the ring identities alone."
+    },
+    {
+      "targetId": "amgm-inequality-oq-02-oq-01-oq-03",
+      "relationship": "related",
+      "description": "A concrete instance of exactly the 'Newton identities as order-free ring equalities' this entry analyses: the fully reduced Newton-Girard k=3 closed form p₃ = e₁³ − 3e₁e₂ + 3e₃, derived from Mathlib's psum_eq_mul_esymm_sub_sum — an equality over any CommRing that, as argued here, carries no log-concavity information."
     }
   ],
   "mainTheorems": [


### PR DESCRIPTION
Enrichment pass for `amgm-inequality-oq-02-oq-03-oq-03-oq-01` (Maclaurin's Step via Mathlib Symmetric Functions: Resolving the Newton-Identities Question).

The entry's thesis is that Newton's *identities* (ring equalities) cannot prove Newton's *inequalities* (order facts) — yet it linked none of the gallery entries that make that contrast concrete. Added two accurate links (crossReferences 3→5, under cap 20):

- **`amgm-inequality-oq-02-oq-01-oq-05-oq-01` (complements)** — supplies exactly the order proof the identities cannot: the k=2 Newton rung e₂² ≥ 3e₁e₃ for all reals via an explicit SOS certificate.
- **`amgm-inequality-oq-02-oq-01-oq-03` (related)** — a concrete instance of the 'order-free ring identities' analysed here: the Newton-Girard k=3 closed form from Mathlib's psum_eq_mul_esymm_sub_sum.

Verified each target before linking. No other fields touched; meta ~16 KB, within all size caps.