### PR TITLE
research(erdos-1018): density is monotone under adding edges (graph-monotone companion)

### DIFF
--- a/proofs/Proofs/Erdos1018Problem.lean
+++ b/proofs/Proofs/Erdos1018Problem.lean
@@ -62,6 +62,26 @@ theorem isDense_of_le (G : SimpleGraph V) [DecidableRel G.Adj] {ε ε' : ℝ}
     Real.rpow_le_rpow_of_exponent_le hV (by linarith)
   linarith
 
+/-- **Edge count is monotone under adding edges.** If `G ≤ H` (every edge of `G` is an edge
+    of `H`, on the same vertex set), then `edgeCount G ≤ edgeCount H`: the edge sets are
+    nested (`SimpleGraph.edgeFinset_mono`), so their cardinalities are ordered. -/
+theorem edgeCount_mono {G H : SimpleGraph V} [DecidableRel G.Adj] [DecidableRel H.Adj]
+    (h : G ≤ H) : edgeCount G ≤ edgeCount H :=
+  Finset.card_le_card (SimpleGraph.edgeFinset_mono h)
+
+/-- **Density is monotone under adding edges.** On a fixed vertex set, a supergraph of a dense
+    graph is dense: if `G ≤ H` and `G` is `(1+ε)`-dense, so is `H`. The density threshold
+    `n^(1+ε)` depends only on the (shared) vertex count, and `edgeCount H ≥ edgeCount G`
+    (`edgeCount_mono`) keeps the edge bound satisfied. The graph-monotone companion of the
+    exponent-monotone `isDense_of_le`; in particular every graph containing a dense subgraph on
+    the same vertices — up to the complete graph `⊤` — is itself dense. -/
+theorem isDense_mono_graph {G H : SimpleGraph V} [DecidableRel G.Adj] [DecidableRel H.Adj]
+    {ε : ℝ} (hGH : G ≤ H) (h : isDense G ε) : isDense H ε := by
+  unfold isDense at h ⊢
+  have hle : (edgeCount G : ℝ) ≤ (edgeCount H : ℝ) := by
+    exact_mod_cast edgeCount_mono hGH
+  linarith
+
 /-
 ## Complete Graphs K₅ and K₃,₃
 


### PR DESCRIPTION
## Summary

Adds the **graph-monotonicity of density** to `Erdos1018Problem.lean` (Erdős #1018, non-planar subgraphs in dense graphs). The file had `isDense_of_le` (density antitone in the exponent `ε`) but no counterpart for the graph itself.

## New theorems (both axiom-free)

- **`edgeCount_mono`** — `G ≤ H ⟹ edgeCount G ≤ edgeCount H`, via `SimpleGraph.edgeFinset_mono` and `Finset.card_le_card` (nested edge sets).
- **`isDense_mono_graph`** — on a fixed vertex set, a supergraph of a dense graph is dense: `G ≤ H` and `isDense G ε ⟹ isDense H ε`. The density threshold `n^(1+ε)` depends only on the shared vertex count, and `edgeCount_mono` keeps the edge bound satisfied. The graph-monotone companion of the exponent-monotone `isDense_of_le`; in particular any graph containing a dense subgraph on the same vertices (up to `⊤`) is itself dense.

## Verification

- Verified green via `lake env lean Proofs/Erdos1018Problem.lean` — exit 0 (curated-import file, type-checks directly on the host). The `unusedSectionVars` linter notes match the file's existing style — the adjacent `isDense_of_le` carries the identical note.
- `#print axioms` for both: `[propext, Classical.choice, Quot.sound]` — axiom-free; neither touches the file's two deep axioms (`kostochka_pyber`, `planar_linear_bound`). File stays **2 axioms, 0 sorry**.
- Diff purely additive (+20 lines). File `655→675L`, `22→24 thm`. Gallery `meta.json` has null claim fields — nothing to resync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)