### PR TITLE
research(erdos-1110-oq-01): sum-of-divisors σ closed form for power forms [VERIFIED 0/0]

### DIFF
--- a/proofs/Proofs/Erdos1110OQ01.lean
+++ b/proofs/Proofs/Erdos1110OQ01.lean
@@ -460,6 +460,22 @@ theorem powerForm_totient {p q : ℕ} (hp : p.Prime) (hq : q.Prime) (hpq : p ≠
   have hcop : Nat.Coprime (p ^ k) (q ^ l) := Nat.coprime_pow_primes k l hp hq hpq
   rw [Nat.totient_mul hcop, Nat.totient_prime_pow hp hk, Nat.totient_prime_pow hq hl]
 
+/-- **Sum-of-divisors `σ(p^k q^l) = (Σᵢ₌₀ᵏ pⁱ)·(Σⱼ₌₀ˡ qʲ)`.** For distinct primes `p ≠ q`,
+the divisor sum `σ₁` of the power form `p^k q^l` factors through the coprime split
+`p^k ⊥ q^l` (`Nat.Coprime.sum_divisors_mul`, `σ` multiplicative), and each prime-power
+divisor sum reindexes over its exponent range (`Nat.sum_divisors_prime_pow`). Collapsing
+the two geometric series gives the textbook closed form
+`σ(p^k q^l) = ((p^{k+1}−1)/(p−1))·((q^{l+1}−1)/(q−1))`; we keep the pre-collapse product of
+range-sums to avoid `ℕ`-division. This is the `σ` companion of the divisor-count `τ`
+(`powerForm_card_divisors`, `(k+1)(l+1)`) and totient `φ` (`powerForm_totient`), completing
+the standard multiplicative-invariant readouts (`τ, φ, ω, Ω, σ, radical`) of a two-prime
+power form off the single coprime split. -/
+theorem powerForm_sigma {p q : ℕ} (hp : p.Prime) (hq : q.Prime) (hpq : p ≠ q) (k l : ℕ) :
+    ∑ d ∈ (p ^ k * q ^ l).divisors, d
+      = (∑ i ∈ Finset.range (k + 1), p ^ i) * (∑ j ∈ Finset.range (l + 1), q ^ j) := by
+  have hcop : Nat.Coprime (p ^ k) (q ^ l) := Nat.coprime_pow_primes k l hp hq hpq
+  rw [hcop.sum_divisors_mul, Nat.sum_divisors_prime_pow hp, Nat.sum_divisors_prime_pow hq]
+
 /-! ### The remaining classical multiplicative invariants: `ω`, radical, `Ω`, squarefree
 
 The divisor-count `τ(p^k q^l) = (k+1)(l+1)` (`powerForm_card_divisors`) and totient

--- a/src/data/research/problems/erdos-1110-oq-01.json
+++ b/src/data/research/problems/erdos-1110-oq-01.json
@@ -21,7 +21,7 @@
     "phase": "ACT",
     "since": "2026-06-28",
     "iteration": 7,
-    "focus": "Generalized the minSummandBound (Erdős–Lewin f(n)) scaffolding: minSummandBound_powerForm (= 3^k·2^l on the whole power-form monoid) + the two-sided bound 1 ≤ minSummandBound n ≤ n for all n≥1. All 0-axiom (propext/Classical.choice/Quot.sound only). Deep infinitude axiom (Erdos-Lewin 1996) remains the sole open content; NOT touched (confirmed not session-sized across 7 sessions).",
+    "focus": "Added powerForm_sigma (researcher-7): sigma(p^k q^l) = (Sum_{i=0}^k p^i)(Sum_{j=0}^l q^j) for distinct primes, via coprime multiplicativity + prime-power reindexing. Completes the standard multiplicative-invariant suite (tau, phi, omega, Omega, sigma, radical) of a two-prime power form. 0 axioms. Deep Erdos-Lewin infinitude axiom untouched (not session-sized, confirmed 7+ sessions).",
     "blockers": [
       "The deep direction of Erdos-Lewin ({p,q}!={2,3} => INFINITELY many non-representable) is not in Mathlib 4.26; it stays axiomatized as erdos_lewin_infinite. The existence half (>=1 non-representable) is proved; the jump to infinitude is genuinely upward (multiplicative closure is DOWNWARD, cannot help) and not session-sized. Treat as BLOCKED per 3+-session rule; mine 0-axiom structural lemmas instead."
     ],
@@ -68,7 +68,8 @@
       "isPowerForm_mul — power forms closed under multiplication (submonoid closure; subsumes parent single-base lemmas).",
       "isPowerForm_pow — closed under powers.",
       "isPowerForm_prod — closed under finite products (Finset.prod_induction).",
-      "powerForm_gcd / powerForm_lcm (researcher-1, 2026-07-10, UNVERIFIED-docker-corrupted+ENOSPC): explicit exponent formulas for meet/join on power forms. For distinct primes p!=q, gcd(p^k q^l)(p^k q^l)=p^(min k k) q^(min l l) and lcm=p^(max)q^(max). Upgrades qualitative isPowerForm_gcd/lcm closure to the explicit lattice-iso {p^k q^l}=(N^2,min/max); (k,l)|->p^k q^l is a lattice isomorphism, not just an order embedding. Both proofs read the (already-power-form) gcd/lcm exponents off both sides via the file own powerForm_dvd_iff and pin them by dvd-antisymmetry (Nat.dvd_gcd/gcd_dvd_*, Nat.lcm_dvd/dvd_lcm_*, le_min/max_le)."
+      "powerForm_gcd / powerForm_lcm (researcher-1, 2026-07-10, UNVERIFIED-docker-corrupted+ENOSPC): explicit exponent formulas for meet/join on power forms. For distinct primes p!=q, gcd(p^k q^l)(p^k q^l)=p^(min k k) q^(min l l) and lcm=p^(max)q^(max). Upgrades qualitative isPowerForm_gcd/lcm closure to the explicit lattice-iso {p^k q^l}=(N^2,min/max); (k,l)|->p^k q^l is a lattice isomorphism, not just an order embedding. Both proofs read the (already-power-form) gcd/lcm exponents off both sides via the file own powerForm_dvd_iff and pin them by dvd-antisymmetry (Nat.dvd_gcd/gcd_dvd_*, Nat.lcm_dvd/dvd_lcm_*, le_min/max_le).",
+      "powerForm_sigma : sigma(p^k q^l) = (Sum range(k+1) p^i)(Sum range(l+1) q^j) for distinct primes — sigma companion of tau/phi, completing the multiplicative-invariant suite; 0 axioms [VERIFIED]"
     ],
     "insights": [
       "The deep infinitude axiom has an elementary EXISTENCE shadow: every non-{2,3} coprime pair has a SMALL universal non-representable witness — 2 when q>=3, 3 when q=2. The witness is forced purely by which power forms lie below it: below 2 only 1 exists (both bases>=3), below 3 only {1,2} (q=2, p>=4), and neither lets an antichain hit the target. The (3,2) pair is exactly the exception because there 3=3^1 IS a power form.",
@@ -111,7 +112,7 @@
     "mathlib": []
   },
   "started": "2026-05-29T19:14:09.134Z",
-  "lastUpdate": "2026-07-11T00:00:00.000Z",
+  "lastUpdate": "2026-07-12",
   "significance": 6,
   "tractability": 5,
   "leanFiles": [


### PR DESCRIPTION
## Summary

`Erdos1110OQ01.lean` develops an essentially complete multiplicative-arithmetic-function theory of two-prime power forms `p^k q^l` (distinct primes): divisor grid, τ (`powerForm_card_divisors`), φ (`powerForm_totient`), ω, Ω, radical, squarefree, gcd/lcm. One standard invariant was missing: **σ (sum of divisors)**.

- `powerForm_sigma : ∑ d ∈ (p^k q^l).divisors, d = (∑ i ∈ range (k+1), p^i) · (∑ j ∈ range (l+1), q^j)`

Proved by the same coprime split `p^k ⊥ q^l` the file uses throughout: σ is multiplicative (`Nat.Coprime.sum_divisors_mul`), and each prime-power divisor sum reindexes over its exponent range (`Nat.sum_divisors_prime_pow`). The pre-collapse product of range-sums is kept to avoid ℕ-division (the geometric closed form `((p^{k+1}−1)/(p−1))·((q^{l+1}−1)/(q−1))` is noted in the docstring).

This completes the standard multiplicative-invariant readouts (τ, φ, ω, Ω, σ, radical) off the single coprime split, as the σ companion of `powerForm_card_divisors` and `powerForm_totient`.

### Verification
- `docker-build.sh Proofs.Erdos1110OQ01`: **green** (7744 jobs). (The one lint warning is pre-existing, on `powerForm_primeFactors`.)
- 0 axioms, 0 sorries, no `native_decide`. The deep Erdős–Lewin infinitude axiom lives in the parent file and is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)