### PR TITLE
research(erdos-101-oq-04): fourPointLineCount monotonicity + lower-bound transfer

### DIFF
--- a/proofs/Proofs/Erdos101OQ04.lean
+++ b/proofs/Proofs/Erdos101OQ04.lean
@@ -204,6 +204,31 @@ theorem fourPointLineCount_ge_of_injOn_family (P : PlanarPointSet) (k : ℕ)
   rwa [Finset.card_image_of_injective _ hinj, Finset.card_univ,
     Fintype.card_fin] at hsub
 
+/-- **Monotonicity of the four-point-line count.**  Adding points to a planar set can only
+increase the number of four-point lines: if `P.points ⊆ Q.points` then
+`fourPointLineCount P ≤ fourPointLineCount Q`.  Every 4-element collinear subset of `P` is
+also a 4-element collinear subset of `Q` — the defining filter predicate depends only on
+the subset `S`, not on the ambient point set — so the powerset-filter defining the count
+is monotone.  This is the external counterpart of `fourPointLineCount_ge_of_subset` and the
+structural fact any growing construction relies on. -/
+theorem fourPointLineCount_mono {P Q : PlanarPointSet} (h : P.points ⊆ Q.points) :
+    fourPointLineCount P ≤ fourPointLineCount Q := by
+  rw [fourPointLineCount, fourPointLineCount]
+  exact Finset.card_le_card (Finset.filter_subset_filter _ (Finset.powerset_mono.mpr h))
+
+/-- **Lower-bound constructions survive point addition in general position.**  If `P` is a
+lower-bound construction for threshold `t` (no five collinear and `t ≤ fourPointLineCount P`)
+and `Q ⊇ P` is still in general position (`NoFiveCollinear Q`), then `Q` is also a
+lower-bound construction for `t`: since `fourPointLineCount` is monotone, the bound is
+inherited.  `NoFiveCollinear` itself is *not* monotone — adding points can create five
+collinear — so it must be assumed for `Q`, which is exactly the no-five-collinear
+certificate a growing construction has to supply at each step. -/
+theorem isLowerBoundConstruction_mono {P Q : PlanarPointSet} {t : ℝ}
+    (hPQ : P.points ⊆ Q.points) (hQ : NoFiveCollinear Q)
+    (hP : IsLowerBoundConstruction P t) :
+    IsLowerBoundConstruction Q t :=
+  ⟨hQ, hP.2.trans (Nat.cast_le.mpr (fourPointLineCount_mono hPQ))⟩
+
 /-- **Lower bound vacuous below size 4**: for `P` with fewer than 4
 points, no four-point line exists.  Restatement of
 `fourPointLineCount_lt_four` to fix the OQ-04 namespace conventions. -/


### PR DESCRIPTION
## Summary

`erdos-101-oq-04` (higher-dimensional point-set four-point-line count) is a large 0-axiom framework whose single remaining open sorry is the deep `solymosi_stojakovic_lower_bound` (the `n^{2-o(1)}` construction). This PR adds two verified structural lemmas directly supporting the recorded next-step ("build a growing family and discharge `k ≤ fourPointLineCount`"), without touching that sorry:

- **`fourPointLineCount_mono`** — `P.points ⊆ Q.points ⇒ fourPointLineCount P ≤ fourPointLineCount Q`. The filter predicate defining the count depends only on the candidate subset `S`, not on the ambient set, so the powerset-filter is monotone (`filter_subset_filter ∘ powerset_mono`, then `card_le_card`). This is the *external* counterpart of the existing internal-subset lemma `fourPointLineCount_ge_of_subset`.
- **`isLowerBoundConstruction_mono`** — a lower-bound construction for threshold `t` extends to any general-position superset `Q`: `t ≤ fourPointLineCount P ≤ fourPointLineCount Q`. `NoFiveCollinear` is *not* monotone (adding points can create five collinear), so it must be re-supplied for `Q` — precisely the no-five-collinear certificate a growing construction has to provide at each step.

## Verification

- `./proofs/scripts/docker-build.sh Proofs.Erdos101OQ04` → **Build completed successfully (3062 jobs)**.
- Both lemmas 0-sorry / 0-axiom (standard Finset API only). The only `sorry` warnings are the pre-existing open obligations (`solymosi_stojakovic_lower_bound`, and the two inherited from `Erdos101OQ01`), untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)