### PR TITLE
research(erdos-3): reconcile stale gallery metadata counts with the grown file

### DIFF
--- a/research/problems/erdos-3-incomplete-01/state.md
+++ b/research/problems/erdos-3-incomplete-01/state.md
@@ -121,3 +121,14 @@ daemon; commit in `/tmp` immediately —
   lean-build containers at build time), unlike the OOM-blocked session that staged it.
   The threshold-critical `required_bound_implies_conjecture` sorry remains
   documented and untouched (as hard as Erdős #3 itself).
+
+## Iteration 6 (researcher-8, 2026-07-11) — metadata reconciliation
+
+`Erdos3Problem.lean` has grown to 1487 lines / 35 theorems / 14 definitions (still exactly
+1 documented sorry at `required_bound_implies_conjecture`, 0 axioms — confirmed by source
+inspection). The gallery `meta.json` carried a stale outer snapshot (`lineCount: 1224`,
+`theoremCount: 33`, `definitionCount: 12`) alongside an accurate nested `leanFile` snapshot
+(1487 lines). Reconciled both snapshots to the true counts: lineCount 1224→1487, theoremCount
+33→35, definitionCount 12→14 (outer) and 13→14 (nested). Pure metadata change; no Lean edit.
+The single sorry remains the threshold-critical open core (as hard as Erdős #3 itself), and the
+strictly stronger `strong_required_bound_implies_conjecture` reduction stays fully proved.

--- a/src/data/proofs/erdos-3/meta.json
+++ b/src/data/proofs/erdos-3/meta.json
@@ -65,7 +65,7 @@
       }
     ],
     "axiomCount": 0,
-    "lineCount": 1224,
+    "lineCount": 1487,
     "prerequisites": [
       "Arithmetic progressions and their properties",
       "Series convergence and divergence (reciprocal sums)",
@@ -74,8 +74,8 @@
       "Extremal combinatorics (Ramsey-type reasoning)"
     ],
     "assumptions": "0 axioms. `euler_prime_sum_diverges` (Euler 1737, ∑ 1/p diverges) is now a proved theorem, discharged from Mathlib's `not_summable_one_div_on_primes`. 1 sorry remains in `required_bound_implies_conjecture` (the o(N/log N) threshold), which is threshold-critical: as hard as Erdős #3 itself. The strictly stronger (log N)^{1+δ} threshold reduction (`strong_required_bound_implies_conjecture`) is fully proved, sorry-free and axiom-free.",
-    "theoremCount": 33,
-    "definitionCount": 12
+    "theoremCount": 35,
+    "definitionCount": 14
   },
   "overview": {
     "historicalContext": "**The Erdos-Turan Conjecture on Arithmetic Progressions**\n\nThis problem was first posed by Erdos and Turan in 1936, making it one of the oldest open problems in additive combinatorics. They conjectured that any subset $A \\subseteq \\mathbb{N}$ with $\\sum_{n \\in A} 1/n = \\infty$ must contain arbitrarily long arithmetic progressions.\n\n**Early History (1936--1975):**\nThe conjecture was motivated by the observation that 'large' sets (measured by reciprocal sum divergence) should be arithmetically rich. Roth made the first breakthrough in 1953, proving $r_3(N) = o(N)$ -- sets of positive density contain 3-term APs. This introduced Fourier analysis into combinatorics and contributed to Roth's Fields Medal. Twenty-two years later, Szemeredi (1975) proved the landmark theorem $r_k(N) = o(N)$ for all $k$, using his Regularity Lemma -- a purely combinatorial tour de force that won him the Abel Prize.\n\n**Multiple Proof Traditions (1977--2001):**\nFurstenberg (1977) gave a completely different proof of Szemeredi's theorem using ergodic theory, showing the equivalence with a multiple recurrence theorem. Gowers (2001) gave a third proof introducing the uniformity norms $\\|f\\|_{U^k}$ and higher-order Fourier analysis, obtaining the first quantitative bounds $r_k(N) \\ll N/(\\log \\log N)^{c_k}$. His Fields Medal recognized this achievement.\n\n**Modern Breakthroughs (2008--2024):**\nGreen and Tao (2008) proved primes contain arbitrarily long APs, confirming Erdos's intuition that the conjecture relates to primes. Kelley and Meka (2023) achieved a dramatic improvement for $k=3$: $r_3(N) \\ll N/\\exp((\\log N)^{1/11})$, nearly matching the Behrend lower bound. Leng, Sah, and Sawhney (2024) extended these methods to general $k$.\n\n**The Persistent Gap:**\nDespite 90 years of progress, the conjecture remains OPEN with Erdos's $5,000 prize unclaimed. Current bounds give $r_k(N) = o(N/\\exp((\\log \\log N)^c))$, but the conjecture requires $o(N/\\log N)$ -- an exponentially stronger statement. Neither a proof nor a counterexample appears within reach of current techniques.",
@@ -252,7 +252,7 @@
     "lineCount": 1487,
     "axiomCount": 0,
     "theoremCount": 35,
-    "definitionCount": 13,
+    "definitionCount": 14,
     "path": "Proofs/Erdos3Problem.lean",
     "sorries": 1
   },


### PR DESCRIPTION
## Summary

`Erdos3Problem.lean` has grown to **1487 lines / 35 theorems / 14 definitions** (still exactly **1 documented sorry** at `required_bound_implies_conjecture` — the threshold-critical open core, "as hard as Erdős #3 itself" — and **0 axioms**). The gallery `meta.json` carried a stale *outer* snapshot alongside an already-accurate *nested* `leanFile` snapshot.

## Changes (metadata only, no Lean edit)

- Outer snapshot: `lineCount` 1224 → 1487, `theoremCount` 33 → 35, `definitionCount` 12 → 14.
- Nested `leanFile` snapshot: `definitionCount` 13 → 14 (its `lineCount`/`theoremCount` were already correct).

Counts are purely syntactic (measured from source): `grep -c '^theorem '` = 35, top-level defs = 14 (3 `noncomputable def` + 11 `def`), `wc -l` = 1487, exactly one standalone `sorry` (line 207), zero `axiom` declarations — matching the unchanged `status: axiomatized`, `sorries: 1`, `axiomCount: 0`.

The single sorry remains the open threshold core; the strictly stronger `strong_required_bound_implies_conjecture` reduction stays fully proved and axiom-free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)