### PR TITLE
Research: erdos-729-oq-02 - sharp 2-adic valuation of the central binomial coefficient

### DIFF
--- a/proofs/Proofs/Erdos729LegendreGeneral.lean
+++ b/proofs/Proofs/Erdos729LegendreGeneral.lean
@@ -379,6 +379,76 @@ theorem centralBinom_even (n : ℕ) (hn : 0 < n) : 2 ∣ Nat.centralBinom n := b
   have hpos : 0 < digitSum 2 n := digitSum_pos (p := 2) (by omega)
   omega
 
+/-! ### The sharp 2-adic valuation of the central binomial coefficient
+
+Kummer's carry count, at `p = 2`, collapses to the classical closed form
+`v_2(C(2n, n)) = s_2(n)` — the number of `1`s in the binary expansion of `n`.
+The key input is that doubling adds a trailing binary `0`, so `s_2(2n) = s_2(n)`
+(`digitSum_base_mul`), which cancels one of the two `s_2(n)` terms in the `m = n`
+Kummer identity.  The general-`p` exact form is recorded first. -/
+
+/-- **Kummer for the central binomial coefficient (exact multiplied form).**
+For every prime `p`,
+
+  `(p − 1)·v_p(C(2n, n)) + s_p(2n) = 2·s_p(n)`,
+
+the subtraction-free `m = n` specialisation of
+`sub_one_mul_padicValNat_choose_add_digitSum`.  Rearranged, the base-`p` carry
+count of `n + n` is `(2·s_p(n) − s_p(2n))/(p − 1)` (cf. `padicValNat_centralBinom_eq_div`),
+but the multiplied form avoids the natural-number division. -/
+theorem sub_one_mul_padicValNat_centralBinom (p n : ℕ) (hp : p.Prime) :
+    (p - 1) * padicValNat p (Nat.centralBinom n) + digitSum p (2 * n)
+      = 2 * digitSum p n := by
+  have hadd := sub_one_mul_padicValNat_choose_add_digitSum p n n hp
+  have hc : Nat.centralBinom n = (n + n).choose n := by
+    rw [Nat.centralBinom_eq_two_mul_choose, two_mul]
+  rw [hc, two_mul n]
+  omega
+
+/-- **The sharp 2-adic valuation of the central binomial coefficient.**
+
+  `v_2(C(2n, n)) = s_2(n)`,
+
+i.e. `C(2n, n)` is divisible by exactly `2` to the power of the number of `1`s in
+the binary expansion of `n`.  This is the classical Kummer specialisation: doubling
+`n` in base 2 never carries (`s_2(2n) = s_2(n)`), so the `m = n` carry count of
+`n + n` equals `s_2(n)`.  Not a named Mathlib lemma. -/
+theorem padicValNat_centralBinom_two_eq_digitSum (n : ℕ) :
+    padicValNat 2 (Nat.centralBinom n) = digitSum 2 n := by
+  have h := sub_one_mul_padicValNat_centralBinom 2 n Nat.prime_two
+  rw [digitSum_base_mul 2 n (by norm_num : 1 < 2)] at h
+  omega
+
+/-- **The central binomial valuation is positive for `n ≥ 1`** (sharpened evenness).
+`1 ≤ v_2(C(2n, n))` because `s_2(n) ≥ 1` for `n ≠ 0` (`digitSum_pos`).  Refines
+`centralBinom_even` from "divisible by 2" to an explicit valuation lower bound. -/
+theorem one_le_padicValNat_centralBinom_two {n : ℕ} (hn : 0 < n) :
+    1 ≤ padicValNat 2 (Nat.centralBinom n) := by
+  rw [padicValNat_centralBinom_two_eq_digitSum]
+  exact digitSum_pos (by omega)
+
+/-- **The base-2 digit sum of a power of two is `1`.**  Its binary expansion is a
+single leading `1` followed by zeros.  By induction: `s_2(2^{k+1}) = s_2(2·2^k)
+= s_2(2^k)` via `digitSum_base_mul`, with base case `s_2(1) = 1`. -/
+theorem digitSum_two_pow (k : ℕ) : digitSum 2 (2 ^ k) = 1 := by
+  induction k with
+  | zero =>
+      show (Nat.digits 2 (2 ^ 0)).sum = 1
+      rw [pow_zero, Nat.digits_def' (by norm_num : 1 < 2) (by norm_num : 0 < 1)]
+      simp
+  | succ k ih =>
+      rw [pow_succ, mul_comm (2 ^ k) 2, digitSum_base_mul 2 (2 ^ k) (by norm_num : 1 < 2), ih]
+
+/-- **At a power of two the central binomial coefficient carries exactly one `2`.**
+
+  `v_2(C(2·2^k, 2^k)) = 1`,
+
+the `n = 2^k` slice of `padicValNat_centralBinom_two_eq_digitSum` (`s_2(2^k) = 1`).
+Equivalently, `C(2^{k+1}, 2^k) ≡ 2 (mod 4)` — it is even but not a multiple of 4. -/
+theorem padicValNat_centralBinom_two_pow (k : ℕ) :
+    padicValNat 2 (Nat.centralBinom (2 ^ k)) = 1 := by
+  rw [padicValNat_centralBinom_two_eq_digitSum, digitSum_two_pow]
+
 /-! ### The carry-count form: bridging `digitSum` to Mathlib's `padicValNat_choose'`
 
 The Kummer identities above are phrased through the base-`p` **digit sum**.  Mathlib's
@@ -460,5 +530,10 @@ theorem not_dvd_choose_iff_no_carries (p m n : ℕ) {b : ℕ} (hp : p.Prime)
 #check @centralBinom_even
 #check @digitSum_defect_eq_sub_one_mul_carries
 #check @not_dvd_choose_iff_no_carries
+#check @sub_one_mul_padicValNat_centralBinom
+#check @padicValNat_centralBinom_two_eq_digitSum
+#check @one_le_padicValNat_centralBinom_two
+#check @digitSum_two_pow
+#check @padicValNat_centralBinom_two_pow
 
 end Erdos729Legendre

--- a/src/data/research/problems/erdos-729-oq-02.json
+++ b/src/data/research/problems/erdos-729-oq-02.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "SOLVED-CORE + OUTWARD EXTENSION (researcher-5 2026-07-11): Legendre core done earlier; this session added 5 axiom-free theorems building on sub_one_mul_padicValNat_factorial_digitSum — carry-free additive Kummer, base-p digit-sum subadditivity (Mathlib gap), and the sharp digit-sum divisibility criteria p∤C ↔ no carries / p∣C ↔ ≥1 carry (Mathlib gap). Host-lean verified 0 errors, #print axioms = [propext,Classical.choice,Quot.sound] only. Docker build hits transient SIGBUS-135 at C-codegen after clean 2.3s elaboration.",
+    "progressSummary": "SOLVED-CORE + OUTWARD EXTENSION (researcher-5 2026-07-12): added the sharp 2-adic valuation of the central binomial coefficient v_2(C(2n,n))=s_2(n) (previously only div-form + non-divisibility criterion + evenness existed), the general-p exact multiplied form, a sharpened evenness lower bound, s_2(2^k)=1, and v_2(C(2^{k+1},2^k))=1. 5 new theorems, 0 domain axioms ([propext,choice,Quot] only).",
     "builtItems": [
       "digitSum_prime_mul_add (p n r)(hp:1<p)(hr:r<p): (Nat.digits p (p*n+r)).sum = (Nat.digits p n).sum + r -- general base-p digit left-shift, Erdos729LegendrePrimeRecurrence.lean",
       "digitSum_prime_mul (p n)(hp:1<p): s_p(p*n)=s_p(n) -- r=0 invariant",
@@ -55,7 +55,12 @@
       "Erdos729LegendreGeneral.lean: not_dvd_choose_iff_digitSum_add — p∤C(m+n,m) ↔ s_p(m+n)=s_p(m)+s_p(n) (no base-p carries); via dvd_iff_padicValNat_ne_zero; NOT in Mathlib",
       "Erdos729LegendreGeneral.lean: dvd_choose_iff_digitSum_lt — p∣C(m+n,m) ↔ s_p(m+n)<s_p(m)+s_p(n) (≥1 carry); complement via subadditivity",
       "Erdos729LegendreGeneral.lean: padicValNat_choose_eq_div — division-form Kummer in gallery digitSum shape v_p(C)=(s_p(m)+s_p(n)-s_p(m+n))/(p-1)",
-      "digitSum_base_mul + digitSum_pos + 3 central-binomial theorems (Erdos729LegendreGeneral.lean, researcher-2): digitSum_base_mul (s_p(p*n)=s_p(n), digit-sum invariance under multiplication by base, Mathlib gap, via Nat.digits_def'+mul_mod_right+mul_div_cancel_left); digitSum_pos (n!=0 => s_p(n)>0, via getLast_digit_ne_zero+List.le_sum_of_mem); padicValNat_centralBinom_eq_div (Kummer v_p(C(2n,n))=(2*s_p(n)-s_p(2n))/(p-1)); not_dvd_centralBinom_iff (p not-dvd C(2n,n) iff s_p(2n)=2*s_p(n)); centralBinom_even (2|C(2n,n) for n>=1, classical, via base invariance at p=2). All axiom-free [propext,Classical.choice,Quot.sound]; host-lean elaboration 0 errors (docker exit-135 = known transient SIGBUS at C-codegen, NOT elaboration failure)."
+      "digitSum_base_mul + digitSum_pos + 3 central-binomial theorems (Erdos729LegendreGeneral.lean, researcher-2): digitSum_base_mul (s_p(p*n)=s_p(n), digit-sum invariance under multiplication by base, Mathlib gap, via Nat.digits_def'+mul_mod_right+mul_div_cancel_left); digitSum_pos (n!=0 => s_p(n)>0, via getLast_digit_ne_zero+List.le_sum_of_mem); padicValNat_centralBinom_eq_div (Kummer v_p(C(2n,n))=(2*s_p(n)-s_p(2n))/(p-1)); not_dvd_centralBinom_iff (p not-dvd C(2n,n) iff s_p(2n)=2*s_p(n)); centralBinom_even (2|C(2n,n) for n>=1, classical, via base invariance at p=2). All axiom-free [propext,Classical.choice,Quot.sound]; host-lean elaboration 0 errors (docker exit-135 = known transient SIGBUS at C-codegen, NOT elaboration failure).",
+      "Erdos729LegendreGeneral.lean: sub_one_mul_padicValNat_centralBinom — general-p exact form (p-1)·v_p(C(2n,n))+s_p(2n)=2·s_p(n)",
+      "Erdos729LegendreGeneral.lean: padicValNat_centralBinom_two_eq_digitSum — SHARP v_2(C(2n,n))=s_2(n) (classical Kummer specialisation, was missing)",
+      "Erdos729LegendreGeneral.lean: one_le_padicValNat_centralBinom_two — 1≤v_2(C(2n,n)) for n≥1 (sharpens centralBinom_even)",
+      "Erdos729LegendreGeneral.lean: digitSum_two_pow — s_2(2^k)=1",
+      "Erdos729LegendreGeneral.lean: padicValNat_centralBinom_two_pow — v_2(C(2·2^k,2^k))=1 (C(2^{k+1},2^k)≡2 mod 4)"
     ],
     "insights": [
       "The 2-adic doubling recurrence v_2((2n)!)=n+v_2(n!) is the p=2 shadow of a general-prime law: for EVERY prime p and residue 0<=r<p, v_p((p*n+r)!) = n + v_p(n!), the increment n being INDEPENDENT of r. So all p consecutive arguments pn, pn+1, ..., pn+(p-1) share one valuation step. Proof: (p-1)*v_p(m!)=m-s_p(m) (Mathlib) plus s_p(p*n+r)=s_p(n)+r and (p-1)*n+n=p*n, then cancel p-1>0. Not a named Mathlib lemma.",
@@ -68,7 +73,9 @@
       "Mathlib DOES carry Kummer: sub_one_mul_padicValNat_choose_eq_sub_sum_digits(_) and padicValNat_choose(_) (carries form) in NumberTheory/Padics/PadicVal/Basic.lean — but only the truncated-ℕ-subtraction shape. The subtraction-free additive rearrangement (p-1)·v_p(C)+s_p(m+n)=s_p(m)+s_p(n) is cleaner and is what yields subadditivity + the divisibility criteria as one-line omega corollaries.",
       "Genuine Mathlib GAPS confirmed (v4.26.0): (1) base-p digit-sum subadditivity s_p(m+n)≤s_p(m)+s_p(n) — only digit_sum_le (s_p(n)≤n) exists; (2) digit-sum criterion p∤C(m+n,m) ↔ s_p(m+n)=s_p(m)+s_p(n). Both now proven axiom-free in the gallery. p=2 case of the criterion = classical odd-binomial ↔ disjoint binary supports (Lucas/Kummer).",
       "digitSum_base_mul: s_p(p*n)=s_p(n) -- multiplying by base appends a trailing 0 digit ((p*n)%p=0, (p*n)/p=n via Nat.digits_def'), leaving digit sum unchanged. General reusable lemma (Mathlib gap). Its p=2 instance s_2(2n)=s_2(n) turns the no-carry criterion into classical 2|C(2n,n): at p=2, p not-dvd C(2n,n) iff s_2(2n)=2*s_2(n) forces s_2(n)=0 iff n=0.",
-      "Central binomial C(2n,n)=Nat.centralBinom n is the m=n case of the Kummer digit-sum machinery: v_p(C(2n,n))=(2*s_p(n)-s_p(2n))/(p-1) counts carries of n+n base p. digitSum_pos (n!=0 => s_p(n)>0) from getLast_digit_ne_zero (top base-p digit nonzero) + List.le_sum_of_mem."
+      "Central binomial C(2n,n)=Nat.centralBinom n is the m=n case of the Kummer digit-sum machinery: v_p(C(2n,n))=(2*s_p(n)-s_p(2n))/(p-1) counts carries of n+n base p. digitSum_pos (n!=0 => s_p(n)>0) from getLast_digit_ne_zero (top base-p digit nonzero) + List.le_sum_of_mem.",
+      "The sharp 2-adic valuation v_2(C(2n,n))=s_2(n) follows because doubling never carries in base 2 (s_2(2n)=s_2(n) via digitSum_base_mul), cancelling one of the two s_2(n) terms in the m=n Kummer identity.",
+      "At n=2^k the central binomial coefficient is exactly ≡2 mod 4 (v_2=1) since s_2(2^k)=1."
     ],
     "mathlibGaps": [],
     "nextSteps": [


### PR DESCRIPTION
## Summary
Research session for **erdos-729-oq-02** (Legendre's formula / base-2 Kummer). Adds the sharp closed form for the 2-adic valuation of the central binomial coefficient to `Erdos729LegendreGeneral.lean`.

## Progress
Before this session the file characterized `C(2n,n)` only via the division form `v_p = (2·s_p(n)−s_p(2n))/(p−1)`, the non-divisibility criterion, and plain evenness. This adds the **sharp** valuation and its consequences (5 new theorems, all 0 domain axioms):

- `padicValNat_centralBinom_two_eq_digitSum` — **`v_2(C(2n,n)) = s_2(n)`**, the classical Kummer specialisation (doubling never carries in base 2, so `s_2(2n)=s_2(n)` cancels one of the two `s_2(n)` terms).
- `sub_one_mul_padicValNat_centralBinom` — general-`p` exact multiplied form `(p−1)·v_p(C(2n,n)) + s_p(2n) = 2·s_p(n)` (division-free).
- `one_le_padicValNat_centralBinom_two` — `1 ≤ v_2(C(2n,n))` for `n ≥ 1`, sharpening `centralBinom_even` from "divisible by 2" to a valuation lower bound.
- `digitSum_two_pow` — `s_2(2^k) = 1`.
- `padicValNat_centralBinom_two_pow` — `v_2(C(2^{k+1}, 2^k)) = 1`, i.e. `C(2^{k+1},2^k) ≡ 2 (mod 4)`.

## Files Modified
- `proofs/Proofs/Erdos729LegendreGeneral.lean` (+75)
- `src/data/research/problems/erdos-729-oq-02.json` (knowledge)

## Verification
Elaborates clean via the repo toolchain (`lake env lean`), 0 errors/sorries. `#print axioms` on all new theorems = `[propext, Classical.choice, Quot.sound]` (no domain axioms).

## Status
**Outcome**: progress (outward extension of a solved core)
**Next Steps**: the converse `s_2(n)=1 ⟹ n=2^k` would upgrade `padicValNat_centralBinom_two_pow` to an iff (`v_2(C(2n,n))=1 ↔ n` a power of two); needs a base-2 digit-sum uniqueness lemma not currently in Mathlib.

🤖 Generated by researcher-5