### PR TITLE
guard: four recurrence guards against dc9fdffa30-style mass deletions (#38398 PR R3)

### DIFF
--- a/.lean/roles/COMMON.md
+++ b/.lean/roles/COMMON.md
@@ -80,6 +80,28 @@ by the backstop janitor (`scripts/clean-branches.sh`) once clean and stale;
 dirty or unpushed worktrees are
 always preserved.
 
+**NEVER delete tracked files from disk to reclaim space.** Git sees raw disk
+deletions as pending changes, and a later stage-all commit (`git add -A`) will
+faithfully stage them as deletions — this is exactly how commit `dc9fdffa30`
+mass-deleted 9,927 files from main (issue #38398). If a worktree must be slimmed
+under disk pressure, use the sparse-checkout helper, which removes files from
+disk while marking them skip-worktree so git does NOT see them as deleted:
+
+```bash
+# Slim: keep only the listed directories (cone mode)
+scripts/research/slim-worktree.sh --worktree <path> proofs research/problems/<problem>
+# Undo: restore the full checkout
+scripts/research/slim-worktree.sh --worktree <path> --restore
+```
+
+Related guards (all from #38398): researcher worktrees get a `pre-commit`
+mass-deletion tripwire (`scripts/research/check-staged-deletions.sh` — more
+than 20 staged deletions blocks the commit; `ALLOW_MASS_DELETION=1` bypasses),
+`parallel-research.sh` refuses to launch a researcher into a worktree with >5%
+of tracked files missing on disk and sparse-checkout off (`LAUNCH_ANYWAY=1`
+overrides), and the deployer skips auto-merging PRs with >100 deleted lines or
+>500 changed files (see `deployer.md`).
+
 ## Honesty Standards
 
 - Do not describe trivial results as significant.
@@ -104,8 +126,10 @@ the remaining root + engine files (root `package.json`/`vite.config.ts`/
 `scripts/lean/update-stats.sh`, `scripts/clean-branches.sh`,
 `scripts/gallery/check-meta-size.ts`, `scripts/annotations/`, `.lean/scripts/`,
 `.claude/commands/`, `.claude/skills/mathlib-contribution/`, `functions/`,
-`drizzle/`, `mcp-servers/aristotle/`, and more); #38398 PR R2 restores
-`research/problems/`.
+`drizzle/`, `mcp-servers/aristotle/`, and more); #38398 PR R2 restored
+`research/problems/`; #38398 PR R3 added the four recurrence guards (commit
+tripwire, deployer diff-stat gate, sparse-checkout slimming helper, worktree
+health check — see Worktree Hygiene above and `deployer.md`).
 
 Remaining gaps (deliberately NOT restored):
 

--- a/.lean/roles/deployer.md
+++ b/.lean/roles/deployer.md
@@ -7,36 +7,21 @@ periodically merging PRs, syncing data, building, and deploying.
 > (`git show dc9fdffa30^:.lean/roles/deployer.md`) and observed deployer cycles.
 > Shared conventions: see [`COMMON.md`](./COMMON.md).
 
-## KNOWN GAP — deploy pipeline currently BLOCKED (issue #38387)
-
-The pipeline entry point `scripts/deploy/sync-and-deploy.sh` is **absent from
-`main`**: it was deleted (along with the rest of `scripts/deploy/`, root
-`package.json`, and `wrangler.toml`) by commit `dc9fdffa30` (PR #37576, merged
-2026-07-11). This is the cause of the chronic "deploy BLOCKED" status in every
-deployer cycle since. The script is recoverable verbatim from history:
-
-```bash
-git show dc9fdffa30^:scripts/deploy/sync-and-deploy.sh
-```
-
-**Do not write a replacement from scratch** — restoration (after a secrets scan)
-is tracked in #38387. Until it lands, run the *merge-only flow* below; the
-Sync-Data / Build / Deploy stages are unavailable, and "Deployment URL: N/A
-(pipeline unavailable)" is the correct report line.
-
-Cloudflare evidence for the deploy target: the historical script ran
-`wrangler pages deploy` against Cloudflare Pages project `lean-genious`
-(deploy URLs `https://<hash>.lean-genious.pages.dev`, production
-`https://leangenius.org`); a `.wrangler/` state directory exists at the repo
-root; `wrangler.toml` was deleted by the same commit.
+> **Pipeline restored (issue #38398 PR R1).** `scripts/deploy/sync-and-deploy.sh`
+> (with the rest of `scripts/deploy/`, root `package.json`, and `wrangler.toml`)
+> was mass-deleted by commit `dc9fdffa30` (PR #37576, merged 2026-07-11) — the
+> cause of the chronic "deploy BLOCKED" status in every deployer cycle from
+> 07-11 until the restore landed. The full pipeline below is available again.
+> Deploy target: Cloudflare Pages project `lean-genious` (deploy URLs
+> `https://<hash>.lean-genious.pages.dev`, production `https://leangenius.org`).
 
 ## Responsibilities
 
 1. **Merge pull requests** — merge all ready PRs, aggressively resolve conflicts
-2. **Sync data files** — update research-listings.json with actual iteration counts *(blocked)*
-3. **Build website** — compile the site and catch errors *(blocked)*
-4. **Deploy to Cloudflare** — push the built site to production *(blocked)*
-5. **Commit changes** — push data-sync changes back to main *(blocked)*
+2. **Sync data files** — update research-listings.json with actual iteration counts
+3. **Build website** — compile the site and catch errors
+4. **Deploy to Cloudflare** — push the built site to production
+5. **Commit changes** — push data-sync changes back to main
 
 ## Merge Eligibility (both flows)
 
@@ -46,8 +31,21 @@ root; `wrangler.toml` was deleted by the same commit.
 - Merge PRs whose mergeable state is MERGEABLE; report CONFLICTING ones (their
   authors rebase). After each merge, GitHub recomputes the queue: expect an
   all-UNKNOWN wave that re-settles in ~30-100s before the next state is trusted.
+- **Diff-stat gate (issue #38398, `dc9fdffa30` guard)**: never auto-merge a PR
+  whose `gh pr view <n> --json additions,deletions,changedFiles` reports
+  **deletions > 100 (lines) or changedFiles > 500**. On 2026-07-11 a
+  single-file research PR silently carried 9,927 file deletions through the
+  auto-merge path (a disk-slimmed worktree + `git add -A`) and wiped most of
+  the repository — nothing in the merge path checked the diff stat.
+  `sync-and-deploy.sh` enforces this automatically (skips the PR, logs loudly,
+  and posts one idempotent explanatory PR comment — it does NOT add labels or
+  close the PR; operator visibility comes from the comment + the cycle report).
+  Apply the same check manually in the merge-only flow. Thresholds are
+  env-overridable for one intentional cycle: `DEPLOY_GATE_MAX_DELETIONS`,
+  `DEPLOY_GATE_MAX_CHANGED_FILES`. Gated PRs go in the cycle report as
+  "skipped (diff-stat gate)" so the operator decides their fate.
 
-## Current Merge-Only Flow (each cycle, ~30 min)
+## Merge-Only Flow (fallback when the pipeline script is unavailable)
 
 1. **Check signals** — `stop-deployer` / `stop-all`; usage throttle: deployer is
    high-priority, defer only at level >= 4 (see COMMON.md).
@@ -57,10 +55,10 @@ root; `wrangler.toml` was deleted by the same commit.
    `N CONFLICTING / 0 MERGEABLE / 0 UNKNOWN` is done for the cycle — do not
    re-poll a settled queue; only new PR numbers change the state.
 4. **Report**: PRs merged, queue state (X CONFLICTING / Y MERGEABLE / Z UNKNOWN),
-   HEAD sha, deploy status (blocked), next cycle time.
+   diff-stat-gated PRs, HEAD sha, deploy status, next cycle time.
 5. Sleep `DEPLOYER_INTERVAL` minutes (default: 30); repeat.
 
-## Full Pipeline (when `sync-and-deploy.sh` is restored)
+## Full Pipeline
 
 ```bash
 ./scripts/deploy/sync-and-deploy.sh              # full pipeline
@@ -125,6 +123,10 @@ status; deploy URL (or "N/A (pipeline unavailable)"); next run time.
 ## Do NOT
 
 - Merge draft PRs or PRs labeled `loom:review-requested`
+- Auto-merge a PR past the diff-stat gate (deletions > 100 lines or
+  changedFiles > 500) — skip it, log it, let the operator decide (#38398)
+- Add labels to or close PRs from the deploy script without operator
+  visibility — the gate posts an explanatory comment instead
 - Auto-resolve `*.lean` conflicts
 - Write an ad-hoc replacement deploy script (restore from history via #38387)
 - Remove locked or running worktrees

--- a/.lean/roles/researcher.md
+++ b/.lean/roles/researcher.md
@@ -383,8 +383,26 @@ This pass does **not** apply to research-only files or gallery proofs; gallery w
 
 ## Step 5: Commit and Push
 
+**Stage explicit paths — do not blind-stage with `git add -A`.** On 2026-07-11 a
+disk-slimmed researcher worktree (tracked files deleted from disk WITHOUT
+sparse-checkout) plus a stage-everything commit silently staged **9,927 file
+deletions** alongside one new Lean file, and the merge wiped most of the
+repository (commit `dc9fdffa30`, issue #38398). Two guards now stand in this path:
+
+- Researcher worktrees carry a `pre-commit` **mass-deletion tripwire**
+  (`scripts/research/check-staged-deletions.sh`, installed by
+  `parallel-research.sh`) that **blocks any commit staging more than 20
+  deletions**. If it fires on deletions you did NOT make: unstage them
+  (`git restore --staged <paths>`), restore the files (`git checkout -- .`),
+  and if you were slimming for disk space use
+  `scripts/research/slim-worktree.sh` instead (see COMMON.md Worktree Hygiene).
+  Only a genuinely intended, operator-acknowledged mass deletion may bypass:
+  `ALLOW_MASS_DELETION=1 git commit ...`.
+- Before committing, review `git status --porcelain | grep '^D\|^ D'` — any
+  deletion you did not intentionally make is a red flag, whatever the count.
+
 ```bash
-git add -A
+git add proofs/Proofs/YourFile.lean src/data/research/problems/<problem>.json  # your actual touched paths
 git commit -m "$(cat <<'EOF'
 Research: [problem-id] - [brief description]
 

--- a/scripts/deploy/sync-and-deploy.sh
+++ b/scripts/deploy/sync-and-deploy.sh
@@ -32,6 +32,13 @@
 #   BUILD_NODE_OPTIONS=...  Extra Node options for the build. Defaults to
 #                           "--max-old-space-size=8192" so vite does not OOM on
 #                           the current bundle.
+#   DEPLOY_GATE_MAX_DELETIONS=100
+#                           Diff-stat merge gate (issue #38398, dc9fdffa30
+#                           incident): skip auto-merging any PR whose
+#                           GitHub-reported deleted LINES exceed this; the PR
+#                           is flagged with a comment for operator review.
+#   DEPLOY_GATE_MAX_CHANGED_FILES=500
+#                           Same gate, limit on the PR's changedFiles count.
 #   SKIP_NOOP_BUILD_DETECTION=1
 #                           Disable Strategy F (issue #22149): skipping the
 #                           whole `pnpm build` invocation when no app-relevant
@@ -251,6 +258,82 @@ pr_branch_safe() {
     return 0
 }
 
+# ----------------------------------------------------------------------------
+# Diff-stat merge gate (issue #38398 — the dc9fdffa30 mass deletion)
+# ----------------------------------------------------------------------------
+# On 2026-07-11 a single-file research PR (#37576) silently carried 9,927 file
+# deletions (a disk-slimmed worktree without sparse-checkout + `git add -A`)
+# through this auto-merge path: research PRs are outside the loom judge
+# lifecycle and nothing anywhere checked the diff stat, so +103/-1,201,128
+# merged on mergeability alone. This gate refuses to AUTO-merge any PR whose
+# reported deletions (lines, per GitHub) exceed DEPLOY_GATE_MAX_DELETIONS
+# (default 100) or whose changedFiles exceed DEPLOY_GATE_MAX_CHANGED_FILES
+# (default 500). Gated PRs are skipped and flagged with an idempotent PR
+# comment for operator review — the deploy script must never silently label
+# or close a PR. Intentional large PRs: an operator merges manually or raises
+# the limits via env for one cycle.
+#
+# Complementary to pr_branch_safe above: pr_branch_safe catches corrupted/
+# ancient branch TIPS (which GitHub's stats miss); this gate catches honest
+# diff stats that are simply too destructive/wide to merge unreviewed.
+DEPLOY_GATE_MAX_DELETIONS="${DEPLOY_GATE_MAX_DELETIONS:-100}"
+DEPLOY_GATE_MAX_CHANGED_FILES="${DEPLOY_GATE_MAX_CHANGED_FILES:-500}"
+DEPLOY_GATE_MARKER="<!-- deploy-diffstat-gate:38398 -->"
+
+post_diffstat_gate_comment() {
+    local pr="$1" additions="$2" deletions="$3" changed="$4"
+
+    if $DRY_RUN; then
+        echo "  Would post diff-stat gate comment on #$pr"
+        return 0
+    fi
+
+    # Idempotent: post at most once per PR (marker survives edits/rebases).
+    if gh pr view "$pr" --json comments --jq '.comments[].body' 2>/dev/null \
+        | grep -qF "$DEPLOY_GATE_MARKER"; then
+        return 0
+    fi
+
+    # Body goes via a temp file: a heredoc inside "$(...)" breaks under the
+    # host's bash 3.2 parser, and --body-file also sidesteps quoting issues.
+    local body_file
+    body_file=$(mktemp)
+    cat > "$body_file" <<EOF
+$DEPLOY_GATE_MARKER
+**Deployer diff-stat gate: auto-merge skipped.**
+
+This PR reports **+$additions / -$deletions lines across $changed files**, exceeding the deployer auto-merge limits (deletions > $DEPLOY_GATE_MAX_DELETIONS or changedFiles > $DEPLOY_GATE_MAX_CHANGED_FILES).
+
+Context: on 2026-07-11, a single-file research PR silently carried **9,927 file deletions** (a disk-slimmed worktree plus \`git add -A\`) through the auto-merge path and wiped most of the repository (commit dc9fdffa30 — see issue #38398). The deployer therefore no longer auto-merges deletion-heavy or very wide PRs.
+
+- **If this diff is intentional**: an operator can merge manually (\`gh pr merge $pr --squash\`) or raise the limits for one cycle via \`DEPLOY_GATE_MAX_DELETIONS\` / \`DEPLOY_GATE_MAX_CHANGED_FILES\`.
+- **If it is not**: check the branch for phantom deletions: \`git diff --name-status --diff-filter=D origin/main...HEAD\`.
+EOF
+    gh pr comment "$pr" --body-file "$body_file" >/dev/null 2>&1 \
+        || print_warning "  Could not post gate comment on #$pr"
+    rm -f "$body_file"
+}
+
+# Returns 0 when the PR's diff stat is within auto-merge limits; 1 when the
+# gate trips (skip the merge). Fails OPEN on inspection errors — the tree-level
+# pr_branch_safe and assert_main_intact guards still stand behind it.
+pr_diffstat_safe() {
+    local pr="$1"
+    local stats additions deletions changed
+    stats=$(gh pr view "$pr" --json additions,deletions,changedFiles 2>/dev/null) || return 0
+    additions=$(echo "$stats" | jq -r '.additions // 0' 2>/dev/null) || return 0
+    deletions=$(echo "$stats" | jq -r '.deletions // 0' 2>/dev/null) || return 0
+    changed=$(echo "$stats" | jq -r '.changedFiles // 0' 2>/dev/null) || return 0
+    [[ "$deletions" =~ ^[0-9]+$ && "$changed" =~ ^[0-9]+$ ]] || return 0
+
+    if (( deletions > DEPLOY_GATE_MAX_DELETIONS || changed > DEPLOY_GATE_MAX_CHANGED_FILES )); then
+        print_warning "  #$pr: DIFF-STAT GATE — +$additions/-$deletions across $changed files exceeds auto-merge limits (deletions <= $DEPLOY_GATE_MAX_DELETIONS, changedFiles <= $DEPLOY_GATE_MAX_CHANGED_FILES); skipping, operator review required (dc9fdffa30 guard, #38398)"
+        post_diffstat_gate_comment "$pr" "$additions" "$deletions" "$changed"
+        return 1
+    fi
+    return 0
+}
+
 # Assert origin/main still holds a full tree. Call after the merge loop; if main
 # has collapsed, something merged a destructive branch — abort before deploying.
 assert_main_intact() {
@@ -306,12 +389,19 @@ merge_prs() {
     # Try to merge each PR
     for pr in $(echo "$eligible_prs" | jq -r '.[] | select(.mergeable == "MERGEABLE") | .number'); do
         if $DRY_RUN; then
-            echo "  Would merge PR #$pr"
-            ((++merged))
+            if ! pr_diffstat_safe "$pr"; then
+                echo "  Would skip PR #$pr (diff-stat gate)"
+            else
+                echo "  Would merge PR #$pr"
+                ((++merged))
+            fi
         else
             echo -n "  #$pr: "
             if ! pr_branch_safe "$pr"; then
                 echo "skipped (unsafe tree)"
+                ((++failed))
+            elif ! pr_diffstat_safe "$pr"; then
+                echo "skipped (diff-stat gate — operator review required)"
                 ((++failed))
             elif gh pr merge "$pr" --squash 2>/dev/null; then
                 echo "merged"
@@ -335,6 +425,8 @@ merge_prs() {
                 echo -n "  #$pr: "
                 if ! pr_branch_safe "$pr"; then
                     echo "skipped (unsafe tree)"
+                elif ! pr_diffstat_safe "$pr"; then
+                    echo "skipped (diff-stat gate — operator review required)"
                 elif gh pr merge "$pr" --squash 2>/dev/null; then
                     echo "merged"
                     ((++merged))
@@ -551,7 +643,7 @@ fs.writeFileSync('$conflict_file', JSON.stringify(ours, null, 2) + '\n');
         sleep 3
         local new_status=$(gh pr view "$pr" --json mergeable --jq '.mergeable' 2>/dev/null || echo "UNKNOWN")
         echo -n "  #$pr (after rebase): "
-        if [[ "$new_status" == "MERGEABLE" ]] && pr_branch_safe "$pr" && gh pr merge "$pr" --squash 2>/dev/null; then
+        if [[ "$new_status" == "MERGEABLE" ]] && pr_branch_safe "$pr" && pr_diffstat_safe "$pr" && gh pr merge "$pr" --squash 2>/dev/null; then
             echo "merged"
             ((++merged))
         else

--- a/scripts/research/check-staged-deletions.sh
+++ b/scripts/research/check-staged-deletions.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+#
+# check-staged-deletions.sh - commit-time mass-deletion tripwire
+#
+# Guards against a repeat of the dc9fdffa30 incident (2026-07-11): a researcher
+# worktree had been "slimmed" by deleting tracked files from disk WITHOUT git
+# sparse-checkout, so git saw ~9,927 tracked files as locally deleted. A
+# stage-everything commit (`git add -A`) for a single new Lean file silently
+# staged all 9,927 deletions, the commit message mentioned only the Lean file,
+# and the merge wiped the research corpus, the engine scripts, and every root
+# config file from main. See issue #38398.
+#
+# Usage:
+#   - As a `pre-commit` hook (parallel-research.sh installs it into every
+#     researcher worktree it creates or reuses).
+#   - Standalone, from anywhere inside a repo/worktree:
+#       scripts/research/check-staged-deletions.sh [--max N]
+#
+# Behavior:
+#   Exits 1 (blocking the commit when run as a hook) if the number of STAGED
+#   deletions exceeds the threshold (default: 20).
+#
+# Overrides:
+#   --max N                  Set the threshold for this invocation
+#   MAX_STAGED_DELETIONS=N   Set the threshold via environment
+#   ALLOW_MASS_DELETION=1    Bypass the tripwire entirely (for a genuinely
+#                            intended, operator-acknowledged mass deletion)
+
+set -euo pipefail
+
+MAX="${MAX_STAGED_DELETIONS:-20}"
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --max)
+            if [[ -z "${2:-}" ]]; then
+                echo "check-staged-deletions: --max requires a value" >&2
+                exit 2
+            fi
+            MAX="$2"
+            shift 2
+            ;;
+        --help|-h)
+            sed -n '2,27p' "$0" | sed 's/^# \{0,1\}//'
+            exit 0
+            ;;
+        *)
+            echo "check-staged-deletions: unknown argument: $1 (see --help)" >&2
+            exit 2
+            ;;
+    esac
+done
+
+if ! [[ "$MAX" =~ ^[0-9]+$ ]]; then
+    echo "check-staged-deletions: threshold must be a non-negative integer (got: $MAX)" >&2
+    exit 2
+fi
+
+if [[ "${ALLOW_MASS_DELETION:-}" == "1" ]]; then
+    echo "check-staged-deletions: ALLOW_MASS_DELETION=1 — bypassing mass-deletion tripwire." >&2
+    exit 0
+fi
+
+deleted_count=$(git diff --cached --diff-filter=D --name-only | wc -l | tr -d ' ')
+
+if (( deleted_count > MAX )); then
+    {
+        echo ""
+        echo "=============================================================================="
+        echo "  COMMIT BLOCKED: $deleted_count staged deletions (threshold: $MAX)"
+        echo "=============================================================================="
+        echo ""
+        echo "  You are about to commit the deletion of $deleted_count tracked files."
+        echo ""
+        echo "  This is exactly how commit dc9fdffa30 (2026-07-11, issue #38398) wiped"
+        echo "  9,927 files from main: a worktree was 'slimmed' by deleting tracked files"
+        echo "  from disk without git sparse-checkout, and a 'git add -A' for one new"
+        echo "  Lean file silently staged every one of those deletions."
+        echo ""
+        echo "  First 10 staged deletions:"
+        git diff --cached --diff-filter=D --name-only | head -10 | sed 's/^/    - /'
+        echo ""
+        echo "  If these deletions are UNINTENDED (phantom deletions from a slimmed or"
+        echo "  damaged worktree):"
+        echo "    1. Unstage them:      git restore --staged \$(git diff --cached --diff-filter=D --name-only)"
+        echo "    2. Restore the files: git checkout -- ."
+        echo "    3. Need disk space?   Use scripts/research/slim-worktree.sh (sparse-checkout),"
+        echo "       NEVER raw 'rm' of tracked files."
+        echo ""
+        echo "  If this mass deletion is INTENDED (operator-acknowledged cleanup):"
+        echo "    ALLOW_MASS_DELETION=1 git commit ..."
+        echo "  or raise the threshold: MAX_STAGED_DELETIONS=N (env) / --max N (flag)."
+        echo "=============================================================================="
+    } >&2
+    exit 1
+fi
+
+exit 0

--- a/scripts/research/parallel-research.sh
+++ b/scripts/research/parallel-research.sh
@@ -112,6 +112,81 @@ create_worktree() {
     fi
 }
 
+# Install the mass-deletion pre-commit tripwire into a worktree (guard 1 of
+# issue #38398 — the dc9fdffa30 incident: a disk-slimmed worktree + `git add -A`
+# staged 9,927 phantom deletions).
+#
+# Hook resolution in worktrees: linked worktrees share the main repo's
+# .git/hooks (and any core.hooksPath from the SHARED .git/config) unless
+# core.hooksPath is set in the WORKTREE-SCOPED config, which requires
+# extensions.worktreeConfig=true. We point each researcher worktree at its own
+# hooks dir under .git/worktrees/<name>/hooks so (a) nothing untracked appears
+# inside the worktree (a stage-all commit would pick it up), and (b) the main
+# checkout and sibling worktrees are unaffected.
+install_deletion_tripwire() {
+    local worktree_path="$1"
+    local tripwire="$REPO_ROOT/scripts/research/check-staged-deletions.sh"
+
+    if [[ ! -f "$tripwire" ]]; then
+        print_warning "Deletion tripwire missing: $tripwire — hook NOT installed"
+        return 0
+    fi
+
+    local wt_git_dir hooks_dir
+    wt_git_dir=$(git -C "$worktree_path" rev-parse --absolute-git-dir 2>/dev/null) || {
+        print_warning "Could not resolve git dir for $worktree_path — hook NOT installed"
+        return 0
+    }
+    hooks_dir="$wt_git_dir/hooks"
+    mkdir -p "$hooks_dir"
+    cp "$tripwire" "$hooks_dir/pre-commit"
+    chmod +x "$hooks_dir/pre-commit"
+    git -C "$worktree_path" config extensions.worktreeConfig true 2>/dev/null || true
+    if git -C "$worktree_path" config --worktree core.hooksPath "$hooks_dir" 2>/dev/null; then
+        print_info "Installed mass-deletion pre-commit tripwire: $hooks_dir/pre-commit"
+    else
+        print_warning "Could not set per-worktree core.hooksPath for $worktree_path — hook NOT active"
+    fi
+}
+
+# Worktree health check (guard 4 of issue #38398). A worktree that was
+# disk-slimmed WITHOUT sparse-checkout shows thousands of tracked files as
+# locally deleted; any stage-all commit would stage those deletions (that is
+# how dc9fdffa30 wiped 9,927 files). Refuse to launch a researcher into such a
+# worktree: missing-on-disk tracked files > 5% of tracked total AND
+# sparse-checkout not enabled. Override with LAUNCH_ANYWAY=1.
+worktree_health_check() {
+    local worktree_path="$1"
+
+    local tracked missing
+    tracked=$(git -C "$worktree_path" ls-files 2>/dev/null | wc -l | tr -d ' ')
+    missing=$(git -C "$worktree_path" status --porcelain 2>/dev/null | grep -c '^ D\|^D ' || true)
+    missing=${missing:-0}
+
+    # Empty/unreadable index — nothing to assess (fail open on inspection error).
+    [[ -z "$tracked" || "$tracked" -eq 0 ]] && return 0
+
+    local sparse
+    sparse=$(git -C "$worktree_path" config --get core.sparseCheckout 2>/dev/null || echo "false")
+
+    if (( missing * 20 > tracked )) && [[ "$sparse" != "true" ]]; then
+        print_error "WORKTREE HEALTH CHECK FAILED: $worktree_path"
+        print_error "  $missing of $tracked tracked files are deleted on disk (>5%) and sparse-checkout is OFF."
+        print_error "  This is the exact state that caused the dc9fdffa30 mass deletion (9,927 files"
+        print_error "  staged by 'git add -A'; issue #38398). A researcher launched here could commit"
+        print_error "  those deletions."
+        print_error "  Fix:      git -C $worktree_path checkout -- ."
+        print_error "  Slim safely instead: scripts/research/slim-worktree.sh (sparse-checkout)"
+        print_error "  Override: LAUNCH_ANYWAY=1"
+        if [[ "${LAUNCH_ANYWAY:-}" == "1" ]]; then
+            print_warning "LAUNCH_ANYWAY=1 set — launching despite failed health check"
+            return 0
+        fi
+        return 1
+    fi
+    return 0
+}
+
 # Create prompt file for agent
 create_prompt_file() {
     local agent_num="$1"
@@ -226,6 +301,16 @@ launch_agent() {
     print_info "Creating worktree for agent $agent_num..."
     create_worktree "$agent_num"
 
+    # Guard 4 (#38398): refuse to launch into a disk-slimmed worktree whose
+    # tracked files are missing without sparse-checkout protection.
+    if ! worktree_health_check "$worktree_path"; then
+        print_error "Refusing to launch researcher-$agent_num (worktree failed health check)"
+        return 1
+    fi
+
+    # Guard 1 (#38398): mass-deletion pre-commit tripwire for this worktree.
+    install_deletion_tripwire "$worktree_path"
+
     # Create prompt file
     local prompt_file
     prompt_file=$(create_prompt_file "$agent_num")
@@ -275,9 +360,16 @@ launch_agents() {
     print_info "Wait interval when no work: $wait_interval minutes"
     echo ""
 
+    local launch_failures=0
     for i in $(seq 1 "$count"); do
-        launch_agent "$i"
+        # A failed health check (guard 4, #38398) skips that slot without
+        # aborting the remaining launches under `set -e`.
+        launch_agent "$i" || { print_warning "researcher-$i NOT launched (see above)"; ((++launch_failures)); }
     done
+
+    if [[ $launch_failures -gt 0 ]]; then
+        print_warning "$launch_failures agent(s) failed to launch"
+    fi
 
     echo ""
     print_success "All agents launched in isolated worktrees!"

--- a/scripts/research/slim-worktree.sh
+++ b/scripts/research/slim-worktree.sh
@@ -1,0 +1,126 @@
+#!/bin/bash
+#
+# slim-worktree.sh - slim a git worktree for disk space the SAFE way
+#
+# NEVER delete tracked files from disk to reclaim space. Git sees raw disk
+# deletions as pending changes, and a later stage-all commit (`git add -A`)
+# will faithfully stage them as deletions — this is exactly how commit
+# dc9fdffa30 (2026-07-11, issue #38398) mass-deleted 9,927 files from main.
+#
+# This helper uses `git sparse-checkout` in cone mode instead: files outside
+# the kept directories are removed from DISK but marked skip-worktree in the
+# index, so git does NOT see them as deleted and no commit can stage their
+# deletion.
+#
+# Usage:
+#   slim-worktree.sh [--worktree PATH] DIR [DIR ...]   Keep only DIRs (+ root files)
+#   slim-worktree.sh [--worktree PATH] --restore       Undo: restore the full checkout
+#   slim-worktree.sh [--worktree PATH] --status        Show sparse-checkout state
+#
+# Examples:
+#   # Slim a researcher worktree down to the Lean project + one problem dir:
+#   scripts/research/slim-worktree.sh --worktree .loom/worktrees/researcher-3 \
+#       proofs research/problems/erdos-771
+#
+#   # Undo (from inside the worktree):
+#   scripts/research/slim-worktree.sh --restore
+
+set -euo pipefail
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+BLUE='\033[0;34m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+print_error() { echo -e "${RED}✗ $1${NC}"; }
+print_success() { echo -e "${GREEN}✓ $1${NC}"; }
+print_info() { echo -e "${BLUE}ℹ $1${NC}"; }
+print_warning() { echo -e "${YELLOW}⚠ $1${NC}"; }
+
+WORKTREE="$PWD"
+ACTION="set"
+DIRS=()
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --worktree)
+            if [[ -z "${2:-}" ]]; then
+                print_error "--worktree requires a path"
+                exit 2
+            fi
+            WORKTREE="$2"
+            shift 2
+            ;;
+        --restore)
+            ACTION="restore"
+            shift
+            ;;
+        --status)
+            ACTION="status"
+            shift
+            ;;
+        --help|-h)
+            sed -n '2,26p' "$0" | sed 's/^# \{0,1\}//'
+            exit 0
+            ;;
+        -*)
+            print_error "Unknown option: $1 (see --help)"
+            exit 2
+            ;;
+        *)
+            DIRS+=("$1")
+            shift
+            ;;
+    esac
+done
+
+if ! git -C "$WORKTREE" rev-parse --git-dir >/dev/null 2>&1; then
+    print_error "Not a git worktree: $WORKTREE"
+    exit 2
+fi
+
+case "$ACTION" in
+    status)
+        if [[ "$(git -C "$WORKTREE" config --get core.sparseCheckout 2>/dev/null || echo false)" == "true" ]]; then
+            print_info "sparse-checkout is ENABLED in $WORKTREE; kept directories:"
+            git -C "$WORKTREE" sparse-checkout list | sed 's/^/    /'
+        else
+            print_info "sparse-checkout is DISABLED in $WORKTREE (full checkout)"
+        fi
+        ;;
+    restore)
+        print_info "Restoring full checkout in $WORKTREE..."
+        git -C "$WORKTREE" sparse-checkout disable
+        print_success "Full checkout restored"
+        ;;
+    set)
+        if [[ ${#DIRS[@]} -eq 0 ]]; then
+            print_error "No directories given. Usage: slim-worktree.sh [--worktree PATH] DIR [DIR ...]"
+            print_error "(or --restore / --status; see --help)"
+            exit 2
+        fi
+
+        # Warn about pre-existing deletions: sparse-checkout cannot repair a
+        # worktree that ALREADY has raw disk deletions pending — those must be
+        # restored first or they remain stageable.
+        pre_missing=$(git -C "$WORKTREE" status --porcelain 2>/dev/null | grep -c '^ D\|^D ' || true)
+        if [[ "${pre_missing:-0}" -gt 0 ]]; then
+            print_warning "$pre_missing tracked file(s) already deleted on disk in $WORKTREE."
+            print_warning "Restore them BEFORE slimming: git -C $WORKTREE checkout -- ."
+        fi
+
+        print_info "Slimming $WORKTREE to: ${DIRS[*]} (cone mode)..."
+        git -C "$WORKTREE" sparse-checkout set --cone "${DIRS[@]}"
+
+        # Prove safety: sparse-checkout must not have introduced any
+        # git-visible deletions (skip-worktree bits protect slimmed paths).
+        post_missing=$(git -C "$WORKTREE" status --porcelain 2>/dev/null | grep -c '^ D\|^D ' || true)
+        if [[ "${post_missing:-0}" -gt "${pre_missing:-0}" ]]; then
+            print_error "sparse-checkout left $post_missing pending deletion(s) — investigate before committing!"
+            exit 1
+        fi
+        print_success "Slimmed safely: git sees ${post_missing:-0} pending deletion(s) (skip-worktree protects the rest)"
+        print_info "Undo anytime with: $0 --worktree $WORKTREE --restore"
+        ;;
+esac


### PR DESCRIPTION
Closes #38398

**PR R3 (final) — the four recurrence guards** from the orchestrator's root-cause forensics on the `dc9fdffa30` mass deletion (9,927 phantom deletions staged by `git add -A` in a disk-slimmed worktree, merged with no diff-stat check anywhere in the path). R1 (#38423, root + engine) and R2 (#38422, research corpus) are merged; this PR closes the incident arc by making each link of the causal chain fail loudly.

## Guard 1 — commit-time deletion tripwire

- **New `scripts/research/check-staged-deletions.sh`**: exits 1 with a loud message (explaining the dc9fdffa30 incident, listing the first 10 staged deletions, and giving the recovery commands) when `git diff --cached --diff-filter=D` exceeds the threshold (default **20**). Overrides: `--max N`, `MAX_STAGED_DELETIONS=N`, or `ALLOW_MASS_DELETION=1` to bypass.
- **Wired into `parallel-research.sh`** (`install_deletion_tripwire`): installed as a `pre-commit` hook in every researcher worktree it creates or reuses. Hook resolution: linked worktrees share the main repo's hooks (this repo additionally has a shared `core.hooksPath=.githooks` pointing at a nonexistent dir, so no hooks ran at all), so the installer copies the script into the worktree's private `.git/worktrees/<name>/hooks/` and sets **worktree-scoped `core.hooksPath`** via `extensions.worktreeConfig` — nothing untracked appears inside the worktree (a stage-all would have committed it), and the main checkout / sibling worktrees are untouched. Proven by test (below), including against a simulated production shared `core.hooksPath`.
- Documented in `.lean/roles/researcher.md` Step 5 (explicit staging instead of `git add -A`, tripwire behavior + bypass) and `.lean/roles/COMMON.md` Worktree Hygiene.

## Guard 2 — deployer diff-stat merge gate

- **`scripts/deploy/sync-and-deploy.sh`** (`pr_diffstat_safe`): before any auto-merge, checks `gh pr view <n> --json additions,deletions,changedFiles`; if **deletions > 100 or changedFiles > 500** the PR is **skipped** (never labeled or closed by the script), logged loudly, and flagged with **one idempotent explanatory PR comment** (HTML marker `<!-- deploy-diffstat-gate:38398 -->`; re-runs detect it and stay silent). Thresholds env-overridable: `DEPLOY_GATE_MAX_DELETIONS` / `DEPLOY_GATE_MAX_CHANGED_FILES`. Wired into all three merge sites (MERGEABLE loop, UNKNOWN retry, post-rebase retry) plus `--dry-run` visibility ("Would skip PR #N (diff-stat gate)"). Fails open on `gh`/`jq` inspection errors — the existing tree-level `pr_branch_safe` + `assert_main_intact` guards still stand behind it.
- Documented in `.lean/roles/deployer.md` (Merge Eligibility + Do NOT), and the doc's stale "pipeline BLOCKED" banner is updated to reflect the R1 restore.

## Guard 3 — safe slimming helper (real sparse-checkout)

- **New `scripts/research/slim-worktree.sh`**: `git sparse-checkout set --cone <dirs>` with `--restore` (undo), `--status`, and `--worktree PATH`. Warns if raw deletions already exist pre-slim, and self-verifies after slimming that git sees **0** new pending deletions (skip-worktree bits). `.lean/roles/COMMON.md` Worktree Hygiene now says in bold: **never delete tracked files from disk** — use the helper.

## Guard 4 — worktree health check at launch

- **`parallel-research.sh`** (`worktree_health_check`), after worktree creation/reuse: if missing-on-disk tracked files (`git status --porcelain` `D` entries) exceed **5%** of `git ls-files` total AND sparse-checkout is not enabled, prints a loud refusal and does not launch that researcher (`LAUNCH_ANYWAY=1` overrides). A failed slot no longer aborts the remaining launches under `set -e`.

## Test transcript highlights (20/20 pass)

The harness runs the **actual production functions** (extracted verbatim from the committed scripts) in a throwaway repo with linked worktrees:

```text
=== TEST 1: install_deletion_tripwire (per-worktree pre-commit hook) ===
--- 1a: staging 25 deletions in the worktree; commit must be BLOCKED ---
==============================================================================
  COMMIT BLOCKED: 25 staged deletions (threshold: 20)
==============================================================================
  You are about to commit the deletion of 25 tracked files.
  This is exactly how commit dc9fdffa30 (2026-07-11, issue #38398) wiped
  9,927 files from main: ...
PASS: commit with 25 staged deletions blocked (exit 1)
--- 1b: ALLOW_MASS_DELETION=1 bypasses ---
check-staged-deletions: ALLOW_MASS_DELETION=1 — bypassing mass-deletion tripwire.
PASS: ALLOW_MASS_DELETION=1 bypass (exit 0)
PASS: 1-deletion commit allowed (exit 0)
PASS: main checkout not hooked (isolation) (exit 0)   # >20-deletion commit still fine OUTSIDE the hooked worktree
PASS: standalone --max 1 trips on 2 deletions (exit 1)

=== TEST 2: worktree_health_check ===
PASS: healthy worktree passes (exit 0)
--- 2b: disk-slimmed worktree (30/31 tracked files rm'd, no sparse-checkout) ---
ERROR: WORKTREE HEALTH CHECK FAILED: .../wt2
ERROR:   30 of 31 tracked files are deleted on disk (>5%) and sparse-checkout is OFF.
PASS: slimmed-without-sparse worktree refused (exit 1)
PASS: LAUNCH_ANYWAY=1 override (exit 0)

=== TEST 3: slim-worktree.sh ===
PASS: slim-worktree set (exit 0)
-- file*.txt remaining on disk: 0 (files removed from disk)
PASS: git sees 0 pending changes after slim (pending=0)
PASS: sparse-slimmed worktree passes health check (exit 0)
PASS: stage-all (git add -A) after sparse slim stages 0 deletions
PASS: restore (exit 0); all 30 files back after --restore

=== TEST 4: deployer diff-stat gate (production functions + stubbed gh) ===
WARN: #101: DIFF-STAT GATE — +103/-1201128 across 9928 files exceeds auto-merge limits ...
PASS: gate trips on dc9fdffa30-shaped PR (exit 1)
PASS: gate trips on changedFiles>500 (exit 1)
PASS: normal PR (+200/-80, 12 files) passes gate (exit 0)
PASS: idempotency — repeat trips post exactly 0 new comments (marker detected)
PASS: raised env limits let the same PR through (exit 0)

=== RESULT: 20 passed, 0 failed ===
```

Extra hook-resolution proof: with a simulated **production shared config** (`core.hooksPath=.githooks` + `extensions.worktreeConfig=true` in the shared `.git/config`, `.githooks` nonexistent — exactly lean-genius's live state), the worktree-scoped override still wins and the mass-deletion commit is blocked (exit 1).

## Verification

- `bash -n` clean on all four touched/added scripts; `shellcheck -S error` clean, `-S warning` clean for all new code (remaining warnings are pre-existing SC2155-style in untouched lines). Note: the gate comment goes through `gh pr comment --body-file <tmpfile>` because a heredoc inside `"$(...)"` mis-parses under this host's bash 3.2.
- `sync-and-deploy.sh` was **not** executed end-to-end (it merges + deploys, and even `--dry-run` performs real `git checkout main` / `reset --hard` in the merge phase — unsafe outside the deployer worktree). The gate was verified by `bash -n`, a dry-read of the diff, and unit tests of the extracted production functions above.
- Doc anchors: no `#38385` / `#38389` / `#38399` sections exist in any tracked `.md`; the #38399-curated researcher/COMMON/deployer content around my edits is untouched (diff is additive plus the two deliberate rewrites: researcher Step 5 staging block, deployer BLOCKED banner).

## Why "Closes"

- R1 #38423 (root + engine) — merged. R2 #38422 (research corpus, byte-identical, 0 overlay) — merged. R3 (this PR) — all four root-cause guards implemented and tested.
- The remaining items are **deliberate operator decisions, tracked in the Known-Gaps Ledger** (`.lean/roles/COMMON.md`): `research/registry.json` tracking (fleet-mutated, conflict risk), a dump strategy for `research/db/knowledge.db` (binary SQLite), and the `research/db/` scripts; the `research/references/OSforGFF` submodule entry stays gitignored per R1's `.gitmodules` decision. These were explicitly deferred by the operator in #38387 and keep their home in the ledger, not this issue.
- Deployer full-cycle verification happens organically on the next scheduled deployer cycle now that `scripts/deploy/` + `wrangler.toml` + root `package.json` are restored; any failure there is a fresh, narrow issue rather than part of this restoration tracker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
