### PR TITLE
Erdős 729 OQ-02: carry-boundary characterizations of the central binomial

### DIFF
--- a/proofs/Proofs/Erdos729DigitSumBound.lean
+++ b/proofs/Proofs/Erdos729DigitSumBound.lean
@@ -289,4 +289,42 @@ theorem choose_odd_iff_digitSum_add (a b : ℕ) :
   rw [dvd_iff_padicValNat_ne_zero hchoose, not_not]
   omega
 
+/-- **The carry criterion (strict subadditivity).**  The binomial `C(a+b,a)` is even iff
+adding `a` and `b` in base `2` produces at least one carry iff the binary digit-sum
+subadditivity `digitSum_two_add_le` is *strict*:
+    `2 ∣ C(a+b,a) ↔ s₂(a+b) < s₂(a) + s₂(b)`.
+The exact complement of the no-carry criterion `choose_odd_iff_digitSum_add`: a carry occurs
+iff a digit-sum bit is lost. -/
+theorem choose_even_iff_digitSum_lt (a b : ℕ) :
+    2 ∣ Nat.choose (a + b) a ↔
+      (Nat.digits 2 (a + b)).sum < (Nat.digits 2 a).sum + (Nat.digits 2 b).sum := by
+  haveI : Fact (Nat.Prime 2) := ⟨Nat.prime_two⟩
+  have hchoose : Nat.choose (a + b) a ≠ 0 := (Nat.choose_pos (Nat.le_add_right a b)).ne'
+  have hkey := v2_choose_add_digitSum a b
+  rw [dvd_iff_padicValNat_ne_zero hchoose]
+  omega
+
+/-- **Vanishing carry count ⟺ additive digit sums.**  The `2`-adic valuation of the central
+binomial vanishes exactly when the binary digit sums add without loss:
+    `v₂(C(a+b,a)) = 0 ↔ s₂(a+b) = s₂(a) + s₂(b)`.
+The valuation form of the no-carry criterion `choose_odd_iff_digitSum_add` (`v₂ = 0` is the
+carry count being zero). -/
+theorem v2_choose_eq_zero_iff_digitSum_add (a b : ℕ) :
+    padicValNat 2 (Nat.choose (a + b) a) = 0 ↔
+      (Nat.digits 2 (a + b)).sum = (Nat.digits 2 a).sum + (Nat.digits 2 b).sum := by
+  have hkey := v2_choose_add_digitSum a b
+  omega
+
+/-- **Positive carry count ⟺ strict subadditivity.**  The `2`-adic valuation of the central
+binomial is positive exactly when a carry is lost from the digit sums:
+    `0 < v₂(C(a+b,a)) ↔ s₂(a+b) < s₂(a) + s₂(b)`.
+Since `v₂(C(a+b,a)) = s₂(a) + s₂(b) − s₂(a+b)` is Kummer's carry count (`excess_eq_v2_choose`),
+this says "at least one carry" `⟺` "the digit-sum bound is strict" — the valuation form of
+`choose_even_iff_digitSum_lt`. -/
+theorem v2_choose_pos_iff_digitSum_lt (a b : ℕ) :
+    0 < padicValNat 2 (Nat.choose (a + b) a) ↔
+      (Nat.digits 2 (a + b)).sum < (Nat.digits 2 a).sum + (Nat.digits 2 b).sum := by
+  have hkey := v2_choose_add_digitSum a b
+  omega
+
 end Erdos729DigitSum


### PR DESCRIPTION
## Summary

Extends `Erdos729DigitSumBound.lean` (Legendre's formula / 2-adic valuation, base-2 Kummer). The file has the no-carry criterion `choose_odd_iff_digitSum_add` (`¬2∣C ↔ s₂(a+b) = s₂(a)+s₂(b)`). This PR adds the **strict (carry) side** of the boundary — the sharp equality-vs-strict-subadditivity follow-up noted in the entry's next steps — all one-liners from the Kummer identity `v2_choose_add_digitSum` via `omega`:

- `choose_even_iff_digitSum_lt` — `2 ∣ C(a+b,a) ↔ s₂(a+b) < s₂(a)+s₂(b)` (at least one carry = strict digit-sum subadditivity, the exact complement of the no-carry criterion).
- `v2_choose_eq_zero_iff_digitSum_add` — `v₂(C) = 0 ↔ s₂(a+b) = s₂(a)+s₂(b)` (valuation form of no-carry).
- `v2_choose_pos_iff_digitSum_lt` — `0 < v₂(C) ↔ s₂(a+b) < s₂(a)+s₂(b)` (valuation form of ≥1 carry).

## Verification

Builds clean under Lean v4.26.0. All 3 new theorems are axiom-free (`#print axioms` reports only `[propext, Classical.choice, Quot.sound]`); the file remains 0-axiom, 0-sorry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)