### PR TITLE
research(cauchy-schwarz-integral-oq-04): strict Gram/uncertainty inequality off the minimum-uncertainty locus [VERIFIED]

### DIFF
--- a/proofs/Proofs/CauchySchwarzIntegralOQ04.lean
+++ b/proofs/Proofs/CauchySchwarzIntegralOQ04.lean
@@ -141,6 +141,26 @@ theorem gram_eq_iff_parallel {u v : E} (hu : u ≠ 0) (hv : v ≠ 0) :
       linarith
   · intro h; rw [h]
 
+/-- **Strict Gram inequality off the minimum-uncertainty locus.**  For nonzero centred
+    vectors `u, v` that are *not* parallel (no `r ≠ 0` with `v = r • u`), the sharp
+    Cauchy–Schwarz / Gram bound is **strict**:
+
+      `(Re⟪u,v⟫)² + (Im⟪u,v⟫)² < ‖u‖²·‖v‖²`.
+
+    This is the `<`-completion of the `≤` bound `inner_sq_le_gram` and its `=`-case
+    `gram_eq_iff_parallel`: equality holds *exactly* on the parallel (minimum-uncertainty)
+    states, so anywhere off that locus the inequality is strict.  With
+    `u = (A−⟨A⟩)ψ`, `v = (B−⟨B⟩)ψ` it says the Schrödinger uncertainty bound is strictly
+    positive unless `ψ` is a generalized coherent/squeezed state
+    `(B−⟨B⟩)ψ = r·(A−⟨A⟩)ψ`. -/
+theorem inner_sq_lt_gram_of_not_parallel {u v : E} (hu : u ≠ 0) (hv : v ≠ 0)
+    (hpar : ¬ ∃ r : 𝕜, r ≠ 0 ∧ v = r • u) :
+    (RCLike.re (inner 𝕜 u v)) ^ 2 + (RCLike.im (inner 𝕜 u v)) ^ 2
+      < ‖u‖ ^ 2 * ‖v‖ ^ 2 := by
+  rcases lt_or_eq_of_le (inner_sq_le_gram (𝕜 := 𝕜) u v) with h | h
+  · exact h
+  · exact absurd ((gram_eq_iff_parallel hu hv).mp h) hpar
+
 /-! ## The full Robertson uncertainty relation
 
 The lemmas above are the Cauchy–Schwarz core.  Here we assemble them into the


### PR DESCRIPTION
## Summary

The foundational Cauchy–Schwarz/Gram section of `CauchySchwarzIntegralOQ04.lean` (Heisenberg/Robertson/Schrödinger uncertainty) has the `≤` bound `inner_sq_le_gram` and its equality case `gram_eq_iff_parallel` — but not the **strict** inequality. This adds it, completing the `≤ / = / <` trichotomy.

## New theorem (axiom-free)

`inner_sq_lt_gram_of_not_parallel`: for nonzero centred `u, v` that are **not** parallel (no `r ≠ 0` with `v = r • u`),
```
(Re⟪u,v⟫)² + (Im⟪u,v⟫)² < ‖u‖²·‖v‖².
```

Equality holds *exactly* on the parallel (minimum-uncertainty) locus (`gram_eq_iff_parallel`), so off it the Gram / Schrödinger bound is strict. Physically: the uncertainty bound is strictly positive unless `ψ` is a generalized coherent/squeezed state `(B−⟨B⟩)ψ = r·(A−⟨A⟩)ψ`.

Proof: `lt_or_eq_of_le` on `inner_sq_le_gram`; the equality branch contradicts non-parallelism via `gram_eq_iff_parallel`.

## Verification

- Built clean via `./proofs/scripts/docker-build.sh Proofs.CauchySchwarzIntegralOQ04`.
- `#print axioms` reports only `[propext, Classical.choice, Quot.sound]` — **no `Lean.ofReduceBool`, no `sorryAx`**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)