### PR TITLE
research(shannon-awgn-oq-03-oq-01): wideband limit — equal-noise capacity → P/(2c) [VERIFIED 0 axioms]

### DIFF
--- a/proofs/Proofs/ShannonChannelCodingAWGNOQ03OQ01EqualNoise.lean
+++ b/proofs/Proofs/ShannonChannelCodingAWGNOQ03OQ01EqualNoise.lean
@@ -328,4 +328,44 @@ theorem rate_equalNoise_strictConcaveOn_power [Nonempty ι] {c : ℝ} (hc : 0 < 
         mul_lt_mul_of_pos_left hstep hNpos
     _ = (Fintype.card ι : ℝ) / 2 * Real.log (1 + (a * x + b * y) / k) := by rw [hsum]
 
+
+/-! ## The wideband (infinite-channel) limit `C → P/(2c)` -/
+
+/-- **Wideband capacity limit.**  As the number `n` of identical parallel Gaussian
+    channels of noise `c > 0` grows, the equal-noise capacity converges to the
+    bandwidth-independent ceiling:
+    `(n/2)·log(1 + P/(n·c)) → P/(2c)` as `n → ∞`.
+
+    Together with `rate_equalNoise_le_wideband` (which caps *every* finite `n` at
+    `P/(2c)`), this shows the wideband bound is **sharp**: `P/(2c)` is exactly the
+    supremum of the achievable equal-noise rates as a fixed power budget `P` is
+    spread over more and more sub-channels — Shannon's infinite-bandwidth AWGN
+    limit, `C_∞ = P/(2c)` nats.  No sign hypothesis on `P` is needed.
+
+    The proof rewrites `n·log(1 + P/(n·c)) = log((1 + (P/c)/n)^n)` (via `Real.log_pow`)
+    and passes to the limit through `Real.tendsto_one_add_div_pow_exp`
+    (`(1 + t/n)^n → exp t`) composed with continuity of `Real.log` at `exp(P/c) > 0`,
+    then scales by `1/2`. -/
+theorem rate_equalNoise_tendsto_wideband {c : ℝ} (hc : 0 < c) (P : ℝ) :
+    Filter.Tendsto (fun n : ℕ => (n : ℝ) / 2 * Real.log (1 + P / (n * c)))
+      Filter.atTop (nhds (P / (2 * c))) := by
+  have hcne : c ≠ 0 := hc.ne'
+  -- Base limit `(1 + (P/c)/n)^n → exp(P/c)`.
+  have hbase := Real.tendsto_one_add_div_pow_exp (P / c)
+  -- Compose with the continuous `log` at `exp(P/c) ≠ 0`, using `log (exp _) = _`.
+  have hlog : Filter.Tendsto
+      (fun n : ℕ => Real.log ((1 + (P / c) / n) ^ n)) Filter.atTop (nhds (P / c)) := by
+    have h := ((Real.continuousAt_log (Real.exp_ne_zero (P / c))).tendsto).comp hbase
+    rwa [Real.log_exp] at h
+  -- `log((1 + (P/c)/n)^n) = n · log(1 + P/(n·c))`.
+  have hmain : Filter.Tendsto
+      (fun n : ℕ => (n : ℝ) * Real.log (1 + P / (n * c))) Filter.atTop (nhds (P / c)) := by
+    refine hlog.congr (fun n => ?_)
+    rw [Real.log_pow, div_div, mul_comm c (n : ℝ)]
+  -- Scale by `1/2` and simplify the constant `(1/2)·(P/c) = P/(2c)`.
+  have key : Filter.Tendsto (fun n : ℕ => (n : ℝ) / 2 * Real.log (1 + P / (n * c)))
+      Filter.atTop (nhds ((1 / 2 : ℝ) * (P / c))) :=
+    (hmain.const_mul (1 / 2 : ℝ)).congr (fun n => by ring)
+  rwa [show (1 / 2 : ℝ) * (P / c) = P / (2 * c) from by ring] at key
+
 end ShannonWaterFilling

--- a/src/data/research/problems/shannon-channel-coding-awgn-oq-03-oq-01.json
+++ b/src/data/research/problems/shannon-channel-coding-awgn-oq-03-oq-01.json
@@ -63,7 +63,9 @@
       "Key identity N_i + (mu-N_i)_+ = max mu N_i turns the derivative coefficient 1/(2(N_i+P_i*)) into 1/(2 max(mu,N_i)), which is constant 1/(2mu) on ACTIVE channels (N_i<mu) and <= 1/(2mu) on inactive ones (P_i*=0, x_i>=0). This case split is exactly what makes the aggregated linear term collapse to (sum x_i - P)/(2mu) <= 0.",
       "Water level existence = IVT on the continuous monotone budget g(mu)=sum (mu-N_i)_+ between g(0)=0 and g(N_{i0}+P)>=P; uniqueness (for P>0) = strict monotonicity of g wherever g>0 (some channel active).",
       "VERIFIED (researcher-2, 2026-07-09, GREEN build attempt 1): capacity properties of the equal-noise closed form C(P)=(n/2)log(1+P/(nc)) in ShannonChannelCodingAWGNOQ03OQ01EqualNoise.lean. rate_equalNoise_nonneg (C(P)≥0 for P≥0, via Real.log_nonneg on 1≤1+P/(nc) + mul_nonneg) and rate_equalNoise_mono_power (P₁≤P₂⟹C(P₁)≤C(P₂), via Real.log_le_log + gcongr for the argument monotonicity). Standard 'capacity is a nonneg increasing function of the power budget' facts, absent from the file. The three parent open items (optimality, water-level existence/uniqueness, closed form) + equal-noise specialization are all complete; remaining nextSteps (operational random-coding theorem, infinite-band integral limit) are substantial.",
-      "The four separately-proved water-filling facts (existence, positivity, optimality, closed form) compose directly into the single \"parallel Gaussian channel capacity is achieved by water-filling\" statement — no new analysis needed, only the μ>0 bridge lemma."
+      "The four separately-proved water-filling facts (existence, positivity, optimality, closed form) compose directly into the single \"parallel Gaussian channel capacity is achieved by water-filling\" statement — no new analysis needed, only the μ>0 bridge lemma.",
+      "Wideband/infinite-bandwidth AWGN limit: as the channel count n→∞, the equal-noise capacity (n/2)·log(1+P/(nc)) converges to EXACTLY P/(2c). Proof rewrites n·log(1+P/(nc)) = log((1+(P/c)/n)^n) via Real.log_pow (unconditional, no sign hyp on P), then applies Real.tendsto_one_add_div_pow_exp ((1+t/n)^n → exp t) composed with continuity of Real.log at exp(P/c)>0 and log∘exp=id, finally scaling by 1/2. No differentiability of log(1+x)/x needed — the (1+t/n)^n→exp form sidesteps the 0/0 tangent limit.",
+      "Sharpness of the wideband ceiling: rate_equalNoise_le_wideband gives C_n ≤ P/(2c) for every finite n, and rate_equalNoise_tendsto_wideband shows the sequence attains P/(2c) in the limit — so P/(2c) is exactly the supremum of achievable equal-noise rates, closing the finite-bound/limit pair."
     ],
     "builtItems": [
       "waterfilling_optimal (KKT optimality of P_i*=(mu-N_i)_+) in ShannonChannelCodingAWGNOQ03OQ01.lean",
@@ -73,14 +75,15 @@
       "exists_waterLevel (IVT existence) + waterLevel_unique (strict-monotone uniqueness) + continuous/monotone_waterBudget",
       "ShannonChannelCodingAWGNOQ03OQ01EqualNoise.lean: rate_equalNoise_nonneg + rate_equalNoise_mono_power. VERIFIED green, 0 axioms/sorries. File now 7 theorems.",
       "waterLevel_pos (ShannonChannelCodingAWGNOQ03OQ01.lean): P>0 ⟹ water level μ>0 — bridges exists_waterLevel (0≤μ) to waterfilling_optimal (0<μ), via monotone_waterBudget + waterBudget_zero",
-      "parallel_gaussian_capacity (ShannonChannelCodingAWGNOQ03OQ01.lean): capstone — for P>0 there is μ>0 whose water-filling allocation is feasible (∑Pᵢ⋆=P), optimal over all feasible x, and attains closed form ∑½log(max μ Nᵢ/Nᵢ); assembles exists_waterLevel+waterLevel_pos+waterfilling_optimal+waterAlloc_rate_closedForm into the single capacity statement"
+      "parallel_gaussian_capacity (ShannonChannelCodingAWGNOQ03OQ01.lean): capstone — for P>0 there is μ>0 whose water-filling allocation is feasible (∑Pᵢ⋆=P), optimal over all feasible x, and attains closed form ∑½log(max μ Nᵢ/Nᵢ); assembles exists_waterLevel+waterLevel_pos+waterfilling_optimal+waterAlloc_rate_closedForm into the single capacity statement",
+      "rate_equalNoise_tendsto_wideband (ShannonChannelCodingAWGNOQ03OQ01EqualNoise.lean): Tendsto (fun n:ℕ => (n/2)·log(1+P/(nc))) atTop (𝓝 (P/(2c))) for c>0, any P. VERIFIED 0 axioms (propext/Choice/Quot.sound), builds clean via lake env lean against Mathlib v4.26 oleans. File now 331→371 lines."
     ],
     "mathlibGaps": [],
     "nextSteps": [
       "Connect to an operational coding theorem (random Gaussian codebooks) tying capacity to achievable rates (parent oq-04).",
-      "Extend the finite water-filling optimum to the continuous infinite-band (integral) limit.",
-      "Prove the explicit water level for the equal-noise case mu = (P + sum N_i)/n and derive C = (n/2) log(1 + P/(sum N_i)) style corollaries."
+      "Prove P/(2c) is the iSup over n of the equal-noise rates (needs monotonicity of n↦(n/2)log(1+P/(nc)) in n), upgrading the tendsto+ceiling pair to an explicit least-upper-bound statement.",
+      "Extend the finite water-filling optimum to a genuine continuous infinite-band (integral over frequency) capacity, beyond the equal-noise wideband scalar limit."
     ],
-    "progressSummary": "PROGRESS: capstone parallel_gaussian_capacity assembles the full capacity theorem (feasible+optimal+closed-form) for P>0; water level existence+uniqueness established. VERIFIED 2026-07-11 (researcher-1): ShannonChannelCodingAWGNOQ03OQ01.lean elaborates clean via `lake env lean` against prebuilt Mathlib v4.26.0 oleans — 0 errors, 0 sorries, only 2 benign unusedSectionVars linter warnings; `#print axioms parallel_gaussian_capacity` = [propext, Classical.choice, Quot.sound] (axiom-free, 3 foundational only)."
+    "progressSummary": "PROGRESS: wideband limit rate_equalNoise_tendsto_wideband proved — equal-noise capacity (n/2)log(1+P/(nc)) → P/(2c) as n→∞, making the existing ceiling C_n ≤ P/(2c) sharp. VERIFIED 2026-07-12 (researcher-11) axiom-free. Capstone parallel_gaussian_capacity + full equal-noise analytic suite (nonneg/mono/antitone/concave/strict/wideband ceiling+limit) complete."
   }
 }


### PR DESCRIPTION
## Summary

Adds the **wideband (infinite-bandwidth) AWGN limit** to the equal-noise water-filling capacity file, closing the finite-ceiling / limit pair.

**New theorem** `rate_equalNoise_tendsto_wideband` (in `ShannonChannelCodingAWGNOQ03OQ01EqualNoise.lean`):

> For `c > 0` and any `P : ℝ`,
> `Tendsto (fun n : ℕ => (n/2)·log(1 + P/(n·c))) atTop (𝓝 (P/(2c)))`.

As the number `n` of identical parallel Gaussian channels grows, the equal-noise capacity converges to **exactly** `P/(2c)` — Shannon's infinite-bandwidth limit `C_∞ = P/(2c)` nats.

### Sharpness
The file already had `rate_equalNoise_le_wideband`: every finite `n` satisfies `C_n ≤ P/(2c)`. The new limit shows that ceiling is **attained asymptotically**, so `P/(2c)` is exactly the supremum of the achievable equal-noise rates as a fixed power budget is spread over more sub-channels.

### Proof
- `n·log(1 + P/(n·c)) = log((1 + (P/c)/n)^n)` via `Real.log_pow` (unconditional — no sign hypothesis on `P`);
- `(1 + t/n)^n → exp t` via `Real.tendsto_one_add_div_pow_exp`;
- compose with continuity of `Real.log` at `exp(P/c) > 0` and `log ∘ exp = id`;
- scale by `1/2`, simplifying `(1/2)·(P/c) = P/(2c)`.

This sidesteps the `0/0` tangent limit `log(1+x)/x → 1` by routing through the `exp` form.

## Verification
- Elaborates clean via `lake env lean` against prebuilt Mathlib v4.26.0 oleans — 0 errors, 0 sorries.
- `#print axioms rate_equalNoise_tendsto_wideband` = `[propext, Classical.choice, Quot.sound]` (axiom-free).
- File `331 → 371` lines.

## Problem
`shannon-channel-coding-awgn-oq-03-oq-01` — advances nextStep "infinite-band limit". Knowledge JSON updated (insights, builtItems, nextSteps, progressSummary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)