### PR TITLE
research(bezout-identity-oq-01-oq-02-oq-02): sharp n=1 obstruction + column characterization

### DIFF
--- a/proofs/Proofs/BezoutIdentityOQ01OQ02OQ02.lean
+++ b/proofs/Proofs/BezoutIdentityOQ01OQ02OQ02.lean
@@ -521,4 +521,89 @@ theorem exists_sl_mulVec_basis_of_isPrimitive (hn : 1 < n) {v : Fin n → ℤ}
     ∃ A : Matrix.SpecialLinearGroup (Fin n) ℤ, ↑ₘA *ᵥ v = Pi.single t (1 : ℤ) :=
   exists_sl_mulVec_eq_of_isPrimitive hn hv (isPrimitive_single t)
 
+/-! ### Structural consequence: primitive ⇔ column of a unimodular matrix
+
+Transitivity has an equivalent classical face.  A vector is primitive **iff** it occurs
+as a column of some `n × n` unimodular integer matrix, equivalently iff it extends to a
+`ℤ`-basis of `ℤⁿ`.  The forward direction is transitivity run backwards (`U · v = eₜ`
+gives `U⁻¹ · eₜ = v`, so `v` is the `t`-th column of `U⁻¹ ∈ SLₙ(ℤ)`); the reverse is the
+easy-half invariance `IsPrimitive.mulVec` applied to the primitive vector `eₜ`. -/
+
+/-- **Primitive ⇔ column of a unimodular matrix (`n ≥ 2`).**  A vector `v` is primitive
+iff it is the `t`-th column of some `A ∈ SLₙ(ℤ)`, i.e. `A · eₜ = v`.  This is the
+column form of the basis-extension theorem: over `ℤ`, a vector extends to a basis of the
+free module `ℤⁿ` exactly when its entries are setwise coprime.  Note the reverse
+implication needs no dimension hypothesis — any column of a unimodular matrix is
+primitive — while the forward one uses transitivity, hence `1 < n`. -/
+theorem isPrimitive_iff_exists_sl_col (hn : 1 < n) (v : Fin n → ℤ) (t : Fin n) :
+    IsPrimitive v ↔ ∃ A : Matrix.SpecialLinearGroup (Fin n) ℤ,
+      ↑ₘA *ᵥ Pi.single t (1 : ℤ) = v := by
+  constructor
+  · intro hv
+    obtain ⟨U, hU⟩ := exists_sl_mulVec_basis_of_isPrimitive hn hv t
+    refine ⟨U⁻¹, ?_⟩
+    rw [← hU, Matrix.mulVec_mulVec, ← SpecialLinearGroup.coe_mul, inv_mul_cancel,
+      SpecialLinearGroup.coe_one, one_mulVec]
+  · rintro ⟨A, hA⟩
+    rw [← hA]
+    exact (isPrimitive_single t).mulVec A
+
+/-! ### The dimension hypothesis `1 < n` is sharp
+
+`exists_sl_mulVec_eq_of_isPrimitive` collapses the primitive vectors into a *single*
+`SLₙ(ℤ)`-orbit only for `n ≥ 2`.  The lemmas below make the failure at `n = 1`
+machine-checked, upgrading the prose remark above `exists_sl_single_orbit_ne` to a
+theorem: `SL₁(ℤ)` is the trivial group, so its action fixes every vector and cannot
+connect the two primitive vectors `e₀ = (1)` and `-e₀ = (-1)`.  These therefore lie in
+*distinct* orbits, and the unit-multiple `c · eₖ` description of
+`isPrimitive_iff_exists_sl_single` — which does leave the sign free — is the best
+possible uniformly in `n`. -/
+
+/-- **`SL₁(ℤ)` is trivial.**  The determinant of a `1 × 1` matrix is its single entry,
+so the unimodularity constraint `det = 1` pins that entry to `1`: the only element of
+`SpecialLinearGroup (Fin 1) ℤ` is the identity.  This is the group-theoretic root of the
+`n = 1` sign obstruction — there simply are no nontrivial moves. -/
+theorem special_linear_fin_one_eq_one (A : Matrix.SpecialLinearGroup (Fin 1) ℤ) :
+    A = 1 := by
+  have hdet : (A : Matrix (Fin 1) (Fin 1) ℤ) 0 0 = 1 := by
+    have h := A.det_coe
+    rwa [Matrix.det_fin_one] at h
+  ext i j
+  fin_cases i; fin_cases j
+  simpa using hdet
+
+instance : Subsingleton (Matrix.SpecialLinearGroup (Fin 1) ℤ) :=
+  ⟨fun A B => by
+    rw [special_linear_fin_one_eq_one A, special_linear_fin_one_eq_one B]⟩
+
+/-- **`e₀` and `-e₀` are not `SL₁(ℤ)`-equivalent.**  No element of the trivial group
+`SL₁(ℤ)` carries `(1)` to `(-1)`: the only available move is the identity, which fixes
+`(1)`.  This is the concrete witness that the sign left free by the uniform `c · eₖ`
+statement genuinely cannot be removed in dimension `1`. -/
+theorem not_exists_sl_mulVec_single_neg_fin_one :
+    ¬ ∃ A : Matrix.SpecialLinearGroup (Fin 1) ℤ,
+        (A : Matrix (Fin 1) (Fin 1) ℤ) *ᵥ Pi.single (0 : Fin 1) (1 : ℤ)
+          = Pi.single (0 : Fin 1) (-1 : ℤ) := by
+  rintro ⟨A, hA⟩
+  rw [special_linear_fin_one_eq_one A, SpecialLinearGroup.coe_one, one_mulVec] at hA
+  have h0 := congrFun hA 0
+  rw [Pi.single_eq_same, Pi.single_eq_same] at h0
+  exact absurd h0 (by norm_num)
+
+/-- **Transitivity fails in dimension `1`.**  There are primitive vectors `v, w : Fin 1 → ℤ`
+— namely `e₀` and `-e₀` — with no `A ∈ SL₁(ℤ)` satisfying `A · v = w`.  So the conclusion
+of `exists_sl_mulVec_eq_of_isPrimitive` is false without the hypothesis `1 < n`, proving
+that hypothesis sharp.  (For `n = 0` transitivity holds *vacuously* — there are no
+primitive vectors at all, by `not_isPrimitive_fin_zero` — so `n = 1` is the unique
+genuine counterexample.) -/
+theorem not_forall_isPrimitive_sl_equiv_fin_one :
+    ¬ ∀ (v w : Fin 1 → ℤ), IsPrimitive v → IsPrimitive w →
+        ∃ A : Matrix.SpecialLinearGroup (Fin 1) ℤ,
+          (A : Matrix (Fin 1) (Fin 1) ℤ) *ᵥ v = w := by
+  intro h
+  have hv : IsPrimitive (Pi.single (0 : Fin 1) (1 : ℤ)) := isPrimitive_single 0
+  have hw : IsPrimitive (Pi.single (0 : Fin 1) (-1 : ℤ)) :=
+    isPrimitive_of_isUnit_apply (i := 0) (by rw [Pi.single_eq_same]; exact isUnit_one.neg)
+  exact not_exists_sl_mulVec_single_neg_fin_one (h _ _ hv hw)
+
 end BezoutPrimitive

--- a/src/data/proofs/bezout-identity-oq-01-oq-02-oq-02/meta.json
+++ b/src/data/proofs/bezout-identity-oq-01-oq-02-oq-02/meta.json
@@ -91,7 +91,7 @@
     "namespace": "BezoutPrimitive",
     "lineCount": 301,
     "axiomCount": 0,
-    "theoremCount": 16,
+    "theoremCount": 27,
     "definitionCount": 2,
     "path": "Proofs/BezoutIdentityOQ01OQ02OQ02.lean",
     "sorries": 0

--- a/src/data/research/problems/bezout-identity-oq-01-oq-02-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-01-oq-02-oq-02.json
@@ -42,7 +42,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (VERIFIED axiom-free, single-file lake env lean exit 0): proved the general-n converse direction exists_sl_mulVec_single_of_isPrimitive — every primitive integer vector is SLn(Z)-equivalent to a unit multiple of a basis vector, by strong induction on the l1 measure sum_k|v_k| via the transvection Euclidean-reduction step sum_natAbs_update_emod_lt. This discharges the open converse (sufficiency) half that orbit_e_isPrimitive recorded as remaining work, in EVERY dimension (previously only n=2 was closed, closed-form). Plus the clean characterization isPrimitive_iff_exists_sl_single. File 302->443 lines, +3 verified theorems. Sole remaining: the n>=2 corollary reaching exactly e0 (rotation assembly).",
+    "progressSummary": "SOLVED core + sharpness: transitivity of SLn(Z) on primitive vectors is fully proved (n>=2); added the column/basis-extension characterization (isPrimitive_iff_exists_sl_col) and machine-checked that the 1<n hypothesis is sharp (SL1(Z) trivial => (1),(-1) in distinct orbits). File 524->611 lines, +4 axiom-free theorems (27 theorems total, 0 sorry, 0 axiom).",
     "builtItems": [
       "IsPrimitive (Fin n → ℤ) := ∃ w, w ⬝ᵥ v = 1 — BezoutIdentityOQ01OQ02OQ02.lean",
       "isPrimitive_iff_span_eq_top: IsPrimitive v ↔ Ideal.span (range v) = ⊤ (bridge to classical gcd=1 via Ideal.mem_span_range_iff_exists_fun)",
@@ -51,7 +51,11 @@
       "orbit_e_isPrimitive: the easy half — every vector in the SLₙ(ℤ)-orbit of eᵢ is primitive",
       "sum_natAbs_update_emod_lt (BezoutIdentityOQ01OQ02OQ02.lean): the Euclidean reduction step strictly lowers sum_k|v_k|. VERIFIED 0-sorry/0-axiom.",
       "exists_sl_mulVec_single_of_isPrimitive (BezoutIdentityOQ01OQ02OQ02.lean): general-n converse — every primitive v is SLn(Z)-equivalent to Pi.single k c with IsUnit c, by strong induction on l1 measure. VERIFIED axiom-free (propext/Classical.choice/Quot.sound only).",
-      "isPrimitive_iff_exists_sl_single (BezoutIdentityOQ01OQ02OQ02.lean): clean iff — IsPrimitive v iff exists A k c, IsUnit c and A *v v = Pi.single k c. VERIFIED."
+      "isPrimitive_iff_exists_sl_single (BezoutIdentityOQ01OQ02OQ02.lean): clean iff — IsPrimitive v iff exists A k c, IsUnit c and A *v v = Pi.single k c. VERIFIED.",
+      "isPrimitive_iff_exists_sl_col (n>=2): primitive <-> t-th column of an SLn(Z) matrix (basis-extension/column characterization), BezoutIdentityOQ01OQ02OQ02.lean",
+      "special_linear_fin_one_eq_one + Subsingleton instance: SL1(Z) is the trivial group (det of 1x1 = single entry = 1)",
+      "not_exists_sl_mulVec_single_neg_fin_one: (1) and (-1) are in distinct SL1(Z) orbits",
+      "not_forall_isPrimitive_sl_equiv_fin_one: transitivity conclusion is FALSE at n=1, proving the 1<n hypothesis sharp (n=0 holds vacuously)"
     ],
     "insights": [
       "Primitivity of an integer vector v is cleanly captured coordinate-free as: ∃ dual w with w ⬝ᵥ v = 1. This dot-product form is manifestly SLₙ(ℤ)-invariant, unlike the gcd-of-entries phrasing.",
@@ -62,15 +66,15 @@
       "The converse (sufficiency) direction of SLn(Z)-transitivity on primitive vectors — every primitive v is SLn(Z)-equivalent to a unit multiple of a basis vector — holds in EVERY dimension by strong induction on the l1 measure sum_k |v_k|, no analytic input needed (elementary Euclidean descent).",
       "The termination measure is sum_k (v k).natAbs; a single transvection T_{i,j}(-(v i / v j)) replaces the pivot v i by v i % v j, and 0 <= v i % v j < |v j| <= |v i| makes exactly the i-th summand shrink (sum_natAbs_update_emod_lt).",
       "Base case: a primitive vector with a single nonzero coordinate must have that entry a unit (from exists w, w dot v = 1 collapsing to w k * v k = 1), so it already equals Pi.single k (v k) with IsUnit (v k) — A = 1.",
-      "Reaching EXACTLY e0 (not just a unit multiple c*e_k) is only true for n >= 2; in n = 1, SL1(Z)={1} fixes -e0 != e0 though both are primitive, so the unit-multiple form is the sharp general-n statement."
+      "Reaching EXACTLY e0 (not just a unit multiple c*e_k) is only true for n >= 2; in n = 1, SL1(Z)={1} fixes -e0 != e0 though both are primitive, so the unit-multiple form is the sharp general-n statement.",
+      "The open question (SLn(Z) transitivity on primitive vectors, n>=2) is fully resolved in the file; remaining outward work is sharpness/structural consequences, not the core theorem."
     ],
     "mathlibGaps": [
       "Mathlib has no packaged transitivity of SLₙ(ℤ) on primitive vectors (only n=2 pieces via bezoutSL in the parent). Foundation built here; the Euclidean-descent converse (every primitive vector reaches eᵢ) remains.",
       "No IsPrimitive predicate for integer vectors in Mathlib; defined here via the dot-product dual."
     ],
     "nextSteps": [
-      "Add the n >= 2 corollary reaching exactly e0: a unit multiple c*e_k is SLn(Z)-equivalent to Pi.single 0 1. Needs a plane-rotation SLn element sending c*e_k to e0 (buildable as a product of 3 transvections via the S = T T T identity, avoiding a new matrix constructor).",
-      "Bridge IsPrimitive to Finset.univ.gcd of entries = 1 to connect explicitly with the parent n=2 IsCoprime phrasing."
+      "Possible further outward work: quantify SLn(Z)-orbit invariants beyond primitivity, or an effective/algorithmic version bounding the number of transvections in the descent."
     ]
   },
   "tags": [


### PR DESCRIPTION
## Summary

The open question for this problem — that `SLₙ(ℤ)` acts **transitively** on primitive integer vectors for `n ≥ 2` — was already fully resolved in `BezoutIdentityOQ01OQ02OQ02.lean` (`exists_sl_mulVec_eq_of_isPrimitive`, `exists_sl_mulVec_basis_of_isPrimitive`). This PR adds the outward consequences the SOLVED state calls for: a classical structural restatement and a machine-checked sharpness of the dimension hypothesis. All additions are axiom-free.

## What's new (+4 theorems, all axiom-free)

- **`isPrimitive_iff_exists_sl_col`** (n ≥ 2): a vector is primitive **iff** it is the `t`-th column of some `A ∈ SLₙ(ℤ)` (`A · eₜ = v`) — the column form of the "primitive vector extends to a ℤ-basis of ℤⁿ" theorem. The reverse implication needs no dimension hypothesis (any column of a unimodular matrix is primitive).
- **`special_linear_fin_one_eq_one`** + `Subsingleton` instance: `SL₁(ℤ)` is the trivial group (the det of a 1×1 matrix is its single entry, forced to 1).
- **`not_exists_sl_mulVec_single_neg_fin_one`**: `(1)` and `(-1)` lie in **distinct** `SL₁(ℤ)` orbits.
- **`not_forall_isPrimitive_sl_equiv_fin_one`**: the transitivity conclusion is **false** at `n = 1`, upgrading the file's prose sharpness remark to a theorem and confirming the `1 < n` hypothesis of `exists_sl_mulVec_eq_of_isPrimitive` is genuinely necessary. (`n = 0` holds vacuously — no primitive vectors exist.)

## Verification

- `524 → 611` lines, `23 → 27` theorems, **0 sorry, 0 axiom declarations**.
- Type-checks via single-file `lake env lean` (exit 0).
- `#print axioms` on all four new theorems: only `propext, Classical.choice, Quot.sound`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)