### PR TITLE
Enrich Exponent-Swap Reflection Symmetry (buffons-needle-oq-...-oq-02): S₂ keyInsight + section split

### DIFF
--- a/src/data/proofs/buffons-needle-oq-01-oq-01-oq-04-oq-01-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/buffons-needle-oq-01-oq-01-oq-04-oq-01-oq-01-oq-01-oq-02/meta.json
@@ -36,16 +36,26 @@
       "The reflection symmetry is not really about FTC or antiderivatives at all — it is a pure change of variables. Stripping the parent's single-power statement down to its mechanism reveals a two-parameter lemma whose proof is three tactic lines: integral_comp_sub_left, simp with the two complementary-angle identities, and integral_congr with mul_comm.",
       "Because the complementary-angle identities sin(π/2−θ)=cos θ and cos(π/2−θ)=sin θ are unconditional and act on the *bases* of the powers, the proof is completely insensitive to the exponent type. The natural-number and Real.rpow versions are literally the same script, so the general (real-exponent) lemma is obtained at no extra cost — and it is the form that meets the Euler Beta integral.",
       "Euler's Beta symmetry B(x,y) = B(y,x), in the trigonometric representation B(x,y) = 2∫_0^{π/2} sin^{2x−1}θ cos^{2y−1}θ dθ, is exactly this exponent swap at exponents 2x−1, 2y−1. The reflection therefore gives a Gamma-free proof of Beta symmetry — the symmetry half of the Beta theory, cleanly separated from the (harder) evaluation half that needs the Gamma recurrence.",
-      "The parent's hand-rolled reflection identity ∫ sin θ · cosᵐ θ = ∫ cos θ · sinᵐ θ is recovered verbatim as the a = 1 slice, confirming the new lemma is a genuine generalization rather than a restatement, and supplying the reusable bridge the open question asked for."
+      "The parent's hand-rolled reflection identity ∫ sin θ · cosᵐ θ = ∫ cos θ · sinᵐ θ is recovered verbatim as the a = 1 slice, confirming the new lemma is a genuine generalization rather than a restatement, and supplying the reusable bridge the open question asked for.",
+      "Structurally the result is an order-2 symmetry: the exponent swap (a,b) ↦ (b,a) is the nontrivial element of the symmetric group S₂ acting on the pair of exponents, and the domain reflection θ ↦ π/2−θ is the involution that realizes it (applying it twice returns the original integral). The fixed locus of this action is the diagonal a = b, where the symmetry is vacuous — the integral is related only to itself. This reading is exactly why the closing example on the diagonal is a genuine orientation check on the statement, not new content: it confirms the lemma is stated in the direction that becomes an identity precisely on the fixed set of the S₂-action."
     ]
   },
   "sections": [
     {
-      "id": "exponent-swap-lemma",
-      "title": "The exponent-swap lemma",
+      "id": "overview-problem",
+      "title": "Overview and problem statement",
       "startLine": 1,
+      "endLine": 44,
+      "summary": "Import (Mathlib), the module docstring, opens (Real, intervalIntegral, MeasureTheory), and the namespace declaration. The docstring frames the open question inherited from the parent — whether the single-power reflection packages into one reusable exponent-swap lemma — lists the four main results (ℕ swap, rpow swap, Beta symmetry, parent recovery), and states the boundary: the file isolates the symmetry content and defers the Gamma-ratio evaluation to the Beta/Gamma API.",
+      "content": "The file opens with the orientation material: the Mathlib import, the module docstring, the opens (Real, intervalIntegral, MeasureTheory), and the namespace. The docstring records the provenance — the parent BuffonsNeedleOQ01OQ01OQ04OQ01OQ01OQ01 proved only the single-power reflection and flagged the general exponent-swap lemma as its second open question — and previews the four theorems this file delivers, together with the explicit scope note that only the symmetry (not the Gamma-dependent evaluation) is treated here.",
+      "mathContext": "Goal: package the reflection $\\theta\\mapsto\\tfrac{\\pi}{2}-\\theta$ into the reusable swap $\\int_0^{\\pi/2}\\sin^a\\theta\\cos^b\\theta = \\int_0^{\\pi/2}\\sin^b\\theta\\cos^a\\theta$."
+    },
+    {
+      "id": "exponent-swap-lemma",
+      "title": "The exponent-swap lemma (ℕ exponents)",
+      "startLine": 45,
       "endLine": 64,
-      "summary": "Module docstring, imports (Mathlib), opens (Real, intervalIntegral, MeasureTheory), namespace, then the headline lemma integral_sin_pow_mul_cos_pow_swap: ∫₀^{π/2} sinᵃθ cosᵇθ = ∫₀^{π/2} sinᵇθ cosᵃθ for a,b : ℕ, by the reflection θ ↦ π/2−θ (which fixes [0,π/2]) via intervalIntegral.integral_comp_sub_left and the complementary-angle identities.",
+      "summary": "The headline lemma integral_sin_pow_mul_cos_pow_swap: ∫₀^{π/2} sinᵃθ cosᵇθ = ∫₀^{π/2} sinᵇθ cosᵃθ for a,b : ℕ, by the reflection θ ↦ π/2−θ (which fixes [0,π/2]) via intervalIntegral.integral_comp_sub_left and the complementary-angle identities.",
       "content": "The headline lemma integral_sin_pow_mul_cos_pow_swap asserts ∫_0^{π/2} sinᵃθ cosᵇθ = ∫_0^{π/2} sinᵇθ cosᵃθ for a, b : ℕ. The proof applies intervalIntegral.integral_comp_sub_left with center π/2 and interval [0, π/2], which is fixed by the reflection (its endpoints map to π/2−π/2 = 0 and π/2−0 = π/2). The complementary-angle identities sin(π/2−θ)=cos θ and cos(π/2−θ)=sin θ rewrite the reflected integrand into cosᵃθ sinᵇθ, and one integral_congr with mul_comm transposes the factors onto the target.",
       "mathContext": "$\\int_0^{\\pi/2}\\sin^a\\theta\\cos^b\\theta\\,d\\theta = \\int_0^{\\pi/2}\\sin^b\\theta\\cos^a\\theta\\,d\\theta$ via $\\theta\\mapsto\\tfrac{\\pi}{2}-\\theta$."
     },


### PR DESCRIPTION
Enrichment pass for `buffons-needle-oq-01-oq-01-oq-04-oq-01-oq-01-oq-01-oq-02`.

This entry was at quality 96 — content-complete (6 fully-populated annotations, 534-char historicalContext, 2 substantive open questions, deep proofStrategy) but below the gallery's quality-100 standard on two count thresholds. Rather than filler, both additions are genuinely substantive:

**1. 5th keyInsight (group-theoretic framing).** The exponent swap (a,b) ↦ (b,a) is the nontrivial element of S₂ acting on exponent pairs, and the domain reflection θ ↦ π/2−θ is the involution realizing it; the fixed locus is the diagonal a=b, where the symmetry is vacuous. This explains *why* the closing diagonal example (Lean lines 109–115) is a genuine orientation check on the statement rather than new content — a conceptual point none of the existing 4 insights made.

**2. Section split (4 → 5).** The old section 1 (lines 1–64) bundled the file-level overview docstring with the ℕ headline lemma. Split into:
- `Overview and problem statement` (1–44): import, docstring provenance/results-list/scope, opens, namespace.
- `The exponent-swap lemma (ℕ exponents)` (45–64): the headline lemma proof.

Sections now cover the full file (1–117) contiguously, matching how quality-100 gallery entries isolate the orientation docstring as its own section.

- meta.json 17.5 KB (well under ~60 KB cap); all collections under their caps.
- No existing content deleted; content depth unchanged elsewhere.
- axiom integrity unchanged: status `verified`, axiomCount 0 — matches the Lean file (0 axioms, 0 sorries).
- `pnpm build` gallery-data + search-index validation pass (final `tsc` step fails only on missing node_modules, an env gap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)