### PR TITLE
docs: require equivalent-strength check when spawning child OQs

### DIFF
--- a/.claude/commands/lean-research.md
+++ b/.claude/commands/lean-research.md
@@ -202,7 +202,9 @@ Before starting work, classify the problem state and choose strategy:
 
 **STUCK (sorries remain, no clear path forward):**
 - Do NOT generalize or broaden scope
-- Decompose into concrete subgoals or intermediate lemmas
+- Decompose into concrete subgoals or intermediate lemmas — but apply the
+  equivalent-strength check (see Follow-Up Question Generation below): a subgoal
+  as strong as the target itself is a blocked route, not decomposition progress
 - Try a different decomposition of the same target
 - Check if the blocking sorry can be submitted to Aristotle
 - If 3+ sessions stuck on same sorry: flag as BLOCKED, move on
@@ -226,6 +228,17 @@ Generate 1-2 strong follow-up questions. Apply quality criteria:
 - REJECT: variable renamings, trivial corollaries, shallow specializations
 
 If no strong follow-up exists, generate 0 questions. This is preferable to weak proposals.
+
+**Equivalent-strength check (MANDATORY at OQ spawn).** Every proposed child OQ
+must include an explicit note stating whether the child is **materially weaker**
+than the parent target. The test: would proving the child immediately yield the
+parent by a known argument? If yes, the child is of equivalent strength — record
+it on the parent as a **blocked route** (reopen bar: "materially new mechanism
+required"), NOT as decomposition progress. An elegant reduction that ends at a
+lemma as strong as the target earns zero progress credit. Judge strength against
+the parent's "Must prove exactly / does not count" section (see
+[Pin the Statement Before Attacking](#pin-the-statement-before-attacking-mandatory)
+— an equivalent same-strength restatement is already a named near-miss there).
 
 ---
 

--- a/.lean/roles/researcher.md
+++ b/.lean/roles/researcher.md
@@ -202,7 +202,9 @@ Before starting work, classify the problem state and choose strategy:
 
 **STUCK (sorries remain, no clear path forward):**
 - Do NOT generalize or broaden scope
-- Decompose into concrete subgoals or intermediate lemmas
+- Decompose into concrete subgoals or intermediate lemmas — but apply the
+  equivalent-strength check (see Follow-Up Question Generation below): a subgoal
+  as strong as the target itself is a blocked route, not decomposition progress
 - Try a different decomposition of the same target
 - Check if the blocking sorry can be submitted to Aristotle
 - If 3+ sessions stuck on same sorry: flag as BLOCKED, move on
@@ -226,6 +228,17 @@ Generate 1-2 strong follow-up questions. Apply quality criteria:
 - REJECT: variable renamings, trivial corollaries, shallow specializations
 
 If no strong follow-up exists, generate 0 questions. This is preferable to weak proposals.
+
+**Equivalent-strength check (MANDATORY at OQ spawn).** Every proposed child OQ
+must include an explicit note stating whether the child is **materially weaker**
+than the parent target. The test: would proving the child immediately yield the
+parent by a known argument? If yes, the child is of equivalent strength — record
+it on the parent as a **blocked route** (reopen bar: "materially new mechanism
+required"), NOT as decomposition progress. An elegant reduction that ends at a
+lemma as strong as the target earns zero progress credit. Judge strength against
+the parent's "Must prove exactly / does not count" section in
+`research/problems/<slug>/problem.md` (element 5 in `research/PROBLEMS-STRUCTURE.md`)
+— an equivalent same-strength restatement is already a named near-miss there.
 
 **OQ-chain depth guard (MANDATORY).** Follow-up questions become child gallery
 entries via the Seeker (`<parent>-oq-NN`), which can recurse without bound. Before


### PR DESCRIPTION
## Summary

Implements **checkbox 2** of #37505 (equivalent-strength check at OQ spawn), the curator's recommended second-PR scope from the "Curator Re-verification (2026-07-12)" section. When a researcher spawns a child OQ, it must now explicitly note whether the child is materially weaker than the parent; equivalent-strength children are recorded as blocked routes (reopen bar: "materially new mechanism required"), not decomposition progress.

Scope context per curator re-verification: checkboxes 1 + 6 already shipped in #37595 (merged 2026-07-11); checkbox 3 (blocked-route registry) is a JSON schema migration to be spun out as its own issue; checkboxes 4 + 5 are blocked pending re-scoping (their target files do not exist on origin/main).

## Changes

- `.claude/commands/lean-research.md` — new **"Equivalent-strength check (MANDATORY at OQ spawn)"** paragraph in "### Follow-Up Question Generation (after SOLVED)" with an unambiguous test ("would proving the child immediately yield the parent by a known argument? → equivalent strength → blocked route"), referencing the shipped "Pin the Statement Before Attacking" section.
- `.claude/commands/lean-research.md` — STUCK-strategy "Decompose into concrete subgoals" bullet cross-references the same rule so both decomposition entry points are consistent.
- `.lean/roles/researcher.md` — same two edits mirrored (verified by grep that this file duplicates the Follow-Up Question Generation / decompose-bullet spawn guidance; the curator's acceptance criteria explicitly allow updating it in that case). Its copy references `research/PROBLEMS-STRUCTURE.md` element 5 since the role doc has no Pin-the-Statement section.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Follow-Up Question Generation gains required equivalent-strength note (materially-weaker statement; equivalent-strength child = blocked route with "materially new mechanism required" reopen bar) | ✅ | New paragraph at lean-research.md L232-242 |
| "Decompose into concrete subgoals" bullet cross-references the same rule | ✅ | lean-research.md L205-207 |
| No JSON schema changes | ✅ | `git diff --stat`: only the two .md files changed |
| No changes outside lean-research.md (optionally researcher.md if it duplicates spawn guidance, verified by grep) | ✅ | Grep confirmed researcher.md duplicates the Follow-Up section verbatim; mirrored there |

## Test Plan

- [x] Manual: amended section gives an unambiguous test — "would proving the child immediately yield the parent by a known argument? If yes ... blocked route."
- [x] `grep -n "equivalent" .claude/commands/lean-research.md` → hits at L206 (decompose bullet), L235/L241 (spawn check), plus pre-existing L192 (Pin-the-Statement near-miss list, referenced not contradicted).
- [x] Automated tests: N/A (doc-only change).

Part of #37505

🤖 Generated with [Claude Code](https://claude.com/claude-code)