### PR TITLE
research(kepler-conjecture-oq-04): the density functional attains exactly [0,1]

### DIFF
--- a/proofs/Proofs/KeplerConjectureOQ04.lean
+++ b/proofs/Proofs/KeplerConjectureOQ04.lean
@@ -1300,4 +1300,20 @@ theorem packingDensity_range_subset_Icc :
   rintro x ⟨d, rfl⟩
   exact ⟨d.nonneg, d.le_one⟩
 
+/-- **The density functional attains exactly the unit interval.**
+`range PackingDensity.density = Set.Icc 0 1`: the image of the density projection is
+*precisely* `[0, 1]`, not merely contained in it. This upgrades
+`packingDensity_range_subset_Icc` (`⊆`) to an equality by supplying the reverse
+inclusion — every `x ∈ [0, 1]` is realized, by the packing `⟨x, hx.1, hx.2⟩` whose two
+structure fields are exactly the interval endpoints. So beyond having its two endpoints
+attained (`isLeast_packingDensity_range`, `isGreatest_packingDensity_range`), the
+functional is *surjective onto* `[0, 1]`: it attains every intermediate value too — a
+genuine strengthening, since a bounded map with both endpoints attained can still skip
+interior values. No axioms. -/
+theorem range_packingDensity_eq_Icc :
+    Set.range (PackingDensity.density) = Set.Icc 0 1 := by
+  apply Set.Subset.antisymm packingDensity_range_subset_Icc
+  rintro x ⟨hx0, hx1⟩
+  exact ⟨⟨x, hx0, hx1⟩, rfl⟩
+
 end KeplerConjectureOQ04

--- a/src/data/proofs/kepler-conjecture-oq-04/meta.json
+++ b/src/data/proofs/kepler-conjecture-oq-04/meta.json
@@ -12,9 +12,9 @@
       "KeplerConjecture"
     ],
     "namespace": "KeplerConjectureOQ04",
-    "lineCount": 1303,
+    "lineCount": 1319,
     "axiomCount": 2,
-    "theoremCount": 47,
+    "theoremCount": 48,
     "definitionCount": 10,
     "path": "Proofs/KeplerConjectureOQ04.lean",
     "sorries": 0,


### PR DESCRIPTION
## Summary

Adds the missing surjectivity capstone to the Kepler OQ-04 packing-density hierarchy file.

The file already proves the range of `PackingDensity.density` is **contained** in `[0,1]` (`packingDensity_range_subset_Icc`) and that **both endpoints are attained** (`isLeast_packingDensity_range`, `isGreatest_packingDensity_range`, `sInf = 0`, `sSup = 1`). It never states the **equality**.

## New theorem (axiom-free)

- **`range_packingDensity_eq_Icc`** — `range PackingDensity.density = Set.Icc 0 1`.

This upgrades the existing `⊆` to `=` by supplying the reverse inclusion: every `x ∈ [0,1]` is realized by the packing `⟨x, hx.1, hx.2⟩`, whose two structure fields (`nonneg`, `le_one`) are exactly the interval endpoints. It is a genuine strengthening over "bounded with both endpoints attained" — a bounded map with endpoints attained can still skip interior values; this shows the functional is **surjective onto the whole unit interval**.

## Verification

- `#print axioms`: `[propext, Classical.choice, Quot.sound]` only — does **not** touch the two Kepler statement axioms (Bezdek–Kuperberg, Ulam); the result is purely structural.
- No drift: the pristine file compiles clean against Mathlib v4.26.0 (verified before editing).
- `axiomCount` stays **2**, 0 sorries. 47 → 48 theorems. `meta.json` counts updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)