### PR TITLE
research(erdos-378): finite additivity of natural density + additive exact-count strata

### DIFF
--- a/proofs/Proofs/Erdos378Problem.lean
+++ b/proofs/Proofs/Erdos378Problem.lean
@@ -776,4 +776,79 @@ theorem eta_partialSum_compl_antitone {k k' : ℕ} (hk : k ≤ k') :
     Finset.sum_le_sum_of_subset_of_nonneg hsub (fun m _ _ => eta_nonneg m)
   linarith
 
+/-
+## Part IX: Finite additivity of natural density, and the exact-count strata
+
+`natDensity_compl` handles the two-set partition `S ⊍ Sᶜ`; the general building block is
+that natural density is **finitely additive over disjoint sets** — if `S` and `T` are
+disjoint and each has a density, then `S ∪ T` has density the sum. This is proved directly
+from the definition by an ε/2 argument: on every window `[0,N)` the counts add exactly
+(`Set.ncard_union_eq`, disjointness), so the union ratio is the sum of the two ratios and
+the errors add. Applied to the Granville–Ramaré strata `exactlySquarefree m` — which are
+pairwise disjoint because a fixed `n` has a single value of `squarefreeCount n` — it shows
+the two-stratum union carries density `η_m + η_{m'}`, the additive structure behind the
+`Σ η_m` density formulas.
+-/
+
+/-- **Natural density is finitely additive over disjoint sets.**  If `S` and `T` are
+disjoint and have densities `d_S`, `d_T`, then `S ∪ T` has density `d_S + d_T`.  On each
+initial window `[0,N)` the counts of `S` and `T` add exactly (`Set.ncard_union_eq`, using
+disjointness and finiteness of the finite pieces), so the union counting ratio is the sum
+of the two ratios; an ε/2 split of the two error bounds closes it.  Generalises
+`natDensity_compl` (the case `T = Sᶜ`, `d_T = 1 − d_S`). -/
+theorem natDensity_union_of_disjoint {S T : Set ℕ} {dS dT : ℝ}
+    (hd : Disjoint S T) (hS : NaturalDensity S dS) (hT : NaturalDensity T dT) :
+    NaturalDensity (S ∪ T) (dS + dT) := by
+  intro ε hε
+  obtain ⟨N₁, hN₁⟩ := hS (ε / 2) (by linarith)
+  obtain ⟨N₂, hN₂⟩ := hT (ε / 2) (by linarith)
+  refine ⟨max N₁ N₂, fun N hN => ?_⟩
+  have hn1 : N₁ ≤ N := le_trans (le_max_left _ _) hN
+  have hn2 : N₂ ≤ N := le_trans (le_max_right _ _) hN
+  have hfinS : (S ∩ Set.Iio N).Finite := (Set.finite_Iio N).inter_of_right S
+  have hfinT : (T ∩ Set.Iio N).Finite := (Set.finite_Iio N).inter_of_right T
+  have hdisj : Disjoint (S ∩ Set.Iio N) (T ∩ Set.Iio N) :=
+    hd.mono Set.inter_subset_left Set.inter_subset_left
+  have hunion : ((S ∪ T) ∩ Set.Iio N) = (S ∩ Set.Iio N) ∪ (T ∩ Set.Iio N) :=
+    Set.union_inter_distrib_right S T (Set.Iio N)
+  have hcard : ((S ∪ T) ∩ Set.Iio N).ncard
+      = (S ∩ Set.Iio N).ncard + (T ∩ Set.Iio N).ncard := by
+    rw [hunion, Set.ncard_union_eq hdisj hfinS hfinT]
+  have hcardR : (((S ∪ T) ∩ Set.Iio N).ncard : ℝ)
+      = ((S ∩ Set.Iio N).ncard : ℝ) + ((T ∩ Set.Iio N).ncard : ℝ) := by
+    exact_mod_cast hcard
+  have hexpand : (((S ∪ T) ∩ Set.Iio N).ncard : ℝ) / (N : ℝ) - (dS + dT)
+      = (((S ∩ Set.Iio N).ncard : ℝ) / (N : ℝ) - dS)
+        + (((T ∩ Set.Iio N).ncard : ℝ) / (N : ℝ) - dT) := by
+    rw [hcardR]; ring
+  rw [hexpand]
+  calc |(((S ∩ Set.Iio N).ncard : ℝ) / (N : ℝ) - dS)
+          + (((T ∩ Set.Iio N).ncard : ℝ) / (N : ℝ) - dT)|
+      ≤ |((S ∩ Set.Iio N).ncard : ℝ) / (N : ℝ) - dS|
+        + |((T ∩ Set.Iio N).ncard : ℝ) / (N : ℝ) - dT| := abs_add_le _ _
+    _ < ε / 2 + ε / 2 := add_lt_add (hN₁ N hn1) (hN₂ N hn2)
+    _ = ε := by ring
+
+/-- **The exact-count strata are pairwise disjoint.**  For `m ≠ m'`,
+`exactlySquarefree m` and `exactlySquarefree m'` are disjoint: an `n` lying in both would
+have `squarefreeCount n` equal to both `2m + 2` and `2m' + 2`, forcing `m = m'`. -/
+theorem exactlySquarefree_disjoint {m m' : ℕ} (h : m ≠ m') :
+    Disjoint (exactlySquarefree m) (exactlySquarefree m') := by
+  rw [Set.disjoint_left]
+  intro n hn hn'
+  simp only [exactlySquarefree, Set.mem_setOf_eq] at hn hn'
+  rw [hn] at hn'
+  omega
+
+/-- **Additivity of the exact-count densities on two strata.**  For `m ≠ m'` the union
+`exactlySquarefree m ∪ exactlySquarefree m'` has density `η_m + η_{m'}`.  Immediate from
+finite additivity (`natDensity_union_of_disjoint`) on the disjoint strata
+(`exactlySquarefree_disjoint`), each of density `η` (`natDensity_eta`).  This is the
+two-term case of the additive `Σ η_m` structure the Granville–Ramaré complement density
+rests on. -/
+theorem natDensity_exactlySquarefree_pair {m m' : ℕ} (h : m ≠ m') :
+    NaturalDensity (exactlySquarefree m ∪ exactlySquarefree m') (eta m + eta m') :=
+  natDensity_union_of_disjoint (exactlySquarefree_disjoint h)
+    (natDensity_eta m) (natDensity_eta m')
+
 end Erdos378

--- a/src/data/proofs/erdos-378/meta.json
+++ b/src/data/proofs/erdos-378/meta.json
@@ -62,12 +62,13 @@
       "complement_density axiom: Granville-Ramaré (1996) Input 2 — {n : squarefreeCount n < r} has density Σ η_m < 1",
       "erdos_378_density_exists / erdos_378_density_positive (no sorries): derived from the two axioms by complementation",
       "erdos_378_density_eq (no sorries, no new axiom): the explicit Granville–Ramaré density formula density(r) = 1 − Σ_{0≤m≤(r-1)/2} η_m — the quantitative answer, pinning the value that density_positive obtains as 1−d to the explicit partial sum of the exact-count densities",
-      "erdos_378, erdos_378_answer (no sorries): combined resolution of both questions"
+      "erdos_378, erdos_378_answer (no sorries): combined resolution of both questions",
+      "Finite additivity of natural density over disjoint sets (natDensity_union_of_disjoint), generalising natDensity_compl; pairwise disjointness of the exact-count strata and the additive two-stratum density η_m + η_m' (natDensity_exactlySquarefree_pair)"
     ],
     "axiomCount": 2,
-    "lineCount": 669,
+    "lineCount": 854,
     "assumptions": "2 axioms, both isolating the deep analytic content of Granville-Ramaré (1996): granville_ramare_density_exists (the density η_m of n with exactly 2m+2 squarefree binomials exists) and complement_density (the set of n with fewer than r squarefree binomials has density Σ_{0≤m≤(r-1)/2} η_m, which is < 1). 0 sorries. All other results, including the resolution of both questions and the parity theorems squarefreeCount_even_of_odd (odd rows have an even count) and squarefreeCount_odd_iff_central_squarefree (an even row has an odd count iff its central binomial C(n,n/2) is squarefree), are fully machine-checked (depend only on propext/Classical.choice/Quot.sound).",
-    "theoremCount": 28,
+    "theoremCount": 31,
     "definitionCount": 8,
     "additionalFiles": [
       "Proofs/Erdos378Aristotle.lean"
@@ -163,9 +164,9 @@
       "Finset"
     ],
     "namespace": "Erdos378",
-    "lineCount": 779,
+    "lineCount": 854,
     "axiomCount": 2,
-    "theoremCount": 30,
+    "theoremCount": 33,
     "definitionCount": 8,
     "path": "Proofs/Erdos378Problem.lean",
     "sorries": 0,


### PR DESCRIPTION
## Summary

Three new theorems for `Erdos378Problem.lean` (Erdős #378, density of squarefree binomial coefficients; `axiomatized` with the 2 Granville–Ramaré axioms), extending the file's self-contained `NaturalDensity` toolkit. **No new axioms.**

- **`natDensity_union_of_disjoint`** — natural density is **finitely additive over disjoint sets**: `Disjoint S T` with densities `dS`, `dT` ⟹ `S ∪ T` has density `dS + dT`. A direct ε/2 argument from the `∀ε∃N₀` definition: on each window `[0,N)` the counts add exactly (`Set.ncard_union_eq` + disjointness), so the union ratio is the sum of ratios. This is the general building block that `natDensity_compl` (the `T = Sᶜ` case) is a special case of.
- **`exactlySquarefree_disjoint`** — the Granville–Ramaré strata `{n | squarefreeCount n = 2m+2}` are pairwise disjoint for distinct `m`.
- **`natDensity_exactlySquarefree_pair`** — hence the two-stratum union `exactlySquarefree m ∪ exactlySquarefree m'` has density `η_m + η_{m'}`, the additive `Σ η_m` structure underlying the complement-density formula.

## Verification

- `./proofs/scripts/docker-build.sh Proofs.Erdos378Problem` → `Build succeeded`.
- `axiomCount` unchanged at **2** (the Granville–Ramaré inputs); the new theorems are derived, 0 sorries.
- `meta.json` synced: `theoremCount` +3, `lineCount` → 854, original contribution recorded.

## Context

The research problem `erdos-378` is already COMPLETE (`axiomatized`, resolved via Granville–Ramaré 1996). This PR is an outward extension of the verified density framework, not a repair.

🤖 Generated with [Claude Code](https://claude.com/claude-code)