### PR TITLE
research(erdos-1014-oq-03): multiplicative telescoping identity for the gap-ratio [VERIFIED]

### DIFF
--- a/proofs/Proofs/Erdos1014OQ03.lean
+++ b/proofs/Proofs/Erdos1014OQ03.lean
@@ -308,6 +308,54 @@ theorem log_increment_gap_eq_sum (R : ℕ → ℝ) (l m : ℕ) :
   have h := Finset.sum_range_sub (fun i => Real.log (R (l + i))) m
   simpa using h.symm
 
+/-- **The gap-ratio telescopes into a product of unit ratios.** The multiplicative
+companion of `increment_gap_eq_sum` (additive) and `log_increment_gap_eq_sum`
+(log-additive): whenever `R` is nonzero across the window `[l, l+m]`, the `m`-step
+ratio is the exact product of the `m` consecutive unit ratios,
+
+`R(l+m) / R l = ∏_{i<m} R(l+i+1) / R(l+i)`.
+
+This is the multiplicative telescoping `R(l+m)/R(l) = ∏ R(l+i+1)/R(l+i)` invoked (but
+not previously stated) in the docstrings of `ratio_gap_tendsto_one` and
+`ratio_gap_tendsto_pow`; it is their exact algebraic backbone, made explicit here.
+Proof: induction on `m`, splitting off one factor with `div_mul_div_cancel₀` (exactly
+as in `ratio_gap_tendsto_one`'s inductive step). -/
+theorem ratio_gap_eq_prod (R : ℕ → ℝ) (l m : ℕ) (hne : ∀ i ≤ m, R (l + i) ≠ 0) :
+    R (l + m) / R l = ∏ i ∈ Finset.range m, (R (l + i + 1) / R (l + i)) := by
+  revert hne
+  induction m with
+  | zero =>
+      intro hne
+      simp only [Finset.range_zero, Finset.prod_empty, Nat.add_zero]
+      exact div_self (by simpa using hne 0 le_rfl)
+  | succ m ih =>
+      intro hne
+      show R (l + m + 1) / R l = ∏ i ∈ Finset.range (m + 1), (R (l + i + 1) / R (l + i))
+      rw [Finset.prod_range_succ,
+          ← ih (fun i hi => hne i (Nat.le_succ_of_le hi)),
+          mul_comm, div_mul_div_cancel₀ (hne m (Nat.le_succ m))]
+
+/-- **The product of consecutive ratios tends to `1`.** Under Erdős #1014's ratio
+convergence `R(l+1)/R(l) → 1`, for every fixed gap `m` the product form of the
+gap-ratio converges,
+
+`∏_{i<m} R(l+i+1) / R(l+i) → 1`.
+
+The product-form reading of `ratio_gap_tendsto_one` (to which it is equal on the
+nonvanishing window by `ratio_gap_eq_prod`): each of the `m` factors is a shifted copy
+of the unit ratio, so each tends to `1`, and the finite product of null-factors tends to
+`∏ 1 = 1` (`tendsto_finset_prod`). Notably this needs **no** positivity hypothesis — it
+holds for the product of shifted ratios directly. -/
+theorem prod_consecutive_ratios_tendsto_one (R : ℕ → ℝ) (m : ℕ)
+    (hratio : Tendsto (fun l => R (l + 1) / R l) atTop (𝓝 1)) :
+    Tendsto (fun l => ∏ i ∈ Finset.range m, (R (l + i + 1) / R (l + i))) atTop (𝓝 1) := by
+  have h : Tendsto (fun l => ∏ i ∈ Finset.range m, (R (l + i + 1) / R (l + i))) atTop
+      (𝓝 (∏ _i ∈ Finset.range m, (1 : ℝ))) := by
+    refine tendsto_finset_prod _ (fun i _ => ?_)
+    have hi := hratio.comp (tendsto_add_atTop_nat i)
+    simpa using hi
+  simpa using h
+
 /-- **Bounded-gap ratio convergence.** If the consecutive ratio `R(l+1)/R(l)` tends to
 `1` (Erdős #1014) and `R` is eventually positive, then for *every fixed gap* `m` the
 gap-ratio `R(l+m)/R(l)` also tends to `1`.


### PR DESCRIPTION
## Summary

`Erdos1014OQ03.lean` studies the off-diagonal Ramsey increment via a self-contained increment/ratio/log-increment bridge. It already proves the **additive** telescoping identity `increment_gap_eq_sum` (`R(l+m)−R(l) = Σ_{i<m} (R(l+i+1)−R(l+i))`) and its **log-additive** analogue `log_increment_gap_eq_sum`, and the docstrings of `ratio_gap_tendsto_one`/`ratio_gap_tendsto_pow` repeatedly cite the **multiplicative** telescoping `R(l+m)/R(l) = ∏ R(l+i+1)/R(l+i)` — but that identity was never stated. This adds it, completing the trio.

## New theorems (axiom-free)

| Theorem | Statement |
|---|---|
| `ratio_gap_eq_prod` | On a window where `R` is nonzero: `R(l+m)/R l = ∏_{i<m} R(l+i+1)/R(l+i)` |
| `prod_consecutive_ratios_tendsto_one` | Under `R(l+1)/R(l) → 1`: `∏_{i<m} R(l+i+1)/R(l+i) → 1` (no positivity needed) |

## Proof notes

- `ratio_gap_eq_prod` — induction on `m`, splitting off one factor with `div_mul_div_cancel₀` (exactly the inductive step already used by `ratio_gap_tendsto_one`). It is the algebraic backbone that theorem invokes implicitly.
- `prod_consecutive_ratios_tendsto_one` — each of the `m` factors is a shifted copy of the unit ratio (`hratio.comp (tendsto_add_atTop_nat i)`), each `→ 1`; the finite product of null-factors converges to `∏ 1 = 1` via `tendsto_finset_prod`. Requires no `hpos`.

## Verification

- Built clean via `./proofs/scripts/docker-build.sh Proofs.Erdos1014OQ03` (7743 jobs).
- `#print axioms` on both new theorems reports only `[propext, Classical.choice, Quot.sound]` — **no `Lean.ofReduceBool`, no `sorryAx`**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)