### PR TITLE
research(algebraic-numbers-countable-oq-07): complex transcendentals cardinality pillar

### DIFF
--- a/proofs/Proofs/AlgebraicRealsNull.lean
+++ b/proofs/Proofs/AlgebraicRealsNull.lean
@@ -291,6 +291,41 @@ theorem ae_transcendental_complex :
   rw [Filter.eventually_iff, hset]
   exact compl_mem_ae_iff.mpr algebraic_complex_null
 
+/-- **The transcendental complex numbers are uncountable.**  The complex analogue of
+`transcendental_reals_uncountable`, supplying the cardinality pillar on `ℂ` (previously
+only the measure, dimension, density, descriptive and category pillars were present for
+the complex transcendentals).  If they were countable, then together with the countable
+algebraic complex numbers their union `ℂ` would be countable, contradicting
+`not_countable_complex`. -/
+theorem transcendental_complex_uncountable :
+    ¬ {z : ℂ | Transcendental ℚ z}.Countable := by
+  intro hcount
+  have hcompl : {z : ℂ | Transcendental ℚ z}ᶜ.Countable := by
+    have hset : {z : ℂ | Transcendental ℚ z}ᶜ = {z : ℂ | IsAlgebraic ℚ z} := by
+      ext z; simp only [mem_compl_iff, mem_setOf_eq, Transcendental, not_not]
+    rw [hset]
+    exact AlgebraicNumbersCountable.algebraic_complex_countable
+  have huniv : (Set.univ : Set ℂ).Countable := by
+    have hu := hcount.union hcompl
+    rwa [Set.union_compl_self] at hu
+  exact not_countable_complex huniv
+
+/-- **The transcendental complex numbers have cardinality the continuum**:
+`#{z | Transcendental ℚ z} = 𝔠`.  The complex analogue of
+`transcendental_reals_mk_eq_continuum`, sharpening `transcendental_complex_uncountable`
+from "not countable" to the exact cardinal value.  The algebraic complex numbers are
+countable, hence of cardinality `≤ ℵ₀ < 𝔠 = #ℂ` (`Cardinal.mk_complex`); deleting a set of
+cardinality strictly below `#ℂ` from `ℂ` leaves the same cardinality
+(`Cardinal.mk_compl_of_infinite`), so the transcendentals still have cardinality `𝔠`. -/
+theorem transcendental_complex_mk_eq_continuum :
+    #{z : ℂ | Transcendental ℚ z} = 𝔠 := by
+  have hcompl : {z : ℂ | Transcendental ℚ z} = {z : ℂ | IsAlgebraic ℚ z}ᶜ := by
+    ext z; simp only [mem_setOf_eq, mem_compl_iff, Transcendental]
+  have hlt : #{z : ℂ | IsAlgebraic ℚ z} < #(ℂ) :=
+    lt_of_le_of_lt AlgebraicNumbersCountable.algebraic_complex_countable.le_aleph0
+      (by rw [Cardinal.mk_complex]; exact Cardinal.aleph0_lt_continuum)
+  rw [hcompl, Cardinal.mk_compl_of_infinite _ hlt, Cardinal.mk_complex]
+
 -- ============================================================================
 -- § 6. Hausdorff dimension zero — a sharpening of Lebesgue-null
 -- ============================================================================


### PR DESCRIPTION
## Summary

`AlgebraicRealsNull.lean` (OQ-07 of `algebraic-numbers-countable`) establishes a full **smallness trichotomy⁺** for the algebraic numbers and the co-smallness of the transcendentals across five independent notions — measure (Lebesgue-null / conull), Baire category (meagre / comeagre), Hausdorff dimension (0 / full), cardinality (countable / continuum), and descriptive set theory (empty Cantor–Bendixson kernel) — for **both** `ℝ` and `ℂ`.

One asymmetry remained: the **cardinality** pillar for the transcendentals existed only on `ℝ` (`transcendental_reals_uncountable`, `transcendental_reals_mk_eq_continuum`) and was absent on `ℂ`. This PR supplies the two missing complex analogues.

## New theorems

- **`transcendental_complex_uncountable`** — `{z : ℂ | Transcendental ℚ z}` is not countable. If it were, then together with the countable algebraic complex numbers their union `ℂ` would be countable, contradicting `not_countable_complex`.
- **`transcendental_complex_mk_eq_continuum`** — `#{z : ℂ | Transcendental ℚ z} = 𝔠`, the quantitative sharpening. The algebraic complex numbers are countable, hence of cardinality `< 𝔠 = #ℂ` (`Cardinal.mk_complex`); deleting a set of cardinality below `#ℂ` from `ℂ` leaves cardinality `𝔠` (`Cardinal.mk_compl_of_infinite`).

These are the exact complex mirrors of the existing `transcendental_reals_*` cardinality results, completing the cardinality pillar on `ℂ`.

## Verification

Adds `import Mathlib.Analysis.Complex.Cardinality`. Built with `lean v4.26.0`; both new theorems:

```
depends on axioms: [propext, Classical.choice, Quot.sound]
```

No `sorry`, no `axiom`, no `native_decide`. `theoremCount` 36→38, `lineCount` 550→586; meta stays `verified` / `axiomCount: 0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)