### PR TITLE
Enrich The Gaussian Integral Equals √π: link direct children + normalization sibling

### DIFF
--- a/src/data/proofs/area-of-circle-oq-07/meta.json
+++ b/src/data/proofs/area-of-circle-oq-07/meta.json
@@ -130,6 +130,21 @@
       "targetId": "basel-problem",
       "relationship": "related",
       "description": "A sibling landmark where π appears from a non-geometric object: Basel gives ∑ 1/n² = π²/6, as this entry gives ∫ e^{-x²} = √π. Both are canonical instances of π surfacing outside its defining circle — one from an infinite series, one from an integral with no elementary antiderivative."
+    },
+    {
+      "targetId": "area-of-circle-oq-07-oq-01",
+      "relationship": "extended by",
+      "description": "Direct child: generalizes the b = 1 real value √π proved here to the complex parameter, ∫_ℝ e^{-b x²} dx = (π/b)^{1/2} for every b : ℂ with Re b > 0 (from Mathlib's integral_gaussian_complex over the right half-plane), and includes a bridge theorem recovering this entry's real √π as the b = 1 specialization."
+    },
+    {
+      "targetId": "area-of-circle-oq-07-oq-02",
+      "relationship": "extended by",
+      "description": "Direct child: evaluates the half-line Gaussian ∫_{0}^{∞} e^{-b x²} dx = √(π/b)/2 (from integral_gaussian_Ioi) and, via the even-symmetry bridge ∫_ℝ e^{-x²} = 2·∫_{(0,∞)} e^{-x²}, re-derives this entry's ∫_ℝ e^{-x²} = √π along an independent route — a cross-check of the value proved here."
+    },
+    {
+      "targetId": "area-of-circle-oq-05-incomplete-01",
+      "relationship": "related",
+      "description": "Resolves this entry's first open question. From the same integral_gaussian it proves the standard-normal normalization ∫ (1/√(2π))e^{-x²/2} = 1 (and the b = 1/2 value ∫ e^{-x²/2} = √(2π)), turning the √π seed established here into the full normal-distribution density normalization constants."
     }
   ],
   "references": [


### PR DESCRIPTION
Enrichment pass for `area-of-circle-oq-07` (∫_ℝ e^{-x²} = √π).

**Gap addressed:** the entry has designated child/extension entries that build directly on its √π result, but none were cross-referenced. Added the three existing, directly-related entries (crossReferences 4→7, cap 20):

- **area-of-circle-oq-07-oq-01** — *Complex Gaussian Integral* `extended by`. Generalizes the b=1 value √π to complex b: ∫ e^{-bx²} = (π/b)^{1/2} for Re b > 0, with a bridge recovering this entry's real √π.
- **area-of-circle-oq-07-oq-02** — *Half-Line Gaussian Integral* `extended by`. Re-derives ∫_ℝ e^{-x²} = √π via the even-symmetry bridge from the half-line value — an independent cross-check.
- **area-of-circle-oq-05-incomplete-01** — `related`. Actually *resolves* this entry's stated first open question: the standard-normal normalization ∫ (1/√(2π))e^{-x²/2} = 1 derived from the same integral_gaussian.

All three verified to exist; relationships checked against their descriptions/Lean content. meta.json 11.8→13.1 KB (well under 60 KB cap). JSON validated; size guardrail passes. No other fields touched.