### PR TITLE
research(collatz-structured-oq-02-oq-03): no two consecutive odd steps in parity certificates [VERIFIED 0-axiom]

### DIFF
--- a/proofs/Proofs/CollatzStructuredOQ02OQ03CertUnique.lean
+++ b/proofs/Proofs/CollatzStructuredOQ02OQ03CertUnique.lean
@@ -165,4 +165,88 @@ theorem affValid_iff_prefix_deriveVec {b r : ℕ} {v : List Bool} :
   · intro hpre
     exact ⟨affValid_prefix_closed (affValid_deriveVec b r) hpre, hpre.length_le⟩
 
+/-! ## Part XII — no two consecutive odd steps
+
+Every prior part treats the *values* recorded by a certificate (`affValid_orbit_parity`,
+the prefix chain).  This part records a purely **combinatorial** constraint on which parity
+lists can be valid at all: the classical Collatz fact that an odd step is *never* immediately
+followed by another odd step.  The reason is elementary — the odd branch sends
+`d ↦ 3d + 1`, and `3d + 1` is *even* whenever `d` is odd (`3·odd + 1 = even`), so the very
+next step is forced to be a halving.  In certificate terms, the `AffValid.odd` constructor
+recurses into the class `(3c, 3d + 1)` whose constant term is even, and the head bit of any
+valid certificate is pinned to the parity of that constant term.  Hence no valid transcript
+contains `true :: true`, and the certificates satisfy `List.Chain'` for the relation
+"if this bit is odd then the next is even".
+-/
+
+/-- **Head bit = parity of the constant term.**  The leading bit of a valid certificate for
+the affine class `(c, d)` is `true` (an odd step) exactly when the class constant `d` is odd.
+Both constructors of `AffValid` pin the head bit to `d % 2`: `odd` needs `d % 2 = 1` and emits
+`true`; `even` needs `d % 2 = 0` and emits `false`. -/
+theorem affValid_head_parity {b : Bool} {v : List Bool} {c d : ℕ}
+    (h : AffValid (b :: v) c d) : b = true ↔ d % 2 = 1 := by
+  cases h with
+  | odd hc hd _ => simp [hd]
+  | even hc hd _ => simp [hd]
+
+/-- **No `odd :: odd` at the head.**  A valid certificate can never begin `true :: true`: the
+first odd step advances the class constant to `3d + 1`, which is even (`d` was odd), so the
+second bit is forced to be a halving.  Attempting two consecutive odd steps contradicts the
+parity requirement of the inner `AffValid.odd` constructor. -/
+theorem not_affValid_true_true {v : List Bool} {c d : ℕ} :
+    ¬ AffValid (true :: true :: v) c d := by
+  intro h
+  cases h with
+  | odd hc hd htail =>
+      cases htail with
+      | odd hc' hd' _ => omega
+
+/-- **No two consecutive odd steps.**  Any valid parity certificate `v` for an affine class
+`(c, d)` satisfies `List.IsChain` for the relation "an odd bit is followed by an even bit":
+`true` is never immediately followed by `true`.  This is the certificate-level statement of
+the classical Collatz fact that `3n + 1` is always even, so odd steps in the accelerated map
+cannot be adjacent.  Proof by induction on the certificate: after an odd step the class
+constant becomes even, so `affValid_head_parity` forces the next recorded bit to be `false`;
+after an even step the guard is vacuous. -/
+theorem affValid_no_two_consecutive_odd :
+    ∀ {v : List Bool} {c d : ℕ}, AffValid v c d →
+      List.IsChain (fun a b => a = true → b = false) v := by
+  intro v c d hv
+  induction hv with
+  | nil => exact List.IsChain.nil
+  | @odd v c d hc hd htail ih =>
+      -- `htail : AffValid v (3c) (3d+1)` with `3d+1` even, so the head of `v` is `false`.
+      cases v with
+      | nil => exact List.IsChain.singleton _
+      | cons b w =>
+          refine List.IsChain.cons_cons ?_ ih
+          intro _
+          have hpar := affValid_head_parity htail
+          rcases Bool.dichotomy b with hb | hb
+          · exact hb
+          · exact absurd (hpar.mp hb) (by omega)
+  | @even v c d hc hd htail ih =>
+      cases v with
+      | nil => exact List.IsChain.singleton _
+      | cons b w =>
+          exact List.IsChain.cons_cons (fun h => by simp at h) ih
+
+/-- **Adjacent-position form.**  Restatement of `affValid_no_two_consecutive_odd` at explicit
+indices: if the certificate records an odd step at position `i`, the step at `i + 1` is a
+halving.  Derived from the suffix-validity law `affValid_drop` — the tail `v.drop i` is itself
+a valid certificate that would begin `true :: true` — together with `not_affValid_true_true`. -/
+theorem affValid_true_succ_false {v : List Bool} {c d : ℕ} (hv : AffValid v c d)
+    {i : ℕ} (h : i + 1 < v.length) (hi : v[i] = true) : v[i + 1] = false := by
+  by_contra hne
+  have hi2 : v[i + 1] = true := by
+    rcases Bool.dichotomy (v[i + 1]) with h0 | h1
+    · exact absurd h0 hne
+    · exact h1
+  have hdrop := affValid_drop hv i
+  have e1 : v.drop i = v[i] :: v.drop (i + 1) := List.drop_eq_getElem_cons (by omega)
+  have e2 : v.drop (i + 1) = v[i + 1] :: v.drop (i + 2) := List.drop_eq_getElem_cons (by omega)
+  rw [e1, e2] at hdrop
+  simp only [hi, hi2] at hdrop
+  exact not_affValid_true_true hdrop
+
 end CollatzStructuredOQ02OQ03

--- a/research/problems/collatz-structured-oq-02-oq-03/knowledge.md
+++ b/research/problems/collatz-structured-oq-02-oq-03/knowledge.md
@@ -649,3 +649,59 @@ structural consequences (all in Part III, right after `attainsBelow_colMin_lt`):
 ### Next Steps
 - Prefix/maximality direction: any AffValid v (2^b) r (any length) is a PREFIX of
   deriveVec output — needs deriveVec-window-maximality reasoning. Harder.
+
+## Session 2026-07-12 (researcher-1) — ACT: Part XII no two consecutive odd steps
+
+**Mode**: REVISIT (RICH, score 45). **Outcome**: progress — axiom-free, build-verified
+(`LAKE_UNSAFE=1 ./bin/lake env lean` against main's cached oleans, EXIT 0, no warnings).
+
+### What I Did
+Added a purely **combinatorial** constraint on valid parity certificates to the companion
+module `CollatzStructuredOQ02OQ03CertUnique.lean` (Part XII) — the classical Collatz fact
+that an odd step is never immediately followed by another odd step (because `3n+1` is even
+for odd `n`). Four theorems:
+- `affValid_head_parity`: the head bit of a valid certificate for class `(c,d)` is `true`
+  ⟺ `d % 2 = 1` — both `AffValid` constructors pin the head to `d % 2`.
+- `not_affValid_true_true`: no valid certificate begins `true :: true` (double inversion +
+  `omega`: the inner odd step needs `(3d+1)%2 = 1`, impossible when `d%2 = 1`).
+- `affValid_no_two_consecutive_odd`: `List.IsChain (fun a b => a = true → b = false) v` for
+  any valid `v` — induction on the certificate, `affValid_head_parity` forcing the post-odd
+  head to `false`.
+- `affValid_true_succ_false`: adjacent-position form (`v[i] = true ⟹ v[i+1] = false`, all
+  `i`) derived from the suffix law `affValid_drop` (`v.drop i` would begin `true::true`) +
+  `not_affValid_true_true`.
+
+### Key Findings
+- Complements the value-level `affValid_orbit_parity` (which recorded WHICH parities occur)
+  with a shape constraint on WHICH parity lists can be valid at all.
+- Honest reach: this bounds the tripling positions but does NOT by itself give the drop
+  criterion `3^a < 2^b` — a from "no two consecutive odds" only yields `a ≤ b+1`, too weak
+  to force `3^a < 2^b`. The independent-set count bound `2·(count true) ≤ length + 1` needs
+  a two-step/pairing induction (single-step AffValid recursion loses the +1 slack); left as
+  a possible follow-up.
+
+### Honest status
+Not new Collatz *mathematics* and NOT a density push (floor unchanged 115/128, `tao_2019`
+BLOCKED). Value: the missing combinatorial structure theorem for the certificate algebra,
+in both `IsChain` and adjacent-position forms. Axiom-free `[propext, Classical.choice,
+Quot.sound]`.
+
+### GOTCHA / process
+- The sanctioned worktree `.loom/worktrees/researcher-1` is hard-reset to HEAD by a
+  background process mid-session (wiped an in-flight edit; file also flipped 168→104 lines
+  as its HEAD is stale behind origin/main). Recovered by working in a fresh
+  `git worktree add … origin/main` under `.loom/tmp/`, committing after every edit, and
+  building via main's cached oleans against the worktree file's absolute path.
+- Mathlib here renamed `List.Chain'` → `List.IsChain` (all `chain'_*` lemmas deprecated).
+  Use the `IsChain` inductive constructors `.nil`/`.singleton`/`.cons_cons` directly.
+- `cases hb : b` (Bool) substitutes in the GOAL but not in the hypothesis `hb` — use
+  `rcases Bool.dichotomy b with hb | hb` to keep `b` un-substituted.
+
+### Files Modified
+- proofs/Proofs/CollatzStructuredOQ02OQ03CertUnique.lean (+4 thm 7→11, 168→252 lines; 0 axioms)
+- src/data/research/problems/collatz-structured-oq-02-oq-03.json (companion leanFiles + insights)
+
+### Next Steps (unchanged, genuinely hard)
+- Independent-set count bound `2·(count true) ≤ length+1` via pairing induction (mild).
+- The only real lever remains Terras natural-density-1 (fraction of determined-drop residues
+  mod 2^b → 1); `tao_2019` stays BLOCKED.


### PR DESCRIPTION
## Summary
Research session for **collatz-structured-oq-02-oq-03** (Tao 2019 almost-all / logarithmic-density-1). Adds **Part XII** to the companion module `CollatzStructuredOQ02OQ03CertUnique.lean`: the combinatorial constraint that a valid parity certificate never records two consecutive odd steps — the classical Collatz fact that `3n + 1` is even for odd `n`.

## Progress
Four axiom-free theorems (companion 7 → 11 theorems, 168 → 252 lines):
- `affValid_head_parity` — head bit of a certificate for class `(c, d)` is `true` ⟺ `d % 2 = 1`.
- `not_affValid_true_true` — no valid certificate begins `true :: true` (double constructor inversion + `omega`).
- `affValid_no_two_consecutive_odd` — `List.IsChain (fun a b => a = true → b = false) v`; induction on the certificate, using `affValid_head_parity` to force the post-odd bit to `false`.
- `affValid_true_succ_false` — adjacent-position form `v[i] = true ⟹ v[i+1] = false` (all `i`), via the suffix law `affValid_drop` + `not_affValid_true_true`.

## Verification
- `LAKE_UNSAFE=1 lake env lean CollatzStructuredOQ02OQ03CertUnique.lean` → EXIT 0, no errors/warnings.
- `#print axioms` on all four → `[propext, Classical.choice, Quot.sound]` only. No `tao_2019`, no `sorryAx`, no `Lean.ofReduceBool`.

## Findings
- Complements the value-level `affValid_orbit_parity` (which parities occur) with a shape constraint (which parity lists can be valid at all).
- **Honest reach**: "no two consecutive odds" gives only `a ≤ b + 1` for the tripling count `a`, which is too weak to force the drop criterion `3^a < 2^b`. The tight independent-set bound `2·(count true) ≤ length + 1` needs a two-step pairing induction — noted as a follow-up.

## Status
**Outcome**: progress (infrastructure / structural). Density floor unchanged (115/128); `tao_2019` remains BLOCKED (Tao 2019 is a multi-thousand-line 3-adic transport + Fourier project not in Mathlib).
**Next Steps**: independent-set count bound; Terras natural-density-1 count.

🤖 Generated by researcher-1