### PR TITLE
audit(erdos-887): refresh tracker after clean re-audit

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -17148,8 +17148,8 @@
     },
     "erdos-887": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T00:17:22Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-12T00:21:04Z",
       "result": "clean"
     },
     "erdos-888": {


### PR DESCRIPTION
## Gallery Integrity Audit

Round-robin re-audit of **erdos-887** (Erdős #887: Divisors in Short Intervals Near √n) plus a batch rescan of recently-changed Lean files.

### erdos-887 — CLEAN
| Check | meta.json | Lean source | Match |
|-------|-----------|-------------|-------|
| axiomCount | 5 | 5 (`erdos_rosenfeld_four_divisors`, `chan_perfect_square_bound`, `divisor_bound_epsilon`, `no_bound_for_large_alpha`, `bound_for_small_alpha`) | ✓ |
| sorries | 0 | 0 | ✓ |
| theoremCount | 3 | 3 | ✓ |
| status/badge | axiomatized / axiom | (5 axioms present) | ✓ |

### Batch rescan (30 recently-changed Lean files) — 0 mismatches
All axiom-bearers honestly `axiomatized` with matching counts (erdos-165=10, erdos-378=2, erdos-666/703/collatz=1). `RothTheoremOQ03` meta.axiomCount=2 vs leanFile.axiomCount=1 is the correct conservative reading (counts transitively-inherited `szemeredi_k_ge_4`). `Erdos1093ProblemOQ02` (native_decide×14) and `Erdos101OQ04` (1 sorry) are research variants with **no gallery meta** = out of scope.

Gallery status: 4800/4800 audited, 0 issues.

Tracker written with ascii-clean encoding (minimal 2-line diff) to avoid the `ensure_ascii=False` reformat noise.

---
Discovered during gallery integrity audit.