### PR TITLE
research(burnside-counting-oq-02): ofReduceBool-free Burnside sum + general fixed-count corollaries [VERIFIED]

### DIFF
--- a/proofs/Proofs/BurnsideCountingOQ03.lean
+++ b/proofs/Proofs/BurnsideCountingOQ03.lean
@@ -438,6 +438,65 @@ theorem polya_necklace_divisor_formula_of_burnside (n k : ℕ) [NeZero n]
   polya_necklace_divisor_formula n k necklace_count h_burnside
     (fun r => polya_cyclic_fixed_count n k r)
 
+/-! ## §8: General Fixed-Point Corollaries (kernel-checked, `ofReduceBool`-free)
+
+The concrete `n = 4` fixed-point counts in §4 are established by `native_decide`, which
+depends on `Lean.ofReduceBool`. The results below instead specialize the general, kernel-checked
+formula `polya_cyclic_fixed_count` (`|Fix(r)| = k^gcd(r.val, n)`), so they hold for arbitrary
+`n, k` and carry no `native_decide` cost. In particular `fp_sum_binary4_kernel` re-proves the
+headline sum `16 + 2 + 4 + 2 = 24` without `Lean.ofReduceBool`. -/
+
+/-- The identity rotation (`r.val = 0`) fixes **every** coloring: `|Fix(r)| = kⁿ`.
+    Kernel-checked specialization of `polya_cyclic_fixed_count`, since `gcd(0, n) = n`. -/
+theorem fixed_count_identity (n k : ℕ) [NeZero n] (r : Fin n) (hr : r.val = 0) :
+    Fintype.card {c : Fin n → Fin k // IsFixed n k r c} = k ^ n := by
+  rw [polya_cyclic_fixed_count, hr, Nat.gcd_zero_left]
+
+/-- A rotation whose step is **coprime** to the length fixes only the `k` constant colorings:
+    `|Fix(r)| = k`. Generalizes the concrete `r = 1, 3` counts for `n = 4` to every coprime
+    step, with no `native_decide` (hence no `Lean.ofReduceBool` dependency). -/
+theorem fixed_count_of_coprime (n k : ℕ) [NeZero n] (r : Fin n)
+    (hr : Nat.Coprime r.val n) :
+    Fintype.card {c : Fin n → Fin k // IsFixed n k r c} = k := by
+  rw [polya_cyclic_fixed_count, hr.gcd_eq_one, pow_one]
+
+/-- Every fixed-coloring count divides `kⁿ`: since `gcd(r, n) ∣ n`, we get
+    `k^gcd(r,n) ∣ kⁿ`. The Burnside orbit count `kⁿ / n` is thus assembled from divisors
+    of `kⁿ`. -/
+theorem fixed_count_dvd_pow (n k : ℕ) [NeZero n] (r : Fin n) :
+    Fintype.card {c : Fin n → Fin k // IsFixed n k r c} ∣ k ^ n := by
+  rw [polya_cyclic_fixed_count]
+  exact pow_dvd_pow k (Nat.le_of_dvd (NeZero.pos n) (Nat.gcd_dvd_right r.val n))
+
+/-- Upper bound (`k ≥ 1`): every rotation fixes at most `kⁿ` colorings — the identity being
+    the unique maximizer. -/
+theorem fixed_count_le_pow (n k : ℕ) [NeZero n] (r : Fin n) (hk : 1 ≤ k) :
+    Fintype.card {c : Fin n → Fin k // IsFixed n k r c} ≤ k ^ n := by
+  rw [polya_cyclic_fixed_count]
+  exact Nat.pow_le_pow_right hk (Nat.le_of_dvd (NeZero.pos n) (Nat.gcd_dvd_right r.val n))
+
+/-- Lower bound (`k ≥ 1`): every rotation fixes at least the `k` constant colorings, since
+    `1 ≤ gcd(r, n)` for `n > 0`. -/
+theorem fixed_count_ge (n k : ℕ) [NeZero n] (r : Fin n) (hk : 1 ≤ k) :
+    k ≤ Fintype.card {c : Fin n → Fin k // IsFixed n k r c} := by
+  rw [polya_cyclic_fixed_count]
+  calc k = k ^ 1 := (pow_one k).symm
+    _ ≤ k ^ Nat.gcd r.val n :=
+        Nat.pow_le_pow_right hk (Nat.gcd_pos_of_pos_right _ (NeZero.pos n))
+
+/-- **Kernel-checked Burnside sum** for `Z_4` on binary 4-colorings: `16 + 2 + 4 + 2 = 24`,
+    obtained by specializing `polya_cyclic_fixed_count` at each rotation and evaluating the
+    resulting `gcd` powers with `decide`. Unlike `fp_sum_binary4` (which routes through the
+    `native_decide` counts of §4), this proof does **not** depend on `Lean.ofReduceBool`. -/
+theorem fp_sum_binary4_kernel :
+    Fintype.card {c : Fin 4 → Fin 2 // IsFixed 4 2 ⟨0, by norm_num⟩ c} +
+    Fintype.card {c : Fin 4 → Fin 2 // IsFixed 4 2 ⟨1, by norm_num⟩ c} +
+    Fintype.card {c : Fin 4 → Fin 2 // IsFixed 4 2 ⟨2, by norm_num⟩ c} +
+    Fintype.card {c : Fin 4 → Fin 2 // IsFixed 4 2 ⟨3, by norm_num⟩ c} = 24 := by
+  rw [polya_cyclic_fixed_count, polya_cyclic_fixed_count,
+      polya_cyclic_fixed_count, polya_cyclic_fixed_count]
+  decide
+
 #check @MulAction.sum_card_fixedBy_eq_card_orbits_mul_card_group
 #check ZMod.addOrderOf_coe
 #check ZMod.natCast_zmod_val

--- a/src/data/proofs/burnside-counting-oq-03/meta.json
+++ b/src/data/proofs/burnside-counting-oq-03/meta.json
@@ -1,10 +1,10 @@
 {
   "id": "burnside-counting-oq-03",
-  "title": "P\u00f3lya Enumeration Theorem for Cyclic Groups",
+  "title": "Pólya Enumeration Theorem for Cyclic Groups",
   "slug": "burnside-counting-oq-03",
-  "description": "The P\u00f3lya enumeration theorem (PET) generalizes Burnside's lemma by identifying the precise fixed-point count for each group element. For cyclic rotation by r on n positions with k colors, the number of fixed colorings is k^gcd(r,n), where gcd(r,n) equals the number of orbits. Combined with Burnside's lemma, this yields the P\u00f3lya necklace formula: n\u00b7(#distinct k-necklaces) = \u03a3_{d|n} \u03c6(n/d)\u00b7k^d. Concretely verified for binary 4-necklaces: 2^4 + 2^1 + 2^2 + 2^1 = 24, giving 6 distinct necklaces.",
+  "description": "The Pólya enumeration theorem (PET) generalizes Burnside's lemma by identifying the precise fixed-point count for each group element. For cyclic rotation by r on n positions with k colors, the number of fixed colorings is k^gcd(r,n), where gcd(r,n) equals the number of orbits. Combined with Burnside's lemma, this yields the Pólya necklace formula: n·(#distinct k-necklaces) = Σ_{d|n} φ(n/d)·k^d. Concretely verified for binary 4-necklaces: 2^4 + 2^1 + 2^2 + 2^1 = 24, giving 6 distinct necklaces.",
   "meta": {
-    "author": "George P\u00f3lya (1937); formalized via Mathlib",
+    "author": "George Pólya (1937); formalized via Mathlib",
     "sourceUrl": "https://en.wikipedia.org/wiki/Polya_enumeration_theorem",
     "date": "1937",
     "status": "axiomatized",
@@ -45,7 +45,7 @@
       },
       {
         "theorem": "MulAction.sum_card_fixedBy_eq_card_orbits_mul_card_group",
-        "description": "Burnside's lemma: \u03a3 |Fix(g)| = |orbits| \u00d7 |G|",
+        "description": "Burnside's lemma: Σ |Fix(g)| = |orbits| × |G|",
         "module": "Mathlib.GroupTheory.GroupAction.Quotient"
       }
     ],
@@ -53,20 +53,20 @@
       "IsFixed: computable fixed-coloring predicate for cyclic rotation",
       "addOrderOf_rotation: orbit size under cyclic rotation = n / gcd(n, r.val) (wraps Mathlib)",
       "fixed_factors_through_mod: positions with same residue mod gcd(r,n) get same color (proved via Bezout)",
-      "polya_cyclic_fixed_count: |Fix(r)| = k^gcd(r,n) via explicit bijection with Fin(gcd) \u2192 Fin(k)",
+      "polya_cyclic_fixed_count: |Fix(r)| = k^gcd(r,n) via explicit bijection with Fin(gcd) → Fin(k)",
       "fp_count_rot{0,1,2,3}_4_2: proved by native_decide (16, 2, 4, 2 fixed colorings)",
       "fp_sum_binary4: Burnside sum = 24 proved (not axiomatized)",
-      "polya_sum_Z4_binary: \u03a3_{r:Fin 4} 2^gcd(r,4) = 24",
-      "polya_divisor_sum_Z4_binary: \u03a3_{d|4} \u03c6(4/d)\u00b72^d = 24",
-      "polya_sum_identity: general \u03a3_{r:Fin n} k^gcd(r,n) = \u03a3_{d|n} \u03c6(n/d)\u00b7k^d (for all n,k)",
-      "polya_sum_equiv_4_2: two P\u00f3lya formulations are equal",
+      "polya_sum_Z4_binary: Σ_{r:Fin 4} 2^gcd(r,4) = 24",
+      "polya_divisor_sum_Z4_binary: Σ_{d|4} φ(4/d)·2^d = 24",
+      "polya_sum_identity: general Σ_{r:Fin n} k^gcd(r,n) = Σ_{d|n} φ(n/d)·k^d (for all n,k)",
+      "polya_sum_equiv_4_2: two Pólya formulations are equal",
       "polya_binary4_necklace_count: 24/4 = 6 necklaces"
     ]
   },
   "sections": [
     {
       "id": "sec-definitions",
-      "title": "\u00a71: Cyclic Rotation Definitions",
+      "title": "§1: Cyclic Rotation Definitions",
       "startLine": 44,
       "endLine": 59,
       "summary": "Defines IsFixed (fixed-coloring predicate) and DecidablePred instance enabling native_decide proofs.",
@@ -74,7 +74,7 @@
     },
     {
       "id": "sec-addorderof",
-      "title": "\u00a72: Connection to addOrderOf",
+      "title": "§2: Connection to addOrderOf",
       "startLine": 61,
       "endLine": 76,
       "summary": "Proves addOrderOf_rotation: addOrderOf(r : ZMod n) = n/gcd(n, r.val), bridging orbit size to Mathlib's additive order theory.",
@@ -82,7 +82,7 @@
     },
     {
       "id": "sec-orbit",
-      "title": "\u00a73: Orbit Structure",
+      "title": "§3: Orbit Structure",
       "startLine": 78,
       "endLine": 223,
       "summary": "Proves fixed_factors_through_mod (positions with same value mod gcd get same color in fixed colorings) and polya_cyclic_fixed_count (bijection giving |Fix(r)| = k^gcd). Both proved as the general theorems.",
@@ -90,7 +90,7 @@
     },
     {
       "id": "sec-concrete",
-      "title": "\u00a74: Concrete Verification n=4, k=2",
+      "title": "§4: Concrete Verification n=4, k=2",
       "startLine": 225,
       "endLine": 258,
       "summary": "Verifies fp_count_rot0-3_4_2 (16, 2, 4, 2) and fp_sum_binary4 (= 24) by native_decide; directly establishes the counts from burnside-counting.",
@@ -98,7 +98,7 @@
     },
     {
       "id": "sec-polya",
-      "title": "\u00a75: P\u00f3lya Sum Formula and Fiber Reindexing",
+      "title": "§5: Pólya Sum Formula and Fiber Reindexing",
       "startLine": 260,
       "endLine": 362,
       "summary": "Proves polya_sum_Z4_binary and polya_divisor_sum_Z4_binary by native_decide; proves polya_sum_identity (general reindexing via Finset.sum_fiberwise_of_maps_to) with fiber_card_eq_totient as a key sublemma.",
@@ -106,22 +106,22 @@
     },
     {
       "id": "sec-necklaces",
-      "title": "\u00a76-7: Necklace Application and General Formula",
+      "title": "§6-7: Necklace Application and General Formula",
       "startLine": 364,
       "endLine": 402,
-      "summary": "Derives 6 binary 4-necklaces (24/4 = 6). States polya_necklace_formula_statement: assuming Burnside and the fixed-point formula, conclude n \u00b7 necklace_count = \u03a3 k^gcd(r,n).",
+      "summary": "Derives 6 binary 4-necklaces (24/4 = 6). States polya_necklace_formula_statement: assuming Burnside and the fixed-point formula, conclude n · necklace_count = Σ k^gcd(r,n).",
       "mathContext": "$\\#\\text{necklaces}(4,2) = 24/4 = 6$. General: $n \\cdot \\#\\text{necklaces}(n,k) = \\sum_{r=0}^{n-1} k^{\\gcd(r,n)} = \\sum_{d \\mid n} \\varphi(n/d) \\cdot k^d$."
     }
   ],
   "overview": {
-    "historicalContext": "George P\u00f3lya (1937) published his enumeration theorem in 'Kombinatorische Anzahlbestimmungen f\u00fcr Gruppen, Graphen und chemische Verbindungen' (Acta Mathematica), introducing the cycle index as a systematic tool to count distinct combinatorial objects under symmetry. The theorem was independently discovered by John Redfield (1927) but P\u00f3lya's cleaner presentation became standard. The cyclic group case (counting necklaces) was already understood via Burnside's lemma, but P\u00f3lya identified the key formula |Fix(rotation r)| = k^{gcd(r,n)}, which makes the computation explicit.\n\nThis proof builds directly on the companion entry burnside-counting, which axiomatized the binary 4-necklace fixed-point counts. Here we replace those axioms with proofs, establishing the general formula k^{gcd(r,n)} and verifying it computationally for the n=4 case.",
+    "historicalContext": "George Pólya (1937) published his enumeration theorem in 'Kombinatorische Anzahlbestimmungen für Gruppen, Graphen und chemische Verbindungen' (Acta Mathematica), introducing the cycle index as a systematic tool to count distinct combinatorial objects under symmetry. The theorem was independently discovered by John Redfield (1927) but Pólya's cleaner presentation became standard. The cyclic group case (counting necklaces) was already understood via Burnside's lemma, but Pólya identified the key formula |Fix(rotation r)| = k^{gcd(r,n)}, which makes the computation explicit.\n\nThis proof builds directly on the companion entry burnside-counting, which axiomatized the binary 4-necklace fixed-point counts. Here we replace those axioms with proofs, establishing the general formula k^{gcd(r,n)} and verifying it computationally for the n=4 case.",
     "problemStatement": "For the cyclic group $\\mathbb{Z}/n\\mathbb{Z}$ acting on colorings $c : \\text{Fin}\\, n \\to \\text{Fin}\\, k$ by rotation, prove: $|\\text{Fix}(r)| = k^{\\gcd(r,n)}$ and $\\#\\text{necklaces} = \\frac{1}{n}\\sum_{r=0}^{n-1} k^{\\gcd(r,n)} = \\frac{1}{n}\\sum_{d \\mid n} \\varphi(n/d) \\cdot k^d$.",
-    "proofStrategy": "**Layer 1 \u2014 Orbit structure**: Prove that two positions i, j in Fin n are in the same orbit under rotation by r iff i \u2261 j (mod gcd(r,n)). This follows from Bezout's lemma: the subgroup \u27e8r\u27e9 in Z/nZ equals \u27e8gcd(r,n)\u27e9. Hence each orbit has size n/gcd(r,n), and there are gcd(r,n) orbits.\n\n**Layer 2 \u2014 Fixed-point bijection**: A coloring is fixed by rotation r iff it is constant on each orbit. The bijection {fixed colorings} \u2194 (Fin gcd(r,n) \u2192 Fin k) sends c to (j \u21a6 c(j)) on orbit representatives. This gives |Fix(r)| = k^{gcd(r,n)}.\n\n**Layer 3 \u2014 P\u00f3lya sum reindexing**: Reindex \u03a3_{r:Fin n} k^{gcd(r,n)} by d = gcd(r,n). For each divisor d|n, there are \u03c6(n/d) rotations r with gcd(r,n) = d (those with r/d coprime to n/d). This yields the divisor sum form \u03a3_{d|n} \u03c6(n/d)\u00b7k^d.\n\n**Layer 4 \u2014 Concrete verification**: For n=4, k=2, all counts (16, 2, 4, 2) and sums (24) are verified by native_decide.",
+    "proofStrategy": "**Layer 1 — Orbit structure**: Prove that two positions i, j in Fin n are in the same orbit under rotation by r iff i ≡ j (mod gcd(r,n)). This follows from Bezout's lemma: the subgroup ⟨r⟩ in Z/nZ equals ⟨gcd(r,n)⟩. Hence each orbit has size n/gcd(r,n), and there are gcd(r,n) orbits.\n\n**Layer 2 — Fixed-point bijection**: A coloring is fixed by rotation r iff it is constant on each orbit. The bijection {fixed colorings} ↔ (Fin gcd(r,n) → Fin k) sends c to (j ↦ c(j)) on orbit representatives. This gives |Fix(r)| = k^{gcd(r,n)}.\n\n**Layer 3 — Pólya sum reindexing**: Reindex Σ_{r:Fin n} k^{gcd(r,n)} by d = gcd(r,n). For each divisor d|n, there are φ(n/d) rotations r with gcd(r,n) = d (those with r/d coprime to n/d). This yields the divisor sum form Σ_{d|n} φ(n/d)·k^d.\n\n**Layer 4 — Concrete verification**: For n=4, k=2, all counts (16, 2, 4, 2) and sums (24) are verified by native_decide.",
     "keyInsights": [
-      "**Orbit = Coset of \u27e8gcd(r,n)\u27e9**: The critical algebraic fact is that \u27e8r\u27e9 = \u27e8gcd(r,n)\u27e9 as subgroups of Z/nZ. This follows because gcd(r,n) | r (so \u27e8r\u27e9 \u2286 \u27e8gcd(r,n)\u27e9) and Bezout gives gcd(r,n) as a Z-linear combination of r and n (so \u27e8gcd(r,n)\u27e9 \u2286 \u27e8r\u27e9 in Z/nZ).",
+      "**Orbit = Coset of ⟨gcd(r,n)⟩**: The critical algebraic fact is that ⟨r⟩ = ⟨gcd(r,n)⟩ as subgroups of Z/nZ. This follows because gcd(r,n) | r (so ⟨r⟩ ⊆ ⟨gcd(r,n)⟩) and Bezout gives gcd(r,n) as a Z-linear combination of r and n (so ⟨gcd(r,n)⟩ ⊆ ⟨r⟩ in Z/nZ).",
       "**Bezout's Lemma in the Proof**: The proof of fixed_factors_through_mod uses Nat.gcd_eq_gcd_ab (Bezout identity) to find an integer multiplier m such that applying the rotation m times moves position i to position j. This is the key step bridging 'same mod gcd' to 'same orbit'.",
       "**ZMod.addOrderOf_coe as Bridge**: The Mathlib theorem `ZMod.addOrderOf_coe` directly gives addOrderOf(r : ZMod n) = n/gcd(n,r). This equals the orbit size, so gcd(n,r) orbits exist. Without this Mathlib fact, proving the orbit size would require substantially more work.",
-      "**Fiber Reindexing for Divisor Sum**: The identity \u03a3_{r:Fin n} k^{gcd(r,n)} = \u03a3_{d|n} \u03c6(n/d)\u00b7k^d is proved by Finset.sum_fiberwise_of_maps_to \u2014 grouping rotations by their gcd with n. The fiber for divisor d has size \u03c6(n/d), proved via an explicit bijection r \u21a6 r/d with coprime-to-n/d elements.",
+      "**Fiber Reindexing for Divisor Sum**: The identity Σ_{r:Fin n} k^{gcd(r,n)} = Σ_{d|n} φ(n/d)·k^d is proved by Finset.sum_fiberwise_of_maps_to — grouping rotations by their gcd with n. The fiber for divisor d has size φ(n/d), proved via an explicit bijection r ↦ r/d with coprime-to-n/d elements.",
       "**native_decide vs. Proof**: The fixed-point counts for n=4 are verified by native_decide (computation), while the general formulas use mathematical proofs. This demonstrates the dual approach in Lean 4: computational verification for concrete instances, formal proof for the general case. The sorry'd theorems (polya_cyclic_fixed_count, fixed_factors_through_mod) are the bridge between these two layers."
     ],
     "prerequisites": [
@@ -130,16 +130,16 @@
       "Euler totient function and Nat.divisors",
       "Finset.sum_fiberwise_of_maps_to"
     ],
-    "what": "The P\u00f3lya enumeration theorem counts distinct colorings of n positions under cyclic rotation. The key insight is that |Fix(rotation r)| = k^gcd(r,n), because rotation by r partitions positions into gcd(r,n) orbits. Burnside's lemma then gives #necklaces = (1/n)\u00b7\u03a3 k^gcd(r,n).",
+    "what": "The Pólya enumeration theorem counts distinct colorings of n positions under cyclic rotation. The key insight is that |Fix(rotation r)| = k^gcd(r,n), because rotation by r partitions positions into gcd(r,n) orbits. Burnside's lemma then gives #necklaces = (1/n)·Σ k^gcd(r,n).",
     "how": "Two layers: (1) prove the fixed-point formula |Fix(r)| = k^gcd(r,n) using the orbit characterization (two positions are orbit-equivalent iff they agree mod gcd(r,n)); (2) apply Burnside's lemma. For the specific case n=4, k=2, all computations are verified by native_decide.",
-    "significance": "P\u00f3lya enumeration is fundamental to combinatorial counting. The connection |Fix(r)| = k^gcd(r,n) follows from `ZMod.addOrderOf_coe`: the orbit size under rotation by r is n/gcd(n,r), so there are gcd(n,r) orbits."
+    "significance": "Pólya enumeration is fundamental to combinatorial counting. The connection |Fix(r)| = k^gcd(r,n) follows from `ZMod.addOrderOf_coe`: the orbit size under rotation by r is n/gcd(n,r), so there are gcd(n,r) orbits."
   },
   "conclusion": {
-    "summary": "Formalizes the P\u00f3lya enumeration theorem for cyclic groups: proves the general fixed-point formula |Fix(r)| = k^{gcd(r,n)} (with 2 sorries for the orbit bijection), verifies all concrete computations for binary 4-necklaces by native_decide, and establishes both forms of the P\u00f3lya sum (rotational and divisor sum) along with the reindexing identity.",
-    "implications": "This entry achieves two goals: (1) it replaces axioms from burnside-counting with proofs, demonstrating the power of computation via native_decide for concrete instances; (2) it states the general formula polya_cyclic_fixed_count which, once proved, will fully generalize Burnside's lemma to the P\u00f3lya enumeration theorem for all cyclic groups. The fiber_card_eq_totient lemma (fully proved) is the hardest combinatorial step and may be reusable for other P\u00f3lya-type arguments.",
+    "summary": "Formalizes the Pólya enumeration theorem for cyclic groups: proves the general fixed-point formula |Fix(r)| = k^{gcd(r,n)} (with 2 sorries for the orbit bijection), verifies all concrete computations for binary 4-necklaces by native_decide, and establishes both forms of the Pólya sum (rotational and divisor sum) along with the reindexing identity.",
+    "implications": "This entry achieves two goals: (1) it replaces axioms from burnside-counting with proofs, demonstrating the power of computation via native_decide for concrete instances; (2) it states the general formula polya_cyclic_fixed_count which, once proved, will fully generalize Burnside's lemma to the Pólya enumeration theorem for all cyclic groups. The fiber_card_eq_totient lemma (fully proved) is the hardest combinatorial step and may be reusable for other Pólya-type arguments.",
     "openQuestions": [
-      "Complete polya_cyclic_fixed_count: the bijection {fixed colorings} \u2194 (Fin d \u2192 Fin k) remains as a sorry \u2014 the invFun half (backward map) is defined but left_inv requires showing that coloring by orbit representative and then evaluating at a representative gives back the original coloring.",
-      "Generalize from cyclic groups to arbitrary finite groups: the full P\u00f3lya enumeration theorem uses the cycle index of an arbitrary permutation group. Can the Lean formalization be extended to, e.g., the dihedral group acting on necklaces?",
+      "Complete polya_cyclic_fixed_count: the bijection {fixed colorings} ↔ (Fin d → Fin k) remains as a sorry — the invFun half (backward map) is defined but left_inv requires showing that coloring by orbit representative and then evaluating at a representative gives back the original coloring.",
+      "Generalize from cyclic groups to arbitrary finite groups: the full Pólya enumeration theorem uses the cycle index of an arbitrary permutation group. Can the Lean formalization be extended to, e.g., the dihedral group acting on necklaces?",
       "Interface with Burnside's lemma in Mathlib: MulAction.sum_card_fixedBy_eq_card_orbits_mul_card_group is cited but not directly applied. A future formalization could connect polya_necklace_formula_statement to this Mathlib theorem."
     ]
   },
@@ -148,13 +148,13 @@
       "id": "xref-burnside-parent",
       "targetId": "burnside-counting",
       "relationship": "extends",
-      "description": "Generalizes the axiomatized binary 4-necklace computation to the full P\u00f3lya formula; removes axioms by computing fixed-point counts directly."
+      "description": "Generalizes the axiomatized binary 4-necklace computation to the full Pólya formula; removes axioms by computing fixed-point counts directly."
     },
     {
       "id": "xref-euler-totient",
       "targetId": "euler-totient",
       "relationship": "uses",
-      "description": "Euler's totient $\\varphi$ is the indispensable coefficient in the P\u00f3lya necklace formula $n \\cdot N(n, k) = \\sum_{d \\mid n} \\varphi(n/d) \\cdot k^d$. The number of cyclic rotations of order exactly $d$ is $\\varphi(d)$ \u2014 those rotations $r$ with $\\gcd(r, n) = n/d$. Without $\\varphi$, the rotation-by-degree group-by counting cannot collapse from $n$ rotations to $\\sum_{d \\mid n} \\varphi(n/d)$ orbits-per-divisor terms."
+      "description": "Euler's totient $\\varphi$ is the indispensable coefficient in the Pólya necklace formula $n \\cdot N(n, k) = \\sum_{d \\mid n} \\varphi(n/d) \\cdot k^d$. The number of cyclic rotations of order exactly $d$ is $\\varphi(d)$ — those rotations $r$ with $\\gcd(r, n) = n/d$. Without $\\varphi$, the rotation-by-degree group-by counting cannot collapse from $n$ rotations to $\\sum_{d \\mid n} \\varphi(n/d)$ orbits-per-divisor terms."
     },
     {
       "id": "xref-gcd-algorithm",
@@ -166,13 +166,13 @@
       "id": "xref-inclusion-exclusion",
       "targetId": "inclusion-exclusion",
       "relationship": "related",
-      "description": "Both Burnside's lemma and inclusion-exclusion are 'averaging' counting techniques that convert overcounted enumerations into orbit/union sizes. Burnside averages fixed-point counts over a group; inclusion-exclusion alternates intersection sizes. P\u00f3lya enumeration unifies them by tracking *which* orbits each group element fixes \u2014 and M\u00f6bius inversion on the divisor lattice (Burnside-by-divisor) is formally analogous to M\u00f6bius inversion on the subset lattice (inclusion-exclusion)."
+      "description": "Both Burnside's lemma and inclusion-exclusion are 'averaging' counting techniques that convert overcounted enumerations into orbit/union sizes. Burnside averages fixed-point counts over a group; inclusion-exclusion alternates intersection sizes. Pólya enumeration unifies them by tracking *which* orbits each group element fixes — and Möbius inversion on the divisor lattice (Burnside-by-divisor) is formally analogous to Möbius inversion on the subset lattice (inclusion-exclusion)."
     },
     {
       "id": "xref-binomial-theorem",
       "targetId": "binomial-theorem",
       "relationship": "related",
-      "description": "P\u00f3lya enumeration generalizes binomial-style counting from unordered selections (color $k$ objects from $n$ with no symmetry) to selections under group action (color $k$ objects from $n$ modulo cyclic rotation). The identity $\\sum_{d \\mid n} \\varphi(n/d) k^d = n \\cdot N(n, k)$ specialises to $k^n$ when the symmetry group is trivial, recovering plain binomial counting; the divisor sum is the symmetry-aware refinement."
+      "description": "Pólya enumeration generalizes binomial-style counting from unordered selections (color $k$ objects from $n$ with no symmetry) to selections under group action (color $k$ objects from $n$ modulo cyclic rotation). The identity $\\sum_{d \\mid n} \\varphi(n/d) k^d = n \\cdot N(n, k)$ specialises to $k^n$ when the symmetry group is trivial, recovering plain binomial counting; the divisor sum is the symmetry-aware refinement."
     }
   ],
   "references": [
@@ -211,7 +211,7 @@
     "axiomCount": 0,
     "sorries": 0,
     "definitionCount": 1,
-    "theoremCount": 20,
+    "theoremCount": 26,
     "additionalFiles": [
       "Proofs/BurnsideCountingOQ03Aristotle.lean",
       {

--- a/src/data/research/problems/burnside-counting-oq-02.json
+++ b/src/data/research/problems/burnside-counting-oq-02.json
@@ -53,7 +53,8 @@
       "Both framings of this problem are already resolved in main: the parent native_decide discharge (oq-01 S3) and the OQ03 Polya divisor-sum theorems. Verification, not new proof, was the remaining work.",
       "The headline necklace count never required bridging Mathlib's multiplicative burnside_lemma to the additive ZMod n action: once IsFixedByRotation/the orbit relation are decidable, both the fixed-point sum and the 6-necklace count collapse to native_decide (BurnsideCounting.lean) or explicit Fin-sum evaluation (BurnsideCountingOQ03.lean).",
       "native_decide closes the two finite counts at the cost of the Lean.ofReduceBool axiom (compiler-trusted, not kernel-reduced); the divisor-sum identity polya_sum_Z4_binary in OQ03 is an alternative kernel-checked route to the same value 24.",
-      "The Burnside engine sum_fixedBy_eq_card_necklaces_mul (sum |Fix(a)| = |necklaces|*n) gives necklace integrality n | sum |Fix(a)| as a one-liner (dvd_mul_left) and the exact Burnside average |necklaces| = (sum |Fix(a)|)/n via Nat.mul_div_cancel — the general statements behind every concrete /n necklace count in the cluster, previously only used implicitly per-case."
+      "The Burnside engine sum_fixedBy_eq_card_necklaces_mul (sum |Fix(a)| = |necklaces|*n) gives necklace integrality n | sum |Fix(a)| as a one-liner (dvd_mul_left) and the exact Burnside average |necklaces| = (sum |Fix(a)|)/n via Nat.mul_div_cancel — the general statements behind every concrete /n necklace count in the cluster, previously only used implicitly per-case.",
+      "§8 (researcher-8, 2026-07-11): the headline Burnside sum 16+2+4+2=24 also has an ofReduceBool-free proof: fp_sum_binary4_kernel specializes the general kernel-checked polya_cyclic_fixed_count at each of the four rotations and closes the residual gcd-power arithmetic with plain decide, avoiding the native_decide route of fp_sum_binary4. The same specialization yields general corollaries fixed_count_identity (r=0 -> k^n), fixed_count_of_coprime (Coprime step -> k), fixed_count_dvd_pow (|Fix(r)| | k^n), and the sandwich k <= |Fix(r)| <= k^n (k>=1)."
     ],
     "mathlibGaps": [],
     "nextSteps": [
@@ -115,8 +116,8 @@
     {
       "path": "Proofs/BurnsideCountingOQ03.lean",
       "filename": "BurnsideCountingOQ03.lean",
-      "lineCount": 405,
-      "theoremCount": 16,
+      "lineCount": 463,
+      "theoremCount": 22,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,


### PR DESCRIPTION
## Summary

Extends `proofs/Proofs/BurnsideCountingOQ03.lean` — the designated clean Pólya-enumeration source for the `burnside-counting-oq-02` entry — with a new **§8** of six general, kernel-checked corollaries of the file's core theorem `polya_cyclic_fixed_count` (`|Fix(r)| = k^gcd(r.val, n)`).

## New theorems (all axiom-free)

| Theorem | Statement |
|---|---|
| `fixed_count_identity` | `r.val = 0 → \|Fix(r)\| = kⁿ` (identity fixes every coloring) |
| `fixed_count_of_coprime` | `Coprime r.val n → \|Fix(r)\| = k` (only the `k` constants fixed) |
| `fixed_count_dvd_pow` | `\|Fix(r)\| ∣ kⁿ` (since `gcd(r,n) ∣ n`) |
| `fixed_count_le_pow` | `\|Fix(r)\| ≤ kⁿ` (`k ≥ 1`; identity is the maximizer) |
| `fixed_count_ge` | `k ≤ \|Fix(r)\|` (`k ≥ 1`; constants always fixed) |
| `fp_sum_binary4_kernel` | `16 + 2 + 4 + 2 = 24` **without `native_decide`** |

## Why this matters

The entry's own knowledge base notes that the headline binary-4-necklace count `Σ\|Fix(r)\| = 24` was only available via `native_decide` (§4, costing the `Lean.ofReduceBool` axiom) or the separate divisor-sum route (`polya_divisor_sum_Z4_binary`). `fp_sum_binary4_kernel` closes that gap: it specializes the general **kernel-checked** `polya_cyclic_fixed_count` at each of the four `Z_4` rotations and discharges the residual `gcd`-power arithmetic with plain `decide`, giving an `ofReduceBool`-free proof of `24`.

The five general corollaries also lift the concrete §4 counts (rotations `0,1,2,3` for `n=4`) to statements about **arbitrary `n, k`**, with no `native_decide`.

## Verification

- Built clean via `./proofs/scripts/docker-build.sh Proofs.BurnsideCountingOQ03` (3058 jobs, success).
- `#print axioms` on the four key new theorems reports only `[propext, Classical.choice, Quot.sound]` — **no `Lean.ofReduceBool`, no `sorryAx`**.
- `theoremCount` 16 → 22 for `BurnsideCountingOQ03.lean`; gallery meta + problem JSON updated accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)