### PR TITLE
fix(erdos-703): resolve committed merge-conflict markers breaking Erdos703Problem.lean

### DIFF
--- a/proofs/Proofs/Erdos703Problem.lean
+++ b/proofs/Proofs/Erdos703Problem.lean
@@ -1134,7 +1134,6 @@ theorem one_le_T_L_of_zero_notMem {n : ℕ} {L : Finset ℕ} (h : 0 ∉ L) :
     _ ≤ _ := Finset.le_sup hmem
 
 /--
-<<<<<<< Updated upstream
 **When every forbidden size exceeds the ground set, the full powerset is `L`-avoiding.**
 If `n < r` for every `r ∈ L`, then no two subsets `A, B ⊆ [n]` can meet in a forbidden
 size: `|A ∩ B| ≤ n < r` for each `r ∈ L`, so `|A ∩ B| ∉ L`. Hence the entire powerset
@@ -1186,7 +1185,8 @@ soon as any attainable size (`≤ n`) is forbidden. -/
 theorem T_L_le_pow_sub_one {n r : ℕ} {L : Finset ℕ} (hr : r ∈ L) (hrn : r ≤ n) :
     T_L n L ≤ 2 ^ n - 1 :=
   le_trans (T_L_le_T_of_mem hr) (T_le_pow_sub_one hrn)
-=======
+
+/--
 **Fully-forbidden top endpoint `T_L n L = 0`.** If *every* attainable intersection size is
 forbidden — `range (n+1) ⊆ L`, i.e. `0, 1, …, n ∈ L` — then no nonempty family can avoid `L`:
 any set `A` in a family of subsets of `[n]` has the self-pair `A ∩ A = A` with size
@@ -1224,7 +1224,6 @@ theorem T_L_union_le_min {n : ℕ} {L L' : Finset ℕ} :
     T_L n (L ∪ L') ≤ min (T_L n L) (T_L n L') :=
   le_min (T_L_antitone_forbidden Finset.subset_union_left)
     (T_L_antitone_forbidden Finset.subset_union_right)
->>>>>>> Stashed changes
 
 /-
 ## Part VIII: Summary


### PR DESCRIPTION
## Problem

`proofs/Proofs/Erdos703Problem.lean` on `main` contains **unresolved git merge-conflict markers** committed into the source (lines 1137/1189/1227):

```
1137: <<<<<<< Updated upstream
1189: =======
1227: >>>>>>> Stashed changes
```

The literal markers are syntax errors, so **the file does not compile**. This is the second such file found on main (companion to the `ProbMethodExpectationOQ04.lean` fix, #38205).

## Resolution

Unlike the ProbMethod case, the two conflict sides here define **entirely distinct** theorems, so the resolution **keeps all five** (union of both sides), adding the one missing `/--` docstring opener for the stashed block:

- **upstream side:** `full_powerset_avoidsL_of_lt`, `T_L_eq_pow_of_lt`, `T_L_le_pow_sub_one`
- **stashed side:** `T_L_eq_zero_of_range_subset`, `T_L_union_le_min`

## Verification

- Docker-built clean against Mathlib 4.26.0: `./proofs/scripts/docker-build.sh Proofs.Erdos703Problem` → `Build completed successfully (7743 jobs)`.
- 0 sorries, 0 new axioms (file's only axiom remains the pre-existing `frankl_rodl_1987`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)