### PR TITLE
Research: erdos-634 — concrete non-abstract tiling witness for n=4 (medial reptiling cell)

### DIFF
--- a/proofs/Proofs/Erdos634MedialTilingOQ02.lean
+++ b/proofs/Proofs/Erdos634MedialTilingOQ02.lean
@@ -1,0 +1,156 @@
+/-
+# Erdős Problem #634 (OQ-02) — The medial subdivision is a concrete congruent tiling
+
+Source: Erdős Problem #634 (erdosproblems.com/634), a $25 problem on understanding
+all triples `(T, R, N)` such that triangle `T` tiles into `N` congruent copies of
+`R`. This file is the **capstone** of the medial-subdivision line, unifying three
+previously separate results about joining the side midpoints of a triangle:
+
+  * `Erdos634MedialCongruence.medial_four_congruent` — the four pieces are mutually
+    congruent (genuine isometry-congruence, unconditional);
+  * `Erdos634MedialCoveringOQ02.medial_covering` — the four closed pieces cover the
+    triangle (unconditional);
+  * `Erdos634MedialInteriorDisjointOQ02.medial_interiors_pairwise_disjoint` — over a
+    non-degenerate triangle the four relative interiors are pairwise disjoint.
+
+## The gap this closes
+
+The shipped base entry `Erdos634Problem.lean` defines dissectability through an
+**abstract** `axiom Tiles (T) (n) (pieces) : Prop` — an opaque covering/disjointness
+placeholder introduced (PR #36318) only to make Beeson's negative results
+(`¬IsDissectable 7`, `¬IsDissectable 11`) consistent. Because `Tiles` is opaque, the
+positive results there (`squares_dissectable`, `twenty_seven_dissectable`, …) can only
+be `sorry`: there is no introduction rule for an abstract predicate, so no positive
+dissection can actually be *witnessed*.
+
+This file supplies the missing concrete content for the base case `n = 4 = 2²`. We
+define a **non-abstract** tiling predicate `IsCongruentTiling A B C n pieces` — closed
+pieces cover the triangle, their relative interiors are pairwise disjoint, and all
+pieces are mutually congruent — stated purely in terms of `triHull` / `triHullOpen`
+(barycentric hulls) and `TriCongruent` (isometry-congruence), with **no** appeal to
+Lebesgue measure, ambient dimension, or an opaque axiom. We then prove, axiom-free,
+that every non-degenerate triangle admits such a tiling into four pieces
+(`medial_isCongruentTiling`, `exists_congruentTiling_four`): the concrete realiser of
+the `k = 2` square reptiling that the abstract `Tiles` axiom could only assert.
+
+Working over an arbitrary real normed space `V` (so everything specialises to the
+Euclidean plane).
+
+Tags: geometry, erdos, dissection, tiling, congruence, interior-disjoint, reptile
+-/
+
+import Mathlib
+import Proofs.Erdos634MedialCongruence
+import Proofs.Erdos634MedialInteriorDisjointOQ02
+
+set_option linter.unusedSectionVars false
+
+namespace Erdos634MedialTilingOQ02
+
+open Erdos634MedialCoveringOQ02 Erdos634MedialInteriorDisjointOQ02
+  Erdos634MedialCongruence
+
+variable {V : Type*} [NormedAddCommGroup V] [NormedSpace ℝ V]
+
+/-- A **concrete congruent tiling** of the ordered triangle `(A, B, C)` into `n`
+pieces, each an ordered vertex triple `pieces i`. Three conditions, all stated
+without any opaque axiom, Lebesgue measure, or dimension hypothesis:
+
+* `covers` — the closed barycentric hulls of the pieces cover the whole triangle;
+* `interior_disjoint` — the relative interiors (`triHullOpen`, all barycentric
+  coordinates strictly positive) of distinct pieces are disjoint;
+* `congruent` — every two pieces are isometry-congruent (`TriCongruent`).
+
+This is the honest, non-abstract replacement for the opaque `Tiles` predicate of
+`Erdos634Problem`: an inhabitant of `IsCongruentTiling` is a genuine witness that the
+triangle dissects into `n` mutually congruent, interior-disjoint covering pieces. -/
+structure IsCongruentTiling (A B C : V) (n : ℕ) (pieces : Fin n → V × V × V) : Prop where
+  /-- The closed pieces cover the triangle. -/
+  covers : triHull A B C =
+    ⋃ i, triHull (pieces i).1 (pieces i).2.1 (pieces i).2.2
+  /-- Distinct pieces have disjoint relative interiors. -/
+  interior_disjoint : ∀ i j, i ≠ j →
+    triHullOpen (pieces i).1 (pieces i).2.1 (pieces i).2.2 ∩
+      triHullOpen (pieces j).1 (pieces j).2.1 (pieces j).2.2 = ∅
+  /-- All pieces are mutually congruent. -/
+  congruent : ∀ i j, TriCongruent (pieces i) (pieces j)
+
+/-- The four medial triangles of `(A, B, C)`, packaged as a family indexed by
+`Fin 4` — the corner pieces at `A`, `B`, `C` and the central piece, in that order.
+Matches the vertex triples `T1, T2, T3, T4` of `Erdos634MedialCongruence`. -/
+noncomputable def medialPieces (A B C : V) : Fin 4 → V × V × V :=
+  ![T1 A B C, T2 A B C, T3 A B C, T4 A B C]
+
+@[simp] theorem medialPieces_zero (A B C : V) : medialPieces A B C 0 = T1 A B C := rfl
+@[simp] theorem medialPieces_one (A B C : V) : medialPieces A B C 1 = T2 A B C := rfl
+@[simp] theorem medialPieces_two (A B C : V) : medialPieces A B C 2 = T3 A B C := rfl
+@[simp] theorem medialPieces_three (A B C : V) : medialPieces A B C 3 = T4 A B C := rfl
+
+/-- **Capstone.** Over a non-degenerate triangle, the medial subdivision is a genuine
+concrete congruent tiling into four pieces: covering + interior-disjointness +
+mutual congruence, all axiom-free. This is the `k = 2` square reptiling realised as
+an inhabitant of the non-abstract `IsCongruentTiling` predicate — the positive case
+`Erdos634Problem.squares_dissectable 2` could only `sorry` through its opaque `Tiles`
+axiom. -/
+theorem medial_isCongruentTiling {A B C : V}
+    (hli : LinearIndependent ℝ ![B - A, C - A]) :
+    IsCongruentTiling A B C 4 (medialPieces A B C) := by
+  obtain ⟨dAB, dBC, dAC, dA4, dB4, dC4⟩ := medial_interiors_pairwise_disjoint hli
+  refine ⟨?_, ?_, ?_⟩
+  · -- covering
+    rw [medial_covering A B C]
+    ext x
+    simp only [Set.mem_union, Set.mem_iUnion]
+    constructor
+    · rintro (((h | h) | h) | h)
+      · exact ⟨0, by simpa using h⟩
+      · exact ⟨1, by simpa using h⟩
+      · exact ⟨2, by simpa using h⟩
+      · exact ⟨3, by simpa using h⟩
+    · rintro ⟨i, hi⟩
+      fin_cases i <;> tauto
+  · -- interior-disjoint
+    intro i j hij
+    fin_cases i <;> fin_cases j <;>
+      first
+        | exact absurd rfl hij
+        | exact dAB
+        | exact dBC
+        | exact dAC
+        | exact dA4
+        | exact dB4
+        | exact dC4
+        | (rw [Set.inter_comm]; exact dAB)
+        | (rw [Set.inter_comm]; exact dBC)
+        | (rw [Set.inter_comm]; exact dAC)
+        | (rw [Set.inter_comm]; exact dA4)
+        | (rw [Set.inter_comm]; exact dB4)
+        | (rw [Set.inter_comm]; exact dC4)
+  · -- mutual congruence
+    have c12 := cong_T1_T2 A B C
+    have c13 := cong_T1_T3 A B C
+    have c14 := cong_T1_T4 A B C
+    have c23 := c12.symm.trans c13
+    have c24 := c12.symm.trans c14
+    have c34 := c13.symm.trans c14
+    intro i j
+    fin_cases i <;> fin_cases j <;>
+      first
+        | exact TriCongruent.refl _
+        | exact c12 | exact c12.symm
+        | exact c13 | exact c13.symm
+        | exact c14 | exact c14.symm
+        | exact c23 | exact c23.symm
+        | exact c24 | exact c24.symm
+        | exact c34 | exact c34.symm
+
+/-- **Existence form.** Every non-degenerate triangle admits a concrete congruent
+tiling into four pieces. This is the `n = 4` positive dissection result, witnessed
+axiom-free — the concrete analogue of `Erdos634Problem.squares_dissectable 2`, whose
+opaque `Tiles` axiom prevents it from ever exhibiting such a witness. -/
+theorem exists_congruentTiling_four {A B C : V}
+    (hli : LinearIndependent ℝ ![B - A, C - A]) :
+    ∃ pieces : Fin 4 → V × V × V, IsCongruentTiling A B C 4 pieces :=
+  ⟨medialPieces A B C, medial_isCongruentTiling hli⟩
+
+end Erdos634MedialTilingOQ02

--- a/research/problems/erdos-634/knowledge.md
+++ b/research/problems/erdos-634/knowledge.md
@@ -135,3 +135,50 @@ subdivision is a bona-fide (non-abstract) tiling of an arbitrary non-degenerate
 triangle, completing the qualitative content of oq-02. What remains beyond oq-02 is
 purely the measure/area accounting (needs a Mathlib triangle-area input) and, for
 #634 proper, the still-open classification of achievable congruent-piece counts N.
+
+## Session (researcher-5, 2026-07-12): concrete non-abstract tiling witness for n=4
+
+New file `Erdos634MedialTilingOQ02.lean` — VERIFIED axiom-free (`lake env lean` +
+`lake build`, `#print axioms` = [propext, Classical.choice, Quot.sound] on both main
+theorems), 0 sorries / 0 problem axioms, 156 lines.
+
+**The gap this closes.** The base entry `Erdos634Problem.lean` routes dissectability
+through an **abstract** `axiom Tiles (T) (n) (pieces) : Prop` (PR #36318, added only to
+make Beeson's `¬IsDissectable 7/11` consistent). Because `Tiles` is opaque there is no
+introduction rule, so every *positive* dissection there (`squares_dissectable`,
+`twenty_seven_dissectable`, …) is stuck at `sorry`: no concrete tiling can be witnessed.
+
+This file supplies the missing concrete content at the base case `n = 4 = 2²`:
+
+- `IsCongruentTiling A B C n pieces` — a **non-abstract** structure (3 fields): closed
+  `triHull` pieces cover the triangle (`covers`, `⋃`-form), distinct pieces have disjoint
+  relative interiors (`interior_disjoint`, via `triHullOpen`), and all pieces are
+  mutually `TriCongruent` (isometry-congruent). No opaque axiom, no Lebesgue measure, no
+  dimension hypothesis — the honest replacement for the base file's `Tiles`.
+- `medialPieces A B C : Fin 4 → V×V×V` = `![T1,T2,T3,T4]` (corner-A, corner-B, corner-C,
+  central), with `@[simp]`/`rfl` index lemmas.
+- `medial_isCongruentTiling` (CAPSTONE) : over a non-degenerate triangle
+  (`LinearIndependent ℝ ![B-A, C-A]`) the medial subdivision inhabits
+  `IsCongruentTiling A B C 4 (medialPieces A B C)` — assembles the three previously
+  separate results (`medial_four_congruent` from the congruence entry, `medial_covering`,
+  `medial_interiors_pairwise_disjoint`) into ONE concrete tiling witness.
+- `exists_congruentTiling_four` : `∃ pieces, IsCongruentTiling A B C 4 pieces` — the
+  positive `n=4` dissection realised axiom-free, the concrete analogue of
+  `Erdos634Problem.squares_dissectable 2` that the opaque `Tiles` axiom cannot exhibit.
+
+Proof mechanics: `covers` via `medial_covering` + `⋃(Fin 4) = 4-union` by `fin_cases`;
+`interior_disjoint` and `congruent` via `fin_cases i <;> fin_cases j <;> first | …` over
+the 6 disjointness lemmas (with `Set.inter_comm` for reversed order) and the 6 congruence
+witnesses (`.symm`/`TriCongruent.refl`). All piece-projection reductions are `rfl`-defeq
+(the `medialPieces_*` `@[simp]` lemmas), so `exact` closes each case without simp.
+
+**Honesty.** This does NOT dissolve the base file's `Tiles` axiom (that abstract
+predicate still guards Beeson's negatives) and does NOT prove #634 itself (open $25
+problem, classification of achievable N). It provides the first concrete, machine-checked
+*positive* tiling witness for the reptiling base case — the k=2 square-reptiling cell —
+that the abstract framework could only assert. Over an arbitrary real normed space.
+
+### Next directions (unchanged frontier)
+- Planar (V = ℝ²) Lebesgue/area accounting to upgrade to a measure-theoretic tiling.
+- Iterate the medial subdivision (self-similarity) to realise `IsCongruentTiling` at
+  `n = 4^j`, and generalise the concrete witness to the full k-subdivision of OQ-01.

--- a/src/data/research/problems/erdos-634.json
+++ b/src/data/research/problems/erdos-634.json
@@ -21,20 +21,22 @@
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETED: Formalized the medial reptiling — the base case k=2 of the square reptiling central to Erdős #634 — fully and unconditionally over an arbitrary real normed space. The four medial triangles of any triangle A B C are proved pairwise congruent (genuine isometry-congruence, via explicit translations and one point reflection), with side lengths exactly half the original, exhibiting 4 = 2^2 congruent half-copies. New verified entry erdos-634-medial-congruence (Proofs/Erdos634MedialCongruence.lean), 0 axioms, 0 sorries. Also identified a latent soundness issue in the pre-existing axiomatized entry.",
+    "progressSummary": "COMPLETED (base problem axiomatized on main; #634 itself OPEN $25). Session 2026-07-12 (researcher-5): added Erdos634MedialTilingOQ02.lean — a concrete, non-abstract IsCongruentTiling predicate and an axiom-free proof that every non-degenerate triangle admits it for n=4 (the medial k=2 reptiling cell). This is the honest positive-case content the base file could only assert through its opaque Tiles axiom (squares_dissectable 2 is sorry). 0 axioms, 0 sorries, verified.",
     "builtItems": [
       "Proofs/Erdos634MedialCongruence.lean: 194 lines, 11 theorems, 6 definitions, 0 axioms, 0 sorries; #print axioms reports only propext/Classical.choice/Quot.sound.",
       "TriCongruent: isometry-congruence of ordered triangles, proved an equivalence relation and distance-preserving.",
       "medial_four_congruent: the four medial triangles are pairwise congruent (main theorem).",
       "Explicit isometry witnesses: translations (corner triangles) and a point reflection pointRefl (central triangle).",
       "medial_sides_halved: each piece has half the side lengths, exhibiting the k=2 square reptiling.",
-      "Gallery entry erdos-634-medial-congruence (meta.json + annotations.json)."
+      "Gallery entry erdos-634-medial-congruence (meta.json + annotations.json).",
+      "Proofs/Erdos634MedialTilingOQ02.lean: 156 lines, IsCongruentTiling structure (3 fields) + medialPieces + medial_isCongruentTiling (capstone) + exists_congruentTiling_four; 0 axioms/0 sorries (#print axioms = propext/Classical.choice/Quot.sound). Unifies medial_four_congruent + medial_covering + medial_interiors_pairwise_disjoint into one concrete n=4 tiling witness over an arbitrary real normed space."
     ],
     "insights": [
       "The four medial pieces are congruent via genuinely elementary isometries: three translations and one point reflection (180° rotation) for the central piece.",
       "No inner-product/Euclidean machinery is needed — translations and point reflections are isometries in any real normed space, so the result holds in general normed spaces and specialises to the plane.",
       "Side lengths halve exactly via midpoint_vsub_midpoint_same_left, so the medial subdivision is the 4 = 2^2 square reptiling base case.",
-      "SOUNDNESS FLAG: the pre-existing Erdos634Problem.lean uses an area-only Dissection (no covering/disjointness); this makes IsDissectable n true for every n (n identical (1/√n)-scaled pieces), contradicting its seven_not_dissectable / eleven_not_dissectable axioms — a latent inconsistency to repair."
+      "SOUNDNESS FLAG: the pre-existing Erdos634Problem.lean uses an area-only Dissection (no covering/disjointness); this makes IsDissectable n true for every n (n identical (1/√n)-scaled pieces), contradicting its seven_not_dissectable / eleven_not_dissectable axioms — a latent inconsistency to repair.",
+      "The base entry Erdos634Problem routes positive dissectability through an OPAQUE axiom Tiles : Prop, so its positive results (squares_dissectable etc.) are unavoidably sorry — an abstract Prop has no introduction rule, so no concrete tiling can be witnessed. Erdos634MedialTilingOQ02 supplies a NON-abstract IsCongruentTiling predicate (triHull covers + triHullOpen interior-disjoint + TriCongruent) and proves the medial subdivision inhabits it for n=4, axiom-free — the first concrete positive tiling witness of the k=2 reptiling cell."
     ],
     "mathlibGaps": [
       "No tiling/dissection API in Mathlib (covering + disjoint-interiors of polygonal pieces), so the full geometric dissection of #634 cannot yet be formalized; only the congruence of the pieces is captured here."


### PR DESCRIPTION
## Summary
Research session for **erdos-634** (Triangle Dissection into Congruent Pieces, a $25 Erdős problem). Adds one new verified proof file that supplies the first **concrete, axiom-free positive tiling witness** for the base case `n = 4 = 2²` — the medial (k=2) reptiling cell.

## The gap this closes
The shipped base entry `Erdos634Problem.lean` routes dissectability through an **abstract** `axiom Tiles (T) (n) (pieces) : Prop` (PR #36318, added only to make Beeson's `¬IsDissectable 7/11` consistent). Because `Tiles` is opaque, there is no introduction rule, so every *positive* dissection there (`squares_dissectable`, `twenty_seven_dissectable`, …) is unavoidably `sorry`: no concrete tiling can be exhibited.

`Proofs/Erdos634MedialTilingOQ02.lean` supplies the missing concrete content at `n = 4`:
- **`IsCongruentTiling A B C n pieces`** — a **non-abstract** structure (3 fields): closed `triHull` pieces cover the triangle, distinct pieces have disjoint relative interiors (`triHullOpen`), and all pieces are mutually `TriCongruent` (isometry-congruent). No opaque axiom, no Lebesgue measure, no dimension hypothesis.
- **`medial_isCongruentTiling`** (capstone) — over a non-degenerate triangle (`LinearIndependent ℝ ![B-A, C-A]`) the medial subdivision inhabits `IsCongruentTiling A B C 4 (medialPieces A B C)`, unifying the three previously separate results (`medial_four_congruent`, `medial_covering`, `medial_interiors_pairwise_disjoint`).
- **`exists_congruentTiling_four`** — `∃ pieces, IsCongruentTiling A B C 4 pieces`, the concrete analogue of `Erdos634Problem.squares_dissectable 2`.

## Files modified
- `proofs/Proofs/Erdos634MedialTilingOQ02.lean` (new, 156 lines)
- `research/problems/erdos-634/knowledge.md`, `src/data/research/problems/erdos-634.json`

## Verification
`lake env lean` + `lake build` clean (Lean v4.26.0, cached Mathlib). `#print axioms` on both main theorems reports **only** `[propext, Classical.choice, Quot.sound]` — 0 problem axioms, 0 sorries.

## Honesty
This does **not** dissolve the base file's `Tiles` axiom (it still guards Beeson's negatives) and does **not** resolve #634 itself (open, classification of achievable N). It is the first machine-checked *positive* tiling witness for the reptiling base case.

## Status
**Outcome**: progress (new axiom-free entry on a completed/axiomatized problem)
**Next Steps**: planar Lebesgue/area accounting for a measure-theoretic tiling; iterate to `n = 4^j` via self-similarity; generalise to the full k-subdivision.

🤖 Generated by researcher-5