### PR TITLE
research(erdos-117-oq-01-incomplete-01): Part IV closure — convergence ⟺ liminf=limsup

### DIFF
--- a/proofs/Proofs/Erdos117OQ01.lean
+++ b/proofs/Proofs/Erdos117OQ01.lean
@@ -561,6 +561,48 @@ theorem growthRate_oscillation_le_window :
   obtain ⟨c₁, c₂, hc1, hc12, hlo, hhi⟩ := limInfLimSup_window
   exact ⟨c₁, c₂, hc1, hc12, by linarith⟩
 
+/-- **Convergence ⟺ `liminf = limsup`.** The two Part-IV formulations of the open question
+    — `growthRateConverges` (the growth rate has *some* limit) and `limInfEqLimSup` (its two
+    cluster extremes coincide) — are equivalent. This is the standard convergence criterion
+    for a bounded real sequence, specialised here: the growth rate is trapped in Pyber's
+    band (`growthRate_lower_bound`/`_upper_bound`), so it is bounded above and below, and for
+    such a sequence Mathlib's `tendsto_of_liminf_eq_limsup` turns `liminf = limsup` into
+    convergence, while `Tendsto.liminf_eq`/`Tendsto.limsup_eq` give the converse. Combined
+    with `exponentialBaseExists_iff_converges`, all three Part-IV phrasings of Erdős #117-OQ-01
+    are one and the same statement. -/
+theorem converges_iff_limInf_eq_limSup :
+    growthRateConverges ↔ limInfEqLimSup := by
+  unfold growthRateConverges limInfEqLimSup
+  constructor
+  · rintro ⟨L, hL⟩
+    have h1 : growthRateLimInf = L := hL.liminf_eq
+    have h2 : growthRateLimSup = L := hL.limsup_eq
+    rw [h1, h2]
+  · intro hEq
+    refine ⟨growthRateLimSup, tendsto_of_liminf_eq_limsup hEq rfl ?_ ?_⟩
+    · obtain ⟨U, hU⟩ := growthRate_upper_bound
+      exact ⟨U, Filter.eventually_atTop.mpr ⟨1, fun n hn => hU n hn⟩⟩
+    · obtain ⟨L, _, hL⟩ := growthRate_lower_bound
+      exact ⟨L, Filter.eventually_atTop.mpr ⟨1, fun n hn => hL n hn⟩⟩
+
+/-- **The open question ⟺ `liminf = limsup`.** Chaining `exponentialBaseExists_iff_converges`
+    with `converges_iff_limInf_eq_limSup`: `h(n)` has a well-defined exponential base iff the
+    liminf and limsup of the growth rate coincide. This is the cleanest single-line statement
+    of Erdős #117-OQ-01 in terms of the cluster values studied in Part III. -/
+theorem exponentialBaseExists_iff_limInfEqLimSup :
+    exponentialBaseExists ↔ limInfEqLimSup :=
+  exponentialBaseExists_iff_converges.trans converges_iff_limInf_eq_limSup
+
+/-- **Convergence ⟺ zero oscillation.** The growth rate converges iff its oscillation
+    `limsup − liminf` is exactly `0`. `growthRate_oscillation_le_window` bounds this
+    oscillation above by the fixed log-width `log(c₂/c₁)` of Pyber's window; this theorem
+    says the open question is precisely whether that bounded oscillation actually vanishes.
+    Immediate from `converges_iff_limInf_eq_limSup` via `sub_eq_zero`. -/
+theorem converges_iff_oscillation_zero :
+    growthRateConverges ↔ growthRateLimSup - growthRateLimInf = 0 := by
+  rw [sub_eq_zero, converges_iff_limInf_eq_limSup]
+  exact ⟨fun h => h.symm, fun h => h.symm⟩
+
 /-- The open question stated precisely -/
 def erdos117OQ01 : Prop := exponentialBaseExists
 

--- a/research/problems/erdos-117-oq-01-incomplete-01/knowledge.md
+++ b/research/problems/erdos-117-oq-01-incomplete-01/knowledge.md
@@ -90,3 +90,32 @@ call, exactly as `base_implies_behavior` does.
 
 Still 0 sorries, 3 structural axioms (h, h_pos, pyber_bounds), no sorryAx/ofReduceBool.
 Theorems 10→12, lines 368→431. Built green on Lean 4.26 (LEAN_SKIP_CACHE, 4.5s).
+
+## Session 2026-07-11 (researcher-6) — Part IV closure: convergence ⟺ liminf=limsup (VERIFIED)
+
+Part IV defined THREE formulations of the open question — `growthRateConverges`,
+`limInfEqLimSup`, `exponentialBaseExists` — and proved `exponentialBaseExists_iff_converges`,
+but NEVER `growthRateConverges ↔ limInfEqLimSup` (the standard bounded-sequence convergence
+criterion). Closed that gap + two capstones (no new axioms; still 3 structural h/h_pos/pyber_bounds):
+
+- `converges_iff_limInf_eq_limSup : growthRateConverges ↔ limInfEqLimSup`. →: `hL.liminf_eq`
+  / `hL.limsup_eq` (Filter.Tendsto.liminf_eq/limsup_eq, NeBot atTop) give both = L, rw. ←:
+  `tendsto_of_liminf_eq_limsup hEq rfl ?bddAbove ?bddBelow` with a := growthRateLimSup (hEq :
+  growthRateLimInf=growthRateLimSup is DEFEQ the needed `liminf (fun n=>growthRate n) atTop =
+  growthRateLimSup`; the limsup side is `rfl`); the two IsBoundedUnder goals reuse the exact
+  `⟨U, eventually_atTop.mpr ⟨1, fun n hn => hU n hn⟩⟩` pattern from `limInf_le_limSup`.
+- `exponentialBaseExists_iff_limInfEqLimSup` = `exponentialBaseExists_iff_converges.trans
+  converges_iff_limInf_eq_limSup` — all three Part-IV phrasings now provably equal.
+- `converges_iff_oscillation_zero : growthRateConverges ↔ growthRateLimSup - growthRateLimInf
+  = 0` — via `sub_eq_zero` + the bridge; makes the "is the gap 0?" narrative of
+  `growthRate_oscillation_le_window` (osc ≤ log(c₂/c₁)) into an exact criterion.
+
+**Reusable.** `tendsto_of_liminf_eq_limsup (hinf)(hsup)(bddAbove)(bddBelow)` is the clean
+converse to `Tendsto.liminf_eq`/`.limsup_eq`; the file's growthRateLimInf/LimSup DEFs are
+eta-defeq to `liminf/limsup growthRate atTop`, so tendsto-derived equalities typecheck against
+them directly (no funext/congr needed).
+
+**Verification.** local lean 4.26.0 full-file elab EXIT 0. `#print axioms` all 3 =
+[propext, Classical.choice, Erdos117OQ01.h, h_pos, pyber_bounds, Quot.sound] — no sorryAx, no
+ofReduceBool, no NEW axiom. 14→17 theorems, 572→614 lines (meta both count blocks synced).
+Terminus unchanged: the open convergence question itself is out of scope (it IS #117-OQ-01).

--- a/src/data/proofs/erdos-117-oq-01/meta.json
+++ b/src/data/proofs/erdos-117-oq-01/meta.json
@@ -25,8 +25,8 @@
     "erdosNumber": 117,
     "erdosUrl": "https://erdosproblems.com/117",
     "erdosProblemStatus": "open",
-    "lineCount": 572,
-    "theoremCount": 14,
+    "lineCount": 614,
+    "theoremCount": 17,
     "definitionCount": 9,
     "additionalFiles": [
       "Proofs/Erdos117OQ01Aristotle.lean",
@@ -158,9 +158,9 @@
       "Filter"
     ],
     "namespace": "Erdos117OQ01",
-    "lineCount": 572,
+    "lineCount": 614,
     "axiomCount": 3,
-    "theoremCount": 14,
+    "theoremCount": 17,
     "substantiveTheoremCount": 9,
     "sorryTheorems": 0,
     "definitionCount": 9,


### PR DESCRIPTION
## Summary

Extends `Erdos117OQ01.lean` (Erdős #117-OQ-01: does `log h(n)/n` converge?) by closing a gap in Part IV. The file defined **three** formulations of the open question — `growthRateConverges`, `limInfEqLimSup`, `exponentialBaseExists` — and proved `exponentialBaseExists_iff_converges`, but never the standard bounded-sequence convergence criterion `growthRateConverges ↔ limInfEqLimSup`. That bridge (plus two capstones) is added here.

All three new theorems introduce **no new axioms** — they depend only on the file's existing structural axioms `h`, `h_pos`, `pyber_bounds`.

## New theorems

1. `converges_iff_limInf_eq_limSup` — the core bridge. `←` uses Mathlib's `tendsto_of_liminf_eq_limsup` (the growth rate is bounded above/below by Pyber's band, so the bounded-sequence criterion applies); `→` uses `Tendsto.liminf_eq`/`Tendsto.limsup_eq`.
2. `exponentialBaseExists_iff_limInfEqLimSup` — chains with `exponentialBaseExists_iff_converges`, so all three Part-IV phrasings are provably one statement.
3. `converges_iff_oscillation_zero` — `growthRateConverges ↔ limsup − liminf = 0`, turning the oscillation-bound narrative (`growthRate_oscillation_le_window`: osc ≤ log(c₂/c₁)) into an exact criterion.

## Verification

- Local lean 4.26.0 full-file elaboration: **EXIT 0**, no errors.
- `#print axioms` on all three = `[propext, Classical.choice, Erdos117OQ01.h, Erdos117OQ01.h_pos, Erdos117OQ01.pyber_bounds, Quot.sound]` — no `sorryAx`, no `ofReduceBool`, **no new axiom** beyond the file's declared 3.

## Files

- `proofs/Proofs/Erdos117OQ01.lean` (+3 thms; 572→614 lines)
- `src/data/proofs/erdos-117-oq-01/meta.json` (lineCount 572→614, theoremCount 14→17, axiomCount unchanged at 3; both count blocks)
- `research/problems/erdos-117-oq-01-incomplete-01/knowledge.md` (session log)

The underlying convergence question (which *is* #117-OQ-01) remains open and out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)