### PR TITLE
research(erdos-490-incomplete-01): universal product-count bound + distinctness-as-saturation

### DIFF
--- a/proofs/Proofs/Erdos490Problem.lean
+++ b/proofs/Proofs/Erdos490Problem.lean
@@ -72,6 +72,26 @@ theorem productSet_eq_image (A B : Finset ℕ) :
   · rintro ⟨a, ha, b, hb, rfl⟩; exact ⟨(a, b), ⟨ha, hb⟩, rfl⟩
   · rintro ⟨⟨a, b⟩, ⟨ha, hb⟩, rfl⟩; exact ⟨a, ha, b, hb, rfl⟩
 
+/-- **The universal product-count bound**: `|A·B| ≤ |A|·|B|`, with *no* distinctness
+hypothesis.  The product set is the image of the product map on `A ×ˢ B`, and an image
+never has more elements than its domain (`Finset.card_image_le`), so `|A·B| ≤ |A ×ˢ B| =
+|A|·|B|`.  This is the trivial upper bound that the entire problem is about *saturating*:
+`HasDistinctProducts A B` is exactly the equality case (see `hasDistinctProducts_iff_card_le`),
+and Szemerédi's theorem asks how large `|A|·|B|` can be while the bound stays tight. -/
+theorem productSet_card_le (A B : Finset ℕ) :
+    (productSet A B).card ≤ A.card * B.card := by
+  rw [productSet_eq_image, ← Finset.card_product A B]
+  exact Finset.card_image_le
+
+/-- **`HasDistinctProducts` is empty on the left**: `A·∅ = ∅` and `∅·B = ∅`, so the
+degenerate pairs carry no products.  (Recorded as `simp` lemmas so the product set
+collapses automatically.) -/
+@[simp] theorem productSet_empty_left (B : Finset ℕ) : productSet ∅ B = ∅ := by
+  simp [productSet]
+
+@[simp] theorem productSet_empty_right (A : Finset ℕ) : productSet A ∅ = ∅ := by
+  ext n; simp [productSet]
+
 /-- **`HasDistinctProducts` is injectivity of the product map.**  The cardinality
 condition `|A·B| = |A||B|` holds iff `(a, b) ↦ a·b` is injective on `A ×ˢ B`
 (via `Finset.card_image_iff`). -/
@@ -79,6 +99,19 @@ theorem hasDistinctProducts_iff_injOn (A B : Finset ℕ) :
     HasDistinctProducts A B ↔ Set.InjOn (fun p : ℕ × ℕ => p.1 * p.2) ↑(A ×ˢ B) := by
   rw [HasDistinctProducts, productSet_eq_image, ← Finset.card_product A B,
     Finset.card_image_iff]
+
+/-- **Distinct products = saturating the universal bound.**  Since `|A·B| ≤ |A|·|B|`
+always holds (`productSet_card_le`), the equality defining `HasDistinctProducts` is
+equivalent to the single reverse inequality `|A|·|B| ≤ |A·B|`.  So to certify a pair has
+distinct products one need only exhibit that its product set is *at least* as large as
+`|A|·|B|` — the matching upper bound is automatic.  This is the inequality form used
+throughout extremal arguments. -/
+theorem hasDistinctProducts_iff_card_le (A B : Finset ℕ) :
+    HasDistinctProducts A B ↔ A.card * B.card ≤ (productSet A B).card := by
+  rw [HasDistinctProducts]
+  constructor
+  · intro h; rw [h]
+  · intro h; exact le_antisymm (productSet_card_le A B) h
 
 /-- **The two distinctness notions agree.**  `ProductMapInjective` (the elementwise
 quantified form) is equivalent to `HasDistinctProducts` (the cardinality form). -/


### PR DESCRIPTION
## Erdős Problem #490 — Distinct Products of Two Sets

Four **axiom-free** foundational lemmas for the product-set API (50 → 54 declarations). The single deep axiom `szemeredi_theorem` (the `N²/log N` upper bound, Szemerédi 1976) is untouched.

- **`productSet_card_le`** — `|A·B| ≤ |A|·|B|` unconditionally. The product set is the image of `(a,b) ↦ a·b` on `A ×ˢ B`, and `Finset.card_image_le` gives the bound. This is the *trivial upper bound the whole problem is about saturating*.
- **`hasDistinctProducts_iff_card_le`** — `HasDistinctProducts A B ↔ |A|·|B| ≤ |A·B|`. Because the reverse inequality is automatic (`productSet_card_le`), distinctness is equivalent to the single lower bound `|A|·|B| ≤ |A·B|` — the inequality form convenient in extremal arguments.
- **`productSet_empty_left` / `productSet_empty_right`** — `∅·B = A·∅ = ∅` (`simp` lemmas), so degenerate pairs collapse automatically.

These sit beside the existing `productSet_eq_image` / `hasDistinctProducts_iff_injOn` API and make explicit the "≤ always, = iff distinct" structure motivating the extremal question.

### Verification
Whole-file **kernel-verified** (`lake env lean Proofs/Erdos490Problem.lean`, `LEAN_EXIT=0`) — the entire 1050-line file with the four additions type-checks. 1 axiom (`szemeredi_theorem`), 0 sorries, unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)