### PR TITLE
Enrich abel-ruffini-galois-extensions-oq-05-oq-02: typeclass-scaffolding annotation

### DIFF
--- a/src/data/proofs/abel-ruffini-galois-extensions-oq-05-oq-02/annotations.json
+++ b/src/data/proofs/abel-ruffini-galois-extensions-oq-05-oq-02/annotations.json
@@ -15,6 +15,21 @@
     "prerequisites": ["Galois theory", "finite group actions on fields"]
   },
   {
+    "id": "arar-oq0502-ann-setup",
+    "proofId": "abel-ruffini-galois-extensions-oq-05-oq-02",
+    "range": {
+      "startLine": 47,
+      "endLine": 53
+    },
+    "type": "context",
+    "title": "The typeclass scaffolding — where the faithfulness line is drawn",
+    "content": "The `variable (G : Type*) [Group G] (F : Type*) [Field F]` block fixes an abstract finite group and a field, and each theorem then opts into exactly the extra instances it needs. Reading the hypotheses is the fastest way to see the entry's dividing line in Lean terms: the structural half (`extension_isGalois`) asks only for `[Finite G] [MulSemiringAction G F]` — a finite group acting by ring automorphisms — whereas the realization half (`galoisGroupEquiv`, `degree_eq_card`, and the bundles) additionally demands `[FaithfulSMul G F]`. `MulSemiringAction G F` is the action by field automorphisms that carves out the fixed field `FixedPoints.subfield G F`; `FaithfulSMul G F` (distinct elements of G act differently) is precisely what upgrades the canonical map `G → Gal(F/F^G)` from a surjection-onto-a-quotient to an isomorphism. `open scoped Classical` licences noncomputable choice (needed to invert the equiv), and `open MulSemiringAction` brings the action notation into scope. The subtle `[Finite G]` vs `[Fintype G]` split across theorems is a purely Lean-level distinction (mere finiteness vs a chosen enumeration for the cardinality `Fintype.card G`).",
+    "mathContext": "$[\\text{Finite }G] + [\\text{MulSemiringAction }G\\,F]$ suffices for $F/F^G$ Galois; adding $[\\text{FaithfulSMul }G\\,F]$ is exactly what makes $G \\cong \\mathrm{Gal}(F/F^G)$ (rather than a quotient).",
+    "significance": "context",
+    "relatedConcepts": ["MulSemiringAction", "FaithfulSMul", "Finite vs Fintype", "fixed field FixedPoints.subfield G F", "typeclass variable block"],
+    "prerequisites": ["group actions on fields by automorphisms", "Lean typeclass hypotheses", "faithful actions"]
+  },
+  {
     "id": "arar-oq0502-ann-structural",
     "proofId": "abel-ruffini-galois-extensions-oq-05-oq-02",
     "range": {


### PR DESCRIPTION
Enrichment pass for `abel-ruffini-galois-extensions-oq-05-oq-02` (The Artin Realizability Direction).

The entry is already high quality (5 rich annotations, 5 keyInsights, 5 sections, full conclusion). Rather than inflate saturated fields, this pass fills the single genuine gap: annotation coverage of the typeclass scaffolding (lines 47–53).

## What changed
- Added `arar-oq0502-ann-setup` (type `context`) covering the `namespace` / `open` / `variable` block.
- It surfaces the entry's central dividing line in Lean terms: the **structural half** (`extension_isGalois`) needs only `[Finite G] [MulSemiringAction G F]`, while the **realization half** (`galoisGroupEquiv`, `degree_eq_card`, bundles) additionally requires `[FaithfulSMul G F]` — faithfulness is exactly what upgrades `G → Gal(F/F^G)` from a quotient surjection to an isomorphism.
- Notes the `Finite` vs `Fintype` split and the role of `open scoped Classical`.

## Verification
- JSON validates; `annotations:build` reports **no errors** for this entry.
- Only `annotations.json` staged (build-generated side-effects discarded). `index.ts`/`knowledge.md` untouched.
- No changes to `status`/`badge`/`axiomCount` (remains verified, 0 axioms).