### PR TITLE
Research: erdos-117-oq-01-incomplete-01 - supermultiplicative dual Fekete condition

### DIFF
--- a/proofs/Proofs/Erdos117OQ01Incomplete01.lean
+++ b/proofs/Proofs/Erdos117OQ01Incomplete01.lean
@@ -135,4 +135,126 @@ theorem not_exponentialBaseExists_implies_not_submultiplicative
     ¬ (∀ m n : ℕ, h (m + n) ≤ h m * h n) :=
   fun hsub => hno (submultiplicative_implies_exponentialBaseExists hsub)
 
+/-! ### The dual sufficient condition: supermultiplicativity
+
+The parent proves `submultiplicative_implies_convergence` via Fekete's lemma
+applied to the *subadditive* sequence `log(h n)` (Mathlib's
+`Subadditive.tendsto_lim`).  Mathlib has no `Superadditive` API, so the dual
+condition — `h(m)·h(n) ≤ h(m+n)` (**supermultiplicativity**) — is not covered.
+We supply it here by applying `Subadditive.tendsto_lim` to the *negated*
+sequence `g n = −log(h n)`, which is subadditive exactly when `log(h n)` is
+superadditive.  The boundedness hypothesis Fekete needs (`g n / n` bounded
+below) is furnished by Pyber's **upper** bound `growthRate n ≤ log c₂`
+(`growthRate_upper_bound`), the mirror of the lower bound used in the
+submultiplicative proof.
+
+Consequently *either* one-sided multiplicative inequality resolves Erdős #117
+OQ-01 in the affirmative, and — the sharpened capstone — a genuine
+counterexample (no exponential base) must violate **both** at once. -/
+
+/-- **Supermultiplicativity ⟹ convergence** (the Fekete dual).  If
+`h(m)·h(n) ≤ h(m+n)` for all `m, n`, the growth rate converges.  Proof: the
+sequence `g n = −log(h n)` is subadditive (superadditivity of `log h`), and
+`g n / n = −growthRate n ≥ −log c₂` is bounded below by Pyber's upper bound, so
+Mathlib's `Subadditive.tendsto_lim` gives `g n / n → g.lim`; negating,
+`growthRate n → −g.lim`.  The mirror image of the parent's
+`submultiplicative_implies_convergence`. -/
+theorem supermultiplicative_implies_convergence
+    (hsup : ∀ m n : ℕ, h m * h n ≤ h (m + n)) :
+    growthRateConverges := by
+  -- `g = -log h` is subadditive; Fekete gives `g n / n → g.lim`, so `growthRate → -g.lim`.
+  let g : ℕ → ℝ := fun n => - Real.log (h n : ℝ)
+  -- `h 0 ≤ 1`: from `hsup 0 0`, `h 0 * h 0 ≤ h 0`.
+  have h0_le : h 0 ≤ 1 := by
+    have hh := hsup 0 0
+    rw [Nat.add_zero] at hh
+    rcases Nat.eq_zero_or_pos (h 0) with h0z | h0p
+    · omega
+    · exact Nat.le_of_mul_le_mul_left (by rwa [Nat.mul_one]) h0p
+  -- Hence `log(h 0) = 0` (whether `h 0 = 0` or `1`).
+  have hlog0 : Real.log (h 0 : ℝ) = 0 := by
+    have : h 0 = 0 ∨ h 0 = 1 := by omega
+    rcases this with h0 | h0 <;> rw [h0] <;> simp
+  have h_pos_ge1 : ∀ n : ℕ, 1 ≤ n → (0 : ℝ) < (h n : ℝ) := fun n hn => by
+    exact_mod_cast Nat.lt_of_lt_of_le Nat.zero_lt_one (h_pos n hn)
+  -- `log h` is superadditive (for all `m, n`, using `log(h 0) = 0` for the boundary).
+  have hlog_super : ∀ m n : ℕ,
+      Real.log (h m : ℝ) + Real.log (h n : ℝ) ≤ Real.log (h (m + n) : ℝ) := by
+    intro m n
+    rcases Nat.eq_zero_or_pos m with rfl | hm
+    · simp [hlog0]
+    rcases Nat.eq_zero_or_pos n with rfl | hn
+    · simp [hlog0]
+    have hm' := h_pos_ge1 m hm
+    have hn' := h_pos_ge1 n hn
+    rw [← Real.log_mul (ne_of_gt hm') (ne_of_gt hn')]
+    exact Real.log_le_log (mul_pos hm' hn') (by exact_mod_cast hsup m n)
+  -- Therefore `g` is subadditive.
+  have hg_sub : Subadditive g := fun m n => by
+    show - Real.log (h (m + n) : ℝ) ≤ - Real.log (h m : ℝ) + - Real.log (h n : ℝ)
+    linarith [hlog_super m n]
+  -- `g n / n` is bounded below: `= -growthRate n ≥ -log c₂` for `n ≥ 1`, `= 0` for `n = 0`.
+  have hbdd : BddBelow (Set.range fun n : ℕ => g n / n) := by
+    obtain ⟨U, hU⟩ := growthRate_upper_bound
+    refine ⟨min (-U) 0, ?_⟩
+    rintro x ⟨n, rfl⟩
+    rcases Nat.eq_zero_or_pos n with rfl | hpos
+    · show min (-U) 0 ≤ g 0 / ((0 : ℕ) : ℝ)
+      simp only [Nat.cast_zero, div_zero]
+      exact min_le_right _ _
+    · have hgn : g n / n = - growthRate n := by
+        show (- Real.log (h n : ℝ)) / (n : ℝ) = - growthRate n
+        unfold growthRate
+        rw [if_neg (show n ≠ 0 from by omega), neg_div]
+      show min (-U) 0 ≤ g n / (n : ℝ)
+      rw [hgn]
+      have hgr : growthRate n ≤ U := hU n hpos
+      calc min (-U) 0 ≤ -U := min_le_left _ _
+        _ ≤ - growthRate n := by linarith
+  -- Fekete on `g`, then negate to recover `growthRate`.
+  refine ⟨- hg_sub.lim, ?_⟩
+  have hneg := (hg_sub.tendsto_lim hbdd).neg
+  apply hneg.congr'
+  apply Filter.eventually_atTop.mpr
+  refine ⟨1, fun n hn => ?_⟩
+  show -((- Real.log (h n : ℝ)) / (n : ℝ)) = growthRate n
+  unfold growthRate
+  rw [if_neg (show n ≠ 0 from by omega), neg_div, neg_neg]
+
+/-- **Supermultiplicativity ⟹ zero oscillation.**  The oscillation form of
+`supermultiplicative_implies_convergence`, dual to
+`submultiplicative_implies_oscillation_zero`. -/
+theorem supermultiplicative_implies_oscillation_zero
+    (hsup : ∀ m n : ℕ, h m * h n ≤ h (m + n)) :
+    growthRateLimSup - growthRateLimInf = 0 :=
+  converges_iff_oscillation_zero.mp (supermultiplicative_implies_convergence hsup)
+
+/-- **Supermultiplicativity ⟹ a single exponential base exists.**  The
+exponential-base form: a supermultiplicative covering number `h` answers Erdős
+#117 OQ-01 *yes*, dual to `submultiplicative_implies_exponentialBaseExists`. -/
+theorem supermultiplicative_implies_exponentialBaseExists
+    (hsup : ∀ m n : ℕ, h m * h n ≤ h (m + n)) :
+    exponentialBaseExists :=
+  exponentialBaseExists_iff_converges.mpr (supermultiplicative_implies_convergence hsup)
+
+/-- **A counterexample must break supermultiplicativity too.**  The
+contrapositive dual of `not_exponentialBaseExists_implies_not_submultiplicative`:
+if no single exponential base exists then `h` is not supermultiplicative either. -/
+theorem not_exponentialBaseExists_implies_not_supermultiplicative
+    (hno : ¬ exponentialBaseExists) :
+    ¬ (∀ m n : ℕ, h m * h n ≤ h (m + n)) :=
+  fun hsup => hno (supermultiplicative_implies_exponentialBaseExists hsup)
+
+/-- **A counterexample must break BOTH one-sided multiplicative laws.**  The
+sharpened structural constraint on any counterexample to Erdős #117 OQ-01:
+since *either* submultiplicativity (`h(m+n) ≤ h(m)·h(n)`) *or*
+supermultiplicativity (`h(m)·h(n) ≤ h(m+n)`) alone would force convergence, a
+genuinely oscillating covering number must violate **both** — its values can be
+neither globally sub- nor globally super-multiplicative. -/
+theorem not_exponentialBaseExists_implies_not_multiplicative
+    (hno : ¬ exponentialBaseExists) :
+    ¬ (∀ m n : ℕ, h (m + n) ≤ h m * h n) ∧ ¬ (∀ m n : ℕ, h m * h n ≤ h (m + n)) :=
+  ⟨not_exponentialBaseExists_implies_not_submultiplicative hno,
+   not_exponentialBaseExists_implies_not_supermultiplicative hno⟩
+
 end Erdos117OQ01Incomplete01

--- a/research/problems/erdos-117-oq-01-incomplete-01/knowledge.md
+++ b/research/problems/erdos-117-oq-01-incomplete-01/knowledge.md
@@ -142,3 +142,35 @@ on Synonym.ir) AND host `.lake` missing ~CategoryTheory oleans (SplitEqualizer) 
 v4.26.0 **targeted-import standalone** (import only Log.Basic + Tactic.Linarith + Tactic.Positivity,
 which are present; reconstruct growthRate/pyber_bounds/ExponentialBehaviorCorrect faithfully and
 take behavior_correct_implies_base as a hypothesis): elaboration EXIT 0. Rest of file unchanged.
+
+## Session 2026-07-12 (researcher-10) — the DUAL sufficient condition: supermultiplicativity (VERIFIED)
+
+The companion had `submultiplicative_implies_convergence`-style results (Fekete via
+Mathlib `Subadditive.tendsto_lim` on `log h`, using the Pyber **lower** bound for
+bounded-below). The dual — supermultiplicativity `h(m)·h(n) ≤ h(m+n)` — was missing,
+and Mathlib has **no `Superadditive` API**. Supplied it by the standard reduction:
+
+- `supermultiplicative_implies_convergence (hsup : ∀ m n, h m * h n ≤ h (m+n)) : growthRateConverges`.
+  Set `g n = −log(h n)`. Then `g` is **subadditive** iff `log h` is superadditive, and
+  `hlog_super : log(h m)+log(h n) ≤ log(h(m+n))` holds for ALL m,n — crucially INCLUDING
+  the zero boundary, because `hsup 0 0` forces `h 0 * h 0 ≤ h 0` ⟹ `h 0 ≤ 1` ⟹ `log(h 0)=0`
+  (`Nat.le_of_mul_le_mul_left`), so the `m=0`/`n=0` cases collapse to equalities via `simp [hlog0]`.
+  Boundedness: `g n / n = −growthRate n ≥ −log c₂` from `growthRate_upper_bound` (the **upper**
+  Pyber bound — the mirror of the submult proof's lower bound); `n=0` term is `0`, so lower
+  bound `min (−U) 0`. `Subadditive.tendsto_lim` ⟹ `g n/n → g.lim`; `.neg` + `congr'` ⟹
+  `growthRate n → −g.lim`.
+- `supermultiplicative_implies_oscillation_zero`, `supermultiplicative_implies_exponentialBaseExists`,
+  `not_exponentialBaseExists_implies_not_supermultiplicative` — the oscillation/base/contrapositive
+  corollaries, mirroring the submultiplicative ones.
+- `not_exponentialBaseExists_implies_not_multiplicative` (capstone) — since EITHER one-sided law
+  forces convergence, a genuine counterexample to #117-OQ-01 must violate **both** at once.
+
+GOTCHAs: (1) `let g` is not `simp`-unfoldable — use `show -Real.log (h (m+n)) ≤ ...` to expose the
+body, then `linarith [hlog_super m n]`. (2) After `rintro x ⟨n, rfl⟩` the range membership goal reads
+`min (-U) 0 ≤ (fun n => g n / ↑n) n` (un-beta-reduced) — a bare `rw` fails to find `g n / ↑n`; insert
+`show min (-U) 0 ≤ g n / (n:ℝ)` first. (3) `Tendsto.neg` gives `𝓝 (-a)` and negates the function, so
+`(hg_sub.tendsto_lim hbdd).neg |>.congr'` lands exactly on `growthRate`.
+
+**Verification.** Docker build `Proofs.Erdos117OQ01Incomplete01` — `✔ Built (3.6s)`. No `sorry`/`axiom`
+in the file; inherits only the parent's 3 structural axioms (h/h_pos/pyber_bounds). 8→13 theorems,
+138→260 lines. Open convergence question itself unchanged (it IS #117-OQ-01).

--- a/research/problems/erdos-666-incomplete-01/knowledge.md
+++ b/research/problems/erdos-666-incomplete-01/knowledge.md
@@ -175,3 +175,36 @@ large hypercubes. Proof: `by_contra h; push_neg at h; obtain ⟨N,hN⟩ := h; ex
 theorems 13→14 (meta was lagging at 12→corrected to 14). No follow-up questions generated:
 file is saturated and the remaining directions (GeneralizedConjecture C_{2k}, explicit Conder
 3-colouring) are all large/open, documented in nextSteps.
+
+## Session 2026-07-12 (researcher-10) — VERIFY standing-UNVERIFIED file; footprint audit
+
+**Mode:** REVISIT (RICH, saturated). **Outcome:** verification, no new theorems (honest — no
+non-filler increment available; see below).
+
+The three prior sessions (researcher-1 07-09, researcher-3 07-10, and the earlier necessary-
+condition work) all shipped **UNVERIFIED** because the Docker/containerd build was down and no
+host Mathlib cache existed. With host `lean` v4.26.0 now available and main's Mathlib
+`LEAN_PATH`, I verified `Erdos666Problem.lean` (757 L) end-to-end:
+
+- **Whole file EXIT 0**, no errors/warnings. All standing-unverified content
+  (`conjectureAt_imp_gt_third`, `conder_counterexamples_unbounded`,
+  `conder_counterexamples_unbounded'`) is confirmed correct — **no bug**, upgrading the
+  file from "UNVERIFIED (by-eye)" to machine-checked.
+- **Axiom footprint audit** (`#print axioms`): every capstone
+  (`generalizedConjecture_false`, `chung_no_threshold`, `conjectureAt_imp_gt_third`,
+  `conder_counterexamples_unbounded`) depends on exactly `[propext, Classical.choice,
+  Quot.sound, Erdos666.conder_no_threshold]` — **no `sorryAx`, no `Lean.ofReduceBool`**. The
+  single mathematical assumption is the deep Conder/BDT 3-colouring axiom
+  `conder_no_threshold : ¬ ConjectureAt (1/3)`; notably even Chung's `1/4` result
+  (`chung_no_threshold`) is derived from it by monotonicity (`chung ≤ conder` interval),
+  so the honest count is genuinely **1 axiom**, not 2.
+
+**No new theorems (deliberate).** The elementary refutation theory is complete: failure at
+every `ε ≤ 1/3` (`conder_no_threshold_le`), sharp necessary condition
+`ConjectureAt ε → 1/3 < ε`, unbounded-`n` counterexamples, `GeneralizedConjecture` refuted at
+`k = 3`. Every candidate increment I considered (strict Chung⊊Conder separation witness,
+downward-closure of the failure set, sInf critical-density restatement) is a **trivial
+specialization of `conder_no_threshold_le` + monotonicity** — rejected as filler per the
+role's quality bar. The genuinely-open core (constant-fraction `C₂ₖ`-free for `k ≥ 4`; dense
+`C₄,C₆`-free ⇒ `C₈`; explicit Conder 3-colouring to eliminate the axiom) is all
+open/session-oversized. Frontier unchanged.

--- a/src/data/research/problems/erdos-117-oq-01-incomplete-01.json
+++ b/src/data/research/problems/erdos-117-oq-01-incomplete-01.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (researcher-5, 2026-07-12): added the first SUFFICIENT-condition results to the oscillation companion. Submultiplicativity of h (h(m+n)≤h(m)·h(n)) ⟹ oscillation=0 and a single exponential base exists (Fekete, lifted from parent submultiplicative_implies_convergence into the oscillation/base language); contrapositive gives a necessary condition on any counterexample. 3 new theorems, 0 new axioms (inherits only h/h_pos/pyber_bounds). The convergence question itself remains open (#117-OQ-01).",
+    "progressSummary": "PROGRESS (researcher-10, 2026-07-12): added the DUAL sufficient condition to the oscillation companion. Supermultiplicativity h(m)·h(n)≤h(m+n) ⟹ convergence / oscillation=0 / exponential base exists — derived by applying Mathlib Subadditive.tendsto_lim to −log(h n) (bounded below via the Pyber UPPER bound), the mirror of the parent submultiplicative (subadditive) Fekete result. Capstone not_exponentialBaseExists_implies_not_multiplicative: any counterexample must violate BOTH one-sided multiplicative laws. 5 new theorems, 0 new axioms (inherits only h/h_pos/pyber_bounds). The convergence question itself remains open (#117-OQ-01).",
     "builtItems": [
       "Erdos117OQ01.base_implies_behavior — proved (was sorry): convergence to log c ⇒ ExponentialBehavior c for ε ∈ (0,c)",
       "Erdos117OQ01.ExponentialBehavior — corrected statement to ε ∈ (0,c) (unrestricted ∀ε>0 form is false)",
@@ -38,7 +38,9 @@
       "Erdos117OQ01OQ01.lean: base_mem_pyber_window — exponential base c localized to Pyber interval [c₁,c₂] (c₁≤c≤c₂). New reasoning VERIFIED host lean v4.26.0 targeted-import standalone (elab EXIT 0); full-file/sibling import-Mathlib blocked by host .lake missing CategoryTheory oleans + docker .ir corruption. 7→8 theorems.",
       "Erdos117OQ01Incomplete01.lean: submultiplicative_implies_oscillation_zero — h(m+n)≤h(m)·h(n) ⟹ oscillation=0 (Fekete via converges_iff_oscillation_zero)",
       "Erdos117OQ01Incomplete01.lean: submultiplicative_implies_exponentialBaseExists — submultiplicative h ⟹ exponential base exists (OQ resolved yes in this sub-case)",
-      "Erdos117OQ01Incomplete01.lean: not_exponentialBaseExists_implies_not_submultiplicative — any counterexample must break submultiplicativity"
+      "Erdos117OQ01Incomplete01.lean: not_exponentialBaseExists_implies_not_submultiplicative — any counterexample must break submultiplicativity",
+      "supermultiplicative_implies_convergence in Erdos117OQ01Incomplete01.lean",
+      "supermultiplicative_implies_oscillation_zero, supermultiplicative_implies_exponentialBaseExists, not_exponentialBaseExists_implies_not_supermultiplicative, not_exponentialBaseExists_implies_not_multiplicative in Erdos117OQ01Incomplete01.lean"
     ],
     "insights": [
       "The 'exponential behavior at base c' notion is only a theorem for ε ∈ (0,c): the lower bound (c−ε)ⁿ ≤ h(n) fails for ε ≥ c because (ε−c)ⁿ at even n outgrows h(n) ≤ c₂ⁿ.",
@@ -47,7 +49,9 @@
       "positivity on (c-ε)^n consults the local context for the base's sign: it needs `0 < c-ε` as a named hypothesis (via linarith) before use, otherwise it fails to prove nonnegativity.",
       "The (hypothetical) exponential base c of ExponentialBehaviorCorrect is PINNED to Pyber window [c₁,c₂]: base_mem_pyber_window shows behavior at c>1 forces c₁≤c≤c₂. Pyber bounds trap growthRate in [log c₁, log c₂] eventually; behavior→convergence to log c (behavior_correct_implies_base); limit of a confined sequence stays confined (ge_of_tendsto/le_of_tendsto); exponentiate back through positivity. Ties the abstract base invariant (exponentialBehaviorCorrect_base_unique) to concrete constants — contrapositively no h has exponential behavior at a base outside its own Pyber window.",
       "GOTCHA le_of_tendsto vs ge_of_tendsto: ge_of_tendsto (Tendsto f→a) (∀ᶠ b≤f) : b≤a (b≤limit); le_of_tendsto (Tendsto f→a) (∀ᶠ f≤b) : a≤b (limit≤b). For lower bound log c₁≤log c use ge_of_tendsto with hev_l:log c₁≤growthRate.",
-      "First SUFFICIENT condition in the companion: the parent Fekete result submultiplicative_implies_convergence, lifted into the oscillation/base language, resolves Erdos #117 OQ-01 positively whenever h is submultiplicative. Contrapositive: a genuinely oscillating (no-base) h must be super-multiplicative at some (m,n) — a necessary condition on any counterexample. No new axioms (inherits only the 3 Pyber axioms)."
+      "First SUFFICIENT condition in the companion: the parent Fekete result submultiplicative_implies_convergence, lifted into the oscillation/base language, resolves Erdos #117 OQ-01 positively whenever h is submultiplicative. Contrapositive: a genuinely oscillating (no-base) h must be super-multiplicative at some (m,n) — a necessary condition on any counterexample. No new axioms (inherits only the 3 Pyber axioms).",
+      "supermultiplicative_implies_convergence (researcher-10): the DUAL Fekete sufficient condition. Mathlib has no Superadditive API, so h(m)·h(n)≤h(m+n) ⟹ convergence is obtained by applying Subadditive.tendsto_lim to g n = −log(h n) (subadditive iff log h superadditive), with g n/n = −growthRate n bounded below by −log c₂ from the Pyber UPPER bound. Mirror of the parent submultiplicative proof which used the lower bound.",
+      "not_exponentialBaseExists_implies_not_multiplicative (researcher-10): sharpened counterexample constraint — since EITHER sub- OR super-multiplicativity alone forces convergence, any genuine counterexample to #117-OQ-01 (oscillating growth rate) must violate BOTH one-sided multiplicative laws simultaneously."
     ],
     "mathlibGaps": [],
     "nextSteps": [

--- a/src/data/research/problems/erdos-666-incomplete-01.json
+++ b/src/data/research/problems/erdos-666-incomplete-01.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "Refutation strengthened to Conder ε=1/3 with axiom count held at 1: conder_no_threshold (¬ConjectureAt 1/3) is the single deep axiom; chung_no_threshold (1/4) is now DERIVED from it by monotonicity (conjectureAt_mono, 1/4≤1/3). conder_no_threshold_le extends the refutation to the whole interval (0,1/3]. The prior True-placeholder conder_better_bound is replaced by the honest existence witness conder_counterexample. 0 sorries, 1 axiom; #print axioms shows only propext/Classical.choice/Quot.sound + Erdos666.conder_no_threshold.",
+    "progressSummary": "VERIFIED + saturated: file compiles clean (EXIT 0), honest 1-axiom footprint (conder_no_threshold, deep/uneliminable). Elementary refutation theory complete; open core (C_{2k} k≥4, dense C4C6-free⇒C8, explicit Conder colouring) is session-oversized.",
     "builtItems": [
       "Proved Erdos666.erdos_conjecture_false from chung_1992 (Proofs/Erdos666Problem.lean)",
       "Repaired Hypercube, HasCycle, DenseSubgraph defs and imports so the file compiles (282 lines, 0 errors)",
@@ -51,7 +51,8 @@
       "Axiom-count-neutral strengthening: when the file axiomatizes result A and a strictly stronger published result B implies A, axiomatize B and derive A as a theorem — net axioms unchanged, math strengthened. #print axioms on the derived A must list B (proof it is genuinely derived, not silently re-axiomatized).",
       "The compact negation form ¬ConjectureAt(1/3) = ¬∃N,∀n≥N,DenseForcesC6 hides its positive content; De Morgan (push_neg) exposes ∀N,∃n≥N,¬DenseForcesC6 — the honest \"counterexamples occur for arbitrarily large n\" statement. Axiom-neutral restatement, no new assumptions.",
       "A SPARSER density threshold makes a cycle-forcing statement STRONGER (applies to more subgraphs), hence EASIER to refute — not harder. The intuition 'sparser threshold ⇒ refutation does not transfer' is backwards. Conder's constant-fraction C6-free construction refutes the generalized conjecture at k=3 a fortiori.",
-      "Formalization faithfulness: GeneralizedConjecture's ∀k≥3 bound is too generous — the k=3 instance is outright false (ex(Q_n,C6)=Θ(n·2^n) means a_3=1, not <1). The genuine open problem starts at k≥4."
+      "Formalization faithfulness: GeneralizedConjecture's ∀k≥3 bound is too generous — the k=3 instance is outright false (ex(Q_n,C6)=Θ(n·2^n) means a_3=1, not <1). The genuine open problem starts at k≥4.",
+      "VERIFIED 2026-07-12 (researcher-10): whole Erdos666Problem.lean elaborates EXIT 0 via host lean v4.26.0 — clears 3 prior UNVERIFIED sessions, no bug. Axiom audit: honest footprint is exactly 1 axiom (conder_no_threshold); even chung_no_threshold derives from it via monotonicity. No sorryAx/ofReduceBool. File saturated: all candidate increments are trivial specializations of conder_no_threshold_le — no non-filler theorem available."
     ],
     "mathlibGaps": [],
     "nextSteps": [


### PR DESCRIPTION
## Summary
Research session for `erdos-117-oq-01-incomplete-01` (Erdős #117 OQ-01: does the normalized log-growth rate `growthRate n = log(h n)/n` of the abelian covering number converge?).

The oscillation companion `Erdos117OQ01Incomplete01.lean` already had the *submultiplicative* sufficient condition (Fekete via Mathlib's `Subadditive.tendsto_lim` on `log h`, using the Pyber **lower** bound). This session adds the **dual**: the *supermultiplicative* condition, which Mathlib does not cover (there is no `Superadditive` API).

## Progress
New theorems in `Erdos117OQ01Incomplete01.lean` (8 → 13):
- `supermultiplicative_implies_convergence` — `h(m)·h(n) ≤ h(m+n)` ⟹ the growth rate converges. Derived by applying `Subadditive.tendsto_lim` to `g n = −log(h n)` (subadditive iff `log h` is superadditive), with `g n / n = −growthRate n` bounded below by `−log c₂` from the Pyber **upper** bound `growthRate_upper_bound` — the mirror image of the parent's submultiplicative proof. The zero boundary is handled because `h(0)·h(0) ≤ h(0)` forces `h 0 ≤ 1`, so `log(h 0) = 0`.
- `supermultiplicative_implies_oscillation_zero`, `supermultiplicative_implies_exponentialBaseExists`, `not_exponentialBaseExists_implies_not_supermultiplicative` — the oscillation / base / contrapositive corollaries mirroring the submultiplicative ones.
- `not_exponentialBaseExists_implies_not_multiplicative` (capstone) — since *either* one-sided multiplicative law alone forces convergence, any genuine counterexample to #117-OQ-01 (an oscillating growth rate) must violate **both** at once.

## Findings
- The subadditive-to-superadditive reduction via negation cleanly plugs the gap left by Mathlib's one-sided `Subadditive` library; the same Pyber window that bounds `log h` below/above supplies the boundedness hypothesis for both directions.

## Status
**Outcome**: progress (0 new axioms — inherits only the parent's `h`/`h_pos`/`pyber_bounds`; 0 sorries; built green via `docker-build.sh Proofs.Erdos117OQ01Incomplete01`).
**Next Steps**: The convergence question itself remains open (it *is* #117-OQ-01). A natural continuation is an *asymptotic* (eventual) super/sub-multiplicativity sufficient condition, weaker than the global one used here.

🤖 Generated by researcher-10