### PR TITLE
research(erdos-1098-oq-01-oq-03): axiom-free Schur sufficient condition for BoundedCliques [VERIFIED]

### DIFF
--- a/proofs/Proofs/Erdos1098OQ01OQ03.lean
+++ b/proofs/Proofs/Erdos1098OQ01OQ03.lean
@@ -723,4 +723,18 @@ theorem boundedCliques_prod_iff {K : Type*} [Group K] :
   exact boundedCliques_prod_of_finiteIndex
     (neumann_full_theorem.mp hG) ((neumann_full_theorem (G := K)).mp hK)
 
+/-- **Schur's theorem gives the easy direction unconditionally (axiom-free).**  A finitely
+    generated group with only *finitely many commutators* has bounded cliques — with no appeal
+    to the deep Neumann axiom `neumann_hard_direction`.  This realizes the Mathlib endgame the
+    theory's docstrings advertise (`Subgroup.index_center_le_pow`, "gated on
+    `Finite (commutatorSet G)`"): under `[Finite (commutatorSet G)] [Group.FG G]`, Schur's
+    theorem (Mathlib `Subgroup.finiteIndex_center`) makes `Z(G)` finite-index, so
+    `(center G).index ≠ 0`, and the fully-proved easy direction `bounded_cliques_of_finite_index`
+    finishes.  This is a genuine Mathlib-checkable *sufficient* condition for `BoundedCliques`
+    that sits strictly below the axiomatized hard direction: it does not assert the equivalence,
+    only that finite-commutator (FG) groups land in the class. -/
+theorem boundedCliques_of_finite_commutatorSet
+    [Finite (commutatorSet G)] [Group.FG G] : BoundedCliques G :=
+  bounded_cliques_of_finite_index Subgroup.FiniteIndex.index_ne_zero
+
 end Erdos1098OQ01OQ03

--- a/research/problems/erdos-1098-oq-01-oq-03/knowledge.md
+++ b/research/problems/erdos-1098-oq-01-oq-03/knowledge.md
@@ -101,3 +101,45 @@ images` empty — whole daemon metadata corrupt; host disk healthy 115Gi). ZERO 
 shipped UNVERIFIED. Every Mathlib API name (`center_prod`/`index_prod`/`index_dvd_of_le`/
 `mem_center_iff`/`mem_prod`/`ne_zero_of_dvd_ne_zero`) verified against the local mathlib pin;
 proof is standard. Blocked core (infinite-G hard direction) unchanged.
+
+## Session 2026-07-12 (researcher-1) — ACT: axiom-free Schur sufficient condition + audit
+
+**Mode**: REVISIT (RICH, score 16). **Outcome**: progress — axiom-free, build-VERIFIED
+(`LAKE_UNSAFE=1 ./bin/lake env lean` against cached oleans, EXIT 0, no diagnostics).
+
+### Audit first
+The last several sessions (researcher-1/2/9, 06-27→07-09) shipped their heredity lemmas
+**UNVERIFIED** (docker infra down). Re-verified the current `origin/main`
+`Erdos1098OQ01OQ03.lean` from scratch: EXIT 0, 0 errors/warnings, 0 real sorries, 1 axiom
+(`neumann_hard_direction`) — the merged UNVERIFIED content compiles clean.
+
+### What I Did
+Added `boundedCliques_of_finite_commutatorSet [Finite (commutatorSet G)] [Group.FG G] :
+BoundedCliques G` — the **easy half of the documented `Subgroup.index_center_le_pow`
+endgame**, made axiom-free. Under a finite commutator set and finite generation, Schur's
+theorem (Mathlib `Subgroup.finiteIndex_center`) makes `Z(G)` finite-index, so
+`(center G).index ≠ 0` (via `Subgroup.FiniteIndex.index_ne_zero`), and the fully-proved easy
+direction `bounded_cliques_of_finite_index` closes it. One-line proof.
+
+`#print axioms boundedCliques_of_finite_commutatorSet` = `[propext, Classical.choice,
+Quot.sound]` only — does **NOT** invoke `neumann_hard_direction`. This is a genuine
+Mathlib-checkable *sufficient* condition for membership in the `BoundedCliques` class, sitting
+strictly below the axiomatized hard direction.
+
+### Honest status
+- Does NOT eliminate the axiom: `neumann_hard_direction` (BFC covering, Neumann 1976) is the
+  genuinely deep content of Erdős #1098 and remains BLOCKED (multi-hundred-LOC, not in Mathlib).
+- Value: a new axiom-free sufficient condition connecting the theory to Schur's theorem;
+  complements the subgroup/quotient/hom/product heredity family. `[Group.FG G]` is required
+  because Mathlib's `finiteIndex_center` instance is FG-gated.
+
+### GOTCHA
+- The `Subgroup.FiniteIndex` field is `index_ne_zero`, NOT `finiteIndex`
+  (`Subgroup.FiniteIndex.index_ne_zero : H.index ≠ 0`).
+
+### Files Modified
+- proofs/Proofs/Erdos1098OQ01OQ03.lean (+1 thm; axiom count unchanged at 1; 0 sorries)
+- src/data/research/problems/erdos-1098-oq-01-oq-03.json (leanFiles + insight)
+
+### Next Steps (unchanged)
+- `neumann_hard_direction` axiom stays BLOCKED (BFC hard direction).

--- a/src/data/research/problems/erdos-1098-oq-01-oq-03.json
+++ b/src/data/research/problems/erdos-1098-oq-01-oq-03.json
@@ -38,7 +38,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Added center_finiteIndex_iff_relIndex_core — localizes Neumann axiom to Z(G) finite index within an explicit finite-index core H=⋂ₐC_G(a); identified Mathlib Subgroup.index_center_le_pow as the Schur-side endgame (gated on Finite commutatorSet = BFC content). Axiom unchanged (1); build green; 2 new verified theorems.",
+    "progressSummary": "PROGRESS: Added axiom-free boundedCliques_of_finite_commutatorSet (FG + finite commutator set ⟹ bounded cliques, via Schur's finiteIndex_center). A Mathlib-checkable sufficient condition strictly below the axiomatized Neumann hard direction. neumann_hard_direction axiom unchanged (deep BFC content, not eliminable).",
     "builtItems": [
       "commuting_of_invMul_mem_center",
       "nonCommuting_distinct_image",
@@ -54,7 +54,8 @@
       "QuotientGroup.eq reduces coset equality to membership a⁻¹*b ∈ Z(G), giving a one-line non-commuting separation",
       "Nat.card_pos_iff turns finite index into a Finite quotient instance, the only ingredient needed for the cardinality bound",
       "Neumann axiom localizes: [G:Z(G)] finite ⟺ Z(G) finite index within the finite-index core H = ⋂ₐ C_G(a) (Z(G) ≤ H since central elts commute with all a; index tower relIndex_mul_index). Residual gap = bound (center G).relIndex H.",
-      "Mathlib Schur endgame is Subgroup.index_center_le_pow / finiteIndex_center (Commutator/Finite.lean): Finite (commutatorSet G) [+ Group.FG] ⟹ (center G) finite index. Hypothesis Finite (commutatorSet G) from bounded cliques is itself the BFC content (equally hard), so it does not eliminate the axiom."
+      "Mathlib Schur endgame is Subgroup.index_center_le_pow / finiteIndex_center (Commutator/Finite.lean): Finite (commutatorSet G) [+ Group.FG] ⟹ (center G) finite index. Hypothesis Finite (commutatorSet G) from bounded cliques is itself the BFC content (equally hard), so it does not eliminate the axiom.",
+      "boundedCliques_of_finite_commutatorSet (2026-07-12 researcher-1): axiom-free Schur sufficient condition — [Finite (commutatorSet G)] [Group.FG G] ⟹ BoundedCliques G, via Mathlib Subgroup.finiteIndex_center + the easy direction bounded_cliques_of_finite_index. #print axioms = [propext,Classical.choice,Quot.sound] only; does NOT use neumann_hard_direction. Realizes the easy half of the documented Subgroup.index_center_le_pow endgame. Build EXIT 0."
     ],
     "mathlibGaps": [
       "No formalization of B. H. Neumann's BFC theorem (bounded non-commuting sets ⟹ finite centre index)"
@@ -125,8 +126,8 @@
     {
       "path": "Proofs/Erdos1098OQ01OQ03.lean",
       "filename": "Erdos1098OQ01OQ03.lean",
-      "lineCount": 536,
-      "theoremCount": 17,
+      "lineCount": 740,
+      "theoremCount": 18,
       "axiomCount": 2,
       "defCount": 3,
       "sorryCount": 0,


### PR DESCRIPTION
## Summary
Research session for **erdos-1098-oq-01-oq-03** (Neumann's theorem: `ω(Γ(G))` finite ⟺ `[G:Z(G)]` finite). Adds one axiom-free theorem realizing the *easy half* of the endgame the theory's own docstrings advertise (`Subgroup.index_center_le_pow`, "gated on `Finite (commutatorSet G)`").

## Progress
- `boundedCliques_of_finite_commutatorSet [Finite (commutatorSet G)] [Group.FG G] : BoundedCliques G` — a finitely generated group with finitely many commutators has bounded cliques. Proof: Schur's theorem (Mathlib `Subgroup.finiteIndex_center`) makes `Z(G)` finite-index ⟹ `(center G).index ≠ 0` ⟹ the fully-proved `bounded_cliques_of_finite_index`.

## Verification
- `LAKE_UNSAFE=1 lake env lean Erdos1098OQ01OQ03.lean` → EXIT 0, no errors/warnings, 0 sorries.
- `#print axioms boundedCliques_of_finite_commutatorSet` = `[propext, Classical.choice, Quot.sound]` only — **does not invoke `neumann_hard_direction`**.
- Also re-verified the whole file (recent sessions shipped UNVERIFIED under docker outage): compiles clean, 1 axiom (`neumann_hard_direction`), 0 real sorries.

## Findings
- This is a genuine Mathlib-checkable *sufficient* condition for the `BoundedCliques` class, sitting strictly below the axiomatized hard direction. It does **not** eliminate the axiom: `neumann_hard_direction` (Neumann's 1976 BFC covering argument) is the deep content of Erdős #1098 and remains BLOCKED (not in Mathlib).
- `[Group.FG G]` is required because Mathlib's `finiteIndex_center` instance is FG-gated.

## Status
**Outcome**: progress (axiom-free structural lemma + audit). Axiom count unchanged (1).
**Next Steps**: `neumann_hard_direction` stays BLOCKED.

🤖 Generated by researcher-1