### PR TITLE
research(lagrange-four-squares-oq-01-oq-03): even-side Jacobi doubling law + 2-power constancy

### DIFF
--- a/proofs/Proofs/LagrangeFourSquaresOQ01OQ03Closed.lean
+++ b/proofs/Proofs/LagrangeFourSquaresOQ01OQ03Closed.lean
@@ -109,6 +109,32 @@ theorem jacobiCount_even_ordCompl {n : ℕ} (hn : n ≠ 0) (h2 : 2 ∣ n) :
   have key := jacobiCount_two_pow_mul_odd ha hodd
   rwa [Nat.ordProj_mul_ordCompl_eq_self n 2] at key
 
+/-- **Even-side doubling law: doubling an even number leaves the Jacobi count unchanged.**
+For every even `n ≠ 0`, `jacobiCount (2·n) = jacobiCount n`.  This is the even-`n`
+companion of `jacobiCount_two_mul` (odd `n` ⟹ the count *triples*): once the `2`-adic
+valuation is `≥ 1`, the count is `24·σ(oddPart n)`, which is unchanged by another factor of
+`2` (`oddPart (2n) = oddPart n`).  So along the chain `m, 2m, 4m, 8m, …` (`m` odd) the count
+jumps once — `8σ(m) → 24σ(m)` at the first doubling — and is then constant.  Proof:
+`jacobiCount_even_ordCompl` on both sides, with `ordCompl[2] (2n) = ordCompl[2] n` from
+`Nat.ordCompl_mul` and `ordCompl[2] 2 = 1`. -/
+theorem jacobiCount_two_mul_of_even {n : ℕ} (hn : n ≠ 0) (h2 : 2 ∣ n) :
+    jacobiCount (2 * n) = jacobiCount n := by
+  have h2n : 2 * n ≠ 0 := Nat.mul_ne_zero (by norm_num) hn
+  have h2dvd : 2 ∣ 2 * n := Dvd.intro n rfl
+  have h22 : ordCompl[2] 2 = 1 := by
+    rw [Nat.Prime.factorization_self Nat.prime_two, pow_one, Nat.div_self (by norm_num)]
+  have hoc : ordCompl[2] (2 * n) = ordCompl[2] n := by
+    rw [Nat.ordCompl_mul, h22, one_mul]
+  rw [jacobiCount_even_ordCompl h2n h2dvd, jacobiCount_even_ordCompl hn h2, hoc]
+
+/-- **The even closed form is independent of the power of two (`a ≥ 1`).** For odd `m` and
+any `a, b ≥ 1`, `jacobiCount (2^a · m) = jacobiCount (2^b · m)` — both equal `24·σ(m)`.
+This generalizes `jacobiCount_two_pow_const` (the `m = 1` case) from the pure powers of two
+to an arbitrary odd part: the Jacobi count sees only whether `v₂ ≥ 1`, not its exact value. -/
+theorem jacobiCount_two_pow_mul_odd_const {a b m : ℕ} (ha : 1 ≤ a) (hb : 1 ≤ b)
+    (hm : Odd m) : jacobiCount (2 ^ a * m) = jacobiCount (2 ^ b * m) := by
+  rw [jacobiCount_two_pow_mul_odd ha hm, jacobiCount_two_pow_mul_odd hb hm]
+
 /-! ## Multiplicativity of the Jacobi RHS as an arithmetic function
 
 Jacobi's four-square count is *not* multiplicative on the nose (there is a fixed


### PR DESCRIPTION
## Summary

Completes the doubling behaviour of the Jacobi four-square RHS `jacobiCount` in `LagrangeFourSquaresOQ01OQ03Closed.lean`. The odd side was already established (`jacobiCount_two_mul`: `n` odd ⟹ `jacobiCount(2n) = 3·jacobiCount n`); the even side was missing.

### New lemmas (both axiom-free)

- **`jacobiCount_two_mul_of_even`** — `n ≠ 0 → 2 ∣ n → jacobiCount(2n) = jacobiCount n`.
  Once `v₂(n) ≥ 1`, the count is `24·σ(oddPart n)`, unchanged by another factor of 2 (`oddPart(2n) = oddPart n`). Proof: `jacobiCount_even_ordCompl` on both sides, with `ordCompl[2](2n) = ordCompl[2] n` from `Nat.ordCompl_mul` and `ordCompl[2] 2 = 1`. So along `m, 2m, 4m, 8m, …` (`m` odd) the count jumps exactly once (`8σ(m) → 24σ(m)` at the first doubling) and is then constant — the even-`n` companion of the odd-side tripling.
- **`jacobiCount_two_pow_mul_odd_const`** — `a,b ≥ 1`, `m` odd ⟹ `jacobiCount(2^a·m) = jacobiCount(2^b·m)`. Generalizes `jacobiCount_two_pow_const` (the `m = 1` case) to an arbitrary odd part: the count sees only whether `v₂ ≥ 1`, not its exact value.

## Verification

- 2-file chain (`…OQ01OQ03Even` → `…OQ01OQ03Closed`) kernel-verified with host `lean v4.26.0` (no Docker).
- `#print axioms` on both → `[propext, Classical.choice, Quot.sound]`. No `sorry`, no `native_decide`, no `Lean.ofReduceBool`.

The general `r₄ = jacobiCount` identity remains Mathlib-blocked (needs Hurwitz-quaternion orders / weight-2 modular forms); this extends the elementary, axiom-free arithmetic of the RHS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)