### PR TITLE
research(cauchy-schwarz-integral-lp-duality-synthesis): strict Cauchy–Schwarz characterization quartet

### DIFF
--- a/proofs/Proofs/CauchySchwarzIntegral.lean
+++ b/proofs/Proofs/CauchySchwarzIntegral.lean
@@ -32,6 +32,7 @@ independently proved it in 1885 for the context of variational calculus.
 - [x] Squared integral form
 - [x] Equality characterization
 - [x] Squared equality characterization (inner and integral forms)
+- [x] Strict inequality characterization (inner and integral forms, abs and squared)
 -/
 
 noncomputable section
@@ -148,6 +149,51 @@ theorem bunyakovsky_schwarz_sq_eq_iff (f g : Lp ℝ 2 μ) (hf : f ≠ 0) (hg : g
   rw [← L2_inner_eq_integral]
   exact cauchy_schwarz_L2_sq_eq_iff f g hf hg
 
+-- Strict Inequality Characterization
+--
+-- The strict companion of `cauchy_schwarz_L2_eq_iff`. Since Cauchy–Schwarz is
+-- always an inequality (`|⟪f,g⟫| ≤ ‖f‖·‖g‖`) and equality holds exactly on
+-- linearly dependent pairs, the inequality is STRICT exactly when `f` and `g`
+-- are linearly INDEPENDENT: for nonzero L² functions,
+-- `|⟪f,g⟫| < ‖f‖·‖g‖ ↔ ¬ ∃ c, f = c • g`. Derived from the `≤` bound and the
+-- equality case via `lt_iff_le_and_ne` (a ≤ b already holds, so `a < b ↔ a ≠ b`).
+theorem cauchy_schwarz_L2_abs_lt_iff (f g : Lp ℝ 2 μ) (hf : f ≠ 0) (hg : g ≠ 0) :
+    |@inner ℝ _ _ f g| < ‖f‖ * ‖g‖ ↔ ¬ ∃ c : ℝ, f = c • g := by
+  rw [lt_iff_le_and_ne, and_iff_right (cauchy_schwarz_L2 f g), ne_eq,
+    cauchy_schwarz_L2_eq_iff f g hf hg]
+
+-- Strict Inequality Characterization (Integral Form)
+--
+-- The integral-form companion of `cauchy_schwarz_L2_abs_lt_iff` and the strict
+-- case of `bunyakovsky_schwarz_abs`. For nonzero L² functions,
+-- `|∫ f·g dμ| < ‖f‖·‖g‖ ↔ ¬ ∃ c, f = c • g`. Same `L2_inner_eq_integral`
+-- bridge used throughout this file.
+theorem bunyakovsky_schwarz_abs_lt_iff (f g : Lp ℝ 2 μ) (hf : f ≠ 0) (hg : g ≠ 0) :
+    |∫ a, (f : α → ℝ) a * (g : α → ℝ) a ∂μ| < ‖f‖ * ‖g‖ ↔ ¬ ∃ c : ℝ, f = c • g := by
+  rw [← L2_inner_eq_integral]
+  exact cauchy_schwarz_L2_abs_lt_iff f g hf hg
+
+-- Strict Inequality Characterization (Squared Inner-Product Form)
+--
+-- The strict companion of `cauchy_schwarz_L2_sq_eq_iff` and the strict case of
+-- `cauchy_schwarz_L2_sq`. For nonzero L² functions,
+-- `⟪f,g⟫² < ‖f‖²·‖g‖² ↔ ¬ ∃ c, f = c • g`. Note no absolute value is needed on
+-- the squared form. Derived from the squared `≤` bound and squared equality case.
+theorem cauchy_schwarz_L2_sq_lt_iff (f g : Lp ℝ 2 μ) (hf : f ≠ 0) (hg : g ≠ 0) :
+    (@inner ℝ _ _ f g) ^ 2 < ‖f‖ ^ 2 * ‖g‖ ^ 2 ↔ ¬ ∃ c : ℝ, f = c • g := by
+  rw [lt_iff_le_and_ne, and_iff_right (cauchy_schwarz_L2_sq f g), ne_eq,
+    cauchy_schwarz_L2_sq_eq_iff f g hf hg]
+
+-- Strict Inequality Characterization (Squared Integral Form)
+--
+-- The integral-form companion of `cauchy_schwarz_L2_sq_lt_iff` and the strict
+-- case of `bunyakovsky_schwarz_sq`. For nonzero L² functions,
+-- `(∫ f·g dμ)² < ‖f‖²·‖g‖² ↔ ¬ ∃ c, f = c • g`.
+theorem bunyakovsky_schwarz_sq_lt_iff (f g : Lp ℝ 2 μ) (hf : f ≠ 0) (hg : g ≠ 0) :
+    (∫ a, (f : α → ℝ) a * (g : α → ℝ) a ∂μ) ^ 2 < ‖f‖ ^ 2 * ‖g‖ ^ 2 ↔ ¬ ∃ c : ℝ, f = c • g := by
+  rw [← L2_inner_eq_integral]
+  exact cauchy_schwarz_L2_sq_lt_iff f g hf hg
+
 -- Summary check
 #check @bunyakovsky_schwarz_abs
 #check @bunyakovsky_schwarz_sq
@@ -155,6 +201,10 @@ theorem bunyakovsky_schwarz_sq_eq_iff (f g : Lp ℝ 2 μ) (hf : f ≠ 0) (hg : g
 #check @bunyakovsky_schwarz_abs_eq_iff
 #check @cauchy_schwarz_L2_sq_eq_iff
 #check @bunyakovsky_schwarz_sq_eq_iff
+#check @cauchy_schwarz_L2_abs_lt_iff
+#check @bunyakovsky_schwarz_abs_lt_iff
+#check @cauchy_schwarz_L2_sq_lt_iff
+#check @bunyakovsky_schwarz_sq_lt_iff
 
 end BunyakovskySchwarz
 


### PR DESCRIPTION
## Summary

Extends the verified light base file `proofs/Proofs/CauchySchwarzIntegral.lean` with the **strict-inequality** companions to its existing equality-case quartet. The file previously characterized *when Cauchy–Schwarz is an equality* (⇔ linear dependence); this adds the dual fact — *when it is strict* (⇔ linear **in**dependence).

For nonzero $f, g \in L^2(\mu)$:

| theorem | statement |
|---|---|
| `cauchy_schwarz_L2_abs_lt_iff`   | $\lvert\langle f,g\rangle\rvert < \lVert f\rVert\,\lVert g\rVert \iff \neg\,\exists c,\ f = c\bullet g$ |
| `bunyakovsky_schwarz_abs_lt_iff` | $\lvert\int f\cdot g\,d\mu\rvert < \lVert f\rVert\,\lVert g\rVert \iff \neg\,\exists c,\ f = c\bullet g$ |
| `cauchy_schwarz_L2_sq_lt_iff`    | $\langle f,g\rangle^2 < \lVert f\rVert^2\lVert g\rVert^2 \iff \neg\,\exists c,\ f = c\bullet g$ |
| `bunyakovsky_schwarz_sq_lt_iff`  | $(\int f\cdot g\,d\mu)^2 < \lVert f\rVert^2\lVert g\rVert^2 \iff \neg\,\exists c,\ f = c\bullet g$ |

## Proof approach

Each strict form follows from the corresponding `≤` bound (already in the file) and equality case via `lt_iff_le_and_ne`: since `a ≤ b` always holds, `a < b ↔ a ≠ b`, and negating the equality-`iff` yields `¬ ∃ c`. The integral forms bridge to the inner-product forms through the file's `L2_inner_eq_integral`. Mirrors the existing inner/integral × abs/squared structure.

## Context

The parent problem `cauchy-schwarz-integral-lp-duality-synthesis` is already **complete** (parent `riesz_lp_surjective` axiom eliminated; full Lp duality 0-axiom). This PR enriches the verified integral-Cauchy–Schwarz API in the light base file, which builds independently of the SIGBUS-prone heavy Synthesis chain.

## Verification

- Docker build: **GREEN `[3061/3061]`** (`docker-build.sh Proofs.CauchySchwarzIntegral`)
- Axiom-free: proofs use only `rw` with foundational lemmas — no `sorry`, no `axiom`, no `native_decide`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)