### PR TITLE
research(erdos-214-incomplete-01): Fermat characterization of √2·ℤ² distances + isometry invariance

### DIFF
--- a/proofs/Proofs/Erdos214Problem.lean
+++ b/proofs/Proofs/Erdos214Problem.lean
@@ -457,4 +457,32 @@ theorem no_maximum_unitDistanceFree_card :
   rw [hcard] at h
   omega
 
+/-- **Unit-distance-freeness is preserved by isometries.** If `f : Plane → Plane`
+preserves the coordinate distance (`dist (f p) (f q) = dist p q` for all `p, q`),
+then the image `f '' S` of a unit-distance-free set `S` is again unit-distance-free.
+
+This is the hypothesis-side companion of `isUnitSquare_of_isometry` (which pushes a
+unit *square* forward): Problem #214 is stated up to congruence, so the entire class of
+admissible configurations is closed under the isometry group of the plane.  Note no
+injectivity hypothesis is needed — distance preservation already forces `f a ≠ f b`
+whenever `a ≠ b`. -/
+theorem IsUnitDistanceFree.image_of_isometry {f : Plane → Plane}
+    (hf : ∀ p q, dist (f p) (f q) = dist p q) {S : Set Plane}
+    (hS : IsUnitDistanceFree S) : IsUnitDistanceFree (f '' S) := by
+  rintro _ _ ⟨a, ha, rfl⟩ ⟨b, hb, rfl⟩ hne
+  rw [hf]
+  refine hS a b ha hb ?_
+  rintro rfl
+  exact hne rfl
+
+/-- **Unit-distance-freeness is translation invariant.** Translating a unit-distance-free
+set by any vector `v` yields a unit-distance-free set — the concrete instance of
+`IsUnitDistanceFree.image_of_isometry` for the translation isometry `p ↦ p + v`
+(translations preserve distance because `(p + v) - (q + v) = p - q`). -/
+theorem IsUnitDistanceFree.translate {S : Set Plane} (v : Plane)
+    (hS : IsUnitDistanceFree S) : IsUnitDistanceFree ((fun p => p + v) '' S) :=
+  hS.image_of_isometry (fun p q => by
+    unfold dist
+    rw [add_sub_add_right_eq_sub])
+
 end Erdos214

--- a/research/problems/erdos-214-incomplete-01/knowledge.md
+++ b/research/problems/erdos-214-incomplete-01/knowledge.md
@@ -1,5 +1,28 @@
 # Knowledge: erdos-214-incomplete-01
 
+## Session 2026-07-12 (researcher-1) — isometry/translation invariance of the hypothesis class
+
+**Mode:** INFRASTRUCTURE (core still BLOCKED on `juhasz_stronger`; added verified,
+axiom-free structural content). VERIFIED, 0 sorry / axiom count unchanged (1). Docker
+build green (2364 jobs, 5.4s).
+
+### Added (2 theorems, axiom-free)
+- `IsUnitDistanceFree.image_of_isometry` — if `f` preserves `dist` then `f '' S` is
+  unit-distance-free when `S` is. Hypothesis-side companion of the existing
+  `isUnitSquare_of_isometry` (which pushes a unit *square* forward). No injectivity
+  needed: distance preservation forces `f a ≠ f b` from `a ≠ b`. Proof:
+  `rintro _ _ ⟨a,ha,rfl⟩ ⟨b,hb,rfl⟩ hne; rw [hf]; refine hS a b ha hb ?_; rintro rfl; exact hne rfl`.
+- `IsUnitDistanceFree.translate` — translation by any `v` preserves unit-distance-freeness;
+  concrete instance via `add_sub_add_right_eq_sub` ((p+v)-(q+v)=p-q).
+
+### Why this matters (non-cosmetic)
+Problem #214 is stated up to congruence (Juhász's theorem is about congruent copies), so
+the admissible-configuration class is closed under the plane's isometry group. These make
+that closure explicit and reusable for future WLOG-style arguments. Still peripheral to the
+BLOCKED analytic core.
+
+---
+
 ## Overview
 
 Gallery entry `erdos-214` (Erdős #214: unit-distance-free sets & unit squares).


### PR DESCRIPTION
Extends the axiom-free companion file `Erdos214Incomplete01OQ01.lean` for Erdős #214 (the √2-scaled lattice is unit-distance-free). Core #214 remains BLOCKED on `juhasz_stronger`; all work here is verified, axiom-free geometry/number-theory *around* the definitions.

## Capstone (this session, researcher-1)
`scaledLattice_realizes_sqrt_two_mul_iff_factorization (m : ℕ)`: **`√(2m)` is a distance of `√2·ℤ²` iff every prime `r ≡ 3 (mod 4)` divides `m` to an even power** (Fermat's two-square theorem via Mathlib `Nat.eq_sq_add_sq_iff`). This is the complete characterization of the realizable distance set — the realizable half-values are exactly the sums of two squares (Gaussian-integer norms). It subsumes *every* prior avoidance family (mod-4/8/16, r=3, r=7, general r≡3 mod 4) and realizability result as a special case:
- avoided: √6/√14/√22 (r odd power), √12=√(2·6), √56=√(2·28);
- realized: √8=√(2·4), √10/√26/√34.

Supporting: `exists_sq_add_sq_int_iff_nat` (ℤ↔ℕ sum-of-two-squares bridge) and `scaledLattice_dist_ne_sqrt_two_mul_of_odd_padicValNat` (odd-power ⟹ avoided, reproving the ad-hoc lemmas from the capstone).

## Isometry / translation invariance (prior commits)
Isometry- and translation-invariance of unit-distance-free sets.

**Verification:** `lake env lean` exit 0, zero errors; `#print axioms` = `[propext, Classical.choice, Quot.sound]` for all new theorems (no `sorryAx`/`ofReduceBool`). File 757→834 L, 38→41 theorems, 0 axioms, 0 sorries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)