### PR TITLE
research(elementary-quadratic-reciprocity-oq-03-oq-02): numerator congruence law + full period

### DIFF
--- a/proofs/Proofs/ElementaryQuadraticReciprocityOQ03OQ02.lean
+++ b/proofs/Proofs/ElementaryQuadraticReciprocityOQ03OQ02.lean
@@ -602,6 +602,27 @@ theorem kronecker_periodic_numerator (a : ℤ) (n : ℕ) (hn : 0 < n) (hno : n %
   rw [kronecker_mod_numerator (a + (n : ℤ)) n hn hno, kronecker_mod_numerator a n hn hno,
     Int.add_emod_right]
 
+/-- **The numerator character `(·/n)` is constant on residue classes (congruence form).**
+    For odd positive `n`, congruent numerators give equal symbols: `a₁ ≡ a₂ (mod n)`
+    implies `(a₁/n) = (a₂/n)`. This is the numerator-side analog of Mathlib's
+    `jacobiSym.mod_left'`, and the precise sense in which `(·/n)` is a genuine function on
+    `ℤ / nℤ` — the form used to *define* the induced Dirichlet character on `ZMod n`
+    (stronger than the representative form `kronecker_mod_numerator`, which only reduces to
+    the canonical residue `a % n`). `sorry`-free, axiom-free. -/
+theorem kronecker_mod_numerator' (a₁ a₂ : ℤ) (n : ℕ) (hn : 0 < n) (hno : n % 2 = 1)
+    (h : a₁ % (n : ℤ) = a₂ % (n : ℤ)) :
+    kronecker a₁ (n : ℤ) = kronecker a₂ (n : ℤ) := by
+  rw [kronecker_mod_numerator a₁ n hn hno, kronecker_mod_numerator a₂ n hn hno, h]
+
+/-- **The numerator character `(·/n)` is invariant under adding any integer multiple of `n`.**
+    For odd positive `n` and any `k : ℤ`, `(a + k·n / n) = (a/n)`. The full period-`n`
+    statement generalising the single-step `kronecker_periodic_numerator` (the `k = 1` case),
+    obtained from the congruence form since `(a + k·n) % n = a % n`. `sorry`-free,
+    axiom-free. -/
+theorem kronecker_add_mul_numerator (a k : ℤ) (n : ℕ) (hn : 0 < n) (hno : n % 2 = 1) :
+    kronecker (a + k * (n : ℤ)) (n : ℤ) = kronecker a (n : ℤ) :=
+  kronecker_mod_numerator' (a + k * (n : ℤ)) a n hn hno (Int.add_mul_emod_self_right a k n)
+
 /-! ### Section 9: the supplementary laws as Mathlib's canonical characters
 
 Section 8 states the supplementary laws in explicit `if`-form (readable residue

--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-03-oq-02/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-03-oq-02/meta.json
@@ -97,9 +97,9 @@
       "Mathlib.NumberTheory.LegendreSymbol.JacobiSymbol"
     ],
     "namespace": "KroneckerSymbol",
-    "lineCount": 1172,
+    "lineCount": 1213,
     "axiomCount": 0,
-    "theoremCount": 81,
+    "theoremCount": 83,
     "definitionCount": 6,
     "path": "Proofs/ElementaryQuadraticReciprocityOQ03OQ02.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

Two axiom-free additions to the Kronecker-symbol file `ElementaryQuadraticReciprocityOQ03OQ02.lean`,
completing the "`(·/n)` is a Dirichlet character mod `n`" numerator API:

- **`kronecker_mod_numerator'`** (congruence form): for odd positive `n`,
  `a₁ ≡ a₂ (mod n) → (a₁/n) = (a₂/n)`. This is the numerator-side analog of Mathlib's
  `jacobiSym.mod_left'`, and the precise sense in which the symbol is a genuine function on
  `ℤ/nℤ` — the form used to **define** the induced character on `ZMod n`. The file previously
  had only the representative form `kronecker_mod_numerator` (`(a/n) = (a % n / n)`), which is
  strictly weaker.
- **`kronecker_add_mul_numerator`** (full period): `(a + k·n / n) = (a/n)` for every `k : ℤ`,
  generalising the single-step `kronecker_periodic_numerator` (the `k = 1` case).

Both are one line off `kronecker_mod_numerator`; the second uses `Int.add_mul_emod_self_right`.

## Note on the WIP "next action"

The recorded next action ("general mul-in-n via 2-adic valuation + odd-part factorization")
is **already complete**: `kronecker_mul_right` establishes denominator multiplicativity
`(a/mn) = (a/m)(a/n)` for *every* nonzero pair (see the file's "what remains open" note). This
PR instead fills a genuine remaining gap — numerator periodicity in congruence form.

## Verification

- Host `lake env lean` (Lean v4.26.0) typechecks the full file exit 0, no errors/warnings
  (the documented docker olean-write SIGBUS-135 affects only the `.olean` write, not host
  elaboration).
- `#print axioms kronecker_mod_numerator'` = `[propext, Classical.choice, Quot.sound]`
- `#print axioms kronecker_add_mul_numerator` = `[propext, Classical.choice, Quot.sound]`

`meta.json` `lineCount` 1172→1213, `theoremCount` 81→83; still 0 axioms / 0 sorries. The
generalized (Gauss-sum) reciprocity core and the `kronecker2` even-modulus refinement remain
open, as documented in the file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)