### PR TITLE
research(erdos-1008-oq-02-oq-02): leading-order asymptotic constant for ex(n;K_{2,t}) [VERIFIED 0 axioms]

### DIFF
--- a/proofs/Proofs/Erdos1008OQ02OQ02.lean
+++ b/proofs/Proofs/Erdos1008OQ02OQ02.lean
@@ -1338,6 +1338,63 @@ theorem hasKst_of_edge_bound_rpow_lt (G : SimpleGraph V) [DecidableRel G.Adj]
   by_contra hfree
   exact absurd (kst_general_edge_bound_rpow G s t hs ht hfree) (not_le.2 hm)
 
+/-! ### Leading-order asymptotic constant
+
+The finite-`n` closed form `kst_edge_bound_leading_order`
+(`m ≤ ½(√(t-1)·n^{3/2} + n)`) determines the *asymptotic* leading coefficient of
+`ex(n; K_{2,t})`.  We package the bound as a function of `n` and show its ratio to
+`n^{3/2}` converges to `½·√(t-1)`, discharging the analytic content of the
+textbook statement `ex(n; K_{2,t}) ≤ (½√(t-1) + o(1))·n^{3/2}`. -/
+
+/-- **Closed-form leading-order KST bound as a function of `n`.**  The right-hand
+side of `kst_edge_bound_leading_order`: `½·(√(t-1)·n^{3/2} + n)`, with `n^{3/2}`
+written `n·√n`.  Packaging it as a function of `n` lets us state the asymptotic
+leading constant (`kst_leading_order_ratio_tendsto`). -/
+noncomputable def kstLeadingBound (t : ℕ) (n : ℝ) : ℝ :=
+  (Real.sqrt ((t : ℝ) - 1) * n * Real.sqrt n + n) / 2
+
+/-- The leading-order bound restated with `kstLeadingBound`: a nonempty
+`K_{2,t}`-free graph (`t ≥ 1`) satisfies `m ≤ kstLeadingBound t n`. -/
+theorem kst_edge_bound_leading_order_def (G : SimpleGraph V) [DecidableRel G.Adj]
+    [Nonempty V] (t : ℕ) (ht : 1 ≤ t) (hfree : ¬ HasK2t G t) :
+    (G.edgeFinset.card : ℝ) ≤ kstLeadingBound t (Fintype.card V) :=
+  kst_edge_bound_leading_order G t ht hfree
+
+/-- **Leading-order asymptotic constant for `ex(n; K_{2,t})`.**  The closed-form
+Kővári–Sós–Turán upper bound `kstLeadingBound t n = ½(√(t-1)·n^{3/2} + n)`,
+divided by `n^{3/2}`, tends to `½·√(t-1)` as `n → ∞`:
+
+      kstLeadingBound t n / n^{3/2}  →  ½·√(t-1).
+
+Combined with `kst_edge_bound_leading_order_def` (`m ≤ kstLeadingBound t n`), this
+makes rigorous the textbook statement `ex(n; K_{2,t}) ≤ (½√(t-1) + o(1))·n^{3/2}`:
+the `+n` correction term contributes `n / n^{3/2} = n^{-1/2} → 0`, so the leading
+coefficient of the proven upper bound is exactly `½√(t-1)`.  For `t = 2` this
+recovers Reiman's `ex(n; C₄) ≤ (½ + o(1))·n^{3/2}`.  The `√(t-1)` factor is a fixed
+constant, so no monotonicity/nonnegativity hypothesis on `t` is needed. -/
+theorem kst_leading_order_ratio_tendsto (t : ℕ) :
+    Filter.Tendsto (fun n : ℝ => kstLeadingBound t n / (n * Real.sqrt n))
+      Filter.atTop (nhds (Real.sqrt ((t : ℝ) - 1) / 2)) := by
+  -- `√n → ∞`, hence `2√n → ∞`, hence `(2√n)⁻¹ → 0`.
+  have hsqrt_atTop : Filter.Tendsto (fun n : ℝ => Real.sqrt n) Filter.atTop Filter.atTop := by
+    have h : (fun n : ℝ => Real.sqrt n) = fun n : ℝ => n ^ (1 / (2 : ℝ)) := by
+      funext x; exact Real.sqrt_eq_rpow x
+    rw [h]; exact tendsto_rpow_atTop (by norm_num)
+  have hinv : Filter.Tendsto (fun n : ℝ => (2 * Real.sqrt n)⁻¹) Filter.atTop (nhds 0) :=
+    (Filter.Tendsto.const_mul_atTop (by norm_num : (0 : ℝ) < 2) hsqrt_atTop).inv_tendsto_atTop
+  -- The target eventually equals the constant `½√(t-1)` plus the vanishing `(2√n)⁻¹`.
+  have hconst : Filter.Tendsto (fun _ : ℝ => Real.sqrt ((t : ℝ) - 1) / 2) Filter.atTop
+      (nhds (Real.sqrt ((t : ℝ) - 1) / 2)) := tendsto_const_nhds
+  have hsum := hconst.add hinv
+  rw [add_zero] at hsum
+  refine hsum.congr' ?_
+  filter_upwards [Filter.eventually_gt_atTop (0 : ℝ)] with n hn
+  have hs : (0 : ℝ) < Real.sqrt n := Real.sqrt_pos.mpr hn
+  have hnn : n ≠ 0 := hn.ne'
+  have hsn : Real.sqrt n ≠ 0 := hs.ne'
+  simp only [kstLeadingBound]
+  field_simp
+
 end GraphLevel
 
 end Erdos1008

--- a/src/data/research/problems/erdos-1008-oq-02-oq-02.json
+++ b/src/data/research/problems/erdos-1008-oq-02-oq-02.json
@@ -37,7 +37,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: added the general K_{s,t} structural layer to Erdos1008OQ02OQ02.lean — monotonicity of HasKst in both part-sizes (hasKst_mono_s/_t/mono), freeness nesting (not_hasKst_mono), and the K_{s,t}≅K_{t,s} symmetry (hasKst_comm, giving ex(n;K_{s,t})=ex(n;K_{t,s})). All 5 axiom-free, elab EXIT 0. File stays 0-axiom/0-sorry.",
+    "progressSummary": "PROGRESS: added the leading-order asymptotic constant — the proven closed-form KST upper bound for K_{2,t}, normalized by n^{3/2}, converges to ½√(t-1) (kst_leading_order_ratio_tendsto), making rigorous ex(n;K_{2,t}) ≤ (½√(t-1)+o(1))n^{3/2}. Upper-bound side of the closed form now complete finite-n AND asymptotically; only the (hard) matching lower-bound construction remains open.",
     "builtItems": [
       "kst_quadratic_solve (Erdos1008OQ02OQ02.lean): solves the general K_{2,t} KST quadratic 4m^2 <= (t-1)n^2(n-1)+2nm for the upper root 4m <= n(1+s), s=sqrt(1+4(t-1)(n-1))",
       "reiman_quadratic_solve_of_kst: t=2 specialisation recovering the sibling C4 lemma verbatim (1+4(t-1)(n-1)=4n-3)",
@@ -60,7 +60,9 @@
       "kst_general_edge_bound_rpow (Erdos1008OQ02OQ02.lean): unconditional classical KST 2m ≤ (t-1)^(1/s) n^(2-1/s) + (s-1)n via monotone s-th root (Real.pow_rpow_inv_natCast, Real.mul_rpow); axiom-free",
       "Erdos1008OQ02OQ02.lean: hasKst_mono_t / hasKst_mono_s / hasKst_mono — HasKst monotone in t, s, and both (general-s analogue of hasK2t_mono).",
       "Erdos1008OQ02OQ02.lean: not_hasKst_mono — K_{s,t}-free classes nest (Free(s,t) ⊆ Free(s,t)).",
-      "Erdos1008OQ02OQ02.lean: hasKst_comm — symmetry HasKst G s t ↔ HasKst G t s (K_{s,t}≅K_{t,s})."
+      "Erdos1008OQ02OQ02.lean: hasKst_comm — symmetry HasKst G s t ↔ HasKst G t s (K_{s,t}≅K_{t,s}).",
+      "kstLeadingBound + kst_leading_order_ratio_tendsto (Erdos1008OQ02OQ02.lean): the closed-form KST bound ½(√(t-1)·n^{3/2}+n) divided by n^{3/2} tends to ½√(t-1) — rigorous leading-order asymptotic constant, axiom-free",
+      "kst_edge_bound_leading_order_def: graph-level restatement m ≤ kstLeadingBound t n tying the asymptotic function to the proven edge bound"
     ],
     "insights": [
       "The C4 algebraic core generalises to K_{2,t} with zero structural change: replace the single-common-neighbour bound by (t-1), so s^2=4n-3 becomes s^2=1+4(t-1)(n-1) and the KST quadratic gains a (t-1) factor on the n^2(n-1) term. Same nlinarith case-split proof works.",
@@ -71,7 +73,8 @@
       "The genuine Kővári–Sós–Turán double-count is the s-general s-star count ∑_v C(d_v,s)=∑_{|S|=s} codeg(S) ≤ (t-1)·C(n,s); the file previously had only the s=2 (K_{2,t}) slice. Proved the full s-general combinatorial core (kst_star_count_nat/_choose/_of_free) via Finset.powersetCard double-counting + Finset.sum_comm, exactly mirroring kst_cherry_count_nat but with powersetCard s in place of offDiag. No analysis needed; axiom-free.",
       "Convexity/Jensen step for the general K_{s,t} bound is realized elementarily WITHOUT proving convexity of the descending factorial: route through C(d,s) ≥ (d-s+1)^s/s! (each of s descending factors ≥ d-s+1, Nat.pow_sub_le_descFactorial) then Mathlib power-mean pow_sum_le_card_mul_sum_pow (Jensen for x↦x^s).",
       "Sharp KST power form (2m-(s-1)n)^s ≤ (t-1)·n^(2s-1) is the general-s analogue of the s=2 quadratic 4m² ≤ (t-1)n²(n-1)+2nm; s-th root gives the classical 2m ≤ (t-1)^(1/s) n^(2-1/s) + (s-1)n unconditionally (sparse regime 2m<(s-1)n handled by nonnegativity).",
-      "General K_{s,t} containment HasKst G s t is symmetric (K_{s,t} ≅ K_{t,s}, hasKst_comm) and monotone in both indices; symmetry gives ex(n;K_{s,t})=ex(n;K_{t,s}). Proved via Finset.exists_subset_card_eq (the correct Mathlib name; exists_smaller_set does not exist here)."
+      "General K_{s,t} containment HasKst G s t is symmetric (K_{s,t} ≅ K_{t,s}, hasKst_comm) and monotone in both indices; symmetry gives ex(n;K_{s,t})=ex(n;K_{t,s}). Proved via Finset.exists_subset_card_eq (the correct Mathlib name; exists_smaller_set does not exist here).",
+      "Asymptotic wrapper needs no relation n=√n²: the ratio identity ½√(t-1)+(2√n)⁻¹ = (√(t-1)·n√n+n)/2/(n√n) is a pure field identity (cancel n√n and n), closed by field_simp alone; only n≠0,√n≠0 required. √n→∞ via Real.sqrt_eq_rpow + tendsto_rpow_atTop(1/2); (2√n)⁻¹→0 via const_mul_atTop.inv_tendsto_atTop."
     ],
     "mathlibGaps": [
       "No graph-level general cherry-count sum_v C(d_v,2) <= (t-1)*C(n,2) for K_{2,t}-free graphs in the gallery; parent Erdos1008Problem only proves the t=2 (C4) case kovari_sos_turan.",
@@ -79,9 +82,9 @@
       "Mathlib has NO named general Kővári–Sós–Turán / Zarankiewicz edge bound; power-mean pow_sum_le_card_mul_sum_pow + Nat.pow_sub_le_descFactorial + Nat.descFactorial_le_pow suffice to build it in ~180 lines."
     ],
     "nextSteps": [
-      "Derive the leading-order asymptotic ex(n;K_{s,t}) = ½ n^{2-1/s} (1+o(1))·(t-1)^{1/s} statement (currently a finite-n inequality; asymptotic wrapper would need o-notation).",
-      "Sharpen constant: current route uses C(n,s) ≤ n^s/s! and (d-s+1)^s ≤ descFactorial; a tighter root-of-quadratic style bound could recover the exact ¼(1+√...)n for s=2 within the general-s theorem.",
-      "Reiman/Kővári–Sós–Turán converse: lower-bound constructions (incidence graphs / norm graphs) showing the n^{2-1/s} exponent is tight."
+      "Sharpen constant: current s=2 route uses C(n,s)≤n^s/s! and (d-s+1)^s≤descFactorial; a tighter root-of-quadratic bound could recover exact ¼(1+√...)n within general-s theorem.",
+      "Reiman/KST converse: lower-bound constructions (incidence graphs / norm graphs) showing the n^{2-1/s} exponent is tight — the genuinely open hard direction.",
+      "General-s asymptotic: lift kst_leading_order_ratio_tendsto to ratio of kst_general_edge_bound_rpow / n^{2-1/s} → (t-1)^{1/s} (the (s-1)n term is lower order)."
     ]
   },
   "tags": [


### PR DESCRIPTION
## Summary

Adds the **leading-order asymptotic constant** for the Kővári–Sós–Turán closed form, discharging the analytic content of nextStep #1 for this problem.

The finite-`n` closed-form upper bound already proven in this file,
`m ≤ ½(√(t-1)·n^{3/2} + n)` (`kst_edge_bound_leading_order`), is packaged as a function `kstLeadingBound t n` and normalized by `n^{3/2}`:

```
kst_leading_order_ratio_tendsto :
  Tendsto (fun n => kstLeadingBound t n / (n * √n)) atTop (𝓝 (√(t-1)/2))
```

i.e. `kstLeadingBound t n / n^{3/2} → ½·√(t-1)`. This makes rigorous the textbook statement
`ex(n; K_{2,t}) ≤ (½√(t-1) + o(1))·n^{3/2}` — the `+n` correction contributes `n/n^{3/2}=n^{-1/2}→0`, so the leading coefficient of the proven upper bound is *exactly* `½√(t-1)`. For `t = 2` this recovers Reiman's `ex(n;C₄) ≤ (½+o(1))·n^{3/2}`.

`kst_edge_bound_leading_order_def` restates the graph edge bound `m ≤ kstLeadingBound t n`, tying the asymptotic function back to the combinatorial theorem so the two together give the full leading-order upper asymptotic.

## Details

- `kstLeadingBound` (noncomputable def), `kst_edge_bound_leading_order_def`, `kst_leading_order_ratio_tendsto` (+57 lines).
- Analytic route: `√n→∞` via `Real.sqrt_eq_rpow` + `tendsto_rpow_atTop (1/2)`; `(2√n)⁻¹→0` via `const_mul_atTop.inv_tendsto_atTop`; the ratio identity is a pure field identity (cancel `n√n` and `n`, needs only `n≠0,√n≠0`), closed by `field_simp`.
- **Axiom-free**: `#print axioms` = `[propext, Classical.choice, Quot.sound]` only.
- Builds clean (`Build completed successfully (7743 jobs)`).

## What remains (honest scope)

This completes the **upper-bound** side of the closed form both at finite `n` and asymptotically. The matching **lower-bound construction** (Reiman/norm-graph incidence graphs showing the exponent/constant is tight) is the genuinely open hard direction and is untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)