### PR TITLE
Enrich area-of-circle-oq-07-oq-04-oq-01-oq-01: 4->5 sections (split preamble/theorem)

### DIFF
--- a/src/data/proofs/area-of-circle-oq-07-oq-04-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/area-of-circle-oq-07-oq-04-oq-01-oq-01/annotations.json
@@ -101,7 +101,7 @@
     "proofId": "area-of-circle-oq-07-oq-04-oq-01-oq-01",
     "range": {
       "startLine": 78,
-      "endLine": 81
+      "endLine": 83
     },
     "type": "concept",
     "title": "The Standard Normalization ∫_{ℝⁿ} e^{-‖x‖²} = π^{n/2}",

--- a/src/data/proofs/area-of-circle-oq-07-oq-04-oq-01-oq-01/meta.json
+++ b/src/data/proofs/area-of-circle-oq-07-oq-04-oq-01-oq-01/meta.json
@@ -95,9 +95,16 @@
   },
   "sections": [
     {
+      "id": "setup-separable-gaussian",
+      "title": "Setup: the separable Gaussian over ℝⁿ",
+      "startLine": 1,
+      "endLine": 45,
+      "summary": "Imports, docstring, and namespace preamble. The load-bearing import is Mathlib.MeasureTheory.Integral.Pi (integral_fintype_prod_volume_eq_pow), which supplies the n-dimensional Fubini engine; GaussianIntegral supplies the base line integral. ℝⁿ is modeled as Fin n → ℝ under the product Lebesgue measure and ∑ᵢ xᵢ² is the squared Euclidean norm ‖x‖². The docstring frames the entry as the arbitrary-dimension generalization of the parent's 2-D polar evaluation, resting on the single structural fact that e^{-b∑xᵢ²} is separable."
+    },
+    {
       "id": "product-fubini",
       "title": "The product–Fubini step (arbitrary dimension)",
-      "startLine": 1,
+      "startLine": 46,
       "endLine": 60,
       "summary": "gaussian_pow_eq_integral_pi: ∫_{ℝⁿ} e^{-b∑xᵢ²} = (∫_ℝ e^{-b t²})ⁿ. The separable integrand factors via Real.exp_sum + Finset.mul_sum into ∏ᵢ e^{-b xᵢ²}, and integral_fintype_prod_volume_eq_pow collapses the product integral to a power. Holds for every real b."
     },


### PR DESCRIPTION
Enrichment pass for `area-of-circle-oq-07-oq-04-oq-01-oq-01` (The n-Dimensional Gaussian Integral).

## Quality improvements
- **Sections 4->5**: split the overloaded first section (lines 1-60, which bundled imports + the 34-line docstring + the first theorem) into a dedicated **Setup** section (1-45) and the **product-Fubini theorem** section (46-60). The 5 sections now cover the full 85-line file with clean, non-overlapping boundaries matching the annotation structure.
- **Annotation coverage**: extended the b=1 normalization annotation range 78->83 so it covers the theorem's proof body (previously stopped at 81).

## Accuracy verification
- Metadata counts (85L / 4 thm / 0 def / 0 axiom / 0 sorry) match the Lean source.
- All 4 `mathlibDependencies` module paths verified to resolve in the pinned Mathlib: `Real.exp_sum`@Analysis/Complex/Exponential, `Real.rpow_mul`@SpecialFunctions/Pow/Real, `integral_fintype_prod_volume_eq_pow`@MeasureTheory/Integral/Pi, `integral_gaussian`@SpecialFunctions/Gaussian/GaussianIntegral.
- meta.json 15.9 KB — within all size guardrails.

Entry already met annotation/keyInsight/conclusion minimums; this pass focused on section structure and coverage.