### PR TITLE
Enrich basel-problem-oq-15: 4->5 sections (separate real series from analytic ζ)

### DIFF
--- a/src/data/proofs/basel-problem-oq-15/meta.json
+++ b/src/data/proofs/basel-problem-oq-15/meta.json
@@ -100,11 +100,19 @@
     },
     {
       "id": "zeta-eight",
-      "title": "The Value ζ(8) = π⁸/9450",
+      "title": "The Value ζ(8) = π⁸/9450 (Real Series)",
       "startLine": 56,
+      "endLine": 66,
+      "summary": "hasSum_one_div_nat_pow_eight (HasSum form of the real series, the k = 4 instance of hasSum_zeta_nat with B₈ = −1/30) and tsum_one_div_nat_pow_eight, the headline value ∑' n, 1/n⁸ = π⁸/9450 as a real tsum.",
+      "mathContext": "$\\sum_{n=1}^\\infty 1/n^8 = \\pi^8/9450$, from Mathlib's `hasSum_zeta_nat` at k = 4."
+    },
+    {
+      "id": "riemann-zeta-eight",
+      "title": "The Analytically-Continued ζ(8) over ℂ",
+      "startLine": 68,
       "endLine": 80,
-      "summary": "hasSum_one_div_nat_pow_eight (HasSum form), tsum_one_div_nat_pow_eight (the headline tsum value ∑' n, 1/n⁸ = π⁸/9450), and riemannZeta_eight_eq (the riemannZeta 8 value over ℂ).",
-      "mathContext": "$\\sum_{n=1}^\\infty 1/n^8 = \\pi^8/9450$ and $\\zeta(8) = \\pi^8/9450$, from Mathlib's `hasSum_zeta_nat` and `riemannZeta_two_mul_nat` at k = 4."
+      "summary": "riemannZeta_eight_eq: the analytically-continued Riemann zeta function riemannZeta 8 = π⁸/9450 over ℂ, via Mathlib's riemannZeta_two_mul_nat at k = 4 — the complex-analytic object, distinct from the real tsum but sharing the same value at the integer 8.",
+      "mathContext": "$\\zeta(8) = \\pi^8/9450$ as the value of the analytically-continued $\\zeta : \\mathbb{C} \\to \\mathbb{C}$ at $8$."
     },
     {
       "id": "ratio",


### PR DESCRIPTION
Enrichment pass for `basel-problem-oq-15` (ζ(8)=π⁸/9450 and the π-free ratio).

## Quality improvements
- **Sections 4->5**: the 'The Value ζ(8)' section (lines 56-80) bundled the real series (`hasSum_one_div_nat_pow_eight`, `tsum_one_div_nat_pow_eight`) with the analytically-continued `riemannZeta 8` over ℂ — a genuinely distinct object (Mathlib's `riemannZeta` is the complex analytic continuation). Split into a real-series section (56-66) and an analytic-continuation section (68-80), matching the existing per-declaration annotations.
- The 5 sections now cover the full 90-line file with declaration-aligned boundaries.

## Accuracy verification
- All 5 `mathlibDependencies` verified: `hasSum_zeta_nat` / `hasSum_zeta_two`@NumberTheory/ZetaValues, `riemannZeta_two_mul_nat`@NumberTheory/LSeries/HurwitzZetaValues, `bernoulli'_def` / `bernoulli'_eq_zero_of_odd`@NumberTheory/Bernoulli.
- Metadata counts (90L / 5 thm / 0 def / 0 axiom / 0 sorry) match the Lean source; within all size guardrails.