### PR TITLE
research(basel-oq-01-oq-02): repair broken proof + additive transcendence frontier

### DIFF
--- a/proofs/Proofs/BaselProblemOQ01OQ02.lean
+++ b/proofs/Proofs/BaselProblemOQ01OQ02.lean
@@ -406,7 +406,7 @@ theorem zeta_even_weighted_prod_eq_rat_mul_pi_pow {ι : Type*} (f g : ι → ℕ
       obtain ⟨qa, hqa, hqaeq⟩ :=
         zeta_even_pow_eq_rat_mul_pi_pow (f a) (g a)
           (hf a (Finset.mem_insert_self a s)) (hg a (Finset.mem_insert_self a s))
-      refine ⟨qa ^ g a * q, mul_ne_zero (pow_ne_zero _ hqa) hq, ?_⟩
+      refine ⟨qa * q, mul_ne_zero hqa hq, ?_⟩
       rw [Finset.prod_insert ha, Finset.sum_insert ha, hqeq, hqaeq, mul_add, pow_add]
       push_cast; ring
 
@@ -428,6 +428,73 @@ theorem zeta_even_weighted_prod_transcendental {ι : Type*} (f g : ι → ℕ) (
   have hpos : 0 < ∑ i ∈ s, f i * g i :=
     Finset.sum_pos (fun i hi => Nat.mul_pos (hf i hi) (hg i hi)) hs
   omega
+
+open Polynomial in
+/-- **Master transcendence engine: every nonconstant rational polynomial of π is transcendental.**
+
+    If `f ∈ ℚ[X]` has `natDegree f ≠ 0` (i.e. `f` is nonconstant) then the value `f(π)` is
+    transcendental over ℚ.  This single lemma *unifies* every transcendence result above: each of
+    `zeta_even_transcendental` (`f = C qₙ · X^(2n)`), `zeta_even_product_transcendental`,
+    `zeta_even_pow_transcendental`, and the ratio results is merely the special case of a *monomial*
+    `f`.  Its genuinely new payoff is **additive**: a `ℚ`-linear combination of even zeta values —
+    which leaves the multiplicative class `ℚ∖{0}·π^(even)` — is *still* transcendental, because it
+    is a nonconstant polynomial in π (see `zeta_even_add_transcendental` below).
+
+    Proof: `f` nonconstant ⟹ `f ≠ 0` ⟹ `leadingCoeff f ≠ 0`, which over the field ℚ lies in the
+    non-zero-divisors; `Transcendental.aeval` then lifts `Transcendental ℚ π`
+    (`pi_transcendental_over_rationals`) to `aeval π f`.
+
+    **Assumption:** `hermite_lindemann` (transcendence of π). -/
+theorem transcendental_aeval_pi (f : ℚ[X]) (hf : f.natDegree ≠ 0) :
+    Transcendental ℚ (Polynomial.aeval π f) := by
+  have hfne : f ≠ 0 := fun h => hf (by rw [h, natDegree_zero])
+  exact pi_transcendental_over_rationals.aeval f hf
+    (mem_nonZeroDivisors_of_ne_zero (leadingCoeff_ne_zero.mpr hfne))
+
+open Polynomial in
+/-- **Sums of two distinct even zeta values are transcendental — the additive frontier.**
+
+    For `n ≠ m` (both `≥ 1`), `ζ(2n) + ζ(2m)` is transcendental over ℚ.  This is a *new* kind of
+    result: the multiplicative structure theorems above (`zeta_even_product_transcendental`,
+    `zeta_even_pow_transcendental`, …) all stay inside the class `ℚ∖{0}·π^(even>0)`, but a sum of
+    two *distinct* even zeta values leaves that class — `qₙ·π^(2n) + qₘ·π^(2m)` is a genuine
+    *two-term* polynomial in π, not a single monomial `q·π^(2k)`.  Transcendence nevertheless
+    survives, because this is a nonconstant polynomial in the transcendental π
+    (`transcendental_aeval_pi`); the two exponents `2n ≠ 2m` cannot cancel and neither leading
+    coefficient vanishes, so the polynomial `C qₙ·X^(2n) + C qₘ·X^(2m)` has degree `max(2n,2m) ≥ 2`.
+    Concretely `ζ(2)+ζ(4) = π²/6 + π⁴/90` and `ζ(2)+ζ(6) = π²/6 + π⁶/945` are transcendental.
+
+    **Assumption:** `hermite_lindemann` (transcendence of π). -/
+theorem zeta_even_add_transcendental (n m : ℕ) (hn : 0 < n) (hm : 0 < m) (hnm : n ≠ m) :
+    Transcendental ℚ
+      ((∑' k : ℕ, 1 / (k : ℝ) ^ (2 * n)) + (∑' k : ℕ, 1 / (k : ℝ) ^ (2 * m))) := by
+  obtain ⟨qn, hqn, hqn_eq⟩ := zeta_even_eq_rat_mul_pi_pow n hn
+  obtain ⟨qm, hqm, hqm_eq⟩ := zeta_even_eq_rat_mul_pi_pow m hm
+  -- Express the sum as a two-term polynomial in π.
+  have hsum : (∑' k : ℕ, 1 / (k : ℝ) ^ (2 * n)) + (∑' k : ℕ, 1 / (k : ℝ) ^ (2 * m))
+      = Polynomial.aeval π (C qn * X ^ (2 * n) + C qm * X ^ (2 * m)) := by
+    rw [hqn_eq, hqm_eq]
+    simp [map_add, map_mul, aeval_C, map_pow, aeval_X]
+  rw [hsum]
+  -- The polynomial is nonconstant: distinct exponents 2n ≠ 2m, both coefficients nonzero.
+  refine transcendental_aeval_pi _ ?_
+  rcases Nat.lt_or_ge (2 * n) (2 * m) with h | h
+  · rw [natDegree_add_eq_right_of_natDegree_lt
+        (by rw [natDegree_C_mul_X_pow _ _ hqn, natDegree_C_mul_X_pow _ _ hqm]; exact h),
+        natDegree_C_mul_X_pow _ _ hqm]
+    omega
+  · have h' : 2 * m < 2 * n := by omega
+    rw [natDegree_add_eq_left_of_natDegree_lt
+        (by rw [natDegree_C_mul_X_pow _ _ hqn, natDegree_C_mul_X_pow _ _ hqm]; exact h'),
+        natDegree_C_mul_X_pow _ _ hqn]
+    omega
+
+/-- **ζ(2) + ζ(4) = π²/6 + π⁴/90 is transcendental over ℚ** — a concrete two-term sum leaving the
+    multiplicative class `ℚ∖{0}·π^(even)` yet remaining transcendental. -/
+theorem zeta_two_add_zeta_four_transcendental :
+    Transcendental ℚ ((∑' k : ℕ, 1 / (k : ℝ) ^ 2) + (∑' k : ℕ, 1 / (k : ℝ) ^ 4)) := by
+  have := zeta_even_add_transcendental 1 2 one_pos (by norm_num) (by norm_num)
+  simpa using this
 
 /-!
 ## The open odd case (documentation only)

--- a/src/data/proofs/basel-problem-oq-01-oq-02/meta.json
+++ b/src/data/proofs/basel-problem-oq-01-oq-02/meta.json
@@ -58,13 +58,16 @@
       "The nonzero-ness of the rational coefficient qₙ is obtained for free from positivity of the series (ζ(2n) > 0), avoiding any Bernoulli-number vanishing lemma",
       "zeta_even_ratio_eq_rat_mul_pi_pow (0-axiom): for m<n, ζ(2n)/ζ(2m) = (nonzero-rational)·π^(2(n-m)) — the axiom-free structural skeleton beneath zeta_even_ratio_transcendental, recording unconditionally that even zeta values are multiplicatively π-power-incommensurable over ℚ (their quotient is never rational). Transcendence enters only when π^(2(n-m)) is declared transcendental; mirrors how zeta_even_eq_rat_mul_pi_pow isolates the axiom for single values",
       "zeta_even_finset_prod_eq_rat_mul_pi_pow (0-axiom): for an arbitrary finite family (f i)_{i∈s} of positive indices, ∏_{i∈s} ζ(2 f i) = (nonzero-rational)·π^(2 ∑_{i∈s} f i) — the Finset generalisation of the pairwise product identity, proved by induction on s. Shows the class ℚ∖{0}·π^(even) housing the even zeta values is closed under ALL finite products, not merely two factors; uses only Euler's closed form, no hermite_lindemann",
-      "zeta_even_finset_prod_transcendental: any finite product ∏_{i∈s} ζ(2 f i) over a nonempty family of positive indices is transcendental over ℚ (its π-exponent 2∑ f i ≥ 2 is positive) — the Finset companion of zeta_even_product_transcendental, showing no finite product of even zeta values can be algebraic"
+      "zeta_even_finset_prod_transcendental: any finite product ∏_{i∈s} ζ(2 f i) over a nonempty family of positive indices is transcendental over ℚ (its π-exponent 2∑ f i ≥ 2 is positive) — the Finset companion of zeta_even_product_transcendental, showing no finite product of even zeta values can be algebraic",
+      "transcendental_aeval_pi: the master transcendence engine — every nonconstant rational polynomial evaluated at π (any f ∈ ℚ[X] with natDegree f ≠ 0) is transcendental over ℚ, via Transcendental.aeval applied to pi_transcendental_over_rationals. This single lemma unifies ALL the file's transcendence results: each monomial case (zeta_even_transcendental, product/pow/ratio) is the special case f = C q·Xᵏ, and it additionally unlocks the additive results that leave the multiplicative class ℚ∖{0}·π^(even)",
+      "zeta_even_add_transcendental: for n ≠ m (both ≥ 1), ζ(2n) + ζ(2m) is transcendental over ℚ — the ADDITIVE frontier. Unlike every prior (multiplicative) theorem, a sum of two distinct even zeta values leaves the class ℚ∖{0}·π^(even): qₙπ^(2n) + qₘπ^(2m) is a genuine two-term polynomial in π (degree max(2n,2m) ≥ 2), not a single monomial q·π^(2k). Transcendence survives because it is a nonconstant rational polynomial in the transcendental π (transcendental_aeval_pi); the distinct exponents 2n ≠ 2m cannot cancel. Concrete corollary zeta_two_add_zeta_four_transcendental: ζ(2)+ζ(4) = π²/6 + π⁴/90 is transcendental",
+      "REPAIR: fixed a coefficient bug in zeta_even_weighted_prod_eq_rat_mul_pi_pow that left the file failing to compile (unsolved goals) under Mathlib 4.26.0 — the induction step used qa^(g a) as the collected coefficient, double-counting the exponent already packaged into qa by zeta_even_pow_eq_rat_mul_pi_pow (whose returned coefficient is qₙ^j); corrected to qa · q. The weighted-product identity is now 0-axiom (foundational only) as claimed"
     ],
     "dateAdded": "2026-07-02",
-    "lineCount": 441,
+    "lineCount": 508,
     "assumptions": "Depends on the axiom hermite_lindemann (Lindemann–Weierstrass theorem, giving transcendence of π), imported via Proofs.PiTranscendental. Mathlib does not yet contain a complete Lindemann–Weierstrass development, and irrationality of π^(2n) provably requires transcendence of π (irrational_pi alone is insufficient, as irrationality does not lift through powers). Everything else is machine-checked with 0 sorries.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 25,
+    "theoremCount": 28,
     "definitionCount": 0
   },
   "overview": {


### PR DESCRIPTION
## Summary

Working on `basel-problem-oq-01-oq-02` (*Every even ζ(2n) is irrational — odd case open*), I found the gallery entry's Lean file **fails to compile on `main`** under Mathlib 4.26.0, then repaired it and extended it with a genuinely new **additive** transcendence result.

### Repair (was silently broken)
`zeta_even_weighted_prod_eq_rat_mul_pi_pow` left `unsolved goals`: its induction step used `qa ^ g a` as the collected coefficient, double-counting the exponent that `zeta_even_pow_eq_rat_mul_pi_pow` already packages into its returned coefficient (`qₙ^j`). Corrected to `qa · q`. The weighted-product identity is now **0-axiom** (foundational only) as its docstring claims.

### New content (same single `hermite_lindemann` assumption — no new axioms)
- **`transcendental_aeval_pi`** — master engine: *every* nonconstant rational polynomial of π (`f ∈ ℚ[X]`, `natDegree f ≠ 0`) is transcendental over ℚ, via `Transcendental.aeval` on `pi_transcendental_over_rationals`. This unifies **all** prior transcendence theorems in the file — each is the monomial special case `f = C q · Xᵏ`.
- **`zeta_even_add_transcendental`** — the **additive frontier**: for `n ≠ m`, `ζ(2n) + ζ(2m)` is transcendental. Every earlier theorem was *multiplicative* and stayed inside the class `ℚ∖{0}·π^(even)`; a sum of two distinct even zeta values *leaves* that class — `qₙ·π^(2n) + qₘ·π^(2m)` is a genuine two-term polynomial in π of degree `max(2n,2m) ≥ 2`, not a single monomial. Transcendence survives because it is a nonconstant rational polynomial in the transcendental π; the distinct exponents cannot cancel.
- **`zeta_two_add_zeta_four_transcendental`** — concrete `ζ(2)+ζ(4) = π²/6 + π⁴/90` is transcendental.

25 → 28 theorems, 441 → 508 lines. `axiomCount` unchanged (1).

## Verification
Compiled with `lake env lean Proofs/BaselProblemOQ01OQ02.lean` (0 errors, 0 sorries). `#print axioms`:
- new transcendence theorems → `[propext, Classical.choice, hermite_lindemann, Quot.sound]`
- repaired `zeta_even_weighted_prod_eq_rat_mul_pi_pow` → `[propext, Classical.choice, Quot.sound]` (axiom-free)

🤖 Generated with [Claude Code](https://claude.com/claude-code)