### PR TITLE
research(cayley-hamilton-cyclic-vector-all-fields-oq-02-oq-02): verify the commutant-dimension headline + degree-level converse reduction [VERIFIED 0 axioms]

### DIFF
--- a/proofs/Proofs/CayleyHamiltonCyclicVectorAllFieldsOQ02OQ02.lean
+++ b/proofs/Proofs/CayleyHamiltonCyclicVectorAllFieldsOQ02OQ02.lean
@@ -298,6 +298,60 @@ theorem finrank_centralizer_dichotomy
   ⟨fun h => (finrank_centralizer_eq_natDegree_minpoly_iff_nonderogatory M).mpr h,
    natDegree_minpoly_lt_finrank_centralizer_of_derogatory M⟩
 
+/-! ### The ambient-dimension (`= n`) reading of the converse -/
+
+/-- **Nonderogatory ⟺ the minimal polynomial has full degree `n`.**  A matrix is
+    nonderogatory (`minpoly K M = charpoly M`) **iff** its minimal polynomial already attains
+    the maximal possible degree `n = Fintype.card (Fin n)`.  Since `minpoly K M ∣ charpoly M`
+    are monic with `deg (charpoly M) = n` (`Matrix.charpoly_natDegree_eq_dim`), equality of the
+    two polynomials is equivalent to equality of their degrees
+    (`Polynomial.eq_of_monic_of_dvd_of_natDegree_le`).  This is the scalar (degree-level)
+    characterization of nonderogatoriness, complementing the centralizer-dimension criteria:
+    it is the hypothesis that the headline `finrank_centralizer_eq_of_nonderogatory`
+    (`dim_K C(M) = n`) consumes. -/
+theorem nonderogatory_iff_natDegree_minpoly_eq_dim
+    (M : Matrix (Fin n) (Fin n) K) :
+    minpoly K M = M.charpoly ↔ (minpoly K M).natDegree = Fintype.card (Fin n) := by
+  constructor
+  · intro h; rw [h, M.charpoly_natDegree_eq_dim]
+  · intro hdeg
+    have hM : IsIntegral K M := IsIntegral.of_finite K M
+    have hdvd : minpoly K M ∣ M.charpoly := minpoly.dvd K M (Matrix.aeval_self_charpoly M)
+    have hmin_monic : (minpoly K M).Monic := minpoly.monic hM
+    have hdeg' : M.charpoly.natDegree ≤ (minpoly K M).natDegree := by
+      rw [M.charpoly_natDegree_eq_dim, hdeg]
+    exact (Polynomial.eq_of_monic_of_dvd_of_natDegree_le hmin_monic M.charpoly_monic hdvd
+      hdeg').symm
+
+/-- **The `= n` converse is exactly the sharp Frobenius bound.**  The headline
+    `finrank_centralizer_eq_of_nonderogatory` proves the forward implication
+    `nonderogatory M → dim_K C(M) = n`.  Its converse `dim_K C(M) = n → nonderogatory M`
+    is *not* derivable from the elementary bounds in this file: `finrank_centralizer_ge`
+    (`n ≤ dim_K C(M)`) together with the strict derogatory bound
+    `natDegree_minpoly_lt_finrank_centralizer_of_derogatory` (`deg(minpoly) < dim_K C(M)`)
+    only give `n ≤ dim_K C(M)` — never a *strict* `n < dim_K C(M)` for derogatory `M`, since
+    `deg(minpoly) < n` there.  The precise missing input is the **sharp Frobenius strictness**:
+    every derogatory matrix has `n < dim_K C(M)` (the invariant-factor content of Frobenius'
+    formula `dim_K C(M) = Σ (2i-1) deg dᵢ`, with `≥ 2` invariant factors forcing a strict
+    excess), which is not yet formalized in this chain.
+
+    This lemma records that reduction honestly: **assuming** the sharp strictness hypothesis,
+    `dim_K C(M) = n` forces `M` nonderogatory.  Discharging `hsharp` unconditionally is the
+    sole remaining gap between the forward headline and a full `dim_K C(M) = n ⟺ nonderogatory`
+    biconditional at the ambient dimension. -/
+theorem nonderogatory_of_finrank_centralizer_eq_dim
+    (hsharp : ∀ M : Matrix (Fin n) (Fin n) K, minpoly K M ≠ M.charpoly →
+        Fintype.card (Fin n) < Module.finrank K
+          ↥(Subalgebra.centralizer K ({M} : Set (Matrix (Fin n) (Fin n) K))))
+    (M : Matrix (Fin n) (Fin n) K)
+    (h : Module.finrank K
+        ↥(Subalgebra.centralizer K ({M} : Set (Matrix (Fin n) (Fin n) K)))
+        = Fintype.card (Fin n)) :
+    minpoly K M = M.charpoly := by
+  by_contra hderog
+  have hlt := hsharp M hderog
+  omega
+
 /-! ### Elementwise (matrix-level) forms -/
 
 /-- **Elementwise commutant characterization for nonderogatory `M`.**  All the results

--- a/src/data/research/problems/cayley-hamilton-cyclic-vector-all-fields-oq-02-oq-02.json
+++ b/src/data/research/problems/cayley-hamilton-cyclic-vector-all-fields-oq-02-oq-02.json
@@ -1,7 +1,7 @@
 {
   "slug": "cayley-hamilton-cyclic-vector-all-fields-oq-02-oq-02",
   "title": "Dimension of the commutant: dim_K C(M) = n for nonderogatory M",
-  "phase": "OBSERVE",
+  "phase": "ACT",
   "status": "active",
   "tier": "B",
   "path": "full",
@@ -69,19 +69,25 @@
   "knowledge": {
     "insights": [
       "Commutant dimension dim_K C(M)=n for nonderogatory M is the equality case of Frobenius bound dim_K C(M)≥n; assembled purely from sibling lemmas (commuting_matrix_is_polynomial, finrank_adjoin_eq_natDegree_minpoly, nonderogatory_iff_has_cyclic_vector).",
-      "Completed the (ii)⟺(iii) edge of the triple equivalence: prior work had only (iii)⟹(ii); this adds the forward (ii)⟹(iii) nonderogatory⟹C(M)=K[M]."
+      "Completed the (ii)⟺(iii) edge of the triple equivalence: prior work had only (iii)⟹(ii); this adds the forward (ii)⟹(iii) nonderogatory⟹C(M)=K[M].",
+      "The env-blocker was the sole obstacle: a fresh docker cache builds the whole cayley-hamilton OQ02 chain cleanly (7748 jobs); no isModule poisoning in an isolated worktree build.",
+      "The `= n` (ambient-dimension) converse dim_K C(M)=n ⟹ nonderogatory is NOT reachable from the file's elementary bounds: finrank_centralizer_ge gives only n ≤ dim C(M), and the strict derogatory bound is deg(minpoly) < dim C(M) with deg(minpoly) < n, so nothing forces a strict n < dim C(M) for derogatory M. The missing input is exactly the sharp Frobenius strictness.",
+      "Nonderogatory has a clean scalar characterization independent of the centralizer: minpoly=charpoly ⟺ deg(minpoly) = n (both monic, minpoly ∣ charpoly, deg charpoly = n)."
     ],
     "builtItems": [
-      "centralizer_eq_adjoin_of_nonderogatory, centralizer_eq_adjoin_iff_nonderogatory, finrank_centralizer_eq_of_nonderogatory (=n), finrank_centralizer_eq_natDegree_charpoly, cayley_hamilton_oq02_oq02_summary in proofs/Proofs/CayleyHamiltonCyclicVectorAllFieldsOQ02OQ02.lean (PR #36663)"
+      "centralizer_eq_adjoin_of_nonderogatory, centralizer_eq_adjoin_iff_nonderogatory, finrank_centralizer_eq_of_nonderogatory (=n), finrank_centralizer_eq_natDegree_charpoly, cayley_hamilton_oq02_oq02_summary in proofs/Proofs/CayleyHamiltonCyclicVectorAllFieldsOQ02OQ02.lean (PR #36663)",
+      "VERIFIED (0-axiom, docker 7748 jobs): cayley_hamilton_oq02_oq02_summary, finrank_centralizer_eq_of_nonderogatory, centralizer_eq_adjoin_of_nonderogatory, finrank_centralizer_eq_natDegree_charpoly in proofs/Proofs/CayleyHamiltonCyclicVectorAllFieldsOQ02OQ02.lean",
+      "nonderogatory_iff_natDegree_minpoly_eq_dim (CayleyHamiltonCyclicVectorAllFieldsOQ02OQ02.lean:312) — minpoly=charpoly ⟺ deg(minpoly)=Fintype.card(Fin n), axiom-free",
+      "nonderogatory_of_finrank_centralizer_eq_dim (CayleyHamiltonCyclicVectorAllFieldsOQ02OQ02.lean:342) — reduction of the `=n` converse to the sharp Frobenius strictness hypothesis, axiom-free"
     ],
     "mathlibGaps": [
       "ENV BLOCKER (not mathlib): shared docker cache had isModule:true poisoned setup.json for dependency OQ02OQ01, blocking build of the whole cayley-hamilton chain in Lean 4.26."
     ],
     "nextSteps": [
-      "Rebuild PR #36663 in a clean docker cache to obtain machine verification; clear isModule:true poisoning of Proofs setup.json for cayley-hamilton chain.",
-      "Possible follow-up: converse dim_K C(M)=n ⟹ nonderogatory (needs full Frobenius invariant-factor dimension formula, not yet built)."
+      "Possible follow-up: converse dim_K C(M)=n ⟹ nonderogatory (needs full Frobenius invariant-factor dimension formula, not yet built).",
+      "Discharge nonderogatory_of_finrank_centralizer_eq_dim's `hsharp` hypothesis unconditionally: prove derogatory M ⟹ Fintype.card (Fin n) < dim_K C(M). This is the sharp Frobenius bound (dim C(M) = Σ(2i-1)deg dᵢ over invariant factors dᵢ; ≥2 factors ⟹ strict excess). Needs invariant-factor / rational-canonical-form degree data — assess Mathlib coverage (Matrix.toLin / Module over K[X] structure theorem) before committing; likely >500 lines if RCF absent."
     ],
-    "progressSummary": "PROGRESS (UNVERIFIED build, env-blocked): proved forward edge (ii)⟹(iii) + headline dim_K C(M)=n; source 0-sorry/0-axiom, machine verification blocked by poisoned shared cache (dependency OQ02OQ01 isModule flag)."
+    "progressSummary": "VERIFIED (2026-07-12 researcher-5): the previously env-blocked headline chain now machine-verifies via a clean docker build (7748 jobs, Lean 4.26). cayley_hamilton_oq02_oq02_summary, finrank_centralizer_eq_of_nonderogatory (dim_K C(M)=n), centralizer_eq_adjoin_of_nonderogatory, and finrank_centralizer_eq_natDegree_charpoly all depend only on [propext, Classical.choice, Quot.sound] (0-axiom). Added two axiom-free lemmas: nonderogatory_iff_natDegree_minpoly_eq_dim (degree-level characterization: minpoly=charpoly ⟺ deg(minpoly)=n) and nonderogatory_of_finrank_centralizer_eq_dim (honest reduction of the open `dim C(M)=n ⟹ nonderogatory` converse to the sharp Frobenius strictness `derogatory ⟹ n<dim C(M)`). Residual open frontier: discharge the sharp strictness hypothesis unconditionally (invariant-factor content of Frobenius' formula), which upgrades the forward headline to a full dim_K C(M)=n ⟺ nonderogatory biconditional."
   },
   "leanFiles": [
     {


### PR DESCRIPTION
## Summary

Clears the previously-recorded environment blocker (poisoned shared docker cache with an `isModule:true` `setup.json` for the OQ02OQ01 dependency) by rebuilding the entire cayley-hamilton OQ02 chain in a clean worktree docker image. `Proofs.CayleyHamiltonCyclicVectorAllFieldsOQ02OQ02` now elaborates cleanly (**7748 jobs**, Lean 4.26), converting the headline from **UNVERIFIED → VERIFIED**.

### Verified (0-axiom: `[propext, Classical.choice, Quot.sound]`)
- `cayley_hamilton_oq02_oq02_summary` — `C(M)=K[M] ⟺ nonderogatory`; and `nonderogatory ⟹ dim_K C(M)=n`
- `finrank_centralizer_eq_of_nonderogatory` — `dim_K C(M) = n`
- `centralizer_eq_adjoin_of_nonderogatory`
- `finrank_centralizer_eq_natDegree_charpoly`

### New axiom-free lemmas (isolate the ambient-dimension `= n` converse)
- **`nonderogatory_iff_natDegree_minpoly_eq_dim`** — the scalar characterization `minpoly K M = charpoly M ⟺ (minpoly K M).natDegree = n`. Both polynomials are monic with `minpoly ∣ charpoly` and `deg charpoly = n`, so `Polynomial.eq_of_monic_of_dvd_of_natDegree_le` upgrades degree equality to polynomial equality.
- **`nonderogatory_of_finrank_centralizer_eq_dim`** — an honest reduction pinning the exact remaining gap. The converse `dim_K C(M)=n ⟹ nonderogatory` is *not* derivable from the file's elementary bounds: `finrank_centralizer_ge` gives only `n ≤ dim_K C(M)`, and the strict derogatory bound lives at `deg(minpoly) < n`, so nothing forces a strict `n < dim_K C(M)` for derogatory `M`. Assuming the **sharp Frobenius strictness** (`derogatory ⟹ n < dim_K C(M)`, the invariant-factor content of `dim_K C(M) = Σ (2i-1) deg dᵢ`), `dim_K C(M)=n` forces nonderogatory. Discharging that hypothesis unconditionally is the sole remaining frontier (requires rational-canonical-form / invariant-factor degree data).

## Verification
Fresh docker build of `Proofs.CayleyHamiltonCyclicVectorAllFieldsOQ02OQ02` — `Build completed successfully (7748 jobs)`. All headline theorems and both new lemmas `#print axioms` to `[propext, Classical.choice, Quot.sound]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)