### PR TITLE
research(alternating-series-boole-summation-oq-01-oq-02-oq-01): strict-interior localization for strictly antitone sequences [VERIFIED 0-axiom]

### DIFF
--- a/proofs/Proofs/AlternatingSeriesBooleSummationOQ01OQ02OQ01.lean
+++ b/proofs/Proofs/AlternatingSeriesBooleSummationOQ01OQ02OQ01.lean
@@ -1,0 +1,200 @@
+/-
+# Alternating-Series Boole Summation — OQ-01-OQ-02-OQ-01
+## Strict localization for a strictly antitone null sequence
+
+The parent entry (`AlternatingSeriesBooleSummationOQ01OQ02.lean`) established, for an
+*antitone* null sequence `a`, the sharp alternating-series remainder bound
+`|L − Sₘ| ≤ aₘ` (`remainder_bound`) and the closed-interval localization
+`L ∈ [0, a₀]` (`sum_mem_Icc`), where `Sₘ = altSum a 0 m = ∑_{j<m} (-1)ʲ aⱼ` and `L`
+is the alternating sum.
+
+Those bounds are attained at the degenerate boundary. If `a` is only *antitone* it
+may be eventually constant, in which case a partial sum can *equal* the limit and `L`
+can sit on an endpoint of `[0, a₀]` (e.g. `a ≡ 0` gives `L = 0 = a₀`). This entry
+shows that as soon as `a` is **strictly** antitone every one of those inequalities is
+strict:
+
+  * `even_partial_lt` / `lt_odd_partial` — even (resp. odd) partial sums lie
+    *strictly* below (resp. above) the limit;
+  * `remainder_bound_strict` — `|L − Sₘ| < aₘ` for every `m`;
+  * `sum_mem_Ioo` — the whole alternating sum lands in the *open* interval,
+    `L ∈ (0, a₀)`.
+
+## The argument
+
+Mathlib's alternating-series test still supplies only the *non-strict* even/odd
+bracketing `S_{2k} ≤ L ≤ S_{2k+1}`, imported here through the parent's
+`even_partial_le` / `le_odd_partial`. Strictness comes from one extra monotone step
+of the *same parity*. Strict antitonicity makes consecutive even partial sums
+strictly increase,
+
+  `S_{2k} < S_{2(k+1)} = S_{2k} + (a_{2k} − a_{2k+1})`   (`even_step_lt`),
+
+and the non-strict bound `S_{2(k+1)} ≤ L` then squeezes `S_{2k} < L`. Dually,
+consecutive odd partial sums strictly decrease (`odd_step_lt`) and `L ≤ S_{2(k+1)+1}`
+squeezes `L < S_{2k+1}`. The strict remainder bound and the open-interval
+localization follow exactly as their non-strict analogues did, with `≤` upgraded to
+`<`.
+
+## What this adds over the parent
+
+The parent gives `≤`/closed-interval control valid for every antitone null sequence.
+This entry pins down *when* those are tight: never in the interior of the strictly
+monotone regime. For a strictly antitone null `a` the partial sums never touch `L`
+and `L` never touches an endpoint — the qualitative "the series brackets its limit"
+becomes the strict "it brackets it with room to spare".
+
+**Sorry count**: 0. **Axiom count**: 0 (only Lean/Mathlib foundational axioms).
+-/
+import Mathlib.Tactic
+import Mathlib.Analysis.SpecificLimits.Normed
+import Proofs.AlternatingSeriesBooleSummationOQ01OQ02
+
+namespace AlternatingSeriesBooleSummationOQ01OQ02OQ01
+
+open AlternatingSeriesBooleSummationOQ01 AlternatingSeriesBooleSummationOQ01OQ02
+open Finset Filter Topology
+
+variable {a : ℕ → ℝ}
+
+/-! ## Strict parity steps
+
+The two elementary "one extra step of the same parity" identities that upgrade the
+non-strict bracketing to a strict one. Both hold from `altSum_succ` and strict
+antitonicity alone — no convergence hypothesis is needed. -/
+
+/-- **Even step is strictly increasing.**  For a strictly antitone sequence,
+`altSum a 0 (2(k+1)) = altSum a 0 (2k) + (a_{2k} − a_{2k+1})`, and the increment is
+positive because `a_{2k+1} < a_{2k}`. -/
+theorem even_step_lt (ha : StrictAnti a) (k : ℕ) :
+    altSum a 0 (2 * k) < altSum a 0 (2 * (k + 1)) := by
+  have e1 : altSum a 0 (2 * k + 1) = altSum a 0 (2 * k) + a (2 * k) := by
+    rw [altSum_succ a (Nat.zero_le _), pow_mul]; norm_num
+  have e2 : altSum a 0 (2 * k + 1 + 1) = altSum a 0 (2 * k + 1) - a (2 * k + 1) := by
+    have hp : ((-1 : ℝ) ^ (2 * k + 1)) = -1 := by rw [pow_succ, pow_mul]; norm_num
+    rw [altSum_succ a (Nat.zero_le _), hp]; ring
+  have hstep : altSum a 0 (2 * (k + 1))
+      = altSum a 0 (2 * k) + (a (2 * k) - a (2 * k + 1)) := by
+    have hidx : 2 * (k + 1) = 2 * k + 1 + 1 := by ring
+    rw [hidx, e2, e1]; ring
+  have hpos : 0 < a (2 * k) - a (2 * k + 1) := by
+    have : a (2 * k + 1) < a (2 * k) := ha (by omega)
+    linarith
+  rw [hstep]; linarith
+
+/-- **Odd step is strictly decreasing.**  For a strictly antitone sequence,
+`altSum a 0 (2(k+1)+1) = altSum a 0 (2k+1) − (a_{2k+1} − a_{2k+2})`, and the decrement
+is positive because `a_{2k+2} < a_{2k+1}`. -/
+theorem odd_step_lt (ha : StrictAnti a) (k : ℕ) :
+    altSum a 0 (2 * (k + 1) + 1) < altSum a 0 (2 * k + 1) := by
+  have e2 : altSum a 0 (2 * k + 1 + 1) = altSum a 0 (2 * k + 1) - a (2 * k + 1) := by
+    have hp : ((-1 : ℝ) ^ (2 * k + 1)) = -1 := by rw [pow_succ, pow_mul]; norm_num
+    rw [altSum_succ a (Nat.zero_le _), hp]; ring
+  have e3 : altSum a 0 (2 * k + 1 + 1 + 1)
+      = altSum a 0 (2 * k + 1 + 1) + a (2 * k + 1 + 1) := by
+    have hp : ((-1 : ℝ) ^ (2 * k + 1 + 1)) = 1 := by
+      rw [pow_succ, pow_succ, pow_mul]; norm_num
+    rw [altSum_succ a (Nat.zero_le _), hp]; ring
+  have hstep : altSum a 0 (2 * (k + 1) + 1)
+      = altSum a 0 (2 * k + 1) - (a (2 * k + 1) - a (2 * k + 1 + 1)) := by
+    have hidx : 2 * (k + 1) + 1 = 2 * k + 1 + 1 + 1 := by ring
+    rw [hidx, e3, e2]; ring
+  have hpos : 0 < a (2 * k + 1) - a (2 * k + 1 + 1) := by
+    have : a (2 * k + 1 + 1) < a (2 * k + 1) := ha (by omega)
+    linarith
+  rw [hstep]; linarith
+
+/-! ## Strict one-sided bracketing -/
+
+/-- **Even partial sums are strictly below the limit.**  `altSum a 0 (2k) < L`.
+One strict even step `S_{2k} < S_{2(k+1)}` combines with the parent's non-strict
+even bound `S_{2(k+1)} ≤ L`. -/
+theorem even_partial_lt (ha : StrictAnti a) {L : ℝ}
+    (hL : Tendsto (fun m => altSum a 0 m) atTop (𝓝 L)) (k : ℕ) :
+    altSum a 0 (2 * k) < L := by
+  have hstep : altSum a 0 (2 * k) < altSum a 0 (2 * (k + 1)) := even_step_lt ha k
+  have hle : altSum a 0 (2 * (k + 1)) ≤ L := even_partial_le ha.antitone hL (k + 1)
+  linarith
+
+/-- **Odd partial sums are strictly above the limit.**  `L < altSum a 0 (2k+1)`.
+One strict odd step `S_{2(k+1)+1} < S_{2k+1}` combines with the parent's non-strict
+odd bound `L ≤ S_{2(k+1)+1}`. -/
+theorem lt_odd_partial (ha : StrictAnti a) {L : ℝ}
+    (hL : Tendsto (fun m => altSum a 0 m) atTop (𝓝 L)) (k : ℕ) :
+    L < altSum a 0 (2 * k + 1) := by
+  have hstep : altSum a 0 (2 * (k + 1) + 1) < altSum a 0 (2 * k + 1) := odd_step_lt ha k
+  have hle : L ≤ altSum a 0 (2 * (k + 1) + 1) := le_odd_partial ha.antitone hL (k + 1)
+  linarith
+
+/-! ## Strict remainder bound and open-interval localization -/
+
+/-- **Strict alternating-series remainder bound.**  For a *strictly* antitone null
+sequence with alternating sum `L`, the `m`-th partial sum approximates `L` to strictly
+better than the `m`-th term: `|L − altSum a 0 m| < a m`.  The strictness is the content
+here: the non-strict bound `≤ aₘ` (parent `remainder_bound`) is never attained in the
+strictly monotone regime.  No null hypothesis on `a` is needed: convergence of the
+partial sums already forces `aₘ > 0` inside the strict brackets. -/
+theorem remainder_bound_strict (ha : StrictAnti a) {L : ℝ}
+    (hL : Tendsto (fun m => altSum a 0 m) atTop (𝓝 L)) (m : ℕ) :
+    |L - altSum a 0 m| < a m := by
+  rcases Nat.even_or_odd m with ⟨k, hk⟩ | ⟨k, hk⟩
+  · -- m = 2k : S_{2k} < L < S_{2k} + a_{2k}
+    have hkk : m = 2 * k := by omega
+    subst hkk
+    have h1 : altSum a 0 (2 * k) < L := even_partial_lt ha hL k
+    have h2 : L < altSum a 0 (2 * k + 1) := lt_odd_partial ha hL k
+    have hs : altSum a 0 (2 * k + 1) = altSum a 0 (2 * k) + a (2 * k) := by
+      rw [altSum_succ a (Nat.zero_le _), pow_mul]; norm_num
+    rw [hs] at h2
+    rw [abs_lt]; constructor <;> linarith
+  · -- m = 2k+1 : S_{2k+1} - a_{2k+1} < L < S_{2k+1}
+    have hkk : m = 2 * k + 1 := by omega
+    subst hkk
+    have h2 : L < altSum a 0 (2 * k + 1) := lt_odd_partial ha hL k
+    have h1 : altSum a 0 (2 * k + 1 + 1) < L := by
+      have := even_partial_lt ha hL (k + 1)
+      rwa [(by ring : 2 * (k + 1) = 2 * k + 1 + 1)] at this
+    have hs : altSum a 0 (2 * k + 1 + 1) = altSum a 0 (2 * k + 1) - a (2 * k + 1) := by
+      have hp : ((-1 : ℝ) ^ (2 * k + 1)) = -1 := by rw [pow_succ, pow_mul]; norm_num
+      rw [altSum_succ a (Nat.zero_le _), hp]; ring
+    rw [hs] at h1
+    rw [abs_lt]; constructor <;> linarith
+
+/-- **Strict two-sided bracketing.**  Consecutive partial sums straddle the limit with
+strict inequalities on both sides: `(altSum a 0 m − L)·(altSum a 0 (m+1) − L) < 0`.
+This sharpens the parent's `partial_bracket` (product `≤ 0`): for a strictly antitone
+sequence neither factor can vanish. -/
+theorem partial_bracket_strict (ha : StrictAnti a) {L : ℝ}
+    (hL : Tendsto (fun m => altSum a 0 m) atTop (𝓝 L)) (m : ℕ) :
+    (altSum a 0 m - L) * (altSum a 0 (m + 1) - L) < 0 := by
+  rcases Nat.even_or_odd m with ⟨k, hk⟩ | ⟨k, hk⟩
+  · have hkk : m = 2 * k := by omega
+    subst hkk
+    have h1 : altSum a 0 (2 * k) < L := even_partial_lt ha hL k
+    have h2 : L < altSum a 0 (2 * k + 1) := lt_odd_partial ha hL k
+    exact mul_neg_of_neg_of_pos (by linarith) (by linarith)
+  · have hkk : m = 2 * k + 1 := by omega
+    subst hkk
+    have h2 : L < altSum a 0 (2 * k + 1) := lt_odd_partial ha hL k
+    have h1 : altSum a 0 (2 * k + 1 + 1) < L := by
+      have := even_partial_lt ha hL (k + 1)
+      rwa [(by ring : 2 * (k + 1) = 2 * k + 1 + 1)] at this
+    exact mul_neg_of_pos_of_neg (by linarith) (by linarith)
+
+/-- **Open-interval localization of the full alternating sum.**  Taking `m = 0` in the
+strict bracketing (where `altSum a 0 0 = 0` and `altSum a 0 1 = a₀`) traps the whole
+alternating series in the *open* interval: `L ∈ (0, a₀)`.  In particular `L` is
+strictly positive and strictly below the leading term. -/
+theorem sum_mem_Ioo (ha : StrictAnti a) {L : ℝ}
+    (hL : Tendsto (fun m => altSum a 0 m) atTop (𝓝 L)) :
+    L ∈ Set.Ioo (0 : ℝ) (a 0) := by
+  have h0 : altSum a 0 0 = 0 := by simp [altSum]
+  have hlow : altSum a 0 (2 * 0) < L := even_partial_lt ha hL 0
+  have hup : L < altSum a 0 (2 * 0 + 1) := lt_odd_partial ha hL 0
+  have hup' : altSum a 0 (2 * 0 + 1) = a 0 := by
+    rw [altSum_succ a (Nat.zero_le _), h0]; norm_num
+  rw [show 2 * 0 = 0 from rfl, h0] at hlow
+  rw [hup'] at hup
+  exact ⟨hlow, hup⟩
+
+end AlternatingSeriesBooleSummationOQ01OQ02OQ01

--- a/src/data/research/problems/alternating-series-boole-summation-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/alternating-series-boole-summation-oq-01-oq-02-oq-01.json
@@ -1,0 +1,97 @@
+{
+  "slug": "alternating-series-boole-summation-oq-01-oq-02-oq-01",
+  "title": "Strict localization of the Boole-summation limit for a strictly antitone sequence",
+  "phase": "COMPLETED",
+  "status": "completed",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "For a strictly antitone null sequence a : ℕ → ℝ with alternating sum L, |L − Sₘ| < aₘ for every m and L ∈ (0, a₀), where Sₘ = ∑_{j<m} (-1)ʲ aⱼ.",
+    "plain": "Sharpen the parent's closed-interval localization L ∈ [0, a₀] and non-strict remainder bound |L − Sₘ| ≤ aₘ to strict interior versions when a is strictly antitone.",
+    "whyMatters": [
+      "Pins down exactly when the classical alternating-series bracketing is tight: the ≤/closed bounds are attained only at the degenerate (eventually-constant) boundary, never in the strictly monotone interior."
+    ]
+  },
+  "knownResults": {
+    "proven": [
+      "|L − Sₘ| < aₘ (strict remainder bound)",
+      "L ∈ (0, a₀) (open-interval localization)"
+    ],
+    "open": [],
+    "goal": "Strict-interior sharpening of the sharp two-sided Boole-summation estimates."
+  },
+  "currentState": {
+    "phase": "COMPLETED",
+    "since": "2026-07-12",
+    "iteration": 1,
+    "focus": "Strict bracketing from one extra same-parity monotone step.",
+    "blockers": [],
+    "nextAction": "None — node solved axiom-free.",
+    "attemptCounts": {
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
+    }
+  },
+  "knowledge": {
+    "progressSummary": "COMPLETE: strict-interior sharpening proved axiom-free (7 theorems, 0 sorries, 0 axioms) in Proofs/AlternatingSeriesBooleSummationOQ01OQ02OQ01.lean.",
+    "builtItems": [
+      "even_step_lt / odd_step_lt: strict same-parity monotonicity of partial sums from StrictAnti a (Proofs/AlternatingSeriesBooleSummationOQ01OQ02OQ01.lean)",
+      "even_partial_lt / lt_odd_partial: strict one-sided bracketing S_{2k} < L < S_{2k+1}, upgrading the parent's non-strict even_partial_le / le_odd_partial",
+      "remainder_bound_strict: |L − Sₘ| < aₘ, the strict form of the parent remainder_bound (no null hypothesis needed)",
+      "partial_bracket_strict: (Sₘ − L)(S_{m+1} − L) < 0, strict form of parent partial_bracket",
+      "sum_mem_Ioo: L ∈ (0, a₀), open-interval sharpening of the parent sum_mem_Icc (L ∈ [0, a₀])"
+    ],
+    "insights": [
+      "Strictness is a one-step-of-the-same-parity phenomenon: S_{2k} < S_{2(k+1)} ≤ L squeezes the strict even bound, dually for odd, so no new analytic input beyond Mathlib's non-strict alternating-series test is required.",
+      "The strict remainder bound needs no null hypothesis on a: convergence of the partial sums already forces aₘ > 0 inside the strict two-sided brackets.",
+      "The closed-interval / ≤ bounds of the parent are attained only at the degenerate eventually-constant boundary (e.g. a ≡ 0 gives L = 0 = a₀); strict antitonicity removes every boundary case."
+    ],
+    "mathlibGaps": [],
+    "nextSteps": []
+  },
+  "tags": [
+    "seeker-selected",
+    "analysis",
+    "series",
+    "alternating-series",
+    "boole-summation",
+    "remainder-bound",
+    "error-estimate",
+    "convergence",
+    "leibniz-criterion",
+    "limits"
+  ],
+  "relatedProofs": [
+    "alternating-series-boole-summation",
+    "alternating-series-boole-summation-oq-01",
+    "alternating-series-boole-summation-oq-01-oq-02",
+    "alternating-series-boole-summation-oq-01-oq-02-oq-02"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": [
+      "Antitone.alternating_series_le_tendsto",
+      "Antitone.tendsto_le_alternating_series"
+    ]
+  },
+  "started": "2026-07-12",
+  "lastUpdate": "2026-07-12",
+  "completed": "2026-07-12",
+  "significance": 6,
+  "tractability": 6,
+  "leanFiles": [
+    {
+      "path": "Proofs/AlternatingSeriesBooleSummationOQ01OQ02OQ01.lean",
+      "filename": "AlternatingSeriesBooleSummationOQ01OQ02OQ01.lean",
+      "lineCount": 200,
+      "theoremCount": 7,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AlternatingSeriesBooleSummationOQ01OQ02OQ01.lean"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Answers the open node **alternating-series-boole-summation-oq-01-oq-02-oq-01**: *sharpen the localization to the strict interior when `a` is strictly antitone*.

The parent (`AlternatingSeriesBooleSummationOQ01OQ02.lean`) proved, for an **antitone** null sequence `a` with alternating sum `L` and partial sums `Sₘ = ∑_{j<m} (-1)ʲ aⱼ`:
- `remainder_bound`: `|L − Sₘ| ≤ aₘ` (non-strict)
- `sum_mem_Icc`: `L ∈ [0, a₀]` (closed interval)

Those bounds are attained only at the degenerate, eventually-constant boundary (e.g. `a ≡ 0` gives `L = 0 = a₀`). This PR shows that under **strict** antitonicity every inequality becomes strict.

## New theorems (all axiom-free)

- `even_step_lt` / `odd_step_lt` — consecutive same-parity partial sums are strictly monotone: `S_{2k} < S_{2(k+1)}` and `S_{2(k+1)+1} < S_{2k+1}`.
- `even_partial_lt` / `lt_odd_partial` — strict one-sided bracketing `S_{2k} < L < S_{2k+1}`, upgrading the parent's non-strict `even_partial_le` / `le_odd_partial`.
- `remainder_bound_strict` — `|L − Sₘ| < aₘ` for every `m` (no null hypothesis on `a` is needed; convergence of the partial sums already forces `aₘ > 0` inside the strict brackets).
- `partial_bracket_strict` — `(Sₘ − L)·(S_{m+1} − L) < 0`.
- `sum_mem_Ioo` — `L ∈ (0, a₀)`.

## Method

Strictness is a one-extra-step-of-the-same-parity phenomenon: `S_{2k} < S_{2(k+1)} ≤ L` squeezes the strict even bound (dually for odd), so no new analytic machinery beyond Mathlib's non-strict alternating-series test (`Antitone.alternating_series_le_tendsto` / `Antitone.tendsto_le_alternating_series`) is required.

## Verification

`#print axioms` on all 7 theorems reports only `[propext, Classical.choice, Quot.sound]`. **0 sorries, 0 declared axioms.** Builds against Mathlib (host `lake build`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)