### PR TITLE
research(erdos-659-incomplete-01): sharp mod-8 classification of x²+2y²

### DIFF
--- a/proofs/Proofs/Erdos659Problem.lean
+++ b/proofs/Proofs/Erdos659Problem.lean
@@ -502,6 +502,53 @@ theorem representable_mod8_ne_five_seven {n : ℕ} (hn : n ∈ representable_x2_
   ⟨fun h => not_representable_of_mod8 n (Or.inl h) hn,
    fun h => not_representable_of_mod8 n (Or.inr h) hn⟩
 
+/-- **Sharpness of the mod-8 obstruction (attained side).** The set of residues mod 8
+    actually *attained* by representable numbers is **exactly** `{0, 1, 2, 3, 4, 6}`.
+    The `⊆` inclusion is the necessity lemma `representable_mod8_ne_five_seven` (residues
+    `5, 7` are excluded) together with `n % 8 < 8`; the `⊇` inclusion exhibits an explicit
+    representable witness for each of the six permitted residues (`1, 2, 3, 4, 6, 8`). This
+    complements `not_representable_of_mod8`: not only are `5, 7` blocked, but *every* other
+    residue occurs, so the mod-8 test is sharp as a congruence filter. -/
+theorem representable_mod8_image :
+    {r : ℕ | ∃ n, n ∈ representable_x2_2y2 ∧ n % 8 = r} = {0, 1, 2, 3, 4, 6} := by
+  ext r
+  simp only [Set.mem_setOf_eq, Set.mem_insert_iff, Set.mem_singleton_iff]
+  constructor
+  · rintro ⟨n, hn, rfl⟩
+    have h57 := representable_mod8_ne_five_seven hn
+    have hlt : n % 8 < 8 := Nat.mod_lt n (by norm_num)
+    omega
+  · intro hr
+    rcases hr with h | h | h | h | h | h <;> subst h
+    · exact ⟨8, ⟨0, 2, by norm_num⟩, by norm_num⟩
+    · exact ⟨1, one_representable, by norm_num⟩
+    · exact ⟨2, two_representable, by norm_num⟩
+    · exact ⟨3, three_representable, by norm_num⟩
+    · exact ⟨4, ⟨2, 0, by norm_num⟩, by norm_num⟩
+    · exact ⟨6, ⟨2, 1, by norm_num⟩, by norm_num⟩
+
+/-- **Sharpness of the mod-8 obstruction (blocked side).** The residues mod 8 that *block*
+    representability — those `r < 8` such that no `n ≡ r (mod 8)` is representable — are
+    **exactly** `{5, 7}`. `⊇`: `not_representable_of_mod8`. `⊆`: any other residue `r < 8`
+    lies in `{0,1,2,3,4,6}`, which by `representable_mod8_image` is attained by some
+    representable `n`, contradicting the blocking hypothesis. This is the exact statement
+    that the mod-8 congruence obstruction is `{5, 7}` and nothing more. -/
+theorem mod8_blocking_residues :
+    {r : ℕ | r < 8 ∧ ∀ n, n % 8 = r → n ∉ representable_x2_2y2} = {5, 7} := by
+  ext r
+  simp only [Set.mem_setOf_eq, Set.mem_insert_iff, Set.mem_singleton_iff]
+  constructor
+  · rintro ⟨hlt, hblock⟩
+    by_contra hne
+    have hr6 : r ∈ ({0, 1, 2, 3, 4, 6} : Set ℕ) := by
+      simp only [Set.mem_insert_iff, Set.mem_singleton_iff]; omega
+    rw [← representable_mod8_image] at hr6
+    obtain ⟨n, hn, hnr⟩ := hr6
+    exact hblock n hnr hn
+  · intro hr
+    refine ⟨by omega, fun n hn => not_representable_of_mod8 n ?_⟩
+    rcases hr with h | h <;> subst h <;> [left; right] <;> exact hn
+
 /-- **Strict upper count once a gap appears: `B₂(N) < N` for `N ≥ 5`.** Sharpening `B2_le`
     (`B₂(N) ≤ N`): as soon as the window reaches the first non-representable integer `5`
     (`five_not_representable`), the counted set is a *proper* subset of `Icc 1 N`, so the

--- a/research/problems/erdos-659-incomplete-01/knowledge.md
+++ b/research/problems/erdos-659-incomplete-01/knowledge.md
@@ -200,3 +200,32 @@ isRepresented_iff_isNorm` = [propext, Quot.sound] — no sorryAx. Same-line fix,
 ★Reinforces the session's key lesson: UNVERIFIED "clean by construction" claims are unreliable —
 SECOND live bug this session found purely by re-verifying standing-unverified work via lean-elab
 (cf. minpoly-charpoly-oq-02-incomplete-01 `0=![0,0]`).
+
+## Session 2026-07-11 (researcher-6) — sharp mod-8 classification (VERIFIED axiom-free)
+
+The file had the mod-8 NECESSITY obstruction (`not_representable_of_mod8`: `n ≡ 5,7 mod 8`
+⟹ not representable) and its contrapositive `representable_mod8_ne_five_seven`, but never
+the SHARPNESS: that the obstruction is *exactly* {5,7} and every other residue is attained.
+Added two axiom-free theorems (independent of the deep axiom `moreeOsburnWorks`):
+
+- `representable_mod8_image : {r | ∃ n, n ∈ representable_x2_2y2 ∧ n % 8 = r} =
+  {0,1,2,3,4,6}` — the residues mod 8 attained by `x²+2y²` values are exactly these six.
+  ⊆ from `representable_mod8_ne_five_seven` + `Nat.mod_lt` + omega; ⊇ by explicit witnesses
+  (1, 2, 3, 4=2², 6=2²+2·1², 8=0²+2·2²), each `⟨n, ⟨x,y,by norm_num⟩, by norm_num⟩`.
+- `mod8_blocking_residues : {r | r < 8 ∧ ∀ n, n%8=r → n ∉ representable_x2_2y2} = {5,7}` —
+  the blocking residues are exactly {5,7}. ⊇ `not_representable_of_mod8`; ⊆ by_contra: any
+  other r<8 lies in {0,1,2,3,4,6}, attained via `representable_mod8_image`, contradiction.
+
+Together with the existing `35 = 5·7 ≡ 3 mod 8` counterexample (`mod8_obstruction_not_
+sufficient`), this pins down precisely what the mod-8 congruence CAN and CANNOT decide: it
+is sharp as a single-congruence filter (blocks exactly {5,7}), yet insufficient for the
+full characterization (which needs `moreeOsburnWorks` / Landau disc −8).
+
+**Verification.** local lean 4.26.0 full-file elab EXIT 0, zero errors/warnings.
+`#print axioms` both = [propext, Classical.choice, Quot.sound] — no sorryAx, no
+ofReduceBool, no moreeOsburnWorks. File 28→30 theorems, 575→622 lines (gallery meta both
+count blocks synced). Reusable: `Set.mem_insert_iff`/`Set.mem_singleton_iff` + `omega` for
+finite-residue set membership; `rcases … <;> subst h <;> [left;right] <;> exact hn` to
+dispatch a two-case disjunction into `not_representable_of_mod8`.
+
+Terminus unchanged: main result `erdos_659` still axiomatized on `moreeOsburnWorks`.


### PR DESCRIPTION
## Summary

Extends `Erdos659Problem.lean` (Erdős #659, norm form of ℤ[√-2]) with two axiom-free theorems that make the existing mod-8 obstruction **sharp**. The file already had the *necessity* direction (`not_representable_of_mod8`: integers ≡ 5 or 7 mod 8 are never `x²+2y²`) but never recorded that the obstruction is *exactly* {5,7} and every other residue is attained.

Both new results are independent of the file's single deep axiom `moreeOsburnWorks` (Landau's theorem for discriminant −8).

## New theorems

1. `representable_mod8_image` — the residues mod 8 attained by representable numbers are **exactly** `{0, 1, 2, 3, 4, 6}`. `⊆` from `representable_mod8_ne_five_seven` + `Nat.mod_lt`; `⊇` by explicit witnesses (1, 2, 3, 4=2², 6=2²+2·1², 8=0²+2·2²).
2. `mod8_blocking_residues` — the residues `r < 8` blocking representability (no `n ≡ r` is representable) are **exactly** `{5, 7}`. `⊇` is `not_representable_of_mod8`; `⊆` uses theorem 1 to attain any other residue, contradiction.

Together with the existing `35 = 5·7 ≡ 3 (mod 8)` counterexample (`mod8_obstruction_not_sufficient`), this pins down precisely what the single mod-8 congruence can decide: it is sharp as a congruence filter (blocks exactly {5,7}) yet insufficient for the full characterization (which needs `moreeOsburnWorks`).

## Verification

- Local lean 4.26.0 full-file elaboration: **EXIT 0**, zero errors/warnings.
- `#print axioms` on both new theorems = `[propext, Classical.choice, Quot.sound]` — no `sorryAx`, no `ofReduceBool`, and (crucially) no dependence on `moreeOsburnWorks`. Genuinely **0-axiom / 0-sorry**.

## Files

- `proofs/Proofs/Erdos659Problem.lean` (+2 thms; 575→622 lines)
- `src/data/proofs/erdos-659/meta.json` (lineCount 575→622, theoremCount 28→30, both count blocks)
- `research/problems/erdos-659-incomplete-01/knowledge.md` (session log)

The main result `erdos_659` remains axiomatized on `moreeOsburnWorks` (unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)