### PR TITLE
research(erdos-634-medial-congruence-oq-02): each medial piece is a half-scale homothetic copy [VERIFIED axiom-free]

### DIFF
--- a/proofs/Proofs/Erdos634MedialHomothetyOQ02.lean
+++ b/proofs/Proofs/Erdos634MedialHomothetyOQ02.lean
@@ -1,0 +1,188 @@
+/-
+# Erdős Problem #634 (OQ-02) — Each medial piece is a half-scale homothetic copy
+
+Source: Erdős Problem #634 (erdosproblems.com/634), open question
+`erdos-634-medial-congruence-oq-02`. Companion to the covering / interior-
+disjointness line of work (`Erdos634MedialCoveringOQ02`,
+`Erdos634MedialDisjointOQ02`, `Erdos634MedialCentralEdgeOQ03`,
+`Erdos634MedialInteriorDisjointOQ02`).
+
+## What this adds
+
+The covering and disjointness files describe *how the four medial pieces fit
+together* (they cover `A B C` and their relative interiors are pairwise
+disjoint). This file supplies the complementary *shape* statement — the
+geometric substance behind the parent entry's **congruence** claim — namely that
+each of the four medial pieces is literally the whole triangle `A B C` shrunk by
+the factor `½` through an explicit homothety (a scaling map). With
+`mAB = midpoint A B`, `mBC = midpoint B C`, `mCA = midpoint C A`:
+
+* `pieceA_eq_homothety` — the corner piece `tri A mAB mCA` is the image of the
+  whole triangle under `x ↦ midpoint A x`, the homothety centred at `A` with
+  ratio `½`.
+* `pieceB_eq_homothety`, `pieceC_eq_homothety` — the same at `B` and `C`.
+* `pieceCentral_eq_homothety` — the central piece `tri mBC mCA mAB` is the image
+  of the whole under `x ↦ ½•(A+B+C) − ½•x`, the point reflection through the
+  centroid followed by the `½` scaling (equivalently the homothety of ratio
+  `−½` centred at the centroid).
+
+Because each piece is a homothetic image of `A B C` with ratio `±½`, every piece
+is directly exhibited as a half-scale copy of the original — which is exactly the
+"four congruent half-scale medial triangles" content of the parent entry, now
+tied to the concrete pieces of the tiling. Homotheties of the same absolute ratio
+are isometry-congruent, so this also re-derives the mutual congruence of the four
+pieces from a single uniform description.
+
+Each statement is a set equality between `triHull` (the barycentric solid
+triangle of `Erdos634MedialCoveringOQ02`) and a `Set.image`; via
+`triHull_eq_convexHull` the corollaries `piece*_eq_homothety_convexHull` phrase
+the same facts with Mathlib's `convexHull`.
+
+## How it is proved
+
+A point of the corner piece at `A` with barycentric coordinates `(a,b,c)` in
+`A, mAB, mCA` and a point of the whole triangle with the *same* coordinates
+`(a,b,c)` in `A, B, C` are related by `x ↦ midpoint A x`: both expand (using
+`a+b+c = 1`) to `(a + b/2 + c/2)•A + (b/2)•B + (c/2)•C`. The coordinate tuple is
+carried across unchanged, so the two inclusions are witnessed by the identical
+triple and closed by `match_scalars <;> linarith` on the midpoint expansion
+(exactly the arithmetic used for the covering inclusions). The central piece is
+identical with the reflection map in place of the corner homothety.
+
+Everything is unconditional and axiom-free — no non-degeneracy hypothesis is
+needed, since these are equalities of parametrised images, not disjointness
+facts.
+
+Tags: geometry, erdos, dissection, tiling, homothety, congruence, barycentric
+-/
+
+import Mathlib
+import Proofs.Erdos634MedialCoveringOQ02
+
+set_option linter.unusedSectionVars false
+
+namespace Erdos634MedialHomothetyOQ02
+
+open Erdos634MedialCoveringOQ02
+
+variable {V : Type*} [AddCommGroup V] [Module ℝ V]
+
+/-
+## The four medial homotheties
+
+Each corner piece is the image of the whole triangle under the half-scale
+homothety centred at that corner (`x ↦ midpoint corner x`). The central piece is
+the image under the `−½`-homothety centred at the centroid, written concretely as
+`x ↦ ½•(A+B+C) − ½•x`.
+-/
+
+/-- **Corner piece at `A` is a half-homothety of the whole.** The corner medial
+triangle `tri A mAB mCA` is exactly the image of `A B C` under `x ↦ midpoint A x`,
+the homothety centred at `A` with ratio `½`. -/
+theorem pieceA_eq_homothety (A B C : V) :
+    triHull A (midpoint ℝ A B) (midpoint ℝ C A)
+      = (fun x => midpoint ℝ A x) '' triHull A B C := by
+  apply Set.Subset.antisymm
+  · rintro x ⟨a, b, c, ha, hb, hc, hs, rfl⟩
+    refine ⟨a • A + b • B + c • C, ⟨a, b, c, ha, hb, hc, hs, rfl⟩, ?_⟩
+    simp only [midpoint_eq_smul_add, invOf_eq_inv]; match_scalars <;> linarith
+  · rintro x ⟨y, ⟨a, b, c, ha, hb, hc, hs, rfl⟩, rfl⟩
+    refine ⟨a, b, c, ha, hb, hc, hs, ?_⟩
+    simp only [midpoint_eq_smul_add, invOf_eq_inv]; match_scalars <;> linarith
+
+/-- **Corner piece at `B` is a half-homothety of the whole.** The corner medial
+triangle `tri mAB B mBC` is the image of `A B C` under `x ↦ midpoint B x`. -/
+theorem pieceB_eq_homothety (A B C : V) :
+    triHull (midpoint ℝ A B) B (midpoint ℝ B C)
+      = (fun x => midpoint ℝ B x) '' triHull A B C := by
+  apply Set.Subset.antisymm
+  · rintro x ⟨a, b, c, ha, hb, hc, hs, rfl⟩
+    refine ⟨a • A + b • B + c • C, ⟨a, b, c, ha, hb, hc, hs, rfl⟩, ?_⟩
+    simp only [midpoint_eq_smul_add, invOf_eq_inv]; match_scalars <;> linarith
+  · rintro x ⟨y, ⟨a, b, c, ha, hb, hc, hs, rfl⟩, rfl⟩
+    refine ⟨a, b, c, ha, hb, hc, hs, ?_⟩
+    simp only [midpoint_eq_smul_add, invOf_eq_inv]; match_scalars <;> linarith
+
+/-- **Corner piece at `C` is a half-homothety of the whole.** The corner medial
+triangle `tri mCA mBC C` is the image of `A B C` under `x ↦ midpoint C x`. -/
+theorem pieceC_eq_homothety (A B C : V) :
+    triHull (midpoint ℝ C A) (midpoint ℝ B C) C
+      = (fun x => midpoint ℝ C x) '' triHull A B C := by
+  apply Set.Subset.antisymm
+  · rintro x ⟨a, b, c, ha, hb, hc, hs, rfl⟩
+    refine ⟨a • A + b • B + c • C, ⟨a, b, c, ha, hb, hc, hs, rfl⟩, ?_⟩
+    simp only [midpoint_eq_smul_add, invOf_eq_inv]; match_scalars <;> linarith
+  · rintro x ⟨y, ⟨a, b, c, ha, hb, hc, hs, rfl⟩, rfl⟩
+    refine ⟨a, b, c, ha, hb, hc, hs, ?_⟩
+    simp only [midpoint_eq_smul_add, invOf_eq_inv]; match_scalars <;> linarith
+
+/-- **Central piece is a `−½`-homothety of the whole.** The central medial
+triangle `tri mBC mCA mAB` is the image of `A B C` under
+`x ↦ ½•(A+B+C) − ½•x`, the homothety of ratio `−½` centred at the centroid
+`(A+B+C)/3`. It carries `A ↦ mBC`, `B ↦ mCA`, `C ↦ mAB`. -/
+theorem pieceCentral_eq_homothety (A B C : V) :
+    triHull (midpoint ℝ B C) (midpoint ℝ C A) (midpoint ℝ A B)
+      = (fun x => (2 : ℝ)⁻¹ • (A + B + C) - (2 : ℝ)⁻¹ • x) '' triHull A B C := by
+  apply Set.Subset.antisymm
+  · rintro x ⟨a, b, c, ha, hb, hc, hs, rfl⟩
+    refine ⟨a • A + b • B + c • C, ⟨a, b, c, ha, hb, hc, hs, rfl⟩, ?_⟩
+    simp only [midpoint_eq_smul_add, invOf_eq_inv]; match_scalars <;> linarith
+  · rintro x ⟨y, ⟨a, b, c, ha, hb, hc, hs, rfl⟩, rfl⟩
+    refine ⟨a, b, c, ha, hb, hc, hs, ?_⟩
+    simp only [midpoint_eq_smul_add, invOf_eq_inv]; match_scalars <;> linarith
+
+/-
+## `convexHull`-phrased corollaries
+
+The same four identities with Mathlib's `convexHull` in place of `triHull`, via
+`triHull_eq_convexHull`.
+-/
+
+/-- Corner piece at `A` as a homothety image, phrased with `convexHull`. -/
+theorem pieceA_eq_homothety_convexHull (A B C : V) :
+    convexHull ℝ ({A, midpoint ℝ A B, midpoint ℝ C A} : Set V)
+      = (fun x => midpoint ℝ A x) '' convexHull ℝ ({A, B, C} : Set V) := by
+  rw [← triHull_eq_convexHull, ← triHull_eq_convexHull, pieceA_eq_homothety]
+
+/-- Corner piece at `B` as a homothety image, phrased with `convexHull`. -/
+theorem pieceB_eq_homothety_convexHull (A B C : V) :
+    convexHull ℝ ({midpoint ℝ A B, B, midpoint ℝ B C} : Set V)
+      = (fun x => midpoint ℝ B x) '' convexHull ℝ ({A, B, C} : Set V) := by
+  rw [← triHull_eq_convexHull, ← triHull_eq_convexHull, pieceB_eq_homothety]
+
+/-- Corner piece at `C` as a homothety image, phrased with `convexHull`. -/
+theorem pieceC_eq_homothety_convexHull (A B C : V) :
+    convexHull ℝ ({midpoint ℝ C A, midpoint ℝ B C, C} : Set V)
+      = (fun x => midpoint ℝ C x) '' convexHull ℝ ({A, B, C} : Set V) := by
+  rw [← triHull_eq_convexHull, ← triHull_eq_convexHull, pieceC_eq_homothety]
+
+/-- Central piece as a homothety image, phrased with `convexHull`. -/
+theorem pieceCentral_eq_homothety_convexHull (A B C : V) :
+    convexHull ℝ ({midpoint ℝ B C, midpoint ℝ C A, midpoint ℝ A B} : Set V)
+      = (fun x => (2 : ℝ)⁻¹ • (A + B + C) - (2 : ℝ)⁻¹ • x) ''
+          convexHull ℝ ({A, B, C} : Set V) := by
+  rw [← triHull_eq_convexHull, ← triHull_eq_convexHull, pieceCentral_eq_homothety]
+
+/-
+## The packaged statement
+-/
+
+/-- **The medial subdivision is four half-scale homothetic copies.** Every one of
+the four medial pieces is the image of the whole triangle `A B C` under an
+explicit homothety of ratio `±½`: the three corner pieces via the half-scale
+homotheties centred at the respective vertices, and the central piece via the
+`−½`-homothety centred at the centroid. This is the uniform "half-scale copy"
+description of the pieces underlying the parent entry's congruence claim. -/
+theorem medial_pieces_are_half_homotheties (A B C : V) :
+    triHull A (midpoint ℝ A B) (midpoint ℝ C A)
+        = (fun x => midpoint ℝ A x) '' triHull A B C ∧
+    triHull (midpoint ℝ A B) B (midpoint ℝ B C)
+        = (fun x => midpoint ℝ B x) '' triHull A B C ∧
+    triHull (midpoint ℝ C A) (midpoint ℝ B C) C
+        = (fun x => midpoint ℝ C x) '' triHull A B C ∧
+    triHull (midpoint ℝ B C) (midpoint ℝ C A) (midpoint ℝ A B)
+        = (fun x => (2 : ℝ)⁻¹ • (A + B + C) - (2 : ℝ)⁻¹ • x) '' triHull A B C :=
+  ⟨pieceA_eq_homothety A B C, pieceB_eq_homothety A B C,
+   pieceC_eq_homothety A B C, pieceCentral_eq_homothety A B C⟩
+
+end Erdos634MedialHomothetyOQ02

--- a/src/data/proofs/erdos-634-medial-congruence-oq-02/meta.json
+++ b/src/data/proofs/erdos-634-medial-congruence-oq-02/meta.json
@@ -50,7 +50,8 @@
       "triBary: a barycentric model of the filled triangle (convex combinations of the three vertices), proven convex (triBary_convex) and shown equal to Mathlib's convexHull of the vertices (triBary_eq_convexHull) — so tri A B C is genuinely THE triangle.",
       "medial_covering: an exact set equality proving the four medial sub-triangles cover the whole triangle. The covering direction is a clean barycentric case split — corner triangle at A when a ≥ ½ (symmetrically B, C), central medial triangle when all three coordinates are ≤ ½ — with explicit convex-combination reweightings; each vertex identity is discharged by match_scalars <;> linarith after expanding midpoints.",
       "medial_covering_convexHull: the same covering statement phrased entirely with Mathlib's convexHull, obtained by rewriting through triBary_eq_convexHull.",
-      "Works over an arbitrary real vector space (AddCommGroup V, Module ℝ V) with no metric assumptions, since covering is a purely affine/convex property; this is strictly weaker than the base entry's normed-space hypotheses."
+      "Works over an arbitrary real vector space (AddCommGroup V, Module ℝ V) with no metric assumptions, since covering is a purely affine/convex property; this is strictly weaker than the base entry's normed-space hypotheses.",
+      "medial_pieces_are_half_homotheties (Erdos634MedialHomothetyOQ02.lean): each of the four medial pieces is exhibited as the image of the whole triangle under an explicit homothety of ratio ±½ — the three corner pieces via x ↦ midpoint {A,B,C} x, the central piece via x ↦ ½•(A+B+C) − ½•x (−½-homothety at the centroid). This is the uniform half-scale-copy description behind the parent congruence claim, tied to the concrete tiling pieces, and phrased both with triHull and with Mathlib convexHull; unconditional and axiom-free."
     ],
     "dateAdded": "2026-07-01",
     "mathlib_version": "4.26.0",
@@ -60,7 +61,7 @@
       "Midpoint API (midpoint_eq_smul_add)",
       "The module / match_scalars tactics for ℝ-linear vector identities"
     ],
-    "relatedNote": "Companion to the k = 2 base entry erdos-634-medial-congruence and its OQ-01 (the square reptiling for all k). Both prove CONGRUENCE of the pieces but explicitly leave the covering/disjointness (analytic) part open; this entry closes the covering direction. Interior-disjointness (measure-zero overlaps in the plane) remains open and would require fixing V = ℝ² and the area measure."
+    "relatedNote": "Companion to the k = 2 base entry erdos-634-medial-congruence and its OQ-01 (the square reptiling for all k). Both prove CONGRUENCE of the pieces but explicitly leave the covering/disjointness (analytic) part open; this entry closes the covering direction. Interior-disjointness is now closed non-metrically in Erdos634MedialInteriorDisjointOQ02.lean (the four open pieces are pairwise disjoint over a non-degenerate triangle); the shape half is supplied by Erdos634MedialHomothetyOQ02.lean (each piece a ±½-homothety of the whole). A Lebesgue/area accounting of the overlaps in the plane (V = ℝ²) remains open."
   },
   "overview": {
     "historicalContext": "Erdős Problem #634 (a $25 problem) asks to understand all triples (T, R, N) such that a triangle T can be tiled by N congruent copies of a triangle R. The medial subdivision — joining the three side midpoints — is the base case k = 2 of the square reptiling. The base gallery entry proved the four medial pieces are pairwise congruent but deliberately did not formalise that they actually tile (cover, with disjoint interiors) the triangle. A dissection into congruent pieces is only a tiling once one verifies the pieces cover the region and overlap only on their boundaries.",


### PR DESCRIPTION
## Summary

Adds `proofs/Proofs/Erdos634MedialHomothetyOQ02.lean` — the **shape** complement to the covering / interior-disjointness line of Erdős #634 oq-02. Where `Erdos634MedialCoveringOQ02` / `Erdos634MedialDisjointOQ02` / `Erdos634MedialInteriorDisjointOQ02` describe *how the four medial pieces fit together* (they cover `A B C` and their relative interiors are pairwise disjoint), this file proves *what each piece is*: literally the whole triangle shrunk by `±½` through an explicit homothety.

## What is proved

With `mAB = midpoint A B`, `mBC = midpoint B C`, `mCA = midpoint C A`, over an arbitrary real vector space `V`:

- `pieceA_eq_homothety` / `pieceB_eq_homothety` / `pieceC_eq_homothety` — each corner piece is the image of `triHull A B C` under `x ↦ midpoint {A,B,C} x`, the half-scale homothety centred at that vertex.
- `pieceCentral_eq_homothety` — the central piece is the image under `x ↦ ½•(A+B+C) − ½•x`, the `−½`-homothety centred at the centroid (it carries `A ↦ mBC`, `B ↦ mCA`, `C ↦ mAB`).
- `piece*_eq_homothety_convexHull` — the same four identities phrased with Mathlib's `convexHull` (via `triHull_eq_convexHull`).
- `medial_pieces_are_half_homotheties` — packaged statement.

This exhibits every medial piece as a half-scale copy of the original — the uniform geometric substance behind the parent entry's **congruence** claim, now tied to the concrete pieces of the tiling. The corner statements reuse the same barycentric coordinate tuple `(a,b,c)` on both sides; both inclusions close by `match_scalars <;> linarith` on the midpoint expansion (the arithmetic already used for the covering inclusions).

## Verification

- Verified with `bin/lake env lean` against prebuilt Mathlib oleans (dependency `Erdos634MedialCoveringOQ02` built into a scoped `LEAN_PATH`).
- **Axiom-free**: `#print axioms medial_pieces_are_half_homotheties` → `[propext, Classical.choice, Quot.sound]` (foundational only). Unconditional — no non-degeneracy hypothesis needed, since these are equalities of parametrised images.

Also refreshes the `erdos-634-medial-congruence-oq-02` gallery meta: adds the homothety contribution and updates the now-stale `relatedNote` (interior-disjointness was closed in #37679; only the planar Lebesgue/area accounting remains open).

🤖 Generated with [Claude Code](https://claude.com/claude-code)