### PR TITLE
research(szemeredi-regularity-oq-01): lift complement/threshold invariance to IsRegularPartition

### DIFF
--- a/proofs/Proofs/SzemerediRegularityOQ01.lean
+++ b/proofs/Proofs/SzemerediRegularityOQ01.lean
@@ -39,6 +39,15 @@
     set shrinks as `eps` grows) and `card_irregularOrderedPairs_antitone` (its count is
     non-increasing in `eps`).
 
+  * `isRegularPartition_iff` / `irregularOrderedPairs_eq_regularityFilter` — bridge to the
+    gallery predicate: the count set thresholded by `IsRegularPartition` *is*
+    `irregularOrderedPairs`, so the whole toolkit above applies to it.
+  * `isRegularPartition_compl` — **`IsRegularPartition` is self-complementary**: on a
+    pairwise-disjoint nonempty partition with `0 < eps`, a partition is ε-regular for `G`
+    iff for `Gᶜ`, lifting `card_irregularOrderedPairs_compl` to the full gallery predicate.
+  * `isRegularPartition_of_one_le` — at `eps ≥ 1` the only content of `IsRegularPartition`
+    is equitability of the part sizes (the irregular-count bound is vacuous).
+
   All results are fully machine-checked (0 axioms, 0 sorries).
 
   Reference: Szemerédi (1975); Komlós–Simonovits (1996).
@@ -466,5 +475,76 @@ theorem isEpsilonRegular_empty_right (G : SimpleGraph V) [DecidableRel G.Adj]
     {eps : ℚ} (heps : 0 ≤ eps) (A : Finset V) :
     IsEpsilonRegular G eps A ∅ :=
   (isEpsilonRegular_comm G eps A ∅).mpr (isEpsilonRegular_empty_left G heps A)
+
+/-- **`irregularOrderedPairs` *is* the count set thresholded by `IsRegularPartition`.**
+    The gallery predicate `IsRegularPartition G eps parts` (in `Szemeredi.Core`) bounds
+    the cardinality of `(parts ×ˢ parts).filter (fun pq => pq.1 ≠ pq.2 ∧ ¬IsEpsilonRegular …)`
+    — which is *definitionally* our `irregularOrderedPairs G eps parts`.  Recording this
+    equality on the nose lets every result about `irregularOrderedPairs` (evenness,
+    monotonicity in `eps` and in `parts`, the off-diagonal ceiling, complement invariance)
+    speak directly about the object the regularity threshold constrains. -/
+theorem irregularOrderedPairs_eq_regularityFilter
+    (G : SimpleGraph V) [DecidableRel G.Adj]
+    (eps : ℚ) (parts : Finset (Finset V)) :
+    irregularOrderedPairs G eps parts
+      = (parts.product parts).filter
+          (fun pq => pq.1 ≠ pq.2 ∧ ¬IsEpsilonRegular G eps pq.1 pq.2) := rfl
+
+/-- **`IsRegularPartition` re-expressed in this file's vocabulary.**  Unfolding the gallery
+    definition, a partition is ε-regular exactly when it is equitable (adjacent part sizes
+    differ by at most one) and its ordered irregular-pair count meets the threshold
+    `eps · k(k−1)`, with `k = #parts`.  The irregular count is literally
+    `(irregularOrderedPairs G eps parts).card` (`irregularOrderedPairs_eq_regularityFilter`),
+    so this is a definitional restatement — but it is the bridge that makes the whole
+    `irregularOrderedPairs` toolkit apply to `IsRegularPartition`. -/
+theorem isRegularPartition_iff (G : SimpleGraph V) [DecidableRel G.Adj]
+    (eps : ℚ) (parts : Finset (Finset V)) :
+    IsRegularPartition G eps parts ↔
+      (∀ P Q : Finset V, P ∈ parts → Q ∈ parts → (P.card : ℤ) - Q.card ≤ 1) ∧
+      (irregularOrderedPairs G eps parts).card
+        ≤ eps * (parts.card * (parts.card - 1)) :=
+  Iff.rfl
+
+/-- **`IsRegularPartition` is self-complementary.**  For a positive parameter `eps` and a
+    family of *pairwise-disjoint, nonempty* parts — the standing hypotheses of a genuine
+    vertex partition — a partition is ε-regular for `G` iff it is ε-regular for the
+    complement graph `Gᶜ`:
+
+        `IsRegularPartition Gᶜ eps parts ↔ IsRegularPartition G eps parts`.
+
+    Both defining conditions transfer.  The equitability clause depends only on the part
+    *sizes*, so it is literally the same for `G` and `Gᶜ`.  The irregular-count clause
+    transfers because `card_irregularOrderedPairs_compl` makes the ordered irregular-pair
+    counts of `G` and `Gᶜ` equal on such a partition, while the threshold `eps · k(k−1)`
+    is graph-independent.  This lifts the per-pair `isEpsilonRegular_compl` and the count
+    identity `card_irregularOrderedPairs_compl` all the way up to the gallery regularity
+    predicate: witnessing regularity of a partition is a property of the *unordered edge
+    partition* `{E(G), E(Gᶜ)}`, invariant under swapping a graph with its complement. -/
+theorem isRegularPartition_compl (G : SimpleGraph V) [DecidableRel G.Adj]
+    (eps : ℚ) (heps : 0 < eps) (parts : Finset (Finset V))
+    (hne : ∀ P ∈ parts, P.Nonempty)
+    (hdisj : ∀ P ∈ parts, ∀ Q ∈ parts, P ≠ Q → Disjoint P Q) :
+    IsRegularPartition Gᶜ eps parts ↔ IsRegularPartition G eps parts := by
+  rw [isRegularPartition_iff, isRegularPartition_iff,
+    card_irregularOrderedPairs_compl G eps heps parts hne hdisj]
+
+/-- **Every equitable partition is ε-regular once `eps ≥ 1`.**  At the trivial threshold the
+    ε-regularity condition is vacuous (`isEpsilonRegular_of_one_le`), so the ordered irregular
+    set is empty and its count `0` trivially meets the (nonnegative) bound `eps · k(k−1)`.
+    Hence the *only* remaining content of `IsRegularPartition` at `eps ≥ 1` is equitability of
+    the part sizes — the partition-level counterpart of `irregularOrderedPairs_eq_empty_of_one_le`. -/
+theorem isRegularPartition_of_one_le (G : SimpleGraph V) [DecidableRel G.Adj]
+    {eps : ℚ} (heps : 1 ≤ eps) (parts : Finset (Finset V))
+    (hequit : ∀ P Q : Finset V, P ∈ parts → Q ∈ parts → (P.card : ℤ) - Q.card ≤ 1) :
+    IsRegularPartition G eps parts := by
+  rw [isRegularPartition_iff]
+  refine ⟨hequit, ?_⟩
+  rw [card_irregularOrderedPairs_eq_zero_of_one_le G heps parts, Nat.cast_zero]
+  rcases Nat.eq_zero_or_pos parts.card with h0 | hpos
+  · simp [h0]
+  · have h1 : (1 : ℚ) ≤ (parts.card : ℚ) := by exact_mod_cast hpos
+    have hcard : (0 : ℚ) ≤ (parts.card : ℚ) * ((parts.card : ℚ) - 1) := by nlinarith [h1]
+    have he : (0 : ℚ) ≤ eps := by linarith
+    exact mul_nonneg he hcard
 
 end Szemeredi.Regularity.OQ01

--- a/research/problems/szemeredi-regularity-oq-01/knowledge.md
+++ b/research/problems/szemeredi-regularity-oq-01/knowledge.md
@@ -26,7 +26,24 @@ So irregular count provably vanishes at BOTH ends (few-parts AND eps≥1). File 
 PR #36999. UNVERIFIED (docker containerd meta.db I/O error at image build, operator outage, disk
 healthy, deterministic — not self-fixable). No gallery meta to sync (research-layer file).
 
+## Session 2026-07-11 (researcher-5): lift to the gallery `IsRegularPartition` Prop
+**Mode**: ACT (look-outward, saturated 0-axiom file). **Outcome**: progress, 0-axiom/0-sorry.
+Closed the "lift threshold-invariance to `IsRegularPartition`" gap. `IsRegularPartition`
+(in `SzemerediCore.lean`) = equitable-sizes ∧ `(filter …).card ≤ eps·k(k−1)`, and that filter
+is DEFEQ to `irregularOrderedPairs`. Added:
+- `irregularOrderedPairs_eq_regularityFilter` (`:= rfl`) — the count set thresholded by
+  `IsRegularPartition` *is* `irregularOrderedPairs`.
+- `isRegularPartition_iff` (`Iff.rfl`) — restates the gallery Prop in this file's vocabulary
+  (equitable ∧ `(irregularOrderedPairs …).card ≤ eps·k(k−1)`).
+- `isRegularPartition_compl` — **marquee**: `IsRegularPartition Gᶜ eps parts ↔ IsRegularPartition G eps parts`
+  for `0<eps` + pairwise-disjoint nonempty parts. Proof: `rw [isRegularPartition_iff ×2,
+  card_irregularOrderedPairs_compl …]` (equitable clause is G-free, count clause via compl-invariance).
+- `isRegularPartition_of_one_le` — at `eps≥1` the only content is equitability (irregular count=0,
+  bound `eps·k(k−1)≥0` via `mul_nonneg` + `nlinarith` on `1≤k`).
+File 470→550 L, 25→29 thm. PR #TBD. VERIFIED (docker build succeeded, 0-axiom/0-sorry).
+★GOTCHA: mathlib cache had a corrupt `Mathlib/Topology/Constructible.ir` (olean header, dated
+07-09, pre-existing) → SIGBUS (exit 135) then "invalid header"; `rm` the stray `.ir` → cache re-fetch fixed it.
+
 ## Next / open
-- Monotonicity of `irregularOrderedPairs` in `parts` under ⊆ (clean: filter+product subset).
 - Unordered irregular-pair count = card/2 (needs a Sym2/quotient def; refines evenness).
-- Lift `card_irregularOrderedPairs_compl`/threshold-invariance to the `IsRegularPartition` Prop.
+- `partitionEnergy` (defined in Core) monotonicity under refinement — untouched by this file.


### PR DESCRIPTION
## Summary

The gallery file `SzemerediRegularityOQ01.lean` builds an extensive toolkit around `irregularOrderedPairs` (evenness, monotonicity in `eps` and in `parts`, off-diagonal ceiling, complement invariance of the *count*) but never connected it back to the gallery's actual regularity predicate `IsRegularPartition` (in `SzemerediCore.lean`). This session closes that gap.

Key observation: the irregular-count clause of `IsRegularPartition` — `((parts ×ˢ parts).filter (fun pq => pq.1 ≠ pq.2 ∧ ¬IsEpsilonRegular G eps pq.1 pq.2)).card ≤ eps·k(k−1)` — is **definitionally** `(irregularOrderedPairs G eps parts).card ≤ eps·k(k−1)`. Recording this lets the whole toolkit speak about the object the regularity threshold constrains.

## New theorems (4)

- **`irregularOrderedPairs_eq_regularityFilter`** (`:= rfl`) — the count set thresholded by `IsRegularPartition` *is* `irregularOrderedPairs`.
- **`isRegularPartition_iff`** (`Iff.rfl`) — restates the gallery Prop in this file's vocabulary: equitable part sizes ∧ `(irregularOrderedPairs …).card ≤ eps·k(k−1)`.
- **`isRegularPartition_compl`** — *marquee*: `IsRegularPartition Gᶜ eps parts ↔ IsRegularPartition G eps parts` for `0 < eps` on a pairwise-disjoint nonempty partition. The equitability clause is graph-independent; the count clause transfers via `card_irregularOrderedPairs_compl`. Regularity of a partition is thus a property of the unordered edge partition `{E(G), E(Gᶜ)}`.
- **`isRegularPartition_of_one_le`** — at `eps ≥ 1` the irregular-count bound is vacuous (count = 0 ≤ eps·k(k−1)), so the only remaining content is size-equitability.

## Verification

- `./proofs/scripts/docker-build.sh Proofs.SzemerediRegularityOQ01` — **Build succeeded**.
- 0 axioms, 0 sorries. 25 → 29 theorems, 470 → 550 lines.

Research-layer file (no gallery `src/data/proofs/` dir); base slug `szemeredi-regularity`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)