### PR TITLE
Enrich area-of-circle-oq-07-oq-05-oq-01-oq-01: fix 2 stale mathlibDependency module paths

### DIFF
--- a/src/data/proofs/area-of-circle-oq-07-oq-05-oq-01-oq-01/meta.json
+++ b/src/data/proofs/area-of-circle-oq-07-oq-05-oq-01-oq-01/meta.json
@@ -61,12 +61,12 @@
       {
         "theorem": "Odd.neg_pow",
         "description": "(-a)^n = -(a^n) when n is odd. Applied with the odd exponent 2n+1 (witness ⟨n, rfl⟩ : Odd (2n+1)) to show the integrand x^{2n+1} e^{-x²} is odd.",
-        "module": "Mathlib.Algebra.GroupPower.Basic"
+        "module": "Mathlib.Algebra.Ring.Parity"
       },
       {
         "theorem": "integral_neg",
         "description": "∫ x, -f x = -∫ x, f x, the linearity step that turns the oddness rewrite ∫ f(-x) = ∫ -f into ∫ f(-x) = -∫ f.",
-        "module": "Mathlib.MeasureTheory.Integral.Bochner"
+        "module": "Mathlib.MeasureTheory.Integral.Bochner.Basic"
       },
       {
         "theorem": "AreaOfCircleOQ07OQ05OQ01.gaussian_even_moment",


### PR DESCRIPTION
Accuracy pass for `area-of-circle-oq-07-oq-05-oq-01-oq-01` (Vanishing Odd Gaussian Moments).

This entry already meets all enrichment minimums (4 clean sections one-per-theorem+docstring, 5 annotations, 4 keyInsights, full conclusion with 3 open questions), so rather than inflate it I fixed the two `mathlibDependencies` module paths that no longer resolve in the pinned Mathlib (4.26.0) due to upstream directory splits:

| theorem | old (broken) module | corrected module | decl |
|---|---|---|---|
| `Odd.neg_pow` | `Mathlib.Algebra.GroupPower.Basic` (removed) | `Mathlib.Algebra.Ring.Parity` | Parity.lean:173 |
| `integral_neg` | `Mathlib.MeasureTheory.Integral.Bochner` (now a directory) | `Mathlib.MeasureTheory.Integral.Bochner.Basic` | Basic.lean:257 |

Verified unchanged/correct: `integral_neg_eq_self`@`MeasureTheory.Group.Integral`, `gaussian_even_moment`@`Proofs.AreaOfCircleOQ07OQ05OQ01`. Metadata counts (98L / 3 thm / 0 def / 0 axiom / 0 sorry) match the Lean source; meta.json within all size guardrails.