### PR TITLE
Enrich Quadratic Convergence of the AGM: convergence-hierarchy cross-reference

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-04-oq-04/annotations.json
+++ b/src/data/proofs/amgm-inequality-oq-04-oq-04/annotations.json
@@ -106,6 +106,8 @@
     "relatedConcepts": [
       "Newton's method",
       "doubly exponential decay",
+      "linear vs quadratic convergence",
+      "Banach contraction (geometric rate)",
       "induction on ℕ",
       "pow_mul / pow_succ"
     ],

--- a/src/data/proofs/amgm-inequality-oq-04-oq-04/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-04-oq-04/meta.json
@@ -152,6 +152,11 @@
       "targetId": "amgm-inequality-oq-04-oq-02",
       "relationship": "related",
       "description": "Sibling under OQ-04: Legendre's relation E(k)·K(k′) + E(k′)·K(k) − K(k)·K(k′) = π/2 for complete elliptic integrals, the analytic companion to the AGM used together with this convergence rate in fast π and elliptic-integral evaluation."
+    },
+    {
+      "targetId": "banach-fixed-point-oq-01",
+      "relationship": "related",
+      "description": "Contrast in the convergence hierarchy of fixed-point iterations: Banach's contraction principle gives only a LINEAR (geometric) rate d(fⁿx,p) ≤ d(x,fx)·Kⁿ/(1−K), where the error is multiplied by a fixed factor K<1 each step. The AGM's per-step gap identity here squares the error instead (gₙ₊₁ ≤ gₙ²/C), upgrading linear to QUADRATIC convergence and the geometric Kⁿ to the doubly exponential (·)^{2ⁿ}. The reusable quadratic_iteration lemma plays for Newton-type iterations the role Banach's Kⁿ bound plays for contractions."
     }
   ],
   "references": [


### PR DESCRIPTION
Enrichment pass for `amgm-inequality-oq-04-oq-04` (Quadratic/Doubly-Exponential Convergence of the AGM).

The entry was already comprehensive (quality 96, all annotation/keyInsight/section/conclusion targets met, 12 KB — well under caps). Rather than inflate an already-rich page, this pass adds the one genuinely missing, instructive link.

**Change (minimal, +7 lines):**
- **crossReferences** (4 → 5, cap 20): added `banach-fixed-point-oq-01`, contrasting Banach's **linear/geometric** rate `d(fⁿx,p) ≤ d(x,fx)·Kⁿ/(1−K)` with the AGM's **quadratic/doubly-exponential** rate `(·)^{2ⁿ}`. This situates the result in the fixed-point-iteration convergence hierarchy and makes concrete the annotation's existing note that `quadratic_iteration` governs Newton-type iterations.
- Added `linear vs quadratic convergence` and `Banach contraction (geometric rate)` to the doubly-exponential annotation's `relatedConcepts` for consistency.

Validated: JSON parses; `pnpm build` enrichment + search-index checks pass (the `tsc` step fails only on this worktree's missing `node_modules`, unrelated to this JSON-only change). Sizes under all caps.