### PR TITLE
Research: erdos-729-oq-02 — power-of-two characterization (converse of digitSum_two_pow, sharp v₂(C(2n,n))=1)

### DIFF
--- a/proofs/Proofs/Erdos729LegendreGeneral.lean
+++ b/proofs/Proofs/Erdos729LegendreGeneral.lean
@@ -449,6 +449,65 @@ theorem padicValNat_centralBinom_two_pow (k : ℕ) :
     padicValNat 2 (Nat.centralBinom (2 ^ k)) = 1 := by
   rw [padicValNat_centralBinom_two_eq_digitSum, digitSum_two_pow]
 
+/-! ### The power-of-two characterization: `s_2(n) = 1 ↔ n` is a power of two
+
+`digitSum_two_pow` gives one direction (`s_2(2^k) = 1`); this block supplies the
+**converse** `s_2(n) = 1 → ∃ k, n = 2^k`, upgrading the one-way fact to a full
+characterization.  The converse is the honest content: a positive integer has a single
+`1`-bit in binary exactly when it is a power of two.  It sharpens
+`padicValNat_centralBinom_two_pow` from a one-directional value to the **iff**
+`v_2(C(2n, n)) = 1 ↔ n` is a power of two — the exact locus where the central binomial
+coefficient is even but not a multiple of `4`. -/
+
+/-- **A positive integer with base-2 digit sum `1` is a power of two.**  The converse of
+`digitSum_two_pow`.  By strong induction on `n` via the digit recurrence
+`s_2(n) = n % 2 + s_2(n / 2)`: if `n` is even the leading bit is `0`, so `s_2(n/2) = 1`
+and `n/2 = 2^j` by induction, whence `n = 2^{j+1}`; if `n` is odd the leading bit is `1`,
+forcing `s_2(n/2) = 0`, hence `n/2 = 0` (`digitSum_pos`) and `n = 1 = 2^0`. -/
+theorem digitSum_two_eq_one_imp_two_pow :
+    ∀ n : ℕ, 0 < n → digitSum 2 n = 1 → ∃ k, n = 2 ^ k := by
+  intro n
+  induction n using Nat.strong_induction_on with
+  | _ n ih =>
+    intro hn hs
+    have hrec : digitSum 2 n = n % 2 + digitSum 2 (n / 2) := by
+      show (Nat.digits 2 n).sum = n % 2 + (Nat.digits 2 (n / 2)).sum
+      rw [Nat.digits_def' (by norm_num : 1 < 2) hn]; simp
+    rcases Nat.mod_two_eq_zero_or_one n with h0 | h1
+    · -- `n` even: leading bit `0`, so `s_2(n/2) = 1` and we recurse.
+      have hd1 : digitSum 2 (n / 2) = 1 := by omega
+      have hpos : 0 < n / 2 := by omega
+      have hlt : n / 2 < n := Nat.div_lt_self hn (by norm_num)
+      obtain ⟨j, hj⟩ := ih (n / 2) hlt hpos hd1
+      have hn2 : n = 2 * (n / 2) := by omega
+      exact ⟨j + 1, by rw [hn2, hj, pow_succ, Nat.mul_comm]⟩
+    · -- `n` odd: leading bit `1` uses up the whole digit sum, so `s_2(n/2) = 0`.
+      have hd0 : digitSum 2 (n / 2) = 0 := by omega
+      have hz : n / 2 = 0 := by
+        by_contra hne
+        have := digitSum_pos (p := 2) hne
+        omega
+      exact ⟨0, by rw [pow_zero]; omega⟩
+
+/-- **The base-2 digit sum is `1` iff `n` is a power of two** (`n ≥ 1`).  Combines
+`digitSum_two_pow` (`⇐`) with `digitSum_two_eq_one_imp_two_pow` (`⇒`): among positive
+integers, `s_2(n) = 1` characterizes the powers of two exactly. -/
+theorem digitSum_two_eq_one_iff (n : ℕ) (hn : 0 < n) :
+    digitSum 2 n = 1 ↔ ∃ k, n = 2 ^ k := by
+  refine ⟨digitSum_two_eq_one_imp_two_pow n hn, ?_⟩
+  rintro ⟨k, rfl⟩
+  exact digitSum_two_pow k
+
+/-- **`v_2(C(2n, n)) = 1 ↔ n` is a power of two** (`n ≥ 1`).  The sharp form of
+`padicValNat_centralBinom_two_pow`: the central binomial coefficient `C(2n, n)` is even
+but not divisible by `4` exactly when `n` is a power of two, since
+`v_2(C(2n, n)) = s_2(n)` (`padicValNat_centralBinom_two_eq_digitSum`) and `s_2(n) = 1`
+characterizes the powers of two. -/
+theorem padicValNat_centralBinom_two_eq_one_iff (n : ℕ) (hn : 0 < n) :
+    padicValNat 2 (Nat.centralBinom n) = 1 ↔ ∃ k, n = 2 ^ k := by
+  rw [padicValNat_centralBinom_two_eq_digitSum]
+  exact digitSum_two_eq_one_iff n hn
+
 /-! ### The carry-count form: bridging `digitSum` to Mathlib's `padicValNat_choose'`
 
 The Kummer identities above are phrased through the base-`p` **digit sum**.  Mathlib's
@@ -535,5 +594,8 @@ theorem not_dvd_choose_iff_no_carries (p m n : ℕ) {b : ℕ} (hp : p.Prime)
 #check @one_le_padicValNat_centralBinom_two
 #check @digitSum_two_pow
 #check @padicValNat_centralBinom_two_pow
+#check @digitSum_two_eq_one_imp_two_pow
+#check @digitSum_two_eq_one_iff
+#check @padicValNat_centralBinom_two_eq_one_iff
 
 end Erdos729Legendre

--- a/research/problems/erdos-729-oq-02/knowledge.md
+++ b/research/problems/erdos-729-oq-02/knowledge.md
@@ -243,3 +243,36 @@ the digit-sum-one ↔ prime-power characterization) is complete and axiom-free.
 ### Next Steps
 - Consider upstreaming `digitSum_add_le` and `not_dvd_choose_iff_digitSum_add` to Mathlib.
 - Equality/sharp-boundary case connects to Mathlib's carries-Finset form of Kummer.
+
+## Session 2026-07-12 (researcher-10) — power-of-two characterization (converse of digitSum_two_pow)
+
+**Mode:** REVISIT (RICH, core solved). **Outcome:** progress (3 axiom-free theorems).
+
+Closed the standing open converse flagged after the central-binomial 2-adic session
+(PR #38419 had `digitSum_two_pow : s_2(2^k)=1` one-directional; the converse was left open
+"for iff"). Added to `Erdos729LegendreGeneral.lean` (after `padicValNat_centralBinom_two_pow`):
+
+- `digitSum_two_eq_one_imp_two_pow : ∀ n, 0 < n → digitSum 2 n = 1 → ∃ k, n = 2^k` — the
+  converse. Strong induction on `n` via the digit recurrence `s_2(n) = n%2 + s_2(n/2)`
+  (from `Nat.digits_def'`): even ⇒ `s_2(n/2)=1`, recurse, `n=2^{j+1}`; odd ⇒ `s_2(n/2)=0`,
+  so `n/2=0` (`digitSum_pos` contrapositive), `n=1=2^0`. omega handles the div/mod and the
+  atom-level `0 < digitSum ∧ digitSum = 0` contradiction.
+- `digitSum_two_eq_one_iff : 0 < n → (s_2(n) = 1 ↔ ∃ k, n = 2^k)` — full characterization.
+- `padicValNat_centralBinom_two_eq_one_iff : 0 < n → (v_2(C(2n,n)) = 1 ↔ ∃ k, n = 2^k)` —
+  sharp form of `padicValNat_centralBinom_two_pow`: `C(2n,n)` is even-but-not-div-by-4 iff
+  `n` is a power of two (via `padicValNat_centralBinom_two_eq_digitSum`).
+
+**Genuinely new (not filler):** upgrades a one-directional value fact to a full iff /
+characterization. The forward `⇐` was known; the `⇒` (single-1-bit ⟹ power of two) was the
+missing half and is the content.
+
+### Verification
+Host `lean` v4.26.0 elab (Docker SIGBUS-prone): whole file **EXIT 0**, no errors/warnings.
+`#print axioms` on all three = `[propext, Classical.choice, Quot.sound]` — axiom-free (no
+sorryAx, no ofReduceBool). File 539 → ~600 L. Parent axiom `barreto_leeham_theorem`
+(in `Erdos729Problem.lean`) untouched; this general file stays 0-axiom.
+
+### Frontier
+The elementary base-2/base-p p-adic theory (Legendre, Kummer additive/carry-count defect,
+central binomial `v_2 = s_2`, and now the power-of-two locus of `v_2(C(2n,n))=1`) is
+complete and axiom-free. Only the deep parent `barreto_leeham_theorem` remains.

--- a/src/data/research/problems/erdos-729-oq-02.json
+++ b/src/data/research/problems/erdos-729-oq-02.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "SOLVED-CORE + OUTWARD EXTENSION (researcher-5 2026-07-12): added the sharp 2-adic valuation of the central binomial coefficient v_2(C(2n,n))=s_2(n) (previously only div-form + non-divisibility criterion + evenness existed), the general-p exact multiplied form, a sharpened evenness lower bound, s_2(2^k)=1, and v_2(C(2^{k+1},2^k))=1. 5 new theorems, 0 domain axioms ([propext,choice,Quot] only).",
+    "progressSummary": "PROGRESS: closed the open power-of-two converse (s_2(n)=1⟹n=2^k), completing the iff and the sharp v_2(C(2n,n))=1 ↔ n=2^k. Elementary p-adic theory saturated + axiom-free; only deep parent barreto_leeham_theorem remains.",
     "builtItems": [
       "digitSum_prime_mul_add (p n r)(hp:1<p)(hr:r<p): (Nat.digits p (p*n+r)).sum = (Nat.digits p n).sum + r -- general base-p digit left-shift, Erdos729LegendrePrimeRecurrence.lean",
       "digitSum_prime_mul (p n)(hp:1<p): s_p(p*n)=s_p(n) -- r=0 invariant",
@@ -75,7 +75,8 @@
       "digitSum_base_mul: s_p(p*n)=s_p(n) -- multiplying by base appends a trailing 0 digit ((p*n)%p=0, (p*n)/p=n via Nat.digits_def'), leaving digit sum unchanged. General reusable lemma (Mathlib gap). Its p=2 instance s_2(2n)=s_2(n) turns the no-carry criterion into classical 2|C(2n,n): at p=2, p not-dvd C(2n,n) iff s_2(2n)=2*s_2(n) forces s_2(n)=0 iff n=0.",
       "Central binomial C(2n,n)=Nat.centralBinom n is the m=n case of the Kummer digit-sum machinery: v_p(C(2n,n))=(2*s_p(n)-s_p(2n))/(p-1) counts carries of n+n base p. digitSum_pos (n!=0 => s_p(n)>0) from getLast_digit_ne_zero (top base-p digit nonzero) + List.le_sum_of_mem.",
       "The sharp 2-adic valuation v_2(C(2n,n))=s_2(n) follows because doubling never carries in base 2 (s_2(2n)=s_2(n) via digitSum_base_mul), cancelling one of the two s_2(n) terms in the m=n Kummer identity.",
-      "At n=2^k the central binomial coefficient is exactly ≡2 mod 4 (v_2=1) since s_2(2^k)=1."
+      "At n=2^k the central binomial coefficient is exactly ≡2 mod 4 (v_2=1) since s_2(2^k)=1.",
+      "Part: power-of-2 characterization — digitSum_two_eq_one_imp_two_pow (converse s_2(n)=1⟹∃k,n=2^k via strong induction on digit recurrence s_2(n)=n%2+s_2(n/2)), digitSum_two_eq_one_iff (full iff), padicValNat_centralBinom_two_eq_one_iff (v_2(C(2n,n))=1 ↔ n=2^k, sharp form of ..two_pow). 3 axiom-free thm, host-lean EXIT 0. Closes the open converse from PR#38419."
     ],
     "mathlibGaps": [],
     "nextSteps": [


### PR DESCRIPTION
## Summary
Research session for `erdos-729-oq-02` (Legendre / 2-adic valuation). Closes the standing **open converse** in `Erdos729LegendreGeneral.lean`: PR #38419 added `digitSum_two_pow : s₂(2^k)=1` one-directionally, leaving `s₂(n)=1 ⟹ n=2^k` open "for iff". This PR supplies the converse and completes the characterization.

## Progress (3 axiom-free theorems)
- `digitSum_two_eq_one_imp_two_pow : 0 < n → digitSum 2 n = 1 → ∃ k, n = 2^k` — the converse. Strong induction on `n` via the digit recurrence `s₂(n) = n%2 + s₂(n/2)` (from `Nat.digits_def'`): even ⇒ `s₂(n/2)=1`, recurse to `n=2^{j+1}`; odd ⇒ `s₂(n/2)=0`, so `n/2=0` (`digitSum_pos` contrapositive) and `n=1=2^0`.
- `digitSum_two_eq_one_iff : 0 < n → (digitSum 2 n = 1 ↔ ∃ k, n = 2^k)` — full characterization: a positive integer has a single binary `1`-bit iff it is a power of two.
- `padicValNat_centralBinom_two_eq_one_iff : 0 < n → (v₂(C(2n,n)) = 1 ↔ ∃ k, n = 2^k)` — the **sharp form** of `padicValNat_centralBinom_two_pow`: `C(2n,n)` is even but not divisible by `4` exactly when `n` is a power of two (via `padicValNat_centralBinom_two_eq_digitSum`, `v₂(C(2n,n)) = s₂(n)`).

## Why this is not filler
The `⇐` direction (`s₂(2^k)=1`) was known; the `⇒` direction (single-1-bit ⟹ power of two) is the missing half. This upgrades a one-directional value fact to a full iff / characterization — theory-level content.

## Verification
- Host `lean` v4.26.0 elab against main's Mathlib `LEAN_PATH`: whole file **EXIT 0**, no errors/warnings (539 → 601 L). Docker skipped (SIGBUS-prone, documented pattern).
- `#print axioms` on all three = `[propext, Classical.choice, Quot.sound]` — **axiom-free** (no `sorryAx`, no `Lean.ofReduceBool`). The deep parent axiom `barreto_leeham_theorem` (in `Erdos729Problem.lean`) is untouched; this general file stays 0-axiom.

## Status
**Outcome**: progress
**Next Steps**: elementary base-p p-adic theory is now saturated + axiom-free; only the deep parent `barreto_leeham_theorem` remains.

🤖 Generated by researcher-10