### PR TITLE
Enrich: fix Real.sqrt algebraic lemmas mis-filed under SpecialFunctions.Pow.* (34 entries)

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-02/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-02/meta.json
@@ -68,12 +68,12 @@
       {
         "theorem": "Real.sq_sqrt",
         "description": "For x ≥ 0, (√x)² = x — critical for the n=2 elementary proof",
-        "module": "Mathlib.Analysis.SpecialFunctions.Pow.Real"
+        "module": "Mathlib.Data.Real.Sqrt"
       },
       {
         "theorem": "Real.sqrt_mul",
         "description": "√(a·b) = √a · √b for a ≥ 0 — used in the n=2 AM-GM proof",
-        "module": "Mathlib.Analysis.SpecialFunctions.Pow.Real"
+        "module": "Mathlib.Data.Real.Sqrt"
       }
     ],
     "originalContributions": [

--- a/src/data/proofs/amgm-inequality/meta.json
+++ b/src/data/proofs/amgm-inequality/meta.json
@@ -36,7 +36,7 @@
       {
         "theorem": "Real.sqrt_mul",
         "description": "sqrt(ab) = sqrt(a) * sqrt(b) for a >= 0",
-        "module": "Mathlib.Analysis.SpecialFunctions.Pow.Real"
+        "module": "Mathlib.Data.Real.Sqrt"
       },
       {
         "theorem": "sq_nonneg",
@@ -46,7 +46,7 @@
       {
         "theorem": "Real.sq_sqrt",
         "description": "For x >= 0, (sqrt x)^2 = x — critical to both the elementary proof and equality characterization",
-        "module": "Mathlib.Analysis.SpecialFunctions.Pow.Real"
+        "module": "Mathlib.Data.Real.Sqrt"
       },
       {
         "theorem": "Real.geom_mean_le_arith_mean3_weighted",

--- a/src/data/proofs/area-of-circle-oq-01-oq-02-oq-02-oq-01/meta.json
+++ b/src/data/proofs/area-of-circle-oq-01-oq-02-oq-02-oq-01/meta.json
@@ -27,7 +27,7 @@
       {
         "theorem": "Real.sqrt_le_sqrt",
         "description": "Monotonicity of square root",
-        "module": "Mathlib.Analysis.SpecialFunctions.Pow.Real"
+        "module": "Mathlib.Data.Real.Sqrt"
       },
       {
         "theorem": "hasSum_le",

--- a/src/data/proofs/area-of-circle-oq-01-oq-03-oq-02/meta.json
+++ b/src/data/proofs/area-of-circle-oq-01-oq-03-oq-02/meta.json
@@ -56,7 +56,7 @@
       {
         "theorem": "Real.sqrt_nonneg",
         "description": "Square root is nonneg",
-        "module": "Mathlib.Analysis.SpecialFunctions.Pow.Real"
+        "module": "Mathlib.Data.Real.Sqrt"
       }
     ],
     "dateAdded": "2026-05-03",

--- a/src/data/proofs/brouwer-fixed-point-oq-01-oq-02-oq-03-oq-01/meta.json
+++ b/src/data/proofs/brouwer-fixed-point-oq-01-oq-02-oq-03-oq-01/meta.json
@@ -42,12 +42,12 @@
       {
         "theorem": "Real.sqrt_sq",
         "description": "√(a²) = a for a ≥ 0",
-        "module": "Mathlib.Analysis.SpecialFunctions.Pow.Real"
+        "module": "Mathlib.Data.Real.Sqrt"
       },
       {
         "theorem": "Real.sq_sqrt",
         "description": "(√a)² = a for a ≥ 0",
-        "module": "Mathlib.Analysis.SpecialFunctions.Pow.Real"
+        "module": "Mathlib.Data.Real.Sqrt"
       },
       {
         "theorem": "Real.continuous_sqrt",

--- a/src/data/proofs/buffons-needle-oq-02-oq-02/meta.json
+++ b/src/data/proofs/buffons-needle-oq-02-oq-02/meta.json
@@ -38,7 +38,7 @@
       {
         "theorem": "Real.sqrt_nonneg",
         "description": "Square root is nonneg",
-        "module": "Mathlib.Analysis.SpecialFunctions.Pow.Real"
+        "module": "Mathlib.Data.Real.Sqrt"
       },
       {
         "theorem": "ContDiff",

--- a/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-02/meta.json
+++ b/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-02/meta.json
@@ -28,12 +28,12 @@
       {
         "theorem": "Real.sqrt_le_sqrt",
         "description": "Monotonicity of square root",
-        "module": "Mathlib.Analysis.SpecialFunctions.Pow.Real"
+        "module": "Mathlib.Data.Real.Sqrt"
       },
       {
         "theorem": "Real.sqrt_sq",
         "description": "sqrt(a^2) = a for a >= 0",
-        "module": "Mathlib.Analysis.SpecialFunctions.Pow.Real"
+        "module": "Mathlib.Data.Real.Sqrt"
       }
     ],
     "originalContributions": [

--- a/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-03-oq-02/meta.json
+++ b/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-03-oq-02/meta.json
@@ -34,7 +34,7 @@
       {
         "theorem": "Real.sq_sqrt",
         "description": "(√x)² = x for x ≥ 0, used to square the WAM = WQM equality",
-        "module": "Mathlib.Analysis.SpecialFunctions.Pow.NNRpow"
+        "module": "Mathlib.Data.Real.Sqrt"
       },
       {
         "theorem": "Real.sqrt_sq",

--- a/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-03/meta.json
+++ b/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-03/meta.json
@@ -33,7 +33,7 @@
       {
         "theorem": "Real.sqrt_le_sqrt",
         "description": "Monotonicity of square root",
-        "module": "Mathlib.Analysis.SpecialFunctions.Pow.Real"
+        "module": "Mathlib.Data.Real.Sqrt"
       },
       {
         "theorem": "inv_le_comm₀",

--- a/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02/meta.json
@@ -26,12 +26,12 @@
       {
         "theorem": "Real.sqrt_le_sqrt",
         "description": "Monotonicity of square root",
-        "module": "Mathlib.Analysis.SpecialFunctions.Pow.Real"
+        "module": "Mathlib.Data.Real.Sqrt"
       },
       {
         "theorem": "Real.sqrt_sq",
         "description": "√(a²) = a for a ≥ 0",
-        "module": "Mathlib.Analysis.SpecialFunctions.Pow.Real"
+        "module": "Mathlib.Data.Real.Sqrt"
       }
     ],
     "originalContributions": [

--- a/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-01/meta.json
@@ -44,7 +44,7 @@
       {
         "theorem": "Real.sqrt_le_sqrt",
         "description": "Monotonicity of square root: a ≤ b → √a ≤ √b — used in AM-GM proof",
-        "module": "Mathlib.Analysis.SpecialFunctions.Pow.Real"
+        "module": "Mathlib.Data.Real.Sqrt"
       },
       {
         "theorem": "div_add_div",

--- a/src/data/proofs/cauchy-schwarz-integral-oq-02/meta.json
+++ b/src/data/proofs/cauchy-schwarz-integral-oq-02/meta.json
@@ -36,7 +36,7 @@
       {
         "theorem": "Real.sqrt_le_sqrt",
         "description": "Monotonicity of square root: a ≤ b → √a ≤ √b",
-        "module": "Mathlib.Analysis.SpecialFunctions.Pow.Real"
+        "module": "Mathlib.Data.Real.Sqrt"
       },
       {
         "theorem": "norm_add_le",

--- a/src/data/proofs/cauchy-schwarz-oq-02-oq-04-oq-02/meta.json
+++ b/src/data/proofs/cauchy-schwarz-oq-02-oq-04-oq-02/meta.json
@@ -34,7 +34,7 @@
       {
         "theorem": "Real.sqrt_mul",
         "description": "√(x·y) = √x · √y for x ≥ 0. Splits the energy seminorm of a product, used in absolute homogeneity and the √-form Cauchy-Schwarz.",
-        "module": "Mathlib.Analysis.SpecialFunctions.Pow.NNRpow"
+        "module": "Mathlib.Data.Real.Sqrt"
       },
       {
         "theorem": "Real.sqrt_le_sqrt",

--- a/src/data/proofs/cevas-theorem-oq-02-oq-01/meta.json
+++ b/src/data/proofs/cevas-theorem-oq-02-oq-01/meta.json
@@ -72,7 +72,7 @@
       {
         "theorem": "Real.sqrt_mul",
         "description": "sqrt(a*b) = sqrt(a)*sqrt(b) for a ≥ 0",
-        "module": "Mathlib.Analysis.SpecialFunctions.Pow.Real"
+        "module": "Mathlib.Data.Real.Sqrt"
       },
       {
         "theorem": "real_inner_self_eq_norm_sq",

--- a/src/data/proofs/chebyshev-bounds-oq-06-oq-01/meta.json
+++ b/src/data/proofs/chebyshev-bounds-oq-06-oq-01/meta.json
@@ -50,7 +50,7 @@
       {
         "theorem": "Real.sq_sqrt / Real.sqrt_sq",
         "description": "(√x)² = x and √(x²) = x for x ≥ 0. Used to eliminate the square roots √(2πn) and √(4πn) = 2√(πn) in the algebraic collapse of the Stirling ratio.",
-        "module": "Mathlib.Analysis.SpecialFunctions.Pow.NNRpow"
+        "module": "Mathlib.Data.Real.Sqrt"
       }
     ],
     "originalContributions": [

--- a/src/data/proofs/descartes-circle-theorem-oq-01/meta.json
+++ b/src/data/proofs/descartes-circle-theorem-oq-01/meta.json
@@ -68,7 +68,7 @@
       {
         "theorem": "Real.sq_sqrt",
         "description": "(√a)² = a for 0 ≤ a, used to convert the Soddy square root into the symmetric product",
-        "module": "Mathlib.Analysis.SpecialFunctions.Pow.NNRpow"
+        "module": "Mathlib.Data.Real.Sqrt"
       }
     ],
     "originalContributions": [

--- a/src/data/proofs/erdos-1007-oq-01/meta.json
+++ b/src/data/proofs/erdos-1007-oq-01/meta.json
@@ -34,7 +34,7 @@
       {
         "theorem": "Real.sqrt_one",
         "description": "√1 = 1.",
-        "module": "Mathlib.Analysis.SpecialFunctions.Pow.Real"
+        "module": "Mathlib.Data.Real.Sqrt"
       },
       {
         "theorem": "Nat.choose_le_choose",
@@ -44,7 +44,7 @@
       {
         "theorem": "Real.sq_sqrt",
         "description": "(√a)² = a for a ≥ 0. Used in simplex embedding distance computation.",
-        "module": "Mathlib.Analysis.SpecialFunctions.Pow.Real"
+        "module": "Mathlib.Data.Real.Sqrt"
       },
       {
         "theorem": "Finset.add_sum_erase",

--- a/src/data/proofs/erdos-1007-oq-05/meta.json
+++ b/src/data/proofs/erdos-1007-oq-05/meta.json
@@ -22,7 +22,7 @@
       {
         "theorem": "Real.sqrt_one",
         "description": "√1 = 1",
-        "module": "Mathlib.Analysis.SpecialFunctions.Pow.Real"
+        "module": "Mathlib.Data.Real.Sqrt"
       },
       {
         "theorem": "Fintype.equivFin",

--- a/src/data/proofs/erdos-103-oq-01/meta.json
+++ b/src/data/proofs/erdos-103-oq-01/meta.json
@@ -48,7 +48,7 @@
       {
         "theorem": "Real.sq_sqrt",
         "description": "Square of square root equals original for nonneg",
-        "module": "Mathlib.Analysis.SpecialFunctions.Pow.Real"
+        "module": "Mathlib.Data.Real.Sqrt"
       },
       {
         "theorem": "sq_eq_zero_iff",

--- a/src/data/proofs/gram-linear-independence-iff-oq-01-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/gram-linear-independence-iff-oq-01-oq-01-oq-02-oq-01/meta.json
@@ -112,7 +112,7 @@
       {
         "theorem": "Real.sqrt_le_sqrt / Real.sqrt_sq / Real.sqrt_mul",
         "description": "Monotonicity and the inverse of squaring for the real square root: descend ‖det A‖² ≤ (∏ ‖col j‖)² to ‖det A‖ ≤ ∏ ‖col j‖, and evaluate √(n·M²) = √n·M for the uniform bound.",
-        "module": "Mathlib.Analysis.SpecialFunctions.Pow.NNRpow"
+        "module": "Mathlib.Data.Real.Sqrt"
       },
       {
         "theorem": "Finset.prod_le_prod / Finset.prod_const / Finset.prod_pow",

--- a/src/data/proofs/herons-formula-oq-01/meta.json
+++ b/src/data/proofs/herons-formula-oq-01/meta.json
@@ -24,7 +24,7 @@
       {
         "theorem": "Real.sqrt_sq",
         "description": "sqrt(x^2) = x for x >= 0",
-        "module": "Mathlib.Analysis.SpecialFunctions.Pow.Real"
+        "module": "Mathlib.Data.Real.Sqrt"
       }
     ],
     "originalContributions": [

--- a/src/data/proofs/herons-formula-oq-03/meta.json
+++ b/src/data/proofs/herons-formula-oq-03/meta.json
@@ -23,12 +23,12 @@
       {
         "theorem": "Real.sqrt_mul",
         "description": "sqrt(a*b) = sqrt(a)*sqrt(b) for a >= 0",
-        "module": "Mathlib.Analysis.SpecialFunctions.Pow.Real"
+        "module": "Mathlib.Data.Real.Sqrt"
       },
       {
         "theorem": "Real.sqrt_sq",
         "description": "sqrt(x^2) = x for x >= 0",
-        "module": "Mathlib.Analysis.SpecialFunctions.Pow.Real"
+        "module": "Mathlib.Data.Real.Sqrt"
       }
     ],
     "originalContributions": [

--- a/src/data/proofs/herons-formula-oq-04/meta.json
+++ b/src/data/proofs/herons-formula-oq-04/meta.json
@@ -25,12 +25,12 @@
       {
         "theorem": "Real.sqrt_le_sqrt",
         "description": "Monotonicity of sqrt",
-        "module": "Mathlib.Analysis.SpecialFunctions.Pow.Real"
+        "module": "Mathlib.Data.Real.Sqrt"
       },
       {
         "theorem": "Real.sq_sqrt",
         "description": "sqrt(x)^2 = x for x >= 0",
-        "module": "Mathlib.Analysis.SpecialFunctions.Pow.Real"
+        "module": "Mathlib.Data.Real.Sqrt"
       }
     ],
     "originalContributions": [

--- a/src/data/proofs/herons-formula-oq-06-oq-02/meta.json
+++ b/src/data/proofs/herons-formula-oq-06-oq-02/meta.json
@@ -191,7 +191,7 @@
       {
         "theorem": "Real.sq_sqrt",
         "description": "sqrt(x)^2 = x for x ≥ 0; used (via the parent's area_sq) to obtain Area² = Heron product.",
-        "module": "Mathlib.Analysis.SpecialFunctions.Pow.Real"
+        "module": "Mathlib.Data.Real.Sqrt"
       }
     ],
     "originalContributions": [

--- a/src/data/proofs/herons-formula-oq-06/meta.json
+++ b/src/data/proofs/herons-formula-oq-06/meta.json
@@ -151,7 +151,7 @@
       {
         "theorem": "Real.sq_sqrt",
         "description": "sqrt(x)^2 = x for x ≥ 0; used to obtain Area² = Heron product.",
-        "module": "Mathlib.Analysis.SpecialFunctions.Pow.Real"
+        "module": "Mathlib.Data.Real.Sqrt"
       },
       {
         "theorem": "Real.sqrt_pos",

--- a/src/data/proofs/herons-formula-oq-07/meta.json
+++ b/src/data/proofs/herons-formula-oq-07/meta.json
@@ -161,7 +161,7 @@
       {
         "theorem": "Real.sq_sqrt",
         "description": "sqrt(x)^2 = x for x ≥ 0; used to obtain Area² = heronProduct and (√3)² = 3.",
-        "module": "Mathlib.Analysis.SpecialFunctions.Pow.Real"
+        "module": "Mathlib.Data.Real.Sqrt"
       },
       {
         "theorem": "Real.sqrt_le_sqrt",

--- a/src/data/proofs/hilbert-17-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/hilbert-17-oq-01-oq-01-oq-01/meta.json
@@ -49,7 +49,7 @@
       {
         "theorem": "Real.sq_sqrt",
         "description": "0 ≤ x → (√x)² = x. Supplies r² = la² + lb² for the rotation scalar r = √(la² + lb²), giving c² + s² = 1 and the unit-vector identity that makes the rotation orthogonal.",
-        "module": "Mathlib.Analysis.SpecialFunctions.Pow.NNReal"
+        "module": "Mathlib.Data.Real.Sqrt"
       }
     ],
     "originalContributions": [

--- a/src/data/proofs/intermediate-value-theorem-oq-01/meta.json
+++ b/src/data/proofs/intermediate-value-theorem-oq-01/meta.json
@@ -37,17 +37,17 @@
       {
         "theorem": "Real.sqrt_le_sqrt",
         "description": "Monotonicity of square root: a ≤ b → √a ≤ √b — used to bound √2",
-        "module": "Mathlib.Analysis.SpecialFunctions.Pow.Real"
+        "module": "Mathlib.Data.Real.Sqrt"
       },
       {
         "theorem": "Real.sq_sqrt",
         "description": "(√a)² = a for a ≥ 0 — proves the witness satisfies x² = 2",
-        "module": "Mathlib.Analysis.SpecialFunctions.Pow.Real"
+        "module": "Mathlib.Data.Real.Sqrt"
       },
       {
         "theorem": "Real.sqrt_sq",
         "description": "√(a²) = a for a ≥ 0 — used to simplify √4 = 2",
-        "module": "Mathlib.Analysis.SpecialFunctions.Pow.Real"
+        "module": "Mathlib.Data.Real.Sqrt"
       }
     ],
     "lineCount": 135,

--- a/src/data/proofs/kepler-conjecture-oq-01/meta.json
+++ b/src/data/proofs/kepler-conjecture-oq-01/meta.json
@@ -58,7 +58,7 @@
       {
         "theorem": "Real.sq_sqrt",
         "description": "(√x)² = x for 0 ≤ x, used to prove the rational brackets `sqrt2_bounds` (1.41421 < √2 < 1.41422) and `sqrt3_bounds` (1.73205 < √3 < 1.73206) via `nlinarith`.",
-        "module": "Mathlib.Analysis.SpecialFunctions.Pow.NNRpow"
+        "module": "Mathlib.Data.Real.Sqrt"
       }
     ],
     "assumptions": "0 sorries, 0 axioms. Every theorem is discharged by `nlinarith`/`norm_num`/`linarith`/`positivity` from Mathlib's rational π bounds `Real.pi_gt_d6` (3.141592 < π) and `Real.pi_lt_d6` (π < 3.141593), plus two-sided √2/√3 brackets proved from `Real.sq_sqrt`. The five density constants Δ₄..Δ₈ are taken from the published literature (Conway–Sloane, *Sphere Packings, Lattices and Groups*) as the best-known lattice packing densities; D₅, E₆, E₇ are the densest lattices known in their dimensions (the true optimum is open), D₄ is conjecturally optimal, and only E₈ (Δ₈ = π⁴/384) is a theorem (Viazovska 2016). `#print axioms` on the three headline theorems lists only `propext, Classical.choice, Quot.sound` — no `sorryAx`, no `Lean.ofReduceBool`. The parent `Proofs/KeplerConjecture.lean` separately axiomatizes the 2D/3D optimality results; this file adds NO new assumptions and reuses only the parent's `PackingDensity` structure."

--- a/src/data/proofs/napoleons-theorem-oq-04/meta.json
+++ b/src/data/proofs/napoleons-theorem-oq-04/meta.json
@@ -23,7 +23,7 @@
       {
         "theorem": "Real.sq_sqrt",
         "description": "√3² = 3 for the nonnegative real square root; the sole non-ring fact behind the cancellation",
-        "module": "Mathlib.Analysis.SpecialFunctions.Pow.NNRpow"
+        "module": "Mathlib.Data.Real.Sqrt"
       },
       {
         "theorem": "Complex.mul_im",

--- a/src/data/proofs/pascals-hexagon-incomplete-01-oq-03-oq-01/meta.json
+++ b/src/data/proofs/pascals-hexagon-incomplete-01-oq-03-oq-01/meta.json
@@ -39,7 +39,7 @@
       {
         "theorem": "Real.sq_sqrt",
         "description": "(√x)² = x for 0 ≤ x — turns the pullback of stdConic's form into the form of diag(a,b,c) coefficient by coefficient",
-        "module": "Mathlib.Analysis.SpecialFunctions.Pow.NNReal"
+        "module": "Mathlib.Data.Real.Sqrt"
       },
       {
         "theorem": "Real.sqrt_pos",

--- a/src/data/proofs/prob-method-applications-oq-02-oq-01/meta.json
+++ b/src/data/proofs/prob-method-applications-oq-02-oq-01/meta.json
@@ -48,7 +48,7 @@
       {
         "theorem": "Real.sqrt_sq_eq_abs",
         "description": "√(a²) = |a|. Converts the polynomial bound (I − |P|)² ≤ |L|²·|P| into the square-root form I − |P| ≤ |L|·√|P| in the m < I case of incidence_bound_sqrt.",
-        "module": "Mathlib.Analysis.SpecialFunctions.Pow.NNRpow"
+        "module": "Mathlib.Data.Real.Sqrt"
       }
     ],
     "originalContributions": [

--- a/src/data/proofs/sqrt2-minpoly/meta.json
+++ b/src/data/proofs/sqrt2-minpoly/meta.json
@@ -40,7 +40,7 @@
       {
         "theorem": "Real.sq_sqrt",
         "description": "(√x)² = x for x ≥ 0",
-        "module": "Mathlib.Analysis.SpecialFunctions.Pow.Real"
+        "module": "Mathlib.Data.Real.Sqrt"
       },
       {
         "theorem": "IntermediateField.adjoin.finrank",

--- a/src/data/proofs/viviani-theorem-oq-01/meta.json
+++ b/src/data/proofs/viviani-theorem-oq-01/meta.json
@@ -37,7 +37,7 @@
       {
         "theorem": "Real.sq_sqrt",
         "description": "(√x)² = x for nonnegative x, used to discharge (√3)² = 3",
-        "module": "Mathlib.Analysis.SpecialFunctions.Pow.NNRpow"
+        "module": "Mathlib.Data.Real.Sqrt"
       },
       {
         "theorem": "Real.sqrt_sq",


### PR DESCRIPTION
## Companion to the `SpecialFunctions.Sqrt` module-path fix

Same systematic error, different wrong module. The **pure algebraic** square-root lemmas — `Real.sq_sqrt`, `Real.sqrt_sq`, `Real.sqrt_le_sqrt`, `Real.sqrt_mul`, `Real.sqrt_one`, `Real.sqrt_nonneg`, `Real.sqrt_sq_eq_abs` — were attributed across 34 entries to `Analysis.SpecialFunctions.Pow.Real` / `Pow.NNRpow` / `Pow.NNReal`.

### Verification
Confirmed against Mathlib 4.26.0 source that **none** of these lemmas are defined in any `Analysis/SpecialFunctions/Pow/` file; every one lives in `Mathlib.Data.Real.Sqrt` (e.g. `sqrt_nonneg` at `Data/Real/Sqrt.lean:129`, `sqrt_sq`/`sq_sqrt` at 166/163).

### Scope / safety
- Only remaps a dependency when its **entire** theorem string consists of these algebraic sqrt names (single or combined). 44 module strings across 34 files; 44/44 insertions/deletions (module value only).
- **Left untouched**: `Real.sqrt_eq_rpow` (genuinely defined in `Pow/Real.lean:981`) and any combined-name entry containing `sqrt_eq_rpow` / `rpow_inv_natCast_pow` / `ofReal_cpow`.

All JSON validated.