### PR TITLE
research(erdos-659-incomplete-01): ramified prime + power/square closure for Q = x²+2y²

### DIFF
--- a/proofs/Proofs/Erdos659OQ05.lean
+++ b/proofs/Proofs/Erdos659OQ05.lean
@@ -109,6 +109,25 @@ theorem Q_eq_one_iff (x y : ℤ) : Q x y = 1 ↔ (x = 1 ∨ x = -1) ∧ y = 0 :=
     · exact ⟨Or.inr (by linarith), hy⟩
   · rintro ⟨hx | hx, rfl⟩ <;> subst hx <;> norm_num
 
+/-- **The ramified prime: norm-`2` vectors are `(0, ±1)`.**
+    `Q x y = 2 ↔ x = 0 ∧ (y = 1 ∨ y = -1)`.  Since `x² ≤ 2` and `2y² ≤ 2` bound both
+    coordinates to `{-1, 0, 1}`, the only lattice vectors at squared distance `2` from the
+    origin are `(0, ±1)` — i.e. `±√-2`.  This is the statement that `2` is the *ramified*
+    prime of `ℤ[√-2]`: `2 = Zsqrtd.norm (√-2)` has an essentially unique representation
+    (up to the units `±1` of `Q_eq_one_iff`), completing the analysis of the smallest norm
+    values `{0, 1, 2}` alongside `Q_eq_zero_iff` and `Q_eq_one_iff`. -/
+theorem Q_eq_two_iff (x y : ℤ) : Q x y = 2 ↔ x = 0 ∧ (y = 1 ∨ y = -1) := by
+  unfold Q
+  constructor
+  · intro h
+    have hyb : -1 ≤ y ∧ y ≤ 1 := ⟨by nlinarith [sq_nonneg x, sq_nonneg (y + 1)],
+                                   by nlinarith [sq_nonneg x, sq_nonneg (y - 1)]⟩
+    have hxb : -1 ≤ x ∧ x ≤ 1 := ⟨by nlinarith [sq_nonneg y, sq_nonneg (x + 1)],
+                                   by nlinarith [sq_nonneg y, sq_nonneg (x - 1)]⟩
+    obtain ⟨hy1, hy2⟩ := hyb; obtain ⟨hx1, hx2⟩ := hxb
+    interval_cases x <;> interval_cases y <;> simp_all
+  · rintro ⟨rfl, rfl | rfl⟩ <;> norm_num
+
 /-- **Strict positivity off the origin.**  Every nonzero lattice vector sits at a
     strictly positive squared distance from the origin: `Q x y > 0` whenever
     `(x, y) ≠ (0, 0)`.  A direct consequence of `isRepresented_nonneg` and the
@@ -159,6 +178,21 @@ theorem isRepresented_prod {ι : Type*} (s : Finset ι) (f : ι → ℤ)
     (hf : ∀ i ∈ s, IsRepresented (f i)) : IsRepresented (∏ i ∈ s, f i) :=
   Finset.prod_induction f IsRepresented (fun _ _ => isRepresented_mul)
     isRepresented_one hf
+
+/-- **Closure under powers.**  If `n` is represented then so is every power `nᵏ` — the
+    represented integers form a submonoid, so `Submonoid.pow_mem` applies.  Combined with
+    multiplicativity this shows the distance spectrum of the lattice is closed under the full
+    multiplicative structure, not merely single products. -/
+theorem isRepresented_pow {n : ℤ} (hn : IsRepresented n) (k : ℕ) : IsRepresented (n ^ k) :=
+  representedSubmonoid.pow_mem hn k
+
+/-- **Every perfect square is represented.**  `n = r²` is `Q r 0 = r² + 2·0²`, so the squares
+    (in particular every `Q x 0`) lie in the represented set.  This pins the "degenerate
+    `y = 0`" slice of the form and shows the represented integers contain all of `{r² : r ∈ ℤ}`
+    — the norms of the rational-integer sublattice `ℤ ⊆ ℤ[√-2]`. -/
+theorem isRepresented_of_isSquare {n : ℤ} (hn : IsSquare n) : IsRepresented n := by
+  obtain ⟨r, rfl⟩ := hn
+  exact ⟨r, 0, by unfold Q; ring⟩
 
 /-- The Moree–Osburn lattice point attached to integer coordinates `(x, y)`:
 the point `(x, y·√2) ∈ ℝ²`. -/

--- a/src/data/proofs/erdos-659-oq-05/meta.json
+++ b/src/data/proofs/erdos-659-oq-05/meta.json
@@ -32,19 +32,21 @@
       "isRepresented_mul + representedSubmonoid: represented integers are closed under × (submonoid of ℤ)",
       "isRepresented_prod: closure under arbitrary finite products",
       "isRepresented_nonneg: represented integers are nonnegative (valid squared distances)",
-      "dist_sq_lattice: squared distance between lattice points (x,y√2) equals Q of coordinate differences — ties the number theory to the actual Moree–Osburn geometry"
+      "dist_sq_lattice: squared distance between lattice points (x,y√2) equals Q of coordinate differences — ties the number theory to the actual Moree–Osburn geometry",
+      "Small-norm value analysis extended to the ramified prime: Q_eq_two_iff (Q x y = 2 ↔ x = 0 ∧ (y = 1 ∨ y = -1) — the norm-2 vectors ±√-2, unique up to units), completing the {0,1,2} value characterisation alongside Q_eq_zero_iff and Q_eq_one_iff.",
+      "Multiplicative-structure corollaries: isRepresented_pow (represented integers closed under powers via Submonoid.pow_mem) and isRepresented_of_isSquare (every perfect square r² = Q r 0 is represented — the norms of the ℤ ⊆ ℤ[√-2] sublattice). All axiom-free."
     ],
-    "lineCount": 191,
-    "theoremCount": 10,
+    "lineCount": 225,
+    "theoremCount": 17,
     "definitionCount": 4
   },
   "leanFile": {
     "path": "Proofs/Erdos659OQ05.lean",
-    "lineCount": 191,
+    "lineCount": 225,
     "axiomCount": 0,
     "sorries": 0,
     "definitionCount": 4,
-    "theoremCount": 10
+    "theoremCount": 17
   },
   "overview": {
     "historicalContext": "Erdős's distinct-distances problem (1946) asks for the minimum number of distinct distances determined by n points in the plane; after seven decades it was essentially settled by Guth and Katz (2015), who proved the near-optimal lower bound Ω(n/log n). Problem #659 concerns a refined variant in which every 4-point subset is required to determine at least 3 distances (forbidding 'too-symmetric' quadruples), yet the whole configuration still realises remarkably few — O(n/√log n) — distinct distances. Pieter Moree and Robert Osburn exhibited such configurations in 'Two-dimensional lattices with few distances' (L'Enseignement Mathématique, 2006) by placing the points on the stretched lattice {(x, y√2) : x, y ∈ ℤ}. A squared distance in this lattice is an integer of the binary quadratic form Q(x,y)=x²+2y² — the norm form of the imaginary quadratic ring ℤ[√−2]. The asymptotic count of integers ≤ N represented by such a form is governed by Landau's 1908 density theorem (#{n ≤ N : n = x²+2y²} ~ C·N/√log N), the same analytic machinery Landau used for sums of two squares with the Landau–Ramanujan constant. The multiplicative structure that makes the represented set so thin goes back much further still: Brahmagupta's identity (Brāhmasphuṭasiddhānta, 628 CE) shows that the values of x²+Ny² are closed under multiplication.",


### PR DESCRIPTION
## Summary

Extends the axiom-free **ℤ[√-2] representability layer** of Erdős #659 (`Erdos659OQ05.lean`), the algebraic engine behind the Moree–Osburn few-distances lattice (squared distances are values of the norm form `Q(x,y) = x² + 2y²`). The file characterised the norm values `0` (`Q_eq_zero_iff`, anisotropy) and `1` (`Q_eq_one_iff`, the units `±1`) but stopped there.

## New theorems (3, all axiom-free)

- **`Q_eq_two_iff : Q x y = 2 ↔ x = 0 ∧ (y = 1 ∨ y = -1)`** — the **ramified prime** `2 = Zsqrtd.norm (√-2)`, with an essentially unique representation up to units. Completes the small-norm value analysis `{0, 1, 2}` alongside `Q_eq_zero_iff`/`Q_eq_one_iff`. Proof bounds both coordinates to `{-1,0,1}` via `nlinarith` then finishes by `interval_cases`.
- **`isRepresented_pow`** — the represented integers are closed under powers (`Submonoid.pow_mem` on the existing `representedSubmonoid`), upgrading single-product closure to the full multiplicative structure.
- **`isRepresented_of_isSquare`** — every perfect square `r² = Q r 0` is represented: the norms of the rational-integer sublattice `ℤ ⊆ ℤ[√-2]`.

## Verification

- Compiled with `lake env lean` (Mathlib 4.26.0), exit 0.
- `#print axioms` on all three: only `[propext, Classical.choice, Quot.sound]` — **axiom-free**; file `axiomCount` stays `0`. The deep Landau density result (the genuinely open part of oq-05) is untouched.
- Also resyncs a **stale meta count**: `theoremCount` 10 → 17 (the source had drifted ahead of the metadata; my 3 additions account for part, the rest corrects prior drift), `lineCount` 191 → 225.

🤖 Generated with [Claude Code](https://claude.com/claude-code)