### PR TITLE
research(erdos-666-incomplete-01): hypercube vertex-count strict monotonicity + injectivity

### DIFF
--- a/proofs/Proofs/Erdos666Problem.lean
+++ b/proofs/Proofs/Erdos666Problem.lean
@@ -140,6 +140,30 @@ recoverable from `|E(Qₙ)|`. -/
 theorem hypercubeEdges_strictMono : StrictMono hypercubeEdges :=
   strictMono_nat_of_lt_succ hypercubeEdges_lt_succ
 
+/-- **The vertex count strictly grows with each dimension:** `|V(Qₙ)| < |V(Q_{n+1})|`.  The
+vertex-count analogue of `hypercubeEdges_lt_succ`: passing to `Q_{n+1}` glues two copies of
+`Qₙ` (`hypercubeVertices_succ`), and since `Qₙ` has at least one vertex the count strictly
+increases. -/
+theorem hypercubeVertices_lt_succ (n : ℕ) :
+    hypercubeVertices n < hypercubeVertices (n + 1) := by
+  rw [hypercubeVertices_succ]
+  have hv : 0 < hypercubeVertices n := hypercubeVertices_pos n
+  omega
+
+/-- **`hypercubeVertices` is strictly monotone:** `m < n → |V(Q_m)| < |V(Qₙ)|`.  The
+vertex-count companion of `hypercubeEdges_strictMono`; like the edge count, `|V(Qₙ)| = 2ⁿ`
+is strictly increasing, so the dimension `n` is recoverable from the vertex count alone
+(`hypercubeVertices_injective`). -/
+theorem hypercubeVertices_strictMono : StrictMono hypercubeVertices :=
+  strictMono_nat_of_lt_succ hypercubeVertices_lt_succ
+
+/-- **The dimension is recoverable from the vertex count:** `hypercubeVertices` is injective.
+Immediate from `hypercubeVertices_strictMono`; the sibling of the edge-count fact implicit in
+`hypercubeEdges_strictMono`, making explicit that distinct-dimensional hypercubes never share a
+vertex count. -/
+theorem hypercubeVertices_injective : Function.Injective hypercubeVertices :=
+  hypercubeVertices_strictMono.injective
+
 /-
 **Degree in Qₙ:** every vertex has degree n.
 -/


### PR DESCRIPTION
## Summary

`Erdos666Problem.lean` (C₆ in hypercube subgraphs) develops a thorough basic-count API for the hypercube `Qₙ`, including `hypercubeEdges_strictMono` (with the noted consequence that the dimension is recoverable from the edge count). The parallel fact for the **vertex** count was never stated. This PR rounds it out, all verified 0-sorry/0-axiom, using the file's own `_succ`+`omega` pattern:

- **`hypercubeVertices_lt_succ`** — `|V(Qₙ)| < |V(Q_{n+1})|`.
- **`hypercubeVertices_strictMono`** — `StrictMono hypercubeVertices`.
- **`hypercubeVertices_injective`** — the dimension is recoverable from the vertex count.

This is a modest rounding-out of the counting API; it does not touch the file's single deep axiom `conder_no_threshold` (Conder's `1/3` refutation), whose elimination and the open `C_{2k}` generalization remain the genuine, non-session-sized work.

## Verification

- `./proofs/scripts/docker-build.sh Proofs.Erdos666Problem` → **Build completed successfully (7743 jobs)**.
- 0 sorries; axiom count unchanged at 1 (`conder_no_threshold`).

Note: the shared build volume was throwing intermittent exit-135 / corrupt-`.ir` faults today; elaboration reached `[7743/7743]` on every attempt and a re-run landed GREEN.

🤖 Generated with [Claude Code](https://claude.com/claude-code)