### PR TITLE
Enrich Gaussian Integral (√π) entry: add authoritative references

### DIFF
--- a/src/data/proofs/area-of-circle-oq-07/meta.json
+++ b/src/data/proofs/area-of-circle-oq-07/meta.json
@@ -166,6 +166,20 @@
       "year": "1812",
       "venue": "Courcier, Paris",
       "description": "Classical home of the Gaussian integral and its role as the normalization of the normal distribution."
+    },
+    {
+      "title": "Real Analysis: Modern Techniques and Their Applications (2nd ed.)",
+      "author": "Gerald B. Folland",
+      "year": "1999",
+      "venue": "Wiley",
+      "description": "Develops the rigorous evaluation of ∫_ℝ e^{-x²} = √π by Tonelli's theorem and the polar-coordinate change of variables on ∫∫_{ℝ²} e^{-(x²+y²)} — the double-integral/Jacobian method this entry's second open question asks to formalize, and the measure-theoretic content encapsulated inside Mathlib's integral_gaussian."
+    },
+    {
+      "title": "Probability and Measure (3rd ed.)",
+      "author": "Patrick Billingsley",
+      "year": "1995",
+      "venue": "Wiley",
+      "description": "Standard measure-theoretic probability text; treats the normal distribution and its √(2π) normalization constant, the b = 1/2 companion of the √π value proved here (the target of this entry's first open question)."
     }
   ],
   "sorries": 0,


### PR DESCRIPTION
Enrichment pass for `area-of-circle-oq-07` (quality 96, pass 0).

The entry was content-complete but `references` held only 2 entries (Mathlib + Laplace 1812) for one of analysis's most iconic integrals. Added two accurate, high-value references that map directly onto existing content:

- **Folland, *Real Analysis* (2nd ed., 1999)** — the rigorous Tonelli + polar-coordinate evaluation of ∫∫_{ℝ²} e^{-(x²+y²)}, i.e. the double-integral/Jacobian method this entry's **second open question** asks to formalize (and the measure-theoretic content inside Mathlib's `integral_gaussian`).
- **Billingsley, *Probability and Measure* (3rd ed., 1995)** — the normal distribution's √(2π) normalization, the b = 1/2 companion targeted by the **first open question**.

references: 2 → 4 (well under the 25 cap). Verified: JSON valid, meta 14 KB (under 60 KB cap).