### PR TITLE
research(erdos-659-oq-06): equilateral triangle + centroid — a second non-similar {1,3} two-distance set

### DIFF
--- a/proofs/Proofs/Erdos659OQ06.lean
+++ b/proofs/Proofs/Erdos659OQ06.lean
@@ -196,4 +196,52 @@ theorem two_distance_examples :
       ¬ IsTwoDistance4 t0 t1 t2 t3 :=
   ⟨unitSquare_isTwoDistance, rhombus60_isTwoDistance, rectangle_not_isTwoDistance⟩
 
+/-! ### Equilateral triangle plus centroid — a second, non-similar `{1,3}` realization
+
+An equilateral triangle together with its centroid is another concrete two-distance
+four-point set: the three centre-to-vertex distances are all equal and each is shorter
+than the (equal) triangle sides.  Placing the centroid at the origin and the three
+vertices on the unit circle (`e1, e2, e3` at radius `1`, `120°` apart) gives centre-to-
+vertex squared distance `1` and side squared distance `3`, so the spectrum is again
+`{1, 3}` — *numerically the same* as the 60° rhombus.  Yet the two configurations are
+**not similar**: here the squared-distance multiset is three `1`s and three `3`s (the
+centroid is equidistant from all three vertices), whereas the rhombus has five `1`s and a
+single `3`.  So the spectrum alone does not determine the configuration, and the
+`√3` in the coordinates again cancels to leave a rational spectrum. -/
+
+noncomputable def e0 : ℝ × ℝ := (0, 0)
+noncomputable def e1 : ℝ × ℝ := (1, 0)
+noncomputable def e2 : ℝ × ℝ := (-1 / 2, Real.sqrt 3 / 2)
+noncomputable def e3 : ℝ × ℝ := (-1 / 2, -Real.sqrt 3 / 2)
+
+/-- The equilateral-triangle-plus-centroid squared-distance spectrum is exactly `{1, 3}`:
+the three centre-to-vertex distances squared are `1`, the three triangle sides squared
+are `3`. -/
+theorem triangleCenter_spectrum : sqDistSet4 e0 e1 e2 e3 = {1, 3} := by
+  have hs : Real.sqrt 3 ^ 2 = 3 := Real.sq_sqrt (by norm_num)
+  have h01 : sqDist e0 e1 = 1 := by simp only [sqDist, e0, e1]; norm_num
+  have h02 : sqDist e0 e2 = 1 := by
+    simp only [sqDist, e0, e2]; linear_combination (1 / 4 : ℝ) * hs
+  have h03 : sqDist e0 e3 = 1 := by
+    simp only [sqDist, e0, e3]; linear_combination (1 / 4 : ℝ) * hs
+  have h12 : sqDist e1 e2 = 3 := by
+    simp only [sqDist, e1, e2]; linear_combination (1 / 4 : ℝ) * hs
+  have h13 : sqDist e1 e3 = 3 := by
+    simp only [sqDist, e1, e3]; linear_combination (1 / 4 : ℝ) * hs
+  have h23 : sqDist e2 e3 = 3 := by
+    simp only [sqDist, e2, e3]; linear_combination hs
+  unfold sqDistSet4
+  rw [h01, h02, h03, h12, h13, h23]
+  ext x
+  simp only [Finset.mem_insert, Finset.mem_singleton]
+  tauto
+
+/-- The equilateral triangle plus its centroid is a two-distance set — a concrete
+realization sharing the rhombus's `{1, 3}` spectrum but with a distinct distance
+multiset (hence a non-similar configuration). -/
+theorem triangleCenter_isTwoDistance : IsTwoDistance4 e0 e1 e2 e3 := by
+  unfold IsTwoDistance4
+  rw [triangleCenter_spectrum, Finset.card_insert_of_notMem (by norm_num),
+    Finset.card_singleton]
+
 end Erdos659TwoDistance

--- a/src/data/proofs/erdos-659-oq-06/meta.json
+++ b/src/data/proofs/erdos-659-oq-06/meta.json
@@ -33,9 +33,9 @@
       "rectangle_spectrum / rectangle_not_isTwoDistance: a non-square 1×2 rectangle has spectrum {1,4,5} (three distances), so the predicate genuinely discriminates",
       "two_distance_examples: packaged summary — square and rhombus are two-distance sets, rectangle is not"
     ],
-    "lineCount": 199,
-    "theoremCount": 10,
-    "definitionCount": 15
+    "lineCount": 247,
+    "theoremCount": 12,
+    "definitionCount": 19
   },
   "overview": {
     "historicalContext": "A two-distance set is a set of points realizing only two distinct pairwise distances; the study of such sets goes back to work of Kelly, and Einhorn–Schoenberg (1966) classified all planar two-distance sets, finding that the maximum size in the plane is 5 (the regular pentagon) and enumerating the four-point cases. Erdős problem #659 (Moree–Osburn, 2006) is a refinement of Erdős's distinct-distances problem in which every four-point subset is forced to determine at least three distances — i.e. no four points may form a two-distance set — while the whole configuration still realizes only O(n/√log n) distinct distances. Understanding which four-point configurations ARE two-distance sets is therefore exactly the local obstruction the construction must avoid. Up to similarity there are six four-point two-distance sets: the square, the 60° rhombus (two glued equilateral triangles), two isosceles trapezoids, a kite, and four vertices of a regular pentagon.",


### PR DESCRIPTION
## Summary

Adds a genuinely distinct concrete realization to the two-distance-4-point companion of Erdős #659. The file already realizes the **unit square** (`{1,2}`) and the **60° rhombus** (`{1,3}`), plus a rectangle counterexample. This PR adds the classic **equilateral triangle + centroid** configuration.

## New theorems (both axiom-free)

- **`triangleCenter_spectrum`** — the equilateral triangle together with its centroid (centroid at the origin, vertices `e1, e2, e3` on the unit circle 120° apart) has squared-distance spectrum exactly `{1, 3}`: three centre-to-vertex distances squared `1`, three triangle sides squared `3`. The `√3` in the coordinates cancels (same `linear_combination Real.sq_sqrt` technique as `rhombus60_spectrum`).
- **`triangleCenter_isTwoDistance`** — it is a two-distance set.

## Why this is new, not a duplicate

Its spectrum `{1,3}` is numerically identical to the 60° rhombus, **yet the two configurations are not similar**: here the squared-distance *multiset* is three `1`s and three `3`s (the centroid is equidistant from all three vertices), whereas the rhombus has five `1`s and a single `3`. So the spectrum alone does not determine the configuration — the file now witnesses two non-similar realizations of `{1,3}`.

## Verification

- `#print axioms` on both: `[propext, Classical.choice, Quot.sound]` only.
- Compiled against Mathlib v4.26.0 (mathlib-only dependency).
- 0 sorries, 0 axioms. `meta.json`: 10 → 12 theorems, 199 → 247 lines, definitionCount 15 → 19.

🤖 Generated with [Claude Code](https://claude.com/claude-code)