### PR TITLE
research(erdos-214-incomplete-01): odd-prime (mod 3) obstruction — a new avoided-distance family

### DIFF
--- a/proofs/Proofs/Erdos214Incomplete01OQ01.lean
+++ b/proofs/Proofs/Erdos214Incomplete01OQ01.lean
@@ -371,6 +371,78 @@ theorem scaledLattice_dist_ne_sqrt_twelve {p q : Plane}
   scaledLattice_dist_ne_sqrt_twelve_mod_sixteen hp hq (n := 12) (by decide)
 
 /-!
+## An odd-prime obstruction: `3` forces a square factor
+
+Every avoidance family above is a *power-of-two* congruence obstruction (`mod 4`, `mod 8`,
+`mod 16`).  The next structural source is the first prime `≡ 3 (mod 4)`, namely `3`: since
+`-1` is not a quadratic residue mod `3`, a sum of two squares divisible by `3` must have
+*both* summands divisible by `3`, so `3 ∣ (u² + v²) ⟹ 9 ∣ (u² + v²)`.  Consequently no
+`n` with `3 ∣ n` but `9 ∤ n` is an achievable square-distance — a genuinely different
+mechanism from the mod-`2ᵏ` families (it is the `k = 3` case of Fermat's two-square theorem,
+the open frontier for the full characterization).
+-/
+
+/-- **`3` is a non-residue obstruction for sums of two squares.**  If `3 ∣ u² + v²` then
+`3 ∣ u` and `3 ∣ v`.  Squares mod `3` are `∈ {0, 1}`, and a square is `≡ 0` exactly when its
+base is `≡ 0`; the only way two of `{0, 1}` sum to `0 (mod 3)` is `0 + 0`, forcing both bases
+divisible by `3`.  The `p = 3` instance of "a prime `≡ 3 (mod 4)` dividing a sum of two
+squares divides each summand". -/
+theorem sq_add_sq_three_dvd (u v : ℤ) (h : (3 : ℤ) ∣ (u ^ 2 + v ^ 2)) :
+    (3 : ℤ) ∣ u ∧ (3 : ℤ) ∣ v := by
+  have key : ∀ w : ℤ, (w ^ 2 % 3 = 0 ∧ w % 3 = 0) ∨ w ^ 2 % 3 = 1 := by
+    intro w
+    obtain ⟨k, hk⟩ : ∃ k, w = 3 * k + w % 3 := ⟨w / 3, by omega⟩
+    have hr : w % 3 = 0 ∨ w % 3 = 1 ∨ w % 3 = 2 := by omega
+    rcases hr with h0 | h1 | h2
+    · left
+      refine ⟨?_, h0⟩
+      have : w ^ 2 = 3 * (3 * k ^ 2) := by rw [hk, h0]; ring
+      omega
+    · right
+      have : w ^ 2 = 3 * (3 * k ^ 2 + 2 * k) + 1 := by rw [hk, h1]; ring
+      omega
+    · right
+      have : w ^ 2 = 3 * (3 * k ^ 2 + 4 * k + 1) + 1 := by rw [hk, h2]; ring
+      omega
+  have hmod : (u ^ 2 + v ^ 2) % 3 = 0 := by omega
+  rcases key u with ⟨_, hu⟩ | hu1 <;> rcases key v with ⟨_, hv⟩ | hv1
+  · exact ⟨by omega, by omega⟩
+  · omega
+  · omega
+  · omega
+
+/-- **`√2·ℤ²` avoids every distance `√n` with `3 ∣ n` but `9 ∤ n`.**  Then
+`dist² = 2·(u² + v²) = n` gives `3 ∣ u² + v²`, so `sq_add_sq_three_dvd` forces `3 ∣ u`,
+`3 ∣ v`, whence `9 ∣ u² + v²` and therefore `9 ∣ n` — contradiction.  This is a *new*
+avoided family, orthogonal to the mod-`2ᵏ` ones: it catches e.g. `√6, √24, √42, √60, …`,
+including values (like `24 ≡ 0 mod 8`) whose residue mod `8` is *achievable*. -/
+theorem scaledLattice_dist_ne_sqrt_of_three_dvd_not_nine {p q : Plane}
+    (hp : p ∈ ScaledLattice) (hq : q ∈ ScaledLattice)
+    {n : ℕ} (h3 : 3 ∣ n) (h9 : ¬ (9 ∣ n)) : dist p q ≠ Real.sqrt n := by
+  intro h
+  obtain ⟨u, v, huv⟩ := scaledLattice_dist_sq_two_mul_sq_add_sq hp hq
+  have hsq : dist p q ^ 2 = (n : ℝ) := by rw [h, Real.sq_sqrt (by positivity)]
+  rw [hsq] at huv
+  have hz : (n : ℤ) = 2 * (u ^ 2 + v ^ 2) := by exact_mod_cast huv
+  have h3z : (3 : ℤ) ∣ (n : ℤ) := by exact_mod_cast h3
+  have h3s : (3 : ℤ) ∣ (u ^ 2 + v ^ 2) := by omega
+  obtain ⟨hu, hv⟩ := sq_add_sq_three_dvd u v h3s
+  obtain ⟨a, ha⟩ := hu
+  obtain ⟨b, hb⟩ := hv
+  have h9s : (9 : ℤ) ∣ (u ^ 2 + v ^ 2) := ⟨a ^ 2 + b ^ 2, by rw [ha, hb]; ring⟩
+  have h9z : (9 : ℤ) ∣ (n : ℤ) := by omega
+  exact h9 (by exact_mod_cast h9z)
+
+/-- **Concrete instance:** no two points of `√2·ℤ²` are at distance `√24` (`3 ∣ 24`,
+`9 ∤ 24`).  Although `24 ≡ 0 (mod 8)` is an *achievable* residue and `24 ≡ 8 (mod 16)`
+escapes the `n ≡ 12 (mod 16)` family, `√24` is nonetheless avoided — the odd-prime
+obstruction reaches distances the power-of-two congruences miss. -/
+theorem scaledLattice_dist_ne_sqrt_twentyfour {p q : Plane}
+    (hp : p ∈ ScaledLattice) (hq : q ∈ ScaledLattice) :
+    dist p q ≠ Real.sqrt 24 :=
+  scaledLattice_dist_ne_sqrt_of_three_dvd_not_nine hp hq (n := 24) (by decide) (by decide)
+
+/-!
 ## Sharpness: the achievable square-distances are *exactly* `2·(u² + v²)`
 
 Every theorem above is one-directional: it lists square-distances the lattice does

--- a/research/problems/erdos-214-incomplete-01/knowledge.md
+++ b/research/problems/erdos-214-incomplete-01/knowledge.md
@@ -230,3 +230,25 @@ Prior session (researcher-3, n≡12 mod 16 family showing mod-8 dichotomy NOT sh
 UNVERIFIED (docker down). `Erdos214Incomplete01OQ01.lean` (373 L, Mathlib-only, 0 ax/0 sorry)
 verified via lean-elab ([[reference-docker-down-lean-elab-verification-path]]): EXIT 0, zero
 errors/warnings. Standing work confirmed correct (no bug). Marked completed.
+
+## Session 2026-07-11 (researcher-10) — first ODD-PRIME (mod 3) obstruction [VERIFIED axiom-free]
+
+Extended Erdos214Incomplete01OQ01.lean (373→445, Mathlib-only, 0 ax/0 sorry) past the
+power-of-2 congruence families (mod4/8/16) with the FIRST odd-prime obstruction — the k=3
+Fermat-two-square mechanism. VERIFIED host lake env lean exit 0, #print axioms foundational
+only (no sorryAx). PR #37682. Three thms:
+- `sq_add_sq_three_dvd (u v : ℤ) (h : 3 ∣ u²+v²) : 3∣u ∧ 3∣v` (−1 non-residue mod 3; squares
+  mod3∈{0,1}, only 0+0≡0). Proof mirrors sq_add_sq_mod_eight_ne_six idiom: w=3k+w%3, per-residue
+  `w²=3*(…)+c` ring identity + omega; final `rcases key u/key v <;> omega`.
+- `scaledLattice_dist_ne_sqrt_of_three_dvd_not_nine {n} (h3: 3∣n)(h9: ¬9∣n)`: avoided (3∣u²+v²
+  →9∣u²+v²→9∣n contra). Key omega steps: 3∣n∧n=2(u²+v²)⟹3∣(u²+v²) (gcd(3,2)=1, omega does it);
+  9∣(u²+v²) needs EXPLICIT witness ⟨a²+b²,…⟩ from u=3a,v=3b (omega can't square); 9∣n via omega.
+- `scaledLattice_dist_ne_sqrt_twentyfour`: √24 avoided — 24≡0 mod8 (achievable residue!) AND
+  24≡8 mod16 (escapes n≡12 mod16 family) → caught by NEITHER power-of-2 family. New witness.
+
+★The achievable-distance set is 2·(sum of two squares); no single-residue mod-p obstruction
+exists for odd p (all residues of u²+v² mod 3,7 achievable) — the real obstruction is STRUCTURAL
+(prime ≡3 mod4 to odd power), captured as "p∣sum ⟹ p²∣sum". Next: mod-7/mod-11 analogues, or the
+full Fermat characterization scaledLattice_achievable_iff already stubbed at line 421 (open frontier).
+
+REMAINING: core #214 BLOCKED on juhasz_stronger (deep incidence geometry, not in Mathlib).


### PR DESCRIPTION
## Summary

Every prior avoidance family for the achievable square-distances of the `√2·ℤ²` lattice (in `Erdos214Incomplete01OQ01.lean`) was a **power-of-two** congruence obstruction (mod 4 / 8 / 16). This adds the first **odd-prime** obstruction — a structurally different mechanism:

- **`sq_add_sq_three_dvd`** — `3 ∣ (u²+v²) ⟹ 3∣u ∧ 3∣v`. Since `−1` is a non-residue mod 3 (squares mod 3 ∈ {0,1}, only `0+0 ≡ 0`), a sum of two squares divisible by 3 has both summands divisible by 3, hence `3 ∣ (u²+v²) ⟹ 9 ∣ (u²+v²)`.
- **`scaledLattice_dist_ne_sqrt_of_three_dvd_not_nine`** — `√2·ℤ²` avoids every `√n` with `3 ∣ n` but `9 ∤ n` (else `dist² = 2(u²+v²) = n` would force `9 ∣ n`). New infinite family `√6, √24, √42, √60, …`.
- **`scaledLattice_dist_ne_sqrt_twentyfour`** — concrete `√24` avoided. Notably `24 ≡ 0 (mod 8)` is an *achievable* residue and `24 ≡ 8 (mod 16)` escapes the `n ≡ 12 (mod 16)` family, so `√24` is caught by **neither** power-of-two family — the odd-prime obstruction reaches distances the mod-`2ᵏ` congruences miss. This is the `k = 3` case of Fermat's two-square mechanism (the open frontier for the full sum-of-two-squares characterization).

## Verification

- Host `lake env lean` (Mathlib-only file), **exit 0**, zero errors; whole file recompiles clean.
- `#print axioms` on all three new theorems = foundational axioms only (no `sorryAx`); the file remains 0-axiom.
- File 373 → 445 lines.

The core `#214` theorem stays blocked on `juhasz_stronger` (deep incidence geometry absent from Mathlib), untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)