### PR TITLE
research(erdos-1098-oq-01-oq-03): bounded cliques pass to quotients (0-axiom, build green)

### DIFF
--- a/proofs/Proofs/Erdos1098OQ01OQ03.lean
+++ b/proofs/Proofs/Erdos1098OQ01OQ03.lean
@@ -506,6 +506,18 @@ theorem boundedCliques_of_surjective {K : Type*} [Group K] (f : G →* K)
   rw [← Finset.card_image_of_injective S hginj]
   exact hB _ hclique
 
+/-- **Bounded cliques pass to quotients (`ω(Γ(G/N)) ≤ ω(Γ(G))`).**  If `Γ(G)` has finite
+    clique number, then so does `Γ(G/N)` for every normal subgroup `N`: the canonical
+    projection `QuotientGroup.mk' N : G →* G/N` is surjective, so this is the special case
+    `f = mk' N` of `boundedCliques_of_surjective` (surjections push cliques back to a clique
+    of the same size in `G`).  Complements `boundedCliques_of_subgroup`
+    (`f = H.subtype`, injective, heredity downward): quotients and subgroups of a
+    bounded-clique group are again bounded-clique.  Axiom-free — only the elementary clique
+    transfer, not the BFC core `neumann_hard_direction`. -/
+theorem boundedCliques_quotient (N : Subgroup G) [N.Normal] (h : BoundedCliques G) :
+    BoundedCliques (G ⧸ N) :=
+  boundedCliques_of_surjective (QuotientGroup.mk' N) (QuotientGroup.mk'_surjective N) h
+
 /-- **Bounded cliques pull back along any injective homomorphism (heredity of ω(Γ)).**
     If `f : G →* K` is an *injective* homomorphism and `Γ(K)` has finite clique number,
     then so does `Γ(G)`: `ω(Γ(G)) ≤ ω(Γ(K))`.  The embedding `f` carries each clique

--- a/src/data/proofs/erdos-1098-oq-01-oq-03/meta.json
+++ b/src/data/proofs/erdos-1098-oq-01-oq-03/meta.json
@@ -34,10 +34,11 @@
       "exists_clique_centralizer_cover: ω(Γ(G)) finite ⟹ a single maximal clique's centralizers cover G (first proved step of Neumann's hard direction)",
       "exists_finiteIndex_centralizer_of_boundedCliques: ω(Γ(G)) finite ⟹ some centralizer C_G(a) has finite index, via Mathlib's CosetCover (B. H. Neumann's coset-covering theorem)",
       "neumann_full_theorem: the equivalence ω(Γ(G)) finite ⟺ [G:Z(G)] finite",
-      "center_finiteIndex_iff_relIndex_core: ω(Γ(G)) finite ⟹ [G:Z(G)] finite iff Z(G) has finite index within the explicit finite-index core H = ⋂ₐ C_G(a); localizes the residual axiom to (center G).relIndex H, whose Mathlib endgame is Subgroup.index_center_le_pow gated on Finite (commutatorSet G)"
+      "center_finiteIndex_iff_relIndex_core: ω(Γ(G)) finite ⟹ [G:Z(G)] finite iff Z(G) has finite index within the explicit finite-index core H = ⋂ₐ C_G(a); localizes the residual axiom to (center G).relIndex H, whose Mathlib endgame is Subgroup.index_center_le_pow gated on Finite (commutatorSet G)",
+      "boundedCliques_quotient: bounded cliques pass to quotients — ω(Γ(G/N)) ≤ ω(Γ(G)) for every normal N, since QuotientGroup.mk' N is surjective (the mk'-instance of boundedCliques_of_surjective); with boundedCliques_of_subgroup this makes both subgroups AND quotients of a bounded-clique group bounded-clique. Axiom-free."
     ],
-    "lineCount": 626,
-    "theoremCount": 15,
+    "lineCount": 698,
+    "theoremCount": 16,
     "defCount": 3,
     "definitionCount": 3
   },
@@ -144,7 +145,7 @@
     "axiomCount": 1,
     "sorries": 0,
     "definitionCount": 3,
-    "theoremCount": 18
+    "theoremCount": 19
   },
   "sorries": 0
 }


### PR DESCRIPTION
## Summary

Adds **`boundedCliques_quotient`** to the Neumann non-commuting-graph entry: if `Γ(G)` has finite clique number, so does `Γ(G/N)` for every normal subgroup `N`, i.e. `ω(Γ(G/N)) ≤ ω(Γ(G))`.

The canonical projection `QuotientGroup.mk' N : G →* G/N` is surjective, so this is the `f = mk' N` special case of the file's existing `boundedCliques_of_surjective` (surjections push cliques back to a clique of the same size in `G`). It completes the closure picture: together with `boundedCliques_of_subgroup` (subgroups, downward heredity), **both subgroups and quotients** of a bounded-clique group are again bounded-clique. Axiom-free — does not touch the BFC core axiom `neumann_hard_direction`.

## Verification

- **Whole-file docker build green (3061 jobs)** — fully machine-checked, no SIGBUS.
- `Erdos1098OQ01OQ03.lean` 686→698 lines, +1 theorem; still 1 axiom (`neumann_hard_direction`), 0 sorries. Gallery `meta.json` counts + contributions synced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)