### PR TITLE
research(ballot-oq-05-oq-02): Catalan-triangle recurrence for the non-negative ballot number

### DIFF
--- a/proofs/Proofs/BallotProblemOQ05OQ02.lean
+++ b/proofs/Proofs/BallotProblemOQ05OQ02.lean
@@ -98,7 +98,7 @@ theorem reflectBallot_sub_exact (a b : ℕ) (hb : 1 ≤ b) (hab : b ≤ a) :
     rw [eb, ed] at h
     -- h : C(a+b, b) * b = C(a+b, b−1) * (a+1)
     have hstep : (a + b).choose (b - 1) * (a + 1) ≤ (a + b).choose b * (a + 1) := by
-      rw [← h]; gcongr; omega
+      rw [← h]; exact Nat.mul_le_mul (le_refl _) (by omega)
     exact Nat.le_of_mul_le_mul_right hstep (by omega)
   simp only [reflectBallot]; omega
 
@@ -129,6 +129,104 @@ paths with `n` up- and `n` down-steps is the number of Dyck paths of semilength 
 theorem reflectBallot_catalan (n : ℕ) (hn : 1 ≤ n) : reflectBallot n n = catalan n := by
   rw [reflectBallot_eq n n hn]
   exact ballotNumber_catalan n
+
+/-! ### The Catalan-triangle recurrence
+
+The non-negative ballot numbers `reflectBallot a b` are exactly the entries of the
+**Catalan triangle**, and as such obey the additive Pascal-type recurrence
+`T(a,b) = T(a−1,b) + T(a,b−1)` in the interior.  Because our `reflectBallot` uses `ℕ`
+(truncated) subtraction, the recurrence holds *verbatim* only away from the two edges
+where a term truncates to `0`; the edges are pinned by two closed forms below.  Together
+the three results generate the whole triangle from its first column. -/
+
+/-- **Exactness of the reflection subtraction on the full valid range `b ≤ a + 1`.**
+This sharpens `reflectBallot_sub_exact` (which assumed `b ≤ a`): the ratio identity
+`C(a+b, b)·b = C(a+b, b−1)·(a+1)` gives `C(a+b, b−1) ≤ C(a+b, b)` precisely when
+`b ≤ a + 1`, so the `ℕ` difference `reflectBallot a b` is untruncated there. -/
+theorem reflectBallot_add_choose (a b : ℕ) (hb : 1 ≤ b) (hab : b ≤ a + 1) :
+    reflectBallot a b + (a + b).choose (b - 1) = (a + b).choose b := by
+  have hle : (a + b).choose (b - 1) ≤ (a + b).choose b := by
+    have h := Nat.choose_succ_right_eq (a + b) (b - 1)
+    have eb : b - 1 + 1 = b := by omega
+    have ed : (a + b) - (b - 1) = a + 1 := by omega
+    rw [eb, ed] at h
+    -- h : C(a+b, b) * b = C(a+b, b−1) * (a+1)
+    have hstep : (a + b).choose (b - 1) * (a + 1) ≤ (a + b).choose b * (a + 1) := by
+      rw [← h]; gcongr
+    exact Nat.le_of_mul_le_mul_right hstep (by omega)
+  simp only [reflectBallot]; omega
+
+/-- **First column of the Catalan triangle.**  `reflectBallot a 1 = a`: there are exactly
+`a` non-negative sequences with `a` up-steps and a single down-step (the down-step may sit
+in any of the `a` gaps at or after the first up-step). -/
+theorem reflectBallot_one (a : ℕ) : reflectBallot a 1 = a := by
+  show (a + 1).choose 1 - (a + 1).choose (1 - 1) = a
+  simp [Nat.choose_one_right]
+
+/-- **Upper edge of the Catalan triangle.**  With one more down-step than up-steps a path
+cannot stay non-negative, so `reflectBallot a (a+1) = 0`.  Arithmetically the two binomials
+coincide by the symmetry `C(2a+1, a+1) = C(2a+1, a)`, and the difference truncates to `0`. -/
+theorem reflectBallot_diag_succ (a : ℕ) : reflectBallot a (a + 1) = 0 := by
+  simp only [reflectBallot]
+  have hsymm : (a + (a + 1)).choose (a + 1) = (a + (a + 1)).choose a := by
+    have h := Nat.choose_symm (show a ≤ a + (a + 1) by omega)
+    have e : a + (a + 1) - a = a + 1 := by omega
+    rw [e] at h
+    exact h
+  have e2 : a + 1 - 1 = a := by omega
+  rw [e2, hsymm]
+  omega
+
+/-- **Catalan-triangle recurrence.**  In the interior `2 ≤ b ≤ a`, the non-negative ballot
+number satisfies the additive Pascal-type recurrence of the Catalan triangle:
+
+  `reflectBallot a b = reflectBallot (a−1) b + reflectBallot a (b−1)`.
+
+All three terms are untruncated reflection differences on the range `2 ≤ b ≤ a` (via
+`reflectBallot_add_choose`), so the identity is two applications of Pascal's rule
+`C(n+1, k+1) = C(n, k) + C(n, k+1)` on the underlying binomials, discharged by `omega`.
+
+The hypotheses are sharp: at `b = 1` the recurrence fails (the `reflectBallot a 0` term is a
+truncation artifact, `reflectBallot_one` is the correct first column), and at `b = a+1` it
+fails (`reflectBallot (a−1) (a+1)` truncates below its integer value, `reflectBallot_diag_succ`
+pins the edge). -/
+theorem reflectBallot_recurrence (a b : ℕ) (hb : 2 ≤ b) (hab : b ≤ a) :
+    reflectBallot a b = reflectBallot (a - 1) b + reflectBallot a (b - 1) := by
+  -- Exactness of all three reflection differences.
+  have E0 : reflectBallot a b + (a + b).choose (b - 1) = (a + b).choose b :=
+    reflectBallot_add_choose a b (by omega) (by omega)
+  have E1 : reflectBallot (a - 1) b + (a - 1 + b).choose (b - 1) = (a - 1 + b).choose b :=
+    reflectBallot_add_choose (a - 1) b (by omega) (by omega)
+  have E2 : reflectBallot a (b - 1) + (a + (b - 1)).choose (b - 1 - 1)
+      = (a + (b - 1)).choose (b - 1) :=
+    reflectBallot_add_choose a (b - 1) (by omega) (by omega)
+  -- Normalise the two lower indices `a-1+b` and `a+(b-1)` to the common `a+b-1`.
+  have ha1 : a - 1 + b = a + b - 1 := by omega
+  have ha2 : a + (b - 1) = a + b - 1 := by omega
+  have hb3 : b - 1 - 1 = b - 2 := by omega
+  rw [ha1] at E1
+  rw [ha2, hb3] at E2
+  -- Pascal's rule on the two top-row binomials `C(a+b, ·)`.
+  have hn1 : a + b - 1 + 1 = a + b := by omega
+  have hb1 : b - 1 + 1 = b := by omega
+  have hb2 : b - 2 + 1 = b - 1 := by omega
+  have P1 : (a + b).choose b
+      = (a + b - 1).choose (b - 1) + (a + b - 1).choose b := by
+    have h := Nat.choose_succ_succ (a + b - 1) (b - 1)
+    simp only [Nat.succ_eq_add_one] at h
+    rwa [hn1, hb1] at h
+  have P2 : (a + b).choose (b - 1)
+      = (a + b - 1).choose (b - 2) + (a + b - 1).choose (b - 1) := by
+    have h := Nat.choose_succ_succ (a + b - 1) (b - 2)
+    simp only [Nat.succ_eq_add_one] at h
+    rwa [hn1, hb2] at h
+  -- All relations are linear in the (opaque) binomials; `omega` finishes.
+  omega
+
+/-- Sanity checks of `reflectBallot_recurrence` on concrete interior entries. -/
+example : reflectBallot 3 2 = reflectBallot 2 2 + reflectBallot 3 1 := by decide
+example : reflectBallot 4 3 = reflectBallot 3 3 + reflectBallot 4 2 := by decide
+example : reflectBallot 5 2 = reflectBallot 4 2 + reflectBallot 5 1 := by decide
 
 /-! ### Worked examples (checked by `decide`, hence `0`-axiom) -/
 

--- a/src/data/research/problems/ballot-problem-oq-05-oq-02.json
+++ b/src/data/research/problems/ballot-problem-oq-05-oq-02.json
@@ -36,25 +36,32 @@
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETE: reflectBallot a b = C(a+b,b) - C(a+b,b-1) formalized as the NON-NEGATIVE ballot number and reconciled to the parent strict ballotNumber(a+1,b) via the prepend-an-up-step shift; verified 0/0.",
+    "progressSummary": "PROGRESS: added the Catalan-triangle recurrence family for reflectBallot — first column (=a), upper edge (=0), and interior Pascal recurrence for 2≤b≤a — plus a sharpened exactness lemma (b≤a+1). Boundary range proven sharp numerically. All 0-axiom (propext/Classical.choice/Quot.sound only), no sorry, no native_decide.",
     "builtItems": [
       "reflectBallot (def): non-negative ballot number C(a+b,b) - C(a+b,b-1) in Proofs/BallotProblemOQ05OQ02.lean:61",
       "reflectBallot_eq: reflectBallot a b = ballotNumber (a+1) b for 1≤b (reconciliation) — BallotProblemOQ05OQ02.lean:73",
       "reflectBallot_sub_exact: C(a+b,b-1) ≤ C(a+b,b) for b≤a, subtraction exact — :91",
       "reflectBallot_mul: aggregate reflectBallot a b·(a+1+b)=(a+1-b)·C(a+1+b,a+1) — :112",
       "reflectBallot_div: probability (a+1-b)/(a+1+b) over ℚ — :120",
-      "reflectBallot_catalan: reflectBallot n n = catalan n (1≤n) — :129"
+      "reflectBallot_catalan: reflectBallot n n = catalan n (1≤n) — :129",
+      "reflectBallot_add_choose (BallotProblemOQ05OQ02.lean): exactness reflectBallot a b + C(a+b,b-1) = C(a+b,b) on sharp range 1≤b≤a+1 [0-axiom]",
+      "reflectBallot_one (BallotProblemOQ05OQ02.lean): reflectBallot a 1 = a, first column of Catalan triangle, all a≥0 [0-axiom]",
+      "reflectBallot_diag_succ (BallotProblemOQ05OQ02.lean): reflectBallot a (a+1) = 0, upper edge via C(2a+1,a+1)=C(2a+1,a) symmetry [0-axiom]",
+      "reflectBallot_recurrence (BallotProblemOQ05OQ02.lean): reflectBallot a b = reflectBallot (a-1) b + reflectBallot a (b-1) for 2≤b≤a, two Pascal applications closed by omega [0-axiom]"
     ],
     "insights": [
       "The OQ identity C(a+b,b)-C(a+b,b-1) is NOT the parent strict ballotNumber (disagree at a=2,b=1: 2 vs 1); it is the non-negative (weakly-ahead) ballot number = Catalan-triangle entries.",
       "Reconciliation is the single shift a↦a+1: reflectBallot a b = ballotNumber(a+1) b, arithmetic form of the prepend-an-up-step bijection. Proved by binomial symmetry Nat.choose_symm on each term.",
       "All consequences (aggregate/probability/Catalan diagonal) transport for free from the parents cycle-lemma arithmetic along the shift.",
-      "b=0 boundary: reflectBallot a 0 = 0 ≠ ballotNumber(a+1,0)=1 due to ℕ truncation of b-1, so reconciliation requires 1≤b; Catalan diagonal requires 1≤n (n=0 gives 0≠catalan 0=1)."
+      "b=0 boundary: reflectBallot a 0 = 0 ≠ ballotNumber(a+1,0)=1 due to ℕ truncation of b-1, so reconciliation requires 1≤b; Catalan diagonal requires 1≤n (n=0 gives 0≠catalan 0=1).",
+      "Catalan-triangle recurrence reflectBallot a b = reflectBallot (a-1) b + reflectBallot a (b-1) holds VERBATIM only on the interior 2≤b≤a; the ℕ-truncated subtraction breaks it at both edges (verified numerically): b=1 fails because reflectBallot a 0 is a truncation artifact (formula gives 0, true count 1), and b=a+1 fails because reflectBallot (a-1)(a+1) truncates below its negative integer value.",
+      "The three-lemma decomposition (first column reflectBallot a 1 = a, upper edge reflectBallot a (a+1) = 0, interior Pascal recurrence) completely generates the Catalan triangle from its first column and is the honest complete characterization given the truncated ℕ subtraction.",
+      "Exactness of C(a+b,b-1) ≤ C(a+b,b) holds on the SHARP range b ≤ a+1 (not just b≤a as in reflectBallot_sub_exact), via the ratio identity C(a+b,b)·b = C(a+b,b-1)·(a+1) from Nat.choose_succ_right_eq."
     ],
     "mathlibGaps": [],
     "nextSteps": [
       "Upgrade reflectBallot_eq to an explicit Finset.card bijection (non-negative (a,b)-paths ≃ strictly-positive (a+1,b)-paths).",
-      "Prove the Catalan-triangle recurrence reflectBallot a b = reflectBallot (a-1) b + reflectBallot a (b-1) directly from the reflection form."
+      "Closed form for the Catalan-triangle column sums / row sums (e.g. Σ_b reflectBallot a b) as a single binomial."
     ]
   },
   "tags": [


### PR DESCRIPTION
## Summary

Adds the **Catalan-triangle recurrence** family for the non-negative (weakly-ahead) ballot number `reflectBallot a b = C(a+b, b) − C(a+b, b−1)` in `BallotProblemOQ05OQ02.lean`, completing nextStep #2 of `ballot-problem-oq-05-oq-02`.

The entries `reflectBallot a b` are exactly the Catalan triangle, so they obey the additive Pascal recurrence `T(a,b) = T(a−1,b) + T(a,b−1)`. Because `reflectBallot` uses `ℕ` (truncated) subtraction, the recurrence holds verbatim only in the interior; the two edges are pinned by closed forms.

## New results (all 0-axiom, no sorry, no native_decide)

- **`reflectBallot_add_choose`** — exactness `reflectBallot a b + C(a+b,b−1) = C(a+b,b)` on the **sharp** range `1 ≤ b ≤ a+1` (sharpens the existing `reflectBallot_sub_exact`, which required `b ≤ a`), via the ratio `C(a+b,b)·b = C(a+b,b−1)·(a+1)`.
- **`reflectBallot_one`** — `reflectBallot a 1 = a` (first column, all `a`).
- **`reflectBallot_diag_succ`** — `reflectBallot a (a+1) = 0` (upper edge), via `C(2a+1,a+1) = C(2a+1,a)`.
- **`reflectBallot_recurrence`** — `reflectBallot a b = reflectBallot (a−1) b + reflectBallot a (b−1)` on the interior `2 ≤ b ≤ a`, two applications of Pascal's rule closed by `omega`.

## Sharpness

The interior hypotheses `2 ≤ b ≤ a` are sharp — the `ℕ`-truncation breaks the recurrence at both edges (verified numerically): at `b=1` the `reflectBallot a 0` term is a truncation artifact (formula `0`, true count `1`), and at `b=a+1` the term `reflectBallot (a−1)(a+1)` truncates below its negative integer value. The first-column and upper-edge closed forms pin those edges, so together the three results generate the whole triangle from its first column.

## Verification

`#print axioms` on all four theorems reports only `[propext, Classical.choice, Quot.sound]`. Three `decide`-checked interior sanity examples included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)