### PR TITLE
research(cube-root-3-irrational-oq-02-oq-03): Vahlen–Capelli prime-power positive-radicand criterion

### DIFF
--- a/proofs/Proofs/CubeRoot3IrrationalOQ02OQ03.lean
+++ b/proofs/Proofs/CubeRoot3IrrationalOQ02OQ03.lean
@@ -937,4 +937,38 @@ theorem vahlen_capelli_pos_two_pow {K : Type*} [Field K] [LinearOrder K] [IsStri
       (dvd_pow_self 2 (by omega)) b
   · exact two_power_capelli_pos hk ha
 
+/-- **Prime-power exponent, positive radicand (any prime `p`).** For `n = p^k` the only
+prime divisor is `p`, so condition (1) collapses to "not a `p`-th power": over a
+`LinearOrderedField` with `a > 0`,
+
+  `Irreducible (X^(p^k) − C a) ↔ ∀ b, bᵖ ≠ a`.
+
+This is the odd-prime companion of `vahlen_capelli_pos_two_pow` (its `p = 2` instance) and
+the `k`-fold tower version of `vahlen_capelli_pos_prime`.  E.g. over `ℚ`, for the non-cube
+`a = 3` it makes `X³ − 3`, `X⁹ − 3`, `X²⁷ − 3`, … simultaneously irreducible. -/
+theorem vahlen_capelli_pos_prime_pow {K : Type*} [Field K] [LinearOrder K]
+    [IsStrictOrderedRing K] {p k : ℕ} (hp : p.Prime) (hk : 1 ≤ k) {a : K} (ha : 0 < a) :
+    Irreducible (X ^ p ^ k - C a) ↔ ∀ b : K, b ^ p ≠ a := by
+  rw [vahlen_capelli_pos (Nat.one_le_pow k p hp.pos) ha]
+  constructor
+  · intro h b
+    exact h p hp (dvd_pow_self p (by omega)) b
+  · intro h q hq hqpk b
+    obtain rfl := (Nat.prime_dvd_prime_iff_eq hq hp).mp (hq.dvd_of_dvd_pow hqpk)
+    exact h b
+
+/-- **Prime exponent, positive radicand.** The `k = 1` case of
+`vahlen_capelli_pos_prime_pow`: over a `LinearOrderedField` with `a > 0` and `p` prime,
+
+  `Irreducible (X^p − C a) ↔ ∀ b, bᵖ ≠ a`.
+
+The cleanest form of the criterion — for a prime exponent condition (1) is exactly "not a
+`p`-th power", and for positive `a` condition (2) is vacuous.  Over `ℚ` with `a = 3` (`p = 3`)
+this is the irreducibility of `X³ − 3`, the polynomial witnessing that `∛3` is irrational. -/
+theorem vahlen_capelli_pos_prime {K : Type*} [Field K] [LinearOrder K]
+    [IsStrictOrderedRing K] {p : ℕ} (hp : p.Prime) {a : K} (ha : 0 < a) :
+    Irreducible (X ^ p - C a) ↔ ∀ b : K, b ^ p ≠ a := by
+  have h := vahlen_capelli_pos_prime_pow hp (le_refl 1) ha (a := a)
+  rwa [pow_one] at h
+
 end CubeRoot3IrrationalOQ02OQ03

--- a/src/data/proofs/cube-root-3-irrational-oq-02-oq-03/meta.json
+++ b/src/data/proofs/cube-root-3-irrational-oq-02-oq-03/meta.json
@@ -23,8 +23,8 @@
     "dateAdded": "2026-07-04",
     "axiomCount": 0,
     "assumptions": "Builds cleanly (Docker-verified 2026-07-05, 3061 jobs, 0 axioms, exactly 1 sorry). The sole remaining sorry is now confined to the pure 2-power regime 8 ∣ n WITH −a ∈ K² (a = −c²) — a strict narrowing of the earlier 'even n ≥ 4' gap, and precisely the residual open content of Mathlib/FieldTheory/KummerExtension.lean's TODO (Lang, Algebra, VI §9). Everything else is machine-checked: the Sophie Germain identity, both necessity factorizations, the full necessity direction for ALL n (both parities), the complete odd-case iff, the even base cases n=2 (prime-exponent criterion) and n=4 (vahlen_capelli_four_suff — the full Sophie-Germain two-quadratic factor analysis via capelli_four_coeff_contra + quartic_two_two_coeffs + no_linear_factor), the odd-part peel-off vahlen_capelli_even_mul_odd (norm transfer through the tower), and the norm-descent keystone two_power_capelli_of_neg_not_square which discharges the ENTIRE −a ∉ K² branch of the 2-power tower unconditionally. Net verified coverage: every even n with 8 ∤ n is fully irreducibility-decided, and for 8 ∣ n only the −a ∈ K² sub-case remains.",
-    "lineCount": 819,
-    "theoremCount": 21,
+    "lineCount": 853,
+    "theoremCount": 23,
     "definitionCount": 1,
     "originalContributions": [
       "VahlenCapelliCond: the full criterion as a reusable predicate over any field",
@@ -43,12 +43,12 @@
     ]
   },
   "leanFile": {
-    "lineCount": 940,
+    "lineCount": 974,
     "path": "Proofs/CubeRoot3IrrationalOQ02OQ03.lean",
     "axiomCount": 0,
     "sorries": 1,
     "definitionCount": 1,
-    "theoremCount": 26
+    "theoremCount": 29
   },
   "overview": {
     "historicalContext": "The irreducibility of pure binomials X^n − a is one of the oldest questions in the theory of equations. Abel and Galois already understood the odd-prime case, but the definitive criterion is due to Theodor Vahlen (1895) and Alfredo Capelli (1897), who independently settled when X^n − a is irreducible over a field: it is irreducible iff a is not a p-th power for any prime p ∣ n and — the subtle extra clause — a ∉ −4·K⁴ whenever 4 ∣ n. This last condition traces directly to the Sophie Germain identity u⁴+4v⁴ = (u²−2uv+2v²)(u²+2uv+2v²), which Germain introduced around 1825 during her work on Fermat's Last Theorem. Serge Lang's Algebra (VI §9) gives the modern textbook treatment. Mathlib formalises only the odd-exponent half (X_pow_sub_C_irreducible_iff_forall_prime_of_odd) and leaves the even case as an explicit TODO citing exactly this Lang reference — so this entry attacks a concrete, named gap in the library. The problem descends from the parent gallery entry proving ∛3 irrational by Eisenstein: that argument is the case n = 3, a = 3, and Vahlen–Capelli is the exact iff that generalises the ad hoc Eisenstein bound to every exponent and radicand.",

--- a/src/data/research/problems/cube-root-3-irrational-oq-02-oq-03-incomplete-01.json
+++ b/src/data/research/problems/cube-root-3-irrational-oq-02-oq-03-incomplete-01.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (open sorry unchanged): added 5 sorry-free theorems (PR #38109) showing the even-case obstruction is vacuous over ordered fields; full positive-radicand criterion vahlen_capelli_pos is machine-checked. Remaining sorry = Lang VI section 9 descent (Mathlib open TODO).",
+    "progressSummary": "PROGRESS (open sorry unchanged): added 5 sorry-free theorems (PR #38109) showing the even-case obstruction is vacuous over ordered fields; full positive-radicand criterion vahlen_capelli_pos is machine-checked. Remaining sorry = Lang VI section 9 descent (Mathlib open TODO). | Session (researcher-5, 2026-07-11): extended the sorry-free positive-radicand branch of CubeRoot3IrrationalOQ02OQ03.lean (Vahlen–Capelli) — vahlen_capelli_pos_prime_pow (Irreducible(X^{p^k}−C a) ↔ ∀b bᵖ≠a for ANY prime p, a>0; the odd-prime companion of vahlen_capelli_pos_two_pow=its p=2 case) + vahlen_capelli_pos_prime (k=1, the clean prime-exponent form; over ℚ with a=3,p=3 = irreducibility of X³−3 witnessing ∛3 irrational). 2 theorems, both axiom-free & SORRY-FREE ([propext,Classical.choice,Quot.sound], verified NOT depending on the line-707 open sorry). Host-lean EXIT 0. File 940→974 lines, 27→29 theorems. The sole open sorry (8∣n, −a∈K², Lang VI§9 descent) is untouched.",
     "builtItems": [
       "neg_not_square_of_pos: a>0 => forall b, b^2 != -a (CubeRoot3IrrationalOQ02OQ03.lean)",
       "capelli_cond_two_of_pos: a>0 => forall b, a != -(4*b^4) (condition 2 vacuous)",
@@ -40,7 +40,8 @@
     "insights": [
       "The sole remaining sorry (line 707, two_power_capelli) is the -a in K^2 branch of the pure 2-power base X^(2^k)-C a, k>=3 (8|n): the classical Lang VI section 9 Galois descent over L=K(i). It is EXACTLY Mathlibs open TODO (X_pow_sub_C_irreducible_of_prime_pow restricted to p != 2). Not one-session closeable manually.",
       "STRUCTURAL/SHARP-BOUNDARY RESULT: over any ordered field ([Field]+[LinearOrder]+[IsStrictOrderedRing]) the -4K^4 obstruction (condition 2) is VACUOUS for a>0, since -a<0 is never a square and -(4b^4)<=0<a. Hence the entire even-case difficulty (the open sorry) is a purely non-formally-real phenomenon; for positive radicands the criterion is unconditional (condition 1 alone).",
-      "The full vahlen_capelli proof invokes the sorry at exactly ONE line (the 8|n branch, via two_power_capelli); every other branch is already sorry-free. Swapping in the positive base two_power_capelli_pos yields a fully sorry-free criterion vahlen_capelli_pos."
+      "The full vahlen_capelli proof invokes the sorry at exactly ONE line (the 8|n branch, via two_power_capelli); every other branch is already sorry-free. Swapping in the positive base two_power_capelli_pos yields a fully sorry-free criterion vahlen_capelli_pos.",
+      "COROLLARY (researcher-5, 2026-07-11): for a PRIME-POWER exponent n=p^k the general Vahlen–Capelli condition (1) collapses to the single 'a not a p-th power' (only prime divisor is p, via Nat.prime_dvd_prime_iff_eq + Nat.Prime.dvd_of_dvd_pow), and for a>0 condition (2) is vacuous — so vahlen_capelli_pos_prime_pow is a clean sorry-free iff covering X^{p^k}−C a for ALL primes, unifying the pre-existing p=2 tower (vahlen_capelli_pos_two_pow). The p=3,a=3 instance is exactly X³−3 irreducible = the entry's ∛3-irrationality headline."
     ],
     "mathlibGaps": [
       "Mathlib FieldTheory/KummerExtension.lean: even-n Vahlen-Capelli is an open TODO (Lang Algebra VI section 9); X_pow_sub_C_irreducible_of_prime_pow restricted to p != 2. The -a in K^2, 8|n descent over K(i) remains unformalized.",
@@ -70,7 +71,7 @@
     "mathlib": []
   },
   "started": "2026-07-09T00:00:00.000Z",
-  "lastUpdate": "2026-07-11T00:00:00.000Z",
+  "lastUpdate": "2026-07-11",
   "significance": 7,
   "tractability": 7
 }


### PR DESCRIPTION
## Summary

Extends the **sorry-free positive-radicand branch** of `CubeRoot3IrrationalOQ02OQ03.lean` (Vahlen–Capelli irreducibility of `X^n − C a`). The file already had the `n = 2^k` corollary `vahlen_capelli_pos_two_pow`; this adds the general **prime** `p`, which the `∛3` headline is a direct instance of.

## New theorems (2, axiom-free **and** sorry-free)

| Theorem | Statement |
|---|---|
| `vahlen_capelli_pos_prime_pow` | for prime `p`, `a > 0`, `k ≥ 1`: `Irreducible (X^{p^k} − C a) ↔ ∀ b, bᵖ ≠ a`. The only prime divisor of `p^k` is `p`, so condition (1) collapses to "not a `p`-th power"; condition (2) is vacuous for `a > 0`. The odd-prime companion of `vahlen_capelli_pos_two_pow` (its `p = 2` case). |
| `vahlen_capelli_pos_prime` | the `k = 1` case — the clean prime-exponent form. Over `ℚ` with `a = 3`, `p = 3` this is the irreducibility of `X³ − 3`, the polynomial witnessing that `∛3` is irrational. |

## Verification

- **Host-lean elaboration**: EXIT 0, **0 errors**, 0 warnings in the new section.
- `#print axioms` on both → `[propext, Classical.choice, Quot.sound]` only — **axiom-free**, and confirmed **not** to depend on the file's sole open `sorry` (the `8 ∣ n`, `−a ∈ K²` Lang VI §9 descent, untouched).
- File `940 → 974` lines, `27 → 29` theorems.

## Files

- `proofs/Proofs/CubeRoot3IrrationalOQ02OQ03.lean` (+2 theorems)
- `src/data/proofs/cube-root-3-irrational-oq-02-oq-03/meta.json` (counts → 974/29)
- `src/data/research/problems/cube-root-3-irrational-oq-02-oq-03-incomplete-01.json` (knowledge update)

🤖 Generated with [Claude Code](https://claude.com/claude-code)