### PR TITLE
research(hilbert-10-oq-01-oq-02): affine pullback is a Boolean-algebra homomorphism (0-axiom)

### DIFF
--- a/proofs/Proofs/Hilbert10OQ01OQ02.lean
+++ b/proofs/Proofs/Hilbert10OQ01OQ02.lean
@@ -3223,6 +3223,33 @@ theorem affinePullback_cancel_left {a : Rat} (ha : a ≠ 0) (b : Rat) (S : RatSu
   have hb : a * -(a⁻¹ * b) + b = 0 := by rw [mul_neg, ← mul_assoc, h1, one_mul]; ring
   rw [h1, hb, affinePullback_id]
 
+/-! ### The affine action is a Boolean-algebra homomorphism on `RatSubset`
+
+Since `affinePullback a b` is precomposition `S ↦ S ∘ (·a + b)` on `RatSubset = ℚ → Prop`, it
+commutes with the pointwise Boolean operations — complement (`¬`), union (`∨`), intersection
+(`∧`). These structural facts sit underneath its interaction with the Σ/Π definability
+hierarchy (e.g. the complement duality `diophantine_iff_codiophantine_complement` and the
+finite union/intersection closures), and complete the algebraic picture of the affine action
+alongside its group laws `affinePullback_id`/`_comp`/`_cancel`/`_cancel_left`. -/
+
+/-- **Affine pullback commutes with complement.**  Precomposition commutes with pointwise
+negation: the pullback of the complement is the complement of the pullback. -/
+theorem affinePullback_compl (a b : Rat) (S : RatSubset) :
+    affinePullback a b (fun q => ¬ S q) = fun q => ¬ affinePullback a b S q := by
+  funext q; rfl
+
+/-- **Affine pullback commutes with union** (pointwise `∨`). -/
+theorem affinePullback_union (a b : Rat) (S T : RatSubset) :
+    affinePullback a b (fun q => S q ∨ T q)
+      = fun q => affinePullback a b S q ∨ affinePullback a b T q := by
+  funext q; rfl
+
+/-- **Affine pullback commutes with intersection** (pointwise `∧`). -/
+theorem affinePullback_inter (a b : Rat) (S T : RatSubset) :
+    affinePullback a b (fun q => S q ∧ T q)
+      = fun q => affinePullback a b S q ∧ affinePullback a b T q := by
+  funext q; rfl
+
 /-! ### Each definability class is an invariant subset of the affine action
 
 The four closure lemmas `affinePullback_is{,Co}DiophantineDefinition` /

--- a/src/data/proofs/hilbert-10-oq-01-oq-02/meta.json
+++ b/src/data/proofs/hilbert-10-oq-01-oq-02/meta.json
@@ -147,7 +147,7 @@
     ],
     "dateAdded": "2026-05-08",
     "axiomCount": 1,
-    "lineCount": 3502,
+    "lineCount": 3625,
     "prerequisites": [
       "Hilbert's 10th problem over ℚ (companion file Hilbert10OQ01.lean)",
       "Arithmetic hierarchy (Σ_n / Π_n) at the level of polynomial formulas",
@@ -155,7 +155,7 @@
     ],
     "assumptions": "One axiom: `koenigsmann_2016_universal` — ℤ is Π₂-definable in ℚ. This is PROVED in Koenigsmann (Annals 2016) via an explicit polynomial built from Hilbert symbols and quaternion algebras over ℚ; axiomatized here pending a Lean formalization of that construction. All other results in this file (Σ₁ → ¬H10/ℚ-decidable, Mazur → ¬Σ₁, the Σ₁/Π₁ and Σ₂/Π₂ dualities and their specializations to ℤ ⊂ ℚ, the Π₁(ℚ\\ℤ) re-exports, the Π₁ ⊆ Σ₂ containment, and the Σ₂(ℚ\\ℤ) corollary of Koenigsmann) are NOT new axioms — they are logical consequences of the OQ-01 axioms together with the Σ₁/Π₁ and Σ₂/Π₂ equivalences proved here. Both duality theorems use classical excluded middle (`Classical.byContradiction`) to convert ¬¬p to p; the Σ₂/Π₂ duality and the Σ₂(ℚ\\ℤ) corollary use it twice, the Σ₁/Π₁ duality once.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 113,
+    "theoremCount": 116,
     "definitionCount": 17
   },
   "overview": {
@@ -303,9 +303,9 @@
     ],
     "opens": [],
     "namespace": "Hilbert10Rationals",
-    "lineCount": 3502,
+    "lineCount": 3625,
     "axiomCount": 1,
-    "theoremCount": 110,
+    "theoremCount": 113,
     "definitionCount": 17,
     "path": "Proofs/Hilbert10OQ01OQ02.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

Three 0-axiom structural lemmas completing the affine-action algebra on `RatSubset = ℚ → Prop`. Since `affinePullback a b` is precomposition `S ↦ S ∘ (·a + b)`, it commutes with the pointwise Boolean operations:

- **`affinePullback_compl`** — pullback of a complement is the complement of the pullback.
- **`affinePullback_union`** — commutes with pointwise `∨`.
- **`affinePullback_inter`** — commutes with pointwise `∧`.

Together these exhibit `affinePullback a b` as a Boolean-algebra homomorphism, the set-operation layer underneath its interaction with the Σ/Π definability hierarchy (complement duality `diophantine_iff_codiophantine_complement`, finite union/intersection closures). They round out the algebraic picture alongside the existing group laws `affinePullback_id`/`_comp`/`_cancel`/`_cancel_left`.

## Verification

- Each proof is a one-line `funext q; rfl`. The reduction pattern was verified **green** in a minimal build; whole-file elaboration of `Hilbert10OQ01OQ02.lean` reported **0 errors**.
- The file (3625 lines) uses targeted imports; in the current sandbox serialization SIGBUS's (exit 135) post-elaboration — an environment memory limit, not a proof error.
- Gallery `meta.json`: theoremCount +3; `lineCount` corrected 3502→3625 (was stale). axiomCount unchanged (1), 0 sorries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)