### PR TITLE
research(hilbert-17-oq-03): Motzkin evenness + four boundary zeros [VERIFIED, +3 thm]

### DIFF
--- a/proofs/Proofs/Hilbert17OQ03OQ05.lean
+++ b/proofs/Proofs/Hilbert17OQ03OQ05.lean
@@ -444,6 +444,32 @@ theorem motzkinFun_three_not_posDef : ¬ ∀ x y : ℝ, 0 < motzkinFun 3 x y := 
   rw [motzkinFun_three_zero_at_one_one] at h11
   exact lt_irrefl 0 h11
 
+/-- **Evenness in the first argument.** `motzkinFun c` depends on `x` only through the
+    even powers `x⁴`, `x²`, so reflecting `x ↦ -x` leaves the value unchanged:
+    `Mₐ(-x, y) = Mₐ(x, y)`.  Together with `motzkinFun_symm` this exhibits the full
+    `(ℤ/2)² ⋊ swap` dihedral symmetry of the family. -/
+theorem motzkinFun_even_left (c x y : ℝ) : motzkinFun c (-x) y = motzkinFun c x y := by
+  unfold motzkinFun; ring
+
+/-- **Evenness in the second argument.** `Mₐ(x, -y) = Mₐ(x, y)`, symmetric to
+    `motzkinFun_even_left` (equivalently, its conjugate by `motzkinFun_symm`). -/
+theorem motzkinFun_even_right (c x y : ℝ) : motzkinFun c x (-y) = motzkinFun c x y := by
+  unfold motzkinFun; ring
+
+/-- **The boundary member vanishes at all four sign-variants of `(1,1)`.**  Because
+    `motzkinFun 3` is even in each argument (`motzkinFun_even_left`/`_even_right`) and
+    vanishes at `(1,1)` (`motzkinFun_three_zero_at_one_one`), it vanishes at every
+    `(±1, ±1)`.  These four points are exactly the real zeros of the Motzkin polynomial —
+    the geometric obstruction that pins `c = 3` onto the PSD-cone boundary and, classically,
+    the reason it admits no sum-of-squares certificate. -/
+theorem motzkinFun_three_zero_at_sign_ones :
+    motzkinFun 3 1 1 = 0 ∧ motzkinFun 3 (-1) 1 = 0 ∧
+      motzkinFun 3 1 (-1) = 0 ∧ motzkinFun 3 (-1) (-1) = 0 := by
+  refine ⟨motzkinFun_three_zero_at_one_one, ?_, ?_, ?_⟩
+  · rw [motzkinFun_even_left]; exact motzkinFun_three_zero_at_one_one
+  · rw [motzkinFun_even_right]; exact motzkinFun_three_zero_at_one_one
+  · rw [motzkinFun_even_left, motzkinFun_even_right]; exact motzkinFun_three_zero_at_one_one
+
 end Hilbert17OQ03OQ05
 
 -- Axiom audit: should list only propext, Classical.choice, Quot.sound.


### PR DESCRIPTION
## Summary

Extends the parametrized Motzkin family analysis in `Hilbert17OQ03OQ05.lean` with the reflection structure that the existing single-zero fact (`motzkinFun_three_zero_at_one_one`) left implicit.

## New theorems (all axiom-free)

- **`motzkinFun_even_left` / `motzkinFun_even_right`** — `motzkinFun c` depends on each variable only through even powers, so `M(-x,y)=M(x,y)` and `M(x,-y)=M(x,y)`. Combined with the existing `motzkinFun_symm`, this exhibits the family's full dihedral symmetry.
- **`motzkinFun_three_zero_at_sign_ones`** — the boundary member `c=3` vanishes at all four `(±1,±1)`. These are exactly the real zeros that pin `c=3` onto the PSD-cone boundary and, classically, obstruct any sum-of-squares certificate; the file previously recorded only the `(1,1)` zero.

## Verification

- Full file compiles clean under Lean v4.26.0 / Mathlib 4.26.0 (raw `lean` with dependency `Hilbert17MotzkinNotSOS` built into the module path).
- All three new theorems verified **axiom-free**: `[propext, Classical.choice, Quot.sound]`.
- File remains **0 sorries / 0 axioms**; the in-file `#print axioms` audit is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)