### PR TITLE
research(combinations-oq-03-oq-04): Gaussian polynomial layer over ℤ[X] — degree, monicity, pinned extreme coefficients

### DIFF
--- a/proofs/Proofs/CombinationsFormulaOQ03OQ04.lean
+++ b/proofs/Proofs/CombinationsFormulaOQ03OQ04.lean
@@ -1,4 +1,5 @@
 import Proofs.CombinationsFormulaOQ03
+import Mathlib
 
 /-
 # Self-Reciprocity (Palindromy) of Gaussian q-Binomial Coefficients
@@ -33,13 +34,28 @@ cancellation is q^{(k+1)(n-k)}·(1/q)^{k+1} = q^{(k+1)(n-k-1)}, valid since q �
 - [x] Self-reciprocity / palindromy: [n,k]_q = q^{k(n-k)}·[n,k]_{1/q}  (main)
 - [x] Reflected form: q^{k(n-k)}·[n,k]_{1/q} = [n,k]_q
 - [x] Involutivity sanity check of the reflection
+- [x] Structural facts of the Gaussian *polynomial* `qBinom X n k` over `ℤ[X]`:
+      monicity, `natDegree = k(n-k)`, constant term `= 1`, nonnegative coefficients,
+      and hence both extreme coefficients pinned to `1`
 - [ ] OPEN: coefficient unimodality (Sylvester/Proctor) — not attempted here
 
 ## Honesty Note
-This is the palindromy/symmetry ingredient only. It does NOT prove unimodality,
-which is the substantive content of the open question. Full unimodality requires
-either an sl₂-action argument or an explicit injection between coefficient levels
-and is not formalized here.
+This is the palindromy/symmetry ingredient plus the structural scaffolding
+(degree, monicity, coefficient nonnegativity, pinned extreme coefficients). It does
+NOT prove unimodality, which is the substantive content of the open question. Full
+unimodality requires either an sl₂-action argument or an explicit injection between
+coefficient levels and is not formalized here.
+
+## Gaussian polynomial layer (over `ℤ[X]`)
+The palindromy above lives over a field (it uses `q⁻¹`). To reason about the actual
+*coefficient array* of `[n,k]_q` we specialise the ambient ring to `ℤ[X]` with `q = X`,
+so `qBinom X n k : ℤ[X]` is the Gaussian polynomial. By induction on the q-Pascal
+recurrence `qBinom X (n+1)(k+1) = qBinom X n k + X^{k+1}·qBinom X n (k+1)` we prove it is
+monic of degree `k(n-k)` with constant term `1` and nonnegative coefficients. In the
+recurrence the `X^{k+1}`-shifted summand strictly dominates in degree (since `n-k ≥ 1`),
+which supplies both the degree and the leading coefficient. Together with the palindromy
+`qBinom_reciprocal`, the pinned extreme coefficients are the structural precursor of the
+symmetric-unimodal shape asserted by Sylvester's theorem.
 -/
 
 namespace QBinomialCoefficients
@@ -117,5 +133,130 @@ involution on the q-binomial, as a palindrome reflection must be. -/
 theorem qBinom_reciprocal_involutive (q : R) (hq : q ≠ 0) (n k : ℕ) :
     qBinom q n k = q ^ (k * (n - k)) * ((q⁻¹) ^ (k * (n - k)) * qBinom q n k) := by
   rw [← mul_assoc, ← mul_pow, mul_inv_cancel₀ hq, one_pow, one_mul]
+
+/-! ## The Gaussian polynomial over `ℤ[X]`: degree, monicity, coefficients
+
+Specialising the ambient ring to `ℤ[X]` with `q = X` turns `qBinom X n k` into the
+Gaussian polynomial whose coefficient sequence is the object of Sylvester's unimodality
+theorem. The results below establish its structural invariants directly from the q-Pascal
+recurrence, needing no field hypothesis (they hold over `ℤ`, an ordered ring, so that
+"nonnegative coefficients" is meaningful). -/
+
+open Polynomial in
+/-- **Monicity and degree of the Gaussian polynomial.** For `k ≤ n`, the polynomial
+`qBinom X n k : ℤ[X]` is monic of `natDegree = k·(n-k)`.
+
+Proof by induction on the q-Pascal recurrence
+`qBinom X (n+1)(k+1) = qBinom X n k + X^{k+1}·qBinom X n (k+1)`. On the diagonal (`k = n`)
+and the left edge (`k = 0`) the polynomial is `1`. In the interior (`k < n`, so `n-k ≥ 1`)
+the shifted summand `X^{k+1}·qBinom X n (k+1)` has degree `(k+1) + (k+1)(n-k-1) = (k+1)(n-k)`,
+strictly exceeding `deg (qBinom X n k) = k(n-k)`, so it supplies both the degree and the
+(monic) leading term of the sum. -/
+theorem qBinom_X_monic_natDegree :
+    ∀ (n k : ℕ), k ≤ n →
+      (qBinom (X : ℤ[X]) n k).Monic ∧
+      (qBinom (X : ℤ[X]) n k).natDegree = k * (n - k)
+  | n, 0, _ => by
+      rw [qBinom_zero_right]; exact ⟨monic_one, by simp⟩
+  | 0, k + 1, h => by omega
+  | n + 1, k + 1, h => by
+      rcases eq_or_lt_of_le h with heq | hlt
+      · have hkn : k = n := by omega
+        subst hkn
+        rw [qBinom_self]; exact ⟨monic_one, by simp⟩
+      · have hk1n : k + 1 ≤ n := by omega
+        have hkn : k ≤ n := by omega
+        have hnk1 : 1 ≤ n - k := by omega
+        obtain ⟨mA, dA⟩ := qBinom_X_monic_natDegree n k hkn
+        obtain ⟨mB, dB⟩ := qBinom_X_monic_natDegree n (k + 1) hk1n
+        rw [qBinom_pascal]
+        set A := qBinom (X : ℤ[X]) n k with hAdef
+        set B := qBinom (X : ℤ[X]) n (k + 1) with hBdef
+        have hBne : B ≠ 0 := mB.ne_zero
+        have hXpow : (X : ℤ[X]) ^ (k + 1) ≠ 0 := pow_ne_zero _ X_ne_zero
+        have mP : ((X : ℤ[X]) ^ (k + 1) * B).Monic := (monic_X_pow (k + 1)).mul mB
+        obtain ⟨t, ht⟩ : ∃ t, n - k = t + 1 := ⟨n - k - 1, by omega⟩
+        have hnk1' : n - (k + 1) = t := by omega
+        have dP : ((X : ℤ[X]) ^ (k + 1) * B).natDegree = (k + 1) * (n - k) := by
+          rw [natDegree_mul hXpow hBne, natDegree_X_pow, dB, hnk1', ht]; ring
+        have hdeglt : A.natDegree < ((X : ℤ[X]) ^ (k + 1) * B).natDegree := by
+          rw [dA, dP, ht]; nlinarith
+        have hdA : A.degree < ((X : ℤ[X]) ^ (k + 1) * B).degree := degree_lt_degree hdeglt
+        refine ⟨?_, ?_⟩
+        · rw [add_comm]
+          exact mP.add_of_left hdA
+        · rw [add_comm,
+            natDegree_eq_of_degree_eq (degree_add_eq_left_of_degree_lt hdA), dP]
+          congr 1
+          omega
+
+open Polynomial in
+/-- **Constant term is `1`.** For `k ≤ n`, `(qBinom X n k).coeff 0 = 1`. Induction on the
+q-Pascal recurrence: the `X^{k+1}`-shifted summand contributes nothing to the constant term
+(`k+1 ≥ 1`), leaving the inductive value `1`. -/
+theorem qBinom_X_coeff_zero :
+    ∀ (n k : ℕ), k ≤ n → (qBinom (X : ℤ[X]) n k).coeff 0 = 1
+  | n, 0, _ => by rw [qBinom_zero_right]; simp
+  | 0, k + 1, h => by omega
+  | n + 1, k + 1, h => by
+      rcases eq_or_lt_of_le h with heq | hlt
+      · have hkn : k = n := by omega
+        subst hkn; rw [qBinom_self]; simp
+      · have hkn : k ≤ n := by omega
+        rw [qBinom_pascal, coeff_add, mul_comm, coeff_mul_X_pow']
+        simp only [Nat.le_zero, Nat.add_one_ne_zero, if_false]
+        rw [qBinom_X_coeff_zero n k hkn]; ring
+
+open Polynomial in
+/-- **Coefficients are nonnegative.** Every coefficient of `qBinom X n k : ℤ[X]` is `≥ 0`.
+Induction on the q-Pascal recurrence: the sum of a polynomial with nonnegative coefficients
+and an `X^{k+1}`-shift of one is again coefficientwise nonnegative. -/
+theorem qBinom_X_coeff_nonneg :
+    ∀ (n k j : ℕ), 0 ≤ (qBinom (X : ℤ[X]) n k).coeff j
+  | n, 0, j => by
+      rw [qBinom_zero_right]
+      rcases eq_or_ne j 0 with rfl | hj
+      · simp
+      · simp [coeff_one, hj]
+  | 0, k + 1, j => by simp
+  | n + 1, k + 1, j => by
+      rw [qBinom_pascal, coeff_add, mul_comm, coeff_mul_X_pow']
+      have h1 := qBinom_X_coeff_nonneg n k j
+      have h2 : 0 ≤ (if k + 1 ≤ j then (qBinom (X : ℤ[X]) n (k + 1)).coeff (j - (k + 1)) else 0) := by
+        split_ifs with h
+        · exact qBinom_X_coeff_nonneg n (k + 1) _
+        · exact le_refl 0
+      linarith
+
+open Polynomial in
+/-- Convenience: the Gaussian polynomial is monic. -/
+theorem qBinom_X_monic {n k : ℕ} (h : k ≤ n) : (qBinom (X : ℤ[X]) n k).Monic :=
+  (qBinom_X_monic_natDegree n k h).1
+
+open Polynomial in
+/-- Convenience: `natDegree (qBinom X n k) = k · (n - k)`. -/
+theorem qBinom_X_natDegree {n k : ℕ} (h : k ≤ n) :
+    (qBinom (X : ℤ[X]) n k).natDegree = k * (n - k) :=
+  (qBinom_X_monic_natDegree n k h).2
+
+open Polynomial in
+/-- The top coefficient (at degree `k(n-k)`) is `1`: it is the leading coefficient of the
+monic Gaussian polynomial. -/
+theorem qBinom_X_coeff_top {n k : ℕ} (h : k ≤ n) :
+    (qBinom (X : ℤ[X]) n k).coeff (k * (n - k)) = 1 := by
+  have hmon := qBinom_X_monic h
+  rw [← qBinom_X_natDegree h]
+  exact hmon
+
+open Polynomial in
+/-- **Extreme coefficients are pinned to `1`.** For `k ≤ n` both the constant term and the
+top coefficient (degree `k(n-k)`) of the Gaussian polynomial equal `1`. Combined with the
+coefficient nonnegativity `qBinom_X_coeff_nonneg` and the palindromy `qBinom_reciprocal`,
+this pins the two ends of the symmetric coefficient array of `[n,k]_q` — the structural
+precursor to Sylvester's unimodality theorem. -/
+theorem qBinom_X_extreme_coeffs {n k : ℕ} (h : k ≤ n) :
+    (qBinom (X : ℤ[X]) n k).coeff 0 = 1 ∧
+    (qBinom (X : ℤ[X]) n k).coeff (k * (n - k)) = 1 :=
+  ⟨qBinom_X_coeff_zero n k h, qBinom_X_coeff_top h⟩
 
 end QBinomialCoefficients

--- a/proofs/Proofs/LagrangeTheoremOQ01.lean
+++ b/proofs/Proofs/LagrangeTheoremOQ01.lean
@@ -480,6 +480,97 @@ theorem exists_normal_subgroup_card_eq_p_of_card_eq_pq (p q : ℕ) (hp : p.Prime
     sylow_p_normal_of_card_eq_pq p q hp hq hpq hmod P hG,
     card_sylow_p_of_card_eq_pq p q hp hq hpq P hG⟩
 
+/-
+═══════════════════════════════════════════════════════════════════════════════
+PART VIII: THE CLASSIFICATION CAPSTONE — `q ≢ 1 (mod p)` ⟹ `G` IS CYCLIC
+
+Parts VI–VII produce, under `q ≢ 1 (mod p)`, normal subgroups of *both* prime
+orders `p` and `q`.  Their orders are coprime, so the two subgroups intersect
+trivially and (being normal) commute elementwise.  A generator `a` of the order-`p`
+subgroup and a generator `b` of the order-`q` subgroup therefore commute and have
+coprime orders, so `a·b` has order `p·q = |G|` — an element of full order, making
+`G` cyclic.  This closes the classification of groups of order `p·q`: away from the
+arithmetic obstruction `q ≡ 1 (mod p)` there is a *unique* group, the cyclic one
+`ℤ/pq`.
+═══════════════════════════════════════════════════════════════════════════════ -/
+
+/-- **Classification capstone: a group of order `p·q` with `q ≢ 1 (mod p)` is cyclic**
+    (`p < q` prime).  This is the positive half of the order-`p·q` dichotomy and the
+    payoff of the whole Sylow development in this file.
+
+    Proof.  Parts VI–VII give normal subgroups `P` (order `p`) and `Q` (order `q`); each
+    has prime order, hence is cyclic.  Let `a` generate `P` and `b` generate `Q`, so
+    `orderOf a = p` and `orderOf b = q` (`Nat.card_zpowers`).  Because `|P ⊓ Q|` divides
+    both `p` and `q`, which are coprime, it is `1`, so `P` and `Q` are `Disjoint`; two
+    disjoint *normal* subgroups commute elementwise
+    (`Subgroup.commute_of_normal_of_disjoint`), giving `Commute a b`.  Coprime orders of
+    commuting elements multiply (`orderOf_mul_eq_mul_orderOf_of_coprime`), so
+    `orderOf (a * b) = p · q = |G|`.  An element of order `|G|` generates the group
+    (`isCyclic_of_orderOf_eq_card`), so `G` is cyclic.
+
+    The hypothesis `q ≢ 1 (mod p)` is essential — it is exactly what forces the Sylow
+    p-subgroup to be normal (Part VII).  Without it a nonabelian group exists (the
+    metacyclic `ℤ/q ⋊ ℤ/p`, e.g. `S₃` for `p·q = 2·3` with `3 ≡ 1 mod 2`). -/
+theorem isCyclic_of_card_eq_pq (p q : ℕ) (hp : p.Prime) (hq : q.Prime)
+    (hpq : p < q) (hmod : q % p ≠ 1) (hG : Nat.card G = p * q) : IsCyclic G := by
+  haveI : Fact p.Prime := ⟨hp⟩
+  haveI : Fact q.Prime := ⟨hq⟩
+  -- Normal subgroups of both prime orders (Parts VI and VII).
+  obtain ⟨P, hPnorm, hPcard⟩ :=
+    exists_normal_subgroup_card_eq_p_of_card_eq_pq p q hp hq hpq hmod hG
+  obtain ⟨Q, hQnorm, hQcard⟩ := exists_normal_subgroup_card_eq_pq p q hp hq hpq hG
+  -- Each is cyclic (prime order); pick generators `a` and `b`.
+  haveI : IsCyclic P := isCyclic_of_prime_card (p := p) hPcard
+  haveI : IsCyclic Q := isCyclic_of_prime_card (p := q) hQcard
+  obtain ⟨a, ha⟩ := (Subgroup.isCyclic_iff_exists_zpowers_eq_top P).mp inferInstance
+  obtain ⟨b, hb⟩ := (Subgroup.isCyclic_iff_exists_zpowers_eq_top Q).mp inferInstance
+  have hao : orderOf a = p := by rw [← Nat.card_zpowers, ha, hPcard]
+  have hbo : orderOf b = q := by rw [← Nat.card_zpowers, hb, hQcard]
+  have haP : a ∈ P := ha ▸ Subgroup.mem_zpowers a
+  have hbQ : b ∈ Q := hb ▸ Subgroup.mem_zpowers b
+  -- Coprimality of the two prime orders.
+  have hcop : Nat.Coprime p q := (Nat.coprime_primes hp hq).mpr (ne_of_lt hpq)
+  -- `P` and `Q` are disjoint: `|P ⊓ Q|` divides both `p` and `q`, hence `1`.
+  have hdis : Disjoint P Q := by
+    rw [disjoint_iff, eq_bot_iff_card]
+    have hdp : Nat.card (P ⊓ Q : Subgroup G) ∣ p := hPcard ▸ card_dvd_of_le inf_le_left
+    have hdq : Nat.card (P ⊓ Q : Subgroup G) ∣ q := hQcard ▸ card_dvd_of_le inf_le_right
+    have hg : Nat.gcd p q = 1 := hcop
+    have := Nat.dvd_gcd hdp hdq
+    rw [hg] at this
+    exact Nat.dvd_one.mp this
+  -- Disjoint normal subgroups commute elementwise, so the generators commute.
+  have hcomm : Commute a b :=
+    Subgroup.commute_of_normal_of_disjoint P Q hPnorm hQnorm hdis a b haP hbQ
+  -- `a·b` has coprime commuting factors, so its order is `p·q = |G|`.
+  have hord : orderOf (a * b) = Nat.card G := by
+    rw [hcomm.orderOf_mul_eq_mul_orderOf_of_coprime (by rw [hao, hbo]; exact hcop),
+      hao, hbo, hG]
+  exact isCyclic_of_orderOf_eq_card (a * b) hord
+
+/-- **The full order-`p·q` dichotomy** (`p < q` prime): either `q ≡ 1 (mod p)` — the
+    arithmetic regime that permits the nonabelian metacyclic group `ℤ/q ⋊ ℤ/p` — or `G`
+    is cyclic.  Combines the two Sylow regimes: Part VII's obstruction `q ≡ 1 (mod p)` is
+    the *only* way a group of order `p·q` can fail to be cyclic.  Together with
+    `not_isSimpleGroup_of_card_eq_pq` and `isSolvable_of_card_eq_pq` this completes the
+    structural picture of order-`p·q` groups. -/
+theorem cyclic_or_q_mod_p_of_card_eq_pq (p q : ℕ) (hp : p.Prime) (hq : q.Prime)
+    (hpq : p < q) (hG : Nat.card G = p * q) : q % p = 1 ∨ IsCyclic G := by
+  by_cases h : q % p = 1
+  · exact Or.inl h
+  · exact Or.inr (isCyclic_of_card_eq_pq p q hp hq hpq h hG)
+
+/-- **Groups of order `p·q` with `q ≢ 1 (mod p)` are abelian** (`p < q` prime): the
+    commutativity consequence of `isCyclic_of_card_eq_pq`.  A convenient elementwise form
+    of the classification — every such group is (isomorphic to) `ℤ/pq`, in particular
+    commutative. -/
+theorem mul_comm_of_card_eq_pq (p q : ℕ) (hp : p.Prime) (hq : q.Prime)
+    (hpq : p < q) (hmod : q % p ≠ 1) (hG : Nat.card G = p * q) (a b : G) :
+    a * b = b * a := by
+  haveI := isCyclic_of_card_eq_pq p q hp hq hpq hmod hG
+  letI := IsCyclic.commGroup (α := G)
+  exact mul_comm a b
+
 end LagrangeOQ01
 
 /-
@@ -506,6 +597,11 @@ end LagrangeOQ01
     p-subgroup is normal (n_p = 1) with a normal subgroup of order p — the symmetric
     counterpart of the q-side and the coprime-normal-subgroup input for the full
     "p·q with q ≢ 1 mod p ⟹ cyclic" classification
+  - Classification capstone (isCyclic_of_card_eq_pq): a group of order p·q with
+    q ≢ 1 (mod p) is CYCLIC — the two coprime normal Sylow subgroups have commuting
+    generators of coprime orders p, q, so their product has order p·q = |G|; hence the
+    full dichotomy cyclic_or_q_mod_p_of_card_eq_pq (either q ≡ 1 mod p or G cyclic) and
+    the abelian corollary mul_comm_of_card_eq_pq. Closes the order-p·q classification.
 
   **Status**: Verified, 0 sorries, 0 axioms
 -/

--- a/src/data/proofs/combinations-formula-oq-03-oq-04/meta.json
+++ b/src/data/proofs/combinations-formula-oq-03-oq-04/meta.json
@@ -2,7 +2,7 @@
   "id": "combinations-formula-oq-03-oq-04",
   "title": "Self-Reciprocity (Palindromy) of Gaussian q-Binomial Coefficients",
   "slug": "combinations-formula-oq-03-oq-04",
-  "description": "Proves that the Gaussian (q-)binomial coefficient [n choose k]_q, viewed as a polynomial in q, is palindromic (self-reciprocal) of degree k·(n-k). Over a field this is the clean algebraic identity [n,k]_q = q^{k(n-k)}·[n,k]_{q⁻¹}, equivalently that the coefficient sequence reads the same forwards and backwards (a_j = a_{k(n-k)-j}). This palindromy is the symmetric half of Sylvester's theorem (1878) that the coefficient sequence is symmetric and unimodal; unimodality itself (Proctor 1982, via sl₂) is the substantive open question and is NOT proved here. Built on the parent's recurrence-defined q-binomial library via both q-Pascal identities. 3 theorems, 0 sorries, 0 axioms — verified over a field.",
+  "description": "Proves that the Gaussian (q-)binomial coefficient [n choose k]_q, viewed as a polynomial in q, is palindromic (self-reciprocal) of degree k·(n-k). Over a field this is the clean algebraic identity [n,k]_q = q^{k(n-k)}·[n,k]_{q⁻¹}, equivalently that the coefficient sequence reads the same forwards and backwards (a_j = a_{k(n-k)-j}). Adds a Gaussian-polynomial layer over ℤ[X] (q = X): by induction on the q-Pascal recurrence the polynomial qBinom X n k is monic of natDegree k·(n-k), has constant term 1, has nonnegative coefficients, and hence both extreme coefficients are pinned to 1 — the structural scaffolding of Sylvester's coefficient array. This palindromy plus the pinned ends is the symmetric half of Sylvester's theorem (1878) that the coefficient sequence is symmetric and unimodal; unimodality itself (Proctor 1982, via sl₂) is the substantive open question and is NOT proved here. Built on the parent's recurrence-defined q-binomial library via both q-Pascal identities. 10 theorems, 0 sorries, 0 axioms — verified.",
   "meta": {
     "author": "Lean Genius Researcher",
     "status": "verified",
@@ -10,10 +10,10 @@
     "badge": "original",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 121,
-    "theoremCount": 3,
+    "lineCount": 262,
+    "theoremCount": 10,
     "definitionCount": 0,
-    "assumptions": "The reciprocity identity is proved over an arbitrary field R for any nonzero q (invertibility of q is genuinely needed to form q⁻¹ and to cancel q^{k+1}·(q⁻¹)^{k+1} = 1). No characteristic or positivity hypotheses. The underlying q-binomial coefficients are the parent's, defined over an arbitrary commutative ring via the q-Pascal recurrence. #print axioms reports only the foundational propext / Classical.choice / Quot.sound — no sorryAx, no Lean.ofReduceBool.",
+    "assumptions": "The reciprocity identity is proved over an arbitrary field R for any nonzero q (invertibility of q is genuinely needed to form q⁻¹ and to cancel q^{k+1}·(q⁻¹)^{k+1} = 1). The Gaussian-polynomial layer (degree, monicity, constant term, coefficient nonnegativity, pinned extreme coefficients) is proved over ℤ[X] with q = X — no field hypothesis there, since it inducts directly on the q-Pascal recurrence over the ordered ring ℤ. No characteristic or positivity hypotheses on R. The underlying q-binomial coefficients are the parent's, defined over an arbitrary commutative ring via the q-Pascal recurrence. #print axioms reports only the foundational propext / Classical.choice / Quot.sound — no sorryAx, no Lean.ofReduceBool.",
     "tags": [
       "combinatorics",
       "q-analogs",
@@ -30,7 +30,9 @@
       "Machine-checked self-reciprocity (palindromy) of the Gaussian binomial: [n,k]_q = q^{k(n-k)}·[n,k]_{q⁻¹} over an arbitrary field, proved by induction on n using BOTH parent q-Pascal identities (the first for the reflected side, the second for the original)",
       "Identification of the exact algebraic mechanism of palindromy: the reflected recurrence matches the original because expanding the left by the second q-Pascal identity and the reflected right by the first q-Pascal identity produces termwise-equal sides after the cancellation q^{(k+1)(n-k)}·(q⁻¹)^{k+1} = q^{(k+1)(n-k-1)}",
       "Reflected convenience form q^{k(n-k)}·[n,k]_{q⁻¹} = [n,k]_q and an involutivity sanity check confirming the twisted reflection q ↦ q⁻¹ is an involution",
-      "Explicit, honestly-scoped separation of the symmetric (palindromy) half of Sylvester's theorem — proved here — from the unimodal half, which remains open"
+      "Explicit, honestly-scoped separation of the symmetric (palindromy) half of Sylvester's theorem — proved here — from the unimodal half, which remains open",
+      "Gaussian-polynomial layer over ℤ[X] (q = X): a single induction on the q-Pascal recurrence proves qBinom X n k is monic with natDegree = k·(n-k) (the X^{k+1}-shifted summand strictly dominates in degree whenever n-k ≥ 1, supplying both the degree and the monic leading term), has constant term 1, and has coefficientwise-nonnegative coefficients",
+      "Pinned extreme coefficients: combining monicity (top coefficient at degree k(n-k) equals 1) with the constant-term computation gives qBinom_X_extreme_coeffs — both ends of the coefficient array equal 1 — which together with nonnegativity and palindromy is the exact structural precursor to Sylvester's symmetric-unimodal shape"
     ],
     "prerequisites": [
       "Gaussian (q-)binomial coefficients and the two q-Pascal recurrences (parent entry combinations-formula-oq-03)",
@@ -43,8 +45,8 @@
     "namespace": "QBinomialCoefficients",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 121,
-    "theoremCount": 3,
+    "lineCount": 262,
+    "theoremCount": 10,
     "definitionCount": 0
   },
   "overview": {
@@ -55,7 +57,9 @@
       "**Palindromy is the symmetric half of unimodality**: A symmetric unimodal sequence is the conclusion of Sylvester's theorem. The symmetry a_j = a_{k(n-k)-j} — proved here — is elementary and reduces to the two q-Pascal recurrences; the unimodality (the actual rise-then-fall) is the hard half and stays open. Separating the two cleanly is the honest way to report partial progress on the open question.",
       "**Both q-Pascal identities together produce termwise agreement**: The single most important structural fact is that expanding the original by the second q-Pascal identity and the reflection by the first q-Pascal identity yields two expressions that agree coefficient-by-coefficient after collecting powers of q. Using the same Pascal identity on both sides does NOT give a termwise match — the two forms are consistent only because qBinom_pascal and qBinom_pascal' compute the same q-binomial.",
       "**Invertibility of q is essential, not cosmetic**: The reflection substitutes q ↦ q⁻¹ and relies on q^{k+1}·(q⁻¹)^{k+1} = 1, so the identity is naturally a field statement with q ≠ 0. Over a general ring one would instead pass to a polynomial reversal; the field formulation keeps the proof to elementary power arithmetic (pow_add, inv_pow, mul_inv_cancel_left₀).",
-      "**Truncated subtraction never bites**: The exponents k(n-k), (k+1)(n-k), and (k+1)(n-k-1) use ℕ subtraction, but the delicate step (writing n-k = (n-k-1)+1) is only taken in the branch k<n where n-k ≥ 1, so the subtraction is exact exactly where it is used; the diagonal and above-diagonal cases are dispatched before any such rewrite."
+      "**Truncated subtraction never bites**: The exponents k(n-k), (k+1)(n-k), and (k+1)(n-k-1) use ℕ subtraction, but the delicate step (writing n-k = (n-k-1)+1) is only taken in the branch k<n where n-k ≥ 1, so the subtraction is exact exactly where it is used; the diagonal and above-diagonal cases are dispatched before any such rewrite.",
+      "**The degree comes from the shifted summand, not the sum**: In the q-Pascal recurrence qBinom X (n+1)(k+1) = A + X^{k+1}·B with A = qBinom X n k and B = qBinom X n (k+1), the shifted term X^{k+1}·B has natDegree (k+1)(n-k), strictly above deg A = k(n-k) whenever n-k ≥ 1. So the sum's degree and leading (monic) coefficient are inherited entirely from X^{k+1}·B (degree_add_eq_left_of_degree_lt / Monic.add_of_left after add_comm); the interior induction never needs to reason about a potential cancellation of leading terms. This is the polynomial-over-ℤ[X] counterpart of the field palindromy: the field proof uses q⁻¹, but the coefficient-array structure lives over ℤ and needs no inverses.",
+      "**Extreme coefficients are pinned but the middle is open**: Monicity fixes the top coefficient (degree k(n-k)) to 1 and coeff_mul_X_pow' fixes the constant term to 1, so qBinom_X_extreme_coeffs closes both ends of the array. With coefficient nonnegativity and the palindromy this is the entire symmetric skeleton — everything except the actual rise-then-fall of the interior coefficients, which is exactly Sylvester's unimodality and stays open."
     ],
     "prerequisites": [
       "Gaussian (q-)binomial coefficients and the two q-Pascal recurrences (parent entry combinations-formula-oq-03)",
@@ -90,8 +94,16 @@
       "id": "corollaries",
       "title": "Reflected Form and Involutivity",
       "startLine": 106,
-      "endLine": 121,
+      "endLine": 136,
       "summary": "qBinom_reflect (the right-to-left convenience form q^{k(n-k)}·[n,k]_{q⁻¹} = [n,k]_q) and qBinom_reciprocal_involutive (applying the twisted reflection twice returns the original, confirming it is an involution as any palindrome reflection must be)."
+    },
+    {
+      "id": "gaussian-polynomial",
+      "title": "The Gaussian polynomial over ℤ[X]: degree, monicity, coefficients",
+      "startLine": 137,
+      "endLine": 262,
+      "summary": "Specialising the ambient ring to ℤ[X] with q = X turns qBinom X n k into the Gaussian polynomial whose coefficient sequence Sylvester's theorem concerns. qBinom_X_monic_natDegree proves it monic of natDegree k·(n-k) by induction on q-Pascal (the X^{k+1}·qBinom X n (k+1) summand strictly dominates in degree when n-k ≥ 1, via degree_add_eq_left_of_degree_lt and Monic.add_of_left). qBinom_X_coeff_zero pins the constant term to 1 (the shifted summand contributes nothing at coefficient 0). qBinom_X_coeff_nonneg shows every coefficient is ≥ 0 over the ordered ring ℤ. The convenience corollaries qBinom_X_monic / qBinom_X_natDegree / qBinom_X_coeff_top and the capstone qBinom_X_extreme_coeffs pin both ends of the coefficient array to 1.",
+      "mathContext": "qBinom (X : ℤ[X]) n k : ℤ[X]; coeff_mul_X_pow', natDegree_mul, natDegree_X_pow, degree_lt_degree, Monic.add_of_left over the ordered ring ℤ."
     }
   ],
   "conclusion": {
@@ -99,7 +111,7 @@
     "implications": "Palindromy is exactly the piece of Sylvester's theorem that is elementary, and isolating it cleanly turns the open unimodality question into 'a symmetric sequence is unimodal', halving what remains to be proved. The identity also encodes the geometric duality between k-dimensional subspaces of 𝔽_qⁿ and their (n−k)-dimensional annihilators (which reverses the q-grading), and it is the q-analogue of the ordinary binomial symmetry C(n,k) = C(n,n−k) recovered at q = 1. Because the argument is purely arithmetic over a field, it is robust and reusable as a lemma toward any future unimodality formalization.",
     "openQuestions": [
       "Unimodality of the coefficient sequence of [n,k]_q — the substantive half of Sylvester's theorem — requiring either an sl₂-action (Proctor 1982) or an explicit injection between adjacent coefficient levels (O'Hara 1990). This is the actual content of the open question and is not attempted here.",
-      "Recast palindromy as a genuine coefficient-reversal statement over ℤ[q] (rather than the field identity with q⁻¹), so that it composes directly with a coefficient-level unimodality argument.",
+      "Recast palindromy as a genuine coefficient-reversal statement over ℤ[X] (rather than the field identity with q⁻¹) — coeff j = coeff (k(n-k) - j) — so that it composes directly with a coefficient-level unimodality argument. The Gaussian-polynomial layer here supplies the ambient ℤ[X] object and pins its extreme coefficients, but the internal reversal symmetry of the coefficient array is not yet formalized.",
       "Formalize the subspace-counting interpretation, deriving palindromy from the bijection between k- and (n−k)-dimensional subspaces of 𝔽_qⁿ instead of from the recurrence."
     ]
   },

--- a/src/data/proofs/lagrange-theorem-oq-01/meta.json
+++ b/src/data/proofs/lagrange-theorem-oq-01/meta.json
@@ -152,9 +152,9 @@
   ],
   "leanFile": {
     "namespace": "LagrangeOQ01",
-    "lineCount": 379,
+    "lineCount": 607,
     "axiomCount": 0,
-    "theoremCount": 27,
+    "theoremCount": 35,
     "definitionCount": 0,
     "path": "Proofs/LagrangeTheoremOQ01.lean",
     "sorries": 0

--- a/src/data/research/problems/lagrange-theorem-oq-01.json
+++ b/src/data/research/problems/lagrange-theorem-oq-01.json
@@ -29,13 +29,14 @@
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETED+extended (Sylow p-side): the |G|=p·q classification now has BOTH primes' normality analysis. New Part VII adds the q≢1(mod p) regime — |P|=p, Sylow p-subgroup normal & unique (n_p=1), and a normal subgroup of order p — the symmetric counterpart of the unconditional q-side. 4 new theorems, 0 sorries, 0 axioms; verified host lean v4.26.0 (docker olean-write hit transient fleet SIGBUS).",
+    "progressSummary": "COMPLETE (order-pq classification closed): the q≢1(mod p) regime now proves G is CYCLIC (isCyclic_of_card_eq_pq), yielding the full dichotomy cyclic_or_q_mod_p_of_card_eq_pq (either q≡1 mod p or G≅ℤ/pq) plus the abelian corollary. 3 new theorems, 0 sorries, 0 axioms; host lean v4.26.0 EXIT 0 (docker codegen SIGBUS135 infra-only, kernel-checked on host, axioms=[propext,Classical.choice,Quot.sound]).",
     "builtItems": [
       "LagrangeTheoremOQ01.lean: ~140 lines, 11 theorems, 0 sorries, 0 axioms",
       "Parts I-V: Lagrange, Sylow existence, conjugacy, counting, partial converse + Cauchy",
       "LagrangeTheoremOQ01.lean: +2 thms — card_sylow_q_of_card_eq_pq (|Q|=q via factorization(pq)=1) and sylow_q_normal_of_card_eq_pq (order-pq groups have normal Sylow q-subgroup)",
       "LagrangeTheoremOQ01.lean: isSolvable_of_card_eq_pq — groups of order p·q (p<q prime) are solvable (IsSolvable G), via cyclic N and G⧸N + solvable_of_ker_le_range. New reasoning VERIFIED host lean v4.26.0 minimal-import standalone (type-check EXIT 0); full-file docker build blocked by shared .lake .ir codegen corruption (infra).",
-      "LagrangeTheoremOQ01.lean Part VII: card_sylow_p_of_card_eq_pq (|P|=p), sylow_p_normal_of_card_eq_pq (q≢1 mod p ⟹ P normal), card_sylow_p_eq_one_of_card_eq_pq (n_p=1), exists_normal_subgroup_card_eq_p_of_card_eq_pq. Now ~30 theorems, 0 axioms/0 sorries. PR (lagrange-oq-01-not-simple)."
+      "LagrangeTheoremOQ01.lean Part VII: card_sylow_p_of_card_eq_pq (|P|=p), sylow_p_normal_of_card_eq_pq (q≢1 mod p ⟹ P normal), card_sylow_p_eq_one_of_card_eq_pq (n_p=1), exists_normal_subgroup_card_eq_p_of_card_eq_pq. Now ~30 theorems, 0 axioms/0 sorries. PR (lagrange-oq-01-not-simple).",
+      "LagrangeTheoremOQ01.lean Part VIII: isCyclic_of_card_eq_pq (|G|=p·q, q≢1 mod p ⟹ G cyclic) — two coprime normal Sylow subgroups P(order p),Q(order q), generators a,b via Subgroup.isCyclic_iff_exists_zpowers_eq_top, Disjoint P Q from |P⊓Q| ∣ gcd(p,q)=1, Commute a b via Subgroup.commute_of_normal_of_disjoint, orderOf(a*b)=p·q via Commute.orderOf_mul_eq_mul_orderOf_of_coprime, then isCyclic_of_orderOf_eq_card. Plus cyclic_or_q_mod_p_of_card_eq_pq (full dichotomy) and mul_comm_of_card_eq_pq (abelian corollary). Now 35 theorems, 0 ax/0 sorries."
     ],
     "insights": [
       "Sylow theorems are fully in Mathlib — file wraps existing API in gallery format",
@@ -46,12 +47,14 @@
       "Groups of order p·q (p<q prime) are SOLVABLE (isSolvable_of_card_eq_pq): strictly strengthens not_isSimpleGroup_of_card_eq_pq. Proof: the normal N (order q) is prime-order hence cyclic hence abelian hence solvable; quotient G⧸N has order p (card_eq_card_quotient_mul_card_subgroup) hence also cyclic/solvable; solvability lifts along 1→N→G→G⧸N→1 via solvable_of_ker_le_range with ker(mk N)=N=range(N.subtype).",
       "Lean recipe: IsSolvable of a prime-order subgroup N — isCyclic_of_prime_card gives IsCyclic N, then isSolvable_of_comm (fun a b => by letI := IsCyclic.commGroup (α:=N); exact mul_comm a b). NOTE: the shorter `letI := IsCyclic.commGroup; inferInstance` route FAILS to synthesize IsSolvable (Group/CommGroup instance diamond) — extract commutativity explicitly and feed isSolvable_of_comm instead.",
       "solvable_of_ker_le_range f g (hfg: g.ker ≤ f.range) with f=N.subtype, g=QuotientGroup.mk N: discharge hfg by le_of_eq (rw [QuotientGroup.ker_mk, Subgroup.range_subtype]) — both sides collapse to N.",
-      "Sylow p-side of pq needs the arithmetic hypothesis q≢1 (mod p): n_p≡1(mod p) divides [G:P]=q, so n_p∈{1,q}, and n_p=q ⟺ q≡1(mod p). S₃ (order 2·3, 3≡1 mod 2) is the extremal witness with three non-normal Sylow 2-subgroups. Under q≢1(mod p) both Sylow subgroups are normal ⟹ two coprime normal subgroups ⟹ internal direct product ⟹ G cyclic."
+      "Sylow p-side of pq needs the arithmetic hypothesis q≢1 (mod p): n_p≡1(mod p) divides [G:P]=q, so n_p∈{1,q}, and n_p=q ⟺ q≡1(mod p). S₃ (order 2·3, 3≡1 mod 2) is the extremal witness with three non-normal Sylow 2-subgroups. Under q≢1(mod p) both Sylow subgroups are normal ⟹ two coprime normal subgroups ⟹ internal direct product ⟹ G cyclic.",
+      "Order-pq classification CLOSED: q≡1(mod p) is the UNIQUE obstruction to cyclicity. When it fails, the two normal Sylow subgroups (Parts VI,VII) are coprime-order, disjoint, hence commute (commutator ⊆ P∩Q=1), and their generators multiply to a full-order element ⟹ cyclic. The nonabelian ℤ/q⋊ℤ/p exists precisely when q≡1(mod p) (S₃ at 2·3).",
+      "Lean recipe for internal-direct-product ⟹ cyclic: get generators of the two normal prime-order subgroups via (Subgroup.isCyclic_iff_exists_zpowers_eq_top H).mp with orderOf from Nat.card_zpowers; disjointness by cardinality (card_dvd_of_le inf_le_left/right into Nat.dvd_gcd, gcd=1); Commute via Subgroup.commute_of_normal_of_disjoint; full order via Commute.orderOf_mul_eq_mul_orderOf_of_coprime (DOT NOTATION on the Commute hyp — bare orderOf_mul_eq_mul_orderOf_of_coprime is unknown, it lives in namespace Commute); conclude isCyclic_of_orderOf_eq_card.",
+      "GOTCHA: docker exit-135 SIGBUS at the codegen (-c *.c) stage MASKED a real elaboration error (unknown identifier) for two builds — host lean type-check (LEAN_PATH from packages .lake, no -o/-c) surfaced it immediately. Always host-verify when docker 135s repeatedly at 2-3s: the worktree .lake already holds the decompressed mathlib oleans after the first docker download."
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "Capstone: q≢1(mod p) ⟹ G cyclic. Assemble the two coprime normal Sylow subgroups (orders p,q) into an internal direct product (Subgroup.isComplement / disjoint + card) and conclude G ≅ ℤ/p × ℤ/q ≅ ℤ/pq via CRT.",
-      "State the full dichotomy: for |G|=p·q either q≡1(mod p) (nonabelian metacyclic possible) or q≢1(mod p) (G cyclic).",
+      "Classification of order p·q is now complete (cyclic vs metacyclic dichotomy). Possible outward extensions: (a) exhibit the nonabelian witness when q≡1 mod p (construct ℤ/q⋊ℤ/p and show |G|=pq, noncyclic); (b) order-p² groups are abelian (isCyclic or ℤ/p×ℤ/p); (c) order p²q or p³ classifications.",
       "Repair the parent LagrangeTheorem.lean drift if any, to keep the gallery imports coherent."
     ]
   },


### PR DESCRIPTION
## Summary

Extends the palindromy entry **combinations-formula-oq-03-oq-04** (Self-Reciprocity of Gaussian q-Binomial Coefficients) with a **Gaussian-polynomial layer** over `ℤ[X]`. Specialising the ambient ring to `ℤ[X]` with `q = X` turns `qBinom X n k` into the actual Gaussian polynomial whose coefficient array Sylvester's 1878 theorem concerns. The field palindromy proof uses `q⁻¹`; this layer establishes the coefficient-array structure directly over `ℤ`, needing no inverses.

## New results (all by induction on the q-Pascal recurrence)

- `qBinom_X_monic_natDegree` — `qBinom X n k` is **monic** with `natDegree = k·(n-k)`. In the interior branch the `X^{k+1}·qBinom X n (k+1)` summand strictly dominates in degree (whenever `n-k ≥ 1`), supplying both the degree and the monic leading term via `degree_add_eq_left_of_degree_lt` / `Monic.add_of_left`.
- `qBinom_X_coeff_zero` — **constant term = 1** (`coeff_mul_X_pow'`; the shifted summand contributes nothing at coefficient 0).
- `qBinom_X_coeff_nonneg` — every coefficient is **≥ 0** over the ordered ring `ℤ`.
- `qBinom_X_monic` / `qBinom_X_natDegree` / `qBinom_X_coeff_top` — convenience corollaries; the top coefficient at degree `k(n-k)` equals 1.
- `qBinom_X_extreme_coeffs` — **both ends of the coefficient array pinned to 1**.

Together with the existing palindromy and the nonnegativity, this is the full symmetric skeleton of Sylvester's symmetric-unimodal shape. Unimodality itself (Proctor 1982 via sl₂ / O'Hara 1990) remains the substantive open question and is **not** attempted.

## Verification

- **+7 theorems** (3 → 10), **0 sorries, 0 axioms**.
- Docker build green: `./proofs/scripts/docker-build.sh Proofs.CombinationsFormulaOQ03OQ04` → `Built Proofs.CombinationsFormulaOQ03OQ04`.
- `#print axioms` reports only foundational `propext` / `Classical.choice` / `Quot.sound` — no `sorryAx`, no `Lean.ofReduceBool`. Status stays `verified` / `original`.
- `meta.json` counts synced (lineCount 121→262, theoremCount 3→10) with new section, contributions, and key insights.

🤖 Generated with [Claude Code](https://claude.com/claude-code)