### PR TITLE
research(brouwer-fixed-point-oq-02-oq-02-oq-01): x*-free Cauchy estimate + iterate-contraction law (+ drift repair)

### DIFF
--- a/proofs/Proofs/BrouwerFixedPointOQ02OQ02OQ01.lean
+++ b/proofs/Proofs/BrouwerFixedPointOQ02OQ02OQ01.lean
@@ -438,7 +438,7 @@ theorem fixed_point_stability (f g : ℝ → ℝ) (L δ : ℝ) (hL1 : L < 1)
   have hstep : |xf - xg| ≤ L * |xf - xg| + δ := by
     have e1 : xf - xg = (f xf - f xg) + (f xg - g xg) := by rw [hxf, hxg]; ring
     calc |xf - xg| = |(f xf - f xg) + (f xg - g xg)| := by rw [e1]
-      _ ≤ |f xf - f xg| + |f xg - g xg| := abs_add _ _
+      _ ≤ |f xf - f xg| + |f xg - g xg| := abs_add_le _ _
       _ ≤ L * |xf - xg| + δ := by
           have ha := hf xf xg
           have hb := hclose xg
@@ -463,5 +463,96 @@ theorem fixed_point_stability_unconditional (f g : ℝ → ℝ) (L M δ : ℝ)
   obtain ⟨xf, hxf⟩ := exists_fixed_point f L hL0 hL1 hf
   obtain ⟨xg, hxg⟩ := exists_fixed_point g M hM0 hM1 hg
   exact ⟨xf, xg, hxf, hxg, fixed_point_stability f g L δ hL1 hf xf xg hxf hxg hclose⟩
+
+/-! ### The self-contained Cauchy estimate between iterates (no fixed point needed)
+
+Every a priori bound above compares an iterate `xₙ` to the fixed point `x*`.  The
+even more elementary — and genuinely `x*`-free — statement is the **Cauchy estimate**
+directly *between two iterates*,
+
+    |x_{n+m} − xₙ| ≤ Lⁿ/(1−L) · |x₁ − x₀|,
+
+bounding the total drift over any number `m` of further steps purely by the *first*
+increment and the current index `n`.  It mentions no fixed point at all (on a complete
+space it is precisely what *proves* one exists, the sequence being Cauchy), and letting
+`m → ∞` recovers `apriori_estimate`.  It rests on the geometric decay of the individual
+increments, `|x_{k+1} − x_k| ≤ Lᵏ·|x₁ − x₀|` (`step_dist`), telescoped and summed as a
+finite geometric series `∑_{j<m} Lⁿ⁺ʲ = Lⁿ(1−Lᵐ)/(1−L) ≤ Lⁿ/(1−L)`. -/
+
+/-- **Geometric decay of the increments.**  `|x_{k+1} − x_k| ≤ Lᵏ · |x₁ − x₀|`: each
+    successive step of the iteration is shorter than the previous one by a factor `L`.
+    Proved by induction, applying the contraction bound to consecutive iterates. -/
+theorem step_dist (f : ℝ → ℝ) (L : ℝ) (hL0 : 0 ≤ L)
+    (hf : ∀ x y, |f x - f y| ≤ L * |x - y|)
+    (x : ℕ → ℝ) (hx : ∀ n, x (n + 1) = f (x n)) (k : ℕ) :
+    |x (k + 1) - x k| ≤ L ^ k * |x 1 - x 0| := by
+  induction k with
+  | zero => simp
+  | succ k ih =>
+    have h := hf (x (k + 1)) (x k)
+    rw [← hx (k + 1), ← hx k] at h
+    calc |x (k + 1 + 1) - x (k + 1)| ≤ L * |x (k + 1) - x k| := h
+      _ ≤ L * (L ^ k * |x 1 - x 0|) := mul_le_mul_of_nonneg_left ih hL0
+      _ = L ^ (k + 1) * |x 1 - x 0| := by ring
+
+/-- **Cauchy estimate between iterates (fixed-point-free a priori bound).**  For a
+    contraction `f` on `ℝ` with `0 ≤ L < 1` and iteration `xₙ₊₁ = f xₙ`, any two iterates
+    satisfy `|x_{n+m} − xₙ| ≤ Lⁿ/(1−L) · |x₁ − x₀|`.  No fixed point is assumed — this is
+    the estimate exhibiting the iteration as a Cauchy sequence, and taking `m → ∞`
+    reproduces `apriori_estimate`.  Proved from `step_dist` via the exact partial geometric
+    sum `Lⁿ(1−Lᵐ)/(1−L)` carried as an induction invariant. -/
+theorem cauchy_estimate (f : ℝ → ℝ) (L : ℝ) (hL0 : 0 ≤ L) (hL1 : L < 1)
+    (hf : ∀ x y, |f x - f y| ≤ L * |x - y|)
+    (x : ℕ → ℝ) (hx : ∀ n, x (n + 1) = f (x n)) (n m : ℕ) :
+    |x (n + m) - x n| ≤ L ^ n / (1 - L) * |x 1 - x 0| := by
+  have hc : (0 : ℝ) < 1 - L := by linarith
+  set S := |x 1 - x 0| with hS
+  have hSnn : 0 ≤ S := abs_nonneg _
+  -- exact partial-sum invariant, cleared of the division by `1 - L`
+  have key : ∀ m, (1 - L) * |x (n + m) - x n| ≤ L ^ n * (1 - L ^ m) * S := by
+    intro m
+    induction m with
+    | zero => simp
+    | succ m ih =>
+      show (1 - L) * |x (n + m + 1) - x n| ≤ L ^ n * (1 - L ^ (m + 1)) * S
+      rw [pow_succ]
+      have hstep := step_dist f L hL0 hf x hx (n + m)
+      rw [pow_add] at hstep
+      have htri : |x (n + m + 1) - x n| ≤ |x (n + m + 1) - x (n + m)| + |x (n + m) - x n| :=
+        abs_sub_le _ _ _
+      have hLnn : (0 : ℝ) ≤ L ^ n := pow_nonneg hL0 n
+      have hLm : (0 : ℝ) ≤ L ^ m := pow_nonneg hL0 m
+      nlinarith [mul_le_mul_of_nonneg_left htri hc.le,
+                 mul_le_mul_of_nonneg_left hstep hc.le, ih, hLnn, hLm, hSnn,
+                 mul_nonneg (mul_nonneg hLnn hLm) hSnn]
+  have hbound : L ^ n * (1 - L ^ m) * S ≤ L ^ n * S := by
+    have hLm : (0 : ℝ) ≤ L ^ m := pow_nonneg hL0 m
+    nlinarith [pow_nonneg hL0 n, hSnn, hLm,
+               mul_nonneg (mul_nonneg (pow_nonneg hL0 n) hLm) hSnn]
+  have hfin : (1 - L) * |x (n + m) - x n| ≤ L ^ n * S := le_trans (key m) hbound
+  rw [div_mul_eq_mul_div, le_div_iff₀ hc]
+  nlinarith [hfin]
+
+/-! ### The `n`-fold iterate is an `Lⁿ`-contraction (structural composition law)
+
+The composition laws `lipschitz_comp`/`lipschitz_comp_list` compose *distinct* maps; the
+special case of composing one map `f` with itself `n` times says the iterate `f^[n]` is
+`Lⁿ`-Lipschitz.  This is the structural fact underlying the geometric decay `iterate_dist`
+(`xₙ = f^[n] x₀`) and, since `Lⁿ < 1`, gives an alternate route to a unique fixed point of
+every iterate.  Stated with Mathlib's `Function.iterate` `f^[n]`. -/
+
+/-- **The `n`-fold iterate of an `L`-contraction is `Lⁿ`-Lipschitz.**
+    `|f^[n] x − f^[n] y| ≤ Lⁿ · |x − y|`.  Proved by induction on `n`, peeling one outer
+    application via `Function.iterate_succ_apply'` and applying the contraction bound. -/
+theorem iterate_lipschitz (f : ℝ → ℝ) (L : ℝ) (hL0 : 0 ≤ L)
+    (hf : ∀ x y, |f x - f y| ≤ L * |x - y|) (n : ℕ) (x y : ℝ) :
+    |f^[n] x - f^[n] y| ≤ L ^ n * |x - y| := by
+  induction n with
+  | zero => simp
+  | succ n ih =>
+    rw [Function.iterate_succ_apply', Function.iterate_succ_apply']
+    calc |f (f^[n] x) - f (f^[n] y)| ≤ L * |f^[n] x - f^[n] y| := hf _ _
+      _ ≤ L * (L ^ n * |x - y|) := mul_le_mul_of_nonneg_left ih hL0
+      _ = L ^ (n + 1) * |x - y| := by ring
 
 end BrouwerOQ02OQ02OQ01

--- a/src/data/proofs/brouwer-fixed-point-oq-02-oq-02-oq-01/meta.json
+++ b/src/data/proofs/brouwer-fixed-point-oq-02-oq-02-oq-01/meta.json
@@ -24,7 +24,7 @@
     "badge": "original",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 422,
+    "lineCount": 513,
     "dateAdded": "2026-07-10",
     "mathlib_version": "4.26.0",
     "mathlibDependencies": [


### PR DESCRIPTION
## Summary

Extends the Banach-contraction estimate suite in `BrouwerFixedPointOQ02OQ02OQ01.lean` with three genuinely-absent classic results, and repairs a Mathlib-drift breakage that had stopped the (gallery-`verified`) file from compiling.

### New theorems (all axiom-free)

- **`step_dist`** — geometric decay of the *increments*: `|x_{k+1} − x_k| ≤ Lᵏ · |x₁ − x₀|`. Each step is a factor `L` shorter than the last.
- **`cauchy_estimate`** — the **fixed-point-free a priori bound** directly between two iterates: `|x_{n+m} − xₙ| ≤ Lⁿ/(1−L) · |x₁ − x₀|`. Mentions no `x*` at all — it is precisely the estimate exhibiting the iteration as a **Cauchy sequence** (what *proves* a fixed point exists on a complete space), and letting `m → ∞` recovers the existing `apriori_estimate`. Proved from `step_dist` via the exact partial geometric sum `Lⁿ(1−Lᵐ)/(1−L)` carried as an induction invariant.
- **`iterate_lipschitz`** — the structural composition law for self-composition: the `n`-fold iterate is `Lⁿ`-Lipschitz, `|f^[n] x − f^[n] y| ≤ Lⁿ · |x − y|` (Mathlib `Function.iterate`). This is the special case of `lipschitz_comp_list` for one repeated map, and the fact underlying `iterate_dist` since `xₙ = f^[n] x₀`.

### Drift repair

`abs_add` → `abs_add_le` (renamed in current Mathlib). The graduated file no longer compiled — line 441 in `fixed_point_stability` raised `unknownIdentifier abs_add`. Fixed; whole file now compiles clean.

## Verification

- Compiles clean under Lean **v4.26.0** / prebuilt Mathlib (`lake env lean`, exit 0, no warnings).
- `#print axioms` on `step_dist`, `cauchy_estimate`, `iterate_lipschitz`, and the repaired `fixed_point_stability`: each depends only on `[propext, Classical.choice, Quot.sound]` — **axiom-free** (no `sorryAx`, no `Lean.ofReduceBool`).
- Status stays `verified` / `original`, `axiomCount = 0`; `lineCount` bumped 422 → 513.

🤖 Generated with [Claude Code](https://claude.com/claude-code)