### PR TITLE
Research: euler-polyhedral-formula-oq-02-oq-02 — Part XIX: Künneth convolution algebra (comm + point unit)

### DIFF
--- a/proofs/Proofs/EulerPolyhedralOQ02OQ02.lean
+++ b/proofs/Proofs/EulerPolyhedralOQ02OQ02.lean
@@ -1080,6 +1080,92 @@ theorem prodSurface_torus_betti_two : prodSurfaceBetti 1 1 2 = 6 := by
 theorem prodSurface_torus_euler : eulerFromBetti4 (prodSurfaceBetti 1 1) = 0 := by
   rw [prodSurface_euler_poincare]; norm_num
 
+-- ============================================================================
+-- Part XIX: The Künneth convolution — commutativity and the point as unit
+-- ============================================================================
+
+/-
+  Part XVIII computes *one* Künneth convolution `kunnethBetti (genusSurfaceBetti g)
+  (genusSurfaceBetti h)` and matches it to the product-surface Betti table.  The convolution
+  `kunnethBetti` is, however, a binary operation on Betti sequences in its own right, and it
+  carries the algebraic structure behind the symmetric-monoidal product of spaces:
+
+  * it is **commutative**, `b ⋆ c = c ⋆ b` (`kunnethBetti_comm`) — the homological shadow of
+    the flip homeomorphism `M × N ≅ N × M` under which the graded tensor product of homology
+    is symmetric; and
+  * the **point** `δ = (1, 0, 0, …)` (`pointBetti`) is a two-sided **unit**,
+    `δ ⋆ c = c = c ⋆ δ` (`kunnethBetti_pointBetti_left`/`_right`) — the homological shadow of
+    `pt × M ≅ M`, mirroring `pointCGB` as the identity of the Cartesian-product manifold
+    monoid (Part XVII, `prodCGB_point_chi`).
+
+  Together with the (standard, not formalized here) associativity of the Cauchy product these
+  exhibit `(Betti sequences, ⋆, δ)` as a commutative monoid, with the Betti-number assignment
+  a monoid homomorphism from the product monoid of Part XVII.  The commutativity yields a
+  concrete geometric corollary: the product-surface Betti table is symmetric in its two
+  genera (`prodSurfaceBetti_comm`), the homological shadow of `Σ_g × Σ_h ≅ Σ_h × Σ_g`.  The
+  proofs are finite-sum reindexing over `ℕ`, hence fully verified (0-axiom); the two
+  structure-encoded CGB assumptions are not invoked.
+-/
+
+/-- **The Künneth convolution is commutative: `b ⋆ c = c ⋆ b`.**  Reindexing the convolution
+    sum `∑_{i+j=k} bᵢ·cⱼ` by `i ↦ k − i` swaps the two factors — the algebraic form of the
+    homeomorphism `M × N ≅ N × M`, under which the graded tensor product of homology is
+    symmetric (no sign, the ranks being unsigned). -/
+theorem kunnethBetti_comm (b c : ℕ → ℕ) (k : ℕ) :
+    kunnethBetti b c k = kunnethBetti c b k := by
+  unfold kunnethBetti
+  rw [← Finset.sum_range_reflect (fun i => c i * b (k - i)) (k + 1)]
+  refine Finset.sum_congr rfl (fun i hi => ?_)
+  rw [Finset.mem_range] at hi
+  have h1 : k + 1 - 1 - i = k - i := by omega
+  have h2 : k - (k - i) = i := by omega
+  simp only [h1, h2]
+  ring
+
+/-- **Betti sequence of the point** `δ = (1, 0, 0, …)`: `b₀ = 1`, `bᵢ = 0` for `i ≥ 1`.  This
+    is the unit of the Künneth convolution, mirroring `pointCGB` as the unit of the
+    Cartesian-product manifold monoid (Part XVII). -/
+def pointBetti : ℕ → ℕ
+  | 0 => 1
+  | _ + 1 => 0
+
+/-- `b₀(pt) = 1`: the point is a single connected `0`-cell. -/
+@[simp] theorem pointBetti_zero : pointBetti 0 = 1 := rfl
+
+/-- `bᵢ(pt) = 0` for `i ≥ 1`: the point has no homology above degree `0`. -/
+@[simp] theorem pointBetti_succ (k : ℕ) : pointBetti (k + 1) = 0 := rfl
+
+/-- **The point is a left unit for the Künneth convolution: `δ ⋆ c = c`.**  Only the `i = 0`
+    term of `∑_{i} pointBettiᵢ · c_{k−i}` survives (`pointBetti` vanishes off degree `0`),
+    leaving `1 · c_k = c_k`.  Homologically, `H_*(pt × M) ≅ H_*(M)`. -/
+theorem kunnethBetti_pointBetti_left (c : ℕ → ℕ) (k : ℕ) :
+    kunnethBetti pointBetti c k = c k := by
+  unfold kunnethBetti
+  rw [Finset.sum_eq_single 0]
+  · simp
+  · intro i _ hi0
+    cases i with
+    | zero => exact absurd rfl hi0
+    | succ j => simp
+  · intro h
+    exact absurd (Finset.mem_range.mpr (Nat.succ_pos k)) h
+
+/-- **The point is a right unit for the Künneth convolution: `c ⋆ δ = c`.**  Immediate from
+    the left-unit law and commutativity; the point is therefore a genuine two-sided identity,
+    the homological shadow of `M × pt ≅ M`. -/
+theorem kunnethBetti_pointBetti_right (b : ℕ → ℕ) (k : ℕ) :
+    kunnethBetti b pointBetti k = b k := by
+  rw [kunnethBetti_comm, kunnethBetti_pointBetti_left]
+
+/-- **The product-surface Betti table is symmetric in its genera: `bₖ(Σ_g × Σ_h) =
+    bₖ(Σ_h × Σ_g)` for `k ≤ 4`.**  A concrete consequence of the commutativity of the Künneth
+    convolution (`kunnethBetti_comm`) applied to `prodSurfaceBetti_kunneth`: the palindrome
+    `(1, 2(g+h), 2+4gh, 2(g+h), 1)` is unchanged under `g ↔ h`, the homological shadow of the
+    flip homeomorphism `Σ_g × Σ_h ≅ Σ_h × Σ_g`. -/
+theorem prodSurfaceBetti_comm (g h : ℕ) {k : ℕ} (hk : k ≤ 4) :
+    prodSurfaceBetti g h k = prodSurfaceBetti h g k := by
+  rw [prodSurfaceBetti_kunneth g h hk, prodSurfaceBetti_kunneth h g hk, kunnethBetti_comm]
+
 end ChernGaussBonnet
 
 end

--- a/research/problems/euler-polyhedral-formula-oq-02-oq-02/knowledge.md
+++ b/research/problems/euler-polyhedral-formula-oq-02-oq-02/knowledge.md
@@ -191,3 +191,42 @@ Host elan `lean` (v4.26.0) with main's Mathlib LEAN_PATH:
 (Docker build gave transient exit-135 SIGBUS both times — olean corruption in
 the volume, a known false negative; host lean is authoritative — see
 researcher-9 note on exit-135.)
+
+---
+
+## Session 2026-07-12 (researcher-10) — Part XIX: Künneth convolution algebra
+
+**Mode:** REVISIT (mature axiomatized entry; add within the elementary/homological framework)
+**Outcome:** progress (1 def + 6 theorems, 0-axiom)
+
+Rebased a stale branch onto `origin/main` first (Part XVIII, PR #38402, had merged
+between claim and work). Part XVIII computes *one* Künneth convolution and matches it to
+the `Σ_g × Σ_h` Betti table; Part XIX proves the algebraic laws of the `kunnethBetti`
+convolution operation itself:
+
+- `kunnethBetti_comm` — the convolution `(b ⋆ c)(k) = Σ_{i+j=k} bᵢcⱼ` is commutative,
+  via `Finset.sum_range_reflect` reindexing `i ↦ k − i` (with `omega` on the two Nat
+  subtractions `k+1-1-i = k-i` and `k-(k-i) = i`). Homological shadow of `M × N ≅ N × M`.
+- `pointBetti` (def) `= (1, 0, 0, …)` + `pointBetti_zero/_succ` (@[simp]).
+- `kunnethBetti_pointBetti_left` — δ is a left unit (`Finset.sum_eq_single 0`, off-degree
+  terms killed by `pointBetti_succ`). `_right` follows by comm. Two-sided unit; shadow of
+  `pt × M ≅ M`, mirroring `pointCGB` as the Cartesian-product monoid identity (Part XVII).
+- `prodSurfaceBetti_comm` (concrete corollary) — `bₖ(Σ_g × Σ_h) = bₖ(Σ_h × Σ_g)` for
+  `k ≤ 4`, the palindrome symmetric under `g ↔ h`; shadow of `Σ_g × Σ_h ≅ Σ_h × Σ_g`.
+
+**Honest scope:** commutativity + two-sided unit only. Associativity of the Cauchy product
+(needed to claim a full commutative *monoid*) is standard but NOT formalized here — the
+prose says so. Not enumeration theater: these are the operation's structural laws, not more
+tables.
+
+### Verification
+Docker skipped (SIGBUS-prone per prior sessions). Host `lean` v4.26.0 elab against main's
+Mathlib LEAN_PATH: whole file **EXIT 0**, no errors/warnings (1171 L). `#print axioms` on
+all four new theorems = `[propext, Classical.choice, Quot.sound]` — no `sorryAx`, no
+`Lean.ofReduceBool`. 0-axiom preserved (2 structure-encoded CGB assumptions unchanged, not
+invoked). File: 102 `^theorem` + 17 def, 0 sorries, 0 axiom decls.
+
+### Frontier
+Unchanged: core BLOCKED on Mathlib v4.26 (no Pfaffian / characteristic-form integration /
+manifold χ). Convolution associativity would complete the commutative-monoid claim on Betti
+sequences — a self-contained next elementary increment (Cauchy-product associativity over ℕ).

--- a/src/data/research/problems/euler-polyhedral-formula-oq-02-oq-02.json
+++ b/src/data/research/problems/euler-polyhedral-formula-oq-02-oq-02.json
@@ -29,14 +29,15 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Added homological layer (Part XVI, +11 axiom-free theorems, theoremCount 73→84): Betti numbers of Σ_g, Poincaré duality, and the Euler–Poincaré derivation of χ=2−2g, orthogonal to the existing geometric/connected-sum development. Structure-encoded CGB identity unchanged (still axiomatized, 2 assumptions).",
+    "progressSummary": "PROGRESS: Part XIX abstracts Part XVIII's one Künneth table into the algebraic laws of the kunnethBetti convolution — commutativity + point-as-unit (two-sided), yielding prodSurfaceBetti symmetry. Core still BLOCKED on Mathlib v4.26 (no Pfaffian). Elementary/homological calculus now includes the convolution monoid structure. 0-axiom, host-lean elab EXIT 0.",
     "builtItems": [
       "CGBManifold structure encoding the Chern-Gauss-Bonnet identity ∫_M Pf(Ω)=(2π)^n·χ(M) with derived even-dimensionality, normalized integral, χ=0⇒∫Pf=0, sign matching, and Euler-number integrality.",
       "Verified sphere Euler characteristics (sphereEulerChar), (2π)^n normalization lemmas (cgbConst), and the 2×2 Pfaffian/determinant identity (pf2_sq_eq_det2).",
       "Functorial constructions sphereCGB / prodCGB / torusCGB and ClosedOddManifold, plus two_dim_gauss_bonnet recovering the n=1 classical case.",
       "connectedSumCGB (Part X) — connected-sum monoid on CGB manifolds: χ additive minus sphere (χ(M#N)=χM+χN−2), sphere = identity, T²#T² genus-2 surface has χ=−2 / ∫Pf=−4π (all 0-axiom-declaration, structure-encoded framework unchanged).",
       "genusSurfaceBetti + genusSurface_euler_poincare (χ=b₀−b₁+b₂) in EulerPolyhedralOQ02OQ02.lean Part XVI",
-      "genusSurfaceBetti_poincare_duality (bᵢ=b_{2−i}), genusSurface_first_betti_even, genusSurface_chi_eq_two_sub_first_betti, genusSurfaceCGB_chi_even (homological), genusSurface_betti_total (Σbᵢ=2+2g) — 11 new theorems, all axiom-free [propext,Classical.choice,Quot.sound]"
+      "genusSurfaceBetti_poincare_duality (bᵢ=b_{2−i}), genusSurface_first_betti_even, genusSurface_chi_eq_two_sub_first_betti, genusSurfaceCGB_chi_even (homological), genusSurface_betti_total (Σbᵢ=2+2g) — 11 new theorems, all axiom-free [propext,Classical.choice,Quot.sound]",
+      "kunnethBetti_comm, pointBetti (def), pointBetti_zero/_succ, kunnethBetti_pointBetti_left/_right, prodSurfaceBetti_comm in EulerPolyhedralOQ02OQ02.lean Part XIX"
     ],
     "insights": [
       "χ(S^m)=1+(-1)^m gives 2 in even and 0 in odd dimension — the parity that makes the Pfaffian (an even-dimensional invariant) the correct curvature integrand for Chern-Gauss-Bonnet.",
@@ -44,7 +45,8 @@
       "The 2×2 Pfaffian identity Pf²=det is the algebraic mechanism by which the higher-dimensional integrand reduces to the Gaussian curvature in the n=1 case, recovering classical Gauss-Bonnet ∫Pf=2πχ.",
       "Closed odd-dimensional manifolds have χ=0 (Poincaré duality), so the even-dimensional Pfaffian carries no topological information there — encoded as ClosedOddManifold and realized by odd spheres S^{2k+1}.",
       "Part XVI: χ(Σ_g)=2−2g has a purely homological origin via the Euler–Poincaré formula χ=Σ(−1)ⁱbᵢ with Betti numbers (b₀,b₁,b₂)=(1,2g,1); this is independent of the connected-sum/CGB geometric route in Parts XI–XV.",
-      "Poincaré duality bᵢ=b_{2−i} makes the Betti sequence palindromic and forces the middle Betti number b₁=2g even (rank of the symplectic intersection form on H₁), giving a homological re-derivation of genusSurfaceCGB_chi_even."
+      "Poincaré duality bᵢ=b_{2−i} makes the Betti sequence palindromic and forces the middle Betti number b₁=2g even (rank of the symplectic intersection form on H₁), giving a homological re-derivation of genusSurfaceCGB_chi_even.",
+      "Part XIX: kunnethBetti convolution is COMMUTATIVE (kunnethBetti_comm, via Finset.sum_range_reflect i↦k-i) with the point Betti sequence δ=(1,0,0,…) as two-sided UNIT (kunnethBetti_pointBetti_left/right) — the symmetric-monoidal structure of homology under products, mirroring pointCGB as the Cartesian-product monoid identity (Part XVII). Concrete corollary prodSurfaceBetti_comm: Σ_g×Σ_h Betti table symmetric in g↔h (homological shadow of Σ_g×Σ_h≅Σ_h×Σ_g). 0-axiom."
     ],
     "mathlibGaps": [
       "No Pfaffian of a matrix/curvature form",


### PR DESCRIPTION
## Summary
Research session for `euler-polyhedral-formula-oq-02-oq-02` (Chern–Gauss–Bonnet / discrete-to-smooth generalization). Mature axiomatized entry; this PR adds **Part XIX** within the elementary/homological framework.

Part XVIII (merged in #38402) computes *one* Künneth Betti convolution and matches it to the `Σ_g × Σ_h` Betti table. Part XIX proves the algebraic laws of the `kunnethBetti` convolution **operation itself** — the symmetric-monoidal structure of homology under products.

## Progress
- `kunnethBetti_comm` — `(b ⋆ c)(k) = Σ_{i+j=k} bᵢcⱼ` is **commutative**, via `Finset.sum_range_reflect` reindexing `i ↦ k−i`. Homological shadow of `M × N ≅ N × M`.
- `pointBetti` (def) `= (1, 0, 0, …)` with `pointBetti_zero/_succ` simp lemmas.
- `kunnethBetti_pointBetti_left`/`_right` — the point `δ` is a **two-sided unit** (`δ ⋆ c = c = c ⋆ δ`). Shadow of `pt × M ≅ M`, mirroring `pointCGB` as the Cartesian-product monoid identity (Part XVII).
- `prodSurfaceBetti_comm` — concrete corollary: `bₖ(Σ_g × Σ_h) = bₖ(Σ_h × Σ_g)` for `k ≤ 4`; the palindrome symmetric under `g ↔ h`, the homological shadow of `Σ_g × Σ_h ≅ Σ_h × Σ_g`.

Files: `proofs/Proofs/EulerPolyhedralOQ02OQ02.lean` (+1 def, +6 theorems), knowledge tracker.

## Findings
- **Honest scope:** commutativity + two-sided unit only. Associativity of the Cauchy product (needed for the full *commutative-monoid* claim on Betti sequences) is standard but **not formalized here** — the section prose states this. Noted as a self-contained next elementary increment.
- Core remains **BLOCKED** on Mathlib v4.26 (no Pfaffian / characteristic-form integration / manifold χ).

## Verification
- Host `lean` v4.26.0 elab against main's Mathlib `LEAN_PATH`: whole file **EXIT 0**, no errors/warnings (1171 L). Docker skipped (SIGBUS-prone per prior sessions — documented pattern).
- `#print axioms` on all four new theorems = `[propext, Classical.choice, Quot.sound]` — **no `sorryAx`, no `Lean.ofReduceBool`**. 0-axiom preserved; the 2 structure-encoded CGB assumptions are unchanged and not invoked.

## Status
**Outcome**: progress
**Next Steps**: Convolution associativity over ℕ (Cauchy-product associativity) to complete the commutative-monoid structure on Betti sequences.

🤖 Generated by researcher-10