### PR TITLE
research(algebraic-numbers-countable-oq-07): transcendentals and Liouville numbers are dense (0-axiom)

### DIFF
--- a/proofs/Proofs/AlgebraicNumbersCountableOQ07.lean
+++ b/proofs/Proofs/AlgebraicNumbersCountableOQ07.lean
@@ -70,4 +70,19 @@ theorem isMeagre_setOf_isAlgebraic : IsMeagre {x : ℝ | IsAlgebraic ℤ x} := b
 theorem exists_null_comeagre : ∃ S : Set ℝ, volume S = 0 ∧ S ∈ residual ℝ :=
   ⟨{x : ℝ | Liouville x}, liouville_null, liouville_comeagre⟩
 
+/-- **The transcendental reals are dense.**  A comeagre subset of the Baire space `ℝ` is
+    dense (`dense_of_mem_residual`), so `comeagre_setOf_transcendental` immediately gives that
+    the transcendentals are dense in `ℝ`: between any two reals lies a transcendental.  The
+    topological ubiquity counterpart to the meagreness of the algebraics
+    (`isMeagre_setOf_isAlgebraic`). -/
+theorem dense_setOf_transcendental : Dense {x : ℝ | Transcendental ℤ x} :=
+  dense_of_mem_residual comeagre_setOf_transcendental
+
+/-- **The Liouville numbers are dense.**  Likewise the comeagre Liouville set is dense in
+    `ℝ` — every open interval contains a Liouville number — so Baire-smallness of the
+    algebraics coexists with a topologically ubiquitous (and Lebesgue-null, by
+    `liouville_null`) set of transcendentals. -/
+theorem dense_setOf_liouville : Dense {x : ℝ | Liouville x} :=
+  dense_of_mem_residual liouville_comeagre
+
 end AlgebraicNumbersCountableOQ07


### PR DESCRIPTION
## Summary

Two 0-axiom corollaries added to `AlgebraicNumbersCountableOQ07.lean` (Liouville / transcendental Baire-category facts), via Mathlib's `dense_of_mem_residual` (comeagre sets in a Baire space are dense):

- **`dense_setOf_transcendental`** — `Dense {x : ℝ | Transcendental ℤ x}`, from the file's `comeagre_setOf_transcendental`. The topological-ubiquity counterpart to `isMeagre_setOf_isAlgebraic`: between any two reals lies a transcendental.
- **`dense_setOf_liouville`** — `Dense {x : ℝ | Liouville x}`, from `liouville_comeagre`. Every open interval contains a Liouville number, so Baire-smallness of the algebraics coexists with a dense, Lebesgue-null (`liouville_null`) set of transcendentals.

## Verification

- The `dense_of_mem_residual` application pattern on `ℝ` (resolving the `BaireSpace ℝ` instance) was verified **green** in a minimal-import build (`Mathlib.Topology.Baire.Lemmas`). Whole-file elaboration of `AlgebraicNumbersCountableOQ07.lean` reported **0 errors**.
- The file uses `import Mathlib`; in the current sandbox that target hits a host-level SIGBUS (exit 135) during olean serialization — post-elaboration, no Lean error output, an environment limit not a proof error.
- This file is not tracked in a gallery `meta.json`, so no metadata changes are needed. Still 0 axioms, 0 sorries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)