### PR TITLE
research(erdos-1059-oq-01-oq-01): exact step recurrence + strict monotonicity of C(n!)

### DIFF
--- a/proofs/Proofs/Erdos1059OQ01OQ01.lean
+++ b/proofs/Proofs/Erdos1059OQ01OQ01.lean
@@ -849,6 +849,39 @@ theorem qualifyingCount_factorial_lt_succ (n : ℕ) (hn : n ≥ 3) :
   have hpos := qualifyingInLevel_pos n hn
   omega
 
+/-- **Exact one-step recurrence for the qualifying count at factorial points.**
+    For `n ≥ 1`,
+
+      `C((n+1)!) = C(n!) + q(n)`,
+
+    where `q(n) = qualifyingInLevel n` is the single new level adjoined in passing from
+    `n!` to `(n+1)!`.  Directly from the level decomposition
+    `C(n!) = Σ_{l<n} q(l)` (`qualifyingCount_decomposition`) together with
+    `Finset.sum_range_succ`.  This is the fundamental recurrence behind the whole
+    Part XI absolute-growth theory: the linear lower bound
+    (`qualifyingCount_factorial_ge`), monotonicity (`qualifyingCount_factorial_mono`),
+    and strict step-growth (`qualifyingCount_factorial_lt_succ`) all read off this exact
+    increment. -/
+theorem qualifyingCount_factorial_succ {n : ℕ} (hn : n ≥ 1) :
+    Erdos1059OQ01.qualifyingPrimeCount (Nat.factorial (n + 1))
+      = Erdos1059OQ01.qualifyingPrimeCount (Nat.factorial n) + qualifyingInLevel n := by
+  rw [qualifyingCount_decomposition (n + 1) (by omega),
+      qualifyingCount_decomposition n hn, Finset.sum_range_succ]
+
+/-- **Strict monotonicity of the qualifying count at factorial points.**  For `3 ≤ n < m`,
+
+      `C(n!) < C(m!)`.
+
+    The strict counterpart of `qualifyingCount_factorial_mono`: chaining the single strict
+    step `qualifyingCount_factorial_lt_succ` (`C(n!) < C((n+1)!)`, valid for `n ≥ 3`) with the
+    non-strict monotonicity `qualifyingCount_factorial_mono` (`C((n+1)!) ≤ C(m!)`) upgrades
+    "non-decreasing" to "strictly increasing" across every gap `n < m` above `3!`. -/
+theorem qualifyingCount_factorial_strictMono {n m : ℕ} (hn : n ≥ 3) (hnm : n < m) :
+    Erdos1059OQ01.qualifyingPrimeCount (Nat.factorial n) <
+      Erdos1059OQ01.qualifyingPrimeCount (Nat.factorial m) :=
+  lt_of_lt_of_le (qualifyingCount_factorial_lt_succ n hn)
+    (qualifyingCount_factorial_mono (by omega) (by omega))
+
 /-
 ## Summary
 


### PR DESCRIPTION
## Summary

Part XI's absolute-growth theory for the qualifying count `C(n!)` at factorial points had the linear lower bound (`qualifyingCount_factorial_ge`, `≥ n − 3`), unboundedness, non-strict monotonicity (`_mono`), and single-step strict growth (`_lt_succ`) — but the **fundamental exact recurrence** appeared only as an internal `have`, and there was no **general strict monotonicity**. This PR adds both.

## New theorems

- **`qualifyingCount_factorial_succ`** (`n ≥ 1`) — the exact one-step recurrence
  ```
  C((n+1)!) = C(n!) + q(n)
  ```
  directly from `qualifyingCount_decomposition` + `Finset.sum_range_succ`. This is the fundamental increment that `_ge` / `_mono` / `_lt_succ` all read off. **Axiom-free** (`[propext, Classical.choice, Quot.sound]`).

- **`qualifyingCount_factorial_strictMono`** (`3 ≤ n < m`) — `C(n!) < C(m!)`, the strict counterpart of `_mono`, chaining the single strict step `_lt_succ` with the non-strict `_mono`. Like the file's other positivity results it inherits the `strong_selberg_density` assumption (no **new** axiom).

## Verification

- Compiles under `lean v4.26.0` (with prebuilt `Proofs.Erdos1059OQ01/OQ02` dependencies), exit 0. The only warnings are 2 pre-existing unused-variable lints in the decomposition lemmas, unrelated to the new code.
- File axiom count unchanged (1, `strong_selberg_density`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)