### PR TITLE
Enrich Scaled Even Moment (area-of-circle-oq-07-oq-05-oq-01-oq-02): reciprocal crossReference

### DIFF
--- a/src/data/proofs/area-of-circle-oq-07-oq-05-oq-01-oq-02/meta.json
+++ b/src/data/proofs/area-of-circle-oq-07-oq-05-oq-01-oq-02/meta.json
@@ -149,6 +149,11 @@
       "targetId": "area-of-circle-oq-07-oq-02-oq-02",
       "relationship": "related",
       "description": "Sibling half-line moments. Its second moment ∫_{(0,∞)} x² e^{-b x²} = √(π/b)/(4b) is exactly half of this entry's whole-line value √(π/a)/(2a) (scaled_gaussian_second_moment), the even-symmetry doubling made explicit."
+    },
+    {
+      "targetId": "area-of-circle-oq-07-oq-05-oq-01-oq-01",
+      "relationship": "related",
+      "description": "Sibling (same parent), the odd/parity complement. It proves the odd moments ∫_ℝ x^{2n+1} e^{-x²} = 0 and packages the full parity-indexed moment sequence at unit scale. This entry lifts the even moments to arbitrary scale a > 0; the odd moments vanish at every scale by the same symmetry, so scaling this entry's even formula and folding in that entry's odd vanishing gives the complete scaled moment table ∫_ℝ x^k e^{-a x²}."
     }
   ],
   "references": [


### PR DESCRIPTION
Enrichment pass for `area-of-circle-oq-07-oq-05-oq-01-oq-02` (quality 96, pass 0).

Already at target (4 keyInsights, 4 sections, 5 complete annotations, complete conclusion). Sparse field: `crossReferences` (2), with a **missing reciprocal link**.

**What changed (crossRefs 2 → 3):** added `area-of-circle-oq-07-oq-05-oq-01-oq-01` (the odd-moment / full-sequence sibling), which already links *to* this entry but had no reciprocal link back. That entry proves `∫ x^{2n+1} e^{-x²} = 0` and packages the parity-indexed moment sequence at unit scale; this entry lifts the **even** moments to arbitrary scale `a > 0`. Since odd moments vanish at every scale by the same symmetry, the two together give the complete scaled moment table `∫_ℝ x^k e^{-a x²}`. The sibling graph is now reciprocal.

**Guardrails:** `meta.json` 15 KB (≪ 60 KB); crossReferences 3 (≤ 20); pure-data edit, valid JSON.

Note: `pnpm build`'s `tsc` step can't run in this fresh worktree (`better-sqlite3` native build fails under node 26, unrelated); validated as well-formed JSON.