### PR TITLE
research(elementary-quadratic-reciprocity-oq-03-oq-02-wip-01): Dirichlet-character periodicity of the Kronecker symbol

### DIFF
--- a/proofs/Proofs/ElementaryQuadraticReciprocityOQ03OQ02WIP01.lean
+++ b/proofs/Proofs/ElementaryQuadraticReciprocityOQ03OQ02WIP01.lean
@@ -1,0 +1,106 @@
+import Proofs.ElementaryQuadraticReciprocityOQ03OQ02
+import Mathlib.Tactic
+
+/-
+# The Kronecker Symbol as a Periodic Character (completion of ...OQ03OQ02)
+
+*Open question* (`elementary-quadratic-reciprocity-oq-03-oq-02-wip-01`): the parent
+file `ElementaryQuadraticReciprocityOQ03OQ02` builds the Kronecker symbol `(a/n)`,
+proves it is completely multiplicative in both arguments, and (Section 5) motivates
+it as *"the associated primitive Dirichlet character"* of a fundamental discriminant.
+The defining property of a Dirichlet character mod `n` — periodicity of the symbol
+in its numerator, `(a/n)` depending only on `a mod n` — is asserted in the prose but
+never formalized.  Likewise, for the `(·/2)` character `kronecker2` the parent proves
+only *single-step* periodicity `kronecker2_periodic` (`(a+8/2) = (a/2)`), leaving the
+full period statement `(a+8k/2) = (a/2)` and the residue-only dependence implicit.
+
+This file closes those gaps, all derived from the parent's public API with no new
+axioms (`propext`, `Classical.choice`, `Quot.sound` only):
+
+## Numerator side — the Dirichlet-character property of `(·/n)`
+
+* `kronecker_congr_left`      — for odd positive `n`, `a ≡ b (mod n) ⟹ (a/n) = (b/n)`.
+                                The symbol is a function of the residue class `a mod n`.
+* `kronecker_add_mul_left`    — `(a + n·k / n) = (a/n)` for every `k`: full periodicity
+                                of the numerator with period `n`.
+* `kronecker_periodic_left`   — the `k = 1` shift `(a + n / n) = (a/n)`, the textbook
+                                statement that `(·/n)` is a character modulo `n`.
+
+## `(·/2)` side — full periodicity of `kronecker2`
+
+* `kronecker2_congr`          — `a ≡ b (mod 8) ⟹ kronecker2 a = kronecker2 b`.
+* `kronecker2_add_mul_eight`  — `kronecker2 (a + 8·k) = kronecker2 a` (full period 8,
+                                generalizing the parent's single-step `kronecker2_periodic`).
+
+Together with the parent's `kronecker2_mul` / `kronecker2_neg` these complete the
+identification of `(·/2)` and `(·/n)` (odd `n`) as genuine periodic characters — the
+structural input the Gauss-sum route to generalized quadratic reciprocity rests on.
+
+All results are fully machine-checked (0 axioms, 0 sorries).
+
+Reference: Kronecker (1885); Hardy–Wright ch. 6; parent `ElementaryQuadraticReciprocityOQ03OQ02`.
+-/
+
+namespace KroneckerSymbol
+
+open Int
+
+-- ============================================================
+-- Section A: The Dirichlet-character property of `(·/n)` (numerator side)
+-- ============================================================
+
+/-- **The Kronecker symbol depends only on the residue class of its numerator.**
+    For odd positive `n`, if `a ≡ b (mod n)` then `(a/n) = (b/n)`.  On odd positive
+    moduli the parent's `kronecker_eq_jacobi` identifies `(·/n)` with the Jacobi
+    symbol, and `jacobiSym.mod_left'` supplies exactly this residue-invariance.  This
+    is the defining periodicity of the Dirichlet character `(·/n)` promised (but not
+    proved) in the parent's Section 5. -/
+theorem kronecker_congr_left {a b : ℤ} {n : ℕ} (hn : 0 < n) (hodd : n % 2 = 1)
+    (h : a % (n : ℤ) = b % (n : ℤ)) :
+    kronecker a n = kronecker b n := by
+  rw [kronecker_eq_jacobi a n hn hodd, kronecker_eq_jacobi b n hn hodd]
+  exact jacobiSym.mod_left' h
+
+/-- **Full numerator periodicity with period `n`.**  For odd positive `n` and every
+    integer shift `k`, `(a + n·k / n) = (a/n)`: adding any multiple of the modulus to
+    the numerator leaves the symbol unchanged.  Immediate from `kronecker_congr_left`
+    since `(a + n·k) % n = a % n`. -/
+theorem kronecker_add_mul_left (a k : ℤ) {n : ℕ} (hn : 0 < n) (hodd : n % 2 = 1) :
+    kronecker (a + n * k) n = kronecker a n :=
+  kronecker_congr_left hn hodd (by rw [Int.add_mul_emod_self_left])
+
+/-- **`(·/n)` is a character modulo `n`: the unit shift.**  The `k = 1` case of
+    `kronecker_add_mul_left`, `(a + n / n) = (a/n)` — the textbook statement that the
+    Kronecker symbol at a fixed odd positive modulus `n` is periodic with period `n`. -/
+theorem kronecker_periodic_left (a : ℤ) {n : ℕ} (hn : 0 < n) (hodd : n % 2 = 1) :
+    kronecker (a + n) n = kronecker a n := by
+  simpa using kronecker_add_mul_left a 1 hn hodd
+
+-- ============================================================
+-- Section B: Full periodicity of the `(·/2)` character `kronecker2`
+-- ============================================================
+
+/-- `kronecker2 x` depends only on `x % 8` (re-derived locally as a helper). -/
+private theorem kronecker2_mod_eight (x : ℤ) : kronecker2 x = kronecker2 (x % 8) := by
+  unfold kronecker2
+  rw [Int.emod_emod_of_dvd x (by norm_num : (2 : ℤ) ∣ 8),
+    Int.emod_emod_of_dvd x (by norm_num : (8 : ℤ) ∣ 8)]
+
+/-- **`kronecker2` depends only on the residue mod `8`.**  If `a ≡ b (mod 8)` then
+    `kronecker2 a = kronecker2 b`: the `(·/2)` symbol is a function of the residue
+    class mod `8`.  This is the congruence-invariance underlying the parent's
+    single-step `kronecker2_periodic`. -/
+theorem kronecker2_congr {a b : ℤ} (h : a % 8 = b % 8) :
+    kronecker2 a = kronecker2 b := by
+  rw [kronecker2_mod_eight a, kronecker2_mod_eight b, h]
+
+/-- **Full period `8` for `kronecker2`.**  `kronecker2 (a + 8·k) = kronecker2 a` for
+    every integer `k`, generalizing the parent's single-step `kronecker2_periodic`
+    (`k = 1`).  Since `kronecker2` depends only on `a % 8` (`kronecker2_congr`) and
+    `(a + 8·k) % 8 = a % 8`, adding any multiple of `8` fixes the value — the exact
+    period-8 statement identifying `(·/2)` as a Dirichlet character mod `8`. -/
+theorem kronecker2_add_mul_eight (a k : ℤ) :
+    kronecker2 (a + 8 * k) = kronecker2 a :=
+  kronecker2_congr (by rw [Int.add_mul_emod_self_left])
+
+end KroneckerSymbol

--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-03-oq-02-wip-01/annotations.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-03-oq-02-wip-01/annotations.json
@@ -1,0 +1,46 @@
+[
+  {
+    "id": "ann-kron-wip01-congr-left",
+    "proofId": "elementary-quadratic-reciprocity-oq-03-oq-02-wip-01",
+    "range": {
+      "startLine": 62,
+      "endLine": 67
+    },
+    "type": "concept",
+    "title": "The Dirichlet-character periodicity of (a/n)",
+    "content": "`kronecker_congr_left` is the defining property of the Kronecker symbol as a Dirichlet character modulo n: for odd positive n, the value (a/n) depends only on the residue class a mod n. On odd positive moduli the parent's `kronecker_eq_jacobi` identifies (a/n) with the Jacobi symbol, so Mathlib's `jacobiSym.mod_left'` — residue-invariance of the Jacobi symbol in its numerator — transports directly. The full-period and unit-shift forms (`kronecker_add_mul_left`, `kronecker_periodic_left`) then follow from the residue identity (a + n·k) % n = a % n.",
+    "mathContext": "For a fundamental discriminant $D$, $n \\mapsto (D/n)$ is a primitive Dirichlet character of conductor $|D|$; periodicity in the argument, $(a/n)=(b/n)$ whenever $a\\equiv b\\pmod n$, is the character axiom.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Dirichlet character",
+      "Jacobi symbol residue-invariance",
+      "quadratic residues mod n"
+    ],
+    "prerequisites": [
+      "Jacobi symbol",
+      "modular arithmetic"
+    ]
+  },
+  {
+    "id": "ann-kron-wip01-kronecker2-period",
+    "proofId": "elementary-quadratic-reciprocity-oq-03-oq-02-wip-01",
+    "range": {
+      "startLine": 98,
+      "endLine": 106
+    },
+    "type": "concept",
+    "title": "Full period 8 for the (a/2) character",
+    "content": "`kronecker2_add_mul_eight` generalizes the parent's single-step `kronecker2_periodic` ((a+8/2)=(a/2)) to the full period statement (a+8·k/2)=(a/2) for every integer k. Since `kronecker2` visibly depends only on a mod 8 (`kronecker2_congr`) and (a + 8·k) % 8 = a % 8, adding any multiple of 8 fixes the value — completing the identification of (·/2) as a real Dirichlet character modulo 8.",
+    "mathContext": "The second-supplement character $(2/\\cdot)$ / $(\\cdot/2)$ is the even real Dirichlet character $\\chi_8$ modulo $8$; full periodicity with period $8$ is the character's modulus.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Dirichlet character mod 8",
+      "second supplement",
+      "period of a character"
+    ],
+    "prerequisites": [
+      "modular arithmetic",
+      "Kronecker symbol at 2"
+    ]
+  }
+]

--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-03-oq-02-wip-01/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-03-oq-02-wip-01/meta.json
@@ -1,0 +1,62 @@
+{
+  "id": "elementary-quadratic-reciprocity-oq-03-oq-02-wip-01",
+  "title": "The Kronecker Symbol as a Periodic Character",
+  "slug": "elementary-quadratic-reciprocity-oq-03-oq-02-wip-01",
+  "description": "Completes the parent Kronecker-symbol file with the Dirichlet-character periodicity that its Section 5 motivates but leaves unproved: the numerator character (a/n) at odd positive n depends only on a mod n and has full period n, and the (a/2) character kronecker2 has full period 8 (generalizing the parent's single-step kronecker2_periodic) and depends only on a mod 8. All five results are machine-verified, 0 axioms and 0 sorries, derived from the parent's public API.",
+  "references": [
+    {
+      "authors": "Leopold Kronecker",
+      "title": "Zur Theorie der elliptischen Functionen",
+      "year": 1885,
+      "note": "Introduces the Kronecker symbol extending Jacobi to even, zero, and negative moduli; the completely multiplicative symbol whose periodic-character structure is formalized here."
+    },
+    {
+      "authors": "G. H. Hardy and E. M. Wright",
+      "title": "An Introduction to the Theory of Numbers (Chapter 6)",
+      "year": 2008,
+      "note": "Classical treatment of the Jacobi/Kronecker symbols; the Dirichlet-character periodicity (a/n) depends only on a mod n is the property proved here."
+    },
+    {
+      "authors": "Jürgen Neukirch",
+      "title": "Algebraic Number Theory",
+      "year": 1999,
+      "note": "For a fundamental discriminant D, n ↦ (D/n) is a primitive Dirichlet character; periodicity in the numerator is the defining character axiom formalized in this file."
+    }
+  ],
+  "meta": {
+    "author": "Kronecker (1885); formalized here",
+    "date": "1885",
+    "status": "axiomatized",
+    "proofRepoPath": "Proofs/ElementaryQuadraticReciprocityOQ03OQ02WIP01.lean",
+    "parent": "elementary-quadratic-reciprocity-oq-03-oq-02",
+    "tags": [
+      "number-theory",
+      "quadratic-reciprocity",
+      "kronecker-symbol",
+      "jacobi-symbol",
+      "dirichlet-character",
+      "research"
+    ],
+    "badge": "wip",
+    "sorries": 0,
+    "axiomCount": 0,
+    "theoremCount": 5,
+    "defCount": 0,
+    "definitionCount": 0,
+    "lineCount": 106,
+    "dateAdded": "2026-07-11",
+    "assumptions": "0 axioms, 0 sorries — every result is machine-verified from the parent file's public API (propext, Classical.choice, Quot.sound only; the two kronecker2 results use only propext). Status is kept 'wip'/'axiomatized' to match the parent: the file proves genuine new lemmas (numerator periodicity of (a/n) for odd positive n via kronecker_congr_left / kronecker_add_mul_left / kronecker_periodic_left, and full period-8 periodicity of the (a/2) character via kronecker2_congr / kronecker2_add_mul_eight) but the broader open target — wiring kronecker2 into the definition at even moduli and generalized quadratic reciprocity for arbitrary fundamental discriminants — remains unformalized, exactly as documented in the parent's module note. Nothing new is assumed.",
+    "mathlib_version": "4.26.0"
+  },
+  "overview": {
+    "historicalContext": "The Kronecker symbol (a/n), completed by Leopold Kronecker in 1885, is the canonical quadratic character in analytic number theory: for a fundamental discriminant D of a quadratic field ℚ(√D), the map n ↦ (D/n) is a primitive Dirichlet character encoding prime splitting via class field theory. The defining property of a Dirichlet character mod n is periodicity in its argument — the symbol depending only on the residue class. The parent file ElementaryQuadraticReciprocityOQ03OQ02 builds the symbol, proves complete multiplicativity in both arguments, and motivates the Dirichlet-character interpretation, but leaves the numerator periodicity itself informal. This file supplies it.",
+    "problemStatement": "Formalize the Dirichlet-character periodicity of the Kronecker symbol left implicit in the parent: (1) for odd positive n, (a/n) depends only on a mod n and is periodic with full period n; (2) the (a/2) character kronecker2 depends only on a mod 8 and is periodic with full period 8, generalizing the parent's single-step kronecker2_periodic.",
+    "text": "Proves the numerator-side Dirichlet-character periodicity of the Kronecker symbol: residue-class dependence and full periodicity of (a/n) at odd positive n, and full period-8 periodicity of the (a/2) character kronecker2.",
+    "proofStrategy": "On odd positive moduli the parent's kronecker_eq_jacobi identifies (a/n) with the Jacobi symbol, so Mathlib's jacobiSym.mod_left' (residue-invariance of the Jacobi symbol in its numerator) transports directly to kronecker_congr_left; full periodicity kronecker_add_mul_left and the unit shift kronecker_periodic_left follow since (a + n·k) % n = a % n. For the (a/2) character, kronecker2 depends only on a % 8 (a two-line residue reduction), giving kronecker2_congr, and (a + 8·k) % 8 = a % 8 then yields the full period kronecker2_add_mul_eight, generalizing the parent's single-step kronecker2_periodic. No axioms or sorries are introduced.",
+    "keyInsights": [
+      "The defining axiom of a Dirichlet character mod n — periodicity in the argument — is, for the Kronecker symbol at odd positive n, exactly the numerator residue-invariance of the Jacobi symbol (Mathlib's jacobiSym.mod_left'), transported through the parent's agreement lemma kronecker_eq_jacobi.",
+      "Full periodicity with period n reduces to the single congruence (a + n·k) % n = a % n (Int.add_mul_emod_self_left); no case analysis on n is needed once residue-invariance is available.",
+      "The (a/2) character kronecker2 is visibly a function of a mod 8, so its full period-8 periodicity (a+8k/2)=(a/2) — generalizing the parent's single-step k=1 result — follows from the same residue-shift identity, completing the identification of (·/2) as a Dirichlet character mod 8."
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

New WIP-01 file `Proofs/ElementaryQuadraticReciprocityOQ03OQ02WIP01.lean` formalizing
the **Dirichlet-character periodicity** of the Kronecker symbol that the parent file
`ElementaryQuadraticReciprocityOQ03OQ02` (Section 5) motivates — *"the associated
primitive Dirichlet character"* — but never proves. All five theorems derive from the
parent's public API; 0 axioms, 0 sorries.

## Numerator side — the character property of `(·/n)` (odd positive `n`)

- **`kronecker_congr_left`** — `a ≡ b (mod n) ⟹ (a/n) = (b/n)`. The symbol depends only
  on the residue class `a mod n` (via the parent's `kronecker_eq_jacobi` + Mathlib's
  `jacobiSym.mod_left'`).
- **`kronecker_add_mul_left`** — `(a + n·k / n) = (a/n)`: full periodicity, period `n`.
- **`kronecker_periodic_left`** — `(a + n / n) = (a/n)`: the textbook unit-shift form.

## `(·/2)` side — full periodicity of `kronecker2`

- **`kronecker2_congr`** — `a ≡ b (mod 8) ⟹ kronecker2 a = kronecker2 b`.
- **`kronecker2_add_mul_eight`** — `kronecker2 (a + 8·k) = kronecker2 a`: full period 8,
  generalizing the parent's single-step `kronecker2_periodic` (`k = 1`).

Together with the parent's `kronecker2_mul` / `kronecker2_neg` these complete the
identification of `(·/2)` and `(·/n)` as genuine periodic characters — the structural
input the Gauss-sum route to generalized quadratic reciprocity rests on.

## Verification

Compiled against Mathlib 4.26.0 (imports the prebuilt parent olean). `#print axioms`:
numerator lemmas `[propext, Classical.choice, Quot.sound]`, `kronecker2` lemmas
`[propext]` — axiom-free. Adds gallery `meta.json` + `annotations.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)