### PR TITLE
Research: brouwer-fixed-point-oq-02-oq-02-oq-01 - tail arc-length bound + arc-dominates-chord

### DIFF
--- a/proofs/Proofs/BrouwerFixedPointOQ02OQ02OQ01.lean
+++ b/proofs/Proofs/BrouwerFixedPointOQ02OQ02OQ01.lean
@@ -771,4 +771,70 @@ theorem increment_tendsto_zero (f : ℝ → ℝ) (L : ℝ) (hL0 : 0 ≤ L) (hL1 
     simpa using h0.mul_const |x 1 - x 0|
   exact squeeze_zero (fun _ => abs_nonneg _) hbound hg
 
+/-! ### Tail arc length and the arc-dominates-chord bridge
+
+`total_path_length_bound` bounds the *full* orbit arc length `∑_{k<m}|x_{k+1}−x_k|` by
+`|x₁−x₀|/(1−L)`; it is the `n = 0` case of a windowed estimate.  The two results below
+close the arc-length picture:
+
+  * `tail_path_length_bound` — the arc length of the window `[n, n+m)` decays like `Lⁿ`:
+    `∑_{k<m}|x_{n+k+1}−x_{n+k}| ≤ Lⁿ·|x₁−x₀|/(1−L)`.  Its `n = 0` case is
+    `total_path_length_bound`; its `m → ∞` limit bounds the distance from `xₙ` to the
+    fixed point (the arc from `xₙ` onward dominates `|xₙ − x*|`).
+
+  * `displacement_le_path_length` — a purely telescoping fact (no contraction needed):
+    the chord `|x_{n+m}−xₙ|` never exceeds the arc `∑_{k<m}|x_{n+k+1}−x_{n+k}|`.
+
+Composed, they re-derive `cauchy_estimate` (`|x_{n+m}−xₙ| ≤ Lⁿ/(1−L)·|x₁−x₀|`) with the
+arc length as the intermediate quantity, exhibiting the Cauchy bound as "chord ≤ arc ≤
+geometric tail". -/
+
+/-- **Tail arc-length bound.**  For a contraction with `0 ≤ L < 1` and iteration
+    `xₙ₊₁ = f xₙ`, the arc length of the window `[n, n+m)` decays geometrically in the
+    window start:
+    `∑_{k<m} |x_{n+k+1} − x_{n+k}| ≤ Lⁿ · |x₁ − x₀| / (1 − L)`.
+    The `n = 0` case is `total_path_length_bound`; each increment obeys `step_dist`
+    (`|x_{n+k+1} − x_{n+k}| ≤ L^{n+k}·|x₁ − x₀|`) and the partial geometric sum
+    `∑_{k<m} L^{n+k} = Lⁿ(1 − Lᵐ)/(1 − L) ≤ Lⁿ/(1 − L)`. -/
+theorem tail_path_length_bound (f : ℝ → ℝ) (L : ℝ) (hL0 : 0 ≤ L) (hL1 : L < 1)
+    (hf : ∀ x y, |f x - f y| ≤ L * |x - y|)
+    (x : ℕ → ℝ) (hx : ∀ n, x (n + 1) = f (x n)) (n m : ℕ) :
+    ∑ k ∈ Finset.range m, |x (n + k + 1) - x (n + k)| ≤ L ^ n * |x 1 - x 0| / (1 - L) := by
+  have hc : (0 : ℝ) < 1 - L := by linarith
+  -- exact partial geometric sum, cleared of the division
+  have hgs : ∀ j, (∑ k ∈ Finset.range j, L ^ k) * (1 - L) = 1 - L ^ j := by
+    intro j
+    induction j with
+    | zero => simp
+    | succ j ih => rw [Finset.sum_range_succ, add_mul, ih, pow_succ]; ring
+  have hgeom : (∑ k ∈ Finset.range m, L ^ k) ≤ 1 / (1 - L) := by
+    rw [le_div_iff₀ hc, hgs m]
+    linarith [pow_nonneg hL0 m]
+  have hstep : ∀ k, |x (n + k + 1) - x (n + k)| ≤ L ^ n * L ^ k * |x 1 - x 0| := by
+    intro k
+    have h := step_dist f L hL0 hf x hx (n + k)
+    rwa [pow_add] at h
+  calc ∑ k ∈ Finset.range m, |x (n + k + 1) - x (n + k)|
+      ≤ ∑ k ∈ Finset.range m, L ^ n * L ^ k * |x 1 - x 0| :=
+        Finset.sum_le_sum (fun k _ => hstep k)
+    _ = L ^ n * |x 1 - x 0| * ∑ k ∈ Finset.range m, L ^ k := by
+        rw [Finset.mul_sum]; apply Finset.sum_congr rfl; intro k _; ring
+    _ ≤ L ^ n * |x 1 - x 0| * (1 / (1 - L)) :=
+        mul_le_mul_of_nonneg_left hgeom (mul_nonneg (pow_nonneg hL0 n) (abs_nonneg _))
+    _ = L ^ n * |x 1 - x 0| / (1 - L) := by ring
+
+/-- **Arc dominates chord (telescoping).**  With no contraction hypothesis, the straight-line
+    displacement `|x_{n+m} − xₙ|` never exceeds the arc length `∑_{k<m}|x_{n+k+1} − x_{n+k}|`
+    of the intervening steps.  Pure telescoping: `x_{n+m} − xₙ = ∑_{k<m}(x_{n+k+1} − x_{n+k})`
+    (`Finset.sum_range_sub`), then `|∑| ≤ ∑|·|`.  Combined with `tail_path_length_bound`, this
+    re-derives `cauchy_estimate` via `chord ≤ arc ≤ Lⁿ/(1−L)·|x₁−x₀|`. -/
+theorem displacement_le_path_length (x : ℕ → ℝ) (n m : ℕ) :
+    |x (n + m) - x n| ≤ ∑ k ∈ Finset.range m, |x (n + k + 1) - x (n + k)| := by
+  have htel : x (n + m) - x n = ∑ k ∈ Finset.range m, (x (n + k + 1) - x (n + k)) := by
+    have h := Finset.sum_range_sub (fun k => x (n + k)) m
+    simpa [Nat.add_assoc] using h.symm
+  calc |x (n + m) - x n|
+      = |∑ k ∈ Finset.range m, (x (n + k + 1) - x (n + k))| := by rw [htel]
+    _ ≤ ∑ k ∈ Finset.range m, |x (n + k + 1) - x (n + k)| := Finset.abs_sum_le_sum_abs _ _
+
 end BrouwerOQ02OQ02OQ01

--- a/src/data/research/problems/brouwer-fixed-point-oq-02-oq-02-oq-01.json
+++ b/src/data/research/problems/brouwer-fixed-point-oq-02-oq-02-oq-01.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETE + two-sided a posteriori: upper bounds (apriori/aposteriori, conditional+unconditional), existence/uniqueness, convergence, sharpness, stability all machine-checked; NEW (researcher-1, 2026-07-10) aposteriori_lower_estimate closes the missing lower-bound direction. Addition verified against local Mathlib (EXIT=0).",
+    "progressSummary": "SOLVED (37 thm, 0 axiom, 0 sorry): added tail/windowed arc-length bound + arc-dominates-chord bridge to the mature Banach error suite",
     "builtItems": [
       "BrouwerFixedPointOQ02OQ02OQ01.lean: 6 theorems, 0 axioms (propext/Classical.choice/Quot.sound only), 0 sorries. Self-contained: contraction given as ∀ x y, |f x − f y| ≤ L·|x − y| with f x* = x* and xₙ₊₁ = f xₙ.",
       "iterate_dist: |xₙ − x*| ≤ Lⁿ·|x₀ − x*| (geometric decay, induction; reproves parent's bound self-containedly).",
@@ -40,7 +40,9 @@
       "BrouwerFixedPointOQ02OQ02OQ01Iteration.lean (researcher-2, PR pending): multi-step iteration bounds closing the base entry's next steps. iterate_contraction (f^[m] is an L^m-contraction), iterate_dist_tendsto (two-point spread -> 0 for 0<=L<1), apriori_iteration_count (for every eps>0 a finite iteration count N gives |x_n - x*|<=eps -- the parent's O(log 1/eps) guarantee), iteration_converges (x_n -> x* in R). VERIFIED 0 axioms / 0 sorries.",
       "applyAll / lipschitz_comp_list / contraction_comp_list (BrouwerFixedPointOQ02OQ02OQ01.lean): GENERAL list-of-maps composition. applyAll folds an ordered list of (fᵢ,Lᵢ) pairs (head applied outermost). lipschitz_comp_list: if each fᵢ is Lᵢ-Lipschitz (Lᵢ≥0), the composite is Lipschitz with constant ∏Lᵢ (structural recursion on the list). contraction_comp_list: a NON-EMPTY family of contractions (0≤Lᵢ<1) composes to a contraction with ∏Lᵢ<1. Supporting list_prod_le_one / list_prod_lt_one (product of reals in [0,1] is ≤1 / in [0,1) over nonempty list is <1). Generalises the 2-map lipschitz_comp/contraction_comp. Axiom-free, 0 sorry, no decide.",
       "BrouwerFixedPointOQ02OQ02OQ01.lean: exists_fixed_point + exists_unique_fixed_point (Banach existence & existence-uniqueness on ℝ). Now 14 theorems, 0 axioms, 0 sorries. Elaboration-clean; olean-write blocked by fleet SIGBUS-135.",
-      "BrouwerFixedPointOQ02OQ02OQ01.lean: +2 thms aposteriori_lower_estimate (+_unconditional) — two-sided a posteriori residual control"
+      "BrouwerFixedPointOQ02OQ02OQ01.lean: +2 thms aposteriori_lower_estimate (+_unconditional) — two-sided a posteriori residual control",
+      "tail_path_length_bound in BrouwerFixedPointOQ02OQ02OQ01.lean",
+      "displacement_le_path_length in BrouwerFixedPointOQ02OQ02OQ01.lean"
     ],
     "insights": [
       "Parent oq-02-oq-02 proves the bound |xₙ − x*| ≤ Lⁿ·|x₀ − x*| which is not directly usable (|x₀ − x*| unknown). The classical fix is the a priori estimate, expressing the bound via the computable first increment |x₁ − x₀|.",
@@ -50,7 +52,9 @@
       "Composition: |g(f x) − g(f y)| ≤ L₂|f x − f y| ≤ L₂L₁|x − y|; L₂L₁ < 1 from 0 ≤ Lᵢ < 1 by nlinarith. Self-contained, no domain restriction needed (contraction stated on all of ℝ).",
       "The 2-map Lipschitz composition law generalises verbatim to an ordered LIST of maps by bundling each map with its constant as a pair (fᵢ,Lᵢ):(ℝ→ℝ)×ℝ and folding via a structural def applyAll (head outermost, matching g∘f). The composite constant is exactly the list product ∏Lᵢ; contraction-ness (∏Lᵢ<1) needs non-emptiness plus the elementary product bound that a product of [0,1)-values is <1 (proved from: product of [0,1]-values ≤1). Structural recursion on the list (equation-compiler pattern | [] | p::rest) is cleaner than the induction tactic here because the ∀-mem hypotheses depend on the list.",
       "Discharged the one standing gap (researcher-2, 2026-07-09): fixed-point EXISTENCE, previously a hypothesis in every estimate. exists_fixed_point: a contraction |f x−f y|≤L|x−y| with 0≤L<1 on the complete space ℝ HAS a fixed point — bridge the raw real-analytic bound to Mathlib's ContractingWith via LipschitzWith.of_dist_le_mul + Real.dist_eq + Real.coe_toNNReal, then ContractingWith.exists_fixedPoint ⟨K<1, LipschitzWith⟩ 0 (edist_ne_top _ _). exists_unique_fixed_point: full Banach existence+uniqueness (pairs it with the existing fixed_point_unique). x* is now a genuine object, not a standing assumption. Elaboration-clean [7743/7743] (olean-write SIGBUS-135, heavy fleet load).",
-      "Added a matching a posteriori LOWER bound |x(n+1)-xn|/(1+L) ≤ |xn-x*| (reverse triangle + one-step contraction), making the residual/increment a two-sided proxy for the error. Only 0≤L needed. Prior estimates were all upper bounds."
+      "Added a matching a posteriori LOWER bound |x(n+1)-xn|/(1+L) ≤ |xn-x*| (reverse triangle + one-step contraction), making the residual/increment a two-sided proxy for the error. Only 0≤L needed. Prior estimates were all upper bounds.",
+      "Tail arc-length bound: ∑_{k<m}|x_{n+k+1}-x_{n+k}| ≤ Lⁿ|x₁-x₀|/(1-L) — generalizes total_path_length_bound (n=0 case); m→∞ limit bounds |xₙ-x*|",
+      "Arc dominates chord (displacement_le_path_length): |x_{n+m}-xₙ| ≤ arc length, pure telescoping (Finset.sum_range_sub + abs_sum_le_sum_abs); combined with tail_path_length_bound re-derives cauchy_estimate as chord≤arc≤geometric tail"
     ],
     "mathlibGaps": [],
     "nextSteps": [


### PR DESCRIPTION
## Summary
Research session for `brouwer-fixed-point-oq-02-oq-02-oq-01` (Banach fixed-point a priori / a posteriori error estimates). The main file `BrouwerFixedPointOQ02OQ02OQ01.lean` was already a saturated, verified suite (0 axioms, 0 sorries). This session closes the arc-length picture opened by the recently added `total_path_length_bound`.

## Progress
Two new theorems (35 → 37; still **0 axioms / 0 sorries**):

- **`tail_path_length_bound`** — windowed arc length decays geometrically in the window start:
  `∑_{k<m} |x_{n+k+1} − x_{n+k}| ≤ Lⁿ · |x₁ − x₀| / (1 − L)`.
  Its `n = 0` case is exactly `total_path_length_bound`; its `m → ∞` limit bounds `|xₙ − x*|`.
- **`displacement_le_path_length`** — arc dominates chord (no contraction hypothesis):
  `|x_{n+m} − xₙ| ≤ ∑_{k<m} |x_{n+k+1} − x_{n+k}|`, pure telescoping via `Finset.sum_range_sub` + `Finset.abs_sum_le_sum_abs`.

Composed, they re-derive `cauchy_estimate` as **chord ≤ arc ≤ geometric tail**.

## Findings
- The tail bound is a genuine strict generalization of the just-added full-orbit path length bound, not a renaming.
- The arc-dominates-chord lemma is contraction-free and supplies the missing bridge between "arc length" and the actual displacement/Cauchy estimates.

## Verification
- Host `lean` type-check (v4.26.0) passed cleanly (exit 0). Docker builds hit transient SIGBUS (135) on unrelated Mathlib cache files (`removing corrupted file`), unrelated to this change.

## Status
**Outcome**: completed
**Follow-up questions**: 0 (problem is at OQ depth 3 — depth guard forbids deeper OQ children)

🤖 Generated by researcher-6