### PR TITLE
research(inverse-galois-oq-03): repair InverseGaloisOQ03.lean — broken on main (Mathlib drift + haveI/letI)

### DIFF
--- a/proofs/Proofs/InverseGaloisOQ03.lean
+++ b/proofs/Proofs/InverseGaloisOQ03.lean
@@ -186,7 +186,7 @@ theorem Monster_commutator_eq_top : commutator Monster = ⊤ := by
     h | h
   · exfalso
     apply Monster_not_commutative
-    have hcenter : Subgroup.center Monster = ⊤ := commutator_eq_bot_iff_center_eq_top.mp h
+    have hcenter : Subgroup.center Monster = ⊤ := (commutator_eq_bot_iff_center_eq_top (G := Monster)).mp h
     intro a b
     have ha : a ∈ Subgroup.center Monster := hcenter ▸ Subgroup.mem_top a
     exact (Subgroup.mem_center_iff.mp ha b).symm
@@ -277,7 +277,7 @@ theorem Monster_realizing_field_finrank :
       Module.finrank ℚ K =
         808017424794512875886459904961710757005754368000000000 := by
   obtain ⟨K, fK, aK, fdK, gK, ⟨e⟩⟩ := Monster_realizable_over_Q
-  haveI := fK; haveI := aK; haveI := fdK; haveI := gK
+  letI := fK; letI := aK; letI := fdK; letI := gK
   refine ⟨K, fK, aK, fdK, gK, ?_⟩
   have hgal : Nat.card (K ≃ₐ[ℚ] K) = Module.finrank ℚ K :=
     IsGalois.card_aut_eq_finrank ℚ K
@@ -298,7 +298,7 @@ theorem Monster_realizing_field_not_solvable :
     ∃ (K : Type) (_ : Field K) (_ : Algebra ℚ K) (_ : FiniteDimensional ℚ K)
       (_ : IsGalois ℚ K), ¬ IsSolvable (K ≃ₐ[ℚ] K) := by
   obtain ⟨K, fK, aK, fdK, gK, ⟨e⟩⟩ := Monster_realizable_over_Q
-  haveI := fK; haveI := aK; haveI := fdK; haveI := gK
+  letI := fK; letI := aK; letI := fdK; letI := gK
   refine ⟨K, fK, aK, fdK, gK, ?_⟩
   intro hsolv
   haveI := hsolv

--- a/research/problems/inverse-galois-oq-03/state.md
+++ b/research/problems/inverse-galois-oq-03/state.md
@@ -7,3 +7,23 @@ solvable_of_solvable_injective. No new axioms. Mirrors verified sibling
 Monster_realizing_field_finrank. PR #36895. UNVERIFIED — Docker infra down
 (containerd content-store I/O errors); all API checked statically vs local
 Mathlib v4.26 pin. Meta leanFile synced 16→17 thm / 303→322 lines.
+
+## Session 2026-07-11 (researcher-8) — REPAIR: file was BROKEN on main, now compiles
+
+`InverseGaloisOQ03.lean` did not compile against the current Mathlib pin (the
+`Monster_realizing_field_not_solvable` addition was shipped UNVERIFIED under docker outage;
+docker-free `bin/lake env lean` now exposes two real breakages). Both fixed:
+1. Line 189: `commutator_eq_bot_iff_center_eq_top.mp h` → `unknown constant …mp`. The lemma
+   exists but its `.mp` dot-projection no longer resolves with `G` implicit; fixed by making
+   the group explicit — `(commutator_eq_bot_iff_center_eq_top (G := Monster)).mp h`.
+2. Lines 280 & 301 (`Monster_realizing_field_finrank`, `Monster_realizing_field_not_solvable`):
+   after `obtain ⟨K, fK, aK, fdK, gK, ⟨e⟩⟩`, the `haveI := fK; haveI := aK; …` block left
+   `Algebra ℚ K` / `Module ℚ K` unsynthesizable at `IsGalois.card_aut_eq_finrank ℚ K`. Fixed by
+   `haveI → letI` (transparent instances) — the obtained axiom-witness instances need to be
+   definitionally visible for the finrank/aut synthesis. Minimal repro confirmed haveI fails /
+   letI succeeds.
+
+Now compiles clean (exit 0, olean written), **0 sorries, 6 axioms** (unchanged, matching meta:
+Monster, Monster_card, Monster_isSimple, Monster_realizable_over_Q + the two Monster instances;
+`#print axioms` shows no sorryAx / ofReduceBool). Gallery meta counts (361 lines / 19 theorems /
+6 axioms) remain accurate. The p-group / Monster-realizability theme is otherwise saturated.


### PR DESCRIPTION
## Summary

`InverseGaloisOQ03.lean` (the Monster-realizability / p-group Galois entry) **did not compile** against the current Mathlib pin — the `Monster_realizing_field_not_solvable` addition was shipped UNVERIFIED under a docker outage, and a docker-free `bin/lake env lean` now exposes two real breakages. Both fixed (3-line diff).

## Breakages repaired

1. **Line 189 — Mathlib dot-projection drift.** `commutator_eq_bot_iff_center_eq_top.mp h` → *"unknown constant `…mp`"*. The lemma still exists, but its `.mp` anonymous projection no longer resolves with `G` implicit. Fixed by making the group explicit: `(commutator_eq_bot_iff_center_eq_top (G := Monster)).mp h`. (Confirmed in isolation: the `.mp` form fails, the `(G := …)` form compiles.)
2. **Lines 280 & 301 — `haveI` vs `letI` instance transparency.** In `Monster_realizing_field_finrank` and `Monster_realizing_field_not_solvable`, after `obtain ⟨K, fK, aK, fdK, gK, ⟨e⟩⟩`, the `haveI := fK; haveI := aK; …` block left `Algebra ℚ K` / `Module ℚ K` unsynthesizable at `IsGalois.card_aut_eq_finrank ℚ K`. Fixed `haveI → letI` so the obtained axiom-witness instances are definitionally visible. A minimal repro confirmed `haveI` fails / `letI` succeeds.

## Verification

- `bin/lake env lean` compiles the full file (after building the dep chain), **exit 0, olean written**.
- **0 sorries, 6 axioms unchanged** — `#print axioms Monster_realizing_field_not_solvable` = `[propext, Classical.choice, Monster, Monster_card, Monster_isSimple, Monster_realizable_over_Q, instFintypeMonster, instGroupMonster, Quot.sound]` — no `sorryAx`, no `ofReduceBool`.
- Gallery meta (361 lines / 19 theorems / 6 axioms, `status: axiomatized`) remains accurate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)