### PR TITLE
research(pythagorean-theorem-oq-01): Hippocrates' quadrature of the lunes

### DIFF
--- a/proofs/Proofs/PythagoreanTheoremOQ01.lean
+++ b/proofs/Proofs/PythagoreanTheoremOQ01.lean
@@ -471,6 +471,32 @@ theorem semicircles_on_sides (A B C : F) (hperp : ⟪A - C, B - C⟫ = (0 : ℝ)
     (fun s => by ring) A B C hperp
   simpa using h
 
+/-- **Hippocrates' quadrature of the lunes.**  Erect a semicircle outward on each *leg*
+(diameters `CA`, `CB`) and the semicircle on the hypotenuse `AB` on the side of the triangle —
+by Thales the latter passes through the right-angle vertex `C`, so it decomposes into the
+triangle `ABC` plus the two circular *segments* cut off by the chords `CA` and `CB`:
+
+`(area of semicircle on AB)  =  (area of triangle ABC)  +  segA  +  segB`   (`hbig`).
+
+Each **lune** is the sliver between a leg-semicircle and the hypotenuse-semicircle, i.e.
+`luneA = (semicircle on CA) − segA` and `luneB = (semicircle on CB) − segB`.  Hippocrates'
+celebrated theorem (c. 440 BC — the first rigorous quadrature of a curvilinear region) is that
+the two lunes together have the **rectilinear** area of the triangle:
+
+`luneA + luneB  =  area of triangle ABC.`
+
+The proof is the algebraic heart of the classical argument: by `semicircles_on_sides` the two
+leg-semicircles sum to the hypotenuse-semicircle, so
+`luneA + luneB = (semiCA + semiCB) − segA − segB = semiAB − segA − segB = triArea` by `hbig`.
+Only this decomposition `hbig` carries geometric content (the Thales inscription of `C`); the
+quadrature identity itself is forced by the Pythagorean additivity of the semicircles. -/
+theorem hippocrates_lunes (A B C : F) (hperp : ⟪A - C, B - C⟫ = (0 : ℝ))
+    (triArea segA segB : ℝ)
+    (hbig : Real.pi * ‖A - B‖ ^ 2 / 8 = triArea + segA + segB) :
+    (Real.pi * ‖A - C‖ ^ 2 / 8 - segA) + (Real.pi * ‖B - C‖ ^ 2 / 8 - segB) = triArea := by
+  have hsemi := semicircles_on_sides A B C hperp
+  linarith
+
 #check @einstein_pythagorean
 #check @pythagorean_via_altitude
 #check @geometric_mean_A


### PR DESCRIPTION
## Summary

The Einstein/Pythagoras OQ-01 file proves the semicircle additivity `semicircles_on_sides` and its docstring notes this is *"the additivity identity underlying Hippocrates' quadrature of the lunes"* — but stops short of the quadrature itself. This PR adds that celebrated capstone (Hippocrates of Chios, c. 440 BC — the first rigorous quadrature of a curvilinear region).

## New theorem (axiom-free)

`hippocrates_lunes`: erect semicircles outward on the two legs and the hypotenuse-semicircle on the triangle's side (through `C` by Thales). With the geometric decomposition
```
area(semicircle on AB) = area(triangle ABC) + segA + segB     (hbig)
```
(the big semicircle = triangle + the two chord-segments over the legs), the two **lunes** — `luneA = semiCA − segA`, `luneB = semiCB − segB` — sum to the triangle's *rectilinear* area:
```
luneA + luneB = area(triangle ABC).
```

**Mechanism.** The quadrature is forced by the Pythagorean semicircle additivity: `luneA + luneB = (semiCA + semiCB) − segA − segB = semiAB − segA − segB = triArea` using `semicircles_on_sides` and `hbig` (`linarith`). Only `hbig` (the Thales inscription of `C`) carries geometric content.

## Style / honesty

Stated in the file's own **abstract-skeleton** convention (cf. `euclid_VI_31`, `einstein_pythagorean`): the geometric decomposition is a hypothesis; the algebraic quadrature identity is what's proved. It isolates the exact reason the lunes are quadrable — semicircle areas are Pythagorean-additive — without formalizing circular-segment areas from scratch.

## Verification

Host `lean v4.26.0` against prebuilt Mathlib oleans, **0 errors**. `#print axioms hippocrates_lunes`: `[propext, Classical.choice, Quot.sound]` — no `sorry`, no `ofReduceBool`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)