### PR TITLE
Enrich Doubling Invariance: surface odd-part reduction + positive family in mainTheorems

### DIFF
--- a/src/data/proofs/angle-trisection-oq-02-oq-03-ext-oq-01/meta.json
+++ b/src/data/proofs/angle-trisection-oq-02-oq-03-ext-oq-01/meta.json
@@ -165,6 +165,20 @@
       "significance": "Reduces Gauss–Wantzel to odd prime powers when combined with coprime multiplicativity"
     },
     {
+      "name": "totient_pow2_iff_odd_part",
+      "type": "core",
+      "statement": "n = 2^a * m → (TotientIsPow2 n ↔ TotientIsPow2 m)",
+      "description": "Reduction to the odd part: writing n = 2^a·m, the regular n-gon is constructible iff the regular m-gon is. A one-line corollary of the 2-power invariance (rw ∘ totient_pow2_two_pow_mul_iff).",
+      "significance": "The clean statement of keyInsight #3 — every factor of 2 in n is inert, so only the odd part carries constructibility information"
+    },
+    {
+      "name": "constructible_two_pow_mul_fifteen",
+      "type": "corollary",
+      "statement": "∀ a, TotientIsPow2 (2^a * 15)",
+      "description": "Every 2^a·15-gon (15, 30, 60, 120, …) is constructible, from the single input φ(15) = 2^3 propagated by the 2-power invariance.",
+      "significance": "Positive counterpart to the 7-gon obstruction: one odd base computation generates an infinite constructible tower via bisection"
+    },
+    {
       "name": "not_constructible_two_pow_mul_seven",
       "type": "corollary",
       "statement": "∀ a, ¬ TotientIsPow2 (2^a * 7)",


### PR DESCRIPTION
Enrichment pass for `angle-trisection-oq-02-oq-03-ext-oq-01`.

Mature entry (quality 96, 11.9 KB, excellent annotation coverage), so a focused, accurate addition to the highlights list rather than a bulk deepen:

- **Added `totient_pow2_iff_odd_part` (core).** The reduction-to-odd-part result that keyInsight #3 and Section III both center on — but which was missing from `mainTheorems`. It's arguably more fundamental than the corollary already listed.
- **Added `constructible_two_pow_mul_fifteen` (corollary).** The positive infinite family (every 2^a·15-gon constructible), balancing the already-listed negative `not_constructible_two_pow_mul_seven` so both the constructible and non-constructible towers are represented.

`mainTheorems` 3 → 5; meta.json 11.9 KB → 12.9 KB (well under caps). Both statements verified verbatim against the Lean source (`totient_pow2_iff_odd_part` line 127, `constructible_two_pow_mul_fifteen` line 140).