### PR TITLE
research(erdos-897-oq-01): ideal closed under nonnegative scaling (positive-cone dual)

### DIFF
--- a/proofs/Proofs/Erdos897OQ01.lean
+++ b/proofs/Proofs/Erdos897OQ01.lean
@@ -473,6 +473,28 @@ theorem not_unboundedOnPrimePowers_of_le_const_mul_log {f : ℕ → ℝ} {C : �
   obtain ⟨p, k, hp, hk, hgt⟩ := h C
   exact absurd hgt (not_lt.mpr (hf p k hp hk))
 
+/-- **Closure of the failing class under nonnegative scaling (ideal-side dual of
+`unboundedOnPrimePowers_smul`).**  If `f` fails the Erdős #897 hypothesis — say
+`f(p^k) ≤ M·log(p^k)` on every prime power — then so does `c • f` for any `c ≥ 0`:
+scaling the bound by `c ≥ 0` gives `c·f(p^k) ≤ (c·M)·log(p^k)`, so the `O(log)`
+criterion `not_unboundedOnPrimePowers_of_le_const_mul_log` applies with constant `c·M`.
+Together with `unboundedOnPrimePowers_smul` (largeness survives positive scaling) this
+shows both the "large" filter and the complementary `O(log)` ideal are **positive
+cones** — closed under multiplication by nonnegative scalars — completing the cone
+structure recorded in the module header. -/
+theorem not_unboundedOnPrimePowers_smul {f : ℕ → ℝ}
+    (hf : ¬ UnboundedOnPrimePowers f) {c : ℝ} (hc : 0 ≤ c) :
+    ¬ UnboundedOnPrimePowers (fun n => c * f n) := by
+  unfold UnboundedOnPrimePowers at hf
+  push_neg at hf
+  obtain ⟨M, hM⟩ := hf
+  apply not_unboundedOnPrimePowers_of_le_const_mul_log (C := c * M)
+  intro p k hp hk
+  show c * f (p ^ k) ≤ c * M * Real.log (p ^ k)
+  calc c * f (p ^ k)
+      ≤ c * (M * Real.log (p ^ k)) := mul_le_mul_of_nonneg_left (hM p k hp hk) hc
+    _ = c * M * Real.log (p ^ k) := by ring
+
 /-
 ## (9) Sup-closure: the order structure is a lattice filter / ideal
 


### PR DESCRIPTION
## Summary

`Proofs/Erdos897OQ01.lean` develops the Erdős #897 prime-power-unboundedness hypothesis as
a **positive cone** on the "large" side (`unboundedOnPrimePowers_smul`: largeness survives
positive scaling) and a sup-closed **ideal** on the "small"/`O(log)` side, but lacked the
ideal-side scaling dual. This adds it, axiom-free.

## What's new

- **`not_unboundedOnPrimePowers_smul`** — if `f` fails the hypothesis (`f(p^k) ≤ M·log(p^k)`
  on every prime power) and `c ≥ 0`, then `c • f` fails it too: scaling by `c ≥ 0` gives
  `c·f(p^k) ≤ (c·M)·log(p^k)`, so the existing `O(log)` criterion applies with constant
  `c·M`.

Together with `unboundedOnPrimePowers_smul` this shows **both** the large filter and the
complementary `O(log)` ideal are positive cones (closed under multiplication by nonnegative
scalars), completing the cone structure recorded in the module header.

31 → 32 theorems, still 0 axioms / 0 sorries.

## Verification

Compiled against Mathlib 4.26.0 (imports prebuilt `Proofs.Erdos897Problem`). `#print axioms`
= `[propext, Classical.choice, Quot.sound]` — axiom-free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)