### PR TITLE
research(weak-goldbach-oq-01): closed-form m/6 hexagonal ceiling on the Goldbach comet [axiom-free]

### DIFF
--- a/proofs/Proofs/StrongGoldbachSymmetric.lean
+++ b/proofs/Proofs/StrongGoldbachSymmetric.lean
@@ -1098,4 +1098,57 @@ example : ((Finset.range 5).filter (fun k => 6 ∣ k)).card = 1 := by decide
 example : symmetricPairCount 25 ≤ ((Finset.range 25).filter (fun k => 6 ∣ k)).card + 1 :=
   symmetricPairCount_le_card_dvd_six_succ (by decide) (by decide)
 
+/-- **Count of multiples of `6` below `m`.**  For `m ≥ 1` there are exactly
+`(m - 1) / 6 + 1` multiples of `6` in `range m` (the offsets `0, 6, 12, …`).  This is the
+finite arithmetic behind the "roughly `m/6`" language accompanying the hexagonal ceiling:
+splitting off the always-present offset `k = 0` reduces the count to the positive
+multiples counted by `Nat.card_multiples'`. -/
+theorem card_range_filter_dvd_six {m : ℕ} (hm : 0 < m) :
+    ((Finset.range m).filter (fun k => 6 ∣ k)).card = (m - 1) / 6 + 1 := by
+  have hsplit : (Finset.range m).filter (fun k => 6 ∣ k)
+      = insert 0 ((Finset.range m).filter (fun k => k ≠ 0 ∧ 6 ∣ k)) := by
+    ext k
+    simp only [Finset.mem_insert, Finset.mem_filter, Finset.mem_range]
+    constructor
+    · rintro ⟨hk, hd⟩
+      rcases eq_or_ne k 0 with rfl | hne
+      · exact Or.inl rfl
+      · exact Or.inr ⟨hk, hne, hd⟩
+    · rintro (rfl | ⟨hk, _, hd⟩)
+      · exact ⟨hm, dvd_zero 6⟩
+      · exact ⟨hk, hd⟩
+  rw [hsplit, Finset.card_insert_of_notMem (by simp)]
+  have hkey := Nat.card_multiples' (m - 1) 6
+  rw [Nat.succ_eq_add_one, Nat.sub_add_cancel hm] at hkey
+  rw [hkey]
+
+/-- **Closed-form hexagonal ceiling on the comet height.**  For odd `m` coprime to `3`,
+
+    symmetricPairCount m ≤ (m - 1) / 6 + 2.
+
+This is the explicit `≈ m / 6` form of the period-`6` banding
+(`symmetricPairCount_le_card_dvd_six_succ`), obtained by evaluating the count of
+multiples of `6` below `m` via `card_range_filter_dvd_six`.  It is a threefold
+sharpening of the parity ceiling `symmetricPairCount m ≤ ⌈m/2⌉`
+(`symmetricPairCount_le_half`), and at midpoints coprime to `6` beats the half-totient
+ceiling `symmetricPairCount_le_half_totient_succ_of_odd` as well. -/
+theorem symmetricPairCount_le_div_six {m : ℕ} (hm : Odd m) (hm3 : ¬ 3 ∣ m) :
+    symmetricPairCount m ≤ (m - 1) / 6 + 2 := by
+  have hpos : 0 < m := by obtain ⟨j, hj⟩ := hm; omega
+  calc symmetricPairCount m
+      ≤ ((Finset.range m).filter (fun k => 6 ∣ k)).card + 1 :=
+        symmetricPairCount_le_card_dvd_six_succ hm hm3
+    _ = (m - 1) / 6 + 1 + 1 := by rw [card_range_filter_dvd_six hpos]
+    _ = (m - 1) / 6 + 2 := rfl
+
+-- `m = 5`: `(5 - 1) / 6 + 2 = 0 + 2 = 2`, matching the exact height `2`
+-- (`10 = 5 + 5 = 3 + 7`) and sharper than the half-totient ceiling `φ(5)/2 + 1 = 3`.
+example : symmetricPairCount 5 ≤ (5 - 1) / 6 + 2 :=
+  symmetricPairCount_le_div_six (by decide) (by decide)
+
+-- `m = 25`: `(25 - 1) / 6 + 2 = 4 + 2 = 6`, matching the hexagonal-count ceiling and
+-- bounding the actual height `4`.
+example : symmetricPairCount 25 ≤ (25 - 1) / 6 + 2 :=
+  symmetricPairCount_le_div_six (by decide) (by decide)
+
 end StrongGoldbach

--- a/research/problems/weak-goldbach-oq-01/knowledge.md
+++ b/research/problems/weak-goldbach-oq-01/knowledge.md
@@ -647,3 +647,26 @@ Schnirelmann basis axiom was already discharged.
 **Assessment: SATURATED + VERIFIED.** The elementary comet-height counting theory is complete
 (decomposition, arm/parity/totient upper bounds); the real advance would be a nontrivial LOWER
 bound = essentially Goldbach. No new lemma; marked completed.
+
+## PART VI — closed-form m/6 hexagonal comet ceiling (researcher-9, 2026-07-11)
+
+**Mode**: REVISIT (RICH). SOLVED-mode outward extension of the comet fine-structure
+line in `StrongGoldbachSymmetric.lean` (strong-goldbach-symmetric gallery entry). The
+prior mod-3 / hexagonal work (#38153) capped the comet height `symmetricPairCount m` by
+a Finset cardinality `#{k < m : 6 ∣ k} + 1`, described only as "roughly m/6". This
+session supplies the explicit arithmetic closed form.
+
+- `card_range_filter_dvd_six` (m ≥ 1): `#{k ∈ range m : 6 ∣ k} = (m-1)/6 + 1`. Proof:
+  split off the always-present offset `k = 0` (`insert 0 …`, `card_insert_of_notMem`),
+  then the positive multiples are counted by Mathlib's `Nat.card_multiples' N n :
+  #{k ∈ range N.succ | k ≠ 0 ∧ n ∣ k} = N/n` with `N = m-1` (`succ_eq_add_one` +
+  `sub_add_cancel hpos`).
+- `symmetricPairCount_le_div_six` (odd m, ¬3∣m): `symmetricPairCount m ≤ (m-1)/6 + 2`.
+  A `calc` chaining `symmetricPairCount_le_card_dvd_six_succ` with the card evaluation.
+  Explicit ≈ m/6 ceiling — threefold sharper than the parity ceiling ⌈m/2⌉ and, at m
+  coprime to 6, sharper than the half-totient ceiling.
+
+Both axiom-free `[propext, Classical.choice, Quot.sound]`; theoremCount 37→39.
+PR #38195. Verified on host lean v4.26.0 (docker exited 135/139 = transient
+SIGBUS/SIGSEGV host mem thrash, not proof errors — the file compiled to completion
+under host `lean` on the full Mathlib LEAN_PATH).

--- a/src/data/proofs/strong-goldbach-symmetric/meta.json
+++ b/src/data/proofs/strong-goldbach-symmetric/meta.json
@@ -119,9 +119,9 @@
   },
   "leanFile": {
     "namespace": "StrongGoldbach",
-    "lineCount": 1101,
+    "lineCount": 1154,
     "axiomCount": 0,
-    "theoremCount": 37,
+    "theoremCount": 39,
     "definitionCount": 5,
     "path": "Proofs/StrongGoldbachSymmetric.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

Extends the Goldbach-comet fine-structure work in `StrongGoldbachSymmetric.lean`. The prior *hexagonal ceiling* `symmetricPairCount_le_card_dvd_six_succ` bounded the comet height by a **Finset cardinality** `#{k < m : 6 ∣ k} + 1`, described only informally as "roughly $m/6$". This PR supplies the explicit arithmetic closed form.

## New theorems (both axiom-free)

- **`card_range_filter_dvd_six`** — for $m \ge 1$ there are exactly $(m-1)/6 + 1$ multiples of $6$ in `range m` (offsets $0, 6, 12, \dots$). Proved by splitting off the always-present offset $k = 0$ and applying `Nat.card_multiples'` to the positive multiples.
- **`symmetricPairCount_le_div_six`** — for odd $m$ coprime to $3$,
  $$ \texttt{symmetricPairCount}\, m \;\le\; (m-1)/6 + 2. $$
  The explicit $\approx m/6$ comet ceiling: a **threefold sharpening** of the elementary parity ceiling $\lceil m/2 \rceil$ and, at midpoints coprime to $6$, sharper than the half-totient ceiling.

Validated with worked examples ($m = 5$ gives $2$, matching the exact height; $m = 25$ gives $6$, bounding the actual height $4$).

## Verification

- `#print axioms` on both theorems: `[propext, Classical.choice, Quot.sound]` — **0 axioms, 0 sorries**.
- Compiles under Lean v4.26.0 (host `lean` on the full Mathlib `LEAN_PATH`).
- `theoremCount` 37 → 39 in `strong-goldbach-symmetric/meta.json`.

The Strong Goldbach Conjecture itself remains open; this PR only adds an unconditional structural ceiling on the comet counting function.

🤖 Generated with [Claude Code](https://claude.com/claude-code)