### PR TITLE
research(algebraic-numbers-countable-oq-07): the algebraic reals are dense

### DIFF
--- a/proofs/Proofs/AlgebraicRealsNull.lean
+++ b/proofs/Proofs/AlgebraicRealsNull.lean
@@ -344,6 +344,19 @@ theorem algebraic_complex_hausdorffMeasure_zero {d : NNReal} (hd : 0 < d) :
   hausdorffMeasure_of_dimH_lt (by
     rw [algebraic_complex_dimH_zero]; exact_mod_cast hd)
 
+/-- **The algebraic reals are dense** — despite being null (`algebraic_reals_null`),
+meagre (`algebraic_reals_meagre`), and of Hausdorff dimension `0`
+(`algebraic_reals_dimH_zero`).  They contain every rational (`isAlgebraic_rat`), and the
+rationals are dense in `ℝ` (`Rat.denseRange_cast`), so the algebraic reals are dense a
+fortiori.  Together with `transcendental_reals_dense` this exhibits `ℝ` as the union of two
+disjoint dense sets — the archetypal "small yet dense" set alongside its "large yet also
+dense" complement: topological density is orthogonal to measure/category/dimension smallness. -/
+theorem algebraic_reals_dense :
+    Dense {x : ℝ | IsAlgebraic ℚ x} := by
+  apply Dense.mono _ (Rat.denseRange_cast (𝕜 := ℝ))
+  rintro _ ⟨q, rfl⟩
+  exact isAlgebraic_rat ℚ q
+
 /-- **The transcendental reals are dense**, obtained from the dimensional bound:
 `dimH {algebraic} = 0 < 1 = finrank ℝ ℝ`, so the complement of the algebraic reals
 is dense (`dense_compl_of_dimH_lt_finrank`).  A dimension-theoretic route to the

--- a/src/data/proofs/algebraic-numbers-countable-oq-07/meta.json
+++ b/src/data/proofs/algebraic-numbers-countable-oq-07/meta.json
@@ -20,8 +20,8 @@
     "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 592,
-    "theoremCount": 38,
+    "lineCount": 605,
+    "theoremCount": 39,
     "definitionCount": 0,
     "dateAdded": "2026-06-21",
     "mathlibDependencies": [
@@ -185,8 +185,8 @@
   ],
   "leanFile": {
     "path": "Proofs/AlgebraicRealsNull.lean",
-    "lineCount": 592,
-    "theoremCount": 38,
+    "lineCount": 605,
+    "theoremCount": 39,
     "axiomCount": 0,
     "definitionCount": 0,
     "sorries": 0


### PR DESCRIPTION
## Summary

Extends `AlgebraicRealsNull.lean` (the "smallness of algebraic numbers across all notions" showcase). The file proves the algebraic reals are Lebesgue-null, meagre, and of Hausdorff dimension 0, and that the *transcendentals* are dense — but never records that the algebraic reals **themselves** are dense.

## New theorem

`algebraic_reals_dense : Dense {x : ℝ | IsAlgebraic ℚ x}` — the algebraic reals contain every rational (`isAlgebraic_rat`), and ℚ is dense in ℝ (`Rat.denseRange_cast`), so they are dense a fortiori.

Together with `transcendental_reals_dense`, this exhibits ℝ as the union of two disjoint dense sets: the "small yet dense" algebraic set (null / meagre / dim 0) alongside its "large yet also dense" complement — making explicit that topological density is orthogonal to measure-, category-, and dimension-theoretic smallness.

## Verification

- Local lean 4.26.0 full-file elaboration: **EXIT 0**, no errors.
- `#print axioms` = `[propext, Classical.choice, Quot.sound]` — **0-axiom / 0-sorry**.

## Files

- `proofs/Proofs/AlgebraicRealsNull.lean` (+1 thm; 592→605 lines)
- `src/data/proofs/algebraic-numbers-countable-oq-07/meta.json` (lineCount 592→605, theoremCount 38→39; both count blocks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)