### PR TITLE
research(erdos-703-incomplete-01): T_L hierarchy endpoints (base case + universal ceiling)

### DIFF
--- a/proofs/Proofs/Erdos703Problem.lean
+++ b/proofs/Proofs/Erdos703Problem.lean
@@ -902,6 +902,44 @@ theorem T_L_le_T_of_mem {n r : ℕ} {L : Finset ℕ} (hr : r ∈ L) : T_L n L �
   rw [← T_L_singleton]
   exact T_L_antitone_forbidden (Finset.singleton_subset_iff.mpr hr)
 
+/--
+**Base case of the hierarchy: `T_L n ∅ = 2ⁿ`.** With no forbidden intersection sizes the
+`avoidsLIntersections ∅` constraint is vacuous (`avoidsLIntersections_empty`), so the
+extremal family is the *entire* power set `2^{[n]}`, of size `2ⁿ`. This anchors the top of
+the antitone `T_L` hierarchy: every `T_L n L` sits below this maximum. -/
+theorem T_L_empty (n : ℕ) : T_L n ∅ = 2 ^ n := by
+  unfold T_L
+  apply le_antisymm
+  · -- Every admissible family is a subfamily of `2^{[n]}`, so has at most `2ⁿ` members.
+    apply Finset.sup_le
+    intro F hF
+    rw [Finset.mem_filter, Finset.mem_powerset] at hF
+    calc F.card ≤ ((Finset.range n).powerset).card := Finset.card_le_card hF.1
+      _ = 2 ^ n := by rw [Finset.card_powerset, Finset.card_range]
+  · -- The full power set `2^{[n]}` is itself admissible and has exactly `2ⁿ` members.
+    have hmem : (Finset.range n).powerset ∈
+        ((Finset.range n).powerset.powerset).filter (avoidsLIntersections ∅) :=
+      Finset.mem_filter.mpr
+        ⟨Finset.mem_powerset.mpr (Finset.Subset.refl _), avoidsLIntersections_empty _⟩
+    calc (2 : ℕ) ^ n = ((Finset.range n).powerset).card := by
+            rw [Finset.card_powerset, Finset.card_range]
+      _ ≤ _ := Finset.le_sup hmem
+
+/--
+**Universal ceiling: `T_L n L ≤ 2ⁿ`.** No `L`-avoiding family can exceed the full power set.
+Immediate from antitonicity (`∅ ⊆ L`) and the base case `T_L_empty`. -/
+theorem T_L_le_two_pow (n : ℕ) (L : Finset ℕ) : T_L n L ≤ 2 ^ n :=
+  (T_L_antitone_forbidden (Finset.empty_subset L)).trans (le_of_eq (T_L_empty n))
+
+/--
+**The concrete extremal quantity is bounded by the ambient size: `T n r ≤ 2ⁿ`.** Every
+`r`-avoiding family is a subfamily of `2^{[n]}`. Recovered from `T_L_le_two_pow` through the
+singleton bridge `T_L_singleton`, giving a uniform trivial upper bound for every `r` that the
+deep Frankl–Rödl theorem (`frankl_rodl_1987`) then sharpens to `(2 − δ)ⁿ` in the middle range. -/
+theorem T_le_two_pow (n r : ℕ) : T n r ≤ 2 ^ n := by
+  rw [← T_L_singleton]
+  exact T_L_le_two_pow n {r}
+
 /-
 ## Part VIII: Summary
 -/

--- a/src/data/proofs/erdos-703/meta.json
+++ b/src/data/proofs/erdos-703/meta.json
@@ -52,13 +52,14 @@
       "Structural lemmas on T: T_le_pow (T(n,r) ≤ 2^n), T_mono_ground (monotone in the ground-set size n), one_le_T (positivity), and full_powerset_avoids_r_of_lt / T_eq_pow_of_lt (T(n,r) = 2^n whenever n < r); plus largeSetsFamily_subset_franklFurediOdd_one linking Frankl's r=1 family into the general Frankl-Füredi construction.",
       "T_le_pow_sub_choose / T_le_pow_sub_one: sharpened upper bound T(n,r) ≤ 2^n − C(n,r), machine-checked. An r-avoiding family can contain no set of size exactly r (its self-pair A,A meets in |A| = r), so the family omits all C(n,r) subsets of size r, giving T(n,r) ≤ 2^n − C(n,r); for r ≤ n this yields the uniform strict improvement T(n,r) ≤ 2^n − 1 over the trivial ceiling, and it is tight at the diagonal r = n (C(n,n) = 1 recovers T(n,n) = 2^n − 1).",
       "smallSetsFamily / smallSetsFamily_avoids_r / smallSetsFamily_card / sum_choose_le_T / n_add_one_le_T_n_2: the 'small' disjunct {A ⊆ [n] : |A| < r} of the Frankl–Füredi families, isolated as its own r-avoiding family (|A ∩ B| ≤ |A| < r). It admits an EXACT binomial-sum cardinality ∑_{k<r} C(n,k) (proved by partitioning into powersetCard k layers), giving the first certified POLYNOMIAL lower bound T(n,r) ≥ ∑_{k<r} C(n,k) for all n,r — specialising to T(n,2) ≥ n+1, a nontrivial bound on the r=2 line at the start of the middle range the Frankl–Rödl question concerns. Axiom-free ([propext, Classical.choice, Quot.sound]).",
-      "T_L(n,L) + T_L_singleton / T_L_antitone_forbidden / T_L_insert_le / T_L_le_T_of_mem: the Frankl–Wilson L-avoiding analogue of the extremal quantity T — T_L(n,L) is the max size of a family avoiding EVERY intersection size in L. It faithfully generalizes T (T_L n {r} = T n r), is antitone in the forbidden-size set (L ⊆ L' ⟹ T_L n L' ≤ T_L n L, via Finset.sup_mono), and is bounded by any single-size extremal it forbids (r ∈ L ⟹ T_L n L ≤ T n r), tying the L-avoiding hierarchy back to the concrete T(n,r) values. Axiom-free ([propext, Classical.choice, Quot.sound])."
+      "T_L(n,L) + T_L_singleton / T_L_antitone_forbidden / T_L_insert_le / T_L_le_T_of_mem: the Frankl–Wilson L-avoiding analogue of the extremal quantity T — T_L(n,L) is the max size of a family avoiding EVERY intersection size in L. It faithfully generalizes T (T_L n {r} = T n r), is antitone in the forbidden-size set (L ⊆ L' ⟹ T_L n L' ≤ T_L n L, via Finset.sup_mono), and is bounded by any single-size extremal it forbids (r ∈ L ⟹ T_L n L ≤ T n r), tying the L-avoiding hierarchy back to the concrete T(n,r) values. Axiom-free ([propext, Classical.choice, Quot.sound]).",
+      "Frankl–Wilson T_L hierarchy endpoints: T_L_empty (T_L n ∅ = 2ⁿ — with no forbidden intersection sizes the whole power set 2^{[n]} is admissible, anchoring the top of the antitone hierarchy), T_L_le_two_pow (T_L n L ≤ 2ⁿ for every forbidden-size set L, the universal ceiling), and T_le_two_pow (T n r ≤ 2ⁿ via the singleton bridge — the uniform trivial upper bound that Frankl–Rödl sharpens to (2−δ)ⁿ). All three axiom-free."
     ],
     "axiomCount": 1,
-    "lineCount": 938,
+    "lineCount": 976,
     "assumptions": "1 axiom: frankl_rodl_1987 (the deep Frankl–Rödl 1987 exponential bound — the affirmative answer to the main question). 0 sorries: the trivial case T(n,0)=2^{n-1} is fully machine-checked (#print axioms T_n_0 = [propext, Classical.choice, Quot.sound]) via a complement-pairing upper bound and a star-family witness. The unused opaque chromaticNumber axiom was removed; the geometric chromatic-number consequence is recorded as prose only since infinite unit-distance chromatic numbers are not yet in Mathlib.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 41,
+    "theoremCount": 44,
     "definitionCount": 10
   },
   "crossReferences": [
@@ -185,9 +186,9 @@
       "Finset"
     ],
     "namespace": "Erdos703",
-    "lineCount": 938,
+    "lineCount": 976,
     "axiomCount": 1,
-    "theoremCount": 41,
+    "theoremCount": 44,
     "definitionCount": 10,
     "path": "Proofs/Erdos703Problem.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

Rounds out the **Frankl–Wilson `L`-avoiding hierarchy** (Part VII of `Erdos703Problem.lean`, Erdős #703 — forbidden `r`-intersection families). The hierarchy `T_L(n, L)` had antitone / insert / singleton lemmas and the lower tie `T_L_le_T_of_mem`, but neither of its two extreme values was recorded. This PR supplies both endpoints (all **axiom-free**).

## New theorems (3)

- **`T_L_empty : T_L n ∅ = 2ⁿ`** — with no forbidden intersection sizes the `avoidsLIntersections ∅` constraint is vacuous, so the extremal family is the *entire* power set `2^{[n]}` (size `2ⁿ`). Anchors the top of the antitone hierarchy. Proof: `Finset.sup_le` (every admissible family ⊆ `2^{[n]}`) for the upper bound; `Finset.le_sup` at the witness `(range n).powerset` for the lower.
- **`T_L_le_two_pow : T_L n L ≤ 2ⁿ`** — universal ceiling for every forbidden-size set `L`, from antitonicity (`∅ ⊆ L`) plus `T_L_empty`.
- **`T_le_two_pow : T n r ≤ 2ⁿ`** — the uniform trivial upper bound on the concrete extremal quantity `T(n,r)`, recovered through the singleton bridge `T_L_singleton`. This is exactly what the deep Frankl–Rödl theorem (`frankl_rodl_1987`) sharpens to `(2 − δ)ⁿ` in the middle range.

## Verification

- Compiled with `lake env lean` (Mathlib 4.26.0), exit 0.
- New lemmas depend only on `[propext, Classical.choice, Quot.sound]` — **axiom-free**; the file's one deep axiom `frankl_rodl_1987` is untouched, so `axiomCount` stays `1`.
- `theoremCount` 41 → 44; `lineCount` 938 → 976; gallery `erdos-703` meta synced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)