### PR TITLE
research(de-moivre-oq-06-oq-02): uniform Dirichlet-kernel bounds away from singularities

### DIFF
--- a/proofs/Proofs/DeMoivreOQ06.lean
+++ b/proofs/Proofs/DeMoivreOQ06.lean
@@ -153,7 +153,7 @@ theorem dirichlet_kernel_bound (θ : ℝ) (hθ : Real.sin (θ / 2) ≠ 0) (n : �
       = Real.sin (((n : ℝ) + 1 / 2) * θ) / (2 * Real.sin (θ / 2)) := by ring
   rw [hrw, abs_div, abs_mul, abs_two]
   have hden : (0 : ℝ) < 2 * |Real.sin (θ / 2)| := mul_pos two_pos (abs_pos.mpr hθ)
-  rw [div_le_div_iff hden hden]
+  rw [div_le_div_iff₀ hden hden]
   have hnum : |Real.sin (((n : ℝ) + 1 / 2) * θ)| ≤ 1 :=
     abs_le.mpr ⟨Real.neg_one_le_sin _, Real.sin_le_one _⟩
   nlinarith [mul_le_mul_of_nonneg_right hnum (le_of_lt hden)]
@@ -167,15 +167,13 @@ theorem dirichlet_conjugate_bound (θ : ℝ) (hθ : Real.sin (θ / 2) ≠ 0) (n 
       ≤ 1 / |Real.sin (θ / 2)| := by
   have hA : (0 : ℝ) < |Real.sin (θ / 2)| := abs_pos.mpr hθ
   rw [lagrange_sin_sum θ hθ n, abs_div, abs_mul, abs_two]
-  rw [div_le_div_iff (mul_pos two_pos hA) hA]
-  have hnum : |Real.cos (θ / 2) - Real.cos (((n : ℝ) + 1 / 2) * θ)| ≤ 2 :=
-    abs_le.mpr ⟨by
-      have := Real.cos_le_one (θ / 2)
-      have := Real.neg_one_le_cos (((n : ℝ) + 1 / 2) * θ)
-      linarith, by
-      have := Real.neg_one_le_cos (θ / 2)
-      have := Real.cos_le_one (((n : ℝ) + 1 / 2) * θ)
-      linarith⟩
+  rw [div_le_div_iff₀ (mul_pos two_pos hA) hA]
+  have hnum : |Real.cos (θ / 2) - Real.cos (((n : ℝ) + 1 / 2) * θ)| ≤ 2 := by
+    have a1 := Real.neg_one_le_cos (θ / 2)
+    have a2 := Real.cos_le_one (θ / 2)
+    have a3 := Real.neg_one_le_cos (((n : ℝ) + 1 / 2) * θ)
+    have a4 := Real.cos_le_one (((n : ℝ) + 1 / 2) * θ)
+    rw [abs_le]; constructor <;> linarith
   nlinarith [mul_le_mul_of_nonneg_right hnum (le_of_lt hA)]
 
 end DeMoivreOQ06

--- a/proofs/Proofs/DeMoivreOQ06OQ02.lean
+++ b/proofs/Proofs/DeMoivreOQ06OQ02.lean
@@ -1,0 +1,135 @@
+/-
+Uniform Dirichlet-kernel bounds away from the singularities
+
+Source: Open question from the de-moivre gallery family (de-moivre-oq-06-oq-02)
+Status: VERIFIED (0 axioms, 0 sorries)
+
+The parent file `DeMoivreOQ06` establishes the *pointwise* Dirichlet-kernel
+estimates
+
+      |∑_{k=0}^{n} cos(kθ) − 1/2| ≤ 1/(2|sin(θ/2)|)          (`dirichlet_kernel_bound`)
+      |∑_{k=0}^{n} sin(kθ)|       ≤ 1/|sin(θ/2)|             (`dirichlet_conjugate_bound`)
+
+valid for each fixed `θ` with `sin(θ/2) ≠ 0`.  These bounds blow up as `θ → 0`
+(mod `2π`).  The *classical* form used in Fourier analysis — the one that powers
+Dirichlet's test for the uniform convergence of Fourier series — is the estimate
+made **uniform in both `n` and `θ`** on a compact interval bounded away from the
+singularities `θ ∈ 2πℤ`.
+
+This file supplies that uniform estimate.  The geometric heart is the elementary
+monotonicity fact that, on the arc `θ ∈ [δ, 2π − δ]` (with `0 < δ ≤ π`), the
+half-angle sine is bounded below by its endpoint value:
+
+      sin(θ/2) ≥ sin(δ/2) > 0.
+
+Feeding this into the pointwise bounds removes the `θ`-dependence and yields a
+single constant `C = 1/sin(δ/2)` controlling *all* partial sums simultaneously.
+
+## Main results
+
+* `sin_half_ge_of_mem_arc` — the endpoint lower bound `sin(δ/2) ≤ sin(θ/2)`.
+* `dirichlet_kernel_uniform_bound` — cosine partial sums bounded by `1/(2 sin(δ/2))`,
+  uniformly in `n` and in `θ ∈ [δ, 2π − δ]`.
+* `dirichlet_conjugate_uniform_bound` — sine partial sums bounded by `1/sin(δ/2)`.
+* `dirichlet_partial_sums_uniformly_bounded` — the packaged `∃ C, ∀ n θ` statement:
+  a single constant simultaneously bounds every cosine and sine partial sum on the arc.
+-/
+
+import Proofs.DeMoivreOQ06
+import Mathlib.Tactic
+
+open Finset
+
+namespace DeMoivreOQ06OQ02
+
+/-- **Half-angle sine is bounded below by its endpoint value on the arc.**
+For `0 < δ ≤ π` and `θ ∈ [δ, 2π − δ]` we have `sin(δ/2) ≤ sin(θ/2)`.
+
+The half-angle `θ/2` ranges over `[δ/2, π − δ/2]`, on which `sin` attains its
+minimum `sin(δ/2)` at both endpoints.  The proof clears the difference through
+the product identity `sin x − sin y = 2 sin((x−y)/2) cos((x+y)/2)`; both factors
+are nonnegative because their arguments lie in `[0, π/2]`. -/
+theorem sin_half_ge_of_mem_arc (δ θ : ℝ) (hδ0 : 0 < δ) (hδπ : δ ≤ Real.pi)
+    (hθ1 : δ ≤ θ) (hθ2 : θ ≤ 2 * Real.pi - δ) :
+    Real.sin (δ / 2) ≤ Real.sin (θ / 2) := by
+  have hpi := Real.pi_pos
+  -- Difference of sines as a product.
+  have hkey : Real.sin (θ / 2) - Real.sin (δ / 2)
+      = 2 * Real.sin ((θ / 2 - δ / 2) / 2) * Real.cos ((θ / 2 + δ / 2) / 2) :=
+    Real.sin_sub_sin (θ / 2) (δ / 2)
+  -- First factor: sin of an argument in [0, π/2] ⊆ [0, π].
+  have hsin : 0 ≤ Real.sin ((θ / 2 - δ / 2) / 2) := by
+    apply Real.sin_nonneg_of_nonneg_of_le_pi <;> [linarith; nlinarith]
+  -- Second factor: cos of an argument in [-π/2, π/2].
+  have hcos : 0 ≤ Real.cos ((θ / 2 + δ / 2) / 2) := by
+    apply Real.cos_nonneg_of_neg_pi_div_two_le_of_le <;> nlinarith
+  nlinarith [hkey, hsin, hcos, mul_nonneg hsin hcos]
+
+/-- `sin(δ/2) > 0` for `0 < δ ≤ π`, recorded once for reuse. -/
+private theorem sin_half_pos (δ : ℝ) (hδ0 : 0 < δ) (hδπ : δ ≤ Real.pi) :
+    0 < Real.sin (δ / 2) := by
+  have hpi := Real.pi_pos
+  exact Real.sin_pos_of_pos_of_lt_pi (by linarith) (by linarith)
+
+/-- **Uniform Dirichlet-kernel bound (cosine form).**
+On the arc `θ ∈ [δ, 2π − δ]` the cosine partial sums are bounded by the single
+constant `1/(2 sin(δ/2))`, uniformly in `n` and `θ`.  This is the estimate that
+makes Dirichlet's kernel a *uniformly bounded* approximate identity away from the
+origin. -/
+theorem dirichlet_kernel_uniform_bound (δ θ : ℝ) (hδ0 : 0 < δ) (hδπ : δ ≤ Real.pi)
+    (hθ1 : δ ≤ θ) (hθ2 : θ ≤ 2 * Real.pi - δ) (n : ℕ) :
+    |(∑ k ∈ Finset.range (n + 1), Real.cos ((k : ℝ) * θ)) - 1 / 2|
+      ≤ 1 / (2 * Real.sin (δ / 2)) := by
+  have hδpos : 0 < Real.sin (δ / 2) := sin_half_pos δ hδ0 hδπ
+  have hθge : Real.sin (δ / 2) ≤ Real.sin (θ / 2) := sin_half_ge_of_mem_arc δ θ hδ0 hδπ hθ1 hθ2
+  have hθpos : 0 < Real.sin (θ / 2) := lt_of_lt_of_le hδpos hθge
+  -- Pointwise bound from the parent file.
+  have hbound := DeMoivreOQ06.dirichlet_kernel_bound θ (ne_of_gt hθpos) n
+  -- The pointwise denominator dominates the uniform one.
+  have habs : |Real.sin (θ / 2)| = Real.sin (θ / 2) := abs_of_pos hθpos
+  rw [habs] at hbound
+  have hmono : 1 / (2 * Real.sin (θ / 2)) ≤ 1 / (2 * Real.sin (δ / 2)) := by
+    apply one_div_le_one_div_of_le
+    · positivity
+    · linarith
+  exact le_trans hbound hmono
+
+/-- **Uniform conjugate Dirichlet-kernel bound (sine form).**
+On the arc `θ ∈ [δ, 2π − δ]` the sine partial sums are bounded by `1/sin(δ/2)`,
+uniformly in `n` and `θ`. -/
+theorem dirichlet_conjugate_uniform_bound (δ θ : ℝ) (hδ0 : 0 < δ) (hδπ : δ ≤ Real.pi)
+    (hθ1 : δ ≤ θ) (hθ2 : θ ≤ 2 * Real.pi - δ) (n : ℕ) :
+    |∑ k ∈ Finset.range (n + 1), Real.sin ((k : ℝ) * θ)|
+      ≤ 1 / Real.sin (δ / 2) := by
+  have hδpos : 0 < Real.sin (δ / 2) := sin_half_pos δ hδ0 hδπ
+  have hθge : Real.sin (δ / 2) ≤ Real.sin (θ / 2) := sin_half_ge_of_mem_arc δ θ hδ0 hδπ hθ1 hθ2
+  have hθpos : 0 < Real.sin (θ / 2) := lt_of_lt_of_le hδpos hθge
+  have hbound := DeMoivreOQ06.dirichlet_conjugate_bound θ (ne_of_gt hθpos) n
+  have habs : |Real.sin (θ / 2)| = Real.sin (θ / 2) := abs_of_pos hθpos
+  rw [habs] at hbound
+  have hmono : 1 / Real.sin (θ / 2) ≤ 1 / Real.sin (δ / 2) :=
+    one_div_le_one_div_of_le hδpos hθge
+  exact le_trans hbound hmono
+
+/-- **Packaged uniform boundedness of Dirichlet partial sums.**
+There is a *single* positive constant `C` (depending only on `δ`) that
+simultaneously bounds every cosine partial sum (centred at `1/2`) and every sine
+partial sum, for all `n` and all `θ ∈ [δ, 2π − δ]`.  This is the quantitative
+input to Dirichlet's convergence test.  We take `C = 1/sin(δ/2)`, which dominates
+the cosine constant `1/(2 sin(δ/2))`. -/
+theorem dirichlet_partial_sums_uniformly_bounded (δ : ℝ) (hδ0 : 0 < δ) (hδπ : δ ≤ Real.pi) :
+    ∃ C : ℝ, 0 < C ∧ ∀ (n : ℕ) (θ : ℝ), δ ≤ θ → θ ≤ 2 * Real.pi - δ →
+      |(∑ k ∈ Finset.range (n + 1), Real.cos ((k : ℝ) * θ)) - 1 / 2| ≤ C ∧
+      |∑ k ∈ Finset.range (n + 1), Real.sin ((k : ℝ) * θ)| ≤ C := by
+  have hδpos : 0 < Real.sin (δ / 2) := sin_half_pos δ hδ0 hδπ
+  refine ⟨1 / Real.sin (δ / 2), by positivity, ?_⟩
+  intro n θ hθ1 hθ2
+  constructor
+  · -- cosine bound: 1/(2 sin) ≤ 1/sin
+    have hcos := dirichlet_kernel_uniform_bound δ θ hδ0 hδπ hθ1 hθ2 n
+    have hle : 1 / (2 * Real.sin (δ / 2)) ≤ 1 / Real.sin (δ / 2) :=
+      one_div_le_one_div_of_le hδpos (by linarith)
+    exact le_trans hcos hle
+  · exact dirichlet_conjugate_uniform_bound δ θ hδ0 hδπ hθ1 hθ2 n
+
+end DeMoivreOQ06OQ02

--- a/src/data/proofs/de-moivre-oq-06-oq-02/annotations.json
+++ b/src/data/proofs/de-moivre-oq-06-oq-02/annotations.json
@@ -1,0 +1,90 @@
+[
+  {
+    "id": "ann-dm0602-docstring",
+    "proofId": "de-moivre-oq-06-oq-02",
+    "range": {
+      "startLine": 1,
+      "endLine": 50
+    },
+    "type": "concept",
+    "title": "From Pointwise to Uniform Dirichlet-Kernel Bounds",
+    "content": "The docstring frames the upgrade. The parent (de-moivre-oq-06) proves the *pointwise* estimates $|\\sum_{k\\le n}\\cos(k\\theta)-\\tfrac12|\\le\\frac{1}{2|\\sin(\\theta/2)|}$ and $|\\sum_{k\\le n}\\sin(k\\theta)|\\le\\frac{1}{|\\sin(\\theta/2)|}$, which blow up as $\\theta\\to0\\pmod{2\\pi}$. The form used in harmonic analysis is uniform in both $n$ and $\\theta$ on a compact arc $\\theta\\in[\\delta,2\\pi-\\delta]$ excising a $\\delta$-neighbourhood of the singularities $\\theta\\in2\\pi\\mathbb{Z}$. The single geometric input is the endpoint lower bound $\\sin(\\theta/2)\\ge\\sin(\\delta/2)$.",
+    "mathContext": "Excising $[- \\delta,\\delta]\\pmod{2\\pi}$ replaces the $\\theta$-dependent denominator $\\sin(\\theta/2)$ by the uniform $\\sin(\\delta/2)>0$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Dirichlet kernel",
+      "uniform boundedness",
+      "Fourier series convergence",
+      "Dirichlet's test"
+    ],
+    "prerequisites": [
+      "pointwise Dirichlet kernel bounds",
+      "compactness away from singularities"
+    ]
+  },
+  {
+    "id": "ann-dm0602-endpoint",
+    "proofId": "de-moivre-oq-06-oq-02",
+    "range": {
+      "startLine": 52,
+      "endLine": 76
+    },
+    "type": "technique",
+    "title": "The Half-Angle Sine Attains its Minimum at the Endpoints",
+    "content": "`sin_half_ge_of_mem_arc` proves $\\sin(\\delta/2)\\le\\sin(\\theta/2)$ for $\\theta\\in[\\delta,2\\pi-\\delta]$, $0<\\delta\\le\\pi$. The half-angle $\\theta/2$ ranges over $[\\delta/2,\\pi-\\delta/2]$, on which $\\sin$ — concave on $[0,\\pi]$ with equal endpoint values $\\sin(\\delta/2)$ — is minimised at the boundary. Rather than a concavity argument, the difference is cleared through the product identity $\\sin x-\\sin y=2\\sin(\\tfrac{x-y}{2})\\cos(\\tfrac{x+y}{2})$ with $x=\\theta/2,\\ y=\\delta/2$: the factor $\\sin(\\tfrac{\\theta-\\delta}{4})\\ge0$ because its argument lies in $[0,\\pi/2]\\subseteq[0,\\pi]$, and $\\cos(\\tfrac{\\theta+\\delta}{4})\\ge0$ because its argument lies in $[0,\\pi/2]\\subseteq[-\\pi/2,\\pi/2]$. Both factors nonnegative gives the difference nonnegative.",
+    "mathContext": "$\\sin(\\theta/2)-\\sin(\\delta/2)=2\\sin(\\tfrac{\\theta-\\delta}{4})\\cos(\\tfrac{\\theta+\\delta}{4})\\ge0$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "product-to-sum identity",
+      "monotonicity of sine",
+      "sign analysis by argument range"
+    ],
+    "prerequisites": [
+      "Real.sin_sub_sin",
+      "sin/cos sign lemmas"
+    ]
+  },
+  {
+    "id": "ann-dm0602-uniform-bounds",
+    "proofId": "de-moivre-oq-06-oq-02",
+    "range": {
+      "startLine": 78,
+      "endLine": 118
+    },
+    "type": "technique",
+    "title": "Removing the θ-Dependence by Reciprocal Monotonicity",
+    "content": "`dirichlet_kernel_uniform_bound` and `dirichlet_conjugate_uniform_bound` apply the parent's pointwise bounds and then dominate the $\\theta$-dependent denominator. Since $\\sin(\\theta/2)\\ge\\sin(\\delta/2)>0$ we have $|\\sin(\\theta/2)|=\\sin(\\theta/2)$, and reciprocal monotonicity (`one_div_le_one_div_of_le`) gives $\\frac{1}{2\\sin(\\theta/2)}\\le\\frac{1}{2\\sin(\\delta/2)}$ (resp. $\\frac{1}{\\sin(\\theta/2)}\\le\\frac{1}{\\sin(\\delta/2)}$). Chaining with the pointwise bound yields the uniform constant. The bound is independent of both $n$ and $\\theta$.",
+    "mathContext": "$|\\sum_{k\\le n}\\cos(k\\theta)-\\tfrac12|\\le\\frac{1}{2\\sin(\\delta/2)}$ and $|\\sum_{k\\le n}\\sin(k\\theta)|\\le\\frac{1}{\\sin(\\delta/2)}$ for all $n$ and all $\\theta\\in[\\delta,2\\pi-\\delta]$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "reciprocal monotonicity",
+      "uniform bound",
+      "Dirichlet kernel"
+    ],
+    "prerequisites": [
+      "parent pointwise bounds",
+      "one_div_le_one_div_of_le"
+    ]
+  },
+  {
+    "id": "ann-dm0602-packaged",
+    "proofId": "de-moivre-oq-06-oq-02",
+    "range": {
+      "startLine": 120,
+      "endLine": 135
+    },
+    "type": "concept",
+    "title": "A Single Constant for Dirichlet's Test",
+    "content": "`dirichlet_partial_sums_uniformly_bounded` packages the two estimates into one $\\exists C>0,\\ \\forall n\\,\\theta$ statement: taking $C=1/\\sin(\\delta/2)$ — which dominates the cosine constant $1/(2\\sin(\\delta/2))$ — a single constant simultaneously bounds every cosine partial sum (centred at $\\tfrac12$) and every sine partial sum on the arc. This $\\exists C,\\forall n\\,\\theta$ shape is precisely the uniform-boundedness hypothesis that, combined with Abel summation, powers Dirichlet's test for the convergence of Fourier and trigonometric series.",
+    "mathContext": "$\\exists C>0,\\ \\forall n\\,\\forall\\theta\\in[\\delta,2\\pi-\\delta],\\ |\\sum\\cos-\\tfrac12|\\le C\\ \\wedge\\ |\\sum\\sin|\\le C$, with $C=1/\\sin(\\delta/2)$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Dirichlet's test",
+      "Abel summation",
+      "uniform convergence of Fourier series"
+    ],
+    "prerequisites": [
+      "uniform Dirichlet bounds"
+    ]
+  }
+]

--- a/src/data/proofs/de-moivre-oq-06-oq-02/meta.json
+++ b/src/data/proofs/de-moivre-oq-06-oq-02/meta.json
@@ -1,0 +1,176 @@
+{
+  "id": "de-moivre-oq-06-oq-02",
+  "title": "De Moivre OQ-06-OQ-02: Uniform Dirichlet-Kernel Bounds Away from the Singularities",
+  "slug": "de-moivre-oq-06-oq-02",
+  "description": "Lifts the pointwise Dirichlet-kernel estimates of the parent (de-moivre-oq-06) to a bound uniform in both n and θ on a compact arc θ ∈ [δ, 2π−δ] bounded away from the singularities θ ∈ 2πℤ. The geometric heart is the endpoint lower bound sin(θ/2) ≥ sin(δ/2), obtained from the product identity sin x − sin y = 2 sin((x−y)/2) cos((x+y)/2); feeding it into the pointwise bounds removes the θ-dependence and yields a single constant C = 1/sin(δ/2) controlling every cosine and sine partial sum simultaneously — the quantitative input to Dirichlet's convergence test.",
+  "meta": {
+    "author": "Formalized in Lean 4 (Mathlib)",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/DeMoivreOQ06OQ02.lean",
+    "tags": [
+      "complex-analysis",
+      "trigonometry",
+      "dirichlet-kernel",
+      "fourier-analysis",
+      "uniform-bound",
+      "de-moivre"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Real.sin_sub_sin",
+        "description": "sin x − sin y = 2 sin((x−y)/2) cos((x+y)/2), the product identity that clears the difference sin(θ/2) − sin(δ/2) into a product of two nonnegative factors",
+        "module": "Mathlib.Analysis.Complex.Trigonometric"
+      },
+      {
+        "theorem": "Real.sin_nonneg_of_nonneg_of_le_pi",
+        "description": "0 ≤ x ≤ π ⇒ 0 ≤ sin x, giving nonnegativity of the first product factor sin((θ−δ)/4)",
+        "module": "Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic"
+      },
+      {
+        "theorem": "Real.cos_nonneg_of_neg_pi_div_two_le_of_le",
+        "description": "−π/2 ≤ x ≤ π/2 ⇒ 0 ≤ cos x, giving nonnegativity of the second product factor cos((θ+δ)/4)",
+        "module": "Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic"
+      },
+      {
+        "theorem": "Real.sin_pos_of_pos_of_lt_pi",
+        "description": "0 < x < π ⇒ 0 < sin x, giving strict positivity of the uniform denominator sin(δ/2)",
+        "module": "Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic"
+      },
+      {
+        "theorem": "one_div_le_one_div_of_le",
+        "description": "0 < a, a ≤ b ⇒ 1/b ≤ 1/a, the monotonicity that replaces the θ-dependent denominator sin(θ/2) by the uniform sin(δ/2)",
+        "module": "Mathlib.Algebra.Order.Field.Basic"
+      }
+    ],
+    "originalContributions": [
+      "sin_half_ge_of_mem_arc: on the arc θ ∈ [δ, 2π−δ] with 0 < δ ≤ π, the half-angle sine satisfies sin(δ/2) ≤ sin(θ/2) — the endpoint minimum of sin over [δ/2, π−δ/2], proved by the product identity with both factors forced nonnegative by argument range",
+      "dirichlet_kernel_uniform_bound: |∑_{k=0}^{n} cos(kθ) − 1/2| ≤ 1/(2 sin(δ/2)) uniformly in n and in θ ∈ [δ, 2π−δ], upgrading the parent's pointwise 1/(2|sin(θ/2)|) to a θ-free constant",
+      "dirichlet_conjugate_uniform_bound: |∑_{k=0}^{n} sin(kθ)| ≤ 1/sin(δ/2) uniformly in n and θ on the arc",
+      "dirichlet_partial_sums_uniformly_bounded: the packaged ∃ C > 0, ∀ n θ statement — a single constant C = 1/sin(δ/2) simultaneously bounds every cosine partial sum (centred at 1/2) and every sine partial sum on the arc, the exact uniform-boundedness hypothesis behind Dirichlet's test"
+    ],
+    "dateAdded": "2026-07-11",
+    "mathlib_version": "4.26.0",
+    "axiomCount": 0,
+    "lineCount": 135,
+    "assumptions": "0 axioms, 0 sorries. Builds on the parent de-moivre-oq-06 (dirichlet_kernel_bound, dirichlet_conjugate_bound). The uniform estimates require 0 < δ ≤ π (so the arc [δ, 2π−δ] is nonempty and sin(δ/2) > 0) and θ ∈ [δ, 2π−δ]; Mathlib supplies the product identity, the sin/cos sign lemmas, and reciprocal monotonicity.",
+    "theoremCount": 5,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "The Dirichlet kernel $D_n(\\theta)$ governs the convergence of Fourier series. The parent formalization (de-moivre-oq-06) records the pointwise bounds $|\\sum_{k\\le n}\\cos(k\\theta)-\\tfrac12|\\le\\frac{1}{2|\\sin(\\theta/2)|}$ and $|\\sum_{k\\le n}\\sin(k\\theta)|\\le\\frac{1}{|\\sin(\\theta/2)|}$, which blow up as $\\theta\\to 0\\ (\\mathrm{mod}\\ 2\\pi)$. The form actually used in analysis — the one that powers Dirichlet's test for the uniform convergence of Fourier series — is the estimate made uniform in both $n$ and $\\theta$ on a compact interval bounded away from the singularities $\\theta\\in 2\\pi\\mathbb{Z}$. This is the classical 'uniformly bounded away from the origin' property of the Dirichlet kernel.",
+    "problemStatement": "**Open Question (de-moivre-oq-06-oq-02)**: Bound the Dirichlet kernel uniformly and derive the classical consequence. \n\n**Result**: On the arc $\\theta\\in[\\delta,2\\pi-\\delta]$ with $0<\\delta\\le\\pi$, both the cosine partial sums (centred at $\\tfrac12$) and the sine partial sums are bounded by the single constant $C=1/\\sin(\\delta/2)$, uniformly in $n$ and $\\theta$: $|\\sum_{k\\le n}\\cos(k\\theta)-\\tfrac12|\\le\\frac{1}{2\\sin(\\delta/2)}$ and $|\\sum_{k\\le n}\\sin(k\\theta)|\\le\\frac{1}{\\sin(\\delta/2)}$.",
+    "text": "Uniform (n- and θ-independent) Dirichlet-kernel bounds on a compact arc away from the singularities, obtained from the endpoint lower bound sin(θ/2) ≥ sin(δ/2) for the half-angle sine.",
+    "proofStrategy": "The single geometric input is that $\\sin$ attains its minimum $\\sin(\\delta/2)$ over the half-angle range $[\\delta/2,\\pi-\\delta/2]$ at both endpoints. This is proved by clearing $\\sin(\\theta/2)-\\sin(\\delta/2)$ through the product-to-sum identity $\\sin x-\\sin y=2\\sin(\\tfrac{x-y}{2})\\cos(\\tfrac{x+y}{2})$: with $x=\\theta/2,\\ y=\\delta/2$ the factor $\\sin(\\tfrac{\\theta-\\delta}{4})\\ge0$ (argument in $[0,\\pi/2]$) and $\\cos(\\tfrac{\\theta+\\delta}{4})\\ge0$ (argument in $[0,\\pi/2]$), so the difference is nonnegative. Since $|\\sin(\\theta/2)|=\\sin(\\theta/2)\\ge\\sin(\\delta/2)>0$, reciprocal monotonicity replaces the $\\theta$-dependent denominator in the parent's pointwise bounds by the uniform constant. The packaged existential takes $C=1/\\sin(\\delta/2)$, which dominates the cosine constant $1/(2\\sin(\\delta/2))$.",
+    "keyInsights": [
+      "The blow-up of the pointwise Dirichlet bound at θ ∈ 2πℤ is the only obstruction to uniformity; excising a δ-neighbourhood of the singularities makes the bound uniform with an explicit δ-dependent constant",
+      "sin(θ/2) ≥ sin(δ/2) on the arc is an endpoint-minimum fact: sin is concave on [0, π] with equal values sin(δ/2) at the two endpoints δ/2 and π−δ/2 of the half-angle range, so the minimum sits at the boundary",
+      "The product identity sin x − sin y = 2 sin((x−y)/2) cos((x+y)/2) turns the monotonicity claim into a sign check on two factors, each pinned nonnegative purely by its argument lying in [0, π/2]",
+      "A single constant C = 1/sin(δ/2) governs both the cosine and sine families at once — the ∃ C, ∀ n θ shape is exactly the uniform-boundedness hypothesis of Dirichlet's test for the convergence of Fourier series"
+    ],
+    "prerequisites": [
+      "Parent formalization de-moivre-oq-06 (pointwise Dirichlet kernel bounds)",
+      "Product-to-sum trigonometric identities",
+      "Monotonicity of sin on [0, π/2] and its reflection symmetry about π/2",
+      "Reciprocal monotonicity of x ↦ 1/x on the positive reals"
+    ]
+  },
+  "sections": [
+    {
+      "id": "preamble",
+      "title": "Preamble and Problem Statement",
+      "summary": "Module docstring: the pointwise-to-uniform upgrade, the singularities θ ∈ 2πℤ, and the four results",
+      "startLine": 1,
+      "endLine": 50,
+      "mathContext": "**Goal**: make the Dirichlet-kernel partial-sum bounds uniform in n and θ on θ ∈ [δ, 2π−δ]."
+    },
+    {
+      "id": "endpoint-lower-bound",
+      "title": "Part I: Endpoint Lower Bound for the Half-Angle Sine",
+      "summary": "sin_half_ge_of_mem_arc: sin(δ/2) ≤ sin(θ/2) on θ ∈ [δ, 2π−δ], via sin x − sin y = 2 sin((x−y)/2) cos((x+y)/2) with both factors nonnegative",
+      "startLine": 52,
+      "endLine": 76,
+      "mathContext": "$\\sin(\\theta/2)-\\sin(\\delta/2)=2\\sin(\\tfrac{\\theta-\\delta}{4})\\cos(\\tfrac{\\theta+\\delta}{4})\\ge0$."
+    },
+    {
+      "id": "uniform-bounds",
+      "title": "Part II: Uniform Dirichlet-Kernel Bounds",
+      "summary": "dirichlet_kernel_uniform_bound and dirichlet_conjugate_uniform_bound: the cosine and sine partial sums bounded by 1/(2 sin(δ/2)) and 1/sin(δ/2) uniformly in n and θ, from the parent's pointwise bounds plus reciprocal monotonicity",
+      "startLine": 78,
+      "endLine": 118,
+      "mathContext": "$|\\sin(\\theta/2)|=\\sin(\\theta/2)\\ge\\sin(\\delta/2)>0\\Rightarrow \\tfrac{1}{2\\sin(\\theta/2)}\\le\\tfrac{1}{2\\sin(\\delta/2)}$."
+    },
+    {
+      "id": "packaged-uniform-boundedness",
+      "title": "Part III: Packaged Uniform Boundedness",
+      "summary": "dirichlet_partial_sums_uniformly_bounded: ∃ C > 0, ∀ n θ on the arc, both partial-sum families are bounded by C = 1/sin(δ/2) — the uniform-boundedness input to Dirichlet's test",
+      "startLine": 120,
+      "endLine": 135,
+      "mathContext": "One constant $C=1/\\sin(\\delta/2)$ dominates both $1/(2\\sin(\\delta/2))$ and $1/\\sin(\\delta/2)$."
+    }
+  ],
+  "conclusion": {
+    "summary": "This formalization upgrades the parent's pointwise Dirichlet-kernel estimates to bounds uniform in both n and θ on a compact arc [δ, 2π−δ] away from the singularities θ ∈ 2πℤ. The geometric core is the endpoint lower bound sin(θ/2) ≥ sin(δ/2), proved by the product-to-sum identity with both factors forced nonnegative. All four theorems are fully proved with zero sorries and zero axioms.",
+    "implications": "The packaged ∃ C, ∀ n θ statement is exactly the uniform-boundedness hypothesis that, combined with Abel summation, yields Dirichlet's test for the convergence of Fourier series and of trigonometric series ∑ a_k cos(kθ), ∑ a_k sin(kθ) with a_k monotone tending to 0. The explicit constant 1/sin(δ/2) makes the dependence on the excised neighbourhood quantitative.",
+    "openQuestions": [
+      "Derive Dirichlet's test itself: for a_k antitone with a_k → 0, ∑ a_k sin(kθ) converges uniformly on [δ, 2π−δ], via Abel summation against the uniformly bounded conjugate partial sums",
+      "The L¹ growth ‖D_n‖₁ ∼ (4/π²) log n (the Lebesgue constants), the complementary non-uniform statement over the full period",
+      "The Fejér kernel as the Cesàro average of the Dirichlet kernels and its uniform nonnegative bound"
+    ]
+  },
+  "relatedProblems": [
+    {
+      "id": "de-moivre-oq-06",
+      "relationship": "Parent: supplies the pointwise Dirichlet-kernel bounds dirichlet_kernel_bound and dirichlet_conjugate_bound that this file makes uniform in θ"
+    },
+    {
+      "id": "de-moivre-oq-05",
+      "relationship": "Sibling in the De Moivre geometric-sum family (roots-of-unity vanishing sum)"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Proofs.DeMoivreOQ06",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Finset"
+    ],
+    "namespace": "DeMoivreOQ06OQ02",
+    "lineCount": 135,
+    "axiomCount": 0,
+    "theoremCount": 5,
+    "definitionCount": 0,
+    "path": "Proofs/DeMoivreOQ06OQ02.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "Peter Gustav Lejeune Dirichlet",
+      "title": "Sur la convergence des séries trigonométriques (the Dirichlet kernel and the convergence test)",
+      "year": "1829",
+      "venue": "Journal für die reine und angewandte Mathematik"
+    },
+    {
+      "authors": "Antoni Zygmund",
+      "title": "Trigonometric Series (uniform boundedness of the Dirichlet kernel away from the origin)",
+      "year": "2002",
+      "venue": "Cambridge University Press"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "de-moivre-oq-06",
+      "relationship": "extends",
+      "description": "Parent formalization; this file lifts its pointwise Dirichlet-kernel bounds to uniform-in-(n, θ) bounds on a compact arc away from the singularities."
+    },
+    {
+      "targetId": "de-moivre-oq-05",
+      "relationship": "sibling",
+      "description": "Companion in the De Moivre geometric-sum family."
+    }
+  ],
+  "sorries": 0
+}

--- a/src/data/proofs/de-moivre-oq-06/meta.json
+++ b/src/data/proofs/de-moivre-oq-06/meta.json
@@ -54,7 +54,7 @@
     "dateAdded": "2026-07-01",
     "mathlib_version": "4.26.0",
     "axiomCount": 0,
-    "lineCount": 181,
+    "lineCount": 179,
     "assumptions": "0 axioms, 0 sorries. Mathlib supplies the raw geometric series (geom_sum_eq), the exponential power law (Complex.exp_nat_mul), and the angle-addition formulas; the finite closed forms for ∑ e^{ikθ}, ∑ cos(kθ), ∑ sin(kθ) and the telescoping product-to-sum steps are supplied here. The real identities require sin(θ/2) ≠ 0 (θ not an integer multiple of 2π); the complex identity requires e^{iθ} ≠ 1.",
     "theoremCount": 9,
     "definitionCount": 0
@@ -154,7 +154,7 @@
       "Finset"
     ],
     "namespace": "DeMoivreOQ06",
-    "lineCount": 181,
+    "lineCount": 179,
     "axiomCount": 0,
     "theoremCount": 9,
     "definitionCount": 0,


### PR DESCRIPTION
## Summary

New verified file **`DeMoivreOQ06OQ02.lean`** (namespace `DeMoivreOQ06OQ02`, imports the parent `Proofs.DeMoivreOQ06`) — **0 sorries, 0 axioms**, GREEN docker-build (3059 jobs).

Answers the gallery follow-up **de-moivre-oq-06-oq-02** ("Bound the Dirichlet kernel and derive the classical consequence"). The parent proves the *pointwise* Dirichlet-kernel estimates, which blow up as `θ → 0 (mod 2π)`. This file lifts them to the form used in Fourier analysis: a bound **uniform in both `n` and `θ`** on a compact arc `θ ∈ [δ, 2π−δ]` that excises a δ-neighbourhood of the singularities `θ ∈ 2πℤ`.

### New theorems
- **`sin_half_ge_of_mem_arc`** — `sin(δ/2) ≤ sin(θ/2)` on `θ ∈ [δ, 2π−δ]`, `0 < δ ≤ π`. The half-angle sine's endpoint minimum, proved by clearing the difference through `sin x − sin y = 2 sin((x−y)/2) cos((x+y)/2)` with both factors forced nonnegative by argument range.
- **`dirichlet_kernel_uniform_bound`** — `|∑_{k≤n} cos(kθ) − 1/2| ≤ 1/(2 sin(δ/2))` uniformly in `n` and `θ`.
- **`dirichlet_conjugate_uniform_bound`** — `|∑_{k≤n} sin(kθ)| ≤ 1/sin(δ/2)` uniformly in `n` and `θ`.
- **`dirichlet_partial_sums_uniformly_bounded`** — packaged `∃ C > 0, ∀ n θ` on the arc (`C = 1/sin(δ/2)`): a single constant simultaneously bounds every cosine and sine partial sum — the uniform-boundedness input to **Dirichlet's convergence test**.

### Incidental parent repair (necessary for the build)
The parent `DeMoivreOQ06.lean` no longer compiled under the current pinned Mathlib (v4.26.0):
- `div_le_div_iff` → **`div_le_div_iff₀`** (renamed upstream, no deprecated alias — this also breaks ~95 other gallery files, tracked separately).
- `dirichlet_conjugate_bound`: the `abs_le.mpr` tuple is made order-independent (supply all four cos sign-bounds and `constructor <;> linarith`).

Parent stays verified 0/0; `lineCount` 181→179 synced in its meta.

### Gallery data
`src/data/proofs/de-moivre-oq-06-oq-02/` — `meta.json` (status `verified`, badge `original`, axiomCount 0) + `annotations.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)