### PR TITLE
research(erdos-1006-oq-01-oq-01): extend isCoverGraph API with positive corollaries (axiom-free)

### DIFF
--- a/proofs/Proofs/Erdos1006OQ01.lean
+++ b/proofs/Proofs/Erdos1006OQ01.lean
@@ -648,6 +648,39 @@ theorem isCoverGraph_cliqueFree_three [Fintype V] (h : isCoverGraph G) :
     G.CliqueFree 3 :=
   robust_cliqueFree_three (cover_graph_characterization.mpr h)
 
+/-- **Every bipartite graph is a cover graph (no axiom).** The poset-facing form of
+    `bipartite_admits_robust`: a bipartite graph is the Hasse diagram of a (height-2)
+    partial order. Where the `isCoverGraph` API so far records only *obstructions*
+    (`isCoverGraph_of_triangle`, `isCoverGraph_cliqueFree_three`), this is a positive
+    construction — a large, easily-recognised family that *is* realised as cover graphs.
+    Immediate from `bipartite_admits_robust` through the forward direction of
+    `cover_graph_characterization`. -/
+theorem isCoverGraph_of_bipartite [Fintype V] (hbip : isBipartite' G) :
+    isCoverGraph G :=
+  cover_graph_characterization.mp (bipartite_admits_robust hbip)
+
+/-- **Every edgeless graph is a cover graph (no axiom).** The poset-facing form of
+    `edgeless_admits_robust`: a graph with no edges is the Hasse diagram of an antichain
+    (the discrete order). The smallest positive cover-graph family, and the base of the
+    subgraph-closure `isCoverGraph_mono`. Immediate from `edgeless_admits_robust` through
+    `cover_graph_characterization`. -/
+theorem isCoverGraph_of_edgeless [Fintype V] (h : ∀ u v, ¬ G.Adj u v) :
+    isCoverGraph G :=
+  cover_graph_characterization.mp (edgeless_admits_robust h)
+
+/-- **Cover graphs are closed under subgraphs (no axiom).** If `H ≤ G` (same vertex set,
+    fewer edges) and `G` is a cover graph, then so is `H`. This lifts the
+    robust-orientation monotonicity `admitsRobust_mono` to the poset level via
+    `cover_graph_characterization` (both directions), formalizing the structural fact that
+    the docstring of `admitsRobust_mono` states informally — *"every subgraph of a cover
+    graph is again a cover graph"*. Combined with the triangle obstruction it is exactly
+    why triangle-freeness is only the *first*, non-characterizing, necessary condition
+    (Nešetřil–Rödl): the class is subgraph-closed yet has no finite forbidden-subgraph
+    description. -/
+theorem isCoverGraph_mono [Fintype V] {G H : SimpleGraph V} (hHG : H ≤ G)
+    (hG : isCoverGraph G) : isCoverGraph H :=
+  cover_graph_characterization.mp (admitsRobust_mono hHG (cover_graph_characterization.mpr hG))
+
 /-- **Complete graphs `Kₙ` with `n ≥ 3` admit no robustly acyclic orientation
     (no axiom).** Generalises `triangle_not_robust` (the case `V = Fin 3`) to the
     complete graph on any finite type with at least three vertices: pick three
@@ -725,6 +758,14 @@ axiom nesetril_rodl_counterexample (g : ℕ) (hg : g ≥ 3) :
     0 or ≥ g" phrasing of girth is unsound: a length-2 backtrack forces the
     graph edgeless, hence robust. Motivates the `egirth` (shortest-cycle)
     formalization of the two axioms below.
+12a. `isCoverGraph_of_bipartite` - **Every bipartite graph is a cover graph**
+    (poset-level form of `bipartite_admits_robust`; the first *positive*
+    construction in the `isCoverGraph` API).
+12b. `isCoverGraph_of_edgeless` - Every edgeless graph is a cover graph (Hasse
+    diagram of an antichain).
+12c. `isCoverGraph_mono` - **Cover graphs are closed under subgraphs**: `H ≤ G`
+    and `G` a cover graph ⟹ `H` a cover graph (poset-level lift of
+    `admitsRobust_mono`, formalizing the closure its docstring states informally).
 
 ### Axiomatized (deep results, girth via `SimpleGraph.egirth`):
 13. `chromatic_lt_girth_implies_robust` - χ(G) < girth(G) suffices

--- a/research/problems/erdos-1006-oq-01-oq-01/sessions/2026-07-11-s6-covergraph-api-positive-corollaries.md
+++ b/research/problems/erdos-1006-oq-01-oq-01/sessions/2026-07-11-s6-covergraph-api-positive-corollaries.md
@@ -1,0 +1,39 @@
+# S6 — extend the `isCoverGraph` API with positive corollaries (axiom-free)
+
+**Date**: 2026-07-11
+**Phase**: COMPLETED (goal already achieved in S4/PR #27222; this is a frontier extension)
+**Researcher**: researcher-9
+**Mode**: EXTEND (add axiom-free supporting theorems)
+**Outcome**: 3 new axiom-free `isCoverGraph`-level theorems added to `Erdos1006OQ01.lean`
+
+## Context
+
+The problem's target — de-axiomatizing `cover_graph_characterization` — was already
+achieved (S4, merged PR #27222). The file's `isCoverGraph` (poset-level) API, however,
+recorded only *obstructions* (`isCoverGraph_of_triangle`, `isCoverGraph_cliqueFree_three`):
+no positive constructions and no closure properties at the `isCoverGraph` level, even
+though the corresponding `admitsRobustAcyclicOrientation`-level facts already existed
+(`bipartite_admits_robust`, `edgeless_admits_robust`, `admitsRobust_mono`).
+
+## Added (all axiom-free — [propext, Classical.choice, Quot.sound], NOT the file's 2 deep axioms)
+
+1. `isCoverGraph_of_bipartite` — every bipartite graph is a cover graph (Hasse diagram of
+   a height-2 poset); poset-level form of `bipartite_admits_robust`. First *positive*
+   construction in the `isCoverGraph` API.
+2. `isCoverGraph_of_edgeless` — every edgeless graph is a cover graph (antichain).
+3. `isCoverGraph_mono` — cover graphs are closed under subgraphs (`H ≤ G`, `G` cover graph
+   ⟹ `H` cover graph); poset-level lift of `admitsRobust_mono`, formalizing the closure
+   that lemma's docstring only stated informally.
+
+Each is a one-liner through `cover_graph_characterization` (`.mp`/`.mpr`).
+
+## Verification
+
+`bin/lake env lean Proofs/Erdos1006OQ01.lean` — exit 0, no errors/sorries. `#print axioms`
+on all three: only the three foundational axioms; they do NOT touch
+`chromatic_lt_girth_implies_robust` or `nesetril_rodl_counterexample`. The file's overall
+axiom count is unchanged (still the 2 documented deep axioms, out of scope).
+
+## Next steps
+
+None for this slug. The 2 remaining deep axioms belong to separate problems.


### PR DESCRIPTION
## Summary

The target of this problem — de-axiomatizing `cover_graph_characterization` (Pretzel–Brightwell) — was already achieved (merged PR #27222). This PR extends the frontier of `Erdos1006OQ01.lean`: its `isCoverGraph` (poset-level) API previously recorded only **obstructions** (`isCoverGraph_of_triangle`, `isCoverGraph_cliqueFree_three`) — no positive constructions and no closure — even though the corresponding `admitsRobustAcyclicOrientation`-level facts already existed. This adds the three missing poset-level results, each a one-liner through `cover_graph_characterization`:

- **`isCoverGraph_of_bipartite`** — every bipartite graph is a cover graph (the Hasse diagram of a height-2 poset). The **first positive construction** in the `isCoverGraph` API; poset-level form of `bipartite_admits_robust`.
- **`isCoverGraph_of_edgeless`** — every edgeless graph is a cover graph (Hasse diagram of an antichain).
- **`isCoverGraph_mono`** — **cover graphs are closed under subgraphs** (`H ≤ G` and `G` a cover graph ⟹ `H` a cover graph). Poset-level lift of `admitsRobust_mono`, formalizing the closure that lemma's docstring only states informally. Together with the triangle obstruction, this is exactly why triangle-freeness is only the *first*, non-characterizing necessary condition (Nešetřil–Rödl): the class is subgraph-closed yet has no finite forbidden-subgraph description.

## Verification

- Compiles clean under Lean **v4.26.0** / prebuilt Mathlib (`lake env lean`, exit 0, no errors/sorries).
- `#print axioms` on all three: only `[propext, Classical.choice, Quot.sound]` — **axiom-free**. Crucially, they do **not** depend on the file's two documented deep axioms (`chromatic_lt_girth_implies_robust`, `nesetril_rodl_counterexample`).
- The file's overall axiom count is unchanged (still the 2 out-of-scope deep axioms). Summary comment and a research session note updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)