### PR TITLE
research(erdos-18-oq-01): double the guaranteed representable range to [0,2m) + sharp σ lower bound

### DIFF
--- a/proofs/Proofs/Erdos18OQ01.lean
+++ b/proofs/Proofs/Erdos18OQ01.lean
@@ -319,6 +319,46 @@ theorem practical_represents_all_of_sigma_le_two_mul {m : ℕ} (hp : IsPractical
   · exact practical_represents_le hp hle
   · exact practical_top_segment hp (by omega) hk
 
+/-- **A practical number represents its entire bottom double-block `[0, 2m)`.**
+    `practical_represents_le` covers `[0, m]`; this doubles it to `[0, 2m)` using *only*
+    divisors of `m` (no divisors of `2m`).  For `m ≤ k < 2m` write `k = m + (k - m)` with
+    `k - m < m`, represent the remainder `k - m` by divisors of `m`, and adjoin the divisor
+    `m` itself — fresh, since the remainder's representing set sums to `k - m < m`, so none
+    of its elements is `m`.  This is the `practical_two_mul` peel argument kept inside
+    `divisors m`, the reusable primitive under both the doubling closure and the
+    `σ`-lower-bound corollary below.  It is tight: for `m = 2ᵏ` the range `[0, 2m)` is
+    exactly `[0, σ(m)]` (`σ(2ᵏ) = 2m − 1`). -/
+theorem practical_represents_lt_two_mul {m : ℕ} (hp : IsPractical m) {k : ℕ}
+    (hk : k < 2 * m) : IsRepresentable k m := by
+  have hm1 : 1 ≤ m := hp.1
+  rcases lt_or_ge k m with hlt | hge
+  · exact practical_represents_le hp (le_of_lt hlt)
+  · -- `m ≤ k < 2m`: peel the divisor `m`, represent the remainder `k - m < m`.
+    have hj : k - m < m := by omega
+    obtain ⟨S, hS, hsum⟩ := practical_represents_le hp (le_of_lt hj)
+    have hmS : m ∉ S := by
+      intro hmem
+      have hle : m ≤ S.sum id :=
+        Finset.single_le_sum (f := id) (fun i _ => Nat.zero_le _) hmem
+      rw [hsum] at hle
+      omega
+    refine ⟨insert m S, ?_, ?_⟩
+    · rw [Finset.insert_subset_iff]
+      exact ⟨Nat.mem_divisors.mpr ⟨dvd_refl m, by omega⟩, hS⟩
+    · rw [Finset.sum_insert hmS, hsum]
+      simp only [id_eq]
+      omega
+
+/-- **Every practical number satisfies `2m − 1 ≤ σ(m)`.**  Since `2m − 1 < 2m` it is
+    representable (`practical_represents_lt_two_mul`), so the `σ(m)` ceiling
+    `representable_le_sigma` forces `2m − 1 ≤ (divisors m).sum id`.  This sharpens
+    `practical_pred_le_sigma` (`m − 1 ≤ σ(m)`) to the tight bound — practical numbers are
+    "almost perfect or abundant"; equality `σ(m) = 2m − 1` holds exactly for the powers of
+    two `m = 2ᵏ`. -/
+theorem practical_two_mul_pred_le_sigma {m : ℕ} (hm : 1 ≤ m) (hp : IsPractical m) :
+    2 * m - 1 ≤ (divisors m).sum id :=
+  representable_le_sigma (practical_represents_lt_two_mul hp (by omega))
+
 /-! ## Multiplicative closure under doubling
 
 If `m` is practical, so is `2m`.  This is the smallest case of the


### PR DESCRIPTION
## Summary

Two axiom-free additions to the practical-number representability theory in `Erdos18OQ01.lean`, advancing the structural theory toward the Stewart–Sierpiński multiplicative criterion.

### New lemmas

- **`practical_represents_lt_two_mul`** — `IsPractical m → k < 2*m → IsRepresentable k m`.
  The packaging lemma `practical_represents_le` guarantees representability only on the bottom block `[0, m]`. This **doubles** the guaranteed range to `[0, 2m)`, using *only divisors of `m`* (no divisors of `2m`): for `m ≤ k < 2m`, write `k = m + (k − m)` with `k − m < m`, represent the remainder by divisors of `m`, and adjoin the divisor `m` itself (fresh, since the remainder's set sums to `< m`). This is the `practical_two_mul` peel argument kept inside `divisors m` — the reusable primitive under both the doubling closure and the σ-bound below. **Tight**: for `m = 2^k` the block `[0, 2m)` is exactly `[0, σ(m)]` since `σ(2^k) = 2m − 1`.

- **`practical_two_mul_pred_le_sigma`** — `IsPractical m → 2m − 1 ≤ σ(m)`.
  Immediate corollary via `representable_le_sigma` at `k = 2m − 1`. This **sharpens** the existing `practical_pred_le_sigma` (`m − 1 ≤ σ(m)`) to the tight bound: practical numbers are "almost perfect or abundant", with equality `σ(m) = 2m − 1` exactly for the powers of two.

## Verification

- 2-file chain (`Erdos18Problem` → `Erdos18OQ01`) kernel-verified with host `lean v4.26.0` (no Docker).
- `#print axioms` on both → `[propext, Classical.choice, Quot.sound]`. No `sorry`, no `Lean.ofReduceBool`.

## Scope note

The general odd-prime Stewart–Sierpiński step (`IsPractical m → p ≤ σ(m)+1 → IsPractical(m·p)`) requires the full-range theorem *m practical ⟹ m represents all of `[0, σ(m)]`*, whose middle segment `[m, σ(m)−m]` needs a genuine greedy/inductive argument (only the abundancy-`≤2` case is currently available, via `practical_represents_all_of_sigma_le_two_mul`). This PR pushes the *unconditional* guaranteed range from `m` to `2m`, a strict step toward it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)