### PR TITLE
research(erdos-1098-oq-01-oq-03): non-commuting graph foundations + finite base case (0-axiom)

### DIFF
--- a/proofs/Proofs/Erdos1098OQ01OQ03.lean
+++ b/proofs/Proofs/Erdos1098OQ01OQ03.lean
@@ -112,6 +112,24 @@ def IsClique (S : Finset G) : Prop :=
 def BoundedCliques (G : Type*) [Group G] : Prop :=
   ∃ B : ℕ, ∀ S : Finset G, IsClique S → S.card ≤ B
 
+/-- **The non-commuting graph Γ(G) is undirected: `nonCommuting` is symmetric.**
+    `g` and `h` fail to commute iff `h` and `g` do — the edge relation `g*h ≠ h*g`
+    is symmetric by `ne_comm`. -/
+theorem nonCommuting_comm {g h : G} : nonCommuting g h ↔ nonCommuting h g := by
+  unfold nonCommuting; exact ne_comm
+
+/-- **Γ(G) has no self-loops: `nonCommuting` is irreflexive.**  No element fails to
+    commute with itself, since `g * g = g * g`. -/
+theorem nonCommuting_irrefl (g : G) : ¬ nonCommuting g g := by
+  unfold nonCommuting; simp
+
+/-- **Edges of Γ(G) are exactly the non-commuting pairs.**  The negation of
+    `nonCommuting g h` is Mathlib's `Commute g h`: two elements are joined by no edge
+    iff they commute.  This bridges the local `nonCommuting` relation to the library's
+    `Commute`/`SemiconjBy` API. -/
+theorem not_nonCommuting_iff_commute {g h : G} : ¬ nonCommuting g h ↔ Commute g h := by
+  unfold nonCommuting; rw [not_not]; exact Iff.rfl
+
 -- ============================================================
 -- SECTION II: Cosets of the centre separate non-commuting elements
 -- ============================================================
@@ -173,6 +191,16 @@ theorem clique_card_le_index {S : Finset G} (hS : IsClique S)
 theorem bounded_cliques_of_finite_index
     (hfin : (Subgroup.center G).index ≠ 0) : BoundedCliques G :=
   ⟨(Subgroup.center G).index, fun _ hS => clique_card_le_index hS hfin⟩
+
+/-- **(Base case, fully proved.)** Every *finite* group has bounded cliques: no clique
+    can be larger than the whole group.  Any clique `S` is a `Finset G`, so
+    `S.card ≤ Fintype.card G` unconditionally (`Finset.card_le_univ`).  This is the
+    trivial-but-fundamental base of the theory — finite groups automatically satisfy the
+    ω(Γ(G))-finite hypothesis of Neumann's theorem (and indeed their centre has finite
+    index), so the interesting content is entirely about infinite groups. -/
+theorem boundedCliques_of_finite [Finite G] : BoundedCliques G := by
+  haveI : Fintype G := Fintype.ofFinite G
+  exact ⟨Fintype.card G, fun S _ => Finset.card_le_univ S⟩
 
 -- ============================================================
 -- SECTION III.5: First step of the hard direction — the centralizer cover

--- a/src/data/proofs/erdos-1098-oq-01-oq-03/meta.json
+++ b/src/data/proofs/erdos-1098-oq-01-oq-03/meta.json
@@ -37,8 +37,8 @@
       "center_finiteIndex_iff_relIndex_core: ω(Γ(G)) finite ⟹ [G:Z(G)] finite iff Z(G) has finite index within the explicit finite-index core H = ⋂ₐ C_G(a); localizes the residual axiom to (center G).relIndex H, whose Mathlib endgame is Subgroup.index_center_le_pow gated on Finite (commutatorSet G)",
       "boundedCliques_quotient: bounded cliques pass to quotients — ω(Γ(G/N)) ≤ ω(Γ(G)) for every normal N, since QuotientGroup.mk' N is surjective (the mk'-instance of boundedCliques_of_surjective); with boundedCliques_of_subgroup this makes both subgroups AND quotients of a bounded-clique group bounded-clique. Axiom-free."
     ],
-    "lineCount": 698,
-    "theoremCount": 16,
+    "lineCount": 726,
+    "theoremCount": 20,
     "defCount": 3,
     "definitionCount": 3
   },
@@ -140,12 +140,12 @@
     }
   ],
   "leanFile": {
-    "lineCount": 686,
+    "lineCount": 726,
     "path": "Proofs/Erdos1098OQ01OQ03.lean",
     "axiomCount": 1,
     "sorries": 0,
     "definitionCount": 3,
-    "theoremCount": 19
+    "theoremCount": 23
   },
   "sorries": 0
 }


### PR DESCRIPTION
## Summary

Extends the B. H. Neumann bounded-cliques / finite-index-center (BFC) formalization (`Proofs/Erdos1098OQ01OQ03.lean`, gallery `erdos-1098-oq-01-oq-03`) with four new axiom-free theorems: the foundational properties of the non-commuting graph Γ(G) and the fundamental finite base case. None depend on the file's single cited axiom `neumann_hard_direction`.

### New theorems (all axiom-free)

- **`nonCommuting_comm`** — Γ(G) is undirected: `nonCommuting g h ↔ nonCommuting h g` (via `ne_comm`).
- **`nonCommuting_irrefl`** — Γ(G) has no self-loops: `¬ nonCommuting g g`.
- **`not_nonCommuting_iff_commute`** — the non-edges are exactly the commuting pairs: `¬ nonCommuting g h ↔ Commute g h`, bridging the local relation to Mathlib's `Commute`/`SemiconjBy` API.
- **`boundedCliques_of_finite`** — `[Finite G] → BoundedCliques G`: every finite group has bounded cliques, since any clique `S : Finset G` satisfies `S.card ≤ Fintype.card G` (`Finset.card_le_univ`). The trivial-but-fundamental base case — the interesting content of Neumann's theorem is entirely about infinite groups.

### Verification

- Type-checks clean under host `lean` v4.26.0 against prebuilt Mathlib (RC=0, no errors/sorries).
- `#print axioms`: `nonCommuting_comm` depends on **no** axioms; the other three on the foundational trio only (`[propext, Classical.choice, Quot.sound]`) — crucially **not** on `neumann_hard_direction`.
- File axiom count unchanged: still the single cited axiom `neumann_hard_direction` (Neumann 1976). Status stays `axiomatized`/`axiom`. Meta theorem/line counts bumped +4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)