### PR TITLE
research(bezout-identity-oq-01-oq-02-oq-02): classical-coprimality bridges for primitive vectors

### DIFF
--- a/proofs/Proofs/BezoutIdentityOQ01OQ02OQ02Coprime.lean
+++ b/proofs/Proofs/BezoutIdentityOQ01OQ02OQ02Coprime.lean
@@ -1,0 +1,121 @@
+/-
+# Bézout / primitive vectors: the classical coprimality bridges
+
+`BezoutIdentityOQ01OQ02OQ02` develops the `SLₙ(ℤ)`-transitivity theory of
+*primitive* integer vectors through the dot-product definition
+
+  `IsPrimitive v := ∃ w, w ⬝ᵥ v = 1`
+
+and already records two structural reformulations: the ideal form
+`isPrimitive_iff_span_eq_top` (`Ideal.span (range v) = ⊤`) and the
+common-divisor form `isPrimitive_iff_forall_isUnit_of_dvd` (every common divisor
+of the entries is a unit).
+
+What is still missing is the bridge to the *literal* classical notions used by
+the `n = 2` parent entry `BezoutIdentityOQ01OQ02`, which is phrased throughout in
+terms of `Int.gcd` and `Int.gcdA/gcdB`.  This file supplies exactly that
+translation, in two forms:
+
+* `isPrimitive_iff_finset_gcd_eq_one` — for arbitrary `n`, primitivity is
+  equivalent to the honest computed value `Finset.univ.gcd v = 1` of the entries'
+  gcd (not merely "every common divisor is a unit").
+* `isPrimitive_iff_isCoprime_fin_two` — in dimension `2`, primitivity of
+  `v : Fin 2 → ℤ` is exactly Mathlib's ring-theoretic `IsCoprime (v 0) (v 1)`,
+  and hence (`isPrimitive_iff_int_gcd_eq_one_fin_two`) exactly
+  `Int.gcd (v 0) (v 1) = 1` — the precise hypothesis under which the parent's
+  `bezoutMatrix` produces a genuine `SL₂(ℤ)` element.
+
+All results are `0`-axiom / `0`-sorry, and reuse the existing
+characterisations of the parent file rather than re-deriving the descent.
+
+Research file — intentionally NOT registered in `Proofs.lean`.
+-/
+import Proofs.BezoutIdentityOQ01OQ02OQ02
+import Mathlib.Algebra.GCDMonoid.Finset
+import Mathlib.RingTheory.Coprime.Lemmas
+import Mathlib.RingTheory.Int.Basic
+
+namespace BezoutPrimitive
+
+open Matrix
+
+variable {n : ℕ}
+
+/-! ### The `Finset.gcd` bridge (all dimensions) -/
+
+/-- **The literal gcd characterisation of primitivity.**  A vector `v : Fin n → ℤ`
+is primitive iff the honest computed gcd of its entries equals `1`:
+
+  `IsPrimitive v ↔ Finset.univ.gcd v = 1`.
+
+This upgrades `isPrimitive_iff_forall_isUnit_of_dvd` (every common divisor is a
+unit) to the concrete value of the gcd itself, using that `Finset.gcd` over `ℤ`
+is normalised (non-negative).
+
+Forward: primitivity makes every common divisor a unit; the gcd `Finset.univ.gcd v`
+divides each entry (`Finset.gcd_dvd`), so it is a unit, and a *normalised* unit of
+`ℤ` is `1`.  Reverse: any common divisor `d` of the entries divides the gcd
+(`Finset.dvd_gcd`), hence divides `1`, so is a unit — primitivity then follows
+from `isPrimitive_iff_forall_isUnit_of_dvd`. -/
+theorem isPrimitive_iff_finset_gcd_eq_one (v : Fin n → ℤ) :
+    IsPrimitive v ↔ (Finset.univ.gcd v) = 1 := by
+  rw [isPrimitive_iff_forall_isUnit_of_dvd]
+  constructor
+  · intro h
+    have hunit : IsUnit (Finset.univ.gcd v) :=
+      h _ (fun i => Finset.gcd_dvd (Finset.mem_univ i))
+    have hnorm : normalize (Finset.univ.gcd v) = Finset.univ.gcd v :=
+      Finset.normalize_gcd
+    rw [← hnorm, normalize_eq_one.mpr hunit]
+  · intro h d hd
+    have hdvd : d ∣ Finset.univ.gcd v :=
+      Finset.dvd_gcd (fun i _ => hd i)
+    rw [h] at hdvd
+    exact isUnit_of_dvd_one hdvd
+
+/-! ### The `IsCoprime` / `Int.gcd` bridge (dimension two) -/
+
+/-- **Primitivity is coprimality in dimension two.**  For `v : Fin 2 → ℤ`,
+
+  `IsPrimitive v ↔ IsCoprime (v 0) (v 1)`.
+
+Both sides unfold to a Bézout identity `a·(v 0) + b·(v 1) = 1`: `IsPrimitive v`
+provides a dual `w` with `w 0 · v 0 + w 1 · v 1 = 1` (`Fin.sum_univ_two` on the
+dot product), which is exactly a coprimality witness `⟨w 0, w 1⟩`, and
+conversely a coprimality witness `⟨a, b⟩` assembles into the dual `![a, b]`.
+This identifies the file's `SLₙ(ℤ)`-invariant `IsPrimitive` with the classical
+`IsCoprime` phrasing the parent `n = 2` entry is built on. -/
+theorem isPrimitive_iff_isCoprime_fin_two (v : Fin 2 → ℤ) :
+    IsPrimitive v ↔ IsCoprime (v 0) (v 1) := by
+  constructor
+  · rintro ⟨w, hw⟩
+    have hwv : w 0 * v 0 + w 1 * v 1 = 1 := by
+      simpa [dotProduct, Fin.sum_univ_two] using hw
+    exact ⟨w 0, w 1, hwv⟩
+  · rintro ⟨a, b, hab⟩
+    refine ⟨![a, b], ?_⟩
+    simp only [dotProduct, Fin.sum_univ_two, Matrix.cons_val_zero, Matrix.cons_val_one]
+    linarith [hab]
+
+/-- **Primitivity is `Int.gcd = 1` in dimension two.**  Composing
+`isPrimitive_iff_isCoprime_fin_two` with `Int.isCoprime_iff_gcd_eq_one` gives the
+concrete arithmetic form matching the parent `BezoutIdentityOQ01OQ02`:
+
+  `IsPrimitive v ↔ Int.gcd (v 0) (v 1) = 1`.
+
+This is precisely the condition under which the parent's `bezoutMatrix (v 0) (v 1)`
+is a genuine `SL₂(ℤ)` element carrying `v` to `e₁`. -/
+theorem isPrimitive_iff_int_gcd_eq_one_fin_two (v : Fin 2 → ℤ) :
+    IsPrimitive v ↔ Int.gcd (v 0) (v 1) = 1 := by
+  rw [isPrimitive_iff_isCoprime_fin_two, Int.isCoprime_iff_gcd_eq_one]
+
+/-- **Consistency of the two bridges.**  For `v : Fin 2 → ℤ` the general
+`Finset.univ.gcd` value and the classical `Int.gcd (v 0) (v 1)` agree on the
+primitive locus: both equal `1` exactly when `v` is primitive.  Recorded as the
+`Finset.gcd = 1 ↔ Int.gcd = 1` corollary tying the two characterisations
+together in the base dimension. -/
+theorem finset_gcd_eq_one_iff_int_gcd_eq_one_fin_two (v : Fin 2 → ℤ) :
+    (Finset.univ.gcd v) = 1 ↔ Int.gcd (v 0) (v 1) = 1 := by
+  rw [← isPrimitive_iff_finset_gcd_eq_one, isPrimitive_iff_int_gcd_eq_one_fin_two]
+
+end BezoutPrimitive

--- a/src/data/research/problems/bezout-identity-oq-01-oq-02-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-01-oq-02-oq-02.json
@@ -42,7 +42,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "SOLVED (n≥2 full transitivity done in prior sessions: exists_sl_mulVec_eq_of_isPrimitive + column completion). This session added the matching SHARPNESS: n=1 obstruction (SL₁ trivial → 2 orbits), machine-checking the 1<n necessity the docstrings only asserted. Axiom-free. PR #38002.",
+    "progressSummary": "SOLVED/enriched: added the classical-coprimality bridges — literal Finset.univ.gcd v=1 (all n) and IsCoprime/Int.gcd=1 (n=2) characterisations of IsPrimitive, connecting the SLₙ(ℤ)-invariant dot-product definition to the parent n=2 Int.gcd/bezoutMatrix phrasing. All axiom-free (propext/Classical.choice/Quot.sound only). BezoutIdentityOQ01OQ02OQ02Coprime.lean companion, verified via lake env lean 4.26.0.",
     "builtItems": [
       "IsPrimitive (Fin n → ℤ) := ∃ w, w ⬝ᵥ v = 1 — BezoutIdentityOQ01OQ02OQ02.lean",
       "isPrimitive_iff_span_eq_top: IsPrimitive v ↔ Ideal.span (range v) = ⊤ (bridge to classical gcd=1 via Ideal.mem_span_range_iff_exists_fun)",
@@ -52,7 +52,10 @@
       "sum_natAbs_update_emod_lt (BezoutIdentityOQ01OQ02OQ02.lean): the Euclidean reduction step strictly lowers sum_k|v_k|. VERIFIED 0-sorry/0-axiom.",
       "exists_sl_mulVec_single_of_isPrimitive (BezoutIdentityOQ01OQ02OQ02.lean): general-n converse — every primitive v is SLn(Z)-equivalent to Pi.single k c with IsUnit c, by strong induction on l1 measure. VERIFIED axiom-free (propext/Classical.choice/Quot.sound only).",
       "isPrimitive_iff_exists_sl_single (BezoutIdentityOQ01OQ02OQ02.lean): clean iff — IsPrimitive v iff exists A k c, IsUnit c and A *v v = Pi.single k c. VERIFIED.",
-      "coe_sl_fin_one_eq_one, sl_fin_one_mulVec, not_exists_sl_fin_one_single_neg, not_forall_sl_fin_one_orbit (BezoutIdentityOQ01OQ02OQ02.lean): the n=1 obstruction package. VERIFIED axiom-free [propext,Classical.choice,Quot.sound]. File 584→646L, 27→31 thm."
+      "coe_sl_fin_one_eq_one, sl_fin_one_mulVec, not_exists_sl_fin_one_single_neg, not_forall_sl_fin_one_orbit (BezoutIdentityOQ01OQ02OQ02.lean): the n=1 obstruction package. VERIFIED axiom-free [propext,Classical.choice,Quot.sound]. File 584→646L, 27→31 thm.",
+      "isPrimitive_iff_finset_gcd_eq_one (BezoutIdentityOQ01OQ02OQ02Coprime.lean): IsPrimitive v ↔ Finset.univ.gcd v = 1 for all n — literal computed-gcd value form, upgrading isPrimitive_iff_forall_isUnit_of_dvd via Finset.gcd_dvd/dvd_gcd + normalize_eq_one. 0-axiom.",
+      "isPrimitive_iff_isCoprime_fin_two + isPrimitive_iff_int_gcd_eq_one_fin_two: for v:Fin 2→ℤ, IsPrimitive v ↔ IsCoprime (v 0)(v 1) ↔ Int.gcd(v 0)(v 1)=1 — the classical-coprimality bridge to the parent BezoutIdentityOQ01OQ02 Int.gcd/bezoutMatrix phrasing. 0-axiom.",
+      "finset_gcd_eq_one_iff_int_gcd_eq_one_fin_two: Finset.gcd and Int.gcd agree on the Fin 2 primitive locus."
     ],
     "insights": [
       "Primitivity of an integer vector v is cleanly captured coordinate-free as: ∃ dual w with w ⬝ᵥ v = 1. This dot-product form is manifestly SLₙ(ℤ)-invariant, unlike the gcd-of-entries phrasing.",
@@ -64,7 +67,8 @@
       "The termination measure is sum_k (v k).natAbs; a single transvection T_{i,j}(-(v i / v j)) replaces the pivot v i by v i % v j, and 0 <= v i % v j < |v j| <= |v i| makes exactly the i-th summand shrink (sum_natAbs_update_emod_lt).",
       "Base case: a primitive vector with a single nonzero coordinate must have that entry a unit (from exists w, w dot v = 1 collapsing to w k * v k = 1), so it already equals Pi.single k (v k) with IsUnit (v k) — A = 1.",
       "Reaching EXACTLY e0 (not just a unit multiple c*e_k) is only true for n >= 2; in n = 1, SL1(Z)={1} fixes -e0 != e0 though both are primitive, so the unit-multiple form is the sharp general-n statement.",
-      "Sharpness of transitivity: SL₁(ℤ)={(1)} acts trivially (coe_sl_fin_one_eq_one via det_fin_one), so (1) and (-1) — both primitive — lie in DISTINCT orbits. SL₁(ℤ) has exactly 2 primitive-vector orbits vs a single orbit for n≥2. This proves the previously prose-only claim that the 1<n hypothesis in exists_sl_mulVec_eq_of_isPrimitive is genuinely necessary."
+      "Sharpness of transitivity: SL₁(ℤ)={(1)} acts trivially (coe_sl_fin_one_eq_one via det_fin_one), so (1) and (-1) — both primitive — lie in DISTINCT orbits. SL₁(ℤ) has exactly 2 primitive-vector orbits vs a single orbit for n≥2. This proves the previously prose-only claim that the 1<n hypothesis in exists_sl_mulVec_eq_of_isPrimitive is genuinely necessary.",
+      "The parent file already had two primitivity reformulations (span=⊤, every-common-divisor-is-unit) but NOT the literal Finset.gcd=1 value nor the ring-theoretic IsCoprime form; both are cheap corollaries of isPrimitive_iff_forall_isUnit_of_dvd + Finset.gcd_dvd/dvd_gcd and Fin.sum_univ_two respectively."
     ],
     "mathlibGaps": [
       "Mathlib has no packaged transitivity of SLₙ(ℤ) on primitive vectors (only n=2 pieces via bezoutSL in the parent). Foundation built here; the Euclidean-descent converse (every primitive vector reaches eᵢ) remains.",


### PR DESCRIPTION
## Summary

Enriches `bezout-identity-oq-01-oq-02-oq-02` (RICH/MODERATE knowledge) by bridging the file's `SLₙ(ℤ)`-invariant dot-product notion of primitivity to the **literal classical characterisations** used by the `n = 2` parent `BezoutIdentityOQ01OQ02` (which is phrased throughout in `Int.gcd` / `bezoutMatrix`).

The parent file already had the ideal form (`Ideal.span (range v) = ⊤`) and the common-divisor form (`every common divisor is a unit`), but **not** the literal computed-gcd value nor the ring-theoretic `IsCoprime` form. This closes that gap — exactly the flagged next step "bridge IsPrimitive to gcd of entries = 1 to connect with the parent n=2 IsCoprime phrasing."

New companion file `proofs/Proofs/BezoutIdentityOQ01OQ02OQ02Coprime.lean`:

- **`isPrimitive_iff_finset_gcd_eq_one`** (all `n`): `IsPrimitive v ↔ Finset.univ.gcd v = 1` — the honest computed gcd value, upgrading `isPrimitive_iff_forall_isUnit_of_dvd` via `Finset.gcd_dvd` / `Finset.dvd_gcd` + `normalize_eq_one` (normalised gcd over ℤ).
- **`isPrimitive_iff_isCoprime_fin_two`** + **`isPrimitive_iff_int_gcd_eq_one_fin_two`** (`n = 2`): `IsPrimitive v ↔ IsCoprime (v 0) (v 1) ↔ Int.gcd (v 0) (v 1) = 1` — precisely the hypothesis under which the parent's `bezoutMatrix` yields a genuine `SL₂(ℤ)` element.
- **`finset_gcd_eq_one_iff_int_gcd_eq_one_fin_two`**: the two gcd notions agree on the primitive locus.

## Verification

- Compiles with `lake env lean` against prebuilt Mathlib **v4.26.0** oleans (importing the prebuilt parent `Proofs.BezoutIdentityOQ01OQ02OQ02`).
- **0 sorry / 0 axiom**: all four theorems depend only on `propext`, `Classical.choice`, `Quot.sound` (`#print axioms` — no `sorryAx`, no `Lean.ofReduceBool`).
- Research file, intentionally **not** registered in `Proofs.lean`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)