### PR TITLE
Enrich The Gaussian Integral Equals √π: π-family cross-references

### DIFF
--- a/src/data/proofs/area-of-circle-oq-07/meta.json
+++ b/src/data/proofs/area-of-circle-oq-07/meta.json
@@ -115,6 +115,21 @@
       "targetId": "area-of-circle",
       "relationship": "extends",
       "description": "Parent. The classical evaluation of ∫ e^{-x²} squares the integral and passes to polar coordinates, where the circle-area Jacobian r dr dθ — the subject of the parent entry — appears. gaussian_integral_sq records the squared value π that this Jacobian computation produces."
+    },
+    {
+      "targetId": "area-of-circle-oq-05",
+      "relationship": "related",
+      "description": "Companion sibling under the same parent: proves the identical Gaussian integral ∫ e^{-x²} dx = √π and, like this entry, ties the factor of π to the polar-coordinate / circle-area Jacobian. The two are parallel treatments of the same OQ, so an improvement or polar-explicit proof in one applies directly to the other."
+    },
+    {
+      "targetId": "gamma-reflection-formula-oq-01",
+      "relationship": "related",
+      "description": "The Gamma-function view of the same value: Γ(½) = √π is the s = ½ special value of Euler's reflection formula Γ(s)Γ(1−s) = π/sin(πs) (giving Γ(½)² = π). Under the substitution t = x² one has Γ(½) = ∫_ℝ e^{-x²} dx, so this entry's √π and the reflection formula's Γ(½) are literally the same number reached by different routes."
+    },
+    {
+      "targetId": "basel-problem",
+      "relationship": "related",
+      "description": "A sibling landmark where π appears from a non-geometric object: Basel gives ∑ 1/n² = π²/6, as this entry gives ∫ e^{-x²} = √π. Both are canonical instances of π surfacing outside its defining circle — one from an infinite series, one from an integral with no elementary antiderivative."
     }
   ],
   "references": [


### PR DESCRIPTION
Enrichment pass for `area-of-circle-oq-07` (The Gaussian Integral Equals √π).

The entry had only **1 crossReference** — sparse for one of analysis's most iconic results. Added three accurate links (no prose bloat):

- **`area-of-circle-oq-05`** — companion sibling proving the identical ∫ e^{-x²} = √π with the same polar/circle-area framing; parallel treatments of the same OQ.
- **`gamma-reflection-formula-oq-01`** — Γ(½) = √π is the s = ½ special value of Euler's reflection formula, and (via t = x²) equals this very integral; the same number by a different route.
- **`basel-problem`** — sibling landmark where π appears from a non-geometric object (∑ 1/n² = π²/6 vs ∫ e^{-x²} = √π).

crossReferences 1 → 4 (cap 20); meta 11.8 KB, under all caps. JSON validated; all targets exist.