### PR TITLE
research(burnside-counting-oq-02): necklace integrality + exact Burnside average [axiom-free]

### DIFF
--- a/proofs/Proofs/BurnsideCounting.lean
+++ b/proofs/Proofs/BurnsideCounting.lean
@@ -473,6 +473,29 @@ theorem sum_fixedBy_eq_card_necklaces_mul (n k : ℕ) [NeZero n] :
     _ = @Fintype.card (Quotient (@coloringSetoid n k _))
           (coloringQuotientFintype n k) * n := rfl
 
+/-- **Necklace integrality (Burnside divisibility).**  The total fixed-point sum
+    `∑_{a : ZMod n} |Fix(a)|` over the rotation group is divisible by the group
+    order `n`.  Immediate from the Burnside engine
+    `sum_fixedBy_eq_card_necklaces_mul` (the sum equals `|necklaces| · n`).  This is
+    the general reason every concrete necklace count in this file comes out an
+    integer: the averaged Burnside quotient `(∑ |Fix|)/n` is *exact*, never a
+    truncated division. -/
+theorem card_group_dvd_sum_fixedBy (n k : ℕ) [NeZero n] :
+    n ∣ ∑ a : ZMod n, Fintype.card { c : Coloring n k // IsFixedByRotation a c } := by
+  rw [sum_fixedBy_eq_card_necklaces_mul n k]
+  exact dvd_mul_left n _
+
+/-- **Burnside average (exact form).**  The number of `k`-colored cyclic necklaces
+    of length `n` is exactly the average of the fixed-point counts over the rotation
+    group: `|necklaces| = (∑_{a} |Fix(a)|) / n`, an *exact* natural-number division
+    (no truncation, thanks to `card_group_dvd_sum_fixedBy`).  This is Burnside's
+    lemma in the necklace setting, solved for the orbit count — the general form of
+    the concrete `(8+2+2)/3 = 4` and `(16+2+4+2)/4 = 6` evaluations below. -/
+theorem card_necklaces_eq_sum_fixedBy_div (n k : ℕ) [NeZero n] :
+    @Fintype.card (Quotient (@coloringSetoid n k _)) (coloringQuotientFintype n k)
+      = (∑ a : ZMod n, Fintype.card { c : Coloring n k // IsFixedByRotation a c }) / n := by
+  rw [sum_fixedBy_eq_card_necklaces_mul n k, Nat.mul_div_cancel _ (NeZero.pos n)]
+
 /-- The fixed-point sum for binary 3-necklaces.
     - |Fix(0)| = 8 (identity fixes all `2^3` colorings)
     - |Fix(1)| = 2 (only the two constant colorings have period 1)

--- a/src/data/research/problems/burnside-counting-oq-02.json
+++ b/src/data/research/problems/burnside-counting-oq-02.json
@@ -46,12 +46,14 @@
       "fixed_point_sum_binary_4 (BurnsideCounting.lean:349): theorem (formerly axiom) — sum of |Fix(r)| over r in {0,1,2,3} of Coloring 4 2 equals 24, closed by native_decide on the decidable IsFixedByRotation subtype cardinalities.",
       "polya_cyclic_fixed_count (BurnsideCountingOQ03.lean:184): general theorem that the cyclic fixed-coloring count for rotation r is k^gcd(r,n).",
       "fp_sum_binary4 / polya_sum_Z4_binary (BurnsideCountingOQ03.lean:253,265): the binary length-4 fixed-point sum equals 24 in both subtype-cardinality and divisor-sum 2^gcd(r,4) forms.",
-      "polya_binary4_necklace_count (BurnsideCountingOQ03.lean:374): the Burnside/Polya count (sum 2^gcd(r,4))/4 = 6 distinct binary 4-necklaces."
+      "polya_binary4_necklace_count (BurnsideCountingOQ03.lean:374): the Burnside/Polya count (sum 2^gcd(r,4))/4 = 6 distinct binary 4-necklaces.",
+      "BurnsideCounting.card_group_dvd_sum_fixedBy (0-axiom): necklace integrality n | sum_a |Fix(a)| for k-colored cyclic necklaces of length n, general in (n,k) — from the engine sum_fixedBy_eq_card_necklaces_mul. BurnsideCounting.card_necklaces_eq_sum_fixedBy_div (0-axiom): exact Burnside average |necklaces| = (sum_a |Fix(a)|)/n, the general form of the concrete (8+2+2)/3=4 and (16+2+4+2)/4=6 evaluations."
     ],
     "insights": [
       "Both framings of this problem are already resolved in main: the parent native_decide discharge (oq-01 S3) and the OQ03 Polya divisor-sum theorems. Verification, not new proof, was the remaining work.",
       "The headline necklace count never required bridging Mathlib's multiplicative burnside_lemma to the additive ZMod n action: once IsFixedByRotation/the orbit relation are decidable, both the fixed-point sum and the 6-necklace count collapse to native_decide (BurnsideCounting.lean) or explicit Fin-sum evaluation (BurnsideCountingOQ03.lean).",
-      "native_decide closes the two finite counts at the cost of the Lean.ofReduceBool axiom (compiler-trusted, not kernel-reduced); the divisor-sum identity polya_sum_Z4_binary in OQ03 is an alternative kernel-checked route to the same value 24."
+      "native_decide closes the two finite counts at the cost of the Lean.ofReduceBool axiom (compiler-trusted, not kernel-reduced); the divisor-sum identity polya_sum_Z4_binary in OQ03 is an alternative kernel-checked route to the same value 24.",
+      "The Burnside engine sum_fixedBy_eq_card_necklaces_mul (sum |Fix(a)| = |necklaces|*n) gives necklace integrality n | sum |Fix(a)| as a one-liner (dvd_mul_left) and the exact Burnside average |necklaces| = (sum |Fix(a)|)/n via Nat.mul_div_cancel — the general statements behind every concrete /n necklace count in the cluster, previously only used implicitly per-case."
     ],
     "mathlibGaps": [],
     "nextSteps": [
@@ -95,15 +97,15 @@
     "mathlib": []
   },
   "started": "2026-04-03T15:38:25.652Z",
-  "lastUpdate": "2026-04-03T15:38:25.669Z",
+  "lastUpdate": "2026-07-11T00:00:00.000Z",
   "significance": 6,
   "tractability": 8,
   "leanFiles": [
     {
       "path": "Proofs/BurnsideCounting.lean",
       "filename": "BurnsideCounting.lean",
-      "lineCount": 671,
-      "theoremCount": 18,
+      "lineCount": 715,
+      "theoremCount": 22,
       "axiomCount": 0,
       "defCount": 8,
       "sorryCount": 0,


### PR DESCRIPTION
## Summary

The Burnside engine `sum_fixedBy_eq_card_necklaces_mul` in `BurnsideCounting.lean` proves `∑_{a:ZMod n} |Fix(a)| = |necklaces| · n`, but the cluster only ever consumed it *per-case* (the concrete `(8+2+2)/3 = 4` and `(16+2+4+2)/4 = 6` necklace evaluations). Two general consequences it implies were never stated:

- **`card_group_dvd_sum_fixedBy`** — necklace integrality: `n ∣ ∑_a |Fix(a)|`, general in `(n,k)`. This is the general reason every concrete necklace count comes out an integer — the Burnside quotient `(∑|Fix|)/n` is *exact*, never a truncated division.
- **`card_necklaces_eq_sum_fixedBy_div`** — the exact Burnside average: `|necklaces| = (∑_a |Fix(a)|)/n`, Burnside's lemma solved for the orbit count; the general form of the concrete divisions.

## Verification
- Compiles clean on Lean 4.26.0 / current Mathlib (only pre-existing linter warnings).
- Both new theorems verified axiom-free: `#print axioms` reports only `[propext, Classical.choice, Quot.sound]` (no `ofReduceBool`, no `sorryAx`).
- File remains 0-axiom, 0-sorry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)