### PR TITLE
Adopt configurable worktree root across the lean fleet (LOOM_WORKTREE_ROOT / worktree.root) — resume of #37509

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,22 @@ git worktree remove .claude/worktrees/my-fix
 
 Or use the Claude Code `isolation: "worktree"` agent option for automatic worktree management.
 
+### Worktree location
+
+Fleet and Loom worktrees honor a configurable worktree root (resolved by
+`scripts/lib/worktree-root.sh`, precedence: `LOOM_WORKTREE_ROOT` env var >
+`.loom/config.json` → `worktree.root` > default `$REPO_ROOT/.loom/worktrees`).
+On this fleet's host the operator sets `worktree.root = "/Volumes/Stripe"`
+in `.loom/config.json` (runtime state — gitignored, NOT tracked), so agent
+worktrees (`enricher-N`, `researcher-N`, `erdos-N`, `aristotle`, …) resolve
+to `/Volumes/Stripe/lean-genius/<name>` on the dedicated 3.6 TiB volume
+instead of the boot disk. Overrides are namespaced by repo basename; an
+override must be an absolute path (a relative value warns and falls back to
+the default).
+Cleanup/GC (`scripts/clean-branches.sh`, `scripts/lean/infra-guardian.sh`)
+services worktrees at both the resolved root and the legacy
+`.loom/worktrees/` location during the transition.
+
 ---
 
 ## DANGER: Never Run `lake build` Directly

--- a/scripts/aristotle/launch-agent.sh
+++ b/scripts/aristotle/launch-agent.sh
@@ -20,7 +20,11 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 
 SESSION_NAME="aristotle-agent"
-WORKTREE_PATH="$REPO_ROOT/.loom/worktrees/aristotle"
+# Resolved worktree base (LOOM_WORKTREE_ROOT env var / .loom/config.json
+# worktree.root override; default $REPO_ROOT/.loom/worktrees).
+# shellcheck source=../lib/worktree-root.sh
+source "$REPO_ROOT/scripts/lib/worktree-root.sh"
+WORKTREE_PATH="$(loom_worktree_root "$REPO_ROOT")/aristotle"
 BRANCH_NAME="feature/aristotle-integrations"
 LOGS_DIR="$REPO_ROOT/.loom/logs"
 SIGNALS_DIR="$REPO_ROOT/.loom/signals"
@@ -132,6 +136,7 @@ create_worktree() {
     git branch -D "$BRANCH_NAME" 2>/dev/null || true
 
     print_info "Creating worktree..."
+    mkdir -p "$(dirname "$WORKTREE_PATH")"
     git worktree add "$WORKTREE_PATH" -b "$BRANCH_NAME" main
 
     # Symlink .lake for fast Lean builds

--- a/scripts/auditor/launch-agent.sh
+++ b/scripts/auditor/launch-agent.sh
@@ -42,7 +42,11 @@ find_repo_root() {
 }
 
 REPO_ROOT="$(find_repo_root)"
-WORKTREES_DIR="$REPO_ROOT/.loom/worktrees"
+# Resolved worktree base (LOOM_WORKTREE_ROOT env var / .loom/config.json
+# worktree.root override; default $REPO_ROOT/.loom/worktrees).
+# shellcheck source=../lib/worktree-root.sh
+source "$REPO_ROOT/scripts/lib/worktree-root.sh"
+WORKTREES_DIR="$(loom_worktree_root "$REPO_ROOT")"
 LOGS_DIR="$REPO_ROOT/.loom/logs"
 SIGNALS_DIR="$REPO_ROOT/.loom/signals"
 SESSION_NAME="${SESSION_NAME:-auditor-agent}"

--- a/scripts/clean-branches.sh
+++ b/scripts/clean-branches.sh
@@ -55,6 +55,30 @@ find_repo_root() {
 
 REPO_ROOT="$(find_repo_root)"
 
+# Resolved worktree base (LOOM_WORKTREE_ROOT env var / .loom/config.json
+# worktree.root override; default $REPO_ROOT/.loom/worktrees). The Phase 4
+# worktree passes below must service BOTH the legacy default location and the
+# resolved override root (when they differ) so worktrees never leak at either
+# location during the transition (issue #37509).
+# shellcheck source=lib/worktree-root.sh
+source "$REPO_ROOT/scripts/lib/worktree-root.sh"
+WORKTREE_ROOT_RESOLVED="$(loom_worktree_root "$REPO_ROOT")"
+WORKTREE_SCAN_ROOTS=("$REPO_ROOT/.loom/worktrees")
+if [[ "$WORKTREE_ROOT_RESOLVED" != "$REPO_ROOT/.loom/worktrees" ]]; then
+    WORKTREE_SCAN_ROOTS+=("$WORKTREE_ROOT_RESOLVED")
+fi
+
+# wt_scan_label <scan_root> <wt_name> — human-facing label for log lines.
+# Keeps the historical ".loom/worktrees/<name>" form for the default root and
+# uses the absolute path for an override root.
+wt_scan_label() {
+    if [[ "$1" == "$REPO_ROOT/.loom/worktrees" ]]; then
+        echo ".loom/worktrees/$2"
+    else
+        echo "$1/$2"
+    fi
+}
+
 # Parse arguments
 DRY_RUN=false
 FORCE=false
@@ -144,13 +168,18 @@ Worktree cleanup:
   Only after every guard passes:
   - .claude/worktrees/*: REMOVE once its branch is merged/closed/gone on
     origin or it has no activity for WORKTREE_MAX_AGE_DAYS
+  All .loom/worktrees/ passes below also scan the resolved worktree root
+  when a LOOM_WORKTREE_ROOT env var or .loom/config.json worktree.root
+  override is set (e.g. /Volumes/Stripe/<repo>/), so worktrees are serviced
+  at BOTH locations during a transition:
   - .loom/worktrees/issue-* for closed GitHub issues: REMOVE
   - .loom/worktrees/temp-* (temporary rebase worktrees): REMOVE
   - .loom/worktrees/* (scratch: audit-*, auditor-*, mechanic-*,
     researcher-*, enricher-*, …): REMOVE when its branch is merged/closed/
     gone on origin OR it has no activity anywhere in its tree for
     WORKTREE_MAX_AGE_DAYS (default 30). Preserved otherwise.
-  - git-registered worktrees OUTSIDE .loom/worktrees/ and .claude/worktrees/
+  - git-registered worktrees OUTSIDE .loom/worktrees/, .claude/worktrees/,
+    and the resolved override worktree root
     additionally get rescue-then-reclaim: once clean and idle everywhere in
     the tree for OUT_OF_TREE_RESCUE_HOURS (default 24), local-only commits
     are pushed to a backup/ ref on origin and the stray is reclaimed —
@@ -990,9 +1019,10 @@ echo ""
 
 # --- .loom/worktrees/issue-* (closed issues) ---
 
-header "  Checking .loom/worktrees/issue-*..."
+header "  Checking .loom/worktrees/issue-* (all worktree roots)..."
 
-for wt_dir in "$REPO_ROOT/.loom/worktrees"/issue-*/; do
+for wt_scan_root in "${WORKTREE_SCAN_ROOTS[@]}"; do
+for wt_dir in "$wt_scan_root"/issue-*/; do
     [[ ! -d "$wt_dir" ]] && continue
     wt_name=$(basename "$wt_dir")
     issue_num="${wt_name#issue-}"
@@ -1004,26 +1034,29 @@ for wt_dir in "$REPO_ROOT/.loom/worktrees"/issue-*/; do
         # Closed issue is the reclaim trigger; reclaim_worktree still applies
         # every structural guard (live session, recent activity, dirty tree,
         # unpushed commits, open PR, …) before removing anything.
-        reclaim_worktree "${wt_dir%/}" ".loom/worktrees/$wt_name" "issue #$issue_num closed"
+        reclaim_worktree "${wt_dir%/}" "$(wt_scan_label "$wt_scan_root" "$wt_name")" "issue #$issue_num closed"
     else
         ((worktrees_preserved++)) || true
-        info "    Preserving: .loom/worktrees/$wt_name (issue $issue_state)"
+        info "    Preserving: $(wt_scan_label "$wt_scan_root" "$wt_name") (issue $issue_state)"
     fi
+done
 done
 
 echo ""
 
 # --- .loom/worktrees/temp-* (temporary rebase worktrees) ---
 
-header "  Checking .loom/worktrees/temp-*..."
+header "  Checking .loom/worktrees/temp-* (all worktree roots)..."
 
-for wt_dir in "$REPO_ROOT/.loom/worktrees"/temp-*/; do
+for wt_scan_root in "${WORKTREE_SCAN_ROOTS[@]}"; do
+for wt_dir in "$wt_scan_root"/temp-*/; do
     [[ ! -d "$wt_dir" ]] && continue
     wt_name=$(basename "$wt_dir")
 
     # "temporary" is the reclaim trigger; the structural guards still protect
     # an in-flight rebase (dirty tree, recent activity, live process).
-    reclaim_worktree "${wt_dir%/}" ".loom/worktrees/$wt_name" "temporary"
+    reclaim_worktree "${wt_dir%/}" "$(wt_scan_label "$wt_scan_root" "$wt_name")" "temporary"
+done
 done
 
 echo ""
@@ -1066,10 +1099,13 @@ echo ""
 #   upstream present + stale             => REMOVE   (reason: stale)
 #   upstream present + recent            => PRESERVE (unmerged, recent)
 
-header "  Checking .loom/worktrees/* (scratch)..."
+header "  Checking .loom/worktrees/* (scratch, all worktree roots)..."
 
-if [[ -d "$REPO_ROOT/.loom/worktrees" ]]; then
-    for wt_dir in "$REPO_ROOT/.loom/worktrees"/*/; do
+wt_scratch_found=0
+for wt_scan_root in "${WORKTREE_SCAN_ROOTS[@]}"; do
+    [[ ! -d "$wt_scan_root" ]] && continue
+    wt_scratch_found=1
+    for wt_dir in "$wt_scan_root"/*/; do
         [[ ! -d "$wt_dir" ]] && continue
         wt_name=$(basename "$wt_dir")
 
@@ -1078,10 +1114,11 @@ if [[ -d "$REPO_ROOT/.loom/worktrees" ]]; then
             issue-*|temp-*) continue ;;
         esac
 
-        reclaim_worktree "${wt_dir%/}" ".loom/worktrees/$wt_name"
+        reclaim_worktree "${wt_dir%/}" "$(wt_scan_label "$wt_scan_root" "$wt_name")"
     done
-else
-    info "    No .loom/worktrees/ directory found"
+done
+if [[ "$wt_scratch_found" -eq 0 ]]; then
+    info "    No worktree root directory found"
 fi
 
 echo ""
@@ -1153,6 +1190,10 @@ rescue_out_of_tree() {
 # other, unrelated repository.
 repo_common_dir="$(cd "$REPO_ROOT" 2>/dev/null && git rev-parse --path-format=absolute --git-common-dir 2>/dev/null || echo "")"
 loom_wt_root="$(cd "$REPO_ROOT/.loom/worktrees" 2>/dev/null && pwd -P || echo "$REPO_ROOT/.loom/worktrees")"
+# An overridden worktree root (LOOM_WORKTREE_ROOT / worktree.root) is
+# Loom-managed too: its worktrees are serviced by the passes above, and must
+# NOT fall through to this stricter out-of-tree policy.
+override_wt_root="$(cd "$WORKTREE_ROOT_RESOLVED" 2>/dev/null && pwd -P || echo "$WORKTREE_ROOT_RESOLVED")"
 claude_wt_root="$(cd "$REPO_ROOT/.claude/worktrees" 2>/dev/null && pwd -P || echo "$REPO_ROOT/.claude/worktrees")"
 repo_root_real="$(cd "$REPO_ROOT" 2>/dev/null && pwd -P || echo "$REPO_ROOT")"
 
@@ -1172,6 +1213,7 @@ while IFS= read -r line; do
     # .loom/worktrees/ or .claude/worktrees/. Prefix-match on the real path.
     [[ "$oot_real" == "$loom_wt_root"/* ]] && continue
     [[ "$oot_real" == "$claude_wt_root"/* ]] && continue
+    [[ "$oot_real" == "$override_wt_root"/* ]] && continue
 
     # Log-and-skip if the directory is gone (a prune candidate, handled below).
     if [[ ! -d "$oot_real" ]]; then

--- a/scripts/deploy/batch-merge.sh
+++ b/scripts/deploy/batch-merge.sh
@@ -7,7 +7,12 @@ set -euo pipefail
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "$REPO_ROOT"
 
-TEMP_WORKTREE="$REPO_ROOT/.loom/worktrees/batch-rebase-$$"
+# Resolved worktree base (LOOM_WORKTREE_ROOT env var / .loom/config.json
+# worktree.root override; default $REPO_ROOT/.loom/worktrees).
+# shellcheck source=../lib/worktree-root.sh
+source "$REPO_ROOT/scripts/lib/worktree-root.sh"
+WORKTREES_BASE="$(loom_worktree_root "$REPO_ROOT")"
+TEMP_WORKTREE="$WORKTREES_BASE/batch-rebase-$$"
 MERGED=0
 FAILED=0
 SKIPPED=0
@@ -46,7 +51,7 @@ git fetch origin main --quiet
 
 # Create temp worktree for rebasing
 echo "Creating temporary worktree..."
-mkdir -p "$REPO_ROOT/.loom/worktrees"
+mkdir -p "$WORKTREES_BASE"
 git worktree add "$TEMP_WORKTREE" origin/main --detach 2>/dev/null
 
 COUNT=0

--- a/scripts/deploy/launch-agent.sh
+++ b/scripts/deploy/launch-agent.sh
@@ -42,7 +42,11 @@ find_repo_root() {
 }
 
 REPO_ROOT="$(find_repo_root)"
-WORKTREES_DIR="$REPO_ROOT/.loom/worktrees"
+# Resolved worktree base (LOOM_WORKTREE_ROOT env var / .loom/config.json
+# worktree.root override; default $REPO_ROOT/.loom/worktrees).
+# shellcheck source=../lib/worktree-root.sh
+source "$REPO_ROOT/scripts/lib/worktree-root.sh"
+WORKTREES_DIR="$(loom_worktree_root "$REPO_ROOT")"
 LOGS_DIR="$REPO_ROOT/.loom/logs"
 SIGNALS_DIR="$REPO_ROOT/.loom/signals"
 SESSION_NAME="deployer"

--- a/scripts/deploy/sync-and-deploy.sh
+++ b/scripts/deploy/sync-and-deploy.sh
@@ -68,6 +68,12 @@ find_repo_root() {
 }
 
 REPO_ROOT="$(find_repo_root)"
+
+# Resolved worktree base (LOOM_WORKTREE_ROOT env var / .loom/config.json
+# worktree.root override; default $REPO_ROOT/.loom/worktrees).
+# shellcheck source=../lib/worktree-root.sh
+source "$REPO_ROOT/scripts/lib/worktree-root.sh"
+WORKTREES_BASE="$(loom_worktree_root "$REPO_ROOT")"
 cd "$REPO_ROOT"
 
 # Pin gh to the correct repo — this repo has a mathlib-fork remote that gh
@@ -498,8 +504,9 @@ This branch has been deleted. If you believe this version carries unique content
         # If no worktree found, create a temporary one
         local temp_worktree=false
         if [[ -z "$worktree_path" ]]; then
-            worktree_path="$REPO_ROOT/.loom/worktrees/temp-rebase-$$"
+            worktree_path="$WORKTREES_BASE/temp-rebase-$$"
             print_info "Creating temporary worktree for rebase..."
+            mkdir -p "$WORKTREES_BASE"
             git fetch origin "$branch"
             git worktree add "$worktree_path" "origin/$branch" --detach 2>/dev/null || {
                 print_warning "Could not create worktree for #$pr"

--- a/scripts/enricher/parallel-enrich.sh
+++ b/scripts/enricher/parallel-enrich.sh
@@ -20,7 +20,11 @@ DEFAULT_AGENTS=2
 MAX_AGENTS=5
 SESSION_PREFIX="enricher"
 REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
-WORKTREES_DIR="$REPO_ROOT/.loom/worktrees"
+# Resolved worktree base (LOOM_WORKTREE_ROOT env var / .loom/config.json
+# worktree.root override; default $REPO_ROOT/.loom/worktrees).
+# shellcheck source=../lib/worktree-root.sh
+source "$REPO_ROOT/scripts/lib/worktree-root.sh"
+WORKTREES_DIR="$(loom_worktree_root "$REPO_ROOT")"
 ROLE_FILE="$REPO_ROOT/.lean/roles/enricher.md"
 LOGS_DIR="$REPO_ROOT/.loom/logs"
 SIGNALS_DIR="$REPO_ROOT/.loom/signals"
@@ -73,7 +77,7 @@ get_running_agents() {
 # Create worktree for an agent.
 #
 # Historically this keyed the worktree by agent slot number
-# (.loom/worktrees/enricher-N) and force-deleted any existing worktree at that
+# (enricher-N under the resolved worktree root) and force-deleted any existing worktree at that
 # path before recreating it. Because the path was slot-keyed, relaunching the
 # same slot always fought over one path, and the unconditional
 # `git worktree remove --force || rm -rf` silently destroyed an in-flight
@@ -451,7 +455,8 @@ PROMPT_EOF
     print_success "All agents launched in isolated worktrees!"
     echo ""
     echo "Each agent has:"
-    echo "  - Its own worktree in .loom/worktrees/enricher-N"
+    echo "  - Its own worktree: enricher-N under the resolved worktree root"
+    echo "    (default .loom/worktrees/; override via LOOM_WORKTREE_ROOT or .loom/config.json worktree.root)"
     echo "  - Its own branch: feature/enricher-N"
     echo "  - Creates PRs instead of committing to main"
     echo ""
@@ -576,7 +581,9 @@ Usage:
   $0 --help             Show this help
 
 How it works:
-  1. Each agent gets its own worktree: .loom/worktrees/enricher-N
+  1. Each agent gets its own worktree: enricher-N under the resolved
+     worktree root (default .loom/worktrees/; override via LOOM_WORKTREE_ROOT
+     env var or .loom/config.json worktree.root)
   2. Each agent works on its own branch: feature/enricher-N
   3. Agents claim targets atomically (no duplicates)
   4. Each agent: claim → enrich → commit → push → create PR → repeat

--- a/scripts/erdos/claim-stub.sh
+++ b/scripts/erdos/claim-stub.sh
@@ -43,6 +43,12 @@ STUBS_SCRIPT="$REPO_ROOT/scripts/erdos/find-stubs.ts"
 HAS_QUALITY_ISSUES="$REPO_ROOT/scripts/erdos/has-quality-issues.sh"
 COMPLETIONS_DIR="$REPO_ROOT/.loom/signals/completions"
 
+# Resolved worktree base (LOOM_WORKTREE_ROOT env var / .loom/config.json
+# worktree.root override; default $REPO_ROOT/.loom/worktrees).
+# shellcheck source=../lib/worktree-root.sh
+source "$REPO_ROOT/scripts/lib/worktree-root.sh"
+WORKTREES_DIR="$(loom_worktree_root "$REPO_ROOT")"
+
 # Defaults
 TTL_MINUTES="${CLAIM_TTL:-60}"
 AGENT_ID="${ENHANCER_ID:-enhancer-$$}"
@@ -122,7 +128,7 @@ claim_stub() {
     local erdos_number="$1"
     local lock_dir="$CLAIMS_DIR/erdos-$erdos_number.lock"
     local claim_file="$CLAIMS_DIR/erdos-$erdos_number.json"
-    local worktree_path="$REPO_ROOT/.loom/worktrees/erdos-$erdos_number"
+    local worktree_path="$WORKTREES_DIR/erdos-$erdos_number"
     local branch_name="feature/erdos-$erdos_number-enhance"
 
     # Check if already completed
@@ -197,7 +203,7 @@ EOF
 # Setup problem-specific worktree (creates new or reuses existing with partial work)
 setup_problem_worktree() {
     local erdos_number="$1"
-    local worktree_path="$REPO_ROOT/.loom/worktrees/erdos-$erdos_number"
+    local worktree_path="$WORKTREES_DIR/erdos-$erdos_number"
     local branch_name="feature/erdos-$erdos_number-enhance"
 
     # Check if worktree already exists (has partial work from previous agent)
@@ -209,6 +215,10 @@ setup_problem_worktree() {
         (cd "$worktree_path" && git fetch origin main 2>/dev/null) || true
         return 0
     fi
+
+    # Ensure the resolved worktree base exists before `git worktree add`
+    # (the resolver never creates directories).
+    mkdir -p "$WORKTREES_DIR"
 
     # Check if branch exists on remote (previous work pushed)
     if git ls-remote --heads origin "$branch_name" 2>/dev/null | grep -q "$branch_name"; then

--- a/scripts/erdos/clean-enhancers.sh
+++ b/scripts/erdos/clean-enhancers.sh
@@ -64,7 +64,17 @@ find_repo_root() {
 
 REPO_ROOT="$(find_repo_root)"
 CLAIMS_DIR="$REPO_ROOT/.lean/state/stub-claims"
-WORKTREES_DIR="$REPO_ROOT/.loom/worktrees"
+# Resolved worktree base (LOOM_WORKTREE_ROOT env var / .loom/config.json
+# worktree.root override; default $REPO_ROOT/.loom/worktrees).
+# shellcheck source=../lib/worktree-root.sh
+source "$REPO_ROOT/scripts/lib/worktree-root.sh"
+WORKTREES_DIR="$(loom_worktree_root "$REPO_ROOT")"
+# During an override transition, worktrees may exist at BOTH the resolved root
+# and the legacy default — scan both (issue #37509).
+WORKTREE_SCAN_ROOTS=("$WORKTREES_DIR")
+if [[ "$WORKTREES_DIR" != "$REPO_ROOT/.loom/worktrees" ]]; then
+    WORKTREE_SCAN_ROOTS+=("$REPO_ROOT/.loom/worktrees")
+fi
 SIGNALS_DIR="$REPO_ROOT/.loom/signals"
 LOGS_DIR="$REPO_ROOT/.loom/logs"
 
@@ -244,9 +254,10 @@ if [[ "$DEEP_CLEAN" == true ]]; then
 
     worktree_count=0
 
-    if [[ -d "$WORKTREES_DIR" ]]; then
+    for wt_scan_root in "${WORKTREE_SCAN_ROOTS[@]}"; do
+    if [[ -d "$wt_scan_root" ]]; then
         # Clean erdos-{N} worktrees for merged/closed PRs
-        for worktree_dir in "$WORKTREES_DIR"/erdos-*; do
+        for worktree_dir in "$wt_scan_root"/erdos-*; do
             [[ ! -d "$worktree_dir" ]] && continue
 
             erdos_num=$(basename "$worktree_dir" | sed 's/erdos-//')
@@ -296,7 +307,7 @@ if [[ "$DEEP_CLEAN" == true ]]; then
         done
 
         # Clean enhancer-{N} worktrees
-        for worktree_dir in "$WORKTREES_DIR"/enhancer-*; do
+        for worktree_dir in "$wt_scan_root"/enhancer-*; do
             [[ ! -d "$worktree_dir" ]] && continue
 
             enhancer_num=$(basename "$worktree_dir" | sed 's/enhancer-//')
@@ -337,6 +348,7 @@ if [[ "$DEEP_CLEAN" == true ]]; then
             fi
         done
     fi
+    done
 
     if [[ $worktree_count -eq 0 ]]; then
         success "No stale worktrees found"
@@ -403,9 +415,11 @@ if [[ "$DEEP_CLEAN" == true ]]; then
 
             # Check if any worktree uses this branch
             worktree_exists=false
-            if [[ -d "$WORKTREES_DIR/enhancer-$enhancer_num" ]]; then
-                worktree_exists=true
-            fi
+            for wt_scan_root in "${WORKTREE_SCAN_ROOTS[@]}"; do
+                if [[ -d "$wt_scan_root/enhancer-$enhancer_num" ]]; then
+                    worktree_exists=true
+                fi
+            done
 
             if [[ "$worktree_exists" == false ]]; then
                 ((++branch_count))

--- a/scripts/erdos/parallel-enhance.sh
+++ b/scripts/erdos/parallel-enhance.sh
@@ -20,7 +20,11 @@ DEFAULT_AGENTS=3
 MAX_AGENTS=8
 SESSION_PREFIX="erdos-enhancer"
 REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
-WORKTREES_DIR="$REPO_ROOT/.loom/worktrees"
+# Resolved worktree base (LOOM_WORKTREE_ROOT env var / .loom/config.json
+# worktree.root override; default $REPO_ROOT/.loom/worktrees).
+# shellcheck source=../lib/worktree-root.sh
+source "$REPO_ROOT/scripts/lib/worktree-root.sh"
+WORKTREES_DIR="$(loom_worktree_root "$REPO_ROOT")"
 ROLE_FILE="$REPO_ROOT/.lean/roles/erdos-enhancer.md"
 LOGS_DIR="$REPO_ROOT/.loom/logs"
 SIGNALS_DIR="$REPO_ROOT/.loom/signals"
@@ -77,7 +81,7 @@ get_running_agents() {
 # Create worktree for an agent.
 #
 # Historically this force-deleted any existing worktree at the slot-keyed path
-# (.loom/worktrees/enhancer-N) with `git worktree remove --force || rm -rf`,
+# (enhancer-N under the resolved worktree root) with `git worktree remove --force || rm -rf`,
 # silently destroying an in-flight agent's uncommitted work (#35223 / #35255).
 #
 # This version:
@@ -483,7 +487,8 @@ PROMPT_EOF
     print_success "All agents launched in isolated worktrees!"
     echo ""
     echo "Each agent has:"
-    echo "  - Its own worktree in .loom/worktrees/enhancer-N"
+    echo "  - Its own worktree: enhancer-N under the resolved worktree root"
+    echo "    (default .loom/worktrees/; override via LOOM_WORKTREE_ROOT or .loom/config.json worktree.root)"
     echo "  - Its own branch: feature/enhancer-N"
     echo "  - Creates PRs instead of committing to main"
     echo ""
@@ -545,7 +550,9 @@ Usage:
   $0 --help             Show this help
 
 How it works:
-  1. Each agent gets its own worktree: .loom/worktrees/enhancer-N
+  1. Each agent gets its own worktree: enhancer-N under the resolved
+     worktree root (default .loom/worktrees/; override via LOOM_WORKTREE_ROOT
+     env var or .loom/config.json worktree.root)
   2. Each agent works on its own branch: feature/enhancer-N
   3. Agents claim stubs atomically (no duplicates)
   4. Each agent: claim → enhance → commit → push → create PR → repeat

--- a/scripts/lean/infra-guardian.sh
+++ b/scripts/lean/infra-guardian.sh
@@ -39,6 +39,14 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 cd "$REPO_ROOT"
 
+# Resolved worktree base (LOOM_WORKTREE_ROOT env var / .loom/config.json
+# worktree.root override; default $REPO_ROOT/.loom/worktrees). The reaper's
+# allow-pattern must match worktrees at the override root, or leaked worktrees
+# there would never be reaped (issue #37509).
+# shellcheck source=../lib/worktree-root.sh
+source "$SCRIPT_DIR/../lib/worktree-root.sh"
+WORKTREE_ROOT_RESOLVED="$(loom_worktree_root "$REPO_ROOT")"
+
 LOG="research/infra-guardian.log"          # gitignored; persists across restarts
 STOP_SIGNAL_FILE=".loom/signals/stop-lean-daemon"
 
@@ -120,7 +128,7 @@ reap_worktrees() {
     while IFS=$'\t' read -r wt ref; do
         [[ -z "$wt" ]] && continue
         case "$wt" in
-            *"/.loom/worktrees/"*|*"/.claude/worktrees/"*|/private/tmp/*) ;;
+            *"/.loom/worktrees/"*|*"/.claude/worktrees/"*|/private/tmp/*|"$WORKTREE_ROOT_RESOLVED/"*) ;;
             *) continue ;;
         esac
         grep -qxF "$wt" <<<"$locked" && continue

--- a/scripts/lean/launch.sh
+++ b/scripts/lean/launch.sh
@@ -24,6 +24,12 @@ _LAUNCH_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=../lib/worktree-cleanup.sh
 source "$_LAUNCH_SCRIPT_DIR/../lib/worktree-cleanup.sh"
 
+# Worktree-root resolver (LOOM_WORKTREE_ROOT env var / .loom/config.json
+# worktree.root override; default $repo_root/.loom/worktrees). Respawned agent
+# worktrees must land at the same resolved base the role launchers use.
+# shellcheck source=../lib/worktree-root.sh
+source "$_LAUNCH_SCRIPT_DIR/../lib/worktree-root.sh"
+
 # Colors
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -1533,15 +1539,20 @@ _do_respawn_agent() {
             # Spawn a specific enricher slot directly (parallel-enrich.sh refuses
             # to start if any enricher is already running, so we inline the logic)
             local agent_num="${session##*-}"
-            local base_dir=".loom/worktrees/enricher-$agent_num"
+            local repo_root
+            repo_root=$(pwd)
+            # Resolved worktree base (LOOM_WORKTREE_ROOT / worktree.root
+            # override; default $repo_root/.loom/worktrees).
+            local wt_base
+            wt_base="$(loom_worktree_root "$repo_root")"
+            mkdir -p "$wt_base"
+            local base_dir="$wt_base/enricher-$agent_num"
             local base_branch="feature/enricher-$agent_num"
             local worktree_dir="$base_dir"
             local branch="$base_branch"
             local enricher_id="enricher-$agent_num"
             local log_file=".loom/logs/$session.log"
             local prompt_file=".loom/logs/$session-prompt.md"
-            local repo_root
-            repo_root=$(pwd)
 
             # Reclaim any existing worktree at the primary path using the shared
             # safety guards instead of an unconditional force-delete.
@@ -1583,7 +1594,7 @@ _do_respawn_agent() {
             fi
 
             # Create tmux session and launch Claude
-            tmux new-session -d -s "$session" -c "$repo_root/$worktree_dir"
+            tmux new-session -d -s "$session" -c "$worktree_dir"
             sleep 0.3
             tmux send-keys -t "$session" "export ENRICHER_ID='$enricher_id'" Enter
             sleep 0.2
@@ -1612,14 +1623,19 @@ _do_respawn_agent() {
         researcher)
             # Respawn the specific researcher slot (mirrors enricher respawn pattern)
             local agent_num="${session##*-}"
-            local base_dir=".loom/worktrees/researcher-$agent_num"
+            local repo_root
+            repo_root=$(pwd)
+            # Resolved worktree base (LOOM_WORKTREE_ROOT / worktree.root
+            # override; default $repo_root/.loom/worktrees).
+            local wt_base
+            wt_base="$(loom_worktree_root "$repo_root")"
+            mkdir -p "$wt_base"
+            local base_dir="$wt_base/researcher-$agent_num"
             local base_branch="feature/researcher-$agent_num"
             local worktree_dir="$base_dir"
             local branch="$base_branch"
             local log_file=".loom/logs/$session.log"
             local prompt_file=".loom/logs/$session-prompt.md"
-            local repo_root
-            repo_root=$(pwd)
 
             # Reclaim any existing worktree at the primary path using the shared
             # safety guards instead of an unconditional force-delete.
@@ -1667,7 +1683,7 @@ _do_respawn_agent() {
             fi
 
             # Create tmux session and launch Claude
-            tmux new-session -d -s "$session" -c "$repo_root/$worktree_dir"
+            tmux new-session -d -s "$session" -c "$worktree_dir"
             sleep 0.3
             tmux send-keys -t "$session" "export ENHANCER_ID='researcher-$agent_num'" Enter
             sleep 0.2

--- a/scripts/lib/worktree-cleanup.sh
+++ b/scripts/lib/worktree-cleanup.sh
@@ -10,9 +10,16 @@
 #
 # On the janitor side, those guards 1-5 (plus the reclaim-eligibility triggers)
 # live in a single `reclaim_worktree` function shared by both the
-# `.loom/worktrees/*` scratch pass and the pass that reclaims git-registered
-# worktrees located OUTSIDE `.loom/worktrees/` (issue #35257); this helper stays
-# in lock-step with those guards.
+# `.loom/worktrees/*` scratch pass (which also scans the resolved worktree
+# root when a LOOM_WORKTREE_ROOT / worktree.root override is set — see
+# scripts/lib/worktree-root.sh, issue #37509) and the pass that reclaims
+# git-registered worktrees located OUTSIDE the sanctioned worktree roots
+# (issue #35257); this helper stays in lock-step with those guards.
+#
+# All guards below operate on the ABSOLUTE worktree path passed by the caller
+# and make no assumption about where that path lives — they work identically
+# for worktrees under the default `.loom/worktrees/` and under an overridden
+# external root (e.g. /Volumes/Stripe/<repo>/).
 #
 # Guards (a worktree is removed ONLY when ALL hold):
 #   1. Not the current checkout (real-path normalized compare).

--- a/scripts/lib/worktree-root.sh
+++ b/scripts/lib/worktree-root.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# worktree-root.sh — Resolve the base directory that holds agent worktrees.
+#
+# Lean-fleet port of Loom's resolver. Keep this file in LOCK-STEP with the
+# upstream helper (rjwalters/loom `defaults/scripts/lib/worktree-root.sh`,
+# v0.10.6, issue #3530 / PR #3538): same function name, same precedence, same
+# env var and config key, so one knob moves both Loom-managed (issue-N / pr-N)
+# and lean-fleet (enricher-N, researcher-N, erdos-N, …) worktrees.
+#
+# Source this file (do not exec). Defines a single function:
+#
+#   loom_worktree_root <repo_root> -> echoes the absolute worktree base dir
+#
+# Resolution precedence (first match wins), all opt-in:
+#
+#   1. LOOM_WORKTREE_ROOT env var          — highest priority
+#   2. .loom/config.json → worktree.root   — jq-guarded, same namespace as
+#                                            worktree.linkPaths (#3534)
+#   3. ${repo_root}/.loom/worktrees        — default, UNCHANGED behavior
+#
+# When an override (env var or config key) is set, the returned path is
+# namespaced by repo basename so multiple workspaces can share one external
+# volume without colliding:
+#
+#     ${override%/}/<repo-basename>
+#
+# Callers then append their leaf names (`enricher-1`, `erdos-42`, …) as
+# before. With neither override set, the function returns
+# `${repo_root}/.loom/worktrees` verbatim — the result is byte-for-byte
+# identical to the historical hardcoded path, so default installations see
+# zero behavior change.
+#
+# Design notes:
+#   - The env-var branch imitates other Loom env overrides (e.g.
+#     LOOM_WORKTREE_ALWAYS_INCLUDE) and always wins over config.
+#   - The config read reuses the exact guard pattern worktree.sh uses for
+#     worktree.linkPaths: only attempt jq when it exists AND the config file
+#     is present, and fall through softly (missing jq / missing key / malformed
+#     JSON → default) so a broken config never breaks worktree creation.
+#   - A RELATIVE override is rejected with a stderr warning and the function
+#     falls back to the default. An external worktree root must be absolute so
+#     that cleanup/GC comparison sites (which resolve absolute paths) match.
+#   - Repo namespacing uses `basename "$repo_root"`. Two repos whose basenames
+#     collide under the same override root would share a namespace; that is a
+#     documented v1 limitation (see the issue), not a bug this helper guards.
+#   - This helper never creates directories; callers `mkdir -p` the parent as
+#     needed (git worktree add creates only the leaf).
+
+# loom_worktree_root <repo_root>
+#
+# Echoes the absolute worktree base directory. `repo_root` must be an absolute
+# path to the main workspace (the parent of the git common dir).
+loom_worktree_root() {
+    local repo_root="$1"
+
+    # 1. Env var override — highest priority.
+    if [[ -n "${LOOM_WORKTREE_ROOT:-}" ]]; then
+        if [[ "$LOOM_WORKTREE_ROOT" == /* ]]; then
+            echo "${LOOM_WORKTREE_ROOT%/}/$(basename "$repo_root")"
+            return 0
+        fi
+        echo "loom_worktree_root: LOOM_WORKTREE_ROOT must be an absolute path (got: '$LOOM_WORKTREE_ROOT'); falling back to default" >&2
+        echo "$repo_root/.loom/worktrees"
+        return 0
+    fi
+
+    # 2. Config key override — .loom/config.json → worktree.root.
+    #    Same jq guard pattern as worktree.linkPaths (worktree.sh).
+    local config_file="$repo_root/.loom/config.json"
+    if command -v jq >/dev/null 2>&1 && [[ -f "$config_file" ]]; then
+        local cfg_root
+        cfg_root=$(jq -r '.worktree.root? // empty' "$config_file" 2>/dev/null)
+        if [[ -n "$cfg_root" ]]; then
+            if [[ "$cfg_root" == /* ]]; then
+                echo "${cfg_root%/}/$(basename "$repo_root")"
+                return 0
+            fi
+            echo "loom_worktree_root: worktree.root in .loom/config.json must be an absolute path (got: '$cfg_root'); falling back to default" >&2
+            echo "$repo_root/.loom/worktrees"
+            return 0
+        fi
+    fi
+
+    # 3. Default — unchanged historical behavior.
+    echo "$repo_root/.loom/worktrees"
+}

--- a/scripts/mechanic/launch-agent.sh
+++ b/scripts/mechanic/launch-agent.sh
@@ -42,7 +42,11 @@ find_repo_root() {
 }
 
 REPO_ROOT="$(find_repo_root)"
-WORKTREES_DIR="$REPO_ROOT/.loom/worktrees"
+# Resolved worktree base (LOOM_WORKTREE_ROOT env var / .loom/config.json
+# worktree.root override; default $REPO_ROOT/.loom/worktrees).
+# shellcheck source=../lib/worktree-root.sh
+source "$REPO_ROOT/scripts/lib/worktree-root.sh"
+WORKTREES_DIR="$(loom_worktree_root "$REPO_ROOT")"
 LOGS_DIR="$REPO_ROOT/.loom/logs"
 SIGNALS_DIR="$REPO_ROOT/.loom/signals"
 SESSION_NAME="${SESSION_NAME:-mechanic-agent}"

--- a/scripts/peer-reviewer/launch-agent.sh
+++ b/scripts/peer-reviewer/launch-agent.sh
@@ -30,7 +30,11 @@ find_repo_root() {
 }
 
 REPO_ROOT="$(find_repo_root)"
-WORKTREES_DIR="$REPO_ROOT/.loom/worktrees"
+# Resolved worktree base (LOOM_WORKTREE_ROOT env var / .loom/config.json
+# worktree.root override; default $REPO_ROOT/.loom/worktrees).
+# shellcheck source=../lib/worktree-root.sh
+source "$REPO_ROOT/scripts/lib/worktree-root.sh"
+WORKTREES_DIR="$(loom_worktree_root "$REPO_ROOT")"
 LOGS_DIR="$REPO_ROOT/.loom/logs"
 SIGNALS_DIR="$REPO_ROOT/.loom/signals"
 

--- a/scripts/research/clean-research.sh
+++ b/scripts/research/clean-research.sh
@@ -64,7 +64,17 @@ find_repo_root() {
 
 REPO_ROOT="$(find_repo_root)"
 CLAIMS_DIR="$REPO_ROOT/research/claims"
-WORKTREES_DIR="$REPO_ROOT/.loom/worktrees"
+# Resolved worktree base (LOOM_WORKTREE_ROOT env var / .loom/config.json
+# worktree.root override; default $REPO_ROOT/.loom/worktrees).
+# shellcheck source=../lib/worktree-root.sh
+source "$REPO_ROOT/scripts/lib/worktree-root.sh"
+WORKTREES_DIR="$(loom_worktree_root "$REPO_ROOT")"
+# During an override transition, worktrees may exist at BOTH the resolved root
+# and the legacy default — scan both (issue #37509).
+WORKTREE_SCAN_ROOTS=("$WORKTREES_DIR")
+if [[ "$WORKTREES_DIR" != "$REPO_ROOT/.loom/worktrees" ]]; then
+    WORKTREE_SCAN_ROOTS+=("$REPO_ROOT/.loom/worktrees")
+fi
 SIGNALS_DIR="$REPO_ROOT/.loom/signals"
 LOGS_DIR="$REPO_ROOT/.loom/logs"
 
@@ -250,7 +260,8 @@ if [[ "$DEEP_CLEAN" == true ]]; then
 
     worktree_count=0
 
-    if [[ -d "$WORKTREES_DIR" ]]; then
+    for wt_scan_root in "${WORKTREE_SCAN_ROOTS[@]}"; do
+    if [[ -d "$wt_scan_root" ]]; then
         # Clean researcher-{N} worktrees.
         #
         # The removal decision is gated by the structural guards 1-5 in
@@ -262,7 +273,7 @@ if [[ "$DEEP_CLEAN" == true ]]; then
         # (dirty tree, unpushed commits, live process, locked, current checkout)
         # are a superset of anything claim correctness could tell us. The claim
         # scan below is retained for diagnostic messaging ONLY.
-        for worktree_dir in "$WORKTREES_DIR"/researcher-*; do
+        for worktree_dir in "$wt_scan_root"/researcher-*; do
             [[ ! -d "$worktree_dir" ]] && continue
 
             researcher_id=$(basename "$worktree_dir")
@@ -318,6 +329,7 @@ if [[ "$DEEP_CLEAN" == true ]]; then
             fi
         done
     fi
+    done
 
     if [[ $worktree_count -eq 0 ]]; then
         success "No stale researcher worktrees found"
@@ -347,9 +359,11 @@ if [[ "$DEEP_CLEAN" == true ]]; then
 
             # Check if any worktree uses this branch
             worktree_exists=false
-            if [[ -d "$WORKTREES_DIR/researcher-$researcher_num" ]]; then
-                worktree_exists=true
-            fi
+            for wt_scan_root in "${WORKTREE_SCAN_ROOTS[@]}"; do
+                if [[ -d "$wt_scan_root/researcher-$researcher_num" ]]; then
+                    worktree_exists=true
+                fi
+            done
 
             if [[ "$worktree_exists" == false ]]; then
                 ((++branch_count))

--- a/scripts/research/launch-seeker.sh
+++ b/scripts/research/launch-seeker.sh
@@ -36,7 +36,11 @@ find_repo_root() {
 }
 
 REPO_ROOT="$(find_repo_root)"
-WORKTREES_DIR="$REPO_ROOT/.loom/worktrees"
+# Resolved worktree base (LOOM_WORKTREE_ROOT env var / .loom/config.json
+# worktree.root override; default $REPO_ROOT/.loom/worktrees).
+# shellcheck source=../lib/worktree-root.sh
+source "$REPO_ROOT/scripts/lib/worktree-root.sh"
+WORKTREES_DIR="$(loom_worktree_root "$REPO_ROOT")"
 LOGS_DIR="$REPO_ROOT/.loom/logs"
 SIGNALS_DIR="$REPO_ROOT/.loom/signals"
 SESSION_NAME="seeker-agent"

--- a/scripts/research/parallel-research.sh
+++ b/scripts/research/parallel-research.sh
@@ -30,7 +30,11 @@ find_repo_root() {
 }
 
 REPO_ROOT="$(find_repo_root)"
-WORKTREES_DIR="$REPO_ROOT/.loom/worktrees"
+# Resolved worktree base (LOOM_WORKTREE_ROOT env var / .loom/config.json
+# worktree.root override; default $REPO_ROOT/.loom/worktrees).
+# shellcheck source=../lib/worktree-root.sh
+source "$REPO_ROOT/scripts/lib/worktree-root.sh"
+WORKTREES_DIR="$(loom_worktree_root "$REPO_ROOT")"
 LOGS_DIR="$REPO_ROOT/.loom/logs"
 SIGNALS_DIR="$REPO_ROOT/.loom/signals"
 CLAIM_SCRIPT="$REPO_ROOT/scripts/research/claim-problem.sh"
@@ -375,7 +379,8 @@ launch_agents() {
     print_success "All agents launched in isolated worktrees!"
     echo ""
     echo "Each agent has:"
-    echo "  - Its own worktree in .loom/worktrees/researcher-N"
+    echo "  - Its own worktree: researcher-N under the resolved worktree root"
+    echo "    (default .loom/worktrees/; override via LOOM_WORKTREE_ROOT or .loom/config.json worktree.root)"
     echo "  - Its own branch: feature/researcher-N"
     echo "  - Creates PRs for research progress"
     echo "  - Waits $wait_interval min when no work available (loops, doesn't exit)"
@@ -601,7 +606,9 @@ Environment Variables:
   RESEARCHER_WAIT_INTERVAL  Minutes to wait when no work available (default: 15)
 
 How it works:
-  1. Each agent gets its own worktree: .loom/worktrees/researcher-N
+  1. Each agent gets its own worktree: researcher-N under the resolved
+     worktree root (default .loom/worktrees/; override via LOOM_WORKTREE_ROOT
+     env var or .loom/config.json worktree.root)
   2. Each agent works on its own branch: feature/researcher-N
   3. Agents claim problems atomically (knowledge-prioritized)
   4. Each agent: claim → research → commit → push → create PR → repeat

--- a/scripts/tests/worktree-root.test.sh
+++ b/scripts/tests/worktree-root.test.sh
@@ -1,0 +1,164 @@
+#!/bin/bash
+# Unit tests for scripts/lib/worktree-root.sh (issue #37509), mirroring
+# Loom's defaults/scripts/tests/test-worktree-root-override.sh.
+#
+# Section 1 exercises the resolver (loom_worktree_root) directly:
+#   - default (no override)              => $repo_root/.loom/worktrees
+#   - LOOM_WORKTREE_ROOT absolute        => ${env%/}/$(basename repo_root)
+#   - LOOM_WORKTREE_ROOT trailing slash  => stripped
+#   - LOOM_WORKTREE_ROOT relative        => stderr warning + default fallback
+#   - config worktree.root absolute      => ${cfg%/}/$(basename repo_root)
+#   - config worktree.root relative      => stderr warning + default fallback
+#   - env var beats config
+#   - malformed config JSON              => soft-fail to default
+#   - config without worktree.root key   => default
+#
+# Section 2 replicates the janitor/guardian override classification:
+#   - clean-branches.sh WORKTREE_SCAN_ROOTS dual-scan (default + override,
+#     deduped when equal)
+#   - clean-branches.sh outside-pass prefix classification (an override-root
+#     worktree is INSIDE / Loom-managed, not out-of-tree)
+#   - infra-guardian.sh reaper allow-pattern matches override-root worktrees
+#
+# Everything is tmpdir-based; no network, no writes outside mktemp dirs.
+# Run: bash scripts/tests/worktree-root.test.sh
+# Exits non-zero if any assertion fails.
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib/worktree-root.sh
+source "$SCRIPT_DIR/../lib/worktree-root.sh"
+
+PASS=0; FAIL=0
+assert_eq() { # <desc> <expected> <actual>
+    if [[ "$3" == "$2" ]]; then echo "  ok: $1 -> $3"; ((PASS++)); else echo "  FAIL: $1 expected '$2' got '$3'"; ((FAIL++)); fi
+}
+assert_contains() { # <desc> <needle> <haystack>
+    if [[ "$3" == *"$2"* ]]; then echo "  ok: $1"; ((PASS++)); else echo "  FAIL: $1 ('$3' does not contain '$2')"; ((FAIL++)); fi
+}
+
+ROOT=$(mktemp -d)
+trap 'rm -rf "$ROOT"' EXIT
+REPO="$ROOT/lean-genius"
+mkdir -p "$REPO/.loom"
+
+echo "--- Section 1: resolver semantics ---"
+
+# Default: no env, no config file.
+unset LOOM_WORKTREE_ROOT 2>/dev/null || true
+assert_eq "default (no override)" "$REPO/.loom/worktrees" "$(loom_worktree_root "$REPO")"
+
+# Env var, absolute.
+assert_eq "env absolute" "$ROOT/stripe/lean-genius" \
+    "$(LOOM_WORKTREE_ROOT="$ROOT/stripe" loom_worktree_root "$REPO")"
+
+# Env var, trailing slash stripped.
+assert_eq "env trailing slash" "$ROOT/stripe/lean-genius" \
+    "$(LOOM_WORKTREE_ROOT="$ROOT/stripe/" loom_worktree_root "$REPO")"
+
+# Env var, relative -> warn + fall back to default.
+out="$(LOOM_WORKTREE_ROOT="relative/path" loom_worktree_root "$REPO" 2>/dev/null)"
+err="$(LOOM_WORKTREE_ROOT="relative/path" loom_worktree_root "$REPO" 2>&1 >/dev/null)"
+assert_eq "env relative falls back" "$REPO/.loom/worktrees" "$out"
+assert_contains "env relative warns on stderr" "must be an absolute path" "$err"
+
+# Config key, absolute.
+printf '{"worktree": {"root": "%s"}}\n' "$ROOT/stripe" > "$REPO/.loom/config.json"
+assert_eq "config absolute" "$ROOT/stripe/lean-genius" "$(loom_worktree_root "$REPO")"
+
+# Config key, trailing slash stripped.
+printf '{"worktree": {"root": "%s/"}}\n' "$ROOT/stripe" > "$REPO/.loom/config.json"
+assert_eq "config trailing slash" "$ROOT/stripe/lean-genius" "$(loom_worktree_root "$REPO")"
+
+# Env var beats config.
+printf '{"worktree": {"root": "%s"}}\n' "$ROOT/config-root" > "$REPO/.loom/config.json"
+assert_eq "env beats config" "$ROOT/env-root/lean-genius" \
+    "$(LOOM_WORKTREE_ROOT="$ROOT/env-root" loom_worktree_root "$REPO")"
+
+# Config key, relative -> warn + fall back.
+printf '{"worktree": {"root": "not/absolute"}}\n' > "$REPO/.loom/config.json"
+out="$(loom_worktree_root "$REPO" 2>/dev/null)"
+err="$(loom_worktree_root "$REPO" 2>&1 >/dev/null)"
+assert_eq "config relative falls back" "$REPO/.loom/worktrees" "$out"
+assert_contains "config relative warns on stderr" "must be an absolute path" "$err"
+
+# Malformed JSON -> soft-fail to default.
+printf 'this is not json{{{\n' > "$REPO/.loom/config.json"
+assert_eq "malformed config soft-fails" "$REPO/.loom/worktrees" "$(loom_worktree_root "$REPO" 2>/dev/null)"
+
+# Config present but key absent -> default.
+printf '{"other": true}\n' > "$REPO/.loom/config.json"
+assert_eq "config without key" "$REPO/.loom/worktrees" "$(loom_worktree_root "$REPO")"
+
+# Config value null -> default (jq '// empty' guard).
+printf '{"worktree": {"root": null}}\n' > "$REPO/.loom/config.json"
+assert_eq "config null value" "$REPO/.loom/worktrees" "$(loom_worktree_root "$REPO")"
+
+echo ""
+echo "--- Section 2: janitor / guardian override classification ---"
+
+# Mirror of scripts/clean-branches.sh scan-roots computation: both the legacy
+# default dir and the resolved override root are serviced; dedupe when equal.
+compute_scan_roots() { # <repo_root> -> newline-separated scan roots
+    local repo_root="$1" resolved
+    resolved="$(loom_worktree_root "$repo_root")"
+    local roots=("$repo_root/.loom/worktrees")
+    if [[ "$resolved" != "$repo_root/.loom/worktrees" ]]; then
+        roots+=("$resolved")
+    fi
+    printf '%s\n' "${roots[@]}"
+}
+
+printf '{"worktree": {"root": "%s"}}\n' "$ROOT/stripe" > "$REPO/.loom/config.json"
+scan="$(compute_scan_roots "$REPO")"
+assert_contains "dual-scan includes default root" "$REPO/.loom/worktrees" "$scan"
+assert_contains "dual-scan includes override root" "$ROOT/stripe/lean-genius" "$scan"
+assert_eq "dual-scan has 2 roots when overridden" "2" "$(echo "$scan" | wc -l | tr -d ' ')"
+
+rm -f "$REPO/.loom/config.json"
+scan="$(compute_scan_roots "$REPO")"
+assert_eq "dual-scan dedupes without override" "1" "$(echo "$scan" | wc -l | tr -d ' ')"
+
+# Mirror of the clean-branches.sh outside-pass: worktrees under the resolved
+# override root must classify as INSIDE (Loom-managed), never out-of-tree.
+classify_outside() { # <repo_root> <wt_path> -> INSIDE|OUTSIDE
+    local repo_root="$1" wt="$2"
+    local loom_wt_root="$repo_root/.loom/worktrees"
+    local claude_wt_root="$repo_root/.claude/worktrees"
+    local override_wt_root
+    override_wt_root="$(loom_worktree_root "$repo_root")"
+    if [[ "$wt" == "$loom_wt_root"/* || "$wt" == "$claude_wt_root"/* || "$wt" == "$override_wt_root"/* ]]; then
+        echo INSIDE
+    else
+        echo OUTSIDE
+    fi
+}
+
+printf '{"worktree": {"root": "%s"}}\n' "$ROOT/stripe" > "$REPO/.loom/config.json"
+assert_eq "outside-pass: override worktree is INSIDE" "INSIDE" \
+    "$(classify_outside "$REPO" "$ROOT/stripe/lean-genius/enricher-1")"
+assert_eq "outside-pass: default worktree is INSIDE" "INSIDE" \
+    "$(classify_outside "$REPO" "$REPO/.loom/worktrees/researcher-2")"
+assert_eq "outside-pass: unrelated path is OUTSIDE" "OUTSIDE" \
+    "$(classify_outside "$REPO" "$ROOT/elsewhere/scratch")"
+
+# Mirror of scripts/lean/infra-guardian.sh reaper allow-pattern.
+guardian_allows() { # <resolved_root> <wt_path> -> YES|NO
+    local WORKTREE_ROOT_RESOLVED="$1" wt="$2"
+    case "$wt" in
+        *"/.loom/worktrees/"*|*"/.claude/worktrees/"*|/private/tmp/*|"$WORKTREE_ROOT_RESOLVED/"*) echo YES ;;
+        *) echo NO ;;
+    esac
+}
+
+resolved="$(loom_worktree_root "$REPO")"
+assert_eq "guardian: override-root worktree reapable" "YES" \
+    "$(guardian_allows "$resolved" "$ROOT/stripe/lean-genius/erdos-42")"
+assert_eq "guardian: default-root worktree reapable" "YES" \
+    "$(guardian_allows "$resolved" "$REPO/.loom/worktrees/auditor-1")"
+assert_eq "guardian: foreign path not reapable" "NO" \
+    "$(guardian_allows "$resolved" "$HOME/some/other/dir")"
+
+echo ""
+echo "PASS=$PASS FAIL=$FAIL"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
Closes #37509

## Summary

Ports Loom v0.10.6's worktree-root resolver into the lean fleet's own scripts. Every fleet worktree construction site (enricher, researcher, erdos, aristotle, auditor, deploy, mechanic, peer-reviewer, seeker, deploy temp/batch-rebase worktrees, `launch.sh` respawn paths) now resolves its base via `scripts/lib/worktree-root.sh`:

1. `LOOM_WORKTREE_ROOT` env var (absolute; relative → stderr warning + default)
2. `.loom/config.json` → `worktree.root` (jq-guarded; malformed/missing → soft-fail to default)
3. default `$REPO_ROOT/.loom/worktrees` — byte-for-byte unchanged when no override is set

Overrides are namespaced by repo basename, so `worktree.root = "/Volumes/Stripe"` resolves to `/Volumes/Stripe/lean-genius/<name>` on the dedicated 3.6 TiB volume. Cleanup/GC surfaces (`clean-branches.sh` dual-root scan + outside-pass classification, `clean-research.sh`, `clean-enhancers.sh`, `infra-guardian.sh` reaper allow-pattern) service BOTH the resolved root and the legacy default during the transition.

## Provenance: salvaged from a stranded builder worktree

This is a **resume** of the original #37509 builder, which died 2026-07-11 leaving ~20 files of uncommitted work in `/Volumes/Stripe/lean-genius/issue-37509` (branch `feature/issue-37509`). Its base files were mass-deleted from main hours later (dc9fdffa30) and restored byte-identical in #38423, so the stranded diff was salvaged (`git diff` → patch) and applied with `git apply --3way` onto a fresh branch off current main — cleanly, no conflicts.

**Salvaged (dead builder's work, ~440 lines):** resolver lib, all construction-site wiring, all cleanup/GC wiring, `worktree-cleanup.sh` prose, CLAUDE.md doc section.

**New in this resume:**
- `scripts/tests/worktree-root.test.sh` (deliverable 5, unwritten by the dead builder): 23 assertions — full resolver semantics (env/config/default/relative-fallback/trailing-slash/env-beats-config/malformed-JSON/null-key) + janitor dual-scan, outside-pass INSIDE classification, and infra-guardian reaper allow-pattern replicas.
- CLAUDE.md wording fix: the stranded text said the repo *commits* `worktree.root`; since #38390 `.loom/*` is gitignored runtime state, so the config key is **operator-local** (issue deliverable 4 superseded by repo policy). Note: `/Users/rwalters/GitHub/lean-genius/.loom/config.json` does not currently exist — the operator must (re)create it with `{"worktree": {"root": "/Volumes/Stripe"}}` (or export `LOOM_WORKTREE_ROOT=/Volumes/Stripe`) for the override to take effect.

## Guard reconciliation (#38433 R3)

Two salvaged files were further modified by today's R3 guards PR; both features verified surviving:
- `scripts/research/parallel-research.sh`: `WORKTREES_DIR` now resolver-based; `install_deletion_tripwire` (guard 1) and `worktree_health_check` (guard 4) intact and operate on the resolved path.
- `scripts/deploy/sync-and-deploy.sh`: temp-rebase worktrees at `$WORKTREES_BASE/temp-rebase-$$`; `pr_diffstat_safe` gate intact.

The R3 hook-install path is **repo-side** (`git rev-parse --absolute-git-dir` → `<main>/.git/worktrees/<name>/hooks` + worktree-scoped `core.hooksPath`), so it works unchanged for worktrees on an external volume — verified live (below).

## Testing

- `bash scripts/tests/worktree-root.test.sh` — 23/23 pass
- `bash scripts/tests/worktree-cleanup.test.sh` — 10/10 pass; `bash scripts/tests/clean-branches-reclaim.test.sh` — 14/14 pass (no regression)
- `bash -n` on all 20 touched scripts — clean; `shellcheck -S warning` — only pre-existing findings (SC2034/SC2155/SC2164 on untouched lines, present on main baseline)
- **Real Stripe-volume round trip**: resolver with `LOOM_WORKTREE_ROOT=/Volumes/Stripe` → `/Volumes/Stripe/lean-genius`; created `/Volumes/Stripe/lean-genius/test-37509-resume-73422` (detached, origin/main); installed the R3 tripwire hook (landed at `<main>/.git/worktrees/test-37509-resume-73422/hooks/pre-commit`, worktree-scoped `core.hooksPath` set, main checkout's `.githooks` untouched); health check PASS; tripwire **verified firing** — a staged mass deletion was blocked ("COMMIT BLOCKED: 10729 staged deletions"); worktree removed and deregistered cleanly.
- Fallback verified: with env unset and no `.loom/config.json`, resolver returns exactly `$REPO_ROOT/.loom/worktrees`.

## Not in scope / operator notes

- **Existing live worktrees are NOT migrated** — the fleet is running; the override applies to newly created worktrees, and both locations are serviced by cleanup during the natural drain.
- The stranded worktree `/Volumes/Stripe/lean-genius/issue-37509` (+ branch `feature/issue-37509`) can be removed by the orchestrator once this PR lands — its entire diff is captured here.
- Vendored Loom upgrade (0.10.4 → 0.10.6) remains a separate operator task per the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)