### PR TITLE
audit(erdos-634): sync stale meta counts (5 axioms, 0 sorries)

### DIFF
--- a/src/data/proofs/erdos-634/meta.json
+++ b/src/data/proofs/erdos-634/meta.json
@@ -17,7 +17,7 @@
       "open-problem"
     ],
     "badge": "axiom",
-    "sorries": 5,
+    "sorries": 0,
     "erdosNumber": 634,
     "erdosUrl": "https://erdosproblems.com/634",
     "erdosProblemStatus": "open",
@@ -55,8 +55,8 @@
     "relatedProblems": [
       "erdos-633"
     ],
-    "axiomCount": 4,
-    "assumptions": "4 axioms in Erdos634Problem.lean: Tiles (abstract tiling predicate), seven_not_dissectable, eleven_not_dissectable, soifer_theorem. 5 sorries: the five positive-result stubs (squares/two/three/six/sum), each a genuine reptiling construction blocked only on Mathlib's missing polygonal-tiling API. SOUNDNESS (resolved): a prior version was internally inconsistent — the area-only IsDissectable is provable for every n >= 1 (constant equilateral witnesses of side 1/sqrt(n), proven in Erdos634AreaCollapse.lean), which contradicted the Beeson non-dissectability axioms; and congruent_implies_similar was a sorry on a false statement (unordered-multiset Congruent vs order-pinned Similar). Both are now fixed: IsDissectable additionally requires an abstract Tiles (covering + interior-disjointness) witness, blocking the trivial equal-area construction so Beeson's negatives are consistent; and Similar is restated on the unordered side multiset, making congruent_implies_similar a real 1-line proof. A faithful non-abstract Tiles still awaits a Mathlib tiling API (the oq-02 covering line).",
+    "axiomCount": 5,
+    "assumptions": "5 axioms in Erdos634Problem.lean: Tiles (abstract tiling predicate), known_positive_dissectable (the positive dissection families squares/two/three/six/sum, each a genuine reptiling construction axiomatized pending Mathlib's missing polygonal-tiling API), seven_not_dissectable, eleven_not_dissectable, soifer_theorem. 0 sorries (the five positive-result stubs were folded into the single known_positive_dissectable axiom in #38353, making the file sorry-free). SOUNDNESS (resolved): a prior version was internally inconsistent — the area-only IsDissectable is provable for every n >= 1 (constant equilateral witnesses of side 1/sqrt(n), proven in Erdos634AreaCollapse.lean), which contradicted the Beeson non-dissectability axioms; and congruent_implies_similar was a sorry on a false statement (unordered-multiset Congruent vs order-pinned Similar). Both are now fixed: IsDissectable additionally requires an abstract Tiles (covering + interior-disjointness) witness, blocking the trivial equal-area construction so Beeson's negatives are consistent; and Similar is restated on the unordered side multiset, making congruent_implies_similar a real 1-line proof. A faithful non-abstract Tiles still awaits a Mathlib tiling API (the oq-02 covering line).",
     "lineCount": 412,
     "theoremCount": 18,
     "definitionCount": 20,


### PR DESCRIPTION
## Gallery Integrity Fix

**Proof**: erdos-634 (Triangle Dissection into Congruent Pieces)
**Problem**: Meta block counts drifted from the Lean source after #38353.

## Evidence

Commit `61d9561ba5` (#38353) axiomatized the five positive-dissection sorry stubs into a single new axiom `known_positive_dissectable`, making `Erdos634Problem.lean` sorry-free with **5 axioms, 0 sorries**.

The inner `meta` block was never updated:
- **meta.json claimed**: `sorries: 5`, `axiomCount: 4`, and an `assumptions` string listing only 4 axioms + describing 5 sorries.
- **Lean file shows**: 5 `axiom` declarations (`Tiles`, `known_positive_dissectable`, `seven_not_dissectable`, `eleven_not_dissectable`, `soifer_theorem`), 0 sorries.

The key integrity concern was the **axiomCount undercount**: `known_positive_dissectable` was an undisclosed assumption (not counted, not named in `assumptions`). The `leanFile` and top-level blocks already had the correct counts (5/0).

## Fix

- `sorries` 5 → 0
- `axiomCount` 4 → 5
- `assumptions`: disclose `known_positive_dissectable`; drop the now-nonexistent 5-sorry description

Status/badge remain `axiomatized`/`axiom` (correct — still an open, axiomatized problem). No Lean source changes.

---
Discovered during gallery integrity audit.