### PR TITLE
research(erdos-3-incomplete-01): SuperSharp threshold lattice — Sharp⇒SuperSharp + monotonicity [axiom-free]

### DIFF
--- a/proofs/Proofs/Erdos3Problem.lean
+++ b/proofs/Proofs/Erdos3Problem.lean
@@ -1384,6 +1384,83 @@ theorem sharpRequiredBound_mono {k m : ℕ} (hkm : k ≤ m)
   filter_upwards [hev] with N hN
   exact le_trans (by exact_mod_cast rothNumber_mono hkm) hN
 
+/-- **The super-sharp threshold hypothesis is downward-closed in the length.**
+    `SuperSharpRequiredBound m` implies `SuperSharpRequiredBound k` for every `k ≤ m`: the
+    same witnesses `δ, C` work because `r_k(N) ≤ r_m(N)` by `rothNumber_mono`, and the
+    (double-iterated-log) denominator is unchanged. Completes the monotonicity row of the
+    threshold lattice alongside `strongRequiredBound_mono`, `sharpRequiredBound_mono`, and
+    `requiredBound_mono`. Axiom-free. -/
+theorem superSharpRequiredBound_mono {k m : ℕ} (hkm : k ≤ m)
+    (h : SuperSharpRequiredBound m) : SuperSharpRequiredBound k := by
+  obtain ⟨δ, hδ, C, hC, hev⟩ := h
+  refine ⟨δ, hδ, C, hC, ?_⟩
+  filter_upwards [hev] with N hN
+  exact le_trans (by exact_mod_cast rothNumber_mono hkm) hN
+
+/-- **The sharp threshold implies the super-sharp threshold.**
+    `SharpRequiredBound k` (`r_k(N) = O(N/(log N · (log log N)^{1+δ}))`) implies
+    `SuperSharpRequiredBound k` (`r_k(N) = O(N/(log N · log log N · (log log log N)^{1+δ'}))`).
+    Setting `M = log log N`, the super-sharp denominator `log N · M · (log M)^2` is dominated
+    by the sharp one `log N · M^{1+δ}` because `(log M)^2 ≤ M^δ` eventually: `log M = o(M^{δ/2})`
+    (`isLittleO_log_rpow_atTop` with exponent `δ/2 > 0`, composed with `log log N → ∞`), and
+    squaring gives the bound. A bigger denominator makes a smaller quotient, so the sharp
+    bound transfers.
+
+    This is the exact analogue of `strongRequiredBound_implies_sharpRequiredBound` one
+    iterated logarithm lower, formalizing the ordering asserted in the
+    `SuperSharpRequiredBound` docstring (`SharpRequiredBound ⇒ SuperSharpRequiredBound`,
+    converse fails) and extending the implication lattice to
+    `StrongRequiredBound ⇒ SharpRequiredBound ⇒ SuperSharpRequiredBound`. It certifies that
+    `superSharp_required_bound_implies_conjecture` genuinely sharpens
+    `sharp_required_bound_implies_conjecture`: its hypothesis is *implied by* — hence no
+    stronger than — the sharp one. Axiom-free. -/
+theorem sharpRequiredBound_implies_superSharpRequiredBound {k : ℕ}
+    (h : SharpRequiredBound k) : SuperSharpRequiredBound k := by
+  obtain ⟨δ, hδ, C, hC, hev⟩ := h
+  refine ⟨1, one_pos, C, hC, ?_⟩
+  -- `log N → ∞`, hence `log log N → ∞`, so `log (log log N) = o((log log N)^{δ/2})`.
+  have hlog : Filter.Tendsto (fun N : ℕ => Real.log (N : ℝ)) Filter.atTop Filter.atTop :=
+    Real.tendsto_log_atTop.comp tendsto_natCast_atTop_atTop
+  have hloglog : Filter.Tendsto (fun N : ℕ => Real.log (Real.log (N : ℝ)))
+      Filter.atTop Filter.atTop := Real.tendsto_log_atTop.comp hlog
+  have hr : (0 : ℝ) < δ / 2 := by linarith
+  have hlittle := (isLittleO_log_rpow_atTop hr).comp_tendsto hloglog
+  have hbound := Asymptotics.isLittleO_iff.mp hlittle (one_pos)
+  simp only [Function.comp_apply] at hbound
+  have hLgt : ∀ᶠ N : ℕ in Filter.atTop, 1 < Real.log (N : ℝ) :=
+    hlog.eventually (eventually_gt_atTop 1)
+  have hMgt : ∀ᶠ N : ℕ in Filter.atTop, 1 < Real.log (Real.log (N : ℝ)) :=
+    hloglog.eventually (eventually_gt_atTop 1)
+  filter_upwards [hev, hbound, hLgt, hMgt] with N hN hb hL hM
+  set L : ℝ := Real.log (N : ℝ) with hLdef
+  set M : ℝ := Real.log L with hMdef
+  have hL0 : 0 < L := lt_trans one_pos hL
+  have hM0 : 0 < M := lt_trans one_pos hM
+  have hLM0 : 0 < Real.log M := Real.log_pos hM
+  have hpow0 : (0 : ℝ) < M ^ (δ / 2) := Real.rpow_pos_of_pos hM0 _
+  rw [one_mul, Real.norm_of_nonneg hLM0.le, Real.norm_of_nonneg hpow0.le] at hb
+  -- `(log M)^2 ≤ (M^{δ/2})^2 = M^δ`.
+  have hstep : (Real.log M) ^ (1 + 1 : ℝ) ≤ (M ^ (δ / 2)) ^ (1 + 1 : ℝ) :=
+    Real.rpow_le_rpow hLM0.le hb (by norm_num)
+  have hcollapse : (M ^ (δ / 2)) ^ (1 + 1 : ℝ) = M ^ δ := by
+    rw [← Real.rpow_mul hM0.le]; congr 1; ring
+  have hpow_le : (Real.log M) ^ (1 + 1 : ℝ) ≤ M ^ δ := hcollapse ▸ hstep
+  -- The super-sharp denominator is dominated by the sharp one: `L·M·(log M)^2 ≤ L·M^{1+δ}`.
+  have hMd : M * M ^ δ = M ^ (1 + δ) := by rw [Real.rpow_add hM0, Real.rpow_one]
+  have hdenom_le : L * M * (Real.log M) ^ (1 + 1 : ℝ) ≤ L * M ^ (1 + δ) := by
+    calc L * M * (Real.log M) ^ (1 + 1 : ℝ)
+          ≤ L * M * M ^ δ :=
+            mul_le_mul_of_nonneg_left hpow_le (mul_nonneg hL0.le hM0.le)
+      _ = L * M ^ (1 + δ) := by rw [mul_assoc, hMd]
+  -- Bigger denominator ⇒ smaller quotient, so the sharp bound `hN` transfers.
+  refine le_trans hN ?_
+  have hsharp_pos : (0 : ℝ) < L * M ^ (1 + δ) :=
+    mul_pos hL0 (Real.rpow_pos_of_pos hM0 _)
+  have hsuper_pos : (0 : ℝ) < L * M * (Real.log M) ^ (1 + 1 : ℝ) :=
+    mul_pos (mul_pos hL0 hM0) (Real.rpow_pos_of_pos hLM0 _)
+  rw [div_le_div_iff₀ hsharp_pos hsuper_pos]
+  exact mul_le_mul_of_nonneg_left hdenom_le (mul_nonneg hC.le (Nat.cast_nonneg N))
+
 /-- **The weak threshold hypothesis is downward-closed in the length.**
     `RequiredBound m` implies `RequiredBound k` for every `k ≤ m`, again by `rothNumber_mono`
     (for each `c > 0`, `r_k(N) ≤ r_m(N) ≤ c·N/log N`). Axiom-free. -/

--- a/src/data/proofs/erdos-3/meta.json
+++ b/src/data/proofs/erdos-3/meta.json
@@ -65,7 +65,7 @@
       }
     ],
     "axiomCount": 0,
-    "lineCount": 1487,
+    "lineCount": 1564,
     "prerequisites": [
       "Arithmetic progressions and their properties",
       "Series convergence and divergence (reciprocal sums)",
@@ -74,7 +74,7 @@
       "Extremal combinatorics (Ramsey-type reasoning)"
     ],
     "assumptions": "0 axioms. `euler_prime_sum_diverges` (Euler 1737, ∑ 1/p diverges) is now a proved theorem, discharged from Mathlib's `not_summable_one_div_on_primes`. 1 sorry remains in `required_bound_implies_conjecture` (the o(N/log N) threshold), which is threshold-critical: as hard as Erdős #3 itself. The strictly stronger (log N)^{1+δ} threshold reduction (`strong_required_bound_implies_conjecture`) is fully proved, sorry-free and axiom-free.",
-    "theoremCount": 35,
+    "theoremCount": 37,
     "definitionCount": 14
   },
   "overview": {
@@ -249,9 +249,9 @@
       "Finset"
     ],
     "namespace": "Erdos3",
-    "lineCount": 1487,
+    "lineCount": 1564,
     "axiomCount": 0,
-    "theoremCount": 35,
+    "theoremCount": 37,
     "definitionCount": 14,
     "path": "Proofs/Erdos3Problem.lean",
     "sorries": 1


### PR DESCRIPTION
## Summary

Completes the lattice position of `SuperSharpRequiredBound` — the double-iterated-log conditional threshold $r_k(N) = O\!\left(N/(\log N \cdot \log\log N \cdot (\log\log\log N)^{1+\delta})\right)$. It was already defined and shown to imply Erdős #3 (`superSharp_required_bound_implies_conjecture`), but had no place in the monotonicity/implication lattice that the strong and sharp thresholds occupy.

## New theorems (both axiom-free)

- **`sharpRequiredBound_implies_superSharpRequiredBound`** — `SharpRequiredBound ⇒ SuperSharpRequiredBound`, extending the chain `Strong ⇒ Sharp ⇒ SuperSharp`. Setting $M = \log\log N$, the super-sharp denominator $L\cdot M\cdot(\log M)^2$ is dominated by the sharp $L\cdot M^{1+\delta}$ because $(\log M)^2 \le M^\delta$ eventually ($\log M = o(M^{\delta/2})$ via `isLittleO_log_rpow_atTop` composed with $\log\log N \to \infty$). This is the exact analogue of `strongRequiredBound_implies_sharpRequiredBound` one iterated logarithm lower, and certifies that `superSharp_required_bound_implies_conjecture` genuinely sharpens the sharp reduction.
- **`superSharpRequiredBound_mono`** — `SuperSharpRequiredBound` is downward-closed in the AP length $k$ (via `rothNumber_mono`), completing the monotonicity row alongside strong/sharp/required.

## Scope & verification

- The threshold-critical open `sorry` `required_bound_implies_conjecture` (as hard as Erdős #3 itself) is **untouched**; the file's status stays `axiomatized` with 1 sorry. This PR only adds sorry-free, axiom-free structural lemmas around the existing conditional-threshold hierarchy.
- `#print axioms` on both new theorems: `[propext, Classical.choice, Quot.sound]`.
- Compiles under Lean v4.26.0 on the full Mathlib `LEAN_PATH`.
- Synced gallery meta counts: `theoremCount` 35 → 37, `lineCount` 1487 → 1564 (`axiomCount` 0, `sorries` 1 unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)