### PR TITLE
research(erdos101-problem-oq-04): pin the low end of the k-point-line support

### DIFF
--- a/proofs/Proofs/Erdos101OQ04OQ01.lean
+++ b/proofs/Proofs/Erdos101OQ04OQ01.lean
@@ -137,4 +137,53 @@ theorem kPointLineCount_eq_zero_of_card_lt (P : PlanarPointSet) {k : ℕ}
   have hle := Finset.card_le_card hS
   omega
 
+/-- **Low-`k` vacuity.** A `k`-point line needs *two distinct anchors* to pin a
+direction, so it carries at least two points: `kPointLineCount P k = 0` whenever
+`k ≤ 1`. Any witnessing subset `S` supplies `a ≠ b` in `S`, forcing `2 ≤ |S| = k ≤ 1`.
+This is the low end of the support: together with `kPointLineCount_eq_zero_of_card_lt`
+(the high end, `|P| < k`) it confines the count to the band `2 ≤ k ≤ |P|`, outside of
+which it vanishes identically. -/
+theorem kPointLineCount_eq_zero_of_le_one (P : PlanarPointSet) {k : ℕ}
+    (hk : k ≤ 1) : kPointLineCount P k = 0 := by
+  rw [kPointLineCount, Finset.card_eq_zero, Finset.filter_eq_empty_iff]
+  intro S hS
+  simp only [Finset.mem_powerset] at hS
+  rintro ⟨hScard, a, b, ha, hb, hab, -⟩
+  have hsub : ({a, b} : Finset (ℝ × ℝ)) ⊆ S := by
+    intro x hx
+    simp only [Finset.mem_insert, Finset.mem_singleton] at hx
+    rcases hx with rfl | rfl
+    · exact ha
+    · exact hb
+  have hle := Finset.card_le_card hsub
+  rw [Finset.card_pair hab] at hle
+  omega
+
+/-- **Exact `k = 2` value: every pair is a line.** Two distinct points always lie on a
+(unique) common line, so *every* `2`-element subset is a `2`-point line and
+`kPointLineCount P 2 = C(|P|, 2)`. The witness for a pair `{a, b}` is the pair itself:
+`collinear a b a` (degenerate, `(b₁−a₁)·0 = 0·(b₂−a₂)`) and `collinear a b b`
+(`collinear_self_right`) hold trivially. This is the *equality* boundary of the generic
+upper bound `kPointLineCount_le_choose` (which is `≤ C(|P|, k)` for all `k`): at `k = 2`
+the collinearity constraint is vacuous, so the bound is attained. It sits at the bottom
+of the support band `[2, |P|]`, one step below the general-position `= 0` region `k ≥ 3`. -/
+theorem kPointLineCount_two (P : PlanarPointSet) :
+    kPointLineCount P 2 = P.points.card.choose 2 := by
+  rw [kPointLineCount, ← Finset.card_powersetCard 2 P.points]
+  congr 1
+  ext S
+  simp only [Finset.mem_filter, Finset.mem_powerset, Finset.mem_powersetCard]
+  constructor
+  · rintro ⟨hsub, hcard, -⟩
+    exact ⟨hsub, hcard⟩
+  · rintro ⟨hsub, hcard⟩
+    refine ⟨hsub, hcard, ?_⟩
+    obtain ⟨a, b, hab, rfl⟩ := Finset.card_eq_two.mp hcard
+    refine ⟨a, b, Finset.mem_insert_self _ _,
+      Finset.mem_insert_of_mem (Finset.mem_singleton_self _), hab, fun p hp => ?_⟩
+    simp only [Finset.mem_insert, Finset.mem_singleton] at hp
+    rcases hp with rfl | rfl
+    · unfold collinear; ring
+    · exact collinear_self_right a _
+
 end Erdos101OQ04OQ01


### PR DESCRIPTION
## Summary

`Erdos101OQ04OQ01.lean` (the `kPointLineCount` companion of Erdős #101 OQ-04) bounded the count from **above** — `≤ C(n,k)` (`kPointLineCount_le_choose`), `= 0` in general position for `k ≥ 3`, and `= 0` for `|P| < k` (`kPointLineCount_eq_zero_of_card_lt`) — but left the **low-k** end open. This PR closes it.

## New theorems (both axiom-free)

- **`kPointLineCount_eq_zero_of_le_one`** — `k ≤ 1 ⟹ kPointLineCount P k = 0`. A `k`-point line needs *two distinct anchors* to pin a direction, so any witnessing subset carries `≥ 2` points; `2 ≤ |S| = k ≤ 1` is impossible. Together with `kPointLineCount_eq_zero_of_card_lt` this confines the count to the band `2 ≤ k ≤ |P|`.
- **`kPointLineCount_two`** — exact value `kPointLineCount P 2 = C(|P|, 2)`. Every pair of distinct points is trivially a 2-point line (`collinear a b a` degenerate, `collinear a b b` = `collinear_self_right`), so the generic upper bound `kPointLineCount_le_choose` is *attained with equality* at `k = 2` — the bottom of the support band, one step below the general-position vanishing region `k ≥ 3`.

Now the full support profile is pinned: `0` for `k ≤ 1`, `C(n,2)` at `k = 2`, `0` for `k ≥ 3` (general position) / `k > n` (vacuity), `≤ C(n,k)` throughout.

## Verification

- File compiles cleanly via `bin/lake env lean` (exit 0).
- `#print axioms` on both new theorems: `[propext, Classical.choice, Quot.sound]` — no `sorryAx`, no `Lean.ofReduceBool`. The parent's single open obligation (`solymosi_stojakovic_lower_bound`) is untouched.
- Research-layer file (no gallery meta dir for `erdos-101-oq-04`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)