### PR TITLE
research(erdos-378): explicit Granville–Ramaré density formula + meta sync

### DIFF
--- a/proofs/Proofs/Erdos378Problem.lean
+++ b/proofs/Proofs/Erdos378Problem.lean
@@ -453,6 +453,23 @@ theorem erdos_378_density_positive (r : ℕ) :
   rw [atLeastSquarefree_eq_compl]
   exact natDensity_compl hd_density
 
+/-- **The explicit Granville–Ramaré density formula.**  Beyond mere existence and
+positivity, the density of `atLeastSquarefree r` has the closed value
+
+    density(r) = 1 − Σ_{0 ≤ m ≤ (r-1)/2} η_m,
+
+the complement of the Granville–Ramaré partial sum of the exact-count densities `η_m`.
+This is the quantitative answer to Erdős #378: `erdos_378_density_exists` /
+`erdos_378_density_positive` assert *that* the density exists and is positive, while this
+records *what it is* — the value that `erdos_378_density_positive` obtains as `1 − d` with
+`d < 1`, here pinned to the explicit sum. No new axiom beyond `complement_density`. -/
+theorem erdos_378_density_eq (r : ℕ) :
+    NaturalDensity (atLeastSquarefree r)
+      (1 - ∑ m ∈ range ((r - 1) / 2 + 1), eta m) := by
+  obtain ⟨d, hd_eq, hd_density, _⟩ := complement_density r
+  rw [atLeastSquarefree_eq_compl, ← hd_eq]
+  exact natDensity_compl hd_density
+
 /-- **Erdős Problem #378 — full resolution.**
 
 For every `r`, the set of `n` with at least `r` squarefree interior binomials has a

--- a/src/data/proofs/erdos-378/meta.json
+++ b/src/data/proofs/erdos-378/meta.json
@@ -61,12 +61,13 @@
       "granville_ramare_density_exists axiom: Granville-Ramaré (1996) Input 1 — density η_m of exactlySquarefree m exists",
       "complement_density axiom: Granville-Ramaré (1996) Input 2 — {n : squarefreeCount n < r} has density Σ η_m < 1",
       "erdos_378_density_exists / erdos_378_density_positive (no sorries): derived from the two axioms by complementation",
+      "erdos_378_density_eq (no sorries, no new axiom): the explicit Granville–Ramaré density formula density(r) = 1 − Σ_{0≤m≤(r-1)/2} η_m — the quantitative answer, pinning the value that density_positive obtains as 1−d to the explicit partial sum of the exact-count densities",
       "erdos_378, erdos_378_answer (no sorries): combined resolution of both questions"
     ],
     "axiomCount": 2,
-    "lineCount": 565,
+    "lineCount": 637,
     "assumptions": "2 axioms, both isolating the deep analytic content of Granville-Ramaré (1996): granville_ramare_density_exists (the density η_m of n with exactly 2m+2 squarefree binomials exists) and complement_density (the set of n with fewer than r squarefree binomials has density Σ_{0≤m≤(r-1)/2} η_m, which is < 1). 0 sorries. All other results, including the resolution of both questions and the parity theorems squarefreeCount_even_of_odd (odd rows have an even count) and squarefreeCount_odd_iff_central_squarefree (an even row has an odd count iff its central binomial C(n,n/2) is squarefree), are fully machine-checked (depend only on propext/Classical.choice/Quot.sound).",
-    "theoremCount": 20,
+    "theoremCount": 26,
     "definitionCount": 8,
     "additionalFiles": [
       "Proofs/Erdos378Aristotle.lean"
@@ -162,9 +163,9 @@
       "Finset"
     ],
     "namespace": "Erdos378",
-    "lineCount": 620,
+    "lineCount": 637,
     "axiomCount": 2,
-    "theoremCount": 19,
+    "theoremCount": 26,
     "definitionCount": 8,
     "path": "Proofs/Erdos378Problem.lean",
     "sorries": 0,


### PR DESCRIPTION
## Summary

Adds the **quantitative answer** to Erdős #378 (density of squarefree binomial coefficients) and resyncs stale gallery counts.

- **`erdos_378_density_eq`** — the explicit density formula

  `density(atLeastSquarefree r) = 1 − Σ_{0 ≤ m ≤ (r-1)/2} η_m`,

  the complement of the Granville–Ramaré partial sum of the exact-count densities `η_m`. The existing theorems assert *that* the density exists and is positive (`erdos_378_density_exists` / `erdos_378_density_positive`); this records *what it is* — the value obtained as `1 − d` with `d < 1`, pinned to the explicit sum.

Derived from `complement_density` + `natDensity_compl`; introduces **no new axiom** (`axiomCount` stays 2 — the two deep Granville–Ramaré inputs).

## Metadata sync

`lineCount` 565→637, `theoremCount` 20→26 (both the `meta` and `leanFile` count blocks were stale relative to the grown file). Status unchanged (`axiomatized`, 2 axioms).

## Verification

- `lake env lean Proofs/Erdos378Problem.lean` → exit 0, no warnings
- `#print axioms erdos_378_density_eq` → `[propext, Classical.choice, Quot.sound, granville_ramare_density_exists, complement_density]` — only the two pre-existing axioms, no new ones
- 0 sorries; JSON validated

🤖 Generated with [Claude Code](https://claude.com/claude-code)