### PR TITLE
research(shannon-channel-coding-awgn-oq-03-oq-01): repair Monotone-companion drift + noise antitonicity

### DIFF
--- a/proofs/Proofs/ShannonChannelCodingAWGNOQ03OQ01Monotone.lean
+++ b/proofs/Proofs/ShannonChannelCodingAWGNOQ03OQ01Monotone.lean
@@ -15,6 +15,10 @@ sorry-free:
   nonnegative rate `½ log(1 + P/N) ≥ 0`.
 * `perUseCapacity_mono`     — the per-channel rate is monotone in the allotted
   power `P`.
+* `perUseCapacity_antitone_noise` — the per-channel rate is *antitone* in the noise
+  power `N` (the noise-side dual of `perUseCapacity_mono`).
+* `parallelRate_antitone_noise` — at a fixed power allocation, the total parallel-channel
+  rate is antitone in the noise profile (pointwise `N₁ ≤ N₂`).
 * `waterAlloc_mono_level`   — the water-filling depth `(μ − Nᵢ)₊` is monotone in
   the water level `μ`.
 * `rate_waterAlloc_nonneg`  — the water-filling rate is nonnegative.
@@ -70,6 +74,29 @@ theorem perUseCapacity_mono {N : ℝ} (hN : 0 < N) {P₁ P₂ : ℝ}
     linarith
   · have hdiv : P₁ / N ≤ P₂ / N := by gcongr
     linarith
+
+/-- **The per-channel rate is antitone in the noise power.**  For fixed allotted power
+`P ≥ 0`, raising the noise `N` never increases the per-use AWGN capacity
+`½ log(1 + P/N)`, since `P/N` decreases with `N`.  The noise-side dual of
+`perUseCapacity_mono` (which is monotone in the power). -/
+theorem perUseCapacity_antitone_noise {P N₁ N₂ : ℝ} (hP : 0 ≤ P) (hN₁ : 0 < N₁)
+    (h : N₁ ≤ N₂) : perUseCapacity P N₂ ≤ perUseCapacity P N₁ := by
+  have hN₂ : 0 < N₂ := lt_of_lt_of_le hN₁ h
+  unfold perUseCapacity
+  apply mul_le_mul_of_nonneg_left _ (by norm_num : (0 : ℝ) ≤ 1 / 2)
+  apply Real.log_le_log (by positivity)
+  have hdiv : P / N₂ ≤ P / N₁ := div_le_div_of_nonneg_left hP hN₁ h
+  linarith
+
+/-- **The parallel-Gaussian rate is antitone in the noise profile.**  At a *fixed* power
+allocation `P`, raising any noise power (pointwise `N₁ ≤ N₂`) never increases the total
+rate `∑ᵢ ½ log(1 + Pᵢ/Nᵢ)` — a term-by-term consequence of `perUseCapacity_antitone_noise`.
+The multi-channel form of noise monotonicity, complementing the power-side monotonicities. -/
+theorem parallelRate_antitone_noise (P N₁ N₂ : ι → ℝ) (hP : ∀ i, 0 ≤ P i)
+    (hN₁ : ∀ i, 0 < N₁ i) (h : ∀ i, N₁ i ≤ N₂ i) :
+    parallelRate N₂ P ≤ parallelRate N₁ P := by
+  unfold parallelRate
+  exact Finset.sum_le_sum fun i _ => perUseCapacity_antitone_noise (hP i) (hN₁ i) (h i)
 
 /-! ## Per-channel rate: strict positivity and its zero set -/
 
@@ -169,20 +196,10 @@ theorem waterBudget_nonneg (N : ι → ℝ) (μ : ℝ) : 0 ≤ waterBudget N μ 
   unfold waterBudget
   exact Finset.sum_nonneg fun i _ => waterAlloc_nonneg μ N i
 
-/-- **A positive budget forces a positive water level.**  If the water level `μ`
-realises a strictly positive budget `P > 0` (with positive noise floors) then
-`μ > 0`: at `μ ≤ 0` every channel is dry (`μ − Nᵢ < 0`) and the budget vanishes. -/
-theorem waterLevel_pos (N : ι → ℝ) (hN : ∀ i, 0 < N i) {μ P : ℝ}
-    (hbudget : waterBudget N μ = P) (hP : 0 < P) : 0 < μ := by
-  by_contra hcon
-  push_neg at hcon
-  have hzero : waterBudget N μ = 0 := by
-    unfold waterBudget waterAlloc
-    apply Finset.sum_eq_zero
-    intro i _
-    exact max_eq_right (by linarith [hN i])
-  rw [hbudget] at hzero
-  linarith
+-- NOTE: `waterLevel_pos` (a positive budget forces a positive water level) was moved
+-- into the base file `ShannonChannelCodingAWGNOQ03OQ01` (namespace `ShannonWaterFilling`);
+-- the former duplicate here is removed to avoid a name clash.  Its base signature is
+-- `waterLevel_pos (N) (hN) {P} (hP : 0 < P) {μ} (hμ : waterBudget N μ = P) : 0 < μ`.
 
 /-- **A zero budget yields zero rate.**  When no power is poured in
 (`g(μ) = 0`) every channel is switched off and the water-filling rate is `0`. -/
@@ -272,12 +289,11 @@ theorem capacity_mono_budget (N : ι → ℝ) (hN : ∀ i, 0 < N i)
     have hP2 : P₂ = 0 := hP2z.symm
     have hP1nonneg : 0 ≤ P₁ := by rw [← h1]; exact waterBudget_nonneg N μ₁
     have hP1 : P₁ = 0 := le_antisymm (hP2 ▸ hP) hP1nonneg
+    -- both capacities are 0, so the rewrite closes the goal `0 ≤ 0`
     rw [rate_waterAlloc_eq_zero_of_budget_zero N (h1.trans hP1),
         rate_waterAlloc_eq_zero_of_budget_zero N (h2.trans hP2)]
-    -- both capacities are 0
-    exact le_refl 0
   · -- generic: P₂ > 0, so μ₂ > 0 and optimality at P₂ dominates the P₁ allocation
-    have hμ₂ : 0 < μ₂ := waterLevel_pos N hN h2 hP2pos
+    have hμ₂ : 0 < μ₂ := waterLevel_pos N hN hP2pos h2
     have hxsum : ∑ i, waterAlloc μ₁ N i ≤ P₂ := by
       have hb : (∑ i, waterAlloc μ₁ N i) = P₁ := h1
       rw [hb]; exact hP

--- a/research/problems/shannon-channel-coding-awgn-oq-03-oq-01/state.md
+++ b/research/problems/shannon-channel-coding-awgn-oq-03-oq-01/state.md
@@ -25,3 +25,25 @@ Problem resolved via PR #36621 (VERIFIED, docker [7743/7743], 0 sorry/0 axiom):
 `waterfilling_optimal` (KKT optimality) + `exists_waterLevel` (IVT) + `waterLevel_unique`
 (strict monotonicity) + `waterAlloc_rate_closedForm`. Future directions logged in knowledge.md
 (operational coding theorem → oq-04; continuous-band integral limit; equal-noise corollary).
+
+## Update (2026-07-11, researcher-8 — drift repair + noise-antitonicity)
+
+The completed water-filling problem's `…Monotone.lean` companion had **bit-rotted**: it no
+longer compiled against the current base olean. Two drifts, both fixed:
+1. `waterLevel_pos` had been added to the base file `ShannonChannelCodingAWGNOQ03OQ01`
+   (same namespace `ShannonWaterFilling`), colliding with the Monotone copy → "already
+   declared". Removed the duplicate; retargeted the one internal call in
+   `capacity_mono_budget` to the base signature (`hP` before `hμ`).
+2. In `capacity_mono_budget`'s `P₂ = 0` branch, the `rw [rate_waterAlloc_eq_zero_of_budget_zero …]`
+   now closes the `0 ≤ 0` goal itself, so the trailing `exact le_refl 0` had become a
+   "No goals to be solved" error → removed.
+
+Also added 2 new axiom-free lemmas completing the noise-side monotonicity:
+- `perUseCapacity_antitone_noise` — the per-channel rate `½ log(1 + P/N)` is antitone in the
+  noise `N` (the dual of the existing `perUseCapacity_mono` in power).
+- `parallelRate_antitone_noise` — at a fixed allocation, the total parallel rate is antitone
+  in the noise profile (term-by-term).
+
+File now compiles clean (`bin/lake env lean` exit 0); `#print axioms` = [propext,
+Classical.choice, Quot.sound] for the new lemmas and the repaired `capacity_mono_budget`.
+No gallery meta change (research-only file).


### PR DESCRIPTION
## Summary

The completed AWGN water-filling problem's `…Monotone.lean` companion had **bit-rotted** — it no longer compiled against the current base olean. This PR repairs the drift and adds the missing noise-side monotonicity lemmas.

## Drift repaired (file was broken on `main`)

1. **`waterLevel_pos` name collision** — the base file `ShannonChannelCodingAWGNOQ03OQ01` (same namespace `ShannonWaterFilling`) had gained its own `waterLevel_pos`, so the Monotone-file duplicate errored with *"already declared"*, and downstream references resolved to the base version's different argument order (type mismatches). Removed the duplicate; retargeted the one internal call in `capacity_mono_budget` to the base signature (`hP` before `hμ`).
2. **Stale `exact le_refl 0`** — in `capacity_mono_budget`'s `P₂ = 0` branch, the `rw [rate_waterAlloc_eq_zero_of_budget_zero …]` now closes the `0 ≤ 0` goal itself, so the trailing `exact le_refl 0` had become a *"No goals to be solved"* error. Removed.

## New lemmas (axiom-free)

- **`perUseCapacity_antitone_noise`** — the per-channel rate `½ log(1 + P/N)` is antitone in the noise power `N`, the noise-side dual of the existing `perUseCapacity_mono` (monotone in power).
- **`parallelRate_antitone_noise`** — at a fixed power allocation, the total parallel-channel rate is antitone in the noise profile (pointwise `N₁ ≤ N₂`), term-by-term.

## Verification

- `bin/lake env lean` compiles the full file, exit 0.
- `#print axioms` = `[propext, Classical.choice, Quot.sound]` for the two new lemmas and the repaired `capacity_mono_budget` / `waterLevel_mono_budget` — **0 sorries, 0 axioms**.
- Research-only file (no gallery meta tracks it), so no meta change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)