### PR TITLE
research(erdos-771): exact maxAvoidingSize at m=2,3 sharpen the f-bound to n−2

### DIFF
--- a/proofs/Proofs/Erdos771Problem.lean
+++ b/proofs/Proofs/Erdos771Problem.lean
@@ -110,6 +110,22 @@ theorem self_mem_subsetSums (S : Finset ℕ) (a : ℕ) (ha : a ∈ S) (hpos : 0 
   · rw [Finset.mem_powerset]; simpa using ha
   · simp
 
+/-- **A two-element sum is a subset sum.**  If `a, b ∈ S` are distinct and `a + b > 0`, then
+    `a + b ∈ subsetSums S`: the pair `{a, b} ⊆ S` sums to `a + b`.  The two-element companion of
+    `self_mem_subsetSums`, used to detect the representation `m = a + b` obstructing avoidance
+    (e.g. `3 = 1 + 2`). -/
+theorem pair_mem_subsetSums (S : Finset ℕ) (a b : ℕ) (ha : a ∈ S) (hb : b ∈ S)
+    (hab : a ≠ b) (hpos : 0 < a + b) : a + b ∈ subsetSums S := by
+  rw [subsetSums, Finset.mem_filter, Finset.mem_image]
+  refine ⟨⟨{a, b}, ?_, ?_⟩, hpos⟩
+  · rw [Finset.mem_powerset]
+    intro x hx
+    rw [Finset.mem_insert, Finset.mem_singleton] at hx
+    rcases hx with rfl | rfl
+    · exact ha
+    · exact hb
+  · rw [Finset.sum_pair hab]
+
 /-- **Subset sums are monotone under inclusion.** If `T ⊆ S` then every subset sum of `T`
     is a subset sum of `S`: `subsetSums T ⊆ subsetSums S`.  A subset `A ⊆ T` is also a
     subset `A ⊆ S`, so its sum survives into `subsetSums S`. -/
@@ -292,6 +308,127 @@ theorem maxAvoidingSize_one (n : ℕ) : maxAvoidingSize n 1 = n - 1 := by
       rw [Finset.mem_Icc] at ha
       omega
 
+/-- **Exact value at the small target `2`:** `maxAvoidingSize n 2 = n - 1` for `n ≥ 2`.  Like
+    `m = 1`, the only distinct-positive representation of `2` is the singleton `{2}`, so avoiding
+    `2` costs exactly one deletion: the largest witness is `{1,…,n} ∖ {2}`, of size `n - 1`.
+    Upper bound: a `2`-avoiding `S` omits `2` (else `self_mem_subsetSums` puts `2 ∈ subsetSums S`),
+    so `S ⊆ {1,…,n} ∖ {2}`.  Lower bound: `{1,…,n} ∖ {2}` avoids `2` because every element is `1`
+    or `≥ 3`, so no subset can sum to `2`.  The value stays at `n - 1` (as at `m = 1`) — the plateau
+    before the target `3` first pushes it down. -/
+theorem maxAvoidingSize_two (n : ℕ) (hn : 2 ≤ n) : maxAvoidingSize n 2 = n - 1 := by
+  classical
+  apply le_antisymm
+  · unfold maxAvoidingSize
+    apply Finset.sup_le
+    intro S hS
+    rw [Finset.mem_filter, Finset.mem_powerset] at hS
+    obtain ⟨hSsub, havoid⟩ := hS
+    have h2 : 2 ∉ S := fun h => havoid (self_mem_subsetSums S 2 h (by norm_num))
+    have hsub : S ⊆ (Icc_n n).erase 2 := by
+      intro x hx
+      rw [Finset.mem_erase]
+      exact ⟨fun he => h2 (he ▸ hx), hSsub hx⟩
+    have hcard := Finset.card_le_card hsub
+    have h2mem : (2 : ℕ) ∈ Icc_n n := by rw [Icc_n, Finset.mem_Icc]; omega
+    rw [Finset.card_erase_of_mem h2mem, Icc_n, Nat.card_Icc] at hcard
+    omega
+  · rw [← maxAvoidingSize_ge_iff]
+    refine ⟨(Icc_n n).erase 2, ?_, ?_, ?_⟩
+    · exact Finset.erase_subset _ _
+    · have h2mem : (2 : ℕ) ∈ Icc_n n := by rw [Icc_n, Finset.mem_Icc]; omega
+      rw [Finset.card_erase_of_mem h2mem, Icc_n, Nat.card_Icc]; omega
+    · intro hmem
+      rw [subsetSums, Finset.mem_filter, Finset.mem_image] at hmem
+      obtain ⟨⟨A, hA, hAsum⟩, _⟩ := hmem
+      rw [Finset.mem_powerset] at hA
+      have hle : ∀ a ∈ A, a ≤ 2 := by
+        intro a ha
+        have hs := Finset.single_le_sum (f := fun x => x) (fun i _ => Nat.zero_le i) ha
+        rw [hAsum] at hs; exact hs
+      have heq1 : ∀ a ∈ A, a = 1 := by
+        intro a ha
+        have haS := hA ha
+        rw [Finset.mem_erase, Icc_n, Finset.mem_Icc] at haS
+        have hle2 := hle a ha
+        omega
+      have hAsub : A ⊆ {1} := fun a ha => Finset.mem_singleton.mpr (heq1 a ha)
+      have hsum := Finset.sum_le_sum_of_subset hAsub
+      rw [Finset.sum_singleton] at hsum
+      omega
+
+/-- **The value first drops: `maxAvoidingSize n 3 = n - 2` for `n ≥ 3`.**  Unlike `m = 1, 2`,
+    the target `3` has *two* distinct-positive representations, `{3}` and `{1, 2}`, so avoiding it
+    costs *two* deletions.  Upper bound: a `3`-avoiding `S` has `3 ∉ S` (`self_mem_subsetSums`) and
+    not both `1, 2 ∈ S` (`pair_mem_subsetSums`, since `1 + 2 = 3`), so `S` misses `3` and at least
+    one of `{1, 2}` — two distinct elements of `{1,…,n}`, hence `|S| ≤ n - 2`.  Lower bound: the
+    witness `{1,…,n} ∖ {1, 3}` (every element is `2` or `≥ 4`) avoids `3` and has size `n - 2`.
+    This is the first target where `maxAvoidingSize` dips strictly below `n - 1`, and it forces the
+    sharpened bound `f n ≤ n - 2` (`f_le_sub_two`). -/
+theorem maxAvoidingSize_three (n : ℕ) (hn : 3 ≤ n) : maxAvoidingSize n 3 = n - 2 := by
+  classical
+  apply le_antisymm
+  · unfold maxAvoidingSize
+    apply Finset.sup_le
+    intro S hS
+    rw [Finset.mem_filter, Finset.mem_powerset] at hS
+    obtain ⟨hSsub, havoid⟩ := hS
+    have h3 : 3 ∉ S := fun h => havoid (self_mem_subsetSums S 3 h (by norm_num))
+    have h12 : ¬ (1 ∈ S ∧ 2 ∈ S) := by
+      rintro ⟨h1, h2⟩
+      refine havoid ?_
+      have hp := pair_mem_subsetSums S 1 2 h1 h2 (by norm_num) (by norm_num)
+      simpa using hp
+    rw [not_and_or] at h12
+    rcases h12 with h1 | h2
+    · have hsub : S ⊆ ((Icc_n n).erase 1).erase 3 := by
+        intro x hx
+        rw [Finset.mem_erase, Finset.mem_erase]
+        exact ⟨fun he => h3 (he ▸ hx), fun he => h1 (he ▸ hx), hSsub hx⟩
+      have hcard := Finset.card_le_card hsub
+      have h1mem : (1 : ℕ) ∈ Icc_n n := by rw [Icc_n, Finset.mem_Icc]; omega
+      have h3mem : (3 : ℕ) ∈ (Icc_n n).erase 1 := by
+        rw [Finset.mem_erase, Icc_n, Finset.mem_Icc]; omega
+      rw [Finset.card_erase_of_mem h3mem, Finset.card_erase_of_mem h1mem,
+        Icc_n, Nat.card_Icc] at hcard
+      omega
+    · have hsub : S ⊆ ((Icc_n n).erase 2).erase 3 := by
+        intro x hx
+        rw [Finset.mem_erase, Finset.mem_erase]
+        exact ⟨fun he => h3 (he ▸ hx), fun he => h2 (he ▸ hx), hSsub hx⟩
+      have hcard := Finset.card_le_card hsub
+      have h2mem : (2 : ℕ) ∈ Icc_n n := by rw [Icc_n, Finset.mem_Icc]; omega
+      have h3mem : (3 : ℕ) ∈ (Icc_n n).erase 2 := by
+        rw [Finset.mem_erase, Icc_n, Finset.mem_Icc]; omega
+      rw [Finset.card_erase_of_mem h3mem, Finset.card_erase_of_mem h2mem,
+        Icc_n, Nat.card_Icc] at hcard
+      omega
+  · rw [← maxAvoidingSize_ge_iff]
+    refine ⟨((Icc_n n).erase 1).erase 3, ?_, ?_, ?_⟩
+    · exact (Finset.erase_subset _ _).trans (Finset.erase_subset _ _)
+    · have h1mem : (1 : ℕ) ∈ Icc_n n := by rw [Icc_n, Finset.mem_Icc]; omega
+      have h3mem : (3 : ℕ) ∈ (Icc_n n).erase 1 := by
+        rw [Finset.mem_erase, Icc_n, Finset.mem_Icc]; omega
+      rw [Finset.card_erase_of_mem h3mem, Finset.card_erase_of_mem h1mem, Icc_n, Nat.card_Icc]
+      omega
+    · intro hmem
+      rw [subsetSums, Finset.mem_filter, Finset.mem_image] at hmem
+      obtain ⟨⟨A, hA, hAsum⟩, _⟩ := hmem
+      rw [Finset.mem_powerset] at hA
+      have hle : ∀ a ∈ A, a ≤ 3 := by
+        intro a ha
+        have hs := Finset.single_le_sum (f := fun x => x) (fun i _ => Nat.zero_le i) ha
+        rw [hAsum] at hs; exact hs
+      have heq2 : ∀ a ∈ A, a = 2 := by
+        intro a ha
+        have haS := hA ha
+        rw [Finset.mem_erase, Finset.mem_erase, Icc_n, Finset.mem_Icc] at haS
+        have hle3 := hle a ha
+        omega
+      have hAsub : A ⊆ {2} := fun a ha => Finset.mem_singleton.mpr (heq2 a ha)
+      have hsum := Finset.sum_le_sum_of_subset hAsub
+      rw [Finset.sum_singleton] at hsum
+      omega
+
 /-- **Exact value at the target `m = 0`: `maxAvoidingSize n 0 = n`.**  Since `0` is never a
     positive subset sum (`avoidSum_zero`), *every* subset of `{1,…,n}` avoids it, so the whole
     box `{1,…,n}` is an avoiding witness of the maximal size `n`.  This is the degenerate
@@ -367,6 +504,23 @@ theorem f_le_pred (n : ℕ) (hn : n ≥ 1) : f n ≤ n - 1 := by
       ≤ maxAvoidingSize n 1 :=
         Finset.inf'_le _ (Finset.mem_Icc.mpr ⟨le_refl 1, by nlinarith [hn]⟩)
     _ = n - 1 := maxAvoidingSize_one n
+
+/-- **Sharper universal upper bound:** `f n ≤ n - 2` for `n ≥ 3`.  The target `m = 3` lies in the
+    range `{1,…,n²}` that `f` minimises over (for `n ≥ 3`, `3 ≤ n²`), and `maxAvoidingSize n 3 =
+    n - 2` (`maxAvoidingSize_three`), so `f n ≤ maxAvoidingSize n 3 = n - 2`.  This strictly
+    improves `f_le_pred` (`f n ≤ n - 1`): the two-representation target `3` forces `f` two below
+    the box size once `n ≥ 3`, the first quantitative evidence of the conjectured `n/log n` decay. -/
+theorem f_le_sub_two (n : ℕ) (hn : 3 ≤ n) : f n ≤ n - 2 := by
+  have hn0 : n ≠ 0 := by omega
+  have H : (Finset.Icc 1 (n * n)).Nonempty :=
+    Finset.nonempty_Icc.mpr (Nat.one_le_iff_ne_zero.mpr (Nat.mul_ne_zero hn0 hn0))
+  have hf : f n = (Finset.Icc 1 (n * n)).inf' H (fun m => maxAvoidingSize n m) := by
+    unfold f; rw [dif_neg hn0]
+  rw [hf]
+  calc (Finset.Icc 1 (n * n)).inf' H (fun m => maxAvoidingSize n m)
+      ≤ maxAvoidingSize n 3 :=
+        Finset.inf'_le _ (Finset.mem_Icc.mpr ⟨by omega, by nlinarith [hn]⟩)
+    _ = n - 2 := maxAvoidingSize_three n hn
 
 /-
 ## Part III: The Erdős-Graham Conjecture

--- a/proofs/Proofs/Erdos771Problem.lean
+++ b/proofs/Proofs/Erdos771Problem.lean
@@ -352,7 +352,8 @@ theorem maxAvoidingSize_two (n : ℕ) (hn : 2 ≤ n) : maxAvoidingSize n 2 = n -
         have hle2 := hle a ha
         omega
       have hAsub : A ⊆ {1} := fun a ha => Finset.mem_singleton.mpr (heq1 a ha)
-      have hsum := Finset.sum_le_sum_of_subset hAsub
+      have hsum : ∑ a ∈ A, a ≤ ∑ a ∈ ({1} : Finset ℕ), a :=
+        Finset.sum_le_sum_of_subset hAsub
       rw [Finset.sum_singleton] at hsum
       omega
 
@@ -425,7 +426,8 @@ theorem maxAvoidingSize_three (n : ℕ) (hn : 3 ≤ n) : maxAvoidingSize n 3 = n
         have hle3 := hle a ha
         omega
       have hAsub : A ⊆ {2} := fun a ha => Finset.mem_singleton.mpr (heq2 a ha)
-      have hsum := Finset.sum_le_sum_of_subset hAsub
+      have hsum : ∑ a ∈ A, a ≤ ∑ a ∈ ({2} : Finset ℕ), a :=
+        Finset.sum_le_sum_of_subset hAsub
       rw [Finset.sum_singleton] at hsum
       omega
 

--- a/src/data/research/problems/erdos-771.json
+++ b/src/data/research/problems/erdos-771.json
@@ -9,7 +9,7 @@
   "knownResults": "SOLVED: f(n) = (1/2 + o(1))·n/log n (Erdős–Graham lower bound via prime multiples; Alon–Freiman upper bound via LCM).",
   "currentState": "Verified the elementary Erdős–Graham construction in a new self-contained file; the deep asymptotics remain axiomatized in the companion file.",
   "knowledge": {
-    "progressSummary": "UPDATE (researcher-7, 2026-07-11): discharged the documented m=1 nextStep and added a sharpened universal bound on f, all axiom-free. New in Erdos771Problem.lean: avoidSum_one_iff (for S⊆{1,…,n}, AvoidSum S 1 ↔ 1∉S — only the singleton {1} can sum to 1), maxAvoidingSize_one (maxAvoidingSize n 1 = n−1, the small-target endpoint companion of maxAvoidingSize_eq_of_lt at m>n²; witness {2,…,n}), and f_le_pred (f n ≤ n−1 for n≥1, strictly sharper than the trivial f n ≤ n, since the box {1,…,n} always contains 1 and so is never 1-avoiding). Also fixed a pre-existing Mathlib-drift breakage: Nat.dvd_sub' (removed) → dvd_sub at the minFac step, which had left the whole file non-compiling on main. VERIFIED via standalone lake env lean (exit 0, full file clean) against prebuilt Mathlib v4.26.0; #print axioms on all three new theorems = [propext, Classical.choice, Quot.sound] only (no sorryAx, independent of the 2 deep external axioms Erdős–Graham/Alon–Freiman). Saturated: Erdos771Problem.lean 0-sorry/2-deep-axiom (Erdős–Graham/Alon–Freiman, BLOCKED). Session (researcher-2, 2026-07-09): added maxAvoidingSize monotonicity-in-n (le_succ + Monotone), 0 new axioms, in the Problem file (avoids companion PR #37121). UNVERIFIED docker-down; names checked vs pinned mathlib; mirrors verified maxAvoidingSize_le.",
+    "progressSummary": "UPDATE (researcher-11, 2026-07-11): added the first exact small-target values that drop maxAvoidingSize below n-1 and a SHARPER f-bound, all axiom-free. maxAvoidingSize_two (=n-1), maxAvoidingSize_three (=n-2, the first strict drop: 3=+{3}={1,2} costs two deletions), pair_mem_subsetSums helper, and f_le_sub_two (f n ≤ n-2 for n≥3, strictly improving f_le_pred's n-1 via m=3∈[1,n²]). Host-lean v4.26.0 verified 0-axiom (docker SIGBUS-135 write-blocked, elaboration clean). UPDATE (researcher-7, 2026-07-11): discharged the documented m=1 nextStep and added a sharpened universal bound on f, all axiom-free. New in Erdos771Problem.lean: avoidSum_one_iff (for S⊆{1,…,n}, AvoidSum S 1 ↔ 1∉S — only the singleton {1} can sum to 1), maxAvoidingSize_one (maxAvoidingSize n 1 = n−1, the small-target endpoint companion of maxAvoidingSize_eq_of_lt at m>n²; witness {2,…,n}), and f_le_pred (f n ≤ n−1 for n≥1, strictly sharper than the trivial f n ≤ n, since the box {1,…,n} always contains 1 and so is never 1-avoiding). Also fixed a pre-existing Mathlib-drift breakage: Nat.dvd_sub' (removed) → dvd_sub at the minFac step, which had left the whole file non-compiling on main. VERIFIED via standalone lake env lean (exit 0, full file clean) against prebuilt Mathlib v4.26.0; #print axioms on all three new theorems = [propext, Classical.choice, Quot.sound] only (no sorryAx, independent of the 2 deep external axioms Erdős–Graham/Alon–Freiman). Saturated: Erdos771Problem.lean 0-sorry/2-deep-axiom (Erdős–Graham/Alon–Freiman, BLOCKED). Session (researcher-2, 2026-07-09): added maxAvoidingSize monotonicity-in-n (le_succ + Monotone), 0 new axioms, in the Problem file (avoids companion PR #37121). UNVERIFIED docker-down; names checked vs pinned mathlib; mirrors verified maxAvoidingSize_le.",
     "builtItems": [
       "prime_multiples_size in Erdos771Construction.lean:64",
       "prime_multiples_avoid in Erdos771Construction.lean:78",
@@ -19,7 +19,8 @@
       "erdos_graham_conjecture_true in Erdos771Problem.lean: combined the two axiomatic bounds into |f n/(n/log n) - 1/2| < ε (squeeze on n≥2 where n/log n>0)",
       "leading_constant in Erdos771Problem.lean: Tendsto form via Metric.tendsto_atTop + Real.dist_eq, derived from the conjecture",
       "Discharged prime_multiples_size and prime_multiples_avoid sorries in Erdos771Problem.lean (ported from verified Erdos771Construction.lean)",
-      "maxAvoidingSize_le_succ + maxAvoidingSize_monotone (Erdos771Problem.lean): maxAvoidingSize is non-decreasing in the range n (0 axioms)."
+      "maxAvoidingSize_le_succ + maxAvoidingSize_monotone (Erdos771Problem.lean): maxAvoidingSize is non-decreasing in the range n (0 axioms).",
+      "Erdos771Problem.lean Part II (researcher-11, 2026-07-11, host-lean v4.26.0 verified 0-axiom; docker SIGBUS-135 write-blocked but full elaboration clean): the exact small-target values that first push maxAvoidingSize below n-1 and SHARPEN the headline f-bound. pair_mem_subsetSums (a+b∈subsetSums S for distinct a,b∈S — two-element companion of self_mem_subsetSums, detects the m=a+b obstruction); maxAvoidingSize_two (n≥2 ⟹ maxAvoidingSize n 2 = n-1: single representation {2}, witness {1..n}∖{2}); maxAvoidingSize_three (n≥3 ⟹ = n-2: target 3 has TWO distinct-positive representations {3},{1,2} so avoiding costs two deletions — upper bound via self_mem_subsetSums+pair_mem_subsetSums, lower-bound witness {1..n}∖{1,3} whose elements are 2 or ≥4 so 3 unreachable); f_le_sub_two (n≥3 ⟹ f n ≤ n-2, strictly improving f_le_pred's f n ≤ n-1, since m=3∈[1,n²] and maxAvoidingSize n 3 = n-2). #print axioms on all four = [propext, Classical.choice, Quot.sound] only (independent of the 2 deep external axioms)."
     ],
     "insights": [
       "If every element of S is a multiple of p, so is every subset sum, so S avoids any m with p ∤ m — the engine of the Erdős–Graham lower bound. Primality is not even needed for avoidance.",
@@ -80,8 +81,8 @@
     {
       "path": "Proofs/Erdos771Problem.lean",
       "filename": "Erdos771Problem.lean",
-      "lineCount": 491,
-      "theoremCount": 19,
+      "lineCount": 1173,
+      "theoremCount": 23,
       "axiomCount": 2,
       "defCount": 16,
       "sorryCount": 0,


### PR DESCRIPTION
## Summary

Extends `Erdos771Problem.lean` (Part II, the maximum-avoiding-size function behind Erdős #771, `f(n) = (1/2+o(1))·n/log n`) with the **first exact small-target values** of `maxAvoidingSize n m` that drop below the box size `n − 1`, and uses them to **strictly sharpen** the known headline upper bound on `f`.

`maxAvoidingSize n m` is the largest subset of `{1,…,n}` whose subset sums avoid `m`, and `f n = min_{1 ≤ m ≤ n²} maxAvoidingSize n m`. Prior work pinned the endpoints (`maxAvoidingSize n 1 = n−1`, `= n` for `m > n²`) and proved `f n ≤ n − 1` (`f_le_pred`). This PR resolves the next two targets and improves the bound:

| target `m` | `maxAvoidingSize n m` | why |
|---|---|---|
| `1` | `n − 1` (prior) | one representation `{1}` |
| `2` | `n − 1` (**new**) | one representation `{2}` |
| `3` | `n − 2` (**new**) | **two** representations `{3}`, `{1,2}` → two deletions |

Since `3 ∈ [1, n²]` for `n ≥ 3`, the minimum defining `f` inherits the drop: **`f n ≤ n − 2`** for `n ≥ 3`, strictly improving `f_le_pred`. This is the first quantitative evidence in the formalization of the conjectured `n/log n` decay.

## New declarations (4, self-contained in the Problem file, 0 sorries / 0 new axioms)

- `pair_mem_subsetSums` — `a + b ∈ subsetSums S` for distinct `a, b ∈ S` (two-element companion of `self_mem_subsetSums`; detects the `m = a + b` obstruction, e.g. `3 = 1 + 2`).
- `maxAvoidingSize_two` — `n ≥ 2 ⟹ maxAvoidingSize n 2 = n − 1` (witness `{1,…,n} ∖ {2}`).
- `maxAvoidingSize_three` — `n ≥ 3 ⟹ maxAvoidingSize n 3 = n − 2` (witness `{1,…,n} ∖ {1,3}`, whose elements are `2` or `≥ 4`, so `3` is unreachable).
- `f_le_sub_two` — `n ≥ 3 ⟹ f n ≤ n − 2` (strictly sharper than `f_le_pred`).

These live entirely in `Erdos771Problem.lean` (no dependency on the sibling `Erdos771Construction.lean`, which proves analogous facts in its own namespace).

## Verification

- **Host `lean` v4.26.0** (elan toolchain, full prebuilt Mathlib cache): the complete file elaborates with **zero errors**.
- `#print axioms` on all four new declarations → `[propext, Classical.choice, Quot.sound]` only — **independent of the two deep external axioms** (Erdős–Graham / Alon–Freiman) that the file's asymptotic statements assume.
- Docker build (`docker-build.sh Proofs.Erdos771Problem`) reached full elaboration `[7743/7743]` but the olean **write** was blocked by the recurring fleet `SIGBUS`/exit-135 on this full-`import Mathlib` module (memory, not a type error); host-lean is the authoritative check, matching the pattern used for prior PRs on this file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)