### PR TITLE
research(e-transcendental-oq-02-oq-06): complete the non-normality corollary API

### DIFF
--- a/proofs/Proofs/ETranscendentalOQ02OQ06.lean
+++ b/proofs/Proofs/ETranscendentalOQ02OQ06.lean
@@ -81,4 +81,37 @@ theorem rational_not_absolutely_normal (q : ℚ) :
     ¬ IsAbsolutelyNormal (q : ℝ) :=
   fun hn => rational_not_normal 2 (le_refl 2) q (hn 2 (le_refl 2))
 
+/-- **A normal number is distinct from every integer.**  Integer specialization of
+    `normal_ne_ratCast`: if `x` is normal in base `b ≥ 2`, then `x ≠ (n : ℝ)` for every
+    `n : ℤ`. Immediate from `intCast_not_normal`. -/
+theorem normal_ne_intCast (b : ℕ) (hb : 2 ≤ b) (x : ℝ) (hx : IsNormalInBase b x)
+    (n : ℤ) : x ≠ (n : ℝ) := by
+  rintro rfl
+  exact intCast_not_normal b hb n hx
+
+/-- **A normal number is distinct from every natural number.**  Natural specialization of
+    `normal_ne_ratCast`, via `natCast_not_normal`. -/
+theorem normal_ne_natCast (b : ℕ) (hb : 2 ≤ b) (x : ℝ) (hx : IsNormalInBase b x)
+    (n : ℕ) : x ≠ (n : ℝ) := by
+  rintro rfl
+  exact natCast_not_normal b hb n hx
+
+/-- **Absolute normality implies irrationality.**  An absolutely normal number is in
+    particular normal in base `2`, hence irrational by `normal_imp_irrational`. The
+    absolute-normality specialization of the parent's positive implication, and the exact
+    strength used in `rational_not_absolutely_normal`. -/
+theorem absolutelyNormal_imp_irrational (x : ℝ) (hx : IsAbsolutelyNormal x) :
+    Irrational x :=
+  normal_imp_irrational 2 (le_refl 2) x (hx 2 (le_refl 2))
+
+/-- **Integers are not absolutely normal.**  An integer is not normal in base `2`, so it
+    fails absolute normality. Integer analogue of `rational_not_absolutely_normal`. -/
+theorem intCast_not_absolutely_normal (n : ℤ) : ¬ IsAbsolutelyNormal (n : ℝ) :=
+  fun hn => intCast_not_normal 2 (le_refl 2) n (hn 2 (le_refl 2))
+
+/-- **Naturals are not absolutely normal.**  Natural analogue of
+    `rational_not_absolutely_normal`. -/
+theorem natCast_not_absolutely_normal (n : ℕ) : ¬ IsAbsolutelyNormal (n : ℝ) :=
+  fun hn => natCast_not_normal 2 (le_refl 2) n (hn 2 (le_refl 2))
+
 end ETranscendentalOQ02OQ06


### PR DESCRIPTION
## Summary

`ETranscendentalOQ02OQ06.lean` packages the contrapositive of `normal_imp_irrational` ("rationals are never normal") with a rational pointwise form (`normal_ne_ratCast`) and rational-level absolute non-normality — but the int/nat pointwise forms and the absolute-normality/irrationality level were missing. This PR fills in the symmetric completions.

## New theorems (all axiom-free)

- **`normal_ne_intCast` / `normal_ne_natCast`** — a normal number differs from every integer / natural (int/nat duals of the existing `normal_ne_ratCast`).
- **`absolutelyNormal_imp_irrational`** — `IsAbsolutelyNormal x ⟹ Irrational x` (an absolutely normal number is normal in base 2, hence irrational) — the exact strength already used inside `rational_not_absolutely_normal`, now named.
- **`intCast_not_absolutely_normal` / `natCast_not_absolutely_normal`** — integers and naturals are not absolutely normal (int/nat duals of `rational_not_absolutely_normal`).

## Verification

- File compiles cleanly via `bin/lake env lean` (exit 0).
- `#print axioms` on all five new theorems: `[propext, Classical.choice, Quot.sound]` — no `sorryAx`, no `Lean.ofReduceBool`, and crucially **no dependency on the parent's open `e_absolutely_normal` axiom**.
- Research-layer file (no gallery meta dir for `e-transcendental-oq-02-oq-06`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)