### PR TITLE
Enrich Closed-Form Buffon Crossing Factor (buffons-needle-oq-02-oq-02-oq-01-oq-01): overview section + parity keyInsight

### DIFF
--- a/src/data/proofs/buffons-needle-oq-02-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/buffons-needle-oq-02-oq-02-oq-01-oq-01/meta.json
@@ -40,10 +40,20 @@
       "Solving the two-step recurrence gives exact telescoping products: alpha_{2m+2} = (2/pi) prod (2j+2)/(2j+3) and alpha_{2m+3} = (1/2) prod (2j+3)/(2j+4), the finite Wallis partial products behind alpha_n = Gamma(n/2)/(sqrt(pi) Gamma((n+1)/2)).",
       "The closed form makes the structural facts transparent: positivity and the maximum 2/pi hold because every product factor lies in (0,1], so the product is positive and at most one.",
       "Concrete higher values drop out by expanding the product over a small range: alpha_4 = 4/(3pi), alpha_6 = 16/(15pi) on the even side, alpha_5 = 3/8, alpha_7 = 5/16 on the odd side.",
-      "Self-containment is forced by upstream bit-rot in the companion crossing-factor file, but the recurrence is a one-line definition, so the closed form is fully reproducible."
+      "Self-containment is forced by upstream bit-rot in the companion crossing-factor file, but the recurrence is a one-line definition, so the closed form is fully reproducible.",
+      "The two subsequences differ in arithmetic character, and the closed forms show why: the odd-dimension factor is (1/2)·∏(2j+3)/(2j+4), a product of rationals times a rational base, so every odd-dimensional crossing factor is rational (α₅ = 3/8, α₇ = 5/16); the even-dimension factor carries the transcendental base 2/π, so π appears only in even dimensions (α₄ = 4/(3π), α₆ = 16/(15π)). The single transcendental constant π enters the whole family exactly through the even base value α₂ = 2/π and is inherited by every even dimension, while the odd tower stays entirely within ℚ."
     ]
   },
   "sections": [
+    {
+      "id": "overview-open-question",
+      "title": "Overview: the unsolved recurrence",
+      "startLine": 1,
+      "endLine": 47,
+      "summary": "Import (Mathlib) and the module docstring framing the open question: the n-dimensional Buffon noodle formula E[crossings] = αₙ·L/d is governed by the crossing factor αₙ = E_{Sⁿ⁻¹}[|u₁|], which satisfies the two-step recurrence α_{n+2} = (n/(n+1))·αₙ with bases α₂ = 2/π, α₃ = 1/2. The parent entry proves the recurrence's qualitative monotone behaviour but never solves it; the docstring states the four results delivered here (even/odd closed forms, positivity+maximum from the product, concrete higher values) and the honest scope note (0 sorries, 0 axioms, no native_decide, self-contained because the companion file is bit-rotted).",
+      "content": "The header material orients the reader before any Lean code: the docstring records that αₙ is the spherical average E_{Sⁿ⁻¹}[|u₁|] appearing in the higher-dimensional Buffon/Barbier noodle formula, recalls the two-step recurrence and its base values, and — crucially — pins the gap this file closes: the parent buffons-needle-oq-02-oq-02-oq-01 establishes only monotone structure, leaving the explicit closed form of the even- and odd-dimension subsequences open. It then previews the four theorem groups and states the verification scope.",
+      "mathContext": "$E[\\text{crossings}] = \\alpha_n\\,L/d$, with $\\alpha_n = E_{S^{n-1}}[|u_1|]$ and $\\alpha_{n+2} = \\tfrac{n}{n+1}\\alpha_n$, $\\alpha_2 = 2/\\pi$, $\\alpha_3 = 1/2$."
+    },
     {
       "id": "recurrence-def",
       "title": "The Crossing Factor and Its Recurrence",


### PR DESCRIPTION
Enrichment pass for `buffons-needle-oq-02-oq-02-oq-01-oq-01`.

Entry was at quality 96 — deeply developed (7 fully-populated annotations, 557-char historicalContext, 4 conclusion open-questions + 3 separate open-questions, originalContributions list) but with a genuine coverage gap and one count threshold. Both additions are substantive, not filler:

**1. Opening section (real coverage gap).** The four existing sections started at line 48, leaving lines 1–47 — the module docstring that frames the open question and lists all four result groups — uncovered by any section. Added `Overview: the unsolved recurrence` (1–47), so the sections now cover the file from line 1. This matches how quality-100 gallery entries give the orientation docstring its own section.

**2. 5th keyInsight (parity dichotomy).** A genuine structural observation visible directly from the two closed forms and the four concrete values: odd-dimension crossing factors are **rational** — α₅ = 3/8, α₇ = 5/16, and the odd form (1/2)·∏(2j+3)/(2j+4) is a rational multiple — while even-dimension factors carry the **transcendental** 2/π (α₄ = 4/(3π), α₆ = 16/(15π)). The single constant π enters the whole family only through the even base α₂ = 2/π. None of the existing 4 insights made this point.

- meta.json 15.6 KB (well under ~60 KB cap); all collections under caps.
- No existing content deleted.
- Axiom integrity unchanged: status `verified`, axiomCount 0 — matches the Lean file (0 sorries, 0 axioms, no native_decide, per its build note).

🤖 Generated with [Claude Code](https://claude.com/claude-code)