### PR TITLE
research(erdos-1110-oq-01): divisor set = exponent grid, τ(p^k q^l)=(k+1)(l+1)

### DIFF
--- a/proofs/Proofs/Erdos1110OQ01.lean
+++ b/proofs/Proofs/Erdos1110OQ01.lean
@@ -383,4 +383,59 @@ theorem powerForm_coprime_iff' {p q : ℕ} (hp : p.Prime) (hq : q.Prime) (hpq : 
       ↔ ((k = 0 ∨ k' = 0) ∧ (l = 0 ∨ l' = 0)) := by
   rw [powerForm_coprime_iff hp hq hpq, Nat.min_eq_zero_iff, Nat.min_eq_zero_iff]
 
+/-! ### The divisor set of a power form: a finite exponent grid
+
+The divisibility order on power forms is the product order on exponent pairs
+(`powerForm_dvd_iff`), and every divisor of a power form is again a power form
+(`isPowerForm_of_dvd`). Together these pin the *divisor set* of `p^k q^l` exactly: for
+distinct primes `p ≠ q` the divisors are precisely the `(k+1)(l+1)` power forms
+`p^a q^b` with `a ≤ k`, `b ≤ l` — the integer grid `[0,k] × [0,l]` under the exponent
+map. The lemmas below record the two halves of this picture: the divisor set as the
+image of that grid, and its cardinality `(k+1)(l+1)` (the classical divisor-count
+formula `τ(p^k q^l) = (k+1)(l+1)`, here as a consequence of the sublattice structure). -/
+
+/-- **Every divisor of a power form is a power form.** The `Finset` form of
+`isPowerForm_of_dvd`: if `n = p^k q^l` and `d ∈ n.divisors` then `d` is a power form. -/
+theorem isPowerForm_of_mem_divisors {p q n d : ℕ} (hp : p.Prime) (hq : q.Prime)
+    (hn : IsPowerForm p q n) (hd : d ∈ n.divisors) : IsPowerForm p q d :=
+  isPowerForm_of_dvd hp hq hn (Nat.dvd_of_mem_divisors hd)
+
+/-- **The divisor set of a power form is the exponent grid.** For distinct primes `p ≠ q`,
+the divisors of `p^k q^l` are exactly the power forms `p^a q^b` with `a ≤ k`, `b ≤ l`:
+
+    (p^k q^l).divisors = (range (k+1) ×ˢ range (l+1)).image (fun (a,b) ↦ p^a q^b).
+
+Forward: any divisor is a power form (`isPowerForm_of_dvd`) whose exponents are `≤ (k,l)`
+(`powerForm_dvd_iff`); backward: any such `p^a q^b` divides `p^k q^l`. This realizes the
+divisor lattice of a power form as the concrete integer grid `[0,k] × [0,l]`. -/
+theorem powerForm_divisors_eq_grid {p q : ℕ} (hp : p.Prime) (hq : q.Prime) (hpq : p ≠ q)
+    (k l : ℕ) :
+    (p ^ k * q ^ l).divisors =
+      (Finset.range (k + 1) ×ˢ Finset.range (l + 1)).image (fun ab => p ^ ab.1 * q ^ ab.2) := by
+  ext d
+  rw [Nat.mem_divisors, Finset.mem_image]
+  constructor
+  · rintro ⟨hd, _⟩
+    obtain ⟨a, b, rfl⟩ := isPowerForm_of_dvd hp hq ⟨k, l, rfl⟩ hd
+    obtain ⟨ha, hb⟩ := (powerForm_dvd_iff hp hq hpq a b k l).mp hd
+    refine ⟨(a, b), ?_, rfl⟩
+    rw [Finset.mem_product, Finset.mem_range, Finset.mem_range]
+    exact ⟨Nat.lt_succ_of_le ha, Nat.lt_succ_of_le hb⟩
+  · rintro ⟨⟨a, b⟩, hab, rfl⟩
+    rw [Finset.mem_product, Finset.mem_range, Finset.mem_range,
+        Nat.lt_succ_iff, Nat.lt_succ_iff] at hab
+    refine ⟨(powerForm_dvd_iff hp hq hpq a b k l).mpr ⟨hab.1, hab.2⟩, ?_⟩
+    exact mul_ne_zero (pow_ne_zero k hp.pos.ne') (pow_ne_zero l hq.pos.ne')
+
+/-- **Divisor-count formula `τ(p^k q^l) = (k+1)(l+1)`.** For distinct primes `p ≠ q`, the
+number of divisors of the power form `p^k q^l` is `(k+1)(l+1)`. Since `p^k` and `q^l` are
+coprime the divisor count is multiplicative (`Nat.Coprime.card_divisors_mul`), and each prime
+power `p^k` has exactly `k+1` divisors (`Nat.divisors_prime_pow`). This counts the exponent
+grid `[0,k] × [0,l]` of `powerForm_divisors_eq_grid`. -/
+theorem powerForm_card_divisors {p q : ℕ} (hp : p.Prime) (hq : q.Prime) (hpq : p ≠ q)
+    (k l : ℕ) : (p ^ k * q ^ l).divisors.card = (k + 1) * (l + 1) := by
+  have hcop : Nat.Coprime (p ^ k) (q ^ l) := Nat.coprime_pow_primes k l hp hq hpq
+  rw [Nat.Coprime.card_divisors_mul hcop, Nat.divisors_prime_pow hp, Nat.divisors_prime_pow hq,
+      Finset.card_map, Finset.card_map, Finset.card_range, Finset.card_range]
+
 end Erdos1110

--- a/research/problems/erdos-1110-oq-01/knowledge.md
+++ b/research/problems/erdos-1110-oq-01/knowledge.md
@@ -143,3 +143,43 @@ refresh if the repo Mathlib pin was bumped — worth a mechanic/auditor look.
 `git worktree add .loom/worktrees/researcher-3 <branch>`; the fresh worktree LACKS the
 `proofs/.lake` symlink (gitignored) → had to `ln -s <main>/proofs/.lake proofs/.lake` before
 lean-elab. Committed+pushed the .lean edit BEFORE re-verifying (worktree-eater insurance).
+
+## Session 2026-07-11 (researcher-6) — divisor set = exponent grid, τ = (k+1)(l+1) [VERIFIED]
+
+**Mode**: extend the mature lattice-structure file (submonoid → closure → divisibility
+order → gcd/lcm meet/join → coprimality). **Outcome**: progress, 3 new axiom-free theorems
+(**VERIFIED green, `#print axioms` = [propext, Classical.choice, Quot.sound] only**;
+23→26 thm, 386→441 L). Baseline re-verified green — the earlier "Finsupp pin-drift" verify
+block was STALE (origin/main OQ01 elaborates cleanly under the current Mathlib pin).
+
+### What I did
+The file had made divisibility of power forms the product order on exponents and shown all
+divisors are power forms (`isPowerForm_of_dvd`), but never pinned the **divisor set / count**.
+Closed that — the finite-grid capstone of the sublattice picture:
+- `isPowerForm_of_mem_divisors` — Finset form of `isPowerForm_of_dvd` (`d ∈ n.divisors →
+  IsPowerForm p q d`), via `Nat.dvd_of_mem_divisors`.
+- `powerForm_divisors_eq_grid` — for distinct primes `p≠q`, `(p^k q^l).divisors =
+  (range(k+1) ×ˢ range(l+1)).image (a,b ↦ p^a q^b)`: the divisor set is exactly the integer
+  grid `[0,k]×[0,l]` under the exponent map. Forward: `isPowerForm_of_dvd` + `powerForm_dvd_iff`
+  read exponents `≤(k,l)`; backward: `powerForm_dvd_iff.mpr` + `mul_ne_zero pow_ne_zero`.
+- `powerForm_card_divisors` — classical `τ(p^k q^l) = (k+1)(l+1)`, via
+  `Nat.Coprime.card_divisors_mul` (mult. of τ on coprimes) + `Nat.divisors_prime_pow`
+  (`#(p^k).divisors = k+1` after `card_map`/`card_range`). Coprimality of `p^k`,`q^l` is
+  the one-liner `Nat.coprime_pow_primes k l hp hq hpq`.
+
+### Lean notes
+- `Nat.coprime_pow_primes (n m) (pp pq) (h : p≠q) : Coprime (p^n) (q^m)` — direct, no manual `.pow`.
+- `Nat.Coprime.card_divisors_mul` lives in `NumberTheory/ArithmeticFunction/Misc.lean` (namespace
+  `Nat.Coprime`); `Nat.divisors_prime_pow` gives divisors as `(range(k+1)).map ⟨(p^·),…⟩`.
+- grid membership: `Finset.mem_product` + `Finset.mem_range` + `Nat.lt_succ_iff`/`Nat.lt_succ_of_le`.
+- ★GOTCHA: worktree is `.loom/worktrees/researcher-6-2`; `cd .../lean-genius/proofs` compiles the
+  MAIN-repo copy (unmodified) → a false "green". Compile the file IN the worktree proofs dir
+  (its `.lake` is symlinked to main). Always `grep -c <newname>` the file you're actually elaborating.
+
+### Files
+- `proofs/Proofs/Erdos1110OQ01.lean` (+3 thm; 26 thm / 1 def / 0 sorry / 0 axiom)
+- `src/data/research/problems/erdos-1110-oq-01.json` (resynced OQ01 leanFiles 288/19 → 441/26)
+
+### Still open (parent, untouched)
+Deep `erdos_lewin_infinite` axiom (coprime `{p,q}≠{2,3}` non-representable density / infinitude).
+Not session-sized.

--- a/src/data/research/problems/erdos-1110-oq-01.json
+++ b/src/data/research/problems/erdos-1110-oq-01.json
@@ -111,15 +111,15 @@
     "mathlib": []
   },
   "started": "2026-05-29T19:14:09.134Z",
-  "lastUpdate": "2026-06-30T00:00:00.000Z",
+  "lastUpdate": "2026-07-11T00:00:00.000Z",
   "significance": 6,
   "tractability": 5,
   "leanFiles": [
     {
       "path": "Proofs/Erdos1110OQ01.lean",
       "filename": "Erdos1110OQ01.lean",
-      "lineCount": 288,
-      "theoremCount": 19,
+      "lineCount": 441,
+      "theoremCount": 26,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,


### PR DESCRIPTION
## Summary

Extends `Erdos1110OQ01.lean` (the power-form lattice-structure companion to Erdős #1110) with the **finite-grid capstone** of its sublattice picture. The file already established that, for distinct primes `p ≠ q`, divisibility of power forms `p^k q^l` is the product order on exponent pairs (`powerForm_dvd_iff`) and that every divisor of a power form is again a power form (`isPowerForm_of_dvd`). These lemmas pin the **divisor set and count** exactly.

## New theorems (3, axiom-free, 0 sorry)

- `isPowerForm_of_mem_divisors` — the `Finset` form of `isPowerForm_of_dvd`: `d ∈ n.divisors → IsPowerForm p q d`.
- `powerForm_divisors_eq_grid` — `(p^k q^l).divisors = (range (k+1) ×ˢ range (l+1)).image (fun (a,b) ↦ p^a q^b)`: the divisor set is exactly the integer grid `[0,k] × [0,l]` under the exponent map.
- `powerForm_card_divisors` — the classical divisor-count formula `τ(p^k q^l) = (k+1)(l+1)`, via `Nat.Coprime.card_divisors_mul` (multiplicativity of τ on coprimes) and `Nat.divisors_prime_pow`.

## Verification

- Compiled green under the repo Mathlib pin (`lean v4.26.0`).
- `#print axioms` on all three: `[propext, Classical.choice, Quot.sound]` only — axiom-free, no `native_decide`, no `sorry`.
- File: 23 → 26 theorems, 386 → 441 lines, still 0 axioms / 0 sorries.

The deep `erdos_lewin_infinite` axiom in the parent (`Erdos1110Problem.lean`, coprime `{p,q} ≠ {2,3}` non-representable density) is untouched — not session-sized.

🤖 Generated with [Claude Code](https://claude.com/claude-code)