### PR TITLE
research(liouville-theorem-oq-03): full-measure complement of W τ is dense (measure/category dichotomy)

### DIFF
--- a/proofs/Proofs/LiouvilleTheoremOQ03.lean
+++ b/proofs/Proofs/LiouvilleTheoremOQ03.lean
@@ -587,4 +587,40 @@ theorem liouville_dimzero_null_yet_residual :
       {x : ℝ | Liouville x} ∈ residual ℝ :=
   ⟨dimH_liouville_eq_zero, volume_liouville_eq_zero, liouville_residual⟩
 
+/-! ## The full-measure complement is also dense
+
+`wellApprox_dense` shows the `τ`-well-approximable numbers are dense.  For `τ > 2` the set
+is Lebesgue-null (`volume_wellApprox_eq_zero`), so its *complement* carries full measure —
+and a full-measure set in `ℝ` is dense, because a null set has empty interior
+(`MeasureTheory.Measure.interior_eq_empty_of_null`, using that `volume` is an open-positive
+measure).  Hence for `τ > 2` **both `W τ` and its complement are dense**: the topological
+face of the measure-versus-category tension, complementary to the comeagre-yet-null
+statement `wellApprox_residual_and_volume_zero`. -/
+
+open MeasureTheory in
+/-- **The complement of `W τ` is dense for `τ > 2`.**  Since `W τ` is Lebesgue-null it has
+empty interior, so its complement (the full-measure set of *badly*-approximable-past-`τ`
+numbers) is dense. -/
+theorem dense_compl_wellApprox {τ : ℝ} (hτ : 2 < τ) : Dense (wellApprox τ)ᶜ :=
+  (interior_eq_empty_iff_dense_compl).mp
+    (MeasureTheory.Measure.interior_eq_empty_of_null (volume_wellApprox_eq_zero hτ))
+
+/-- **A set and its complement both dense.**  For `τ > 2` the `τ`-well-approximable numbers
+`W τ` are dense (`wellApprox_dense`, category/genericity) and so is their complement
+(`dense_compl_wellApprox`, full measure).  This packages the topological form of the
+measure/category dichotomy: neither `W τ` nor its complement has any interior. -/
+theorem wellApprox_dense_and_dense_compl {τ : ℝ} (hτ : 2 < τ) :
+    Dense (wellApprox τ) ∧ Dense (wellApprox τ)ᶜ :=
+  ⟨wellApprox_dense τ, dense_compl_wellApprox hτ⟩
+
+open MeasureTheory in
+/-- **The complement of the Liouville set is dense.**  The Liouville numbers are null
+(`volume_liouville_eq_zero`), hence have empty interior, so the (full-measure) set of
+non-Liouville numbers is dense — even though the Liouville set is itself a dense comeagre
+`Gδ` (`liouville_residual`, `wellApprox_dense`).  Both the generic-but-null Liouville set
+and its full-measure complement are dense. -/
+theorem dense_compl_liouville : Dense {x : ℝ | Liouville x}ᶜ :=
+  (interior_eq_empty_iff_dense_compl).mp
+    (MeasureTheory.Measure.interior_eq_empty_of_null volume_liouville_eq_zero)
+
 end LiouvilleTheoremOQ03

--- a/src/data/proofs/liouville-theorem-oq-03/meta.json
+++ b/src/data/proofs/liouville-theorem-oq-03/meta.json
@@ -23,8 +23,8 @@
     "dateAdded": "2026-06-24",
     "axiomCount": 1,
     "assumptions": "One axiom: `dimH_wellApprox` — the Jarník–Besicovitch dimension formula dimH(W τ) = ENNReal.ofReal(2/τ) for τ ≥ 2. This is the deep theorem of metric Diophantine approximation (Jarník 1931, Besicovitch 1934) and is not yet available in Mathlib (the upper bound requires a covering/Borel–Cantelli Hausdorff-measure estimate; the lower bound a mass-distribution principle / Frostman construction on a Cantor subset). `#print axioms` confirms: the structural lemmas (wellApprox_antitone, liouville_subset_wellApprox, dimH_liouville_le_wellApprox, and the jbDim exponent facts) depend on no axioms beyond the standard foundational trio; only the formula-dependent results (dimH_wellApprox_two, dimH_liouville_le, dimH_liouville_eq_zero, the summary) carry dimH_wellApprox.",
-    "lineCount": 463,
-    "theoremCount": 31,
+    "lineCount": 626,
+    "theoremCount": 44,
     "definitionCount": 2,
     "originalContributions": [
       "wellApprox τ := {x | LiouvilleWith τ x}: the τ-well-approximable sets, packaged on top of Mathlib's LiouvilleWith with the JB exponent in mind",
@@ -134,9 +134,9 @@
     "path": "Proofs/LiouvilleTheoremOQ03.lean",
     "sorries": 0,
     "axiomCount": 1,
-    "theoremCount": 36,
+    "theoremCount": 44,
     "definitionCount": 2,
-    "lineCount": 514
+    "lineCount": 626
   },
   "sorries": 0
 }


### PR DESCRIPTION
## Summary

Adds the **topological face** of the measure-versus-category tension already recorded for the well-approximable sets `W τ` (comeagre yet Lebesgue-null). Since `W τ` is null for $\tau > 2$ (`volume_wellApprox_eq_zero`), it has empty interior (`MeasureTheory.Measure.interior_eq_empty_of_null`, using that `volume` is an open-positive measure), so its **full-measure complement is dense**.

## New theorems

- **`dense_compl_wellApprox`** ($\tau > 2$): `Dense (wellApprox τ)ᶜ`.
- **`wellApprox_dense_and_dense_compl`** ($\tau > 2$): both `W τ` (`wellApprox_dense`, generic) and its complement (full measure) are dense — neither has interior.
- **`dense_compl_liouville`**: the full-measure complement of the Liouville set is dense, even though the Liouville set is itself a dense comeagre $G_\delta$ (`liouville_residual`). Both the generic-but-null Liouville set and its complement are dense.

## Axiom status — **not** axiom-free

These inherit the entry's single Jarník–Besicovitch axiom `dimH_wellApprox` through the measure-zero lemmas (this formalization derives volume-zero from $\dim_H < 1$). `#print axioms` on all three:
`[propext, Classical.choice, LiouvilleTheoremOQ03.dimH_wellApprox, Quot.sound]`.

**No new axiom is introduced**; the entry stays `axiomatized` / `axiomCount: 1`. I also synced the stale gallery meta counts (`theoremCount` 31/36 → 44, `lineCount` 463/514 → 626; `axiomCount` unchanged at 1).

## Verification

- Compiles under Lean v4.26.0 on the full Mathlib `LEAN_PATH`, 0 sorries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)