### PR TITLE
Enrich banach-fixed-point-oq-01-oq-02-oq-01: target-independent contraction constant insight

### DIFF
--- a/src/data/proofs/banach-fixed-point-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/banach-fixed-point-oq-01-oq-02-oq-01/meta.json
@@ -79,7 +79,8 @@
       "**The inverse is an algorithm, not just an existence theorem.** Inverting id + g is the contraction T_y x = y − g x; its iterates are the successive approximations and their limit is f⁻¹ y, so the abstract fixed point of the parent becomes a runnable iteration with certified accuracy.",
       "**A priori and a posteriori bounds answer different questions.** The a priori bound kⁿ/(1−k) fixes the iteration count in advance from the first step; the a posteriori bound ‖xₙ − xₙ₊₁‖/(1−k) is a computable stopping criterion measured during the run. Both are exposed.",
       "**Uniqueness comes free from the contraction.** Because T_y has a unique fixed point, the inverse is the only solution of x + g x = y — recovering injectivity of id + g from the iterative side, complementing the parent's antilipschitz argument.",
-      "**Seed at the target for the cleanest constant.** Starting the iteration at x₀ = y makes the first increment exactly ‖g y‖, so the error after n steps is ‖g y‖·kⁿ/(1−k) — a bound depending only on the data g, y and the contraction constant."
+      "**Seed at the target for the cleanest constant.** Starting the iteration at x₀ = y makes the first increment exactly ‖g y‖, so the error after n steps is ‖g y‖·kⁿ/(1−k) — a bound depending only on the data g, y and the contraction constant.",
+      "**The contraction constant is independent of the target y.** T_y = (translate by y) ∘ (−g) differs from −g only by a constant shift, so ‖T_y a − T_y b‖ = ‖g a − g b‖ ≤ k‖a − b‖ with the *same* k for every right-hand side y. One modulus therefore governs the whole inverse family at once: it explains why the parent's f⁻¹ is uniformly (1−k)⁻¹-Lipschitz across all y, and why the Picard rate kⁿ and both error bounds hold with a y-independent constant — the target only relocates the fixed point, never the speed of convergence."
     ],
     "exampleSections": [
       {


### PR DESCRIPTION
Enrichment pass for the explicit-Picard-inverse entry (quality 98 → 100).

The entry was already rich (full section coverage, full annotations, 4 keyInsights). The one scorer gap was keyInsights (4 → needs 5). Added a genuine, distinct insight rather than padding:

- **The contraction constant is independent of the target y.** `T_y = (translate by y) ∘ (−g)` differs from `−g` only by a constant shift, so its Lipschitz constant is exactly `k` for every right-hand side `y`. A single modulus governs the whole inverse family — which is *why* the parent's `f⁻¹` is uniformly `(1−k)⁻¹`-Lipschitz across all `y`, and why the Picard rate `kⁿ` and both a priori/a posteriori error bounds hold with a `y`-independent constant. The target relocates the fixed point but never the convergence speed.

No content deleted; meta.json 16.6 KB → 17.2 KB (well under the 60 KB cap). JSON validates and the quality heuristic now reports 100.