### PR TITLE
Enrich Prime 2 in Gauss–Wantzel (doubling invariance): prime-asymmetry insight

### DIFF
--- a/src/data/proofs/angle-trisection-oq-02-oq-03-ext-oq-01/meta.json
+++ b/src/data/proofs/angle-trisection-oq-02-oq-03-ext-oq-01/meta.json
@@ -51,7 +51,8 @@
       "**Doubling invariance**: TotientIsPow2 (2n) ↔ TotientIsPow2 n. The reverse direction is angle bisection (n-gon ⇒ 2n-gon); the forward direction (2n-gon ⇒ n-gon) is the arithmetically forced converse — bisection can never *create* constructibility where there was none.",
       "**The prime 2 splits by parity**: φ(2n) equals 2φ(n) for even n but only φ(n) for odd n. Both cases nonetheless preserve the power-of-2 property, which is why the prime 2 is 'free' in the Gauss–Wantzel criterion and only the odd part of n matters.",
       "**Reduction to the odd part**: writing n = 2^a·m collapses constructibility of the n-gon to that of the m-gon. This complements the parent's coprime multiplicativity — together they reduce the whole criterion to odd prime powers.",
-      "**Infinite families from one computation**: φ(15)=8 gives that every 2^a·15-gon (15,30,60,120,…) is constructible; φ(7)=6 has the odd prime factor 3, so no 2^a·7-gon (7,14,28,56,…) is ever constructible, regardless of how many bisections are applied."
+      "**Infinite families from one computation**: φ(15)=8 gives that every 2^a·15-gon (15,30,60,120,…) is constructible; φ(7)=6 has the odd prime factor 3, so no 2^a·7-gon (7,14,28,56,…) is ever constructible, regardless of how many bisections are applied.",
+      "**The two Gauss–Wantzel primes play asymmetric roles.** This file and its parent together explain the *shape* of the characterization n = 2^a × (product of distinct Fermat primes): the prime 2 is *inert*, admitting an arbitrarily high power a with no effect (proved here), whereas each odd Fermat prime may appear **at most once** — a squared odd prime p² already forces the factor p(p−1) into φ, killing the power-of-2 property (the parent's coprime multiplicativity). The doubling invariance is exactly the statement that 2 sits outside this squarefree constraint; only the odd primes are rationed."
     ]
   },
   "sections": [


### PR DESCRIPTION
Enrichment pass for `angle-trisection-oq-02-oq-03-ext-oq-01` (quality 96, passes 0). One targeted, non-inflating addition (meta.json well under the 60 KB cap):

- **New keyInsight (5th):** the structural *asymmetry* of the two prime types in Gauss–Wantzel that explains the shape of the `n = 2^a × (distinct Fermat primes)` characterization. This file proves the prime 2 is **inert** (any power `a`, no effect); the parent's coprime multiplicativity forces each odd Fermat prime to appear **at most once** (a squared odd prime `p²` drags the odd factor `p(p−1)` into φ, killing the power-of-2 property). The doubling invariance is precisely the statement that 2 sits outside this squarefree constraint. Complements the existing four insights (which cover mechanics + families) with the *why-this-shape* structural fact, and ties the file to its parent.

JSON validated; math re-checked against the Lean source. Uses a per-target branch to avoid the shared `feature/enricher-1-6` branch race.