### PR TITLE
Research: erdos-703-incomplete-01 — T_L windowing (forbidden sizes > n are vacuous) [VERIFIED axiom-free]

### DIFF
--- a/proofs/Proofs/Erdos703Problem.lean
+++ b/proofs/Proofs/Erdos703Problem.lean
@@ -1187,6 +1187,53 @@ theorem T_L_le_pow_sub_one {n r : ℕ} {L : Finset ℕ} (hr : r ∈ L) (hrn : r 
   le_trans (T_L_le_T_of_mem hr) (T_le_pow_sub_one hrn)
 
 /--
+**Forbidding an unattainable size is vacuous.** For any family `F ⊆ 2^{[n]}`, every
+realized intersection size is `≤ n` (since `|A ∩ B| ≤ |A| ≤ n`), so a forbidden size
+`> n` is never met: `F` avoids `L` iff it avoids only the attainable part
+`L.filter (· ≤ n)`. This is the family-level windowing lemma underlying `T_L_filter_le`. -/
+theorem avoidsLIntersections_filter_le_of_mem_powerset
+    {n : ℕ} {L : Finset ℕ} {F : Finset (Finset ℕ)}
+    (hF : F ∈ (Finset.range n).powerset.powerset) :
+    avoidsLIntersections L F ↔ avoidsLIntersections (L.filter (· ≤ n)) F := by
+  have hFsub : F ⊆ (Finset.range n).powerset := Finset.mem_powerset.mp hF
+  constructor
+  · intro h A B hA hB hmem
+    exact h A B hA hB (Finset.mem_filter.mp hmem).1
+  · intro h A B hA hB hmem
+    have hAsub : A ⊆ Finset.range n := Finset.mem_powerset.mp (hFsub hA)
+    have hcard : (A ∩ B).card ≤ n :=
+      calc (A ∩ B).card ≤ A.card := Finset.card_le_card Finset.inter_subset_left
+        _ ≤ (Finset.range n).card := Finset.card_le_card hAsub
+        _ = n := Finset.card_range n
+    exact h A B hA hB (Finset.mem_filter.mpr ⟨hmem, hcard⟩)
+
+/--
+**`T_L` only sees the attainable window of forbidden sizes.** Since no two subsets of
+`[n]` can meet in a size exceeding `n`, forbidding sizes `> n` does not change the
+extremal quantity: `T_L n L = T_L n (L.filter (· ≤ n))`. This is the exact structural
+reason the hierarchy `T_L n ·` depends on `L` only through `L ∩ {0, …, n}`; it strictly
+**subsumes** `T_L_eq_pow_of_lt` (if every `r ∈ L` has `n < r` then the filter is empty
+and `T_L n L = T_L n ∅ = 2ⁿ`). -/
+theorem T_L_filter_le (n : ℕ) (L : Finset ℕ) :
+    T_L n L = T_L n (L.filter (· ≤ n)) := by
+  unfold T_L
+  refine congrArg _ (Finset.filter_congr ?_)
+  intro F hF
+  simpa using avoidsLIntersections_filter_le_of_mem_powerset hF
+
+/--
+**Only intersection sizes `0, …, n` matter.** The clean restatement of `T_L_filter_le`:
+`T_L n L = T_L n (L ∩ range (n+1))`, since `L.filter (· ≤ n) = L ∩ range (n+1)`. The
+`L`-avoiding hierarchy on ground set `[n]` factors through the intersection of the
+forbidden set with the attainable window `{0, 1, …, n}`. -/
+theorem T_L_inter_range (n : ℕ) (L : Finset ℕ) :
+    T_L n L = T_L n (L ∩ Finset.range (n + 1)) := by
+  have hfilt : L.filter (· ≤ n) = L ∩ Finset.range (n + 1) := by
+    ext r
+    simp only [Finset.mem_filter, Finset.mem_inter, Finset.mem_range, Nat.lt_succ_iff]
+  rw [T_L_filter_le, hfilt]
+
+/--
 **Fully-forbidden top endpoint `T_L n L = 0`.** If *every* attainable intersection size is
 forbidden — `range (n+1) ⊆ L`, i.e. `0, 1, …, n ∈ L` — then no nonempty family can avoid `L`:
 any set `A` in a family of subsets of `[n]` has the self-pair `A ∩ A = A` with size

--- a/research/problems/erdos-703-incomplete-01/knowledge.md
+++ b/research/problems/erdos-703-incomplete-01/knowledge.md
@@ -70,3 +70,36 @@ build passes**. Committed the .lean before touching meta this time.
 
 ### Still open (unchanged)
 `frankl_rodl_1987` (deep 1987 exponential bound, no Mathlib pathway) — BLOCKED.
+
+## Session 2026-07-12 (researcher-3) — T_L windowing: forbidden sizes > n are vacuous (VERIFIED axiom-free)
+
+**Mode**: REVISIT (RICH). The `T_L` (L-indexed forbidden-intersection) theory was well-developed
+(singleton=T, antitone, empty=2ⁿ, zero-endpoint, le_pow_sub_one, eq_pow_of_lt, union_le_min,
+eq_pow_iff). Added the missing **windowing structural fact**: since every realized intersection
+size is `≤ n` (`|A∩B| ≤ |A| ≤ |range n| = n`), forbidding sizes `> n` is vacuous, so `T_L n L`
+depends only on `L ∩ {0,…,n}`. All 0-axiom (deep `frankl_rodl_1987` UNTOUCHED; `#print axioms` =
+`[propext, Classical.choice, Quot.sound]`):
+
+- `avoidsLIntersections_filter_le_of_mem_powerset` — family-level: for `F ∈ 2^{2^{[n]}}`,
+  `avoidsLIntersections L F ↔ avoidsLIntersections (L.filter (· ≤ n)) F`. Forward = `mem_filter.mp .1`;
+  reverse bounds `(A∩B).card ≤ n` via `card_le_card inter_subset_left` + `card_le_card hAsub` +
+  `card_range`, then `mem_filter.mpr`.
+- **`T_L_filter_le`** — `T_L n L = T_L n (L.filter (· ≤ n))`. Proof: `unfold T_L; refine congrArg _
+  (Finset.filter_congr ?_); intro F hF; simpa using avoidsLIntersections_filter_le_of_mem_powerset hF`.
+  **Subsumes `T_L_eq_pow_of_lt`** (all `r>n` ⟹ filter empty ⟹ `T_L n ∅ = 2ⁿ`).
+- `T_L_inter_range` — clean restatement `T_L n L = T_L n (L ∩ range (n+1))` (`L.filter (·≤n) =
+  L ∩ range(n+1)` via `ext; simp [mem_filter, mem_inter, mem_range, Nat.lt_succ_iff]`).
+
+**Why not scaffolding.** This is the precise sense in which the whole `T_L n ·` hierarchy factors
+through the finite window `{0,…,n}` — a genuine reduction (infinite `L` ↦ finite relevant part),
+not a cosmetic variant; it retroactively explains the endpoint lemmas (`eq_pow_of_lt`,
+`eq_zero_of_range_subset`) as the two extremes of the windowed forbidden set.
+
+**Verification.** `./bin/lake env lean Proofs/Erdos703Problem.lean` exit 0, no errors/warnings
+(toolchain v4.26.0, no docker needed — self-contained file). `#print axioms` clean on all three.
+Counts: 1284→1331 lines, 58→61 thm, 11 def, 1 axiom (unchanged), 0 sorry. meta.json synced (was
+stale at 1222/55 → 1331/61).
+
+**No follow-up OQ.** The deep answer (`frankl_rodl_1987` exponential bound) is genuinely
+open-literature; the surrounding `T`/`T_L` extremal scaffolding is now saturated (endpoints,
+monotonicity, hierarchy structure, windowing all present).

--- a/src/data/proofs/erdos-703/meta.json
+++ b/src/data/proofs/erdos-703/meta.json
@@ -57,10 +57,10 @@
       "Positive lower endpoint of the L-avoiding hierarchy (Erdos703Problem.lean): avoidsLIntersections_singleton_family (a singleton family {A} avoids L iff |A| ∉ L, since its only pair is the self-intersection A∩A = A) and one_le_T_L_of_zero_notMem (0 ∉ L ⟹ 1 ≤ T_L n L, witnessed by the family {∅}). Together with the ceiling T_L_le_pow this sandwiches 1 ≤ T_L n L ≤ 2ⁿ for every L missing 0 — the L-avoiding analogue of one_le_T, complementing the empty-forbidden endpoint T_L n ∅ = 2ⁿ. Axiom-free ([propext, Classical.choice, Quot.sound])."
     ],
     "axiomCount": 1,
-    "lineCount": 1222,
+    "lineCount": 1331,
     "assumptions": "1 axiom: frankl_rodl_1987 (the deep Frankl–Rödl 1987 exponential bound — the affirmative answer to the main question). 0 sorries: the trivial case T(n,0)=2^{n-1} is fully machine-checked (#print axioms T_n_0 = [propext, Classical.choice, Quot.sound]) via a complement-pairing upper bound and a star-family witness. The unused opaque chromaticNumber axiom was removed; the geometric chromatic-number consequence is recorded as prose only since infinite unit-distance chromatic numbers are not yet in Mathlib.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 55,
+    "theoremCount": 61,
     "definitionCount": 11
   },
   "crossReferences": [
@@ -187,9 +187,9 @@
       "Finset"
     ],
     "namespace": "Erdos703",
-    "lineCount": 1222,
+    "lineCount": 1331,
     "axiomCount": 1,
-    "theoremCount": 55,
+    "theoremCount": 61,
     "definitionCount": 11,
     "path": "Proofs/Erdos703Problem.lean",
     "sorries": 0

--- a/src/data/research/problems/erdos-703-incomplete-01.json
+++ b/src/data/research/problems/erdos-703-incomplete-01.json
@@ -17,7 +17,7 @@
   },
   "currentState": "Added T_L_eq_pow_iff (researcher-7): sharp top-endpoint characterization T_L n L = 2^n <-> (∀ r ∈ L, n < r), packaging as one iff the dichotomy previously stated only in prose across T_L_eq_pow_of_lt (⟸) and T_L_le_pow_sub_one (⟹). Mirror of bottom endpoint T_L_eq_zero_of_range_subset. 0 new axioms; deep Frankl-Rödl bound remains the sole axiom. Prior: T(n,0)=2^{n-1} fully machine-checked, Frankl-Füredi small cases, rich T/T_L bound theory.",
   "knowledge": {
-    "progressSummary": "PROGRESS (researcher-2, 2026-07-09, VERIFIED green build): proved the exact diagonal value T(n,n)=2^n-1, the third exactly-known boundary value of T(n,r) alongside T(n,0)=2^{n-1} and T(n,r)=2^n (n<r). A family avoids n-intersection iff it omits the full ground set [n] (the unique n-meeting pair among subsets of [n] is [n] with itself, forbidden as a self-pair by avoidsRIntersection). Deep frankl_rodl_1987 axiom and exact T(n,1) (Frankl 1977 upper bound) remain open.",
+    "progressSummary": "ACT/progress: added the T_L windowing structural fact (T_L_filter_le, T_L_inter_range) — the L-avoiding extremal quantity depends only on L intersect {0..n}, subsuming T_L_eq_pow_of_lt. File 1284->1331 lines, 58->61 thm, 1 deep axiom (frankl_rodl_1987, untouched), 0 sorries. Deep exponential bound remains open-literature; T/T_L scaffolding now saturated.",
     "builtItems": [
       "card_le_of_avoids_zero (Erdos703Problem.lean:97): complement-pairing upper bound |F| <= 2^{n-1} for 0-avoiding families",
       "star_family_card (Erdos703Problem.lean:164): fixed-point star family has 2^{n-1} members (Finset.card_nbij' bijection)",
@@ -26,7 +26,10 @@
       "franklFurediEven_card_le_T (Erdos703Problem.lean): even-parity T(n,r) lower bound, mirroring franklFurediOdd_card_le_T via Finset.le_sup. VERIFIED 0 extra axioms.",
       "Erdos703Problem.lean: inter_card_eq_n_iff (|A cap B|=n iff A=B=range n for A,B subseteq range n; Finset.eq_of_subset_of_card_le) + T_n_n (T(n,n)=2^n-1 via le_antisymm: upper = every avoiding family omits range n so embeds in powerset.erase, Finset.card_erase_of_mem+card_powerset; lower = powerset.erase(range n) is n-avoiding via inter_card_eq_n_iff, Finset.le_sup). VERIFIED GREEN [7743/7743], 0 new axioms/sorries.",
       "Erdos703Problem.lean (researcher-6, 2026-07-11): the T_L large-forbidden dichotomy — full_powerset_avoidsL_of_lt (∀r∈L, n<r ⟹ 2^[n] avoids L; |A∩B|≤n<r), T_L_eq_pow_of_lt (T_L n L = 2^n under same hyp, le_antisymm with T_L_le_pow ceiling + full-powerset witness; strictly generalizes T_L_empty), T_L_le_pow_sub_one (∃r∈L, r≤n ⟹ T_L n L ≤ 2^n−1 by le_trans T_L_le_T_of_mem T_le_pow_sub_one). 3 axiom-free thms; the pair pins T_L n L = 2^n ⟺ every forbidden size exceeds n.",
-      "T_L_eq_pow_iff : T_L n L = 2^n ↔ ∀ r ∈ L, n < r — sharp top-endpoint of the antitone forbidden-set hierarchy (0 new axioms) [VERIFIED]"
+      "T_L_eq_pow_iff : T_L n L = 2^n ↔ ∀ r ∈ L, n < r — sharp top-endpoint of the antitone forbidden-set hierarchy (0 new axioms) [VERIFIED]",
+      "T_L_filter_le: T_L n L = T_L n (L.filter (.<= n)) — forbidding sizes > n is vacuous; subsumes T_L_eq_pow_of_lt (Erdos703Problem.lean)",
+      "T_L_inter_range: T_L n L = T_L n (L intersect range(n+1)) — the L-avoiding hierarchy factors through the window {0..n}",
+      "avoidsLIntersections_filter_le_of_mem_powerset: family-level windowing iff (intersection sizes are always <= n)"
     ],
     "insights": [
       "T(n,0) = 2^{n-1}: the 0-avoiding families are exactly the intersecting families; the complement map sending A to its complement in [n] injects any intersecting F into a disjoint copy, giving 2|F| <= 2^n, hence |F| <= 2^{n-1}.",
@@ -34,7 +37,8 @@
       "The remaining open content (Frankl-Rodl 1987 main bound, exponential chromatic number) is genuinely deep and stays axiomatized; only the trivial base case was within reach of a from-scratch Lean proof.",
       "The even-parity Frankl-Füredi family needs the |A\\{0}| (centred) size condition, not |A|: removing the fixed element 0 shrinks the ground set to n-1, which exactly compensates for the non-strict ≥ so that 2⌊(n+r)/2⌋-(n-1)=r+1 when n+r is even. For n+r odd the same bound only gives r (not r+1), which is why franklFurediOdd (strict >) covers the odd parity instead.",
       "VERIFIED (researcher-2, 2026-07-09, GREEN docker build [7743/7743]): the exact DIAGONAL value T(n,n)=2^n-1. Key structural fact inter_card_eq_n_iff: for A,B subseteq [n]=range n, |A cap B|=n iff A=B=[n] (an n-element subset of the n-element ground set is the whole set). Since avoidsRIntersection quantifies over ALL pairs INCLUDING A=B, a family avoids n-intersection iff it omits [n] itself (the self-pair ([n],[n]) has |[n] cap [n]|=n, forbidden), and no other pair can meet in n. So the maximum n-avoiding family = powerset(range n).erase (range n), card 2^n-1. This is the THIRD exactly-known boundary value, completing T(n,0)=2^{n-1} (trivial/intersecting) and T(n,r)=2^n for n<r (degenerate large-r); T(n,n) is the r=n diagonal endpoint. 0 axioms (does not touch frankl_rodl_1987).",
-      "T_L hierarchy top endpoint is sharp: =2^n iff no attainable size forbidden; forward dir needs only T_L_le_pow_sub_one (strict drop once r≤n forbidden), no Frankl-Rödl needed."
+      "T_L hierarchy top endpoint is sharp: =2^n iff no attainable size forbidden; forward dir needs only T_L_le_pow_sub_one (strict drop once r≤n forbidden), no Frankl-Rödl needed.",
+      "T_L n L depends on L only through L intersect {0..n}: since |A intersect B| <= |A| <= n for subsets of [n], any forbidden size > n is never realized. This retroactively explains the endpoint lemmas as the two extremes of the windowed forbidden set."
     ],
     "mathlibGaps": [],
     "nextSteps": [


### PR DESCRIPTION
## Summary
Research session for **erdos-703-incomplete-01** (Forbidden r-Intersection Families). The `T_L` (L-indexed forbidden-intersection) theory was well-developed, but the fundamental **windowing** fact was missing: since every realized intersection size is `≤ n`, forbidding sizes `> n` is vacuous, so `T_L n L` depends only on `L ∩ {0,…,n}`.

## Progress
New lemmas in `proofs/Proofs/Erdos703Problem.lean` (all axiom-free):
- `avoidsLIntersections_filter_le_of_mem_powerset` — family-level windowing iff: for `F ⊆ 2^{[n]}`, `avoidsLIntersections L F ↔ avoidsLIntersections (L.filter (· ≤ n)) F` (bound `|A ∩ B| ≤ |A| ≤ n`).
- `T_L_filter_le` — `T_L n L = T_L n (L.filter (· ≤ n))`. **Subsumes** `T_L_eq_pow_of_lt` (all `r > n` ⟹ filter empty ⟹ `T_L n ∅ = 2ⁿ`).
- `T_L_inter_range` — clean restatement `T_L n L = T_L n (L ∩ range (n+1))`: the L-avoiding hierarchy factors through the attainable window `{0,…,n}`.

## Verification
`./bin/lake env lean Proofs/Erdos703Problem.lean` exit 0, no errors/warnings (toolchain v4.26.0). `#print axioms` on all three = `[propext, Classical.choice, Quot.sound]` — the deep `frankl_rodl_1987` axiom is untouched.

Counts: file 1284→1331 lines, 58→61 thm, 1 axiom (unchanged), 0 sorries. `meta.json` synced (was stale at 1222/55).

## Status
**Outcome**: progress (3 axiom-free structural theorems). Status unchanged (`axiomatized` — deep Frankl–Rödl bound is open-literature).
**Next Steps**: the deep exponential bound remains genuinely open; the `T`/`T_L` extremal scaffolding is now saturated.

🤖 Generated by researcher-3