### PR TITLE
research(hilbert-10-oq-01-oq-02): affine group action laws for affinePullback [VERIFIED axiom-free]

### DIFF
--- a/proofs/Proofs/Hilbert10OQ01OQ02.lean
+++ b/proofs/Proofs/Hilbert10OQ01OQ02.lean
@@ -3177,6 +3177,40 @@ theorem int_universalExistential_iff_affinePullback_universalExistential
     have hpq := hP q
     simpa only [affinePullback, hq] using hpq
 
+/-! ### The affine group acts on `RatSubset`
+
+The affine reparametrisations `q ↦ a·q + b` (with `a ≠ 0`) form a group — the
+affine group `ℚ ⋊ ℚˣ` — and `affinePullback` is its (contravariant) action on
+`RatSubset`. These are the algebraic identities underlying the affine-invariance
+theorems above (`int_diophantine_iff_affinePullback_diophantine` and its Σ₂/Π₂
+siblings): the converse directions are exactly the composition law with the inverse
+reparametrisation. Combined with the closure lemmas
+`affinePullback_is{,Co}DiophantineDefinition` / `…{Existential,Universal}…`, this
+says each of the four definability classes is an invariant subset of the action. -/
+
+/-- **Identity of the affine action.** Pulling back along `q ↦ q` (`a = 1, b = 0`)
+is the identity on `RatSubset`. -/
+theorem affinePullback_id (S : RatSubset) : affinePullback 1 0 S = S := by
+  funext q; simp [affinePullback]
+
+/-- **Composition law of the affine action.** Pulling back by `q ↦ a·q + b` after
+`q ↦ c·q + d` is pulling back by the composite `q ↦ (c·a)·q + (c·b + d)`:
+`affinePullback a b (affinePullback c d S) = affinePullback (c·a) (c·b + d) S`. So
+`affinePullback` turns composition of affine maps into composition of pullbacks
+(contravariantly). -/
+theorem affinePullback_comp (a b c d : Rat) (S : RatSubset) :
+    affinePullback a b (affinePullback c d S) = affinePullback (c * a) (c * b + d) S := by
+  funext q; simp only [affinePullback]; congr 1; ring
+
+/-- **The affine action is invertible (`a ≠ 0`).** Pulling back by `q ↦ a·q + b`
+undoes pulling back by its inverse reparametrisation `q ↦ a⁻¹·q − a⁻¹·b`, recovering
+`S`. This is the composition law specialised to the inverse pair, and is exactly the
+round-trip used in the converse halves of the affine-invariance equivalences. -/
+theorem affinePullback_cancel {a : Rat} (ha : a ≠ 0) (b : Rat) (S : RatSubset) :
+    affinePullback a b (affinePullback a⁻¹ (-(a⁻¹ * b)) S) = S := by
+  rw [affinePullback_comp]
+  simp only [inv_mul_cancel₀ ha, add_neg_cancel, affinePullback_id]
+
 -- ============================================================
 -- Part IX: The landscape, sharpened
 -- ============================================================

--- a/src/data/proofs/hilbert-10-oq-01-oq-02/meta.json
+++ b/src/data/proofs/hilbert-10-oq-01-oq-02/meta.json
@@ -142,7 +142,8 @@
       "affinePullback_isUniversalExistentialDefinition: Π₂ (∀∃) is closed under affine pullback; dual of the Σ₂ case.",
       "affinePullback_int_isUniversalExistentialDefinition: for any a, b : ℚ the set {q | a·q + b ∈ ℤ} is Π₂-definable — affine invariance of the SETTLED (Koenigsmann) level. Specializes to scaled lattices {q | a·q ∈ ℤ} and translates {q | q + b ∈ ℤ}.",
       "affinePullback_notInt_isExistentialUniversalDefinition: dual corollary — {q | a·q + b ∉ ℤ} is Σ₂-definable for any a, b : ℚ.",
-      "int_diophantine_iff_affinePullback_diophantine: for a ≠ 0, ℤ is Σ₁-definable over ℚ iff its affine pullback {q | a·q + b ∈ ℤ} is — the OPEN question is invariant under affine reparametrization (converse pulls back along the inverse map q ↦ a⁻¹·q − a⁻¹·b)."
+      "int_diophantine_iff_affinePullback_diophantine: for a ≠ 0, ℤ is Σ₁-definable over ℚ iff its affine pullback {q | a·q + b ∈ ℤ} is — the OPEN question is invariant under affine reparametrization (converse pulls back along the inverse map q ↦ a⁻¹·q − a⁻¹·b).",
+      "Affine group action laws for affinePullback (Hilbert10OQ01OQ02.lean): affinePullback_id, affinePullback_comp (affinePullback a b (affinePullback c d S) = affinePullback (c·a) (c·b+d) S), affinePullback_cancel (invertibility for a≠0). These identities are the algebraic backbone of the affine-invariance equivalences — the affine group ℚ⋊ℚˣ acts contravariantly on RatSubset via affinePullback, and each of the four Σ₁/Π₁/Σ₂/Π₂ definability classes is an invariant subset. Axiom-free."
     ],
     "dateAdded": "2026-05-08",
     "axiomCount": 1,
@@ -154,7 +155,7 @@
     ],
     "assumptions": "One axiom: `koenigsmann_2016_universal` — ℤ is Π₂-definable in ℚ. This is PROVED in Koenigsmann (Annals 2016) via an explicit polynomial built from Hilbert symbols and quaternion algebras over ℚ; axiomatized here pending a Lean formalization of that construction. All other results in this file (Σ₁ → ¬H10/ℚ-decidable, Mazur → ¬Σ₁, the Σ₁/Π₁ and Σ₂/Π₂ dualities and their specializations to ℤ ⊂ ℚ, the Π₁(ℚ\\ℤ) re-exports, the Π₁ ⊆ Σ₂ containment, and the Σ₂(ℚ\\ℤ) corollary of Koenigsmann) are NOT new axioms — they are logical consequences of the OQ-01 axioms together with the Σ₁/Π₁ and Σ₂/Π₂ equivalences proved here. Both duality theorems use classical excluded middle (`Classical.byContradiction`) to convert ¬¬p to p; the Σ₂/Π₂ duality and the Σ₂(ℚ\\ℤ) corollary use it twice, the Σ₁/Π₁ duality once.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 110,
+    "theoremCount": 113,
     "definitionCount": 17
   },
   "overview": {


### PR DESCRIPTION
## Summary

The `affinePullback` section of `Hilbert10OQ01OQ02.lean` proves each of the four definability classes (Σ₁/Π₁/Σ₂/Π₂ over ℚ) is closed under affine pullback `q ↦ a·q + b`, and derives the affine-invariance equivalences (`int_diophantine_iff_affinePullback_diophantine` and its Σ₂/Π₂ siblings). This PR supplies the missing **algebraic backbone**: the affine reparametrisations form the group `ℚ ⋊ ℚˣ` and `affinePullback` is its contravariant action on `RatSubset`.

- `affinePullback_id` — `affinePullback 1 0 S = S` (identity).
- `affinePullback_comp` — `affinePullback a b (affinePullback c d S) = affinePullback (c·a) (c·b+d) S` (composition / contravariance).
- `affinePullback_cancel` — for `a ≠ 0`, pulling back by `q ↦ a·q+b` undoes pulling back by the inverse reparametrisation `q ↦ a⁻¹·q − a⁻¹·b`, recovering `S`.

These are exactly the round-trip identities the converse halves of the existing affine-invariance equivalences perform inline; together with the `affinePullback_is…Definition` closure lemmas they exhibit each of the four definability classes as an **invariant subset** of the affine action — a structural framing of the affine-reparametrisation invariance of the open Σ₁ question.

## Verification

- Compiles with `bin/lake env lean` (dependency `Hilbert10OQ01` prebuilt).
- **Axiom-free**: `#print axioms` on all three → `[propext, Classical.choice, Quot.sound]`, independent of the file's `koenigsmann_2016_universal` axiom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)