### PR TITLE
research(feuerbach-oq04): spherical midpoint lies strictly in the near hemisphere

### DIFF
--- a/proofs/Proofs/FeuerbachsTheoremOQ04Midpoint.lean
+++ b/proofs/Proofs/FeuerbachsTheoremOQ04Midpoint.lean
@@ -266,4 +266,53 @@ theorem sphericalNinePointCircle_equidistant [FiniteDimensional ℝ E]
       sdist (sMidpoint A C) O = sdist (sMidpoint A B) O :=
   sphericalCircumcircle_equidistant (sMidpoint B C) (sMidpoint A C) (sMidpoint A B) hdim
 
+/-! ### The spherical midpoint lies strictly in the near hemisphere
+
+The half-arc computations `sdist_sMidpoint_half` / `sdist_sMidpoint_half_right` locate the
+midpoint at spherical distance `½·sdist A B` from each endpoint. Since a non-degenerate side
+has `sdist A B < π`, both half-arcs are strictly less than `π/2`: the midpoint sits strictly
+inside the open hemisphere centred at each endpoint. This positional bound (`scos > 0`, i.e.
+positive inner product with each endpoint) is what a Feuerbach tangency argument needs to place
+contact points on the *minor* arc and rule out their antipodes. -/
+
+/-- **The spherical midpoint is at positive inner product with its endpoint.**
+For a non-degenerate side (`A + B ≠ 0`, i.e. `B` not antipodal to `A`) the spherical midpoint
+`M = sMidpoint A B` satisfies `scos A M = ‖A+B‖⁻¹(1 + ⟪A,B⟫) > 0`, because `A + B ≠ 0` forces
+`⟪A,B⟫ > -1` (from `‖A+B‖² = 2 + 2⟪A,B⟫ > 0`). -/
+theorem scos_sMidpoint_pos (A B : E) (hA : OnSphere A) (hB : OnSphere B)
+    (hAB : A + B ≠ 0) :
+    0 < scos A (sMidpoint A B) := by
+  have hnormpos : 0 < ‖A + B‖ := norm_pos_iff.mpr hAB
+  have hnsq : ‖A + B‖ ^ 2 = 2 + 2 * ⟪A, B⟫ := norm_add_sq_unit A B hA hB
+  have hnsqpos : 0 < ‖A + B‖ ^ 2 := pow_pos hnormpos 2
+  have hip : (-1 : ℝ) < ⟪A, B⟫ := by rw [hnsq] at hnsqpos; linarith
+  rw [scos_sMidpoint_left A B hA hB]
+  exact mul_pos (inv_pos.mpr hnormpos) (by linarith)
+
+/-- **The spherical midpoint lies strictly in the near hemisphere of its endpoint:**
+`sdist A (sMidpoint A B) < π/2`. Equivalent to the positive-inner-product bound
+`scos_sMidpoint_pos` via `arccos x < π/2 ↔ 0 < x`; geometrically the midpoint of a
+non-degenerate side is closer than a quarter-turn to each vertex. -/
+theorem sdist_sMidpoint_lt_pi_div_two (A B : E) (hA : OnSphere A) (hB : OnSphere B)
+    (hAB : A + B ≠ 0) :
+    sdist A (sMidpoint A B) < Real.pi / 2 := by
+  unfold sdist
+  exact Real.arccos_lt_pi_div_two.mpr (scos_sMidpoint_pos A B hA hB hAB)
+
+/-- **Near-hemisphere bound from the far endpoint:** `sdist (sMidpoint A B) B < π/2`.
+Companion of `sdist_sMidpoint_lt_pi_div_two`, by the symmetry `sdist_comm` / `sMidpoint_comm`. -/
+theorem sdist_sMidpoint_lt_pi_div_two_right (A B : E) (hA : OnSphere A) (hB : OnSphere B)
+    (hAB : A + B ≠ 0) :
+    sdist (sMidpoint A B) B < Real.pi / 2 := by
+  rw [sdist_comm, sMidpoint_comm]
+  exact sdist_sMidpoint_lt_pi_div_two B A hB hA (by rw [add_comm]; exact hAB)
+
+/-- **Arc-doubling form of the bisection identity:** `2 · sdist A (sMidpoint A B) = sdist A B`.
+The multiplicative restatement of `sdist_sMidpoint_half`, often more convenient than the
+`/2` form when the full side length is the quantity of interest. -/
+theorem two_sdist_sMidpoint (A B : E) (hA : OnSphere A) (hB : OnSphere B)
+    (hAB : A + B ≠ 0) :
+    2 * sdist A (sMidpoint A B) = sdist A B := by
+  rw [sdist_sMidpoint_half A B hA hB hAB]; ring
+
 end FeuerbachsTheoremOQ04


### PR DESCRIPTION
## Summary

Advances the **spherical Feuerbach** frontier (`feuerbachs-theorem-oq-04`) by pinning down the *positional* geometry of the spherical side-midpoint `sMidpoint A B` in `proofs/Proofs/FeuerbachsTheoremOQ04Midpoint.lean`.

The file already proves the half-arc bisection (`sdist_sMidpoint_half`: the midpoint is at spherical distance `½·sdist A B` from each endpoint) and builds the spherical nine-point circle from the medial triangle. This PR adds the near-hemisphere bound — the midpoint is strictly within a quarter-turn of each vertex — which a Feuerbach tangency argument needs to place contact points on the *minor* arc and rule out their antipodes.

## New theorems (all axiom-free)

- **`scos_sMidpoint_pos`** — `scos A (sMidpoint A B) > 0` for a non-degenerate side (`A + B ≠ 0`, i.e. `B` not antipodal to `A`). Key step: `A + B ≠ 0` forces `⟪A,B⟫ > -1` via `‖A+B‖² = 2 + 2⟪A,B⟫ > 0`.
- **`sdist_sMidpoint_lt_pi_div_two`** and **`sdist_sMidpoint_lt_pi_div_two_right`** — `sdist A (sMidpoint A B) < π/2` (and from the far endpoint), i.e. the midpoint of a non-degenerate side lies strictly in the open near hemisphere of each vertex. Via `Real.arccos_lt_pi_div_two ↔ 0 < x`.
- **`two_sdist_sMidpoint`** — arc-doubling restatement `2 · sdist A (sMidpoint A B) = sdist A B`.

## Verification

Built with the docker wrapper (`Proofs.FeuerbachsTheoremOQ04Midpoint`), all 7745 jobs incl. dependency chain built successfully.

Axiom profile (`#print axioms`): all three new results depend only on `[propext, Classical.choice, Quot.sound]` — fully axiom-free, 0 sorries, 0 `axiom` declarations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)