### PR TITLE
research(roth-theorem-oq-01): sharpest universal density bound (pointwise min)

### DIFF
--- a/proofs/Proofs/RothTheoremOQ01.lean
+++ b/proofs/Proofs/RothTheoremOQ01.lean
@@ -477,6 +477,26 @@ theorem threeAPFree_card_le_bourgain
           (Real.log (Real.log N) / Real.log N) ^ ((1 : ℝ) / 2) :=
         rothNumberNat_le_bourgain N hN
 
+/-- **Sharpest density bound for an arbitrary 3-AP-free set: the pointwise minimum.**
+The universal-set lift of `rothNumberNat_le_min_bourgain_blasi`: every 3-AP-free finite set
+`s ⊆ [0, N)` (`N ≥ 3`) is bounded by the *better* of the Bourgain and Bloom–Sisask bounds,
+
+  `#s ≤ min (C · N · (log log N / log N)^{1/2})  (N / (log N)^{1+c})`.
+
+Combining `threeAPFree_card_le_bourgain` and `threeAPFree_card_le_blasi` via `le_min`, this
+is the tightest bound an application can quote for a specific set — for each `N` it is
+whichever of the two known savings is stronger, with no need to pick in advance. Inherits
+exactly the one imported Bloom–Sisask assumption through the Bloom–Sisask branch; adds no
+new axiom. -/
+theorem threeAPFree_card_le_min_bourgain_blasi
+    {s : Finset ℕ} (hs : ThreeAPFree (s : Set ℕ)) {N : ℕ} (hN : 3 ≤ N)
+    (hsub : ∀ x ∈ s, x < N) :
+    (s.card : ℝ) ≤
+      min (bourgainConst * (N : ℝ) *
+            (Real.log (Real.log N) / Real.log N) ^ ((1 : ℝ) / 2))
+          ((N : ℝ) / Real.log N ^ (1 + RothTheoremOQ02.blasiConst)) :=
+  le_min (threeAPFree_card_le_bourgain hs hN hsub) (threeAPFree_card_le_blasi hs hN hsub)
+
 /-- **Roth's 1953 saving factor vanishes.**  `1 / log log N → 0`.  This is the
 qualitative content of Roth's original theorem (`r₃(N) ≪ N / log log N ⟹ r₃(N) = o(N)`),
 the weakest saving in the landscape table.  Recorded here as the companion of

--- a/src/data/proofs/roth-theorem-oq-01/meta.json
+++ b/src/data/proofs/roth-theorem-oq-01/meta.json
@@ -36,8 +36,8 @@
       "threeAPFree_summable_reciprocal (companion file RothTheoremOQ01Reciprocal.lean): the genuine headline consequence of the Bloom–Sisask bound — every 3-AP-free set A ⊆ ℕ has a CONVERGENT reciprocal sum Σ_{a∈A} 1/a < ∞ (the k=3 case of the Erdős conjecture on arithmetic progressions). Proved by dyadic partial summation: the k-th block A ∩ [2^k,2^{k+1}) is 3-AP-free with elements < 2^{k+1}, so threeAPFree_card_le_blasi bounds its reciprocal contribution by 2/((k+1)·log2)^{1+c}, and Σ_k of that converges (p-series, exponent 1+c > 1). Supporting: recipMajorant (dyadic majorant), summable_recipMajorant, fiber_sum_le (per-block bound), finite_recip_sum_le (uniform partial-sum bound). This is strictly stronger than the qualitative r₃(N)=o(N); it needs a full power-of-log saving. Rests on exactly the single imported axiom rothNumberNat_bloom_sisask — no new axiom."
     ],
     "dateAdded": "2026-07-02",
-    "lineCount": 573,
-    "theoremCount": 15,
+    "lineCount": 593,
+    "theoremCount": 20,
     "definitionCount": 1,
     "additionalFiles": [
       "Proofs/RothTheoremOQ02.lean",
@@ -80,9 +80,9 @@
       "Proofs.RothTheoremOQ02"
     ],
     "namespace": "RothTheoremOQ01",
-    "lineCount": 512,
+    "lineCount": 593,
     "axiomCount": 0,
-    "theoremCount": 15,
+    "theoremCount": 20,
     "definitionCount": 1,
     "path": "Proofs/RothTheoremOQ01.lean",
     "sorries": 0,


### PR DESCRIPTION
## Summary

The universal (arbitrary 3-AP-free set) density-bound family in `RothTheoremOQ01.lean` had `threeAPFree_card_le_blasi` and `threeAPFree_card_le_bourgain` separately, plus the *extremal* combined bound `rothNumberNat_le_min_bourgain_blasi` — but not the **universal-set lift** of that pointwise minimum. This PR adds it.

## New theorem

- **`threeAPFree_card_le_min_bourgain_blasi`** — every 3-AP-free finite `s ⊆ [0, N)` (`N ≥ 3`) satisfies `#s ≤ min (Bourgain bound) (Bloom–Sisask bound)`. This is the tightest density bound an application can quote for a specific set: for each `N` it is whichever of the two known savings is stronger, with no need to choose in advance. Proved by `le_min` of the two existing universal bounds.

## Verification

- File compiles cleanly via `bin/lake env lean` (exit 0).
- `#print axioms`: `[propext, RothTheoremOQ02.rothNumberNat_bloom_sisask]` — **identical footprint to its siblings** `threeAPFree_card_le_blasi` / `_bourgain` (the single imported Bloom–Sisask assumption). No new axiom, no `sorryAx`, no `Lean.ofReduceBool`.
- Entry stays `axiomatized`; meta counts refreshed (theoremCount 20, lineCount 593).

🤖 Generated with [Claude Code](https://claude.com/claude-code)