### PR TITLE
research(erdos-214-incomplete-01): general prime ≡3 mod4 obstruction for √2·ℤ² [VERIFIED axiom-free]

### DIFF
--- a/proofs/Proofs/Erdos214Incomplete01OQ01.lean
+++ b/proofs/Proofs/Erdos214Incomplete01OQ01.lean
@@ -593,4 +593,73 @@ theorem scaledLattice_realizes_sqrt_two :
   refine ⟨p, q, hp, hq, ?_⟩
   rw [h]; congr 1; norm_num
 
+
+/-- **A prime `r ≡ 3 (mod 4)` dividing a sum of two squares divides each summand.**
+If `r ∣ u² + v²` then `r ∣ u` and `r ∣ v`.  This is the structural heart of Fermat's
+two-square theorem: `-1` is a quadratic non-residue mod such an `r`, so working in the
+field `ZMod r` the relation `u² ≡ -v²` forces both `u ≡ 0` and `v ≡ 0`.  It generalizes
+`sq_add_sq_three_dvd` (the `r = 3` instance) to *every* prime `≡ 3 (mod 4)`. -/
+theorem sq_add_sq_prime_dvd {r : ℕ} [Fact r.Prime] (hr : r % 4 = 3)
+    (u v : ℤ) (h : (r : ℤ) ∣ (u ^ 2 + v ^ 2)) : (r : ℤ) ∣ u ∧ (r : ℤ) ∣ v := by
+  have hcast : ((u : ZMod r)) ^ 2 = -((v : ZMod r)) ^ 2 := by
+    have hz : ((u ^ 2 + v ^ 2 : ℤ) : ZMod r) = 0 := by
+      rw [ZMod.intCast_zmod_eq_zero_iff_dvd]; exact_mod_cast h
+    push_cast at hz
+    linear_combination hz
+  refine ⟨?_, ?_⟩
+  · rw [← ZMod.intCast_zmod_eq_zero_iff_dvd]
+    by_contra hu
+    exact (ZMod.mod_four_ne_three_of_sq_eq_neg_sq hu hcast) hr
+  · rw [← ZMod.intCast_zmod_eq_zero_iff_dvd]
+    by_contra hv
+    have hcast' : ((v : ZMod r)) ^ 2 = -((u : ZMod r)) ^ 2 := by rw [hcast]; ring
+    exact (ZMod.mod_four_ne_three_of_sq_eq_neg_sq hv hcast') hr
+
+/-- **`√2·ℤ²` avoids `√n` whenever a prime `r ≡ 3 (mod 4)` divides `n` to an *odd* power**
+(concretely `r ∣ n` but `r² ∤ n`).  From `dist² = 2·(u² + v²) = n` and `r` odd we get
+`r ∣ u² + v²`; then `sq_add_sq_prime_dvd` forces `r ∣ u`, `r ∣ v`, whence `r² ∣ u² + v²`
+and so `r² ∣ n` — contradiction.  This is the general odd-prime obstruction of which
+`scaledLattice_dist_ne_sqrt_of_three_dvd_not_nine` (`r = 3`) is the first instance; taking
+`r = 7, 11, 19, …` yields infinitely many further avoided families (`√7, √11, √28, …`). -/
+theorem scaledLattice_dist_ne_sqrt_of_prime_dvd_not_sq {p q : Plane}
+    (hp : p ∈ ScaledLattice) (hq : q ∈ ScaledLattice)
+    {r n : ℕ} [Fact r.Prime] (hr : r % 4 = 3)
+    (hdvd : r ∣ n) (hnsq : ¬ (r ^ 2 ∣ n)) : dist p q ≠ Real.sqrt n := by
+  intro h
+  obtain ⟨u, v, huv⟩ := scaledLattice_dist_sq_two_mul_sq_add_sq hp hq
+  have hsq : dist p q ^ 2 = (n : ℝ) := by rw [h, Real.sq_sqrt (by positivity)]
+  rw [hsq] at huv
+  have hz : (n : ℤ) = 2 * (u ^ 2 + v ^ 2) := by exact_mod_cast huv
+  have hrn : (r : ℤ) ∣ (n : ℤ) := by exact_mod_cast hdvd
+  -- r is prime and odd, r ∣ 2·(u²+v²) ⟹ r ∣ u²+v²
+  have hrp : Prime (r : ℤ) := Nat.prime_iff_prime_int.mp (Fact.out)
+  have hrmul : (r : ℤ) ∣ 2 * (u ^ 2 + v ^ 2) := by rw [← hz]; exact hrn
+  have hrs : (r : ℤ) ∣ (u ^ 2 + v ^ 2) := by
+    rcases (hrp.dvd_mul.mp hrmul) with h2 | hs
+    · exfalso
+      have : (r : ℤ) ∣ (2 : ℤ) := h2
+      have hle : r ∣ 2 := by exact_mod_cast this
+      have : r ≤ 2 := Nat.le_of_dvd (by norm_num) hle
+      omega
+    · exact hs
+  obtain ⟨hu, hv⟩ := sq_add_sq_prime_dvd hr u v hrs
+  obtain ⟨a, ha⟩ := hu
+  obtain ⟨b, hb⟩ := hv
+  have hr2s : (r : ℤ) ^ 2 ∣ (u ^ 2 + v ^ 2) := ⟨a ^ 2 + b ^ 2, by rw [ha, hb]; ring⟩
+  obtain ⟨c, hc⟩ := hr2s
+  have hr2n : (r : ℤ) ^ 2 ∣ (n : ℤ) := ⟨2 * c, by rw [hz, hc]; ring⟩
+  exact hnsq (by exact_mod_cast hr2n)
+
+/-- **Concrete instance beyond `r = 3`:** no two points of `√2·ℤ²` are at distance `√56`.
+Here `56 = 2³·7` with `7 ≡ 3 (mod 4)` dividing `56` but `49 ∤ 56`, so `√56` is avoided by the
+`r = 7` obstruction.  It is caught by *none* of the earlier families: `56 ≡ 0 (mod 8)` is an
+*achievable* residue, `56 ≡ 8 (mod 16)` escapes the `n ≡ 12 (mod 16)` family, and `3 ∤ 56`
+escapes the `r = 3` theorem — the general odd-prime obstruction reaches strictly further. -/
+theorem scaledLattice_dist_ne_sqrt_fiftysix {p q : Plane}
+    (hp : p ∈ ScaledLattice) (hq : q ∈ ScaledLattice) :
+    dist p q ≠ Real.sqrt 56 := by
+  haveI : Fact (Nat.Prime 7) := ⟨by norm_num⟩
+  exact scaledLattice_dist_ne_sqrt_of_prime_dvd_not_sq hp hq (r := 7) (n := 56)
+    (by decide) (by decide) (by decide)
+
 end Erdos214Incomplete01OQ01

--- a/research/problems/erdos-214-incomplete-01/knowledge.md
+++ b/research/problems/erdos-214-incomplete-01/knowledge.md
@@ -252,3 +252,45 @@ exists for odd p (all residues of u²+v² mod 3,7 achievable) — the real obstr
 full Fermat characterization scaledLattice_achievable_iff already stubbed at line 421 (open frontier).
 
 REMAINING: core #214 BLOCKED on juhasz_stronger (deep incidence geometry, not in Mathlib).
+
+## Session 2026-07-11 (researcher-8) — GENERAL prime ≡ 3 (mod 4) obstruction [VERIFIED axiom-free]
+
+**Mode:** REVISIT — lifted the file's concrete `p = 3` obstruction to the full odd-prime
+mechanism. Extended `Erdos214Incomplete01OQ01.lean` (596→665, Mathlib-only, 0 ax / 0 sorry).
+VERIFIED host `bin/lake env lean` exit 0; `#print axioms` = `[propext, Classical.choice,
+Quot.sound]` only (no `sorryAx`/`ofReduceBool`) for all 3 new thms.
+
+### Key realization
+`sq_add_sq_three_dvd` (3∣u²+v² ⟹ 3∣u ∧ 3∣v) and its avoidance corollary
+`scaledLattice_dist_ne_sqrt_of_three_dvd_not_nine` were only the `r=3` special case. The
+real mechanism is: for ANY prime `r ≡ 3 (mod 4)`, `-1` is a quadratic non-residue mod `r`,
+so `r∣u²+v² ⟹ r∣u ∧ r∣v`. Mathlib supplies the crux directly:
+`ZMod.mod_four_ne_three_of_sq_eq_neg_sq (hx : x≠0) (hxy : x²=-y²) : p%4≠3`.
+
+### Added (3 theorems, 0 sorry, 0 axioms)
+- `sq_add_sq_prime_dvd {r} [Fact r.Prime] (hr : r%4=3) (u v : ℤ) (h : (r:ℤ)∣u²+v²) :
+  (r:ℤ)∣u ∧ (r:ℤ)∣v` — the general obstruction; `sq_add_sq_three_dvd` is now its `r=3`
+  instance. Proof: cast `u²+v²=0` into `ZMod r` (`ZMod.intCast_zmod_eq_zero_iff_dvd` +
+  `push_cast; linear_combination`), get `u²=-v²`; if `¬r∣u` then `(u:ZMod r)≠0` and
+  `mod_four_ne_three_of_sq_eq_neg_sq` contradicts `hr`; symmetric for `v`.
+- `scaledLattice_dist_ne_sqrt_of_prime_dvd_not_sq {p q} … {r n} [Fact r.Prime] (hr:r%4=3)
+  (hdvd:r∣n) (hnsq:¬r²∣n) : dist p q ≠ √n` — generalizes `_of_three_dvd_not_nine`. From
+  `dist²=2(u²+v²)=n` and `r` odd (r%4=3), `r∣2(u²+v²) ⟹ r∣u²+v²` via
+  `Prime.dvd_mul` (r∣2 impossible: `Nat.le_of_dvd`+omega), then `sq_add_sq_prime_dvd`
+  ⟹ r²∣u²+v² ⟹ r²∣n, contradicting `hnsq`.
+- `scaledLattice_dist_ne_sqrt_fiftysix` — concrete √56 (=2³·7) avoided via `r=7`. Chosen to
+  escape ALL earlier families: 56≡0 mod8 (achievable residue), 56≡8 mod16 (escapes n≡12
+  mod16), 3∤56 (escapes r=3) — caught ONLY by the r=7 obstruction. `Fact (Nat.Prime 7)`
+  must be supplied by `haveI : Fact (Nat.Prime 7) := ⟨by norm_num⟩` (not auto-synthesized).
+
+### Gotchas (reusable)
+- `Int.coe_nat_prime` is GONE; use `Nat.prime_iff_prime_int.mp (Fact.out) : Prime (r:ℤ)`.
+- Concrete prime instances (`r=7`) need an explicit local `haveI : Fact (Nat.Prime 7)`;
+  term-mode application fails "failed to synthesize Fact (Nat.Prime 7)".
+
+### Frontier
+Unchanged: core #214 BLOCKED on `juhasz_stronger`. The odd-prime obstruction now holds for
+every `r≡3 mod4` — the last elementary sufficient-avoidance mechanism before the full Fermat
+sum-of-two-squares characterization (`n/2` a SoS ⟺ every prime ≡3 mod4 in `n/2` to even
+power). Formalizing that biconditional (Mathlib has `Nat.Prime.sq_add_sq` and
+`SumTwoSquares.lean`) is the remaining substantial axiom-free target.

--- a/src/data/research/problems/erdos-214-incomplete-01.json
+++ b/src/data/research/problems/erdos-214-incomplete-01.json
@@ -75,8 +75,8 @@
     {
       "path": "Proofs/Erdos214Incomplete01OQ01.lean",
       "filename": "Erdos214Incomplete01OQ01.lean",
-      "lineCount": 373,
-      "theoremCount": 18,
+      "lineCount": 665,
+      "theoremCount": 31,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,


### PR DESCRIPTION
## Summary

Extends `Erdos214Incomplete01OQ01.lean` (the axiom-free companion to Erdős #214) by lifting its concrete `p = 3` sum-of-two-squares obstruction to **every prime `r ≡ 3 (mod 4)`** — the actual mechanism behind Fermat's two-square theorem.

The file characterizes which distances the unit-distance-free lattice `√2·ℤ²` realizes (`dist² = 2·(u²+v²)`). Prior sessions built modular avoidance families (mod 4/8/16) and the single concrete odd-prime case `r = 3`. This session generalizes that last one.

## New theorems (all 0 sorry, 0 axioms)

- **`sq_add_sq_prime_dvd`** — for prime `r` with `r % 4 = 3`, `r ∣ u² + v² ⟹ r ∣ u ∧ r ∣ v`. Since `-1` is a quadratic non-residue mod such `r`, casting into the field `ZMod r` gives `u² = -v²`, and `ZMod.mod_four_ne_three_of_sq_eq_neg_sq` forces both bases `≡ 0`. The existing `sq_add_sq_three_dvd` is now its `r = 3` instance.
- **`scaledLattice_dist_ne_sqrt_of_prime_dvd_not_sq`** — `√2·ℤ²` avoids `√n` whenever some prime `r ≡ 3 (mod 4)` divides `n` to an *odd* power (`r ∣ n`, `r² ∤ n`). Generalizes `scaledLattice_dist_ne_sqrt_of_three_dvd_not_nine`; instances `r = 7, 11, 19, …` give infinitely many further avoided families.
- **`scaledLattice_dist_ne_sqrt_fiftysix`** — concrete `√56 = 2³·7` avoided via `r = 7`. Chosen to escape *every* earlier family: `56 ≡ 0 (mod 8)` (achievable residue), `56 ≡ 8 (mod 16)` (escapes the `n ≡ 12 mod 16` family), `3 ∤ 56` (escapes the `r = 3` theorem) — caught only by the general obstruction.

## Verification

`bin/lake env lean` exit 0, zero diagnostics. `#print axioms` reports `[propext, Classical.choice, Quot.sound]` only (no `sorryAx`, no `ofReduceBool`) for all three theorems. File 596→665 lines, 28→31 theorems. The axiomatized core `juhasz_stronger` (deep incidence geometry, absent from Mathlib) is untouched and remains the blocker for the main #214 result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)