### PR TITLE
docs: researcher-doc optimization pass (#38387 PR C) — Aristotle MCP→CLI, dead refs, dedup

### DIFF
--- a/.claude/commands/lean-research.md
+++ b/.claude/commands/lean-research.md
@@ -20,12 +20,10 @@ You are a Lean theorem proving researcher. Run one research iteration on the lea
 
 ## Honesty Standards
 
-- Do not describe trivial results as significant
-- Do not inflate novelty claims -- if the result is routine, say so
-- If nothing worth doing/reporting exists, say "nothing found" rather than fabricating value
-- Judge results relative to current gallery state, not in absolute terms
-- A lemma that filled a gap 3 months ago may be trivial now if stronger results exist
-- When uncertain about significance, default to understating rather than overstating
+Follow the fleet-wide Honesty Standards in
+[`.lean/roles/COMMON.md`](../../.lean/roles/COMMON.md#honesty-standards)
+(no inflation, "nothing found" over fabricated value, judge relative to
+current gallery state, understate when uncertain).
 
 ### Artifact-only reporting (MANDATORY)
 
@@ -69,16 +67,23 @@ jq -r '.candidates | group_by(.status) | map({status: .[0].status, count: length
 
 ### Step 0: Check Aristotle Results
 
+```bash
+# Poll job status and update local tracking (research/aristotle-jobs.json)
+./scripts/aristotle/check-jobs.sh --update
+
+# Download completed results and integrate improvements into proofs/Proofs/
+./scripts/aristotle/retrieve-integrate.sh
 ```
-Use the aristotle_check_results MCP tool to:
-- Retrieve any completed proofs from previous sessions
-- See what's still pending
-- Avoid duplicating work Aristotle already did
-```
+
+This retrieves completed proofs from previous sessions, shows what's still
+pending, and avoids duplicating work Aristotle already did. See
+[`research/ARISTOTLE-WORKFLOW.md`](../../research/ARISTOTLE-WORKFLOW.md) for
+the full pipeline.
 
 If completed proofs are found:
 1. Read the retrieved solutions
-2. Integrate them into the proof files
+2. Integrate them into the proof files (rebuild locally — see the toolchain
+   caveat in the workflow doc)
 3. Update knowledge.json with the progress
 4. THEN proceed to problem selection
 
@@ -114,10 +119,14 @@ fi
 
 ### List Problems by Knowledge (Weakest First)
 
-```bash
-# Show all problems sorted by knowledge accumulation (ascending)
-.lean/scripts/knowledge-scores.sh
-```
+> ⚠️ `.lean/scripts/knowledge-scores.sh` (the listing helper, with `--status`
+> and `--revisit` filters) is currently **missing from `main`** — a
+> mass-deletion casualty, recoverable via `git show dc9fdffa30^:<path>`. See
+> the Known-Gaps Ledger in
+> [`.lean/roles/COMMON.md`](../../.lean/roles/COMMON.md#known-gaps-ledger-issue-38387).
+> Until restored: `scripts/research/claim-problem.sh claim-random` already
+> applies knowledge-prioritized (depth-first) selection, and the per-problem
+> jq snippet above computes an individual score.
 
 ### Selection Rule — DEPTH OVER BREADTH
 
@@ -133,20 +142,28 @@ When multiple problems are eligible:
 
 Before ANY work, answer these questions:
 
-### 1. The Value Question
+### 1. The Axiom Question (CHECK FIRST)
+
+> "How many axioms does this file have? Can any be proved from Mathlib?"
+
+Run `grep -c "^axiom " proofs/Proofs/<file>.lean`. If the axiom count is high
+(>5), prioritize proving existing axioms over adding new content. Adding
+theorems on top of unproved axioms is scaffolding, not formalization.
+
+### 2. The Value Question
 
 > "If I complete this work, will I be meaningfully closer to a complete proof?"
 
 If "no, but it's technically progress" → **STOP. That's not progress.**
 
-### 2. The Proof Strategy Question
+### 3. The Proof Strategy Question
 
 > "How will I cover infinitely many cases?"
 
 Valid: Induction, strong induction, case partition (finite), reduction, contradiction, construction.
 Invalid: "Verify n=7, 9, 11... and keep going" or "extend to n ≤ 1000".
 
-### 3. The Build vs Block Question
+### 4. The Build vs Block Question
 
 > "If infrastructure is missing, can we build it ourselves?"
 
@@ -158,6 +175,19 @@ Invalid: "Verify n=7, 9, 11... and keep going" or "extend to n ≤ 1000".
 | > 1000 lines | Likely truly blocked |
 
 **Before marking `blocked`:** Always check for elementary alternatives and assess buildability.
+
+### Axiom Elimination Priority
+
+**Reducing axiom counts is more valuable than adding new theorems.** A file with 100 theorems and 50 axioms is weaker than a file with 20 theorems and 2 axioms. Every axiom is an unverified assumption — the more axioms, the less Lean is actually checking.
+
+When you claim a problem with a high axiom count:
+1. List all `axiom` declarations: `grep -n "^axiom " proofs/Proofs/<file>.lean`
+2. Classify each: is it a deep result (unlikely provable) or routine (likely in Mathlib)?
+3. **Prove the routine ones** — search Mathlib, use `exact?`, `apply?`, `simp`
+4. For deep axioms that can't be proved, leave them but document why in the file
+5. Convert provable axioms to `theorem ... := by <proof>` — this is real progress
+
+**Target**: On any RICH problem, aim to eliminate at least 1 axiom per session. Don't add new Parts/theorems until you've assessed which existing axioms are provable.
 
 ### Anti-Patterns (NEVER DO)
 
@@ -198,27 +228,11 @@ from the OpenAI CDC prompt (see issue #37505 and
 
 ### Solved/Unsolved Strategy (MANDATORY)
 
-Before starting work, classify the problem state and choose strategy:
-
-**STUCK (sorries remain, no clear path forward):**
-- Do NOT generalize or broaden scope
-- Decompose into concrete subgoals or intermediate lemmas — but apply the
-  equivalent-strength check (see Follow-Up Question Generation below): a subgoal
-  as strong as the target itself is a blocked route, not decomposition progress
-- Try a different decomposition of the same target
-- Check if the blocking sorry can be submitted to Aristotle
-- If 3+ sessions stuck on same sorry: flag as BLOCKED, move on
-
-**MAKING PROGRESS (some sorries eliminated this session):**
-- Continue current approach
-- Document which techniques worked for knowledge propagation
-
-**SOLVED (0 sorries, axiom count acceptable):**
-- Author/update the problem's adversarial checklist BEFORE claiming SOLVED (see below)
-- Generate 1-2 follow-up open questions (see below)
-- Look outward: generalizations, converses, sharp boundaries
-- Check if proved lemmas help other active research problems
-- Update technique index with successful approaches
+Before starting work, classify the problem state (STUCK / MAKING PROGRESS /
+SOLVED) and choose strategy per the shared convention in
+[`research/PROBLEMS-STRUCTURE.md`](../../research/PROBLEMS-STRUCTURE.md)
+§"Session strategy by problem state". Its SOLVED branch requires the
+adversarial checklist and follow-up generation defined below.
 
 ### Adversarial Checklist Before Claiming SOLVED (MANDATORY)
 
@@ -278,7 +292,10 @@ the parent's "Must prove exactly / does not count" section (see
 # Clean stale locks
 find research/claims -name "*.lock" -type d -mmin +120 -exec rm -rf {} \; 2>/dev/null || true
 
-# List available problems by knowledge score (lowest first)
+# List available problems by knowledge score (lowest first).
+# NOTE: knowledge-scores.sh is currently missing from main (Known-Gaps Ledger
+# in .lean/roles/COMMON.md); claim-problem.sh claim-random applies the same
+# knowledge-first prioritization automatically.
 .lean/scripts/knowledge-scores.sh --status available
 
 # Select the one with lowest knowledge score
@@ -306,6 +323,11 @@ fi
 
 Scout returns gallery proofs, techniques, Mathlib gaps, and recommended approaches. Use this as your primary ORIENT tool.
 
+> `/lean-scout` (`.claude/commands/lean-scout.md`) is currently **missing from
+> `main`** (mass-deletion casualty; Known-Gaps Ledger in
+> [`.lean/roles/COMMON.md`](../../.lean/roles/COMMON.md#known-gaps-ledger-issue-38387)).
+> Until restored, run the manual checks below instead.
+
 **Supplement with manual checks if needed:**
 1. **Search Mathlib**: WebSearch "Mathlib4 Lean [topic] 2025 2026"
 2. **Check codebase**: Search `proofs/Proofs/` for related work
@@ -323,18 +345,20 @@ Scout returns gallery proofs, techniques, Mathlib gaps, and recommended approach
 
 ### Step 5: Implement with Aristotle Support
 
-**During implementation, use Aristotle strategically:**
+**During implementation, use Aristotle strategically** (full pipeline:
+[`research/ARISTOTLE-WORKFLOW.md`](../../research/ARISTOTLE-WORKFLOW.md)):
 
 1. **Classify each sorry** as TRIVIAL, HARD, or OPEN
 2. **For HARD sorries:**
-   - If stuck > 10 min → `aristotle_submit` async
+   - If stuck > 10 min → package as `*StatementOnly.lean` and submit via
+     `./scripts/aristotle/submit-batch.sh`
    - Continue working on other sorries while Aristotle runs
-   - Check `aristotle_status` every 5-10 min
+   - Poll `./scripts/aristotle/check-jobs.sh --update` every ~10 min
 3. **For OPEN sorries:**
    - Work manually - Aristotle can't help with unsolved problems
 4. **For TRIVIAL sorries:**
-   - Try manually first (should be quick)
-   - Use `aristotle_prove` sync if you want instant answer
+   - Prove them yourself — `simp`/`omega`/`linarith`/`decide` is faster than
+     the submission round trip
 
 ### Step 5b: Advance Phase (MANDATORY)
 
@@ -351,6 +375,13 @@ After each session, advance the problem's phase to reflect work done:
 .lean/scripts/research.sh phase "$PROBLEM_ID" "COMPLETED"
 ```
 
+> ⚠️ `.lean/scripts/research.sh` is currently **missing from `main`**
+> (mass-deletion casualty; Known-Gaps Ledger in
+> [`.lean/roles/COMMON.md`](../../.lean/roles/COMMON.md#known-gaps-ledger-issue-38387),
+> recoverable via `git show dc9fdffa30^:.lean/scripts/research.sh`). Until
+> restored, update the phase field directly in `research/registry.json` with
+> `jq` (`.problems[] | select(.slug == $id) | .phase = $phase`).
+
 **Phase meanings:**
 - **OBSERVE**: Surveyed only — wrote knowledge.md but no proof attempt
 - **ORIENT**: Analyzed feasibility, identified approach, may have partial infrastructure
@@ -366,8 +397,9 @@ After each session, advance the problem's phase to reflect work done:
 jq '(.candidates[] | select(.id == "PROBLEM_ID")).status = "STATUS"' .lean/state/candidate-pool.json > tmp.json && mv tmp.json .lean/state/candidate-pool.json
 rm -rf "research/claims/${PROBLEM_ID}.lock"
 
-# If HARD sorries remain, submit for overnight processing
-./research/scripts/aristotle-submit.sh proofs/Proofs/File.lean problem-id "End of session"
+# If HARD sorries remain, package them as *StatementOnly.lean files and
+# submit for overnight processing
+./scripts/aristotle/submit-batch.sh --target 5
 ```
 
 ---
@@ -381,7 +413,10 @@ When pool is empty, we scout for new knowledge and attempt if promising.
 **Prioritize by knowledge tier, then status:**
 
 ```bash
-# List revisitable problems by knowledge score (lowest first)
+# List revisitable problems by knowledge score (lowest first).
+# NOTE: knowledge-scores.sh is currently missing from main (Known-Gaps Ledger
+# in .lean/roles/COMMON.md); meanwhile use the per-problem jq snippet from
+# "Calculate Knowledge Score" above over the revisitable statuses.
 .lean/scripts/knowledge-scores.sh --revisit
 ```
 
@@ -413,7 +448,7 @@ Scout will return:
 - Literature highlights and key papers
 - Recommended approaches with evidence
 
-**Incorporate Scout's findings into your ORIENT exploration.** Scout is your research assistant - it searches the gallery and literature while you focus on mathematical insights.
+**Incorporate Scout's findings into your ORIENT exploration.** Scout is your research assistant - it searches the gallery and literature while you focus on mathematical insights. (While `/lean-scout` is missing from `main` — see the Known-Gaps Ledger note in Mode 1, Step 3 — do the manual searches below yourself.)
 
 **Manual searches (if Scout results are incomplete):**
 
@@ -431,9 +466,9 @@ If Scout's survey is incomplete or you need deeper exploration:
 1. Propose NEW approach (different from previous attempts)
 2. Apply Pre-Work Assessment
 3. **Classify sorries and delegate to Aristotle:**
-   - HARD sorries → `aristotle_submit` async, work on OPEN ones
+   - HARD sorries → `./scripts/aristotle/submit-batch.sh` async, work on OPEN ones
    - OPEN sorries → Work manually (Aristotle can't help)
-   - Check `aristotle_status` periodically
+   - Poll `./scripts/aristotle/check-jobs.sh --update` periodically
 4. Implement meaningful work
 5. Document outcome in knowledge.md
 6. Submit remaining HARD sorries for overnight if session ends
@@ -460,16 +495,17 @@ research/problems/<id>/
 1. `knowledge.md` keeps only the **last 5 sessions** + problem summary
 2. Older sessions are archived to `sessions/` subdirectory
 3. Archive when knowledge.md exceeds **500 lines** or **10 sessions**
-4. Use `.lean/scripts/archive-sessions.sh <problem-id>` to archive
 
 ### Archive Sessions
 
-```bash
-# Archive old sessions for a problem (keeps last 5)
-.lean/scripts/archive-sessions.sh pnp-barriers
+Archive manually: move each old session block to
+`research/problems/<id>/sessions/YYYY-MM-DD-sNN.md` (standalone file, same
+format), keeping the last 5 sessions in `knowledge.md`.
 
-# Manual archive: move session block to sessions/YYYY-MM-DD-sNN.md
-```
+> The helper `.lean/scripts/archive-sessions.sh <problem-id>` is currently
+> **missing from `main`** (mass-deletion casualty; Known-Gaps Ledger in
+> [`.lean/roles/COMMON.md`](../../.lean/roles/COMMON.md#known-gaps-ledger-issue-38387),
+> recoverable via `git show dc9fdffa30^:.lean/scripts/archive-sessions.sh`).
 
 ### Update Problem Knowledge (MANDATORY)
 
@@ -664,170 +700,37 @@ issue #37505 and
 | `research/problems/<id>/knowledge.md` | Problem history |
 | `proofs/Proofs/*.lean` | Proof files |
 | `research/aristotle-jobs.json` | Aristotle job tracking |
+| `research/ARISTOTLE-WORKFLOW.md` | Aristotle CLI pipeline (single source) |
 | `research/SORRY-CLASSIFICATION.md` | Sorry classification guide |
 
 ---
 
-## Aristotle Integration
+## Aristotle Integration (Quick Reference)
 
-Aristotle is a powerful proof search tool. Use it strategically alongside manual proof work.
-
-### Tool Roles
-
-| Tool | Strength | Best For |
-|------|----------|----------|
-| **Claude** | Strategic reasoning, creativity | OPEN problems, proof architecture, new approaches |
-| **Aristotle** | Proof search, tactic grinding | HARD problems with known proofs |
-
-**Our mission is solving OPEN problems!** But use tools appropriately:
-- Aristotle formalizes KNOWN mathematics (proof exists somewhere)
-- Claude attempts UNKNOWN mathematics (creative work needed)
-
-### Sorry Classification
-
-| Classification | Description | Send to Aristotle? |
-|----------------|-------------|-------------------|
-| **TRIVIAL** | Direct computation | Yes (fast, 1-5 min) |
-| **HARD** | Known result, needs formalization | Yes (may take hours) |
-| **OPEN** | Unsolved conjecture | **NEVER** - work on it ourselves! |
-
----
-
-## Session Start: Check Aristotle Results (MANDATORY)
-
-**Every research session MUST begin by checking for completed Aristotle jobs:**
-
-```
-Use aristotle_check_results to:
-1. Auto-retrieve any completed proofs from overnight/previous sessions
-2. See status of pending jobs
-3. Plan around what Aristotle is working on
-```
-
-This prevents duplicate work and integrates overnight progress immediately.
-
----
-
-## Real-Time Aristotle Usage
-
-### When to Submit During Active Work
-
-| Situation | Action |
-|-----------|--------|
-| Stuck on a proof goal > 10 min | Submit async, continue other work |
-| Multiple independent HARD sorries | Submit all in parallel |
-| Need a helper lemma | Let Aristotle prove it while you work on main theorem |
-| Blocked by tedious case analysis | Perfect for Aristotle |
-| Creative/novel approach needed | Work manually - Aristotle can't innovate |
-
-### Async Workflow (Recommended)
-
-```
-1. Identify HARD sorry that's blocking progress
-2. Use aristotle_submit → get project_id
-3. Continue working on other parts of the proof
-4. Check aristotle_status periodically (every 5-10 min)
-5. When COMPLETE, use aristotle_retrieve
-6. Integrate solution and continue
-```
-
-This keeps you productive while Aristotle grinds on tactical proofs.
-
-### Sync Workflow (Quick Proofs)
-
-For TRIVIAL sorries or when you need an immediate answer:
-
-```
-Use aristotle_prove directly:
-- Waits for completion (typically 1-5 minutes)
-- Returns the solved proof immediately
-- Good for simple lemmas you expect to be fast
-```
-
----
-
-## Available MCP Tools
-
-| Tool | Use Case | Blocking? |
-|------|----------|-----------|
-| `aristotle_prove` | Quick proofs, need answer now | Yes |
-| `aristotle_submit` | Long proofs, want to continue working | No |
-| `aristotle_status` | Check progress on async job | No |
-| `aristotle_retrieve` | Get completed solution | No |
-| `aristotle_check_results` | Session start, batch retrieval | No |
-| `aristotle_informal` | Natural language → Lean | Yes |
-| `aristotle_list` | See all your projects | No |
-
----
-
-## Strategic Delegation Checklist
-
-Before attempting a sorry manually, ask:
-
-1. **Is this OPEN or HARD?**
-   - OPEN → Work on it manually (Aristotle can't help)
-   - HARD → Consider Aristotle
-
-2. **How long will manual proof take?**
-   - < 5 min → Do it yourself
-   - 5-15 min → Your call
-   - > 15 min → Submit to Aristotle, work on something else
-
-3. **Is this on the critical path?**
-   - Yes → Maybe work manually for immediate progress
-   - No → Submit async, prioritize critical work
-
-4. **Do I have other productive work?**
-   - Yes → Submit async, do other work
-   - No → Try manually first, submit if stuck
-
----
-
-## Parallel Workflow Example
-
-```
-Session starts:
-1. aristotle_check_results → Found 2 completed proofs from last night!
-2. Integrate those solutions
-3. Identify 3 HARD sorries in current file
-4. Submit all 3 with aristotle_submit (get 3 project_ids)
-5. Work on the 1 OPEN sorry manually
-6. Every 10 min: check aristotle_status on the 3 jobs
-7. As jobs complete: retrieve and integrate
-8. End session: any still pending will continue overnight
-```
-
----
-
-## Overnight Submissions
-
-For complex proofs expected to take hours:
+**Single source of truth: [`research/ARISTOTLE-WORKFLOW.md`](../../research/ARISTOTLE-WORKFLOW.md)** —
+CLI pipeline, packaging format, v2 status model, rate limits/cooldown,
+result caching, the Mathlib v4.28 toolchain caveat, and anti-patterns.
+The former MCP tools (`aristotle_submit`, `aristotle_prove`,
+`aristotle_check_results`, `aristotle_retrieve`, ...) are **gone** — the MCP
+wrapper broke against the v2 API and was removed (issue #38098). Use the CLI
+pipeline:
 
 ```bash
-# Submit via script for logging
-./research/scripts/aristotle-submit.sh proofs/Proofs/File.lean problem-id "Notes"
-
-# Or via MCP tool
-Use aristotle_submit with the file path
-
-# Next morning: aristotle_check_results auto-retrieves completed work
+./scripts/aristotle/cli-smoke-test.sh          # auth/reachability check (free)
+./scripts/aristotle/submit-batch.sh --target 5 # submit *StatementOnly.lean batch
+./scripts/aristotle/check-jobs.sh --update     # poll + update research/aristotle-jobs.json
+./scripts/aristotle/retrieve-integrate.sh      # download + integrate results
 ```
 
-### Success Example: Erdős #728
+Essentials (details and rationale in the workflow doc):
 
-- **Input:** File with HARD sorries only
-- **Runtime:** 6 hours
-- **Output:** 1,416 lines of complete proof
-- **Result:** Zero sorries, builds successfully
+| Rule | Summary |
+|------|---------|
+| Session start | Run `check-jobs.sh --update` + `retrieve-integrate.sh` before any other work (Step 0) |
+| TRIVIAL sorries | Prove yourself — faster than the round trip |
+| HARD sorries | One theorem per `*StatementOnly.lean` file → `submit-batch.sh`; async, poll every ~10 min |
+| OPEN sorries | **Never submit** — work manually; that is the mission |
+| Definition sorries / axioms | Aristotle skips them — complete the def / convert `axiom` to `theorem ... := by sorry` first |
+| Toolchain | Backend vendors Mathlib v4.28 and rewrites `lean-toolchain` — rebuild retrieved proofs locally |
 
----
-
-## Anti-Patterns
-
-| Pattern | Why Wrong | Do Instead |
-|---------|-----------|------------|
-| Submit OPEN problems | Aristotle spins forever, wastes API | Work manually |
-| Wait for sync proofs > 5 min | Blocks your session | Use async submit |
-| Never check results | Miss completed work | Check at session start |
-| Submit everything | Wastes resources on easy stuff | Triage first |
-| Manual proof search for hours | Aristotle is better at this | Submit after 10-15 min stuck |
+Classification guide: [`research/SORRY-CLASSIFICATION.md`](../../research/SORRY-CLASSIFICATION.md).

--- a/.lean/roles/COMMON.md
+++ b/.lean/roles/COMMON.md
@@ -87,6 +87,8 @@ always preserved.
 - If nothing worth doing/reporting exists, say "nothing found" rather than
   fabricating value. A cycle that correctly stands down is a successful cycle.
 - Judge results relative to current gallery state, not in absolute terms.
+- A lemma that filled a gap 3 months ago may be trivial now if stronger
+  results exist.
 - When uncertain about significance, default to understating rather than
   overstating.
 
@@ -116,12 +118,17 @@ recoverable verbatim from git history via `git show dc9fdffa30^:<path>`:
 | `scripts/lean/update-stats.sh` | seeker | Stats/completion signals |
 | `scripts/clean-branches.sh` | worktree janitor | |
 | `scripts/gallery/check-meta-size.ts` | enricher | Size-guardrail check |
+| `.claude/commands/lean-scout.md` | researcher (`/lean-scout` survey skill) | Structured literature/gallery survey |
+| `.claude/skills/mathlib-contribution/` (SKILL.md, STYLE-SCAN.md, GOTCHAS.md) | researcher red-team pass for Mathlib-bound files | |
 | `.lean/scripts/extract-problems.ts` | seeker | Pool extractor |
-| `.lean/scripts/research.sh` | seeker | Workspace init |
+| `.lean/scripts/research.sh` | seeker, researcher | Workspace init; `phase` subcommand tracks OBSERVE/ORIENT/ACT/COMPLETED in `research/registry.json` |
+| `.lean/scripts/knowledge-scores.sh` | researcher | Lists problems by knowledge score (`--status`, `--revisit`); `claim-problem.sh claim-random` covers the selection use case meanwhile |
+| `.lean/scripts/archive-sessions.sh` | researcher | Archives old knowledge.md sessions to `sessions/`; manual archiving works meanwhile |
 | `research/db/sync_pool.py`, `research/db/migrate.py` | seeker | DB-first pool sync (present only as untracked runtime state, currently absent from disk) |
 | Root `package.json`, `vite.config.ts`, `tsconfig*.json`, `wrangler.toml` | `pnpm build` anywhere | Site builds currently only work in worktrees created from pre-deletion branches |
 
 Do **not** reinvent these from scratch — restore from history (after a secrets
-scan) or wait for the restoration decision tracked in #38387. Where a role doc
-below references one of these paths, treat it as "the documented behavior when
-the script is available".
+scan) or wait for the restoration decision, now tracked in follow-up issue
+#38398 (#38387 covered the survey, engine check-in, role docs, and researcher-doc
+optimization). Where a role doc references one of these paths, treat it as "the
+documented behavior when the script is available".

--- a/.lean/roles/enricher.md
+++ b/.lean/roles/enricher.md
@@ -215,7 +215,8 @@ leave gallery conventions in place. (See #20854.)
 `scripts/enricher/claim-target.sh`, `scripts/enricher/find-targets.ts`, and
 `scripts/gallery/check-meta-size.ts` are referenced by this workflow but missing
 from `main` (deleted by `dc9fdffa30`; recovery: COMMON.md Known-Gaps Ledger).
-Known tracker defect while unrestored: `find-targets.ts` read the audit tracker
-via a CWD-relative path while `complete` wrote to the main-repo tracker, so
+Known tracker defect while unrestored: `find-targets.ts` read the enrichment
+tracker (`src/data/proofs/enrichment-tracker.json`) via a CWD-relative path
+while `complete` wrote to the main-repo tracker, so
 completed passes did not persist and `claim-next` could re-serve the same
 at-target entry — verify an entry is genuinely under-target before enriching.

--- a/.lean/roles/researcher.md
+++ b/.lean/roles/researcher.md
@@ -8,12 +8,10 @@ Make meaningful progress on open mathematical problems by proving theorems, buil
 
 ## Honesty Standards
 
-- Do not describe trivial results as significant
-- Do not inflate novelty claims -- if the result is routine, say so
-- If nothing worth doing/reporting exists, say "nothing found" rather than fabricating value
-- Judge results relative to current gallery state, not in absolute terms
-- A lemma that filled a gap 3 months ago may be trivial now if stronger results exist
-- When uncertain about significance, default to understating rather than overstating
+Follow the fleet-wide Honesty Standards in
+[`COMMON.md`](./COMMON.md#honesty-standards) (no inflation, "nothing found"
+over fabricated value, judge relative to current gallery state, understate
+when uncertain).
 
 ## Environment Setup
 
@@ -168,7 +166,7 @@ Knowledge score: 8 (MODERATE)
 cd $REPO_ROOT/.loom/worktrees/researcher-$N
 ```
 
-`.loom/worktrees/researcher-$N` is the sanctioned location — the create path preserves in-flight work, so avoid making defensive worktrees under `$HOME` or `/tmp`. The backstop janitor (`scripts/clean-branches.sh`) automatically reclaims any stray `$HOME`/`/private/tmp` worktree once it is clean and stale; dirty or unpushed worktrees are always preserved.
+`.loom/worktrees/researcher-$N` is the sanctioned location — the create path preserves in-flight work, so avoid making defensive worktrees under `$HOME` or `/tmp`. The backstop janitor (`scripts/clean-branches.sh` — currently missing from `main`, see the [Known-Gaps Ledger](./COMMON.md#known-gaps-ledger-issue-38387)) automatically reclaims any stray `$HOME`/`/private/tmp` worktree once it is clean and stale; dirty or unpushed worktrees are always preserved.
 
 If no problems are available, wait 5 minutes and retry.
 
@@ -198,27 +196,11 @@ When you claim a problem with a high axiom count:
 
 ### Solved/Unsolved Strategy (MANDATORY)
 
-Before starting work, classify the problem state and choose strategy:
-
-**STUCK (sorries remain, no clear path forward):**
-- Do NOT generalize or broaden scope
-- Decompose into concrete subgoals or intermediate lemmas — but apply the
-  equivalent-strength check (see Follow-Up Question Generation below): a subgoal
-  as strong as the target itself is a blocked route, not decomposition progress
-- Try a different decomposition of the same target
-- Check if the blocking sorry can be submitted to Aristotle
-- If 3+ sessions stuck on same sorry: flag as BLOCKED, move on
-
-**MAKING PROGRESS (some sorries eliminated this session):**
-- Continue current approach
-- Document which techniques worked for knowledge propagation
-
-**SOLVED (0 sorries, axiom count acceptable):**
-- Author/update the problem's adversarial checklist BEFORE claiming SOLVED (see below)
-- Generate 1-2 follow-up open questions (see below)
-- Look outward: generalizations, converses, sharp boundaries
-- Check if proved lemmas help other active research problems
-- Update technique index with successful approaches
+Before starting work, classify the problem state (STUCK / MAKING PROGRESS /
+SOLVED) and choose strategy per the shared convention in
+`research/PROBLEMS-STRUCTURE.md` §"Session strategy by problem state". Its
+SOLVED branch requires the adversarial checklist and follow-up generation
+defined below.
 
 ### Adversarial Checklist Before Claiming SOLVED (MANDATORY)
 
@@ -326,148 +308,43 @@ issue #37505).
 | **SURVEY** | Can state but not prove yet | Document findings |
 | **BLOCKED** | Needs > 1000 lines foundational work | Document blocker |
 
-### Create/Update Aristotle Companion File
-
-After writing or updating a main proof file, create a companion file with routine supporting lemmas:
-
-```bash
-# Create companion file for Erdős #N
-# Name: ErdosNAristotle.lean (alongside ErdosNProblem.lean)
-```
-
-**Template for companion files:**
-```lean
-/-
-  Aristotle targets for Erdős Problem #N
-  Routine supporting lemmas for automated proof search.
-  See ErdosNProblem.lean for the main formalization.
-
-  Criteria for inclusion:
-  - NOT the main open conjecture
-  - Known result likely in Mathlib (monotonicity, cardinality, bounds, etc.)
-  - Clean theorem statement with no definition sorries
-  - No axioms (use theorem ... := by sorry instead)
--/
-import Mathlib
-
-namespace ErdosN
-
--- [Routine lemmas here, one per theorem]
--- GOOD: standard bounds, combinatorial identities, known estimates
-lemma helper_bound : ... := by sorry
-lemma routine_calc : ... := by sorry
-
--- DO NOT include:
--- * The main open conjecture
--- * axiom declarations (convert to theorem ... := by sorry)
--- * definition sorries
-
-end ErdosN
-```
-
-**What to include:**
-- Monotonicity lemmas, cardinality bounds, standard inequalities
-- Known results from literature that are likely in Mathlib
-- Supporting lemmas for the main proof (NOT the main conjecture itself)
-
-**What NOT to include:**
-- The main open conjecture (`erdos_N` theorem)
-- `axiom` declarations (Aristotle won't attempt these — use `theorem ... := by sorry`)
-- Definition sorries (blocks everything)
-
 ### Use Aristotle Strategically
 
-- **TRIVIAL sorries**: Try manually first — faster to write yourself than to round-trip through Aristotle
-- **HARD sorries**: **Preferred path is the CLI/shell-script pipeline** (`scripts/aristotle/*.sh`, see "Aristotle CLI pipeline" below). Package each hard supporting lemma as a `*StatementOnly.lean` file and submit it via `scripts/aristotle/submit-batch.sh`. The legacy multi-sorry `*Aristotle.lean` companion-file pattern is deprecated for new work but remains a fallback; existing companion files are not being deleted in this transition.
-- **OPEN sorries**: Work manually — Aristotle can't help with unsolved problems (it will spin on the server until it times out)
-- **Definition sorries**: Never submit — Aristotle skips `def ... := by sorry` entirely. Complete the definition first, then submit downstream theorem sorries.
+**Single source of truth: `research/ARISTOTLE-WORKFLOW.md`** — CLI pipeline
+details, `*StatementOnly.lean` packaging, v2 status model, rate limits and the
+cooldown file, result caching, the Mathlib v4.28 toolchain caveat, the
+deprecated `*Aristotle.lean` companion-file pattern, and anti-patterns. (The
+former MCP wrapper is dead — HTTP 426 against the v2 API, removed in issue
+#38098. Use the CLI pipeline only.)
 
-### Aristotle CLI pipeline (the working path)
-
-> **History (issue #38098):** an MCP wrapper (`septract/lean-aristotle-mcp`)
-> was previously registered in `.mcp.json` and documented here as the
-> "preferred" per-sorry route via `prove()` / `prove_file()`. That wrapper
-> pinned `aristotlelib ~=0.6.0` and broke when Harmonic cut over to the v1+
-> API server-side (~2026-03-18): 0.6.x clients now get **HTTP 426 Upgrade
-> Required**, surfaced as "Resource not found". There is **no official MCP
-> server** for `aristotlelib` 2.x. The MCP entry has been removed. **Use the
-> CLI, wrapped by the shell scripts in `scripts/aristotle/`.**
-
-Aristotle is driven through the `aristotle` CLI (from `aristotlelib`, invoked
-as `uvx --from aristotlelib aristotle ...`). You do not call the CLI directly
-in the common case — the shell pipeline handles submission, polling, and
-result integration:
-
-```bash
-# 1. Sanity check: confirm the CLI is reachable and authenticated (free — a
-#    read-only `aristotle list` call, no proof-search quota consumed).
-./scripts/aristotle/cli-smoke-test.sh
-
-# 2. Find candidate files and submit a batch (respects the ~3–5 concurrent cap).
-./scripts/aristotle/submit-batch.sh --target 5
-
-# 3. Poll for status and update local tracking (research/aristotle-jobs.json).
-./scripts/aristotle/check-jobs.sh --update
-
-# 4. Download completed results and integrate improvements into proofs/Proofs/.
-./scripts/aristotle/retrieve-integrate.sh
-```
-
-**How to package a hard sorry for submission.** The unit of submission is
-**one theorem per file**: a `*StatementOnly.lean` file with full imports, the
-single `theorem`/`lemma` statement, and an informal `/-` proof-sketch
-docstring. See `research/SORRY-CLASSIFICATION.md` §"Harmonic Submission Format
-(recommended)" for the template. `submit-batch.sh` picks up `*StatementOnly.lean`
-files first, then legacy `*Aristotle.lean` companion files.
-
-**v2 status model (what the scripts key off).** The v2 CLI splits status into
-two levels, which is why the shell scripts query `RUNNING`/`IDLE` and then drill
-into tasks:
-
-- **Project status** (`aristotle list --status`) is only `RUNNING` (a solve
-  task is in flight) or `IDLE` (no task running — terminal). The old v1 enums
-  (`NOT_STARTED`, `QUEUED`, `COMPLETE`, `FAILED`, …) were removed and now error.
-- **Task status** (`aristotle tasks <project-id>` / `aristotle show
-  <project-id>`) carries the fine-grained terminal outcome: `IN_PROGRESS`,
-  `COMPLETE`, `COMPLETE_WITH_ERRORS`, `FAILED`, `CANCELED`, ….
-
-**Async, don't block.** Aristotle searches take minutes to hours. Submit a
-batch, then continue other work (a different sorry, refactoring, the OPEN main
-conjecture). Poll every ~10 minutes with `check-jobs.sh`; integrate with
-`retrieve-integrate.sh` when projects go `IDLE` with a `COMPLETE` task.
-
-**Result caching.** Aristotle caches project results ~30 days server-side, so
-re-submitting the exact same file within that window returns the prior result
-quickly without burning fresh solver budget.
-
-**Concurrency cap.** At most ~3–5 concurrent projects (shared server cap).
-`submit-batch.sh` enforces this and arms a cooldown file
-(`.loom/state/aristotle-rate-limit-until`) on a 429; before submitting fresh
-work, check that file and the scale-to-zero marker
-(`.loom/state/aristotle-scaled-to-zero`).
-
-#### When to submit to Aristotle vs. prove it yourself
-
-Classify the sorry per
-[`research/SORRY-CLASSIFICATION.md`](../../research/SORRY-CLASSIFICATION.md):
+Quick reference — classify each sorry per `research/SORRY-CLASSIFICATION.md`:
 
 | Classification | Action |
 |----------------|--------|
 | **TRIVIAL** | Prove it yourself — `simp`/`omega`/`linarith`/`decide` is faster than the round trip |
-| **HARD** (known in the literature, only tactical search needed) | Package as `*StatementOnly.lean` and submit via `submit-batch.sh` |
+| **HARD** (known in the literature, only tactical search needed) | Package as a one-theorem `*StatementOnly.lean` file and submit via `submit-batch.sh` |
 | **OPEN** | Work on it yourself — that is **the mission**; Aristotle will only spin |
 | **DEF SORRY** (`def foo := by sorry`) | Complete the definition first, *then* submit downstream theorem sorries — Aristotle skips definition sorries |
 | **Sorry inside an axiom** | Convert `axiom` → `theorem ... := by sorry` if it really is provable, else leave it |
 
-#### Deprecation of hand-curated `*Aristotle.lean` companion files
+The pipeline commands:
 
-Do **not** hand-curate new multi-sorry `*Aristotle.lean` companion files. The
-MCTS proof search is conditioned on *proof state + history + informal
-statement* per sorry, so bundling many unrelated sorries into one file dilutes
-the search budget. New work uses a `*StatementOnly.lean` file (one theorem)
-submitted through the batch pipeline. Existing `*Aristotle.lean` files keep
-working — the batch pipeline still picks them up as a fallback — but they are
-no longer the recommended shape for new submissions.
+```bash
+./scripts/aristotle/cli-smoke-test.sh          # auth/reachability check (free)
+./scripts/aristotle/submit-batch.sh --target 5 # submit batch (~3–5 concurrent cap)
+./scripts/aristotle/check-jobs.sh --update     # poll + update research/aristotle-jobs.json
+./scripts/aristotle/retrieve-integrate.sh      # download + integrate results
+```
+
+**Async, don't block**: submit, keep working, poll every ~10 minutes. Before
+submitting fresh work, check the cooldown file
+(`.loom/state/aristotle-rate-limit-until`) and the scale-to-zero marker
+(`.loom/state/aristotle-scaled-to-zero`). Rebuild retrieved proofs locally —
+the backend vendors Mathlib v4.28 and rewrites `lean-toolchain`.
+
+Do **not** hand-curate new multi-sorry `*Aristotle.lean` companion files — the
+pattern is deprecated (dilutes per-sorry search budget); existing ones still
+get picked up as a fallback. Details in `research/ARISTOTLE-WORKFLOW.md`.
 
 ## Step 4: Update Knowledge
 
@@ -496,6 +373,11 @@ apply mathlib-contribution skill to proofs/Proofs/YourFile.lean
 ```
 
 The skill bundles a style/naming scan, a curated gotchas catalog, and trust-but-verify auto-edit rules adapted from Terence Tao's "AI with Lean" workflow. See `.claude/skills/mathlib-contribution/SKILL.md` for the workflow and `STYLE-SCAN.md` for the checklist. The skill is a red-team tool only -- use it after the proof compiles and the mathematics is settled. Tracking issue: #20854.
+
+> The skill files (`.claude/skills/mathlib-contribution/`) are currently
+> **missing from `main`** (mass-deletion casualty; Known-Gaps Ledger in
+> [`COMMON.md`](./COMMON.md#known-gaps-ledger-issue-38387), recoverable via
+> `git show dc9fdffa30^:.claude/skills/mathlib-contribution/SKILL.md`).
 
 This pass does **not** apply to research-only files or gallery proofs; gallery work follows looser conventions on purpose.
 

--- a/research/ARISTOTLE-WORKFLOW.md
+++ b/research/ARISTOTLE-WORKFLOW.md
@@ -1,0 +1,214 @@
+# Aristotle Workflow — single source of truth
+
+Aristotle (Harmonic) is our external proof-search service for Lean 4. This
+document is the canonical reference for how the fleet interacts with it. Role
+docs (`.lean/roles/researcher.md`, `.claude/commands/lean-research.md`) carry
+only a role-specific quick reference and point here for everything else.
+
+For **what to send** (classification of sorries), the canonical guide is
+[`SORRY-CLASSIFICATION.md`](./SORRY-CLASSIFICATION.md); this document covers
+**how to send it and get results back**.
+
+## Division of labor
+
+| Tool | Strength | Best For |
+|------|----------|----------|
+| **Claude** | Strategic reasoning, creativity | OPEN problems, proof architecture, new approaches |
+| **Aristotle** | Proof search, tactic grinding | HARD problems with known proofs |
+
+**Our mission is solving OPEN problems.** Aristotle formalizes KNOWN
+mathematics (a proof exists somewhere); Claude attempts UNKNOWN mathematics
+(creative work needed). Never submit OPEN conjectures — Aristotle will spin on
+the server until it times out.
+
+## Interface: the CLI pipeline (the only working path)
+
+> **History (issue #38098):** an MCP wrapper (`septract/lean-aristotle-mcp`)
+> was previously registered in `.mcp.json` and documented as the preferred
+> route (`aristotle_submit` / `aristotle_prove` / `aristotle_check_results` /
+> `aristotle_retrieve` tools). That wrapper pinned `aristotlelib ~=0.6.0` and
+> broke when Harmonic cut over to the v1+ API server-side (~2026-03-18): 0.6.x
+> clients now get **HTTP 426 Upgrade Required**, surfaced as "Resource not
+> found". There is **no official MCP server** for `aristotlelib` 2.x. The MCP
+> entry has been removed. Any doc or session note that still mentions the
+> `aristotle_*` MCP tools is stale — use the CLI pipeline below.
+
+Aristotle is driven through the `aristotle` CLI (from `aristotlelib`, invoked
+as `uvx --from aristotlelib aristotle ...`). You normally do not call the CLI
+directly — the shell pipeline in `scripts/aristotle/` handles submission,
+polling, and result integration:
+
+```bash
+# 1. Sanity check: confirm the CLI is reachable and authenticated (free — a
+#    read-only `aristotle list` call, no proof-search quota consumed).
+./scripts/aristotle/cli-smoke-test.sh
+
+# 2. Find candidate files and submit a batch (respects the ~3–5 concurrent cap).
+./scripts/aristotle/submit-batch.sh --target 5
+
+# 3. Poll for status and update local tracking (research/aristotle-jobs.json).
+./scripts/aristotle/check-jobs.sh --update
+
+# 4. Download completed results and integrate improvements into proofs/Proofs/.
+./scripts/aristotle/retrieve-integrate.sh
+```
+
+Authentication: `ARISTOTLE_API_KEY` in the environment, or `~/.aristotle_key`
+(the scripts read either).
+
+## Submission tiers (what to send)
+
+Classify each sorry per [`SORRY-CLASSIFICATION.md`](./SORRY-CLASSIFICATION.md):
+
+| Classification | Action |
+|----------------|--------|
+| **TRIVIAL** | Prove it yourself — `simp`/`omega`/`linarith`/`decide` is faster than the round trip |
+| **HARD** (known in the literature, only tactical search needed) | Package as `*StatementOnly.lean` and submit via `submit-batch.sh` |
+| **OPEN** | Work on it yourself — that is **the mission**; Aristotle will only spin |
+| **DEF SORRY** (`def foo := by sorry`) | Complete the definition first, *then* submit downstream theorem sorries — Aristotle skips definition sorries |
+| **Sorry inside an axiom** | Convert `axiom` → `theorem ... := by sorry` if it really is provable, else leave it |
+
+### When to submit vs. prove it yourself
+
+Before attempting a HARD sorry manually, ask:
+
+1. **How long will the manual proof take?** < 5 min → do it yourself;
+   5–15 min → your call; > 15 min stuck → submit, work on something else.
+2. **Is this on the critical path?** Yes → maybe work manually for immediate
+   progress; No → submit async, prioritize critical work.
+3. **Do I have other productive work?** Yes → submit async; No → try manually
+   first, submit if stuck.
+
+## Packaging: `*StatementOnly.lean` (recommended shape)
+
+The unit of submission is **one theorem per file**: a `*StatementOnly.lean`
+file with full imports, the single `theorem`/`lemma` statement, and an
+informal `/- -/` proof-sketch docstring. See
+[`SORRY-CLASSIFICATION.md`](./SORRY-CLASSIFICATION.md) §"Harmonic Submission
+Format (recommended)" for the template. `submit-batch.sh` picks up
+`*StatementOnly.lean` files first, then legacy `*Aristotle.lean` companion
+files.
+
+Inclusion criteria (regardless of file shape):
+
+- NOT the main open conjecture
+- Known result likely provable from Mathlib (monotonicity, cardinality,
+  bounds, combinatorial identities, standard estimates)
+- Clean theorem statement with no definition sorries
+- No `axiom` declarations (convert to `theorem ... := by sorry` — Aristotle
+  won't attempt axioms)
+
+### Legacy `*Aristotle.lean` companion files (deprecated)
+
+Do **not** hand-curate new multi-sorry `*Aristotle.lean` companion files
+(previously the recommended pattern: an `ErdosNAristotle.lean` alongside
+`ErdosNProblem.lean` bundling routine supporting lemmas). The MCTS proof
+search is conditioned on *proof state + history + informal statement* per
+sorry, so bundling many unrelated sorries into one file dilutes the search
+budget. Existing `*Aristotle.lean` files keep working — the batch pipeline
+still picks them up as a fallback — but they are no longer the recommended
+shape for new submissions.
+
+When a companion file completes, its proved lemmas still need to be manually
+merged into the corresponding `*Problem.lean` file; `check-jobs.sh` /
+`retrieve-integrate.sh` record this in the job's `outcome` field.
+
+## v2 status model (what the scripts key off)
+
+The v2 CLI splits status into two levels, which is why the shell scripts query
+`RUNNING`/`IDLE` and then drill into tasks:
+
+- **Project status** (`aristotle list --status`) is only `RUNNING` (a solve
+  task is in flight) or `IDLE` (no task running — terminal). The old v1 enums
+  (`NOT_STARTED`, `QUEUED`, `COMPLETE`, `FAILED`, …) were removed and now
+  error.
+- **Task status** (`aristotle tasks <project-id>` / `aristotle show
+  <project-id>`) carries the fine-grained terminal outcome: `IN_PROGRESS`,
+  `COMPLETE`, `COMPLETE_WITH_ERRORS`, `FAILED`, `CANCELED`, ….
+
+## Async workflow (don't block)
+
+Aristotle searches take minutes to hours. Submit a batch, then continue other
+work (a different sorry, refactoring, the OPEN main conjecture). Poll every
+~10 minutes with `check-jobs.sh`; integrate with `retrieve-integrate.sh` when
+projects go `IDLE` with a `COMPLETE` task.
+
+A typical session:
+
+```
+1. ./scripts/aristotle/check-jobs.sh --update       → found completed overnight jobs
+2. ./scripts/aristotle/retrieve-integrate.sh        → integrate those solutions
+3. Identify HARD sorries; package as *StatementOnly.lean
+4. ./scripts/aristotle/submit-batch.sh --target N   → submit the batch
+5. Work on the OPEN sorry manually
+6. Every ~10 min: ./scripts/aristotle/check-jobs.sh --update
+7. As jobs complete: ./scripts/aristotle/retrieve-integrate.sh
+8. End session: pending jobs continue overnight; next session's Step 1 picks
+   them up
+```
+
+**Every session starts with steps 1–2** — this prevents duplicate work and
+integrates overnight progress immediately.
+
+## Rate limits and concurrency
+
+- **Concurrency cap**: at most ~3–5 concurrent projects (shared server cap).
+  `submit-batch.sh` enforces this.
+- **Cooldown file**: on a 429 / rate-limit response, `submit-batch.sh` writes
+  a UTC timestamp ~5 minutes in the future to
+  `.loom/state/aristotle-rate-limit-until`; subsequent invocations short-circuit
+  until it passes.
+- **Scale-to-zero marker**: `.loom/state/aristotle-scaled-to-zero` — check it
+  (along with the cooldown file) before submitting fresh work.
+
+## Result caching
+
+Aristotle caches project results ~30 days server-side, so re-submitting the
+exact same file within that window returns the prior result quickly without
+burning fresh solver budget.
+
+## Toolchain caveat (Mathlib v4.28)
+
+Aristotle's backend vendors **Mathlib v4.28.0** and **rewrites submitted
+projects' `lean-toolchain` to v4.28.0** (observed in issue #38098; tracked
+against the toolchain flip in #38066). Our repo pins
+`proofs/lean-toolchain` (currently `leanprover/lean4:v4.26.0`), so:
+
+- A proof that Aristotle verified on v4.28 may not elaborate unchanged on our
+  toolchain (and vice versa). **Always rebuild retrieved proofs locally**
+  before counting them as integrated — `retrieve-integrate.sh` compares
+  against the original but does not replace a local verification build.
+- Do not commit a `lean-toolchain` that came back inside an Aristotle result
+  bundle.
+
+## Job tracking
+
+Local job state lives in `research/aristotle-jobs.json` (maintained by
+`check-jobs.sh --update` and `retrieve-integrate.sh`). Useful queries:
+
+```bash
+# Completed jobs awaiting integration
+jq '.jobs[] | select(.status == "completed")' research/aristotle-jobs.json
+
+# Companion-file integrations whose lemmas still need manual merging
+jq -r '.jobs[] | select(.status == "integrated" and .companion_file == true) | .outcome' \
+  research/aristotle-jobs.json
+```
+
+## Anti-patterns
+
+| Pattern | Why Wrong | Do Instead |
+|---------|-----------|------------|
+| Submit OPEN problems | Aristotle spins forever, wastes quota | Work manually |
+| Block the session waiting on a submission | Searches take minutes–hours | Submit async, keep working |
+| Never check results | Miss completed work | `check-jobs.sh --update` at session start |
+| Submit everything | Wastes budget on easy stuff | Triage per the tier table first |
+| Manual proof search for hours on a HARD sorry | Aristotle is better at tactic grinding | Submit after 10–15 min stuck |
+| Bundle many sorries in one file | Dilutes per-sorry search budget | One `*StatementOnly.lean` per theorem |
+
+## Success example: Erdős #728
+
+- **Input:** file with HARD sorries only
+- **Runtime:** 6 hours
+- **Output:** 1,416 lines of complete proof
+- **Result:** zero sorries, builds successfully

--- a/research/PROBLEMS-STRUCTURE.md
+++ b/research/PROBLEMS-STRUCTURE.md
@@ -155,6 +155,38 @@ repository:
 These are short lists; they exist so that an agent picking up the slug for the
 first time can find the surrounding code without grepping.
 
+## Session strategy by problem state (Solved/Unsolved Strategy)
+
+Shared convention for research sessions (referenced by
+`.lean/roles/researcher.md` and `.claude/commands/lean-research.md`, which
+previously each carried a verbatim copy). Before starting work on a problem,
+classify its state and choose strategy:
+
+**STUCK (sorries remain, no clear path forward):**
+- Do NOT generalize or broaden scope
+- Decompose into concrete subgoals or intermediate lemmas — but apply the
+  equivalent-strength check (defined in the researcher docs' "Follow-Up
+  Question Generation" section): a subgoal as strong as the target itself is a
+  blocked route, not decomposition progress
+- Try a different decomposition of the same target
+- Check if the blocking sorry can be submitted to Aristotle
+  (see [`ARISTOTLE-WORKFLOW.md`](./ARISTOTLE-WORKFLOW.md))
+- If 3+ sessions stuck on same sorry: flag as BLOCKED, move on
+
+**MAKING PROGRESS (some sorries eliminated this session):**
+- Continue current approach
+- Document which techniques worked for knowledge propagation
+
+**SOLVED (0 sorries, axiom count acceptable):**
+- Author/update the problem's adversarial checklist BEFORE claiming SOLVED
+  (element 6 above)
+- Generate 1-2 follow-up open questions (per the researcher docs' "Follow-Up
+  Question Generation" section, including its equivalent-strength check and
+  OQ-chain depth guard)
+- Look outward: generalizations, converses, sharp boundaries
+- Check if proved lemmas help other active research problems
+- Update technique index with successful approaches
+
 ## Lifecycle
 
 A `research/problems/<slug>/` entry exists exactly when:


### PR DESCRIPTION
Closes #38387

Final PR (C) of the three-PR plan on #38387 (A = #38390 engine check-in, B = #38392 role docs). This is the researcher-doc optimization pass from the survey's section 3.

## Per-change summary

### 1. Aristotle interface consolidation (top priority)
- **New `research/ARISTOTLE-WORKFLOW.md` (+214)** — single source of truth: v2 CLI pipeline (`uvx --from aristotlelib aristotle` via `scripts/aristotle/{cli-smoke-test,submit-batch,check-jobs,retrieve-integrate}.sh`), MCP-removal history (HTTP 426, issue #38098), project/task status model (`RUNNING`/`IDLE` + task-level terminal states), rate-limit cooldown file (`.loom/state/aristotle-rate-limit-until`) and scale-to-zero marker, submission tiers/classification, `*StatementOnly.lean` packaging, deprecated companion-file pattern, result caching, and the **"backend vendors Mathlib v4.28.0 and rewrites lean-toolchain" caveat** (exact wording verified against issue #38098; local pin is v4.26.0).
- **`lean-research.md`**: every removed-MCP reference replaced with CLI truth — Step 0, FRESH Step 5/6, REVISIT Step 4, and the entire ~163-line tail (Aristotle Integration / MCP tool table / Real-Time Usage / Strategic Delegation / Parallel Workflow / Overnight / Anti-Patterns) collapsed to a ~35-line quick reference + pointer. All script flags (`--update`, `--target`) verified against the checked-in scripts.
- **`researcher.md`**: CLI section condensed to a role quick reference (classification table + 4 commands + async/cooldown/toolchain essentials + pointer). The "Create/Update Aristotle Companion File" template was removed — it directly contradicted the doc's own deprecation note; the template's inclusion criteria and the deprecation rationale live on in ARISTOTLE-WORKFLOW.md.

### 2. Dead script references (all investigated)
All three are `dc9fdffa30` mass-deletion casualties (verified present at `dc9fdffa30^`, absent from main AND from the live main-tree disk), so per the issue spec they point at the Known-Gaps Ledger rather than being deleted:
- `.lean/scripts/knowledge-scores.sh` (3 refs) — annotated; interim: `claim-problem.sh claim-random` already does knowledge-prioritized (depth-first) selection, and the doc's jq snippet computes per-problem scores.
- `.lean/scripts/archive-sessions.sh` (2 refs) — annotated; manual archive procedure kept as the interim path.
- `.lean/scripts/research.sh` (3 `phase` refs) — annotated; interim: jq edit of `research/registry.json` (where the historical script's `phase` subcommand wrote).
- Bonus (found by the full-reference verification pass, same casualty class): `/lean-scout` (`.claude/commands/lean-scout.md`, 2 refs) and `.claude/skills/mathlib-contribution/` (red-team pass) annotated the same way; `./research/scripts/aristotle-submit.sh` (2 refs) replaced outright by its live successor `scripts/aristotle/submit-batch.sh`.
- New ledger rows added in `COMMON.md` for all of the above; `.lean/scripts/research.sh` row extended to researcher/phase-tracking.

### 3. Duplication extraction
- **Honesty Standards** (6 bullets verbatim in both docs) → reconciled into `COMMON.md`'s existing honesty section (added the one missing bullet: "a lemma that filled a gap 3 months ago…"); both role docs now carry a one-line reference.
- **Solved/Unsolved Strategy** (23 lines verbatim in both docs) → new "Session strategy by problem state" section in `research/PROBLEMS-STRUCTURE.md` (chosen because its SOLVED branch references elements 5/6 defined in that same file); both role docs now carry a 5-line reference. Cross-refs inside the moved text rephrased doc-neutrally.
- Pre-Work Assessment variants deliberately NOT extracted (they differ by design).

### 4. Axiom-elimination parity
`lean-research.md` Pre-Work Assessment now has "The Axiom Question (CHECK FIRST)" and the full "Axiom Elimination Priority" subsection, matching `researcher.md` (questions renumbered 1–4 to match; no anchors referenced the old numbers).

### 5. Enricher nit (PR B review)
`.lean/roles/enricher.md` Known-gaps: "audit tracker" → "enrichment tracker (`src/data/proofs/enrichment-tracker.json`)" (name verified against the historical `claim-target.sh`).

## Line deltas

| File | Before | After | Delta |
|---|---|---|---|
| `.claude/commands/lean-research.md` | 833 | 736 | **−97** |
| `.lean/roles/researcher.md` | 684 | 566 | **−118** |
| `research/ARISTOTLE-WORKFLOW.md` | — | 214 | +214 (new, single source) |
| `research/PROBLEMS-STRUCTURE.md` | 175 | 207 | +32 |
| `.lean/roles/COMMON.md` | 127 | 136 | +9 |
| `.lean/roles/enricher.md` | 221 | 222 | +1 |

Both role docs are meaningfully shorter (−215 combined) with the removed mass replaced by one shared doc instead of two drifting copies.

**Deliberately dropped (and why):**
- The MCP tool table and all `aristotle_prove`/`aristotle_submit`/`aristotle_status`/`aristotle_retrieve`/`aristotle_check_results`/`aristotle_informal`/`aristotle_list` usage guidance — the wrapper is dead (HTTP 426, confirmed again today); the async-vs-sync split it described maps onto submit-batch/check-jobs and is covered in the workflow doc.
- The "sync workflow for TRIVIAL sorries" advice ("use aristotle_prove for an instant answer") — no sync CLI equivalent in our pipeline, and it contradicted the standing rule that TRIVIAL sorries should be proved by hand; the rule now says prove them yourself.
- `researcher.md`'s companion-file creation template — contradicted its own deprecation section; preserved (as deprecated-legacy documentation) in ARISTOTLE-WORKFLOW.md.

## Verification
- Every concrete script/file reference in both docs now resolves in the worktree or carries a Known-Gaps Ledger pointer (extraction + existence check run over all path-like tokens).
- All #38385/#38389 sections and anchors intact: `#pin-the-statement-before-attacking-mandatory` (2 uses), `#follow-up-question-generation-after-solved` (1 use) still resolve; the adversarial-checklist, equivalent-strength, OQ-depth-guard, and independence-preservation sections are byte-untouched (checked via diff grep).
- Documented CLI flags (`check-jobs.sh --update`, `submit-batch.sh --target`) verified against the checked-in scripts.

## Why Closes
The issue's scope after the operator upgrade — survey, engine check-in (A, #38390), role docs (B, #38392), researcher-doc optimization (C, this PR) — is complete. The one substantive discovery still open (restoring the remaining `dc9fdffa30` mass-deleted scripts + the registry/db tracking decisions) is now tracked in follow-up **#38398** (`loom:triage`), and `COMMON.md`'s ledger pointer was updated accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)