### PR TITLE
research(erdos-1008-oq-02-oq-02): close the convexity/Jensen gap — general K_{s,t} closed-form edge bound [VERIFIED 0 axioms]

### DIFF
--- a/proofs/Proofs/Erdos1008OQ02OQ02.lean
+++ b/proofs/Proofs/Erdos1008OQ02OQ02.lean
@@ -73,12 +73,17 @@ of the Kővári–Sós–Turán *combinatorial core* (the `s`-star double-count)
 `codegree_lt_of_kstFree`, and the double-count `kst_star_count_nat` /
 `kst_star_count_choose` / `kst_star_count_of_free` proving
 `∑_v C(d_v, s) ≤ (t-1)·C(n, s)` for `K_{s,t}`-free graphs — the exact `s`-analogue
-of `kst_cherry_count_nat`.  The passage from this codegree bound to a closed-form
-`ex(n ; K_{s,t})` edge bound needs only the convexity of `x ↦ C(x, s)` (Jensen);
-that single analytic step is *not* claimed here (for `s = 2` it is the
-Cauchy–Schwarz `sq_sum_le_card` already used).  All additions are local-lean
-verified (Lean v4.26.0 + pinned Mathlib oleans, 0 errors) and axiom-free
-(`#print axioms kst_star_count_of_free = [propext, Classical.choice, Quot.sound]`).
+of `kst_cherry_count_nat`.  This session then carries out the remaining **convexity
+(Jensen) step** and lands the closed-form edge bound: `kst_analytic_core` (the
+abstract power-mean upgrade), `kst_general_power_bound`
+(`(2m-(s-1)n)^s ≤ (t-1) n^{2s-1}`) and its `s`-th root
+`kst_general_edge_bound_rpow` (`2m ≤ (t-1)^{1/s} n^{2-1/s} + (s-1)n`), the classical
+Kővári–Sós–Turán bound for the full `K_{s,t}` family.  The convexity input is
+Mathlib's power-mean inequality `pow_sum_le_card_mul_sum_pow` (Jensen for `x ↦ x^s`),
+fed by the elementary casts `Nat.pow_sub_le_descFactorial` and
+`Nat.descFactorial_le_pow`.  All additions are local-lean verified (Lean v4.26.0 +
+pinned Mathlib oleans, 0 errors) and axiom-free
+(`#print axioms kst_general_edge_bound_rpow = [propext, Classical.choice, Quot.sound]`).
 -/
 
 import Mathlib
@@ -923,12 +928,15 @@ most `t-1` common neighbours.  This is the exact `s`-generalisation of
 `kst_cherry_count_nat` (which is the `s = 2` case, `∑ d(d-1) = ∑ 2·C(d,2)`).
 
 The double-count itself needs no analysis and is proved here in full.  The
-*remaining* gap toward a closed-form `ex(n ; K_{s,t}) = O((t-1)^{1/s}·n^{2-1/s})`
-edge bound is the convexity step `∑_v C(d_v, s) ≥ n·C(2m/n, s)` (Jensen for the
-convex map `x ↦ C(x, s) = x(x-1)⋯(x-s+1)/s!`), which for `s = 2` degenerates to
-the Cauchy–Schwarz `sq_sum_le_card` used above but for general `s` requires the
-convexity of the descending factorial — that analytic step is deliberately *not*
-claimed here.
+convexity step toward a closed-form `ex(n ; K_{s,t}) = O((t-1)^{1/s}·n^{2-1/s})`
+edge bound — `∑_v C(d_v, s) ≥ n·C(2m/n, s)`, Jensen for the convex map
+`x ↦ C(x, s)` — **is now carried out** below (`kst_analytic_core`,
+`kst_general_power_bound`, `kst_general_edge_bound_rpow`).  Rather than proving
+convexity of the descending factorial directly, we route through the sharp
+elementary lower bound `C(d, s) ≥ (d-s+1)^s/s!` (each of the `s` descending factors
+is `≥ d-s+1`, `Nat.pow_sub_le_descFactorial`) and Mathlib's power-mean inequality
+`pow_sum_le_card_mul_sum_pow` (Jensen for the convex `x ↦ x^s`), which for `s = 2`
+degenerates to the Cauchy–Schwarz `sq_sum_le_card` used above.
 -/
 
 /-- **General `K_{s,t}` containment.**  There is a set `S` of `s` vertices with at
@@ -1070,6 +1078,184 @@ theorem kst_star_count_of_free (G : SimpleGraph V) [DecidableRel G.Adj]
   intro S hS
   have h := codegree_lt_of_kstFree G s t hfree S hS
   omega
+
+/-! ### The convexity (Jensen) step: from codegrees to a closed-form power bound
+
+The combinatorial core `kst_star_count_of_free` delivers `∑_v C(d_v, s) ≤ (t-1) C(n, s)`.
+The section note above flagged the remaining passage to a closed-form edge bound as
+"the convexity of `x ↦ C(x, s)` (Jensen)".  We now carry out exactly that step, in the
+sharp elementary form used in the classical Kővári–Sós–Turán proof.
+
+The convexity input is packaged by Mathlib's power-mean inequality
+`pow_sum_le_card_mul_sum_pow` (`(∑ f)^s ≤ n^{s-1} ∑ f^s` for `f ≥ 0`), which is Jensen
+for the convex map `x ↦ x^s`.  Two elementary casts feed it:
+
+* `Nat.pow_sub_le_descFactorial` : `(d+1-s)^s ≤ d(d-1)⋯(d-s+1) = s! · C(d, s)`
+  (each of the `s` descending factors is `≥ d-s+1`), giving `f_v := (d_v+1-s)` with
+  `f_v^s ≤ s! · C(d_v, s)`;
+* `Nat.descFactorial_le_pow` : `s! · C(n, s) ≤ n^s`.
+
+Chaining `(2m - (s-1)n) ≤ ∑_v f_v`, the power mean, the codegree bound and `s!·C(n,s) ≤ n^s`
+yields the sharp KST power bound `(2m - (s-1)n)^s ≤ (t-1) · n^{2s-1}`. -/
+
+/-- **Abstract analytic core of general Kővári–Sós–Turán.**  For any degree sequence
+`d : ι → ℕ` on a finite vertex set with `2M = ∑_v d_v` (handshake) satisfying the
+codegree double-count `∑_v C(d_v, s) ≤ (t-1) · C(n, s)`, the power-mean inequality
+(Jensen for `x ↦ x^s`) upgrades it to the closed-form power bound
+
+      (2M - (s-1)·n)^s ≤ (t-1) · n^{2s-1}
+
+whenever `2M ≥ (s-1)·n` (the meaningful regime; below it the graph is trivially sparse).
+This is stated abstractly in the degree sequence so it can be instantiated on any graph
+via `kst_general_power_bound`. -/
+theorem kst_analytic_core {ι : Type*} [Fintype ι] (d : ι → ℕ) (s t : ℕ)
+    (hs : 1 ≤ s) (ht : 1 ≤ t) (M : ℝ)
+    (hM : (2 : ℝ) * M = ∑ v, (d v : ℝ))
+    (hcore : ∑ v, ((d v).choose s : ℝ) ≤ ((t : ℝ) - 1) * ((Fintype.card ι).choose s : ℝ))
+    (hL : (0 : ℝ) ≤ 2 * M - ((s : ℝ) - 1) * (Fintype.card ι)) :
+    (2 * M - ((s : ℝ) - 1) * (Fintype.card ι)) ^ s
+      ≤ ((t : ℝ) - 1) * (Fintype.card ι : ℝ) ^ (2 * s - 1) := by
+  set N : ℝ := (Fintype.card ι : ℝ) with hN
+  set f : ι → ℝ := fun v => ((d v + 1 - s : ℕ) : ℝ) with hf_def
+  have htR : (1 : ℝ) ≤ (t : ℝ) := by exact_mod_cast ht
+  have hNnn : (0 : ℝ) ≤ N := by positivity
+  have hfnn : ∀ v ∈ (Finset.univ : Finset ι), 0 ≤ f v := fun v _ => by positivity
+  -- per-vertex factor bound: `f_v^s ≤ s! · C(d_v, s)`
+  have per : ∀ v, f v ^ s ≤ (s.factorial : ℝ) * ((d v).choose s : ℝ) := by
+    intro v
+    have h : (d v + 1 - s) ^ s ≤ s.factorial * (d v).choose s := by
+      calc (d v + 1 - s) ^ s ≤ (d v).descFactorial s := Nat.pow_sub_le_descFactorial _ _
+        _ = s.factorial * (d v).choose s := Nat.descFactorial_eq_factorial_mul_choose _ _
+    have := (Nat.cast_le (α := ℝ)).mpr h
+    push_cast at this ⊢
+    simpa [hf_def] using this
+  -- `s! · C(n, s) ≤ n^s`
+  have facN : (s.factorial : ℝ) * ((Fintype.card ι).choose s : ℝ) ≤ N ^ s := by
+    have h : s.factorial * (Fintype.card ι).choose s ≤ (Fintype.card ι) ^ s := by
+      calc s.factorial * (Fintype.card ι).choose s = (Fintype.card ι).descFactorial s :=
+            (Nat.descFactorial_eq_factorial_mul_choose _ _).symm
+        _ ≤ (Fintype.card ι) ^ s := Nat.descFactorial_le_pow _ _
+    have := (Nat.cast_le (α := ℝ)).mpr h
+    push_cast at this
+    simpa [hN] using this
+  -- summed factor bound: `∑ f_v^s ≤ (t-1) n^s`
+  have sumf_sq : ∑ v, f v ^ s ≤ ((t : ℝ) - 1) * N ^ s := by
+    calc ∑ v, f v ^ s ≤ ∑ v, (s.factorial : ℝ) * ((d v).choose s : ℝ) :=
+          Finset.sum_le_sum (fun v _ => per v)
+      _ = (s.factorial : ℝ) * ∑ v, ((d v).choose s : ℝ) := by rw [← Finset.mul_sum]
+      _ ≤ (s.factorial : ℝ) * (((t : ℝ) - 1) * ((Fintype.card ι).choose s : ℝ)) :=
+          mul_le_mul_of_nonneg_left hcore (by positivity)
+      _ = ((t : ℝ) - 1) * ((s.factorial : ℝ) * ((Fintype.card ι).choose s : ℝ)) := by ring
+      _ ≤ ((t : ℝ) - 1) * N ^ s := mul_le_mul_of_nonneg_left facN (by linarith)
+  -- linear lower bound: `2M - (s-1)n ≤ ∑ f_v`
+  have sumf_lin : 2 * M - ((s : ℝ) - 1) * N ≤ ∑ v, f v := by
+    have hterm : ∀ v ∈ (Finset.univ : Finset ι), ((d v : ℝ) + 1 - s) ≤ f v := by
+      intro v _
+      have hsub : (↑(d v + 1) : ℝ) - s ≤ ((d v + 1 - s : ℕ) : ℝ) := by
+        rcases le_total s (d v + 1) with h | h
+        · rw [Nat.cast_sub h]
+        · rw [Nat.sub_eq_zero_of_le h]
+          simp only [Nat.cast_zero, sub_nonpos]
+          exact_mod_cast h
+      simpa [hf_def] using (by push_cast at hsub ⊢; linarith : ((d v : ℝ) + 1 - s) ≤ f v)
+    calc 2 * M - ((s : ℝ) - 1) * N
+        = ∑ v, ((d v : ℝ) + 1 - s) := by
+          rw [Finset.sum_sub_distrib, Finset.sum_add_distrib, hM]
+          simp only [Finset.sum_const, Finset.card_univ, nsmul_eq_mul, mul_one, hN]
+          ring
+      _ ≤ ∑ v, f v := Finset.sum_le_sum hterm
+  -- power mean (Jensen for `x ↦ x^s`)
+  have hpm : (∑ v, f v) ^ s ≤ N ^ (s - 1) * ∑ v, f v ^ s := by
+    have h := pow_sum_le_card_mul_sum_pow hfnn (s - 1)
+    rw [Nat.sub_add_cancel hs] at h
+    simpa [hN, Finset.card_univ] using h
+  -- assemble
+  have step1 : (2 * M - ((s : ℝ) - 1) * N) ^ s ≤ (∑ v, f v) ^ s :=
+    pow_le_pow_left₀ hL sumf_lin s
+  have step2 : (∑ v, f v) ^ s ≤ N ^ (s - 1) * (((t : ℝ) - 1) * N ^ s) :=
+    hpm.trans (mul_le_mul_of_nonneg_left sumf_sq (by positivity))
+  have hexp : N ^ (s - 1) * (((t : ℝ) - 1) * N ^ s) = ((t : ℝ) - 1) * N ^ (2 * s - 1) := by
+    rw [show 2 * s - 1 = (s - 1) + s by omega, pow_add]; ring
+  calc (2 * M - ((s : ℝ) - 1) * N) ^ s
+      ≤ N ^ (s - 1) * (((t : ℝ) - 1) * N ^ s) := step1.trans step2
+    _ = ((t : ℝ) - 1) * N ^ (2 * s - 1) := hexp
+
+/-- **General Kővári–Sós–Turán closed-form power bound.**  A `K_{s,t}`-free graph on
+`n` vertices with `m` edges (`s ≥ 1`, `t ≥ 1`) satisfies
+
+      (2m - (s-1)·n)^s ≤ (t-1) · n^{2s-1}
+
+whenever `2m ≥ (s-1)·n`.  This is the sharp closed form of the codegree double-count
+`kst_star_count_of_free`: instantiating the abstract Jensen core `kst_analytic_core` at
+`d = G.degree`, `2m = ∑_v d_v` (handshake), and the `K_{s,t}`-free codegree bound.
+
+Taking `s`-th roots gives the classical leading-order edge bound
+`2m ≤ (t-1)^{1/s} · n^{2-1/s} + (s-1)·n`, i.e.
+`ex(n; K_{s,t}) ≤ ½ (t-1)^{1/s} n^{2-1/s} + ½(s-1) n` — see `kst_general_edge_bound_rpow`. -/
+theorem kst_general_power_bound (G : SimpleGraph V) [DecidableRel G.Adj]
+    (s t : ℕ) (hs : 1 ≤ s) (ht : 1 ≤ t) (hfree : ¬ HasKst G s t)
+    (hL : ((s : ℝ) - 1) * (Fintype.card V) ≤ 2 * (G.edgeFinset.card : ℝ)) :
+    (2 * (G.edgeFinset.card : ℝ) - ((s : ℝ) - 1) * (Fintype.card V)) ^ s
+      ≤ ((t : ℝ) - 1) * (Fintype.card V : ℝ) ^ (2 * s - 1) := by
+  refine kst_analytic_core (fun v => G.degree v) s t hs ht (G.edgeFinset.card : ℝ) ?_ ?_ ?_
+  · rw [← Nat.cast_sum, G.sum_degrees_eq_twice_card_edges]; push_cast; ring
+  · have h := kst_star_count_of_free G s t ht hfree
+    calc ∑ v, ((G.degree v).choose s : ℝ)
+        = ((∑ v, (G.degree v).choose s : ℕ) : ℝ) := by push_cast; rfl
+      _ ≤ (((t - 1) * (Fintype.card V).choose s : ℕ) : ℝ) := by exact_mod_cast h
+      _ = ((t : ℝ) - 1) * ((Fintype.card V).choose s : ℝ) := by
+          rw [Nat.cast_mul, Nat.cast_sub ht, Nat.cast_one]
+  · linarith [hL]
+
+/-- **General Kővári–Sós–Turán edge bound (classical closed form).**  Taking `s`-th
+roots in `kst_general_power_bound` gives the recognisable Kővári–Sós–Turán bound: a
+`K_{s,t}`-free graph on `n` vertices with `m` edges (`s ≥ 1`, `t ≥ 1`) satisfies
+
+      2m ≤ (t-1)^{1/s} · n^{2 - 1/s} + (s-1)·n,
+
+i.e. `ex(n; K_{s,t}) ≤ ½ (t-1)^{1/s} n^{2 - 1/s} + ½(s-1) n`.  Unconditional: in the
+sparse regime `2m < (s-1)n` the bound is immediate from nonnegativity of the leading
+term; otherwise `kst_general_power_bound` supplies `(2m-(s-1)n)^s ≤ (t-1) n^{2s-1}`
+and the monotone `s`-th root (`Real.rpow`) extracts the stated inequality
+(`((t-1) n^{2s-1})^{1/s} = (t-1)^{1/s} n^{(2s-1)/s} = (t-1)^{1/s} n^{2-1/s}`).
+
+For `s = 2` this reads `2m ≤ (t-1)^{1/2} n^{3/2} + n`, the `√(t-1)·n^{3/2}` leading
+order matched by the algebraic solve `kst_edge_bound_leading_order` in the `s = 2` core. -/
+theorem kst_general_edge_bound_rpow (G : SimpleGraph V) [DecidableRel G.Adj]
+    (s t : ℕ) (hs : 1 ≤ s) (ht : 1 ≤ t) (hfree : ¬ HasKst G s t) :
+    2 * (G.edgeFinset.card : ℝ)
+      ≤ ((t : ℝ) - 1) ^ ((s : ℝ)⁻¹) * (Fintype.card V : ℝ) ^ (2 - (s : ℝ)⁻¹)
+        + ((s : ℝ) - 1) * (Fintype.card V) := by
+  have hNnn : (0 : ℝ) ≤ (Fintype.card V : ℝ) := by positivity
+  have hTnn : (0 : ℝ) ≤ (t : ℝ) - 1 := by
+    have : (1 : ℝ) ≤ (t : ℝ) := by exact_mod_cast ht
+    linarith
+  have hrhs : (0 : ℝ) ≤ ((t : ℝ) - 1) ^ ((s : ℝ)⁻¹) * (Fintype.card V : ℝ) ^ (2 - (s : ℝ)⁻¹) :=
+    mul_nonneg (Real.rpow_nonneg hTnn _) (Real.rpow_nonneg hNnn _)
+  rcases le_or_gt (((s : ℝ) - 1) * (Fintype.card V : ℝ)) (2 * (G.edgeFinset.card : ℝ)) with hL | hL
+  · -- main regime `2m ≥ (s-1)n`: take the `s`-th root of the power bound
+    have hpow := kst_general_power_bound G s t hs ht hfree hL
+    have hLnn : (0 : ℝ) ≤ 2 * (G.edgeFinset.card : ℝ) - ((s : ℝ) - 1) * (Fintype.card V : ℝ) := by
+      linarith
+    have hcast : ((2 * s - 1 : ℕ) : ℝ) = 2 * (s : ℝ) - 1 := by
+      have h2 : 1 ≤ 2 * s := by omega
+      rw [Nat.cast_sub h2]; push_cast; ring
+    have key : ((Fintype.card V : ℝ) ^ (2 * s - 1)) ^ ((s : ℝ)⁻¹)
+        = (Fintype.card V : ℝ) ^ (2 - (s : ℝ)⁻¹) := by
+      rw [← Real.rpow_natCast (Fintype.card V : ℝ) (2 * s - 1), ← Real.rpow_mul hNnn]
+      congr 1
+      rw [hcast]; field_simp
+    have hroot : 2 * (G.edgeFinset.card : ℝ) - ((s : ℝ) - 1) * (Fintype.card V : ℝ)
+        = ((2 * (G.edgeFinset.card : ℝ) - ((s : ℝ) - 1) * (Fintype.card V : ℝ)) ^ s) ^ ((s : ℝ)⁻¹) :=
+      (Real.pow_rpow_inv_natCast hLnn (by omega)).symm
+    have hLle : 2 * (G.edgeFinset.card : ℝ) - ((s : ℝ) - 1) * (Fintype.card V : ℝ)
+        ≤ ((t : ℝ) - 1) ^ ((s : ℝ)⁻¹) * (Fintype.card V : ℝ) ^ (2 - (s : ℝ)⁻¹) := by
+      rw [hroot]
+      refine (Real.rpow_le_rpow (by positivity) hpow (by positivity)).trans ?_
+      rw [Real.mul_rpow hTnn (by positivity), key]
+    linarith [hLle]
+  · -- sparse regime `2m < (s-1)n`: bound is immediate
+    linarith [hrhs, hL]
 
 end GraphLevel
 

--- a/src/data/research/problems/erdos-1008-oq-02-oq-02.json
+++ b/src/data/research/problems/erdos-1008-oq-02-oq-02.json
@@ -37,7 +37,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (VERIFIED host-lean v4.26.0, axiom-free): generalized the K_{2,t} graph-level KST bound to the s-general combinatorial core — HasKst def + hasKst_two_iff_hasK2t bridge + kst_star_count_nat/_choose/_of_free giving ∑_v C(d_v,s) ≤ (t-1)·C(n,s) for K_{s,t}-free graphs (+163L, 1 def + 5 thm). Remaining gap to a closed-form edge bound is the convexity/Jensen of x↦C(x,s), documented precisely. The prior s=2 OQ deliverable remains complete/verified.",
+    "progressSummary": "PROGRESS: closed the documented convexity/Jensen gap — general K_{s,t} now has a fully axiom-free closed-form edge bound 2m ≤ (t-1)^{1/s} n^{2-1/s} + (s-1)n (kst_general_edge_bound_rpow), not just the codegree double-count.",
     "builtItems": [
       "kst_quadratic_solve (Erdos1008OQ02OQ02.lean): solves the general K_{2,t} KST quadratic 4m^2 <= (t-1)n^2(n-1)+2nm for the upper root 4m <= n(1+s), s=sqrt(1+4(t-1)(n-1))",
       "reiman_quadratic_solve_of_kst: t=2 specialisation recovering the sibling C4 lemma verbatim (1+4(t-1)(n-1)=4n-3)",
@@ -54,7 +54,10 @@
       "hasKst_two_iff_hasK2t bridge (HasKst G 2 t ↔ HasK2t G t) tying general s to existing s=2 API",
       "codegree_lt_of_kstFree (K_{s,t}-free ⟹ every s-set has <t common nbrs)",
       "kst_star_count_nat / kst_star_count_choose (∑_v C(d_v,s) ≤ κ·C(n,s) under codegree hypothesis)",
-      "kst_star_count_of_free (∑_v C(d_v,s) ≤ (t-1)·C(n,s), the s-general KST core) — all axiom-free, host-lean VERIFIED v4.26.0"
+      "kst_star_count_of_free (∑_v C(d_v,s) ≤ (t-1)·C(n,s), the s-general KST core) — all axiom-free, host-lean VERIFIED v4.26.0",
+      "kst_analytic_core (Erdos1008OQ02OQ02.lean): abstract Jensen upgrade — degree seq d, 2M=∑d_v, ∑C(d_v,s)≤(t-1)C(n,s), 2M≥(s-1)n ⊢ (2M-(s-1)n)^s ≤ (t-1)n^(2s-1); axiom-free",
+      "kst_general_power_bound (Erdos1008OQ02OQ02.lean): graph-level closed-form power bound for K_{s,t}-free G via handshake + kst_star_count_of_free; axiom-free",
+      "kst_general_edge_bound_rpow (Erdos1008OQ02OQ02.lean): unconditional classical KST 2m ≤ (t-1)^(1/s) n^(2-1/s) + (s-1)n via monotone s-th root (Real.pow_rpow_inv_natCast, Real.mul_rpow); axiom-free"
     ],
     "insights": [
       "The C4 algebraic core generalises to K_{2,t} with zero structural change: replace the single-common-neighbour bound by (t-1), so s^2=4n-3 becomes s^2=1+4(t-1)(n-1) and the KST quadratic gains a (t-1) factor on the n^2(n-1) term. Same nlinarith case-split proof works.",
@@ -62,16 +65,19 @@
       "The graph-level file only had the K_{2,t}-free upper bounds; the forcing converse (too many edges ⟹ K_{2,t}) is what makes KST an extremal theorem and was missing. Trivial via by_contra + absurd (bound) (not_le.2 hm).",
       "HasK2t (∃ a≠b, T with t≤|T|, all of T common-adjacent to a,b) is antitone in t by reusing the SAME witness T and only weakening its cardinality bound t↦s (le_trans). This gives the K_{2,t}-free-class monotonicity for free — orthogonal to the edge-bound/KST machinery, a pure structural fact about the forbidden-subgraph predicate.",
       "The problem title ('explicit closed-form solve of the KST quadratic') is fully witnessed at the algebraic level by kst_quadratic_factor: the quadratic 4x²-2nx-(t-1)n²(n-1) has EXACTLY the two roots n(1±s)/4 with s²=1+4(t-1)(n-1), so the Reiman/KST upper bound n(1+s)/4 loses nothing algebraically — all residual slack in ex(n;K_{2,t}) is extremal-graph existence, not the quadratic-formula step. Equality goal closed by linear_combination with coefficient n²/4 (the s²-coefficient of the discriminant), not nlinarith.",
-      "The genuine Kővári–Sós–Turán double-count is the s-general s-star count ∑_v C(d_v,s)=∑_{|S|=s} codeg(S) ≤ (t-1)·C(n,s); the file previously had only the s=2 (K_{2,t}) slice. Proved the full s-general combinatorial core (kst_star_count_nat/_choose/_of_free) via Finset.powersetCard double-counting + Finset.sum_comm, exactly mirroring kst_cherry_count_nat but with powersetCard s in place of offDiag. No analysis needed; axiom-free."
+      "The genuine Kővári–Sós–Turán double-count is the s-general s-star count ∑_v C(d_v,s)=∑_{|S|=s} codeg(S) ≤ (t-1)·C(n,s); the file previously had only the s=2 (K_{2,t}) slice. Proved the full s-general combinatorial core (kst_star_count_nat/_choose/_of_free) via Finset.powersetCard double-counting + Finset.sum_comm, exactly mirroring kst_cherry_count_nat but with powersetCard s in place of offDiag. No analysis needed; axiom-free.",
+      "Convexity/Jensen step for the general K_{s,t} bound is realized elementarily WITHOUT proving convexity of the descending factorial: route through C(d,s) ≥ (d-s+1)^s/s! (each of s descending factors ≥ d-s+1, Nat.pow_sub_le_descFactorial) then Mathlib power-mean pow_sum_le_card_mul_sum_pow (Jensen for x↦x^s).",
+      "Sharp KST power form (2m-(s-1)n)^s ≤ (t-1)·n^(2s-1) is the general-s analogue of the s=2 quadratic 4m² ≤ (t-1)n²(n-1)+2nm; s-th root gives the classical 2m ≤ (t-1)^(1/s) n^(2-1/s) + (s-1)n unconditionally (sparse regime 2m<(s-1)n handled by nonnegativity)."
     ],
     "mathlibGaps": [
       "No graph-level general cherry-count sum_v C(d_v,2) <= (t-1)*C(n,2) for K_{2,t}-free graphs in the gallery; parent Erdos1008Problem only proves the t=2 (C4) case kovari_sos_turan.",
-      "Convexity of the descending-factorial / generalized binomial x↦C(x,s)=x(x-1)…(x-s+1)/s! (Jensen ∑_v C(d_v,s) ≥ n·C(2m/n,s)) is the sole remaining analytic step from the s-general codegree bound to a closed-form ex(n;K_{s,t})=O((t-1)^{1/s}·n^{2-1/s}) edge bound; for s=2 it degenerates to Cauchy–Schwarz (sq_sum_le_card, already present)."
+      "Convexity of the descending-factorial / generalized binomial x↦C(x,s)=x(x-1)…(x-s+1)/s! (Jensen ∑_v C(d_v,s) ≥ n·C(2m/n,s)) is the sole remaining analytic step from the s-general codegree bound to a closed-form ex(n;K_{s,t})=O((t-1)^{1/s}·n^{2-1/s}) edge bound; for s=2 it degenerates to Cauchy–Schwarz (sq_sum_le_card, already present).",
+      "Mathlib has NO named general Kővári–Sós–Turán / Zarankiewicz edge bound; power-mean pow_sum_le_card_mul_sum_pow + Nat.pow_sub_le_descFactorial + Nat.descFactorial_le_pow suffice to build it in ~180 lines."
     ],
     "nextSteps": [
-      "VERIFY the graph-level GraphLevel section of Erdos1008OQ02OQ02.lean once containerd/docker build backend is repaired (this session: meta.db + content-store blob I/O errors)",
-      "Optional: derive the leading-order asymptotic ex(n;K_{2,t}) ≤ ½(√(t-1)·n^{3/2}+n) as an explicit ℝ corollary of kst_edge_bound",
-      "Prove convexity of x↦C(x,s) on x≥s-1 and apply Jensen to upgrade kst_star_count_of_free to the closed-form K_{s,t} edge bound m ≤ ½((t-1)^{1/s}·n^{2-1/s}+ (s-1)·n)-style estimate; substantial analytic step (~200+ lines)."
+      "Derive the leading-order asymptotic ex(n;K_{s,t}) = ½ n^{2-1/s} (1+o(1))·(t-1)^{1/s} statement (currently a finite-n inequality; asymptotic wrapper would need o-notation).",
+      "Sharpen constant: current route uses C(n,s) ≤ n^s/s! and (d-s+1)^s ≤ descFactorial; a tighter root-of-quadratic style bound could recover the exact ¼(1+√...)n for s=2 within the general-s theorem.",
+      "Reiman/Kővári–Sós–Turán converse: lower-bound constructions (incidence graphs / norm graphs) showing the n^{2-1/s} exponent is tight."
     ]
   },
   "tags": [


### PR DESCRIPTION
## Summary

Closes the **convexity (Jensen) step** flagged as *"deliberately not claimed here"* in the `GraphLevel` section note of `Erdos1008OQ02OQ02.lean`. The previous general-`K_{s,t}` work (PR #38332) landed the codegree double-count

    ∑_v C(d_v, s) ≤ (t-1)·C(n, s)   (kst_star_count_of_free)

but stopped short of a closed-form edge bound. This PR carries out the analytic step and lands the classical Kővári–Sós–Turán bound for the full `K_{s,t}` family.

## New theorems (all axiom-free, 0 sorries, local-lean verified)

- **`kst_analytic_core`** — abstract power-mean upgrade: for a degree sequence `d` with `2M = ∑_v d_v` and `∑_v C(d_v,s) ≤ (t-1)C(n,s)`, gives `(2M-(s-1)n)^s ≤ (t-1)·n^{2s-1}` (when `2M ≥ (s-1)n`).
- **`kst_general_power_bound`** — graph-level instantiation for a `K_{s,t}`-free graph `G` via the handshake lemma + `kst_star_count_of_free`.
- **`kst_general_edge_bound_rpow`** — unconditional `s`-th root, the recognizable closed form:

      2m ≤ (t-1)^{1/s} · n^{2-1/s} + (s-1)·n.

## Method

Rather than proving convexity of the descending factorial directly, the proof routes through the sharp elementary lower bound `C(d,s) ≥ (d-s+1)^s/s!` (each of the `s` descending factors is `≥ d-s+1`, `Nat.pow_sub_le_descFactorial`) together with Mathlib's power-mean inequality `pow_sum_le_card_mul_sum_pow` (Jensen for the convex `x ↦ x^s`) and `Nat.descFactorial_le_pow`. For `s = 2` this degenerates to the Cauchy–Schwarz `sq_sum_le_card` already used in the `K_{2,t}` core.

## Verification

```
#print axioms Erdos1008.kst_analytic_core          = [propext, Classical.choice, Quot.sound]
#print axioms Erdos1008.kst_general_power_bound     = [propext, Classical.choice, Quot.sound]
#print axioms Erdos1008.kst_general_edge_bound_rpow = [propext, Classical.choice, Quot.sound]
```

Full file builds with 0 errors (Lean v4.26.0 + pinned Mathlib oleans); only pre-existing `unusedSectionVars` lints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)