### PR TITLE
Enrich Gaussian-moments ladder (oq-07-oq-03-oq-03): finer sections (3→5)

### DIFF
--- a/src/data/proofs/area-of-circle-oq-07-oq-03-oq-03/meta.json
+++ b/src/data/proofs/area-of-circle-oq-07-oq-03-oq-03/meta.json
@@ -77,12 +77,28 @@
       "mathContext": "$\\int_{x>0} x^{2n} e^{-x^2}\\,dx = \\tfrac12\\Gamma(n+\\tfrac12)$; evenness doubles it."
     },
     {
-      "id": "closed-and-values",
-      "title": "Closed Form and Base Cases",
-      "startLine": 91,
+      "id": "closed-form",
+      "title": "The Double-Factorial Closed Form",
+      "startLine": 90,
+      "endLine": 94,
+      "summary": "gaussian_moment_closed turns the Gamma-valued ladder into an elementary closed form: ∫_ℝ x^{2n} e^{-x²} dx = (2n-1)‼·√π/2ⁿ. A one-line proof — rewrite by the ladder identity, then by Mathlib's Real.Gamma_nat_add_half, which supplies Γ(n + 1/2) = (2n-1)‼·√π/2ⁿ.",
+      "mathContext": "$\\Gamma(n+\\tfrac12) = (2n-1)!!\\,\\sqrt\\pi/2^n$, so the even Gaussian moment is elementary in $n$."
+    },
+    {
+      "id": "base-zero",
+      "title": "Base Case n = 0: Recovering the Parent √π",
+      "startLine": 96,
+      "endLine": 100,
+      "summary": "gaussian_moment_zero specializes the ladder at n = 0 to recover the parent entry's Gaussian integral ∫_ℝ e^{-x²} dx = √π, using Γ(1/2) = √π (Real.Gamma_one_half_eq). The zeroth even moment is the total mass of the Gaussian weight.",
+      "mathContext": "$\\int_{\\mathbb R} x^{0} e^{-x^2}\\,dx = \\Gamma(\\tfrac12) = \\sqrt\\pi$."
+    },
+    {
+      "id": "base-two",
+      "title": "Base Case n = 1: The Second Even Moment √π/2",
+      "startLine": 102,
       "endLine": 109,
-      "summary": "gaussian_moment_closed gives the double-factorial form (2n-1)‼·√π/2ⁿ via Real.Gamma_nat_add_half. gaussian_moment_zero recovers the parent's ∫_ℝ e^{-x²} dx = √π, and gaussian_moment_two gives ∫_ℝ x² e^{-x²} dx = √π/2 (from Γ(3/2) = √π/2).",
-      "mathContext": "$\\Gamma(\\tfrac12)=\\sqrt\\pi$, $\\Gamma(\\tfrac32)=\\tfrac{\\sqrt\\pi}2$."
+      "summary": "gaussian_moment_two specializes at n = 1: ∫_ℝ x² e^{-x²} dx = √π/2. The proof reduces Γ(3/2) via Γ(s+1) = s·Γ(s) (Real.Gamma_add_one) to (1/2)·Γ(1/2) = √π/2. This second moment is the (unnormalized) variance datum of the Gaussian weight.",
+      "mathContext": "$\\int_{\\mathbb R} x^{2} e^{-x^2}\\,dx = \\Gamma(\\tfrac32) = \\tfrac12\\Gamma(\\tfrac12) = \\tfrac{\\sqrt\\pi}{2}$."
     }
   ],
   "openQuestions": [


### PR DESCRIPTION
## Summary

Enrichment pass for `area-of-circle-oq-07-oq-03-oq-03` ("The half-integer Gamma ladder as even Gaussian moments"). Splits the bundled *Closed Form and Base Cases* section into three, so each of the file's four theorems gets its own section (docstring + 4 theorems = **5 sections**), lifting rubric quality **96 → 100**:

| id | lines | content |
|----|-------|---------|
| `docstring` | 1–32 | the moment ↔ Gamma-ladder framing and u = x² route |
| `ladder` | 38–90 | `gaussian_moment_eq_gamma` (the substantial multi-step proof) |
| `closed-form` | 90–94 | `gaussian_moment_closed`, the (2n-1)‼·√π/2ⁿ form |
| `base-zero` | 96–100 | `gaussian_moment_zero`, n = 0 recovering the parent √π |
| `base-two` | 102–109 | `gaussian_moment_two`, n = 1 giving √π/2 |

**Not padding**: the two base cases are genuinely distinct theorems (n = 0 total mass vs. n = 1 second moment, proved via different Gamma lemmas), so the split reflects real structure.

## Accuracy verified before enriching
- **Counts match the Lean file**: 110 lines, 4 theorems, 0 axioms, 0 sorries. The lone `sorry` grep hit is the docstring phrase *"`sorry`-free and `axiom`-free"* (line 30), not a real sorry.
- **Axiom integrity honest**: `status: verified`, `badge: mathlib`, `axiomCount: 0`, no `native_decide`.

## Guardrails
- Section boundaries only; no prose inflation. `meta.json` 13.7 → 14.9 KB, far under the 60 KB cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)