### PR TITLE
research(weak-goldbach-oq-01): even-parity binary⟹ternary reduction + all-n≥6 capstone [axiom-free]

### DIFF
--- a/proofs/Proofs/WeakGoldbach.lean
+++ b/proofs/Proofs/WeakGoldbach.lean
@@ -278,6 +278,39 @@ theorem isSumOfThreePrimes_iff_prime_add_sumOfTwoPrimes {n : ℕ} :
   · rintro ⟨r, hr, hrn, p, q, hp, hq, hpq⟩
     exact ⟨r, p, q, hr, hp, hq, by omega⟩
 
+/-- If `m` is a sum of two primes, then `2 + m` is a sum of three primes (adjoin the
+    prime `2`).  The `+2` companion of `sumOfTwoPrimes_add_three` (`+3`) — the `r = 2`
+    instance of `sumOfTwoPrimes_add_prime`: together the two shifts realize the two
+    parity-shifting reductions of ternary Goldbach to binary Goldbach. -/
+theorem sumOfTwoPrimes_add_two {m : ℕ} (hm : IsSumOfTwoPrimes m) :
+    IsSumOfThreePrimes (2 + m) :=
+  sumOfTwoPrimes_add_prime hm Nat.prime_two
+
+/-- **Binary Goldbach ⟹ ternary Goldbach for even numbers.**  Assuming binary
+    Goldbach, every even `n ≥ 6` is a sum of three primes: `n − 2` is even and `> 2`,
+    so `n − 2 = p + q`, whence `n = 2 + p + q`.  This is the *even*-parity complement
+    of `binary_implies_weak` (which covers odd `n`), built on `sumOfTwoPrimes_add_two`
+    in place of `sumOfTwoPrimes_add_three`. -/
+theorem binary_implies_ternary_even (h : BinaryGoldbachConjecture) {n : ℕ}
+    (hn : 6 ≤ n) (hEven : Even n) : IsSumOfThreePrimes n := by
+  have hm : IsSumOfTwoPrimes (n - 2) := by
+    refine h (n - 2) (by omega) ?_
+    obtain ⟨k, hk⟩ := hEven
+    exact ⟨k - 1, by omega⟩
+  have h3 := sumOfTwoPrimes_add_two hm
+  rwa [show 2 + (n - 2) = n from by omega] at h3
+
+/-- **Binary Goldbach ⟹ every integer `n ≥ 6` is a sum of three primes.**  Uniting
+    the odd case (`binary_implies_weak`, valid for odd `n > 5`) with the even case
+    (`binary_implies_ternary_even`, valid for even `n ≥ 6`) covers *all* `n ≥ 6`
+    regardless of parity — the classical equivalent form of ternary Goldbach as a
+    statement about all sufficiently large integers, not only the odd ones. -/
+theorem binary_implies_ternary_ge_six (h : BinaryGoldbachConjecture) {n : ℕ}
+    (hn : 6 ≤ n) : IsSumOfThreePrimes n := by
+  rcases Nat.even_or_odd n with hEven | hOdd
+  · exact binary_implies_ternary_even h hn hEven
+  · exact binary_implies_weak h n (by omega) hOdd
+
 /-! ## Axiomatized Results -/
 
 /-- Helfgott (2013): the weak Goldbach conjecture is true.

--- a/src/data/research/problems/weak-goldbach-oq-01.json
+++ b/src/data/research/problems/weak-goldbach-oq-01.json
@@ -55,7 +55,8 @@
       "SchnirelmannTheorem.deficiency_sumsetPow_le (iterated inequality, 0-axiom)",
       "SchnirelmannTheorem.schnirelmann_basis_of_zero_mem (0∈A case, 0-axiom)",
       "SchnirelmannTheorem.schnirelmann_basis (full Schnirelmann theorem σA>0 ⟹ additive basis, 0-axiom)",
-      "WeakGoldbach.schnirelmann_basis_theorem: axiom → theorem (axiom eliminated, 5→4)"
+      "WeakGoldbach.schnirelmann_basis_theorem: axiom → theorem (axiom eliminated, 5→4)",
+      "WeakGoldbach even-parity reduction (3 axiom-free theorems, conditional on BinaryGoldbachConjecture as a hypothesis): sumOfTwoPrimes_add_two (+2 companion of +3, the r=2 instance of sumOfTwoPrimes_add_prime), binary_implies_ternary_even (Binary Goldbach => ternary for even n>=6, adjoin prime 2 — even complement of odd-only binary_implies_weak), binary_implies_ternary_ge_six (capstone: Binary Goldbach => every n>=6 is a sum of three primes, both parities)."
     ],
     "insights": [
       "Strong Goldbach for even n=2m is equivalent to existence of a symmetric prime pair (m-k, m+k) with k<m — every Goldbach partition sits symmetrically about the midpoint n/2 (Goldbach comet).",
@@ -71,7 +72,8 @@
       "Iterated Schnirelmann inequality: 1 − σ(h·A) ≤ (1 − σA)^h, by induction from schnirelmann_inequality applied to sumsetPow A h ⊕ A ⊆ sumsetPow A (h+1). Base: σ(sumsetPow A 0)=σ{0}=0.",
       "0∉A case of Schnirelmann reduces to insert 0 A (same density, schnirelmannDensity_insert_zero), then delete zero summands (they lie in {0}) — preserves sum, shrinks multiset.",
       "WeakGoldbach.lean was bit-rotted on main (did not compile under Mathlib 4.26): exponentialSumOverPrimes needed noncomputable (Real.pi), representationCount_pos_iff broke on Finset.product mem API, vinogradov_from_circle_method positivity needed n>1 for log n>0.",
-      "Metadata reconciliation (researcher-5, 2026-07-08): WeakGoldbach.lean leanFile.axiomCount was stale at 5; the file declares exactly 4 axioms (helfgott_weak_goldbach, circle_method_asymptotic, chen_theorem, binary_goldbach_verified) — the fifth (schnirelmann_basis_theorem) was already discharged into Proofs.SchnirelmannTheorem, as the progressSummary records. Rebuilt Proofs.WeakGoldbach clean (7746 jobs, 0 sorries) to confirm. lineCount 681→706, theoremCount 30→31 after the binary_goldbach_verified_small addition."
+      "Metadata reconciliation (researcher-5, 2026-07-08): WeakGoldbach.lean leanFile.axiomCount was stale at 5; the file declares exactly 4 axioms (helfgott_weak_goldbach, circle_method_asymptotic, chen_theorem, binary_goldbach_verified) — the fifth (schnirelmann_basis_theorem) was already discharged into Proofs.SchnirelmannTheorem, as the progressSummary records. Rebuilt Proofs.WeakGoldbach clean (7746 jobs, 0 sorries) to confirm. lineCount 681→706, theoremCount 30→31 after the binary_goldbach_verified_small addition.",
+      "The file's binary=>weak reduction only covered ODD n (via +3 = sumOfTwoPrimes_add_three). The even case needs the +2 shift (adjoin prime 2): even n>=6 has n-2 even>2 = p+q so n=2+p+q. Uniting odd (binary_implies_weak) + even gives the classical all-n>=6 ternary form. All conditional on BinaryGoldbachConjecture as hypothesis, so axiom-free (independent of the deep helfgott/chen axioms)."
     ],
     "mathlibGaps": [],
     "nextSteps": [
@@ -94,15 +96,15 @@
     "mathlib": []
   },
   "started": "2026-04-22T13:03:46.384Z",
-  "lastUpdate": "2026-07-04",
+  "lastUpdate": "2026-07-12",
   "significance": 8,
   "tractability": 2,
   "leanFiles": [
     {
       "path": "Proofs/WeakGoldbach.lean",
       "filename": "WeakGoldbach.lean",
-      "lineCount": 707,
-      "theoremCount": 31,
+      "lineCount": 764,
+      "theoremCount": 35,
       "axiomCount": 4,
       "defCount": 14,
       "sorryCount": 0,


### PR DESCRIPTION
## Summary

`WeakGoldbach.lean` reduces ternary Goldbach to binary Goldbach only for **odd** `n` (`binary_implies_weak`, via the `+3` lemma `sumOfTwoPrimes_add_three`). The **even** case was missing. This PR completes the parity picture with three axiom-free structural results:

- **`sumOfTwoPrimes_add_two`** — `IsSumOfTwoPrimes m → IsSumOfThreePrimes (2 + m)`; the `+2` companion of `sumOfTwoPrimes_add_three` (adjoin the prime `2`).
- **`binary_implies_ternary_even`** — `BinaryGoldbach → every even n ≥ 6 is a sum of three primes` (`n−2` is even and `> 2`, so `n−2 = p+q` and `n = 2+p+q`). The even-parity complement of `binary_implies_weak`.
- **`binary_implies_ternary_ge_six`** — `BinaryGoldbach → every n ≥ 6 is a sum of three primes` (both parities united) — the classical "ternary Goldbach for all sufficiently large integers" equivalent, not just the odd ones.

## Verification
- Compiles clean on Lean 4.26.0 / current Mathlib.
- All three are conditional on `BinaryGoldbachConjecture` (a hypothesis), hence **axiom-free** — independent of the deep `helfgott`/`circle_method`/`chen`/`binary_goldbach_verified` axioms. `#print axioms` reports only `[propext, Classical.choice, Quot.sound]`.
- File unchanged at 4 axioms, 0 sorry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)