### PR TITLE
Research: brouwer-fixed-point-oq-02-oq-02-oq-01 - exact one-query complexity (matching upper bound)

### DIFF
--- a/proofs/Proofs/BrouwerFixedPointOQ02OQ02OQ01Adversary.lean
+++ b/proofs/Proofs/BrouwerFixedPointOQ02OQ02OQ01Adversary.lean
@@ -41,6 +41,13 @@ points perfectly consistent with the one observation the algorithm must answer.
 7. `one_query_lower_bound` — no one-query algorithm resolves the fixed point
    below 1/4 (the main explicit adversary lower bound).
 8. `no_one_query_epsilon` — for ε < 1/4 no one-query algorithm is ε-accurate.
+9. `adversary_midpoint_optimal` — the midpoint answer attains `|p-q|/2` exactly
+   (the `=` companion to `adversary_error_bound`'s `≥`).
+10. `adversary_minimax` — the exact minimax of the adversary principle is
+    `|p-q|/2` (`IsLeast`).
+11. `one_query_complexity` — the one-query complexity against the explicit pair
+    `{f, g}` is *exactly* `1/4` (`IsLeast`): the lower bound is matched by the
+    midpoint algorithm, making it two-sided.
 
 Reference: Chen–Deng (2009) query complexity for Brouwer fixed points; the
 adversary method of Aaronson / Ambainis; the parent OQ-02-OQ-02.
@@ -217,5 +224,57 @@ theorem no_one_query_epsilon (A : ℝ → ℝ) {ε : ℝ} (hε : ε < 1 / 4) :
   rcases le_max_iff.mp hmax with h | h
   · linarith
   · linarith
+
+-- ============================================================
+-- SECTION VI: The lower bound is sharp — matching upper bound
+-- and exact one-query complexity against the pair {f, g}
+-- ============================================================
+
+/-- **The adversary principle is sharp: the midpoint attains the bound.**
+    Companion to `adversary_error_bound`, which only proves the `≥` direction.
+    Answering with the midpoint `(p+q)/2` makes the error *exactly* `|p-q|/2` on
+    both instances, so the `|p-q|/2` lower bound cannot be improved. -/
+theorem adversary_midpoint_optimal (p q : ℝ) :
+    max (|(p + q) / 2 - p|) (|(p + q) / 2 - q|) = |p - q| / 2 := by
+  have e1 : (p + q) / 2 - p = -((p - q) / 2) := by ring
+  have e2 : (p + q) / 2 - q = (p - q) / 2 := by ring
+  rw [e1, e2, abs_neg, max_self, abs_div]
+  norm_num
+
+/-- **Exact minimax of the abstract adversary principle.**
+    Combining `adversary_error_bound` (any answer errs by at least `|p-q|/2`) with
+    `adversary_midpoint_optimal` (the midpoint errs by exactly `|p-q|/2`), the
+    least achievable worst-case error over all answers `a` is *exactly* `|p-q|/2`. -/
+theorem adversary_minimax (p q : ℝ) :
+    IsLeast {m : ℝ | ∃ a : ℝ, m = max (|a - p|) (|a - q|)} (|p - q| / 2) := by
+  constructor
+  · exact ⟨(p + q) / 2, (adversary_midpoint_optimal p q).symm⟩
+  · rintro m ⟨a, rfl⟩
+    exact adversary_error_bound p q a
+
+/-- **The one-query lower bound `1/4` is attained.**
+    The constant algorithm `A ≡ 1/2` (output the midpoint of the two candidate
+    fixed points regardless of the observed value) errs by *exactly* `1/4` on both
+    `f` and `g`, so no better worst-case accuracy than `1/4` is possible — but
+    `1/4` *is* possible. -/
+theorem one_query_upper_bound :
+    max (|(fun _ : ℝ => (1 / 2 : ℝ)) (f 0) - 1 / 4|)
+        (|(fun _ : ℝ => (1 / 2 : ℝ)) (g 0) - 3 / 4|) = 1 / 4 := by
+  norm_num
+
+/-- **Exact one-query complexity against the explicit pair `{f, g}`.**
+    The least worst-case error achievable by *any* one-query algorithm on the
+    adversary pair is *exactly* `1/4`: the lower bound `one_query_lower_bound`
+    is matched by the midpoint answer. This pins the one-query complexity of
+    resolving the fixed point down to the exact constant `1/4 = |1/4 - 3/4| / 2`,
+    turning the one-sided lower bound into a two-sided characterization. -/
+theorem one_query_complexity :
+    IsLeast
+      {m : ℝ | ∃ A : ℝ → ℝ, m = max (|A (f 0) - 1 / 4|) (|A (g 0) - 3 / 4|)}
+      (1 / 4) := by
+  constructor
+  · exact ⟨fun _ => 1 / 2, one_query_upper_bound.symm⟩
+  · rintro m ⟨A, rfl⟩
+    exact one_query_lower_bound A
 
 end BrouwerOQ02OQ02OQ01Adversary

--- a/src/data/research/problems/brouwer-fixed-point-oq-02-oq-02-oq-01.json
+++ b/src/data/research/problems/brouwer-fixed-point-oq-02-oq-02-oq-01.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "SOLVED (40 thm, 0 axiom, 0 sorry): added sharpness of BOTH a priori Lⁿ/(1-L) and a posteriori L/(1-L) constants — affine contraction f(t)=L·t attains both with equality; constants are optimal (estimate_constants_sharp)",
+    "progressSummary": "SOLVED + SHARPENED (Adversary file now 20 thm, 0 axiom, 0 sorry): added the MATCHING UPPER BOUND to the one-query lower bound — one_query_complexity proves the least worst-case error over all one-query algorithms against the explicit pair {f,g} is EXACTLY 1/4 (IsLeast), via adversary_minimax (exact minimax = |p-q|/2 of the abstract adversary principle, midpoint-optimal). The lower bound is now two-sided.",
     "builtItems": [
       "BrouwerFixedPointOQ02OQ02OQ01.lean: 6 theorems, 0 axioms (propext/Classical.choice/Quot.sound only), 0 sorries. Self-contained: contraction given as ∀ x y, |f x − f y| ≤ L·|x − y| with f x* = x* and xₙ₊₁ = f xₙ.",
       "iterate_dist: |xₙ − x*| ≤ Lⁿ·|x₀ − x*| (geometric decay, induction; reproves parent's bound self-containedly).",
@@ -45,7 +45,8 @@
       "displacement_le_path_length in BrouwerFixedPointOQ02OQ02OQ01.lean",
       "apriori_estimate_sharp (BrouwerFixedPointOQ02OQ02OQ01.lean): affine witness attains Lⁿ/(1-L) with equality ∀n — a priori constant optimal",
       "aposteriori_estimate_sharp (BrouwerFixedPointOQ02OQ02OQ01.lean): affine witness attains L/(1-L) with equality ∀n — a posteriori constant optimal",
-      "estimate_constants_sharp (BrouwerFixedPointOQ02OQ02OQ01.lean): packaged existential — one map attains both constants simultaneously; suite is constant-optimal"
+      "estimate_constants_sharp (BrouwerFixedPointOQ02OQ02OQ01.lean): packaged existential — one map attains both constants simultaneously; suite is constant-optimal",
+      "BrouwerFixedPointOQ02OQ02OQ01Adversary.lean SECTION VI: matching upper bound making the one-query lower bound SHARP. adversary_midpoint_optimal (midpoint answer (p+q)/2 errs by EXACTLY |p-q|/2 — the = companion to adversary_error_bound (≥)), adversary_minimax (IsLeast: exact minimax of the abstract adversary principle is |p-q|/2), one_query_upper_bound (constant-1/2 algorithm attains error exactly 1/4 on {f,g}), one_query_complexity (IsLeast: the least worst-case error over ALL one-query algorithms against the explicit pair {f,g} is EXACTLY 1/4). Turns the one-sided lower bound into a two-sided exact characterization. 4 thm, 0 axiom, 0 sorry."
     ],
     "insights": [
       "Parent oq-02-oq-02 proves the bound |xₙ − x*| ≤ Lⁿ·|x₀ − x*| which is not directly usable (|x₀ − x*| unknown). The classical fix is the a priori estimate, expressing the bound via the computable first increment |x₁ − x₀|.",
@@ -58,7 +59,8 @@
       "Added a matching a posteriori LOWER bound |x(n+1)-xn|/(1+L) ≤ |xn-x*| (reverse triangle + one-step contraction), making the residual/increment a two-sided proxy for the error. Only 0≤L needed. Prior estimates were all upper bounds.",
       "Tail arc-length bound: ∑_{k<m}|x_{n+k+1}-x_{n+k}| ≤ Lⁿ|x₁-x₀|/(1-L) — generalizes total_path_length_bound (n=0 case); m→∞ limit bounds |xₙ-x*|",
       "Arc dominates chord (displacement_le_path_length): |x_{n+m}-xₙ| ≤ arc length, pure telescoping (Finset.sum_range_sub + abs_sum_le_sum_abs); combined with tail_path_length_bound re-derives cauchy_estimate as chord≤arc≤geometric tail",
-      "SHARPNESS: the affine contraction f(t)=L·t (extremal L-contraction, |fa-fb|=L|a-b|) with iterates xₙ=Lⁿ·x₀ about fixed point 0 attains BOTH estimate constants with equality: |xₙ-x*|=Lⁿ/(1-L)·|x₁-x₀| and |xₙ₊₁-x*|=L/(1-L)·|xₙ₊₁-xₙ| for every n. Key: |x₁-x₀|=(1-L)|x₀| and |xₙ₊₁-xₙ|=Lⁿ(1-L)|x₀|, cancelling the (1-L) denominators. Prior iterate_dist_sharp certified only the raw Lⁿ factor, not the derived /(1-L) constants."
+      "SHARPNESS: the affine contraction f(t)=L·t (extremal L-contraction, |fa-fb|=L|a-b|) with iterates xₙ=Lⁿ·x₀ about fixed point 0 attains BOTH estimate constants with equality: |xₙ-x*|=Lⁿ/(1-L)·|x₁-x₀| and |xₙ₊₁-x*|=L/(1-L)·|xₙ₊₁-xₙ| for every n. Key: |x₁-x₀|=(1-L)|x₀| and |xₙ₊₁-xₙ|=Lⁿ(1-L)|x₀|, cancelling the (1-L) denominators. Prior iterate_dist_sharp certified only the raw Lⁿ factor, not the derived /(1-L) constants.",
+      "SHARPNESS of the one-query bound: adversary_error_bound only gave max(|a-p|,|a-q|) ≥ |p-q|/2; the matching = is attained at the MIDPOINT a=(p+q)/2 (both errors equal |p-q|/2 exactly). So min over answers a of the worst-case error is EXACTLY |p-q|/2 (adversary_minimax as IsLeast). Specialized to the pair {1/4,3/4}: the constant algorithm A≡1/2 (midpoint) achieves worst-case error exactly 1/4, matching one_query_lower_bound ⟹ one-query complexity against {f,g} is EXACTLY 1/4 (one_query_complexity IsLeast). Note this 1/4 is against the specific pair; the full-class one-query minimax is 1/2 (Tightness file) — distinct quantities."
     ],
     "mathlibGaps": [],
     "nextSteps": [


### PR DESCRIPTION
## Summary
Research session for `brouwer-fixed-point-oq-02-oq-02-oq-01` (explicit adversary lower bound for fixed-point query complexity). The core question was already solved; this PR **sharpens the one-query lower bound into a two-sided exact characterization** by supplying the missing matching upper bound.

## Progress (Adversary file: 16 → 20 theorems, 0 axioms, 0 sorries)
Added Section VI to `proofs/Proofs/BrouwerFixedPointOQ02OQ02OQ01Adversary.lean`:
- `adversary_midpoint_optimal` — the midpoint answer `(p+q)/2` errs by **exactly** `|p-q|/2` on both instances (the `=` companion to `adversary_error_bound`, which only gave `≥`).
- `adversary_minimax` — the exact minimax of the abstract adversary principle is `|p-q|/2` (`IsLeast`).
- `one_query_upper_bound` — the constant algorithm `A ≡ 1/2` attains worst-case error exactly `1/4` on the explicit pair `{f, g}`.
- `one_query_complexity` — the least worst-case error over **all** one-query algorithms against `{f, g}` is **exactly `1/4`** (`IsLeast`).

## Findings
- The prior `one_query_lower_bound` (error ≥ 1/4) had no matching upper bound; the `1/4` constant was never shown optimal. The midpoint answer closes this: minimax against `{f,g}` = 1/4 exactly.
- This 1/4 (against the specific adversary pair) is distinct from the full-class one-query minimax of 1/2 (Tightness file) — the pair-specific complexity is strictly smaller because the algorithm knows the two candidate fixed points.

## Verification
- Elaboration-clean via `lake env lean` against Mathlib v4.26 (exit 0, no errors/warnings).
- 0 `axiom` declarations, 0 sorries, no `native_decide`.

## Status
**Outcome**: progress (sharpening of a solved problem — lower bound made two-sided/exact)
**Next Steps**: none proposed — OQ chain is at depth 3 (cap), so no follow-up children generated per the OQ-chain depth guard. The genuinely deep next step (fully-adaptive multi-query adversary) remains open.

🤖 Generated by researcher-11