### PR TITLE
research(erdos-1093-oq-02): window-check location bound closes k=28 — the record slice — frontier → k≥29

### DIFF
--- a/proofs/Proofs/Erdos1093ProblemOQ02.lean
+++ b/proofs/Proofs/Erdos1093ProblemOQ02.lean
@@ -2284,3 +2284,150 @@ theorem maximalDeficiencyIs_nine_iff_kGe28 :
     by_cases hk : k ≤ 27
     · exact deficiency_le_nine_of_k_le_27 hv.1 hv.2 hk
     · exact h n k (by omega) hv
+
+/-
+## Section XXIX: The location bound closes `k = 28` — frontier `k ≥ 28` → `k ≥ 29`
+
+Section XXVIII was described as the *terminal* elementary step, on the ground that the
+`k = 28` location window is inhabited by the genuine admissible deficiency-`9` example
+`(284, 28)`, so the pure **inadmissibility** argument that closes every earlier slice
+(`k = 16, …, 27`: *some* prime `≤ k` divides `C(n,k)` for **every** `n` in the window)
+provably fails at `k = 28`.  That is correct — but it is not the end of the elementary
+road, because the location window is *finite* and the deficiency of each admissible pair in
+it is a *decidable* quantity.  We close `k = 28` by the stronger, still elementary,
+**window-check** argument: instead of showing every window pair is inadmissible, we show
+that every *admissible* window pair has deficiency `≤ 9`.
+
+Concretely, a deficiency `≥ 10` at `k = 28` forces the window-floor power bound
+`(n - 27)^{10} ≤ 28!`, and `28! < 889^{10}` (`factorial_28_lt_889_pow_ten`), so
+`n - 27 < 889`, i.e. `n ≤ 915`.  With the admissibility floor `n ≥ 56 (= 2·28)` this
+leaves the finite window `n ∈ {56, 57, …, 915}` (eight hundred and sixty values).  Across
+that whole window there is **exactly one** admissible pair — the record `(284, 28)` itself
+— and its deficiency is `9`, not `≥ 10`.  Every other `n ∈ {56, …, 915}` is *inadmissible*:
+some prime `p ≤ 28` (in fact `p ∈ {2, 3, 5, 7, 11, 13, 17, 19, 23}`) divides `C(n,28)`.
+The single decidable fact `window_k28_admissible_deficiency_le_nine` records exactly this
+— for each `m` in the window, either a small prime divides `C(m,28)` or `deficiency m 28 ≤ 9`
+— and closes the slice.
+
+This is the true terminus of the elementary ladder: `k = 28` is the slice that *contains*
+the record, and the argument works precisely because the location window isolates the
+record as the **unique** admissible pair, whose deficiency is the record value `9`.  For
+`k ≥ 29` the record pair is gone, no analogous unique-admissible-pair phenomenon is known,
+and the remaining universal bound is the irreducibly analytic Erdős–Lacampagne–Selfridge
+input.  The elementary resolution of OQ-02 now covers **all `k ≤ 28`**, moving the open
+frontier to `k ≥ 29`.  As before the `(k!)²` factorial method is powerless here
+(`sharp_bound_permits_deficiency_ten` permits deficiency `10` for every `k ≥ 16`); only the
+window-check refinement of the *location* bound closes the slice.  The structural results
+remain `ofReduceBool`-free; only the concrete window fact uses `native_decide`. -/
+
+/-- `28! < 889^10`, the numeric input that pins the `k = 28` window: `(n-27)^{10} ≤ 28!`
+forces `n - 27 < 889`.  `ofReduceBool`-free (`Nat.factorial` and `Nat.pow` on literals
+reduce under kernel `decide`; `28! = 304888344611713860501504000000 <
+308331296938836253127540655601 = 889^{10}`; and `889` is sharp: `888^{10} =
+304880506868562346036873396224 ≤ 28!`). -/
+theorem factorial_28_lt_889_pow_ten : Nat.factorial 28 < 889 ^ 10 := by decide
+
+/-- **The `k = 28` window check.**  For every `m` in the location window `56 ≤ m ≤ 915`
+either some prime `p ∈ {2, 3, 5, 7, 11, 13, 17, 19, 23}` (each `≤ 28`) divides `C(m,28)` —
+so `m` is inadmissible — or `deficiency m 28 ≤ 9`.  Equivalently: the only *admissible*
+pair in the window is the record `(284, 28)`, and its deficiency is `9`.  Uses
+`native_decide` (⇒ `Lean.ofReduceBool`): computing `C(m,28)` and the smooth-window count
+`deficiency m 28` for the eight hundred and sixty values is infeasible for kernel `decide`. -/
+theorem window_k28_admissible_deficiency_le_nine :
+    ∀ m ∈ Finset.Icc 56 915,
+      (2 ∣ Nat.choose m 28 ∨ 3 ∣ Nat.choose m 28 ∨ 5 ∣ Nat.choose m 28 ∨
+       7 ∣ Nat.choose m 28 ∨ 11 ∣ Nat.choose m 28 ∨ 13 ∣ Nat.choose m 28 ∨
+       17 ∣ Nat.choose m 28 ∨ 19 ∣ Nat.choose m 28 ∨ 23 ∣ Nat.choose m 28)
+      ∨ deficiency m 28 ≤ 9 := by
+  native_decide
+
+/-- Every *admissible* pair in the `k = 28` location window has deficiency `≤ 9`.  From the
+window check: an admissible `m` cannot have any prime `≤ 28` dividing `C(m,28)`, so the
+divisibility disjunction is impossible and `deficiency m 28 ≤ 9` remains.  (The single
+admissible `m` in the window is the record `m = 284`, with deficiency exactly `9`.) -/
+theorem admissible_k28_window_deficiency_le_nine {m : ℕ} (hlo : 56 ≤ m) (hhi : m ≤ 915)
+    (h : NoSmallPrimeFactors m 28) : deficiency m 28 ≤ 9 := by
+  have hm : m ∈ Finset.Icc 56 915 := Finset.mem_Icc.mpr ⟨hlo, hhi⟩
+  rcases window_k28_admissible_deficiency_le_nine m hm with hdvd | hdef
+  · exfalso
+    rcases hdvd with hd | hd | hd | hd | hd | hd | hd | hd | hd
+    · have := h 2 Nat.prime_two hd; omega
+    · have := h 3 Nat.prime_three hd; omega
+    · have := h 5 (by norm_num) hd; omega
+    · have := h 7 (by norm_num) hd; omega
+    · have := h 11 (by norm_num) hd; omega
+    · have := h 13 (by norm_num) hd; omega
+    · have := h 17 (by norm_num) hd; omega
+    · have := h 19 (by norm_num) hd; omega
+    · have := h 23 (by norm_num) hd; omega
+  · exact hdef
+
+/-- **Window-check location engine.**  A variant of `deficiency_le_nine_of_location`
+(Section XVIIB) whose finite-window hypothesis is the *window check* "every admissible pair
+in the window has deficiency `≤ 9`" rather than "every window pair is inadmissible".  This
+is the strictly weaker requirement needed once the window is inhabited by an admissible pair
+(as at `k = 28`): from the certificate `k! < M^{10}` a deficiency `≥ 10` would land `n` in
+the window `2k ≤ n ≤ k + M - 2`, where the check already caps the deficiency at `9`.
+Independent of the axiomatized ELS bound `els_upper_bound`. -/
+theorem deficiency_le_nine_of_location_window {n k M : ℕ} (hn : 2 * k ≤ n)
+    (h : NoSmallPrimeFactors n k)
+    (hnum : Nat.factorial k < M ^ 10)
+    (hwin : ∀ m : ℕ, 2 * k ≤ m → m ≤ k + M - 2 → NoSmallPrimeFactors m k →
+      deficiency m k ≤ 9) :
+    deficiency n k ≤ 9 := by
+  by_contra hcon
+  push_neg at hcon
+  have hpow : (n - k + 1) ^ 10 ≤ Nat.factorial k :=
+    windowFloor_pow_le_factorial_of_le hn h (by omega)
+  have hlt : (n - k + 1) ^ 10 < M ^ 10 := lt_of_le_of_lt hpow hnum
+  have hfloor : n - k + 1 < M := by
+    by_contra hge
+    push_neg at hge
+    exact absurd (Nat.pow_le_pow_left hge 10) (not_le.mpr hlt)
+  have hle := hwin n hn (by omega) h
+  omega
+
+/-- **The location bound closes `k = 28`.**  For an admissible pair with `k = 28` the
+deficiency never exceeds `9`.  A deficiency `≥ 10` would force, via the window-floor bound,
+`(n - 27)^{10} ≤ 28! < 889^{10}`, hence `n ≤ 915`; with the admissibility floor `n ≥ 56`
+this leaves only `n ∈ {56,…,915}`, whose sole admissible member is the record `(284, 28)`
+of deficiency `9` (`admissible_k28_window_deficiency_le_nine`).  A one-line instantiation of
+the window-check engine `deficiency_le_nine_of_location_window` at `k = 28, M = 889`.  This
+is the slice containing the record pair itself. -/
+theorem deficiency_le_nine_of_k_eq_28 {n : ℕ} (hn : 56 ≤ n)
+    (h : NoSmallPrimeFactors n 28) : deficiency n 28 ≤ 9 :=
+  deficiency_le_nine_of_location_window (k := 28) (M := 889) (by omega) h
+    factorial_28_lt_889_pow_ten
+    (fun m hlo hhi hadm => admissible_k28_window_deficiency_le_nine (by omega) (by omega) hadm)
+
+/-- **Elementary resolution of OQ-02 for all `k ≤ 28`.**  Combines the location bound at
+`k ≤ 27` (`deficiency_le_nine_of_k_le_27`) with the window-check location bound at `k = 28`
+(`deficiency_le_nine_of_k_eq_28`).  Strictly extends the `k ≤ 27` reach of Section XXVIII to
+the slice `k = 28` that contains the record pair. -/
+theorem deficiency_le_nine_of_k_le_28 {n k : ℕ} (hn : 2 * k ≤ n)
+    (h : NoSmallPrimeFactors n k) (hk : k ≤ 28) : deficiency n k ≤ 9 := by
+  by_cases hk27 : k ≤ 27
+  · exact deficiency_le_nine_of_k_le_27 hn h hk27
+  · have hk28 : k = 28 := by omega
+    subst hk28
+    exact deficiency_le_nine_of_k_eq_28 (by omega) h
+
+/-- **Sharpened reduction to `k ≥ 29`.**  `MaximalDeficiencyIs 9` is equivalent to the open
+universal bound restricted to `k ≥ 29`: the cases `k ≤ 27` are discharged by the
+sharp/location bounds and `k = 28` by the window-check location bound
+(`deficiency_le_nine_of_k_le_28`).  Strictly sharper than `maximalDeficiencyIs_nine_iff_kGe28`:
+the `k = 28` slice — the one containing the record `(284, 28)` — is now *closed*, because the
+location window isolates the record as the unique admissible pair and its deficiency is the
+record value `9`.  The remaining open content of OQ-02 lives entirely at `k ≥ 29`, where no
+record pair survives and the universal bound is the irreducibly analytic Erdős–Lacampagne–
+Selfridge input. -/
+theorem maximalDeficiencyIs_nine_iff_kGe29 :
+    MaximalDeficiencyIs 9 ↔
+      ∀ n k, 29 ≤ k → ValidDeficiencyExample n k → deficiency n k ≤ 9 := by
+  rw [maximalDeficiencyIs_nine_iff_upperBound]
+  constructor
+  · intro h n k _ hv; exact h n k hv
+  · intro h n k hv
+    by_cases hk : k ≤ 28
+    · exact deficiency_le_nine_of_k_le_28 hv.1 hv.2 hk
+    · exact h n k (by omega) hv

--- a/proofs/Proofs/PuiseuxTheorem.lean
+++ b/proofs/Proofs/PuiseuxTheorem.lean
@@ -1192,6 +1192,105 @@ theorem iSup_puiseuxRamificationSubfield {K : Type*} [Field K] :
 end FieldFiltration
 
 /-! ═══════════════════════════════════════════════════════════════════════════════
+PART XIII: THE VALUE GROUP OF THE PUISEUX VALUATION
+═══════════════════════════════════════════════════════════════════════════════ -/
+
+/-!
+### Part XIII: The value group — why `K⦃⦃x⦄⦄` is `ℚ`-graded while `K((x))` is `ℤ`-graded
+
+Every earlier part builds the *algebraic* structure (Subring → Subalgebra → Subfield,
+Parts VIII–X) and its *ramification filtration* (Parts XI–XII). This part records the
+single order-theoretic fact that is the whole reason the Puiseux field exists: its
+`orderTop` valuation takes **every** rational value, whereas the Laurent field `K((x))`
+— Hahn series supported on `ℤ` — has value group only `ℤ`.
+
+For a Hahn series `f ≠ 0`, `f.orderTop ∈ WithTop ℚ` is the least exponent in its support
+(`⊤` when `f = 0`); it is the canonical `ℚ`-valued valuation on `HahnSeries ℚ K`. Its
+image on the nonzero elements is the **value group**. We show:
+
+* `exists_puiseux_orderTop_eq` / `puiseux_orderTop_range` — the value group of the full
+  Puiseux field is *all* of `ℚ` (every `q : ℚ` is `orderTop` of a nonzero Puiseux
+  series, namely `single q 1`). This is exactly what a Laurent series can never achieve
+  for `q ∉ ℤ`, so it is the sharpest statement of "`K⦃⦃x⦄⦄` strictly extends `K((x))`".
+* `orderTop_mem_ramification` / `exists_ramification_orderTop_eq` /
+  `ramification_orderTop_range` — the value group of the level-`n` Laurent subfield
+  `K((x^{1/n}))` is *exactly* `(1/n)ℤ = {k/n : k ∈ ℤ}`. Refining the ramification
+  refines the value group `ℤ ⊆ ½ℤ ⊆ ⅓ℤ ⊆ …`, whose union `⋃ₙ (1/n)ℤ = ℚ` recovers the
+  full value group — the valuation-theoretic shadow of the field colimit
+  `iSup_puiseuxRamificationSubfield`.
+-/
+
+section ValueGroup
+
+/-- **The value group of the Puiseux field contains every rational.** For each `q : ℚ`
+the single-term series `single q 1` is a nonzero Puiseux series with `orderTop = q`.
+Over the Laurent field (`ℤ`-supported Hahn series) this is impossible once `q ∉ ℤ`;
+this is the sharpest witness that `K⦃⦃x⦄⦄` extends `K((x))`. -/
+theorem exists_puiseux_orderTop_eq {K : Type*} [Field K] (q : ℚ) :
+    ∃ f : HahnSeries ℚ K, IsPuiseuxSeries f ∧ f ≠ 0 ∧ f.orderTop = (q : WithTop ℚ) :=
+  ⟨HahnSeries.single q 1, isPuiseux_single q 1, HahnSeries.single_ne_zero one_ne_zero,
+    HahnSeries.orderTop_single one_ne_zero⟩
+
+/-- **The value group of the Puiseux field is all of `ℚ`.** The set of `orderTop` values
+attained by nonzero Puiseux series is precisely the finite part of `WithTop ℚ`, i.e. the
+image of `ℚ`. Forward: a nonzero series has a finite `orderTop`. Backward:
+`exists_puiseux_orderTop_eq` realizes every rational. -/
+theorem puiseux_orderTop_range {K : Type*} [Field K] :
+    {v : WithTop ℚ |
+        ∃ f : HahnSeries ℚ K, IsPuiseuxSeries f ∧ f ≠ 0 ∧ f.orderTop = v}
+      = {v : WithTop ℚ | v ≠ ⊤} := by
+  ext v
+  constructor
+  · rintro ⟨f, _, hf0, rfl⟩
+    exact HahnSeries.orderTop_ne_top.2 hf0
+  · intro hv
+    obtain ⟨q, rfl⟩ := WithTop.ne_top_iff_exists.mp hv
+    exact exists_puiseux_orderTop_eq q
+
+/-- **The valuation of a level-`n` series is `(1/n)`-integral.** For a nonzero series
+ramified by `n`, `orderTop` is a finite rational of the form `k/n` (its least exponent,
+which lies in the support and hence in `(1/n)ℤ`). This is the forward inclusion "value
+group of `K((x^{1/n}))` ⊆ `(1/n)ℤ`". -/
+theorem orderTop_mem_ramification {K : Type*} [Field K] {n : ℕ+} {f : HahnSeries ℚ K}
+    (hf : IsPuiseuxOfRamification n f) (hf0 : f ≠ 0) :
+    ∃ k : ℤ, f.orderTop = (((k : ℚ) / (n : ℚ) : ℚ) : WithTop ℚ) := by
+  obtain ⟨q, hq⟩ := WithTop.ne_top_iff_exists.mp (HahnSeries.orderTop_ne_top.2 hf0)
+  have hmem : q ∈ f.support := (HahnSeries.mem_support f q).mpr (HahnSeries.coeff_orderTop_ne hq.symm)
+  obtain ⟨k, hk⟩ := hf q hmem
+  exact ⟨k, by rw [← hq, hk]⟩
+
+/-- **Every `(1/n)`-integral value is attained at level `n`.** For each `k : ℤ` the
+series `single (k/n) 1` is a nonzero level-`n` Laurent series with `orderTop = k/n`. This
+is the backward inclusion "value group of `K((x^{1/n}))` ⊇ `(1/n)ℤ`". -/
+theorem exists_ramification_orderTop_eq {K : Type*} [Field K] (n : ℕ+) (k : ℤ) :
+    ∃ f : HahnSeries ℚ K, IsPuiseuxOfRamification n f ∧ f ≠ 0 ∧
+      f.orderTop = (((k : ℚ) / (n : ℚ) : ℚ) : WithTop ℚ) := by
+  refine ⟨HahnSeries.single ((k : ℚ) / (n : ℚ)) 1, ?_, HahnSeries.single_ne_zero one_ne_zero,
+    HahnSeries.orderTop_single one_ne_zero⟩
+  intro q hq
+  rw [HahnSeries.support_single_of_ne (one_ne_zero (α := K)), Set.mem_singleton_iff] at hq
+  exact ⟨k, hq⟩
+
+/-- **The value group of the level-`n` Laurent field is exactly `(1/n)ℤ`.** Combining the
+two inclusions, the set of `orderTop` values of nonzero `(1/n)`-ramified series is
+precisely `{k/n : k ∈ ℤ}`. The chain of value groups `ℤ ⊆ ½ℤ ⊆ ⅓ℤ ⊆ …` (under
+divisibility) has union `ℚ`, the valuation-theoretic image of the field colimit
+`K⦃⦃x⦄⦄ = colimₙ K((x^{1/n}))`. -/
+theorem ramification_orderTop_range {K : Type*} [Field K] (n : ℕ+) :
+    {v : WithTop ℚ |
+        ∃ f : HahnSeries ℚ K, IsPuiseuxOfRamification n f ∧ f ≠ 0 ∧ f.orderTop = v}
+      = {v : WithTop ℚ | ∃ k : ℤ, v = (((k : ℚ) / (n : ℚ) : ℚ) : WithTop ℚ)} := by
+  ext v
+  constructor
+  · rintro ⟨f, hf, hf0, rfl⟩
+    exact orderTop_mem_ramification hf hf0
+  · rintro ⟨k, rfl⟩
+    obtain ⟨f, hf, hf0, hfv⟩ := exists_ramification_orderTop_eq (K := K) n k
+    exact ⟨f, hf, hf0, hfv⟩
+
+end ValueGroup
+
+/-! ═══════════════════════════════════════════════════════════════════════════════
 SUMMARY
 ═══════════════════════════════════════════════════════════════════════════════ -/
 

--- a/research/problems/erdos-1093-oq-02/knowledge.md
+++ b/research/problems/erdos-1093-oq-02/knowledge.md
@@ -1,5 +1,64 @@
 # Erdős #1093 — OQ-02: Is d(284,28)=9 the maximal deficiency?
 
+## Session 2026-07-11 (researcher-6) — Section XXIX: window-check CLOSES k=28 (the record slice!) → frontier k≥29
+
+**Mode:** REVISIT (RICH tier). **Outcome:** BREAKTHROUGH — closes `k = 28`, the slice
+*containing the record pair* `(284, 28)`. Prior sessions (up to Section XXVIII in the Lean
+file, which had already silently advanced far past this knowledge.md's Section XXIII) called
+`k = 28` the **terminal** elementary step, because the pure **inadmissibility** engine
+(`deficiency_le_nine_of_location`: *some* prime `≤ k` divides `C(n,k)` for *every* window `n`)
+provably fails at `k = 28` — the location window is inhabited by the admissible record.
+
+### Key realization — the window is finite, so USE the deficiency, don't just rule out admissibility
+The inadmissibility engine is not the only elementary tool. A deficiency `≥ 10` at `k = 28`
+forces `(n-27)^{10} ≤ 28!`, and `28! = 304888344611713860501504000000 < 889^{10} =
+308331296938836253127540655601` (`889` sharp: `888^{10} = 304880506868562346036873396224 ≤
+28!`), so `n - 27 < 889 ⟹ n ≤ 915`. With floor `n ≥ 56 (=2·28)` the window is
+`n ∈ {56,…,915}` (860 values). **Python-verified: exactly ONE admissible pair in the whole
+window — the record `(284,28)` itself — with deficiency exactly 9 (not ≥10).** Every other
+`n` is inadmissible via a prime in `{2,3,5,7,11,13,17,19,23}` dividing `C(n,28)`. So no
+admissible `k=28` pair has deficiency `≥10`.
+
+### What I did — Section XXIX (7 theorems, 0 sorry, 0 NEW axioms), VERIFIED
+- `factorial_28_lt_889_pow_ten` — `28! < 889^10` (kernel `decide`, `ofReduceBool`-free).
+- `window_k28_admissible_deficiency_le_nine` — the single `native_decide` fact: `∀ m ∈
+  Icc 56 915`, (small prime `∈{2,…,23}` divides `C(m,28)`) `∨ deficiency m 28 ≤ 9`.
+  Compiled in ~5s standalone; full-file build clean.
+- `admissible_k28_window_deficiency_le_nine` — admissible ⟹ divisibility impossible ⟹
+  `deficiency ≤ 9` (the 9-prime `rcases`, each `h p prime hd; omega`).
+- `deficiency_le_nine_of_location_window` — NEW **window-check engine** (variant of
+  `deficiency_le_nine_of_location` whose finite-window hyp is "admissible ⟹ deficiency ≤ 9"
+  not "inadmissible"); `ofReduceBool`-FREE `[propext,choice,Quot.sound]`.
+- `deficiency_le_nine_of_k_eq_28` — one-line instantiation at `k=28, M=889`.
+- `deficiency_le_nine_of_k_le_28`, `maximalDeficiencyIs_nine_iff_kGe29`.
+
+### Verification — VERIFIED axiom-free engine (Docker-free)
+`proofs/bin/lake env lean` (v4.26.0, prebuilt mathlib oleans). Full file compiles clean
+(exit 0). `#print axioms`: `deficiency_le_nine_of_location_window` and
+`factorial_28_lt_889_pow_ten` are `ofReduceBool`-free; `maximalDeficiencyIs_nine_iff_kGe29`
+carries `[propext, Classical.choice, Lean.ofReduceBool, Lean.trustCompiler, Quot.sound]` —
+the `ofReduceBool`/`trustCompiler` come from the single `native_decide` window fact, exactly
+as every prior section. **No new axiom declaration.**
+
+### Why this is more than the mechanical k-ladder
+Sections XVII–XXVIII each closed one `k` by the *inadmissibility* engine and stopped at `k=27`
+because `k=28`'s window contains the record. This is a genuinely different (strictly stronger)
+argument that resolves the record slice by isolating `(284,28)` as the *unique admissible pair*
+in its location window. The elementary resolution of OQ-02 now covers **all `k ≤ 28`**; open
+content is confined to `k ≥ 29`, where no record pair survives and the remaining universal
+bound is the irreducibly analytic Erdős–Lacampagne–Selfridge input.
+
+### Gotcha logged
+Shared-main-checkout thrash bit again: my first `Edit` targeted the main checkout path
+(`/Users/rwalters/GitHub/lean-genius/proofs/...`, on an unrelated enricher branch) and a
+concurrent `git reset` reverted it before build. FIX: edit the researcher-6-2 *worktree*
+file, build it (`.lake` symlinked to main's prebuilt oleans), commit immediately.
+
+### Files Modified
+- `proofs/Proofs/Erdos1093ProblemOQ02.lean` (Section XXIX, +~150 lines, +7 theorems)
+
+---
+
 ## Session 2026-07-09 (researcher-3) — Section XXIII: location bound CLOSES k=22 → frontier k≥23
 
 **Mode:** REVISIT (RICH tier). **Outcome:** progress — strict advance (frontier k≥22→k≥23),

--- a/research/problems/puiseux-theorem-wip-01/knowledge.md
+++ b/research/problems/puiseux-theorem-wip-01/knowledge.md
@@ -289,3 +289,59 @@ lineCount 1107→1216, theoremCount 34→39 & 36→41, definitionCount 7→8).
 
 **Assessment.** Structure line is now complete symmetrically at ring AND field level; the
 only remaining frontier is full Newton–Puiseux algebraic closure (>1000-line, out of scope).
+
+## Session (researcher-6, 2026-07-11): Part XIII — the value group of the valuation
+
+**Mode**: REVISIT (MODERATE, saturated) · **Outcome**: progress (5 thms VERIFIED
+0-sorry/0-axiom via local lean 4.26.0 elab — docker running but no image, irrelevant).
+
+**First VERIFY.** Re-elaborated the whole file (Parts VIII–XII, standing at 1216 lines):
+EXIT 0, zero errors (only the two long-standing warnings at 353 unused `hq`, 380 no-op
+push_cast). The UNVERIFIED-shipped filtration parts remain correct.
+
+**Gap closed — Part XIII (section `ValueGroup`).** Every prior part built the *algebraic*
+structure (Subring→Subfield, Parts VIII–X) and the *ramification filtration*
+(Parts XI–XII), but never recorded the one order-theoretic fact that is the entire
+*raison d'être* of the Puiseux field: its `orderTop` valuation is `ℚ`-valued and hits
+**every** rational, whereas the Laurent field `K((x))` (ℤ-supported) has value group only
+`ℤ`. This is the sharpest "`K⦃⦃x⦄⦄` strictly extends `K((x))`" statement and was missing.
+
+1. `exists_puiseux_orderTop_eq (q : ℚ)` — every rational is `orderTop` of a nonzero
+   Puiseux series (`single q 1`, via `orderTop_single one_ne_zero` + `single_ne_zero`).
+2. `puiseux_orderTop_range` — the value group of the full Puiseux field is *all* of `ℚ`,
+   as a set-equality `{orderTop of nonzero Puiseux f} = {v : WithTop ℚ | v ≠ ⊤}`.
+   Forward = `orderTop_ne_top`; backward = (1) after `WithTop.ne_top_iff_exists`.
+3. `orderTop_mem_ramification` — forward inclusion for level `n`: a nonzero
+   `(1/n)`-ramified series has `orderTop = k/n` for some `k:ℤ`. The least exponent is
+   finite (`orderTop_ne_top`), lies in the support (`coeff_orderTop_ne` + `mem_support`),
+   hence in `(1/n)ℤ` by the ramification predicate.
+4. `exists_ramification_orderTop_eq (n) (k)` — backward inclusion: `single (k/n) 1` is a
+   nonzero level-`n` series with `orderTop = k/n`.
+5. `ramification_orderTop_range (n)` — capstone: the value group of the level-`n` Laurent
+   subfield `K((x^{1/n}))` is *exactly* `{k/n : k∈ℤ} = (1/n)ℤ`. The chain
+   `ℤ ⊆ ½ℤ ⊆ ⅓ℤ ⊆ …` unions to `ℚ`, the valuation-image of the field colimit
+   `iSup_puiseuxRamificationSubfield`.
+
+**Technique / reusable.**
+- `HahnSeries.coeff_orderTop_ne (hg : x.orderTop = ↑g) : x.coeff g ≠ 0` — the bridge from
+  a *finite* `orderTop` value to a support element (the min is attained). Pair with
+  `WithTop.ne_top_iff_exists.mp (orderTop_ne_top.2 hf0)` to extract that finite value.
+- `orderTop_single (h : r ≠ 0) : (single a r).orderTop = a` and `single_ne_zero` give the
+  witness half of a value-group surjectivity for free — over a `Field K`, `one_ne_zero`
+  discharges `(1:K) ≠ 0`.
+- Value-group-as-set-equality proofs: `ext v; constructor; rintro ⟨f,…,rfl⟩` /
+  `rintro ⟨k,rfl⟩` — the `rfl` on `f.orderTop = v` (resp. `v = ↑(k/n)`) substitutes `v`
+  cleanly so each direction reduces to one existing inclusion lemma.
+
+**Verification.** `#print axioms` on `puiseux_orderTop_range`, `ramification_orderTop_range`,
+`exists_puiseux_orderTop_eq`, `orderTop_mem_ramification` = `[propext, Classical.choice,
+Quot.sound]` only — no `sorryAx`, no `ofReduceBool`. Genuinely 0-axiom/0-sorry.
+
+**Files Modified:** proofs/Proofs/PuiseuxTheorem.lean (+Part XIII: 5 thms; 1216→1315
+lines), src/data/proofs/puiseux-theorem/meta.json (lineCount 1216→1315, theoremCount
+39→44 & 41→46).
+
+**Assessment.** With the value group pinned down at both the full-field (`= ℚ`) and every
+finite level (`= (1/n)ℤ`), the "structural rounding-out" line is now complete on the
+*algebraic*, *filtration*, and *valuation* axes. The only remaining frontier is the deep
+Newton–Puiseux algebraic closure (>1000-line, out of scope).

--- a/src/data/proofs/puiseux-theorem/meta.json
+++ b/src/data/proofs/puiseux-theorem/meta.json
@@ -55,10 +55,10 @@
     ],
     "dateAdded": "2025-12-29",
     "axiomCount": 0,
-    "lineCount": 1216,
+    "lineCount": 1315,
     "assumptions": "No axiom declarations, no sorries, no native_decide (all theorems depend only on propext/Classical.choice/Quot.sound). The two headline placeholders (puiseux_theorem, puiseux_is_algebraic_closure) were replaced by genuine, fully computed Hahn-series theorems puiseux_binomial_root and puiseux_binomial_ramification, which establish the binomial base case of Puiseux's theorem (every binomial Yⁿ = c·xᵐ has a Puiseux root of ramification n over an algebraically closed field). Four narrative theorems remain as String-literal descriptors carrying no formal content (curve_branches_are_puiseux, newton_polygon_tropicalization, galois_group_is_profinite_integers, char_zero_required); each merely asserts ∃ desc : String, desc = \"…\" and marks an informal application/connection rather than a machine-checked result. This is a rigorously verified FRAGMENT: the full Newton–Puiseux theorem for arbitrary polynomials over the Puiseux field (assembling binomial roots term by term, with its char-0 convergence argument) is not formalized here — the required infrastructure is absent from Mathlib. Badge remains 'wip' to reflect that the headline algebraic-closure theorem is not fully proven.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 39,
+    "theoremCount": 44,
     "definitionCount": 8
   },
   "overview": {
@@ -173,9 +173,9 @@
       "Polynomial"
     ],
     "namespace": "PuiseuxTheorem",
-    "lineCount": 1216,
+    "lineCount": 1315,
     "axiomCount": 0,
-    "theoremCount": 41,
+    "theoremCount": 46,
     "definitionCount": 8,
     "path": "Proofs/PuiseuxTheorem.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

**Erdős #1093, OQ-02** asks whether `d(284,28) = 9` is the maximal deficiency of a binomial coefficient with no small prime factors. This PR adds **Section XXIX** to `Erdos1093ProblemOQ02.lean`, which **closes the `k = 28` slice** — the one that *contains the record pair* `(284, 28)` — advancing the elementary open frontier from `k ≥ 28` to `k ≥ 29`.

## Why this is a genuine advance, not the mechanical ladder

Sections XVII–XXVIII closed `k = 16, …, 27` one at a time via the **inadmissibility** engine (`deficiency_le_nine_of_location`): for every `n` in the finite location window, *some* prime `≤ k` divides `C(n,k)`. That engine **provably fails at `k = 28`**, because the location window is inhabited by the genuine admissible record `(284,28)` — which is why prior work called `k = 28` the "terminal" elementary step.

This PR closes `k = 28` with a strictly stronger, still elementary **window-check** argument. A deficiency `≥ 10` forces the window-floor bound `(n-27)^10 ≤ 28! < 889^10`, so `n ≤ 915`; with the floor `n ≥ 56` the window is `{56, …, 915}` (860 values). Across the whole window there is **exactly one admissible pair — the record `(284,28)` itself — with deficiency exactly 9 `< 10`**. Every other `n` is inadmissible via a prime in `{2,3,5,7,11,13,17,19,23}`. Hence no admissible `k=28` pair has deficiency `≥ 10`.

## New theorems (7, 0 sorry, 0 new axiom declarations)

- `factorial_28_lt_889_pow_ten` — `28! < 889^10` (kernel `decide`, `ofReduceBool`-free)
- `window_k28_admissible_deficiency_le_nine` — the single `native_decide` fact over the 860-value window
- `admissible_k28_window_deficiency_le_nine` — admissible ⟹ `deficiency ≤ 9`
- `deficiency_le_nine_of_location_window` — new window-check engine (`ofReduceBool`-**free**)
- `deficiency_le_nine_of_k_eq_28`, `deficiency_le_nine_of_k_le_28`
- `maximalDeficiencyIs_nine_iff_kGe29` — the sharpened reduction; open content now confined to `k ≥ 29`

## Verification

Built clean with `proofs/bin/lake env lean` (Lean v4.26.0, prebuilt Mathlib oleans), exit 0. `#print axioms`:
- `deficiency_le_nine_of_location_window`, `factorial_28_lt_889_pow_ten` — `ofReduceBool`-free
- `maximalDeficiencyIs_nine_iff_kGe29` — `[propext, Classical.choice, Lean.ofReduceBool, Lean.trustCompiler, Quot.sound]`; the `ofReduceBool`/`trustCompiler` come solely from the one `native_decide` window fact, consistent with every prior section. No new `axiom` declaration.

The elementary resolution of OQ-02 now covers **all `k ≤ 28`**; the remaining open content lives entirely at `k ≥ 29`, where no record pair survives and the universal bound is the irreducibly analytic Erdős–Lacampagne–Selfridge estimate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Additional commit — Part XIII: value group of the Puiseux valuation (puiseux-theorem-wip-01)

Adds `section ValueGroup` to `PuiseuxTheorem.lean` (5 theorems, VERIFIED 0-sorry/0-axiom): the `orderTop` valuation of the Puiseux field surjects onto **all** of ℚ (`puiseux_orderTop_range`), while each level-`n` Laurent subfield `K((x^{1/n}))` has value group exactly `(1/n)ℤ` (`ramification_orderTop_range`) — the valuation shadow of the earlier field colimit. Whole file elaborates EXIT 0; `#print axioms` = `[propext, Classical.choice, Quot.sound]`. 1216→1315 lines; meta counts synced.