### PR TITLE
audit(erdos-630): correct axiom count 22→11 (de-dup identical stub)

### DIFF
--- a/src/data/proofs/erdos-630/meta.json
+++ b/src/data/proofs/erdos-630/meta.json
@@ -13,8 +13,7 @@
       "Proofs/Erdos630Aristotle.lean",
       "Proofs/Erdos630ProblemAristotle.lean",
       "Proofs/GraphCore.lean",
-      "Proofs/Stubs/Erdos630Aristotle.lean",
-      "Proofs/Stubs/Erdos630Problem.lean"
+      "Proofs/Stubs/Erdos630Aristotle.lean"
     ],
     "tags": [
       "erdos",
@@ -57,9 +56,9 @@
       "Connection to Combinatorial Nullstellensatz",
       "Graph polynomial formulation"
     ],
-    "axiomCount": 22,
+    "axiomCount": 11,
     "lineCount": 246,
-    "assumptions": "22 axiom(s) and 15 sorries(s).",
+    "assumptions": "11 axiom(s) and 15 sorries(s).",
     "mathlib_version": "4.26.0",
     "theoremCount": 11,
     "definitionCount": 8
@@ -214,7 +213,7 @@
     ],
     "namespace": "Erdos630",
     "lineCount": 246,
-    "axiomCount": 22,
+    "axiomCount": 11,
     "theoremCount": 11,
     "definitionCount": 8,
     "path": "Proofs/Erdos630Problem.lean",
@@ -223,8 +222,7 @@
       "Proofs/Erdos630Aristotle.lean",
       "Proofs/Erdos630ProblemAristotle.lean",
       "Proofs/GraphCore.lean",
-      "Proofs/Stubs/Erdos630Aristotle.lean",
-      "Proofs/Stubs/Erdos630Problem.lean"
+      "Proofs/Stubs/Erdos630Aristotle.lean"
     ]
   },
   "sorries": 15


### PR DESCRIPTION
## Gallery Integrity Fix

**Proof**: erdos-630 (Erdős #630: List Chromatic Number of Planar Bipartite Graphs)
**Problem**: `meta.axiomCount` overstated the assumption count as **22** when the presented proof declares **11** axioms.

## Evidence

- `Proofs/Erdos630Problem.lean` declares **11** `axiom` declarations and **15** sorries (verified via `quickcheck.sh` and `grep`).
- `Proofs/Stubs/Erdos630Problem.lean` is **byte-identical** (`diff` reports no differences) to the main file and was listed in `additionalFiles`.
- The auditor's `find-targets.ts` aggregates axioms across `additionalFiles`, so it counted 11 (main) + 11 (identical stub) = **22**, and `meta.axiomCount` had been set to 22 to match — a conservative but factually inaccurate double-count.
- This entry has been flagged as an axiom mismatch **6× since 2026-06-02**; the duplicate stub is the root cause.

## Fix

- `meta.axiomCount` / `leanFile.axiomCount`: `22 → 11`
- `assumptions`: `"22 axiom(s) and 15 sorries(s)."` → `"11 axiom(s) and 15 sorries(s)."`
- Remove the byte-identical `Proofs/Stubs/Erdos630Problem.lean` from `additionalFiles` (it contributes no distinct assumptions).

Sorries (15) were already correct. Status `axiomatized` / badge `axiom` remain appropriate (11 axioms + 15 sorries). No overclaim was present; this corrects an over-count in the conservative direction so the gallery matches the Lean source exactly.

---
Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)