### PR TITLE
research(erdos-659): machine-check the Chebyshev-vs-Euclidean metric caveat + add euclSq [VERIFIED 0 axioms]

### DIFF
--- a/proofs/Proofs/Erdos659Problem.lean
+++ b/proofs/Proofs/Erdos659Problem.lean
@@ -706,4 +706,87 @@ theorem thirteen_not_representable : 13 ∉ representable_x2_2y2 :=
 theorem twentythree_not_representable : 23 ∉ representable_x2_2y2 :=
   not_representable_of_mod8 23 (Or.inr (by decide))
 
+/-! ## The metric matters: Chebyshev (`dist`) versus Euclidean
+
+Erdős #659 is a statement about **Euclidean** distances in the plane, but the
+`distinctDistances`, `isConfiguration`, and `fourPointProperty` definitions above are
+phrased through Mathlib's `dist` on `ℝ × ℝ`, which is the **sup (Chebyshev) metric**
+`dist (x₁,y₁) (x₂,y₂) = max |x₁-x₂| |y₁-y₂|` — *not* the Euclidean metric. The two
+notions of distance genuinely disagree on the distinct-distance count of concrete
+sets, so the `dist`-based layer is not a faithful model of the Euclidean problem. (On
+the Moree–Osburn lattice this is invisible because `latticeDistSq` hard-codes the
+Euclidean form `x²+2y²`; the mismatch only surfaces for the general geometric
+predicates.) The lemmas below make the discrepancy a **machine-checked fact** rather
+than a prose caveat, and introduce the correct Euclidean squared distance.
+
+The witness is the unit square `(0,0), (1,0), (1,1), (0,1)`: under the Chebyshev
+metric a *side* and a *diagonal* have equal length `1`, so the square collapses to a
+single distance; under the Euclidean metric they are `1` and `√2`, the genuine
+two-distance square configuration. -/
+
+/-- Euclidean squared distance on the coordinate plane `ℝ × ℝ`. Unlike the ambient
+    `dist` (which is the sup/Chebyshev metric), this is the metric of Erdős #659. Its
+    restriction to Moree–Osburn lattice points is exactly `latticeDistSq`. -/
+def euclSq (p q : ℝ × ℝ) : ℝ := (p.1 - q.1) ^ 2 + (p.2 - q.2) ^ 2
+
+/-- `euclSq` restricted to two Moree–Osburn lattice points reproduces `latticeDistSq`:
+    the general Euclidean squared distance agrees with the lattice's own quadratic form
+    `x² + 2y²`. This is why the `latticeDistSq_*` API is Euclidean-faithful even though
+    the ambient `dist` is not. -/
+theorem euclSq_latticePoint (a₁ b₁ a₂ b₂ : ℤ) :
+    euclSq (latticePoint a₁ b₁) (latticePoint a₂ b₂)
+      = ((latticeDistSq a₁ b₁ a₂ b₂ : ℤ) : ℝ) := by
+  have hsq : (Real.sqrt 2) ^ 2 = 2 := Real.sq_sqrt (by norm_num)
+  simp only [euclSq, latticePoint, latticeDistSq]
+  push_cast
+  have hb : ((b₁ : ℝ) * Real.sqrt 2 - (b₂ : ℝ) * Real.sqrt 2) ^ 2
+      = 2 * ((b₁ : ℝ) - (b₂ : ℝ)) ^ 2 := by
+    rw [show ((b₁ : ℝ) * Real.sqrt 2 - (b₂ : ℝ) * Real.sqrt 2)
+          = ((b₁ : ℝ) - (b₂ : ℝ)) * Real.sqrt 2 by ring, mul_pow, hsq]; ring
+  rw [hb]
+
+/-- **The four sides of the unit square have Euclidean squared length `1`.** -/
+theorem unitSquare_sides :
+    euclSq (0, 0) (1, 0) = 1 ∧ euclSq (1, 0) (1, 1) = 1 ∧
+    euclSq (1, 1) (0, 1) = 1 ∧ euclSq (0, 1) (0, 0) = 1 := by
+  refine ⟨?_, ?_, ?_, ?_⟩ <;> · simp only [euclSq]; norm_num
+
+/-- **The two diagonals of the unit square have Euclidean squared length `2`.** Together
+    with `unitSquare_sides`, the square realises exactly two Euclidean distances (`1` and
+    `√2`), so it is a genuine two-distance `square` configuration in the Euclidean plane. -/
+theorem unitSquare_diagonals :
+    euclSq (0, 0) (1, 1) = 2 ∧ euclSq (1, 0) (0, 1) = 2 := by
+  refine ⟨?_, ?_⟩ <;> · simp only [euclSq]; norm_num
+
+/-- **Chebyshev conflates a side and a diagonal of the unit square.** Under the ambient
+    sup metric `dist`, the diagonal `(0,0)–(1,1)` and the side `(0,0)–(1,0)` both have
+    length `1`. -/
+theorem chebyshev_conflates_square_side_and_diagonal :
+    dist ((0 : ℝ), (0 : ℝ)) (1, 1) = dist ((0 : ℝ), (0 : ℝ)) (1, 0) := by
+  rw [Prod.dist_eq, Prod.dist_eq]
+  simp only [Real.dist_eq]
+  norm_num
+
+/-- **Euclidean separates the same side and diagonal.** The two segments Chebyshev
+    identifies (`chebyshev_conflates_square_side_and_diagonal`) have *different* Euclidean
+    squared lengths (`2` versus `1`). -/
+theorem euclid_separates_square_side_and_diagonal :
+    euclSq (0, 0) (1, 1) ≠ euclSq (0, 0) (1, 0) := by
+  simp only [euclSq]; norm_num
+
+/-- **The sup metric is not the Euclidean metric on the plane** — a self-contained
+    witness that the `dist`-based `distinctDistances`/`isConfiguration`/`fourPointProperty`
+    layer does not faithfully count Euclidean distances. There are three collinear-free
+    points (two adjacent corners and the opposite corner of the unit square) at which the
+    Euclidean metric sees two distinct distances while the ambient Chebyshev `dist` sees
+    only one. Consequently a Euclidean two-distance classification cannot be read off the
+    `dist`-based predicates directly; the geometric layer must be reformulated over
+    `euclSq` (as `euclSq_latticePoint` already does for the lattice). -/
+theorem chebyshev_ne_euclidean_distinctness :
+    ∃ p q r : ℝ × ℝ, dist p q = dist p r ∧ euclSq p q ≠ euclSq p r :=
+  ⟨(0, 0), (1, 1), (1, 0),
+    chebyshev_conflates_square_side_and_diagonal,
+    euclid_separates_square_side_and_diagonal⟩
+
 end Erdos659
+

--- a/src/data/research/problems/erdos-659-incomplete-01.json
+++ b/src/data/research/problems/erdos-659-incomplete-01.json
@@ -29,24 +29,30 @@
     }
   },
   "knowledge": {
-    "progressSummary": "AT AXIOMATIZED TERMINUS. All 5 Erdos659 files sorry-free (the 'incomplete-01/1 sorry' title is a stale false positive — grep matches only docstring 'sorry-free'; real sorry resolved 2026-06-25). Remaining assumptions = deep Landau density axioms, out of reach in Mathlib 4.26. researcher-3 (2026-07-09) added isRepresented_iff_isNorm to Erdos659OQ05.lean: represented integers = norm image of ℤ[√-2] (the conceptual source of multiplicative closure). 1 theorem, 0 axioms, 0 sorries. UNVERIFIED-by-build (docker containerd meta.db I/O corruption fleet-wide); high elaboration confidence (rintro + existing Q_eq_zsqrtd_norm, structure eta on Zsqrtd).",
+    "progressSummary": "AT AXIOMATIZED TERMINUS (deep Landau/Moree-Osburn axioms). 2026-07-12 (researcher-5): turned the previously prose-only Chebyshev-vs-Euclidean metric caveat into 4 machine-checked lemmas (0 axioms) and introduced euclSq, the correct Euclidean squared distance, proving it restricts to the lattice form x²+2y² and giving the first metric-correct unit-square 2-distance witness. This is a soundness/rigor contribution on the geometric layer feeding moreeOsburnWorks, NOT a discharge of the deep axioms.",
     "builtItems": [
       "latticeDistSq_symm / latticeDistSq_nonneg / latticeDistSq_eq_zero_iff in Erdos659Problem.lean (positive-definiteness of x²+2y²)",
       "Verified fourPointProperty_from_avoiding_configs (0 sorries) with explicit lower-bound hypothesis",
       "sq_representable / representable_pow / two_pow_representable: closure of the x²+2y² representable set under squares and powers; completes the 'every power of 2 is representable' claim from the representable_mul docstring.",
-      "isRepresented_iff_isNorm (researcher-3, 2026-07-09) in Erdos659OQ05.lean: IsRepresented n ↔ ∃ z:ℤ√(-2), Zsqrtd.norm z = n — identifies represented integers with the norm image of ℤ[√-2] (conceptual reason for isRepresented_mul: norm is a monoid hom)."
+      "isRepresented_iff_isNorm (researcher-3, 2026-07-09) in Erdos659OQ05.lean: IsRepresented n ↔ ∃ z:ℤ√(-2), Zsqrtd.norm z = n — identifies represented integers with the norm image of ℤ[√-2] (conceptual reason for isRepresented_mul: norm is a monoid hom).",
+      "euclSq (p q : ℝ×ℝ) := (p.1-q.1)^2+(p.2-q.2)^2 — the correct Euclidean squared distance, added to Erdos659Problem.lean (~line 724)",
+      "euclSq_latticePoint: euclSq(latticePoint a₁ b₁)(latticePoint a₂ b₂) = latticeDistSq a₁ b₁ a₂ b₂ — the general Euclidean metric restricts to the lattice form x²+2y², explaining why the latticeDistSq API is Euclidean-faithful while ambient dist is not",
+      "unitSquare_sides / unitSquare_diagonals: the unit square realises exactly 2 Euclidean distances (sides²=1, diagonals²=2) — first metric-correct concrete 2-distance square witness",
+      "chebyshev_ne_euclidean_distinctness: ∃ p q r, dist p q = dist p r ∧ euclSq p q ≠ euclSq p r — verified proof the sup metric conflates distances Euclidean separates. All 4 thms 0 axioms beyond propext/Classical.choice/Quot.sound, independent of moreeOsburnWorks."
     ],
     "insights": [
       "The original fourPointProperty_from_avoiding_configs was false under the product/Chebyshev metric on ℝ×ℝ: unit-square corners (0,0),(1,0),(0,1),(1,1) are mutually equidistant (sup-distance 1), so distinctDistances=1 while avoiding every named 2-distance config. A geometric lower bound (2 ≤ distinctDistances on 4-subsets) is required and now explicit.",
       "The defining form x²+2y² is positive-definite over ℤ (latticeDistSq_eq_zero_iff), so distinct lattice points have positive squared distance — verified independently of the deep axiom.",
-      "The 'incomplete-01 (1 sorry)' label is STALE/FALSE: all 5 Erdos659 files (Problem/OQ01/OQ01OQ02/OQ05/OQ06) are genuinely sorry-free (grep 'sorry' matches only docstring 'sorry-free'). The real sorry was resolved 2026-06-25 (researcher-10). Remaining assumptions are deep Landau density axioms (moreeOsburnWorks, uniform_landau_lower_bound, moreeosburn_upper_bound) — out of reach in Mathlib."
+      "The 'incomplete-01 (1 sorry)' label is STALE/FALSE: all 5 Erdos659 files (Problem/OQ01/OQ01OQ02/OQ05/OQ06) are genuinely sorry-free (grep 'sorry' matches only docstring 'sorry-free'). The real sorry was resolved 2026-06-25 (researcher-10). Remaining assumptions are deep Landau density axioms (moreeOsburnWorks, uniform_landau_lower_bound, moreeosburn_upper_bound) — out of reach in Mathlib.",
+      "The distinctDistances/isConfiguration/fourPointProperty layer is phrased through Mathlib dist on ℝ×ℝ = the SUP (Chebyshev) metric, NOT Euclidean. This is now a MACHINE-CHECKED soundness caveat: on the unit square (0,0),(1,0),(1,1),(0,1) a side and a diagonal from (0,0) have EQUAL Chebyshev length 1 (chebyshev_conflates_square_side_and_diagonal) but Euclidean squared lengths 1 vs 2 (euclid_separates). So the dist-based distinct-distance count is not the Euclidean count (chebyshev_ne_euclidean_distinctness). A faithful Euclidean two-distance classification must be phrased over euclSq, not dist."
     ],
     "mathlibGaps": [
       "Landau (1908) asymptotic count of integers representable as x²+2y² (~N/√log N) — not in Mathlib 4.26; blocks eliminating moreeOsburnWorks"
     ],
     "nextSteps": [
       "Formalize Landau count for x²+2y² to discharge moreeOsburnWorks (major analytic NT project)",
-      "Replace the three True placeholders in isConfiguration (isoTrap1/isoTrap2/kite) with genuine Euclidean characterizations and prove the 2-distance classification"
+      "Replace the three True placeholders in isConfiguration (isoTrap1/isoTrap2/kite) with genuine Euclidean characterizations and prove the 2-distance classification",
+      "Reformulate isConfiguration (.square/.rhombus/.pentagonSubset and the isoTrap/kite placeholders) over euclSq instead of ambient dist, then attempt the Euclidean 4-point 2-distance classification. The dist-based fourPointProperty_from_avoiding_configs currently only exploits the card=4 ∧ dist=2 conjuncts; a euclSq version would need the genuine geometric characterizations."
     ]
   },
   "tags": [
@@ -65,7 +71,7 @@
     "mathlib": []
   },
   "started": "2026-04-03T12:23:52.516Z",
-  "lastUpdate": "2026-07-08",
+  "lastUpdate": "2026-07-12",
   "significance": 7,
   "tractability": 6
 }


### PR DESCRIPTION
## Summary

Erdős Problem #659 is about **Euclidean** distances in the plane, but `Erdos659Problem.lean`'s `distinctDistances`, `isConfiguration`, and `fourPointProperty` predicates are all phrased through Mathlib's `dist` on `ℝ × ℝ`, which is the **sup (Chebyshev) metric** — *not* Euclidean. The knowledge base already flagged this in prose; this PR turns it into **machine-checked lemmas** and introduces the correct Euclidean squared distance.

All additions are purely additive (+83 lines), build cleanly, and depend on **0 axioms** beyond `propext / Classical.choice / Quot.sound` — in particular they do **not** touch the deep `moreeOsburnWorks` axiom.

## What's added (in `proofs/Proofs/Erdos659Problem.lean`)

- **`euclSq p q := (p.1-q.1)^2 + (p.2-q.2)^2`** — the correct Euclidean squared distance (the file previously had only `latticeDistSq`, specialised to the lattice).
- **`euclSq_latticePoint`** — `euclSq` restricted to two Moree–Osburn lattice points equals `latticeDistSq` (the form `x²+2y²`). This explains why the `latticeDistSq_*` API is Euclidean-faithful even though the ambient `dist` is not.
- **`unitSquare_sides` / `unitSquare_diagonals`** — the unit square `(0,0),(1,0),(1,1),(0,1)` realises exactly two Euclidean distances (sides² = 1, diagonals² = 2): the first metric-correct concrete two-distance *square* witness.
- **`chebyshev_conflates_square_side_and_diagonal`** — under the ambient sup metric, a *side* and a *diagonal* of the unit square from `(0,0)` both have length `1`.
- **`euclid_separates_square_side_and_diagonal`** — the same two segments have *different* Euclidean squared lengths (`2` vs `1`).
- **`chebyshev_ne_euclidean_distinctness`** — `∃ p q r, dist p q = dist p r ∧ euclSq p q ≠ euclSq p r`: the sup metric conflates distances the Euclidean metric separates, so the `dist`-based distinct-distance count is **not** the Euclidean count.

## Honesty note

This is a **soundness / rigor** contribution on the geometric layer that feeds the axiomatised `moreeOsburnWorks`; it is **not** a discharge of the deep Landau / Moree–Osburn analytic-number-theory axioms, which remain out of reach in Mathlib 4.26. The concrete next step it opens is to reformulate `isConfiguration` over `euclSq` and attempt the Euclidean 4-point two-distance classification.

## Verification

`LAKE_UNSAFE=1 ./bin/lake build Proofs.Erdos659Problem` → `Build completed successfully`. `#print axioms` on all four new theorems shows only `[propext, Classical.choice, Quot.sound]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)