### PR TITLE
research(de-moivre-oq-06-oq-02-oq-01): Fejér kernel as the Cesàro average of the Dirichlet kernels

### DIFF
--- a/proofs/Proofs/DeMoivreOQ06OQ02OQ01.lean
+++ b/proofs/Proofs/DeMoivreOQ06OQ02OQ01.lean
@@ -1,0 +1,186 @@
+/-
+The Fejér kernel as the Cesàro average of the Dirichlet kernels
+
+Source: Open question from the de-moivre gallery family (de-moivre-oq-06-oq-02-oq-01)
+Status: VERIFIED (0 axioms, 0 sorries)
+
+The parent file `DeMoivreOQ06OQ02` supplies *uniform* bounds for the Dirichlet
+kernel on an arc `θ ∈ [δ, 2π − δ]` bounded away from the singularities `θ ∈ 2πℤ`.
+The grandparent `DeMoivreOQ06` gives Lagrange's closed forms
+
+      ∑_{k=0}^{n} cos(kθ) = 1/2 + sin((n+1/2)θ) / (2 sin(θ/2)).
+
+The (symmetric) **Dirichlet kernel** is
+      Dₙ(θ) = ∑_{k=−n}^{n} e^{ikθ} = 1 + 2 ∑_{k=1}^{n} cos(kθ)
+            = 2·(∑_{k=0}^{n} cos(kθ)) − 1 = sin((n+1/2)θ) / sin(θ/2).
+
+Its Cesàro average is the **Fejér kernel**
+      F_N(θ) = (1/(N+1)) ∑_{n=0}^{N} Dₙ(θ).
+
+This file establishes the three defining facts about `F_N`, all reusing the
+parent's product-to-sum telescoping:
+
+* `sum_sin_half_odd` — the telescoping identity
+  `2 sin(θ/2) · ∑_{m=0}^{N} sin((m+1/2)θ) = 1 − cos((N+1)θ)`.
+* `fejerKernel_closed_form` — the celebrated closed form
+  `F_N(θ) = sin²((N+1)θ/2) / ((N+1) sin²(θ/2))`.  Being a perfect square over a
+  positive quantity, the Fejér kernel is **nonnegative** — the property that
+  makes `{F_N}` an *approximate identity* (unlike the sign-changing Dirichlet
+  kernel), the engine behind Fejér's theorem on Cesàro summability of Fourier
+  series.
+* `fejerKernel_nonneg` — `0 ≤ F_N(θ)`.
+* `fejerKernel_uniform_bound` — on the arc `θ ∈ [δ, 2π − δ]`,
+  `F_N(θ) ≤ 1 / ((N+1) sin²(δ/2))`, so the mass of `F_N` concentrates at the
+  origin as `N → ∞`.
+-/
+
+import Proofs.DeMoivreOQ06OQ02
+import Mathlib.Tactic
+
+open Finset
+
+namespace DeMoivreOQ06OQ02OQ01
+
+/-- Product-to-sum telescoping step for the half-integer sines:
+`2 sin(θ/2) sin((m+1/2)θ) = cos(mθ) − cos((m+1)θ)`.
+
+The identity `cos(X−Y) − cos(X+Y) = 2 sin X sin Y` with `X = (m+1/2)θ`,
+`Y = θ/2` (so `X−Y = mθ` and `X+Y = (m+1)θ`). -/
+theorem two_sin_half_mul_sin_odd (θ m : ℝ) :
+    2 * Real.sin (θ / 2) * Real.sin ((m + 1 / 2) * θ)
+      = Real.cos (m * θ) - Real.cos ((m + 1) * θ) := by
+  have h1 : m * θ = (m + 1 / 2) * θ - θ / 2 := by ring
+  have h2 : (m + 1) * θ = (m + 1 / 2) * θ + θ / 2 := by ring
+  rw [h1, h2, Real.cos_sub, Real.cos_add]
+  ring
+
+/-- **Telescoped half-integer sine sum.**
+`2 sin(θ/2) · ∑_{m=0}^{N} sin((m+1/2)θ) = 1 − cos((N+1)θ)`.
+
+Distributing `2 sin(θ/2)` across the sum and applying `two_sin_half_mul_sin_odd`
+term-by-term makes the sum telescope: consecutive `cos(mθ)` cancel, leaving the
+endpoints `cos(0) − cos((N+1)θ) = 1 − cos((N+1)θ)`. -/
+theorem sum_sin_half_odd (θ : ℝ) (N : ℕ) :
+    2 * Real.sin (θ / 2) * (∑ m ∈ Finset.range (N + 1), Real.sin (((m : ℝ) + 1 / 2) * θ))
+      = 1 - Real.cos (((N : ℝ) + 1) * θ) := by
+  induction N with
+  | zero =>
+      rw [Finset.sum_range_one]
+      have h := two_sin_half_mul_sin_odd θ 0
+      simp only [zero_mul, Real.cos_zero] at h
+      push_cast
+      linear_combination h
+  | succ N ih =>
+      rw [Finset.sum_range_succ, mul_add, ih]
+      have h := two_sin_half_mul_sin_odd θ ((N : ℝ) + 1)
+      push_cast
+      push_cast at h
+      linear_combination h
+
+/-- The (symmetric) **Dirichlet kernel**
+`Dₙ(θ) = 1 + 2 ∑_{k=1}^{n} cos(kθ) = 2·(∑_{k=0}^{n} cos(kθ)) − 1`. -/
+noncomputable def dirichletKernel (n : ℕ) (θ : ℝ) : ℝ :=
+  2 * (∑ k ∈ Finset.range (n + 1), Real.cos ((k : ℝ) * θ)) - 1
+
+/-- Closed form of the Dirichlet kernel: `Dₙ(θ) = sin((n+1/2)θ) / sin(θ/2)`
+for `sin(θ/2) ≠ 0`. Immediate from Lagrange's cosine identity in `DeMoivreOQ06`. -/
+theorem dirichletKernel_closed_form (θ : ℝ) (hθ : Real.sin (θ / 2) ≠ 0) (n : ℕ) :
+    dirichletKernel n θ = Real.sin (((n : ℝ) + 1 / 2) * θ) / Real.sin (θ / 2) := by
+  unfold dirichletKernel
+  rw [DeMoivreOQ06.lagrange_cos_sum θ hθ n]
+  field_simp
+  ring
+
+/-- The **Fejér kernel** `F_N(θ) = (1/(N+1)) ∑_{n=0}^{N} Dₙ(θ)`, the Cesàro
+(arithmetic) mean of the first `N+1` Dirichlet kernels. -/
+noncomputable def fejerKernel (N : ℕ) (θ : ℝ) : ℝ :=
+  (∑ n ∈ Finset.range (N + 1), dirichletKernel n θ) / ((N : ℝ) + 1)
+
+/-- **Sum of Dirichlet kernels in closed form.**
+`∑_{n=0}^{N} Dₙ(θ) = sin²((N+1)θ/2) / sin²(θ/2)` for `sin(θ/2) ≠ 0`.
+
+Rewrite each `Dₙ` by its closed form, factor out `1/sin(θ/2)`, apply the
+telescoping `sum_sin_half_odd`, and convert `1 − cos((N+1)θ) = 2 sin²((N+1)θ/2)`
+via the double-angle formula. -/
+theorem sum_dirichletKernel (θ : ℝ) (hθ : Real.sin (θ / 2) ≠ 0) (N : ℕ) :
+    ∑ n ∈ Finset.range (N + 1), dirichletKernel n θ
+      = (Real.sin (((N : ℝ) + 1) * θ / 2)) ^ 2 / (Real.sin (θ / 2)) ^ 2 := by
+  -- Sum of the closed forms, with `1/sin(θ/2)` factored out.
+  have hsum : ∑ n ∈ Finset.range (N + 1), dirichletKernel n θ
+      = (∑ n ∈ Finset.range (N + 1), Real.sin (((n : ℝ) + 1 / 2) * θ)) / Real.sin (θ / 2) := by
+    rw [Finset.sum_div]
+    exact Finset.sum_congr rfl fun n _ => dirichletKernel_closed_form θ hθ n
+  -- Half-angle identity `1 − cos((N+1)θ) = 2 sin²((N+1)θ/2)`.
+  have hcos : 1 - Real.cos (((N : ℝ) + 1) * θ) = 2 * (Real.sin (((N : ℝ) + 1) * θ / 2)) ^ 2 := by
+    set y := ((N : ℝ) + 1) * θ / 2 with hy
+    have h2y : ((N : ℝ) + 1) * θ = 2 * y := by rw [hy]; ring
+    rw [h2y, Real.cos_two_mul]
+    nlinarith [Real.sin_sq_add_cos_sq y]
+  -- `sin(θ/2) · ∑ sin((n+1/2)θ) = sin²((N+1)θ/2)`.
+  have hS : Real.sin (θ / 2) * (∑ n ∈ Finset.range (N + 1), Real.sin (((n : ℝ) + 1 / 2) * θ))
+      = (Real.sin (((N : ℝ) + 1) * θ / 2)) ^ 2 := by
+    have hodd := sum_sin_half_odd θ N
+    rw [hcos] at hodd
+    linarith
+  rw [hsum]
+  rw [div_eq_div_iff hθ (pow_ne_zero 2 hθ)]
+  linear_combination Real.sin (θ / 2) * hS
+
+/-- **Fejér kernel closed form.**
+`F_N(θ) = sin²((N+1)θ/2) / ((N+1) sin²(θ/2))` for `sin(θ/2) ≠ 0`. -/
+theorem fejerKernel_closed_form (θ : ℝ) (hθ : Real.sin (θ / 2) ≠ 0) (N : ℕ) :
+    fejerKernel N θ
+      = (Real.sin (((N : ℝ) + 1) * θ / 2)) ^ 2
+          / (((N : ℝ) + 1) * (Real.sin (θ / 2)) ^ 2) := by
+  unfold fejerKernel
+  rw [sum_dirichletKernel θ hθ N, div_div, mul_comm ((Real.sin (θ / 2)) ^ 2)]
+
+/-- **The Fejér kernel is nonnegative.**
+`0 ≤ F_N(θ)` for `sin(θ/2) ≠ 0`.  A perfect square over the positive quantity
+`(N+1) sin²(θ/2)`.  This is the property that fails for the Dirichlet kernel and
+makes `{F_N}` a genuine approximate identity. -/
+theorem fejerKernel_nonneg (θ : ℝ) (hθ : Real.sin (θ / 2) ≠ 0) (N : ℕ) :
+    0 ≤ fejerKernel N θ := by
+  rw [fejerKernel_closed_form θ hθ N]
+  apply div_nonneg
+  · positivity
+  · have : 0 < (Real.sin (θ / 2)) ^ 2 := by positivity
+    positivity
+
+/-- **Uniform bound for the Fejér kernel on the arc.**
+On `θ ∈ [δ, 2π − δ]` (with `0 < δ ≤ π`),
+`F_N(θ) ≤ 1 / ((N+1) sin²(δ/2))`, uniformly in `θ`, and `→ 0` as `N → ∞`.
+
+The numerator `sin²((N+1)θ/2) ≤ 1`, while the denominator is bounded below using
+the parent's `sin(θ/2) ≥ sin(δ/2) > 0`.  Concentration of the Fejér mass at the
+origin is the analytic heart of Fejér's theorem. -/
+theorem fejerKernel_uniform_bound (δ θ : ℝ) (hδ0 : 0 < δ) (hδπ : δ ≤ Real.pi)
+    (hθ1 : δ ≤ θ) (hθ2 : θ ≤ 2 * Real.pi - δ) (N : ℕ) :
+    fejerKernel N θ ≤ 1 / (((N : ℝ) + 1) * (Real.sin (δ / 2)) ^ 2) := by
+  have hpi := Real.pi_pos
+  have hδpos : 0 < Real.sin (δ / 2) :=
+    Real.sin_pos_of_pos_of_lt_pi (by linarith) (by linarith)
+  have hθge : Real.sin (δ / 2) ≤ Real.sin (θ / 2) :=
+    DeMoivreOQ06OQ02.sin_half_ge_of_mem_arc δ θ hδ0 hδπ hθ1 hθ2
+  have hθpos : 0 < Real.sin (θ / 2) := lt_of_lt_of_le hδpos hθge
+  have hθne : Real.sin (θ / 2) ≠ 0 := ne_of_gt hθpos
+  rw [fejerKernel_closed_form θ hθne N]
+  -- numerator ≤ 1
+  have hnum : (Real.sin (((N : ℝ) + 1) * θ / 2)) ^ 2 ≤ 1 := by
+    nlinarith [Real.sin_sq_add_cos_sq (((N : ℝ) + 1) * θ / 2),
+      sq_nonneg (Real.cos (((N : ℝ) + 1) * θ / 2))]
+  -- denominators are positive and comparable
+  have hNpos : 0 < (N : ℝ) + 1 := by positivity
+  have hden_arc : 0 < ((N : ℝ) + 1) * (Real.sin (δ / 2)) ^ 2 := by positivity
+  have hden_θ : 0 < ((N : ℝ) + 1) * (Real.sin (θ / 2)) ^ 2 := by positivity
+  have hden_le : ((N : ℝ) + 1) * (Real.sin (δ / 2)) ^ 2
+      ≤ ((N : ℝ) + 1) * (Real.sin (θ / 2)) ^ 2 := by
+    apply mul_le_mul_of_nonneg_left _ (le_of_lt hNpos)
+    nlinarith [hθge, hδpos.le, hθpos.le]
+  calc (Real.sin (((N : ℝ) + 1) * θ / 2)) ^ 2 / (((N : ℝ) + 1) * (Real.sin (θ / 2)) ^ 2)
+      ≤ 1 / (((N : ℝ) + 1) * (Real.sin (θ / 2)) ^ 2) := by
+        rw [div_le_div_iff_of_pos_right hden_θ]; exact hnum
+    _ ≤ 1 / (((N : ℝ) + 1) * (Real.sin (δ / 2)) ^ 2) :=
+        one_div_le_one_div_of_le hden_arc hden_le
+
+end DeMoivreOQ06OQ02OQ01

--- a/src/data/proofs/de-moivre-oq-06-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/de-moivre-oq-06-oq-02-oq-01/annotations.json
@@ -1,0 +1,116 @@
+[
+  {
+    "id": "ann-dm060201-docstring",
+    "proofId": "de-moivre-oq-06-oq-02-oq-01",
+    "range": {
+      "startLine": 1,
+      "endLine": 42
+    },
+    "type": "concept",
+    "title": "Averaging Repairs the Dirichlet Kernel",
+    "content": "The docstring frames the construction. The Dirichlet kernel $D_n(\\theta)=\\sin((n+\\tfrac12)\\theta)/\\sin(\\theta/2)$ represents Fourier partial sums, but it changes sign and $\\|D_n\\|_1\\sim\\log n$, so partial sums can diverge. Fejér's remedy is the **Cesàro average** $F_N=\\frac{1}{N+1}\\sum_{n=0}^{N}D_n$, whose kernel is nonnegative and concentrates at the origin. This file constructs $F_N$ from the parent family's Dirichlet kernels and proves the three properties — closed form, nonnegativity, uniform decay away from the singularities $\\theta\\in2\\pi\\mathbb{Z}$ — that drive Fejér's theorem on uniform Cesàro convergence.",
+    "mathContext": "$F_N(\\theta)=\\frac{1}{N+1}\\sum_{n=0}^{N}D_n(\\theta)$ with $D_n(\\theta)=2\\big(\\sum_{k=0}^{n}\\cos(k\\theta)\\big)-1$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Fejér kernel",
+      "Dirichlet kernel",
+      "Cesàro summability",
+      "approximate identity"
+    ],
+    "prerequisites": [
+      "Dirichlet kernel closed form",
+      "Cesàro (arithmetic) means"
+    ]
+  },
+  {
+    "id": "ann-dm060201-telescoping",
+    "proofId": "de-moivre-oq-06-oq-02-oq-01",
+    "range": {
+      "startLine": 44,
+      "endLine": 78
+    },
+    "type": "technique",
+    "title": "Telescoping the Half-Integer Sine Sum",
+    "content": "The engine of the closed form is a single product-to-sum step. `two_sin_half_mul_sin_odd` proves $2\\sin(\\theta/2)\\sin((m+\\tfrac12)\\theta)=\\cos(m\\theta)-\\cos((m+1)\\theta)$ — the identity $\\cos(X-Y)-\\cos(X+Y)=2\\sin X\\sin Y$ with $X=(m+\\tfrac12)\\theta$, $Y=\\theta/2$ (so $X-Y=m\\theta$, $X+Y=(m+1)\\theta$), reduced by `Real.cos_sub`/`Real.cos_add` and `ring`. Distributing $2\\sin(\\theta/2)$ across $\\sum_{m=0}^{N}\\sin((m+\\tfrac12)\\theta)$ and applying this term-by-term makes consecutive cosines cancel; `sum_sin_half_odd` runs the induction (`Finset.sum_range_succ` + `linear_combination`) to collapse the sum to its endpoints $\\cos(0)-\\cos((N+1)\\theta)=1-\\cos((N+1)\\theta)$. This is the same telescoping technique the grandparent used for the Dirichlet closed forms, here applied to the half-integer frequencies $(m+\\tfrac12)$ that appear in the Cesàro sum.",
+    "mathContext": "$2\\sin(\\theta/2)\\sum_{m=0}^{N}\\sin((m+\\tfrac12)\\theta)=\\sum_{m=0}^{N}\\big(\\cos(m\\theta)-\\cos((m+1)\\theta)\\big)=1-\\cos((N+1)\\theta)$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "product-to-sum identity",
+      "telescoping sum",
+      "induction on Finset.range"
+    ],
+    "prerequisites": [
+      "Real.cos_sub / Real.cos_add",
+      "Finset.sum_range_succ"
+    ]
+  },
+  {
+    "id": "ann-dm060201-dirichlet",
+    "proofId": "de-moivre-oq-06-oq-02-oq-01",
+    "range": {
+      "startLine": 80,
+      "endLine": 92
+    },
+    "type": "definition",
+    "title": "The Symmetric Dirichlet Kernel in Closed Form",
+    "content": "`dirichletKernel n θ` is defined as $2\\big(\\sum_{k=0}^{n}\\cos(k\\theta)\\big)-1$, the symmetric kernel $1+2\\sum_{k=1}^{n}\\cos(k\\theta)=\\sum_{k=-n}^{n}e^{ik\\theta}$. `dirichletKernel_closed_form` puts it in the classical form $D_n(\\theta)=\\sin((n+\\tfrac12)\\theta)/\\sin(\\theta/2)$ for $\\sin(\\theta/2)\\ne0$, immediately from the grandparent's Lagrange cosine identity $\\sum_{k=0}^{n}\\cos(k\\theta)=\\tfrac12+\\tfrac{\\sin((n+\\frac12)\\theta)}{2\\sin(\\theta/2)}$: doubling and subtracting $1$ cancels the $\\tfrac12$ and clears the factor $2$ in the denominator (`field_simp`/`ring`). This is the object whose Cesàro average is taken next.",
+    "mathContext": "$D_n(\\theta)=2\\big(\\tfrac12+\\tfrac{\\sin((n+\\frac12)\\theta)}{2\\sin(\\theta/2)}\\big)-1=\\tfrac{\\sin((n+\\frac12)\\theta)}{\\sin(\\theta/2)}$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Dirichlet kernel",
+      "Lagrange's trigonometric identity",
+      "geometric sum of exponentials"
+    ],
+    "prerequisites": [
+      "DeMoivreOQ06.lagrange_cos_sum"
+    ]
+  },
+  {
+    "id": "ann-dm060201-closed-form",
+    "proofId": "de-moivre-oq-06-oq-02-oq-01",
+    "range": {
+      "startLine": 94,
+      "endLine": 139
+    },
+    "type": "technique",
+    "title": "The Fejér Closed Form: a Perfect Square",
+    "content": "`fejerKernel N θ` is the Cesàro average $\\frac{1}{N+1}\\sum_{n=0}^{N}D_n(\\theta)$. `sum_dirichletKernel` computes the sum: rewriting each $D_n$ by its closed form and factoring $1/\\sin(\\theta/2)$ gives $\\sum_{n=0}^{N}D_n=\\tfrac{1}{\\sin(\\theta/2)}\\sum_{n=0}^{N}\\sin((n+\\tfrac12)\\theta)$; the telescoping `sum_sin_half_odd` supplies $\\sum\\sin((n+\\tfrac12)\\theta)=\\tfrac{1-\\cos((N+1)\\theta)}{2\\sin(\\theta/2)}$, and the double-angle identity $1-\\cos((N+1)\\theta)=2\\sin^2((N+1)\\theta/2)$ — proved locally with `Real.cos_two_mul` and `Real.sin_sq_add_cos_sq` after a `set` to protect the half-angle from the rewrite — turns it into $\\sin^2((N+1)\\theta/2)/\\sin^2(\\theta/2)$. Dividing by $N+1$ (`fejerKernel_closed_form`, via `div_div`) yields the celebrated $F_N(\\theta)=\\dfrac{\\sin^2((N+1)\\theta/2)}{(N+1)\\sin^2(\\theta/2)}$. The kernel is now manifestly a square over a positive quantity.",
+    "mathContext": "$\\sum_{n=0}^{N}D_n=\\tfrac{\\sin^2((N+1)\\theta/2)}{\\sin^2(\\theta/2)}\\ \\Rightarrow\\ F_N(\\theta)=\\tfrac{\\sin^2((N+1)\\theta/2)}{(N+1)\\sin^2(\\theta/2)}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Fejér kernel closed form",
+      "double-angle identity",
+      "Cesàro mean"
+    ],
+    "prerequisites": [
+      "sum_sin_half_odd",
+      "Real.cos_two_mul",
+      "Real.sin_sq_add_cos_sq"
+    ]
+  },
+  {
+    "id": "ann-dm060201-nonneg-bound",
+    "proofId": "de-moivre-oq-06-oq-02-oq-01",
+    "range": {
+      "startLine": 141,
+      "endLine": 186
+    },
+    "type": "concept",
+    "title": "Nonnegativity and Concentration: the Approximate Identity",
+    "content": "The two properties that distinguish the Fejér kernel from the Dirichlet kernel. `fejerKernel_nonneg` reads $0\\le F_N(\\theta)$ straight off the closed form — a squared numerator over the positive denominator $(N+1)\\sin^2(\\theta/2)$ (`div_nonneg`, `positivity`); the sign-changing Dirichlet kernel has no such lower bound, and this is exactly why Cesàro means converge where partial sums may not. `fejerKernel_uniform_bound` gives the concentration estimate: on the arc $\\theta\\in[\\delta,2\\pi-\\delta]$, the numerator satisfies $\\sin^2((N+1)\\theta/2)\\le1$ while the parent's `sin_half_ge_of_mem_arc` forces $\\sin(\\theta/2)\\ge\\sin(\\delta/2)>0$, so $F_N(\\theta)\\le\\frac{1}{(N+1)\\sin^2(\\delta/2)}$ — an $O(1/N)$ decay uniform in $\\theta$, proved by `div_le_div_iff_of_pos_right` (numerator step) chained with `one_div_le_one_div_of_le` (denominator step). Nonnegativity plus this decay away from the origin are precisely the two hypotheses of an approximate identity, the analytic heart of Fejér's theorem.",
+    "mathContext": "$0\\le F_N(\\theta)$ everywhere; $F_N(\\theta)\\le\\frac{1}{(N+1)\\sin^2(\\delta/2)}\\xrightarrow[N\\to\\infty]{}0$ on $[\\delta,2\\pi-\\delta]$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "approximate identity",
+      "nonnegative summability kernel",
+      "concentration at the origin",
+      "Fejér's theorem"
+    ],
+    "prerequisites": [
+      "fejerKernel_closed_form",
+      "DeMoivreOQ06OQ02.sin_half_ge_of_mem_arc",
+      "div_le_div_iff_of_pos_right",
+      "one_div_le_one_div_of_le"
+    ]
+  }
+]

--- a/src/data/proofs/de-moivre-oq-06-oq-02-oq-01/meta.json
+++ b/src/data/proofs/de-moivre-oq-06-oq-02-oq-01/meta.json
@@ -1,0 +1,203 @@
+{
+  "id": "de-moivre-oq-06-oq-02-oq-01",
+  "title": "De Moivre OQ-06-OQ-02-OQ-01: The Fejér Kernel as the Cesàro Average of the Dirichlet Kernels",
+  "slug": "de-moivre-oq-06-oq-02-oq-01",
+  "description": "Constructs the Fejér kernel F_N(θ) as the Cesàro (arithmetic) mean of the first N+1 Dirichlet kernels D_n(θ) = sin((n+1/2)θ)/sin(θ/2), and establishes its three defining properties. A product-to-sum telescoping 2 sin(θ/2) ∑ sin((m+1/2)θ) = 1 − cos((N+1)θ) collapses the average into the celebrated closed form F_N(θ) = sin²((N+1)θ/2)/((N+1) sin²(θ/2)). Being a perfect square over a positive quantity, the Fejér kernel is nonnegative — the property that fails for the sign-changing Dirichlet kernel and makes {F_N} a genuine approximate identity — and on the arc θ ∈ [δ, 2π−δ] it satisfies the uniform bound F_N(θ) ≤ 1/((N+1) sin²(δ/2)), exhibiting the concentration of its mass at the origin as N → ∞ that underlies Fejér's theorem on Cesàro summability of Fourier series.",
+  "meta": {
+    "author": "Formalized in Lean 4 (Mathlib)",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/DeMoivreOQ06OQ02OQ01.lean",
+    "tags": [
+      "complex-analysis",
+      "trigonometry",
+      "fejer-kernel",
+      "dirichlet-kernel",
+      "fourier-analysis",
+      "cesaro-summability",
+      "approximate-identity",
+      "de-moivre"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Real.cos_two_mul",
+        "description": "cos(2x) = 2 cos²x − 1, the double-angle identity that converts 1 − cos((N+1)θ) into 2 sin²((N+1)θ/2), producing the squared numerator of the Fejér closed form",
+        "module": "Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic"
+      },
+      {
+        "theorem": "Real.sin_sq_add_cos_sq",
+        "description": "sin²x + cos²x = 1, used to pass from 2 − 2 cos²x to 2 sin²x in the half-angle collapse",
+        "module": "Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic"
+      },
+      {
+        "theorem": "Real.cos_sub / Real.cos_add",
+        "description": "cos(X∓Y) expansions giving the product-to-sum step 2 sin(θ/2) sin((m+1/2)θ) = cos(mθ) − cos((m+1)θ) that makes the sine sum telescope",
+        "module": "Mathlib.Analysis.Complex.Trigonometric"
+      },
+      {
+        "theorem": "Finset.sum_range_succ",
+        "description": "peels the top term of ∑_{m∈range(N+1)}, driving the telescoping induction for sum_sin_half_odd",
+        "module": "Mathlib.Algebra.BigOperators.Basic"
+      },
+      {
+        "theorem": "div_le_div_iff_of_pos_right",
+        "description": "a/c ≤ b/c ↔ a ≤ b for c > 0, reducing the Fejér bound to the numerator estimate sin²((N+1)θ/2) ≤ 1",
+        "module": "Mathlib.Algebra.Order.Field.Basic"
+      },
+      {
+        "theorem": "one_div_le_one_div_of_le",
+        "description": "0 < a, a ≤ b ⇒ 1/b ≤ 1/a, replacing the θ-dependent denominator sin²(θ/2) by the uniform sin²(δ/2) via the parent's sin(θ/2) ≥ sin(δ/2)",
+        "module": "Mathlib.Algebra.Order.Field.Basic"
+      }
+    ],
+    "originalContributions": [
+      "sum_sin_half_odd: the telescoping identity 2 sin(θ/2) · ∑_{m=0}^{N} sin((m+1/2)θ) = 1 − cos((N+1)θ), proved by distributing sin(θ/2) across the sum and applying the product-to-sum step 2 sin(θ/2) sin((m+1/2)θ) = cos(mθ) − cos((m+1)θ) term-by-term so consecutive cosines cancel",
+      "dirichletKernel and dirichletKernel_closed_form: the symmetric Dirichlet kernel D_n(θ) = 2·(∑_{k=0}^{n} cos(kθ)) − 1 with its closed form sin((n+1/2)θ)/sin(θ/2), derived from the grandparent's Lagrange cosine identity",
+      "fejerKernel and sum_dirichletKernel: the Cesàro average F_N = (1/(N+1)) ∑_{n=0}^{N} D_n, with the summed-kernel identity ∑_{n=0}^{N} D_n(θ) = sin²((N+1)θ/2)/sin²(θ/2)",
+      "fejerKernel_closed_form: the celebrated closed form F_N(θ) = sin²((N+1)θ/2)/((N+1) sin²(θ/2))",
+      "fejerKernel_nonneg: 0 ≤ F_N(θ) — a perfect square over the positive quantity (N+1) sin²(θ/2); the nonnegativity that fails for the Dirichlet kernel and makes {F_N} an approximate identity",
+      "fejerKernel_uniform_bound: on the arc θ ∈ [δ, 2π−δ] with 0 < δ ≤ π, F_N(θ) ≤ 1/((N+1) sin²(δ/2)), so the Fejér mass concentrates at the origin as N → ∞"
+    ],
+    "dateAdded": "2026-07-12",
+    "mathlib_version": "4.26.0",
+    "axiomCount": 0,
+    "lineCount": 186,
+    "assumptions": "0 axioms, 0 sorries. Builds on the parent de-moivre-oq-06-oq-02 (sin_half_ge_of_mem_arc) and the grandparent de-moivre-oq-06 (lagrange_cos_sum). The closed form, nonnegativity, and pointwise identities require sin(θ/2) ≠ 0; the uniform Fejér bound additionally requires 0 < δ ≤ π and θ ∈ [δ, 2π−δ]. Mathlib supplies the double-angle and Pythagorean identities, the product-to-sum expansions, and reciprocal monotonicity.",
+    "theoremCount": 7,
+    "definitionCount": 2
+  },
+  "overview": {
+    "historicalContext": "The Dirichlet kernel $D_n(\\theta)=\\sin((n+\\tfrac12)\\theta)/\\sin(\\theta/2)$ represents the partial sums of a Fourier series, but it changes sign and its $L^1$ norm grows like $\\log n$, so partial sums need not converge for every continuous function. Fejér's 1900 discovery was that the *Cesàro averages* of the partial sums behave far better: their kernel, the Fejér kernel $F_N=\\frac{1}{N+1}\\sum_{n=0}^{N}D_n$, is **nonnegative** and concentrates at the origin, making $\\{F_N\\}$ an approximate identity. Consequently the Cesàro means of the Fourier series of any continuous $2\\pi$-periodic function converge uniformly to that function — Fejér's theorem. This file constructs $F_N$ from the parent's Dirichlet kernels and proves the three properties (closed form, nonnegativity, uniform decay away from the origin) that drive that theorem.",
+    "problemStatement": "**Open Question (de-moivre-oq-06-oq-02-oq-01)**: Realize the Fejér kernel as the Cesàro average of the Dirichlet kernels and establish its uniform nonnegative bound.\n\n**Result**: With $D_n(\\theta)=2\\big(\\sum_{k=0}^{n}\\cos(k\\theta)\\big)-1$ and $F_N(\\theta)=\\frac{1}{N+1}\\sum_{n=0}^{N}D_n(\\theta)$, one has the closed form $F_N(\\theta)=\\dfrac{\\sin^2((N+1)\\theta/2)}{(N+1)\\sin^2(\\theta/2)}$, hence $F_N(\\theta)\\ge 0$ for all $\\theta$ with $\\sin(\\theta/2)\\ne 0$, and on the arc $\\theta\\in[\\delta,2\\pi-\\delta]$ the uniform bound $F_N(\\theta)\\le\\dfrac{1}{(N+1)\\sin^2(\\delta/2)}\\xrightarrow[N\\to\\infty]{}0$.",
+    "text": "The Fejér kernel as the Cesàro average of the Dirichlet kernels: closed form sin²((N+1)θ/2)/((N+1)sin²(θ/2)), nonnegativity, and a uniform O(1/N) bound away from the singularities.",
+    "proofStrategy": "Each Dirichlet kernel is put in closed form $D_n(\\theta)=\\sin((n+\\tfrac12)\\theta)/\\sin(\\theta/2)$ using the grandparent's Lagrange cosine identity. Summing, $\\sum_{n=0}^{N}D_n=\\frac{1}{\\sin(\\theta/2)}\\sum_{n=0}^{N}\\sin((n+\\tfrac12)\\theta)$, and the inner sum telescopes: the product-to-sum step $2\\sin(\\theta/2)\\sin((m+\\tfrac12)\\theta)=\\cos(m\\theta)-\\cos((m+1)\\theta)$ makes consecutive cosines cancel, leaving $2\\sin(\\theta/2)\\sum_{m=0}^{N}\\sin((m+\\tfrac12)\\theta)=1-\\cos((N+1)\\theta)$. The double-angle identity $1-\\cos((N+1)\\theta)=2\\sin^2((N+1)\\theta/2)$ then gives $\\sum_{n=0}^{N}D_n=\\sin^2((N+1)\\theta/2)/\\sin^2(\\theta/2)$; dividing by $N+1$ yields the closed form. Nonnegativity is immediate (a square over a positive denominator). The uniform bound follows from $\\sin^2((N+1)\\theta/2)\\le 1$ and the parent's endpoint estimate $\\sin(\\theta/2)\\ge\\sin(\\delta/2)>0$, via reciprocal monotonicity.",
+    "keyInsights": [
+      "Averaging repairs the Dirichlet kernel: the sign-changing D_n has no useful uniform lower bound, but its Cesàro mean F_N is a perfect square sin²((N+1)θ/2)/((N+1)sin²(θ/2)) and hence nonnegative — the single structural fact that turns Fourier partial sums (which can diverge) into Cesàro means that always converge",
+      "The closed form comes from one telescoping: 2 sin(θ/2) sin((m+1/2)θ) = cos(mθ) − cos((m+1)θ) collapses ∑ sin((m+1/2)θ) to the endpoints, and 1 − cos((N+1)θ) = 2 sin²((N+1)θ/2) supplies the square",
+      "Nonnegativity is the property Dirichlet lacks and Fejér has; it is exactly what makes {F_N} an approximate identity, so that Cesàro means of Fourier series converge where the raw partial sums may not (Fejér's theorem)",
+      "The uniform bound F_N(θ) ≤ 1/((N+1) sin²(δ/2)) is an O(1/N) decay away from the origin: the Fejér mass concentrates in a shrinking neighbourhood of θ ∈ 2πℤ, the analytic mechanism of the approximate identity",
+      "The construction reuses the family's machinery end-to-end: the grandparent's Lagrange closed form for each D_n, the same product-to-sum telescoping now applied to half-integer sines, and the parent's arc lower bound sin(θ/2) ≥ sin(δ/2) for the uniform estimate"
+    ],
+    "prerequisites": [
+      "Parent formalization de-moivre-oq-06-oq-02 (endpoint lower bound sin(θ/2) ≥ sin(δ/2) on the arc)",
+      "Grandparent de-moivre-oq-06 (Lagrange cosine identity / Dirichlet kernel closed form)",
+      "Product-to-sum and double-angle trigonometric identities",
+      "Telescoping finite sums via induction",
+      "Reciprocal monotonicity of x ↦ 1/x on the positive reals"
+    ]
+  },
+  "sections": [
+    {
+      "id": "preamble",
+      "title": "Preamble and Problem Statement",
+      "summary": "Module docstring: the Dirichlet kernel, its Cesàro average the Fejér kernel, and the closed form / nonnegativity / uniform bound to be proved",
+      "startLine": 1,
+      "endLine": 42,
+      "mathContext": "**Goal**: build F_N = (1/(N+1)) ∑_{n≤N} D_n and prove F_N(θ) = sin²((N+1)θ/2)/((N+1)sin²(θ/2)) ≥ 0 with a uniform bound on the arc."
+    },
+    {
+      "id": "telescoping",
+      "title": "Part I: Product-to-Sum Telescoping of the Half-Integer Sines",
+      "summary": "two_sin_half_mul_sin_odd (2 sin(θ/2) sin((m+1/2)θ) = cos(mθ) − cos((m+1)θ)) and sum_sin_half_odd (2 sin(θ/2) ∑_{m≤N} sin((m+1/2)θ) = 1 − cos((N+1)θ)), the telescoping engine of the closed form",
+      "startLine": 44,
+      "endLine": 78,
+      "mathContext": "$\\sum_{m=0}^{N}(\\cos(m\\theta)-\\cos((m+1)\\theta))=1-\\cos((N+1)\\theta)$."
+    },
+    {
+      "id": "dirichlet-kernel",
+      "title": "Part II: The Dirichlet Kernel and its Closed Form",
+      "summary": "dirichletKernel (D_n = 2·∑_{k≤n} cos(kθ) − 1) and dirichletKernel_closed_form (D_n(θ) = sin((n+1/2)θ)/sin(θ/2)), from the grandparent's Lagrange cosine identity",
+      "startLine": 80,
+      "endLine": 92,
+      "mathContext": "$D_n(\\theta)=2\\big(\\tfrac12+\\tfrac{\\sin((n+1/2)\\theta)}{2\\sin(\\theta/2)}\\big)-1=\\tfrac{\\sin((n+1/2)\\theta)}{\\sin(\\theta/2)}$."
+    },
+    {
+      "id": "fejer-closed-form",
+      "title": "Part III: The Fejér Kernel and its Closed Form",
+      "summary": "fejerKernel (Cesàro average), sum_dirichletKernel (∑_{n≤N} D_n = sin²((N+1)θ/2)/sin²(θ/2)) via the telescoping and the double-angle 1 − cos = 2 sin², and fejerKernel_closed_form (F_N = sin²((N+1)θ/2)/((N+1)sin²(θ/2)))",
+      "startLine": 94,
+      "endLine": 139,
+      "mathContext": "$\\sum_{n=0}^{N}D_n=\\tfrac{1}{\\sin(\\theta/2)}\\cdot\\tfrac{\\sin^2((N+1)\\theta/2)}{\\sin(\\theta/2)}=\\tfrac{\\sin^2((N+1)\\theta/2)}{\\sin^2(\\theta/2)}$."
+    },
+    {
+      "id": "nonneg-and-bound",
+      "title": "Part IV: Nonnegativity and Uniform Bound",
+      "summary": "fejerKernel_nonneg (0 ≤ F_N, a square over a positive denominator — the approximate-identity property) and fejerKernel_uniform_bound (F_N(θ) ≤ 1/((N+1)sin²(δ/2)) on the arc, from sin²((N+1)θ/2) ≤ 1 and sin(θ/2) ≥ sin(δ/2))",
+      "startLine": 141,
+      "endLine": 186,
+      "mathContext": "$F_N(\\theta)=\\tfrac{\\sin^2((N+1)\\theta/2)}{(N+1)\\sin^2(\\theta/2)}\\le\\tfrac{1}{(N+1)\\sin^2(\\delta/2)}\\to 0$."
+    }
+  ],
+  "conclusion": {
+    "summary": "This formalization realizes the Fejér kernel as the Cesàro average of the parent family's Dirichlet kernels and proves its three defining properties with zero sorries and zero axioms: the closed form F_N(θ) = sin²((N+1)θ/2)/((N+1) sin²(θ/2)), the nonnegativity 0 ≤ F_N(θ), and the uniform bound F_N(θ) ≤ 1/((N+1) sin²(δ/2)) on the arc θ ∈ [δ, 2π−δ]. The proof reuses the same product-to-sum telescoping that produced the Dirichlet closed forms and the parent's endpoint lower bound sin(θ/2) ≥ sin(δ/2).",
+    "implications": "Nonnegativity and the O(1/N) uniform decay away from the origin are exactly the two hypotheses of an approximate identity, and they are the analytic heart of Fejér's theorem: the Cesàro means of the Fourier series of a continuous 2π-periodic function converge uniformly to it, even though the raw partial sums (governed by the sign-changing, logarithmically-growing Dirichlet kernel) may diverge. The explicit constant 1/((N+1) sin²(δ/2)) makes the concentration rate quantitative.",
+    "openQuestions": [
+      "Derive Fejér's theorem itself: for continuous 2π-periodic f, the Cesàro means σ_N f = f ∗ F_N converge uniformly to f, using nonnegativity, ∫ F_N = 1, and the uniform decay proved here",
+      "The total-mass normalization (1/2π) ∫_{−π}^{π} F_N(θ) dθ = 1, complementing the pointwise bound to complete the approximate-identity package",
+      "Weierstrass approximation as a corollary: trigonometric (hence, via Taylor truncation, polynomial) density in C(𝕋) from uniform Cesàro convergence"
+    ]
+  },
+  "relatedProblems": [
+    {
+      "id": "de-moivre-oq-06-oq-02",
+      "relationship": "Parent: supplies the arc endpoint lower bound sin(θ/2) ≥ sin(δ/2) used for the uniform Fejér bound, and the uniform Dirichlet-kernel estimates this file's Cesàro average complements"
+    },
+    {
+      "id": "de-moivre-oq-06",
+      "relationship": "Grandparent: supplies the Lagrange cosine identity (Dirichlet kernel closed form) used to put each D_n in the form sin((n+1/2)θ)/sin(θ/2)"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Proofs.DeMoivreOQ06OQ02",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Finset"
+    ],
+    "namespace": "DeMoivreOQ06OQ02OQ01",
+    "lineCount": 186,
+    "axiomCount": 0,
+    "theoremCount": 7,
+    "definitionCount": 2,
+    "path": "Proofs/DeMoivreOQ06OQ02OQ01.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "Lipót Fejér",
+      "title": "Sur les fonctions bornées et intégrables (nonnegativity of the Fejér kernel and Cesàro summability of Fourier series)",
+      "year": "1900",
+      "venue": "Comptes Rendus de l'Académie des Sciences"
+    },
+    {
+      "authors": "Elias M. Stein and Rami Shakarchi",
+      "title": "Fourier Analysis: An Introduction",
+      "year": "2003",
+      "venue": "Princeton University Press",
+      "note": "Ch. 2–3 develop the Fejér kernel, its closed form and nonnegativity, and Fejér's theorem on Cesàro summability — the exact application these three properties are designed to feed."
+    },
+    {
+      "authors": "Antoni Zygmund",
+      "title": "Trigonometric Series",
+      "year": "2002",
+      "venue": "Cambridge University Press",
+      "note": "Ch. III: Fejér kernel as an approximate identity, the concentration bound away from the origin, and (C,1) summability."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "de-moivre-oq-06-oq-02",
+      "relationship": "extends",
+      "description": "Parent formalization; reuses its arc endpoint lower bound sin(θ/2) ≥ sin(δ/2) for the uniform Fejér bound and forms the Cesàro average of the Dirichlet kernels it bounds uniformly."
+    },
+    {
+      "targetId": "de-moivre-oq-06",
+      "relationship": "extends",
+      "description": "Grandparent formalization; reuses its Lagrange cosine identity to put each Dirichlet kernel in closed form."
+    }
+  ],
+  "sorries": 0
+}

--- a/src/data/proofs/de-moivre-oq-06-oq-02/meta.json
+++ b/src/data/proofs/de-moivre-oq-06-oq-02/meta.json
@@ -182,6 +182,11 @@
       "description": "Parent formalization; this file lifts its pointwise Dirichlet-kernel bounds to uniform-in-(n, θ) bounds on a compact arc away from the singularities."
     },
     {
+      "targetId": "de-moivre-oq-06-oq-02-oq-01",
+      "relationship": "extended-by",
+      "description": "Child formalization; builds the Fejér kernel as the Cesàro average of the Dirichlet kernels, reusing this file's arc endpoint lower bound sin(θ/2) ≥ sin(δ/2) for the uniform Fejér bound (addresses the Fejér open question below)."
+    },
+    {
       "targetId": "de-moivre-oq-05",
       "relationship": "sibling",
       "description": "Companion in the De Moivre geometric-sum family."


### PR DESCRIPTION
## Summary

New gallery entry **de-moivre-oq-06-oq-02-oq-01** realizing the **Fejér kernel** as the Cesàro (arithmetic) average of the parent family's Dirichlet kernels, and proving its three defining properties. This addresses the parent's open question *"The Fejér kernel as the Cesàro average of the Dirichlet kernels and its uniform nonnegative bound."*

**`proofs/Proofs/DeMoivreOQ06OQ02OQ01.lean`** — 186 lines, **0 sorries / 0 axioms**, GREEN docker-build (3060 jobs), Mathlib v4.26.0.

## Mathematical content

With $D_n(\theta)=2\big(\sum_{k=0}^{n}\cos(k\theta)\big)-1=\dfrac{\sin((n+\tfrac12)\theta)}{\sin(\theta/2)}$ and $F_N(\theta)=\dfrac{1}{N+1}\sum_{n=0}^{N}D_n(\theta)$:

- **`two_sin_half_mul_sin_odd`** — $2\sin(\theta/2)\sin((m+\tfrac12)\theta)=\cos(m\theta)-\cos((m+1)\theta)$ (product-to-sum).
- **`sum_sin_half_odd`** — $2\sin(\theta/2)\sum_{m=0}^{N}\sin((m+\tfrac12)\theta)=1-\cos((N+1)\theta)$ (telescoping induction).
- **`dirichletKernel` / `dirichletKernel_closed_form`** — the symmetric Dirichlet kernel and its closed form, from the grandparent's Lagrange cosine identity.
- **`fejerKernel` / `sum_dirichletKernel`** — the Cesàro average, with $\sum_{n=0}^{N}D_n=\dfrac{\sin^2((N+1)\theta/2)}{\sin^2(\theta/2)}$.
- **`fejerKernel_closed_form`** — the celebrated $F_N(\theta)=\dfrac{\sin^2((N+1)\theta/2)}{(N+1)\sin^2(\theta/2)}$.
- **`fejerKernel_nonneg`** — $0\le F_N(\theta)$: a perfect square over a positive denominator. This is the property the sign-changing Dirichlet kernel lacks, making $\{F_N\}$ a genuine **approximate identity**.
- **`fejerKernel_uniform_bound`** — on the arc $\theta\in[\delta,2\pi-\delta]$, $F_N(\theta)\le\dfrac{1}{(N+1)\sin^2(\delta/2)}$, an $O(1/N)$ uniform decay exhibiting concentration of the Fejér mass at the origin — the analytic heart of Fejér's theorem on Cesàro summability of Fourier series.

The construction reuses the family's machinery end-to-end: the grandparent's Lagrange closed form for each $D_n$, the same product-to-sum telescoping now applied to the half-integer frequencies, and the parent's arc endpoint bound $\sin(\theta/2)\ge\sin(\delta/2)$ for the uniform estimate.

## Files
- `proofs/Proofs/DeMoivreOQ06OQ02OQ01.lean` (new)
- `src/data/proofs/de-moivre-oq-06-oq-02-oq-01/{meta.json,annotations.json}` (new)
- `src/data/proofs/de-moivre-oq-06-oq-02/meta.json` (forward `extended-by` cross-reference)

## Verification
- `./proofs/scripts/docker-build.sh Proofs.DeMoivreOQ06OQ02OQ01` → GREEN (3060 jobs)
- 0 `sorry`, 0 `axiom`, no `native_decide`; status `verified`, badge `original`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)