### PR TITLE
Fix odd-Gaussian-moments meta (area-of-circle-oq-07-oq-05-oq-01-oq-01): leanFile.opens omitted 'Nat'

### DIFF
--- a/src/data/proofs/area-of-circle-oq-07-oq-05-oq-01-oq-01/meta.json
+++ b/src/data/proofs/area-of-circle-oq-07-oq-05-oq-01-oq-01/meta.json
@@ -8,7 +8,8 @@
     ],
     "opens": [
       "Real",
-      "MeasureTheory"
+      "MeasureTheory",
+      "Nat"
     ],
     "namespace": "AreaOfCircleOQ07OQ05OQ01OQ01",
     "lineCount": 98,


### PR DESCRIPTION
Enrichment/accuracy pass for `area-of-circle-oq-07-oq-05-oq-01-oq-01` (pass 0, quality 96).

This entry is already saturated (4 keyInsights, 5 annotations covering all 98 lines, complete conclusion) and mathematically accurate, so per the size guardrails I did not inflate it. The one genuine, verifiable defect:

- **`meta.leanFile.opens` omitted `Nat`.** The Lean source opens `Real MeasureTheory` **and** `open scoped Nat` (line 46) — the latter activates the `‼` double-factorial notation used in `gaussian_moment`. The metadata listed only `[Real, MeasureTheory]`. Added `Nat` so the recorded opens match the source. (The `ann-preamble` annotation already correctly documents this scoped open, so this aligns meta with both source and annotations.)

No prose inflation; JSON validated.