### PR TITLE
Enrich Anisotropic n-Dim Gaussian (area-of-circle-oq-07-oq-04-oq-01-oq-01-oq-02): cross-link to oq-07

### DIFF
--- a/src/data/proofs/area-of-circle-oq-07-oq-04-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/area-of-circle-oq-07-oq-04-oq-01-oq-01-oq-02/meta.json
@@ -145,6 +145,11 @@
       "targetId": "area-of-circle-oq-07-oq-04-oq-01",
       "relationship": "extends",
       "description": "Grandparent. Recovers the planar value as the isotropic n = 2 case ∫_{ℝ²} e^{-b(x²+y²)} = π/b."
+    },
+    {
+      "targetId": "area-of-circle-oq-07",
+      "relationship": "related",
+      "description": "Lineage root (∫_ℝ e^{-x²} = √π). That entry's n-dimensional open question asks for the general positive-definite quadratic-form Gaussian ∫_{ℝⁿ} e^{-⟨Ax,x⟩} = π^{n/2}/√(det A); this entry supplies its diagonal case, since ∏ᵢ bᵢ = det diag(b₁,…,bₙ) makes π^{n/2}/√(∏ᵢ bᵢ) exactly π^{n/2}/√(det A) for A = diag b. Together with the isotropic sibling area-of-circle-oq-07-oq-04-oq-01-oq-01 (the A = bI case), it reduces the general open question to the orthogonal-diagonalization step left as this entry's own follow-up."
     }
   ],
   "references": [


### PR DESCRIPTION
Enrichment pass for `area-of-circle-oq-07-oq-04-oq-01-oq-01-oq-02` (quality 96, pass 0).

Already thorough (5 keyInsights, 3 sections covering all 114 lines, 5 complete annotations, complete conclusion with 2 open questions, 3 references). The one sparse field: `crossReferences` listed only the two ancestors.

**What changed:** added a crossReference to the lineage root `area-of-circle-oq-07`. That entry's n-dimensional open question asks for the general positive-definite quadratic-form Gaussian `∫_{ℝⁿ} e^{-⟨Ax,x⟩} = π^{n/2}/√(det A)`; this entry supplies its **diagonal case** (since `∏ᵢ bᵢ = det diag(b₁,…,bₙ)`, the value `π^{n/2}/√(∏bᵢ)` is exactly `π^{n/2}/√(det A)` for `A = diag b`). Together with the isotropic sibling `…-oq-01-oq-01` (the `A = bI` case), it reduces oq-07's general open question to the orthogonal-diagonalization step left as this entry's own follow-up — making the lineage's progress toward that question explicit.

**Guardrails:** `meta.json` 17.5 KB (≪ 60 KB); crossReferences 3 (≤ 20); pure-data edit, valid JSON.

Note: `pnpm build`'s `tsc` step can't run in this fresh worktree (`better-sqlite3` native build fails under node 26, unrelated); validated as well-formed JSON.