### PR TITLE
research(lagrange-four-squares-oq-01-oq-03): sharp naive-formula boundary for Jacobi's count

### DIFF
--- a/proofs/Proofs/LagrangeFourSquaresOQ01OQ03.lean
+++ b/proofs/Proofs/LagrangeFourSquaresOQ01OQ03.lean
@@ -328,6 +328,53 @@ theorem jacobiCount_eq_zero_iff (n : ℕ) : jacobiCount n = 0 ↔ n = 0 := by
   · rintro rfl
     exact jacobiCount_zero
 
+/-- **Jacobi's count never exceeds `8·σ` (0-axiom, general).** The `4 ∤ d` filter only
+removes divisors, so the filtered divisor-sum is bounded by the full one:
+`jacobiCount n ≤ 8·σ(n)` for every `n`.  Equality holds precisely in the "no `2²` in `n`"
+regime (`jacobiCount_of_not_four_dvd`); the gap opens exactly when `4 ∣ n`
+(`jacobiCount_lt_of_four_dvd`).  This is the uniform upper envelope that the convention
+guard `naive_sigma_fails` witnesses being strict at `n = 4`. -/
+theorem jacobiCount_le (n : ℕ) : jacobiCount n ≤ 8 * ∑ d ∈ n.divisors, d := by
+  unfold jacobiCount
+  refine Nat.mul_le_mul (le_refl 8) ?_
+  exact Finset.sum_le_sum_of_subset_of_nonneg
+    (Finset.filter_subset (fun d => ¬ 4 ∣ d) n.divisors) (fun i _ _ => Nat.zero_le i)
+
+/-- **The bound is strict exactly when `4 ∣ n` (0-axiom, general).** For `4 ∣ n` (`n ≠ 0`)
+the count falls strictly below the naive `8·σ(n)`: by the even-side recursion
+`jacobiCount_four_dvd`, the excluded `4 ∣ d` divisors contribute `32·σ(n/4) > 0`
+(the divisor `1` of `n/4` alone forces `σ(n/4) ≥ 1`).  So `jacobiCount n < 8·σ(n)`,
+quantifying the deficit as exactly `32·σ(n/4)` — e.g. `n = 4`: `24 < 56` with deficit
+`32 = 32·σ(1)`, the `naive_sigma_fails` witness. -/
+theorem jacobiCount_lt_of_four_dvd {n : ℕ} (h4 : 4 ∣ n) (hn : n ≠ 0) :
+    jacobiCount n < 8 * ∑ d ∈ n.divisors, d := by
+  have H := jacobiCount_four_dvd h4 hn
+  have hn4 : n / 4 ≠ 0 := by
+    rw [Ne, Nat.div_eq_zero_iff]; push_neg
+    exact ⟨by norm_num, Nat.le_of_dvd (Nat.pos_of_ne_zero hn) h4⟩
+  have hpos : 1 ≤ ∑ e ∈ (n / 4).divisors, e :=
+    Finset.single_le_sum (f := fun d => d) (fun i _ => Nat.zero_le i)
+      (by rw [Nat.mem_divisors]; exact ⟨one_dvd _, hn4⟩)
+  omega
+
+/-- **Exact characterization of the naive-formula regime (0-axiom, general).** For every
+positive `n`, Jacobi's count equals the naive `8·σ(n)` *iff* `4 ∤ n`:
+
+    jacobiCount n = 8·σ(n)  ↔  ¬ 4 ∣ n     (n ≠ 0).
+
+The forward direction is `jacobiCount_lt_of_four_dvd` (a `4 ∣ n` would force a strict
+drop), the reverse is `jacobiCount_of_not_four_dvd`.  This is the sharp boundary the
+whole file organizes around: `jacobiCount_odd` and `jacobiCount_two_mul_odd_eq` live on
+the `¬4∣n` side (count `= 8·σ` of the odd part), while `jacobiCount_four_dvd` governs the
+complementary `4 ∣ n` side where the naive formula genuinely fails
+(`naive_sigma_fails`). -/
+theorem jacobiCount_eq_eight_sigma_iff {n : ℕ} (hn : n ≠ 0) :
+    jacobiCount n = 8 * ∑ d ∈ n.divisors, d ↔ ¬ 4 ∣ n := by
+  constructor
+  · intro heq h4
+    exact absurd heq (jacobiCount_lt_of_four_dvd h4 hn).ne
+  · exact jacobiCount_of_not_four_dvd
+
 /-- **Convention guard (0-axiom).** The naive formula `8·σ(n)` is WRONG for `n = 4`:
 `8·σ(4) = 8·(1+2+4) = 56`, whereas the true count is `r4 4 = 24`. Equivalently the
 `4 ∤ d` exclusion drops the divisor `d = 4`. This is exactly why the general formula

--- a/src/data/proofs/lagrange-four-squares-oq-01-oq-03/meta.json
+++ b/src/data/proofs/lagrange-four-squares-oq-01-oq-03/meta.json
@@ -35,8 +35,8 @@
       }
     ],
     "assumptions": "The general Jacobi four-square theorem is NOT proved — it is a genuine Mathlib gap requiring either Hurwitz-quaternion order arithmetic or weight-2 modular forms (θ⁴∈M₂(Γ₀(4))), each ≫1000 LOC of absent number theory. This entry proves (a) a 0-axiom general lemma jacobiCount_odd (for odd n the 4∤d filter is vacuous, so jacobiCount n = 8·σ(n)), and (b) a machine-checked oracle jacobi_oracle : ∀ n∈[1,24], r₄ n = jacobiCount n, discharged by native_decide. native_decide trusts the Lean compiler and depends on the Lean.ofReduceBool axiom (#print axioms lists it, together with Lean.trustCompiler); naive_sigma_fails and r4_anchor_values also use native_decide. The entry is therefore axiomatized, not axiom-free. The literal `axiom` declaration count in the Lean file is 0; the single counted assumption is Lean.ofReduceBool introduced via native_decide.",
-    "lineCount": 355,
-    "theoremCount": 20,
+    "lineCount": 402,
+    "theoremCount": 23,
     "definitionCount": 3,
     "originalContributions": [
       "r4: the ordered, signed four-square representation count r₄(n), defined as a computable Finset.card over the integer box [-√n,√n]⁴ — an object Mathlib lacks entirely",
@@ -48,7 +48,8 @@
       "jacobiCount_two_pow: 0-axiom general closed form — for every k≥1, jacobiCount(2^k)=24 (the 4∤d filter keeps only divisors 1 and 2), the elementary even-side companion to jacobiCount_odd, revealing r₄ is constant on powers of two",
       "jacobiCount_two_pow_const: 0-axiom corollary — Jacobi's count is independent of the exponent, jacobiCount(2^j)=jacobiCount(2^k) for all j,k≥1",
       "jacobiCount_odd_prime_pow: 0-axiom general prime-power case — for an odd prime p every power p^k is odd so the 4∤d filter is vacuous, giving jacobiCount(p^k)=8·Σ_{i=0}^{k}p^i; the missing prime-power value between jacobiCount_prime (k=1) and jacobiCount_two_pow (p=2), and (with multiplicativity of r₄/8) the data that determines jacobiCount on every n from its factorization",
-      "jacobiCount_odd_prime_pow_geom: 0-axiom geometric closed form jacobiCount(p^k)=8·(p^{k+1}−1)/(p−1) for odd prime p, recovering jacobiCount_prime's 8·(p+1) at k=1; jacobiCount_nine anchors r₄(9)=104=8·σ(9) inside the oracle range"
+      "jacobiCount_odd_prime_pow_geom: 0-axiom geometric closed form jacobiCount(p^k)=8·(p^{k+1}−1)/(p−1) for odd prime p, recovering jacobiCount_prime's 8·(p+1) at k=1; jacobiCount_nine anchors r₄(9)=104=8·σ(9) inside the oracle range",
+      "jacobiCount_le / jacobiCount_lt_of_four_dvd / jacobiCount_eq_eight_sigma_iff (0-axiom, general): the sharp naive-formula boundary — jacobiCount n <= 8*sigma(n) always, with strict inequality exactly when 4|n (deficit 32*sigma(n/4)), so jacobiCount n = 8*sigma(n) iff not 4|n (for n != 0); pins when Jacobi's count collapses to the naive 8*sigma and formalizes why naive_sigma_fails at n=4"
     ]
   },
   "overview": {


### PR DESCRIPTION
## Summary

Extends the Jacobi four-square count file (`LagrangeFourSquaresOQ01OQ03.lean`) with three fully machine-checked, **0-axiom general** theorems that pin *exactly* when Jacobi's count `jacobiCount n = 8·Σ_{d∣n, 4∤d} d` collapses to the naive `8·σ(n)`.

- **`jacobiCount_le`** — `jacobiCount n ≤ 8·σ(n)` for every `n`. The `4 ∤ d` filter only removes divisors, so the filtered divisor-sum is bounded by the full one. The uniform upper envelope.
- **`jacobiCount_lt_of_four_dvd`** — for `4 ∣ n` (`n ≠ 0`) the bound is **strict**, with deficit exactly `32·σ(n/4) > 0`, via the existing even-side recursion `jacobiCount_four_dvd`.
- **`jacobiCount_eq_eight_sigma_iff`** — for `n ≠ 0`: `jacobiCount n = 8·σ(n) ↔ ¬ 4 ∣ n`. The sharp boundary between the elementary regime (`jacobiCount_odd`, `jacobiCount_two_mul_odd_eq`, count `= 8·σ` of the odd part) and the genuinely-Jacobi regime (`jacobiCount_four_dvd`) — formalizing precisely why `naive_sigma_fails` at `n = 4`.

These sharpen the file's central dichotomy: they characterize, for all `n`, the exact set on which the naive `8·σ` formula is correct.

## Verification

- `docker-build.sh Proofs.LagrangeFourSquaresOQ01OQ03` → `✔ [7743/7743] Built` (build succeeded).
- **Axiom count unchanged** (still the single `native_decide` oracle `Lean.ofReduceBool`); the three new results use only `Finset`/divisor API and the file's existing `jacobiCount_four_dvd` / `jacobiCount_of_not_four_dvd` — no new assumptions, 0 sorries.
- meta.json updated: `theoremCount` 20→23, `lineCount` 355→402, contribution noted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)