### PR TITLE
research(binary-gcd-oq-01-oq-04-oq-03): general-base successor recurrence + monotonicity [VERIFIED axiom-free]

### DIFF
--- a/proofs/Proofs/BinaryGcdOQ01OQ04OQ03.lean
+++ b/proofs/Proofs/BinaryGcdOQ01OQ04OQ03.lean
@@ -788,4 +788,30 @@ theorem avgSteps_one_unbounded (M : ℚ) :
   have hMn : M < (n : ℚ) - 1 := by linarith
   linarith
 
+/-- **Successor recurrence for the total step count (general base `a`).**  Extending the
+range from `[1, N]` to `[1, N+1]` adds exactly the single term `binaryGcdSteps a (N+1)`:
+
+    totalSteps a (N+1) = totalSteps a N + binaryGcdSteps a (N+1).
+
+The general-`a` companion of `totalSteps_one_succ` (which specialises the added term to
+`log₂(N+1) + 1` via `binaryGcdSteps_one_eq_log`). -/
+theorem totalSteps_succ (a N : ℕ) :
+    totalSteps a (N + 1) = totalSteps a N + binaryGcdSteps a (N + 1) := by
+  unfold totalSteps
+  rw [Finset.sum_Icc_succ_top (by omega : 1 ≤ N + 1)]
+
+/-- **Monotonicity of the total step count (general base `a`).**  For every fixed base
+`a`, the total step count `totalSteps a N = ∑_{b=1}^{N} binaryGcdSteps a b` is monotone in
+the range endpoint `N`: enlarging the range `[1, N]` only adds nonnegative summands.  The
+general-`a` companion of `totalSteps_one_mono` (which was stated only for `a = 1`). -/
+theorem totalSteps_mono (a : ℕ) : Monotone (totalSteps a) := by
+  intro M N hMN
+  unfold totalSteps
+  apply Finset.sum_le_sum_of_subset_of_nonneg
+  · intro b hb
+    rw [Finset.mem_Icc] at hb ⊢
+    omega
+  · intro b _ _
+    exact Nat.zero_le _
+
 end BinaryGcdOQ01OQ04OQ03


### PR DESCRIPTION
The binary-GCD average-steps file establishes the successor recurrence and monotonicity of `totalSteps` only for the base `a = 1`. This PR adds the **general-`a`** companions.

## New theorems (both axiom-free)

- **`totalSteps_succ`** — `totalSteps a (N+1) = totalSteps a N + binaryGcdSteps a (N+1)`. The general-`a` recurrence (the `a=1` case `totalSteps_one_succ` specialises the added term to `log₂(N+1)+1` via `binaryGcdSteps_one_eq_log`).
- **`totalSteps_mono`** — `Monotone (totalSteps a)` for every base `a`: enlarging the range `[1,N]` only adds nonnegative summands (`Finset.sum_le_sum_of_subset_of_nonneg`). Generalises `totalSteps_one_mono`.

## Verification

- Whole file re-verified local-lean (Lean v4.26.0 + pinned Mathlib oleans), **0 errors**.
- `#print axioms` for each new theorem = `[propext, Classical.choice, Quot.sound]` — axiom-free.
- No new axioms or sorries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
