### PR TITLE
research(liouville-theorem-oq-03): category (Baire) face — W τ comeagre, comeagre-yet-null dichotomy

### DIFF
--- a/proofs/Proofs/LiouvilleTheoremOQ03.lean
+++ b/proofs/Proofs/LiouvilleTheoremOQ03.lean
@@ -511,4 +511,48 @@ theorem dimH_wellApprox_eq_one_of_le_one {τ : ℝ} (hτ : τ ≤ 1) :
     dimH (wellApprox τ) = 1 := by
   rw [wellApprox_le_one hτ]; exact Real.dimH_univ
 
+/-! ## Part X: The category (Baire) face — comeagre yet null
+
+Parts II–VIII established that for `τ > 2` the well-approximable set is *metrically*
+small: Lebesgue-null (`volume_wellApprox_eq_zero`) and of sub-line Hausdorff dimension
+(`dimH_wellApprox_lt_one`).  `wellApprox_dense` already noted it is topologically dense.
+The sharp topological statement is stronger still: each `W τ` is **comeagre
+(residual)** — it contains a dense `Gδ`.  This is inherited for free from Mathlib's
+`eventually_residual_liouville` (the Liouville numbers are residual) because the
+residual filter is upward closed and `{x | Liouville x} ⊆ W τ`.  Combined with the
+measure side it exhibits the textbook **category/measure dichotomy**: for `τ > 2`,
+`W τ` is a comeagre set of Lebesgue measure zero, so `ℝ` decomposes into the meagre
+full-measure complement `(W τ)ᶜ` and the comeagre null set `W τ`. -/
+
+/-- **Each well-approximable set is residual (comeagre).**  `W τ ∈ residual ℝ` for
+every exponent `τ`: it contains the residual Liouville set
+(`eventually_residual_liouville`) and the residual filter is upward closed
+(`Filter.mem_of_superset`).  Axiom-free — strengthens `wellApprox_dense`
+(`dense_of_mem_residual`). -/
+theorem wellApprox_residual (τ : ℝ) : wellApprox τ ∈ residual ℝ :=
+  Filter.mem_of_superset eventually_residual_liouville (liouville_subset_wellApprox τ)
+
+/-- **Comeagre form.**  A residual-a.e. real is `τ`-well-approximable:
+`∀ᶠ x in residual ℝ, x ∈ W τ`.  The `Filter.Eventually` restatement of
+`wellApprox_residual`. -/
+theorem eventually_residual_wellApprox (τ : ℝ) : ∀ᶠ x in residual ℝ, x ∈ wellApprox τ :=
+  wellApprox_residual τ
+
+/-- **The complement is meagre.**  `(W τ)ᶜ` is a meagre set for every `τ`: the reals
+that are *not* `τ`-well-approximable form a first-category set.  Immediate from
+`wellApprox_residual` since `IsMeagre s ↔ sᶜ ∈ residual`. -/
+theorem meagre_compl_wellApprox (τ : ℝ) : IsMeagre (wellApprox τ)ᶜ := by
+  rw [IsMeagre, compl_compl]; exact wellApprox_residual τ
+
+open MeasureTheory in
+/-- **Category/measure dichotomy.**  For `τ > 2` the well-approximable set is
+*simultaneously* comeagre (`wellApprox_residual`) and Lebesgue-null
+(`volume_wellApprox_eq_zero`).  Thus `W τ` is a residual set of measure zero — the
+classical demonstration that Baire category and Lebesgue measure can disagree
+completely: the "typical" real in the category sense lies in `W τ`, while the
+"typical" real in the measure sense does not. -/
+theorem wellApprox_residual_and_volume_zero {τ : ℝ} (hτ : 2 < τ) :
+    wellApprox τ ∈ residual ℝ ∧ volume (wellApprox τ) = 0 :=
+  ⟨wellApprox_residual τ, volume_wellApprox_eq_zero hτ⟩
+
 end LiouvilleTheoremOQ03

--- a/src/data/research/problems/liouville-theorem-oq-03.json
+++ b/src/data/research/problems/liouville-theorem-oq-03.json
@@ -18,7 +18,7 @@
   "currentState": {
     "phase": "COMPLETED",
     "since": "2026-04-22T12:51:58.295Z",
-    "iteration": 1,
+    "iteration": 2,
     "focus": "Shipped Jarník–Besicovitch dimension formalization (axiomatized JB formula, derived Liouville dim 0).",
     "blockers": [],
     "nextAction": "Discharge dimH_wellApprox axiom via Borel–Cantelli (upper) + Frostman mass distribution (lower).",
@@ -29,12 +29,13 @@
     }
   },
   "knowledge": {
-    "progressSummary": "Formalized Jarník–Besicovitch dimH(W τ)=2/τ (τ≥2) over Mathlib LiouvilleWith + dimH; JB formula = single axiom; derived dimH{Liouville}=0 by tendsto squeeze. Structural lemmas 0-axiom (LiouvilleWith.mono, Liouville.liouvilleWith, dimH_mono). 210L, 17 thm, 2 def, 1 axiom.",
+    "progressSummary": "FOLLOW-UP (researcher-7, 2026-07-11, VERIFIED): added Part X, the category (Baire) face — each well-approximable set W τ is comeagre (wellApprox_residual: W τ ∈ residual ℝ, AXIOM-FREE, from eventually_residual_liouville + upward-closed residual filter), its complement is meagre (meagre_compl_wellApprox, AXIOM-FREE), and for τ>2 W τ is simultaneously comeagre and Lebesgue-null (wellApprox_residual_and_volume_zero) — the textbook category/measure dichotomy. Strengthens the prior wellApprox_dense. --- Formalized Jarník–Besicovitch dimH(W τ)=2/τ (τ≥2) over Mathlib LiouvilleWith + dimH; JB formula = single axiom; derived dimH{Liouville}=0 by tendsto squeeze. Structural lemmas 0-axiom (LiouvilleWith.mono, Liouville.liouvilleWith, dimH_mono). 210L, 17 thm, 2 def, 1 axiom.",
     "builtItems": [
       "wellApprox τ := {x | LiouvilleWith τ x} + antitonicity (LiouvilleWith.mono) and {Liouville}⊆W τ (Liouville.liouvilleWith), 0-axiom",
       "dimH_mono transport: dimH(W τ) antitone, dimH{Liouville} ≤ dimH(W τ)",
       "dimH_wellApprox axiom (Jarník–Besicovitch formula) + derived dimH_liouville_eq_zero via ge_of_tendsto squeeze (n→∞)",
-      "Family-level dimension shape (VERIFIED, from JB axiom): dimH_wellApprox_pos (0<dimH for τ≥2), dimH_wellApprox_lt_one (<1 for τ>2), dimH_wellApprox_strictAntitone (2≤σ<τ ⇒ strict drop), dimH_wellApprox_tendsto_zero (dimH(W τ)→0 as τ→∞)"
+      "Family-level dimension shape (VERIFIED, from JB axiom): dimH_wellApprox_pos (0<dimH for τ≥2), dimH_wellApprox_lt_one (<1 for τ>2), dimH_wellApprox_strictAntitone (2≤σ<τ ⇒ strict drop), dimH_wellApprox_tendsto_zero (dimH(W τ)→0 as τ→∞)",
+      "LiouvilleTheoremOQ03.lean Part X — category (Baire) face (researcher-7, 2026-07-11, VERIFIED): wellApprox_residual (W τ ∈ residual ℝ, i.e. comeagre, for every τ — inherited from Mathlib eventually_residual_liouville via Filter.mem_of_superset since {Liouville}⊆W τ and residual is upward closed; AXIOM-FREE, strengthens wellApprox_dense), eventually_residual_wellApprox (Eventually restatement), meagre_compl_wellApprox ((W τ)ᶜ meagre via IsMeagre+compl_compl; AXIOM-FREE), and the capstone wellApprox_residual_and_volume_zero (τ>2: W τ comeagre AND Lebesgue-null — the classical category/measure dichotomy; uses dimH_wellApprox axiom via volume_wellApprox_eq_zero). #print axioms: first three [propext,Classical.choice,Quot.sound], dichotomy adds only dimH_wellApprox. File now 40 theorem-decls (558L), still 1 axiom."
     ],
     "insights": [
       "Mathlib's LiouvilleWith τ x IS membership in the τ-well-approximable set; .mono gives set antitonicity in the exponent for free.",
@@ -68,7 +69,7 @@
     "mathlib": []
   },
   "started": "2026-04-22T12:51:58.295Z",
-  "lastUpdate": "2026-07-08T00:00:00.000Z",
+  "lastUpdate": "2026-07-11T00:00:00.000Z",
   "significance": 7,
   "tractability": 4,
   "leanFiles": [
@@ -86,8 +87,8 @@
     {
       "path": "Proofs/LiouvilleTheoremOQ03.lean",
       "filename": "LiouvilleTheoremOQ03.lean",
-      "lineCount": 414,
-      "theoremCount": 25,
+      "lineCount": 558,
+      "theoremCount": 40,
       "axiomCount": 1,
       "defCount": 2,
       "sorryCount": 0,


### PR DESCRIPTION
## Summary

Adds **Part X**, the Baire-category face, to `LiouvilleTheoremOQ03.lean` — the complement to the file's existing measure / Hausdorff-dimension / cardinality / topology analyses of the well-approximable sets `W τ = {x | LiouvilleWith τ x}`.

Prior work showed each `W τ` (for `τ > 2`) is *metrically small*: Lebesgue-null and of sub-line Hausdorff dimension, while `wellApprox_dense` recorded it is topologically dense. The sharp topological statement is stronger:

- `wellApprox_residual` — `W τ ∈ residual ℝ`: each `W τ` is **comeagre** (contains a dense `Gδ`), for every exponent `τ`
- `eventually_residual_wellApprox` — the `Filter.Eventually` restatement
- `meagre_compl_wellApprox` — `(W τ)ᶜ` is **meagre**
- `wellApprox_residual_and_volume_zero` — for `τ > 2`, `W τ` is **simultaneously comeagre and Lebesgue-null**: the classical **category/measure dichotomy**

## Why this is honest / new

Comeagreness is inherited for free from Mathlib's `eventually_residual_liouville` (the Liouville numbers are residual) via `Filter.mem_of_superset`, since `{x | Liouville x} ⊆ W τ` and the residual filter is upward closed. This strictly strengthens the existing `wellApprox_dense` (`dense_of_mem_residual`). The category/measure coexistence is the textbook demonstration that Baire category and Lebesgue measure can disagree completely.

## Verification

`lean` v4.26.0 against prebuilt Mathlib oleans (no Docker):

```
'…wellApprox_residual'              depends on axioms: [propext, Classical.choice, Quot.sound]
'…eventually_residual_wellApprox'   depends on axioms: [propext, Classical.choice, Quot.sound]
'…meagre_compl_wellApprox'          depends on axioms: [propext, Classical.choice, Quot.sound]
'…wellApprox_residual_and_volume_zero' depends on axioms: [propext, Classical.choice,
                                          LiouvilleTheoremOQ03.dimH_wellApprox, Quot.sound]
```

The first three are fully axiom-free; the dichotomy capstone honestly carries the Jarník–Besicovitch axiom `dimH_wellApprox` (via `volume_wellApprox_eq_zero`). The file's axiom count is unchanged (1). 0 sorries, no `native_decide`. Meta (`liouville-theorem-oq-03.json`) updated with the knowledge entry and refreshed line/theorem counts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)