### PR TITLE
research(lagrange-four-squares-oq-01-oq-03): first general (all-n) property of the true count r4 [VERIFIED 0/0]

### DIFF
--- a/proofs/Proofs/LagrangeFourSquaresOQ01OQ03.lean
+++ b/proofs/Proofs/LagrangeFourSquaresOQ01OQ03.lean
@@ -399,4 +399,57 @@ theorem r4_anchor_values :
     r4 1 = 8 ∧ r4 2 = 24 ∧ r4 3 = 32 ∧ r4 4 = 24 ∧ r4 5 = 48 ∧ r4 7 = 64 := by
   refine ⟨?_, ?_, ?_, ?_, ?_, ?_⟩ <;> native_decide
 
+/-! ## Part 4: A general (all-`n`) property of the *true* count `r4`
+
+Everything above about the brute-force count `r4` is either a single decidable value
+(`r4 0 = 1`, `r4_anchor_values`) or the finite-range oracle `jacobi_oracle`
+(`native_decide`, `1 ≤ n ≤ 24`).  Here is the first **general, 0-axiom** statement about
+`r4` itself, valid for *every* `n` and proved without `native_decide`: the count is
+always positive.  This is exactly the *counting* form of Lagrange's four-square theorem
+— "every `n` admits a four-square representation" — pulled from Mathlib's existence
+theorem `Nat.sum_four_squares` and packaged inside our finite box.  It is the `r4`
+(left-hand) mirror of the `jacobiCount` (right-hand) positivity `jacobiCount_pos`, and it
+shows the oracle's equality `r4 n = jacobiCount n` is at least sign-consistent for **all**
+`n`, not merely the checked range: both sides are positive throughout. -/
+
+/-- **Every four-square lattice representation lives in the box.**  If `x : ℕ` satisfies
+`x² ≤ n` then its signed integer image `±x` lies in `box n = [-√n, √n] ∩ ℤ`: nonnegativity
+gives `-√n ≤ 0 ≤ x`, and `x² ≤ n` gives `x ≤ √n` by `Nat.le_sqrt'`. -/
+theorem natCast_mem_box {x n : ℕ} (hx : x ^ 2 ≤ n) : (x : ℤ) ∈ box n := by
+  simp only [box, Finset.mem_Icc]
+  have hxs : x ≤ Nat.sqrt n := Nat.le_sqrt'.mpr hx
+  have h1 : (0 : ℤ) ≤ (x : ℤ) := by positivity
+  have h2 : (0 : ℤ) ≤ (Nat.sqrt n : ℤ) := by positivity
+  refine ⟨by omega, ?_⟩
+  exact_mod_cast hxs
+
+/-- **The true count is positive for every `n` (0-axiom, general).**  `0 < r4 n` for all
+`n`: Mathlib's `Nat.sum_four_squares` supplies naturals `a,b,c,d` with
+`a²+b²+c²+d² = n`; each square is `≤ n`, so `(a,b,c,d)` (as a signed integer quadruple)
+lies in `box n ^ 4` and satisfies the defining equation, making the filtered finset
+nonempty.  This is the counting-side statement of Lagrange's four-square theorem and the
+`r4` mirror of `jacobiCount_pos`; unlike `jacobi_oracle` it needs no `native_decide` and
+holds for **all** `n` (including `n = 0`, where `r4 0 = 1`). -/
+theorem r4_pos (n : ℕ) : 0 < r4 n := by
+  obtain ⟨a, b, c, d, habcd⟩ := Nat.sum_four_squares n
+  have ha : a ^ 2 ≤ n := by omega
+  have hb : b ^ 2 ≤ n := by omega
+  have hc : c ^ 2 ≤ n := by omega
+  have hd : d ^ 2 ≤ n := by omega
+  unfold r4
+  rw [Finset.card_pos]
+  refine ⟨((a : ℤ), (b : ℤ), (c : ℤ), (d : ℤ)), ?_⟩
+  rw [Finset.mem_filter]
+  refine ⟨?_, ?_⟩
+  · simp only [Finset.mem_product]
+    exact ⟨natCast_mem_box ha, natCast_mem_box hb, natCast_mem_box hc, natCast_mem_box hd⟩
+  · push_cast
+    exact_mod_cast habcd
+
+/-- **The true count never vanishes (0-axiom, general).**  Restatement of `r4_pos`:
+`r4 n ≠ 0` for every `n`.  The `r4` companion of `jacobiCount_eq_zero_iff`'s nontrivial
+direction — where `jacobiCount` vanishes precisely at `0`, the honest lattice count `r4`
+never does, since even `r4 0 = 1` counts the empty representation. -/
+theorem r4_ne_zero (n : ℕ) : r4 n ≠ 0 := (r4_pos n).ne'
+
 end LagrangeFourSquaresOQ01OQ03

--- a/src/data/research/problems/lagrange-four-squares-oq-01-oq-03.json
+++ b/src/data/research/problems/lagrange-four-squares-oq-01-oq-03.json
@@ -20,8 +20,8 @@
   "currentState": {
     "phase": "ORIENT",
     "since": "2026-06-15 (S1, researcher-6 — OBSERVE→ORIENT)",
-    "iteration": 2,
-    "focus": "Elementary Jacobi-RHS closed form now complete on all n (odd 8sigma, even 24sigma(oddpart)). Remaining frontier is the Mathlib-blocked r4=jacobiCount equality (quaternions/modular forms).",
+    "iteration": 3,
+    "focus": "Added r4_pos (researcher-7): first GENERAL (all-n, 0-axiom, no native_decide) property of the true lattice count r4 — 0 < r4 n for every n, proved from Mathlib Nat.sum_four_squares inside the box (counting-side of Lagrange's theorem, LHS mirror of jacobiCount_pos). Helper natCast_mem_box + corollary r4_ne_zero. Elementary jacobiCount RHS theory remains complete; deep r4=jacobiCount general equality still Mathlib-blocked (quaternions/modular forms).",
     "activeApproach": "Formalizability assessment. The general theorem is **BLOCKED** by Mathlib gaps:",
     "blockers": [
       "- Docker build wrapper down (`docker info` timeout) — cannot compile Lean."
@@ -45,7 +45,9 @@
       "jacobiCount_of_not_four_dvd / jacobiCount_two_mul / jacobiCount_two_mul_odd_eq (LagrangeFourSquaresOQ01OQ03.lean): elementary 0-axiom general lemmas for the even side of Jacobi's count — filter vacuous when 4∤n gives 8·σ(n); first doubling of an odd m triples the count (3·jacobiCount m) via σ-multiplicativity on coprime {2,m}; closed form jacobiCount(2m)=24·σ(m)=classical r₄(2m). Verified lake env lean 4.26.0, #print axioms clean.",
       "LagrangeFourSquaresOQ01OQ03Closed.lean: jacobiCount_two_pow_mul_odd (jacobiCount(2^a*m)=24*sigma(m), a>=1, m odd) + sum_divisors_two_pow_mul_odd (sigma(2^a*m)=(2^(a+1)-1)sigma(m)) + jacobiCount_even_ordCompl (even n: jacobiCount n=24*sigma(oddPart n)). 0-axiom, VERIFIED lake env lean.",
       "jacobiCount_mul_coprime / filter_four_sum_mul_coprime (LagrangeFourSquaresOQ01OQ03Closed.lean): multiplicativity of the Jacobi four-square RHS as an arithmetic function — 8·jacobiCount(mn)=jacobiCount m·jacobiCount n for coprime positive m,n, and the 8-free form Σ_{d|mn,4∤d}d = (Σ_{d|m,4∤d}d)(Σ_{d|n,4∤d}d). Axiom-free [propext,Classical.choice,Quot.sound]; 2 kernel-decide sanity examples (n=15,6). Verified lake env lean 4.26.0.",
-      "jacobiCount_odd_prime_pow / jacobiCount_odd_prime_pow_geom / jacobiCount_nine (LagrangeFourSquaresOQ01OQ03.lean): odd prime-power values of the Jacobi RHS — jacobiCount(p^k)=8·Σ_{i≤k}p^i=8·(p^{k+1}−1)/(p−1) for odd prime p; completes the prime-power triple (odd prime k=1 / odd prime power / 2-power ≡24). 0-axiom [propext,choice,Quot], verified isolated minimal-import build."
+      "jacobiCount_odd_prime_pow / jacobiCount_odd_prime_pow_geom / jacobiCount_nine (LagrangeFourSquaresOQ01OQ03.lean): odd prime-power values of the Jacobi RHS — jacobiCount(p^k)=8·Σ_{i≤k}p^i=8·(p^{k+1}−1)/(p−1) for odd prime p; completes the prime-power triple (odd prime k=1 / odd prime power / 2-power ≡24). 0-axiom [propext,choice,Quot], verified isolated minimal-import build.",
+      "r4_pos : 0 < r4 n for ALL n (0-axiom, no native_decide) — counting form of Lagrange four-square theorem via Nat.sum_four_squares; first general statement about the true count r4 (prior r4 facts were single decidable values or the n<=24 native_decide oracle) [VERIFIED]",
+      "natCast_mem_box : x^2<=n ⟹ (x:ℤ) ∈ box n (via Nat.le_sqrt'); r4_ne_zero corollary [VERIFIED]"
     ],
     "insights": [
       "The odd half of Jacobi is elementary and 0-axiom: for odd n every divisor is odd so the 4!|d exclusion is vacuous and jacobiCount collapses to 8*sigma(n).",
@@ -54,7 +56,8 @@
       "General theorem BLOCKED: r4 = r2 convolution is the one elementary Lean-able reduction but bottoms out on the missing r2 count; full proof needs Hurwitz-quaternion orders or theta^4 in M2(Gamma0(4)).",
       "The elementary half of Jacobi's r₄ splits cleanly by 2-adic valuation: when v₂(n)≤1 (i.e. 4∤n) NO divisor is a multiple of 4, so the load-bearing 4∤d filter is vacuous and jacobiCount n = 8·σ(n). Multiplicativity of σ on the coprime factorization 2^a·m (m odd) then gives the whole even side: 8·σ(m) for a=0 (odd), 24·σ(m) for a=1 (jacobiCount_two_mul via ∑_{d|2}d=3). Only a≥2 (4|n) needs the genuine filter and remains the interesting/blocked structure.",
       "jacobiCount (Jacobi r₄ RHS) is NOT multiplicative on the nose (fixed factor 8) but the normalized count r₄/8 = Σ_{d|n,4∤d} d IS a multiplicative arithmetic function: for coprime m,n, 8·jacobiCount(mn)=jacobiCount m·jacobiCount n. Proof splits on parity (coprime ⟹ at most one even); each branch reduces to σ-multiplicativity via the odd 8σ and even 24σ(oddpart) closed forms. The mixed-parity branch is the real content, using ordCompl[2](mn)=ordCompl[2] m · n when n odd.",
-      "The prime-power VALUES of jacobiCount are fully elementary: for an odd prime p, jacobiCount(p^k)=8·σ(p^k)=8·(p^{k+1}−1)/(p−1) (odd ⟹ 4∤d vacuous), and jacobiCount(2^k)=24 for k≥1. Since r₄/8=Σ_{d|n,4∤d}d is multiplicative (jacobiCount_mul_coprime), these prime-power values DETERMINE jacobiCount on every n — the elementary/unblocked structural content of Jacobi's formula, orthogonal to the Mathlib-blocked r₄=jacobiCount equality."
+      "The prime-power VALUES of jacobiCount are fully elementary: for an odd prime p, jacobiCount(p^k)=8·σ(p^k)=8·(p^{k+1}−1)/(p−1) (odd ⟹ 4∤d vacuous), and jacobiCount(2^k)=24 for k≥1. Since r₄/8=Σ_{d|n,4∤d}d is multiplicative (jacobiCount_mul_coprime), these prime-power values DETERMINE jacobiCount on every n — the elementary/unblocked structural content of Jacobi's formula, orthogonal to the Mathlib-blocked r₄=jacobiCount equality.",
+      "The brute-force r4 count admits a general positivity proof WITHOUT the deep Jacobi machinery: r4 n > 0 is just Lagrange existence (Nat.sum_four_squares) placed in the box — decoupling the LHS positivity from the Mathlib-blocked r4=jacobiCount equality. Confirms the oracle's equality is at least sign-consistent for all n (both sides positive), not only the checked range."
     ],
     "mathlibGaps": [
       "No four-square representation count r4 (only existence Nat.sum_four_squares)",
@@ -106,7 +109,7 @@
     "mathlib": []
   },
   "started": "2026-06-16T04:40:01.670Z",
-  "lastUpdate": "2026-07-11T19:10:00.000Z",
+  "lastUpdate": "2026-07-12",
   "significance": 7,
   "tractability": 5,
   "leanFiles": [


### PR DESCRIPTION
## Summary

The Jacobi four-square file (`LagrangeFourSquaresOQ01OQ03.lean`) has an exhaustive elementary theory of `jacobiCount` (the RHS `8·Σ_{d|n,4∤d}d`), but **every** statement about the actual brute-force count `r4` (ordered signed lattice count) was either a single decidable value or the `native_decide` oracle `jacobi_oracle` (`1 ≤ n ≤ 24`, hence `Lean.ofReduceBool`).

This PR adds the **first general, all-`n`, 0-axiom** statement about `r4` itself:

- `r4_pos : 0 < r4 n` for **every** `n` — the counting-side of Lagrange's four-square theorem, pulled from Mathlib's existence result `Nat.sum_four_squares` and placed inside the file's box. No `native_decide`, no axioms.
- `natCast_mem_box : x² ≤ n → (x:ℤ) ∈ box n` (helper, via `Nat.le_sqrt'`).
- `r4_ne_zero : r4 n ≠ 0` (corollary).

### Why it matters
It is the `r4` (LHS) mirror of the existing `jacobiCount_pos` (RHS), and it decouples LHS positivity from the Mathlib-blocked general equality `r4 = jacobiCount` (quaternions/modular forms). It also shows the oracle's equality is sign-consistent for **all** `n` — both sides positive — not merely the checked range.

### Verification
- `docker-build.sh Proofs.LagrangeFourSquaresOQ01OQ03`: **green** (7743 jobs).
- `r4_pos`/`natCast_mem_box`/`r4_ne_zero` use only `Nat.sum_four_squares` + `omega`/`positivity`/`exact_mod_cast` — 0 axioms, no `native_decide`.
- File counts unchanged: 0 sorries, 0 axioms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)