### PR TITLE
research(erdos-1064-oq-03): three-way shared landing + general landing criterion [VERIFIED]

### DIFF
--- a/proofs/Proofs/EulerTotientOQ04OQ03.lean
+++ b/proofs/Proofs/EulerTotientOQ04OQ03.lean
@@ -3471,4 +3471,149 @@ theorem shared_landing_opposite_verdict_129_145 (k : ℕ) :
   · simpa using mem_ForwardSet_fiveTimes (q := 29) (by norm_num) (by norm_num)
       (by norm_num) (by norm_num) k
 
+-- ----------------------------------------------------------------------------
+-- General shared-landing criterion, and a THREE-way shared landing
+-- ----------------------------------------------------------------------------
+-- `shared_landing_opposite_verdict` shows two seeds with a common double iterate
+-- falling on OPPOSITE sides of the trichotomy (reversal vs forward).  Two natural
+-- questions remain (both flagged as next steps): (1) is there a *general* principle
+-- behind such coincidences, and (2) can a single shared landing realise ALL THREE
+-- verdicts — reversal, forward AND equality — at once?  Both are answered here.
+
+/-- **General shared-landing criterion.**  Two transport-admissible odd seeds
+    `a₁, a₂` — each with an odd transport partner `bᵢ` (`2aᵢ − φ(aᵢ) = 2bᵢ`) — send
+    their `·2^(k+1)` families onto the SAME double iterate iff their *landing values*
+    `2aᵢ − φ(bᵢ)` agree:
+        `D(a₁·2^(k+1)) = D(a₂·2^(k+1))  ↔  2a₁ − φ(b₁) = 2a₂ − φ(b₂)`.
+    Both sides reduce, via `dblIter_transport`, to `(2aᵢ − φ(bᵢ))·2^k`, and the shared
+    positive factor `2^k` cancels.  This is the general principle underneath every
+    concrete shared landing (`dblIter_primeTriple_eq_fiveTimes`, and the triple
+    `shared_landing_triple_verdict_917` below): a landing coincidence is EXACTLY a
+    coincidence of landing values, uniformly in `k`. -/
+theorem dblIter_eq_iff_landing_value {a₁ a₂ b₁ b₂ : ℕ}
+    (ha₁ : Odd a₁) (hb₁ : Odd b₁) (hstep₁ : 2 * a₁ - Nat.totient a₁ = 2 * b₁)
+    (ha₂ : Odd a₂) (hb₂ : Odd b₂) (hstep₂ : 2 * a₂ - Nat.totient a₂ = 2 * b₂)
+    (k : ℕ) :
+    dblIter (a₁ * 2 ^ (k + 1)) = dblIter (a₂ * 2 ^ (k + 1))
+      ↔ 2 * a₁ - Nat.totient b₁ = 2 * a₂ - Nat.totient b₂ := by
+  rw [dblIter_transport ha₁ hb₁ hstep₁ k, dblIter_transport ha₂ hb₂ hstep₂ k]
+  constructor
+  · exact fun h => mul_right_cancel₀ (pow_ne_zero k (by norm_num)) h
+  · exact fun h => by rw [h]
+
+/-- **Constructive shared landing.**  The `←` direction of
+    `dblIter_eq_iff_landing_value`, packaged for direct use: equal landing values
+    force a shared double iterate for every `k`. -/
+theorem dblIter_eq_of_landing_value_eq {a₁ a₂ b₁ b₂ : ℕ}
+    (ha₁ : Odd a₁) (hb₁ : Odd b₁) (hstep₁ : 2 * a₁ - Nat.totient a₁ = 2 * b₁)
+    (ha₂ : Odd a₂) (hb₂ : Odd b₂) (hstep₂ : 2 * a₂ - Nat.totient a₂ = 2 * b₂)
+    (hval : 2 * a₁ - Nat.totient b₁ = 2 * a₂ - Nat.totient b₂) (k : ℕ) :
+    dblIter (a₁ * 2 ^ (k + 1)) = dblIter (a₂ * 2 ^ (k + 1)) :=
+  (dblIter_eq_iff_landing_value ha₁ hb₁ hstep₁ ha₂ hb₂ hstep₂ k).mpr hval
+
+-- Concrete totients for the three-way witness at landing `917`.  Computed through
+-- the factorisations (NOT kernel `decide` on `Nat.totient`, which blows the stack
+-- for arguments this size — cf. the note near `totient_15`).
+theorem totient_1097 : Nat.totient 1097 = 1096 := Nat.totient_prime (by norm_num)
+
+theorem totient_1137 : Nat.totient 1137 = 756 := by
+  rw [show (1137 : ℕ) = 3 * 379 from rfl, Nat.totient_mul (by decide),
+      Nat.totient_prime (by norm_num), Nat.totient_prime (by norm_num)]
+
+theorem totient_1179 : Nat.totient 1179 = 780 := by
+  rw [show (1179 : ℕ) = 3 ^ 2 * 131 from rfl, Nat.totient_mul (by decide),
+      Nat.totient_prime_pow (by norm_num) (by norm_num), Nat.totient_prime (by norm_num)]
+  norm_num
+
+theorem totient_549 : Nat.totient 549 = 360 := by
+  rw [show (549 : ℕ) = 3 ^ 2 * 61 from rfl, Nat.totient_mul (by decide),
+      Nat.totient_prime_pow (by norm_num) (by norm_num), Nat.totient_prime (by norm_num)]
+  norm_num
+
+theorem totient_759 : Nat.totient 759 = 440 := by
+  rw [show (759 : ℕ) = 3 * 253 from rfl, Nat.totient_mul (by decide),
+      Nat.totient_prime (by norm_num), show (253 : ℕ) = 11 * 23 from rfl,
+      Nat.totient_mul (by decide), Nat.totient_prime (by norm_num),
+      Nat.totient_prime (by norm_num)]
+
+theorem totient_789 : Nat.totient 789 = 524 := by
+  rw [show (789 : ℕ) = 3 * 263 from rfl, Nat.totient_mul (by decide),
+      Nat.totient_prime (by norm_num), Nat.totient_prime (by norm_num)]
+
+theorem totient_917 : Nat.totient 917 = 780 := by
+  rw [show (917 : ℕ) = 7 * 131 from rfl, Nat.totient_mul (by decide),
+      Nat.totient_prime (by norm_num), Nat.totient_prime (by norm_num)]
+
+/-- `D(1137·2^(k+1)) = 917·2^(k+1)` (seed `1137 = 3·379`, partner `759 = 3·11·23`). -/
+theorem dblIter_seed1137 (k : ℕ) :
+    dblIter (1137 * 2 ^ (k + 1)) = 917 * 2 ^ (k + 1) := by
+  have h := dblIter_transport (a := 1137) (b := 759)
+    (by decide) (by decide) (by rw [totient_1137]) k
+  rw [h, totient_759, show (2 * 1137 - 440 : ℕ) = 1834 from by norm_num, pow_succ]
+  ring
+
+/-- `D(1179·2^(k+1)) = 917·2^(k+1)` (seed `1179 = 3²·131`, partner `789 = 3·263`). -/
+theorem dblIter_seed1179 (k : ℕ) :
+    dblIter (1179 * 2 ^ (k + 1)) = 917 * 2 ^ (k + 1) := by
+  have h := dblIter_transport (a := 1179) (b := 789)
+    (by decide) (by decide) (by rw [totient_1179]) k
+  rw [h, totient_789, show (2 * 1179 - 524 : ℕ) = 1834 from by norm_num, pow_succ]
+  ring
+
+/-- `D(1097·2^(k+1)) = 917·2^(k+1)` (seed `1097` prime, partner `549 = 3²·61`). -/
+theorem dblIter_seed1097 (k : ℕ) :
+    dblIter (1097 * 2 ^ (k + 1)) = 917 * 2 ^ (k + 1) := by
+  have h := dblIter_transport (a := 1097) (b := 549)
+    (by decide) (by decide) (by rw [totient_1097]) k
+  rw [h, totient_549, show (2 * 1097 - 360 : ℕ) = 1834 from by norm_num, pow_succ]
+  ring
+
+/-- **Three-way shared landing — all three verdicts at one point.**  The odd seeds
+    `1137 = 3·379`, `1179 = 3²·131` and `1097` (prime) send their `·2^(k+1)` families
+    onto the identical double iterate `917·2^(k+1)` (`917 = 7·131`, `φ(917) = 780`),
+    yet realise all three regimes of the totient trichotomy simultaneously:
+      `1137·2^(k+1) ∈ ReversalSet`  (`φ = 756·2^k < 780·2^k = φ(D)`),
+      `1179·2^(k+1) ∈ EqualitySet`  (`φ = 780·2^k = 780·2^k = φ(D)`),
+      `1097·2^(k+1) ∈ ForwardSet`   (`φ = 1096·2^k > 780·2^k = φ(D)`).
+    This is the sharpest landing-independence statement: one shared value of `D(n)`
+    (hence of `φ(D(n))`) is compatible with reversal, equality AND forward at once,
+    so the trichotomy is decided purely by the seed's own totient, never by `D(n)`.
+    `L = 917` is the least common landing admitting all three verdicts (exhaustive
+    search over odd seeds).  Strengthens the two-way `shared_landing_opposite_verdict`
+    (reversal vs forward only). -/
+theorem shared_landing_triple_verdict_917 (k : ℕ) :
+    dblIter (1137 * 2 ^ (k + 1)) = 917 * 2 ^ (k + 1) ∧
+      dblIter (1179 * 2 ^ (k + 1)) = 917 * 2 ^ (k + 1) ∧
+      dblIter (1097 * 2 ^ (k + 1)) = 917 * 2 ^ (k + 1) ∧
+      1137 * 2 ^ (k + 1) ∈ ReversalSet ∧
+      1179 * 2 ^ (k + 1) ∈ EqualitySet ∧
+      1097 * 2 ^ (k + 1) ∈ ForwardSet := by
+  have hp2 : Nat.totient (2 ^ (k + 1)) = 2 ^ k := by
+    rw [Nat.totient_prime_pow Nat.prime_two (Nat.succ_pos k)]; simp
+  have pos : 0 < 2 ^ k := pow_pos (by norm_num) k
+  have hφ1137 : Nat.totient (1137 * 2 ^ (k + 1)) = 756 * 2 ^ k := by
+    rw [Nat.totient_mul ((by decide : Nat.Coprime 1137 2).pow_right (k + 1)), hp2,
+        totient_1137]
+  have hφ1179 : Nat.totient (1179 * 2 ^ (k + 1)) = 780 * 2 ^ k := by
+    rw [Nat.totient_mul ((by decide : Nat.Coprime 1179 2).pow_right (k + 1)), hp2,
+        totient_1179]
+  have hφ1097 : Nat.totient (1097 * 2 ^ (k + 1)) = 1096 * 2 ^ k := by
+    rw [Nat.totient_mul ((by decide : Nat.Coprime 1097 2).pow_right (k + 1)), hp2,
+        totient_1097]
+  have hφ917 : Nat.totient (917 * 2 ^ (k + 1)) = 780 * 2 ^ k := by
+    rw [Nat.totient_mul ((by decide : Nat.Coprime 917 2).pow_right (k + 1)), hp2,
+        totient_917]
+  have hD1137 := dblIter_seed1137 k
+  have hD1179 := dblIter_seed1179 k
+  have hD1097 := dblIter_seed1097 k
+  refine ⟨hD1137, hD1179, hD1097, ?_, ?_, ?_⟩
+  · show Nat.totient (1137 * 2 ^ (k + 1)) < Nat.totient (dblIter (1137 * 2 ^ (k + 1)))
+    rw [hD1137, hφ1137, hφ917]
+    exact mul_lt_mul_of_pos_right (by norm_num) pos
+  · show Nat.totient (1179 * 2 ^ (k + 1)) = Nat.totient (dblIter (1179 * 2 ^ (k + 1)))
+    rw [hD1179, hφ1179, hφ917]
+  · show Nat.totient (dblIter (1097 * 2 ^ (k + 1))) < Nat.totient (1097 * 2 ^ (k + 1))
+    rw [hD1097, hφ1097, hφ917]
+    exact mul_lt_mul_of_pos_right (by norm_num) pos
+
 end Erdos1064OQ03

--- a/src/data/research/problems/erdos-1064-oq-03.json
+++ b/src/data/research/problems/erdos-1064-oq-03.json
@@ -35,7 +35,7 @@
     }
   ],
   "knowledge": {
-    "progressSummary": "PROGRESS (structural, axiom-free): established SHARED-LANDING OPPOSITE-VERDICT — the reversal seed 18m+3 and forward seed 20m+5 transport onto the same double iterate (14m+3)·2^(k+1) yet fall on opposite sides of the totient trichotomy (shared_landing_opposite_verdict: ReversalSet vs ForwardSet), proving the double-iterate comparison is NOT a function of D(n). Added the shared-landing bridge (dblIter_primeTriple/dblIter_fiveTimes/_eq_fiveTimes), the exact 2^(k+2) margin difference (shared_landing_gap_difference, reusing the concurrently-added forward_gap_fiveTimes_eq), and a concrete m=7 witness (seeds 129,145 → landing 101). All axiom-free [propext,Classical.choice,Quot.sound]. The sole OPEN direction remains the analytic density-1 forward statement (Mathlib gap, unchanged).",
+    "progressSummary": "PROGRESS (structural, axiom-free, 176→189 thm): general shared-landing CRITERION dblIter_eq_iff_landing_value (landing coincidence ⟺ landing-value coincidence, subsumes all concrete shared landings) + THREE-way shared landing shared_landing_triple_verdict_917 (seeds 1137/1179/1097 → 917·2^(k+1), realising reversal+equality+forward simultaneously; L=917 least such). Sole OPEN direction remains the analytic density-1 forward statement (Mathlib gap, unchanged). PR #38110.",
     "builtItems": [
       "dblIter (EulerTotientOQ04OQ03.lean) — the double cototient iterate D(n) = n − φ(n − φ(n)), the object of OQ-03.",
       "dblIter_prime — collapse lemma: for EVERY prime p, D(p) = p − 1 exactly (φ(p)=p−1 ⟹ p−φ(p)=1 ⟹ φ(1)=1 ⟹ D(p)=p−1).",
@@ -111,7 +111,11 @@
       "dblIter_primeTriple_eq_fiveTimes (EulerTotientOQ04OQ03.lean:3411): the reversal and forward families share the identical double iterate",
       "shared_landing_opposite_verdict (EulerTotientOQ04OQ03.lean:3425): MAIN structural theorem — same D(n), opposite trichotomy verdicts (ReversalSet vs ForwardSet); proves the double-iterate comparison is not a function of D(n)",
       "shared_landing_gap_difference (EulerTotientOQ04OQ03.lean:3444): reversal margin exceeds forward margin by exactly 2^(k+2) at the shared landing (reuses the existing forward_gap_fiveTimes_eq)",
-      "shared_landing_opposite_verdict_129_145 (EulerTotientOQ04OQ03.lean:3461): concrete m=7 instance, seeds 129 & 145 both land on 101·2^(k+1) with opposite verdicts"
+      "shared_landing_opposite_verdict_129_145 (EulerTotientOQ04OQ03.lean:3461): concrete m=7 instance, seeds 129 & 145 both land on 101·2^(k+1) with opposite verdicts",
+      "dblIter_eq_iff_landing_value (EulerTotientOQ04OQ03.lean): general shared-landing criterion D(a₁·2^(k+1))=D(a₂·2^(k+1)) ↔ 2a₁−φ(b₁)=2a₂−φ(b₂), via dblIter_transport + cancel 2^k",
+      "dblIter_eq_of_landing_value_eq: constructive ← direction",
+      "shared_landing_triple_verdict_917: three-way witness with ReversalSet/EqualitySet/ForwardSet memberships",
+      "dblIter_seed1097/1137/1179 landings; totient_1097/1137/1179/549/759/789/917 helpers (factorisation, no kernel decide)"
     ],
     "insights": [
       "On primes the higher iterate is trivial: D(p) = p − 1 for all primes p, because the first cototient step p − φ(p) = 1 and φ(1) = 1. So φ(D(p)) = φ(p−1), and φ(p−1) < p−1 = φ(p) for every p ≥ 3 (with equality only at p = 2). This gives the forward direction on an infinite explicit family with a one-line reduction to Nat.totient_lt — no density machinery needed.",
@@ -148,7 +152,8 @@
       "4∣φ(a) is necessary but NOT sufficient for reversal: the transport-admissible EQUALITY regime (seedS a=1 ∧ classifySeed a=.eq, the Sophie-Germain seeds 15,33,69,…) also satisfies 4∣φ(a) yet classifies eq. So the divisibility test only excludes seedS≠1 seeds; distinguishing lt from eq within seedS=1 needs the finer φ(a) vs φ(e)·2^{t-1} comparison, not a totient-divisibility check.",
       "The prime-triple reversal family (a=18m+3, with 4m+1,6m+1,14m+3 all prime) reverses by an EXACT gap phi(D(n))-phi(n) = (2m+2)*2^k along n=(18m+3)*2^(k+1); the margin diverges in both m and k (contrast the isolated 5q seed 55 whose margin is bounded). So reversal in this family is quantitatively robust, not marginal.",
       "SHARED LANDING, OPPOSITE VERDICT: the prime-triple reversal seed 18m+3=3(6m+1) and the fiveTimes forward seed 20m+5=5(4m+1) — two distinct odd seeds — transport onto the IDENTICAL double iterate D(n)=(14m+3)·2^(k+1). So φ(D(n)) is common to both families, yet one reverses (φ(n)<φ(D(n))) and the other goes forward (φ(D(n))<φ(n)). The double-iterate trichotomy is therefore NOT a function of the landing point D(n); it is decided by the seed own totient (12m·2^k vs 16m·2^k) relative to the shared φ(D(n))=(14m+2)·2^k. Concrete m=7: seeds 129=3·43 (reversal) and 145=5·29 (forward) both land on 101·2^(k+1).",
-      "At a shared prime landing the two verdict margins straddle the common φ(D(n)) and differ by EXACTLY 2^(k+2): reversal margin (2m+2)·2^k minus forward margin (2m-2)·2^k = 4·2^k, independent of m; their sum 4m·2^k is the seed-totient gap 16m·2^k−12m·2^k."
+      "At a shared prime landing the two verdict margins straddle the common φ(D(n)) and differ by EXACTLY 2^(k+2): reversal margin (2m+2)·2^k minus forward margin (2m-2)·2^k = 4·2^k, independent of m; their sum 4m·2^k is the seed-totient gap 16m·2^k−12m·2^k.",
+      "THREE-way shared landing exists: odd seeds 1137=3·379 (rev, φ=756), 1179=3²·131 (eq, φ=780), 1097 prime (fwd, φ=1096) all transport onto 917·2^(k+1) (917=7·131, φ=780) — one shared D(n) compatible with reversal, equality AND forward at once. L=917 is the LEAST such common landing (exhaustive search over odd seeds). Sharpest landing-independence statement."
     ],
     "mathlibGaps": [
       "Kernel `decide` on Nat.totient of a seed (e.g. totient 21) blows the stack → SIGBUS (Lean exit 135, line-less); must prove totient values by factorisation (Nat.totient_mul + Nat.totient_prime). Reconfirms the file's existing note."
@@ -158,7 +163,9 @@
       "Possible follow-up (elementary): characterise WHICH transport-admissible seeds (seedS a=1) reverse — i.e. describe {odd a : seedS a=1 ∧ classifySeed a=.lt} beyond its least element a=21. This is the natural next structural question now that the excluded regime is fully closed.",
       "Possible follow-up: is the reversal-seed set (seedS=1, classify=.lt) infinite with positive density among transport-admissible seeds? (21·2^(k+1) family already gives infinitely-often.)",
       "Elementary follow-up: is the reversal gap the LARGEST among transport-admissible (seedS=1) reversal seeds at fixed a-size, or can a 5q/other-shape seed reverse by a wider margin? Compare (2m+2)*2^k against the general classifier margin phi(seedE a)*2^(seedT a-1) - phi(a).",
-      "Do OTHER shared landings occur? Characterise all seed pairs (a1,a2) with 2a1-φ(b1)=2a2-φ(b2) so D(a1·2^(k+1))=D(a2·2^(k+1)); the 3q/5q pair 18m+3,20m+5 is one infinite family. A shared landing whose two seeds hit the reversal and EQUALITY regimes (or all three) would be the sharpest landing-independence statement."
+      "Do OTHER shared landings occur? Characterise all seed pairs (a1,a2) with 2a1-φ(b1)=2a2-φ(b2) so D(a1·2^(k+1))=D(a2·2^(k+1)); the 3q/5q pair 18m+3,20m+5 is one infinite family. A shared landing whose two seeds hit the reversal and EQUALITY regimes (or all three) would be the sharpest landing-independence statement.",
+      "Is the three-way shared landing infinite / does a PARAMETRIC family of triples exist (like 18m+3,20m+5 for the two-way)? Equality seed on the landing L needs φ(seed)=φ(L) with matching transport — a hard Diophantine constraint (e.g. landing 14m+3 forces 7(7m+1)(m−1) a perfect square), so no obvious infinite family; L=917 found only by search.",
+      "ENV: docker-build broken (code 135 SIGBUS on pristine file AND minimal Mathlib import) — verify new work via host elan lean v4.26.0 + project Mathlib LEAN_PATH on a self-contained copy until docker recovers."
     ]
   },
   "relatedProofs": [


### PR DESCRIPTION
## Erdős #1064 OQ-03 — φ(n) vs φ(D(n)), D = double totient-descent

Extends the mature, axiom-free structural theory of the double-iterate `D(n) = n − φ(n − φ(n))` on families `a·2^(k+1)`. The two-way `shared_landing_opposite_verdict` already showed two seeds sharing a landing while falling on opposite sides of the trichotomy. This PR closes two documented next steps.

### General shared-landing criterion (theory-level)
- **`dblIter_eq_iff_landing_value`** — transport-admissible odd seeds `a₁,a₂` (odd partners `bᵢ`, `2aᵢ−φ(aᵢ)=2bᵢ`) share a double iterate **iff** their landing values agree:
  `D(a₁·2^(k+1)) = D(a₂·2^(k+1)) ↔ 2a₁−φ(b₁) = 2a₂−φ(b₂)`.
  Both sides reduce via `dblIter_transport` to `(2aᵢ−φ(bᵢ))·2^k`; the positive factor `2^k` cancels. This is the general principle behind every concrete shared landing.
- **`dblIter_eq_of_landing_value_eq`** — the constructive `←` direction.

### Three-way shared landing (sharpest landing-independence witness)
- **`shared_landing_triple_verdict_917`** — the odd seeds `1137 = 3·379`, `1179 = 3²·131` and `1097` (prime) all transport onto the identical double iterate `917·2^(k+1)` (`917 = 7·131`, `φ(917) = 780`), yet realise **all three** regimes simultaneously:
  - `1137·2^(k+1) ∈ ReversalSet` (`φ = 756·2^k < 780·2^k = φ(D)`)
  - `1179·2^(k+1) ∈ EqualitySet` (`φ = 780·2^k = 780·2^k = φ(D)`)
  - `1097·2^(k+1) ∈ ForwardSet` (`φ = 1096·2^k > 780·2^k = φ(D)`)

  One shared value of `D(n)` (hence of `φ(D(n))`) is compatible with reversal, equality **and** forward at once: the trichotomy is decided purely by the seed's own totient, never by the landing. `L = 917` is the least common landing admitting all three verdicts (exhaustive search over odd seeds).

Supporting: `dblIter_seed1097/1137/1179` (landings) and `totient_1097/1137/1179/549/759/789/917` (totients via factorisation, no kernel `decide` on `Nat.totient`).

### Status
- **176 → 189 theorems**, 0 sorries, 0 `native_decide`.
- **Axiom-pure** `[propext, Classical.choice, Quot.sound]` (`#print axioms` on both headline theorems).

### ⚠️ Verification note
The project **docker-build environment is currently broken**: `docker-build.sh Proofs.EulerTotientOQ04OQ03` crashes with `Lean exited with code 135` (SIGBUS) even on the **pristine unmodified file**, and a minimal file importing only `Mathlib.Data.Nat.Totient` likewise crashes in ~0.4 s — a corrupted/incompatible Mathlib olean cache in the docker volume, **not** this change. The new theorems were machine-checked in isolation on the **host elan toolchain** (lean v4.26.0, project Mathlib `LEAN_PATH`): a self-contained file with the exact defs + `dblIter_transport` (copied verbatim) + this block elaborates with **exit 0** and clean axioms. Full-file re-verification should be re-run once the docker environment recovers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)