### PR TITLE
research(erdos-214-incomplete-01): complete Fermat characterization of √2·ℤ² realizable distances

### DIFF
--- a/proofs/Proofs/Erdos214Incomplete01OQ01.lean
+++ b/proofs/Proofs/Erdos214Incomplete01OQ01.lean
@@ -754,4 +754,81 @@ theorem scaledLattice_realizes_two_mul_sq_add_sq_mul (a b c d : ℤ) :
   push_cast
   ring
 
+/-!
+## The complete Fermat characterization of the realizable distances
+
+Every avoidance theorem above (`√6`, `√12`, `√24`, `√56`, and the mod-4/8/16 and
+odd-prime families) is a *special case* of one sharp statement: `√(2m)` is a
+distance of `√2·ℤ²` **iff** `m` is a sum of two squares, and — by Fermat's
+two-square theorem in the form `Nat.eq_sq_add_sq_iff` — iff every prime `r ≡ 3
+(mod 4)` divides `m` to an **even** power.  This closes the description of the
+realizable half-values `m` completely: they are exactly the norms of Gaussian
+integers.
+-/
+
+/-- **Sum-of-two-squares bridge `ℤ ↔ ℕ`.**  A natural number `m` is a sum of two
+*integer* squares iff it is a sum of two *natural* squares.  (`←` is a cast; `→`
+replaces each integer by its absolute value, using `(|u|)² = u²`.) -/
+theorem exists_sq_add_sq_int_iff_nat (m : ℕ) :
+    (∃ u v : ℤ, (m : ℤ) = u ^ 2 + v ^ 2) ↔ (∃ x y : ℕ, m = x ^ 2 + y ^ 2) := by
+  constructor
+  · rintro ⟨u, v, huv⟩
+    refine ⟨u.natAbs, v.natAbs, ?_⟩
+    have : (m : ℤ) = ((u.natAbs ^ 2 + v.natAbs ^ 2 : ℕ) : ℤ) := by
+      push_cast
+      rw [sq_abs, sq_abs]
+      linarith [huv]
+    exact_mod_cast this
+  · rintro ⟨x, y, hxy⟩
+    exact ⟨x, y, by exact_mod_cast hxy⟩
+
+/-- **Complete Fermat characterization of the realizable distances.**  For a natural
+number `m`, the value `√(2m)` is a distance between two points of `√2·ℤ²` **iff**
+every prime `r ≡ 3 (mod 4)` occurs to an even power in the prime factorization of
+`m`.
+
+This is the sharp capstone the whole file builds toward.  Combining
+`scaledLattice_achievable_iff` (realizable `⟺ m = u² + v²`), the `ℤ ↔ ℕ` bridge,
+and Fermat's two-square theorem `Nat.eq_sq_add_sq_iff`, it subsumes *every*
+avoidance and realizability result above:
+
+* `√6, √14, √22, …` avoided — `r = 3, 7, 11` to power `1` (odd);
+* `√12 = √(2·6)` avoided — `6 = 2·3`, `padicValNat 3 6 = 1` odd;
+* `√56 = √(2·28)` avoided — `28 = 2²·7`, `padicValNat 7 28 = 1` odd;
+* `√10, √26, √34, …` realized — no prime `≡ 3 (mod 4)` divides `5, 13, 17`;
+* `√8 = √(2·4)` realized — `4 = 2²` has no odd prime factor at all.
+
+So the realizable half-values are exactly the sums of two squares (norms of
+Gaussian integers), a set strictly finer than any single modular condition. -/
+theorem scaledLattice_realizes_sqrt_two_mul_iff_factorization (m : ℕ) :
+    (∃ p q : Plane, p ∈ ScaledLattice ∧ q ∈ ScaledLattice ∧
+        dist p q = Real.sqrt (2 * (m : ℝ)))
+      ↔ ∀ r ∈ m.primeFactors, r % 4 = 3 → Even (padicValNat r m) := by
+  have hcast : Real.sqrt (2 * (m : ℝ)) = Real.sqrt (((2 * m : ℕ) : ℝ)) := by
+    congr 1; push_cast; ring
+  rw [hcast, scaledLattice_achievable_iff, ← Nat.eq_sq_add_sq_iff,
+    ← exists_sq_add_sq_int_iff_nat]
+  -- Goal: (∃ u v, (↑(2m):ℤ) = 2·(u²+v²)) ↔ (∃ u v, (↑m:ℤ) = u²+v²)
+  constructor
+  · rintro ⟨u, v, h⟩
+    exact ⟨u, v, by push_cast at h ⊢; linarith⟩
+  · rintro ⟨u, v, h⟩
+    exact ⟨u, v, by push_cast; linarith⟩
+
+/-- **Every avoidance family is a special case of the capstone.**  If some prime
+`r ≡ 3 (mod 4)` divides `m` to an *odd* power, then `√(2m)` is not a lattice
+distance.  This reproves — from the single characterization
+`scaledLattice_realizes_sqrt_two_mul_iff_factorization` — every ad-hoc avoidance
+result of this file (`√6`, `√12`, `√24`, `√56`, and all the mod-4/8/16 and
+odd-prime obstruction lemmas). -/
+theorem scaledLattice_dist_ne_sqrt_two_mul_of_odd_padicValNat
+    {p q : Plane} (hp : p ∈ ScaledLattice) (hq : q ∈ ScaledLattice)
+    {m r : ℕ} (hr4 : r % 4 = 3) (hmem : r ∈ m.primeFactors)
+    (hodd : ¬ Even (padicValNat r m)) :
+    dist p q ≠ Real.sqrt (2 * (m : ℝ)) := by
+  intro h
+  have hreal := (scaledLattice_realizes_sqrt_two_mul_iff_factorization m).mp
+    ⟨p, q, hp, hq, h⟩
+  exact hodd (hreal r hmem hr4)
+
 end Erdos214Incomplete01OQ01

--- a/research/problems/erdos-214-incomplete-01/knowledge.md
+++ b/research/problems/erdos-214-incomplete-01/knowledge.md
@@ -317,3 +317,46 @@ every `r≡3 mod4` — the last elementary sufficient-avoidance mechanism before
 sum-of-two-squares characterization (`n/2` a SoS ⟺ every prime ≡3 mod4 in `n/2` to even
 power). Formalizing that biconditional (Mathlib has `Nat.Prime.sq_add_sq` and
 `SumTwoSquares.lean`) is the remaining substantial axiom-free target.
+
+## Session 2026-07-12 (researcher-1) — CAPSTONE: complete Fermat characterization [VERIFIED axiom-free]
+
+**Mode:** REVISIT — closed the "open frontier" of the OQ01 companion file. Extended
+`Erdos214Incomplete01OQ01.lean` (757→834, Mathlib-only, 0 ax / 0 sorry). VERIFIED via
+`lake env lean` against the main-repo Mathlib oleans: EXIT 0, zero errors/warnings;
+`#print axioms` = `[propext, Classical.choice, Quot.sound]` only (no `sorryAx`/`ofReduceBool`)
+for all 3 new theorems.
+
+### The capstone (subsumes every prior avoidance/realizability lemma in the file)
+- `scaledLattice_realizes_sqrt_two_mul_iff_factorization (m : ℕ)`: `√(2m)` is a distance
+  of `√2·ℤ²` **iff** `∀ r ∈ m.primeFactors, r%4=3 → Even (padicValNat r m)`. This is the
+  complete Fermat characterization: realizable half-values are exactly the sums of two
+  squares (Gaussian-integer norms). Every earlier result is a special case — `√6/√14/√22`
+  (r=3,7,11 to odd power), `√12=√(2·6)` (padicValNat 3 6=1), `√56=√(2·28)` (padicValNat 7
+  28=1) avoided; `√10/√26/√34` and `√8=√(2·4)` realized.
+- `exists_sq_add_sq_int_iff_nat (m : ℕ)`: the `ℤ↔ℕ` sum-of-two-squares bridge. `←` cast;
+  `→` via `u.natAbs`/`v.natAbs` + `sq_abs`.
+- `scaledLattice_dist_ne_sqrt_two_mul_of_odd_padicValNat`: odd-power prime `r≡3 mod4` ⟹
+  `√(2m)` avoided — reproves every ad-hoc avoidance lemma directly from the capstone.
+
+### Proof architecture (3-step Iff chain)
+`scaledLattice_achievable_iff (2m)` (realizable ⟺ `2m = 2(u²+v²)`, i.e. `m = u²+v²` over ℤ)
+→ `exists_sq_add_sq_int_iff_nat` (ℤ→ℕ) → Mathlib `Nat.eq_sq_add_sq_iff` (ℕ sum-of-two-squares
+⟺ prime-factorization condition). Assembled by `rw [hcast, scaledLattice_achievable_iff,
+← Nat.eq_sq_add_sq_iff, ← exists_sq_add_sq_int_iff_nat]` leaving only the `2·` cancellation
+(closed by `push_cast; linarith`).
+
+### Gotchas (reusable)
+- `push_cast` rewrites `(↑n.natAbs : ℤ)` to `|n|` (via `Int.cast_natAbs`) BEFORE `Int.natAbs_sq`
+  can fire, leaving `|u|²`. Fix: `push_cast; rw [sq_abs, sq_abs]` (not `push_cast [Int.natAbs_sq]`).
+- Mathlib key lemma: `Nat.eq_sq_add_sq_iff {n} : (∃ x y, n = x²+y²) ↔ ∀ q ∈ n.primeFactors,
+  q%4=3 → Even (padicValNat q n)` (in `Mathlib.NumberTheory.SumTwoSquares`).
+
+### Frontier
+The realizable distance set of `√2·ℤ²` is now COMPLETELY characterized (this file is
+essentially done). Core #214 unchanged: BLOCKED on `juhasz_stronger` (deep incidence
+geometry, not in Mathlib).
+
+### Verification note
+Worktree `.lake` has 0 mathlib oleans; verified a scratch copy (`import Mathlib`, self-contained)
+against the main-repo Mathlib oleans via `lake env lean` — the main repo auto-reverts uncommitted
+edits so edits live only in the researcher-1-2 worktree / feature branch.

--- a/src/data/research/problems/erdos-214-incomplete-01.json
+++ b/src/data/research/problems/erdos-214-incomplete-01.json
@@ -33,14 +33,17 @@
     }
   },
   "knowledge": {
-    "progressSummary": "AXIOMATIZED/BLOCKED on juhasz_stronger. Axiom-free scaffolding now includes: full metric axioms for Erdos214.dist, isometry-invariance + vertex-distinctness of unit squares, and infinitude of the √2·ℤ² witness. 0 sorries, 1 intended axiom.",
+    "progressSummary": "PROGRESS: companion OQ01 file COMPLETE — full Fermat characterization of √2·ℤ² realizable distances proved axiom-free; core #214 remains BLOCKED on juhasz_stronger",
     "builtItems": [
       "Erdos214Problem.lean: dist_coords (coordinate distance formula), isUnitSquare_standard (the standard unit square is a unit square), unit_square_from_stronger (sorry eliminated, 0-axiom reduction)",
       "Fixed Mathlib-4.26 build break: UnitDistanceGraph tuple set-builder → setOf on Prod",
       "dist_nonneg, dist_triangle in Erdos214Problem.lean: the two metric axioms missing from dist_self/dist_comm (via norm_nonneg, norm_add_le + sub_add_sub_cancel) — Erdos214.dist certified a genuine metric",
       "scaledLattice_horiz_mem + scaledLattice_infinite: √2·ℤ² is infinite (horizontal axis n↦(√2·n,0) embeds ℤ via Set.infinite_of_injective_forall_mem), sharpening scaledLattice_unitDistanceFree from non-empty to infinite",
       "scaledLatticeGen_unitDistanceFree: c·ℤ² is unit-distance-free for every real c with c²>1 (generalizes the √2 case; squared distance c²·m never hits 1 since m∈ℕ, m=0→0, m≥1→c²·m≥c²>1). scaledLattice_eq_gen (rfl) exhibits ScaledLattice as the c=√2 instance. [elaboration-clean [2364/2364]; olean-write blocked by fleet SIGBUS-135/139]",
-      "Erdos214Incomplete01OQ01.lean §Fermat (researcher-2): scaledLattice_realizes_sqrt_two_mul_prime, scaledLattice_dist_ne_sqrt_two_mul_of_mod_four, scaledLattice_realizes_sqrt_two_mul_prime_iff (SHARP prime iff √(2p)⇔p≢3 mod4), scaledLattice_realizes_sqrt_ten (p=5 witness), scaledLattice_realizes_two_mul_sq_add_sq_mul (Brahmagupta closure). Uses Mathlib Nat.Prime.sq_add_sq. [elaboration-clean via `lake env lean` (no -c); codegen olean-write still SIGBUS-135 on fleet — a known infra crash AFTER successful elaboration, not a proof error]"
+      "Erdos214Incomplete01OQ01.lean §Fermat (researcher-2): scaledLattice_realizes_sqrt_two_mul_prime, scaledLattice_dist_ne_sqrt_two_mul_of_mod_four, scaledLattice_realizes_sqrt_two_mul_prime_iff (SHARP prime iff √(2p)⇔p≢3 mod4), scaledLattice_realizes_sqrt_ten (p=5 witness), scaledLattice_realizes_two_mul_sq_add_sq_mul (Brahmagupta closure). Uses Mathlib Nat.Prime.sq_add_sq. [elaboration-clean via `lake env lean` (no -c); codegen olean-write still SIGBUS-135 on fleet — a known infra crash AFTER successful elaboration, not a proof error]",
+      "exists_sq_add_sq_int_iff_nat (Erdos214Incomplete01OQ01.lean): ℤ↔ℕ sum-of-two-squares bridge (natAbs + sq_abs)",
+      "scaledLattice_realizes_sqrt_two_mul_iff_factorization: capstone iff via scaledLattice_achievable_iff + bridge + Nat.eq_sq_add_sq_iff",
+      "scaledLattice_dist_ne_sqrt_two_mul_of_odd_padicValNat: odd-power prime≡3mod4 ⟹ √(2m) avoided, reproving every ad-hoc avoidance lemma from the capstone"
     ],
     "insights": [
       "erdos-214 (Juhász 1979, unit-distance-free sets): the 1 sorry was in unit_square_from_stronger (JuhaszStrongerTheorem → Erdos214Statement) — a pure logical reduction, NOT one of the 2 deep Juhász axioms.",
@@ -52,13 +55,15 @@
       "The √2 lattice is not special: any scaling c with |c|>1 yields a unit-distance-free copy of ℤ². The sharp condition is arithmetic (no sum-of-two-squares integer m with c²·m=1), so c²>1 is sufficient but not necessary (e.g. c=1/√3 also works since 3 is not a sum of two squares).",
       "The realizable distances of √2·ℤ² are exactly √n with n=2·(sum of two squares) — i.e. dist²=2·(u²+v²). This makes the whole 'distance spectrum' a sum-of-two-squares question. For a PRIME p the family √(2p) is now sharp: realized ⇔ p≢3 mod4 (Fermat). Forward (avoidance) is the u²+v²≢3 mod4 residue obstruction; converse is Fermat's Nat.Prime.sq_add_sq. Note every 2p with p≡3 mod4 is ≡6 mod8, so the avoidance overlaps scaledLattice_dist_ne_sqrt_six_mod_eight — but the realizability converse is genuinely new.",
       "Brahmagupta–Fibonacci identity (a²+b²)(c²+d²)=(ac−bd)²+(ad+bc)² proved by pure `ring` after push_cast — realizes √(2·(a²+b²)(c²+d²)) at latticePoint (ac−bd) (ad+bc). Exhibits the realizable squared-half distances as the multiplicative monoid of Gaussian-integer norms, the structural reason primes ≡3 mod4 govern the avoidance families.",
-      "VERIFICATION WORKAROUND for `import Mathlib` files when fleet codegen SIGBUS-135s: `docker run … lake env lean <file>.lean` (plain `lean`, no -o/-c) elaborates + runs `#print axioms` WITHOUT triggering the crashing C-codegen/olean-write phase. A type error would print `error: <file>:<line>` and exit 1 BEFORE any crash; exit 135 = SIGBUS = infra, post-elaboration. Confirms both type-correctness and axiom set."
+      "VERIFICATION WORKAROUND for `import Mathlib` files when fleet codegen SIGBUS-135s: `docker run … lake env lean <file>.lean` (plain `lean`, no -o/-c) elaborates + runs `#print axioms` WITHOUT triggering the crashing C-codegen/olean-write phase. A type error would print `error: <file>:<line>` and exit 1 BEFORE any crash; exit 135 = SIGBUS = infra, post-elaboration. Confirms both type-correctness and axiom set.",
+      "CAPSTONE: scaledLattice_realizes_sqrt_two_mul_iff_factorization — √(2m) is a lattice distance IFF every prime r≡3 mod4 divides m to an even power (Nat.eq_sq_add_sq_iff). Complete Fermat characterization of the realizable distance set; subsumes ALL prior avoidance families (mod-4/8/16, r=3, r=7, general r≡3 mod4) and realizability results as special cases."
     ],
     "mathlibGaps": [],
     "nextSteps": [
       "Distance-spectrum thread: prime family √(2p) now sharp both directions (Fermat). Next: full sum-of-two-squares characterization of ALL realizable √n via Nat.eq_sq_add_sq_iff (n realized ⇔ n even ∧ n/2 has no prime ≡3 mod4 to an odd power) — moderate, would subsume every one-off avoidance theorem in the file.",
       "Realizability of √(2·p·q) product distances follows quickly from scaledLattice_realizes_two_mul_sq_add_sq_mul + the prime realizability lemma.",
-      "Core BLOCKED on juhasz_stronger (deep 1979 4-point theorem, not in Mathlib). Only substantial work left on the CORE = formalizing that axiom."
+      "Core BLOCKED on juhasz_stronger (deep 1979 4-point theorem, not in Mathlib). Only substantial work left on the CORE = formalizing that axiom.",
+      "Realizable half-values now fully characterized; remaining OQ01 work is optional cosmetic corollaries. Core #214 still BLOCKED on juhasz_stronger (deep incidence geometry not in Mathlib)."
     ],
     "markdown": "# Knowledge: erdos-214-incomplete-01\n\n## Research Notes\n\n*No research conducted yet. See problem.md for context.*\n\n## Known Facts\n\n- Lean file: `proofs/Proofs/`\n- Sorries: see problem.md\n\n## Approaches Tried\n\n*None yet.*\n"
   },
@@ -75,15 +80,15 @@
     "mathlib": []
   },
   "started": "2026-04-03T08:27:10.206Z",
-  "lastUpdate": "2026-07-11",
+  "lastUpdate": "2026-07-12",
   "significance": 7,
   "tractability": 4,
   "leanFiles": [
     {
       "path": "Proofs/Erdos214Incomplete01OQ01.lean",
       "filename": "Erdos214Incomplete01OQ01.lean",
-      "lineCount": 757,
-      "theoremCount": 38,
+      "lineCount": 834,
+      "theoremCount": 41,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,


### PR DESCRIPTION
Extends the axiom-free companion file `Erdos214Incomplete01OQ01.lean` for Erdős #214 (the √2-scaled lattice is unit-distance-free). Core #214 remains BLOCKED on `juhasz_stronger` (deep incidence geometry, not in Mathlib); all work here is verified, axiom-free number theory *around* the definitions.

## Capstone
`scaledLattice_realizes_sqrt_two_mul_iff_factorization (m : ℕ)`: **`√(2m)` is a distance between two points of `√2·ℤ²` iff every prime `r ≡ 3 (mod 4)` divides `m` to an even power** (Fermat's two-square theorem via Mathlib `Nat.eq_sq_add_sq_iff`). This completely characterizes the realizable distance set: the realizable half-values `m` are exactly the sums of two squares (Gaussian-integer norms). It subsumes *every* prior avoidance family (mod-4/8/16, r=3, r=7, general r≡3 mod 4) and realizability result as a special case:
- avoided: √6/√14/√22 (prime ≡3 mod4 to odd power), √12=√(2·6), √56=√(2·28);
- realized: √8=√(2·4), √10/√26/√34.

## Supporting lemmas
- `exists_sq_add_sq_int_iff_nat` — the ℤ↔ℕ sum-of-two-squares bridge (`natAbs` + `sq_abs`).
- `scaledLattice_dist_ne_sqrt_two_mul_of_odd_padicValNat` — odd-power prime ≡3 mod4 ⟹ `√(2m)` avoided, reproving the ad-hoc avoidance lemmas directly from the capstone.

## Verification
`lake env lean` exit 0, zero errors/warnings; `#print axioms` = `[propext, Classical.choice, Quot.sound]` for all three new theorems (no `sorryAx`/`ofReduceBool`). File 757→834 L, 38→41 theorems, 0 axioms, 0 sorries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)