### PR TITLE
research(e-transcendental-oq-02-oq-06): set-level packaging of "rationals are never normal"

### DIFF
--- a/proofs/Proofs/ETranscendentalOQ02OQ06.lean
+++ b/proofs/Proofs/ETranscendentalOQ02OQ06.lean
@@ -114,4 +114,43 @@ theorem intCast_not_absolutely_normal (n : ℤ) : ¬ IsAbsolutelyNormal (n : ℝ
 theorem natCast_not_absolutely_normal (n : ℕ) : ¬ IsAbsolutelyNormal (n : ℝ) :=
   fun hn => natCast_not_normal 2 (le_refl 2) n (hn 2 (le_refl 2))
 
+/-!
+### Set-level packaging
+
+The pointwise corollaries above are most reusable as statements about the *set* of
+normal numbers: it is contained in the irrationals and is disjoint from the rationals.
+These are the exact forms a downstream argument invokes when it wants to conclude a
+whole family of numbers (e.g. `Set.range ((↑) : ℚ → ℝ)`) contains no normal number.
+-/
+
+/-- **The normal numbers of base `b` form a subset of the irrationals.**  Set-inclusion
+    packaging of the parent's pointwise `normal_imp_irrational`. -/
+theorem setOf_normal_subset_irrational (b : ℕ) (hb : 2 ≤ b) :
+    {x : ℝ | IsNormalInBase b x} ⊆ {x : ℝ | Irrational x} :=
+  fun x hx => normal_imp_irrational b hb x hx
+
+/-- **The absolutely normal numbers form a subset of the irrationals.**  Absolute-normality
+    analogue of `setOf_normal_subset_irrational`, via `absolutelyNormal_imp_irrational`. -/
+theorem setOf_absolutelyNormal_subset_irrational :
+    {x : ℝ | IsAbsolutelyNormal x} ⊆ {x : ℝ | Irrational x} :=
+  fun x hx => absolutelyNormal_imp_irrational x hx
+
+/-- **The base-`b` normal numbers are disjoint from the rationals.**  The set-level
+    contrapositive: no `q : ℚ` casts to a base-`b`-normal real. Directly from
+    `rational_not_normal`. This is the reusable "a rational is never in the normal set"
+    fact for `Set.range ((↑) : ℚ → ℝ)`. -/
+theorem normal_disjoint_ratCast (b : ℕ) (hb : 2 ≤ b) :
+    Disjoint {x : ℝ | IsNormalInBase b x} (Set.range ((↑) : ℚ → ℝ)) := by
+  rw [Set.disjoint_left]
+  rintro x hx ⟨q, rfl⟩
+  exact rational_not_normal b hb q hx
+
+/-- **The absolutely normal numbers are disjoint from the rationals.**  Absolute-normality
+    analogue of `normal_disjoint_ratCast`, via `rational_not_absolutely_normal`. -/
+theorem absolutelyNormal_disjoint_ratCast :
+    Disjoint {x : ℝ | IsAbsolutelyNormal x} (Set.range ((↑) : ℚ → ℝ)) := by
+  rw [Set.disjoint_left]
+  rintro x hx ⟨q, rfl⟩
+  exact rational_not_absolutely_normal q hx
+
 end ETranscendentalOQ02OQ06


### PR DESCRIPTION
## Summary

Extends `ETranscendentalOQ02OQ06.lean` — which records the contrapositive of the parent's `normal_imp_irrational` ("rationals are never normal") — with its **set-level packaging**, the form a downstream argument actually invokes to rule out normality across a whole family of numbers.

Four new sorry-free, **0-axiom** corollaries:

- **`setOf_normal_subset_irrational`** — `{x | IsNormalInBase b x} ⊆ {x | Irrational x}` (set-inclusion form of the pointwise `normal_imp_irrational`).
- **`setOf_absolutelyNormal_subset_irrational`** — absolute-normality analogue.
- **`normal_disjoint_ratCast`** — the base-`b` normal set is `Disjoint` from `Set.range ((↑) : ℚ → ℝ)`; the reusable "no rational is normal" fact at the set level.
- **`absolutelyNormal_disjoint_ratCast`** — absolute-normality analogue.

All are derived from the parent's machine-checked `normal_imp_irrational` and the file's existing `rational_not_normal` / `absolutelyNormal_imp_irrational`. The parent's only `axiom` (`e_absolutely_normal`, the open conjecture that `e` is normal) is **not used**.

## Verification

- `docker-build.sh Proofs.ETranscendentalOQ02OQ06` → `✔ [3086/3086] Built` (build succeeded).
- 0 sorries, 0 new axioms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)