### PR TITLE
Enrich Vandermonde Convolution (binomial-theorem-oq-06): multinomial sibling cross-ref

### DIFF
--- a/src/data/proofs/binomial-theorem-oq-06/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-06/meta.json
@@ -116,6 +116,11 @@
       "targetId": "catalan-numbers-oq-01",
       "relationship": "thematic",
       "description": "The central binomial coefficient C(2n,n) computed here is, up to the factor 1/(n+1), the n-th Catalan number Cₙ = C(2n,n)/(n+1). The lattice-path / Catalan reading of ∑ C(n,k)² = C(2n,n) is exactly the combinatorial interpretation flagged in this entry's open questions, and the Catalan cluster develops that enumerative side."
+    },
+    {
+      "targetId": "binomial-theorem-oq-03-oq-03",
+      "relationship": "related",
+      "description": "Sibling in the binomial-theorem thread. Vandermonde's convolution here counts r objects drawn from a set split into two blocks of sizes m and n; that entry carries the same 'partition into blocks and count' idea to arbitrarily many categories, deriving the multinomial distribution's aggregation (lumping) property from the multinomial theorem."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
Enrichment pass for `binomial-theorem-oq-06` (quality 96). The entry was already rich (5 keyInsights, 4 sections with mathContext, 6 annotations, 3 refs; concurrent passes had added the central-binomial/Catalan cross-refs). One genuine gap remained: no link to the multinomial sibling.

- **Added crossReference** to `binomial-theorem-oq-03-oq-03`: Vandermonde's convolution counts r objects from a set split into two blocks of sizes m, n; the multinomial-aggregation entry carries the same 'partition into blocks and count' idea to arbitrarily many categories. crossReferences 3 → 4 (well under the 20 cap).

Target existence verified on disk. Validation: JSON parses; meta.json within all size caps.