### PR TITLE
research(puiseux-theorem-wip-01): directedness of the ramification subring/subfield towers

### DIFF
--- a/proofs/Proofs/PuiseuxTheorem.lean
+++ b/proofs/Proofs/PuiseuxTheorem.lean
@@ -1080,6 +1080,18 @@ theorem iSup_puiseuxRamificationSubring {K : Type*} [Ring K] :
   obtain ⟨n, hn⟩ := hx
   exact (le_iSup (puiseuxRamificationSubring K) n) hn
 
+/-- **The ramification subring tower is directed.** `n ↦ puiseuxRamificationSubring K n` is
+`Directed (· ≤ ·)`: any two levels `n, m` are dominated by `n*m` (both `n ∣ n*m` and `m ∣ n*m`,
+so `puiseuxRamificationSubring_mono` embeds each level into level `n*m`). This is the
+order-theoretic hypothesis that makes `iSup_puiseuxRamificationSubring` a *filtered* colimit of
+Laurent subrings rather than an arbitrary supremum — the ring-level companion of
+`directed_ramification_valueGroup`. -/
+theorem directed_puiseuxRamificationSubring {K : Type*} [Ring K] :
+    Directed (· ≤ ·) (puiseuxRamificationSubring K) := by
+  intro n m
+  exact ⟨n * m, puiseuxRamificationSubring_mono (dvd_mul_right n m),
+    puiseuxRamificationSubring_mono (dvd_mul_left m n)⟩
+
 end Filtration
 
 /-! ═══════════════════════════════════════════════════════════════════════════════
@@ -1188,6 +1200,18 @@ theorem iSup_puiseuxRamificationSubfield {K : Type*} [Field K] :
   rw [mem_puiseuxSubfield] at hx
   obtain ⟨n, hn⟩ := hx
   exact (le_iSup (puiseuxRamificationSubfield K) n) hn
+
+/-- **The ramification subfield tower is directed.** `n ↦ puiseuxRamificationSubfield K n` is
+`Directed (· ≤ ·)`: any two levels `n, m` are dominated by `n*m` via
+`puiseuxRamificationSubfield_mono`. This is the directedness that makes
+`iSup_puiseuxRamificationSubfield` a *filtered* colimit of Laurent fields — the field-level
+companion of `directed_puiseuxRamificationSubring` and `directed_ramification_valueGroup`,
+completing the "colimit of Laurent fields `K((x^{1/n}))`" picture as a directed system. -/
+theorem directed_puiseuxRamificationSubfield {K : Type*} [Field K] :
+    Directed (· ≤ ·) (puiseuxRamificationSubfield K) := by
+  intro n m
+  exact ⟨n * m, puiseuxRamificationSubfield_mono (dvd_mul_right n m),
+    puiseuxRamificationSubfield_mono (dvd_mul_left m n)⟩
 
 end FieldFiltration
 

--- a/src/data/proofs/puiseux-theorem/meta.json
+++ b/src/data/proofs/puiseux-theorem/meta.json
@@ -173,9 +173,9 @@
       "Polynomial"
     ],
     "namespace": "PuiseuxTheorem",
-    "lineCount": 1315,
+    "lineCount": 1440,
     "axiomCount": 0,
-    "theoremCount": 46,
+    "theoremCount": 48,
     "definitionCount": 8,
     "path": "Proofs/PuiseuxTheorem.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

Extends the Puiseux-series-over-Hahn-series formalization (`Proofs/PuiseuxTheorem.lean`) with **2 axiom-free theorems** packaging the ramification towers as *directed systems* — the ring/field companions of the existing `directed_ramification_valueGroup`.

### New theorems
- `directed_puiseuxRamificationSubring`: `Directed (· ≤ ·) (puiseuxRamificationSubring K)`.
- `directed_puiseuxRamificationSubfield`: `Directed (· ≤ ·) (puiseuxRamificationSubfield K)`.

Any two levels `n, m` are dominated by `n*m` (since `n | n*m` and `m | n*m`), so the existing `_mono` lemmas embed each level into level `n*m`. This is the order-theoretic directedness that upgrades the existing `iSup_puiseuxRamificationSubring` / `iSup_puiseuxRamificationSubfield` colimit identities from arbitrary suprema to genuine *filtered* colimits — completing the colimit-of-Laurent-fields picture.

### Verification
- Docker build (`Proofs.PuiseuxTheorem`) **succeeds** (3070 jobs). Warnings all pre-existing.
- 0 axioms, 0 sorries preserved (the `axiomatized`/`wip` status reflects the genuine open remainder — full Newton–Puiseux with char-0 convergence — not this verified fragment). Counts synced in meta.json.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
