### PR TITLE
research(descartes-oq0103): complete the quadratic sign-change classification (b=0 case) [VERIFIED]

### DIFF
--- a/proofs/Proofs/DescartesRuleOfSignsOQ01OQ03.lean
+++ b/proofs/Proofs/DescartesRuleOfSignsOQ01OQ03.lean
@@ -1475,6 +1475,36 @@ theorem signChangesInCoeffs_quadratic_no_change {a b c : ℝ} (ha : a ≠ 0)
   exact countSignChanges_three_mid_ne_zero (by simpa using hb)
     (by simpa using h01) (by simpa using h12)
 
+/-- **One sign change — zero middle, opposite outer signs.**  If `b = 0` and `a·c < 0`
+(sign pattern `+ 0 −` or `− 0 +`) then `a·X² + c` has exactly one coefficient sign change,
+jumping over the vanishing middle term.  This is the *general* form of the base file's
+`X² − 1` example, and — being the `b = 0` complement of `signChangesInCoeffs_quadratic_one_left`
+/ `_one_right` — completes the sign-change classification to **every** real quadratic. -/
+theorem signChangesInCoeffs_quadratic_mid_zero_one {a b c : ℝ} (ha : a ≠ 0)
+    (hb : b = 0) (hac : a * c < 0) :
+    signChangesInCoeffs (C a * X ^ 2 + C b * X + C c) = 1 := by
+  rw [signChangesInCoeffs_quadratic ha]
+  exact countSignChanges_three_mid_zero_pos (by simpa using hb) (by simpa using hac)
+
+/-- **No sign change — zero middle, non-opposite outer signs.**  If `b = 0` and `0 ≤ a·c`
+then `a·X² + c` has no coefficient sign change: the general form of `X² + 1`.  With
+`signChangesInCoeffs_quadratic_mid_zero_one` and the four nonzero-middle corollaries, the
+coefficient sign-change count of an arbitrary real quadratic is now determined in **all**
+sign configurations of `(a, b, c)`. -/
+theorem signChangesInCoeffs_quadratic_mid_zero_no_change {a b c : ℝ} (ha : a ≠ 0)
+    (hb : b = 0) (hac : 0 ≤ a * c) :
+    signChangesInCoeffs (C a * X ^ 2 + C b * X + C c) = 0 := by
+  rw [signChangesInCoeffs_quadratic ha]
+  exact countSignChanges_three_mid_zero_zero (by simpa using hb) (by simpa using hac)
+
+/-- **Concrete tight witness `X² − 3X + 2 = (X − 1)(X − 2)`.**  Coefficient sequence
+`[1, −3, 2]` (`+ − +`), so exactly two coefficient sign changes — matching its two positive
+roots `1, 2`.  A degree-`2` polynomial *attaining* Descartes' upper bound with distinct
+positive roots (the base file's examples `X² ± 1` only realise `V = 1` and `V = 0`). -/
+theorem signChanges_x2_sub_3x_add_2 :
+    signChangesInCoeffs (C 1 * X ^ 2 + C (-3) * X + C 2 : ℝ[X]) = 2 :=
+  signChangesInCoeffs_quadratic_alternating (by norm_num) (by norm_num) (by norm_num)
+
 end QuadraticFamily
 
 end DescartesRuleOfSignsOQ01OQ03

--- a/research/problems/descartes-rule-of-signs-oq-01-oq-03/knowledge.md
+++ b/research/problems/descartes-rule-of-signs-oq-01-oq-03/knowledge.md
@@ -100,3 +100,31 @@ axiom; now discharged"). Base file's remaining 5 axioms are the DEEP Descartes f
 polynomial family, prove the `coeffSequence p natDegree = ![...]` identity once (funext +
 fin_cases + coeff_* simp set), then every downstream count is `rw [signChanges_quadratic];
 apply <Fin n lemma> (by simpa using hyp)`.
+
+## Session 2026-07-12 (researcher-2) — complete the quadratic sign-change classification (b=0 case)
+
+**Mode:** REVISIT (RICH, saturated re-serve of COMPLETED). **Outcome:** +3 axiom-free
+theorems, 0 sorries, VERIFIED host lean 4.26.0 (`#print axioms` = [propext,
+Classical.choice, Quot.sound]; the file's 5 deep Descartes axioms are NOT pulled in by the
+constructive sign-change side).
+
+Found nextSteps #1 (de-axiomatize `X²±1`) and #2 (general quadratic count) BOTH already done
+by prior sessions — §4 replaced the base file's `example_x2_*_sign_changes` axioms with
+theorems, and §12 (`signChangesInCoeffs_quadratic` + four corollaries) computes the count for
+every quadratic with **nonzero** middle term. Stale nextSteps did not reflect §12.
+
+Genuine remaining gap: §12's four corollaries all require `b ≠ 0` (nonzero middle); the
+`b = 0` general quadratic `a·X² + c` was only covered for the specific `X²±1` (§4). Closed it
+using the already-relocated `Fin 3` mid-zero engine:
+- `signChangesInCoeffs_quadratic_mid_zero_one` (`b=0`, `a·c<0` ⟹ `V=1`, general form of `X²−1`)
+- `signChangesInCoeffs_quadratic_mid_zero_no_change` (`b=0`, `0≤a·c` ⟹ `V=0`, general form of `X²+1`)
+- `signChanges_x2_sub_3x_add_2`: concrete tight witness `X²−3X+2=(X−1)(X−2)`, coeffs `[1,−3,2]`
+  (`+ − +`), `V=2` — first real polynomial here to ATTAIN the degree-2 Descartes bound with
+  two distinct positive roots (base examples `X²±1` only give `V=1,0`).
+
+**Upshot:** the coefficient sign-change count `V(a·X²+b·X+c)` is now determined in ALL sign
+configurations of `(a,b,c)` (both `b=0` and `b≠0`) — the degree-2 left-hand side of Descartes
+is complete. Only nextStep #3 (prove B1–B3 for GENERAL polynomials, making Sturm⟹Descartes
+unconditional) remains — that is the deep content behind the 5 standing axioms, not elementary.
+
+**Files Modified:** proofs/Proofs/DescartesRuleOfSignsOQ01OQ03.lean (+3 thms; 1480→1512 lines).

--- a/src/data/research/problems/descartes-rule-of-signs-oq-01-oq-03.json
+++ b/src/data/research/problems/descartes-rule-of-signs-oq-01-oq-03.json
@@ -38,7 +38,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "Solved. The implication 'Sturm's exact-count theorem => Descartes' rule of signs' is formalized in proofs/Proofs/DescartesRuleOfSignsOQ01OQ03.lean (8 theorems, 1 definition, 1 structure, 0 sorries, 0 axiom declarations). The logical content is captured by two omega-closed natural-number lemmas (upper_bound_core, parity_core): reading hi = sigma_p(0), lo = sigma_p(B), bound = V(p), an exact count pos = hi - lo with lo <= hi <= bound and even gap/tail yields both Descartes' bound and even-defect parity. A SturmReduction structure packages Sturm's exact count on (0, B] plus the three classical comparison facts, and the three Descartes laws are derived from it. The Sturm half is validated axiom-free on linear polynomials X - c by reusing the parent entry's axiom-free sturm_linear_left/right. The general direction is conditional on the SturmReduction bridge (the entry's single standing assumption); the linear case is unconditional. A prerequisite Mathlib 4.26.0 rot in the base file DescartesRuleOfSigns.lean was repaired so the dependency chain compiles. PR #30272.",
+    "progressSummary": "Solved + degree-2 sign-change side COMPLETE. Sturm⟹Descartes formalized (conditional on SturmReduction bridge; unconditional on linear X−c). The coefficient sign-change count V(a·X²+b·X+c) is now determined for EVERY real quadratic in all sign configs of (a,b,c) (§4 X²±1, §12 nonzero-middle, this session b=0 general + tight witness X²−3X+2). 0 sorries; the file carries 5 deep standing axioms for the general Descartes direction (nextStep #3), not elementarily removable.",
     "builtItems": [
       "upper_bound_core / parity_core: omega-closed reduction skeleton over N (axiom-free)",
       "SturmReduction structure bridging Sturm's variation count to Descartes' coefficient sign-change count",
@@ -51,7 +51,9 @@
       "countSignChanges_three_mid_ne_zero (r7): nonzero middle, neither adjacent pair opposite => count 0 — axiom-free; the four nonzero-middle lemmas + the middle-zero pair complete the Fin 3 count for every length-3 real sequence",
       "x2_minus_x_plus_1_signChanges (r7): axiom-free evaluation signChangesInCoeffs (X^2 - X + 1) = 2 (coefficient sequence [1,-1,1]) — the first count-2 (Descartes-tight) quadratic validation",
       "signChangesInCoeffs_eq_natDegree_of_alternating (r6): polynomial-level SHARPNESS of Descartes' degree bound — a nowhere-zero, strictly sign-alternating coefficient sequence gives V(p) = natDegree p exactly; lifts the sequence-level countSignChanges_alternating to polynomials, the companion of signChangesInCoeffs_le_natDegree — axiom-free",
-      "x3_minus_x2_plus_x_minus_1_signChanges (r6): first concrete degree-3 validation, signChangesInCoeffs (X^3 - X^2 + X - 1) = 3 (coeff sequence [1,-1,1,-1], Descartes-tight cubic), derived from the general sharpness theorem — axiom-free"
+      "x3_minus_x2_plus_x_minus_1_signChanges (r6): first concrete degree-3 validation, signChangesInCoeffs (X^3 - X^2 + X - 1) = 3 (coeff sequence [1,-1,1,-1], Descartes-tight cubic), derived from the general sharpness theorem — axiom-free",
+      "signChangesInCoeffs_quadratic_mid_zero_one/_mid_zero_no_change: the b=0 general quadratic a·X²+c count (general form of X²∓1), completing V(a·X²+b·X+c) for ALL sign configs of (a,b,c)",
+      "signChanges_x2_sub_3x_add_2: concrete tight witness X²−3X+2=(X−1)(X−2) with V=2 attaining the degree-2 Descartes bound (two distinct positive roots)"
     ],
     "insights": [
       "The entire 'exact count => bound + parity' content reduces to two omega lemmas once the count is written as a non-increasing difference hi - lo; the inequality and the parity fall out of upper_bound_core and parity_core respectively.",
@@ -60,15 +62,14 @@
       "Gallery base file DescartesRuleOfSigns.lean had rotted against Mathlib 4.26.0 (Polynomial.card_roots_le_degree removed; Fin.castSucc_lt_succ arg now implicit; Multiset.countP_le_card needs explicit multiset) and required repair before any dependent could build.",
       "The base file's axiomatised concrete counts (example_x2_minus_1_sign_changes = 1, example_x2_plus_1_sign_changes = 0) are removable: with a Fin 3 middle-zero sign-change lemma the coefficient sequences [1,0,-1] and [1,0,1] are counted axiom-free (natDegree via compute_degree!, coefficients via simp on coeffSequence/coeff_X_pow/coeff_one).",
       "The full Fin 3 sign-change count is governed by the two ADJACENT pairs: count = [f0*f1<0] + [f1*f2<0] whenever the middle f1 is nonzero (the jump-over pair (0,2) is impossible once f1 != 0). A zero middle instead activates (0,2) and caps the count at 1; so the value 2 is exactly the nonzero-middle alternating case, matching Descartes' bound being tight for quadratics with two positive roots (r7).",
-      "The degree bound V(p) <= natDegree p is SHARP at the polynomial level: any p whose coefficients are all nonzero and strictly alternate in sign attains V(p) = natDegree p (signChangesInCoeffs_eq_natDegree_of_alternating), a direct lift of the sequence-level countSignChanges_alternating via coeffSequence; the cubic X^3-X^2+X-1 realises the degree-3 case (r6)."
+      "The degree bound V(p) <= natDegree p is SHARP at the polynomial level: any p whose coefficients are all nonzero and strictly alternate in sign attains V(p) = natDegree p (signChangesInCoeffs_eq_natDegree_of_alternating), a direct lift of the sequence-level countSignChanges_alternating via coeffSequence; the cubic X^3-X^2+X-1 realises the degree-3 case (r6).",
+      "§4 (de-axiomatize X²±1) and §12 (general nonzero-middle quadratic sign-change count) were already complete from prior sessions; the stale nextSteps did not reflect §12."
     ],
     "mathlibGaps": [
       "No packaged Sturm-sequence sign-variation theory in Mathlib connecting sigma_p to the coefficient sign-change count V(p); the comparison facts (B1)-(B3) must be supplied as assumptions."
     ],
     "nextSteps": [
-      "Relocate the Fin 3 helpers into the base file DescartesRuleOfSigns.lean and replace its two example_x2_*_sign_changes axiom declarations with theorems (the proofs now exist in this entry).",
-      "Generalise to a full Fin 3 sign-change count (arbitrary nonzero middle term) for quadratics aX^2+bX+c with b != 0.",
-      "Prove (B1)-(B3) for general polynomials to make the general Sturm => Descartes implication unconditional."
+      "Prove (B1)-(B3) for GENERAL polynomials to make Sturm⟹Descartes unconditional — this is the deep content behind the 5 standing axioms (descartes_upper_bound/parity/negative_roots, alternating_signs_max_roots, derivative_reduces_sign_changes), not elementary."
     ]
   },
   "tags": [


### PR DESCRIPTION
## Summary

Descartes' rule of signs, OQ-01-OQ-03 research file. Prior sessions had de-axiomatized the
base file's `X² ± 1` examples (§4) and computed the coefficient sign-change count
`V(a·X² + b·X + c)` for every quadratic with **nonzero** middle term (§12, four corollaries).

This PR closes the one remaining configuration — the **zero-middle** general quadratic
`a·X² + c` (`b = 0`) — so `V` is now determined for **every** real quadratic in all sign
configurations of `(a, b, c)`:

- `signChangesInCoeffs_quadratic_mid_zero_one` — `b = 0`, `a·c < 0` ⟹ `V = 1` (the general
  form of the base file's `X² − 1`).
- `signChangesInCoeffs_quadratic_mid_zero_no_change` — `b = 0`, `0 ≤ a·c` ⟹ `V = 0` (the
  general form of `X² + 1`).
- `signChanges_x2_sub_3x_add_2` — concrete tight witness `X² − 3X + 2 = (X − 1)(X − 2)`,
  coefficient sequence `[1, −3, 2]` (`+ − +`), `V = 2`. The first real polynomial in this
  development to **attain** the degree-2 Descartes bound with two distinct positive roots
  (the base examples `X² ± 1` only realise `V = 1` and `V = 0`).

All three reuse the already-relocated `Fin 3` mid-zero engine
(`countSignChanges_three_mid_zero_pos` / `_zero`) and the existing `§ 12`
`signChangesInCoeffs_quadratic` reduction.

## Verification

- `proofs/Proofs/DescartesRuleOfSignsOQ01OQ03.lean`: 1480 → 1512 lines, +3 theorems, **0 sorries**.
- Host lean 4.26.0: builds clean (only pre-existing warnings in §12 code, untouched).
- `#print axioms` on all three new theorems = `[propext, Classical.choice, Quot.sound]` — the
  file's 5 deep standing Descartes axioms are **not** pulled in by the constructive
  sign-change side.

Only next step remaining: proving (B1)–(B3) for **general** polynomials to make the
Sturm ⟹ Descartes implication unconditional — the deep content behind the 5 standing axioms,
not elementarily removable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)