### PR TITLE
research(erdos-1098-oq-01-oq-03): clique number ≤ 1 ⟺ abelian (Γ(G) edgeless iff commutative)

### DIFF
--- a/proofs/Proofs/Erdos1098OQ01OQ03.lean
+++ b/proofs/Proofs/Erdos1098OQ01OQ03.lean
@@ -399,6 +399,37 @@ theorem abelian_bounded_cliques {H : Type*} [CommGroup H] : BoundedCliques H := 
   rw [CommGroup.center_eq_top, Subgroup.index_top]
   exact one_ne_zero
 
+/-- **Clique number `≤ 1` characterizes commutativity (`Γ(G)` is edgeless iff `G` is
+    abelian).**  Every clique of the non-commuting graph has size at most `1` if and only
+    if `G` is abelian: a clique of size `2` is precisely a non-commuting pair, i.e. an edge
+    of `Γ(G)`.  This is the base value grounding `abelian_bounded_cliques` — for an abelian
+    group the sharpest uniform clique bound is `B = 1`, and conversely `ω(Γ(G)) ≤ 1` forces
+    every pair to commute. -/
+theorem clique_card_le_one_iff_comm :
+    (∀ S : Finset G, IsClique S → S.card ≤ 1) ↔ (∀ a b : G, a * b = b * a) := by
+  classical
+  constructor
+  · intro h a b
+    by_contra hab
+    have hnc : nonCommuting a b := hab
+    have hne : a ≠ b := by rintro rfl; exact hnc rfl
+    have hcl : IsClique ({a, b} : Finset G) := by
+      intro g hg h hh hgh
+      simp only [Finset.mem_insert, Finset.mem_singleton] at hg hh
+      rcases hg with rfl | rfl <;> rcases hh with rfl | rfl
+      · exact absurd rfl hgh
+      · exact hnc
+      · exact fun heq => hnc heq.symm
+      · exact absurd rfl hgh
+    have h2 := h {a, b} hcl
+    rw [Finset.card_pair hne] at h2
+    omega
+  · intro hcomm S hS
+    by_contra hcard
+    push_neg at hcard
+    obtain ⟨a, ha, b, hb, hne⟩ := Finset.one_lt_card.mp hcard
+    exact hS a ha b hb hne (hcomm a b)
+
 /-- **Bounded cliques pass to subgroups (heredity of ω(Γ)).**  The non-commuting
     graph `Γ(H)` of a subgroup `H ≤ G` is an *induced subgraph* of `Γ(G)`: the
     inclusion `H ↪ G` is an injective homomorphism, so it carries every clique of

--- a/src/data/proofs/erdos-1098-oq-01-oq-03/meta.json
+++ b/src/data/proofs/erdos-1098-oq-01-oq-03/meta.json
@@ -139,12 +139,12 @@
     }
   ],
   "leanFile": {
-    "lineCount": 655,
+    "lineCount": 686,
     "path": "Proofs/Erdos1098OQ01OQ03.lean",
     "axiomCount": 1,
     "sorries": 0,
     "definitionCount": 3,
-    "theoremCount": 17
+    "theoremCount": 18
   },
   "sorries": 0
 }


### PR DESCRIPTION
## Summary

The file formalizes Neumann's theorem on the non-commuting graph `Γ(G)` (`ω(Γ(G))` finite ⟺ `[G:Z(G)]` finite) with a full closure-property family, but never records the **base characterization** at the bottom of the clique-number scale. This PR adds it, grounding `abelian_bounded_cliques`.

## New theorem (axiom-free)

- **`clique_card_le_one_iff_comm`** — `(∀ clique S, |S| ≤ 1) ↔ G is abelian`. A clique of size `2` is exactly a non-commuting pair (an edge of `Γ(G)`), so `ω(Γ(G)) ≤ 1` iff the graph is **edgeless** iff every pair commutes.
  - Forward: a non-commuting pair `{a,b}` is a 2-clique (`Finset.card_pair`).
  - Reverse: a `≥ 2` clique yields two distinct pairwise-non-commuting elements (`Finset.one_lt_card`), contradicting commutativity.

This is the sharpest possible clique bound (`B = 1`) for abelian groups, the base value underneath `abelian_bounded_cliques`.

## Verification

- `#print axioms`: `[propext, Classical.choice, Quot.sound]` only — the two deep Neumann statement axioms are untouched.
- `classical` supplies `DecidableEq G` for the `{a,b}` construction (`G` carries only `[Group G]`).
- Compiled against Mathlib v4.26.0 (mathlib-only dependency). 0 sorries. `meta.json`: 17 → 18 theorems, 655 → 686 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)