### PR TITLE
research(shannon-channel-coding-awgn-oq-03-oq-01): parallel-rate power monotonicity + generic nonneg

### DIFF
--- a/proofs/Proofs/ShannonChannelCodingAWGNOQ03OQ01Monotone.lean
+++ b/proofs/Proofs/ShannonChannelCodingAWGNOQ03OQ01Monotone.lean
@@ -98,6 +98,26 @@ theorem parallelRate_antitone_noise (P N₁ N₂ : ι → ℝ) (hP : ∀ i, 0 �
   unfold parallelRate
   exact Finset.sum_le_sum fun i _ => perUseCapacity_antitone_noise (hP i) (hN₁ i) (h i)
 
+/-- **The parallel-Gaussian rate is monotone in the power profile.**  At a *fixed* noise
+profile `N`, allocating pointwise more (nonnegative) power `P₁ ≤ P₂` never decreases the
+total rate `∑ᵢ ½ log(1 + Pᵢ/Nᵢ)` — a term-by-term consequence of `perUseCapacity_mono`.
+The power-side companion of `parallelRate_antitone_noise` (which is antitone in the noise),
+lifting the single-channel `perUseCapacity_mono` to the multi-channel sum. -/
+theorem parallelRate_mono_power (N : ι → ℝ) (hN : ∀ i, 0 < N i)
+    {P₁ P₂ : ι → ℝ} (hP₁ : ∀ i, 0 ≤ P₁ i) (h : ∀ i, P₁ i ≤ P₂ i) :
+    parallelRate N P₁ ≤ parallelRate N P₂ := by
+  unfold parallelRate
+  exact Finset.sum_le_sum fun i _ => perUseCapacity_mono (hN i) (hP₁ i) (h i)
+
+/-- **The parallel-Gaussian rate is nonnegative.**  For a positive noise profile and any
+nonnegative power allocation, the total rate `∑ᵢ ½ log(1 + Pᵢ/Nᵢ) ≥ 0` — the term-by-term
+sum of `perUseCapacity_nonneg`.  The generic (arbitrary-allocation) form of the floor,
+specializing to `rate_waterAlloc_nonneg` at the water-filling depths. -/
+theorem parallelRate_nonneg (N P : ι → ℝ) (hN : ∀ i, 0 < N i) (hP : ∀ i, 0 ≤ P i) :
+    0 ≤ parallelRate N P := by
+  unfold parallelRate
+  exact Finset.sum_nonneg fun i _ => perUseCapacity_nonneg (hP i) (hN i)
+
 /-! ## Per-channel rate: strict positivity and its zero set -/
 
 /-- **A single sub-channel with positive power has strictly positive rate.**  For


### PR DESCRIPTION
## Summary

Completes the `parallelRate` monotonicity table in `ShannonChannelCodingAWGNOQ03OQ01Monotone.lean`. The file already had the noise-side `parallelRate_antitone_noise` and the single-channel `perUseCapacity_mono` / `perUseCapacity_nonneg`, but not their multi-channel power-side lifts.

### New lemmas (both axiom-free)

- **`parallelRate_mono_power`** — at fixed noise `N`, pointwise `P₁ ≤ P₂` (with `P₁ ≥ 0`) gives `parallelRate N P₁ ≤ parallelRate N P₂`. The term-by-term lift of `perUseCapacity_mono`; the power-side dual of `parallelRate_antitone_noise`.
- **`parallelRate_nonneg`** — for `N > 0`, `P ≥ 0`: `0 ≤ parallelRate N P`. The generic (arbitrary-allocation) floor, term-by-term sum of `perUseCapacity_nonneg`; specializes to the existing `rate_waterAlloc_nonneg` at the water-filling depths.

Both are one-line `Finset.sum_le_sum` / `Finset.sum_nonneg` lifts of the per-channel primitives — the natural symmetric completion of the noise/power monotonicity pair.

## Verification

- 2-file chain (`…OQ03OQ01` → `…Monotone`) rebuilt clean with host `lean v4.26.0` (no Docker).
- `#print axioms` on both → `[propext, Classical.choice, Quot.sound]`. No `sorry`, no `Lean.ofReduceBool`.

Research-only file; no gallery `meta.json` change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)