### PR TITLE
research(erdos-1039-incomplete-01): conjectured bound < benchmark — complete the ordering chain (0-axiom)

### DIFF
--- a/proofs/Proofs/Erdos1039Problem.lean
+++ b/proofs/Proofs/Erdos1039Problem.lean
@@ -190,6 +190,19 @@ theorem bounds_gap (n : ℕ) (hn : n ≥ 3) (c : ℝ) (hc : 0 < c) (hc' : c < Re
     mul_lt_mul_of_pos_right hc' (show (0 : ℝ) < 2 * (n : ℝ) by positivity),
     mul_le_mul_of_nonneg_left hsqrt_ge_1 (show (0 : ℝ) ≤ Real.pi * (n : ℝ) by positivity)]
 
+/-- **Even the conjectured optimal bound stays below the benchmark.** For `c < π/2` and any
+`n ≥ 1`, the conjectured rate `c/n` is strictly below the benchmark `π/(2n)`.  This completes
+the ordering chain `pommerenke < klr < conjectured < benchmark`: `bounds_gap` places KLR below
+the benchmark and `klrBound_lt_conjecturedBound` places KLR below the conjecture, but the
+conjecture itself is also below the benchmark for admissible constants — clearing the common
+positive denominator reduces it to `2c < π`. -/
+theorem conjecturedBound_lt_benchmarkBound (c : ℝ) (hc' : c < Real.pi / 2) (n : ℕ) (hn : 0 < n) :
+    conjecturedBound c n < benchmarkBound n := by
+  simp only [conjecturedBound, benchmarkBound]
+  have hn_pos : (0 : ℝ) < (n : ℝ) := by exact_mod_cast hn
+  rw [div_lt_div_iff₀ hn_pos (by positivity : (0 : ℝ) < 2 * ↑n)]
+  nlinarith [mul_lt_mul_of_pos_right hc' (show (0 : ℝ) < 2 * (n : ℝ) by positivity)]
+
 /-
 ## The KLR–Conjecture Gap
 

--- a/src/data/proofs/erdos-1039/meta.json
+++ b/src/data/proofs/erdos-1039/meta.json
@@ -23,7 +23,7 @@
     "erdosProblemStatus": "open",
     "relatedProblems": [],
     "axiomCount": 4,
-    "lineCount": 762,
+    "lineCount": 854,
     "assumptions": "4 axioms, all genuine published research results the proof correctly leaves unformalized (not overclaimed): benchmark_upper (Erdos-Herzog-Piranian benchmark rho(z^n-1) <= pi/(2n)), pommerenke_lower (Pommerenke 1961, rho >= 1/(2en^2)), and klr_lower + klr_area_bound (Krishnapur-Lundberg-Ramachandran 2025, rho >> 1/(n*sqrt(log n))). Formalizing any of these would require reproducing the source papers, so they are stated as axioms. The three elementary-geometry lemmas (area_implies_disc_bound, degree_one_optimal, clustered_implies_large_disc) were completed in PR #33815 and the main file Proofs/Erdos1039Problem.lean has 0 sorries (543 lines). UPDATE: the former 5th axiom random_polynomial_expected was DEGENERATE — its intended Expected[rho] middle term was only a comment, so the Lean proposition collapsed to the trivially-true c1/sqrt(n) <= c2/sqrt(n); it has been converted to a proved theorem (witness c1=c2=1), removing a spurious entry from the axiom list (5 -> 4). The real Theta(1/sqrt n) expected-order claim needs an Expected functional and remains unformalized. The deprecated stub Proofs/Stubs/Erdos1039Problem.lean still holds the pre-#33815 state (3 sorries, the original 5 axioms) and is not the presented proof (proofRepoPath is the main file); it adds no distinct assumptions.",
     "mathlib_version": "4.29.0",
     "mathlibDependencies": [
@@ -60,7 +60,7 @@
       "random_polynomial_expected: now a proved theorem (degenerate as stated — c₁/√n ≤ c₂/√n, witness c₁=c₂=1); the genuine Θ(1/√n) expected-order claim needs an Expected functional and is unformalized",
       "sublevelSet_isBounded / rho_le_two / rho_mem_Ioc: assumption-free structural bounds on the geometry. The lemniscate sublevel set {z:|f(z)|<1} is bounded (it lies in B(0,2)), and every inscribed disc is therefore capped, giving the universal ceiling rho(f) ≤ 2 and hence rho(f) ∈ (0,2] for all positive-degree f. This frames the deep lower-bound axioms (Pommerenke, KLR), which sharpen the FLOOR of rho, with a matching elementary cap on its HEIGHT. Axiom-free ([propext, Classical.choice, Quot.sound])."
     ],
-    "theoremCount": 23,
+    "theoremCount": 24,
     "definitionCount": 17,
     "additionalFiles": [
       "Proofs/Erdos1039Aristotle.lean",
@@ -243,9 +243,9 @@
     ],
     "opens": [],
     "namespace": "Erdos1039",
-    "lineCount": 762,
+    "lineCount": 854,
     "axiomCount": 4,
-    "theoremCount": 23,
+    "theoremCount": 24,
     "definitionCount": 17,
     "path": "Proofs/Erdos1039Problem.lean",
     "sorries": 0,


### PR DESCRIPTION
## Summary

Adds **`conjecturedBound_lt_benchmarkBound`** to the polynomial-lemniscate inscribed-disc entry: for `c < π/2` and any `n ≥ 1`, the conjectured optimal rate `c/n` is strictly below the benchmark `π/(2n)`.

The file already establishes `klr < benchmark` (`bounds_gap`) and `klr < conjectured` (`klrBound_lt_conjecturedBound`), but not the conjectured-vs-benchmark edge. This fills it, so the full ordering chain **`pommerenke < klr < conjectured < benchmark`** holds. Proof clears the common positive denominator (`div_lt_div_iff₀`), reducing to `2c < π`, closed by `nlinarith` — the same pattern as the file's existing `bounds_gap`. Uses none of the file's axioms.

## Verification

- The arithmetic core was verified **green-elaborating** in a minimal-import build (with `π` abstracted): 0 elaboration errors across runs. Whole-file elaboration in `Erdos1039Problem.lean` also reported **0 errors**.
- The file uses `import Mathlib`; in the current sandbox that target (and even minimal files) hit a host-level SIGBUS (exit 135) during olean serialization — post-elaboration, no Lean error output, an environment limit rather than a proof error.
- Gallery `meta.json`: theoremCount 23→24; `lineCount` corrected 762→854 (was stale). axiomCount unchanged (4), 0 sorries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)