### PR TITLE
research(erdos-1038-wip-01): quadratic-family sublevel measure is strictly monotone

### DIFF
--- a/proofs/Proofs/Erdos1038WIP01.lean
+++ b/proofs/Proofs/Erdos1038WIP01.lean
@@ -510,6 +510,31 @@ theorem le_sublevelSup'_Xsq {d : ℝ} (hd0 : 0 ≤ d) (hd1 : d < 1) :
     (le_iSup_of_le (Xsq_sub_C_admissible' ⟨hd0, le_of_lt hd1⟩)
       (sublevelMeasure_Xsq_sub_C hd0 hd1).ge)
 
+/-- **The quadratic family sweeps its measure interval strictly monotonically.** For
+    `0 ≤ d₁ < d₂ < 1`, the sublevel measure of `X² − d₁` is strictly smaller than that of
+    `X² − d₂`: deepening the constant term (spreading the two roots `±√d` apart) strictly
+    enlarges the sublevel set `(−√(d+1), √(d+1))`. The measure `2√(d+1)` is strictly
+    increasing in `d`, so the sweep of `[2, 2√2)` by `exists_faithful_sublevelMeasure_eq`
+    is order-preserving — each target value is hit by a *unique* `d`. -/
+theorem sublevelMeasure_Xsq_sub_C_lt {d₁ d₂ : ℝ} (hd₁ : 0 ≤ d₁) (hd₂ : d₂ < 1)
+    (h : d₁ < d₂) :
+    sublevelMeasure (X ^ 2 - C d₁) < sublevelMeasure (X ^ 2 - C d₂) := by
+  rw [sublevelMeasure_Xsq_sub_C hd₁ (lt_trans h hd₂),
+    sublevelMeasure_Xsq_sub_C (le_trans hd₁ h.le) hd₂,
+    ENNReal.ofReal_lt_ofReal_iff
+      (mul_pos two_pos (Real.sqrt_pos.mpr (by linarith)))]
+  have hsqrt : Real.sqrt (d₁ + 1) < Real.sqrt (d₂ + 1) :=
+    Real.sqrt_lt_sqrt (by linarith) (by linarith)
+  linarith
+
+/-- **The quadratic sublevel measure is strictly monotone on `[0, 1)`.** The `StrictMonoOn`
+    packaging of `sublevelMeasure_Xsq_sub_C_lt`: `d ↦ sublevelMeasure (X² − d)` is strictly
+    increasing on `Set.Ico 0 1`. Hence the parametrisation of the elementary measure spectrum
+    `[2, 2√2)` by the constant term is an order isomorphism onto its image. -/
+theorem sublevelMeasure_Xsq_sub_C_strictMonoOn :
+    StrictMonoOn (fun d : ℝ => sublevelMeasure (X ^ 2 - C d)) (Set.Ico 0 1) :=
+  fun _ ha _ hb hab => sublevelMeasure_Xsq_sub_C_lt ha.1 hb.2 hab
+
 /-- **Every measure `m ∈ [2, 2√2)` is realised exactly by a faithful distinct-root
     quadratic.**  This formalizes the surjectivity claim above: solving `2√(d+1) = m`
     gives `d = m²/4 − 1`, which lies in `[0, 1)` precisely when `2 ≤ m < 2√2`, so the

--- a/research/problems/erdos-1038-wip-01/knowledge.md
+++ b/research/problems/erdos-1038-wip-01/knowledge.md
@@ -190,3 +190,35 @@ the shared primary checkout `/Users/rwalters/GitHub/lean-genius` was on *another
 (`feature/enricher-5-4-altseries2`, its own 682-line variant) and got `git reset`-wiped mid-edit;
 local `main` ref was also stale (behind origin). Base research worktrees on **`origin/main`**
 (fetch first), external path `/Users/rwalters/lg-r6-*`, symlink `proofs/.lake`, commit immediately.
+
+## Update (2026-07-11, researcher-6 — quadratic-family measure is strictly monotone)
+
+**Mode:** REVISIT (RICH, saturated). **Outcome:** +2 theorems, 0 axioms / 0 sorries,
+VERIFIED local lean 4.26.0 (`#print axioms` = [propext, Classical.choice, Quot.sound]).
+
+Prior sessions proved the distinct-root quadratic family `X² − d` (`0 ≤ d < 1`) has sublevel
+measure `2√(d+1)` and sweeps `[2, 2√2)` (`sublevelMeasure_Xsq_sub_C`,
+`exists_faithful_sublevelMeasure_eq`), but never that the sweep is **order-preserving** — so
+nothing ruled out the parametrisation `d ↦ measure` folding back on itself. Recorded the
+monotonicity:
+
+- `sublevelMeasure_Xsq_sub_C_lt {d₁ d₂} (0≤d₁)(d₂<1)(d₁<d₂) : sublevelMeasure(X²−d₁) <
+  sublevelMeasure(X²−d₂)`. Rewrite both sides by `sublevelMeasure_Xsq_sub_C`, then
+  `ENNReal.ofReal_lt_ofReal_iff (mul_pos two_pos (Real.sqrt_pos.mpr …))` reduces to
+  `2√(d₁+1) < 2√(d₂+1)`, closed by `Real.sqrt_lt_sqrt` + `linarith`.
+- `sublevelMeasure_Xsq_sub_C_strictMonoOn : StrictMonoOn (fun d => sublevelMeasure(X²−C d))
+  (Set.Ico 0 1)` — one-line packaging `fun _ ha _ hb hab => …_lt ha.1 hb.2 hab`.
+
+**Upshot:** the constant term `d` parametrises the elementary measure spectrum `[2, 2√2)`
+strictly monotonically, so each target measure is hit by a *unique* `d` (the sweep is an
+order iso onto its image). Complements the surjectivity theorems with injectivity/ordering.
+Only the sharp `sublevelSup' = 2√2` and exact faithful inf `2^(4/3)−1` remain open (potential
+theory, Tao 2025, absent from Mathlib).
+
+**GOTCHA:** `positivity` on `0 < 2 * √(d₂+1)` FAILS here — it only sees `hd₂ : d₂ < 1`, not
+`0 ≤ d₂` (which comes transitively via `hd₁ ≤ d₁ < d₂`); supply `mul_pos two_pos
+(Real.sqrt_pos.mpr (by linarith))` explicitly instead.
+
+**Files Modified:** proofs/Proofs/Erdos1038WIP01.lean (+2 thms; 747→772 lines). Gallery meta
+(`src/data/proofs/erdos-1038/meta.json`) tracks the 93-line stub `Erdos1038Problem.lean`, NOT
+this WIP research file, so it is left untouched (confirmed: no meta references Erdos1038WIP01).


### PR DESCRIPTION
## Summary

Extends the Erdős #1038 research file `Erdos1038WIP01.lean` (sublevel sets of monic real-rooted-in-[-1,1] polynomials). Prior sessions established that the distinct-root quadratic family `X² − d` (`0 ≤ d < 1`) has sublevel measure `2√(d+1)` and *surjects* onto the elementary measure spectrum `[2, 2√2)` — but never recorded that the parametrisation `d ↦ measure` is **order-preserving**. This adds the monotonicity (the injectivity/ordering companion).

## New theorems (both axiom-free)

1. `sublevelMeasure_Xsq_sub_C_lt` — for `0 ≤ d₁ < d₂ < 1`, `sublevelMeasure(X²−d₁) < sublevelMeasure(X²−d₂)`. Via `ENNReal.ofReal_lt_ofReal_iff` + `Real.sqrt_lt_sqrt`.
2. `sublevelMeasure_Xsq_sub_C_strictMonoOn` — `StrictMonoOn (fun d => sublevelMeasure (X²−C d)) (Set.Ico 0 1)`, the packaged form.

So each target measure in `[2, 2√2)` is hit by a *unique* `d`: the sweep is an order isomorphism onto its image, complementing the existing surjectivity results.

## Verification

- Local lean 4.26.0 full-file elaboration: **EXIT 0** (only the two pre-existing warnings at lines 113/725, untouched).
- `#print axioms` on both new theorems = `[propext, Classical.choice, Quot.sound]` — no `sorryAx`, no `ofReduceBool`. Genuinely **0-axiom / 0-sorry**.

## Files

- `proofs/Proofs/Erdos1038WIP01.lean` (+2 thms; 747→772 lines)
- `research/problems/erdos-1038-wip-01/knowledge.md` (session log)

The gallery meta (`src/data/proofs/erdos-1038/meta.json`) tracks the stub `Erdos1038Problem.lean`, not this WIP research file, so it is intentionally left untouched. The sharp extremal values (`sublevelSup' = 2√2`, faithful inf `2^(4/3)−1`) remain open (require logarithmic potential theory absent from Mathlib).

🤖 Generated with [Claude Code](https://claude.com/claude-code)