### PR TITLE
audit(erdos-434): correct stale sorry count 2→0 in meta.json

### DIFF
--- a/src/data/proofs/erdos-434/meta.json
+++ b/src/data/proofs/erdos-434/meta.json
@@ -19,7 +19,7 @@
       "coin-problem"
     ],
     "badge": "axiom",
-    "sorries": 2,
+    "sorries": 0,
     "erdosNumber": 434,
     "erdosUrl": "https://erdosproblems.com/434",
     "erdosProblemStatus": "solved",
@@ -69,9 +69,9 @@
       "Proved zero_representable, mem_representable, add_representable"
     ],
     "axiomCount": 4,
-    "lineCount": 372,
-    "assumptions": "4 axioms (kiss_2002, sylvester_frobenius, sylvester_count, frobenius_consecutive) and 2 sorries (nonrep_finite, topK_finite).",
-    "theoremCount": 15,
+    "lineCount": 465,
+    "assumptions": "4 axioms (kiss_2002, sylvester_frobenius, sylvester_count, frobenius_consecutive). 0 sorries: all supporting lemmas, including the finiteness results nonrep_finite and topK_finite, are fully proved.",
+    "theoremCount": 19,
     "definitionCount": 10,
     "additionalFiles": [
       "Proofs/Erdos434Aristotle.lean"
@@ -106,12 +106,12 @@
     ],
     "opens": [],
     "namespace": "Erdos434",
-    "lineCount": 372,
+    "lineCount": 465,
     "axiomCount": 4,
-    "theoremCount": 15,
+    "theoremCount": 19,
     "definitionCount": 10,
     "path": "Proofs/Erdos434Problem.lean",
-    "sorries": 2,
+    "sorries": 0,
     "additionalFiles": [
       "Proofs/Erdos434Aristotle.lean"
     ]
@@ -158,16 +158,16 @@
       "title": "The Extremal Problem",
       "startLine": 106,
       "endLine": 123,
-      "summary": "topK n k = Set.Icc (n-k+1) n. topK_card (sorry): |topK| = k. ExtremalFrobeniusQuestion: ∀ A valid, nCardNonRepresentable(A) ≤ nCardNonRepresentable(topK n k).",
-      "mathContext": "topK n k = Set.Icc (n-k+1) n. topK_card (sorry): |topK| = k. ExtremalFrobeniusQuestion: ∀ A valid, nCardNonRepresentable(A) $\\leq$ nCardNonRepresentable(topK n k)."
+      "summary": "topK n k = Set.Icc (n-k+1) n. topK_card (proved): |topK| = k. ExtremalFrobeniusQuestion: ∀ A valid, nCardNonRepresentable(A) ≤ nCardNonRepresentable(topK n k).",
+      "mathContext": "topK n k = Set.Icc (n-k+1) n. topK_card (proved): |topK| = k. ExtremalFrobeniusQuestion: ∀ A valid, nCardNonRepresentable(A) $\\leq$ nCardNonRepresentable(topK n k)."
     },
     {
       "id": "examples",
       "title": "Small Examples",
       "startLine": 124,
       "endLine": 193,
-      "summary": "Three examples: example_2_3 (sorry: NonRepresentable {2,3} = {1}), example_3_5_frobenius (sorry: frobeniusNumber {3,5} = 7), topK_5_2 (proved: topK 5 2 = {4, 5} via ext + simp + omega).",
-      "mathContext": "Mathematical content: Three examples: example_2_3 (sorry: NonRepresentable {2,3} = {1}), example_3_5_frobenius (sorry: frobeniusNumber {3,5} = 7), topK_5_2 (proved: topK 5 2 = {4, 5} via ext + simp + omega)."
+      "summary": "Three examples: example_2_3 (proved: NonRepresentable {2,3} = {1}), example_3_5_frobenius (proved: frobeniusNumber {3,5} = 7), topK_5_2 (proved: topK 5 2 = {4, 5} via ext + simp + omega).",
+      "mathContext": "Mathematical content: Three examples: example_2_3 (proved: NonRepresentable {2,3} = {1}), example_3_5_frobenius (proved: frobeniusNumber {3,5} = 7), topK_5_2 (proved: topK 5 2 = {4, 5} via ext + simp + omega)."
     },
     {
       "id": "kiss",
@@ -182,16 +182,16 @@
       "title": "Why topK is Optimal",
       "startLine": 213,
       "endLine": 241,
-      "summary": "larger_numbers_fewer_reps (sorry): nCardNonRepresentable({n-1,n}) > nCardNonRepresentable({1,2}) for n ≥ 2. Illustrates that larger numbers create more gaps in representability.",
-      "mathContext": "larger_numbers_fewer_reps (sorry): nCardNonRepresentable({n-1,n}) > nCardNonRepresentable({1,2}) for n $\\geq$ 2. Illustrates that larger numbers create more gaps in representability."
+      "summary": "larger_numbers_fewer_reps (proved):nCardNonRepresentable({n-1,n}) > nCardNonRepresentable({1,2}) for n ≥ 2. Illustrates that larger numbers create more gaps in representability.",
+      "mathContext": "larger_numbers_fewer_reps (proved):nCardNonRepresentable({n-1,n}) > nCardNonRepresentable({1,2}) for n $\\geq$ 2. Illustrates that larger numbers create more gaps in representability."
     },
     {
       "id": "sylvester",
       "title": "Sylvester-Frobenius Connection",
       "startLine": 242,
       "endLine": 263,
-      "summary": "Two axioms: sylvester_frobenius (frobeniusNumber {a,b} = ab-a-b for coprime a,b) and sylvester_count (count = (a-1)(b-1)/2). consecutive_count (sorry): specializes to {n-1,n} giving (n-2)(n-1)/2.",
-      "mathContext": "Axiomatized: Two axioms: sylvester_frobenius (frobeniusNumber {a,b} = ab-a-b for coprime a,b) and sylvester_count (count = (a-1)(b-1)/2). consecutive_count (sorry): specializes to {n-1,n} giving (n-2)(n-1)/2."
+      "summary": "Two axioms: sylvester_frobenius (frobeniusNumber {a,b} = ab-a-b for coprime a,b) and sylvester_count (count = (a-1)(b-1)/2). consecutive_count (proved):specializes to {n-1,n} giving (n-2)(n-1)/2.",
+      "mathContext": "Axiomatized: Two axioms: sylvester_frobenius (frobeniusNumber {a,b} = ab-a-b for coprime a,b) and sylvester_count (count = (a-1)(b-1)/2). consecutive_count (proved):specializes to {n-1,n} giving (n-2)(n-1)/2."
     },
     {
       "id": "greedy",
@@ -206,8 +206,8 @@
       "title": "Bounds on Non-Representables",
       "startLine": 278,
       "endLine": 292,
-      "summary": "nonrep_finite (sorry): coprime elements imply finite NonRepresentable. topK_finite (sorry): NonRepresentable(topK n k) is finite for k ≥ 2.",
-      "mathContext": "nonrep_finite (sorry): coprime elements imply finite NonRepresentable. topK_finite (sorry): NonRepresentable(topK n k) is finite for k $\\geq$ 2."
+      "summary": "nonrep_finite (proved): coprime elements imply finite NonRepresentable. topK_finite (proved): NonRepresentable(topK n k) is finite for k ≥ 2.",
+      "mathContext": "nonrep_finite (proved): coprime elements imply finite NonRepresentable. topK_finite (proved): NonRepresentable(topK n k) is finite for k $\\geq$ 2."
     },
     {
       "id": "problem433",
@@ -222,12 +222,12 @@
       "title": "Main Result",
       "startLine": 309,
       "endLine": 372,
-      "summary": "erdos_434_complete: proved by exact kiss_2002 application. topK_is_maximum (sorry): strongest formulation using IsGreatest, requires proving topK is valid and applying kiss_2002.",
-      "mathContext": "erdos_434_complete: proved by exact kiss_2002 application. topK_is_maximum (sorry): strongest formulation using IsGreatest, requires proving topK is valid and applying kiss_2002."
+      "summary": "erdos_434_complete: proved by exact kiss_2002 application. topK_is_maximum (proved):strongest formulation using IsGreatest, requires proving topK is valid and applying kiss_2002.",
+      "mathContext": "erdos_434_complete: proved by exact kiss_2002 application. topK_is_maximum (proved):strongest formulation using IsGreatest, requires proving topK is valid and applying kiss_2002."
     }
   ],
   "conclusion": {
-    "summary": "This formalization captures Erdős Problem #434 on the extremal Frobenius problem. Kiss (2002) proved that the 'top k' set {n-k+1, ..., n} maximizes the count of non-representable integers among all k-element subsets of {1, ..., n}. 2 sorries remain (finiteness lemmas) and 4 axioms (Kiss's theorem, Sylvester-Frobenius formula and count, consecutive Frobenius). Core representability theory and examples are fully proved.",
+    "summary": "This formalization captures Erdős Problem #434 on the extremal Frobenius problem. Kiss (2002) proved that the 'top k' set {n-k+1, ..., n} maximizes the count of non-representable integers among all k-element subsets of {1, ..., n}. The formalization rests on 4 axioms (Kiss's theorem, Sylvester-Frobenius formula and count, consecutive Frobenius); there are no sorries. Core representability theory, examples, and the finiteness lemmas are fully proved.",
     "implications": "**Theoretical Significance**: The problem connects the classical Frobenius (coin) problem with extremal combinatorics and numerical semigroup theory.\n\nThe greedy approach of selecting largest elements is optimal, contrasting with many optimization problems where greedy fails. The result also connects to computational complexity: while the Frobenius problem for ≥ 3 elements is NP-hard, the extremal problem has a clean, explicit optimal solution.",
     "openQuestions": [
       "Exact formula for the maximum count of non-representables as a function of n and k?",
@@ -276,5 +276,5 @@
       "note": "Comprehensive survey proving NP-hardness for ≥ 3 elements and collecting known results"
     }
   ],
-  "sorries": 2
+  "sorries": 0
 }


### PR DESCRIPTION
## Gallery Integrity Audit — erdos-434

**Proof**: erdos-434 (Erdős #434: Extremal Frobenius Problem)
**Problem**: meta.json claims **2 sorries** but `proofs/Proofs/Erdos434Problem.lean` has **0**.

## Evidence

**meta.json claimed**: `sorries: 2` (also in `leanFile.sorries` and top-level `sorries`); `assumptions` named "2 sorries (nonrep_finite, topK_finite)".

**Lean file shows** (verified by grep):
- `sorry` occurrences: **0**
- `axiom` declarations: **4** (`kiss_2002`, `sylvester_frobenius`, `sylvester_count`, `frobenius_consecutive`)
- No structures/typeclasses → no structure-encoded assumptions
- No `native_decide`
- 465 lines, 19 theorems/lemmas (meta said 372 / 15 — stale undercounts)

Both finiteness lemmas `nonrep_finite` and `topK_finite` are now proved theorems. This is an *understatement* (not an overclaim), but the metadata was factually wrong.

## Fix

- `meta.sorries`, `leanFile.sorries`, top-level `sorries`: `2 → 0`
- `lineCount`: `372 → 465`; `theoremCount`: `15 → 19`
- `assumptions` / `conclusion.summary`: drop the "2 sorries remain" wording
- Section summaries: relabel `topK_card`, `example_2_3`, `example_3_5_frobenius`, `larger_numbers_fewer_reps`, `consecutive_count`, `nonrep_finite`, `topK_finite`, `topK_is_maximum` from `(sorry)` to `(proved)`

Status `axiomatized` / badge `axiom` unchanged — the 4 genuine axioms remain correctly disclosed (`axiomCount: 4`).

---
Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)