### PR TITLE
research(erdos-1110-oq-01): totient and prime-factor formulas for power forms

### DIFF
--- a/proofs/Proofs/Erdos1110OQ01.lean
+++ b/proofs/Proofs/Erdos1110OQ01.lean
@@ -438,4 +438,26 @@ theorem powerForm_card_divisors {p q : ℕ} (hp : p.Prime) (hq : q.Prime) (hpq :
   rw [Nat.Coprime.card_divisors_mul hcop, Nat.divisors_prime_pow hp, Nat.divisors_prime_pow hq,
       Finset.card_map, Finset.card_map, Finset.card_range, Finset.card_range]
 
+/-- **Prime-factor set of a power form.** For distinct primes `p ≠ q` and positive
+exponents, the prime factors of `p^k q^l` are exactly `{p, q}` (both primes actually
+occur, and no others). This is the support of the factorization underlying the exponent
+grid of `powerForm_divisors_eq_grid`. -/
+theorem powerForm_primeFactors {p q : ℕ} (hp : p.Prime) (hq : q.Prime) (hpq : p ≠ q)
+    {k l : ℕ} (hk : 0 < k) (hl : 0 < l) :
+    (p ^ k * q ^ l).primeFactors = {p, q} := by
+  rw [Nat.primeFactors_mul (pow_ne_zero k hp.pos.ne') (pow_ne_zero l hq.pos.ne'),
+      Nat.primeFactors_prime_pow hk.ne' hp, Nat.primeFactors_prime_pow hl.ne' hq,
+      Finset.singleton_union]
+
+/-- **Euler totient of a power form `φ(p^k q^l) = p^{k-1}(p-1)·q^{l-1}(q-1)`.** For distinct
+primes `p ≠ q` and positive exponents. The multiplicative companion of the divisor-count
+formula `powerForm_card_divisors` (`τ(p^k q^l) = (k+1)(l+1)`): since `p^k` and `q^l` are
+coprime, `φ` factors as `φ(p^k)·φ(q^l)` (`Nat.totient_mul`), and each prime-power totient is
+`φ(p^k) = p^{k-1}(p-1)` (`Nat.totient_prime_pow`). -/
+theorem powerForm_totient {p q : ℕ} (hp : p.Prime) (hq : q.Prime) (hpq : p ≠ q)
+    {k l : ℕ} (hk : 0 < k) (hl : 0 < l) :
+    (p ^ k * q ^ l).totient = p ^ (k - 1) * (p - 1) * (q ^ (l - 1) * (q - 1)) := by
+  have hcop : Nat.Coprime (p ^ k) (q ^ l) := Nat.coprime_pow_primes k l hp hq hpq
+  rw [Nat.totient_mul hcop, Nat.totient_prime_pow hp hk, Nat.totient_prime_pow hq hl]
+
 end Erdos1110


### PR DESCRIPTION
## Summary

Adds two arithmetic-function facts to `Erdos1110OQ01.lean` (Erdős Problem #1110, OQ-01 — numbers of "power form" `p^k q^l`), extending the existing structural API (submonoid, factorization, dvd/gcd/lcm, divisor grid, divisor count).

These are the natural multiplicative companions to the file's divisor-count formula `powerForm_card_divisors` (`τ(p^k q^l) = (k+1)(l+1)`):

| Theorem | Statement |
|---|---|
| `powerForm_primeFactors` | `(p^k q^l).primeFactors = {p, q}` (distinct primes, `k,l ≥ 1`) |
| `powerForm_totient` | `φ(p^k q^l) = p^{k-1}(p-1)·q^{l-1}(q-1)` (distinct primes, `k,l ≥ 1`) |

The totient formula uses coprimality of `p^k` and `q^l` (`Nat.totient_mul`) together with the prime-power totient `Nat.totient_prime_pow`, exactly mirroring how the divisor count uses multiplicativity of `τ`.

## Verification

VERIFIED **axiom-free** — `#print axioms` reports only `propext, Classical.choice, Quot.sound` for both new theorems (no `sorryAx`, no `Lean.ofReduceBool`). The **entire file** (27 prior + 2 new theorems) elaborated end-to-end under lean 4.26.0 against the prebuilt Mathlib oleans, via narrow-import substitution with the single used parent def `IsPowerForm` inlined (the parent olean transitively needs a CategoryTheory module absent from the local cache).

🤖 Generated with [Claude Code](https://claude.com/claude-code)