### PR TITLE
Enrich ζ(6)=π⁶/945 (basel-problem-oq-12): link even/odd zeta arithmetic siblings

### DIFF
--- a/src/data/proofs/basel-problem-oq-12/meta.json
+++ b/src/data/proofs/basel-problem-oq-12/meta.json
@@ -122,6 +122,16 @@
       "targetId": "basel-problem-oq-15",
       "relationship": "extendedBy",
       "description": "ζ(8) = π⁸/9450, the k = 4 case — the next even zeta value in Euler's family after this ζ(6), built from the same hasSum_zeta_nat template with B₈ = −1/30. It realises this entry's first open question (\"Can ζ(8) = π⁸/9450 be obtained the same way?\"), the B₈ recurrence consuming this entry's B₆ = 1/42 as a summand."
+    },
+    {
+      "targetId": "basel-problem-oq-01-oq-02",
+      "relationship": "related",
+      "description": "The arithmetic-nature companion to this explicit evaluation: it proves every even zeta value ζ(2n) is irrational (indeed transcendental, being a rational multiple of π^{2n} as ζ(6) = π⁶/945 witnesses here) and records that the odd case ζ(2n+1) remains open — the transcendence remark this entry's historical context raises, stated as a general theorem."
+    },
+    {
+      "targetId": "basel-problem-oq-01-oq-01-oq-02",
+      "relationship": "related",
+      "description": "The odd-zeta counterpoint referenced in this entry's historical context: Apéry's 1978 proof that ζ(3) is irrational — the sole odd zeta value whose arithmetic nature is settled, in stark contrast to the fully-understood even values like this ζ(6) = π⁶/945."
     }
   ],
   "sorries": 0,


### PR DESCRIPTION
Enrichment pass for `basel-problem-oq-12` (ζ(6) = π⁶/945).

**Gap addressed:** crossReferences covered the neighboring *values* (ζ(2), ζ(4), ζ(8)) but not the *arithmetic-nature* siblings that this entry's own narrative invokes (even zeta values are transcendental; only ζ(3) is known irrational, by Apéry). Added both (crossReferences 3→5, cap 20):

- **basel-problem-oq-01-oq-02** `related` — 'Every Even Zeta Value ζ(2n) is Irrational', the general arithmetic companion to this explicit π⁶/945 evaluation.
- **basel-problem-oq-01-oq-01-oq-02** `related` — Apéry's proof of ζ(3) irrationality, the odd-zeta counterpoint named in this entry's historical context.

Both verified to exist; relationships checked against their titles. meta.json within 60 KB cap; JSON valid; size guardrail passes. No other fields touched.