### PR TITLE
research(collatz-structured-oq-02-oq-03): deriveVec is the MAXIMAL valid certificate [VERIFIED 0-axiom]

### DIFF
--- a/proofs/Proofs/CollatzStructuredOQ02OQ03CertUnique.lean
+++ b/proofs/Proofs/CollatzStructuredOQ02OQ03CertUnique.lean
@@ -248,5 +248,98 @@ theorem affValid_true_succ_false {v : List Bool} {c d : ℕ} (hv : AffValid v c 
   rw [e1, e2] at hdrop
   simp only [hi, hi2] at hdrop
   exact not_affValid_true_true hdrop
+/-! ## Part XI (cont.) — Length maximality of the derived window
+
+The prefix results above (`affValid_prefix_deriveVec`) still assume a comparison against
+`deriveVec`'s *own* length.  The lemmas below discharge that hypothesis at its root: the
+`deriveVec` engine records a bit under exactly the branch condition (`c` even) that the
+`AffValid` constructors demand, so the certificate recursion and the engine recursion stay
+in lockstep.  Consequently a valid certificate is *never* longer than the window the fuel
+can reach — `deriveVec` produces the maximal faithful transcript — and increasing the fuel
+only extends the window, never revising a recorded bit.  This settles the standing
+"maximality of `deriveVec` length" step: no valid certificate is strictly longer than
+`deriveVec fuel c d` once `fuel` covers it, and the canonical choice `fuel = v.length`
+always covers it.  Still axiom-free (independent of `tao_2019`; no `decide`). -/
+
+/-- The auto-derived window never records more bits than its fuel: `deriveVec` stops as soon
+as the leading coefficient turns odd or the fuel runs out, so `(deriveVec fuel c d).length ≤
+fuel` unconditionally.  This is the intrinsic length budget that replaces the
+self-referential bound `v.length ≤ (deriveVec …).length`. -/
+theorem deriveVec_length_le : ∀ (fuel c d : ℕ), (deriveVec fuel c d).length ≤ fuel := by
+  intro fuel
+  induction fuel with
+  | zero => intro c d; simp [deriveVec]
+  | succ f ih =>
+    intro c d
+    rw [deriveVec]
+    split_ifs
+    · simp
+    · simp only [List.length_cons]; exact Nat.succ_le_succ (ih (3 * c) (3 * d + 1))
+    · simp only [List.length_cons]; exact Nat.succ_le_succ (ih (c / 2) (d / 2))
+
+/-- **Maximality of the derived window (prefix form).**  Any valid certificate `v` for the
+affine class `(c, d)` whose length is within the available `fuel` is a *prefix* of the
+auto-derived window `deriveVec fuel c d`.  Unlike `affValid_prefix_deriveVec`, this needs no
+hypothesis comparing `v` to `deriveVec`'s own length — only `v.length ≤ fuel`, met by the
+canonical choice `fuel = v.length`.  Proof: induction on the `AffValid` derivation.  Both
+constructors (`odd`, `even`) require `c % 2 = 0`, which is exactly the branch `deriveVec`
+takes before recording a bit, so at each step the engine emits the same parity the
+certificate does and recurses into the same successor pair. -/
+theorem affValid_prefix_deriveVec_of_length :
+    ∀ {v : List Bool} {c d : ℕ}, AffValid v c d → ∀ {fuel : ℕ}, v.length ≤ fuel →
+      v <+: deriveVec fuel c d := by
+  intro v c d hv
+  induction hv with
+  | nil => intro fuel _; exact List.nil_prefix
+  | @odd v c d hc hd _ ih =>
+    intro fuel hfuel
+    obtain ⟨fuel', rfl⟩ : ∃ f, fuel = f + 1 := by
+      cases fuel with
+      | zero => simp only [List.length_cons] at hfuel; omega
+      | succ f => exact ⟨f, rfl⟩
+    rw [deriveVec, if_neg (by omega : ¬ c % 2 = 1), if_pos hd]
+    obtain ⟨t, ht⟩ := ih (show v.length ≤ fuel' by
+      simp only [List.length_cons] at hfuel; omega)
+    exact ⟨t, by rw [List.cons_append, ht]⟩
+  | @even v c d hc hd _ ih =>
+    intro fuel hfuel
+    obtain ⟨fuel', rfl⟩ : ∃ f, fuel = f + 1 := by
+      cases fuel with
+      | zero => simp only [List.length_cons] at hfuel; omega
+      | succ f => exact ⟨f, rfl⟩
+    rw [deriveVec, if_neg (by omega : ¬ c % 2 = 1), if_neg (by omega : ¬ d % 2 = 1)]
+    obtain ⟨t, ht⟩ := ih (show v.length ≤ fuel' by
+      simp only [List.length_cons] at hfuel; omega)
+    exact ⟨t, by rw [List.cons_append, ht]⟩
+
+/-- **Length maximality.**  A valid certificate is never longer than the auto-derived window
+the fuel can reach: `deriveVec` yields the *longest* faithful transcript of the
+residue-determined parity window.  Immediate from the prefix form via `IsPrefix.length_le`. -/
+theorem affValid_length_le_deriveVec {v : List Bool} {c d fuel : ℕ}
+    (hv : AffValid v c d) (hfuel : v.length ≤ fuel) :
+    v.length ≤ (deriveVec fuel c d).length :=
+  (affValid_prefix_deriveVec_of_length hv hfuel).length_le
+
+/-- **Fuel monotonicity of the engine.**  Increasing the fuel only *extends* the derived
+window — it never revises an already-recorded bit: `deriveVec fuel c d` is a prefix of
+`deriveVec fuel' c d` whenever `fuel ≤ fuel'`.  (The shorter window is itself a valid
+certificate by `affValidB_deriveVec`, and its length is `≤ fuel ≤ fuel'`, so the previous
+lemma applies.)  Hence the derived certificates for a fixed class form a *chain* under the
+prefix order, stabilizing at the maximal valid transcript once the window closes. -/
+theorem deriveVec_prefix_mono {c d fuel fuel' : ℕ} (h : fuel ≤ fuel') :
+    deriveVec fuel c d <+: deriveVec fuel' c d :=
+  affValid_prefix_deriveVec_of_length
+    (affValidB_sound (affValidB_deriveVec fuel c d))
+    (le_trans (deriveVec_length_le fuel c d) h)
+
+/-- **Prefix maximality for the dyadic engine, without a self-referential hypothesis.**  For
+the residue class `r (mod 2^b)`, any valid certificate `v` of length `≤ 2b+1` is a prefix of
+the canonical window `deriveVec (2b+1) (2^b) r`.  This is `affValid_prefix_deriveVec` with its
+hypothesis `v.length ≤ (deriveVec …).length` replaced by the intrinsic fuel budget
+`v.length ≤ 2b+1` — a bound on the engine's input, not a quantity read back off its output. -/
+theorem affValid_prefix_deriveVec_pow {b r : ℕ} {v : List Bool}
+    (hv : AffValid v (2 ^ b) r) (hlen : v.length ≤ 2 * b + 1) :
+    v <+: deriveVec (2 * b + 1) (2 ^ b) r :=
+  affValid_prefix_deriveVec_of_length hv hlen
 
 end CollatzStructuredOQ02OQ03

--- a/research/problems/collatz-structured-oq-02-oq-03/knowledge.md
+++ b/research/problems/collatz-structured-oq-02-oq-03/knowledge.md
@@ -705,3 +705,40 @@ Quot.sound]`.
 - Independent-set count bound `2·(count true) ≤ length+1` via pairing induction (mild).
 - The only real lever remains Terras natural-density-1 (fraction of determined-drop residues
   mod 2^b → 1); `tao_2019` stays BLOCKED.
+## Session 2026-07-12 (Iteration 11, researcher-11) - Maximality of the derived window
+
+**Mode**: REVISIT (RICH problem, depth-first)
+**Outcome**: progress (VERIFIED axiom-free)
+
+### What I Did
+- Closed the standing `nextStep` "maximality of deriveVec length" — proved `deriveVec`
+  is the *maximal* valid certificate, not just faithful/unique-of-its-length.
+- Added 5 theorems to `proofs/Proofs/CollatzStructuredOQ02OQ03CertUnique.lean`:
+  - `deriveVec_length_le` — `(deriveVec fuel c d).length ≤ fuel` (induction on fuel).
+  - `affValid_prefix_deriveVec_of_length` — `AffValid v c d → v.length ≤ fuel →
+    v <+: deriveVec fuel c d`, by induction on the `AffValid` derivation.
+  - `affValid_length_le_deriveVec` — length maximality corollary.
+  - `deriveVec_prefix_mono` — `fuel ≤ fuel' → deriveVec fuel c d <+: deriveVec fuel' c d`.
+  - `affValid_prefix_deriveVec_pow` — dyadic prefix maximality with intrinsic bound
+    `v.length ≤ 2b+1`, dropping the self-referential hypothesis of the old
+    `affValid_prefix_deriveVec`.
+
+### Key Findings
+- **Lockstep principle**: both `AffValid` constructors (`odd`, `even`) demand `c % 2 = 0`,
+  which is *exactly* the branch `deriveVec` takes before recording a bit. So the certificate
+  recursion and the engine recursion advance in lockstep; the induction is clean, no
+  arithmetic on the leading coefficient needed.
+- The earlier `affValid_prefix_deriveVec` needed the hypothesis `v.length ≤ (deriveVec …).length`
+  — self-referential. The new bound `v.length ≤ fuel` is intrinsic (a budget on the *input*),
+  satisfiable canonically by `fuel = v.length`.
+- All 5 theorems: `#print axioms` = `[propext, Classical.choice, Quot.sound]` only —
+  independent of `tao_2019`.
+
+### Files Modified
+- `proofs/Proofs/CollatzStructuredOQ02OQ03CertUnique.lean` (+~70 lines, builds green 3.8s)
+- `src/data/research/problems/collatz-structured-oq-02-oq-03.json` (knowledge update)
+
+### Next Steps
+- Closure length bound: any `AffValid v (2^b) r` has `v.length ≤ 2b+1` (track `v₂(c)`:
+  even steps drop it by 1, odd steps preserve it, no two consecutive odds), making
+  `fuel = 2b+1` always sufficient so `affValid_prefix_deriveVec_pow` becomes unconditional.

--- a/src/data/research/problems/collatz-structured-oq-02-oq-03.json
+++ b/src/data/research/problems/collatz-structured-oq-02-oq-03.json
@@ -63,7 +63,12 @@
       "CollatzStructuredOQ02OQ03CertMaximal.lean (self-contained, re-declares AffValid+deriveVec exactly, import Mathlib only — mother at kernel SIGBUS ceiling): affValid_eq_deriveVec_self (CANONICAL GENERATION/MAXIMALITY: EVERY valid cert v for ANY class (c,d) is literally deriveVec v.length c d, structural induction on AffValid, each extending step has c%2=0 so deriveVec skips its c%2=1 halt and takes the d%2 branch) + affValid_nil_of_odd_modulus (odd modulus ⟹ empty cert, the structural reason deriveVec halts on c%2=1) + affValid_length_eq_deriveVec_self. Removes the residue-determined-window length side-hypothesis of affValid_iff_prefix_deriveVec in fully general form. 3 thm, axioms [propext,Quot.sound] only.",
       "affOrbit_snd_bound, affOrbit_snd_mono (constant fold bound + monotone in d) in CollatzStructuredOQ02OQ03ConstBound.lean",
       "affine_value_lt / affine_value_lt_of_threshold (affine drop: raw + closed-form threshold) in ConstBound.lean",
-      "affValid_attainsBelow_of_large / affValid_attainsBelow_of_large_pow (uniform eventual-drop, no D<r condition) in ConstBound.lean"
+      "affValid_attainsBelow_of_large / affValid_attainsBelow_of_large_pow (uniform eventual-drop, no D<r condition) in ConstBound.lean",
+      "deriveVec_length_le (CollatzStructuredOQ02OQ03CertUnique.lean): (deriveVec fuel c d).length <= fuel, axiom-free",
+      "affValid_prefix_deriveVec_of_length (CertUnique.lean): AffValid v c d and v.length <= fuel imply v prefix of deriveVec fuel c d, induction on AffValid, axiom-free",
+      "affValid_length_le_deriveVec (CertUnique.lean): length maximality v.length <= (deriveVec fuel c d).length, axiom-free",
+      "deriveVec_prefix_mono (CertUnique.lean): fuel <= fuel2 implies deriveVec fuel c d prefix of deriveVec fuel2 c d, axiom-free",
+      "affValid_prefix_deriveVec_pow (CertUnique.lean): dyadic prefix maximality with intrinsic bound v.length <= 2b+1 (drops self-referential hypothesis of affValid_prefix_deriveVec), axiom-free"
     ],
     "insights": [
       "The odd residue class n ≡ 1 (mod 4), n ≥ 5, deterministically drops below itself in 3 Collatz steps: 4m+1 → 12m+4 → 6m+2 → 3m+1, with 3m+1 < 4m+1 iff m ≥ 1. First elementary family exercising the 3n+1 branch (even/powers-of-two only touch the n/2 branch).",
@@ -91,7 +96,16 @@
       "Mechanize certificate GENERATION as a tactic/decision procedure now that affValid_eq_deriveVec_self identifies the generator as deriveVec v.length c d.",
       "Attempt the unconditional density→1 (Terras/Korec) milestone toward tao_2019, rather than more finite residue levels (enumeration theater).",
       "Tao axiom genuinely blocked (deep analytic, >>1000 lines).",
-      "Sharpen the Part XIII eventual-drop threshold: the bound D+1<=3^a(d+1) is worst-case (all triples first); a tighter constant estimate would shrink the m-threshold and could pin the exact finite set of non-dropping members per determined-drop class."
+      "Sharpen the Part XIII eventual-drop threshold: the bound D+1<=3^a(d+1) is worst-case (all triples first); a tighter constant estimate would shrink the m-threshold and could pin the exact finite set of non-dropping members per determined-drop class.",
+      "Part XI maximality (researcher-11 2026-07-12, VERIFIED axiom-free): deriveVec produces the MAXIMAL valid certificate. Both AffValid constructors (odd/even) require c%2=0 -- exactly the branch deriveVec takes before emitting a bit -- so the certificate recursion and the engine recursion stay in lockstep. affValid_prefix_deriveVec_of_length: AffValid v c d and v.length <= fuel imply v is a prefix of deriveVec fuel c d, by induction on the AffValid derivation. This DISCHARGES the self-referential hypothesis v.length <= (deriveVec ...).length that affValid_prefix_deriveVec assumed, replacing it with the intrinsic fuel budget v.length <= fuel (met by fuel = v.length).",
+      "deriveVec_length_le: (deriveVec fuel c d).length <= fuel unconditionally (induction on fuel; each recorded bit consumes one fuel). Gives affValid_length_le_deriveVec: v.length <= (deriveVec fuel c d).length -- the length-maximality capstone: no valid certificate is strictly longer than the window the fuel reaches. Also deriveVec_prefix_mono: fuel <= fuel2 implies deriveVec fuel c d is a prefix of deriveVec fuel2 c d (the shorter derived window is itself AffValid with length <= fuel <= fuel2, so the prefix lemma applies) -- the derived certificates for a fixed class form a CHAIN under prefix, converging to the maximal transcript once the window closes."
+    ],
+    "mathlibGaps": [],
+    "nextSteps": [
+      "Closure length bound: prove any AffValid v (2^b) r has v.length <= 2b+1 (track the 2-adic valuation of the leading coefficient: even steps drop v2(c) by 1, odd steps preserve it since 3 is odd, and no two odd steps are consecutive), so fuel = 2b+1 is always sufficient and affValid_prefix_deriveVec_pow applies unconditionally.",
+      "Mechanize certificate GENERATION: a tactic/decision procedure computing the forced parity vector v and AffValid certificate from a residue r mod 2^b automatically.",
+      "Attempt the unconditional density->1 (Terras/Korec) as the real milestone toward tao_2019, rather than adding more finite residue levels (enumeration theater).",
+      "Tao axiom genuinely blocked (deep analytic, >>1000 lines)."
     ],
     "markdown": "# Knowledge Base: collatz-structured-oq-02-oq-03\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },


### PR DESCRIPTION
## Summary

Closes the standing **"maximality of `deriveVec` length"** next-step for the certificate-uniqueness layer (Part XI) of `collatz-structured-oq-02-oq-03`. Prior work (`affValid_unique`, `affValid_isPrefix`, `affValid_prefix_deriveVec`) established that a valid Terras parity certificate is *faithful* and *unique of its own length*, but the prefix-into-`deriveVec` result still assumed a self-referential hypothesis `v.length ≤ (deriveVec …).length`. This PR proves `deriveVec` is the **maximal** valid certificate and removes that hypothesis.

## Key idea

Both `AffValid` constructors (`odd`, `even`) require `c % 2 = 0` — *exactly* the branch condition `deriveVec` tests before recording a bit. So the certificate recursion and the engine recursion advance in lockstep, and the maximality proof is a clean induction on the `AffValid` derivation with no arithmetic on the leading coefficient.

## New theorems (`proofs/Proofs/CollatzStructuredOQ02OQ03CertUnique.lean`)

- `deriveVec_length_le` — `(deriveVec fuel c d).length ≤ fuel` (unconditional, induction on fuel).
- `affValid_prefix_deriveVec_of_length` — `AffValid v c d → v.length ≤ fuel → v <+: deriveVec fuel c d`. **Discharges** the self-referential hypothesis of the earlier `affValid_prefix_deriveVec`, replacing it with the intrinsic fuel budget `v.length ≤ fuel` (met by `fuel = v.length`).
- `affValid_length_le_deriveVec` — length maximality: no valid certificate is strictly longer than the window the fuel reaches.
- `deriveVec_prefix_mono` — `fuel ≤ fuel' → deriveVec fuel c d <+: deriveVec fuel' c d`: increasing fuel only extends the window, never revises a recorded bit — the derived certificates form a prefix chain.
- `affValid_prefix_deriveVec_pow` — dyadic prefix maximality with the intrinsic bound `v.length ≤ 2b+1`.

## Verification

- Builds green (`Proofs.CollatzStructuredOQ02OQ03CertUnique`, ~3.8s).
- `#print axioms` on all 5 theorems: `[propext, Classical.choice, Quot.sound]` only — **axiom-free** (independent of `tao_2019`).

## Next step (documented)

Closure length bound: any `AffValid v (2^b) r` has `v.length ≤ 2b+1` (track the 2-adic valuation of the leading coefficient), making `fuel = 2b+1` always sufficient so `affValid_prefix_deriveVec_pow` becomes unconditional.

🤖 Generated with [Claude Code](https://claude.com/claude-code)