### PR TITLE
research(erdos-1090-incomplete-01): colored realizable-size set is infinite

### DIFF
--- a/proofs/Proofs/Erdos1090Problem.lean
+++ b/proofs/Proofs/Erdos1090Problem.lean
@@ -1319,6 +1319,18 @@ theorem hasRamseyPropertyColored_realizable_setOf_eq_Ici {C : Type*} [Finite C] 
   simpa only [Set.mem_setOf_eq, Set.mem_Ici] using
     hasRamseyPropertyColored_realizable_card_iff hk n
 
+/-- **The colored realizable-size set is infinite.**  For a finite palette `C` and `k ≥ 3`
+there are arbitrarily large finite point sets with the `C`-colored Ramsey property: the
+realizable cardinalities form the infinite up-ray `Set.Ici (ramseyNumberColored C k)`
+(`hasRamseyPropertyColored_realizable_setOf_eq_Ici`), and `ℕ` has no maximal element.  The
+colored analogue of `hasRamseyProperty_realizable_setOf_infinite`, completing the colored
+realizable-set characterization. -/
+theorem hasRamseyPropertyColored_realizable_setOf_infinite {C : Type*} [Finite C] {k : ℕ}
+    (hk : k ≥ 3) :
+    {n : ℕ | ∃ A : Finset Point, A.card = n ∧ HasRamseyPropertyColored C A k}.Infinite := by
+  rw [hasRamseyPropertyColored_realizable_setOf_eq_Ici hk]
+  exact Set.Ici_infinite _
+
 /--
 The main theorem: Erdős #1090 is solved affirmatively.
 -/


### PR DESCRIPTION
## Summary

`Erdos1090Problem.lean` (Erdős #1090, monochromatic collinear points — solved, 0/0) has a thorough colored-Ramsey-number API. The uncolored realizable-size set is characterized both as the up-ray `Set.Ici (ramseyNumber k)` (`hasRamseyProperty_realizable_setOf_eq_Ici`) **and** as infinite (`hasRamseyProperty_realizable_setOf_infinite`). The colored side had the up-ray form but was missing its infinitude companion. This PR adds it (0-sorry/0-axiom):

- **`hasRamseyPropertyColored_realizable_setOf_infinite`** — for a finite palette `C` and `k ≥ 3`, `{n | ∃ A, |A| = n ∧ HasRamseyPropertyColored C A k}` is infinite (it equals `Set.Ici (ramseyNumberColored C k)`, and `ℕ` has no maximal element).

A one-line mirror of the uncolored proof, completing the colored realizable-set characterization. Does not touch the file's genuinely-blocked open direction (a quantitative upper bound on `ramseyNumber k` needs a non-explicit Hales–Jewett dimension bound).

## Verification

- `./proofs/scripts/docker-build.sh Proofs.Erdos1090Problem` → **Build completed successfully (2433 jobs)**.
- 0 sorries, 0 axioms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)