### PR TITLE
Enrich combinations-formula-oq-03-oq-04: annotations, conclusion, references, crossRefs

### DIFF
--- a/src/data/proofs/combinations-formula-oq-03-oq-04/annotations.json
+++ b/src/data/proofs/combinations-formula-oq-03-oq-04/annotations.json
@@ -1,0 +1,119 @@
+[
+  {
+    "id": "ann-qbinom-palindromy-overview",
+    "proofId": "combinations-formula-oq-03-oq-04",
+    "range": { "startLine": 3, "endLine": 43 },
+    "type": "concept",
+    "title": "Palindromy: the symmetric half of Sylvester's theorem",
+    "content": "The module docstring frames the target. The Gaussian binomial [n,k]_q is a polynomial in q of degree k(n-k) with nonnegative integer coefficients; Sylvester (1878) proved its coefficient sequence is symmetric AND unimodal. This file formalizes only the symmetric (palindromic) half — the elementary precursor — and is scrupulously honest that unimodality (the hard half, Proctor 1982 via sl₂) is NOT proved. Over a field, palindromy is packaged as the algebraic identity below rather than as a coefficient statement, which keeps the whole proof inside elementary power arithmetic.",
+    "mathContext": "$\\genfrac{[}{]}{0pt}{}{n}{k}_q = q^{k(n-k)}\\,\\genfrac{[}{]}{0pt}{}{n}{k}_{q^{-1}}$, i.e. $a_j = a_{k(n-k)-j}$ for the coefficient sequence.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Gaussian q-binomial coefficient",
+      "Sylvester's unimodality theorem (1878)",
+      "palindromic (self-reciprocal) polynomial",
+      "honest scoping of partial progress"
+    ],
+    "prerequisites": [
+      "q-binomial coefficients (parent combinations-formula-oq-03)",
+      "polynomial degree and coefficient symmetry"
+    ]
+  },
+  {
+    "id": "ann-qbinom-field-setup",
+    "proofId": "combinations-formula-oq-03-oq-04",
+    "range": { "startLine": 45, "endLine": 49 },
+    "type": "definition",
+    "title": "Working over a field so q⁻¹ exists",
+    "content": "The namespace opens `Nat` and fixes `[Field R]`. The field hypothesis is not cosmetic: the reflection substitutes q ↦ q⁻¹, so q must be invertible to even state the identity, and the closing cancellation q^{k+1}·(q⁻¹)^{k+1} = 1 needs a genuine inverse. Over a general commutative ring one would instead phrase palindromy as a polynomial coefficient-reversal; the field formulation trades that generality for a short, purely arithmetic proof.",
+    "mathContext": "$R$ a field, $q \\in R$ with $q \\neq 0$ so that $q^{-1}$ and $q^{k}\\,(q^{-1})^{k} = 1$ make sense.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "field of fractions vs polynomial reversal",
+      "invertibility of q",
+      "q-binomial over a commutative ring (parent)"
+    ],
+    "prerequisites": [
+      "fields and multiplicative inverses",
+      "the parent's ring-level q-binomial definition"
+    ]
+  },
+  {
+    "id": "ann-qbinom-reciprocal-main",
+    "proofId": "combinations-formula-oq-03-oq-04",
+    "range": { "startLine": 51, "endLine": 104 },
+    "type": "theorem",
+    "title": "qBinom_reciprocal: the palindromy identity by induction on n",
+    "content": "The headline theorem, proved by well-founded recursion on (n,k). Boundary cases are direct: k=0 and k>n both simp away, and the diagonal k=n makes both q-binomials equal 1. The generic interior case k<n is the heart: the LEFT side [n+1,k+1]_q is expanded by the SECOND q-Pascal identity (qBinom_pascal'), while the reflected RIGHT side [n+1,k+1]_{q⁻¹} is expanded by the FIRST (qBinom_pascal). After substituting the induction hypothesis at (n,k) and (n,k+1), the two coefficient atoms A = [n,k]_{q⁻¹} and B = [n,k+1]_{q⁻¹} are matched term-by-term (eA, eB) and closed by ring.",
+    "mathContext": "Interior step: $\\genfrac{[}{]}{0pt}{}{n+1}{k+1}_q = q^{n-k}\\genfrac{[}{]}{0pt}{}{n}{k}_q + \\genfrac{[}{]}{0pt}{}{n}{k+1}_q$ vs. the reflected $\\genfrac{[}{]}{0pt}{}{n+1}{k+1}_{q^{-1}} = \\genfrac{[}{]}{0pt}{}{n}{k}_{q^{-1}} + q^{k+1}\\genfrac{[}{]}{0pt}{}{n}{k+1}_{q^{-1}}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "q-Pascal recurrences (P1 qBinom_pascal, P2 qBinom_pascal')",
+      "strong induction / well-founded recursion",
+      "case split on boundary vs interior",
+      "qBinom_eq_zero_of_lt"
+    ],
+    "prerequisites": [
+      "both q-Pascal identities from the parent",
+      "induction on natural numbers in Lean",
+      "rewriting with an induction hypothesis"
+    ]
+  },
+  {
+    "id": "ann-qbinom-both-pascals",
+    "proofId": "combinations-formula-oq-03-oq-04",
+    "range": { "startLine": 75, "endLine": 81 },
+    "type": "insight",
+    "title": "Why BOTH q-Pascal identities are needed",
+    "content": "The single most important structural fact of the proof: expanding the original by P2 and the reflection by P1 is what makes the two sides agree coefficient-by-coefficient. Using the SAME Pascal identity on both sides would NOT produce a termwise match — the reflected recurrence only lines up with the original because qBinom_pascal and qBinom_pascal' are two decompositions of the very same q-binomial. This asymmetry (P2 for the q-side, P1 for the q⁻¹-side) is the mechanism of palindromy.",
+    "mathContext": "The two Pascal identities are related by $q \\mapsto q^{-1}$ up to the $q^{k(n-k)}$ twist; applying the twisted one to each side is exactly the reflection symmetry.",
+    "significance": "key",
+    "relatedConcepts": [
+      "two forms of the q-Pascal recurrence",
+      "reflection q ↦ q⁻¹",
+      "termwise coefficient agreement"
+    ],
+    "prerequisites": [
+      "the two q-Pascal identities",
+      "the palindromy statement"
+    ]
+  },
+  {
+    "id": "ann-qbinom-power-cancellation",
+    "proofId": "combinations-formula-oq-03-oq-04",
+    "range": { "startLine": 85, "endLine": 97 },
+    "type": "technique",
+    "title": "The two coefficient matches eA and eB",
+    "content": "The coefficient of A collapses by additivity of exponents: q^{n-k}·q^{k(n-k)} = q^{(k+1)(n-k)} (hexpA proved by ring, eA by pow_add). The coefficient of B is the delicate one: it requires q^{(k+1)(n-k-1)} = q^{(k+1)(n-k)}·(q⁻¹)^{k+1}, i.e. cancelling a factor of q^{k+1}, which is exactly where q ≠ 0 is used via mul_inv_cancel_left₀ (pow_ne_zero (k+1) hq). The rewrite n-k = (n-k-1)+1 (hsplit) is legal precisely because the branch is k<n, so ℕ truncated subtraction is exact here.",
+    "mathContext": "$q^{(k+1)(n-k)}\\,(q^{-1})^{k+1} = q^{(k+1)(n-k-1)}$, valid since $q^{k+1} \\neq 0$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "pow_add / inv_pow / mul_inv_cancel_left₀",
+      "pow_ne_zero",
+      "ℕ truncated subtraction (omega)"
+    ],
+    "prerequisites": [
+      "laws of exponents in a field",
+      "cancellation of nonzero powers"
+    ]
+  },
+  {
+    "id": "ann-qbinom-reflect-involutive",
+    "proofId": "combinations-formula-oq-03-oq-04",
+    "range": { "startLine": 106, "endLine": 121 },
+    "type": "theorem",
+    "title": "Reflected form and involutivity sanity check",
+    "content": "Two corollaries. qBinom_reflect is qBinom_reciprocal read right-to-left (q^{k(n-k)}·[n,k]_{q⁻¹} = [n,k]_q), packaged for downstream convenience. qBinom_reciprocal_involutive confirms the twisted reflection q ↦ q⁻¹ is an involution: applying it twice returns the original because q^{k(n-k)}·(q⁻¹)^{k(n-k)} = 1 (mul_inv_cancel₀ under mul_pow). Any genuine palindrome reflection must square to the identity, so this is the expected consistency check.",
+    "mathContext": "$q^{k(n-k)}\\,(q^{-1})^{k(n-k)} = (q\\,q^{-1})^{k(n-k)} = 1$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "involution",
+      "mul_inv_cancel₀ / mul_pow",
+      "reflection consistency"
+    ],
+    "prerequisites": [
+      "the main reciprocity identity",
+      "involutions and self-inverse maps"
+    ]
+  }
+]

--- a/src/data/proofs/combinations-formula-oq-03-oq-04/meta.json
+++ b/src/data/proofs/combinations-formula-oq-03-oq-04/meta.json
@@ -85,5 +85,63 @@
       "endLine": 121,
       "summary": "qBinom_reflect (the right-to-left convenience form q^{k(n-k)}·[n,k]_{q⁻¹} = [n,k]_q) and qBinom_reciprocal_involutive (applying the twisted reflection twice returns the original, confirming it is an involution as any palindrome reflection must be)."
     }
+  ],
+  "conclusion": {
+    "summary": "A self-contained, axiom-free Lean file establishing that the Gaussian q-binomial coefficient [n,k]_q is palindromic, in the clean field form [n,k]_q = q^{k(n-k)}·[n,k]_{q⁻¹} (for q ≠ 0), together with its reflected convenience form and an involutivity check. The proof is a single induction on n that expands the original by one q-Pascal identity and the reflection by the other, matching the two sides coefficient-by-coefficient. This is the symmetric half of Sylvester's 1878 theorem; the unimodal half is deliberately left open.",
+    "implications": "Palindromy is exactly the piece of Sylvester's theorem that is elementary, and isolating it cleanly turns the open unimodality question into 'a symmetric sequence is unimodal', halving what remains to be proved. The identity also encodes the geometric duality between k-dimensional subspaces of 𝔽_qⁿ and their (n−k)-dimensional annihilators (which reverses the q-grading), and it is the q-analogue of the ordinary binomial symmetry C(n,k) = C(n,n−k) recovered at q = 1. Because the argument is purely arithmetic over a field, it is robust and reusable as a lemma toward any future unimodality formalization.",
+    "openQuestions": [
+      "Unimodality of the coefficient sequence of [n,k]_q — the substantive half of Sylvester's theorem — requiring either an sl₂-action (Proctor 1982) or an explicit injection between adjacent coefficient levels (O'Hara 1990). This is the actual content of the open question and is not attempted here.",
+      "Recast palindromy as a genuine coefficient-reversal statement over ℤ[q] (rather than the field identity with q⁻¹), so that it composes directly with a coefficient-level unimodality argument.",
+      "Formalize the subspace-counting interpretation, deriving palindromy from the bijection between k- and (n−k)-dimensional subspaces of 𝔽_qⁿ instead of from the recurrence."
+    ]
+  },
+  "references": [
+    {
+      "authors": "Sylvester, J. J.",
+      "title": "Proof of the hitherto undemonstrated fundamental theorem of invariants",
+      "year": "1878",
+      "note": "Philosophical Magazine. Establishes that the coefficient sequence of the Gaussian binomial is symmetric and unimodal; the symmetry (palindromy) half is what is formalized here."
+    },
+    {
+      "authors": "Proctor, R. A.",
+      "title": "Solution of two difficult combinatorial problems with linear algebra",
+      "year": "1982",
+      "note": "American Mathematical Monthly 89(10). The first fully rigorous proof of unimodality via an sl₂ (raising/lowering operator) action — the open half of the result."
+    },
+    {
+      "authors": "O'Hara, K. M.",
+      "title": "Unimodality of Gaussian coefficients: a constructive proof",
+      "year": "1990",
+      "note": "Journal of Combinatorial Theory, Series A 53(1). A purely combinatorial (injection-based) proof of unimodality, avoiding representation theory."
+    },
+    {
+      "authors": "Andrews, G. E.",
+      "title": "The Theory of Partitions",
+      "year": "1976",
+      "note": "Encyclopedia of Mathematics and its Applications, Cambridge University Press. Standard reference for Gaussian binomials, q-Pascal recurrences, and their symmetry as generating functions for partitions in a box."
+    },
+    {
+      "authors": "Kac, V. and Cheung, P.",
+      "title": "Quantum Calculus",
+      "year": "2002",
+      "note": "Springer Universitext. Develops q-binomial coefficients and the two q-Pascal rules used here as the engine of the palindromy induction."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "combinations-formula-oq-03",
+      "relationship": "extends",
+      "description": "Parent. Defines the q-binomial coefficient over an arbitrary commutative ring via the q-Pascal recurrence and proves BOTH q-Pascal identities (qBinom_pascal, qBinom_pascal') plus the vanishing lemma qBinom_eq_zero_of_lt — exactly the toolkit this file inducts with to prove palindromy."
+    },
+    {
+      "targetId": "combinations-formula",
+      "relationship": "specializes",
+      "description": "Grandparent. The ordinary binomial coefficient and its symmetry C(n,k) = C(n,n−k); palindromy of the q-binomial is the q-analogue that degenerates to this classical symmetry at q = 1."
+    },
+    {
+      "targetId": "binomial-theorem",
+      "relationship": "related",
+      "description": "The classical binomial theorem, whose coefficients are the q = 1 specialization of the Gaussian binomials studied here; the q-Pascal recurrences reduce to ordinary Pascal's rule at q = 1."
+    }
   ]
 }


### PR DESCRIPTION
Enrichment pass for `combinations-formula-oq-03-oq-04` (Palindromy of Gaussian q-binomials, quality 24, pass 0). The entry had a rich `overview` but was missing several core fields; this pass fills the highest-impact gaps.

**Added (meta.json 9.2 → 13.8 KB, well within the 60 KB cap):**
- **annotations.json (0 → 6 annotations)**, each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`: docstring/framing, field setup (why q⁻¹ needs a field), the main induction `qBinom_reciprocal`, the key insight that BOTH q-Pascal identities are required for termwise agreement, the power-cancellation technique (eA/eB), and the reflect/involutive corollaries.
- **conclusion** — `summary`, `implications` (subspace-duality reading, q=1 degeneration to C(n,k)=C(n,n−k)), and 3 `openQuestions` led by the genuinely-open unimodality half of Sylvester's theorem.
- **references (0 → 5)**: Sylvester 1878, Proctor 1982 (sl₂), O'Hara 1990 (combinatorial), Andrews *Theory of Partitions*, Kac–Cheung *Quantum Calculus*.
- **crossReferences (0 → 3)**: parent `combinations-formula-oq-03` (the q-Pascal toolkit), grandparent `combinations-formula` (classical symmetry), and `binomial-theorem` (q=1 specialization).

Verified: JSON valid, size within caps, gallery build enrichment resolves all crossReferences (52 lean/50 related), search-index checks pass, no annotation-line errors for this entry (the build's other errors are pre-existing in unrelated entries).