### PR TITLE
Enrich Axiom-Free Isoperimetric Capstone: companion cross-references

### DIFF
--- a/src/data/proofs/area-of-circle-oq-01-oq-02-oq-02-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/area-of-circle-oq-01-oq-02-oq-02-oq-01-oq-01-oq-02/meta.json
@@ -140,6 +140,16 @@
       "targetId": "area-of-circle-oq-01-oq-02-oq-02-oq-01",
       "relationship": "extends",
       "description": "Parent isoperimetric entry, which proved 4πA ≤ L² for smooth closed curves from five disclosed analytic axioms (Fourier decomposition, constant-speed reparametrization, the Wirtinger sum bound, and two Cauchy–Schwarz bounds). This capstone replaces every one of those axioms with its independently-discharged 0-axiom companion and assembles them into a fully axiom-free proof on the regular locus — the maximal honest endpoint, since the reparametrization axiom is genuinely false at stationary points."
+    },
+    {
+      "targetId": "area-of-circle-oq-01-oq-02-oq-02-oq-01-oq-01",
+      "relationship": "builds on",
+      "description": "The reparametrization-invariance companion: proves 0-axiom that arc length ∫√(x'²+y'²) and signed area ∫(x·y'−y·x') are invariant under a period-commuting C¹ reparametrization. These are exactly the circumference/area-preservation clauses that let this capstone pass to the constant-speed zero-mean curve ρ and then transport the proved bound 4πA ≤ L² back to the original γ (the ann-transport step)."
+    },
+    {
+      "targetId": "area-of-circle-oq-01-oq-02-oq-02-oq-01-oq-01-oq-01",
+      "relationship": "complements",
+      "description": "The equality/rigidity companion, addressing this entry's first open question. It characterizes the equality case of Wirtinger's inequality 0-axiom — ∫f² = ∫(f')² forces f(t) = a·cos t + b·sin t (only the first harmonic survives) — which is the analytic core of isoperimetric rigidity 4πA = L² ⟺ γ is a circle. Together with this capstone's strict inequality, it supplies both halves of the sharp Hurwitz statement."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
Enrichment pass for `area-of-circle-oq-01-oq-02-oq-02-oq-01-oq-01-oq-02` (Hurwitz isoperimetric capstone).

**Gap addressed:** the entry had only 1 crossReference (the parent) despite depending on a whole companion lineage. Added the two *existing* sibling gallery entries that are directly relevant:

- **Reparametrization Invariance of Arc Length and Signed Area** (`…-oq-01-oq-01`) — `builds on`. Supplies the circumference/area-preservation clauses that let the capstone pass to the constant-speed zero-mean curve ρ and transport 4πA ≤ L² back to γ.
- **Equality Case of Wirtinger's Inequality / Isoperimetric Rigidity** (`…-oq-01-oq-01-oq-01`) — `complements`. The analytic core of 4πA = L² ⟺ circle, which is exactly this entry's own first open question; together they give both halves of the sharp Hurwitz statement.

crossReferences 1→3 (cap 20). Both targets verified to exist; relationships checked against their descriptions. meta.json 16.3→17.4 KB (well under the 60 KB cap). JSON validated; size guardrail passes. No other fields touched.