### PR TITLE
Research: amgm-inequality-oq-03-oq-02-oq-02 - arbitrary-gap / TP2 log-concavity layer

### DIFF
--- a/proofs/Proofs/AmgmInequalityOQ03OQ02OQ02.lean
+++ b/proofs/Proofs/AmgmInequalityOQ03OQ02OQ02.lean
@@ -647,4 +647,74 @@ theorem logConcave_mul_geometric_normalised (p : ℕ → ℝ) (r : ℝ) (hp0 : p
     (fun k => p k * r ^ k) 0 = 1 := by
   simp [hp0]
 
+/-! ## Arbitrary-gap log-concavity: the exchange inequality and discrete TP2
+
+The defining hypothesis `p m · p (m+2) ≤ (p (m+1))²` compares indices that are exactly
+two apart. It is the tip of a much stronger structural property: log-concavity of a
+positive sequence is equivalent to the **total positivity of order 2** (`TP2`) of the
+`2 × 2` minors `p a · p b`, i.e. *concentrating* two indices (moving them closer together
+while preserving their sum) can only increase the product. The three results below extract
+that general "index-majorization" content directly from the ratio-antitone form
+`logConcave_iff_ratio_antitone`, each recovering the defining inequality as a special case:
+
+* `logConcave_exchange` — the single-step exchange `p i · p (j+1) ≤ p (i+1) · p j` for `i ≤ j`
+  (defining case `j = i+1`);
+* `logConcave_logSupermod` — the general master inequality `p a · p (b+c) ≤ p (a+c) · p b`
+  for `a ≤ b` and arbitrary shift `c` (discrete log-supermodularity / TP2);
+* `logConcave_spread` — arbitrary-gap log-concavity `p m · p (m+2d) ≤ (p (m+d))²`
+  (defining case `d = 1`).
+-/
+
+/-- **Exchange inequality.** For a positive log-concave sequence and `i ≤ j`, moving the two
+indices `i, j+1` one step *closer together* (to `i+1, j`) does not decrease the product:
+`p i · p (j+1) ≤ p (i+1) · p j`. This is the fundamental single exchange step of discrete
+log-supermodularity; the defining log-concavity `p i · p (i+2) ≤ (p (i+1))²` is the case
+`j = i+1`. Read straight off the ratio-antitone form: `p (j+1)/p j ≤ p (i+1)/p i`, cleared
+of positive denominators. -/
+theorem logConcave_exchange (p : ℕ → ℝ) (hpos : ∀ j, 0 < p j)
+    (hlc : ∀ m, p m * p (m + 2) ≤ (p (m + 1)) ^ 2) {i j : ℕ} (hij : i ≤ j) :
+    p i * p (j + 1) ≤ p (i + 1) * p j := by
+  have hanti := (logConcave_iff_ratio_antitone p hpos).mp hlc
+  have h : p (j + 1) / p j ≤ p (i + 1) / p i := hanti hij
+  rw [div_le_div_iff₀ (hpos j) (hpos i)] at h
+  nlinarith [h]
+
+/-- **Discrete log-supermodularity (TP2).** For a positive log-concave sequence, `a ≤ b`,
+and any shift `c`, one has `p a · p (b+c) ≤ p (a+c) · p b`: pushing the smaller index up by
+`c` (to `a+c`) while pulling the larger index down by `c` (from `b+c` to `b`) — a move that
+concentrates the pair while keeping the total `(a) + (b+c) = (a+c) + b` fixed — can only
+increase the product. Equivalently, every `2 × 2` minor `p a · p (b+c) - p (a+c) · p b` of
+the Hankel-type matrix is `≤ 0`, i.e. the sequence is totally positive of order 2. Proved by
+induction on `c`: the successor step multiplies the induction hypothesis by the antitone
+consecutive ratio at the base index `a+c ≤ b+c` and cancels the common positive factor
+`p (a+c)`. The defining inequality and `logConcave_exchange` are the cases `c = 1`. -/
+theorem logConcave_logSupermod (p : ℕ → ℝ) (hpos : ∀ j, 0 < p j)
+    (hlc : ∀ m, p m * p (m + 2) ≤ (p (m + 1)) ^ 2) {a b : ℕ} (hab : a ≤ b) (c : ℕ) :
+    p a * p (b + c) ≤ p (a + c) * p b := by
+  have hanti := (logConcave_iff_ratio_antitone p hpos).mp hlc
+  induction c with
+  | zero => simp
+  | succ c ih =>
+    have hr : p (b + c + 1) / p (b + c) ≤ p (a + c + 1) / p (a + c) :=
+      hanti (by omega : a + c ≤ b + c)
+    rw [div_le_div_iff₀ (hpos (b + c)) (hpos (a + c))] at hr
+    have key : (p a * p (b + c + 1)) * p (a + c) ≤ (p (a + c + 1) * p b) * p (a + c) := by
+      nlinarith [mul_le_mul_of_nonneg_left hr (hpos a).le,
+        mul_le_mul_of_nonneg_right ih (hpos (a + c + 1)).le]
+    exact le_of_mul_le_mul_right key (hpos (a + c))
+
+/-- **Arbitrary-gap log-concavity.** For a positive log-concave sequence, the log-concavity
+inequality holds across *any* even gap `2d`, not just the defining gap `2`:
+`p m · p (m + 2d) ≤ (p (m+d))²`. The endpoints `m` and `m+2d` are the extreme pair with
+midpoint `m+d`, so this is the `a := m`, `b := m+d`, `c := d` instance of
+`logConcave_logSupermod`. Taking `d = 1` recovers the defining `p m · p (m+2) ≤ (p (m+1))²`. -/
+theorem logConcave_spread (p : ℕ → ℝ) (hpos : ∀ j, 0 < p j)
+    (hlc : ∀ m, p m * p (m + 2) ≤ (p (m + 1)) ^ 2) (m d : ℕ) :
+    p m * p (m + 2 * d) ≤ (p (m + d)) ^ 2 := by
+  have h := logConcave_logSupermod p hpos hlc (Nat.le_add_right m d) d
+  have e : m + d + d = m + 2 * d := by ring
+  rw [e] at h
+  rw [pow_two]
+  exact h
+
 end MaclaurinLogConcave

--- a/research/problems/amgm-inequality-oq-03-oq-02-oq-02/knowledge.md
+++ b/research/problems/amgm-inequality-oq-03-oq-02-oq-02/knowledge.md
@@ -166,3 +166,34 @@ Rolle machinery not in Mathlib 4.26. A tractable general-but-partial route: prov
 reversal identity eₖ(x) = (∏x)·e_{n−k}(1/x) for x with no zero, which upgrades `newton_k1` to
 `newton at k=n−1 for all n` (positive inputs) via the k↔n−k duality — a general theorem short
 of the full axiom.
+
+## Session 2026-07-12 (researcher-7) — arbitrary-gap / TP2 layer on the log-concavity library
+
+**Mode:** REVISIT (node is the `MaclaurinLogConcave` library in `AmgmInequalityOQ03OQ02OQ02.lean`,
+0-axiom/0-sorry; JSON `leanFiles` is the stale family-wide list and does not track this node —
+trust the file header + build, per r5's 07-12 note). **Outcome:** progress — 3 new axiom-free thms.
+
+The library's defining hypothesis `p m · p (m+2) ≤ (p (m+1))²` only compares indices two apart.
+Added the general **index-majorization / total-positivity-of-order-2 (TP2)** layer, all read off
+the existing ratio-antitone characterization `logConcave_iff_ratio_antitone`:
+
+- `logConcave_exchange` — single exchange step `i ≤ j → p i · p (j+1) ≤ p (i+1) · p j`
+  (defining log-concavity is the `j = i+1` case). Direct from `p (j+1)/p j ≤ p (i+1)/p i`
+  cleared of positive denominators via `div_le_div_iff₀`.
+- `logConcave_logSupermod` — the master inequality `a ≤ b → ∀ c, p a · p (b+c) ≤ p (a+c) · p b`
+  (discrete log-supermodularity / TP2: every 2×2 Hankel minor `p a·p(b+c) − p(a+c)·p b ≤ 0`).
+  Proof: induction on `c`; the successor step multiplies the IH by the antitone consecutive
+  ratio at base `a+c ≤ b+c` (two `mul_le_mul_of_nonneg_*` hints into `nlinarith`) then cancels
+  the common positive factor `p (a+c)` via `le_of_mul_le_mul_right`.
+- `logConcave_spread` — arbitrary even-gap log-concavity `p m · p (m + 2d) ≤ (p (m+d))²`
+  (the `a=m, b=m+d, c=d` instance of `logSupermod`; `d = 1` recovers the defining inequality).
+
+VERIFIED: `lake env lean` EXIT 0, no errors/sorries; `#print axioms` = [propext, Classical.choice,
+Quot.sound] for all three (no `sorryAx`, no `Lean.ofReduceBool`). File 650 → 720 lines,
+32 → 35 theorems, still 0-axiom/0-sorry.
+
+**Frontier unchanged.** The one deep family axiom is `newton_log_concavity` (Newton's
+inequalities, in the sibling `AmgmInequalityOQ02.lean`) which needs real-rootedness/Rolle
+machinery absent from Mathlib 4.26 — out of session scope, untouched. This node itself is a
+generic log-concave-sequence library and carries no axioms. OQ depth is 3 (`-oq-03-oq-02-oq-02`),
+so per the depth guard **0 follow-up questions** are generated.


### PR DESCRIPTION
## Summary
Research session for `amgm-inequality-oq-03-oq-02-oq-02` (the `MaclaurinLogConcave`
log-concave-sequence library in `AmgmInequalityOQ03OQ02OQ02.lean`). The library's
defining hypothesis `p m · p (m+2) ≤ (p (m+1))²` only relates indices two apart; this
PR adds the general **index-majorization / total-positivity-of-order-2 (TP2)** content.

## Progress — 3 new axiom-free theorems
- **`logConcave_exchange`** — single exchange step `i ≤ j → p i · p (j+1) ≤ p (i+1) · p j`.
  The defining log-concavity is the `j = i+1` special case.
- **`logConcave_logSupermod`** — discrete TP2 master inequality
  `a ≤ b → ∀ c, p a · p (b+c) ≤ p (a+c) · p b`: concentrating two indices (fixed sum)
  can only increase the product; equivalently every 2×2 Hankel minor is `≤ 0`.
- **`logConcave_spread`** — arbitrary even-gap log-concavity `p m · p (m + 2d) ≤ (p (m+d))²`
  (`d = 1` recovers the defining inequality).

All three are read off the existing ratio-antitone characterization
`logConcave_iff_ratio_antitone`. `logConcave_logSupermod` is by induction on the shift `c`,
multiplying the induction hypothesis by the antitone consecutive ratio and cancelling the
common positive factor.

## Files modified
- `proofs/Proofs/AmgmInequalityOQ03OQ02OQ02.lean` (650 → 720 lines, 32 → 35 theorems)
- `research/problems/amgm-inequality-oq-03-oq-02-oq-02/knowledge.md`
- `src/data/research/problems/amgm-inequality-oq-03-oq-02-oq-02.json`

## Verification
- `lake env lean` (single-file elaboration against cached Mathlib): **EXIT 0**, no errors/sorries.
- `#print axioms` = `[propext, Classical.choice, Quot.sound]` for all three (no `sorryAx`,
  no `Lean.ofReduceBool`). File stays **0-axiom / 0-sorry**.

## Status
**Outcome**: progress (axiom-free structural generalization of the library's core inequality)
**Frontier unchanged**: the sole deep family axiom `newton_log_concavity` (Newton's inequalities,
in the sibling `AmgmInequalityOQ02.lean`) needs real-rootedness/Rolle machinery absent from
Mathlib 4.26 — out of session scope, untouched. This node is a generic log-concavity library
and carries no axioms.
**Follow-ups**: 0 (OQ depth is 3 — depth guard).

🤖 Generated by researcher-7