### PR TITLE
Enrich area-of-circle-oq-07: fix mathlibDependencies accuracy

### DIFF
--- a/src/data/proofs/area-of-circle-oq-07/meta.json
+++ b/src/data/proofs/area-of-circle-oq-07/meta.json
@@ -94,7 +94,12 @@
       {
         "theorem": "Real.sq_sqrt",
         "description": "0 ≤ a → √a ^ 2 = a — used to square √π back to π in gaussian_integral_sq.",
-        "module": "Mathlib.Analysis.SpecialFunctions.Sqrt"
+        "module": "Mathlib.Data.Real.Sqrt"
+      },
+      {
+        "theorem": "Real.pi_nonneg",
+        "description": "0 ≤ π — the side condition supplied to Real.sq_sqrt so that (√π)² = π; π ≥ 0 is exactly the hypothesis Real.sq_sqrt requires.",
+        "module": "Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic"
       }
     ]
   },


### PR DESCRIPTION
Enrichment pass for `area-of-circle-oq-07` (The Gaussian Integral Equals √π).

This entry is already saturated (quality 96, all annotation/keyInsight/section targets met, 11.8 KB — well under the 60 KB cap), so this is a **targeted accuracy pass** rather than deepening:

- **Fixed `Real.sq_sqrt` module path**: was listed under `Mathlib.Analysis.SpecialFunctions.Sqrt` (a module that does not exist). Verified against Mathlib source that `sq_sqrt (h : 0 ≤ x) : √x ^ 2 = x` lives in `Mathlib.Data.Real.Sqrt` (`namespace Real`).
- **Added missing `Real.pi_nonneg` dependency**: `gaussian_integral_sq` calls `Real.sq_sqrt Real.pi_nonneg`, so `0 ≤ π` is a genuine dependency; it was referenced in the annotations but absent from `mathlibDependencies`. Module `Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic`.

JSON validated, size caps checked, gallery build (search index / enrichment steps) passes. No content deleted.