### PR TITLE
Enrich Odd Gaussian Moments Vanish (area-of-circle-oq-07-oq-05-oq-01-oq-01): complete annotation + even-complement link

### DIFF
--- a/src/data/proofs/area-of-circle-oq-07-oq-05-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/area-of-circle-oq-07-oq-05-oq-01-oq-01/annotations.json
@@ -84,7 +84,7 @@
       "odd function",
       "first moment"
     ],
-    "prerequisites": []
+    "prerequisites": ["odd functions", "vanishing of a symmetric integral over ℝ"]
   },
   {
     "id": "ann-full-sequence",

--- a/src/data/proofs/area-of-circle-oq-07-oq-05-oq-01-oq-01/meta.json
+++ b/src/data/proofs/area-of-circle-oq-07-oq-05-oq-01-oq-01/meta.json
@@ -142,6 +142,11 @@
       "targetId": "area-of-circle-oq-07-oq-05-oq-01-oq-02",
       "relationship": "related",
       "description": "Sibling (same parent). Lifts the even moments to an arbitrary Gaussian scale, ∫ x^{2n} e^{-a x²} = (2n-1)‼·√(π/a)/(2a)ⁿ, by the dilation x ↦ √a·x. It generalizes the even branch of this entry's full moment sequence in the scale parameter a; the odd moments proved here vanish at every scale by the same symmetry, so the two together give the complete scaled moment table."
+    },
+    {
+      "targetId": "area-of-circle-oq-07-oq-03-oq-03",
+      "relationship": "related",
+      "description": "The even complement. That entry proves the even moments ∫_ℝ x^{2n} e^{-x²} = Γ(n+1/2) = (2n-1)‼·√π/2ⁿ (the half-integer Gamma ladder); this entry proves the odd moments ∫_ℝ x^{2n+1} e^{-x²} = 0. Together they give the complete moment sequence of the Gaussian weight e^{-x²} — and answer that entry's open question of packaging odd-moment vanishing with the even ladder into one statement about all moments."
     }
   ],
   "references": [


### PR DESCRIPTION
Enrichment pass for `area-of-circle-oq-07-oq-05-oq-01-oq-01` (quality 96, pass 0).

Two genuine, targeted gaps:

**1. Incomplete annotation.** `ann-first-moment` carried an empty `prerequisites: []`. Filled it (odd functions; vanishing of a symmetric integral over ℝ) so all 5 annotations now have the full field set (`mathContext` + `significance` + `relatedConcepts` + `prerequisites`).

**2. Missing complement crossReference (3 → 4).** Added `area-of-circle-oq-07-oq-03-oq-03` (the even-moment ladder). That entry proves the **even** moments `∫ x^{2n} e^{-x²} = Γ(n+1/2) = (2n-1)‼·√π/2ⁿ`; this entry proves the **odd** moments `∫ x^{2n+1} e^{-x²} = 0`. Together they are the complete moment sequence of the Gaussian weight `e^{-x²}`, and this link directly answers that entry's standing open question about packaging odd-moment vanishing with the even ladder into one statement.

**Guardrails:** `meta.json` 15.7 KB (≪ 60 KB); crossReferences 4 (≤ 20); annotations 5; pure-data edits, valid JSON.

Note: `pnpm build`'s `tsc` step can't run in this fresh worktree (`better-sqlite3` native build fails under node 26, unrelated); validated as well-formed JSON.