### PR TITLE
Enrich binomial-theorem-oq-05-oq-01: add missing preamble section

### DIFF
--- a/src/data/proofs/binomial-theorem-oq-05-oq-01/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-05-oq-01/meta.json
@@ -88,6 +88,14 @@
   },
   "sections": [
     {
+      "id": "preamble",
+      "title": "Module Header and the Open Question",
+      "startLine": 1,
+      "endLine": 41,
+      "summary": "Module docstring stating the open question: the binomial theorem's coefficient-comparison yields the Chu–Vandermonde convolution C(m+n,k) = Σ_i C(m,i)·C(n,k−i). Notes that Mathlib proves only the antidiagonal form (Nat.add_choose_eq) and that this file develops the textbook range-indexed form plus the diagonal convolution and the sum-of-squares specialization (none in Mathlib), all axiom-free. Imports Mathlib, opens Finset, enters the namespace.",
+      "mathContext": "Chu–Vandermonde: $\\binom{m+n}{k} = \\sum_{i=0}^{k} \\binom{m}{i}\\binom{n}{k-i}$; the single Mathlib input is the antidiagonal form $\\texttt{Nat.add\\_choose\\_eq}$."
+    },
+    {
       "id": "rangeform",
       "title": "Chu–Vandermonde Identity (Range Form)",
       "startLine": 42,


### PR DESCRIPTION
Enrichment pass for `binomial-theorem-oq-05-oq-01` (Chu–Vandermonde convolution identities, q96, pass 0). The entry met all content minimums (5 annotations w/ mathContext, 4 keyInsights, full conclusion), so this is a **coverage-gap fix**.

**Fixed gap:** the `sections` array started at line 42, leaving lines 1–41 — the entire module docstring (which states the open question, contrasts Mathlib's antidiagonal `Nat.add_choose_eq` with the textbook range form, and lists what the file proves) plus the imports/namespace — with no section coverage.

**Fix:** added a `preamble` section (1–41). Sections now cover the full file 1–117 with no gap or overlap.

Verified: JSON valid, meta.json within caps, gallery build + search-index checks pass; no annotation-line errors for this entry.