### PR TITLE
research(erdos-490-incomplete-01): energy monotonicity + trivial upper bound [VERIFIED, +2 thm]

### DIFF
--- a/proofs/Proofs/Erdos490Problem.lean
+++ b/proofs/Proofs/Erdos490Problem.lean
@@ -764,6 +764,37 @@ theorem multiplicativeEnergy_comm (A B : Finset ℕ) :
   case right =>
     rintro ⟨⟨b₁, b₂⟩, ⟨a₁, a₂⟩⟩ _; rfl
 
+/-- **Multiplicative energy is monotone under subsets**: if `A' ⊆ A` and `B' ⊆ B` then
+`E(A', B') ≤ E(A, B)`.  Enlarging the two factor sets can only add coincidence
+quadruples: `(A' ×ˢ A') ×ˢ (B' ×ˢ B') ⊆ (A ×ˢ A) ×ˢ (B ×ˢ B)`, and the energy filter
+predicate `a₁·b₁ = a₂·b₂` is unchanged, so `Finset.filter_subset_filter` gives the
+inclusion of energy sets and `Finset.card_le_card` the bound.  This is the
+`multiplicativeEnergy` companion to `productSet_mono` and `HasDistinctProducts.subset`. -/
+theorem multiplicativeEnergy_mono {A A' B B' : Finset ℕ} (hA : A' ⊆ A) (hB : B' ⊆ B) :
+    multiplicativeEnergy A' B' ≤ multiplicativeEnergy A B := by
+  classical
+  unfold multiplicativeEnergy
+  apply Finset.card_le_card
+  apply Finset.filter_subset_filter
+  intro q hq
+  simp only [Finset.mem_product] at hq ⊢
+  obtain ⟨⟨ha1, ha2⟩, hb1, hb2⟩ := hq
+  exact ⟨⟨hA ha1, hA ha2⟩, hB hb1, hB hb2⟩
+
+/-- **Trivial upper bound on multiplicative energy**: `E(A, B) ≤ (|A|·|B|)²`.  The energy
+set is a `filter` of the full quadruple set `(A ×ˢ A) ×ˢ (B ×ˢ B)`, whose cardinality is
+`|A|²·|B|² = (|A||B|)²`, so the count of coincidences never exceeds it.  Together with the
+lower bound `multiplicativeEnergy_ge` (`|A||B| ≤ E`) this two-sidedly sandwiches the
+energy: `|A||B| ≤ E(A, B) ≤ (|A||B|)²`. -/
+theorem multiplicativeEnergy_le_sq (A B : Finset ℕ) :
+    multiplicativeEnergy A B ≤ (A.card * B.card) ^ 2 := by
+  classical
+  unfold multiplicativeEnergy
+  refine le_trans (Finset.card_filter_le _ _) ?_
+  rw [Finset.card_product, Finset.card_product, Finset.card_product]
+  apply le_of_eq
+  ring
+
 /-- **Strict energy excess characterizes product collisions.**  Combining the general
 lower bound `|A||B| ≤ E(A, B)` (`multiplicativeEnergy_ge`) with its equality case
 (`distinct_minimal_energy`): the energy *strictly* exceeds `|A||B|` exactly when the


### PR DESCRIPTION
## Summary

Extends `Erdos490Problem.lean` (Erdős #490, distinct products) with two axiom-free multiplicative-energy lemmas, completing the two-sided energy sandwich.

## New theorems

- **`multiplicativeEnergy_mono`** — `E(A',B') ≤ E(A,B)` for `A' ⊆ A`, `B' ⊆ B`. The energy companion to the existing `productSet_mono` / `HasDistinctProducts.subset`: enlarging the factor sets can only add coincidence quadruples, since `(A'×A')×(B'×B') ⊆ (A×A)×(B×B)` and the filter predicate is unchanged.
- **`multiplicativeEnergy_le_sq`** — `E(A,B) ≤ (|A||B|)²`. The trivial upper bound: the energy set is a `filter` of the `|A|²|B|²`-element quadruple set. Combined with the existing `multiplicativeEnergy_ge` (`|A||B| ≤ E`), this two-sidedly sandwiches the energy:
  ```
  |A||B| ≤ E(A,B) ≤ (|A||B|)²
  ```

## Verification

- Full file compiles clean under Lean v4.26.0 / Mathlib 4.26.0 (`bin/lake env lean`).
- Both new theorems verified **axiom-free**: `[propext, Classical.choice, Quot.sound]` — no dependency on the file's `szemeredi_theorem` axiom, no `sorryAx`, no `Lean.ofReduceBool`.
- File status unchanged: **0 sorries, 1 axiom** (`szemeredi_theorem`), theorem count 23 → 25.

🤖 Generated with [Claude Code](https://claude.com/claude-code)