### PR TITLE
Research: shannon-channel-coding-awgn-oq-03-oq-01 — fill referenced water-filling lemmas

### DIFF
--- a/proofs/Proofs/ShannonChannelCodingAWGNOQ03OQ01.lean
+++ b/proofs/Proofs/ShannonChannelCodingAWGNOQ03OQ01.lean
@@ -141,6 +141,52 @@ theorem waterAlloc_pos_of_le {μ₁ μ₂ : ℝ} (h : μ₁ ≤ μ₂) (N : ι �
     (hi : 0 < waterAlloc μ₁ N i) : 0 < waterAlloc μ₂ N i :=
   (waterAlloc_pos_iff μ₂ N i).mpr (lt_of_lt_of_le ((waterAlloc_pos_iff μ₁ N i).mp hi) h)
 
+/-- **The water-filling depth is monotone in the water level.**  Raising the water level
+    can only deepen every channel: `μ₁ ≤ μ₂ ⟹ (μ₁ − Nᵢ)₊ ≤ (μ₂ − Nᵢ)₊`.  The depth-level
+    statement whose active-set corollary is `waterAlloc_pos_of_le`; immediate from
+    monotonicity of `max`. -/
+theorem waterAlloc_mono_level {μ₁ μ₂ : ℝ} (h : μ₁ ≤ μ₂) (N : ι → ℝ) (i : ι) :
+    waterAlloc μ₁ N i ≤ waterAlloc μ₂ N i := by
+  unfold waterAlloc
+  exact max_le_max (by linarith) (le_refl 0)
+
+/-- The per-channel capacity is non-negative for non-negative power and positive noise:
+    `½·log(1 + P/N) ≥ 0` since `1 + P/N ≥ 1`. -/
+theorem perUseCapacity_nonneg {P N : ℝ} (hP : 0 ≤ P) (hN : 0 < N) :
+    0 ≤ perUseCapacity P N := by
+  unfold perUseCapacity
+  have h1 : (1 : ℝ) ≤ 1 + P / N := by have := div_nonneg hP hN.le; linarith
+  have := Real.log_nonneg h1
+  linarith
+
+/-- The per-channel capacity is strictly positive for positive power and positive noise:
+    `½·log(1 + P/N) > 0` since `1 + P/N > 1`. -/
+theorem perUseCapacity_pos {P N : ℝ} (hP : 0 < P) (hN : 0 < N) :
+    0 < perUseCapacity P N := by
+  unfold perUseCapacity
+  have h1 : (1 : ℝ) < 1 + P / N := by have := div_pos hP hN; linarith
+  have := Real.log_pos h1
+  linarith
+
+/-- The total water-filling budget is non-negative: `∑ᵢ (μ − Nᵢ)₊ ≥ 0` as a sum of
+    non-negative depths (`waterAlloc_nonneg`). -/
+theorem waterBudget_nonneg (N : ι → ℝ) (μ : ℝ) : 0 ≤ waterBudget N μ :=
+  Finset.sum_nonneg (fun i _ => waterAlloc_nonneg μ N i)
+
+/-- **Positive rate from an active channel (sum level).**  If at least one channel is
+    active (`∃ i, Nᵢ < μ`) then the water-filling allocation achieves a strictly positive
+    total rate: `0 < parallelRate N (waterAlloc μ N)`.  The sum-level companion of the
+    per-channel `waterAlloc_pos_iff`: every capacity term is non-negative
+    (`perUseCapacity_nonneg`), and the active channel contributes a strictly positive one
+    (`waterAlloc_pos_iff` + `perUseCapacity_pos`), so the sum is positive. -/
+theorem rate_waterAlloc_pos (N : ι → ℝ) (hN : ∀ i, 0 < N i) {μ : ℝ}
+    (hex : ∃ i, N i < μ) : 0 < parallelRate N (waterAlloc μ N) := by
+  unfold parallelRate
+  obtain ⟨j, hj⟩ := hex
+  refine Finset.sum_pos' (fun i _ => perUseCapacity_nonneg (waterAlloc_nonneg μ N i) (hN i))
+    ⟨j, Finset.mem_univ j, ?_⟩
+  exact perUseCapacity_pos ((waterAlloc_pos_iff μ N j).mpr hj) (hN j)
+
 /-! ## Optimality of the water-filling allocation -/
 
 /-- **Per-channel tangent bound** (the first-order optimality condition, in


### PR DESCRIPTION
## Summary

Extends `ShannonChannelCodingAWGNOQ03OQ01.lean` (water-filling for parallel Gaussian / AWGN channels). Two lemmas are **referenced in docstrings but were never defined** — `waterAlloc_mono_level` (cited by `waterAlloc_pos_of_le`) and `rate_waterAlloc_pos` (cited by `waterAlloc_pos_iff`). This adds them and the building blocks they need.

## New theorems (axiom-free)

- **`waterAlloc_mono_level`** — the depth `(μ − Nᵢ)₊` is monotone in the water level `μ` (the depth-level statement whose active-set corollary is `waterAlloc_pos_of_le`).
- **`perUseCapacity_nonneg`** / **`perUseCapacity_pos`** — `½·log(1 + P/N) ≥ 0` for `P ≥ 0` and `> 0` for `P > 0` (with `N > 0`).
- **`waterBudget_nonneg`** — the total budget `∑ᵢ (μ − Nᵢ)₊` is non-negative.
- **`rate_waterAlloc_pos`** — an active channel (`∃ i, Nᵢ < μ`) forces a strictly positive total rate `parallelRate N (waterAlloc μ N)` (the sum-level companion of the per-channel `waterAlloc_pos_iff`, via `Finset.sum_pos'`).

Research-variant file (no gallery `meta.json`).

## Verification

The full-file `docker-build.sh` currently fails at `import Mathlib` (line 61) with `invalid header` on category-theory / Aesop `.olean` cache files — the build host's shared Mathlib cache is intermittently corrupt (unrelated to the proofs).

Verified by **direct `lean` elaboration** of a standalone file importing only the relevant analysis / big-operator Mathlib modules, with the four definitions and the two helper lemmas (`waterAlloc_nonneg`, `waterAlloc_pos_iff`) reproduced identically from the target file:

- Elaboration **exit 0**, no errors / no `sorry`.
- `#print axioms` on `waterAlloc_mono_level` and `rate_waterAlloc_pos`: `[propext, Classical.choice, Quot.sound]` — **axiom-free**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)