### PR TITLE
research(erdos-748): f(6) = 24 — extend the machine-checked OEIS A007865 table

### DIFF
--- a/proofs/Proofs/Erdos748Problem.lean
+++ b/proofs/Proofs/Erdos748Problem.lean
@@ -734,6 +734,12 @@ theorem f_4 : f 4 = 9 := by decide
     subsets containing `{1,4,5}` or `{2,3,5}`. -/
 theorem f_5 : f 5 = 16 := by decide
 
+/-- `f 6 = 24`: upgrades the OEIS A007865 table value `f(6) = 24` from prose to a
+    kernel-`decide` fact, extending the machine-checked small-value table one step past
+    `f_5`. Beyond the `n = 5` exclusions this adds the sums `6 = 1+5`, `6 = 2+4`
+    (and `6 = 3+3`), so the count rises from `16` to `24`. -/
+theorem f_6 : f 6 = 24 := by decide
+
 /-
 ## Part IX: Summary
 -/

--- a/src/data/proofs/erdos-748/meta.json
+++ b/src/data/proofs/erdos-748/meta.json
@@ -182,9 +182,9 @@
       "Finset"
     ],
     "namespace": "Erdos748",
-    "lineCount": 825,
+    "lineCount": 831,
     "axiomCount": 2,
-    "theoremCount": 29,
+    "theoremCount": 30,
     "definitionCount": 5,
     "path": "Proofs/Erdos748Problem.lean",
     "sorries": 0,


### PR DESCRIPTION
## Summary

Part VIII of the Erdős #748 (sum-free set counting / Cameron–Erdős) file upgrades the OEIS **A007865** small-value table — the number of sum-free subsets of `{1,…,n}` — from prose to kernel-`decide` facts, one value at a time (`f_1` … `f_5`). This PR adds the next entry, continuing the file's own established methodology.

## New theorem (axiom-free)

- **`f_6`** — `f 6 = 24`, verified by kernel `decide` over the 64 subsets of `{1,…,6}`. Beyond the `n = 5` exclusions, the new sums `6 = 1+5`, `6 = 2+4`, `6 = 3+3` forbid further subsets, so the count rises `16 → 24`.

## Verification

- **Kernel `decide`, not `native_decide`** — so `#print axioms f_6` = `[propext, Classical.choice, Quot.sound]`, **no `Lean.ofReduceBool`**. Compiles in ~4s.
- The two deep Cameron–Erdős statement axioms (`green_upper_bound`, `precise_asymptotic`) are untouched; `axiomCount` stays **2**.
- Compiled against Mathlib v4.26.0 (mathlib-only dependency). 0 sorries. `meta.json`: 29 → 30 theorems, 825 → 831 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)