### PR TITLE
research(erdos-1204): prove exact value A(10)=32, extending the frontier [VERIFIED 0 axioms]

### DIFF
--- a/proofs/Proofs/Erdos1204A10.lean
+++ b/proofs/Proofs/Erdos1204A10.lean
@@ -1,0 +1,126 @@
+import Proofs.Erdos1204A9
+
+/-
+# Erdős #1204 — the exact value `A(10) = 32`
+
+Continues the exact-value frontier
+`A(2)=2, A(3)=6, A(4)=8, A(5)=12, A(6)=16, A(7)=20, A(8)=26, A(9)=30`
+(`Erdos1204Problem.lean`, `Erdos1204A4`–`A9`) with the next Hardy–Littlewood minimal
+diameter `A(10) = H(10) = 32` (OEIS A008407), verified and axiom-free.
+
+- **Upper bound** `A(10) ≤ 32` (`A_ten_le`): the witness `{0,2,6,8,12,18,20,26,30,32}`
+  (the `A(9)` witness extended by `32`) is admissible — all even (misses the odd class
+  mod 2); residues `0,2,0,2,0,0,2,2,0,2` mod 3 (misses class 1); residues
+  `0,2,1,3,2,3,0,1,0,2` mod 5 (misses class 4); residues `0,2,6,1,5,4,6,5,2,4` mod 7
+  (misses class 3). Primes `p ≥ 11` are automatic since `|a| = 10 < p`.
+- **Lower bound** `A(10) ≥ 32` (`admissible_ten_sup_ge`): as at `A(9)`, the mod-`2,3,5`
+  sieve alone already closes the bound — the prime `7` is *not* needed. An admissible set
+  misses one residue class modulo each of `2, 3, 5`; the surviving residues inside the
+  window `{0,…,31}` number at most `9` for *every* choice of the three missed classes
+  (checked by `decide` over the `2·3·5 = 30` combinations). So an admissible set contained
+  in `{0,…,31}` has at most `9` elements — strictly fewer than `10`. Any admissible
+  `10`-set therefore has an element `≥ 32`.
+
+**Correcting the earlier estimate.** The prior next-step note (see `erdos-1204.json`)
+predicted that `A(10)` would need `p = 7` back as a binding constraint, reasoning from the
+*average* mod-`2,3,5` density `32·(1/2)(2/3)(4/5) = 8.53` that "up to ~10–11 survive". The
+exact maximum over all `30` class-triples is only `9`, not `10` or `11`: the odd-`+`
+mod-`3` mod-`5` filter of `{0,…,31}` peaks at `9` survivors (e.g. missing `0` mod each of
+`2,3,5`). So `A(10)` joins `A(9)` as a value the mod-`2,3,5` sieve settles outright, and the
+window `{0,…,31}` (length `32`, just above the primorial `2·3·5 = 30`) still holds the
+density below the target `10`.
+
+The asymptotics `A(k) ∼ k log k` remain OPEN (need sieve theory).
+-/
+
+namespace Erdos1204
+
+open Finset
+
+/-- The witness `{0,2,6,8,12,18,20,26,30,32}` (the `A(9)` witness plus `32`) is admissible:
+even ⇒ misses the odd class mod 2; residues `0,2,0,2,0,0,2,2,0,2` mod 3 ⇒ misses class 1;
+residues `0,2,1,3,2,3,0,1,0,2` mod 5 ⇒ misses class 4; residues `0,2,6,1,5,4,6,5,2,4` mod 7
+⇒ misses class 3. (Primes `p ≥ 11` are automatic since `|a| = 10 < p`.) Gives `A(10) ≤ 32`. -/
+theorem admissible_witness_ten :
+    Admissible ({0, 2, 6, 8, 12, 18, 20, 26, 30, 32} : Finset ℕ) := by
+  rw [admissible_iff_card]
+  intro p hp hcard
+  have hc : ({0, 2, 6, 8, 12, 18, 20, 26, 30, 32} : Finset ℕ).card = 10 := by decide
+  rw [hc] at hcard
+  interval_cases p
+  · exact absurd hp (by decide)   -- p = 0
+  · exact absurd hp (by decide)   -- p = 1
+  · exact ⟨1, by intro x hx; fin_cases hx <;> decide⟩   -- p = 2: miss class 1
+  · exact ⟨1, by intro x hx; fin_cases hx <;> decide⟩   -- p = 3: miss class 1
+  · exact absurd hp (by decide)   -- p = 4: not prime
+  · exact ⟨4, by intro x hx; fin_cases hx <;> decide⟩   -- p = 5: miss class 4
+  · exact absurd hp (by decide)   -- p = 6: not prime
+  · exact ⟨3, by intro x hx; fin_cases hx <;> decide⟩   -- p = 7: miss class 3
+  · exact absurd hp (by decide)   -- p = 8: not prime
+  · exact absurd hp (by decide)   -- p = 9: not prime
+  · exact absurd hp (by decide)   -- p = 10: not prime
+
+/-- **`A(10) ≤ 32`.** The admissible `10`-set `{0,2,6,8,12,18,20,26,30,32}` has largest
+element `32`, so the minimal largest element of an admissible `10`-set is at most `32`.
+This is the upper half of the Hardy–Littlewood value `H(10) = 32`. -/
+theorem A_ten_le : A 10 ≤ 32 := by
+  have h := A_le (k := 10) (a := ({0, 2, 6, 8, 12, 18, 20, 26, 30, 32} : Finset ℕ)) (by decide)
+    admissible_witness_ten
+  have hs : ({0, 2, 6, 8, 12, 18, 20, 26, 30, 32} : Finset ℕ).sup id = 32 := by decide
+  rwa [hs] at h
+
+/-- **Lower-bound core.** Every admissible `10`-set has largest element at least `32`.
+
+If the maximum were `≤ 31`, the set would sit in `{0,…,31}`. Admissibility supplies a
+missed residue class modulo each of `2`, `3` and `5`, so the set is contained in the
+filter of `{0,…,31}` avoiding all three classes. That filter has at most `9` elements for
+*every* choice of the three missed classes (checked by `decide` over the `2·3·5 = 30`
+combinations). Hence the set has at most `9 < 10` elements — impossible.
+
+As with `A(9)`, the prime `7` plays no role: the mod-`2,3,5` sieve density already falls
+below `10` on the window `{0,…,31}`. -/
+theorem admissible_ten_sup_ge {a : Finset ℕ} (hcard : a.card = 10)
+    (ha : Admissible a) : 32 ≤ a.sup id := by
+  by_contra hlt
+  push_neg at hlt
+  have hbound : ∀ x ∈ a, x ≤ 31 := by
+    intro x hx
+    have h1 : id x ≤ a.sup id := Finset.le_sup hx
+    simp only [id_eq] at h1
+    omega
+  obtain ⟨r2, hr2⟩ := ha 2 (by decide)
+  obtain ⟨r3, hr3⟩ := ha 3 (by decide)
+  obtain ⟨r5, hr5⟩ := ha 5 (by decide)
+  -- Every element of `a` lies in `{0,…,31}` and dodges the three missed classes.
+  have hsub : a ⊆ (Finset.range 32).filter
+      (fun x : ℕ => (x : ZMod 2) ≠ r2 ∧ (x : ZMod 3) ≠ r3 ∧ (x : ZMod 5) ≠ r5) := by
+    intro x hx
+    rw [Finset.mem_filter, Finset.mem_range]
+    exact ⟨by have := hbound x hx; omega, hr2 x hx, hr3 x hx, hr5 x hx⟩
+  -- For every triple of missed classes the surviving filter has at most `9` elements.
+  have hcardf : ((Finset.range 32).filter
+      (fun x : ℕ => (x : ZMod 2) ≠ r2 ∧ (x : ZMod 3) ≠ r3 ∧ (x : ZMod 5) ≠ r5)).card ≤ 9 := by
+    fin_cases r2 <;> fin_cases r3 <;> fin_cases r5 <;> decide
+  have hle := Finset.card_le_card hsub
+  rw [hcard] at hle
+  omega
+
+/-- **`A(10) = 32`.** The minimal largest element of an admissible `10`-set is `32`,
+attained by `{0,2,6,8,12,18,20,26,30,32}`. This matches the Hardy–Littlewood minimal
+diameter `H(10) = 32` (OEIS A008407) and continues the frontier
+`A(2)=2, …, A(9)=30, A(10)=32`. Like `A(9)`, its lower bound is settled by the mod-`2,3,5`
+sieve alone — `p = 7` is not needed. -/
+theorem A_ten : A 10 = 32 := by
+  refine le_antisymm A_ten_le ?_
+  obtain ⟨a, hcard, ha, hsup⟩ := A_mem 10
+  have hge := admissible_ten_sup_ge hcard ha
+  omega
+
+/-- **`A(10) ≥ 32`.** Restatement of the lower bound now that the exact value is known. -/
+theorem A_ten_ge : 32 ≤ A 10 := by rw [A_ten]
+
+/-- **`A(10) = 32`, as the sharp two-sided sandwich.** -/
+theorem A_ten_bounds : 32 ≤ A 10 ∧ A 10 ≤ 32 :=
+  ⟨A_ten_ge, A_ten_le⟩
+
+end Erdos1204

--- a/src/data/research/problems/erdos-1204.json
+++ b/src/data/research/problems/erdos-1204.json
@@ -1,7 +1,7 @@
 {
   "slug": "erdos-1204",
   "title": "Erdős #1204",
-  "phase": "ORIENT",
+  "phase": "ACT",
   "status": "active",
   "tier": "A",
   "path": "full",
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (researcher-1, 2026-07-12): proved the EXACT value A(9)=30 (companion Erdos1204A9.lean), tightening the earlier 27<=A(9)<=30 bracket to equality and extending the exact frontier to A(2..9)=2,6,8,12,16,20,26,30. New lower bound admissible_nine_sup_ge: an admissible set misses one residue class mod each of 2,3,5, so within {0,..,29} it survives at most 30*(1/2)*(2/3)*(4/5)=8 residues (checked by decide over all 2*3*5=30 class-triples), which is < 9 — so any admissible 9-set has an element >=30. Notably p=7 is NOT needed (unlike A(8)=26): the primorial 2*3*5=30 equals the window length {0,..,29}, forcing the mod-2,3,5 density below 9. 0 sorries / 0 axioms ([propext,Classical.choice,Quot.sound] only, no native_decide), docker-verified Lean v4.26.0 (7746 jobs).",
+    "progressSummary": "PROGRESS (researcher-5, 2026-07-12): proved the EXACT value A(10)=32 (Erdos1204A10.lean), extending the exact frontier to A(2..10)=2,6,8,12,16,20,26,30,32. Like A(9), the lower bound is settled by the mod-2,3,5 sieve ALONE (p=7 not needed): the exact max over all 30 missed-class triples of the range-32 avoidance filter is exactly 9<10 (by decide), correcting an earlier next-step note that predicted p=7 would be binding. 0 sorries / 0 axioms ([propext,Classical.choice,Quot.sound], no native_decide), host-lake verified Lean v4.26.0.",
     "builtItems": [
       "Erdos1204.Admissible (def) in Proofs/Erdos1204Problem.lean",
       "Erdos1204.missing_class_of_card_lt",
@@ -49,7 +49,10 @@
       "Erdos1204A9.lean: admissible_witness_nine + A_nine_le (A(9)<=30) + A_nine_ge (A(9)>=27 via A_lt_A_succ at A(8)=26) + A_nine_bounds; 0 axioms/0 sorries",
       "theorem admissible_nine_sup_ge — every admissible 9-set has sup ≥ 30, via the mod-2,3,5 CRT filter-card bound (8<9).",
       "theorem A_nine : A 9 = 30 — the exact Hardy–Littlewood minimal diameter H(9), closing the 27≤A(9)≤30 bracket.",
-      "theorem A_nine_ge : 30 ≤ A 9 and updated A_nine_bounds sharp sandwich."
+      "theorem A_nine_ge : 30 ≤ A 9 and updated A_nine_bounds sharp sandwich.",
+      "admissible_witness_ten (Erdos1204A10.lean): {0,2,6,8,12,18,20,26,30,32} = A(9) witness + 32 is admissible (misses class 1 mod2, 1 mod3, 4 mod5, 3 mod7); gives A(10)<=32",
+      "admissible_ten_sup_ge (Erdos1204A10.lean): every admissible 10-set has sup>=32, via mod-2,3,5 sieve fin_cases r2,r3,r5 <;> decide (filter card <=9 over range 32)",
+      "A_ten / A_ten_ge / A_ten_bounds (Erdos1204A10.lean): A(10)=32 exact, axiom-free [propext,Classical.choice,Quot.sound], extends frontier A(2..10)=2,6,8,12,16,20,26,30,32"
     ],
     "insights": [
       "Admissibility is purely local: only the residue pattern mod each prime matters.",
@@ -65,13 +68,14 @@
       "The vanishing locus of A is exactly {0,1}: A(0)=A(1)=0 (∅ and {0}), while every admissible k-set with k≥2 is forced by the prime 2 to have maximum ≥2(k-1)≥2, so A is strictly positive from k=2.",
       "A(9) sits in 27 <= A(9) <= 30 (H(9)=30). The exact value needs the exhaustive p=2,3,5,7 pruning over {0,..,29} (as A(8)=26 required over {0,..,25}); the general slope ladder Erdos1204C..F (slopes 3, 15/4, 35/8, 77/16) gives only A(9)>=3(9-2)=21, weaker than the monotonicity bound 27, so per-value exact computation and the asymptotic ladder are complementary.",
       "A(9)=30 exact (OEIS A008407): the mod-2,3,5 sieve alone closes the lower bound because 2*3*5=30 equals the window length {0,..,29}; by CRT exactly 1*2*4=8 residues survive avoiding one class each mod 2,3,5, and 8<9. p=7 is unnecessary here, unlike A(8)=26 where the 13-per-parity window leaves 9-slot pools that only p=7 kills.",
-      "Formalization pattern for these primorial-window lower bounds: bound a by (Finset.range N).filter (fun x:ℕ => (x:ZMod p1)≠r1 ∧ ...), then close all class-choices at once with fin_cases r1 <;> ... <;> decide proving the filter card ≤ target-1. Much shorter than the per-branch forced-set case bash used for A(8). GOTCHA: annotate the lambda binder `fun x : ℕ =>` — a bare `(x : ZMod 2)` ascription makes Lean infer x:ZMod 2 and the later (x:ZMod 3) mismatches."
+      "Formalization pattern for these primorial-window lower bounds: bound a by (Finset.range N).filter (fun x:ℕ => (x:ZMod p1)≠r1 ∧ ...), then close all class-choices at once with fin_cases r1 <;> ... <;> decide proving the filter card ≤ target-1. Much shorter than the per-branch forced-set case bash used for A(8). GOTCHA: annotate the lambda binder `fun x : ℕ =>` — a bare `(x : ZMod 2)` ascription makes Lean infer x:ZMod 2 and the later (x:ZMod 3) mismatches.",
+      "A(10)=32 (Erdos1204A10.lean): the mod-2,3,5 sieve ALONE closes the lower bound — p=7 is NOT needed. The exact max over all 2*3*5=30 missed-class triples of |{x<32 : x avoids one class each mod 2,3,5}| is exactly 9 < 10 (checked by decide), correcting the earlier next-step prediction that averaged density 32*(1/2)(2/3)(4/5)=8.53 to guess ~10-11 survivors and expected p=7 to become binding. Window length 32 sits just above the primorial 2*3*5=30 yet density stays below target 10."
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "Prove A(10)=32: window {0,..,31}, need to rule out admissible 10-sets with sup ≤ 31. The clean mod-2,3,5 density is 32*(1/2)*(2/3)*(4/5)=8.53→ up to ~10-11 survive, so p=7 becomes binding again (as at A(8)); expect an A(8)-style forced-set case analysis. Non-trivial but mechanical.",
-      "Generalize the primorial-window observation: when the search window {0,..,P-1} has length equal to a primorial P=2·3·…·p_j, the mod-2..p_j sieve density is exactly φ-like ∏(p_i-1)/p_i · P, giving a clean closed-form lower bound A(k) ≥ P whenever that density < k. This is the elementary mod-small-primes lower bound flagged in prior nextSteps.",
-      "The headline A(k)∼k log k asymptotic needs sieve theory / prime distribution — remains OPEN."
+      "Prove A(11)=36: window {0,..,35}, target 11. Check whether the mod-2,3,5(,7) sieve density stays below 11 (decide over class-tuples) or whether a genuine forced-set case analysis is needed — A(10) showed the averaged-density heuristic is unreliable, so COMPUTE the exact per-tuple max before predicting which primes are binding.",
+      "Generalize the primorial-window observation into a reusable lemma: for the first j primes with primorial P=prod p_i, an admissible set inside {0,..,P-1} has card <= prod (p_i-1) via CRT (ZMod P ≅ prod ZMod p_i), giving A(k) >= P whenever prod(p_i-1) < k. Mathlib: ZMod.chineseRemainder. Est ~300-500 lines; moderate risk.",
+      "The headline A(k) ∼ k log k asymptotic needs sieve theory / prime distribution — remains OPEN."
     ],
     "markdown": "# Erdős #1204 - Knowledge Base\n\n## Problem Statement\n\nWe call a sequence of integers $0\\leq a_1<\\cdots <a_k$ admissible if it is missing at least one congruence class modulo every prime $p$. Let $A(k)=\\min a_k$. Estimate $A(k)$ - in particular, is it true that\\[A(k)\\sim k\\log k?\\]Estimate\\[B(k)=\\min \\frac{a_1+\\cdots+a_k}{k}.\\]\n\n## Status\n\n**Erdős Database Status**: OPEN\n\n**Tractability Score**: 5/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #337\n- Problem #2000\n- Problem #60\n- Problem #2\n- Problem #855\n- Problem #1203\n- Problem #1205\n- Problem #39\n- Problem #1\n\n## References\n\n- Er80\n- HeRi73\n- Po14c\n- El65\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-04-16*\n",
     "score": 27


### PR DESCRIPTION
## Summary

Proves the exact Hardy–Littlewood minimal admissible diameter **A(10) = 32** (`Erdos1204A10.lean`), continuing the exact-value frontier

`A(2)=2, A(3)=6, A(4)=8, A(5)=12, A(6)=16, A(7)=20, A(8)=26, A(9)=30, A(10)=32`

matching OEIS A008407 (`H(k)`).

## What's proved

- **Upper bound** `A(10) ≤ 32` (`A_ten_le`): the witness `{0,2,6,8,12,18,20,26,30,32}` — the `A(9)` witness extended by `32` — is admissible (misses class `1` mod `2`, `1` mod `3`, `4` mod `5`, `3` mod `7`; primes `≥ 11` automatic since `|a|=10 < p`).
- **Lower bound** `A(10) ≥ 32` (`admissible_ten_sup_ge`): the **mod-2,3,5 sieve alone** settles it — `p = 7` is *not* needed. An admissible set inside `{0,…,31}` avoids one residue class mod each of `2,3,5`; the exact maximum over all `2·3·5 = 30` missed-class triples of the resulting range-32 avoidance filter is exactly `9 < 10` (checked by `decide`). Hence no admissible `10`-set fits in `{0,…,31}`.
- `A_ten : A 10 = 32`, plus `A_ten_ge` and `A_ten_bounds`.

## Correcting the earlier estimate

The prior next-step note predicted `A(10)` would need `p = 7` back as a binding constraint, extrapolating from the *average* density `32·(1/2)(2/3)(4/5) = 8.53` to guess "~10–11 survive". The exact per-triple maximum is only `9`, so `A(10)` joins `A(9)` as a value the mod-`2,3,5` sieve closes outright.

## Verification

- Host `lake` build, Lean `v4.26.0`, 7747 jobs, builds clean.
- Axiom-free: `#print axioms A_ten` = `[propext, Classical.choice, Quot.sound]` (no `native_decide`, no `sorry`) — same for `admissible_witness_ten` and `admissible_ten_sup_ge`.

The asymptotic `A(k) ∼ k log k` (Erdős #1204's headline question) remains OPEN.

🤖 Generated with [Claude Code](https://claude.com/claude-code)