### PR TITLE
research(liouville-theorem-oq-03): Liouville measure/category/dimension trichotomy [VERIFIED]

### DIFF
--- a/proofs/Proofs/LiouvilleTheoremOQ03.lean
+++ b/proofs/Proofs/LiouvilleTheoremOQ03.lean
@@ -555,4 +555,36 @@ theorem wellApprox_residual_and_volume_zero {τ : ℝ} (hτ : 2 < τ) :
     wellApprox τ ∈ residual ℝ ∧ volume (wellApprox τ) = 0 :=
   ⟨wellApprox_residual τ, volume_wellApprox_eq_zero hτ⟩
 
+/-- **The Liouville numbers are residual (comeagre).**  A named restatement of Mathlib's
+`eventually_residual_liouville` as set membership: `{x | Liouville x} ∈ residual ℝ`.  So the
+*topologically typical* real is Liouville — despite the Liouville set being both
+Hausdorff-dimension `0` (`dimH_liouville_eq_zero`) and Lebesgue-null
+(`volume_liouville_eq_zero`).  Axiom-free (pure Baire category). -/
+theorem liouville_residual : {x : ℝ | Liouville x} ∈ residual ℝ :=
+  eventually_residual_liouville
+
+/-- **The non-Liouville reals are meagre.**  `{x | Liouville x}ᶜ` is first category: the
+transcendence-generic (non-Liouville) reals form a meagre set, even though they are
+Lebesgue-conull and dimension-`1`.  Immediate from `liouville_residual`; axiom-free. -/
+theorem meagre_compl_liouville : IsMeagre {x : ℝ | Liouville x}ᶜ := by
+  rw [IsMeagre, compl_compl]; exact liouville_residual
+
+open MeasureTheory in
+/-- **The Liouville measure/category/dimension trichotomy.**  The set of Liouville numbers is
+*simultaneously* Hausdorff-dimension `0`, Lebesgue-null, and comeagre (residual):
+
+    dimH {x | Liouville x} = 0  ∧  volume {x | Liouville x} = 0  ∧  {x | Liouville x} ∈ residual ℝ.
+
+So both classical notions of "smallness" — dimension and measure — declare the Liouville set
+negligible, while Baire category declares it *generic*: the sharpest form of the
+measure-versus-category disagreement, now for the Liouville set itself (the file's
+`wellApprox_residual_and_volume_zero` states the two-way version for `W τ`, `τ > 2`).  The
+dimension component rests on the entry's Jarník–Besicovitch axiom (via
+`dimH_liouville_eq_zero`); the measure and category components are axiom-free. -/
+theorem liouville_dimzero_null_yet_residual :
+    dimH {x : ℝ | Liouville x} = 0 ∧
+      volume {x : ℝ | Liouville x} = 0 ∧
+      {x : ℝ | Liouville x} ∈ residual ℝ :=
+  ⟨dimH_liouville_eq_zero, volume_liouville_eq_zero, liouville_residual⟩
+
 end LiouvilleTheoremOQ03


### PR DESCRIPTION
The file states the measure-vs-category paradox only for the well-approximable sets `W τ` (`wellApprox_residual_and_volume_zero`). This PR adds the striking version for the **Liouville set itself**.

## New theorems

- **`liouville_residual`** — `{x | Liouville x} ∈ residual ℝ` (named restatement of Mathlib's `eventually_residual_liouville`). The *topologically typical* real is Liouville. **Axiom-free.**
- **`meagre_compl_liouville`** — the non-Liouville reals form a meagre (first-category) set, even though they are Lebesgue-conull and dimension-1. **Axiom-free.**
- **`liouville_dimzero_null_yet_residual`** — the full trichotomy `dimH = 0 ∧ volume = 0 ∧ residual`: the Liouville set is negligible in **both** Hausdorff dimension and Lebesgue measure, yet topologically **generic** — the sharpest form of the measure-versus-category disagreement.

## Axioms

- `liouville_residual` and `meagre_compl_liouville`: `[propext, Classical.choice, Quot.sound]` — axiom-free.
- `liouville_dimzero_null_yet_residual`: its dimension component rests on the entry's Jarník–Besicovitch axiom (`dimH_wellApprox`, via `dimH_liouville_eq_zero`) — as documented in the theorem's docstring; the measure and category components are axiom-free.

## Verification

- Whole file re-verified local-lean (Lean v4.26.0 + pinned Mathlib oleans), **0 errors**. No new axioms or sorries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
