### PR TITLE
research(erdos-666-incomplete-01): refute the generalized C_{2k} conjecture at k=3 [VERIFIED 0 new axioms]

### DIFF
--- a/proofs/Proofs/Erdos666Problem.lean
+++ b/proofs/Proofs/Erdos666Problem.lean
@@ -616,8 +616,13 @@ exponent `a ∈ (0,1)` such that every subgraph of `Qₙ` (`n ≥ 10`) with at l
 at `k = 3` and rewriting its conclusion `HasC2k H 3` to `HasC6 H` via
 `hasC2k_three_iff_hasC6`.  This pins down exactly how the generalization meets the
 original problem: same cycle length, but a *sparser* `n^a·2ⁿ` density threshold than
-the `ε·n·2ⁿ⁻¹` of `ConjectureAt`, which is why the `C₆` refutation
-(`conder_no_threshold`) does **not** transfer to it.  No new axioms. -/
+the `ε·n·2ⁿ⁻¹` of `ConjectureAt`.  A sparser threshold makes the forcing statement
+**stronger** (it applies to more subgraphs), so — contrary to first appearances — the
+`C₆` refutation `conder_no_threshold` **does** transfer to it: Conder's `C₆`-free
+subgraph carries a *constant* fraction of the edges, which dominates any sub-linear
+`c·n^a·2ⁿ` threshold once `n` is large.  This is made precise in
+`generalizedConjecture_false` below, which refutes the whole `∀ k ≥ 3` conjecture at
+its `k = 3` instance.  No new axioms. -/
 theorem generalizedConjecture_three_forces_c6 (h : GeneralizedConjecture) :
     ∃ c : ℝ, 0 < c ∧ ∃ a : ℝ, 0 < a ∧ a < 1 ∧
       ∀ n : ℕ, n ≥ 10 →
@@ -628,8 +633,87 @@ theorem generalizedConjecture_three_forces_c6 (h : GeneralizedConjecture) :
   exact ⟨c, hc, a, ha0, ha1,
     fun n hn H hden => (hasC2k_three_iff_hasC6 H).mp (hforce n hn H hden)⟩
 
+unseal EpsilonDenseSubgraph in
+/-- **Edge-count reading of `ε`-density.**  Unfolds `EpsilonDenseSubgraph` to its
+underlying inequality `Nat.card H.edgeSet ≥ ε · Eₙ`.  Isolated as its own
+`unseal`-scoped lemma (its type never mentions `HasC6`/`HasCycle`) so that callers can
+extract the edge bound without co-unfolding `Nat.card edgeSet` alongside `HasCycle` —
+the co-unfolding that triggers the Mathlib v4.26 elaborator stack overflow (header note). -/
+theorem epsilonDense_card_ge {n : ℕ} {ε : ℝ} {H : SimpleGraph (Fin (2 ^ n))}
+    (hH : EpsilonDenseSubgraph n ε H) :
+    (Nat.card H.edgeSet : ℝ) ≥ ε * hypercubeEdges n := hH
+
+/-- **The generalized conjecture, as literally stated (`∀ k ≥ 3`), is false.**
+Its `k = 3` instance is exactly Erdős's original C₆ question, and there the required
+density threshold `c·nᵃ·2ⁿ` (with `a < 1`) is *sub-linear* in `n·2ⁿ` — a **vanishing**
+fraction of the `≈ n·2ⁿ⁻¹` edges of `Qₙ`.  But Conder's construction
+(`conder_no_threshold`) supplies, for arbitrarily large `n`, a `C₆`-free subgraph
+carrying a **constant** fraction `1/3` of all edges, i.e. `(1/6)·n·2ⁿ` edges.  Since
+`n / nᵃ = n^{1-a} → ∞`, for large `n` this constant-fraction count dominates the
+sub-linear threshold `c·nᵃ·2ⁿ`, so Conder's `C₆`-free subgraph already **exceeds** the
+threshold — refuting the `k = 3` forcing claim, hence the whole `∀ k ≥ 3` conjecture.
+
+The moral corrects a natural but backwards intuition: a *smaller* threshold makes the
+forcing statement *stronger*, so the `C₆` refutation transfers to (indeed overshoots)
+the generalized version at `k = 3`.  The honest open problem is therefore the
+`k ≥ 4` restriction — there `ex(Qₙ, C₂ₖ)` is genuinely believed sub-linear
+(`nᵃᵏ·2ⁿ`, `aₖ < 1`) and no constant-fraction `C₂ₖ`-free construction is known, so the
+`k = 3` refutation does not carry over.  No new axioms: the single `conder_no_threshold`
+(via its unbounded-`n` form) drives everything, combined with the elementary growth fact
+`n^{1-a} → ∞`. -/
+theorem generalizedConjecture_false : ¬ GeneralizedConjecture := by
+  intro h
+  obtain ⟨c, hc, a, ha0, ha1, hforce⟩ := h 3 (by norm_num)
+  -- For every large `n` the sub-linear threshold `c·nᵃ` is dominated by `(1/6)·n`.
+  have hgrow : ∀ᶠ n : ℕ in Filter.atTop, c * (n : ℝ) ^ a ≤ (1 / 6) * (n : ℝ) := by
+    have hb : (0 : ℝ) < 1 - a := by linarith
+    have htend : Filter.Tendsto (fun n : ℕ => (n : ℝ) ^ (1 - a)) Filter.atTop Filter.atTop :=
+      (tendsto_rpow_atTop hb).comp tendsto_natCast_atTop_atTop
+    filter_upwards [htend.eventually_ge_atTop (6 * c), Filter.eventually_ge_atTop 1]
+      with n hn6 hn1
+    have hnpos : (0 : ℝ) < (n : ℝ) := by exact_mod_cast hn1
+    have hrpow : (n : ℝ) ^ (1 - a) * (n : ℝ) ^ a = (n : ℝ) := by
+      rw [← Real.rpow_add hnpos, show (1 - a) + a = 1 by ring, Real.rpow_one]
+    have hna : (0 : ℝ) ≤ (n : ℝ) ^ a := Real.rpow_nonneg hnpos.le a
+    calc c * (n : ℝ) ^ a
+        ≤ ((1 / 6) * (n : ℝ) ^ (1 - a)) * (n : ℝ) ^ a :=
+          mul_le_mul_of_nonneg_right (by linarith) hna
+      _ = (1 / 6) * ((n : ℝ) ^ (1 - a) * (n : ℝ) ^ a) := by ring
+      _ = (1 / 6) * (n : ℝ) := by rw [hrpow]
+  rw [Filter.eventually_atTop] at hgrow
+  obtain ⟨N₀, hN₀⟩ := hgrow
+  -- Conder supplies a `(1/3)`-dense `C₆`-free subgraph at some `n ≥ max N₀ 10`.
+  obtain ⟨n, hnge, hnd⟩ := conder_counterexamples_unbounded (max N₀ 10)
+  have hn10 : n ≥ 10 := le_trans (le_max_right _ _) hnge
+  have hnN0 : n ≥ N₀ := le_trans (le_max_left _ _) hnge
+  have hn1 : 1 ≤ n := by omega
+  -- It suffices to show `DenseForcesC6 n (1/3)` — every `(1/3)`-dense subgraph exceeds the
+  -- generalized threshold, hence contains `C₆` — contradicting Conder's `hnd`.  Proving the
+  -- ∀-statement (rather than extracting a witness of `∃ H, dense ∧ ¬ HasC6 H`) keeps
+  -- `Nat.card edgeSet` and `HasCycle` out of any single elaborated type (header note).
+  refine hnd (fun H hHdense => ?_)
+  -- `hHdense : EpsilonDenseSubgraph n (1/3) H`; goal `HasC6 H`.
+  have hd : (1 / 3 : ℝ) * (hypercubeEdges n : ℝ) ≤ (Nat.card H.edgeSet : ℝ) :=
+    epsilonDense_card_ge hHdense
+  have hE : (hypercubeEdges n : ℝ) = (n : ℝ) * (2 : ℝ) ^ (n - 1) := by
+    unfold hypercubeEdges; push_cast; ring
+  have hpow : (2 : ℝ) ^ (n - 1) * 2 = (2 : ℝ) ^ n := by
+    rw [← pow_succ]; congr 1; omega
+  have hEreal : (1 / 3 : ℝ) * (hypercubeEdges n : ℝ) = (1 / 6) * (n : ℝ) * (2 : ℝ) ^ n := by
+    rw [hE, ← hpow]; ring
+  have h2pos : (0 : ℝ) < (2 : ℝ) ^ n := by positivity
+  have hbound : (Nat.card H.edgeSet : ℝ) ≥ c * (n : ℝ) ^ a * (2 : ℝ) ^ n := by
+    calc c * (n : ℝ) ^ a * (2 : ℝ) ^ n
+        ≤ (1 / 6) * (n : ℝ) * (2 : ℝ) ^ n :=
+          mul_le_mul_of_nonneg_right (hN₀ n hnN0) h2pos.le
+      _ = (1 / 3) * (hypercubeEdges n : ℝ) := by rw [hEreal]
+      _ ≤ (Nat.card H.edgeSet : ℝ) := hd
+  exact (hasC2k_three_iff_hasC6 H).mp (hforce n hn10 H hbound)
+
 /-
-**This generalization remains open.**
+**The genuine open problem is the `k ≥ 4` restriction** (see
+`generalizedConjecture_false`): the `∀ k ≥ 3` form above is refuted at `k = 3`, but no
+constant-fraction `C₂ₖ`-free construction is known for `k ≥ 4`, so that case remains open.
 -/
 
 /-


### PR DESCRIPTION
## Summary

Erdős #666 (C₆ in hypercube subgraphs) is already complete on the C₆ side (0 sorries, 1 deep axiom `conder_no_threshold`). This PR adds a genuinely new theorem and **corrects an incorrect narrative claim** in the file.

### The correction
The docstring on `generalizedConjecture_three_forces_c6` claimed the C₆ refutation "does **not** transfer" to the generalized `C_{2k}` conjecture *because* its `n^a·2ⁿ` density threshold is sparser. That reasoning is backwards: a **sparser (smaller) threshold makes the forcing statement stronger**, hence *easier* to refute — not harder.

### The new theorem: `generalizedConjecture_false : ¬ GeneralizedConjecture`
The `GeneralizedConjecture` as literally stated (`∀ k ≥ 3`) is **false**, refuted at its `k = 3` instance:
- At `k = 3` the threshold `c·nᵃ·2ⁿ` (`a < 1`) is *sub-linear* in `n·2ⁿ` — a **vanishing** fraction of the `≈ n·2ⁿ⁻¹` edges.
- Conder's construction (`conder_no_threshold`) supplies, for arbitrarily large `n`, a C₆-free subgraph carrying a **constant** fraction `1/3` of all edges, i.e. `(1/6)·n·2ⁿ`.
- Since `n / nᵃ = n^{1-a} → ∞`, for large `n` this constant-fraction count dominates the sub-linear threshold, so Conder's C₆-free subgraph already exceeds it — refuting the `k = 3` forcing claim, hence the whole `∀ k ≥ 3` conjecture.

The honest open problem is therefore the **`k ≥ 4` restriction**, where `ex(Qₙ, C₂ₖ)` is genuinely believed sub-linear and no constant-fraction `C₂ₖ`-free construction is known.

### Proof ingredients (no new axioms)
- Single existing axiom `conder_no_threshold` (via its unbounded-`n` form `conder_counterexamples_unbounded`).
- Elementary growth fact `n^{1-a} → ∞` (`tendsto_rpow_atTop` ∘ `tendsto_natCast_atTop_atTop`).
- New helper `epsilonDense_card_ge` isolating the `EpsilonDenseSubgraph` unfold so `Nat.card edgeSet` and `HasCycle` never co-unfold in one type (avoids the documented v4.26 elaborator crash).

### Verification
- `docker-build.sh Proofs.Erdos666Problem`: **green** (7743 jobs).
- `#print axioms generalizedConjecture_false` → `[propext, Classical.choice, Erdos666.conder_no_threshold, Quot.sound]` — **no new axioms**, no `sorryAx`/`ofReduceBool`.
- Counts: 0 sorries, 1 axiom (unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)