### PR TITLE
research(elementary-quadratic-reciprocity-oq-03-oq-02-wip-01): 8 is the minimal period — (·/2) is primitive

### DIFF
--- a/proofs/Proofs/ElementaryQuadraticReciprocityOQ03OQ02WIP01.lean
+++ b/proofs/Proofs/ElementaryQuadraticReciprocityOQ03OQ02WIP01.lean
@@ -103,4 +103,40 @@ theorem kronecker2_add_mul_eight (a k : ℤ) :
     kronecker2 (a + 8 * k) = kronecker2 a :=
   kronecker2_congr (by rw [Int.add_mul_emod_self_left])
 
+-- ============================================================
+-- Section C: `8` is the *minimal* period — `(·/2)` is primitive (conductor `8`)
+-- ============================================================
+
+/-- **`kronecker2` is not `4`-periodic.**  `kronecker2 (a + 4) = kronecker2 a` fails —
+    witnessed at `a = 1`, where `kronecker2 5 = −1 ≠ 1 = kronecker2 1`
+    (`kronecker2_five`, `kronecker2_one`).  So the period-`8` character `(·/2)` does not
+    descend to a character mod `4`. -/
+theorem kronecker2_not_period_four : ¬ ∀ a : ℤ, kronecker2 (a + 4) = kronecker2 a := by
+  intro h
+  have h1 := h 1
+  rw [show (1 : ℤ) + 4 = 5 by norm_num, kronecker2_five, kronecker2_one] at h1
+  norm_num at h1
+
+/-- **`kronecker2` is not `2`-periodic.**  `kronecker2 (a + 2) = kronecker2 a` fails at
+    `a = 1`: `kronecker2 3 = −1 ≠ 1 = kronecker2 1` (`kronecker2_three`,
+    `kronecker2_one`).  A fortiori `(·/2)` is not `1`-periodic either. -/
+theorem kronecker2_not_period_two : ¬ ∀ a : ℤ, kronecker2 (a + 2) = kronecker2 a := by
+  intro h
+  have h1 := h 1
+  rw [show (1 : ℤ) + 2 = 3 by norm_num, kronecker2_three, kronecker2_one] at h1
+  norm_num at h1
+
+/-- **`8` is the exact conductor of `(·/2)`: primitivity.**  The `(·/2)` character
+    `kronecker2` is periodic with period `8` (`kronecker2_add_mul_eight`) but with no
+    proper divisor of `8` as a period — neither `4` (`kronecker2_not_period_four`) nor `2`
+    (`kronecker2_not_period_two`).  Hence `8` is its *minimal* period: `χ₈ = (·/2)` is a
+    **primitive** Dirichlet character mod `8`, not induced from a character of any smaller
+    modulus.  This upgrades the period-`8` statement to the sharp conductor, the input the
+    Gauss-sum route needs (only primitive characters have nonvanishing Gauss sums). -/
+theorem kronecker2_conductor_eight :
+    (∀ a k : ℤ, kronecker2 (a + 8 * k) = kronecker2 a) ∧
+      (¬ ∀ a : ℤ, kronecker2 (a + 4) = kronecker2 a) ∧
+      (¬ ∀ a : ℤ, kronecker2 (a + 2) = kronecker2 a) :=
+  ⟨kronecker2_add_mul_eight, kronecker2_not_period_four, kronecker2_not_period_two⟩
+
 end KroneckerSymbol

--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-03-oq-02-wip-01/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-03-oq-02-wip-01/meta.json
@@ -40,10 +40,10 @@
     "badge": "wip",
     "sorries": 0,
     "axiomCount": 0,
-    "theoremCount": 5,
+    "theoremCount": 8,
     "defCount": 0,
     "definitionCount": 0,
-    "lineCount": 106,
+    "lineCount": 142,
     "dateAdded": "2026-07-11",
     "assumptions": "0 axioms, 0 sorries — every result is machine-verified from the parent file's public API (propext, Classical.choice, Quot.sound only; the two kronecker2 results use only propext). Status is kept 'wip'/'axiomatized' to match the parent: the file proves genuine new lemmas (numerator periodicity of (a/n) for odd positive n via kronecker_congr_left / kronecker_add_mul_left / kronecker_periodic_left, and full period-8 periodicity of the (a/2) character via kronecker2_congr / kronecker2_add_mul_eight) but the broader open target — wiring kronecker2 into the definition at even moduli and generalized quadratic reciprocity for arbitrary fundamental discriminants — remains unformalized, exactly as documented in the parent's module note. Nothing new is assumed.",
     "mathlib_version": "4.26.0"


### PR DESCRIPTION
## Summary

The WIP file establishes that the `(·/2)` Kronecker character `kronecker2` is periodic with period `8` (`kronecker2_add_mul_eight`), identifying it as a Dirichlet character mod `8`. It never shows `8` is the **minimal** period. This PR adds the sharp conductor / primitivity result, derived purely from the parent's explicit values.

## New theorems (all axiom-free)

- **`kronecker2_not_period_four`** — `¬ ∀ a, kronecker2 (a+4) = kronecker2 a`, witnessed at `a = 1`: `kronecker2 5 = −1 ≠ 1 = kronecker2 1`.
- **`kronecker2_not_period_two`** — `¬ ∀ a, kronecker2 (a+2) = kronecker2 a`, at `a = 1`: `kronecker2 3 = −1 ≠ 1`.
- **`kronecker2_conductor_eight`** — bundles it: period `8` holds, but neither `4` nor `2` is a period, so **`8` is the exact conductor**. Hence `χ₈ = (·/2)` is a **primitive** Dirichlet character mod `8`, not induced from any smaller modulus.

This upgrades "periodic mod 8" to "conductor exactly 8" — a genuine distinction (primitivity), and the precise input the Gauss-sum route to generalized reciprocity needs (only primitive characters have nonvanishing Gauss sums).

## Verification

- `#print axioms` on `kronecker2_conductor_eight`: `[propext]` only.
- Compiled against Mathlib v4.26.0 + the parent `ElementaryQuadraticReciprocityOQ03OQ02`.
- 0 sorries, 0 axioms. `meta.json`: 5 → 8 theorems, 106 → 142 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)