### PR TITLE
Research: erdos-897-oq-01 — positive-affine invariance of the unbounded-on-prime-powers class

### DIFF
--- a/proofs/Proofs/Erdos897OQ01.lean
+++ b/proofs/Proofs/Erdos897OQ01.lean
@@ -695,4 +695,47 @@ theorem not_unboundedOnPrimePowers_min_right {f g : ℕ → ℝ}
     ¬ UnboundedOnPrimePowers (fun n => min (f n) (g n)) :=
   not_unboundedOnPrimePowers_of_le hg (fun _ _ _ _ => min_le_right _ _)
 
+/-
+## Positive-affine invariance of the unbounded-on-prime-powers class
+
+`unboundedOnPrimePowers_add_bddBelow` shows the class is insensitive to any
+bounded-below perturbation.  The following record the exact algebraic invariance this
+gives: the class is preserved by *subtracting* anything bounded above (the mirror of
+`add_bddBelow`), by adding any constant, and — combining with the positive scaling
+`unboundedOnPrimePowers_smul` — by every strictly-positive affine map `f ↦ c·f + d`
+(`c > 0`).  So the Erdős #897 hypothesis is a property of `f` modulo the positive-affine
+group, exactly as one expects of an "unbounded ratio to `log`" condition.
+-/
+
+/-- **Closure under subtracting a function bounded above on prime powers** (mirror of
+`unboundedOnPrimePowers_add_bddBelow`).  If `f` is unbounded on prime powers and `g` has a
+ceiling `g(p^k) ≤ C` at every prime power, then `f − g` is still unbounded on prime powers:
+`f − g ≥ f − C`, and subtracting a constant cannot spoil the unbounded ratio.  The dual of
+the bounded-below closure, obtained from it via `g ↦ −g`. -/
+theorem unboundedOnPrimePowers_sub_bddAbove {f g : ℕ → ℝ} {C : ℝ} (hC : 0 ≤ C)
+    (hf : UnboundedOnPrimePowers f)
+    (hg : ∀ p k : ℕ, p.Prime → 1 ≤ k → g (p ^ k) ≤ C) :
+    UnboundedOnPrimePowers (fun n => f n - g n) := by
+  have h := unboundedOnPrimePowers_add_bddBelow (C := C) hC hf (g := fun n => - g n)
+    (fun p k hp hk => by show -C ≤ - g (p ^ k); linarith [hg p k hp hk])
+  simpa [sub_eq_add_neg] using h
+
+/-- **Closure under an additive constant.**  `f` unbounded on prime powers ⟹ `f + c` is,
+for every real `c` (positive or negative).  The `g ≡ c` case of
+`unboundedOnPrimePowers_add_bddBelow` with floor `−|c| ≤ c`: a constant shift never changes
+whether `f(p^k)/log(p^k)` is unbounded. -/
+theorem unboundedOnPrimePowers_add_const {f : ℕ → ℝ} (hf : UnboundedOnPrimePowers f)
+    (c : ℝ) : UnboundedOnPrimePowers (fun n => f n + c) :=
+  unboundedOnPrimePowers_add_bddBelow (C := |c|) (abs_nonneg c) hf
+    (fun _ _ _ _ => neg_abs_le c)
+
+/-- **Positive-affine invariance.**  For `c > 0` and any `d`, `f` unbounded on prime powers
+⟹ `c·f + d` is.  Combining positive scaling (`unboundedOnPrimePowers_smul`) with the
+constant shift (`unboundedOnPrimePowers_add_const`): the Erdős #897 hypothesis depends on
+`f` only through its class under the strictly-positive affine group `f ↦ c·f + d`, `c > 0`.
+So a witness may be normalized (`c = 1`, `d = 0`) without loss of generality. -/
+theorem unboundedOnPrimePowers_affine {f : ℕ → ℝ} (hf : UnboundedOnPrimePowers f)
+    {c d : ℝ} (hc : 0 < c) : UnboundedOnPrimePowers (fun n => c * f n + d) :=
+  unboundedOnPrimePowers_add_const (unboundedOnPrimePowers_smul hf hc) d
+
 end Erdos897

--- a/src/data/proofs/erdos-897-oq-01/meta.json
+++ b/src/data/proofs/erdos-897-oq-01/meta.json
@@ -55,9 +55,9 @@
       "not_unboundedOnPrimePowers_add / _min_left / _min_right: PROVED the MEET (min) and ADDITIVE closure of the failing class, completing the lattice picture. The O(log)-on-prime-powers functions form a genuine order IDEAL — closed under max of two AND min with any function — that is additionally an additive convex cone (f ≤ Mf·log, g ≤ Mg·log ⟹ f+g ≤ (Mf+Mg)·log, no sign input needed). Dual to the filter side, which is only join-closed (never meet-closed). Axiom-free."
     ],
     "axiomCount": 0,
-    "lineCount": 650,
+    "lineCount": 741,
     "assumptions": "None. Fully machine-checked with 0 axioms and 0 sorries; proofs use no native_decide (so #print axioms shows only propext/Classical.choice/Quot.sound). Part I of Erdős #897 — whether the prime-power growth hypothesis forces limsup_n (f(n+1)-f(n))/log n = ∞ — remains OPEN and is NOT asserted; this entry proves only the verified surrounding theory (non-vacuity, selectivity, plain unboundedness, and the strongly-additive reduction).",
-    "theoremCount": 29,
+    "theoremCount": 37,
     "definitionCount": 1
   },
   "overview": {
@@ -131,11 +131,11 @@
       "Finset"
     ],
     "namespace": "Erdos897",
-    "lineCount": 650,
+    "lineCount": 741,
     "axiomCount": 0,
     "sorries": 0,
     "definitionCount": 1,
-    "theoremCount": 31
+    "theoremCount": 37
   },
   "crossReferences": [
     {


### PR DESCRIPTION
## Summary

Extends `Erdos897OQ01.lean` (the algebra of the Erdős #897 hypothesis `UnboundedOnPrimePowers f` — `f(pᵏ)/log(pᵏ)` unbounded). The file already proves closure under bounded-below perturbation (`unboundedOnPrimePowers_add_bddBelow`) and positive scaling. This records the exact invariance those give.

## New theorems (axiom-free)

- **`unboundedOnPrimePowers_sub_bddAbove`** — the mirror of `add_bddBelow`: if `f` is UOPP and `g` has a ceiling `g(pᵏ) ≤ C` on prime powers, then `f − g` is UOPP (`f − g ≥ f − C`). Obtained from the bounded-below closure via `g ↦ −g`.
- **`unboundedOnPrimePowers_add_const`** — `f` UOPP ⟹ `f + c` UOPP for every real `c` (the `g ≡ c` case, floor `−|c| ≤ c`).
- **`unboundedOnPrimePowers_affine`** — for `c > 0`, `f` UOPP ⟹ `c·f + d` UOPP. Combining positive scaling with the constant shift: the hypothesis depends on `f` only modulo the strictly-positive affine group `f ↦ c·f + d`, so a witness normalizes to `c = 1, d = 0`.

Second visit (prior PR #37944 added `not_unboundedOnPrimePowers_smul`). 34 → 37 theorems.

## Verification

- `./proofs/scripts/docker-build.sh Proofs.Erdos897OQ01` → **succeeds** (7744 jobs, 5.2s).
- `#print axioms` on `unboundedOnPrimePowers_affine` and `unboundedOnPrimePowers_sub_bddAbove`: `[propext, Classical.choice, Quot.sound]` — **axiom-free**, no `sorry`.
- `meta.json` counts refreshed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)