### PR TITLE
Enrich Brouwer Fixed Point Theorem (root): link the 1D elementary axiom-free child

### DIFF
--- a/src/data/proofs/brouwer-fixed-point/meta.json
+++ b/src/data/proofs/brouwer-fixed-point/meta.json
@@ -284,6 +284,11 @@
       "description": "Both guarantee existence of special points for continuous functions. The 1D Brouwer theorem follows from IVT (which also implies MVT): for $f:[a,b] \\to [a,b]$ continuous, $g(x) = f(x) - x$ satisfies $g(a) \\geq 0 \\geq g(b)$, so IVT gives $g(c) = 0$, i.e., $f(c) = c$"
     },
     {
+      "targetId": "brouwer-fixed-point-oq-01",
+      "relationship": "extended-by",
+      "description": "The elementary 1D case: proves Brouwer on $[a,b]$ using only the Intermediate Value Theorem — no algebraic topology and, unlike this axiomatized $n$-dimensional entry, entirely axiom-free. It shows 1D Brouwer is equivalent to IVT and derives the 1D No-Retraction theorem and 1D Borsuk–Ulam, giving a from-scratch base case for the general theorem stated here via the No-Retraction axiom."
+    },
+    {
       "targetId": "brouwer-fixed-point-oq-02",
       "relationship": "extended-by",
       "description": "Explores the computational complexity of finding approximate fixed points (PPAD-completeness) — the constructive dimension of Brouwer's inherently non-constructive existence result, with implications for Nash equilibrium computation"


### PR DESCRIPTION
Enrichment pass for `brouwer-fixed-point` (the root Brouwer entry, axiomatized on the No-Retraction theorem).

**Gap addressed:** the root cross-references its children oq-02 (PPAD-completeness) and oq-04 (Kakutani) but omits **oq-01**, its primary child. Added it (crossReferences 8→9, cap 20):

- **brouwer-fixed-point-oq-01** `extended-by` — the elementary 1D proof via the Intermediate Value Theorem, which (unlike this axiomatized n-dimensional entry) is entirely axiom-free, and also derives 1D No-Retraction and 1D Borsuk–Ulam. It gives readers the from-scratch base case for the theorem stated here.

(Verified Sperner's lemma and Kakutani, named in this entry's open questions, have no standalone gallery entry — Kakutani is covered by the already-linked oq-04 — so no phantom links were added.) meta.json unchanged in structure and within the 60 KB cap; JSON valid; size guardrail passes. No other fields touched.