### PR TITLE
research(tetrahedral-number-formula-oq-01): clear Nat.succ_mul_choose_eq deprecation

### DIFF
--- a/proofs/Proofs/TetrahedralNumberFormulaOQ01Absorption.lean
+++ b/proofs/Proofs/TetrahedralNumberFormulaOQ01Absorption.lean
@@ -43,8 +43,7 @@ absorption identity `Nat.succ_mul_choose_eq`, and the multiplicative counterpart
 additive Pascal rule `simplexNumber_succ_succ`. -/
 theorem simplexNumber_absorption (d n : ℕ) :
     (n + d + 1) * simplexNumber d n = (d + 1) * simplexNumber (d + 1) n := by
-  have key := Nat.succ_mul_choose_eq (n + d) d
-  simp only [Nat.succ_eq_add_one] at key
+  have key := Nat.add_one_mul_choose_eq (n + d) d
   unfold simplexNumber
   rw [show n + (d + 1) = n + d + 1 from by ring, key]
   ring


### PR DESCRIPTION
## Summary

Maintenance fix: `TetrahedralNumberFormulaOQ01Absorption.lean` emitted a deprecation warning —
`Nat.succ_mul_choose_eq` (deprecated 2025-12-09) → `Nat.add_one_mul_choose_eq`.

Swapped to the replacement in `simplexNumber_absorption`. Since the new lemma is already stated in `+1` form (not `succ`), the follow-up `simp only [Nat.succ_eq_add_one] at key` normalization is no longer needed and is dropped. The proof is otherwise unchanged.

## Why

Mathlib deprecations become hard errors on a future toolchain bump — the recurring "Mathlib drift" failure mode that has repeatedly broken proofs in this repo. Clearing them proactively keeps the chain building.

## Verification

- `lake env lean Proofs/TetrahedralNumberFormulaOQ01Absorption.lean` → exit 0, **zero warnings** (previously one deprecation warning)
- Whole OQ-01 chain re-verified: main file (690 lines / 38 theorems) + this companion (8 theorems), both 0-sorry / 0-axiom, EXIT 0
- No mathematical content changed; research-only chain (no gallery `meta.json` for oq-01)

🤖 Generated with [Claude Code](https://claude.com/claude-code)