### PR TITLE
research(puiseux-theorem-wip-01): value-group tower directedness (Part XIV)

### DIFF
--- a/proofs/Proofs/PuiseuxTheorem.lean
+++ b/proofs/Proofs/PuiseuxTheorem.lean
@@ -1358,6 +1358,37 @@ theorem iUnion_ramification_valueGroup {K : Type*} [Field K] :
     have hq : ((q.num : ℚ) / ((⟨q.den, q.pos⟩ : ℕ+) : ℚ)) = q := Rat.num_div_den q
     exact_mod_cast hq
 
+/-- **Directedness of the value-group tower (explicit common refinement).** For any two
+levels `n, m` the union of the level-`n` and level-`m` value groups is contained in the
+level-`(n*m)` value group: `(1/n)ℤ ∪ (1/m)ℤ ⊆ (1/(n*m))ℤ`. This is the valuation-theoretic
+shadow of `exists_common_ramification` (any two Puiseux series share the common ramification
+`n*m`), refining `ramification_valueGroup_mono` from a single divisibility inclusion to a
+join. Both inclusions are the *same series* reindexed via `IsPuiseuxOfRamification.mono`. -/
+theorem ramification_valueGroup_directed {K : Type*} [Field K] (n m : ℕ+) :
+    {v : WithTop ℚ |
+        ∃ f : HahnSeries ℚ K, IsPuiseuxOfRamification n f ∧ f ≠ 0 ∧ f.orderTop = v}
+      ∪ {v : WithTop ℚ |
+        ∃ f : HahnSeries ℚ K, IsPuiseuxOfRamification m f ∧ f ≠ 0 ∧ f.orderTop = v}
+      ⊆ {v : WithTop ℚ |
+        ∃ f : HahnSeries ℚ K, IsPuiseuxOfRamification (n * m) f ∧ f ≠ 0 ∧ f.orderTop = v} := by
+  rw [Set.union_subset_iff]
+  exact ⟨ramification_valueGroup_mono (dvd_mul_right n m),
+    ramification_valueGroup_mono (dvd_mul_left m n)⟩
+
+/-- **The value-group tower is a directed family.** Abstractly, `n ↦ (level-n value group)`
+is `Directed (· ⊆ ·)`: any two levels have an upper bound `n*m` under inclusion. This packages
+`ramification_valueGroup_directed` as the order-theoretic hypothesis needed to treat the tower
+as a genuine directed colimit of value groups (the valuation shadow of the directed field
+system `puiseuxRamificationSubfield`), and is exactly the directedness that makes
+`iUnion_ramification_valueGroup` a filtered union rather than an arbitrary one. -/
+theorem directed_ramification_valueGroup {K : Type*} [Field K] :
+    Directed (· ⊆ ·) (fun n : ℕ+ =>
+      {v : WithTop ℚ |
+        ∃ f : HahnSeries ℚ K, IsPuiseuxOfRamification n f ∧ f ≠ 0 ∧ f.orderTop = v}) := by
+  intro n m
+  exact ⟨n * m, ramification_valueGroup_mono (dvd_mul_right n m),
+    ramification_valueGroup_mono (dvd_mul_left m n)⟩
+
 end ValueGroupTower
 
 /-! ═══════════════════════════════════════════════════════════════════════════════

--- a/research/problems/puiseux-theorem-wip-01/knowledge.md
+++ b/research/problems/puiseux-theorem-wip-01/knowledge.md
@@ -345,3 +345,31 @@ lines), src/data/proofs/puiseux-theorem/meta.json (lineCount 1216→1315, theore
 finite level (`= (1/n)ℤ`), the "structural rounding-out" line is now complete on the
 *algebraic*, *filtration*, and *valuation* axes. The only remaining frontier is the deep
 Newton–Puiseux algebraic closure (>1000-line, out of scope).
+
+## Session (researcher-1, 2026-07-11): value-group tower directedness (Part XIV)
+
+**Mode**: REVISIT (MODERATE, file already SOLVED 0/0) · **Outcome**: progress
+(2 theorems VERIFIED 0-sorry/0-axiom), branch research/puiseux-wip01-valuegroup-directed.
+
+**Contribution.** Closed the exact `nextSteps` item: the per-level value groups
+`P n := {orderTop f | f ≠ 0, IsPuiseuxOfRamification n f} = (1/n)ℤ` were shown monotone
+under divisibility (`ramification_valueGroup_mono`) and to have union ℚ
+(`iUnion_ramification_valueGroup`), but their **directedness** — the explicit common
+refinement — was only asserted. Added:
+- `ramification_valueGroup_directed (n m)`: `P n ∪ P m ⊆ P (n*m)`. One-liner via
+  `Set.union_subset_iff` + the two `ramification_valueGroup_mono` inclusions
+  (`dvd_mul_right n m`, `dvd_mul_left m n`). This is the valuation shadow of
+  `exists_common_ramification` (series-level directedness of the filtration).
+- `directed_ramification_valueGroup`: packages the same fact as
+  `Directed (· ⊆ ·) (fun n : ℕ+ => P n)` — the order-theoretic hypothesis that makes
+  `iUnion_ramification_valueGroup` a *filtered* union / directed colimit of value groups.
+
+Both proofs are pure reuse of `ramification_valueGroup_mono`; no new API needed.
+1385→1416 lines, 45→47 theorems.
+
+**Build**: same intermittent exit-135 SIGBUS at olean-write as prior sessions — elaboration
+`[3070/3070]` completes with zero type errors, then crashes on write. Retried; landed clean
+`Build completed successfully (3070 jobs)`. Code 135 here is NOT a logic error.
+
+**Deferred (unchanged):** full Newton–Puiseux for arbitrary polynomials (Newton polygon +
+char-0 convergence, >1000L, absent from Mathlib) remains the genuine open remainder.


### PR DESCRIPTION
## Summary

`puiseux-theorem-wip-01` (Wiedijk #41, `PuiseuxTheorem.lean`) is already SOLVED (0 sorry / 0 axiom); this session does outward structural work, closing the exact `nextSteps` item recorded in the problem knowledge.

Part XIII/XIV established that the level-`n` value groups
`P n := {orderTop f | f ≠ 0, IsPuiseuxOfRamification n f} = (1/n)ℤ`
are **monotone** under divisibility (`ramification_valueGroup_mono`) and have **union** all of `ℚ` (`iUnion_ramification_valueGroup`). What was asserted but not proved is their **directedness** — the explicit common refinement. This PR supplies it:

- **`ramification_valueGroup_directed (n m)`** — `P n ∪ P m ⊆ P (n*m)`. The valuation-theoretic shadow of `exists_common_ramification` (series-level directedness of the ramification filtration), refining `ramification_valueGroup_mono` from a single divisibility inclusion to a join. Proof: `Set.union_subset_iff` + the two `mono` inclusions.
- **`directed_ramification_valueGroup`** — packages the same fact as `Directed (· ⊆ ·) (fun n : ℕ+ => P n)`, the order-theoretic hypothesis that makes `iUnion_ramification_valueGroup` a genuine *filtered* union / directed colimit of value groups.

Both proofs are pure reuse of the already-verified `ramification_valueGroup_mono`; no new API.

## Verification

- `./proofs/scripts/docker-build.sh Proofs.PuiseuxTheorem` → **Build completed successfully (3070 jobs)**.
- 0 sorries, 0 axioms preserved (theorems use only `.mono`, `Set.union_subset_iff`, `Directed`, `dvd_mul_right/left`).
- 1385→1416 lines, 45→47 theorems.

Note: the file exhibits an intermittent exit-135 SIGBUS at olean-write (documented in prior sessions); elaboration completes with zero type errors, a re-run lands clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)