### PR TITLE
Enrich ℤ[√d] irreducible-norm dichotomy: link concrete d=−1, d=−2 payoffs

### DIFF
--- a/src/data/proofs/bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-03-oq-03-oq-02-oq-01/meta.json
+++ b/src/data/proofs/bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-03-oq-03-oq-02-oq-01/meta.json
@@ -74,6 +74,16 @@
       "targetId": "bezout-identity-oq-02-oq-01-oq-02-oq-02",
       "relationship": "thematic",
       "description": "Grandparent: Gaussian integers ℤ[i] = ℤ[√-1] as a Euclidean domain; the norm dichotomy here is the d = −1 arithmetic behind the sum-of-two-squares factorization of rational primes."
+    },
+    {
+      "targetId": "fermat-two-squares",
+      "relationship": "instantiated by",
+      "description": "The d = −1 payoff. This entry's abstract dichotomy (irreducible ⟹ norm p or p²) leaves open which rational primes are split (norm p) versus inert (norm p²) — a genuinely d-dependent question. For ℤ[i] = ℤ[√-1] that split criterion is precisely Fermat's theorem: an odd prime has norm-p irreducible factors (equivalently p = a² + b²) iff p ≡ 1 mod 4, while p ≡ 3 mod 4 stays inert with norm p². Fermat's Sum of Two Squares supplies exactly the congruence condition this norm bound cannot see."
+    },
+    {
+      "targetId": "bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-03",
+      "relationship": "instantiated by",
+      "description": "The d = −2 payoff. For ℤ[√-2] the split-vs-inert split of a rational prime is decided by (−2/p): p is inert (norm p², irreducible) iff p ≡ 5 or 7 mod 8, and otherwise splits with norm p (equivalently p = x² + 2y²). That sibling classifies exactly the inert primes whose existence the abstract norm dichotomy proved here guarantees but does not identify."
     }
   ],
   "sections": [


### PR DESCRIPTION
Enrichment pass for `bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-03-oq-03-oq-02-oq-01` (0 prior passes, quality 96).

This entry proves the abstract norm dichotomy — every irreducible of ℤ[√d] (−2 ≤ d < 0) has |N(z)| = p or p² — and explicitly flags the *which primes are inert vs split* question as "the genuinely d-dependent part" it does not resolve. It was missing cross-links to the two gallery entries that resolve exactly that per-d question.

## Change (crossReferences 2 → 4, meta.json 13.1 KB — well under cap)
- **`fermat-two-squares`** ("Fermat's Sum of Two Squares"): the d = −1 payoff — an odd prime has norm-p factors (p = a²+b²) iff p ≡ 1 mod 4; else inert with norm p². Supplies the congruence this norm bound cannot see.
- **`bezout-...-oq-03`** ("ℤ[√-2] as a Euclidean Domain: Inert Prime Classification"): the d = −2 payoff — p inert iff p ≡ 5,7 mod 8 via (−2/p); else splits with norm p (p = x²+2y²).

Both cross-reference targets were verified present in the gallery. Purely additive; no existing content changed, no axiom/status changes (remains verified, 0 sorry / 0 axiom).

Note: this entry carries an obsolete per-proof `index.ts` (dead since #20993); left untouched per the enricher role (do not create/remove these here).