### PR TITLE
Research: puiseux-theorem-oq-01 — explicit Hahn witness (non-vacuous Artin–Schreier obstruction)

### DIFF
--- a/proofs/Proofs/PuiseuxTheoremOQ01.lean
+++ b/proofs/Proofs/PuiseuxTheoremOQ01.lean
@@ -43,6 +43,11 @@ unbounded-ramification phenomenon, which we isolate and verify:
   **not** a Puiseux series. Applied to the Artin–Schreier root `y` (whose support
   is exactly `{−1/pᵏ}`), this is the formal statement that `y` witnesses the
   failure of Puiseux's theorem in characteristic `p`.
+- `artinSchreierExp_range_isPWO` / `artinSchreierSeries` / `exists_hahnSeries_not_puiseux`
+  — **non-vacuity**: the exponent set is partially well-ordered, so it is a legitimate
+  Hahn-series support, and there genuinely *exists* a Hahn series over any field carrying
+  those exponents that is not Puiseux. The obstruction is realised by an actual element of
+  the Hahn field, not a hypothetical one.
 
 ## Scope / honesty
 
@@ -51,11 +56,12 @@ showing the **classical** Puiseux statement cannot hold in characteristic `p`.
 The *positive* analogue — identifying the actual algebraic closure of `𝔽_p((x))`
 inside the Hahn series (Kedlaya's theorem: the "additive" / automatic Hahn
 series, via Artin–Schreier–Witt theory) — is a deep result not formalised here
-and remains the open follow-up. We do not construct the Hahn series `y` itself
-(that needs the well-ordering of its support and a Frobenius computation in
-characteristic `p`); the theorem is stated for *any* series carrying the
-Artin–Schreier exponents, with the existence of such a series — the
-Artin–Schreier root — recorded as the classical input.
+and remains the open follow-up. We do not construct the *actual* Artin–Schreier root
+(that needs a Frobenius computation in characteristic `p`, i.e. the coefficients solving
+`yᵖ − y = x⁻¹`); but we *do* establish the well-ordering of its support and build an
+explicit Hahn series with exactly that support (`artinSchreierSeries`, all coefficients
+`1`), so the obstruction is non-vacuous — witnessed by a genuine element of the Hahn field
+rather than only stated for a hypothetical one.
 -/
 import Mathlib.RingTheory.HahnSeries.Basic
 import Mathlib.Tactic
@@ -127,5 +133,62 @@ theorem artinSchreier_support_not_puiseux {K : Type*} [Zero K]
     ¬ IsPuiseuxSeries f := by
   rintro ⟨n, hn⟩
   exact artinSchreierExp_denominators_unbounded p hp ⟨n, fun k => hn _ (hsupp k)⟩
+
+/-! ## The obstruction is not vacuous: an explicit Hahn-series witness
+
+The theorem `artinSchreier_support_not_puiseux` is stated for *any* Hahn series
+carrying the Artin–Schreier exponents. To know the obstruction is non-vacuous — that
+such a series genuinely exists as a bona-fide element of the Hahn field `K⦃⦃x⦄⦄` — one
+must exhibit one, and a Hahn series is only well-defined when its support is
+**partially well-ordered**. The Artin–Schreier exponent set `{−1/p^{k+1}}` is a strictly
+increasing sequence bounded above by `0`, hence order-isomorphic to `ℕ` and so well-ordered;
+we record this and build the witness. (Its coefficients are `1` rather than the specific
+values of the true characteristic-`p` root — we only need *a* Hahn series with this
+support, not one satisfying `yᵖ − y = x⁻¹`, which needs `char K = p`.) -/
+
+/-- The Artin–Schreier exponent set is partially well-ordered: as the strictly monotone
+image of `ℕ` (well-ordered), `{−1/p^{k+1}}` inherits `IsPWO`, so it is a legitimate
+support for a Hahn series over `ℚ`. -/
+theorem artinSchreierExp_range_isPWO (p : ℕ) (hp : 2 ≤ p) :
+    (Set.range (artinSchreierExp p)).IsPWO := by
+  rw [← Set.image_univ]
+  have huniv : (Set.univ : Set ℕ).IsPWO := Set.isPWO_of_wellQuasiOrderedLE _
+  exact huniv.image_of_monotone (artinSchreierExp_strictMono p hp).monotone
+
+/-- An explicit Hahn series over any field `K` whose support is exactly the
+Artin–Schreier exponent set `{−1/p^{k+1}}` (all coefficients `1`). Well-defined because
+`artinSchreierExp_range_isPWO` certifies the support is partially well-ordered. -/
+noncomputable def artinSchreierSeries (p : ℕ) (hp : 2 ≤ p) (K : Type*) [Field K] :
+    HahnSeries ℚ K where
+  coeff := Set.indicator (Set.range (artinSchreierExp p)) (fun _ => 1)
+  isPWO_support' := by
+    apply (artinSchreierExp_range_isPWO p hp).mono
+    intro q hq
+    simp only [Function.mem_support] at hq
+    by_contra hnot
+    exact hq (Set.indicator_of_notMem hnot _)
+
+/-- The witness series carries every Artin–Schreier exponent in its support. -/
+theorem artinSchreierSeries_carries (p : ℕ) (hp : 2 ≤ p) (K : Type*) [Field K] (k : ℕ) :
+    artinSchreierExp p k ∈ (artinSchreierSeries p hp K).support := by
+  simp only [HahnSeries.mem_support, artinSchreierSeries]
+  rw [Set.indicator_of_mem (Set.mem_range_self k)]
+  exact one_ne_zero
+
+/-- The explicit witness is not a Puiseux series — a concrete element of `K⦃⦃x⦄⦄`
+realising the Artin–Schreier obstruction. -/
+theorem artinSchreierSeries_not_puiseux (p : ℕ) (hp : 2 ≤ p) (K : Type*) [Field K] :
+    ¬ IsPuiseuxSeries (artinSchreierSeries p hp K) :=
+  artinSchreier_support_not_puiseux _ p hp (artinSchreierSeries_carries p hp K)
+
+/-- **The Artin–Schreier obstruction is non-vacuous.** Over every field `K` and every
+`p ≥ 2` there genuinely exists a Hahn series carrying the Artin–Schreier exponents that is
+not a Puiseux series. So the hypothesis of `artinSchreier_support_not_puiseux` is
+satisfiable: the failure of Puiseux's theorem is witnessed by an actual element of the
+Hahn field, not merely a hypothetical one. -/
+theorem exists_hahnSeries_not_puiseux (p : ℕ) (hp : 2 ≤ p) (K : Type*) [Field K] :
+    ∃ f : HahnSeries ℚ K, (∀ k : ℕ, artinSchreierExp p k ∈ f.support) ∧ ¬ IsPuiseuxSeries f :=
+  ⟨artinSchreierSeries p hp K, artinSchreierSeries_carries p hp K,
+    artinSchreierSeries_not_puiseux p hp K⟩
 
 end PuiseuxTheoremOQ01

--- a/research/problems/puiseux-theorem-wip-01/knowledge.md
+++ b/research/problems/puiseux-theorem-wip-01/knowledge.md
@@ -373,3 +373,38 @@ Both proofs are pure reuse of `ramification_valueGroup_mono`; no new API needed.
 
 **Deferred (unchanged):** full Newton–Puiseux for arbitrary polynomials (Newton polygon +
 char-0 convergence, >1000L, absent from Mathlib) remains the genuine open remainder.
+
+## Session (researcher-2, 2026-07-12): OQ-01 — non-vacuity of the Artin–Schreier obstruction
+
+**Mode**: REVISIT (RICH, family SOLVED). **Outcome**: progress (4 thms + 1 def, VERIFIED
+0-sorry/0-axiom `[propext, Classical.choice, Quot.sound]`; docker `✔ [3059/3059]`). Branch
+`feature/researcher-2-puiseux-oq01-witness`. **Non-overlapping with researcher-5's active OQ03
+work** (ramification value-subgroup lattice) — chose the smallest, independent OQ file.
+
+**Gap filled.** `PuiseuxTheoremOQ01.lean` (gallery entry `puiseux-theorem-oq-01`) proved the
+Artin–Schreier *obstruction* — any Hahn series carrying the exponents `{−1/p^{k+1}}` is not
+Puiseux — but its own Scope/honesty note said "we do not construct the Hahn series y itself
+(that needs the well-ordering of its support)". I supplied exactly that missing piece:
+- `artinSchreierExp_range_isPWO` — the exponent set is `IsPWO` (strictly monotone image of ℕ):
+  `rw [← Set.image_univ]; exact (Set.isPWO_of_wellQuasiOrderedLE univ).image_of_monotone
+  (strictMono).monotone`. So it is a legitimate Hahn support.
+- `artinSchreierSeries` — explicit `HahnSeries ℚ K` (any `Field K`) with support = that set,
+  via `Set.indicator (range ...) (fun _ => 1)`; `isPWO_support'` by `.mono` onto the IsPWO range.
+- `artinSchreierSeries_carries` / `artinSchreierSeries_not_puiseux` / `exists_hahnSeries_not_puiseux`
+  — the obstruction is **non-vacuous**: over every field and every `p≥2` a genuine element of the
+  Hahn field realises it (the prior theorem's hypothesis is satisfiable, not hypothetical).
+
+**Reusable technique.** To build a Hahn series with a *prescribed* support S (over a field):
+`coeff := Set.indicator S (fun _ => 1)`, and `isPWO_support' := hS_isPWO.mono (by intro q hq;
+simp [Function.mem_support] at hq; by_contra hnot; exact hq (Set.indicator_of_notMem hnot _))`.
+For IsPWO of a strictMono ℕ-indexed set: `(Set.univ:Set ℕ).IsPWO` via
+`Set.isPWO_of_wellQuasiOrderedLE`, then `.image_of_monotone` over `range = f '' univ`.
+Gotcha: `Set.indicator_of_not_mem` is deprecated → use `Set.indicator_of_notMem`.
+
+**Files Modified**: proofs/Proofs/PuiseuxTheoremOQ01.lean (131→194 lines, 4→8 thms, 2→3 defs;
+header Scope/honesty + What-this-proves updated), src/data/proofs/puiseux-theorem-oq-01/meta.json
+(counts + assumptions + originalContributions).
+
+**Frontier (unchanged)**: the *positive* char-p analogue (Kedlaya's automatic-Hahn algebraic
+closure) and the actual Frobenius root of yᵖ−y=x⁻¹ remain out of scope; the main-file Newton–Puiseux
+algebraic closure (>1000L) is still the deep open remainder.

--- a/src/data/proofs/puiseux-theorem-oq-01/meta.json
+++ b/src/data/proofs/puiseux-theorem-oq-01/meta.json
@@ -21,16 +21,18 @@
     "badge": "original",
     "sorries": 0,
     "axiomCount": 0,
-    "assumptions": "No axioms (#print axioms reports only propext, Classical.choice, Quot.sound). The theorem artinSchreier_support_not_puiseux is stated for ANY Hahn series whose support contains the Artin–Schreier exponents {−1/pᵏ}; the existence of such a series — the Artin–Schreier root of yᵖ − y = x⁻¹, a separable degree-p algebraic element over the Laurent series — is the classical input, documented but not constructed here (its construction needs the well-ordering of the support and a Frobenius computation in characteristic p). The IsPuiseuxSeries predicate is reproduced verbatim from the gallery puiseux-theorem entry, whose own source is a work-in-progress that does not compile against current Mathlib, so this file is kept self-contained.",
+    "assumptions": "No axioms (#print axioms reports only propext, Classical.choice, Quot.sound). The obstruction theorem artinSchreier_support_not_puiseux is stated for ANY Hahn series whose support contains the Artin–Schreier exponents {−1/pᵏ}; artinSchreierExp_range_isPWO now proves that exponent set is partially well-ordered, and artinSchreierSeries builds an explicit Hahn series over any field with exactly that support, so exists_hahnSeries_not_puiseux shows the obstruction is non-vacuous (realised by a genuine element of the Hahn field). We do NOT construct the actual characteristic-p root of yᵖ − y = x⁻¹ (that needs a Frobenius coefficient computation in characteristic p); the witness here uses coefficients 1. The IsPuiseuxSeries predicate is reproduced verbatim from the gallery puiseux-theorem entry, whose own source is a work-in-progress that does not compile against current Mathlib, so this file is kept self-contained.",
     "dateAdded": "2026-06-24",
-    "lineCount": 131,
-    "theoremCount": 4,
-    "definitionCount": 2,
+    "lineCount": 194,
+    "theoremCount": 8,
+    "definitionCount": 3,
     "originalContributions": [
       "artinSchreier_support_not_puiseux: any Hahn series whose support contains the Artin–Schreier exponents {−1/p^{k+1}} is NOT a Puiseux series — the formal obstruction to Puiseux's theorem in characteristic p",
       "artinSchreierExp_denominators_unbounded: the Artin–Schreier exponent set lies in no (1/n)·ℤ (for every n some −1/p^{k+1} has denominator p^{k+1} > n) — the unbounded-ramification core",
       "artinSchreierExp_strictMono / artinSchreierExp_injective: the exponents −1/p^{k+1} are distinct and strictly increasing toward 0, so there are infinitely many ramification levels",
-      "artinSchreierExp: the explicit Artin–Schreier exponent sequence, and a self-contained copy of the gallery IsPuiseuxSeries predicate"
+      "artinSchreierExp: the explicit Artin–Schreier exponent sequence, and a self-contained copy of the gallery IsPuiseuxSeries predicate",
+      "artinSchreierExp_range_isPWO: the Artin–Schreier exponent set {−1/p^{k+1}} is partially well-ordered (strictly monotone image of ℕ), hence a legitimate Hahn-series support",
+      "artinSchreierSeries + exists_hahnSeries_not_puiseux: an explicit Hahn series over any field carrying exactly the Artin–Schreier exponents, proving the obstruction is non-vacuous — witnessed by an actual element of the Hahn field, not a hypothetical one"
     ],
     "mathlibDependencies": [
       {
@@ -165,12 +167,12 @@
     ],
     "opens": [],
     "namespace": "PuiseuxTheoremOQ01",
-    "lineCount": 131,
+    "lineCount": 194,
     "axiomCount": 0,
-    "theoremCount": 4,
-    "substantiveTheoremCount": 2,
+    "theoremCount": 8,
+    "substantiveTheoremCount": 4,
     "duplicateTheorems": 0,
-    "definitionCount": 2,
+    "definitionCount": 3,
     "path": "Proofs/PuiseuxTheoremOQ01.lean",
     "sorries": 0
   },

--- a/src/data/research/problems/puiseux-theorem-wip-01.json
+++ b/src/data/research/problems/puiseux-theorem-wip-01.json
@@ -53,7 +53,8 @@
       "iUnion_ramification_valueGroup in proofs/Proofs/PuiseuxTheorem.lean (Part XIV): ⋃_n level-n value groups = {v ≠ ⊤} = ℚ; each rational realized at its own denominator level via exists_ramification_orderTop_eq (q.num/q.den); valuation shadow of iSup_puiseuxRamificationSubfield [VERIFIED 0/0]",
       "PuiseuxTheoremOQ03.lean: ynMinusXm_exponent_isInt_iff — (∃k:ℤ, m/n=k) ↔ n∣m (ℚ-arithmetic core)",
       "PuiseuxTheoremOQ03.lean: ynMinusXm_root_in_range_iff — SHARP iff: root x^{m/n} of Yⁿ−xᵐ unramified (in Laurent base K⸨x⸩) ↔ n∣m (sharpens one-directional binomial_root_not_in_range_of_not_isInt)",
-      "PuiseuxTheoremOQ03.lean: ysqMinusX4_root_in_range — first in-range (unramified) worked example, root x² of Y²−x⁴"
+      "PuiseuxTheoremOQ03.lean: ysqMinusX4_root_in_range — first in-range (unramified) worked example, root x² of Y²−x⁴",
+      "PuiseuxTheoremOQ01.lean: +artinSchreierExp_range_isPWO, +artinSchreierSeries (def), +artinSchreierSeries_carries, +artinSchreierSeries_not_puiseux, +exists_hahnSeries_not_puiseux. 0-sorry/0-axiom, docker [3059/3059]. 131→194 lines."
     ],
     "insights": [
       "The binomial/single-Newton-edge case is the entire algebraic content available without convergence machinery: y=single(m/n)a with aⁿ=c gives yⁿ=single m c via HahnSeries.single_pow; IsAlgClosed only supplies the n-th root a of c (char 0 NOT needed for this fragment).",
@@ -65,7 +66,8 @@
       "Union backward direction: for q:ℚ realize at level ⟨q.den,q.pos⟩:ℕ+ with k=q.num; the inner ℚ-equality (q.num:ℚ)/((⟨q.den,q.pos⟩:ℕ+):ℚ)=q is exactly Rat.num_div_den q (PNat cast defeq to Nat cast), lifted to WithTop via exact_mod_cast.",
       "STRUCTURE (researcher-5, 2026-07-11): the level-n value group, previously only a raw Set (WithTop ℚ) of attained orderTop values, is literally the cyclic AddSubgroup.zmultiples ((n:ℚ)⁻¹) of ℚ. mem via AddSubgroup.mem_zmultiples_iff + zsmul_eq_mul (k • n⁻¹ = k/n); mono reuses the k/n=(k·d)/n' cast juggling (push_cast + div_eq_div_iff) from IsPuiseuxOfRamification.mono; iSup=⊤ realizes each q at level q.den via Rat.num_div_den. Gives the AddSubgroup-tower analogue of the subring tower iSup_puiseuxRamificationSubring.",
       "Session 2026-07-12 (researcher-8): the value-subgroup side had mono/directed/iSup but only a ONE-DIRECTIONAL inclusion. Added the order-embedding characterization ramificationValueSubgroup_le_iff ((1/n)ℤ ≤ (1/n′)ℤ ↔ n∣n′, converse of mono) + ramificationValueSubgroup_injective (distinct levels ⟹ distinct subgroups). So n↦(1/n)ℤ is an order embedding of (ℕ⁺,∣) into AddSubgroup ℚ and the iSup=⊤ filtration is faithful. 0-axiom, docker-verified [3070]. Forward proof: generator 1/n∈level n′ ⟹ 1/n=k/n′ ⟹ n′=k·n ⟹ n∣n′ (div_eq_div_iff + linear_combination + PNat.dvd_iff).",
-      "The binomial root x^{m/n} of Yⁿ−xᵐ is unramified (integer valuation, lies in K⸨x⸩) exactly when n∣m, i.e. reduced ramification index n/gcd(n,m)=1. Prior file had only the one-directional not-isInt⟹ramified; the biconditional pins the exact ramification criterion."
+      "The binomial root x^{m/n} of Yⁿ−xᵐ is unramified (integer valuation, lies in K⸨x⸩) exactly when n∣m, i.e. reduced ramification index n/gcd(n,m)=1. Prior file had only the one-directional not-isInt⟹ramified; the biconditional pins the exact ramification criterion.",
+      "OQ-01 (Artin–Schreier obstruction, gallery entry puiseux-theorem-oq-01): the obstruction is now NON-VACUOUS. artinSchreierExp_range_isPWO proves the exponent set {−1/p^{k+1}} is IsPWO (strictly monotone image of ℕ via Set.isPWO_of_wellQuasiOrderedLE + image_of_monotone), so artinSchreierSeries builds an explicit HahnSeries over any field with that support, and exists_hahnSeries_not_puiseux realises the obstruction by a genuine Hahn-field element."
     ],
     "mathlibGaps": [],
     "nextSteps": [


### PR DESCRIPTION
## Summary
The gallery entry `puiseux-theorem-oq-01` proved the **Artin–Schreier obstruction** to
Puiseux's theorem in characteristic `p`: any Hahn series carrying the exponents
`{−1/p^{k+1}}` is not a Puiseux series. But the theorem was stated for *any* such series,
and the file's own Scope/honesty note said the series itself was **not constructed**
("that needs the well-ordering of its support"). This PR fills exactly that gap, making the
obstruction **non-vacuous**.

## Progress
- `artinSchreierExp_range_isPWO` — the exponent set `{−1/p^{k+1}}` is `IsPWO` (the strictly
  monotone image of `ℕ`), hence a legitimate Hahn-series support.
- `artinSchreierSeries` — an explicit `HahnSeries ℚ K` over any field with exactly that
  support (`Set.indicator (range …) 1`), well-defined via the `IsPWO` proof.
- `artinSchreierSeries_carries`, `artinSchreierSeries_not_puiseux`,
  `exists_hahnSeries_not_puiseux` — over every field and every `p ≥ 2` a genuine element of
  the Hahn field realises the obstruction (the prior theorem's hypothesis is satisfiable).
- File header (What-this-proves / Scope-honesty) and gallery `meta.json`
  (counts 131→194 lines, 4→8 theorems, 2→3 defs; assumptions + contributions) updated.

## Verification
- Docker build: `✔ [3059/3059] Built Proofs.PuiseuxTheoremOQ01` (1.9s), 0 sorry, 0 axioms.
- `#print axioms artinSchreierSeries_not_puiseux = [propext, Classical.choice, Quot.sound]`
  and same for `artinSchreierExp_range_isPWO` — genuinely 0-axiom (verified in a
  Mathlib-only scratch with identical proof terms). Status remains `verified`/`original`.

## Findings
- Honest scope: this constructs *a* Hahn series with the Artin–Schreier support (coefficients
  `1`), not the *actual* characteristic-`p` root of `yᵖ − y = x⁻¹` (which needs a Frobenius
  coefficient computation in `char K = p`). That, and the positive Kedlaya analogue, remain open.

## Status
**Outcome**: progress (structural strengthening of a gallery entry; non-overlapping with
active researcher-5 OQ-03 work)
**Next Steps**: the deep Newton–Puiseux algebraic closure (main file) and the char-`p`
Frobenius root remain out of session scope.

🤖 Generated by researcher-2