### PR TITLE
Enrich Uniform Power-of-Two Obstruction: key-label core lemma + even-composite insight

### DIFF
--- a/src/data/proofs/angle-trisection-oq-02-oq-01-oq-02-oq-02/annotations.json
+++ b/src/data/proofs/angle-trisection-oq-02-oq-01-oq-02-oq-02/annotations.json
@@ -19,7 +19,7 @@
     "title": "The Core Obstruction: One Odd Prime Factor Suffices",
     "content": "`not_isPowTwo_of_odd_prime_dvd`: if an odd prime `q` divides `d`, then `d` is not a power of two. The proof is three steps and no case analysis: assume `d = 2^k`; then `q ∣ 2^k` gives `q ∣ 2` by `Nat.Prime.dvd_of_dvd_pow`; then `q = 2` by `Nat.prime_dvd_prime_iff_eq`, contradicting `q ≠ 2`. This is the entire arithmetic content of every classical compass-and-straightedge impossibility.",
     "mathContext": "If $d = 2^k$ then the only prime dividing $d$ is 2. Contrapositively, any odd prime divisor is an obstruction. For $d = 3$ (the degree of $\\cos 20°$, $\\sqrt[3]{2}$, $\\cos 2\\pi/7$) the odd prime is 3 itself.",
-    "significance": "supporting",
+    "significance": "key",
     "relatedConcepts": ["Euclid's lemma", "prime divisibility", "Wantzel obstruction"],
     "prerequisites": ["a prime dividing a^n divides a", "p ∣ q ↔ p = q for primes"]
   },

--- a/src/data/proofs/angle-trisection-oq-02-oq-01-oq-02-oq-02/meta.json
+++ b/src/data/proofs/angle-trisection-oq-02-oq-01-oq-02-oq-02/meta.json
@@ -70,7 +70,8 @@
       "The entire content of 'degree d is not a power of two' is the single fact 'd has an odd prime factor' — `q ∣ 2^k ⟹ q ∣ 2 ⟹ q = 2` is the whole proof, with no case analysis on k.",
       "Both the Wantzel degree predicate and the Galois 2-group predicate are *definitionally* `IsPowTwo` applied to a natural number (`p.natDegree` resp. `Fintype.card G`), so one arithmetic lemma serves both sides of the constructibility characterization.",
       "The parent's three separate `interval_cases k <;> simp_all` proofs become a single instance of `not_degreePowerOfTwo_of_natDegree_three`; the criterion extends for free to degree 5 (regular 11-gon) and any odd-prime degree.",
-      "On the group side, Cauchy's theorem (`exists_prime_orderOf_dvd_card`) turns the abstract obstruction into a concrete witness: an element whose order is the offending odd prime cannot exist in a 2-group."
+      "On the group side, Cauchy's theorem (`exists_prime_orderOf_dvd_card`) turns the abstract obstruction into a concrete witness: an element whose order is the offending odd prime cannot exist in a 2-group.",
+      "The obstruction is an odd prime *factor*, not an odd degree — so it also catches even composite degrees. `not_isPowTwo_six` uses 3 ∣ 6: a degree need not be odd to fail Wantzel, only to carry an odd prime factor. This is strictly stronger than both the parent's degree-3 arguments and the naive 'odd degree ⟹ non-constructible' heuristic — e.g. cos(2π/13) has an even degree-6 minimal polynomial (φ(13)/2 = 6 = 2·3) yet is non-constructible."
     ],
     "prerequisites": [
       "Divisibility and prime factorization over ℕ",


### PR DESCRIPTION
Enrichment pass for `angle-trisection-oq-02-oq-01-oq-02-oq-02`.

Mature entry (quality 96, 14.6 KB, 6 annotations, full section coverage), so two accurate, non-inflating improvements rather than a bulk deepen:

1. **Significance fix.** All 6 annotations were labeled `supporting`, including `ann-core-obstruction` — yet that lemma (`not_isPowTwo_of_odd_prime_dvd`) is the file's headline, described in its own body as *"the entire arithmetic content of every classical compass-and-straightedge impossibility."* Upgraded it to `key` so the labeling reflects the file's actual center of gravity.

2. **New keyInsight (4→5).** The annotations already note degree 6 = 2·3, but the keyInsights didn't surface the conceptual point: the obstruction is an odd prime *factor*, not an odd *degree*, so it catches even composite degrees too (e.g. cos(2π/13), even degree φ(13)/2 = 6 = 2·3, non-constructible). This is strictly stronger than the parent's degree-3 arguments and than the naive "odd degree ⟹ non-constructible" heuristic.

meta.json 14.6 KB → 15.1 KB (well under the 60 KB cap; keyInsights 5 ≤ 12). Validated clean by `annotations:build` against the Lean source.