### PR TITLE
research(erdos-1-oq-02): f(6)=24 Conway-Guy witness + cardinality distinctness certificate

### DIFF
--- a/proofs/Proofs/Erdos1OQ02.lean
+++ b/proofs/Proofs/Erdos1OQ02.lean
@@ -616,6 +616,39 @@ theorem f_five :
   have hT' : T ∈ ({6, 9, 11, 12, 13} : Finset ℕ).powerset := Finset.mem_powerset.mpr hT
   fin_cases hS' <;> fin_cases hT' <;> revert heq <;> decide
 
+/-- **Cardinality certificate for distinct subset sums (0 axioms).**  A finite set `A`
+    has distinct subset sums exactly when the subset-sum map `S ↦ ∑_{i∈S} i` is injective
+    on `A.powerset`, i.e. when its image has the full cardinality `2^|A| = |A.powerset|`.
+    This converts the `∀ S T` distinctness obligation into a *single* decidable
+    cardinality equality, which `decide` checks by computing the `2^|A|` subset sums and
+    counting distinct values — cheap where the quadratic `fin_cases` over pairs
+    (`2^|A| × 2^|A|` cases) becomes intractable (e.g. `|A| = 6`). -/
+theorem hasDistinctSubsetSums_iff_card (A : Finset ℕ) :
+    hasDistinctSubsetSums A ↔
+    (A.powerset.image (fun S => S.sum id)).card = A.powerset.card := by
+  rw [Finset.card_image_iff]
+  constructor
+  · intro h S hS T hT heq
+    exact h S T (Finset.mem_powerset.mp hS) (Finset.mem_powerset.mp hT) heq
+  · intro h S T hS hT heq
+    exact h (Finset.mem_powerset.mpr hS) (Finset.mem_powerset.mpr hT) heq
+
+/-- f(6) = 24: the Conway–Guy set `{11, 17, 20, 22, 23, 24}` has `2⁶ = 64` distinct
+    subset sums with maximum element `24`.  This is the `n = 6` entry of OEIS A005318,
+    continuing `f_zero`…`f_five`.  The margin over the greedy powers-of-two witness
+    keeps widening: `{1, 2, 4, 8, 16, 32}` also has distinct subset sums but maximum
+    `32`, so `f(6) = 24 < 32 = 2⁵` and the gap `2ⁿ⁻¹ − f(n)` grows again
+    (`8 − 7 = 1`, `16 − 13 = 3`, `32 − 24 = 8`).  The `hasDistinctSubsetSums` obligation
+    is discharged through `hasDistinctSubsetSums_iff_card`: the pairwise `fin_cases` used
+    for `f_two_max`…`f_five` blows up to `64 × 64 = 4096` cases at `n = 6` (heartbeat
+    timeout), so we instead `decide` the single cardinality equality
+    `|image of the 64 subset sums| = 64`. -/
+theorem f_six :
+    ∃ (A : Finset ℕ), A.card = 6 ∧ hasDistinctSubsetSums A ∧ A.sup id = 24 := by
+  refine ⟨{11, 17, 20, 22, 23, 24}, by decide, ?_, by decide⟩
+  rw [hasDistinctSubsetSums_iff_card]
+  decide
+
 /-! ## Conclusion
 
 The DFX framework is formalized with:
@@ -623,9 +656,13 @@ The DFX framework is formalized with:
   fully proved theorem `anticoncentration_bound`, no longer an axiom)
 - 0 sorries (dfx_lower_bound fully proved)
 - Variance bounds and Cauchy–Schwarz (proved)
-- Small case verifications `f_zero`…`f_five` (proved; `f_four` shows `f(4)=7`
-  beats the greedy powers-of-two witness `{1,2,4,8}` of maximum `8`, and `f_five`
-  shows `f(5)=13 < 16` via the Conway–Guy set `{6,9,11,12,13}`)
+- Small case verifications `f_zero`…`f_six` (proved; `f_four` shows `f(4)=7`
+  beats the greedy powers-of-two witness `{1,2,4,8}` of maximum `8`, `f_five`
+  shows `f(5)=13 < 16` via the Conway–Guy set `{6,9,11,12,13}`, and `f_six`
+  shows `f(6)=24 < 32` via `{11,17,20,22,23,24}`; from `f_four` on, the gap
+  `2ⁿ⁻¹ − f(n)` grows `1, 3, 8`). The reusable certificate
+  `hasDistinctSubsetSums_iff_card` reduces distinctness to one decidable
+  cardinality check, sidestepping the quadratic `fin_cases` blow-up.
 
 The anticoncentration bound is discharged entirely by the probability-free CORE
 built up in the "Verified ingredients toward discharging" section

--- a/src/data/proofs/erdos-1-oq-02/meta.json
+++ b/src/data/proofs/erdos-1-oq-02/meta.json
@@ -211,9 +211,9 @@
       "Mathlib"
     ],
     "namespace": "Erdos1OQ02",
-    "lineCount": 625,
+    "lineCount": 682,
     "axiomCount": 0,
-    "theoremCount": 20,
+    "theoremCount": 22,
     "definitionCount": 0,
     "path": "Proofs/Erdos1OQ02.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

Extends the OEIS **A005318** small-case ladder in `Erdos1OQ02.lean` (Erdős #1, distinct
subset sums) from `f_zero`…`f_five` to **`f_six`**, and adds a reusable, axiom-free
decidability certificate.

- **`f_six`**: the Conway–Guy set `{11, 17, 20, 22, 23, 24}` has `2⁶ = 64` distinct subset
  sums with maximum `24`, so `f(6) = 24 < 32 = 2⁵`. The gap `2ⁿ⁻¹ − f(n)` over the greedy
  powers-of-two witness grows `1, 3, 8` across `n = 4, 5, 6` — the doubling construction is
  beaten by an ever-widening margin.
- **`hasDistinctSubsetSums_iff_card`** (reusable, 0-axiom): `A` has distinct subset sums iff
  the subset-sum map `S ↦ ∑_{i∈S} i` is injective on `A.powerset`, iff its image has the
  full cardinality `|A.powerset| = 2^|A|`. This converts the `∀ S T` distinctness obligation
  into a **single** decidable cardinality equality.

## Why the new certificate

The pairwise `fin_cases` used for `f_two_max`…`f_five` enumerates `2^|A| × 2^|A|` subset
pairs — at `|A| = 6` that is `4096` `decide` calls and hits a `whnf` heartbeat timeout
(confirmed: `(deterministic) timeout` at 200000 heartbeats, ~6 min). Routing through
`hasDistinctSubsetSums_iff_card`, `decide` instead computes the `64` subset sums once and
checks `|image| = 64`. The whole file rebuilds in ~20s under **default** heartbeats.

Uses plain `decide` (kernel reduction), **not** `native_decide`, so no `Lean.ofReduceBool` —
the additions stay fully axiom-free.

## Verification

- Host `lake env lean` (Lean v4.26.0) exit 0, no errors/warnings.
- `#print axioms f_six` = `[propext, Classical.choice, Quot.sound]`
- `#print axioms hasDistinctSubsetSums_iff_card` = `[propext, Classical.choice, Quot.sound]`
- The Conway–Guy set independently checked in Python: 64 distinct subset sums, max 24.

`meta.json` `lineCount` 625→682, `theoremCount` 20→22; file remains 0 axioms / 0 sorries.
`f_zero`…`f_six` are existence witnesses attaining `sup = f(n)` (not minimality); Erdős #1's
`c·2ⁿ` conjecture itself remains open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)