### PR TITLE
Enrich Exponent-Swap Reflection Symmetry: realign annotation ranges

### DIFF
--- a/src/data/proofs/buffons-needle-oq-01-oq-01-oq-04-oq-01-oq-01-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/buffons-needle-oq-01-oq-01-oq-04-oq-01-oq-01-oq-01-oq-02/annotations.json
@@ -2,7 +2,7 @@
   {
     "id": "ann-swap-overview",
     "proofId": "buffons-needle-oq-01-oq-01-oq-04-oq-01-oq-01-oq-01-oq-02",
-    "range": { "startLine": 3, "endLine": 54 },
+    "range": { "startLine": 3, "endLine": 40 },
     "type": "concept",
     "title": "From a Single-Power Reflection to a Reusable Exponent-Swap Lemma",
     "content": "The module docstring states the open question inherited from the parent (BuffonsNeedleOQ01OQ01OQ04OQ01OQ01OQ01): the parent proved only the single-power instance ∫_0^{π/2} sin θ · cosᵐ θ = ∫_0^{π/2} cos θ · sinᵐ θ and asked whether the reflection argument packages into one clean lemma. The answer is the two-parameter statement ∫_0^{π/2} sinᵃθ cosᵇθ = ∫_0^{π/2} sinᵇθ cosᵃθ. Its entire content is the reflection θ ↦ π/2 − θ, an involution of [0, π/2] that interchanges sin and cos. Crucially the argument touches only the bases of the powers, so it is indifferent to whether a, b are natural numbers or arbitrary reals — and it needs no positivity, integrability, or antiderivative.",
@@ -20,7 +20,7 @@
   {
     "id": "ann-nat-swap",
     "proofId": "buffons-needle-oq-01-oq-01-oq-04-oq-01-oq-01-oq-01-oq-02",
-    "range": { "startLine": 56, "endLine": 73 },
+    "range": { "startLine": 46, "endLine": 63 },
     "type": "tactic",
     "title": "The Headline Lemma: Exponent Swap for Natural-Number Powers",
     "content": "integral_sin_pow_mul_cos_pow_swap is the three-line core. intervalIntegral.integral_comp_sub_left (fun θ => sinᵃθ cosᵇθ) (π/2) produces an equality whose left side is the integral of the reflected integrand sinᵃ(π/2−θ)cosᵇ(π/2−θ) over [π/2−π/2, π/2−0] = [0, π/2]. The simp set {Real.sin_pi_div_two_sub, Real.cos_pi_div_two_sub, sub_zero, sub_self} rewrites the bases to cosᵃθ sinᵇθ and normalizes the endpoints. The hypothesis h then reads ∫ cosᵃθ sinᵇθ = ∫ sinᵃθ cosᵇθ; `rw [← h]` turns the goal's left side into ∫ cosᵃθ sinᵇθ, and a single intervalIntegral.integral_congr with mul_comm transposes the two factors onto the swapped target sinᵇθ cosᵃθ.",
@@ -32,7 +32,7 @@
   {
     "id": "ann-rpow-swap",
     "proofId": "buffons-needle-oq-01-oq-01-oq-04-oq-01-oq-01-oq-01-oq-02",
-    "range": { "startLine": 75, "endLine": 96 },
+    "range": { "startLine": 65, "endLine": 81 },
     "type": "insight",
     "title": "Same Proof, Real Exponents: Reaching the Beta Function",
     "content": "integral_sin_rpow_mul_cos_rpow_swap is the strictly more general statement with a, b : ℝ, where the powers are Real.rpow. The proof script is byte-for-byte the same as the natural-number version: integral_comp_sub_left, the same simp set, rw [← h], integral_congr with mul_comm. This works because the complementary-angle identities rewrite the bases sin(π/2−θ), cos(π/2−θ) regardless of how those bases are subsequently raised to a power, and mul_comm is exponent-agnostic. The real-exponent form is the one that meets the trigonometric Beta integral, where the exponents are 2x−1 and 2y−1.",
@@ -44,7 +44,7 @@
   {
     "id": "ann-beta-symm",
     "proofId": "buffons-needle-oq-01-oq-01-oq-04-oq-01-oq-01-oq-01-oq-02",
-    "range": { "startLine": 98, "endLine": 110 },
+    "range": { "startLine": 83, "endLine": 93 },
     "type": "concept",
     "title": "Euler Beta Symmetry Without the Gamma Function",
     "content": "integral_beta_trig_symm instantiates the real-exponent lemma at exponents 2x−1 and 2y−1. In the classical trigonometric representation B(x,y) = 2∫_0^{π/2} sin^{2x−1}θ cos^{2y−1}θ dθ, this is precisely Euler's Beta symmetry B(x,y) = B(y,x). The standard route to that symmetry goes through B(x,y) = Γ(x)Γ(y)/Γ(x+y), where symmetry is visible from the commutativity of multiplication in the numerator; here the symmetry is obtained directly from the reflection, isolating it from the (harder, Gamma-dependent) evaluation of the Beta function.",
@@ -56,7 +56,7 @@
   {
     "id": "ann-parent-recovery",
     "proofId": "buffons-needle-oq-01-oq-01-oq-04-oq-01-oq-01-oq-01-oq-02",
-    "range": { "startLine": 112, "endLine": 117 },
+    "range": { "startLine": 95, "endLine": 107 },
     "type": "concept",
     "title": "The Parent's Identity as the a = 1 Corollary",
     "content": "integral_sin_mul_cos_pow_eq_reflect re-proves the parent's single-power reflection identity ∫ sin θ · cosᵐ θ = ∫ cos θ · sinᵐ θ as the special case a = 1, b = m of the headline lemma (with sin θ ^ 1 = sin θ, cos θ ^ 1 = cos θ via pow_one, then one mul_comm). This confirms the new two-parameter statement is a genuine generalization of the parent rather than a cosmetic restatement, and that the bespoke reflection the parent performed by hand is subsumed by the reusable lemma the open question requested.",
@@ -68,7 +68,7 @@
   {
     "id": "ann-scope-boundary",
     "proofId": "buffons-needle-oq-01-oq-01-oq-04-oq-01-oq-01-oq-01-oq-02",
-    "range": { "startLine": 37, "endLine": 47 },
+    "range": { "startLine": 109, "endLine": 117 },
     "type": "warning",
     "title": "Scope: Symmetry, Not Evaluation",
     "content": "This file proves only the symmetry of the trigonometric power integral, not its value. The evaluation of ∫ sin^{2x−1}θ cos^{2y−1}θ as Γ(x)Γ(y)/(2Γ(x+y)), and the bridge from this trigonometric form to Mathlib's Real.betaIntegral (∫_0^1 t^{x−1}(1−t)^{y−1} dt) via the half-angle substitution t = sin²θ, require the Gamma recurrence and lie outside the elementary reflection method. The open questions record connecting to Real.betaIntegral and deriving the Wallis recurrence as the natural next steps.",


### PR DESCRIPTION
## Enrichment pass — buffons-needle-oq-01-oq-01-oq-04-oq-01-oq-01-oq-01-oq-02

This entry is already at content-depth target (6 rich annotations with
`mathContext`/`significance`/`relatedConcepts`, 4 keyInsights, full conclusion,
sections, cross-refs), so no content was inflated. Instead this PR fixes a
genuine **annotation-anchoring correctness bug**: several annotation line-ranges
pointed at the wrong theorems in the Lean source.

Mapping `BuffonsNeedleOQ01OQ01OQ04OQ01OQ01OQ01OQ02.lean`:
nat theorem 46–63 · rpow 65–81 · beta 83–93 · parent-recovery 95–107 · diagonal example/end 109–117.

Before → after:

| annotation | old range | corrected | problem |
|---|---|---|---|
| `ann-swap-overview` | 3–54 | 3–40 | overran into first lemma |
| `ann-nat-swap` | 56–73 | 46–63 | overran into rpow docstring |
| `ann-rpow-swap` | 75–96 | 65–81 | overran into beta + parent |
| `ann-beta-symm` | 98–110 | 83–93 | **anchored over the parent theorem, not beta (90–93)** |
| `ann-parent-recovery` | 112–117 | 95–107 | **anchored over the diagonal example, not the parent theorem** |
| `ann-scope-boundary` | 37–47 | 109–117 | sat inside the docstring; now on the scope/boundary region |

Result: ranges are now monotonic, non-overlapping, and each annotation anchors
to exactly the theorem it explains (previously, clicking the beta theorem showed
no annotation while clicking the parent theorem showed the beta explanation).

No content deleted; `meta.json` unchanged. `axiomCount: 0` / `status: verified`
verified accurate against the Lean file (no axioms, no sorries, no
structure-encoded assumptions).

**Build note:** gallery-data validation (enrichment pass, search-index, loading-facts)
passed; the final `tsc` typecheck could not run because `node_modules` is not
installed in this worktree (`tsc: command not found`) — an environment gap
unrelated to this JSON-only change.