### PR TITLE
Fix: correct erdos-630 axiomCount metadata (22 → 11)

### DIFF
--- a/src/data/proofs/erdos-630/meta.json
+++ b/src/data/proofs/erdos-630/meta.json
@@ -57,9 +57,9 @@
       "Connection to Combinatorial Nullstellensatz",
       "Graph polynomial formulation"
     ],
-    "axiomCount": 22,
+    "axiomCount": 11,
     "lineCount": 246,
-    "assumptions": "22 axiom(s) and 15 sorries(s).",
+    "assumptions": "11 axiom(s) and 15 sorries(s).",
     "mathlib_version": "4.26.0",
     "theoremCount": 11,
     "definitionCount": 8
@@ -214,7 +214,7 @@
     ],
     "namespace": "Erdos630",
     "lineCount": 246,
-    "axiomCount": 22,
+    "axiomCount": 11,
     "theoremCount": 11,
     "definitionCount": 8,
     "path": "Proofs/Erdos630Problem.lean",


### PR DESCRIPTION
## Fix

Corrects the `axiomCount` metadata for the erdos-630 gallery entry from 22 to 11 to match the actual Lean source.

## Evidence

`proofs/Proofs/Erdos630Problem.lean` declares **11** literal `axiom` declarations (verified via comment-stripped scan and `grep -cE '^\s*axiom '`):

```
complete_bipartite_list_chromatic, euler_formula, four_color_theorem,
thomassen_five_list, alon_tarsi_theorem, combinatorial_nullstellensatz,
alon_tarsi_coefficient, k24_list_chromatic, complete_bipartite_lower_bound,
list_coloring_conjecture_open, outerplanar_3_choosable
```

The file contains **no** structures/classes, so there are no structure-encoded assumptions to add (per the Axiom Integrity Policy). All other metadata (`lineCount` 246, `theoremCount` 11, `definitionCount` 8, `sorries` 15) already matches the source and is left unchanged.

**Before**: `meta.axiomCount` and `leanFile.axiomCount` = 22; `assumptions` = "22 axiom(s) and 15 sorries(s)."
**After**: both counts = 11; `assumptions` = "11 axiom(s) and 15 sorries(s)."

Status remains `axiomatized` / badge `axiom` (unchanged). Gallery data pipeline (enrichment, search index, loading facts) validated via `pnpm build`.

---
Automated fix by lean-mechanic agent.