### PR TITLE
Enrich Bounded Prime Gaps OQ-01-OQ-01: cover the module docstring

### DIFF
--- a/src/data/proofs/bounded-prime-gaps-oq-01-oq-01/meta.json
+++ b/src/data/proofs/bounded-prime-gaps-oq-01-oq-01/meta.json
@@ -87,6 +87,14 @@
   },
   "sections": [
     {
+      "id": "preamble",
+      "title": "Overview: Why the Gap-Sieve Axioms Are Redundant",
+      "startLine": 1,
+      "endLine": 63,
+      "summary": "Module docstring, imports (Mathlib only), and namespace. States the open question — can the parent file's two gap-sieve axioms (maynard_tao_sieve, maynard_tao_sieve_eh) be eliminated? — and the answer: their conclusion (∀ N, ∃ n ≥ N, primeGap n ≤ D) follows by a purely elementary, axiom-free argument from the MaynardTaoDensity H 2 statement alone, using only the diameter bound (not even admissibility). The irreducible sieve input is therefore a single density statement, not three axioms. Includes the key-arithmetic sketch: two primes p < q = n+h₂ within D force the next prime after p to be ≤ q, so primeGap π(p) ≤ D.",
+      "mathContext": "Goal: derive `∀ N, ∃ n ≥ N, primeGap n ≤ D` from `MaynardTaoDensity H 2`, eliminating maynard_tao_sieve and maynard_tao_sieve_eh."
+    },
+    {
       "id": "definitions",
       "title": "Definitions (mirrored from BoundedPrimeGaps)",
       "startLine": 64,
@@ -96,7 +104,7 @@
     {
       "id": "arithmetic-core",
       "title": "The arithmetic core: gap_from_two_primes",
-      "startLine": 98,
+      "startLine": 85,
       "endLine": 147,
       "summary": "Given two primes p = n+x < q = n+y with y <= D and the shift n >= nthPrime N, produces a consecutive prime gap <= D at index >= N. The next prime after p is bounded by q via Nat.nth monotonicity; the index is pushed past N via Nat.count monotonicity and the nth/count inverse lemmas."
     },


### PR DESCRIPTION
Enrichment pass for `bounded-prime-gaps-oq-01-oq-01` (quality 96, pass 0).

## Change
The `sections` array started at line 64, leaving a **substantial coverage hole**: the entire 63-line module docstring — the entry's introduction, which states the open question (can the parent's two gap-sieve axioms be eliminated?) and the answer (their conclusion follows by an elementary axiom-free density-to-gap reduction) — had **no section**, as did lines 85–97 (the Part I header and `gap_from_two_primes` docstring).

- Added an **Overview** section (1–63) summarizing the axiom-elimination result and the key arithmetic.
- Extended the arithmetic-core section to start at line 85.

Sections now cover the full 207-line file with **no holes**. sections 4 → 5.

## Guardrails
- meta.json = 14.0 KB (well under the ~60 KB cap); `gallery:check-size` passes.
- Only `meta.json` changed (annotations untouched). Data-build steps pass. One pre-existing, tolerated "No Lean construct found" notice on an `open`-anchored annotation (line 64) is unrelated to this change.
- Axiom integrity unchanged: entry is a 0-axiom elementary reduction; `verified`, 0 sorries.