### PR TITLE
research(euler-polyhedral-formula-oq-02-oq-02): the Cartesian-product monoid on CGB manifolds

### DIFF
--- a/proofs/Proofs/EulerPolyhedralOQ02OQ02.lean
+++ b/proofs/Proofs/EulerPolyhedralOQ02OQ02.lean
@@ -814,6 +814,92 @@ theorem genusSurfaceCGB_chi_even' (g : ℕ) : Even (genusSurfaceCGB g).chi := by
   obtain ⟨k, hk⟩ := genusSurface_first_betti_even g
   exact ⟨1 - (k : ℤ), by rw [hk]; push_cast; ring⟩
 
+-- ============================================================================
+-- Part XVII: The Cartesian-product monoid — (CGBManifolds, ×) with the point as
+--            identity, and χ a monoid homomorphism to (ℤ, ·)
+-- ============================================================================
+
+/-
+  Part X exhibits the *connected-sum* monoid `(2n`-manifolds, `#)`, with the sphere
+  `S^{2n}` as identity and `χ − 2` the induced additive homomorphism to `(ℤ, +)`.
+  The Cartesian product `×` (`prodCGB`) carries the complementary monoid structure:
+  it is commutative and associative on `χ`, its identity is the single **point**
+  (the `0`-dimensional manifold with `χ = 1`), and `χ` is *multiplicative*
+  (`prodCGB_chi`).  So `χ` is a monoid homomorphism `((CGBManifolds, ×) → (ℤ, ·))`,
+  exactly as `χ − 2` is one `((·, #) → (ℤ, +))`.  Everything reduces to the
+  commutative-ring structure of `ℤ`, hence is fully verified (the two
+  structure-encoded CGB assumptions are not invoked).
+-/
+
+/-- **The point manifold** — the `0`-dimensional closed manifold consisting of a single
+    point: `halfDim = 0`, `χ = 1`, `∫Pf = 1` (the empty Pfaffian integrates to the point
+    count).  It is the identity for the Cartesian product `prodCGB`. -/
+def pointCGB : CGBManifold where
+  halfDim := 0
+  chi := 1
+  totalPfaffian := 1
+  chern_gauss_bonnet := by rw [cgbConst_zero]; norm_num
+
+/-- `χ(pt) = 1`: the point has Euler characteristic one. -/
+@[simp] theorem pointCGB_chi : pointCGB.chi = 1 := rfl
+
+/-- `dim(pt) = 0`: the point is `0`-dimensional. -/
+@[simp] theorem pointCGB_dim : pointCGB.dim = 0 := rfl
+
+/-- `∫Pf(pt) = 1`: the point's total Pfaffian is its point count. -/
+@[simp] theorem pointCGB_totalPfaffian : pointCGB.totalPfaffian = 1 := rfl
+
+/-- **Left identity for `×` (Euler characteristic): `χ(pt × M) = χ(M)`.**  Since
+    `χ(pt) = 1` and `χ` is multiplicative, the point is a left identity for the
+    Cartesian-product monoid — the multiplicative analogue of the sphere's role as
+    connected-sum identity (`connectedSum_sphere_chi`). -/
+theorem prodCGB_point_chi (M : CGBManifold) : (prodCGB pointCGB M).chi = M.chi := by
+  rw [prodCGB_chi]; show (1 : ℤ) * M.chi = M.chi; rw [one_mul]
+
+/-- **Right identity for `×` (Euler characteristic): `χ(M × pt) = χ(M)`.**  The mirror of
+    `prodCGB_point_chi`; together they make the point a genuine *two-sided* identity for
+    the product monoid on `χ`. -/
+theorem prodCGB_chi_point (M : CGBManifold) : (prodCGB M pointCGB).chi = M.chi := by
+  rw [prodCGB_chi]; show M.chi * (1 : ℤ) = M.chi; rw [mul_one]
+
+/-- **Commutativity on Euler characteristics: `χ(M × N) = χ(N × M)`.**  `χ` is multiplicative
+    and `ℤ` is commutative, so the Cartesian product is commutative on `χ` — the commutativity
+    axiom of the product monoid, paralleling `connectedSumCGB_chi_comm`. -/
+theorem prodCGB_chi_comm (M N : CGBManifold) :
+    (prodCGB M N).chi = (prodCGB N M).chi := by
+  rw [prodCGB_chi, prodCGB_chi]; ring
+
+/-- **Associativity on Euler characteristics: `χ((M × N) × P) = χ(M × (N × P))`.**  Both sides
+    equal `χ(M)·χ(N)·χ(P)`, so the Cartesian product is associative on `χ` — the associativity
+    axiom of the product monoid, paralleling `connectedSumCGB_chi_assoc`. -/
+theorem prodCGB_chi_assoc (M N P : CGBManifold) :
+    (prodCGB (prodCGB M N) P).chi = (prodCGB M (prodCGB N P)).chi := by
+  rw [prodCGB_chi, prodCGB_chi, prodCGB_chi, prodCGB_chi]; ring
+
+/-- **Left identity for `×` (total curvature): `∫Pf(pt × M) = ∫Pf(M)`.**  The total Pfaffian
+    multiplies under products (`prodCGB_totalPfaffian`) and `∫Pf(pt) = 1`, so the point is
+    also neutral for the Gauss-Bonnet total curvature — the product monoid is realised on
+    `∫Pf`, not merely on `χ`. -/
+theorem prodCGB_point_totalPfaffian (M : CGBManifold) :
+    (prodCGB pointCGB M).totalPfaffian = M.totalPfaffian := by
+  rw [prodCGB_totalPfaffian]; show (1 : ℝ) * M.totalPfaffian = M.totalPfaffian; rw [one_mul]
+
+/-- **Commutativity on the total curvature: `∫Pf(M × N) = ∫Pf(N × M)`.**  The Gauss-Bonnet
+    companion of `prodCGB_chi_comm`: the product total Pfaffian `M.totalPfaffian ·
+    N.totalPfaffian` is symmetric in `M, N`, so the Cartesian product is commutative as a
+    Chern-Gauss-Bonnet operation. -/
+theorem prodCGB_totalPfaffian_comm (M N : CGBManifold) :
+    (prodCGB M N).totalPfaffian = (prodCGB N M).totalPfaffian := by
+  rw [prodCGB_totalPfaffian, prodCGB_totalPfaffian]; ring
+
+/-- **The point is `0`-dimensional identity: `dim(pt × M) = dim M`.**  Cartesian product adds
+    dimensions (`prodCGB_dim`) and `dim(pt) = 0`, so multiplying by the point preserves
+    dimension — confirming the point is the product identity on the full invariant triple
+    `(dim, χ, ∫Pf)`, just as the sphere `S^{2n}` is the connected-sum identity in each
+    fixed dimension. -/
+theorem prodCGB_point_dim (M : CGBManifold) : (prodCGB pointCGB M).dim = M.dim := by
+  rw [prodCGB_dim]; show pointCGB.dim + M.dim = M.dim; rw [pointCGB_dim, zero_add]
+
 end ChernGaussBonnet
 
 end

--- a/src/data/proofs/euler-polyhedral-formula-oq-02-oq-02/meta.json
+++ b/src/data/proofs/euler-polyhedral-formula-oq-02-oq-02/meta.json
@@ -39,14 +39,15 @@
       "Functorial constructions: even spheres S^{2n}, products M×N with multiplicative χ(M×N)=χ(M)χ(N) and multiplicative total Pfaffian, flat tori with χ=0",
       "Odd-dimensional vanishing: a ClosedOddManifold structure recording χ=0 (Poincaré duality), explaining why Chern-Gauss-Bonnet carries no information in odd dimension",
       "Connected-sum construction connectedSumCGB (Part X): χ(M # N) = χ(M) + χ(N) − 2 and the additive-minus-sphere total Pfaffian, with the sphere S^{2n} as the connected-sum identity (χ and ∫Pf neutral) and the genus-2 surface T²#T² realised with χ = −2, ∫Pf = −4π",
-      "Genus additivity of connected sum (Part XII): Σ_g # Σ_h = Σ_{g+h} on both invariants (χ and ∫Pf), exhibiting genus as the monoid isomorphism (closed orientable surfaces, #) ≅ (ℕ, +) — the full additivity behind the single-handle recursion χ(Σ_{g+1})=χ(Σ_g)−2"
+      "Genus additivity of connected sum (Part XII): Σ_g # Σ_h = Σ_{g+h} on both invariants (χ and ∫Pf), exhibiting genus as the monoid isomorphism (closed orientable surfaces, #) ≅ (ℕ, +) — the full additivity behind the single-handle recursion χ(Σ_{g+1})=χ(Σ_g)−2",
+      "Part XVII product monoid (10 thm, 0-axiom): pointCGB (0-dim point, chi=1) as the Cartesian-product identity; prodCGB_point_chi/chi_point (two-sided identity), prodCGB_chi_comm/chi_assoc (commutative+associative on chi), prodCGB_point_totalPfaffian/totalPfaffian_comm/point_dim — completing (CGBManifolds, x) as a commutative monoid with chi a monoid homomorphism to (Z, *), the multiplicative parallel to the connected-sum monoid (Part X) where chi-2 maps to (Z, +)"
     ],
     "historicalContext": "Gauss (1827) and Bonnet (1848) related Gaussian curvature to topology for surfaces: ∫K dA = 2πχ. Allendoerfer-Weil (1943) and then Chern (1944-45) generalized this to all closed oriented even-dimensional Riemannian manifolds, expressing the Euler characteristic as the integral of the Pfaffian of the curvature form: ∫_M Pf(Ω/2π) = χ(M). Chern's intrinsic proof, via the transgression of the Euler form, became a cornerstone of characteristic-class theory. For 2-manifolds (n=1) the Pfaffian of the 2×2 curvature is the Gaussian curvature times the area form, recovering classical Gauss-Bonnet; for polyhedral surfaces the curvature concentrates at vertices as angular deficiency, recovering the discrete theorem Σδ(v)=2πχ.",
     "axiomCount": 2,
-    "lineCount": 612,
+    "lineCount": 905,
     "assumptions": "0 sorries; 0 axiom declarations; 2 structure-encoded assumptions. (1) CGBManifold.chern_gauss_bonnet encodes the Chern-Gauss-Bonnet identity ∫_M Pf(Ω) = (2π)^n·χ(M); Mathlib v4.26.0 has no Pfaffian of a curvature form, no integration of characteristic forms over manifolds, and no manifold Euler characteristic, so the identity is taken as a field rather than derived. (2) ClosedOddManifold.chi_zero encodes the Poincaré-duality fact that closed odd-dimensional manifolds have χ=0. All 54 theorems are then derived; the sphere Euler characteristics, normalization-constant lemmas, and the 2×2 Pfaffian identity are independently verified (depend only on propext/Classical.choice/Quot.sound). #print axioms confirms no sorryAx and no Lean.ofReduceBool.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 84,
+    "theoremCount": 94,
     "definitionCount": 12
   },
   "overview": {


### PR DESCRIPTION
## Summary

Extends the Chern-Gauss-Bonnet file (`EulerPolyhedralOQ02OQ02.lean`) with **Part XVII**: the Cartesian-product monoid structure on `CGBManifold`s, the multiplicative parallel to the well-developed connected-sum monoid of Part X.

Part X exhibits `(2n`-manifolds, `#)` as a commutative monoid with the sphere `S^{2n}` as identity and `χ − 2` a homomorphism to `(ℤ, +)`. The Cartesian product `prodCGB` carries the complementary structure — and 10 new sorry-free, **0-axiom** theorems record it:

- **`pointCGB`** — the `0`-dimensional point manifold (`χ = 1`, `∫Pf = 1`), the product identity.
- **`prodCGB_point_chi` / `prodCGB_chi_point`** — two-sided identity on `χ`.
- **`prodCGB_chi_comm` / `prodCGB_chi_assoc`** — commutativity and associativity on `χ`.
- **`prodCGB_point_totalPfaffian` / `prodCGB_totalPfaffian_comm` / `prodCGB_point_dim`** — the same structure realised on `∫Pf` and dimension.

Together these exhibit `χ` as a monoid homomorphism `(CGBManifolds, ×) → (ℤ, ·)`, exactly as `χ − 2` is one `(·, #) → (ℤ, +)`. Everything reduces to the commutative-ring structure of `ℤ`/`ℝ`; the two structure-encoded CGB assumptions are **not** invoked.

## Verification

- `docker-build.sh Proofs.EulerPolyhedralOQ02OQ02` → `✔ [7743/7743] Built` (build succeeded).
- 0 sorries, 0 new axioms (axiom count unchanged at 2 structure-encoded assumptions).
- meta.json updated: `theoremCount` 84→94, `lineCount` 612→905, contribution noted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)