### PR TITLE
research(pythagorean-oq-01): law of cosines + acute/obtuse trichotomy (0-axiom)

### DIFF
--- a/proofs/Proofs/PythagoreanTheoremOQ01.lean
+++ b/proofs/Proofs/PythagoreanTheoremOQ01.lean
@@ -567,6 +567,35 @@ theorem pythagorean_core_iff (A B C : F) :
     ⟪A - C, B - C⟫ = (0 : ℝ) ↔ ‖A - B‖ ^ 2 = ‖A - C‖ ^ 2 + ‖B - C‖ ^ 2 :=
   ⟨pythagorean_core A B C, pythagorean_core_converse A B C⟩
 
+/-- **The law of cosines (inner-product form).**  For *any* three points `A, B, C` — no right
+angle assumed — the squared side opposite `C` equals the sum of the squared legs minus twice the
+inner product at `C`:
+`‖A − B‖² = ‖A − C‖² + ‖B − C‖² − 2⟪A − C, B − C⟫`.
+Since `⟪A − C, B − C⟫ = ‖A − C‖·‖B − C‖·cos γ` with `γ` the angle at `C`, this is exactly the
+classical law of cosines `c² = a² + b² − 2ab·cos γ`, and `pythagorean_core` is precisely its
+`γ = 90°` (`⟪⟫ = 0`) special case.  Because the inner product enters *linearly*, both
+`pythagorean_core` and `pythagorean_core_converse` are one-line corollaries. -/
+theorem law_of_cosines (A B C : F) :
+    ‖A - B‖ ^ 2 = ‖A - C‖ ^ 2 + ‖B - C‖ ^ 2 - 2 * ⟪A - C, B - C⟫ := by
+  have hAB : A - B = (A - C) - (B - C) := by abel
+  rw [hAB, norm_sub_sq_real]; ring
+
+/-- **Acute angle ⇔ sub-Pythagorean.**  Generalizing `pythagorean_core_iff` to the acute case:
+the angle at `C` is acute (`⟪A − C, B − C⟫ > 0`) iff the side opposite `C` is *shorter* than the
+Pythagorean value, i.e. `‖A − B‖² < ‖A − C‖² + ‖B − C‖²`.  Immediate from `law_of_cosines`. -/
+theorem pythagorean_acute_iff (A B C : F) :
+    0 < ⟪A - C, B - C⟫ ↔ ‖A - B‖ ^ 2 < ‖A - C‖ ^ 2 + ‖B - C‖ ^ 2 := by
+  rw [law_of_cosines A B C]; constructor <;> intro h <;> linarith
+
+/-- **Obtuse angle ⇔ super-Pythagorean.**  The angle at `C` is obtuse (`⟪A − C, B − C⟫ < 0`) iff
+the side opposite `C` is *longer* than the Pythagorean value,
+`‖A − C‖² + ‖B − C‖² < ‖A − B‖²`.  Together with `pythagorean_core_iff` (right angle ⇔ equality)
+and `pythagorean_acute_iff`, this completes the right/acute/obtuse trichotomy that the law of
+cosines governs. -/
+theorem pythagorean_obtuse_iff (A B C : F) :
+    ⟪A - C, B - C⟫ < 0 ↔ ‖A - C‖ ^ 2 + ‖B - C‖ ^ 2 < ‖A - B‖ ^ 2 := by
+  rw [law_of_cosines A B C]; constructor <;> intro h <;> linarith
+
 /-- **Converse of Thales' theorem.**  `thales_circumradius` shows the right-angle vertex lies on
 the circle with diameter `AB` (distance exactly `‖A−B‖/2` from the hypotenuse midpoint
 `M = A + ½·(B−A)`).  This is the converse — the classical statement that *any* point `C` on that

--- a/src/data/proofs/pythagorean-theorem-oq-01/meta.json
+++ b/src/data/proofs/pythagorean-theorem-oq-01/meta.json
@@ -36,7 +36,9 @@
       "geometric_mean_A / geometric_mean_B: the two geometric-mean relations |CA|² = |AB|·|AH| and |CB|² = |AB|·|HB|, the numerical shadow of 'the two sub-triangles are similar to the whole', proved by computing |AH| = |CA|²/|AB| and |HB| = |CB|²/|AB| from the explicit foot.",
       "segments_sum: betweenness |AH| + |HB| = |AB| — the foot lies inside the hypotenuse, i.e. the dissection Area(T) = Area(T₁) + Area(T₂) at the level of the base.",
       "pythagorean_via_altitude: Einstein's route assembled — |AB|² = |AB|·(|AH| + |HB|) = |AB|·|AH| + |AB|·|HB| = |CA|² + |CB|², reconstructing Pythagoras from the altitude decomposition rather than from the bare polarization identity.",
-      "einstein_matches_core: the altitude route (pythagorean_via_altitude) reproduces the one-line metric identity (pythagorean_core), confirming the similar-triangles decomposition is faithful."
+      "einstein_matches_core: the altitude route (pythagorean_via_altitude) reproduces the one-line metric identity (pythagorean_core), confirming the similar-triangles decomposition is faithful.",
+      "law_of_cosines: the inner-product law of cosines ‖A − B‖² = ‖A − C‖² + ‖B − C‖² − 2⟪A − C, B − C⟫ for ANY three points (no right angle assumed) — since ⟪A − C, B − C⟫ = |CA||CB|cos γ this is c² = a² + b² − 2ab·cos γ, and pythagorean_core is exactly its ⟪⟫ = 0 (γ = 90°) case; both pythagorean_core and its converse are one-line corollaries of this single identity.",
+      "pythagorean_acute_iff / pythagorean_obtuse_iff: the acute/obtuse companions of pythagorean_core_iff — the angle at C is acute iff ‖A − B‖² < ‖A − C‖² + ‖B − C‖² (⟪⟫ > 0) and obtuse iff ‖A − C‖² + ‖B − C‖² < ‖A − B‖² (⟪⟫ < 0). With the right-angle equality case this gives the full right/acute/obtuse trichotomy governed by the law of cosines, each proved in one line by rewriting law_of_cosines and linarith."
     ],
     "additionalFiles": [
       "Proofs/PythagoreanTheoremOQ06.lean",
@@ -74,9 +76,9 @@
   },
   "leanFile": {
     "namespace": "PythagoreanEinstein",
-    "lineCount": 608,
+    "lineCount": 637,
     "axiomCount": 0,
-    "theoremCount": 28,
+    "theoremCount": 31,
     "definitionCount": 2,
     "path": "Proofs/PythagoreanTheoremOQ01.lean",
     "imports": [


### PR DESCRIPTION
## Summary

Generalizes the Einstein similar-triangles Pythagorean entry beyond the right-angle case by adding the **inner-product law of cosines** and the **acute/obtuse companions** of the existing right-angle characterization `pythagorean_core_iff`.

Three new theorems in `PythagoreanTheoremOQ01.lean` (0 new axioms):

- **`law_of_cosines`** — `‖A − B‖² = ‖A − C‖² + ‖B − C‖² − 2⟪A − C, B − C⟫` for *any* three points `A, B, C`. Since `⟪A − C, B − C⟫ = ‖CA‖·‖CB‖·cos γ`, this is exactly `c² = a² + b² − 2ab·cos γ`; `pythagorean_core` is precisely its `⟪⟫ = 0` (`γ = 90°`) case, and both it and its converse are one-line corollaries of this single identity.
- **`pythagorean_acute_iff`** — `0 < ⟪A − C, B − C⟫ ↔ ‖A − B‖² < ‖A − C‖² + ‖B − C‖²`.
- **`pythagorean_obtuse_iff`** — `⟪A − C, B − C⟫ < 0 ↔ ‖A − C‖² + ‖B − C‖² < ‖A − B‖²`.

Together with `pythagorean_core_iff` (right angle ⇔ equality), these complete the full **right/acute/obtuse trichotomy** that the law of cosines governs — filling a conceptual gap in a file that already covered Thales, Hippocrates' lunes, Euclid VI.31 and the altitude decomposition, but only for the perpendicular case.

## Verification

- `PythagoreanTheoremOQ01.lean` 608→637 lines, 28→31 theorems, still **0 axioms, 0 sorries**.
- Docker build green (3058 jobs).
- `#print axioms` = `[propext, Classical.choice, Quot.sound]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)