### PR TITLE
Fix duplicate annotation IDs in 5 gallery entries

### DIFF
--- a/src/data/proofs/chebyshev-bounds-oq-04-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/chebyshev-bounds-oq-04-oq-01-oq-01/annotations.json
@@ -24,28 +24,6 @@
     ]
   },
   {
-    "id": "cb04oq0101-setup",
-    "proofId": "chebyshev-bounds-oq-04-oq-01-oq-01",
-    "range": {
-      "startLine": 94,
-      "endLine": 105
-    },
-    "type": "insight",
-    "title": "Imports, Options & the ArithmeticFunction Namespace",
-    "content": "The setup block pulls in all of Mathlib (`import Mathlib`) — appropriate for a gallery proof that needs the `ArithmeticFunction` convolution API — and raises two resource limits: `maxHeartbeats 1000000` and `maxRecDepth 4000`, anticipating the heavier elaboration of the divisor-sum rewrites. `autoImplicit false` enforces explicit binders (a correctness-hygiene choice), and `linter.all false` silences style lints on this batch-derived file.\n\nThe three `open`s are what make the proof readable: `open scoped BigOperators` for the `∑` notation, `open ArithmeticFunction` to use `coe_mul_zeta_apply`, `moebius_mul_coe_zeta`, and `one_apply` unqualified, and `open scoped ArithmeticFunction.Moebius` to write `μ` for `ArithmeticFunction.moebius`. Without the Moebius scope the theorem statement could not use the bare `μ`.",
-    "mathContext": "`open scoped ArithmeticFunction.Moebius` binds `μ = ` `ArithmeticFunction.moebius : ArithmeticFunction ℤ`; the convolution lemmas live in the `ArithmeticFunction` namespace.",
-    "significance": "supporting",
-    "prerequisites": [
-      "Lean 4 imports, set_option, and scoped notation",
-      "ArithmeticFunction namespace"
-    ],
-    "relatedConcepts": [
-      "scoped notation",
-      "maxHeartbeats / maxRecDepth",
-      "ArithmeticFunction.moebius"
-    ]
-  },
-  {
     "id": "cb04oq0101-theorem",
     "proofId": "chebyshev-bounds-oq-04-oq-01-oq-01",
     "range": {

--- a/src/data/proofs/erdos-929/annotations.json
+++ b/src/data/proofs/erdos-929/annotations.json
@@ -293,7 +293,7 @@
     ]
   },
   {
-    "id": "erdos-929-ann-density",
+    "id": "erdos-929-ann-density-machinery",
     "proofId": "erdos-929",
     "range": {
       "startLine": 100,
@@ -339,7 +339,7 @@
     ]
   },
   {
-    "id": "erdos-929-ann-threshold",
+    "id": "erdos-929-ann-threshold-bounds",
     "proofId": "erdos-929",
     "range": {
       "startLine": 227,

--- a/src/data/proofs/mantel-theorem-oq-01/annotations.json
+++ b/src/data/proofs/mantel-theorem-oq-01/annotations.json
@@ -2,26 +2,25 @@
   {
     "id": "mantel-oq01-ann-import",
     "proofId": "mantel-theorem-oq-01",
-    "range": { "startLine": 1, "endLine": 5 },
+    "range": {
+      "startLine": 1,
+      "endLine": 5
+    },
     "type": "concept",
     "title": "A Single `import Mathlib`: Standing on Brandt's Theorem",
     "content": "The file imports all of Mathlib for one reason: it needs SimpleGraph.colorable_of_cliqueFree_lt_minDegree, which lives in Mathlib.Combinatorics.SimpleGraph.FiveWheelLike and encodes Stephan Brandt's proof of the general Andrásfai–Erdős–Sós colorability theorem. Because the heavy structural work is already upstream, the entry's own contribution is deliberately thin — a numeral specialization and its contrapositive — and carries no new axioms or sorries.",
     "mathContext": "Brandt (general AES): a $K_{r+1}$-free graph with $\\frac{(3r-4)n}{3r-1} < \\delta(G)$ is $r$-colorable.",
     "significance": "supporting",
-    "relatedConcepts": ["Mathlib", "FiveWheelLike", "Andrásfai–Erdős–Sós theorem", "graph colorability"],
-    "prerequisites": ["simple graphs", "clique-free graphs"]
-  },
-  {
-    "id": "mantel-oq01-ann-setup",
-    "proofId": "mantel-theorem-oq-01",
-    "range": { "startLine": 44, "endLine": 48 },
-    "type": "concept",
-    "title": "Ambient Setup: Finite Graphs with Decidable Adjacency",
-    "content": "The variable block fixes a finite vertex type V with a graph G whose adjacency relation is decidable: [Fintype V] (G : SimpleGraph V) [DecidableRel G.Adj]. These are exactly the typeclass assumptions under which G.minDegree is well-defined (a minimum over the finite set of vertex degrees) and G.CliqueFree 3 is a meaningful finite condition. Stating the lemmas at this generality — rather than over a concrete Fin n — keeps them drop-in usable for whatever survivor subgraph the degree-cleaning step produces.",
-    "mathContext": "$\\delta(G) = \\min_{v \\in V} \\deg(v)$, defined for finite $V$ with decidable $\\mathrm{Adj}$.",
-    "significance": "supporting",
-    "relatedConcepts": ["minimum degree", "Fintype", "DecidableRel", "finite graphs"],
-    "prerequisites": ["typeclasses", "SimpleGraph.minDegree"]
+    "relatedConcepts": [
+      "Mathlib",
+      "FiveWheelLike",
+      "Andrásfai–Erdős–Sós theorem",
+      "graph colorability"
+    ],
+    "prerequisites": [
+      "simple graphs",
+      "clique-free graphs"
+    ]
   },
   {
     "id": "mantel-oq01-ann-docstring",

--- a/src/data/proofs/newton-power-sum-identities-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/newton-power-sum-identities-oq-01-oq-01/annotations.json
@@ -30,34 +30,22 @@
       "startLine": 39,
       "endLine": 43
     },
-    "type": "technique",
-    "title": "The ambient setting and the reusable unrolling recipe",
-    "content": "`variable (σ : Type*) (R : Type*) [CommRing R] [Fintype σ]` fixes the generality for all seven lemmas: an arbitrary commutative ring R and any finite index type σ, with no stronger hypothesis. The degree-4 and degree-5 proofs then reuse — at larger index sets — the same four-step recipe that settled degrees 2 and 3: (1) apply `psum_eq_mul_esymm_sub_sum` at the target k; (2) rewrite the recurrence's inner index set {a ∈ antidiagonal k | 0 < a.1 < k} to an explicit finite set via an `omega`-proved `ext` lemma; (3) collapse the finite sum with `Finset.sum_insert`/`sum_pair`/`sum_singleton`; (4) substitute the already-proved lower-degree identities and close with `push_cast; ring`. Only steps (2)–(3) grow with k — {(1,3),(2,2),(3,1)} for k=4 and {(1,4),(2,3),(3,2),(4,1)} for k=5 — so the method is purely mechanical to continue.",
-    "mathContext": "For fixed k the recurrence's inner sum $\\sum_{0<i<k}(-1)^i e_i\\,p_{k-i}$ is finite; the only per-degree work is enumerating $\\{(i,k-i):0<i<k\\}$, a linear-arithmetic fact `omega` settles, after which `ring` over the bare `CommRing` discharges the algebra.",
-    "significance": "key",
-    "relatedConcepts": [
-      "MvPolynomial over a commutative ring",
-      "Fintype index type",
-      "proof-by-recurrence-unrolling",
-      "omega + ring"
-    ],
-    "prerequisites": [
-      "Lean variable / instance binders",
-      "the Newton recurrence psum_eq_mul_esymm_sub_sum",
-      "Finset.antidiagonal enumeration"
-    ]
-  },
-  {
-    "id": "newton-ps-oq0101-setup",
-    "proofId": "newton-power-sum-identities-oq-01-oq-01",
-    "range": { "startLine": 39, "endLine": 43 },
     "type": "concept",
     "title": "Universality: identities in MvPolynomial σ R for any finite σ, any commutative ring",
     "content": "`variable (σ : Type*) (R : Type*) [CommRing R] [Fintype σ]` fixes the maximal generality. The results are proven inside the polynomial ring `MvPolynomial σ R`, so they are *universal symmetric-function identities* — one formula that holds no matter how the variables Xᵢ are later specialized, over any commutative ring (no field, no characteristic-zero hypothesis, and no invertibility of the integer coefficients 2, 4, 5 is required, since the recurrence produces them by repeated addition rather than division). Only `CommRing` and `Fintype σ` are assumed; the finiteness of σ makes the sums pₖ = ∑ᵢ Xᵢᵏ and eⱼ well-defined. When `card σ < k`, the elementary symmetric polynomial eₖ is the empty sum 0, so the higher terms silently vanish and the identities degenerate correctly (a single variable ⇒ p₄ = e₁⁴, p₅ = e₁⁵). This universality is exactly why the same statement specializes to the root-power relations of a quartic or quintic and to the trace-power/coefficient conversion of 4×4 and 5×5 matrices.",
     "mathContext": "$p_k,\\,e_j \\in \\mathrm{MvPolynomial}\\,\\sigma\\,R,\\quad R\\ \\text{any CommRing},\\ \\sigma\\ \\text{finite};\\ \\ \\mathrm{card}\\,\\sigma < k \\Rightarrow e_k = 0$",
     "significance": "supporting",
-    "relatedConcepts": ["MvPolynomial", "symmetric function identity", "commutative ring generality", "esymm vanishing"],
-    "prerequisites": ["MvPolynomial", "Fintype", "elementary symmetric polynomial"]
+    "relatedConcepts": [
+      "MvPolynomial",
+      "symmetric function identity",
+      "commutative ring generality",
+      "esymm vanishing"
+    ],
+    "prerequisites": [
+      "MvPolynomial",
+      "Fintype",
+      "elementary symmetric polynomial"
+    ]
   },
   {
     "id": "newton-ps-oq0101-deg123",

--- a/src/data/proofs/urysohns-lemma-oq-01-oq-01-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/urysohns-lemma-oq-01-oq-01-oq-02-oq-01/annotations.json
@@ -49,28 +49,6 @@
     ]
   },
   {
-    "id": "ann-unit-interval",
-    "proofId": "urysohns-lemma-oq-01-oq-01-oq-02-oq-01",
-    "range": {
-      "startLine": 98,
-      "endLine": 105
-    },
-    "type": "theorem",
-    "title": "tietze_extension_unitInterval — the [0,1] Specialisation",
-    "content": "`tietze_extension_unitInterval` is the `a = 0, b = 1` instance of `tietze_extension_Icc`, proved in a single line: `tietze_extension_Icc hs f (by norm_num) hf`, where `norm_num` discharges `0 ≤ 1`. This `[0,1]`-valued form is the workhorse behind *partitions of unity*: given a locally finite cover, one extends each bump function from a closed piece to a continuous `[0,1]`-valued function on the whole space, then normalises the sum to `1`. Isolating it as a named lemma makes the downstream partition-of-unity construction read directly, and records that the gallery's hand-built Urysohn series — not Mathlib's `TietzeExtension` — is sufficient for this canonical application.",
-    "mathContext": "$0 \\le f \\le 1 \\ \\Rightarrow\\ \\exists\\,G,\\ G|_s = f \\ \\wedge\\ 0 \\le G \\le 1.$",
-    "significance": "supporting",
-    "relatedConcepts": [
-      "unit interval [0,1]",
-      "partitions of unity",
-      "bump functions",
-      "specialisation of a general lemma"
-    ],
-    "prerequisites": [
-      "tietze_extension_Icc"
-    ]
-  },
-  {
     "id": "ann-pi-sup",
     "proofId": "urysohns-lemma-oq-01-oq-01-oq-02-oq-01",
     "range": {


### PR DESCRIPTION
**Data-integrity fix.** A gallery-wide scan of all 4801 `annotations.json` files found 6 entries containing two annotation objects that share a single `id` — which breaks annotation id uniqueness (duplicate React keys, ambiguous id lookup). One (abel-ruffini-galois-extensions-oq-02-oq-01) is handled separately in #38039; this PR fixes the remaining 5.

Two root causes, two fixes:

**Accidental id collision on distinct annotations → rename (preserve both):**
- `erdos-929`: `erdos-929-ann-density` named two different annotations (ranges 45–49 and 100–127); `erdos-929-ann-threshold` likewise (51–56 and 227–281). Renamed the second of each pair to `erdos-929-ann-density-machinery` / `erdos-929-ann-threshold-bounds`. No content lost.

**Redundant near-duplicate at the same range → keep the richer, drop the other:**
- `newton-power-sum-identities-oq-01-oq-01` (`newton-ps-oq0101-setup`, both at 39–43)
- `mantel-theorem-oq-01` (`mantel-oq01-ann-setup`, both at 44–48)
- `urysohns-lemma-oq-01-oq-01-oq-02-oq-01` (`ann-unit-interval`, both at 98–105)
- `chebyshev-bounds-oq-04-oq-01-oq-01` (`cb04oq0101-setup`, both at 94–105/106)

Each of these had two annotations describing the same lines; kept the longer/more-informative one and removed the redundant copy.

**Verification:** post-fix scan shows 0 duplicate ids in all 5 files; every annotation retains required schema fields (id, proofId, range, type, title, content); `scripts/annotations/build.ts` completes without new errors. (Some diff churn is json normalization of inline arrays — content unchanged.)