### PR TITLE
research(e-transcendental-oq-02-oq-06): translation invariance of normality under integer shifts [VERIFIED 0 new axioms]

### DIFF
--- a/proofs/Proofs/ETranscendentalOQ02.lean
+++ b/proofs/Proofs/ETranscendentalOQ02.lean
@@ -1343,6 +1343,149 @@ theorem isNormalInBase_of_all_but_one (b : ℕ) (hb : 2 ≤ b) (x : ℝ)
   · simpa only [matchFreq] using h k s hs
 
 -- ============================================================
+-- PART IV.11: TRANSLATION INVARIANCE
+-- ============================================================
+
+/-!
+## Normality is invariant under integer translation
+
+Normality is a property of the *tail* digit structure: only the digit at
+position `0` (the integer part) can change when an integer `m` is added to `x`.
+For every position `n ≥ 1` the digit is literally unchanged
+(`nthDigit_add_int`), because `⌊bⁿ(x+m)⌋ = ⌊bⁿ x⌋ + bⁿ m` and `b ∣ bⁿ m` for
+`n ≥ 1`, so the residue mod `b` is preserved. Consequently, for any fixed tuple
+length `k` and tuple `s`, the two matching counts over `range N` — one for `x`,
+one for `x + m` — can differ only at the single starting position `n = 0` (the
+only window that touches digit `0`). Their difference is therefore at most `1`,
+which is `o(N)`, so the empirical frequencies share the same limit:
+
+* `isNormalInBase_add_int` — `IsNormalInBase b x → IsNormalInBase b (x + m)`;
+* `isNormalInBase_add_int_iff` — the two-sided form (apply the forward map with
+  `+m` and then `-m`);
+* `isAbsolutelyNormal_add_int` — the same for absolute normality, base by base.
+
+Note none of these needs `b ≥ 2`: the shift identity is purely arithmetic. This
+places normality alongside irrationality as a translation-invariant property, and
+shows the equidistribution phenomenon lives entirely in the fractional expansion.
+-/
+
+/-- **Integer shift preserves every positive-index digit.** For `n ≥ 1` and any
+    integer `m`, the `n`-th base-`b` digit of `x + m` equals that of `x`: writing
+    `⌊bⁿ(x+m)⌋ = ⌊bⁿ x⌋ + bⁿ m` and using `b ∣ bⁿ m` (valid because `n ≥ 1`), the
+    residue mod `b` is unchanged. -/
+lemma nthDigit_add_int (b : ℕ) (n : ℕ) (hn : 1 ≤ n) (x : ℝ) (m : ℤ) :
+    nthDigit b n (x + (m : ℝ)) = nthDigit b n x := by
+  unfold nthDigit
+  set M : ℤ := (b : ℤ) ^ n * m with hM
+  have hreal : (b : ℝ) ^ n * (x + (m : ℝ)) = (b : ℝ) ^ n * x + (M : ℝ) := by
+    rw [hM]; push_cast; ring
+  rw [hreal, Int.floor_add_intCast]
+  obtain ⟨j, hj⟩ : ∃ j, n = j + 1 := ⟨n - 1, by omega⟩
+  have hMdvd : M = (b : ℤ) * ((b : ℤ) ^ j * m) := by rw [hM, hj]; ring
+  rw [hMdvd, Int.add_mul_emod_self_left]
+
+/-- **Difference-of-one squeeze.** Two `ℕ`-valued sequences whose values differ by
+    at most `1` at every index have the same limiting frequency `count / N`
+    (the correction is bounded by `1/N → 0`). Used to transfer the normality
+    limit across the single-position perturbation of an integer shift. -/
+private lemma tendsto_div_of_diff_le_one {A B : ℕ → ℕ} {L : ℝ}
+    (hAB : ∀ N, A N ≤ B N + 1) (hBA : ∀ N, B N ≤ A N + 1)
+    (hB : Tendsto (fun N => (B N : ℝ) / (N : ℝ)) atTop (nhds L)) :
+    Tendsto (fun N => (A N : ℝ) / (N : ℝ)) atTop (nhds L) := by
+  have h_inv : Tendsto (fun N : ℕ => (N : ℝ)⁻¹) atTop (nhds 0) :=
+    tendsto_inv_atTop_zero.comp tendsto_natCast_atTop_atTop
+  have hlow : Tendsto (fun N : ℕ => (B N : ℝ) / (N : ℝ) - (N : ℝ)⁻¹) atTop (nhds L) := by
+    have h := hB.sub h_inv; rwa [sub_zero] at h
+  have hhigh : Tendsto (fun N : ℕ => (B N : ℝ) / (N : ℝ) + (N : ℝ)⁻¹) atTop (nhds L) := by
+    have h := hB.add h_inv; rwa [add_zero] at h
+  refine tendsto_of_tendsto_of_tendsto_of_le_of_le' hlow hhigh ?_ ?_
+  · refine Filter.Eventually.of_forall (fun N => ?_)
+    rcases Nat.eq_zero_or_pos N with hN | hN
+    · simp [hN]
+    · have hNR : (0 : ℝ) < (N : ℝ) := by exact_mod_cast hN
+      have hnum : (B N : ℝ) - 1 ≤ (A N : ℝ) := by
+        have : (B N : ℝ) ≤ (A N : ℝ) + 1 := by exact_mod_cast hBA N
+        linarith
+      rw [show (N : ℝ)⁻¹ = (1 : ℝ) / (N : ℝ) from (one_div _).symm, div_sub_div_same,
+        div_le_div_iff_of_pos_right hNR]
+      exact hnum
+  · refine Filter.Eventually.of_forall (fun N => ?_)
+    rcases Nat.eq_zero_or_pos N with hN | hN
+    · simp [hN]
+    · have hNR : (0 : ℝ) < (N : ℝ) := by exact_mod_cast hN
+      have hnum : (A N : ℝ) ≤ (B N : ℝ) + 1 := by exact_mod_cast hAB N
+      rw [show (N : ℝ)⁻¹ = (1 : ℝ) / (N : ℝ) from (one_div _).symm, ← add_div,
+        div_le_div_iff_of_pos_right hNR]
+      exact hnum
+
+/-- **Translation invariance (forward).** Adding an integer to a normal number
+    yields a normal number. Only the digit at position `0` can change, so for each
+    tuple `s` the matching counts of `x` and `x + m` over `range N` differ by at
+    most one; `tendsto_div_of_diff_le_one` then transfers the definitional limit.
+    No hypothesis `b ≥ 2` is required — the digit-shift identity is arithmetic. -/
+theorem isNormalInBase_add_int (b : ℕ) (x : ℝ) (m : ℤ)
+    (hx : IsNormalInBase b x) : IsNormalInBase b (x + (m : ℝ)) := by
+  intro k s
+  have hpred : ∀ n : ℕ, 1 ≤ n →
+      ((∀ i : Fin k, nthDigit b (n + i.val) (x + (m : ℝ)) = (s i : ℤ)) ↔
+        (∀ i : Fin k, nthDigit b (n + i.val) x = (s i : ℤ))) := by
+    intro n hn
+    refine forall_congr' (fun i => ?_)
+    rw [nthDigit_add_int b (n + i.val) (by omega) x m]
+  set Qm : ℕ → Prop :=
+    fun n => ∀ i : Fin k, nthDigit b (n + i.val) (x + (m : ℝ)) = (s i : ℤ) with hQm
+  set Q : ℕ → Prop :=
+    fun n => ∀ i : Fin k, nthDigit b (n + i.val) x = (s i : ℤ) with hQ
+  have hAB : ∀ N, ((Finset.range N).filter Qm).card
+      ≤ ((Finset.range N).filter Q).card + 1 := by
+    intro N
+    have hsub : (Finset.range N).filter Qm ⊆ insert 0 ((Finset.range N).filter Q) := by
+      intro n hn
+      rw [Finset.mem_filter, Finset.mem_range] at hn
+      rcases Nat.eq_zero_or_pos n with h0 | hpos
+      · subst h0; exact Finset.mem_insert_self 0 _
+      · refine Finset.mem_insert_of_mem ?_
+        rw [Finset.mem_filter, Finset.mem_range]
+        exact ⟨hn.1, (hpred n hpos).mp hn.2⟩
+    calc ((Finset.range N).filter Qm).card
+        ≤ (insert 0 ((Finset.range N).filter Q)).card := Finset.card_le_card hsub
+      _ ≤ ((Finset.range N).filter Q).card + 1 := Finset.card_insert_le _ _
+  have hBA : ∀ N, ((Finset.range N).filter Q).card
+      ≤ ((Finset.range N).filter Qm).card + 1 := by
+    intro N
+    have hsub : (Finset.range N).filter Q ⊆ insert 0 ((Finset.range N).filter Qm) := by
+      intro n hn
+      rw [Finset.mem_filter, Finset.mem_range] at hn
+      rcases Nat.eq_zero_or_pos n with h0 | hpos
+      · subst h0; exact Finset.mem_insert_self 0 _
+      · refine Finset.mem_insert_of_mem ?_
+        rw [Finset.mem_filter, Finset.mem_range]
+        exact ⟨hn.1, (hpred n hpos).mpr hn.2⟩
+    calc ((Finset.range N).filter Q).card
+        ≤ (insert 0 ((Finset.range N).filter Qm)).card := Finset.card_le_card hsub
+      _ ≤ ((Finset.range N).filter Qm).card + 1 := Finset.card_insert_le _ _
+  exact tendsto_div_of_diff_le_one hAB hBA (hx k s)
+
+/-- **Translation invariance (two-sided).** `x + m` is normal in base `b` iff `x`
+    is. The backward direction applies the forward map to `x + m` with shift `-m`. -/
+theorem isNormalInBase_add_int_iff (b : ℕ) (x : ℝ) (m : ℤ) :
+    IsNormalInBase b (x + (m : ℝ)) ↔ IsNormalInBase b x := by
+  constructor
+  · intro h
+    have hback := isNormalInBase_add_int b (x + (m : ℝ)) (-m) h
+    have heq : (x + (m : ℝ)) + (((-m : ℤ)) : ℝ) = x := by push_cast; ring
+    rwa [heq] at hback
+  · exact isNormalInBase_add_int b x m
+
+/-- **Absolute normality is translation invariant.** If `x` is absolutely normal
+    then so is `x + m` for every integer `m` (apply `isNormalInBase_add_int` in
+    each base `b ≥ 2`). -/
+theorem isAbsolutelyNormal_add_int (x : ℝ) (m : ℤ) (hx : IsAbsolutelyNormal x) :
+    IsAbsolutelyNormal (x + (m : ℝ)) := by
+  intro b hb
+  exact isNormalInBase_add_int b x m (hx b hb)
+
+-- ============================================================
 -- PART V: OPEN QUESTION
 -- ============================================================
 

--- a/src/data/research/problems/e-transcendental-oq-02-oq-06.json
+++ b/src/data/research/problems/e-transcendental-oq-02-oq-06.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (VERIFIED 0 sorry / axiom unchanged): added the effective-modulus layer — EffectivelyNormalWithModulus (normality + explicit convergence rate) implying IsNormalInBase, plus first_occurrence_lt_of_modulus (explicit first-occurrence position < max(M k (b^{-k}/2)) 1) and match_count_ge_linear_of_modulus (explicit-threshold linear density). Resolves the effective/rate-based first-occurrence next-step. Open axiom e_absolutely_normal remains genuinely open.",
+    "progressSummary": "PROGRESS (VERIFIED 0 sorry / axiom unchanged, researcher-2 2026-07-12): added PART IV.11 TRANSLATION INVARIANCE to ETranscendentalOQ02.lean — normality is invariant under integer translation x ↦ x+m. nthDigit_add_int (positive-index digits are unchanged by an integer shift, via ⌊bⁿ(x+m)⌋=⌊bⁿx⌋+bⁿm and b∣bⁿm for n≥1), the difference-of-one squeeze tendsto_div_of_diff_le_one, and isNormalInBase_add_int / _iff / isAbsolutelyNormal_add_int. Only position 0 (integer part) can change, so the two match-counts over range N differ by ≤1 = o(N) and share the limit b^{-k}. Needs NO b≥2. Open axiom e_absolutely_normal remains genuinely open.",
     "builtItems": [
       "normal_ktuple_infinitely_often (Proofs/ETranscendentalOQ02.lean): {n | s occurs at n}.Infinite for x normal in base b. Verified 0 sorry; axioms [propext, Classical.choice, Quot.sound].",
       "normal_imp_disjunctive (same file): every finite digit string appears at least once (corollary via Set.Infinite.nonempty).",
@@ -53,7 +53,12 @@
       "match_count_ge_linear_of_normal (ETranscendentalOQ02.lean:998): occurrence count eventually >= (b^{-k}/2)*N, i.e. positive lower density (strengthens normal_ktuple_infinitely_often)",
       "EffectivelyNormalWithModulus (def) + isNormal_of_effectivelyNormal (ETranscendentalOQ02.lean PART IV.9): modulus form ⇒ IsNormalInBase, VERIFIED 0 sorry",
       "first_occurrence_lt_of_modulus (ETranscendentalOQ02.lean): explicit first-occurrence bound < max(M k (b^{-k}/2)) 1 — effective form of the non-constructive eventually_exists_match_lt_of_normal",
-      "match_count_ge_linear_of_modulus (ETranscendentalOQ02.lean): explicit-threshold linear density lower bound (b^{-k}/2)·N for every N≥max(M k (b^{-k}/2)) 1 — effective form of match_count_ge_linear_of_normal"
+      "match_count_ge_linear_of_modulus (ETranscendentalOQ02.lean): explicit-threshold linear density lower bound (b^{-k}/2)·N for every N≥max(M k (b^{-k}/2)) 1 — effective form of match_count_ge_linear_of_normal",
+      "nthDigit_add_int (ETranscendentalOQ02.lean PART IV.11): for n≥1, nthDigit b n (x+↑m) = nthDigit b n x — integer shift preserves every positive-index base-b digit (⌊bⁿ(x+m)⌋=⌊bⁿx⌋+bⁿm via Int.floor_add_intCast, then b∣bⁿm gives Int.add_mul_emod_self_left). VERIFIED 0 sorry / axiom-free.",
+      "tendsto_div_of_diff_le_one (private, same file): two ℕ-sequences with |A−B|≤1 pointwise share the limit of count/N (squeeze between (B∓1)/N, correction 1/N→0). Reusable transfer lemma.",
+      "isNormalInBase_add_int (same file): IsNormalInBase b x → IsNormalInBase b (x+↑m). Only the n=0 window touches digit 0, so match-counts over range N differ by ≤1. No b≥2 hypothesis needed. VERIFIED axiom-free.",
+      "isNormalInBase_add_int_iff (same file): two-sided translation invariance (backward via forward map on x+m with shift −m).",
+      "isAbsolutelyNormal_add_int (same file): IsAbsolutelyNormal x → IsAbsolutelyNormal (x+↑m), base by base."
     ],
     "insights": [
       "The stated target normal_imp_irrational was ALREADY a complete 0-sorry theorem (Session 13); OQ-02-OQ-06 as literally phrased was resolved. Added genuinely new theory instead of reclaiming.",
@@ -69,15 +74,17 @@
       "Filter.Tendsto.eventually_const_lt (hv : u < v) (h : Tendsto f l (nhds v)) : eventually u < f — the clean way to turn a Tendsto-to-positive-limit into an eventual strict positivity; eventually_gt_of_tendsto_gt does NOT exist in Mathlib v4.26.",
       "Effective normality needs an EXPLICIT modulus: IsNormalInBase is a bare Tendsto with no rate, so first-occurrence positions cannot be bounded by k alone. Adding a modulus M:ℕ→ℝ→ℕ (the ε–N / Metric.tendsto_atTop form) recovers effective bounds while STILL implying IsNormalInBase (isNormal_of_effectivelyNormal via Real.dist_eq).",
       "First-occurrence recipe from a modulus: at tolerance ε=b^{-k}/2, the frequency at N₁=max(M k ε) 1 is within ε of b^{-k} (abs_lt), hence >b^{-k}/2>0 using the identity b^{-k}-δ=δ; so the matching count is positive and exists_match_lt_of_count_pos yields a witness <N₁, an EXPLICIT function of M and k.",
-      "VERIFIED (researcher-2, 2026-07-09, GREEN build): absolute-level corollaries of IsAbsolutelyNormal added to ETranscendentalOQ02.lean (Part VIII) — the definition previously had NO consequences drawn as named theorems, only per-base instantiations. absolutely_normal_imp_irrational (IsAbsolutelyNormal x → Irrational x, via normal_imp_irrational at base 2) and absolutely_normal_imp_disjunctive (→ disjunctive in every base b≥2, via normal_imp_disjunctive). One-line base-instantiations packaging the base-uniform consequences. Open axiom e_absolutely_normal untouched (genuinely open, 1 axiom)."
+      "VERIFIED (researcher-2, 2026-07-09, GREEN build): absolute-level corollaries of IsAbsolutelyNormal added to ETranscendentalOQ02.lean (Part VIII) — the definition previously had NO consequences drawn as named theorems, only per-base instantiations. absolutely_normal_imp_irrational (IsAbsolutelyNormal x → Irrational x, via normal_imp_irrational at base 2) and absolutely_normal_imp_disjunctive (→ disjunctive in every base b≥2, via normal_imp_disjunctive). One-line base-instantiations packaging the base-uniform consequences. Open axiom e_absolutely_normal untouched (genuinely open, 1 axiom).",
+      "STRUCTURAL (researcher-2, 2026-07-12): normality is TRANSLATION INVARIANT under integer shifts — it is a property of the fractional/tail digit expansion, not the integer part. Adding m∈ℤ changes only the position-0 digit (⌊bⁿ(x+m)⌋≡⌊bⁿx⌋ mod b for n≥1 since b∣bⁿm), so at most one starting window (n=0) of any tuple-match count over range N is affected; a ≤1 = o(N) perturbation leaves every empirical frequency limit b^{-k} intact. Places normality alongside irrationality (also translation invariant) and complements the Liouville non-normal sharpness witness.",
+      "The single-position perturbation is handled cleanly by an insert-0 subset bound (filter Qm ⊆ insert 0 (filter Q) and symmetrically), giving card differ ≤1 without Finset symmetric-difference machinery, then a generic 1/N squeeze (tendsto_div_of_diff_le_one). The digit-shift identity needs no b≥2, so the invariance theorems are stated without it — strictly cleaner than the surrounding hb-threaded API."
     ],
     "mathlibGaps": [
       "omega does not discharge variable-divisor Euclidean identities (a/T*T + a%T = a with T variable, nonlinear); use Nat.mod_add_div'/Nat.div_add_mod explicitly.",
       "Genuine irrational-AND-non-normal WITNESS (true sharpness of 'irrational ⇏ normal') still needs the real→digit bridge for a specific transcendental: computing nthDigit b n x = ⌊bⁿx⌋%b for an explicit series (e.g. Liouville ∑ b^(-k!)) requires summing the tail to isolate the k-th digit — a real-analysis construction not present. The abstract criterion is the tool; only the witness digit-computation is missing."
     ],
     "nextSteps": [
-      "The open axiom e_absolutely_normal is genuinely open — not eliminable. The effective-modulus layer (EffectivelyNormalWithModulus + first_occurrence_lt_of_modulus + match_count_ge_linear_of_modulus), the frequency-mismatch criterion, quantitative disjunctivity, and the Liouville sharpness witness now form a complete effective normality theory around the bare definition.",
-      "Optional low-novelty: instantiate EffectivelyNormalWithModulus for an explicitly-constructed normal number (e.g. a Champernowne-style constant) to exhibit a concrete modulus — requires a digit-frequency rate Mathlib does not currently provide."
+      "The open axiom e_absolutely_normal is genuinely open — not eliminable. Structural theory around the bare definition is now broad: effective-modulus layer, frequency-mismatch criterion, quantitative disjunctivity, conservation law, Liouville sharpness witness, and now integer-translation invariance (PART IV.11).",
+      "Optional next structural direction: rational-translation invariance (x ↦ x + p/q) — a rational shift only eventually-periodically perturbs the digits, so should also preserve normality, but requires bounding the perturbed window count by a period-dependent constant rather than a single position. Strictly harder than the integer case handled here."
     ],
     "markdown": "# Knowledge Base: e-transcendental-oq-02-oq-06\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },
@@ -102,7 +109,7 @@
     "mathlib": []
   },
   "started": "2026-07-04T19:52:25.455Z",
-  "lastUpdate": "2026-07-08",
+  "lastUpdate": "2026-07-12T09:28:13Z",
   "leanFiles": [
     {
       "path": "Proofs/ETranscendentalOQ01.lean",
@@ -129,8 +136,8 @@
     {
       "path": "Proofs/ETranscendentalOQ02.lean",
       "filename": "ETranscendentalOQ02.lean",
-      "lineCount": 2062,
-      "theoremCount": 68,
+      "lineCount": 2205,
+      "theoremCount": 73,
       "axiomCount": 1,
       "defCount": 5,
       "sorryCount": 0,


### PR DESCRIPTION
## Summary

Adds **PART IV.11: TRANSLATION INVARIANCE** to `ETranscendentalOQ02.lean`. Normality is invariant under integer translation `x ↦ x + m`: a normal number's equidistribution lives entirely in the fractional/tail digit expansion. Adding `m ∈ ℤ` changes only the position-0 digit (the integer part), so tuple-match counts over `range N` are perturbed at most at the single starting window `n = 0` — a `≤ 1 = o(N)` change that leaves every empirical frequency limit `b^{-k}` intact.

This places normality alongside irrationality as a translation-invariant property and complements the existing Liouville non-normal sharpness witness.

## New declarations (all axiom-free)

- `nthDigit_add_int` — for `n ≥ 1`, the `n`-th base-`b` digit of `x + m` equals that of `x` (`⌊bⁿ(x+m)⌋ = ⌊bⁿx⌋ + bⁿm` via `Int.floor_add_intCast`, then `b ∣ bⁿm` gives `Int.add_mul_emod_self_left`).
- `tendsto_div_of_diff_le_one` (private) — two `ℕ`-sequences differing by `≤ 1` pointwise share the limit of `count/N` (correction bounded by `1/N → 0`). Reusable.
- `isNormalInBase_add_int` — `IsNormalInBase b x → IsNormalInBase b (x + m)`. Needs **no** `b ≥ 2` hypothesis (the shift identity is purely arithmetic).
- `isNormalInBase_add_int_iff` — two-sided form.
- `isAbsolutelyNormal_add_int` — absolute-normality version, base by base.

## Verification

- Full file compiles under host Lean (Mathlib) with **0 errors** (only pre-existing deprecation/lint warnings unrelated to this change).
- `#print axioms` on all four new named results: `[propext, Classical.choice, Quot.sound]` only — no `sorryAx`, no new domain axioms.
- The single genuinely-open axiom `e_absolutely_normal` is untouched (file axiomCount stays 1, sorryCount 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)