### PR TITLE
Enrich Catalan's Identity (cassini-identity-oq-01-oq-01): section mathContext

### DIFF
--- a/src/data/proofs/cassini-identity-oq-01-oq-01/meta.json
+++ b/src/data/proofs/cassini-identity-oq-01-oq-01/meta.json
@@ -86,28 +86,32 @@
       "title": "Module header and setup",
       "startLine": 1,
       "endLine": 35,
-      "summary": "The docstring states Catalan's identity F_n² − F_{n−r}·F_{n+r} = (−1)^{n−r}·F_r² as the r-step generalization of Cassini, notes that Mathlib carries only the r = 1 integer-indexed Cassini specialization, and lays out the three-lemma plan (cassini_sub → catalan_aux → catalan) that needs only one induction. Followed by the Mathlib import and namespace."
+      "summary": "The docstring states Catalan's identity F_n² − F_{n−r}·F_{n+r} = (−1)^{n−r}·F_r² as the r-step generalization of Cassini, notes that Mathlib carries only the r = 1 integer-indexed Cassini specialization, and lays out the three-lemma plan (cassini_sub → catalan_aux → catalan) that needs only one induction. Followed by the Mathlib import and namespace.",
+      "mathContext": "Catalan's identity: $F_n^2 - F_{n-r}F_{n+r} = (-1)^{n-r}F_r^2$ for $r \\le n$, the r-step generalization of Cassini ($r=1$: $F_n^2 - F_{n-1}F_{n+1} = (-1)^{n-1}$)."
     },
     {
       "id": "cassini-core",
       "title": "The Cassini core (normalized form)",
       "startLine": 37,
       "endLine": 54,
-      "summary": "cassini_sub proves F_{m+1}² − F_m·F_{m+1} − F_m² = (−1)^m by induction off Nat.fib_add_two. This is the r = 1 engine that the general identity scales by F_r²."
+      "summary": "cassini_sub proves F_{m+1}² − F_m·F_{m+1} − F_m² = (−1)^m by induction off Nat.fib_add_two. This is the r = 1 engine that the general identity scales by F_r².",
+      "mathContext": "$F_{m+1}^2 - F_m F_{m+1} - F_m^2 = (-1)^m$ — the normalized Cassini core, by induction on $m$ off $F_{m+2} = F_{m+1} + F_m$."
     },
     {
       "id": "catalan-subtraction-free",
       "title": "Catalan's identity, subtraction-free",
       "startLine": 57,
       "endLine": 83,
-      "summary": "catalan_aux proves F_{m+r}² − F_m·F_{m+2r} = (−1)^m·F_r². Three applications of Nat.fib_add expand the compound terms into the basis {F_m, F_{m+1}, F_s, F_{s+1}}, and a single linear_combination against the Cassini core closes the goal."
+      "summary": "catalan_aux proves F_{m+r}² − F_m·F_{m+2r} = (−1)^m·F_r². Three applications of Nat.fib_add expand the compound terms into the basis {F_m, F_{m+1}, F_s, F_{s+1}}, and a single linear_combination against the Cassini core closes the goal.",
+      "mathContext": "Subtraction-free form $F_{m+r}^2 - F_m F_{m+2r} = (-1)^m F_r^2$; expand via $F_{a+b+1} = F_a F_b + F_{a+1}F_{b+1}$ (`Nat.fib_add`) and close by linear_combination against the Cassini core."
     },
     {
       "id": "catalan-classical",
       "title": "Classical signed form and sanity checks",
       "startLine": 85,
       "endLine": 114,
-      "summary": "catalan reindexes catalan_aux by m = n − r to the classical F_n² − F_{n−r}·F_{n+r} = (−1)^{n−r}·F_r² for r ≤ n. catalan_one recovers Cassini (r = 1); catalan_5_2 and catalan_6_2 check concrete instances (F₅²−F₃F₇=−1, F₆²−F₄F₈=1)."
+      "summary": "catalan reindexes catalan_aux by m = n − r to the classical F_n² − F_{n−r}·F_{n+r} = (−1)^{n−r}·F_r² for r ≤ n. catalan_one recovers Cassini (r = 1); catalan_5_2 and catalan_6_2 check concrete instances (F₅²−F₃F₇=−1, F₆²−F₄F₈=1).",
+      "mathContext": "Reindex $m = n-r$ to recover the classical $F_n^2 - F_{n-r}F_{n+r} = (-1)^{n-r}F_r^2$ ($r \\le n$); $r=1$ gives Cassini, and $F_5^2 - F_3 F_7 = -1$, $F_6^2 - F_4 F_8 = 1$ are checked."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
Enrichment pass for `cassini-identity-oq-01-oq-01` (quality 96). Structural gap: all 4 sections lacked `mathContext` (0/4).

- **Added `mathContext` to all 4 sections** (now 4/4): Catalan's identity F_n²−F_{n−r}F_{n+r}=(−1)^{n−r}F_r²; the normalized Cassini core F_{m+1}²−F_m F_{m+1}−F_m²=(−1)^m; the subtraction-free F_{m+r}²−F_m F_{m+2r}=(−1)^m F_r² via the fib addition formula; and the classical reindexed form with concrete checks (F₅²−F₃F₇=−1, F₆²−F₄F₈=1).

Validation: JSON parses; 4/4 sections now have mathContext; meta.json within all size caps.