### PR TITLE
Enrich Doubling Invariance (Gauss–Wantzel prime 2): add field-theoretic bridge

### DIFF
--- a/src/data/proofs/angle-trisection-oq-02-oq-03-ext-oq-01/annotations.json
+++ b/src/data/proofs/angle-trisection-oq-02-oq-03-ext-oq-01/annotations.json
@@ -23,11 +23,11 @@
     },
     "type": "definition",
     "title": "The Constructibility Predicate TotientIsPow2",
-    "content": "TotientIsPow2 n := ∃ k, φ(n) = 2^k is the arithmetic surrogate for constructibility of the regular n-gon (matching the parent file's definition). The whole file studies how this predicate behaves under multiplication by 2, so 'TotientIsPow2 n' should be read throughout as 'the regular n-gon is constructible'.",
-    "mathContext": "$\\mathrm{TotientIsPow2}(n) := \\exists k,\\ \\varphi(n)=2^k$.",
+    "content": "TotientIsPow2 n := ∃ k, φ(n) = 2^k is the arithmetic surrogate for constructibility of the regular n-gon (matching the parent file's definition). The whole file studies how this predicate behaves under multiplication by 2, so 'TotientIsPow2 n' should be read throughout as 'the regular n-gon is constructible'. Why is φ(n) a power of 2 the right condition? A point is ruler-and-compass constructible iff it lies in a tower of quadratic (degree-2) extensions of ℚ, so its coordinate has degree 2^m over ℚ. The regular n-gon is constructible iff cos(2π/n) is, and [ℚ(cos 2π/n):ℚ] = φ(n)/2 (half the degree φ(n) of the cyclotomic field ℚ(ζ_n), since complex conjugation is the order-2 automorphism fixing the real subfield). Hence constructibility ⟺ φ(n)/2 is a power of 2 ⟺ φ(n) is a power of 2 — the predicate defined here.",
+    "mathContext": "$\\mathrm{TotientIsPow2}(n) := \\exists k,\\ \\varphi(n)=2^k$; constructible $\\iff [\\mathbb{Q}(\\cos\\tfrac{2\\pi}{n}):\\mathbb{Q}] = \\tfrac{\\varphi(n)}{2}$ is a power of $2$.",
     "significance": "supporting",
-    "relatedConcepts": ["Euler totient", "power of two", "existential predicate"],
-    "prerequisites": ["Nat.totient"]
+    "relatedConcepts": ["Euler totient", "power of two", "existential predicate", "cyclotomic field degree", "tower of quadratic extensions"],
+    "prerequisites": ["Nat.totient", "degree of a field extension"]
   },
   {
     "id": "ann-single-step",


### PR DESCRIPTION
Enrichment pass for `angle-trisection-oq-02-oq-03-ext-oq-01` (pass 0, quality 96 — already comprehensively annotated).

The entry already met every quality target (6 annotations with full mathContext/significance/relatedConcepts/prerequisites, complete meta, 4 sections). Rather than pad it, I improved **one existing annotation in place** to close a genuine depth gap: the `TotientIsPow2` definition annotation stated the predicate is 'the arithmetic surrogate for constructibility' but never said *why* `φ(n)=2^k` is the constructibility criterion.

Added that reasoning: a point is constructible iff it sits in a tower of quadratic extensions of ℚ, the regular n-gon is constructible iff `cos(2π/n)` is, and `[ℚ(cos 2π/n):ℚ] = φ(n)/2` (half the cyclotomic degree, complex conjugation being the order-2 automorphism fixing the real subfield) — so constructibility ⟺ φ(n)/2 is a power of 2 ⟺ φ(n) is a power of 2. This connects the arithmetic predicate the whole file manipulates back to the actual geometry.

No bulk added (net +4 lines, still 7.6 KB annotations, meta unchanged and well under the 60 KB cap). Validated: JSON parses, `check-meta-size.ts` within caps.