### PR TITLE
research(shannon-entropy-oq-03): entropy monotonicity + I(X;Z|Y) ≤ H(X|Y)

### DIFF
--- a/proofs/Proofs/ShannonEntropySSA.lean
+++ b/proofs/Proofs/ShannonEntropySSA.lean
@@ -246,4 +246,55 @@ theorem conditionalMutualInfo_swap (pXYZ : α × β × γ → ℝ) :
     shannonEntropy_comp_equiv (Equiv.prodComm β α) (marginalXY pXYZ)]
   ring
 
+/-! ## Entropy monotonicity under adding a variable, and the bound `I(X ; Z | Y) ≤ H(X | Y)`
+
+All results above bound differences of entropies against each other; a complementary
+*absolute* fact is that entropy only *grows* when a variable is added: dropping `X` from
+the triple cannot increase entropy,
+
+    H(Y, Z) ≤ H(X, Y, Z).
+
+Because `α × β × γ` is definitionally `α × (β × γ)`, the joint law `pXYZ` is *itself* a
+two-variable distribution over `α × (β × γ)`, and its `(β × γ)`-marginal
+`fun (y,z) => ∑ x, pXYZ (x,y,z)` is exactly `marginalYZ pXYZ`.  The parent chain rule
+`entropy_chain_rule` then reads `H(X,Y,Z) = H(Y,Z) + H(X | Y,Z)` with the conditional
+entropy `H(X | Y,Z) ≥ 0` (`conditionalEntropy_nonneg`), giving the monotonicity directly.
+
+Feeding this into the conditioning-deficit identity yields the standard sandwich for the
+conditional mutual information: `0 ≤ I(X ; Z | Y) ≤ H(X | Y)`.  The lower bound is
+`conditionalMutualInfo_nonneg` (strong subadditivity); the upper bound says the extra
+variable `Z` can reduce the conditional entropy of `X` by *at most* all of it — `X` is never
+made *more* uncertain by learning `Z`, and cannot lose more information than it had. -/
+
+/-- **Entropy is monotone under adding a variable.**  `H(Y, Z) ≤ H(X, Y, Z)`: marginalizing
+    out `X` cannot increase entropy.  Since `α × β × γ = α × (β × γ)` definitionally, `pXYZ`
+    is a two-variable law over `α × (β × γ)` whose `(β × γ)`-marginal is `marginalYZ pXYZ`;
+    the parent chain rule `H(X,Y,Z) = H(Y,Z) + H(X | Y,Z)` with `H(X | Y,Z) ≥ 0`
+    (`conditionalEntropy_nonneg`) gives the bound. -/
+theorem entropy_marginalYZ_le {pXYZ : α × β × γ → ℝ}
+    (hp : ∀ xyz, 0 ≤ pXYZ xyz)
+    (hsum : ∑ xyz : α × β × γ, pXYZ xyz = 1) :
+    shannonEntropy (marginalYZ pXYZ) ≤ shannonEntropy pXYZ := by
+  have hmarg : (fun w : β × γ => ∑ x : α, pXYZ (x, w)) = marginalYZ pXYZ := by
+    funext w; obtain ⟨y, z⟩ := w; rfl
+  have hchain := entropy_chain_rule (pXY := pXYZ) hp hsum
+  rw [hmarg] at hchain
+  have hce := conditionalEntropy_nonneg (pXY := pXYZ) hp hsum
+  linarith
+
+/-- **The conditional mutual information is bounded by the conditional entropy.**
+    `I(X ; Z | Y) ≤ H(X | Y)`, where `H(X | Y) = H(X, Y) − H(Y)`.  Combined with
+    `conditionalMutualInfo_nonneg` this is the sandwich `0 ≤ I(X ; Z | Y) ≤ H(X | Y)`:
+    learning `Z` reduces the conditional entropy of `X` by an amount between `0` and all of
+    `H(X | Y)`.  Immediate from the deficit identity
+    `I(X ; Z | Y) = H(X | Y) − H(X | Y, Z)` and `H(X | Y, Z) = H(X,Y,Z) − H(Y,Z) ≥ 0`
+    (`entropy_marginalYZ_le`). -/
+theorem conditionalMutualInfo_le_conditional_entropy {pXYZ : α × β × γ → ℝ}
+    (hp : ∀ xyz, 0 ≤ pXYZ xyz)
+    (hsum : ∑ xyz : α × β × γ, pXYZ xyz = 1) :
+    conditionalMutualInfo pXYZ ≤
+      shannonEntropy (marginalXY pXYZ) - shannonEntropy (marginalY pXYZ) := by
+  unfold conditionalMutualInfo
+  linarith [entropy_marginalYZ_le hp hsum]
+
 end InformationTheory.SSA

--- a/src/data/proofs/shannon-entropy-oq-03/meta.json
+++ b/src/data/proofs/shannon-entropy-oq-03/meta.json
@@ -40,11 +40,13 @@
     "originalContributions": [
       "Three-variable 'conditioning reduces entropy' H(X|Y,Z) ≤ H(X|Y) as a corollary of SSA",
       "Non-negativity of conditional mutual information I(X;Z|Y) ≥ 0",
-      "Conditional mutual information as a first-class definition (conditionalMutualInfo), with the deficit identity I(X;Z|Y) = H(X|Y) − H(X|Y,Z) formalizing the prose claim of the conditioning corollaries"
+      "Conditional mutual information as a first-class definition (conditionalMutualInfo), with the deficit identity I(X;Z|Y) = H(X|Y) − H(X|Y,Z) formalizing the prose claim of the conditioning corollaries",
+      "Entropy monotonicity under adding a variable H(Y,Z) ≤ H(X,Y,Z) (entropy_marginalYZ_le), via the definitional identity α×β×γ = α×(β×γ) and the parent chain rule",
+      "Upper bound I(X;Z|Y) ≤ H(X|Y) (conditionalMutualInfo_le_conditional_entropy), giving the sandwich 0 ≤ I(X;Z|Y) ≤ H(X|Y)"
     ],
     "dateAdded": "2026-03-30",
-    "lineCount": 249,
-    "theoremCount": 8,
+    "lineCount": 300,
+    "theoremCount": 10,
     "definitionCount": 1,
     "additionalFiles": [],
     "mathlib_version": "4.26.0",
@@ -172,9 +174,9 @@
       "Finset"
     ],
     "namespace": "InformationTheory.SSA",
-    "lineCount": 249,
+    "lineCount": 300,
     "axiomCount": 0,
-    "theoremCount": 10,
+    "theoremCount": 12,
     "definitionCount": 1,
     "path": "Proofs/ShannonEntropySSA.lean",
     "sorries": 0,


### PR DESCRIPTION
## Summary

Two new theorems for `ShannonEntropySSA.lean` (gallery `shannon-entropy-oq-03`, Strong Subadditivity, `verified`/0-axiom), extending the conditional-mutual-information framework with the standard **upper** bound to complement the existing non-negativity.

- **`entropy_marginalYZ_le`** — `H(Y,Z) ≤ H(X,Y,Z)`: entropy is monotone under adding a variable (marginalizing out `X` cannot increase entropy). Key observation: `α × β × γ` is *definitionally* `α × (β × γ)`, so `pXYZ` is already a two-variable law over `α × (β×γ)` whose `(β×γ)`-marginal is exactly `marginalYZ pXYZ` — no relabeling equiv needed. The parent chain rule `H(X,Y,Z) = H(Y,Z) + H(X|Y,Z)` with `conditionalEntropy_nonneg` closes it.
- **`conditionalMutualInfo_le_conditional_entropy`** — `I(X;Z|Y) ≤ H(X|Y)`. Together with the existing `conditionalMutualInfo_nonneg` this is the sandwich `0 ≤ I(X;Z|Y) ≤ H(X|Y)`: learning `Z` reduces the conditional entropy of `X` by an amount between `0` and all of it.

Both reuse the parent file's verified `entropy_chain_rule` / `conditionalEntropy_nonneg`.

## Verification

- `./proofs/scripts/docker-build.sh Proofs.ShannonEntropySSA` → `Build completed successfully (7744 jobs)`.
- 10 → 12 theorems, **0 axioms, 0 sorries** (inherits the parent's axiom-free `[propext, Classical.choice, Quot.sound]` trio; no `native_decide`, no `sorry`).
- `meta.json` synced: `theoremCount` 10 → 12, `lineCount` 249 → 300, two `originalContributions` added.

## Context

The research problem `shannon-entropy-oq-03-incomplete-01` is already COMPLETE (its "remaining SSA sorry" premise is false — SSA is fully proven). This PR is an outward extension of the verified entry rather than a repair.

🤖 Generated with [Claude Code](https://claude.com/claude-code)