### PR TITLE
Enrich basel-problem-oq-12: 3->4 sections (separate ζ(6) theorem from corollaries)

### DIFF
--- a/src/data/proofs/basel-problem-oq-12/meta.json
+++ b/src/data/proofs/basel-problem-oq-12/meta.json
@@ -85,18 +85,26 @@
     {
       "id": "bernoulli-six",
       "title": "The Bernoulli Number B₆ = 1/42",
-      "startLine": 41,
-      "endLine": 56,
-      "summary": "bernoulli'_six and bernoulli_six: compute B₆ = 1/42 from the recurrence bernoulli'_def, the one value Mathlib's explicit table omits.",
-      "mathContext": "Expands the order-6 Bernoulli recurrence; the odd term B₅ vanishes by bernoulli'_eq_zero_of_odd, leaving an inner sum of 41/42."
+      "startLine": 37,
+      "endLine": 57,
+      "summary": "bernoulli'_six computes B₆ = 1/42 from the defining recurrence bernoulli'_def (the odd term B₅ vanishes by bernoulli'_eq_zero_of_odd, leaving an inner sum of 41/42); bernoulli_six transfers it to the signed bernoulli 6 via bernoulli_eq_bernoulli'_of_ne_one. This is the one value Mathlib's explicit table (which stops at bernoulli'_four) omits — the genuine new content of the entry.",
+      "mathContext": "$B_6 = 1 - \\sum_{k<6}\\binom{6}{k}\\frac{B_k}{6-k+1} = 1 - \\frac{41}{42} = \\frac{1}{42}$."
     },
     {
       "id": "zeta-six",
       "title": "ζ(6) = π⁶/945",
-      "startLine": 58,
+      "startLine": 59,
+      "endLine": 67,
+      "summary": "hasSum_zeta_six: the sixth-power zeta value as a HasSum, obtained by specialising Euler's general formula hasSum_zeta_nat at k = 3 and plugging in bernoulli 6 = 1/42, then evaluating the rational coefficient 32/(42·720) = 1/945 by norm_num + ring.",
+      "mathContext": "$\\zeta(6) = (-1)^4\\,2^5\\,\\pi^6\\,B_6/6! = 32\\pi^6(1/42)/720 = \\pi^6/945$."
+    },
+    {
+      "id": "corollaries",
+      "title": "Summability and tsum Corollaries",
+      "startLine": 69,
       "endLine": 76,
-      "summary": "hasSum_zeta_six, summable_zeta_six, tsum_zeta_six: the sixth-power zeta value via hasSum_zeta_nat at k = 3 with B₆ = 1/42.",
-      "mathContext": "Specialises Euler's general zeta formula and evaluates the resulting rational coefficient 32/(42·720) = 1/945."
+      "summary": "summable_zeta_six and tsum_zeta_six: the standard consequences of the HasSum statement — summability of ∑ 1/n⁶ over ℝ, and the tsum form ∑' n, 1/n⁶ = π⁶/945 — obtained directly from hasSum_zeta_six via .summable and .tsum_eq.",
+      "mathContext": "$\\sum'_{n} n^{-6} = \\pi^6/945$."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
Enrichment pass for `basel-problem-oq-12` (The Sixth-Power Zeta Value ζ(6)=π⁶/945).

## Quality improvements
- **Sections 3->4**: the 'ζ(6) = π⁶/945' section (lines 58-76) bundled the main theorem `hasSum_zeta_six` with its two trivial corollaries. Split into the main ζ(6) theorem (59-67) and a Summability/tsum corollaries section (`summable_zeta_six`, `tsum_zeta_six`, 69-76).
- Aligned the B₆ section to cover both `bernoulli'_six` and `bernoulli_six` (37-57).
- The 4 sections now cover the full 77-line file with declaration-aligned boundaries.

## Accuracy verification
- All 4 `mathlibDependencies` module paths verified: `hasSum_zeta_nat`@NumberTheory/ZetaValues, and `bernoulli'_def` / `bernoulli'_eq_zero_of_odd` / `bernoulli_eq_bernoulli'_of_ne_one`@NumberTheory/Bernoulli.
- Metadata counts (77L / 5 thm / 0 def / 0 axiom / 0 sorry) match the Lean source; within all size guardrails.