### PR TITLE
research(law-of-cosines-oq-03-oq-03): PART 9a — closed form of the hyperbolic law-of-sines ratio

### DIFF
--- a/proofs/Proofs/LawOfCosinesOQ03OQ03.lean
+++ b/proofs/Proofs/LawOfCosinesOQ03OQ03.lean
@@ -790,6 +790,60 @@ theorem hyperbolic_law_of_sines_ac (t : HyperbolicTriangle) :
   rw [div_eq_div_iff hA hC]; linear_combination law_of_sines_ac t
 
 -- ============================================================
+-- PART 9a: Explicit closed form of the common law-of-sines ratio
+-- ============================================================
+
+/-- **Square-root extraction of the Gram numerator along side `a`.** `sinh_a_num_sq`
+    only pins the *square* `(sinh a · sin B · sin C)² = gramNumerator`; since the base
+    `sinh a · sin B · sin C` is strictly positive it is the *positive* square root of the
+    Gram numerator: `sinh a · sin B · sin C = √(gramNumerator)`. This is the step that
+    turns the squared law of sines into an explicit (unsquared) value. -/
+theorem sinh_a_mul_sin_eq_sqrt_gram (t : HyperbolicTriangle) :
+    Real.sinh t.a * (Real.sin t.B * Real.sin t.C) = Real.sqrt (gramNumerator t) := by
+  have hpos : 0 < Real.sinh t.a * (Real.sin t.B * Real.sin t.C) :=
+    mul_pos (sinh_a_pos t) (mul_pos (sin_B_pos t) (sin_C_pos t))
+  rw [← sinh_a_num_sq t, Real.sqrt_sq hpos.le]
+
+/-- **The common law-of-sines ratio in closed form.** `hyperbolic_law_of_sines` shows the
+    three ratios `sinh(side)/sin(opposite angle)` coincide but does not say *what* they
+    equal. Extracting the positive root of the Gram numerator pins the common value
+    explicitly and symmetrically in the three angles:
+
+      sinh a / sin A  =  √(cos²A + cos²B + cos²C + 2 cos A cos B cos C − 1)
+                          / (sin A · sin B · sin C).
+
+    So the "hyperbolic circumradius" constant of the law of sines is a function of the
+    *angles alone* — the manifest symmetry of the right-hand side under permuting
+    `A, B, C` is an independent proof that the three ratios agree. -/
+theorem law_of_sines_common_ratio (t : HyperbolicTriangle) :
+    Real.sinh t.a / Real.sin t.A
+      = Real.sqrt (gramNumerator t)
+          / (Real.sin t.A * Real.sin t.B * Real.sin t.C) := by
+  have hA : Real.sin t.A ≠ 0 := (sin_A_pos t).ne'
+  have hprod : Real.sin t.A * Real.sin t.B * Real.sin t.C ≠ 0 :=
+    mul_ne_zero (mul_ne_zero hA (sin_B_pos t).ne') (sin_C_pos t).ne'
+  rw [div_eq_div_iff hA hprod]
+  linear_combination Real.sin t.A * sinh_a_mul_sin_eq_sqrt_gram t
+
+/-- **The common ratio is the same symmetric expression for all three sides.** Combining
+    the side-`a` closed form `law_of_sines_common_ratio` with the equality of ratios
+    (`hyperbolic_law_of_sines`, `hyperbolic_law_of_sines_ac`) shows every one of the three
+    law-of-sines ratios equals the *single* symmetric value `√(gramNumerator)/(sin A·sin B·sin C)`.
+    This exhibits the invariant `R = sinh(side)/sin(opposite angle)` of the hyperbolic
+    triangle in explicit closed form. -/
+theorem law_of_sines_common_ratio_symm (t : HyperbolicTriangle) :
+    Real.sinh t.a / Real.sin t.A
+        = Real.sqrt (gramNumerator t) / (Real.sin t.A * Real.sin t.B * Real.sin t.C)
+      ∧ Real.sinh t.b / Real.sin t.B
+        = Real.sqrt (gramNumerator t) / (Real.sin t.A * Real.sin t.B * Real.sin t.C)
+      ∧ Real.sinh t.c / Real.sin t.C
+        = Real.sqrt (gramNumerator t) / (Real.sin t.A * Real.sin t.B * Real.sin t.C) := by
+  have ha := law_of_sines_common_ratio t
+  refine ⟨ha, ?_, ?_⟩
+  · rw [← (hyperbolic_law_of_sines t).1]; exact ha
+  · rw [← hyperbolic_law_of_sines_ac t]; exact ha
+
+-- ============================================================
 -- PART 10: Realizability — the defect condition A+B+C<π is SUFFICIENT
 -- ============================================================
 

--- a/research/problems/law-of-cosines-oq-03-oq-03/knowledge.md
+++ b/research/problems/law-of-cosines-oq-03-oq-03/knowledge.md
@@ -185,3 +185,27 @@ Prior session shipped work UNVERIFIED (docker containerd meta.db I/O down). `Law
 ([[reference-docker-down-lean-elab-verification-path]]): whole file EXIT 0, zero errors/warnings.
 `#print axioms equilateral_cosh_a` = [propext, Classical.choice, Quot.sound] — no sorryAx. Standing
 work confirmed correct (no bug). Depth-3 slug → 0 follow-ups. Marked completed.
+
+## Session 2026-07-11 (researcher-7) — explicit closed form of the law-of-sines ratio
+
+PART 9 proved the three ratios sinh(side)/sin(opposite angle) COINCIDE (via the shared
+Gram numerator N = cos²A+cos²B+cos²C+2cosAcosBcosC−1) but never said WHAT they equal.
+Added PART 9a (3 thm, 978→1032 L, meta thm 59→62; axiomatized/badge axiom/6 structure
+assumptions unchanged; #print axioms = [propext,choice,Quot.sound]):
+- `sinh_a_mul_sin_eq_sqrt_gram`: sinh a·(sin B·sin C) = √N. Positive-root extraction from
+  the squared identity `sinh_a_num_sq` — base is strictly positive so it IS √N. Proof:
+  `rw [← sinh_a_num_sq t, Real.sqrt_sq hpos.le]` (Real.sqrt_sq : 0≤x → √(x²)=x, must be
+  fully qualified — `open Real` collides with the ℝ≥0 `sqrt_sq`).
+- `law_of_sines_common_ratio`: sinh a/sin A = √N / (sin A·sin B·sin C) — the explicit,
+  angle-only closed form of the common ratio ("hyperbolic circumradius"). Proof:
+  `rw [div_eq_div_iff hA hprod]; linear_combination (Real.sin t.A) * sinh_a_mul_sin_eq_sqrt_gram t`
+  (√N treated as ring atom).
+- `law_of_sines_common_ratio_symm`: all three ratios (a,b,c) equal the SAME symmetric
+  expression √N/(sinA sinB sinC). Combines side-a form with hyperbolic_law_of_sines(.1)
+  and _ac via `rw [← …]; exact ha`. The RHS symmetry is an independent proof the ratios agree.
+
+Recipe (turn a squared trig identity into an explicit value): base>0 ⟹ base = √(RHS) via
+`rw [← squared_lemma, Real.sqrt_sq pos.le]`; then divide through with div_eq_div_iff +
+linear_combination scaling the extraction lemma. Genuine frontier still open (heavy algebra):
+FIRST law of cosines cosh c = cosh a cosh b − sinh a sinh b cos C, and SAS/ASA congruence.
+Docker healthy (mathlib cache, built clean 3063 jobs / 4.2s).

--- a/src/data/proofs/law-of-cosines-oq-03-oq-03/meta.json
+++ b/src/data/proofs/law-of-cosines-oq-03-oq-03/meta.json
@@ -17,8 +17,8 @@
     ],
     "axiomCount": 0,
     "sorries": 0,
-    "lineCount": 978,
-    "theoremCount": 59,
+    "lineCount": 1032,
+    "theoremCount": 62,
     "definitionCount": 4
   },
   "openQuestion": {
@@ -463,8 +463,8 @@
     ],
     "sorries": 0,
     "axiomCount": 6,
-    "lineCount": 978,
-    "theoremCount": 59,
+    "lineCount": 1032,
+    "theoremCount": 62,
     "definitionCount": 4,
     "originalContributions": [
       "HyperbolicTriangle structure encoding the three second laws of cosines plus the angular defect",


### PR DESCRIPTION
## Summary

Extends the hyperbolic law of sines in `Proofs/LawOfCosinesOQ03OQ03.lean` (`HyperbolicAAA`) with the **explicit closed form of the common ratio**.

PART 9 proved that the three ratios `sinh(side)/sin(opposite angle)` *coincide* — via the shared symmetric Gram numerator `N = cos²A + cos²B + cos²C + 2 cos A cos B cos C − 1` — but never stated *what* they equal. PART 9a pins the value.

## New theorems (PART 9a)

- **`sinh_a_mul_sin_eq_sqrt_gram`** — `sinh a · (sin B · sin C) = √N`. Positive-root extraction: the squared identity `sinh_a_num_sq` gives `(sinh a·sin B·sin C)² = N`, and the base is strictly positive, so it is the positive square root.
- **`law_of_sines_common_ratio`** — `sinh a / sin A = √N / (sin A · sin B · sin C)`. The angle-only closed form of the common law-of-sines ratio (the hyperbolic "circumradius" constant). The manifest symmetry of the right-hand side under permuting `A, B, C` is an independent proof that the three ratios agree.
- **`law_of_sines_common_ratio_symm`** — all three ratios (`a`, `b`, `c`) equal the *same* symmetric expression `√N / (sin A · sin B · sin C)`.

## Verification

- Built via `./proofs/scripts/docker-build.sh Proofs.LawOfCosinesOQ03OQ03` — clean (3063 jobs, 4.2s).
- `#print axioms` on all three new theorems: `[propext, Classical.choice, Quot.sound]` — no `sorryAx`, no new assumptions.
- Status unchanged: `axiomatized` / badge `axiom`, 6 structure-encoded second-law assumptions (the three `lawA/lawB/lawC` fields per vertex). 0 sorries, no `native_decide`.
- Resyncs `meta.json` line/theorem counts (978→1032 L, 59→62 thm; were stale).

Genuine frontier still open (heavy algebra, out of session scope): the *first* law of cosines `cosh c = cosh a cosh b − sinh a sinh b cos C` and SAS/ASA congruence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)