### PR TITLE
research(lagrange-theorem-oq-01): order-pq classification capstone — q≢1(mod p) ⟹ G cyclic [VERIFIED]

### DIFF
--- a/proofs/Proofs/LagrangeTheoremOQ01.lean
+++ b/proofs/Proofs/LagrangeTheoremOQ01.lean
@@ -480,6 +480,97 @@ theorem exists_normal_subgroup_card_eq_p_of_card_eq_pq (p q : ℕ) (hp : p.Prime
     sylow_p_normal_of_card_eq_pq p q hp hq hpq hmod P hG,
     card_sylow_p_of_card_eq_pq p q hp hq hpq P hG⟩
 
+/-
+═══════════════════════════════════════════════════════════════════════════════
+PART VIII: THE CLASSIFICATION CAPSTONE — `q ≢ 1 (mod p)` ⟹ `G` IS CYCLIC
+
+Parts VI–VII produce, under `q ≢ 1 (mod p)`, normal subgroups of *both* prime
+orders `p` and `q`.  Their orders are coprime, so the two subgroups intersect
+trivially and (being normal) commute elementwise.  A generator `a` of the order-`p`
+subgroup and a generator `b` of the order-`q` subgroup therefore commute and have
+coprime orders, so `a·b` has order `p·q = |G|` — an element of full order, making
+`G` cyclic.  This closes the classification of groups of order `p·q`: away from the
+arithmetic obstruction `q ≡ 1 (mod p)` there is a *unique* group, the cyclic one
+`ℤ/pq`.
+═══════════════════════════════════════════════════════════════════════════════ -/
+
+/-- **Classification capstone: a group of order `p·q` with `q ≢ 1 (mod p)` is cyclic**
+    (`p < q` prime).  This is the positive half of the order-`p·q` dichotomy and the
+    payoff of the whole Sylow development in this file.
+
+    Proof.  Parts VI–VII give normal subgroups `P` (order `p`) and `Q` (order `q`); each
+    has prime order, hence is cyclic.  Let `a` generate `P` and `b` generate `Q`, so
+    `orderOf a = p` and `orderOf b = q` (`Nat.card_zpowers`).  Because `|P ⊓ Q|` divides
+    both `p` and `q`, which are coprime, it is `1`, so `P` and `Q` are `Disjoint`; two
+    disjoint *normal* subgroups commute elementwise
+    (`Subgroup.commute_of_normal_of_disjoint`), giving `Commute a b`.  Coprime orders of
+    commuting elements multiply (`orderOf_mul_eq_mul_orderOf_of_coprime`), so
+    `orderOf (a * b) = p · q = |G|`.  An element of order `|G|` generates the group
+    (`isCyclic_of_orderOf_eq_card`), so `G` is cyclic.
+
+    The hypothesis `q ≢ 1 (mod p)` is essential — it is exactly what forces the Sylow
+    p-subgroup to be normal (Part VII).  Without it a nonabelian group exists (the
+    metacyclic `ℤ/q ⋊ ℤ/p`, e.g. `S₃` for `p·q = 2·3` with `3 ≡ 1 mod 2`). -/
+theorem isCyclic_of_card_eq_pq (p q : ℕ) (hp : p.Prime) (hq : q.Prime)
+    (hpq : p < q) (hmod : q % p ≠ 1) (hG : Nat.card G = p * q) : IsCyclic G := by
+  haveI : Fact p.Prime := ⟨hp⟩
+  haveI : Fact q.Prime := ⟨hq⟩
+  -- Normal subgroups of both prime orders (Parts VI and VII).
+  obtain ⟨P, hPnorm, hPcard⟩ :=
+    exists_normal_subgroup_card_eq_p_of_card_eq_pq p q hp hq hpq hmod hG
+  obtain ⟨Q, hQnorm, hQcard⟩ := exists_normal_subgroup_card_eq_pq p q hp hq hpq hG
+  -- Each is cyclic (prime order); pick generators `a` and `b`.
+  haveI : IsCyclic P := isCyclic_of_prime_card (p := p) hPcard
+  haveI : IsCyclic Q := isCyclic_of_prime_card (p := q) hQcard
+  obtain ⟨a, ha⟩ := (Subgroup.isCyclic_iff_exists_zpowers_eq_top P).mp inferInstance
+  obtain ⟨b, hb⟩ := (Subgroup.isCyclic_iff_exists_zpowers_eq_top Q).mp inferInstance
+  have hao : orderOf a = p := by rw [← Nat.card_zpowers, ha, hPcard]
+  have hbo : orderOf b = q := by rw [← Nat.card_zpowers, hb, hQcard]
+  have haP : a ∈ P := ha ▸ Subgroup.mem_zpowers a
+  have hbQ : b ∈ Q := hb ▸ Subgroup.mem_zpowers b
+  -- Coprimality of the two prime orders.
+  have hcop : Nat.Coprime p q := (Nat.coprime_primes hp hq).mpr (ne_of_lt hpq)
+  -- `P` and `Q` are disjoint: `|P ⊓ Q|` divides both `p` and `q`, hence `1`.
+  have hdis : Disjoint P Q := by
+    rw [disjoint_iff, eq_bot_iff_card]
+    have hdp : Nat.card (P ⊓ Q : Subgroup G) ∣ p := hPcard ▸ card_dvd_of_le inf_le_left
+    have hdq : Nat.card (P ⊓ Q : Subgroup G) ∣ q := hQcard ▸ card_dvd_of_le inf_le_right
+    have hg : Nat.gcd p q = 1 := hcop
+    have := Nat.dvd_gcd hdp hdq
+    rw [hg] at this
+    exact Nat.dvd_one.mp this
+  -- Disjoint normal subgroups commute elementwise, so the generators commute.
+  have hcomm : Commute a b :=
+    Subgroup.commute_of_normal_of_disjoint P Q hPnorm hQnorm hdis a b haP hbQ
+  -- `a·b` has coprime commuting factors, so its order is `p·q = |G|`.
+  have hord : orderOf (a * b) = Nat.card G := by
+    rw [hcomm.orderOf_mul_eq_mul_orderOf_of_coprime (by rw [hao, hbo]; exact hcop),
+      hao, hbo, hG]
+  exact isCyclic_of_orderOf_eq_card (a * b) hord
+
+/-- **The full order-`p·q` dichotomy** (`p < q` prime): either `q ≡ 1 (mod p)` — the
+    arithmetic regime that permits the nonabelian metacyclic group `ℤ/q ⋊ ℤ/p` — or `G`
+    is cyclic.  Combines the two Sylow regimes: Part VII's obstruction `q ≡ 1 (mod p)` is
+    the *only* way a group of order `p·q` can fail to be cyclic.  Together with
+    `not_isSimpleGroup_of_card_eq_pq` and `isSolvable_of_card_eq_pq` this completes the
+    structural picture of order-`p·q` groups. -/
+theorem cyclic_or_q_mod_p_of_card_eq_pq (p q : ℕ) (hp : p.Prime) (hq : q.Prime)
+    (hpq : p < q) (hG : Nat.card G = p * q) : q % p = 1 ∨ IsCyclic G := by
+  by_cases h : q % p = 1
+  · exact Or.inl h
+  · exact Or.inr (isCyclic_of_card_eq_pq p q hp hq hpq h hG)
+
+/-- **Groups of order `p·q` with `q ≢ 1 (mod p)` are abelian** (`p < q` prime): the
+    commutativity consequence of `isCyclic_of_card_eq_pq`.  A convenient elementwise form
+    of the classification — every such group is (isomorphic to) `ℤ/pq`, in particular
+    commutative. -/
+theorem mul_comm_of_card_eq_pq (p q : ℕ) (hp : p.Prime) (hq : q.Prime)
+    (hpq : p < q) (hmod : q % p ≠ 1) (hG : Nat.card G = p * q) (a b : G) :
+    a * b = b * a := by
+  haveI := isCyclic_of_card_eq_pq p q hp hq hpq hmod hG
+  letI := IsCyclic.commGroup (α := G)
+  exact mul_comm a b
+
 end LagrangeOQ01
 
 /-
@@ -506,6 +597,11 @@ end LagrangeOQ01
     p-subgroup is normal (n_p = 1) with a normal subgroup of order p — the symmetric
     counterpart of the q-side and the coprime-normal-subgroup input for the full
     "p·q with q ≢ 1 mod p ⟹ cyclic" classification
+  - Classification capstone (isCyclic_of_card_eq_pq): a group of order p·q with
+    q ≢ 1 (mod p) is CYCLIC — the two coprime normal Sylow subgroups have commuting
+    generators of coprime orders p, q, so their product has order p·q = |G|; hence the
+    full dichotomy cyclic_or_q_mod_p_of_card_eq_pq (either q ≡ 1 mod p or G cyclic) and
+    the abelian corollary mul_comm_of_card_eq_pq. Closes the order-p·q classification.
 
   **Status**: Verified, 0 sorries, 0 axioms
 -/

--- a/src/data/proofs/lagrange-theorem-oq-01/meta.json
+++ b/src/data/proofs/lagrange-theorem-oq-01/meta.json
@@ -152,9 +152,9 @@
   ],
   "leanFile": {
     "namespace": "LagrangeOQ01",
-    "lineCount": 379,
+    "lineCount": 607,
     "axiomCount": 0,
-    "theoremCount": 27,
+    "theoremCount": 35,
     "definitionCount": 0,
     "path": "Proofs/LagrangeTheoremOQ01.lean",
     "sorries": 0

--- a/src/data/research/problems/lagrange-theorem-oq-01.json
+++ b/src/data/research/problems/lagrange-theorem-oq-01.json
@@ -29,13 +29,14 @@
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETED+extended (Sylow p-side): the |G|=p·q classification now has BOTH primes' normality analysis. New Part VII adds the q≢1(mod p) regime — |P|=p, Sylow p-subgroup normal & unique (n_p=1), and a normal subgroup of order p — the symmetric counterpart of the unconditional q-side. 4 new theorems, 0 sorries, 0 axioms; verified host lean v4.26.0 (docker olean-write hit transient fleet SIGBUS).",
+    "progressSummary": "COMPLETE (order-pq classification closed): the q≢1(mod p) regime now proves G is CYCLIC (isCyclic_of_card_eq_pq), yielding the full dichotomy cyclic_or_q_mod_p_of_card_eq_pq (either q≡1 mod p or G≅ℤ/pq) plus the abelian corollary. 3 new theorems, 0 sorries, 0 axioms; host lean v4.26.0 EXIT 0 (docker codegen SIGBUS135 infra-only, kernel-checked on host, axioms=[propext,Classical.choice,Quot.sound]).",
     "builtItems": [
       "LagrangeTheoremOQ01.lean: ~140 lines, 11 theorems, 0 sorries, 0 axioms",
       "Parts I-V: Lagrange, Sylow existence, conjugacy, counting, partial converse + Cauchy",
       "LagrangeTheoremOQ01.lean: +2 thms — card_sylow_q_of_card_eq_pq (|Q|=q via factorization(pq)=1) and sylow_q_normal_of_card_eq_pq (order-pq groups have normal Sylow q-subgroup)",
       "LagrangeTheoremOQ01.lean: isSolvable_of_card_eq_pq — groups of order p·q (p<q prime) are solvable (IsSolvable G), via cyclic N and G⧸N + solvable_of_ker_le_range. New reasoning VERIFIED host lean v4.26.0 minimal-import standalone (type-check EXIT 0); full-file docker build blocked by shared .lake .ir codegen corruption (infra).",
-      "LagrangeTheoremOQ01.lean Part VII: card_sylow_p_of_card_eq_pq (|P|=p), sylow_p_normal_of_card_eq_pq (q≢1 mod p ⟹ P normal), card_sylow_p_eq_one_of_card_eq_pq (n_p=1), exists_normal_subgroup_card_eq_p_of_card_eq_pq. Now ~30 theorems, 0 axioms/0 sorries. PR (lagrange-oq-01-not-simple)."
+      "LagrangeTheoremOQ01.lean Part VII: card_sylow_p_of_card_eq_pq (|P|=p), sylow_p_normal_of_card_eq_pq (q≢1 mod p ⟹ P normal), card_sylow_p_eq_one_of_card_eq_pq (n_p=1), exists_normal_subgroup_card_eq_p_of_card_eq_pq. Now ~30 theorems, 0 axioms/0 sorries. PR (lagrange-oq-01-not-simple).",
+      "LagrangeTheoremOQ01.lean Part VIII: isCyclic_of_card_eq_pq (|G|=p·q, q≢1 mod p ⟹ G cyclic) — two coprime normal Sylow subgroups P(order p),Q(order q), generators a,b via Subgroup.isCyclic_iff_exists_zpowers_eq_top, Disjoint P Q from |P⊓Q| ∣ gcd(p,q)=1, Commute a b via Subgroup.commute_of_normal_of_disjoint, orderOf(a*b)=p·q via Commute.orderOf_mul_eq_mul_orderOf_of_coprime, then isCyclic_of_orderOf_eq_card. Plus cyclic_or_q_mod_p_of_card_eq_pq (full dichotomy) and mul_comm_of_card_eq_pq (abelian corollary). Now 35 theorems, 0 ax/0 sorries."
     ],
     "insights": [
       "Sylow theorems are fully in Mathlib — file wraps existing API in gallery format",
@@ -46,12 +47,14 @@
       "Groups of order p·q (p<q prime) are SOLVABLE (isSolvable_of_card_eq_pq): strictly strengthens not_isSimpleGroup_of_card_eq_pq. Proof: the normal N (order q) is prime-order hence cyclic hence abelian hence solvable; quotient G⧸N has order p (card_eq_card_quotient_mul_card_subgroup) hence also cyclic/solvable; solvability lifts along 1→N→G→G⧸N→1 via solvable_of_ker_le_range with ker(mk N)=N=range(N.subtype).",
       "Lean recipe: IsSolvable of a prime-order subgroup N — isCyclic_of_prime_card gives IsCyclic N, then isSolvable_of_comm (fun a b => by letI := IsCyclic.commGroup (α:=N); exact mul_comm a b). NOTE: the shorter `letI := IsCyclic.commGroup; inferInstance` route FAILS to synthesize IsSolvable (Group/CommGroup instance diamond) — extract commutativity explicitly and feed isSolvable_of_comm instead.",
       "solvable_of_ker_le_range f g (hfg: g.ker ≤ f.range) with f=N.subtype, g=QuotientGroup.mk N: discharge hfg by le_of_eq (rw [QuotientGroup.ker_mk, Subgroup.range_subtype]) — both sides collapse to N.",
-      "Sylow p-side of pq needs the arithmetic hypothesis q≢1 (mod p): n_p≡1(mod p) divides [G:P]=q, so n_p∈{1,q}, and n_p=q ⟺ q≡1(mod p). S₃ (order 2·3, 3≡1 mod 2) is the extremal witness with three non-normal Sylow 2-subgroups. Under q≢1(mod p) both Sylow subgroups are normal ⟹ two coprime normal subgroups ⟹ internal direct product ⟹ G cyclic."
+      "Sylow p-side of pq needs the arithmetic hypothesis q≢1 (mod p): n_p≡1(mod p) divides [G:P]=q, so n_p∈{1,q}, and n_p=q ⟺ q≡1(mod p). S₃ (order 2·3, 3≡1 mod 2) is the extremal witness with three non-normal Sylow 2-subgroups. Under q≢1(mod p) both Sylow subgroups are normal ⟹ two coprime normal subgroups ⟹ internal direct product ⟹ G cyclic.",
+      "Order-pq classification CLOSED: q≡1(mod p) is the UNIQUE obstruction to cyclicity. When it fails, the two normal Sylow subgroups (Parts VI,VII) are coprime-order, disjoint, hence commute (commutator ⊆ P∩Q=1), and their generators multiply to a full-order element ⟹ cyclic. The nonabelian ℤ/q⋊ℤ/p exists precisely when q≡1(mod p) (S₃ at 2·3).",
+      "Lean recipe for internal-direct-product ⟹ cyclic: get generators of the two normal prime-order subgroups via (Subgroup.isCyclic_iff_exists_zpowers_eq_top H).mp with orderOf from Nat.card_zpowers; disjointness by cardinality (card_dvd_of_le inf_le_left/right into Nat.dvd_gcd, gcd=1); Commute via Subgroup.commute_of_normal_of_disjoint; full order via Commute.orderOf_mul_eq_mul_orderOf_of_coprime (DOT NOTATION on the Commute hyp — bare orderOf_mul_eq_mul_orderOf_of_coprime is unknown, it lives in namespace Commute); conclude isCyclic_of_orderOf_eq_card.",
+      "GOTCHA: docker exit-135 SIGBUS at the codegen (-c *.c) stage MASKED a real elaboration error (unknown identifier) for two builds — host lean type-check (LEAN_PATH from packages .lake, no -o/-c) surfaced it immediately. Always host-verify when docker 135s repeatedly at 2-3s: the worktree .lake already holds the decompressed mathlib oleans after the first docker download."
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "Capstone: q≢1(mod p) ⟹ G cyclic. Assemble the two coprime normal Sylow subgroups (orders p,q) into an internal direct product (Subgroup.isComplement / disjoint + card) and conclude G ≅ ℤ/p × ℤ/q ≅ ℤ/pq via CRT.",
-      "State the full dichotomy: for |G|=p·q either q≡1(mod p) (nonabelian metacyclic possible) or q≢1(mod p) (G cyclic).",
+      "Classification of order p·q is now complete (cyclic vs metacyclic dichotomy). Possible outward extensions: (a) exhibit the nonabelian witness when q≡1 mod p (construct ℤ/q⋊ℤ/p and show |G|=pq, noncyclic); (b) order-p² groups are abelian (isCyclic or ℤ/p×ℤ/p); (c) order p²q or p³ classifications.",
       "Repair the parent LagrangeTheorem.lean drift if any, to keep the gallery imports coherent."
     ]
   },


### PR DESCRIPTION
## Summary

Closes the classification of groups of order **p·q** (`p < q` prime) in `LagrangeTheoremOQ01.lean`. Parts VI–VII of the file already produce, under `q ≢ 1 (mod p)`, **normal Sylow subgroups of both prime orders** `p` and `q`. Part VIII assembles them into the cyclicity conclusion.

## New theorems (Part VIII)

- **`isCyclic_of_card_eq_pq`** — `|G| = p·q` with `q ≢ 1 (mod p)` ⟹ `G` is cyclic. The two normal subgroups `P` (order `p`), `Q` (order `q`) have coprime orders, so `|P ⊓ Q| ∣ gcd(p,q) = 1` makes them `Disjoint`; disjoint normal subgroups commute elementwise (`Subgroup.commute_of_normal_of_disjoint`), so generators `a, b` (of coprime orders) satisfy `orderOf (a·b) = p·q = |G|` (`Commute.orderOf_mul_eq_mul_orderOf_of_coprime`), an element of full order ⟹ `IsCyclic G` (`isCyclic_of_orderOf_eq_card`).
- **`cyclic_or_q_mod_p_of_card_eq_pq`** — the full dichotomy: either `q ≡ 1 (mod p)` (the arithmetic regime permitting the nonabelian metacyclic `ℤ/q ⋊ ℤ/p`, e.g. `S₃` at `2·3`) or `G` is cyclic.
- **`mul_comm_of_card_eq_pq`** — abelian corollary.

Together with the existing `not_isSimpleGroup_of_card_eq_pq` and `isSolvable_of_card_eq_pq`, this completes the structural picture: away from `q ≡ 1 (mod p)` there is a **unique** group of order `p·q`, the cyclic one.

## Verification

- **35 theorems, 0 sorries, 0 axioms.**
- Kernel dependencies of all three new theorems: `[propext, Classical.choice, Quot.sound]` (no `sorryAx`, no `Lean.ofReduceBool`).
- Verified with host **lean v4.26.0**, `EXIT 0`, 0 errors. The Docker build hit a transient `SIGBUS` (exit 135) at the C-codegen stage under concurrent-container load — an infra issue, not a proof failure; elaboration + kernel checking pass cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)