### PR TITLE
research(elementary-quadratic-reciprocity-oq-03-oq-02-wip-01): Kronecker symbol value at n=-1 [VERIFIED axiom-free]

### DIFF
--- a/proofs/Proofs/ElementaryQuadraticReciprocityOQ03OQ02.lean
+++ b/proofs/Proofs/ElementaryQuadraticReciprocityOQ03OQ02.lean
@@ -1121,4 +1121,24 @@ above.
 -- #print axioms kronecker_quadratic_reciprocity
 -- #print axioms kronecker_reciprocity_one_mod_four
 
+/-- **Value at the modulus `n = -1` (definitional bridge).**  The `n = -1` branch of
+`kronecker` is exactly the sign character `kroneckerNeg1`: the symbol `(a ∣ -1)` equals
+`kroneckerNeg1 a`.  This exposes as a named theorem the boundary case only implicit in
+the definition, alongside the existing `kronecker_one_right` (`(a ∣ 1) = 1`). -/
+theorem kronecker_neg_one_right_eq_kroneckerNeg1 (a : ℤ) :
+    kronecker a (-1) = kroneckerNeg1 a := by
+  simp [kronecker]
+
+/-- **The symbol at `n = -1` is the sign character.**  `(a ∣ -1) = 1` for `a ≥ 0` and
+`-1` for `a < 0` — the archimedean/real place of the Kronecker symbol.  Completes the
+boundary-value table `n = 0, 1, -1`:  `kronecker_one_right` gives `(a ∣ 1) = 1`, and
+this gives the sign at `n = -1`, matching the `sign(n)` factor of the normal form
+`kronecker_eq_sign_jacobi`. -/
+theorem kronecker_neg_one_right (a : ℤ) :
+    kronecker a (-1) = if 0 ≤ a then 1 else -1 := by
+  rw [kronecker_neg_one_right_eq_kroneckerNeg1]
+  rcases le_or_lt 0 a with h | h
+  · rw [if_pos h, kroneckerNeg1_nonneg a h]
+  · rw [if_neg (not_le.mpr h), kroneckerNeg1_neg a h]
+
 end KroneckerSymbol


### PR DESCRIPTION
The Kronecker-symbol file characterizes the second argument at `n = 0` and `n = 1` (`kronecker_one_right`) but had **no theorem for `n = -1`** — although the definition's `n = -1` branch handles it. This PR completes the boundary-value table.

## New theorems (both axiom-free)

- **`kronecker_neg_one_right_eq_kroneckerNeg1`** — `(a ∣ -1) = kroneckerNeg1 a`, the definitional bridge exposing the sign-character branch as a named lemma.
- **`kronecker_neg_one_right`** — `(a ∣ -1) = 1` for `a ≥ 0` and `-1` for `a < 0`: the archimedean/real place of the Kronecker symbol, matching the `sign(n)` factor of the normal form `kronecker_eq_sign_jacobi`.

## Verification

- Whole file re-verified local-lean (Lean v4.26.0 + pinned Mathlib oleans), **0 errors**.
- `#print axioms` for each new theorem = `[propext, Classical.choice, Quot.sound]` — axiom-free.
- No new axioms or sorries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
