### PR TITLE
Enrich Normal Refinement of the Galois Correspondence (OQ-02-OQ-01)

### DIFF
--- a/src/data/proofs/abel-ruffini-galois-extensions-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/abel-ruffini-galois-extensions-oq-02-oq-01/annotations.json
@@ -147,8 +147,8 @@
     "range": { "startLine": 113, "endLine": 127 },
     "type": "theorem",
     "title": "Instantiation on the Abel–Ruffini Quintic X⁵ − 4X + 2",
-    "content": "Specializes the counting corollary to the OQ-01 witness q = X⁵ − 4X + 2, whose splitting field is a finite Galois extension of ℚ with Galois group S₅ (OQ-01's galEquivS5). The Galois subextensions of the splitting field biject with the normal subgroups of S₅. Since S₅ has exactly three normal subgroups ({1}, A₅, S₅), this pins the number of ℚ-Galois subextensions at three — the concrete payoff of the abstract correspondence and the link back to the Abel–Ruffini unsolvability chain.",
-    "mathContext": "For $q = X^5 - 4X + 2$: $\\#\\{K \\mid \\mathrm{IsGalois}\\,\\mathbb{Q}\\,K\\} = \\#\\{H \\trianglelefteq S_5\\} = 3$.",
+    "content": "Specializes the counting corollary to the OQ-01 witness q = X⁵ − 4X + 2, whose splitting field is a finite Galois extension of ℚ with Galois group S₅ (OQ-01's galEquivS5). The Galois subextensions of the splitting field biject with the normal subgroups of S₅. Since S₅ has exactly three normal subgroups ({1}, A₅, S₅), this pins the number of ℚ-Galois subextensions at three, and the correspondence even names them: the splitting field itself (fixing subgroup {1}), the base ℚ (fixing subgroup S₅), and the unique quadratic ℚ(√Δ) — the fixed field of A₅, with Δ the discriminant of X⁵ − 4X + 2. This is the concrete payoff of the abstract correspondence and the link back to the Abel–Ruffini unsolvability chain.",
+    "mathContext": "For $q = X^5 - 4X + 2$: $\\#\\{K \\mid \\mathrm{IsGalois}\\,\\mathbb{Q}\\,K\\} = \\#\\{H \\trianglelefteq S_5\\} = 3$; the three are $E$, $\\mathbb{Q}(\\sqrt{\\Delta}) = E^{A_5}$, and $\\mathbb{Q}$.",
     "significance": "key",
     "relatedConcepts": [
       "Abel–Ruffini quintic",


### PR DESCRIPTION
Enrichment pass for `abel-ruffini-galois-extensions-oq-02-oq-01` (quality 96, pass 0).

This entry was already very rich, so the pass is curation, not accretion — one targeted, high-value addition each to `meta.json` and `annotations.json`.

**What changed**
- **keyInsights 4 → 5:** added the concrete payoff that the counting corollary only *implied*. Because `S₅` has exactly the three normal subgroups `{1} ◁ A₅ ◁ S₅`, the bijection forces exactly three ℚ-Galois subextensions of the splitting field of X⁵−4X+2, and *names* them: the whole field `E`, the base `ℚ`, and the unique quadratic `ℚ(√Δ) = E^{A₅}` (Δ = discriminant) — the standard discriminant subextension any `Sₙ`-polynomial produces.
- **Quintic annotation** (`content` + `mathContext`): deepened from counting the three subextensions to naming them.

**Guardrails:** `meta.json` 20 KB (≪ 60 KB cap); keyInsights 5 (≤ 12); no collections at cap; existing content preserved.

**Accuracy:** discriminant-quadratic-as-fixed-field-of-Aₙ is classical; the S₅ normal-subgroup list matches the existing openQuestion. Only my two target files are staged (build-generated cross-reference churn discarded).