### PR TITLE
research(prob-method-expectation-oq-04): canonical value form + nonneg floor; whole file kernel-verified

### DIFF
--- a/proofs/Proofs/ProbMethodExpectationOQ04.lean
+++ b/proofs/Proofs/ProbMethodExpectationOQ04.lean
@@ -492,4 +492,26 @@ theorem expectedMonoCliques_self (k : ℕ) :
   unfold expectedMonoCliques
   rw [Nat.choose_self, Nat.cast_one, one_mul]
 
+/-- **Canonical `zpow`-free rational form of the expected count.**
+`E(n,k) = (C(n,k)·2) / 2^{C(k,2)}` — the value-level companion of
+`expectedMonoCliques_lt_one_iff` (which compares the numerator to the denominator).
+Rewriting away the integer `zpow (1 − C(k,2))` into a plain `ℕ`-power quotient is the form
+every downstream numeric estimate or evaluation of `E` actually wants; the `< 1` iff is
+then just `div_lt_one` on this quotient. -/
+theorem expectedMonoCliques_eq_div (n k : ℕ) :
+    expectedMonoCliques n k = ((n.choose k : ℚ) * 2) / (2 : ℚ) ^ (k.choose 2) := by
+  unfold expectedMonoCliques
+  rw [sub_eq_add_neg, zpow_add₀ (by norm_num : (2 : ℚ) ≠ 0), zpow_one, zpow_neg,
+    zpow_natCast, div_eq_mul_inv]
+  ring
+
+/-- **The expected count is nonnegative** — the base fact recorded by the parent gallery
+lemma `expected_mono_cliques`, on which the whole first-moment argument rests: `E(n,k) ≥ 0`
+for all `n, k`. The `< 1` upper bounds sit *above* this floor; together they trap `E` in
+`[0, 1)` on the sub-threshold range, the exact window the probabilistic method exploits.
+The strict companion `0 < E ↔ k ≤ n` is `expectedMonoCliques_pos_iff`. -/
+theorem expectedMonoCliques_nonneg (n k : ℕ) : 0 ≤ expectedMonoCliques n k := by
+  unfold expectedMonoCliques
+  exact mul_nonneg (Nat.cast_nonneg _) (zpow_nonneg (by norm_num : (0 : ℚ) ≤ 2) _)
+
 end ProbMethod.ExpectationOQ04


### PR DESCRIPTION
## Summary

Two axiom-free API-completing companions to the `expectedMonoCliques` Erdős-1947 block in `ProbMethodExpectationOQ04.lean`, plus an independent kernel-verification of the whole file (which prior sessions could only ship *unverified*).

### New lemmas

- **`expectedMonoCliques_eq_div`** — canonical `zpow`-free rational value form:
  ```
  E(n,k) = (C(n,k)·2) / 2^{C(k,2)}
  ```
  The value-level companion of `expectedMonoCliques_lt_one_iff` (which only compares numerator vs denominator *inside an iff*). This is the form any downstream numeric estimate or evaluation of `E` wants; the `< 1` iff is then just `div_lt_one` on this quotient.

- **`expectedMonoCliques_nonneg`** — the base floor `0 ≤ E(n,k)`:
  Exactly the fact the parent gallery lemma `expected_mono_cliques` records, on which the whole first-moment argument rests. Together with the `< 1` upper bounds it traps `E` in `[0,1)` on the sub-threshold range — the window the probabilistic method exploits. Strict companion: `expectedMonoCliques_pos_iff`.

## Verification

- **Whole file independently kernel-verified** with host `lean v4.26.0` (single-file, Mathlib-only, no Docker). Prior sessions (researcher-9 / researcher-11, 2026-07-09) shipped the existence-engine lemmas **UNVERIFIED** because Docker was down and the build hit SIGBUS-135 at olean-write. This build completes clean.
- `#print axioms` → `[propext, Classical.choice, Quot.sound]` on the key results (`expectedMonoCliques_lt_one_of_sq_lt`, `erdos_1947_clique_bound`, `exists_avoiding_all_events`) and both new lemmas. No `sorry`, no `Lean.ofReduceBool`. Axiom-free.

The larger open step — a colouring/counting model instantiating `exists_avoiding_all_events` into a formal `R(k,k) > n` — remains, as noted in `state.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)