### PR TITLE
Enrich De Moivre OQ-06-OQ-02: split conjugate-kernel coverage

### DIFF
--- a/src/data/proofs/de-moivre-oq-06-oq-02/annotations.json
+++ b/src/data/proofs/de-moivre-oq-06-oq-02/annotations.json
@@ -49,12 +49,12 @@
     "proofId": "de-moivre-oq-06-oq-02",
     "range": {
       "startLine": 78,
-      "endLine": 118
+      "endLine": 96
     },
     "type": "technique",
-    "title": "Removing the θ-Dependence by Reciprocal Monotonicity",
-    "content": "`dirichlet_kernel_uniform_bound` and `dirichlet_conjugate_uniform_bound` apply the parent's pointwise bounds and then dominate the $\\theta$-dependent denominator. Since $\\sin(\\theta/2)\\ge\\sin(\\delta/2)>0$ we have $|\\sin(\\theta/2)|=\\sin(\\theta/2)$, and reciprocal monotonicity (`one_div_le_one_div_of_le`) gives $\\frac{1}{2\\sin(\\theta/2)}\\le\\frac{1}{2\\sin(\\delta/2)}$ (resp. $\\frac{1}{\\sin(\\theta/2)}\\le\\frac{1}{\\sin(\\delta/2)}$). Chaining with the pointwise bound yields the uniform constant. The bound is independent of both $n$ and $\\theta$.",
-    "mathContext": "$|\\sum_{k\\le n}\\cos(k\\theta)-\\tfrac12|\\le\\frac{1}{2\\sin(\\delta/2)}$ and $|\\sum_{k\\le n}\\sin(k\\theta)|\\le\\frac{1}{\\sin(\\delta/2)}$ for all $n$ and all $\\theta\\in[\\delta,2\\pi-\\delta]$.",
+    "title": "The Cosine Kernel: Removing θ-Dependence by Reciprocal Monotonicity",
+    "content": "`dirichlet_kernel_uniform_bound` upgrades the parent's *pointwise* cosine estimate to a bound uniform in $n$ and $\\theta$. The cosine partial sum $\\sum_{k\\le n}\\cos(k\\theta)$ centred at $\\tfrac12$ is exactly the Dirichlet kernel $D_n(\\theta)=\\tfrac{\\sin((n+\\frac12)\\theta)}{2\\sin(\\theta/2)}$, so the parent bound has the $\\theta$-dependent denominator $2\\sin(\\theta/2)$. Since $\\sin(\\theta/2)\\ge\\sin(\\delta/2)>0$ on the arc, $|\\sin(\\theta/2)|=\\sin(\\theta/2)$ and reciprocal monotonicity (`one_div_le_one_div_of_le`) replaces it by the constant denominator: $\\frac{1}{2\\sin(\\theta/2)}\\le\\frac{1}{2\\sin(\\delta/2)}$. Chaining with the pointwise bound (`le_trans`) yields the uniform constant $\\frac{1}{2\\sin(\\delta/2)}$, independent of both $n$ and $\\theta$.",
+    "mathContext": "$|\\sum_{k\\le n}\\cos(k\\theta)-\\tfrac12|\\le\\frac{1}{2\\sin(\\delta/2)}$ for all $n$ and all $\\theta\\in[\\delta,2\\pi-\\delta]$; the Dirichlet kernel $D_n(\\theta)=\\tfrac{\\sin((n+\\frac12)\\theta)}{2\\sin(\\theta/2)}$.",
     "significance": "key",
     "relatedConcepts": [
       "reciprocal monotonicity",
@@ -64,6 +64,30 @@
     "prerequisites": [
       "parent pointwise bounds",
       "one_div_le_one_div_of_le"
+    ]
+  },
+  {
+    "id": "ann-dm0602-conjugate",
+    "proofId": "de-moivre-oq-06-oq-02",
+    "range": {
+      "startLine": 97,
+      "endLine": 118
+    },
+    "type": "concept",
+    "title": "The Conjugate (Sine) Kernel and the Conjugate Fourier Series",
+    "content": "`dirichlet_conjugate_uniform_bound` gives the companion estimate for the *sine* partial sums $\\widetilde{D}_n(\\theta)=\\sum_{k\\le n}\\sin(k\\theta)$ — the **conjugate Dirichlet kernel**. The proof is the same reciprocal-monotonicity chain applied to the parent's conjugate bound (now with a single $\\sin(\\theta/2)$ in the denominator, so the uniform constant is $\\frac{1}{\\sin(\\delta/2)}$ — twice the cosine constant). Its significance is distinct from the cosine kernel: $\\widetilde{D}_n$ is the kernel of the *conjugate partial sums* $\\widetilde{S}_n f$, whose limit is the conjugate function $\\widetilde f$ — the circle analogue of the Hilbert transform, and the boundary value of the harmonic conjugate. A uniform bound on $\\widetilde{D}_n$ away from the singularities $\\theta\\in 2\\pi\\mathbb{Z}$ is exactly what Dirichlet's test needs to establish convergence of the *conjugate* Fourier series, in parallel with the ordinary one.",
+    "mathContext": "$|\\sum_{k\\le n}\\sin(k\\theta)|\\le\\frac{1}{\\sin(\\delta/2)}$ for all $n$, $\\theta\\in[\\delta,2\\pi-\\delta]$; conjugate kernel $\\widetilde{D}_n(\\theta)=\\sum_{k=1}^n\\sin(k\\theta)=\\tfrac{\\cos(\\theta/2)-\\cos((n+\\frac12)\\theta)}{2\\sin(\\theta/2)}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "conjugate Dirichlet kernel",
+      "conjugate function / Hilbert transform",
+      "conjugate Fourier series",
+      "reciprocal monotonicity"
+    ],
+    "prerequisites": [
+      "parent conjugate pointwise bound",
+      "one_div_le_one_div_of_le",
+      "conjugate function on the circle"
     ]
   },
   {

--- a/src/data/proofs/de-moivre-oq-06-oq-02/meta.json
+++ b/src/data/proofs/de-moivre-oq-06-oq-02/meta.json
@@ -96,11 +96,19 @@
     },
     {
       "id": "uniform-bounds",
-      "title": "Part II: Uniform Dirichlet-Kernel Bounds",
-      "summary": "dirichlet_kernel_uniform_bound and dirichlet_conjugate_uniform_bound: the cosine and sine partial sums bounded by 1/(2 sin(δ/2)) and 1/sin(δ/2) uniformly in n and θ, from the parent's pointwise bounds plus reciprocal monotonicity",
+      "title": "Part IIa: Uniform Bound for the Cosine (Dirichlet) Kernel",
+      "summary": "dirichlet_kernel_uniform_bound: the cosine partial sums (centred at 1/2) — the Dirichlet kernel D_n — bounded by 1/(2 sin(δ/2)) uniformly in n and θ, from the parent's pointwise bound plus reciprocal monotonicity of the denominator sin(θ/2) ≥ sin(δ/2).",
       "startLine": 78,
-      "endLine": 118,
+      "endLine": 96,
       "mathContext": "$|\\sin(\\theta/2)|=\\sin(\\theta/2)\\ge\\sin(\\delta/2)>0\\Rightarrow \\tfrac{1}{2\\sin(\\theta/2)}\\le\\tfrac{1}{2\\sin(\\delta/2)}$."
+    },
+    {
+      "id": "conjugate-bound",
+      "title": "Part IIb: Uniform Bound for the Conjugate (Sine) Kernel",
+      "summary": "dirichlet_conjugate_uniform_bound: the sine partial sums — the conjugate Dirichlet kernel D̃_n, kernel of the conjugate Fourier series / harmonic-conjugate (Hilbert-transform) partial sums — bounded by 1/sin(δ/2) uniformly in n and θ, by the same reciprocal-monotonicity chain applied to the parent's conjugate pointwise bound.",
+      "startLine": 97,
+      "endLine": 118,
+      "mathContext": "$|\\sum_{k\\le n}\\sin(k\\theta)|\\le\\tfrac{1}{\\sin(\\theta/2)}\\le\\tfrac{1}{\\sin(\\delta/2)}$ on $[\\delta,2\\pi-\\delta]$."
     },
     {
       "id": "packaged-uniform-boundedness",


### PR DESCRIPTION
Enrichment pass for `de-moivre-oq-06-oq-02` (quality 91, pass 0).

## Change
Part II of the file proves **two distinct theorems** — `dirichlet_kernel_uniform_bound` (cosine / Dirichlet kernel) and `dirichlet_conjugate_uniform_bound` (sine / conjugate kernel) — but they were bundled under a single section and a single annotation. Split them:

- **Part IIa** (lines 78–96): the cosine Dirichlet kernel $D_n$, bounded by $1/(2\sin(\delta/2))$.
- **Part IIb** (lines 97–118): the conjugate/sine kernel $\widetilde D_n$, bounded by $1/\sin(\delta/2)$.

The new conjugate-kernel annotation adds genuine harmonic-analysis context not previously present: the sine partial sums are the **conjugate Dirichlet kernel**, kernel of the *conjugate Fourier series* / harmonic-conjugate (circle Hilbert-transform) partial sums, and the uniform bound is exactly what Dirichlet's test needs for convergence of the *conjugate* series. Added closed forms for both $D_n$ and $\widetilde D_n$.

Annotations 4 → 5; sections 4 → 5.

## Guardrails
- meta.json = 13.7 KB (well under the ~60 KB cap); `gallery:check-size` passes.
- Entry has **0** annotation errors in the build; data-build steps pass. Additions/split only — no substantive content removed.
- Axiom integrity unchanged: `verified`, 0 sorries, 0 axioms.