### PR TITLE
research(feuerbachs-theorem-oq-04): antipodal-centre symmetry of spherical circles

### DIFF
--- a/proofs/Proofs/FeuerbachsTheoremOQ04.lean
+++ b/proofs/Proofs/FeuerbachsTheoremOQ04.lean
@@ -1307,4 +1307,44 @@ theorem excircleB_excircleC_distinct {Na Nb Nc O : E} {ρ : ℝ}
   rw [h0] at hpos
   exact lt_irrefl 0 hpos
 
+/-! ### Antipodal-centre symmetry of spherical circles
+
+A spherical circle is cut by *two* poles: the centre `O` at radius `ρ` and its antipode `-O`
+at the complementary radius `π − ρ`.  This intrinsic two-centre ambiguity is precisely the
+`±⟪O, ·⟫` sign symmetry that the incircle/excircle contact analysis above turns on
+(`incircle_excircleAB_signs_exclusive`, the `excircle*_distinct` family): swapping a centre
+for its antipode negates every `scos` and complements every radius.  The lemmas below make
+that symmetry a checked identity. -/
+
+omit [InnerProductSpace ℝ E] in
+/-- **The antipode lies on the sphere.**  If `P` is a unit vector then so is `-P`; the
+spherical model is closed under antipodal reflection (`‖-P‖ = ‖P‖`). -/
+theorem onSphere_neg {P : E} (hP : OnSphere P) : OnSphere (-P) := by
+  rw [OnSphere, norm_neg]; exact hP
+
+/-- **Spherical cosine flips sign under antipodal reflection of the second argument.**
+`scos P (-Q) = -scos P Q`, directly from `⟪P, -Q⟫ = -⟪P, Q⟫`. -/
+theorem scos_neg_right (P Q : E) : scos P (-Q) = -scos P Q := by
+  rw [scos, scos, inner_neg_right]
+
+/-- **Antipodal points are at spherical distance `π`.**  For a unit vector `O`,
+`sdist O (-O) = π`: the antipode is the unique farthest model point, since
+`⟪O, -O⟫ = -‖O‖² = -1` and `arccos (-1) = π`. -/
+theorem sdist_antipode {O : E} (hO : OnSphere O) : sdist O (-O) = Real.pi := by
+  have h : (⟪O, -O⟫ : ℝ) = -1 := by
+    rw [inner_neg_right, real_inner_self_eq_norm_sq, hO]; norm_num
+  rw [sdist, h, Real.arccos_neg_one]
+
+/-- **Every spherical circle has an antipodal centre with complementary radius.**
+`sCircle O ρ = sCircle (-O) (π − ρ)`: a point `P` satisfies `⟪P, O⟫ = cos ρ` iff it satisfies
+`⟪P, -O⟫ = cos (π − ρ)`, because `⟪P, -O⟫ = -⟪P, O⟫` and `cos (π − ρ) = -cos ρ`.  The same
+locus is therefore cut by the pole `O` at radius `ρ` and by its antipode `-O` at the
+complementary radius `π − ρ` — the intrinsic *two-centre ambiguity* of a spherical circle, and
+exactly the `±⟪O, ·⟫` sign symmetry underlying the incircle/excircle contact analysis above.
+No hypothesis on `O` is needed: it is an identity of level sets of the inner product. -/
+theorem sCircle_antipodal_center (O : E) (ρ : ℝ) :
+    sCircle O ρ = sCircle (-O) (Real.pi - ρ) := by
+  ext P
+  simp only [sCircle, Set.mem_setOf_eq, scos, inner_neg_right, Real.cos_pi_sub, neg_inj]
+
 end FeuerbachsTheoremOQ04

--- a/src/data/research/problems/feuerbachs-theorem-oq-04.json
+++ b/src/data/research/problems/feuerbachs-theorem-oq-04.json
@@ -21,8 +21,8 @@
   "currentState": {
     "phase": "ACT",
     "since": "2026-06-28T10:40:00.000Z",
-    "iteration": 4,
-    "focus": "Spherical circles (level sets of scos) + internal/external tangency relations formalized on top of the metric layer; level-set circle identified with the metric circle (mem_sCircle_iff_sdist).",
+    "iteration": 5,
+    "focus": "ACT iteration 5 (researcher-5, 2026-07-11) — VERIFIED axiom-free (bin/lake env lean, exit 0; #print axioms = [propext, Classical.choice, Quot.sound] for all four new lemmas). Added the antipodal-centre symmetry layer for spherical circles: onSphere_neg (the model is closed under P ↦ -P), scos_neg_right (scos P (-Q) = -scos P Q), sdist_antipode (sdist O (-O) = π for unit O), and the capstone sCircle_antipodal_center (sCircle O ρ = sCircle (-O) (π-ρ) with NO hypothesis on O). This makes precise the intrinsic two-centre ambiguity of a spherical circle — the same locus is cut by pole O at radius ρ and by antipode -O at complementary radius π-ρ — which is exactly the ±⟨O,·⟩ sign symmetry the incircle/excircle contact analysis (incircle_excircleAB_signs_exclusive, the excircle*_distinct family) turns on. Also corrected the stale tracked sorryCount 2→0 (the '2' were docstring '0-sorry' false-positives; the file has no actual sorry). 0 axioms, 0 sorries.",
     "blockers": [],
     "nextAction": "Tangent-point existence: exhibit the unique common point on the geodesic between centres for tangent circles (spherical slerp) and verify it lies on both sCircles; then build spherical incircle / nine-point circle and attempt the spherical Feuerbach tangency.",
     "attemptCounts": {
@@ -116,7 +116,7 @@
     "mathlib": []
   },
   "started": "2026-04-22T12:51:58.293Z",
-  "lastUpdate": "2026-06-30",
+  "lastUpdate": "2026-07-11",
   "significance": 7,
   "tractability": 4,
   "leanFiles": [
@@ -398,11 +398,11 @@
     {
       "path": "Proofs/FeuerbachsTheoremOQ04.lean",
       "filename": "FeuerbachsTheoremOQ04.lean",
-      "lineCount": 1311,
-      "theoremCount": 65,
+      "lineCount": 1350,
+      "theoremCount": 69,
       "axiomCount": 0,
       "defCount": 12,
-      "sorryCount": 2,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/FeuerbachsTheoremOQ04.lean"
     },


### PR DESCRIPTION
## Summary

Non-Euclidean Feuerbach problem (`feuerbachs-theorem-oq-04`), spherical model. The file already develops the metric layer `(Sⁿ, sdist)`, spherical circles, internal/external tangency, and an incircle/excircle contact analysis whose distinctness lemmas turn on the `±⟨O,·⟩` sign of the inner product. This PR adds the **antipodal-centre symmetry** that makes that sign structure a first-class fact.

A spherical circle is cut by **two poles**: the centre `O` at radius `ρ` and its antipode `-O` at the complementary radius `π-ρ`. Four axiom-free lemmas:

- **`onSphere_neg`** — the model is closed under `P ↦ -P` (`‖-P‖ = ‖P‖`).
- **`scos_neg_right`** — `scos P (-Q) = -scos P Q` (from `⟪P,-Q⟫ = -⟪P,Q⟫`).
- **`sdist_antipode`** — `sdist O (-O) = π` for a unit vector `O` (`⟪O,-O⟫ = -1`, `arccos(-1) = π`).
- **`sCircle_antipodal_center`** — `sCircle O ρ = sCircle (-O) (π-ρ)`, an identity of inner-product level sets requiring **no hypothesis on `O`**.

Together these pin the intrinsic two-centre ambiguity of a spherical circle, which is precisely the `±⟨O,·⟩` symmetry underlying `incircle_excircleAB_signs_exclusive` and the `excircle*_distinct` family already in the file.

## Verification

- Built with `bin/lake env lean` against prebuilt Mathlib v4.26.0 oleans — exit 0, no errors, no warnings.
- `#print axioms` for all four new lemmas = `[propext, Classical.choice, Quot.sound]` (foundational only).
- **0 axioms, 0 sorries.**

## Metadata correction

Also corrects the stale tracked `sorryCount` **2 → 0** for `FeuerbachsTheoremOQ04.lean` (the "2" were docstring "0-sorry" false-positives — the file has no actual `sorry`, confirmed by full elaboration) and refreshes `lineCount` 1311→1350, `theoremCount` 65→69.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
