### PR TITLE
research(erdos-18-oq-01): practical numbers are infinite / unbounded

### DIFF
--- a/proofs/Proofs/Erdos18OQ01.lean
+++ b/proofs/Proofs/Erdos18OQ01.lean
@@ -553,4 +553,19 @@ theorem twelve_practical : IsPractical 12 := by
   norm_num at h
   exact h
 
+/-- **There are infinitely many practical numbers.**  The set of practical numbers is
+    infinite: the powers of two `2^k` are all practical (`two_pow_practical`) and
+    `k ↦ 2^k` is injective (`Nat.pow_right_injective`), so they form an infinite family
+    inside `{m | IsPractical m}`.  This packages the file's first infinite family into
+    the global statement that practical numbers never run out. -/
+theorem practical_infinite : {m : ℕ | IsPractical m}.Infinite :=
+  Set.infinite_of_injective_forall_mem
+    (Nat.pow_right_injective (le_refl 2)) (fun k => two_pow_practical k)
+
+/-- **Practical numbers are unbounded.**  For every `N` there is a practical number
+    exceeding it — the power of two `2^N > N` (`Nat.lt_two_pow_self`), practical by
+    `two_pow_practical`.  The explicit-witness form of `practical_infinite`. -/
+theorem exists_practical_gt (N : ℕ) : ∃ m, N < m ∧ IsPractical m :=
+  ⟨2 ^ N, N.lt_two_pow_self, two_pow_practical N⟩
+
 end Erdos18OQ01


### PR DESCRIPTION
## Problem
`erdos-18-oq-01` — Erdős Problem #18, *practical numbers* (`m` is practical if every `1 ≤ k < m` is a sum of distinct divisors of `m`). Research-layer file `Proofs/Erdos18OQ01.lean` (0 axioms / 0 sorries).

## What's new (axiom-free)
The file constructs the first **infinite family** of practical numbers — the powers of two `2^k` (`two_pow_practical`) — but never states the global consequence that practical numbers are infinite. Added the two capstones:

- **`practical_infinite`** — `{m : ℕ | IsPractical m}.Infinite`. The powers of two are all practical and `k ↦ 2^k` is injective (`Nat.pow_right_injective`), so they witness an infinite subfamily.
- **`exists_practical_gt`** — `∀ N, ∃ m, N < m ∧ IsPractical m`, the explicit-witness (unboundedness) form via `2^N > N` (`Nat.lt_two_pow_self`).

## Verification
- Type-checks against prebuilt Mathlib via `bin/lake env lean Proofs/Erdos18OQ01.lean` (no errors; one pre-existing `le_or_lt` deprecation warning unrelated to this change).
- `#print axioms` for both new theorems → `[propext, Classical.choice, Quot.sound]` only.
- Research-layer file — the gallery `erdos-18` meta references the parent `Erdos18Problem.lean` only, so no meta update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)