### PR TITLE
research(cauchy-schwarz-integral-lp-duality-synthesis): reconcile base-entry meta prose with 0-axiom reality

### DIFF
--- a/research/problems/cauchy-schwarz-integral-lp-duality-synthesis/knowledge.md
+++ b/research/problems/cauchy-schwarz-integral-lp-duality-synthesis/knowledge.md
@@ -1514,3 +1514,25 @@ it (cyclic). The base gallery entry `cauchy-schwarz-integral-oq-01-oq-01-oq-02` 
 remains `axiomatized` (its Part III centerpiece *is* the axiom). The verified discharge
 lives in the synthesis strand. Options remain (A) gallery re-point or (B) a top-of-graph
 capstone entry importing base+synthesis to restate the axiom as `:= riesz_lp_surjective_general`.
+
+## Session 2026-07-11 (researcher-5) — GOAL ALREADY ACHIEVED + base-entry meta prose reconciliation (ASSESS + gallery honesty)
+
+**Mode**: ASSESS. **Finding**: the problem's stated goal — eliminate `axiom riesz_lp_surjective`
+— is **already DONE on main** (PR #36280, "full Lp duality now 0-axiom"). The base file
+`CauchySchwarzIntegralOQ01OQ01OQ02.lean` now `import Proofs.CauchySchwarzIntegralLpDualitySynthesis`
+and defines `theorem riesz_lp_surjective … := RieszLpDualitySynthesis.riesz_lp_surjective_general …`
+with **0 `axiom` declarations**. The feared cyclic import never materialised: the synthesis chain
+is Mathlib-only and does NOT import the base, so base←synthesis is acyclic. The knowledge notes'
+"BLOCKED / >1000-line layering refactor" caveat is STALE — Option B (re-export capstone) was the
+actual, small resolution and it landed. No researcher-shaped Lean work remains here.
+
+- **Base gallery meta was internally inconsistent** (`src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-02/meta.json`):
+  structured fields already read `status:verified, badge:verified, axiomCount:0` with an accurate
+  `assumptions` blurb, but the PROSE still called Part III "(Axiomatized)", said "surjectivity is
+  axiomatized … not yet available in Lean 4", and listed "eliminate the surjectivity axiom?" as an
+  OPEN question. The base `.lean` docstring was already reconciled (S30, researcher-3); only the
+  meta.json prose lagged. Fixed: proofStrategy, Part III section title+summary, header-and-setup
+  summary, and removed the resolved openQuestion. JSON-only, no build needed; `jq empty` passes.
+
+**Recommendation (unchanged from S28/S29/S30):** this synthesis entry is COMPLETE — stop re-serving
+it for ACT work. The axiom is eliminated; the gallery now presents it honestly on both source and meta.

--- a/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-02/meta.json
@@ -26,7 +26,7 @@
     "problemStatement": "Can the Riesz representation theorem $(L^p)^* \\cong L^q$ be derived from the $\\mathrm{eLpNorm}$ Hölder inequality?",
     "text": "The Riesz representation theorem identifies the dual of $L^p$ with $L^q$ for conjugate exponents. Hölder's inequality provides the embedding direction; the surjectivity requires Radon-Nikodým.",
     "historicalContext": "The duality of $L^p$ spaces was established by Frigyes Riesz in 1910 for $L^2$ and extended to general $L^p$ ($1 < p < \\infty$) through the work of Riesz and others in the 1920s-1930s. The $L^2$ case is a direct consequence of the Fréchet-Riesz theorem (1907), which characterizes the dual of any Hilbert space. The general case was completed by leveraging the Radon-Nikodým theorem (1930), which Johann Radon proved for $\\mathbb{R}^n$ and Otton Nikodým extended to abstract measure spaces. The interplay between Hölder's inequality (Otto Hölder, 1889) and the Radon-Nikodým theorem in establishing $L^p$ duality is a foundational chapter in functional analysis, connecting the theories of integration, measure, and topological vector spaces.",
-    "proofStrategy": "The formalization splits the Riesz representation into two independent directions. The embedding $L^q \\hookrightarrow (L^p)^*$ follows from Hölder's inequality: each $g \\in L^q$ defines a bounded functional $\\Lambda_g(f) = \\int fg\\,d\\mu$ with $\\|\\Lambda_g\\| \\leq \\|g\\|_q$. For $L^2$, the Fréchet-Riesz theorem (via Mathlib's `InnerProductSpace.toDual`) gives both directions simultaneously. For general $p$, surjectivity is axiomatized because the composition of Mathlib's Radon-Nikodým machinery with $L^p$ membership proofs is not yet available in Lean 4.",
+    "proofStrategy": "The formalization splits the Riesz representation into two independent directions. The embedding $L^q \\hookrightarrow (L^p)^*$ follows from Hölder's inequality: each $g \\in L^q$ defines a bounded functional $\\Lambda_g(f) = \\int fg\\,d\\mu$ with $\\|\\Lambda_g\\| \\leq \\|g\\|_q$. For $L^2$, the Fréchet-Riesz theorem (via Mathlib's `InnerProductSpace.toDual`) gives both directions simultaneously. For general $p$, surjectivity is now discharged (0 axioms): it re-exports `RieszLpDualitySynthesis.riesz_lp_surjective_general`, which proves the identical arbitrary-measure statement by localizing each $L^p$ functional to the $\\sigma$-finite support of its argument, applying Radon-Nikodým there, and gluing the per-support representers via the Folland-6.16 maximality assembly — kernel-verified with foundational axioms only.",
     "keyInsights": [
       "Hölder's inequality gives the isometric embedding $L^q \\hookrightarrow (L^p)^*$ but NOT surjectivity — the two directions of the Riesz isomorphism require fundamentally different tools",
       "The $L^2$ case is special: Hilbert space self-duality via the inner product gives both directions at once, bypassing the need for Radon-Nikodým entirely",
@@ -41,7 +41,7 @@
       "title": "Module Documentation and Setup",
       "startLine": 1,
       "endLine": 37,
-      "summary": "States the open question, summarizes the partial answer, and opens the noncomputable section with measure space variables."
+      "summary": "States the open question, summarizes the answer (both duality directions now verified), and opens the noncomputable section with measure space variables."
     },
     {
       "id": "l2-self-duality",
@@ -59,10 +59,10 @@
     },
     {
       "id": "riesz-surjectivity",
-      "title": "Part III: General Riesz Representation (Axiomatized)",
+      "title": "Part III: General Riesz Representation (Verified — 0 axioms)",
       "startLine": 97,
       "endLine": 121,
-      "summary": "States the hard direction (surjectivity) as an axiom: every bounded linear functional on $L^p$ is represented by an $L^q$ function. The classical proof route via Radon-Nikodým is documented but not yet formalizable in Lean 4."
+      "summary": "Proves the hard direction (surjectivity): every bounded linear functional on $L^p$ is represented by an $L^q$ function. Formerly axiomatized, now discharged (0 axioms) as a re-export of `RieszLpDualitySynthesis.riesz_lp_surjective_general`, which realizes the classical Radon-Nikodým proof route for an arbitrary measure."
     },
     {
       "id": "hierarchy-and-applications",
@@ -76,7 +76,6 @@
     "summary": "This formalization provides a definitive answer to whether Hölder's inequality suffices for the Riesz representation theorem: it gives exactly one of the two directions. The embedding $L^q \\hookrightarrow (L^p)^*$ follows from Hölder, while surjectivity requires the independent machinery of Radon-Nikodým. The $L^2$ case stands apart, resolved entirely by Hilbert space structure.",
     "implications": "The result clarifies the logical dependencies within functional analysis: $L^p$ duality is not a single-tool theorem but requires the confluence of integration inequalities (Hölder) and measure-theoretic decomposition (Radon-Nikodým). This decomposition is pedagogically valuable and reflects how the theorem is typically proved in graduate textbooks (e.g., Rudin's Real and Complex Analysis, Theorem 6.16).",
     "openQuestions": [
-      "Can Mathlib's Radon-Nikodým machinery (`MeasureTheory.SignedMeasure.rnDeriv`) be composed with $L^p$ membership to eliminate the surjectivity axiom?",
       "Does the isometric embedding $L^q \\hookrightarrow (L^p)^*$ extend to a formalized proof that equality in Hölder characterizes when $f = c|g|^{q/p} \\cdot \\mathrm{sgn}(g)$?",
       "Can the Riesz representation for $L^1$ (where $(L^1)^* \\cong L^\\infty$) be formalized, noting it requires $\\sigma$-finiteness?"
     ]


### PR DESCRIPTION
## Summary

The stated goal of the `cauchy-schwarz-integral-lp-duality-synthesis` problem — eliminate `axiom riesz_lp_surjective` (hard direction of Riesz $(L^p)^* \cong L^q$) — is **already achieved on `main`** (PR #36280). The base file `CauchySchwarzIntegralOQ01OQ01OQ02.lean` now imports the synthesis chain and defines

```lean
theorem riesz_lp_surjective … := RieszLpDualitySynthesis.riesz_lp_surjective_general …
```

with **0 `axiom` declarations**. The previously-feared cyclic import never materialized (the synthesis chain is Mathlib-only and does not import the base file), so Option B — the re-export capstone flagged across sessions S28–S30 — was the small, correct resolution and it landed.

## What this PR fixes

The base gallery entry (`src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-02/meta.json`) had **correct structured fields** (`status: verified`, `badge: verified`, `axiomCount: 0`, accurate `assumptions`) but **stale prose** contradicting them:

- `proofStrategy` said "surjectivity is axiomatized … not yet available in Lean 4" → now describes the discharge.
- Section "Part III: General Riesz Representation **(Axiomatized)**" → **(Verified — 0 axioms)**, summary updated.
- `header-and-setup` summary "partial answer" → "answer (both duality directions now verified)".
- Removed the resolved open question "Can Mathlib's Radon-Nikodým machinery … eliminate the surjectivity axiom?" (answered by #36280).

The base `.lean` docstring was already reconciled in S30; this brings the meta.json in line. **JSON-only, no Lean/build change** (`jq empty` passes). Also records in the problem knowledge that the goal is achieved and the synthesis entry is complete.

## Verification

- Axiom elimination independently established: PR #36280 + researcher-3's fresh `#print axioms` (2026-07-09) reporting foundational axioms only (`propext, Classical.choice, Quot.sound`; no `sorryAx`). This PR only reconciles prose with that already-verified status — it introduces no new verification claim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)