### PR TITLE
Enrich anisotropic n-dim Gaussian (area-of-circle-oq-07-oq-04-oq-01-oq-01-oq-02): probabilistic-interpretation insight

### DIFF
--- a/src/data/proofs/area-of-circle-oq-07-oq-04-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/area-of-circle-oq-07-oq-04-oq-01-oq-01-oq-02/meta.json
@@ -31,7 +31,8 @@
       "The product-Fubini step holds for EVERY real weight vector b — no positivity or integrability hypothesis — because the closed value of each factor is supplied by integral_gaussian, which is itself unconditional; positivity is needed only later to write the determinant under a single square root.",
       "The product of weights ∏ᵢ bᵢ is exactly the determinant of the diagonal matrix diag(b₁,…,bₙ), so the closed form π^{n/2}/√(∏ᵢ bᵢ) is literally the diagonal instance of the general quadratic-form Gaussian π^{n/2}/√(det A).",
       "The two algebraic identities that assemble the determinant form — ∏ᵢ √bᵢ = √(∏ᵢ bᵢ) (multiplicativity of the square root on nonnegatives, via rpow at exponent 1/2) and (√π)ⁿ = π^{n/2} — are handled uniformly through Real.sqrt_eq_rpow and the rpow power laws.",
-      "Setting bᵢ = c collapses the product back to a power and recovers the parent's (π/c)^{n/2}, certifying this entry as a strict generalization rather than a parallel result."
+      "Setting bᵢ = c collapses the product back to a power and recovers the parent's (π/c)^{n/2}, certifying this entry as a strict generalization rather than a parallel result.",
+      "Probabilistically, the weight bᵢ is an inverse variance: e^{-bᵢ xᵢ²} is (unnormalized) the density of an independent centered Gaussian with variance σᵢ² = 1/(2bᵢ). The anisotropic integrand is thus a product of independent, differently-scaled coordinates — a diagonal covariance Σ = diag(σ₁²,…,σₙ²) — and the factor √(∏ᵢ bᵢ) = √(det diag b) in the denominator is exactly the |Σ|^{-1/2} that normalizes the multivariate normal density (Bishop, PRML §2.3). Anisotropy is precisely the statement that the coordinates, though still independent, no longer share a common scale."
     ]
   },
   "sections": [


### PR DESCRIPTION
Enrichment pass for `area-of-circle-oq-07-oq-04-oq-01-oq-01-oq-02` (pass 0, quality 96).

This entry was already saturated and accurate — 5 keyInsights, 3 sections covering all 114 lines, 5 thorough annotations, complete conclusion. Every claim was verified against the Lean source. Rather than inflate it, this pass adds **one** genuinely non-redundant layer:

- **6th keyInsight (5→6, well under the 12 cap): the probabilistic reading.** The weight bᵢ is an inverse variance (σᵢ² = 1/(2bᵢ)); the anisotropic integrand is a product of independent, differently-scaled Gaussian coordinates (diagonal covariance Σ), and the denominator √(∏ᵢ bᵢ) = √(det diag b) is exactly the |Σ|^{-1/2} normalizing the multivariate normal density. This ties the already-listed Bishop PRML reference into the insight set and explains what 'anisotropic' means statistically.

meta.json 17.5 KB → ~18 KB (well under the 60 KB cap; guardrail check passes). No content removed. JSON validated.