### PR TITLE
research(erdos101-problem-oq-04): prove the [5/2,10] ellipsoid radius range is sharp

### DIFF
--- a/proofs/Proofs/Erdos101OQ04.lean
+++ b/proofs/Proofs/Erdos101OQ04.lean
@@ -3326,4 +3326,50 @@ theorem ternary_conic_sq_sum_pos_of_mem (p q r : ℝ)
     0 < p ^ 2 + q ^ 2 + r ^ 2 :=
   lt_of_lt_of_le (by norm_num) (ternary_conic_sq_sum_ge_of_mem p q r h)
 
+/-! ### Sharpness of the ellipsoidal shell: both extreme radii are attained
+
+`ternary_conic_sq_sum_mem_Icc` confines the squared abscissa radius to `[5/2, 10]`, and the
+docstring identifies these as the squared extreme semi-axes.  The two witnesses below prove
+those endpoints are actually *attained* on the surface `Q = 5`, so the image of `p²+q²+r²`
+over the conic is exactly the closed interval `[5/2, 10]` — the shell characterization is
+sharp, not merely an enclosure. -/
+
+/-- The upper radius bound `10` is attained on `Q = 5`: the trace-free point
+`(√5, -√5, 0)` satisfies `Q = 5` and `p²+q²+r² = 10`.  The trace `p+q+r` vanishes, so all of
+`Q = ½·((p²+q²+r²) + (p+q+r)²)` comes from the radius term — the maximal-radius direction. -/
+theorem exists_ternary_conic_sq_sum_eq_ten :
+    ∃ p q r : ℝ, p ^ 2 + q ^ 2 + r ^ 2 + p * q + q * r + r * p = 5
+      ∧ p ^ 2 + q ^ 2 + r ^ 2 = 10 := by
+  refine ⟨Real.sqrt 5, -Real.sqrt 5, 0, ?_, ?_⟩
+  · have h : Real.sqrt 5 ^ 2 = 5 := Real.sq_sqrt (by norm_num)
+    nlinarith [h]
+  · have h : Real.sqrt 5 ^ 2 = 5 := Real.sq_sqrt (by norm_num)
+    nlinarith [h]
+
+/-- The lower radius bound `5/2` is attained on `Q = 5`: the diagonal point
+`(√(5/6), √(5/6), √(5/6))` satisfies `Q = 5` and `p²+q²+r² = 5/2`.  Here `p = q = r`, the
+trace direction `(1,1,1)` — the minimal-radius semi-axis of the ellipsoid. -/
+theorem exists_ternary_conic_sq_sum_eq_five_halves :
+    ∃ p q r : ℝ, p ^ 2 + q ^ 2 + r ^ 2 + p * q + q * r + r * p = 5
+      ∧ p ^ 2 + q ^ 2 + r ^ 2 = 5 / 2 := by
+  refine ⟨Real.sqrt (5 / 6), Real.sqrt (5 / 6), Real.sqrt (5 / 6), ?_, ?_⟩
+  · have h : Real.sqrt (5 / 6) ^ 2 = 5 / 6 := Real.sq_sqrt (by norm_num)
+    nlinarith [h]
+  · have h : Real.sqrt (5 / 6) ^ 2 = 5 / 6 := Real.sq_sqrt (by norm_num)
+    nlinarith [h]
+
+/-- **The `[5/2, 10]` radius range is sharp.**  Both endpoints of
+`ternary_conic_sq_sum_mem_Icc` are attained on the conic `Q = 5`: the maximum `10` at the
+trace-free point `(√5, -√5, 0)` and the minimum `5/2` at the diagonal point
+`(√(5/6), √(5/6), √(5/6))`.  Together with the containment `ternary_conic_sq_sum_mem_Icc`,
+the image of `p²+q²+r²` over the surface is *exactly* `[5/2, 10]`: the ellipsoidal shell's
+extreme semi-axes `√(5/2)` and `√10` are genuinely realized, upgrading the docstring's
+"sharp" from prose to proof. -/
+theorem ternary_conic_sq_sum_range_sharp :
+    (∃ p q r : ℝ, p ^ 2 + q ^ 2 + r ^ 2 + p * q + q * r + r * p = 5
+        ∧ p ^ 2 + q ^ 2 + r ^ 2 = 5 / 2)
+      ∧ (∃ p q r : ℝ, p ^ 2 + q ^ 2 + r ^ 2 + p * q + q * r + r * p = 5
+        ∧ p ^ 2 + q ^ 2 + r ^ 2 = 10) :=
+  ⟨exists_ternary_conic_sq_sum_eq_five_halves, exists_ternary_conic_sq_sum_eq_ten⟩
+
 end Erdos101OQ04


### PR DESCRIPTION
## Summary

Proves the **sharpness** of the ellipsoidal-shell characterization of the four-point-line solution surface in `Erdos101OQ04.lean` (Erdős #101, problem `erdos101-problem-oq-04`).

The ternary-conic section shows the surface `Q = 5` (where `Q(p,q,r) = p²+q²+r²+pq+qr+rp`) is a bounded shell with squared abscissa radius `p²+q²+r² ∈ [5/2, 10]` (`ternary_conic_sq_sum_mem_Icc`). The docstring calls this interval "sharp" via the eigenvalue/semi-axis picture but never proves the endpoints are **attained**. This PR closes that gap:

- **`exists_ternary_conic_sq_sum_eq_ten`** — the maximum `10` is attained at the trace-free point `(√5, -√5, 0)` (where `p+q+r = 0`, so all of `Q = ½·((p²+q²+r²)+(p+q+r)²)` is radius).
- **`exists_ternary_conic_sq_sum_eq_five_halves`** — the minimum `5/2` is attained at the diagonal point `(√(5/6), √(5/6), √(5/6))` (the trace direction `(1,1,1)`).
- **`ternary_conic_sq_sum_range_sharp`** — packages both, so together with the containment `ternary_conic_sq_sum_mem_Icc` the image of `p²+q²+r²` over `Q = 5` is *exactly* `[5/2, 10]`: the extreme semi-axes `√(5/2)`, `√10` are genuinely realized.

## Verification

Compiled with Lean `v4.26.0` (host toolchain, prebuilt Mathlib oleans); full file elaborates clean (the two pre-existing open-asymptotic `sorry`s are untouched). All three new theorems are axiom-free:

```
'Erdos101OQ04.exists_ternary_conic_sq_sum_eq_ten'         depends on axioms: [propext, Classical.choice, Quot.sound]
'Erdos101OQ04.exists_ternary_conic_sq_sum_eq_five_halves' depends on axioms: [propext, Classical.choice, Quot.sound]
'Erdos101OQ04.ternary_conic_sq_sum_range_sharp'           depends on axioms: [propext, Classical.choice, Quot.sound]
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
