### PR TITLE
Enrich Schur-convexity collision probability: add operator-stability open question

### DIFF
--- a/src/data/proofs/birthday-problem-oq-02-oq-01-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/birthday-problem-oq-02-oq-01-oq-02-oq-01-oq-01/meta.json
@@ -107,7 +107,8 @@
     "implications": "Passing a vector through any averaging (doubly stochastic) operator can only decrease its sum of squares — the operator form of Schur-convexity of ∑ xᵢ². Via Birkhoff–von Neumann and the HLP theorem this is exactly the majorization statement p ≺ q ⟹ ∑ pᵢ² ≤ ∑ qᵢ², so the parent's two extremal endpoints (uniform minimum, concentration maximum) sit at the two ends of a single monotone order rather than being isolated bounds. The uniform-minimizer corollary shows the bottom endpoint falling out as one instance at the all-1/d matrix.",
     "openQuestions": [
       "Prove the equality case: ∑ᵢ (Dq)ᵢ² = ∑ᵢ qᵢ² holds iff D acts as a permutation on the support of q (each row that meets the support concentrates on a single equal-q coordinate), pinning down exactly when averaging fails to strictly decrease collision.",
-      "Extend the operator inequality from ∑ xᵢ² to ∑ φ(xᵢ) for an arbitrary convex φ — the general Schur-convexity / Karamata statement — and identify which φ are handled verbatim by the same per-row-Jensen + column-collapse argument."
+      "Extend the operator inequality from ∑ xᵢ² to ∑ φ(xᵢ) for an arbitrary convex φ — the general Schur-convexity / Karamata statement — and identify which φ are handled verbatim by the same per-row-Jensen + column-collapse argument.",
+      "Quantify the operator inequality into a stability bound: does a defect estimate ∑ᵢ qᵢ² − ∑ᵢ (Dq)ᵢ² ≥ c·‖Dq − q‖² (or ≥ c·Var of the row combinations) hold uniformly in every doubly stochastic D? This would be the operator-level lift of the sibling entry's two-coordinate Pinsker bound ∑ pᵢ² − 1/d ≥ (4/d)·dTV(p,u)², upgrading 'averaging cannot increase collision' to 'averaging strictly decreases collision by at least how far it moved the vector.'"
     ]
   },
   "crossReferences": [


### PR DESCRIPTION
Enrichment pass for `birthday-problem-oq-02-oq-01-oq-02-oq-01-oq-01` (Schur-Convexity of Collision Probability: the Global Doubly-Stochastic Inequality).

Verified the entry end-to-end against `Proofs/BirthdayProblemOQ02OQ01OQ02OQ01OQ01.lean`: 3 theorems (`sum_sq_mulVec_le_of_mem_doublyStochastic`, `uniformAveraging_mem_doublyStochastic`, `one_div_card_le_sum_sq`), 0 axioms, 0 sorries — status `verified`/badge `original`/axiomCount 0 all accurate. All 3 crossReference targets exist in the gallery. The entry already meets every quality minimum (5 keyInsights, 6 annotations with full mathContext/significance/relatedConcepts, sections covering the full file), so per the curation guardrails I made a single high-value, non-inflating addition rather than deepening.

**Change:** added a 3rd `conclusion.openQuestion` (2→3) that bridges this entry's *qualitative* operator inequality (∑(Dq)ᵢ² ≤ ∑qᵢ²) with the sibling entry's *quantitative* Pinsker bound (∑pᵢ² − 1/d ≥ (4/d)·dTV(p,u)²): does a uniform defect/stability estimate ∑qᵢ² − ∑(Dq)ᵢ² ≥ c·‖Dq−q‖² hold for every doubly stochastic D? This is non-redundant with the two existing questions (equality case; arbitrary convex φ).

meta.json 13.1→13.6 KB (well under the 60 KB cap). JSON validated.