### PR TITLE
research(erdos-729-oq-02): prove the delegated digit-sum-one characterization s_p(n)=1 ⟺ n=p^k

### DIFF
--- a/proofs/Proofs/Erdos729LegendrePrimeRecurrence.lean
+++ b/proofs/Proofs/Erdos729LegendrePrimeRecurrence.lean
@@ -23,9 +23,17 @@
   * `padicValNat_factorial_prime_mul p n` :
         `v_p((p·n)!) = n + v_p(n!)`            (the `r = 0` corollary)
   * `sub_one_mul_padicValNat_factorial_eq_pred_iff p n (hn : 1 ≤ n)` :
-        `(p-1)·v_p(n!) = n - 1 ⟺ s_p(n) = 1`  (maximality; `s_p(n) = 1` means `n`
-        is a power of `p`, the equivalence with `n = p^k` delegated as in the
-        `p = 2` companion)
+        `(p-1)·v_p(n!) = n - 1 ⟺ s_p(n) = 1`  (maximality)
+  * `digitSum_pos p m (hm : m ≠ 0)` :
+        `0 < s_p(m)`                          (nonzero numbers have positive digit sum)
+  * `digitSum_prime_pow p k` :
+        `s_p(p^k) = 1`                        (a prime power is a single leading `1`)
+  * `digitSum_eq_one_iff_isPow p n` :
+        `s_p(n) = 1 ⟺ ∃ k, n = p^k`           (the digit-sum-one characterization —
+        previously DELEGATED here and in the `p = 2` companion, now proven)
+  * `sub_one_mul_padicValNat_factorial_eq_pred_iff_isPow p n (hn : 1 ≤ n)` :
+        `(p-1)·v_p(n!) = n - 1 ⟺ ∃ k, n = p^k`  (maximality in fully-closed form:
+        `v_p(n!)` attains Legendre's ceiling exactly at the powers of `p`)
 
   ## The bridge
 
@@ -37,13 +45,15 @@
   The doubling recurrence is then a one-line cancellation of `p - 1 > 0` after
   observing `s_p(p·n + r) = s_p(n) + r` and `(p-1)·n + n = p·n`.
 
-  None of the five named results are Mathlib lemmas.
+  None of the named results are Mathlib lemmas.
 
   Bearer lemmas verified against the Mathlib pin `v4.26.0`:
   `sub_one_mul_padicValNat_factorial`,
   `sub_one_mul_padicValNat_factorial_lt_of_ne_zero`,
   `Nat.digits_def'`, `Nat.digit_sum_le`, `Nat.add_mul_mod_self_left`,
-  `Nat.mul_add_div`, `Nat.sub_one_mul`, `Nat.le_mul_of_pos_left`, `List.sum_cons`.
+  `Nat.mul_add_div`, `Nat.sub_one_mul`, `Nat.le_mul_of_pos_left`, `List.sum_cons`,
+  `Nat.digits_base_pow_mul`, `Nat.digits_of_lt`, `Nat.getLast_digit_ne_zero`,
+  `Nat.digits_ne_nil_iff_ne_zero`, `List.le_sum_of_mem`, `Nat.strong_induction_on`.
 -/
 
 import Mathlib
@@ -125,6 +135,90 @@ theorem sub_one_mul_padicValNat_factorial_eq_pred_iff
     omega
   rw [sub_one_mul_padicValNat_factorial n]
   omega
+
+/-- **Digit-sum positivity.** For `1 < p` and `m ≠ 0` the base-`p` digit sum is
+    positive.  The digit list of a nonzero `m` is nonempty and its top (last) digit
+    is nonzero (`Nat.getLast_digit_ne_zero`); since every digit is `≥ 0`, that
+    nonzero top digit is a lower bound for the whole sum. -/
+theorem digitSum_pos (p m : ℕ) (hp : 1 < p) (hm : m ≠ 0) :
+    0 < (Nat.digits p m).sum := by
+  have hne : Nat.digits p m ≠ [] := Nat.digits_ne_nil_iff_ne_zero.mpr hm
+  have hmem : (Nat.digits p m).getLast hne ∈ Nat.digits p m := List.getLast_mem hne
+  have hlast : (Nat.digits p m).getLast hne ≠ 0 := Nat.getLast_digit_ne_zero p hm
+  have hle : (Nat.digits p m).getLast hne ≤ (Nat.digits p m).sum := List.le_sum_of_mem hmem
+  omega
+
+/-- **The digit sum of a prime power is `1`.** In base `p`, `p^k` is a single
+    leading `1` followed by `k` trailing zeros (`Nat.digits_base_pow_mul` with the
+    unit part `m = 1`), so `s_p(p^k) = 1`.  This is the easy direction of the
+    digit-sum-one characterization. -/
+theorem digitSum_prime_pow (p k : ℕ) (hp : 1 < p) :
+    (Nat.digits p (p ^ k)).sum = 1 := by
+  have h := Nat.digits_base_pow_mul (b := p) (k := k) (m := 1) hp (by norm_num)
+  rw [Nat.mul_one] at h
+  rw [h, List.sum_append, Nat.digits_of_lt p 1 (by norm_num) hp]
+  simp
+
+/-- **Forward direction of the digit-sum-one characterization.** If the base-`p`
+    digit sum of `n` is `1` then `n` is a power of `p`.  Strong induction on `n`
+    via the left-shift law `s_p(p·q + r) = s_p(q) + r`: writing `n = p·(n/p) + n%p`
+    forces the low digit `n%p ∈ {0,1}`.  When `n%p = 1` the remaining digit sum is
+    `0`, so `n/p = 0` (`digitSum_pos`) and `n = 1 = p^0`; when `n%p = 0` the quotient
+    `n/p` again has digit sum `1` and, being smaller, is a power `p^j` by induction,
+    whence `n = p^{j+1}`. -/
+theorem isPow_of_digitSum_eq_one (p : ℕ) (hp : 1 < p) :
+    ∀ n, (Nat.digits p n).sum = 1 → ∃ k, n = p ^ k := by
+  intro n
+  induction n using Nat.strong_induction_on with
+  | _ n ih =>
+    intro hs
+    have hn0 : n ≠ 0 := by rintro rfl; simp at hs
+    have hrlt : n % p < p := Nat.mod_lt n (by omega)
+    have hdecomp : p * (n / p) + n % p = n := Nat.div_add_mod n p
+    -- `s_p(n) = s_p(n/p) + n%p`
+    have hsplit : (Nat.digits p (n / p)).sum + n % p = 1 := by
+      have hh := digitSum_prime_mul_add p (n / p) (n % p) hp hrlt
+      rw [hdecomp] at hh
+      rw [← hh]; exact hs
+    rcases Nat.eq_zero_or_pos (n % p) with hr0 | hrpos
+    · -- `n%p = 0`: `s_p(n/p) = 1`; recurse on the strictly smaller `n/p`.
+      rw [hr0, Nat.add_zero] at hsplit
+      have hlt : n / p < n := Nat.div_lt_self (by omega) hp
+      obtain ⟨j, hj⟩ := ih (n / p) hlt hsplit
+      have hnp : p * (n / p) = n := by rw [hr0] at hdecomp; simpa using hdecomp
+      exact ⟨j + 1, by rw [← hnp, hj, pow_succ]; ring⟩
+    · -- `n%p ≥ 1`: forces `n%p = 1` and `s_p(n/p) = 0`, so `n/p = 0` and `n = p^0`.
+      have hr1 : n % p = 1 := by omega
+      have hsum0 : (Nat.digits p (n / p)).sum = 0 := by omega
+      have hnp0 : n / p = 0 := by
+        by_contra hc
+        have := digitSum_pos p (n / p) hp hc
+        omega
+      exact ⟨0, by rw [pow_zero, ← hdecomp, hnp0, Nat.mul_zero, Nat.zero_add, hr1]⟩
+
+/-- **Digit-sum-one characterization (fills the delegated equivalence).** For every
+    base `1 < p`,
+        `s_p(n) = 1  ↔  ∃ k, n = p^k`,
+    i.e. a natural number has base-`p` digit sum `1` exactly when it is a power of
+    `p`.  This discharges the equivalence `s_p(n) = 1 ⟺ n = p^k` that the
+    maximality lemma `sub_one_mul_padicValNat_factorial_eq_pred_iff` (and its `p = 2`
+    Kummer companion) previously left delegated. -/
+theorem digitSum_eq_one_iff_isPow (p n : ℕ) (hp : 1 < p) :
+    (Nat.digits p n).sum = 1 ↔ ∃ k, n = p ^ k := by
+  constructor
+  · exact isPow_of_digitSum_eq_one p hp n
+  · rintro ⟨k, rfl⟩; exact digitSum_prime_pow p k hp
+
+/-- **Maximality of `v_p(n!)` ⟺ `n` is a power of `p`.** Combining the digit-sum
+    maximality characterization `sub_one_mul_padicValNat_factorial_eq_pred_iff` with
+    the now-proven `digitSum_eq_one_iff_isPow`: for `n ≥ 1`, Legendre's bound
+    `(p-1)·v_p(n!) ≤ n - 1` is attained with equality exactly when `n = p^k`.  This
+    is the fully-closed form of the maximality statement — no delegated step. -/
+theorem sub_one_mul_padicValNat_factorial_eq_pred_iff_isPow
+    (p n : ℕ) [hp : Fact p.Prime] (hn : 1 ≤ n) :
+    (p - 1) * padicValNat p n.factorial = n - 1 ↔ ∃ k, n = p ^ k := by
+  rw [sub_one_mul_padicValNat_factorial_eq_pred_iff p n hn,
+    digitSum_eq_one_iff_isPow p n hp.out.one_lt]
 
 /-- Sanity instance: `p = 2` doubling recurrence falls out of the general one. -/
 example (n : ℕ) :

--- a/research/problems/erdos-729-oq-02/knowledge.md
+++ b/research/problems/erdos-729-oq-02/knowledge.md
@@ -179,3 +179,35 @@ inequality without its equality/slack analysis.
 Only `barreto_leeham_theorem` (the deep Barreto–Leeham "NO" resolution) remains axiomatized
 in the parent — genuinely open/hard, not session-sized. The elementary 2-adic theory now
 covers both the bound (★) AND its exact carry-slack characterization.
+
+## Session 2026-07-11 (researcher-1) — filled the delegated digit-sum-one characterization
+
+**Mode**: ACT (SOLVED-side; executes the standing nextAction "prove s_p(n)=1 <-> n=p^k
+for general p"). The maximality lemma `sub_one_mul_padicValNat_factorial_eq_pred_iff`
+proved `(p-1)·v_p(n!) = n-1 ⟺ s_p(n)=1` but **explicitly delegated** the equivalence
+`s_p(n)=1 ⟺ n=p^k` (both here and in the p=2 Kummer companion). Closed that gap.
+
+**Added to `Erdos729LegendrePrimeRecurrence.lean` (5 theorems, VERIFIED 0-axiom
+`{propext, Classical.choice, Quot.sound}`, host `lake env lean` EXIT 0):**
+- `digitSum_pos` : `m≠0 → 0 < s_p(m)` — nonempty digit list + nonzero top digit
+  (`Nat.getLast_digit_ne_zero`) as a lower bound (`List.le_sum_of_mem`).
+- `digitSum_prime_pow` : `s_p(p^k)=1` — the easy ⟸ direction via
+  `Nat.digits_base_pow_mul` (m=1): `digits p (p^k) = replicate k 0 ++ [1]`.
+- `isPow_of_digitSum_eq_one` : the ⟹ direction, strong induction on n using the
+  file's own left-shift law `digitSum_prime_mul_add`: `n = p·(n/p)+n%p` forces the
+  low digit `n%p ∈ {0,1}`; `n%p=1` ⟹ s_p(n/p)=0 ⟹ n/p=0 (digitSum_pos) ⟹ n=p^0;
+  `n%p=0` ⟹ s_p(n/p)=1, recurse (n/p<n) ⟹ n=p^{j+1}.
+- `digitSum_eq_one_iff_isPow` : the full iff.
+- `sub_one_mul_padicValNat_factorial_eq_pred_iff_isPow` : capstone — maximality of
+  v_p(n!) now stated directly as `⟺ ∃k, n=p^k` (no delegated step).
+
+**Key API**: `Nat.digits_base_pow_mul hb hm : digits b (b^k * m) = replicate k 0 ++ digits b m`;
+`Nat.digits_of_lt p 1 _ hp : digits p 1 = [1]`; `List.le_sum_of_mem` (member ≤ sum in ℕ).
+**GOTCHA**: `rw [← hdecomp]` where `hdecomp : p*(n/p)+n%p = n` rewrites EVERY `n`
+(including inside `n/p`, `n%p`) — proving `p*(n/p)=n` this way loops. Instead
+`rw [hr0] at hdecomp; simpa using hdecomp`.
+
+### Terminus (unchanged)
+Only the deep `barreto_leeham_theorem` axiom in the parent remains. The elementary
+p-adic theory (Legendre, Kummer/multinomial carries, digit-sum recurrences, and now
+the digit-sum-one ↔ prime-power characterization) is complete and axiom-free.

--- a/src/data/research/problems/erdos-729-oq-02.json
+++ b/src/data/research/problems/erdos-729-oq-02.json
@@ -18,10 +18,10 @@
   "currentState": {
     "phase": "ACT",
     "since": "2026-04-05T23:54:18-07:00",
-    "iteration": 2,
-    "focus": "General-prime Legendre recurrences companion shipped (verified, 0-axiom): the p=2 doubling/digit-sum/maximality results lifted to every prime p.",
+    "iteration": 3,
+    "focus": "Filled the twice-delegated digit-sum-one characterization s_p(n)=1 <-> n=p^k (general prime p); the maximality lemma now closes to fully-explicit power-of-p form.",
     "blockers": [],
-    "nextAction": "Optional: prove s_p(n)=1 <-> n=p^k for general p (digit-sum-one characterization), or the dual Kummer-style carry count for v_p(C(m+n, n)) at general p.",
+    "nextAction": "Elementary p-adic theory is saturated (Legendre identity, general-p Kummer/multinomial carry theory, digit-sum recurrences, digit-sum-one characterization -- all axiom-free). Only the deep barreto_leeham_theorem axiom in the parent remains (open-question resolution, not session-sized).",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -127,8 +127,8 @@
     {
       "path": "Proofs/Erdos729LegendrePrimeRecurrence.lean",
       "filename": "Erdos729LegendrePrimeRecurrence.lean",
-      "lineCount": 136,
-      "theoremCount": 5,
+      "lineCount": 229,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,


### PR DESCRIPTION
## Summary

Erdős #729 OQ-02 (Legendre `v_p(n!) = (n − s_p(n))/(p−1)`). The general-prime
recurrence companion `Erdos729LegendrePrimeRecurrence.lean` proved the maximality
characterization

    (p−1)·v_p(n!) = n − 1  ⟺  s_p(n) = 1

but **explicitly delegated** the arithmetic equivalence `s_p(n) = 1 ⟺ n = p^k` (a
`TODO` shared with the `p = 2` Kummer companion). This PR fills that gap and closes
the maximality statement to fully-explicit power-of-`p` form.

## New theorems (all axiom-free)

- `digitSum_pos` — `m ≠ 0 → 0 < s_p(m)` (nonzero ⇒ positive digit sum).
- `digitSum_prime_pow` — `s_p(p^k) = 1` (easy ⟸: `Nat.digits_base_pow_mul` gives
  `digits p (p^k) = replicate k 0 ++ [1]`).
- `isPow_of_digitSum_eq_one` — the ⟹ direction, strong induction on `n` via the
  file's own left-shift law `digitSum_prime_mul_add`: `n = p·(n/p) + n%p` forces the
  low digit `n%p ∈ {0,1}`.
- `digitSum_eq_one_iff_isPow` — `s_p(n) = 1 ⟺ ∃ k, n = p^k`.
- `sub_one_mul_padicValNat_factorial_eq_pred_iff_isPow` — the capstone: `v_p(n!)`
  attains Legendre's ceiling `(p−1)·v_p(n!) = n − 1` exactly at the powers of `p`.

## Verification

`#print axioms` on all five reports `{propext, Classical.choice, Quot.sound}`
(axiom-free), compiled host-side via `lake env lean` against the prebuilt Mathlib
`v4.26.0` oleans. File 136→229 lines, 5→10 theorems, 0 axioms / 0 sorries.

Only the deep `barreto_leeham_theorem` axiom in the parent `Erdos729Problem.lean`
remains — the genuine open-question resolution, not session-sized.