### PR TITLE
research(algebraic-numbers-countable-oq-07): full-measure/null structure on arbitrary sets + measurability

### DIFF
--- a/proofs/Proofs/AlgebraicRealsNull.lean
+++ b/proofs/Proofs/AlgebraicRealsNull.lean
@@ -676,4 +676,83 @@ theorem measure_independent_of_category :
       (∃ S : Set ℝ, volume Sᶜ = 0 ∧ IsMeagre S) :=
   ⟨exists_null_not_meagre, exists_conull_meagre⟩
 
+-- ============================================================================
+-- § 7. Measurability and full-measure structure on arbitrary sets
+-- ============================================================================
+
+/-!
+The measure-zero facts above are stated for specific ambient sets (the whole
+line, an interval). Because "countable ⟹ null" uses no structure of the ambient
+set, the algebraic reals subtract nothing from the measure of *any* set `s`: the
+transcendental part `s ∩ {transcendental}` always carries the full measure of `s`,
+and the algebraic part `s ∩ {algebraic}` is always null. Being countable, the
+algebraic reals are moreover Borel-measurable (`Set.Countable.measurableSet`),
+hence so are the transcendentals, so all of these intersections are genuine
+measurable events. Finally the existence corollary sharpens from "contains a
+transcendental" to "contains uncountably many": a positive-measure set cannot
+have countable transcendental part, since a countable set is null.
+-/
+
+/-- **The algebraic reals are measurable.** A countable set is measurable
+(`Set.Countable.measurableSet`), and `ℝ` has measurable singletons. -/
+theorem algebraic_reals_measurableSet :
+    MeasurableSet {x : ℝ | IsAlgebraic ℚ x} :=
+  AlgebraicNumbersCountable.algebraic_reals_countable.measurableSet
+
+/-- **The transcendental reals are measurable**, as the complement of the
+measurable algebraic reals. -/
+theorem transcendental_reals_measurableSet :
+    MeasurableSet {x : ℝ | Transcendental ℚ x} := by
+  rw [show {x : ℝ | Transcendental ℚ x} = {x : ℝ | IsAlgebraic ℚ x}ᶜ from by
+    ext x; simp only [mem_setOf_eq, mem_compl_iff, Transcendental]]
+  exact algebraic_reals_measurableSet.compl
+
+/-- **The algebraic part of any set is null**: `volume (s ∩ {algebraic}) = 0`
+for every `s`. Generalizes `algebraic_inter_interval_null` from intervals to
+arbitrary ambient sets — a subset of a null set is null. -/
+theorem algebraic_inter_null (s : Set ℝ) :
+    volume (s ∩ {x : ℝ | IsAlgebraic ℚ x}) = 0 :=
+  measure_mono_null inter_subset_right algebraic_reals_null
+
+/-- **The transcendentals fill almost all of every set**: for any `s`,
+`volume (s ∩ {transcendental}) = volume s`. Removing the null algebraic reals
+from `s` leaves its measure unchanged (`measure_diff_null`). Generalizes
+`transcendental_full_on_interval` from intervals to arbitrary ambient sets. -/
+theorem transcendental_inter_eq_measure (s : Set ℝ) :
+    volume (s ∩ {x : ℝ | Transcendental ℚ x}) = volume s := by
+  have hset : s ∩ {x : ℝ | Transcendental ℚ x} = s \ {x : ℝ | IsAlgebraic ℚ x} := by
+    ext x; simp only [mem_inter_iff, mem_diff, mem_setOf_eq, Transcendental]
+  rw [hset, measure_diff_null algebraic_reals_null]
+
+/-- **A positive-measure set has positive-measure transcendental part.** Since
+the algebraic part is null (`algebraic_inter_null`), all of `s`'s measure lives
+on its transcendental part `s ∩ {transcendental}`. -/
+theorem pos_measure_inter_transcendental_pos {s : Set ℝ} (hs : 0 < volume s) :
+    0 < volume (s ∩ {x : ℝ | Transcendental ℚ x}) := by
+  rw [transcendental_inter_eq_measure]; exact hs
+
+/-- **Any positive-measure set contains uncountably many transcendentals.**
+Sharpens `exists_transcendental_of_pos_measure` from "at least one" to
+"uncountably many": were `s ∩ {transcendental}` countable it would be null
+(`Set.Countable.measure_zero`), contradicting its positive measure
+(`pos_measure_inter_transcendental_pos`). -/
+theorem pos_measure_inter_transcendental_uncountable {s : Set ℝ}
+    (hs : 0 < volume s) : ¬ (s ∩ {x : ℝ | Transcendental ℚ x}).Countable := by
+  intro hcount
+  exact (pos_measure_inter_transcendental_pos hs).ne' (hcount.measure_zero volume)
+
+/-- **The complex algebraic numbers are measurable**, the complex analogue of
+`algebraic_reals_measurableSet`. -/
+theorem algebraic_complex_measurableSet :
+    MeasurableSet {z : ℂ | IsAlgebraic ℚ z} :=
+  AlgebraicNumbersCountable.algebraic_complex_countable.measurableSet
+
+/-- **The transcendental complex numbers are measurable**, as the complement of
+the measurable complex algebraic numbers. -/
+theorem transcendental_complex_measurableSet :
+    MeasurableSet {z : ℂ | Transcendental ℚ z} := by
+  rw [show {z : ℂ | Transcendental ℚ z} = {z : ℂ | IsAlgebraic ℚ z}ᶜ from by
+    ext z; simp only [mem_setOf_eq, mem_compl_iff, Transcendental]]
+  exact algebraic_complex_measurableSet.compl
+
 end AlgebraicRealsNull

--- a/src/data/proofs/algebraic-numbers-countable-oq-07/meta.json
+++ b/src/data/proofs/algebraic-numbers-countable-oq-07/meta.json
@@ -20,8 +20,8 @@
     "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 679,
-    "theoremCount": 45,
+    "lineCount": 758,
+    "theoremCount": 53,
     "definitionCount": 0,
     "dateAdded": "2026-06-21",
     "mathlibDependencies": [
@@ -185,8 +185,8 @@
   ],
   "leanFile": {
     "path": "Proofs/AlgebraicRealsNull.lean",
-    "lineCount": 679,
-    "theoremCount": 45,
+    "lineCount": 758,
+    "theoremCount": 53,
     "axiomCount": 0,
     "definitionCount": 0,
     "sorries": 0

--- a/src/data/research/problems/algebraic-numbers-countable-oq-07.json
+++ b/src/data/research/problems/algebraic-numbers-countable-oq-07.json
@@ -37,7 +37,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETED + SHARPENED: the algebraic reals are Lebesgue-null (existing) and now shown to have Hausdorff DIMENSION zero — strictly stronger, killing every positive-order Hausdorff gauge μH[d] (Lebesgue-null = d=1 slice). Dimensional corollary yields density of the transcendentals in ℝ and ℂ (dimH 0 < finrank), a route independent of Baire category. 16 theorems, 0 axioms, 0 sorries (elaboration-clean; olean-write blocked by fleet SIGBUS-135). | Session (researcher-1): added algebraic_complex_hausdorffMeasure_zero — the complex Hausdorff-measure-zero corollary the ℝ branch already had (algebraic_reals_hausdorffMeasure_zero) but ℂ lacked despite having algebraic_complex_dimH_zero. 1 thm, 0 axiom, 0 sorry. UNVERIFIED (Docker infra down).",
+    "progressSummary": "COMPLETED + SHARPENED: the algebraic reals are Lebesgue-null (existing) and now shown to have Hausdorff DIMENSION zero — strictly stronger, killing every positive-order Hausdorff gauge μH[d] (Lebesgue-null = d=1 slice). Dimensional corollary yields density of the transcendentals in ℝ and ℂ (dimH 0 < finrank), a route independent of Baire category. 16 theorems, 0 axioms, 0 sorries (elaboration-clean; olean-write blocked by fleet SIGBUS-135). | Session (researcher-1): added algebraic_complex_hausdorffMeasure_zero — the complex Hausdorff-measure-zero corollary the ℝ branch already had (algebraic_reals_hausdorffMeasure_zero) but ℂ lacked despite having algebraic_complex_dimH_zero. 1 thm, 0 axiom, 0 sorry. UNVERIFIED (Docker infra down). | Session (researcher-5, 2026-07-11): added § 7 'Measurability and full-measure structure on arbitrary sets' — generalized the interval-level full-measure/null facts to ARBITRARY ambient sets and added Borel-measurability. 8 new theorems, 0 axiom, 0 sorry, Docker-verified [3087/3087].",
     "builtItems": [
       "algebraic_reals_null: volume {x : ℝ | IsAlgebraic ℚ x} = 0 in Proofs/AlgebraicRealsNull.lean",
       "ae_transcendental: almost every real is transcendental (∀ᵐ x ∂volume, Transcendental ℚ x)",
@@ -46,7 +46,8 @@
       "NoAtoms (volume : Measure ℂ) + algebraic_complex_null: complex algebraic numbers are null",
       "AlgebraicRealsNull.lean §6 (researcher-2): algebraic_reals_dimH_zero (dimH{alg reals}=0 via Set.Countable.dimH_zero), algebraic_reals_hausdorffMeasure_zero (μH[d]{alg}=0 for d>0 via hausdorffMeasure_of_dimH_lt), algebraic_complex_dimH_zero, transcendental_reals_dense + transcendental_complex_dense (dense_compl_of_dimH_lt_finrank + Module.finrank_pos). File now 16 theorems, 0 axioms, 0 sorries. Elaboration-clean; olean-write blocked by fleet SIGBUS-135.",
       "algebraic_complex_hausdorffMeasure_zero {d>0}: μH[d]{z|IsAlgebraic ℚ z}=0 — the complex analogue of algebraic_reals_hausdorffMeasure_zero, completing the dimH-zero corollary parity between the ℝ and ℂ branches. AlgebraicRealsNull.lean.",
-      "transcendental_reals_mk_eq_continuum: #{x:ℝ|Transcendental ℚ x}=𝔠 (AlgebraicRealsNull.lean §2) via Cardinal.mk_compl_of_infinite + mk_real"
+      "transcendental_reals_mk_eq_continuum: #{x:ℝ|Transcendental ℚ x}=𝔠 (AlgebraicRealsNull.lean §2) via Cardinal.mk_compl_of_infinite + mk_real",
+      "AlgebraicRealsNull.lean §7 (researcher-5): algebraic_reals_measurableSet + transcendental_reals_measurableSet (+ complex analogues) — countable ⟹ MeasurableSet via Set.Countable.measurableSet; algebraic_inter_null (∀ s, volume(s∩{alg})=0) and transcendental_inter_eq_measure (∀ s, volume(s∩{trans})=volume s) generalizing algebraic_inter_interval_null/transcendental_full_on_interval from intervals to arbitrary s via measure_diff_null; pos_measure_inter_transcendental_pos and pos_measure_inter_transcendental_uncountable (positive-measure set ⟹ uncountably-many transcendentals, sharpening exists_transcendental_of_pos_measure). File now 758 lines, 53 theorems, 0 axioms, 0 sorries; Docker [3087/3087] 2.9s."
     ],
     "insights": [
       "Countable ⟹ null requires the measure to be atomless; Lebesgue measure qualifies via Real.noAtoms_volume, so Set.Countable.measure_zero applies to the parent's countability theorem in one line.",
@@ -54,7 +55,8 @@
       "The complex case needs NoAtoms (volume : Measure ℂ), which is not a single named instance; transport singletons through the measure-preserving ℂ ≃ᵐ ℝ × ℝ to the atomless planar measure (Measure.prod.instNoAtoms_fst).",
       "measure_diff_null gives the interval full-measure result directly: Ioo a b ∩ {transcendental} = Ioo a b \\ {algebraic}, and removing the null algebraic set leaves the interval's measure unchanged.",
       "SHARPENING (researcher-2, 2026-07-09): the algebraic reals have Hausdorff DIMENSION zero, strictly stronger than Lebesgue-null. Since {x|IsAlgebraic ℚ x} is countable, Set.Countable.dimH_zero gives dimH=0; then hausdorffMeasure_of_dimH_lt kills EVERY positive-order Hausdorff measure μH[d] (d>0), of which Lebesgue-null (algebraic_reals_null) is only the d=1 slice. Dimensional corollary: dimH{alg}=0 < finrank ℝ ℝ=1 (and < finrank ℝ ℂ=2), so dense_compl_of_dimH_lt_finrank makes the transcendentals DENSE in ℝ and ℂ — a dimension-theoretic route to their topological largeness, independent of the Baire-category argument. Added algebraic_reals_dimH_zero, algebraic_reals_hausdorffMeasure_zero, algebraic_complex_dimH_zero, transcendental_reals_dense, transcendental_complex_dense to AlgebraicRealsNull.lean §6. Elaboration-clean [3073/3073] (olean-write SIGBUS-135).",
-      "Cardinality pillar can be made quantitative (=𝔠, not just uncountable) with mk_compl_of_infinite: complement of a <#ℝ set in ℝ keeps cardinality #ℝ"
+      "Cardinality pillar can be made quantitative (=𝔠, not just uncountable) with mk_compl_of_infinite: complement of a <#ℝ set in ℝ keeps cardinality #ℝ",
+      "GENERALIZATION (researcher-5, 2026-07-11): the interval-specific full-measure facts need nothing special about intervals — for ANY s, s∩{transcendental} = s\\{algebraic} and measure_diff_null (removing a null set preserves measure) gives volume(s∩{trans})=volume s; dually s∩{alg} is a subset of a null set so measure_mono_null gives 0. Positive measure then forces the transcendental part uncountable (countable ⟹ null), upgrading the existence corollary from 'one' to 'uncountably many'. Countability also gives Set.Countable.measurableSet, so all these intersections are honest measurable events."
     ],
     "mathlibGaps": [
       "No single named NoAtoms instance for volume on ℂ; derived locally via the measure-preserving equivalence to ℝ × ℝ."
@@ -347,5 +349,5 @@
     "almost-everywhere"
   ],
   "started": "2026-06-21",
-  "lastUpdate": "2026-07-09"
+  "lastUpdate": "2026-07-11"
 }


### PR DESCRIPTION
## Summary

Outward extension of the mature, COMPLETED entry **algebraic-numbers-countable-oq-07** (*The algebraic reals are Lebesgue-null*). The existing file proved full-measure/null facts only for specific ambient sets (the whole line, an interval). This PR adds **§ 7** generalizing them to **arbitrary** ambient sets and supplying Borel-measurability.

## New theorems (8, all axiom-free)

| Theorem | Statement |
|---|---|
| `algebraic_reals_measurableSet` | `MeasurableSet {x \| IsAlgebraic ℚ x}` (countable ⟹ measurable) |
| `transcendental_reals_measurableSet` | complement of the above |
| `algebraic_complex_measurableSet` / `transcendental_complex_measurableSet` | complex analogues |
| `algebraic_inter_null (s)` | `volume (s ∩ {algebraic}) = 0` for **every** `s` (generalizes `algebraic_inter_interval_null`) |
| `transcendental_inter_eq_measure (s)` | `volume (s ∩ {transcendental}) = volume s` — transcendentals fill almost all of **any** set (generalizes `transcendental_full_on_interval` via `measure_diff_null`) |
| `pos_measure_inter_transcendental_pos` | a positive-measure set has positive-measure transcendental part |
| `pos_measure_inter_transcendental_uncountable` | …and hence **uncountably many** transcendentals — sharpens `exists_transcendental_of_pos_measure` from "one" to "uncountably many" |

## Verification

- **Docker build**: `✔ [3087/3087] Built Proofs.AlgebraicRealsNull (2.9s)` — success.
- File now **758 lines, 53 theorems, 0 axioms, 0 sorries** (no `native_decide`).
- New lemmas used: `Set.Countable.measurableSet`, `measure_mono_null`, `measure_diff_null` — all axiom-free.

## Files

- `proofs/Proofs/AlgebraicRealsNull.lean` (+8 theorems, +79 lines)
- `src/data/proofs/algebraic-numbers-countable-oq-07/meta.json` (lineCount/theoremCount → 758/53)
- `src/data/research/problems/algebraic-numbers-countable-oq-07.json` (knowledge update)

🤖 Generated with [Claude Code](https://claude.com/claude-code)