### PR TITLE
Research: inverse-galois-oq-03 — more Monster element orders + not cyclic/nilpotent

### DIFF
--- a/proofs/Proofs/InverseGaloisOQ03.lean
+++ b/proofs/Proofs/InverseGaloisOQ03.lean
@@ -377,6 +377,45 @@ Status of sporadic simple groups for the Inverse Galois Problem over ℚ:
 - M₂₃ is the sole remaining open case — see InverseGaloisOQ02.lean.
 -/
 
+/-! ### More element orders (Cauchy) and structural refinements -/
+
+/-- **𝕄 contains an element of order 3.**  Cauchy's theorem applied to the prime
+    `3 ∣ |𝕄|` (`three_dvd_Monster_card`); `3²⁰ ∥ |𝕄|`. -/
+theorem Monster_exists_element_orderOf_3 : ∃ g : Monster, orderOf g = 3 :=
+  haveI : Fact (Nat.Prime 3) := ⟨by norm_num⟩
+  exists_prime_orderOf_dvd_card 3 three_dvd_Monster_card
+
+/-- **𝕄 contains an element of order 5.**  Cauchy's theorem applied to the prime
+    `5 ∣ |𝕄|` (`five_dvd_Monster_card`); `5⁹ ∥ |𝕄|`. -/
+theorem Monster_exists_element_orderOf_5 : ∃ g : Monster, orderOf g = 5 :=
+  haveI : Fact (Nat.Prime 5) := ⟨by norm_num⟩
+  exists_prime_orderOf_dvd_card 5 five_dvd_Monster_card
+
+/-- **𝕄 contains an element of order 7.**  Cauchy's theorem applied to the prime
+    `7 ∣ |𝕄|` (`seven_dvd_Monster_card`); `7⁶ ∥ |𝕄|`. -/
+theorem Monster_exists_element_orderOf_7 : ∃ g : Monster, orderOf g = 7 :=
+  haveI : Fact (Nat.Prime 7) := ⟨by norm_num⟩
+  exists_prime_orderOf_dvd_card 7 seven_dvd_Monster_card
+
+/-- **𝕄 is not cyclic.**  A cyclic group is commutative (`IsCyclic.commGroup`), which
+    would contradict `Monster_not_commutative`.  (Every nonabelian group is non-cyclic; for
+    the simple 𝕄 this is another face of `Monster_center_eq_bot`.) -/
+theorem Monster_not_cyclic : ¬ IsCyclic Monster := by
+  intro h
+  apply Monster_not_commutative
+  intro a b
+  letI := @IsCyclic.commGroup Monster _ h
+  exact mul_comm a b
+
+/-- **𝕄 is not nilpotent.**  Every nilpotent group is solvable
+    (`IsNilpotent.to_isSolvable`), so non-solvability (`Monster_not_solvable`) upgrades to
+    non-nilpotency.  A strengthening of `Monster_not_solvable`: 𝕄 sits outside even the
+    larger class of nilpotent groups, as any non-abelian simple group must. -/
+theorem Monster_not_nilpotent : ¬ Group.IsNilpotent Monster := by
+  intro h
+  haveI := h
+  exact Monster_not_solvable inferInstance
+
 /-- 25 sporadic groups realized + 1 open (M₂₃) = 26 sporadic groups total. -/
 theorem sporadic_census : 25 + 1 = 26 := by norm_num
 

--- a/src/data/proofs/inverse-galois-oq-03/meta.json
+++ b/src/data/proofs/inverse-galois-oq-03/meta.json
@@ -39,9 +39,9 @@
         "relationship": "Sister entry on the non-solvable frontier and the solvability divide"
       }
     ],
-    "lineCount": 383,
+    "lineCount": 422,
     "mathlib_version": "4.26.0",
-    "theoremCount": 22,
+    "theoremCount": 27,
     "definitionCount": 0,
     "additionalFiles": []
   },
@@ -145,10 +145,10 @@
   "sorries": 0,
   "leanFile": {
     "path": "Proofs/InverseGaloisOQ03.lean",
-    "lineCount": 383,
+    "lineCount": 422,
     "axiomCount": 6,
     "sorries": 0,
-    "theoremCount": 22,
+    "theoremCount": 27,
     "definitionCount": 0,
     "imports": [
       "Mathlib",


### PR DESCRIPTION
## Summary

Extends `InverseGaloisOQ03.lean` (the Monster group 𝕄 and its realization as a Galois group over ℚ). Adds structural refinements alongside the existing order-2 (involution) and order-71 element results and the non-solvability chain.

## New theorems

- **`Monster_exists_element_orderOf_3` / `_5` / `_7`** — Cauchy's theorem (`exists_prime_orderOf_dvd_card`) at the primes `3, 5, 7 ∣ |𝕄|`, matching the existing order-2 and order-71 witnesses.
- **`Monster_not_cyclic`** — 𝕄 is not cyclic (a cyclic group is commutative via `IsCyclic.commGroup`, contradicting `Monster_not_commutative`).
- **`Monster_not_nilpotent`** — 𝕄 is not nilpotent (nilpotent ⟹ solvable via `IsNilpotent.to_isSolvable`, contradicting `Monster_not_solvable`); strengthens `Monster_not_solvable`.

Built on the file's intended `Monster` axioms (entry status: `axiomatized`). **No new axioms.** 22 → 27 theorems.

## Verification

The full-file `docker-build.sh` currently `exit 135`s (SIGBUS) — this file is bare `import Mathlib` + sibling chain, and the build host's Mathlib `.ir` codegen cache is intermittently corrupt under heavy load (unrelated to the proofs).

Verified by **direct `lean` elaboration** of a standalone file importing only the relevant group-theory Mathlib modules, with the `Monster` axioms and the same-file lemmas (`three/five/seven_dvd_Monster_card`, `Monster_not_commutative`, `Monster_not_solvable`) stubbed as `axiom`:

- Elaboration **exit 0**, no errors / no `sorry`.
- `#print axioms`: each new theorem depends only on `[propext, Classical.choice, Quot.sound]` plus the stubbed (intended) `Monster` axioms — **no new axioms**, no `sorryAx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)