### PR TITLE
research(cayley-hamilton-cyclic-vector-all-fields-oq-02-oq-02): the nonderogatory commutant is abelian

### DIFF
--- a/proofs/Proofs/CayleyHamiltonCyclicVectorAllFieldsOQ02OQ02.lean
+++ b/proofs/Proofs/CayleyHamiltonCyclicVectorAllFieldsOQ02OQ02.lean
@@ -387,6 +387,44 @@ theorem cayley_hamilton_oq02_oq02_summary
   ⟨centralizer_eq_adjoin_iff_nonderogatory M,
    finrank_centralizer_eq_of_nonderogatory M⟩
 
+/-! ### The commutant of a nonderogatory matrix is abelian
+
+For a nonderogatory `M` the centralizer is `C(M) = K[M]` (`centralizer_eq_adjoin_of_nonderogatory`),
+and polynomials in a single matrix commute with one another.  So *any two* matrices that each
+commute with `M` automatically commute with *each other*: the commutant is a commutative algebra.
+This is a distinctive feature of the nonderogatory case — for a derogatory `M` the commutant is
+strictly larger than `K[M]` and generally non-abelian. -/
+
+/-- **Commuting matrices with a nonderogatory `M` pairwise commute.**  If `M` is nonderogatory
+    (`minpoly K M = charpoly M`) and both `N₁` and `N₂` commute with `M`, then `N₁` and `N₂`
+    commute with each other: `N₁ N₂ = N₂ N₁`.  Since each `Nᵢ` is a polynomial in `M`
+    (`commute_iff_mem_range_aeval_of_nonderogatory`), write `Nᵢ = p_i(M)`; then
+    `p_1(M) p_2(M) = (p_1 p_2)(M) = (p_2 p_1)(M) = p_2(M) p_1(M)` by `map_mul` and the
+    commutativity of `K[X]`. -/
+theorem commute_of_commute_nonderogatory
+    (M : Matrix (Fin n) (Fin n) K) (hM : minpoly K M = M.charpoly)
+    (N₁ N₂ : Matrix (Fin n) (Fin n) K)
+    (h₁ : N₁ * M = M * N₁) (h₂ : N₂ * M = M * N₂) :
+    N₁ * N₂ = N₂ * N₁ := by
+  obtain ⟨p, rfl⟩ := (commute_iff_mem_range_aeval_of_nonderogatory M hM N₁).mp h₁
+  obtain ⟨q, rfl⟩ := (commute_iff_mem_range_aeval_of_nonderogatory M hM N₂).mp h₂
+  rw [← map_mul, ← map_mul, mul_comm p q]
+
+/-- **The commutant of a nonderogatory matrix is abelian (subalgebra form).**  Any two elements
+    `A, B` of the centralizer `C(M)` of a nonderogatory `M` commute: `A B = B A`.  This is the
+    subalgebra-level reading of `commute_of_commute_nonderogatory` — `C(M) = K[M]` is a
+    commutative algebra — obtained by unfolding centralizer membership to the commuting relations
+    with `M`.  (No `CommRing` instance on the subalgebra is needed.) -/
+theorem centralizer_mul_comm_of_nonderogatory
+    (M : Matrix (Fin n) (Fin n) K) (hM : minpoly K M = M.charpoly)
+    (A B : Matrix (Fin n) (Fin n) K)
+    (hA : A ∈ Subalgebra.centralizer K ({M} : Set (Matrix (Fin n) (Fin n) K)))
+    (hB : B ∈ Subalgebra.centralizer K ({M} : Set (Matrix (Fin n) (Fin n) K))) :
+    A * B = B * A := by
+  rw [Subalgebra.mem_centralizer_iff] at hA hB
+  exact commute_of_commute_nonderogatory M hM A B
+    (hA M (Set.mem_singleton M)).symm (hB M (Set.mem_singleton M)).symm
+
 end CyclicCommutantDimension
 
 end


### PR DESCRIPTION
## Summary

Two new theorems for `CayleyHamiltonCyclicVectorAllFieldsOQ02OQ02.lean` (commutant/centralizer dimension of a matrix over an arbitrary field), recording a distinctive structural feature of the nonderogatory case.

- **`commute_of_commute_nonderogatory`** — for a nonderogatory `M` (`minpoly K M = charpoly M`), any two matrices `N₁, N₂` that each commute with `M` also commute with each other: `N₁ N₂ = N₂ N₁`. Since `C(M) = K[M]` for nonderogatory `M`, each `Nᵢ = pᵢ(M)`, and `p₁(M) p₂(M) = (p₁ p₂)(M) = (p₂ p₁)(M) = p₂(M) p₁(M)` by `map_mul` and commutativity of `K[X]`.
- **`centralizer_mul_comm_of_nonderogatory`** — the subalgebra-level reading: `C(M) = K[M]` is a commutative algebra (any `A, B ∈ C(M)` commute). No `CommRing` instance on the subalgebra required.

This contrasts the derogatory case, where the commutant is strictly larger than `K[M]` (`natDegree_minpoly_lt_finrank_centralizer_of_derogatory`) and generally non-abelian.

## Verification

- `./proofs/scripts/docker-build.sh Proofs.CayleyHamiltonCyclicVectorAllFieldsOQ02OQ02` → `Build completed successfully (7748 jobs)`. (The full dependency chain builds cleanly under docker's self-healing volume; the prior "poisoned host cache" note does not apply.)
- 14 → 16 theorems, **0 axioms, 0 sorries** (built on the sibling files' verified `commute_iff_mem_range_aeval_of_nonderogatory`).

## Context

Research problem `cayley-hamilton-cyclic-vector-all-fields-oq-02-oq-02` is COMPLETE. This is an outward extension of the verified commutant development. This is a research-only file (no gallery `meta.json`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)