### PR TITLE
Enrich algebraic-numbers-countable: fully contiguous section coverage

### DIFF
--- a/src/data/proofs/algebraic-numbers-countable/meta.json
+++ b/src/data/proofs/algebraic-numbers-countable/meta.json
@@ -157,7 +157,7 @@
       "id": "sec-algebraic-header",
       "title": "Header: Module Documentation, Degree Examples, and Historical Context",
       "startLine": 1,
-      "endLine": 68,
+      "endLine": 71,
       "description": "Module header explaining the 6 key results (algebraic reals/complex countable, bounded degree countable, cardinality ℵ₀, exact degree countable, degree stratification). Three proof approach sections: Foundation (Mathlib's Algebraic.countable and cardinalMk), Original Contributions (degree stratification), Proof Techniques. Mathematical background defining algebraic numbers and degree, with examples by degree (degree 1: rationals; degree 2: √2, (1+√5)/2; degree 3: ∛2; degree n: roots of irreducible n-polys). Historical note on Cantor 1874. Connection to denumerability of ℚ: all these sets (ℚ, degree ≤ d, all algebraic) have cardinality ℵ₀. Opens namespace AlgebraicNumbersCountable.",
       "summary": "Lines 1–68 establish the module's eight Mathlib imports and a comprehensive 56-line docstring."
     },
@@ -165,7 +165,7 @@
       "id": "sec-algebraic-core",
       "title": "§1. Core Countability and Cardinality Results",
       "startLine": 72,
-      "endLine": 101,
+      "endLine": 102,
       "description": "Four one-line theorems delegating to Mathlib: `algebraic_reals_countable` (Algebraic.countable ℚ ℝ), `algebraic_complex_countable` (Algebraic.countable ℚ ℂ), `card_algebraic_reals_eq_aleph0` (cardinalMk_of_countable_of_charZero ℚ ℝ), `card_algebraic_complex_eq_aleph0` (cardinalMk_of_countable_of_charZero ℚ ℂ). The cardinality results are strictly stronger than countability: they prove |algebraic reals| = ℵ₀ (countably infinite), ruling out finite algebraic number sets. The char_zero condition on ℝ and ℂ ensures the field is of characteristic 0, needed for Mathlib's API.",
       "summary": "Lines 72–101 (§ 1) state the four headline countability and cardinality results in 4 one-line theorems, each delegating directly to a Mathlib lemma: `algebraic_reals_countable : Set.Countable {x : ℝ | IsAlgebraic ℚ x}` and …"
     },
@@ -173,7 +173,7 @@
       "id": "sec-algebraic-bounded",
       "title": "§2. Algebraic Numbers of Bounded Degree",
       "startLine": 103,
-      "endLine": 135,
+      "endLine": 136,
       "description": "Defines `algebraicRealsOfBoundedDegree d` = {x : ℝ | IsAlgebraic ℚ x ∧ (minpoly ℚ x).natDegree ≤ d} and `algebraicComplexOfBoundedDegree d` (analogous for ℂ). Both are noncomputable (because minpoly is noncomputable). Proves `bounded_degree_subset_algebraic_reals`: the bounded-degree set ⊆ all algebraic numbers (fun _ hx => hx.1 extracts the IsAlgebraic component from the conjunction). Proves countability of both sets via Set.Countable.mono — subsets of countable sets are countable.",
       "summary": "Lines 103–135 (§ 2) introduce two `noncomputable def` constructions parametrized by a bound $d : \\mathbb{N}$: `algebraicRealsOfBoundedDegree d := {x : ℝ | IsAlgebraic ℚ x ∧ (minpoly ℚ x).natDegree ≤ d}` and the …"
     },
@@ -181,7 +181,7 @@
       "id": "sec-algebraic-exact",
       "title": "§3. Algebraic Numbers of Exact Degree",
       "startLine": 137,
-      "endLine": 165,
+      "endLine": 166,
       "description": "Defines `algebraicRealsOfDegree d` = {x : ℝ | IsAlgebraic ℚ x ∧ (minpoly ℚ x).natDegree = d} and `algebraicComplexOfDegree d`. Proves `exact_degree_subset_bounded`: exact-degree d ⊆ bounded-degree d (le_of_eq converts equality to ≤). Proves `algebraicRealsOfDegree_countable`: via two-step subset chain exact → bounded → all algebraic. For complex: uses apply Set.Countable.mono with explicit lambda to convert the exact-degree condition to bounded-degree. This establishes that each horizontal slice of the degree stratification is individually countable.",
       "summary": "Lines 137–165 (§ 3) define the strict-equality analog of § 2: `algebraicRealsOfDegree d := {x : ℝ | IsAlgebraic ℚ x ∧ (minpoly ℚ x).natDegree = d}` and its complex counterpart."
     },
@@ -189,7 +189,7 @@
       "id": "sec-algebraic-stratification",
       "title": "§4. Degree Stratification and Alternative Countability Proof",
       "startLine": 167,
-      "endLine": 201,
+      "endLine": 202,
       "description": "Proves `algebraic_reals_eq_iUnion_degree`: {x : ℝ | IsAlgebraic ℚ x} = ⋃ d : ℕ, algebraicRealsOfDegree d. Proof by ext x, simp, constructor: (→) given IsAlgebraic x, use d = natDegree(minpoly ℚ x) and rfl; (←) extract IsAlgebraic from the existential. Analogous for complex numbers. `algebraic_reals_countable_via_strata`: alternative proof by rewriting via the union and applying Set.countable_iUnion algebraicRealsOfDegree_countable (countable union of countable sets). This demonstrates the stratification is not just a structural description but a valid proof technique.",
       "summary": "Lines 167–201 (§ 4) state and prove the **degree stratification theorem**: the algebraic reals decompose as a countable disjoint union of countable strata, `{x : ℝ | IsAlgebraic ℚ x} = ⋃ d : ℕ, algebraicRealsOfDegree …"
     },
@@ -197,7 +197,7 @@
       "id": "sec-algebraic-degree1",
       "title": "§5. Degree 1 = Rationals and Monotone Filtration",
       "startLine": 203,
-      "endLine": 217,
+      "endLine": 218,
       "description": "Two theorems: `rat_algebraic_degree_one`: every q ∈ ℚ is algebraic (isAlgebraic_algebraMap q — elements mapped from the base field are algebraic, with minimal polynomial X − q of degree 1). `bounded_degree_monotone`: algebraicRealsOfBoundedDegree d ⊆ algebraicRealsOfBoundedDegree (d+1), proved by Nat.le_succ_of_le on the degree bound. These establish the filtration structure: ℚ ⊆ deg≤1 ⊆ deg≤2 ⊆ ... ⊆ all algebraic, each inclusion strict (e.g., √2 ∈ deg≤2 but √2 ∉ ℚ).",
       "summary": "Lines 203–217 (§ 5) anchor the **degree-1 stratum** as exactly the rationals and prove the bounded-degree filtration is monotone."
     },
@@ -205,7 +205,7 @@
       "id": "sec-algebraic-cardinality",
       "title": "§6. Cardinality Comparisons",
       "startLine": 219,
-      "endLine": 235,
+      "endLine": 236,
       "description": "`card_algebraic_eq_card_rat` proves |{x : ℝ // IsAlgebraic ℚ x}| = |ℚ| by rewriting both sides through aleph0 (card_algebraic_reals_eq_aleph0 on the left, Cardinal.mk_denumerable on the right). `card_algebraic_eq_card_nat` proves the same equals |ℕ|. Together these illustrate Dedekind's 'paradox' that a proper superset can have the same cardinality as its subset: ℚ ⊊ {algebraic reals} yet |ℚ| = |{algebraic reals}| = ℵ₀. The two-line proofs (each a single rewrite chain) make the cardinality identity look elementary, but they package the deep result that minpoly-based stratification yields the same count as the standard enumeration of ℚ ≅ ℕ.",
       "summary": "Lines 219–235 (§ 6) state two **cardinality coincidences** that illustrate the paradoxical nature of infinite cardinalities: `card_algebraic_eq_card_rat : Cardinal.mk {x : ℝ // IsAlgebraic ℚ x} = Cardinal.mk ℚ` and …"
     },


### PR DESCRIPTION
Enrichment pass for `algebraic-numbers-countable` (quality 100, pass 0).

**Change:** the eight sections left gaps — the header stopped at the `namespace` line, leaving the `open Polynomial Cardinal` setup (lines 69–71) uncovered, and each `§`-banner introduced a one-line blank gap between sections. Snapping each section's `endLine` to the line before the next makes the sections tile lines **1–254 with no gaps**.

Section titles/summaries already align to the file's own `§1–§7` banners, one theme each. This is a pure contiguity fix — no field content added or removed (the entry is already comprehensive, with `crossReferences` at the 20-item cap). meta.json 44.5 KB (under 60 KB cap).