### PR TITLE
research(erdos-1022-oq-02): §9 value-form divergence modulus + Property-B converse

### DIFF
--- a/proofs/Proofs/Erdos1022OQ02.lean
+++ b/proofs/Proofs/Erdos1022OQ02.lean
@@ -629,4 +629,93 @@ theorem admissibleCoeff_mono {a b : ℕ} (hab : a ≤ b) :
       ≤ firstMomentThreshold b / Fintype.card V :=
   Nat.div_le_div_right (firstMomentThreshold_mono hab)
 
+-- ══════════════════════════════════════════════════════════════════
+-- § 9: Modulus of divergence in *value* form, and the Property-B payoff
+-- ══════════════════════════════════════════════════════════════════
+
+/-
+  §§ 5-7 measure the growth of the coefficient `c(t) = ⌊2^{t-1}/|V|⌋` *by rate*:
+  every explicit bound is phrased as "`2^k ≤ c(t + k)`" — a statement about the
+  exponent `k`, not the value reached.  What is still missing is the dual,
+  *value*-indexed reading of the same divergence: given a target coefficient
+  `N`, at which step is it attained?  This section supplies the explicit
+  (linear) modulus `t₀ = |V| + 1 + N` with `N ≤ c(t₀)`, names the coefficient's
+  own `Tendsto … atTop` (used only inline so far, inside
+  `exists_admissible_coeff`), and — the mathematical point — *inverts* the
+  divergence back to Property B: because `c(t)` overtakes every fixed `N`, any
+  *fixed* sparseness coefficient `N`, however large, is defeated once the
+  minimum set size is large enough.  This is the effective converse to
+  `exists_admissible_coeff`, which fixed a diverging `c(t)`; here `N` is fixed
+  and the minimum size varies.
+-/
+
+/-- **The admissible coefficient tends to infinity (named).**  Over a fixed
+    nonempty ground set, `c(t) = ⌊2^{t-1}/|V|⌋ → ∞` as `t → ∞`.  This divergence
+    is used *inline* in the proof of `exists_admissible_coeff` (as the first
+    conjunct of its witness), but is recorded here as a standalone lemma — the
+    coefficient-level companion of `firstMomentThreshold_tendsto_atTop`, and the
+    literal `c_t → ∞` of Problem #1022 read off the explicit coefficient. -/
+theorem admissibleCoeff_tendsto_atTop (hV : 0 < Fintype.card V) :
+    Filter.Tendsto (fun t => firstMomentThreshold t / Fintype.card V)
+      Filter.atTop Filter.atTop :=
+  (tendsto_div_const_atTop hV).comp firstMomentThreshold_tendsto_atTop
+
+/-- **Explicit linear modulus of divergence (value form).**  Every target
+    coefficient value `N` is reached by the explicit, *linear* step
+    `t₀ = |V| + 1 + N`:
+
+        `N ≤ c(|V| + 1 + N) = ⌊2^{|V| + N}/|V|⌋`.
+
+    Where §§ 5-7 bound the coefficient by rate (`2^k ≤ c(|V|+1+k)`, an exponent
+    statement), this reads the same divergence off in the dual direction — as an
+    explicit *inverse* modulus telling, for each desired value `N`, a concrete
+    step at which the coefficient has surpassed it.  Proof: the exponential
+    bound `2^N ≤ c(|V|+1+N)` of `admissibleCoeff_ge_two_pow_of_card` combined
+    with `N ≤ 2^N`. -/
+theorem admissibleCoeff_ge_self (hV : 0 < Fintype.card V) (N : ℕ) :
+    N ≤ firstMomentThreshold (Fintype.card V + 1 + N) / Fintype.card V := by
+  have hpow := admissibleCoeff_ge_two_pow_of_card hV N
+  have hN : N ≤ 2 ^ N := Nat.le_of_lt Nat.lt_two_pow_self
+  exact le_trans hN hpow
+
+/-- **Eventual dominance of any target (value form, filter).**  Packaging
+    `admissibleCoeff_ge_self` with the monotonicity `admissibleCoeff_mono`: for
+    every target `N`, the coefficient is *eventually* at least `N`,
+
+        `∀ N, ∀ᶠ t, N ≤ c(t)`,
+
+    with the explicit witness step `t₀ = |V| + 1 + N`.  This is the value-indexed
+    shadow of `admissibleCoeff_tendsto_atTop` with a concrete modulus attached. -/
+theorem admissibleCoeff_eventually_ge (hV : 0 < Fintype.card V) (N : ℕ) :
+    ∀ᶠ t in Filter.atTop, N ≤ firstMomentThreshold t / Fintype.card V :=
+  Filter.eventually_atTop.mpr
+    ⟨Fintype.card V + 1 + N, fun _t ht =>
+      le_trans (admissibleCoeff_ge_self hV N) (admissibleCoeff_mono ht)⟩
+
+/-- **Large minimum size defeats any fixed sparseness coefficient (the payoff).**
+    The effective converse of `exists_admissible_coeff`.  There the coefficient
+    `c(t)` was allowed to grow with `t`; here we *fix* an arbitrary target
+    sparseness coefficient `N` and show it is tolerated once the minimum set size
+    is large enough: there is an explicit threshold `t₀` (namely `|V| + 1 + N`)
+    such that every `N`-sparse family whose members all have size at least `t₀`
+    has Property B.
+
+        `∀ N, ∃ t₀ ≥ 1, ∀ F, (∀ e ∈ F, t₀ ≤ |e|) → IsSparse F N → HasPropertyB F`.
+
+    So no *constant* sparseness bound is an obstruction to first-moment
+    2-colorability: the minimum size can always be pushed high enough to absorb
+    it.  Proof: `admissibleCoeff_ge_self` gives `N ≤ c(t₀)`, hence
+    `N · |V| ≤ 2^{t₀-1}`, which is exactly the hypothesis `propertyB_of_sparse`
+    needs. -/
+theorem exists_min_size_for_sparse_bound [DecidableEq V] (hV : 0 < Fintype.card V)
+    (N : ℕ) :
+    ∃ t₀ : ℕ, 1 ≤ t₀ ∧ ∀ (F : Finset (Finset V)),
+      (∀ e ∈ F, t₀ ≤ e.card) → IsSparse F N → HasPropertyB F := by
+  refine ⟨Fintype.card V + 1 + N, by omega, fun F hmin hsparse => ?_⟩
+  have hcoeff : N ≤ firstMomentThreshold (Fintype.card V + 1 + N) / Fintype.card V :=
+    admissibleCoeff_ge_self hV N
+  have hbound : N * Fintype.card V ≤ firstMomentThreshold (Fintype.card V + 1 + N) :=
+    (Nat.le_div_iff_mul_le hV).mp hcoeff
+  exact propertyB_of_sparse F (Fintype.card V + 1 + N) N (by omega) hmin hsparse hbound
+
 end Erdos1022OQ02

--- a/src/data/proofs/erdos-1022-oq-02/meta.json
+++ b/src/data/proofs/erdos-1022-oq-02/meta.json
@@ -25,7 +25,7 @@
     "mathlib_version": "4.26.0",
     "axiomCount": 0,
     "assumptions": "No axioms and no sorries: all theorems are fully machine-checked from Mathlib (depends only on propext / Classical.choice / Quot.sound). This is a partial result addressing the first-moment regime of OQ-02; the open conjecture of Erdős #1022 (whether c_t → ∞ for arbitrarily large ground sets) is NOT resolved here.",
-    "lineCount": 632,
+    "lineCount": 721,
     "relatedProblems": [
       {
         "id": "erdos-1022",
@@ -40,7 +40,7 @@
         "relationship": "Builds on: Erdős 1963 uniform first-moment theorem (reuses Mono, card_mono, exists_zero_of_sum_lt_card)"
       }
     ],
-    "theoremCount": 25,
+    "theoremCount": 32,
     "definitionCount": 3
   },
   "overview": {
@@ -129,10 +129,10 @@
     }
   ],
   "leanFile": {
-    "lineCount": 632,
+    "lineCount": 721,
     "structureCount": 0,
     "axiomCount": 0,
-    "theoremCount": 25,
+    "theoremCount": 32,
     "lemmaCount": 0,
     "imports": [
       "Mathlib",


### PR DESCRIPTION
## Summary

Extends the saturated first-moment sparseness-threshold file for **Erdős #1022 OQ-02** (growth rate of the sparseness threshold `c_t`) with a new **§9**. Sections §1–§8 were already fully axiom-free and measured the coefficient `c(t)=⌊2^{t-1}/|V|⌋` growth *by rate* — every effective bound was of the form `2^k ≤ c(|V|+1+k)`, a statement about the exponent `k`. This iteration reads the **same divergence in the dual, value-indexed direction** and inverts it back to Property B.

## New theorems (all axiom-free)

- **`admissibleCoeff_tendsto_atTop`** — names the coefficient's own `Tendsto … atTop`, which until now appeared only *inline* inside `exists_admissible_coeff`. The literal `c_t → ∞` read off the explicit coefficient.
- **`admissibleCoeff_ge_self`** — explicit **linear modulus** `N ≤ c(|V|+1+N)`: for each target value `N`, a concrete step at which the coefficient has surpassed it (dual to the rate-form `2^k` bounds).
- **`admissibleCoeff_eventually_ge`** — filter form `∀ N, ∀ᶠ t, N ≤ c(t)` with the explicit witness `t₀ = |V|+1+N`.
- **`exists_min_size_for_sparse_bound`** — **the payoff**: the effective *converse* of `exists_admissible_coeff`. Where that theorem fixed a diverging coefficient `c(t)`, here we fix an **arbitrary constant** sparseness coefficient `N` and show it is defeated once the minimum set size is large enough — there is an explicit threshold `t₀ = |V|+1+N` past which every `N`-sparse family of minimum size `t₀` has Property B. So no *constant* sparseness bound obstructs first-moment 2-colorability.

## Verification

- `#print axioms` on all four: `[propext, Classical.choice, Quot.sound]` only — no `sorryAx`, no `ofReduceBool`.
- Compiled against Mathlib v4.26.0 + `Proofs.PropertyBFirstMoment`.
- **28 → 32 theorems, 632 → 721 lines, 0 sorries, 0 axioms.** `meta.json` counts updated.

## Honest scope

Does **not** resolve the open conjecture. The crude ground-set bound still fails once `V` is allowed to grow with the family; this is the first-moment regime for bounded ground sets, read in value-form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)