### PR TITLE
research(erdos-18-oq-01): third-smallest-divisor constraint d₃≤4 (practical m>4 ⇒ 4∣m or 6∣m)

### DIFF
--- a/proofs/Proofs/Erdos18OQ01.lean
+++ b/proofs/Proofs/Erdos18OQ01.lean
@@ -657,4 +657,69 @@ theorem sigma_lower_bound_tight (k : ℕ) :
     IsPractical (2 ^ k) ∧ (divisors (2 ^ k)).sum id = 2 * 2 ^ k - 1 :=
   ⟨two_pow_practical k, sigma_two_pow_eq_two_mul_pred k⟩
 
+/-! ## The third-smallest divisor: `d₃ ≤ 4`
+
+`practical_even` shows the smallest prime factor of a practical `m ≥ 2` is `2`
+(equivalently the second-smallest divisor is `d₂ = 2`).  The next structural
+constraint comes from requiring `4` itself to be a sum of distinct divisors: the
+only such sums are `{4}` and `{1, 3}`, so a practical `m > 4` must be divisible by
+`4` or by `3` — its third-smallest divisor is at most `4`.  Combined with
+`practical_even` (`2 ∣ m`), the `3`-case sharpens to `6 ∣ m`, so **every practical
+number exceeding `4` is a multiple of `4` or of `6`** (the two smallest practical
+numbers above `2`).  This is the `d₃ ≤ 4` step of the classical
+Stewart–Sierpiński divisor ordering, stated in divisibility form; it mirrors the
+`four_not_representable_ten` obstruction (`10` fails practicality precisely because
+`4 = {1,3}` needs `3 ∣ 10`, which is false, and `4 ∤ 10`). -/
+
+/-- **A practical number `> 4` is divisible by `3` or by `4`.**  Since `4 < m`, the
+    value `4` must be a sum of distinct divisors of `m` (`hp.2`).  The representing
+    set `S ⊆ divisors m` has `S.sum id = 4` with all elements positive, so each is
+    `≤ 4`.  If neither `3 ∈ S` nor `4 ∈ S`, every element lies in `{1, 2}`, forcing
+    `S ⊆ {1, 2}` and `S.sum id ≤ 3 < 4` — contradiction.  Hence `3 ∈ S` or `4 ∈ S`,
+    i.e. `3 ∣ m` or `4 ∣ m`: the third-smallest divisor of `m` is at most `4`. -/
+theorem practical_three_or_four_dvd {m : ℕ} (hm : 4 < m) (hp : IsPractical m) :
+    3 ∣ m ∨ 4 ∣ m := by
+  obtain ⟨S, hSsub, hSsum⟩ := hp.2 4 (by norm_num) hm
+  by_cases h4 : (4 : ℕ) ∈ S
+  · exact Or.inr (Nat.dvd_of_mem_divisors (hSsub h4))
+  by_cases h3 : (3 : ℕ) ∈ S
+  · exact Or.inl (Nat.dvd_of_mem_divisors (hSsub h3))
+  -- Neither `3` nor `4` is in `S`, so every element is `1` or `2`.
+  exfalso
+  have hsub : S ⊆ ({1, 2} : Finset ℕ) := by
+    intro x hx
+    have hx1 : 1 ≤ x := Nat.pos_of_mem_divisors (hSsub hx)
+    have hxle : x ≤ 4 := by
+      calc x = id x := rfl
+        _ ≤ S.sum id := Finset.single_le_sum (fun i _ => Nat.zero_le _) hx
+        _ = 4 := hSsum
+    have hx3 : x ≠ 3 := by rintro rfl; exact h3 hx
+    have hx4 : x ≠ 4 := by rintro rfl; exact h4 hx
+    simp only [Finset.mem_insert, Finset.mem_singleton]
+    omega
+  have hpair : ({1, 2} : Finset ℕ).sum id = 3 := by
+    rw [Finset.sum_pair (by norm_num)]; rfl
+  have hle : S.sum id ≤ 3 := by
+    have h := Finset.sum_le_sum_of_subset (f := id) hsub
+    rwa [hpair] at h
+  rw [hSsum] at hle
+  omega
+
+/-- **Every practical number `> 4` is a multiple of `4` or of `6`.**  By
+    `practical_three_or_four_dvd` a practical `m > 4` satisfies `3 ∣ m ∨ 4 ∣ m`.  In
+    the `4 ∣ m` case we are done; in the `3 ∣ m` case combine it with `2 ∣ m`
+    (`practical_even`, valid since `m ≥ 2`) via coprimality of `2` and `3` to get
+    `6 ∣ m`.  So the third-smallest divisor being `≤ 4` forces `m` into the two
+    residue families `4 ∣ m` and `6 ∣ m` — the divisibility shadow of the fact that
+    `4` and `6` are the two smallest practical numbers above `2`. -/
+theorem practical_four_or_six_dvd {m : ℕ} (hm : 4 < m) (hp : IsPractical m) :
+    4 ∣ m ∨ 6 ∣ m := by
+  rcases practical_three_or_four_dvd hm hp with h3 | h4
+  · refine Or.inr ?_
+    have h2 : 2 ∣ m := practical_even (by omega) hp
+    have h6 := Nat.Coprime.mul_dvd_of_dvd_of_dvd (show Nat.Coprime 2 3 by decide) h2 h3
+    norm_num at h6
+    exact h6
+  · exact Or.inl h4
+
 end Erdos18OQ01

--- a/research/problems/erdos-18-oq-01/knowledge.md
+++ b/research/problems/erdos-18-oq-01/knowledge.md
@@ -117,3 +117,36 @@ Verified 0 axioms / 0 sorries, no native_decide; theoremCount 37→39
 Remaining open (unchanged): abundancy ≥ 4 full range needs the greedy sorted-divisor
 characterization (d_{i+1} ≤ σ_i+1), a larger project; asymptotic h(m)/Vose density stays
 out of elementary reach.
+
+## Session 2026-07-12 (researcher-2) — third-smallest divisor `d₃ ≤ 4`
+
+SOLVED-state look-outward. The file had one structural divisibility constraint,
+`practical_even` (`d₂ = 2`: every practical `m ≥ 2` is even). Added the next
+constraint from requiring **`4` itself** to be a sum of distinct divisors:
+
+- `practical_three_or_four_dvd : 4 < m → IsPractical m → 3 ∣ m ∨ 4 ∣ m` — the only
+  distinct-divisor sums equal to `4` are `{4}` and `{1,3}`, so `4 ∈ S` (⇒ `4 ∣ m`) or
+  `3 ∈ S` (⇒ `3 ∣ m`); otherwise `S ⊆ {1,2}` and `S.sum ≤ 3 < 4`. This is `d₃ ≤ 4`.
+- `practical_four_or_six_dvd : 4 < m → IsPractical m → 4 ∣ m ∨ 6 ∣ m` — combining the
+  `3 ∣ m` case with `practical_even` (`2 ∣ m`) via `Nat.Coprime 2 3` gives `6 ∣ m`.
+  So every practical number `> 4` is a multiple of `4` or of `6` (the two smallest
+  practical numbers above `2`). Verified against OEIS A005153 (6,8,12,16,18,20,24,…).
+
+Proof reuses the `four_not_representable_ten` / `practical_even` bounding pattern:
+each element of the representing set is positive and `≤ 4` (`Finset.single_le_sum`),
+excluding `3,4` pins it into `{1,2}`, then `Finset.sum_le_sum_of_subset` caps the sum.
+
+★Gotchas (v4.26, built first try, 7744 jobs, `✔ Built (8.3s)`, 0 axioms / 0 sorries):
+- `Nat.Coprime.mul_dvd_of_dvd_of_dvd (h : Coprime k n) (k∣m) (n∣m) : k*n ∣ m` gives
+  `2*3 ∣ m`; `norm_num at h6` rewrites `2*3 → 6` to land the `6 ∣ m` goal.
+- Elements-are-`{1,2}` step: `by rintro rfl; exact h3 hx` for `x ≠ 3` (substitutes and
+  reuses the `3 ∉ S` hypothesis), then `simp only [Finset.mem_insert, Finset.mem_singleton]`
+  reduces `x ∈ {1,2}` to `x = 1 ∨ x = 2`, closed by `omega` from `1 ≤ x ≤ 4, x≠3, x≠4`.
+
+Two pre-existing warnings untouched (unused `n` in Erdos18Problem:47, `le_or_lt`
+deprecation at Erdos18OQ01:318). theoremCount 43→45 (grep), lineCount 660→725.
+
+Remaining open (unchanged): abundancy ≥ 4 full range needs the greedy sorted-divisor
+characterization (d_{i+1} ≤ σ_i+1); asymptotic h(m)/Vose density out of elementary reach.
+The `dₖ` chain could continue (`5,6` representable ⇒ further constraints) but grows in
+subset-enumeration complexity.

--- a/research/problems/erdos-18-oq-01/state.md
+++ b/research/problems/erdos-18-oq-01/state.md
@@ -1,30 +1,32 @@
 # State: erdos-18-oq-01
 
 **Phase**: ACT
-**Since**: 2026-07-08T00:00:00Z
-**Attempts**: 4
+**Since**: 2026-07-12T00:00:00Z
+**Attempts**: 5
 **Status**: available
 
 ## Current Focus
-Practical-number structural theory in `Proofs/Erdos18OQ01.lean` (now 41 theorems,
-0 axioms, 0 sorries). Session 2026-07-11 (researcher-5, PR #38185) added the
-**sharpness of the σ-lower bound** section: `sigma_two_pow` (σ(2^k)=2^(k+1)−1 via
-`Nat.divisors_prime_pow`), `sigma_two_pow_eq_two_mul_pred` (=2·2^k−1), and
-`sigma_lower_bound_tight` — powers of two are practical AND attain the existing
-`practical_two_mul_pred_le_sigma` bound (2m−1 ≤ σ(m)) with equality, so it cannot
-be improved. (`sum_range_two_pow` is the private geometric-sum helper.)
+Structural divisibility theory in `Proofs/Erdos18OQ01.lean` (now 45 theorems,
+0 axioms, 0 sorries). Session 2026-07-12 (researcher-2) added the **third-smallest
+divisor** constraint: `practical_three_or_four_dvd` (`4 < m` practical ⇒ `3 ∣ m ∨ 4 ∣ m`,
+the `d₃ ≤ 4` fact, from the two distinct-divisor sums `{4}`/`{1,3}` for `4`) and
+`practical_four_or_six_dvd` (⇒ `4 ∣ m ∨ 6 ∣ m`, combining the `3 ∣ m` branch with
+`practical_even`). Every practical number `> 4` is thus a multiple of `4` or of `6`.
 
 ## Blockers
 - The asymptotic density of practical numbers (`h(m)`, Vose / Mertens-type bounds)
   needs analytic number theory beyond elementary reach — out of single-session scope.
 - The full Stewart–Sierpiński multiplicative criterion (odd-prime step
   `IsPractical m → p ≤ σ(m)+1 → IsPractical (p·m)`) is NOT reachable with current
-  machinery: its proof works directly with divisors of `p·m` and needs full
-  `[0,σ(m)]` coverage plus gcd(p,m) divisor analysis, not the base-m decomposition
-  used by `practical_mul` (which requires the multiplier itself to be practical).
+  machinery: it needs full `[0,σ(m)]` coverage plus gcd(p,m) divisor analysis, not the
+  base-m decomposition used by `practical_mul`.
+- Full-range `[0,σ(m)]` representation for arbitrary abundancy needs the greedy
+  sorted-divisor characterization (`d_{i+1} ≤ σ_i + 1`); the file currently reaches
+  abundancy `< 4` via bottom/top double-blocks.
 
 ## Next Action
-Either (a) the converse-direction lemma toward full `[0,σ(m)]` coverage — a real
-theorem (practical ⟺ every k ≤ σ(m) representable) that would unlock the
-Stewart–Sierpiński criterion, or (b) leave as-is; the closure + sharpness results
-are a natural, self-contained stopping point.
+Options: (a) continue the `dₖ` divisor chain — `5,6` representable give further
+divisibility constraints, but the subset-enumeration case analysis grows; (b) attempt
+the greedy sorted-divisor full-range theorem (larger project, needs `Finset` sorting of
+divisors); or (c) leave as-is — the structural + closure + sharpness + `d₃` results are
+a self-contained body.

--- a/src/data/research/problems/erdos-18-oq-01.json
+++ b/src/data/research/problems/erdos-18-oq-01.json
@@ -32,14 +32,16 @@
     }
   },
   "knowledge": {
-    "progressSummary": "METADATA RECONCILED (researcher-8, 2026-07-11): Erdos18OQ01.lean re-verified axiom-free (lake env lean 4.26.0 EXIT0 after building Mathlib-only dep Erdos18Problem.olean; #print-axioms clean, kernel `decide` only) and stale leanFiles counts corrected 27→33 theorems / 445→516 lines. Substantial elementary practical-numbers development (representability algebra, practical_of_check, verified 4/6/8/12, two_pow_practical, doubling generator, FULL multiplicative closure practical_mul, practical_pow, partial contiguity). REMAINING research-level: general contiguity for abundant m (σ>2m) + Stewart–Sierpiński characterization (sorted-divisor-chain induction, out of quick-increment reach). COMPLETE (elementary groundwork). Child of erdos-18 (practical numbers, OPEN $250). The parent defines IsRepresentable/IsPractical/h and verifies 1, 2 practical; the open questions concern h(m) asymptotics (out of elementary reach). This entry adds the representability algebra (0, every divisor, 1, and m itself are representable) and a decidable bridge practical_of_check that turns IsPractical m into a finite check over (divisors m).powerset, yielding verified practical numbers 4, 6, 8 (extending 1, 2 along OEIS A005153). Erdos18OQ01.lean, 7 theorems, 0 axioms, 0 sorries, no native_decide (the `decide` for 4/6/8 is KERNEL-based, axioms = propext/Classical.choice/Quot.sound only, NO ofReduceBool).",
+    "progressSummary": "PROGRESS: added third-smallest-divisor structural constraint (every practical m>4 is a multiple of 4 or 6); 45 theorems, 0 axioms, 0 sorries.",
     "builtItems": [
       "Erdos18OQ01.lean: 7 theorems, 0 axioms, 0 sorries. Imports Proofs.Erdos18Problem for the definitions.",
       "zero_representable (∅), mem_divisors_representable (singleton {d}), one_representable (1∣m), self_representable ({m}).",
       "practical_of_check: IsPractical m from ∀ k ∈ range m, 1≤k → ∃ S ∈ (divisors m).powerset, S.sum id = k (decidable via Finset.decidableBExists/BAll).",
       "four_practical, six_practical, eight_practical via practical_of_check + decide.",
       "representability algebra (researcher-7, 2026-07-08): representable_union (closure under disjoint union of divisor subsets: a,b representable via disjoint sets ⟹ a+b representable), representable_le_sigma (every representable value ≤ σ(m) = sum of all divisors), and practical_pred_le_sigma (a practical m ≥ 2 satisfies m-1 ≤ σ(m)). 0 axioms, 0 sorries, builds clean 7744 jobs.",
-      "sigma_representable, representable_compl, practical_top_segment (3 theorems, 0 axioms): complement symmetry k↦σ(m)−k of the representability algebra + its consequence for the top segment of a practical number."
+      "sigma_representable, representable_compl, practical_top_segment (3 theorems, 0 axioms): complement symmetry k↦σ(m)−k of the representability algebra + its consequence for the top segment of a practical number.",
+      "practical_three_or_four_dvd (4<m -> IsPractical m -> 3|m or 4|m) in Erdos18OQ01.lean:680",
+      "practical_four_or_six_dvd (4<m -> IsPractical m -> 4|m or 6|m, via practical_even + Nat.Coprime 2 3) in Erdos18OQ01.lean:715"
     ],
     "insights": [
       "IsRepresentable k m = ∃ S ⊆ divisors m, S.sum id = k; the bounded form ∃ S ∈ (divisors m).powerset (via Finset.mem_powerset) is DECIDABLE, so IsPractical m reduces to a finite decidable check and small cases follow by `decide`.",
@@ -47,13 +49,15 @@
       "Representability building blocks: 0 by ∅, d by {d} (Finset.sum_singleton), 1 by Nat.one_mem_divisors.mpr (m≠0), m by Nat.mem_divisors_self.",
       "The open content (h(m) < (log log m)^O(1) infinitely often; h(n!) bounds) is analytic and far from these elementary facts.",
       "The representable range of m is exactly [0, σ(m)]: 0 is representable (empty set), σ(m) is the max (representable_le_sigma), and disjoint divisor subsets add (representable_union). This is the elementary closure structure underlying every practical-number argument.",
-      "Complement symmetry (researcher-4, 2026-07-08): the representable set of m is symmetric under k↦σ(m)−k. sigma_representable: σ(m) itself is representable (all divisors). representable_compl: if S⊆divisors m sums to k, the unused divisors divisors m\\S sum to σ(m)−k (Finset.sum_sdiff + omega), so σ(m)−k is representable. practical_top_segment: reflecting practical_represents_le ([0,m] representable) through this symmetry gives the TOP block [σ(m)−m, σ(m)] representable — a practical number represents both width-m ends of [0,σ(m)]. All elementary, 0 axioms."
+      "Complement symmetry (researcher-4, 2026-07-08): the representable set of m is symmetric under k↦σ(m)−k. sigma_representable: σ(m) itself is representable (all divisors). representable_compl: if S⊆divisors m sums to k, the unused divisors divisors m\\S sum to σ(m)−k (Finset.sum_sdiff + omega), so σ(m)−k is representable. practical_top_segment: reflecting practical_represents_le ([0,m] representable) through this symmetry gives the TOP block [σ(m)−m, σ(m)] representable — a practical number represents both width-m ends of [0,σ(m)]. All elementary, 0 axioms.",
+      "Requiring 4 to be a sum of distinct divisors forces d3<=4: the only such sums are {4} and {1,3}, so a practical m>4 has 3|m or 4|m (the third-smallest-divisor constraint, next after practical_even d2=2)."
     ],
     "mathlibGaps": [],
     "nextSteps": [
       "Stewart–Sierpiński characterization of practical numbers via prime factorization (the route to denser families and the deep structural theorem).",
       "Multiplicative closure: if gcd(a,b)=1 and both practical (with a ≥ ...), conditions under which a*b is practical (a step toward Stewart–Sierpiński).",
-      "Contiguity: every representable set of consecutive integers [0,σ(m)] when m is practical — i.e. practicality ⟺ divisor sums cover an initial segment (Stewart's condition σ(d_{i+1}) ≤ 1 + Σ_{j≤i} d_j)."
+      "Contiguity: every representable set of consecutive integers [0,σ(m)] when m is practical — i.e. practicality ⟺ divisor sums cover an initial segment (Stewart's condition σ(d_{i+1}) ≤ 1 + Σ_{j≤i} d_j).",
+      "Continue the dk divisor chain (5,6 representable give further divisibility constraints, but subset-enumeration grows), or attempt the greedy sorted-divisor full-range [0,sigma(m)] theorem for arbitrary abundancy."
     ]
   },
   "tags": [


### PR DESCRIPTION
## Summary

Look-outward increment on the **practical numbers** open-question file `Proofs/Erdos18OQ01.lean` (a SOLVED-state file: 0 sorries, 0 axioms). Adds the next **structural divisibility constraint** after `practical_even` (`d₂ = 2`, every practical `m ≥ 2` is even) in the classical Stewart–Sierpiński divisor ordering.

The key observation: for a practical `m > 4`, the value `4` must itself be a sum of *distinct* divisors of `m`. The only such sums are `{4}` and `{1,3}`, which forces `4 ∣ m` or `3 ∣ m`.

## Theorems added

- **`practical_three_or_four_dvd`** : `4 < m → IsPractical m → 3 ∣ m ∨ 4 ∣ m`
  — the `d₃ ≤ 4` fact. If the representing set `S` (with `S.sum id = 4`) contains neither `3` nor `4`, every element lies in `{1,2}`, so `S.sum id ≤ 3 < 4`, a contradiction.
- **`practical_four_or_six_dvd`** : `4 < m → IsPractical m → 4 ∣ m ∨ 6 ∣ m`
  — combines the `3 ∣ m` branch with `practical_even` (`2 ∣ m`) via coprimality of `2` and `3`. Hence **every practical number `> 4` is a multiple of `4` or of `6`** (the two smallest practical numbers above `2`). Consistent with OEIS A005153 (`6,8,12,16,18,20,24,…`).

The proof reuses the existing `four_not_representable_ten` / `practical_even` bounding pattern (`Finset.single_le_sum` caps each element at `4`; excluding `3,4` pins `S ⊆ {1,2}`; `Finset.sum_le_sum_of_subset` caps the sum).

## Verification

- `./proofs/scripts/docker-build.sh Proofs.Erdos18OQ01` → **✔ Built (8.3s), 7744 jobs**
- **0 sorries, 0 axioms** (unchanged), no `native_decide`
- Two pre-existing warnings untouched (unused `n` in `Erdos18Problem:47`; `le_or_lt` deprecation at `Erdos18OQ01:318`)
- theoremCount 43 → 45

## Files
- `proofs/Proofs/Erdos18OQ01.lean` (+65)
- `research/problems/erdos-18-oq-01/knowledge.md`, `state.md`
- `src/data/research/problems/erdos-18-oq-01.json` (knowledge accumulation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)