### PR TITLE
research(combinations-formula-oq-03-oq-04): Gaussian q-binomial self-reciprocity (palindromy)

### DIFF
--- a/proofs/Proofs/CombinationsFormulaOQ03OQ04.lean
+++ b/proofs/Proofs/CombinationsFormulaOQ03OQ04.lean
@@ -1,0 +1,121 @@
+import Proofs.CombinationsFormulaOQ03
+
+/-
+# Self-Reciprocity (Palindromy) of Gaussian q-Binomial Coefficients
+
+## What This Proves
+The Gaussian binomial coefficient [n choose k]_q, viewed as a polynomial in q,
+is **palindromic** (self-reciprocal) of degree k·(n-k). Over a field, this is the
+clean algebraic identity
+
+    [n choose k]_q = q^{k(n-k)} · [n choose k]_{1/q}   (for q ≠ 0).
+
+Reading off coefficients, this says the coefficient sequence of [n,k]_q reads the
+same forwards and backwards: a_j = a_{k(n-k)-j}. This palindromy is the *symmetric*
+half of Sylvester's theorem (1878): the coefficient sequence of [n,k]_q is a
+symmetric **unimodal** sequence. Unimodality (the harder half, first proved
+rigorously by Proctor 1982 via sl₂ representation theory) remains open in this
+gallery; this file establishes the symmetry precursor rigorously and axiom-free.
+
+## Approach
+The parent file `CombinationsFormulaOQ03` defines [n,k]_q over an arbitrary
+commutative ring via the q-Pascal recurrence and proves *both* Pascal identities:
+
+  (P1)  [n+1,k+1]_q = [n,k]_q + q^{k+1}·[n,k+1]_q          (`qBinom_pascal`)
+  (P2)  [n+1,k+1]_q = q^{n-k}·[n,k]_q + [n,k+1]_q          (`qBinom_pascal'`)
+
+Palindromy follows by induction on n: expand the left side [n+1,k+1]_q via (P2)
+and the reflected right side [n+1,k+1]_{1/q} via (P1); the induction hypothesis
+then makes the two sides agree term-by-term after collecting powers of q. The key
+cancellation is q^{(k+1)(n-k)}·(1/q)^{k+1} = q^{(k+1)(n-k-1)}, valid since q ≠ 0.
+
+## Status
+- [x] Self-reciprocity / palindromy: [n,k]_q = q^{k(n-k)}·[n,k]_{1/q}  (main)
+- [x] Reflected form: q^{k(n-k)}·[n,k]_{1/q} = [n,k]_q
+- [x] Involutivity sanity check of the reflection
+- [ ] OPEN: coefficient unimodality (Sylvester/Proctor) — not attempted here
+
+## Honesty Note
+This is the palindromy/symmetry ingredient only. It does NOT prove unimodality,
+which is the substantive content of the open question. Full unimodality requires
+either an sl₂-action argument or an explicit injection between coefficient levels
+and is not formalized here.
+-/
+
+namespace QBinomialCoefficients
+
+open Nat
+
+variable {R : Type*} [Field R]
+
+/-- **Self-reciprocity (palindromy) of the Gaussian binomial coefficient.**
+
+For a nonzero `q` in a field, the q-binomial coefficient satisfies
+
+    [n choose k]_q = q^{k(n-k)} · [n choose k]_{q⁻¹}.
+
+Equivalently, as a polynomial in `q` of degree `k(n-k)`, `[n,k]_q` is palindromic:
+its coefficient sequence reads the same forwards and backwards. This is the
+symmetric half of Sylvester's unimodality theorem.
+
+The proof is by induction on `n`. The `k = 0`, `k > n`, and `k = n` (diagonal)
+boundary cases are direct. In the generic interior case `k < n` we expand the left
+side by the second q-Pascal identity `qBinom_pascal'` and the reflected right side
+by the first q-Pascal identity `qBinom_pascal`, then apply the induction hypothesis
+at `(n, k)` and `(n, k+1)`; the powers of `q` line up after the cancellation
+`q^{(k+1)(n-k)} · (q⁻¹)^{k+1} = q^{(k+1)(n-k-1)}`. -/
+theorem qBinom_reciprocal (q : R) (hq : q ≠ 0) :
+    ∀ (n k : ℕ), qBinom q n k = q ^ (k * (n - k)) * qBinom q⁻¹ n k
+  | _, 0 => by simp
+  | 0, k + 1 => by simp
+  | n + 1, k + 1 => by
+    rcases le_or_lt (k + 1) n with hkn | hkn
+    · -- k + 1 ≤ n, i.e. k < n : generic interior case
+      have hsplit : n - k = (n - k - 1) + 1 := by omega
+      -- Expand LHS via the SECOND q-Pascal identity (P2)
+      rw [qBinom_pascal' q n k (by omega)]
+      -- Expand the reflected RHS via the FIRST q-Pascal identity (P1)
+      rw [show n + 1 - (k + 1) = n - k from by omega, qBinom_pascal q⁻¹ n k]
+      -- Apply the induction hypothesis to rewrite [n,k]_q and [n,k+1]_q
+      rw [qBinom_reciprocal q hq n k, qBinom_reciprocal q hq n (k + 1),
+          show n - (k + 1) = n - k - 1 from by omega]
+      -- Abbreviate the two reflected atoms
+      set A := qBinom q⁻¹ n k with hA
+      set B := qBinom q⁻¹ n (k + 1) with hB
+      -- Coefficient of A: q^{n-k} · q^{k(n-k)} = q^{(k+1)(n-k)}
+      have hexpA : (n - k) + k * (n - k) = (k + 1) * (n - k) := by ring
+      have eA : q ^ (n - k) * (q ^ (k * (n - k)) * A) = q ^ ((k + 1) * (n - k)) * A := by
+        rw [← mul_assoc, ← pow_add, hexpA]
+      -- Coefficient of B: q^{(k+1)(n-k-1)} = q^{(k+1)(n-k)} · (q⁻¹)^{k+1}
+      have hexpB : (k + 1) * (n - k) = (k + 1) * (n - k - 1) + (k + 1) := by
+        conv_lhs => rw [hsplit]
+        ring
+      have eB : q ^ ((k + 1) * (n - k - 1)) * B
+          = q ^ ((k + 1) * (n - k)) * (q⁻¹ ^ (k + 1) * B) := by
+        rw [hexpB, pow_add, inv_pow, mul_assoc,
+            mul_inv_cancel_left₀ (pow_ne_zero (k + 1) hq)]
+      rw [eA, eB]; ring
+    · -- k + 1 > n : either the diagonal k = n or above it
+      rcases eq_or_ne n k with heq | hne
+      · -- n = k : diagonal, both q-binomials equal 1
+        rw [heq]; simp
+      · -- n < k : both q-binomials vanish
+        rw [qBinom_eq_zero_of_lt q (n + 1) (k + 1) (by omega),
+            qBinom_eq_zero_of_lt q⁻¹ (n + 1) (k + 1) (by omega), mul_zero]
+
+/-- **Reflected form of self-reciprocity.** Applying `q^{k(n-k)}` to the
+`q⁻¹`-binomial recovers the `q`-binomial. This is `qBinom_reciprocal` read from
+right to left, packaged for convenience. -/
+theorem qBinom_reflect (q : R) (hq : q ≠ 0) (n k : ℕ) :
+    q ^ (k * (n - k)) * qBinom q⁻¹ n k = qBinom q n k :=
+  (qBinom_reciprocal q hq n k).symm
+
+/-- **Involutivity sanity check.** Applying reciprocity twice returns the original:
+`[n,k]_q = q^{k(n-k)} · (q⁻¹)^{k(n-k)} · [n,k]_q`, and the two power factors cancel.
+This confirms the reflection `q ↦ q⁻¹` composed with the `q^{k(n-k)}` twist is an
+involution on the q-binomial, as a palindrome reflection must be. -/
+theorem qBinom_reciprocal_involutive (q : R) (hq : q ≠ 0) (n k : ℕ) :
+    qBinom q n k = q ^ (k * (n - k)) * ((q⁻¹) ^ (k * (n - k)) * qBinom q n k) := by
+  rw [← mul_assoc, ← mul_pow, mul_inv_cancel₀ hq, one_pow, one_mul]
+
+end QBinomialCoefficients

--- a/src/data/proofs/combinations-formula-oq-03-oq-04/meta.json
+++ b/src/data/proofs/combinations-formula-oq-03-oq-04/meta.json
@@ -1,0 +1,89 @@
+{
+  "id": "combinations-formula-oq-03-oq-04",
+  "title": "Self-Reciprocity (Palindromy) of Gaussian q-Binomial Coefficients",
+  "slug": "combinations-formula-oq-03-oq-04",
+  "description": "Proves that the Gaussian (q-)binomial coefficient [n choose k]_q, viewed as a polynomial in q, is palindromic (self-reciprocal) of degree k·(n-k). Over a field this is the clean algebraic identity [n,k]_q = q^{k(n-k)}·[n,k]_{q⁻¹}, equivalently that the coefficient sequence reads the same forwards and backwards (a_j = a_{k(n-k)-j}). This palindromy is the symmetric half of Sylvester's theorem (1878) that the coefficient sequence is symmetric and unimodal; unimodality itself (Proctor 1982, via sl₂) is the substantive open question and is NOT proved here. Built on the parent's recurrence-defined q-binomial library via both q-Pascal identities. 3 theorems, 0 sorries, 0 axioms — verified over a field.",
+  "meta": {
+    "author": "Lean Genius Researcher",
+    "status": "verified",
+    "proofRepoPath": "Proofs/CombinationsFormulaOQ03OQ04.lean",
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 121,
+    "theoremCount": 3,
+    "definitionCount": 0,
+    "assumptions": "The reciprocity identity is proved over an arbitrary field R for any nonzero q (invertibility of q is genuinely needed to form q⁻¹ and to cancel q^{k+1}·(q⁻¹)^{k+1} = 1). No characteristic or positivity hypotheses. The underlying q-binomial coefficients are the parent's, defined over an arbitrary commutative ring via the q-Pascal recurrence. #print axioms reports only the foundational propext / Classical.choice / Quot.sound — no sorryAx, no Lean.ofReduceBool.",
+    "tags": [
+      "combinatorics",
+      "q-analogs",
+      "gaussian-binomial",
+      "palindromic-polynomial",
+      "unimodality",
+      "sylvester",
+      "number-theory",
+      "quantum-groups"
+    ],
+    "dateAdded": "2026-07-11",
+    "mathlib_version": "4.26.0",
+    "originalContributions": [
+      "Machine-checked self-reciprocity (palindromy) of the Gaussian binomial: [n,k]_q = q^{k(n-k)}·[n,k]_{q⁻¹} over an arbitrary field, proved by induction on n using BOTH parent q-Pascal identities (the first for the reflected side, the second for the original)",
+      "Identification of the exact algebraic mechanism of palindromy: the reflected recurrence matches the original because expanding the left by the second q-Pascal identity and the reflected right by the first q-Pascal identity produces termwise-equal sides after the cancellation q^{(k+1)(n-k)}·(q⁻¹)^{k+1} = q^{(k+1)(n-k-1)}",
+      "Reflected convenience form q^{k(n-k)}·[n,k]_{q⁻¹} = [n,k]_q and an involutivity sanity check confirming the twisted reflection q ↦ q⁻¹ is an involution",
+      "Explicit, honestly-scoped separation of the symmetric (palindromy) half of Sylvester's theorem — proved here — from the unimodal half, which remains open"
+    ],
+    "prerequisites": [
+      "Gaussian (q-)binomial coefficients and the two q-Pascal recurrences (parent entry combinations-formula-oq-03)",
+      "Field arithmetic with inverses (mul_inv_cancel₀, mul_inv_cancel_left₀, inv_pow, pow_ne_zero)",
+      "Natural-number arithmetic with truncated subtraction (omega) and the ring tactic on ℕ exponents"
+    ]
+  },
+  "leanFile": {
+    "path": "Proofs/CombinationsFormulaOQ03OQ04.lean",
+    "namespace": "QBinomialCoefficients",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 121,
+    "theoremCount": 3,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "The Gaussian binomial coefficient [n choose k]_q was studied by Gauss as the generating polynomial counting k-dimensional subspaces of an n-dimensional vector space over F_q. As a polynomial in q it has degree k(n-k) and nonnegative integer coefficients. In 1878 J. J. Sylvester proved, in the course of his work on invariant theory and the resolution of a conjecture of Cayley, that this coefficient sequence is not merely symmetric but unimodal — it rises to a peak and then falls. The symmetry (palindromy) is elementary and classical; the unimodality is deep. The first fully rigorous proof of unimodality was given by R. Proctor in 1982 using the representation theory of sl₂ (a 'raising/lowering operator' argument), following K. O'Hara's later combinatorial proof (1990). Sylvester's theorem is the prototype for a large family of unimodality results in algebraic combinatorics.",
+    "problemStatement": "The seeker's open question combinations-formula-oq-03-oq-04 asks to establish unimodality of the Gaussian q-binomial coefficients on top of the parent's q-binomial library. Full unimodality is the substantive, hard content (it requires an sl₂-action or an explicit injection between coefficient levels) and is not attempted here. This entry rigorously formalizes the symmetric precursor: the coefficient sequence is palindromic, stated over a field as [n,k]_q = q^{k(n-k)}·[n,k]_{q⁻¹}.",
+    "proofStrategy": "The palindromy identity is proved by induction on n with a case split on k. The boundary cases k=0, the diagonal k=n (both q-binomials equal 1), and k>n (both vanish) are direct. In the generic interior case k<n, the left side [n+1,k+1]_q is expanded by the SECOND q-Pascal identity qBinom_pascal' ([n+1,k+1]_q = q^{n-k}·[n,k]_q + [n,k+1]_q) while the reflected right side [n+1,k+1]_{q⁻¹} is expanded by the FIRST q-Pascal identity qBinom_pascal ([n+1,k+1]_q = [n,k]_q + q^{k+1}·[n,k+1]_q). Substituting the induction hypothesis at (n,k) and (n,k+1) makes the two sides coincide term-by-term: the coefficient of the reflected [n,k]_{q⁻¹} matches after q^{n-k}·q^{k(n-k)} = q^{(k+1)(n-k)}, and the coefficient of [n,k+1]_{q⁻¹} matches after the cancellation q^{(k+1)(n-k)}·(q⁻¹)^{k+1} = q^{(k+1)(n-k-1)}, valid since q ≠ 0.",
+    "keyInsights": [
+      "**Palindromy is the symmetric half of unimodality**: A symmetric unimodal sequence is the conclusion of Sylvester's theorem. The symmetry a_j = a_{k(n-k)-j} — proved here — is elementary and reduces to the two q-Pascal recurrences; the unimodality (the actual rise-then-fall) is the hard half and stays open. Separating the two cleanly is the honest way to report partial progress on the open question.",
+      "**Both q-Pascal identities together produce termwise agreement**: The single most important structural fact is that expanding the original by the second q-Pascal identity and the reflection by the first q-Pascal identity yields two expressions that agree coefficient-by-coefficient after collecting powers of q. Using the same Pascal identity on both sides does NOT give a termwise match — the two forms are consistent only because qBinom_pascal and qBinom_pascal' compute the same q-binomial.",
+      "**Invertibility of q is essential, not cosmetic**: The reflection substitutes q ↦ q⁻¹ and relies on q^{k+1}·(q⁻¹)^{k+1} = 1, so the identity is naturally a field statement with q ≠ 0. Over a general ring one would instead pass to a polynomial reversal; the field formulation keeps the proof to elementary power arithmetic (pow_add, inv_pow, mul_inv_cancel_left₀).",
+      "**Truncated subtraction never bites**: The exponents k(n-k), (k+1)(n-k), and (k+1)(n-k-1) use ℕ subtraction, but the delicate step (writing n-k = (n-k-1)+1) is only taken in the branch k<n where n-k ≥ 1, so the subtraction is exact exactly where it is used; the diagonal and above-diagonal cases are dispatched before any such rewrite."
+    ],
+    "prerequisites": [
+      "Gaussian (q-)binomial coefficients and the two q-Pascal recurrences (parent entry combinations-formula-oq-03)",
+      "Field arithmetic with inverses and powers (mul_inv_cancel_left₀, inv_pow, pow_ne_zero, pow_add)",
+      "Natural-number truncated subtraction and the omega / ring tactics"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Open Question and Mathematical Context",
+      "startLine": 1,
+      "endLine": 44,
+      "summary": "Module docstring stating the target (palindromy of Gaussian q-binomials as the symmetric half of Sylvester's unimodality theorem), the proof outline via both q-Pascal identities, and an explicit honesty note that unimodality itself is NOT proved."
+    },
+    {
+      "id": "reciprocal",
+      "title": "Main — Self-Reciprocity / Palindromy",
+      "startLine": 51,
+      "endLine": 104,
+      "summary": "qBinom_reciprocal: [n,k]_q = q^{k(n-k)}·[n,k]_{q⁻¹} over a field for q ≠ 0, by induction on n. Interior case k<n expands the left by qBinom_pascal' and the reflected right by qBinom_pascal, applies the induction hypothesis, and closes by the power cancellation q^{(k+1)(n-k)}·(q⁻¹)^{k+1} = q^{(k+1)(n-k-1)}; boundary/diagonal/vanishing cases are direct."
+    },
+    {
+      "id": "corollaries",
+      "title": "Reflected Form and Involutivity",
+      "startLine": 106,
+      "endLine": 121,
+      "summary": "qBinom_reflect (the right-to-left convenience form q^{k(n-k)}·[n,k]_{q⁻¹} = [n,k]_q) and qBinom_reciprocal_involutive (applying the twisted reflection twice returns the original, confirming it is an involution as any palindrome reflection must be)."
+    }
+  ]
+}

--- a/src/data/research/problems/combinations-formula-oq-03-oq-04.json
+++ b/src/data/research/problems/combinations-formula-oq-03-oq-04.json
@@ -1,7 +1,7 @@
 {
   "slug": "combinations-formula-oq-03-oq-04",
   "title": "Unimodality of Gaussian (q-)binomial coefficients",
-  "phase": "OBSERVE",
+  "phase": "ACT",
   "status": "active",
   "tier": "B",
   "path": "full",
@@ -86,7 +86,8 @@
     "combinations-formula-oq-09",
     "combinations-formula-oq-09-oq-01",
     "combinations-formula-oq-10",
-    "combinations-formula-oq-10-oq-01"
+    "combinations-formula-oq-10-oq-01",
+    "combinations-formula-oq-03-oq-04"
   ],
   "references": {
     "papers": [],
@@ -662,6 +663,42 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CombinationsFormulaOQ10OQ01.lean"
+    },
+    {
+      "path": "Proofs/CombinationsFormulaOQ03OQ04.lean",
+      "filename": "CombinationsFormulaOQ03OQ04.lean",
+      "lineCount": 121,
+      "theoremCount": 3,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CombinationsFormulaOQ03OQ04.lean"
     }
-  ]
+  ],
+  "knowledge": {
+    "insights": [
+      "The Gaussian q-binomial [n,k]_q is a PALINDROMIC polynomial of degree k(n-k): coefficient sequence a_j = a_{k(n-k)-j}. Over a field this is the reciprocity identity [n,k]_q = q^{k(n-k)} times [n,k]_{q inverse} (q nonzero).",
+      "Palindromy is exactly the SYMMETRIC half of Sylvester (1878): the coefficient sequence is symmetric AND unimodal. Unimodality is the hard half (Proctor 1982 via sl_2) and remains OPEN.",
+      "KEY MECHANISM: expand the original [n+1,k+1]_q by the SECOND q-Pascal identity and the reflected [n+1,k+1]_{q inverse} by the FIRST q-Pascal identity; the two sides then agree TERM-BY-TERM after the induction hypothesis. Using the same Pascal on both sides does NOT give a termwise match.",
+      "Invertibility of q is essential (not cosmetic): the reflection uses q^{k+1} times (q inverse)^{k+1} = 1, so the natural home is a field with q nonzero. Over a general ring one would instead use a polynomial reversal.",
+      "Truncated natural-subtraction never bites: the delicate rewrite n-k = (n-k-1)+1 is used only in the branch k<n where n-k >= 1; the diagonal (k=n, both sides 1) and above-diagonal (k>n, both vanish) are dispatched first."
+    ],
+    "builtItems": [
+      "qBinom_reciprocal (CombinationsFormulaOQ03OQ04.lean): [n,k]_q = q^{k(n-k)} times [n,k]_{q inverse} over a field, induction on n using both q-Pascal identities",
+      "qBinom_reflect: right-to-left convenience form",
+      "qBinom_reciprocal_involutive: the twisted reflection q to q inverse is an involution",
+      "meta.json gallery entry (verified, 3 thm, 0 sorry, 0 axiom)"
+    ],
+    "mathlibGaps": [
+      "No direct need: proof uses only parent q-binomial API plus elementary field/power lemmas (mul_inv_cancel_left_zero, inv_pow, pow_ne_zero, pow_add).",
+      "For a COEFFICIENT-LEVEL palindromy over the polynomial ring (Polynomial.reflect), the parent q-binomial would need specializing to Polynomial over the integers with q = X; not done here (field formulation avoids Polynomial machinery)."
+    ],
+    "nextSteps": [
+      "Attempt the UNIMODALITY half: the real open question. Routes are (a) sl_2 raising/lowering operator action on the subspace lattice (Proctor 1982), (b) O'Hara-style explicit injection between coefficient levels. Both substantial; assess buildability first.",
+      "Cheaper structural step: formalize DEGREE = k(n-k) and NONNEGATIVITY of coefficients over the polynomial ring (specialize parent to Polynomial over the integers, q = X); with palindromy this pins the extreme coefficients.",
+      "Cross-check: palindromy plus the parent qBinom_symm ([n,k] = [n,n-k]) give the full symmetry group of the coefficient array."
+    ],
+    "progressSummary": "PROGRESS: palindromy/self-reciprocity of q-binomial proved and verified (PR#38119). Unimodality (Sylvester/Proctor) remains OPEN, the substantive content."
+  }
 }


### PR DESCRIPTION
## Summary

Adds `proofs/Proofs/CombinationsFormulaOQ03OQ04.lean` (+ gallery `meta.json`) proving that the Gaussian (q-)binomial coefficient `[n choose k]_q`, viewed as a polynomial in `q`, is **palindromic (self-reciprocal)** of degree `k(n-k)`. Over a field this is the clean identity

```
[n, k]_q  =  q^{k(n-k)} · [n, k]_{q⁻¹}       (q ≠ 0)
```

Reading off coefficients: `a_j = a_{k(n-k)-j}` — the sequence reads the same forwards and backwards.

This is the **symmetric half of Sylvester's theorem (1878)**: the coefficient sequence of `[n,k]_q` is symmetric *and* unimodal. **Unimodality — the substantive, hard half (Proctor 1982, via sl₂) — is the open question and is NOT proved here.** This PR rigorously establishes only the palindromy precursor, axiom-free.

## Theorems (3, all axiom-free over a field)

| Theorem | Statement |
|---------|-----------|
| `qBinom_reciprocal` | `[n,k]_q = q^{k(n-k)} · [n,k]_{q⁻¹}` (main; induction on `n`) |
| `qBinom_reflect` | right-to-left convenience form |
| `qBinom_reciprocal_involutive` | the twisted reflection `q ↦ q⁻¹` is an involution |

## Proof mechanism

Induction on `n`. Interior case `k<n`: expand the left `[n+1,k+1]_q` by the **second** q-Pascal identity `qBinom_pascal'` and the reflected right `[n+1,k+1]_{q⁻¹}` by the **first** q-Pascal identity `qBinom_pascal` (both from the parent). The induction hypothesis then makes the two sides agree term-by-term, closing on the power cancellation `q^{(k+1)(n-k)} · (q⁻¹)^{k+1} = q^{(k+1)(n-k-1)}` (needs `q ≠ 0`). Diagonal `k=n` (both sides `1`) and above-diagonal `k>n` (both vanish) are direct.

Using the *same* Pascal identity on both sides does **not** give a termwise match — the two forms agree only because `qBinom_pascal` and `qBinom_pascal'` compute the same q-binomial.

## Verification

Built green via `./proofs/scripts/docker-build.sh Proofs.CombinationsFormulaOQ03OQ04` — **exit 0, 3059 jobs** (`✔ Built Proofs.CombinationsFormulaOQ03` then `Built Proofs.CombinationsFormulaOQ03OQ04`). The committed file is byte-identical to the exit-0 build. 0 sorries, 0 `axiom` declarations, no `native_decide`; assumptions limited to the ordinary foundational axioms (`propext`/`Classical.choice`/`Quot.sound`).

Note: the shared Docker Mathlib/packages cache is intermittently corrupted by concurrent agents (roaming `exit-135`/SIGBUS on even a trivial `import Mathlib.Tactic`); a `--repair-cache` pass plus retries produced a clean window in which the exit-0 build was obtained.

🤖 Generated with [Claude Code](https://claude.com/claude-code)