### PR TITLE
research(lagrange-theorem-oq-01): sharp Third Sylow n_p ∣ |G|/p^k + pq-uniqueness

### DIFF
--- a/proofs/Proofs/LagrangeTheoremOQ01.lean
+++ b/proofs/Proofs/LagrangeTheoremOQ01.lean
@@ -102,6 +102,29 @@ theorem sylow_count_dvd_card (p : ℕ) [hp : Fact p.Prime] (P : Sylow p G) :
     Nat.card (Sylow p G) ∣ Nat.card G :=
   P.card_dvd_index.trans P.toSubgroup.index_dvd_card
 
+/-- **The index of a Sylow p-subgroup equals `|G| / p^k`** where `p^k ‖ |G|`.
+    Since `|P| = p^(vₚ|G|)` is the full p-power dividing `|G|` (`sylow_card_eq`),
+    Lagrange `|G| = |P|·[G:P]` (`lagrange_index`) gives `[G:P] = |G| / p^(vₚ|G|)`.
+    This identifies the abstract index with the concrete "p-free part" `|G|/p^k`
+    appearing in the classical statement of the Third Sylow Theorem. -/
+theorem sylow_index_eq_card_div_pow (p : ℕ) [hp : Fact p.Prime] (P : Sylow p G) :
+    P.toSubgroup.index = Nat.card G / p ^ (Nat.card G).factorization p := by
+  have hlag : Nat.card G
+      = p ^ (Nat.card G).factorization p * P.toSubgroup.index := by
+    rw [← sylow_card_eq p P]; exact lagrange_index P.toSubgroup
+  have hb : 0 < p ^ (Nat.card G).factorization p := pow_pos hp.out.pos _
+  exact (Nat.div_eq_of_eq_mul_right hb hlag).symm
+
+/-- **Sharp Third Sylow Theorem, `n_p ∣ |G|/p^k`.**  The classical divisibility stated in
+    the file header (`n_p ∣ |G|/p^k`): the number of Sylow p-subgroups divides the p-free
+    part `|G|/p^k` of the group order.  Combine `sylow_count_dvd_index` (`n_p ∣ [G:P]`) with
+    the identification `[G:P] = |G|/p^k` (`sylow_index_eq_card_div_pow`).  Strictly sharper
+    than `sylow_count_dvd_card` (`n_p ∣ |G|`), which discards the `p^k` factor. -/
+theorem sylow_count_dvd_card_div_pow (p : ℕ) [hp : Fact p.Prime] (P : Sylow p G) :
+    Nat.card (Sylow p G) ∣ Nat.card G / p ^ (Nat.card G).factorization p := by
+  rw [← sylow_index_eq_card_div_pow p P]
+  exact sylow_count_dvd_index p P
+
 /-- The number of Sylow p-subgroups is congruent to 1 mod p. -/
 theorem sylow_count_mod_p (p : ℕ) [hp : Fact p.Prime] :
     Nat.card (Sylow p G) % p = 1 := by
@@ -284,6 +307,18 @@ theorem sylow_q_normal_of_card_eq_pq (p q : ℕ) (hp : p.Prime) (hq : q.Prime)
     have hmod := sylow_count_mod_p (G := G) q
     rw [hpeq, Nat.mod_eq_of_lt hpq] at hmod
     exact hp.one_lt.ne' hmod
+
+/-- **The Sylow q-subgroup of a group of order `p·q` is unique** (`n_q = 1`), `p < q`
+    prime.  Immediate from its normality (`sylow_q_normal_of_card_eq_pq`) via the normality
+    criterion (`sylow_normal_iff_card_eq_one`): a normal Sylow subgroup is the only one.
+    This is the counting-level shadow of the structural non-simplicity result, and the exact
+    input (`n_q = 1`) used when classifying groups of order `p·q`. -/
+theorem card_sylow_q_eq_one_of_card_eq_pq (p q : ℕ) (hp : p.Prime) (hq : q.Prime)
+    (hpq : p < q) (Q : Sylow q G) (hG : Nat.card G = p * q) :
+    Nat.card (Sylow q G) = 1 := by
+  haveI : Fact q.Prime := ⟨hq⟩
+  exact (sylow_normal_iff_card_eq_one q Q).mp
+    (sylow_q_normal_of_card_eq_pq p q hp hq hpq Q hG)
 
 /-- **Every group of order `p·q` (with `p < q` prime) has a normal subgroup of order
     `q`.** Existence form of `sylow_q_normal_of_card_eq_pq`: rather than assume a Sylow

--- a/src/data/proofs/lagrange-theorem-oq-01/meta.json
+++ b/src/data/proofs/lagrange-theorem-oq-01/meta.json
@@ -20,8 +20,8 @@
     "sorries": 0,
     "dateAdded": "2026-04-04",
     "axiomCount": 0,
-    "lineCount": 344,
-    "theoremCount": 24,
+    "lineCount": 379,
+    "theoremCount": 27,
     "definitionCount": 0,
     "assumptions": "None.",
     "originalContributions": [
@@ -152,9 +152,9 @@
   ],
   "leanFile": {
     "namespace": "LagrangeOQ01",
-    "lineCount": 344,
+    "lineCount": 379,
     "axiomCount": 0,
-    "theoremCount": 24,
+    "theoremCount": 27,
     "definitionCount": 0,
     "path": "Proofs/LagrangeTheoremOQ01.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

`LagrangeTheoremOQ01.lean` presents the Sylow theorems as a partial converse to Lagrange. Its header states the **sharp Third Sylow Theorem** `n_p ≡ 1 (mod p)` **and** `n_p ∣ |G|/p^k`, but the file only proved the coarser index-form `n_p ∣ [G:P]` (`sylow_count_dvd_index`) and the weaker `n_p ∣ |G|` (`sylow_count_dvd_card`). This PR makes the explicitly-claimed `|G|/p^k` form a proved theorem, plus a natural `pq` corollary.

## New theorems

- **`sylow_index_eq_card_div_pow`** — `[G:P] = |G| / p^(vₚ|G|)`: identifies the abstract Sylow index with the concrete p-free part `|G|/p^k`. Since `|P| = p^(vₚ|G|)` is the full p-power in `|G|` (`sylow_card_eq`), Lagrange `|G| = |P|·[G:P]` (`lagrange_index`) divides out.
- **`sylow_count_dvd_card_div_pow`** — `n_p ∣ |G|/p^k`, the classical sharp Third Sylow divisibility stated in the header. Combines `sylow_count_dvd_index` with the index identification. Strictly sharper than `sylow_count_dvd_card` (`n_p ∣ |G|`), which discards the `p^k` factor.
- **`card_sylow_q_eq_one_of_card_eq_pq`** — in a group of order `p·q` (`p < q` prime) the Sylow q-count is exactly `1` (a unique Sylow q-subgroup). The counting-level shadow of the existing non-simplicity capstone, via the normality criterion.

## Verification

Built with `lean v4.26.0`; all three new theorems:

```
depends on axioms: [propext, Classical.choice, Quot.sound]
```

No `sorry`, no `axiom`, no `native_decide`. `theoremCount` 24→27, `lineCount` 344→379; meta stays `verified` / `axiomCount: 0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)