### PR TITLE
research(erdos-378): endpoint characterization and count bounds for squarefree binomials

### DIFF
--- a/proofs/Proofs/Erdos378Problem.lean
+++ b/proofs/Proofs/Erdos378Problem.lean
@@ -106,6 +106,62 @@ theorem binomialSquarefree_symm {n k : ℕ} (hk : k ≤ n) :
   unfold BinomialSquarefree
   rw [Nat.choose_symm hk]
 
+/-- **The first endpoint.** Since `C(n,1) = n`, the first interior binomial is
+squarefree exactly when `n` itself is squarefree. -/
+theorem binomialSquarefree_one_iff (n : ℕ) :
+    BinomialSquarefree n 1 ↔ Squarefree n := by
+  unfold BinomialSquarefree
+  rw [Nat.choose_one_right]
+
+/-- **The last endpoint.** Symmetrically, `C(n, n-1) = n`, so the last interior
+binomial (for `n ≥ 1`) is squarefree exactly when `n` is squarefree.  The two
+endpoints `k = 1` and `k = n-1` are the `k ↦ n-k` image pair of the involution. -/
+theorem binomialSquarefree_self_sub_one_iff {n : ℕ} (hn : 1 ≤ n) :
+    BinomialSquarefree n (n - 1) ↔ Squarefree n := by
+  rw [binomialSquarefree_symm (Nat.sub_le n 1), show n - (n - 1) = 1 from by omega]
+  exact binomialSquarefree_one_iff n
+
+/-- **Trivial upper bound.** The squarefree-binomial count of row `n` is at most
+`n - 1`, the number of interior indices `1 ≤ k < n`. -/
+theorem squarefreeCount_le (n : ℕ) : squarefreeCount n ≤ n - 1 := by
+  unfold squarefreeCount
+  have hsub : (range n).filter (fun k => 1 ≤ k ∧ Squarefree (n.choose k)) ⊆ Finset.Ioo 0 n := by
+    intro k hk
+    rw [Finset.mem_filter, Finset.mem_range] at hk
+    rw [Finset.mem_Ioo]
+    exact ⟨hk.2.1, hk.1⟩
+  calc _ ≤ (Finset.Ioo 0 n).card := Finset.card_le_card hsub
+    _ = n - 1 := by rw [Nat.card_Ioo]; omega
+
+/-- **Endpoint lower bound.** For squarefree `n ≥ 3`, both endpoints `k = 1` and
+`k = n-1` are distinct squarefree indices (both give `C(n,·) = n`), so row `n` has
+at least two squarefree binomials.  Combined with `squarefreeCount_even_of_odd`,
+an odd squarefree `n ≥ 3` therefore has an *even* count `≥ 2` — consistent with the
+Granville–Ramaré values `2m + 2`. -/
+theorem squarefreeCount_ge_two_of_squarefree {n : ℕ} (hn : 3 ≤ n) (hsf : Squarefree n) :
+    2 ≤ squarefreeCount n := by
+  unfold squarefreeCount
+  set S : Finset ℕ := (range n).filter (fun k => 1 ≤ k ∧ Squarefree (n.choose k)) with hS
+  have h1 : (1 : ℕ) ∈ S := by
+    rw [hS, Finset.mem_filter, Finset.mem_range]
+    refine ⟨by omega, le_refl 1, ?_⟩
+    rw [Nat.choose_one_right]; exact hsf
+  have h2 : (n - 1) ∈ S := by
+    rw [hS, Finset.mem_filter, Finset.mem_range]
+    refine ⟨by omega, by omega, ?_⟩
+    rw [show n.choose (n - 1) = n from by
+      rw [Nat.choose_symm (show (1 : ℕ) ≤ n by omega), Nat.choose_one_right]]
+    exact hsf
+  have hne : (1 : ℕ) ≠ n - 1 := by omega
+  have hpair : ({1, n - 1} : Finset ℕ) ⊆ S := by
+    intro x hx
+    simp only [Finset.mem_insert, Finset.mem_singleton] at hx
+    rcases hx with rfl | rfl
+    · exact h1
+    · exact h2
+  calc 2 = ({1, n - 1} : Finset ℕ).card := by rw [Finset.card_pair hne]
+    _ ≤ S.card := Finset.card_le_card hpair
+
 /-- **Parity theorem.** For odd `n`, the number of squarefree interior binomials
 in row `n` is even.
 

--- a/src/data/proofs/erdos-378/meta.json
+++ b/src/data/proofs/erdos-378/meta.json
@@ -163,9 +163,9 @@
       "Finset"
     ],
     "namespace": "Erdos378",
-    "lineCount": 637,
+    "lineCount": 779,
     "axiomCount": 2,
-    "theoremCount": 26,
+    "theoremCount": 30,
     "definitionCount": 8,
     "path": "Proofs/Erdos378Problem.lean",
     "sorries": 0,


### PR DESCRIPTION
## Summary

Adds four **axiom-free** structural facts to `Erdos378Problem.lean` (Erdős #378 — density of squarefree binomial coefficients). None depend on the file's two Granville–Ramaré analytic axioms; they sharpen the elementary combinatorics around `squarefreeCount`.

The two interior endpoints `k=1` and `k=n-1` both give `C(n,·) = n`, tying squarefreeness of the extreme binomials directly to squarefreeness of `n`:

| Theorem | Statement |
|---|---|
| `binomialSquarefree_one_iff` | `BinomialSquarefree n 1 ↔ Squarefree n` |
| `binomialSquarefree_self_sub_one_iff` | `BinomialSquarefree n (n-1) ↔ Squarefree n` (`n ≥ 1`, via `binomialSquarefree_symm`) |
| `squarefreeCount_le` | `squarefreeCount n ≤ n - 1` |
| `squarefreeCount_ge_two_of_squarefree` | squarefree `n ≥ 3` ⇒ `squarefreeCount n ≥ 2` |

**Connection to the answer.** The two endpoints are the `k ↦ n-k` image pair of the file's involution. For a squarefree `n ≥ 3` they are distinct and both squarefree, so `squarefreeCount n ≥ 2`; combined with `squarefreeCount_even_of_odd`, an odd squarefree `n ≥ 3` has an *even* count `≥ 2` — exactly the shape `2m + 2` of the Granville–Ramaré values.

Also syncs `leanFile` metadata: `theoremCount` 26→30, `lineCount` 637→779 (`axiomCount` unchanged at 2).

## Verification

VERIFIED **axiom-free** — `#print axioms` reports only `propext` (and `Classical.choice, Quot.sound`) for the new theorems, with **no dependence on the file's `granville_ramare_density_exists` / `complement_density` axioms**. The **entire file** (26 prior + 4 new theorems, incl. the density theory) elaborated end-to-end under lean 4.26.0 against the prebuilt Mathlib oleans via narrow-import substitution (the full `import Mathlib` olean cache is incomplete locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)