### PR TITLE
Enrich Classical AM-GM Inequality: full-file section coverage

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-05-oq-02-oq-01/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-05-oq-02-oq-01/meta.json
@@ -76,6 +76,13 @@
   ],
   "sections": [
     {
+      "id": "preamble",
+      "title": "Preamble: from weighted to classical AM-GM",
+      "startLine": 1,
+      "endLine": 39,
+      "summary": "Module docstring recalling the parent's weighted equality case ∏ xᵢ^{wᵢ} = ∑ wᵢxᵢ ↔ all xⱼ equal, and framing this entry's task (its first open question): specialise to equal weights wᵢ = 1/n and read off the classical statement (∏ xᵢ)^{1/n} ≤ (∑ xᵢ)/n, with equality iff the xᵢ coincide. Imports Mathlib and opens Real, Finset."
+    },
+    {
       "id": "engine",
       "title": "Self-contained weighted equality-case engine",
       "startLine": 40,


### PR DESCRIPTION
## Enrichment pass — amgm-inequality-oq-05-oq-02-oq-01

Already high quality (quality 96, 12 KB, all minimum targets met, well under all caps). Single targeted coverage improvement, no inflation.

**Change:** The `sections` array covered lines 40–164 but omitted the 39-line module docstring that recalls the parent's weighted equality case and frames this entry's task (specialise the weights to wᵢ = 1/n and read off the classical statement). Added a `preamble` section (lines 1–39) so sections now span the full 164-line Lean file. Matched the file's existing section convention (summary only, no mathContext field).

**Verification:** JSON valid; gallery enrichment + search-index checks pass; entry produces no annotation-validation errors. No content deleted; meta.json ~12.2 → ~12.8 KB (well under 60 KB cap).