### PR TITLE
research(binary-gcd-oq-01-oq-04-oq-03): general-a interval additivity + single-call lower bound

### DIFF
--- a/proofs/Proofs/BinaryGcdOQ01OQ04OQ03.lean
+++ b/proofs/Proofs/BinaryGcdOQ01OQ04OQ03.lean
@@ -821,4 +821,40 @@ theorem totalSteps_mono (a : ℕ) : Monotone (totalSteps a) := by
 theorem totalSteps_le_of_le {a M N : ℕ} (h : M ≤ N) : totalSteps a M ≤ totalSteps a N :=
   totalSteps_mono a h
 
+/-- **Interval additivity of the running total (general `a`).** For `M ≤ N` the work
+    over `[1, N]` splits exactly at `M` into the work over `[1, M]` and the work over the
+    tail `[M+1, N]`:
+
+      `totalSteps a N = totalSteps a M + ∑_{b=M+1}^{N} binaryGcdSteps a b`.
+
+    This is the multi-step generalization of the per-argument recurrence
+    `totalSteps_succ` (the `N = M+1`, singleton-tail case) and the exact decomposition
+    underlying `totalSteps_mono` — the tail sum is the nonnegative increment that makes
+    the total monotone. Proved by `Nat.le_induction` on `N` from `M`, using
+    `totalSteps_succ` to peel the new argument and `Finset.sum_Icc_succ_top` to grow the
+    tail range in lockstep. -/
+theorem totalSteps_add_Icc {a M N : ℕ} (h : M ≤ N) :
+    totalSteps a N
+      = totalSteps a M + ∑ b ∈ Finset.Icc (M + 1) N, binaryGcdSteps a b := by
+  induction N, h using Nat.le_induction with
+  | base => simp [Finset.Icc_eq_empty_of_lt (by omega : M < M + 1)]
+  | succ N hMN ih =>
+      rw [totalSteps_succ, ih, Finset.sum_Icc_succ_top (by omega : M + 1 ≤ N + 1)]
+      omega
+
+/-- **Single-argument cost is a lower bound on the running total (general `a`).** For any
+    `1 ≤ k ≤ N`, the step count of the single call `binaryGcdSteps a k` is dominated by
+    the total over `[1, N]`:
+
+      `binaryGcdSteps a k ≤ totalSteps a N`.
+
+    The elementary lower-bound companion of the `O(log N)` upper bound `totalSteps_le`:
+    a single summand never exceeds the sum of the (nonnegative) step counts. Immediate
+    from `Finset.single_le_sum`. -/
+theorem single_le_totalSteps {a k N : ℕ} (hk1 : 1 ≤ k) (hkN : k ≤ N) :
+    binaryGcdSteps a k ≤ totalSteps a N := by
+  unfold totalSteps
+  exact Finset.single_le_sum (f := fun b => binaryGcdSteps a b)
+    (fun b _ => Nat.zero_le _) (Finset.mem_Icc.2 ⟨hk1, hkN⟩)
+
 end BinaryGcdOQ01OQ04OQ03


### PR DESCRIPTION
## Summary

Extends **Part V** (general-`a` running-total structure) of the saturated binary-GCD average-case file `BinaryGcdOQ01OQ04OQ03.lean` with two axiom-free companions. The file previously had only the per-argument recurrence `totalSteps_succ` and monotonicity (`totalSteps_mono`, `totalSteps_le_of_le`) in the general-`a` row; these add the exact multi-step decomposition and an elementary lower bound.

### New lemmas

- **`totalSteps_add_Icc`** — interval additivity of the running total:
  ```
  M ≤ N → totalSteps a N = totalSteps a M + ∑_{b=M+1}^{N} binaryGcdSteps a b
  ```
  The multi-step generalization of `totalSteps_succ` (its `N = M+1`, singleton-tail case) and the exact decomposition underlying `totalSteps_mono` (the tail sum is the nonnegative monotone increment). Proved by `Nat.le_induction` on `N` from `M`, peeling the new argument with `totalSteps_succ` and growing the tail range with `Finset.sum_Icc_succ_top`.

- **`single_le_totalSteps`** — single-call lower bound:
  ```
  1 ≤ k → k ≤ N → binaryGcdSteps a k ≤ totalSteps a N
  ```
  The general-`a` lower-bound companion of the `O(log N)` upper bound `totalSteps_le`: one summand never exceeds the sum of the (nonnegative) step counts. From `Finset.single_le_sum`.

## Verification

- Full 3-file chain (`GCDAlgorithmOQ01` → `BinaryGcdOQ01` → this) kernel-built bottom-up with host `lean v4.26.0` against prebuilt Mathlib oleans (no Docker).
- `#print axioms` on both new lemmas → `[propext, Classical.choice, Quot.sound]` (no `sorryAx`, no `Lean.ofReduceBool`). Axiom-free.

Brent's sharp `0.7050` leading constant remains out of reach (requires transfer-operator / dynamical-systems machinery absent from Mathlib), per the file header and problem `state.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)