### PR TITLE
research(tetrahedral-number-formula-oq-01): first-moment weighted hockey stick

### DIFF
--- a/proofs/Proofs/TetrahedralNumberFormulaOQ01.lean
+++ b/proofs/Proofs/TetrahedralNumberFormulaOQ01.lean
@@ -896,5 +896,77 @@ theorem sum_Ioc_simplex_over_dim (d : ℕ) {m n : ℕ} (h : m ≤ n) :
   rw [simplexNumber_symm m (d + 1), simplexNumber_symm n (d + 1), hsum]
   exact sum_Ioc_simplex d h
 
+/-! ### First-moment (weighted) hockey stick
+
+The hockey stick `sum_simplex` computes the *plain* sum of a figurate row,
+`∑_{k≤n} P_d(k) = P_{d+1}(n)` — the discrete analogue of `∫₀ⁿ x^d = n^{d+1}/(d+1)`.
+The lemmas below compute the *first moment* of a figurate row, weighting each term by
+its index `k`. This is the discrete analogue of `∫₀ⁿ x·x^d = n^{d+2}/(d+2)`, and it
+identifies the (unnormalised) centre of mass of the figurate row as, again, a single
+higher-dimensional simplex number.
+
+The one-step engine is the pointwise **figurate absorption identity**
+`(j+1)·P_d(j+1) = (d+1)·P_{d+1}(j)`, the figurate face of Mathlib's binomial absorption
+`Nat.choose_succ_right_eq`. Summing it and collapsing with `sum_simplex` gives the moment.
+-/
+
+/-- **Figurate absorption identity.** Moving the index weight `j+1` inside the simplex
+number raises the dimension and lowers the size:
+
+`(j+1)·P_d(j+1) = (d+1)·P_{d+1}(j)`.
+
+This is the figurate face of the binomial absorption rule `Nat.choose_succ_right_eq`
+(`C(m,k+1)·(k+1) = C(m,k)·(m-k)`): with `m = j+d+1` and `k = d` the top-index difference
+`m - d` is exactly the weight `j+1`. It is the pointwise engine behind the first-moment
+hockey stick `weighted_sum_simplex`. -/
+theorem succ_mul_simplexNumber (d j : ℕ) :
+    (j + 1) * simplexNumber d (j + 1) = (d + 1) * simplexNumber (d + 1) j := by
+  unfold simplexNumber
+  have hm : j + 1 + d = j + d + 1 := by ring
+  have hm2 : j + (d + 1) = j + d + 1 := by ring
+  rw [hm, hm2]
+  have h := Nat.choose_succ_right_eq (j + d + 1) d
+  have hsub : j + d + 1 - d = j + 1 := by omega
+  rw [hsub] at h
+  rw [Nat.mul_comm (j + 1), Nat.mul_comm (d + 1)]
+  exact h.symm
+
+/-- **First-moment (weighted) hockey stick.** Weighting each figurate number in a row by
+its index and summing collapses to a single higher-dimensional simplex number:
+
+`∑_{k≤n+1} k·P_d(k) = (d+1)·P_{d+2}(n)`.
+
+This is the index-weighted companion of the plain hockey stick `sum_simplex`
+(`∑ P_d = P_{d+1}`), and the discrete analogue of the first moment
+`∫₀ⁿ x·x^d = n^{d+2}/(d+2)`. Proof: the `k = 0` term vanishes, so reindexing `k = j+1`
+(`Finset.sum_range_succ'`) turns each term into `(j+1)·P_d(j+1)`, which the absorption
+identity `succ_mul_simplexNumber` rewrites as `(d+1)·P_{d+1}(j)`; pulling the constant
+`d+1` out and applying `sum_simplex (d+1)` collapses the remaining plain row to
+`P_{d+2}(n)`. The `d = 0` case is `∑_{k≤n+1} k = C(n+2,2)`, the triangular numbers. -/
+theorem weighted_sum_simplex (d n : ℕ) :
+    ∑ k ∈ range (n + 2), k * simplexNumber d k
+      = (d + 1) * simplexNumber (d + 2) n := by
+  rw [Finset.sum_range_succ' (fun k => k * simplexNumber d k) (n + 1)]
+  simp only [Nat.zero_mul, Nat.add_zero]
+  rw [Finset.sum_congr rfl (fun i _ => succ_mul_simplexNumber d i),
+      ← Finset.mul_sum, sum_simplex (d + 1) n]
+
+/-- **First-moment hockey stick along the dimension axis.** The dimension-axis companion
+of `weighted_sum_simplex`, mirroring how `sum_simplex_over_dim` shadows `sum_simplex`:
+weighting a *column* of the figurate array (fixed size `d`, increasing dimension) by the
+index and summing gives
+
+`∑_{k≤n+1} k·P_k(d) = (d+1)·P_n(d+2)`.
+
+Immediate from `weighted_sum_simplex` through the reflection symmetry `simplexNumber_symm`
+(`P_a(b) = P_b(a)`), so the two axes of Pascal's simplex carry identical first moments. -/
+theorem weighted_sum_simplex_over_dim (d n : ℕ) :
+    ∑ k ∈ range (n + 2), k * simplexNumber k d
+      = (d + 1) * simplexNumber n (d + 2) := by
+  have h : ∑ k ∈ range (n + 2), k * simplexNumber k d
+      = ∑ k ∈ range (n + 2), k * simplexNumber d k :=
+    Finset.sum_congr rfl fun k _ => by rw [simplexNumber_symm k d]
+  rw [h, weighted_sum_simplex, simplexNumber_symm (d + 2) n]
+
 end TetrahedralNumberFormulaOQ01
 

--- a/src/data/research/problems/tetrahedral-number-formula-oq-01.json
+++ b/src/data/research/problems/tetrahedral-number-formula-oq-01.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "SOLVED/RICH: general figurate theory (38 thm, 0 sorry, 0 axiom) now includes the iterated forward-difference operator and general discrete FTC (Δ^a inverts ∑^a), completing the summation↔difference duality at the iterated level.",
+    "progressSummary": "COMPLETE: core hockey-stick theory plus first-moment (weighted) hockey stick; 0 sorries, 0 axioms",
     "builtItems": [
       "simplexNumber d n := (n+d).choose d - the d-dimensional hyper-tetrahedral number (TetrahedralNumberFormulaOQ01.lean)",
       "sum_simplex: sum_{k<=n} simplexNumber d k = simplexNumber (d+1) n - general hockey stick, any dimension d (via Nat.sum_range_add_choose)",
@@ -51,7 +51,10 @@
       "iterForwardDiff (TetrahedralNumberFormulaOQ01.lean:624) — iterated forward-difference operator Δ^a",
       "iterForwardDiff_iterSum (:639) — general discrete FTC: Δ^a(∑^a f)(n) = f(n+a), two-sided inverse of iterSum",
       "iterForwardDiff_simplexNumber (:665) — Δ^a P_{a+b}(n) = P_b(n+a), inverse of iterSum_simplexNumber",
-      "iterForwardDiff_self_simplexNumber (:681) — Δ^a P_a = 1, dual of iterSum_one"
+      "iterForwardDiff_self_simplexNumber (:681) — Δ^a P_a = 1, dual of iterSum_one",
+      "succ_mul_simplexNumber: figurate absorption (j+1)P_d(j+1)=(d+1)P_{d+1}(j) via Nat.choose_succ_right_eq (TetrahedralNumberFormulaOQ01.lean)",
+      "weighted_sum_simplex: first-moment hockey stick sum_{k<=n+1} k*P_d(k) = (d+1)*P_{d+2}(n)",
+      "weighted_sum_simplex_over_dim: dimension-axis dual via simplexNumber_symm"
     ],
     "insights": [
       "The hyper-tetrahedral / d-simplex number is exactly Mathlib Nat.multichoose (n+1) d = C(n+d,d); Mathlib gives the one-step hockey stick Nat.sum_range_add_choose : sum i in range(n+1),(i+d).choose d = (n+d+1).choose(d+1)",
@@ -61,7 +64,8 @@
       "Finset.sum_Ico_Ico_comm (a<=i<=j<b triangular swap) + Finset.sum_Ico_eq_sum_range cleanly reduce a nested partial-sum-of-convolution to a single hockey-stick collapse.",
       "VERIFIED (researcher-2, 2026-07-09, GREEN build): the order facts of the figurate ladder P_d(n)=C(n+d,d), absent from the file. simplexNumber_pos (0<P_d(n), Nat.choose_pos on d≤n+d), simplexNumber_mono_size (m≤n⟹P_d(m)≤P_d(n), Nat.choose_le_choose on m+d≤n+d), simplexNumber_mono_dim (a≤b⟹P_a(n)≤P_b(n), reduced to mono_size through the reflection symmetry simplexNumber_symm P_d(n)=P_n(d)). Monotone in BOTH arguments + positive. Complements the exact-value/summation theory with the growth/order structure.",
       "The figurate calculus is ℕ-linear: both iterated summation (iterSum) and simplex convolution (simplexConv) are additive and ℕ-homogeneous in the summand — the summand-side companion to the dimension-side semigroup laws iterSum_add / simplexConv_comp.",
-      "The summation↔difference duality closes at the ITERATED level: iterSum a (raise a dims) and iterForwardDiff a = Δ^a (lower a dims) are two-sided inverses up to the intrinsic shift Δ^a∘∑^a = shift^a; the shift is forced because each Δ reads a running total one index ahead."
+      "The summation↔difference duality closes at the ITERATED level: iterSum a (raise a dims) and iterForwardDiff a = Δ^a (lower a dims) are two-sided inverses up to the intrinsic shift Δ^a∘∑^a = shift^a; the shift is forced because each Δ reads a running total one index ahead.",
+      "Index-weighted figurate row sum (first moment) collapses to a single higher-dim simplex number, discrete analogue of int x*x^d = n^{d+2}/(d+2); engine is pointwise binomial absorption"
     ],
     "mathlibGaps": [
       "Mathlib has the one-step hockey stick and multichoose but no dimension-indexed figurate theory: no iterated-partial-sum characterization of simplex numbers, no figurate recurrence/closed form stated uniformly in the dimension d."


### PR DESCRIPTION
## Summary

Extends the fully-solved hyper-tetrahedral figurate theory in `TetrahedralNumberFormulaOQ01.lean` with the **first-moment (index-weighted) hockey stick** — the discrete analogue of the first moment `∫₀ⁿ x·xᵈ dx = n^{d+2}/(d+2)`. Where the file's `sum_simplex` computes the plain sum of a figurate row (`∑ Pᵈ = P^{d+1}`), this computes the row's (unnormalised) centre of mass, which again collapses to a single higher-dimensional simplex number.

Three new theorems (50 → 53), all **0 sorries, 0 axioms**, built clean (2.4s):

- **`succ_mul_simplexNumber`** — figurate absorption identity `(j+1)·Pᵈ(j+1) = (d+1)·P^{d+1}(j)`, the figurate face of Mathlib's binomial absorption `Nat.choose_succ_right_eq`. The pointwise engine.
- **`weighted_sum_simplex`** — the first-moment hockey stick `∑_{k≤n+1} k·Pᵈ(k) = (d+1)·P^{d+2}(n)`. Proof: the `k=0` term vanishes, reindex `k=j+1`, apply absorption pointwise, pull out `d+1`, collapse the residual plain row with `sum_simplex`. The `d=0` case is `∑ k = C(n+2,2)` (triangular numbers); `d=1` gives `∑ k(k+1) = n(n+1)(n+2)/3`.
- **`weighted_sum_simplex_over_dim`** — the dimension-axis dual via the reflection symmetry `simplexNumber_symm`, mirroring the file's existing `sum_simplex` / `sum_simplex_over_dim` pairing.

## Verification

`./proofs/scripts/docker-build.sh Proofs.TetrahedralNumberFormulaOQ01` → `Built (2.4s)`, 3060 jobs, no sorries/axioms introduced (uses only `Nat.choose_succ_right_eq`, `Finset.sum_range_succ'`, `Finset.mul_sum`, and the file's own `sum_simplex` / `simplexNumber_symm`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)