### PR TITLE
research(erdos-729-oq-02): Kummer digit-sum additive form + digit-sum subadditivity + prime-divisibility criteria

### DIFF
--- a/proofs/Proofs/Erdos729LegendreGeneral.lean
+++ b/proofs/Proofs/Erdos729LegendreGeneral.lean
@@ -165,6 +165,142 @@ theorem padicValNat_factorial_pos_iff (p n : ℕ) (hp : p.Prime) :
     0 < padicValNat p n.factorial ↔ p ≤ n := by
   rw [Nat.pos_iff_ne_zero, ne_eq, padicValNat_factorial_eq_zero_iff p n hp, Nat.not_lt]
 
+/-! ## Kummer's theorem in additive digit-sum form, and its divisibility corollaries
+
+The general Legendre identity `(p-1)·v_p(n!) = n − s_p(n)` above is precisely the
+starting point flagged in `sub_one_mul_padicValNat_factorial_digitSum`.  Applying
+it to `(m+n)!`, `m!`, `n!` and combining with the valuation-additive factorisation
+`C(m+n,m)·m!·n! = (m+n)!` yields the **carry-free additive form of Kummer's
+theorem**:
+
+    (p−1)·v_p(C(m+n,m)) + s_p(m+n) = s_p(m) + s_p(n).
+
+Mathlib carries Kummer only in the *truncated-subtraction* shape
+`sub_one_mul_padicValNat_choose_eq_sub_sum_digits'`
+(`(p-1)·v_p = s_p(k)+s_p(n) − s_p(n+k)` in ℕ).  The additive rearrangement below
+is subtraction-free, which is what makes the two genuinely new corollaries fall
+out cleanly and which Mathlib does **not** state:
+
+  * `digitSum_add_le` — base-`p` **digit-sum subadditivity** `s_p(m+n) ≤ s_p(m)+s_p(n)`
+    (the base-`p` Hamming-weight triangle inequality; not in Mathlib), and
+  * `not_dvd_choose_iff_digitSum_add` / `dvd_choose_iff_digitSum_lt` — the sharp
+    **digit-sum criterion for whether a prime divides a binomial coefficient**:
+    `p ∤ C(m+n,m) ↔ s_p(m+n) = s_p(m)+s_p(n)` (no carries), and its negation
+    `p ∣ C(m+n,m) ↔ s_p(m+n) < s_p(m)+s_p(n)` (at least one carry). -/
+
+/-- **Kummer's theorem, carry-free additive form.**  For every prime `p`,
+
+  `(p − 1)·v_p(C(m+n, m)) + s_p(m+n) = s_p(m) + s_p(n)`.
+
+The subtraction-free rearrangement of Kummer's theorem.  Proof: the factorisation
+`C(m+n,m)·m!·n! = (m+n)!` makes `v_p` additive (`padicValNat.mul`, all factors
+nonzero), so `v_p((m+n)!) = v_p(C) + v_p(m!) + v_p(n!)`; scaling by `p−1` and
+substituting the Legendre identity `(p−1)·v_p(k!) = k − s_p(k)`
+(`sub_one_mul_padicValNat_factorial_digitSum`) for each of `m`, `n`, `m+n`, the
+`k` terms cancel and `omega` clears the (bounded) natural subtractions using
+`s_p(k) ≤ k`. -/
+theorem sub_one_mul_padicValNat_choose_add_digitSum (p m n : ℕ) (hp : p.Prime) :
+    (p - 1) * padicValNat p ((m + n).choose m) + digitSum p (m + n)
+      = digitSum p m + digitSum p n := by
+  haveI : Fact p.Prime := ⟨hp⟩
+  have hstep : (m + n).choose m * m.factorial * n.factorial = (m + n).factorial := by
+    have h := Nat.choose_mul_factorial_mul_factorial (Nat.le_add_right m n)
+    simpa [Nat.add_sub_cancel_left] using h
+  have hcne : (m + n).choose m ≠ 0 := (Nat.choose_pos (Nat.le_add_right m n)).ne'
+  have hmf : m.factorial ≠ 0 := Nat.factorial_ne_zero m
+  have hnf : n.factorial ≠ 0 := Nat.factorial_ne_zero n
+  have hval : padicValNat p (m + n).factorial
+      = padicValNat p ((m + n).choose m) + padicValNat p m.factorial
+        + padicValNat p n.factorial := by
+    rw [← hstep, padicValNat.mul (mul_ne_zero hcne hmf) hnf, padicValNat.mul hcne hmf]
+  have h2 : (p - 1) * padicValNat p ((m + n).choose m)
+      + (p - 1) * padicValNat p m.factorial
+      + (p - 1) * padicValNat p n.factorial
+      = (p - 1) * padicValNat p (m + n).factorial := by
+    rw [hval, Nat.mul_add, Nat.mul_add]
+  have leg_m := sub_one_mul_padicValNat_factorial_digitSum p m hp
+  have leg_n := sub_one_mul_padicValNat_factorial_digitSum p n hp
+  have leg_mn := sub_one_mul_padicValNat_factorial_digitSum p (m + n) hp
+  have hsm : digitSum p m ≤ m := by simpa [digitSum] using Nat.digit_sum_le p m
+  have hsn : digitSum p n ≤ n := by simpa [digitSum] using Nat.digit_sum_le p n
+  have hsmn : digitSum p (m + n) ≤ m + n := by
+    simpa [digitSum] using Nat.digit_sum_le p (m + n)
+  omega
+
+/-- **Base-`p` digit-sum subadditivity** (the base-`p` Hamming-weight triangle
+inequality): for every prime `p`,
+
+  `s_p(m + n) ≤ s_p(m) + s_p(n)`.
+
+Adding never *increases* the total base-`p` digit sum — carries only merge digits.
+Immediate from the carry-free Kummer identity: the shortfall
+`s_p(m)+s_p(n) − s_p(m+n)` equals `(p−1)·v_p(C(m+n,m)) ≥ 0`.  Not a named Mathlib
+lemma. -/
+theorem digitSum_add_le (p m n : ℕ) (hp : p.Prime) :
+    digitSum p (m + n) ≤ digitSum p m + digitSum p n := by
+  have h := sub_one_mul_padicValNat_choose_add_digitSum p m n hp
+  omega
+
+/-- **Kummer's theorem, division form (gallery `digitSum` shape).**  For every
+prime `p`,
+
+  `v_p(C(m+n, m)) = (s_p(m) + s_p(n) − s_p(m+n)) / (p − 1)`,
+
+the exact count of base-`p` carries when adding `m` and `n`.  Obtained from the
+additive form by transposing `s_p(m+n)` and dividing by `p − 1 > 0`
+(`Nat.mul_div_cancel_left`); the numerator subtraction is exact by
+`digitSum_add_le`.  Mathlib states only the multiplied subtraction form, not this
+division form. -/
+theorem padicValNat_choose_eq_div (p m n : ℕ) (hp : p.Prime) :
+    padicValNat p ((m + n).choose m)
+      = (digitSum p m + digitSum p n - digitSum p (m + n)) / (p - 1) := by
+  have hadd := sub_one_mul_padicValNat_choose_add_digitSum p m n hp
+  have hp1 : 0 < p - 1 := by have := hp.two_le; omega
+  have hmul : (p - 1) * padicValNat p ((m + n).choose m)
+      = digitSum p m + digitSum p n - digitSum p (m + n) := by omega
+  rw [← hmul, Nat.mul_div_cancel_left _ hp1]
+
+/-- **Digit-sum criterion for a prime NOT dividing a binomial coefficient.**  For
+every prime `p`,
+
+  `p ∤ C(m+n, m) ↔ s_p(m+n) = s_p(m) + s_p(n)`,
+
+i.e. `p` misses the binomial exactly when adding `m` and `n` in base `p` produces
+no carries (Kummer's carry count is `0`).  The `p = 2` case is the classical
+"`C(m+n,m)` is odd iff the binary supports of `m` and `n` are disjoint".  Derived
+from the additive Kummer identity via `dvd_iff_padicValNat_ne_zero` and
+`p − 1 > 0`.  Not a named Mathlib lemma. -/
+theorem not_dvd_choose_iff_digitSum_add (p m n : ℕ) (hp : p.Prime) :
+    ¬ (p ∣ (m + n).choose m) ↔ digitSum p (m + n) = digitSum p m + digitSum p n := by
+  haveI : Fact p.Prime := ⟨hp⟩
+  have hcne : (m + n).choose m ≠ 0 := (Nat.choose_pos (Nat.le_add_right m n)).ne'
+  have hadd := sub_one_mul_padicValNat_choose_add_digitSum p m n hp
+  have hp1 : 0 < p - 1 := by have := hp.two_le; omega
+  rw [dvd_iff_padicValNat_ne_zero hcne, not_not]
+  constructor
+  · intro h
+    rw [h] at hadd
+    omega
+  · intro h
+    have hz : (p - 1) * padicValNat p ((m + n).choose m) = 0 := by omega
+    rcases Nat.mul_eq_zero.mp hz with h1 | h2
+    · omega
+    · exact h2
+
+/-- **Digit-sum criterion for a prime dividing a binomial coefficient.**  The
+complement of `not_dvd_choose_iff_digitSum_add`: for every prime `p`,
+
+  `p ∣ C(m+n, m) ↔ s_p(m+n) < s_p(m) + s_p(n)`,
+
+i.e. `p` divides the binomial exactly when adding `m` and `n` in base `p` produces
+at least one carry.  Strictness comes from pairing the non-divisibility criterion
+with digit-sum subadditivity `s_p(m+n) ≤ s_p(m)+s_p(n)`. -/
+theorem dvd_choose_iff_digitSum_lt (p m n : ℕ) (hp : p.Prime) :
+    p ∣ (m + n).choose m ↔ digitSum p (m + n) < digitSum p m + digitSum p n := by
+  have hle := digitSum_add_le p m n hp
+  rw [← not_iff_not, not_dvd_choose_iff_digitSum_add p m n hp, not_lt]
+  omega
+
 -- The numerical content (v_p(n!) = (n - s_p(n))/(p-1) for many p, n) is certified
 -- independently in `research/problems/erdos-729-oq-02/verify_legendre_general.py`
 -- (no Lean `decide` on `Nat.digits`, which is well-founded and does not reduce
@@ -179,5 +315,10 @@ theorem padicValNat_factorial_pos_iff (p n : ℕ) (hp : p.Prime) :
 #check @modEq_digitSum
 #check @padicValNat_factorial_eq_zero_iff
 #check @padicValNat_factorial_pos_iff
+#check @sub_one_mul_padicValNat_choose_add_digitSum
+#check @digitSum_add_le
+#check @padicValNat_choose_eq_div
+#check @not_dvd_choose_iff_digitSum_add
+#check @dvd_choose_iff_digitSum_lt
 
 end Erdos729Legendre

--- a/research/problems/erdos-729-oq-02/knowledge.md
+++ b/research/problems/erdos-729-oq-02/knowledge.md
@@ -211,3 +211,35 @@ proved `(p-1)·v_p(n!) = n-1 ⟺ s_p(n)=1` but **explicitly delegated** the equi
 Only the deep `barreto_leeham_theorem` axiom in the parent remains. The elementary
 p-adic theory (Legendre, Kummer/multinomial carries, digit-sum recurrences, and now
 the digit-sum-one ↔ prime-power characterization) is complete and axiom-free.
+
+## Session 2026-07-11 (researcher-5) - Kummer digit-sum form + subadditivity + divisibility criteria
+
+**Mode**: REVISIT (RICH problem, core already solved)
+**Outcome**: progress (outward extension, 5 new axiom-free theorems)
+
+### What I Did
+- Confirmed the main-file axiom fix (nextStep #1) was already landed: Erdos729Problem.lean is down to 1 axiom (barreto_leeham_theorem only).
+- Checked Mathlib v4.26.0: Kummer's theorem IS present (`sub_one_mul_padicValNat_choose_eq_sub_sum_digits`, carries form `padicValNat_choose'`) — so re-proving Kummer would be duplication. Instead extended in directions Mathlib does NOT cover.
+- Added 5 axiom-free theorems to `Erdos729LegendreGeneral.lean`, all building on the existing `sub_one_mul_padicValNat_factorial_digitSum`:
+  - `sub_one_mul_padicValNat_choose_add_digitSum`: carry-free additive Kummer.
+  - `digitSum_add_le`: base-p digit-sum subadditivity (Mathlib gap).
+  - `padicValNat_choose_eq_div`: division-form Kummer in gallery digitSum shape.
+  - `not_dvd_choose_iff_digitSum_add`: p∤C(m+n,m) ↔ no base-p carries (Mathlib gap).
+  - `dvd_choose_iff_digitSum_lt`: p∣C(m+n,m) ↔ ≥1 carry.
+
+### Key Findings
+- The subtraction-free additive rearrangement of Kummer is the right engine: subadditivity and both divisibility criteria drop out as one-line `omega` corollaries once digit sums are bounded by their arguments.
+- Mathlib genuinely lacks digit-sum subadditivity and the prime-non-divisibility digit-sum criterion; both are general-purpose and upstreamable.
+
+### Verification
+- Host `lean` (v4.26.0) elaboration: exit 0, no errors/warnings.
+- `#print axioms` on all 5: `[propext, Classical.choice, Quot.sound]` only — axiom-free.
+- Docker build: transient SIGBUS-135 at C-codegen phase after a clean 2.3s elaboration (host-lean fallback used to verify).
+
+### Files Modified
+- proofs/Proofs/Erdos729LegendreGeneral.lean (+~130 lines, 5 theorems)
+- src/data/research/problems/erdos-729-oq-02.json (knowledge)
+
+### Next Steps
+- Consider upstreaming `digitSum_add_le` and `not_dvd_choose_iff_digitSum_add` to Mathlib.
+- Equality/sharp-boundary case connects to Mathlib's carries-Finset form of Kummer.

--- a/src/data/research/problems/erdos-729-oq-02.json
+++ b/src/data/research/problems/erdos-729-oq-02.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "AXIOM ELIMINATION (researcher-1 2026-07-08): removed the UNSOUND barreto_leeham_bound axiom (Erdos729Problem.lean 2->1 axioms). It asserted a FALSE proposition — for any D it fails at n in {0,1} (e.g. n=1,a=b=1: DividesFactorialModSmall holds yet a+b=2 > 1+D*log 1 = 1), the same small-n defect as the retired erdos_1968_classical. Since DividesFactorialModSmall n a b C unfolds to exists k (small primes) with k*a!*b! | n!, which forces a!*b! | n!, the SOUND uniform form (2<=n) is a corollary of the axiom-free Erdos729DigitSum.erdos_1968_uniform. Converted the axiom to a verified theorem and tightened erdos_729_summary with 2<=n. Only barreto_leeham_theorem (the deep Barreto-Leeham resolution) remains as a documented axiom. VERIFIED docker Built; #print axioms: barreto_leeham_bound axiom-free, erdos_729_summary depends only on barreto_leeham_theorem.",
+    "progressSummary": "SOLVED-CORE + OUTWARD EXTENSION (researcher-5 2026-07-11): Legendre core done earlier; this session added 5 axiom-free theorems building on sub_one_mul_padicValNat_factorial_digitSum — carry-free additive Kummer, base-p digit-sum subadditivity (Mathlib gap), and the sharp digit-sum divisibility criteria p∤C ↔ no carries / p∣C ↔ ≥1 carry (Mathlib gap). Host-lean verified 0 errors, #print axioms = [propext,Classical.choice,Quot.sound] only. Docker build hits transient SIGBUS-135 at C-codegen after clean 2.3s elaboration.",
     "builtItems": [
       "digitSum_prime_mul_add (p n r)(hp:1<p)(hr:r<p): (Nat.digits p (p*n+r)).sum = (Nat.digits p n).sum + r -- general base-p digit left-shift, Erdos729LegendrePrimeRecurrence.lean",
       "digitSum_prime_mul (p n)(hp:1<p): s_p(p*n)=s_p(n) -- r=0 invariant",
@@ -49,7 +49,12 @@
       "Erdos729DigitSumBound.lean: digitSum_two_le_log — s₂(m) ≤ Nat.log 2 m + 1 (List.sum_le_card_nsmul + Nat.digits_len)",
       "Erdos729DigitSumBound.lean: erdos_two_adic_bound_log — log form a+b ≤ n+(log₂a+1)+(log₂b+1)",
       "natLog_two_mul_log_two_le_log (Erdos729DigitSumBound.lean): (⌊log₂ n⌋:ℝ)·log 2 ≤ log n via Real.log of 2^⌊log₂n⌋≤n + Real.log_pow.",
-      "erdos_1968_uniform (Erdos729DigitSumBound.lean): ∃ uniform C=4/log2>0, ∀ n≥2 ∀ a,b, a!b!∣n! → (a+b:ℝ)≤n+C·log n — axiom-free honest Erdős-1968; correct replacement for the unsound/vacuous main-file axiom erdos_1968_classical."
+      "erdos_1968_uniform (Erdos729DigitSumBound.lean): ∃ uniform C=4/log2>0, ∀ n≥2 ∀ a,b, a!b!∣n! → (a+b:ℝ)≤n+C·log n — axiom-free honest Erdős-1968; correct replacement for the unsound/vacuous main-file axiom erdos_1968_classical.",
+      "Erdos729LegendreGeneral.lean: sub_one_mul_padicValNat_choose_add_digitSum — carry-free additive Kummer (p-1)·v_p(C(m+n,m))+s_p(m+n)=s_p(m)+s_p(n); via C·m!·n!=(m+n)! (padicValNat.mul additivity) + Legendre per m,n,m+n + omega on bounded ℕ subtraction",
+      "Erdos729LegendreGeneral.lean: digitSum_add_le — base-p digit-sum SUBADDITIVITY s_p(m+n)≤s_p(m)+s_p(n) (base-p Hamming-weight triangle ineq; NOT in Mathlib), corollary of additive Kummer since shortfall=(p-1)·v_p≥0",
+      "Erdos729LegendreGeneral.lean: not_dvd_choose_iff_digitSum_add — p∤C(m+n,m) ↔ s_p(m+n)=s_p(m)+s_p(n) (no base-p carries); via dvd_iff_padicValNat_ne_zero; NOT in Mathlib",
+      "Erdos729LegendreGeneral.lean: dvd_choose_iff_digitSum_lt — p∣C(m+n,m) ↔ s_p(m+n)<s_p(m)+s_p(n) (≥1 carry); complement via subadditivity",
+      "Erdos729LegendreGeneral.lean: padicValNat_choose_eq_div — division-form Kummer in gallery digitSum shape v_p(C)=(s_p(m)+s_p(n)-s_p(m+n))/(p-1)"
     ],
     "insights": [
       "The 2-adic doubling recurrence v_2((2n)!)=n+v_2(n!) is the p=2 shadow of a general-prime law: for EVERY prime p and residue 0<=r<p, v_p((p*n+r)!) = n + v_p(n!), the increment n being INDEPENDENT of r. So all p consecutive arguments pn, pn+1, ..., pn+(p-1) share one valuation step. Proof: (p-1)*v_p(m!)=m-s_p(m) (Mathlib) plus s_p(p*n+r)=s_p(n)+r and (p-1)*n+n=p*n, then cancel p-1>0. Not a named Mathlib lemma.",
@@ -58,13 +63,15 @@
       "The exact 2-adic core of the Erdős (1968) constraint is elementary and axiom-free: a!·b! ∣ n! ⟹ v₂(a!)+v₂(b!) ≤ v₂(n!) (factorization is monotone under divisibility and additive over products), so by Legendre v₂(m!)=m−s₂(m) one gets the SHARP subtraction-free bound a + b ≤ n + s₂(a) + s₂(b). The excess a+b−n never exceeds the total 1-bit count of the two parts — no O(·) needed. The log form a+b ≤ n+(⌊log₂a⌋+1)+(⌊log₂b⌋+1) follows from s₂(m) ≤ Nat.log 2 m + 1 (each binary digit ≤ 1, digit count = log₂+1). Parent file carries this only as the deep axiom erdos_1968_classical.",
       "The main-file axiom erdos_1968_classical (∀ n a b, a!b!∣n! → ∃C>0, a+b≤n+C·log n) is defective TWO ways: unsound at n∈{0,1} (Real.log=0 there, but a+b can be 2>n), and mathematically VACUOUS for n≥2 because the ∃C sits INSIDE the ∀ (pick C=(a+b)/log n). The meaningful form puts a single uniform C outside the quantifiers; that form IS provable axiom-free with C=4/log2 for n≥2.",
       "Nat.log→Real.log bridge: 2^⌊log₂ n⌋≤n (Nat.pow_log_le_self) ⟹ (via Real.log monotone + Real.log_pow) ⌊log₂ n⌋·log2≤log n ⟹ ⌊log₂ n⌋≤log n/log2. Combined with a,b≤n (from a!∣a!b!∣n! ⟹ a!≤n! ⟹ a≤n via Nat.factorial_lt) the ℕ digit-sum bound a+b≤n+2⌊log₂n⌋+2 lifts to the real n+O(log n) shape with explicit constant.",
-      "v4.26 rename: le_div_iff → le_div_iff₀ (one_le_div still exists as an alias in Field/Basic)."
+      "v4.26 rename: le_div_iff → le_div_iff₀ (one_le_div still exists as an alias in Field/Basic).",
+      "Mathlib DOES carry Kummer: sub_one_mul_padicValNat_choose_eq_sub_sum_digits(_) and padicValNat_choose(_) (carries form) in NumberTheory/Padics/PadicVal/Basic.lean — but only the truncated-ℕ-subtraction shape. The subtraction-free additive rearrangement (p-1)·v_p(C)+s_p(m+n)=s_p(m)+s_p(n) is cleaner and is what yields subadditivity + the divisibility criteria as one-line omega corollaries.",
+      "Genuine Mathlib GAPS confirmed (v4.26.0): (1) base-p digit-sum subadditivity s_p(m+n)≤s_p(m)+s_p(n) — only digit_sum_le (s_p(n)≤n) exists; (2) digit-sum criterion p∤C(m+n,m) ↔ s_p(m+n)=s_p(m)+s_p(n). Both now proven axiom-free in the gallery. p=2 case of the criterion = classical odd-binomial ↔ disjoint binary supports (Lucas/Kummer)."
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "PROPOSE main-file fix (auditor/follow-up): replace the unsound axiom erdos_1968_classical with either a `2 ≤ n` hypothesis + reference to erdos_1968_uniform, or import the companion and delete the axiom (reduces main-file axiomCount 3→2). erdos_729_statement's first conjunct is currently backed by a false axiom.",
-      "Kummer refinement: s₂(a)+s₂(b)−s₂(n) = number of base-2 carries adding a and n−a; characterize equality a+b=n+carries.",
-      "The two barreto_leeham axioms (mod-small-primes resolution) are the genuinely deep research inputs — not Mathlib-eliminable; leave and document."
+      "The two barreto_leeham axioms in Erdos729Problem.lean remain the genuine deep research inputs — not Mathlib-eliminable.",
+      "Possible: consider upstreaming digitSum_add_le (digit-sum subadditivity) and the not_dvd_choose criterion to Mathlib — both are general-purpose and fill obvious gaps.",
+      "Possible sharp-boundary follow-up: equality case of subadditivity s_p(m+n)=s_p(m)+s_p(n) is EXACTLY the no-carry condition = p∤C(m+n,m); a fully carry-based characterization would connect to Mathlib padicValNat_choose (carries Finset form)."
     ],
     "markdown": "# Knowledge Base: erdos-729-oq-02\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },


### PR DESCRIPTION
## Summary

Outward extension of **erdos-729-oq-02** (Legendre's formula for the p-adic valuation of factorials). The Legendre core was already proven axiom-free; this PR adds 5 axiom-free theorems to `proofs/Proofs/Erdos729LegendreGeneral.lean`, all built on the existing general Legendre identity `sub_one_mul_padicValNat_factorial_digitSum`.

I first checked Mathlib v4.26.0: **Kummer's theorem is already present** (`sub_one_mul_padicValNat_choose_eq_sub_sum_digits`, and the carries form `padicValNat_choose'`), but only in the *truncated-ℕ-subtraction* shape. So rather than duplicate it, this PR proves the subtraction-free rearrangement and the two genuine gaps that fall out of it.

## New theorems (all axiom-free)

| Theorem | Statement | In Mathlib? |
|---|---|---|
| `sub_one_mul_padicValNat_choose_add_digitSum` | `(p-1)·v_p(C(m+n,m)) + s_p(m+n) = s_p(m)+s_p(n)` (carry-free additive Kummer) | only truncated-subtraction form |
| `digitSum_add_le` | `s_p(m+n) ≤ s_p(m)+s_p(n)` (base-p digit-sum **subadditivity**) | **no** |
| `not_dvd_choose_iff_digitSum_add` | `p ∤ C(m+n,m) ↔ s_p(m+n) = s_p(m)+s_p(n)` (no base-p carries) | **no** |
| `dvd_choose_iff_digitSum_lt` | `p ∣ C(m+n,m) ↔ s_p(m+n) < s_p(m)+s_p(n)` (≥1 carry) | **no** |
| `padicValNat_choose_eq_div` | `v_p(C(m+n,m)) = (s_p(m)+s_p(n)-s_p(m+n))/(p-1)` (division-form Kummer, gallery shape) | division form: no |

The `p = 2` case of the divisibility criterion is the classical "`C(m+n,m)` is odd iff the binary supports of `m` and `n` are disjoint."

## Proof method

The engine is the factorisation `C(m+n,m)·m!·n! = (m+n)!`, which makes `v_p` additive (`padicValNat.mul`, all factors nonzero); scaling by `p-1` and substituting the Legendre identity for each of `m`, `n`, `m+n`, the argument terms cancel and `omega` clears the bounded ℕ subtractions (using `s_p(k) ≤ k`). Subadditivity and both divisibility criteria are then one-line `omega`/`dvd_iff_padicValNat_ne_zero` corollaries.

## Verification

- Host `lean` (v4.26.0) elaboration: **exit 0, no errors/warnings** (full `#check` output confirms all types).
- `#print axioms` on all 5 theorems: `[propext, Classical.choice, Quot.sound]` only — **axiom-free** (no `sorryAx`, no `Lean.ofReduceBool`).
- Docker build hits a transient **SIGBUS (exit 135)** at the C-codegen phase *after* a clean 2.3s elaboration; verified via the documented host-`lean` fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)