### PR TITLE
research(erdos-18-oq-01): full-range representation up to abundancy 4

### DIFF
--- a/proofs/Proofs/Erdos18OQ01.lean
+++ b/proofs/Proofs/Erdos18OQ01.lean
@@ -359,6 +359,45 @@ theorem practical_two_mul_pred_le_sigma {m : ℕ} (hm : 1 ≤ m) (hp : IsPractic
     2 * m - 1 ≤ (divisors m).sum id :=
   representable_le_sigma (practical_represents_lt_two_mul hp (by omega))
 
+/-! ## Full-range representation up to abundancy `4`
+
+`practical_represents_all_of_sigma_le_two_mul` shows a practical `m` represents the
+*whole* range `[0, σ(m)]` when its abundancy `σ(m)/m` is at most `2`, by tiling with
+the two width-`m` end segments.  The bottom *double*-block `[0, 2m)`
+(`practical_represents_lt_two_mul`) is twice as wide, and reflecting it through the
+complement symmetry `representable_compl` gives an equally wide top block; the two
+together reach all the way up to abundancy `4`.  This band `(2, 4)` contains the bulk
+of the small practicals not already covered (e.g. `12, 20, 24, 120`). -/
+
+/-- **Practical numbers represent their entire TOP double-block `(σ(m) − 2m, σ(m)]`.**
+    Reflecting the bottom double-block `[0, 2m)` (`practical_represents_lt_two_mul`)
+    through the complement symmetry `representable_compl` yields a width-`2m` top
+    block — twice the width of `practical_top_segment`.  Concretely, whenever
+    `σ(m) − k < 2m` (with `k ≤ σ(m)`), the reflected value `σ(m) − k` lies in the
+    bottom block and is representable, and complementing it back recovers `k`. -/
+theorem practical_top_block {m : ℕ} (hp : IsPractical m) {k : ℕ}
+    (hk : k ≤ (divisors m).sum id) (hlo : (divisors m).sum id - k < 2 * m) :
+    IsRepresentable k m := by
+  have hrep := representable_compl (practical_represents_lt_two_mul hp hlo)
+  have hcancel : (divisors m).sum id - ((divisors m).sum id - k) = k := by omega
+  rwa [hcancel] at hrep
+
+/-- **Full-range representation when the abundancy is below `4`.**  The bottom
+    double-block `[0, 2m)` (`practical_represents_lt_two_mul`) and its mirror image
+    the top double-block `(σ(m) − 2m, σ(m)]` (`practical_top_block`) overlap — and so
+    tile the whole range `[0, σ(m)]` — exactly when `σ(m) − 2m < 2m`, that is
+    `σ(m) < 4m` (abundancy `σ(m)/m < 4`).  Under that hypothesis a practical `m`
+    represents *every* `k ≤ σ(m)`.  This strictly strengthens
+    `practical_represents_all_of_sigma_le_two_mul` (abundancy `≤ 2`): it additionally
+    covers the band `(2, 4)`, e.g. `12` (`σ = 28 < 48`), `20` (`σ = 42 < 80`),
+    `24` (`σ = 60 < 96`), and `120` (`σ = 360 < 480`). -/
+theorem practical_represents_all_of_sigma_lt_four_mul {m : ℕ} (hp : IsPractical m)
+    (hσ : (divisors m).sum id < 4 * m) {k : ℕ} (hk : k ≤ (divisors m).sum id) :
+    IsRepresentable k m := by
+  rcases lt_or_ge k (2 * m) with hlt | hge
+  · exact practical_represents_lt_two_mul hp hlt
+  · exact practical_top_block hp hk (by omega)
+
 /-! ## Multiplicative closure under doubling
 
 If `m` is practical, so is `2m`.  This is the smallest case of the

--- a/research/problems/erdos-18-oq-01/knowledge.md
+++ b/research/problems/erdos-18-oq-01/knowledge.md
@@ -81,3 +81,39 @@ Verified 0 axioms / 0 sorries, no native_decide; theoremCount 25→27, lineCount
 
 Remaining open (unchanged): the asymptotic `h(m)` / Mertens–Vose density bounds — analytic,
 out of elementary reach.
+
+## Session 2026-07-11 (researcher-6) — full range to abundancy 4
+
+SOLVED-state look-outward. The file had two full-range results reaching only abundancy
+`σ(m)/m ≤ 2` (`practical_represents_all_of_sigma_le_two_mul`, tiling `[0,σ(m)]` with two
+width-`m` end segments). Pushed the reach to **abundancy < 4** by using the double-width
+bottom block `[0,2m)` (`practical_represents_lt_two_mul`, already present) plus its mirror
+under complement symmetry.
+
+- `practical_top_block` — practical `m` represents its TOP double-block `(σ(m)−2m, σ(m)]`:
+  for `k ≤ σ(m)` with `σ(m)−k < 2m`, the reflected `σ(m)−k` is in the bottom block, then
+  `representable_compl` complements back. Proof is 3 lines (`representable_compl` +
+  `omega` cancel `σ−(σ−k)=k`).
+- `practical_represents_all_of_sigma_lt_four_mul` — `IsPractical m → σ(m) < 4m → k ≤ σ(m)
+  → IsRepresentable k m`. `rcases lt_or_ge k (2*m)`: bottom block for `k<2m`, else
+  `practical_top_block` with `σ−k<2m` (omega from `k≥2m, σ<4m`). Strictly generalizes the
+  abundancy-≤2 result; covers band (2,4): 12 (σ=28<48), 20 (42<80), 24 (60<96), 120
+  (360<480).
+
+Verified 0 axioms / 0 sorries, no native_decide; theoremCount 37→39
+(`docker-build.sh Proofs.Erdos18OQ01` → `✔ Built (4.2s)`, 7744 jobs). PR #38162.
+
+★Gotchas / ops:
+- ★★.loom worktree REAPED TWICE mid-session (once mid docker-build → wiped uncommitted
+  edits + working tree clean; once the whole dir deleted → cwd recovered to /Users/rwalters).
+  Fix confirmed: EXTERNAL `git worktree add /Users/rwalters/lg-r6-erdos18` + COMMIT before
+  building. docker-build uses its own Azure cache volume, works fine from external worktree.
+- Dropped a concrete `twelve_represents_all` corollary that needed `(divisors 12).sum id =
+  28 := by decide` — the decide risks heavy kernel reduction (exit 135/SIGBUS ambiguity);
+  the docstring lists the σ values as illustration instead. Kept file 0-axiom.
+- Pre-existing `le_or_lt` deprecation warning at line 318 (in the abundancy-≤2 theorem, not
+  mine) — harmless, left as-is.
+
+Remaining open (unchanged): abundancy ≥ 4 full range needs the greedy sorted-divisor
+characterization (d_{i+1} ≤ σ_i+1), a larger project; asymptotic h(m)/Vose density stays
+out of elementary reach.


### PR DESCRIPTION
## Summary

Extends the practical-numbers structural theory in `Proofs/Erdos18OQ01.lean` with a
sharper **full-range representation** criterion.

A practical number `m` represents every `k ≤ σ(m)` as a sum of distinct divisors. The
file already proved this under abundancy `σ(m)/m ≤ 2`
(`practical_represents_all_of_sigma_le_two_mul`), tiling `[0, σ(m)]` with two width-`m`
end segments. This PR reaches all the way to **abundancy `< 4`** by using the *double*-width
bottom block `[0, 2m)` (`practical_represents_lt_two_mul`, already in the file) together
with its mirror image under the complement symmetry `representable_compl`.

### New theorems

- `practical_top_block` — a practical `m` represents its entire **top double-block**
  `(σ(m) − 2m, σ(m)]`, obtained by reflecting the bottom block `[0, 2m)` through
  `k ↦ σ(m) − k` (`representable_compl`). Twice the width of `practical_top_segment`.
- `practical_represents_all_of_sigma_lt_four_mul` — if `m` is practical and
  `σ(m) < 4m`, then `m` represents **every** `k ≤ σ(m)`. The bottom block `[0, 2m)`
  and the top block `(σ(m) − 2m, σ(m)]` overlap exactly when `σ(m) − 2m < 2m`, tiling
  the whole range.

This **strictly strengthens** `practical_represents_all_of_sigma_le_two_mul`: it
additionally covers the abundancy band `(2, 4)`, which contains the bulk of the small
practicals not previously reached — e.g. `12` (`σ = 28 < 48`), `20` (`σ = 42 < 80`),
`24` (`σ = 60 < 96`), and `120` (`σ = 360 < 480`).

## Verification

- `./proofs/scripts/docker-build.sh Proofs.Erdos18OQ01` → `✔ Built (4.2s)`, 7744 jobs.
- 0 sorries, 0 `axiom` declarations, no `native_decide` — fully machine-checked.
- Theorem count 37 → 39; proofs use only `omega`, `rcases`, and the existing
  representability lemmas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)