### PR TITLE
research(erdos-771): clear le_or_lt deprecation, correct stale docstring, sync meta counts

### DIFF
--- a/proofs/Proofs/Erdos771Construction.lean
+++ b/proofs/Proofs/Erdos771Construction.lean
@@ -7,10 +7,11 @@ The answer `f(n) = (1/2 + o(1)) · n / log n` is known (Erdős–Graham lower bo
 Alon–Freiman upper bound), and both bounds are deep.
 
 This file does NOT reprove the asymptotics. It **fully verifies (0 axioms, 0 sorries)** the
-elementary **construction** at the heart of the Erdős–Graham *lower* bound, which the
-companion `Erdos771Problem.lean` left as `sorry` (and which, in any case, no longer compiles
-under Mathlib 4.26.0 — stale module path, `DecidablePred` gaps, and dangling doc-comments;
-flagged for a Mechanic). The construction is:
+elementary **construction** at the heart of the Erdős–Graham *lower* bound. The companion
+`Erdos771Problem.lean` packages the same lower bound via the axiom `erdos_graham_lower_bound`;
+that file's earlier Mathlib-4.26 drift has since been repaired and it now compiles cleanly, so
+this standalone construction stands alongside it as an axiom-free witness of the underlying
+combinatorial fact. The construction is:
 
 > Take `S = ` the multiples of a prime `p` in `{1,…,n}`. Every subset sum of `S` is a
 > multiple of `p`, so if `p ∤ m` then `m` is **not** a subset sum — `S` avoids `m`.

--- a/proofs/Proofs/Erdos771Problem.lean
+++ b/proofs/Proofs/Erdos771Problem.lean
@@ -283,7 +283,7 @@ theorem f_characterization (n : ℕ) (hn : n ≥ 1) :
   · -- f_property n (f n)
     intro m hm
     rw [maxAvoidingSize_ge_iff]
-    rcases le_or_lt m (n * n) with hmle | hmgt
+    rcases le_or_gt m (n * n) with hmle | hmgt
     · rw [hf]; exact Finset.inf'_le _ (Finset.mem_Icc.mpr ⟨hm, hmle⟩)
     · have hfull : n ≤ maxAvoidingSize n m := by
         have hmemfull : Icc_n n ∈

--- a/src/data/proofs/erdos-771/meta.json
+++ b/src/data/proofs/erdos-771/meta.json
@@ -79,9 +79,9 @@
       "erdos_771, erdos_771_main, erdos_771_solved: main theorem statements"
     ],
     "axiomCount": 2,
-    "lineCount": 575,
+    "lineCount": 645,
     "assumptions": "2 axioms: erdos_graham_lower_bound, alon_freiman_upper_bound. 0 sorries.",
-    "theoremCount": 23,
+    "theoremCount": 30,
     "definitionCount": 16,
     "additionalFiles": [
       "Proofs/Erdos771Aristotle.lean",
@@ -214,9 +214,9 @@
       "Nat"
     ],
     "namespace": "Erdos771",
-    "lineCount": 575,
+    "lineCount": 645,
     "axiomCount": 2,
-    "theoremCount": 23,
+    "theoremCount": 30,
     "definitionCount": 16,
     "sorries": 0,
     "path": "Proofs/Erdos771Problem.lean",


### PR DESCRIPTION
## Summary

Three accuracy/maintenance fixes to the Erdős #771 pair (subsets avoiding a given sum):

1. **`Erdos771Problem.lean`**: `le_or_lt` → `le_or_gt` (deprecated). Clears the sole compiler warning; same meaning, proof unchanged.

2. **`Erdos771Construction.lean`**: corrected a **stale docstring**. It asserted the companion `Erdos771Problem.lean` *"no longer compiles under Mathlib 4.26.0 … flagged for a Mechanic"*. That drift was since repaired — `Erdos771Problem.lean` now compiles cleanly (`lake env lean` exit 0). The misleading claim (which could trigger unnecessary Mechanic work) is replaced with an accurate description of the two files' relationship.

3. **`meta.json`**: synced stale counts — `lineCount` 575→645, `theoremCount` 23→30 (both count blocks; `definitionCount` 16, `axiomCount` 2, `sorries` 0 unchanged).

## Verification

- `lake env lean Proofs/Erdos771Problem.lean` → exit 0, **zero warnings** (previously one deprecation warning)
- `lake env lean Proofs/Erdos771Construction.lean` → exit 0
- Status stays `axiomatized` (2 axioms: `erdos_graham_lower_bound`, `alon_freiman_upper_bound`); JSON validated

🤖 Generated with [Claude Code](https://claude.com/claude-code)