### PR TITLE
Enrich bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-03-oq-03-oq-02-oq-01: contiguous annotation coverage

### DIFF
--- a/src/data/proofs/bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-03-oq-03-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-03-oq-03-oq-02-oq-01/annotations.json
@@ -14,7 +14,7 @@
   {
     "id": "bezout-irrednorm-ann-euclidean-instance",
     "proofId": "bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-03-oq-03-oq-02-oq-01",
-    "range": { "startLine": 42, "endLine": 45 },
+    "range": { "startLine": 40, "endLine": 45 },
     "type": "concept",
     "title": "The imported Euclidean structure: why irreducible ⟹ prime here",
     "content": "The whole necessity argument silently rests on one structural fact carried over from the parent import: for −2 ≤ d < 0, ℤ[√d] is norm-Euclidean, hence a PID, hence a unique factorization domain. That is exactly why `irreducible` can be traded for the far stronger `prime` — the step `UniqueFactorizationMonoid.irreducible_iff_prime` used at the top of the main theorem, activated by `letI := NormEuclideanZsqrtdFamily.euclideanDomain d hd hd2`. In a general integral domain irreducibles need not be prime, and neither the divides-a-rational-prime lemma (which uses `Prime.dvd_or_dvd`) nor the norm-comparison finish would go through. The bare `open Zsqrtd` / `variable {d : ℤ}` here is thus the seam where the earlier Euclidean-domain development is grafted onto this file; the hypotheses `hd : d < 0` and `hd2 : -2 ≤ d` threaded through every theorem are precisely the conditions under which that instance exists.",
@@ -38,10 +38,10 @@
   {
     "id": "bezout-irrednorm-ann-irred-to-prime",
     "proofId": "bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-03-oq-03-oq-02-oq-01",
-    "range": { "startLine": 95, "endLine": 110 },
+    "range": { "startLine": 82, "endLine": 110 },
     "type": "tactic",
     "title": "From irreducible to a divisibility of ↑|N(z)|",
-    "content": "The main theorem first installs the parent's euclideanDomain as a local instance (letI), which is what makes ℤ[√d] a UFD for −2 ≤ d < 0; in a UFD irreducible and prime coincide, so UniqueFactorizationMonoid.irreducible_iff_prime upgrades z to a prime. From primality z ≠ 0, hence N(z) ≠ 0 (norm_eq_zero_iff) and |N(z)| ≠ 0. Because d < 0 the norm is nonnegative (norm_nonneg), so ↑|N(z)| = N(z) as integers; combined with N(z) = z·z̄ (norm_eq_mul_conj) this exhibits z ∣ ↑|N(z)| with cofactor star z. This is the bridge that feeds the natural number |N(z)| into the crux lemma.",
+    "content": "Section II opens with the statement of the headline result irreducible_norm_eq_prime_or_sq: for −2 ≤ d < 0, an irreducible z has |N(z)| equal to a rational prime p or p², the necessary half matching the parent's sufficient irreducible_of_prime_norm. The proof first installs the parent's euclideanDomain as a local instance (letI), which is what makes ℤ[√d] a UFD for −2 ≤ d < 0; in a UFD irreducible and prime coincide, so UniqueFactorizationMonoid.irreducible_iff_prime upgrades z to a prime. From primality z ≠ 0, hence N(z) ≠ 0 (norm_eq_zero_iff) and |N(z)| ≠ 0. Because d < 0 the norm is nonnegative (norm_nonneg), so ↑|N(z)| = N(z) as integers; combined with N(z) = z·z̄ (norm_eq_mul_conj) this exhibits z ∣ ↑|N(z)| with cofactor star z. This is the bridge that feeds the natural number |N(z)| into the crux lemma.",
     "mathContext": "$N(z) = z\\cdot\\bar z$ and $N(z) \\ge 0$ for $d<0$, so $\\overline{|N(z)|} = N(z)$ and $z \\mid \\overline{|N(z)|}$.",
     "significance": "supporting",
     "relatedConcepts": ["UniqueFactorizationMonoid.irreducible_iff_prime", "Zsqrtd.norm_eq_mul_conj", "norm nonnegativity", "conjugate / star"],


### PR DESCRIPTION
Enrichment pass for `bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-03-oq-03-oq-02-oq-01` (Zsqrtd irreducible-norm classification; quality 96, passes 0).

## Change
Closed the two annotation coverage gaps so the file is contiguously annotated `1–128` (only blank line 39 uncovered):
- **Line 40** (`open Zsqrtd`): extended the euclidean-instance annotation `42 → 40` — its content already discussed `open Zsqrtd`.
- **Lines 82–94** (Section II header + the main theorem `irreducible_norm_eq_prime_or_sq`'s own docstring): extended the irreducible-to-divisibility annotation `95 → 82` and added a sentence framing the headline statement (necessary half matching the parent's sufficient `irreducible_of_prime_norm`). This was the gap between the crux lemma (ends 81) and the proof body (started 95).

## Also
Bumped `enrichment-tracker.json` (passes 1) **in this PR** for durable completion (find-targets reads only the git-tracked tracker; local bumps revert under concurrent main resets).

## Verification
- Ranges non-overlapping; all schema fields present. `meta.json` 12 KB (under cap); no meta changes.
- `tsc --noEmit` clean. Status/badge/axiomCount unchanged (verified, 0 axioms). Descriptive only.