### PR TITLE
Enrich Normal Refinement of the Galois Correspondence: annotate ambient setup

### DIFF
--- a/src/data/proofs/abel-ruffini-galois-extensions-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/abel-ruffini-galois-extensions-oq-02-oq-01/annotations.json
@@ -21,6 +21,27 @@
     ]
   },
   {
+    "id": "ann-galois-normal-setup",
+    "proofId": "abel-ruffini-galois-extensions-oq-02-oq-01",
+    "range": { "startLine": 55, "endLine": 64 },
+    "type": "technique",
+    "title": "Ambient Setup: a Finite Galois Extension E/F",
+    "content": "Every result in the file is stated relative to the typeclass context on the `variable` line: `[Field F] [Field E] [Algebra F E] [FiniteDimensional F E] [IsGalois F E]`. These four instances are exactly the hypotheses of the Fundamental Theorem — finite dimension makes the Galois group finite and the correspondence a bijection (not merely a Galois connection), while `IsGalois F E` (= normal + separable) is what forces `fixedField ∘ fixingSubgroup = id` and makes both implications of the normal refinement available. Separability of the ambient extension is also what lets the `Normal F K` rephrasing recover `IsGalois F K` for free. The import of `Proofs.AbelRuffiniGaloisExtensionsOQ02` brings the parent's `intermediateFieldEquivSubgroup'` bijection and `IsGalois` instances into scope; `open IntermediateField` exposes `fixedField`/`fixingSubgroup`.",
+    "mathContext": "Ambient hypotheses: $E/F$ finite ($[E:F] < \\infty$) and Galois ($\\mathrm{Normal} \\wedge \\mathrm{Separable}$), so $\\mathrm{Gal}(E/F)$ is finite and $K \\mapsto K.\\mathrm{fixingSubgroup}$ is a bijection.",
+    "significance": "technical",
+    "relatedConcepts": [
+      "FiniteDimensional",
+      "IsGalois = Normal + Separable",
+      "fixedField ∘ fixingSubgroup = id",
+      "finite Galois group"
+    ],
+    "prerequisites": [
+      "Lean typeclass variables",
+      "finite-dimensional field extensions",
+      "the definition of a Galois extension"
+    ]
+  },
+  {
     "id": "ann-galois-normal-biconditional",
     "proofId": "abel-ruffini-galois-extensions-oq-02-oq-01",
     "range": { "startLine": 66, "endLine": 81 },


### PR DESCRIPTION
Enrichment pass for `abel-ruffini-galois-extensions-oq-02-oq-01` (pass 0, quality 96 — already richly annotated).

The entry was already comprehensive (19 KB meta, 6 annotations, 4 sections). The one genuine coverage gap was the ambient setup block (lines 55–64: imports + the `variable` line). Added a single focused `technique` annotation there:

- **ann-galois-normal-setup** — explains that every result is stated over the typeclass context `[FiniteDimensional F E] [IsGalois F E]`, which are exactly the FTGT hypotheses: finite dimension makes `Gal(E/F)` finite and the correspondence a genuine bijection, and `IsGalois = Normal + Separable` is what forces `fixedField ∘ fixingSubgroup = id` and makes both implications of the normal refinement available (and gives separability of K/F for free in the `Normal F K` rephrasing).

No inflation: meta.json unchanged (still 19 KB, well under the 60 KB cap), no fields deepened past their targets. Validated: JSON parses, gallery data-build pipeline (enrichment summary + search-index + loading-facts) passes, `check-meta-size.ts` reports within caps.

(Note: full `tsc` typecheck could not run in this worktree — `better-sqlite3` fails to compile a native addon under node v26; this is a pre-existing environment issue unrelated to a JSON-only change.)