### PR TITLE
research(pythagorean-theorem-oq-01): converses of Pythagoras and Thales

### DIFF
--- a/proofs/Proofs/PythagoreanTheoremOQ01.lean
+++ b/proofs/Proofs/PythagoreanTheoremOQ01.lean
@@ -540,6 +540,66 @@ theorem hypotenuse_midpoint_circumcenter (A B C : F) (hperp : ⟪A - C, B - C⟫
     rw [hd, norm_smul, Real.norm_eq_abs, abs_of_pos (by norm_num : (0:ℝ) < 2⁻¹)]
     ring
 
+-- ============================================================
+-- Converses: recovering the right angle from the metric data
+-- ============================================================
+
+/-- **Converse of the (metric) Pythagorean theorem.**  The forward direction
+`pythagorean_core` shows a right angle at `C` forces `‖A−B‖² = ‖A−C‖² + ‖B−C‖²`.  This is the
+converse: *whenever* the hypotenuse square equals the sum of the leg squares, the angle at `C`
+must be right (`⟪A−C, B−C⟫ = 0`).  Expanding `‖A−B‖² = ‖(A−C)−(B−C)‖²
+= ‖A−C‖² − 2⟪A−C,B−C⟫ + ‖B−C‖²` and comparing with the hypothesis leaves `2⟪A−C,B−C⟫ = 0`.
+Together with `pythagorean_core` this makes the right angle *equivalent* to the numerical
+Pythagorean relation (`pythagorean_core_iff`). -/
+theorem pythagorean_core_converse (A B C : F)
+    (h : ‖A - B‖ ^ 2 = ‖A - C‖ ^ 2 + ‖B - C‖ ^ 2) :
+    ⟪A - C, B - C⟫ = (0 : ℝ) := by
+  have hR : ‖A - B‖ ^ 2
+      = ‖A - C‖ ^ 2 - 2 * ⟪A - C, B - C⟫ + ‖B - C‖ ^ 2 := by
+    have hAB : A - B = (A - C) - (B - C) := by abel
+    rw [hAB]; exact norm_sub_sq_real _ _
+  rw [hR] at h
+  linarith
+
+/-- **Pythagoras characterises the right angle.**  Combining `pythagorean_core` with its
+converse: the angle at `C` is right iff the metric Pythagorean identity holds. -/
+theorem pythagorean_core_iff (A B C : F) :
+    ⟪A - C, B - C⟫ = (0 : ℝ) ↔ ‖A - B‖ ^ 2 = ‖A - C‖ ^ 2 + ‖B - C‖ ^ 2 :=
+  ⟨pythagorean_core A B C, pythagorean_core_converse A B C⟩
+
+/-- **Converse of Thales' theorem.**  `thales_circumradius` shows the right-angle vertex lies on
+the circle with diameter `AB` (distance exactly `‖A−B‖/2` from the hypotenuse midpoint
+`M = A + ½·(B−A)`).  This is the converse — the classical statement that *any* point `C` on that
+circle sees the diameter at a right angle: if `‖M − C‖ = ‖A−B‖/2` then `⟪A−C, B−C⟫ = 0`.
+Writing `M − C = ½·((A−C)+(B−C))`, the hypothesis says `‖(A−C)+(B−C)‖ = ‖A−B‖`; squaring and
+expanding both sides (via `norm_add_sq_real` on the left, `norm_sub_sq_real` on the right,
+since `A−B = (A−C)−(B−C)`) cancels the common leg-square terms and forces `4⟪A−C,B−C⟫ = 0`.
+This is exactly the inscription of `C` in the hypotenuse semicircle that `hippocrates_lunes`
+invokes but did not prove in that direction. -/
+theorem thales_converse (A B C : F)
+    (h : ‖(A + (2⁻¹ : ℝ) • (B - A)) - C‖ = ‖A - B‖ / 2) :
+    ⟪A - C, B - C⟫ = (0 : ℝ) := by
+  have hdecomp : (A + (2⁻¹ : ℝ) • (B - A)) - C = (2⁻¹ : ℝ) • ((A - C) + (B - C)) := by module
+  rw [hdecomp, norm_smul, Real.norm_eq_abs, abs_of_pos (by norm_num : (0:ℝ) < 2⁻¹)] at h
+  have hnorm : ‖(A - C) + (B - C)‖ = ‖A - B‖ := by linarith
+  have hsq : ‖(A - C) + (B - C)‖ ^ 2 = ‖A - B‖ ^ 2 := by rw [hnorm]
+  -- Expand each side explicitly (avoids `norm_sub_sq_real` mis-firing on `‖A−C‖²`).
+  have hL : ‖(A - C) + (B - C)‖ ^ 2
+      = ‖A - C‖ ^ 2 + 2 * ⟪A - C, B - C⟫ + ‖B - C‖ ^ 2 := norm_add_sq_real _ _
+  have hR : ‖A - B‖ ^ 2
+      = ‖A - C‖ ^ 2 - 2 * ⟪A - C, B - C⟫ + ‖B - C‖ ^ 2 := by
+    have hAB : A - B = (A - C) - (B - C) := by abel
+    rw [hAB]; exact norm_sub_sq_real _ _
+  rw [hL, hR] at hsq
+  linarith
+
+/-- **Thales characterises the right angle.**  Combining `thales_circumradius` with its
+converse: the angle at `C` is right iff `C` lies on the circle with diameter `AB` (the
+hypotenuse midpoint is equidistant, at `‖A−B‖/2`, from `C`). -/
+theorem thales_iff (A B C : F) :
+    ⟪A - C, B - C⟫ = (0 : ℝ) ↔ ‖(A + (2⁻¹ : ℝ) • (B - A)) - C‖ = ‖A - B‖ / 2 :=
+  ⟨thales_circumradius A B C, thales_converse A B C⟩
+
 #check @einstein_pythagorean
 #check @pythagorean_via_altitude
 #check @geometric_mean_A

--- a/src/data/proofs/pythagorean-theorem-oq-01/meta.json
+++ b/src/data/proofs/pythagorean-theorem-oq-01/meta.json
@@ -74,9 +74,9 @@
   },
   "leanFile": {
     "namespace": "PythagoreanEinstein",
-    "lineCount": 382,
+    "lineCount": 608,
     "axiomCount": 0,
-    "theoremCount": 17,
+    "theoremCount": 28,
     "definitionCount": 2,
     "path": "Proofs/PythagoreanTheoremOQ01.lean",
     "imports": [


### PR DESCRIPTION
## Summary

Einstein's similar-triangles file (`PythagoreanTheoremOQ01`) proved the *forward* implications — a right angle at `C` forces the metric Pythagorean identity (`pythagorean_core`) and puts `C` on the circle with diameter `AB` (`thales_circumradius`) — but neither **converse**, even though `hippocrates_lunes` explicitly invokes the Thales inscription ("by Thales the latter passes through the right-angle vertex `C`") without proving that direction. This PR adds the two classical converses and their `iff` characterizations.

## New theorems (all axiom-free)

- **`pythagorean_core_converse`** — `‖A−B‖² = ‖A−C‖² + ‖B−C‖² ⟹ ⟪A−C, B−C⟫ = 0`. The converse Pythagorean theorem: the numerical relation forces the right angle.
- **`pythagorean_core_iff`** — the right angle at `C` is *equivalent* to the metric Pythagorean identity.
- **`thales_converse`** — any `C` at distance `‖A−B‖/2` from the hypotenuse midpoint `M = A + ½·(B−A)` sees the diameter at a right angle (`⟪A−C, B−C⟫ = 0`). This is the "any point on the circle" direction of Thales — exactly the inscription `hippocrates_lunes` invoked but did not establish.
- **`thales_iff`** — the right angle at `C` is *equivalent* to `C` lying on the circle with diameter `AB`.

Both converses reduce to expanding `‖·‖²` via `norm_add_sq_real` / `norm_sub_sq_real` and cancelling the common leg-square terms.

## Verification

- `./proofs/scripts/docker-build.sh Proofs.PythagoreanTheoremOQ01` — builds clean (3058 jobs), **0 axioms, 0 sorries**.
- `#print axioms` on each new theorem: only `[propext, Classical.choice, Quot.sound]` — fully axiom-free; the `verified`/`mathlib` badge is preserved.
- `meta.json` `leanFile` counts refreshed (`lineCount` 382→608, `theoremCount` 17→28; both were stale relative to the pre-existing file); `axiomCount` unchanged at 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)