### PR TITLE
Research: erdos-117-oq-01-incomplete-01 - submultiplicativity resolves the open question

### DIFF
--- a/proofs/Proofs/Erdos117OQ01Incomplete01.lean
+++ b/proofs/Proofs/Erdos117OQ01Incomplete01.lean
@@ -96,4 +96,43 @@ theorem limInf_limSup_mem_window :
   have hle := limInf_le_limSup
   exact ⟨c₁, c₂, hc1, hc12, ⟨hlo, hle.trans hhi⟩, ⟨hlo.trans hle, hhi⟩⟩
 
+/-! ### A sufficient condition that resolves the open question: submultiplicativity
+
+The results above only *characterise* the open question (as "is the oscillation
+positive?").  This section supplies the first *sufficient condition* that answers it,
+lifting the parent's Fekete result `submultiplicative_implies_convergence` into the
+oscillation / exponential-base language of this file: if the covering number `h` is
+submultiplicative (`h(m+n) ≤ h(m)·h(n)`), the oscillation vanishes, a single exponential
+base exists, and the open question is resolved *yes*.  Contrapositively, a genuinely
+oscillating growth rate (no exponential base) forces `h` to violate submultiplicativity —
+a concrete necessary condition on any counterexample to Erdős #117 OQ-01. -/
+
+/-- **Submultiplicativity ⟹ zero oscillation.**  If `h(m+n) ≤ h(m)·h(n)` for all `m, n`,
+then the oscillation `limsup − liminf` of the growth rate is exactly `0`.  Fekete's lemma
+(`submultiplicative_implies_convergence`) gives convergence, and
+`converges_iff_oscillation_zero` turns that into vanishing oscillation. -/
+theorem submultiplicative_implies_oscillation_zero
+    (hsub : ∀ m n : ℕ, h (m + n) ≤ h m * h n) :
+    growthRateLimSup - growthRateLimInf = 0 :=
+  converges_iff_oscillation_zero.mp (submultiplicative_implies_convergence hsub)
+
+/-- **Submultiplicativity ⟹ a single exponential base exists.**  The exponential-base form
+of `submultiplicative_implies_oscillation_zero`: a submultiplicative covering number `h` has
+a well-defined exponential base, so Erdős #117 OQ-01 is answered *yes* under this hypothesis.
+Fekete convergence (`submultiplicative_implies_convergence`) transported through
+`exponentialBaseExists_iff_converges`. -/
+theorem submultiplicative_implies_exponentialBaseExists
+    (hsub : ∀ m n : ℕ, h (m + n) ≤ h m * h n) :
+    exponentialBaseExists :=
+  exponentialBaseExists_iff_converges.mpr (submultiplicative_implies_convergence hsub)
+
+/-- **A counterexample must break submultiplicativity.**  The contrapositive: if no single
+exponential base exists (the growth rate genuinely oscillates), then `h` is *not*
+submultiplicative — there exist `m, n` with `h(m+n) > h(m)·h(n)`.  A concrete necessary
+condition on any counterexample to Erdős #117 OQ-01. -/
+theorem not_exponentialBaseExists_implies_not_submultiplicative
+    (hno : ¬ exponentialBaseExists) :
+    ¬ (∀ m n : ℕ, h (m + n) ≤ h m * h n) :=
+  fun hsub => hno (submultiplicative_implies_exponentialBaseExists hsub)
+
 end Erdos117OQ01Incomplete01

--- a/src/data/research/problems/erdos-117-oq-01-incomplete-01.json
+++ b/src/data/research/problems/erdos-117-oq-01-incomplete-01.json
@@ -29,13 +29,16 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (researcher-9, 2026-07-11): added base_mem_pyber_window — if h exhibits corrected exponential behavior at base c>1 then c lies in Pyber window [c₁,c₂], localizing the abstract base invariant to concrete Pyber constants. New reasoning VERIFIED via host lean targeted-import standalone (EXIT 0); note dual infra breakage this cycle (docker .lake .ir codegen SIGBUS + host .lake missing CategoryTheory oleans) so full-file import-Mathlib elaboration unavailable — verified new logic in isolation with faithful context. 3 structural axioms (h/h_pos/pyber_bounds) unchanged; the convergence question itself remains the open #117-OQ-01.",
+    "progressSummary": "PROGRESS (researcher-5, 2026-07-12): added the first SUFFICIENT-condition results to the oscillation companion. Submultiplicativity of h (h(m+n)≤h(m)·h(n)) ⟹ oscillation=0 and a single exponential base exists (Fekete, lifted from parent submultiplicative_implies_convergence into the oscillation/base language); contrapositive gives a necessary condition on any counterexample. 3 new theorems, 0 new axioms (inherits only h/h_pos/pyber_bounds). The convergence question itself remains open (#117-OQ-01).",
     "builtItems": [
       "Erdos117OQ01.base_implies_behavior — proved (was sorry): convergence to log c ⇒ ExponentialBehavior c for ε ∈ (0,c)",
       "Erdos117OQ01.ExponentialBehavior — corrected statement to ε ∈ (0,c) (unrestricted ∀ε>0 form is false)",
       "Lean 4.26 bit-rot repair of Erdos117OQ01.lean and Erdos117OQ01OQ01.lean (div/le_div iff₀ renames, le_liminf_of_le, two-IsBoundedUnder liminf_le_limsup, log_pow arg order, one_lt_exp_iff)",
       "Erdos117OQ01.behavior_implies_base + exponential_behavior_iff_base — converse of base_implies_behavior; exponential behavior at c ⟺ growthRate → log c",
-      "Erdos117OQ01OQ01.lean: base_mem_pyber_window — exponential base c localized to Pyber interval [c₁,c₂] (c₁≤c≤c₂). New reasoning VERIFIED host lean v4.26.0 targeted-import standalone (elab EXIT 0); full-file/sibling import-Mathlib blocked by host .lake missing CategoryTheory oleans + docker .ir corruption. 7→8 theorems."
+      "Erdos117OQ01OQ01.lean: base_mem_pyber_window — exponential base c localized to Pyber interval [c₁,c₂] (c₁≤c≤c₂). New reasoning VERIFIED host lean v4.26.0 targeted-import standalone (elab EXIT 0); full-file/sibling import-Mathlib blocked by host .lake missing CategoryTheory oleans + docker .ir corruption. 7→8 theorems.",
+      "Erdos117OQ01Incomplete01.lean: submultiplicative_implies_oscillation_zero — h(m+n)≤h(m)·h(n) ⟹ oscillation=0 (Fekete via converges_iff_oscillation_zero)",
+      "Erdos117OQ01Incomplete01.lean: submultiplicative_implies_exponentialBaseExists — submultiplicative h ⟹ exponential base exists (OQ resolved yes in this sub-case)",
+      "Erdos117OQ01Incomplete01.lean: not_exponentialBaseExists_implies_not_submultiplicative — any counterexample must break submultiplicativity"
     ],
     "insights": [
       "The 'exponential behavior at base c' notion is only a theorem for ε ∈ (0,c): the lower bound (c−ε)ⁿ ≤ h(n) fails for ε ≥ c because (ε−c)ⁿ at even n outgrows h(n) ≤ c₂ⁿ.",
@@ -43,7 +46,8 @@
       "Mathlib 4.26: div/le_div/lt_div iff lemmas are now the *_₀ GroupWithZero variants; Filter.liminf_le_limsup takes two IsBoundedUnder (≤ and ≥) args; Real.log_pow has signature (x : ℝ) (n : ℕ).",
       "positivity on (c-ε)^n consults the local context for the base's sign: it needs `0 < c-ε` as a named hypothesis (via linarith) before use, otherwise it fails to prove nonnegativity.",
       "The (hypothetical) exponential base c of ExponentialBehaviorCorrect is PINNED to Pyber window [c₁,c₂]: base_mem_pyber_window shows behavior at c>1 forces c₁≤c≤c₂. Pyber bounds trap growthRate in [log c₁, log c₂] eventually; behavior→convergence to log c (behavior_correct_implies_base); limit of a confined sequence stays confined (ge_of_tendsto/le_of_tendsto); exponentiate back through positivity. Ties the abstract base invariant (exponentialBehaviorCorrect_base_unique) to concrete constants — contrapositively no h has exponential behavior at a base outside its own Pyber window.",
-      "GOTCHA le_of_tendsto vs ge_of_tendsto: ge_of_tendsto (Tendsto f→a) (∀ᶠ b≤f) : b≤a (b≤limit); le_of_tendsto (Tendsto f→a) (∀ᶠ f≤b) : a≤b (limit≤b). For lower bound log c₁≤log c use ge_of_tendsto with hev_l:log c₁≤growthRate."
+      "GOTCHA le_of_tendsto vs ge_of_tendsto: ge_of_tendsto (Tendsto f→a) (∀ᶠ b≤f) : b≤a (b≤limit); le_of_tendsto (Tendsto f→a) (∀ᶠ f≤b) : a≤b (limit≤b). For lower bound log c₁≤log c use ge_of_tendsto with hev_l:log c₁≤growthRate.",
+      "First SUFFICIENT condition in the companion: the parent Fekete result submultiplicative_implies_convergence, lifted into the oscillation/base language, resolves Erdos #117 OQ-01 positively whenever h is submultiplicative. Contrapositive: a genuinely oscillating (no-base) h must be super-multiplicative at some (m,n) — a necessary condition on any counterexample. No new axioms (inherits only the 3 Pyber axioms)."
     ],
     "mathlibGaps": [],
     "nextSteps": [


### PR DESCRIPTION
## Summary
Research session for **erdos-117-oq-01-incomplete-01** (Erdős #117 OQ-01: does the growth rate `log h(n)/n` converge / does `h` have an exponential base?). The oscillation companion so far only *characterised* the open question ("is the oscillation `limsup − liminf` positive?"). This session adds the first *sufficient condition* that resolves it.

## Progress (3 new theorems, 0 new axioms)
Lifting the parent's Fekete result `submultiplicative_implies_convergence` into the oscillation / exponential-base language:
- `submultiplicative_implies_oscillation_zero` — `h(m+n) ≤ h(m)·h(n)` for all `m,n` ⟹ oscillation `= 0`.
- `submultiplicative_implies_exponentialBaseExists` — submultiplicative `h` ⟹ a single exponential base exists (Erdős #117 OQ-01 answered *yes* under this hypothesis).
- `not_exponentialBaseExists_implies_not_submultiplicative` — contrapositive: any counterexample (genuinely oscillating `h`) must violate submultiplicativity, a concrete necessary condition on counterexamples.

## Files Modified
- `proofs/Proofs/Erdos117OQ01Incomplete01.lean` (+39)
- `src/data/research/problems/erdos-117-oq-01-incomplete-01.json` (knowledge)

## Verification
Full-file `lake build Proofs.Erdos117OQ01Incomplete01` succeeds (7744 jobs, warning-free). `#print axioms` on all 3 new theorems = `[propext, Classical.choice, Quot.sound, Erdos117OQ01.h, Erdos117OQ01.h_pos, Erdos117OQ01.pyber_bounds]` — no new axioms beyond the inherited three Pyber-bound assumptions.

## Status
**Outcome**: progress (first sufficient condition; open question still open in general)
**Next Steps**: the convergence question itself remains #117-OQ-01. A natural next sufficient condition is the parent's `AsymptoticallyMultiplicative` predicate (currently a def without a convergence lemma).

🤖 Generated by researcher-5