### PR TITLE
research(cauchy-interlacing-oq-02-oq-02-oq-01): native eigenvalues₀ Poincaré separation

### DIFF
--- a/proofs/Proofs/CauchyInterlacingPoincareSubmatrixEigenvalues.lean
+++ b/proofs/Proofs/CauchyInterlacingPoincareSubmatrixEigenvalues.lean
@@ -105,7 +105,7 @@ theorem poincare_separation_submatrix_eigenvalues₀
   -- The remaining `Fin.cast`s of the explicit index literals collapse to the
   -- parent's literals; `hlow`/`hup` are exactly the goals up to `Fin.ext`.
   refine ⟨?_, ?_⟩
-  · convert hlow using 2 <;> exact Fin.ext rfl
-  · convert hup using 2 <;> exact Fin.ext rfl
+  · convert hlow using 2
+  · convert hup using 2
 
 end CauchyInterlacing.PoincareSubmatrix

--- a/proofs/Proofs/CauchyInterlacingPoincareSubmatrixEigenvalues.lean
+++ b/proofs/Proofs/CauchyInterlacingPoincareSubmatrixEigenvalues.lean
@@ -1,0 +1,111 @@
+import Mathlib
+import Proofs.CauchyInterlacingPoincareSubmatrix
+
+/-
+# Poincaré separation in native `Matrix.IsHermitian.eigenvalues₀` form
+
+`CauchyInterlacingPoincareSubmatrix.lean` proves the principal-submatrix Poincaré
+separation theorem `poincare_separation_submatrix`, but phrases its eigenvalues
+through the *operator* layer: `(isHermitian_iff_isSymmetric.1 hA).eigenvalues`,
+i.e. `LinearMap.IsSymmetric.eigenvalues` of `toEuclideanLin A`, using the finrank
+witness `finrank_euclideanSpace_fin : finrank 𝕜 (EuclideanSpace 𝕜 (Fin (n+m))) = n+m`.
+
+That entry's first open question asks to restate the conclusion with Mathlib's
+native matrix eigenvalues `Matrix.IsHermitian.eigenvalues₀`, threading the
+`Fintype.card (Fin (n+m)) = n+m` reindexing so the signature is *fully matrix
+facing*.  This file supplies that restatement.
+
+## The reindexing obstruction
+
+`Matrix.IsHermitian.eigenvalues₀ hA : Fin (Fintype.card (Fin (n+m))) → ℝ` is
+*defined* as `(isHermitian_iff_isSymmetric.1 hA).eigenvalues finrank_euclideanSpace`
+— the **same** operator eigenvalues, but built from the finrank witness
+`finrank_euclideanSpace : finrank 𝕜 (EuclideanSpace 𝕜 (Fin (n+m))) = Fintype.card (Fin (n+m))`.
+The two witnesses differ only in their right-hand side, and
+`Fintype.card (Fin (n+m)) = n+m` is **not** definitional (it unfolds through
+`List.length_finRange`), so `eigenvalues₀` and the submatrix theorem's `lam`/`mu`
+do not agree on the nose; a `Fin.cast` sits between them.
+
+The bridge is `LinearMap.IsSymmetric.eigenvalues_cast`: the operator eigenvalues
+are independent of *which* finrank proof is used — beyond the forced `Fin.cast`
+between the (propositionally equal) index bounds — because once the two natural
+numbers are identified the two witnesses are equal by proof irrelevance and the
+`Fin.cast` collapses to the identity.  With that in hand, `eigenvalues₀` reduces
+verbatim to the operator eigenvalues at the reindexed coordinate, and the
+matrix-facing interlacing follows from `poincare_separation_submatrix` with no
+new spectral content.
+
+Research file — intentionally NOT registered in `Proofs.lean`.
+-/
+
+open scoped InnerProductSpace Matrix
+open Matrix WithLp
+
+namespace CauchyInterlacing.PoincareSubmatrix
+
+variable {𝕜 : Type*} [RCLike 𝕜] {n m : ℕ}
+
+/-! ### The finrank-witness bridge for symmetric-operator eigenvalues -/
+
+/-- The sorted eigenvalues of a symmetric operator do not depend on *which* proof
+`finrank 𝕜 E = N` is supplied, beyond the canonical `Fin.cast` between the two
+index bounds.  Once the two dimensions are identified, the two finrank witnesses
+agree by proof irrelevance and the cast is the identity. -/
+theorem _root_.LinearMap.IsSymmetric.eigenvalues_cast
+    {𝕜 E : Type*} [RCLike 𝕜] [NormedAddCommGroup E] [InnerProductSpace 𝕜 E]
+    [FiniteDimensional 𝕜 E] {T : E →ₗ[𝕜] E} (hT : T.IsSymmetric)
+    {N₁ N₂ : ℕ} (h₁ : Module.finrank 𝕜 E = N₁) (h₂ : Module.finrank 𝕜 E = N₂)
+    (i : Fin N₁) :
+    hT.eigenvalues h₁ i = hT.eigenvalues h₂ (Fin.cast (h₁.symm.trans h₂) i) := by
+  obtain rfl : N₁ = N₂ := h₁.symm.trans h₂
+  have hi : Fin.cast (h₁.symm.trans h₂) i = i := Fin.ext rfl
+  rw [hi]
+
+/-- `Matrix.IsHermitian.eigenvalues₀` is the operator eigenvalues built with the
+`finrank_euclideanSpace_fin` witness, at the coordinate reindexed by the canonical
+`Fintype.card (Fin N) = N` cast.  (`eigenvalues₀` itself uses `finrank_euclideanSpace`.) -/
+theorem eigenvalues₀_eq_op {N : ℕ} {B : Matrix (Fin N) (Fin N) 𝕜} (hB : B.IsHermitian)
+    (i : Fin (Fintype.card (Fin N))) :
+    hB.eigenvalues₀ i
+      = (Matrix.isHermitian_iff_isSymmetric.1 hB).eigenvalues finrank_euclideanSpace_fin
+          (Fin.cast (Fintype.card_fin N) i) := by
+  have hdef : hB.eigenvalues₀ i
+      = (Matrix.isHermitian_iff_isSymmetric.1 hB).eigenvalues finrank_euclideanSpace i := rfl
+  rw [hdef]
+  exact (Matrix.isHermitian_iff_isSymmetric.1 hB).eigenvalues_cast
+    finrank_euclideanSpace finrank_euclideanSpace_fin i
+
+/-! ### The matrix Poincaré separation theorem in `eigenvalues₀` form -/
+
+/-- **Poincaré separation / Cauchy interlacing — native matrix eigenvalue form.**
+
+Let `A` be a Hermitian `(n+m) × (n+m)` matrix over `𝕜`, and let
+`e : Fin n → Fin (n+m)` be an injective choice of retained coordinates, so
+`A.submatrix e e` is the principal submatrix obtained by deleting the `m`
+complementary rows and columns.  Writing `λ := hA.eigenvalues₀` (descending
+eigenvalues of `A`, indexed by `Fin (Fintype.card (Fin (n+m)))`) and
+`μ := (hA.submatrix e).eigenvalues₀` (descending eigenvalues of the principal
+submatrix), the two spectra interlace:
+
+  `λ ⟨k+m⟩ ≤ μ ⟨k⟩`   and   `μ ⟨k⟩ ≤ λ ⟨k⟩`   for every `k : Fin n`.
+
+This is the parent entry's `poincare_separation_submatrix` restated purely
+through Mathlib's `Matrix.IsHermitian.eigenvalues₀`, closing that entry's first
+open question. -/
+theorem poincare_separation_submatrix_eigenvalues₀
+    (A : Matrix (Fin (n + m)) (Fin (n + m)) 𝕜) (hA : A.IsHermitian)
+    (e : Fin n → Fin (n + m)) (he : Function.Injective e) (k : Fin n) :
+    hA.eigenvalues₀ ⟨(k : ℕ) + m, by rw [Fintype.card_fin]; have := k.isLt; omega⟩
+        ≤ (hA.submatrix e).eigenvalues₀ ⟨(k : ℕ), by rw [Fintype.card_fin]; exact k.isLt⟩
+    ∧ (hA.submatrix e).eigenvalues₀ ⟨(k : ℕ), by rw [Fintype.card_fin]; exact k.isLt⟩
+        ≤ hA.eigenvalues₀ ⟨(k : ℕ), by rw [Fintype.card_fin]; have := k.isLt; omega⟩ := by
+  obtain ⟨hlow, hup⟩ := poincare_separation_submatrix A hA e he k
+  -- Rewrite every `eigenvalues₀` back to the operator eigenvalues used by the parent.
+  simp only [eigenvalues₀_eq_op]
+  -- The remaining `Fin.cast`s of the explicit index literals collapse to the
+  -- parent's literals; `hlow`/`hup` are exactly the goals up to `Fin.ext`.
+  refine ⟨?_, ?_⟩
+  · convert hlow using 2 <;> exact Fin.ext rfl
+  · convert hup using 2 <;> exact Fin.ext rfl
+
+end CauchyInterlacing.PoincareSubmatrix

--- a/src/data/proofs/cauchy-interlacing-theorem-oq-02-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/cauchy-interlacing-theorem-oq-02-oq-02-oq-01/annotations.json
@@ -1,0 +1,50 @@
+[
+  {
+    "id": "ann-overview",
+    "proofId": "cauchy-interlacing-theorem-oq-02-oq-02-oq-01",
+    "range": { "startLine": 4, "endLine": 39 },
+    "type": "concept",
+    "title": "Restating Interlacing in Native Matrix Eigenvalues",
+    "content": "The parent entry oq-02-oq-02 proves the principal-submatrix Poincaré separation λ⟨k+m⟩ ≤ μ⟨k⟩ ≤ λ⟨k⟩ but phrases the eigenvalues through the operator layer — LinearMap.IsSymmetric.eigenvalues of toEuclideanLin A. This file answers that entry's first open question by restating the same inequalities through Mathlib's native matrix eigenvalues Matrix.IsHermitian.eigenvalues₀. The subtlety is purely reindexing: eigenvalues₀ is DEFINED as the operator eigenvalues, but built from the finrank witness finrank_euclideanSpace (right-hand side Fintype.card (Fin (n+m))), whereas the parent uses finrank_euclideanSpace_fin (right-hand side n+m). Since Fintype.card (Fin k) = k is not definitional, a Fin.cast separates the two presentations.",
+    "mathContext": "$A \\in \\mathrm{Herm}_{n+m}(\\mathbb{K})$, $e:\\mathrm{Fin}\\,n \\hookrightarrow \\mathrm{Fin}(n{+}m)$: $\\lambda_{k+m} \\le \\mu_k \\le \\lambda_k$ with $\\lambda = \\mathtt{eigenvalues_0}\\,A$, $\\mu = \\mathtt{eigenvalues_0}\\,(A_{e,e})$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Matrix.IsHermitian.eigenvalues₀", "Poincaré separation", "eigenvalue interlacing", "reindexing", "toEuclideanLin"],
+    "prerequisites": ["the parent principal-submatrix interlacing (oq-02-oq-02)", "Hermitian matrix eigenvalues", "EuclideanSpace finrank"]
+  },
+  {
+    "id": "ann-eigenvalues-cast",
+    "proofId": "cauchy-interlacing-theorem-oq-02-oq-02-oq-01",
+    "range": { "startLine": 50, "endLine": 64 },
+    "type": "theorem",
+    "title": "The finrank-witness bridge (eigenvalues_cast)",
+    "content": "LinearMap.IsSymmetric.eigenvalues_cast: the sorted (descending) eigenvalues hT.eigenvalues of a symmetric operator do not depend on WHICH proof finrank 𝕜 E = N is supplied — only on the natural number N — beyond the canonical Fin.cast between the two index bounds. The proof is a two-line collapse: obtain rfl : N₁ = N₂ identifies the two dimensions; the Fin.cast then goes Fin N₁ → Fin N₁ and equals the identity (Fin.ext rfl on the value); and the two finrank witnesses h₁, h₂ are now inhabitants of the same Prop, hence definitionally equal by Lean 4 proof irrelevance. Notably this needs no fact about how eigenvalues are actually computed.",
+    "mathContext": "$\\mathtt{eigenvalues}\\,h_1\\,i = \\mathtt{eigenvalues}\\,h_2\\,(\\mathrm{Fin.cast}\\,(h_1^{-1}\\cdot h_2)\\,i)$; proof irrelevance makes $h_1 \\equiv h_2$ once $N_1 = N_2$.",
+    "significance": "key",
+    "relatedConcepts": ["proof irrelevance", "Fin.cast", "subst / obtain rfl", "LinearMap.IsSymmetric.eigenvalues"],
+    "prerequisites": ["symmetric-operator eigenvalues", "Lean Prop proof irrelevance", "Fin.ext"]
+  },
+  {
+    "id": "ann-eigenvalues0-eq-op",
+    "proofId": "cauchy-interlacing-theorem-oq-02-oq-02-oq-01",
+    "range": { "startLine": 65, "endLine": 77 },
+    "type": "theorem",
+    "title": "eigenvalues₀ as the operator eigenvalues (eigenvalues₀_eq_op)",
+    "content": "eigenvalues₀_eq_op specialises eigenvalues_cast to a Hermitian matrix: hB.eigenvalues₀ i equals (isHermitian_iff_isSymmetric.1 hB).eigenvalues finrank_euclideanSpace_fin at the coordinate reindexed by the Fintype.card (Fin N) = N cast. Since eigenvalues₀ is by definition the operator eigenvalues built with finrank_euclideanSpace, the first step is rfl; eigenvalues_cast then bridges the finrank_euclideanSpace / finrank_euclideanSpace_fin gap. This is the exact interface that lets the native matrix eigenvalues be substituted into the parent's operator-layer theorem.",
+    "mathContext": "$(\\mathtt{eigenvalues_0}\\,B)\\,i = \\mathtt{eigenvalues}\\,\\mathtt{finrank\\_euclideanSpace\\_fin}\\,(\\mathrm{Fin.cast}\\,(\\mathrm{card\\_fin}\\,N)\\,i)$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Matrix.IsHermitian.eigenvalues₀", "finrank_euclideanSpace", "Fintype.card_fin"],
+    "prerequisites": ["the definition of eigenvalues₀", "eigenvalues_cast"]
+  },
+  {
+    "id": "ann-main",
+    "proofId": "cauchy-interlacing-theorem-oq-02-oq-02-oq-01",
+    "range": { "startLine": 80, "endLine": 111 },
+    "type": "theorem",
+    "title": "Matrix-eigenvalue interlacing (poincare_separation_submatrix_eigenvalues₀)",
+    "content": "The main result: for a Hermitian A and injective e, the native eigenvalues₀ of A and of A.submatrix e e interlace as λ⟨k+m⟩ ≤ μ⟨k⟩ ≤ λ⟨k⟩. The proof invokes the parent poincare_separation_submatrix A hA e he k to get the operator-layer inequalities, rewrites every eigenvalues₀ via simp only [eigenvalues₀_eq_op], and closes each inequality with convert … using 2 — whose only residual, that the Fin.cast of the explicit index literal ⟨k+m⟩ / ⟨k⟩ equals that literal (same underlying value), is discharged by Fin.ext. No new spectral theory enters; the mathematical content is entirely inherited from the parent.",
+    "mathContext": "$\\lambda_{k+m} \\le \\mu_k$ and $\\mu_k \\le \\lambda_k$ for all $k:\\mathrm{Fin}\\,n$, with $\\lambda = \\mathtt{eigenvalues_0}\\,A$, $\\mu = \\mathtt{eigenvalues_0}\\,(A_{e,e})$ — a fully matrix-facing signature.",
+    "significance": "key",
+    "relatedConcepts": ["poincare_separation_submatrix", "principal submatrix", "convert", "eigenvalue interlacing"],
+    "prerequisites": ["the parent poincare_separation_submatrix", "eigenvalues₀_eq_op", "Fin.ext"]
+  }
+]

--- a/src/data/proofs/cauchy-interlacing-theorem-oq-02-oq-02-oq-01/meta.json
+++ b/src/data/proofs/cauchy-interlacing-theorem-oq-02-oq-02-oq-01/meta.json
@@ -1,0 +1,149 @@
+{
+  "id": "cauchy-interlacing-theorem-oq-02-oq-02-oq-01",
+  "title": "Poincaré Separation in Native Matrix-Eigenvalue Form",
+  "slug": "cauchy-interlacing-theorem-oq-02-oq-02-oq-01",
+  "description": "Restates the principal-submatrix Poincaré separation / Cauchy interlacing theorem (parent oq-02-oq-02) purely through Mathlib's native matrix eigenvalues Matrix.IsHermitian.eigenvalues₀, rather than the operator-layer LinearMap.IsSymmetric.eigenvalues of toEuclideanLin. For a Hermitian (n+m)×(n+m) matrix A and an injective coordinate map e : Fin n → Fin (n+m), writing λ := hA.eigenvalues₀ and μ := (hA.submatrix e).eigenvalues₀ for the descending eigenvalues of A and of its principal submatrix A.submatrix e e, the two spectra interlace: λ⟨k+m⟩ ≤ μ⟨k⟩ ≤ λ⟨k⟩ for every k : Fin n. The bridge is entirely a reindexing problem: eigenvalues₀ is defined as the operator eigenvalues built from the finrank witness finrank_euclideanSpace (right-hand side Fintype.card (Fin (n+m))), while the parent theorem uses finrank_euclideanSpace_fin (right-hand side n+m), and Fintype.card (Fin (n+m)) = n+m is only propositional, not definitional. The general lemma eigenvalues_cast shows the sorted symmetric-operator eigenvalues are independent of which finrank proof is supplied (up to the forced Fin.cast between index bounds), so eigenvalues₀ reduces verbatim to the parent's operator eigenvalues and the interlacing follows with no new spectral content. This answers the parent entry's first open question: a fully matrix-facing signature.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-07-11",
+    "status": "verified",
+    "proofRepoPath": "Proofs/CauchyInterlacingPoincareSubmatrixEigenvalues.lean",
+    "tags": [
+      "linear-algebra",
+      "spectral-theory",
+      "eigenvalues",
+      "cauchy-interlacing",
+      "poincare-separation",
+      "hermitian-matrix",
+      "principal-submatrix",
+      "matrix-eigenvalues",
+      "reindexing",
+      "proof-irrelevance"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-07-11",
+    "axiomCount": 0,
+    "lineCount": 111,
+    "theoremCount": 3,
+    "definitionCount": 0,
+    "assumptions": "None. The main theorem poincare_separation_submatrix_eigenvalues₀ is stated and proved for an arbitrary Hermitian matrix A : Matrix (Fin (n+m)) (Fin (n+m)) 𝕜 (𝕜 an RCLike field) and an arbitrary injective coordinate map e : Fin n → Fin (n+m); no side hypotheses beyond A.IsHermitian and Function.Injective e (the ordinary hypotheses of the statement). There are no axiom declarations, no sorries, and no native_decide. The proof composes only the parent entry's poincare_separation_submatrix (a 0-axiom, propext/Classical.choice/Quot.sound result) with the standard tactics subst (obtain rfl), rfl, rw, simp only, convert and Fin.ext — none of which introduce sorryAx, Lean.ofReduceBool, or any non-foundational axiom. The file compiles green (lake build exit 0, no warnings). #print axioms is therefore expected to list only [propext, Classical.choice, Quot.sound], the standard foundational trio that does not count as an assumption; the automated axiom print could not be captured during this session only because of transient shared-Docker-volume corruption from concurrent agents, not because of any proof dependency.",
+    "originalContributions": [
+      "poincare_separation_submatrix_eigenvalues₀: the principal-submatrix Poincaré separation / Cauchy interlacing inequalities λ⟨k+m⟩ ≤ μ⟨k⟩ and μ⟨k⟩ ≤ λ⟨k⟩ stated entirely through Mathlib's native Matrix.IsHermitian.eigenvalues₀ of A and of its principal submatrix A.submatrix e e — a fully matrix-facing signature with the Fintype.card (Fin (n+m)) = n+m reindexing threaded internally. Discharges the parent entry's first open question.",
+      "LinearMap.IsSymmetric.eigenvalues_cast: a reusable general lemma that the sorted (descending) eigenvalues hT.eigenvalues of a symmetric operator do not depend on which proof finrank 𝕜 E = N is supplied, beyond the canonical Fin.cast between the two propositionally-equal index bounds. Proved by identifying the two dimensions (obtain rfl), after which the two finrank witnesses agree by proof irrelevance and the Fin.cast collapses to the identity. This is the piece that lets one move freely between the finrank_euclideanSpace (Fintype.card-indexed) and finrank_euclideanSpace_fin (Nat-indexed) presentations of the same spectrum.",
+      "eigenvalues₀_eq_op: the definitional bridge identifying Matrix.IsHermitian.eigenvalues₀ (built with finrank_euclideanSpace) with the operator eigenvalues LinearMap.IsSymmetric.eigenvalues finrank_euclideanSpace_fin at the coordinate reindexed by the Fintype.card (Fin N) = N cast — the exact interface between the native matrix eigenvalues and the parent entry's operator-layer statement."
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "Matrix.IsHermitian.eigenvalues₀",
+        "description": "The eigenvalues of a Hermitian matrix, indexed by Fin (Fintype.card n); defined as (isHermitian_iff_isSymmetric.1 hA).eigenvalues finrank_euclideanSpace — the operator eigenvalues of toEuclideanLin A. This entry's whole task is to expose the interlacing through this native object rather than the underlying operator eigenvalues.",
+        "module": "Mathlib.Analysis.Matrix.Spectrum"
+      },
+      {
+        "theorem": "LinearMap.IsSymmetric.eigenvalues",
+        "description": "The sorted (descending) eigenvalues of a symmetric operator on a finite-dimensional inner product space, parameterised by a proof finrank 𝕜 E = N; eigenvalues_cast establishes their independence from the choice of that proof, and eigenvalues_antitone their descending order.",
+        "module": "Mathlib.Analysis.InnerProductSpace.Spectrum"
+      },
+      {
+        "theorem": "finrank_euclideanSpace / finrank_euclideanSpace_fin",
+        "description": "The two finrank identities for EuclideanSpace 𝕜 (Fin (n+m)): one with right-hand side Fintype.card (Fin (n+m)) (used by eigenvalues₀), the other with right-hand side n+m (used by the parent theorem). Their non-definitional difference — Fintype.card (Fin k) unfolds through List.length_finRange, not to k — is precisely the reindexing this entry threads.",
+        "module": "Mathlib.Analysis.InnerProductSpace.PiL2"
+      },
+      {
+        "theorem": "Fintype.card_fin",
+        "description": "Fintype.card (Fin n) = n — the propositional (not definitional) equality supplying the Fin.cast between the eigenvalues₀ index Fin (Fintype.card (Fin (n+m))) and the operator index Fin (n+m).",
+        "module": "Mathlib.Data.Fintype.Card"
+      }
+    ],
+    "mathlib_version": "4.26.0"
+  },
+  "overview": {
+    "historicalContext": "The parent gallery entry oq-02-oq-02 (CauchyInterlacingPoincareSubmatrix.lean) proves the principal-submatrix Poincaré separation theorem — Cauchy's 1829 interlacing theorem in its delete-m form (Poincaré 1890; Horn–Johnson Thm 4.3.17 & 4.3.28) — but phrases its conclusion through the operator eigenvalues of toEuclideanLin A. It explicitly lists, as its first open question, the task of restating the same inequalities with Mathlib's native matrix eigenvalues Matrix.IsHermitian.eigenvalues₀, threading the Fintype.card (Fin (n+m)) = n+m reindexing so the signature is fully matrix facing. This entry supplies that restatement.",
+    "problemStatement": "Restate the principal-submatrix Poincaré separation theorem directly through Matrix.IsHermitian.eigenvalues₀: for a Hermitian matrix A : Matrix (Fin (n+m)) (Fin (n+m)) 𝕜 and an injective coordinate map e : Fin n → Fin (n+m), with λ := hA.eigenvalues₀ (descending eigenvalues of A) and μ := (hA.submatrix e).eigenvalues₀ (descending eigenvalues of the principal submatrix A.submatrix e e), prove λ⟨k+m⟩ ≤ μ⟨k⟩ and μ⟨k⟩ ≤ λ⟨k⟩ for every k : Fin n, with the index arithmetic carried through the Fintype.card (Fin (n+m)) = n+m reindexing.",
+    "text": "Matrix.IsHermitian.eigenvalues₀ hA : Fin (Fintype.card (Fin (n+m))) → ℝ is defined as (isHermitian_iff_isSymmetric.1 hA).eigenvalues finrank_euclideanSpace — literally the operator eigenvalues used by the parent, but built from a different finrank witness. finrank_euclideanSpace has right-hand side Fintype.card (Fin (n+m)); finrank_euclideanSpace_fin (the parent's witness) has right-hand side n+m. Since Fintype.card (Fin k) unfolds through List.length_finRange rather than reducing definitionally to k, these two presentations of the same spectrum are separated by a Fin.cast. The whole content of this entry is discharging that cast: eigenvalues_cast identifies the two dimensions, collapses the cast by proof irrelevance, and eigenvalues₀_eq_op then rewrites eigenvalues₀ back to the parent's operator eigenvalues. The interlacing is inherited verbatim from poincare_separation_submatrix.",
+    "proofStrategy": "The keystone is LinearMap.IsSymmetric.eigenvalues_cast: given h₁ : finrank 𝕜 E = N₁ and h₂ : finrank 𝕜 E = N₂, one has hT.eigenvalues h₁ i = hT.eigenvalues h₂ (Fin.cast (h₁.symm.trans h₂) i). Proof: obtain rfl : N₁ = N₂ := h₁.symm.trans h₂ identifies the two dimensions; the Fin.cast then has type Fin N₁ → Fin N₁ and equals the identity (Fin.ext rfl on the value); and hT.eigenvalues h₁ = hT.eigenvalues h₂ holds because h₁ and h₂ are now proofs of the same proposition, definitionally equal by Lean 4's proof irrelevance. eigenvalues₀_eq_op specialises this to B = A (resp. A.submatrix e e): eigenvalues₀ i = eigenvalues finrank_euclideanSpace_fin (Fin.cast (Fintype.card_fin N) i). The main theorem then applies poincare_separation_submatrix A hA e he k to obtain the operator-layer inequalities, rewrites every eigenvalues₀ via simp only [eigenvalues₀_eq_op], and closes each side with convert … using 2, whose only residual — that Fin.cast of the explicit index literal ⟨k+m⟩ / ⟨k⟩ equals that literal — is discharged by Fin.ext (both share the same underlying value). No new spectral theory is introduced.",
+    "keyInsights": [
+      "**The obstruction is reindexing, not mathematics.** Matrix.IsHermitian.eigenvalues₀ IS the operator eigenvalues of toEuclideanLin A — the parent already proved the interlacing for exactly these numbers. The only gap is that eigenvalues₀ is indexed by Fin (Fintype.card (Fin (n+m))) while the parent's statement is indexed by Fin (n+m), and Fintype.card (Fin k) = k is not definitional. All the work is threading that one propositional equality.",
+      "**Proof irrelevance collapses the finrank witness.** LinearMap.IsSymmetric.eigenvalues depends on a proof finrank 𝕜 E = N, but only through the natural number N (the index bound). Once the two candidate N's are identified by subst, the two proofs become inhabitants of the same Prop and are definitionally equal — so the sorted eigenvalues they produce are literally the same function, and the accompanying Fin.cast is the identity. This is why eigenvalues_cast needs no facts about how the eigenvalues are computed.",
+      "**Fintype.card (Fin k) is not definitionally k.** A quick example : Fintype.card (Fin k) = k := rfl fails — the cardinality unfolds through List.length_finRange, so the equality is genuinely propositional. This is exactly why eigenvalues₀ (which uses finrank_euclideanSpace, with a Fintype.card right-hand side) cannot be fed to the parent theorem on the nose and a Fin.cast is unavoidable.",
+      "**eigenvalues₀ is the right matrix-facing object, and eigenvalues (index-reused) is not.** Only eigenvalues₀ is antitone (descending), which the interlacing inequalities require; Matrix.IsHermitian.eigenvalues (reindexed onto the raw matrix index type via an arbitrary Fintype.equivOfCardEq) is not sorted, so a pointwise interlacing statement in terms of it would be false. The restatement is therefore correctly phrased through eigenvalues₀."
+    ],
+    "prerequisites": [
+      "The parent entry oq-02-oq-02 (principal-submatrix Poincaré separation): λ⟨k+m⟩ ≤ μ⟨k⟩ ≤ λ⟨k⟩ for a Hermitian matrix and its principal submatrix, through the operator eigenvalues of toEuclideanLin",
+      "Matrix.IsHermitian.eigenvalues₀ and its definition as the toEuclideanLin operator eigenvalues; Matrix.IsHermitian.eigenvalues₀_antitone",
+      "LinearMap.IsSymmetric.eigenvalues and its parameterisation by a finrank proof",
+      "Lean 4 proof irrelevance for Props, subst / obtain rfl, and Fin.cast / Fin.ext"
+    ]
+  },
+  "sections": [
+    {
+      "id": "eigenvalues-cast",
+      "title": "The finrank-witness bridge",
+      "startLine": 47,
+      "endLine": 78,
+      "summary": "eigenvalues_cast: the sorted symmetric-operator eigenvalues are independent of which proof finrank 𝕜 E = N is supplied, up to the canonical Fin.cast between index bounds. eigenvalues₀_eq_op specialises it to identify Matrix.IsHermitian.eigenvalues₀ with the operator eigenvalues at the reindexed coordinate.",
+      "mathContext": "hT.eigenvalues h₁ i = hT.eigenvalues h₂ (Fin.cast (h₁.symm.trans h₂) i); proof irrelevance makes h₁ and h₂ defeq once N₁ = N₂ is substituted."
+    },
+    {
+      "id": "matrix-interlacing",
+      "title": "The matrix-eigenvalue interlacing theorem",
+      "startLine": 79,
+      "endLine": 111,
+      "summary": "poincare_separation_submatrix_eigenvalues₀: λ⟨k+m⟩ ≤ μ⟨k⟩ ≤ λ⟨k⟩ with λ, μ the native eigenvalues₀ of A and of A.submatrix e e. The proof invokes the parent poincare_separation_submatrix, rewrites via eigenvalues₀_eq_op, and closes with convert / Fin.ext.",
+      "mathContext": "The parent entry's second-question bridge, now stated with a fully matrix-facing signature via Matrix.IsHermitian.eigenvalues₀."
+    }
+  ],
+  "conclusion": {
+    "summary": "A machine-checked Lean 4 restatement of the principal-submatrix Poincaré separation / Cauchy interlacing theorem entirely through Mathlib's native matrix eigenvalues Matrix.IsHermitian.eigenvalues₀: for a Hermitian A and its principal submatrix A.submatrix e e, the descending eigenvalues satisfy λ⟨k+m⟩ ≤ μ⟨k⟩ ≤ λ⟨k⟩. The file is 0-axiom, 0-sorry and compiles green; it answers the parent entry oq-02-oq-02's first open question by threading the Fintype.card (Fin (n+m)) = n+m reindexing, whose crux is the reusable lemma eigenvalues_cast (the sorted operator eigenvalues are independent of the finrank witness, by proof irrelevance).",
+    "implications": "Gives downstream matrix corollaries of the min-max principle a native eigenvalues₀-facing interlacing statement, so they need not descend to the toEuclideanLin operator layer. The eigenvalues_cast lemma is independently reusable wherever one must move between the Fintype.card-indexed and Nat-indexed presentations of a symmetric operator's spectrum — a recurring friction point when combining Matrix.IsHermitian.eigenvalues₀ with LinearMap.IsSymmetric.eigenvalues.",
+    "openQuestions": [
+      "Specialise e to a monotone embedding (a genuine contiguous or index-ordered principal submatrix) and derive the classical bordered-matrix interlacing λ_k ≤ μ_k ≤ λ_{k+1} (the m = 1, delete-last-row case) directly in eigenvalues₀ form — the parent's remaining second open question, now over the native matrix eigenvalues.",
+      "Read the interlacing off the characteristic polynomial: since sort_roots_charpoly_eq_eigenvalues₀ gives (A.charpoly.roots.map RCLike.re).sort (· ≥ ·) = List.ofFn hA.eigenvalues₀, restate λ⟨k+m⟩ ≤ μ⟨k⟩ ≤ λ⟨k⟩ purely as an inequality between the sorted descending lists of real parts of the characteristic-polynomial roots of A and of A.submatrix e e."
+    ]
+  },
+  "references": [
+    {
+      "authors": ["Horn, R.A.", "Johnson, C.R."],
+      "title": "Matrix Analysis",
+      "year": "2013",
+      "venue": "Cambridge University Press, 2nd ed.",
+      "note": "Theorem 4.3.17 (Cauchy interlacing) and Theorem 4.3.28 / §4.3 (Poincaré separation for general principal submatrices)"
+    },
+    {
+      "authors": ["Bhatia, R."],
+      "title": "Matrix Analysis",
+      "year": "1997",
+      "venue": "Springer GTM 169",
+      "note": "Corollary III.1.5 and §III (Poincaré separation and interlacing via the min-max principle)"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "cauchy-interlacing-theorem-oq-02-oq-02",
+      "relationship": "parent",
+      "description": "Parent entry — proves the principal-submatrix Poincaré separation λ⟨k+m⟩ ≤ μ⟨k⟩ ≤ λ⟨k⟩ through the operator eigenvalues of toEuclideanLin, and lists the native-eigenvalues₀ restatement as its first open question. This entry supplies that restatement, reusing poincare_separation_submatrix verbatim."
+    },
+    {
+      "targetId": "cauchy-interlacing-theorem-oq-02",
+      "relationship": "ancestor",
+      "description": "Grandparent entry — the abstract Poincaré separation theorem for a symmetric operator and a codimension-m compression, on which the principal-submatrix bridge and this restatement ultimately rest."
+    },
+    {
+      "targetId": "cauchy-interlacing-theorem",
+      "relationship": "ancestor",
+      "description": "Root entry — the codimension-one Cauchy interlacing theorem and the Courant–Fischer keystone underlying the entire chain."
+    }
+  ],
+  "leanFile": {
+    "imports": ["Mathlib", "Proofs.CauchyInterlacingPoincareSubmatrix"],
+    "opens": ["InnerProductSpace", "Matrix", "WithLp"],
+    "namespace": "CauchyInterlacing.PoincareSubmatrix",
+    "lineCount": 111,
+    "axiomCount": 0,
+    "theoremCount": 3,
+    "definitionCount": 0,
+    "path": "Proofs/CauchyInterlacingPoincareSubmatrixEigenvalues.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the **first open question** of the parent gallery entry `cauchy-interlacing-theorem-oq-02-oq-02` (*Poincaré Separation: the Principal-Submatrix Bridge*): restate the interlacing conclusion through Mathlib's native matrix eigenvalues `Matrix.IsHermitian.eigenvalues₀` rather than the operator-layer `LinearMap.IsSymmetric.eigenvalues` of `toEuclideanLin A`, threading the `Fintype.card (Fin (n+m)) = n+m` reindexing for a fully matrix-facing signature.

## Result

```
theorem poincare_separation_submatrix_eigenvalues₀
    (A : Matrix (Fin (n + m)) (Fin (n + m)) 𝕜) (hA : A.IsHermitian)
    (e : Fin n → Fin (n + m)) (he : Function.Injective e) (k : Fin n) :
    hA.eigenvalues₀ ⟨k+m, …⟩ ≤ (hA.submatrix e).eigenvalues₀ ⟨k, …⟩
    ∧ (hA.submatrix e).eigenvalues₀ ⟨k, …⟩ ≤ hA.eigenvalues₀ ⟨k, …⟩
```

i.e. `λ⟨k+m⟩ ≤ μ⟨k⟩ ≤ λ⟨k⟩` with `λ, μ` the descending eigenvalues of `A` and of its principal submatrix `A.submatrix e e`.

## Why it is not trivial

`eigenvalues₀` **is** the operator eigenvalues the parent already handled — but it is built from the finrank witness `finrank_euclideanSpace` (RHS `Fintype.card (Fin (n+m))`), while the parent theorem uses `finrank_euclideanSpace_fin` (RHS `n+m`). Since `Fintype.card (Fin k) = k` is **not definitional** (`example : Fintype.card (Fin k) = k := rfl` fails — it unfolds through `List.length_finRange`), a `Fin.cast` sits between the two presentations. The reusable keystone

- **`LinearMap.IsSymmetric.eigenvalues_cast`** — the sorted symmetric-operator eigenvalues are independent of *which* `finrank 𝕜 E = N` proof is supplied (up to the canonical `Fin.cast`), because once the two `N`s are identified by `subst` the two witnesses agree by **proof irrelevance** and the cast collapses to the identity —

discharges the gap; `eigenvalues₀_eq_op` then rewrites `eigenvalues₀` back to the parent's operator eigenvalues and the interlacing follows verbatim from `poincare_separation_submatrix`.

## Verification

- **Builds green** via `./proofs/scripts/docker-build.sh Proofs.CauchyInterlacingPoincareSubmatrixEigenvalues` — exit 0, no warnings (7746 jobs).
- 111 lines · 3 theorems · 0 definitions · **0 sorries · 0 `axiom` declarations · no `native_decide`**.
- Axioms are the standard trio `[propext, Classical.choice, Quot.sound]` by composition (0-axiom parent + only `subst`/`rfl`/`rw`/`simp only`/`convert`/`Fin.ext`); the automated `#print axioms` could not be *captured* this session solely due to transient shared-Docker-volume corruption from concurrent agents (repeated SIGBUS/invalid-header on rotating mathlib oleans), not any proof dependency. `meta.json` marks the entry `verified`/`original`, `axiomCount: 0`.

## Gallery

New entry `src/data/proofs/cauchy-interlacing-theorem-oq-02-oq-02-oq-01/` (meta.json + annotations.json), cross-referenced to the parent, grandparent, and root Cauchy-interlacing entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)