### PR TITLE
research(erdos-771): subset-sum monotonicity + avoidance downward-closure [VERIFIED axiom-free]

### DIFF
--- a/proofs/Proofs/Erdos771Construction.lean
+++ b/proofs/Proofs/Erdos771Construction.lean
@@ -533,4 +533,22 @@ consecutive `m`). The deep asymptotics (the matching `(1/2 + o(1)) n / log n` lo
 bounds) are not addressed here.
 -/
 
+/-- **Subset-sum monotonicity.**  Enlarging the ground set can only add subset sums:
+`S ⊆ T ⟹ subsetSums S ⊆ subsetSums T`.  Every subset of `S` is a subset of `T`, so its
+sum is already a `T`-subset-sum.  The structural backbone of the avoidance ladder. -/
+theorem subsetSums_mono {S T : Finset ℕ} (h : S ⊆ T) : subsetSums S ⊆ subsetSums T := by
+  unfold subsetSums
+  apply Finset.filter_subset_filter
+  apply Finset.image_subset_image
+  exact Finset.powerset_mono.mpr h
+
+/-- **Avoidance is downward closed.**  If the larger set `T` avoids the sum `m`, then so
+does every subset `S ⊆ T`: `AvoidSum T m ⟹ AvoidSum S m`.  Contrapositive of
+`subsetSums_mono` — a subset of a sum-`m`-avoiding set still avoids `m`, so the avoidance
+property is inherited by all subsets (the reason maximal avoiding sets are the object of
+interest). -/
+theorem AvoidSum_antitone {S T : Finset ℕ} (h : S ⊆ T) {m : ℕ} (hT : AvoidSum T m) :
+    AvoidSum S m :=
+  fun hS => hT (subsetSums_mono h hS)
+
 end Erdos771Construction


### PR DESCRIPTION
The avoid-subset-sum-`m` construction ladder (`m = 1..4`) uses monotonicity implicitly but never states it. This PR adds the two structural lemmas.

## New theorems (both axiom-free)

- **`subsetSums_mono`** — `S ⊆ T ⟹ subsetSums S ⊆ subsetSums T`. Enlarging the ground set can only add subset sums (`powerset_mono` + `image_subset_image` + `filter_subset_filter`).
- **`AvoidSum_antitone`** — `AvoidSum T m ∧ S ⊆ T ⟹ AvoidSum S m`: avoidance is downward closed — a subset of a sum-`m`-avoiding set still avoids `m`. This is exactly why *maximal* avoiding sets are the object of interest in Erdős #771.

## Verification

- Whole file re-verified local-lean (Lean v4.26.0 + pinned Mathlib oleans), **0 errors**.
- `#print axioms` for each new theorem = `[propext, Classical.choice, Quot.sound]` — axiom-free.
- No new axioms or sorries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
