### PR TITLE
Enrich Γ(1/2)=√π (area-of-circle-oq-07-oq-03): add missing reciprocal crossReference

### DIFF
--- a/src/data/proofs/area-of-circle-oq-07-oq-03/meta.json
+++ b/src/data/proofs/area-of-circle-oq-07-oq-03/meta.json
@@ -139,6 +139,11 @@
       "description": "Direct child answering this entry's second open question. It gives an independent, Beta-function derivation of Γ(1/2)² = π via Mathlib's Beta–Gamma relation and B(1/2,1/2) = π (the arcsine density) — a route that, unlike gamma_one_half_sq here, does not pass through the Gaussian integral."
     },
     {
+      "targetId": "area-of-circle-oq-07-oq-03-oq-03",
+      "relationship": "extended by",
+      "description": "Direct child that also climbs this entry's first open question (the half-integer ladder), by the moment route: it proves ∫_ℝ x^{2n} e^{-x²} dx = Γ(n+1/2) = (2n−1)‼·√π/2ⁿ for every n, evaluating each even Gaussian moment via the u = x² substitution and even symmetry, and recovers this entry's Γ(1/2) = √π as the n = 0 rung. A sibling formalization to area-of-circle-oq-07-oq-03-oq-01 of the same moment–Gamma ladder."
+    },
+    {
       "targetId": "gamma-reflection-formula-oq-01",
       "relationship": "related",
       "description": "Euler's reflection formula Γ(s)Γ(1−s) = π/sin(πs) at s = 1/2 gives Γ(1/2)² = π directly — the same squared identity proved here as gamma_one_half_sq, reached from functional-equation symmetry rather than from the Gaussian integral."


### PR DESCRIPTION
Enrichment pass for `area-of-circle-oq-07-oq-03` (quality 96, pass 0).

Already at the quality target (4 keyInsights, 4 sections covering all 62 lines, complete conclusion, 5 complete annotations, 5 crossReferences). One genuine graph gap: this entry linked to its children `-oq-01` and `-oq-02` but **not** `-oq-03` — even though `area-of-circle-oq-07-oq-03-oq-03` ('The Half-Integer Gamma Ladder as Even Gaussian Moments') is a direct child that names this entry as its parent.

**What changed:** added the missing `extended by` crossReference (5 → 6). `-oq-03` also climbs this entry's first open question — the half-integer ladder `Γ(n+1/2) = (2n−1)‼·√π/2ⁿ` — by the even-Gaussian-moment route (u=x² substitution + even symmetry) and recovers `Γ(1/2)=√π` as its n=0 rung, making it a sibling formalization to `-oq-01`. The parent→child family graph is now complete and reciprocal.

**Guardrails:** `meta.json` 14 KB (≪ 60 KB); crossReferences 6 (≤ 20); pure-data edit, valid JSON.

Note: `pnpm build`'s `tsc` step can't run in this fresh worktree (`better-sqlite3` native build fails under node 26, unrelated); validated as well-formed JSON.