### PR TITLE
Research: sylow-theorem-oq-04-oq-03 — every Sylow-p is ℤ/p, distinct ones meet trivially [VERIFIED axiom-free]

### DIFF
--- a/proofs/Proofs/SylowTheoremOQ04OQ03.lean
+++ b/proofs/Proofs/SylowTheoremOQ04OQ03.lean
@@ -1390,6 +1390,60 @@ theorem card_sylow_eq (hp : 5 ≤ p) :
   have hge := card_sylow_ge hp
   exact sylow_count_arith hp hdvd hmod hge
 
+/-! ### Every Sylow `p`-subgroup is a copy of `ℤ/p`, and distinct ones meet trivially
+
+`unipotentSylow` is one explicit Sylow `p`-subgroup, cyclic of order `p`
+(`isCyclic_unipotentSylow`).  Since all Sylow `p`-subgroups are conjugate they share these
+properties: **every** Sylow `p`-subgroup of `SL(2, p)` has order exactly `p` (`card_sylowP`)
+and is therefore cyclic `≅ ℤ/p` (`isCyclic_sylowP`).  As subgroups of prime order, two
+*distinct* Sylow `p`-subgroups intersect trivially (`sylowP_inf_eq_bot`): the `p + 1` Sylow
+`p`-subgroups (`card_sylow_eq`) overlap only in the identity.  These are the exact
+ingredients of the classical count "`SL(2, p)` has `(p+1)(p-1) = p² - 1` elements of order
+`p`". -/
+
+/-- **Every Sylow `p`-subgroup of `SL(2, p)` has order exactly `p`.**  The `p`-part of the
+group order is `p ^ 1` (`factorization_card_SL2`), and a Sylow `p`-subgroup realises the full
+`p`-part (`Sylow.card_eq_multiplicity`).  Generalises `card_unipotentHom_range` from the one
+explicit unipotent Sylow to every Sylow `p`-subgroup. -/
+theorem card_sylowP (P : Sylow p (Matrix.SpecialLinearGroup (Fin 2) (ZMod p))) :
+    Nat.card (P : Subgroup (Matrix.SpecialLinearGroup (Fin 2) (ZMod p))) = p := by
+  rw [P.card_eq_multiplicity, factorization_card_SL2, pow_one]
+
+/-- **Every Sylow `p`-subgroup of `SL(2, p)` is cyclic `≅ ℤ/p`.**  It has prime order `p`
+(`card_sylowP`), and any group of prime order is cyclic (`isCyclic_of_prime_card`).  This
+generalises `isCyclic_unipotentSylow` from the one explicit unipotent Sylow to *all* of them. -/
+theorem isCyclic_sylowP (P : Sylow p (Matrix.SpecialLinearGroup (Fin 2) (ZMod p))) :
+    IsCyclic (P : Subgroup (Matrix.SpecialLinearGroup (Fin 2) (ZMod p))) :=
+  isCyclic_of_prime_card (card_sylowP P)
+
+/-- **Distinct Sylow `p`-subgroups of `SL(2, p)` intersect trivially.**  Each has prime order
+`p` (`card_sylowP`), so `P ⊓ Q ≤ P` has order dividing `p`: either `1` (giving `P ⊓ Q = ⊥`)
+or `p`, in which case `P ⊓ Q = P` and, by symmetry, `= Q`, forcing `P = Q` and contradicting
+`P ≠ Q`.  Hence the `p + 1` Sylow `p`-subgroups pairwise meet only in the identity — the
+disjointness underlying the classical order-`p` element count. -/
+theorem sylowP_inf_eq_bot {P Q : Sylow p (Matrix.SpecialLinearGroup (Fin 2) (ZMod p))}
+    (hPQ : P ≠ Q) :
+    (P : Subgroup (Matrix.SpecialLinearGroup (Fin 2) (ZMod p)))
+      ⊓ (Q : Subgroup (Matrix.SpecialLinearGroup (Fin 2) (ZMod p))) = ⊥ := by
+  have hp : Nat.Prime p := Fact.out
+  set G := Matrix.SpecialLinearGroup (Fin 2) (ZMod p) with hG
+  have hle : (P : Subgroup G) ⊓ (Q : Subgroup G) ≤ (P : Subgroup G) := inf_le_left
+  -- `|P ⊓ Q|` divides `|P| = p`.
+  have hdvd : Nat.card ((P : Subgroup G) ⊓ (Q : Subgroup G) : Subgroup G) ∣ p := by
+    have h := Subgroup.card_subgroup_dvd_card
+      (((P : Subgroup G) ⊓ (Q : Subgroup G)).subgroupOf (P : Subgroup G))
+    rwa [Nat.card_congr (Subgroup.subgroupOfEquivOfLe hle).toEquiv, card_sylowP] at h
+  rcases (Nat.dvd_prime hp).mp hdvd with h1 | hpc
+  · -- order 1 ⟹ trivial
+    exact Subgroup.card_eq_one.mp h1
+  · -- order p ⟹ `P ⊓ Q = P` and `= Q`, so `P = Q`, contradiction
+    exfalso
+    have hPeq : (P : Subgroup G) ⊓ (Q : Subgroup G) = (P : Subgroup G) :=
+      Subgroup.eq_of_le_of_card_ge hle (le_of_eq (by rw [card_sylowP, hpc]))
+    have hQeq : (P : Subgroup G) ⊓ (Q : Subgroup G) = (Q : Subgroup G) :=
+      Subgroup.eq_of_le_of_card_ge inf_le_right (le_of_eq (by rw [card_sylowP, hpc]))
+    exact hPQ (Sylow.ext (hPeq.symm.trans hQeq))
+
 end SylowOQ04OQ03
 
 #print axioms SylowOQ04OQ03.sylow_count_arith

--- a/research/problems/sylow-theorem-oq-04-oq-03/state.md
+++ b/research/problems/sylow-theorem-oq-04-oq-03/state.md
@@ -122,3 +122,31 @@ unsolvable) — bind `have hrr : r*r=1 := by rw[← pow_two]; exact hr` FIRST to
 
 REMAINING: Next math steps toward Iwasawa simplicity — PSL(2,p) action on P¹(𝔽_p) +
 2-transitivity + Borel point-stabilizers (the >1000-line Mathlib gap). Order formula now DONE.
+
+## Progress This Iteration (iter 6, 2026-07-12, researcher-3) — VERIFIED, 0-axiom
+
+Generalised the file's unipotent-specific Sylow facts to **all** Sylow p-subgroups, and
+added the trivial-intersection structure (all `#print axioms` = propext/Classical.choice/
+Quot.sound; whole file `lake env lean` EXIT 0, only pre-existing warnings in untouched
+Bruhat theorems):
+
+- `card_sylowP (P) : Nat.card ↑P = p` — every Sylow p-subgroup has order exactly p
+  (`Sylow.card_eq_multiplicity` + `factorization_card_SL2`, pow_one), generalising
+  `card_unipotentHom_range`.
+- `isCyclic_sylowP (P) : IsCyclic ↑P` — hence every Sylow p-subgroup is cyclic ℤ/p
+  (`isCyclic_of_prime_card`), generalising `isCyclic_unipotentSylow`.
+- `sylowP_inf_eq_bot (P ≠ Q) : ↑P ⊓ ↑Q = ⊥` — distinct Sylow p-subgroups meet trivially.
+  `|P⊓Q| ∣ |P| = p` (via `card_subgroup_dvd_card` on `(P⊓Q).subgroupOf P` +
+  `subgroupOfEquivOfLe`), so it is 1 (→ ⊥ by `Subgroup.card_eq_one`) or p, and the p-case
+  forces `P⊓Q = P = Q` (`Subgroup.eq_of_le_of_card_ge`) ⟹ `P = Q` (`Sylow.ext`), contra.
+
+These are the exact ingredients of the classical count "SL(2,p) has (p+1)(p−1)=p²−1 elements
+of order p": the p+1 (`card_sylow_eq`) cyclic-ℤ/p Sylows overlapping only in the identity.
+File 1397→1451 L, 59→62 thm. meta.json synced (leanFile 1205/51 stale → 1451/62). The deep
+PSL(2,p) simplicity (P¹ action + 2-transitivity + Iwasawa) remains BLOCKED as before.
+
+### Next Action (updated)
+The order-p element count `p²−1` itself (biUnion of the p+1 Sylows minus identity, using
+`sylowP_inf_eq_bot` for disjointness + "every order-p element generates a Sylow") is the
+natural next tractable step; the simplicity theorem stays blocked on the missing P¹-action
+infrastructure.

--- a/src/data/proofs/sylow-theorem-oq-04-oq-03/meta.json
+++ b/src/data/proofs/sylow-theorem-oq-04-oq-03/meta.json
@@ -24,8 +24,8 @@
     "dateAdded": "2026-07-04",
     "axiomCount": 0,
     "assumptions": "No assumptions: 0 `axiom` declarations, 0 sorries, 0 structure-encoded hypotheses, no `native_decide` (so no `Lean.ofReduceBool`). `#print axioms` for `torusHom_conj_unipotent` and `card_torus_range` reports only the ordinary foundational axioms `propext`, `Classical.choice`, `Quot.sound`. Every result is machine-checked from Mathlib. The parent simplicity theorem for PSL(2, p) remains open; this entry proves only the verified unipotent-subgroup and split-torus infrastructure and makes no claim about the open question itself.",
-    "lineCount": 1370,
-    "theoremCount": 56,
+    "lineCount": 1451,
+    "theoremCount": 62,
     "definitionCount": 9,
     "originalContributions": [
       "unipotentUpper: the matrix [[1,t],[0,1]] packaged as a determinant-1 element of SL(2, ZMod p)",
@@ -269,12 +269,12 @@
     }
   ],
   "leanFile": {
-    "lineCount": 1205,
+    "lineCount": 1451,
     "path": "Proofs/SylowTheoremOQ04OQ03.lean",
     "axiomCount": 0,
     "sorries": 0,
     "definitionCount": 9,
-    "theoremCount": 51
+    "theoremCount": 62
   },
   "sorries": 0
 }


### PR DESCRIPTION
## Summary
Research session for **sylow-theorem-oq-04-oq-03** (PSL(2,p) simplicity via Sylow theory). Generalises the file's unipotent-specific Sylow facts to **all** Sylow p-subgroups of SL(2,p) and adds the pairwise-disjointness structure.

## Progress
New lemmas in `proofs/Proofs/SylowTheoremOQ04OQ03.lean` (all axiom-free):
- `card_sylowP` — **every** Sylow p-subgroup has order exactly `p` (`Sylow.card_eq_multiplicity` + `factorization_card_SL2`), generalising `card_unipotentHom_range`.
- `isCyclic_sylowP` — hence every Sylow p-subgroup is cyclic `≅ ℤ/p` (`isCyclic_of_prime_card`), generalising `isCyclic_unipotentSylow`.
- `sylowP_inf_eq_bot` — distinct Sylow p-subgroups intersect trivially: `|P ⊓ Q| ∣ |P| = p` (via `card_subgroup_dvd_card` on `(P⊓Q).subgroupOf P`), so it is `1` (⟹ `⊥`) or `p`, and the `p`-case forces `P ⊓ Q = P = Q` (`Subgroup.eq_of_le_of_card_ge` + `Sylow.ext`), contradicting `P ≠ Q`.

## Findings
These are exactly the ingredients of the classical count "**SL(2,p) has `(p+1)(p−1) = p²−1` elements of order p**": the `p+1` Sylow p-subgroups (`card_sylow_eq`) are each cyclic ℤ/p and overlap only in the identity.

## Verification
`./bin/lake env lean Proofs/SylowTheoremOQ04OQ03.lean` exit 0 (Mathlib-only import, self-contained). `#print axioms` on all three = `[propext, Classical.choice, Quot.sound]`.

Counts: file 1397→1451 lines, 59→62 thm, 0 axioms, 0 sorries. `meta.json` synced (leanFile was stale at 1205/51).

## Status
**Outcome**: progress (3 axiom-free structural theorems). 
**Next Steps**: the order-p element count `p²−1` itself (biUnion of the p+1 Sylows minus identity, using `sylowP_inf_eq_bot`) is the natural next tractable step. The deep PSL(2,p) simplicity theorem remains BLOCKED on the missing P¹(𝔽_p)-action / 2-transitivity / Iwasawa infrastructure (>1000 lines, absent from Mathlib).

🤖 Generated by researcher-3