### PR TITLE
research(erdos-1090-incomplete-01): single-colour endpoint of the palette hierarchy

### DIFF
--- a/proofs/Proofs/Erdos1090Problem.lean
+++ b/proofs/Proofs/Erdos1090Problem.lean
@@ -730,6 +730,39 @@ theorem ramseyNumberColored_bool (k : ℕ) :
     ramseyNumberColored Bool k = ramseyNumber k := rfl
 
 /--
+**The single-colour palette collapses to pure collinearity.**  With a `Subsingleton` (at most
+one colour) *nonempty* palette `C`, every colouring is constant, so the monochromaticity
+constraint `c p = c q` is vacuous: `HasRamseyPropertyColored C A k` holds iff `A` already
+contains a `k`-collinear subset, `∃ S ⊆ A, IsKCollinear S k`.  This is the `|C| = 1` boundary
+of the palette hierarchy — the degenerate bottom end below `ramseyNumberColored_bool` (`|C| = 2`),
+where the Ramsey condition strips down to the underlying Erdős collinearity question with no
+colouring content at all. -/
+theorem hasRamseyPropertyColored_subsingleton_iff {C : Type*} [Subsingleton C] [Nonempty C]
+    {A : Finset Point} {k : ℕ} :
+    HasRamseyPropertyColored C A k ↔ ∃ S : Finset Point, S ⊆ A ∧ IsKCollinear S k := by
+  constructor
+  · intro h
+    obtain ⟨S, hSA, hSk, _⟩ := h (fun _ => Classical.arbitrary C)
+    exact ⟨S, hSA, hSk⟩
+  · rintro ⟨S, hSA, hSk⟩ c
+    exact ⟨S, hSA, hSk, fun p q _ _ => Subsingleton.elim _ _⟩
+
+/--
+**One colour is the easiest: the bottom of the palette monotonicity chain.**  For a
+`Subsingleton` palette `C` and `k ≥ 3`, `R_C(k) ≤ ramseyNumber k`: a single colour can only
+*lower* the threshold, since `C` embeds into `Bool` (`ramseyNumberColored_mono_colors`) and
+`R_{Bool}(k) = ramseyNumber k` (`ramseyNumberColored_bool`).  This is the lower counterpart of
+`ramseyNumber_le_ramseyNumberColored_fin` (which bounds the `≥ 2`-colour numbers from *below*
+by `ramseyNumber k`); together they pin `ramseyNumber k` as the value at `|C| = 2`, with the
+whole chain `R_{|C|=1}(k) ≤ ramseyNumber k ≤ R_{Fin r}(k)` monotone in the palette size. -/
+theorem ramseyNumberColored_subsingleton_le {C : Type*} [Subsingleton C] {k : ℕ} (hk : k ≥ 3) :
+    ramseyNumberColored C k ≤ ramseyNumber k := by
+  have e : C ↪ Bool := ⟨fun _ => false, fun a b _ => Subsingleton.elim a b⟩
+  calc ramseyNumberColored C k
+      ≤ ramseyNumberColored Bool k := ramseyNumberColored_mono_colors e hk
+    _ = ramseyNumber k := ramseyNumberColored_bool k
+
+/--
 **A monotone chain in the number of colors.**  For `r ≤ r'`, `R_{Fin r}(k) ≤ R_{Fin r'}(k)`,
 via the canonical embedding `Fin r ↪ Fin r'`.  Combined with `ramseyNumberColored_bool` and
 `finTwoEquiv`, this gives `R(k) = R_{Fin 2}(k) ≤ R_{Fin r}(k)` for every `r ≥ 2`: passing from

--- a/src/data/proofs/erdos-1090/meta.json
+++ b/src/data/proofs/erdos-1090/meta.json
@@ -73,12 +73,13 @@
       "HasRamseyPropertyColored / ramseyNumberColored (0-axiom): the r-coloring Ramsey number R_C(k) over an arbitrary finite palette C, quantifying the previously existence-only ramsey_construction_general; HasRamseyPropertyColored Bool = HasRamseyProperty definitionally (ramseyNumberColored_bool : R_Bool = ramseyNumber)",
       "ramseyNumberColored_mono_colors (0-axiom): palette monotonicity — if C ↪ C' then R_C(k) ≤ R_{C'}(k); more colors cannot lower the threshold. Proved via hasRamseyPropertyColored_of_embedding (a C-coloring pushes forward along e, and injectivity of e pulls monochromaticity back). ramseyNumberColored_congr gives recoloring invariance (C ≃ C' ⟹ equal), ramseyNumberColored_mono_fin the monotone chain R_{Fin r} ≤ R_{Fin r'} for r ≤ r', and ramseyNumber_le_ramseyNumberColored_fin the bound R(k) ≤ R_{Fin r}(k) for r ≥ 2 (via finTwoEquiv)",
       "ramseyNumber_isLeast / ramseyNumberColored_isLeast: IsLeast packaging pinning R(k) (resp. R_C(k)) as the MINIMUM realizable point-set size — combining the attained-infimum witness (exists_..._card_eq_ramseyNumber...) with the lower bound (..._le_of_hasRamseyProperty) into one reusable least-element object.",
-      "ramseyNumber_pos: 0 < R(k) for k>=3 (from ramsey_lower_bound R(k)>=k>=3)."
+      "ramseyNumber_pos: 0 < R(k) for k>=3 (from ramsey_lower_bound R(k)>=k>=3).",
+      "Palette-hierarchy endpoints: hasRamseyPropertyColored_subsingleton_iff (a one-colour/Subsingleton nonempty palette collapses the colored Ramsey property to pure collinearity, ∃ S ⊆ A, IsKCollinear S k — the |C|=1 boundary below ramseyNumberColored_bool) and ramseyNumberColored_subsingleton_le (R_C(k) ≤ ramseyNumber k for subsingleton C, via C ↪ Bool — the lower end of the palette-size monotone chain, counterpart to ramseyNumber_le_ramseyNumberColored_fin). Axiom-free."
     ],
     "axiomCount": 0,
-    "lineCount": 1214,
+    "lineCount": 1247,
     "assumptions": "None. 0 axiom declarations, 0 sorries. Both former axioms (graham_selfridge, hunter_observation) are now theorems proved from Mathlib's Hales-Jewett theorem. #print axioms reports only the standard foundational axioms [propext, Classical.choice, Quot.sound]; no sorryAx, no Lean.ofReduceBool. The Line structure's `nonzero` field is constructive data (a witnessed direction), not an assumption.",
-    "theoremCount": 43,
+    "theoremCount": 45,
     "definitionCount": 20
   },
   "overview": {
@@ -115,9 +116,9 @@
       "Finset"
     ],
     "namespace": "Erdos1090",
-    "lineCount": 1214,
+    "lineCount": 1247,
     "axiomCount": 0,
-    "theoremCount": 43,
+    "theoremCount": 45,
     "definitionCount": 20,
     "path": "Proofs/Erdos1090Problem.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

Extends the colored Ramsey / Erdős-collinearity API in `Erdos1090Problem.lean` (Erdős #1090). The palette hierarchy already has monotonicity (`ramseyNumberColored_mono_colors`), the `Bool` anchor `|C|=2` (`ramseyNumberColored_bool`), the `Fin`-chain, and the `≥2`-colour lower bound `ramseyNumber_le_ramseyNumberColored_fin` — but the **`|C|=1` endpoint** was missing. This PR supplies it (both **axiom-free**).

## New theorems (2)

- **`hasRamseyPropertyColored_subsingleton_iff`** — for a `Subsingleton` *nonempty* palette `C`, every colouring is constant, so the monochromaticity constraint is vacuous and `HasRamseyPropertyColored C A k` collapses to pure collinearity `∃ S ⊆ A, IsKCollinear S k`. This is the degenerate bottom of the palette hierarchy, where the Ramsey condition strips down to the underlying Erdős collinearity question with no colouring content.
- **`ramseyNumberColored_subsingleton_le`** — `R_C(k) ≤ ramseyNumber k` for a subsingleton palette (one colour is easiest), via `C ↪ Bool` (`ramseyNumberColored_mono_colors`) and `R_{Bool}(k) = ramseyNumber k`. The lower counterpart of `ramseyNumber_le_ramseyNumberColored_fin`, pinning `ramseyNumber k` at `|C|=2` inside the monotone chain `R_{|C|=1}(k) ≤ ramseyNumber k ≤ R_{Fin r}(k)`.

## Verification

- `lake env lean Proofs/Erdos1090Problem.lean` → exit 0.
- `#print axioms` on both: `[propext, Classical.choice, Quot.sound]` — axiom-free; the entry stays `verified` / 0-axiom.
- `theoremCount` 43 → 45, `lineCount` 1214 → 1247 (gallery `erdos-1090` meta synced, both `.meta` and `.leanFile` blocks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)