### PR TITLE
research(erdos-1064-oq-03): first formalization of the OQ-03 higher iterate D(n)

### DIFF
--- a/proofs/Proofs/Erdos1064Problem.lean
+++ b/proofs/Proofs/Erdos1064Problem.lean
@@ -334,4 +334,141 @@ For n = 15 · 2^k, we have φ(n) < φ(n - φ(n)).
 - This is because 15 · 2^k - φ(15 · 2^k) = 15 · 2^k - 4 · 2^k = 11 · 2^k
   and φ(11 · 2^k) = 5 · 2^k > 4 · 2^k = φ(15 · 2^k) -/
 
+/-! ## OQ-03: the higher iterate `D(n) = n − φ(n − φ(n))`
+
+Erdős 1064 OQ-03 iterates the construction one step further: from `n` form the
+*second-order* value `D(n) = n − φ(n − φ(n))` and compare `φ(n)` with `φ(D(n))`.
+This is the object the open question is stated about; the parent file above only
+develops the first-order comparison `φ(n)` vs `φ(n − φ(n))`.  Here we give the
+first Lean formalization of the OQ-03 iterate together with its elementary
+structural facts.
+
+The trichotomy `B₊ / B₋ / B₌` partitions ℕ exactly as `A₊ / A₋ / A₌` does.  Two
+elementary infinitude results are proved unconditionally (no density input):
+
+* **Odd primes lie in `B₊`.**  For an odd prime `p`, `n − φ(n) = 1`, so
+  `D(p) = p − φ(1) = p − 1` and `φ(D(p)) = φ(p − 1) < p − 1 = φ(p)`.  Hence `B₊`
+  is infinite.
+* **The parent reversal family lands in `B₌`.**  The family `15·2^(k+1)` — which
+  *reverses* the first-order comparison (`mem_A_less_pow`, it lies in `A₋`) —
+  gives `D(15·2^(k+1)) = 5·2^(k+2)` with `φ(D(n)) = 8·2^k = φ(n)`: **equality** at
+  the second order.  So the second iterate *neutralizes* the parent reversal, and
+  `B₌` is infinite.
+
+The deep forward direction (`φ(n) > φ(D(n))` for almost all `n`, the density-1
+analogue of Luca–Pomerance for the iterate) needs the same class of analytic input
+as the parent and is left open. -/
+
+/-- The OQ-03 second-order iterate `D(n) = n − φ(n − φ(n))`. -/
+def D (n : ℕ) : ℕ := n - Nat.totient (n - Nat.totient n)
+
+/-- `B₊`: the set where `φ(n) > φ(D(n))` (OQ-03 "greater" regime). -/
+def B_greater : Set ℕ := {n : ℕ | Nat.totient n > Nat.totient (D n)}
+
+/-- `B₋`: the set where `φ(n) < φ(D(n))` (OQ-03 "less" regime). -/
+def B_less : Set ℕ := {n : ℕ | Nat.totient n < Nat.totient (D n)}
+
+/-- `B₌`: the set where `φ(n) = φ(D(n))` (OQ-03 "equal" regime). -/
+def B_equal : Set ℕ := {n : ℕ | Nat.totient n = Nat.totient (D n)}
+
+/-- The OQ-03 trichotomy is exhaustive: `B₊ ∪ B₋ ∪ B₌ = ℕ`. -/
+theorem B_greater_union_B_less_union_B_equal :
+    B_greater ∪ B_less ∪ B_equal = Set.univ := by
+  ext n
+  simp only [B_greater, B_less, B_equal, Set.mem_union, Set.mem_setOf_eq, Set.mem_univ,
+    iff_true]
+  omega
+
+/-- `B₊` and `B₋` are disjoint. -/
+theorem B_greater_disjoint_B_less : Disjoint B_greater B_less := by
+  rw [Set.disjoint_left]; intro n hn hn'
+  simp only [B_greater, B_less, Set.mem_setOf_eq] at hn hn'; omega
+
+/-- `B₊` and `B₌` are disjoint. -/
+theorem B_greater_disjoint_B_equal : Disjoint B_greater B_equal := by
+  rw [Set.disjoint_left]; intro n hn hn'
+  simp only [B_greater, B_equal, Set.mem_setOf_eq] at hn hn'; omega
+
+/-- `B₋` and `B₌` are disjoint. -/
+theorem B_less_disjoint_B_equal : Disjoint B_less B_equal := by
+  rw [Set.disjoint_left]; intro n hn hn'
+  simp only [B_less, B_equal, Set.mem_setOf_eq] at hn hn'; omega
+
+/-- **Every odd prime lies in `B₊`** (OQ-03 greater regime).  For an odd prime
+    `p`: `φ(p) = p − 1`, so `p − φ(p) = 1`, `D(p) = p − φ(1) = p − 1`, and
+    `φ(D(p)) = φ(p − 1) < p − 1 = φ(p)` by `Nat.totient_lt` (as `p − 1 ≥ 2`). -/
+theorem mem_B_greater_of_prime {p : ℕ} (hp : p.Prime) (hp3 : 3 ≤ p) : p ∈ B_greater := by
+  have hφ : Nat.totient p = p - 1 := Nat.totient_prime hp
+  have hsub1 : p - Nat.totient p = 1 := by rw [hφ]; omega
+  have hD : D p = p - 1 := by unfold D; rw [hsub1, Nat.totient_one]
+  show Nat.totient p > Nat.totient (D p)
+  rw [hD, hφ]
+  exact Nat.totient_lt (p - 1) (by omega)
+
+/-- **`B₊` is infinite (axiom-free).**  Every odd prime lies in `B₊`
+    (`mem_B_greater_of_prime`) and there are infinitely many primes.  The OQ-03
+    analogue of `A_greater_infinite`. -/
+theorem B_greater_infinite : B_greater.Infinite := by
+  have hsub : {p : ℕ | p.Prime} \ {2} ⊆ B_greater := by
+    rintro p ⟨hp, hp2⟩
+    have hne : p ≠ 2 := by simpa using hp2
+    exact mem_B_greater_of_prime hp (by have := hp.two_le; omega)
+  exact Set.Infinite.mono hsub
+    (Nat.infinite_setOf_prime.diff (Set.finite_singleton 2))
+
+/-- **The parent reversal family `15·2^(k+1)` lands in `B₌`.**  For `n = 15·2^(k+1)`
+    the parent computation gives `φ(n) = 8·2^k` and `n − φ(n) = 11·2^(k+1)` with
+    `φ(n − φ(n)) = 10·2^k`, so `D(n) = n − 10·2^k = 20·2^k = 5·2^(k+2)` and
+    `φ(D(n)) = φ(5)·φ(2^(k+2)) = 4·2^(k+1) = 8·2^k = φ(n)`.  So although this family
+    *reverses* the first-order comparison (`mem_A_less_pow`, `n ∈ A₋`), the second
+    iterate produces **equality**: the reversal is neutralized at order two. -/
+theorem mem_B_equal_pow (k : ℕ) : 15 * 2 ^ (k + 1) ∈ B_equal := by
+  have h15 : Nat.totient 15 = 8 := by
+    have h35 : (15 : ℕ) = 3 * 5 := by norm_num
+    rw [h35, Nat.totient_mul (by norm_num), Nat.totient_prime (by norm_num),
+        Nat.totient_prime (by norm_num)]
+  have h11 : Nat.totient 11 = 10 := Nat.totient_prime (by norm_num)
+  have h5 : Nat.totient 5 = 4 := Nat.totient_prime (by norm_num)
+  have hp2 : Nat.totient (2 ^ (k + 1)) = 2 ^ k := by
+    rw [Nat.totient_prime_pow Nat.prime_two (Nat.succ_pos k)]; simp
+  have hp2' : Nat.totient (2 ^ (k + 2)) = 2 ^ (k + 1) := by
+    rw [Nat.totient_prime_pow Nat.prime_two (Nat.succ_pos (k + 1))]; simp
+  have cop15 : Nat.Coprime 15 (2 ^ (k + 1)) :=
+    (show Nat.Coprime 15 2 by norm_num).pow_right (k + 1)
+  have cop11 : Nat.Coprime 11 (2 ^ (k + 1)) :=
+    (show Nat.Coprime 11 2 by norm_num).pow_right (k + 1)
+  have cop5 : Nat.Coprime 5 (2 ^ (k + 2)) :=
+    (show Nat.Coprime 5 2 by norm_num).pow_right (k + 2)
+  -- φ(n) = 8·2^k
+  have hφn : Nat.totient (15 * 2 ^ (k + 1)) = 8 * 2 ^ k := by
+    rw [Nat.totient_mul cop15, h15, hp2]
+  -- n − φ(n) = 11·2^(k+1)
+  have hsub : 15 * 2 ^ (k + 1) - 8 * 2 ^ k = 11 * 2 ^ (k + 1) := by
+    have h2 : (2 : ℕ) ^ (k + 1) = 2 * 2 ^ k := by rw [pow_succ]; ring
+    rw [h2]; omega
+  -- φ(n − φ(n)) = 10·2^k
+  have hφsub : Nat.totient (11 * 2 ^ (k + 1)) = 10 * 2 ^ k := by
+    rw [Nat.totient_mul cop11, h11, hp2]
+  -- D(n) = n − 10·2^k = 20·2^k = 5·2^(k+2)
+  have hDval : 15 * 2 ^ (k + 1) - 10 * 2 ^ k = 5 * 2 ^ (k + 2) := by
+    have h2 : (2 : ℕ) ^ (k + 1) = 2 * 2 ^ k := by rw [pow_succ]; ring
+    have h2' : (2 : ℕ) ^ (k + 2) = 4 * 2 ^ k := by rw [pow_succ, pow_succ]; ring
+    rw [h2, h2']; omega
+  have hD : D (15 * 2 ^ (k + 1)) = 5 * 2 ^ (k + 2) := by
+    unfold D; rw [hφn, hsub, hφsub, hDval]
+  -- φ(D(n)) = 8·2^k
+  have hφD : Nat.totient (5 * 2 ^ (k + 2)) = 8 * 2 ^ k := by
+    rw [Nat.totient_mul cop5, h5, hp2']
+    have h2' : (2 : ℕ) ^ (k + 1) = 2 * 2 ^ k := by rw [pow_succ]; ring
+    rw [h2']; ring
+  show Nat.totient (15 * 2 ^ (k + 1)) = Nat.totient (D (15 * 2 ^ (k + 1)))
+  rw [hφn, hD, hφD]
+
+/-- **`B₌` is infinite (axiom-free).**  The family `15·2^(k+1)` lies in `B₌`
+    (`mem_B_equal_pow`) and `k ↦ 15·2^(k+1)` is injective (`witness_injective`).
+    So the OQ-03 comparison is an *equality* infinitely often — a regime distinct
+    from the parent, where the same family instead produced strict reversal. -/
+theorem B_equal_infinite : B_equal.Infinite :=
+  Set.infinite_of_injective_forall_mem witness_injective mem_B_equal_pow
+
 end Erdos1064


### PR DESCRIPTION
## Summary

Erdős 1064 **OQ-03** iterates the parent construction one step further: from `n` form the second-order value `D(n) = n − φ(n − φ(n))` and compare `φ(n)` with `φ(D(n))`. The gallery file `Proofs/Erdos1064Problem.lean` previously formalized only the *first-order* comparison (`φ(n)` vs `φ(n − φ(n))`); the OQ-03 object itself was **not present anywhere in the repo**. This PR gives its first Lean formalization plus elementary structural theory.

## New content (all axiom-free, no `native_decide`)

- `def D (n) := n − φ(n − φ(n))`, sets `B_greater / B_less / B_equal`, and the trichotomy (pairwise `Disjoint` + `B₊ ∪ B₋ ∪ B₌ = univ`).
- **`mem_B_greater_of_prime`** — every odd prime `p` lies in `B₊`: `n − φ(n) = 1`, so `D(p) = p − φ(1) = p − 1` and `φ(D(p)) = φ(p−1) < p − 1 = φ(p)` (via `Nat.totient_lt`). ⇒ **`B_greater_infinite`**.
- **`mem_B_equal_pow`** — the parent *reversal* family `15·2^(k+1)` (which lies in `A₋`, `mem_A_less_pow`) lands in **`B₌`** at the second order: `D(15·2^(k+1)) = 5·2^(k+2)` and `φ(D(n)) = φ(5)·φ(2^(k+2)) = 4·2^(k+1) = 8·2^k = φ(n)`. The second iterate **neutralizes** the parent reversal into equality. ⇒ **`B_equal_infinite`** (reusing the parent's `witness_injective`).

## Verification

- `./proofs/scripts/docker-build.sh Proofs.Erdos1064Problem` → **Build succeeded (7743 jobs)**, 0 sorries.
- `axiomCount` unchanged (1 — the deep `lucaPomerance_density_one`). The only build warning (`mul_le_mul_left'` deprecation, line 282) is pre-existing in the parent code, not from this change.

## Honest significance

Modest but genuine: it introduces the OQ-03 comparison object (absent until now) and its elementary structural facts, including the clean observation that the parent's strict-reversal family becomes an OQ-03 *equality* family. The deep forward direction — `φ(n) > φ(D(n))` for almost all `n`, the density-1 analogue of Luca–Pomerance for the iterate — needs the same class of analytic input as the parent and is left open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)