### PR TITLE
Research: cantor-diagonalization-oq-06-oq-01 — the [1/9, 2/9] localization is sharp (both endpoints attained)

### DIFF
--- a/proofs/Proofs/CantorDiagonalizationOQ06OQ01.lean
+++ b/proofs/Proofs/CantorDiagonalizationOQ06OQ01.lean
@@ -356,4 +356,60 @@ theorem diagonalReal_mem_Icc (f : ℕ → ℝ) :
     diagonalReal f ∈ Set.Icc (1 / 9 : ℝ) (2 / 9) :=
   ⟨diagonalReal_ge_one_ninth f, diagonalReal_le_two_ninths f⟩
 
+/-! ## Both endpoints of `[1/9, 2/9]` are attained
+
+`diagonalReal_mem_Icc` localizes the diagonal to `[1/9, 2/9]`; its docstring asserts
+that *both endpoints are attained* — the minorant `1/9` by listings whose `n`-th digit
+is never `1` (so `db f n ≡ 1`), the majorant `2/9` by listings whose `n`-th digit is
+always `1` (so `db f n ≡ 2`).  Here we formalize exactly that claim: the two conditional
+evaluations, and explicit witnesses realizing each endpoint (`f ≡ 0` reaches `1/9`;
+`f n = 10^{-(n+1)}`, whose `n`-th digit is `1`, reaches `2/9`).  So the localization
+`[1/9, 2/9]` is *sharp* — neither bound can be tightened.  Still routed entirely through
+the bespoke `diagonalReal`. -/
+
+/-- **The majorant `2/9` is realized by all-`1`-digit listings.**  If every `f n` has
+`n`-th digit equal to `1`, then each disagreeing digit is `db f n = 2`, and the diagonal
+is exactly the geometric majorant `∑ 2/10^(n+1) = 2/9`. -/
+theorem diagonalReal_eq_two_ninths_of {f : ℕ → ℝ} (h : ∀ n, digit (f n) n = 1) :
+    diagonalReal f = 2 / 9 := by
+  have hdb : ∀ n, (db f n : ℝ) = 2 := fun n => by
+    unfold db; rw [if_pos (h n)]; norm_num
+  rw [diagonalReal, ← tsum_geo_shift]
+  apply tsum_congr; intro n
+  rw [hdb n, div_pow, one_pow, mul_one_div]
+
+/-- **The minorant `1/9` is realized by never-`1`-digit listings.**  If no `f n` has
+`n`-th digit equal to `1`, then each disagreeing digit is `db f n = 1`, and the diagonal
+is exactly the geometric minorant `∑ 1/10^(n+1) = 1/9`. -/
+theorem diagonalReal_eq_one_ninth_of {f : ℕ → ℝ} (h : ∀ n, digit (f n) n ≠ 1) :
+    diagonalReal f = 1 / 9 := by
+  have hdb : ∀ n, (db f n : ℝ) = 1 := fun n => by
+    unfold db; rw [if_neg (h n)]; norm_num
+  rw [diagonalReal, ← tsum_geo_shift_one]
+  apply tsum_congr; intro n
+  rw [hdb n, div_pow, one_pow]
+
+/-- **The minorant `1/9` is attained.**  The constant listing `f ≡ 0` has every `n`-th
+digit `0 ≠ 1`, so its diagonal is exactly `1/9` — the lower endpoint of the localization
+interval is achieved. -/
+theorem exists_diagonalReal_eq_one_ninth : ∃ f : ℕ → ℝ, diagonalReal f = 1 / 9 := by
+  refine ⟨fun _ => 0, diagonalReal_eq_one_ninth_of (fun n => ?_)⟩
+  show digit (0 : ℝ) n ≠ 1
+  unfold digit
+  rw [zero_mul, Int.floor_zero]
+  decide
+
+/-- **The majorant `2/9` is attained.**  The listing `f n = 10^{-(n+1)}` has `n`-th digit
+`⌊10^{-(n+1)}·10^(n+1)⌋ % 10 = ⌊1⌋ % 10 = 1`, so its diagonal is exactly `2/9` — the upper
+endpoint of the localization interval is achieved.  Together with
+`exists_diagonalReal_eq_one_ninth` this shows `[1/9, 2/9]` is the *sharp* range of
+`diagonalReal`, matching the `diagonalReal_mem_Icc` docstring. -/
+theorem exists_diagonalReal_eq_two_ninths : ∃ f : ℕ → ℝ, diagonalReal f = 2 / 9 := by
+  refine ⟨fun n => 1 / 10 ^ (n + 1), diagonalReal_eq_two_ninths_of (fun n => ?_)⟩
+  have h10 : (10 : ℝ) ^ (n + 1) ≠ 0 := by positivity
+  show digit (1 / 10 ^ (n + 1) : ℝ) n = 1
+  unfold digit
+  rw [one_div, inv_mul_cancel₀ h10, Int.floor_one]
+  decide
+
 end CantorDiagonalizationOQ06OQ01

--- a/src/data/proofs/cantor-diagonalization-oq-06-oq-01/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-06-oq-01/meta.json
@@ -59,10 +59,10 @@
       "diagonalReal_ge_one_ninth / diagonalReal_le_two_ninths / diagonalReal_mem_Icc: the SHARP two-sided localization diagonalReal f ∈ [1/9, 2/9]. The docstring claimed the diagonal is squeezed between ∑1/10^(n+1)=1/9 and ∑2/10^(n+1)=2/9, but only the upper end (≤2/9) had been formalized; the matching lower bound 1/9 ≤ diagonalReal f is proved here from the geometric minorant tsum_geo_shift_one = 1/9 (every digit db f n ≥ 1 via term_ge'), tightening diagonalReal_mem_Ioo (0,1) to the exact interval [1/9,2/9]. Axiom-free ([propext, Classical.choice, Quot.sound])."
     ],
     "dateAdded": "2026-07-11",
-    "lineCount": 359,
+    "lineCount": 415,
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries; #print axioms reports only [propext, Classical.choice, Quot.sound]. No use of Cardinal.not_countable_real.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 28,
+    "theoremCount": 32,
     "definitionCount": 4
   },
   "overview": {
@@ -164,9 +164,9 @@
     ],
     "opens": [],
     "namespace": "CantorDiagonalizationOQ06OQ01",
-    "lineCount": 359,
+    "lineCount": 415,
     "axiomCount": 0,
-    "theoremCount": 28,
+    "theoremCount": 32,
     "definitionCount": 4,
     "path": "Proofs/CantorDiagonalizationOQ06OQ01.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

Extends `CantorDiagonalizationOQ06OQ01.lean` (Cantor's *explicit* diagonal real `diagonalReal f`, built from digits in `{1,2}`, proving `Uncountable ℝ` constructively without `Cardinal.not_countable_real`). The existing `diagonalReal_mem_Icc` localizes the diagonal to `[1/9, 2/9]` and its docstring *asserts* both endpoints are attained — but that claim was stated, not formalized. This PR formalizes it.

## New theorems (axiom-free)

- **`diagonalReal_eq_two_ninths_of`** — if every `f n` has `n`-th digit `1` (so each disagreeing digit is `db f n = 2`), then `diagonalReal f = 2/9` exactly (the geometric majorant `∑ 2/10^(n+1)`).
- **`diagonalReal_eq_one_ninth_of`** — if no `f n` has `n`-th digit `1` (so `db f n = 1`), then `diagonalReal f = 1/9` exactly (the geometric minorant `∑ 1/10^(n+1)`).
- **`exists_diagonalReal_eq_one_ninth`** — the constant listing `f ≡ 0` (every digit `0 ≠ 1`) attains the lower endpoint `1/9`.
- **`exists_diagonalReal_eq_two_ninths`** — the listing `f n = 10^{-(n+1)}` (whose `n`-th digit is `⌊10^{-(n+1)}·10^(n+1)⌋ % 10 = ⌊1⌋ % 10 = 1`) attains the upper endpoint `2/9`.

Together these show `[1/9, 2/9]` is the **sharp** range of `diagonalReal` — neither bound of `diagonalReal_mem_Icc` can be tightened.

## Verification

- `./proofs/scripts/docker-build.sh Proofs.CantorDiagonalizationOQ06OQ01` → **succeeds**.
- `#print axioms`: `[propext, Classical.choice, Quot.sound]` — **axiom-free** (the `decide` steps are kernel `decide`, not `native_decide`, so no `Lean.ofReduceBool`). No `sorry`.
- Routed entirely through the bespoke `diagonalReal`; never appeals to `Cardinal.not_countable_real`.
- `meta.json` counts refreshed (28 → 32 theorems).

🤖 Generated with [Claude Code](https://claude.com/claude-code)