### PR TITLE
audit(cantor-diagonalization-oq-06-oq-01): resync stale theorem/line counts

### DIFF
--- a/src/data/proofs/cantor-diagonalization-oq-06-oq-01/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-06-oq-01/meta.json
@@ -56,10 +56,10 @@
       "not_surjective_of_countable: no countable type α surjects onto ℝ (the general form of uncountability), obtained by composing an α-surjection ℕ→α with the diagonal argument"
     ],
     "dateAdded": "2026-07-11",
-    "lineCount": 239,
+    "lineCount": 299,
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries; #print axioms reports only [propext, Classical.choice, Quot.sound]. No use of Cardinal.not_countable_real.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 16,
+    "theoremCount": 22,
     "definitionCount": 4
   },
   "overview": {
@@ -161,9 +161,9 @@
     ],
     "opens": [],
     "namespace": "CantorDiagonalizationOQ06OQ01",
-    "lineCount": 209,
+    "lineCount": 299,
     "axiomCount": 0,
-    "theoremCount": 14,
+    "theoremCount": 22,
     "definitionCount": 4,
     "path": "Proofs/CantorDiagonalizationOQ06OQ01.lean",
     "sorries": 0


### PR DESCRIPTION
## Gallery Integrity Audit

**Proof**: cantor-diagonalization-oq-06-oq-01
**Result**: content is clean; only informational counts had drifted.

PR #37689 expanded the file (added `uncountable_real`, `uncountable_Ioo`, the `(0,1)` localization lemmas, and standard consequences) growing it from **14→22 theorems** and **209→299 lines**, but the `meta.json` counts were not resynced.

### Kernel verification (rebuilt fresh, olean was stale)
All theorems — including the new ones — depend only on the foundational axioms:
```
uncountable_real       → [propext, Classical.choice, Quot.sound]
uncountable_Ioo        → [propext, Classical.choice, Quot.sound]
not_surjective_nat_Ioo → [propext, Classical.choice, Quot.sound]
diagonalReal_mem_Ioo   → [propext, Classical.choice, Quot.sound]
tsum_geo_shift         → [propext, Classical.choice, Quot.sound]
```
0 sorries, 0 `axiom` declarations, 0 True stubs. It genuinely avoids `Cardinal.not_countable_real`, so `status: verified` / `badge: original` (Tier A) remain accurate.

### Fix
- `meta.theoremCount` 16 → 22, `meta.lineCount` 239 → 299
- `leanFile.theoremCount` 14 → 22, `leanFile.lineCount` 209 → 299
- `definitionCount` (4) unchanged, already correct

Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)