### PR TITLE
Research: erdos-729-oq-02 — even-odd plateau + quantitative lower bound for v2(n!)

### DIFF
--- a/proofs/Proofs/Erdos729LegendreRecurrence.lean
+++ b/proofs/Proofs/Erdos729LegendreRecurrence.lean
@@ -147,6 +147,42 @@ theorem v2_factorial_monotone :
   monotone_nat_of_le_succ fun n => by
     rw [v2_factorial_succ]; omega
 
+/-- **Even→odd plateau.** `v₂((2n)!) = v₂((2n+1)!)`: the 2-adic valuation of the
+factorial is *constant* across each even-to-odd step, because the odd number `2n+1`
+contributes no new factor of two.  This is exactly where the monotone map
+`v2_factorial_monotone` fails to be *strict* — both doubling recurrences land on the
+same value `n + v₂(n!)`, so `v₂(·!)` is flat on `{2n, 2n+1}` and only increases on the
+even steps `2n+1 → 2n+2`. -/
+theorem v2_factorial_two_mul_eq_two_mul_add_one (n : ℕ) :
+    padicValNat 2 (2 * n).factorial = padicValNat 2 (2 * n + 1).factorial := by
+  rw [v2_factorial_two_mul, v2_factorial_two_mul_add_one]
+
+/-- **Binary digit sum is at most the bit length.** `s₂(n) ≤ ⌊log₂ n⌋ + 1` for `n ≥ 1`:
+each binary digit is `≤ 1`, and `n` has exactly `⌊log₂ n⌋ + 1` binary digits.  Sharper
+than the trivial `s₂(n) ≤ n` (`Nat.digit_sum_le`), and the input to the factorial
+valuation lower bound. -/
+theorem s₂_le_log_succ (n : ℕ) (hn : n ≠ 0) : s₂ n ≤ Nat.log 2 n + 1 := by
+  have hlen : (Nat.digits 2 n).length = Nat.log 2 n + 1 :=
+    Nat.digits_len 2 n (by norm_num) hn
+  have hbound : (Nat.digits 2 n).sum ≤ (Nat.digits 2 n).length := by
+    have h := List.sum_le_card_nsmul (Nat.digits 2 n) 1
+      (fun x hx => Nat.lt_succ_iff.mp (Nat.digits_lt_base (by norm_num) hx))
+    simpa using h
+  simp only [s₂]
+  omega
+
+/-- **Quantitative lower bound.** `v₂(n!) ≥ n − (⌊log₂ n⌋ + 1)` for `n ≥ 1`.  Since
+`v₂(n!) = n − s₂(n)` (`legendre_two`) and `s₂(n) ≤ ⌊log₂ n⌋ + 1` (`s₂_le_log_succ`), the
+2-adic valuation of `n!` is within `⌊log₂ n⌋ + 1` of its ceiling `n`: it grows like
+`n − O(log n)`, so `v₂(n!)/n → 1`.  The lower companion to the maximality
+characterization `v2_factorial_eq_pred_iff` (`v₂(n!) = n − 1 ⟺ s₂(n) = 1`). -/
+theorem v2_factorial_ge (n : ℕ) (hn : n ≠ 0) :
+    padicValNat 2 n.factorial ≥ n - (Nat.log 2 n + 1) := by
+  have hL := legendre_two n
+  have hs := s₂_le_log_succ n hn
+  rw [hL]
+  omega
+
 #check @v2_factorial_two_mul
 #check @v2_factorial_two_mul_add_one
 #check @v2_factorial_eq_pred_iff


### PR DESCRIPTION
## Summary

Extends `Erdos729LegendreRecurrence.lean` (2-adic valuation of factorials, `v₂(n!) = n − s₂(n)`). Two new consequences of Legendre's identity not previously in the file.

## New theorems (axiom-free)

- **`v2_factorial_two_mul_eq_two_mul_add_one`** — `v₂((2n)!) = v₂((2n+1)!)`: the valuation is **flat** across each even→odd step (the odd number `2n+1` adds no factor of two). This pinpoints exactly where `v2_factorial_monotone` fails to be *strict*: both doubling recurrences land on `n + v₂(n!)`.
- **`s₂_le_log_succ`** — `s₂(n) ≤ ⌊log₂ n⌋ + 1` for `n ≥ 1` (each binary digit is `≤ 1`, and `n` has `⌊log₂ n⌋ + 1` binary digits). Sharpens the trivial `s₂(n) ≤ n`.
- **`v2_factorial_ge`** — `v₂(n!) ≥ n − (⌊log₂ n⌋ + 1)` for `n ≥ 1`: the quantitative lower bound. Combined with `v₂(n!) = n − s₂(n)`, it shows `v₂(n!) = n − O(log n)` (so `v₂(n!)/n → 1`) — the lower companion to the maximality characterization `v2_factorial_eq_pred_iff`.

8 → 11 theorems. (Second visit; the prior PR #37825 added the single-step recurrence and monotonicity.) No gallery `meta.json` (research variant).

## Verification

The full-file `docker-build.sh` currently `exit 135`s during codegen — this file uses `import Mathlib`, and the shared Mathlib `.ir` build cache on the build host is intermittently corrupt / the host is under heavy memory pressure (load avg ~10–13), causing SIGBUS during code generation. This is unrelated to the proofs (no proof error is reported; the crash is in codegen).

The three theorems were verified by **direct `lean` elaboration** of a standalone file importing only the specific number-theory Mathlib modules they use (no `import Mathlib`, so no corrupt category-theory `.ir`), with the same-file lemmas they call (`legendre_two`, `v2_factorial_two_mul`, `v2_factorial_two_mul_add_one`) stubbed as `axiom`:

- Elaboration **exit 0**, no errors / no `sorry`.
- `#print axioms`: `s₂_le_log_succ` depends only on `[propext, Classical.choice, Quot.sound]`; the other two additionally depend only on the stubbed (proven) same-file lemmas — **no new axioms**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)