### PR TITLE
fix(prob-method-expectation-oq-04): resolve committed merge-conflict markers breaking ProbMethodExpectationOQ04.lean

### DIFF
--- a/proofs/Proofs/ProbMethodExpectationOQ04.lean
+++ b/proofs/Proofs/ProbMethodExpectationOQ04.lean
@@ -514,28 +514,6 @@ theorem expectedMonoCliques_nonneg (n k : ℕ) : 0 ≤ expectedMonoCliques n k :
   unfold expectedMonoCliques
   exact mul_nonneg (Nat.cast_nonneg _) (zpow_nonneg (by norm_num : (0 : ℚ) ≤ 2) _)
 
-<<<<<<< Updated upstream
-/-- **The diagonal is already sub-threshold: `E(k,k) < 1` for `k ≥ 3`.**  Turning the
-`expectedMonoCliques_self` docstring remark into a theorem: at `n = k` the single potential
-clique is monochromatic with probability `2^{1−C(k,2)}`, and for `k ≥ 3` (so `C(k,2) ≥ 3`)
-this is at most `2^{−2} = ¼ < 1`.  Via `E(k,k) = 2 / 2^{C(k,2)}` (`expectedMonoCliques_eq_div`
-at `C(k,k) = 1`) the bound reduces to `2 < 2^{C(k,2)}`.  This is the trivial Ramsey endpoint
-`R(k,k) > k` — the `n = k` base value underneath the asymptotic `2^{k/2}` bounds
-(`expectedMonoCliques_lt_one_pow`): the expected count is `< 1` already on the diagonal, so
-first-moment yields a good colouring of `K_k`. -/
-theorem expectedMonoCliques_self_lt_one {k : ℕ} (hk : 3 ≤ k) :
-    expectedMonoCliques k k < 1 := by
-  rw [expectedMonoCliques_eq_div, Nat.choose_self, Nat.cast_one, one_mul]
-  have h3 : 3 ≤ k.choose 2 := by
-    calc 3 = (3 : ℕ).choose 2 := by decide
-      _ ≤ k.choose 2 := Nat.choose_le_choose 2 hk
-  have hden : (2 : ℚ) < (2 : ℚ) ^ (k.choose 2) := by
-    calc (2 : ℚ) = 2 ^ 1 := (pow_one 2).symm
-      _ < 2 ^ (k.choose 2) := by
-          apply pow_lt_pow_right₀ (by norm_num : (1 : ℚ) < 2); omega
-  rw [div_lt_one (by positivity)]
-  exact hden
-=======
 /-- **The `≥ 1` threshold — dual of `expectedMonoCliques_lt_one_iff`.**  The expected count
 is at least `1` *exactly* when `2^{C(k,2)} ≤ C(n,k)·2`.  Together with the strict `< 1`
 criterion this pins the sharp cutoff of the first-moment method: below it (`E < 1`) a
@@ -563,6 +541,5 @@ theorem expectedMonoCliques_self_lt_one {k : ℕ} (hk : 3 ≤ k) :
   calc (2 : ℚ) ^ (1 - (k.choose 2 : ℤ))
       ≤ (2 : ℚ) ^ (-2 : ℤ) := zpow_le_zpow_right₀ (by norm_num) hexp
     _ < 1 := by norm_num
->>>>>>> Stashed changes
 
 end ProbMethod.ExpectationOQ04


### PR DESCRIPTION
## Problem

`proofs/Proofs/ProbMethodExpectationOQ04.lean` on `main` contains **unresolved git merge-conflict markers** committed into the source:

```
517: <<<<<<< Updated upstream
538: =======
566: >>>>>>> Stashed changes
```

The literal markers are syntax errors, so **the file does not compile** — a `git stash pop` conflict was committed and merged.

## Resolution

Both conflict sides defined `expectedMonoCliques_self_lt_one` (two different proofs of the same statement). The **"Stashed changes"** side additionally defined the unique dual theorem `expectedMonoCliques_one_le_iff` (the `≥ 1` threshold, dual of `expectedMonoCliques_lt_one_iff`).

This PR takes the stashed side (a superset), keeping **both distinct theorems** and dropping the duplicate `expectedMonoCliques_self_lt_one`:
- `expectedMonoCliques_one_le_iff` — `1 ≤ E(n,k) ↔ 2^{C(k,2)} ≤ C(n,k)·2`.
- `expectedMonoCliques_self_lt_one` — `E(k,k) < 1` for `k ≥ 3` (via `expectedMonoCliques_self` + the negative-exponent bound).

## Verification

- Docker-built clean against Mathlib 4.26.0: `./proofs/scripts/docker-build.sh Proofs.ProbMethodExpectationOQ04` → `Build completed successfully (7743 jobs)`.
- 0 sorries, 0 new axioms. Remaining messages are pre-existing linter warnings/info only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)