### PR TITLE
research(burnside-counting-oq-02): aperiodic prime-length necklace count + lower bound

### DIFF
--- a/proofs/Proofs/BurnsideCounting.lean
+++ b/proofs/Proofs/BurnsideCounting.lean
@@ -741,3 +741,25 @@ theorem pow_prime_sub_one_modEq_one {p : ℕ} (hp : p.Prime) {k : ℕ} (hk : ¬ 
   have hstep : k * k ^ (p - 1) ≡ k * 1 [MOD p] := by
     rw [mul_one, hrw]; exact pow_prime_modEq_self hp k
   exact Nat.ModEq.cancel_left_of_coprime hcop hstep
+
+/-- **At least the constant necklaces.**  For a prime `p`, the number of `k`-colored
+necklaces of length `p` is at least `k` — the `k` monochromatic colorings are each fixed
+by every rotation, so each is its own singleton orbit.  Immediate from the closed form
+`card_necklaces_prime_length = (kᵖ − k)/p + k`, whose leading term is a nonnegative
+`ℕ`-quotient. -/
+theorem card_necklaces_prime_length_ge {p : ℕ} [NeZero p] (hp : p.Prime) (k : ℕ) :
+    k ≤ @Fintype.card (Quotient (@coloringSetoid p k _)) (coloringQuotientFintype p k) := by
+  rw [card_necklaces_prime_length hp k]
+  exact Nat.le_add_left k _
+
+/-- **Aperiodic prime-length necklace count.**  Subtracting the `k` constant necklaces from
+the total leaves exactly `(kᵖ − k)/p` necklaces — the *aperiodic* ones.  Because `p` is
+prime, a coloring of length `p` has trivial rotational stabiliser unless it is constant, so
+every non-constant coloring lies in a free orbit of size exactly `p`; the `kᵖ − k`
+non-constant colorings therefore split into `(kᵖ − k)/p` necklaces.  This is the exact-orbit
+refinement underlying the combinatorial Fermat proof `prime_dvd_pow_sub_self`, and for prime
+`p` it equals the number of length-`p` Lyndon words up to rotation. -/
+theorem card_aperiodic_necklaces_prime_length {p : ℕ} [NeZero p] (hp : p.Prime) (k : ℕ) :
+    @Fintype.card (Quotient (@coloringSetoid p k _)) (coloringQuotientFintype p k) - k
+      = (k ^ p - k) / p := by
+  rw [card_necklaces_prime_length hp k, Nat.add_sub_cancel]


### PR DESCRIPTION
## Summary

Extends the combinatorial-Fermat corner of `proofs/Proofs/BurnsideCounting.lean` with two corollaries of the merged closed-form count `card_necklaces_prime_length` ($|necklaces| = (k^p-k)/p + k$):

| theorem | statement |
|---|---|
| `card_necklaces_prime_length_ge` | $k \le |necklaces|$ |
| `card_aperiodic_necklaces_prime_length` | $|necklaces| - k = (k^p - k)/p$ |

- **Lower bound:** the $k$ monochromatic colorings are each fixed by every rotation, so they contribute at least $k$ singleton necklaces.
- **Aperiodic count:** because $p$ is prime, a length-$p$ coloring has trivial rotational stabiliser unless it is constant, so the $k^p-k$ non-constant colorings split into exactly $(k^p-k)/p$ free size-$p$ orbits. This is the exact-orbit refinement underlying the combinatorial Fermat proof `prime_dvd_pow_sub_self`, and for prime $p$ equals the number of length-$p$ Lyndon words up to rotation.

## Verification

- **Build GREEN:** `docker-build.sh Proofs.BurnsideCounting` → `Build completed successfully (3058 jobs)`.
- **Axiom-free:** the new lemmas use only `rw` + `Nat.le_add_left` / `Nat.add_sub_cancel`; no `native_decide` (so no new `Lean.ofReduceBool` dependency beyond the file's pre-existing one).

Context: `burnside-counting-oq-02` is a completed Polya-enumeration entry; this enriches the verified necklace/Fermat API rather than changing any claim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)