### PR TITLE
Enrich cauchy-interlacing-theorem-oq-02-oq-02-oq-01: full section coverage + ambient-setup annotation

### DIFF
--- a/src/data/proofs/cauchy-interlacing-theorem-oq-02-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/cauchy-interlacing-theorem-oq-02-oq-02-oq-01/annotations.json
@@ -12,6 +12,18 @@
     "prerequisites": ["the parent principal-submatrix interlacing (oq-02-oq-02)", "Hermitian matrix eigenvalues", "EuclideanSpace finrank"]
   },
   {
+    "id": "ann-setup",
+    "proofId": "cauchy-interlacing-theorem-oq-02-oq-02-oq-01",
+    "range": { "startLine": 41, "endLine": 46 },
+    "type": "context",
+    "title": "Ambient setup: arbitrary RCLike field and dimensions",
+    "content": "The whole file works over an arbitrary RCLike field 𝕜 (so both ℝ and ℂ, hence real symmetric and complex Hermitian matrices, are covered at once) and arbitrary block sizes n m : ℕ, declared once by the variable line and reused by every result. The open scoped InnerProductSpace Matrix and open Matrix WithLp lines bring the eigenvalues₀ / submatrix / toEuclideanLin notation into scope. Everything lives in namespace CauchyInterlacing.PoincareSubmatrix; note the docstring's remark that this is a research file intentionally NOT registered in Proofs.lean — it is a companion restatement of the parent, not a new gallery-registered proof, so it is type-checked directly with lake env lean rather than through the aggregate Proofs import.",
+    "mathContext": "$\\mathbb{K}$ an $\\mathrm{RCLike}$ field, $n,m:\\mathbb{N}$; the ambient matrix is $A\\in\\mathrm{Herm}_{n+m}(\\mathbb{K})$ with principal submatrix indexed by $e:\\mathrm{Fin}\\,n\\hookrightarrow\\mathrm{Fin}(n{+}m)$.",
+    "significance": "context",
+    "relatedConcepts": ["RCLike field", "real symmetric vs complex Hermitian", "scoped notation", "research file (not registered in Proofs.lean)"],
+    "prerequisites": ["RCLike / inner product spaces over ℝ and ℂ", "Lean variable binders and scoped opens"]
+  },
+  {
     "id": "ann-eigenvalues-cast",
     "proofId": "cauchy-interlacing-theorem-oq-02-oq-02-oq-01",
     "range": { "startLine": 50, "endLine": 64 },

--- a/src/data/proofs/cauchy-interlacing-theorem-oq-02-oq-02-oq-01/meta.json
+++ b/src/data/proofs/cauchy-interlacing-theorem-oq-02-oq-02-oq-01/meta.json
@@ -77,6 +77,14 @@
   },
   "sections": [
     {
+      "id": "preamble",
+      "title": "Preamble: the reindexing obstruction and setup",
+      "startLine": 1,
+      "endLine": 46,
+      "summary": "Imports (Mathlib + the parent CauchyInterlacingPoincareSubmatrix), the module docstring diagnosing why eigenvalues₀ (built from finrank_euclideanSpace, right-hand side Fintype.card (Fin (n+m))) does not agree on the nose with the parent's operator eigenvalues (built from finrank_euclideanSpace_fin, right-hand side n+m), the note that this is a research file intentionally NOT registered in Proofs.lean, and the ambient context: an arbitrary RCLike field 𝕜 and arbitrary n m : ℕ.",
+      "mathContext": "eigenvalues₀ = eigenvalues finrank_euclideanSpace; the parent uses eigenvalues finrank_euclideanSpace_fin; the two differ only by the non-definitional Fintype.card (Fin (n+m)) = n+m, i.e. a Fin.cast."
+    },
+    {
       "id": "eigenvalues-cast",
       "title": "The finrank-witness bridge",
       "startLine": 47,


### PR DESCRIPTION
Enrichment pass (pass 0) for `cauchy-interlacing-theorem-oq-02-oq-02-oq-01` (Poincaré separation in native `Matrix.IsHermitian.eigenvalues₀` form). Targeted coverage gaps, not accretion.

## Changes

**meta.json** — added a `preamble` section (lines 1–46):
- The two existing sections covered only 47–111, leaving the imports, the module docstring that diagnoses the whole reindexing obstruction (`eigenvalues₀` uses `finrank_euclideanSpace` / `Fintype.card (Fin (n+m))` vs the parent's `finrank_euclideanSpace_fin` / `n+m`), the research-file-not-registered note, and the ambient `variable` block unsectioned. Sections now cover the file contiguously: `1–46, 47–78, 79–111`.

**annotations.json** — added `ann-setup` (4 → 5 annotations, clearing the 5-annotation minimum):
- Documents the ambient setup: an arbitrary `RCLike` field 𝕜 (so real symmetric **and** complex Hermitian matrices are covered at once), arbitrary block sizes `n m : ℕ`, the scoped opens, and the research-file status (`intentionally NOT registered in Proofs.lean`). Full `mathContext`, `significance: context`, `relatedConcepts`, `prerequisites`.

## Verification
- Both JSON files parse cleanly (node).
- meta.json 17.9 KB → 18.8 KB (well under the ~60 KB cap); annotations 5, sections 3 (full coverage), keyInsights 4.
- No status/badge/axiomCount changes — the `verified` / 0-axiom / 0-sorry claims are left intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)