### PR TITLE
research(tetrahedral-number-formula-oq-02): uniform cleared-denominator polynomial form for figurate sums [VERIFIED 0-axiom]

### DIFF
--- a/proofs/Proofs/TetrahedralNumberFormulaOQ02.lean
+++ b/proofs/Proofs/TetrahedralNumberFormulaOQ02.lean
@@ -1,0 +1,138 @@
+import Proofs.TetrahedralNumberFormulaOQ01
+
+/-
+# Uniform Cleared-Denominator Polynomial Form for Higher-Dimensional Figurate Sums
+
+## Open Question (tetrahedral-number-formula-oq-02)
+
+The base entry `TetrahedralNumberFormula` gives the `d = 3` cleared-denominator
+identity for the running total of triangular numbers,
+
+    6 · ∑_{k≤n} C(k+1, 2) = n·(n+1)·(n+2),
+
+and the follow-up `TetrahedralNumberFormulaOQ01` proves, separately, the
+general-dimension hockey-stick identity `sum_simplex`
+
+    ∑_{k≤n} P_d(k) = P_{d+1}(n)          where `P_d(n) = C(n+d, d)`,
+
+and the general-dimension cleared closed form `factorial_mul_simplexNumber_prod`
+
+    d! · P_d(n) = ∏_{i<d} (n+1+i).
+
+This entry supplies the missing **uniform** statement that ties the two together:
+a single division-free polynomial identity for the *partial sum itself*, valid
+for every dimension `d` at once.
+
+## Result
+
+Let `S_d(n) = ∑_{k≤n} P_d(k)` be the running total of the `d`-dimensional
+figurate row. Then
+
+* `factorial_mul_sum_simplex` :
+    `(d+1)! · S_d(n) = ∏_{i<d+1} (n+1+i) = (n+1)(n+2)⋯(n+d+1)`
+  — the uniform cleared-denominator polynomial form. The right side is an
+  explicit product of `d+1` consecutive integers, a monic polynomial of degree
+  `d+1` in `n`; the left side clears the sole `(d+1)!` denominator of the closed
+  form `S_d(n) = C(n+d+1, d+1)`.
+
+* `factorial_mul_sum_simplex_asc` : the same with the product written as the
+  ascending factorial `(n+1)^{(d+1)} = (n+1).ascFactorial (d+1)`.
+
+* `sum_simplex_closed` : `S_d(n) = C(n+d+1, d+1)` — the closed form as a single
+  binomial coefficient.
+
+* `factorial_dvd_prod_consec` : `(d+1)! ∣ ∏_{i<d+1} (n+1+i)` — the integrality
+  content: a product of `d+1` consecutive integers is divisible by `(d+1)!`
+  (obtained here as a corollary of the cleared identity, since the quotient is
+  exactly `S_d(n)`).
+
+* `sum_simplex_eq_prod_div` : `S_d(n) = (∏_{i<d+1} (n+1+i)) / (d+1)!` — the
+  classical division form, now with the division proved exact.
+
+* `sum_simplex_two`, `sum_simplex_three` : the `d = 2` and `d = 3` rungs written
+  out, `6·S_2(n) = (n+1)(n+2)(n+3)` and `24·S_3(n) = (n+1)(n+2)(n+3)(n+4)`,
+  recovering the parent's tetrahedral pattern one dimension up the ladder.
+
+## Novelty
+
+`OQ01` proves the hockey-stick identity and the closed-form product *separately*;
+neither file states the combined cleared-denominator identity for the partial
+sum, nor the resulting `(d+1)! ∣ ∏` integrality corollary in this uniform,
+dimension-free shape. Every result below is an immediate but previously
+unrecorded composition of the two `OQ01` lemmas.
+
+0 sorries, 0 axioms.
+-/
+
+namespace TetrahedralNumberFormulaOQ02
+
+open Finset TetrahedralNumberFormulaOQ01
+
+/-- The running total of the `d`-dimensional figurate row, `S_d(n) = ∑_{k≤n} P_d(k)`. -/
+abbrev figurateSum (d n : ℕ) : ℕ := ∑ k ∈ range (n + 1), simplexNumber d k
+
+/-- **Uniform cleared-denominator polynomial form.** For every dimension `d`,
+
+`(d+1)! · S_d(n) = ∏_{i<d+1} (n+1+i) = (n+1)(n+2)⋯(n+d+1)`.
+
+The single sum `S_d(n)`, cleared of its unique `(d+1)!` denominator, is exactly
+the product of the `d+1` consecutive integers `n+1, …, n+d+1`. This is the
+dimension-free companion to the parent's `6·∑ triangular = n(n+1)(n+2)`. -/
+theorem factorial_mul_sum_simplex (d n : ℕ) :
+    Nat.factorial (d + 1) * figurateSum d n = ∏ i ∈ range (d + 1), (n + 1 + i) := by
+  unfold figurateSum
+  rw [sum_simplex, factorial_mul_simplexNumber_prod]
+
+/-- The uniform cleared form with the product written as an ascending factorial:
+`(d+1)! · S_d(n) = (n+1)^{(d+1)}`. -/
+theorem factorial_mul_sum_simplex_asc (d n : ℕ) :
+    Nat.factorial (d + 1) * figurateSum d n = (n + 1).ascFactorial (d + 1) := by
+  unfold figurateSum
+  rw [sum_simplex, factorial_mul_simplexNumber]
+
+/-- **Closed form of the figurate sum as a single binomial coefficient:**
+`S_d(n) = C(n+d+1, d+1)`. The `d`-dimensional hockey-stick identity read as the
+`(d+1)`-dimensional simplex number. -/
+theorem sum_simplex_closed (d n : ℕ) :
+    figurateSum d n = (n + d + 1).choose (d + 1) := by
+  unfold figurateSum
+  rw [sum_simplex, simplexNumber, show n + (d + 1) = n + d + 1 from by ring]
+
+/-- **Integrality corollary.** The product of `d+1` consecutive integers
+`(n+1)(n+2)⋯(n+d+1)` is divisible by `(d+1)!`. Immediate from the cleared
+identity: the quotient is precisely `S_d(n)`, an honest natural number. -/
+theorem factorial_dvd_prod_consec (d n : ℕ) :
+    Nat.factorial (d + 1) ∣ ∏ i ∈ range (d + 1), (n + 1 + i) := by
+  rw [← factorial_mul_sum_simplex]
+  exact Dvd.intro _ rfl
+
+/-- **Classical division form, with the division proved exact.**
+`S_d(n) = (∏_{i<d+1} (n+1+i)) / (d+1)!`. -/
+theorem sum_simplex_eq_prod_div (d n : ℕ) :
+    figurateSum d n = (∏ i ∈ range (d + 1), (n + 1 + i)) / Nat.factorial (d + 1) := by
+  rw [← factorial_mul_sum_simplex, Nat.mul_div_cancel_left _ (Nat.factorial_pos _)]
+
+/-- **Dimension `d = 2` rung.** `6 · S_2(n) = (n+1)(n+2)(n+3)`: the running total
+of the two-dimensional figurate (triangular) row, cleared of denominators, is a
+product of three consecutive integers — the tetrahedral pattern one step up from
+the parent entry. -/
+theorem sum_simplex_two (n : ℕ) :
+    6 * figurateSum 2 n = (n + 1) * (n + 2) * (n + 3) := by
+  have h := factorial_mul_sum_simplex 2 n
+  rw [show Nat.factorial (2 + 1) = 6 from rfl] at h
+  rw [h, Finset.prod_range_succ, Finset.prod_range_succ, Finset.prod_range_succ,
+    Finset.prod_range_zero]
+  ring
+
+/-- **Dimension `d = 3` rung.** `24 · S_3(n) = (n+1)(n+2)(n+3)(n+4)`: the running
+total of the three-dimensional (tetrahedral) figurate row cleared to a product of
+four consecutive integers. -/
+theorem sum_simplex_three (n : ℕ) :
+    24 * figurateSum 3 n = (n + 1) * (n + 2) * (n + 3) * (n + 4) := by
+  have h := factorial_mul_sum_simplex 3 n
+  rw [show Nat.factorial (3 + 1) = 24 from rfl] at h
+  rw [h, Finset.prod_range_succ, Finset.prod_range_succ, Finset.prod_range_succ,
+    Finset.prod_range_succ, Finset.prod_range_zero]
+  ring
+
+end TetrahedralNumberFormulaOQ02

--- a/proofs/Proofs/TetrahedralNumberFormulaOQ02Polynomial.lean
+++ b/proofs/Proofs/TetrahedralNumberFormulaOQ02Polynomial.lean
@@ -1,0 +1,97 @@
+import Proofs.TetrahedralNumberFormulaOQ02
+import Mathlib.Algebra.Polynomial.Monic
+import Mathlib.Algebra.Polynomial.BigOperators
+import Mathlib.Algebra.Polynomial.Degree.Operations
+import Mathlib.Algebra.Polynomial.Eval.Defs
+
+/-
+# The Figurate-Sum Cleared Form as a First-Class Monic Polynomial
+
+## Open Question (tetrahedral-number-formula-oq-02, polynomial follow-up)
+
+The companion file `TetrahedralNumberFormulaOQ02` proves the uniform
+cleared-denominator identity
+
+    (d+1)! · S_d(n) = ∏_{i<d+1} (n+1+i)          (`factorial_mul_sum_simplex`)
+
+where `S_d(n) = ∑_{k≤n} P_d(k)` is the running total of the `d`-dimensional
+figurate row.  There the right-hand side is a *product expression* in `ℕ`,
+described informally in the docstring as "a monic polynomial of degree `d+1` in
+`n`".  This entry makes that description **literal**: it packages the cleared
+form as a genuine `Polynomial ℤ`
+
+    Q_d(X) = ∏_{i<d+1} (X + (i+1)) = (X+1)(X+2)⋯(X+d+1)        (`figuratePoly`)
+
+and proves its three structural properties as a polynomial.
+
+## Result
+
+* `figuratePoly_monic` : `Q_d` is **monic** — a product of monic linear factors.
+
+* `figuratePoly_natDegree` : `Q_d` has **degree exactly `d+1`**, the sum of the
+  `d+1` unit degrees of its linear factors.
+
+* `figuratePoly_eval` : the **bridge to the arithmetic** — evaluating `Q_d` at an
+  integer point `n` recovers the cleared figurate sum,
+  `Q_d(n) = (d+1)! · S_d(n)`.  This ties the abstract polynomial back to the
+  `ℕ`-identity `factorial_mul_sum_simplex`.
+
+* `figuratePoly_factorial_dvd_eval` : the integrality content read off the
+  polynomial — `(d+1)! ∣ Q_d(n)` for every integer `n`.
+
+## Novelty
+
+`OQ02` states the cleared form only as an equation between natural numbers; the
+"polynomial of degree `d+1`" is prose.  Here the object is a first-class
+`Polynomial ℤ` whose monicity and degree are theorems, and whose evaluation map
+is proved to reproduce the figurate partial sum.  This is the Mathlib-native
+`Polynomial` upgrade flagged as the sole remaining `nextStep` of `OQ02`.
+
+0 sorries, 0 axioms.
+-/
+
+namespace TetrahedralNumberFormulaOQ02
+
+open Finset Polynomial TetrahedralNumberFormulaOQ01
+
+/-- The **figurate-sum cleared-form polynomial**
+`Q_d(X) = ∏_{i<d+1} (X + (i+1)) = (X+1)(X+2)⋯(X+d+1)`, the `Polynomial ℤ` whose
+value at `n` is `(d+1)! · S_d(n)`. -/
+noncomputable def figuratePoly (d : ℕ) : Polynomial ℤ :=
+  ∏ i ∈ range (d + 1), (X + C ((i : ℤ) + 1))
+
+/-- `Q_d` is **monic**: a finite product of the monic linear factors `X + (i+1)`. -/
+theorem figuratePoly_monic (d : ℕ) : (figuratePoly d).Monic :=
+  monic_prod_of_monic _ _ (fun _ _ => monic_X_add_C _)
+
+/-- `Q_d` has **degree exactly `d+1`**: the sum of the `d+1` unit degrees of its
+monic linear factors. -/
+theorem figuratePoly_natDegree (d : ℕ) : (figuratePoly d).natDegree = d + 1 := by
+  rw [figuratePoly, natDegree_prod_of_monic _ _ (fun _ _ => monic_X_add_C _)]
+  simp only [natDegree_X_add_C, Finset.sum_const, Finset.card_range, smul_eq_mul, mul_one]
+
+/-- **Evaluation bridge.** Evaluating the cleared-form polynomial at the integer
+point `n` returns the cleared figurate sum: `Q_d(n) = (d+1)! · S_d(n)`. This is
+the `Polynomial`-level restatement of `factorial_mul_sum_simplex`. -/
+theorem figuratePoly_eval (d n : ℕ) :
+    (figuratePoly d).eval (n : ℤ)
+      = ((Nat.factorial (d + 1) * figurateSum d n : ℕ) : ℤ) := by
+  have hnat := factorial_mul_sum_simplex d n
+  rw [figuratePoly, eval_prod]
+  have hcast : ∀ i ∈ range (d + 1),
+      (X + C ((i : ℤ) + 1)).eval (n : ℤ) = ((n + 1 + i : ℕ) : ℤ) := by
+    intro i _
+    simp only [eval_add, eval_X, eval_C]
+    push_cast
+    ring
+  rw [Finset.prod_congr rfl hcast, ← Nat.cast_prod, ← hnat]
+
+/-- **Integrality, read off the polynomial.** `(d+1)!` divides the value of the
+cleared-form polynomial at every integer point `n`, since that value is exactly
+`(d+1)! · S_d(n)`. -/
+theorem figuratePoly_factorial_dvd_eval (d n : ℕ) :
+    ((Nat.factorial (d + 1) : ℤ)) ∣ (figuratePoly d).eval (n : ℤ) := by
+  rw [figuratePoly_eval, Nat.cast_mul]
+  exact Dvd.intro _ rfl
+
+end TetrahedralNumberFormulaOQ02

--- a/src/data/research/problems/tetrahedral-number-formula-oq-02.json
+++ b/src/data/research/problems/tetrahedral-number-formula-oq-02.json
@@ -29,23 +29,31 @@
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETE: uniform cleared-denominator polynomial form for the figurate partial sum proved (0 sorries, 0 custom axioms).",
+    "progressSummary": "COMPLETE (VERIFIED 0-axiom): cleared figurate-sum form upgraded to a first-class monic Polynomial ℤ (figuratePoly) with proved monicity, degree d+1, and evaluation Q_d(n)=(d+1)!·S_d(n); closes the sole remaining Polynomial nextStep of OQ02.",
     "builtItems": [
       "factorial_mul_sum_simplex (TetrahedralNumberFormulaOQ02.lean:82): (d+1)!·∑_{k≤n}C(k+d,d) = ∏_{i<d+1}(n+1+i), the uniform cleared-denominator polynomial form for every dimension d",
       "factorial_mul_sum_simplex_asc (TetrahedralNumberFormulaOQ02.lean:88): same via ascending factorial (n+1).ascFactorial (d+1)",
       "sum_simplex_closed (TetrahedralNumberFormulaOQ02.lean:96): S_d(n) = C(n+d+1, d+1)",
       "factorial_dvd_prod_consec (TetrahedralNumberFormulaOQ02.lean:104): (d+1)! ∣ ∏_{i<d+1}(n+1+i) — integrality of product of d+1 consecutive integers, as a corollary",
       "sum_simplex_eq_prod_div (TetrahedralNumberFormulaOQ02.lean:111): division form with exact division proved",
-      "sum_simplex_two / sum_simplex_three (TetrahedralNumberFormulaOQ02.lean:119,130): d=2,3 rungs 6·S_2=(n+1)(n+2)(n+3), 24·S_3=(n+1)(n+2)(n+3)(n+4)"
+      "sum_simplex_two / sum_simplex_three (TetrahedralNumberFormulaOQ02.lean:119,130): d=2,3 rungs 6·S_2=(n+1)(n+2)(n+3), 24·S_3=(n+1)(n+2)(n+3)(n+4)",
+      "figuratePoly (d) : Polynomial ℤ = ∏_{i<d+1}(X + C(i+1)), first-class Mathlib Polynomial for the cleared figurate-sum form (TetrahedralNumberFormulaOQ02Polynomial.lean)",
+      "figuratePoly_monic: Q_d is monic (monic_prod_of_monic of monic_X_add_C factors)",
+      "figuratePoly_natDegree: Q_d has natDegree exactly d+1 (natDegree_prod_of_monic + sum of unit degrees)",
+      "figuratePoly_eval: Q_d.eval (n:ℤ) = (d+1)!·S_d(n) — evaluation bridge back to factorial_mul_sum_simplex",
+      "figuratePoly_factorial_dvd_eval: (d+1)! ∣ Q_d.eval(n) — integrality read off the polynomial"
     ],
     "insights": [
       "The oq-02 target (uniform cleared-denominator form of the partial SUM) is an immediate but previously-unrecorded composition of two OQ01 lemmas kept separate there: sum_simplex (hockey stick) and factorial_mul_simplexNumber_prod (cleared closed form). Composing at dimension d+1 gives (d+1)!·S_d(n)=∏(n+1+i).",
       "The cleared identity yields the classical integrality fact (d+1)!∣(product of d+1 consecutive integers) for free, since the exact quotient is the natural number S_d(n).",
-      "Uses OQ01 simplexNumber convention P_d(k)=C(k+d,d) (so P_2 is triangular T_{k+1}); the d=2/d=3 rungs are the tetrahedral pattern one dimension up from the parent entry, not the parent's index-shifted C(k+1,2) convention."
+      "Uses OQ01 simplexNumber convention P_d(k)=C(k+d,d) (so P_2 is triangular T_{k+1}); the d=2/d=3 rungs are the tetrahedral pattern one dimension up from the parent entry, not the parent's index-shifted C(k+1,2) convention.",
+      "The OQ02 cleared form ∏(n+1+i) is literally a monic degree-(d+1) Polynomial ℤ; packaging it as figuratePoly makes monicity/degree theorems rather than prose, with eval reproducing (d+1)!·S_d(n).",
+      "simp gotcha: full simp normalizes C(a+b) via C_add/map_add and destroys the X+C _ shape needed by natDegree_X_add_C; use simp only [natDegree_X_add_C, sum_const, card_range, ...]."
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "Optional: express (d+1)!·S_d(n) as an explicit Polynomial ℤ (monic degree d+1) to make the 'polynomial form' a first-class Mathlib Polynomial rather than a product expression."
+      "Optional: relate figuratePoly to a shifted binomial/Pochhammer Polynomial and derive its coefficients (Stirling numbers of the first kind) explicitly.",
+      "Optional: express S_d itself (not just (d+1)!·S_d) as a Polynomial ℚ of degree d+1 via the (d+1)! scalar, tying to the Bernoulli/Faulhaber viewpoint."
     ],
     "markdown": "# Knowledge Base: tetrahedral-number-formula-oq-02\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },

--- a/src/data/research/problems/tetrahedral-number-formula-oq-02.json
+++ b/src/data/research/problems/tetrahedral-number-formula-oq-02.json
@@ -1,0 +1,102 @@
+{
+  "slug": "tetrahedral-number-formula-oq-02",
+  "title": "Uniform Cleared-Denominator Polynomial Form for Higher-Dimensional Figurate Sums",
+  "phase": "COMPLETED",
+  "status": "completed",
+  "tier": "C",
+  "path": "full",
+  "problemStatement": {
+    "formal": "\\sum_{k=0}^{n} \\binom{k+d-1}{d} = \\binom{n+d}{d+1}\n\\qquad\\text{(hockey-stick identity, dimension } d)",
+    "plain": "The base gallery proof (`tetrahedral-number-formula`) shows that summing the",
+    "whyMatters": []
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": ""
+  },
+  "currentState": {
+    "phase": "COMPLETED",
+    "since": "2026-07-09T20:46:01-07:00",
+    "iteration": 1,
+    "focus": "Solved: uniform cleared-denominator polynomial form proved and verified axiom-free.",
+    "blockers": [],
+    "nextAction": "None — problem complete.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "COMPLETE: uniform cleared-denominator polynomial form for the figurate partial sum proved (0 sorries, 0 custom axioms).",
+    "builtItems": [
+      "factorial_mul_sum_simplex (TetrahedralNumberFormulaOQ02.lean:82): (d+1)!·∑_{k≤n}C(k+d,d) = ∏_{i<d+1}(n+1+i), the uniform cleared-denominator polynomial form for every dimension d",
+      "factorial_mul_sum_simplex_asc (TetrahedralNumberFormulaOQ02.lean:88): same via ascending factorial (n+1).ascFactorial (d+1)",
+      "sum_simplex_closed (TetrahedralNumberFormulaOQ02.lean:96): S_d(n) = C(n+d+1, d+1)",
+      "factorial_dvd_prod_consec (TetrahedralNumberFormulaOQ02.lean:104): (d+1)! ∣ ∏_{i<d+1}(n+1+i) — integrality of product of d+1 consecutive integers, as a corollary",
+      "sum_simplex_eq_prod_div (TetrahedralNumberFormulaOQ02.lean:111): division form with exact division proved",
+      "sum_simplex_two / sum_simplex_three (TetrahedralNumberFormulaOQ02.lean:119,130): d=2,3 rungs 6·S_2=(n+1)(n+2)(n+3), 24·S_3=(n+1)(n+2)(n+3)(n+4)"
+    ],
+    "insights": [
+      "The oq-02 target (uniform cleared-denominator form of the partial SUM) is an immediate but previously-unrecorded composition of two OQ01 lemmas kept separate there: sum_simplex (hockey stick) and factorial_mul_simplexNumber_prod (cleared closed form). Composing at dimension d+1 gives (d+1)!·S_d(n)=∏(n+1+i).",
+      "The cleared identity yields the classical integrality fact (d+1)!∣(product of d+1 consecutive integers) for free, since the exact quotient is the natural number S_d(n).",
+      "Uses OQ01 simplexNumber convention P_d(k)=C(k+d,d) (so P_2 is triangular T_{k+1}); the d=2/d=3 rungs are the tetrahedral pattern one dimension up from the parent entry, not the parent's index-shifted C(k+1,2) convention."
+    ],
+    "mathlibGaps": [],
+    "nextSteps": [
+      "Optional: express (d+1)!·S_d(n) as an explicit Polynomial ℤ (monic degree d+1) to make the 'polynomial form' a first-class Mathlib Polynomial rather than a product expression."
+    ],
+    "markdown": "# Knowledge Base: tetrahedral-number-formula-oq-02\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
+  },
+  "tags": [
+    "combinatorics",
+    "algebra",
+    "figurate-numbers"
+  ],
+  "relatedProofs": [
+    "tetrahedral-number-formula"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": []
+  },
+  "started": "2026-07-10T05:15:55.896Z",
+  "lastUpdate": "2026-07-12",
+  "leanFiles": [
+    {
+      "path": "Proofs/TetrahedralNumberFormula.lean",
+      "filename": "TetrahedralNumberFormula.lean",
+      "lineCount": 147,
+      "theoremCount": 8,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/TetrahedralNumberFormula.lean"
+    },
+    {
+      "path": "Proofs/TetrahedralNumberFormulaOQ01.lean",
+      "filename": "TetrahedralNumberFormulaOQ01.lean",
+      "lineCount": 901,
+      "theoremCount": 50,
+      "axiomCount": 0,
+      "defCount": 6,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/TetrahedralNumberFormulaOQ01.lean"
+    },
+    {
+      "path": "Proofs/TetrahedralNumberFormulaOQ01Absorption.lean",
+      "filename": "TetrahedralNumberFormulaOQ01Absorption.lean",
+      "lineCount": 159,
+      "theoremCount": 10,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 1,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/TetrahedralNumberFormulaOQ01Absorption.lean"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Closes the open question **tetrahedral-number-formula-oq-02** — *Uniform Cleared-Denominator Polynomial Form for Higher-Dimensional Figurate Sums*.

The base entry proves the `d = 3` cleared identity `6·∑ C(k+1,2) = n(n+1)(n+2)`, and `OQ01` proves — **separately** — the general hockey-stick identity `sum_simplex` and the general cleared closed form `factorial_mul_simplexNumber_prod`. Neither states the combined **uniform** identity for the partial sum itself. This entry supplies it.

For the running total `S_d(n) = ∑_{k≤n} C(k+d, d)` of the `d`-dimensional figurate row, cleared of its sole `(d+1)!` denominator:

```
(d+1)! · S_d(n) = ∏_{i<d+1} (n+1+i) = (n+1)(n+2)⋯(n+d+1)
```

valid simultaneously for every dimension `d` — a product of `d+1` consecutive integers (a monic degree-`d+1` polynomial in `n`).

## Theorems (`proofs/Proofs/TetrahedralNumberFormulaOQ02.lean`)

| Theorem | Statement |
|---|---|
| `factorial_mul_sum_simplex` | `(d+1)!·S_d(n) = ∏_{i<d+1}(n+1+i)` — uniform cleared form |
| `factorial_mul_sum_simplex_asc` | same via `(n+1).ascFactorial (d+1)` |
| `sum_simplex_closed` | `S_d(n) = C(n+d+1, d+1)` |
| `factorial_dvd_prod_consec` | `(d+1)! ∣ ∏_{i<d+1}(n+1+i)` — integrality of a product of `d+1` consecutive integers, as a corollary |
| `sum_simplex_eq_prod_div` | `S_d(n) = (∏(n+1+i)) / (d+1)!`, division proved exact |
| `sum_simplex_two` / `sum_simplex_three` | `d=2,3` rungs: `6·S_2=(n+1)(n+2)(n+3)`, `24·S_3=(n+1)(n+2)(n+3)(n+4)` |

## Verification

- 7 theorems, **0 sorries, 0 custom axioms** (`#print axioms` → only `propext`, `Classical.choice`, `Quot.sound`).
- `LAKE_UNSAFE=1 lake build Proofs.TetrahedralNumberFormulaOQ02` succeeds against Mathlib v4.26.

## Honesty note

Each result is an immediate composition of two existing `OQ01` lemmas; the contribution is recording the uniform partial-sum form (and its integrality corollary) that `OQ01` left implicit. No new deep infrastructure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)---

## Follow-up commit — first-class monic `Polynomial ℤ` (`TetrahedralNumberFormulaOQ02Polynomial.lean`)

The base entry describes the cleared form's right-hand side as "a monic polynomial of degree `d+1`" only in prose. This follow-up makes that **literal**, packaging it as a genuine `Polynomial ℤ`:

```
figuratePoly d = ∏_{i<d+1} (X + C (i+1))  = (X+1)(X+2)⋯(X+d+1)
```

| Theorem | Statement |
|---|---|
| `figuratePoly_monic` | `Q_d` is **monic** (product of monic linear factors) |
| `figuratePoly_natDegree` | `deg Q_d = d+1` **exactly** |
| `figuratePoly_eval` | `Q_d.eval (n:ℤ) = (d+1)!·S_d(n)` — evaluation bridge to `factorial_mul_sum_simplex` |
| `figuratePoly_factorial_dvd_eval` | `(d+1)! ∣ Q_d.eval n` — integrality read off the polynomial |

Monicity and degree are now **theorems about a `Polynomial` object**, not prose, and evaluation is proved to reproduce the figurate partial sum. This closes the sole remaining `nextStep` of OQ02.

**Verification:** 4 theorems + 1 def, **0 sorries, 0 custom axioms** (`#print axioms` → only `propext`, `Classical.choice`, `Quot.sound`); `lake build Proofs.TetrahedralNumberFormulaOQ02Polynomial` succeeds against Mathlib v4.26.