### PR TITLE
fix(erdos-1012-oq-01-oq-02): repair non-compiling Erdos1012OQ01OQ02.lean [VERIFIED axiom-free]

### DIFF
--- a/proofs/Proofs/Erdos1012OQ01OQ02.lean
+++ b/proofs/Proofs/Erdos1012OQ01OQ02.lean
@@ -395,7 +395,7 @@ theorem edgeThreshold_monotone_right (n : ℕ) {k j : ℕ} (hkj : k ≤ j)
     single global minimizer — the well-defined minimum underlying `f(k)`. -/
 theorem edgeThreshold_min_at (n : ℕ) (hn : 5 ≤ n) {k : ℕ} (hk : k + 2 ≤ n) :
     edgeThreshold n ((n - 3) / 2) ≤ edgeThreshold n k := by
-  rcases le_or_lt k ((n - 3) / 2) with hle | hlt
+  rcases le_or_gt k ((n - 3) / 2) with hle | hlt
   · exact edgeThreshold_antitone_left n hle (by omega)
   · exact edgeThreshold_monotone_right n (le_of_lt hlt) (by omega) (by omega)
 
@@ -492,8 +492,8 @@ theorem edgeThreshold_min_at_unique_odd (n : ℕ) (hn : 5 ≤ n) (hodd : Odd n) 
   rw [hk0] at hne ⊢
   rcases lt_or_gt_of_ne hne with hlt | hgt
   · -- k < k₀ = m-1: strictly decreasing branch, upper index m-1 with 2(m-1)+3 = n
-    exact edgeThreshold_antitone_left_strict n hlt (by omega)
+    exact edgeThreshold_antitone_left_strict (2 * m + 1) hlt (by omega)
   · -- k > k₀ = m-1: strictly increasing branch, bottom index m-1 with n ≤ 2(m-1)+3
-    exact edgeThreshold_monotone_right_strict n hgt (by omega) (by omega)
+    exact edgeThreshold_monotone_right_strict (2 * m + 1) hgt (by omega) (by omega)
 
 end Erdos1012OQ01OQ02

--- a/src/data/research/problems/erdos-1012-oq-01-oq-02.json
+++ b/src/data/research/problems/erdos-1012-oq-01-oq-02.json
@@ -22,7 +22,7 @@
     "phase": "COMPLETED",
     "since": "2026-06-22T00:00:00-07:00",
     "iteration": 2,
-    "focus": "Connected n-recurrence to parent threshold_diff; established Theta(n^2) growth sandwich.",
+    "focus": "Connected n-recurrence to parent threshold_diff; established Theta(n^2) growth sandwich. | Repair (researcher-3, 2026-07-11): Erdos1012OQ01OQ02.lean did not compile on main — `edgeThreshold_min_at_unique_odd` referenced `n` after `obtain ⟨m,rfl⟩ := hodd` substituted it away (n:=2*m+1), 2 unknown-identifier errors; replaced with (2*m+1) and modernized deprecated `le_or_lt`→`le_or_gt`. File now compiles clean (0 err/0 warn), axiom-free [propext,choice,Quot.sound]. leanFiles count refreshed 344→499L, 20→29 thm.",
     "blockers": [],
     "nextAction": "None -- complete.",
     "attemptCounts": {
@@ -93,8 +93,8 @@
     {
       "path": "Proofs/Erdos1012OQ01OQ02.lean",
       "filename": "Erdos1012OQ01OQ02.lean",
-      "lineCount": 344,
-      "theoremCount": 20,
+      "lineCount": 499,
+      "theoremCount": 29,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,


### PR DESCRIPTION
## Summary

`Erdos1012OQ01OQ02.lean` (edge-threshold variation for Erdős #1012) **did not compile on `main`**. `edgeThreshold_min_at_unique_odd` destructures `hodd : Odd n` via `obtain ⟨m, rfl⟩`, which substitutes `n := 2*m+1` and removes `n` from scope — but two subsequent term-mode applications still passed the now-undefined identifier `n`:

```
Erdos1012OQ01OQ02.lean:495: Unknown identifier `n`
Erdos1012OQ01OQ02.lean:497: Unknown identifier `n`
```

**Fix:** pass the concrete vertex count `(2 * m + 1)` to `edgeThreshold_antitone_left_strict` / `edgeThreshold_monotone_right_strict`. Also modernized the deprecated `le_or_lt` → `le_or_gt` (semantically identical, `b < a` ≡ `a > b`) to clear the remaining warning.

## Verification

- Built the `Proofs.Erdos1012OQ01` dependency olean, then `lake env lean Proofs/Erdos1012OQ01OQ02.lean` (toolchain v4.26.0): **EXIT 0, no errors, no warnings**.
- `#print axioms edgeThreshold_min_at_unique_odd` = `[propext, Classical.choice, Quot.sound]` — **axiom-free**.
- The uniqueness theorem (odd-`n` edge-threshold minimizer) was previously unusable; it now genuinely checks.
- Research `leanFiles` count refreshed (344→499 lines, 20→29 theorems — the file had grown while shipped UNVERIFIED).

This is a drift/latent-bug repair: the broken theorem was committed while Docker verification was unavailable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)