### PR TITLE
Enrich beta-integral-recurrence-oq-01-oq-03-oq-01: add preamble section (3→4)

### DIFF
--- a/src/data/proofs/beta-integral-recurrence-oq-01-oq-03-oq-01/meta.json
+++ b/src/data/proofs/beta-integral-recurrence-oq-01-oq-03-oq-01/meta.json
@@ -90,6 +90,14 @@
   },
   "sections": [
     {
+      "id": "preamble",
+      "title": "Preamble: docstring, imports, and setup",
+      "startLine": 1,
+      "endLine": 41,
+      "summary": "Module docstring framing the leaf: the parent BetaIntegralRecurrenceOQ01OQ03 supplied the diagonal real integral ∫₀¹ xⁿ(1-x)ⁿ = (n!)²/(2n+1)!, and this leaf supplies the full off-diagonal value ∫₀¹ xᵐ(1-x)ⁿ = m!·n!/(m+n+1)!, proved two independent ways — the complex bridge (Route 1) and a self-contained integration-by-parts recurrence that never leaves ℝ (Route 2), with an agreement lemma checking they coincide. Notes that neither the off-diagonal real integral nor its recurrence is in Mathlib. Imports the grandparent BetaIntegralRecurrence, opens Complex/intervalIntegral/MeasureTheory, and enters namespace BetaIntegralRecurrenceOQ01OQ03OQ01.",
+      "mathContext": "$\\int_0^1 x^m(1-x)^n\\,dx = \\dfrac{m!\\,n!}{(m+n+1)!}$, proved two ways."
+    },
+    {
       "id": "complex-bridge",
       "title": "Route 1 — the complex bridge",
       "startLine": 42,


### PR DESCRIPTION
Enrichment pass for `beta-integral-recurrence-oq-01-oq-03-oq-01` (off-diagonal real Euler Beta integral, proved two ways).

The entry is already high quality (5 keyInsights, 6 annotations, structured crossReferences, full conclusion). The one gap: `sections` started at line 42, so the docstring/imports/setup (lines 1–41) had **no section**.

## What changed
- Added a `Preamble: docstring, imports, and setup` section (lines 1–41), completing full-file section coverage (3 → 4 sections).
- Summarizes the two-routes framing (complex bridge vs self-contained integration-by-parts recurrence + agreement lemma) and the import/namespace setup.

## Verification
- JSON validates; sections now 4, first startLine 1; meta.json 16.7 KB (< 60 KB).
- Only `meta.json` staged; build side-effects discarded; `index.ts` untouched.
- No change to `status`/`badge`/`axiomCount` (original, 0 axioms).