### PR TITLE
Enrich area-of-circle-oq-03-oq-03-oq-01: fix mathlibDependency module path

### DIFF
--- a/src/data/proofs/area-of-circle-oq-03-oq-03-oq-01/meta.json
+++ b/src/data/proofs/area-of-circle-oq-03-oq-03-oq-01/meta.json
@@ -46,7 +46,7 @@
       {
         "theorem": "MeasureTheory.integral_Icc_eq_integral_Ioc",
         "description": "∫ over Icc equals ∫ over Ioc (endpoints are null) — bridges the set integral of volume_regionBetween to the interval integral",
-        "module": "Mathlib.MeasureTheory.Integral.SetIntegral"
+        "module": "Mathlib.MeasureTheory.Integral.Bochner.Set"
       }
     ],
     "originalContributions": [


### PR DESCRIPTION
Enrichment/accuracy pass for `area-of-circle-oq-03-oq-03-oq-01` (rigorous ellipse-area via change of variables).

The entry is already saturated (quality 96, 14.9 KB — under cap), so this is a **targeted accuracy fix**:

- **`MeasureTheory.integral_Icc_eq_integral_Ioc`** was attributed to module `Mathlib.MeasureTheory.Integral.SetIntegral`, which **does not exist** in Mathlib 4.26.0 (this project's pinned version — confirmed via `lean-toolchain`).
- Verified against Mathlib source that the lemma lives in `namespace MeasureTheory` in `Mathlib/MeasureTheory/Integral/Bochner/Set.lean` → module **`Mathlib.MeasureTheory.Integral.Bochner.Set`**. Confirmed the lemma is genuinely used at `AreaOfCircleOQ03OQ03OQ01.lean:104`.
- The other four `mathlibDependencies` (`integral_sqrt_one_sub_sq`, `intervalIntegral.integral_comp_div`, `intervalIntegral.integral_const_mul`, `volume_regionBetween_eq_integral`) were each checked against source and are correct — left unchanged.

JSON validated; size caps checked. No content deleted.