### PR TITLE
Research: erdos-165-oq-05 — the Erdős R(3,k) conjecture reduces to the upper bound

### DIFF
--- a/proofs/Proofs/Erdos165Problem.lean
+++ b/proofs/Proofs/Erdos165Problem.lean
@@ -607,4 +607,49 @@ theorem asymptotic_constant_unique
       (fun ε hε => by obtain ⟨k₀, hk₀⟩ := h₁ ε hε; exact ⟨k₀, fun k hk => (hk₀ k hk).2⟩)
   linarith
 
+/- ## Part X: The conjecture reduces to the upper bound
+
+The two-sided obstruction of Parts VI–IX pins any exact constant to `[1/2, 1]`.  This final
+section records the sharper structural payoff hiding in that interval: the *lower* endpoint
+`1/2` is not merely a fence but an already-proved theorem (`hhkp_bound`), so the Erdős main
+conjecture `R(3,k) ~ (1/2)·k²/log k` is logically equivalent to a *one-sided* statement —
+improving Shearer's upper constant from `1` down to `1/2`.  We also complete the
+lower-constant/upper-constant symmetry left open in Part IX: `R3_lower_constant_of_le_half`
+is the exact dual of `R3_upper_constant_of_one_le`.  Both are axiom-frugal (only the two
+sharp Ramsey bounds). -/
+
+/-- **Every constant `a ≤ 1/2` is a valid first-order lower constant for `R(3,k)`** (dual of
+    `R3_upper_constant_of_one_le`).  Whereas Shearer (`1`) makes every *larger* constant a valid
+    upper bound, HHKP (`1/2`) makes every *smaller* constant a valid lower bound, via
+    `lower_bound_mono`.  This is the general statement behind the specific `hhkp_subsumes_*`
+    family (`1/162, 1/4, 1/3` are its instances), completing the Part IX symmetry: valid lower
+    constants contain `(−∞, 1/2]`, valid upper constants contain `[1, ∞)`. -/
+theorem R3_lower_constant_of_le_half (a : ℝ) (ha : a ≤ 1/2) :
+    ∀ ε > 0, ∃ k₀ : ℕ, ∀ k : ℕ, k ≥ k₀ →
+        (R3 k : ℝ) ≥ (a - ε) * k^2 / log k :=
+  lower_bound_mono ha hhkp_bound
+
+/-- **The Erdős conjecture reduces to the upper bound.**  Because the lower half of
+    `mainConjecture` — `R(3,k) ≥ (1/2 − ε)·k²/log k` — is already the theorem `hhkp_bound`, the
+    full conjecture `R(3,k) ~ (1/2)·k²/log k` is *equivalent* to its upper half alone:
+
+      `mainConjecture ↔ ∀ ε > 0, eventually R(3,k) ≤ (1/2 + ε)·k²/log k`.
+
+    In other words, settling Erdős #165 is exactly the problem of sharpening Shearer's upper
+    constant from `1` to `1/2`; the matching lower bound is done.  Forward is projection to the
+    upper half; backward pairs the hypothesized upper half with `hhkp_bound`. -/
+theorem mainConjecture_iff_upper_half :
+    mainConjecture ↔
+      (∀ ε > 0, ∃ k₀ : ℕ, ∀ k : ℕ, k ≥ k₀ →
+          (R3 k : ℝ) ≤ (1/2 + ε) * k^2 / log k) := by
+  constructor
+  · intro h ε hε
+    obtain ⟨k₀, hk₀⟩ := h ε hε
+    exact ⟨k₀, fun k hk => (hk₀ k hk).2⟩
+  · intro hup ε hε
+    obtain ⟨k₁, hk₁⟩ := hhkp_bound ε hε
+    obtain ⟨k₂, hk₂⟩ := hup ε hε
+    exact ⟨max k₁ k₂, fun k hk =>
+      ⟨hk₁ k (le_of_max_le_left hk), hk₂ k (le_of_max_le_right hk)⟩⟩
+
 end Erdos165

--- a/src/data/proofs/erdos-165/meta.json
+++ b/src/data/proofs/erdos-165/meta.json
@@ -56,10 +56,10 @@
       "Repaired latent Mathlib-drift breakage in erdos_165 (linarith could not widen 5/4 to 2 without k²/log k ≥ 0)"
     ],
     "axiomCount": 10,
-    "lineCount": 448,
+    "lineCount": 655,
     "assumptions": "10 axioms (unchanged): ramseyNumber, ramseyNumber_symm, ramseyNumber_recurrence, R3_small_values, aks_upper_bound, shearer_upper_bound, kim_lower_bound, bk_pgm_bound, cjms_bound, hhkp_bound. 0 sorries. New theorems add no axioms; asymptotic_constant_le is fully axiom-free; pgm_conjecture_refuted depends only on the existing hhkp_bound.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 14,
+    "theoremCount": 26,
     "definitionCount": 4,
     "additionalFiles": [
       "Proofs/Stubs/Erdos165Aristotle.lean"
@@ -166,9 +166,9 @@
       "Real"
     ],
     "namespace": "Erdos165",
-    "lineCount": 610,
+    "lineCount": 655,
     "axiomCount": 10,
-    "theoremCount": 24,
+    "theoremCount": 26,
     "definitionCount": 4,
     "path": "Proofs/Erdos165Problem.lean",
     "sorries": 0,


### PR DESCRIPTION
## Summary

Extends `Erdos165Problem.lean` (Erdős #165: `R(3,k) = Θ(k²/log k)`, conjectured constant `c = 1/2`). The file's Parts VI–IX bracket any exact constant to `[1/2, 1]` and prove a lower/upper monotone-weakening machinery. This adds **Part X** with two payoffs.

## New theorems

- **`R3_lower_constant_of_le_half`** — every constant `a ≤ 1/2` is a valid first-order lower constant for `R(3,k)` (via `lower_bound_mono` + `hhkp_bound`). This is the exact **dual** of the existing `R3_upper_constant_of_one_le` (every `b ≥ 1` is a valid upper constant), and the general statement behind the specific `hhkp_subsumes_*` family — completing the Part IX symmetry: valid lower constants ⊇ `(−∞, 1/2]`, valid upper constants ⊇ `[1, ∞)`.
- **`mainConjecture_iff_upper_half`** — since the *lower* half of `mainConjecture` (`R(3,k) ≥ (1/2−ε)·k²/log k`) is **already the theorem `hhkp_bound`**, the full Erdős conjecture `R(3,k) ~ (1/2)·k²/log k` is *equivalent* to its upper half alone:

  `mainConjecture ↔ ∀ ε > 0, eventually R(3,k) ≤ (1/2 + ε)·k²/log k`.

  In other words: settling Erdős #165 is *exactly* the problem of sharpening Shearer's upper constant from `1` down to `1/2`; the matching lower bound is done.

Base-file extension (`erdos-165-oq-05` has no dedicated Lean file). 24 → 26 theorems.

## Verification

Direct `lean` elaboration against the repo's prebuilt Mathlib oleans (Docker build was blocked by an unrelated, transient host-load `.ir`/codegen crash on the build machine; the file type-checks cleanly):

- Elaboration exit 0, no errors/sorries.
- `#print axioms` on both new theorems: `[propext, Classical.choice, Erdos165.hhkp_bound, Quot.sound]` — **no new axioms** (`hhkp_bound` is the file's pre-existing intended Ramsey axiom), no `sorry`, no `native_decide`.
- `meta.json` counts refreshed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)