### PR TITLE
research(feuerbachs-theorem-oq-04): spherical model has diameter π + repair Antipode drift [VERIFIED axiom-free]

### DIFF
--- a/proofs/Proofs/FeuerbachsTheoremOQ04Antipode.lean
+++ b/proofs/Proofs/FeuerbachsTheoremOQ04Antipode.lean
@@ -14,11 +14,16 @@ Everything is built on the *merged* metric/circle API of `Proofs.FeuerbachsTheor
 
 ## What this file proves (0 axioms, 0 sorries)
 
-* `onSphere_neg` — the antipode of a model point is a model point (`‖−P‖ = ‖P‖`).
-* `scos_neg_right`, `scos_neg_left` — the spherical cosine flips sign under antipode
-  (`⟪P, −Q⟫ = −⟪P, Q⟫`), the algebraic source of the pole swap.
-* `sdist_antipode` — a model point and its antipode are at the maximal spherical distance
-  `π` (`arccos (−1)`).
+The core antipodal primitives `onSphere_neg`, `scos_neg_right` and `sdist_antipode`
+now live in the *merged* file `Proofs.FeuerbachsTheoremOQ04` (they were absorbed there
+alongside `sCircle_antipodal_center`); this file reuses them and supplies the
+remaining antipodal-symmetry layer:
+
+* `scos_neg_left` — the spherical cosine flips sign in the left slot under antipode
+  (`⟪−P, Q⟫ = −⟪P, Q⟫`), the companion of the merged `scos_neg_right`.
+* `scos_neg_neg` — negating *both* points preserves the spherical cosine.
+* `sdist_neg_neg` — the antipodal map is a spherical isometry
+  (`sdist (−P) (−Q) = sdist P Q`).
 * `sCircle_neg_centre` — the **two-pole identity** `sCircle O ρ = sCircle (−O) (π − ρ)`:
   a spherical circle is centred on either pole, with complementary angular radius.
 -/
@@ -31,16 +36,6 @@ open scoped RealInnerProductSpace
 
 variable {E : Type*} [NormedAddCommGroup E] [InnerProductSpace ℝ E]
 
-/-- The antipode of a model point is again a model point: negation preserves the unit norm. -/
-theorem onSphere_neg {P : E} (hP : OnSphere P) : OnSphere (-P) := by
-  unfold OnSphere at hP ⊢
-  rw [norm_neg]; exact hP
-
-/-- The spherical cosine flips sign in the right slot under the antipodal map: this is the
-algebraic engine behind the pole swap, since `cos (π − ρ) = −cos ρ` matches `⟪P, −O⟫`. -/
-theorem scos_neg_right (P Q : E) : scos P (-Q) = - scos P Q := by
-  unfold scos; rw [inner_neg_right]
-
 /-- The spherical cosine flips sign in the left slot under the antipodal map. -/
 theorem scos_neg_left (P Q : E) : scos (-P) Q = - scos P Q := by
   unfold scos; rw [inner_neg_left]
@@ -51,13 +46,6 @@ the involution `P ↦ −P` is a symmetry of the spherical-cosine pairing.  The 
 of the individual slot-flip lemmas. -/
 theorem scos_neg_neg (P Q : E) : scos (-P) (-Q) = scos P Q := by
   rw [scos_neg_left, scos_neg_right, neg_neg]
-
-/-- **A model point and its antipode are at maximal spherical distance `π`.**  The inner
-product `⟪P, −P⟫ = −‖P‖² = −1`, and `arccos (−1) = π`. -/
-theorem sdist_antipode {P : E} (hP : OnSphere P) : sdist P (-P) = Real.pi := by
-  unfold sdist
-  rw [inner_neg_right, real_inner_self_eq_norm_sq, hP, one_pow]
-  exact Real.arccos_neg_one
 
 /-- **The antipodal map is a spherical isometry.**  Negating both points leaves the spherical
 distance unchanged: `sdist (−P) (−Q) = sdist P Q`.  Since `sdist = arccos ∘ ⟪·,·⟫` and the two

--- a/proofs/Proofs/FeuerbachsTheoremOQ04Diameter.lean
+++ b/proofs/Proofs/FeuerbachsTheoremOQ04Diameter.lean
@@ -1,0 +1,71 @@
+/-
+# Feuerbach's Theorem in Non-Euclidean Geometry (OQ-04): the spherical model has diameter π
+
+Companion to `Proofs.FeuerbachsTheoremOQ04Metric`, which packaged the spherical model
+`SphereModel E` (unit vectors of `E`) as a bundled `MetricSpace` with `dist = sdist` and
+recorded the pointwise bound `dist P Q ≤ π` (`SphereModel.dist_le_pi`).
+
+That bound is *sharp*: `dist P (−P) = π` for the antipode of any model point
+(`FeuerbachsTheoremOQ04.sdist_antipode`).  This file promotes the pointwise bound into the
+two metric-space statements it was aiming at, now expressed through Mathlib's `Bornology` /
+`Metric.diam` API on the bundled instance:
+
+* `SphereModel.antipode` — the antipodal involution `P ↦ −P` as a self-map of the model.
+* `SphereModel.dist_antipode` — `dist P (antipode P) = π`: the antipode realises the bound.
+* `SphereModel.isBounded_univ` — the whole spherical model is metrically bounded
+  (`Bornology.IsBounded Set.univ`), so it plugs into Mathlib's boundedness API.
+* `SphereModel.diam_le_pi` — `Metric.diam Set.univ ≤ π`.
+* `SphereModel.diam_univ_eq_pi` — for a nonempty model the diameter is *exactly* `π`
+  (the upper bound is attained at any antipodal pair), so the spherical model is a
+  bounded metric space of diameter `π`.
+
+Everything is `0`-axiom / `0`-sorry (`propext`/`Classical.choice`/`Quot.sound` only) on top
+of Mathlib and the sibling files.
+-/
+import Mathlib
+import Proofs.FeuerbachsTheoremOQ04Metric
+
+namespace FeuerbachsTheoremOQ04
+
+open scoped RealInnerProductSpace
+
+variable {E : Type*} [NormedAddCommGroup E] [InnerProductSpace ℝ E]
+
+namespace SphereModel
+
+/-- The **antipodal involution** of the spherical model: `P ↦ −P`, again a model point
+(`onSphere_neg`).  A point and its antipode are the diametrically opposite pair. -/
+def antipode (P : SphereModel E) : SphereModel E := ⟨-P.1, onSphere_neg P.2⟩
+
+/-- **The antipode realises the diameter bound.**  `dist P (antipode P) = π`: a model point
+and its antipode sit at the maximal spherical distance, so the bound `dist ≤ π`
+(`dist_le_pi`) is attained.  Directly `sdist_antipode`. -/
+@[simp] theorem dist_antipode (P : SphereModel E) : dist P (antipode P) = Real.pi := by
+  rw [dist_eq]; exact sdist_antipode P.2
+
+/-- **The spherical model is bounded.**  Every distance is at most `π`, so `Set.univ` is a
+`Bornology.IsBounded` set — the spherical model is a bounded metric space, usable with
+Mathlib's entire boundedness API. -/
+theorem isBounded_univ : Bornology.IsBounded (Set.univ : Set (SphereModel E)) :=
+  Metric.isBounded_iff.mpr ⟨Real.pi, fun x _ y _ => dist_le_pi x y⟩
+
+/-- **Diameter upper bound.**  `Metric.diam Set.univ ≤ π` for the spherical model. -/
+theorem diam_le_pi : Metric.diam (Set.univ : Set (SphereModel E)) ≤ Real.pi :=
+  Metric.diam_le_of_forall_dist_le Real.pi_nonneg (fun x _ y _ => dist_le_pi x y)
+
+/-- **The spherical model has diameter exactly `π`.**  For a nonempty model the upper bound
+`Metric.diam ≤ π` is attained — any point and its antipode are `π` apart — so the diameter of
+the whole spherical model equals `π`.  This is the metric-space form of the sharpness of
+`dist_le_pi`: the spherical model is a bounded metric space of diameter `π`, with the maximum
+realised at antipodal pairs. -/
+theorem diam_univ_eq_pi [Nonempty (SphereModel E)] :
+    Metric.diam (Set.univ : Set (SphereModel E)) = Real.pi := by
+  refine le_antisymm diam_le_pi ?_
+  obtain ⟨P⟩ := (inferInstance : Nonempty (SphereModel E))
+  calc Real.pi = dist P (antipode P) := (dist_antipode P).symm
+    _ ≤ Metric.diam (Set.univ : Set (SphereModel E)) :=
+        Metric.dist_le_diam_of_mem isBounded_univ (Set.mem_univ P) (Set.mem_univ _)
+
+end SphereModel
+
+end FeuerbachsTheoremOQ04


### PR DESCRIPTION
## Summary

Two changes to the OQ-04 spherical-geometry (non-Euclidean Feuerbach) chain.

### 1. Repair — `FeuerbachsTheoremOQ04Antipode.lean` no longer compiled

PR #37687 merged `onSphere_neg`, `scos_neg_right` and `sdist_antipode` into the foundational `FeuerbachsTheoremOQ04.lean` (alongside `sCircle_antipodal_center`), but left the `Antipode.lean` file with its own copies of those three lemmas. Since `Antipode.lean` imports the foundational file, this is a **duplicate-declaration error** (`'FeuerbachsTheoremOQ04.onSphere_neg' has already been declared`) — the file no longer builds on current `main`.

Fix: remove the 3 now-duplicated lemmas. `Antipode.lean` reuses the merged versions and retains its unique antipodal-symmetry layer: `scos_neg_left`, `scos_neg_neg`, `sdist_neg_neg`, `sCircle_neg_centre`. Compiles clean, 0-axiom.

### 2. New — `FeuerbachsTheoremOQ04Diameter.lean`

The `Metric` sibling packaged the spherical model as a bundled `MetricSpace` and recorded the pointwise bound `dist P Q ≤ π`. That bound is **sharp** (`dist P (−P) = π`). This file promotes it into metric-space statements via Mathlib's `Bornology` / `Metric.diam` API:

- `SphereModel.antipode` / `dist_antipode` — the antipodal involution, with `dist P (antipode P) = π` (the bound is attained);
- `SphereModel.isBounded_univ` — the model is `Bornology.IsBounded`;
- `SphereModel.diam_le_pi` — `Metric.diam Set.univ ≤ π`;
- `SphereModel.diam_univ_eq_pi` — for a nonempty model the diameter is **exactly** `π`.

## Verification

- Both files compile with `bin/lake env lean` against the prebuilt/rebuilt sibling oleans.
- **Axiom-free**: `#print axioms` on the new theorems and the repaired `Antipode` lemmas → `[propext, Classical.choice, Quot.sound]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)