### PR TITLE
research(erdos101-problem-oq-04): lower bound + shell character of the ternary conic Q=5

### DIFF
--- a/proofs/Proofs/Erdos101OQ04.lean
+++ b/proofs/Proofs/Erdos101OQ04.lean
@@ -3291,4 +3291,39 @@ theorem ternary_conic_sq_sum_le_of_mem (p q r : ℝ)
     p ^ 2 + q ^ 2 + r ^ 2 ≤ 10 := by
   nlinarith [sq_nonneg (p + q + r), h]
 
+/-- **The solution surface is bounded away from the origin.** On the ternary conic `Q = 5`,
+the squared abscissa radius satisfies `5/2 ≤ p² + q² + r²`.  From
+`Q = ½·((p²+q²+r²) + (p+q+r)²)`: at `Q = 5` we have `(p²+q²+r²) + (p+q+r)² = 10`, and the trace
+obeys `(p+q+r)² ≤ 3·(p²+q²+r²)` (Cauchy–Schwarz, i.e.
+`3·(p²+q²+r²) − (p+q+r)² = (p−q)² + (q−r)² + (r−p)² ≥ 0`).  Substituting,
+`10 = (p²+q²+r²) + (p+q+r)² ≤ 4·(p²+q²+r²)`, so `p²+q²+r² ≥ 5/2`.  This is the missing lower
+companion to `ternary_conic_sq_sum_le_of_mem`: the surface `Q = 5` never approaches the
+origin, so it is a genuine ellipsoidal *shell*, not a full solid ball. -/
+theorem ternary_conic_sq_sum_ge_of_mem (p q r : ℝ)
+    (h : p ^ 2 + q ^ 2 + r ^ 2 + p * q + q * r + r * p = 5) :
+    5 / 2 ≤ p ^ 2 + q ^ 2 + r ^ 2 := by
+  nlinarith [sq_nonneg (p - q), sq_nonneg (q - r), sq_nonneg (r - p), h]
+
+/-- **The squared abscissa radius lives in the closed interval `[5/2, 10]`.** Packaging the two
+one-sided bounds `ternary_conic_sq_sum_ge_of_mem` and `ternary_conic_sq_sum_le_of_mem`: every
+point of the ternary conic `Q = 5` satisfies `p² + q² + r² ∈ [5/2, 10]`.  These are the
+squares of the extreme semi-axes of the ellipsoid (eigenvalues `2` and `½` of the conic form,
+giving radii `√(5/2)` along the trace direction `(1,1,1)` and `√10` in the trace-free plane),
+so the interval is sharp: the surface `Q = 5` is exactly the ellipsoidal shell between the two
+concentric spheres of radius `√(5/2)` and `√10`. -/
+theorem ternary_conic_sq_sum_mem_Icc (p q r : ℝ)
+    (h : p ^ 2 + q ^ 2 + r ^ 2 + p * q + q * r + r * p = 5) :
+    p ^ 2 + q ^ 2 + r ^ 2 ∈ Set.Icc (5 / 2 : ℝ) 10 :=
+  ⟨ternary_conic_sq_sum_ge_of_mem p q r h, ternary_conic_sq_sum_le_of_mem p q r h⟩
+
+/-- **The solution surface avoids the origin.** No point of the ternary conic `Q = 5` is the
+origin: `(p,q,r) = (0,0,0)` would force `p²+q²+r² = 0 < 5/2`, contradicting
+`ternary_conic_sq_sum_ge_of_mem`.  Concretely `0 < p² + q² + r²`, so at least one abscissa is
+nonzero on every family four-point line — the degenerate all-zero "quadruple" is not a
+solution, confirming the surface is a bona-fide shell around (but never through) the origin. -/
+theorem ternary_conic_sq_sum_pos_of_mem (p q r : ℝ)
+    (h : p ^ 2 + q ^ 2 + r ^ 2 + p * q + q * r + r * p = 5) :
+    0 < p ^ 2 + q ^ 2 + r ^ 2 :=
+  lt_of_lt_of_le (by norm_num) (ternary_conic_sq_sum_ge_of_mem p q r h)
+
 end Erdos101OQ04

--- a/src/data/research/problems/erdos101-problem-oq-04.json
+++ b/src/data/research/problems/erdos101-problem-oq-04.json
@@ -35,8 +35,8 @@
   "currentState": {
     "phase": "ACT",
     "since": "2026-07-09",
-    "iteration": 11,
-    "focus": "ACT iteration 11 (researcher-4, 2026-07-09) — UNVERIFIED (env SIGBUS on fresh elaboration, confirmed via pristine-file crash; not code). Added four_onQuartic_collinear_iff_sq (four points on y=x^4-5x^2 collinear iff Sum x=0 and Sum x^2=10, the sum-of-squares form of the Vieta criterion) and quartic_fourPointLineCount_from_quadruples (any injective family of k quadruples with Sum x=0, Sum x^2=10 gives a no-five-collinear set on <=4k points with fourPointLineCount >= k). Subsumes quartic_linear_lower_bound (symmetric quadruples) and drops the horizontal restriction; the exact geometry->arithmetic count reduction the open n^(2-o(1)) growth rests on. 0 new axioms, 0 new sorries; single open sorry (solymosi_stojakovic_lower_bound) untouched."
+    "iteration": 12,
+    "focus": "ACT iteration 12 (researcher-5, 2026-07-11) — VERIFIED axiom-free (bin/lake env lean, exit 0; #print axioms = [propext, Classical.choice, Quot.sound] for all three new lemmas). Closed the shape of the ternary conic Q(p,q,r)=p²+q²+r²+pq+qr+rp=5 that parametrizes the quartic four-point-line quadruples (x₃=−(p+q+r)): the prior iteration proved only the UPPER cap p²+q²+r²≤10; added the missing LOWER companion ternary_conic_sq_sum_ge_of_mem (p²+q²+r²≥5/2 via (p+q+r)²≤3(p²+q²+r²)), the two-sided packaging ternary_conic_sq_sum_mem_Icc (p²+q²+r²∈[5/2,10] — the sharp squared semi-axes √(5/2),√10 from the conic-form eigenvalues 2,½), and ternary_conic_sq_sum_pos_of_mem (surface avoids the origin, so the degenerate all-zero quadruple is not a solution). The surface Q=5 is now pinned as a genuine ellipsoidal shell, not a solid ball. 0 new axioms, 0 new sorries; single open sorry (solymosi_stojakovic_lower_bound) untouched."
   },
   "leanFiles": [
     {
@@ -161,7 +161,7 @@
     "sourceTitle": "Erdős Problem #101: Four-Point Lines from Planar Point Sets",
     "sourceType": "open-question"
   },
-  "lastUpdate": "2026-07-09",
+  "lastUpdate": "2026-07-11",
   "relatedProofs": [
     "erdos-101",
     "erdos101-problem",


### PR DESCRIPTION
## Summary

Erdős Problem #101 OQ-04 (Solymosi–Stojaković lower bound on four-point lines). The four-point-line quadruples on the quartic `y = x⁴ − 5x²` are parametrized by the **ternary conic** `Q(p,q,r) = p²+q²+r²+pq+qr+rp = 5` (with the fourth abscissa `x₃ = −(p+q+r)`). A prior iteration established only the **upper** cap `p²+q²+r² ≤ 10` on this surface. This PR adds the missing **lower** companion and thereby pins the surface's exact geometric shape.

## New theorems (all axiom-free)

- **`ternary_conic_sq_sum_ge_of_mem`** — `p²+q²+r² ≥ 5/2` on `Q = 5`, via the trace bound `(p+q+r)² ≤ 3(p²+q²+r²)` (equivalently `(p−q)²+(q−r)²+(r−p)² ≥ 0`): from `(p²+q²+r²)+(p+q+r)² = 10` we get `10 ≤ 4(p²+q²+r²)`.
- **`ternary_conic_sq_sum_mem_Icc`** — `p²+q²+r² ∈ [5/2, 10]`. These are the sharp squared semi-axes `√(5/2)`, `√10` of the ellipsoid (conic-form eigenvalues `2`, `½`).
- **`ternary_conic_sq_sum_pos_of_mem`** — the surface avoids the origin, so the degenerate all-zero "quadruple" is never a solution.

Together with the existing upper cap, `Q = 5` is now pinned as a genuine ellipsoidal **shell** between the concentric spheres of radius `√(5/2)` and `√10` — not a solid ball. This sharpens the "two-parameter surface" docstring into a two-sided quantitative fact and confirms every family four-point line has at least one nonzero abscissa.

## Verification

- Built with `bin/lake env lean` against prebuilt Mathlib v4.26.0 oleans — exit 0, only the single pre-existing open `sorry` (`solymosi_stojakovic_lower_bound`).
- `#print axioms` for all three new lemmas = `[propext, Classical.choice, Quot.sound]` (foundational only).
- **0 new axioms, 0 new sorries.** The open lower-bound obligation is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
