### PR TITLE
research(weak-goldbach-oq-01): generalize + reverse the ternary–binary prime bridge

### DIFF
--- a/proofs/Proofs/WeakGoldbach.lean
+++ b/proofs/Proofs/WeakGoldbach.lean
@@ -253,6 +253,31 @@ theorem binary_implies_weak (h : BinaryGoldbachConjecture) : WeakGoldbachConject
   apply sumOfTwoPrimes_add_three
   exact h m hm_gt hm_even
 
+/-- **Adding any prime to a sum of two primes gives a sum of three primes.**
+    The general form of `sumOfTwoPrimes_add_three` (the case `r = 3`): the extra prime need
+    not be `3`. Prepending any prime `r` to a binary Goldbach decomposition `m = p + q`
+    yields the ternary decomposition `r + m = r + p + q`. -/
+theorem sumOfTwoPrimes_add_prime {m r : ℕ} (hm : IsSumOfTwoPrimes m) (hr : Nat.Prime r) :
+    IsSumOfThreePrimes (r + m) := by
+  obtain ⟨p, q, hp, hq, heq⟩ := hm
+  exact ⟨r, p, q, hr, hp, hq, by omega⟩
+
+/-- **"Peel one prime": the ternary–binary bridge as an exact characterization.**
+    A number is a sum of three primes iff some prime `r ≤ n` can be removed to leave a sum of
+    two primes: `IsSumOfThreePrimes n ↔ ∃ r, Nat.Prime r ∧ r ≤ n ∧ IsSumOfTwoPrimes (n - r)`.
+    The backward direction is `sumOfTwoPrimes_add_prime` (reassembling `n = r + (n - r)` using
+    `r ≤ n`); the forward direction peels off the first prime of a ternary decomposition. This
+    makes the one-directional reduction `binary_implies_weak` reversible at the level of the
+    predicates, exhibiting the sum-of-three-primes property as exactly one prime away from the
+    sum-of-two-primes property. -/
+theorem isSumOfThreePrimes_iff_prime_add_sumOfTwoPrimes {n : ℕ} :
+    IsSumOfThreePrimes n ↔ ∃ r, Nat.Prime r ∧ r ≤ n ∧ IsSumOfTwoPrimes (n - r) := by
+  constructor
+  · rintro ⟨p, q, r, hp, hq, hr, hn⟩
+    exact ⟨p, hp, by omega, q, r, hq, hr, by omega⟩
+  · rintro ⟨r, hr, hrn, p, q, hp, hq, hpq⟩
+    exact ⟨r, p, q, hr, hp, hq, by omega⟩
+
 /-! ## Axiomatized Results -/
 
 /-- Helfgott (2013): the weak Goldbach conjecture is true.


### PR DESCRIPTION
## Summary

The structural section of `WeakGoldbach.lean` reduces weak (ternary) Goldbach to binary Goldbach via the one-directional `sumOfTwoPrimes_add_three` (`m` a sum of two primes ⟹ `3 + m` a sum of three primes). This PR adds its natural generalization and its converse, turning the reduction into an exact characterization.

## New theorems (both axiom-free)

- **`sumOfTwoPrimes_add_prime`** — the extra prime need not be `3`: prepending *any* prime `r` to a binary decomposition `m = p + q` gives the ternary `r + m = r + p + q`. Generalizes `sumOfTwoPrimes_add_three` (the `r = 3` case).
- **`isSumOfThreePrimes_iff_prime_add_sumOfTwoPrimes`** — the exact "peel one prime" characterization:
  ```
  IsSumOfThreePrimes n ↔ ∃ r, Nat.Prime r ∧ r ≤ n ∧ IsSumOfTwoPrimes (n - r).
  ```
  Backward is `sumOfTwoPrimes_add_prime` (reassembling `n = r + (n − r)` using `r ≤ n`); forward peels the first prime off a ternary decomposition. This makes `binary_implies_weak` reversible at the predicate level — being a sum of three primes is exactly one prime away from being a sum of two primes.

## Verification

- Compiles under `lean v4.26.0`, exit 0 (the full `Schnirelmann{Basis,Counting,Theorem}` dependency chain was built Docker-free).
- `#print axioms` on both new theorems: `[propext, Quot.sound]` — axiom-free, and **independent of the file's 4 deep axioms** (`helfgott_weak_goldbach`, `circle_method_asymptotic`, `chen_theorem`, `binary_goldbach_verified`). File axiom count unchanged (4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)