### PR TITLE
research(burnside-counting-oq-02): prime Pólya sum + necklace proof of Fermat's Little Theorem

### DIFF
--- a/proofs/Proofs/BurnsideCountingOQ03.lean
+++ b/proofs/Proofs/BurnsideCountingOQ03.lean
@@ -497,6 +497,90 @@ theorem fp_sum_binary4_kernel :
       polya_cyclic_fixed_count, polya_cyclic_fixed_count]
   decide
 
+/-! ## §9: Prime Specialization and the Necklace Proof of Fermat's Little Theorem
+
+For a **prime** length `p` the reindexing identity `polya_sum_identity` collapses to a
+two-term sum, because `divisors p = {1, p}`. This yields the closed form
+  `Σ_{r : Fin p} k^gcd(r, p) = kᵖ + (p − 1)·k`
+(the identity rotation `r = 0` contributes `k^gcd(0,p) = kᵖ`; each of the `p − 1` nonzero
+rotations is coprime to `p` and contributes `k^1 = k`).
+
+Feeding this closed form into Burnside's lemma gives the classical *combinatorial* proof of
+Fermat's little theorem: since the number of `k`-colored necklaces of prime length `p` is an
+integer (it counts orbits), `p ∣ kᵖ + (p − 1)k`, and as `(p − 1)k = pk − k` this forces
+`p ∣ kᵖ − k`. Crucially the divisibility is supplied by the orbit count (Burnside's lemma),
+**not** by any number-theoretic lemma such as `ZMod.pow_card` — here Fermat's little theorem is
+a *consequence* of the counting, not an input to it. -/
+
+/-- **Prime specialization of the Pólya sum.** For a prime `p`, the divisor sum of
+    `polya_sum_identity` has only the two terms `d = 1` and `d = p`, giving the closed form
+      `Σ_{r : Fin p} k^gcd(r, p) = kᵖ + (p − 1)·k`. -/
+theorem polya_sum_prime (p k : ℕ) (hp : p.Prime) :
+    ∑ r : Fin p, k ^ Nat.gcd r.val p = k ^ p + (p - 1) * k := by
+  rw [polya_sum_identity p k hp.pos, hp.divisors, Finset.sum_pair hp.one_lt.ne,
+      Nat.div_one, Nat.div_self hp.pos, Nat.totient_prime hp, Nat.totient_one,
+      pow_one, one_mul]
+  exact Nat.add_comm _ _
+
+/-- The prime specialization at `p = 3, k = 2`: `Σ_{r : Fin 3} 2^gcd(r,3) = 2³ + 2·2 = 12`.
+    A direct numeric instance of `polya_sum_prime` (no `native_decide`). -/
+theorem polya_sum_three_binary : ∑ r : Fin 3, (2 : ℕ) ^ Nat.gcd r.val 3 = 12 :=
+  polya_sum_prime 3 2 (by norm_num)
+
+/-- **Fermat's Little Theorem via necklace counting (Burnside ⇒ FLT).**
+    Suppose Burnside's lemma holds for the `Z_p` rotation action on `k`-colorings, i.e. the
+    fixed-point sum equals `p · necklace_count` for some `necklace_count : ℕ` (the number of
+    orbits). Then `p ∣ kᵖ − k`.
+
+    This is the classical combinatorial proof of Fermat's little theorem. By `polya_sum_prime`
+    the fixed-point sum is `kᵖ + (p − 1)k`, so `p ∣ kᵖ + (p − 1)k`; rewriting
+    `(p − 1)k + k = p·k` and cancelling the `p·k` term gives `p ∣ kᵖ − k`. The divisibility
+    input is the orbit count alone; no `ZMod.pow_card` or other number-theoretic fact is used. -/
+theorem fermat_little_of_burnside (p k : ℕ) [NeZero p] (hp : p.Prime)
+    (necklace_count : ℕ)
+    (h_burnside : p * necklace_count =
+      ∑ r : Fin p, Fintype.card {c : Fin p → Fin k // IsFixed p k r c}) :
+    p ∣ k ^ p - k := by
+  -- The fixed-point sum equals `p · necklace_count` and (by `polya_sum_prime`) `kᵖ + (p−1)k`.
+  have hsum : ∑ r : Fin p, k ^ Nat.gcd r.val p = p * necklace_count := by
+    rw [h_burnside]
+    exact Finset.sum_congr rfl (fun r _ => (polya_cyclic_fixed_count p k r).symm)
+  have hdvd : p ∣ k ^ p + (p - 1) * k := by
+    rw [← polya_sum_prime p k hp, hsum]; exact dvd_mul_right p necklace_count
+  -- Arithmetic: `kᵖ + (p−1)k = (kᵖ − k) + p·k`, using `k ≤ kᵖ` and `(p−1)k + k = p·k`.
+  have hk : k ≤ k ^ p := Nat.le_self_pow hp.pos.ne' k
+  have hpm : (p - 1) * k + k = p * k := by
+    cases p with
+    | zero => exact (hp.pos.ne' rfl).elim
+    | succ q => rw [Nat.add_sub_cancel, add_mul, one_mul]
+  have heq : k ^ p + (p - 1) * k = (k ^ p - k) + p * k := by omega
+  rw [heq] at hdvd
+  exact (dvd_add_right (dvd_mul_right p k)).mp (by rwa [Nat.add_comm] at hdvd)
+
+/-! ## §10: Binary 6-Necklaces (concrete `n = 6` instance, OEIS A000031(6) = 14) -/
+
+/-- Pólya fixed-point sum for `Z_6` on binary colorings:
+    `Σ_{r : Fin 6} 2^gcd(r,6) = 2⁶ + 2¹ + 2² + 2³ + 2² + 2¹ = 64+2+4+8+4+2 = 84`. -/
+theorem polya_sum_Z6_binary : ∑ r : Fin 6, (2 : ℕ) ^ Nat.gcd r.val 6 = 84 := by
+  native_decide
+
+/-- Divisor-sum form for `n = 6, k = 2`:
+    `Σ_{d | 6} φ(6/d)·2^d = φ(6)·2 + φ(3)·4 + φ(2)·8 + φ(1)·64 = 4+8+8+64 = 84`. -/
+theorem polya_divisor_sum_Z6_binary :
+    ∑ d ∈ Nat.divisors 6, Nat.totient (6 / d) * 2 ^ d = 84 := by
+  native_decide
+
+/-- The two formulations agree for `n = 6, k = 2`. -/
+theorem polya_sum_equiv_6_2 :
+    ∑ r : Fin 6, (2 : ℕ) ^ Nat.gcd r.val 6 =
+    ∑ d ∈ Nat.divisors 6, Nat.totient (6 / d) * 2 ^ d := by
+  native_decide
+
+/-- The Pólya formula gives `84 / 6 = 14` binary necklaces of length 6 (OEIS A000031). -/
+theorem polya_binary6_necklace_count :
+    (∑ r : Fin 6, (2 : ℕ) ^ Nat.gcd r.val 6) / 6 = 14 := by
+  simp [polya_sum_Z6_binary]
+
 #check @MulAction.sum_card_fixedBy_eq_card_orbits_mul_card_group
 #check ZMod.addOrderOf_coe
 #check ZMod.natCast_zmod_val

--- a/proofs/Proofs/BurnsideCountingOQ03.lean
+++ b/proofs/Proofs/BurnsideCountingOQ03.lean
@@ -556,7 +556,7 @@ theorem fermat_little_of_burnside (p k : ℕ) [NeZero p] (hp : p.Prime)
   have heq : k ^ p + (p - 1) * k = (k ^ p - k) + p * k := by omega
   rw [heq] at hdvd
   -- Cancel the `p·k` term: `p ∣ (kᵖ − k) + p·k` and `p ∣ p·k` give `p ∣ kᵖ − k`.
-  simpa using Nat.dvd_sub' hdvd (dvd_mul_right p k)
+  simpa using Nat.dvd_sub hdvd (dvd_mul_right p k)
 
 /-! ## §10: Binary 6-Necklaces (concrete `n = 6` instance, OEIS A000031(6) = 14) -/
 

--- a/proofs/Proofs/BurnsideCountingOQ03.lean
+++ b/proofs/Proofs/BurnsideCountingOQ03.lean
@@ -555,7 +555,8 @@ theorem fermat_little_of_burnside (p k : ℕ) [NeZero p] (hp : p.Prime)
     | succ q => rw [Nat.add_sub_cancel, add_mul, one_mul]
   have heq : k ^ p + (p - 1) * k = (k ^ p - k) + p * k := by omega
   rw [heq] at hdvd
-  exact (dvd_add_right (dvd_mul_right p k)).mp (by rwa [Nat.add_comm] at hdvd)
+  -- Cancel the `p·k` term: `p ∣ (kᵖ − k) + p·k` and `p ∣ p·k` give `p ∣ kᵖ − k`.
+  simpa using Nat.dvd_sub' hdvd (dvd_mul_right p k)
 
 /-! ## §10: Binary 6-Necklaces (concrete `n = 6` instance, OEIS A000031(6) = 14) -/
 

--- a/src/data/proofs/burnside-counting-oq-03/meta.json
+++ b/src/data/proofs/burnside-counting-oq-03/meta.json
@@ -111,6 +111,30 @@
       "endLine": 402,
       "summary": "Derives 6 binary 4-necklaces (24/4 = 6). States polya_necklace_formula_statement: assuming Burnside and the fixed-point formula, conclude n · necklace_count = Σ k^gcd(r,n).",
       "mathContext": "$\\#\\text{necklaces}(4,2) = 24/4 = 6$. General: $n \\cdot \\#\\text{necklaces}(n,k) = \\sum_{r=0}^{n-1} k^{\\gcd(r,n)} = \\sum_{d \\mid n} \\varphi(n/d) \\cdot k^d$."
+    },
+    {
+      "id": "sec-fixedpoint-corollaries",
+      "title": "§8: General Fixed-Point Corollaries (kernel-checked)",
+      "startLine": 441,
+      "endLine": 499,
+      "summary": "Kernel-checked specializations of polya_cyclic_fixed_count (no native_decide): the identity rotation fixes kⁿ colorings (fixed_count_identity), a coprime step fixes exactly the k constant colorings (fixed_count_of_coprime), each fixed count divides kⁿ and lies in [k, kⁿ], and fp_sum_binary4_kernel re-proves 16+2+4+2=24 without Lean.ofReduceBool.",
+      "mathContext": "$|\\mathrm{Fix}(r)| = k^{\\gcd(r,n)}$, with $\\gcd(0,n)=n$ giving $k^n$ and $\\gcd(r,n)=1$ giving $k$; $k \\le |\\mathrm{Fix}(r)| \\le k^n$ and $|\\mathrm{Fix}(r)| \\mid k^n$."
+    },
+    {
+      "id": "sec-prime-fermat",
+      "title": "§9: Prime Specialization and the Necklace Proof of Fermat's Little Theorem",
+      "startLine": 500,
+      "endLine": 560,
+      "summary": "For prime p the divisor sum collapses to a two-term closed form polya_sum_prime: Σ_{r:Fin p} k^gcd(r,p) = kᵖ + (p−1)·k (r=0 gives kᵖ, the p−1 nonzero rotations are coprime and each give k). fermat_little_of_burnside then gives the classical combinatorial proof of Fermat's little theorem: Burnside's lemma (fixed-point sum = p·necklace_count) forces p ∣ kᵖ − k with NO number-theoretic input (no ZMod.pow_card); FLT is a consequence of the orbit count, not an input. polya_sum_three_binary is the p=3,k=2 instance (=12).",
+      "mathContext": "$\\sum_{r=0}^{p-1} k^{\\gcd(r,p)} = k^p + (p-1)k$ for prime $p$; Burnside gives $p \\mid p\\cdot\\#\\text{necklaces} = k^p+(p-1)k$, and since $(p-1)k = pk-k$ this yields $p \\mid k^p - k$."
+    },
+    {
+      "id": "sec-necklaces6",
+      "title": "§10: Binary 6-Necklaces (OEIS A000031(6) = 14)",
+      "startLine": 561,
+      "endLine": 585,
+      "summary": "Concrete n=6 instance: polya_sum_Z6_binary (Σ 2^gcd(r,6) = 84), its divisor-sum form, their agreement, and polya_binary6_necklace_count (84/6 = 14 binary necklaces of length 6, OEIS A000031).",
+      "mathContext": "$\\sum_{r=0}^{5} 2^{\\gcd(r,6)} = 2^6+2+2^2+2^3+2^2+2 = 84$ and $\\sum_{d\\mid 6}\\varphi(6/d)2^d = 84$, giving $84/6 = 14$ necklaces."
     }
   ],
   "overview": {
@@ -206,12 +230,12 @@
     }
   ],
   "leanFile": {
-    "lineCount": 445,
+    "lineCount": 589,
     "path": "Proofs/BurnsideCountingOQ03.lean",
     "axiomCount": 0,
     "sorries": 0,
     "definitionCount": 1,
-    "theoremCount": 26,
+    "theoremCount": 32,
     "additionalFiles": [
       "Proofs/BurnsideCountingOQ03Aristotle.lean",
       {


### PR DESCRIPTION
## Summary

Extends `proofs/Proofs/BurnsideCountingOQ03.lean` — the designated clean source for the `burnside-counting-oq-02` gallery entry (per its research problem JSON) — with the **prime specialization** of the general Pólya reindexing identity and its number-theoretic payoff, the classic **necklace proof of Fermat's Little Theorem**.

The file already proved the general identity `Σ_{r:Fin n} k^gcd(r,n) = Σ_{d|n} φ(n/d)·k^d` (`polya_sum_identity`). This PR specializes it to prime length and draws out the FLT consequence.

## New theorems (§9–§10)

- **`polya_sum_prime`** — for prime `p`, the divisor sum collapses to the closed form
  `Σ_{r:Fin p} k^gcd(r,p) = kᵖ + (p−1)·k`
  (the identity rotation contributes `kᵖ`; each of the `p−1` coprime nonzero rotations contributes `k`). Kernel-checked.
- **`fermat_little_of_burnside`** — the classical combinatorial proof of Fermat's Little Theorem: if Burnside's lemma holds for the `Z_p` action (fixed-point sum `= p·necklace_count`), then `p ∣ kᵖ − k`. Divisibility comes purely from the orbit count — **no number-theoretic input** (no `ZMod.pow_card`); FLT is a *consequence* of the counting, not an input. Kernel-checked.
- **`polya_sum_three_binary`** — numeric instance `p=3, k=2` (= 12), via `polya_sum_prime` (no `native_decide`).
- **`polya_sum_Z6_binary` / `polya_divisor_sum_Z6_binary` / `polya_sum_equiv_6_2` / `polya_binary6_necklace_count`** — concrete length-6 binary necklace count = **14** (OEIS A000031), in both fixed-point and divisor-sum forms.

## Verification

Built and checked with host `elan lean` v4.26.0 against the pinned Mathlib (the docker wrapper hit a transient native-codegen `exit 135` SIGBUS, unrelated to the proof; host Lean builds the entire file including all `native_decide` cleanly).

Axiom profile (`#print axioms`):
- `polya_sum_prime`, `fermat_little_of_burnside`, `polya_sum_three_binary`: `[propext, Classical.choice, Quot.sound]` — fully kernel-checked, no `ofReduceBool`.
- `polya_binary6_necklace_count` (and the other length-6 concretes): carry `Lean.ofReduceBool` via `native_decide`, consistent with the file's existing §4/§5.

0 new `sorry`, 0 new `axiom` declarations. Gallery status/badge (`axiomatized`/`axiom`, from the pre-existing `native_decide`) is unchanged.

## Gallery metadata

Synced `src/data/proofs/burnside-counting-oq-03/meta.json`: `leanFile.theoremCount` 26→32, `lineCount` 445→589 (the meta was already stale relative to the §8 additions on main), and added §8/§9/§10 section entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)