### PR TITLE
research(erdos-634): congruent triangles have equal area (Heron is a congruence invariant)

### DIFF
--- a/proofs/Proofs/Erdos634Problem.lean
+++ b/proofs/Proofs/Erdos634Problem.lean
@@ -116,6 +116,32 @@ noncomputable def Triangle.area (T : Triangle) : ℝ :=
   Real.sqrt (T.semiperimeter * (T.semiperimeter - T.a) *
              (T.semiperimeter - T.b) * (T.semiperimeter - T.c))
 
+/-- **Congruent triangles have equal area.**  Heron's formula
+`Area = √(s(s−a)(s−b)(s−c))` is a *symmetric* function of the side lengths `a, b, c`
+(the semiperimeter `s` is half their sum, and the radicand's remaining factor is the
+product over the three sides), so it depends only on the *multiset* `{a, b, c}` — which is
+exactly what `Congruent` fixes.  Hence congruence preserves area: the area invariant on
+which the `Dissection.area_partition` balance condition rests is genuinely a congruence
+invariant. -/
+theorem congruent_implies_equal_area {T₁ T₂ : Triangle} (h : Congruent T₁ T₂) :
+    T₁.area = T₂.area := by
+  have hs : T₁.semiperimeter = T₂.semiperimeter := by
+    unfold Triangle.semiperimeter
+    have hh := congrArg Multiset.sum h
+    simp only [Congruent, Multiset.sum_coe, List.sum_cons, List.sum_nil, add_zero] at hh
+    linarith
+  have hprod :
+      (T₂.semiperimeter - T₁.a) * ((T₂.semiperimeter - T₁.b) * (T₂.semiperimeter - T₁.c))
+        = (T₂.semiperimeter - T₂.a) * ((T₂.semiperimeter - T₂.b) * (T₂.semiperimeter - T₂.c)) := by
+    have hp := congrArg
+      (fun m => (Multiset.map (fun x => T₂.semiperimeter - x) m).prod) h
+    simpa only [Congruent, Multiset.map_coe, List.map_cons, List.map_nil,
+      Multiset.prod_coe, List.prod_cons, List.prod_nil, mul_one] using hp
+  unfold Triangle.area
+  rw [hs]
+  congr 1
+  linear_combination T₂.semiperimeter * hprod
+
 /-- A dissection of triangle T into n pieces where the pieces partition T by area.
     Note: area equality is necessary but not sufficient for a genuine tiling;
     a full formalization would also require disjointness and coverage. -/

--- a/src/data/proofs/erdos-634/meta.json
+++ b/src/data/proofs/erdos-634/meta.json
@@ -57,8 +57,8 @@
     ],
     "axiomCount": 4,
     "assumptions": "4 axioms in Erdos634Problem.lean: Tiles (abstract tiling predicate), seven_not_dissectable, eleven_not_dissectable, soifer_theorem. 5 sorries: the five positive-result stubs (squares/two/three/six/sum), each a genuine reptiling construction blocked only on Mathlib's missing polygonal-tiling API. SOUNDNESS (resolved): a prior version was internally inconsistent — the area-only IsDissectable is provable for every n >= 1 (constant equilateral witnesses of side 1/sqrt(n), proven in Erdos634AreaCollapse.lean), which contradicted the Beeson non-dissectability axioms; and congruent_implies_similar was a sorry on a false statement (unordered-multiset Congruent vs order-pinned Similar). Both are now fixed: IsDissectable additionally requires an abstract Tiles (covering + interior-disjointness) witness, blocking the trivial equal-area construction so Beeson's negatives are consistent; and Similar is restated on the unordered side multiset, making congruent_implies_similar a real 1-line proof. A faithful non-abstract Tiles still awaits a Mathlib tiling API (the oq-02 covering line).",
-    "lineCount": 386,
-    "theoremCount": 17,
+    "lineCount": 412,
+    "theoremCount": 18,
     "definitionCount": 20,
     "additionalFiles": [
       "Proofs/Erdos634Aristotle.lean",
@@ -201,9 +201,9 @@
       "Function"
     ],
     "namespace": "Erdos634",
-    "lineCount": 386,
+    "lineCount": 412,
     "axiomCount": 4,
-    "theoremCount": 17,
+    "theoremCount": 18,
     "definitionCount": 20,
     "sorries": 5,
     "path": "Proofs/Erdos634Problem.lean",


### PR DESCRIPTION
## Summary

The primary Erdős #634 triangle-dissection file develops the `Congruent` / `Similar` / `area` apparatus (equivalence lemmas, `congruent_implies_similar`) but never records that **congruence preserves area** — the invariant on which the `Dissection.area_partition` balance condition rests. This PR adds it.

## New theorem (axiom-free)

- **`congruent_implies_equal_area`** — `Congruent T₁ T₂ → T₁.area = T₂.area`. Heron's radicand `s(s−a)(s−b)(s−c)` is a *symmetric* function of the side lengths, so it depends only on the multiset `{a,b,c}` that `Congruent` fixes. Proof: the semiperimeters agree (`Multiset.sum` invariance) and the product `∏(s − side)` agrees (`Multiset.map`/`prod` invariance), combined via `linear_combination`.

Adds **no axioms** (the 4 existing — including the deliberately-abstract `Tiles` — are untouched) and **no sorries** (the 5 pre-existing construction sorries, blocked by the uninterpreted `Tiles` predicate *by design*, remain). 17 → 18 theorems.

## Verification note

The full file **cannot be compiled in the current environment**: the shared Mathlib build is missing the `.ir` data file for `Mathlib.Topology.Constructible`, so even the **pristine** file fails at `import Mathlib` (a pre-existing infrastructure gap, unrelated to this change).

The new proof was therefore verified **in isolation** against byte-identical `Triangle` / `Congruent` / `semiperimeter` / `area` definitions, using targeted imports (`Mathlib.Data.Real.Sqrt` + `Multiset.Basic` + `Tactic.Linarith` + `Tactic.LinearCombination`) that avoid the broken module:

- `#print axioms congruent_implies_equal_area` → `[propext, Classical.choice, Quot.sound]`, **no `sorryAx`**, no errors.

The theorem depends only on `Triangle`/`Congruent`/`semiperimeter`/`area`, all identical to the real file, so it will elaborate there once the environment's Mathlib IR is complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)