### PR TITLE
Enrich bezout-identity-oq-02-oq-01-oq-01-oq-02: close Section III coverage gap

### DIFF
--- a/src/data/proofs/bezout-identity-oq-02-oq-01-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/bezout-identity-oq-02-oq-01-oq-01-oq-02/annotations.json
@@ -75,10 +75,10 @@
   {
     "id": "ann-bezout-fp-contrast",
     "proofId": "bezout-identity-oq-02-oq-01-oq-01-oq-02",
-    "range": { "startLine": 112, "endLine": 128 },
+    "range": { "startLine": 102, "endLine": 128 },
     "type": "insight",
     "title": "Where Fermat Factorization Fails: ℚ vs 𝔽_p",
-    "content": "Fermat factorization is a characteristic-p phenomenon. The scalar 2 makes this concrete: over 𝔽_5, ZMod.pow_card forces 2^5 = 2 so 2 is a root of X^5 − X (as is every element); over ℚ, evaluating gives 2^5 − 2 = 30 ≠ 0, so 2 is not a root and the all-linear split cannot survive. The small case X^3 − X = X(X − 1)(X + 1) does split over ℚ — but only because its roots 0, ±1 happen to be rational; for X^5 − X the rational roots are exhausted by 0, ±1 and the rest stay irreducible over ℚ.",
+    "content": "Section III turns to characteristic 0. The section docstring states the principle — over a field of characteristic 0, X^q − X no longer has every scalar as a root, so it does not split into linear factors — and Fermat factorization is thereby a characteristic-p phenomenon. The scalar 2 makes this concrete: over 𝔽_5, ZMod.pow_card forces 2^5 = 2 so 2 is a root of X^5 − X (as is every element); over ℚ, evaluating gives 2^5 − 2 = 30 ≠ 0, so 2 is not a root and the all-linear split cannot survive. The small case X^3 − X = X(X − 1)(X + 1) (proved by a bare `ring`) does split over ℚ — but only coincidentally, because its roots 0, ±1 happen to be rational; for X^5 − X the rational roots are exhausted by 0, ±1 and the remaining factor X^2 + 1 stays irreducible over ℚ.",
     "mathContext": "$\\operatorname{eval}_2 (X^5 - X) = 30$ over $\\mathbb{Q}$, but $= 0$ over $\\mathbb{F}_5$. Fermat factorization needs $\\operatorname{char} = p$.",
     "significance": "supporting",
     "relatedConcepts": [

--- a/src/data/proofs/enrichment-tracker.json
+++ b/src/data/proofs/enrichment-tracker.json
@@ -7097,6 +7097,11 @@
       "passes": 1,
       "lastEnriched": "2026-07-12T01:21:20Z",
       "quality": 96
+    },
+    "bezout-identity-oq-02-oq-01-oq-01-oq-02": {
+      "passes": 1,
+      "lastEnriched": "2026-07-12T04:30:00Z",
+      "quality": 96
     }
   }
 }


### PR DESCRIPTION
Enrichment pass for `bezout-identity-oq-02-oq-01-oq-01-oq-02` (quality 96, passes 0).

## Change
The only annotation coverage gap was lines 101–111 — Section III's docstring (why Fermat factorization fails in characteristic 0) and the `X³−X = X(X−1)(X+1)` example — sitting between the Frobenius annotation (ends 100) and the ℚ-vs-𝔽ₚ contrast annotation (starts 112). Extended the contrast annotation's range `112 → 102` so it covers the full Section III (its content already discussed both), and lightly framed the section intro: the coincidental rational split of `X³−X`, and that `X⁵−X` factors over ℚ as `X(X−1)(X+1)(X²+1)` with `X²+1` irreducible.

Coverage is now contiguous: `1–50, 51–73, 74–90, 91–100, 102–128` (only the blank line 101 uncovered).

## Also
Bumped `enrichment-tracker.json` (passes 1) **in this PR** so the completion durably lands on `main` — `find-targets.ts` reads only the git-tracked tracker, and local `complete` bumps get reverted by concurrent main resets (re-serve loop).

## Verification
- Annotation ranges non-overlapping; all schema fields present. `meta.json` 11 KB (well under cap); no meta changes.
- `tsc --noEmit` clean. Status/badge/axiomCount unchanged (verified, 0 axioms).
- Math checked: `X⁵−X = X(X⁴−1) = X(X−1)(X+1)(X²+1)`; `eval₂(X⁵−X)=30` over ℚ, `=0` over 𝔽₅.