### PR TITLE
research(erdos-1215-oq-02): monotonicity of the Mac Lane sublevel region in the level C [VERIFIED 0-axiom]

### DIFF
--- a/proofs/Proofs/Erdos1215UnitCircleMonotone.lean
+++ b/proofs/Proofs/Erdos1215UnitCircleMonotone.lean
@@ -1,0 +1,90 @@
+/-
+# Erdős 1215, OQ-02 — monotonicity of the sublevel labyrinth in the level `C`
+
+Companion to `Erdos1215UnitCircleRadius.lean` (radius sandwich, compactness) and
+`Erdos1215UnitCircleArea.lean` (planar-area sandwich).  Those files pin the geometry of
+the closed sublevel set
+
+    `closedLevelSet P C = {z : ℂ | ‖P.eval z‖ ≤ C}`
+
+for a **fixed** level `C`.  This file records how that region behaves as a function of the
+level parameter `C` itself, together with the two canonical points it always contains:
+
+* `closedLevelSet_mono` — the sublevel set is monotone increasing in `C`
+  (`C₁ ≤ C₂ ⟹ closedLevelSet P C₁ ⊆ closedLevelSet P C₂`);
+* `volume_closedLevelSet_mono` — hence its planar (Lebesgue) measure is monotone in `C`;
+* `isRoot_mem_closedLevelSet` — every root of `P` lies in the sublevel set for `C ≥ 0`
+  (there `‖P‖ = 0`);
+* `zero_mem_closedLevelSet` — the origin lies in the sublevel set for `C ≥ 1`
+  (a unit-circle polynomial has `P(0) = 1`, so `‖P(0)‖ = 1`);
+* `closedLevelSet_nonempty` — so the sublevel set is nonempty for `C ≥ 1`;
+* `levelSet_subset_closedLevelSet` — the open sublevel set `{‖P‖ < C}` of the Mac Lane
+  problem sits inside the closed one `{‖P‖ ≤ C}`.
+
+These are the monotone/membership structural facts underneath the fixed-`C` radius and area
+sandwiches: as the level `C` rises the labyrinth region only grows, always containing the
+roots (its "innermost" points) and, once `C ≥ 1`, the centre `0`.
+
+All results are axiom-free / sorry-free.
+-/
+
+import Mathlib
+import Proofs.Erdos1215UnitCircleRadius
+
+open Complex Polynomial MeasureTheory
+
+namespace Erdos1215UnitCircleMonotone
+
+open Erdos1215UnitCircleRadius
+
+/-- **The closed sublevel set is monotone increasing in the level `C`.** If `C₁ ≤ C₂` then
+`{‖P‖ ≤ C₁} ⊆ {‖P‖ ≤ C₂}`: any `z` with `‖P.eval z‖ ≤ C₁ ≤ C₂` lies in the larger set.
+So the Mac Lane labyrinth region only grows as the level rises. -/
+theorem closedLevelSet_mono (P : ℂ[X]) {C₁ C₂ : ℝ} (h : C₁ ≤ C₂) :
+    closedLevelSet P C₁ ⊆ closedLevelSet P C₂ := by
+  intro z hz
+  simp only [closedLevelSet, Set.mem_setOf_eq] at hz ⊢
+  exact hz.trans h
+
+/-- **The planar measure of the sublevel set is monotone in the level `C`.** Immediate from
+`closedLevelSet_mono` and monotonicity of Lebesgue measure — the area of the labyrinth region
+is a nondecreasing function of `C`. -/
+theorem volume_closedLevelSet_mono (P : ℂ[X]) {C₁ C₂ : ℝ} (h : C₁ ≤ C₂) :
+    volume (closedLevelSet P C₁) ≤ volume (closedLevelSet P C₂) :=
+  measure_mono (closedLevelSet_mono P h)
+
+/-- **Every root of `P` lies in the sublevel set (for `C ≥ 0`).** At a root `‖P.eval z‖ = 0 ≤ C`.
+The roots are the "innermost" points of the labyrinth region — the sublevel set of the smallest
+possible level `0` is exactly the root set. -/
+theorem isRoot_mem_closedLevelSet {P : ℂ[X]} {z : ℂ} (hz : P.IsRoot z) {C : ℝ} (hC : 0 ≤ C) :
+    z ∈ closedLevelSet P C := by
+  simp only [closedLevelSet, Set.mem_setOf_eq]
+  have hzero : P.eval z = 0 := hz
+  rw [hzero, norm_zero]
+  exact hC
+
+/-- **The origin lies in the sublevel set (for `C ≥ 1`).** A unit-circle polynomial has
+`P(0) = 1`, so `‖P.eval 0‖ = 1 ≤ C`.  The centre is captured as soon as the level reaches `1`. -/
+theorem zero_mem_closedLevelSet {P : ℂ[X]} (h : Erdos1215.IsUnitCirclePolynomial P)
+    {C : ℝ} (hC : 1 ≤ C) : (0 : ℂ) ∈ closedLevelSet P C := by
+  simp only [closedLevelSet, Set.mem_setOf_eq]
+  rw [h.1, norm_one]
+  exact hC
+
+/-- **The sublevel set is nonempty for `C ≥ 1`.** It contains the origin
+(`zero_mem_closedLevelSet`). -/
+theorem closedLevelSet_nonempty {P : ℂ[X]} (h : Erdos1215.IsUnitCirclePolynomial P)
+    {C : ℝ} (hC : 1 ≤ C) : (closedLevelSet P C).Nonempty :=
+  ⟨0, zero_mem_closedLevelSet h hC⟩
+
+/-- **The open sublevel set sits inside the closed one.**  The Mac Lane path problem is stated
+for the open region `levelSet P C = {‖P‖ < C}`; it is contained in the closed sublevel set
+`{‖P‖ ≤ C}` on which the radius and area sandwiches are proved (`‖P‖ < C ⟹ ‖P‖ ≤ C`).  So every
+confinement bound for the closed set restricts to the open one. -/
+theorem levelSet_subset_closedLevelSet (P : ℂ[X]) (C : ℝ) :
+    Erdos1215.levelSet P C ⊆ closedLevelSet P C := by
+  intro z hz
+  simp only [Erdos1215.levelSet, closedLevelSet, Set.mem_setOf_eq] at hz ⊢
+  exact le_of_lt hz
+
+end Erdos1215UnitCircleMonotone

--- a/src/data/research/problems/erdos-1215-oq-02.json
+++ b/src/data/research/problems/erdos-1215-oq-02.json
@@ -40,8 +40,9 @@
     }
   },
   "knowledge": {
-    "progressSummary": "AREA BOUND (researcher-11, 2026-07-12, VERIFIED 0-axiom): new Erdos1215UnitCircleArea.lean lifts the radius sandwich to an explicit PLANAR-AREA sandwich π·(C^{1/deg}−1)² ≤ area({|P|≤C}) ≤ π·(1+C^{1/deg})² (C≥1) for every IsUnitCirclePolynomial, plus finiteness via compactness. Root-independent quantitative confinement of the Mac Lane labyrinth region. --- FOLLOW-UP (researcher-7, 2026-07-11, VERIFIED 0-axiom): added the INNER confinement dual to the outer sublevel bound — norm_eval_le_pow_add_one (|P(z)|≤(‖z‖+1)^deg) and closedBall_subset_closedLevelSet (sublevel set ⊇ closedBall(0,C^{1/deg}−1) for C≥1), sandwiching the sublevel set between radii C^{1/deg}∓1. --- PROGRESS (researcher-8, 2026-07-11): realized the research nextStep 'the sublevel set is compact' — extended Erdos1215UnitCircleRadius.lean (176→241L, +5 thm +1 def, 0-sorry/0-axiom [propext,Classical.choice,Quot.sound]) from the OPEN level set to the CLOSED sublevel set. Added norm_le_sharp_of_norm_eval_le (≤-variant of the sharp radius: |P(z)|≤C ⟹ ‖z‖≤1+C^{1/deg}); closedLevelSet def {z:|P(z)|≤C}; isClosed_closedLevelSet (preimage of closed ball under continuous |P|=P.continuous.norm); isBounded_closedLevelSet (sharp radius); and the capstone isCompact_closedLevelSet (Heine–Borel Metric.isCompact_of_isClosed_isBounded in ℂ). Compactness precondition for reducing Mac Lane path-length to component geometry. Deep maclane_labyrinth axiom (base #1215) still open. PROGRESS (researcher-3 2026-07-11): New file Erdos1215UnitCircleRadiusLimit.lean (4 results, 0-sorry / 0-axiom; #pr",
+    "progressSummary": "MONOTONICITY & MEMBERSHIP (researcher-5, 2026-07-12, VERIFIED 0-axiom): new file Erdos1215UnitCircleMonotone.lean records how the closed sublevel set closedLevelSet P C = {|P|<=C} behaves as a function of the LEVEL C (the radius/area sandwiches all fix C). closedLevelSet_mono (C1<=C2 => set inclusion; the labyrinth region only grows with C), volume_closedLevelSet_mono (hence planar Lebesgue measure is nondecreasing in C, via measure_mono), isRoot_mem_closedLevelSet (every root lies in the set for C>=0, |P|=0 there), zero_mem_closedLevelSet (origin lies in the set for C>=1, since P(0)=1 for a unit-circle poly), closedLevelSet_nonempty (C>=1 => nonempty via 0), and levelSet_subset_closedLevelSet (the open Mac Lane region {|P|<C} sits inside the closed {|P|<=C}). 6 theorems, all [propext,Classical.choice,Quot.sound]. --- AREA BOUND (researcher-11, 2026-07-12, VERIFIED 0-axiom): new Erdos1215UnitCircleArea.lean lifts the radius sandwich to an explicit PLANAR-AREA sandwich π·(C^{1/deg}−1)² ≤ area({|P|≤C}) ≤ π·(1+C^{1/deg})² (C≥1) for every IsUnitCirclePolynomial, plus finiteness via compactness. Root-independent quantitative confinement of the Mac Lane labyrinth region. --- FOLLOW-UP (researcher-7, 2026-07-11, VERIFIED 0-axiom): added the INNER confinement dual to the outer sublevel bound — norm_eval_le_pow_add_one (|P(z)|≤(‖z‖+1)^deg) and closedBall_subset_closedLevelSet (sublevel set ⊇ closedBall(0,C^{1/deg}−1) for C≥1), sandwiching the sublevel set between radii C^{1/deg}∓1. --- PROGRESS (researcher-8, 2026-07-11): realized the research nextStep 'the sublevel set is compact' — extended Erdos1215UnitCircleRadius.lean (176→241L, +5 thm +1 def, 0-sorry/0-axiom [propext,Classical.choice,Quot.sound]) from the OPEN level set to the CLOSED sublevel set. Added norm_le_sharp_of_norm_eval_le (≤-variant of the sharp radius: |P(z)|≤C ⟹ ‖z‖≤1+C^{1/deg}); closedLevelSet def {z:|P(z)|≤C}; isClosed_closedLevelSet (preimage of closed ball under continuous |P|=P.continuous.norm); isBounded_closedLevelSet (sharp radius); and the capstone isCompact_closedLevelSet (Heine–Borel Metric.isCompact_of_isClosed_isBounded in ℂ). Compactness precondition for reducing Mac Lane path-length to component geometry. Deep maclane_labyrinth axiom (base #1215) still open. PROGRESS (researcher-3 2026-07-11): New file Erdos1215UnitCircleRadiusLimit.lean (4 results, 0-sorry / 0-axiom; #pr",
     "builtItems": [
+      "Erdos1215UnitCircleMonotone.lean (researcher-5, 2026-07-12, 0-axiom VERIFIED): monotone/membership block for the sublevel set as a function of the level C — closedLevelSet_mono (C1<=C2 => closedLevelSet P C1 subset closedLevelSet P C2), volume_closedLevelSet_mono (measure nondecreasing in C via measure_mono), isRoot_mem_closedLevelSet (roots in set for C>=0), zero_mem_closedLevelSet (0 in set for C>=1 via P(0)=1), closedLevelSet_nonempty (C>=1), levelSet_subset_closedLevelSet (open {|P|<C} subset closed {|P|<=C}). 6 thm [propext,Classical.choice,Quot.sound].",
       "eventually_levelSet_subset_closedBall (Erdos1215UnitCircleRadiusLimit.lean): for C>=1, eps>0, one degree threshold K confines the level set of EVERY unit-circle polynomial of degree>=K to closedBall 0 (2+eps) -- uniform confinement of the whole high-degree Mac Lane class (VERIFIED 0/0)",
       "sharpRadius_ge_two / sharpRadius_antitone / tendsto_sharpRadius (Erdos1215UnitCircleRadiusLimit.lean): the general-class sharp radius 1+C^(1/deg P) has floor 2, is antitone in degree, and tends to 2 (VERIFIED 0/0)",
       "norm_cyclotomic_eval (CyclotomicPolynomialsOQ02OQ01.lean): |Phi_n(z)| = prod distances to primitive roots, via cyclotomic_eq_prod_X_sub_primitiveRoots + norm_prod (VERIFIED 0/0)",
@@ -120,7 +121,18 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1215UnitCircleRadius.lean"
+    },
+    {
+      "path": "Proofs/Erdos1215UnitCircleMonotone.lean",
+      "filename": "Erdos1215UnitCircleMonotone.lean",
+      "lineCount": 90,
+      "theoremCount": 6,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1215UnitCircleMonotone.lean"
     }
   ],
-  "lastUpdate": "2026-07-11T00:00:00.000Z"
+  "lastUpdate": "2026-07-12"
 }


### PR DESCRIPTION
## Summary

New file `proofs/Proofs/Erdos1215UnitCircleMonotone.lean`. The existing radius sandwich (`Erdos1215UnitCircleRadius.lean`) and planar-area sandwich (`Erdos1215UnitCircleArea.lean`) both pin the geometry of the closed sublevel set `closedLevelSet P C = {z | ‖P.eval z‖ ≤ C}` for a **fixed** level `C`. This file records how that Mac Lane labyrinth region behaves as a function of the level parameter `C` itself, plus the two canonical points it always contains:

- **`closedLevelSet_mono`** — `C₁ ≤ C₂ ⟹ closedLevelSet P C₁ ⊆ closedLevelSet P C₂` (the region only grows as the level rises).
- **`volume_closedLevelSet_mono`** — hence its planar Lebesgue measure is nondecreasing in `C` (`measure_mono`).
- **`isRoot_mem_closedLevelSet`** — every root of `P` lies in the set for `C ≥ 0` (there `‖P‖ = 0`); the roots are its innermost points.
- **`zero_mem_closedLevelSet`** — the origin lies in the set for `C ≥ 1` (a unit-circle polynomial has `P(0) = 1`, so `‖P(0)‖ = 1`).
- **`closedLevelSet_nonempty`** — the set is nonempty for `C ≥ 1` (contains `0`).
- **`levelSet_subset_closedLevelSet`** — the open Mac Lane region `{‖P‖ < C}` sits inside the closed `{‖P‖ ≤ C}` on which the sandwiches are proved.

## Verification

- `#print axioms` on all six → `[propext, Classical.choice, Quot.sound]` (0 extra axioms).
- Builds green via `lake env lean` against Mathlib v4.26 (imports `Proofs.Erdos1215UnitCircleRadius`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)