### PR TITLE
Enrich Buffon–Barbier C¹ Integrability-Discharge (buffons-needle-oq-01-oq-01-oq-05): overview section + C¹-completeness keyInsight

### DIFF
--- a/src/data/proofs/buffons-needle-oq-01-oq-01-oq-05/meta.json
+++ b/src/data/proofs/buffons-needle-oq-01-oq-01-oq-05/meta.json
@@ -46,10 +46,20 @@
       "The integrand (t, θ) ↦ |A(t)·sin θ + B(t)·cos θ| is jointly continuous when A and B are continuous, and the interval of integration [0, π] is fixed and compact — so continuous_parametric_intervalIntegral_of_continuous' applies directly with no dominated-convergence bookkeeping.",
       "Continuity is enough: the proof never uses the closed form 2‖γ'(t)‖ of the inner integral, only joint continuity of the integrand and the fixed compact interval. This keeps the result robust and self-contained on Mathlib's parametric-integral API.",
       "Continuity on a compact parameter interval [a, b] immediately gives interval-integrability (Continuous.intervalIntegrable), turning the analytic side condition into a one-line consequence of regularity.",
-      "Honest scope: this discharges exactly the Buffon-specific integrability residue (hInnerInt), not the general co-area / Cauchy–Crofton formula, which remains absent from Mathlib."
+      "Honest scope: this discharges exactly the Buffon-specific integrability residue (hInnerInt), not the general co-area / Cauchy–Crofton formula, which remains absent from Mathlib.",
+      "The upgraded capstone buffon_smooth_C1 is hypothesis-minimal for the smooth case: once hInnerInt is discharged, the only surviving hypotheses of buffon_smooth_full are the differentiability of the two coordinate functions — which is exactly what it means for the curve to be C¹. Buffon–Barbier is therefore shown to hold for every C¹ planar curve with no analytic side condition beyond C¹ regularity itself. The genuine next frontier is not another side condition but weakening the differentiability class (rectifiable/Lipschitz arcs), a qualitatively different problem where the velocity need not be continuous and the parametric-integral argument no longer applies."
     ]
   },
   "sections": [
+    {
+      "id": "overview-hypothesis-discharge",
+      "title": "Overview: discharging the integrability hypothesis",
+      "startLine": 1,
+      "endLine": 47,
+      "summary": "Imports (Mathlib and the parent Proofs.BuffonsNeedleOQ01OQ01) and the module docstring. It frames the goal: the parent's buffon_smooth_full carries the C¹ differentiability hypotheses (hdx, hdy) and an interval-integrability hypothesis (hInnerInt) on the inner angular integral t ↦ ∫₀^π |γ'₁(t)·sin θ + γ'₂(t)·cos θ| dθ; the parent's fifth open question asks to remove the Fubini/co-area condition. The docstring states what is achieved (hInnerInt discharged from continuity of the velocity, giving buffon_smooth_C1) and the honest scope (this is the Buffon-specific residue, not the general co-area formula, which stays open in Mathlib).",
+      "content": "The header orients the reader before any Lean code: the two imports (Mathlib and the parent entry Proofs.BuffonsNeedleOQ01OQ01, whose buffon_smooth_full is upgraded here) and the module docstring. The docstring identifies the exact residue of the parent's open question that this file closes — the interval-integrability hypothesis hInnerInt — records that continuity of the velocity field suffices to discharge it, and delimits the scope: the general co-area / Cauchy–Crofton formula remains an open Mathlib target, so only the one Buffon-specific analytic side condition is eliminated.",
+      "mathContext": "Discharge $\\mathtt{hInnerInt}$: interval-integrability of $t \\mapsto \\int_0^\\pi |\\gamma_1'(t)\\sin\\theta + \\gamma_2'(t)\\cos\\theta|\\,d\\theta$ from continuity of $\\gamma'$."
+    },
     {
       "id": "inner-angular",
       "title": "The Inner Angular Integral",


### PR DESCRIPTION
Enrichment pass for `buffons-needle-oq-01-oq-01-oq-05`.

Entry was at quality 96 — well-developed (5 fully-populated annotations, 765-char historicalContext, detailed proofStrategy, 4 conclusion open-questions) but with a genuine coverage gap and one count threshold. Both additions are substantive:

**1. Opening section (real coverage gap).** The four existing sections started at line 48, leaving lines 1–47 — the two imports and the module docstring framing the parent's open question, the hInnerInt discharge, and the honest scope note — uncovered by any section. Added `Overview: discharging the integrability hypothesis` (1–47); sections now cover the file from line 1.

**2. 5th keyInsight (C¹-completeness).** A distinct framing of the result's final form: once hInnerInt is discharged, the only surviving hypotheses of `buffon_smooth_full` are the differentiability of the coordinate functions — which is exactly the definition of C¹. So `buffon_smooth_C1` establishes Buffon–Barbier for *every* C¹ planar curve with no analytic side condition beyond C¹ regularity, and the genuine next frontier is weakening the differentiability class (rectifiable/Lipschitz), a qualitatively different problem. None of the existing 4 insights (joint continuity, continuity-not-closed-form, continuity→integrability, honest scope) made this hypothesis-minimality point.

- meta.json 13.6 KB (well under ~60 KB cap); all collections under caps.
- No existing content deleted.
- Axiom integrity unchanged: status `verified`, axiomCount 0 — matches the Lean file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)