### PR TITLE
research(erdos-1039-incomplete-01): sublevel set has positive area [VERIFIED axiom-free]

### DIFF
--- a/proofs/Proofs/Erdos1039Problem.lean
+++ b/proofs/Proofs/Erdos1039Problem.lean
@@ -759,4 +759,17 @@ polynomials with roots in the unit disc.
 **Status**: OPEN - the gap between 1/(n√log n) and 1/n remains.
 -/
 
+/-- **The sublevel set has positive area.**  For a positive-degree polynomial the
+sublevel set `{z : |f(z)| < 1}` is open (`sublevelSet_isOpen`), nonempty
+(`sublevelSet_nonempty` — it contains every root) and bounded (`sublevelSet_isBounded`),
+so its Lebesgue area is strictly positive and finite: `0 < sublevelArea f`.  The positive
+counterpart of the boundedness ceiling, and the reason the inscribed-disc problem is
+non-degenerate (`sublevelArea` is a genuine positive real, not `0` or `∞`). -/
+theorem sublevelArea_pos (hf : 0 < f.degree) : 0 < sublevelArea f := by
+  unfold sublevelArea
+  have hpos : 0 < volume (sublevelSet f) :=
+    (sublevelSet_isOpen f).measure_pos volume (sublevelSet_nonempty f hf)
+  have hlt : volume (sublevelSet f) < ⊤ := (sublevelSet_isBounded f hf).measure_lt_top
+  exact ENNReal.toReal_pos hpos.ne' hlt.ne
+
 end Erdos1039


### PR DESCRIPTION
The inscribed-disc formalization of Erdős #1039 bounds the sublevel set (`sublevelSet_isBounded`, `rho_le_two`) but never records that its **area is positive**. This PR adds it — an axiom-free lemma with no dependence on the deep analytic axioms (`pommerenke_lower`, `klr_lower`, …).

## New theorem (axiom-free)

- **`sublevelArea_pos`** — `0 < sublevelArea f` for positive-degree `f`. The sublevel set `{z : |f(z)| < 1}` is open (`sublevelSet_isOpen`) + nonempty (`sublevelSet_nonempty`, it contains every root) + bounded (`sublevelSet_isBounded`), so its Lebesgue area is strictly positive and finite (`IsOpen.measure_pos` + `IsBounded.measure_lt_top` + `ENNReal.toReal_pos`). The positive counterpart of the boundedness ceiling: the inscribed-disc problem is non-degenerate — `sublevelArea` is a genuine positive real, not `0` or `∞`.

## Verification

- Whole file re-verified local-lean (Lean v4.26.0 + pinned Mathlib oleans), **0 errors**.
- `#print axioms sublevelArea_pos` = `[propext, Classical.choice, Quot.sound]` — axiom-free (does not pull in the problem's analytic axioms).
- No new axioms or sorries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
