### PR TITLE
research(erdos-378): density is constant across each odd→even threshold pair

### DIFF
--- a/proofs/Proofs/Erdos378Problem.lean
+++ b/proofs/Proofs/Erdos378Problem.lean
@@ -634,4 +634,36 @@ theorem erdos_378_density_antitone {r r' : ℕ} {d d' : ℝ} (hr : r ≤ r')
     (hd' : NaturalDensity (atLeastSquarefree r') d') : d' ≤ d :=
   natDensity_mono (atLeastSquarefree_antitone hr) hd' hd
 
+/-- **The density is constant across each odd → even threshold pair.**  The Granville–Ramaré
+value `erdos_378_density_eq` is `density(r) = 1 − Σ_{m ≤ (r-1)/2} η_m`, whose summation range
+bound `(r-1)/2 + 1` takes the *same* value `t + 1` at both `r = 2t+1` and `r = 2t+2` (integer
+division: `(2t)/2 = (2t+1)/2 = t`).  Hence the answer sets at an odd threshold and the next even
+threshold have **identical density** `1 − Σ_{m<t+1} η_m`.  Combined with the antitone profile
+`erdos_378_density_antitone`, this pins down the shape of `r ↦ density(r)`: a descending step
+function that drops only at *odd* thresholds and is flat across each `2t+1 → 2t+2` step. -/
+theorem erdos_378_density_odd_even_pair (t : ℕ) :
+    NaturalDensity (atLeastSquarefree (2 * t + 1))
+        (1 - ∑ m ∈ range (t + 1), eta m)
+      ∧ NaturalDensity (atLeastSquarefree (2 * t + 2))
+        (1 - ∑ m ∈ range (t + 1), eta m) := by
+  refine ⟨?_, ?_⟩
+  · have h := erdos_378_density_eq (2 * t + 1)
+    have he : (2 * t + 1 - 1) / 2 + 1 = t + 1 := by omega
+    rwa [he] at h
+  · have h := erdos_378_density_eq (2 * t + 2)
+    have he : (2 * t + 2 - 1) / 2 + 1 = t + 1 := by omega
+    rwa [he] at h
+
+/-- **Odd and next-even thresholds share every density.**  Corollary of
+`erdos_378_density_odd_even_pair` via `naturalDensity_unique`: any density of
+`atLeastSquarefree (2t+1)` is also a density of `atLeastSquarefree (2t+2)` (they are equal as
+real numbers).  So the strict drops in the Erdős #378 density profile can occur only at even
+→ odd transitions, never across an odd → even step. -/
+theorem atLeastSquarefree_density_odd_even_agree (t : ℕ) {d : ℝ}
+    (h : NaturalDensity (atLeastSquarefree (2 * t + 1)) d) :
+    NaturalDensity (atLeastSquarefree (2 * t + 2)) d := by
+  obtain ⟨h1, h2⟩ := erdos_378_density_odd_even_pair t
+  have hd : d = 1 - ∑ m ∈ range (t + 1), eta m := naturalDensity_unique h h1
+  rwa [hd]
+
 end Erdos378

--- a/src/data/proofs/erdos-378/meta.json
+++ b/src/data/proofs/erdos-378/meta.json
@@ -65,9 +65,9 @@
       "erdos_378, erdos_378_answer (no sorries): combined resolution of both questions"
     ],
     "axiomCount": 2,
-    "lineCount": 637,
+    "lineCount": 669,
     "assumptions": "2 axioms, both isolating the deep analytic content of Granville-Ramaré (1996): granville_ramare_density_exists (the density η_m of n with exactly 2m+2 squarefree binomials exists) and complement_density (the set of n with fewer than r squarefree binomials has density Σ_{0≤m≤(r-1)/2} η_m, which is < 1). 0 sorries. All other results, including the resolution of both questions and the parity theorems squarefreeCount_even_of_odd (odd rows have an even count) and squarefreeCount_odd_iff_central_squarefree (an even row has an odd count iff its central binomial C(n,n/2) is squarefree), are fully machine-checked (depend only on propext/Classical.choice/Quot.sound).",
-    "theoremCount": 26,
+    "theoremCount": 28,
     "definitionCount": 8,
     "additionalFiles": [
       "Proofs/Erdos378Aristotle.lean"


### PR DESCRIPTION
## Summary

Refines the Erdős #378 density profile with a **shape** result. The file proves the density is antitone in the threshold `r` (`erdos_378_density_antitone`) and has the explicit Granville–Ramaré value `density(r) = 1 − Σ_{m ≤ (r-1)/2} η_m` (`erdos_378_density_eq`). This PR observes that the summation range bound `(r−1)/2 + 1` is **identical** for `r = 2t+1` and `r = 2t+2` (integer division: `(2t)/2 = (2t+1)/2 = t`), so the density is *flat* across each odd → even step.

## New theorems

| Theorem | Statement |
|---|---|
| `erdos_378_density_odd_even_pair` | `density(atLeastSquarefree (2t+1)) = density(atLeastSquarefree (2t+2)) = 1 − Σ_{m<t+1} η_m` |
| `atLeastSquarefree_density_odd_even_agree` | corollary via `naturalDensity_unique`: any density of the `(2t+1)`-set is a density of the `(2t+2)`-set |

**Consequence.** The profile `r ↦ density(r)` is a descending step function that drops **only at even → odd transitions** and is constant across each `2t+1 → 2t+2` step — a structural sharpening of the monotone (antitone) result, pinning down *where* the density can decrease.

## Verification

Host `lean v4.26.0` against prebuilt Mathlib oleans, **0 errors**. Both new theorems rest solely on the file's two existing disclosed Granville–Ramaré axioms (`granville_ramare_density_exists`, `complement_density`) — **no new axioms** (`axiomCount` stays 2), no `sorry`. Meta updated: `theoremCount` 26→28, `lineCount` 637→669.

🤖 Generated with [Claude Code](https://claude.com/claude-code)