### PR TITLE
Enrich 3 gallery entries: annotation coverage + cross-references (batch)

### DIFF
--- a/src/data/proofs/binomial-theorem-oq-03-oq-03/annotations.json
+++ b/src/data/proofs/binomial-theorem-oq-03-oq-03/annotations.json
@@ -1,5 +1,17 @@
 [
   {
+    "id": "ann-agg-header",
+    "proofId": "binomial-theorem-oq-03-oq-03",
+    "range": { "startLine": 1, "endLine": 74 },
+    "type": "concept",
+    "title": "The aggregation property and the generating-function strategy",
+    "content": "The framing docstring states the goal and the method in advance. Goal: the multinomial family's defining closure property — for ANY union of categories A ⊆ s, the aggregated count X_A = Σ_{i∈A} X_i of a Multinomial(n, p) vector is again Binomial(n, p_A) with p_A = Σ_{i∈A} p_i. The parent thread built the binomial distribution from the binomial theorem; a sibling proved the single-coordinate marginal X_{i₀} ~ Binomial(n, p_{i₀}); this file gives the genuine generalization. Method: the multinomial moment-generating identity (a repackaging of the multinomial theorem) is fed the block indicator g(i) = if i∈A then t else 1, collapsing the generating product to t^{Σ_{i∈A} k(i)} = t^{X_A} and — using Σ_{i∈s} p_i = 1 — the PGF base to p_A·t + (1−p_A), so E[t^{X_A}] = (p_A·t + (1−p_A))^n, exactly the Binomial(n, p_A) PGF. The only change from the single-coordinate proof is swapping the equality indicator (if i = i₀) for the membership indicator (if i ∈ A), which is why aggregation is essentially free here. The block of imports and namespace opening (Mathlib, Finset, BigOperators) makes the file self-contained.",
+    "mathContext": "$X_A=\\sum_{i\\in A}X_i\\sim\\mathrm{Binomial}(n,p_A)$, $p_A=\\sum_{i\\in A}p_i$. Via the PGF with $g(i)=\\mathbf{1}[i\\in A]\\,t+\\mathbf{1}[i\\notin A]$: $\\;E[t^{X_A}]=(p_A t+(1-p_A))^n$.",
+    "significance": "context",
+    "relatedConcepts": ["multinomial distribution", "aggregation / lumping", "probability generating function", "binomial closure"],
+    "prerequisites": ["the parent binomial-distribution entry", "block / membership indicators", "the multinomial theorem"]
+  },
+  {
     "id": "ann-pmf-mgf",
     "proofId": "binomial-theorem-oq-03-oq-03",
     "range": { "startLine": 76, "endLine": 95 },

--- a/src/data/proofs/birthday-problem-oq-03-oq-01-oq-01-oq-03/annotations.json
+++ b/src/data/proofs/birthday-problem-oq-03-oq-01-oq-01-oq-03/annotations.json
@@ -70,5 +70,17 @@
     "significance": "key",
     "relatedConcepts": ["asymptotic equivalence", "error bound", "absolute value"],
     "prerequisites": ["two-sided bound", "abs_le"]
+  },
+  {
+    "id": "bday-oq03010103-ann-summary",
+    "proofId": "birthday-problem-oq-03-oq-01-oq-01-oq-03",
+    "range": { "startLine": 95, "endLine": 119 },
+    "type": "context",
+    "title": "Summary and axiom-free verification",
+    "content": "The closing block records the file's three results — cubeRoot_cube ((x³)^(1/3) = x for x ≥ 0), birthday_triple_threshold (the two-sided sandwich (6d²ln2)^(1/3) ≤ n ≤ (6d²ln2)^(1/3) + 2), and birthday_triple_threshold_gap (the packaged |n − (6d²ln2)^(1/3)| ≤ 2) — and answers the parent's OQ-03: the k = 3 (triple-coincidence) threshold is (6d²ln2)^(1/3) to leading order with a bounded, d-independent additive error at most 2, proved by the cube-root sandwich (n−2)³ ≤ n(n−1)(n−2) ≤ n³. The trailing #print axioms commands are the machine-checked confirmation of the 0-axiom claim: both main theorems reduce to the foundational axioms alone, with no sorry and no native_decide.",
+    "mathContext": "$n \\approx (6 d^2 \\ln 2)^{1/3}$, rigorously $\\bigl|n-(6d^2\\ln 2)^{1/3}\\bigr|\\le 2$; verified axiom-free via $(n-2)^3 \\le n(n-1)(n-2) \\le n^3$.",
+    "significance": "context",
+    "relatedConcepts": ["birthday problem", "triple coincidence", "leading-order asymptotics", "axiom-free verification"],
+    "prerequisites": ["#print axioms", "the cube-root sandwich"]
   }
 ]

--- a/src/data/proofs/british-flag-theorem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/british-flag-theorem-oq-01-oq-01/meta.json
@@ -96,6 +96,21 @@
       "targetId": "british-flag-theorem-oq-01",
       "relationship": "extends",
       "description": "Parent: the British Flag Theorem in the coordinate plane ℝ². This entry generalizes it to an arbitrary parallelogram in any real inner product space, with the defect 2⟪u,v⟫ measuring the deviation from a right angle — the parent's first open question."
+    },
+    {
+      "targetId": "british-flag-theorem-oq-01-oq-02",
+      "relationship": "related",
+      "description": "Sibling that answers this entry's first open question (orthotopes vs. parallelepipeds): it pushes the same norm-expansion identity from the 4-vertex parallelogram to an n-dimensional box, summing squared distances over the 2ⁿ vertices with alternating signs and expressing the defect through the pairwise edge inner products Σ_{i<j} ±2⟪uᵢ,uⱼ⟫. This 2-D parallelogram case is the n = 2 instance."
+    },
+    {
+      "targetId": "british-flag-theorem-oq-01-oq-01-oq-02",
+      "relationship": "extended by",
+      "description": "Direct child answering this entry's second open question (weighted / affine-combination version): the Weighted Leibniz identity replaces the four parallelogram corners by a weighted affine simplex, connecting the defect to the Leibniz / Stewart relations and absorbing the parallelogram identity proved here as a special case."
+    },
+    {
+      "targetId": "law-of-cosines",
+      "relationship": "related",
+      "description": "The defect value 2⟪u,v⟫ isolated here is exactly the cross term of the law of cosines (|A+u|² relative to |A|² and ‖u‖² differs by 2⟪·,u⟫). The British-flag defect vanishes precisely when u ⊥ v — the same orthogonality that collapses the cosine term — so the rectangle case of the theorem is the law of cosines with a right angle."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
Batch of purely-additive gallery enrichments (each verified against its Lean source; no existing content removed):

**1. `binomial-theorem-oq-03-oq-03` (multinomial aggregation/lumping)** — added a `concept` annotation covering the previously-uncovered 74-line framing docstring + imports (annotations 5 → 6). States the aggregation goal (X_A ~ Binomial(n, p_A) for any A ⊆ s) and the PGF method up front.

**2. `british-flag-theorem-oq-01-oq-01` (Parallelogram Defect Identity)** — crossReferences 1 → 4: the n-dimensional orthotope sibling (`british-flag-theorem-oq-01-oq-02`, answering this entry's own first open question), the Weighted Leibniz child (`british-flag-theorem-oq-01-oq-01-oq-02`, answering its second), and `law-of-cosines` (the defect 2⟪u,v⟫ is the cosine cross term, vanishing exactly when u ⊥ v).

**3. `birthday-problem-oq-03-oq-01-oq-01-oq-03` (triple-coincidence threshold)** — added a `context` annotation covering the previously-uncovered Summary docstring + `#print axioms` block (annotations 6 → 7). Recaps the three theorems and the (6d²ln2)^{1/3} ± 2 threshold, and flags the `#print axioms` commands as the machine-checked confirmation of the 0-axiom claim.

All cross-ref targets verified to exist; all JSON validates; each entry well under the 60 KB cap with all collections under caps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)