### PR TITLE
research(erdos-634): make Erdos634Problem.lean sorry-free — axiomatize positive dissection families symmetric to Beeson

### DIFF
--- a/proofs/Proofs/Erdos634Problem.lean
+++ b/proofs/Proofs/Erdos634Problem.lean
@@ -224,34 +224,55 @@ private noncomputable def unitEquil : Triangle where
   triangle_ineq_bc := by norm_num
   triangle_ineq_ca := by norm_num
 
-/-- Perfect squares are dissectable (divide each side into k parts).
-    The explicit construction subdivides an equilateral triangle into k² congruent sub-triangles
-    via affine subdivision; area equality follows from the k²-fold scaling of each sub-triangle.
-    Awaiting formalization of the explicit subdivision map. -/
-theorem squares_dissectable (k : ℕ) (hk : k ≥ 1) : IsDissectable (k^2) := by
-  sorry
+/-- **The known positive dissection families.** `n` matches a value that the
+    literature establishes *is* dissectable into congruent triangles:
+    `k²`, `2k²`, `3k²`, `6k²`, or a sum of two positive squares `k² + m²`
+    (Snover–Waiveris–Williams and the classical reptiling constructions). -/
+def IsKnownPositive (n : ℕ) : Prop :=
+  (∃ k, k ≥ 1 ∧ n = k ^ 2) ∨
+  (∃ k, k ≥ 1 ∧ n = 2 * k ^ 2) ∨
+  (∃ k, k ≥ 1 ∧ n = 3 * k ^ 2) ∨
+  (∃ k, k ≥ 1 ∧ n = 6 * k ^ 2) ∨
+  (∃ k m, k ≥ 1 ∧ m ≥ 1 ∧ n = k ^ 2 + m ^ 2)
 
-/-- 2n² is dissectable.
-    Construction: subdivide a right-isoceles triangle; area equality pending formalization. -/
-theorem two_squares_dissectable (n : ℕ) (hn : n ≥ 1) : IsDissectable (2 * n^2) := by
-  sorry
+/-- **Known positive dissection results (axiom).** Every `IsKnownPositive n`
+    admits an explicit congruent tiling in the literature. The required `Tiles`
+    witness (covering + interior-disjointness) cannot be *constructed* here — for
+    the very same reason Beeson's negative results below cannot be *refuted* here:
+    `Tiles` is abstract and Mathlib has no polygonal-tiling API. So these known
+    results are recorded as a single disclosed axiom, mirroring the axiomatized
+    negative results `seven_not_dissectable`/`eleven_not_dissectable`, rather than
+    left as an unproved placeholder (which would falsely claim they are proved).
 
-/-- 3n² is dissectable (equilateral triangle subdivision).
-    Construction: subdivide into 3n² congruent pieces; area equality pending formalization. -/
-theorem three_squares_dissectable (n : ℕ) (hn : n ≥ 1) : IsDissectable (3 * n^2) := by
-  sorry
+    **Consistency with Beeson.** `7` and `11` are `≡ 3 (mod 4)`, so neither is a
+    perfect square, twice/thrice/six-times a square, nor a sum of two positive
+    squares (a prime `≡ 3 (mod 4)` is never a sum of two squares); hence neither
+    satisfies `IsKnownPositive`, and this axiom never yields `IsDissectable 7` or
+    `IsDissectable 11`. The positive axiom and the negative axioms therefore
+    coexist without contradiction (they are simultaneously satisfiable: take
+    `Tiles` to hold exactly on the known-positive `n`). -/
+axiom known_positive_dissectable {n : ℕ} (h : IsKnownPositive n) : IsDissectable n
 
-/-- 6n² is dissectable.
-    Construction: combine k²- and 2k²-type subdivisions; pending formalization. -/
-theorem six_squares_dissectable (n : ℕ) (hn : n ≥ 1) : IsDissectable (6 * n^2) := by
-  sorry
+/-- Perfect squares are dissectable (the `k²` congruent-triangle reptiling). -/
+theorem squares_dissectable (k : ℕ) (hk : k ≥ 1) : IsDissectable (k ^ 2) :=
+  known_positive_dissectable (Or.inl ⟨k, hk, rfl⟩)
 
-/-- n² + m² is dissectable for n, m ≥ 1.
-    Construction: juxtapose k²- and m²-type pieces sharing a common base;
-    area equality pending formalization. -/
+/-- `2n²` is dissectable. -/
+theorem two_squares_dissectable (n : ℕ) (hn : n ≥ 1) : IsDissectable (2 * n ^ 2) :=
+  known_positive_dissectable (Or.inr (Or.inl ⟨n, hn, rfl⟩))
+
+/-- `3n²` is dissectable (equilateral-triangle subdivision). -/
+theorem three_squares_dissectable (n : ℕ) (hn : n ≥ 1) : IsDissectable (3 * n ^ 2) :=
+  known_positive_dissectable (Or.inr (Or.inr (Or.inl ⟨n, hn, rfl⟩)))
+
+/-- `6n²` is dissectable. -/
+theorem six_squares_dissectable (n : ℕ) (hn : n ≥ 1) : IsDissectable (6 * n ^ 2) :=
+  known_positive_dissectable (Or.inr (Or.inr (Or.inr (Or.inl ⟨n, hn, rfl⟩))))
+
+/-- `n² + m²` is dissectable for `n, m ≥ 1` (sum-of-two-squares construction). -/
 theorem sum_squares_dissectable (n m : ℕ) (hn : n ≥ 1) (hm : m ≥ 1) :
-    IsDissectable (n^2 + m^2) := by
-  sorry
+    IsDissectable (n ^ 2 + m ^ 2) :=
+  known_positive_dissectable (Or.inr (Or.inr (Or.inr (Or.inr ⟨n, m, hn, hm, rfl⟩))))
 
 /-- 27 is dissectable (special equilateral construction; 27 = 3·3²). -/
 theorem twenty_seven_dissectable : IsDissectable 27 := by
@@ -270,6 +291,41 @@ axiom seven_not_dissectable : ¬IsDissectable 7
 
 /-- **Beeson's Theorem**: 11 is NOT dissectable. -/
 axiom eleven_not_dissectable : ¬IsDissectable 11
+
+/-- Machine-checked consistency (I): `7` matches none of the positive families,
+    so `known_positive_dissectable` can never produce `IsDissectable 7`. Together
+    with the model argument in that axiom's docstring, this shows the positive
+    axiom does not contradict `seven_not_dissectable`. -/
+theorem not_isKnownPositive_seven : ¬ IsKnownPositive 7 := by
+  have hpow : ∀ j : ℕ, j ≤ j ^ 2 := fun j => Nat.le_self_pow (by norm_num) j
+  rintro (⟨k, hk, h⟩ | ⟨k, hk, h⟩ | ⟨k, hk, h⟩ | ⟨k, hk, h⟩ | ⟨k, m, hk, hm, h⟩)
+  · have := hpow k; have hk7 : k ≤ 7 := by omega
+    interval_cases k <;> norm_num at h
+  · omega
+  · omega
+  · omega
+  · have := hpow k; have := hpow m
+    have hk7 : k ≤ 7 := by omega
+    have hm7 : m ≤ 7 := by omega
+    interval_cases k <;> interval_cases m <;> norm_num at h
+
+/-- Machine-checked consistency (II): `11` matches none of the positive families,
+    so `known_positive_dissectable` can never produce `IsDissectable 11`; the
+    positive axiom does not contradict `eleven_not_dissectable`. -/
+theorem not_isKnownPositive_eleven : ¬ IsKnownPositive 11 := by
+  have hpow : ∀ j : ℕ, j ≤ j ^ 2 := fun j => Nat.le_self_pow (by norm_num) j
+  rintro (⟨k, hk, h⟩ | ⟨k, hk, h⟩ | ⟨k, hk, h⟩ | ⟨k, hk, h⟩ | ⟨k, m, hk, hm, h⟩)
+  · have := hpow k; have hk11 : k ≤ 11 := by omega
+    interval_cases k <;> norm_num at h
+  · have := hpow k; have hk11 : k ≤ 11 := by omega
+    interval_cases k <;> norm_num at h
+  · have := hpow k; have hk11 : k ≤ 11 := by omega
+    interval_cases k <;> norm_num at h
+  · omega
+  · have := hpow k; have := hpow m
+    have hk11 : k ≤ 11 := by omega
+    have hm11 : m ≤ 11 := by omega
+    interval_cases k <;> interval_cases m <;> norm_num at h
 
 /-- The set of known non-dissectable values. -/
 def KnownNonDissectable : Set ℕ := {7, 11}

--- a/research/problems/erdos-634/knowledge.md
+++ b/research/problems/erdos-634/knowledge.md
@@ -3,6 +3,36 @@
 Status: gallery entry present (`Erdos634Problem.lean`), status `axiomatized`.
 The general classification of (T, R, N) is OPEN ($25 prize).
 
+## Session (researcher-1, 2026-07-12): eliminate the 5 positive-result `sorry`s (base entry now sorry-free)
+
+**Mode:** REVISIT · **Outcome:** progress (soundness/honesty cleanup, Docker-verified)
+
+`Erdos634Problem.lean` carried **5 `sorry`s** in its positive-results section
+(`squares_dissectable`, `two_squares_dissectable`, `three_squares_dissectable`,
+`six_squares_dissectable`, `sum_squares_dissectable`). These were **permanently
+unprovable**: the tiling predicate `Tiles` is declared as an opaque
+`axiom … : Prop` with no constructor, so `IsDissectable n` (which requires a
+`Tiles` witness) can never be a *theorem* for any `n` without the missing
+polygonal-tiling API. A `sorry` there falsely claimed the results were proved.
+
+**Fix (symmetric to Beeson):** the negative known-results are honestly
+axiomatized (`seven_not_dissectable`, `eleven_not_dissectable`); the positive
+known-results (Snover–Waiveris–Williams / classical reptiling) now are too. Added
+
+- `def IsKnownPositive n` — the families `k² | 2k² | 3k² | 6k² | k²+m²`;
+- `axiom known_positive_dissectable : IsKnownPositive n → IsDissectable n` (one
+  disclosed axiom);
+- the 5 positive results are now **one-line theorems** applying it (0 sorries);
+- `not_isKnownPositive_seven` / `not_isKnownPositive_eleven` — **machine-checked**
+  (`interval_cases` + `norm_num`) proofs that 7 and 11 (both ≡ 3 mod 4) lie in no
+  positive family, so the positive axiom never yields `IsDissectable 7/11`. This
+  upgrades the "consistent with Beeson" claim from prose to a verified no-clash.
+
+Net: `sorries 5 → 0`, `axiomCount 4 → 5`, `lineCount 412 → 503`. Docker build
+`[7743/7743]` exit 0 (Mathlib 4.26). Sole residual blocker unchanged: no
+polygonal-tiling API in Mathlib to *define* `Tiles` and promote the positive
+axiom to a theorem; the general classification stays OPEN ($25 prize).
+
 ## Session (researcher-6, 2026-07-09): soundness repair of the base entry
 
 The shipped entry `Erdos634Problem.lean` was **logically inconsistent** — it

--- a/src/data/proofs/erdos-634/meta.json
+++ b/src/data/proofs/erdos-634/meta.json
@@ -201,11 +201,11 @@
       "Function"
     ],
     "namespace": "Erdos634",
-    "lineCount": 412,
-    "axiomCount": 4,
-    "theoremCount": 18,
-    "definitionCount": 20,
-    "sorries": 5,
+    "lineCount": 503,
+    "axiomCount": 5,
+    "theoremCount": 20,
+    "definitionCount": 21,
+    "sorries": 0,
     "path": "Proofs/Erdos634Problem.lean",
     "additionalFiles": [
       "Proofs/Erdos634Aristotle.lean",
@@ -266,5 +266,7 @@
       "description": "Lagrange's four squares theorem (every positive integer is a sum of four squares) contrasts with the incomplete coverage of dissectable numbers: k², 2k², 3k², k²+m² cover most integers but not all (7, 11, 19 are open). The arithmetic of sums of squares governs which n are dissectable — Lagrange and Fermat's results on square representations directly constrain the structure of dissectable families."
     }
   ],
-  "sorries": 5
+  "sorries": 0,
+  "axiomCount": 5,
+  "lineCount": 503
 }


### PR DESCRIPTION
## Summary

`Proofs/Erdos634Problem.lean` (Erdős #634, triangle dissection into congruent pieces) shipped as a **completed** gallery entry but carried **5 `sorry`s** in its positive-results section:
`squares_dissectable`, `two_squares_dissectable`, `three_squares_dissectable`, `six_squares_dissectable`, `sum_squares_dissectable`.

These were **permanently unprovable**, not works-in-progress. The tiling predicate is declared

```lean
axiom Tiles (T : Triangle) (n : ℕ) (pieces : Fin n → Triangle) : Prop
```

— an *opaque* Prop with no constructor. `IsDissectable n` requires a `Tiles` witness, so it can **never** be a theorem for any `n` without the polygonal-tiling API that Mathlib lacks. A `sorry` there falsely claimed the results were proved.

## Fix — symmetric to Beeson's negative results

The negative known-results are honestly axiomatized (`seven_not_dissectable`, `eleven_not_dissectable`). This PR does the same for the positive known-results (Snover–Waiveris–Williams / classical reptiling):

- `def IsKnownPositive n` — the families `k² | 2k² | 3k² | 6k² | k²+m²`;
- `axiom known_positive_dissectable : IsKnownPositive n → IsDissectable n` (one disclosed axiom);
- the 5 positive results become **one-line theorems** applying it → **0 sorries**;
- `not_isKnownPositive_seven` / `not_isKnownPositive_eleven` — **machine-checked** (`interval_cases` + `norm_num`) proofs that 7 and 11 (both ≡ 3 mod 4, hence not sums of two squares nor of the form k²/2k²/3k²/6k²) lie in **no** positive family. This upgrades the "consistent with Beeson" claim from prose to a verified no-clash: the positive axiom can never derive `IsDissectable 7/11`.

## Verification

- Docker build `[7743/7743]` exit 0 (Mathlib 4.26).
- `sorries 5 → 0`, `axiomCount 4 → 5`, `lineCount 412 → 503`.

## Scope / what remains

The general classification (which `n` are dissectable) is **OPEN** ($25 prize); 19 is the smallest open case. The sole residual blocker is unchanged: no polygonal-tiling API in Mathlib to *define* `Tiles` and promote `known_positive_dissectable` to a theorem. No enumeration of specific finite `n` was added (that would be theater).

🤖 Generated with [Claude Code](https://claude.com/claude-code)