### PR TITLE
Enrich cauchy-interlacing-theorem-oq-01: realign drifted section ranges + add preamble

### DIFF
--- a/src/data/proofs/cauchy-interlacing-theorem-oq-01/annotations.json
+++ b/src/data/proofs/cauchy-interlacing-theorem-oq-01/annotations.json
@@ -24,9 +24,21 @@
     "prerequisites": ["orthogonal projection onto a subspace", "linear map composition"]
   },
   {
+    "id": "ann-projection-adjoint",
+    "proofId": "cauchy-interlacing-theorem-oq-01",
+    "range": { "startLine": 72, "endLine": 99 },
+    "type": "technique",
+    "title": "The Projection-Adjoint Identity (the workhorse)",
+    "content": "`inner_compress_eq` and `inner_compress_eq'` record the same fact in the two inner-product slots: for `y, z ∈ H`, `⟪compress T H y, z⟫_H = ⟪T ↑y, ↑z⟫_V` and `⟪y, compress T H z⟫_H = ⟪↑y, T ↑z⟫_V`. Both are unconditional (no symmetry of `T` needed) and both reduce to the orthogonal-projection adjoint identity `⟪P_H v, u⟫ = ⟪v, u⟫` for `u ∈ H`. Isolating these two lemmas is what lets the symmetry and Rayleigh results below be one-liners.",
+    "mathContext": "$\\langle P_H v, u\\rangle = \\langle v, u\\rangle$ for $u \\in H$: the orthogonal projection is self-adjoint and fixes $H$ pointwise, so it vanishes when paired against a vector of $H$.",
+    "significance": "supporting",
+    "relatedConcepts": ["orthogonal projection adjoint", "self-adjoint operator", "inner product on a submodule"],
+    "prerequisites": ["orthogonal projection onto a subspace", "adjoint of an orthogonal projection"]
+  },
+  {
     "id": "ann-compress-symmetric",
     "proofId": "cauchy-interlacing-theorem-oq-01",
-    "range": { "startLine": 72, "endLine": 85 },
+    "range": { "startLine": 100, "endLine": 114 },
     "type": "insight",
     "title": "The Compression Inherits Symmetry",
     "content": "`isSymmetric_compress`: for `y, z ∈ H`, the adjoint identity `⟪P_H v, u⟫ = ⟪v, u⟫` (valid because `u ∈ H`) collapses `⟪compress y, z⟫_H` to the ambient `⟪T ↑y, ↑z⟫_V` and `⟪y, compress z⟫_H` to `⟪↑y, T ↑z⟫_V`. These agree precisely because `T` is symmetric. So projecting before pairing against a vector of `H` is invisible, and symmetry passes to the compression.",
@@ -38,7 +50,7 @@
   {
     "id": "ann-rayleigh-agreement",
     "proofId": "cauchy-interlacing-theorem-oq-01",
-    "range": { "startLine": 87, "endLine": 96 },
+    "range": { "startLine": 115, "endLine": 125 },
     "type": "insight",
     "title": "Rayleigh Quotients Agree Exactly",
     "content": "`rayleigh_compress_eq`: the same projection identity with `z = y` gives `⟪compress y, y⟫_H = ⟪T ↑y, ↑y⟫_V`, and the subspace inherits the ambient norm so `‖y‖ = ‖↑y‖` (`Submodule.coe_norm`). Hence `re⟪compress y, y⟫_H / ‖y‖² = re⟪T ↑y, ↑y⟫_V / ‖↑y‖²` exactly. This is the Rayleigh-agreement hypothesis that the abstract parent theorem takes as an input — here proved.",
@@ -50,7 +62,7 @@
   {
     "id": "ann-corollary",
     "proofId": "cauchy-interlacing-theorem-oq-01",
-    "range": { "startLine": 98, "endLine": 138 },
+    "range": { "startLine": 126, "endLine": 166 },
     "type": "insight",
     "title": "The Unconditional Compression Corollary",
     "content": "`cauchy_interlacing_compression`: the spectral data of `T` on `V` and of `compress T H` on `H` are pulled from Mathlib's spectral theorem (`eigenvectorBasis`, `eigenvalues`, `eigenvalues_antitone`), `rayleigh_compress_eq` supplies the Rayleigh hypothesis, and the parent's `cauchy_interlacing` then yields `λ(k.succ) ≤ μ(k) ∧ μ(k) ≤ λ(k.castSucc)`. No hypothesis is needed beyond 'T symmetric, H a codimension-one subspace'.",

--- a/src/data/proofs/cauchy-interlacing-theorem-oq-01/meta.json
+++ b/src/data/proofs/cauchy-interlacing-theorem-oq-01/meta.json
@@ -76,34 +76,50 @@
   },
   "sections": [
     {
+      "id": "preamble",
+      "title": "Module Header and Imports",
+      "startLine": 1,
+      "endLine": 62,
+      "summary": "Imports Mathlib and the parent assembly file (Proofs.CauchyInterlacingAssembly), and gives the module docstring: the parent proves abstract Cauchy interlacing with a Rayleigh-agreement hypothesis; this file constructs the orthogonal compression explicitly and discharges that hypothesis. Opens the inner-product-space and parent namespaces and fixes the ambient variables (𝕜 an RCLike field, V an inner product space).",
+      "mathContext": "Set-up: symmetric $T$ on a finite-dimensional inner product space $V$, and a codimension-one subspace $H$; goal is the unconditional interlacing $\\lambda_{k+1} \\le \\mu_k \\le \\lambda_k$."
+    },
+    {
       "id": "compress-def",
       "title": "The Compression Operator",
-      "startLine": 60,
-      "endLine": 70,
-      "summary": "Defines compress T H := (P_H : V →L[𝕜] H) ∘ₗ (T ∘ₗ H.subtype) and the unfolding simp lemma compress_apply: compress T H y = P_H (T ↑y). This is the orthogonal compression of T to H, the coordinate-free principal-submatrix operator.",
+      "startLine": 63,
+      "endLine": 71,
+      "summary": "Defines compress T H := (P_H : V →L[𝕜] H) ∘ₗ (T ∘ₗ H.subtype), the orthogonal compression of T to H — the coordinate-free principal-submatrix operator that projects T ↑y back into H.",
       "mathContext": "Projecting T ↑y back into H is exactly what deleting the rows/columns outside H does to a matrix."
+    },
+    {
+      "id": "projection-adjoint",
+      "title": "The Projection-Adjoint Identity",
+      "startLine": 72,
+      "endLine": 99,
+      "summary": "inner_compress_eq and inner_compress_eq' (unconditional, left- and right-slot): ⟪compress T H y, z⟫_H = ⟪T ↑y, ↑z⟫ and ⟪y, compress T H z⟫_H = ⟪↑y, T ↑z⟫, both via the orthogonal-projection adjoint identity ⟪P_H v, u⟫ = ⟪v, u⟫ for u ∈ H. This one identity powers both the symmetry and the Rayleigh lemmas below.",
+      "mathContext": "$\\langle P_H v, u\\rangle = \\langle v, u\\rangle$ for $u \\in H$ — the orthogonal projection is self-adjoint and fixes H pointwise."
     },
     {
       "id": "symmetry",
       "title": "Symmetry of the Compression",
-      "startLine": 72,
-      "endLine": 85,
-      "summary": "isSymmetric_compress: both ⟪compress y, z⟫_H and ⟪y, compress z⟫_H collapse to ambient inner products via the projection adjoint identity, then agree because T is symmetric.",
+      "startLine": 100,
+      "endLine": 114,
+      "summary": "isSymmetric_compress: both ⟪compress y, z⟫_H and ⟪y, compress z⟫_H collapse to ambient inner products via the projection-adjoint identities, then agree because T is symmetric.",
       "mathContext": "The orthogonal projection is self-adjoint and fixes H, so it disappears when paired against a vector of H."
     },
     {
       "id": "rayleigh",
       "title": "Rayleigh-Quotient Agreement",
-      "startLine": 87,
-      "endLine": 96,
+      "startLine": 115,
+      "endLine": 125,
       "summary": "rayleigh_compress_eq: re⟪compress y, y⟫_H / ‖y‖² = re⟪T ↑y, ↑y⟫_V / ‖↑y‖² exactly — the projection identity plus the subspace-norm equality ‖y‖ = ‖↑y‖. This is the hypothesis the abstract theorem demands, now proved.",
       "mathContext": "The compression and the ambient operator have identical Rayleigh quotients on H, which is the defining property used to transport eigenvalue bounds across the compression."
     },
     {
       "id": "corollary",
       "title": "The Compression Corollary",
-      "startLine": 98,
-      "endLine": 138,
+      "startLine": 126,
+      "endLine": 166,
       "summary": "cauchy_interlacing_compression: pulls the spectral data of T (on V) and of compress T H (on H) from Mathlib's spectral theorem, packages rayleigh_compress_eq as the Rayleigh hypothesis, and applies the parent's cauchy_interlacing to conclude λ(k.succ) ≤ μ(k) ∧ μ(k) ≤ λ(k.castSucc).",
       "mathContext": "The unconditional operator-level Cauchy interlacing theorem: any symmetric operator interlaces its compression to any hyperplane."
     }


### PR DESCRIPTION
Enrichment pass for `cauchy-interlacing-theorem-oq-01` (self-contained compression corollary of Cauchy interlacing, q96, pass 0). **Accuracy fix** — the section ranges had drifted out of alignment with the Lean file.

**Fixed defects:**
- The section line ranges no longer matched the theorems they described: `symmetry` (72–85) actually sat on `inner_compress_eq`, `rayleigh` (87–96) on `inner_compress_eq'`, and `corollary` (98–138) ended before its theorem `cauchy_interlacing_compression` at line 140.
- Lines 1–59 (module docstring + imports) were uncovered, and the two **projection-adjoint** theorems (`inner_compress_eq`/`inner_compress_eq'`) — the identity that powers the whole file — had no section.

**Fix:** re-partitioned into 6 correctly-aligned, contiguous sections: preamble (1–62), compress-def (63–71), projection-adjoint (72–99), symmetry (100–114), rayleigh (115–125), corollary (126–166). Sections now cover the whole file 1–166 with no gaps or overlaps and each maps to its actual theorem(s).

Verified: JSON valid, within caps, build + search-index checks pass.