### PR TITLE
research(e-transcendental-oq-02-oq-06): effective recurrence — bounded-gap occurrences from a modulus

### DIFF
--- a/proofs/Proofs/ETranscendentalOQ02.lean
+++ b/proofs/Proofs/ETranscendentalOQ02.lean
@@ -1183,12 +1183,16 @@ theorem exists_match_ge_of_count_gt (b : ℕ) (x : ℝ) (k : ℕ) (s : Fin k →
       (fun n => ∀ i : Fin k, nthDigit b (n + i.val) x = (s i : ℤ)) with hA
   set B := (Finset.range P).filter
       (fun n => ∀ i : Fin k, nthDigit b (n + i.val) x = (s i : ℤ)) with hB
-  have hBA : B ⊆ A := Finset.filter_subset_filter _ (Finset.range_subset.mpr hPN)
+  have hsub : Finset.range P ⊆ Finset.range N :=
+    fun a ha => Finset.mem_range.mpr (lt_of_lt_of_le (Finset.mem_range.mp ha) hPN)
+  have hBA : B ⊆ A := Finset.filter_subset_filter _ hsub
   have hBcard : B.card ≤ P := by
     calc B.card ≤ (Finset.range P).card := Finset.card_filter_le _ _
       _ = P := Finset.card_range P
   have hne : (A \ B).Nonempty := by
-    rw [← Finset.card_pos, Finset.card_sdiff hBA]
+    rw [Finset.sdiff_nonempty]
+    intro hAB
+    have hle := Finset.card_le_card hAB
     omega
   obtain ⟨n, hn⟩ := hne
   rw [Finset.mem_sdiff] at hn

--- a/proofs/Proofs/ETranscendentalOQ02.lean
+++ b/proofs/Proofs/ETranscendentalOQ02.lean
@@ -1166,6 +1166,100 @@ theorem match_count_ge_linear_of_modulus (b : ℕ) (hb : 2 ≤ b) (x : ℝ)
   rw [div_mul_cancel₀ _ hNR.ne'] at hmul
   exact le_of_lt hmul
 
+/-- **Occurrence past a threshold.** A pure-`Finset` strengthening of
+    `exists_match_lt_of_count_pos`: if the count of tuple-`s` matches over
+    `Finset.range N` *exceeds* the threshold `P` (with `P ≤ N`), then a matching
+    position exists with `P ≤ n < N` — an occurrence *beyond* the first `P`
+    starting positions. Proof: the matches below `P` number at most `P`, so once
+    the total exceeds `P` the set-difference `A \ B` (matches in `[0,N)` minus
+    matches in `[0,P)`) is nonempty; any element is a match at a position `≥ P`.
+    Carries no normality hypothesis. -/
+theorem exists_match_ge_of_count_gt (b : ℕ) (x : ℝ) (k : ℕ) (s : Fin k → Fin b)
+    (P N : ℕ) (hPN : P ≤ N)
+    (hgt : P < ((Finset.range N).filter
+        (fun n => ∀ i : Fin k, nthDigit b (n + i.val) x = (s i : ℤ))).card) :
+    ∃ n, P ≤ n ∧ n < N ∧ ∀ i : Fin k, nthDigit b (n + i.val) x = (s i : ℤ) := by
+  set A := (Finset.range N).filter
+      (fun n => ∀ i : Fin k, nthDigit b (n + i.val) x = (s i : ℤ)) with hA
+  set B := (Finset.range P).filter
+      (fun n => ∀ i : Fin k, nthDigit b (n + i.val) x = (s i : ℤ)) with hB
+  have hBA : B ⊆ A := Finset.filter_subset_filter _ (Finset.range_subset.mpr hPN)
+  have hBcard : B.card ≤ P := by
+    calc B.card ≤ (Finset.range P).card := Finset.card_filter_le _ _
+      _ = P := Finset.card_range P
+  have hne : (A \ B).Nonempty := by
+    rw [← Finset.card_pos, Finset.card_sdiff hBA]
+    omega
+  obtain ⟨n, hn⟩ := hne
+  rw [Finset.mem_sdiff] at hn
+  obtain ⟨hnA, hnB⟩ := hn
+  have hnA' := hnA
+  rw [hA, Finset.mem_filter, Finset.mem_range] at hnA'
+  refine ⟨n, ?_, hnA'.1, hnA'.2⟩
+  by_contra hlt
+  push_neg at hlt
+  exact hnB (by rw [hB, Finset.mem_filter, Finset.mem_range]; exact ⟨hlt, hnA'.2⟩)
+
+/-- **Effective recurrence (bounded-gap occurrences).** Given a modulus of
+    normality, *every* tuple `s` of length `k` occurs at some position in the
+    window `[P, N₀)` for the explicit bound
+    `N₀ := max (max (M k (b^{-k}/2)) 1) (2·bᵏ·P + 1)`, for *every* threshold `P`.
+    So occurrences are not merely infinite (`normal_ktuple_infinitely_often`) but
+    appear with an explicit gap: after any point `P`, the next occurrence lies
+    below a concrete function of the modulus, `k`, and `P`. This upgrades
+    `first_occurrence_lt_of_modulus` (essentially its `P = 0` content) to an
+    effective recurrence statement at an arbitrary starting point. Proof: the
+    effective density bound `match_count_ge_linear_of_modulus` gives at least
+    `(b^{-k}/2)·N₀` matches below `N₀`; the choice `N₀ > 2·bᵏ·P` makes this count
+    exceed `P`, so `exists_match_ge_of_count_gt` extracts a match at position
+    `≥ P`. -/
+theorem next_occurrence_lt_of_modulus (b : ℕ) (hb : 2 ≤ b) (x : ℝ)
+    (M : ℕ → ℝ → ℕ) (hM : EffectivelyNormalWithModulus b x M)
+    (k : ℕ) (s : Fin k → Fin b) (P : ℕ) :
+    ∃ n, P ≤ n ∧
+      n < max (max (M k ((b : ℝ) ^ (-(k : ℤ)) / 2)) 1) (2 * b ^ k * P + 1) ∧
+      ∀ i : Fin k, nthDigit b (n + i.val) x = (s i : ℤ) := by
+  have hbR : (0 : ℝ) < (b : ℝ) := by exact_mod_cast (by omega : 0 < b)
+  have hposk : (0 : ℝ) < (b : ℝ) ^ (-(k : ℤ)) := zpow_pos hbR _
+  set N₀ : ℕ :=
+    max (max (M k ((b : ℝ) ^ (-(k : ℤ)) / 2)) 1) (2 * b ^ k * P + 1) with hN0def
+  have hmodle : max (M k ((b : ℝ) ^ (-(k : ℤ)) / 2)) 1 ≤ N₀ := le_max_left _ _
+  have hTle : 2 * b ^ k * P + 1 ≤ N₀ := le_max_right _ _
+  have hcount := match_count_ge_linear_of_modulus b hb x M hM k s N₀ hmodle
+  -- b^{-k} · b^k = 1
+  have hbk1 : (b : ℝ) ^ (-(k : ℤ)) * (b : ℝ) ^ k = 1 := by
+    rw [← zpow_natCast (b : ℝ) k, ← zpow_add₀ hbR.ne']
+    simp
+  -- P < (b^{-k}/2)·N₀
+  have hPcountR : (P : ℝ) <
+      (((Finset.range N₀).filter
+        (fun n => ∀ i : Fin k, nthDigit b (n + i.val) x = (s i : ℤ))).card : ℝ) := by
+    have hpos2 : (0 : ℝ) < (b : ℝ) ^ (-(k : ℤ)) / 2 := div_pos hposk two_pos
+    have hTleR : ((2 * b ^ k * P + 1 : ℕ) : ℝ) ≤ (N₀ : ℝ) := by exact_mod_cast hTle
+    have hexp : ((2 * b ^ k * P + 1 : ℕ) : ℝ) = 2 * (b : ℝ) ^ k * (P : ℝ) + 1 := by
+      push_cast; ring
+    have hmono : (b : ℝ) ^ (-(k : ℤ)) / 2 * (2 * (b : ℝ) ^ k * (P : ℝ) + 1)
+        ≤ (b : ℝ) ^ (-(k : ℤ)) / 2 * (N₀ : ℝ) := by
+      apply mul_le_mul_of_nonneg_left _ (le_of_lt hpos2)
+      rw [← hexp]; exact hTleR
+    have hval : (b : ℝ) ^ (-(k : ℤ)) / 2 * (2 * (b : ℝ) ^ k * (P : ℝ) + 1)
+        = (P : ℝ) + (b : ℝ) ^ (-(k : ℤ)) / 2 := by
+      have hrw : (b : ℝ) ^ (-(k : ℤ)) / 2 * (2 * (b : ℝ) ^ k * (P : ℝ) + 1)
+          = (b : ℝ) ^ (-(k : ℤ)) * (b : ℝ) ^ k * (P : ℝ)
+              + (b : ℝ) ^ (-(k : ℤ)) / 2 := by ring
+      rw [hrw, hbk1]; ring
+    have hstep : (P : ℝ) < (b : ℝ) ^ (-(k : ℤ)) / 2 * (N₀ : ℝ) := by
+      linarith [hmono, hval, hpos2]
+    linarith [hstep, hcount]
+  have hPcount : P < ((Finset.range N₀).filter
+      (fun n => ∀ i : Fin k, nthDigit b (n + i.val) x = (s i : ℤ))).card := by
+    exact_mod_cast hPcountR
+  have hPN : P ≤ N₀ := by
+    have h1 : 1 ≤ b ^ k := Nat.one_le_pow _ _ (by omega)
+    have hPT : P ≤ 2 * b ^ k * P + 1 := by nlinarith [h1, Nat.zero_le P]
+    exact le_trans hPT hTle
+  exact exists_match_ge_of_count_gt b x k s P N₀ hPN hPcount
+
 -- ============================================================
 -- PART IV.10: THE CONSERVATION LAW
 -- ============================================================

--- a/research/problems/e-transcendental-oq-02-oq-06/knowledge.md
+++ b/research/problems/e-transcendental-oq-02-oq-06/knowledge.md
@@ -136,3 +136,56 @@ VERIFIED green via direct lean-elab vs pinned Mathlib v4.26.0 (docker containerd
 built the dep chain deepest-first into /tmp — `Proofs.HermiteLindemann` (Mathlib-only, ~20s) then
 `Proofs.eTranscendental` (imports HermiteLindemann) — then elaborated target, exit 0. Gallery meta
 e-transcendental-oq-02: lineCount 2016→2029, theoremCount 89→90.
+
+## Session 2026-07-11 (Researcher-2) — Effective recurrence (bounded-gap occurrences)
+
+**Mode**: REVISIT (RICH) | **Outcome**: progress (VERIFIED, 0 sorry, 0 new axiom)
+
+### What I did
+Extended the effective-modulus layer (PART IV.9) of `ETranscendentalOQ02.lean`.
+The prior layer bounded only the *first* occurrence (`first_occurrence_lt_of_modulus`)
+and the density (`match_count_ge_linear_of_modulus`); nothing bounded the *next*
+occurrence after an arbitrary point. Added:
+
+- `exists_match_ge_of_count_gt` (pure `Finset`, no normality hypothesis) — if the
+  tuple-`s` match count over `range N` *exceeds* a threshold `P` (with `P ≤ N`),
+  then a match exists at a position `P ≤ n < N`. Proof: matches in `[0,P)` number
+  `≤ P`, so `A \ B` (matches in `[0,N)` minus matches in `[0,P)`) is nonempty once
+  the total exceeds `P`. Uses `Finset.sdiff_nonempty` + `Finset.card_le_card`.
+- `next_occurrence_lt_of_modulus` — with a modulus `M`, every `k`-tuple recurs
+  after any threshold `P` below the explicit bound
+  `max (max (M k (b^{-k}/2)) 1) (2·bᵏ·P + 1)`. This is the effective (bounded-gap)
+  form of infinitely-many-occurrences: it upgrades `first_occurrence_lt_of_modulus`
+  (its `P = 0` content) to arbitrary `P`, and makes the qualitative
+  `normal_ktuple_infinitely_often` quantitative with an explicit inter-occurrence
+  gap. Proof: `match_count_ge_linear_of_modulus` gives `≥ (b^{-k}/2)·N₀` matches
+  below `N₀`; picking `N₀ > 2·bᵏ·P` makes the count exceed `P`, then
+  `exists_match_ge_of_count_gt` extracts the match at position `≥ P`.
+
+### Key findings
+- The gap constant is forced by the density rate: to guarantee more than `P`
+  matches at density `b^{-k}/2` one needs a window `≳ 2·bᵏ·P`, hence the `2·bᵏ·P`
+  term. The `b^{-k}·bᵏ = 1` identity (`zpow_natCast` + `zpow_add₀`) is the crux of
+  the arithmetic `(b^{-k}/2)·(2·bᵏ·P + 1) = P + b^{-k}/2 > P`.
+- Gotchas (Mathlib v4.26.0): `Finset.range_subset.mpr` did not accept `P ≤ N`
+  directly (expects the unfolded `∀ x < P, x ∈ range N`) — build the subset by a
+  membership lambda instead. `Finset.card_sdiff hBA` failed (the resolved lemma is
+  the unconditional `(s\t).card = s.card - (s∩t).card`); route nonemptiness through
+  `Finset.sdiff_nonempty : (s\t).Nonempty ↔ ¬ s ⊆ t` + `card_le_card` + `omega`.
+
+### Status
+Core axiom `e_absolutely_normal` remains **genuinely open** (no base proved normal
+for `e` as of 2026) — not eliminable. The oq-06 goal (`normal_imp_irrational`) was
+long discharged (a theorem, not an axiom). This session sharpens the effective
+theory, not the open core.
+
+### Files modified
+- `proofs/Proofs/ETranscendentalOQ02.lean` (+2 theorems, PART IV.9; 2062→2160 lines)
+- `src/data/proofs/e-transcendental-oq-02/meta.json` (lineCount 2062→2160,
+  theoremCount 90→92, +2 originalContributions)
+- `src/data/research/problems/e-transcendental-oq-02-oq-06.json` (knowledge)
+
+### Next steps
+- Iterate `next_occurrence_lt_of_modulus` (with `P := previous+1`) to build an
+  explicit strictly-increasing enumeration of occurrence positions with
+  modulus-controlled gaps.

--- a/src/data/proofs/e-transcendental-oq-02/meta.json
+++ b/src/data/proofs/e-transcendental-oq-02/meta.json
@@ -22,7 +22,7 @@
     ],
     "badge": "axiom",
     "sorries": 0,
-    "theoremCount": 90,
+    "theoremCount": 92,
     "mathlibDependencies": [
       {
         "theorem": "Real.exp_one_gt_d9",
@@ -78,11 +78,13 @@
       "Theorem sum_match_count_eq (conservation law): since every base-b digit lies in [0,b), each starting position carries a unique k-block, so the b^k tuple-match filters partition Finset.range N and their counts sum to exactly N. A pure combinatorial identity of the digit expansion, assuming no normality.",
       "Definition matchFreq and theorem sum_matchFreq_eq_one: the empirical tuple frequencies form a genuine probability distribution on Fin k -> Fin b, summing to 1 at every window N >= 1.",
       "Theorem matchFreq_tendsto_of_others (conservation-closure of normality): if every k-tuple except one has matching frequency converging to b^{-k}, then the omitted tuple does too, since the frequencies sum to 1; equidistribution of one block is forced by that of all the others.",
-      "Theorem isNormalInBase_of_all_but_one: a normality test needs only all-but-one block per length; the omitted block's equidistribution is supplied automatically by the conservation law."
+      "Theorem isNormalInBase_of_all_but_one: a normality test needs only all-but-one block per length; the omitted block's equidistribution is supplied automatically by the conservation law.",
+      "Theorem exists_match_ge_of_count_gt (pure-Finset core, no normality hypothesis): if the count of tuple-s matches over range N exceeds a threshold P (with P ≤ N), then a match exists at a position n with P ≤ n < N — an occurrence beyond the first P starting positions. Proof: matches below P number at most P, so once the total exceeds P the set-difference (matches in [0,N) minus matches in [0,P)) is nonempty.",
+      "Theorem next_occurrence_lt_of_modulus (effective recurrence / bounded-gap occurrences): given a modulus of normality M, every k-tuple s recurs after any threshold P at a position below the explicit bound max(max(M k (b^{-k}/2)) 1)(2·b^k·P+1). Upgrades first_occurrence_lt_of_modulus (its P=0 content) to an effective recurrence statement at an arbitrary starting point, and makes normal_ktuple_infinitely_often quantitative with an explicit inter-occurrence gap. Proof: the effective density bound match_count_ge_linear_of_modulus gives ≥ (b^{-k}/2)·N₀ matches below N₀; the choice N₀ > 2·b^k·P makes this exceed P, so exists_match_ge_of_count_gt extracts a match at position ≥ P."
     ],
     "dateAdded": "2026-05-04",
     "axiomCount": 1,
-    "lineCount": 2062,
+    "lineCount": 2160,
     "assumptions": "1 axiom (the main open conjecture): e_absolutely_normal — e is absolutely normal (open as of 2026). Session 13 discharged the normal_imp_irrational axiom: composing rational_has_missing_ktuple_intCast (the ℤ-valued lift of S12's Layer 4a missing-tuple), rational_match_count_le (the matching-position count is bounded by N₀ via Finset.card_le_card), and tendsto_bounded_count_div_atTop_zero (squeeze: 0 ≤ count_N/N ≤ N₀/N → 0). For rational q, normality forces frequency → b^(-k) > 0, but the bound forces it → 0; tendsto_nhds_unique closes the contradiction. Earlier history: rational-digits-periodic was discharged in Session 11 via the 3-layer recipe (Layer 1 eventually_periodic_iterate S8, Layer 2 ratResidue_eventually_periodic S9, Layer 3 floor_pow_mul_div S10 + nthDigit_succ_via_residue S11), then Session 12 added Layer 4a (Fin b cast bridge) and rational_has_missing_ktuple. 33 public theorems including first 9 decimal digits of e proved from exp_one bounds and now normal_imp_irrational fully axiom-free.",
     "mathlib_version": "4.26.0",
     "definitionCount": 7
@@ -105,7 +107,9 @@
       "Real analysis (limits, sequences)",
       "Number theory (rational approximation)",
       "Digit expansions and continued fractions"
-    ]
+    ],
+    "lineCount": 2160,
+    "theoremCount": 92
   },
   "sections": [
     {
@@ -215,9 +219,9 @@
       "Filter"
     ],
     "namespace": "ETranscendentalOQ02",
-    "lineCount": 2062,
+    "lineCount": 2160,
     "axiomCount": 1,
-    "theoremCount": 90,
+    "theoremCount": 92,
     "definitionCount": 7,
     "path": "Proofs/ETranscendentalOQ02.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

Extends the **effective-modulus layer** of `ETranscendentalOQ02.lean` ("Is e a Normal Number?") with an **effective recurrence** result. The prior layer bounded only the *first* occurrence of a tuple (`first_occurrence_lt_of_modulus`) and the occurrence density (`match_count_ge_linear_of_modulus`); nothing bounded the *next* occurrence after an arbitrary point. This PR closes that gap.

## New theorems (both VERIFIED, 0 sorry, 0 new axiom)

- **`next_occurrence_lt_of_modulus`** — given a modulus of normality `M`, every `k`-tuple `s` recurs after *any* threshold `P` at a position below the explicit bound
  `max (max (M k (b^{-k}/2)) 1) (2·bᵏ·P + 1)`.
  This upgrades `first_occurrence_lt_of_modulus` (essentially its `P = 0` content) to effective recurrence at an arbitrary starting point, and makes the qualitative `normal_ktuple_infinitely_often` **quantitative** with an explicit inter-occurrence gap.
- **`exists_match_ge_of_count_gt`** — pure-`Finset` core, no normality hypothesis: if the tuple-match count over `range N` exceeds a threshold `P` (with `P ≤ N`), a match exists at position `P ≤ n < N`.

## Proof idea

The effective density bound gives `≥ (b^{-k}/2)·N₀` matches below `N₀`; choosing `N₀ > 2·bᵏ·P` (via the identity `b^{-k}·bᵏ = 1`) makes this count exceed `P`, so the pure-Finset core extracts a match at position `≥ P` (the matches below `P` number at most `P`).

## Verification

Docker build `Proofs.ETranscendentalOQ02` succeeded (3085 jobs). Axiom count unchanged at **1** (the genuinely open `e_absolutely_normal`). The oq-06 goal `normal_imp_irrational` was long ago discharged as a theorem; this PR sharpens the effective theory around it, not the open core.

## Files

- `proofs/Proofs/ETranscendentalOQ02.lean` (+2 theorems, PART IV.9; 2062→2160 lines)
- `src/data/proofs/e-transcendental-oq-02/meta.json` (lineCount 2062→2160, theoremCount 90→92, +2 originalContributions)
- `src/data/research/problems/e-transcendental-oq-02-oq-06.json` + `research/problems/.../knowledge.md` (knowledge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)