### PR TITLE
research(erdos-703-incomplete-01): positive lower endpoint of the L-avoiding hierarchy

### DIFF
--- a/proofs/Proofs/Erdos703Problem.lean
+++ b/proofs/Proofs/Erdos703Problem.lean
@@ -1090,6 +1090,49 @@ theorem T_L_empty (n : ℕ) : T_L n ∅ = 2 ^ n := by
         rw [Finset.card_powerset, Finset.card_range]
     _ ≤ _ := Finset.le_sup hmem
 
+/--
+**A singleton family avoids `L` iff its one set has a permitted cardinality.**
+The family `{A}` has only the self-pair `A ∩ A = A`, so it avoids every forbidden size
+in `L` exactly when `|A| ∉ L`. This is the `L`-avoiding structural analogue of the
+`avoidsRIntersection` self-pair observation, and the tool that produces admissible
+singleton families for lower bounds on `T_L`. -/
+theorem avoidsLIntersections_singleton_family {L : Finset ℕ} {A : Finset ℕ} :
+    avoidsLIntersections L {A} ↔ A.card ∉ L := by
+  unfold avoidsLIntersections
+  constructor
+  · intro h
+    have := h A A (Finset.mem_singleton_self A) (Finset.mem_singleton_self A)
+    simpa using this
+  · intro h B C hB hC
+    rw [Finset.mem_singleton] at hB hC
+    subst hB; subst hC
+    simpa using h
+
+/--
+**Positive lower endpoint `1 ≤ T_L n L` whenever `0 ∉ L`.** The singleton family `{∅}`
+has its only intersection size equal to `0` (`avoidsLIntersections_singleton_family`), so as
+long as `0` is not a forbidden size it is an admissible `L`-avoiding family, giving
+`T_L n L ≥ 1`. This is the nontrivial lower endpoint of the antitone hierarchy `T_L n ·`:
+together with the ceiling `T_L_le_pow` it sandwiches `1 ≤ T_L n L ≤ 2ⁿ` for every `L` missing
+`0`, the `L`-avoiding analogue of `one_le_T`. -/
+theorem one_le_T_L_of_zero_notMem {n : ℕ} {L : Finset ℕ} (h : 0 ∉ L) :
+    1 ≤ T_L n L := by
+  unfold T_L
+  have hmem : ({∅} : Finset (Finset ℕ)) ∈
+      ((Finset.range n).powerset.powerset).filter (avoidsLIntersections L) := by
+    rw [Finset.mem_filter]
+    refine ⟨?_, ?_⟩
+    · rw [Finset.mem_powerset]
+      intro B hB
+      rw [Finset.mem_singleton] at hB
+      subst hB
+      rw [Finset.mem_powerset]
+      exact Finset.empty_subset _
+    · rw [avoidsLIntersections_singleton_family]
+      simpa using h
+  calc 1 = ({∅} : Finset (Finset ℕ)).card := (Finset.card_singleton _).symm
+    _ ≤ _ := Finset.le_sup hmem
+
 /-
 ## Part VIII: Summary
 -/

--- a/src/data/proofs/erdos-703/meta.json
+++ b/src/data/proofs/erdos-703/meta.json
@@ -53,14 +53,15 @@
       "T_le_pow_sub_choose / T_le_pow_sub_one: sharpened upper bound T(n,r) ≤ 2^n − C(n,r), machine-checked. An r-avoiding family can contain no set of size exactly r (its self-pair A,A meets in |A| = r), so the family omits all C(n,r) subsets of size r, giving T(n,r) ≤ 2^n − C(n,r); for r ≤ n this yields the uniform strict improvement T(n,r) ≤ 2^n − 1 over the trivial ceiling, and it is tight at the diagonal r = n (C(n,n) = 1 recovers T(n,n) = 2^n − 1).",
       "smallSetsFamily / smallSetsFamily_avoids_r / smallSetsFamily_card / sum_choose_le_T / n_add_one_le_T_n_2: the 'small' disjunct {A ⊆ [n] : |A| < r} of the Frankl–Füredi families, isolated as its own r-avoiding family (|A ∩ B| ≤ |A| < r). It admits an EXACT binomial-sum cardinality ∑_{k<r} C(n,k) (proved by partitioning into powersetCard k layers), giving the first certified POLYNOMIAL lower bound T(n,r) ≥ ∑_{k<r} C(n,k) for all n,r — specialising to T(n,2) ≥ n+1, a nontrivial bound on the r=2 line at the start of the middle range the Frankl–Rödl question concerns. Axiom-free ([propext, Classical.choice, Quot.sound]).",
       "T_L(n,L) + T_L_singleton / T_L_antitone_forbidden / T_L_insert_le / T_L_le_T_of_mem: the Frankl–Wilson L-avoiding analogue of the extremal quantity T — T_L(n,L) is the max size of a family avoiding EVERY intersection size in L. It faithfully generalizes T (T_L n {r} = T n r), is antitone in the forbidden-size set (L ⊆ L' ⟹ T_L n L' ≤ T_L n L, via Finset.sup_mono), and is bounded by any single-size extremal it forbids (r ∈ L ⟹ T_L n L ≤ T n r), tying the L-avoiding hierarchy back to the concrete T(n,r) values. Axiom-free ([propext, Classical.choice, Quot.sound]).",
-      "Large-sets family and combined polynomial lower bound (Erdos703Problem.lean): largeSetsFamilyR (sets of size > (n+r)/2 avoid r-intersection since |A∩B| ≥ |A|+|B|−n > r), its exact card ∑_{(n+r)/2<k≤n} C(n,k), the lower bound sum_choose_large_le_T, and — combining with the disjoint small-sets family — small_add_large_le_T giving T(n,r) ≥ ∑_{k<r} C(n,k) + ∑_{(n+r)/2<k≤n} C(n,k). The top-layer dual of the existing small-sets bound. Axiom-free."
+      "Large-sets family and combined polynomial lower bound (Erdos703Problem.lean): largeSetsFamilyR (sets of size > (n+r)/2 avoid r-intersection since |A∩B| ≥ |A|+|B|−n > r), its exact card ∑_{(n+r)/2<k≤n} C(n,k), the lower bound sum_choose_large_le_T, and — combining with the disjoint small-sets family — small_add_large_le_T giving T(n,r) ≥ ∑_{k<r} C(n,k) + ∑_{(n+r)/2<k≤n} C(n,k). The top-layer dual of the existing small-sets bound. Axiom-free.",
+      "Positive lower endpoint of the L-avoiding hierarchy (Erdos703Problem.lean): avoidsLIntersections_singleton_family (a singleton family {A} avoids L iff |A| ∉ L, since its only pair is the self-intersection A∩A = A) and one_le_T_L_of_zero_notMem (0 ∉ L ⟹ 1 ≤ T_L n L, witnessed by the family {∅}). Together with the ceiling T_L_le_pow this sandwiches 1 ≤ T_L n L ≤ 2ⁿ for every L missing 0 — the L-avoiding analogue of one_le_T, complementing the empty-forbidden endpoint T_L n ∅ = 2ⁿ. Axiom-free ([propext, Classical.choice, Quot.sound])."
     ],
     "axiomCount": 1,
-    "lineCount": 938,
+    "lineCount": 1169,
     "assumptions": "1 axiom: frankl_rodl_1987 (the deep Frankl–Rödl 1987 exponential bound — the affirmative answer to the main question). 0 sorries: the trivial case T(n,0)=2^{n-1} is fully machine-checked (#print axioms T_n_0 = [propext, Classical.choice, Quot.sound]) via a complement-pairing upper bound and a star-family witness. The unused opaque chromaticNumber axiom was removed; the geometric chromatic-number consequence is recorded as prose only since infinite unit-distance chromatic numbers are not yet in Mathlib.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 47,
-    "definitionCount": 10
+    "theoremCount": 52,
+    "definitionCount": 11
   },
   "crossReferences": [
     {
@@ -186,10 +187,10 @@
       "Finset"
     ],
     "namespace": "Erdos703",
-    "lineCount": 938,
+    "lineCount": 1169,
     "axiomCount": 1,
-    "theoremCount": 41,
-    "definitionCount": 10,
+    "theoremCount": 52,
+    "definitionCount": 11,
     "path": "Proofs/Erdos703Problem.lean",
     "sorries": 0
   },


### PR DESCRIPTION
## Summary

Extends the Frankl–Wilson **L-avoiding hierarchy** in `Erdos703Problem.lean` with its missing **positive lower endpoint**. The section already had a uniform ceiling `T_L_le_pow` (`T_L n L ≤ 2ⁿ`) and the empty-forbidden endpoint `T_L_empty` (`T_L n ∅ = 2ⁿ`), but no lower bound establishing `T_L` is positive.

## New theorems (both axiom-free)

- **`avoidsLIntersections_singleton_family`** — a singleton family `{A}` avoids `L` iff `|A| ∉ L`, since its only pair is the self-intersection `A ∩ A = A`. The `L`-avoiding structural analogue of the `avoidsRIntersection` self-pair observation.
- **`one_le_T_L_of_zero_notMem`** — `0 ∉ L ⟹ 1 ≤ T_L n L`, witnessed by the admissible family `{∅}` (whose only intersection size is `0`).

Together with `T_L_le_pow` these sandwich `1 ≤ T_L n L ≤ 2ⁿ` for every `L` missing `0` — the `L`-avoiding analogue of the existing `one_le_T`, complementing `T_L_empty`.

## Verification

- Full file compiles cleanly via `bin/lake env lean Proofs/Erdos703Problem.lean` (exit 0).
- `#print axioms` on both new theorems: `[propext, Classical.choice, Quot.sound]` — no `sorryAx`, no `Lean.ofReduceBool`.
- The deep `frankl_rodl_1987` axiom (the affirmative answer to the main question) is untouched; `axiomCount` stays 1.
- meta.json counts refreshed (theoremCount, definitionCount, lineCount).

🤖 Generated with [Claude Code](https://claude.com/claude-code)