### PR TITLE
Research: erdos-748-incomplete-01 - extremal max sum-free size = ⌈n/2⌉

### DIFF
--- a/proofs/Proofs/Erdos748Problem.lean
+++ b/proofs/Proofs/Erdos748Problem.lean
@@ -703,6 +703,85 @@ theorem exists_sumFree_card_ceil (n : ℕ) :
   · -- `|U| = n − ⌊n/2⌋ = ⌈n/2⌉ = (n+1)/2`.
     rw [hU, Nat.card_Icc]; omega
 
+/-- **No sum-free subset exceeds `⌈n/2⌉` (the extremal upper bound).**  Every sum-free
+`A ⊆ {1,…,n}` has `|A| ≤ ⌈n/2⌉ = (n+1)/2`.  This is the matching upper bound for
+`exists_sumFree_card_ceil`, and it is *elementary* — the classical Erdős difference-set
+argument, not the deep counting of `green_upper_bound`.  Let `m = max A`.  The difference
+set `D = {m − a : a ∈ A, a ≠ m}` is disjoint from `A` (if `m − a ∈ A` then `m = (m−a) + a`
+with all three terms in `A`, contradicting sum-freeness) and has `|D| = |A| − 1` (subtraction
+is injective on `[1,m]`), and both `A, D ⊆ {1,…,m}`.  Hence `|A| + (|A| − 1) ≤ m ≤ n`, i.e.
+`2|A| − 1 ≤ n`, giving `|A| ≤ (n+1)/2`.  Axiom-free; complements the "achievable" direction and
+discharges the Part VII claim that the maximum sum-free size is `⌈n/2⌉`. -/
+theorem sumFree_card_le_ceil {n : ℕ} {A : Finset ℕ}
+    (hsub : A ⊆ Finset.Icc 1 n) (hsf : IsSumFree A) :
+    A.card ≤ (n + 1) / 2 := by
+  rcases A.eq_empty_or_nonempty with rfl | hne
+  · simp
+  set m := A.max' hne with hm
+  have hmA : m ∈ A := A.max'_mem hne
+  have hmle : m ≤ n := by
+    have := hsub hmA; rw [Finset.mem_Icc] at this; exact this.2
+  have hle_m : ∀ a ∈ A, a ≤ m := fun a ha => A.le_max' a ha
+  have hpos : ∀ a ∈ A, 1 ≤ a := by
+    intro a ha; have := hsub ha; rw [Finset.mem_Icc] at this; exact this.1
+  -- the difference set `D = {m − a : a ∈ A.erase m}`
+  set D : Finset ℕ := (A.erase m).image (fun a => m - a) with hD
+  -- subtraction is injective on `A.erase m` (all elements are `≤ m`)
+  have hinj : Set.InjOn (fun a => m - a) (A.erase m : Set ℕ) := by
+    intro a ha b hb hab
+    rw [Finset.mem_coe] at ha hb
+    have ha' : a ≤ m := hle_m a (Finset.mem_of_mem_erase ha)
+    have hb' : b ≤ m := hle_m b (Finset.mem_of_mem_erase hb)
+    simp only at hab
+    omega
+  -- `A` and `D` are disjoint: `m − a ∈ A` would give `m = (m−a) + a` inside `A`
+  have hdisj : Disjoint A D := by
+    rw [Finset.disjoint_left]
+    intro x hxA hxD
+    rw [hD, Finset.mem_image] at hxD
+    obtain ⟨a, ha, rfl⟩ := hxD
+    have ha' : a ∈ A := Finset.mem_of_mem_erase ha
+    have halt : a < m := lt_of_le_of_ne (hle_m a ha') (Finset.ne_of_mem_erase ha)
+    have hsum : m = (m - a) + a := by omega
+    exact hsf m (m - a) a hmA hxA ha' hsum
+  -- `|D| = |A| − 1`
+  have hcardD : D.card = A.card - 1 := by
+    rw [hD, Finset.card_image_of_injOn hinj, Finset.card_erase_of_mem hmA]
+  -- both `A` and `D` lie in `{1,…,m}`
+  have hDsub : D ⊆ Finset.Icc 1 m := by
+    intro x hx
+    rw [hD, Finset.mem_image] at hx
+    obtain ⟨a, ha, rfl⟩ := hx
+    have ha' : a ∈ A := Finset.mem_of_mem_erase ha
+    have halt : a < m := lt_of_le_of_ne (hle_m a ha') (Finset.ne_of_mem_erase ha)
+    have hpa : 1 ≤ a := hpos a ha'
+    rw [Finset.mem_Icc]; omega
+  have hAsub : A ⊆ Finset.Icc 1 m := fun a ha => by
+    rw [Finset.mem_Icc]; exact ⟨hpos a ha, hle_m a ha⟩
+  -- disjoint union of `A` and `D` fits in `{1,…,m}`, so `2|A| − 1 ≤ m ≤ n`
+  have hunion : A.card + (A.card - 1) ≤ m := by
+    have h1 : A ∪ D ⊆ Finset.Icc 1 m := Finset.union_subset hAsub hDsub
+    have h2 : (A ∪ D).card = A.card + (A.card - 1) := by
+      rw [Finset.card_union_of_disjoint hdisj, hcardD]
+    calc A.card + (A.card - 1) = (A ∪ D).card := h2.symm
+      _ ≤ (Finset.Icc 1 m).card := Finset.card_le_card h1
+      _ = m := by rw [Nat.card_Icc]; omega
+  have hApos : 1 ≤ A.card := Finset.card_pos.mpr hne
+  omega
+
+/-- **The maximum sum-free subset size is exactly `⌈n/2⌉`.**  Packaging
+`exists_sumFree_card_ceil` (achievability) with `sumFree_card_le_ceil` (the extremal upper
+bound), the greatest cardinality attained by a sum-free subset of `{1,…,n}` is precisely
+`⌈n/2⌉ = (n+1)/2`.  This formalizes the Part VII prose claim — "the maximum size of a
+sum-free subset of `[1,n]` is `⌈n/2⌉`" — in full, both directions, axiom-free. -/
+theorem max_sumFree_card_eq_ceil (n : ℕ) :
+    IsGreatest {k | ∃ A ∈ sumFreeSubsets n, A.card = k} ((n + 1) / 2) := by
+  constructor
+  · exact exists_sumFree_card_ceil n
+  · rintro k ⟨A, hA, rfl⟩
+    rw [sumFreeSubsets, Finset.mem_filter, Finset.mem_powerset] at hA
+    exact sumFree_card_le_ceil hA.1 hA.2
+
 /-- **Enlarging the ground set only adds sum-free subsets.**  For `m ≤ n`, every sum-free
 subset of `{1,…,m}` is a sum-free subset of `{1,…,n}`: sum-freeness (`IsSumFree`) is a
 property of the set itself, independent of the ambient range, and `{1,…,m} ⊆ {1,…,n}`.

--- a/src/data/research/problems/erdos-748-incomplete-01.json
+++ b/src/data/research/problems/erdos-748-incomplete-01.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "Saturated RICH file (0 sorries, 2 deep BLOCKED axioms Green/Sapozhenko). Session (researcher-3, 2026-07-11): added oddNumbers_card (|O| = (n+1)/2 = ⌈n/2⌉, by induction) and oddFamily_lower_bound_ceil (f(n) ≥ 2^{⌈n/2⌉} via the ODD family, distinct construction from sharp_lower_bound). Together they discharge the prose-only '|O| = ⌈n/2⌉' claim in oddFamily_lower_bound. 0 new axioms. VERIFIED axiom-free ([propext,Classical.choice,Quot.sound]) via `lake env lean` against prebuilt mathlib oleans, exit 0. Prior session (researcher-2, 2026-07-09): two_family_bound_gt_upperHalf.",
+    "progressSummary": "PROGRESS (researcher-1, 2026-07-12, VERIFIED axiom-free): completed the maximum-sum-free-size characterization. sumFree_card_le_ceil proves the extremal UPPER bound |A|≤⌈n/2⌉ for any sum-free A⊆[1,n] via the elementary Erdős difference-set argument (previously deferred in the Part VII docstring as the classical hard direction — it is elementary, not the deep green_upper_bound). max_sumFree_card_eq_ceil packages it with the existing achievability (exists_sumFree_card_ceil) into IsGreatest {|A|} = (n+1)/2. Both depend only on [propext,Classical.choice,Quot.sound] — independent of the 2 deep BLOCKED axioms (Green 2004 / Sapozhenko 2003). 0 new axioms. File still 2 axioms (both deep asymptotic, genuinely blocked, out of single-session scope).",
     "builtItems": [
       "Proved trivial_lower_bound in Erdos748Problem.lean: U.powerset ⊆ sumFreeSubsets n ⇒ f n ≥ 2^|U| ≥ 2^{⌊n/2⌋}",
       "Added decidableIsSumFree instance (sum-free predicate is decidable via bounded ∀∈A form)",
@@ -39,13 +39,16 @@
       "two_family_bound_ge_upperHalf: the two-family lower bound 2^|O|+2^|U|-2^|O∩U| ≥ 2^|U| (dominates sharp_lower_bound), formalising the prose domination claim. Erdos748Problem.lean.",
       "two_family_bound_gt_upperHalf (Erdos748Problem.lean): strict version of two_family_bound_ge_upperHalf for n≥3 — formalizes the prose strictness claim in two_family_lower_bound. Witness 1∈O\\U ⇒ O∩U⊊O ⇒ 2^|O∩U|<2^|O| ⇒ RHS > 2^⌈n/2⌉.",
       "oddNumbers_card (Erdos748Problem.lean, VERIFIED axiom-free): |O| = (n+1)/2 = ⌈n/2⌉ — exact size of the odd family in [1,n], by induction on n (Finset.range_add_one + filter_insert + card_insert_of_notMem, omega on the ⌈·⌉ increment). Discharges the previously prose-only '|O| = ⌈n/2⌉' claim in oddFamily_lower_bound.",
-      "oddFamily_lower_bound_ceil (Erdos748Problem.lean, VERIFIED axiom-free): f(n) ≥ 2^{⌈n/2⌉} via the ODD family, a genuinely distinct witnessing construction from sharp_lower_bound's upper half. Follows by rewriting oddFamily_lower_bound with oddNumbers_card."
+      "oddFamily_lower_bound_ceil (Erdos748Problem.lean, VERIFIED axiom-free): f(n) ≥ 2^{⌈n/2⌉} via the ODD family, a genuinely distinct witnessing construction from sharp_lower_bound's upper half. Follows by rewriting oddFamily_lower_bound with oddNumbers_card.",
+      "sumFree_card_le_ceil (Erdos748Problem.lean, VERIFIED axiom-free): every sum-free A⊆{1,…,n} has |A|≤⌈n/2⌉=(n+1)/2 — the EXTREMAL UPPER BOUND via the elementary Erdős difference-set argument (m=max A; D={m−a:a∈A,a≠m} disjoint from A since m−a∈A ⇒ m=(m−a)+a violates sum-freeness; |D|=|A|−1; A,D⊆[1,m] ⇒ 2|A|−1≤m≤n). Discharges the Part VII docstring gap that called this the classical hard direction (it is elementary, NOT the deep green_upper_bound).",
+      "max_sumFree_card_eq_ceil (Erdos748Problem.lean, VERIFIED axiom-free): IsGreatest {|A| : A sum-free ⊆[1,n]} = ⌈n/2⌉ — packages exists_sumFree_card_ceil (achievable) + sumFree_card_le_ceil (upper bound) into the full both-directions characterization of the maximum sum-free subset size."
     ],
     "insights": [
       "The trivial lower bound needs no analysis: every subset of the upper half {⌊n/2⌋+1,…,n} is sum-free (upperHalf_sumFree), giving 2^{n-⌊n/2⌋} ≥ 2^{⌊n/2⌋} distinct sum-free sets",
       "File was broken against mathlib v4.26.0: stale Asymptotics import, .1/.2 mixups in upperHalf_sumFree and sumFree_iff, missing DecidablePred IsSumFree, le_div_iff→le_div_iff₀, orphan /-- doc comments",
       "The small values f(1)=2, f(2)=3, f(3)=6 (counts of sum-free subsets of {1,…,n}) are provable by kernel `decide` (axiom-free, no native_decide/ofReduceBool needed) thanks to the bounded-quantifier decidableIsSumFree instance.",
-      "The two dominant sum-free families (odds O, upper-half U) count STRICTLY more together than U alone for all n≥3: 1 is odd and below n/2+1, so O∩U⊊O and the surplus 2^|O|−2^|O∩U| is positive. Names verified vs pinned Mathlib: Finset.ssubset_iff_of_subset, Finset.mem_of_mem_inter_right, Finset.card_lt_card, Nat.pow_lt_pow_right."
+      "The two dominant sum-free families (odds O, upper-half U) count STRICTLY more together than U alone for all n≥3: 1 is odd and below n/2+1, so O∩U⊊O and the surplus 2^|O|−2^|O∩U| is positive. Names verified vs pinned Mathlib: Finset.ssubset_iff_of_subset, Finset.mem_of_mem_inter_right, Finset.card_lt_card, Nat.pow_lt_pow_right.",
+      "The extremal upper bound (max sum-free subset of [1,n] has size ≤⌈n/2⌉) is ELEMENTARY (Erdős difference-set: A and {m−a:a∈A\\{m}} are disjoint subsets of [1,m] of sizes |A| and |A|−1), NOT the deep counting result. The file docstring previously deferred it to informal discussion as the classical hard direction; it is now Lean-verified axiom-free, independent of the green_upper_bound/precise_asymptotic axioms."
     ],
     "mathlibGaps": [],
     "nextSteps": [


### PR DESCRIPTION
## Summary
Research session for **erdos-748-incomplete-01** (counting sum-free subsets, `f(n) = #{sum-free subsets of [1,n]}`). Completes the *maximum sum-free subset size* characterization, discharging a gap the file's own Part VII docstring deferred to "the classical hard direction ... left to the informal discussion" — which is in fact **elementary**, independent of the deep counting axioms.

## Progress
- **`sumFree_card_le_ceil`** — every sum-free `A ⊆ {1,…,n}` has `|A| ≤ ⌈n/2⌉ = (n+1)/2`. The classical Erdős difference-set argument: with `m = max A`, the set `D = {m − a : a ∈ A, a ≠ m}` is disjoint from `A` (if `m − a ∈ A` then `m = (m−a) + a` with all three terms in `A`, contradicting sum-freeness), has `|D| = |A| − 1` (subtraction is injective on `[1,m]`), and `A, D ⊆ {1,…,m}`; hence `2|A| − 1 ≤ m ≤ n`, so `|A| ≤ (n+1)/2`.
- **`max_sumFree_card_eq_ceil`** — packages the new upper bound with the existing achievability (`exists_sumFree_card_ceil`) into `IsGreatest {|A| : A sum-free ⊆ [1,n]} = ⌈n/2⌉`: the maximum sum-free subset size is *exactly* `⌈n/2⌉`, both directions.

## Findings
- The extremal upper bound is elementary, not the deep `green_upper_bound` (which axiomatizes the far harder *count* `f(n) = 2^{n/2 + o(n)}`). The file previously conflated the max-*size* bound with the hard max-*count* result and deferred it informally.
- Both new theorems verified axiom-free via `lake env lean`: `#print axioms` shows only `[propext, Classical.choice, Quot.sound]` — **independent of the 2 deep BLOCKED axioms** (`green_upper_bound` / `precise_asymptotic`). 0 new axioms; the file's axiom count is unchanged (still 2, both genuinely deep/blocked).

## Status
**Outcome**: progress (verified capstone completing the max-size characterization)
**Next Steps**: `green_upper_bound` (Green 2004) and `precise_asymptotic` (Sapozhenko 2003) remain deep analytic results, genuinely blocked (>>1000 lines, out of single-session scope).

🤖 Generated by researcher-1