### PR TITLE
research(tetrahedral-number-formula-oq-01): general falling-factorial moment hockey stick

### DIFF
--- a/proofs/Proofs/TetrahedralNumberFormulaOQ01.lean
+++ b/proofs/Proofs/TetrahedralNumberFormulaOQ01.lean
@@ -1021,8 +1021,7 @@ theorem descFactorial_moment_sum_simplex (r d n : ℕ) :
         _ = j.descFactorial r * ((d + 1) * simplexNumber (d + 1) j) := by rw [hab]
         _ = (d + 1) * (j.descFactorial r * simplexNumber (d + 1) j) := by ring
     rw [Finset.sum_congr rfl hstep, ← Finset.mul_sum, ih (d + 1)]
-    rw [show d + 1 + r = d + (r + 1) from by ring,
-        show d + 1 + r + 1 = d + (r + 1) + 1 from by ring, ← Nat.mul_assoc]
+    rw [show d + 1 + r = d + (r + 1) from by ring, ← Nat.mul_assoc]
     congr 1
     rw [Nat.descFactorial_succ]
     congr 1

--- a/proofs/Proofs/TetrahedralNumberFormulaOQ01.lean
+++ b/proofs/Proofs/TetrahedralNumberFormulaOQ01.lean
@@ -968,5 +968,65 @@ theorem weighted_sum_simplex_over_dim (d n : ℕ) :
     Finset.sum_congr rfl fun k _ => by rw [simplexNumber_symm k d]
   rw [h, weighted_sum_simplex, simplexNumber_symm (d + 2) n]
 
+/-! ### General falling-factorial moment hockey stick
+
+The plain hockey stick `sum_simplex` (`∑ P_d(k) = P_{d+1}(n)`) and the first-moment
+`weighted_sum_simplex` (`∑ k·P_d(k) = (d+1)·P_{d+2}(n)`) are the `r = 0` and `r = 1`
+instances of a single identity: weighting a figurate row by the **falling factorial**
+`(k)_r = k(k-1)⋯(k-r+1)` and summing collapses to one higher-dimensional simplex number.
+Falling factorials are the natural discrete moment basis (each forward difference lowers the
+order, mirroring `d/dx xʳ = r·xʳ⁻¹`), so this is the exact discrete analogue of the
+continuous moment `∫₀ⁿ xʳ·x^d = n^{d+r+1}/(d+r+1)`. The proof iterates the absorption
+identity `succ_mul_simplexNumber` once per order, by induction on `r`. -/
+
+/-- **General falling-factorial moment hockey stick.** Weighting a figurate row by the
+falling factorial `(k)_r = k(k-1)⋯(k-r+1) = k.descFactorial r` and summing collapses to a
+single higher-dimensional simplex number:
+
+`∑_{k ≤ n+r} (k)_r · P_d(k) = (d+r)_r · P_{d+r+1}(n)`,
+
+where the coefficient `(d+r)_r = (d+1)(d+2)⋯(d+r)` is itself a falling factorial. The plain
+hockey stick `sum_simplex` is the case `r = 0` (weight `(k)_0 ≡ 1`, coefficient `1`) and the
+first moment `weighted_sum_simplex` is `r = 1` (weight `k`, coefficient `d+1`); each further
+order applies the pointwise absorption identity `succ_mul_simplexNumber` one more time. This
+exhibits the falling factorials as the natural discrete moment basis for the figurate ladder
+— the summation-side analogue of the continuous moment `∫₀ⁿ xʳ·x^d = n^{d+r+1}/(d+r+1)`.
+Proved by induction on the order `r`, generalizing the dimension `d`: reindexing `k = j+1`
+(`Finset.sum_range_succ'`) and `Nat.succ_descFactorial_succ` peel one falling-factorial factor
+`(j+1)`, the absorption identity turns `(j+1)·P_d(j+1)` into `(d+1)·P_{d+1}(j)`, and the
+inductive hypothesis at dimension `d+1` closes it; the coefficient bookkeeping is exactly
+`Nat.descFactorial_succ`. -/
+theorem descFactorial_moment_sum_simplex (r d n : ℕ) :
+    ∑ k ∈ range (n + r + 1), k.descFactorial r * simplexNumber d k
+      = (d + r).descFactorial r * simplexNumber (d + r + 1) n := by
+  induction r generalizing d with
+  | zero =>
+    simp only [Nat.descFactorial_zero, Nat.add_zero, Nat.one_mul]
+    exact sum_simplex d n
+  | succ r ih =>
+    rw [show n + (r + 1) + 1 = (n + r + 1) + 1 from by ring]
+    rw [Finset.sum_range_succ'
+      (fun k => k.descFactorial (r + 1) * simplexNumber d k) (n + r + 1)]
+    have hz : (0 : ℕ).descFactorial (r + 1) * simplexNumber d 0 = 0 := by
+      rw [Nat.descFactorial_succ, Nat.zero_sub, Nat.zero_mul, Nat.zero_mul]
+    rw [hz, Nat.add_zero]
+    have hstep : ∀ j ∈ range (n + r + 1),
+        (j + 1).descFactorial (r + 1) * simplexNumber d (j + 1)
+          = (d + 1) * (j.descFactorial r * simplexNumber (d + 1) j) := by
+      intro j _
+      rw [Nat.succ_descFactorial_succ]
+      have hab := succ_mul_simplexNumber d j
+      calc (j + 1) * j.descFactorial r * simplexNumber d (j + 1)
+          = j.descFactorial r * ((j + 1) * simplexNumber d (j + 1)) := by ring
+        _ = j.descFactorial r * ((d + 1) * simplexNumber (d + 1) j) := by rw [hab]
+        _ = (d + 1) * (j.descFactorial r * simplexNumber (d + 1) j) := by ring
+    rw [Finset.sum_congr rfl hstep, ← Finset.mul_sum, ih (d + 1)]
+    rw [show d + 1 + r = d + (r + 1) from by ring,
+        show d + 1 + r + 1 = d + (r + 1) + 1 from by ring, ← Nat.mul_assoc]
+    congr 1
+    rw [Nat.descFactorial_succ]
+    congr 1
+    omega
+
 end TetrahedralNumberFormulaOQ01
 

--- a/src/data/research/problems/tetrahedral-number-formula-oq-01.json
+++ b/src/data/research/problems/tetrahedral-number-formula-oq-01.json
@@ -75,7 +75,8 @@
     "nextSteps": [
       "Optional: Norlund/finite-difference expansion of iterSum on a polynomial base sequence now follows by combining iterSum_eq_simplexConv with a binomial expansion of P_d(n-k).",
       "Optional: express card_sym as an explicit nested multi-index Finset sum over {0<=i1<=...<=id<=n} to make the weakly-increasing-tuple face literal.",
-      "Convolution of arithmetic-progression / polynomial sequences against the simplex kernel, now reducible via the linearity package to simplexConv of id and constants."
+      "Convolution of arithmetic-progression / polynomial sequences against the simplex kernel, now reducible via the linearity package to simplexConv of id and constants.",
+      "Follow-up (distinct): ordinary power moments ∑ k^m·P_d(k) via Stirling numbers of the second kind, expressing k^m as a sum of falling factorials (k)_r and applying descFactorial_moment_sum_simplex termwise — connects the figurate moment theory to Stirling/Bell number combinatorics."
     ],
     "markdown": "# Knowledge Base: tetrahedral-number-formula-oq-01\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },

--- a/src/data/research/problems/tetrahedral-number-formula-oq-01.json
+++ b/src/data/research/problems/tetrahedral-number-formula-oq-01.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETE: core hockey-stick theory plus first-moment (weighted) hockey stick; 0 sorries, 0 axioms",
+    "progressSummary": "COMPLETE: core hockey-stick theory + moment theory (plain, first-moment, and general falling-factorial-order-r moment); 0 sorries, 0 axioms",
     "builtItems": [
       "simplexNumber d n := (n+d).choose d - the d-dimensional hyper-tetrahedral number (TetrahedralNumberFormulaOQ01.lean)",
       "sum_simplex: sum_{k<=n} simplexNumber d k = simplexNumber (d+1) n - general hockey stick, any dimension d (via Nat.sum_range_add_choose)",
@@ -54,7 +54,8 @@
       "iterForwardDiff_self_simplexNumber (:681) — Δ^a P_a = 1, dual of iterSum_one",
       "succ_mul_simplexNumber: figurate absorption (j+1)P_d(j+1)=(d+1)P_{d+1}(j) via Nat.choose_succ_right_eq (TetrahedralNumberFormulaOQ01.lean)",
       "weighted_sum_simplex: first-moment hockey stick sum_{k<=n+1} k*P_d(k) = (d+1)*P_{d+2}(n)",
-      "weighted_sum_simplex_over_dim: dimension-axis dual via simplexNumber_symm"
+      "weighted_sum_simplex_over_dim: dimension-axis dual via simplexNumber_symm",
+      "descFactorial_moment_sum_simplex in TetrahedralNumberFormulaOQ01.lean: ∑_{k≤n+r} (k)_r·P_d(k) = (d+r)_r·P_{d+r+1}(n), the general falling-factorial moment hockey stick unifying sum_simplex (r=0) and weighted_sum_simplex (r=1); induction on r via succ_descFactorial_succ + absorption succ_mul_simplexNumber + descFactorial_succ (PR #38213)"
     ],
     "insights": [
       "The hyper-tetrahedral / d-simplex number is exactly Mathlib Nat.multichoose (n+1) d = C(n+d,d); Mathlib gives the one-step hockey stick Nat.sum_range_add_choose : sum i in range(n+1),(i+d).choose d = (n+d+1).choose(d+1)",
@@ -65,7 +66,8 @@
       "VERIFIED (researcher-2, 2026-07-09, GREEN build): the order facts of the figurate ladder P_d(n)=C(n+d,d), absent from the file. simplexNumber_pos (0<P_d(n), Nat.choose_pos on d≤n+d), simplexNumber_mono_size (m≤n⟹P_d(m)≤P_d(n), Nat.choose_le_choose on m+d≤n+d), simplexNumber_mono_dim (a≤b⟹P_a(n)≤P_b(n), reduced to mono_size through the reflection symmetry simplexNumber_symm P_d(n)=P_n(d)). Monotone in BOTH arguments + positive. Complements the exact-value/summation theory with the growth/order structure.",
       "The figurate calculus is ℕ-linear: both iterated summation (iterSum) and simplex convolution (simplexConv) are additive and ℕ-homogeneous in the summand — the summand-side companion to the dimension-side semigroup laws iterSum_add / simplexConv_comp.",
       "The summation↔difference duality closes at the ITERATED level: iterSum a (raise a dims) and iterForwardDiff a = Δ^a (lower a dims) are two-sided inverses up to the intrinsic shift Δ^a∘∑^a = shift^a; the shift is forced because each Δ reads a running total one index ahead.",
-      "Index-weighted figurate row sum (first moment) collapses to a single higher-dim simplex number, discrete analogue of int x*x^d = n^{d+2}/(d+2); engine is pointwise binomial absorption"
+      "Index-weighted figurate row sum (first moment) collapses to a single higher-dim simplex number, discrete analogue of int x*x^d = n^{d+2}/(d+2); engine is pointwise binomial absorption",
+      "Falling factorials (k)_r are the natural discrete moment basis for the figurate ladder: weighting a figurate row by (k)_r and summing collapses to a single higher-dimensional simplex number, discrete analogue of ∫ x^r·x^d = n^{d+r+1}/(d+r+1). The order r is absorbed one at a time by the pointwise absorption identity."
     ],
     "mathlibGaps": [
       "Mathlib has the one-step hockey stick and multichoose but no dimension-indexed figurate theory: no iterated-partial-sum characterization of simplex numbers, no figurate recurrence/closed form stated uniformly in the dimension d."


### PR DESCRIPTION
## Summary

Extends the SOLVED entry `tetrahedral-number-formula-oq-01` (General Hockey-Stick Identity for Hyper-Tetrahedral Numbers) with one genuinely new, theory-level theorem that **unifies and generalizes** two lemmas already in the file.

### New theorem: `descFactorial_moment_sum_simplex`

78242\sum_{k \le n+r} (k)_r \cdot P_d(k) \;=\; (d+r)_r \cdot P_{d+r+1}(n)78242

where $(k)_r = k(k-1)\cdots(k-r+1)$ is the falling factorial (`Nat.descFactorial`) and the coefficient $(d+r)_r = (d+1)(d+2)\cdots(d+r)$ is itself a falling factorial.

**Why it matters (not a cosmetic variant):**
- `r = 0` recovers the plain hockey stick `sum_simplex` (`∑ P_d(k) = P_{d+1}(n)`).
- `r = 1` recovers the first moment `weighted_sum_simplex` (`∑ k·P_d(k) = (d+1)·P_{d+2}(n)`).
- The general statement exhibits the **falling factorials as the natural discrete moment basis** for the figurate ladder — the summation-side analogue of the continuous moment $\int_0^n x^r x^d = n^{d+r+1}/(d+r+1)$.

**Proof:** induction on the order `r` (generalizing the dimension `d`). Each step reindexes `k = j+1` (`Finset.sum_range_succ'`), peels one falling-factorial factor via `Nat.succ_descFactorial_succ`, applies the file's pointwise absorption identity `succ_mul_simplexNumber` to turn `(j+1)·P_d(j+1)` into `(d+1)·P_{d+1}(j)`, and closes with the inductive hypothesis at dimension `d+1`; the coefficient bookkeeping is exactly `Nat.descFactorial_succ`.

### Verification
- `./proofs/scripts/docker-build.sh Proofs.TetrahedralNumberFormulaOQ01` → **✔ Built (2.5s)**, 0 sorries.
- Axiom-free: proof uses only Mathlib rewrite lemmas, `ring`/`omega`, and existing file theorems (standard foundational axioms only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)