### PR TITLE
Enrich Gaussian Normalization Family: add probability-theory references

### DIFF
--- a/src/data/proofs/area-of-circle-oq-05-incomplete-01/meta.json
+++ b/src/data/proofs/area-of-circle-oq-05-incomplete-01/meta.json
@@ -154,6 +154,20 @@
       "year": "2024",
       "venue": "leanprover-community/mathlib4",
       "note": "Provides integral_gaussian, the source of every rescaling here."
+    },
+    {
+      "authors": "Feller, William",
+      "title": "An Introduction to Probability Theory and Its Applications, Vol. II",
+      "year": "1971",
+      "venue": "2nd ed., Wiley",
+      "note": "The normal distribution N(μ, σ²), its density, and the normalization constant σ√(2π) — the probability-theory strand this entry derives from the bare Gaussian integral ∫e^{−x²}=√π."
+    },
+    {
+      "authors": "Billingsley, Patrick",
+      "title": "Probability and Measure",
+      "year": "1995",
+      "venue": "3rd ed., Wiley",
+      "note": "Rigorous measure-theoretic treatment of the normal density, including that ∫ e^{−x²/2}/√(2π) dx = 1 — the identity the rescaling family here makes explicit and machine-checked."
     }
   ],
   "mainTheorems": [

--- a/src/data/proofs/enrichment-tracker.json
+++ b/src/data/proofs/enrichment-tracker.json
@@ -7092,6 +7092,11 @@
       "passes": 1,
       "lastEnriched": "2026-06-19T22:21:39Z",
       "quality": 100
+    },
+    "area-of-circle-oq-05-incomplete-01": {
+      "passes": 1,
+      "lastEnriched": "2026-07-12T01:21:20Z",
+      "quality": 96
     }
   }
 }


### PR DESCRIPTION
Enrichment pass for `area-of-circle-oq-05-incomplete-01` (pass 0, quality 96 — fully annotated, 6 annotations covering lines 10–95).

The entry's subject is the normal distribution's normalization constants (√(2π), σ√(2π)) derived from the bare Gaussian integral, yet its references covered only history (Gauss 1809) and formalization (Mathlib) — the **probability-theory pillar was absent**. Added two standard, on-topic references (2 → 4, well under the 25 cap):

- **Feller, *Probability Theory* Vol. II** — the normal distribution N(μ,σ²), its density, and the σ√(2π) normalization the entry's rescaling family produces.
- **Billingsley, *Probability and Measure*** — the rigorous identity ∫ e^{−x²/2}/√(2π) = 1 that the machine-checked family makes explicit.

Validated: JSON parses, `check-meta-size.ts` within caps. Bundles a durable enrichment-tracker pass (re-serve fix, cf. #25999).