### PR TITLE
research(szemeredi-regularity-oq-04): m-fold whole-partition refinement monotonicity [VERIFIED]

### DIFF
--- a/proofs/Proofs/SzemerediRegularityOQ04FamilySplit.lean
+++ b/proofs/Proofs/SzemerediRegularityOQ04FamilySplit.lean
@@ -1,0 +1,173 @@
+/-
+# Szemerédi Regularity (OQ-04): m-fold whole-partition refinement monotonicity
+
+The `partitionEnergy` docstring states, as a general fact, that the size-weighted
+energy is *"monotone under refinement (splitting a part never decreases energy)"*.
+The OQ-04 development proves this only for a **two-piece** single-part split
+(`partitionEnergy_single_split_mono`, Bridge) and for the sharp **2×2** product
+refinement (`partitionEnergy_prod_refinement_gain`, Assembly).  This file discharges
+the documented `2×2 → m×k` next step at the monotonicity level: refining **one part**
+`A` into an arbitrary disjoint family `{Aᵢ}_{i∈I}` with `A = ⋃ᵢ Aᵢ` never decreases
+`partitionEnergy`.
+
+## What this file proves (0 axioms, 0 sorries)
+
+* `pairEnergy_biUnion_split_mono` — the m-fold left analogue of `pairEnergy_split_mono`:
+  `pairEnergy G (⋃ᵢ Aᵢ) B ≤ Σᵢ pairEnergy G (Aᵢ) B` for a disjoint family `{Aᵢ}`.
+  Proved by `Finset.induction` on `I`, folding the two-piece split lemma over the
+  `biUnion`.
+* `pairEnergy_biUnion_split_mono_right` — its second-argument mirror, transported
+  through `pairEnergy_comm`.
+* `partitionEnergy_biUnion_split_mono` — **the m-fold whole-partition refinement
+  monotonicity.**  For a disjoint family `{Aᵢ}_{i∈I}` (`As` injective on `I`, each
+  `Aᵢ ∉ R`, and `⋃ᵢ Aᵢ ∉ R`),
+  `partitionEnergy G (insert (⋃ᵢ Aᵢ) R) ≤ partitionEnergy G (I.image As ∪ R)`.
+
+The whole-partition proof mirrors `partitionEnergy_single_split_mono`: the ordered-pair
+sum `partitionEnergy = Σ_{P,Q} pairEnergy` (bridge `partitionEnergy_eq_sum_pairEnergy`)
+splits into a diagonal block `(A,A)`, a row block `(A,R)`, a column block `(R,A)` and
+the untouched `R × R` block; each of the three affected blocks is controlled by the
+m-fold pair split lemmas above (the row/column blocks by a single application, the
+diagonal by one on each coordinate).  Only the arithmetic of `Finset.sum_image`
+(over the injective family) and `Finset.sum_comm` (to align the row block) is added.
+
+This is the reusable structural half of the true AFKS refinement — where every part is
+split simultaneously into many pieces — and it upgrades the `partitionEnergy` docstring's
+general monotonicity claim from the two-piece special case to arbitrary finite families.
+-/
+import Mathlib
+import Proofs.SzemerediRegularityOQ04Bridge
+
+namespace Szemeredi.RegularityOQ04FamilySplit
+
+open Szemeredi.Core Szemeredi.Regularity Szemeredi.RegularityOQ04Energy
+open Szemeredi.RegularityOQ04Bridge
+
+variable {V : Type*} [Fintype V] [DecidableEq V]
+
+-- ═══════════════════════════════════════════════════════════════════
+-- PART I: m-FOLD ONE-SIDED PAIR-ENERGY SPLIT MONOTONICITY
+-- ═══════════════════════════════════════════════════════════════════
+
+/-- **m-fold left refinement monotonicity of `pairEnergy`.**  Splitting the `A`-side of
+a pair into an arbitrary disjoint family `{Aᵢ}_{i∈I}` (with `A = ⋃ᵢ Aᵢ`) never decreases
+its total normalized energy contribution:
+`pairEnergy G (⋃ᵢ Aᵢ) B ≤ Σᵢ pairEnergy G (Aᵢ) B`.  This is the `Finset`-family analogue
+of the two-piece `pairEnergy_split_mono`, obtained by induction on `I` folding the
+two-piece split over `Finset.biUnion`. -/
+theorem pairEnergy_biUnion_split_mono (G : SimpleGraph V) [DecidableRel G.Adj]
+    {ι : Type*} [DecidableEq ι] (I : Finset ι) (As : ι → Finset V) (B : Finset V)
+    (hA : (↑I : Set ι).PairwiseDisjoint As) :
+    pairEnergy G (I.biUnion As) B ≤ ∑ i ∈ I, pairEnergy G (As i) B := by
+  classical
+  revert hA
+  induction I using Finset.induction with
+  | empty => intro _; simp [pairEnergy, Finset.biUnion_empty]
+  | @insert a s ha ih =>
+      intro hA
+      rw [Finset.biUnion_insert, Finset.sum_insert ha]
+      have hsub : (↑s : Set ι).PairwiseDisjoint As :=
+        hA.subset (by rw [Finset.coe_insert]; exact Set.subset_insert _ _)
+      have hdisj : Disjoint (As a) (s.biUnion As) := by
+        rw [Finset.disjoint_biUnion_right]
+        intro i hi
+        exact hA (Finset.mem_insert_self a s) (Finset.mem_insert_of_mem hi)
+          (by rintro rfl; exact ha hi)
+      calc pairEnergy G (As a ∪ s.biUnion As) B
+          ≤ pairEnergy G (As a) B + pairEnergy G (s.biUnion As) B :=
+            pairEnergy_split_mono G (As a) (s.biUnion As) B hdisj
+        _ ≤ pairEnergy G (As a) B + ∑ i ∈ s, pairEnergy G (As i) B := by
+            linarith [ih hsub]
+
+/-- **m-fold right refinement monotonicity of `pairEnergy`.**  The second-argument
+mirror of `pairEnergy_biUnion_split_mono`, transported through `pairEnergy_comm`:
+`pairEnergy G A (⋃ⱼ Bⱼ) ≤ Σⱼ pairEnergy G A (Bⱼ)`. -/
+theorem pairEnergy_biUnion_split_mono_right (G : SimpleGraph V) [DecidableRel G.Adj]
+    (A : Finset V) {ι : Type*} [DecidableEq ι] (J : Finset ι) (Bs : ι → Finset V)
+    (hB : (↑J : Set ι).PairwiseDisjoint Bs) :
+    pairEnergy G A (J.biUnion Bs) ≤ ∑ j ∈ J, pairEnergy G A (Bs j) := by
+  rw [pairEnergy_comm G A (J.biUnion Bs)]
+  refine (pairEnergy_biUnion_split_mono G J Bs A hB).trans (le_of_eq ?_)
+  exact Finset.sum_congr rfl (fun j _ => pairEnergy_comm G (Bs j) A)
+
+-- ═══════════════════════════════════════════════════════════════════
+-- PART II: m-FOLD WHOLE-PARTITION REFINEMENT MONOTONICITY
+-- ═══════════════════════════════════════════════════════════════════
+
+/-- **m-fold whole-partition refinement monotonicity of `partitionEnergy`.**
+Refining a single part `A = ⋃ᵢ Aᵢ` of a partition into an arbitrary disjoint family
+`{Aᵢ}_{i∈I}` — the `As` injective on `I`, each fine cell `Aᵢ ∉ R`, and the coarse part
+`⋃ᵢ Aᵢ ∉ R` — never decreases `partitionEnergy`:
+
+`partitionEnergy G (insert (⋃ᵢ Aᵢ) R) ≤ partitionEnergy G (I.image As ∪ R)`.
+
+This is the arbitrary-family generalization of the two-piece `partitionEnergy_single_split_mono`.
+The ordered-pair sum decomposes into a diagonal `(A,A)` block, a row `(A,R)` block, a
+column `(R,A)` block and the untouched `R × R` block; the three affected blocks are each
+controlled by the m-fold pair split lemmas of PART I. -/
+theorem partitionEnergy_biUnion_split_mono (G : SimpleGraph V) [DecidableRel G.Adj]
+    {ι : Type*} [DecidableEq ι] (R : Finset (Finset V)) (I : Finset ι) (As : ι → Finset V)
+    (hA : (↑I : Set ι).PairwiseDisjoint As) (hinj : Set.InjOn As ↑I)
+    (hAR : ∀ i ∈ I, As i ∉ R) (hfresh : I.biUnion As ∉ R) :
+    partitionEnergy G (insert (I.biUnion As) R) ≤
+      partitionEnergy G (I.image As ∪ R) := by
+  classical
+  -- The refined cells are disjoint from the untouched blocks `R`.
+  have hdisjImR : Disjoint (I.image As) R := by
+    rw [Finset.disjoint_left]
+    intro x hx hxR
+    rw [Finset.mem_image] at hx
+    obtain ⟨i, hi, rfl⟩ := hx
+    exact hAR i hi hxR
+  -- Nested-double-sum form of `partitionEnergy`, from the bridge lemma.
+  have hdouble : ∀ parts : Finset (Finset V),
+      partitionEnergy G parts = ∑ P ∈ parts, ∑ Q ∈ parts, pairEnergy G P Q := by
+    intro parts
+    rw [partitionEnergy_eq_sum_pairEnergy,
+      show parts.product parts = parts ×ˢ parts from rfl, Finset.sum_product]
+  -- Rewrite the family image-sums as `I`-sums via injectivity.
+  have himg : ∀ F : Finset V → ℚ, ∑ P ∈ I.image As, F P = ∑ i ∈ I, F (As i) := by
+    intro F
+    rw [Finset.sum_image]
+    intro x hx y hy h
+    exact hinj (Finset.mem_coe.mpr hx) (Finset.mem_coe.mpr hy) h
+  -- LHS block decomposition.
+  have hL : partitionEnergy G (insert (I.biUnion As) R)
+      = pairEnergy G (I.biUnion As) (I.biUnion As)
+        + (∑ Q ∈ R, pairEnergy G (I.biUnion As) Q)
+        + (∑ P ∈ R, pairEnergy G P (I.biUnion As))
+        + (∑ P ∈ R, ∑ Q ∈ R, pairEnergy G P Q) := by
+    rw [hdouble, Finset.sum_insert hfresh]
+    simp only [Finset.sum_insert hfresh]
+    rw [Finset.sum_add_distrib]
+    ring
+  -- RHS block decomposition.
+  have hR : partitionEnergy G (I.image As ∪ R)
+      = (∑ i ∈ I, ∑ j ∈ I, pairEnergy G (As i) (As j))
+        + (∑ i ∈ I, ∑ Q ∈ R, pairEnergy G (As i) Q)
+        + (∑ P ∈ R, ∑ i ∈ I, pairEnergy G P (As i))
+        + (∑ P ∈ R, ∑ Q ∈ R, pairEnergy G P Q) := by
+    rw [hdouble, Finset.sum_union hdisjImR]
+    simp only [Finset.sum_union hdisjImR, Finset.sum_add_distrib, himg]
+    ring
+  -- Diagonal block: `pe A A ≤ Σᵢⱼ pe Aᵢ Aⱼ`.
+  have hdiag : pairEnergy G (I.biUnion As) (I.biUnion As)
+      ≤ ∑ i ∈ I, ∑ j ∈ I, pairEnergy G (As i) (As j) := by
+    refine (pairEnergy_biUnion_split_mono G I As (I.biUnion As) hA).trans ?_
+    exact Finset.sum_le_sum
+      (fun i _ => pairEnergy_biUnion_split_mono_right G (As i) I As hA)
+  -- Row block: `Σ_{Q∈R} pe A Q ≤ Σᵢ Σ_{Q∈R} pe Aᵢ Q`.
+  have hrow : ∑ Q ∈ R, pairEnergy G (I.biUnion As) Q
+      ≤ ∑ i ∈ I, ∑ Q ∈ R, pairEnergy G (As i) Q := by
+    have step : ∑ Q ∈ R, pairEnergy G (I.biUnion As) Q
+        ≤ ∑ Q ∈ R, ∑ i ∈ I, pairEnergy G (As i) Q :=
+      Finset.sum_le_sum (fun Q _ => pairEnergy_biUnion_split_mono G I As Q hA)
+    rwa [Finset.sum_comm] at step
+  -- Column block: `Σ_{P∈R} pe P A ≤ Σ_{P∈R} Σᵢ pe P Aᵢ`.
+  have hcol : ∑ P ∈ R, pairEnergy G P (I.biUnion As)
+      ≤ ∑ P ∈ R, ∑ i ∈ I, pairEnergy G P (As i) :=
+    Finset.sum_le_sum (fun P _ => pairEnergy_biUnion_split_mono_right G P I As hA)
+  rw [hL, hR]
+  linarith [hdiag, hrow, hcol]
+
+end Szemeredi.RegularityOQ04FamilySplit

--- a/research/problems/szemeredi-regularity-oq-04/knowledge.md
+++ b/research/problems/szemeredi-regularity-oq-04/knowledge.md
@@ -4,6 +4,56 @@ Insights accumulated during research on this problem.
 
 ---
 
+## Session 2026-07-12 (researcher-8) — m-fold whole-partition refinement MONOTONICITY
+
+**Mode:** FRESH (RICH tier, claimed via lock). **Outcome:** progress — the documented
+`2×2 → m×k` next step discharged at the monotonicity level.
+
+### What I did — new file `SzemerediRegularityOQ04FamilySplit.lean` (3 thm, 0 ax, 0 sorry)
+The `partitionEnergy` docstring asserts, in full generality, that "splitting a part never
+decreases energy", but the OQ-04 development only proved this for a **two-piece** single-part
+split (`partitionEnergy_single_split_mono`, Bridge) and the sharp **2×2** product refinement.
+This session generalizes the monotonicity to an **arbitrary disjoint family**:
+
+- `pairEnergy_biUnion_split_mono` — `pe (⋃ᵢ Aᵢ) B ≤ Σᵢ pe (Aᵢ) B`, the m-fold left analogue
+  of the two-piece `pairEnergy_split_mono`, by `Finset.induction` on `I` folding the two-piece
+  split over `Finset.biUnion` (disjointness of the head cell against the tail biUnion via
+  `Finset.disjoint_biUnion_right` + the `PairwiseDisjoint` hypothesis).
+- `pairEnergy_biUnion_split_mono_right` — the second-argument mirror, transported through
+  `pairEnergy_comm`.
+- `partitionEnergy_biUnion_split_mono` — **the whole-partition statement:** refining one part
+  `A = ⋃ᵢ Aᵢ` (with `As` injective on `I`, each `Aᵢ ∉ R`, `⋃ᵢ Aᵢ ∉ R`) into its family never
+  decreases `partitionEnergy`:
+  `partitionEnergy G (insert (⋃ᵢ Aᵢ) R) ≤ partitionEnergy G (I.image As ∪ R)`.
+  Proof mirrors `partitionEnergy_single_split_mono`: expand both sides via the bridge
+  `partitionEnergy_eq_sum_pairEnergy` into a diagonal `(A,A)` block, row `(A,R)` block,
+  column `(R,A)` block and untouched `R×R` block; the three affected blocks are each bounded
+  by the m-fold pair split lemmas (`Finset.sum_image` over the injective family, `Finset.sum_comm`
+  to align the row block, then `linarith`).
+
+### Verification — docker-VERIFIED (clean, no SIGBUS)
+`./proofs/scripts/docker-build.sh Proofs.SzemerediRegularityOQ04FamilySplit` → `Build completed
+successfully (7749 jobs)` on first try; Bridge dependency built in 22s with no exit-135 this cycle.
+`#print axioms` on all three theorems: `[propext, Classical.choice, Quot.sound]` — genuinely
+axiom-free, 0 sorries. (One transient hazard: the `researcher-8-2` worktree was deleted mid-build
+by a fleet sweep before the first commit; recovered by recreating the file in a dedicated worktree
+`lg-r8-szem-mxk` and committing before rebuilding — commit early on shared infra.)
+
+### Why this matters / honesty
+This is the **structural** half of the true AFKS refinement (every part split simultaneously
+into many pieces). It is genuine reusable infrastructure and closes the documented next step at
+the monotonicity level, but it is a lateral move relative to the standing analytic blocker: it
+adds no strict energy *gain* and does not touch the equipartition-realizability question. The
+`≥` here is non-strict; the meaningful `mxk` GAIN (variance surplus among the fine cells) and the
+two-sided product refinement remain the next steps.
+
+### Files Modified
+- `proofs/Proofs/SzemerediRegularityOQ04FamilySplit.lean` (NEW, 173 lines, 3 theorems)
+- `src/data/research/problems/szemeredi-regularity-oq-04.json` (leanFiles entry + knowledge)
+
+---
+
+
 ## Session 2026-07-09 (researcher-8) — TERMINATION capstone: a regular step is reached in bounded time
 
 **Mode:** REVISIT (RICH tier). **Outcome:** progress — the conclusion the whole development

--- a/src/data/research/problems/szemeredi-regularity-oq-04.json
+++ b/src/data/research/problems/szemeredi-regularity-oq-04.json
@@ -26,7 +26,7 @@
     "nextAction": "Reconstruct the energy-increment step (epsilon-irregular refinement raises partitionEnergy by >= delta) from split_energy_excess_bound, then assemble the outer AFKS loop using partitionEnergy_no_infinite_increments as termination certificate."
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (researcher-8, 2026-07-11): WIRED freshness_of_partition into the Assembly capstone (new SzemerediRegularityOQ04FreshGain.lean). partitionEnergy_prod_refinement_gain_of_partition + partitionEnergy_prod_gain_eps4_of_partition reprove the sharp 2×2 whole-partition energy gain / ε⁴ floor with the SIX ∉-freshness side-conditions REPLACED by a genuine partition model (nonempty disjoint cells tiling two disjoint coarse blocks A,B fresh against R). Discharges the set-theoretic half of the equipartition-realizability blocker; only the analytic size floors |A₁|≥ε|A|, |B₁|≥ε|B|, d≥ε remain. VERIFIED axiom-free [propext,Classical.choice,Quot.sound] via lake env lean (Assembly+Fresh oleans prebuilt).",
+    "progressSummary": "PROGRESS (researcher-8, 2026-07-12): m-fold whole-partition refinement MONOTONICITY (partitionEnergy_biUnion_split_mono) generalizing the two-piece partitionEnergy_single_split_mono to arbitrary disjoint families; new file SzemerediRegularityOQ04FamilySplit.lean, 3 thm 0 ax 0 sorry, docker-VERIFIED. Discharges the documented 2x2 -> mxk next step at the monotonicity level. Remaining: the mxk GAIN (variance surplus) and the two-sided product refinement.",
     "builtItems": [
       "edgeDensity_union_mul in SzemerediRegularityOQ04Energy.lean — weighted-average identity |A1cupA2||B|d = |A1||B|d1+|A2||B|d2 for disjoint A-split (reusable public API; previously trapped inside density_sq_convex proof).",
       "pairEnergy def + pairEnergy_split_mono — one-sided refinement never decreases the normalized pair energy (|A||B|/n^2)d^2; transports density_sq_convex to partitionEnergy units.",
@@ -67,7 +67,11 @@
       "energy_increment_steps_card_bound / energy_increment_count_le (SzemerediRegularityOQ04.lean Part V): for a MONOTONE [0,1]-valued potential, the δ-increment (irregular) steps have bounded total count card·δ≤1, hence ≤⌊1/δ⌋ in ANY window [0,N), independent of N. Telescoping f N−f 0≤1 via Finset.sum_range_sub, drop non-increment terms by monotonicity (sum_le_sum_of_subset_of_nonneg). VERIFIED 0/0 (3 clean docker builds).",
       "energy_regular_steps_card_ge (Part V): at least N−1/δ of the first N steps are REGULAR (non-increment); regular fraction→1 as N→∞. Complement-count via Finset.filter_card_add_filter_neg_card_eq_card. VERIFIED 0/0.",
       "partitionEnergy_increment_count_le + partitionEnergy_regular_steps_card_ge (Part V): graph instantiations threading refinement-monotonicity hmono (partitionEnergy G (parts n) ≤ partitionEnergy G (parts (n+1))). Along a monotone AFKS refinement chain ≤⌊1/δ⌋ energy-increment steps total; ≥N−1/δ regular steps — the quantitative form of almost-everywhere regularity. VERIFIED 0/0.",
-      "SzemerediRegularityOQ04FreshGain.lean (researcher-8, 2026-07-11): partitionEnergy_prod_refinement_gain_of_partition + partitionEnergy_prod_gain_eps4_of_partition — the sharp 2×2 gain / ε⁴ floor with the six ∉-freshness hyps discharged from a partition model via freshness_of_partition (nonempty disjoint cells A₁∪A₂=A, B₁∪B₂=B; Disjoint A B; R disjoint from both). Thin corollaries of the verified Assembly base lemmas. 0-axiom. Strips the frontier to the analytic size floors only."
+      "SzemerediRegularityOQ04FreshGain.lean (researcher-8, 2026-07-11): partitionEnergy_prod_refinement_gain_of_partition + partitionEnergy_prod_gain_eps4_of_partition — the sharp 2×2 gain / ε⁴ floor with the six ∉-freshness hyps discharged from a partition model via freshness_of_partition (nonempty disjoint cells A₁∪A₂=A, B₁∪B₂=B; Disjoint A B; R disjoint from both). Thin corollaries of the verified Assembly base lemmas. 0-axiom. Strips the frontier to the analytic size floors only.",
+      "SzemerediRegularityOQ04FamilySplit.lean (NEW, 3 thm, 0 ax, 0 sorry, docker-VERIFIED axioms=[propext,Classical.choice,Quot.sound]): m-fold whole-partition refinement monotonicity",
+      "pairEnergy_biUnion_split_mono: pe (biUnion As) B <= sum_i pe (As i) B (m-fold left analogue of pairEnergy_split_mono, by Finset.induction folding the two-piece split)",
+      "pairEnergy_biUnion_split_mono_right: second-argument mirror via pairEnergy_comm",
+      "partitionEnergy_biUnion_split_mono: refining one part A=biUnion As into the disjoint family {As i} never decreases partitionEnergy (block decomposition of partitionEnergy_eq_sum_pairEnergy: diagonal (A,A) + row (A,R) + column (R,A) + untouched RxR)"
     ],
     "insights": [
       "partitionEnergy IS the standard size-weighted energy |Pi||Pj|/n^2 d^2 (SzemerediCore:63), NOT 1/k^2. The abandoned energy_increment_step note in SzemerediRegularity (lines 212-219) rests on a false premise; refinement monotonicity is genuine and now proven per-pair.",
@@ -93,14 +97,18 @@
       "The 2×2 product-refinement increment generalizes verbatim to an arbitrary m×k product of disjoint families: weighted_second_moment_atom_gain already handles arbitrary finite index, so only the general law of total density (mean identity) and total-weight identity are needed as new inputs. Both are Finset.induction/card_biUnion routine over the existing 2-way one-sided laws.",
       "General law of total density is obtained compositionally: one A-side biUnion induction (edgeDensity_biUnion_mul) times one B-side biUnion induction (edgeDensity_mul_biUnion), avoiding any direct product-partition biUnion decomposition.",
       "VERIFIED (researcher-2, 2026-07-09, GREEN build [7745/7745]): the finite-horizon EXISTENCE counterpart of the energy-iteration engine, added to the self-contained OQ04.lean (depends only on SzemerediRegularity, NOT the SIGBUS-prone Bridge). energy_regular_step_exists: for any horizon N>1/δ, an [0,1]-valued potential incrementing by δ each step is impossible, so ∃ n<N with ¬(f n+δ ≤ f(n+1)) — a NON-increment ('regular') step is reached within N. Contrapositive of energy_iteration_count_le (by_contra+push_neg→N≤1/δ contradicts 1/δ<N). partitionEnergy_regular_step_exists: graph instantiation (regular refinement reached in ≤⌈1/δ⌉ steps). This is the abstract, finite-horizon positive form of no_infinite_energy_increments — the abstract heart of Assembly's afks_regular_step_within_bound, now available directly on the clean abstract engine.",
-      "Parts I-IV only guarantee ONE regular step in a window N>1/δ; adding the MONOTONICITY hypothesis (true for AFKS refinement energy) upgrades this to a COUNTING result: the irregular (δ-increment) steps number at most ⌊1/δ⌋ across the ENTIRE run, so in any window N at least N−1/δ steps are regular. The deficit 1/δ is a fixed constant, so the regular-step fraction →1: irregular steps are a bounded exceptional set. This is genuinely stronger than existence — it is the quantitative why-almost-every-refinement-is-regular statement. Monotonicity is essential: without it a [0,1] potential can bounce 0→δ→0→δ and increment unboundedly often."
+      "Parts I-IV only guarantee ONE regular step in a window N>1/δ; adding the MONOTONICITY hypothesis (true for AFKS refinement energy) upgrades this to a COUNTING result: the irregular (δ-increment) steps number at most ⌊1/δ⌋ across the ENTIRE run, so in any window N at least N−1/δ steps are regular. The deficit 1/δ is a fixed constant, so the regular-step fraction →1: irregular steps are a bounded exceptional set. This is genuinely stronger than existence — it is the quantitative why-almost-every-refinement-is-regular statement. Monotonicity is essential: without it a [0,1] potential can bounce 0→δ→0→δ and increment unboundedly often.",
+      "The partitionEnergy docstring general monotonicity claim (splitting a part never decreases energy) had only been proved for two-piece splits (partitionEnergy_single_split_mono); the arbitrary-family m-fold generalization is now discharged via the same block decomposition, one m-fold pair-split application per affected block.",
+      "The m-fold one-sided pair split (pe (biUnion As) B <= sum_i pe (As i) B) is a clean Finset.induction folding the existing two-piece pairEnergy_split_mono over biUnion; it plus its comm-mirror are the reusable atoms the whole-partition lift consumes."
     ],
     "mathlibGaps": [],
     "nextSteps": [
       "DONE (researcher-6): k-explicit tower-free bound N ≤ k²/ε⁴ via afks_sharp_iteration_count_equipartition (equipartition mass floor m=n/k). Follow-on: derive the equipartition mass floor m ≥ n/k INTERNALLY from a nonempty k-equipartition model (parts of size ⌈n/k⌉/⌊n/k⌋) so the k-explicit bound consumes ¬IsEpsilonRegular directly, matching the Fresh-file freshness discharge.",
       "Discharge the freshness hypotheses (A₁,A₂,B₁,B₂ distinct and ∉R) of afks_sharp_energy_iteration_count_of_prod_witness / partitionEnergy_prod_gain_eps4 from a nonempty-equipartition model to obtain a fully-internal ∃P′ capstone from ¬IsEpsilonRegular (the standing blocker, shared with the one-sided route).",
       "Generalize 2×2 → m×k product refinement via Finset(Finset V) families + card_biUnion over a product partition.",
-      "State two-level AFKS conclusion with dependent tolerance E:ℕ→(0,1]."
+      "State two-level AFKS conclusion with dependent tolerance E:ℕ→(0,1].",
+      "Add the m-fold whole-partition GAIN (family analogue of partitionEnergy_single_split_gain / partitionEnergy_prod_refinement_gain): with a variance witness among the fine cells {As i} against an irregular partner, add a strict energy surplus on top of the monotonicity floor proved here.",
+      "Lift to the full two-sided m x k product refinement of a partition (refine both A and B simultaneously into families), the whole-partition analogue of pairEnergy_prod_family_refinement_gain (Product file)."
     ],
     "markdown": "# Knowledge Base: szemeredi-regularity-oq-04\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n",
     "score": 63
@@ -256,6 +264,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/SzemerediRegularityOQ04Witness.lean"
+    },
+    {
+      "path": "Proofs/SzemerediRegularityOQ04FamilySplit.lean",
+      "filename": "SzemerediRegularityOQ04FamilySplit.lean",
+      "lineCount": 173,
+      "theoremCount": 3,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/SzemerediRegularityOQ04FamilySplit.lean"
     }
   ],
   "lastUpdate": "2026-07-11"


### PR DESCRIPTION
## Summary

Generalizes the OQ-04 refinement monotonicity from the **two-piece** single-part split (`partitionEnergy_single_split_mono`) to an **arbitrary disjoint family**, discharging the development's documented `2×2 → m×k` next step at the monotonicity level. This upgrades the `partitionEnergy` docstring's own general claim — *"splitting a part never decreases energy"* — from the two-piece special case to arbitrary finite families.

New file `proofs/Proofs/SzemerediRegularityOQ04FamilySplit.lean` (**3 theorems, 0 axioms, 0 sorries**):

- `pairEnergy_biUnion_split_mono` — `pe (⋃ᵢ Aᵢ) B ≤ Σᵢ pe (Aᵢ) B`, the m-fold left analogue of the two-piece `pairEnergy_split_mono`, by `Finset.induction` folding the two-piece split over `Finset.biUnion`.
- `pairEnergy_biUnion_split_mono_right` — the second-argument mirror via `pairEnergy_comm`.
- `partitionEnergy_biUnion_split_mono` — the whole-partition statement: refining one part `A = ⋃ᵢ Aᵢ` (`As` injective on `I`, each `Aᵢ ∉ R`, `⋃ᵢ Aᵢ ∉ R`) into its family never decreases `partitionEnergy`. Proof mirrors `partitionEnergy_single_split_mono`: expand both sides via `partitionEnergy_eq_sum_pairEnergy` into diagonal `(A,A)` + row `(A,R)` + column `(R,A)` + untouched `R×R` blocks, bound each affected block by the m-fold pair lemmas (`Finset.sum_image`, `Finset.sum_comm`, `linarith`).

## Verification

`./proofs/scripts/docker-build.sh Proofs.SzemerediRegularityOQ04FamilySplit` → **Build completed successfully (7749 jobs)**. `#print axioms` on all three theorems reports exactly `[propext, Classical.choice, Quot.sound]` — genuinely axiom-free, 0 sorries.

## Honesty note

This is the **structural** half of the true AFKS refinement (all parts split simultaneously). It is reusable infrastructure and closes the documented next step at the monotonicity level, but it is a lateral move relative to the standing analytic/equipartition-realizability blocker: the inequality is non-strict (no energy *gain*). The m×k **gain** (variance surplus among the fine cells) and the two-sided product refinement remain the next steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)