### PR TITLE
research(erdos-1204): characterize the vanishing locus of A(k)

### DIFF
--- a/proofs/Proofs/Erdos1204Problem.lean
+++ b/proofs/Proofs/Erdos1204Problem.lean
@@ -388,6 +388,43 @@ theorem A_one : A 1 = 0 := by
   refine Nat.le_zero.mp ?_
   simpa using A_le (a := ({0} : Finset ℕ)) (by simp) (admissible_singleton 0)
 
+/-- **`A(k)` is positive for `k ≥ 2`.** As soon as an admissible set must contain two
+distinct elements of the same parity (the prime-`2` constraint), its maximum is at least
+`2(k-1) ≥ 2 > 0` (`two_mul_sub_one_le_A`). This is the positive half of the vanishing
+characterization `A_eq_zero_iff`. -/
+theorem A_pos {k : ℕ} (hk : 2 ≤ k) : 0 < A k := by
+  have h := two_mul_sub_one_le_A k
+  omega
+
+/-- **Vanishing locus of `A`: `A(k) = 0 ↔ k ≤ 1`.** The empty set and the singleton `{0}`
+are the only admissible sets with maximum `0` (`A_zero`, `A_one`), and every admissible set
+of `k ≥ 2` elements is forced by the prime `2` to reach a maximum `≥ 2(k-1) ≥ 2`
+(`A_pos`). So `A` vanishes exactly on `{0, 1}` and is positive from `k = 2` onward. -/
+theorem A_eq_zero_iff (k : ℕ) : A k = 0 ↔ k ≤ 1 := by
+  constructor
+  · intro h
+    rcases Nat.lt_or_ge k 2 with hk | hk
+    · omega
+    · have := A_pos hk; omega
+  · intro hk
+    interval_cases k
+    · exact A_zero
+    · exact A_one
+
+/-- **`A(k) ≥ 2 ↔ k ≥ 2`.** The complement of the vanishing characterization
+`A_eq_zero_iff`: `A` reaches the first admissibility-forced value `2` exactly when
+`k ≥ 2`, matching `A 2 = 2` as the sharp base case (below that `A` is `0`). -/
+theorem two_le_A_iff (k : ℕ) : 2 ≤ A k ↔ 2 ≤ k := by
+  constructor
+  · intro h
+    rcases Nat.lt_or_ge k 2 with hk | hk
+    · have : A k = 0 := (A_eq_zero_iff k).mpr (by omega)
+      omega
+    · exact hk
+  · intro hk
+    have h := two_mul_sub_one_le_A k
+    omega
+
 /-- **`A(2) = 2`.** The upper bound comes from the admissible set `{0, 2}`. The lower
 bound `A(2) ≥ 2` is where admissibility first bites: the only `2`-set with maximum `1` is
 `{0, 1}`, which is *not* admissible, so the minimal maximum jumps from the packing value

--- a/research/problems/erdos-1204/knowledge.md
+++ b/research/problems/erdos-1204/knowledge.md
@@ -406,3 +406,22 @@ mathlib cache `.ir` earlier this session (see researcher-5 szemeredi note).
 ### Next rung
 prime 13 → 1·2·4·6·10·12 = 5760 classes mod 30030, slope 30030/5760 = 1001/192 ≈ 5.214. Same
 compositional-card template (NOT decide). Offset −5760 pushes the crossover to ~k≥60000.
+
+## Session 2026-07-11 (researcher-8) — vanishing locus of A(k)
+
+**Mode:** REVISIT (RICH, mature 0-axiom/0-sorry multi-file entry)
+**Outcome:** progress — 3 new verified structural lemmas in `Erdos1204Problem.lean`.
+
+Characterized the low structure of `A(k) = min a_k`:
+- `A_pos {k} (hk : 2 ≤ k) : 0 < A k` — positivity, from the prime-2 bound `2(k-1) ≤ A k`.
+- `A_eq_zero_iff (k) : A k = 0 ↔ k ≤ 1` — the exact vanishing locus (`A` is 0 only on
+  {0,1}: ∅ and {0}), positive from k=2 onward.
+- `two_le_A_iff (k) : 2 ≤ A k ↔ 2 ≤ k` — complement; `A` first hits the
+  admissibility-forced value 2 exactly at k=2 (sharp, matching `A 2 = 2`).
+
+All three follow cleanly from the existing `two_mul_sub_one_le_A`, `A_zero`, `A_one`.
+34 → 37 theorems; still 0 sorries / 0 axioms.
+
+**Verification:** host elan `lean` v4.26.0 (main Mathlib LEAN_PATH) — EXIT 0, no errors
+(one pre-existing `mul_le_mul_right'` deprecation warning at the primorial bound,
+unrelated). Docker build unusable this session (transient exit-135 SIGBUS).

--- a/src/data/research/problems/erdos-1204.json
+++ b/src/data/research/problems/erdos-1204.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (researcher-1, 2026-07-10): completed the divergence trilogy — added S_tendsto_atTop and B_tendsto_atTop to Erdos1204B.lean, the sum/average companions of the already-merged A_tendsto_atTop. All three extremal quantities of #1204 (min diameter A, min sum S, min average B) now provably →∞. S→∞ by domination A≤S; B→∞ by the k-1 lower bound. Sharp rates (A~k log k) remain OPEN. Verified local Lean v4.26.0 (B.lean untracked in meta → Lean-only).",
+    "progressSummary": "PROGRESS (researcher-8): characterized the low structure of A(k) — A_pos, A_eq_zero_iff (A k = 0 ↔ k ≤ 1), two_le_A_iff. 34→37 theorems in Erdos1204Problem.lean, still 0 sorries/0 axioms. Host-lean verified.",
     "builtItems": [
       "Erdos1204.Admissible (def) in Proofs/Erdos1204Problem.lean",
       "Erdos1204.missing_class_of_card_lt",
@@ -44,7 +44,8 @@
       "admissible_three_sup_ge: every admissible 3-set has max ≥ 6 (parity forces {0,2,4} or {1,3,5}, both inadmissible mod 3)",
       "not_admissible_zero_two_four / not_admissible_one_three_five / admissible_zero_two_six: supporting examples for A(3)",
       "Erdos1204Problem.lean: primorialUpTo k := ((range(k+1)).filter Nat.Prime).prod id + A_le_primorial (A k ≤ (k-1)*primorialUpTo k). Reuses the exists_admissible_card construction, adding the sup bound. 0 new axioms/sorries. Elaboration-clean; olean-write blocked by fleet SIGBUS-135.",
-      "Erdos1204B.lean: S_tendsto_atTop (Filter.tendsto_atTop_mono A_le_S A_tendsto_atTop) + B_tendsto_atTop (tendsto_atTop_mono` off sub_one_le_B eventual bound). 0 axioms/0 sorries; verified local Lean v4.26.0 (docker image build down, containerd meta.db I/O)."
+      "Erdos1204B.lean: S_tendsto_atTop (Filter.tendsto_atTop_mono A_le_S A_tendsto_atTop) + B_tendsto_atTop (tendsto_atTop_mono` off sub_one_le_B eventual bound). 0 axioms/0 sorries; verified local Lean v4.26.0 (docker image build down, containerd meta.db I/O).",
+      "A_pos / A_eq_zero_iff / two_le_A_iff (Erdos1204Problem.lean): characterized the vanishing locus of A(k)=min a_k — A vanishes exactly on {0,1} and is ≥2 from k=2 onward, from the prime-2 bound 2(k-1)≤A(k)"
     ],
     "insights": [
       "Admissibility is purely local: only the residue pattern mod each prime matters.",
@@ -56,7 +57,8 @@
       "A(k) equals the Hardy–Littlewood minimal diameter H(k) (by translation invariance min a_k = min diameter); so A(3)=H(3)=6, A(4)=H(4)=8, etc. — the exact-value frontier is computing successive H(k).",
       "Lower bound for A(3): the mod-2 admissibility constraint forces all three elements to share a parity, so within {0,..,5} the only candidates are {0,2,4} and {1,3,5}, both of which cover every class mod 3. This parity-then-residue pruning is the model for larger exact values.",
       "Formalized the explicit weak UPPER bound A(k) ≤ (k-1)·∏_{p≤k prime}p (A_le_primorial), previously only asserted in a docstring. Uses the arithmetic progression {0,N,2N,…,(k-1)N} with N=primorialUpTo k (product of primes ≤k): admissible because every element ≡0 mod each prime p≤k so class 1 is missed (larger primes automatic via missing_class_of_card_lt), k elements (injective ·*N since N>0), largest element (k-1)·N (Finset.sup_le, i*N≤(k-1)*N via mul_le_mul_right'), fed to A_le. This SANDWICHES A(k) between the parity lower bound 2(k-1) (two_mul_sub_one_le_A) and (k-1)·primorial — the elementary two-sided companion, far from the conjectured A(k)∼k log k (primorial grows like e^{(1+o(1))k}). Elaboration-clean [7743/7743] (olean-write SIGBUS-135).",
-      "Divergence extends from A to all three extremal quantities: S(k)→∞ (via A(k)≤S(k), A_le_S + A_tendsto_atTop domination) and B(k)→∞ (via k-1≤B(k), sub_one_le_B + (k:ℚ)-1→∞ eventual domination). No admissible k-tuple can keep its diameter, sum, OR average bounded as k→∞; the sharp rates all remain OPEN (sieve theory)."
+      "Divergence extends from A to all three extremal quantities: S(k)→∞ (via A(k)≤S(k), A_le_S + A_tendsto_atTop domination) and B(k)→∞ (via k-1≤B(k), sub_one_le_B + (k:ℚ)-1→∞ eventual domination). No admissible k-tuple can keep its diameter, sum, OR average bounded as k→∞; the sharp rates all remain OPEN (sieve theory).",
+      "The vanishing locus of A is exactly {0,1}: A(0)=A(1)=0 (∅ and {0}), while every admissible k-set with k≥2 is forced by the prime 2 to have maximum ≥2(k-1)≥2, so A is strictly positive from k=2."
     ],
     "mathlibGaps": [],
     "nextSteps": [


### PR DESCRIPTION
## Summary
Erdős #1204 (OPEN): a sequence `0 ≤ a_1 < ⋯ < a_k` is *admissible* if it misses at least one residue class mod every prime; `A(k) = min a_k`. The gallery entry (`Erdos1204Problem.lean`, 0-axiom / 0-sorry) already has monotonicity, `A 2 = 2`, `A 3 = 6`, the prime-2 lower bound `2(k-1) ≤ A(k)`, and the primorial upper bound — but the **vanishing locus of `A` was not characterized**. This PR pins it down.

## New theorems (3)
All follow cleanly from the existing `two_mul_sub_one_le_A`, `A_zero`, `A_one`:

- `A_pos {k} (hk : 2 ≤ k) : 0 < A k` — positivity from the prime-2 bound.
- `A_eq_zero_iff (k) : A k = 0 ↔ k ≤ 1` — `A` vanishes **exactly** on `{0,1}` (the empty set and `{0}`), positive from `k = 2` onward.
- `two_le_A_iff (k) : 2 ≤ A k ↔ 2 ≤ k` — the complement; `A` first reaches the admissibility-forced value `2` exactly at `k = 2` (sharp, matching `A 2 = 2`).

34 → 37 theorems; still **0 sorries, 0 axioms**.

## Verification
Type-checked with host elan `lean` v4.26.0 against `main`'s Mathlib `LEAN_PATH`: **EXIT 0**, no errors (one pre-existing `mul_le_mul_right'` deprecation warning at the primorial bound, unrelated to this change). The Docker build was unusable this session (transient exit-135 SIGBUS, an olean-volume false negative).

## Status
**Outcome**: progress (3 verified structural lemmas on an OPEN problem)
**Files modified**: `proofs/Proofs/Erdos1204Problem.lean`, `research/problems/erdos-1204/knowledge.md`, `src/data/research/problems/erdos-1204.json`

🤖 Generated by researcher-8