### PR TITLE
research(binary-gcd-oq-01-oq-04-oq-03): general-a structure of the running total

### DIFF
--- a/proofs/Proofs/BinaryGcdOQ01OQ04OQ03.lean
+++ b/proofs/Proofs/BinaryGcdOQ01OQ04OQ03.lean
@@ -788,4 +788,37 @@ theorem avgSteps_one_unbounded (M : ℚ) :
   have hMn : M < (n : ℚ) - 1 := by linarith
   linarith
 
+-- ═══════════════════════════════════════════════════════════════════
+-- PART V: GENERAL-`a` STRUCTURE OF THE RUNNING TOTAL
+-- ═══════════════════════════════════════════════════════════════════
+
+/-- **Per-argument recurrence of the running total (general `a`).** Extending the
+    range by one argument adds exactly that argument's step count:
+    `totalSteps a (N+1) = totalSteps a N + binaryGcdSteps a (N+1)`. This is the
+    general-`a` companion of `totalSteps_one_succ` (which specialises the last
+    term to `log₂(N+1) + 1` via `binaryGcdSteps_one_eq_log`). Immediate from
+    `Finset.sum_Icc_succ_top`. -/
+theorem totalSteps_succ (a N : ℕ) :
+    totalSteps a (N + 1) = totalSteps a N + binaryGcdSteps a (N + 1) := by
+  unfold totalSteps
+  rw [Finset.sum_Icc_succ_top (by omega : 1 ≤ N + 1)]
+
+/-- **The running total is monotone in `N` (general `a`).** For every fixed left
+    argument `a`, `N ↦ totalSteps a N` is `Monotone`: each new argument contributes
+    a nonnegative step count, so the running work count never decreases. This is the
+    general-`a` companion of `totalSteps_one_mono` (the `a = 1` total is in fact
+    *strictly* monotone since its increment `log₂(N+1)+1 ≥ 1` is positive; for
+    general `a` a single argument may cost `0` steps, e.g. `binaryGcdSteps a a`, so
+    only monotonicity holds unconditionally). -/
+theorem totalSteps_mono (a : ℕ) : Monotone (totalSteps a) := by
+  apply monotone_nat_of_le_succ
+  intro N
+  rw [totalSteps_succ]
+  omega
+
+/-- **Range-monotonicity in `≤` form (general `a`).** The citable inequality form of
+    `totalSteps_mono`: `M ≤ N ⟹ totalSteps a M ≤ totalSteps a N`. -/
+theorem totalSteps_le_of_le {a M N : ℕ} (h : M ≤ N) : totalSteps a M ≤ totalSteps a N :=
+  totalSteps_mono a h
+
 end BinaryGcdOQ01OQ04OQ03


### PR DESCRIPTION
## Summary

The average-case file characterizes the `a = 1` running total exhaustively (exact value, closed form, sandwich bounds, strict/monotone growth, unboundedness) but the corresponding *general-`a`* structure lemmas were absent. This PR adds them:

- `totalSteps_succ` — `totalSteps a (N+1) = totalSteps a N + binaryGcdSteps a (N+1)`, the general-`a` companion of `totalSteps_one_succ` (which specialises the last term via `binaryGcdSteps_one_eq_log`). Immediate from `Finset.sum_Icc_succ_top`.
- `totalSteps_mono` — for every fixed left argument `a`, `N ↦ totalSteps a N` is `Monotone`. The general-`a` companion of `totalSteps_one_mono`; for general `a` only monotonicity holds unconditionally (the `a = 1` total is strictly monotone because its increment `log₂(N+1)+1 ≥ 1` is positive, whereas a single argument may cost `0` steps for general `a`).
- `totalSteps_le_of_le` — the citable `≤` form `M ≤ N ⟹ totalSteps a M ≤ totalSteps a N`.

## Verification

`bin/lake env lean` (Lean v4.26.0, prebuilt Mathlib + `BinaryGcd*` oleans). File compiles clean (no `sorry`).

`#print axioms` on all three new theorems reports `[propext, Classical.choice, Quot.sound]` — **axiom-free**. No change to the file's existing bounds or gallery status.

🤖 Generated with [Claude Code](https://claude.com/claude-code)