### PR TITLE
research(erdos-1204): exact A(8)=26 — prime 7 first becomes binding

### DIFF
--- a/proofs/Proofs/Erdos1204A8.lean
+++ b/proofs/Proofs/Erdos1204A8.lean
@@ -43,16 +43,15 @@ namespace Erdos1204
 
 open Finset
 
-/-- A set whose image in `ZMod p` is all of `ZMod p` cannot be admissible: it fails
-to miss any residue class at the prime `p`. This is the workhorse for killing the
-"forced" sets that arise in the lower-bound case analysis. -/
-private theorem not_admissible_of_image_univ {a : Finset ℕ} {p : ℕ} (hp : p.Prime)
-    (hcov : a.image (fun x : ℕ => (x : ZMod p)) = Finset.univ) : ¬ Admissible a := by
+/-- A set that hits *every* residue class modulo `p` cannot be admissible: it fails
+to miss any class at the prime `p`. This is the workhorse for killing the "forced"
+sets that arise in the lower-bound case analysis (checked by `decide` at concrete
+primes). -/
+private theorem not_admissible_of_covers {a : Finset ℕ} {p : ℕ} (hp : p.Prime)
+    (hcov : ∀ r : ZMod p, ∃ x ∈ a, (x : ZMod p) = r) : ¬ Admissible a := by
   intro ha
   obtain ⟨r, hr⟩ := ha p hp
-  have hmem : r ∈ a.image (fun x : ℕ => (x : ZMod p)) := by
-    rw [hcov]; exact Finset.mem_univ r
-  obtain ⟨x, hx, hxr⟩ := Finset.mem_image.mp hmem
+  obtain ⟨x, hx, hxr⟩ := hcov r
   exact hr x hx hxr
 
 /-- The witness `{0,2,6,8,12,18,20,26}` (the `A(7)` witness plus `26`) is admissible:
@@ -107,7 +106,7 @@ theorem no_admissible_eight_evens {a : Finset ℕ}
     have heq : a = ({2, 4, 8, 10, 14, 16, 20, 22} : Finset ℕ) :=
       Finset.eq_of_subset_of_card_le hs (by rw [hcard]; decide)
     rw [heq] at ha
-    exact not_admissible_of_image_univ (p := 5) (by decide) (by decide) ha
+    exact not_admissible_of_covers (p := 5) (by decide) (by decide) ha
   · -- misses class 1 mod 3 ⇒ pool {0,2,6,8,12,14,18,20,24} (card 9)
     have hs : a ⊆ ({0, 2, 6, 8, 12, 14, 18, 20, 24} : Finset ℕ) := by
       intro x hx
@@ -132,7 +131,7 @@ theorem no_admissible_eight_evens {a : Finset ℕ}
       have heq : a = ({0, 2, 8, 12, 14, 18, 20, 24} : Finset ℕ) :=
         Finset.eq_of_subset_of_card_le hs5 (by rw [hcard]; decide)
       rw [heq] at ha
-      exact not_admissible_of_image_univ (p := 7) (by decide) (by decide) ha
+      exact not_admissible_of_covers (p := 7) (by decide) (by decide) ha
     · -- miss 2 mod 5 ⇒ ⊆ {0,6,8,14,18,20,24} (card 7)
       have hs5 : a ⊆ ({0, 6, 8, 14, 18, 20, 24} : Finset ℕ) := by
         intro x hx
@@ -192,7 +191,7 @@ theorem no_admissible_eight_evens {a : Finset ℕ}
       have heq : a = ({0, 4, 6, 10, 12, 16, 22, 24} : Finset ℕ) :=
         Finset.eq_of_subset_of_card_le hs5 (by rw [hcard]; decide)
       rw [heq] at ha
-      exact not_admissible_of_image_univ (p := 7) (by decide) (by decide) ha
+      exact not_admissible_of_covers (p := 7) (by decide) (by decide) ha
     · -- miss 4 mod 5 ⇒ ⊆ {0,6,10,12,16,18,22} (card 7)
       have hs5 : a ⊆ ({0, 6, 10, 12, 16, 18, 22} : Finset ℕ) := by
         intro x hx
@@ -259,7 +258,7 @@ theorem no_admissible_eight_odds {a : Finset ℕ}
       have heq : a = ({1, 5, 7, 11, 13, 17, 23, 25} : Finset ℕ) :=
         Finset.eq_of_subset_of_card_le hs5 (by rw [hcard]; decide)
       rw [heq] at ha
-      exact not_admissible_of_image_univ (p := 7) (by decide) (by decide) ha
+      exact not_admissible_of_covers (p := 7) (by decide) (by decide) ha
   · -- misses class 1 mod 3 ⇒ forced 8-set {3,5,9,11,15,17,21,23}, covers mod 5
     have hs : a ⊆ ({3, 5, 9, 11, 15, 17, 21, 23} : Finset ℕ) := by
       intro x hx
@@ -269,7 +268,7 @@ theorem no_admissible_eight_odds {a : Finset ℕ}
     have heq : a = ({3, 5, 9, 11, 15, 17, 21, 23} : Finset ℕ) :=
       Finset.eq_of_subset_of_card_le hs (by rw [hcard]; decide)
     rw [heq] at ha
-    exact not_admissible_of_image_univ (p := 5) (by decide) (by decide) ha
+    exact not_admissible_of_covers (p := 5) (by decide) (by decide) ha
   · -- misses class 2 mod 3 ⇒ pool {1,3,7,9,13,15,19,21,25} (card 9)
     have hs : a ⊆ ({1, 3, 7, 9, 13, 15, 19, 21, 25} : Finset ℕ) := by
       intro x hx
@@ -301,7 +300,7 @@ theorem no_admissible_eight_odds {a : Finset ℕ}
       have heq : a = ({1, 3, 9, 13, 15, 19, 21, 25} : Finset ℕ) :=
         Finset.eq_of_subset_of_card_le hs5 (by rw [hcard]; decide)
       rw [heq] at ha
-      exact not_admissible_of_image_univ (p := 7) (by decide) (by decide) ha
+      exact not_admissible_of_covers (p := 7) (by decide) (by decide) ha
     · -- miss 3 mod 5 ⇒ ⊆ {1,7,9,15,19,21,25} (card 7)
       have hs5 : a ⊆ ({1, 7, 9, 15, 19, 21, 25} : Finset ℕ) := by
         intro x hx

--- a/proofs/Proofs/Erdos1204A8.lean
+++ b/proofs/Proofs/Erdos1204A8.lean
@@ -1,33 +1,59 @@
 import Proofs.Erdos1204A7
 
 /-
-# Erdős #1204 — the upper bound `A(8) ≤ 26` (Hardy–Littlewood witness)
+# Erdős #1204 — the exact value `A(8) = 26`
 
 Continues the exact-value frontier `A(2)=2, A(3)=6, A(4)=8, A(5)=12, A(6)=16,
-A(7)=20` (`Erdos1204Problem.lean`, `Erdos1204A4`–`A7`) toward the next Hardy–
-Littlewood minimal diameter `H(8) = 26`.
+A(7)=20` (`Erdos1204Problem.lean`, `Erdos1204A4`–`A7`) with the next Hardy–Littlewood
+minimal diameter `A(8) = H(8) = 26`, verified and axiom-free.
 
-This file certifies the **upper half** of `A(8) = 26`: the explicit admissible
-`8`-tuple `{0,2,6,8,12,18,20,26}` (the `A(7)` witness extended by `26`), whose
-largest element is `26`, so `A(8) ≤ 26`. Together with the one-step strict
-monotonicity `A(7) < A(8)` (`A_lt_A_succ`, giving `A(8) ≥ 21`) this sandwiches
-`21 ≤ A(8) ≤ 26`.
+Note the *jump of six* (`20 → 26`, not the `+4` of every earlier step): `H(8)` is the
+first place in the sequence where a single-parity window minus one mod-3 class still
+admits an 8-set, so a *second* prime (namely `7`) is needed to close the lower bound.
+This is the qualitative milestone the frontier had been approaching — at `A(7)` the
+prime `7` was not yet binding.
 
-The **matching lower bound** `A(8) ≥ 26` — no admissible `8`-set fits in `{0,…,25}` —
-is the hard extremal direction: unlike `A(7)` (killed already at `p = 5`), the `A(8)`
-lower bound is where the prime `7` first becomes binding, requiring a mod-`2,3,5,7`
-pruning over the `26`-element window. It is left for future work; the exact value and
-the asymptotics `A(k) ∼ k log k` (sieve theory) remain OPEN.
+- **Upper bound** `A(8) ≤ 26` (`A_eight_le`): the witness `{0,2,6,8,12,18,20,26}`
+  (the `A(7)` witness extended by `26`) is admissible — all even (misses the odd class
+  mod 2); residues `0,2,0,2,0,0,2,2` mod 3 (misses class 1); residues `0,2,1,3,2,3,0,1`
+  mod 5 (misses class 4); residues `0,2,6,1,5,4,6,5` mod 7 (misses class 3). Primes
+  `p ≥ 11` are automatic since `|a| = 8 < p`.
+- **Lower bound** `A(8) ≥ 26` (`admissible_eight_sup_ge`): any admissible 8-set with
+  maximum `≤ 25` sits in `{0,…,25}`; missing a class mod 2 forces a single parity, so
+  it is an 8-element subset of the thirteen evens `{0,2,…,24}` or thirteen odds
+  `{1,3,…,25}`. Within each thirteen-element window the residue classes mod 3 have
+  sizes `5,4,4`.
+  * Missing the *size-5* class leaves exactly `8` slots — a single **forced** 8-set,
+    which covers every residue class mod `5`, so it dies at `p = 5`.
+  * Missing a *size-4* class leaves `9` slots. Among the five residue classes mod `5`
+    in this 9-element pool, four have two elements and one is a singleton; an
+    admissible 8-subset must miss a class mod `5`, but a two-element class cannot be
+    avoided by dropping a single element, so the missed class is the singleton — pinning
+    the 8-subset to one **forced** set. Each such forced set covers every class mod `7`,
+    so it dies at `p = 7`.
 
-- **Witness admissibility.** `{0,2,6,8,12,18,20,26}` is admissible: all even (misses
-  the odd class mod 2); residues `0,2,0,2,0,0,2,2` mod 3 (misses class 1); residues
-  `0,2,1,3,2,3,0,1` mod 5 (misses class 4); residues `0,2,6,1,5,4,6,5` mod 7 (misses
-  class 3). Primes `p ≥ 11` are automatic since `|a| = 8 < p`.
+So `p = 7` is genuinely binding here (unlike at `A(7) = 20`): the even branches
+`mod 3 ≡ 1,2` and the odd branches `mod 3 ≡ 0,2` each produce a forced 8-set that
+survives `p = 5` and is killed only at `p = 7`. `A(8) = 26` lies between the general
+bounds `2(k−1) = 14 ≤ A(k)` and `A(k) ≤ (k−1)·primorial`; `26 > 14 = 2(k−1)`. The
+asymptotics `A(k) ∼ k log k` remain OPEN (need sieve theory).
 -/
 
 namespace Erdos1204
 
 open Finset
+
+/-- A set whose image in `ZMod p` is all of `ZMod p` cannot be admissible: it fails
+to miss any residue class at the prime `p`. This is the workhorse for killing the
+"forced" sets that arise in the lower-bound case analysis. -/
+private theorem not_admissible_of_image_univ {a : Finset ℕ} {p : ℕ} (hp : p.Prime)
+    (hcov : a.image (fun x : ℕ => (x : ZMod p)) = Finset.univ) : ¬ Admissible a := by
+  intro ha
+  obtain ⟨r, hr⟩ := ha p hp
+  have hmem : r ∈ a.image (fun x : ℕ => (x : ZMod p)) := by
+    rw [hcov]; exact Finset.mem_univ r
+  obtain ⟨x, hx, hxr⟩ := Finset.mem_image.mp hmem
+  exact hr x hx hxr
 
 /-- The witness `{0,2,6,8,12,18,20,26}` (the `A(7)` witness plus `26`) is admissible:
 even ⇒ misses the odd class mod 2; residues `0,2,0,2,0,0,2,2` mod 3 ⇒ misses class 1;
@@ -59,20 +85,297 @@ theorem A_eight_le : A 8 ≤ 26 := by
   have hs : ({0, 2, 6, 8, 12, 18, 20, 26} : Finset ℕ).sup id = 26 := by decide
   rwa [hs] at h
 
-/-- **`A(8) ≥ 21`.** Strict one-step monotonicity `A(7) < A(8)` (`A_lt_A_succ`)
-together with the exact value `A(7) = 20` (`A_seven`) forces `A(8) ≥ 21` — sharper
-than the general parity bound `2·(8−1) = 14 ≤ A(8)`. -/
-theorem A_eight_ge : 21 ≤ A 8 := by
-  have hlt : A 7 < A 8 := A_lt_A_succ (k := 7) (by norm_num)
-  rw [A_seven] at hlt
+/-- **Lower-bound core (even parity).** An 8-element subset of the thirteen evens
+`{0,2,4,…,24}` is never admissible. The size-5 class mod 3 is `0 mod 3`; missing it
+forces the 8-set `{2,4,8,10,14,16,20,22}`, which covers every class mod 5 (dies at
+`p = 5`). Missing either size-4 class (`1 mod 3` / `2 mod 3`) leaves a 9-element pool,
+and admissibility at `p = 5` pins the 8-subset to a forced set
+(`{0,2,8,12,14,18,20,24}` / `{0,4,6,10,12,16,22,24}`), each covering every class mod 7
+(dies at `p = 7`). -/
+theorem no_admissible_eight_evens {a : Finset ℕ}
+    (hsub : a ⊆ ({0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24} : Finset ℕ))
+    (hcard : a.card = 8) : ¬ Admissible a := by
+  intro ha
+  obtain ⟨r, hr⟩ := ha 3 (by decide)
+  fin_cases r
+  · -- misses class 0 mod 3 ⇒ forced 8-set {2,4,8,10,14,16,20,22}, covers mod 5
+    have hs : a ⊆ ({2, 4, 8, 10, 14, 16, 20, 22} : Finset ℕ) := by
+      intro x hx
+      have hxE := hsub hx
+      have hxne : (x : ZMod 3) ≠ 0 := hr x hx
+      fin_cases hxE <;> first | decide | exact absurd (by decide) hxne
+    have heq : a = ({2, 4, 8, 10, 14, 16, 20, 22} : Finset ℕ) :=
+      Finset.eq_of_subset_of_card_le hs (by rw [hcard]; decide)
+    rw [heq] at ha
+    exact not_admissible_of_image_univ (p := 5) (by decide) (by decide) ha
+  · -- misses class 1 mod 3 ⇒ pool {0,2,6,8,12,14,18,20,24} (card 9)
+    have hs : a ⊆ ({0, 2, 6, 8, 12, 14, 18, 20, 24} : Finset ℕ) := by
+      intro x hx
+      have hxE := hsub hx
+      have hxne : (x : ZMod 3) ≠ 1 := hr x hx
+      fin_cases hxE <;> first | decide | exact absurd (by decide) hxne
+    obtain ⟨r5, hr5⟩ := ha 5 (by decide)
+    fin_cases r5
+    · -- miss 0 mod 5 ⇒ ⊆ {2,6,8,12,14,18,24} (card 7)
+      have hs5 : a ⊆ ({2, 6, 8, 12, 14, 18, 24} : Finset ℕ) := by
+        intro x hx
+        have hxP := hs hx
+        have hxne : (x : ZMod 5) ≠ 0 := hr5 x hx
+        fin_cases hxP <;> first | decide | exact absurd (by decide) hxne
+      have hle := Finset.card_le_card hs5; rw [hcard] at hle; revert hle; decide
+    · -- miss 1 mod 5 ⇒ forced {0,2,8,12,14,18,20,24}, covers mod 7
+      have hs5 : a ⊆ ({0, 2, 8, 12, 14, 18, 20, 24} : Finset ℕ) := by
+        intro x hx
+        have hxP := hs hx
+        have hxne : (x : ZMod 5) ≠ 1 := hr5 x hx
+        fin_cases hxP <;> first | decide | exact absurd (by decide) hxne
+      have heq : a = ({0, 2, 8, 12, 14, 18, 20, 24} : Finset ℕ) :=
+        Finset.eq_of_subset_of_card_le hs5 (by rw [hcard]; decide)
+      rw [heq] at ha
+      exact not_admissible_of_image_univ (p := 7) (by decide) (by decide) ha
+    · -- miss 2 mod 5 ⇒ ⊆ {0,6,8,14,18,20,24} (card 7)
+      have hs5 : a ⊆ ({0, 6, 8, 14, 18, 20, 24} : Finset ℕ) := by
+        intro x hx
+        have hxP := hs hx
+        have hxne : (x : ZMod 5) ≠ 2 := hr5 x hx
+        fin_cases hxP <;> first | decide | exact absurd (by decide) hxne
+      have hle := Finset.card_le_card hs5; rw [hcard] at hle; revert hle; decide
+    · -- miss 3 mod 5 ⇒ ⊆ {0,2,6,12,14,20,24} (card 7)
+      have hs5 : a ⊆ ({0, 2, 6, 12, 14, 20, 24} : Finset ℕ) := by
+        intro x hx
+        have hxP := hs hx
+        have hxne : (x : ZMod 5) ≠ 3 := hr5 x hx
+        fin_cases hxP <;> first | decide | exact absurd (by decide) hxne
+      have hle := Finset.card_le_card hs5; rw [hcard] at hle; revert hle; decide
+    · -- miss 4 mod 5 ⇒ ⊆ {0,2,6,8,12,18,20} (card 7)
+      have hs5 : a ⊆ ({0, 2, 6, 8, 12, 18, 20} : Finset ℕ) := by
+        intro x hx
+        have hxP := hs hx
+        have hxne : (x : ZMod 5) ≠ 4 := hr5 x hx
+        fin_cases hxP <;> first | decide | exact absurd (by decide) hxne
+      have hle := Finset.card_le_card hs5; rw [hcard] at hle; revert hle; decide
+  · -- misses class 2 mod 3 ⇒ pool {0,4,6,10,12,16,18,22,24} (card 9)
+    have hs : a ⊆ ({0, 4, 6, 10, 12, 16, 18, 22, 24} : Finset ℕ) := by
+      intro x hx
+      have hxE := hsub hx
+      have hxne : (x : ZMod 3) ≠ 2 := hr x hx
+      fin_cases hxE <;> first | decide | exact absurd (by decide) hxne
+    obtain ⟨r5, hr5⟩ := ha 5 (by decide)
+    fin_cases r5
+    · -- miss 0 mod 5 ⇒ ⊆ {4,6,12,16,18,22,24} (card 7)
+      have hs5 : a ⊆ ({4, 6, 12, 16, 18, 22, 24} : Finset ℕ) := by
+        intro x hx
+        have hxP := hs hx
+        have hxne : (x : ZMod 5) ≠ 0 := hr5 x hx
+        fin_cases hxP <;> first | decide | exact absurd (by decide) hxne
+      have hle := Finset.card_le_card hs5; rw [hcard] at hle; revert hle; decide
+    · -- miss 1 mod 5 ⇒ ⊆ {0,4,10,12,18,22,24} (card 7)
+      have hs5 : a ⊆ ({0, 4, 10, 12, 18, 22, 24} : Finset ℕ) := by
+        intro x hx
+        have hxP := hs hx
+        have hxne : (x : ZMod 5) ≠ 1 := hr5 x hx
+        fin_cases hxP <;> first | decide | exact absurd (by decide) hxne
+      have hle := Finset.card_le_card hs5; rw [hcard] at hle; revert hle; decide
+    · -- miss 2 mod 5 ⇒ ⊆ {0,4,6,10,16,18,24} (card 7)
+      have hs5 : a ⊆ ({0, 4, 6, 10, 16, 18, 24} : Finset ℕ) := by
+        intro x hx
+        have hxP := hs hx
+        have hxne : (x : ZMod 5) ≠ 2 := hr5 x hx
+        fin_cases hxP <;> first | decide | exact absurd (by decide) hxne
+      have hle := Finset.card_le_card hs5; rw [hcard] at hle; revert hle; decide
+    · -- miss 3 mod 5 ⇒ forced {0,4,6,10,12,16,22,24}, covers mod 7
+      have hs5 : a ⊆ ({0, 4, 6, 10, 12, 16, 22, 24} : Finset ℕ) := by
+        intro x hx
+        have hxP := hs hx
+        have hxne : (x : ZMod 5) ≠ 3 := hr5 x hx
+        fin_cases hxP <;> first | decide | exact absurd (by decide) hxne
+      have heq : a = ({0, 4, 6, 10, 12, 16, 22, 24} : Finset ℕ) :=
+        Finset.eq_of_subset_of_card_le hs5 (by rw [hcard]; decide)
+      rw [heq] at ha
+      exact not_admissible_of_image_univ (p := 7) (by decide) (by decide) ha
+    · -- miss 4 mod 5 ⇒ ⊆ {0,6,10,12,16,18,22} (card 7)
+      have hs5 : a ⊆ ({0, 6, 10, 12, 16, 18, 22} : Finset ℕ) := by
+        intro x hx
+        have hxP := hs hx
+        have hxne : (x : ZMod 5) ≠ 4 := hr5 x hx
+        fin_cases hxP <;> first | decide | exact absurd (by decide) hxne
+      have hle := Finset.card_le_card hs5; rw [hcard] at hle; revert hle; decide
+
+/-- **Lower-bound core (odd parity).** An 8-element subset of the thirteen odds
+`{1,3,5,…,25}` is never admissible. The size-5 class mod 3 is now `1 mod 3`; missing
+it forces `{3,5,9,11,15,17,21,23}`, which covers every class mod 5 (dies at `p = 5`).
+Missing either size-4 class (`0 mod 3` / `2 mod 3`) leaves a 9-element pool, and
+admissibility at `p = 5` pins the 8-subset to a forced set
+(`{1,5,7,11,13,17,23,25}` / `{1,3,9,13,15,19,21,25}`), each covering every class
+mod 7 (dies at `p = 7`). -/
+theorem no_admissible_eight_odds {a : Finset ℕ}
+    (hsub : a ⊆ ({1, 3, 5, 7, 9, 11, 13, 15, 17, 19, 21, 23, 25} : Finset ℕ))
+    (hcard : a.card = 8) : ¬ Admissible a := by
+  intro ha
+  obtain ⟨r, hr⟩ := ha 3 (by decide)
+  fin_cases r
+  · -- misses class 0 mod 3 ⇒ pool {1,5,7,11,13,17,19,23,25} (card 9)
+    have hs : a ⊆ ({1, 5, 7, 11, 13, 17, 19, 23, 25} : Finset ℕ) := by
+      intro x hx
+      have hxE := hsub hx
+      have hxne : (x : ZMod 3) ≠ 0 := hr x hx
+      fin_cases hxE <;> first | decide | exact absurd (by decide) hxne
+    obtain ⟨r5, hr5⟩ := ha 5 (by decide)
+    fin_cases r5
+    · -- miss 0 mod 5 ⇒ ⊆ {1,7,11,13,17,19,23} (card 7)
+      have hs5 : a ⊆ ({1, 7, 11, 13, 17, 19, 23} : Finset ℕ) := by
+        intro x hx
+        have hxP := hs hx
+        have hxne : (x : ZMod 5) ≠ 0 := hr5 x hx
+        fin_cases hxP <;> first | decide | exact absurd (by decide) hxne
+      have hle := Finset.card_le_card hs5; rw [hcard] at hle; revert hle; decide
+    · -- miss 1 mod 5 ⇒ ⊆ {5,7,13,17,19,23,25} (card 7)
+      have hs5 : a ⊆ ({5, 7, 13, 17, 19, 23, 25} : Finset ℕ) := by
+        intro x hx
+        have hxP := hs hx
+        have hxne : (x : ZMod 5) ≠ 1 := hr5 x hx
+        fin_cases hxP <;> first | decide | exact absurd (by decide) hxne
+      have hle := Finset.card_le_card hs5; rw [hcard] at hle; revert hle; decide
+    · -- miss 2 mod 5 ⇒ ⊆ {1,5,11,13,19,23,25} (card 7)
+      have hs5 : a ⊆ ({1, 5, 11, 13, 19, 23, 25} : Finset ℕ) := by
+        intro x hx
+        have hxP := hs hx
+        have hxne : (x : ZMod 5) ≠ 2 := hr5 x hx
+        fin_cases hxP <;> first | decide | exact absurd (by decide) hxne
+      have hle := Finset.card_le_card hs5; rw [hcard] at hle; revert hle; decide
+    · -- miss 3 mod 5 ⇒ ⊆ {1,5,7,11,17,19,25} (card 7)
+      have hs5 : a ⊆ ({1, 5, 7, 11, 17, 19, 25} : Finset ℕ) := by
+        intro x hx
+        have hxP := hs hx
+        have hxne : (x : ZMod 5) ≠ 3 := hr5 x hx
+        fin_cases hxP <;> first | decide | exact absurd (by decide) hxne
+      have hle := Finset.card_le_card hs5; rw [hcard] at hle; revert hle; decide
+    · -- miss 4 mod 5 ⇒ forced {1,5,7,11,13,17,23,25}, covers mod 7
+      have hs5 : a ⊆ ({1, 5, 7, 11, 13, 17, 23, 25} : Finset ℕ) := by
+        intro x hx
+        have hxP := hs hx
+        have hxne : (x : ZMod 5) ≠ 4 := hr5 x hx
+        fin_cases hxP <;> first | decide | exact absurd (by decide) hxne
+      have heq : a = ({1, 5, 7, 11, 13, 17, 23, 25} : Finset ℕ) :=
+        Finset.eq_of_subset_of_card_le hs5 (by rw [hcard]; decide)
+      rw [heq] at ha
+      exact not_admissible_of_image_univ (p := 7) (by decide) (by decide) ha
+  · -- misses class 1 mod 3 ⇒ forced 8-set {3,5,9,11,15,17,21,23}, covers mod 5
+    have hs : a ⊆ ({3, 5, 9, 11, 15, 17, 21, 23} : Finset ℕ) := by
+      intro x hx
+      have hxE := hsub hx
+      have hxne : (x : ZMod 3) ≠ 1 := hr x hx
+      fin_cases hxE <;> first | decide | exact absurd (by decide) hxne
+    have heq : a = ({3, 5, 9, 11, 15, 17, 21, 23} : Finset ℕ) :=
+      Finset.eq_of_subset_of_card_le hs (by rw [hcard]; decide)
+    rw [heq] at ha
+    exact not_admissible_of_image_univ (p := 5) (by decide) (by decide) ha
+  · -- misses class 2 mod 3 ⇒ pool {1,3,7,9,13,15,19,21,25} (card 9)
+    have hs : a ⊆ ({1, 3, 7, 9, 13, 15, 19, 21, 25} : Finset ℕ) := by
+      intro x hx
+      have hxE := hsub hx
+      have hxne : (x : ZMod 3) ≠ 2 := hr x hx
+      fin_cases hxE <;> first | decide | exact absurd (by decide) hxne
+    obtain ⟨r5, hr5⟩ := ha 5 (by decide)
+    fin_cases r5
+    · -- miss 0 mod 5 ⇒ ⊆ {1,3,7,9,13,19,21} (card 7)
+      have hs5 : a ⊆ ({1, 3, 7, 9, 13, 19, 21} : Finset ℕ) := by
+        intro x hx
+        have hxP := hs hx
+        have hxne : (x : ZMod 5) ≠ 0 := hr5 x hx
+        fin_cases hxP <;> first | decide | exact absurd (by decide) hxne
+      have hle := Finset.card_le_card hs5; rw [hcard] at hle; revert hle; decide
+    · -- miss 1 mod 5 ⇒ ⊆ {3,7,9,13,15,19,25} (card 7)
+      have hs5 : a ⊆ ({3, 7, 9, 13, 15, 19, 25} : Finset ℕ) := by
+        intro x hx
+        have hxP := hs hx
+        have hxne : (x : ZMod 5) ≠ 1 := hr5 x hx
+        fin_cases hxP <;> first | decide | exact absurd (by decide) hxne
+      have hle := Finset.card_le_card hs5; rw [hcard] at hle; revert hle; decide
+    · -- miss 2 mod 5 ⇒ forced {1,3,9,13,15,19,21,25}, covers mod 7
+      have hs5 : a ⊆ ({1, 3, 9, 13, 15, 19, 21, 25} : Finset ℕ) := by
+        intro x hx
+        have hxP := hs hx
+        have hxne : (x : ZMod 5) ≠ 2 := hr5 x hx
+        fin_cases hxP <;> first | decide | exact absurd (by decide) hxne
+      have heq : a = ({1, 3, 9, 13, 15, 19, 21, 25} : Finset ℕ) :=
+        Finset.eq_of_subset_of_card_le hs5 (by rw [hcard]; decide)
+      rw [heq] at ha
+      exact not_admissible_of_image_univ (p := 7) (by decide) (by decide) ha
+    · -- miss 3 mod 5 ⇒ ⊆ {1,7,9,15,19,21,25} (card 7)
+      have hs5 : a ⊆ ({1, 7, 9, 15, 19, 21, 25} : Finset ℕ) := by
+        intro x hx
+        have hxP := hs hx
+        have hxne : (x : ZMod 5) ≠ 3 := hr5 x hx
+        fin_cases hxP <;> first | decide | exact absurd (by decide) hxne
+      have hle := Finset.card_le_card hs5; rw [hcard] at hle; revert hle; decide
+    · -- miss 4 mod 5 ⇒ ⊆ {1,3,7,13,15,21,25} (card 7)
+      have hs5 : a ⊆ ({1, 3, 7, 13, 15, 21, 25} : Finset ℕ) := by
+        intro x hx
+        have hxP := hs hx
+        have hxne : (x : ZMod 5) ≠ 4 := hr5 x hx
+        fin_cases hxP <;> first | decide | exact absurd (by decide) hxne
+      have hle := Finset.card_le_card hs5; rw [hcard] at hle; revert hle; decide
+
+/-- **Lower-bound core.** Every admissible `8`-set has largest element at least `26`.
+If the maximum were `≤ 25`, the set would sit in `{0,…,25}`; missing a class mod `2`
+forces a single parity, placing the 8-set inside the thirteen evens `{0,2,…,24}` or
+thirteen odds `{1,3,…,25}`, where the combined mod-3, mod-5 and mod-7 constraints then
+rule it out. -/
+theorem admissible_eight_sup_ge {a : Finset ℕ} (hcard : a.card = 8)
+    (ha : Admissible a) : 26 ≤ a.sup id := by
+  by_contra hlt
+  push_neg at hlt
+  have hbound : ∀ x ∈ a, x ≤ 25 := by
+    intro x hx
+    have h1 : id x ≤ a.sup id := Finset.le_sup hx
+    simp only [id_eq] at h1
+    omega
+  have hy : ∀ y : ZMod 2, y = 0 ∨ y = 1 := by decide
+  have hdvd : ∀ x : ℕ, (x : ZMod 2) = 0 ↔ 2 ∣ x := fun x =>
+    ZMod.natCast_eq_zero_iff x 2
+  obtain ⟨r2, hr2⟩ := ha 2 (by decide)
+  fin_cases r2
+  · -- misses class 0 mod 2 ⇒ all elements odd ⇒ a ⊆ {1,3,…,25}
+    have hsub : a ⊆ ({1, 3, 5, 7, 9, 11, 13, 15, 17, 19, 21, 23, 25} : Finset ℕ) := by
+      intro x hx
+      have hx25 := hbound x hx
+      have hne : (x : ZMod 2) ≠ 0 := hr2 x hx
+      have hodd : ¬ 2 ∣ x := fun hd => hne ((hdvd x).mpr hd)
+      simp only [Finset.mem_insert, Finset.mem_singleton]
+      omega
+    exact no_admissible_eight_odds hsub hcard ha
+  · -- misses class 1 mod 2 ⇒ all elements even ⇒ a ⊆ {0,2,…,24}
+    have hsub : a ⊆ ({0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24} : Finset ℕ) := by
+      intro x hx
+      have hx25 := hbound x hx
+      have hne : (x : ZMod 2) ≠ 1 := hr2 x hx
+      have heven : 2 ∣ x := by
+        rcases hy (x : ZMod 2) with h0 | h1
+        · exact (hdvd x).mp h0
+        · exact absurd h1 hne
+      simp only [Finset.mem_insert, Finset.mem_singleton]
+      omega
+    exact no_admissible_eight_evens hsub hcard ha
+
+/-- **`A(8) = 26`.** The minimal largest element of an admissible `8`-set is `26`,
+attained by `{0,2,6,8,12,18,20,26}`. This matches the Hardy–Littlewood minimal
+diameter `H(8) = 26` and continues the frontier
+`A(2)=2, A(3)=6, A(4)=8, A(5)=12, A(6)=16, A(7)=20, A(8)=26`. Its lower bound is the
+first in the sequence to genuinely require the prime `7`: two forced 8-sets per parity
+survive `p = 5` and are killed only at `p = 7`. -/
+theorem A_eight : A 8 = 26 := by
+  refine le_antisymm A_eight_le ?_
+  obtain ⟨a, hcard, ha, hsup⟩ := A_mem 8
+  have hge := admissible_eight_sup_ge hcard ha
   omega
 
-/-- **`21 ≤ A(8) ≤ 26`.** The current sandwich for the next frontier value. The upper
-bound is the Hardy–Littlewood witness `{0,2,6,8,12,18,20,26}`; the lower bound is
-one-step strict monotonicity from `A(7) = 20`. Closing the gap to the exact
-`A(8) = 26` needs the mod-`2,3,5,7` lower-bound case analysis (where `p = 7` first
-becomes binding), left as future work. -/
-theorem A_eight_bounds : 21 ≤ A 8 ∧ A 8 ≤ 26 :=
+/-- **`A(8) ≥ 26`.** Restatement of the lower bound now that the exact value is
+known, superseding the earlier one-step-monotonicity bound `A(8) ≥ 21`. -/
+theorem A_eight_ge : 26 ≤ A 8 := by rw [A_eight]
+
+/-- **`A(8) = 26`, as the sharp two-sided sandwich.** Both bounds are now exact. -/
+theorem A_eight_bounds : 26 ≤ A 8 ∧ A 8 ≤ 26 :=
   ⟨A_eight_ge, A_eight_le⟩
 
 end Erdos1204

--- a/research/problems/erdos-1204/state.md
+++ b/research/problems/erdos-1204/state.md
@@ -1,24 +1,35 @@
 # Current State
 
-**Phase**: ACTIVE
+**Phase**: ACT
 **Since**: 2026-06-25
-**Iteration**: 6
+**Iteration**: 7
 
 ## Current Focus
 
 Extending the exact-value frontier A(k) = min largest element of an admissible k-tuple
 (= Hardy–Littlewood minimal diameter H(k)). Values now A(2)=2, A(3)=6, A(4)=8, A(5)=12,
-A(6)=16, A(7)=20, each in an axiom-free companion file.
+A(6)=16, A(7)=20, **A(8)=26** (this iteration), each in an axiom-free companion file.
 
 ## Active Approach
 
-Finite case analysis combining small primes. A(7)=20 (this session, iteration 6) was
-expected to need primes 2,3,5,7 but in fact closes with only 2,3,5: within each
-10-element single-parity window {0,2,…,18} / {1,3,…,19} the mod-3 classes have sizes
-4,3,3, so missing the size-4 class leaves 6 slots (< 7, contradiction) and missing
-either size-3 class leaves a *forced* 7-set. There are TWO forced 7-sets per parity
-(vs one at A(6)), but all four are mod-5-complete, so p=5 alone kills them — the prime
-7 is not yet binding.
+Finite case analysis combining small primes. Iteration 7 (2026-07-11) closed
+**A(8) = 26 EXACT** (`Erdos1204A8.lean`, `A_eight`), upgrading the previous file which
+had only the upper bound `A(8) ≤ 26` and a weak `A(8) ≥ 21` (one-step monotonicity),
+explicitly left as future work.
+
+This is the first frontier value where the prime **7 becomes binding**. The lower bound
+(max ≤ 25 ⇒ 8-set in a 13-element single-parity window {0,2,…,24} / {1,3,…,25}): the
+mod-3 classes now have sizes **5,4,4** (vs 4,3,3 at A(7)).
+- Missing the size-5 class leaves exactly 8 slots = one *forced* 8-set, which is
+  mod-5-complete ⇒ killed at p=5.
+- Missing a size-4 class leaves a 9-element pool. Four of its five mod-5 classes have
+  two elements and one is a singleton; an admissible 8-subset must miss a mod-5 class,
+  but a two-element class can't be dropped by removing a single element, so the missed
+  class is the singleton — pinning the 8-subset to a *forced* set that is mod-7-complete
+  ⇒ killed at p=7. (Even branches mod3≡1,2 and odd branches mod3≡0,2 each give one.)
+
+Helper `not_admissible_of_covers` (a set hitting every class mod p is not admissible,
+`decide`-checked at concrete p) cleanly kills all forced sets.
 
 ## Blockers
 
@@ -26,25 +37,23 @@ The headline asymptotics A(k) ∼ k log k and the B(k) estimate remain OPEN — 
 analytic sieve theory (summing p/(p−1) factors / CRT counting) not yet formalized. The
 per-value frontier keeps advancing but the case analysis grows with each new prime.
 
-Infra note (2026-07-08): the shared docker Mathlib-cache volume developed a
-filesystem-level SIGBUS (exit 135) corruption that fails EVERY `import Mathlib` build at
-the Erdos1204Problem dependency in ~1s; `--repair-cache` (`cache get!`) reported success
-but did NOT fix it, and a full `--nuke` volume reset needs a zero-container window. A(7)
-was verified via the host-lake bypass (`lake exe cache get` + `lake env lean`,
-outside docker) instead.
+Infra note (2026-07-11): the shared docker Mathlib-cache volume STILL has the SIGBUS
+(exit 135) corruption — this session it failed at `Mathlib.Algebra.CharP.Frobenius`
+(`unexpected end of input` on the `.trace` file) during cache download/decompress. A(8)
+was verified via the **host-lake bypass**: symlink existing `Proofs/*.olean` into a tmp
+LEAN_PATH root, then `~/.elan/.../v4.26.0/bin/lean Proofs/Erdos1204A7.lean -o …` then
+`…A8.lean` (host Mathlib oleans are intact). `#print axioms A_eight` = only
+propext/Classical.choice/Quot.sound (axiom-free; `decide`, not `native_decide`).
 
 ## Next Action
 
-A(8)=26 (H(8) jumps by 6, not 4): the witness is a diameter-26 admissible 8-tuple, e.g.
-verify {0,2,6,8,12,18,20,26}. The lower bound (max ≤ 25, 8-set) enlarges the parity
-windows to 13 evens {0,2,…,24} / 13 odds {1,3,…,25}; missing a mod-3 class leaves up to
-~9 elements, so the forced-set argument branches further and the prime 7 (and possibly
-mod-5 interplay) should finally become binding. Expect the case analysis to grow — a
-generic "single-parity window minus one mod-p class" helper lemma may be worth factoring
-out before A(8)/A(9).
+A(9)=30 (H(9)=30, back to +4). Lower bound: 15-element parity windows {0,2,…,28} /
+{1,3,…,29}; mod-3 class sizes 5,5,5. Expect p=7 firmly binding and the case analysis to
+grow again — worth factoring a generic "single-parity window minus one mod-p class"
+helper (pool → forced set → killed by next prime) before A(9)/A(10) to tame growth.
 
 ## Attempt Counts
 
-- Total attempts: 6
-- Current approach attempts: 1
+- Total attempts: 7
+- Current approach attempts: 2
 - Approaches tried: 2


### PR DESCRIPTION
## Summary

Closes the gap left in `Erdos1204A8.lean`, which previously held only the **upper
bound** `A(8) ≤ 26` (the Hardy–Littlewood witness) plus a weak `A(8) ≥ 21` (one-step
monotonicity), with the exact lower bound explicitly deferred as *future work*.

This PR proves the **exact value** `A_eight : A 8 = 26`, axiom-free, extending the
frontier `A(2)=2, A(3)=6, A(4)=8, A(5)=12, A(6)=16, A(7)=20, A(8)=26`.

Here `A(k)` = the minimal largest element of an *admissible* `k`-set (one missing a
residue class mod every prime) = the Hardy–Littlewood minimal diameter `H(k)`.

## The mathematical milestone: prime 7 first becomes binding

At `A(7)=20` the prime 7 was **not** binding — everything closed with `{2,3,5}`.
`A(8)=26` is the first frontier value that genuinely needs `p=7`. The `+6` jump
(`20 → 26`, vs `+4` at every earlier step) is exactly the `H(k)` signature of needing
a second prime beyond `{2,3,5}`.

Lower bound (any admissible 8-set with max `≤ 25` lives in a 13-element single-parity
window `{0,2,…,24}` / `{1,3,…,25}`, whose mod-3 classes now have sizes **5,4,4**):
- Missing the **size-5** mod-3 class ⇒ an *exactly-8* forced set that is mod-5-complete ⇒ dies at `p=5`.
- Missing a **size-4** mod-3 class ⇒ a 9-element pool; four of its five mod-5 classes
  have two elements and one is a singleton, so admissibility at `p=5` forces dropping
  that singleton — pinning a forced 8-set that is mod-7-complete ⇒ dies at `p=7`.
  (Even branches `mod 3 ≡ 1,2` and odd branches `mod 3 ≡ 0,2` each produce one.)

## Contents (`proofs/Proofs/Erdos1204A8.lean`)

- `not_admissible_of_covers` — helper: a set hitting every class mod `p` is not admissible.
- `no_admissible_eight_evens` / `no_admissible_eight_odds` — no admissible 8-subset of the 13-element parity windows.
- `admissible_eight_sup_ge` — every admissible 8-set has largest element `≥ 26`.
- `A_eight : A 8 = 26` (plus refreshed `A_eight_ge`, `A_eight_bounds`).

## Verification

`#print axioms A_eight` → `[propext, Classical.choice, Quot.sound]` — **axiom-free**
(`decide`, not `native_decide`, so no `Lean.ofReduceBool`).

Verified via the host-lake bypass: the shared docker Mathlib cache is still hitting the
SIGBUS/exit-135 corruption (this time at `Mathlib.Algebra.CharP.Frobenius`), so A7→A8
were compiled with host `lean v4.26.0` over the intact host Mathlib oleans.

The asymptotics `A(k) ∼ k log k` and the `B(k)` estimate remain OPEN (need sieve theory).

🤖 Generated with [Claude Code](https://claude.com/claude-code)