### PR TITLE
Enrich area-of-circle-oq-07-oq-04-oq-01-oq-01-oq-02: 3->4 sections (split preamble/theorem)

### DIFF
--- a/src/data/proofs/area-of-circle-oq-07-oq-04-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/area-of-circle-oq-07-oq-04-oq-01-oq-01-oq-02/meta.json
@@ -36,11 +36,18 @@
   },
   "sections": [
     {
+      "id": "setup",
+      "title": "Setup: the diagonal Gaussian and the determinant target",
+      "startLine": 1,
+      "endLine": 50,
+      "summary": "Imports, docstring, and namespace preamble. The load-bearing import Mathlib.MeasureTheory.Integral.Pi supplies the general n-variable Fubini lemma integral_fintype_prod_volume_eq_prod (distinct per-axis factors), and GaussianIntegral supplies the base line integral. ℝⁿ is Fin n → ℝ under the product Lebesgue measure and the integrand is the separable product e^{-∑ᵢ bᵢ xᵢ²} = ∏ᵢ e^{-bᵢ xᵢ²}. The docstring frames the target π^{n/2}/√(∏ᵢ bᵢ) as the diagonal case A = diag(b₁,…,bₙ) of the general quadratic-form Gaussian π^{n/2}/√(det A)."
+    },
+    {
       "id": "product-fubini",
       "title": "The Anisotropic Product–Fubini Step",
-      "startLine": 1,
+      "startLine": 51,
       "endLine": 72,
-      "summary": "gaussian_anisotropic_eq_prod: for every real weight vector b, ∫_{ℝⁿ} e^{-∑ᵢ bᵢ xᵢ²} = ∏ᵢ √(π/bᵢ), via separable factoring (Real.exp_sum), general n-variable Fubini (integral_fintype_prod_volume_eq_prod), and per-axis integral_gaussian."
+      "summary": "gaussian_anisotropic_eq_prod: for every real weight vector b, ∫_{ℝⁿ} e^{-∑ᵢ bᵢ xᵢ²} = ∏ᵢ √(π/bᵢ), via separable factoring (Real.exp_sum), general n-variable Fubini (integral_fintype_prod_volume_eq_prod), and per-axis integral_gaussian. An explicit beta-reduction (simp only []) is needed before Real.exp_sum matches the integrand."
     },
     {
       "id": "determinant-closed-form",
@@ -53,7 +60,7 @@
       "id": "isotropic-recovery",
       "title": "Isotropic Recovery",
       "startLine": 100,
-      "endLine": 113,
+      "endLine": 114,
       "summary": "gaussian_isotropic_recover: the constant weight bᵢ = c collapses the product to a power, recovering the parent's isotropic (π/c)^{n/2} and certifying this as a strict generalization."
     }
   ],
@@ -177,7 +184,7 @@
   ],
   "sorries": 0,
   "conclusion": {
-    "summary": "For every weight vector b : Fin n → ℝ the anisotropic (diagonal) Gaussian integral over ℝⁿ = Fin n → ℝ factors as a product of per-axis one-dimensional Gaussians: ∫_{ℝⁿ} e^{-∑ᵢ bᵢ xᵢ²} = ∏ᵢ √(π/bᵢ) (gaussian_anisotropic_eq_prod), valid for every b with no positivity hypothesis. The separable integrand e^{-∑ᵢ bᵢ xᵢ²} is rewritten as the product ∏ᵢ e^{-bᵢ xᵢ²} (Real.exp_sum) and the general n-variable Fubini theorem integral_fintype_prod_volume_eq_prod collapses the product integral to a product of distinct line integrals, each evaluated by Mathlib's integral_gaussian. For positive weights bᵢ > 0 the product re-assembles into the determinant closed form π^{n/2}/√(∏ᵢ bᵢ) (gaussian_anisotropic_closed_form), using Real.sqrt_div to factor √π and Real.finset_prod_rpow to collect ∏ᵢ √bᵢ = √(∏ᵢ bᵢ). The constant weight bᵢ = c recovers the parent's isotropic (π/c)^{n/2} (gaussian_isotropic_recover). 112 lines, 3 theorems, 0 definitions, 0 axioms, 0 sorries. Every Mathlib dependency was checked against the Mathlib v4 source (integral_fintype_prod_volume_eq_prod, integral_gaussian, Real.exp_sum, Real.finset_prod_rpow, Real.sqrt_div, Real.sqrt_eq_rpow, Real.rpow_natCast, Real.rpow_mul, Finset.prod_div_distrib, Finset.sum_neg_distrib, Fintype.card_fin); the file is kernel-verified with `lake env lean` on Mathlib v4.26.0 — all three theorems depend only on the standard foundational axioms [propext, Classical.choice, Quot.sound]. (The product–Fubini step required an explicit beta-reduction (`simp only []`) before `Real.exp_sum` could rewrite the integrand.)",
+    "summary": "For every weight vector b : Fin n → ℝ the anisotropic (diagonal) Gaussian integral over ℝⁿ = Fin n → ℝ factors as a product of per-axis one-dimensional Gaussians: ∫_{ℝⁿ} e^{-∑ᵢ bᵢ xᵢ²} = ∏ᵢ √(π/bᵢ) (gaussian_anisotropic_eq_prod), valid for every b with no positivity hypothesis. The separable integrand e^{-∑ᵢ bᵢ xᵢ²} is rewritten as the product ∏ᵢ e^{-bᵢ xᵢ²} (Real.exp_sum) and the general n-variable Fubini theorem integral_fintype_prod_volume_eq_prod collapses the product integral to a product of distinct line integrals, each evaluated by Mathlib's integral_gaussian. For positive weights bᵢ > 0 the product re-assembles into the determinant closed form π^{n/2}/√(∏ᵢ bᵢ) (gaussian_anisotropic_closed_form), using Real.sqrt_div to factor √π and Real.finset_prod_rpow to collect ∏ᵢ √bᵢ = √(∏ᵢ bᵢ). The constant weight bᵢ = c recovers the parent's isotropic (π/c)^{n/2} (gaussian_isotropic_recover). 114 lines, 3 theorems, 0 definitions, 0 axioms, 0 sorries. Every Mathlib dependency was checked against the Mathlib v4 source (integral_fintype_prod_volume_eq_prod, integral_gaussian, Real.exp_sum, Real.finset_prod_rpow, Real.sqrt_div, Real.sqrt_eq_rpow, Real.rpow_natCast, Real.rpow_mul, Finset.prod_div_distrib, Finset.sum_neg_distrib, Fintype.card_fin); the file is kernel-verified with `lake env lean` on Mathlib v4.26.0 — all three theorems depend only on the standard foundational axioms [propext, Classical.choice, Quot.sound]. (The product–Fubini step required an explicit beta-reduction (`simp only []`) before `Real.exp_sum` could rewrite the integrand.)",
     "implications": "This upgrades the isotropic n-dimensional Gaussian from a single weight to a diagonal covariance, identifying the normalizing constant π^{n/2}/√(∏ᵢ bᵢ) = π^{n/2}/√(det diag b) as the diagonal case of the general positive-definite quadratic-form value π^{n/2}/√(det A). The engine is the same separable Fubini factorization as the parent, upgraded from a power of one integral to a product of n distinct line integrals; the parent is exactly the constant-weight specialization. The general quadratic-form statement (via orthogonal diagonalization) is left as the open follow-up.",
     "openQuestions": [
       "Extend to a general positive-definite quadratic form ∫_{ℝⁿ} e^{-⟨Ax,x⟩} = π^{n/2}/√(det A) by orthogonal diagonalization, reducing to the diagonal case proved here.",


### PR DESCRIPTION
Enrichment pass for `area-of-circle-oq-07-oq-04-oq-01-oq-01-oq-02` (The Anisotropic n-Dimensional Gaussian Integral).

## Quality improvements
- **Sections 3->4**: split the overloaded first section (lines 1-72, which bundled imports + the docstring + the entire first theorem) into a dedicated **Setup** section (1-50) and the **anisotropic product-Fubini** theorem section (51-72). The 4 sections now map one-to-one onto the preamble + 3 theorems and cover the full 114-line file.
- Extended the isotropic-recovery section to line 114 (namespace end).
- Fixed a stale count in `conclusion.summary`: '112 lines' -> '114 lines' (leanFile.lineCount=114).

## Accuracy verification
- Metadata counts (114L / 3 thm / 0 def / 0 axiom / 0 sorry) match the Lean source.
- All `mathlibDependencies` module paths verified in pinned Mathlib: `integral_fintype_prod_volume_eq_prod`@MeasureTheory/Integral/Pi, `Real.finset_prod_rpow`@SpecialFunctions/Pow/NNReal, `Real.sqrt_div`@Data/Real/Sqrt, `Real.rpow_mul`@SpecialFunctions/Pow/Real, `integral_gaussian`, `Real.exp_sum`.
- meta.json 18.4 KB — within all size guardrails.

Entry already met annotation/keyInsight/conclusion minimums; this pass focused on section structure and count accuracy.