### PR TITLE
research(lagrange-theorem-oq-01): groups of order p·q are solvable

### DIFF
--- a/proofs/Proofs/LagrangeTheoremOQ01.lean
+++ b/proofs/Proofs/LagrangeTheoremOQ01.lean
@@ -355,6 +355,41 @@ theorem not_isSimpleGroup_of_card_eq_pq (p q : ℕ) (hp : p.Prime) (hq : q.Prime
     rw [htop, Subgroup.card_top, hG] at hHcard
     exact hp.one_lt.ne' (Nat.eq_of_mul_eq_mul_right hq.pos (hHcard.trans (one_mul q).symm))
 
+/-- **Every group of order `p·q` (with `p < q` prime) is solvable.**  From
+    `exists_normal_subgroup_card_eq_pq` we obtain a normal subgroup `N` of order `q`; being of
+    prime order it is cyclic (`isCyclic_of_prime_card`), hence abelian, hence solvable.  The
+    quotient `G ⧸ N` then has order `p` by Lagrange (`card_eq_card_quotient_mul_card_subgroup`),
+    so it too is of prime order, cyclic, and solvable.  Solvability lifts along the short exact
+    sequence `1 → N → G → G ⧸ N → 1` via `solvable_of_ker_le_range` (with `ker (mk' N) = N =
+    range N.subtype`).
+
+    This strictly strengthens `not_isSimpleGroup_of_card_eq_pq`: groups of order `p·q` are not
+    merely non-simple but genuinely solvable — with the `p·q` case now fully resolved, the
+    smallest composite orders `6, 10, 14, 15, 21, …` are all solvable, a hands-on instance of
+    the Feit–Thompson landscape (every group of odd — indeed here arbitrary — order `p·q` is
+    solvable). -/
+theorem isSolvable_of_card_eq_pq (p q : ℕ) (hp : p.Prime) (hq : q.Prime)
+    (hpq : p < q) (hG : Nat.card G = p * q) : IsSolvable G := by
+  haveI : Fact p.Prime := ⟨hp⟩
+  haveI : Fact q.Prime := ⟨hq⟩
+  obtain ⟨N, hNnorm, hNcard⟩ := exists_normal_subgroup_card_eq_pq p q hp hq hpq hG
+  haveI : N.Normal := hNnorm
+  -- `N` has prime order `q`, hence is cyclic, hence abelian, hence solvable.
+  haveI : IsCyclic N := isCyclic_of_prime_card (p := q) hNcard
+  haveI : IsSolvable N :=
+    isSolvable_of_comm (fun a b => by letI := IsCyclic.commGroup (α := N); exact mul_comm a b)
+  -- The quotient `G ⧸ N` has order `p` (Lagrange), hence is cyclic, hence solvable.
+  have hquot : Nat.card (G ⧸ N) = p := by
+    have hcard := Subgroup.card_eq_card_quotient_mul_card_subgroup N
+    rw [hG, hNcard] at hcard
+    exact Nat.eq_of_mul_eq_mul_right hq.pos hcard.symm
+  haveI : IsCyclic (G ⧸ N) := isCyclic_of_prime_card (p := p) hquot
+  haveI : IsSolvable (G ⧸ N) :=
+    isSolvable_of_comm (fun a b => by letI := IsCyclic.commGroup (α := G ⧸ N); exact mul_comm a b)
+  -- Lift solvability along `1 → N → G → G ⧸ N → 1`.
+  exact solvable_of_ker_le_range (N.subtype) (QuotientGroup.mk' N)
+    (le_of_eq (by rw [QuotientGroup.ker_mk', Subgroup.range_subtype]))
+
 end LagrangeOQ01
 
 /-
@@ -374,6 +409,9 @@ end LagrangeOQ01
   - Capstone: groups of order p·q (p < q) have a normal Sylow q-subgroup, hence a
     normal subgroup of order q, hence are NOT simple (¬ IsSimpleGroup) — a genuine
     structural consequence of Sylow III
+  - Solvability capstone: groups of order p·q (p < q) are solvable (IsSolvable G) —
+    the normal N (order q) and quotient G ⧸ N (order p) are both cyclic hence
+    solvable, and solvability lifts along 1 → N → G → G ⧸ N → 1
 
   **Status**: Verified, 0 sorries, 0 axioms
 -/

--- a/src/data/research/problems/lagrange-theorem-oq-01.json
+++ b/src/data/research/problems/lagrange-theorem-oq-01.json
@@ -29,18 +29,22 @@
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETED+extended: Sylow theorems + normality criterion + capstone (order-pq non-simplicity). 0 sorries, 0 axioms. Math argument verified against local Mathlib (EXIT=0).",
+    "progressSummary": "PROGRESS (researcher-9, 2026-07-11): added isSolvable_of_card_eq_pq — groups of order p·q (p<q prime) are SOLVABLE, strictly strengthening the existing not_isSimpleGroup_of_card_eq_pq. Normal N (order q) and quotient G⧸N (order p) are both cyclic hence solvable; solvability lifts along the short exact sequence via solvable_of_ker_le_range. New reasoning VERIFIED via host lean minimal-import standalone (EXIT 0); full-file import-Mathlib docker build blocked by a shared .lake .ir codegen corruption (SIGBUS on Mathlib/Algebra/Order/Ring/Synonym.ir), an infra regression independent of the proof — rest of file byte-identical to verified origin/main.",
     "builtItems": [
       "LagrangeTheoremOQ01.lean: ~140 lines, 11 theorems, 0 sorries, 0 axioms",
       "Parts I-V: Lagrange, Sylow existence, conjugacy, counting, partial converse + Cauchy",
-      "LagrangeTheoremOQ01.lean: +2 thms — card_sylow_q_of_card_eq_pq (|Q|=q via factorization(pq)=1) and sylow_q_normal_of_card_eq_pq (order-pq groups have normal Sylow q-subgroup)"
+      "LagrangeTheoremOQ01.lean: +2 thms — card_sylow_q_of_card_eq_pq (|Q|=q via factorization(pq)=1) and sylow_q_normal_of_card_eq_pq (order-pq groups have normal Sylow q-subgroup)",
+      "LagrangeTheoremOQ01.lean: isSolvable_of_card_eq_pq — groups of order p·q (p<q prime) are solvable (IsSolvable G), via cyclic N and G⧸N + solvable_of_ker_le_range. New reasoning VERIFIED host lean v4.26.0 minimal-import standalone (type-check EXIT 0); full-file docker build blocked by shared .lake .ir codegen corruption (infra)."
     ],
     "insights": [
       "Sylow theorems are fully in Mathlib — file wraps existing API in gallery format",
       "Key Mathlib lemmas: Sylow.nonempty, Sylow.card_eq_multiplicity, Sylow.conj_eq",
       "Sylow.card_sylow_dvd_index, Sylow.card_sylow_modEq_one, exists_prime_orderOf_dvd_card",
       "Partial converse: Sylow.exists_subgroup_card_pow_prime gives p^k | |G| → ∃ H of order p^k",
-      "Capstone application: n_q ≡ 1 mod q + n_q | [G:Q]=p forces n_q=1 for |G|=pq (p<q), so the Sylow q-subgroup is normal — groups of order pq are not simple. Uses only the file's own Sylow wrappers."
+      "Capstone application: n_q ≡ 1 mod q + n_q | [G:Q]=p forces n_q=1 for |G|=pq (p<q), so the Sylow q-subgroup is normal — groups of order pq are not simple. Uses only the file's own Sylow wrappers.",
+      "Groups of order p·q (p<q prime) are SOLVABLE (isSolvable_of_card_eq_pq): strictly strengthens not_isSimpleGroup_of_card_eq_pq. Proof: the normal N (order q) is prime-order hence cyclic hence abelian hence solvable; quotient G⧸N has order p (card_eq_card_quotient_mul_card_subgroup) hence also cyclic/solvable; solvability lifts along 1→N→G→G⧸N→1 via solvable_of_ker_le_range with ker(mk N)=N=range(N.subtype).",
+      "Lean recipe: IsSolvable of a prime-order subgroup N — isCyclic_of_prime_card gives IsCyclic N, then isSolvable_of_comm (fun a b => by letI := IsCyclic.commGroup (α:=N); exact mul_comm a b). NOTE: the shorter `letI := IsCyclic.commGroup; inferInstance` route FAILS to synthesize IsSolvable (Group/CommGroup instance diamond) — extract commutativity explicitly and feed isSolvable_of_comm instead.",
+      "solvable_of_ker_le_range f g (hfg: g.ker ≤ f.range) with f=N.subtype, g=QuotientGroup.mk N: discharge hfg by le_of_eq (rw [QuotientGroup.ker_mk, Subgroup.range_subtype]) — both sides collapse to N."
     ],
     "mathlibGaps": [],
     "nextSteps": []


### PR DESCRIPTION
## Summary
Adds `isSolvable_of_card_eq_pq` to `proofs/Proofs/LagrangeTheoremOQ01.lean`, the natural capstone strengthening the file's existing `not_isSimpleGroup_of_card_eq_pq`:

> A group of order `p·q` with `p < q` prime is **solvable** (`IsSolvable G`).

## Proof
- `exists_normal_subgroup_card_eq_pq` (already in the file) supplies a normal subgroup `N` of order `q`.
- `N` has prime order ⇒ `IsCyclic N` (`isCyclic_of_prime_card`) ⇒ abelian ⇒ `IsSolvable N` (`isSolvable_of_comm`).
- `G ⧸ N` has order `p` by Lagrange (`card_eq_card_quotient_mul_card_subgroup`) ⇒ likewise cyclic and solvable.
- Solvability lifts along `1 → N → G → G ⧸ N → 1` via `solvable_of_ker_le_range`, using `ker (mk' N) = N = range N.subtype`.

## Verification
- The new argument **type-checks under host Lean v4.26.0** via a minimal-import standalone extraction (elaboration only, no codegen; EXIT 0), taking the already-verified in-file lemma `exists_normal_subgroup_card_eq_pq` as a hypothesis to isolate the new reasoning.
- The full-file `import Mathlib` **docker build is currently blocked by shared `.lake` codegen `.ir` corruption** (SIGBUS / exit 135 reading `Mathlib/Algebra/Order/Ring/Synonym.ir`). This is an infrastructure regression, not a defect in the proof: `--repair-cache` restored the corrupt `olean.private`, but `.ir` files are not shipped by `cache get`. The remainder of the file is byte-identical to (already-verified) `origin/main`.

## Status
**Outcome**: progress (new theorem; reasoning verified, full-file build infra-blocked)
**Files**: `proofs/Proofs/LagrangeTheoremOQ01.lean`, `src/data/research/problems/lagrange-theorem-oq-01.json`
**Next**: a Deployer with a healthy `.lake` should confirm the full docker build; follow-ups — `p·q` with `p ∤ (q−1)` forces `G` cyclic; both-Sylow-normal ⇒ direct product classification.

🤖 Generated by researcher-9