### PR TITLE
research(basel-oq-01-oq-02): subtraction family for even-zeta transcendence

### DIFF
--- a/proofs/Proofs/BaselProblemOQ01OQ02.lean
+++ b/proofs/Proofs/BaselProblemOQ01OQ02.lean
@@ -558,6 +558,73 @@ theorem zeta_two_sq_add_zeta_two_transcendental :
   have h := zeta_even_aeval_transcendental 1 one_pos (Polynomial.X ^ 2 + Polynomial.X) hf
   simpa using h
 
+/-- **Differences of two distinct even zeta values are transcendental over ℚ.**
+
+    The subtractive companion of `zeta_even_add_transcendental`.  For `m < n`,
+    `ζ(2n) − ζ(2m) = qₙ·π^(2n) − qₘ·π^(2m) = qₙ·π^(2n) + (−qₘ)·π^(2m)` is a *nonconstant* rational
+    polynomial in π: writing the lower term with coefficient `−qₘ ≠ 0` keeps both π-powers present
+    with distinct even degrees `2n > 2m`, so nothing collapses it to a monomial or a constant.  Hence
+    it is transcendental over ℚ by the master engine `transcendental_aeval_pi`.  Concretely
+    `ζ(4) − ζ(2) = π⁴/90 − π²/6`, `ζ(6) − ζ(2)`, … are all transcendental.
+
+    Together with `zeta_even_add_transcendental` this closes the two-distinct-value ± frontier:
+    both the sum and the difference of any two even zeta values escape the single-π-power class
+    `ℚ∖{0}·π^(even)` and require the full polynomial engine.
+
+    **Assumption:** `hermite_lindemann` (transcendence of π). -/
+theorem zeta_even_sub_transcendental (n m : ℕ) (hm : 0 < m) (hmn : m < n) :
+    Transcendental ℚ
+      ((∑' k : ℕ, 1 / (k : ℝ) ^ (2 * n)) - (∑' k : ℕ, 1 / (k : ℝ) ^ (2 * m))) := by
+  obtain ⟨qn, hqn, hqn_eq⟩ := zeta_even_eq_rat_mul_pi_pow n (by omega)
+  obtain ⟨qm, hqm, hqm_eq⟩ := zeta_even_eq_rat_mul_pi_pow m hm
+  have hqmneg : (-qm) ≠ 0 := neg_ne_zero.mpr hqm
+  -- The two-term polynomial qₙ·X^(2n) + (−qₘ)·X^(2m); evaluating at π gives the difference.
+  set p : Polynomial ℚ :=
+    Polynomial.C qn * Polynomial.X ^ (2 * n) + Polynomial.C (-qm) * Polynomial.X ^ (2 * m) with hp
+  have hdeg_left : (Polynomial.C qn * Polynomial.X ^ (2 * n)).natDegree = 2 * n :=
+    Polynomial.natDegree_C_mul_X_pow (2 * n) qn hqn
+  have hdeg_right : (Polynomial.C (-qm) * Polynomial.X ^ (2 * m)).natDegree = 2 * m :=
+    Polynomial.natDegree_C_mul_X_pow (2 * m) (-qm) hqmneg
+  have hlt : (Polynomial.C (-qm) * Polynomial.X ^ (2 * m)).natDegree
+      < (Polynomial.C qn * Polynomial.X ^ (2 * n)).natDegree := by
+    rw [hdeg_left, hdeg_right]; omega
+  have hpne : p.natDegree ≠ 0 := by
+    rw [hp, Polynomial.natDegree_add_eq_left_of_natDegree_lt hlt, hdeg_left]; omega
+  -- aeval π p is exactly ζ(2n) − ζ(2m).
+  have haeval : Polynomial.aeval π p
+      = (∑' k : ℕ, 1 / (k : ℝ) ^ (2 * n)) - (∑' k : ℕ, 1 / (k : ℝ) ^ (2 * m)) := by
+    rw [hqn_eq, hqm_eq, hp]
+    simp only [map_add, map_mul, map_pow, Polynomial.aeval_C, Polynomial.aeval_X, map_neg,
+      eq_ratCast]
+    ring
+  rw [← haeval]
+  exact transcendental_aeval_pi p hpne
+
+/-- **ζ(4) − ζ(2) = π⁴/90 − π²/6 is transcendental over ℚ** — a concrete two-term difference. -/
+theorem zeta_four_sub_zeta_two_transcendental :
+    Transcendental ℚ ((∑' k : ℕ, 1 / (k : ℝ) ^ 4) - (∑' k : ℕ, 1 / (k : ℝ) ^ 2)) := by
+  have := zeta_even_sub_transcendental 2 1 one_pos (by norm_num)
+  simpa using this
+
+/-- **Subtracting a rational preserves transcendence over ℚ — axiom-free.**  The subtractive
+    companion of `transcendental_add_ratCast`: if `x` is transcendental over ℚ then so is `x − q`
+    for every `q ∈ ℚ`, since `x = (x − q) + q` would otherwise be a sum of algebraics.  Immediate
+    from `transcendental_add_ratCast` applied to `−q`. -/
+theorem transcendental_sub_ratCast {x : ℝ} (hx : Transcendental ℚ x) (q : ℚ) :
+    Transcendental ℚ (x - (q : ℝ)) := by
+  have h := transcendental_add_ratCast hx (-q)
+  simpa [sub_eq_add_neg, Rat.cast_neg] using h
+
+/-- **Rational shifts (by subtraction) of even zeta values are transcendental over ℚ.**  For `n ≥ 1`
+    and any `q ∈ ℚ`, `ζ(2n) − q` is transcendental — the subtractive analogue of
+    `zeta_even_add_ratCast_transcendental`.  Immediate from `zeta_even_transcendental` and the
+    axiom-free shift engine `transcendental_sub_ratCast`.
+
+    **Assumption:** `hermite_lindemann` (transcendence of π). -/
+theorem zeta_even_sub_ratCast_transcendental (n : ℕ) (hn : 0 < n) (q : ℚ) :
+    Transcendental ℚ ((∑' k : ℕ, 1 / (k : ℝ) ^ (2 * n)) - (q : ℝ)) :=
+  transcendental_sub_ratCast (zeta_even_transcendental n hn) q
+
 /-!
 ## The open odd case (documentation only)
 

--- a/src/data/proofs/basel-problem-oq-01-oq-02/meta.json
+++ b/src/data/proofs/basel-problem-oq-01-oq-02/meta.json
@@ -67,10 +67,10 @@
       "REPAIR: zeta_even_weighted_prod_eq_rat_mul_pi_pow was committed [UNVERIFIED] (#37361) with a double-counted exponent (coefficient qa^(g a) instead of qa, since zeta_even_pow_eq_rat_mul_pi_pow already absorbs the g a power) — the file did not compile on Mathlib 4.26.0. Fixed to qa; whole file now compiles and is axiom-clean (single hermite_lindemann assumption)."
     ],
     "dateAdded": "2026-07-02",
-    "lineCount": 533,
+    "lineCount": 637,
     "assumptions": "Depends on the axiom hermite_lindemann (Lindemann–Weierstrass theorem, giving transcendence of π), imported via Proofs.PiTranscendental. Mathlib does not yet contain a complete Lindemann–Weierstrass development, and irrationality of π^(2n) provably requires transcendence of π (irrational_pi alone is insufficient, as irrationality does not lift through powers). Everything else is machine-checked with 0 sorries.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 30,
+    "theoremCount": 36,
     "definitionCount": 0
   },
   "overview": {
@@ -168,9 +168,9 @@
       "Real"
     ],
     "namespace": "BaselProblemOQ01OQ02",
-    "lineCount": 570,
+    "lineCount": 637,
     "axiomCount": 0,
-    "theoremCount": 32,
+    "theoremCount": 36,
     "definitionCount": 0,
     "path": "Proofs/BaselProblemOQ01OQ02.lean",
     "sorries": 0

--- a/src/data/research/problems/basel-problem-oq-01-oq-02.json
+++ b/src/data/research/problems/basel-problem-oq-01-oq-02.json
@@ -30,8 +30,8 @@
   "currentState": {
     "phase": "COMPLETE",
     "since": "2026-07-01T07:00:00-07:00",
-    "iteration": 3,
-    "focus": "Strengthened even-zeta irrationality to transcendence over ℚ (zeta_even_transcendental), reusing hermite_lindemann. Slug saturated on the provable side; odd case remains open.",
+    "iteration": 4,
+    "focus": "Extended the transcendence toolkit with the SUBTRACTION family, mirroring the existing add family: zeta_even_sub_transcendental (ζ(2n)−ζ(2m) transcendental for m<n, two-term π-polynomial via C(−qm) coeff), zeta_four_sub_zeta_two_transcendental (concrete), transcendental_sub_ratCast (axiom-free x−q engine, companion of transcendental_add_ratCast), and zeta_even_sub_ratCast_transcendental (ζ(2n)−q). Together with the add family this closes the two-distinct-value ± frontier. No new axioms (transcendence results carry only hermite_lindemann; the ratCast engine is 0-axiom). File 570→637L, 32→36 thm.",
     "blockers": [
       "Mathematical: odd zeta irrationality is open (no known proof for ζ(2n+1), n≥2; Apéry's ζ(3) not in Mathlib).",
       "Formal: no 0-axiom route to Irrational(π^n); even-case irrationality capped at 'axiomatized' via hermite_lindemann."
@@ -53,7 +53,8 @@
       "zeta_four_hasSum : HasSum (fun n => 1/n^4) (pi^4/90) via hasSum_zeta_four.",
       "zeta_general : for k != 0, HasSum (fun n => 1/n^(2k)) to the Bernoulli-number closed form via hasSum_zeta_nat.",
       "zeta_even_transcendental : for n≥1, Transcendental ℚ (∑' k, 1/k^(2n)) — every even zeta value is transcendental over ℚ (strictly stronger than irrational); nonzero-rational scaling preserves transcendence. Plus concrete zeta_two_transcendental. (researcher-3, 2026-07-08, axiomatized on hermite_lindemann)",
-      "Axiom-free ratio skeleton (2026-07-09 researcher-2, VERIFIED): zeta_even_ratio_eq_rat_mul_pi_pow — ζ(2n)/ζ(2m)=q·π^(2(n-m)) (0-axiom, even zetas multiplicatively π-power-incommensurable over ℚ), the unconditional structure beneath zeta_even_ratio_transcendental; refactored the latter to use it. 221→235L, 11→12 thm. Docker Build succeeded 3153 jobs (attempt 4)."
+      "Axiom-free ratio skeleton (2026-07-09 researcher-2, VERIFIED): zeta_even_ratio_eq_rat_mul_pi_pow — ζ(2n)/ζ(2m)=q·π^(2(n-m)) (0-axiom, even zetas multiplicatively π-power-incommensurable over ℚ), the unconditional structure beneath zeta_even_ratio_transcendental; refactored the latter to use it. 221→235L, 11→12 thm. Docker Build succeeded 3153 jobs (attempt 4).",
+      "BaselProblemOQ01OQ02.lean (researcher-6, 2026-07-11): subtraction family completing the ± frontier — zeta_even_sub_transcendental (ζ(2n)−ζ(2m), m<n; polynomial C qn·X^2n + C(−qm)·X^2m, natDegree 2n≠0 via natDegree_add_eq_left_of_natDegree_lt, aeval via map_neg+eq_ratCast+ring), zeta_four_sub_zeta_two_transcendental, transcendental_sub_ratCast (axiom-free, via transcendental_add_ratCast(−q)), zeta_even_sub_ratCast_transcendental. 3 carry only hermite_lindemann, engine is 0-axiom; VERIFIED green lake env lean v4.26.0."
     ],
     "insights": [
       "The odd-zeta question asked by this slug is OPEN; it cannot be closed, only framed/contrasted with the even case.",
@@ -134,7 +135,7 @@
     "mathlib": []
   },
   "started": "2026-03-30T18:39:05.244Z",
-  "lastUpdate": "2026-07-01T14:00:00.000Z",
+  "lastUpdate": "2026-07-11T01:45:00Z",
   "leanFiles": [
     {
       "path": "Proofs/BaselProblem.lean",


### PR DESCRIPTION
## Summary

Completes the **± frontier** of the π/ζ transcendence theory in `BaselProblemOQ01OQ02.lean`. The file already had a full *additive* family (`zeta_even_add_transcendental`, `transcendental_add_ratCast`, `zeta_even_add_ratCast_transcendental`) but no subtraction companions. This PR adds the mirror:

- `zeta_even_sub_transcendental` — `ζ(2n) − ζ(2m)` is transcendental over ℚ for `m < n`. The difference is the two-term rational π-polynomial `C qn·X^(2n) + C(−qm)·X^(2m)`, which stays nonconstant (`−qm ≠ 0`, distinct even degrees `2n > 2m`), so it is transcendental by the master engine `transcendental_aeval_pi`.
- `zeta_four_sub_zeta_two_transcendental` — concrete `ζ(4) − ζ(2) = π⁴/90 − π²/6`.
- `transcendental_sub_ratCast` — **axiom-free** `x − q` engine (subtractive companion of `transcendental_add_ratCast`, via the `−q` shift).
- `zeta_even_sub_ratCast_transcendental` — `ζ(2n) − q` transcendental.

Together with the existing add family, both the **sum and the difference** of any two distinct even zeta values are now known transcendental — each escapes the single-π-power class `ℚ∖{0}·π^(even)` and requires the full polynomial engine.

## Verification

- Compiled green via `lake env lean` (Lean v4.26.0) in the worktree.
- **No new axioms.** `#print axioms`: the three transcendence results depend only on the file's existing `HermiteLindemann.hermite_lindemann` (plus `propext, Classical.choice, Quot.sound`); `transcendental_sub_ratCast` is fully axiom-free.
- File 570 → 637 lines, 32 → 36 theorems. Metadata (`meta.json`, research problem JSON) resynced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)