### PR TITLE
research(tetrahedral-number-formula-oq-01): reverse discrete FTC (∑∘Δ telescoping), axiom-free

### DIFF
--- a/proofs/Proofs/TetrahedralNumberFormulaOQ01.lean
+++ b/proofs/Proofs/TetrahedralNumberFormulaOQ01.lean
@@ -526,6 +526,52 @@ theorem forwardDiff_simplexNumber (d n : ℕ) :
   simp only [forwardDiff]
   rw [simplexNumber_succ_succ, Nat.add_sub_cancel_left]
 
+/-- **Reverse discrete Fundamental Theorem of Calculus (summing a difference telescopes).**
+The running total of the forward differences of a *monotone* sequence recovers the
+sequence, up to the boundary value `f 0`:
+
+`∑_{j=0}^{n} Δf(j) + f 0 = f (n + 1)`,  i.e.  `partialSum (Δf) n = f(n+1) − f 0`.
+
+This is the antiderivative-of-derivative half of the discrete FTC — the exact converse of
+`forwardDiff_partialSum` (`Δ ∘ ∑ = shift`), completing the `∑ ↔ Δ` duality in *both*
+directions. Monotonicity makes every truncated `ℕ`-subtraction `Δf(j) = f(j+1) − f(j)`
+exact, so the alternating cancellation telescopes cleanly. Proved by induction on `n`,
+peeling the last summand with `Finset.sum_range_succ` and closing each step by `omega` from
+the two-point monotonicity `f(n+1) ≤ f(n+2)`. -/
+theorem partialSum_forwardDiff {f : ℕ → ℕ} (hf : Monotone f) (n : ℕ) :
+    partialSum (forwardDiff f) n + f 0 = f (n + 1) := by
+  induction n with
+  | zero =>
+    show (∑ j ∈ range 1, forwardDiff f j) + f 0 = f 1
+    rw [Finset.sum_range_one]
+    have h01 : f 0 ≤ f 1 := hf (Nat.le_succ 0)
+    have hd : forwardDiff f 0 = f 1 - f 0 := rfl
+    omega
+  | succ n ih =>
+    show (∑ j ∈ range (n + 1 + 1), forwardDiff f j) + f 0 = f (n + 1 + 1)
+    rw [Finset.sum_range_succ]
+    have hd : forwardDiff f (n + 1) = f (n + 1 + 1) - f (n + 1) := rfl
+    have hmono : f (n + 1) ≤ f (n + 1 + 1) := hf (Nat.le_succ (n + 1))
+    unfold partialSum at ih
+    omega
+
+/-- **Reverse discrete FTC on the figurate ladder.** Specialising `partialSum_forwardDiff`
+to the (size-monotone) simplex sequence `P_d`, whose boundary value is `P_d(0) = 1`:
+
+`partialSum (Δ P_d) n + 1 = P_d(n + 1)`.
+
+So summing the first differences of the `d`-dimensional ladder rebuilds it (offset by the
+constant `1 = P_d(0)`), the exact counterpart of `sum_simplex` (`∑ P_d = P_{d+1}`) read
+through the difference operator. -/
+theorem partialSum_forwardDiff_simplexNumber (d n : ℕ) :
+    partialSum (forwardDiff (simplexNumber d)) n + 1 = simplexNumber d (n + 1) := by
+  have h0 : simplexNumber d 0 = 1 := by
+    simp only [simplexNumber, Nat.zero_add, Nat.choose_self]
+  have hmono : Monotone (simplexNumber d) := fun _ _ h => simplexNumber_mono_size d h
+  have hkey := partialSum_forwardDiff hmono n
+  rw [h0] at hkey
+  exact hkey
+
 
 /-! ### Linearity of the discrete Cauchy transform
 

--- a/research/problems/tetrahedral-number-formula-oq-01/state.md
+++ b/research/problems/tetrahedral-number-formula-oq-01/state.md
@@ -6,6 +6,19 @@
 **Since**: 2026-07-09T16:49:44-07:00
 **Iteration**: 4
 
+## Iteration 5 (researcher-9, 2026-07-11) — reverse discrete FTC (∑∘Δ telescoping) [VERIFIED, axiom-free]
+The file had `Δ∘∑` in both single (`forwardDiff_partialSum`) and iterated
+(`iterForwardDiff_iterSum`) forms, but NOT the reverse `∑∘Δ` (the antiderivative-of-
+derivative half of the FTC). Added it (35→37 theorems):
+- `partialSum_forwardDiff` (general, monotone f): `∑_{j≤n} Δf(j) + f 0 = f(n+1)`, i.e.
+  `partialSum (Δf) n = f(n+1) − f 0`. Monotonicity makes each truncated ℕ-subtraction
+  exact so the telescoping cancels; induction + `Finset.sum_range_succ` + `omega`.
+- `partialSum_forwardDiff_simplexNumber`: the `P_d` specialisation, boundary `P_d(0)=1`,
+  giving `partialSum (Δ P_d) n + 1 = P_d(n+1)` — the difference-operator counterpart of
+  the hockey stick `sum_simplex`. Completes the ∑↔Δ duality in both directions.
+VERIFIED via `bin/lake env lean` EXIT 0; `#print axioms` → `[propext, Classical.choice,
+Quot.sound]` (no sorryAx/ofReduceBool).
+
 ## Iteration 4 (researcher-9, 2026-07-11) — forward-difference operator + FULL-FILE RE-VERIFICATION [VERIFIED, axiom-free]
 Infra recovered (disk 81Gi free). Re-ran the standing "re-verify once docker repaired"
 action via the fast host path `proofs/bin/lake env lean Proofs/TetrahedralNumberFormulaOQ01.lean`


### PR DESCRIPTION
## Summary

The figurate-number engine in `TetrahedralNumberFormulaOQ01.lean` already had the **difference-of-sum** direction of the discrete Fundamental Theorem of Calculus — `forwardDiff_partialSum` (`Δ ∘ ∑ = shift`) and its iterated form `iterForwardDiff_iterSum` (`Δ^a ∘ ∑^a = shift`) — but **not the reverse `∑ ∘ Δ`** (the antiderivative-of-derivative half: summing a difference telescopes). This adds it, closing the `∑ ↔ Δ` duality in both directions. All axiom-free.

- **`partialSum_forwardDiff`** (general, for monotone `f`): `∑_{j=0}^{n} Δf(j) + f 0 = f(n+1)`, equivalently `partialSum (Δf) n = f(n+1) − f 0`. Monotonicity makes every truncated `ℕ`-subtraction `Δf(j) = f(j+1) − f(j)` exact, so the alternating cancellation telescopes cleanly. Induction on `n` + `Finset.sum_range_succ` + `omega`.
- **`partialSum_forwardDiff_simplexNumber`**: the figurate specialisation, with boundary value `P_d(0) = 1`, giving `partialSum (Δ P_d) n + 1 = P_d(n+1)` — the difference-operator counterpart of the hockey stick `sum_simplex` (`∑ P_d = P_{d+1}`).

## Verification

- Compiles clean under Lean **v4.26.0** / prebuilt Mathlib (`lake env lean`, exit 0, no errors/warnings).
- `#print axioms` on both new theorems: only `[propext, Classical.choice, Quot.sound]` — **axiom-free** (no `sorryAx`, no `Lean.ofReduceBool`).
- Research-only slug (no gallery `meta.json`); `state.md` updated with the iteration note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)