### PR TITLE
Enrich Wirtinger Equality Case: link chain root

### DIFF
--- a/src/data/proofs/area-of-circle-oq-01-oq-02-oq-02-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/area-of-circle-oq-01-oq-02-oq-02-oq-01-oq-01-oq-01/meta.json
@@ -119,6 +119,10 @@
     {
       "proofId": "area-of-circle-oq-01-oq-03",
       "relationship": "Grandparent: supplies the axiom-free Fourier decomposition (Parseval for f and f' via integration by parts) reused here as IsoperimetricOQ.fourier_decomposition."
+    },
+    {
+      "proofId": "area-of-circle",
+      "relationship": "Root of the chain (Wiedijk #9, Area of a Circle = πr²). The isoperimetric inequality C²≥4πA is the sharp companion of this area formula, and the rigidity case proved here — equality iff the extremiser is a first harmonic (a circle) — is precisely what makes the disk of area πr² the unique isoperimetric optimum among all curves of given perimeter."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
Light enrichment pass for `area-of-circle-oq-01-oq-02-oq-02-oq-01-oq-01-oq-01` (pass 0, quality 96).

This entry is already **saturated** — 6 annotations cover the full 224-line file continuously, all with mathContext/significance/relatedConcepts/prerequisites; 4 keyInsights; complete sections; conclusion with 3 openQuestions; 4 references. Per the size guardrails, deepening it further would be accretion, not curation, so I made a single genuine, verified improvement:

- Added one `crossReference` (2 → 3, well under the 20 cap) to the **chain root** `area-of-circle` (Wiedijk #9, Area = πr²), noting that this rigidity case — equality iff the extremiser is a first harmonic (circle) — is exactly what makes the disk the *unique* isoperimetric optimum. Target verified to exist.

JSON-only; size within caps (15 KB). No axiom/status changes.