### PR TITLE
research(erdos-1039-oq-03): the roots always lie in the lemniscate interior

### DIFF
--- a/proofs/Proofs/Erdos1039Conformal.lean
+++ b/proofs/Proofs/Erdos1039Conformal.lean
@@ -152,6 +152,23 @@ theorem rootPoly_differentiable {n : ℕ} (roots : Fin n → ℂ) :
   unfold rootPoly
   fun_prop
 
+/-- **Each root is a zero of the polynomial.**  `f(rootⱼ) = ∏ᵢ (rootⱼ − rootsᵢ) = 0`,
+    since the `i = j` factor vanishes. -/
+theorem rootPoly_root_eq_zero {n : ℕ} (roots : Fin n → ℂ) (j : Fin n) :
+    rootPoly roots (roots j) = 0 := by
+  unfold rootPoly
+  exact Finset.prod_eq_zero (Finset.mem_univ j) (sub_self _)
+
+/-- **Every root lies in the lemniscate interior.**  `rootⱼ ∈ {z : ‖f z‖ < 1}`, because
+    `f` vanishes there (`rootPoly_root_eq_zero`), so `‖f(rootⱼ)‖ = 0 < 1`.  Thus the `n`
+    roots are always interior points of the sublevel set whose inscribed discs define
+    `ρ(f)` — the elementary geometric fact underlying the whole inscribed-radius question. -/
+theorem root_mem_sublevel {n : ℕ} (roots : Fin n → ℂ) (j : Fin n) :
+    roots j ∈ sublevel (rootPoly roots) := by
+  show ‖rootPoly roots (roots j)‖ < 1
+  rw [rootPoly_root_eq_zero, norm_zero]
+  exact one_pos
+
 /-- **Conformal inscribed-radius bound for a monic polynomial.**
 If the open disc `D(c, r)` is inscribed in the lemniscate interior
 `{z : ‖∏ᵢ (z - rootsᵢ)‖ < 1}` and the centre is not a critical point, then

--- a/src/data/proofs/erdos-1039-oq-03/meta.json
+++ b/src/data/proofs/erdos-1039-oq-03/meta.json
@@ -70,10 +70,10 @@
     ],
     "dateAdded": "2026-06-23",
     "axiomCount": 0,
-    "lineCount": 164,
+    "lineCount": 181,
     "assumptions": "0 axioms. 0 sorries. The core estimate is the C = 1 specialization of Mathlib's Cauchy estimate Complex.norm_deriv_le_of_forall_mem_sphere_norm_le; the inscribed-disc and polynomial results are corollaries, and the obstruction is an explicit witness. The parent open problem (is ρ(f) ≫ 1/n?) is NOT asserted — only the elementary conformal estimate and its critical-point degeneracy. The obstruction witness f ≡ 0 is a constant, not a monic polynomial; it is used solely to certify that the hypothesis f'(c) ≠ 0 in the radius bound is necessary, which is the mathematical point. Build note: local kernel verification was blocked by an unresponsive Docker build host this session (docker info timed out; the container never materialized). The proof uses only Mathlib v4.26.0 lemma signatures grep-confirmed against the pinned toolchain (Complex.norm_deriv_le_of_forall_mem_sphere_norm_le, Differentiable.diffContOnCl, closure_ball with the r ≠ 0 hypothesis, isClosed_le, sphere_subset_closedBall, DifferentiableAt.fun_finset_prod via fun_prop, le_div_iff₀, deriv_const'); arithmetic was hand-checked. It is gated by the deployer build before merge.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 7,
+    "theoremCount": 9,
     "definitionCount": 2
   },
   "sections": [
@@ -184,9 +184,9 @@
       "Set"
     ],
     "namespace": "Erdos1039Conformal",
-    "lineCount": 207,
+    "lineCount": 224,
     "axiomCount": 0,
-    "theoremCount": 9,
+    "theoremCount": 11,
     "definitionCount": 2,
     "sorries": 0,
     "path": "Proofs/Erdos1039Conformal.lean"


### PR DESCRIPTION
## Summary

The conformal-estimate companion for Erdős #1039 builds `rootPoly f(z) = ∏ᵢ(z − rootsᵢ)` and the sublevel set `{z : ‖f z‖ < 1}` whose inscribed discs define `ρ(f)`, but never records the basic geometric fact grounding the whole question — that the **roots are interior points** of that set. This PR adds it.

## New theorems (both axiom-free)

- **`rootPoly_root_eq_zero`** — `f(rootⱼ) = ∏ᵢ(rootⱼ − rootsᵢ) = 0` (the `i=j` factor vanishes; `Finset.prod_eq_zero`).
- **`root_mem_sublevel`** — `rootⱼ ∈ {z : ‖f z‖ < 1}`, since `‖f(rootⱼ)‖ = 0 < 1`. The `n` roots are always interior points of the sublevel set — the elementary geometry underlying the inscribed-radius bounds `ρ(f)`.

## Verification note

The environment's shared Mathlib build **lost the `.ir` data file for `Mathlib.Topology.Constructible` mid-session**, so every `import Mathlib` file — including a trivial one — now fails at the import line with "missing IR data file" (an infra regression unrelated to this change).

The two new proofs were therefore verified **in isolation** against byte-identical `sublevel` / `rootPoly` definitions, using targeted imports (`Mathlib.Analysis.Complex.Basic` + `BigOperators` + `Tactic`) that avoid the broken module:

- `#print axioms` → `[propext, Classical.choice, Quot.sound]` for both, **no `sorryAx`**, no errors.

Axiom-free companion (axiom count unchanged), 0 sorries. `meta.json`: 9 → 11 theorems.

🤖 Generated with [Claude Code](https://claude.com/claude-code)