### PR TITLE
research(cauchy-schwarz-integral-oq-04): correct stale OBSERVE state — file complete & verified

### DIFF
--- a/research/problems/cauchy-schwarz-integral-oq-04/state.md
+++ b/research/problems/cauchy-schwarz-integral-oq-04/state.md
@@ -23,3 +23,14 @@ None.
 ## Next Action
 Read problem.md thoroughly and acquire full context.
 Then move to ORIENT phase to explore literature and related proofs.
+
+## Update (2026-07-11, researcher-8) — COMPLETED (state was stale-reset to OBSERVE)
+
+The phase block above is a stale re-initialization (0 attempts / "Read problem.md"); the work is
+in fact done and on main. `CauchySchwarzIntegralOQ04.lean` is 612 lines / 25 theorems /
+**0 axioms / 0 sorries**, re-verified docker-free this session (`bin/lake env lean -o`, exit 0,
+olean written). It includes the LITERAL standard-deviation uncertainty forms added in PR #37600
+(`robertson_std_form`, `heisenberg_std_form`, `heisenberg_canonical_std` — Δx·Δp ≥ ℏ/2 in genuine
+std-dev form, complementing the file's earlier variance/squared forms). No gallery meta tracks
+this research-only OQ04 file (the `cauchy-schwarz-integral` slug tracks the parent proof), so no
+meta resync is needed. Marking completed to stop the pool re-serving it on the stale OBSERVE state.


### PR DESCRIPTION
## Summary

The `cauchy-schwarz-integral-oq-04` research `state.md` had been stale-reset to the OBSERVE phase (0 attempts, "Read problem.md thoroughly"), which causes the claim pool to keep re-serving an already-finished problem. This PR records the true completed state.

## Findings

- `CauchySchwarzIntegralOQ04.lean` is **612 lines / 25 theorems / 0 axioms / 0 sorries**, re-verified docker-free this session (`bin/lake env lean -o`, exit 0, olean written).
- It includes the **literal standard-deviation uncertainty forms** added in PR #37600 — `robertson_std_form`, `heisenberg_std_form`, `heisenberg_canonical_std` (`Δx·Δp ≥ ℏ/2` in genuine std-dev form, complementing the file's earlier variance/squared forms).
- No gallery meta tracks this research-only OQ04 file (the `cauchy-schwarz-integral` slug tracks the parent proof), so no meta resync is needed.

State-only change; appends a completion note so the problem stops being re-served on its stale OBSERVE snapshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)