### PR TITLE
Research: erdos-1022-oq-02 — base positivity + t≤1 characterization of firstMomentThreshold

### DIFF
--- a/proofs/Proofs/Erdos1022OQ02.lean
+++ b/proofs/Proofs/Erdos1022OQ02.lean
@@ -230,6 +230,28 @@ theorem firstMoment_threshold_ge_self (t : ℕ) (ht : 1 ≤ t) :
 theorem firstMomentThreshold_two : firstMomentThreshold 2 = 2 := by
   unfold firstMomentThreshold; norm_num
 
+/-- The first-moment threshold is always strictly positive: `2^{t-1} ≥ 1`.  A base
+    positivity fact for the sparseness bound `c · n ≤ 2^{t-1}` — the admissible density is
+    never vacuously zero. -/
+theorem firstMomentThreshold_pos (t : ℕ) : 0 < firstMomentThreshold t := by
+  unfold firstMomentThreshold; positivity
+
+/-- **Lovász base case `t = 1`** (companion to `firstMomentThreshold_two`).  The threshold
+    at `t = 1` is `1`: `2^0 = 1`.  A single-element set family is trivially 2-colorable, and
+    the crude first-moment bound reflects this with the minimal threshold `1`. -/
+theorem firstMomentThreshold_one : firstMomentThreshold 1 = 1 := by
+  unfold firstMomentThreshold; norm_num
+
+/-- **The threshold is `1` exactly on the degenerate regime `t ≤ 1`.**  `2^{t-1} = 1 ↔ t ≤ 1`:
+    the first-moment sparseness threshold sits at its minimal value `1` precisely for the two
+    truncated-subtraction-collapsed cases `t = 0, 1`, and is `≥ 2` (strictly growing) from
+    `t = 2` onward.  This pins the boundary of the exponential-growth regime driving
+    `firstMoment_threshold_lt` / `_doubles`. -/
+theorem firstMomentThreshold_eq_one_iff (t : ℕ) : firstMomentThreshold t = 1 ↔ t ≤ 1 := by
+  unfold firstMomentThreshold
+  rw [Nat.pow_eq_one]
+  omega
+
 -- ══════════════════════════════════════════════════════════════════
 -- § 6: The threshold diverges — a formal `c_t → ∞`
 -- ══════════════════════════════════════════════════════════════════

--- a/src/data/proofs/erdos-1022-oq-02/meta.json
+++ b/src/data/proofs/erdos-1022-oq-02/meta.json
@@ -25,7 +25,7 @@
     "mathlib_version": "4.26.0",
     "axiomCount": 0,
     "assumptions": "No axioms and no sorries: all theorems are fully machine-checked from Mathlib (depends only on propext / Classical.choice / Quot.sound). This is a partial result addressing the first-moment regime of OQ-02; the open conjecture of Erdős #1022 (whether c_t → ∞ for arbitrarily large ground sets) is NOT resolved here.",
-    "lineCount":      786,
+    "lineCount": 786,
     "relatedProblems": [
       {
         "id": "erdos-1022",
@@ -129,7 +129,7 @@
     }
   ],
   "leanFile": {
-    "lineCount":      786,
+    "lineCount": 786,
     "structureCount": 0,
     "axiomCount": 0,
     "theoremCount": 37,

--- a/src/data/proofs/erdos-1022-oq-02/meta.json
+++ b/src/data/proofs/erdos-1022-oq-02/meta.json
@@ -25,7 +25,7 @@
     "mathlib_version": "4.26.0",
     "axiomCount": 0,
     "assumptions": "No axioms and no sorries: all theorems are fully machine-checked from Mathlib (depends only on propext / Classical.choice / Quot.sound). This is a partial result addressing the first-moment regime of OQ-02; the open conjecture of Erdős #1022 (whether c_t → ∞ for arbitrarily large ground sets) is NOT resolved here.",
-    "lineCount": 721,
+    "lineCount":      786,
     "relatedProblems": [
       {
         "id": "erdos-1022",
@@ -40,7 +40,7 @@
         "relationship": "Builds on: Erdős 1963 uniform first-moment theorem (reuses Mono, card_mono, exists_zero_of_sum_lt_card)"
       }
     ],
-    "theoremCount": 32,
+    "theoremCount": 37,
     "definitionCount": 3
   },
   "overview": {
@@ -129,10 +129,10 @@
     }
   ],
   "leanFile": {
-    "lineCount": 721,
+    "lineCount":      786,
     "structureCount": 0,
     "axiomCount": 0,
-    "theoremCount": 32,
+    "theoremCount": 37,
     "lemmaCount": 0,
     "imports": [
       "Mathlib",


### PR DESCRIPTION
## Summary

Extends `Erdos1022OQ02.lean` (Property B / first-moment sparseness for the `k`-uniform 2-coloring problem). Fills missing basic facts about the first-moment threshold `firstMomentThreshold(t) = 2^{t-1}`, complementing the existing `_doubles`, `_lt`, `_ge_self`, `_mono`, `_two`.

## New theorems (axiom-free)

- **`firstMomentThreshold_pos`** — `2^{t-1} > 0` always (base positivity of the sparseness bound `c·n ≤ 2^{t-1}`).
- **`firstMomentThreshold_one`** — the threshold at `t = 1` is `1` (companion to the existing `firstMomentThreshold_two`).
- **`firstMomentThreshold_eq_one_iff`** — `2^{t-1} = 1 ↔ t ≤ 1`, pinning the degenerate constant regime (`t = 0, 1`, collapsed by truncated subtraction) that the exponential growth `firstMoment_threshold_lt` / `_doubles` grows out of from `t = 2` onward.

Third visit to this file (prior `admissibleCoeff` PRs #37778 / #37858 are pending; these `firstMomentThreshold` lemmas are independent and non-conflicting).

## Verification

Full-file `docker-build.sh` is blocked by the recurring environmental corrupt-Mathlib-`.ir`/host-load SIGBUS on `import Mathlib`. Verified by **direct `lean` elaboration** of a standalone file (minimal `Nat` imports, `firstMomentThreshold` reproduced identically):

- Elaboration **exit 0**, no errors / no `sorry`.
- `#print axioms firstMomentThreshold_eq_one_iff`: `[propext, Classical.choice, Quot.sound]` — **axiom-free**.
- `meta.json` counts synced to the actual file state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)