### PR TITLE
Research: erdos-1008-oq-02-oq-02 - general K_{s,t} monotonicity + K_{s,t}≅K_{t,s} symmetry

### DIFF
--- a/proofs/Proofs/Erdos1008OQ02OQ02.lean
+++ b/proofs/Proofs/Erdos1008OQ02OQ02.lean
@@ -971,6 +971,57 @@ theorem hasKst_two_iff_hasK2t (G : SimpleGraph V) (t : ℕ) :
     · exact (hadj v hv).1
     · exact (hadj v hv).2
 
+/-- **`HasKst` is antitone in the common-neighbour count `t`.**  Shrinking the required
+number of common neighbours cannot destroy a `K_{s,t}`: the same witness `⟨S, T⟩` serves,
+its cardinality bound merely weakened `t ↦ t'` (`le_trans`).  The `s`-general analogue of
+`hasK2t_mono`. -/
+theorem hasKst_mono_t (G : SimpleGraph V) {s t t' : ℕ} (htt' : t' ≤ t)
+    (h : HasKst G s t) : HasKst G s t' := by
+  obtain ⟨S, T, hS, hT, hadj⟩ := h
+  exact ⟨S, T, hS, le_trans htt' hT, hadj⟩
+
+/-- **`HasKst` is antitone in the part size `s`.**  Shrinking the `s`-side cannot destroy a
+`K_{s,t}`: any `s'`-subset `S' ⊆ S` (`s' ≤ s = |S|`) keeps all of `T` as common neighbours,
+since fewer vertices impose fewer adjacency constraints.  Uses `Finset.exists_subset_card_eq`
+to extract `S'`; the adjacency clause restricts along `S' ⊆ S`. -/
+theorem hasKst_mono_s (G : SimpleGraph V) {s s' t : ℕ} (hss' : s' ≤ s)
+    (h : HasKst G s t) : HasKst G s' t := by
+  obtain ⟨S, T, hS, hT, hadj⟩ := h
+  obtain ⟨S', hS'sub, hS'card⟩ := Finset.exists_subset_card_eq (hss'.trans_eq hS.symm)
+  exact ⟨S', T, hS'card, hT, fun a ha v hv => hadj a (hS'sub ha) v hv⟩
+
+/-- **`HasKst` is monotone in both indices.**  `K_{s',t'} ⊆ K_{s,t}` whenever `s' ≤ s` and
+`t' ≤ t`, so a graph containing the larger complete bipartite graph contains the smaller.
+Compose `hasKst_mono_s` and `hasKst_mono_t`. -/
+theorem hasKst_mono (G : SimpleGraph V) {s s' t t' : ℕ} (hss' : s' ≤ s) (htt' : t' ≤ t)
+    (h : HasKst G s t) : HasKst G s' t' :=
+  hasKst_mono_t G htt' (hasKst_mono_s G hss' h)
+
+/-- **`K_{s,t}`-freeness nests.**  A graph free of the smaller `K_{s',t'}` (`s' ≤ s`,
+`t' ≤ t`) is automatically free of the larger `K_{s,t}` — the contrapositive of
+`hasKst_mono`.  So the `K_{s,t}`-free graph classes form a lattice-decreasing family,
+`Free(s',t') ⊆ Free(s,t)`. -/
+theorem not_hasKst_mono (G : SimpleGraph V) {s s' t t' : ℕ} (hss' : s' ≤ s) (htt' : t' ≤ t)
+    (h : ¬ HasKst G s' t') : ¬ HasKst G s t :=
+  fun hc => h (hasKst_mono G hss' htt' hc)
+
+/-- **Symmetry of `K_{s,t}` containment: `K_{s,t} ≅ K_{t,s}`.**  A graph contains `K_{s,t}`
+iff it contains `K_{t,s}`: the complete bipartite graph is symmetric under swapping its two
+parts.  Given an `s`-set `S` with `≥ t` common neighbours `T`, cut `T` down to a `t`-set
+`T'` (`Finset.exists_subset_card_eq`); then `T'` is an `t`-set whose `s` common neighbours
+include all of `S` (every `v ∈ S` is adjacent to every `a ∈ T' ⊆ T`, using `G.Adj` symmetry).
+Both directions are the same argument with `s, t` swapped.  A consequence:
+`ex(n; K_{s,t}) = ex(n; K_{t,s})`, so the KST forcing applies from either side. -/
+theorem hasKst_comm (G : SimpleGraph V) (s t : ℕ) :
+    HasKst G s t ↔ HasKst G t s := by
+  constructor
+  · rintro ⟨S, T, hS, hT, hadj⟩
+    obtain ⟨T', hT'sub, hT'card⟩ := Finset.exists_subset_card_eq hT
+    exact ⟨T', S, hT'card, hS.ge, fun a ha v hv => (hadj v hv a (hT'sub ha)).symm⟩
+  · rintro ⟨S, T, hS, hT, hadj⟩
+    obtain ⟨T', hT'sub, hT'card⟩ := Finset.exists_subset_card_eq hT
+    exact ⟨T', S, hT'card, hS.ge, fun a ha v hv => (hadj v hv a (hT'sub ha)).symm⟩
+
 /-- **Codegree bound from `K_{s,t}`-freeness.**  In a `K_{s,t}`-free graph any
 `s`-set `S` of vertices has fewer than `t` common neighbours: otherwise those
 `≥ t` common neighbours would witness a `K_{s,t}`.  The `s`-general analogue of

--- a/research/problems/erdos-1008-oq-02-oq-02/knowledge.md
+++ b/research/problems/erdos-1008-oq-02-oq-02/knowledge.md
@@ -126,3 +126,32 @@ converse, plus the leading-order closed form `ex(n;K_{2,t}) ≤ ½(√(t-1)·n^{
 machine-checked. The OQ deliverable is complete and verified; the only remaining item
 noted earlier — an explicit ℝ leading-order corollary — was already shipped as
 `kst_edge_bound_leading_order` / `kst_radical_envelope`.
+
+## Session 2026-07-12 (researcher-7) — general K_{s,t} structural layer: monotonicity + symmetry
+
+**Mode:** REVISIT (node `Erdos1008OQ02OQ02.lean`, 1292→1338 lines, 0-axiom/0-sorry; JSON
+`leanFiles` lineCount is stale). **Outcome:** progress — 5 new axiom-free theorems.
+
+The general `HasKst G s t` (`∃ S T, |S|=s ∧ t ≤ |T| ∧ complete bipartite`) had the s=2
+monotonicity (`hasK2t_mono`) but no general-s structural closure and, notably, no symmetry.
+Added, right after `hasKst_two_iff_hasK2t`:
+
+- `hasKst_mono_t` — antitone in `t` (weaken `t ≤ |T|` via `le_trans`; same witness).
+- `hasKst_mono_s` — antitone in `s`: restrict to an `s'`-subset `S' ⊆ S` via
+  `Finset.exists_subset_card_eq (hss'.trans_eq hS.symm)`; fewer vertices ⇒ fewer adjacency
+  constraints, `T` still common.
+- `hasKst_mono` — monotone in both indices (compose the two).
+- `not_hasKst_mono` — contrapositive: `K_{s',t'}`-free ⇒ `K_{s,t}`-free (`s'≤s`, `t'≤t`);
+  the free classes nest.
+- `hasKst_comm : HasKst G s t ↔ HasKst G t s` — **symmetry `K_{s,t} ≅ K_{t,s}`**: cut the
+  `≥ t` common neighbours down to a `t`-set `T'`, which is a `t`-set whose `s` common
+  neighbours include `S` (via `G.Adj` symmetry). Both directions identical with `s,t` swapped.
+  Consequence: `ex(n; K_{s,t}) = ex(n; K_{t,s})`, so the KST forcing applies from either side.
+
+★Mathlib lemma is `Finset.exists_subset_card_eq (h : n ≤ #s) : ∃ t ⊆ s, #t = n`
+(NOT `Finset.exists_smaller_set`, which does not exist in this Mathlib v4.26).
+
+VERIFIED: `lake env lean` EXIT 0, no errors/sorries; `#print axioms` = [propext,(Classical.choice,)
+Quot.sound] for all five (no `sorryAx`, no `Lean.ofReduceBool`). File research-only (no gallery
+meta). OQ depth 2; **0 follow-ups** generated (general K_{s,t} theory saturated; the open frontier
+is the sharp lower-bound / Reiman construction, already tracked).

--- a/src/data/research/problems/erdos-1008-oq-02-oq-02.json
+++ b/src/data/research/problems/erdos-1008-oq-02-oq-02.json
@@ -37,7 +37,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: closed the documented convexity/Jensen gap — general K_{s,t} now has a fully axiom-free closed-form edge bound 2m ≤ (t-1)^{1/s} n^{2-1/s} + (s-1)n (kst_general_edge_bound_rpow), not just the codegree double-count.",
+    "progressSummary": "PROGRESS: added the general K_{s,t} structural layer to Erdos1008OQ02OQ02.lean — monotonicity of HasKst in both part-sizes (hasKst_mono_s/_t/mono), freeness nesting (not_hasKst_mono), and the K_{s,t}≅K_{t,s} symmetry (hasKst_comm, giving ex(n;K_{s,t})=ex(n;K_{t,s})). All 5 axiom-free, elab EXIT 0. File stays 0-axiom/0-sorry.",
     "builtItems": [
       "kst_quadratic_solve (Erdos1008OQ02OQ02.lean): solves the general K_{2,t} KST quadratic 4m^2 <= (t-1)n^2(n-1)+2nm for the upper root 4m <= n(1+s), s=sqrt(1+4(t-1)(n-1))",
       "reiman_quadratic_solve_of_kst: t=2 specialisation recovering the sibling C4 lemma verbatim (1+4(t-1)(n-1)=4n-3)",
@@ -57,7 +57,10 @@
       "kst_star_count_of_free (∑_v C(d_v,s) ≤ (t-1)·C(n,s), the s-general KST core) — all axiom-free, host-lean VERIFIED v4.26.0",
       "kst_analytic_core (Erdos1008OQ02OQ02.lean): abstract Jensen upgrade — degree seq d, 2M=∑d_v, ∑C(d_v,s)≤(t-1)C(n,s), 2M≥(s-1)n ⊢ (2M-(s-1)n)^s ≤ (t-1)n^(2s-1); axiom-free",
       "kst_general_power_bound (Erdos1008OQ02OQ02.lean): graph-level closed-form power bound for K_{s,t}-free G via handshake + kst_star_count_of_free; axiom-free",
-      "kst_general_edge_bound_rpow (Erdos1008OQ02OQ02.lean): unconditional classical KST 2m ≤ (t-1)^(1/s) n^(2-1/s) + (s-1)n via monotone s-th root (Real.pow_rpow_inv_natCast, Real.mul_rpow); axiom-free"
+      "kst_general_edge_bound_rpow (Erdos1008OQ02OQ02.lean): unconditional classical KST 2m ≤ (t-1)^(1/s) n^(2-1/s) + (s-1)n via monotone s-th root (Real.pow_rpow_inv_natCast, Real.mul_rpow); axiom-free",
+      "Erdos1008OQ02OQ02.lean: hasKst_mono_t / hasKst_mono_s / hasKst_mono — HasKst monotone in t, s, and both (general-s analogue of hasK2t_mono).",
+      "Erdos1008OQ02OQ02.lean: not_hasKst_mono — K_{s,t}-free classes nest (Free(s,t) ⊆ Free(s,t)).",
+      "Erdos1008OQ02OQ02.lean: hasKst_comm — symmetry HasKst G s t ↔ HasKst G t s (K_{s,t}≅K_{t,s})."
     ],
     "insights": [
       "The C4 algebraic core generalises to K_{2,t} with zero structural change: replace the single-common-neighbour bound by (t-1), so s^2=4n-3 becomes s^2=1+4(t-1)(n-1) and the KST quadratic gains a (t-1) factor on the n^2(n-1) term. Same nlinarith case-split proof works.",
@@ -67,7 +70,8 @@
       "The problem title ('explicit closed-form solve of the KST quadratic') is fully witnessed at the algebraic level by kst_quadratic_factor: the quadratic 4x²-2nx-(t-1)n²(n-1) has EXACTLY the two roots n(1±s)/4 with s²=1+4(t-1)(n-1), so the Reiman/KST upper bound n(1+s)/4 loses nothing algebraically — all residual slack in ex(n;K_{2,t}) is extremal-graph existence, not the quadratic-formula step. Equality goal closed by linear_combination with coefficient n²/4 (the s²-coefficient of the discriminant), not nlinarith.",
       "The genuine Kővári–Sós–Turán double-count is the s-general s-star count ∑_v C(d_v,s)=∑_{|S|=s} codeg(S) ≤ (t-1)·C(n,s); the file previously had only the s=2 (K_{2,t}) slice. Proved the full s-general combinatorial core (kst_star_count_nat/_choose/_of_free) via Finset.powersetCard double-counting + Finset.sum_comm, exactly mirroring kst_cherry_count_nat but with powersetCard s in place of offDiag. No analysis needed; axiom-free.",
       "Convexity/Jensen step for the general K_{s,t} bound is realized elementarily WITHOUT proving convexity of the descending factorial: route through C(d,s) ≥ (d-s+1)^s/s! (each of s descending factors ≥ d-s+1, Nat.pow_sub_le_descFactorial) then Mathlib power-mean pow_sum_le_card_mul_sum_pow (Jensen for x↦x^s).",
-      "Sharp KST power form (2m-(s-1)n)^s ≤ (t-1)·n^(2s-1) is the general-s analogue of the s=2 quadratic 4m² ≤ (t-1)n²(n-1)+2nm; s-th root gives the classical 2m ≤ (t-1)^(1/s) n^(2-1/s) + (s-1)n unconditionally (sparse regime 2m<(s-1)n handled by nonnegativity)."
+      "Sharp KST power form (2m-(s-1)n)^s ≤ (t-1)·n^(2s-1) is the general-s analogue of the s=2 quadratic 4m² ≤ (t-1)n²(n-1)+2nm; s-th root gives the classical 2m ≤ (t-1)^(1/s) n^(2-1/s) + (s-1)n unconditionally (sparse regime 2m<(s-1)n handled by nonnegativity).",
+      "General K_{s,t} containment HasKst G s t is symmetric (K_{s,t} ≅ K_{t,s}, hasKst_comm) and monotone in both indices; symmetry gives ex(n;K_{s,t})=ex(n;K_{t,s}). Proved via Finset.exists_subset_card_eq (the correct Mathlib name; exists_smaller_set does not exist here)."
     ],
     "mathlibGaps": [
       "No graph-level general cherry-count sum_v C(d_v,2) <= (t-1)*C(n,2) for K_{2,t}-free graphs in the gallery; parent Erdos1008Problem only proves the t=2 (C4) case kovari_sos_turan.",


### PR DESCRIPTION
## Summary
Research session for `erdos-1008-oq-02-oq-02` (Kővári–Sós–Turán extremal number, node
`Erdos1008OQ02OQ02.lean`). The general `HasKst G s t` containment relation had s=2
monotonicity (`hasK2t_mono`) but no general-`s` structural closure and, notably, no
symmetry. This PR adds both.

## Progress — 5 new axiom-free theorems
- **`hasKst_mono_t`** — antitone in the common-neighbour count `t`.
- **`hasKst_mono_s`** — antitone in the part size `s` (restrict to an `s'`-subset via
  `Finset.exists_subset_card_eq`; fewer vertices ⇒ fewer adjacency constraints).
- **`hasKst_mono`** — monotone in both indices (compose the two).
- **`not_hasKst_mono`** — contrapositive: the `K_{s,t}`-free graph classes nest,
  `Free(s',t') ⊆ Free(s,t)`.
- **`hasKst_comm`** — symmetry `HasKst G s t ↔ HasKst G t s` (`K_{s,t} ≅ K_{t,s}`): cut the
  `≥ t` common neighbours down to a `t`-set, which is a `t`-set whose common neighbours
  include the original `s`-set (using `G.Adj` symmetry). Consequence:
  `ex(n; K_{s,t}) = ex(n; K_{t,s})`, so the KST forcing applies from either side.

## Files modified
- `proofs/Proofs/Erdos1008OQ02OQ02.lean` (1292 → 1343 lines; still 0-axiom / 0-sorry)
- `research/problems/erdos-1008-oq-02-oq-02/knowledge.md`
- `src/data/research/problems/erdos-1008-oq-02-oq-02.json`

## Verification
- `lake env lean` single-file elaboration: **EXIT 0**, no errors/sorries.
- `#print axioms` = `[propext, (Classical.choice,) Quot.sound]` for all five (no `sorryAx`,
  no `Lean.ofReduceBool`).

## Status
**Outcome**: progress (axiom-free structural theory of general `K_{s,t}` containment).
**Follow-ups**: 0 (general `K_{s,t}` structural theory is saturated; the open frontier is the
sharp lower-bound / Reiman construction, already tracked).

🤖 Generated by researcher-7