### PR TITLE
research(erdos-729-oq-02): single-step v₂-factorial recurrence + monotonicity

### DIFF
--- a/proofs/Proofs/Erdos729LegendreRecurrence.lean
+++ b/proofs/Proofs/Erdos729LegendreRecurrence.lean
@@ -125,6 +125,28 @@ theorem v2_factorial_eq_pred_iff (n : ℕ) (hn : 1 ≤ n) :
   rw [hL]
   omega
 
+/-- **Single-step recurrence.** `v₂((n+1)!) = v₂(n+1) + v₂(n!)`.
+
+The fundamental one-step form underlying the doubling (`v2_factorial_two_mul`)
+and odd-step (`v2_factorial_two_mul_add_one`) recurrences: passing from `n!` to
+`(n+1)!` multiplies by `n+1`, adding exactly `v₂(n+1)` factors of two.  Immediate
+from `Nat.factorial_succ` and additivity of `padicValNat` over products. -/
+theorem v2_factorial_succ (n : ℕ) :
+    padicValNat 2 (n + 1).factorial
+      = padicValNat 2 (n + 1) + padicValNat 2 n.factorial := by
+  haveI : Fact (Nat.Prime 2) := ⟨Nat.prime_two⟩
+  rw [Nat.factorial_succ,
+    padicValNat.mul (Nat.succ_ne_zero n) (Nat.factorial_ne_zero n)]
+
+/-- **Monotonicity of the 2-adic valuation of factorials.** `n ↦ v₂(n!)` is
+`Monotone`: the valuation never decreases as `n` grows, since each step from `n!`
+to `(n+1)!` adds the nonnegative amount `v₂(n+1)` (`v2_factorial_succ`).  The
+qualitative envelope of the exact doubling/odd-step recurrences above. -/
+theorem v2_factorial_monotone :
+    Monotone (fun n => padicValNat 2 (Nat.factorial n)) :=
+  monotone_nat_of_le_succ fun n => by
+    rw [v2_factorial_succ]; omega
+
 #check @v2_factorial_two_mul
 #check @v2_factorial_two_mul_add_one
 #check @v2_factorial_eq_pred_iff


### PR DESCRIPTION
## Summary

OQ-02 (Legendre's formula `v₂(n!) = n − s₂(n)`) is already resolved. This PR extends the p=2 recurrence toolkit in `Erdos729LegendreRecurrence.lean`, which had the **doubling** (`v2_factorial_two_mul`) and **odd-step** (`v2_factorial_two_mul_add_one`) recurrences but not the fundamental single-step form they both specialise, nor the monotonicity corollary.

## New theorems

- **`v2_factorial_succ`** — `v₂((n+1)!) = v₂(n+1) + v₂(n!)`. The fundamental one-step recurrence: passing from `n!` to `(n+1)!` multiplies by `n+1`, adding exactly `v₂(n+1)` factors of two. From `Nat.factorial_succ` and additivity of `padicValNat` over products.
- **`v2_factorial_monotone`** — `n ↦ v₂(n!)` is `Monotone`: the valuation never decreases, since each step adds the nonnegative `v₂(n+1)`. The qualitative envelope of the exact doubling/odd-step recurrences.

## Verification

Built with `lean v4.26.0`; both new theorems:

```
depends on axioms: [propext, Classical.choice, Quot.sound]
```

No `sorry`, no `axiom`, no `native_decide`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)