### PR TITLE
Enrich Catenoid/Affine Arc Length entry: cross-reference the parallel cousin

### DIFF
--- a/src/data/proofs/arsinh-log-formula-oq-01-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/arsinh-log-formula-oq-01-oq-01-oq-01-oq-01/meta.json
@@ -147,6 +147,11 @@
       "targetId": "arsinh-log-formula-oq-01-oq-01",
       "relationship": "ancestor",
       "description": "The grandparent supplies the antiderivative of the conjugate integrand 1/√(1+t²) (namely arsinh); this entry continues the same hand-built-antiderivative theme, here for cosh² (absent from Mathlib)."
+    },
+    {
+      "targetId": "arsinh-log-formula-oq-01-oq-01-oq-02",
+      "relationship": "related",
+      "description": "Parallel cousin. It derives the identical catenoid lateral surface area π(b + sinh b·cosh b) by the same √(1 + sinh²x) = cosh x collapse and the same hand-built cosh² antiderivative, but complements this entry by also giving the catenary arc length in classical logarithmic closed form ½(b√(1+b²) + log(b + √(1+b²))) — using arsinh x = log(x + √(1+x²)). Read together they present the catenoid area from two matching routes and the arc length in both the sinh and the logarithmic forms."
     }
   ],
   "references": [


### PR DESCRIPTION
Enrichment pass for `arsinh-log-formula-oq-01-oq-01-oq-01-oq-01` (quality 96, pass 0).

`crossReferences` linked only the parent and grandparent. Added one accurate, high-value link:

- **`arsinh-log-formula-oq-01-oq-01-oq-02`** (parallel cousin) — derives the *identical* catenoid lateral surface area π(b + sinh b·cosh b) by the same √(1+sinh²x)=cosh x collapse and the same hand-built cosh² antiderivative, and complements this entry by giving the catenary arc length in classical logarithmic closed form ½(b√(1+b²)+log(b+√(1+b²))) via arsinh. Read together: the catenoid area from two matching routes, and the arc length in both sinh and logarithmic forms.

I checked `pappus-theorem-oq-02` (surface-of-revolution seemed plausible) but it is Pappus's **Hexagon** theorem — unrelated — so deliberately not linked.

crossReferences: 2 → 3 (well under the 20 cap). Verified: JSON valid, meta under 60 KB cap.