### PR TITLE
Fix duplicate annotation ID in abel-ruffini-galois-extensions-oq-02-oq-01

### DIFF
--- a/src/data/proofs/abel-ruffini-galois-extensions-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/abel-ruffini-galois-extensions-oq-02-oq-01/annotations.json
@@ -1,26 +1,5 @@
 [
   {
-    "id": "ann-galois-normal-setup",
-    "proofId": "abel-ruffini-galois-extensions-oq-02-oq-01",
-    "range": { "startLine": 55, "endLine": 63 },
-    "type": "context",
-    "title": "Ambient Setup: an Arbitrary Finite Galois Extension E/F",
-    "content": "The `variable` line fixes the theatre for Parts I and II: an arbitrary pair of fields with `[FiniteDimensional F E]` and `[IsGalois F E]`, i.e. E/F is a finite Galois extension. Every result about the biconditional, the restricted bijection, and the counting corollary is proved once at this level of generality; nothing is specific to the quintic until Part III. The two imports are the minimal dependency set — Mathlib's `Galois.Basic` (which carries the two type-class instances assembled here) and the parent OQ-02 (which supplies `intermediateFieldEquivSubgroup'` and the `open`ed namespace). `open IntermediateField` brings `fixingSubgroup` and `fixedField` into scope by short name.",
-    "mathContext": "Ambient hypotheses: $E/F$ finite ($[\\mathrm{FiniteDimensional}\\,F\\,E]$) and Galois ($[\\mathrm{IsGalois}\\,F\\,E]$); all of Parts I–II hold at this generality.",
-    "significance": "context",
-    "relatedConcepts": [
-      "finite Galois extension",
-      "type-class variable context",
-      "IntermediateField.fixingSubgroup / fixedField",
-      "importing the parent OQ-02"
-    ],
-    "prerequisites": [
-      "finite-dimensional field extensions",
-      "the IsGalois type class",
-      "Lean variable / instance binders"
-    ]
-  },
-  {
     "id": "ann-galois-normal-overview",
     "proofId": "abel-ruffini-galois-extensions-oq-02-oq-01",
     "range": { "startLine": 1, "endLine": 53 },


### PR DESCRIPTION
**Data-integrity fix (not a new enrichment).**

While enriching `abel-ruffini-galois-extensions-oq-02-oq-01` I found that two previously-merged enrichment PRs — #37840 and #37842 — *both* added an annotation with the id `ann-galois-normal-setup` (overlapping ranges 55–63 and 55–64). As a result `main` carries two annotation objects sharing a single id, which breaks the invariant that annotation ids are unique (duplicate React keys, ambiguous id lookup).

**Fix:** remove the shallower `context`-typed copy and keep the richer `technique`-typed entry ("Ambient Setup: a Finite Galois Extension E/F"), which explains why `[FiniteDimensional F E]` and `[IsGalois F E]` are load-bearing hypotheses.

**After:** 7 annotations, 0 duplicate ids (verified). meta.json unchanged. JSON validated.