### PR TITLE
research(erdos-214-incomplete-01): sharp prime-distance spectrum of √2·ℤ² via Fermat [VERIFIED]

### DIFF
--- a/proofs/Proofs/Erdos214Incomplete01OQ01.lean
+++ b/proofs/Proofs/Erdos214Incomplete01OQ01.lean
@@ -662,4 +662,96 @@ theorem scaledLattice_dist_ne_sqrt_fiftysix {p q : Plane}
   exact scaledLattice_dist_ne_sqrt_of_prime_dvd_not_sq hp hq (r := 7) (n := 56)
     (by decide) (by decide) (by decide)
 
+/-!
+## Fermat's two-square theorem pins down the realizable prime distances `√(2p)`
+
+Every avoidance result above is *one-directional* about a specific residue or prime
+power.  The exact characterization `dist² = 2·(u² + v²)` combined with **Fermat's
+theorem on sums of two squares** (`Nat.Prime.sq_add_sq`) closes the loop for the
+family `√(2p)`, `p` prime:
+
+  `√(2p)` is a lattice distance  **⟺**  `p ≢ 3 (mod 4)`.
+
+The forward (avoidance) direction is the `u² + v² ≢ 3 (mod 4)` obstruction; the
+converse is Fermat's theorem, writing `p = a² + b²` and realizing `√(2p)` at
+`latticePoint a b` and the origin.  This is the first result in the file to prove a
+*realizability* converse for a whole infinite family (rather than a single hand-picked
+value like `√8`), and the only one using a genuinely deep Mathlib import.
+-/
+
+/-- **Realizability of `√(2p)` for a prime `p ≢ 3 (mod 4)`.**  By Fermat's two-square
+theorem `p = a² + b²`, so `2p = 2·(a² + b²)` is a squared lattice distance, realized by
+`latticePoint a b` and the origin (`scaledLattice_realizes`).  Together with the
+avoidance direction below this makes the prime family `√(2p)` sharp. -/
+theorem scaledLattice_realizes_sqrt_two_mul_prime {p : ℕ} [Fact p.Prime] (hp : p % 4 ≠ 3) :
+    ∃ x y : Plane, x ∈ ScaledLattice ∧ y ∈ ScaledLattice ∧
+      dist x y = Real.sqrt (2 * p) := by
+  obtain ⟨a, b, hab⟩ := Nat.Prime.sq_add_sq hp
+  obtain ⟨x, y, hx, hy, h⟩ := scaledLattice_realizes (a : ℤ) (b : ℤ)
+  refine ⟨x, y, hx, hy, ?_⟩
+  rw [h]
+  congr 1
+  have hp' : ((a : ℝ) ^ 2 + (b : ℝ) ^ 2) = (p : ℝ) := by exact_mod_cast hab
+  push_cast
+  linarith [hp']
+
+/-- **Avoidance of `√(2r)` for `r ≡ 3 (mod 4)`.**  If `√(2r)` were a lattice distance
+then `2r = 2·(u² + v²)`, hence `r = u² + v²`; but `u² + v² ≢ 3 (mod 4)`
+(`sq_add_sq_mod_four_ne_three`), contradicting `r ≡ 3 (mod 4)`.  For a prime `r ≡ 3`
+this is the forward half of the sharp iff below.  (As every such `2r ≡ 6 (mod 8)`, the
+statement also refines `scaledLattice_dist_ne_sqrt_six_mod_eight` to the exact `mod 4`
+criterion on the *half* `r`.) -/
+theorem scaledLattice_dist_ne_sqrt_two_mul_of_mod_four {p q : Plane}
+    (hp : p ∈ ScaledLattice) (hq : q ∈ ScaledLattice)
+    {r : ℕ} (hr : r % 4 = 3) : dist p q ≠ Real.sqrt (2 * r) := by
+  intro h
+  obtain ⟨u, v, huv⟩ := scaledLattice_dist_sq_two_mul_sq_add_sq hp hq
+  have hsq : dist p q ^ 2 = 2 * (r : ℝ) := by rw [h, Real.sq_sqrt (by positivity)]
+  rw [hsq] at huv
+  have hz : (2 : ℤ) * (r : ℤ) = 2 * (u ^ 2 + v ^ 2) := by exact_mod_cast huv
+  have h3 := sq_add_sq_mod_four_ne_three u v
+  omega
+
+/-- **Sharp characterization of the realizable prime distances.**  For a prime `p`, the
+value `√(2p)` is a distance between two points of `√2·ℤ²` **iff** `p ≢ 3 (mod 4)`.
+Forward: `scaledLattice_dist_ne_sqrt_two_mul_of_mod_four`; converse: Fermat's theorem via
+`scaledLattice_realizes_sqrt_two_mul_prime`.  So the realizable prime distances are
+exactly `√4 (= 2, p = 2)` and `√(2p)` for `p ≡ 1 (mod 4)` (`√10, √26, √34, …`), while
+`p ≡ 3 (mod 4)` (`√6, √14, √22, …`) are all avoided. -/
+theorem scaledLattice_realizes_sqrt_two_mul_prime_iff {p : ℕ} [Fact p.Prime] :
+    (∃ x y : Plane, x ∈ ScaledLattice ∧ y ∈ ScaledLattice ∧ dist x y = Real.sqrt (2 * p))
+      ↔ p % 4 ≠ 3 := by
+  constructor
+  · rintro ⟨x, y, hx, hy, h⟩ hp3
+    exact scaledLattice_dist_ne_sqrt_two_mul_of_mod_four hx hy hp3 h
+  · intro hp
+    exact scaledLattice_realizes_sqrt_two_mul_prime hp
+
+/-- **Concrete realization:** `√10` *is* a lattice distance (`p = 5 ≡ 1 (mod 4)`,
+`5 = 1² + 2²`, so `10 = 2·(1² + 2²)`).  The first realized `√(2p)` for an odd prime,
+witnessing the converse direction of the sharp iff. -/
+theorem scaledLattice_realizes_sqrt_ten :
+    ∃ x y : Plane, x ∈ ScaledLattice ∧ y ∈ ScaledLattice ∧ dist x y = Real.sqrt 10 := by
+  haveI : Fact (Nat.Prime 5) := ⟨by norm_num⟩
+  obtain ⟨x, y, hx, hy, h⟩ := scaledLattice_realizes_sqrt_two_mul_prime (p := 5) (by decide)
+  exact ⟨x, y, hx, hy, by rw [h]; congr 1; norm_num⟩
+
+/-- **Multiplicative closure (Brahmagupta–Fibonacci / Gaussian-integer norms).**  The
+half-values `m` for which `√(2m)` is a lattice distance are exactly the sums of two
+squares, and these are *closed under multiplication* via the two-square identity
+`(a² + b²)(c² + d²) = (ac − bd)² + (ad + bc)²`.  Hence `√(2·(a² + b²)(c² + d²))` is
+always a lattice distance — realized by `latticePoint (ac − bd) (ad + bc)` and the
+origin.  This exhibits the realizable squared-half distances as the multiplicative monoid
+of norms of Gaussian integers, the structural reason the avoidance families are governed
+by primes `≡ 3 (mod 4)`. -/
+theorem scaledLattice_realizes_two_mul_sq_add_sq_mul (a b c d : ℤ) :
+    ∃ x y : Plane, x ∈ ScaledLattice ∧ y ∈ ScaledLattice ∧
+      dist x y = Real.sqrt (2 * (((a ^ 2 + b ^ 2) * (c ^ 2 + d ^ 2) : ℤ) : ℝ)) := by
+  obtain ⟨x, y, hx, hy, h⟩ := scaledLattice_realizes (a * c - b * d) (a * d + b * c)
+  refine ⟨x, y, hx, hy, ?_⟩
+  rw [h]
+  congr 1
+  push_cast
+  ring
+
 end Erdos214Incomplete01OQ01

--- a/src/data/research/problems/erdos-214-incomplete-01.json
+++ b/src/data/research/problems/erdos-214-incomplete-01.json
@@ -15,16 +15,17 @@
     "open": [],
     "goal": "",
     "completedThisIter": [
-      "researcher-8, 2026-07-09: added 3 verified axiom-free theorems answering the 'maximum size of a unit-distance-free set' half of #214 for the plane — IsUnitDistanceFree.mono (subsets of UDF sets are UDF), exists_unitDistanceFree_finset_card (a UDF finset of every cardinality n via an n-subset of the infinite scaledLattice), and no_maximum_unitDistanceFree_card (no finite cap). Docker build 2364 jobs, 0 errors/sorry, axiomCount unchanged (1)."
+      "researcher-8, 2026-07-09: added 3 verified axiom-free theorems answering the 'maximum size of a unit-distance-free set' half of #214 for the plane — IsUnitDistanceFree.mono (subsets of UDF sets are UDF), exists_unitDistanceFree_finset_card (a UDF finset of every cardinality n via an n-subset of the infinite scaledLattice), and no_maximum_unitDistanceFree_card (no finite cap). Docker build 2364 jobs, 0 errors/sorry, axiomCount unchanged (1).",
+      "researcher-2, 2026-07-11: added 5 verified axiom-free theorems to Erdos214Incomplete01OQ01.lean giving the SHARP characterization of the realizable prime distances of √2·ℤ² via Fermat's two-square theorem — scaledLattice_realizes_sqrt_two_mul_prime (p≢3 mod4 ⇒ √(2p) realized, from Nat.Prime.sq_add_sq), scaledLattice_dist_ne_sqrt_two_mul_of_mod_four (r≡3 mod4 ⇒ √(2r) avoided), scaledLattice_realizes_sqrt_two_mul_prime_iff (the capstone iff: for prime p, √(2p) realized ⇔ p≢3 mod4), scaledLattice_realizes_sqrt_ten (concrete p=5 witness), scaledLattice_realizes_two_mul_sq_add_sq_mul (Brahmagupta–Fibonacci multiplicative closure: realizable squared-half distances = Gaussian-integer norm monoid). Elaboration-clean, all 5 [propext,Classical.choice,Quot.sound]. File 665→757 lines, theoremCount 33→38."
     ]
   },
   "currentState": {
     "phase": "OBSERVE",
     "since": "2026-04-03T08:28:28Z",
     "iteration": 2,
-    "focus": "S+1 ACT (researcher-8, 2026-07-09): core sorry unit_square_exists_in_set remains BLOCKED on juhasz_stronger (deep incidence geometry, absent from Mathlib). Added peripheral verified corollaries showing UDF-set cardinality is unbounded (no finite maximum). File 382->414 lines, theoremCount 20->23.",
+    "focus": "S+1 ACT (researcher-2, 2026-07-11): closed the realizability converse for the prime family √(2p) of the √2·ℤ² distance spectrum. The file's avoidance results were all one-directional; Fermat's two-square theorem (Nat.Prime.sq_add_sq) supplies the missing converse, yielding the sharp iff √(2p) realized ⇔ p≢3 mod4, plus Brahmagupta multiplicative closure of the realizable half-values. Erdos214Incomplete01OQ01.lean 665→757 lines, theoremCount 33→38, still 0 axioms/0 sorries. Core juhasz_stronger still BLOCKED (separate file/axiom).",
     "blockers": [],
-    "nextAction": "Core still needs juhasz_stronger (not session-sized / not in Mathlib). Optional: explicit finite UDF configurations, or the 5-point case HoldsFor5Points.",
+    "nextAction": "Distance-spectrum thread near-complete: prime family now sharp both directions. Remaining: full sum-of-two-squares characterization of ALL realizable √n (needs Nat.eq_sq_add_sq_iff factorization arithmetic — moderate), or realizability of √(2·p·q) products. Core Juhász theorem still needs juhasz_stronger (not session-sized / not in Mathlib).",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -38,7 +39,8 @@
       "Fixed Mathlib-4.26 build break: UnitDistanceGraph tuple set-builder → setOf on Prod",
       "dist_nonneg, dist_triangle in Erdos214Problem.lean: the two metric axioms missing from dist_self/dist_comm (via norm_nonneg, norm_add_le + sub_add_sub_cancel) — Erdos214.dist certified a genuine metric",
       "scaledLattice_horiz_mem + scaledLattice_infinite: √2·ℤ² is infinite (horizontal axis n↦(√2·n,0) embeds ℤ via Set.infinite_of_injective_forall_mem), sharpening scaledLattice_unitDistanceFree from non-empty to infinite",
-      "scaledLatticeGen_unitDistanceFree: c·ℤ² is unit-distance-free for every real c with c²>1 (generalizes the √2 case; squared distance c²·m never hits 1 since m∈ℕ, m=0→0, m≥1→c²·m≥c²>1). scaledLattice_eq_gen (rfl) exhibits ScaledLattice as the c=√2 instance. [elaboration-clean [2364/2364]; olean-write blocked by fleet SIGBUS-135/139]"
+      "scaledLatticeGen_unitDistanceFree: c·ℤ² is unit-distance-free for every real c with c²>1 (generalizes the √2 case; squared distance c²·m never hits 1 since m∈ℕ, m=0→0, m≥1→c²·m≥c²>1). scaledLattice_eq_gen (rfl) exhibits ScaledLattice as the c=√2 instance. [elaboration-clean [2364/2364]; olean-write blocked by fleet SIGBUS-135/139]",
+      "Erdos214Incomplete01OQ01.lean §Fermat (researcher-2): scaledLattice_realizes_sqrt_two_mul_prime, scaledLattice_dist_ne_sqrt_two_mul_of_mod_four, scaledLattice_realizes_sqrt_two_mul_prime_iff (SHARP prime iff √(2p)⇔p≢3 mod4), scaledLattice_realizes_sqrt_ten (p=5 witness), scaledLattice_realizes_two_mul_sq_add_sq_mul (Brahmagupta closure). Uses Mathlib Nat.Prime.sq_add_sq. [elaboration-clean via `lake env lean` (no -c); codegen olean-write still SIGBUS-135 on fleet — a known infra crash AFTER successful elaboration, not a proof error]"
     ],
     "insights": [
       "erdos-214 (Juhász 1979, unit-distance-free sets): the 1 sorry was in unit_square_from_stronger (JuhaszStrongerTheorem → Erdos214Statement) — a pure logical reduction, NOT one of the 2 deep Juhász axioms.",
@@ -47,11 +49,16 @@
       "The file ALSO didn't compile on pinned Mathlib 4.26: UnitDistanceGraph used the tuple set-builder {(p,q) | ...} which no longer parses ('unknown identifier q'); rewrote as {pq | pq.1∈S ∧ ...}.",
       "Coordinate extraction from !₂[a,b]: congrFun FAILS (WithLp.toLp wrapper not a syntactic pi type) — use congrArg (fun x => x 0) then simp [Matrix.cons_val_zero]",
       "Root Mathlib dist is Dist.dist, NOT accessible as _root_.dist; prove metric facts directly from ‖p-q‖ (norm_nonneg/norm_add_le) rather than bridging to Mathlib dist",
-      "The √2 lattice is not special: any scaling c with |c|>1 yields a unit-distance-free copy of ℤ². The sharp condition is arithmetic (no sum-of-two-squares integer m with c²·m=1), so c²>1 is sufficient but not necessary (e.g. c=1/√3 also works since 3 is not a sum of two squares)."
+      "The √2 lattice is not special: any scaling c with |c|>1 yields a unit-distance-free copy of ℤ². The sharp condition is arithmetic (no sum-of-two-squares integer m with c²·m=1), so c²>1 is sufficient but not necessary (e.g. c=1/√3 also works since 3 is not a sum of two squares).",
+      "The realizable distances of √2·ℤ² are exactly √n with n=2·(sum of two squares) — i.e. dist²=2·(u²+v²). This makes the whole 'distance spectrum' a sum-of-two-squares question. For a PRIME p the family √(2p) is now sharp: realized ⇔ p≢3 mod4 (Fermat). Forward (avoidance) is the u²+v²≢3 mod4 residue obstruction; converse is Fermat's Nat.Prime.sq_add_sq. Note every 2p with p≡3 mod4 is ≡6 mod8, so the avoidance overlaps scaledLattice_dist_ne_sqrt_six_mod_eight — but the realizability converse is genuinely new.",
+      "Brahmagupta–Fibonacci identity (a²+b²)(c²+d²)=(ac−bd)²+(ad+bc)² proved by pure `ring` after push_cast — realizes √(2·(a²+b²)(c²+d²)) at latticePoint (ac−bd) (ad+bc). Exhibits the realizable squared-half distances as the multiplicative monoid of Gaussian-integer norms, the structural reason primes ≡3 mod4 govern the avoidance families.",
+      "VERIFICATION WORKAROUND for `import Mathlib` files when fleet codegen SIGBUS-135s: `docker run … lake env lean <file>.lean` (plain `lean`, no -o/-c) elaborates + runs `#print axioms` WITHOUT triggering the crashing C-codegen/olean-write phase. A type error would print `error: <file>:<line>` and exit 1 BEFORE any crash; exit 135 = SIGBUS = infra, post-elaboration. Confirms both type-correctness and axiom set."
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "Remaining elementary follow-ups exhausted around definitions; core BLOCKED on juhasz_stronger (deep 1979 4-point theorem, not in Mathlib). Only substantial work left = formalizing that axiom."
+      "Distance-spectrum thread: prime family √(2p) now sharp both directions (Fermat). Next: full sum-of-two-squares characterization of ALL realizable √n via Nat.eq_sq_add_sq_iff (n realized ⇔ n even ∧ n/2 has no prime ≡3 mod4 to an odd power) — moderate, would subsume every one-off avoidance theorem in the file.",
+      "Realizability of √(2·p·q) product distances follows quickly from scaledLattice_realizes_two_mul_sq_add_sq_mul + the prime realizability lemma.",
+      "Core BLOCKED on juhasz_stronger (deep 1979 4-point theorem, not in Mathlib). Only substantial work left on the CORE = formalizing that axiom."
     ],
     "markdown": "# Knowledge: erdos-214-incomplete-01\n\n## Research Notes\n\n*No research conducted yet. See problem.md for context.*\n\n## Known Facts\n\n- Lean file: `proofs/Proofs/`\n- Sorries: see problem.md\n\n## Approaches Tried\n\n*None yet.*\n"
   },
@@ -68,15 +75,15 @@
     "mathlib": []
   },
   "started": "2026-04-03T08:27:10.206Z",
-  "lastUpdate": "2026-07-09",
+  "lastUpdate": "2026-07-11",
   "significance": 7,
   "tractability": 4,
   "leanFiles": [
     {
       "path": "Proofs/Erdos214Incomplete01OQ01.lean",
       "filename": "Erdos214Incomplete01OQ01.lean",
-      "lineCount": 665,
-      "theoremCount": 31,
+      "lineCount": 757,
+      "theoremCount": 38,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,


### PR DESCRIPTION
## Summary

Adds **5 verified, axiom-free theorems** to `proofs/Proofs/Erdos214Incomplete01OQ01.lean`, closing the **realizability converse** the file's number-theoretic distance-spectrum thread was missing.

The √2-scaled integer lattice has `dist² = 2·(u² + v²)`, so its realizable distances are exactly `√n` with `n = 2·(sum of two squares)`. The file previously had many *one-directional avoidance* families (odd `n`, `n ≡ 6 mod 8`, `n ≡ 12 mod 16`, primes `≡ 3 mod 4` to odd power) and an abstract `achievable_iff`, but no *realizability* converse for any infinite family. **Fermat's two-square theorem** supplies it for the prime family.

## New theorems

- **`scaledLattice_realizes_sqrt_two_mul_prime`** — for a prime `p ≢ 3 (mod 4)`, `√(2p)` **is** a lattice distance (via Mathlib's `Nat.Prime.sq_add_sq`, writing `p = a²+b²`).
- **`scaledLattice_dist_ne_sqrt_two_mul_of_mod_four`** — for `r ≡ 3 (mod 4)`, `√(2r)` is avoided (the `u²+v² ≢ 3 mod 4` residue obstruction).
- **`scaledLattice_realizes_sqrt_two_mul_prime_iff`** — the capstone **sharp iff**: for prime `p`, `√(2p)` is a lattice distance **⟺** `p ≢ 3 (mod 4)`. (Realized: `√4, √10, √26, √34, …`; avoided: `√6, √14, √22, …`.)
- **`scaledLattice_realizes_sqrt_ten`** — concrete `p = 5` witness (`10 = 2·(1²+2²)`).
- **`scaledLattice_realizes_two_mul_sq_add_sq_mul`** — **Brahmagupta–Fibonacci** multiplicative closure: `(a²+b²)(c²+d²) = (ac−bd)²+(ad+bc)²`, exhibiting the realizable squared-half distances as the multiplicative monoid of Gaussian-integer norms — the structural reason primes `≡ 3 mod 4` govern the avoidance families.

## Verification

Elaboration-clean via `docker … lake env lean` (plain `lean`, no `-c` codegen — the fleet's C-codegen phase currently SIGBUS-135s on `import Mathlib` files *after* successful elaboration, a known infra crash, not a proof error). `#print axioms` for all 5 theorems → `[propext, Classical.choice, Quot.sound]` only. **No `sorry`, no `native_decide`, genuinely axiom-free.**

File: 665 → 757 lines, theoremCount 33 → 38, axiomCount unchanged (0).

Core Juhász theorem (`juhasz_stronger`) remains separately blocked and untouched.