### PR TITLE
research(descartes-rule-of-signs-oq-01-oq-03): explicit reflected count + alternation characterization

### DIFF
--- a/proofs/Proofs/DescartesRuleOfSignsOQ01OQ03.lean
+++ b/proofs/Proofs/DescartesRuleOfSignsOQ01OQ03.lean
@@ -1294,4 +1294,33 @@ theorem signChangesInCoeffs_comp_neg_X_add {p : ℝ[X]} (hp : p ≠ 0)
   have hmain := countSignChanges_alternate_add hcpnz
   simpa using hmain
 
+/-- **Explicit reflected count — the negative-root Descartes bound in closed form.**  For a
+gap-free polynomial the complementarity `signChangesInCoeffs_comp_neg_X_add`
+(`V(p) + V(p(−X)) = deg p`) rearranges to the explicit value
+
+    `V(p(−X)) = deg p − V(p)`.
+
+This is the form actually cited for the *negative* half of Descartes' rule: the number of
+negative roots of `p` is bounded by `deg p − V(p)`, the degree minus the positive-root bound.
+Immediate (`omega`) from the additive identity. Axiom-free. -/
+theorem signChangesInCoeffs_comp_neg_X_eq_sub {p : ℝ[X]} (hp : p ≠ 0)
+    (hnz : ∀ k, k ≤ p.natDegree → p.coeff k ≠ 0) :
+    DescartesRuleOfSigns.signChangesInCoeffs (p.comp (-X))
+      = p.natDegree - DescartesRuleOfSigns.signChangesInCoeffs p := by
+  have h := signChangesInCoeffs_comp_neg_X_add hp hnz
+  omega
+
+/-- **Fully-alternating ⟺ reflection sign-constant.**  For a gap-free polynomial the two
+extremes of the complementarity `V(p) + V(p(−X)) = deg p` coincide: the reflection `p(−X)`
+has *no* sign changes (all its coefficients share a sign) **iff** `p` is *fully alternating*
+(`V(p) = deg p`, every adjacent coefficient pair flips sign).  The Descartes reading: `p`
+attains the maximal positive-root bound `deg p` exactly when `p(−X)` attains the minimal
+one `0`.  Immediate (`omega`) from the additive identity. Axiom-free. -/
+theorem signChangesInCoeffs_comp_neg_X_eq_zero_iff {p : ℝ[X]} (hp : p ≠ 0)
+    (hnz : ∀ k, k ≤ p.natDegree → p.coeff k ≠ 0) :
+    DescartesRuleOfSigns.signChangesInCoeffs (p.comp (-X)) = 0
+      ↔ DescartesRuleOfSigns.signChangesInCoeffs p = p.natDegree := by
+  have h := signChangesInCoeffs_comp_neg_X_add hp hnz
+  omega
+
 end DescartesRuleOfSignsOQ01OQ03


### PR DESCRIPTION
## Summary

Rounds out **§ 9 (reflection complementarity)** of `DescartesRuleOfSignsOQ01OQ03.lean`. The capstone `signChangesInCoeffs_comp_neg_X_add` proves `V(p) + V(p(−X)) = deg p` for gap-free polynomials — the positive- and negative-root Descartes bounds *partition* the degree — but only in additive form. This PR adds the two standard corollaries actually cited downstream.

## New theorems (both axiom-free)

- **`signChangesInCoeffs_comp_neg_X_eq_sub`** — `V(p(−X)) = deg p − V(p)`, the explicit closed form of the **negative-root Descartes bound** (the number of negative roots of `p` is `≤ deg p − V(p)`). From the additive identity by `omega`.
- **`signChangesInCoeffs_comp_neg_X_eq_zero_iff`** — `V(p(−X)) = 0 ⟺ V(p) = deg p`: the reflection `p(−X)` is sign-constant (no sign changes) **iff** `p` is fully alternating. Descartes-wise, `p` attains the maximal positive-root bound `deg p` exactly when `p(−X)` attains the minimal one `0`. From the additive identity by `omega`.

## Verification

- Built green via the **Docker build**: `./proofs/scripts/docker-build.sh Proofs.DescartesRuleOfSignsOQ01OQ03` — 3064 jobs, exit 0, **no warnings** (builds the two `DescartesRuleOfSigns*` dependencies).
- Both proofs are a single `have` + `omega` on the § 9 identity — no `sorry`, no `native_decide`, no axioms. File stays **0-axiom, 0-sorry**.
- Diff purely additive (+29 lines). File `1297→1326L`, `45→47 thm`. Gallery `meta.json` has null claim fields — nothing to resync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)