### PR TITLE
research(collatz-structured-oq-02-oq-03): when a Collatz step preserves the orbit minimum

### DIFF
--- a/proofs/Proofs/CollatzStructuredOQ02OQ03.lean
+++ b/proofs/Proofs/CollatzStructuredOQ02OQ03.lean
@@ -1064,6 +1064,30 @@ theorem colMin_eq_min_collatz (n : ℕ) : colMin n = min n (colMin (collatz n)) 
       exact hstep.symm
     exact le_trans (min_le_right _ _) hcn
 
+/-- **When a Collatz step preserves the orbit minimum.**  Peeling the head off the orbit
+(`colMin_eq_min_collatz`: `colMin n = min n (colMin (collatz n))`), the step `n ↦ collatz n`
+leaves the orbit minimum unchanged *exactly* when the tail minimum already lies at or below
+the start `n`: `colMin (collatz n) = colMin n ↔ colMin (collatz n) ≤ n`.  Equivalently, the
+head `n` is never the unique orbit minimum unless it is a genuine new low. -/
+theorem colMin_collatz_eq_iff {n : ℕ} :
+    colMin (collatz n) = colMin n ↔ colMin (collatz n) ≤ n := by
+  rw [colMin_eq_min_collatz n]
+  constructor
+  · intro h
+    calc colMin (collatz n) = min n (colMin (collatz n)) := h
+      _ ≤ n := min_le_left _ _
+  · intro h; rw [min_eq_right h]
+
+/-- **A decreasing step preserves the orbit minimum.**  If one Collatz step already drops
+below the start (`collatz n < n`), then `colMin (collatz n) = colMin n`: the minimum of the
+whole orbit is already determined by the post-step value, since the head `n` is not the
+minimum.  This is the abstract principle behind `colMin_two_mul` (where `collatz (2n) = n < 2n`)
+and, iterated along a residue-determined drop window, is why the per-residue families of
+Part II pin down `colMin n` below the start. -/
+theorem colMin_collatz_of_lt {n : ℕ} (h : collatz n < n) :
+    colMin (collatz n) = colMin n :=
+  colMin_collatz_eq_iff.mpr ((colMin_le_self _).trans h.le)
+
 /-- Sharpening `colMin_pow_two_le_one`: the orbit minimum of `2^k` is **exactly**
 `1` (the orbit hits `1` and, being positive, never goes lower). -/
 theorem colMin_pow_two_eq_one (k : ℕ) : colMin (2 ^ k) = 1 := by

--- a/src/data/proofs/collatz-structured-oq-02-oq-03/meta.json
+++ b/src/data/proofs/collatz-structured-oq-02-oq-03/meta.json
@@ -24,7 +24,7 @@
     "assumptions": "1 axiom: tao_2019 — the precise statement of Tao (2019, Forum Math. Pi), that for every f : ℕ → ℝ with f n → ∞ the set {n : 0 < n ∧ Col_min(n) < f n} has logarithmic density one. This is the deep analytic result the open question asks about; it is recorded, not proved, because its proof (3-adic transport/concentration estimates plus a Fourier-analytic input) is far beyond current Mathlib. No theorem in the file is derived from this axiom — the proven Parts II–III are independently machine-verified and depend only on the standard foundational axioms propext / Classical.choice / Quot.sound.",
     "dateAdded": "2026-06-25",
     "mathlib_version": "4.26.0",
-    "theoremCount": 79,
+    "theoremCount": 81,
     "definitionCount": 14,
     "originalContributions": [
       "attainsBelow_density_of_autoDropCert: fuses the general density lemma attainsBelow_density_of_residues with the turnkey autoDropCert engine, so the drop-below density floor at any 2^b level is (#auto-certified residues)·(N-1) with ZERO per-residue proof — the residue count is a decide, every drop hypothesis is autoDropCert_attainsBelow (axiom-free, no native_decide)",


### PR DESCRIPTION
## Summary

Adds the structural **step-invariance principle** for the orbit minimum `colMin` to
`Proofs.CollatzStructuredOQ02OQ03` (Tao-2019 almost-all anchor). The file develops a
rich `colMin` theory (`colMin_eq_min_collatz`, `colMin_two_mul`, `colMin_two_pow_mul`,
`colMin_idempotent`, …) but never isolates the elementary fact governing *when a single
Collatz step leaves the orbit minimum unchanged* — the principle that actually powers
`colMin_two_mul` and the per-residue drop families of Part II.

## New lemmas (2)

- **`colMin_collatz_eq_iff`** — `colMin (collatz n) = colMin n ↔ colMin (collatz n) ≤ n`.
  Peeling the head off the orbit (`colMin_eq_min_collatz : colMin n = min n (colMin (collatz n))`),
  a step preserves the orbit minimum exactly when the tail minimum already lies at/below
  the start `n`.
- **`colMin_collatz_of_lt`** — `collatz n < n → colMin (collatz n) = colMin n`: a
  decreasing step preserves the orbit minimum (the head `n` is not the minimum). This is
  the abstract principle behind `colMin_two_mul` (`collatz (2n) = n < 2n`) and, iterated
  along a residue-determined drop window, is *why* Part II's families pin `colMin n` below
  the start.

Both use only `min_eq_right` / `min_le_left` / `colMin_le_self` / `colMin_eq_min_collatz`;
the file's single `tao_2019` axiom is untouched (79 → 81 theorems, `meta.theoremCount`
bumped 79 → 81).

## Verification

Full `docker-build.sh Proofs.CollatzStructuredOQ02OQ03` **succeeds** (exit 0). The file
stays axiom-free in its elementary part (only the pre-existing `tao_2019` axiom;
`decide`-based, no `native_decide`).

(Note: an intermediate build run hit the documented shared-Mathlib-cache exit-135/SIGBUS
corruption from concurrent OOM builds; `--repair-cache` cleared it and the clean build
above confirms the change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)