### PR TITLE
research(lagrange-theorem-oq-01): repair Mathlib-bump drift + non-simplicity capstone (¬IsSimpleGroup for |G|=pq)

### DIFF
--- a/proofs/Proofs/LagrangeTheoremOQ01.lean
+++ b/proofs/Proofs/LagrangeTheoremOQ01.lean
@@ -13,6 +13,8 @@
   **Sylow Theorem III** (Counting): n_p ≡ 1 mod p and n_p | |G|/p^k.
 
   This file connects Mathlib's Sylow theory to the Lagrange theorem context.
+  Orders are measured with `Nat.card` and finiteness with `[Finite G]`, matching
+  the current Mathlib Sylow API.
 
   Tags: group-theory, algebra, classic, wiedijk-100
 -/
@@ -21,9 +23,9 @@ import Mathlib
 
 namespace LagrangeOQ01
 
-open Subgroup Fintype
+open Subgroup
 
-variable {G : Type*} [Group G] [Fintype G]
+variable {G : Type*} [Group G] [Finite G]
 
 /-
 ═══════════════════════════════════════════════════════════════════════════════
@@ -31,39 +33,35 @@ PART I: LAGRANGE'S THEOREM (FROM MATHLIB)
 ═══════════════════════════════════════════════════════════════════════════════ -/
 
 /-- Lagrange's theorem: the order of a subgroup divides the order of the group. -/
-theorem lagrange (H : Subgroup G) [Fintype H] : card H ∣ card G :=
+theorem lagrange (H : Subgroup G) : Nat.card H ∣ Nat.card G :=
   H.card_subgroup_dvd_card
 
 /-- The index formula: |G| = |H| · [G : H]. -/
-theorem lagrange_index (H : Subgroup G) [Fintype H] :
-    card G = card H * H.index :=
+theorem lagrange_index (H : Subgroup G) :
+    Nat.card G = Nat.card H * H.index :=
   (Subgroup.card_mul_index H).symm
 
 /-- The order of every element divides |G|. -/
-theorem order_dvd_card (g : G) : orderOf g ∣ card G :=
-  orderOf_dvd_card
+theorem order_dvd_card (g : G) : orderOf g ∣ Nat.card G :=
+  orderOf_dvd_natCard g
 
 /-
 ═══════════════════════════════════════════════════════════════════════════════
 PART II: SYLOW EXISTENCE (FIRST SYLOW THEOREM)
-
-Mathlib proves: for every prime p, if p divides |G|, then G has a
-Sylow p-subgroup P with |P| = p^k where p^k is the largest power
-of p dividing |G|.
 ═══════════════════════════════════════════════════════════════════════════════ -/
 
-/-- Sylow subgroups exist: for every prime p, there is a Sylow p-subgroup. -/
+/-- Every finite group has a Sylow p-subgroup (First Sylow Theorem). -/
 theorem sylow_exists (p : ℕ) [hp : Fact p.Prime] : Nonempty (Sylow p G) :=
   Sylow.nonempty
 
 /-- A Sylow p-subgroup has order p^k where p^k || |G| (maximal p-power). -/
 theorem sylow_card_eq (p : ℕ) [hp : Fact p.Prime] (P : Sylow p G) :
-    card P = p ^ (card G).factorization p :=
+    Nat.card P = p ^ (Nat.card G).factorization p :=
   Sylow.card_eq_multiplicity P
 
 /-- The order of a Sylow p-subgroup divides |G| (special case of Lagrange). -/
 theorem sylow_order_dvd (p : ℕ) [hp : Fact p.Prime] (P : Sylow p G) :
-    card P ∣ card G :=
+    Nat.card P ∣ Nat.card G :=
   P.toSubgroup.card_subgroup_dvd_card
 
 /-
@@ -75,11 +73,11 @@ then there exists g ∈ G with Q = gPg⁻¹.
 ═══════════════════════════════════════════════════════════════════════════════ -/
 
 /-- All Sylow p-subgroups are conjugate (Second Sylow Theorem).
-    Mathlib gives this as an action on Sylow subgroups. -/
+    Mathlib gives this as a transitive action of `G` on the Sylow subgroups:
+    there is a `g : G` with `g • P = Q`. -/
 theorem sylow_conjugate (p : ℕ) [hp : Fact p.Prime] (P Q : Sylow p G) :
-    ∃ g : G, P.toSubgroup.map (MulEquiv.toMonoidHom (MulAut.conj g)) = Q.toSubgroup := by
-  obtain ⟨g, hg⟩ := Sylow.conj_eq P Q
-  exact ⟨g, by rw [← hg]; ext; simp [Subgroup.mem_map, MulAut.conj_apply]; aesop⟩
+    ∃ g : G, g • P = Q :=
+  MulAction.exists_smul_eq G P Q
 
 /-
 ═══════════════════════════════════════════════════════════════════════════════
@@ -92,8 +90,8 @@ The number n_p of Sylow p-subgroups satisfies:
 
 /-- The number of Sylow p-subgroups divides the index of any Sylow p-subgroup. -/
 theorem sylow_count_dvd_index (p : ℕ) [hp : Fact p.Prime] (P : Sylow p G) :
-    card (Sylow p G) ∣ P.toSubgroup.index :=
-  Sylow.card_sylow_dvd_index P
+    Nat.card (Sylow p G) ∣ P.toSubgroup.index :=
+  P.card_dvd_index
 
 /-- The number of Sylow p-subgroups divides `|G|`.
     Since `n_p` divides the index `[G : P] = |G| / p^k` (`sylow_count_dvd_index`)
@@ -101,21 +99,22 @@ theorem sylow_count_dvd_index (p : ℕ) [hp : Fact p.Prime] (P : Sylow p G) :
     headline Third-Sylow divisibility `n_p | |G|` — the coarser but self-contained
     form of `n_p | |G|/p^k` that needs no reference to the Sylow order. -/
 theorem sylow_count_dvd_card (p : ℕ) [hp : Fact p.Prime] (P : Sylow p G) :
-    card (Sylow p G) ∣ card G := by
-  have h := (Sylow.card_sylow_dvd_index P).trans P.toSubgroup.index_dvd_card
-  rwa [Nat.card_eq_fintype_card] at h
+    Nat.card (Sylow p G) ∣ Nat.card G :=
+  P.card_dvd_index.trans P.toSubgroup.index_dvd_card
 
 /-- The number of Sylow p-subgroups is congruent to 1 mod p. -/
 theorem sylow_count_mod_p (p : ℕ) [hp : Fact p.Prime] :
-    card (Sylow p G) % p = 1 := by
-  exact Sylow.card_sylow_modEq_one p G |>.out
+    Nat.card (Sylow p G) % p = 1 := by
+  have h := card_sylow_modEq_one (p := p) (G := G)
+  have hp1 : (1 : ℕ) % p = 1 := Nat.mod_eq_of_lt hp.out.one_lt
+  rwa [Nat.ModEq, hp1] at h
 
 /-- The Sylow count `n_p` is **not** divisible by `p` — equivalently, `n_p` is coprime
     to `p`.  Immediate from `sylow_count_mod_p`: a multiple of `p` would have residue `0`,
     but `n_p ≡ 1 (mod p)`.  This is the residue-form companion to `sylow_count_mod_p`
     used, e.g., to rule out `n_p = p` in the classification of groups of small order. -/
 theorem sylow_count_not_dvd_p (p : ℕ) [hp : Fact p.Prime] :
-    ¬ p ∣ card (Sylow p G) := by
+    ¬ p ∣ Nat.card (Sylow p G) := by
   rw [Nat.dvd_iff_mod_eq_zero, sylow_count_mod_p]
   exact one_ne_zero
 
@@ -127,8 +126,8 @@ theorem sylow_count_not_dvd_p (p : ℕ) [hp : Fact p.Prime] :
     when `q ≢ 1 (mod p)` the value `n_p = q` is excluded and `n_p = 1`, making `P` normal
     by `sylow_normal_iff_card_eq_one`. -/
 theorem sylow_count_eq_one_or_prime (p q : ℕ) [hp : Fact p.Prime] (hq : q.Prime)
-    (h : card (Sylow p G) ∣ q) :
-    card (Sylow p G) = 1 ∨ card (Sylow p G) = q :=
+    (h : Nat.card (Sylow p G) ∣ q) :
+    Nat.card (Sylow p G) = 1 ∨ Nat.card (Sylow p G) = q :=
   hq.eq_one_or_self_of_dvd _ h
 
 /-- **Hall property of Sylow subgroups**: the index `[G : P]` of a Sylow p-subgroup is
@@ -137,7 +136,7 @@ theorem sylow_count_eq_one_or_prime (p q : ℕ) [hp : Fact p.Prime] (hq : q.Prim
     what makes a Sylow subgroup a *Hall* subgroup (`|P|` and `[G:P]` coprime) and the
     defining maximality property behind the First Sylow Theorem.  From
     `Sylow.not_dvd_index` (the `[P.FiniteIndex]` and `Finite (Sylow p G)` instances are
-    supplied automatically by `[Fintype G]`). -/
+    supplied automatically by `[Finite G]`). -/
 theorem sylow_index_not_dvd_p (p : ℕ) [hp : Fact p.Prime] (P : Sylow p G) :
     ¬ p ∣ P.toSubgroup.index :=
   P.not_dvd_index
@@ -150,7 +149,7 @@ theorem sylow_index_not_dvd_p (p : ℕ) [hp : Fact p.Prime] (P : Sylow p G) :
     `Nat.Coprime.pow_left`.  A subgroup whose order is coprime to its index is by
     definition a Hall subgroup, so every Sylow subgroup is a Hall subgroup. -/
 theorem sylow_card_coprime_index (p : ℕ) [hp : Fact p.Prime] (P : Sylow p G) :
-    Nat.Coprime (card P) P.toSubgroup.index := by
+    Nat.Coprime (Nat.card P) P.toSubgroup.index := by
   rw [sylow_card_eq]
   exact ((hp.out.coprime_iff_not_dvd).mpr P.not_dvd_index).pow_left _
 
@@ -173,14 +172,13 @@ of many orders (e.g. `|G| = pq`).
     subgroup is normal (`Sylow.normal_of_subsingleton`).  This is the standard bridge
     from the Third-Sylow counting data to structural normality. -/
 theorem sylow_normal_iff_card_eq_one (p : ℕ) [hp : Fact p.Prime] (P : Sylow p G) :
-    P.Normal ↔ card (Sylow p G) = 1 := by
+    P.Normal ↔ Nat.card (Sylow p G) = 1 := by
   constructor
   · intro h
     haveI := P.unique_of_normal h
-    exact Fintype.card_unique
+    exact Nat.card_unique
   · intro h
-    haveI : Subsingleton (Sylow p G) :=
-      Fintype.card_le_one_iff_subsingleton.mp (le_of_eq h)
+    haveI : Subsingleton (Sylow p G) := (Nat.card_eq_one_iff_unique.mp h).1
     exact P.normal_of_subsingleton
 
 /-- A normal Sylow p-subgroup is even **characteristic** (invariant under every
@@ -203,30 +201,29 @@ subgroups of that order exist. For composite divisors, this can fail.
     for every prime p and natural number k with p^k | |G|, there is a
     subgroup of order p^k. -/
 theorem partial_converse_lagrange (p : ℕ) [hp : Fact p.Prime] (k : ℕ)
-    (hk : p ^ k ∣ card G) :
-    ∃ H : Subgroup G, Fintype.card H = p ^ k := by
-  -- Mathlib's IsPGroup.exists_le_sylow gives subgroups for all p-power divisors
-  exact Sylow.exists_subgroup_card_pow_prime p hk
+    (hk : p ^ k ∣ Nat.card G) :
+    ∃ H : Subgroup G, Nat.card H = p ^ k :=
+  Sylow.exists_subgroup_card_pow_prime p hk
 
 /-- Cauchy's theorem as a corollary: if p | |G|, then G has an element of order p. -/
-theorem cauchy_theorem (p : ℕ) [hp : Fact p.Prime] (h : p ∣ card G) :
+theorem cauchy_theorem (p : ℕ) [hp : Fact p.Prime] (h : p ∣ Nat.card G) :
     ∃ g : G, orderOf g = p :=
-  exists_prime_orderOf_dvd_card p h
+  exists_prime_orderOf_dvd_card' p h
 
 /-- **There is always at least one Sylow p-subgroup**: `n_p > 0`.  The positivity
     underlying every Third-Sylow statement (`n_p ≡ 1 mod p`, `n_p ∣ [G:P]`): the set of
     Sylow p-subgroups is nonempty (`Sylow.nonempty`, the First Sylow Theorem), hence its
     cardinality is positive.  Records the base fact that `sylow_count_mod_p` implicitly
     relies on. -/
-theorem sylow_count_pos (p : ℕ) [hp : Fact p.Prime] : 0 < card (Sylow p G) :=
-  card_pos_iff.mpr Sylow.nonempty
+theorem sylow_count_pos (p : ℕ) [hp : Fact p.Prime] : 0 < Nat.card (Sylow p G) :=
+  Nat.card_pos_iff.mpr ⟨Sylow.nonempty, inferInstance⟩
 
 /-- **Subgroup form of Cauchy's theorem**: if `p ∣ |G|` then `G` has a subgroup of order
     exactly `p`.  This is the `k = 1` case of `partial_converse_lagrange` (`p¹ ∣ |G|`), the
     subgroup companion to `cauchy_theorem` (which produces an *element* of order `p`; the
     cyclic group it generates is precisely such a subgroup). -/
-theorem exists_subgroup_card_prime (p : ℕ) [hp : Fact p.Prime] (h : p ∣ card G) :
-    ∃ H : Subgroup G, Fintype.card H = p := by
+theorem exists_subgroup_card_prime (p : ℕ) [hp : Fact p.Prime] (h : p ∣ Nat.card G) :
+    ∃ H : Subgroup G, Nat.card H = p := by
   obtain ⟨H, hH⟩ := partial_converse_lagrange p 1 (by rwa [pow_one])
   exact ⟨H, by rwa [pow_one] at hH⟩
 
@@ -248,12 +245,12 @@ not merely about orders.
     `|G|` to the first power only, so the Sylow q-subgroup has order exactly `q`.
     (From `sylow_card_eq`: `|Q| = q^(vq(|G|))` and `v_q(p·q) = 1` since `q ∤ p`.) -/
 theorem card_sylow_q_of_card_eq_pq (p q : ℕ) (hp : p.Prime) (hq : q.Prime)
-    (hpq : p < q) (Q : Sylow q G) (hG : card G = p * q) :
-    card Q = q := by
+    (hpq : p < q) (Q : Sylow q G) (hG : Nat.card G = p * q) :
+    Nat.card Q = q := by
   haveI : Fact q.Prime := ⟨hq⟩
   have hqp : ¬ q ∣ p := fun hdvd =>
     absurd ((Nat.prime_dvd_prime_iff_eq hq hp).mp hdvd) (ne_of_gt hpq)
-  have hfact : (card G).factorization q = 1 := by
+  have hfact : (Nat.card G).factorization q = 1 := by
     rw [hG, Nat.factorization_mul hp.pos.ne' hq.pos.ne', Finsupp.add_apply,
       Nat.factorization_eq_zero_of_not_dvd hqp, hq.factorization_self, zero_add]
   rw [sylow_card_eq, hfact, pow_one]
@@ -267,17 +264,17 @@ theorem card_sylow_q_of_card_eq_pq (p q : ℕ) (hp : p.Prime) (hq : q.Prime)
     Therefore `n_q = 1`, and `Q` is normal by the normality criterion
     (`sylow_normal_iff_card_eq_one`). -/
 theorem sylow_q_normal_of_card_eq_pq (p q : ℕ) (hp : p.Prime) (hq : q.Prime)
-    (hpq : p < q) (Q : Sylow q G) (hG : card G = p * q) :
+    (hpq : p < q) (Q : Sylow q G) (hG : Nat.card G = p * q) :
     Q.Normal := by
   haveI : Fact q.Prime := ⟨hq⟩
   -- The index [G : Q] equals p (Lagrange with |Q| = q).
-  have hcardQ : card Q.toSubgroup = q := card_sylow_q_of_card_eq_pq p q hp hq hpq Q hG
+  have hcardQ : Nat.card Q.toSubgroup = q := card_sylow_q_of_card_eq_pq p q hp hq hpq Q hG
   have hidx : Q.toSubgroup.index = p := by
     have hlag := lagrange_index Q.toSubgroup
     rw [hcardQ, hG, mul_comm p q] at hlag
     exact (Nat.eq_of_mul_eq_mul_left hq.pos hlag).symm
   -- n_q divides p.
-  have hdvd : card (Sylow q G) ∣ p := by
+  have hdvd : Nat.card (Sylow q G) ∣ p := by
     have h := sylow_count_dvd_index (G := G) q Q
     rwa [hidx] at h
   -- n_q = 1 or n_q = p; the latter contradicts n_q ≡ 1 (mod q).
@@ -287,6 +284,41 @@ theorem sylow_q_normal_of_card_eq_pq (p q : ℕ) (hp : p.Prime) (hq : q.Prime)
     have hmod := sylow_count_mod_p (G := G) q
     rw [hpeq, Nat.mod_eq_of_lt hpq] at hmod
     exact hp.one_lt.ne' hmod
+
+/-- **Every group of order `p·q` (with `p < q` prime) has a normal subgroup of order
+    `q`.** Existence form of `sylow_q_normal_of_card_eq_pq`: rather than assume a Sylow
+    q-subgroup is given, invoke `sylow_exists` to produce one, then package its exact
+    order `q` (`card_sylow_q_of_card_eq_pq`) with its normality
+    (`sylow_q_normal_of_card_eq_pq`).  This is the clean structural statement — a normal
+    subgroup of the top prime order always exists — with no Sylow object in the
+    signature. -/
+theorem exists_normal_subgroup_card_eq_pq (p q : ℕ) (hp : p.Prime) (hq : q.Prime)
+    (hpq : p < q) (hG : Nat.card G = p * q) :
+    ∃ H : Subgroup G, H.Normal ∧ Nat.card H = q := by
+  haveI : Fact q.Prime := ⟨hq⟩
+  obtain ⟨Q⟩ := sylow_exists (G := G) q
+  exact ⟨Q.toSubgroup,
+    sylow_q_normal_of_card_eq_pq p q hp hq hpq Q hG,
+    card_sylow_q_of_card_eq_pq p q hp hq hpq Q hG⟩
+
+/-- **No group of order `p·q` is simple** (`p < q` prime).  The normal subgroup `H` of
+    order `q` from `exists_normal_subgroup_card_eq_pq` is neither trivial (`|H| = q > 1`)
+    nor the whole group (`|H| = q < p·q = |G|`, as `p ≥ 2`), so it witnesses a proper
+    nontrivial normal subgroup — contradicting the definition of a simple group.  This is
+    the headline consequence of Sylow III for the `pq` case: the smallest genuinely
+    composite orders `6, 10, 14, 15, 21, …` all fail to be simple, the first structural
+    obstruction beyond prime order in the classification of finite simple groups. -/
+theorem not_isSimpleGroup_of_card_eq_pq (p q : ℕ) (hp : p.Prime) (hq : q.Prime)
+    (hpq : p < q) (hG : Nat.card G = p * q) : ¬ IsSimpleGroup G := by
+  obtain ⟨H, hHnorm, hHcard⟩ := exists_normal_subgroup_card_eq_pq p q hp hq hpq hG
+  intro hsimple
+  rcases hsimple.eq_bot_or_eq_top_of_normal H hHnorm with hbot | htop
+  · -- `H = ⊥` would force `q = |H| = 1`, impossible for a prime `q`.
+    rw [hbot, Subgroup.card_bot] at hHcard
+    exact hq.one_lt.ne' hHcard.symm
+  · -- `H = ⊤` would force `p·q = |G| = |H| = q`, i.e. `p = 1`, impossible for a prime `p`.
+    rw [htop, Subgroup.card_top, hG] at hHcard
+    exact hp.one_lt.ne' (Nat.eq_of_mul_eq_mul_right hq.pos (hHcard.trans (one_mul q).symm))
 
 end LagrangeOQ01
 
@@ -304,8 +336,9 @@ end LagrangeOQ01
   - Normality criterion: P normal ⟺ n_p = 1; a normal Sylow is characteristic
   - Partial converse: p^k | |G| implies ∃ subgroup of order p^k
   - Cauchy's theorem: p | |G| implies ∃ element of order p
-  - Capstone: groups of order p·q (p < q) have a normal Sylow q-subgroup
-    (hence are not simple) — a genuine structural consequence of Sylow III
+  - Capstone: groups of order p·q (p < q) have a normal Sylow q-subgroup, hence a
+    normal subgroup of order q, hence are NOT simple (¬ IsSimpleGroup) — a genuine
+    structural consequence of Sylow III
 
   **Status**: Verified, 0 sorries, 0 axioms
 -/

--- a/src/data/proofs/lagrange-theorem-oq-01/meta.json
+++ b/src/data/proofs/lagrange-theorem-oq-01/meta.json
@@ -20,15 +20,16 @@
     "sorries": 0,
     "dateAdded": "2026-04-04",
     "axiomCount": 0,
-    "lineCount": 210,
-    "theoremCount": 16,
+    "lineCount": 344,
+    "theoremCount": 24,
     "definitionCount": 0,
     "assumptions": "None.",
     "originalContributions": [
       "Unified formal presentation of all three Sylow theorems connecting to Lagrange's theorem context",
       "Explicit statement that n_p ≡ 1 mod p using Sylow.card_sylow_modEq_one",
       "Partial converse to Lagrange: p^k | |G| implies subgroup of order p^k via Sylow.exists_subgroup_card_pow_prime",
-      "Cauchy's theorem as corollary of Sylow existence"
+      "Cauchy's theorem as corollary of Sylow existence",
+      "REPAIR + capstone: the file had bit-rotted against a Mathlib bump (Fintype.card/[Fintype G] → Nat.card/[Finite G], and Sylow API renames conj_eq→MulAction.exists_smul_eq, card_sylow_dvd_index→Sylow.card_dvd_index, Sylow.card_sylow_modEq_one→card_sylow_modEq_one, exists_prime_orderOf_dvd_card→_card') — migrated all 22 theorems back to a clean compile, then added exists_normal_subgroup_card_eq_pq (a normal subgroup of order q always exists) and not_isSimpleGroup_of_card_eq_pq (¬ IsSimpleGroup G for |G|=pq), the headline non-simplicity capstone. Axiom-free."
     ]
   },
   "overview": {
@@ -151,9 +152,9 @@
   ],
   "leanFile": {
     "namespace": "LagrangeOQ01",
-    "lineCount": 227,
+    "lineCount": 344,
     "axiomCount": 0,
-    "theoremCount": 18,
+    "theoremCount": 24,
     "definitionCount": 0,
     "path": "Proofs/LagrangeTheoremOQ01.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

`LagrangeTheoremOQ01.lean` (Sylow theory as a partial converse of Lagrange) was marked **verified / 0 axioms** in the gallery but had **fully bit-rotted** against a Mathlib bump — the pristine file produced **20 compile errors**. This PR restores it to a clean axiom-free build **and** adds the headline structural capstone.

## Repair (all 22 pre-existing theorems migrated)

| Old (broken) | New (current Mathlib) |
|---|---|
| `[Fintype G]` / `Fintype.card` | `[Finite G]` / `Nat.card` (throughout) |
| `Sylow.conj_eq` | `MulAction.exists_smul_eq` (`∃ g, g • P = Q`) |
| `Sylow.card_sylow_dvd_index` | `Sylow.card_dvd_index` |
| `Sylow.card_sylow_modEq_one` | `card_sylow_modEq_one` (`Nat.card`, `ModEq` form) |
| `exists_prime_orderOf_dvd_card` | `exists_prime_orderOf_dvd_card'` (Finite variant) |
| normality criterion internals | `Nat.card_unique` / `Nat.card_eq_one_iff_unique` |

## New capstone theorems (Part VI)

- **`exists_normal_subgroup_card_eq_pq`** — every group of order `p·q` (`p < q` prime) has a **normal subgroup of order `q`**: the existence form of `sylow_q_normal_of_card_eq_pq`, with no Sylow object in the signature (invokes `sylow_exists` internally).
- **`not_isSimpleGroup_of_card_eq_pq`** — **no group of order `p·q` is simple**. The order-`q` normal subgroup is proper (`q < pq`) and nontrivial (`q > 1`), witnessing a proper nontrivial normal subgroup and contradicting `IsSimpleGroup`. This is the first structural obstruction beyond prime order — orders `6, 10, 14, 15, 21, …` all fail to be simple.

## Verification

- All theorems `#print axioms` = `[propext, Classical.choice, Quot.sound]` — **axiom-free**, no `native_decide`, 0 sorries.
- Built `lean v4.26.0` against prebuilt Mathlib oleans (exit 0).
- `meta.json`: `theoremCount` 16→24, `lineCount` 210→344 (both were also stale, understating the pristine file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)