### PR TITLE
Enrich Half-Integer Gamma Ladder (oq-07-oq-03-oq-03): link parallel sibling + Gaussian base

### DIFF
--- a/src/data/proofs/area-of-circle-oq-07-oq-03-oq-03/meta.json
+++ b/src/data/proofs/area-of-circle-oq-07-oq-03-oq-03/meta.json
@@ -128,6 +128,16 @@
       "targetId": "area-of-circle",
       "relationship": "ancestor",
       "description": "Root of the OQ chain: the area πr² ultimately rests on the constant π, of which √π = Γ(1/2) (the n = 0 rung here) is the Gaussian avatar. This entry sits at the analytic end of that lineage, expressing the whole √π ladder Γ(n + 1/2) through Gaussian moments."
+    },
+    {
+      "targetId": "area-of-circle-oq-07-oq-03-oq-01",
+      "relationship": "related",
+      "description": "Parallel treatment of the same result: it also proves the half-integer ladder ∫_ℝ x^{2n} e^{-x²} dx = Γ(n + 1/2) = (2n-1)‼·√π/2ⁿ, identifying each rung with an even Gaussian moment. The two entries are sibling formalizations of the identical moment–Gamma identity reached by the same substitution-and-symmetry route, and are worth reading together."
+    },
+    {
+      "targetId": "area-of-circle-oq-07",
+      "relationship": "related",
+      "description": "The Gaussian √π base entry proving ∫_ℝ e^{-x²} dx = √π — exactly the n = 0 rung of the ladder here (gaussian_moment_zero). Every higher even moment computed in this entry sits above that single value, so this ladder is the moment tower over oq-07's base case."
     }
   ],
   "references": [


### PR DESCRIPTION
Enrichment pass for `area-of-circle-oq-07-oq-03-oq-03` (∫ x^{2n}e^{-x²} = Γ(n+1/2)).

**Gap addressed:** crossReferences held only the parent and the root ancestor. Two directly-related existing entries were unlinked (crossReferences 2→4, cap 20):

- **area-of-circle-oq-07-oq-03-oq-01** `related` — a *parallel formalization proving the identical ladder identity* ∫_ℝ x^{2n} e^{-x²} = Γ(n+1/2) = (2n-1)‼·√π/2ⁿ. The two sibling entries cover the same result by the same substitution-and-symmetry route yet were mutually unlinked; readers of one should find the other. (Flagging for maintainers: these two may be near-duplicate formalizations worth consolidating — out of scope for this enrichment pass.)
- **area-of-circle-oq-07** `related` — the Gaussian √π base ∫_ℝ e^{-x²} = √π, exactly the n=0 rung recovered here by gaussian_moment_zero.

Both targets verified to exist; relationships checked against their content. meta.json within the 60 KB cap; JSON valid; size guardrail passes. No other fields touched.