### PR TITLE
Enrich 2-Group Backbone of Constructibility: fix overlapping sections + Nat.card design insight

### DIFF
--- a/src/data/proofs/angle-trisection-oq-02-oq-01-oq-02-oq-03/meta.json
+++ b/src/data/proofs/angle-trisection-oq-02-oq-01-oq-02-oq-03/meta.json
@@ -75,7 +75,8 @@
       "The sufficiency direction of Wantzel–Galois factors cleanly into a group-theoretic core (proved here, fully machine-checked) and a field-theoretic translation (the Galois correspondence), so the hard-looking `wantzel_galois_iff` reduces to standard Mathlib 2-group machinery plus a fixed-field bookkeeping step.",
       "A nontrivial finite 2-group always has a normal subgroup of index 2 — Sylow's first theorem supplies a subgroup of order 2^(k-1), and index-2 subgroups are automatically normal. Iterating on the quotient gives the full normal chain with ℤ/2 factors.",
       "Under the Galois correspondence this descending chain of normal index-2 subgroups is an ascending tower of degree-2 field extensions — i.e. a compass-and-straightedge tower — which is precisely the constructibility witness `IsConstructible` in the parent entry.",
-      "Nilpotency (not merely solvability) is what guarantees the chain can be taken with each subgroup normal in the whole group at the top step; solvability is recorded separately because it is the customary hypothesis in the classical Galois phrasing."
+      "Nilpotency (not merely solvability) is what guarantees the chain can be taken with each subgroup normal in the whole group at the top step; solvability is recorded separately because it is the customary hypothesis in the classical Galois phrasing.",
+      "Defining `IsTwoGroup` with `Nat.card` rather than `Fintype.card` is the choice that lets the Mathlib API apply off the shelf: `IsPGroup`, Sylow's theorems, and `Subgroup.index` are all stated in `Nat.card` terms. The explicit bridge lemma `isTwoGroup_of_fintype_card` exists solely to reconcile this with the parent/sibling entries' `Fintype.card` phrasing — a reminder that in a formalization the right definitional packaging, not a clever proof, is often what unlocks an existing library."
     ],
     "prerequisites": [
       "Finite p-groups and IsPGroup",
@@ -90,13 +91,13 @@
       "id": "part1-definition-bridge",
       "title": "Part 1: The 2-group predicate and the bridge to the parent",
       "startLine": 65,
-      "endLine": 90,
+      "endLine": 82,
       "summary": "Defines IsTwoGroup via Nat.card (so it plugs into Mathlib's IsPGroup/Sylow/Index API) and proves isTwoGroup_of_fintype_card connecting it to the parent entry's Fintype.card formulation."
     },
     {
       "id": "part2-nilpotent-solvable",
       "title": "Part 2: Every finite 2-group is nilpotent and solvable",
-      "startLine": 84,
+      "startLine": 83,
       "endLine": 104,
       "summary": "isPGroup_two turns 'order 2^k' into IsPGroup 2; isNilpotent and isSolvable deduce nilpotency (via IsPGroup.isNilpotent) and solvability (via the nilpotent ⟹ solvable instance)."
     },


### PR DESCRIPTION
Enrichment pass for `angle-trisection-oq-02-oq-01-oq-02-oq-03`.

Mature entry (quality 96, 14.4 KB), so a correctness fix plus one accurate insight rather than a bulk deepen:

1. **Section-overlap fix (real defect).** `part1` (65–90) and `part2` (84–104) overlapped, and `isPGroup_two` (line 83/85) was straddled between them even though both section summaries assign it to part2. Retiled to non-overlapping `65–82 / 83–104 / 105–133 / 134–152`, placing `isPGroup_two` in part2.

2. **New keyInsight (4→5).** A genuine formalization design point the file embodies: `IsTwoGroup` is defined with `Nat.card` (not `Fintype.card`) precisely so Mathlib's `IsPGroup`/Sylow/`Subgroup.index` API applies off the shelf — and `isTwoGroup_of_fintype_card` exists only to bridge to the parent/sibling `Fintype.card` phrasing.

meta.json 14.4 KB → 14.9 KB (well under caps; keyInsights 5 ≤ 12; sections verified non-overlapping). Validated clean by `annotations:build`.