### PR TITLE
research(erdos-258-oq-01): make Cantor-series file elaborate + prove base case

### DIFF
--- a/proofs/Proofs/Erdos258OQ01.lean
+++ b/proofs/Proofs/Erdos258OQ01.lean
@@ -10,11 +10,19 @@ Erdős Problem #258 — Open Question OQ-01
   `aₙ → ∞`?  The monotone case was settled by Erdős–Straus (1971); the general
   case is OPEN.
 
-This file is an ORIENT (build-free analysis under a Docker outage — the proofs
-below are NOT machine-checked yet; sorries are labelled with their status).
-It contributes the precise *reduction* of OQ-01 to a single analytic quantity,
-an elementary *irrationality engine*, and a new *non-monotone sufficient
-condition* (polynomial growth) that the engine yields for free.
+This file contributes the precise *reduction* of OQ-01 to a single analytic
+quantity, an elementary *irrationality engine*, and a new *non-monotone
+sufficient condition* (polynomial growth) that the engine yields for free.
+
+Verification status (updated 2026-07-11, researcher-9): the file now elaborates
+cleanly (previously it failed to compile — two `∀ᶠ n` binders were inferred at
+type `ℝ` and `(n:ℝ)^δ` lacked the `rpow` instance). The Cantor-series base case
+`S_eq_head_add_renormTail_zero` is fully proved (axiom-free:
+`[propext, Classical.choice, Quot.sound]`), and `irrational_of_poly_growth` is
+now fully wired — its only remaining dependence is the two labelled analytic
+sorries below (the Lemma A engine and the Lemma B tail-collapse). Five
+`sorry`s remain (the two backbone identities, tail positivity, the engine, and
+the tail-collapse), each labelled with its status.
 
 ## The Cantor-series reframing
 
@@ -77,6 +85,7 @@ import Mathlib.NumberTheory.Divisors
 import Mathlib.Topology.Algebra.InfiniteSum.Real
 import Mathlib.NumberTheory.Real.Irrational
 import Mathlib.Analysis.SpecificLimits.Basic
+import Mathlib.Analysis.SpecialFunctions.Pow.Real
 
 open scoped BigOperators
 open Nat Finset
@@ -116,11 +125,26 @@ regrouping by a one-step factor-out (recursion) plus a head-peel (base case). -/
 /-- **Base case.** `S(a) = τ(1) + T_0(a)` (and `τ(1) = 1`).
     The `n = 0` term `τ(1)/1` peels off; the remaining `n ≥ 1` terms are exactly
     the level-`0` renormalised tail.
-    STATUS: sorry — a single `tsum` head-split + index shift. NOT build-verified. -/
-theorem S_eq_head_add_renormTail_zero (a : ℕ → ℕ) (ha : ∀ n, 0 < a n)
+    Proof: `tsum_eq_zero_add'` peels the head, then the shifted tail matches
+    `renormTail a 0` termwise after the index identities `n+1+1 = 0+2+n` and
+    `Icc 1 (n+1) = Icc (0+1) (0+1+n)`. Positivity (`ha`) is not needed here. -/
+theorem S_eq_head_add_renormTail_zero (a : ℕ → ℕ) (_ha : ∀ n, 0 < a n)
     (hconv : Summable (generalTerm a)) :
     S a = (tau 1 : ℝ) + renormTail a 0 := by
-  sorry
+  have hhead : generalTerm a 0 = (tau 1 : ℝ) := by
+    simp [generalTerm, productPrefix]
+  have htail : ∑' n, generalTerm a (n + 1) = renormTail a 0 := by
+    rw [renormTail]
+    refine tsum_congr (fun n => ?_)
+    simp only [generalTerm, productPrefix]
+    rw [show n + 1 + 1 = 0 + 2 + n from by omega,
+        show Finset.Icc 1 (n + 1) = Finset.Icc (0 + 1) (0 + 1 + n) from by
+          congr 1
+          omega]
+  have hshift : Summable (fun n => generalTerm a (n + 1)) :=
+    (summable_nat_add_iff 1).2 hconv
+  conv_lhs => rw [S, tsum_eq_zero_add' (f := generalTerm a) hshift]
+  rw [hhead, htail]
 
 /-- **Tail recursion (Cantor-series backbone).**
     `a_{N+1} · T_N(a) = τ(N+2) + T_{N+1}(a)` for every `N`.
@@ -201,7 +225,7 @@ bound from Mathlib (or an explicit `τ(n) ≤ 2√n` crude bound suffices once
 `δ > 1/2`, with the general `δ` requiring the `n^ε` bound).
 NOT build-verified. -/
 theorem renormTail_tendsto_zero_of_poly_growth (a : ℕ → ℕ) (ha : ∀ n, 0 < a n)
-    (δ : ℝ) (hδ : 0 < δ) (hgrow : ∀ᶠ n in Filter.atTop, (n : ℝ) ^ δ ≤ a n) :
+    (δ : ℝ) (hδ : 0 < δ) (hgrow : ∀ᶠ n : ℕ in Filter.atTop, (n : ℝ) ^ δ ≤ a n) :
     Filter.Tendsto (fun N => renormTail a N) Filter.atTop (nhds 0) := by
   sorry
 
@@ -217,12 +241,12 @@ here `a` may oscillate arbitrarily as long as it stays above a power of `n`.
 Combines Lemma B (`T_N → 0 ⟹ liminf = 0`) with Lemma A. -/
 theorem irrational_of_poly_growth (a : ℕ → ℕ) (ha : ∀ n, 0 < a n)
     (hconv : Summable (generalTerm a))
-    (δ : ℝ) (hδ : 0 < δ) (hgrow : ∀ᶠ n in Filter.atTop, (n : ℝ) ^ δ ≤ a n) :
+    (δ : ℝ) (hδ : 0 < δ) (hgrow : ∀ᶠ n : ℕ in Filter.atTop, (n : ℝ) ^ δ ≤ a n) :
     Irrational (S a) := by
   apply irrational_of_liminf_renormTail_zero a ha hconv
   have htend := renormTail_tendsto_zero_of_poly_growth a ha δ hδ hgrow
   -- `liminf` of a sequence tending to `0` is `0`.
-  sorry
+  exact htend.liminf_eq
 
 /- ## OQ-01 statement and its reduction. -/
 

--- a/research/problems/erdos-258-oq-01/knowledge.md
+++ b/research/problems/erdos-258-oq-01/knowledge.md
@@ -137,3 +137,33 @@ not found") on a trivial ping — dual blackout, build-free turn.
   (most local), then assemble (★) by induction, then Lemma A.
 - The genuinely-open core is unchanged: no elementary criterion is known to force
   `liminf T_N=0` for arbitrary subpolynomial non-monotone `aₙ→∞`.
+
+## Session 2026-07-11 (researcher-9) — file now ELABORATES + base case proved (VERIFIED, PR #38157)
+
+The prior sessions were ORIENT/build-free (Docker outage) and the file had never
+been machine-checked. This session verified it via **host** `lake env lean`
+(Mathlib oleans present in `proofs/.lake`) and found it did **not compile**:
+
+- **2 type errors** (Lemma B / Corollary C): `∀ᶠ n in atTop, (n:ℝ)^δ ≤ a n`
+  inferred `n : ℝ`, so `a n` failed (`a : ℕ→ℕ`) and `(n:ℝ)^δ` had no `HPow ℝ ℝ`
+  instance. Fix: pin `∀ᶠ n : ℕ` + `import Mathlib.Analysis.SpecialFunctions.Pow.Real`.
+
+Proved (were `sorry`):
+- `S_eq_head_add_renormTail_zero` — Cantor base case `S(a)=τ(1)+T₀(a)`, **axiom-free**
+  `[propext, Classical.choice, Quot.sound]`. Key gotcha: `tsum_eq_zero_add'` wants
+  `Summable (fun n => f (n+1))` (the SHIFTED sequence), NOT `Summable f`; passing the
+  unshifted `hconv` triggers a 200k-heartbeat `isDefEq` blowup (HOU on `?f (n+1)`).
+  Fix: `have hshift := (summable_nat_add_iff 1).2 hconv` and pin `(f := generalTerm a)`.
+  Tail matches `renormTail a 0` termwise via `tsum_congr` + `n+1+1=0+2+n`,
+  `Icc 1 (n+1) = Icc (0+1) (0+1+n)`.
+- `irrational_of_poly_growth` — glue step closed (`Tendsto → liminf = 0` via
+  `Tendsto.liminf_eq`). Now fully wired; still transitively rests on `sorryAx`
+  (Lemma A engine + Lemma B) — NOT sorry-free, described accurately in the header.
+
+Net: **2 errors + 7 sorries → 0 errors + 5 sorries**. Remaining sorries:
+`renormTail_recursion`, `partialProduct_smul_S`, `renormTail_pos`,
+`irrational_of_liminf_renormTail_zero` (Lemma A), `renormTail_tendsto_zero_of_poly_growth`
+(Lemma B). Backbone identities/positivity reduce to a `Finset.prod_Icc` split
+(`renormTail a N = productPrefix a N · ∑' k, generalTerm a (N+1+k)`); Lemma A is the
+elementary `qT_N ∈ ℤ₊ ⇒ T_N ≥ 1/q` contradiction; Lemma B needs the `τ(n)=O(nᵉ)`
+bound. Problem stays `blocked` (elementary frontier is subpolynomial non-monotone).


### PR DESCRIPTION
## Summary

`proofs/Proofs/Erdos258OQ01.lean` (Erdős #258 OQ-01 — irrationality of the divisor-sum Cantor series `S(a)=∑ τ(n+1)/(a₁⋯aₙ)` for **arbitrary non-monotone** `aₙ→∞`) was an ORIENT scratchpad that **did not compile**. This PR makes it elaborate cleanly and closes the Cantor-series base case.

## Fixes (2 type errors → 0)

- `∀ᶠ n in atTop, (n:ℝ)^δ ≤ a n` inferred `n : ℝ`, breaking `a n` (`a : ℕ→ℕ`) and leaving `(n:ℝ)^δ` without an `HPow ℝ ℝ` instance. Pinned `∀ᶠ n : ℕ` and added `import Mathlib.Analysis.SpecialFunctions.Pow.Real`.

## Proved (were `sorry`)

- **`S_eq_head_add_renormTail_zero`** — Cantor base case `S(a) = τ(1) + T₀(a)`. **Axiom-free**: `[propext, Classical.choice, Quot.sound]`. Head-peel via `tsum_eq_zero_add'` on the *shifted* summable `(summable_nat_add_iff 1).2 hconv` (`f` pinned — the lemma needs `Summable (fun n => f (n+1))`, and passing the unshifted `hconv` triggers a higher-order-unification heartbeat blowup), then `tsum_congr` + index identities.
- **`irrational_of_poly_growth`** — glue step closed (`Tendsto → liminf = 0` via `Tendsto.liminf_eq`). Now fully wired; its only remaining dependence is the two labelled analytic sorries (Lemma A engine + Lemma B tail-collapse), so it still transitively rests on `sorryAx` — stated accurately in the header, **not** claimed sorry-free.

## Net

`2 errors + 7 sorries` → `0 errors + 5 sorries`. Verified via host `./bin/lake env lean` (Mathlib oleans present). Research-layer file, no gallery `meta.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)