### PR TITLE
research(szemeredi-regularity-oq-04): tower-free k²/ε⁴ iteration bound

### DIFF
--- a/proofs/Proofs/SzemerediRegularityOQ04Assembly.lean
+++ b/proofs/Proofs/SzemerediRegularityOQ04Assembly.lean
@@ -288,6 +288,79 @@ theorem afks_sharp_energy_iteration_count_of_prod_witness
   linarith [hgain, hfloor]
 
 -- ═══════════════════════════════════════════════════════════════════
+-- THE TOWER-FREE, VERTEX-COUNT-INDEPENDENT BOUND  N ≤ k²/ε⁴
+-- ═══════════════════════════════════════════════════════════════════
+
+/-- **Equipartition mass floor collapses the sharp bound to `k²/ε⁴`.**  The sharp
+    iteration count `afks_sharp_energy_iteration_count` reads `N ≤ n²/(ε⁴·m²)`,
+    where `n = |V|` and `m` is the minimum mass of a refined part.  This bound still
+    carries the ambient vertex count `n`.  The classical AFKS/Szemerédi payoff is that
+    it is in fact **independent of `n`**: if the refinement keeps the partition
+    *equitable* — every refined part carries at least the equipartition mass `n/k`,
+    i.e. `n ≤ k·m` — then the `n²` in the numerator is absorbed by the `m² ≥ n²/k²` in
+    the denominator and the bound collapses to the purely `(k, ε)`-explicit
+
+    `N ≤ k²/ε⁴`,
+
+    with no dependence on the number of vertices.  (A genuine equitable partition of
+    `n` vertices into `k` parts realizes `m ≥ ⌊n/k⌋`, so the idealized floor `n ≤ k·m`
+    is the exact-equipartition limit; the hypothesis is stated on `m` so that any
+    caller supplying an equitable mass floor obtains the tower-free count directly.)
+
+    This is a pure ordered-field consequence of the sharp bound: squaring the mass
+    floor `n ≤ k·m` gives `n² ≤ k²·m²`, so `n²/(ε⁴·m²) ≤ k²/ε⁴`. -/
+theorem afks_sharp_energy_iteration_count_tower_free
+    (N : ℕ) (eps m k : ℚ)
+    (hε : 0 < eps) (hm : 0 < m) (hk : 0 < k) (hn : 0 < (Fintype.card V : ℚ))
+    (hmass : (Fintype.card V : ℚ) ≤ k * m)
+    (hbound : (N : ℚ) ≤ (Fintype.card V : ℚ) ^ 2 / (eps ^ 4 * m ^ 2)) :
+    (N : ℚ) ≤ k ^ 2 / eps ^ 4 := by
+  have heps4 : (0 : ℚ) < eps ^ 4 := by positivity
+  -- Square the equipartition mass floor `n ≤ k·m`.
+  have hn2 : (Fintype.card V : ℚ) ^ 2 ≤ k ^ 2 * m ^ 2 := by
+    nlinarith [mul_le_mul hmass hmass hn.le (mul_nonneg hk.le hm.le)]
+  -- Absorb `n²` into `m²`, so the sharp bound loses its vertex-count dependence.
+  have hkey : (Fintype.card V : ℚ) ^ 2 / (eps ^ 4 * m ^ 2) ≤ k ^ 2 / eps ^ 4 := by
+    rw [div_le_div_iff (by positivity) heps4]
+    nlinarith [hn2, heps4.le]
+  linarith [hbound, hkey]
+
+/-- **Tower-free AFKS iteration count from an equitable irregular-product witness.**
+    The end-to-end `n`-independent certificate: combining the per-step irregular-product
+    witness bound `afks_sharp_energy_iteration_count_of_prod_witness`
+    (`N ≤ n²/(ε⁴·m²)`) with an equitable mass floor `n ≤ k·m` yields the tower-free
+
+    `N ≤ k²/ε⁴`.
+
+    Every hypothesis is inherited verbatim from `_of_prod_witness`, plus the single
+    equipartition datum `hmass : |V| ≤ k·m` (each of the `≥ m`-mass refined parts is at
+    least the equipartition size `n/k`).  The conclusion no longer mentions `|V|`: the
+    number of sharp `ε`-irregular `2×2` refinement steps before a regular step is reached
+    is bounded by `k²/ε⁴`, depending only on the part count `k` and the tolerance `ε`. -/
+theorem afks_sharp_energy_iteration_count_of_equipartition_witness
+    (G : SimpleGraph V) [DecidableRel G.Adj]
+    (parts : ℕ → Finset (Finset V)) (N : ℕ) (eps m k : ℚ)
+    (hε : 0 < eps) (hm : 0 < m) (hk : 0 < k) (hcard : 0 < (Fintype.card V : ℚ))
+    (hmass : (Fintype.card V : ℚ) ≤ k * m)
+    (hcover : ∀ n, ∀ v : V, ∃ P ∈ parts n, v ∈ P)
+    (hdisjoint : ∀ n, ∀ P Q : Finset V, P ∈ parts n → Q ∈ parts n → P ≠ Q →
+      Disjoint P Q)
+    (hwit : ∀ n, n < N → ∃ R : Finset (Finset V), ∃ A B A₁ A₂ B₁ B₂ : Finset V,
+      parts n = insert A (insert B R) ∧
+      parts (n + 1) = insert A₁ (insert A₂ (insert B₁ (insert B₂ R))) ∧
+      A₁ ∪ A₂ = A ∧ B₁ ∪ B₂ = B ∧ Disjoint A₁ A₂ ∧ Disjoint B₁ B₂ ∧
+      A ∉ insert B R ∧ B ∉ R ∧
+      A₁ ∉ insert A₂ (insert B₁ (insert B₂ R)) ∧ A₂ ∉ insert B₁ (insert B₂ R) ∧
+      B₁ ∉ insert B₂ R ∧ B₂ ∉ R ∧
+      m ≤ (A.card : ℚ) ∧ m ≤ (B.card : ℚ) ∧
+      eps * A.card ≤ (A₁.card : ℚ) ∧ eps * B.card ≤ (B₁.card : ℚ) ∧
+      eps ≤ |edgeDensity G A₁ B₁ - edgeDensity G A B|) :
+    (N : ℚ) ≤ k ^ 2 / eps ^ 4 := by
+  have hbound := afks_sharp_energy_iteration_count_of_prod_witness
+    G parts N eps m hε hm hcard hcover hdisjoint hwit
+  exact afks_sharp_energy_iteration_count_tower_free N eps m k hε hm hk hcard hmass hbound
+
+-- ═══════════════════════════════════════════════════════════════════
 -- TERMINATION: A REGULAR REFINEMENT STEP IS REACHED IN BOUNDED TIME
 -- ═══════════════════════════════════════════════════════════════════
 

--- a/proofs/Proofs/SzemerediRegularityOQ04Assembly.lean
+++ b/proofs/Proofs/SzemerediRegularityOQ04Assembly.lean
@@ -291,6 +291,7 @@ theorem afks_sharp_energy_iteration_count_of_prod_witness
 -- THE TOWER-FREE, VERTEX-COUNT-INDEPENDENT BOUND  N ≤ k²/ε⁴
 -- ═══════════════════════════════════════════════════════════════════
 
+omit [DecidableEq V] in
 /-- **Equipartition mass floor collapses the sharp bound to `k²/ε⁴`.**  The sharp
     iteration count `afks_sharp_energy_iteration_count` reads `N ≤ n²/(ε⁴·m²)`,
     where `n = |V|` and `m` is the minimum mass of a refined part.  This bound still
@@ -321,7 +322,7 @@ theorem afks_sharp_energy_iteration_count_tower_free
     nlinarith [mul_le_mul hmass hmass hn.le (mul_nonneg hk.le hm.le)]
   -- Absorb `n²` into `m²`, so the sharp bound loses its vertex-count dependence.
   have hkey : (Fintype.card V : ℚ) ^ 2 / (eps ^ 4 * m ^ 2) ≤ k ^ 2 / eps ^ 4 := by
-    rw [div_le_div_iff (by positivity) heps4]
+    rw [div_le_div_iff₀ (by positivity) heps4]
     nlinarith [hn2, heps4.le]
   linarith [hbound, hkey]
 

--- a/research/problems/szemeredi-regularity-oq-04/knowledge.md
+++ b/research/problems/szemeredi-regularity-oq-04/knowledge.md
@@ -655,3 +655,44 @@ won't fire; use `min_eq_left`/`min_eq_right` on the ℚ side after `push_cast`, 
 against `Nat.min_eq_left` (works because norm_cast knows `Nat.cast_min`). This is the THIRD
 verification-found bug this session (cf. minpoly `0=![0,0]`, erdos-659 spurious `.symm`) — the
 docker-down era left multiple live errors in "UNVERIFIED, high-confidence" files. File 509→506.
+
+## Session 2026-07-11 (researcher-9) — tower-free k²/ε⁴ bound: removing the vertex-count dependence
+
+**Mode**: REVISIT (FRESH claim of RICH problem) · **Outcome**: progress (VERIFIED, axiom-free)
+
+### What I Did
+Turned the sharp AFKS iteration count `afks_sharp_energy_iteration_count` (`N ≤ n²/(ε⁴·m²)`,
+`m` = minimum refined-part mass, `n = |V|`) into the classical **vertex-count-independent**
+bound. Added to `SzemerediRegularityOQ04Assembly.lean` (namespace `Szemeredi.RegularityOQ04Bridge`):
+
+- `afks_sharp_energy_iteration_count_tower_free` — pure ordered-field corollary: given the
+  sharp bound plus an equitable mass floor `n ≤ k·m`, square the floor (`n² ≤ k²·m²`) so the
+  `n²` numerator cancels against `m² ≥ n²/k²`, yielding `N ≤ k²/ε⁴`. Proof: `div_le_div_iff₀`
+  + `nlinarith [mul_le_mul hmass hmass ...]`. `omit [DecidableEq V]` (pure `card` algebra).
+- `afks_sharp_energy_iteration_count_of_equipartition_witness` — end-to-end certificate:
+  composes `_of_prod_witness` (per-step ε-irregular sharp-2×2 witness ⟹ `N ≤ n²/(ε⁴m²)`) with
+  the equitable floor to conclude `N ≤ k²/ε⁴` directly; conclusion no longer mentions `|V|`.
+
+### Key Findings
+- The `n`-dependence of the sharp bound is **removable in one algebraic step** — the whole
+  AFKS/Szemerédi "iteration count independent of graph size" phenomenon is exactly the mass
+  floor `n ≤ k·m` (equitable partition into `k` parts each ≥ equipartition size `n/k`).
+- Mathlib drift: `div_le_div_iff` → `div_le_div_iff₀` (same sig `a/b ≤ c/d ↔ a*d ≤ c*b`).
+
+### Verification
+Host `lean` v4.26.0 (docker-free path, `LEAN_PATH` from `lake env printenv`, prebuilt Bridge
+olean), full-file compile exit 0. `#print axioms` on both = `[propext, Classical.choice,
+Quot.sound]` — no `sorryAx`, no `ofReduceBool`. Assembly theorem count 5→7.
+
+### Files Modified
+- `proofs/Proofs/SzemerediRegularityOQ04Assembly.lean` (+2 theorems)
+- `src/data/research/problems/szemeredi-regularity-oq-04.json` (knowledge)
+
+### Next Steps
+- Instantiate `m := ⌊n/k⌋` for a *genuine* equipartition (min part ≥ ⌊n/k⌋), replacing the
+  idealized `n ≤ k·m` by the honest floor and tracking the `k → k·n/(n−k)` inflation.
+- The remaining open content stays the analytic split-realizability (`|A₁| ≥ ε|A|`) — freshness
+  is already discharged (`SzemerediRegularityOQ04Fresh.lean`, researcher-8).
+
+### NOTE (housekeeping)
+knowledge.md now >650 lines — due for `.lean/scripts/archive-sessions.sh szemeredi-regularity-oq-04`.


### PR DESCRIPTION
## Summary

Removes the **vertex-count dependence** from the sharp AFKS energy-iteration bound in the Szemerédi Regularity OQ-04 line, delivering the classical **tower-free, `n`-independent** count `N ≤ k²/ε⁴`.

The prior capstone `afks_sharp_energy_iteration_count` bounds the number of sharp 2×2 irregular-refinement steps by `N ≤ n²/(ε⁴·m²)` (`n = |V|`, `m` = minimum refined-part mass). This PR shows that dependence on `n` is removable in one algebraic step once the partition stays **equitable**.

## New theorems (in `SzemerediRegularityOQ04Assembly.lean`, namespace `Szemeredi.RegularityOQ04Bridge`)

- **`afks_sharp_energy_iteration_count_tower_free`** — pure ordered-field corollary: from the sharp bound plus an equitable mass floor `n ≤ k·m`, squaring gives `n² ≤ k²·m²`, so the `n²` numerator cancels against `m² ≥ n²/k²` and `N ≤ k²/ε⁴`.
- **`afks_sharp_energy_iteration_count_of_equipartition_witness`** — end-to-end certificate: composes the per-step ε-irregular sharp-2×2 witness bound (`_of_prod_witness`) with the equitable floor to conclude `N ≤ k²/ε⁴` directly; the conclusion no longer mentions `|V|`.

This is exactly the AFKS/Szemerédi "iteration count independent of graph size" phenomenon, isolated to the single hypothesis `n ≤ k·m` (each refined part at least the equipartition size `n/k`).

## Verification

- Host `lean` v4.26.0 (docker-free path, prebuilt Bridge olean), full-file compile **exit 0**.
- `#print axioms` on both new theorems = `[propext, Classical.choice, Quot.sound]` — **axiom-free** (no `sorryAx`, no `ofReduceBool`).
- Assembly theorem count 5 → 7. Fixed one Mathlib drift along the way: `div_le_div_iff` → `div_le_div_iff₀`.

## Next steps (documented in knowledge.md)

- Instantiate `m := ⌊n/k⌋` for a genuine equipartition (honest floor, tracking `k → k·n/(n−k)` inflation).
- Remaining open content stays the analytic split-realizability `|A₁| ≥ ε|A|`; freshness is already discharged (`SzemerediRegularityOQ04Fresh.lean`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)