### PR TITLE
research(erdos-897-oq-01): failing class is an order ideal + additive cone (min & add closure)

### DIFF
--- a/proofs/Proofs/Erdos897OQ01.lean
+++ b/proofs/Proofs/Erdos897OQ01.lean
@@ -572,4 +572,79 @@ theorem not_unboundedOnPrimePowers_of_bounded {f : ℕ → ℝ} {C : ℝ}
     linarith
   exact le_trans (hf p k hp hk) hmid
 
+/-
+## (11) The failing class is a genuine order ideal and additive cone
+
+Sections (9)–(10) established the *join* structure: the large functions are closed
+under `max` with anything (a sup-closed filter), and the failing `O(log)` functions
+are closed under `max` of two (`not_unboundedOnPrimePowers_max`).  This section
+completes the algebraic and lattice picture of the failing class:
+
+* **Additivity.** If `f ≤ Mf·log` and `g ≤ Mg·log` on prime powers, then
+  `f + g ≤ (Mf + Mg)·log`, so the sum fails too — no sign or positivity hypothesis
+  is needed, the two upper bounds simply add (`not_unboundedOnPrimePowers_add`).
+  Thus the failing class is closed under addition, dual to the filter-side
+  `unboundedOnPrimePowers_add_bddBelow` (which added *largeness* to a below-bounded
+  function).
+* **Meet-closure.** Dual to the sup-closure `unboundedOnPrimePowers_max_left`: if `f`
+  fails, then `min (f, g)` fails for *any* `g`, because `min (f, g) ≤ f` on every
+  prime power, and failure transfers downward (`not_unboundedOnPrimePowers_of_le`).
+  So the failing class is closed under `min` with an arbitrary function
+  (`not_unboundedOnPrimePowers_min_left` / `_min_right`).
+
+Combined with (9)–(10) this shows the `O(log)`-on-prime-powers functions form a
+genuine **order ideal** — a down-set closed under both `max` (join of two) and `min`
+(meet with anything) — that is *additionally* an additive convex cone (closed under
+`+` and, by `unboundedOnPrimePowers_smul`'s contrapositive shape, under nonnegative
+scaling).  By contrast the large class is only join-closed (a filter), never
+meet-closed: two functions each large on a different infinite set of primes have a
+pointwise `min` that is small everywhere, so no analogue of `min`-closure holds on
+the filter side.
+-/
+
+/-- **The failing class is closed under addition.**  If both `f` and `g` fail the
+Erdős #897 hypothesis — each bounded above on prime powers by a constant multiple of
+`log`, say `f ≤ Mf·log` and `g ≤ Mg·log` — then their pointwise sum also fails:
+`(f + g)(p^k) ≤ (Mf + Mg)·log(p^k)` on every prime power, so the `O(log)` criterion
+of section (8) applies with `C = Mf + Mg`.  Unlike the `max` case this needs no
+`log ≥ 0` sign input: the two upper bounds add directly.  Together with
+`not_unboundedOnPrimePowers_max` this makes the failing class an additive cone as
+well as a sup-closed ideal. -/
+theorem not_unboundedOnPrimePowers_add {f g : ℕ → ℝ}
+    (hf : ¬ UnboundedOnPrimePowers f) (hg : ¬ UnboundedOnPrimePowers g) :
+    ¬ UnboundedOnPrimePowers (fun n => f n + g n) := by
+  unfold UnboundedOnPrimePowers at hf hg
+  push_neg at hf hg
+  obtain ⟨Mf, hMf⟩ := hf
+  obtain ⟨Mg, hMg⟩ := hg
+  refine not_unboundedOnPrimePowers_of_le_const_mul_log
+    (C := Mf + Mg) (fun p k hp hk => ?_)
+  have h1 := hMf p k hp hk
+  have h2 := hMg p k hp hk
+  have hsum : f (p ^ k) + g (p ^ k) ≤ (Mf + Mg) * Real.log (p ^ k) :=
+    calc f (p ^ k) + g (p ^ k)
+        ≤ Mf * Real.log (p ^ k) + Mg * Real.log (p ^ k) := add_le_add h1 h2
+      _ = (Mf + Mg) * Real.log (p ^ k) := by ring
+  exact hsum
+
+/-- **Meet-closure of the failing class (ideal side, dual of
+`unboundedOnPrimePowers_max_left`).**  If `f` fails the Erdős #897 hypothesis, then so
+does its pointwise minimum with *any* function `g`: `min (f n) (g n) ≤ f n` on every
+prime power, so failure transfers downward through the anti-domination lemma
+`not_unboundedOnPrimePowers_of_le`.  The failing class is therefore closed under `min`
+with an arbitrary function — the exact meet-dual of the filter's `max`-closure, and
+what upgrades "sup-closed ideal" to "genuine order ideal". -/
+theorem not_unboundedOnPrimePowers_min_left {f g : ℕ → ℝ}
+    (hf : ¬ UnboundedOnPrimePowers f) :
+    ¬ UnboundedOnPrimePowers (fun n => min (f n) (g n)) :=
+  not_unboundedOnPrimePowers_of_le hf (fun _ _ _ _ => min_le_left _ _)
+
+/-- **Meet-closure of the failing class (symmetric form).**  Likewise `min` fails when
+the *right* argument fails: `min (f n) (g n) ≤ g n`, so `¬ UnboundedOnPrimePowers g`
+suffices. -/
+theorem not_unboundedOnPrimePowers_min_right {f g : ℕ → ℝ}
+    (hg : ¬ UnboundedOnPrimePowers g) :
+    ¬ UnboundedOnPrimePowers (fun n => min (f n) (g n)) :=
+  not_unboundedOnPrimePowers_of_le hg (fun _ _ _ _ => min_le_right _ _)
+
 end Erdos897

--- a/src/data/proofs/erdos-897-oq-01/meta.json
+++ b/src/data/proofs/erdos-897-oq-01/meta.json
@@ -51,12 +51,13 @@
       "not_unboundedOnPrimePowers_logN and not_unboundedOnPrimePowers_omega: SELECTIVITY — the parent file's flagship additive functions log and ω both FAIL the hypothesis. log sits exactly at the boundary (log(p^k)/log(p^k)=1); ω is bounded on prime powers (ω(p^k)=1). The hypothesis isolates functions growing strictly faster than log on prime powers",
       "unboundedOnPrimePowers_unbounded: the hypothesis forces plain unboundedness of f on prime powers (for every B some f(p^k) > B), by dialing the multiplier against the uniform lower bound log(p^k) ≥ log 2 > 0",
       "stronglyAdditive_unboundedOnPrimePowers_iff: a strongly-additive reduction collapsing UnboundedOnPrimePowers f to 'f(p)/log p unbounded over primes' — the strongly-additive counterpart of the parent's completely-additive reduction. Since f(p^k)=f(p) is constant in k, the binding case is k=1; the M<0 branch is handled by invoking the hypothesis at 0 (then f(p) > 0 ≥ M·log p)",
-      "unboundedOnPrimePowers_max_left / _max_right / not_unboundedOnPrimePowers_max: PROVED the JOIN (sup) closure completing the file's prime-power domination order into a lattice — the Erdős #897 hypothesis functions form a sup-closed filter (closed under pointwise max with any function), and the failing O(log)-on-prime-powers functions form a sup-closed ideal (closed under max of two, merging the two O(log) constants via log(p^k) ≥ 0)."
+      "unboundedOnPrimePowers_max_left / _max_right / not_unboundedOnPrimePowers_max: PROVED the JOIN (sup) closure completing the file's prime-power domination order into a lattice — the Erdős #897 hypothesis functions form a sup-closed filter (closed under pointwise max with any function), and the failing O(log)-on-prime-powers functions form a sup-closed ideal (closed under max of two, merging the two O(log) constants via log(p^k) ≥ 0).",
+      "not_unboundedOnPrimePowers_add / _min_left / _min_right: PROVED the MEET (min) and ADDITIVE closure of the failing class, completing the lattice picture. The O(log)-on-prime-powers functions form a genuine order IDEAL — closed under max of two AND min with any function — that is additionally an additive convex cone (f ≤ Mf·log, g ≤ Mg·log ⟹ f+g ≤ (Mf+Mg)·log, no sign input needed). Dual to the filter side, which is only join-closed (never meet-closed). Axiom-free."
     ],
     "axiomCount": 0,
-    "lineCount": 575,
+    "lineCount": 650,
     "assumptions": "None. Fully machine-checked with 0 axioms and 0 sorries; proofs use no native_decide (so #print axioms shows only propext/Classical.choice/Quot.sound). Part I of Erdős #897 — whether the prime-power growth hypothesis forces limsup_n (f(n+1)-f(n))/log n = ∞ — remains OPEN and is NOT asserted; this entry proves only the verified surrounding theory (non-vacuity, selectivity, plain unboundedness, and the strongly-additive reduction).",
-    "theoremCount": 26,
+    "theoremCount": 29,
     "definitionCount": 1
   },
   "overview": {
@@ -130,11 +131,11 @@
       "Finset"
     ],
     "namespace": "Erdos897",
-    "lineCount": 575,
+    "lineCount": 650,
     "axiomCount": 0,
     "sorries": 0,
     "definitionCount": 1,
-    "theoremCount": 28
+    "theoremCount": 31
   },
   "crossReferences": [
     {


### PR DESCRIPTION
## Summary

Extends `Erdos897OQ01.lean` (Erdős #897 Part I surrounding theory) with a new **section (11)** completing the lattice/algebra picture of the `O(log)`-on-prime-powers **failing class**. Three axiom-free theorems, each dual to an existing filter-side lemma:

- **`not_unboundedOnPrimePowers_add`** — the failing class is closed under **addition**: `f ≤ Mf·log`, `g ≤ Mg·log` on prime powers ⟹ `f+g ≤ (Mf+Mg)·log`, so the `O(log)` criterion of §(8) applies with `C = Mf+Mg`. No sign/positivity input needed — the upper bounds add directly. Dual to the filter-side `unboundedOnPrimePowers_add_bddBelow`.
- **`not_unboundedOnPrimePowers_min_left` / `_min_right`** — the failing class is closed under **`min` with an arbitrary function**: `min (f,g) ≤ f`, and failure transfers downward via `not_unboundedOnPrimePowers_of_le`. The exact meet-dual of the filter's sup-closure `unboundedOnPrimePowers_max_left`.

## Why it matters

Sections (9)–(10) already showed the failing (`O(log)`) class is a **sup-closed ideal** (closed under `max` of two) and the large class a **sup-closed filter** (closed under `max` with anything). This PR upgrades that to the sharp statement: the failing class is a **genuine order ideal** — a down-set stable under both `max` (join of two) *and* `min` (meet with anything) — that is *additionally* an **additive convex cone**. The large class, by contrast, is only join-closed (a filter), never meet-closed.

## Verification

- All three new theorems `#print axioms` = `[propext, Classical.choice, Quot.sound]` — **axiom-free**, no `native_decide`.
- Built with `lean v4.26.0` against prebuilt Mathlib oleans (exit 0), 0 sorries.
- The Erdős #897 Part I forward implication remains **OPEN** and is not asserted.
- `meta.json`: `theoremCount` 26→29, `lineCount` 575→650.

🤖 Generated with [Claude Code](https://claude.com/claude-code)