### PR TITLE
Research: cayley-hamilton-cyclic-vector-all-fields-oq-02-oq-02 — elementwise commutant forms

### DIFF
--- a/proofs/Proofs/CayleyHamiltonCyclicVectorAllFieldsOQ02OQ02.lean
+++ b/proofs/Proofs/CayleyHamiltonCyclicVectorAllFieldsOQ02OQ02.lean
@@ -298,6 +298,75 @@ theorem finrank_centralizer_dichotomy
   ⟨fun h => (finrank_centralizer_eq_natDegree_minpoly_iff_nonderogatory M).mpr h,
    natDegree_minpoly_lt_finrank_centralizer_of_derogatory M⟩
 
+/-! ### Elementwise (matrix-level) forms -/
+
+/-- **Elementwise commutant characterization for nonderogatory `M`.**  All the results
+    above are phrased at the level of the subalgebra `C(M) = Subalgebra.centralizer …`.
+    Unfolded to individual matrices, for a nonderogatory `M` a matrix `N` commutes with
+    `M` **iff** it is a polynomial in `M`:
+
+      `N * M = M * N  ⟺  ∃ p, aeval M p = N`.
+
+    This is the pointwise reading of `centralizer_eq_adjoin_of_nonderogatory`
+    (`C(M) = K[M]`) via `Algebra.adjoin_singleton_eq_range_aeval`: the directly usable
+    "commuting = polynomial" form of the (i) ⟹ (iii) edge. -/
+theorem commute_iff_mem_range_aeval_of_nonderogatory
+    (M : Matrix (Fin n) (Fin n) K) (hM : minpoly K M = M.charpoly)
+    (N : Matrix (Fin n) (Fin n) K) :
+    N * M = M * N ↔ ∃ p : K[X], (aeval M) p = N := by
+  constructor
+  · intro hcomm
+    have hN : N ∈ Subalgebra.centralizer K ({M} : Set (Matrix (Fin n) (Fin n) K)) := by
+      rw [Subalgebra.mem_centralizer_iff]
+      intro g hg; rw [Set.mem_singleton_iff] at hg; subst hg
+      exact hcomm.symm
+    rw [centralizer_eq_adjoin_of_nonderogatory M hM,
+      Algebra.adjoin_singleton_eq_range_aeval] at hN
+    exact hN
+  · rintro ⟨p, rfl⟩
+    have hmem : (aeval M) p ∈ Algebra.adjoin K ({M} : Set (Matrix (Fin n) (Fin n) K)) := by
+      rw [Algebra.adjoin_singleton_eq_range_aeval]; exact ⟨p, rfl⟩
+    have hc := adjoin_le_centralizer M hmem
+    rw [Subalgebra.mem_centralizer_iff] at hc
+    exact (hc M (Set.mem_singleton M)).symm
+
+/-- **A derogatory matrix has a commuting non-polynomial — formalized.**  The strict bound
+    `natDegree_minpoly_lt_finrank_centralizer_of_derogatory` says a derogatory commutant is
+    strictly larger than `K[M]`; its docstring reads "it contains a matrix commuting with `M`
+    that is not a polynomial in `M`".  Here that existential is made explicit and turned into
+    an iff:
+
+      `(∃ N, N·M = M·N ∧ N ∉ K[M])  ⟺  M is derogatory (minpoly ≠ charpoly)`.
+
+    Forward: such an `N` witnesses `C(M) ≠ K[M]`, so by
+    `centralizer_eq_adjoin_iff_nonderogatory` `M` is not nonderogatory.  Backward:
+    derogatoriness gives `K[M] < C(M)` (proper, via `adjoin_le_centralizer`), and
+    `SetLike.exists_of_lt` extracts a commuting matrix outside `K[M]`. -/
+theorem exists_commute_not_mem_adjoin_iff_derogatory
+    (M : Matrix (Fin n) (Fin n) K) :
+    (∃ N : Matrix (Fin n) (Fin n) K, N * M = M * N ∧
+        N ∉ Algebra.adjoin K ({M} : Set (Matrix (Fin n) (Fin n) K)))
+      ↔ minpoly K M ≠ M.charpoly := by
+  constructor
+  · rintro ⟨N, hcomm, hnotmem⟩ hnon
+    have hN : N ∈ Subalgebra.centralizer K ({M} : Set (Matrix (Fin n) (Fin n) K)) := by
+      rw [Subalgebra.mem_centralizer_iff]
+      intro g hg; rw [Set.mem_singleton_iff] at hg; subst hg
+      exact hcomm.symm
+    rw [centralizer_eq_adjoin_of_nonderogatory M hnon] at hN
+    exact hnotmem hN
+  · intro hderog
+    have hne : Subalgebra.centralizer K ({M} : Set (Matrix (Fin n) (Fin n) K))
+        ≠ Algebra.adjoin K ({M} : Set (Matrix (Fin n) (Fin n) K)) :=
+      fun heq => hderog ((centralizer_eq_adjoin_iff_nonderogatory M).mp heq)
+    have hlt : Algebra.adjoin K ({M} : Set (Matrix (Fin n) (Fin n) K))
+        < Subalgebra.centralizer K ({M} : Set (Matrix (Fin n) (Fin n) K)) :=
+      lt_of_le_of_ne (adjoin_le_centralizer M) (Ne.symm hne)
+    obtain ⟨N, hNc, hNa⟩ := SetLike.exists_of_lt hlt
+    refine ⟨N, ?_, hNa⟩
+    rw [Subalgebra.mem_centralizer_iff] at hNc
+    exact (hNc M (Set.mem_singleton M)).symm
+
 /-! ### Summary -/
 
 /-- **De Moivre / Cayley–Hamilton OQ-02-OQ-02 summary.**  For an `n × n` matrix


### PR DESCRIPTION
## Summary

Extends `CayleyHamiltonCyclicVectorAllFieldsOQ02OQ02.lean` (commutant dimension for the nonderogatory triple equivalence). Every result there is phrased at the level of the subalgebra `C(M) = Subalgebra.centralizer …`. This adds the **matrix-level (pointwise)** counterparts.

## New theorems

- **`commute_iff_mem_range_aeval_of_nonderogatory`** — for a nonderogatory `M`, a matrix `N` commutes with `M` **iff** it is a polynomial in `M`: `N·M = M·N ↔ ∃ p, aeval M p = N`. The directly-usable pointwise reading of `centralizer_eq_adjoin_of_nonderogatory` (`C(M) = K[M]`) via `Algebra.adjoin_singleton_eq_range_aeval`.
- **`exists_commute_not_mem_adjoin_iff_derogatory`** — formalizes the docstring claim of `natDegree_minpoly_lt_finrank_centralizer_of_derogatory` ("a derogatory matrix contains a matrix commuting with `M` that is not a polynomial in `M`"), as an iff: `(∃ N, N·M = M·N ∧ N ∉ K[M]) ↔ minpoly K M ≠ charpoly M`. The witness is extracted from `K[M] < C(M)` via `SetLike.exists_of_lt`.

12 → 14 theorems. No gallery `meta.json` (research variant).

## Verification

The full-file `docker-build.sh` is currently **blocked by an environmental issue** unrelated to this change: this file's import chain (via `…OQ01OQ01 → …MinpolyOQ05OQ01OQ04WIP04`) transitively needs category-theory codegen (`Order.Category.BddOrd`), and the shared Mathlib `.ir` build cache for those modules is currently corrupt (`invalid header`), causing an `exit 135` during codegen. The imported files build fine in isolation (`WIP04` builds in 5.2s); the failure is memory-pressure/`.ir`-cache-driven, not a proof error.

The two new theorems were therefore verified by **direct `lean` elaboration** of a standalone file that imports only the specific (category-theory-free) Mathlib modules they need and stubs the three same-file lemmas they call (`centralizer_eq_adjoin_of_nonderogatory`, `centralizer_eq_adjoin_iff_nonderogatory`, `adjoin_le_centralizer` — each fully proven in the target file) as `axiom`:

- Elaboration **exit 0**, no errors / no `sorry`.
- `#print axioms`: both theorems depend only on `[propext, Classical.choice, Quot.sound]` plus those three stubbed (proven) same-file lemmas — **no new axioms**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)