### PR TITLE
research(erdos-1039-incomplete-01): exact KLR/Pommerenke ratio + unboundedness (axiom-free)

### DIFF
--- a/proofs/Proofs/Erdos1039Problem.lean
+++ b/proofs/Proofs/Erdos1039Problem.lean
@@ -303,6 +303,72 @@ theorem conjecturedBound_div_pommerenkeBound_tendsto_atTop (c : ℝ) (hc : 0 < c
   exact (conjecturedBound_div_pommerenkeBound c hc n hn).symm
 
 /-
+## The KLR–Pommerenke Improvement
+
+The two blocks above measure the KLR bound `c/(n√log n)` and the Pommerenke bound
+`1/(2en²)` each against the conjectured `c/n`.  Comparing the two *lower* bounds directly
+completes the triangle: `klr_better_than_pommerenke` only records that KLR eventually
+*exceeds* Pommerenke (at the fixed constant `c = 1`).  The results here pin the improvement
+*exactly* and show it is unbounded, matching the pattern of the two gap blocks:
+
+* `klrBound_div_pommerenkeBound` — the *exact* ratio is `2ec·n / √log n`.
+* `klrBound_div_pommerenkeBound_tendsto_atTop` — that ratio `→ ∞`, so KLR beats Pommerenke
+  by an unbounded factor (roughly `n / √log n`), for *every* fixed `c > 0`.
+
+Unconditional facts about the bound functions; they use none of the deep axioms.
+-/
+
+/-- **Exact KLR-over-Pommerenke ratio.** For `c > 0` and `n ≥ 2`, the KLR lower bound
+    exceeds the older Pommerenke lower bound by exactly the factor `2ec·n / √log n`:
+    `klrBound c n / pommerenkeBound n = 2ec·n / √log n`.  The quantitative form of
+    `klr_better_than_pommerenke`. -/
+theorem klrBound_div_pommerenkeBound (c : ℝ) (hc : 0 < c) (n : ℕ) (hn : n ≥ 2) :
+    klrBound c n / pommerenkeBound n
+      = 2 * Real.exp 1 * c * n / Real.sqrt (Real.log n) := by
+  have hn_pos : (0 : ℝ) < (n : ℝ) := by exact_mod_cast show 0 < n by omega
+  have hlog_pos : 0 < Real.log (n : ℝ) := Real.log_pos (by exact_mod_cast show 1 < n by omega)
+  have hsqrt_pos : 0 < Real.sqrt (Real.log (n : ℝ)) := Real.sqrt_pos.mpr hlog_pos
+  have he : (0 : ℝ) < Real.exp 1 := Real.exp_pos 1
+  have hn0 : (n : ℝ) ≠ 0 := hn_pos.ne'
+  have hs0 : Real.sqrt (Real.log (n : ℝ)) ≠ 0 := hsqrt_pos.ne'
+  have he0 : Real.exp 1 ≠ 0 := he.ne'
+  simp only [klrBound, pommerenkeBound]
+  field_simp
+
+/-- **The KLR improvement over Pommerenke is unbounded.** For every fixed `c > 0` the ratio
+    `klrBound c n / pommerenkeBound n = 2ec·n/√log n → ∞`, so KLR beats Pommerenke by an
+    unbounded factor (`≈ n/√log n`).  Bounded below by `2ec·√n → ∞` (using
+    `√n·√log n ≤ n`, i.e. `log n ≤ n`). -/
+theorem klrBound_div_pommerenkeBound_tendsto_atTop (c : ℝ) (hc : 0 < c) :
+    Filter.Tendsto (fun n : ℕ => klrBound c n / pommerenkeBound n)
+      Filter.atTop Filter.atTop := by
+  have hsqrt_atTop : Filter.Tendsto Real.sqrt Filter.atTop Filter.atTop := by
+    rw [Filter.tendsto_atTop_atTop]
+    intro b
+    refine ⟨b ^ 2 + 1, fun x hx => ?_⟩
+    calc b ≤ |b| := le_abs_self b
+      _ = Real.sqrt (b ^ 2) := (Real.sqrt_sq_eq_abs b).symm
+      _ ≤ Real.sqrt x := Real.sqrt_le_sqrt (by nlinarith)
+  have hg : Filter.Tendsto (fun n : ℕ => 2 * Real.exp 1 * c * Real.sqrt n)
+      Filter.atTop Filter.atTop :=
+    (hsqrt_atTop.comp tendsto_natCast_atTop_atTop).const_mul_atTop (by positivity)
+  apply Filter.tendsto_atTop_mono' Filter.atTop _ hg
+  filter_upwards [Filter.eventually_ge_atTop 2] with n hn
+  have hn_pos : (0 : ℝ) < (n : ℝ) := by exact_mod_cast show 0 < n by omega
+  have hlog_pos : 0 < Real.log (n : ℝ) := Real.log_pos (by exact_mod_cast show 1 < n by omega)
+  have hsqrt_pos : 0 < Real.sqrt (Real.log (n : ℝ)) := Real.sqrt_pos.mpr hlog_pos
+  have he : (0 : ℝ) < Real.exp 1 := Real.exp_pos 1
+  rw [klrBound_div_pommerenkeBound c hc n hn, le_div_iff₀ hsqrt_pos]
+  have hlogn : Real.log (n : ℝ) ≤ (n : ℝ) := by
+    have := Real.add_one_le_exp (Real.log (n : ℝ)); rw [Real.exp_log hn_pos] at this; linarith
+  have hkey : Real.sqrt n * Real.sqrt (Real.log n) ≤ (n : ℝ) := by
+    rw [← Real.sqrt_mul (Nat.cast_nonneg n)]
+    calc Real.sqrt ((n : ℝ) * Real.log n) ≤ Real.sqrt ((n : ℝ) * (n : ℝ)) :=
+          Real.sqrt_le_sqrt (by nlinarith [mul_le_mul_of_nonneg_left hlogn hn_pos.le])
+      _ = (n : ℝ) := Real.sqrt_mul_self hn_pos.le
+  nlinarith [mul_le_mul_of_nonneg_left hkey (show (0 : ℝ) ≤ 2 * Real.exp 1 * c by positivity)]
+
+/-
 ## Lemniscate Properties
 -/
 

--- a/research/problems/erdos-1039-incomplete-01/state.md
+++ b/research/problems/erdos-1039-incomplete-01/state.md
@@ -1,8 +1,21 @@
 # Current State
 
-**Phase**: NEW
-**Since**: 2026-03-30T16:34:54.972Z
-**Iteration**: 1
+**Phase**: ACT
+**Since**: 2026-07-11
+**Iteration**: 2
+
+## Iteration 2 (researcher-9, 2026-07-11) — exact KLR/Pommerenke ratio + unboundedness [VERIFIED, axiom-free]
+The bound-comparison scaffold pinned the exact ratio + tendsto for conjectured/KLR and
+conjectured/Pommerenke, but the direct KLR-vs-Pommerenke comparison existed only as an
+eventual `>` at c=1 (`klr_better_than_pommerenke`). Added the matching pair (axiom-free):
+- `klrBound_div_pommerenkeBound`: exact ratio klr/pomm = 2ec·n/√(log n) (field_simp).
+- `klrBound_div_pommerenkeBound_tendsto_atTop`: that ratio → ∞ for every c>0, via lower
+  bound 2ec·√n (using √n·√(log n) ≤ n ⟺ log n ≤ n). So KLR beats Pommerenke by an
+  unbounded ≈ n/√(log n) factor. VERIFIED lake env lean exit 0, #print axioms →
+  [propext, Classical.choice, Quot.sound] (independent of the 4 deep axioms).
+The EHP conjecture itself remains open (deep axioms benchmark_upper / pommerenke_lower /
+klr_lower / klr_area_bound untouched); this only sharpens the unconditional bound-function
+landscape.
 
 ## Current Focus
 


### PR DESCRIPTION
## Summary

The Erdős #1039 (Erdős–Herzog–Piranian polynomial-lemniscate) file `Erdos1039Problem.lean` carries a scaffold of unconditional bound-function comparisons. It pins the *exact ratio* and its `tendsto` for **conjectured/KLR** and **conjectured/Pommerenke**, but the direct **KLR-vs-Pommerenke** comparison existed only as an eventual strict inequality at the fixed constant `c = 1` (`klr_better_than_pommerenke`). This PR adds the matching quantitative pair, completing the comparison triangle. Both **axiom-free**.

- **`klrBound_div_pommerenkeBound`** — the exact ratio `klrBound c n / pommerenkeBound n = 2ec·n / √log n` for `c > 0`, `n ≥ 2` (`field_simp`). The quantitative form of `klr_better_than_pommerenke`.
- **`klrBound_div_pommerenkeBound_tendsto_atTop`** — that ratio `→ ∞` for **every** fixed `c > 0`, so the KLR lower bound beats the older Pommerenke bound by an unbounded factor (`≈ n/√log n`). Proved by bounding below by `2ec·√n → ∞`, using `√n·√log n ≤ n` (i.e. `log n ≤ n`).

## Verification

- Compiles clean under Lean **v4.26.0** / prebuilt Mathlib (`lake env lean`, exit 0, no errors/sorries).
- `#print axioms` on both: only `[propext, Classical.choice, Quot.sound]` — **axiom-free**, independent of the file's four deep axioms (`benchmark_upper`, `pommerenke_lower`, `klr_lower`, `klr_area_bound`).
- The EHP conjecture itself remains open (deep axioms untouched); this only sharpens the unconditional bound-function landscape. Research-only slug — `state.md` updated with the iteration note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)