### PR TITLE
Enrich n-Dimensional Gaussian Integral (area-of-circle-oq-07-oq-04-oq-01-oq-01): cross-link to oq-07

### DIFF
--- a/src/data/proofs/area-of-circle-oq-07-oq-04-oq-01-oq-01/meta.json
+++ b/src/data/proofs/area-of-circle-oq-07-oq-04-oq-01-oq-01/meta.json
@@ -145,6 +145,11 @@
       "targetId": "area-of-circle-oq-07-oq-04",
       "relationship": "extends",
       "description": "Grandparent. Recovers the squared one-dimensional value (∫_ℝ e^{-b x²})² = π/b as the n = 2 specialization, and the bare line integral as n = 1."
+    },
+    {
+      "targetId": "area-of-circle-oq-07",
+      "relationship": "related",
+      "description": "The √π base entry. This entry's n = 2, b = 1 case is ∫_{ℝ²} e^{-‖x‖²} = π^{2/2} = π, which is exactly the planar integral (∫_ℝ e^{-x²})² = π behind that entry's gaussian_integral_sq — the same Poisson squaring-and-Fubini step, here generalized to every dimension. So this entry is the arbitrary-dimension home of oq-07's squared identity; the isotropic n-dimensional Gaussian mass π^{n/2} it computes is what oq-07's n-dimensional open question asks for."
     }
   ],
   "references": [


### PR DESCRIPTION
Enrichment pass for `area-of-circle-oq-07-oq-04-oq-01-oq-01` (quality 96, pass 0).

Already at the quality target (4 keyInsights, 4 sections covering all 85 lines, complete conclusion with 2 implications + 2 open questions, 5 complete annotations). One genuinely valuable, accurate gap: the crossReferences listed only the two ancestors.

**What changed:** added a crossReference to `area-of-circle-oq-07` (the √π base entry). This entry's **n = 2, b = 1** case is `∫_{ℝ²} e^{-‖x‖²} = π^{2/2} = π` — exactly the planar integral `(∫_ℝ e^{-x²})² = π` behind oq-07's `gaussian_integral_sq`, i.e. the same Poisson squaring/Fubini step generalized to every dimension. It is also precisely the isotropic n-dimensional Gaussian mass `π^{n/2}` that oq-07's n-dimensional open question calls for, so the two entries are now explicitly linked.

**Guardrails:** `meta.json` 15 KB (≪ 60 KB); crossReferences 3 (≤ 20); pure-data edit, valid JSON.

Note: `pnpm build`'s `tsc` step can't run in this fresh worktree (`better-sqlite3` native build fails under node 26, unrelated); validated as well-formed JSON.