### PR TITLE
Enrich amgm-inequality-oq-02-oq-04: link the all-reals SOS rung and general Newton's inequality

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-02-oq-04/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-02-oq-04/meta.json
@@ -173,6 +173,16 @@
       "targetId": "amgm-inequality",
       "relationship": "related",
       "description": "Recovers the AM–GM inequality as the endpoints M₁ ≥ M₃ of the three-variable Maclaurin chain."
+    },
+    {
+      "targetId": "amgm-inequality-oq-02-oq-01-oq-05-oq-01",
+      "relationship": "related",
+      "description": "Proves the very same k=2 rung e₂² ≥ 3e₁e₃ via an explicit SOS certificate but for ALL reals (no nonnegativity hypothesis), with the exact equality locus xy = yz = zx. This entry establishes it for nonnegative inputs as part of the full n=3 chain; that one is the strict all-reals strengthening of one rung."
+    },
+    {
+      "targetId": "newton-inductive-step-oq-01",
+      "relationship": "related",
+      "description": "The general-n Newton log-concavity inequality eₖ² ≥ eₖ₋₁·eₖ₊₁ for nonnegative reals. This entry discharges its n=3 case (both rungs) axiom-free via explicit SOS symmetrization, giving a self-contained base for the general induction."
     }
   ],
   "references": [


### PR DESCRIPTION
Enrichment pass for `amgm-inequality-oq-02-oq-04` (Newton's Inequalities for Three Variables: the n=3 Maclaurin Chain, Axiom-Free).

The entry was richly enriched (5 keyInsights, 11 annotations) but linked only its parent and the AM–GM root. Added two accurate links (crossReferences 2→4, under cap 20):

- **`amgm-inequality-oq-02-oq-01-oq-05-oq-01` (related)** — proves the very same k=2 rung e₂² ≥ 3e₁e₃ via SOS but for *all* reals (this entry does the nonnegative n=3 chain; that one is the all-reals strengthening of one rung).
- **`newton-inductive-step-oq-01` (related)** — the general-n Newton log-concavity eₖ² ≥ eₖ₋₁·eₖ₊₁ this n=3 chain is an axiom-free base case of.

Verified each target before linking. No other fields touched; meta ~14 KB, within all size caps.