### PR TITLE
research(erdos-744): max-cut positivity dual + balanced-cut characterization

### DIFF
--- a/proofs/Proofs/Erdos744Problem.lean
+++ b/proofs/Proofs/Erdos744Problem.lean
@@ -396,6 +396,27 @@ theorem bipartitionNumber_eq_edgeCount_iff {V : Type*} [Fintype V] [LinearOrder 
   have h := bipartitionNumber_add_maxCut G
   omega
 
+/-- **The max-cut is positive iff `G` has an edge.** The positivity dual of
+`maxCut_eq_zero_iff` (`maxCut = 0 ↔ edgeless`): some edge can be cut exactly when some
+edge exists to cut. -/
+theorem maxCut_pos_iff {V : Type*} [Fintype V] [LinearOrder V]
+    (G : SimpleGraph' V) [DecidableRel G.Adj] :
+    0 < maxCut G ↔ 0 < edgeCount G := by
+  simp only [Nat.pos_iff_ne_zero, ne_eq, maxCut_eq_zero_iff]
+
+/-- **The min-uncut equals the max-cut iff the optimal cut splits the edges exactly in
+half.** By the complementarity `bipartitionNumber G + maxCut G = edgeCount G`, the two
+extremal invariants coincide precisely when each is half the edge count
+(`2 * bipartitionNumber G = edgeCount G`, equivalently `2 * maxCut G = edgeCount G`). This
+is the balanced middle case between the two saturated corners already characterized:
+bipartite (`bipartitionNumber = 0`, `maxCut = edgeCount`) and edgeless
+(`maxCut = 0`, `bipartitionNumber = edgeCount`). -/
+theorem bipartitionNumber_eq_maxCut_iff {V : Type*} [Fintype V] [LinearOrder V]
+    (G : SimpleGraph' V) [DecidableRel G.Adj] :
+    bipartitionNumber G = maxCut G ↔ 2 * bipartitionNumber G = edgeCount G := by
+  have h := bipartitionNumber_add_maxCut G
+  omega
+
 /-
 # Part 3c: Monotonicity of the cut quantities under edge addition
 

--- a/src/data/proofs/erdos-744/meta.json
+++ b/src/data/proofs/erdos-744/meta.json
@@ -66,9 +66,9 @@
       "bipartitionNumber_add_edge_sandwich / maxCut_add_edge_sandwich: both extremal invariants are 1-Lipschitz under a single-edge edit — if H = G + {a,b} then the invariant lands in {value(G), value(G)+1}. Sharpens the earlier monotonicity (which only gave the lower bound ≥) with a matching +1 upper bound; the exact modulus of continuity for the edge-edit metric. Axiom-free."
     ],
     "axiomCount": 1,
-    "lineCount": 948,
+    "lineCount": 969,
     "assumptions": "1 axiom: rodl_tuza_theorem (the deep Rödl–Tuza 1985 result, stated as an assumption since a full formalization of the extremal argument is out of scope). The chromatic number is now defined intrinsically (least number of colors admitting a proper coloring) rather than axiomatized, and is proved well-defined by chromaticNumber_le_card. 0 sorries.",
-    "theoremCount": 37,
+    "theoremCount": 39,
     "definitionCount": 13
   },
   "overview": {
@@ -192,9 +192,9 @@
       "Finset"
     ],
     "namespace": "Erdos744",
-    "lineCount": 948,
+    "lineCount": 969,
     "axiomCount": 1,
-    "theoremCount": 37,
+    "theoremCount": 39,
     "definitionCount": 13,
     "path": "Proofs/Erdos744Problem.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

Two new axiom-free theorems for the `bipartitionNumber` / max-cut theory in `proofs/Proofs/Erdos744Problem.lean` (Erdős #744, critical graphs), rounding out the qualitative picture of the max-cut / min-uncut complementarity `bipartitionNumber G + maxCut G = edgeCount G`:

- **`maxCut_pos_iff`** — `0 < maxCut G ↔ 0 < edgeCount G`. The positivity dual of the existing `maxCut_eq_zero_iff`.
- **`bipartitionNumber_eq_maxCut_iff`** — `bipartitionNumber G = maxCut G ↔ 2 * bipartitionNumber G = edgeCount G`. The min-uncut equals the max-cut exactly when the optimal cut splits the edges in half.

This fills in the balanced middle case between the two saturated corners the file already characterizes:

| case | `bipartitionNumber` | `maxCut` |
|------|--------------------|----------|
| bipartite | `0` | `edgeCount` |
| **balanced** | **`edgeCount / 2`** | **`edgeCount / 2`** |
| edgeless | `edgeCount` | `0` |

Both proofs are `omega`/`simp` from the existing complementarity (`bipartitionNumber_add_maxCut`) and zero-characterization (`maxCut_eq_zero_iff`) lemmas.

## Verification

- Host `lean` v4.26.0 type-check: **exit 0, no errors**.
- `#print axioms` on both new theorems: `[propext, Classical.choice, Quot.sound]` only — **no dependence on the file's `rodl_tuza_theorem` axiom**, 0 sorries, no native_decide.
- `meta.json`: `theoremCount` 37→39, `lineCount` 948→969. Status remains `axiomatized`/`axiom` (the pre-existing Rödl–Tuza axiom is untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)