### PR TITLE
Enrich amgm-inequality-oq-02-oq-01-oq-03-oq-01-oq-01-oq-02: split universal section (4→5)

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-02-oq-01-oq-03-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-02-oq-01-oq-03-oq-01-oq-01-oq-02/meta.json
@@ -84,11 +84,19 @@
       "mathContext": "$p_6 = e_1^6 - 6 e_1^4 e_2 + 9 e_1^2 e_2^2 - 2 e_2^3 + 6 e_1^3 e_3 - 12 e_1 e_2 e_3 + 3 e_3^2 - 6 e_1^2 e_4 + 6 e_2 e_4 + 6 e_1 e_5 - 6 e_6$."
     },
     {
-      "id": "universal",
-      "title": "Universal Closed Form (MvPolynomial)",
+      "id": "universal-recurrence",
+      "title": "Universal Recurrence Form (MvPolynomial)",
       "startLine": 65,
+      "endLine": 96,
+      "summary": "psum_six_recurrence extracts p₆ = e₁p₅ − e₂p₄ + e₃p₃ − e₄p₂ + e₅p₁ − 6e₆ from Mathlib's psum_eq_mul_esymm_sub_sum at n=6. The antidiagonal filter {a : a₁+a₂=6, 0<a₁<6} = {(1,5),(2,4),(3,3),(4,2),(5,1)} (five terms now) is pinned by omega and the lead term is (−1)⁷·6·e₆ = −6e₆; five sum_insert steps + ring finish it.",
+      "mathContext": "Recurrence: $p_6 = e_1 p_5 - e_2 p_4 + e_3 p_3 - e_4 p_2 + e_5 p_1 - 6 e_6$."
+    },
+    {
+      "id": "universal-closed",
+      "title": "Universal Closed Form (MvPolynomial)",
+      "startLine": 97,
       "endLine": 119,
-      "summary": "psum_six_recurrence extracts p₆ = e₁p₅ − e₂p₄ + e₃p₃ − e₄p₂ + e₅p₁ − 6e₆ from psum_eq_mul_esymm_sub_sum at n=6 (antidiagonal {(1,5),(2,4),(3,3),(4,2),(5,1)}). psum_six_closed substitutes the proven p₅, p₄, p₃, p₂, p₁ closed forms and ring-normalises.",
+      "summary": "psum_six_closed substitutes the already-reduced psum_five_closed (p₅), psum_four_closed (p₄), psum_three_closed (p₃), psum_two_eq (p₂) and psum_one_eq_esymm_one (p₁) into the recurrence and ring-normalises. k=6 is the first rung whose reduced form carries cubic-in-a-single-eₖ terms: −2·e₂³ and +3·e₃² (the partitions 6=2+2+2 and 6=3+3), on top of the mixed −12·e₁e₂e₃.",
       "mathContext": "In MvPolynomial σ R: $p_6 = e_1^6 - 6 e_1^4 e_2 + 9 e_1^2 e_2^2 - 2 e_2^3 + 6 e_1^3 e_3 - 12 e_1 e_2 e_3 + 3 e_3^2 - 6 e_1^2 e_4 + 6 e_2 e_4 + 6 e_1 e_5 - 6 e_6$."
     },
     {


### PR DESCRIPTION
Enrichment pass (pass 0, quality 96) for the Newton–Girard k=6 closed-form entry — completing the k=3→k=6 chain enriched this run (#37686, #37690, #37696).

## Changes (meta.json only; 19.9 KB → 20.2 KB, under caps)
- **Sections 4→5 (non-padding).** The *Universal Closed Form* section (65–119) held two distinct theorems — `psum_six_recurrence` (5-term antidiagonal extraction) and `psum_six_closed` (substitution + `ring`) — already annotated separately (`ng6-recurrence`, `ng6-closed`). Split into *Universal Recurrence Form* (65–96) and *Universal Closed Form* (97–119) along the real theorem boundary.
- Enriched the closed-form summary: k=6 is the first rung with cubic-in-one-eₖ terms (−2·e₂³, +3·e₃²), reflecting the degree-6 partitions 6=2+2+2 and 6=3+3.

keyInsights already at 5 (not inflated). No content removed; verified/0-axiom unchanged. `pnpm build` JSON validation + search-index checks pass.