### PR TITLE
research(erdos-1008-oq-02-oq-02): general K_{s,t} Kővári–Sós–Turán codegree double-count [VERIFIED]

### DIFF
--- a/proofs/Proofs/Erdos1008OQ02OQ02.lean
+++ b/proofs/Proofs/Erdos1008OQ02OQ02.lean
@@ -65,6 +65,20 @@ This session further adds the Vieta relations `kst_vieta_sum` / `kst_vieta_prod`
 (pinning `R⁺+R⁻ = n/2` and `R⁺·R⁻ = -(t-1)n²(n-1)/4` to the quadratic's
 coefficients) and the `K_{2,3}` closed form `k23_quadratic_solve_of_kst`
 (discriminant `8n-7`, `m ≤ ¼ n(1+√(8n-7))`), also local-lean verified.
+
+The final `GraphLevel` subsection generalises the whole graph-level development
+from the `s = 2` (`K_{2,t}`) slice to the full **`K_{s,t}`** family, at the level
+of the Kővári–Sós–Turán *combinatorial core* (the `s`-star double-count): `HasKst`
+(the general `K_{s,t}` containment), the bridge `hasKst_two_iff_hasK2t`,
+`codegree_lt_of_kstFree`, and the double-count `kst_star_count_nat` /
+`kst_star_count_choose` / `kst_star_count_of_free` proving
+`∑_v C(d_v, s) ≤ (t-1)·C(n, s)` for `K_{s,t}`-free graphs — the exact `s`-analogue
+of `kst_cherry_count_nat`.  The passage from this codegree bound to a closed-form
+`ex(n ; K_{s,t})` edge bound needs only the convexity of `x ↦ C(x, s)` (Jensen);
+that single analytic step is *not* claimed here (for `s = 2` it is the
+Cauchy–Schwarz `sq_sum_le_card` already used).  All additions are local-lean
+verified (Lean v4.26.0 + pinned Mathlib oleans, 0 errors) and axiom-free
+(`#print axioms kst_star_count_of_free = [propext, Classical.choice, Quot.sound]`).
 -/
 
 import Mathlib
@@ -893,6 +907,169 @@ theorem notMem_commonNbrs_right (G : SimpleGraph V) [DecidableRel G.Adj] (a b : 
   rw [mem_commonNbrs]
   rintro ⟨-, hbb⟩
   exact G.irrefl hbb
+
+/-!
+### General `K_{s,t}` codegree double-count (Kővári–Sós–Turán combinatorial core)
+
+The graph-level bounds above are the `s = 2` slice of Kővári–Sós–Turán: two
+vertices (`K_{2,t}`) and a codegree hypothesis on *pairs*.  The genuine
+Kővári–Sós–Turán double-count is the `s`-general statement — count *`s`-stars*
+`(S, v)` with `S` an `s`-subset of `N(v)`:
+
+      ∑_v C(d_v, s) = ∑_{S : |S| = s} codeg(S) ≤ (t-1)·C(n, s),
+
+valid in a `K_{s,t}`-free graph because every `s`-set of vertices then has at
+most `t-1` common neighbours.  This is the exact `s`-generalisation of
+`kst_cherry_count_nat` (which is the `s = 2` case, `∑ d(d-1) = ∑ 2·C(d,2)`).
+
+The double-count itself needs no analysis and is proved here in full.  The
+*remaining* gap toward a closed-form `ex(n ; K_{s,t}) = O((t-1)^{1/s}·n^{2-1/s})`
+edge bound is the convexity step `∑_v C(d_v, s) ≥ n·C(2m/n, s)` (Jensen for the
+convex map `x ↦ C(x, s) = x(x-1)⋯(x-s+1)/s!`), which for `s = 2` degenerates to
+the Cauchy–Schwarz `sq_sum_le_card` used above but for general `s` requires the
+convexity of the descending factorial — that analytic step is deliberately *not*
+claimed here.
+-/
+
+/-- **General `K_{s,t}` containment.**  There is a set `S` of `s` vertices with at
+least `t` common neighbours `T` (every vertex of `T` adjacent to every vertex of
+`S`).  This is the bipartite `K_{s,t}` as a subgraph — no edges are required
+*within* `S` or *within* `T`.  For `s = 2` it is equivalent to `HasK2t`
+(`hasKst_two_iff_hasK2t`).  The common neighbours `T` are automatically disjoint
+from `S` (a vertex adjacent to itself is excluded by `G.irrefl`), so no extra
+disjointness hypothesis is needed.  `Fintype`/`DecidableEq` are carried by the
+enclosing section but unused by this definition and the `s = 2` bridge. -/
+def HasKst (G : SimpleGraph V) (s t : ℕ) : Prop :=
+  ∃ (S T : Finset V), S.card = s ∧ t ≤ T.card ∧ (∀ a ∈ S, ∀ v ∈ T, G.Adj a v)
+
+/-- **`HasKst` at `s = 2` is `HasK2t`.**  The general `s`-set formulation
+specialises to the ordered-pair `K_{2,t}` definition used by the graph-level KST
+API above: an `s = 2` witness set `{a, b}` (`a ≠ b` from `S.card = 2`) is exactly
+a distinct pair, and "every vertex of `T` adjacent to every vertex of `S`" unpacks
+to "adjacent to both `a` and `b`". -/
+theorem hasKst_two_iff_hasK2t (G : SimpleGraph V) (t : ℕ) :
+    HasKst G 2 t ↔ HasK2t G t := by
+  constructor
+  · rintro ⟨S, T, hScard, hTcard, hadj⟩
+    obtain ⟨a, b, hab, rfl⟩ := Finset.card_eq_two.mp hScard
+    refine ⟨a, b, T, hab, hTcard, fun y hy => ⟨?_, ?_⟩⟩
+    · exact hadj a (by simp) y hy
+    · exact hadj b (by simp) y hy
+  · rintro ⟨a, b, T, hab, hTcard, hadj⟩
+    refine ⟨{a, b}, T, Finset.card_pair hab, hTcard, ?_⟩
+    intro x hx v hv
+    rw [Finset.mem_insert, Finset.mem_singleton] at hx
+    rcases hx with rfl | rfl
+    · exact (hadj v hv).1
+    · exact (hadj v hv).2
+
+/-- **Codegree bound from `K_{s,t}`-freeness.**  In a `K_{s,t}`-free graph any
+`s`-set `S` of vertices has fewer than `t` common neighbours: otherwise those
+`≥ t` common neighbours would witness a `K_{s,t}`.  The `s`-general analogue of
+`commonNbrs_card_lt_of_free` (the `s = 2` codegree-`< t` statement).  The common
+neighbours of `S` are collected as `univ.filter (S ⊆ N(v))`. -/
+theorem codegree_lt_of_kstFree (G : SimpleGraph V) [DecidableRel G.Adj]
+    (s t : ℕ) (hfree : ¬ HasKst G s t) (S : Finset V) (hS : S.card = s) :
+    (Finset.univ.filter (fun v => S ⊆ G.neighborFinset v)).card < t := by
+  by_contra h
+  push_neg at h
+  refine hfree ⟨S, Finset.univ.filter (fun v => S ⊆ G.neighborFinset v), hS, h, ?_⟩
+  intro a ha v hv
+  rw [Finset.mem_filter] at hv
+  have hav : a ∈ G.neighborFinset v := hv.2 ha
+  rw [SimpleGraph.mem_neighborFinset] at hav
+  exact hav.symm
+
+/-- **General `s`-star double count (`ℕ`, powerset form).**  If every `s`-set of
+vertices has at most `κ` common neighbours, then the total number of `s`-stars
+`∑_v |{S ⊆ N(v) : |S| = s}|` is at most `κ · C(n, s)`.
+
+The proof double-counts incidences `(S, v)` with `S ∈ (N(v)).powersetCard s`:
+summed over `v` and swapped (`Finset.sum_comm`), the fibre over each `s`-set `S`
+is exactly its common-neighbour set `univ.filter (S ⊆ N(v))`, bounded by `κ`; the
+number of `s`-sets is `C(n, s)` (`Finset.card_powersetCard`).  This is the
+`s`-generalisation of the cherry double-count `kst_cherry_count_nat`. -/
+theorem kst_star_count_nat (G : SimpleGraph V) [DecidableRel G.Adj] (s κ : ℕ)
+    (hfree : ∀ S : Finset V, S.card = s →
+      (Finset.univ.filter (fun v => S ⊆ G.neighborFinset v)).card ≤ κ) :
+    ∑ v : V, ((G.neighborFinset v).powersetCard s).card ≤
+      κ * (Fintype.card V).choose s := by
+  have hsub : ∀ v : V,
+      (G.neighborFinset v).powersetCard s ⊆ (Finset.univ : Finset V).powersetCard s := by
+    intro v S hS
+    rw [Finset.mem_powersetCard] at hS ⊢
+    exact ⟨Finset.subset_univ _, hS.2⟩
+  have expand : ∀ v : V, ((G.neighborFinset v).powersetCard s).card =
+      ∑ S ∈ (Finset.univ : Finset V).powersetCard s,
+        (if S ∈ (G.neighborFinset v).powersetCard s then 1 else 0) := by
+    intro v
+    rw [← Finset.card_filter, Finset.filter_mem_eq_inter,
+      Finset.inter_eq_right.mpr (hsub v)]
+  calc ∑ v : V, ((G.neighborFinset v).powersetCard s).card
+      = ∑ v : V, ∑ S ∈ (Finset.univ : Finset V).powersetCard s,
+          (if S ∈ (G.neighborFinset v).powersetCard s then 1 else 0) :=
+        Finset.sum_congr rfl (fun v _ => expand v)
+    _ = ∑ S ∈ (Finset.univ : Finset V).powersetCard s, ∑ v : V,
+          (if S ∈ (G.neighborFinset v).powersetCard s then 1 else 0) := Finset.sum_comm
+    _ ≤ ∑ _S ∈ (Finset.univ : Finset V).powersetCard s, κ := by
+        apply Finset.sum_le_sum
+        intro S hS
+        rw [Finset.mem_powersetCard] at hS
+        rw [← Finset.card_filter]
+        have hset : (Finset.univ.filter
+            (fun v => S ∈ (G.neighborFinset v).powersetCard s)) =
+            Finset.univ.filter (fun v => S ⊆ G.neighborFinset v) := by
+          ext v
+          simp only [Finset.mem_filter, Finset.mem_univ, true_and, Finset.mem_powersetCard]
+          constructor
+          · rintro ⟨hsv, _⟩; exact hsv
+          · intro hsv; exact ⟨hsv, hS.2⟩
+        rw [hset]
+        exact hfree S hS.2
+    _ = ((Finset.univ : Finset V).powersetCard s).card * κ := by
+        rw [Finset.sum_const, smul_eq_mul]
+    _ = κ * (Fintype.card V).choose s := by
+        rw [Finset.card_powersetCard, Finset.card_univ]; ring
+
+/-- **General `s`-star double count (`choose` form).**  The recognisable
+Kővári–Sós–Turán inequality on binomial codegrees: if every `s`-set has at most
+`κ` common neighbours then
+
+      ∑_v C(d_v, s) ≤ κ · C(n, s).
+
+Rewrites `kst_star_count_nat` via `|{S ⊆ N(v) : |S| = s}| = C(d_v, s)`
+(`Finset.card_powersetCard` + `card_neighborFinset_eq_degree`).  Setting `s = 2`,
+`κ = t-1` recovers the content of `kst_cherry_count_nat`
+(`∑ d(d-1) = ∑ 2·C(d,2) ≤ (t-1)·2·C(n,2)`). -/
+theorem kst_star_count_choose (G : SimpleGraph V) [DecidableRel G.Adj] (s κ : ℕ)
+    (hfree : ∀ S : Finset V, S.card = s →
+      (Finset.univ.filter (fun v => S ⊆ G.neighborFinset v)).card ≤ κ) :
+    ∑ v : V, (G.degree v).choose s ≤ κ * (Fintype.card V).choose s := by
+  have h := kst_star_count_nat G s κ hfree
+  calc ∑ v : V, (G.degree v).choose s
+      = ∑ v : V, ((G.neighborFinset v).powersetCard s).card := by
+        apply Finset.sum_congr rfl
+        intro v _
+        rw [Finset.card_powersetCard, SimpleGraph.card_neighborFinset_eq_degree]
+    _ ≤ κ * (Fintype.card V).choose s := h
+
+/-- **`K_{s,t}`-free binomial codegree bound.**  The genuine Kővári–Sós–Turán
+double-count in its forbidden-subgraph form: a `K_{s,t}`-free graph (`t ≥ 1`)
+satisfies
+
+      ∑_v C(d_v, s) ≤ (t-1) · C(n, s).
+
+Combines `kst_star_count_choose` with `codegree_lt_of_kstFree` (every `s`-set has
+`< t`, i.e. `≤ t-1`, common neighbours).  This is the `s`-general combinatorial
+core; the passage to a closed-form edge bound needs the convexity of
+`x ↦ C(x, s)` (Jensen), the analytic step recorded in the section note above. -/
+theorem kst_star_count_of_free (G : SimpleGraph V) [DecidableRel G.Adj]
+    (s t : ℕ) (ht : 1 ≤ t) (hfree : ¬ HasKst G s t) :
+    ∑ v : V, (G.degree v).choose s ≤ (t - 1) * (Fintype.card V).choose s := by
+  apply kst_star_count_choose G s (t - 1)
+  intro S hS
+  have h := codegree_lt_of_kstFree G s t hfree S hS
+  omega
 
 end GraphLevel
 

--- a/src/data/research/problems/erdos-1008-oq-02-oq-02.json
+++ b/src/data/research/problems/erdos-1008-oq-02-oq-02.json
@@ -37,7 +37,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (UNVERIFIED, docker infra down): graph-level K_{2,t} KST development now has BOTH directions — the K_{2,t}-free edge upper bounds AND the forcing/existence converse (edges over threshold ⟹ K_{2,t}). OQ deliverable (graph-level K_{2,t} bound) complete; only re-verification pending build-backend repair.",
+    "progressSummary": "PROGRESS (VERIFIED host-lean v4.26.0, axiom-free): generalized the K_{2,t} graph-level KST bound to the s-general combinatorial core — HasKst def + hasKst_two_iff_hasK2t bridge + kst_star_count_nat/_choose/_of_free giving ∑_v C(d_v,s) ≤ (t-1)·C(n,s) for K_{s,t}-free graphs (+163L, 1 def + 5 thm). Remaining gap to a closed-form edge bound is the convexity/Jensen of x↦C(x,s), documented precisely. The prior s=2 OQ deliverable remains complete/verified.",
     "builtItems": [
       "kst_quadratic_solve (Erdos1008OQ02OQ02.lean): solves the general K_{2,t} KST quadratic 4m^2 <= (t-1)n^2(n-1)+2nm for the upper root 4m <= n(1+s), s=sqrt(1+4(t-1)(n-1))",
       "reiman_quadratic_solve_of_kst: t=2 specialisation recovering the sibling C4 lemma verbatim (1+4(t-1)(n-1)=4n-3)",
@@ -49,21 +49,29 @@
       "hasK2t_of_edge_bound_lt / hasK2t_of_edge_bound_leading_order_lt / hasK2t_two_of_edge_bound_leading_order_lt in Erdos1008OQ02OQ02.lean (GraphLevel): the KST forcing/existence direction — edges above the exact / leading-order / Reiman-C4 threshold force HasK2t; one-line contrapositives of the corresponding upper bounds (PR #37195, UNVERIFIED docker-down)",
       "hasK2t_mono / not_hasK2t_mono : K_{2,t}-containment is antitone in t (HasK2t G t → HasK2t G s for s≤t, same witness T reused) and dually K_{2,t}-freeness is monotone (¬HasK2t G s → ¬HasK2t G t) — the nested lattice ⋯⊇Free(s)⊇Free(t)⊇⋯. [VERIFIED axiom-free, lean-elab exit 0, #print axioms=propext/Quot.sound]",
       "kst_lower_root_exact (Erdos1008OQ02OQ02.lean): the LOWER root R⁻=n(1-s)/4 also makes the general KST quadratic vanish exactly (4R⁻²=(t-1)n²(n-1)+2nR⁻), companion to kst_root_exact; both roots n(1±s)/4 now certified [VERIFIED local-lean v4.26.0, 0 errors]",
-      "kst_quadratic_factor (Erdos1008OQ02OQ02.lean): FULL factorization 4x²-2nx-(t-1)n²(n-1)=4(x-n(1+s)/4)(x-n(1-s)/4) over the two roots n(1±s)/4 — the definitive 'solving the quadratic' identity; encodes Vieta R⁺+R⁻=n/2, R⁺R⁻=-(t-1)n²(n-1)/4; proof linear_combination (n²/4)*hs2 [VERIFIED local-lean v4.26.0, 0 errors]"
+      "kst_quadratic_factor (Erdos1008OQ02OQ02.lean): FULL factorization 4x²-2nx-(t-1)n²(n-1)=4(x-n(1+s)/4)(x-n(1-s)/4) over the two roots n(1±s)/4 — the definitive 'solving the quadratic' identity; encodes Vieta R⁺+R⁻=n/2, R⁺R⁻=-(t-1)n²(n-1)/4; proof linear_combination (n²/4)*hs2 [VERIFIED local-lean v4.26.0, 0 errors]",
+      "HasKst def (general K_{s,t} containment: s-set with ≥t common neighbours) in Erdos1008OQ02OQ02.lean:~918",
+      "hasKst_two_iff_hasK2t bridge (HasKst G 2 t ↔ HasK2t G t) tying general s to existing s=2 API",
+      "codegree_lt_of_kstFree (K_{s,t}-free ⟹ every s-set has <t common nbrs)",
+      "kst_star_count_nat / kst_star_count_choose (∑_v C(d_v,s) ≤ κ·C(n,s) under codegree hypothesis)",
+      "kst_star_count_of_free (∑_v C(d_v,s) ≤ (t-1)·C(n,s), the s-general KST core) — all axiom-free, host-lean VERIFIED v4.26.0"
     ],
     "insights": [
       "The C4 algebraic core generalises to K_{2,t} with zero structural change: replace the single-common-neighbour bound by (t-1), so s^2=4n-3 becomes s^2=1+4(t-1)(n-1) and the KST quadratic gains a (t-1) factor on the n^2(n-1) term. Same nlinarith case-split proof works.",
       "Leading-order closed form is ex(n;K_{2,t}) <= (1/2)(sqrt(t-1)*n^{3/2}+n), matching the classical Kovari-Sos-Turan asymptotic.",
       "The graph-level file only had the K_{2,t}-free upper bounds; the forcing converse (too many edges ⟹ K_{2,t}) is what makes KST an extremal theorem and was missing. Trivial via by_contra + absurd (bound) (not_le.2 hm).",
       "HasK2t (∃ a≠b, T with t≤|T|, all of T common-adjacent to a,b) is antitone in t by reusing the SAME witness T and only weakening its cardinality bound t↦s (le_trans). This gives the K_{2,t}-free-class monotonicity for free — orthogonal to the edge-bound/KST machinery, a pure structural fact about the forbidden-subgraph predicate.",
-      "The problem title ('explicit closed-form solve of the KST quadratic') is fully witnessed at the algebraic level by kst_quadratic_factor: the quadratic 4x²-2nx-(t-1)n²(n-1) has EXACTLY the two roots n(1±s)/4 with s²=1+4(t-1)(n-1), so the Reiman/KST upper bound n(1+s)/4 loses nothing algebraically — all residual slack in ex(n;K_{2,t}) is extremal-graph existence, not the quadratic-formula step. Equality goal closed by linear_combination with coefficient n²/4 (the s²-coefficient of the discriminant), not nlinarith."
+      "The problem title ('explicit closed-form solve of the KST quadratic') is fully witnessed at the algebraic level by kst_quadratic_factor: the quadratic 4x²-2nx-(t-1)n²(n-1) has EXACTLY the two roots n(1±s)/4 with s²=1+4(t-1)(n-1), so the Reiman/KST upper bound n(1+s)/4 loses nothing algebraically — all residual slack in ex(n;K_{2,t}) is extremal-graph existence, not the quadratic-formula step. Equality goal closed by linear_combination with coefficient n²/4 (the s²-coefficient of the discriminant), not nlinarith.",
+      "The genuine Kővári–Sós–Turán double-count is the s-general s-star count ∑_v C(d_v,s)=∑_{|S|=s} codeg(S) ≤ (t-1)·C(n,s); the file previously had only the s=2 (K_{2,t}) slice. Proved the full s-general combinatorial core (kst_star_count_nat/_choose/_of_free) via Finset.powersetCard double-counting + Finset.sum_comm, exactly mirroring kst_cherry_count_nat but with powersetCard s in place of offDiag. No analysis needed; axiom-free."
     ],
     "mathlibGaps": [
-      "No graph-level general cherry-count sum_v C(d_v,2) <= (t-1)*C(n,2) for K_{2,t}-free graphs in the gallery; parent Erdos1008Problem only proves the t=2 (C4) case kovari_sos_turan."
+      "No graph-level general cherry-count sum_v C(d_v,2) <= (t-1)*C(n,2) for K_{2,t}-free graphs in the gallery; parent Erdos1008Problem only proves the t=2 (C4) case kovari_sos_turan.",
+      "Convexity of the descending-factorial / generalized binomial x↦C(x,s)=x(x-1)…(x-s+1)/s! (Jensen ∑_v C(d_v,s) ≥ n·C(2m/n,s)) is the sole remaining analytic step from the s-general codegree bound to a closed-form ex(n;K_{s,t})=O((t-1)^{1/s}·n^{2-1/s}) edge bound; for s=2 it degenerates to Cauchy–Schwarz (sq_sum_le_card, already present)."
     ],
     "nextSteps": [
       "VERIFY the graph-level GraphLevel section of Erdos1008OQ02OQ02.lean once containerd/docker build backend is repaired (this session: meta.db + content-store blob I/O errors)",
-      "Optional: derive the leading-order asymptotic ex(n;K_{2,t}) ≤ ½(√(t-1)·n^{3/2}+n) as an explicit ℝ corollary of kst_edge_bound"
+      "Optional: derive the leading-order asymptotic ex(n;K_{2,t}) ≤ ½(√(t-1)·n^{3/2}+n) as an explicit ℝ corollary of kst_edge_bound",
+      "Prove convexity of x↦C(x,s) on x≥s-1 and apply Jensen to upgrade kst_star_count_of_free to the closed-form K_{s,t} edge bound m ≤ ½((t-1)^{1/s}·n^{2-1/s}+ (s-1)·n)-style estimate; substantial analytic step (~200+ lines)."
     ]
   },
   "tags": [


### PR DESCRIPTION
## Summary

Generalises the graph-level Kővári–Sós–Turán development in `Erdos1008OQ02OQ02.lean` from the `s = 2` (`K_{2,t}`) slice to the **full `K_{s,t}` family**, at the level of the KST *combinatorial core* — the `s`-star double-count.

Previously the file proved the `K_{2,t}` bound `4m ≤ n(1+√(1+4(t-1)(n-1)))` and its leading-order/forcing forms, all resting on the `s = 2` cherry count `∑_v d_v(d_v-1) ≤ (t-1)·n(n-1)` (= `∑ 2·C(d_v,2)`). This PR proves the genuine `s`-general statement:

  ∑_v C(d_v, s) ≤ (t-1)·C(n, s)   for K_{s,t}-free graphs.

## New declarations (+163 lines, 1 def + 5 theorems, axiom-free)

- **`HasKst`** — general `K_{s,t}` containment: an `s`-set of vertices with ≥ `t` common neighbours.
- **`hasKst_two_iff_hasK2t`** — bridges the general definition to the file's existing `s = 2` API (`HasKst G 2 t ↔ HasK2t G t`).
- **`codegree_lt_of_kstFree`** — `K_{s,t}`-free ⟹ every `s`-set has `< t` common neighbours (the `s`-analogue of `commonNbrs_card_lt_of_free`).
- **`kst_star_count_nat` / `kst_star_count_choose`** — the double-count `∑_v C(d_v,s) ≤ κ·C(n,s)` under an `s`-set codegree hypothesis, via `Finset.powersetCard` incidence counting + `Finset.sum_comm` (the exact `s`-analogue of `kst_cherry_count_nat`).
- **`kst_star_count_of_free`** — the forbidden-subgraph form `∑_v C(d_v,s) ≤ (t-1)·C(n,s)`.

## Remaining gap (documented, not claimed)

The passage from this codegree bound to a closed-form `ex(n;K_{s,t}) = O((t-1)^{1/s}·n^{2-1/s})` edge bound needs exactly one analytic step: the convexity of `x ↦ C(x,s)` (Jensen: `∑_v C(d_v,s) ≥ n·C(2m/n,s)`). For `s = 2` this degenerates to the Cauchy–Schwarz `sq_sum_le_card` already in the file. That step is deliberately **not** claimed here.

## Verification

Host-lean verified (Lean v4.26.0 + pinned Mathlib oleans, 0 errors, only a benign `unusedSectionVars` warning matching the file's existing `hasK2t_mono` siblings). `#print axioms kst_star_count_of_free = [propext, Classical.choice, Quot.sound]` — axiom-free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)