### PR TITLE
research(bezout-identity-oq-01-oq-02-oq-02): Finset-gcd bridge for primitivity

### DIFF
--- a/proofs/Proofs/BezoutIdentityOQ01OQ02OQ02.lean
+++ b/proofs/Proofs/BezoutIdentityOQ01OQ02OQ02.lean
@@ -115,6 +115,30 @@ theorem isPrimitive_iff_forall_isUnit_of_dvd (v : Fin n → ℤ) :
     rw [← hgen]
     exact Ideal.span_singleton_eq_top.mpr hu
 
+/-- **Primitivity via the `Finset`-gcd (unit form).**  Packaging
+`isPrimitive_iff_forall_isUnit_of_dvd` through the universal property of
+`Finset.gcd`: the single element `Finset.univ.gcd v` is *the* greatest common
+divisor of the entries (it divides each `vᵢ` and is divisible by every common
+divisor), so "every common divisor is a unit" collapses to the single statement
+that this gcd is a unit. -/
+theorem isPrimitive_iff_isUnit_finsetGcd (v : Fin n → ℤ) :
+    IsPrimitive v ↔ IsUnit (Finset.univ.gcd v) := by
+  rw [isPrimitive_iff_forall_isUnit_of_dvd]
+  constructor
+  · intro h
+    exact h _ fun i => Finset.gcd_dvd (Finset.mem_univ i)
+  · intro hu d hd
+    exact isUnit_of_dvd_unit (Finset.dvd_gcd fun i _ => hd i) hu
+
+/-- **Primitivity is setwise coprimality: `gcd(v₁, …, vₙ) = 1`.**  The classical
+entry-level statement named in the opening docstring, now literally in terms of
+the normalized `ℤ`-gcd.  Since `Finset.gcd` over `ℤ` is normalized (nonnegative),
+being a unit is the same as being `1` (`normalize_eq_one`), so this is the unit
+form `isPrimitive_iff_isUnit_finsetGcd` written in normal form. -/
+theorem isPrimitive_iff_finsetGcd_eq_one (v : Fin n → ℤ) :
+    IsPrimitive v ↔ Finset.univ.gcd v = 1 := by
+  rw [isPrimitive_iff_isUnit_finsetGcd, ← normalize_eq_one, Finset.normalize_gcd]
+
 /-! ### `SLₙ(ℤ)` preserves primitivity -/
 
 /-- **`SLₙ(ℤ)` sends primitive vectors to primitive vectors.**  If `w ⬝ᵥ v = 1`


### PR DESCRIPTION
## Summary

Discharges nextStep 2 of the entry ("Bridge `IsPrimitive` to `Finset.univ.gcd` of entries = 1") with two new theorems in `proofs/Proofs/BezoutIdentityOQ01OQ02OQ02.lean`:

| theorem | statement |
|---|---|
| `isPrimitive_iff_isUnit_finsetGcd` | `IsPrimitive v ↔ IsUnit (Finset.univ.gcd v)` |
| `isPrimitive_iff_finsetGcd_eq_one` | `IsPrimitive v ↔ Finset.univ.gcd v = 1` |

The file already characterized primitivity via common divisors (`isPrimitive_iff_forall_isUnit_of_dvd`: every common divisor of the entries is a unit). These package that through the **universal property of `Finset.gcd`** — the single element `Finset.univ.gcd v` divides each entry and is divisible by every common divisor — collapsing "every common divisor is a unit" to the single statement that the gcd is a unit. The second theorem is the classical setwise-coprimality statement $\gcd(v_1,\dots,v_n)=1$, obtained by noting `Finset.gcd` over $\mathbb{Z}$ is normalized (`normalize_eq_one` + `Finset.normalize_gcd`). This connects the dot-product `IsPrimitive` notion explicitly with the parent $n=2$ `IsCoprime`/gcd phrasing.

## Verification

- **Build GREEN (3×):** `docker-build.sh Proofs.BezoutIdentityOQ01OQ02OQ02` → `Build completed successfully (3058 jobs)`.
- **Axiom-free:** no `sorry`, no `axiom`, no `native_decide`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)