### PR TITLE
Research: erdos-1138-oq-03-oq-01 - fully general envelope engine (power structure irrelevant)

### DIFF
--- a/proofs/Proofs/Erdos1138OQ03OQ01.lean
+++ b/proofs/Proofs/Erdos1138OQ03OQ01.lean
@@ -350,6 +350,62 @@ theorem gap_eventually_le_eps_of_rpow_bound {θ : ℝ} (hθ : θ < 1)
   rw [div_lt_iff₀ hx_pos] at hxlt
   exact le_of_lt hxlt
 
+/-! ### The fully general envelope engine: the power structure is genuinely irrelevant
+
+Every engine above assumes the envelope is a *power* `x^θ`, yet the docstrings repeatedly
+observe that "the exponent plays no role" in the sublinearity conclusion. This section
+removes the power assumption altogether: sublinearity `maxPrimeGap x / x → 0` follows from
+**any** eventual envelope `maxPrimeGap x ≤ f x` whose own normalisation `f x / x → 0`. The
+power engine `gap_littleo_of_rpow_bound` is the instance `f x = x^θ` (with `θ < 1`), and the
+parent's *conditional* Cramér branch — envelope `f x = C·(log x)²`, which is not a power of
+`x` — plugs into the very same engine. This is the true mathematical content: only
+sublinearity of the envelope matters, never its shape. -/
+
+/-- **Fully general sublinearity engine.** From *any* eventual envelope
+`maxPrimeGap x ≤ f x` whose normalisation `f x / x → 0`, the normalised maximal gap
+`maxPrimeGap x / x → 0`. A real-analysis squeeze between `0` and `f x / x`; the envelope
+need not be a power of `x` (subsuming both the `x^θ` and Cramér `(log x)²` branches). -/
+theorem gap_littleo_of_littleo_envelope (f : ℕ → ℝ)
+    (H : ∀ᶠ x : ℕ in atTop, (maxPrimeGap x : ℝ) ≤ f x)
+    (hf : Tendsto (fun x : ℕ => f x / x) atTop (𝓝 0)) :
+    Tendsto (fun x : ℕ => (maxPrimeGap x : ℝ) / x) atTop (𝓝 0) := by
+  have h_lo : ∀ x : ℕ, 0 ≤ (maxPrimeGap x : ℝ) / x := fun x =>
+    div_nonneg (Nat.cast_nonneg _) (Nat.cast_nonneg _)
+  have h_hi : ∀ᶠ x : ℕ in atTop, (maxPrimeGap x : ℝ) / x ≤ f x / x := by
+    filter_upwards [H, eventually_ge_atTop 1] with x hx hx1
+    have hx_pos : (0 : ℝ) < (x : ℝ) := by exact_mod_cast (lt_of_lt_of_le Nat.zero_lt_one hx1)
+    gcongr
+  exact squeeze_zero' (Eventually.of_forall h_lo) h_hi hf
+
+/-- **Fully general engine, little-o against `id`.** The `=o[atTop] id` idiom of
+`gap_littleo_of_littleo_envelope`: any envelope `maxPrimeGap x ≤ f x` with `f x / x → 0`
+gives `maxPrimeGap =o[atTop] id`. Generalises `gap_isLittleO_id_of_rpow_bound` off the
+power family. -/
+theorem gap_isLittleO_id_of_littleo_envelope (f : ℕ → ℝ)
+    (H : ∀ᶠ x : ℕ in atTop, (maxPrimeGap x : ℝ) ≤ f x)
+    (hf : Tendsto (fun x : ℕ => f x / x) atTop (𝓝 0)) :
+    (fun x : ℕ => (maxPrimeGap x : ℝ)) =o[atTop] (fun x : ℕ => (x : ℝ)) := by
+  refine (isLittleO_iff_tendsto' ?_).mpr (gap_littleo_of_littleo_envelope f H hf)
+  filter_upwards [eventually_ge_atTop 1] with x hx h0
+  have hxpos : (0 : ℝ) < (x : ℝ) := by exact_mod_cast Nat.lt_of_lt_of_le Nat.zero_lt_one hx
+  rw [h0] at hxpos
+  exact absurd hxpos (lt_irrefl 0)
+
+/-- **The power engine is an instance of the general engine.**  Re-derives
+`gap_littleo_of_rpow_bound` (envelope `x^θ`, `θ < 1`) from
+`gap_littleo_of_littleo_envelope`, exhibiting the general engine as a strict generalisation:
+the normalisation `x^θ / x = x^(θ-1) → 0` supplies the `hf` hypothesis. -/
+theorem gap_littleo_of_rpow_bound_via_envelope {θ : ℝ} (hθ : θ < 1)
+    (H : ∀ᶠ x : ℕ in atTop, (maxPrimeGap x : ℝ) ≤ (x : ℝ) ^ θ) :
+    Tendsto (fun x : ℕ => (maxPrimeGap x : ℝ) / x) atTop (𝓝 0) := by
+  refine gap_littleo_of_littleo_envelope (fun x => (x : ℝ) ^ θ) H ?_
+  have h_env : Tendsto (fun x : ℕ => (x : ℝ) ^ (-(1 - θ))) atTop (𝓝 0) :=
+    (tendsto_rpow_neg_atTop (by linarith)).comp tendsto_natCast_atTop_atTop
+  refine h_env.congr' ?_
+  filter_upwards [eventually_ge_atTop 1] with x hx1
+  have hx_pos : (0 : ℝ) < (x : ℝ) := by exact_mod_cast (lt_of_lt_of_le Nat.zero_lt_one hx1)
+  rw [show (-(1 - θ)) = θ - 1 by ring, Real.rpow_sub hx_pos, Real.rpow_one]
+
 -- ============================================================================
 -- Individual-gap bridge: from the maximal gap `sSup` back to actual gaps
 -- ============================================================================

--- a/src/data/research/problems/erdos-1138-oq-03-oq-01.json
+++ b/src/data/research/problems/erdos-1138-oq-03-oq-01.json
@@ -30,21 +30,25 @@
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETE + generalized: bhp_implies_gap_littleo (θ=0.525) now subsumed by the abstract engine gap_littleo_of_rpow_bound (any θ<1 power envelope ⟹ sublinear). Only assumption remains the deep parent axiom baker_harman_pintz (BHP theorem, unprovable from Mathlib). 0 sorries, 0 new axioms.",
+    "progressSummary": "COMPLETE + generalized further (researcher-5 2026-07-12): the power-envelope engines are now subsumed by a FULLY GENERAL envelope engine gap_littleo_of_littleo_envelope — any eventual envelope f with f x/x→0 forces sublinearity, removing the power assumption entirely (captures both x^θ and the non-power Cramér (log x)² branch). Added =o id form and a subsumption proof re-deriving the rpow engine. 3 new theorems, 0 new axioms. Only assumption remains the deep parent axiom baker_harman_pintz (BHP theorem).",
     "builtItems": [
       "gap_div_le_rpow_neg (Erdos1138OQ03OQ01.lean:37): maxPrimeGap x / x <= x^(-0.475) for x >= 25",
       "bhp_implies_gap_littleo (Erdos1138OQ03OQ01.lean:57): Tendsto (maxPrimeGap x / x) atTop (nhds 0)",
       "bhp_gap_eventually_le_eps (Erdos1138OQ03OQ01.lean:74): forall eps>0, eventually maxPrimeGap x <= eps*x",
       "Erdos1138OQ03OQ01.lean:186 gap_littleo_of_rpow_bound (source-exponent-parametric sublinearity engine). Elaboration-clean; olean-write blocked by fleet SIGBUS storm.",
       "gap_div_isBigO_rpow_neg (Erdos1138OQ03OQ01.lean, VERIFIED [propext,choice,Quot.sound,baker_harman_pintz]): explicit decay RATE of the normalised gap, maxPrimeGap x / x = O(x^(-0.475)) — sharpens bhp_implies_gap_littleo (Tendsto→0) to a quantitative polynomial-rate big-O; normalised counterpart of gap_isBigO_rpow.",
-      "gap_div_isBigO_rpow_sub_one_of_rpow_bound (Erdos1138OQ03OQ01.lean, VERIFIED axiom-free [propext,choice,Quot.sound]): abstract normalised-decay-rate engine, any eventual envelope maxPrimeGap x≤x^θ ⟹ maxPrimeGap x/x = O(x^(θ-1)); source-parametric twin of the concrete decay-rate result."
+      "gap_div_isBigO_rpow_sub_one_of_rpow_bound (Erdos1138OQ03OQ01.lean, VERIFIED axiom-free [propext,choice,Quot.sound]): abstract normalised-decay-rate engine, any eventual envelope maxPrimeGap x≤x^θ ⟹ maxPrimeGap x/x = O(x^(θ-1)); source-parametric twin of the concrete decay-rate result.",
+      "Erdos1138OQ03OQ01.lean: gap_littleo_of_littleo_envelope — fully general engine: ANY envelope maxPrimeGap x≤f x with f x/x→0 ⟹ maxPrimeGap x/x→0 (no power assumption)",
+      "Erdos1138OQ03OQ01.lean: gap_isLittleO_id_of_littleo_envelope — =o[atTop] id form",
+      "Erdos1138OQ03OQ01.lean: gap_littleo_of_rpow_bound_via_envelope — re-derives the power engine as an instance (subsumption proof)"
     ],
     "insights": [
       "BHP exponent 0.525 < 1: one division by x yields a negative power x^(-0.475) that vanishes at infinity - no finer analysis needed",
       "x^0.525 / x must be rewritten via Real.rpow_sub on x^(0.525-1); rewriting x as x^1 via rpow_one hits the numerator base and fails",
       "tendsto_rpow_neg_atTop is root-namespace (not Real.); the earlier survey mis-quoted it",
       "Abstract sublinearity engine: the specific BHP exponent 0.525 is inessential — ANY eventual power envelope maxPrimeGap x ≤ x^θ with θ<1 forces maxPrimeGap x / x → 0 (envelope x^θ/x = x^(θ-1) = x^(-(1-θ)) → 0 since 1-θ>0). gap_littleo_of_rpow_bound {θ} (hθ:θ<1) (H: ∀ᶠ x, gap ≤ x^θ). bhp_implies_gap_littleo is the θ=0.525 instance; future BHP tightenings (0.5+ε) plug in with no re-proof.",
-      "Added the explicit decay RATE of the normalised gap (previously only the qualitative Tendsto→0 was recorded): concrete gap_div_isBigO_rpow_neg = O(x^(-0.475)) and abstract gap_div_isBigO_rpow_sub_one_of_rpow_bound = O(x^(θ-1)). Also cleaned two dead `gcongr <;> exact hx` linter warnings. File VERIFIED via lake env lean (built parent olean first), EXIT 0, 0 warnings; 18→20 theorems."
+      "Added the explicit decay RATE of the normalised gap (previously only the qualitative Tendsto→0 was recorded): concrete gap_div_isBigO_rpow_neg = O(x^(-0.475)) and abstract gap_div_isBigO_rpow_sub_one_of_rpow_bound = O(x^(θ-1)). Also cleaned two dead `gcongr <;> exact hx` linter warnings. File VERIFIED via lake env lean (built parent olean first), EXIT 0, 0 warnings; 18→20 theorems.",
+      "The power structure x^θ is genuinely irrelevant to sublinearity: only f x/x→0 matters. The general envelope engine gap_littleo_of_littleo_envelope subsumes BOTH the x^θ branch (θ<1) AND the parent conditional Cramér (log x)² branch (not a power of x) under one squeeze. gap_littleo_of_rpow_bound is now provably its f x=x^θ instance."
     ],
     "mathlibGaps": [],
     "nextSteps": [],


### PR DESCRIPTION
## Summary
Research session for **erdos-1138-oq-03-oq-01** (unconditional sublinearity of prime gaps). The file's sublinearity engines all assume a *power* envelope `x^θ`, though their own docstrings repeatedly note "the exponent plays no role". This session removes the power assumption entirely, capturing the true mathematical content.

## Progress (3 new theorems, 0 new axioms)
- `gap_littleo_of_littleo_envelope` — **any** eventual envelope `maxPrimeGap x ≤ f x` whose normalisation `f x / x → 0` forces `maxPrimeGap x / x → 0`. The envelope need not be a power of `x`, so this one engine subsumes both the `x^θ` branch (`θ < 1`) and the parent's *conditional* Cramér branch (envelope `C·(log x)²`, not a power).
- `gap_isLittleO_id_of_littleo_envelope` — the `=o[atTop] id` idiom of the same.
- `gap_littleo_of_rpow_bound_via_envelope` — re-derives the existing power engine `gap_littleo_of_rpow_bound` as the instance `f x = x^θ`, exhibiting the general engine as a strict generalisation (the normalisation `x^θ/x = x^(θ-1) → 0` supplies the hypothesis).

## Files Modified
- `proofs/Proofs/Erdos1138OQ03OQ01.lean` (+56)
- `src/data/research/problems/erdos-1138-oq-03-oq-01.json` (knowledge)

## Verification
Full-file `lake build Proofs.Erdos1138OQ03OQ01` succeeds (7744 jobs, warning-free). `#print axioms` on all 3 new theorems = `[propext, Classical.choice, Quot.sound]` (no new domain axioms; the file remains dependent only on the parent's `baker_harman_pintz`).

## Status
**Outcome**: progress (unifying generalisation of the engine family)
**Next Steps**: instantiate the general engine at the Cramér `(log x)²` envelope to give the conditional sublinearity result through the same engine (needs `(log x)²/x → 0` from Mathlib).

🤖 Generated by researcher-5