### PR TITLE
research(cauchy-schwarz-integral-oq-04): Schrödinger std-form uncertainty [VERIFIED, +2 thm]

### DIFF
--- a/proofs/Proofs/CauchySchwarzIntegralOQ04.lean
+++ b/proofs/Proofs/CauchySchwarzIntegralOQ04.lean
@@ -610,6 +610,48 @@ theorem heisenberg_canonical_std {A B : E →ₗ[𝕜] E} (hA : A.IsSymmetric)
   rw [hnorm] at h
   linarith [h]
 
+/-- **Schrödinger uncertainty principle, standard-deviation form.**  The Schrödinger
+analogue of `robertson_std_form`: taking square roots of the (nonnegative) two sides of
+`schrodinger_uncertainty` — whose right side `‖(A−a)ψ‖²·‖(B−b)ψ‖²` is the square of the
+product of standard deviations — gives the tighter-than-Heisenberg bound
+
+  `√(¼‖⟪ψ,[A,B]ψ⟫‖² + (Re⟪(A−a)ψ,(B−b)ψ⟫)²) ≤ ‖(A−a)ψ‖·‖(B−b)ψ‖`.
+
+Dropping the covariance term under the root recovers `robertson_std_form`. -/
+theorem schrodinger_std_form {A B : E →ₗ[𝕜] E} (hA : A.IsSymmetric)
+    (hB : B.IsSymmetric) (ψ : E) (a b : ℝ) :
+    Real.sqrt ((1 / 4 : ℝ) * ‖inner 𝕜 ψ (A (B ψ) - B (A ψ))‖ ^ 2
+        + RCLike.re (inner 𝕜 (A ψ - (a : 𝕜) • ψ) (B ψ - (b : 𝕜) • ψ)) ^ 2)
+      ≤ ‖A ψ - (a : 𝕜) • ψ‖ * ‖B ψ - (b : 𝕜) • ψ‖ := by
+  have hsch := schrodinger_uncertainty hA hB ψ a b
+  have hr : (0 : ℝ) ≤ ‖A ψ - (a : 𝕜) • ψ‖ * ‖B ψ - (b : 𝕜) • ψ‖ :=
+    mul_nonneg (norm_nonneg _) (norm_nonneg _)
+  rw [show ‖A ψ - (a : 𝕜) • ψ‖ * ‖B ψ - (b : 𝕜) • ψ‖
+        = Real.sqrt ((‖A ψ - (a : 𝕜) • ψ‖ * ‖B ψ - (b : 𝕜) • ψ‖) ^ 2) from
+      (Real.sqrt_sq hr).symm]
+  apply Real.sqrt_le_sqrt
+  rw [mul_pow]
+  exact hsch
+
+/-- **Schrödinger uncertainty principle, standard-deviation form at the expectation
+values.**  Instantiating `schrodinger_std_form` at `⟨A⟩ = Re⟪ψ,Aψ⟫`, `⟨B⟩ = Re⟪ψ,Bψ⟫`
+turns each right-hand factor into a standard deviation, giving Schrödinger's sharpening of
+`heisenberg_std_form`:
+
+  `√(¼‖⟪ψ,[A,B]ψ⟫‖² + Cov_ψ(A,B)²) ≤ Δ_ψ(A)·Δ_ψ(B)`,
+
+with `Cov_ψ(A,B) = Re⟪(A−⟨A⟩)ψ,(B−⟨B⟩)ψ⟫`.  The square-root companion of
+`schrodinger_variance_form`, and the Schrödinger counterpart of `heisenberg_std_form`. -/
+theorem schrodinger_std_variance_form {A B : E →ₗ[𝕜] E} (hA : A.IsSymmetric)
+    (hB : B.IsSymmetric) (ψ : E) :
+    Real.sqrt ((1 / 4 : ℝ) * ‖inner 𝕜 ψ (A (B ψ) - B (A ψ))‖ ^ 2
+        + RCLike.re (inner 𝕜 (A ψ - ((RCLike.re (inner 𝕜 ψ (A ψ)) : ℝ) : 𝕜) • ψ)
+            (B ψ - ((RCLike.re (inner 𝕜 ψ (B ψ)) : ℝ) : 𝕜) • ψ)) ^ 2)
+      ≤ ‖A ψ - ((RCLike.re (inner 𝕜 ψ (A ψ)) : ℝ) : 𝕜) • ψ‖
+        * ‖B ψ - ((RCLike.re (inner 𝕜 ψ (B ψ)) : ℝ) : 𝕜) • ψ‖ :=
+  schrodinger_std_form hA hB ψ (RCLike.re (inner 𝕜 ψ (A ψ)))
+    (RCLike.re (inner 𝕜 ψ (B ψ)))
+
 /-! ## The additive (sum) uncertainty relation `Var(A) + Var(B) ≥ ‖⟪ψ,[A,B]ψ⟫‖`
 
 All the forms above are *multiplicative*: they bound the **product** of the


### PR DESCRIPTION
## Summary

Completes the standard-deviation (square-root) family of uncertainty relations in `CauchySchwarzIntegralOQ04.lean`. The file had `robertson_std_form` and `heisenberg_std_form` (√-shape), and Schrödinger's relation only in its squared `schrodinger_variance_form` — the Schrödinger standard-deviation form was the missing member.

## New theorems (both axiom-free)

- **`schrodinger_std_form`** — `√(¼‖⟪ψ,[A,B]ψ⟫‖² + (Re⟪(A−a)ψ,(B−b)ψ⟫)²) ≤ ‖(A−a)ψ‖·‖(B−b)ψ‖`, the square-root of `schrodinger_uncertainty` (its RHS `‖u‖²‖v‖²` is `(‖u‖‖v‖)²` via `mul_pow`). The tighter-than-Heisenberg √-shape; dropping the covariance term under the root gives back `robertson_std_form`.
- **`schrodinger_std_variance_form`** — the same at the expectation values `⟨A⟩ = Re⟪ψ,Aψ⟫`, `⟨B⟩ = Re⟪ψ,Bψ⟫`, so each factor is a standard deviation. The √-companion of `schrodinger_variance_form` and the Schrödinger counterpart of `heisenberg_std_form`.

## Verification

- Full file compiles clean under Lean v4.26.0 / Mathlib 4.26.0.
- Both new theorems verified **axiom-free**: `[propext, Classical.choice, Quot.sound]`.
- File remains **0 sorries / 0 axioms**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)