### PR TITLE
Enrich Classical AM-GM (n terms): add sibling & Maclaurin cross-references

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-05-oq-02-oq-01/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-05-oq-02-oq-01/meta.json
@@ -56,6 +56,16 @@
       "targetId": "amgm-inequality",
       "relationship": "related",
       "description": "Delivers the AM-GM family's most familiar member — geometric mean ≤ arithmetic mean for n positive reals, sharp iff the reals are equal — in the canonical (∏ xᵢ)^{1/n} versus (∑ xᵢ)/n form."
+    },
+    {
+      "targetId": "amgm-inequality-oq-05-oq-01",
+      "relationship": "related",
+      "description": "A sibling equality-case characterisation under the same oq-05 parent: the equality case of Hölder's inequality for finite sums. Like this entry it supplies a sharpness clause that Mathlib provides the inequality for but does not package, and both are read off from the same strict convexity/concavity (Jensen) equality machinery — here strictConcaveOn_log_Ioi.map_sum_eq_iff, there the conjugate-exponent convexity underlying Hölder."
+    },
+    {
+      "targetId": "amgm-inequality-oq-02-oq-02",
+      "relationship": "related",
+      "description": "Newton's log-concavity and the Maclaurin step Mₖ ≥ Mₖ₊₁ for the normalised elementary symmetric means Sₖ = eₖ/C(n,k). The Maclaurin chain S₁ ≥ S₂^{1/2} ≥ … ≥ Sₙ^{1/n} refines exactly this AM ≥ GM result: its endpoints are S₁ = (∑ xᵢ)/n = A and Sₙ^{1/n} = (∏ xᵢ)^{1/n} = G, so it interpolates intermediate symmetric means strictly between the arithmetic and geometric means of this entry — the symmetric-function counterpart of the power-mean chain in the first open question."
     }
   ],
   "references": [


### PR DESCRIPTION
Enrichment pass for `amgm-inequality-oq-05-oq-02-oq-01`.

The entry is already high quality (prose, keyInsights, sections, annotations all meet targets; meta.json well under the 60 KB cap). The marginal quality gap is cross-referencing: it had only 2 crossReferences despite sitting in a rich AM-GM family. Added 2 accurate lateral links (2 → 4):

- **amgm-inequality-oq-05-oq-01** (Equality Case of Hölder's Inequality) — sibling equality-case characterisation under the same `oq-05` parent; both supply a sharpness clause Mathlib omits, both derived from the strict convexity/concavity Jensen equality machinery.
- **amgm-inequality-oq-02-oq-02** (Newton log-concavity / Maclaurin step) — the Maclaurin mean chain $S_1 \ge S_2^{1/2} \ge \cdots \ge S_n^{1/n}$ refines this AM ≥ GM result, with endpoints $S_1 = A$ and $S_n^{1/n} = G$; directly answers the theme of the entry's first open question (interpolating means between A and G).

Both target slugs verified present. JSON validated; `check-meta-size.ts` passes (13.4 KB). No prose deepening — entry is saturated, so this is curation, not accretion.