### PR TITLE
research(cauchy-interlacing-theorem-oq-02-oq-01): minpoly degree bracket across a reducing pair

### DIFF
--- a/proofs/Proofs/CauchyInterlacingPoincareCompression.lean
+++ b/proofs/Proofs/CauchyInterlacingPoincareCompression.lean
@@ -1689,4 +1689,50 @@ theorem minpoly_eq_lcm_compress_of_reducing {T : V →ₗ[𝕜] V} (H : Submodul
         normalize_eq_normalize_iff.mpr ⟨d1, d2⟩
     _ = lcm (minpoly 𝕜 (compress T H)) (minpoly 𝕜 (compress T Hᗮ)) := normalize_lcm _ _
 
+/-- **Each block minpoly has degree at most the ambient one (reducing pair).**
+Since each block minimal polynomial divides `minpoly T`
+(`minpoly_compress_dvd_of_reducing`) and `minpoly T ≠ 0` (it is monic, `T` being a
+finite-dimensional endomorphism), their degrees are bounded by `deg (minpoly T)`.  The
+lower half of the degree bracket for `minpoly T`, complementing the sum upper bound
+`natDegree_minpoly_le_add_compress_of_reducing`. -/
+theorem natDegree_minpoly_compress_le_of_reducing {T : V →ₗ[𝕜] V} (H : Submodule 𝕜 V)
+    (hH : ∀ y ∈ H, T y ∈ H) (hHp : ∀ y ∈ Hᗮ, T y ∈ Hᗮ) :
+    (minpoly 𝕜 (compress T H)).natDegree ≤ (minpoly 𝕜 T).natDegree ∧
+      (minpoly 𝕜 (compress T Hᗮ)).natDegree ≤ (minpoly 𝕜 T).natDegree := by
+  have hint : IsIntegral 𝕜 T :=
+    have : Algebra.IsIntegral 𝕜 (Module.End 𝕜 V) := Algebra.IsIntegral.of_finite 𝕜 _
+    Algebra.IsIntegral.isIntegral T
+  have hT0 : minpoly 𝕜 T ≠ 0 := (minpoly.monic hint).ne_zero
+  obtain ⟨hdvdH, hdvdHp⟩ := minpoly_compress_dvd_of_reducing H hH hHp
+  exact ⟨Polynomial.natDegree_le_of_dvd hdvdH hT0,
+    Polynomial.natDegree_le_of_dvd hdvdHp hT0⟩
+
+/-- **The ambient minpoly degree is at most the sum of the block minpoly degrees
+(reducing pair).**  From the product divisibility `minpoly T ∣ minpoly (compress T H) ·
+minpoly (compress T Hᗮ)` (`minpoly_dvd_mul_compress_of_reducing`) and the fact that both
+block minpolys are monic (hence nonzero, so their product is nonzero and its degree is the
+sum of theirs), `deg (minpoly T) ≤ deg (minpoly (compress T H)) + deg (minpoly (compress T
+Hᗮ))`.  The upper half of the degree bracket; together with
+`natDegree_minpoly_compress_le_of_reducing` this pins `deg (minpoly T)` between the block
+maximum and the block sum — the degree shadow of `minpoly T = lcm` of the two blocks. -/
+theorem natDegree_minpoly_le_add_compress_of_reducing {T : V →ₗ[𝕜] V} (H : Submodule 𝕜 V)
+    (hH : ∀ y ∈ H, T y ∈ H) (hHp : ∀ y ∈ Hᗮ, T y ∈ Hᗮ) :
+    (minpoly 𝕜 T).natDegree ≤
+      (minpoly 𝕜 (compress T H)).natDegree + (minpoly 𝕜 (compress T Hᗮ)).natDegree := by
+  have hpint : IsIntegral 𝕜 (compress T H) :=
+    have : Algebra.IsIntegral 𝕜 (Module.End 𝕜 (↥H)) := Algebra.IsIntegral.of_finite 𝕜 _
+    Algebra.IsIntegral.isIntegral (compress T H)
+  have hqint : IsIntegral 𝕜 (compress T Hᗮ) :=
+    have : Algebra.IsIntegral 𝕜 (Module.End 𝕜 (↥Hᗮ)) := Algebra.IsIntegral.of_finite 𝕜 _
+    Algebra.IsIntegral.isIntegral (compress T Hᗮ)
+  have hp0 : minpoly 𝕜 (compress T H) ≠ 0 := (minpoly.monic hpint).ne_zero
+  have hq0 : minpoly 𝕜 (compress T Hᗮ) ≠ 0 := (minpoly.monic hqint).ne_zero
+  have hprod : minpoly 𝕜 (compress T H) * minpoly 𝕜 (compress T Hᗮ) ≠ 0 :=
+    mul_ne_zero hp0 hq0
+  calc (minpoly 𝕜 T).natDegree
+      ≤ (minpoly 𝕜 (compress T H) * minpoly 𝕜 (compress T Hᗮ)).natDegree :=
+        Polynomial.natDegree_le_of_dvd (minpoly_dvd_mul_compress_of_reducing H hH hHp) hprod
+    _ = (minpoly 𝕜 (compress T H)).natDegree + (minpoly 𝕜 (compress T Hᗮ)).natDegree :=
+        Polynomial.natDegree_mul hp0 hq0
+
 end CauchyInterlacing.PoincareCompression

--- a/src/data/proofs/cauchy-interlacing-theorem-oq-01-oq-02/meta.json
+++ b/src/data/proofs/cauchy-interlacing-theorem-oq-01-oq-02/meta.json
@@ -62,9 +62,9 @@
       "CauchyInterlacing.Poincare"
     ],
     "namespace": "CauchyInterlacing.PoincareCompression",
-    "lineCount": 1575,
+    "lineCount": 1738,
     "axiomCount": 0,
-    "theoremCount": 40,
+    "theoremCount": 42,
     "definitionCount": 0,
     "path": "Proofs/CauchyInterlacingPoincareCompression.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

Extends the operator-compression spectral file `Proofs/CauchyInterlacingPoincareCompression.lean` with **2 axiom-free theorems** giving the *degree shadow* of the capstone `minpoly_eq_lcm_compress_of_reducing` (which shows `minpoly T = lcm` of the two block minpolys across a reducing pair).

### New theorems
- `natDegree_minpoly_compress_le_of_reducing`: each block minpoly has degree `≤ deg(minpoly T)` — from block-∣-`minpoly T` (`minpoly_compress_dvd_of_reducing`) plus `minpoly T` monic/nonzero (**lower** bracket).
- `natDegree_minpoly_le_add_compress_of_reducing`: `deg(minpoly T) ≤ deg(block H) + deg(block Hᗮ)` — from `minpoly T ∣ block · block` (`minpoly_dvd_mul_compress_of_reducing`) plus degree-additivity of the monic product (**upper** bracket).

Together they pin `deg(minpoly T)` between the block maximum and the block sum — the natural degree consequence of the `lcm` identity.

### Verification
- Docker build (`Proofs.CauchyInterlacingPoincareCompression`) **succeeds** (7747 jobs). Warnings all pre-existing.
- 0 axioms, 0 sorries preserved. Counts synced in meta.json (lineCount was stale; set to actual).

🤖 Generated with [Claude Code](https://claude.com/claude-code)