### PR TITLE
research(erdos-1064-oq-03): master closed-form forward gap + 2^k divisibility

### DIFF
--- a/proofs/Proofs/EulerTotientOQ04OQ03.lean
+++ b/proofs/Proofs/EulerTotientOQ04OQ03.lean
@@ -3219,6 +3219,68 @@ theorem sophieGermain_gap_zero {q : ℕ} (hq : q.Prime) (hq5 : 5 ≤ q)
 -- vacuous.  With this, all three regimes now have an *exact* gap once the landing is
 -- prime:  reversal `+(2m+2)·2^k`, forward `−(2m−2)·2^k`, equality `0`.
 
+/-- **Master exact forward gap of the fiveTimes family (closed form in `φ` of the landing).**
+    For a seed `a = 5·(4m+1)` with only the *family* primes `4m+1`, `12m+5` (`= 3q+2`) prime
+    (`m ≥ 3`) — and **no** assumption on the landing `14m+3` — the forward margin along
+    `n = 5·(4m+1)·2^(k+1)` is exactly
+        `φ(n) − φ(D(n)) = (16m − φ(14m+3))·2^k`.
+    This is the unifying identity underneath both `forward_gap_fiveTimes_ge` (apply
+    `φ(14m+3) ≤ 14m+2` to get the lower bound `(2m−2)·2^k`) and `forward_gap_fiveTimes_eq`
+    (apply `φ(14m+3) = 14m+2` when the landing is prime to get the exact `(2m−2)·2^k`): both
+    were previously proved directly, but each hid this closed form. The mechanism is the same
+    `dblIter_transport` landing `D(n) = (14m+3)·2^(k+1)`, so `φ(D(n)) = φ(14m+3)·2^k` and the
+    gap is `16m·2^k − φ(14m+3)·2^k = (16m − φ(14m+3))·2^k` — with the totient of the landing
+    left *symbolic*, so the identity needs nothing about `14m+3`'s factorisation. -/
+theorem forward_gap_fiveTimes_eq_totient {m : ℕ} (hm : 3 ≤ m)
+    (hq : (4 * m + 1).Prime) (hb : (12 * m + 5).Prime) (k : ℕ) :
+    Nat.totient (5 * (4 * m + 1) * 2 ^ (k + 1))
+        - Nat.totient (dblIter (5 * (4 * m + 1) * 2 ^ (k + 1)))
+      = (16 * m - Nat.totient (14 * m + 3)) * 2 ^ k := by
+  have hcop : Nat.Coprime 5 (4 * m + 1) :=
+    (Nat.coprime_primes (by norm_num) hq).mpr (by omega)
+  -- φ(a) = 16m  (a = 5·(4m+1))
+  have hφa : Nat.totient (5 * (4 * m + 1)) = 16 * m := by
+    rw [Nat.totient_mul hcop, show Nat.totient 5 = 4 from by decide,
+        Nat.totient_prime hq]; omega
+  -- φ(b) = 12m+4  (b = 12m+5 prime)
+  have hφb : Nat.totient (12 * m + 5) = 12 * m + 4 := by
+    rw [Nat.totient_prime hb]; omega
+  have ha_odd : Odd (5 * (4 * m + 1)) := Nat.odd_iff.mpr (by omega)
+  have hb_odd : Odd (12 * m + 5) := Nat.odd_iff.mpr (by omega)
+  have hp2 : Nat.totient (2 ^ (k + 1)) = 2 ^ k := by
+    rw [Nat.totient_prime_pow Nat.prime_two (Nat.succ_pos k)]; simp
+  -- φ(n) = φ(5·(4m+1))·2^k = 16m·2^k
+  have copa : Nat.Coprime (5 * (4 * m + 1)) (2 ^ (k + 1)) :=
+    ((Nat.prime_two.coprime_iff_not_dvd).mpr (by omega)).symm.pow_right (k + 1)
+  have hφn : Nat.totient (5 * (4 * m + 1) * 2 ^ (k + 1)) = 16 * m * 2 ^ k := by
+    rw [Nat.totient_mul copa, hp2, hφa]
+  -- transport: D(n) = (2a − φ(b))·2^k = (14m+3)·2^(k+1)  (landing factorisation unused)
+  have hstep : 2 * (5 * (4 * m + 1)) - Nat.totient (5 * (4 * m + 1)) = 2 * (12 * m + 5) := by
+    rw [hφa]; omega
+  have hD : dblIter (5 * (4 * m + 1) * 2 ^ (k + 1)) = (14 * m + 3) * 2 ^ (k + 1) := by
+    rw [dblIter_transport ha_odd hb_odd hstep k, hφb,
+        show 2 * (5 * (4 * m + 1)) - (12 * m + 4) = (14 * m + 3) * 2 from by omega]
+    ring
+  -- φ(D(n)) = φ(14m+3)·2^k, keeping φ(14m+3) SYMBOLIC (no primality of the landing)
+  have cope : Nat.Coprime (14 * m + 3) (2 ^ (k + 1)) :=
+    ((Nat.prime_two.coprime_iff_not_dvd).mpr (by omega)).symm.pow_right (k + 1)
+  have hφD : Nat.totient (dblIter (5 * (4 * m + 1) * 2 ^ (k + 1)))
+      = Nat.totient (14 * m + 3) * 2 ^ k := by
+    rw [hD, Nat.totient_mul cope, hp2]
+  rw [hφn, hφD, ← Nat.sub_mul]
+
+/-- **The forward gap of the fiveTimes family is always a multiple of `2^k`.**  Immediate from
+    the master closed form `forward_gap_fiveTimes_eq_totient`: the whole family scales by `2^k`,
+    so `2^k ∣ (φ(n) − φ(D(n)))` for *every* `k`, with **no** condition on the landing `14m+3`.
+    (When the landing is prime, `forward_gap_fiveTimes_eq` identifies the cofactor as the
+    explicit `2m−2`.) This is the unconditional 2-adic structure of the forward margin. -/
+theorem forward_gap_fiveTimes_pow_dvd {m : ℕ} (hm : 3 ≤ m)
+    (hq : (4 * m + 1).Prime) (hb : (12 * m + 5).Prime) (k : ℕ) :
+    2 ^ k ∣ (Nat.totient (5 * (4 * m + 1) * 2 ^ (k + 1))
+        - Nat.totient (dblIter (5 * (4 * m + 1) * 2 ^ (k + 1)))) := by
+  rw [forward_gap_fiveTimes_eq_totient hm hq hb k]
+  exact ⟨16 * m - Nat.totient (14 * m + 3), by ring⟩
+
 /-- **Exact forward gap of the fiveTimes family under a prime landing.**  For a seed
     `a = 5·(4m+1)` with `4m+1`, `12m+5` (`= 3q+2`) *and* the landing `14m+3` all prime
     (`m ≥ 3`), the forward margin along `n = 5·(4m+1)·2^(k+1)` is not merely bounded below


### PR DESCRIPTION
## Summary

Erdős #1064 OQ-03 studies the higher totient iterate `D(n) = n − φ(n − φ(n))` and which seeds make `φ(D(n))` overtake, tie, or fall short of `φ(n)`. The elementary/structural side is complete; the quantitative side has *exact* signed gaps for the reversal (`+(2m+2)·2^k`), equality (`0`), and forward regimes. This PR fills a genuine gap in the **forward** regime's quantitative theory.

The forward `fiveTimes` family `n = 5·(4m+1)·2^(k+1)` previously had:
- `forward_gap_fiveTimes_ge`: a one-sided **lower bound** `φ(n) − φ(D(n)) ≥ (2m−2)·2^k`;
- `forward_gap_fiveTimes_eq`: the **exact** value `(2m−2)·2^k`, but only under the extra hypothesis that the landing `14m+3` is **prime**.

The unifying identity underneath both — exact, but keeping the landing's totient symbolic — was missing.

## New theorems (both axiom-free)

- **`forward_gap_fiveTimes_eq_totient`** — under only the family primes (`4m+1`, `12m+5` prime, `m ≥ 3`) and **no** condition on the landing:
  ```
  φ(n) − φ(D(n)) = (16m − φ(14m+3)) · 2^k.
  ```
  Both existing forward-gap theorems are specializations: `φ(14m+3) ≤ 14m+2` recovers the lower bound; `φ(14m+3) = 14m+2` (landing prime) recovers the exact `(2m−2)·2^k`.

- **`forward_gap_fiveTimes_pow_dvd`** — immediate corollary: the forward gap is always a multiple of `2^k`, **unconditionally** in the landing's factorisation — the 2-adic structure of the whole parametric family.

Mechanism: the same `dblIter_transport` landing `D(n) = (14m+3)·2^(k+1)`, so `φ(D(n)) = φ(14m+3)·2^k` and the gap is `16m·2^k − φ(14m+3)·2^k = (16m − φ(14m+3))·2^k` with `φ(14m+3)` left symbolic.

## Verification

- Compiles under `lean v4.26.0`, exit 0 (only the file's 4 pre-existing `mul_le_mul_*` deprecation warnings, none from the new code).
- `#print axioms` on both new theorems: `[propext, Classical.choice, Quot.sound]` — axiom-free (uses `decide`, not `native_decide`).
- Consistent with `forward_gap_fiveTimes_eq_85` at `m = 4`: `(64 − φ(59))·2^k = 6·2^k`.
- File `3285 → 3357` lines, still **0 sorry / 0 axiom**. Research-only file (no gallery meta).

🤖 Generated with [Claude Code](https://claude.com/claude-code)