### PR TITLE
research(erdos-117-oq-01-incomplete-01): oscillation of the growth rate — lower bound + negation form

### DIFF
--- a/proofs/Proofs/Erdos117OQ01Incomplete01.lean
+++ b/proofs/Proofs/Erdos117OQ01Incomplete01.lean
@@ -1,0 +1,84 @@
+/-
+  Erdős #117 OQ-01 (incomplete-01): the oscillation of the growth rate
+
+  Companion to `Proofs.Erdos117OQ01`, which studies whether the normalized
+  logarithmic growth rate `growthRate n = log(h n)/n` of the abelian covering
+  number `h(n)` converges (equivalently, whether `h(n)` has a single exponential
+  base — Erdős #117 OQ-01).  The parent pins the open question down to the
+  cluster values `growthRateLimInf`, `growthRateLimSup` and their difference
+  (the *oscillation* `limsup − liminf`), and shows
+
+      converges ⟺ liminf = limsup ⟺ oscillation = 0 ⟺ exponential base exists,
+
+  together with the one-sided window bound
+  `oscillation ≤ log c₂ − log c₁` (`growthRate_oscillation_le_window`).
+
+  This file supplies the missing lower side and the negation form, so the
+  oscillation is fully trapped and the open question has a clean "is the
+  oscillation strictly positive?" phrasing.  All results are proved from the
+  parent's API and add **no new axioms** (they inherit only the parent's three
+  Pyber-bound assumptions `h`, `h_pos`, `pyber_bounds`).
+
+  ## What this file proves (0 new axioms, 0 sorries)
+
+  * `growthRate_oscillation_nonneg` — `0 ≤ limsup − liminf` (from `limInf_le_limSup`).
+  * `oscillation_mem_window` — the oscillation lies in `[0, log c₂ − log c₁]`,
+    combining the new lower bound with the parent's upper bound.
+  * `exponentialBaseExists_iff_oscillation_zero` — the open question restated:
+    a single exponential base exists iff the oscillation vanishes.
+  * `not_exponentialBaseExists_iff_oscillation_pos` — the negation: **no** single
+    base exists iff the oscillation is strictly positive (`0 < limsup − liminf`),
+    the crispest form of "does the limit fail to exist?".
+
+  Parent: Erdos117OQ01.lean
+-/
+
+import Mathlib
+import Proofs.Erdos117OQ01
+
+open Real Filter
+
+namespace Erdos117OQ01Incomplete01
+
+open Erdos117OQ01
+
+/-- **The oscillation is nonnegative.**  `0 ≤ growthRateLimSup − growthRateLimInf`:
+the limsup of a sequence always dominates its liminf (`limInf_le_limSup`).  The lower
+companion of `growthRate_oscillation_le_window`, so the oscillation of the growth rate is
+trapped in `[0, log c₂ − log c₁]`. -/
+theorem growthRate_oscillation_nonneg :
+    0 ≤ growthRateLimSup - growthRateLimInf :=
+  sub_nonneg.mpr limInf_le_limSup
+
+/-- **The oscillation lies in Pyber's log-window.**  Combining the new lower bound
+`growthRate_oscillation_nonneg` with the parent's upper bound
+`growthRate_oscillation_le_window`, the oscillation `limsup − liminf` of the growth rate
+is trapped in `[0, log c₂ − log c₁]` for Pyber's constants `1 < c₁ < c₂`.  Even without
+knowing whether the limit exists, the amount by which the growth rate can oscillate is
+bounded by the fixed log-width of Pyber's exponential window. -/
+theorem oscillation_mem_window :
+    ∃ c₁ c₂ : ℝ, 1 < c₁ ∧ c₁ < c₂ ∧
+      0 ≤ growthRateLimSup - growthRateLimInf ∧
+      growthRateLimSup - growthRateLimInf ≤ Real.log c₂ - Real.log c₁ := by
+  obtain ⟨c₁, c₂, h1, h12, hle⟩ := growthRate_oscillation_le_window
+  exact ⟨c₁, c₂, h1, h12, growthRate_oscillation_nonneg, hle⟩
+
+/-- **The open question ⟺ zero oscillation.**  Chaining
+`exponentialBaseExists_iff_converges` with `converges_iff_oscillation_zero`:
+`h(n)` has a single exponential base iff the oscillation `limsup − liminf` of the growth
+rate is exactly `0`.  The oscillation form of `exponentialBaseExists_iff_limInfEqLimSup`. -/
+theorem exponentialBaseExists_iff_oscillation_zero :
+    exponentialBaseExists ↔ growthRateLimSup - growthRateLimInf = 0 :=
+  exponentialBaseExists_iff_converges.trans converges_iff_oscillation_zero
+
+/-- **The negation of the open question ⟺ strictly positive oscillation.**  No single
+exponential base exists iff the oscillation is strictly positive: since the oscillation is
+nonnegative (`growthRate_oscillation_nonneg`), failing to vanish means being `> 0`.  This
+is the crispest form of "the limit `lim log h(n)/n` fails to exist" — it is exactly the
+statement that the growth rate genuinely oscillates within Pyber's window. -/
+theorem not_exponentialBaseExists_iff_oscillation_pos :
+    ¬ exponentialBaseExists ↔ 0 < growthRateLimSup - growthRateLimInf := by
+  rw [exponentialBaseExists_iff_oscillation_zero]
+  exact ⟨fun h => lt_of_le_of_ne growthRate_oscillation_nonneg (Ne.symm h), fun h => h.ne'⟩
+
+end Erdos117OQ01Incomplete01


### PR DESCRIPTION
## Summary

Creates the companion `Proofs.Erdos117OQ01Incomplete01` to the Erdős #117 OQ-01
growth-rate framework (does `log h(n)/n` converge, i.e. does the abelian covering
number `h(n)` have a single exponential base?). The parent
`Proofs.Erdos117OQ01` characterises the open question via the *oscillation*
`growthRateLimSup − growthRateLimInf` and proves the one-sided window bound
`oscillation ≤ log c₂ − log c₁`, but never records the lower side or the negation.

## New theorems (4, 0 new axioms)

- **`growthRate_oscillation_nonneg`** — `0 ≤ limsup − liminf` (from `limInf_le_limSup`).
- **`oscillation_mem_window`** — the oscillation lies in `[0, log c₂ − log c₁]`,
  trapping it two-sided inside Pyber's log-window.
- **`exponentialBaseExists_iff_oscillation_zero`** — the open question restated: a
  single exponential base exists iff the oscillation vanishes.
- **`not_exponentialBaseExists_iff_oscillation_pos`** — the negation: **no** single
  base exists iff `0 < limsup − liminf`, the crispest "the limit fails to exist"
  phrasing (the growth rate genuinely oscillates within Pyber's window).

## Verification

- Docker build of `Proofs.Erdos117OQ01Incomplete01` **succeeds** (exit 0).
- **No new axioms** (the file inherits only the parent's three Pyber-bound
  assumptions `h` / `h_pos` / `pyber_bounds`), 0 sorries. Proofs use only
  `sub_nonneg` / `lt_of_le_of_ne` / `Iff.trans` over the parent's public API.
  Research variant — no gallery meta.

(Note: intermediate builds hit the documented shared-Mathlib-cache exit-135/SIGBUS
corruption from concurrent OOM builds; `--repair-cache` cleared it and the clean
build above confirms the change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)