### PR TITLE
Enrich Quadratic Convergence of the AGM: full-file section coverage

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-04-oq-04/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-04-oq-04/meta.json
@@ -82,6 +82,14 @@
   },
   "sections": [
     {
+      "id": "preamble",
+      "title": "Preamble: statement of the quadratic-convergence problem",
+      "startLine": 1,
+      "endLine": 35,
+      "summary": "Module docstring framing OQ-04: the AGM iteration aₙ₊₁=(aₙ+bₙ)/2, bₙ₊₁=√(aₙbₙ) converges quadratically, so the gap aₙ−bₙ contracts doubly exponentially like (b/a)^{2ⁿ}. States the two ingredients formalized below (per-step gap-squaring identity and abstract recursion-to-rate lemma) and records the 0-axiom provenance.",
+      "mathContext": "Goal: the AGM gap satisfies aₙ − bₙ = O(M·(b/a)^{2ⁿ}) — doubly exponential, not merely geometric, decay."
+    },
+    {
       "id": "gap-identity",
       "title": "Section I: The One-Step Gap Squares",
       "startLine": 36,


### PR DESCRIPTION
## Enrichment pass — amgm-inequality-oq-04-oq-04

This entry was already high quality (quality 96, 12 KB, all minimum targets met, well under all size caps). Single targeted coverage improvement, no inflation.

**Change:** The `sections` array covered lines 36–98 but omitted the 35-line module docstring that states the OQ-04 problem (doubly-exponential AGM convergence). Added a `preamble` section (lines 1–35) so sections now span the full 100-line Lean file, giving gallery readers a navigable entry point to the problem statement before the three proof sections.

**Verification:** JSON valid; gallery enrichment + search-index checks pass; the entry produces no annotation-validation errors. No content deleted; meta.json 12.3 → 12.9 KB (well under the 60 KB cap).