### PR TITLE
research(erdos-771): completeness of {1,…,n} + sharp avoidance threshold [VERIFIED 0-axiom]

### DIFF
--- a/proofs/Proofs/Erdos771Problem.lean
+++ b/proofs/Proofs/Erdos771Problem.lean
@@ -256,6 +256,121 @@ theorem maxAvoidingSize_eq_of_lt (n m : ℕ) (h : n * n < m) :
     maxAvoidingSize n m = n :=
   le_antisymm (maxAvoidingSize_le n m) (le_maxAvoidingSize_of_lt n m h)
 
+/-
+## Part II.b: Completeness of the full box and the sharp avoidance threshold
+
+The crude witness `avoid_full` uses the loose threshold `n² < m`.  The **sharp**
+threshold is the actual total `∑_{a=1}^n a = n(n+1)/2`: the interval `{1,…,n}` is a
+*complete sequence* — its subset sums realise *every* value in `[1, n(n+1)/2]`.
+Consequently the full box avoids `m` exactly when `m = 0` or `m` exceeds the total,
+and `maxAvoidingSize n m = n` precisely on that boundary.  This pins down where the
+trivial ceiling `maxAvoidingSize n m ≤ n` is attained.
+-/
+
+/-- **Completeness of `{1,…,n}`.** Every `k ≤ ∑_{a=1}^n a` is realised as the sum of
+    some subset `A ⊆ {1,…,n}`.  Greedy induction on `n`: adjoining `n+1` to a subset
+    of `{1,…,n}` summing to `k-(n+1)` reaches every `k` in the new top band
+    `(∑_{a≤n} a, ∑_{a≤n+1} a]`. -/
+theorem exists_subset_sum_eq :
+    ∀ (n k : ℕ), k ≤ ∑ a ∈ Icc_n n, a → ∃ A ⊆ Icc_n n, ∑ a ∈ A, a = k := by
+  intro n
+  induction n with
+  | zero =>
+    intro k hk
+    have hz : Icc_n 0 = (∅ : Finset ℕ) := by
+      unfold Icc_n; exact Finset.Icc_eq_empty (by omega)
+    rw [hz, Finset.sum_empty] at hk
+    refine ⟨∅, Finset.empty_subset _, ?_⟩
+    rw [Finset.sum_empty]; omega
+  | succ n ih =>
+    intro k hk
+    have hins : Icc_n (n + 1) = insert (n + 1) (Icc_n n) := by
+      unfold Icc_n; ext x; simp only [Finset.mem_insert, Finset.mem_Icc]; omega
+    have hnm : (n + 1) ∉ Icc_n n := by
+      unfold Icc_n; simp only [Finset.mem_Icc]; omega
+    have htot : ∑ a ∈ Icc_n (n + 1), a = ((n + 1) + ∑ a ∈ Icc_n n, a) := by
+      rw [hins, Finset.sum_insert hnm]
+    rw [htot] at hk
+    by_cases hcase : k ≤ ∑ a ∈ Icc_n n, a
+    · obtain ⟨A, hAsub, hAsum⟩ := ih k hcase
+      exact ⟨A, hAsub.trans (by rw [hins]; exact Finset.subset_insert _ _), hAsum⟩
+    · push_neg at hcase
+      have hnle : n ≤ ∑ a ∈ Icc_n n, a := by
+        rcases Nat.eq_zero_or_pos n with h0 | hpos
+        · simp [h0]
+        · have hmem : n ∈ Icc_n n := by
+            unfold Icc_n; simp only [Finset.mem_Icc]; omega
+          exact Finset.single_le_sum (fun i _ => Nat.zero_le i) hmem
+      obtain ⟨A, hAsub, hAsum⟩ := ih (k - (n + 1)) (by omega)
+      have hnmA : (n + 1) ∉ A := fun h => hnm (hAsub h)
+      refine ⟨insert (n + 1) A, ?_, ?_⟩
+      · rw [hins]; exact Finset.insert_subset_insert _ hAsub
+      · rw [Finset.sum_insert hnmA, hAsum]; omega
+
+/-- The total of the full box in closed form: `2·∑_{a=1}^n a = n(n+1)`
+    (equivalently `∑_{a=1}^n a = n(n+1)/2`, the Gauss sum). -/
+theorem two_mul_sum_Icc_n (n : ℕ) : 2 * ∑ a ∈ Icc_n n, a = n * (n + 1) := by
+  induction n with
+  | zero => simp [Icc_n]
+  | succ n ih =>
+    have hins : Icc_n (n + 1) = insert (n + 1) (Icc_n n) := by
+      unfold Icc_n; ext x; simp only [Finset.mem_insert, Finset.mem_Icc]; omega
+    have hnm : (n + 1) ∉ Icc_n n := by
+      unfold Icc_n; simp only [Finset.mem_Icc]; omega
+    rw [hins, Finset.sum_insert hnm, Nat.mul_add, ih]; ring
+
+/-- **Subset sums of the full box.** `subsetSums {1,…,n}` is exactly the interval
+    `{1,…,∑_{a=1}^n a}`: completeness (`exists_subset_sum_eq`) supplies every value in
+    range, and no subset sum can exceed the total. -/
+theorem subsetSums_Icc_n (n : ℕ) :
+    subsetSums (Icc_n n) = Finset.Icc 1 (∑ a ∈ Icc_n n, a) := by
+  ext k
+  rw [subsetSums, Finset.mem_filter, Finset.mem_image, Finset.mem_Icc]
+  constructor
+  · rintro ⟨⟨A, hA, hAsum⟩, hpos⟩
+    rw [Finset.mem_powerset] at hA
+    refine ⟨hpos, ?_⟩
+    rw [← hAsum]
+    exact Finset.sum_le_sum_of_subset hA
+  · rintro ⟨hk1, hk2⟩
+    obtain ⟨A, hAsub, hAsum⟩ := exists_subset_sum_eq n k hk2
+    exact ⟨⟨A, Finset.mem_powerset.mpr hAsub, hAsum⟩, by omega⟩
+
+/-- **Sharp full-box avoidance.** `{1,…,n}` avoids `m` iff `m = 0` or `m` exceeds the
+    total `∑_{a=1}^n a`.  Sharpens `avoid_full` (`n² < m`) to the exact threshold: for
+    `∑_{a=1}^n a ≥ m ≥ 1` the full box necessarily hits `m` as a subset sum. -/
+theorem avoid_full_iff (n m : ℕ) :
+    AvoidSum (Icc_n n) m ↔ m = 0 ∨ (∑ a ∈ Icc_n n, a) < m := by
+  rw [AvoidSum, subsetSums_Icc_n, Finset.mem_Icc]
+  omega
+
+/-- **The full box is optimal exactly on the avoidance boundary.**
+    `maxAvoidingSize n m = n` iff `m = 0` or `m` exceeds the total `∑_{a=1}^n a`.
+    Forward: an `m`-avoiding subset of size `n` must be all of `{1,…,n}`, so the box
+    itself avoids `m`.  Backward: on the boundary the box avoids `m` and has size `n`.
+    Sharpens `maxAvoidingSize_eq_of_lt` (`n² < m`) to the exact `n(n+1)/2` threshold. -/
+theorem maxAvoidingSize_eq_n_iff (n m : ℕ) :
+    maxAvoidingSize n m = n ↔ m = 0 ∨ (∑ a ∈ Icc_n n, a) < m := by
+  classical
+  constructor
+  · intro heq
+    by_contra hcon
+    push_neg at hcon
+    have hnotavoid : ¬ AvoidSum (Icc_n n) m := by
+      rw [avoid_full_iff]; push_neg; exact hcon
+    obtain ⟨S, hSsub, hScard, hSavoid⟩ :=
+      (maxAvoidingSize_ge_iff n m n).mpr (le_of_eq heq.symm)
+    have hcardn : (Icc_n n).card = n := by rw [Icc_n, Nat.card_Icc]; omega
+    have hSeq : S = Icc_n n :=
+      Finset.eq_of_subset_of_card_le hSsub (by rw [hcardn]; exact hScard)
+    rw [hSeq] at hSavoid
+    exact hnotavoid hSavoid
+  · intro h
+    have havoid : AvoidSum (Icc_n n) m := (avoid_full_iff n m).mpr h
+    refine le_antisymm (maxAvoidingSize_le n m) ?_
+    exact (maxAvoidingSize_ge_iff n m n).mp
+      ⟨Icc_n n, Finset.Subset.refl _, by rw [Icc_n, Nat.card_Icc]; omega, havoid⟩
+
 /-- **Avoiding the target `1` means omitting `1`.**  For `S ⊆ {1,…,n}`, `AvoidSum S 1`
     holds iff `1 ∉ S`: every element is a positive integer, so the only nonempty subset
     that can sum to `1` is the singleton `{1}`.  (`→` uses `self_mem_subsetSums`; `←` uses

--- a/src/data/research/problems/erdos-771.json
+++ b/src/data/research/problems/erdos-771.json
@@ -21,7 +21,12 @@
       "Discharged prime_multiples_size and prime_multiples_avoid sorries in Erdos771Problem.lean (ported from verified Erdos771Construction.lean)",
       "maxAvoidingSize_le_succ + maxAvoidingSize_monotone (Erdos771Problem.lean): maxAvoidingSize is non-decreasing in the range n (0 axioms).",
       "Erdos771Problem.lean Part II (researcher-11, 2026-07-11, host-lean v4.26.0 verified 0-axiom; docker SIGBUS-135 write-blocked but full elaboration clean): the exact small-target values that first push maxAvoidingSize below n-1 and SHARPEN the headline f-bound. pair_mem_subsetSums (a+b∈subsetSums S for distinct a,b∈S — two-element companion of self_mem_subsetSums, detects the m=a+b obstruction); maxAvoidingSize_two (n≥2 ⟹ maxAvoidingSize n 2 = n-1: single representation {2}, witness {1..n}∖{2}); maxAvoidingSize_three (n≥3 ⟹ = n-2: target 3 has TWO distinct-positive representations {3},{1,2} so avoiding costs two deletions — upper bound via self_mem_subsetSums+pair_mem_subsetSums, lower-bound witness {1..n}∖{1,3} whose elements are 2 or ≥4 so 3 unreachable); f_le_sub_two (n≥3 ⟹ f n ≤ n-2, strictly improving f_le_pred's f n ≤ n-1, since m=3∈[1,n²] and maxAvoidingSize n 3 = n-2). #print axioms on all four = [propext, Classical.choice, Quot.sound] only (independent of the 2 deep external axioms).",
-      "maxAvoidingSize_ge_sub_ceil_half in Erdos771Problem.lean (0 new axiom/sorry; avoidance = any 2 distinct elements >= ceil(m/2) sum > m, singleton m erased)"
+      "maxAvoidingSize_ge_sub_ceil_half in Erdos771Problem.lean (0 new axiom/sorry; avoidance = any 2 distinct elements >= ceil(m/2) sum > m, singleton m erased)",
+      "exists_subset_sum_eq (Erdos771Problem.lean): completeness of {1,…,n} — every k ≤ ∑ Icc_n n is a subset sum, greedy induction adjoining n+1",
+      "two_mul_sum_Icc_n (Erdos771Problem.lean): Gauss closed form 2·∑_{a=1}^n a = n(n+1)",
+      "subsetSums_Icc_n (Erdos771Problem.lean): subsetSums {1,…,n} = Icc 1 (n(n+1)/2)",
+      "avoid_full_iff (Erdos771Problem.lean): AvoidSum {1,…,n} m ↔ m=0 ∨ n(n+1)/2 < m (sharp)",
+      "maxAvoidingSize_eq_n_iff (Erdos771Problem.lean): maxAvoidingSize n m = n ↔ m=0 ∨ n(n+1)/2 < m"
     ],
     "insights": [
       "If every element of S is a multiple of p, so is every subset sum, so S avoids any m with p ∤ m — the engine of the Erdős–Graham lower bound. Primality is not even needed for avoidance.",
@@ -29,12 +34,13 @@
       "The two deep bounds (Erdős–Graham lower, Alon–Freiman upper) are genuinely external and stay as axioms; but the o(1) asymptotic + limit form follow from them by elementary real analysis (div_le_iff₀/le_div_iff₀ squeeze), so those need not be axiomatized separately.",
       "In this Docker environment the codegen crash (exit 135/139) is nondeterministic and can MASK a real parse/elaboration error; capture full build output (not tail) to see the actual diagnostic. Here the true error was an open-Classical-in placed after a doc-comment.",
       "Sharp closed-form lower bound maxAvoidingSize n m >= n - ceil(m/2) (= n-(m+1)/2) for 1<=m<=n, via witness S = {ceil(m/2),...,n} \\ {m}: strictly beats interval_avoiding_lower (n-m) and is TIGHT — matches exact m=1..4 values (n-1,n-1,n-2,n-2). Conjecture (upper bound, follow-up): equality holds via ceil(m/2) pairwise-disjoint sum-m subsets {m},{i,m-i}.",
-      "EXACT closed form maxAvoidingSize n m = n - ceil(m/2) (= n - (m+1)/2) for 1<=m<=n, upgrading the previously one-sided lower bound to equality. Upper bound: any m-avoiding S in {1..n} keeps at most floor(m/2) elements of {1..m}, since x |-> min x (m-x) injects S cap {1..m} into {1..floor(m/2)} (a collision forces two distinct elements summing to m, a forbidden subset sum), plus at most n-m elements above m. Recovers the tabulated small-m values n-1,n-1,n-2,n-2 for m=1..4 uniformly. Axiom-free (Erdos771Problem.lean: maxAvoidingSize_le_sub_ceil_half, maxAvoidingSize_eq_sub_ceil_half)."
+      "EXACT closed form maxAvoidingSize n m = n - ceil(m/2) (= n - (m+1)/2) for 1<=m<=n, upgrading the previously one-sided lower bound to equality. Upper bound: any m-avoiding S in {1..n} keeps at most floor(m/2) elements of {1..m}, since x |-> min x (m-x) injects S cap {1..m} into {1..floor(m/2)} (a collision forces two distinct elements summing to m, a forbidden subset sum), plus at most n-m elements above m. Recovers the tabulated small-m values n-1,n-1,n-2,n-2 for m=1..4 uniformly. Axiom-free (Erdos771Problem.lean: maxAvoidingSize_le_sub_ceil_half, maxAvoidingSize_eq_sub_ceil_half).",
+      "Sharp avoidance threshold: {1,…,n} is a COMPLETE sequence — its subset sums realise EVERY value in [1, n(n+1)/2]. Hence the full box avoids m iff m=0 or m > n(n+1)/2, and maxAvoidingSize n m = n exactly on that boundary. Sharpens the crude n²<m threshold of avoid_full/maxAvoidingSize_eq_of_lt to the exact total n(n+1)/2."
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "Discharge f_characterization by relating the inf/sup definition of f to f_property.",
-      "Keep the deep bounds as axioms (external results); do not attempt to prove Erdős–Graham/Alon–Freiman."
+      "Keep the deep bounds as axioms (external Erdős–Graham/Alon–Freiman results); do not attempt to prove them.",
+      "Possible follow-up: determine maxAvoidingSize n m in the intermediate regime n < m ≤ n(n+1)/2 (between the sharp small-m formula n-⌈m/2⌉ and the boundary)."
     ]
   },
   "tags": [


### PR DESCRIPTION
## Summary

erdos-771 ("Subsets Avoiding a Given Sum") is already SOLVED (0-sorry; the two remaining axioms are the deep external Erdős–Graham / Alon–Freiman asymptotics). Looking outward, this PR adds a genuinely new **structural** result that sharpens the existing coarse bounds.

The interval `{1,…,n}` is a **complete sequence**: its subset sums realise *every* value in `[1, n(n+1)/2]`. Consequently the full box avoids a target `m` exactly when `m = 0` or `m` exceeds the total — a sharp characterization of when `maxAvoidingSize n m = n`. This replaces the crude `n² < m` threshold used by `avoid_full` / `maxAvoidingSize_eq_of_lt` with the exact `n(n+1)/2`.

## New theorems (Erdos771Problem.lean, all axiom-free)

- `exists_subset_sum_eq` — every `k ≤ ∑_{a=1}^n a` is the sum of some subset of `{1,…,n}` (greedy induction adjoining `n+1`).
- `two_mul_sum_Icc_n` — Gauss closed form `2·∑_{a=1}^n a = n(n+1)`.
- `subsetSums_Icc_n` — `subsetSums {1,…,n} = Icc 1 (n(n+1)/2)`.
- `avoid_full_iff` — `AvoidSum {1,…,n} m ↔ m = 0 ∨ n(n+1)/2 < m`.
- `maxAvoidingSize_eq_n_iff` — `maxAvoidingSize n m = n ↔ m = 0 ∨ n(n+1)/2 < m`.

## Verification

- `lake build Proofs.Erdos771Problem` succeeds (0 errors, 0 sorries, no warnings).
- `#print axioms` on all 5 new theorems: only `[propext, Classical.choice, Quot.sound]`. The deep external axioms are **not** pulled in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)