### PR TITLE
Research: erdos-744-incomplete-01 — complement & complete-graph outer partition layer [VERIFIED axiom-free]

### DIFF
--- a/proofs/Proofs/Erdos744Problem.lean
+++ b/proofs/Proofs/Erdos744Problem.lean
@@ -773,6 +773,109 @@ theorem maxCut_add_edge_sandwich {V : Type*} [Fintype V] [LinearOrder V]
     maxCut G ≤ maxCut H ∧ maxCut H ≤ maxCut G + 1 :=
   ⟨maxCut_mono G H hsub, maxCut_add_edge_le G H a b hab hnew⟩
 
+/-
+# Part 3e: Complement and the complete graph
+
+The complement `Gᶜ` and the complete graph `Kₙ` are absent from the single-graph
+cut engine above, yet they carry the natural *outer* partition of the vertex-pair
+set. For any fixed 2-coloring `c`, an edge of `Kₙ` is monochromatic exactly when
+its two (same-colored) endpoints are joined in `G` *or* in `Gᶜ` — never both, never
+neither. So the monochromatic counts of `G` and `Gᶜ` partition those of `Kₙ`,
+which specializes (at a constant coloring) to the edge-count identity
+`edgeCount G + edgeCount Gᶜ = edgeCount Kₙ`. This is a genuinely new direction:
+it relates a graph to its complement rather than adding another corner to the
+single-graph max-cut / min-uncut square. -/
+
+/-- **The complete graph on `V`.** Every pair of distinct vertices is adjacent. -/
+def completeGraph' (V : Type*) : SimpleGraph' V where
+  Adj u v := u ≠ v
+  sym _ _ h := h.symm
+  loopless _ h := h rfl
+
+instance completeGraph'.instDecidableRelAdj {V : Type*} [DecidableEq V] :
+    DecidableRel (completeGraph' V).Adj :=
+  fun u v => inferInstanceAs (Decidable (u ≠ v))
+
+/-- **The complement `Gᶜ` of `G`.** Distinct vertices are adjacent in `Gᶜ`
+exactly when they are *non*-adjacent in `G`. -/
+def complement {V : Type*} (G : SimpleGraph' V) : SimpleGraph' V where
+  Adj u v := u ≠ v ∧ ¬ G.Adj u v
+  sym _ _ h := ⟨h.1.symm, fun hadj => h.2 (G.sym _ _ hadj)⟩
+  loopless _ h := h.1 rfl
+
+instance complement.instDecidableRelAdj {V : Type*} [DecidableEq V]
+    (G : SimpleGraph' V) [DecidableRel G.Adj] : DecidableRel (complement G).Adj :=
+  fun u v => inferInstanceAs (Decidable (u ≠ v ∧ ¬ G.Adj u v))
+
+/-- **Monochromatic-edge partition through the complement.** For a fixed
+2-coloring `c`, the monochromatic edges of `G` and of `Gᶜ` together exhaust the
+monochromatic edges of the complete graph: every same-colored pair `u < v` lies
+in exactly one of `G`, `Gᶜ`.
+
+    monochromaticEdges G c + monochromaticEdges Gᶜ c = monochromaticEdges Kₙ c. -/
+theorem monochromaticEdges_add_complement {V : Type*} [Fintype V] [LinearOrder V]
+    (G : SimpleGraph' V) [DecidableRel G.Adj] (c : V → Bool) :
+    monochromaticEdges G c + monochromaticEdges (complement G) c
+      = monochromaticEdges (completeGraph' V) c := by
+  -- Base set: the same-colored ordered pairs `u < v` (= `Kₙ`'s monochromatic edges).
+  set S := Finset.univ.filter (fun p : V × V => p.1 < p.2 ∧ c p.1 = c p.2) with hS
+  have hbase : monochromaticEdges (completeGraph' V) c = S.card := by
+    rw [hS, monochromaticEdges]
+    congr 1; ext p
+    simp only [Finset.mem_filter, Finset.mem_univ, true_and, completeGraph']
+    exact ⟨fun ⟨h1, _, h3⟩ => ⟨h1, h3⟩, fun ⟨h1, h3⟩ => ⟨h1, ne_of_lt h1, h3⟩⟩
+  have hG : monochromaticEdges G c = (S.filter (fun p => G.Adj p.1 p.2)).card := by
+    rw [hS, monochromaticEdges, Finset.filter_filter]
+    congr 1; ext p; simp only [Finset.mem_filter]; tauto
+  have hGc : monochromaticEdges (complement G) c
+      = (S.filter (fun p => ¬ G.Adj p.1 p.2)).card := by
+    rw [hS, monochromaticEdges, Finset.filter_filter]
+    congr 1; ext p
+    simp only [Finset.mem_filter, Finset.mem_univ, true_and, complement]
+    exact ⟨fun ⟨h1, ⟨_, h3⟩, h4⟩ => ⟨⟨h1, h4⟩, h3⟩,
+      fun ⟨⟨h1, h4⟩, h3⟩ => ⟨h1, ⟨ne_of_lt h1, h3⟩, h4⟩⟩
+  rw [hbase, hG, hGc, Finset.filter_card_add_filter_neg_card_eq_card]
+
+/-- `edgeCount` is the monochromatic count of the constant `true` coloring: every
+edge is monochromatic when all endpoints share a color. -/
+theorem monochromaticEdges_const_true {V : Type*} [Fintype V] [LinearOrder V]
+    (G : SimpleGraph' V) [DecidableRel G.Adj] :
+    monochromaticEdges G (fun _ => true) = edgeCount G := by
+  unfold monochromaticEdges edgeCount
+  congr 1; ext p; simp [Finset.mem_filter]
+
+/-- **Edge-count complementarity.** A graph and its complement partition the edges
+of the complete graph: `edgeCount G + edgeCount Gᶜ = edgeCount Kₙ`. The constant-
+coloring specialization of `monochromaticEdges_add_complement`. -/
+theorem edgeCount_add_edgeCount_complement {V : Type*} [Fintype V] [LinearOrder V]
+    (G : SimpleGraph' V) [DecidableRel G.Adj] :
+    edgeCount G + edgeCount (complement G) = edgeCount (completeGraph' V) := by
+  rw [← monochromaticEdges_const_true G, ← monochromaticEdges_const_true (complement G),
+      ← monochromaticEdges_const_true (completeGraph' V)]
+  exact monochromaticEdges_add_complement G (fun _ => true)
+
+/-- **The max-cuts of `G` and `Gᶜ` fit inside the complete graph.** Since each
+max-cut is bounded by its own edge count and the two edge counts partition
+`edgeCount Kₙ`, we get `maxCut G + maxCut Gᶜ ≤ edgeCount Kₙ`. -/
+theorem maxCut_add_maxCut_complement_le {V : Type*} [Fintype V] [LinearOrder V]
+    (G : SimpleGraph' V) [DecidableRel G.Adj] :
+    maxCut G + maxCut (complement G) ≤ edgeCount (completeGraph' V) := by
+  have h1 := maxCut_le_edgeCount G
+  have h2 := maxCut_le_edgeCount (complement G)
+  have h3 := edgeCount_add_edgeCount_complement G
+  omega
+
+/-- **The bipartition numbers of `G` and `Gᶜ` fit inside the complete graph.**
+Dual of `maxCut_add_maxCut_complement_le`:
+`bipartitionNumber G + bipartitionNumber Gᶜ ≤ edgeCount Kₙ`. -/
+theorem bipartitionNumber_add_bipartitionNumber_complement_le {V : Type*} [Fintype V]
+    [LinearOrder V] (G : SimpleGraph' V) [DecidableRel G.Adj] :
+    bipartitionNumber G + bipartitionNumber (complement G) ≤ edgeCount (completeGraph' V) := by
+  have h1 := bipartitionNumber_le_edgeCount G
+  have h2 := bipartitionNumber_le_edgeCount (complement G)
+  have h3 := edgeCount_add_edgeCount_complement G
+  omega
+
 /--
 **The f_k(n) Function**
 

--- a/research/problems/erdos-744-incomplete-01/knowledge.md
+++ b/research/problems/erdos-744-incomplete-01/knowledge.md
@@ -210,3 +210,50 @@ Counts: leanFile/meta 828→948 lines, 31→37 thm, defs 13, axiomCount 1 unchan
 status stays `axiomatized`. No follow-up OQ proposed (slug already at depth 1 but
 the engine is saturated; a Lipschitz variant would be a cosmetic sibling — 0
 questions is the honest choice here).
+
+## Session 2026-07-12 (researcher-3) — complement & complete graph: outer partition layer (VERIFIED)
+
+**Mode**: REVISIT (RICH). Prior sessions declared the single-graph max-cut/min-uncut engine
+saturated (extremal square + monotonicity + single-edge Lipschitz + ceil/floor forms all present).
+Rather than add a cosmetic 5th corner to the same square, opened a genuinely NEW direction absent
+from the entire file: the **complement `Gᶜ` and complete graph `Kₙ`**, which the cut engine had
+never referenced. All axiom-free (`#print axioms` = `[propext, Classical.choice, Quot.sound]` on all
+five — the tautological `rodl_tuza_theorem` axiom is UNTOUCHED per standing integrity finding).
+
+New Part 3e in `Erdos744Problem.lean`:
+- `completeGraph' V` (def) — `Adj u v := u ≠ v`, with `DecidableRel` instance (needs `DecidableEq V`).
+- `complement G` (def, `Gᶜ`) — `Adj u v := u ≠ v ∧ ¬ G.Adj u v`, `sym`/`loopless` from `G.sym`;
+  `DecidableRel` instance from `[DecidableEq V] [DecidableRel G.Adj]`.
+- **`monochromaticEdges_add_complement`** — the headline: for a FIXED coloring `c`,
+  `monochromaticEdges G c + monochromaticEdges Gᶜ c = monochromaticEdges Kₙ c`. Every same-colored
+  pair `u < v` lies in exactly one of `G`, `Gᶜ`. Proof mirrors `monochromaticEdges_add_bichromaticEdges`:
+  set base `S = filter (p.1<p.2 ∧ c p.1=c p.2)` (= `Kₙ`'s monochromatic edges via `ne_of_lt`),
+  rewrite `G`/`Gᶜ` counts as `S.filter (G.Adj)` / `S.filter (¬G.Adj)` (`filter_filter`), close with
+  `Finset.filter_card_add_filter_neg_card_eq_card`. The `p.1≠p.2` conjunct of `Gᶜ`/`Kₙ` is discharged
+  by `ne_of_lt h1` (NOT by `tauto` — it can't derive `≠` from `<`; supply an explicit `⟨…⟩` iff).
+- `monochromaticEdges_const_true` — `monochromaticEdges G (fun _ => true) = edgeCount G` (all-same
+  colour makes every edge monochromatic); the reusable bridge specializing coloring identities to
+  `edgeCount`.
+- **`edgeCount_add_edgeCount_complement`** — `edgeCount G + edgeCount Gᶜ = edgeCount Kₙ`: constant-
+  coloring specialization of the partition identity.
+- `maxCut_add_maxCut_complement_le` / `bipartitionNumber_add_bipartitionNumber_complement_le` —
+  `maxCut G + maxCut Gᶜ ≤ edgeCount Kₙ` and the min-uncut dual, each one `omega` off
+  `edgeCount_add_edgeCount_complement` + the respective `_le_edgeCount` bound.
+
+**Why not scaffolding.** Complement and complete graph are fundamental objects the file had never
+introduced; the partition `G ⊔ Gᶜ = Kₙ` at the coloring level is standard structural graph theory and
+orthogonal to the single-graph extremal square. `Kₙ`'s exact edge count `C(n,2)` is left open (a
+`Fintype`-pair-counting lemma, not needed here).
+
+**Verification.** `lake env lean Proofs/Erdos744Problem.lean` exit 0 (docker image build still hits the
+containerd blob I/O error; single-file elab against pinned Mathlib v4.26.0 oleans is the reusable path).
+Only pre-existing `unused variable` warnings in the untouched `f_*` theorems. `#print axioms` clean on
+all five new theorems.
+
+**Counts.** `Erdos744Problem.lean` 1011→1114 lines, 42→47 thm, 15→17 def, +2 instances, axiomCount 1
+(unchanged), 0 sorry. `meta.json` leanFile synced to actual (lineCount 969→1114 [was stale], theoremCount
+39→47, definitionCount 13→17); integrity fields unchanged (axiomCount=1, status=axiomatized).
+
+**No follow-up OQ.** Slug at depth 1; the natural next step (`C(n,2)` closed form, or complement of the
+`maxCut`/`bipartitionNumber` *values*) is a routine counting lemma, not a theory-level new direction —
+0 questions is the honest choice.

--- a/src/data/proofs/erdos-744/meta.json
+++ b/src/data/proofs/erdos-744/meta.json
@@ -192,10 +192,10 @@
       "Finset"
     ],
     "namespace": "Erdos744",
-    "lineCount": 969,
+    "lineCount": 1114,
     "axiomCount": 1,
-    "theoremCount": 39,
-    "definitionCount": 13,
+    "theoremCount": 47,
+    "definitionCount": 17,
     "path": "Proofs/Erdos744Problem.lean",
     "sorries": 0
   },

--- a/src/data/research/problems/erdos-744-incomplete-01.json
+++ b/src/data/research/problems/erdos-744-incomplete-01.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETE + extended (Part 3d added): the axiom-free bipartitionNumber/maxCut engine now includes single-edge Lipschitz continuity — adding one edge raises each extremal invariant by at most one, sharpening monotonicity with a matching +1 upper bound. File: 0 sorries, 1 axiom (honest Rödl–Tuza statement axiom, untouched), 37 theorems, 948 lines.",
+    "progressSummary": "COMPLETE + extended (Part 3e added): complement Gc and complete graph Kn introduced (both absent before); per-coloring partition monochromaticEdges G + Gc = Kn, its edgeCount specialization edgeCount G + Gc = Kn, and both cut-invariant sums bounded by edgeCount Kn. All 0-axiom (tautological Rodl-Tuza axiom untouched). File: 0 sorries, 1 axiom, 47 theorems, 1114 lines.",
     "builtItems": [
       "monochromaticEdges G c : ℕ — count of same-colored adjacent pairs u<v (Erdos744Problem.lean:99)",
       "bipartitionNumber G := inf over c:V→Bool of monochromaticEdges G c — total, sorry-free, no chromaticNumber axiom (Erdos744Problem.lean:115)",
@@ -39,7 +39,11 @@
       "edgeCount_mono / bichromaticEdges_mono / maxCut_mono: the cut-side monotonicity trio under edge addition (G⊆H ⇒ edgeCount, bichromaticEdges c, and maxCut all non-decreasing), dual to monochromaticEdges_mono/bipartitionNumber_mono. maxCut_mono via the optimal cut of G already separating maxCut G edges of H (Erdos744Problem.lean, Part 3c) [VERIFIED axiom-free: propext/Classical.choice/Quot.sound, lake env lean exit 0]",
       "monochromaticEdges_add_edge_le / bichromaticEdges_add_edge_le: per-coloring single-edge step bounds (Erdos744Problem.lean, Part 3d) [VERIFIED axiom-free]",
       "bipartitionNumber_add_edge_le / maxCut_add_edge_le: invariant rises by ≤1 per added edge [VERIFIED axiom-free]",
-      "bipartitionNumber_add_edge_sandwich / maxCut_add_edge_sandwich: both invariants are 1-Lipschitz under a single-edge edit [VERIFIED axiom-free]"
+      "bipartitionNumber_add_edge_sandwich / maxCut_add_edge_sandwich: both invariants are 1-Lipschitz under a single-edge edit [VERIFIED axiom-free]",
+      "completeGraph and complement (Gc) definitions + DecidableRel instances in Erdos744Problem.lean (Part 3e)",
+      "monochromaticEdges_add_complement: monochromaticEdges G c + monochromaticEdges Gc c = monochromaticEdges Kn c (per-coloring outer partition)",
+      "edgeCount_add_edgeCount_complement: edgeCount G + edgeCount Gc = edgeCount Kn (0-axiom)",
+      "maxCut_add_maxCut_complement_le & bipartitionNumber_add_bipartitionNumber_complement_le: cut invariants of G,Gc fit inside edgeCount Kn"
     ],
     "insights": [
       "The original bipartitionNumber was Nat.find ⟨witness, sorry⟩ over a metavariable predicate p — ill-formed, not a real definition; the right completion is a redefinition, not discharging the sorry.",
@@ -47,7 +51,9 @@
       "log_conjecture_false needs only f 4 n = 3 by definition (no Rödl-Tuza axiom): #print axioms shows it depends only on propext/Classical/Quot.",
       "The four extremal characterizations of the bipartitionNumber/maxCut engine form a 2x2 square: maxCut=0⟺edgeless, maxCut=edgeCount⟺bipartite, bipartitionNumber=0⟺bipartite, bipartitionNumber=edgeCount⟺edgeless. All four follow from the single complementarity identity bipartitionNumber+maxCut=edgeCount plus one of the ⟺ endpoints via omega.",
       "Both extremal invariants grow with the graph: bipartitionNumber_mono (min-uncut side) and maxCut_mono (max-cut side) are duals, each reducing to per-colouring monotonicity of monochromatic/bichromatic edge counts. This is the formal content of Erdős's original growth intuition for f_k, cleanly separated from the (false) asymptotic-divergence claim.",
-      "Single-edge Lipschitz continuity: adding one edge {a,b} raises both bipartitionNumber and maxCut by AT MOST 1 (they land in {v(G), v(G)+1}). This sharpens the earlier monotonicity (which only gave ≥) with a matching +1 upper bound — the exact modulus of continuity for the edge-edit metric. Proof: for a fixed coloring the monochromatic/bichromatic edge set of H is contained in that of G together with the single added ordered pair (a,b), so its card rises by ≤1 (Finset.card_insert_le); transfer through the optimal coloring."
+      "Single-edge Lipschitz continuity: adding one edge {a,b} raises both bipartitionNumber and maxCut by AT MOST 1 (they land in {v(G), v(G)+1}). This sharpens the earlier monotonicity (which only gave ≥) with a matching +1 upper bound — the exact modulus of continuity for the edge-edit metric. Proof: for a fixed coloring the monochromatic/bichromatic edge set of H is contained in that of G together with the single added ordered pair (a,b), so its card rises by ≤1 (Finset.card_insert_le); transfer through the optimal coloring.",
+      "Complement/complete-graph give a genuinely new direction orthogonal to the saturated single-graph max-cut/min-uncut square: G join Gc = Kn at the coloring level partitions monochromatic counts.",
+      "ne_of_lt discharges the p.1 != p.2 conjunct of complement/completeGraph adjacency; tauto cannot derive != from <, so filter-equality steps need explicit iff witnesses."
     ],
     "mathlibGaps": [],
     "nextSteps": [


### PR DESCRIPTION
## Summary
Research session for **erdos-744-incomplete-01** (Erdős #744, `bipartitionNumber`). The served definition-sorry remains phantom-complete and the single-graph max-cut/min-uncut engine was declared saturated by prior sessions. Rather than add a cosmetic sibling to that square, this session opens a **genuinely new direction absent from the whole file**: the complement `Gᶜ` and complete graph `Kₙ`.

## Progress
New **Part 3e** in `proofs/Proofs/Erdos744Problem.lean`:
- `completeGraph' V` and `complement G` (`Gᶜ`) definitions + `DecidableRel` instances.
- `monochromaticEdges_add_complement` — per-coloring outer partition: `monochromaticEdges G c + monochromaticEdges Gᶜ c = monochromaticEdges Kₙ c` (every same-colored pair `u<v` lies in exactly one of `G`, `Gᶜ`).
- `monochromaticEdges_const_true` — reusable bridge `monochromaticEdges G (fun _ => true) = edgeCount G`.
- `edgeCount_add_edgeCount_complement` — `edgeCount G + edgeCount Gᶜ = edgeCount Kₙ`.
- `maxCut_add_maxCut_complement_le`, `bipartitionNumber_add_bipartitionNumber_complement_le` — cut invariants of `G` and `Gᶜ` fit inside `edgeCount Kₙ`.

## Findings
- Complement/complete-graph is orthogonal to the single-graph extremal square: `G ⊔ Gᶜ = Kₙ` at the coloring level partitions monochromatic counts.
- `ne_of_lt` discharges the `p.1 ≠ p.2` conjunct; `tauto` cannot derive `≠` from `<`, so filter-equality steps use explicit iff witnesses.
- `Kₙ`'s exact edge count `C(n,2)` left open (routine pair-counting, not needed here) — no follow-up OQ.

## Verification
`lake env lean Proofs/Erdos744Problem.lean` exit 0 (docker image build still hits the containerd blob I/O error; single-file elab vs pinned Mathlib v4.26.0 oleans is the reusable path). Only the two pre-existing `unused variable` warnings in untouched `f_*` theorems. `#print axioms` on all five new theorems = `[propext, Classical.choice, Quot.sound]` — the tautological `rodl_tuza_theorem` axiom is **untouched**.

Counts: file 1011→1114 lines, 42→47 thm, 15→17 def, axiomCount 1 (unchanged), 0 sorry. `meta.json` leanFile counts synced (lineCount was stale at 969).

## Status
**Outcome**: progress (5 axiom-free theorems, 2 defs; 0 new axioms). Status stays `axiomatized`.
**Next Steps**: engine remains saturated; `C(n,2)` closed form is the only routine follow-on.

🤖 Generated by researcher-3