### PR TITLE
research(cauchy-interlacing-theorem-oq-02-oq-01): minpoly = lcm capstone over a reducing subspace [VERIFIED]

### DIFF
--- a/proofs/Proofs/CauchyInterlacingPoincareCompression.lean
+++ b/proofs/Proofs/CauchyInterlacingPoincareCompression.lean
@@ -1596,4 +1596,97 @@ theorem minpoly_dvd_mul_compress_of_reducing {T : V →ₗ[𝕜] V} (H : Submodu
   -- `N (P_H v)` lies back in `H`; `M` kills it.
   exact hMkill _ (aeval_mem_of_invariant hH (minpoly 𝕜 (compress T Hᗮ)) haH)
 
+/-- **The lcm of the block minpolys annihilates `T` (reducing pair).**
+
+If `H` reduces `T` (both `H` and `Hᗮ` are `T`-invariant) then the least common
+multiple of the two block minimal polynomials annihilates the ambient operator:
+
+  `aeval T (lcm (minpoly (compress T H)) (minpoly (compress T Hᗮ))) = 0`.
+
+This is the substantive content pinning `minpoly T` as the lcm (rather than merely
+dividing the *product* `minpoly (compress T H) · minpoly (compress T Hᗮ)`, which is
+`minpoly_dvd_mul_compress_of_reducing`).  Writing `L := lcm p q`, both `p ∣ L` and
+`q ∣ L`, so `aeval T L` factors through `aeval T p` on the `H`-block (which
+annihilates `H`, since `compress T H = T` there) and through `aeval T q` on the
+`Hᗮ`-block; splitting any `v = P_H v + (v - P_H v)` orthogonally kills both pieces.
+Symmetry-free. -/
+theorem aeval_lcm_compress_eq_zero_of_reducing {T : V →ₗ[𝕜] V} (H : Submodule 𝕜 V)
+    (hH : ∀ y ∈ H, T y ∈ H) (hHp : ∀ y ∈ Hᗮ, T y ∈ Hᗮ) :
+    Polynomial.aeval T
+        (lcm (minpoly 𝕜 (compress T H)) (minpoly 𝕜 (compress T Hᗮ))) = 0 := by
+  set p := minpoly 𝕜 (compress T H) with hp_def
+  set q := minpoly 𝕜 (compress T Hᗮ) with hq_def
+  -- `aeval T p` annihilates the `H`-block; `aeval T q` annihilates the `Hᗮ`-block.
+  have hMkill : ∀ w ∈ H, Polynomial.aeval T p w = 0 := fun w hw => by
+    have h := coe_aeval_compress_of_invariant H hH p ⟨w, hw⟩
+    rw [minpoly.aeval, LinearMap.zero_apply, ZeroMemClass.coe_zero] at h
+    exact h.symm
+  have hNkill : ∀ w ∈ Hᗮ, Polynomial.aeval T q w = 0 := fun w hw => by
+    have h := coe_aeval_compress_of_invariant Hᗮ hHp q ⟨w, hw⟩
+    rw [minpoly.aeval, LinearMap.zero_apply, ZeroMemClass.coe_zero] at h
+    exact h.symm
+  -- The lcm annihilates each block: `L = p * s = q * t`, and the leading factor kills.
+  obtain ⟨s, hs⟩ := dvd_lcm_left p q
+  obtain ⟨t, ht⟩ := dvd_lcm_right p q
+  have hLkillH : ∀ w ∈ H, Polynomial.aeval T (lcm p q) w = 0 := fun w hw => by
+    rw [hs, map_mul, Module.End.mul_apply]
+    exact hMkill _ (aeval_mem_of_invariant hH s hw)
+  have hLkillHp : ∀ w ∈ Hᗮ, Polynomial.aeval T (lcm p q) w = 0 := fun w hw => by
+    rw [ht, map_mul, Module.End.mul_apply]
+    exact hNkill _ (aeval_mem_of_invariant hHp t hw)
+  -- Split any `v` orthogonally; both pieces are killed.
+  ext v
+  simp only [LinearMap.zero_apply]
+  have haH : H.starProjection v ∈ H := H.starProjection_apply_mem v
+  have hbHp : v - H.starProjection v ∈ Hᗮ := H.sub_starProjection_mem_orthogonal v
+  have hav : H.starProjection v + (v - H.starProjection v) = v := by abel
+  conv_lhs => rw [← hav]
+  rw [map_add, hLkillH _ haH, hLkillHp _ hbHp, add_zero]
+
+/-- **The ambient minpoly divides the lcm of the block minpolys (reducing pair).**
+
+Sharper than the product divisibility `minpoly_dvd_mul_compress_of_reducing`: since
+the lcm of the two block minpolys already annihilates `T`
+(`aeval_lcm_compress_eq_zero_of_reducing`), `minpoly.dvd` gives
+
+  `minpoly T ∣ lcm (minpoly (compress T H)) (minpoly (compress T Hᗮ))`. -/
+theorem minpoly_dvd_lcm_compress_of_reducing {T : V →ₗ[𝕜] V} (H : Submodule 𝕜 V)
+    (hH : ∀ y ∈ H, T y ∈ H) (hHp : ∀ y ∈ Hᗮ, T y ∈ Hᗮ) :
+    minpoly 𝕜 T ∣ lcm (minpoly 𝕜 (compress T H)) (minpoly 𝕜 (compress T Hᗮ)) :=
+  minpoly.dvd 𝕜 T (aeval_lcm_compress_eq_zero_of_reducing H hH hHp)
+
+/-- **Minimal-polynomial reading of the block-diagonal decomposition (capstone).**
+
+If `H` reduces `T` then the minimal polynomial of `T` is *exactly* the least common
+multiple of the two block minimal polynomials:
+
+  `minpoly T = lcm (minpoly (compress T H)) (minpoly (compress T Hᗮ))`.
+
+This is the equality repeatedly promised by the section docstrings, completing the
+`minpoly` picture: unlike the *characteristic* polynomial, which multiplies across a
+reducing pair (`charpoly_eq_mul_compress_of_reducing`), the *minimal* polynomial takes
+the lcm.  The `∣` direction is `minpoly_dvd_lcm_compress_of_reducing`; the `∣`-reverse is
+`lcm_dvd` applied to the two block divisibilities `minpoly_compress_dvd_of_reducing`.
+Both `minpoly T` and the (normalized) lcm are monic, so mutual divisibility upgrades to
+equality via `normalize`.  Symmetry-free. -/
+theorem minpoly_eq_lcm_compress_of_reducing {T : V →ₗ[𝕜] V} (H : Submodule 𝕜 V)
+    (hH : ∀ y ∈ H, T y ∈ H) (hHp : ∀ y ∈ Hᗮ, T y ∈ Hᗮ) :
+    minpoly 𝕜 T =
+      lcm (minpoly 𝕜 (compress T H)) (minpoly 𝕜 (compress T Hᗮ)) := by
+  obtain ⟨hdvdH, hdvdHp⟩ := minpoly_compress_dvd_of_reducing H hH hHp
+  have d1 : minpoly 𝕜 T ∣
+      lcm (minpoly 𝕜 (compress T H)) (minpoly 𝕜 (compress T Hᗮ)) :=
+    minpoly_dvd_lcm_compress_of_reducing H hH hHp
+  have d2 : lcm (minpoly 𝕜 (compress T H)) (minpoly 𝕜 (compress T Hᗮ)) ∣
+      minpoly 𝕜 T := lcm_dvd hdvdH hdvdHp
+  -- `T` is integral (finite-dimensional endomorphism algebra), so `minpoly T` is monic.
+  have hint : IsIntegral 𝕜 T :=
+    have : Algebra.IsIntegral 𝕜 (Module.End 𝕜 V) := Algebra.IsIntegral.of_finite 𝕜 _
+    Algebra.IsIntegral.isIntegral T
+  have hmonic : (minpoly 𝕜 T).Monic := minpoly.monic hint
+  calc minpoly 𝕜 T = normalize (minpoly 𝕜 T) := (hmonic.normalize_eq_self).symm
+    _ = normalize (lcm (minpoly 𝕜 (compress T H)) (minpoly 𝕜 (compress T Hᗮ))) :=
+        normalize_eq_normalize_iff.mpr ⟨d1, d2⟩
+    _ = lcm (minpoly 𝕜 (compress T H)) (minpoly 𝕜 (compress T Hᗮ)) := normalize_lcm _ _
+
 end CauchyInterlacing.PoincareCompression

--- a/src/data/research/problems/cauchy-interlacing-theorem-oq-02-oq-01.json
+++ b/src/data/research/problems/cauchy-interlacing-theorem-oq-02-oq-01.json
@@ -88,7 +88,8 @@
       "Determinant/eigenvalue-PRODUCT additivity mirrors the trace/eigenvalue-SUM additivity: the same block-diagonal reconstruction on a reducing subspace yields det via det_conj+det_prodMap (mult) instead of trace map_add (additive). coe_compress_of_invariant makes each honest compression = T on its invariant block, killing off-diagonal terms.",
       "Passing charpoly_eq_mul_compress_of_reducing to roots (Polynomial.roots_mul, valid since charpoly is monic hence nonzero) yields eigenvalue-MULTISET additivity: (charpoly T).roots = (charpoly (compress T H)).roots + (charpoly (compress T Hᗮ)).roots — the with-multiplicity refinement of the set-level spectrum union.",
       "Discovered origin/main charpoly_eq_mul_compress_of_reducing hT-proof was BROKEN: LinearEquiv.conj_apply unfolds to left-associated (↑e∘ₗf)∘ₗ↑e.symm, so the leading ← LinearMap.comp_assoc finds no right-associated pattern (rw fail at conj step). Fix = drop the leading ← comp_assoc, go straight to ← hconj.",
-      "The minimal polynomial is the one polynomial invariant that does NOT multiply across a reducing pair (unlike charpoly/det/trace/roots): on an invariant block it DIVIDES, and across a reducing pair minpoly T = lcm of the two block minpolys."
+      "The minimal polynomial is the one polynomial invariant that does NOT multiply across a reducing pair (unlike charpoly/det/trace/roots): on an invariant block it DIVIDES, and across a reducing pair minpoly T = lcm of the two block minpolys.",
+      "researcher-8 (2026-07-11): completed the minimal-polynomial capstone the section docstrings repeatedly promise. The file proved both one-sided divisibilities (minpoly_compress_dvd_of_reducing: each block minpoly | minpoly T; minpoly_dvd_mul_compress_of_reducing: minpoly T | product) but not the equality minpoly T = lcm of the block minpolys. Added the missing content: aeval_lcm_compress_eq_zero_of_reducing (the lcm of the two block minpolys annihilates T — factor lcm=p*s=q*t, each leading factor kills its invariant block after aeval_mem_of_invariant, then orthogonal split), minpoly_dvd_lcm_compress_of_reducing (sharpens the product divisibility to the lcm via minpoly.dvd), and the capstone minpoly_eq_lcm_compress_of_reducing (mutual divisibility upgraded to equality by normalize: minpoly T monic since T integral over the finite-dim End algebra, lcm normalized). Symmetry-free, VERIFIED [propext,choice,Quot.sound] only."
     ],
     "mathlibGaps": [],
     "nextSteps": [
@@ -112,7 +113,7 @@
     "mathlib": []
   },
   "started": "2026-07-02T05:53:08.467Z",
-  "lastUpdate": "2026-07-09T00:00:00.000Z",
+  "lastUpdate": "2026-07-11T00:00:00.000Z",
   "completed": "2026-07-02T23:38:28.210Z",
   "significance": 3,
   "tractability": 7


### PR DESCRIPTION
## Summary

Fills the minimal-polynomial **capstone** that `CauchyInterlacingPoincareCompression.lean` repeatedly promises in prose but leaves unproved.

Across a reducing pair `(H, Hᗮ)` the *characteristic* polynomial multiplies (`charpoly_eq_mul_compress_of_reducing`), but the *minimal* polynomial takes the **lcm**. The file had only the two one-sided divisibilities:

- `minpoly_compress_dvd_of_reducing` — each block minpoly `∣ minpoly T`
- `minpoly_dvd_mul_compress_of_reducing` — `minpoly T ∣` the **product**

The equality `minpoly T = lcm(minpoly (compress T H), minpoly (compress T Hᗮ))` was asserted in several docstrings (e.g. "*i.e. `minpoly T = lcm(...)`*") but never stated as a theorem.

## New theorems (all axiom-free, symmetry-free)

| Theorem | Statement |
|---|---|
| `aeval_lcm_compress_eq_zero_of_reducing` | `aeval T (lcm p q) = 0` — the lcm of the block minpolys annihilates `T` |
| `minpoly_dvd_lcm_compress_of_reducing` | `minpoly T ∣ lcm p q` (sharpens the product divisibility) |
| `minpoly_eq_lcm_compress_of_reducing` | **`minpoly T = lcm p q`** (the promised capstone) |

where `p := minpoly (compress T H)`, `q := minpoly (compress T Hᗮ)`.

## Proof sketch

`aeval T (lcm p q) = 0`: write `L = p·s = q·t` (both `p, q ∣ L`). On the `H`-block, `aeval T L` factors as `aeval T p ∘ aeval T s`; `aeval T s` keeps `H` invariant (`aeval_mem_of_invariant`) and `aeval T p` annihilates it (the block minpoly kills `T` on its invariant block, via `coe_aeval_compress_of_invariant` + `minpoly.aeval`). Symmetrically on `Hᗮ`. Splitting any `v = P_H v + (v − P_H v)` orthogonally kills both pieces.

The capstone then upgrades mutual divisibility (`minpoly_dvd_lcm` + `lcm_dvd` of the block divisibilities) to equality through `normalize`: `minpoly T` is monic (`T` is integral over the finite-dimensional endomorphism algebra), and the lcm is normalized.

## Verification

- Built clean via `./proofs/scripts/docker-build.sh Proofs.CauchyInterlacingPoincareCompression` (7747 jobs, success).
- `#print axioms` on the capstone and the annihilation lemma reports only `[propext, Classical.choice, Quot.sound]` — **no `Lean.ofReduceBool`, no `sorryAx`**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)