### PR TITLE
Enrich Beta-Integral diagonal asymptotic: close section-coverage holes

### DIFF
--- a/src/data/proofs/beta-integral-recurrence-oq-01-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/beta-integral-recurrence-oq-01-oq-02-oq-01-oq-01/meta.json
@@ -92,10 +92,18 @@
     {
       "id": "docstring",
       "title": "Module Docstring: Correcting the Naive Asymptotic",
-      "startLine": 5,
+      "startLine": 1,
       "endLine": 52,
       "summary": "States the result B(n+1/2,n+1/2) ~ √(π/n)·4^(-n) and explains why the parent's conjectured √(π/n) is wrong: the central binomial grows only like 4^n against the 4^(2n) denominator, so an exponential factor 4^(-n) survives. Notes the agreement with the classical B(x,x) ~ 2^(1-2x)·√(π/x) at x=n+1/2 and outlines the pure-field-identity assembly from the parent value and the central binomial asymptotic.",
       "mathContext": "$B(n+\\tfrac12,n+\\tfrac12) \\sim \\sqrt{\\tfrac{\\pi}{n}}\\,4^{-n}$, not $\\sqrt{\\pi/n}$."
+    },
+    {
+      "id": "setup",
+      "title": "Setup: filter/asymptotics opens and namespace",
+      "startLine": 53,
+      "endLine": 58,
+      "summary": "Opens Filter, Topology, Asymptotics (for Tendsto / IsEquivalent / atTop) and the Real and Nat scoped notations, then enters namespace BetaIntegralRecurrenceOQ01OQ02OQ01OQ01. These opens fix the vocabulary in which the asymptotic is later stated as an Asymptotics.IsEquivalent over the atTop filter.",
+      "mathContext": "Asymptotics vocabulary: IsEquivalent, Tendsto, atTop — the setting for f ~ g."
     },
     {
       "id": "real-form",


### PR DESCRIPTION
Enrichment pass for `beta-integral-recurrence-oq-01-oq-02-oq-01-oq-01` (quality 96, pass 0).

## Change
The `sections` array covered lines 5–52, 59–79, 81–97, and 99–138, leaving the **imports** (1–4) and the **opens/namespace** block (53–58) with no section coverage. Closed both holes:
- Extended the docstring section to start at line 1 (absorbing the imports).
- Added a `setup` section (53–58) documenting the `open Filter Topology Asymptotics` / scoped `Real Nat` and the namespace, which fix the `IsEquivalent` / `Tendsto` / `atTop` vocabulary in which the main asymptotic is stated.

sections 4 → 5; full-file coverage.

## Guardrails
- meta.json = 15.1 KB (well under the ~60 KB cap); `gallery:check-size` passes.
- Only `meta.json` changed (annotations untouched). Data-build steps pass. One pre-existing, tolerated "No Lean construct found" notice on an `open`-anchored annotation is unrelated to this change.
- Axiom integrity unchanged: `verified`, 0 sorries, 0 axioms.