### PR TITLE
research(brouwer-fixed-point-oq-02-oq-02-oq-01): sharpness of a priori & a posteriori error constants [VERIFIED]

### DIFF
--- a/proofs/Proofs/BrouwerFixedPointOQ02OQ02OQ01.lean
+++ b/proofs/Proofs/BrouwerFixedPointOQ02OQ02OQ01.lean
@@ -837,4 +837,102 @@ theorem displacement_le_path_length (x : ℕ → ℝ) (n m : ℕ) :
       = |∑ k ∈ Finset.range m, (x (n + k + 1) - x (n + k))| := by rw [htel]
     _ ≤ ∑ k ∈ Finset.range m, |x (n + k + 1) - x (n + k)| := Finset.abs_sum_le_sum_abs _ _
 
+/-! ### Sharpness of the estimate constants (the affine contraction is extremal)
+
+The upper bounds `apriori_estimate` (`|xₙ − x*| ≤ Lⁿ/(1−L)·|x₁ − x₀|`) and
+`aposteriori_estimate` (`|xₙ₊₁ − x*| ≤ L/(1−L)·|xₙ₊₁ − xₙ|`) carry the derived
+constants `Lⁿ/(1−L)` and `L/(1−L)`.  `iterate_dist_sharp` certifies only the *raw*
+geometric factor `Lⁿ` of `iterate_dist`; it says nothing about these two constants.
+The affine contraction `f t = L·t` — the extremal `L`-contraction, meeting
+`|f a − f b| = L·|a − b|` with equality — attains **both** estimate constants at
+once: its iterates `xₙ = Lⁿ·x₀` about the fixed point `0` satisfy the a priori and
+a posteriori bounds with *equality* at every step.  Indeed `|xₙ − 0| = Lⁿ|x₀|`,
+while `|x₁ − x₀| = (1−L)|x₀|` and `|xₙ₊₁ − xₙ| = Lⁿ(1−L)|x₀|`, so both right-hand
+sides collapse to `Lⁿ|x₀|` and `Lⁿ⁺¹|x₀|` respectively.  Hence neither
+`Lⁿ/(1−L)` nor `L/(1−L)` can be lowered: the estimate suite is constant-optimal. -/
+
+/-- **Sharpness of the a priori constant.**  The affine contraction `f t = L·t`
+    (an `L`-contraction with fixed point `0`) and its iterates `xₙ = Lⁿ·x₀` meet
+    the a priori estimate `|xₙ − x*| ≤ Lⁿ/(1−L)·|x₁ − x₀|` with **equality** for
+    every `n`, so the constant `Lⁿ/(1−L)` in `apriori_estimate` is optimal. -/
+theorem apriori_estimate_sharp (L : ℝ) (hL0 : 0 ≤ L) (hL1 : L < 1) (x0 : ℝ)
+    (f : ℝ → ℝ) (hf : f = fun t => L * t)
+    (x : ℕ → ℝ) (hxdef : x = fun n => L ^ n * x0) :
+    (∀ a b, |f a - f b| ≤ L * |a - b|) ∧
+      (∀ n, x (n + 1) = f (x n)) ∧
+      f 0 = 0 ∧
+      ∀ n, |x n - (0 : ℝ)| = L ^ n / (1 - L) * |x 1 - x 0| := by
+  have h1L : (0 : ℝ) < 1 - L := by linarith
+  have h1Lne : (1 - L) ≠ 0 := ne_of_gt h1L
+  subst hf hxdef
+  refine ⟨?_, ?_, ?_, ?_⟩
+  · intro a b
+    show |L * a - L * b| ≤ L * |a - b|
+    rw [← mul_sub, abs_mul, abs_of_nonneg hL0]
+  · intro n
+    show L ^ (n + 1) * x0 = L * (L ^ n * x0)
+    rw [pow_succ]; ring
+  · show L * 0 = 0
+    ring
+  · intro n
+    show |L ^ n * x0 - 0| = L ^ n / (1 - L) * |L ^ 1 * x0 - L ^ 0 * x0|
+    rw [sub_zero, abs_mul, abs_of_nonneg (pow_nonneg hL0 n)]
+    have hchord : |L ^ 1 * x0 - L ^ 0 * x0| = (1 - L) * |x0| := by
+      rw [pow_one, pow_zero, one_mul,
+        show L * x0 - x0 = -((1 - L) * x0) by ring, abs_neg, abs_mul,
+        abs_of_nonneg (le_of_lt h1L)]
+    rw [hchord]
+    field_simp
+
+/-- **Sharpness of the a posteriori constant.**  The same affine contraction
+    `f t = L·t` and its iterates `xₙ = Lⁿ·x₀` meet the a posteriori estimate
+    `|xₙ₊₁ − x*| ≤ L/(1−L)·|xₙ₊₁ − xₙ|` with **equality** for every `n`, so the
+    constant `L/(1−L)` in `aposteriori_estimate` is optimal. -/
+theorem aposteriori_estimate_sharp (L : ℝ) (hL0 : 0 ≤ L) (hL1 : L < 1) (x0 : ℝ)
+    (f : ℝ → ℝ) (hf : f = fun t => L * t)
+    (x : ℕ → ℝ) (hxdef : x = fun n => L ^ n * x0) :
+    (∀ a b, |f a - f b| ≤ L * |a - b|) ∧
+      (∀ n, x (n + 1) = f (x n)) ∧
+      f 0 = 0 ∧
+      ∀ n, |x (n + 1) - (0 : ℝ)| = L / (1 - L) * |x (n + 1) - x n| := by
+  have h1L : (0 : ℝ) < 1 - L := by linarith
+  have h1Lne : (1 - L) ≠ 0 := ne_of_gt h1L
+  subst hf hxdef
+  refine ⟨?_, ?_, ?_, ?_⟩
+  · intro a b
+    show |L * a - L * b| ≤ L * |a - b|
+    rw [← mul_sub, abs_mul, abs_of_nonneg hL0]
+  · intro n
+    show L ^ (n + 1) * x0 = L * (L ^ n * x0)
+    rw [pow_succ]; ring
+  · show L * 0 = 0
+    ring
+  · intro n
+    show |L ^ (n + 1) * x0 - 0| = L / (1 - L) * |L ^ (n + 1) * x0 - L ^ n * x0|
+    rw [sub_zero, abs_mul, abs_of_nonneg (pow_nonneg hL0 (n + 1))]
+    have hincr : |L ^ (n + 1) * x0 - L ^ n * x0| = L ^ n * (1 - L) * |x0| := by
+      rw [show L ^ (n + 1) * x0 - L ^ n * x0 = -(L ^ n * (1 - L) * x0) by rw [pow_succ]; ring,
+        abs_neg, abs_mul, abs_mul, abs_of_nonneg (pow_nonneg hL0 n),
+        abs_of_nonneg (le_of_lt h1L)]
+    rw [hincr]
+    field_simp; ring
+
+/-- **Both estimate constants are attained by one map.**  Consequence of
+    `apriori_estimate_sharp` and `aposteriori_estimate_sharp`: the single affine
+    contraction `f t = L·t` (iterates `Lⁿ·x₀`, fixed point `0`) attains the a
+    priori constant `Lⁿ/(1−L)` and the a posteriori constant `L/(1−L)`
+    simultaneously — so the estimate suite's constants are jointly optimal. -/
+theorem estimate_constants_sharp (L : ℝ) (hL0 : 0 ≤ L) (hL1 : L < 1) (x0 : ℝ) :
+    ∃ (f : ℝ → ℝ) (x : ℕ → ℝ),
+      (∀ a b, |f a - f b| ≤ L * |a - b|) ∧ f 0 = 0 ∧
+      (∀ n, x (n + 1) = f (x n)) ∧
+      (∀ n, |x n - (0 : ℝ)| = L ^ n / (1 - L) * |x 1 - x 0|) ∧
+      (∀ n, |x (n + 1) - (0 : ℝ)| = L / (1 - L) * |x (n + 1) - x n|) := by
+  refine ⟨fun t => L * t, fun n => L ^ n * x0, ?_, ?_, ?_, ?_, ?_⟩
+  · exact (apriori_estimate_sharp L hL0 hL1 x0 _ rfl _ rfl).1
+  · exact (apriori_estimate_sharp L hL0 hL1 x0 _ rfl _ rfl).2.2.1
+  · exact (apriori_estimate_sharp L hL0 hL1 x0 _ rfl _ rfl).2.1
+  · exact (apriori_estimate_sharp L hL0 hL1 x0 _ rfl _ rfl).2.2.2
+  · exact (aposteriori_estimate_sharp L hL0 hL1 x0 _ rfl _ rfl).2.2.2
+
 end BrouwerOQ02OQ02OQ01

--- a/src/data/research/problems/brouwer-fixed-point-oq-02-oq-02-oq-01.json
+++ b/src/data/research/problems/brouwer-fixed-point-oq-02-oq-02-oq-01.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "SOLVED (37 thm, 0 axiom, 0 sorry): added tail/windowed arc-length bound + arc-dominates-chord bridge to the mature Banach error suite",
+    "progressSummary": "SOLVED (40 thm, 0 axiom, 0 sorry): added sharpness of BOTH a priori Lⁿ/(1-L) and a posteriori L/(1-L) constants — affine contraction f(t)=L·t attains both with equality; constants are optimal (estimate_constants_sharp)",
     "builtItems": [
       "BrouwerFixedPointOQ02OQ02OQ01.lean: 6 theorems, 0 axioms (propext/Classical.choice/Quot.sound only), 0 sorries. Self-contained: contraction given as ∀ x y, |f x − f y| ≤ L·|x − y| with f x* = x* and xₙ₊₁ = f xₙ.",
       "iterate_dist: |xₙ − x*| ≤ Lⁿ·|x₀ − x*| (geometric decay, induction; reproves parent's bound self-containedly).",
@@ -42,7 +42,10 @@
       "BrouwerFixedPointOQ02OQ02OQ01.lean: exists_fixed_point + exists_unique_fixed_point (Banach existence & existence-uniqueness on ℝ). Now 14 theorems, 0 axioms, 0 sorries. Elaboration-clean; olean-write blocked by fleet SIGBUS-135.",
       "BrouwerFixedPointOQ02OQ02OQ01.lean: +2 thms aposteriori_lower_estimate (+_unconditional) — two-sided a posteriori residual control",
       "tail_path_length_bound in BrouwerFixedPointOQ02OQ02OQ01.lean",
-      "displacement_le_path_length in BrouwerFixedPointOQ02OQ02OQ01.lean"
+      "displacement_le_path_length in BrouwerFixedPointOQ02OQ02OQ01.lean",
+      "apriori_estimate_sharp (BrouwerFixedPointOQ02OQ02OQ01.lean): affine witness attains Lⁿ/(1-L) with equality ∀n — a priori constant optimal",
+      "aposteriori_estimate_sharp (BrouwerFixedPointOQ02OQ02OQ01.lean): affine witness attains L/(1-L) with equality ∀n — a posteriori constant optimal",
+      "estimate_constants_sharp (BrouwerFixedPointOQ02OQ02OQ01.lean): packaged existential — one map attains both constants simultaneously; suite is constant-optimal"
     ],
     "insights": [
       "Parent oq-02-oq-02 proves the bound |xₙ − x*| ≤ Lⁿ·|x₀ − x*| which is not directly usable (|x₀ − x*| unknown). The classical fix is the a priori estimate, expressing the bound via the computable first increment |x₁ − x₀|.",
@@ -54,12 +57,12 @@
       "Discharged the one standing gap (researcher-2, 2026-07-09): fixed-point EXISTENCE, previously a hypothesis in every estimate. exists_fixed_point: a contraction |f x−f y|≤L|x−y| with 0≤L<1 on the complete space ℝ HAS a fixed point — bridge the raw real-analytic bound to Mathlib's ContractingWith via LipschitzWith.of_dist_le_mul + Real.dist_eq + Real.coe_toNNReal, then ContractingWith.exists_fixedPoint ⟨K<1, LipschitzWith⟩ 0 (edist_ne_top _ _). exists_unique_fixed_point: full Banach existence+uniqueness (pairs it with the existing fixed_point_unique). x* is now a genuine object, not a standing assumption. Elaboration-clean [7743/7743] (olean-write SIGBUS-135, heavy fleet load).",
       "Added a matching a posteriori LOWER bound |x(n+1)-xn|/(1+L) ≤ |xn-x*| (reverse triangle + one-step contraction), making the residual/increment a two-sided proxy for the error. Only 0≤L needed. Prior estimates were all upper bounds.",
       "Tail arc-length bound: ∑_{k<m}|x_{n+k+1}-x_{n+k}| ≤ Lⁿ|x₁-x₀|/(1-L) — generalizes total_path_length_bound (n=0 case); m→∞ limit bounds |xₙ-x*|",
-      "Arc dominates chord (displacement_le_path_length): |x_{n+m}-xₙ| ≤ arc length, pure telescoping (Finset.sum_range_sub + abs_sum_le_sum_abs); combined with tail_path_length_bound re-derives cauchy_estimate as chord≤arc≤geometric tail"
+      "Arc dominates chord (displacement_le_path_length): |x_{n+m}-xₙ| ≤ arc length, pure telescoping (Finset.sum_range_sub + abs_sum_le_sum_abs); combined with tail_path_length_bound re-derives cauchy_estimate as chord≤arc≤geometric tail",
+      "SHARPNESS: the affine contraction f(t)=L·t (extremal L-contraction, |fa-fb|=L|a-b|) with iterates xₙ=Lⁿ·x₀ about fixed point 0 attains BOTH estimate constants with equality: |xₙ-x*|=Lⁿ/(1-L)·|x₁-x₀| and |xₙ₊₁-x*|=L/(1-L)·|xₙ₊₁-xₙ| for every n. Key: |x₁-x₀|=(1-L)|x₀| and |xₙ₊₁-xₙ|=Lⁿ(1-L)|x₀|, cancelling the (1-L) denominators. Prior iterate_dist_sharp certified only the raw Lⁿ factor, not the derived /(1-L) constants."
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "DONE (researcher-2): fixed-point existence discharged (exists_fixed_point / exists_unique_fixed_point) — the standing gap is closed.",
-      "Optional: make apriori_estimate / aposteriori_estimate UNCONDITIONAL by threading exists_fixed_point (drop the x* hypothesis from their statements)."
+      "Sharpness of both estimate constants now certified (apriori/aposteriori). Suite is constant-optimal. Optional future: sharpness of the a posteriori LOWER constant 1/(1+L), or an order-of-convergence (eₙ₊₁/eₙ→L) characterization."
     ]
   },
   "tags": [
@@ -462,5 +465,5 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BrouwerFixedPointOQ04OQ04.lean"
     }
   ],
-  "lastUpdate": "2026-07-09"
+  "lastUpdate": "2026-07-12"
 }


### PR DESCRIPTION
## Summary

Problem **brouwer-fixed-point-oq-02-oq-02-oq-01** — *a priori / a posteriori error estimates for contraction iteration* — is a mature, SOLVED suite (0 axiom, 0 sorry). Its two workhorse bounds carry derived constants:

- **a priori**: `|xₙ − x*| ≤ Lⁿ/(1−L)·|x₁ − x₀|`
- **a posteriori**: `|xₙ₊₁ − x*| ≤ L/(1−L)·|xₙ₊₁ − xₙ|`

The pre-existing `iterate_dist_sharp` certifies only the **raw** geometric factor `Lⁿ` of `iterate_dist`; it says nothing about whether the *derived* constants `Lⁿ/(1−L)` and `L/(1−L)` in the actual estimates can be lowered. This PR closes that gap by exhibiting a witness that attains **both** with equality.

## What's added (3 theorems, 37 → 40)

- `apriori_estimate_sharp` — the affine contraction `f(t)=L·t` (the extremal `L`-contraction, `|f a − f b| = L·|a − b|`) with iterates `xₙ = Lⁿ·x₀` about fixed point `0` meets the a priori bound with **equality** for every `n`. Hence `Lⁿ/(1−L)` is optimal.
- `aposteriori_estimate_sharp` — the same witness meets the a posteriori bound with **equality** for every `n`. Hence `L/(1−L)` is optimal.
- `estimate_constants_sharp` — packaged existential: a single map attains both constants simultaneously, so the suite's constants are jointly optimal.

## Mechanism

`|x₁ − x₀| = (1−L)|x₀|` and `|xₙ₊₁ − xₙ| = Lⁿ(1−L)|x₀|` cancel the `(1−L)` denominators against `|xₙ − x*| = Lⁿ|x₀|` and `|xₙ₊₁ − x*| = Lⁿ⁺¹|x₀|`.

## Verification

- Elaborates with **0 errors, 0 warnings** (`lake env lean`).
- `#print axioms` on all three theorems → `[propext, Classical.choice, Quot.sound]` only (**axiom-free, 0 sorry**).
- Diff is purely additive (98 lines) plus a knowledge-json update; no existing proof touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)