### PR TITLE
research(erdos-117-oq-01-incomplete-01): both oscillation endpoints in Pyber's window

### DIFF
--- a/proofs/Proofs/Erdos117OQ01Incomplete01.lean
+++ b/proofs/Proofs/Erdos117OQ01Incomplete01.lean
@@ -81,4 +81,19 @@ theorem not_exponentialBaseExists_iff_oscillation_pos :
   rw [exponentialBaseExists_iff_oscillation_zero]
   exact ⟨fun h => lt_of_le_of_ne growthRate_oscillation_nonneg (Ne.symm h), fun h => h.ne'⟩
 
+/-- **Both endpoints of the oscillation lie in Pyber's window individually.**  The parent's
+`limInfLimSup_window` bounds `growthRateLimInf` from *below* by `log c₁` and `growthRateLimSup`
+from *above* by `log c₂`.  Chaining with `limInf_le_limSup` closes the gap: *each* of the
+liminf and the limsup lies in the full closed window `[log c₁, log c₂]`.  This is the
+individual-endpoint companion of `oscillation_mem_window` (which traps only their *difference*),
+and in particular shows both are genuine finite reals confined to Pyber's exponential window,
+whether or not the growth rate converges. -/
+theorem limInf_limSup_mem_window :
+    ∃ c₁ c₂ : ℝ, 1 < c₁ ∧ c₁ < c₂ ∧
+      growthRateLimInf ∈ Set.Icc (Real.log c₁) (Real.log c₂) ∧
+      growthRateLimSup ∈ Set.Icc (Real.log c₁) (Real.log c₂) := by
+  obtain ⟨c₁, c₂, hc1, hc12, hlo, hhi⟩ := limInfLimSup_window
+  have hle := limInf_le_limSup
+  exact ⟨c₁, c₂, hc1, hc12, ⟨hlo, hle.trans hhi⟩, ⟨hlo.trans hle, hhi⟩⟩
+
 end Erdos117OQ01Incomplete01


### PR DESCRIPTION
## Summary

`Erdos117OQ01Incomplete01.lean` studies the oscillation `growthRateLimSup − growthRateLimInf` of the abelian-covering growth rate `log h(n)/n`, which the parent (`Erdos117OQ01`) traps between Pyber's constants. The file already has `oscillation_mem_window` bounding the *difference* by `log c₂ − log c₁`. This PR adds the per-endpoint companion (0-sorry/0-axiom):

- **`limInf_limSup_mem_window`** — `∃ c₁ c₂, 1 < c₁ < c₂ ∧ growthRateLimInf ∈ [log c₁, log c₂] ∧ growthRateLimSup ∈ [log c₁, log c₂]`.

The parent's `limInfLimSup_window` bounds `liminf` from below by `log c₁` and `limsup` from above by `log c₂`; chaining with `limInf_le_limSup` closes the gap so that *each* quantity individually lies in the full closed window — in particular both are genuine finite reals confined to Pyber's exponential window, whether or not the growth rate converges. No new axioms (the 3 structural axioms `h`/`h_pos`/`pyber_bounds` are untouched; the convergence question itself remains the open #117-OQ-01).

## Verification

- `./proofs/scripts/docker-build.sh Proofs.Erdos117OQ01Incomplete01` → **Build completed successfully (7744 jobs)**.
- 0 sorries, axiom count unchanged.

Note: intermittent exit-135 SIGBUS from the shared build volume today; elaboration completes and a re-run lands GREEN.

🤖 Generated with [Claude Code](https://claude.com/claude-code)