### PR TITLE
Enrich abel-ruffini-oq-04-oq-03: close section coverage gap

### DIFF
--- a/src/data/proofs/abel-ruffini-oq-04-oq-03/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-03/meta.json
@@ -161,7 +161,7 @@
     {
       "id": "setup",
       "title": "Namespace and Variable Setup",
-      "startLine": 41,
+      "startLine": 40,
       "endLine": 51,
       "summary": "Declares the GaloisCriterion namespace with abstract fields F and E, setting up the general field-extension context."
     },


### PR DESCRIPTION
Enrichment pass for `abel-ruffini-oq-04-oq-03` (quality 100, pass 0).

**Change:** the 9 sections previously left line 40 uncovered — the blank line between the module docstring (ends line 39) and the `set_option` / `noncomputable section` setup. Extending the *Namespace and Variable Setup* section to start at line 40 makes the sections tile lines **1–242 contiguously**.

This entry is already comprehensive and well-curated (30 KB; 10 keyInsights; 19 crossReferences; axiom integrity correct — 1 axiom `solvableGal_implies_solvableByRad`, `status: axiomatized`, `badge: axiom`, disclosed in `assumptions`), so this is a minimal contiguity fix only. No field content added or removed.