### PR TITLE
Enrich Catenoid Surface Area (arsinh-log-formula-oq-01-oq-01-oq-01-oq-01): 4->5 sections

### DIFF
--- a/src/data/proofs/arsinh-log-formula-oq-01-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/arsinh-log-formula-oq-01-oq-01-oq-01-oq-01/meta.json
@@ -109,19 +109,27 @@
       "mathContext": "$\\int_a^b \\sqrt{1+m^2}\\,dt = (b-a)\\sqrt{1+m^2}$."
     },
     {
+      "id": "pythagorean",
+      "title": "The Pythagorean Integrand Simplification √(1+sinh²)=cosh",
+      "startLine": 57,
+      "endLine": 65,
+      "summary": "sqrt_one_add_sinh_sq: the identity √(1 + sinh²x) = cosh x, from cosh²x = 1 + sinh²x and cosh x > 0. This single lemma is the linchpin reused twice below — it collapses both the arc-length integrand and the catenoid surface-of-revolution integrand.",
+      "mathContext": "$\\sqrt{1+\\sinh^2 x} = \\cosh x$ since $\\cosh^2 x = 1 + \\sinh^2 x$ and $\\cosh x>0$."
+    },
+    {
       "id": "antiderivative",
-      "title": "The New Antiderivative of cosh²",
-      "startLine": 58,
-      "endLine": 92,
-      "summary": "sqrt_one_add_sinh_sq (√(1 + sinh²x) = cosh x), hasDerivAt_coshSqAntideriv (the from-scratch derivative d/dx [½(x + sinh x·cosh x)] = cosh²x via the product rule and cosh²x = 1 + sinh²x), and continuous_cosh_sq (the integrand is continuous, hence interval-integrable for the FTC).",
-      "mathContext": "$\\dfrac{d}{dx}\\left[\\tfrac12\\left(x + \\sinh x\\cosh x\\right)\\right] = \\cosh^2 x$."
+      "title": "The New Antiderivative of cosh² and its FTC Evaluation",
+      "startLine": 66,
+      "endLine": 100,
+      "summary": "hasDerivAt_coshSqAntideriv (the from-scratch derivative d/dx [½(x + sinh x·cosh x)] = cosh²x via the product rule and cosh²x = 1 + sinh²x — Mathlib has the sinh/cosh derivatives but no cosh² antiderivative), continuous_cosh_sq (the integrand is continuous, hence interval-integrable), and integral_cosh_sq_zero_to (the FTC evaluation ∫_0^b cosh²x dx = ½(b + sinh b·cosh b)).",
+      "mathContext": "$\\dfrac{d}{dx}\\left[\\tfrac12\\left(x + \\sinh x\\cosh x\\right)\\right] = \\cosh^2 x$; hence $\\int_0^b \\cosh^2 x\\,dx = \\tfrac12(b + \\sinh b\\cosh b)$."
     },
     {
       "id": "catenoid",
       "title": "The Catenoid Surface of Revolution",
-      "startLine": 94,
+      "startLine": 101,
       "endLine": 126,
-      "summary": "integral_cosh_sq_zero_to (∫_0^b cosh²x dx = ½(b + sinh b·cosh b)), catenoid_surface_area (the surface area of the catenoid over [0, b] is 2π ∫_0^b cosh x·√(1 + sinh²x) dx = π(b + sinh b·cosh b)), and catenoid_surface_area_zero_to_one (the concrete value π(1 + sinh 1·cosh 1) over [0, 1]).",
+      "summary": "catenoid_surface_area (revolving the catenary y = cosh x over [0, b] about the x-axis gives the catenoid, whose area 2π ∫_0^b cosh x·√(1 + sinh²x) dx collapses via √(1 + sinh²x) = cosh x to 2π ∫_0^b cosh²x dx = π(b + sinh b·cosh b)) and catenoid_surface_area_zero_to_one (the concrete value π(1 + sinh 1·cosh 1) over [0, 1]).",
       "mathContext": "$2\\pi\\int_0^b \\cosh x\\,\\sqrt{1+\\sinh^2 x}\\,dx = 2\\pi\\int_0^b \\cosh^2 x\\,dx = \\pi(b + \\sinh b\\cosh b)$."
     }
   ],


### PR DESCRIPTION
Enrichment pass for `arsinh-log-formula-oq-01-oq-01-oq-01-oq-01`.

**Change:** the `antiderivative` section (lines 58–92) bundled three conceptually distinct pieces. Split along a genuine boundary into 5 sections (matches merged precedent for finer section coverage):

1. **docstring** (1–41) — unchanged
2. **affine** (43–56) — the straight-line boundary case
3. **pythagorean** (57–65) — **new**: the linchpin identity `√(1+sinh²x)=cosh x`, reused twice below (arc-length + surface-of-revolution integrands)
4. **antiderivative** (66–100) — the from-scratch `cosh²` antiderivative, continuity, and the FTC evaluation ∫cosh²=½(b+sinh b·cosh b)
5. **catenoid** (101–126) — the geometric payoff: surface area + concrete [0,1] value

Added/kept per-section `mathContext`. No content deleted; line/theorem/axiom counts unchanged (7 theorems, 0 axioms, 0 sorries, verified against the Lean source).