### PR TITLE
feat: blocked-route registry — reopen-criterion structure for tracker blockers

### DIFF
--- a/.claude/commands/lean-research.md
+++ b/.claude/commands/lean-research.md
@@ -280,6 +280,27 @@ the parent's "Must prove exactly / does not count" section (see
 [Pin the Statement Before Attacking](#pin-the-statement-before-attacking-mandatory)
 — an equivalent same-strength restatement is already a named near-miss there).
 
+**Blocked-route registry (tracker JSON shape, issue #38388).** Record blocked
+routes in the problem tracker `src/data/research/problems/<id>.json` under
+`currentState.blockers`. Entries are either a legacy plain string (valid
+forever) or — REQUIRED for new blocked-route entries — a structured object:
+
+```json
+{
+  "route": "second-moment / L² averaging",
+  "reopenCriterion": "materially new mechanism required",
+  "blockedAt": "2026-07-12"
+}
+```
+
+`route` names the blocked approach by mathematical mechanism;
+`reopenCriterion` states when it may be retried (default, and the bar for
+equivalent-strength blocks: "materially new mechanism required");
+`blockedAt` is an optional ISO date. **Enforcement:** do not re-attempt a
+blocked route unless its `reopenCriterion` is met. An entry without an
+explicit criterion (including every legacy string entry) carries the implicit
+default "materially new mechanism required".
+
 ---
 
 ## Mode 1: FRESH
@@ -677,7 +698,9 @@ When several researchers work one problem or problem family concurrently
   properly blocked. A route stalling at a lemma of equivalent strength to the
   target is blocked per the equivalent-strength check (see
   [Follow-Up Question Generation](#follow-up-question-generation-after-solved))
-  — reopen bar: "materially new mechanism required".
+  — reopen bar: "materially new mechanism required". Record it as a structured
+  `currentState.blockers` entry (`{ route, reopenCriterion, blockedAt? }`) per
+  the blocked-route registry above.
 
 **Spawner-side convention (binding on the orchestrator/operator, not just
 researchers):** when dispatching multiple researchers onto one problem family,

--- a/.lean/roles/researcher.md
+++ b/.lean/roles/researcher.md
@@ -246,6 +246,27 @@ the parent's "Must prove exactly / does not count" section in
 `research/problems/<slug>/problem.md` (element 5 in `research/PROBLEMS-STRUCTURE.md`)
 — an equivalent same-strength restatement is already a named near-miss there.
 
+**Blocked-route registry (tracker JSON shape, issue #38388).** Record blocked
+routes in the problem tracker `src/data/research/problems/<id>.json` under
+`currentState.blockers`. Entries are either a legacy plain string (valid
+forever) or — REQUIRED for new blocked-route entries — a structured object:
+
+```json
+{
+  "route": "second-moment / L² averaging",
+  "reopenCriterion": "materially new mechanism required",
+  "blockedAt": "2026-07-12"
+}
+```
+
+`route` names the blocked approach by mathematical mechanism;
+`reopenCriterion` states when it may be retried (default, and the bar for
+equivalent-strength blocks: "materially new mechanism required");
+`blockedAt` is an optional ISO date. **Enforcement:** do not re-attempt a
+blocked route unless its `reopenCriterion` is met. An entry without an
+explicit criterion (including every legacy string entry) carries the implicit
+default "materially new mechanism required".
+
 **OQ-chain depth guard (MANDATORY).** Follow-up questions become child gallery
 entries via the Seeker (`<parent>-oq-NN`), which can recurse without bound. Before
 proposing any follow-up:
@@ -287,7 +308,9 @@ When several researchers work one problem or problem family concurrently
   another researcher's route looks favored; converge only when your route is
   properly blocked. A route stalling at a lemma of equivalent strength to the
   target is blocked per the equivalent-strength check above — reopen bar:
-  "materially new mechanism required".
+  "materially new mechanism required". Record it as a structured
+  `currentState.blockers` entry (`{ route, reopenCriterion, blockedAt? }`) per
+  the blocked-route registry above.
 
 **Spawner-side convention (binding on the orchestrator/operator, not just
 researchers):** when dispatching multiple researchers onto one problem family,

--- a/src/pages/ResearchProblemPage.tsx
+++ b/src/pages/ResearchProblemPage.tsx
@@ -6,6 +6,7 @@ import { MarkdownMath } from '@/components/ui/markdown-math'
 // PHASE_INFO available if needed for phase styling
 // import { PHASE_INFO } from '@/types/research'
 import type { ResearchProblem } from '@/types/research'
+import { blockerText } from '@/types/research'
 import {
   ArrowLeft,
   FlaskConical,
@@ -303,12 +304,14 @@ export function ResearchProblemPage() {
                         <p className="text-sm text-muted-foreground">{problem.currentState.focus}</p>
                       </div>
                     )}
-                    {problem.currentState.blockers.length > 0 && (
+                    {/* Tolerant guard: a few tracker JSONs carry a non-array
+                        `blockers` (or a string `currentState`) — never crash on them */}
+                    {Array.isArray(problem.currentState.blockers) && problem.currentState.blockers.length > 0 && (
                       <div className="p-3 bg-red-500/10 border border-red-500/30 rounded">
                         <p className="text-sm font-medium text-red-400 mb-1">Blockers</p>
                         <ul className="list-disc list-inside text-sm text-red-400/80">
                           {problem.currentState.blockers.map((blocker, i) => (
-                            <li key={i}>{blocker}</li>
+                            <li key={i}>{blockerText(blocker)}</li>
                           ))}
                         </ul>
                       </div>

--- a/src/types/research.ts
+++ b/src/types/research.ts
@@ -195,6 +195,55 @@ export interface KnownResults {
 }
 
 /**
+ * A structured blocked-route entry (blocked-route registry, see issue #38388).
+ *
+ * New blocked-route entries MUST use this object form with an explicit
+ * `reopenCriterion`. Legacy plain-string entries remain valid forever and
+ * carry the implicit default criterion `DEFAULT_REOPEN_CRITERION`.
+ */
+export interface BlockerEntry {
+  /** What is blocked — the route/approach identity (by mathematical mechanism) */
+  route: string
+  /** When the route may be retried; default: "materially new mechanism required" */
+  reopenCriterion: string
+  /** ISO date the route was blocked (optional) */
+  blockedAt?: string
+}
+
+/**
+ * A blocker is either a legacy plain string or a structured BlockerEntry.
+ */
+export type Blocker = string | BlockerEntry
+
+/**
+ * Default reopen bar for blocked routes (see .lean/roles/researcher.md and
+ * .claude/commands/lean-research.md — equivalent-strength check).
+ */
+export const DEFAULT_REOPEN_CRITERION = 'materially new mechanism required'
+
+/**
+ * Tolerant display text for a blocker entry (single source of truth).
+ *
+ * - Legacy strings render verbatim.
+ * - Structured entries render as `route — reopen: criterion`.
+ * - Pre-schema "wildcat" objects (ad-hoc keys already in the data) fall back
+ *   through `description`/`summary` before JSON.stringify, so nothing ever
+ *   renders as "[object Object]".
+ */
+export function blockerText(b: Blocker): string {
+  if (typeof b === 'string') return b
+  const entry = b as Partial<BlockerEntry> & { description?: unknown; summary?: unknown }
+  const label =
+    (typeof entry.route === 'string' && entry.route) ||
+    (typeof entry.description === 'string' && entry.description) ||
+    (typeof entry.summary === 'string' && entry.summary) ||
+    JSON.stringify(b)
+  return typeof entry.reopenCriterion === 'string' && entry.reopenCriterion !== ''
+    ? `${label} — reopen: ${entry.reopenCriterion}`
+    : label
+}
+
+/**
  * Current state of research on a problem
  */
 export interface ResearchState {
@@ -203,7 +252,7 @@ export interface ResearchState {
   iteration: number
   focus: string
   activeApproach?: string
-  blockers: string[]
+  blockers: Blocker[]
   nextAction: string
   attemptCounts: {
     total: number


### PR DESCRIPTION
## Summary

Implements the curated spec of #38388: blocker entries in `src/data/research/problems/*.json` (`currentState.blockers`) may now be either a legacy plain string (valid forever) or a structured `BlockerEntry` `{ route, reopenCriterion, blockedAt? }` operationalizing the "materially new mechanism required" reopen bar from #38385/#37505. No big-bang data migration — zero data files touched.

## Changes

- **`src/types/research.ts`** — `BlockerEntry` interface (required `route` + `reopenCriterion`, optional `blockedAt`), `Blocker = string | BlockerEntry` union, `ResearchState.blockers: Blocker[]` (was `string[]`, already violated by 14 wildcat objects in the wild), `DEFAULT_REOPEN_CRITERION` constant, and the tolerant `blockerText` helper (single source of truth: strings verbatim; objects as `route — reopen: criterion`; wildcat fallback through `description`/`summary` then `JSON.stringify` — never `[object Object]`).
- **`src/pages/ResearchProblemPage.tsx`** — blockers list renders via `blockerText` (fixes the latent `[object Object]` bug for the 14 existing wildcat entries across 7 files) plus an `Array.isArray` guard: 88 tracker files carry a string `currentState` and 1 a string `blockers`, all of which would throw at the blockers line today.
- **`.claude/commands/lean-research.md`** + **`.lean/roles/researcher.md`** — object-form JSON shape documented directly after the equivalent-strength-check reopen-bar prose, with the enforcement half (do not re-attempt a blocked route unless its `reopenCriterion` is met; entries without a criterion, including all legacy strings, default to "materially new mechanism required"); one-line pointers added at the independence-preservation bullets. #38385/#38389 text untouched.
- **No change (verified per spec)**: `scripts/research/build.ts` still emits `string[]` (assignable to `Blocker[]`); `ContributeSection.tsx` is a prose mention only.

## Test plan (all run in the worktree at origin/main `c93a9396cf`)

1. **Parse-all**: `find src/data/research/problems -name '*.json' | xargs jq -e .` — all 3,033 files parse.
2. **Census re-run**: 638 array-form entries = 624 strings + 14 objects (matches the curated census exactly).
3. **Typecheck**: `tsc -b --force` green (after restoring the two untracked generated manifest artifacts from the main workspace — their absence is a pre-existing generated-file gap, unrelated).
4. **Bundle**: `vite build` green (12s). Full `pnpm build` not run because its prebuild steps (`research:sync` etc.) mutate tracker data.
5. **Render-logic verification**: a tsx script exercised `blockerText` against **all 638 real entries** plus the canonical new-form entry and an empty-object edge case — 0 throws, 0 `[object Object]`, 0 empty outputs; canonical entry renders `second-moment / L² averaging — reopen: materially new mechanism required`.
6. **Grep checks**: `reopenCriterion` hits all four surfaces; `materially new mechanism required` appears 4× in each doc file.
7. **Lint**: `eslint` on both touched TS files — the single `react-hooks/set-state-in-effect` error at `ResearchProblemPage.tsx:68` is **pre-existing** (reproduced verbatim on the HEAD version of the file); no new lint issues introduced.

Closes #38388

🤖 Generated with [Claude Code](https://claude.com/claude-code)