### PR TITLE
research(hilbert-17-oq-03): constructive Artin certificate for whole Motzkin PSD family

### DIFF
--- a/proofs/Proofs/Hilbert17OQ03OQ05.lean
+++ b/proofs/Proofs/Hilbert17OQ03OQ05.lean
@@ -527,7 +527,93 @@ theorem motzkinFun_posDef_iff (c : ℝ) :
   · intro hc x y
     exact motzkinFun_pos_of_lt_three hc x y
 
+/-! ## Constructive Artin certificate for the whole PSD family (rational SOS)
+
+`motzkinPoly_psd_not_sos` shows every `0 < c ≤ 3` member is PSD but *not* a
+polynomial sum of squares.  Artin's theorem nevertheless guarantees each is a sum
+of squares of *rational functions*.  Here we make that constructive **uniformly
+across the entire PSD segment** `c ≤ 3`, extending the classical single-`c = 3`
+Motzkin certificate (`Hilbert17MotzkinRationalSOS`) to the whole family.
+
+The multiplier `g = 4 + 4x² + 4y²` is itself a strictly positive sum of squares,
+and the Positivstellensatz identity
+
+    g · Mₐ  =  3·G₀² + G₁² + G₂² + G₃² + G₄²
+             + (√(3−c)·2xy)² + (√(3−c)·2x²y)² + (√(3−c)·2xy²)²
+
+is an honest 10-term SOS whenever `c ≤ 3` (so `√(3−c)` is real), where
+`G₀ = 2xy − x³y − xy³`, `G₁ = x³y − xy³`, `G₂ = 2x − 2xy²`, `G₃ = 2y − 2x²y`,
+`G₄ = 2 − 2x²y²`.  The first five squares are exactly the `c = 3` certificate;
+the extra three absorb the non-negative slack `(3 − c)·g·x²y²` opened up when
+`c < 3`.  Since `g` is a positive SOS, `Mₐ = (g·Mₐ)/g` is a sum of squares of
+rational functions — a concrete instance of Artin's theorem valid across the full
+PSD range, recovering the Motzkin certificate at the boundary `c = 3`.  All
+`0`-axiom. -/
+
+/-- The positive SOS multiplier `g = 4 + 4x² + 4y²` of the Artin certificate. -/
+noncomputable def motzkinMultiplier : MvPolynomial (Fin 2) ℝ :=
+  4 + 4 * X 0 ^ 2 + 4 * X 1 ^ 2
+
+/-- The multiplier is a sum of squares: `g = 2² + (2x)² + (2y)²`. -/
+theorem motzkinMultiplier_isSOS : IsSOS motzkinMultiplier := by
+  refine ⟨3, ![2, 2 * X 0, 2 * X 1], ?_⟩
+  rw [motzkinMultiplier, Fin.sum_univ_three]
+  simp only [Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.head_cons,
+    Matrix.cons_val_two, Matrix.tail_cons]
+  ring
+
+/-- The multiplier is strictly positive everywhere (`≥ 4 > 0`), so dividing by it
+    is legitimate — this is what makes the certificate a genuine rational-SOS
+    representation. -/
+theorem motzkinMultiplier_pos (v : Fin 2 → ℝ) :
+    0 < MvPolynomial.eval v motzkinMultiplier := by
+  rw [motzkinMultiplier]
+  simp only [map_add, map_mul, map_pow, map_ofNat, eval_X]
+  positivity
+
+/-- **Positivstellensatz certificate for the PSD family.** For every `c ≤ 3` the
+    product `g · Mₐ` of the positive multiplier `g = 4 + 4x² + 4y²` with the family
+    member `Mₐ` is an explicit sum of `10` squares.  The extra `√(3−c)` squares
+    vanish at `c = 3`, recovering the classical Motzkin certificate. -/
+theorem motzkinPoly_mul_multiplier_isSOS {c : ℝ} (hc : c ≤ 3) :
+    IsSOS (motzkinMultiplier * motzkinPoly c) := by
+  set s : MvPolynomial (Fin 2) ℝ := C (Real.sqrt (3 - c)) with hs_def
+  have hs : s ^ 2 = 3 - C c := by
+    rw [hs_def, ← map_pow, Real.sq_sqrt (by linarith : (0 : ℝ) ≤ 3 - c),
+      map_sub, map_ofNat]
+  refine ⟨10, ![
+    2 * X 0 * X 1 - X 0 ^ 3 * X 1 - X 0 * X 1 ^ 3,
+    2 * X 0 * X 1 - X 0 ^ 3 * X 1 - X 0 * X 1 ^ 3,
+    2 * X 0 * X 1 - X 0 ^ 3 * X 1 - X 0 * X 1 ^ 3,
+    X 0 ^ 3 * X 1 - X 0 * X 1 ^ 3,
+    2 * X 0 - 2 * (X 0 * X 1 ^ 2),
+    2 * X 1 - 2 * (X 0 ^ 2 * X 1),
+    2 - 2 * (X 0 ^ 2 * X 1 ^ 2),
+    s * (2 * X 0 * X 1),
+    s * (2 * X 0 ^ 2 * X 1),
+    s * (2 * X 0 * X 1 ^ 2)], ?_⟩
+  rw [motzkinMultiplier, motzkinPoly]
+  simp only [Fin.sum_univ_succ, Fin.sum_univ_zero, Matrix.cons_val_zero,
+    Matrix.cons_val_succ, mul_pow, hs]
+  ring
+
+/-- **Constructive Artin for the whole PSD Motzkin family.** For every `c ≤ 3`
+    there is a strictly positive sum-of-squares multiplier `g` with `g · Mₐ` a sum
+    of squares.  Hence `Mₐ = (g · Mₐ)/g` is a sum of squares of rational functions
+    — a concrete, uniform instance of Artin's theorem across the entire PSD segment
+    `c ≤ 3`, complementing the polynomial-SOS *failure* on `0 < c ≤ 3`
+    (`motzkinPoly_psd_not_sos`) and recovering the classical certificate at
+    `c = 3`. -/
+theorem motzkinPoly_artin_certificate {c : ℝ} (hc : c ≤ 3) :
+    ∃ g : MvPolynomial (Fin 2) ℝ,
+      IsSOS g ∧
+      (∀ v : Fin 2 → ℝ, 0 < MvPolynomial.eval v g) ∧
+      IsSOS (g * motzkinPoly c) :=
+  ⟨motzkinMultiplier, motzkinMultiplier_isSOS, motzkinMultiplier_pos,
+    motzkinPoly_mul_multiplier_isSOS hc⟩
+
 end Hilbert17OQ03OQ05
 
 -- Axiom audit: should list only propext, Classical.choice, Quot.sound.
 #print axioms Hilbert17OQ03OQ05.motzkinPoly_not_sos
+#print axioms Hilbert17OQ03OQ05.motzkinPoly_artin_certificate

--- a/research/problems/hilbert-17-oq-03/knowledge.md
+++ b/research/problems/hilbert-17-oq-03/knowledge.md
@@ -558,3 +558,50 @@ and its dep `Hilbert17MotzkinNotSOS.lean` via dep-building lean-elab
 ([[reference-docker-down-lean-elab-verification-path]]): both EXIT 0, zero errors/warnings. The
 prior session's VERIFIED claim holds; standing work is correct against the current Mathlib pin
 (no drift, unlike 6 build-repairs found elsewhere this session). 0 sorries; marked completed.
+
+## Session 2026-07-11 (researcher-10) — constructive Artin certificate for the whole PSD Motzkin family (VERIFIED)
+
+Worked in the direct child file `Hilbert17OQ03OQ05.lean` (Motzkin family
+Mₐ = x⁴y²+x²y⁴+1−c·x²y²). It already had the sharp PSD threshold (`c ≤ 3`), the
+sharp *polynomial*-SOS threshold (`IsSOS ↔ c ≤ 0`, researcher-3), and the
+PSD-but-not-SOS band `0 < c ≤ 3`. The missing piece was the **positive** side of
+Artin's theorem made constructive *across the whole PSD range*. Added (0-axiom,
+docker `[7744/7744]` green, `#print axioms` = propext/Classical.choice/Quot.sound):
+
+- `motzkinMultiplier := 4 + 4·X0² + 4·X1²` + `motzkinMultiplier_isSOS`
+  (= 2²+(2x)²+(2y)²) + `motzkinMultiplier_pos` (eval ≥ 4 > 0, `positivity`).
+- `motzkinPoly_mul_multiplier_isSOS (hc : c ≤ 3)`: `g·Mₐ` is an explicit **10-term
+  SOS**. Certificate = the classical 5-square `c=3` Motzkin certificate
+  (3·G₀²+G₁²+G₂²+G₃²+G₄², G's from `Hilbert17MotzkinRationalSOS`) PLUS three
+  `√(3−c)`-scaled squares `(√(3−c)·2xy)², (√(3−c)·2x²y)², (√(3−c)·2xy²)²`
+  absorbing the non-negative slack `(3−c)·g·x²y² = (3−c)·(4x²y²+4x⁴y²+4x²y⁴)`.
+- `motzkinPoly_artin_certificate (hc : c ≤ 3)`: packaged
+  `∃ g, IsSOS g ∧ (∀v, 0 < eval v g) ∧ IsSOS (g·Mₐ)` — Mₐ = (g·Mₐ)/g is a rational
+  SOS, uniform over the entire PSD segment, recovering the classical certificate
+  at the boundary c=3. Directly answers the entry's open question on an *effective
+  Positivstellensatz certificate*.
+
+### Certificate derivation / Lean technique
+- Algebra pre-verified in sympy: `(4+4x²+4y²)·Mₐ = base₅ + (3−c)·((2xy)²+(2x²y)²+(2xy²)²)`
+  where base₅ is the `c=3` certificate. The `(3−c)` slack splits `g·x²y²` into three
+  squares (`g·x²y² = x²y²·(4+4x²+4y²) = (2xy)²+(2x²y)²+(2xy²)²`).
+- Lean: `set s := C (Real.sqrt (3−c))`; `have hs : s^2 = 3 − C c` via
+  `← map_pow, Real.sq_sqrt (0 ≤ 3−c), map_sub, map_ofNat`. Witness `![…]` : Fin 10,
+  then `simp only [Fin.sum_univ_succ, Fin.sum_univ_zero, Matrix.cons_val_zero,
+  Matrix.cons_val_succ, mul_pow, hs]; ring`. `mul_pow` exposes `s²` on the three
+  scaled terms so `hs` (as a simp lemma) rewrites them before `ring` (ring treats
+  `s`, `C c`, `X0`, `X1` as atoms — it cannot use `s²=3−Cc` itself).
+
+### Infra gotcha
+- **WORKTREE REAPED mid-session** (documented hazard): the sanctioned
+  `.loom/worktrees/researcher-10` dir was deleted while I was mid-edit (pre-build),
+  losing uncommitted edits. Recovered: `git worktree add .loom/worktrees/researcher-10
+  -b research/… origin/main`, re-applied the edit, **committed immediately before
+  building**. Docker build then went green first try.
+
+## Still open (parent hilbert-17, 1 axiom) — unchanged
+- `pfister_bound_aux` (Pfister's 2ⁿ bound over formally real fields) — the last
+  parent axiom, genuinely deep, no short Mathlib path, correctly axiomatized.
+  This session added no parent-axiom reduction (this slug's remaining hard target
+  is Pfister, a multi-session effort); it enriched the oq-03 subtree with the
+  constructive positive-side counterpart to the already-formalized negative side.

--- a/src/data/proofs/hilbert-17-oq-03-oq-05/meta.json
+++ b/src/data/proofs/hilbert-17-oq-03-oq-05/meta.json
@@ -48,7 +48,7 @@
       "The arithmetic–geometric mean (AM–GM) inequality and sum-of-squares certificates for non-negativity.",
       "Evaluation of multivariate polynomials and the PSD predicate ∀ v, 0 ≤ eval v p."
     ],
-    "lineCount": 533,
+    "lineCount": 619,
     "relatedProblems": [
       {
         "id": "hilbert-17-oq-03-oq-02",
@@ -68,20 +68,20 @@
       }
     ],
     "assumptions": "0 axioms. #print axioms reports only propext, Classical.choice, Quot.sound for motzkinFun_psd_iff, motzkinPoly_psd_iff, three_is_sharp, and motzkin_amgm. No sorryAx, no native_decide / Lean.ofReduceBool. The MvPolynomial PSD predicate IsPSDMv matches the parent entry's IsPositiveSemidefiniteMv definitionally.",
-    "theoremCount": 36,
-    "definitionCount": 3,
+    "theoremCount": 40,
+    "definitionCount": 4,
     "additionalFiles": []
   },
   "leanFile": {
-    "lineCount": 533,
+    "lineCount": 619,
     "namespace": "Hilbert17OQ03OQ05",
     "opens": [
       "MvPolynomial"
     ],
     "structureCount": 0,
     "axiomCount": 0,
-    "theoremCount": 36,
-    "substantiveTheoremCount": 9,
+    "theoremCount": 40,
+    "substantiveTheoremCount": 11,
     "computationalVerifications": 0,
     "lemmaCount": 0,
     "imports": [
@@ -89,7 +89,7 @@
     ],
     "path": "Proofs/Hilbert17OQ03OQ05.lean",
     "sorries": 0,
-    "definitionCount": 3,
+    "definitionCount": 4,
     "additionalFiles": []
   },
   "sorries": 0,
@@ -147,6 +147,12 @@
       "type": "theorem",
       "description": "Generalised degree bound: if ∑ qᵢ² = p with totalDegree p ≤ 6, then every qᵢ has total degree ≤ 3 (the top homogeneous component of a sum of squares is itself a sum of squares, so it vanishes above the target degree).",
       "leanType": "p.totalDegree ≤ 6 → (∑ i, q i ^ 2 = p) → (q j).totalDegree ≤ 3"
+    },
+    {
+      "name": "motzkinPoly_artin_certificate",
+      "type": "theorem",
+      "description": "Constructive Artin certificate for the whole PSD Motzkin family: for every c ≤ 3 there is a strictly positive sum-of-squares multiplier g = 4 + 4x² + 4y² with g·Mₐ an explicit sum of 10 squares. Hence Mₐ = (g·Mₐ)/g is a sum of squares of rational functions — a uniform instance of Artins theorem across the entire PSD segment, complementing the polynomial-SOS failure on 0 < c ≤ 3 and recovering the classical Motzkin certificate at c = 3.",
+      "leanType": "c ≤ 3 → ∃ g, IsSOS g ∧ (∀ v, 0 < eval v g) ∧ IsSOS (g * motzkinPoly c)"
     }
   ],
   "overview": {
@@ -162,8 +168,8 @@
     ]
   },
   "conclusion": {
-    "summary": "A 142-line, 0-sorry, 0-axiom formalization establishing the sharp PSD threshold of the Motzkin family: x⁴y² + x²y⁴ + 1 − c·x²y² is positive-semidefinite on ℝ² if and only if c ≤ 3, in both real-function and MvPolynomial forms. The Motzkin polynomial (c = 3) is the extremal PSD member.",
-    "implications": "By exhibiting the Motzkin coefficient 3 as an exact threshold rather than a fixed constant, the entry quantifies — for the canonical example — where the PSD/SOS gap of the parent open question opens: the family stays PSD up to c = 3, and the boundary member is exactly the one that fails to be a sum of squares of polynomials. The sufficient direction is a genuine SOS certificate for the affine form, complementing the sibling non-SOS result for the homogeneous Motzkin polynomial.",
+    "summary": "A 619-line, 0-sorry, 0-axiom formalization of the Motzkin family x⁴y² + x²y⁴ + 1 − c·x²y². It establishes the sharp PSD threshold (PSD on ℝ² ⟺ c ≤ 3, in both real-function and MvPolynomial forms; c = 3 is the extremal PSD member), the sharp polynomial-SOS threshold (IsSOS ⟺ c ≤ 0), and a constructive Artin certificate covering the whole PSD range: for every c ≤ 3 the positive SOS multiplier g = 4 + 4x² + 4y² makes g·Mₐ an explicit 10-term sum of squares, so Mₐ is a sum of squares of rational functions.",
+    "implications": "By exhibiting the Motzkin coefficient 3 as an exact threshold rather than a fixed constant, the entry quantifies — for the canonical example — where the PSD/SOS gap of the parent open question opens: the family stays PSD up to c = 3, but leaves the polynomial-SOS cone already at c = 0, so the entire segment 0 < c ≤ 3 is PSD-but-not-SOS. The complementary constructive Artin certificate (motzkinPoly_artin_certificate) makes the positive resolution explicit across that whole segment — an effective Positivstellensatz multiplier g with g·Mₐ a sum of 10 squares — recovering the classical single-c=3 Motzkin certificate as the boundary case and directly answering the entry's open question on an effective certificate quantifying SOS-membership.",
     "openQuestions": [
       "The sharp threshold isolates c = 3 as the PSD boundary; can it be paired with a formalized non-SOS proof AT c = 3 to certify, fully in Lean, that the boundary of the PSD cone is exactly where the family leaves the SOS cone for this family?",
       "Does the threshold generalize to the n-variable affine Motzkin-type families x₁⁴x₂² + ⋯ + 1 − c·∏xᵢ² — is the sharp coefficient always the number of AM–GM terms, and is the boundary member always non-SOS?",

--- a/src/data/research/problems/hilbert-17-oq-03.json
+++ b/src/data/research/problems/hilbert-17-oq-03.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Robinson form now has an explicit 0-axiom rational-SOS certificate (Hilbert17RobinsonRationalSOS.lean), the ternary-sextic analog of the Motzkin rational-SOS entry and the positive-side constructive witness for the second canonical extremal example.",
+    "progressSummary": "PROGRESS: oq-03 subtree enriched with the constructive positive side of Artin for the whole PSD Motzkin family (10-term SOS certificate g·Mₐ, c ≤ 3). Sharp trichotomy now complete: PSD ⟺ c≤3, polynomial-SOS ⟺ c≤0, rational-SOS for all c≤3. Parent hilbert-17 still has its single deep axiom pfister_bound_aux (multi-session).",
     "builtItems": [
       "Hilbert17UnivariatePSDSOS.univariate_psd_is_sos (verified, 0-axiom): every non-negative univariate real polynomial is a sum of two squares, Proofs/Hilbert17UnivariatePSDSOS.lean",
       "Hilbert17RobinsonNotSOS.robinson_not_sos (verified, 0-axiom): Robinson's polynomial is not polynomial-SOS, Proofs/Hilbert17RobinsonNotSOS.lean",
@@ -37,7 +37,8 @@
       "Hilbert17.artin_univariate (now theorem ⟸ univariate_psd_is_sos_aux via algebraMap), Hilbert17SumOfSquares.lean",
       "Hilbert17.cassels_bound_bivariate (now theorem ⟸ pfister_bound_aux 2), Hilbert17SumOfSquares.lean",
       "Proofs/Hilbert17RobinsonRationalSOS.lean: robinson_isSOS_ratFunc (R is SOS of rational functions, 0 axioms), multiplier_mul_robinson_eq (ring-closed Positivstellensatz certificate), product_identity, multiplier_isSumOfSquares — 191 lines, 7 theorems, 0 sorries.",
-      "Hilbert17MotzkinRationalSOS.motzkin_eval_nonneg + multiplier_eval_pos (0-axiom): pointwise M(v) ≥ 0 derived from the SOS certificate via strictly-positive multiplier. Hilbert17RobinsonRationalSOS.robinson_eval_nonneg + multiplier_eval_nonneg (0-axiom): pointwise R(v) ≥ 0 via origin-split. Also repaired Mathlib drift in Hilbert17RobinsonRationalSOS.multiplier_ne_zero (if (2:Fin 3)=0 no longer reduces under current simp set → evaluate at constant-1 point)."
+      "Hilbert17MotzkinRationalSOS.motzkin_eval_nonneg + multiplier_eval_pos (0-axiom): pointwise M(v) ≥ 0 derived from the SOS certificate via strictly-positive multiplier. Hilbert17RobinsonRationalSOS.robinson_eval_nonneg + multiplier_eval_nonneg (0-axiom): pointwise R(v) ≥ 0 via origin-split. Also repaired Mathlib drift in Hilbert17RobinsonRationalSOS.multiplier_ne_zero (if (2:Fin 3)=0 no longer reduces under current simp set → evaluate at constant-1 point).",
+      "motzkinPoly_artin_certificate + motzkinPoly_mul_multiplier_isSOS + motzkinMultiplier(_isSOS/_pos) in Hilbert17OQ03OQ05.lean (0-axiom, docker 7744/7744 green)"
     ],
     "insights": [
       "The univariate case has an elementary induction-on-degree proof needing only the FTA plus continuity: the sole analytic input is that a real root of a non-negative polynomial has multiplicity ≥ 2 (if it were simple, p=(x-r)g changes sign across r — one-sided limits force g(r)≥0 and g(r)≤0). Real roots come out as (X-C r)², conjugate pairs as a positive quadratic, and the Brahmagupta–Fibonacci identity keeps everything a sum of two squares. No real-closed-field or Gram-matrix machinery — and unlike n≥2, the conclusion is genuine polynomials, not rational functions.",
@@ -48,7 +49,8 @@
       "Eliminating a redundant axiom is honest axiom reduction: when axiom B is provable from axiom A already in the file, B was never adding assumptive content, so converting B to `theorem ... := <derivation>` genuinely shrinks the independent-assumption set.",
       "Robinson ternary sextic R has an explicit 0-axiom rational-SOS certificate: the multiplier 4(x²+y²+z²) times R is a sum of 7 integer-coefficient polynomial squares (Q1²+3Q2²+Ga²+Gb²+Gc²), giving R = Σ 21 rational-function squares (Proofs/Hilbert17RobinsonRationalSOS.lean).",
       "The symmetry substitution u=x²,v=y²,w=z² reduces the ternary-sextic boundary SDP to a symmetric quartic in u,v,w: (u+v+w)R = Σu⁴−2Σu²v²+uvw(u+v+w), which splits into a rank-2 even block (2q1−q2)²+3q2² plus three rank-1 odd blocks uv(u−v)² (and cyclic) = (xy(x²−y²))². This gives an EXACT small rational Gram over ℚ where a numeric boundary Gram would not rationalize cleanly.",
-      "The exhibited SOS Positivstellensatz certificate s·M = Σ squares is itself a proof of nonnegativity: at any real point, s(v)·M(v) = Σ(Gᵢ(v))² ≥ 0. For Motzkin the multiplier s = 4+4x²+4y² ≥ 4 > 0 never vanishes so M(v) ≥ 0 divides out directly; for Robinson the homogeneous s = 4x²+4y²+4z² vanishes only at the origin (where R = 0), so a single origin-split recovers R(v) ≥ 0. This gives certificate-based nonnegativity (motzkin_eval_nonneg, robinson_eval_nonneg) — an independent route to the parent's Schur/AM-GM motzkin_nonneg/robinson_nonneg."
+      "The exhibited SOS Positivstellensatz certificate s·M = Σ squares is itself a proof of nonnegativity: at any real point, s(v)·M(v) = Σ(Gᵢ(v))² ≥ 0. For Motzkin the multiplier s = 4+4x²+4y² ≥ 4 > 0 never vanishes so M(v) ≥ 0 divides out directly; for Robinson the homogeneous s = 4x²+4y²+4z² vanishes only at the origin (where R = 0), so a single origin-split recovers R(v) ≥ 0. This gives certificate-based nonnegativity (motzkin_eval_nonneg, robinson_eval_nonneg) — an independent route to the parent's Schur/AM-GM motzkin_nonneg/robinson_nonneg.",
+      "Constructive Artin certificate for the whole PSD Motzkin family (Hilbert17OQ03OQ05.lean): the positive SOS multiplier g = 4+4x²+4y² makes g·Mₐ an explicit 10-term SOS for every c ≤ 3, so Mₐ is a rational SOS uniformly across the PSD segment — recovers the classical c=3 Motzkin certificate at the boundary and answers the effective-Positivstellensatz open question."
     ],
     "mathlibGaps": [],
     "nextSteps": [


### PR DESCRIPTION
## Summary

Adds the **constructive positive side of Artin's theorem** for the whole PSD range of the Motzkin family `Mₐ = x⁴y² + x²y⁴ + 1 − c·x²y²`, in the direct child file `Hilbert17OQ03OQ05.lean` (problem `hilbert-17-oq-03`, "complexity of deciding PSD ⇒ SOS").

The family file already had the sharp PSD threshold (`PSD ⟺ c ≤ 3`), the sharp *polynomial*-SOS threshold (`IsSOS ⟺ c ≤ 0`), and the PSD-but-not-SOS band `0 < c ≤ 3`. What was missing is the positive resolution: every PSD member is a sum of squares of *rational* functions. This PR supplies it **uniformly across the whole segment `c ≤ 3`**, not just the classical `c = 3` case.

## New declarations (all 0-axiom)

- `motzkinMultiplier` `g = 4 + 4x² + 4y²`, with `motzkinMultiplier_isSOS` (`g = 2² + (2x)² + (2y)²`) and `motzkinMultiplier_pos` (`eval ≥ 4 > 0`).
- `motzkinPoly_mul_multiplier_isSOS (c ≤ 3)`: `g·Mₐ` is an explicit **10-term sum of squares** — the classical 5-square `c = 3` Motzkin certificate (`3G₀² + G₁² + G₂² + G₃² + G₄²`) plus three `√(3−c)`-scaled squares `(√(3−c)·2xy)², (√(3−c)·2x²y)², (√(3−c)·2xy²)²` that absorb the non-negative slack `(3−c)·g·x²y²`.
- `motzkinPoly_artin_certificate (c ≤ 3)`: `∃ g, IsSOS g ∧ (∀ v, 0 < eval v g) ∧ IsSOS (g·Mₐ)` — so `Mₐ = (g·Mₐ)/g` is a rational SOS.

Together these complete the **sharp trichotomy** of the family: `PSD ⟺ c ≤ 3`, `polynomial-SOS ⟺ c ≤ 0`, `rational-SOS for all c ≤ 3`. The certificate recovers the classical single-`c=3` Motzkin certificate at the boundary and directly answers the entry's standing open question on an *effective Positivstellensatz certificate*.

## Verification

- Docker build `Proofs.Hilbert17OQ03OQ05`: **`[7744/7744]` succeeded**.
- `#print axioms motzkinPoly_artin_certificate` → `[propext, Classical.choice, Quot.sound]` (0 real axioms).
- Certificate algebra independently checked in sympy before formalization.

Gallery meta (`hilbert-17-oq-03-oq-05`) updated: lineCount 533→619, theoremCount 36→40, definitionCount 3→4, new mainTheorem, refreshed conclusion. No parent-axiom change (the parent's remaining `pfister_bound_aux` is a separate multi-session target).

🤖 Generated with [Claude Code](https://claude.com/claude-code)