### PR TITLE
Enrich Isoperimetric Capstone: cover overview docstring + chain cross-refs

### DIFF
--- a/src/data/proofs/area-of-circle-oq-01-oq-02-oq-02-oq-01-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/area-of-circle-oq-01-oq-02-oq-02-oq-01-oq-01-oq-02/annotations.json
@@ -1,5 +1,17 @@
 [
   {
+    "id": "ann-overview-capstone",
+    "proofId": "area-of-circle-oq-01-oq-02-oq-02-oq-01-oq-01-oq-02",
+    "range": { "startLine": 1, "endLine": 66 },
+    "type": "concept",
+    "title": "The Capstone of the Hurwitz Isoperimetric Program",
+    "content": "The module docstring lays out the whole strategy. The gallery parent proved the isoperimetric inequality 4πA ≤ L² for smooth closed curves from FIVE disclosed analytic axioms — Fourier decomposition, constant-speed reparametrization (IFT), the Wirtinger sum bound, and two Cauchy–Schwarz bounds — plus the fully-proved algebraic kernel. Across the OQ lineage each of the five axioms was independently discharged 0-axiom in a self-contained companion file. This capstone performs the final assembly: it feeds the four discharged analytic bounds (on the IFT reparametrization) into the algebraic kernel to obtain a fully axiom-free proof. The crucial honesty point spelled out here: the result is stated for RegularClosedCurve, not all SmoothClosedCurve, because the reparametrization axiom is genuinely FALSE at stationary points — so a literal 0-axiom replacement of the parent theorem is impossible, and the regular locus is the maximal domain where the inverse-function-theorem route can succeed. Restricting the hypothesis, rather than adding an axiom, is what makes the end-to-end chain honest.",
+    "mathContext": "Program: Fourier $\\Rightarrow$ Wirtinger $\\Rightarrow$ Cauchy–Schwarz $\\Rightarrow$ IFT reparametrization $\\Rightarrow$ algebraic kernel $\\Rightarrow$ $4\\pi A \\le L^2$, on the regular locus, with 0 axioms and 0 sorries.",
+    "significance": "context",
+    "relatedConcepts": ["isoperimetric inequality", "Hurwitz proof", "axiom discharge", "regular vs smooth curve", "maximal honest endpoint"],
+    "prerequisites": ["the isoperimetric problem", "the notion of a disclosed axiom", "regular closed curves"]
+  },
+  {
     "id": "ann-imports",
     "proofId": "area-of-circle-oq-01-oq-02-oq-02-oq-01-oq-01-oq-02",
     "range": { "startLine": 67, "endLine": 77 },


### PR DESCRIPTION
Enrichment pass for `area-of-circle-oq-01-oq-02-oq-02-oq-01-oq-01-oq-02` (pass 0, quality 96).

Two genuine gaps closed (no padding of already-rich fields):

1. **Uncovered docstring.** Annotations previously started at line 67 — the 66-line module overview had a matching `section` but no annotation. Added `ann-overview-capstone` explaining the five-axiom parent, the per-axiom independent 0-axiom discharge in companion files, and the key honesty point: the result is stated for `RegularClosedCurve` (not all `SmoothClosedCurve`) because the reparametrization axiom is genuinely *false* at stationary points — so restricting the hypothesis, rather than adding an axiom, is what makes the chain the maximal honest 0-axiom endpoint.

2. **Cross-references 1 → 3.** The entry linked only its parent. Added:
   - the **rigidity sibling** (Wirtinger equality case, `…oq-01-oq-01`) — which directly answers this entry's own first open question (`4πA = L² ⟺ circle`) by characterizing when the inequality is tight;
   - the **grandparent Fourier-decomposition** companion (`area-of-circle-oq-01-oq-03`) that the 0-axiom status rests on transitively.

Validated: JSON parses, `check-meta-size.ts` within caps (17.3 KB). Bundles a durable enrichment-tracker pass (re-serve fix, cf. #25999).