### PR TITLE
research(inverse-galois-oq-03): Cauchy elements of the Monster (orders 2 and 71)

### DIFF
--- a/proofs/Proofs/InverseGaloisOQ03.lean
+++ b/proofs/Proofs/InverseGaloisOQ03.lean
@@ -149,6 +149,28 @@ theorem seven_dvd_Monster_card : 7 ∣ Fintype.card Monster := by
 theorem seventyone_dvd_Monster_card : 71 ∣ Fintype.card Monster := by
   rw [Monster_card]; norm_num
 
+/-- 𝕄 is nontrivial as a group. Immediate from `|𝕄| > 1`; recorded because the
+    element-order (Cauchy) results below are stated for a genuine group with `> 1` element. -/
+theorem Monster_nontrivial : Nontrivial Monster :=
+  Fintype.one_lt_card_iff_nontrivial.mp Monster_card_pos
+
+/-- **𝕄 contains an involution** — an element of order exactly 2.
+    By Cauchy's theorem (`exists_prime_orderOf_dvd_card`), since the prime `2` divides `|𝕄|`
+    there is an element of order `2`. The Monster's even order (`2⁴⁶ ∥ |𝕄|`) is what makes its
+    involution centralizers — the seed of Griess's 1982 construction of 𝕄 — nonempty. -/
+theorem Monster_exists_involution : ∃ g : Monster, orderOf g = 2 :=
+  haveI : Fact (Nat.Prime 2) := ⟨by norm_num⟩
+  exists_prime_orderOf_dvd_card 2 two_dvd_Monster_card
+
+/-- **𝕄 contains an element of order 71.**
+    Cauchy's theorem applied to the largest prime factor `71 ∣ |𝕄|` produces an element of order
+    exactly `71`, substantiating the remark on `seventyone_dvd_Monster_card` that `71` is realised
+    as an element order in the Monster (in fact `71` is the largest prime order of any element
+    of 𝕄). -/
+theorem Monster_exists_element_orderOf_71 : ∃ g : Monster, orderOf g = 71 :=
+  haveI : Fact (Nat.Prime 71) := ⟨by norm_num⟩
+  exists_prime_orderOf_dvd_card 71 seventyone_dvd_Monster_card
+
 -- ============================================================================
 -- Part III: Non-Solvability — The Core Structural Result
 -- ============================================================================

--- a/src/data/proofs/inverse-galois-oq-03/meta.json
+++ b/src/data/proofs/inverse-galois-oq-03/meta.json
@@ -39,9 +39,9 @@
         "relationship": "Sister entry on the non-solvable frontier and the solvability divide"
       }
     ],
-    "lineCount": 361,
+    "lineCount": 383,
     "mathlib_version": "4.26.0",
-    "theoremCount": 19,
+    "theoremCount": 22,
     "definitionCount": 0,
     "additionalFiles": []
   },
@@ -145,10 +145,10 @@
   "sorries": 0,
   "leanFile": {
     "path": "Proofs/InverseGaloisOQ03.lean",
-    "lineCount": 361,
+    "lineCount": 383,
     "axiomCount": 6,
     "sorries": 0,
-    "theoremCount": 19,
+    "theoremCount": 22,
     "definitionCount": 0,
     "imports": [
       "Mathlib",


### PR DESCRIPTION
## Summary

The Monster-group entry records that 2, 3, 5, 7, 71 divide `|𝕄|`, and the docstring on `seventyone_dvd_Monster_card` even remarks that 71 is realised as an element order — but the file never exhibited an element of any given order. This PR closes that gap with three structural facts (0 new axioms):

- **`Monster_nontrivial`** `: Nontrivial Monster` — from `|𝕄| > 1` via `Fintype.one_lt_card_iff_nontrivial`.
- **`Monster_exists_involution`** `: ∃ g : Monster, orderOf g = 2` — Cauchy's theorem for the prime 2 (`exists_prime_orderOf_dvd_card`), the even order underlying the involution centralizers of Griess's construction.
- **`Monster_exists_element_orderOf_71`** `: ∃ g : Monster, orderOf g = 71` — Cauchy's theorem for the largest prime factor, substantiating the docstring claim.

All three follow from Mathlib's Cauchy theorem plus the existing divisibility lemmas; they depend only on the Monster group/fintype/card axioms already in the file (no new axioms; status stays `axiomatized`).

## Verification

- `InverseGaloisOQ03.lean` 361→383 lines, 19→22 theorems, axiomCount unchanged (6), 0 sorries. Gallery `meta.json` counts synced (both `meta` and `leanFile` blocks).
- The full file uses `import Mathlib`; in the current sandbox that target intermittently hits a SIGBUS (exit 135) during olean *serialization* (post-elaboration, no Lean error output) — an environment memory limit, not a proof error. The three new proofs were verified **green (3058 jobs)** in a minimal-import standalone file (`Mathlib.GroupTheory.Perm.Cycle.Type` + `Mathlib.Data.Fintype.EquivFin`) reproducing the Monster axioms and the exact proof terms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)