### PR TITLE
Enrich Vandermonde convolution (binomial-theorem-oq-06): cross-refs + coverage

### DIFF
--- a/src/data/proofs/binomial-theorem-oq-06/annotations.json
+++ b/src/data/proofs/binomial-theorem-oq-06/annotations.json
@@ -80,5 +80,17 @@
     "significance": "supporting",
     "relatedConcepts": ["Nat.centralBinom", "definitional equality"],
     "prerequisites": ["Nat.centralBinom"]
+  },
+  {
+    "id": "vandermonde-oq06-examples",
+    "proofId": "binomial-theorem-oq-06",
+    "range": { "startLine": 95, "endLine": 108 },
+    "type": "context",
+    "title": "Worked examples: the range form and ∑ C(3,k)² = 20",
+    "content": "Three `example` declarations exercise the lemmas on concrete inputs. The first checks the range form for m=2, n=3, r=2: C(5,2) = ∑_{k=0}^{2} C(2,k)·C(3,2−k). The second instantiates the sum-of-squares corollary at n=3, ∑_{k=0}^{3} C(3,k)² = C(6,3). The third evaluates it numerically: the squares of Pascal's row 3, (1,3,3,1), give 1²+3²+3²+1² = 20 = C(6,3), closed by `rfl` after rewriting with sum_sq_choose. These act as machine-checked sanity checks and as a reader's-eye illustration that the abstract identities compute the expected values.",
+    "mathContext": "$1^2 + 3^2 + 3^2 + 1^2 = 20 = \\binom{6}{3}$",
+    "significance": "context",
+    "relatedConcepts": ["worked examples", "central binomial coefficient", "numeric verification"],
+    "prerequisites": ["Finset.range sums", "rfl evaluation"]
   }
 ]

--- a/src/data/proofs/binomial-theorem-oq-06/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-06/meta.json
@@ -71,7 +71,8 @@
       "**Mathlib has only the antidiagonal form.** Nat.add_choose_eq states Vandermonde as a sum over antidiagonal k; the textbook single-index form over range (r+1) — the way the identity is actually used — required a reindexing step (sum_antidiagonal_eq_sum_range_succ) and was not available.",
       "**The diagonal corollaries are absent from Mathlib.** Neither ∑ C(m,k)C(n,k) = C(m+n,n) nor the famous ∑ C(n,k)² = C(2n,n) appears in Mathlib; both fall out of the range form once one factor is flipped by the symmetry C(n,n−k)=C(n,k) on the summation range.",
       "**Sum of squares of a Pascal row is the central binomial coefficient.** ∑_{k=0}^{n} C(n,k)² = C(2n,n) is the m=n diagonal case: counting n-subsets of a 2n-set by how many come from each half. The Lean proof is a two-line specialization once the symmetric product form is available.",
-      "**Symmetry does the combinatorial work.** The single lemma Nat.choose_symm (C(n,n−k)=C(n,k) for k≤n), applied inside Finset.sum_congr on the range where k≤n holds, is what turns the convolution r−k index into the diagonal k index."
+      "**Symmetry does the combinatorial work.** The single lemma Nat.choose_symm (C(n,n−k)=C(n,k) for k≤n), applied inside Finset.sum_congr on the range where k≤n holds, is what turns the convolution r−k index into the diagonal k index.",
+      "**The exact identity heads a well-studied asymptotic and enumerative circle.** The value it lands on, C(2n,n) = centralBinom n, grows like 4ⁿ/√(πn) (Wallis/Stirling) and, divided by n+1, is the n-th Catalan number — so this elementary sum of squares of a Pascal row sits at the entrance to the central-binomial / Catalan / lattice-path family of results, connecting an exact finite identity to its analytic size and its combinatorial meaning."
     ],
     "exampleSections": [
       {
@@ -105,6 +106,16 @@
       "targetId": "binomial-theorem",
       "relationship": "extends",
       "description": "The parent entry proves the binomial theorem; this entry answers its open question on Vandermonde's convolution identity, adding the classical range form and the diagonal corollaries missing from Mathlib."
+    },
+    {
+      "targetId": "beta-central-binomial-asymptotic",
+      "relationship": "related",
+      "description": "The sum-of-squares identity proved here pins ∑_{k=0}^{n} C(n,k)² to the central binomial coefficient C(2n,n) = centralBinom n exactly; that entry supplies its asymptotic size, C(2n,n) ~ 4ⁿ/√(πn) (Wallis/Stirling via Mathlib's centralBinom_isEquivalent). Together they give the exact closed form and its growth rate for the same quantity."
+    },
+    {
+      "targetId": "catalan-numbers-oq-01",
+      "relationship": "thematic",
+      "description": "The central binomial coefficient C(2n,n) computed here is, up to the factor 1/(n+1), the n-th Catalan number Cₙ = C(2n,n)/(n+1). The lattice-path / Catalan reading of ∑ C(n,k)² = C(2n,n) is exactly the combinatorial interpretation flagged in this entry's open questions, and the Catalan cluster develops that enumerative side."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
Enrichment pass for `binomial-theorem-oq-06` (Vandermonde's convolution and ∑ C(n,k)² = C(2n,n)).

The entry was already strong (verified, 0 axioms) but had a thin cross-reference set (only the parent) and one uncovered code section. Targeted, additive improvements only — no existing content removed:

- **crossReferences 1 → 3**: added `beta-central-binomial-asymptotic` (supplies the asymptotic C(2n,n) ~ 4ⁿ/√(πn) of the exact quantity this entry computes) and `catalan-numbers-oq-01` (Cₙ = C(2n,n)/(n+1); the lattice-path/Catalan reading flagged in this entry's own open questions). Both targets verified to exist.
- **keyInsights 4 → 5**: added one insight situating ∑ C(n,k)² = C(2n,n) at the entrance to the central-binomial / Catalan / lattice-path family, linking the exact identity to its analytic size and combinatorial meaning.
- **annotations 6 → 7**: added coverage for the worked-examples section (lines 95–108), completing full-file annotation coverage.

All claims verified against `Proofs/VandermondeConvolutionOQ06.lean`. meta.json 14.8 KB (well under the 60 KB cap); all collections under caps. JSON validation and search-index checks pass under `pnpm build` (final `tsc` step fails only on a pre-existing missing-node_modules env issue, unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)