### PR TITLE
Enrich Uniform Power-of-Two Constructibility Obstruction: add degree/group-side cross-references

### DIFF
--- a/src/data/proofs/angle-trisection-oq-02-oq-01-oq-02-oq-02/meta.json
+++ b/src/data/proofs/angle-trisection-oq-02-oq-01-oq-02-oq-02/meta.json
@@ -127,6 +127,21 @@
       "targetId": "abel-ruffini",
       "relationship": "related",
       "description": "Abel–Ruffini uses Galois-group structure (solvability) to prove insolvability of the quintic; here the Galois-group structure at issue is being a 2-group, obstructed by the same odd-prime-factor lemma."
+    },
+    {
+      "targetId": "angle-trisection-cos-20-gal",
+      "relationship": "related",
+      "description": "The concrete group-side witness of this uniform obstruction: the Galois group of 8X³ − 6X − 1 (the minimal polynomial of cos 20°) over ℚ has order 3. Because 3 carries an odd prime factor it is not a power of two — exactly the arithmetic fact isolated here — so cos 20° is non-constructible and the 60° angle cannot be trisected. It instantiates the 'Galois 2-group side' with a specific polynomial."
+    },
+    {
+      "targetId": "angle-trisection-oq-01-oq-02",
+      "relationship": "related",
+      "description": "The arithmetic Gauss–Wantzel criterion: a regular n-gon is constructible iff φ(n) is a power of two. This entry's power-of-two obstruction is the necessity engine — whenever φ(n) has an odd prime factor the n-gon is non-constructible. Feeding φ(11) = 10 (odd factor 5) into that criterion is precisely what would close this entry's second open question on the regular 11-gon."
+    },
+    {
+      "targetId": "angle-trisection-oq-02-oq-01-oq-02-oq-03",
+      "relationship": "related",
+      "description": "A sibling under the same parent covering the opposite (sufficiency) direction: the 2-group backbone — every finite 2-group is nilpotent, hence solvable, with a normal subgroup of index 2. This entry supplies the necessity obstruction (an odd prime factor forces a non-power-of-two order, blocking constructibility); the sibling supplies the group-side backbone of the converse. Together they are the two halves this entry's first open question proposes to merge into wantzel_galois_iff."
     }
   ],
   "mainTheorems": [


### PR DESCRIPTION
Enrichment pass for `angle-trisection-oq-02-oq-01-oq-02-oq-02` (A Uniform Power-of-Two Obstruction for Constructibility).

Entry is already high quality and well under all size caps; the marginal gap is cross-referencing (only 2 links despite being the shared arithmetic core of the whole constructibility cluster). Added 3 accurate, on-theme links (2 → 5):

- **angle-trisection-cos-20-gal** — the concrete *group-side* witness: |Gal(8X³−6X−1/ℚ)| = 3, an odd (non-power-of-two) order, hence cos 20° is non-constructible and 60° cannot be trisected. Instantiates the entry's 'Galois 2-group side'.
- **angle-trisection-oq-01-oq-02** — the arithmetic Gauss–Wantzel criterion (regular n-gon constructible iff φ(n) a power of two). This obstruction is its necessity engine; φ(11)=10 is exactly what closes the entry's second open question on the regular 11-gon.
- **angle-trisection-oq-02-oq-01-oq-02-oq-03** — sibling under the same parent covering the *sufficiency* (2-group backbone) direction; together the two entries are the halves the first open question proposes to merge into `wantzel_galois_iff`.

All target slugs verified present; JSON validated; `check-meta-size.ts` passes. Curation only — no prose inflation.