### PR TITLE
Research: puiseux-theorem-wip-01 - exact ramification criterion for Yⁿ−xᵐ

### DIFF
--- a/proofs/Proofs/PuiseuxTheoremOQ03.lean
+++ b/proofs/Proofs/PuiseuxTheoremOQ03.lean
@@ -1623,4 +1623,70 @@ theorem y3MinusX2_root_valuation :
 #print axioms nthRoot_xm
 #print axioms y3MinusX2_root_valuation
 
+/-! ### The exact ramification criterion for `Yⁿ − xᵐ`: unramified ⟺ `n ∣ m`
+
+`binomial_root_not_in_range_of_not_isInt` proves only *one* direction — a
+non-integer exponent forces the root outside the Laurent base `K⸨x⸩`.  For the
+natural-number binomial family `Yⁿ − xᵐ` the condition is pinned **exactly**: the
+root `x^{m/n}` is unramified (lies in `K⸨x⸩`, is a genuine Laurent series with no
+fractional exponents) *iff* `n ∣ m`, i.e. iff the reduced ramification index
+`n / gcd(n, m)` collapses to `1`.  This is the precise integrality dichotomy the
+prose of `binomial_root_not_in_range_of_not_isInt` only gestured at, and it supplies
+the first *in-range* (unramified) worked example to sit opposite the ramified
+`cubeRoot_x_not_in_range`. -/
+
+/-- **Integrality of the binomial root exponent.**  For `n ≥ 1` the exponent `m/n`
+of the root `x^{m/n}` of `Yⁿ − xᵐ` is an integer iff `n ∣ m`.  Pure `ℚ`-arithmetic
+core of the ramification criterion (no dependence on `K`). -/
+theorem ynMinusXm_exponent_isInt_iff (n m : ℕ) (hn : 0 < n) :
+    (∃ k : ℤ, (m : ℚ) / (n : ℚ) = (k : ℚ)) ↔ n ∣ m := by
+  have hn' : (n : ℚ) ≠ 0 := Nat.cast_ne_zero.mpr hn.ne'
+  constructor
+  · rintro ⟨k, hk⟩
+    have hmn : (m : ℚ) = (k : ℚ) * (n : ℚ) := (div_eq_iff hn').mp hk
+    have hmnZ : (m : ℤ) = k * (n : ℤ) := by exact_mod_cast hmn
+    have hdvd : (n : ℤ) ∣ (m : ℤ) := ⟨k, by rw [hmnZ]; ring⟩
+    exact_mod_cast hdvd
+  · rintro ⟨c, rfl⟩
+    refine ⟨(c : ℤ), ?_⟩
+    push_cast
+    rw [div_eq_iff hn']
+    ring
+
+/-- **The exact ramification criterion for `Yⁿ − xᵐ`.**  The root `x^{m/n}` of the
+binomial `Yⁿ − xᵐ` lies in the unramified Laurent base `K⸨x⸩` **iff** `n ∣ m`.
+
+Forward: any Laurent preimage `z` has *integer* valuation
+(`laurentToPuiseux_addVal`), which via `binomial_root_not_in_range_of_not_isInt`
+forces the exponent `m/n` to be an integer, hence `n ∣ m`.  Backward: when `n ∣ m`
+the exponent is the integer `k = m/n`, and `x^{m/n} = x^k` is the image of the
+Laurent monomial `single k 1`.  Sharpens the one-directional
+`binomial_root_not_in_range_of_not_isInt` to a biconditional. -/
+theorem ynMinusXm_root_in_range_iff (n m : ℕ) (hn : 0 < n) :
+    (∃ z : HahnSeries ℤ K,
+        laurentToPuiseux z = puiseuxMonomial (K := K) ((m : ℚ) / (n : ℚ)))
+      ↔ n ∣ m := by
+  rw [← ynMinusXm_exponent_isInt_iff n m hn]
+  constructor
+  · rintro ⟨z, hz⟩
+    by_contra hcon
+    push_neg at hcon
+    exact binomial_root_not_in_range_of_not_isInt (K := K) n (m : ℚ) hcon ⟨z, hz⟩
+  · rintro ⟨k, hk⟩
+    refine ⟨HahnSeries.single k 1, ?_⟩
+    rw [laurentToPuiseux_single, puiseuxMonomial, hk]
+
+/-- Worked **unramified** instance: the root `x²` of `Y² − x⁴` lies in the Laurent
+base `K⸨x⸩` (`2 ∣ 4`, so the exponent `4/2 = 2` is an integer) — the first in-range
+witness of the binomial family, complementing the ramified `cubeRoot_x_not_in_range`
+and `puiseuxMonomial_half_not_in_range`. -/
+theorem ysqMinusX4_root_in_range :
+    ∃ z : HahnSeries ℤ K,
+      laurentToPuiseux z = puiseuxMonomial (K := K) (((4 : ℕ) : ℚ) / ((2 : ℕ) : ℚ)) :=
+  (ynMinusXm_root_in_range_iff (K := K) 2 4 (by norm_num)).mpr (by norm_num)
+
+#print axioms ynMinusXm_exponent_isInt_iff
+#print axioms ynMinusXm_root_in_range_iff
+#print axioms ysqMinusX4_root_in_range
+
 end PuiseuxTheoremOQ03

--- a/src/data/research/problems/puiseux-theorem-wip-01.json
+++ b/src/data/research/problems/puiseux-theorem-wip-01.json
@@ -44,13 +44,16 @@
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETE (verified fragment). The value-subgroup tower is now fully characterized order-theoretically: mono + directed + iSup=⊤ (Part XV) PLUS the order-embedding ramificationValueSubgroup_le_iff (≤ ⟺ ∣, converse of mono) and ramificationValueSubgroup_injective (faithful filtration), added 2026-07-12 (researcher-8), 0-axiom docker-verified. n↦(1/n)ℤ is an order embedding of (ℕ⁺,∣) into AddSubgroup ℚ. Full Newton–Puiseux (arbitrary polynomials + char-0 convergence) is NOT in Mathlib and remains the genuine open remainder (>1000L).",
+    "progressSummary": "COMPLETE (verified fragment) + ramification criterion (researcher-5 2026-07-12): sharpened the binomial ramification result to a biconditional — root x^{m/n} of Yⁿ−xᵐ is unramified (in Laurent base K⸨x⸩) ⟺ n∣m, plus the ℚ-arithmetic core ynMinusXm_exponent_isInt_iff and the first in-range (unramified) worked example Y²−x⁴. 3 new theorems, 0 domain axioms. Full Newton–Puiseux (arbitrary polynomials + char-0 convergence) remains the genuine open remainder (>1000L).",
     "builtItems": [
       "puiseux_binomial_isRoot in proofs/Proofs/PuiseuxTheorem.lean (binomial Puiseux root as Polynomial.IsRoot of Xⁿ-C(single m c); verified, 0 substantive axioms)",
       "puiseuxSubalgebra (K:CommRing): the Puiseux series form a K-subalgebra of HahnSeries Q K, upgrading the Subring; algebraMap_mem via isPuiseux_algebraMap (algebraMap = C = single 0) [VERIFIED]",
       "isPuiseux_inv_single (K:Field): (single m a)-inverse = single (-m) a-inverse is Puiseux — base case of inverse closure toward the subfield statement [VERIFIED]",
       "ramification_valueGroup_mono in proofs/Proofs/PuiseuxTheorem.lean (Part XIV): n|n_ prime -> level-n value-group set ⊆ level-n_ set; same-series witness via IsPuiseuxOfRamification.mono; valuation shadow of puiseuxRamificationSubfield_mono [VERIFIED 0/0]",
-      "iUnion_ramification_valueGroup in proofs/Proofs/PuiseuxTheorem.lean (Part XIV): ⋃_n level-n value groups = {v ≠ ⊤} = ℚ; each rational realized at its own denominator level via exists_ramification_orderTop_eq (q.num/q.den); valuation shadow of iSup_puiseuxRamificationSubfield [VERIFIED 0/0]"
+      "iUnion_ramification_valueGroup in proofs/Proofs/PuiseuxTheorem.lean (Part XIV): ⋃_n level-n value groups = {v ≠ ⊤} = ℚ; each rational realized at its own denominator level via exists_ramification_orderTop_eq (q.num/q.den); valuation shadow of iSup_puiseuxRamificationSubfield [VERIFIED 0/0]",
+      "PuiseuxTheoremOQ03.lean: ynMinusXm_exponent_isInt_iff — (∃k:ℤ, m/n=k) ↔ n∣m (ℚ-arithmetic core)",
+      "PuiseuxTheoremOQ03.lean: ynMinusXm_root_in_range_iff — SHARP iff: root x^{m/n} of Yⁿ−xᵐ unramified (in Laurent base K⸨x⸩) ↔ n∣m (sharpens one-directional binomial_root_not_in_range_of_not_isInt)",
+      "PuiseuxTheoremOQ03.lean: ysqMinusX4_root_in_range — first in-range (unramified) worked example, root x² of Y²−x⁴"
     ],
     "insights": [
       "The binomial/single-Newton-edge case is the entire algebraic content available without convergence machinery: y=single(m/n)a with aⁿ=c gives yⁿ=single m c via HahnSeries.single_pow; IsAlgClosed only supplies the n-th root a of c (char 0 NOT needed for this fragment).",
@@ -61,7 +64,8 @@
       "Value-group monotonicity is cleanest via the SAME series, not arithmetic on k/n: rintro v ⟨f,hf,hf0,rfl⟩ then ⟨f, hf.mono hdvd, hf0, rfl⟩ — IsPuiseuxOfRamification.mono reindexes f without moving its orderTop.",
       "Union backward direction: for q:ℚ realize at level ⟨q.den,q.pos⟩:ℕ+ with k=q.num; the inner ℚ-equality (q.num:ℚ)/((⟨q.den,q.pos⟩:ℕ+):ℚ)=q is exactly Rat.num_div_den q (PNat cast defeq to Nat cast), lifted to WithTop via exact_mod_cast.",
       "STRUCTURE (researcher-5, 2026-07-11): the level-n value group, previously only a raw Set (WithTop ℚ) of attained orderTop values, is literally the cyclic AddSubgroup.zmultiples ((n:ℚ)⁻¹) of ℚ. mem via AddSubgroup.mem_zmultiples_iff + zsmul_eq_mul (k • n⁻¹ = k/n); mono reuses the k/n=(k·d)/n' cast juggling (push_cast + div_eq_div_iff) from IsPuiseuxOfRamification.mono; iSup=⊤ realizes each q at level q.den via Rat.num_div_den. Gives the AddSubgroup-tower analogue of the subring tower iSup_puiseuxRamificationSubring.",
-      "Session 2026-07-12 (researcher-8): the value-subgroup side had mono/directed/iSup but only a ONE-DIRECTIONAL inclusion. Added the order-embedding characterization ramificationValueSubgroup_le_iff ((1/n)ℤ ≤ (1/n′)ℤ ↔ n∣n′, converse of mono) + ramificationValueSubgroup_injective (distinct levels ⟹ distinct subgroups). So n↦(1/n)ℤ is an order embedding of (ℕ⁺,∣) into AddSubgroup ℚ and the iSup=⊤ filtration is faithful. 0-axiom, docker-verified [3070]. Forward proof: generator 1/n∈level n′ ⟹ 1/n=k/n′ ⟹ n′=k·n ⟹ n∣n′ (div_eq_div_iff + linear_combination + PNat.dvd_iff)."
+      "Session 2026-07-12 (researcher-8): the value-subgroup side had mono/directed/iSup but only a ONE-DIRECTIONAL inclusion. Added the order-embedding characterization ramificationValueSubgroup_le_iff ((1/n)ℤ ≤ (1/n′)ℤ ↔ n∣n′, converse of mono) + ramificationValueSubgroup_injective (distinct levels ⟹ distinct subgroups). So n↦(1/n)ℤ is an order embedding of (ℕ⁺,∣) into AddSubgroup ℚ and the iSup=⊤ filtration is faithful. 0-axiom, docker-verified [3070]. Forward proof: generator 1/n∈level n′ ⟹ 1/n=k/n′ ⟹ n′=k·n ⟹ n∣n′ (div_eq_div_iff + linear_combination + PNat.dvd_iff).",
+      "The binomial root x^{m/n} of Yⁿ−xᵐ is unramified (integer valuation, lies in K⸨x⸩) exactly when n∣m, i.e. reduced ramification index n/gcd(n,m)=1. Prior file had only the one-directional not-isInt⟹ramified; the biconditional pins the exact ramification criterion."
     ],
     "mathlibGaps": [],
     "nextSteps": [


### PR DESCRIPTION
## Summary
Research session for **puiseux-theorem-wip-01** (Newton–Puiseux, OQ-03 combinatorial file). Sharpens the binomial ramification result in `PuiseuxTheoremOQ03.lean` from a one-directional implication to an exact biconditional.

## Progress
The file previously proved only `binomial_root_not_in_range_of_not_isInt` — a *non-integer* exponent `m/n` forces the root `x^{m/n}` of `Yⁿ−xᵐ` outside the Laurent base `K⸨x⸩` — and stated the `n ∣ m` criterion only in prose. This session pins it exactly (3 new theorems, all 0 domain axioms):

- `ynMinusXm_root_in_range_iff` — **the root `x^{m/n}` is unramified (lies in `K⸨x⸩`) ⟺ `n ∣ m`**, i.e. iff the reduced ramification index `n/gcd(n,m)` is `1`. Forward via `laurentToPuiseux_addVal` (image has integer valuation) + the existing one-directional lemma; backward by exhibiting the Laurent preimage `single (m/n) 1`.
- `ynMinusXm_exponent_isInt_iff` — the pure `ℚ`-arithmetic core `(∃ k:ℤ, m/n = k) ↔ n ∣ m`.
- `ysqMinusX4_root_in_range` — the first *in-range* (unramified) worked example (root `x²` of `Y²−x⁴`), complementing the ramified `cubeRoot_x_not_in_range` and `puiseuxMonomial_half_not_in_range`.

## Files Modified
- `proofs/Proofs/PuiseuxTheoremOQ03.lean` (+66)
- `src/data/research/problems/puiseux-theorem-wip-01.json` (knowledge)

## Verification
`lake build Proofs.PuiseuxTheoremOQ03` succeeds (3072 jobs). `#print axioms` on all 3 new theorems = `[propext, Classical.choice, Quot.sound]` (no domain axioms).

## Status
**Outcome**: progress (sharpens a verified fragment)
**Next Steps**: full Newton–Puiseux for arbitrary `P ∈ K⸨x⸩[Y]` (multi-edge slopes = root valuations) remains blocked on a ramified-embedding valuation API not in Mathlib v4.26.0 (>1000L).

🤖 Generated by researcher-5