### PR TITLE
Enrich: fix Real.sqrt algebraic lemmas mis-filed under Analysis.SpecialFunctions.Sqrt (34 entries)

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-02-oq-04/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-02-oq-04/meta.json
@@ -24,12 +24,12 @@
       {
         "theorem": "Real.sqrt_le_sqrt",
         "description": "Monotonicity of the square root, used to pass from e₂/3 ≤ (e₁/3)² to √(e₂/3) ≤ e₁/3 in the M₁ ≥ M₂ step",
-        "module": "Mathlib.Analysis.SpecialFunctions.Sqrt"
+        "module": "Mathlib.Data.Real.Sqrt"
       },
       {
         "theorem": "Real.sqrt_sq",
         "description": "For x ≥ 0, √(x²) = x, collapsing √((e₁/3)²) to e₁/3",
-        "module": "Mathlib.Analysis.SpecialFunctions.Sqrt"
+        "module": "Mathlib.Data.Real.Sqrt"
       },
       {
         "theorem": "Real.sqrt_eq_rpow",

--- a/src/data/proofs/amgm-inequality-oq-04-oq-04/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-04-oq-04/meta.json
@@ -25,12 +25,12 @@
       {
         "theorem": "Real.sqrt_mul / Real.sq_sqrt",
         "description": "√(ab) = √a·√b and (√a)² = a for a ≥ 0, used to expand the geometric mean",
-        "module": "Mathlib.Analysis.SpecialFunctions.Sqrt"
+        "module": "Mathlib.Data.Real.Sqrt"
       },
       {
         "theorem": "Real.sqrt_le_sqrt / Real.sqrt_pos",
         "description": "Monotonicity and positivity of √, used for the squaring bound",
-        "module": "Mathlib.Analysis.SpecialFunctions.Sqrt"
+        "module": "Mathlib.Data.Real.Sqrt"
       },
       {
         "theorem": "pow_succ / pow_mul",

--- a/src/data/proofs/area-of-circle-oq-07-oq-05-oq-01-oq-02/meta.json
+++ b/src/data/proofs/area-of-circle-oq-07-oq-05-oq-01-oq-02/meta.json
@@ -113,7 +113,7 @@
       {
         "theorem": "Real.sq_sqrt",
         "description": "(√a)² = a for a ≥ 0, used to identify (√a·x)^{2n} = aⁿ x^{2n} and (√a·x)² = a x² after the substitution.",
-        "module": "Mathlib.Analysis.SpecialFunctions.Sqrt"
+        "module": "Mathlib.Data.Real.Sqrt"
       },
       {
         "theorem": "Real.sqrt_div",

--- a/src/data/proofs/beta-integral-recurrence-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/beta-integral-recurrence-oq-01-oq-01-oq-01/meta.json
@@ -188,7 +188,7 @@
       {
         "theorem": "Real.mul_self_sqrt",
         "description": "√x·√x = x for 0 ≤ x; used (with Real.sqrt_mul and Real.sqrt_sq) in the Wallis-ratio collapse to eliminate the square roots.",
-        "module": "Mathlib.Analysis.SpecialFunctions.Sqrt"
+        "module": "Mathlib.Data.Real.Sqrt"
       }
     ],
     "verificationNote": "Proof written and rigorously verified offline against Mathlib source (every lemma name, signature, and type checked); 0 sorries and 0 axioms by construction. NOT machine-checked locally because the Docker build daemon was unavailable during this session (build infrastructure outage). Requires a clean `docker-build.sh Proofs.BetaCentralBinomialAsymptotic` (CI / deployer) to confirm before merge."

--- a/src/data/proofs/beta-integral-recurrence-oq-01-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/beta-integral-recurrence-oq-01-oq-02-oq-01-oq-01/meta.json
@@ -68,12 +68,12 @@
       {
         "theorem": "Real.mul_self_sqrt",
         "description": "√a·√a = a for 0 ≤ a, used to reduce √(πn) and √n to their radicands when matching the two normalizations.",
-        "module": "Mathlib.Analysis.SpecialFunctions.Sqrt"
+        "module": "Mathlib.Data.Real.Sqrt"
       },
       {
         "theorem": "Real.sq_sqrt",
         "description": "(√a)² = a for 0 ≤ a, the final square-root elimination after field_simp in the equivalence ratio.",
-        "module": "Mathlib.Analysis.SpecialFunctions.Sqrt"
+        "module": "Mathlib.Data.Real.Sqrt"
       }
     ]
   },

--- a/src/data/proofs/buffons-needle-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/buffons-needle-oq-01-oq-02-oq-01/meta.json
@@ -39,7 +39,7 @@
       {
         "theorem": "Real.sq_sqrt",
         "description": "(√a)² = a for a ≥ 0, collapsing the (√π)² product",
-        "module": "Mathlib.Analysis.SpecialFunctions.Sqrt"
+        "module": "Mathlib.Data.Real.Sqrt"
       },
       {
         "theorem": "Real.pi_pos",

--- a/src/data/proofs/buffons-needle-oq-01-oq-04/meta.json
+++ b/src/data/proofs/buffons-needle-oq-01-oq-04/meta.json
@@ -45,7 +45,7 @@
       {
         "theorem": "Real.sqrt_sq",
         "description": "√(a²) = a for a ≥ 0",
-        "module": "Mathlib.Analysis.SpecialFunctions.Sqrt"
+        "module": "Mathlib.Data.Real.Sqrt"
       },
       {
         "theorem": "intervalIntegral.integral_const",

--- a/src/data/proofs/buffons-needle-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/buffons-needle-oq-02-oq-01-oq-01/meta.json
@@ -47,7 +47,7 @@
       {
         "theorem": "Real.mul_self_sqrt",
         "description": "√π·√π = π, used to evaluate the base case gammaForm 2 = 2/π",
-        "module": "Mathlib.Analysis.SpecialFunctions.Sqrt"
+        "module": "Mathlib.Data.Real.Sqrt"
       }
     ],
     "originalContributions": [

--- a/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-03-oq-02/meta.json
+++ b/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-03-oq-02/meta.json
@@ -39,7 +39,7 @@
       {
         "theorem": "Real.sqrt_sq",
         "description": "√(x²) = x for x ≥ 0, used in the strict WAM < WQM bound and the collapse value of WQM",
-        "module": "Mathlib.Analysis.SpecialFunctions.Sqrt"
+        "module": "Mathlib.Data.Real.Sqrt"
       },
       {
         "theorem": "Real.div_rpow",

--- a/src/data/proofs/cauchy-schwarz-oq-02-oq-04-oq-02/meta.json
+++ b/src/data/proofs/cauchy-schwarz-oq-02-oq-04-oq-02/meta.json
@@ -39,7 +39,7 @@
       {
         "theorem": "Real.sqrt_le_sqrt",
         "description": "Monotonicity of √: reduces the triangle inequality and the √-form Cauchy-Schwarz to inequalities between the squared quantities.",
-        "module": "Mathlib.Analysis.SpecialFunctions.Sqrt"
+        "module": "Mathlib.Data.Real.Sqrt"
       },
       {
         "theorem": "real_inner_smul_left",

--- a/src/data/proofs/cevas-theorem-non-euclidean-oq-01/meta.json
+++ b/src/data/proofs/cevas-theorem-non-euclidean-oq-01/meta.json
@@ -31,7 +31,7 @@
       {
         "theorem": "Real.sqrt_pos / Real.sqrt_one",
         "description": "√κ > 0 for κ > 0, and √1 = 1 (curvature normalization)",
-        "module": "Mathlib.Analysis.SpecialFunctions.Sqrt"
+        "module": "Mathlib.Data.Real.Sqrt"
       },
       {
         "theorem": "ceva_unified_principle (parent)",

--- a/src/data/proofs/cevas-theorem-oq-02-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/cevas-theorem-oq-02-oq-01-oq-02-oq-01/meta.json
@@ -30,7 +30,7 @@
       {
         "theorem": "Real.sqrt_pos",
         "description": "0 < √x ↔ 0 < x, used to show the spherical/hyperbolic factors √(1−m²)/n and √(m²−1)/n are nonzero",
-        "module": "Mathlib.Analysis.SpecialFunctions.Sqrt"
+        "module": "Mathlib.Data.Real.Sqrt"
       }
     ],
     "originalContributions": [

--- a/src/data/proofs/chebyshev-pnt-bridge-oq-05-oq-01/meta.json
+++ b/src/data/proofs/chebyshev-pnt-bridge-oq-05-oq-01/meta.json
@@ -28,7 +28,7 @@
       {
         "theorem": "Real.sqrt_le_sqrt / Real.sqrt_sq",
         "description": "monotonicity of √ and √(a²) = a; turn the polynomial bounds √m ≤ m and √(m+1) ≤ m/8 into the m/log m normalization",
-        "module": "Mathlib.Analysis.SpecialFunctions.Sqrt"
+        "module": "Mathlib.Data.Real.Sqrt"
       },
       {
         "theorem": "Real.log_two_gt_d9",

--- a/src/data/proofs/de-moivre-oq-05-oq-01-oq-01-oq-01-oq-03-oq-01/meta.json
+++ b/src/data/proofs/de-moivre-oq-05-oq-01-oq-01-oq-01-oq-03-oq-01/meta.json
@@ -182,7 +182,7 @@
       {
         "theorem": "Real.mul_self_sqrt",
         "description": "0 ≤ a → √a · √a = a; cancels the two 1/√n normalisation factors of U into a single 1/n in the entry of U²",
-        "module": "Mathlib.Analysis.SpecialFunctions.Sqrt"
+        "module": "Mathlib.Data.Real.Sqrt"
       },
       {
         "theorem": "Matrix.mul_apply",

--- a/src/data/proofs/de-moivre-oq-05-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/de-moivre-oq-05-oq-01-oq-01-oq-01/meta.json
@@ -44,12 +44,12 @@
       {
         "theorem": "Real.mul_self_sqrt",
         "description": "0 ≤ a → √a · √a = a; cancels the two 1/√n normalisation factors into a single 1/n",
-        "module": "Mathlib.Analysis.SpecialFunctions.Sqrt"
+        "module": "Mathlib.Data.Real.Sqrt"
       },
       {
         "theorem": "Real.sq_sqrt",
         "description": "0 ≤ a → (√a)² = a; turns ‖(√n:ℂ)‖² into n in the energy computation",
-        "module": "Mathlib.Analysis.SpecialFunctions.Sqrt"
+        "module": "Mathlib.Data.Real.Sqrt"
       },
       {
         "theorem": "Complex.conj_ofReal",

--- a/src/data/proofs/dirichlets-theorem-oq-01-oq-01-oq-04/meta.json
+++ b/src/data/proofs/dirichlets-theorem-oq-01-oq-01-oq-04/meta.json
@@ -26,7 +26,7 @@
       {
         "theorem": "Real.sqrt_pos",
         "description": "0 < Real.sqrt x ↔ 0 < x",
-        "module": "Mathlib.Analysis.SpecialFunctions.Sqrt"
+        "module": "Mathlib.Data.Real.Sqrt"
       },
       {
         "theorem": "le_of_mul_le_mul_left",

--- a/src/data/proofs/erdos-100-oq-05-oq-01-oq-01/meta.json
+++ b/src/data/proofs/erdos-100-oq-05-oq-01-oq-01/meta.json
@@ -30,7 +30,7 @@
       {
         "theorem": "Real.sqrt_sq",
         "description": "0 ≤ a → √(a ^ 2) = a. Finishes each distance computation once the sum of squared coordinate differences is written as k² (e.g. 289 = 17²), yielding dist = k.",
-        "module": "Mathlib.Analysis.SpecialFunctions.Sqrt"
+        "module": "Mathlib.Data.Real.Sqrt"
       },
       {
         "theorem": "Matrix.det_succ_row_zero",

--- a/src/data/proofs/erdos-100-oq-05-oq-01/meta.json
+++ b/src/data/proofs/erdos-100-oq-05-oq-01/meta.json
@@ -30,7 +30,7 @@
       {
         "theorem": "Real.sqrt_sq",
         "description": "0 ≤ a → √(a ^ 2) = a. Finishes each distance computation once the sum of squared coordinate differences is written as k² (e.g. 121 = 11²), yielding dist = k.",
-        "module": "Mathlib.Analysis.SpecialFunctions.Sqrt"
+        "module": "Mathlib.Data.Real.Sqrt"
       },
       {
         "theorem": "Matrix.linearIndependent_rows_of_det_ne_zero",

--- a/src/data/proofs/erdos-100-oq-05/meta.json
+++ b/src/data/proofs/erdos-100-oq-05/meta.json
@@ -30,7 +30,7 @@
       {
         "theorem": "Real.sqrt_sq",
         "description": "0 ≤ a → √(a ^ 2) = a. Finishes each distance computation once the sum of squared coordinate differences is rewritten as k² (e.g. 36 = 6²), yielding dist = k.",
-        "module": "Mathlib.Analysis.SpecialFunctions.Sqrt"
+        "module": "Mathlib.Data.Real.Sqrt"
       },
       {
         "theorem": "Matrix.linearIndependent_rows_of_det_ne_zero",

--- a/src/data/proofs/erdos-1004-oq-02/meta.json
+++ b/src/data/proofs/erdos-1004-oq-02/meta.json
@@ -45,7 +45,7 @@
       {
         "theorem": "Real.sqrt_sq",
         "description": "√(x²) = x for x ≥ 0 — used to read the integer bound n ≤ 2φ(n)² as the real-analytic √(n/2) ≤ φ(n)",
-        "module": "Mathlib.Analysis.SpecialFunctions.Sqrt"
+        "module": "Mathlib.Data.Real.Sqrt"
       }
     ],
     "originalContributions": [

--- a/src/data/proofs/erdos-214-incomplete-01-oq-01/meta.json
+++ b/src/data/proofs/erdos-214-incomplete-01-oq-01/meta.json
@@ -30,7 +30,7 @@
       {
         "theorem": "Real.sq_sqrt",
         "description": "(√x)² = x for x ≥ 0 — used both for (√2)² = 2 and to square the distance equation back to its radicand",
-        "module": "Mathlib.Analysis.SpecialFunctions.Sqrt"
+        "module": "Mathlib.Data.Real.Sqrt"
       }
     ],
     "originalContributions": [

--- a/src/data/proofs/erdos-mordell-inequality-oq-01/meta.json
+++ b/src/data/proofs/erdos-mordell-inequality-oq-01/meta.json
@@ -37,7 +37,7 @@
       {
         "theorem": "Real.sqrt_sq",
         "description": "√(a²) = a for 0 ≤ a (collapses the chord √ to PA·sin A in the assembly lemma)",
-        "module": "Mathlib.Analysis.SpecialFunctions.Sqrt"
+        "module": "Mathlib.Data.Real.Sqrt"
       }
     ],
     "dateAdded": "2026-06-18",

--- a/src/data/proofs/gelfond-schneider-oq-01/meta.json
+++ b/src/data/proofs/gelfond-schneider-oq-01/meta.json
@@ -48,7 +48,7 @@
       {
         "theorem": "Real.sq_sqrt",
         "description": "(√x)² = x for x ≥ 0 — verifies √2 is a root of X² − 2, supplying the algebraic coefficient.",
-        "module": "Mathlib.Analysis.SpecialFunctions.Sqrt"
+        "module": "Mathlib.Data.Real.Sqrt"
       }
     ],
     "originalContributions": [

--- a/src/data/proofs/herons-formula-oq-06/meta.json
+++ b/src/data/proofs/herons-formula-oq-06/meta.json
@@ -156,7 +156,7 @@
       {
         "theorem": "Real.sqrt_pos",
         "description": "0 < sqrt x ↔ 0 < x; used for area positivity.",
-        "module": "Mathlib.Analysis.SpecialFunctions.Sqrt"
+        "module": "Mathlib.Data.Real.Sqrt"
       },
       {
         "theorem": "div_le_div_iff₀",

--- a/src/data/proofs/herons-formula-oq-07/meta.json
+++ b/src/data/proofs/herons-formula-oq-07/meta.json
@@ -166,12 +166,12 @@
       {
         "theorem": "Real.sqrt_le_sqrt",
         "description": "monotonicity of sqrt; upgrades the squared inequality to the linear one.",
-        "module": "Mathlib.Analysis.SpecialFunctions.Sqrt"
+        "module": "Mathlib.Data.Real.Sqrt"
       },
       {
         "theorem": "Real.sqrt_sq",
         "description": "sqrt(a^2) = a for a ≥ 0; recovers each side from its square.",
-        "module": "Mathlib.Analysis.SpecialFunctions.Sqrt"
+        "module": "Mathlib.Data.Real.Sqrt"
       }
     ],
     "originalContributions": [

--- a/src/data/proofs/hilbert-4-oq-04/meta.json
+++ b/src/data/proofs/hilbert-4-oq-04/meta.json
@@ -26,7 +26,7 @@
       {
         "theorem": "Real.sq_sqrt",
         "description": "√Δ ^ 2 = Δ for Δ ≥ 0; turns the discriminant into a usable square so the fixed-point quadratic can be verified algebraically",
-        "module": "Mathlib.Analysis.SpecialFunctions.Sqrt"
+        "module": "Mathlib.Data.Real.Sqrt"
       },
       {
         "theorem": "tendsto_pow_atTop_nhds_zero_of_abs_lt_one",

--- a/src/data/proofs/morleys-theorem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/morleys-theorem-oq-01-oq-01/meta.json
@@ -48,7 +48,7 @@
       {
         "theorem": "Real.sqrt_sq / Real.sq_sqrt",
         "description": "√(x²)=x for x≥0 and (√x)²=x for x≥0, used to extract the side length from its square",
-        "module": "Mathlib.Analysis.SpecialFunctions.Sqrt"
+        "module": "Mathlib.Data.Real.Sqrt"
       }
     ],
     "originalContributions": [

--- a/src/data/proofs/pascals-hexagon-incomplete-01-oq-03-oq-01/meta.json
+++ b/src/data/proofs/pascals-hexagon-incomplete-01-oq-03-oq-01/meta.json
@@ -44,7 +44,7 @@
       {
         "theorem": "Real.sqrt_pos",
         "description": "0 < √x ↔ 0 < x — gives strict positivity of the three diagonal scale factors, hence det ≠ 0",
-        "module": "Mathlib.Analysis.SpecialFunctions.Sqrt"
+        "module": "Mathlib.Data.Real.Sqrt"
       },
       {
         "theorem": "Matrix.det_fin_three",

--- a/src/data/proofs/pell-equation-oq-01-oq-04-oq-01/meta.json
+++ b/src/data/proofs/pell-equation-oq-01-oq-04-oq-01/meta.json
@@ -54,7 +54,7 @@
       {
         "theorem": "Real.sq_sqrt",
         "description": "0 ≤ x → (√x)² = x — the lone analytic input, used in Brahmagupta multiplicativity (needs d ≥ 0)",
-        "module": "Mathlib.Analysis.SpecialFunctions.Sqrt"
+        "module": "Mathlib.Data.Real.Sqrt"
       }
     ],
     "dateAdded": "2026-06-24"

--- a/src/data/proofs/pell-equation-oq-01-oq-04/meta.json
+++ b/src/data/proofs/pell-equation-oq-01-oq-04/meta.json
@@ -43,7 +43,7 @@
       {
         "theorem": "Real.sq_sqrt",
         "description": "0 ≤ x → (√x)² = x — used to evaluate (√d)² = d in the Brahmagupta expansion (needs d ≥ 0)",
-        "module": "Mathlib.Analysis.SpecialFunctions.Sqrt"
+        "module": "Mathlib.Data.Real.Sqrt"
       },
       {
         "theorem": "Real.log_mul / Real.log_pow",

--- a/src/data/proofs/ptolemys-theorem-oq-03/meta.json
+++ b/src/data/proofs/ptolemys-theorem-oq-03/meta.json
@@ -48,7 +48,7 @@
       {
         "theorem": "Real.sqrt_sq",
         "description": "√(a²) = a for a ≥ 0, turning each squared chord length into the length itself (all six lengths are nonnegative on [0,π/2]²)",
-        "module": "Mathlib.Analysis.SpecialFunctions.Sqrt"
+        "module": "Mathlib.Data.Real.Sqrt"
       },
       {
         "theorem": "Real.sin_sq_add_cos_sq",

--- a/src/data/proofs/sqrt2-minpoly-oq-01-oq-02/meta.json
+++ b/src/data/proofs/sqrt2-minpoly-oq-01-oq-02/meta.json
@@ -24,7 +24,7 @@
       {
         "theorem": "Real.sq_sqrt",
         "description": "(√x)² = x for 0 ≤ x, the root witness for X² - r",
-        "module": "Mathlib.Analysis.SpecialFunctions.Sqrt"
+        "module": "Mathlib.Data.Real.Sqrt"
       },
       {
         "theorem": "minpoly.dvd",

--- a/src/data/proofs/synthesis-curvature-ptolemy-oq-02/meta.json
+++ b/src/data/proofs/synthesis-curvature-ptolemy-oq-02/meta.json
@@ -40,7 +40,7 @@
       {
         "theorem": "Real.sqrt_mul",
         "description": "√(x·y) = √x·√y for x ≥ 0 — splits the conformal factor into a product of two roots",
-        "module": "Mathlib.Analysis.SpecialFunctions.Sqrt"
+        "module": "Mathlib.Data.Real.Sqrt"
       }
     ],
     "originalContributions": [

--- a/src/data/proofs/viviani-theorem-oq-01/meta.json
+++ b/src/data/proofs/viviani-theorem-oq-01/meta.json
@@ -42,7 +42,7 @@
       {
         "theorem": "Real.sqrt_sq",
         "description": "√(x²) = x for nonnegative x, used to simplify √4 = 2",
-        "module": "Mathlib.Analysis.SpecialFunctions.Sqrt"
+        "module": "Mathlib.Data.Real.Sqrt"
       },
       {
         "theorem": "abs_of_nonneg",


### PR DESCRIPTION
## Systematic `mathlibDependencies` module-path accuracy fix

While auditing individual entries I found a **systematic error** repeated across the gallery: the *algebraic* square-root lemmas are attributed to `Mathlib.Analysis.SpecialFunctions.Sqrt`, but in Mathlib 4.26.0 (this project's pinned version) they are **defined in `Mathlib.Data.Real.Sqrt`**.

### Verification (against Mathlib 4.26.0 source)
Each of these has its definition in `Mathlib/Data/Real/Sqrt.lean` and **does not appear** in `Mathlib/Analysis/SpecialFunctions/Sqrt.lean`:
`Real.sqrt_sq`, `Real.sq_sqrt`, `Real.mul_self_sqrt`, `Real.sqrt_pos`, `Real.sqrt_le_sqrt`, `Real.sqrt_mul`, `Real.sqrt_one`, `Real.sqrt_sq_eq_abs` (plus combined-name variants like `Real.sqrt_sq / Real.sq_sqrt`).

### Scope
- **34 meta.json entries**, 39 module strings corrected (module value only — text-targeted replacement, no other content or formatting touched; diff is 39/39 insertions/deletions).
- **Deliberately left untouched** (correctly placed or out of scope):
  - `Real.continuous_sqrt`, `HasDerivAt.sqrt`, `ContinuousOn.sqrt` — genuinely defined in `Analysis.SpecialFunctions.Sqrt`.
  - `irrational_sqrt_two` — belongs to `NumberTheory.Real.Irrational` (a different fix).
  - a mixed multi-name entry (`Real.sqrt_sq_eq_abs / Rat.cast_abs / Rat.not_irrational`).
  - two entries already covered by open PRs #37894 and #37912.

All 34 changed files validated as parseable JSON; all remain within size caps.