### PR TITLE
research(erdos-1064-oq-03): A₊/A₋/A₌ trichotomy partitions ℕ (0-axiom)

### DIFF
--- a/proofs/Proofs/Erdos1064Problem.lean
+++ b/proofs/Proofs/Erdos1064Problem.lean
@@ -60,6 +60,37 @@ def A_less : Set ℕ := {n : ℕ | totient n < totient (n - totient n)}
 /-- The set A₌ where φ(n) = φ(n - φ(n)) -/
 def A_equal : Set ℕ := {n : ℕ | totient n = totient (n - totient n)}
 
+/-! ### The trichotomy `A₊ / A₋ / A₌` partitions ℕ
+
+Comparing `φ(n)` with `φ(n − φ(n))` places every `n` in exactly one of the three sets
+`A_greater` (`>`), `A_less` (`<`), `A_equal` (`=`). The following record that they are
+pairwise disjoint and jointly exhaust ℕ — the structural backdrop against which the density-1
+(`lucaPomerance_density_one`) and infinitely-often (`glw_infinitely_many`,
+`A_greater_infinite`) results are stated. -/
+
+/-- `A₊` and `A₋` are disjoint: `φ(n)` cannot be both `>` and `<` than `φ(n − φ(n))`. -/
+theorem A_greater_disjoint_A_less : Disjoint A_greater A_less := by
+  rw [Set.disjoint_left]; intro n hn hn'
+  simp only [A_greater, A_less, Set.mem_setOf_eq] at hn hn'; omega
+
+/-- `A₊` and `A₌` are disjoint. -/
+theorem A_greater_disjoint_A_equal : Disjoint A_greater A_equal := by
+  rw [Set.disjoint_left]; intro n hn hn'
+  simp only [A_greater, A_equal, Set.mem_setOf_eq] at hn hn'; omega
+
+/-- `A₋` and `A₌` are disjoint. -/
+theorem A_less_disjoint_A_equal : Disjoint A_less A_equal := by
+  rw [Set.disjoint_left]; intro n hn hn'
+  simp only [A_less, A_equal, Set.mem_setOf_eq] at hn hn'; omega
+
+/-- The trichotomy is exhaustive: `A₊ ∪ A₋ ∪ A₌ = ℕ`. -/
+theorem A_greater_union_A_less_union_A_equal :
+    A_greater ∪ A_less ∪ A_equal = Set.univ := by
+  ext n
+  simp only [A_greater, A_less, A_equal, Set.mem_union, Set.mem_setOf_eq, Set.mem_univ,
+    iff_true]
+  omega
+
 /- ## Concrete Examples -/
 
 /-- φ(1) = 1 -/

--- a/src/data/proofs/erdos-1064/meta.json
+++ b/src/data/proofs/erdos-1064/meta.json
@@ -48,7 +48,7 @@
       "A second axiom-free witness family for A₊'s infinitude: every 2^(k+2) lies in A₊ (powers of two), mirroring the 15·2^k family for A₋"
     ],
     "axiomCount": 1,
-    "lineCount": 306,
+    "lineCount": 337,
     "prerequisites": [
       "Euler's totient function φ(n) and its multiplicativity",
       "Natural density of subsets of ℕ",
@@ -56,7 +56,7 @@
       "Prime factorization and coprimality"
     ],
     "assumptions": "1 axiom: lucaPomerance_density_one (the density-1 result of Luca-Pomerance 2002, requiring analytic number theory). The former glw_infinitely_many axiom (Grytczuk-Luca-Wojtowicz 2001, infinitely many n with phi(n) < phi(n-phi(n))) is now constructively PROVED via the explicit family n = 15*2^(k+1). Concrete illustrative examples use native_decide (Lean.ofReduceBool). See Lean source for complete statements.",
-    "theoremCount": 11,
+    "theoremCount": 15,
     "definitionCount": 4
   },
   "overview": {
@@ -195,9 +195,9 @@
       "Nat"
     ],
     "namespace": "Erdos1064",
-    "lineCount": 306,
+    "lineCount": 337,
     "axiomCount": 1,
-    "theoremCount": 11,
+    "theoremCount": 15,
     "definitionCount": 4,
     "path": "Proofs/Erdos1064Problem.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

Four 0-axiom structural lemmas for Erdős #1064 (comparing `φ(n)` with `φ(n − φ(n))`), recording that the three comparison sets partition ℕ:

- **`A_greater_disjoint_A_less`**, **`A_greater_disjoint_A_equal`**, **`A_less_disjoint_A_equal`** — the sets `A₊` (`φ(n) > φ(n−φ(n))`), `A₋` (`<`), `A₌` (`=`) are pairwise disjoint.
- **`A_greater_union_A_less_union_A_equal`** — they are jointly exhaustive: `A₊ ∪ A₋ ∪ A₌ = Set.univ`.

Together these say `{A₊, A₋, A₌}` is a partition of ℕ — the structural backdrop against which the density-1 (`lucaPomerance_density_one`) and infinitely-often (`glw_infinitely_many`, `A_greater_infinite`) results are stated.

## Verification

- Each proof is a pure `Set.disjoint_left` / `ext` + `omega` (no `native_decide`, independent of the file's witness computations). The `Set.disjoint_left` + `omega` logic was verified via **clean elaboration** in a minimal-import build.
- The file uses `import Mathlib` with `native_decide` witnesses; in the current sandbox serialization SIGBUS's (exit 135) — an environment limit, not a proof error (the deployer's build environment merges these fine).
- Gallery `meta.json`: theoremCount 11→15, lineCount 306→337. axiomCount unchanged (1, `ofReduceBool` from the existing `native_decide` witnesses), 0 sorries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)