### PR TITLE
research(erdos-1059-oq-01-oq-01): Part XII — axiom-free absolute growth of π(n!)

### DIFF
--- a/proofs/Proofs/Erdos1059OQ01OQ01.lean
+++ b/proofs/Proofs/Erdos1059OQ01OQ01.lean
@@ -883,6 +883,102 @@ theorem qualifyingCount_factorial_strictMono {n m : ℕ} (hn : n ≥ 3) (hnm : n
     (qualifyingCount_factorial_mono (by omega) (by omega))
 
 /-
+## Part XII: Absolute Growth of the *Prime* Count at Factorial Points
+
+Part XI established the absolute-growth theory for the qualifying count `C(n!)`
+(exact recurrence, monotonicity, strict step-growth, linear lower bound). The
+parallel — and more classical — theory for the underlying *prime* count `π(n!)`
+was left implicit, even though the interval decomposition `π(n!) = Σ_{l<n} p(l)`
+(`primeCount_decomposition`) is already available. We record it here.
+
+Crucially, this dual uses **no sieve axiom**: it rests only on the Bertrand-based
+positivity `primesInLevel_pos` (`p(l) ≥ 1` for `l ≥ 1`). Every primorial interval
+`I(l) = (l!, (l+1)!]` with `l ≥ 1` contains a prime (Bertrand), so passing from
+`n!` to `(n+1)!` strictly increases the prime count, and summing the per-level
+`≥ 1` contributions over `1 ≤ l < n` gives `π(n!) ≥ n − 1`. In particular this
+reproves the (classical) infinitude of primes read at factorial evaluation points,
+entirely independently of `strong_selberg_density`.
+-/
+
+/-- **Exact one-step recurrence for the prime count at factorial points.**  For
+    `n ≥ 1`, `π((n+1)!) = π(n!) + primesInLevel n`.  The prime-count dual of
+    `qualifyingCount_factorial_succ`, directly from `primeCount_decomposition` and
+    `Finset.sum_range_succ` (level `n` is the single interval adjoined). -/
+theorem primeCount_factorial_succ {n : ℕ} (hn : n ≥ 1) :
+    Erdos1059OQ01.primeCount (Nat.factorial (n + 1))
+      = Erdos1059OQ01.primeCount (Nat.factorial n) + primesInLevel n := by
+  rw [primeCount_decomposition (n + 1) (by omega),
+      primeCount_decomposition n hn, Finset.sum_range_succ]
+
+/-- **Monotonicity of the prime count at factorial points.**  For `1 ≤ n ≤ m`,
+    `π(n!) ≤ π(m!)`.  From `π(n!) = Σ_{l<n} p(l)` (`primeCount_decomposition`),
+    enlarging the evaluation point only adjoins non-negative level contributions.
+    The prime-count dual of `qualifyingCount_factorial_mono`. -/
+theorem primeCount_factorial_mono {n m : ℕ} (hn : n ≥ 1) (hnm : n ≤ m) :
+    Erdos1059OQ01.primeCount (Nat.factorial n) ≤
+      Erdos1059OQ01.primeCount (Nat.factorial m) := by
+  have hsub : Finset.range n ⊆ Finset.range m := by
+    intro x hx; simp only [Finset.mem_range] at hx ⊢; omega
+  rw [primeCount_decomposition n hn, primeCount_decomposition m (by omega)]
+  exact Finset.sum_le_sum_of_subset hsub
+
+/-- **Absolute linear lower bound on the prime count at factorial points.**  For
+    `n ≥ 1`, `π(n!) ≥ n − 1`.  Since `π(n!) = Σ_{l<n} p(l)` and every level
+    `l ≥ 1` contributes at least one prime (`primesInLevel_pos`, from Bertrand's
+    postulate), the `n − 1` levels `1 ≤ l < n` each contribute `≥ 1`.  The
+    prime-count dual of `qualifyingCount_factorial_ge` (`C(n!) ≥ n − 3`), using no
+    sieve axiom. -/
+theorem primeCount_factorial_ge (n : ℕ) (hn : n ≥ 1) :
+    Erdos1059OQ01.primeCount (Nat.factorial n) ≥ n - 1 := by
+  rw [primeCount_decomposition n hn]
+  have h1n : 1 ≤ n := hn
+  have hsplit : (Finset.range n).sum primesInLevel
+      = (Finset.range 1).sum primesInLevel + (Finset.Ico 1 n).sum primesInLevel := by
+    rw [← Finset.sum_range_add_sum_Ico _ h1n]
+  have hle : (Finset.Ico 1 n).sum (fun _ => (1 : ℕ)) ≤
+      (Finset.Ico 1 n).sum primesInLevel := by
+    apply Finset.sum_le_sum
+    intro l hl
+    simp only [Finset.mem_Ico] at hl
+    exact primesInLevel_pos l (by omega)
+  have hone : (Finset.Ico 1 n).sum (fun _ => (1 : ℕ)) = n - 1 := by
+    simp [Finset.sum_const, Nat.card_Ico]
+  omega
+
+/-- **Strict step-growth of the prime count at factorial points.**  For `n ≥ 1`,
+    `π(n!) < π((n+1)!)`.  Passing to `(n+1)!` adjoins level `n`, whose contribution
+    `p(n) ≥ 1` is strictly positive (`primesInLevel_pos`).  So the prime count
+    strictly increases at *every* factorial step — the prime-count dual of
+    `qualifyingCount_factorial_lt_succ`. -/
+theorem primeCount_factorial_lt_succ (n : ℕ) (hn : n ≥ 1) :
+    Erdos1059OQ01.primeCount (Nat.factorial n) <
+      Erdos1059OQ01.primeCount (Nat.factorial (n + 1)) := by
+  have key := primeCount_factorial_succ hn
+  have hpos := primesInLevel_pos n hn
+  omega
+
+/-- **Strict monotonicity of the prime count at factorial points.**  For
+    `1 ≤ n < m`, `π(n!) < π(m!)`.  The strict counterpart of
+    `primeCount_factorial_mono`, chaining the single strict step
+    `primeCount_factorial_lt_succ` with the non-strict monotonicity — the
+    prime-count dual of `qualifyingCount_factorial_strictMono`. -/
+theorem primeCount_factorial_strictMono {n m : ℕ} (hn : n ≥ 1) (hnm : n < m) :
+    Erdos1059OQ01.primeCount (Nat.factorial n) <
+      Erdos1059OQ01.primeCount (Nat.factorial m) :=
+  lt_of_lt_of_le (primeCount_factorial_lt_succ n hn)
+    (primeCount_factorial_mono (by omega) (by omega))
+
+/-- **The prime count is unbounded at factorial points** (infinitude of primes,
+    factorial-point form, axiom-free). For every `M` there is an `N` such that
+    `π(n!) ≥ M` for all `n ≥ N`; hence `π(n!) → ∞`. Immediate from the linear
+    lower bound `primeCount_factorial_ge`, independently of any sieve axiom. -/
+theorem primeCount_factorial_unbounded (M : ℕ) : ∃ N : ℕ, ∀ n : ℕ, n ≥ N →
+    Erdos1059OQ01.primeCount (Nat.factorial n) ≥ M := by
+  refine ⟨M + 1, fun n hn => ?_⟩
+  have hge := primeCount_factorial_ge n (by omega)
+  omega
+
+/-
 ## Summary
 
 **Proved from first principles** (no sorry):

--- a/src/data/research/problems/erdos-1059-oq-01-oq-01.json
+++ b/src/data/research/problems/erdos-1059-oq-01-oq-01.json
@@ -45,14 +45,16 @@
       "levelwise_strict_surplus: PROVED per-level surplus ≥ 1 for l ≥ max(3, k+2)",
       "density_at_levels: PROVED (main theorem) — level-sum density bound via sum splitting and surplus accumulation",
       "Gap analysis: factorial growth of interval sizes prevents extending from factorial points to general x",
-      "Gallery entry src/data/proofs/erdos-1059-oq-01-oq-01 (meta.json + annotations.json); Lean source proofs/Proofs/Erdos1059OQ01OQ01.lean."
+      "Gallery entry src/data/proofs/erdos-1059-oq-01-oq-01 (meta.json + annotations.json); Lean source proofs/Proofs/Erdos1059OQ01OQ01.lean.",
+      "Erdos1059OQ01OQ01 Part XII (6 axiom-free thm): absolute-growth theory for the PRIME count pi(n!) dual to Part XI's qualifying-count theory — primeCount_factorial_succ (pi((n+1)!)=pi(n!)+p(n)), _mono, _ge (pi(n!) >= n-1 from Bertrand-based primesInLevel_pos), _lt_succ, _strictMono, _unbounded. Uses NO sieve axiom (independent of strong_selberg_density); a factorial-point reproof of the infinitude of primes."
     ],
     "insights": [
       "**Weak axiom is provably insufficient**: ≥1 qualifying prime per interval I(l) = (l!, (l+1)!] gives only C((N+3)!) ≥ N, not density 1. The qualifying-to-prime ratio from this bound is ≈ N/π((N+3)!) → 0.",
       "**Strong axiom captures sieve content**: The Selberg sieve gives qualifying fraction ≈ 1 − O((l+1)/log(l!)) → 1 at each level. The axiom q(l)·(l+1) ≥ p(l)·l captures this with the clean bound l/(l+1).",
       "**Surplus accumulation overcomes deficit**: Each high level contributes ≥1 unit of surplus to the density bound. The finite deficit from early levels is eventually absorbed.",
       "**Factorial growth blocks general-x extension**: Between factorial points, the partial-interval deficit can be as large as p(l)·k (growing factorially), while cumulative surplus grows only linearly in the number of levels. Closing this gap requires within-interval sieve estimates.",
-      "**The strong axiom is the natural intermediate target**: Rather than attacking density 1 directly, the formalization identifies strong_selberg_density as a clean, believable axiom that could be proved from PNT + Brun-Titchmarsh + Selberg sieve, yielding both the main conjecture and density at factorial points."
+      "**The strong axiom is the natural intermediate target**: Rather than attacking density 1 directly, the formalization identifies strong_selberg_density as a clean, believable axiom that could be proved from PNT + Brun-Titchmarsh + Selberg sieve, yielding both the main conjecture and density at factorial points.",
+      "The primeCount_decomposition pi(n!)=sum_{l<n} p(l) plus Bertrand positivity primesInLevel_pos (p(l)>=1 for l>=1) yields the full absolute-growth theory for pi(n!) — recurrence, monotonicity, strict step growth, linear lower bound pi(n!)>=n-1 — entirely without the strong_selberg_density sieve axiom. This mirrors Part XI's qualifying-count theory (C(n!)>=n-3) but is axiom-independent, isolating which growth facts are classical (prime side) vs sieve-conditional (qualifying side)."
     ],
     "mathlibGaps": [],
     "nextSteps": []
@@ -81,11 +83,11 @@
     {
       "path": "Proofs/Erdos1059OQ01OQ01.lean",
       "filename": "Erdos1059OQ01OQ01.lean",
-      "lineCount": 497,
-      "theoremCount": 12,
+      "lineCount": 1030,
+      "theoremCount": 35,
       "axiomCount": 1,
       "defCount": 2,
-      "sorryCount": 5,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1059OQ01OQ01.lean"
     },
@@ -168,5 +170,6 @@
     "erdos-1059-oq-03",
     "erdos-1059-oq-04",
     "erdos-1059-oq-05"
-  ]
+  ],
+  "lastUpdate": "2026-07-11T00:00:00.000Z"
 }


### PR DESCRIPTION
## Summary

`Erdos1059OQ01OQ01.lean` develops (Part XI) the absolute-growth theory for the **qualifying** count `C(n!)` — exact recurrence, monotonicity, strict step-growth, linear lower bound `C(n!) ≥ n−3`. The parallel — and more classical — theory for the underlying **prime** count `π(n!)` was left implicit, even though the interval decomposition `π(n!) = Σ_{l<n} p(l)` (`primeCount_decomposition`) is already in the file. This PR fills that dual (new Part XII, 6 theorems):

- `primeCount_factorial_succ` — `π((n+1)!) = π(n!) + primesInLevel n`
- `primeCount_factorial_mono` — `1 ≤ n ≤ m → π(n!) ≤ π(m!)`
- `primeCount_factorial_ge` — `π(n!) ≥ n − 1`
- `primeCount_factorial_lt_succ` — `π(n!) < π((n+1)!)`
- `primeCount_factorial_strictMono` — `1 ≤ n < m → π(n!) < π(m!)`
- `primeCount_factorial_unbounded` — `π(n!) → ∞`

## Why it matters
Crucially these use **no sieve axiom**: they rest only on the Bertrand-based positivity `primesInLevel_pos` (`p(l) ≥ 1`), so they are independent of `strong_selberg_density`. This is a factorial-point reproof of the infinitude of primes and cleanly isolates which growth facts are *classical* (prime side) vs *sieve-conditional* (qualifying side, Part XI).

## Verification
- Compiles clean on Lean 4.26.0 / current Mathlib (only pre-existing unused-variable warnings).
- All 6 new theorems verified axiom-free: `#print axioms` reports only `[propext, Classical.choice, Quot.sound]` — **not** `strong_selberg_density`, no `ofReduceBool`, no `sorryAx`.
- File remains 1-axiom (`strong_selberg_density`), 0-sorry.

## Metadata fix
Corrected stale `sorryCount` `5 → 0` — the file is genuinely sorry-free (the two former decomposition sorries were long discharged by `count_decomp`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)