### PR TITLE
research(eqr-oq-03-oq-02-wip-01): residue-level character table of (·/2) — zero-set + ±1 unit classes (0-axiom)

### DIFF
--- a/proofs/Proofs/ElementaryQuadraticReciprocityOQ03OQ02WIP01.lean
+++ b/proofs/Proofs/ElementaryQuadraticReciprocityOQ03OQ02WIP01.lean
@@ -139,4 +139,44 @@ theorem kronecker2_conductor_eight :
       (¬ ∀ a : ℤ, kronecker2 (a + 2) = kronecker2 a) :=
   ⟨kronecker2_add_mul_eight, kronecker2_not_period_four, kronecker2_not_period_two⟩
 
+-- ============================================================
+-- Section D: The residue-level character table of `(·/2)`
+-- ============================================================
+
+/-- **`(·/2)` vanishes exactly on the even residues.**  `kronecker2 a = 0 ↔ a` even.
+    Squaring `(·/2)` collapses its two unit classes onto the principal character mod `2`
+    (`kronecker2_sq`: `(a/2)² = 0` on evens, `1` on odds), and over `ℤ` a value squares to
+    `0` iff it is `0` (`mul_self_eq_zero`).  This pins the *support* of the character. -/
+theorem kronecker2_eq_zero_iff (a : ℤ) : kronecker2 a = 0 ↔ a % 2 = 0 := by
+  rw [← mul_self_eq_zero, kronecker2_sq]
+  split_ifs with h <;> simp [h]
+
+/-- **`(·/2)` is a unit exactly on the odd residues.**  `kronecker2 a ≠ 0 ↔ a` odd — the
+    complement of `kronecker2_eq_zero_iff`, stating that `(·/2)` takes an invertible value
+    `±1` precisely on the units mod `2`. -/
+theorem kronecker2_ne_zero_iff (a : ℤ) : kronecker2 a ≠ 0 ↔ a % 2 = 1 := by
+  rw [ne_eq, kronecker2_eq_zero_iff]; omega
+
+/-- **`(·/2)` takes the value `+1` exactly on the residues `1, 7 (mod 8)`.**  The upper
+    unit class of the primitive character `χ₈ = (·/2)`.  Direct from the definition: the
+    `a % 8 = -1` disjunct is vacuous since `Int.emod` by `8` lands in `[0, 8)`, so the
+    positive branch fires precisely on `a % 8 ∈ {1, 7}`. -/
+theorem kronecker2_eq_one_iff (a : ℤ) : kronecker2 a = 1 ↔ a % 8 = 1 ∨ a % 8 = 7 := by
+  unfold kronecker2
+  split_ifs with h1 h2
+  · exact ⟨fun h => by norm_num at h, fun h => by omega⟩
+  · exact ⟨fun _ => by omega, fun _ => rfl⟩
+  · exact ⟨fun h => by norm_num at h, fun h => by omega⟩
+
+/-- **`(·/2)` takes the value `−1` exactly on the residues `3, 5 (mod 8)`.**  The lower
+    unit class of `χ₈ = (·/2)`.  Together with `kronecker2_eq_one_iff` and
+    `kronecker2_eq_zero_iff` this is the complete residue-level character table of the
+    `(·/2)` symbol: `0` on evens, `+1` on `{1,7}`, `−1` on `{3,5}` mod `8`. -/
+theorem kronecker2_eq_neg_one_iff (a : ℤ) : kronecker2 a = -1 ↔ a % 8 = 3 ∨ a % 8 = 5 := by
+  unfold kronecker2
+  split_ifs with h1 h2
+  · exact ⟨fun h => by norm_num at h, fun h => by omega⟩
+  · exact ⟨fun h => by norm_num at h, fun h => by omega⟩
+  · exact ⟨fun _ => rfl, fun _ => by omega⟩
+
 end KroneckerSymbol

--- a/proofs/Proofs/ElementaryQuadraticReciprocityOQ03OQ02WIP01.lean
+++ b/proofs/Proofs/ElementaryQuadraticReciprocityOQ03OQ02WIP01.lean
@@ -177,6 +177,6 @@ theorem kronecker2_eq_neg_one_iff (a : ℤ) : kronecker2 a = -1 ↔ a % 8 = 3 �
   split_ifs with h1 h2
   · exact ⟨fun h => by norm_num at h, fun h => by omega⟩
   · exact ⟨fun h => by norm_num at h, fun h => by omega⟩
-  · exact ⟨fun _ => rfl, fun _ => by omega⟩
+  · exact ⟨fun _ => by omega, fun _ => rfl⟩
 
 end KroneckerSymbol

--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-03-oq-02-wip-01/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-03-oq-02-wip-01/meta.json
@@ -40,10 +40,10 @@
     "badge": "wip",
     "sorries": 0,
     "axiomCount": 0,
-    "theoremCount": 8,
+    "theoremCount": 12,
     "defCount": 0,
     "definitionCount": 0,
-    "lineCount": 142,
+    "lineCount": 182,
     "dateAdded": "2026-07-11",
     "assumptions": "0 axioms, 0 sorries — every result is machine-verified from the parent file's public API (propext, Classical.choice, Quot.sound only; the two kronecker2 results use only propext). Status is kept 'wip'/'axiomatized' to match the parent: the file proves genuine new lemmas (numerator periodicity of (a/n) for odd positive n via kronecker_congr_left / kronecker_add_mul_left / kronecker_periodic_left, and full period-8 periodicity of the (a/2) character via kronecker2_congr / kronecker2_add_mul_eight, plus the exact conductor 8 / primitivity of (·/2) via kronecker2_not_period_four / kronecker2_not_period_two / kronecker2_conductor_eight) but the broader open target — wiring kronecker2 into the definition at even moduli and generalized quadratic reciprocity for arbitrary fundamental discriminants — remains unformalized, exactly as documented in the parent's module note. Nothing new is assumed.",
     "mathlibDependencies": [
@@ -188,6 +188,26 @@
       "name": "kronecker2_conductor_eight",
       "statement": "(∀ a k : ℤ, kronecker2 (a + 8 * k) = kronecker2 a) ∧ (¬ ∀ a : ℤ, kronecker2 (a + 4) = kronecker2 a) ∧ (¬ ∀ a : ℤ, kronecker2 (a + 2) = kronecker2 a)",
       "description": "8 is the exact conductor of (·/2): full period 8 together with the failure of periods 4 and 2 shows 8 is the minimal period, so χ₈ = (·/2) is a primitive Dirichlet character mod 8. This is the sharp input the Gauss-sum route to reciprocity needs, since only primitive characters have nonvanishing Gauss sums."
+    },
+    {
+      "name": "kronecker2_eq_zero_iff",
+      "statement": "kronecker2 a = 0 ↔ a % 2 = 0",
+      "description": "The (·/2) character vanishes exactly on the even residues. Proved by squaring (kronecker2_sq: (a/2)²=0 on evens, 1 on odds) and mul_self_eq_zero (over ℤ a value squares to 0 iff it is 0), pinning the support of the character."
+    },
+    {
+      "name": "kronecker2_ne_zero_iff",
+      "statement": "kronecker2 a ≠ 0 ↔ a % 2 = 1",
+      "description": "The (·/2) character is a unit (±1) exactly on the odd residues — the complement of kronecker2_eq_zero_iff, the units mod 2."
+    },
+    {
+      "name": "kronecker2_eq_one_iff",
+      "statement": "kronecker2 a = 1 ↔ a % 8 = 1 ∨ a % 8 = 7",
+      "description": "The value +1 of the primitive character χ₈=(·/2) occurs exactly on residues 1,7 mod 8. Direct from the definition; the a%8=-1 disjunct is vacuous since Int.emod by 8 lands in [0,8)."
+    },
+    {
+      "name": "kronecker2_eq_neg_one_iff",
+      "statement": "kronecker2 a = -1 ↔ a % 8 = 3 ∨ a % 8 = 5",
+      "description": "The value -1 of χ₈=(·/2) occurs exactly on residues 3,5 mod 8. With kronecker2_eq_one_iff and kronecker2_eq_zero_iff this is the complete residue-level character table: 0 on evens, +1 on {1,7}, -1 on {3,5} mod 8."
     }
   ]
 }


### PR DESCRIPTION
## Summary

Extends the Kronecker-symbol WIP file (`Proofs/ElementaryQuadraticReciprocityOQ03OQ02WIP01.lean`, gallery `elementary-quadratic-reciprocity-oq-03-oq-02-wip-01`) with **Section D: the residue-level character table of `(·/2)`** — four new 0-axiom theorems that make the value pattern of the primitive Dirichlet character `χ₈ = (·/2)` fully explicit, complementing Section C's conductor/primitivity result.

### New theorems (all 0-axiom)

- **`kronecker2_eq_zero_iff`** — `kronecker2 a = 0 ↔ a % 2 = 0`. The character vanishes exactly on the even residues (its support). Proved by squaring (`kronecker2_sq`) + `mul_self_eq_zero`.
- **`kronecker2_ne_zero_iff`** — `kronecker2 a ≠ 0 ↔ a % 2 = 1`. Unit exactly on the odd residues.
- **`kronecker2_eq_one_iff`** — `kronecker2 a = 1 ↔ a % 8 = 1 ∨ a % 8 = 7`. The `+1` unit class.
- **`kronecker2_eq_neg_one_iff`** — `kronecker2 a = -1 ↔ a % 8 = 3 ∨ a % 8 = 5`. The `−1` unit class.

Together: `0` on evens, `+1` on `{1,7}`, `−1` on `{3,5}` mod 8 — the complete character table of `(·/2)`.

### Verification

- Type-checks clean under host `lean` v4.26.0 with the prebuilt Mathlib + parent oleans (RC=0, no errors/sorries). (Docker wrapper hit transient SIGBUS/exit-135 host-memory thrash; the host toolchain is identical.)
- `#print axioms` on all four: only the foundational trio (`[propext, Classical.choice, Quot.sound]` / subset) — no `sorryAx`, no `native_decide`/`Lean.ofReduceBool`.
- Uses only `omega`, `simp`, `norm_num`, `mul_self_eq_zero`, and the parent's `kronecker2_sq`.
- Meta `theoremCount` 8→12, `lineCount` 142→182, 4 `mainTheorems` entries added. Status stays `axiomatized`/`wip` (the reciprocity OQ itself remains open); `axiomCount: 0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)