### PR TITLE
research(erdos-666-incomplete-01): axiom-free boundary isolating the deep Conder axiom

### DIFF
--- a/proofs/Proofs/Erdos666Problem.lean
+++ b/proofs/Proofs/Erdos666Problem.lean
@@ -367,6 +367,64 @@ works is the remaining quantitative question; here we only pin the barrier from 
 theorem conjectureAt_imp_gt_third {ε : ℝ} (h : ConjectureAt ε) : 1/3 < ε :=
   not_le.mp (fun hle => conder_no_threshold_le hle h)
 
+/-!
+### Part IV.6: The elementary boundary — where the deep axiom is *not* needed
+
+The refutations above (`conder_no_threshold_le`, `conjectureAt_imp_gt_third`) rest on
+the single deep axiom `conder_no_threshold`.  It is worth isolating exactly how much
+they buy over what is provable *outright*: for every **nonpositive** density the
+conjecture fails for an elementary reason — the required edge count `ε·Eₙ ≤ 0` is met
+by the *empty* graph `⊥`, which has no edges and hence no `C₆`.  So `⊥` is a
+`C₆`-free `ε`-dense "subgraph" at every `n`, refuting the conjecture with no
+combinatorics at all.
+
+The axiom-free necessary condition this yields is `ConjectureAt ε → 0 < ε`
+(`conjectureAt_imp_pos`).  Conder's axiom is precisely what upgrades that barrier from
+`0` to `1/3` (`conjectureAt_imp_gt_third`): all of the genuinely combinatorial content
+of Erdős #666 lives in the window `0 < ε ≤ 1/3`.
+-/
+
+unseal HasC6 HasCycle in
+/-- **The empty graph has no `C₆`.**  The reusable form of the witness already used in
+`chung_c6free`: `⊥` has no edges, so it contains no cycle of any length. -/
+theorem not_hasC6_bot {n : ℕ} : ¬ HasC6 (⊥ : SimpleGraph (Fin (2^n))) := by
+  rintro ⟨cycle, -, hadj, -⟩
+  simpa using hadj 0
+
+unseal EpsilonDenseSubgraph in
+/-- **At nonpositive density the empty graph is `ε`-dense.**  For `ε ≤ 0` the required
+edge count `ε·Eₙ` is `≤ 0`, and `⊥` has `0` edges, so `Nat.card ⊥.edgeSet = 0 ≥ ε·Eₙ`. -/
+theorem epsilonDense_bot_of_nonpos {n : ℕ} {ε : ℝ} (hε : ε ≤ 0) :
+    EpsilonDenseSubgraph n ε (⊥ : SimpleGraph (Fin (2^n))) := by
+  show (Nat.card (⊥ : SimpleGraph (Fin (2^n))).edgeSet : ℝ) ≥ ε * hypercubeEdges n
+  have hle : ε * (hypercubeEdges n : ℝ) ≤ 0 :=
+    mul_nonpos_of_nonpos_of_nonneg hε (Nat.cast_nonneg _)
+  simp only [SimpleGraph.edgeSet_bot, Nat.card_coe_set_eq, Set.ncard_empty,
+    Nat.cast_zero, ge_iff_le]
+  linarith
+
+/-- **The conjecture fails at every `n` for nonpositive density.**  `⊥` is a `C₆`-free
+`ε`-dense graph, so `DenseForcesC6 n ε` is false for every `n` (not merely large `n`)
+whenever `ε ≤ 0`.  Axiom-free. -/
+theorem not_denseForcesC6_of_nonpos {n : ℕ} {ε : ℝ} (hε : ε ≤ 0) :
+    ¬ DenseForcesC6 n ε :=
+  fun h => not_hasC6_bot (h ⊥ (epsilonDense_bot_of_nonpos hε))
+
+/-- **`ConjectureAt` fails at every nonpositive density.**  Immediate from
+`not_denseForcesC6_of_nonpos`: any threshold `N` already fails at `n = N`.  Axiom-free —
+this half of the refutation needs no combinatorics. -/
+theorem not_conjectureAt_of_nonpos {ε : ℝ} (hε : ε ≤ 0) : ¬ ConjectureAt ε := by
+  rintro ⟨N, hN⟩
+  exact not_denseForcesC6_of_nonpos hε (hN N le_rfl)
+
+/-- **Axiom-free necessary condition: any working density is positive.**  The
+elementary lower barrier `ConjectureAt ε → 0 < ε`, proved without `conder_no_threshold`.
+Conder's axiom sharpens this to `1/3 < ε` (`conjectureAt_imp_gt_third`); the gap
+between the two — the interval `(0, 1/3]` — is exactly where the deep combinatorial
+input is required. -/
+theorem conjectureAt_imp_pos {ε : ℝ} (h : ConjectureAt ε) : 0 < ε :=
+  not_le.mp (fun hle => not_conjectureAt_of_nonpos hle h)
+
 /-- **Conder's counterexamples recur for arbitrarily large hypercubes.**
 The axiom `conder_no_threshold` is stated in the compact negation form `¬ ConjectureAt (1/3)`
 (no threshold `N` works), which conceals its positive content.  Unfolding the two nested

--- a/src/data/proofs/erdos-666/meta.json
+++ b/src/data/proofs/erdos-666/meta.json
@@ -54,12 +54,13 @@
       "chung_c6free theorem (de-axiomatized): for n ≥ 3, Qₙ has a C₆-free subgraph — proved via the empty subgraph ⊥ (no edges ⇒ no C₆), since the bare existence form carries no edge-count data; feeds the ε = 1/4 and ε = 1/3 corollaries. Drops the entry's axiom count from 2 to 1.",
       "hypercubeVertices_succ / hypercubeEdges_succ: the recursive Cartesian-product structure Q_{n+1} = Qₙ □ K₂ in count form — vertices double (2^{n+1} = 2·2ⁿ) and edges satisfy |E(Q_{n+1})| = 2·|E(Qₙ)| + |V(Qₙ)| (two interior copies of Qₙ plus the perfect matching across them). Axiom-free; pins n·2ⁿ⁻¹ by its recurrence rather than the closed form.",
       "erdosConjecture_iff_small: for any fixed cutoff c > 0, ErdosConjecture ⟺ its restriction to small densities 0 < ε ≤ c — the conjecture's truth is decided entirely at the bottom of the density scale (monotonicity, axiom-free).",
+      "conjectureAt_imp_pos and the elementary boundary (not_hasC6_bot / epsilonDense_bot_of_nonpos / not_denseForcesC6_of_nonpos / not_conjectureAt_of_nonpos): the AXIOM-FREE necessary condition ConjectureAt ε → 0 < ε. For ε ≤ 0 the required edge count ε·Eₙ ≤ 0 is met by the empty graph ⊥, which is C₆-free, so the conjecture fails at every n with no combinatorics. This isolates the deep axiom conder_no_threshold precisely: it upgrades the barrier from 0 to 1/3 (conjectureAt_imp_gt_third), so all genuine combinatorial content of Erdős #666 lives in the window 0 < ε ≤ 1/3.",
       "GeneralizedConjecture: open question for C_{2k}"
     ],
     "axiomCount": 1,
-    "lineCount": 554,
+    "lineCount": 612,
     "assumptions": "1 axiom (Conder 1993): conder_no_threshold — ¬ ConjectureAt (1/3), i.e. no threshold N makes every (1/3)-dense subgraph of Qₙ contain C₆; the pigeonhole consequence of Conder's 3-edge-colouring of Qₙ (n ≥ 3) with no monochromatic C₄ or C₆, not available in Mathlib. This is the single deep input: Chung's earlier 1/4 refutation (chung_no_threshold) is now DERIVED from it by monotonicity (1/4 ≤ 1/3), not separately assumed. The companion existence statement chung_c6free (for n ≥ 3, Qₙ has some C₆-free subgraph) carries no edge-count data and is PROVED outright via the empty subgraph ⊥. The deep density content stays isolated in the single axiom conder_no_threshold.",
-    "theoremCount": 21,
+    "theoremCount": 26,
     "definitionCount": 13,
     "proofStrategy": "**Formalization Approach**\\n\\n1. **Hypercube Definition:** Qₙ defined on Fin(2ⁿ) - vertices x, y are adjacent iff their bitwise XOR is a power of two (exactly one differing bit, i.e. Hamming distance 1). Symmetry and looplessness are discharged from Nat.xor_comm and Nat.xor_self.\\n\\n2. **Cycle Definitions:**\\n   - HasCycle G k: injective k-sequence with cyclic adjacency\\n   - HasC4, HasC6, HasC2k: specific even cycle predicates\\n\\n3. **Density:**\\n   - EpsilonDenseSubgraph: at least ε·n·2ⁿ⁻¹ edges\\n\\n4. **Main Results:**\\n   - ErdosConjecture: the (false) original conjecture\\n   - erdos_conjecture_false: theorem showing it is false, fully proved (no sorry) from chung_no_threshold\\n   - conder_no_threshold axiom (ε = 1/3): no threshold N forces C₆ in every (1/3)-dense subgraph of Qₙ — the pigeonhole consequence of Conder 1993's 3-edge-colouring, the sharpest known refutation and the single deep input\\n   - chung_no_threshold theorem (ε = 1/4): now DERIVED from conder_no_threshold via monotonicity of ConjectureAt (1/4 ≤ 1/3), so no separate Chung axiom is needed; still consumed by erdos_conjecture_false\\n   - conjectureAt_mono / epsilonDense_antitone / denseForcesC6_mono: axiom-free monotonicity bookkeeping used to derive Chung from Conder and to spread each refutation across an interval\\n   - chung_no_threshold_le / conder_no_threshold_le: the refutation holds on the whole intervals ε ≤ 1/4 and (sharpest) ε ≤ 1/3\\n   - chung_c6free theorem (de-axiomatized): for n ≥ 3, Qₙ has a C₆-free subgraph — proved via the empty subgraph ⊥ (no edges ⇒ no C₆)\\n   - chung_counterexample / conder_counterexample: ε = 1/4 and ε = 1/3 C₆-free existence witnesses, both derived from chung_c6free\\n\\n5. **Why axioms:** Conder's explicit 3-edge-colouring construction is combinatorial and not available in Mathlib. It is captured by a single density axiom conder_no_threshold, whose ¬ ConjectureAt (1/3) arrow form avoids a Mathlib v4.26 elaborator stack overflow triggered by the bundled ∃ H, (edge bound) ∧ ¬ HasC6 H form. Definitions HasCycle/HasC6/EpsilonDenseSubgraph are marked @[irreducible] for the same reason (1 axiom, 0 sorries)."
   },
@@ -175,9 +176,9 @@
       "SimpleGraph"
     ],
     "namespace": "Erdos666",
-    "lineCount": 510,
+    "lineCount": 612,
     "axiomCount": 1,
-    "theoremCount": 13,
+    "theoremCount": 26,
     "definitionCount": 13,
     "path": "Proofs/Erdos666Problem.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

Adds five **axiom-free** lemmas to `Erdos666Problem.lean` (Erdős #666, C₆ in hypercube subgraphs) that pin down exactly where the file's single deep axiom `conder_no_threshold` (Conder 1993) is actually required.

The file already refutes the conjecture for `ε ≤ 1/3` (via `conder_no_threshold` + monotonicity) and derives `ConjectureAt ε → 1/3 < ε`. This PR shows the **elementary half** of that barrier is provable outright, with no combinatorics.

## New results (all axiom-free)

`#print axioms` on each reports only `[propext, Classical.choice, Quot.sound]` — none depend on `conder_no_threshold`.

- **`not_hasC6_bot`** — the empty graph `⊥` has no `C₆` (reusable form of the witness already used inline in `chung_c6free`).
- **`epsilonDense_bot_of_nonpos`** — for `ε ≤ 0` the required edge count `ε·Eₙ ≤ 0` is met by `⊥` (`Nat.card ⊥.edgeSet = 0`), so `⊥` is `ε`-dense.
- **`not_denseForcesC6_of_nonpos` / `not_conjectureAt_of_nonpos`** — hence the conjecture fails at *every* `n` for nonpositive density.
- **`conjectureAt_imp_pos`** — the axiom-free necessary condition `ConjectureAt ε → 0 < ε`.

Together these isolate `conder_no_threshold` precisely: **axiom-free the barrier is `0 < ε`; the Conder axiom upgrades it to `1/3 < ε`** (`conjectureAt_imp_gt_third`). So the genuine combinatorial content of Erdős #666 lives entirely in the window `0 < ε ≤ 1/3`.

## Metadata

Entry `axiomCount` unchanged (still 1 — the deep Conder axiom). Synced stale counts (`lineCount` 554→612, `theoremCount` 21→26) and added an `originalContributions` entry describing the boundary result.

## Verification

- `lake env lean Proofs/Erdos666Problem.lean` → exit 0, no warnings
- `#print axioms` on all five new theorems → foundational only (no `conder_no_threshold`)
- 0 sorries, 1 literal `axiom` (unchanged), no `native_decide`; JSON validated

🤖 Generated with [Claude Code](https://claude.com/claude-code)