### PR TITLE
research(combinations-formula-oq-03-oq-04): base-change bridge qBinom_map + eval-at-1 = C(n,k) [VERIFIED 0/0]

### DIFF
--- a/proofs/Proofs/CombinationsFormulaOQ03OQ04.lean
+++ b/proofs/Proofs/CombinationsFormulaOQ03OQ04.lean
@@ -259,4 +259,49 @@ theorem qBinom_X_extreme_coeffs {n k : ℕ} (h : k ≤ n) :
     (qBinom (X : ℤ[X]) n k).coeff (k * (n - k)) = 1 :=
   ⟨qBinom_X_coeff_zero n k h, qBinom_X_coeff_top h⟩
 
+/-! ### Base change: specializing the Gaussian polynomial
+
+The `q`-binomial is assembled purely from the ring operations of the `q`-Pascal recurrence,
+so it commutes with any ring homomorphism (`qBinom_map`).  Two instances tie the polynomial
+layer above back to scalars: evaluating `qBinom X n k ∈ ℤ[X]` at a point `c` recovers the
+scalar `q`-binomial `qBinom c n k` (`qBinom_X_eval`), and at `c = 1` it degenerates to the
+ordinary binomial coefficient `C(n,k)` (`qBinom_X_eval_one`) — equivalently, the coefficients
+of the Gaussian polynomial sum to `C(n,k)`, the `q = 1` shadow at the root of the whole
+`combinations-formula` lineage. -/
+
+/-- **`qBinom` commutes with ring homomorphisms.** For a ring hom `f : A →+* B` and `q : A`,
+`f ([n choose k]_q) = [n choose k]_{f q}`.  The `q`-binomial is built solely from `+`, `*`,
+`^` via the `q`-Pascal recurrence, so any ring hom carries it through; this is the uniform
+base-change statement of which the scalar specialization `qBinom_at_one` and the polynomial
+evaluation `qBinom_X_eval` are instances. -/
+theorem qBinom_map {A B : Type*} [CommRing A] [CommRing B] (f : A →+* B) (q : A) :
+    ∀ n k : ℕ, f (qBinom q n k) = qBinom (f q) n k
+  | _, 0 => by rw [qBinom_zero_right, qBinom_zero_right, map_one]
+  | 0, _ + 1 => by rw [qBinom_zero_succ, qBinom_zero_succ, map_zero]
+  | n + 1, k + 1 => by
+    rw [qBinom_pascal, map_add, map_mul, map_pow,
+        qBinom_map f q n k, qBinom_map f q n (k + 1), qBinom_pascal]
+
+open Polynomial in
+/-- **Evaluation of the Gaussian polynomial recovers the scalar `q`-binomial.**
+`([n choose k]_X).eval c = [n choose k]_c` for every `c : ℤ`.  Evaluation at `c` is the ring
+hom `evalRingHom c`, so `qBinom_map` turns it into `qBinom (eval c X) n k = qBinom c n k` —
+the bridge between the polynomial layer of this file and the scalar `q`-binomials of the
+parent. -/
+theorem qBinom_X_eval (c : ℤ) (n k : ℕ) :
+    (qBinom (X : ℤ[X]) n k).eval c = qBinom c n k := by
+  have h := qBinom_map (evalRingHom c) (X : ℤ[X]) n k
+  rwa [coe_evalRingHom, eval_X] at h
+
+open Polynomial in
+/-- **The Gaussian polynomial degenerates to the ordinary binomial at `q = 1`.**
+`([n choose k]_X).eval 1 = C(n,k)`, combining `qBinom_X_eval` at `c = 1` with the scalar
+specialization `qBinom_at_one`.  Since a polynomial's value at `1` is the sum of its
+coefficients, this says the coefficient sequence of the palindromic Gaussian polynomial
+`qBinom X n k` sums to the ordinary combination count `C(n,k)` — the `q = 1` degeneration at
+the root of the `combinations-formula` lineage. -/
+theorem qBinom_X_eval_one (n k : ℕ) :
+    (qBinom (X : ℤ[X]) n k).eval 1 = (Nat.choose n k : ℤ) := by
+  rw [qBinom_X_eval, qBinom_at_one]
+
 end QBinomialCoefficients

--- a/src/data/research/problems/combinations-formula-oq-03-oq-04.json
+++ b/src/data/research/problems/combinations-formula-oq-03-oq-04.json
@@ -693,7 +693,8 @@
       "meta.json gallery entry (verified, 3 thm, 0 sorry, 0 axiom)",
       "qBinom_X_monic_natDegree: Gaussian polynomial qBinom X n k over ℤ[X] is monic of natDegree=k(n-k) (CombinationsFormulaOQ03OQ04.lean)",
       "qBinom_X_coeff_zero / qBinom_X_coeff_top / qBinom_X_extreme_coeffs: both extreme coefficients pinned to 1",
-      "qBinom_X_coeff_nonneg: all coefficients of the Gaussian polynomial are ≥ 0 over ℤ"
+      "qBinom_X_coeff_nonneg: all coefficients of the Gaussian polynomial are ≥ 0 over ℤ",
+      "qBinom_map / qBinom_X_eval / qBinom_X_eval_one : base-change bridge — q-binomial commutes with ring homs, so (qBinom X n k).eval c = qBinom c n k and .eval 1 = C(n,k) (coefficient-sum = ordinary binomial). 0 axioms [VERIFIED]"
     ],
     "mathlibGaps": [
       "No direct need: proof uses only parent q-binomial API plus elementary field/power lemmas (mul_inv_cancel_left_zero, inv_pow, pow_ne_zero, pow_add).",
@@ -706,5 +707,7 @@
       "Attempt unimodality proper: sl₂ raising/lowering operator action (Proctor 1982) or an O'Hara-style explicit injection between adjacent coefficient levels."
     ],
     "progressSummary": "PROGRESS (researcher-7, 2026-07-12): added Gaussian-polynomial structural layer over ℤ[X] — monic, natDegree=k(n-k), constant term=1, nonneg coefficients, extreme coefficients pinned to 1 (qBinom_X_* in CombinationsFormulaOQ03OQ04.lean, 0 sorry/0 axiom, lake env lean verified). Palindromy+pinned-extremes+nonnegativity complete the symmetric boundary; interior unimodality (Proctor/sl₂) remains the open substance. PR #38303."
-  }
+  },
+  "currentState": "Added base-change bridge (researcher-7): qBinom_map (q-binomial commutes with ring homs) + qBinom_X_eval ((qBinom X n k).eval c = qBinom c n k) + qBinom_X_eval_one ((qBinom X n k).eval 1 = C(n,k)). Ties the Gaussian polynomial layer back to scalars: coefficient-sum of the palindromic Gaussian polynomial is the ordinary combination count (q=1 degeneration). 0 axioms. Unimodality (Sylvester/Proctor) remains open.",
+  "lastUpdate": "2026-07-12"
 }


### PR DESCRIPTION
## Summary

The Gaussian q-binomial file develops the polynomial `qBinom X n k ∈ ℤ[X]` (palindromy, monicity, degree, coefficient structure) but had no bridge connecting the *polynomial* layer back to the scalar `q`-binomials — in particular, the fundamental `q = 1` degeneration to the ordinary binomial was only available at the scalar level (`qBinom_at_one`), not for the polynomial.

This PR adds that bridge:

- `qBinom_map (f : A →+* B) (q) : f (qBinom q n k) = qBinom (f q) n k` — the `q`-binomial is assembled purely from the ring operations of the `q`-Pascal recurrence, so **any ring hom commutes with it** (proved by induction matching the recurrence).
- `qBinom_X_eval (c : ℤ) : (qBinom X n k).eval c = qBinom c n k` — instance via `evalRingHom c`.
- `qBinom_X_eval_one : (qBinom X n k).eval 1 = C(n,k)` — composing with `qBinom_at_one`. Since a polynomial's value at `1` is the sum of its coefficients, this says the **coefficient sequence of the palindromic Gaussian polynomial sums to the ordinary combination count** `C(n,k)` — the `q = 1` shadow at the root of the whole `combinations-formula` lineage.

### Verification
- `docker-build.sh Proofs.CombinationsFormulaOQ03OQ04`: **green** (7744 jobs). (Sole warning is a pre-existing `le_or_lt` deprecation on line 88.)
- 0 axioms, 0 sorries, no `native_decide`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)