### PR TITLE
Enrich Ellipse Area via Change of Variables: add analysis + measure-theory references

### DIFF
--- a/src/data/proofs/area-of-circle-oq-03-oq-03-oq-01/meta.json
+++ b/src/data/proofs/area-of-circle-oq-03-oq-03-oq-01/meta.json
@@ -164,6 +164,20 @@
       "year": "2020",
       "venue": "CPP 2020",
       "note": "integral_sqrt_one_sub_sq, intervalIntegral.integral_comp_div, and volume_regionBetween_eq_integral"
+    },
+    {
+      "authors": "Apostol, Tom M.",
+      "title": "Calculus, Volume I: One-Variable Calculus, with an Introduction to Linear Algebra",
+      "year": "1967",
+      "venue": "2nd ed., Wiley",
+      "note": "Develops area as a definite integral and the substitution (change-of-variables) rule for integrals — the 1D content behind ellipse_halfheight_integral, where x ↦ x/a reduces the ellipse arc integral to the unit-circle integral ∫√(1−x²)=π/2."
+    },
+    {
+      "authors": "Folland, Gerald B.",
+      "title": "Real Analysis: Modern Techniques and Their Applications",
+      "year": "1999",
+      "venue": "2nd ed., Wiley",
+      "note": "Product measures, Fubini–Tonelli, and the measure of a region between two graphs — the measure-theoretic foundation of volume_regionBetween_eq_integral that certifies the 1D integral π·a·b is the genuine 2D Lebesgue measure of the filled ellipse (ellipse_volume)."
     }
   ],
   "sorries": [],


### PR DESCRIPTION
Enrichment pass for `area-of-circle-oq-03-oq-03-oq-01` (pass 0, quality 96 — fully annotated, all 108 lines covered).

The entry met all annotation/section/insight targets but carried only **2 references** (Archimedes + Mathlib) for a result with a clean two-stage analytic structure. Added the two standard modern pillars that map directly onto that structure (references 2 → 4, far under the 25 cap):

- **Apostol, *Calculus* Vol. I** — area-as-a-definite-integral and the substitution/change-of-variables rule: the 1D content behind `ellipse_halfheight_integral`, where `x ↦ x/a` reduces the ellipse arc integral to Mathlib's unit-circle integral `∫√(1−x²)=π/2`.
- **Folland, *Real Analysis*** — product measures, Fubini–Tonelli, and the measure of a region between two graphs: the measure-theoretic foundation of `volume_regionBetween_eq_integral` that certifies the 1D integral `π·a·b` is the genuine 2D Lebesgue measure of the filled ellipse (`ellipse_volume`).

So the reference list now spans history (Archimedes) → analysis/substitution (Apostol) → measure theory (Folland) → formalization (Mathlib), matching the file's exhaustion → interval-integral → Lebesgue-measure arc.

Also bundles a durable **enrichment-tracker** pass for this entry (same re-serve fix as #25999 / this session's #37862). Validated: JSON parses, `check-meta-size.ts` within caps (15.9 KB).