### PR TITLE
Enrich Unconditional bracelet(4,2)=6 (burnside-counting-oq-04-oq-01): Part III section + decide-vs-native_decide keyInsight

### DIFF
--- a/src/data/proofs/burnside-counting-oq-04-oq-01/meta.json
+++ b/src/data/proofs/burnside-counting-oq-04-oq-01/meta.json
@@ -70,7 +70,8 @@
       "The reflection must act as x ↦ -i - x, not the geometrically tempting x ↦ i - x: only the former makes the position assignment a homomorphism for Mathlib's dihedral multiplication convention sr i * sr j = r (j - i)",
       "Burnside lets one avoid enumerating the orbit quotient (the expensive step the parent did with native_decide): only the fixed-point sum needs evaluation, and that is light enough for kernel decide (8 × 16 checks over Fin-based data)",
       "The single fixed-point sum 48 subsumes both hypotheses the parent assumed — the necklace contribution (16+2+4+2 = 24 from the rotations) and the reflection total (8+8+4+4 = 24 from the reflections) — so the count becomes unconditional",
-      "Representing positions as ZMod 4 and colours as Fin 2 keeps every object Fin-based, so kernel reduction of the action and the decidable-equality of colourings stays cheap"
+      "Representing positions as ZMod 4 and colours as Fin 2 keeps every object Fin-based, so kernel reduction of the action and the decidable-equality of colourings stays cheap",
+      "The fixed-point sum is discharged by kernel decide, not native_decide, and this is the point of the entry's honesty claim: native_decide trusts the compiler and injects the Lean.ofReduceBool axiom, whereas kernel decide reduces inside the trusted kernel and adds nothing — the closing #print axioms confirms only propext / Classical.choice / Quot.sound. So this count is genuinely axiom-free/verified, where the parent's native_decide route would carry Lean.ofReduceBool; the Fin-based encoding is exactly what keeps the 8×16 reduction light enough for the kernel to do it without native compilation."
     ],
     "prerequisites": [
       "Group actions, orbits, and the orbit-counting (Burnside/Cauchy–Frobenius) lemma",
@@ -99,9 +100,17 @@
       "id": "action",
       "title": "The Induced Action on Colourings",
       "startLine": 108,
-      "endLine": 130,
-      "summary": "(g • c) p = c ((ρ g)⁻¹ p) is a genuine MulAction of D₄ on Coloring = ZMod 4 → Fin 2 because ρ is a homomorphism; Fintype/DecidablePred instances for the fixed-point sets follow.",
+      "endLine": 122,
+      "summary": "(g • c) p = c ((ρ g)⁻¹ p) is a genuine MulAction of D₄ on Coloring = ZMod 4 → Fin 2 because ρ is a homomorphism (one_smul from ρ.map_one, mul_smul from ρ.map_mul); smul_apply unfolds the action pointwise for the fixed-point computations.",
       "mathContext": "$(g \\cdot c)(p) = c\\big((\\rho g)^{-1} p\\big).$"
+    },
+    {
+      "id": "fintype-instances",
+      "title": "Fintype and Decidability Instances for Burnside",
+      "startLine": 124,
+      "endLine": 151,
+      "summary": "Part III supplies the instances that make Burnside's lemma applicable and the bracelet count well-defined: decFixed (each fixed-point predicate g • c = c is decidable via decEq) and fintypeFixedBy (each Fix(g) is a Fintype), plus decidability of the orbit relation (two colourings are related iff ∃ g, g • b = a — decidable because D₄ is a Fintype and colourings have decidable equality) and the resulting Fintype instance on the orbit quotient orbitRel.Quotient (DihedralGroup 4) Coloring, so its cardinality — the bracelet count — is well-defined.",
+      "mathContext": "$\\mathrm{Fix}(g) = \\{c : g\\cdot c = c\\}$ decidable and finite; $a \\sim b \\iff \\exists g,\\, g\\cdot b = a$ decidable $\\Rightarrow$ the orbit quotient is a $\\mathrm{Fintype}$."
     },
     {
       "id": "count",


### PR DESCRIPTION
Enrichment pass for `burnside-counting-oq-04-oq-01`.

Entry was at quality 96. Two substantive additions (no filler):

**1. Filled a real coverage gap.** Part III (the Fintype/decidability instances, Lean lines 124–151) was mostly uncovered — the `action` section ended at line 130 and the `count` section began at line 152, leaving lines 131–151 (orbit-relation decidability and the quotient `Fintype`) dark. Rebalanced: `The Induced Action on Colourings` now covers 108–122 (just the `MulAction`), and a new `Fintype and Decidability Instances for Burnside` section covers 124–151 (`decFixed`, `fintypeFixedBy`, orbit-relation decidability, quotient `Fintype`). Sections now cover the file 1–173 (tail 174–180 is the closing `#print axioms` comment).

**2. 5th keyInsight (axiom integrity).** The fixed-point sum is discharged by kernel `decide`, **not** `native_decide`: kernel reduction adds no axiom, so the `#print axioms` audit shows only propext / Classical.choice / Quot.sound — a genuinely verified, `Lean.ofReduceBool`-free count, where the parent's `native_decide` route would carry that axiom. Directly aligned with the project's axiom-integrity policy and distinct from the existing insights (which cover the homomorphism convention, avoiding orbit enumeration, the sum subsuming both hypotheses, and Fin-based cheapness).

- meta.json 15.9 KB (well under ~60 KB cap); all collections under caps.
- No existing content deleted.
- Axiom integrity: status `verified`, axiomCount 0 — consistent with kernel `decide` (no native_decide, no Lean.ofReduceBool).

🤖 Generated with [Claude Code](https://claude.com/claude-code)