### PR TITLE
research(sperner-ndim-oq-02): general no-canonical-representative theorem for small-lex-minimum cells

### DIFF
--- a/proofs/Proofs/SpernerNDimOQ02Obstruction.lean
+++ b/proofs/Proofs/SpernerNDimOQ02Obstruction.lean
@@ -75,6 +75,26 @@ theorem not_canon_of_lexMin_small {d N : ℕ} (t : GridSimplex d N) (v : BaryPoi
   rw [hbase] at hge
   exact absurd hge (by have := hsmall t.miss; omega)
 
+/-- **General no-canonical-representative theorem.**  The abstract principle behind
+the concrete `sBad_no_canon_rep`: if a grid simplex `t` has a vertex `v` that is the
+lex-minimum of its vertex set (`v` is `lexLE` every vertex *in the range*) and every
+coordinate of `v` is `< d`, then **no** grid simplex `t'` sharing `t`'s vertex set is
+canonical.  Any such `t'` would have the same lex-minimum `v` — forcing its base to
+`v` by canonicality and antisymmetry — but `base_miss_ge_d` demands a base coordinate
+`≥ d`, which `v`'s small coordinates cannot supply (`not_canon_of_lexMin_small`).  This
+lifts the single-witness obstruction to *every* cell with a small lex-minimum: the
+`IsCanon` carrier omits the entire family of such cells, not just `sBad`. -/
+theorem no_canon_rep_of_lexMin_small {d N : ℕ} (t : GridSimplex d N) (v : BaryPoint d N)
+    (hmem : v ∈ Set.range t.verts)
+    (hmin : ∀ w ∈ Set.range t.verts, v.lexLE w)
+    (hsmall : ∀ j, (v.coords j) < d) :
+    ¬ ∃ t' : GridSimplex d N, IsCanon t' ∧ Set.range t'.verts = Set.range t.verts := by
+  rintro ⟨t', hcanon, hrange⟩
+  have hvmem : v ∈ Set.range t'.verts := by rw [hrange]; exact hmem
+  have hmin' : ∀ k, v.lexLE (t'.verts k) := fun k =>
+    hmin (t'.verts k) (by rw [← hrange]; exact ⟨k, rfl⟩)
+  exact not_canon_of_lexMin_small t' v hvmem hmin' hsmall hcanon
+
 /-- The three barycentric points of the witness cell. -/
 def p2 : BaryPoint 2 2 := ⟨![2, 0, 0], by decide⟩
 def p1 : BaryPoint 2 2 := ⟨![1, 1, 0], by decide⟩


### PR DESCRIPTION
## Summary

`Proofs/SpernerNDimOQ02Obstruction.lean` shows the `IsCanon` (lex-min-base) carrier omits
genuine Freudenthal cells — but only via the *specific* witness `sBad` (`sBad_no_canon_rep`,
`d=2, N=2`). This adds the **abstract principle** behind that witness, axiom-free.

## What's new

- **`no_canon_rep_of_lexMin_small`** — for *any* grid simplex `t` whose vertex set has a
  lex-minimum `v` with every coordinate `< d`, **no** grid simplex sharing `t`'s vertex set
  is canonical. Any such `t'` inherits the same lex-minimum `v`; canonicality + antisymmetry
  force its base to `v`, contradicting `base_miss_ge_d` (which demands a base coordinate
  `≥ d`). Proved by reusing the general `not_canon_of_lexMin_small`.

This lifts the single-witness obstruction to the entire family of small-lex-minimum cells:
`sBad_no_canon_rep` is now the `d=2, N=2` instance of a general theorem.

4 → 5 theorems, still 0 axioms / 0 sorries.

## Verification

Compiled against Mathlib 4.26.0 with the `Proofs.SpernerGridBase` dependency built locally
(Lean v4.26.0 + pinned Mathlib oleans, 0 errors). `#print axioms` =
`[propext, Classical.choice, Quot.sound]` — axiom-free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)