### PR TITLE
Enrich Gaussian Integral =√π (area-of-circle-oq-07): 3->5 sections

### DIFF
--- a/src/data/proofs/area-of-circle-oq-07/meta.json
+++ b/src/data/proofs/area-of-circle-oq-07/meta.json
@@ -34,12 +34,28 @@
   },
   "sections": [
     {
-      "id": "overview",
-      "title": "Overview: the Gaussian integral and the circle-area link",
+      "id": "question",
+      "title": "The Open Question: ∫ e^{-x²} = √π",
       "startLine": 1,
+      "endLine": 11,
+      "summary": "Header docstring stating the open question (area-of-circle-oq-07): the total integral of the Gaussian bell curve e^{-x²} over the whole real line equals √π — the normalization constant behind the standard normal distribution.",
+      "mathContext": "$\\int_{-\\infty}^{\\infty} e^{-x^2}\\,dx = \\sqrt{\\pi}$."
+    },
+    {
+      "id": "answer",
+      "title": "Answer: the b = 1 specialization of integral_gaussian",
+      "startLine": 13,
+      "endLine": 19,
+      "summary": "The answer is YES: it is the b = 1 case of Mathlib's parametrized integral_gaussian b = √(π/b). Setting b = 1 turns exp(-1·x²) into exp(-x²) via neg_one_mul and √(π/1) into √π via div_one.",
+      "mathContext": "$\\int e^{-b x^2} = \\sqrt{\\pi/b}$; at $b=1$, $\\sqrt{\\pi/1}=\\sqrt{\\pi}$."
+    },
+    {
+      "id": "polar-link",
+      "title": "The circle-area link and the squared identity",
+      "startLine": 21,
       "endLine": 29,
-      "summary": "Header docstring stating the open question ∫_{-∞}^{∞} e^{-x²} dx = √π and its answer: the b = 1 specialization of Mathlib's integral_gaussian b = √(π/b). It also recalls the classical evaluation — square the integral and pass to polar coordinates, where the circle-area Jacobian of the parent entry area-of-circle appears — which the squared corollary records algebraically.",
-      "mathContext": "$\\int_{-\\infty}^{\\infty} e^{-x^2}\\,dx = \\sqrt{\\pi}$, the $b=1$ case of $\\int e^{-bx^2} = \\sqrt{\\pi/b}$."
+      "summary": "Recalls the classical evaluation — square the integral and pass to polar coordinates, where the circle-area Jacobian of the parent entry area-of-circle appears. The corollary gaussian_integral_sq records that squared identity (∫ e^{-x²})² = π algebraically. Closes noting no new axioms: a routine specialization of an existing Mathlib result.",
+      "mathContext": "$\\left(\\int e^{-x^2}\\right)^2 = \\iint e^{-(x^2+y^2)}\\,dx\\,dy = \\pi$ via polar coordinates."
     },
     {
       "id": "main",


### PR DESCRIPTION
Enrichment pass for `area-of-circle-oq-07`.

**Change:** the header docstring was covered by a single coarse `overview` section (lines 1–29). Split it along the docstring's genuine conceptual movements into three sections, keeping the two theorem sections — a real 3→5 split (matches merged precedent `abel-ruffini … 3→5 sections`):

1. **question** (1–11) — the open question ∫ e^{-x²} = √π
2. **answer** (13–19) — the b=1 specialization of `integral_gaussian`
3. **polar-link** (21–29) — the circle-area/polar-coordinate connection + squared-identity corollary
4. **main** (31–35) / 5. **squared** (37–41) — unchanged theorem sections

Added per-section `mathContext`. No content deleted; line/theorem/axiom counts unchanged. Accuracy pre-verified against the Lean source.