### PR TITLE
research(euler-polyhedral-formula-oq-02-oq-02): genus χ order/parity + product-surface Euler characteristic

### DIFF
--- a/proofs/Proofs/EulerPolyhedralOQ02OQ02.lean
+++ b/proofs/Proofs/EulerPolyhedralOQ02OQ02.lean
@@ -649,6 +649,53 @@ theorem genusSurfaceCGB_totalPfaffian_neg_iff (g : ℕ) :
     have : (2 : ℝ) ≤ (g : ℝ) := by exact_mod_cast hg
     linarith
 
+-- ============================================================================
+-- Part XV: Order and parity of the genus Euler characteristic, and the
+--          Euler characteristic of product surfaces `Σ_g × Σ_h`
+-- ============================================================================
+
+/-- **`χ(Σ_g)` is strictly decreasing in the genus.**  Each added handle drops the
+    Euler characteristic by exactly `2`, so `g ↦ χ(Σ_g) = 2 − 2g` is strictly
+    antitone: `g < h ⇒ χ(Σ_h) < χ(Σ_g)`.  This upgrades the injectivity
+    `genusSurfaceCGB_chi_inj` to a genuine order-reversing structure on the
+    connected-sum monoid `(surfaces, #) ≅ (ℕ, +)`. -/
+theorem genusSurfaceCGB_chi_strictAnti :
+    StrictAnti (fun g : ℕ => (genusSurfaceCGB g).chi) := by
+  intro a b hab
+  simp only [genusSurfaceCGB_chi]
+  omega
+
+/-- **`χ(Σ_g)` is (weakly) antitone in the genus**, the `≤`-form of
+    `genusSurfaceCGB_chi_strictAnti`. -/
+theorem genusSurfaceCGB_chi_antitone :
+    Antitone (fun g : ℕ => (genusSurfaceCGB g).chi) :=
+  genusSurfaceCGB_chi_strictAnti.antitone
+
+/-- **The Euler characteristic of a closed orientable surface is even.**  `χ(Σ_g) =
+    2 − 2g = 2(1 − g)` is even for every genus `g` — the parity obstruction that no
+    closed orientable surface has odd Euler characteristic. -/
+theorem genusSurfaceCGB_chi_even (g : ℕ) : Even (genusSurfaceCGB g).chi :=
+  ⟨1 - (g : ℤ), by rw [genusSurfaceCGB_chi]; ring⟩
+
+/-- **Euler characteristic of the product surface `Σ_g × Σ_h`.**  Since `χ` is
+    multiplicative under products (`prodCGB_chi`), the product `4`-manifold
+    `Σ_g × Σ_h` has `χ = (2 − 2g)(2 − 2h)`.  Generalises `sphere_prod_sphere_chi`
+    (the `g = h = 0` case, `χ = 4`) to arbitrary genera. -/
+theorem prodCGB_genusSurface_chi (g h : ℕ) :
+    (prodCGB (genusSurfaceCGB g) (genusSurfaceCGB h)).chi
+      = (2 - 2 * (g : ℤ)) * (2 - 2 * (h : ℤ)) := by
+  rw [prodCGB_chi, genusSurfaceCGB_chi, genusSurfaceCGB_chi]
+
+/-- **Total Gauss-Bonnet curvature of the product surface `Σ_g × Σ_h`.**  The total
+    Pfaffian multiplies under products (`prodCGB_totalPfaffian`), giving the closed
+    form `∫Pf(Σ_g × Σ_h) = [4π(1−g)]·[4π(1−h)] = 16π²(1−g)(1−h)` for the product
+    `4`-manifold — the Chern-Gauss-Bonnet content `(2π)²·χ(Σ_g × Σ_h)` written out. -/
+theorem prodCGB_genusSurface_totalPfaffian (g h : ℕ) :
+    (prodCGB (genusSurfaceCGB g) (genusSurfaceCGB h)).totalPfaffian
+      = 16 * π ^ 2 * (1 - (g : ℝ)) * (1 - (h : ℝ)) := by
+  rw [prodCGB_totalPfaffian, genusSurfaceCGB_totalPfaffian, genusSurfaceCGB_totalPfaffian]
+  ring
+
 end ChernGaussBonnet
 
 end

--- a/src/data/proofs/euler-polyhedral-formula-oq-02-oq-02/meta.json
+++ b/src/data/proofs/euler-polyhedral-formula-oq-02-oq-02/meta.json
@@ -154,9 +154,9 @@
       "Real"
     ],
     "namespace": "ChernGaussBonnet",
-    "lineCount": 612,
+    "lineCount": 701,
     "axiomCount": 0,
-    "theoremCount": 62,
+    "theoremCount": 67,
     "definitionCount": 12,
     "path": "Proofs/EulerPolyhedralOQ02OQ02.lean",
     "sorries": 0


### PR DESCRIPTION
## Problem
`euler-polyhedral-formula-oq-02-oq-02` — the Chern-Gauss-Bonnet manifold layer of the Euler polyhedral formula family (`Proofs/EulerPolyhedralOQ02OQ02.lean`, 0 axioms / 0 sorries, saturated).

## What's new (axiom-free)
Two frontiers of the existing `genusSurfaceCGB` / `prodCGB` API were incomplete:

**Order & parity of the genus Euler characteristic** — the file already proved `χ(Σ_g) = 2 − 2g` is *injective* (`genusSurfaceCGB_chi_inj`), but recorded no order or parity structure:
- **`genusSurfaceCGB_chi_strictAnti`** — `g ↦ χ(Σ_g)` is `StrictAnti`: each added handle drops `χ` by exactly `2`. Upgrades injectivity to an order-reversing structure on the connected-sum monoid `(surfaces, #) ≅ (ℕ, +)`.
- **`genusSurfaceCGB_chi_antitone`** — the weak (`≤`) form.
- **`genusSurfaceCGB_chi_even`** — `χ(Σ_g)` is even for every genus (parity obstruction: no closed orientable surface has odd `χ`).

**Euler characteristic / total curvature of product surfaces** — the product section (`prodCGB`) only had the concrete `sphere_prod_sphere_chi` (`χ = 4`); nothing for genus surfaces:
- **`prodCGB_genusSurface_chi`** — `χ(Σ_g × Σ_h) = (2 − 2g)(2 − 2h)` (via multiplicativity `prodCGB_chi`), generalizing `sphere_prod_sphere_chi` to arbitrary genera.
- **`prodCGB_genusSurface_totalPfaffian`** — `∫Pf(Σ_g × Σ_h) = 16π²(1 − g)(1 − h)`, the Chern-Gauss-Bonnet total curvature of the product 4-manifold in closed form.

## Verification
- Type-checks against prebuilt Mathlib via `bin/lake env lean Proofs/EulerPolyhedralOQ02OQ02.lean` (no errors).
- `#print axioms` for all new theorems → `[propext, Classical.choice, Quot.sound]` only.
- File remains 0-axiom / 0-sorry. Meta bumped: `theoremCount` 62→67, `lineCount` 612→701.

🤖 Generated with [Claude Code](https://claude.com/claude-code)