### PR TITLE
Enrich beta-integral-recurrence-oq-01-oq-02-oq-01-oq-01: notational-setup annotation

### DIFF
--- a/src/data/proofs/beta-integral-recurrence-oq-01-oq-02-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/beta-integral-recurrence-oq-01-oq-02-oq-01-oq-01/annotations.json
@@ -45,6 +45,26 @@
     ]
   },
   {
+    "id": "betadiagasymp-ann-opens",
+    "proofId": "beta-integral-recurrence-oq-01-oq-02-oq-01-oq-01",
+    "range": { "startLine": 54, "endLine": 57 },
+    "type": "context",
+    "title": "Notational Setup: the Asymptotics and Filter Namespaces",
+    "content": "The `open Filter Topology Asymptotics` and `open scoped Real Nat` lines fix the vocabulary the whole file speaks in. From `Filter`/`Topology` come `atTop` (the eventually-large filter on ℕ) and the neighborhood notation `𝓝 1`, which together spell the limit `Tendsto _ atTop (𝓝 1)`. From `Asymptotics` comes the `~[l]` notation for `Asymptotics.IsEquivalent`, so the headline statement can be written `f ~[atTop] g`. The scoped `Real`/`Nat` opens bring in `π` and the `Nat.centralBinom` binomial notation without qualification. None of this is mathematical content — but the entire result is phrased in `IsEquivalent`/`Tendsto` language, so these opens are what make the statements read the way they do.",
+    "mathContext": "$f \\sim_{\\mathrm{atTop}} g$ abbreviates $\\mathrm{Asymptotics.IsEquivalent}\\;\\mathrm{atTop}\\;f\\;g$; $\\mathrm{Tendsto}\\,h\\,\\mathrm{atTop}\\,(\\mathcal N\\,1)$ means $h(n)\\to 1$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "atTop filter",
+      "neighborhood filter 𝓝",
+      "IsEquivalent notation ~[l]",
+      "scoped notation (π, Nat.centralBinom)"
+    ],
+    "prerequisites": [
+      "filters and Tendsto in Mathlib",
+      "Lean open / open scoped"
+    ]
+  },
+  {
     "id": "betadiagasymp-ann-realform",
     "proofId": "beta-integral-recurrence-oq-01-oq-02-oq-01-oq-01",
     "range": {


### PR DESCRIPTION
Enrichment pass for `beta-integral-recurrence-oq-01-oq-02-oq-01-oq-01` (quality 96, passes 0).

## Change
Added `betadiagasymp-ann-opens`, an annotation covering lines 54–57 — the `open Filter Topology Asymptotics` + `open scoped Real Nat` block — which was the only uncovered section (sitting between the docstring annotation ending at line 52 and the real-form annotation starting at line 59). It explains where the notation the theorem statements are actually phrased in comes from: `atTop` and `𝓝` (Filter/Topology), the `~[l]` `IsEquivalent` notation (Asymptotics), and `π`/`Nat.centralBinom` (scoped Real/Nat). Full `mathContext`/`significance`/`relatedConcepts`/`prerequisites`.

## Verification
- Annotation ranges non-overlapping; all schema fields present.
- `meta.json` 14.5 KB (well under 60 KB cap); no meta changes.
- `tsc --noEmit` clean. Status/badge/axiomCount unchanged (verified, 0 axioms) — accurate.

Descriptive/pedagogical only; no new mathematical claims.