### PR TITLE
Enrich Banach Fixed Point Theorem (oq-01): link children answering its open questions

### DIFF
--- a/src/data/proofs/banach-fixed-point-oq-01/meta.json
+++ b/src/data/proofs/banach-fixed-point-oq-01/meta.json
@@ -98,6 +98,16 @@
       "targetId": "schauder-fixed-point",
       "relationship": "related",
       "description": "Schauder extends existence to compact convex sets in Banach spaces (no uniqueness); Banach's contraction principle trades that generality for uniqueness and an explicit convergence rate."
+    },
+    {
+      "targetId": "banach-fixed-point-oq-01-oq-01",
+      "relationship": "extended by",
+      "description": "Direct child answering this entry's first open question: Picard–Lindelöf (Cauchy–Lipschitz) local existence and uniqueness for the initial value problem, obtained by recasting y' = f(y), y(t₀)=x₀ as a fixed point of the Picard integral operator and applying exactly the contraction machinery packaged here."
+    },
+    {
+      "targetId": "banach-fixed-point-oq-01-oq-02",
+      "relationship": "extended by",
+      "description": "Direct child answering this entry's second open question: on a complete normed group, a k-Lipschitz perturbation of the identity f x = x + g x (k < 1) is a homeomorphism with two-sided Lipschitz control — the perturbation-of-identity result that is a step toward the inverse function theorem, built on the contraction principle stated here."
     }
   ],
   "leanFile": {


### PR DESCRIPTION
Enrichment pass for `banach-fixed-point-oq-01` (quantitative contraction mapping principle).

**Gap addressed:** crossReferences held only the two comparison entries (Brouwer, Schauder). The entry's two stated open questions are each *already answered* by a direct child, neither of which was linked. Added both (crossReferences 2→4, cap 20):

- **banach-fixed-point-oq-01-oq-01** `extended by` — Picard–Lindelöf local existence/uniqueness via the contraction principle (recasts y'=f(y) as a Picard-operator fixed point). Answers open question 1.
- **banach-fixed-point-oq-01-oq-02** `extended by` — a k-Lipschitz perturbation of the identity (id + g, k<1) is a homeomorphism with two-sided Lipschitz control, a step toward the inverse function theorem. Answers open question 2.

Both verified to exist; relationships checked against their descriptions. meta.json within 60 KB cap; JSON valid; size guardrail passes. No other fields touched.