### PR TITLE
audit: persist cantor-diagonalization-oq-06-oq-01 clean result (stop cyclic re-audit)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -29792,6 +29792,12 @@
       "lastAudited": "2026-07-11T21:56:02Z",
       "result": "clean",
       "notes": "External-result axiomatized entry (CDC, resolved 2026). Verified: 1 axiom decl (cycleDoubleCover_of_bridgeless = the CDC theorem, fully disclosed), 0 sorries, native_decide only in comments, 3 theorems (elementary facts proved without the axiom). status=axiomatized/badge=axiom/axiomCount=1/theoremCount=3 all match. Minor: definitionCount=7 vs 8 actual (trivial abbrev F2), cosmetic."
+    },
+    "cantor-diagonalization-oq-06-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-12T00:00:15Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Gallery Integrity Audit — tracker persistence fix

**Proof**: cantor-diagonalization-oq-06-oq-01
**Result**: clean (kernel-verified)

### Why this PR

This entry has been the sole "unaudited" gallery target for many consecutive auditor cycles. Root cause: the `claim-target.sh complete ... clean` write lands only in the local worktree, and the next cycle's `git fetch && git reset --hard origin/main` wipes it before it's committed — so the entry re-queues every 20 minutes forever. This PR commits the entry so it persists.

### Audit findings (HEAD, after PR #37689 expanded the file to 22 theorems)

- 0 sorries, 0 `axiom` declarations, no `True` stubs, no `native_decide`
- `#print axioms` on the headline results (`uncountable_real`, `uncountable_Ioo`, `not_exists_surjective_nat_real`, `diagonalReal_mem_Ioo`) → `[propext, Classical.choice, Quot.sound]` only (foundational; none count as assumptions)
- Tier A: bespoke floor/emod decimal-digit diagonal construction, not routed through `Cardinal.not_countable_real`
- meta.json `status=verified` / `badge=original` / `sorries=0` / `axiomCount=0` — all accurate

No overclaim. Diff is a single 6-line tracker entry (ASCII-escaping preserved to match existing file style — no reformatting noise).

---
Discovered during gallery integrity audit. Also confirmed: full gallery 4800/4800 audited, 0 issues; batch rescan of 38 recently-changed Lean files (21 with metas) → 0 contradictions.