### PR TITLE
research(descartes-rule-of-signs-oq-01-oq-03): general quadratic sign-change count (§12)

### DIFF
--- a/proofs/Proofs/DescartesRuleOfSignsOQ01OQ03.lean
+++ b/proofs/Proofs/DescartesRuleOfSignsOQ01OQ03.lean
@@ -1395,4 +1395,86 @@ theorem signChangesInCoeffs_X_pow (k : ℕ) :
   rw [X_pow_eq_monomial]
   exact signChangesInCoeffs_monomial 1 k
 
+/-! ## § 12. The general quadratic sign-change count
+
+The `§ 4` quadratic results (`x2_minus_1_signChanges`, `x2_plus_1_signChanges`,
+`x2_minus_x_plus_1_signChanges`) computed `signChangesInCoeffs` for three *hardcoded*
+polynomials.  This section generalises them to the full three-parameter family
+`a·X² + b·X + c` with `a ≠ 0`, closing the standing next-step "full `Fin 3` sign-change
+count for quadratics with nonzero middle term".
+
+The key is a single coefficient-sequence identity: for a genuine quadratic the
+highest-degree-first coefficient vector `coeffSequence p 2` is exactly `![a, b, c]`
+(`coeffSequence_quadratic`).  Feeding that through the `§ 2¾` `Fin 3` engine gives a
+closed form for the coefficient sign-change count in terms of the sign pattern of the
+coefficients `(a, b, c)` — for a nonzero middle `b` this is the complete case split
+(two changes when strictly alternating, one when exactly one adjacent pair alternates,
+zero when neither does).  The three hardcoded `§ 4` examples are special cases (their
+middle coefficient is `0`, handled by the middle-zero lemmas instead). -/
+
+section QuadraticFamily
+
+/-- **Coefficient vector of a genuine quadratic.**  For `a ≠ 0` the highest-degree-first
+coefficient sequence of `a·X² + b·X + c` is `![a, b, c]`.  Combines
+`natDegree_quadratic` with the term-by-term coefficient computation. -/
+theorem coeffSequence_quadratic {a b c : ℝ} (ha : a ≠ 0) :
+    DescartesRuleOfSigns.coeffSequence (C a * X ^ 2 + C b * X + C c) 2 = ![a, b, c] := by
+  funext i
+  fin_cases i <;>
+    simp [DescartesRuleOfSigns.coeffSequence, coeff_add, coeff_C_mul_X_pow,
+      coeff_C_mul_X, coeff_C]
+
+/-- **Sign-change count of a general quadratic.**  For `a ≠ 0`, the coefficient
+sign-change count of `a·X² + b·X + c` is the length-3 sequence sign-change count of
+`![a, b, c]`.  This reduces the whole three-parameter family to the `Fin 3` engine of
+`§ 2¾`, generalising the hardcoded `§ 4` examples. -/
+theorem signChangesInCoeffs_quadratic {a b c : ℝ} (ha : a ≠ 0) :
+    signChangesInCoeffs (C a * X ^ 2 + C b * X + C c)
+      = DescartesRuleOfSigns.countSignChanges ![a, b, c] := by
+  have hdeg : (C a * X ^ 2 + C b * X + C c : ℝ[X]).natDegree = 2 := natDegree_quadratic ha
+  have hne : (C a * X ^ 2 + C b * X + C c : ℝ[X]) ≠ 0 := by
+    intro h; rw [h, natDegree_zero] at hdeg; exact absurd hdeg (by norm_num)
+  unfold signChangesInCoeffs
+  rw [dif_neg hne, hdeg, coeffSequence_quadratic ha]
+
+/-- **Two sign changes — the strictly alternating quadratic.**  If `a·b < 0` and
+`b·c < 0` (sign pattern `+ − +` or `− + −`) then `a·X² + b·X + c` has two coefficient
+sign changes, the maximum for a quadratic (Descartes' bound is *attained*: up to two
+positive roots).  Generalises `x2_minus_x_plus_1_signChanges`. -/
+theorem signChangesInCoeffs_quadratic_alternating {a b c : ℝ} (ha : a ≠ 0)
+    (h01 : a * b < 0) (h12 : b * c < 0) :
+    signChangesInCoeffs (C a * X ^ 2 + C b * X + C c) = 2 := by
+  rw [signChangesInCoeffs_quadratic ha]
+  exact countSignChanges_three_alternating (by simpa using h01) (by simpa using h12)
+
+/-- **One sign change — left pair alternates.**  If `a·b < 0` but `0 ≤ b·c`, then
+`a·X² + b·X + c` has exactly one coefficient sign change (across the `a,b` pair). -/
+theorem signChangesInCoeffs_quadratic_one_left {a b c : ℝ} (ha : a ≠ 0)
+    (h01 : a * b < 0) (h12 : 0 ≤ b * c) :
+    signChangesInCoeffs (C a * X ^ 2 + C b * X + C c) = 1 := by
+  rw [signChangesInCoeffs_quadratic ha]
+  exact countSignChanges_three_mid_ne_left (by simpa using h01) (by simpa using h12)
+
+/-- **One sign change — right pair alternates.**  If `0 ≤ a·b` but `b·c < 0`, then
+`a·X² + b·X + c` has exactly one coefficient sign change (across the `b,c` pair). -/
+theorem signChangesInCoeffs_quadratic_one_right {a b c : ℝ} (ha : a ≠ 0)
+    (h01 : 0 ≤ a * b) (h12 : b * c < 0) :
+    signChangesInCoeffs (C a * X ^ 2 + C b * X + C c) = 1 := by
+  rw [signChangesInCoeffs_quadratic ha]
+  exact countSignChanges_three_mid_ne_right (by simpa using h01) (by simpa using h12)
+
+/-- **No sign change — nonzero middle, neither pair alternates.**  If `b ≠ 0`,
+`0 ≤ a·b` and `0 ≤ b·c` (sign pattern `+ + +` or `− − −`) then `a·X² + b·X + c` has no
+coefficient sign change, hence (Descartes) no positive roots.  Together with the three
+preceding corollaries this is the complete sign-change classification for a quadratic
+with nonzero middle coefficient. -/
+theorem signChangesInCoeffs_quadratic_no_change {a b c : ℝ} (ha : a ≠ 0)
+    (hb : b ≠ 0) (h01 : 0 ≤ a * b) (h12 : 0 ≤ b * c) :
+    signChangesInCoeffs (C a * X ^ 2 + C b * X + C c) = 0 := by
+  rw [signChangesInCoeffs_quadratic ha]
+  exact countSignChanges_three_mid_ne_zero (by simpa using hb)
+    (by simpa using h01) (by simpa using h12)
+
+end QuadraticFamily
+
 end DescartesRuleOfSignsOQ01OQ03

--- a/research/problems/descartes-rule-of-signs-oq-01-oq-03/knowledge.md
+++ b/research/problems/descartes-rule-of-signs-oq-01-oq-03/knowledge.md
@@ -70,3 +70,33 @@ is a sharp complementarity.
 ### Terminus (unchanged)
 Transformation family now complete. Remaining open work is the deep (B1)-(B3) Sturm/Descartes
 comparison (structure-encoded assumptions in SturmReduction), genuinely multi-week.
+
+## Session (researcher-1, 2026-07-11): general quadratic sign-change count (§12)
+
+**Mode**: REVISIT (RICH, already SOLVED 0/0) · **Outcome**: progress (6 theorems VERIFIED
+0-sorry/0-axiom), branch research/descartes-oq0103-quadratic-family, PR #38202.
+
+**Contribution.** Closed the standing next-step "full Fin 3 sign-change count for
+quadratics aX²+bX+c with nonzero middle term". §4 only handled three HARDCODED
+polynomials; §12 generalises to the whole 3-parameter family:
+- `coeffSequence_quadratic (ha:a≠0)`: coeffSequence (C a*X^2+C b*X+C c) 2 = ![a,b,c].
+  Proof: `funext i; fin_cases i <;> simp [coeffSequence, coeff_add, coeff_C_mul_X_pow,
+  coeff_C_mul_X, coeff_C]`.
+- `signChangesInCoeffs_quadratic (ha)`: = countSignChanges ![a,b,c]. Uses Mathlib
+  `natDegree_quadratic ha` (poly form C a*X^2+C b*X+C c is EXACTLY Mathlib's
+  Degree/SmallDegree form) + dif_neg + coeffSequence_quadratic.
+- Four sign-pattern corollaries reusing the §2¾ Fin 3 lemmas via `by simpa using h`
+  (simp rewrites ![a,b,c] 0/1/2 to a/b/c): alternating→2, one_left→1, one_right→1,
+  no_change→0 (needs b≠0). Complete classification for nonzero middle.
+
+The nextStep "replace example_x2_*_sign_changes axioms in base file" is STALE/DONE — the
+base DescartesRuleOfSigns.lean already has them as theorems (line 312/332, "Formerly an
+axiom; now discharged"). Base file's remaining 5 axioms are the DEEP Descartes facts
+(upper_bound/parity/negative_roots/alternating_max/derivative_reduces) — not routine.
+
+**Build**: docker-build GREEN first try (3064 jobs). 51→57 theorems.
+
+**Reusable technique**: to lift a hardcoded coefficient computation to a parametric
+polynomial family, prove the `coeffSequence p natDegree = ![...]` identity once (funext +
+fin_cases + coeff_* simp set), then every downstream count is `rw [signChanges_quadratic];
+apply <Fin n lemma> (by simpa using hyp)`.


### PR DESCRIPTION
## Summary

`descartes-rule-of-signs-oq-01-oq-03` (SOLVED, 0/0) already computed `signChangesInCoeffs` for three **hardcoded** quadratics in §4 (`x2_minus_1_signChanges`, `x2_plus_1_signChanges`, `x2_minus_x_plus_1_signChanges`). This PR closes the standing next-step — *"full `Fin 3` sign-change count for quadratics `aX²+bX+c` with nonzero middle term"* — by generalising them to the full three-parameter family. New §12 `QuadraticFamily` section, all axiom-free:

- **`coeffSequence_quadratic`** (`a ≠ 0`) — the highest-degree-first coefficient vector of `a·X² + b·X + c` is exactly `![a, b, c]` (`natDegree_quadratic` + term-by-term coefficient computation).
- **`signChangesInCoeffs_quadratic`** (`a ≠ 0`) — reduces the whole family to the `Fin 3` engine: `signChangesInCoeffs (a·X²+b·X+c) = countSignChanges ![a,b,c]`.
- Four sign-pattern corollaries giving the **complete classification** for a nonzero middle coefficient:
  - `..._alternating` (`a·b<0 ∧ b·c<0`) → **2** (Descartes bound attained),
  - `..._one_left` (`a·b<0 ∧ 0≤b·c`) → **1**,
  - `..._one_right` (`0≤a·b ∧ b·c<0`) → **1**,
  - `..._no_change` (`b≠0 ∧ 0≤a·b ∧ 0≤b·c`) → **0**.

The three §4 examples are the `b = 0` special cases (handled by the middle-zero lemmas), so this genuinely extends coverage rather than restating it.

## Verification

- `./proofs/scripts/docker-build.sh Proofs.DescartesRuleOfSignsOQ01OQ03` → **Build completed successfully (3064 jobs)**.
- 0 sorries, 0 axiom declarations added (corollaries reuse the existing §2¾ `Fin 3` lemmas and Mathlib `natDegree_quadratic` / `coeff_*`).
- File: 51 → 57 theorems.

🤖 Generated with [Claude Code](https://claude.com/claude-code)