### PR TITLE
audit(erdos-885): clean — 20-file batch rescan, 0 mismatches

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -17136,8 +17136,8 @@
     },
     "erdos-885": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T00:17:22Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-12T00:32:14Z",
       "result": "clean"
     },
     "erdos-886": {


### PR DESCRIPTION
## Gallery Integrity Audit

Gallery **4800/4800 audited, 0 issues, 0 critical**.

### erdos-885 (round-robin target) — CLEAN
- 6 concrete membership theorems proved via anonymous constructors (e.g. `⟨3, 4, rfl, rfl⟩`), not True-stubs
- 0 axioms, 0 sorries, 0 native_decide
- meta `status`/`badge`/`axiomCount` = null (conservative — the open Erdős–Rosenfeld conjecture is stated only in docstrings; no verified claim). No overclaim.

### Batch rescan of 20 recently-changed Lean files — 0 mismatches
All 11 changed files with gallery metas have source axiom/sorry counts matching `meta.leanFile` exactly:

| slug | meta.leanFile.ax | source ax |
|------|-----|-----|
| erdos-887 | 5 | 5 |
| erdos-1018 | 2 | 2 |
| erdos-771 | 2 | 2 |
| erdos-744 | 1 | 1 |
| liouville-theorem-oq-03 | 1 | 1 |
| brouwer-fixed-point-oq-02-oq-02-oq-01, elementary-quadratic-reciprocity-oq-03-oq-02, erdos-1138-oq-03-oq-01, erdos-771-construction, erdos-897-oq-01, lagrange-theorem-oq-01, roth-theorem-oq-01 | 0 | 0 |

All have conservative null `status`/`badge` and `sorries=0` matching source.

`Erdos1093ProblemOQ02.lean` has 15 `native_decide` but **no gallery meta** (research variant, out of scope) — consistent with prior audits.

Minimal 2-line ascii-clean tracker refresh (avoids the 119-line unicode reformat noise from the `complete` script).