### PR TITLE
Enrich bezout-identity-oq-02-oq-01-oq-02-oq-04: close preamble coverage gap

### DIFF
--- a/src/data/proofs/bezout-identity-oq-02-oq-01-oq-02-oq-04/annotations.json
+++ b/src/data/proofs/bezout-identity-oq-02-oq-01-oq-02-oq-04/annotations.json
@@ -2,10 +2,10 @@
   {
     "id": "ann-header",
     "proofId": "bezout-identity-oq-02-oq-01-oq-02-oq-04",
-    "range": { "startLine": 1, "endLine": 31 },
+    "range": { "startLine": 1, "endLine": 39 },
     "type": "concept",
     "title": "OQ-04: Eisenstein in the UFD/Euclidean-Domain Framework",
-    "content": "**Module framing.** The parent (bezout-identity-oq-02-oq-01-oq-02, 'FTA Generalization to Euclidean Domains') asks as its fourth open question whether Eisenstein's criterion — a key application of the UFD framework — is in Mathlib and usable here. The answer is yes, and at greater generality than UFDs: Mathlib's `Polynomial.irreducible_of_eisenstein_criterion` works at any prime ideal of any commutative ring. This file packages it into the clean headline that $X^n - p$ is irreducible over $R[X]$ for any integral domain $R$ and prime $p$, then specializes the domain to exhibit the criterion over $\\mathbb{Z}$ and over the Euclidean domain $\\mathbb{Q}[X]$ (the parent's own theme). Zero axioms, imports only Mathlib.",
+    "content": "**Module framing.** The parent (bezout-identity-oq-02-oq-01-oq-02, 'FTA Generalization to Euclidean Domains') asks as its fourth open question whether Eisenstein's criterion — a key application of the UFD framework — is in Mathlib and usable here. The answer is yes, and at greater generality than UFDs: Mathlib's `Polynomial.irreducible_of_eisenstein_criterion` works at any prime ideal of any commutative ring. This file packages it into the clean headline that $X^n - p$ is irreducible over $R[X]$ for any integral domain $R$ and prime $p$, then specializes the domain to exhibit the criterion over $\\mathbb{Z}$ and over the Euclidean domain $\\mathbb{Q}[X]$ (the parent's own theme). The preamble is minimal: the single blanket `import Mathlib` (gallery convention), `open Polynomial` to bring in the `X`, `C`, `coeff`, `degree` notation the statements use, and the enclosing namespace. Zero axioms.",
     "mathContext": "Eisenstein at a prime ideal $\\mathfrak{p}$: if all non-leading coefficients lie in $\\mathfrak{p}$, the leading does not, and the constant is not in $\\mathfrak{p}^2$, then the primitive polynomial is irreducible.",
     "significance": "supporting",
     "relatedConcepts": [

--- a/src/data/proofs/enrichment-tracker.json
+++ b/src/data/proofs/enrichment-tracker.json
@@ -7102,6 +7102,11 @@
       "passes": 1,
       "lastEnriched": "2026-07-12T04:30:00Z",
       "quality": 96
+    },
+    "bezout-identity-oq-02-oq-01-oq-02-oq-04": {
+      "passes": 1,
+      "lastEnriched": "2026-07-12T04:48:00Z",
+      "quality": 96
     }
   }
 }


### PR DESCRIPTION
Enrichment pass for `bezout-identity-oq-02-oq-01-oq-02-oq-04` (Eisenstein's criterion; quality 96, passes 0). Near-saturated entry — the only gap was the import/`open Polynomial`/namespace preamble (lines 32–39), between the header annotation (ended 31) and the main-theorem annotation (starts 40). Extended the header annotation `31 → 39` (it already discussed the imports), noting why `open Polynomial` is needed. Coverage now contiguous `1–108`. Tracker bumped in-PR. `tsc --noEmit` clean; no meta changes; status unchanged (verified, 0 axioms).