### PR TITLE
research(sperner-ndim-oq-02): base-never-small + range-form canonicality primitives

### DIFF
--- a/proofs/Proofs/SpernerNDimOQ02Obstruction.lean
+++ b/proofs/Proofs/SpernerNDimOQ02Obstruction.lean
@@ -95,6 +95,29 @@ theorem no_canon_rep_of_lexMin_small {d N : ℕ} (t : GridSimplex d N) (v : Bary
     hmin (t'.verts k) (by rw [← hrange]; exact ⟨k, rfl⟩)
   exact not_canon_of_lexMin_small t' v hvmem hmin' hsmall hcanon
 
+/-- **The chain base is never small in every coordinate.**  The hypothesis-free core of
+the obstruction: for *any* grid simplex `t`, a barycentric point `v` all of whose
+coordinates are `< d` can never be the base `t.verts 0`.  Indeed `base_miss_ge_d` forces
+the base's `miss` coordinate to be `≥ d`, which `v`'s small coordinates cannot match.  No
+canonicality or lex-minimality assumption is needed — it is a property of the base alone,
+and is exactly what makes a small lex-minimum unreachable in `not_canon_of_lexMin_small`. -/
+theorem base_ne_of_small {d N : ℕ} (t : GridSimplex d N) (v : BaryPoint d N)
+    (hsmall : ∀ j, (v.coords j) < d) : v ≠ t.verts 0 := by
+  intro h
+  have hge : d ≤ (t.verts 0).coords t.miss := t.base_miss_ge_d
+  rw [← h] at hge
+  exact absurd hge (by have := hsmall t.miss; omega)
+
+/-- **Range form of canonicality.**  Unfolds `IsCanon t` (the base is `lexLE` every indexed
+vertex) to the set form: the base `t.verts 0` is `lexLE` every vertex `w` in the cell's
+vertex *set* `Set.range t.verts`.  This is the shape the general obstruction consumes
+(`no_canon_rep_of_lexMin_small` compares against `Set.range`), so it bridges the indexed
+predicate to the geometry-level statement "the base is a lex-minimum of the cell". -/
+theorem isCanon_base_lexLE_of_mem {d N : ℕ} (t : GridSimplex d N) (h : IsCanon t)
+    {w : BaryPoint d N} (hw : w ∈ Set.range t.verts) : (t.verts 0).lexLE w := by
+  obtain ⟨k, rfl⟩ := hw
+  exact h k
+
 /-- The three barycentric points of the witness cell. -/
 def p2 : BaryPoint 2 2 := ⟨![2, 0, 0], by decide⟩
 def p1 : BaryPoint 2 2 := ⟨![1, 1, 0], by decide⟩


### PR DESCRIPTION
## Summary

Extends the lex-min-base obstruction aux file `Proofs.SpernerNDimOQ02Obstruction`
(which proves `CanonSimplex`'s existence direction *fails* — a genuine Freudenthal cell
with no canonical representative) with two general primitives underlying that result.

## New theorems (2)

- **`base_ne_of_small`** — for *any* grid simplex `t`, a barycentric point `v` all of whose
  coordinates are `< d` is never the chain base `t.verts 0`. `base_miss_ge_d` forces the
  base's `miss` coordinate to be `≥ d`, which `v`'s small coordinates cannot match. This is
  the **hypothesis-free core** of `not_canon_of_lexMin_small` — no canonicality or
  lex-minimality assumption is needed; smallness alone excludes a vertex from being the base.
- **`isCanon_base_lexLE_of_mem`** — the **range form** of `IsCanon`: the base is `lexLE`
  every vertex `w` in the cell's vertex *set* `Set.range t.verts`, bridging the indexed
  predicate to the geometry-level statement consumed by `no_canon_rep_of_lexMin_small`.

Both re-use proof patterns already verified in this same file (`base_miss_ge_d` +
antisymmetry/`omega`; `Set.range` destructuring). 5 → 7 theorems, axiom-free, 0 sorries.

## Verification (honest note)

Both lemmas are mechanical instances of reasoning **already machine-checked in this file**:
`base_ne_of_small` is exactly the `base_miss_ge_d`/`omega` contradiction used in
`not_canon_of_lexMin_small` and `sBad_no_canon_rep`; `isCanon_base_lexLE_of_mem` is the
`obtain ⟨k, rfl⟩; exact h k` destructuring used at the top of `not_canon_of_lexMin_small`.

A fresh `docker-build.sh Proofs.SpernerNDimOQ02Obstruction` is currently **blocked by the
documented shared-Mathlib-cache exit-135/SIGBUS corruption** (`DOCKER-BUILD-RUNBOOK.md`):
the parent `Proofs.SpernerGridBase` SIGBUSes on a truncated shared olean, and two
`--repair-cache` passes did not clear it (concurrent build containers keep re-truncating the
shared volume). The failure is environmental, not a defect in this change. **Recommend a
clean re-verification once the shared cache is healthy** before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)