### PR TITLE
research(erdos-1022-oq-02): strict monotonicity + named coefficient divergence

### DIFF
--- a/proofs/Proofs/Erdos1022OQ02.lean
+++ b/proofs/Proofs/Erdos1022OQ02.lean
@@ -629,4 +629,60 @@ theorem admissibleCoeff_mono {a b : ℕ} (hab : a ≤ b) :
       ≤ firstMomentThreshold b / Fintype.card V :=
   Nat.div_le_div_right (firstMomentThreshold_mono hab)
 
+-- ══════════════════════════════════════════════════════════════════
+-- § 9: Strict monotonicity and the coefficient's own divergence
+-- ══════════════════════════════════════════════════════════════════
+
+/-
+  § 8 records the bare *non-strict* monotone envelope `c(a) ≤ c(b)`.  The
+  companion strict statement — that once the coefficient has become positive it
+  is genuinely *strictly* increasing over *any* gap `a < b`, not merely the
+  consecutive step of `admissibleCoeff_lt_of_pos` — completes the qualitative
+  picture underlying OQ-02's "growth rate": beyond the positivity threshold
+  `t₀ = |V|` the admissible coefficient never plateaus.  We also extract, as a
+  reusable named result, the divergence of the coefficient itself (so far only
+  available inlined inside `exists_admissible_coeff`).
+-/
+
+/-- **Strict monotonicity of the admissible coefficient past the positivity
+    threshold.**  Once the minimum set size reaches `|V|` the coefficient
+    `c(t) = ⌊2^{t-1}/|V|⌋` is strictly increasing over *arbitrary* gaps: for
+    `|V| ≤ a < b`, `c(a) < c(b)`.  This upgrades the non-strict envelope
+    `admissibleCoeff_mono` and the consecutive-step `admissibleCoeff_lt_of_pos`
+    to a full strict order relation, chaining one strict step at `a` (positive by
+    `admissibleCoeff_pos_of_card_le`) with monotonicity `c(a+1) ≤ c(b)`. -/
+theorem admissibleCoeff_strictMono_of_card_le (hV : 0 < Fintype.card V) {a b : ℕ}
+    (ha : Fintype.card V ≤ a) (hab : a < b) :
+    firstMomentThreshold a / Fintype.card V
+      < firstMomentThreshold b / Fintype.card V := by
+  have ha1 : 1 ≤ a := le_trans hV ha
+  have hpos : 0 < firstMomentThreshold a / Fintype.card V :=
+    admissibleCoeff_pos_of_card_le hV a ha
+  have hstep : firstMomentThreshold a / Fintype.card V
+      < firstMomentThreshold (a + 1) / Fintype.card V :=
+    admissibleCoeff_lt_of_pos hV a ha1 hpos
+  exact lt_of_lt_of_le hstep (admissibleCoeff_mono (by omega))
+
+/-- **`StrictMonoOn` packaging.**  The admissible coefficient
+    `c(t) = ⌊2^{t-1}/|V|⌋` is strictly monotone on `[|V|, ∞)` — the idiomatic
+    order-theoretic form of `admissibleCoeff_strictMono_of_card_le`, recording
+    that the coefficient is eventually a strictly increasing function of the
+    minimum set size `t`. -/
+theorem admissibleCoeff_strictMonoOn (hV : 0 < Fintype.card V) :
+    StrictMonoOn (fun t => firstMomentThreshold t / Fintype.card V)
+      (Set.Ici (Fintype.card V)) :=
+  fun _a ha _b _hb hab =>
+    admissibleCoeff_strictMono_of_card_le hV (Set.mem_Ici.mp ha) hab
+
+/-- **The admissible coefficient diverges (named form).**  The coefficient
+    `c(t) = ⌊2^{t-1}/|V|⌋ → ∞` as `t → ∞`, over any fixed nonempty ground set.
+    This is exactly the `Filter.Tendsto` witness constructed inline inside
+    `exists_admissible_coeff`, extracted here as a standalone reusable theorem:
+    the exponential threshold survives division by the fixed ground-set size, so
+    the integer coefficient the problem asks about genuinely tends to infinity. -/
+theorem admissibleCoeff_tendsto_atTop (hV : 0 < Fintype.card V) :
+    Filter.Tendsto (fun t => firstMomentThreshold t / Fintype.card V)
+      Filter.atTop Filter.atTop :=
+  (tendsto_div_const_atTop hV).comp firstMomentThreshold_tendsto_atTop
+
 end Erdos1022OQ02

--- a/src/data/proofs/erdos-1022-oq-02/meta.json
+++ b/src/data/proofs/erdos-1022-oq-02/meta.json
@@ -25,7 +25,7 @@
     "mathlib_version": "4.26.0",
     "axiomCount": 0,
     "assumptions": "No axioms and no sorries: all theorems are fully machine-checked from Mathlib (depends only on propext / Classical.choice / Quot.sound). This is a partial result addressing the first-moment regime of OQ-02; the open conjecture of Erdős #1022 (whether c_t → ∞ for arbitrarily large ground sets) is NOT resolved here.",
-    "lineCount": 632,
+    "lineCount": 688,
     "relatedProblems": [
       {
         "id": "erdos-1022",
@@ -40,7 +40,7 @@
         "relationship": "Builds on: Erdős 1963 uniform first-moment theorem (reuses Mono, card_mono, exists_zero_of_sum_lt_card)"
       }
     ],
-    "theoremCount": 25,
+    "theoremCount": 28,
     "definitionCount": 3
   },
   "overview": {
@@ -129,10 +129,10 @@
     }
   ],
   "leanFile": {
-    "lineCount": 632,
+    "lineCount": 688,
     "structureCount": 0,
     "axiomCount": 0,
-    "theoremCount": 25,
+    "theoremCount": 28,
     "lemmaCount": 0,
     "imports": [
       "Mathlib",


### PR DESCRIPTION
## Summary

Extends the saturated first-moment treatment of **OQ-02 of Erdős #1022** (growth rate of the Property-B sparseness threshold `c_t`) with a new **§9** — three axiom-free theorems completing the qualitative growth-rate picture of the admissible coefficient `c(t) = ⌊2^{t-1}/|V|⌋`.

The existing file pins the *rate* (per-step doubling, two-sided exponential brackets, explicit positivity thresholds) but its final section only records the **non-strict** monotone envelope `c(a) ≤ c(b)` and the coefficient's divergence is buried inline inside `exists_admissible_coeff`. This iteration closes both gaps.

## New theorems

- **`admissibleCoeff_strictMono_of_card_le`** — strict monotonicity over **arbitrary** gaps `|V| ≤ a < b` (not merely the consecutive step of `admissibleCoeff_lt_of_pos`): `c(a) < c(b)`. Upgrades the non-strict `admissibleCoeff_mono`. Chains one strict step at `a` (positive by `admissibleCoeff_pos_of_card_le`) with monotonicity `c(a+1) ≤ c(b)`.
- **`admissibleCoeff_strictMonoOn`** — idiomatic `StrictMonoOn` packaging on `Set.Ici (Fintype.card V)`: past the positivity threshold `t₀ = |V|` the coefficient is a strictly increasing function of the minimum set size `t`, i.e. it never plateaus.
- **`admissibleCoeff_tendsto_atTop`** — the coefficient's own `Filter.Tendsto` divergence `c(t) → ∞`, extracted as a standalone reusable named result (previously only constructed inline inside `exists_admissible_coeff`).

## Verification

Built with `lean v4.26.0` (external worktree, symlinked `.lake`). All three new theorems:

```
depends on axioms: [propext, Classical.choice, Quot.sound]
```

No `sorry`, no `axiom`, no `native_decide`. `theoremCount` 25→28, `lineCount` 632→688; meta.json stays `verified` / `axiomCount: 0`.

## Honest scope

Unchanged: this is the **first-moment / bounded-ground-set** regime. The open conjecture of Erdős #1022 (whether `c_t → ∞` for arbitrarily large ground sets, the Lovász-type regime) is **not** resolved. These lemmas sharpen the qualitative monotonicity/divergence backbone of the already-established growth-rate results; they do not touch the hard regime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)