### PR TITLE
research(hilbert-17-oq-03): certificate-based nonnegativity for Motzkin & Robinson [axiom-free]

### DIFF
--- a/proofs/Proofs/Hilbert17MotzkinRationalSOS.lean
+++ b/proofs/Proofs/Hilbert17MotzkinRationalSOS.lean
@@ -123,6 +123,38 @@ theorem multiplier_isSumOfSquares : IsSumOfSquaresMv multiplier := by
   simp only [multiplier]
   ring
 
+/-! ### The certificate proves nonnegativity (the Positivstellensatz payoff)
+
+A sum-of-squares Positivstellensatz certificate `s·M = Σ squares` with a strictly
+positive multiplier `s` is not merely a curiosity: it is a *proof* that `M` is
+nonnegative.  Here the multiplier `4 + 4x² + 4y² ≥ 4 > 0` never vanishes, so
+evaluating the certificate at any real point `v` gives
+`s(v)·M(v) = Σ (Gᵢ(v))² ≥ 0` with `s(v) > 0`, whence `M(v) ≥ 0`.  This recovers
+Motzkin nonnegativity (`Hilbert17SumOfSquares.motzkin_nonneg`, proved there by a
+direct AM–GM `nlinarith`) as a *corollary of the exhibited certificate* — the
+logical reason the certificate is worth having. -/
+
+/-- The multiplier `4 + 4x² + 4y²` is strictly positive at every real point
+(its value is at least its constant term `4`). -/
+theorem multiplier_eval_pos (v : Fin 2 → ℝ) : 0 < eval v multiplier := by
+  simp only [multiplier, map_add, map_mul, map_pow, map_ofNat, eval_X]
+  nlinarith [sq_nonneg (v 0), sq_nonneg (v 1)]
+
+/-- **Certificate-based nonnegativity of Motzkin.**  For every real point `v`,
+`M(v) ≥ 0`, derived from the SOS certificate `multiplier·M = Σ Gᵢ²` and the strict
+positivity of the multiplier.  (Independent route to `motzkin_nonneg`.) -/
+theorem motzkin_eval_nonneg (v : Fin 2 → ℝ) : 0 ≤ eval v motzkin := by
+  have hpos := multiplier_eval_pos v
+  have key : eval v multiplier * eval v motzkin
+      = (eval v G0) ^ 2 + (eval v G0) ^ 2 + (eval v G0) ^ 2 + (eval v G1) ^ 2
+        + (eval v G2) ^ 2 + (eval v G3) ^ 2 + (eval v G4) ^ 2 := by
+    have h := congrArg (eval v) multiplier_mul_motzkin_eq
+    simpa only [map_mul, map_add, map_pow] using h
+  have hrhs : 0 ≤ eval v multiplier * eval v motzkin := by rw [key]; positivity
+  rcases le_or_gt 0 (eval v motzkin) with h | h
+  · exact h
+  · exact absurd hrhs (not_le.mpr (mul_neg_of_pos_of_neg hpos h))
+
 /-! ### The rational-function corollary (Artin for Motzkin, constructively) -/
 
 /-- The multiplier is nonzero in `ℝ[x, y]` (its constant term is `4`). -/

--- a/proofs/Proofs/Hilbert17RobinsonRationalSOS.lean
+++ b/proofs/Proofs/Hilbert17RobinsonRationalSOS.lean
@@ -136,13 +136,56 @@ theorem multiplier_isSumOfSquares : IsSumOfSquaresMv multiplier := by
   simp only [multiplier]
   ring
 
+/-! ### The certificate proves nonnegativity (the Positivstellensatz payoff)
+
+An SOS Positivstellensatz certificate `s·R = Σ squares` is a *proof* that `R ≥ 0`.
+Unlike the Motzkin case, the homogeneous multiplier `s = 4x² + 4y² + 4z²` vanishes
+at the origin, so we split: away from the origin `s(v) > 0` and evaluating the
+certificate gives `R(v) ≥ 0`; at the origin `R(0,0,0) = 0 ≥ 0` outright.  This
+recovers Robinson nonnegativity (`Hilbert17SumOfSquares.robinson_nonneg`, proved
+there by a direct Schur-inequality `nlinarith`) as a *corollary of the exhibited
+certificate*. -/
+
+/-- The multiplier `4x² + 4y² + 4z²` is nonnegative at every real point. -/
+theorem multiplier_eval_nonneg (v : Fin 3 → ℝ) : 0 ≤ eval v multiplier := by
+  simp only [multiplier, map_add, map_mul, map_pow, map_ofNat, eval_X]
+  positivity
+
+/-- **Certificate-based nonnegativity of Robinson.**  For every real point `v`,
+`R(v) ≥ 0`, derived from the SOS certificate `multiplier·R = Q1² + 3Q2² + Ga² +
+Gb² + Gc²`.  (Independent route to `robinson_nonneg`.) -/
+theorem robinson_eval_nonneg (v : Fin 3 → ℝ) : 0 ≤ eval v robinson := by
+  have key : eval v multiplier * eval v robinson
+      = (eval v Q1) ^ 2 + (eval v Q2) ^ 2 + (eval v Q2) ^ 2 + (eval v Q2) ^ 2
+        + (eval v Ga) ^ 2 + (eval v Gb) ^ 2 + (eval v Gc) ^ 2 := by
+    have h := congrArg (eval v) multiplier_mul_robinson_eq
+    simpa only [map_mul, map_add, map_pow] using h
+  have hrhs : 0 ≤ eval v multiplier * eval v robinson := by rw [key]; positivity
+  rcases eq_or_ne (eval v multiplier) 0 with hz | hnz
+  · -- The multiplier vanishes only at the origin, where `R` is `0`.
+    have hsum : (v 0) ^ 2 + (v 1) ^ 2 + (v 2) ^ 2 = 0 := by
+      have := hz
+      simp only [multiplier, map_add, map_mul, map_pow, map_ofNat, eval_X] at this
+      nlinarith [sq_nonneg (v 0), sq_nonneg (v 1), sq_nonneg (v 2)]
+    have e0 : v 0 = 0 := by nlinarith [sq_nonneg (v 0), sq_nonneg (v 1), sq_nonneg (v 2)]
+    have e1 : v 1 = 0 := by nlinarith [sq_nonneg (v 0), sq_nonneg (v 1), sq_nonneg (v 2)]
+    have e2 : v 2 = 0 := by nlinarith [sq_nonneg (v 0), sq_nonneg (v 1), sq_nonneg (v 2)]
+    simp only [robinson, map_add, map_sub, map_mul, map_pow, eval_X, map_ofNat, e0, e1, e2]
+    norm_num
+  · have hpos : 0 < eval v multiplier :=
+      lt_of_le_of_ne (multiplier_eval_nonneg v) (Ne.symm hnz)
+    rcases le_or_gt 0 (eval v robinson) with h | h
+    · exact h
+    · exact absurd hrhs (not_le.mpr (mul_neg_of_pos_of_neg hpos h))
+
 /-! ### The rational-function corollary (Artin for Robinson, constructively) -/
 
-/-- The multiplier is nonzero in `ℝ[x, y, z]` (its coefficient of `x²` is `4`). -/
+/-- The multiplier is nonzero in `ℝ[x, y, z]` (it evaluates to `12` at `(1,1,1)`). -/
 theorem multiplier_ne_zero : multiplier ≠ 0 := by
   intro h
-  have := congrArg (eval (fun i => if i = 0 then (1 : ℝ) else 0)) h
-  simp only [multiplier, map_add, map_mul, map_pow, map_ofNat, eval_X, map_zero] at this
+  have := congrArg (eval (fun _ => (1 : ℝ))) h
+  simp only [multiplier, map_add, map_mul, map_pow, map_ofNat, eval_X, map_zero,
+    one_pow, mul_one] at this
   norm_num at this
 
 /-- The image of the multiplier in `ℝ(x, y, z)` is nonzero. -/

--- a/src/data/research/problems/hilbert-17-oq-03.json
+++ b/src/data/research/problems/hilbert-17-oq-03.json
@@ -36,7 +36,8 @@
       "Hilbert17.artin_hilbert17 (now theorem ⟸ pfister_bound_aux), Hilbert17SumOfSquares.lean",
       "Hilbert17.artin_univariate (now theorem ⟸ univariate_psd_is_sos_aux via algebraMap), Hilbert17SumOfSquares.lean",
       "Hilbert17.cassels_bound_bivariate (now theorem ⟸ pfister_bound_aux 2), Hilbert17SumOfSquares.lean",
-      "Proofs/Hilbert17RobinsonRationalSOS.lean: robinson_isSOS_ratFunc (R is SOS of rational functions, 0 axioms), multiplier_mul_robinson_eq (ring-closed Positivstellensatz certificate), product_identity, multiplier_isSumOfSquares — 191 lines, 7 theorems, 0 sorries."
+      "Proofs/Hilbert17RobinsonRationalSOS.lean: robinson_isSOS_ratFunc (R is SOS of rational functions, 0 axioms), multiplier_mul_robinson_eq (ring-closed Positivstellensatz certificate), product_identity, multiplier_isSumOfSquares — 191 lines, 7 theorems, 0 sorries.",
+      "Hilbert17MotzkinRationalSOS.motzkin_eval_nonneg + multiplier_eval_pos (0-axiom): pointwise M(v) ≥ 0 derived from the SOS certificate via strictly-positive multiplier. Hilbert17RobinsonRationalSOS.robinson_eval_nonneg + multiplier_eval_nonneg (0-axiom): pointwise R(v) ≥ 0 via origin-split. Also repaired Mathlib drift in Hilbert17RobinsonRationalSOS.multiplier_ne_zero (if (2:Fin 3)=0 no longer reduces under current simp set → evaluate at constant-1 point)."
     ],
     "insights": [
       "The univariate case has an elementary induction-on-degree proof needing only the FTA plus continuity: the sole analytic input is that a real root of a non-negative polynomial has multiplicity ≥ 2 (if it were simple, p=(x-r)g changes sign across r — one-sided limits force g(r)≥0 and g(r)≤0). Real roots come out as (X-C r)², conjugate pairs as a positive quadratic, and the Brahmagupta–Fibonacci identity keeps everything a sum of two squares. No real-closed-field or Gram-matrix machinery — and unlike n≥2, the conclusion is genuine polynomials, not rational functions.",
@@ -46,7 +47,8 @@
       "Three of the parent hilbert-17 axioms were redundant restatements, not independent assumptions: artin_hilbert17 and cassels_bound_bivariate are specializations of pfister_bound_aux (take m=2^n; and 2^2=4 defeq gives the n=2 case directly), and artin_univariate is the algebraMap image of the stronger polynomial result univariate_psd_is_sos_aux. All three now derived as theorems — axiom count 7 → 4.",
       "Eliminating a redundant axiom is honest axiom reduction: when axiom B is provable from axiom A already in the file, B was never adding assumptive content, so converting B to `theorem ... := <derivation>` genuinely shrinks the independent-assumption set.",
       "Robinson ternary sextic R has an explicit 0-axiom rational-SOS certificate: the multiplier 4(x²+y²+z²) times R is a sum of 7 integer-coefficient polynomial squares (Q1²+3Q2²+Ga²+Gb²+Gc²), giving R = Σ 21 rational-function squares (Proofs/Hilbert17RobinsonRationalSOS.lean).",
-      "The symmetry substitution u=x²,v=y²,w=z² reduces the ternary-sextic boundary SDP to a symmetric quartic in u,v,w: (u+v+w)R = Σu⁴−2Σu²v²+uvw(u+v+w), which splits into a rank-2 even block (2q1−q2)²+3q2² plus three rank-1 odd blocks uv(u−v)² (and cyclic) = (xy(x²−y²))². This gives an EXACT small rational Gram over ℚ where a numeric boundary Gram would not rationalize cleanly."
+      "The symmetry substitution u=x²,v=y²,w=z² reduces the ternary-sextic boundary SDP to a symmetric quartic in u,v,w: (u+v+w)R = Σu⁴−2Σu²v²+uvw(u+v+w), which splits into a rank-2 even block (2q1−q2)²+3q2² plus three rank-1 odd blocks uv(u−v)² (and cyclic) = (xy(x²−y²))². This gives an EXACT small rational Gram over ℚ where a numeric boundary Gram would not rationalize cleanly.",
+      "The exhibited SOS Positivstellensatz certificate s·M = Σ squares is itself a proof of nonnegativity: at any real point, s(v)·M(v) = Σ(Gᵢ(v))² ≥ 0. For Motzkin the multiplier s = 4+4x²+4y² ≥ 4 > 0 never vanishes so M(v) ≥ 0 divides out directly; for Robinson the homogeneous s = 4x²+4y²+4z² vanishes only at the origin (where R = 0), so a single origin-split recovers R(v) ≥ 0. This gives certificate-based nonnegativity (motzkin_eval_nonneg, robinson_eval_nonneg) — an independent route to the parent's Schur/AM-GM motzkin_nonneg/robinson_nonneg."
     ],
     "mathlibGaps": [],
     "nextSteps": [
@@ -85,7 +87,7 @@
     "mathlib": []
   },
   "started": "2026-04-03T12:03:52.282Z",
-  "lastUpdate": "2026-06-24T00:00:00.000Z",
+  "lastUpdate": "2026-07-11T00:00:00.000Z",
   "significance": 6,
   "tractability": 5,
   "leanFiles": [
@@ -103,8 +105,8 @@
     {
       "path": "Proofs/Hilbert17MotzkinRationalSOS.lean",
       "filename": "Hilbert17MotzkinRationalSOS.lean",
-      "lineCount": 178,
-      "theoremCount": 7,
+      "lineCount": 209,
+      "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 11,
       "sorryCount": 0,
@@ -224,8 +226,8 @@
     {
       "path": "Proofs/Hilbert17RobinsonRationalSOS.lean",
       "filename": "Hilbert17RobinsonRationalSOS.lean",
-      "lineCount": 192,
-      "theoremCount": 7,
+      "lineCount": 234,
+      "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 11,
       "sorryCount": 0,


### PR DESCRIPTION
## Summary

The two rational-SOS files under `hilbert-17-oq-03` exhibit **Positivstellensatz certificates** `s·P = Σ squares` for the Motzkin and Robinson forms, but never drew the logical payoff: such a certificate is itself a *proof* that `P` is nonnegative. This PR adds that corollary to both files, deriving pointwise nonnegativity directly from the exhibited certificate.

## Motzkin (`Hilbert17MotzkinRationalSOS.lean`, 7→9 theorems)
- `multiplier_eval_pos` — the multiplier `4 + 4x² + 4y² ≥ 4 > 0` never vanishes.
- `motzkin_eval_nonneg` — `M(v) ≥ 0` for all real `v`, from `s(v)·M(v) = Σ Gᵢ(v)² ≥ 0` and `s(v) > 0`.

## Robinson (`Hilbert17RobinsonRationalSOS.lean`, 7→9 theorems)
- `multiplier_eval_nonneg` — `4x² + 4y² + 4z² ≥ 0`.
- `robinson_eval_nonneg` — `R(v) ≥ 0`. The homogeneous multiplier vanishes only at the origin (where `R = 0`), handled by a single origin-split.
- **Drift repair:** `multiplier_ne_zero` no longer compiled on the current toolchain — `if (2 : Fin 3) = 0` is no longer reduced by the file's `simp only` set. Re-proved by evaluating at the constant-`1` point (value `12`), which needs no `if`.

## Why this is not a duplicate
The parent `Hilbert17SumOfSquares.lean` proves `motzkin_nonneg` / `robinson_nonneg` by a **different** route (a direct AM–GM / Schur-inequality `nlinarith`). These new lemmas are the *independent, certificate-based* route — the reason a Positivstellensatz certificate is worth exhibiting.

## Verification
- Both files compile clean on Lean 4.26.0 / current Mathlib.
- All new theorems axiom-free: `#print axioms` reports only `[propext, Classical.choice, Quot.sound]` (no `Lean.ofReduceBool`, no `sorryAx`).
- Files remain 0-axiom, 0-sorry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)