### PR TITLE
Enrich amgm-inequality-oq-02-oq-01-oq-02: realign sections to PART banners (6->7)

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-02-oq-01-oq-02/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-02-oq-01-oq-02/meta.json
@@ -96,25 +96,33 @@
       "id": "symmetry",
       "title": "Part III: Core Symmetry via sum_image",
       "startLine": 71,
-      "endLine": 99,
+      "endLine": 98,
       "summary": "sum_lower_eq_sum_upper: ∑_{j<i} f = ∑_{i<j} f for symmetric f. Uses sum_image with swap injectivity.",
       "mathContext": "For $f(i,j) = f(j,i)$: $\\sum_{j<i} f(i,j) = \\sum_{i<j} f(i,j)$."
     },
     {
       "id": "main-theorem",
       "title": "Part IV: Main Theorem",
-      "startLine": 100,
-      "endLine": 117,
+      "startLine": 99,
+      "endLine": 115,
       "summary": "sum_offDiag_eq_two_mul_sum_upper: Σ_{i≠j} f = 2·Σ_{i<j} f. Combines decomposition + symmetry.",
       "mathContext": "$\\sum_{i \\neq j} f(i,j) = 2 \\sum_{i < j} f(i,j)$."
     },
     {
       "id": "application",
-      "title": "Part V: Application and Examples",
-      "startLine": 118,
-      "endLine": 138,
-      "summary": "offDiag_prod_eq_two_mul_e2: specialization to xᵢxⱼ. Concrete ring examples verified by ring.",
+      "title": "Part V: Application to Products xᵢxⱼ",
+      "startLine": 116,
+      "endLine": 126,
+      "summary": "offDiag_prod_eq_two_mul_e2: specialization of the main theorem to f(i,j) = xᵢxⱼ, giving Σ_{i≠j} xᵢxⱼ = 2·Σ_{i<j} xᵢxⱼ = 2e₂ — the identity linking the off-diagonal sum to the elementary symmetric polynomial e₂.",
       "mathContext": "$\\sum_{i \\neq j} x_i x_j = 2 \\sum_{i < j} x_i x_j = 2 e_2$."
+    },
+    {
+      "id": "examples",
+      "title": "Part VI: Concrete Examples",
+      "startLine": 127,
+      "endLine": 138,
+      "summary": "Two concrete `example`s verified by `ring`: the three-element off-diagonal product sum (a·b + a·c + b·a + b·c + c·a + c·b = 2(ab + ac + bc)) and the binomial square (a+b)² = a² + b² + 2ab, illustrating the 2× off-diagonal identity on small cases. Closes the namespace.",
+      "mathContext": "$(a+b)^2 = a^2 + b^2 + 2ab$ and the 3-element off-diagonal product sum as concrete instances of $\\sum_{i\\neq j} = 2\\sum_{i<j}$."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
Enrichment pass for `amgm-inequality-oq-02-oq-01-oq-02` (quality 100, pass 0).

**Problem:** section boundaries cut *through* the file's `Part` banner blocks — Part III's section grabbed Part IV's opening `===` (line 99), and Part IV's section started on its title line (100), missing its own top `===`. The file also has **six** PART banners (I–VI), but Parts V and VI were merged into a single 'Application and Examples' section.

**Fix:** realign each section so it owns its complete banner block, and split the merged section:
- **Part V: Application to Products xᵢxⱼ** (116–126) — `offDiag_prod_eq_two_mul_e2` (= 2e₂)
- **Part VI: Concrete Examples** (127–138) — the two `ring` examples + `end`

Sections stay contiguous over lines **1–138**; no theorem/insight content changed. meta.json 15.6 KB (under cap).