### PR TITLE
research(feuerbachs-theorem-oq-04): antipode characterisation sdist = π ↔ Q = -P (axiom-free)

### DIFF
--- a/proofs/Proofs/FeuerbachsTheoremOQ04.lean
+++ b/proofs/Proofs/FeuerbachsTheoremOQ04.lean
@@ -45,6 +45,9 @@ construction; this file establishes the metric layer underneath that constructio
 * `scos_eq_one_iff`, `sdist_eq_zero_iff`, `sdist_pos` — **point separation**: for unit
   vectors `sdist P Q = 0 ↔ P = Q`, so together with symmetry and nonnegativity `sdist`
   separates points.
+* `scos_eq_neg_one_iff`, `sdist_eq_pi_iff` — **antipode characterisation** (the dual far
+  end): for unit vectors `sdist P Q = π ↔ Q = -P`, so `sdist` attains its maximum `π`
+  exactly at the antipode (upgrading `sdist_antipode` to an iff).
 * `sdist_eq_angle`, `sdist_triangle`, `sdist_isMetric` — the **spherical triangle
   inequality** and metric capstone: identifying `sdist` with Mathlib's unoriented angle
   transports `angle_le_angle_add_angle` to `sdist P R ≤ sdist P Q + sdist Q R`, completing
@@ -1346,5 +1349,42 @@ theorem sCircle_antipodal_center (O : E) (ρ : ℝ) :
     sCircle O ρ = sCircle (-O) (Real.pi - ρ) := by
   ext P
   simp only [sCircle, Set.mem_setOf_eq, scos, inner_neg_right, Real.cos_pi_sub, neg_inj]
+
+/-- **Antipode characterisation of `scos = -1`.**  The exact dual of `scos_eq_one_iff`:
+for unit vectors, `scos P Q = -1` iff `Q` is the antipode `-P`.  Proof mirrors the
+coincidence case but on the *sum*: `‖P + Q‖² = 2 + 2·scos P Q`, so `scos P Q = -1` forces
+`P + Q = 0`.  Together with `scos_eq_one_iff` this pins the two extreme values of the
+spherical cosine `±1` to coincidence and antipodality. -/
+theorem scos_eq_neg_one_iff {P Q : E} (hP : OnSphere P) (hQ : OnSphere Q) :
+    scos P Q = -1 ↔ Q = -P := by
+  refine ⟨fun h => ?_, fun h => ?_⟩
+  · have hsq : ‖P + Q‖ ^ 2 = 0 := by
+      have expand : ⟪P + Q, P + Q⟫ = ‖P‖ ^ 2 + 2 * ⟪P, Q⟫ + ‖Q‖ ^ 2 := by
+        rw [inner_add_left, inner_add_right, inner_add_right,
+          real_inner_self_eq_norm_sq, real_inner_self_eq_norm_sq, real_inner_comm Q P]; ring
+      rw [← real_inner_self_eq_norm_sq, expand, hP, hQ]
+      rw [scos] at h; nlinarith [h]
+    have hz : ‖P + Q‖ = 0 := by nlinarith [norm_nonneg (P + Q), hsq]
+    rw [norm_eq_zero] at hz
+    exact (eq_neg_iff_add_eq_zero).mpr (by rw [add_comm]; exact hz)
+  · subst h; rw [scos_neg_right, scos_self P hP]
+
+/-- **The antipode is the unique point at spherical distance `π`.**  The dual of
+`sdist_eq_zero_iff` (point separation at the near end): for unit vectors `sdist P Q = π`
+iff `Q = -P`.  So `sdist` attains its maximum `π` exactly at the antipode, generalising the
+specific `sdist_antipode` (`sdist O (-O) = π`) to an *iff*.  Proof: `arccos` of the inner
+product equals `π` iff that inner product is `≤ -1`, which for unit vectors (where
+`scos ≥ -1`) forces `scos P Q = -1`, hence `Q = -P` by `scos_eq_neg_one_iff`. -/
+theorem sdist_eq_pi_iff {P Q : E} (hP : OnSphere P) (hQ : OnSphere Q) :
+    sdist P Q = Real.pi ↔ Q = -P := by
+  rw [sdist, Real.arccos_eq_pi]
+  constructor
+  · intro h
+    have hge : (-1 : ℝ) ≤ scos P Q := neg_one_le_scos P Q hP hQ
+    have hle : scos P Q ≤ -1 := by rw [scos]; exact h
+    exact (scos_eq_neg_one_iff hP hQ).mp (le_antisymm hle hge)
+  · intro h
+    have h1 : scos P Q = -1 := (scos_eq_neg_one_iff hP hQ).mpr h
+    rw [scos] at h1; exact h1.le
 
 end FeuerbachsTheoremOQ04


### PR DESCRIPTION
## Summary

The spherical-model metric layer in `FeuerbachsTheoremOQ04.lean` had **point separation at the near end** (`scos_eq_one_iff`, `sdist_eq_zero_iff`: `sdist = 0 ↔ P = Q`) and the *specific* `sdist_antipode` (`sdist O (-O) = π`), but not the **dual far-end characterisation**. This adds it — the `sdist = π` endpoint of the metric — axiom-free.

- **`scos_eq_neg_one_iff`** — for unit vectors, `scos P Q = -1 ↔ Q = -P`. Mirror of `scos_eq_one_iff` on the *sum*: `‖P + Q‖² = 2 + 2·scos P Q`, so `scos = -1` forces `P + Q = 0`. Together with `scos_eq_one_iff` this pins both extreme spherical-cosine values `±1` to coincidence / antipodality.
- **`sdist_eq_pi_iff`** — `sdist P Q = π ↔ Q = -P`, upgrading `sdist_antipode` from a single instance to an *iff*. So `sdist` attains its maximum `π` exactly at the antipode — the exact dual of `sdist_eq_zero_iff`.

## Verification

- Compiles clean under Lean **v4.26.0** / prebuilt Mathlib (`lake env lean`, exit 0, no errors/sorries).
- `#print axioms` on both: only `[propext, Classical.choice, Quot.sound]` — **axiom-free** (the file is 0-axiom/0-sorry throughout).
- Docstring feature list updated. Research-only slug (no gallery `meta.json`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)