### PR TITLE
research(tetrahedral-oq-01): cross-absorption identity + strictly-increasing central diagonal (0-axiom)

### DIFF
--- a/proofs/Proofs/TetrahedralNumberFormulaOQ01Absorption.lean
+++ b/proofs/Proofs/TetrahedralNumberFormulaOQ01Absorption.lean
@@ -121,4 +121,38 @@ theorem four_pow_le_two_mul_diag {d : ℕ} (hd : 0 < d) :
   rw [simplexNumber_diag_eq_centralBinom d]
   exact Nat.four_pow_le_two_mul_self_mul_centralBinom d hd
 
+/-- **Cross absorption — raising the dimension vs. raising the size.**  Both single-step
+absorptions (`simplexNumber_absorption`, `simplexNumber_size_absorption`) equal
+`(n+d+1)·P_d(n)`, so raising the *dimension* and raising the *size* are related by a swap
+of the two weights:
+
+`(d+1) · P_{d+1}(n) = (n+1) · P_d(n+1)`.
+
+Equivalently `P_{d+1}(n)/P_d(n+1) = (n+1)/(d+1)` — the reflection symmetry `P_d(n) = P_n(d)`
+made multiplicative. This is the diagonal-independent identity tying the two absorption
+recurrences together; it specialises (at fixed small `n`) to the classical
+triangular↔tetrahedral column relations. -/
+theorem simplexNumber_dim_size_absorption (d n : ℕ) :
+    (d + 1) * simplexNumber (d + 1) n = (n + 1) * simplexNumber d (n + 1) := by
+  rw [← simplexNumber_absorption d n]
+  exact simplexNumber_size_absorption d n
+
+/-- **The central simplex diagonal is strictly increasing.**  `d ↦ P_d(d) = C(2d, d)` is a
+`StrictMono` function of `d`.  From the diagonal doubling recurrence
+`(d+1)·P_{d+1}(d+1) = 2(2d+1)·P_d(d)` (`simplexNumber_diag_succ`): since `2(2d+1) > d+1` and
+`P_d(d) > 0`, we get `(d+1)·P_d(d) < (d+1)·P_{d+1}(d+1)`, and cancelling `d+1` gives
+`P_d(d) < P_{d+1}(d+1)`.  So the central binomial coefficients `C(2d,d)` strictly increase —
+the monotone spine underlying their `4^d/√(πd)` growth. -/
+theorem simplexNumber_diag_strictMono :
+    StrictMono (fun d => simplexNumber d d) := by
+  apply strictMono_nat_of_lt_succ
+  intro d
+  show simplexNumber d d < simplexNumber (d + 1) (d + 1)
+  have hrec := simplexNumber_diag_succ d
+  have hpos : 0 < simplexNumber d d := simplexNumber_pos d d
+  have hmul : (d + 1) * simplexNumber d d < 2 * (2 * d + 1) * simplexNumber d d := by
+    have h := Nat.mul_pos (show 0 < 3 * d + 1 by omega) hpos
+    nlinarith [h]
+  exact lt_of_mul_lt_mul_left (hmul.trans_eq hrec.symm) (Nat.zero_le _)
+
 end TetrahedralNumberFormulaOQ01


### PR DESCRIPTION
## Summary

Two verified, 0-axiom additions to the simplex-number absorption companion (`TetrahedralNumberFormulaOQ01Absorption.lean`), which develops the multiplicative (absorption / column) structure of the figurate numbers `P_d(n) = C(n+d, d)`:

- **`simplexNumber_dim_size_absorption`** — `(d+1)·P_{d+1}(n) = (n+1)·P_d(n+1)`. Both single-step absorptions (`simplexNumber_absorption`, `simplexNumber_size_absorption`) equal `(n+d+1)·P_d(n)`, so raising the *dimension* and raising the *size* are related by swapping the `(d+1)/(n+1)` weights — the reflection symmetry `P_d(n) = P_n(d)` made multiplicative, tying the two absorption recurrences together.
- **`simplexNumber_diag_strictMono`** — `d ↦ P_d(d) = C(2d, d)` is `StrictMono`. From the diagonal doubling recurrence `(d+1)·P_{d+1}(d+1) = 2(2d+1)·P_d(d)` (`simplexNumber_diag_succ`): `2(2d+1) > d+1` and `P_d(d) > 0` give `(d+1)·P_d(d) < (d+1)·P_{d+1}(d+1)`; cancelling `d+1` yields `P_d(d) < P_{d+1}(d+1)`. So the central binomials `C(2d,d)` strictly increase — the monotone spine of their `4^d/√(πd)` growth.

## Verification

- Both theorems verified **green (3061 jobs)** in a minimal-import build (`Proofs.TetrahedralNumberFormulaOQ01` + `Mathlib.Tactic.Linarith`) that reproduces the prerequisite absorption lemmas and the exact new proof terms. The Absorption file itself uses `import Mathlib`, which in the current sandbox intermittently hits a corrupted-cache/SIGBUS during heavy-module loading — an environment issue, not a proof error.
- This is a research-variant file not tracked in the gallery `meta.json` (which describes only the base `TetrahedralNumberFormula.lean`), so no gallery metadata changes are needed. Still 0 axioms, 0 sorries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)