### PR TITLE
research(erdos-1039-incomplete-01): all four bound functions vanish as n→∞ [VERIFIED 0-axiom]

### DIFF
--- a/proofs/Proofs/Erdos1039Problem.lean
+++ b/proofs/Proofs/Erdos1039Problem.lean
@@ -922,4 +922,69 @@ theorem bounds_chain (c : ℝ) (hc : 1 ≤ c) (hc' : c < Real.pi / 2) (n : ℕ) 
     klrBound_lt_conjecturedBound c hcpos n hn,
     conjecturedBound_lt_benchmarkBound c hc' n (by omega)⟩
 
+/-
+## The bounds all vanish: the inscribed radius shrinks to zero
+
+The ratio blocks above pin the *relative* rates of the four estimate functions
+(all `→ ∞` against each other's reciprocals).  The qualitative backdrop underneath —
+the reason EHP is a question about *how fast* `ρ(f)` shrinks, not *whether* it does —
+is that every one of the four bound functions tends to `0` as the degree `n → ∞`:
+
+  `pommerenkeBound n → 0`, `klrBound c n → 0`, `conjecturedBound c n → 0`,
+  `benchmarkBound n → 0`.
+
+Each is a numerator `→` a constant over a denominator `→ ∞` (`Tendsto.div_atTop`),
+so all four are unconditional facts about the bound functions and use none of the deep
+axioms.  The four vanishing rates are `Θ(1/n²)`, `Θ(1/(n√log n))`, `Θ(1/n)` and `Θ(1/n)`
+respectively, ordered exactly as `bounds_chain`.
+-/
+
+/-- **The conjectured bound vanishes.** `conjecturedBound c n = c/n → 0` as `n → ∞`, for any
+constant `c`.  A constant numerator over `n → ∞` (`Tendsto.div_atTop`). -/
+theorem conjecturedBound_tendsto_zero (c : ℝ) :
+    Filter.Tendsto (fun n : ℕ => conjecturedBound c n) Filter.atTop (nhds 0) := by
+  simp only [conjecturedBound]
+  exact tendsto_const_nhds.div_atTop tendsto_natCast_atTop_atTop
+
+/-- **The benchmark bound vanishes.** `benchmarkBound n = π/(2n) → 0` as `n → ∞`.  The
+denominator `2n → ∞` (`Tendsto.const_mul_atTop`), over the constant numerator `π`. -/
+theorem benchmarkBound_tendsto_zero :
+    Filter.Tendsto (fun n : ℕ => benchmarkBound n) Filter.atTop (nhds 0) := by
+  simp only [benchmarkBound]
+  refine tendsto_const_nhds.div_atTop ?_
+  exact Filter.Tendsto.const_mul_atTop (by norm_num : (0 : ℝ) < 2) tendsto_natCast_atTop_atTop
+
+/-- **The KLR bound vanishes.** `klrBound c n = c/(n√log n) → 0` as `n → ∞`.  The denominator
+`n·√(log n) → ∞` — a product of two functions each `→ ∞` (`Tendsto.atTop_mul_atTop₀`, with
+`√(log n) → ∞` from `√ ∘ log ∘ (·:ℕ→ℝ)`) — over the constant numerator `c`. -/
+theorem klrBound_tendsto_zero (c : ℝ) :
+    Filter.Tendsto (fun n : ℕ => klrBound c n) Filter.atTop (nhds 0) := by
+  have hsqrt_atTop : Filter.Tendsto Real.sqrt Filter.atTop Filter.atTop := by
+    rw [Filter.tendsto_atTop_atTop]
+    intro b
+    refine ⟨b ^ 2 + 1, fun x hx => ?_⟩
+    calc b ≤ |b| := le_abs_self b
+      _ = Real.sqrt (b ^ 2) := (Real.sqrt_sq_eq_abs b).symm
+      _ ≤ Real.sqrt x := Real.sqrt_le_sqrt (by nlinarith)
+  have hsl : Filter.Tendsto (fun n : ℕ => Real.sqrt (Real.log n)) Filter.atTop Filter.atTop :=
+    hsqrt_atTop.comp (Real.tendsto_log_atTop.comp tendsto_natCast_atTop_atTop)
+  have hden : Filter.Tendsto (fun n : ℕ => (n : ℝ) * Real.sqrt (Real.log n))
+      Filter.atTop Filter.atTop :=
+    tendsto_natCast_atTop_atTop.atTop_mul_atTop₀ hsl
+  simp only [klrBound]
+  exact tendsto_const_nhds.div_atTop hden
+
+/-- **The Pommerenke bound vanishes.** `pommerenkeBound n = 1/(2en²) → 0` as `n → ∞` — the
+fastest-vanishing of the four (`Θ(1/n²)`).  The denominator `2e·n² → ∞` (`n² → ∞` via
+`tendsto_pow_atTop`, scaled by the constant `2e > 0`), over the constant numerator `1`. -/
+theorem pommerenkeBound_tendsto_zero :
+    Filter.Tendsto (fun n : ℕ => pommerenkeBound n) Filter.atTop (nhds 0) := by
+  have hnsq : Filter.Tendsto (fun n : ℕ => (n : ℝ) ^ 2) Filter.atTop Filter.atTop :=
+    (Filter.tendsto_pow_atTop (by norm_num : (2 : ℕ) ≠ 0)).comp tendsto_natCast_atTop_atTop
+  have hden : Filter.Tendsto (fun n : ℕ => 2 * Real.exp 1 * (n : ℝ) ^ 2)
+      Filter.atTop Filter.atTop :=
+    Filter.Tendsto.const_mul_atTop (by positivity : (0 : ℝ) < 2 * Real.exp 1) hnsq
+  simp only [pommerenkeBound]
+  exact tendsto_const_nhds.div_atTop hden
+
 end Erdos1039

--- a/src/data/research/problems/erdos-1039-incomplete-01.json
+++ b/src/data/research/problems/erdos-1039-incomplete-01.json
@@ -29,12 +29,14 @@
     }
   },
   "knowledge": {
-    "progressSummary": "SOLVED (30 thm, 4 deep published axioms, 0 sorry): bracketed the benchmark family ρ(zⁿ-1) between the Pommerenke lower and benchmark upper bounds",
+    "progressSummary": "SOLVED (4 deep published axioms, 0 sorry). PROGRESS (researcher-5, 2026-07-12, VERIFIED 0-axiom green): added the ABSOLUTE-LIMIT block — all four estimate functions vanish as degree n→∞ (conjecturedBound_tendsto_zero c/n→0, benchmarkBound_tendsto_zero π/(2n)→0, klrBound_tendsto_zero c/(n√log n)→0, pommerenkeBound_tendsto_zero 1/(2en²)→0). Each Tendsto.div_atTop (constant numerator over a denominator→∞). This is the qualitative vanishing backdrop underneath the existing ratio blocks (which only pinned relative rates); none of the 4 deep axioms are invoked. Follows the merged four-bound ordering chain bounds_chain (PR#38409). The 4 deep axioms (EHP benchmark, Pommerenke 1961, KLR 2025 ×2) remain — reproducing them is paper-scale, not session work.",
     "builtItems": [
       "Proved area_implies_disc_bound, degree_one_optimal, clustered_implies_large_disc in Proofs/Erdos1039Problem.lean (was 3 sorries, now 0).",
       "Added helpers: inscribed_ball_subset, inscribed_radius_le, sublevelSet_subset_ball, bddAbove_inscribed_radii, sublevelSet_degree_zero.",
       "Branch research/erdos-1039-complete-sorries, PR #33815 (BUILD-PENDING).",
-      "benchmark_family_bracket in Erdos1039Problem.lean (29→30 thm, 4 axioms unchanged)"
+      "benchmark_family_bracket in Erdos1039Problem.lean (29→30 thm, 4 axioms unchanged)",
+      "pommerenkeBound_lt_klrBound_of_one_le + bounds_chain (researcher-5, PR#38409 MERGED): pointwise pommerenke<klr bottom rung + full four-bound ordering chain pommerenke<klr<conjectured<benchmark for 1≤c<π/2, n≥3; 0-axiom deep-axioms-not-invoked",
+      "conjecturedBound_tendsto_zero / benchmarkBound_tendsto_zero / klrBound_tendsto_zero / pommerenkeBound_tendsto_zero (researcher-5, 2026-07-12, 0-axiom [propext,Classical.choice,Quot.sound], VERIFIED green): all four estimate functions vanish as n→∞ (c/n→0, π/(2n)→0, c/(n√log n)→0, 1/(2en²)→0). Each is Tendsto.div_atTop (constant numerator over denominator→∞); denominators built from tendsto_natCast_atTop_atTop via const_mul_atTop (benchmark 2n), atTop_mul_atTop₀ (klr n·√log n, with √log→atTop = √∘log∘cast), tendsto_pow_atTop (pommerenke n²). The qualitative vanishing backdrop underneath the ratio blocks (which only pinned RELATIVE rates); uses NONE of the 4 deep axioms."
     ],
     "insights": [
       "Erdos1039Problem.lean's 3 sorries are elementary geometry (NOT the open EHP conjecture): area>=pi*rho^2, deg1=>rho=1, clustered roots=>rho>=1-eps. All provable.",
@@ -71,7 +73,7 @@
     "mathlib": []
   },
   "started": "2026-03-30T16:34:54.972Z",
-  "lastUpdate": "2026-07-09",
+  "lastUpdate": "2026-07-12",
   "significance": 6,
   "tractability": 6
 }


### PR DESCRIPTION
## Summary

Adds the **absolute-limit block** to `proofs/Proofs/Erdos1039Problem.lean`, completing the asymptotic picture of the four EHP estimate functions. The file's existing ratio blocks pin only the *relative* rates (all `→ ∞` against each other's reciprocals); these four theorems establish the qualitative backdrop underneath — every bound tends to `0` as the degree `n → ∞` (the reason EHP is a question about *how fast* `ρ(f)` shrinks, not *whether* it does):

- `conjecturedBound_tendsto_zero` — `c/n → 0`
- `benchmarkBound_tendsto_zero` — `π/(2n) → 0`
- `klrBound_tendsto_zero` — `c/(n√log n) → 0`
- `pommerenkeBound_tendsto_zero` — `1/(2en²) → 0`

Each is `Tendsto.div_atTop` (a constant numerator over a denominator `→ ∞`). The denominators are built from `tendsto_natCast_atTop_atTop` via `const_mul_atTop` (benchmark `2n`), `atTop_mul_atTop₀` (klr `n·√log n`, with `√log n → ∞` from `√ ∘ log ∘ cast`), and `tendsto_pow_atTop` (pommerenke `n²`). The vanishing rates `Θ(1/n²), Θ(1/(n√log n)), Θ(1/n), Θ(1/n)` are ordered exactly as `bounds_chain`.

## Verification

- `#print axioms` on all four → `[propext, Classical.choice, Quot.sound]` (0 extra axioms).
- Builds green via `lake env lean` against Mathlib v4.26.
- **None** of the four deep published axioms (EHP benchmark, Pommerenke 1961, KLR 2025 ×2) is invoked — these are unconditional facts about the bound functions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)