### PR TITLE
Enrich cauchy-group-theorem-oq-01-oq-01: add missing preamble section

### DIFF
--- a/src/data/proofs/cauchy-group-theorem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/cauchy-group-theorem-oq-01-oq-01/meta.json
@@ -63,6 +63,14 @@
   },
   "sections": [
     {
+      "id": "preamble",
+      "title": "Module Header and Imports",
+      "startLine": 1,
+      "endLine": 63,
+      "summary": "Imports (GroupTheory.OrderOfElement, Perm.Cycle.Type, ZMod.Basic, Tactic) and the module docstring, which frames the theme: consequences of odd group order — squaring is a bijection, there are no involutions, and the connection to the odd-order setting of the Feit–Thompson programme. Enters the namespace and fixes the ambient group variable {G}.",
+      "mathContext": "Odd $|G|$ ⟹ $x \\mapsto x^2$ bijective and no element of order 2; the standing hypothesis of the Feit–Thompson odd-order theorem."
+    },
+    {
       "id": "squaring",
       "title": "Squaring in Odd-Order Groups",
       "startLine": 64,


### PR DESCRIPTION
Enrichment pass for `cauchy-group-theorem-oq-01-oq-01` (consequences of odd group order, q96, pass 0). Met all content minimums — **coverage-gap fix**.

**Fixed gap:** `sections` started at line 64, leaving lines 1–63 (the imports and the module docstring that frames the odd-order/Feit–Thompson theme) uncovered.

**Fix:** added a `preamble` section (1–63). Sections now cover the full file 1–151 with no gap or overlap.

Verified: JSON valid, within caps, build + search-index checks pass.