### PR TITLE
research(szemeredi-regularity-oq-04): variance minimizer — the energy-monotonicity core

### DIFF
--- a/proofs/Proofs/SzemerediRegularityOQ04.lean
+++ b/proofs/Proofs/SzemerediRegularityOQ04.lean
@@ -517,6 +517,59 @@ theorem weighted_variance_eq {ι : Type*} (s : Finset ι) (w x : ι → ℚ) (μ
       ← Finset.mul_sum, ← Finset.mul_sum, hmean]
   ring
 
+/-- **Weighted variance is nonnegative.**  For nonnegative weights with weighted mean `μ`,
+    the weighted second moment about the mean is `≥ 0`:
+    `0 ≤ (∑ wᵢxᵢ²) − (∑ wᵢ)·μ²`.  The `d = 0` skeleton of `weighted_variance_atom_bound`,
+    recording that the energy of a partition never drops below that of its coarsening. -/
+theorem weighted_variance_nonneg {ι : Type*} (s : Finset ι) (w x : ι → ℚ) (μ : ℚ)
+    (hw : ∀ i ∈ s, 0 ≤ w i)
+    (hmean : ∑ i ∈ s, w i * x i = (∑ i ∈ s, w i) * μ) :
+    0 ≤ (∑ i ∈ s, w i * x i ^ 2) - (∑ i ∈ s, w i) * μ ^ 2 := by
+  rw [← weighted_variance_eq s w x μ hmean]
+  exact Finset.sum_nonneg (fun i hi => mul_nonneg (hw i hi) (sq_nonneg _))
+
+/-- **The weighted mean minimizes the weighted mean-squared deviation.**  For nonnegative
+    weights and *any* centre `c`, the weighted sum of squared deviations about the true
+    weighted mean `μ` is no larger than about `c`:
+    `∑ wᵢ(xᵢ − μ)² ≤ ∑ wᵢ(xᵢ − c)²`.
+
+    This is the abstract heart of *energy monotonicity under refinement* in AFKS: replacing
+    a part's single mean density by the sub-cell means (the conditional means on a refinement)
+    can only *decrease* the residual variance, i.e. *increase* the partition energy.  The
+    proof is the parallel-axis expansion `∑ wᵢ(xᵢ − c)² = ∑ wᵢ(xᵢ − μ)² + (∑ wᵢ)(μ − c)²`,
+    whose extra term is a nonnegative multiple of `(μ − c)²`. -/
+theorem weighted_variance_le_of_mean {ι : Type*} (s : Finset ι) (w x : ι → ℚ) (μ : ℚ)
+    (hw : ∀ i ∈ s, 0 ≤ w i)
+    (hmean : ∑ i ∈ s, w i * x i = (∑ i ∈ s, w i) * μ) (c : ℚ) :
+    ∑ i ∈ s, w i * (x i - μ) ^ 2 ≤ ∑ i ∈ s, w i * (x i - c) ^ 2 := by
+  have hsw : (0 : ℚ) ≤ ∑ i ∈ s, w i := Finset.sum_nonneg hw
+  have hmeandev : ∑ i ∈ s, w i * (x i - μ) = 0 := by
+    have hrw : ∑ i ∈ s, w i * (x i - μ)
+        = (∑ i ∈ s, w i * x i) - (∑ i ∈ s, w i) * μ := by
+      rw [Finset.sum_mul, ← Finset.sum_sub_distrib]
+      exact Finset.sum_congr rfl (fun i _ => by ring)
+    rw [hrw, hmean]; ring
+  have hkey : ∑ i ∈ s, w i * (x i - c) ^ 2
+      = ∑ i ∈ s, w i * (x i - μ) ^ 2
+        + 2 * (μ - c) * (∑ i ∈ s, w i * (x i - μ))
+        + (μ - c) ^ 2 * (∑ i ∈ s, w i) := by
+    rw [Finset.mul_sum, Finset.mul_sum, ← Finset.sum_add_distrib, ← Finset.sum_add_distrib]
+    exact Finset.sum_congr rfl (fun i _ => by ring)
+  rw [hkey, hmeandev]
+  have hnn : 0 ≤ (μ - c) ^ 2 * (∑ i ∈ s, w i) := mul_nonneg (sq_nonneg _) hsw
+  linarith
+
+/-- **Variance is bounded by any centred second moment.**  The directly-consumable form of
+    `weighted_variance_le_of_mean` in the file's multiplicative variance notation: for any
+    centre `c`, `(∑ wᵢxᵢ²) − (∑ wᵢ)·μ² ≤ ∑ wᵢ(xᵢ − c)²`.  Combines the Huygens identity
+    `weighted_variance_eq` with the minimizing property. -/
+theorem weighted_variance_le_second_moment {ι : Type*} (s : Finset ι) (w x : ι → ℚ) (μ : ℚ)
+    (hw : ∀ i ∈ s, 0 ≤ w i)
+    (hmean : ∑ i ∈ s, w i * x i = (∑ i ∈ s, w i) * μ) (c : ℚ) :
+    (∑ i ∈ s, w i * x i ^ 2) - (∑ i ∈ s, w i) * μ ^ 2 ≤ ∑ i ∈ s, w i * (x i - c) ^ 2 := by
+  rw [← weighted_variance_eq s w x μ hmean]
+  exact weighted_variance_le_of_mean s w x μ hw hmean c
+
 /-- **The variance atom: a single deviating cell forces a positive second moment.**
     Weighted values with nonnegative weights and weighted mean `μ` have their
     weighted second moment about `μ` bounded below by the single-cell contribution:

--- a/research/problems/szemeredi-regularity-oq-04/state.md
+++ b/research/problems/szemeredi-regularity-oq-04/state.md
@@ -116,3 +116,22 @@ variance/second-moment bound (the hard analytic core). Remaining:
 2. State the two-level AFKS conclusion (coarse ε-regular partition + refinement
    with all but `ε·C(ℓ,2)` pairs regular), dependent tolerance `E : ℕ → (0,1]`.
 3. Assemble the outer loop using `afks_energy_iteration_count` as the certificate.
+
+## Update (2026-07-11, researcher-8 — variance minimizer / energy-monotonicity core)
+
+The variance-atom bounds (`weighted_variance_atom_bound`, `weighted_variance_subset_bound`)
+were already present; item 1 of the prior "Next Action" is done. Added the complementary
+*variational* half of the variance toolkit — the abstract reason partition energy is monotone
+under refinement (3 theorems, 0 sorry / 0 axiom, VERIFIED `bin/lake env lean`, all
+`[propext, Classical.choice, Quot.sound]`):
+- `weighted_variance_nonneg` — `0 ≤ (∑ wᵢxᵢ²) − (∑ wᵢ)μ²` (the `d = 0` skeleton of the atom
+  bound; energy never drops below a coarsening's).
+- `weighted_variance_le_of_mean` — the weighted mean minimizes weighted MSE:
+  `∑ wᵢ(xᵢ−μ)² ≤ ∑ wᵢ(xᵢ−c)²` for every centre `c`, via the parallel-axis expansion
+  `∑ wᵢ(xᵢ−c)² = ∑ wᵢ(xᵢ−μ)² + (∑ wᵢ)(μ−c)²`. This is exactly why replacing a part's mean
+  density by sub-cell (conditional) means increases the partition energy.
+- `weighted_variance_le_second_moment` — the directly-consumable multiplicative form:
+  `(∑ wᵢxᵢ²) − (∑ wᵢ)μ² ≤ ∑ wᵢ(xᵢ−c)²`.
+
+Remaining (unchanged): the two-level AFKS conclusion (item 2) and the outer-loop assembly
+(item 3). No gallery meta change (research-only file; parent slug tracks the base proof).


### PR DESCRIPTION
## Summary

`SzemerediRegularityOQ04.lean` already carries the variance-atom *lower* bounds (`weighted_variance_atom_bound`, `weighted_variance_subset_bound`) that drive the AFKS energy-increment step. This PR adds the complementary **variational** half of the weighted-variance toolkit — the abstract reason partition energy is **monotone under refinement**.

## What's added (3 theorems, axiom-free)

- **`weighted_variance_nonneg`** — `0 ≤ (∑ wᵢxᵢ²) − (∑ wᵢ)μ²`, the `d = 0` skeleton of the atom bound (energy never drops below a coarsening's).
- **`weighted_variance_le_of_mean`** — the weighted mean **minimizes** weighted mean-squared deviation: `∑ wᵢ(xᵢ−μ)² ≤ ∑ wᵢ(xᵢ−c)²` for every centre `c`, via the parallel-axis expansion `∑ wᵢ(xᵢ−c)² = ∑ wᵢ(xᵢ−μ)² + (∑ wᵢ)(μ−c)²`. This is exactly why replacing a part's single mean density with the sub-cell (conditional) means can only **increase** the partition energy — the abstract heart of energy monotonicity.
- **`weighted_variance_le_second_moment`** — the directly-consumable multiplicative form: `(∑ wᵢxᵢ²) − (∑ wᵢ)μ² ≤ ∑ wᵢ(xᵢ−c)²`.

## Verification

- `bin/lake env lean` compiles the full file, exit 0 (only pre-existing benign linter warnings).
- `#print axioms` for all three new theorems = `[propext, Classical.choice, Quot.sound]` — **0 sorries, 0 axioms, no `native_decide`**.
- No gallery meta change (research-only file; parent `szemeredi-regularity` slug tracks the base proof).

The two-level AFKS conclusion and the outer-loop assembly remain the open frontier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)