### PR TITLE
research(bezout-identity-oq-01-oq-02-oq-02): unimodular completion as a Basis object

### DIFF
--- a/proofs/Proofs/BezoutIdentityOQ01OQ02OQ02Basis.lean
+++ b/proofs/Proofs/BezoutIdentityOQ01OQ02OQ02Basis.lean
@@ -1,0 +1,137 @@
+/-
+# Unimodular completion: a primitive vector extends to a `ℤ`-basis
+
+Research: bezout-identity-oq-01-oq-02-oq-02
+
+The parent file `BezoutIdentityOQ01OQ02OQ02.lean` establishes that `SLₙ(ℤ)` acts
+transitively on primitive integer vectors (`exists_sl_mulVec_basis_of_isPrimitive`,
+`isPrimitive_iff_exists_sl_column`) and repeatedly asserts, in prose, the classical
+consequence that
+
+> a primitive integer vector **extends to a `ℤ`-basis** of `ℤⁿ` (unimodular
+> completion): the columns of `SLₙ(ℤ)` are exactly the primitive vectors.
+
+That statement is only ever phrased there through the *matrix* datum `↑ₘA *ᵥ eₖ = v`.
+This file turns it into the honest object it is describing: an actual
+`Basis (Fin n) ℤ (Fin n → ℤ)` one of whose members is the prescribed vector.  Nothing
+here is axiomatized — everything reduces to the parent transitivity theorem and the
+standard `Matrix`/`Basis` bridge, so the whole file is `propext`/`Classical.choice`/
+`Quot.sound`-only.
+
+* `slColumnBasis A` — the `ℤ`-basis of `ℤⁿ` given by the **columns** of `A ∈ SLₙ(ℤ)`,
+  built as the image of the standard basis under the linear equivalence
+  `SpecialLinearGroup.toLin' A`.  `slColumnBasis_apply` identifies its `k`-th member
+  with the column `↑ₘA *ᵥ eₖ`.
+* `slColumnBasis_isPrimitive` — every member of such a basis is primitive (the parent
+  `orbit_e_isPrimitive` restated for the basis object).
+* `isPrimitive_of_mem_basis` — the **converse in every dimension**: *any* member of
+  *any* `ℤ`-basis of `ℤⁿ` is primitive.  Uses the dual functional `b.coord i`, which
+  provides an integer dual vector `w` with `w · (b i) = 1`.  No dimension hypothesis.
+* `exists_basis_apply_eq_of_isPrimitive` — the **capstone (`n ≥ 2`)**: for any
+  prescribed slot `i`, a primitive vector `v` is the `i`-th member of some `ℤ`-basis of
+  `ℤⁿ`.  This is unimodular completion with the completing basis produced explicitly.
+* `isPrimitive_iff_mem_basis` — the resulting **characterization (`n ≥ 2`)**: a vector
+  is primitive iff it is a member of some `ℤ`-basis of `ℤⁿ`.
+-/
+import Mathlib
+import Proofs.BezoutIdentityOQ01OQ02OQ02
+
+namespace BezoutPrimitive
+
+open Matrix Module
+
+variable {n : ℕ}
+
+local notation:1024 "↑ₘ" A:1024 =>
+  ((A : Matrix.SpecialLinearGroup (Fin n) ℤ) : Matrix (Fin n) (Fin n) ℤ)
+
+/-! ### The column basis of a unimodular matrix -/
+
+/-- The `ℤ`-basis of `ℤⁿ` whose `k`-th member is the `k`-th **column** of a unimodular
+matrix `A ∈ SLₙ(ℤ)`.  It is the image of the standard basis `Pi.basisFun` under the
+linear equivalence `SpecialLinearGroup.toLin' A`; being an isomorphism carries a basis to
+a basis, and its action on `eₖ` extracts the `k`-th column of `A`. -/
+noncomputable def slColumnBasis (A : Matrix.SpecialLinearGroup (Fin n) ℤ) :
+    Basis (Fin n) ℤ (Fin n → ℤ) :=
+  (Pi.basisFun ℤ (Fin n)).map (Matrix.SpecialLinearGroup.toLin' A)
+
+/-- The `k`-th member of `slColumnBasis A` is the `k`-th column `↑ₘA *ᵥ eₖ` of `A`. -/
+@[simp]
+theorem slColumnBasis_apply (A : Matrix.SpecialLinearGroup (Fin n) ℤ) (k : Fin n) :
+    slColumnBasis A k = ↑ₘA *ᵥ Pi.single k (1 : ℤ) := by
+  rw [slColumnBasis, Basis.map_apply, Pi.basisFun_apply,
+    Matrix.SpecialLinearGroup.toLin'_apply, Matrix.toLin'_apply]
+
+/-- Every member of a column basis of a unimodular matrix is primitive.  This is the
+parent `orbit_e_isPrimitive` (any column of an `SLₙ(ℤ)` matrix is primitive), transported
+onto the `Basis` object. -/
+theorem slColumnBasis_isPrimitive (A : Matrix.SpecialLinearGroup (Fin n) ℤ) (k : Fin n) :
+    IsPrimitive (slColumnBasis A k) := by
+  rw [slColumnBasis_apply]
+  exact orbit_e_isPrimitive A k
+
+/-! ### The converse: members of any `ℤ`-basis are primitive -/
+
+/-- **Members of a `ℤ`-basis are primitive (all `n`).**  If `b` is any `ℤ`-basis of `ℤⁿ`
+then each `b i` is a primitive vector.  The dual coordinate functional `b.coord i` is a
+`ℤ`-linear map `ℤⁿ → ℤ` sending `b i` to `1`; representing it by its values on the
+standard basis gives an explicit integer dual vector `w` with `w · (b i) = 1`, which is
+exactly primitivity.  No dimension hypothesis is needed — this even resolves the `n = 1`
+case, where `(−1)` is a one-element basis of `ℤ¹` and is indeed primitive. -/
+theorem isPrimitive_of_mem_basis (b : Basis (Fin n) ℤ (Fin n → ℤ)) (i : Fin n) :
+    IsPrimitive (b i) := by
+  classical
+  -- The functional `b.coord i` equals dotting with `w j = b.coord i (eⱼ)`.
+  have key : ∀ x : Fin n → ℤ,
+      (b.coord i) x = ∑ j, x j * (b.coord i) (Pi.single j (1 : ℤ)) := by
+    intro x
+    conv_lhs => rw [← (Pi.basisFun ℤ (Fin n)).sum_repr x]
+    rw [map_sum]
+    refine Finset.sum_congr rfl fun j _ => ?_
+    rw [Pi.basisFun_repr, Pi.basisFun_apply, map_smul, smul_eq_mul]
+  refine ⟨fun j => (b.coord i) (Pi.single j (1 : ℤ)), ?_⟩
+  have hcoord : (b.coord i) (b i) = 1 := by
+    rw [Basis.coord_apply, Basis.repr_self, Finsupp.single_eq_same]
+  calc (fun j => (b.coord i) (Pi.single j (1 : ℤ))) ⬝ᵥ b i
+      = ∑ j, (b i) j * (b.coord i) (Pi.single j (1 : ℤ)) := by
+        simp only [dotProduct]; exact Finset.sum_congr rfl fun j _ => mul_comm _ _
+    _ = (b.coord i) (b i) := (key (b i)).symm
+    _ = 1 := hcoord
+
+/-! ### Unimodular completion for `n ≥ 2` -/
+
+/-- **Unimodular completion (`n ≥ 2`), prescribed slot.**  Given a primitive vector `v`
+and any index `i`, there is a `ℤ`-basis of `ℤⁿ` whose `i`-th member is exactly `v`.  The
+completing basis is produced explicitly: transitivity (`exists_sl_mulVec_basis_of_isPrimitive`)
+gives `U ∈ SLₙ(ℤ)` with `↑ₘU *ᵥ v = eᵢ`, and then `v` is the `i`-th column of `U⁻¹`, i.e.
+the `i`-th member of `slColumnBasis U⁻¹`.
+
+Taking `i` to be the first coordinate places `v` as the leading basis vector, matching the
+parent `bezoutSL` construction which carries a coprime pair onto `e₁`. -/
+theorem exists_basis_apply_eq_of_isPrimitive (hn : 1 < n) {v : Fin n → ℤ}
+    (hv : IsPrimitive v) (i : Fin n) :
+    ∃ b : Basis (Fin n) ℤ (Fin n → ℤ), b i = v := by
+  obtain ⟨U, hU⟩ := exists_sl_mulVec_basis_of_isPrimitive hn hv i
+  refine ⟨slColumnBasis U⁻¹, ?_⟩
+  rw [slColumnBasis_apply, ← hU, Matrix.mulVec_mulVec, ← Matrix.SpecialLinearGroup.coe_mul,
+    inv_mul_cancel, Matrix.SpecialLinearGroup.coe_one, Matrix.one_mulVec]
+
+/-- **A primitive vector extends to a `ℤ`-basis (`n ≥ 2`).**  Existence form of unimodular
+completion: every primitive vector is a member of some `ℤ`-basis of `ℤⁿ`. -/
+theorem exists_basis_mem_of_isPrimitive (hn : 1 < n) {v : Fin n → ℤ}
+    (hv : IsPrimitive v) :
+    ∃ (b : Basis (Fin n) ℤ (Fin n → ℤ)) (i : Fin n), b i = v := by
+  obtain ⟨b, hb⟩ := exists_basis_apply_eq_of_isPrimitive hn hv ⟨0, by omega⟩
+  exact ⟨b, ⟨0, by omega⟩, hb⟩
+
+/-- **Primitive ⇔ member of a `ℤ`-basis (`n ≥ 2`).**  Combining unimodular completion
+(forward) with `isPrimitive_of_mem_basis` (backward) pins down primitivity as *exactly*
+the property of extending to a `ℤ`-basis of `ℤⁿ`: for `n ≥ 2` the primitive vectors are
+precisely the vectors that occur as a member of some basis. -/
+theorem isPrimitive_iff_mem_basis (hn : 1 < n) (v : Fin n → ℤ) :
+    IsPrimitive v ↔ ∃ (b : Basis (Fin n) ℤ (Fin n → ℤ)) (i : Fin n), b i = v := by
+  refine ⟨exists_basis_mem_of_isPrimitive hn, ?_⟩
+  rintro ⟨b, i, rfl⟩
+  exact isPrimitive_of_mem_basis b i
+
+end BezoutPrimitive

--- a/src/data/proofs/bezout-identity-oq-01-oq-02-oq-02/meta.json
+++ b/src/data/proofs/bezout-identity-oq-01-oq-02-oq-02/meta.json
@@ -23,8 +23,8 @@
     "dateAdded": "2026-07-09",
     "axiomCount": 0,
     "assumptions": "None beyond Mathlib's foundational axioms. Fully machine-checked (0 sorries, 0 axiom declarations, no structure-encoded assumptions, no native_decide). Note: in the local Docker sandbox the file elaborates cleanly across repeated runs but the .olean cache write intermittently aborts with SIGBUS (exit 135), an environment/IO issue independent of the proofs; CI produces the build artifact.",
-    "lineCount": 548,
-    "theoremCount": 20,
+    "lineCount": 685,
+    "theoremCount": 26,
     "definitionCount": 2,
     "originalContributions": [
       "IsPrimitive v := ∃ w, w ⬝ᵥ v = 1 — a coordinate-free, manifestly SLₙ(ℤ)-invariant notion of primitivity for integer vectors (absent from Mathlib)",
@@ -32,7 +32,8 @@
       "transvectionSL / transvectionSL_mulVec: the elementary Euclidean-descent generators packaged in SLₙ(ℤ) with their explicit action v ↦ update v i (vᵢ + c·vⱼ)",
       "orbit_e_isPrimitive: the necessity half of transitivity — every SLₙ(ℤ)-orbit of a basis vector consists of primitive vectors",
       "BezoutIdentityOQ01OQ02OQ02Invariant.lean — the invariance (necessity) complement to the transitivity results: the content (gcd) of an integer vector is a complete SLₙ(ℤ)-invariant. dvd_mulVec (integer matrices carry common divisors forward), common_dvd_mulVec_iff (SLₙ preserves the full set of common divisors, strengthening isPrimitive_mulVec_iff from primitivity to arbitrary content), sameOrbit_common_dvd_eq (content is an orbit invariant), IsPrimitive.common_dvd_isUnit (primitive = trivial content). Axiom-free.",
-      "Sharpness of the 1<n hypothesis (n=1 obstruction): coe_sl_fin_one_eq_one (SL₁(ℤ)={(1)} at the matrix level), sl_fin_one_mulVec (SL₁ acts trivially), not_exists_sl_fin_one_single_neg (no SL₁ move carries (1) to (-1)), not_forall_sl_fin_one_orbit (transitivity fails at n=1). Proves the entry's previously prose-only claim that the 1<n hypothesis in exists_sl_mulVec_eq_of_isPrimitive is genuinely necessary — SL₁(ℤ) has two primitive-vector orbits, not one. Axiom-free."
+      "Sharpness of the 1<n hypothesis (n=1 obstruction): coe_sl_fin_one_eq_one (SL₁(ℤ)={(1)} at the matrix level), sl_fin_one_mulVec (SL₁ acts trivially), not_exists_sl_fin_one_single_neg (no SL₁ move carries (1) to (-1)), not_forall_sl_fin_one_orbit (transitivity fails at n=1). Proves the entry's previously prose-only claim that the 1<n hypothesis in exists_sl_mulVec_eq_of_isPrimitive is genuinely necessary — SL₁(ℤ) has two primitive-vector orbits, not one. Axiom-free.",
+      "BezoutIdentityOQ01OQ02OQ02Basis.lean — unimodular completion as an actual Module.Basis object (the parent only ever phrased extends to a ℤ-basis through the matrix datum ↑ₘA *ᵥ eₖ = v). slColumnBasis A (the ℤ-basis given by the columns of A ∈ SLₙ(ℤ), as the image of the standard basis under SpecialLinearGroup.toLin A), slColumnBasis_apply/slColumnBasis_isPrimitive; isPrimitive_of_mem_basis (converse in ALL n: any member of any ℤ-basis of ℤⁿ is primitive, via b.coord i); exists_basis_apply_eq_of_isPrimitive (n≥2: a primitive vector is the i-th member of an explicit ℤ-basis, any slot i); isPrimitive_iff_mem_basis (n≥2: primitive ⇔ member of a ℤ-basis). 1 def, 6 theorems, 0 sorries, 0 axioms."
     ]
   },
   "overview": {
@@ -97,6 +98,11 @@
       "name": "not_forall_sl_fin_one_orbit",
       "type": "theorem",
       "description": "Sharpness of the 1<n hypothesis: transitivity FAILS at n=1. Since SL₁(ℤ)={1} acts trivially on every vector (coe_sl_fin_one_eq_one, sl_fin_one_mulVec), the two primitive vectors (1) and (-1) lie in distinct orbits (not_exists_sl_fin_one_single_neg), so exists_sl_mulVec_eq_of_isPrimitive and its corollaries genuinely require 1<n. This turns the entry's repeated prose 'the dimension hypothesis is genuinely necessary, not an artefact' into a machine-checked theorem: SL₁(ℤ) has exactly two orbits of primitive vectors, versus a single orbit for n ≥ 2."
+    },
+    {
+      "name": "isPrimitive_iff_mem_basis",
+      "type": "theorem",
+      "description": "Primitive ⇔ member of a ℤ-basis (n ≥ 2). Sharpens the column-completion statement isPrimitive_iff_exists_sl_column into an actual Module.Basis object: a vector is primitive iff it occurs as a member b i of some ℤ-basis b of ℤⁿ. Forward is explicit unimodular completion (exists_basis_apply_eq_of_isPrimitive places v in any prescribed slot i of slColumnBasis U⁻¹); backward is isPrimitive_of_mem_basis, which holds in every dimension via the dual functional b.coord i. Turns the parent files repeated prose claim that a primitive vector extends to a ℤ-basis into a machine-checked Basis. Axiom-free."
     }
   ],
   "leanFile": {

--- a/src/data/research/problems/bezout-identity-oq-01-oq-02-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-01-oq-02-oq-02.json
@@ -42,7 +42,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "SOLVED/enriched: added the classical-coprimality bridges — literal Finset.univ.gcd v=1 (all n) and IsCoprime/Int.gcd=1 (n=2) characterisations of IsPrimitive, connecting the SLₙ(ℤ)-invariant dot-product definition to the parent n=2 Int.gcd/bezoutMatrix phrasing. All axiom-free (propext/Classical.choice/Quot.sound only). BezoutIdentityOQ01OQ02OQ02Coprime.lean companion, verified via lake env lean 4.26.0.",
+    "progressSummary": "SOLVED + capstone: unimodular completion now formalized as an actual Module.Basis object (isPrimitive_iff_mem_basis, n≥2) with an all-n converse (isPrimitive_of_mem_basis). New companion BezoutIdentityOQ01OQ02OQ02Basis.lean, axiom-free, verified via lake env lean 4.26.0.",
     "builtItems": [
       "IsPrimitive (Fin n → ℤ) := ∃ w, w ⬝ᵥ v = 1 — BezoutIdentityOQ01OQ02OQ02.lean",
       "isPrimitive_iff_span_eq_top: IsPrimitive v ↔ Ideal.span (range v) = ⊤ (bridge to classical gcd=1 via Ideal.mem_span_range_iff_exists_fun)",
@@ -55,7 +55,11 @@
       "coe_sl_fin_one_eq_one, sl_fin_one_mulVec, not_exists_sl_fin_one_single_neg, not_forall_sl_fin_one_orbit (BezoutIdentityOQ01OQ02OQ02.lean): the n=1 obstruction package. VERIFIED axiom-free [propext,Classical.choice,Quot.sound]. File 584→646L, 27→31 thm.",
       "isPrimitive_iff_finset_gcd_eq_one (BezoutIdentityOQ01OQ02OQ02Coprime.lean): IsPrimitive v ↔ Finset.univ.gcd v = 1 for all n — literal computed-gcd value form, upgrading isPrimitive_iff_forall_isUnit_of_dvd via Finset.gcd_dvd/dvd_gcd + normalize_eq_one. 0-axiom.",
       "isPrimitive_iff_isCoprime_fin_two + isPrimitive_iff_int_gcd_eq_one_fin_two: for v:Fin 2→ℤ, IsPrimitive v ↔ IsCoprime (v 0)(v 1) ↔ Int.gcd(v 0)(v 1)=1 — the classical-coprimality bridge to the parent BezoutIdentityOQ01OQ02 Int.gcd/bezoutMatrix phrasing. 0-axiom.",
-      "finset_gcd_eq_one_iff_int_gcd_eq_one_fin_two: Finset.gcd and Int.gcd agree on the Fin 2 primitive locus."
+      "finset_gcd_eq_one_iff_int_gcd_eq_one_fin_two: Finset.gcd and Int.gcd agree on the Fin 2 primitive locus.",
+      "slColumnBasis (Proofs/BezoutIdentityOQ01OQ02OQ02Basis.lean): the ℤ-basis of ℤⁿ given by the columns of A ∈ SLₙ(ℤ), plus slColumnBasis_apply (k-th member = ↑ₘA *ᵥ e_k) and slColumnBasis_isPrimitive.",
+      "isPrimitive_of_mem_basis (Basis.lean): all-n converse — every member of any ℤ-basis of ℤⁿ is primitive.",
+      "exists_basis_apply_eq_of_isPrimitive (Basis.lean, n≥2): explicit unimodular completion — a primitive vector is the i-th member of slColumnBasis U⁻¹ for any prescribed slot i.",
+      "isPrimitive_iff_mem_basis (Basis.lean, n≥2): the characterization primitive ⇔ member of a ℤ-basis, turning the parent files prose extends-to-a-ℤ-basis claim into a machine-checked Module.Basis. 1 def + 6 theorems, 0 sorries, 0 axioms."
     ],
     "insights": [
       "Primitivity of an integer vector v is cleanly captured coordinate-free as: ∃ dual w with w ⬝ᵥ v = 1. This dot-product form is manifestly SLₙ(ℤ)-invariant, unlike the gcd-of-entries phrasing.",
@@ -68,15 +72,18 @@
       "Base case: a primitive vector with a single nonzero coordinate must have that entry a unit (from exists w, w dot v = 1 collapsing to w k * v k = 1), so it already equals Pi.single k (v k) with IsUnit (v k) — A = 1.",
       "Reaching EXACTLY e0 (not just a unit multiple c*e_k) is only true for n >= 2; in n = 1, SL1(Z)={1} fixes -e0 != e0 though both are primitive, so the unit-multiple form is the sharp general-n statement.",
       "Sharpness of transitivity: SL₁(ℤ)={(1)} acts trivially (coe_sl_fin_one_eq_one via det_fin_one), so (1) and (-1) — both primitive — lie in DISTINCT orbits. SL₁(ℤ) has exactly 2 primitive-vector orbits vs a single orbit for n≥2. This proves the previously prose-only claim that the 1<n hypothesis in exists_sl_mulVec_eq_of_isPrimitive is genuinely necessary.",
-      "The parent file already had two primitivity reformulations (span=⊤, every-common-divisor-is-unit) but NOT the literal Finset.gcd=1 value nor the ring-theoretic IsCoprime form; both are cheap corollaries of isPrimitive_iff_forall_isUnit_of_dvd + Finset.gcd_dvd/dvd_gcd and Fin.sum_univ_two respectively."
+      "The parent file already had two primitivity reformulations (span=⊤, every-common-divisor-is-unit) but NOT the literal Finset.gcd=1 value nor the ring-theoretic IsCoprime form; both are cheap corollaries of isPrimitive_iff_forall_isUnit_of_dvd + Finset.gcd_dvd/dvd_gcd and Fin.sum_univ_two respectively.",
+      "Module.Basis is the current Mathlib name for the Basis type (moved into the Module namespace, Lean/Mathlib 4.26 module system); granular `import Mathlib.LinearAlgebra.StdBasis` does not re-export `Basis` to a non-module file — use `import Mathlib` + `open Module`.",
+      "SpecialLinearGroup.toLin A : (n→R) ≃ₗ[R] n→R gives the linear equivalence of a unimodular matrix directly (no Invertible-instance juggling); its action on the standard basis vector e_k extracts the k-th column via toLin_apply + Matrix.toLin_apply + mulVec_single_one.",
+      "The converse `member of a ℤ-basis ⇒ primitive` needs NO dimension hypothesis: the dual coordinate functional b.coord i is a ℤ-linear map ℤⁿ→ℤ sending b i to 1; representing it by its values w j = b.coord i (e_j) on the standard basis gives an explicit integer dual with w · (b i) = 1 (= primitivity). This even covers n=1 where SLₙ transitivity fails."
     ],
     "mathlibGaps": [
       "Mathlib has no packaged transitivity of SLₙ(ℤ) on primitive vectors (only n=2 pieces via bezoutSL in the parent). Foundation built here; the Euclidean-descent converse (every primitive vector reaches eᵢ) remains.",
       "No IsPrimitive predicate for integer vectors in Mathlib; defined here via the dot-product dual."
     ],
     "nextSteps": [
-      "Add the n >= 2 corollary reaching exactly e0: a unit multiple c*e_k is SLn(Z)-equivalent to Pi.single 0 1. Needs a plane-rotation SLn element sending c*e_k to e0 (buildable as a product of 3 transvections via the S = T T T identity, avoiding a new matrix constructor).",
-      "Bridge IsPrimitive to Finset.univ.gcd of entries = 1 to connect explicitly with the parent n=2 IsCoprime phrasing."
+      "Optional: upgrade isPrimitive_iff_mem_basis to hold at n=1 too (the (-1) singleton basis) by supplying the trivial construction there, giving an all-n characterization.",
+      "Optional: an effective/computable version of the completing basis (the whyMatters reusable reduction tool), replacing the existence quantifier by a def."
     ]
   },
   "tags": [


### PR DESCRIPTION
## Summary

Advances the **RICH** research problem `bezout-identity-oq-01-oq-02-oq-02` (*Transitivity of SLₙ(ℤ) on primitive vectors*). The parent file `BezoutIdentityOQ01OQ02OQ02.lean` already proves the full open question (transitivity for `n ≥ 2`, sharpness at `n = 1`) and its docstrings repeatedly assert the classical consequence that

> a primitive integer vector **extends to a ℤ-basis** of ℤⁿ (unimodular completion)

— but only ever through the *matrix* datum `↑ₘA *ᵥ eₖ = v`. This PR turns that prose into the honest object it describes: an actual Mathlib `Module.Basis`.

## New companion: `BezoutIdentityOQ01OQ02OQ02Basis.lean`

1 def + 6 theorems, **0 sorries, 0 axioms** (`#print axioms` = `propext, Classical.choice, Quot.sound` only).

| Declaration | Statement |
|---|---|
| `slColumnBasis A` | the ℤ-basis of ℤⁿ given by the **columns** of `A ∈ SLₙ(ℤ)` (image of the standard basis under `SpecialLinearGroup.toLin' A`) |
| `slColumnBasis_apply` | its `k`-th member is the column `↑ₘA *ᵥ eₖ` |
| `slColumnBasis_isPrimitive` | every member of such a basis is primitive |
| `isPrimitive_of_mem_basis` | **converse, all `n`**: any member of any ℤ-basis of ℤⁿ is primitive (via the dual functional `b.coord i`) — even covers `n = 1` |
| `exists_basis_apply_eq_of_isPrimitive` | **capstone (`n ≥ 2`)**: a primitive vector is the `i`-th member of an explicit ℤ-basis, for any prescribed slot `i` |
| `isPrimitive_iff_mem_basis` | **characterization (`n ≥ 2`)**: primitive ⇔ member of a ℤ-basis |

The forward direction uses the parent transitivity theorem `exists_sl_mulVec_basis_of_isPrimitive` to place `v` as a column of `U⁻¹`; the converse is dimension-free and elementary (the coordinate functional `b.coord i` supplies an integer dual vector `w` with `w · (b i) = 1`).

## Verification

Verified with `lake env lean` (toolchain `leanprover/lean4:v4.26.0`) against the prebuilt parent olean: exit 0, no warnings. Axiom-free.

## Files
- `proofs/Proofs/BezoutIdentityOQ01OQ02OQ02Basis.lean` (new, verified)
- `src/data/proofs/bezout-identity-oq-01-oq-02-oq-02/meta.json` (mainTheorem + contribution)
- `src/data/research/problems/bezout-identity-oq-01-oq-02-oq-02.json` (knowledge)

## Honesty note
The underlying open question was already fully proved in the parent file; this PR is a **capstone enrichment** that formalizes the "extends to a ℤ-basis" corollary as a first-class `Basis` object and adds the sharp iff characterization. No new axioms; the converse strengthens the picture to all `n`.