### PR TITLE
research(law-of-cosines-oq-03-oq-03): Part XII cyclic-complete side-angle ordering + global sort [VERIFIED 0/0]

### DIFF
--- a/proofs/Proofs/LawOfCosinesOQ03OQ03.lean
+++ b/proofs/Proofs/LawOfCosinesOQ03OQ03.lean
@@ -1251,4 +1251,42 @@ theorem equilateral_iff_equiangular (t : HyperbolicTriangle) :
   · rintro ⟨hAB, hBC⟩
     exact equilateral_sides_eq t hAB hBC
 
+-- ============================================================
+-- PART 12: Cyclic completion of the side–angle order-equivalence
+-- ============================================================
+
+/-- **Side–angle order-equivalence for the `(b,c)/(B,C)` pair (strict).** `b < c ↔ B < C`,
+    the cyclic companion of `side_lt_iff_angle_lt` (`a < b ↔ A < B`), obtained by applying it
+    to the relabeling `rotate` (which cycles `(a,b,c) → (b,c,a)` and `(A,B,C) → (B,C,A)`, so the
+    `(a,b)/(A,B)` slots become the `(b,c)/(B,C)` pair). -/
+theorem side_lt_iff_angle_lt_bc (t : HyperbolicTriangle) : t.b < t.c ↔ t.B < t.C :=
+  side_lt_iff_angle_lt t.rotate
+
+/-- **Side–angle order-equivalence for the `(c,a)/(C,A)` pair (strict).** `c < a ↔ C < A`, the
+    third leg completing the strict order trio, obtained by applying the `(b,c)` criterion to
+    `rotate`. With its two companions this gives the strict order-equivalence for every pair. -/
+theorem side_lt_iff_angle_lt_ca (t : HyperbolicTriangle) : t.c < t.a ↔ t.C < t.A :=
+  side_lt_iff_angle_lt_bc t.rotate
+
+/-- **Non-strict side–angle order-equivalence for the `(b,c)/(B,C)` pair.** `b ≤ c ↔ B ≤ C`,
+    the `≤` companion via `rotate`. -/
+theorem side_le_iff_angle_le_bc (t : HyperbolicTriangle) : t.b ≤ t.c ↔ t.B ≤ t.C :=
+  side_le_iff_angle_le t.rotate
+
+/-- **Non-strict side–angle order-equivalence for the `(c,a)/(C,A)` pair.** `c ≤ a ↔ C ≤ A`,
+    completing the `≤` order trio for every pair of a hyperbolic triangle. -/
+theorem side_le_iff_angle_le_ca (t : HyperbolicTriangle) : t.c ≤ t.a ↔ t.C ≤ t.A :=
+  side_le_iff_angle_le_bc t.rotate
+
+/-- **Global side–angle order correspondence.** Sorting the angles sorts the sides the same
+    way: `A ≤ B ≤ C ⟹ a ≤ b ≤ c`, so the longest side lies opposite the largest angle and the
+    shortest opposite the smallest. The qualitative ordering matches the Euclidean law even
+    though hyperbolic sides are a strictly *decreasing* function of the opposite angle when the
+    other two are pinned (`side_antitone_in_angle`): the two facts are consistent because
+    reordering the angles also reindexes which side is "opposite". Assembles the three cyclic
+    non-strict order-equivalences. -/
+theorem sides_ordered_of_angles_ordered (t : HyperbolicTriangle)
+    (hAB : t.A ≤ t.B) (hBC : t.B ≤ t.C) : t.a ≤ t.b ∧ t.b ≤ t.c :=
+  ⟨(side_le_iff_angle_le t).mpr hAB, (side_le_iff_angle_le_bc t).mpr hBC⟩
+
 end HyperbolicAAA

--- a/src/data/proofs/law-of-cosines-oq-03-oq-03/meta.json
+++ b/src/data/proofs/law-of-cosines-oq-03-oq-03/meta.json
@@ -17,8 +17,8 @@
     ],
     "axiomCount": 0,
     "sorries": 0,
-    "lineCount": 1032,
-    "theoremCount": 62,
+    "lineCount": 1292,
+    "theoremCount": 71,
     "definitionCount": 4
   },
   "openQuestion": {

--- a/src/data/research/problems/law-of-cosines-oq-03-oq-03.json
+++ b/src/data/research/problems/law-of-cosines-oq-03-oq-03.json
@@ -13,7 +13,7 @@
   "significance": "AAA congruence is one of the sharpest qualitative differences between hyperbolic and Euclidean geometry, and underlies the rigidity of hyperbolic structures (Thurston). Completes the basic congruence theory alongside the parent law of cosines and sibling law of sines.",
   "currentState": "COMPLETED. Proved AAA congruence: the second law of cosines inverts to cosh c = (cos C + cos A cos B)/(sin A sin B), a function of the angles alone; injectivity of cosh on [0,∞) turns equal angles into equal sides. Also proved internal consistency (the defect A+B+C<π is exactly what makes the formula exceed 1) and the equilateral closed form cosh(side)=cos θ/(1-cos θ).",
   "knowledge": {
-    "progressSummary": "COMPLETE: AAA congruence + hyperbolic law of sines + realizability (defect condition is necessary AND sufficient; angles↦triangle is a bijection). 0 sorries, structure-encoded second-law assumptions only. | Session (researcher-1): completed the side-angle ORDER-EQUIVALENCE — added the converse direction (a<b ⟹ A<B, a=b ⟹ A=B) via a HyperbolicTriangle.swapAB relabeling (valid since the 3 second-law fields are A↔B symmetric), giving side_lt_iff_angle_lt / side_eq_iff_angle_eq. 0 sorry, 0 new axioms. UNVERIFIED (Docker infra down).",
+    "progressSummary": "COMPLETE: AAA congruence + hyperbolic law of sines + first law of cosines + realizability. 0 sorries, structure-encoded second-law assumptions only. | Session (researcher-10): CYCLIC-COMPLETED the side-angle order-equivalence to all three vertex pairs — added side_lt_iff_angle_lt_bc/_ca and side_le_iff_angle_le_bc/_ca (via the existing rotate relabeling, mirroring side_eq_iff_angle_eq_bc/_ca), and the capstone sides_ordered_of_angles_ordered (A<=B<=C => a<=b<=c: the global 'largest side opposite largest angle' law). 0 sorry, 0 new axioms, #print axioms = [propext, Classical.choice, Quot.sound].",
     "builtItems": [
       "LawOfCosinesOQ03OQ03.lean: hyperbolic AAA congruence (0 sorries, 7 structure-encoded axioms)",
       "HyperbolicTriangle: structure with sides a,b,c, angles A,B,C, side positivity, angle bounds, defect, and three second laws of cosines lawA/lawB/lawC",
@@ -28,7 +28,9 @@
       "angle_ineq (LawOfCosinesOQ03OQ03.lean Part 10): raw-real form sin A sin B < cos C + cos A cos B from 0<A,B,C and A+B+C<π; applied under cyclic permutations to bound all three inverted-side quotients above 1",
       "exists_triangle_of_defect (Part 10): constructs a HyperbolicTriangle from any A,B,C∈(0,π) with A+B+C<π, sides = arcosh of inverted second-law quotients (Real.cosh_arcosh, Real.arcosh_pos); laws proved by field_simp;ring",
       "exists_iff_defect + exists_equilateral (Part 10): full bijection characterization (realized ⟺ defect>0) and equilateral existence for every θ∈(0,π/3)",
-      "swapAB relabeling (A↔B, fixing C) + side_gt_of_angle_gt + angle_lt_of_side_lt + angle_eq_of_side_eq + side_lt_iff_angle_lt + side_eq_iff_angle_eq: the CONVERSE side↔angle ordering, completing the strict order-equivalence a<b ↔ A<B and a=b ↔ A=B. LawOfCosinesOQ03OQ03.lean."
+      "swapAB relabeling (A↔B, fixing C) + side_gt_of_angle_gt + angle_lt_of_side_lt + angle_eq_of_side_eq + side_lt_iff_angle_lt + side_eq_iff_angle_eq: the CONVERSE side↔angle ordering, completing the strict order-equivalence a<b ↔ A<B and a=b ↔ A=B. LawOfCosinesOQ03OQ03.lean.",
+      "side_lt_iff_angle_lt_bc/_ca + side_le_iff_angle_le_bc/_ca (LawOfCosinesOQ03OQ03.lean Part 12): cyclic completion of the strict and non-strict side-angle order-equivalence to the (b,c)/(B,C) and (c,a)/(C,A) pairs, each a one-line application of the (a,b) version to HyperbolicTriangle.rotate — the strict/non-strict analogue of the already-present isosceles trio side_eq_iff_angle_eq/_bc/_ca",
+      "sides_ordered_of_angles_ordered (Part 12 capstone): A<=B<=C => a<=b<=c, the GLOBAL side-angle ordering (longest side opposite largest angle), assembling the two cyclic non-strict order-equivalences (side_le_iff_angle_le + _bc)"
     ],
     "insights": [
       "The second law of cosines is linear in cosh of the opposite side, so it inverts algebraically — no Euclidean analogue, since the Euclidean law relates a side to the other two sides, not purely to angles.",
@@ -39,13 +41,14 @@
       "Angle-side monotonicity is a free corollary of the inversion: cosh c = (cos C + cos A cos B)/(sin A sin B) is strictly antitone in C over a fixed positive denominator, so a larger opposite angle forces a strictly shorter side — the reverse of the Euclidean larger-angle/longer-side law, and quantitative because the side is a definite function of the angles.",
       "Squaring the side-from-angle inversion cosh a=(cosA+cosBcosC)/(sinBsinC) and using sinh^2=cosh^2-1, the Pythagorean identities collapse (sinh a sinB sinC)^2 to the fully SYMMETRIC Gram numerator N = cos^2A+cos^2B+cos^2C+2cosAcosBcosC-1. Symmetry across a,b,c is exactly the law of sines: every side shares numerator N, so cancelling the common third sine gives sinh a sinB = sinh b sinA. The hyperbolic law of sines is thus a COROLLARY of the second law of cosines, no independent axiom needed.",
       "N >= 0 for free: it equals a real square (sinh a sinB sinC)^2, giving the triangle inequality-type constraint cos^2A+cos^2B+cos^2C+2cosAcosBcosC >= 1 on the angles of any hyperbolic triangle (gramNumerator_nonneg).",
-      "Realizability (converse of AAA): the angular-defect condition A+B+C<π is not just necessary but SUFFICIENT — every admissible angle triple is realized by an actual hyperbolic triangle. Key structural observation: the three second laws of cosines are DECOUPLED (the law at a vertex constrains only that vertex opposite side), so each side is constructed independently by inverting its own law via arcosh."
+      "Realizability (converse of AAA): the angular-defect condition A+B+C<π is not just necessary but SUFFICIENT — every admissible angle triple is realized by an actual hyperbolic triangle. Key structural observation: the three second laws of cosines are DECOUPLED (the law at a vertex constrains only that vertex opposite side), so each side is constructed independently by inverting its own law via arcosh.",
+      "The rotate cyclic relabeling turns the SINGLE proved order-equivalence a<b<->A<B into all six per-pair statements (strict/non-strict x 3 pairs) with one-line proofs, and those combine into the global sort A<=B<=C => a<=b<=c. This is consistent with side_antitone_in_angle (side strictly DECREASING in its opposite angle when the other two are fixed): sorting the angle triple also reindexes which side is 'opposite', so the qualitative Euclidean ordering survives while the pointwise dependence stays reversed."
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "Derive the FIRST law of cosines cosh c = cosh a cosh b - sinh a sinh b cos C from the second-law structure + the law of sines (dual identity closing the trig system)",
       "Formalize SAS and ASA hyperbolic congruence by inverting the angle-side system",
-      "Recover the area defect as an integral of the side-from-angle formulas"
+      "Recover the area defect as an integral / closed form of the side-from-angle formulas",
+      "Prove the reverse global ordering strictly: A<B<C => a<b<c (strict chain), and a full angle-sorted <-> side-sorted permutation equivalence"
     ]
   },
   "knownResults": [


### PR DESCRIPTION
## Hyperbolic AAA — cyclic completion of the side–angle order-equivalence

Extends the completed **Hyperbolic AAA Congruence** entry (`law-of-cosines-oq-03-oq-03`). The strict/non-strict side–angle order-equivalence `a < b ↔ A < B` and `a ≤ b ↔ A ≤ B` existed only for the `(a,b)/(A,B)` pair, while the *equality* version had already been cyclically completed to the other two pairs via the `rotate` relabeling. This PR closes that asymmetry and adds the global ordering.

### New theorems (Part XII)
- `side_lt_iff_angle_lt_bc` / `side_lt_iff_angle_lt_ca` — strict `b < c ↔ B < C`, `c < a ↔ C < A`, each a one-line application of the `(a,b)` version to `HyperbolicTriangle.rotate`.
- `side_le_iff_angle_le_bc` / `side_le_iff_angle_le_ca` — non-strict companions.
- `sides_ordered_of_angles_ordered` — **global ordering**: `A ≤ B ≤ C ⟹ a ≤ b ≤ c` (the longest side is opposite the largest angle), assembled from the cyclic `≤` versions.

This mirrors the existing isosceles trio `side_eq_iff_angle_eq/_bc/_ca`, so all three vertex pairs now carry the full `<`/`≤`/`=` order-equivalence. The global ordering is consistent with `side_antitone_in_angle` (a side strictly *decreases* in its opposite angle when the other two are pinned): sorting the angles also reindexes which side is "opposite", so the qualitative Euclidean ordering survives while the pointwise dependence stays reversed.

### Verification
- **0 sorries, 0 new axioms.** `#print axioms` for all five new theorems = `[propext, Classical.choice, Quot.sound]` — no `sorryAx`, no `ofReduceBool`.
- Structure-encoded second-law-of-cosines assumptions unchanged (still `axiomatized`).
- Verified via direct `lean` against prebuilt Mathlib v4.26.0 oleans. Docker build hits SIGBUS (exit 135) on this file — a container stack limit, not a proof error; the committed baseline fails identically.
- File: 1254 → 1292 lines, 71 theorems.

🤖 Generated with [Claude Code](https://claude.com/claude-code)