### PR TITLE
Enrich stars-and-bars-weak-compositions family: structure crossReferences (9 entries)

### DIFF
--- a/src/data/proofs/stars-and-bars-weak-compositions-oq-01-oq-01/meta.json
+++ b/src/data/proofs/stars-and-bars-weak-compositions-oq-01-oq-01/meta.json
@@ -147,8 +147,20 @@
     ]
   },
   "crossReferences": [
-    "stars-and-bars-weak-compositions-oq-01",
-    "stars-and-bars-weak-compositions-oq-03",
-    "stars-and-bars-weak-compositions-oq-02"
+    {
+      "targetId": "stars-and-bars-weak-compositions-oq-01",
+      "relationship": "extends",
+      "description": "Builds on this entry’s parent line: Generating-function view of weak compositions: ∑ₙ #(weak comps) Xⁿ = 1/(1−X)ᵏ. The present entry extends/refines that result."
+    },
+    {
+      "targetId": "stars-and-bars-weak-compositions-oq-03",
+      "relationship": "related",
+      "description": "Related result in the stars-and-bars / weak-compositions family: Stars-and-bars duality: weak ↔ positive compositions via an explicit ±1 bijection."
+    },
+    {
+      "targetId": "stars-and-bars-weak-compositions-oq-02",
+      "relationship": "related",
+      "description": "Related result in the stars-and-bars / weak-compositions family: Bounded-parts refinement of weak compositions via inclusion–exclusion."
+    }
   ]
 }

--- a/src/data/proofs/stars-and-bars-weak-compositions-oq-01/meta.json
+++ b/src/data/proofs/stars-and-bars-weak-compositions-oq-01/meta.json
@@ -125,8 +125,20 @@
     ]
   },
   "crossReferences": [
-    "stars-and-bars-weak-compositions",
-    "stars-and-bars-weak-compositions-oq-02",
-    "composition-parts-choose-oq-01"
+    {
+      "targetId": "stars-and-bars-weak-compositions",
+      "relationship": "extends",
+      "description": "Builds on this entry’s parent line: Stars and Bars: Weak Compositions of n into k Parts Number C(n+k−1, n). The present entry extends/refines that result."
+    },
+    {
+      "targetId": "stars-and-bars-weak-compositions-oq-02",
+      "relationship": "related",
+      "description": "Related result in the stars-and-bars / weak-compositions family: Bounded-parts refinement of weak compositions via inclusion–exclusion."
+    },
+    {
+      "targetId": "composition-parts-choose-oq-01",
+      "relationship": "related",
+      "description": "Companion counting result in the compositions line: Compositions of n into k parts number C(n−1, k−1)."
+    }
   ]
 }

--- a/src/data/proofs/stars-and-bars-weak-compositions-oq-02-oq-02/meta.json
+++ b/src/data/proofs/stars-and-bars-weak-compositions-oq-02-oq-02/meta.json
@@ -114,8 +114,16 @@
     ]
   },
   "crossReferences": [
-    "stars-and-bars-weak-compositions-oq-02",
-    "stars-and-bars-weak-compositions"
+    {
+      "targetId": "stars-and-bars-weak-compositions-oq-02",
+      "relationship": "extends",
+      "description": "Builds on this entry’s parent line: Bounded-parts refinement of weak compositions via inclusion–exclusion. The present entry extends/refines that result."
+    },
+    {
+      "targetId": "stars-and-bars-weak-compositions",
+      "relationship": "extends",
+      "description": "Builds on this entry’s parent line: Stars and Bars: Weak Compositions of n into k Parts Number C(n+k−1, n). The present entry extends/refines that result."
+    }
   ],
   "references": [
     {

--- a/src/data/proofs/stars-and-bars-weak-compositions-oq-02/meta.json
+++ b/src/data/proofs/stars-and-bars-weak-compositions-oq-02/meta.json
@@ -130,7 +130,15 @@
     ]
   },
   "crossReferences": [
-    "stars-and-bars-weak-compositions",
-    "composition-parts-choose-oq-01"
+    {
+      "targetId": "stars-and-bars-weak-compositions",
+      "relationship": "extends",
+      "description": "Builds on this entry’s parent line: Stars and Bars: Weak Compositions of n into k Parts Number C(n+k−1, n). The present entry extends/refines that result."
+    },
+    {
+      "targetId": "composition-parts-choose-oq-01",
+      "relationship": "related",
+      "description": "Companion counting result in the compositions line: Compositions of n into k parts number C(n−1, k−1)."
+    }
   ]
 }

--- a/src/data/proofs/stars-and-bars-weak-compositions-oq-03/meta.json
+++ b/src/data/proofs/stars-and-bars-weak-compositions-oq-03/meta.json
@@ -118,7 +118,15 @@
     ]
   },
   "crossReferences": [
-    "stars-and-bars-weak-compositions",
-    "composition-parts-choose-oq-01"
+    {
+      "targetId": "stars-and-bars-weak-compositions",
+      "relationship": "extends",
+      "description": "Builds on this entry’s parent line: Stars and Bars: Weak Compositions of n into k Parts Number C(n+k−1, n). The present entry extends/refines that result."
+    },
+    {
+      "targetId": "composition-parts-choose-oq-01",
+      "relationship": "related",
+      "description": "Companion counting result in the compositions line: Compositions of n into k parts number C(n−1, k−1)."
+    }
   ]
 }

--- a/src/data/proofs/stars-and-bars-weak-compositions-oq-04-oq-02/meta.json
+++ b/src/data/proofs/stars-and-bars-weak-compositions-oq-04-oq-02/meta.json
@@ -152,7 +152,15 @@
     ]
   },
   "crossReferences": [
-    "stars-and-bars-weak-compositions-oq-04",
-    "stars-and-bars-weak-compositions"
+    {
+      "targetId": "stars-and-bars-weak-compositions-oq-04",
+      "relationship": "extends",
+      "description": "Builds on this entry’s parent line: Convolution law of weak compositions W(k₁)·W(k₂)=W(k₁+k₂) and the negative-binomial Vandermonde identity. The present entry extends/refines that result."
+    },
+    {
+      "targetId": "stars-and-bars-weak-compositions",
+      "relationship": "extends",
+      "description": "Builds on this entry’s parent line: Stars and Bars: Weak Compositions of n into k Parts Number C(n+k−1, n). The present entry extends/refines that result."
+    }
   ]
 }

--- a/src/data/proofs/stars-and-bars-weak-compositions-oq-04/meta.json
+++ b/src/data/proofs/stars-and-bars-weak-compositions-oq-04/meta.json
@@ -153,7 +153,15 @@
     ]
   },
   "crossReferences": [
-    "stars-and-bars-weak-compositions-oq-01",
-    "stars-and-bars-weak-compositions"
+    {
+      "targetId": "stars-and-bars-weak-compositions-oq-01",
+      "relationship": "related",
+      "description": "Related result in the stars-and-bars / weak-compositions family: Generating-function view of weak compositions: ∑ₙ #(weak comps) Xⁿ = 1/(1−X)ᵏ."
+    },
+    {
+      "targetId": "stars-and-bars-weak-compositions",
+      "relationship": "extends",
+      "description": "Builds on this entry’s parent line: Stars and Bars: Weak Compositions of n into k Parts Number C(n+k−1, n). The present entry extends/refines that result."
+    }
   ]
 }

--- a/src/data/proofs/stars-and-bars-weak-compositions-oq-05/meta.json
+++ b/src/data/proofs/stars-and-bars-weak-compositions-oq-05/meta.json
@@ -119,7 +119,15 @@
     ]
   },
   "crossReferences": [
-    "stars-and-bars-weak-compositions",
-    "stars-and-bars-weak-compositions-oq-04"
+    {
+      "targetId": "stars-and-bars-weak-compositions",
+      "relationship": "extends",
+      "description": "Builds on this entry’s parent line: Stars and Bars: Weak Compositions of n into k Parts Number C(n+k−1, n). The present entry extends/refines that result."
+    },
+    {
+      "targetId": "stars-and-bars-weak-compositions-oq-04",
+      "relationship": "related",
+      "description": "Related result in the stars-and-bars / weak-compositions family: Convolution law of weak compositions W(k₁)·W(k₂)=W(k₁+k₂) and the negative-binomial Vandermonde identity."
+    }
   ]
 }

--- a/src/data/proofs/stars-and-bars-weak-compositions/meta.json
+++ b/src/data/proofs/stars-and-bars-weak-compositions/meta.json
@@ -126,8 +126,16 @@
     ]
   },
   "crossReferences": [
-    "composition-parts-choose-oq-01",
-    "composition-card-2pow-oq-01"
+    {
+      "targetId": "composition-parts-choose-oq-01",
+      "relationship": "related",
+      "description": "Companion counting result in the compositions line: Compositions of n into k parts number C(n−1, k−1)."
+    },
+    {
+      "targetId": "composition-card-2pow-oq-01",
+      "relationship": "related",
+      "description": "Companion counting result in the compositions line: There are 2^(n−1) compositions of n."
+    }
   ],
   "references": [
     {


### PR DESCRIPTION
Enrichment batch across the 9-entry `stars-and-bars-weak-compositions` family.

## Problem
Every entry in this family had `crossReferences` as **bare string IDs**, e.g. `["stars-and-bars-weak-compositions", ...]`. Bare strings do not conform to the `CrossReference` type (`src/types/proof.ts` requires a `relationship` field) and render with no relationship label or navigational context.

## Fix
Converted each to the documented object form `{ targetId, relationship, description }`:
- **relationship** inferred from the slug hierarchy — an ancestor slug → `extends`, a sibling / cross-family entry → `related`.
- **description** grounded in each target's actual title, so the reader sees what the linked entry is and how it relates.

Entries updated: base + oq-01, oq-01-oq-01, oq-02, oq-02-oq-02, oq-03, oq-04, oq-04-oq-02, oq-05.

## Verification
- All 9 JSON files validate; every crossReference is now a typed object; all metas well under the 60 KB cap.
- Diffs are minimal (only the `crossReferences` block changed per file); no other fields touched.
- No change to `status`/`badge`/`axiomCount` for any entry.