### PR TITLE
Enrich: structure bare-string crossReferences across 21 entries

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-02-oq-02-oq-05/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-02-oq-02-oq-05/meta.json
@@ -110,10 +110,26 @@
     }
   ],
   "crossReferences": [
-    "amgm-inequality-oq-02-oq-02",
-    "amgm-inequality-oq-02-oq-03-oq-03-oq-01",
-    "newton-power-sum-identities-oq-01",
-    "descartes-rule-of-signs"
+    {
+      "targetId": "amgm-inequality-oq-02-oq-02",
+      "relationship": "extends",
+      "description": "Ancestor in this entry’s line: Newton's Log-Concavity: Complete Proof of Maclaurin's Step. The present entry extends or refines it."
+    },
+    {
+      "targetId": "amgm-inequality-oq-02-oq-03-oq-03-oq-01",
+      "relationship": "related",
+      "description": "Related result: Maclaurin's Step via Mathlib Symmetric Functions: Resolving the Newton-Identities Question."
+    },
+    {
+      "targetId": "newton-power-sum-identities-oq-01",
+      "relationship": "related",
+      "description": "Related result: Newton's Identities in Low Degree: Power Sums from Elementary Symmetric Polynomials."
+    },
+    {
+      "targetId": "descartes-rule-of-signs",
+      "relationship": "related",
+      "description": "Related result: Descartes' Rule of Signs."
+    }
   ],
   "references": [
     {

--- a/src/data/proofs/ballot-problem-oq-02-oq-03/meta.json
+++ b/src/data/proofs/ballot-problem-oq-02-oq-03/meta.json
@@ -118,12 +118,26 @@
     ]
   },
   "crossReferences": [
-    "ballot-problem-oq-02",
-    "ballot-problem-oq-02-oq-04"
+    {
+      "targetId": "ballot-problem-oq-02",
+      "relationship": "extends",
+      "description": "Ancestor in this entry’s line: Continuous-Time Ballot Problem via Brownian Motion. The present entry extends or refines it."
+    },
+    {
+      "targetId": "ballot-problem-oq-02-oq-04",
+      "relationship": "related",
+      "description": "Related result: The Arcsine Distribution: verified core of Lévy's Arcsine Law."
+    }
   ],
   "leanFile": {
-    "imports": ["Mathlib"],
-    "opens": ["Real", "Set", "intervalIntegral"],
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Real",
+      "Set",
+      "intervalIntegral"
+    ],
     "namespace": "ArcsineLawDensity",
     "lineCount": 216,
     "mainTheorems": [

--- a/src/data/proofs/ballot-problem-oq-02-oq-04/meta.json
+++ b/src/data/proofs/ballot-problem-oq-02-oq-04/meta.json
@@ -131,11 +131,19 @@
     ]
   },
   "crossReferences": [
-    "ballot-problem-oq-02"
+    {
+      "targetId": "ballot-problem-oq-02",
+      "relationship": "extends",
+      "description": "Ancestor in this entry’s line: Continuous-Time Ballot Problem via Brownian Motion. The present entry extends or refines it."
+    }
   ],
   "leanFile": {
-    "imports": ["Mathlib"],
-    "opens": ["Real"],
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Real"
+    ],
     "namespace": "ArcsineLaw",
     "lineCount": 199,
     "mainTheorems": [

--- a/src/data/proofs/cayleys-theorem-oq-01-oq-01-oq-02-oq-02-oq-01/meta.json
+++ b/src/data/proofs/cayleys-theorem-oq-01-oq-01-oq-02-oq-02-oq-01/meta.json
@@ -118,7 +118,11 @@
     }
   ],
   "crossReferences": [
-    "cayleys-theorem-oq-01-oq-01-oq-02-oq-02"
+    {
+      "targetId": "cayleys-theorem-oq-01-oq-01-oq-02-oq-02",
+      "relationship": "extends",
+      "description": "Ancestor in this entry’s line: The Centralizer of the Left-Regular Image is the Right-Regular Image (equal iff abelian). The present entry extends or refines it."
+    }
   ],
   "sections": [
     {

--- a/src/data/proofs/composition-card-2pow-oq-01-oq-01/meta.json
+++ b/src/data/proofs/composition-card-2pow-oq-01-oq-01/meta.json
@@ -115,6 +115,10 @@
     ]
   },
   "crossReferences": [
-    "composition-card-2pow-oq-01"
+    {
+      "targetId": "composition-card-2pow-oq-01",
+      "relationship": "extends",
+      "description": "Ancestor in this entry’s line: Composition Card OQ-01: There Are 2^(n−1) Compositions of n. The present entry extends or refines it."
+    }
   ]
 }

--- a/src/data/proofs/composition-card-2pow-oq-01/meta.json
+++ b/src/data/proofs/composition-card-2pow-oq-01/meta.json
@@ -111,7 +111,11 @@
     ]
   },
   "crossReferences": [
-    "dyck-catalan-count-oq-01"
+    {
+      "targetId": "dyck-catalan-count-oq-01",
+      "relationship": "related",
+      "description": "Related result: Dyck Words Are Counted by the Catalan Numbers."
+    }
   ],
   "references": [
     {

--- a/src/data/proofs/composition-parts-choose-oq-01-oq-01/meta.json
+++ b/src/data/proofs/composition-parts-choose-oq-01-oq-01/meta.json
@@ -117,7 +117,15 @@
     ]
   },
   "crossReferences": [
-    "composition-parts-choose-oq-01",
-    "composition-card-2pow-oq-01"
+    {
+      "targetId": "composition-parts-choose-oq-01",
+      "relationship": "extends",
+      "description": "Ancestor in this entry’s line: Composition Parts OQ-01: Compositions of n into k Parts Number C(n−1, k−1). The present entry extends or refines it."
+    },
+    {
+      "targetId": "composition-card-2pow-oq-01",
+      "relationship": "related",
+      "description": "Related result: Composition Card OQ-01: There Are 2^(n−1) Compositions of n."
+    }
   ]
 }

--- a/src/data/proofs/composition-parts-choose-oq-01/meta.json
+++ b/src/data/proofs/composition-parts-choose-oq-01/meta.json
@@ -1,5 +1,5 @@
 {
-  "references":   [
+  "references": [
     {
       "authors": "R. P. Stanley",
       "title": "Enumerative Combinatorics, Volume 1",
@@ -140,7 +140,15 @@
     ]
   },
   "crossReferences": [
-    "composition-card-2pow-oq-01",
-    "dyck-catalan-count-oq-01"
+    {
+      "targetId": "composition-card-2pow-oq-01",
+      "relationship": "related",
+      "description": "Related result: Composition Card OQ-01: There Are 2^(n−1) Compositions of n."
+    },
+    {
+      "targetId": "dyck-catalan-count-oq-01",
+      "relationship": "related",
+      "description": "Related result: Dyck Words Are Counted by the Catalan Numbers."
+    }
   ]
 }

--- a/src/data/proofs/det-conjugate-transpose-oq-01-oq-03/meta.json
+++ b/src/data/proofs/det-conjugate-transpose-oq-01-oq-03/meta.json
@@ -161,6 +161,10 @@
     ]
   },
   "crossReferences": [
-    "det-conjugate-transpose-oq-01"
+    {
+      "targetId": "det-conjugate-transpose-oq-01",
+      "relationship": "extends",
+      "description": "Ancestor in this entry’s line: Determinant of the Conjugate Transpose: det Mᴴ = star (det M), with the Hermitian and Unitary Corollaries. The present entry extends or refines it."
+    }
   ]
 }

--- a/src/data/proofs/det-conjugate-transpose-oq-01/meta.json
+++ b/src/data/proofs/det-conjugate-transpose-oq-01/meta.json
@@ -1,5 +1,5 @@
 {
-  "references":   [
+  "references": [
     {
       "authors": "R. A. Horn and C. R. Johnson",
       "title": "Matrix Analysis",
@@ -167,6 +167,10 @@
     ]
   },
   "crossReferences": [
-    "cramers-rule-oq-05"
+    {
+      "targetId": "cramers-rule-oq-05",
+      "relationship": "related",
+      "description": "Related result: Cramer's Rule OQ-05: Conjugation Invariance of Determinant, Trace, and Characteristic Polynomial."
+    }
   ]
 }

--- a/src/data/proofs/dirichlet-approximation-theorem-oq-05-oq-02/meta.json
+++ b/src/data/proofs/dirichlet-approximation-theorem-oq-05-oq-02/meta.json
@@ -117,10 +117,26 @@
     ]
   },
   "crossReferences": [
-    "dirichlet-approximation-theorem-oq-05",
-    "dirichlet-approximation-theorem",
-    "dirichlet-approximation-theorem-oq-01",
-    "dirichlet-approximation-theorem-oq-03"
+    {
+      "targetId": "dirichlet-approximation-theorem-oq-05",
+      "relationship": "extends",
+      "description": "Ancestor in this entry’s line: Dirichlet Approximation OQ-05: The Golden Ratio is Badly Approximable. The present entry extends or refines it."
+    },
+    {
+      "targetId": "dirichlet-approximation-theorem",
+      "relationship": "extends",
+      "description": "Ancestor in this entry’s line: Dirichlet's Approximation Theorem. The present entry extends or refines it."
+    },
+    {
+      "targetId": "dirichlet-approximation-theorem-oq-01",
+      "relationship": "related",
+      "description": "Related result: Dirichlet Approximation OQ-01: Infinitude of Good Rational Approximations."
+    },
+    {
+      "targetId": "dirichlet-approximation-theorem-oq-03",
+      "relationship": "related",
+      "description": "Related result: Dirichlet Approximation OQ-03: Minkowski Geometry-of-Numbers Re-derivation."
+    }
   ],
   "references": [
     {

--- a/src/data/proofs/eisenstein-criterion-oq-01-oq-02/meta.json
+++ b/src/data/proofs/eisenstein-criterion-oq-01-oq-02/meta.json
@@ -146,9 +146,21 @@
     }
   ],
   "crossReferences": [
-    "eisenstein-criterion-oq-01",
-    "abel-ruffini",
-    "algebraic-numbers-countable"
+    {
+      "targetId": "eisenstein-criterion-oq-01",
+      "relationship": "extends",
+      "description": "Ancestor in this entry’s line: Eisenstein's Criterion and the Irreducibility of Xⁿ − p. The present entry extends or refines it."
+    },
+    {
+      "targetId": "abel-ruffini",
+      "relationship": "related",
+      "description": "Related result: Abel-Ruffini Theorem."
+    },
+    {
+      "targetId": "algebraic-numbers-countable",
+      "relationship": "related",
+      "description": "Related result: Countability of Algebraic Numbers."
+    }
   ],
   "sorries": [],
   "mainTheorems": [

--- a/src/data/proofs/erdos-95-oq-04/meta.json
+++ b/src/data/proofs/erdos-95-oq-04/meta.json
@@ -130,8 +130,16 @@
     ]
   },
   "crossReferences": [
-    "erdos-95",
-    "erdos-94"
+    {
+      "targetId": "erdos-95",
+      "relationship": "extends",
+      "description": "Ancestor in this entry’s line: Erdős Problem #95: Sum of Squared Distance Multiplicities. The present entry extends or refines it."
+    },
+    {
+      "targetId": "erdos-94",
+      "relationship": "related",
+      "description": "Related result: Erdős #94: Distance Multiplicities in Convex Polygons."
+    }
   ],
   "references": [
     {

--- a/src/data/proofs/euler-identity-oq-05/meta.json
+++ b/src/data/proofs/euler-identity-oq-05/meta.json
@@ -186,6 +186,10 @@
     ]
   },
   "crossReferences": [
-    "euler-identity"
+    {
+      "targetId": "euler-identity",
+      "relationship": "extends",
+      "description": "Ancestor in this entry’s line: Euler's Identity. The present entry extends or refines it."
+    }
   ]
 }

--- a/src/data/proofs/euler-totient-oq-02-oq-02-oq-01/meta.json
+++ b/src/data/proofs/euler-totient-oq-02-oq-02-oq-01/meta.json
@@ -122,7 +122,15 @@
     }
   ],
   "crossReferences": [
-    "euler-totient-oq-02-oq-02",
-    "euler-totient"
+    {
+      "targetId": "euler-totient-oq-02-oq-02",
+      "relationship": "extends",
+      "description": "Ancestor in this entry’s line: Euler's Theorem via the Group Structure of (ℤ/nℤ)ˣ. The present entry extends or refines it."
+    },
+    {
+      "targetId": "euler-totient",
+      "relationship": "extends",
+      "description": "Ancestor in this entry’s line: Euler's Generalization of Fermat's Little Theorem. The present entry extends or refines it."
+    }
   ]
 }

--- a/src/data/proofs/matrix-posdef-sqrt-oq-01-oq-01/meta.json
+++ b/src/data/proofs/matrix-posdef-sqrt-oq-01-oq-01/meta.json
@@ -134,7 +134,11 @@
     ]
   },
   "crossReferences": [
-    "matrix-posdef-sqrt-oq-01"
+    {
+      "targetId": "matrix-posdef-sqrt-oq-01",
+      "relationship": "extends",
+      "description": "Ancestor in this entry’s line: The Positive Semidefinite Square Root of a Matrix: Existence, Structure, and Uniqueness. The present entry extends or refines it."
+    }
   ],
   "references": [
     {

--- a/src/data/proofs/matrix-posdef-sqrt-oq-01/meta.json
+++ b/src/data/proofs/matrix-posdef-sqrt-oq-01/meta.json
@@ -134,6 +134,10 @@
     ]
   },
   "crossReferences": [
-    "det-conjugate-transpose-oq-01"
+    {
+      "targetId": "det-conjugate-transpose-oq-01",
+      "relationship": "related",
+      "description": "Related result: Determinant of the Conjugate Transpose: det Mᴴ = star (det M), with the Hermitian and Unitary Corollaries."
+    }
   ]
 }

--- a/src/data/proofs/navier-stokes-oq-01-oq-01/meta.json
+++ b/src/data/proofs/navier-stokes-oq-01-oq-01/meta.json
@@ -124,9 +124,21 @@
     ]
   },
   "crossReferences": [
-    "navier-stokes-oq-01",
-    "amgm-inequality",
-    "cauchy-schwarz"
+    {
+      "targetId": "navier-stokes-oq-01",
+      "relationship": "extends",
+      "description": "Ancestor in this entry’s line: 2D Navier-Stokes: Quantitative Enstrophy Decay and Energy Identity. The present entry extends or refines it."
+    },
+    {
+      "targetId": "amgm-inequality",
+      "relationship": "related",
+      "description": "Related result: Arithmetic Mean - Geometric Mean Inequality."
+    },
+    {
+      "targetId": "cauchy-schwarz",
+      "relationship": "related",
+      "description": "Related result: Cauchy-Schwarz Inequality."
+    }
   ],
   "references": [
     {

--- a/src/data/proofs/stars-and-bars-last-part-recurrence-oq-01-oq-01/meta.json
+++ b/src/data/proofs/stars-and-bars-last-part-recurrence-oq-01-oq-01/meta.json
@@ -124,8 +124,20 @@
     ]
   },
   "crossReferences": [
-    "stars-and-bars-weak-compositions",
-    "stars-and-bars-weak-compositions-oq-01",
-    "stars-and-bars-weak-compositions-oq-01-oq-01"
+    {
+      "targetId": "stars-and-bars-weak-compositions",
+      "relationship": "related",
+      "description": "Related result: Stars and Bars: Weak Compositions of n into k Parts Number C(n+k−1, n)."
+    },
+    {
+      "targetId": "stars-and-bars-weak-compositions-oq-01",
+      "relationship": "related",
+      "description": "Related result: Generating-Function View of Weak Compositions: ∑ₙ #(weak comps) Xⁿ = 1/(1−X)ᵏ."
+    },
+    {
+      "targetId": "stars-and-bars-weak-compositions-oq-01-oq-01",
+      "relationship": "related",
+      "description": "Related result: Generating Function of Positive Compositions: ∑ₙ #(positive comps) Xⁿ = Xᵏ/(1−X)ᵏ."
+    }
   ]
 }

--- a/src/data/proofs/tangent-addition-formula-oq-01/meta.json
+++ b/src/data/proofs/tangent-addition-formula-oq-01/meta.json
@@ -132,6 +132,10 @@
     ]
   },
   "crossReferences": [
-    "triangle-angle-sum-oq-06"
+    {
+      "targetId": "triangle-angle-sum-oq-06",
+      "relationship": "related",
+      "description": "Related result: Triangle Angle Sum OQ-06/07: Sum-to-Product (Prosthaphaeresis) Identities and the Triangle Half-Angle Products."
+    }
   ]
 }

--- a/src/data/proofs/triangle-angle-sum-oq-06/meta.json
+++ b/src/data/proofs/triangle-angle-sum-oq-06/meta.json
@@ -120,8 +120,16 @@
     ]
   },
   "crossReferences": [
-    "triangle-angle-sum-oq-04",
-    "triangle-angle-sum-oq-07"
+    {
+      "targetId": "triangle-angle-sum-oq-04",
+      "relationship": "related",
+      "description": "Related result: Triangle Angle Sum OQ-04: Werner Product-to-Sum Identities and the Finite Dirichlet Kernel."
+    },
+    {
+      "targetId": "triangle-angle-sum-oq-07",
+      "relationship": "related",
+      "description": "Related result: Triangle Angle Sum OQ-07: Degenerate (Collinear) Triangles and the Angle Sum."
+    }
   ],
   "mainTheorems": [
     {


### PR DESCRIPTION
Enrichment batch — the second and final sweep of pass-0 entries whose `crossReferences` were **bare string IDs**.

## Problem
21 entries stored `crossReferences` as plain strings, e.g. `["erdos-95", "erdos-94"]`. Bare strings don't conform to the `CrossReference` type (`src/types/proof.ts` requires a `relationship` field) and render with no relationship label or navigational context.

## Fix
Converted each to `{ targetId, relationship, description }`:
- **relationship** inferred from the slug hierarchy — an ancestor slug → `extends`, otherwise `related`.
- **description** grounded in each target's actual title.

Entries: amgm-inequality-oq-02-oq-02-oq-05, ballot-problem-oq-02-oq-03 / -oq-04, cayleys-theorem-oq-01-oq-01-oq-02-oq-02-oq-01, composition-card-2pow(-oq-01, -oq-01-oq-01), composition-parts-choose(-oq-01, -oq-01-oq-01), det-conjugate-transpose(-oq-01, -oq-01-oq-03), dirichlet-approximation-theorem-oq-05-oq-02, eisenstein-criterion-oq-01-oq-02, erdos-95-oq-04, euler-identity-oq-05, euler-totient-oq-02-oq-02-oq-01, matrix-posdef-sqrt(-oq-01, -oq-01-oq-01), navier-stokes-oq-01-oq-01, stars-and-bars-last-part-recurrence-oq-01-oq-01, tangent-addition-formula-oq-01, triangle-angle-sum-oq-06.

## Verification
- All 21 JSON files validate; every crossReference is now a typed object; all metas well under the 60 KB cap.
- Minimal diffs (only the `crossReferences` block per file).
- No change to `status`/`badge`/`axiomCount` for any entry.

(Companion to the stars-and-bars family batch in the sibling PR; together they clear all bare-string crossReferences among pass-0 entries.)