### PR TITLE
research(bezout-identity-oq-01-oq-02-oq-02): sharpness of the 1<n hypothesis — SL₁(ℤ) has two primitive-vector orbits

### DIFF
--- a/proofs/Proofs/BezoutIdentityOQ01OQ02OQ02.lean
+++ b/proofs/Proofs/BezoutIdentityOQ01OQ02OQ02.lean
@@ -581,4 +581,66 @@ theorem isPrimitive_iff_exists_sl_column (hn : 1 < n) (v : Fin n → ℤ) :
   · rintro ⟨A, k, rfl⟩
     exact orbit_e_isPrimitive A k
 
+/-! ### Sharpness of the dimension hypothesis: the `n = 1` obstruction
+
+Every transitivity statement above (`exists_sl_mulVec_eq_of_isPrimitive`,
+`exists_sl_mulVec_basis_of_isPrimitive`, `isPrimitive_iff_exists_sl_column`) carries the
+hypothesis `1 < n`, and their docstrings assert that this is *genuinely necessary* rather
+than a proof artefact: in dimension `1` the group `SL₁(ℤ)` is trivial, so it acts trivially
+on vectors and cannot connect the two primitive vectors `(1)` and `(-1)`.  The lemmas below
+turn that repeated prose remark into machine-checked statements, pinning down the orbit
+structure at the base dimension: `SL₁(ℤ)` has **two** orbits of primitive vectors
+(`{(1)}` and `{(-1)}`), in contrast with the single orbit for `n ≥ 2`. -/
+
+/-- **`SL₁(ℤ)` is the trivial group at the matrix level.**  The only `1 × 1` integer matrix
+of determinant `1` is the identity `(1)`: the determinant of a `1 × 1` matrix is its sole
+entry (`Matrix.det_fin_one`), so `det = 1` forces that entry to be `1`, and a
+`Fin 1`-indexed matrix is determined by its single entry. -/
+theorem coe_sl_fin_one_eq_one (A : Matrix.SpecialLinearGroup (Fin 1) ℤ) :
+    (A : Matrix (Fin 1) (Fin 1) ℤ) = 1 := by
+  have hdet : (A : Matrix (Fin 1) (Fin 1) ℤ) 0 0 = 1 := by
+    have h : (A : Matrix (Fin 1) (Fin 1) ℤ).det = 1 := A.2
+    rwa [Matrix.det_fin_one] at h
+  ext i j
+  rw [Subsingleton.elim i 0, Subsingleton.elim j 0, Matrix.one_apply_eq]
+  exact hdet
+
+/-- **`SL₁(ℤ)` acts trivially on every vector.**  Immediate from `coe_sl_fin_one_eq_one`:
+multiplying by the identity matrix fixes `v`.  So no `SL₁(ℤ)` move changes a vector at all —
+the one-dimensional orbits are singletons. -/
+theorem sl_fin_one_mulVec (A : Matrix.SpecialLinearGroup (Fin 1) ℤ) (v : Fin 1 → ℤ) :
+    (A : Matrix (Fin 1) (Fin 1) ℤ) *ᵥ v = v := by
+  rw [coe_sl_fin_one_eq_one, Matrix.one_mulVec]
+
+/-- **No `SL₁(ℤ)` move connects `(1)` and `(-1)`.**  Both are primitive
+(`isPrimitive_fin_one_iff`), yet since `SL₁(ℤ)` acts trivially (`sl_fin_one_mulVec`) any
+image of `e₀ = (1)` is `(1)`, never `(-1)`.  This is the sign obstruction that forces the
+`1 < n` hypothesis in the transitivity theorems: the uniform normal form
+`isPrimitive_iff_exists_sl_single` reaches only a *unit multiple* `c · eₖ` precisely because
+the sign `c` cannot be normalized away at `n = 1`. -/
+theorem not_exists_sl_fin_one_single_neg :
+    ¬ ∃ A : Matrix.SpecialLinearGroup (Fin 1) ℤ,
+      (A : Matrix (Fin 1) (Fin 1) ℤ) *ᵥ Pi.single 0 (1 : ℤ) = Pi.single 0 (-1 : ℤ) := by
+  rintro ⟨A, hA⟩
+  rw [sl_fin_one_mulVec] at hA
+  have h0 := congrFun hA 0
+  rw [Pi.single_eq_same, Pi.single_eq_same] at h0
+  norm_num at h0
+
+/-- **Transitivity fails outright at `n = 1`.**  The single-orbit conclusion of
+`exists_sl_mulVec_eq_of_isPrimitive` is false without `1 < n`: the primitive vectors `(1)`
+and `(-1)` are not `SL₁(ℤ)`-equivalent.  Hence the dimension hypothesis in that theorem (and
+all its corollaries) cannot be dropped — the sharpness statement the docstrings claimed. -/
+theorem not_forall_sl_fin_one_orbit :
+    ¬ ∀ (v w : Fin 1 → ℤ), IsPrimitive v → IsPrimitive w →
+      ∃ A : Matrix.SpecialLinearGroup (Fin 1) ℤ,
+        (A : Matrix (Fin 1) (Fin 1) ℤ) *ᵥ v = w := by
+  intro H
+  have hp1 : IsPrimitive (Pi.single (0 : Fin 1) (1 : ℤ)) := isPrimitive_single 0
+  have hp2 : IsPrimitive (Pi.single (0 : Fin 1) (-1 : ℤ)) := by
+    rw [isPrimitive_fin_one_iff]
+    right
+    rw [Pi.single_eq_same]
+  exact not_exists_sl_fin_one_single_neg (H _ _ hp1 hp2)
+
 end BezoutPrimitive

--- a/src/data/proofs/bezout-identity-oq-01-oq-02-oq-02/meta.json
+++ b/src/data/proofs/bezout-identity-oq-01-oq-02-oq-02/meta.json
@@ -31,7 +31,8 @@
       "isPrimitive_mulVec_iff: SLₙ(ℤ) preserves primitivity in both directions — the exact invariant transitivity must respect",
       "transvectionSL / transvectionSL_mulVec: the elementary Euclidean-descent generators packaged in SLₙ(ℤ) with their explicit action v ↦ update v i (vᵢ + c·vⱼ)",
       "orbit_e_isPrimitive: the necessity half of transitivity — every SLₙ(ℤ)-orbit of a basis vector consists of primitive vectors",
-      "BezoutIdentityOQ01OQ02OQ02Invariant.lean — the invariance (necessity) complement to the transitivity results: the content (gcd) of an integer vector is a complete SLₙ(ℤ)-invariant. dvd_mulVec (integer matrices carry common divisors forward), common_dvd_mulVec_iff (SLₙ preserves the full set of common divisors, strengthening isPrimitive_mulVec_iff from primitivity to arbitrary content), sameOrbit_common_dvd_eq (content is an orbit invariant), IsPrimitive.common_dvd_isUnit (primitive = trivial content). Axiom-free."
+      "BezoutIdentityOQ01OQ02OQ02Invariant.lean — the invariance (necessity) complement to the transitivity results: the content (gcd) of an integer vector is a complete SLₙ(ℤ)-invariant. dvd_mulVec (integer matrices carry common divisors forward), common_dvd_mulVec_iff (SLₙ preserves the full set of common divisors, strengthening isPrimitive_mulVec_iff from primitivity to arbitrary content), sameOrbit_common_dvd_eq (content is an orbit invariant), IsPrimitive.common_dvd_isUnit (primitive = trivial content). Axiom-free.",
+      "Sharpness of the 1<n hypothesis (n=1 obstruction): coe_sl_fin_one_eq_one (SL₁(ℤ)={(1)} at the matrix level), sl_fin_one_mulVec (SL₁ acts trivially), not_exists_sl_fin_one_single_neg (no SL₁ move carries (1) to (-1)), not_forall_sl_fin_one_orbit (transitivity fails at n=1). Proves the entry's previously prose-only claim that the 1<n hypothesis in exists_sl_mulVec_eq_of_isPrimitive is genuinely necessary — SL₁(ℤ) has two primitive-vector orbits, not one. Axiom-free."
     ]
   },
   "overview": {
@@ -91,13 +92,18 @@
       "name": "isPrimitive_iff_exists_sl_column",
       "type": "theorem",
       "description": "Unimodular column completion (n ≥ 2): a vector is primitive iff it is a column of some matrix in SLₙ(ℤ) (IsPrimitive v ↔ ∃ A k, ↑ₘA *ᵥ eₖ = v). The classical statement that a primitive integer vector extends to a ℤ-basis — the columns of SLₙ(ℤ) are exactly the primitive vectors. Backward is orbit_e_isPrimitive; forward inverts exists_sl_mulVec_basis_of_isPrimitive. The 1<n hypothesis is essential: at n=1 the primitive vector (-1) is no column of SL₁(ℤ)={1}."
+    },
+    {
+      "name": "not_forall_sl_fin_one_orbit",
+      "type": "theorem",
+      "description": "Sharpness of the 1<n hypothesis: transitivity FAILS at n=1. Since SL₁(ℤ)={1} acts trivially on every vector (coe_sl_fin_one_eq_one, sl_fin_one_mulVec), the two primitive vectors (1) and (-1) lie in distinct orbits (not_exists_sl_fin_one_single_neg), so exists_sl_mulVec_eq_of_isPrimitive and its corollaries genuinely require 1<n. This turns the entry's repeated prose 'the dimension hypothesis is genuinely necessary, not an artefact' into a machine-checked theorem: SL₁(ℤ) has exactly two orbits of primitive vectors, versus a single orbit for n ≥ 2."
     }
   ],
   "leanFile": {
     "namespace": "BezoutPrimitive",
-    "lineCount": 584,
+    "lineCount": 646,
     "axiomCount": 0,
-    "theoremCount": 27,
+    "theoremCount": 31,
     "definitionCount": 2,
     "path": "Proofs/BezoutIdentityOQ01OQ02OQ02.lean",
     "sorries": 0

--- a/src/data/research/problems/bezout-identity-oq-01-oq-02-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-01-oq-02-oq-02.json
@@ -42,7 +42,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (VERIFIED axiom-free, single-file lake env lean exit 0): proved the general-n converse direction exists_sl_mulVec_single_of_isPrimitive — every primitive integer vector is SLn(Z)-equivalent to a unit multiple of a basis vector, by strong induction on the l1 measure sum_k|v_k| via the transvection Euclidean-reduction step sum_natAbs_update_emod_lt. This discharges the open converse (sufficiency) half that orbit_e_isPrimitive recorded as remaining work, in EVERY dimension (previously only n=2 was closed, closed-form). Plus the clean characterization isPrimitive_iff_exists_sl_single. File 302->443 lines, +3 verified theorems. Sole remaining: the n>=2 corollary reaching exactly e0 (rotation assembly).",
+    "progressSummary": "SOLVED (n≥2 full transitivity done in prior sessions: exists_sl_mulVec_eq_of_isPrimitive + column completion). This session added the matching SHARPNESS: n=1 obstruction (SL₁ trivial → 2 orbits), machine-checking the 1<n necessity the docstrings only asserted. Axiom-free. PR #38002.",
     "builtItems": [
       "IsPrimitive (Fin n → ℤ) := ∃ w, w ⬝ᵥ v = 1 — BezoutIdentityOQ01OQ02OQ02.lean",
       "isPrimitive_iff_span_eq_top: IsPrimitive v ↔ Ideal.span (range v) = ⊤ (bridge to classical gcd=1 via Ideal.mem_span_range_iff_exists_fun)",
@@ -51,7 +51,8 @@
       "orbit_e_isPrimitive: the easy half — every vector in the SLₙ(ℤ)-orbit of eᵢ is primitive",
       "sum_natAbs_update_emod_lt (BezoutIdentityOQ01OQ02OQ02.lean): the Euclidean reduction step strictly lowers sum_k|v_k|. VERIFIED 0-sorry/0-axiom.",
       "exists_sl_mulVec_single_of_isPrimitive (BezoutIdentityOQ01OQ02OQ02.lean): general-n converse — every primitive v is SLn(Z)-equivalent to Pi.single k c with IsUnit c, by strong induction on l1 measure. VERIFIED axiom-free (propext/Classical.choice/Quot.sound only).",
-      "isPrimitive_iff_exists_sl_single (BezoutIdentityOQ01OQ02OQ02.lean): clean iff — IsPrimitive v iff exists A k c, IsUnit c and A *v v = Pi.single k c. VERIFIED."
+      "isPrimitive_iff_exists_sl_single (BezoutIdentityOQ01OQ02OQ02.lean): clean iff — IsPrimitive v iff exists A k c, IsUnit c and A *v v = Pi.single k c. VERIFIED.",
+      "coe_sl_fin_one_eq_one, sl_fin_one_mulVec, not_exists_sl_fin_one_single_neg, not_forall_sl_fin_one_orbit (BezoutIdentityOQ01OQ02OQ02.lean): the n=1 obstruction package. VERIFIED axiom-free [propext,Classical.choice,Quot.sound]. File 584→646L, 27→31 thm."
     ],
     "insights": [
       "Primitivity of an integer vector v is cleanly captured coordinate-free as: ∃ dual w with w ⬝ᵥ v = 1. This dot-product form is manifestly SLₙ(ℤ)-invariant, unlike the gcd-of-entries phrasing.",
@@ -62,7 +63,8 @@
       "The converse (sufficiency) direction of SLn(Z)-transitivity on primitive vectors — every primitive v is SLn(Z)-equivalent to a unit multiple of a basis vector — holds in EVERY dimension by strong induction on the l1 measure sum_k |v_k|, no analytic input needed (elementary Euclidean descent).",
       "The termination measure is sum_k (v k).natAbs; a single transvection T_{i,j}(-(v i / v j)) replaces the pivot v i by v i % v j, and 0 <= v i % v j < |v j| <= |v i| makes exactly the i-th summand shrink (sum_natAbs_update_emod_lt).",
       "Base case: a primitive vector with a single nonzero coordinate must have that entry a unit (from exists w, w dot v = 1 collapsing to w k * v k = 1), so it already equals Pi.single k (v k) with IsUnit (v k) — A = 1.",
-      "Reaching EXACTLY e0 (not just a unit multiple c*e_k) is only true for n >= 2; in n = 1, SL1(Z)={1} fixes -e0 != e0 though both are primitive, so the unit-multiple form is the sharp general-n statement."
+      "Reaching EXACTLY e0 (not just a unit multiple c*e_k) is only true for n >= 2; in n = 1, SL1(Z)={1} fixes -e0 != e0 though both are primitive, so the unit-multiple form is the sharp general-n statement.",
+      "Sharpness of transitivity: SL₁(ℤ)={(1)} acts trivially (coe_sl_fin_one_eq_one via det_fin_one), so (1) and (-1) — both primitive — lie in DISTINCT orbits. SL₁(ℤ) has exactly 2 primitive-vector orbits vs a single orbit for n≥2. This proves the previously prose-only claim that the 1<n hypothesis in exists_sl_mulVec_eq_of_isPrimitive is genuinely necessary."
     ],
     "mathlibGaps": [
       "Mathlib has no packaged transitivity of SLₙ(ℤ) on primitive vectors (only n=2 pieces via bezoutSL in the parent). Foundation built here; the Euclidean-descent converse (every primitive vector reaches eᵢ) remains.",


### PR DESCRIPTION
## Summary

The gallery entry `bezout-identity-oq-01-oq-02-oq-02` proves that **SLₙ(ℤ) acts transitively on primitive integer vectors for n ≥ 2** (`exists_sl_mulVec_eq_of_isPrimitive`, `exists_sl_mulVec_basis_of_isPrimitive`, `isPrimitive_iff_exists_sl_column`). Those theorems all carry a `1 < n` hypothesis, and the docstrings repeatedly assert it is *"genuinely necessary, not an artefact"* — **but that sharpness claim was never machine-checked.** This PR fills exactly that gap.

## What's added (4 axiom-free theorems)

- **`coe_sl_fin_one_eq_one`** — `SL₁(ℤ) = {(1)}` at the matrix level. The determinant of a `1×1` matrix is its sole entry (`Matrix.det_fin_one`), so `det = 1` forces that entry to `1`, and a `Fin 1`-indexed matrix is determined by its single entry.
- **`sl_fin_one_mulVec`** — `SL₁(ℤ)` acts trivially on every vector (the one-dimensional orbits are singletons).
- **`not_exists_sl_fin_one_single_neg`** — no `SL₁(ℤ)` move carries `(1)` to `(-1)`.
- **`not_forall_sl_fin_one_orbit`** — transitivity fails outright at `n = 1`: the primitive vectors `(1)` and `(-1)` are inequivalent, so the `1 < n` hypothesis of `exists_sl_mulVec_eq_of_isPrimitive` (and all its corollaries) cannot be dropped.

**Upshot:** `SL₁(ℤ)` has exactly **two** orbits of primitive vectors, versus a **single** orbit for `n ≥ 2` — completing the orbit structure at the base dimension and turning the entry's prose sharpness remark into a theorem.

## Verification

- `lake env lean Proofs/BezoutIdentityOQ01OQ02OQ02.lean` → exit 0, clean elaboration.
- `#print axioms` of the new theorems: `[propext, Classical.choice, Quot.sound]` — **axiom-free** (no `sorryAx`, no `Lean.ofReduceBool`).
- File 584 → 646 lines, 27 → 31 theorems, 0 sorries, 0 axioms.
- `meta.json`: `leanFile` counts, a `mainTheorems` entry, and an `originalContributions` bullet synced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)