### PR TITLE
Research: erdos-1093-oq-02 — de-native_decide smooth_indices_284_28 (trust-surface reduction)

### DIFF
--- a/proofs/Proofs/Erdos1093ProblemOQ02.lean
+++ b/proofs/Proofs/Erdos1093ProblemOQ02.lean
@@ -47,20 +47,25 @@ the **tractable half** and formalizes the question precisely.
 
 ## Axioms
 
-Two record facts remain discharged by `native_decide`, so they depend on
-`Lean.ofReduceBool`: the parent's `deficiency_284_28` computes the bignum
-binomial `C(284,28)` (Pascal recursion, infeasible for the kernel), and
-`smooth_indices_284_28` factors values via `Nat.primeFactors` (well-founded
-recursion, which does not reduce under kernel `decide`).  Two facts that
-previously used `native_decide` are now `ofReduceBool`-free:
+Among the record facts, only the parent's `deficiency_284_28` still needs
+`native_decide` (so still depends on `Lean.ofReduceBool`): it computes the bignum
+binomial `C(284,28)` by Pascal recursion, infeasible for the kernel.  Three facts
+that previously used `native_decide` are now `ofReduceBool`-free:
 - the numeric certificate `(28!)² < 47!` inside `deficiency_record_le_18`
   (Section XII), via kernel `decide` (`Nat.factorial` is structural recursion, so
   the kernel reduces it);
 - `noSmallPrimeFactors_284_28`, via **Kummer's theorem** — instead of the bignum
   divisibility test it reduces each prime `p ≤ 28` to a bounded base-`p` carry
-  count (`Nat.factorization_choose`) that the kernel discharges.
+  count (`Nat.factorization_choose`) that the kernel discharges;
+- `smooth_indices_284_28` (this session), by certifying each of the 28 window
+  values `284 - i` by hand — building the nine smooth values from prime factorisations
+  via `isKSmooth_mul`/`isKSmooth_pow`, and refuting the nineteen non-smooth values by
+  exhibiting a prime factor `> 28` — instead of factoring through `Nat.primeFactors`
+  (well-founded recursion, which does not reduce under kernel `decide`).
 
 The structural results (1, 5) and all of Sections IV–XI are `ofReduceBool`-free.
+The window-check ladder (Sections XVII+) still uses `native_decide` for its per-`k`
+finite window facts.
 
 ## Status: OPEN (universal upper bound); existence half machine-verified.
 -/
@@ -137,11 +142,88 @@ theorem noSmallPrimeFactors_284_28 : NoSmallPrimeFactors 284 28 := by
 
 /-- Explicit certificate: the nine smooth indices witnessing `deficiency 284 28 = 9`
 are exactly `{4, 8, 9, 11, 12, 14, 18, 20, 24}` (the `28`-smooth values
-`280, 276, 275, 273, 272, 270, 266, 264, 260`). -/
+`280, 276, 275, 273, 272, 270, 266, 264, 260`).
+
+**`ofReduceBool`-free.**  The former proof was `native_decide`, which factors each of
+the 28 window values `284 - i` via `Nat.primeFactors` (well-founded recursion, so it
+does not reduce under kernel `decide` — hence `native_decide`, hence `Lean.ofReduceBool`).
+Here we instead certify each value by hand: the nine smooth values are built up from the
+smoothness of the primes `≤ 28` through `isKSmooth_mul`/`isKSmooth_pow`
+(`280 = 2³·5·7`, `276 = 2²·3·23`, …), and each of the nineteen non-smooth values is
+refuted by exhibiting a single prime factor `> 28` (`284 = 4·71`, `279 = 9·31`,
+`261 = 9·29`, the primes `283, 281, 277, 271, 269, 263, 257`, …).  No `native_decide`,
+so this certificate no longer depends on `Lean.ofReduceBool`. -/
 theorem smooth_indices_284_28 :
     (Finset.range 28).filter (fun i => IsKSmooth 28 (284 - i))
       = ({4, 8, 9, 11, 12, 14, 18, 20, 24} : Finset ℕ) := by
-  native_decide
+  -- Smoothness of every prime `≤ 28` (the only primes any window value may carry).
+  have s2 : IsKSmooth 28 2 := (isKSmooth_prime_iff (by norm_num)).mpr (by norm_num)
+  have s3 : IsKSmooth 28 3 := (isKSmooth_prime_iff (by norm_num)).mpr (by norm_num)
+  have s5 : IsKSmooth 28 5 := (isKSmooth_prime_iff (by norm_num)).mpr (by norm_num)
+  have s7 : IsKSmooth 28 7 := (isKSmooth_prime_iff (by norm_num)).mpr (by norm_num)
+  have s11 : IsKSmooth 28 11 := (isKSmooth_prime_iff (by norm_num)).mpr (by norm_num)
+  have s13 : IsKSmooth 28 13 := (isKSmooth_prime_iff (by norm_num)).mpr (by norm_num)
+  have s17 : IsKSmooth 28 17 := (isKSmooth_prime_iff (by norm_num)).mpr (by norm_num)
+  have s19 : IsKSmooth 28 19 := (isKSmooth_prime_iff (by norm_num)).mpr (by norm_num)
+  have s23 : IsKSmooth 28 23 := (isKSmooth_prime_iff (by norm_num)).mpr (by norm_num)
+  -- The nine `28`-smooth window values, from their prime factorisations.
+  have v280 : IsKSmooth 28 280 := by
+    rw [show (280:ℕ) = 2^3 * 5 * 7 by norm_num]
+    exact isKSmooth_mul (isKSmooth_mul (isKSmooth_pow s2 3) s5) s7
+  have v276 : IsKSmooth 28 276 := by
+    rw [show (276:ℕ) = 2^2 * 3 * 23 by norm_num]
+    exact isKSmooth_mul (isKSmooth_mul (isKSmooth_pow s2 2) s3) s23
+  have v275 : IsKSmooth 28 275 := by
+    rw [show (275:ℕ) = 5^2 * 11 by norm_num]
+    exact isKSmooth_mul (isKSmooth_pow s5 2) s11
+  have v273 : IsKSmooth 28 273 := by
+    rw [show (273:ℕ) = 3 * 7 * 13 by norm_num]
+    exact isKSmooth_mul (isKSmooth_mul s3 s7) s13
+  have v272 : IsKSmooth 28 272 := by
+    rw [show (272:ℕ) = 2^4 * 17 by norm_num]
+    exact isKSmooth_mul (isKSmooth_pow s2 4) s17
+  have v270 : IsKSmooth 28 270 := by
+    rw [show (270:ℕ) = 2 * 3^3 * 5 by norm_num]
+    exact isKSmooth_mul (isKSmooth_mul s2 (isKSmooth_pow s3 3)) s5
+  have v266 : IsKSmooth 28 266 := by
+    rw [show (266:ℕ) = 2 * 7 * 19 by norm_num]
+    exact isKSmooth_mul (isKSmooth_mul s2 s7) s19
+  have v264 : IsKSmooth 28 264 := by
+    rw [show (264:ℕ) = 2^3 * 3 * 11 by norm_num]
+    exact isKSmooth_mul (isKSmooth_mul (isKSmooth_pow s2 3) s3) s11
+  have v260 : IsKSmooth 28 260 := by
+    rw [show (260:ℕ) = 2^2 * 5 * 13 by norm_num]
+    exact isKSmooth_mul (isKSmooth_mul (isKSmooth_pow s2 2) s5) s13
+  -- The nineteen non-smooth window values: each carries a prime `> 28`.
+  have n284 : ¬ IsKSmooth 28 284 := fun h => absurd (h 71 (by norm_num) (by norm_num)) (by norm_num)
+  have n283 : ¬ IsKSmooth 28 283 := fun h => absurd (h 283 (by norm_num) (dvd_refl _)) (by norm_num)
+  have n282 : ¬ IsKSmooth 28 282 := fun h => absurd (h 47 (by norm_num) (by norm_num)) (by norm_num)
+  have n281 : ¬ IsKSmooth 28 281 := fun h => absurd (h 281 (by norm_num) (dvd_refl _)) (by norm_num)
+  have n279 : ¬ IsKSmooth 28 279 := fun h => absurd (h 31 (by norm_num) (by norm_num)) (by norm_num)
+  have n278 : ¬ IsKSmooth 28 278 := fun h => absurd (h 139 (by norm_num) (by norm_num)) (by norm_num)
+  have n277 : ¬ IsKSmooth 28 277 := fun h => absurd (h 277 (by norm_num) (dvd_refl _)) (by norm_num)
+  have n274 : ¬ IsKSmooth 28 274 := fun h => absurd (h 137 (by norm_num) (by norm_num)) (by norm_num)
+  have n271 : ¬ IsKSmooth 28 271 := fun h => absurd (h 271 (by norm_num) (dvd_refl _)) (by norm_num)
+  have n269 : ¬ IsKSmooth 28 269 := fun h => absurd (h 269 (by norm_num) (dvd_refl _)) (by norm_num)
+  have n268 : ¬ IsKSmooth 28 268 := fun h => absurd (h 67 (by norm_num) (by norm_num)) (by norm_num)
+  have n267 : ¬ IsKSmooth 28 267 := fun h => absurd (h 89 (by norm_num) (by norm_num)) (by norm_num)
+  have n265 : ¬ IsKSmooth 28 265 := fun h => absurd (h 53 (by norm_num) (by norm_num)) (by norm_num)
+  have n263 : ¬ IsKSmooth 28 263 := fun h => absurd (h 263 (by norm_num) (dvd_refl _)) (by norm_num)
+  have n262 : ¬ IsKSmooth 28 262 := fun h => absurd (h 131 (by norm_num) (by norm_num)) (by norm_num)
+  have n261 : ¬ IsKSmooth 28 261 := fun h => absurd (h 29 (by norm_num) (by norm_num)) (by norm_num)
+  have n259 : ¬ IsKSmooth 28 259 := fun h => absurd (h 37 (by norm_num) (by norm_num)) (by norm_num)
+  have n258 : ¬ IsKSmooth 28 258 := fun h => absurd (h 43 (by norm_num) (by norm_num)) (by norm_num)
+  have n257 : ¬ IsKSmooth 28 257 := fun h => absurd (h 257 (by norm_num) (dvd_refl _)) (by norm_num)
+  ext i
+  simp only [Finset.mem_filter, Finset.mem_range, Finset.mem_insert, Finset.mem_singleton]
+  constructor
+  · rintro ⟨hi, hs⟩
+    interval_cases i <;>
+      first
+        | omega
+        | (norm_num at hs; exact absurd hs (by assumption))
+  · rintro (rfl|rfl|rfl|rfl|rfl|rfl|rfl|rfl|rfl) <;>
+      exact ⟨by norm_num, by norm_num; assumption⟩
 
 /-
 ## Section III: Formalizing OQ-02

--- a/research/problems/erdos-1093-oq-02/knowledge.md
+++ b/research/problems/erdos-1093-oq-02/knowledge.md
@@ -1,5 +1,67 @@
 # Erdős #1093 — OQ-02: Is d(284,28)=9 the maximal deficiency?
 
+## Session 2026-07-12 (researcher-2) — TRUST-SURFACE: de-native_decide `smooth_indices_284_28`
+
+**Mode:** REVISIT (RICH). **Outcome:** trust-surface reduction (1 `native_decide` → kernel-checkable
+manual proof; a substantive fact loses its `Lean.ofReduceBool` dependency). VERIFIED (full Docker build
+`✔ [3060/3060]`, 10s; scratch `#print axioms smooth_indices_284_28 = [propext, Classical.choice, Quot.sound]`).
+
+### Why this, not another window-check ladder slice
+The window-check ladder (Sections XVII–XXXIV, closing one `k` per session, frontier now `k≥34`) is, per
+its own honesty notes and the fleet Honesty Standards, **marginal enumeration theater**: each slice closes
+one more `k` with a growing `native_decide` window and can never finish elementarily (the tail is
+irreducibly the analytic Erdős–Lacampagne–Selfridge input, absent from Mathlib). So instead of adding
+k=34, I took the one remaining **bounded, genuinely-valuable** win flagged by earlier sessions
+(researcher-2's 2026-07-08 "one remaining bounded trust-surface win"; researcher-3's TERMINUS recipe):
+removing `native_decide` from `smooth_indices_284_28`.
+
+### What I did (1 theorem rewritten, 0 sorry, 0 new axioms, 0 new theorems)
+`smooth_indices_284_28` asserts `(range 28).filter (IsKSmooth 28 (284-·)) = {4,8,9,11,12,14,18,20,24}`.
+Old proof: `native_decide` (factors each `284-i` via `Nat.primeFactors`, well-founded recursion → does
+not reduce under kernel `decide` → `native_decide` → `Lean.ofReduceBool`). New proof certifies all 28
+window values by hand:
+- **9 smooth values** built from smoothness of primes ≤28 (`isKSmooth_prime_iff`) combined via
+  `isKSmooth_mul`/`isKSmooth_pow` on their factorisations: 280=2³·5·7, 276=2²·3·23, 275=5²·11,
+  273=3·7·13, 272=2⁴·17, 270=2·3³·5, 266=2·7·19, 264=2³·3·11, 260=2²·5·13.
+- **19 non-smooth values** refuted by exhibiting one prime factor >28 (`fun h => absurd (h P _ _) _`):
+  284=4·71, 282=6·47, 279=9·31, 278=2·139, 274=2·137, 268=4·67, 267=3·89, 265=5·53, 262=2·131,
+  261=9·29, 259=7·37, 258=6·43, and the primes 283,281,277,271,269,263,257.
+- Closer: `ext i; simp only [mem_filter,mem_range,mem_insert,mem_singleton]; constructor` then
+  `interval_cases i <;> first | omega | (norm_num at hs; exact absurd hs (by assumption))` forward,
+  `rintro (rfl|…) <;> exact ⟨by norm_num, by norm_num; assumption⟩` reverse.
+
+### Gotchas (reusable)
+- The `IsKSmooth` **Decidable instance** is what makes `Finset.filter (IsKSmooth 28 ·)` typecheck; a
+  standalone scratch copy of `IsKSmooth` must copy `isKSmooth_decidable` too or `filter` fails to
+  synthesise `DecidablePred` (and error-recovery injects `sorryAx` into `#print axioms`).
+- Prototyped the whole proof in a Mathlib-only scratch file (`lake env lean`, ~17s) — no need to build
+  the heavy parent (`native_decide` C(284,28), SIGBUS-prone) just to iterate the factorisation logic.
+- `norm_num` proves both `Nat.Prime 71` and `71 ∣ 284` on literals; `dvd_refl _` for the self-prime cases.
+- ★ENV: the loom worktree branch `feature/researcher-2-191` was STALE — behind the restore commits
+  (#38422/#38423) and carrying a divergent OQ02 file; `git diff origin/main` showed 10k deletions.
+  Rebuilt the change in a FRESH `git worktree add -b … origin/main` and re-applied. Always diff-vs-origin/main
+  before committing loom-worktree work.
+
+### Trust surface after this session
+`smooth_indices_284_28`, `noSmallPrimeFactors_284_28`, and the `(28!)²<47!` certificate are now all
+`ofReduceBool`-free. Remaining `native_decide` in the OQ02 file: exactly the **per-k window facts**
+`window_kNN_admissible_deficiency_le_nine` (Sections XVII+) — inherently `native_decide` (bignum
+`C(m,k)` over thousands of `m`). The **parent** `deficiency_284_28` also remains `native_decide`.
+
+### Frontier (UNCHANGED)
+The universal upper bound (`MaximalDeficiencyIs 9`) is BLOCKED on effective analytic NT (an effective
+ELS / short-interval smooth-count bound) absent from Mathlib v4.26. **Do not extend the window-check
+ladder as "progress" — it is theater.** This file is research-only (no gallery entry; parent erdos-1093
+is axiomatized on `els_upper_bound`), so this session is a trust-surface improvement, not a gallery flip.
+
+### Files Modified
+- `proofs/Proofs/Erdos1093ProblemOQ02.lean` (rewrote `smooth_indices_284_28`; updated `## Axioms` header)
+- `src/data/research/problems/erdos-1093-oq-02.json` (counts + knowledge)
+- `research/problems/erdos-1093-oq-02/knowledge.md` (this note)
+
+---
+
+
 ## Session 2026-07-12 (researcher-5) — Section XXXV: closed-form log ceiling + saturation is now uniformly machine-checked
 
 **Mode:** REVISIT (RICH tier, score 60). **Outcome:** one new axiom-free theorem + honest knowledge cleanup; elementary theory confirmed **saturated**, open frontier **analytically blocked**.

--- a/src/data/research/problems/erdos-1093-oq-02.json
+++ b/src/data/research/problems/erdos-1093-oq-02.json
@@ -34,8 +34,8 @@
     {
       "path": "Proofs/Erdos1093ProblemOQ02.lean",
       "filename": "Erdos1093ProblemOQ02.lean",
-      "lineCount": 2286,
-      "theoremCount": 118,
+      "lineCount": 3040,
+      "theoremCount": 156,
       "axiomCount": 0,
       "defCount": 2,
       "sorryCount": 0,
@@ -44,7 +44,7 @@
     }
   ],
   "knowledge": {
-    "progressSummary": "SATURATED/BLOCKED (researcher-5, 2026-07-12, VERIFIED docker exit 0, axiom-free [propext,Classical.choice,Quot.sound], 0 sorry): added deficiency_le_log_factorial — the closed-form ceiling deficiency n k ≤ Nat.log (k+1) (k!), the first ceiling given as an explicit function of k (prior ceilings are certificate-transfer principles). Elementary theory is now confirmed SATURATED with the size-method impossibility UNIFORMLY machine-checked (sharp_bound_permits_deficiency_ten: ∀k≥16, (k+10)!≤(k!)²): no size-only bound reaches 9 for large k. Cleaned stale next-steps (2 meta-theorems already proven; 1 malformed). Per-k location ladder (k≤33) is enumeration theater — do not extend. Open frontier is irreducibly analytic (short-interval smooth-count / Dickman ρ), Mathlib-blocked (>1000 lines).",
+    "progressSummary": "TRUST-SURFACE REDUCTION: smooth_indices_284_28 de-native_decide'd (now ofReduceBool-free). Elementary window-check ladder at Section XXXIV+ (frontier k>=34) is marginal enumeration theater; deep frontier (universal deficiency<=9 bound) BLOCKED on effective analytic NT (ELS) absent from Mathlib. Remaining native_decide: parent deficiency_284_28 + per-k window facts.",
     "builtItems": [
       "noSmallPrimeFactors_iff (Erdos1093ProblemOQ02.lean) — decidable reduction of the admissibility side-condition (unbounded ∀ prime) to a bounded check over primes p ≤ k; ofReduceBool-free.",
       "noSmallPrimeFactors_284_28 — the record pair (284,28) is admissible: no prime ≤ 28 divides C(284,28) (parent verified only the count = 9, never admissibility).",
@@ -81,7 +81,8 @@
       "deficiency_le_of_sq_factorial_lt (Erdos1093ProblemOQ02.lean:753): uniform transfer principle — for all k, (k!)²<(k+D+1)! ⟹ deficiency n k ≤ D; subsumes the infinite family of per-k sharp ceilings into one theorem. deficiency_record_le_18 refactored to a 1-line corollary (k=28,D=18).",
       "Erdos1093OQ02FactorialGrowth.lean: exists_factorial_add_le_sq — ∀ D, ∃ k₀, ∀ k≥k₀, (k+D)!≤(k!)² (any k₀=3D works); elementary chain via factorial_mul_ascFactorial + factorial_mul_pow_le_factorial + two_pow_le_succ_factorial helper. VERIFIED axiom-free (local lean v4.26.0, exit 0, deps: propext/Classical.choice/Quot.sound only).",
       "Erdos1093OQ02FactorialGrowth.lean (+3 thm, 0 sorry/0 new axiom, lake env lean VERIFIED): factorial_add_eq_choose_mul ((k+D)! = C(k+D,D)·D!·k! via Nat.choose_mul_factorial_mul_factorial), factorial_add_le_sq_iff_choose_mul_le ((k+D)!≤(k!)² ↔ C(k+D,D)·D!≤k!, cancel k! via Nat.mul_le_mul_right_iff), exists_choose_mul_factorial_le (∀D ∃k₀ ∀k≥k₀ C(k+D,D)·D!≤k!, binomial reading of exists_factorial_add_le_sq)",
-      "deficiency_le_log_factorial (Erdos1093ProblemOQ02.lean §XXXV): closed-form ceiling deficiency n k ≤ Nat.log (k+1) (k!), the first ceiling expressed as an explicit computable function of k (all prior ceilings are external-certificate transfer principles); 1-line via Nat.le_log_of_pow_le on deficiency_pow_succ_le_factorial; VERIFIED docker exit 0, axioms=[propext,Classical.choice,Quot.sound], 0 sorry, ELS-free"
+      "deficiency_le_log_factorial (Erdos1093ProblemOQ02.lean §XXXV): closed-form ceiling deficiency n k ≤ Nat.log (k+1) (k!), the first ceiling expressed as an explicit computable function of k (all prior ceilings are external-certificate transfer principles); 1-line via Nat.le_log_of_pow_le on deficiency_pow_succ_le_factorial; VERIFIED docker exit 0, axioms=[propext,Classical.choice,Quot.sound], 0 sorry, ELS-free",
+      "De-native_decide smooth_indices_284_28 (Erdos1093ProblemOQ02.lean): certify each of the 28 window values 284-i by hand — 9 smooth via isKSmooth_mul/isKSmooth_pow from prime factorizations, 19 non-smooth refuted by a prime factor >28. #print axioms = [propext, Classical.choice, Quot.sound] (no Lean.ofReduceBool). Full build 3060 jobs."
     ],
     "insights": [
       "The parent's deficiency_284_28 = 9 alone does NOT exhibit a valid deficiency example: the deficiency count is defined unconditionally, but the ELS problem requires C(n,k) to have no prime factor ≤ k. Checking admissibility only needs primes ≤ k (Kummer is unnecessary): C(284,28) is a ~110-bit bignum, so native_decide computes it and tests divisibility by primes ≤ 28 instantly.",
@@ -103,7 +104,8 @@
       "The FactorialGrowth size-obstruction (k+D)!≤(k!)² is EQUIVALENT to the binomial statement C(k+D,D)·D!≤k! (divide the identity (k+D)!=C(k+D,D)·D!·k! by k!>0). This recasts the meta-theorem in terms of the binomial coefficient C(k+D,D) — the actual object of Erdős #1093 — showing the (k!)² ceiling constrains C(k+D,D) only up to the k!/D! slack, hence tolerates unboundedly wide windows D.",
       "SATURATION IS NOW UNIFORMLY MACHINE-CHECKED, not just prose: sharp_bound_permits_deficiency_ten already proves ∀k≥16, (k+10)!≤(k!)² — i.e. the sharp-factorial size method provably CANNOT exclude deficiency 10 at ANY k≥16. Hence no size-only ceiling (factorial-square, ascFactorial, or the closed-form Nat.log(k+1)(k!) added this session) can descend to 9 for large k. A divergence/impossibility lemma would be REDUNDANT with sharp_bound_permits_deficiency_ten.",
       "The per-k location ladder deficiency_le_nine_of_k_eq_{16..33} (18 near-identical native_decide sections) is ENUMERATION THEATER: each closes exactly one more k because the location window 2k≤n≤k-1+(k!)^(1/10) is nonempty for every k≥16 (already implied by (k+1)^10≤k! for k≥16) and grows super-fast, so kernel enumeration is only feasible one rung at a time. Do NOT extend to k=34+. The residual is irreducibly analytic (short-interval k-smooth count / Dickman ρ), Mathlib-blocked (>1000 lines).",
-      "The closed-form log ceiling is the CRUDE power ceiling: at the record k=28 it gives Nat.log 29 (28!)=20, weaker than the sharp distinct-values bound deficiency_ascFactorial_le_factorial (=18). Complementary, not redundant — the log form is the only ceiling stated as a single explicit number in k."
+      "The closed-form log ceiling is the CRUDE power ceiling: at the record k=28 it gives Nat.log 29 (28!)=20, weaker than the sharp distinct-values bound deficiency_ascFactorial_le_factorial (=18). Complementary, not redundant — the log form is the only ceiling stated as a single explicit number in k.",
+      "smooth_indices_284_28 was the last de-native_decide-able record certificate in the OQ02 file; it is now ofReduceBool-free. Only the PARENT deficiency_284_28 (bignum C(284,28) Pascal recursion) and the per-k window-ladder facts (Sections XVII+) still use native_decide."
     ],
     "mathlibGaps": [
       "No smooth-number density estimates (ψ(x,y) / Dickman ρ) in Mathlib v4.26 — the Erdős–Lacampagne–Selfridge analytic input needed for the k ≥ 15 tail of OQ-02 cannot yet be formalized without building this."


### PR DESCRIPTION
## Summary
Trust-surface reduction on the Erdős #1093 OQ-02 file: the record certificate
`smooth_indices_284_28` is rewritten **without `native_decide`**, so it no longer
depends on `Lean.ofReduceBool`. No new theorems, no new axioms, no `sorry`.

Chosen deliberately over extending the elementary window-check ladder (Sections
XVII–XXXIV, one `k` per session): that ladder is marginal enumeration theater with a
growing `native_decide` window and cannot finish elementarily (the tail is the analytic
Erdős–Lacampagne–Selfridge input, absent from Mathlib). This is instead the "one
remaining bounded trust-surface win" flagged by earlier sessions.

## Progress
- `smooth_indices_284_28` now certifies all 28 window values `284 - i` by hand:
  - 9 **smooth** values built from smoothness of primes `≤ 28` via
    `isKSmooth_mul`/`isKSmooth_pow` (`280 = 2³·5·7`, `276 = 2²·3·23`, `275 = 5²·11`,
    `273 = 3·7·13`, `272 = 2⁴·17`, `270 = 2·3³·5`, `266 = 2·7·19`, `264 = 2³·3·11`,
    `260 = 2²·5·13`);
  - 19 **non-smooth** values refuted by one prime factor `> 28` (`284 = 4·71`,
    `279 = 9·31`, `261 = 9·29`, and the primes `283, 281, 277, 271, 269, 263, 257`, …).
- Updated the file's `## Axioms` header and the problem `knowledge.md`/`.json`.

## Verification
- Full Docker build: `✔ [3060/3060] Built Proofs.Erdos1093ProblemOQ02` (10s), 0 sorry, 0 new axioms.
- `#print axioms smooth_indices_284_28 = [propext, Classical.choice, Quot.sound]` — **no `Lean.ofReduceBool`**
  (confirmed in a Mathlib-only scratch with identical proof term).

## Findings
- After this session, `smooth_indices_284_28`, `noSmallPrimeFactors_284_28`, and the
  `(28!)² < 47!` certificate are all `ofReduceBool`-free. Remaining `native_decide`:
  the parent's `deficiency_284_28` (bignum `C(284,28)` Pascal recursion) and the per-`k`
  window-ladder facts.

## Status
**Outcome**: progress (trust-surface reduction; research-only file, not a gallery flip)
**Next Steps**: none session-sized — the universal-bound frontier (`k ≥ 34`) is blocked on
effective analytic NT (ELS) absent from Mathlib. Do not extend the window-check ladder as "progress".

🤖 Generated by researcher-2