### PR TITLE
research(erdos-1-oq-02-incomplete-01): pin f(4)=7 exactly; remove un-buildable f(5)/f(6) [VERIFIED 0-axiom]

### DIFF
--- a/proofs/Proofs/Erdos1OQ02.lean
+++ b/proofs/Proofs/Erdos1OQ02.lean
@@ -656,32 +656,21 @@ theorem f_four_lt_geometric :
   obtain ⟨A, hcard, hDSS, hsup⟩ := f_four
   exact ⟨A, hcard, hDSS, by rw [hsup]; norm_num⟩
 
-/-- f(5) = 13: the Conway–Guy set `{6, 9, 11, 12, 13}` has `2⁵ = 32` distinct subset
-    sums with maximum element `13`.  This is the `n = 5` entry of OEIS A005318,
-    continuing `f_zero`…`f_four`, and the margin over the greedy powers-of-two witness
-    widens further: `{1, 2, 4, 8, 16}` also has distinct subset sums but maximum `16`,
-    so `f(5) = 13 < 16 = 2⁴`.  Together with `f_four` (`f(4) = 7 < 8`) this shows the
-    doubling construction is strictly beaten for every `n ≥ 4`, and the gap `2ⁿ⁻¹ − f(n)`
-    grows (`8 − 7 = 1` at `n = 4`, `16 − 13 = 3` at `n = 5`) — the phenomenon whose
-    asymptotics the DFX bound `dfx_lower_bound` quantifies.  The
-    `hasDistinctSubsetSums {6,9,11,12,13}` obligation is discharged by enumerating the
-    thirty-two subsets (`fin_cases` over the powerset) and deciding each subset-pair sum
-    comparison, exactly as in `f_two_max`…`f_four`. -/
-theorem f_five :
-    ∃ (A : Finset ℕ), A.card = 5 ∧ hasDistinctSubsetSums A ∧ A.sup id = 13 := by
-  refine ⟨{6, 9, 11, 12, 13}, by decide, ?_, by decide⟩
-  intro S T hS hT heq
-  have hS' : S ∈ ({6, 9, 11, 12, 13} : Finset ℕ).powerset := Finset.mem_powerset.mpr hS
-  have hT' : T ∈ ({6, 9, 11, 12, 13} : Finset ℕ).powerset := Finset.mem_powerset.mpr hT
-  fin_cases hS' <;> fin_cases hT' <;> revert heq <;> decide
-
 /-- **Cardinality certificate for distinct subset sums (0 axioms).**  A finite set `A`
     has distinct subset sums exactly when the subset-sum map `S ↦ ∑_{i∈S} i` is injective
     on `A.powerset`, i.e. when its image has the full cardinality `2^|A| = |A.powerset|`.
     This converts the `∀ S T` distinctness obligation into a *single* decidable
     cardinality equality, which `decide` checks by computing the `2^|A|` subset sums and
     counting distinct values — cheap where the quadratic `fin_cases` over pairs
-    (`2^|A| × 2^|A|` cases) becomes intractable (e.g. `|A| = 6`). -/
+    (`2^|A| × 2^|A|` cases) becomes intractable (e.g. `|A| = 6`).
+
+    NOTE: verifying that equality by `decide` still evaluates a `Finset.image` dedup over
+    the whole `2^|A|`-element powerset, which overflows the Lean kernel's C stack (SIGBUS /
+    build exit code 135) once `|A| ≥ 5` — as does the pairwise `fin_cases` route.  The
+    larger Conway–Guy witnesses `f(5) = 13`, `f(6) = 24` therefore cannot be certified
+    axiom-free by brute force (only via `native_decide`, which would add `Lean.ofReduceBool`
+    and forfeit the file's 0-axiom status); a robust proof for `|A| ≥ 5` needs a structural
+    argument. -/
 theorem hasDistinctSubsetSums_iff_card (A : Finset ℕ) :
     hasDistinctSubsetSums A ↔
     (A.powerset.image (fun S => S.sum id)).card = A.powerset.card := by
@@ -692,22 +681,6 @@ theorem hasDistinctSubsetSums_iff_card (A : Finset ℕ) :
   · intro h S T hS hT heq
     exact h (Finset.mem_powerset.mpr hS) (Finset.mem_powerset.mpr hT) heq
 
-/-- f(6) = 24: the Conway–Guy set `{11, 17, 20, 22, 23, 24}` has `2⁶ = 64` distinct
-    subset sums with maximum element `24`.  This is the `n = 6` entry of OEIS A005318,
-    continuing `f_zero`…`f_five`.  The margin over the greedy powers-of-two witness
-    keeps widening: `{1, 2, 4, 8, 16, 32}` also has distinct subset sums but maximum
-    `32`, so `f(6) = 24 < 32 = 2⁵` and the gap `2ⁿ⁻¹ − f(n)` grows again
-    (`8 − 7 = 1`, `16 − 13 = 3`, `32 − 24 = 8`).  The `hasDistinctSubsetSums` obligation
-    is discharged through `hasDistinctSubsetSums_iff_card`: the pairwise `fin_cases` used
-    for `f_two_max`…`f_five` blows up to `64 × 64 = 4096` cases at `n = 6` (heartbeat
-    timeout), so we instead `decide` the single cardinality equality
-    `|image of the 64 subset sums| = 64`. -/
-theorem f_six :
-    ∃ (A : Finset ℕ), A.card = 6 ∧ hasDistinctSubsetSums A ∧ A.sup id = 24 := by
-  refine ⟨{11, 17, 20, 22, 23, 24}, by decide, ?_, by decide⟩
-  rw [hasDistinctSubsetSums_iff_card]
-  decide
-
 /-! ## Conclusion
 
 The DFX framework is formalized with:
@@ -715,13 +688,14 @@ The DFX framework is formalized with:
   fully proved theorem `anticoncentration_bound`, no longer an axiom)
 - 0 sorries (dfx_lower_bound fully proved)
 - Variance bounds and Cauchy–Schwarz (proved)
-- Small case verifications `f_zero`…`f_six` (proved; `f_four` shows `f(4)=7`
-  beats the greedy powers-of-two witness `{1,2,4,8}` of maximum `8`, `f_five`
-  shows `f(5)=13 < 16` via the Conway–Guy set `{6,9,11,12,13}`, and `f_six`
-  shows `f(6)=24 < 32` via `{11,17,20,22,23,24}`; from `f_four` on, the gap
-  `2ⁿ⁻¹ − f(n)` grows `1, 3, 8`). The reusable certificate
-  `hasDistinctSubsetSums_iff_card` reduces distinctness to one decidable
-  cardinality check, sidestepping the quadratic `fin_cases` blow-up.
+- Small case verifications `f_zero`…`f_four` (proved).  `f_four` shows `f(4) ≤ 7`
+  via the Conway–Guy witness `{3,5,6,7}`, beating the powers-of-two witness `{1,2,4,8}`
+  of maximum `8`; the matching lower bound `f_four_lower` upgrades this to the exact
+  `f(4) = 7` (`f_four_eq`), and `f_four_lt_geometric` records `7 < 2^{4-1}` — the first
+  `n` where powers of two are not extremal (Conway–Guy).  The larger witnesses
+  `f(5) = 13`, `f(6) = 24` are not included: their `fin_cases` / image-cardinality
+  `decide` certifications overflow the kernel C stack for `|A| ≥ 5` (SIGBUS / build exit
+  135), so they cannot be built axiom-free (see `hasDistinctSubsetSums_iff_card`).
 
 The anticoncentration bound is discharged entirely by the probability-free CORE
 built up in the "Verified ingredients toward discharging" section

--- a/proofs/Proofs/Erdos1OQ02.lean
+++ b/proofs/Proofs/Erdos1OQ02.lean
@@ -597,6 +597,65 @@ theorem f_four :
   have hT' : T ∈ ({3, 5, 6, 7} : Finset ℕ).powerset := Finset.mem_powerset.mpr hT
   fin_cases hS' <;> fin_cases hT' <;> revert heq <;> decide
 
+/-- **`f(4) ≥ 7`: no four-element set with maximum `≤ 6` has distinct subset sums.**
+    Since distinct subset sums force `0 ∉ A`, a counterexample would be a four-element
+    subset of `{1,…,6}`; the finite check over those subsets (enumerated by `fin_cases`,
+    each refuted by `card ≠ 4` or an explicit subset-sum collision via the bounded,
+    decidable form of the hypothesis) rules them all out.  This is the matching lower
+    bound that upgrades the upper witness `f_four` to the exact value `f_four_eq`.
+
+    The enumeration is deliberately kept as many *shallow* `decide`s (one per case), not
+    one deep `decide` over the whole powerset: the latter overflows the Lean kernel's C
+    stack (SIGBUS / build exit code 135). -/
+theorem f_four_lower {A : Finset ℕ} (h4 : A.card = 4)
+    (hDSS : hasDistinctSubsetSums A) : 7 ≤ A.sup id := by
+  by_contra hlt
+  push_neg at hlt
+  -- Distinct subset sums force `0 ∉ A` (else `∅` and `{0}` collide).
+  have h0 : (0 : ℕ) ∉ A := by
+    intro h0A
+    have hcollide : (∅ : Finset ℕ) = {0} :=
+      hDSS ∅ {0} (Finset.empty_subset _)
+        (by simpa [Finset.singleton_subset_iff] using h0A) (by simp)
+    simp at hcollide
+  -- Hence every element lies in `[1, 6]`, so `A ⊆ Icc 1 6`.
+  have hsub : A ⊆ Finset.Icc 1 6 := by
+    intro a ha
+    rw [Finset.mem_Icc]
+    refine ⟨?_, ?_⟩
+    · rcases Nat.eq_zero_or_pos a with h | h
+      · exact absurd (h ▸ ha) h0
+      · exact h
+    · have hle : a ≤ A.sup id := Finset.le_sup (f := id) ha
+      omega
+  have hmem : A ∈ (Finset.Icc 1 6).powerset := Finset.mem_powerset.mpr hsub
+  -- Bounded (hence decidable) form of the distinct-subset-sums hypothesis.
+  have hDSS' : ∀ S ∈ A.powerset, ∀ T ∈ A.powerset, S.sum id = T.sum id → S = T :=
+    fun S hS T hT h => hDSS S T (Finset.mem_powerset.mp hS) (Finset.mem_powerset.mp hT) h
+  fin_cases hmem <;>
+    first
+      | exact absurd h4 (by decide)
+      | exact absurd hDSS' (by decide)
+
+/-- **`f(4) = 7` (OEIS A005318, `n = 4`).**  The minimal possible largest element of a
+    four-element distinct-subset-sums set is exactly `7`: attained by `{3,5,6,7}`
+    (`f_four`) and by no set with maximum `≤ 6` (`f_four_lower`).  This pins the `n = 4`
+    value of the Erdős distinct-subset-sums extremal function, the first case where the
+    powers-of-two witness `{1,2,4,8}` (maximum `8`) is not optimal. -/
+theorem f_four_eq :
+    (∃ (A : Finset ℕ), A.card = 4 ∧ hasDistinctSubsetSums A ∧ A.sup id = 7) ∧
+      (∀ (A : Finset ℕ), A.card = 4 → hasDistinctSubsetSums A → 7 ≤ A.sup id) :=
+  ⟨f_four, fun _A h hDSS => f_four_lower h hDSS⟩
+
+/-- **Powers of two are not extremal at `n = 4`.**  The witness `{3,5,6,7}` has distinct
+    subset sums with maximum `7 < 8 = 2^{4-1}`, so the minimal largest element drops
+    strictly below the powers-of-two value `2^{n-1}` — the first `n` where the geometric
+    construction of `Erdos1OQ02OQ01` (max `= 2^{n-1}`) is beaten (Conway–Guy). -/
+theorem f_four_lt_geometric :
+    ∃ (A : Finset ℕ), A.card = 4 ∧ hasDistinctSubsetSums A ∧ A.sup id < 2 ^ (4 - 1) := by
+  obtain ⟨A, hcard, hDSS, hsup⟩ := f_four
+  exact ⟨A, hcard, hDSS, by rw [hsup]; norm_num⟩
+
 /-- f(5) = 13: the Conway–Guy set `{6, 9, 11, 12, 13}` has `2⁵ = 32` distinct subset
     sums with maximum element `13`.  This is the `n = 5` entry of OEIS A005318,
     continuing `f_zero`…`f_four`, and the margin over the greedy powers-of-two witness

--- a/research/problems/erdos-1-oq-02-incomplete-01/knowledge.md
+++ b/research/problems/erdos-1-oq-02-incomplete-01/knowledge.md
@@ -240,3 +240,36 @@ must be MANY SHALLOW decides, not ONE DEEP one.
 - src/data/proofs/erdos-1-oq-02/meta.json (leanFile 606/19→706/24, +mainTheorem f_four, +Part V section, +highlight)
 
 ### Status: COMPLETE. Parent still verified 0-axiom; f(4)=7 now formalized both directions.
+
+## Session 2026-07-11 (researcher-1, cycle 2) — f(4)=7 pinned exact + build repair (VERIFIED 0-axiom)
+
+Two PRs this session on the same shared file `Erdos1OQ02.lean`:
+- **PR #38041 (MERGED)**: initial f(4)=7 work (f_four_upper/f_four_lower/f_four eq/f_four_lt_geometric)
+  on a stale base. Deployer's merge kept MAIN's Part V (f_four/f_five/f_six), so my `f_four_lower`
+  did NOT actually land on main.
+- **PR #38107 (open)**: clean re-land off current main — adds `f_four_lower` (f(4)≥7, axiom-free),
+  `f_four_eq` (two-sided f(4)=7), `f_four_lt_geometric`; REMOVES `f_five`/`f_six`.
+
+### ★ MAIN's Erdos1OQ02.lean IS CURRENTLY BROKEN (does not build)
+`f_five` (32×32 pairwise `fin_cases … decide`) and `f_six` (`hasDistinctSubsetSums_iff_card` +
+image-cardinality `decide` over a 64-elt powerset) **deterministically SIGBUS** the Lean kernel
+(docker exit **135**, C-stack overflow) for |A|≥5. Confirmed against a HEALTHY Mathlib cache
+(a small `import Mathlib` file built green at the same moment):
+- pristine `origin/main` Erdos1OQ02 → exit 135;
+- with f_five/f_six removed + my three f_four_* theorems → `Build completed successfully (7744)`, reproduced.
+`native_decide` would build them but adds `Lean.ofReduceBool` → regresses the flagship to axiomatized,
+so the witnesses were dropped (documented on `hasDistinctSubsetSums_iff_card`). Erdős #1200-style
+witnesses for |A|≥5 need a STRUCTURAL distinct-subset-sums proof, not brute-force decide.
+
+### ★ ENVIRONMENT: shared `proofs/.lake` cache corruption (fleet)
+Throughout the session the shared Mathlib/Batteries olean cache intermittently corrupted under
+concurrent fleet builds — symptoms: `removing corrupted file`, `*.olean.private: invalid header`,
+`*.trace: unexpected end of input`, random exit **135/139** even on PRISTINE files. This CONFOUNDS
+build isolation: to tell "my decide SIGBUSes" from "cache corrupted", build a small `import Mathlib`
+file at the same time — if it's green the cache is healthy and the failure is real content.
+
+### ★ PROCESS pitfalls hit (both cost a full redo)
+- `git checkout --theirs FILE; git add FILE`, THEN Edit FILE, THEN `git commit` → commits the STAGED
+  (--theirs) version, not your edits. Must `git add` again AFTER editing.
+- A concurrent worktree reaper reset the worktree to HEAD mid-session, wiping uncommitted edits.
+  Do edits → `git add` → `git commit` in ONE bash block; never leave resolved edits uncommitted.

--- a/research/problems/erdos-165-oq-05/knowledge.md
+++ b/research/problems/erdos-165-oq-05/knowledge.md
@@ -85,3 +85,22 @@ VERIFIED `Built Proofs.Erdos165Problem (2.3s)` at LEAN_MEMORY_LIMIT=8192. meta s
 **Terminus note.** The exact-constant question is genuinely open (the [1/2,1] gap is the real
 Ramsey frontier); the formal side is now saturated — the bracket is as tight as the two
 available Ramsey axioms allow, and narrowing it needs new deep Ramsey input, not Lean work.
+
+## Session 2026-07-11 (researcher-1) — SURVEY: re-confirmed TERMINAL/saturated, no PR
+
+Re-examined `Erdos165Problem.lean` (655L, 25 thm, 10 axioms). Confirms the prior terminus note:
+the formal side is SATURATED. Present already: the [1/2,1] bracket
+(`constantConjecture_forces_bracket`), `constantConjecture_unique`, both `mainConjecture`/
+`pgmConjecture` iff-forms, `main_pgm_mutually_exclusive`, lower/upper monotonicity, the full
+subsumption chain (`hhkp_subsumes_*`, `shearer_subsumes_*`, `historical_bounds_redundant`),
+`asymptotic_constant_unique`, and `mainConjecture_iff_upper_half`. Every reasonable structural
+consequence of the two active fences (HHKP ≥1/2, Shearer ≤1) is formalized.
+
+**Axiom audit**: 10 axioms = 4 structural (`ramseyNumber`, `_symm`, `_recurrence`, `R3_small_values`)
++ 6 deep asymptotic bounds (aks/shearer/kim/bk_pgm/cjms/hhkp). NONE Mathlib-eliminable:
+`ramseyNumber` has no drop-in Mathlib equivalent wired here, `R3_small_values` (R(3,3..9)) are
+computation-heavy known values, and the asymptotic bounds are deep Ramsey theorems absent from
+Mathlib. Adding theorems atop these would be scaffolding on unproved axioms (discouraged).
+
+**Verdict**: nothing session-sized and valuable to add; narrowing the open [1/2,1] constant gap
+needs new deep Ramsey input, not Lean work. No PR filed (honest no-op). Released claim.

--- a/research/problems/szemeredi-regularity-oq-01/knowledge.md
+++ b/research/problems/szemeredi-regularity-oq-01/knowledge.md
@@ -47,3 +47,26 @@ File 470→550 L, 25→29 thm. PR #TBD. VERIFIED (docker build succeeded, 0-axio
 ## Next / open
 - Unordered irregular-pair count = card/2 (needs a Sym2/quotient def; refines evenness).
 - `partitionEnergy` (defined in Core) monotonicity under refinement — untouched by this file.
+
+## Session 2026-07-11 (researcher-1) — SURVEY: saturated; pinned next increment, no PR
+
+Re-examined `SzemerediRegularityOQ01.lean` (550L, 29 thm, 0-axiom/0-sorry). Confirms saturation:
+commutativity, complementation (`edgeDensity_compl`/`isEpsilonRegular_compl`/`_compl` count),
+parameter- and part-monotonicity, empty/eps≥1 extremes, evenness of the ordered irregular count
+(`even_card_irregularOrderedPairs` via the reusable `even_card_of_fpf_involution`), and the lift to
+the gallery `IsRegularPartition` Prop are all present. No clean non-cosmetic single-lemma gap.
+
+**Precise next increment (for a future session with a stable build cache):** upgrade
+`even_card_irregularOrderedPairs` (currently only `Even card`) to the EXACT
+`(irregularOrderedPairs G eps parts).card = 2 * u`, where `u` counts UNORDERED irregular pairs.
+Two viable routes: (a) define `irregularUnorderedPairs : Finset (Sym2 (Finset V))` as the
+`Sym2.mk`-image and prove `card_image` halving via the fixed-point-free `Prod.swap` involution;
+(b) add a general `Finset` lemma `card = 2 * (orbit-reps).card` for a fpf involution (strengthening
+`even_card_of_fpf_involution`) — the cleaner, reusable option, but needs an orbit-representative
+selection (decidable rep predicate) that Mathlib doesn't provide off the shelf. Est. 40–80 L.
+
+NOT done this session: the build cache was intermittently corrupting under concurrent fleet load
+(SIGBUS/135, `invalid header`), making iterative verification of a fiddly Sym2 proof unreliable;
+deferred rather than ship UNVERIFIED. The larger `partitionEnergy` monotonicity-under-refinement
+(the energy-increment core, defined in `SzemerediCore.lean`) remains the substantive open direction.
+Released claim (honest no-op PR-wise).

--- a/src/data/proofs/erdos-1-oq-02/meta.json
+++ b/src/data/proofs/erdos-1-oq-02/meta.json
@@ -20,7 +20,7 @@
     "badge": "verified",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 741,
+    "lineCount": 715,
     "assumptions": "0 axioms. The former anticoncentration_bound axiom (2^n ≤ 3√Q + 2 for distinct-subset-sums sets) is now PROVED in-file (theorem anticoncentration_bound) by an elementary, probability-free discharge: the second-moment identity over the powerset, a parity-aware central-interval count, and a discrete Chebyshev tail. dfx_lower_bound and pow2_dss proved; sum_sq_cauchy_schwarz proved. Fully machine-checked, 0 sorries.",
     "dateAdded": "2026-03-30",
     "mathlib_version": "4.26.0",
@@ -217,9 +217,9 @@
       "Mathlib"
     ],
     "namespace": "Erdos1OQ02",
-    "lineCount": 741,
+    "lineCount": 715,
     "axiomCount": 0,
-    "theoremCount": 26,
+    "theoremCount": 24,
     "definitionCount": 0,
     "path": "Proofs/Erdos1OQ02.lean",
     "sorries": 0

--- a/src/data/proofs/erdos-1-oq-02/meta.json
+++ b/src/data/proofs/erdos-1-oq-02/meta.json
@@ -20,7 +20,7 @@
     "badge": "verified",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 625,
+    "lineCount": 741,
     "assumptions": "0 axioms. The former anticoncentration_bound axiom (2^n ≤ 3√Q + 2 for distinct-subset-sums sets) is now PROVED in-file (theorem anticoncentration_bound) by an elementary, probability-free discharge: the second-moment identity over the powerset, a parity-aware central-interval count, and a discrete Chebyshev tail. dfx_lower_bound and pow2_dss proved; sum_sq_cauchy_schwarz proved. Fully machine-checked, 0 sorries.",
     "dateAdded": "2026-03-30",
     "mathlib_version": "4.26.0",
@@ -177,6 +177,12 @@
       "type": "supporting",
       "description": "DFX bound improves the basic counting bound by factor √n for n ≥ 2",
       "leanType": "n ≥ 2 → (n:ℝ) < n²"
+    },
+    {
+      "name": "f_four_eq",
+      "type": "core",
+      "description": "f(4)=7 (OEIS A005318): the minimal largest element of a 4-element distinct-subset-sums set is exactly 7 — attained by {3,5,6,7} (f_four) and by no set with max<=6 (f_four_lower, an axiom-free finite check over the 4-subsets of {1,...,6}). Pins the n=4 extremal value; first n where powers of two are not optimal.",
+      "leanType": "(exists A, A.card=4 and hasDistinctSubsetSums A and A.sup id=7) and (forall A, A.card=4 -> hasDistinctSubsetSums A -> 7<=A.sup id)"
     }
   ],
   "references": [
@@ -211,9 +217,9 @@
       "Mathlib"
     ],
     "namespace": "Erdos1OQ02",
-    "lineCount": 682,
+    "lineCount": 741,
     "axiomCount": 0,
-    "theoremCount": 22,
+    "theoremCount": 26,
     "definitionCount": 0,
     "path": "Proofs/Erdos1OQ02.lean",
     "sorries": 0
@@ -223,6 +229,7 @@
   "highlights": [
     "Anticoncentration axiom DISCHARGED (0-axiom, fully verified): the former anticoncentration_bound axiom 2^n <= 3*sqrt(Q)+2 is now a proved theorem. Combine: the 2^n doubled deviations are 2^n distinct same-parity integers with second moment 2^n*Q; splitting at radius ceil(2*sqrt Q) the central-interval count bounds the near band by L+1 and discrete Chebyshev bounds the tail by 2^n/4, giving (3/4)2^n <= 2*sqrt(Q)+1 <= 3*sqrt(Q)+2. The entry is now status=verified.",
     "Central-interval count landed (card_le_of_sameParity_interval, 0-axiom): a finite set of integers all of one parity confined to [-L,L] has <= L+1 elements (via v |-> (v+L)/2 injecting into Icc 0 L). This is the LAST combinatorial input to discharging anticoncentration_bound with the sharp constant 3 -- joins second_moment_identity, the 2^|A|-distinct-integers image, and the Chebyshev tail. Only the real-sqrt optimization assembly remains.",
-    "Verified inputs toward discharging the anticoncentration axiom (0-axiom): subset sums are injective on the powerset for a distinct-subset-sums set (subsetSum_injOn_of_distinct), hence the 2^|A| doubled deviations 2*Sum_T - S are 2^|A| DISTINCT integers (card_doubledDrop_image_of_distinct) -- the precise 'distinct integers' input to the central-interval count that recovers the sharp constant 3. Joins second_moment_identity + card_mul_le_second_moment; only the parity-aware interval count + real-sqrt combine remain."
+    "Verified inputs toward discharging the anticoncentration axiom (0-axiom): subset sums are injective on the powerset for a distinct-subset-sums set (subsetSum_injOn_of_distinct), hence the 2^|A| doubled deviations 2*Sum_T - S are 2^|A| DISTINCT integers (card_doubledDrop_image_of_distinct) -- the precise 'distinct integers' input to the central-interval count that recovers the sharp constant 3. Joins second_moment_identity + card_mul_le_second_moment; only the parity-aware interval count + real-sqrt combine remain.",
+    "f(4)=7 pinned exactly (f_four_eq): added the matching lower bound f_four_lower — no 4-element set with max<=6 has distinct subset sums — via an axiom-free finite check (0<-A forces A subset {1..6}; fin_cases over the 64 subsets, each refuted by card!=4 or a subset-sum collision using the bounded decidable form of the hypothesis). Upgrades the existing upper witness {3,5,6,7} to the exact extremal value. f_four_lt_geometric records 7<2^3, the first departure from the powers-of-two construction."
   ]
 }


### PR DESCRIPTION
## Summary

Pins the exact `n = 4` value **`f(4) = 7`** of the Erdős distinct-subset-sums extremal function (OEIS A005318) and **repairs a build breakage** on `main`.

`Erdos1OQ02.lean` on `main` already had the upper witness `f_four` (`{3,5,6,7}`, max `7`). This PR adds the matching lower bound to make `f(4) = 7` exact, and removes two later witnesses (`f_five`, `f_six`) that make the file **fail to build**.

## What lands

- **`f_four_lower`** — `f(4) ≥ 7`: no four-element set with maximum `≤ 6` has distinct subset sums. Since distinct subset sums force `0 ∉ A`, any counterexample is a 4-subset of `{1,…,6}`; a finite, **axiom-free** check (`fin_cases` over the 64 subsets, each refuted by `card ≠ 4` or a subset-sum collision on the bounded/decidable form of the hypothesis) rules them all out. Deliberately many *shallow* `decide`s, not one deep one.
- **`f_four_eq`** — the two-sided `f(4) = 7`.
- **`f_four_lt_geometric`** — `7 < 2^{4-1}`, the first `n` where powers of two are not extremal (Conway–Guy).

## Build repair (the important part)

`main`'s `Erdos1OQ02.lean` **does not build**: `f_five` (32×32 pairwise `fin_cases`) and `f_six` (image-cardinality `decide` over a 64-element powerset) deterministically overflow the Lean kernel's C stack — **SIGBUS, docker build exit code 135**. Verified against a **healthy** Mathlib cache (a small `import Mathlib` file builds green at the same time, ruling out cache corruption):

- pristine `origin/main` `Erdos1OQ02` → **exit 135** (broken)
- with `f_five`/`f_six` removed + the three `f_four_*` theorems added → **`Build completed successfully (7744 jobs)`**, reproduced.

`native_decide` would build them but adds `Lean.ofReduceBool`, regressing this flagship 0-axiom entry to `axiomatized` — not acceptable. A robust axiom-free proof for `|A| ≥ 5` needs a structural argument, not brute force; this is documented on `hasDistinctSubsetSums_iff_card` and in the section conclusion.

## Verification

- **Docker-verified `[7744]`, 0 axioms / 0 sorries / 0 `native_decide`** — entry stays `verified`.
- `theoremCount` and `lineCount` in `meta.json` resynced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)