### PR TITLE
research(cantor-diagonalization-oq-06-oq-01): structural behavior of the diagonal map [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/CantorDiagonalizationOQ06OQ01.lean
+++ b/proofs/Proofs/CantorDiagonalizationOQ06OQ01.lean
@@ -412,4 +412,71 @@ theorem exists_diagonalReal_eq_two_ninths : ∃ f : ℕ → ℝ, diagonalReal f 
   rw [one_div, inv_mul_cancel₀ h10, Int.floor_one]
   decide
 
+/-! ## Structural behavior of the diagonal map `f ↦ diagonalReal f`
+
+The three preceding sections pin `diagonalReal f` to the sharp interval `[1/9, 2/9]` and
+show both endpoints are attained.  Here we record how the map `f ↦ diagonalReal f` behaves
+as a function of `f`.  Three facts capture its structure:
+
+* **Locality.**  `diagonalReal f` reads only the *diagonal* digits `digit (f n) n`; two
+  listings agreeing on their diagonal digits have the same diagonal real, regardless of
+  their off-diagonal values.  This is the mechanical content of "diagonal" argument.
+* **Monotonicity.**  The map is monotone in the disagreeing-digit sequence `db f`.
+* **Binary decomposition.**  `diagonalReal f = 1/9 + (a `{0,1}`-digit real)`, exhibiting the
+  diagonal as the minorant `1/9` plus an indicator tail that flags exactly the positions
+  where `f`'s diagonal digit equals `1`.
+
+All three remain routed entirely through the bespoke `diagonalReal`, axiom-free. -/
+
+/-- **Locality of the diagonal map.**  `diagonalReal f` depends only on the *diagonal*
+digits `digit (f n) n`: if two enumerations agree on their diagonal digits then their
+diagonal reals coincide, no matter how they differ off the diagonal.  This is the essence
+of the diagonal argument — only the `n`-th digit of the `n`-th real is ever consulted. -/
+theorem diagonalReal_congr {f g : ℕ → ℝ} (h : ∀ n, digit (f n) n = digit (g n) n) :
+    diagonalReal f = diagonalReal g := by
+  unfold diagonalReal
+  apply tsum_congr
+  intro n
+  have hdb : db f n = db g n := by unfold db; rw [h n]
+  rw [hdb]
+
+/-- **Monotonicity in the disagreeing digits.**  If `db f n ≤ db g n` at every position,
+then `diagonalReal f ≤ diagonalReal g`: the diagonal real is monotone in its digit
+sequence.  (Since each `db · n ∈ {1,2}`, the hypothesis says `g` selects the larger digit
+`2` at least as often as `f` does.) -/
+theorem diagonalReal_mono {f g : ℕ → ℝ} (h : ∀ n, db f n ≤ db g n) :
+    diagonalReal f ≤ diagonalReal g := by
+  unfold diagonalReal
+  apply Summable.tsum_le_tsum _ (summable_term f) (summable_term g)
+  intro n
+  gcongr
+  exact_mod_cast h n
+
+/-- The indicator tail `∑' n, [digit (f n) n = 1]/10^(n+1)` is summable — it is dominated
+termwise by the geometric minorant `(1/10)^(n+1)`. -/
+theorem summable_indicator_shift (f : ℕ → ℝ) :
+    Summable (fun n => (if digit (f n) n = 1 then (1 : ℝ) else 0) / 10 ^ (n + 1)) := by
+  apply Summable.of_nonneg_of_le (fun n => ?_) (fun n => ?_) summable_geo_shift_one
+  · apply div_nonneg _ (by positivity); split_ifs <;> norm_num
+  · rw [div_pow, one_pow]; gcongr; split_ifs <;> norm_num
+
+/-- **Binary `{0,1}`-digit decomposition.**  Writing `db f n = 1 + [digit (f n) n = 1]`
+splits the diagonal into the geometric minorant `∑ 1/10^(n+1) = 1/9` plus an *indicator*
+tail whose `n`-th digit is `1` exactly when `f`'s `n`-th diagonal digit is `1`.  Thus
+`diagonalReal f - 1/9 ∈ [0, 1/9]` is itself a real with all digits in `{0,1}`, making the
+localization `diagonalReal f ∈ [1/9, 2/9]` transparent: the tail contributes at most
+`∑ 1/10^(n+1) = 1/9`. -/
+theorem diagonalReal_eq_one_ninth_add (f : ℕ → ℝ) :
+    diagonalReal f
+      = 1 / 9 + ∑' n, (if digit (f n) n = 1 then (1 : ℝ) else 0) / 10 ^ (n + 1) := by
+  have hterm : ∀ n, (db f n : ℝ) / 10 ^ (n + 1)
+      = (1 / 10 : ℝ) ^ (n + 1)
+        + (if digit (f n) n = 1 then (1 : ℝ) else 0) / 10 ^ (n + 1) := by
+    intro n
+    have hdb : (db f n : ℝ) = 1 + (if digit (f n) n = 1 then (1 : ℝ) else 0) := by
+      unfold db; split_ifs <;> norm_num
+    rw [hdb, add_div, div_pow, one_pow]
+  rw [diagonalReal, tsum_congr hterm,
+      Summable.tsum_add summable_geo_shift_one (summable_indicator_shift f), tsum_geo_shift_one]
+
 end CantorDiagonalizationOQ06OQ01

--- a/src/data/proofs/cantor-diagonalization-oq-06-oq-01/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-06-oq-01/meta.json
@@ -56,13 +56,14 @@
       "not_surjective_of_countable: no countable type α surjects onto ℝ (the general form of uncountability), obtained by composing an α-surjection ℕ→α with the diagonal argument",
       "diagonalReal_pos / diagonalReal_lt_one / diagonalReal_mem_Ioo: the digit-{1,2} diagonal is squeezed between ∑1/10^(n+1)=1/9 and ∑2/10^(n+1)=2/9, so diagonalReal f ∈ (0,1) for every f (via the geometric majorant tsum_geo_shift = 2/9)",
       "not_surjective_nat_Ioo / uncountable_Ioo: the open unit interval (0,1) is uncountable — the diagonal of any listing lands in (0,1) yet differs from every listed real — strengthening uncountable_real to an arbitrarily small subinterval, still with NO appeal to Cardinal.not_countable_real",
-      "diagonalReal_ge_one_ninth / diagonalReal_le_two_ninths / diagonalReal_mem_Icc: the SHARP two-sided localization diagonalReal f ∈ [1/9, 2/9]. The docstring claimed the diagonal is squeezed between ∑1/10^(n+1)=1/9 and ∑2/10^(n+1)=2/9, but only the upper end (≤2/9) had been formalized; the matching lower bound 1/9 ≤ diagonalReal f is proved here from the geometric minorant tsum_geo_shift_one = 1/9 (every digit db f n ≥ 1 via term_ge'), tightening diagonalReal_mem_Ioo (0,1) to the exact interval [1/9,2/9]. Axiom-free ([propext, Classical.choice, Quot.sound])."
+      "diagonalReal_ge_one_ninth / diagonalReal_le_two_ninths / diagonalReal_mem_Icc: the SHARP two-sided localization diagonalReal f ∈ [1/9, 2/9]. The docstring claimed the diagonal is squeezed between ∑1/10^(n+1)=1/9 and ∑2/10^(n+1)=2/9, but only the upper end (≤2/9) had been formalized; the matching lower bound 1/9 ≤ diagonalReal f is proved here from the geometric minorant tsum_geo_shift_one = 1/9 (every digit db f n ≥ 1 via term_ge'), tightening diagonalReal_mem_Ioo (0,1) to the exact interval [1/9,2/9]. Axiom-free ([propext, Classical.choice, Quot.sound]).",
+      "diagonalReal_congr / diagonalReal_mono / diagonalReal_eq_one_ninth_add: the STRUCTURAL behavior of the diagonal map f ↦ diagonalReal f. (1) Locality (diagonalReal_congr): diagonalReal f depends only on the diagonal digits digit (f n) n — two enumerations agreeing there have equal diagonal reals regardless of off-diagonal values, the mechanical content of the word 'diagonal'. (2) Monotonicity (diagonalReal_mono): the map is monotone in the disagreeing-digit sequence db (∀ n, db f n ≤ db g n → diagonalReal f ≤ diagonalReal g), via Summable.tsum_le_tsum on the defining series. (3) Binary decomposition (diagonalReal_eq_one_ninth_add): db f n = 1 + [digit (f n) n = 1] splits diagonalReal f = 1/9 + ∑' n, [digit (f n) n = 1]/10^(n+1), exhibiting the diagonal as the minorant 1/9 plus a {0,1}-digit indicator tail (bounded by ∑1/10^(n+1)=1/9), making the localization [1/9,2/9] transparent. Axiom-free ([propext, Classical.choice, Quot.sound])."
     ],
     "dateAdded": "2026-07-11",
-    "lineCount": 415,
+    "lineCount": 482,
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries; #print axioms reports only [propext, Classical.choice, Quot.sound]. No use of Cardinal.not_countable_real.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 32,
+    "theoremCount": 36,
     "definitionCount": 4
   },
   "overview": {
@@ -164,9 +165,9 @@
     ],
     "opens": [],
     "namespace": "CantorDiagonalizationOQ06OQ01",
-    "lineCount": 415,
+    "lineCount": 482,
     "axiomCount": 0,
-    "theoremCount": 32,
+    "theoremCount": 36,
     "definitionCount": 4,
     "path": "Proofs/CantorDiagonalizationOQ06OQ01.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

Extends the verified, 0-axiom **Cantor's Explicit Diagonal Real** entry (`CantorDiagonalizationOQ06OQ01.lean`) with a new section characterizing the **structural behavior of the diagonal map** `f ↦ diagonalReal f`. The existing file pins `diagonalReal f` to the sharp interval `[1/9, 2/9]` and shows both endpoints are attained; this PR records how the map behaves as a function of `f`.

Three new axiom-free theorems (32 → 36):

- **`diagonalReal_congr` (locality)** — `diagonalReal f` depends only on the *diagonal* digits `digit (f n) n`; two enumerations agreeing on their diagonal digits have equal diagonal reals, regardless of off-diagonal values. This is the mechanical content of the word "diagonal": only the `n`-th digit of the `n`-th real is ever consulted.
- **`diagonalReal_mono` (monotonicity)** — the map is monotone in the disagreeing-digit sequence: `(∀ n, db f n ≤ db g n) → diagonalReal f ≤ diagonalReal g`, via `Summable.tsum_le_tsum` on the defining series.
- **`diagonalReal_eq_one_ninth_add` (binary decomposition)** — writing `db f n = 1 + [digit (f n) n = 1]` splits the diagonal as `diagonalReal f = 1/9 + ∑' n, [digit (f n) n = 1]/10^(n+1)`, exhibiting it as the minorant `1/9` plus a `{0,1}`-digit indicator tail (bounded by `∑ 1/10^(n+1) = 1/9`). This makes the `[1/9, 2/9]` localization transparent.

A supporting summability lemma `summable_indicator_shift` is also added.

## Verification

- `./proofs/scripts/docker-build.sh Proofs.CantorDiagonalizationOQ06OQ01` → **Build succeeded** (0 sorries).
- `#print axioms` on all three new theorems → `[propext, Classical.choice, Quot.sound]` (axiom-free; no `Lean.ofReduceBool`).
- `meta.json` `lineCount` 415 → 482, `theoremCount` 32 → 36, `originalContributions` updated. Status remains `verified` / `axiomCount: 0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)