### PR TITLE
Enrich Combinations Formula OQ-03-OQ-04: close section-coverage hole

### DIFF
--- a/src/data/proofs/combinations-formula-oq-03-oq-04/meta.json
+++ b/src/data/proofs/combinations-formula-oq-03-oq-04/meta.json
@@ -72,6 +72,14 @@
       "summary": "Module docstring stating the target (palindromy of Gaussian q-binomials as the symmetric half of Sylvester's unimodality theorem), the proof outline via both q-Pascal identities, and an explicit honesty note that unimodality itself is NOT proved."
     },
     {
+      "id": "setup",
+      "title": "Setup: namespace and the field hypothesis",
+      "startLine": 45,
+      "endLine": 50,
+      "summary": "Enters namespace QBinomialCoefficients, opens Nat, and fixes the ambient ring as an arbitrary field [Field R]. The field hypothesis is essential rather than cosmetic: the reciprocity identity substitutes q ↦ q⁻¹, so R must contain the inverse of every nonzero q — exactly what a field guarantees. This is the smallest setting in which the palindromy statement is even expressible.",
+      "mathContext": "R : Type* with [Field R]; needed so q⁻¹ exists for every q ≠ 0 in the reciprocity q ↦ q⁻¹."
+    },
+    {
       "id": "reciprocal",
       "title": "Main — Self-Reciprocity / Palindromy",
       "startLine": 51,


### PR DESCRIPTION
Enrichment pass for `combinations-formula-oq-03-oq-04` (quality 94, pass 0).

## Change
The `sections` array covered lines 1–44, 51–104, and 106–121, leaving the `namespace` / `open Nat` / `variable {R} [Field R]` setup block (lines 45–50) with **no section** — even though an annotation already covered it. Added a `setup` section (45–50) so sections now cover the full 121-line file. Its content explains why the field hypothesis is essential rather than cosmetic: the reciprocity identity substitutes $q \mapsto q^{-1}$, so $R$ must contain the inverse of every nonzero $q$ — exactly what `[Field R]` guarantees.

sections 3 → 4.

## Guardrails
- meta.json = 14.5 KB (well under the ~60 KB cap); `gallery:check-size` passes.
- Entry has **0** annotation errors in the build; data-build steps pass. Addition only — no content changed or removed.
- Axiom integrity unchanged: `verified`/`original`, 0 sorries, 0 axioms.