### PR TITLE
research(shannon-entropy-oq-03-incomplete-01): symmetry of conditional mutual information I(X;Z|Y)=I(Z;X|Y)

### DIFF
--- a/proofs/Proofs/ShannonEntropySSAEq.lean
+++ b/proofs/Proofs/ShannonEntropySSAEq.lean
@@ -600,4 +600,75 @@ theorem conditioning_reduces_entropy_eq_iff {α β γ : Type*}
   · intro h; linarith
   · intro h; linarith
 
+-- ═══════════════════════════════════════════════════════════════
+-- PART VI: Symmetry of conditional mutual information  I(X;Z|Y) = I(Z;X|Y)
+-- ═══════════════════════════════════════════════════════════════
+
+/-- Flatten a triple `Finset`-sum over `α × β × γ` into a single sum over the
+    product type, so that a coordinate permutation becomes an `Equiv` reindexing. -/
+private lemma triple_sum_prod {α β γ : Type*}
+    [Fintype α] [Fintype β] [Fintype γ] (f : α → β → γ → ℝ) :
+    (∑ x : α, ∑ y : β, ∑ z : γ, f x y z)
+      = ∑ w : α × β × γ, f w.1 w.2.1 w.2.2 := by
+  rw [Fintype.sum_prod_type]
+  refine Finset.sum_congr rfl fun x _ => ?_
+  rw [Fintype.sum_prod_type]
+
+/-- The `X ↔ Z` reflection of a joint law: `reflectXZ p (z,y,x) = p (x,y,z)`.
+    Reflecting the law and re-reading it as a law on `Z – Y – X` swaps the two
+    outer marginals (`marginalXY ↔ marginalYZ`) while fixing the middle marginal
+    `marginalY_3`; it is the joint distribution of `(Z, Y, X)`. -/
+noncomputable def reflectXZ {α β γ : Type*}
+    (pXYZ : α × β × γ → ℝ) : γ × β × α → ℝ :=
+  fun q => pXYZ (q.2.2, q.2.1, q.1)
+
+/-- **Symmetry of conditional mutual information.**  `I(X;Z|Y) = I(Z;X|Y)`:
+    the conditional mutual information is invariant under exchanging the two outer
+    variables `X` and `Z`.  Concretely, reflecting the joint law by
+    `(z,y,x) ↦ (x,y,z)` leaves `cmiSum` unchanged.  Combined with
+    `ssa_deficit_eq_cmi`, this says the strong-subadditivity deficit
+    `H(X,Y) + H(Y,Z) − H(X,Y,Z) − H(Y)` is symmetric in `X` and `Z` — as it must
+    be, since `H(X,Y,Z) = H(Z,Y,X)` and the middle marginal `H(Y)` is fixed while
+    the two outer marginals merely swap.  The proof reindexes the defining triple
+    sum by the coordinate transposition; the summand is invariant because its
+    numerator `p·p_Y` is symmetric and its denominator `p_{XY}·p_{YZ}` only
+    commutes. -/
+theorem cmiSum_reflectXZ {α β γ : Type*}
+    [Fintype α] [Fintype β] [Fintype γ]
+    (pXYZ : α × β × γ → ℝ) :
+    cmiSum (reflectXZ pXYZ) = cmiSum pXYZ := by
+  unfold cmiSum
+  dsimp only [reflectXZ]
+  rw [triple_sum_prod, triple_sum_prod]
+  refine (Fintype.sum_equiv
+    { toFun := fun (w : α × β × γ) => (w.2.2, w.2.1, w.1)
+      invFun := fun (w : γ × β × α) => (w.2.2, w.2.1, w.1)
+      left_inv := fun ⟨_, _, _⟩ => rfl
+      right_inv := fun ⟨_, _, _⟩ => rfl } _ _ ?_).symm
+  rintro ⟨x, y, z⟩
+  dsimp only [Equiv.coe_fn_mk]
+  by_cases h : pXYZ (x, y, z) = 0
+  · simp [h]
+  · rw [if_neg h, if_neg h]
+    exact congrArg (fun t => pXYZ (x, y, z) * Real.log t)
+      (by rw [show (∑ x' : γ, ∑ z' : α, pXYZ (z', y, x'))
+                   = ∑ x' : α, ∑ z' : γ, pXYZ (x', y, z') from Finset.sum_comm]; ring)
+
+/-- **Symmetry of the strong-subadditivity deficit.**  The SSA deficit is
+    unchanged under swapping the roles of the outer variables `X` and `Z`, stated
+    at the level of Shannon entropies of the reflected law.  This is the
+    entropy-side reading of `cmiSum_reflectXZ`. -/
+theorem ssa_deficit_reflectXZ {α β γ : Type*}
+    [Fintype α] [Fintype β] [Fintype γ]
+    [DecidableEq α] [DecidableEq β] [DecidableEq γ]
+    {pXYZ : α × β × γ → ℝ} (hp : ∀ xyz, 0 ≤ pXYZ xyz) :
+    shannonEntropy' (marginalXY (reflectXZ pXYZ))
+        + shannonEntropy' (marginalYZ (reflectXZ pXYZ))
+        - shannonEntropy' (reflectXZ pXYZ)
+        - shannonEntropy' (marginalY_3 (reflectXZ pXYZ))
+      = shannonEntropy' (marginalXY pXYZ) + shannonEntropy' (marginalYZ pXYZ)
+        - shannonEntropy' pXYZ - shannonEntropy' (marginalY_3 pXYZ) := by
+  have hpr : ∀ xyz, 0 ≤ reflectXZ pXYZ xyz := fun _ => hp _
+  rw [ssa_deficit_eq_cmi hpr, ssa_deficit_eq_cmi hp, cmiSum_reflectXZ]
+
 end InformationTheory

--- a/src/data/proofs/shannon-entropy-oq-03-oq-01/meta.json
+++ b/src/data/proofs/shannon-entropy-oq-03-oq-01/meta.json
@@ -146,10 +146,10 @@
       "Finset"
     ],
     "namespace": "InformationTheory",
-    "lineCount": 603,
+    "lineCount": 674,
     "axiomCount": 0,
-    "theoremCount": 9,
-    "definitionCount": 5,
+    "theoremCount": 12,
+    "definitionCount": 6,
     "path": "Proofs/ShannonEntropySSAEq.lean",
     "sorries": 0
   },
@@ -171,6 +171,18 @@
       "type": "core",
       "description": "SSA holds with equality iff X–Y–Z is a Markov chain",
       "leanType": "(shannonEntropy' pXYZ + shannonEntropy' (marginalY_3 pXYZ) = shannonEntropy' (marginalXY pXYZ) + shannonEntropy' (marginalYZ pXYZ)) ↔ (∀ x y z, pXYZ (x,y,z) * marginalY_3 pXYZ y = marginalXY pXYZ (x,y) * marginalYZ pXYZ (y,z))"
+    },
+    {
+      "name": "cmiSum_reflectXZ",
+      "type": "core",
+      "description": "Symmetry of conditional mutual information: I(X;Z|Y) = I(Z;X|Y); reflecting the joint law by (z,y,x) to (x,y,z) leaves cmiSum invariant",
+      "leanType": "cmiSum (reflectXZ pXYZ) = cmiSum pXYZ"
+    },
+    {
+      "name": "ssa_deficit_reflectXZ",
+      "type": "supporting",
+      "description": "The strong-subadditivity deficit is symmetric under swapping the outer variables X and Z, stated on Shannon entropies of the reflected law",
+      "leanType": "shannonEntropy' (marginalXY (reflectXZ pXYZ)) + shannonEntropy' (marginalYZ (reflectXZ pXYZ)) - shannonEntropy' (reflectXZ pXYZ) - shannonEntropy' (marginalY_3 (reflectXZ pXYZ)) = shannonEntropy' (marginalXY pXYZ) + shannonEntropy' (marginalYZ pXYZ) - shannonEntropy' pXYZ - shannonEntropy' (marginalY_3 pXYZ)"
     }
   ],
   "sorries": 0

--- a/src/data/research/problems/shannon-entropy-oq-03-incomplete-01.json
+++ b/src/data/research/problems/shannon-entropy-oq-03-incomplete-01.json
@@ -35,16 +35,18 @@
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETE: the premise (a remaining SSA sorry) is FALSE — SSA is fully proven in ShannonEntropy.lean (strong_subadditivity). Every thread is now closed on main: (1) the SSA EQUALITY CONDITION (Markov-chain characterization) shipped as self-contained ShannonEntropySSAEq.lean → gallery shannon-entropy-oq-03-oq-01; (2) #35820 added the self-contained SSA inequality (cmiSum_nonneg + ssa_inequality) to that same file; (3) ShannonEntropySSA.lean (gallery oq-03) was REPAIRED — the old dup-decl conflict is gone, it now sits in namespace InformationTheory.SSA, re-exports the verified parent SSA, and adds conditioning_reduces_entropy_general + conditional_mi_nonneg (axiom-free). The 'broken file / repoint gallery' Mechanic nextStep is therefore already done and needs no action.",
+    "progressSummary": "COMPLETE (main SSA inequality + equality/Markov characterization proven axiom-free). This session added the structural SYMMETRY of conditional mutual information I(X;Z|Y)=I(Z;X|Y) (cmiSum_reflectXZ) and its entropy-side deficit form (ssa_deficit_reflectXZ) to gallery oq-03-oq-01. Only remaining open direction is a quantitative/stability (Pinsker-type) SSA, blocked on Mathlib Pinsker usability.",
     "builtItems": [
-      "cmiSum def + ssa_deficit_eq_cmi + ssa_cmi_eq_zero_iff + strong_subadditivity_eq_iff + cmiSum_nonneg + ssa_inequality (#35820) in Proofs/ShannonEntropySSAEq.lean (self-contained, 0 sorry/0 axiom)"
+      "cmiSum def + ssa_deficit_eq_cmi + ssa_cmi_eq_zero_iff + strong_subadditivity_eq_iff + cmiSum_nonneg + ssa_inequality (#35820) in Proofs/ShannonEntropySSAEq.lean (self-contained, 0 sorry/0 axiom)",
+      "reflectXZ def + cmiSum_reflectXZ (I(X;Z|Y)=I(Z;X|Y), symmetry of CMI) + ssa_deficit_reflectXZ (SSA deficit symmetric in X,Z on entropy side) in Proofs/ShannonEntropySSAEq.lean (axiom-free [propext,Classical.choice,Quot.sound]); helper private lemma triple_sum_prod flattens triple Finset-sum to product for equiv reindexing"
     ],
     "insights": [
       "Suggested proof route: rewrite the entropy deficit as conditional mutual information and discharge nonnegativity via KL divergence.",
       "ShannonEntropySSA.lean was REPAIRED (no longer conflicts): it now uses namespace InformationTheory.SSA, imports and re-exports the parent's verified strong_subadditivity, and adds two three-variable corollaries (conditioning_reduces_entropy_general, conditional_mi_nonneg); axiom-free. Historical note: an older revision re-declared marginalXY/marginalYZ/strong_subadditivity in the parent's namespace and failed to elaborate. SSA is genuinely proven in ShannonEntropy.lean.",
       "SSA deficit = conditional mutual information I(X;Z|Y) exactly (ssa_deficit_eq_cmi).",
       "I(X;Z|Y)=0 iff the division-free Markov factorization p·p_Y = p_XY·p_YZ holds everywhere; forward via the STRICT KL bound, backward by substitution.",
-      "v4.26.0: `hp _` underscore fails to infer in single_le_sum hint lists (need explicit triples); local universe-poly `have` leaks a 4th universe param (extract top-level); conv `ext y` fails on Finset.sum."
+      "v4.26.0: `hp _` underscore fails to infer in single_le_sum hint lists (need explicit triples); local universe-poly `have` leaks a 4th universe param (extract top-level); conv `ext y` fails on Finset.sum.",
+      "Conditional mutual information is symmetric in its outer arguments: I(X;Z|Y) = I(Z;X|Y). Formalized as cmiSum_reflectXZ — reflecting the joint law by (z,y,x)↦(x,y,z) leaves cmiSum invariant. The defining summand is invariant because its numerator p·p_Y is symmetric and its denominator p_XY·p_YZ merely commutes; proof reindexes the triple sum by the X↔Z coordinate transposition (Fintype.sum_equiv over α×β×γ ≃ γ×β×α)."
     ],
     "mathlibGaps": [
       "No SSA equality-case lemma in Mathlib; KL equality (klDivergence_eq_zero_iff) exists in ShannonEntropy.lean but is private and the file conflicts."


### PR DESCRIPTION
## Summary

Adds the structural **symmetry of conditional mutual information** to the self-contained SSA equality-condition file (`ShannonEntropySSAEq.lean`, gallery entry `shannon-entropy-oq-03-oq-01`).

The file already establishes the SSA *inequality* (`ssa_inequality`, `cmiSum_nonneg`) and characterizes *when* the deficit `I(X;Z|Y)` vanishes (Markov-chain factorization, `strong_subadditivity_eq_iff`). This session adds the complementary structural fact that the conditional mutual information is **symmetric in its two outer arguments**:

| Theorem | Statement |
|---------|-----------|
| `cmiSum_reflectXZ` | `cmiSum (reflectXZ pXYZ) = cmiSum pXYZ`  — i.e. `I(X;Z|Y) = I(Z;X|Y)` |
| `ssa_deficit_reflectXZ` | the SSA deficit `H(X,Y)+H(Y,Z)−H(X,Y,Z)−H(Y)` is invariant under swapping `X` and `Z`, on the Shannon-entropy side |

`reflectXZ p (z,y,x) = p (x,y,z)` is the `(Z,Y,X)` reflection of the joint law. The defining summand is invariant because its numerator `p·p_Y` is symmetric and its denominator `p_XY·p_YZ` merely commutes; the proof reindexes the defining triple sum by the `X↔Z` coordinate transposition via `Fintype.sum_equiv` over `α×β×γ ≃ γ×β×α`, with a small helper `triple_sum_prod` flattening the nested sum to a product sum.

## Verification

- **Axiom-free**: `#print axioms` → `[propext, Classical.choice, Quot.sound]` for both new theorems (no `sorryAx`, no `Lean.ofReduceBool`).
- Compiles cleanly via host `elan lean` v4.26.0, EXIT=0, no warnings. (Docker builds hit a transient `exit-135` SIGBUS / olean-cache corruption, unrelated to the proof.)
- `ShannonEntropySSAEq.lean`: 603 → 674 lines; `theoremCount` 9 → 12; `definitionCount` 5 → 6; still 0 sorries / 0 axioms.

## Files

- `proofs/Proofs/ShannonEntropySSAEq.lean` — new PART VI (symmetry).
- `src/data/proofs/shannon-entropy-oq-03-oq-01/meta.json` — counts + two new `mainTheorems`.
- `src/data/research/problems/shannon-entropy-oq-03-incomplete-01.json` — knowledge update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)