### PR TITLE
Enrich Wirtinger equality case: add Poincaré/first-eigenvalue framing

### DIFF
--- a/src/data/proofs/area-of-circle-oq-01-oq-02-oq-02-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/area-of-circle-oq-01-oq-02-oq-02-oq-01-oq-01-oq-01/meta.json
@@ -73,7 +73,8 @@
       "Wirtinger's inequality and its equality case are both spectral facts: the gap ∫(f')²−∫f² = Σ(n²−1)cₙ² is a manifestly non-negative sum, and rigidity is just the statement that a non-negative sum vanishes iff each term does",
       "The mean-zero hypothesis enters exactly to make the n=0 term non-negative (it kills c₀), which is what makes the whole gap a sum of non-negative terms",
       "Equality extremisers are precisely the first harmonics a cos t + b sin t — geometrically, forcing this in both coordinates of a constant-speed closed curve produces a circle, the isoperimetric extremiser",
-      "Summable.tsum_pos turns 'one coefficient survives' into 'the gap is strictly positive', giving the contradiction that drives the forward (rigidity) direction without needing pointwise Fourier inversion"
+      "Summable.tsum_pos turns 'one coefficient survives' into 'the gap is strictly positive', giving the contradiction that drives the forward (rigidity) direction without needing pointwise Fourier inversion",
+      "Wirtinger's inequality is the sharp Poincaré inequality for the operator −d²/dt² on mean-zero 2π-periodic functions: its first nonzero eigenvalue is λ₁ = 1, attained exactly on the eigenspace spanned by cos t and sin t. The coefficient n²−1 = n² − λ₁ in the spectral gap is the eigenvalue of the n-th mode minus λ₁, so 'equality ⟺ first harmonic' is precisely the statement that the extremiser lies in the λ₁-eigenspace — the eigenvalue-rigidity viewpoint that generalizes to the Laplace–Beltrami spectrum in higher dimensions"
     ],
     "prerequisites": [
       "Fourier series and Parseval's identity",


### PR DESCRIPTION
Enrichment pass for `area-of-circle-oq-01-oq-02-oq-02-oq-01-oq-01-oq-01` (pass 0, quality 96 — already fully annotated, all 224 lines covered).

The entry met every quality target already, so instead of padding I added exactly **one keyInsight** (4→5, well under the 12 cap) supplying the one missing conceptual layer: Wirtinger's inequality is the **sharp Poincaré inequality for −d²/dt² on mean-zero 2π-periodic functions**, with first nonzero eigenvalue λ₁=1 attained on the eigenspace ⟨cos t, sin t⟩. The spectral-gap coefficient `n²−1 = n² − λ₁` is then the n-th eigenvalue minus λ₁, so 'equality ⟺ first harmonic' *is* 'extremiser lies in the λ₁-eigenspace' — the eigenvalue-rigidity viewpoint that generalizes to the Laplace–Beltrami spectrum (directly supporting the entry's higher-dimensional open question).

Also bundles a durable **enrichment-tracker** update recording this session's three completed passes (this entry + abel-ruffini-oq-02-oq-01 #37842 + angle-trisection-ext-oq-01 #37850). The tracker's pass-bump was being reverted by concurrent `git pull`s in the shared main checkout, causing already-enriched entries to be re-served; committing the entries makes the passes durable on merge (same fix as #25999).

Validated: JSON parses, `check-meta-size.ts` within caps (15.2 KB, well under 60 KB).