### PR TITLE
research(law-of-cosines-oq-03-oq-03): complete the cyclic isosceles-criterion trio (c=a leg)

### DIFF
--- a/proofs/Proofs/LawOfCosinesOQ03OQ03.lean
+++ b/proofs/Proofs/LawOfCosinesOQ03OQ03.lean
@@ -1014,6 +1014,15 @@ def HyperbolicTriangle.rotate (t : HyperbolicTriangle) : HyperbolicTriangle wher
 theorem side_eq_iff_angle_eq_bc (t : HyperbolicTriangle) : t.b = t.c ↔ t.B = t.C :=
   side_eq_iff_angle_eq t.rotate
 
+/-- **Isosceles criterion for the `(c,a)/(C,A)` pair.** `c = a ↔ C = A`, the third leg of
+    the cyclic isosceles trio completing `side_eq_iff_angle_eq` (`a = b ↔ A = B`) and
+    `side_eq_iff_angle_eq_bc` (`b = c ↔ B = C`), obtained by applying the `(b,c)` criterion
+    to `rotate` (which cycles `(a,b,c) → (b,c,a)`, sending the `(b,c)` pair to `(c,a)`). With
+    its two companions this gives the isosceles criterion for every pair of a hyperbolic
+    triangle. -/
+theorem side_eq_iff_angle_eq_ca (t : HyperbolicTriangle) : t.c = t.a ↔ t.C = t.A :=
+  side_eq_iff_angle_eq_bc t.rotate
+
 /-- **Equilateral ⟺ equiangular.** A hyperbolic triangle has all three sides equal iff it
     has all three angles equal. The `⟸` direction is `equilateral_sides_eq` (equal angles
     force equal sides); the `⟹` direction combines the two isosceles criteria


### PR DESCRIPTION
## Summary

Completes the cyclic isosceles criterion for hyperbolic triangles in `LawOfCosinesOQ03OQ03.lean`. The equivalence "equal sides ⟺ equal opposite angles" was established for the `(a,b)` pair (`side_eq_iff_angle_eq`) and the `(b,c)` pair (`side_eq_iff_angle_eq_bc`), but the third leg was missing.

### New lemma

- **`side_eq_iff_angle_eq_ca`** — `t.c = t.a ↔ t.C = t.A`.

Obtained by applying the `(b,c)` criterion to the cyclic relabeling `rotate` (which cycles `(a,b,c) → (b,c,a)`, sending the `(b,c)` pair to `(c,a)`). With its two companions this gives the isosceles criterion for **every** pair of a hyperbolic triangle — mirroring the already-complete order trio `side_lt_iff_angle_lt` / `side_eq_iff_angle_eq` / `side_le_iff_angle_le`.

## Verification

- File rebuilt clean with host `lean v4.26.0` (self-contained, Mathlib-only, no Docker).
- `#print axioms` → `[propext, Classical.choice, Quot.sound]` (the `HyperbolicTriangle` structure assumptions are hypotheses of the input, unchanged). No `sorry`.

Entry status (`axiomatized` / 6 structure assumptions) is unchanged. The genuine open frontier — the *first* law of cosines `cosh c = cosh a cosh b − sinh a sinh b cos C` and SAS/ASA congruence — remains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)