### PR TITLE
Enrich basel-problem-oq-01-oq-01-oq-02-oq-01-oq-01: add preamble section (3→4)

### DIFF
--- a/src/data/proofs/basel-problem-oq-01-oq-01-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/basel-problem-oq-01-oq-01-oq-02-oq-01-oq-01/meta.json
@@ -136,6 +136,14 @@
   ],
   "sections": [
     {
+      "id": "preamble",
+      "title": "Preamble: overview, imports, and setup",
+      "startLine": 1,
+      "endLine": 46,
+      "summary": "Imports (the parent companion BaselProblemOQ01OQ01OQ02OQ01 supplying the Apéry b-sequence and its lower bound 4ⁿ ≤ bₙ, plus Nat.Choose.Vandermonde and the NatAntidiagonal big-operators API) and a module docstring that frames the two open questions being closed — a matching axiom-free geometric UPPER bound and the parity of bₙ — against the grandparent ζ(3) file's axiomatic bₙ ≤ 34ⁿ. Lists all seven results and opens BigOperators/Finset/Nat under namespace AperyCentralBinom.",
+      "mathContext": "$b_n=\\sum_{k=0}^n\\binom{n}{k}^2\\binom{n+k}{k}^2$; goal: $b_n\\le 64^n$ and $b_n$ odd, $0$ axioms."
+    },
+    {
       "id": "vandermonde-diagonal",
       "title": "Section I: Vandermonde on the diagonal",
       "startLine": 47,


### PR DESCRIPTION
Enrichment pass for `basel-problem-oq-01-oq-01-oq-02-oq-01-oq-01` (Apéry numbers: axiom-free geometric upper bound & parity).

The entry is already high quality (5 keyInsights, 5 annotations, full mainTheorems/conclusion). The one genuine gap: the `sections` array started at line 47, so the docstring/imports/setup (lines 1–46) had **no section**.

## What changed
- Added a `Preamble: overview, imports, and setup` section (lines 1–46), completing full-file section coverage (3 → 4 sections).
- Summarizes the imports (parent `b`-sequence + Vandermonde/antidiagonal APIs) and the docstring framing: two closed open questions (axiom-free upper bound `bₙ ≤ 64ⁿ` + parity `bₙ` odd) against the grandparent ζ(3) file's axiomatic `bₙ ≤ 34ⁿ`.

## Verification
- JSON validates; sections now 4, first startLine 1; meta.json 16.3 KB (< 60 KB cap).
- Only `meta.json` staged; build side-effects discarded; `index.ts` untouched.
- No change to `status`/`badge`/`axiomCount` (original, 0 axioms).