### PR TITLE
research(elementary-quadratic-reciprocity-oq-03-oq-02-wip-01): χ₈ anti-periodicity + orthogonality normalization

### DIFF
--- a/proofs/Proofs/ElementaryQuadraticReciprocityOQ03OQ02WIP01.lean
+++ b/proofs/Proofs/ElementaryQuadraticReciprocityOQ03OQ02WIP01.lean
@@ -36,6 +36,16 @@ Together with the parent's `kronecker2_mul` / `kronecker2_neg` these complete th
 identification of `(·/2)` and `(·/n)` (odd `n`) as genuine periodic characters — the
 structural input the Gauss-sum route to generalized quadratic reciprocity rests on.
 
+## Anti-periodicity and the orthogonality relations of `χ₈ = (·/2)`
+
+* `kronecker2_add_four`         — `(a+4/2) = −(a/2)`: a half-period shift *flips the sign*,
+                                  the sharp form of "period `8` does not descend to `4`".
+* `kronecker2_sum_shifted_period` — `∑_{a=0}^{7} (c+a/2) = 0` for every `c`: the mean of
+                                  `χ₈` over *any* full period vanishes (generalizes the
+                                  parent-window `kronecker2_sum_period`, `c = 0`).
+* `kronecker2_sq_sum_period`    — `∑_{a=0}^{7} (a/2)² = φ(8) = 4`: the self-orthogonality /
+                                  `L²`-norm normalizing the Gauss sum `|τ(χ₈)|² = 8`.
+
 All results are fully machine-checked (0 axioms, 0 sorries).
 
 Reference: Kronecker (1885); Hardy–Wright ch. 6; parent `ElementaryQuadraticReciprocityOQ03OQ02`.
@@ -199,6 +209,71 @@ theorem kronecker2_abs_le_one (a : ℤ) : |kronecker2 a| ≤ 1 := by
     Gauss sum `∑ χ₈(a) ζ^a` has no constant-mode contribution. -/
 theorem kronecker2_sum_period :
     (∑ a ∈ Finset.range 8, kronecker2 (a : ℤ)) = 0 := by
+  simp only [Finset.sum_range_succ, Finset.sum_range_zero, Nat.cast_ofNat,
+    Nat.cast_zero, Nat.cast_one]
+  decide
+
+-- ============================================================
+-- Section E: Anti-periodicity, translation-invariant orthogonality, and the
+--            self-orthogonality (L²) normalization of χ₈ = (·/2)
+-- ============================================================
+
+/-- **`χ₈` is anti-periodic with anti-period `4`: `(a+4/2) = −(a/2)`.**  Shifting the
+    numerator by `4` negates the Kronecker symbol at `2`, for *every* integer `a` (on the
+    even residues both sides are `0`).  Concretely `1↦5, 3↦7, 5↦1, 7↦3` swaps the two unit
+    classes `{1,7}` (value `+1`) and `{3,5}` (value `−1`) mod `8`.  This anti-periodicity is
+    the structural reason the period `8` does **not** descend to `4` — it upgrades
+    `kronecker2_not_period_four` from "`4` is not a period" to the exact statement that a
+    half-period shift *flips the sign*, the hallmark of a primitive character of conductor
+    `8`.  Proved by reducing both sides to the residue mod `8` (`kronecker2_mod_eight`) and
+    checking the eight classes. -/
+theorem kronecker2_add_four (a : ℤ) : kronecker2 (a + 4) = - kronecker2 a := by
+  have key : kronecker2 (a + 4) = kronecker2 (a % 8 + 4) := by
+    rw [kronecker2_mod_eight (a + 4), kronecker2_mod_eight (a % 8 + 4)]
+    congr 1
+    omega
+  rw [key, kronecker2_mod_eight a]
+  have hr : a % 8 = 0 ∨ a % 8 = 1 ∨ a % 8 = 2 ∨ a % 8 = 3 ∨ a % 8 = 4 ∨
+      a % 8 = 5 ∨ a % 8 = 6 ∨ a % 8 = 7 := by omega
+  rcases hr with h | h | h | h | h | h | h | h <;> rw [h] <;> decide
+
+/-- **Translation-invariant orthogonality: `χ₈` sums to zero over *any* full period.**
+
+        ∀ c, ∑_{a = 0}^{7} kronecker2 (c + a) = 0.
+
+    The parent's `kronecker2_sum_period` proves this only for the window `[0, 8)`; this is
+    the full non-principal-character statement that the mean over *every* length-`8` window
+    vanishes (the `c = 0` case recovers `kronecker2_sum_period`).  Clean proof from the
+    anti-periodicity `kronecker2_add_four`: the second half of the window cancels the first,
+    `kronecker2 (c+a+4) = −kronecker2 (c+a)`, so the eight terms pair off to `0`.  This is
+    the translation invariance of the character mean that the Gauss-sum evaluation uses when
+    it re-centers the sum `∑ χ₈(a) ζ^a` at an arbitrary residue. -/
+theorem kronecker2_sum_shifted_period (c : ℤ) :
+    (∑ a ∈ Finset.range 8, kronecker2 (c + a)) = 0 := by
+  have h1 : kronecker2 (c + 5) = - kronecker2 (c + 1) := by
+    have h := kronecker2_add_four (c + 1)
+    rwa [show (c + 1 + 4 : ℤ) = c + 5 by ring] at h
+  have h2 : kronecker2 (c + 6) = - kronecker2 (c + 2) := by
+    have h := kronecker2_add_four (c + 2)
+    rwa [show (c + 2 + 4 : ℤ) = c + 6 by ring] at h
+  have h3 : kronecker2 (c + 7) = - kronecker2 (c + 3) := by
+    have h := kronecker2_add_four (c + 3)
+    rwa [show (c + 3 + 4 : ℤ) = c + 7 by ring] at h
+  simp only [Finset.sum_range_succ, Finset.sum_range_zero, Nat.cast_ofNat,
+    Nat.cast_zero, Nat.cast_one, add_zero, zero_add]
+  linarith [kronecker2_add_four c, h1, h2, h3]
+
+/-- **Self-orthogonality: the `L²`-norm of `χ₈` over a period is `φ(8) = 4`.**
+
+        ∑_{a = 0}^{7} (kronecker2 a)² = 4.
+
+    Since `χ₈` takes the value `±1` on the four units mod `8` (`{1,3,5,7}`) and `0` on the
+    four evens, its second moment counts the units: `⟨χ₈, χ₈⟩ = 4`.  This is the diagonal
+    orthogonality relation complementing the mean-zero `kronecker2_sum_period`; together they
+    are the `⟨χ_i, χ_j⟩ = φ(8)·δ_{ij}` normalization that fixes the modulus of the Gauss sum
+    (`|τ(χ₈)|² = 8`) in the Gauss-sum route to generalized reciprocity. -/
+theorem kronecker2_sq_sum_period :
+    (∑ a ∈ Finset.range 8, kronecker2 (a : ℤ) * kronecker2 (a : ℤ)) = 4 := by
   simp only [Finset.sum_range_succ, Finset.sum_range_zero, Nat.cast_ofNat,
     Nat.cast_zero, Nat.cast_one]
   decide

--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-03-oq-02-wip-01/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-03-oq-02-wip-01/meta.json
@@ -40,12 +40,12 @@
     "badge": "wip",
     "sorries": 0,
     "axiomCount": 0,
-    "theoremCount": 14,
+    "theoremCount": 17,
     "defCount": 0,
     "definitionCount": 0,
-    "lineCount": 206,
+    "lineCount": 281,
     "dateAdded": "2026-07-11",
-    "assumptions": "0 axioms, 0 sorries — every result is machine-verified from the parent file's public API (propext, Classical.choice, Quot.sound only; the two kronecker2 results use only propext). Status is kept 'wip'/'axiomatized' to match the parent: the file proves genuine new lemmas (numerator periodicity of (a/n) for odd positive n via kronecker_congr_left / kronecker_add_mul_left / kronecker_periodic_left, and full period-8 periodicity of the (a/2) character via kronecker2_congr / kronecker2_add_mul_eight, plus the exact conductor 8 / primitivity of (·/2) via kronecker2_not_period_four / kronecker2_not_period_two / kronecker2_conductor_eight) but the broader open target — wiring kronecker2 into the definition at even moduli and generalized quadratic reciprocity for arbitrary fundamental discriminants — remains unformalized, exactly as documented in the parent's module note. Nothing new is assumed.",
+    "assumptions": "0 axioms, 0 sorries — every result is machine-verified from the parent file's public API (propext, Classical.choice, Quot.sound only; the two kronecker2 results use only propext). Status is kept 'wip'/'axiomatized' to match the parent: the file proves genuine new lemmas (numerator periodicity of (a/n) for odd positive n via kronecker_congr_left / kronecker_add_mul_left / kronecker_periodic_left, and full period-8 periodicity of the (a/2) character via kronecker2_congr / kronecker2_add_mul_eight, plus the exact conductor 8 / primitivity of (·/2) via kronecker2_not_period_four / kronecker2_not_period_two / kronecker2_conductor_eight) but the broader open target — wiring kronecker2 into the definition at even moduli and generalized quadratic reciprocity for arbitrary fundamental discriminants — remains unformalized, exactly as documented in the parent's module note. Nothing new is assumed. Section E adds three further machine-verified results with no new assumptions: the anti-periodicity kronecker2_add_four ((a+4/2) = -(a/2), the sharp form of 'period 8 does not descend to 4'), the translation-invariant orthogonality kronecker2_sum_shifted_period (the mean of (·/2) over ANY full period vanishes, generalizing the parent-window kronecker2_sum_period), and the self-orthogonality kronecker2_sq_sum_period (∑ (a/2)² = φ(8) = 4 over a period) — all derived from the anti-periodicity and decidable residue arithmetic (propext, Classical.choice, Quot.sound only).",
     "mathlibDependencies": [
       {
         "theorem": "jacobiSym.mod_left'",
@@ -115,6 +115,22 @@
       "endLine": 142,
       "summary": "`kronecker2_not_period_four` (period 4 fails, witnessed by kronecker2 5 = −1 ≠ 1 = kronecker2 1) and `kronecker2_not_period_two` (period 2 fails, witnessed by kronecker2 3 = −1 ≠ 1 = kronecker2 1), bundled with the full period-8 result in `kronecker2_conductor_eight`: 8 is the exact minimal period, so (·/2) = χ₈ is a *primitive* Dirichlet character mod 8, not induced from any smaller modulus. This upgrades the period-8 statement to the sharp conductor — the input the Gauss-sum route requires, since only primitive characters have nonvanishing Gauss sums.",
       "mathContext": "$\\chi_8=(\\cdot/2)$ has exact conductor $8$: periodic mod $8$ but not mod $4$ or mod $2$, hence primitive with nonvanishing Gauss sum $\\tau(\\chi_8)$."
+    },
+    {
+      "id": "section-d",
+      "title": "Section D: the residue-level character table and boundedness of χ₈",
+      "startLine": 152,
+      "endLine": 215,
+      "summary": "The complete character table of (·/2): kronecker2_eq_zero_iff (0 on evens), kronecker2_ne_zero_iff (±1 on odds), kronecker2_eq_one_iff (+1 on {1,7} mod 8), kronecker2_eq_neg_one_iff (−1 on {3,5} mod 8), together with the pointwise bound kronecker2_abs_le_one and the mean-zero orthogonality kronecker2_sum_period over the base window [0,8).",
+      "mathContext": "A non-principal Dirichlet character is pinned by its support and its two unit classes; the |χ|≤1 bound and ∑χ = 0 over a period are the elementary inputs the Gauss-sum / Pólya–Vinogradov estimates consume."
+    },
+    {
+      "id": "section-e",
+      "title": "Section E: anti-periodicity and the orthogonality normalization of χ₈",
+      "startLine": 216,
+      "endLine": 280,
+      "summary": "Anti-periodicity kronecker2_add_four ((a+4/2) = -(a/2)); translation-invariant orthogonality kronecker2_sum_shifted_period (the mean over ANY full period vanishes, generalizing kronecker2_sum_period); and self-orthogonality kronecker2_sq_sum_period (∑ (a/2)² = φ(8) = 4). The anti-periodicity cancels the two halves of any window and normalizes the second moment.",
+      "mathContext": "For the Gauss-sum route to generalized quadratic reciprocity: translation invariance of the character mean lets the Gauss sum ∑ χ₈(a) ζ^a be re-centered freely, and the diagonal norm ⟨χ₈,χ₈⟩ = φ(8) = 4 fixes |τ(χ₈)|² = 8. Anti-periodicity χ₈(a+4) = −χ₈(a) is the primitivity signature (conductor 8, not 4)."
     }
   ],
   "conclusion": {
@@ -218,6 +234,21 @@
       "name": "kronecker2_sum_period",
       "statement": "(∑ a ∈ Finset.range 8, kronecker2 (a : ℤ)) = 0",
       "description": "Orthogonality: χ₈=(·/2) sums to zero over a full period (0 + 1 + 0 − 1 + 0 − 1 + 0 + 1 = 0), the defining property of a non-principal Dirichlet character. This is the orthogonality relation that opens the Gauss-sum evaluation: the mean of χ₈ is 0."
+    },
+    {
+      "name": "kronecker2_add_four",
+      "statement": "∀ a : ℤ, kronecker2 (a + 4) = - kronecker2 a",
+      "description": "Anti-periodicity of χ₈ = (·/2): a half-period shift by 4 negates the symbol for every integer a (both sides vanish on evens). Concretely it swaps the two unit classes {1,7} (value +1) and {3,5} (value −1) mod 8. This is the sharp structural reason period 8 does not descend to 4, upgrading kronecker2_not_period_four from 'not a period' to 'flips the sign'. Proved by reducing both sides to the residue mod 8 and checking the eight classes."
+    },
+    {
+      "name": "kronecker2_sum_shifted_period",
+      "statement": "∀ c : ℤ, (∑ a ∈ Finset.range 8, kronecker2 (c + a)) = 0",
+      "description": "Translation-invariant orthogonality: the mean of χ₈ over ANY length-8 window vanishes, generalizing the parent-window kronecker2_sum_period (the c = 0 case). Clean proof from the anti-periodicity kronecker2_add_four — the second half of the window cancels the first, so the eight terms pair off to 0. This is the character-mean translation invariance the Gauss-sum evaluation uses when re-centering ∑ χ₈(a) ζ^a at an arbitrary residue."
+    },
+    {
+      "name": "kronecker2_sq_sum_period",
+      "statement": "(∑ a ∈ Finset.range 8, kronecker2 a * kronecker2 a) = 4",
+      "description": "Self-orthogonality: the L²-norm of χ₈ over a period counts the units mod 8, ⟨χ₈, χ₈⟩ = φ(8) = 4. The diagonal orthogonality relation complementing the mean-zero kronecker2_sum_period; together they are the ⟨χ_i, χ_j⟩ = φ(8)·δ_ij normalization fixing the modulus of the Gauss sum |τ(χ₈)|² = 8 in the Gauss-sum route to generalized reciprocity."
     }
   ]
 }


### PR DESCRIPTION
## Summary

Extends the Kronecker-character WIP file `ElementaryQuadraticReciprocityOQ03OQ02WIP01` with **three new machine-verified theorems (0 axioms, 0 sorries)** that advance its stated goal — supplying the structural inputs the Gauss-sum route to generalized quadratic reciprocity rests on. All derive from the existing anti-periodicity + decidable residue arithmetic (`propext`, `Classical.choice`, `Quot.sound` only).

## New results (Section E)

| Theorem | Statement | Significance |
|---|---|---|
| `kronecker2_add_four` | `(a+4/2) = −(a/2)` for all `a` | **Anti-periodicity** of χ₈ — the *sharp* form of "period 8 does not descend to 4": a half-period shift *flips the sign*, swapping the unit classes `{1,7}`↔`{3,5}` mod 8. Upgrades `kronecker2_not_period_four` from "not a period" to the exact primitivity signature. |
| `kronecker2_sum_shifted_period` | `∑_{a=0}^{7} (c+a/2) = 0` for every `c` | **Translation-invariant orthogonality** — the mean of χ₈ over *any* full period vanishes, generalizing the parent-window `kronecker2_sum_period` (the `c=0` case). Clean proof: the second half of the window cancels the first via anti-periodicity. This is the mean translation-invariance the Gauss sum uses to re-center `∑ χ₈(a) ζ^a` at an arbitrary residue. |
| `kronecker2_sq_sum_period` | `∑_{a=0}^{7} (a/2)² = φ(8) = 4` | **Self-orthogonality / L²-norm** — `⟨χ₈,χ₈⟩ = φ(8) = 4`, the diagonal orthogonality complementing mean-zero, fixing the Gauss-sum modulus `|τ(χ₈)|² = 8`. |

The docstring previously claimed χ₈ "sums to zero over any full period" but proved it only for the window `[0,8)`; `kronecker2_sum_shifted_period` closes exactly that gap.

## Verification

- Docker build green: `✔ [3059/3059] Built Proofs.ElementaryQuadraticReciprocityOQ03OQ02WIP01` (fresh, not replayed). Only pre-existing parent-file lint warnings.
- 0 `axiom` declarations, 0 `sorry`, no `native_decide` — remains axiom-free (badge `wip`, status `axiomatized` kept to match parent's broader open target).
- `meta.json` counts synced: 14→17 theorems, 206→281 lines; `mainTheorems`, Sections D & E, and `assumptions` narrative updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)