### PR TITLE
research(erdos-490-incomplete-01): characterize the degenerate ordered multiplicative-Sidon property

### DIFF
--- a/proofs/Proofs/Erdos490Problem.lean
+++ b/proofs/Proofs/Erdos490Problem.lean
@@ -650,6 +650,31 @@ theorem primes_products_determine_pair {p₁ q₁ p₂ q₂ : ℕ}
     rw [← hp₁q₂, Nat.mul_comm p₂ p₁] at h
     exact Nat.eq_of_mul_eq_mul_left hp₁.pos h
 
+/-- **The ordered multiplicative-Sidon property is degenerate.**  For the *ordered*
+notion `IsMultiplicativeSidon A = HasDistinctProducts A A` (which demands the product
+map injective on `A ×ˢ A`),
+
+    `IsMultiplicativeSidon A  ↔  A.card ≤ 1`.
+
+This makes precise the observation, sketched in prose above for `A = {2, 3}`, that the
+ordered notion collapses: any two *distinct* elements `a, b ∈ A` give the coincidence
+`a·b = b·a` with `(a, b) ≠ (b, a)`, so injectivity of the product map on `A ×ˢ A` forces
+`A` to have at most one element (and conversely a set of size `≤ 1` trivially satisfies
+it).  Hence the honest multiplicative-Sidon content for `|A| ≥ 2` is the *unordered*
+statement `primes_products_determine_pair`, not this ordered one.  Axiom-free. -/
+theorem isMultiplicativeSidon_iff_card_le_one (A : Finset ℕ) :
+    IsMultiplicativeSidon A ↔ A.card ≤ 1 := by
+  rw [IsMultiplicativeSidon, ← productMapInjective_iff_hasDistinctProducts]
+  constructor
+  · intro h
+    by_contra hc
+    push_neg at hc
+    obtain ⟨a, ha, b, hb, hab⟩ := Finset.one_lt_card.mp hc
+    exact hab (h a b b a ha hb hb ha (by ring)).1
+  · intro h a₁ a₂ b₁ b₂ ha₁ ha₂ hb₁ hb₂ _
+    have hall := Finset.card_le_one.mp h
+    exact ⟨hall a₁ ha₁ a₂ ha₂, hall b₁ hb₁ b₂ hb₂⟩
+
 /-
 ## Part VII: Related Problems
 -/


### PR DESCRIPTION
## Summary

`Erdos490Problem.lean` defines `IsMultiplicativeSidon A := HasDistinctProducts A A`
and observes *in prose* (via the `A = {2, 3}` example) that this **ordered** notion
collapses for `|A| ≥ 2`: commutativity forces `a·b = b·a` with `(a, b) ≠ (b, a)`, so
the product map cannot be injective on `A ×ˢ A`. The file never proves the general
statement. This PR supplies it:

    isMultiplicativeSidon_iff_card_le_one : IsMultiplicativeSidon A ↔ A.card ≤ 1

Consequently the honest multiplicative-Sidon content for `|A| ≥ 2` is the *unordered*
`primes_products_determine_pair` already in the file, not the ordered `A = B`
specialization. Elementary `Finset` argument (`Finset.one_lt_card`,
`Finset.card_le_one`), axiom-free; the deep `szemeredi_theorem` axiom is untouched.

## Verification

The proof logic is verified against Mathlib `v4.26.0` in an isolated harness
(reproducing the file's `HasDistinctProducts` / `ProductMapInjective` /
`IsMultiplicativeSidon` definitions and the proven
`productMapInjective_iff_hasDistinctProducts` bridge), compiling clean.

Full-file host compilation is currently blocked by a transient gap in the shared
prebuilt Mathlib cache (a missing `Mathlib.Topology.Constructible.ir` — one IR file
absent from an otherwise-complete cache, removed by a concurrent build mid-session).
A background job re-runs `#print axioms` on full-file compile once the cache is
restored; the result will be posted here.