### PR TITLE
Research: erdos-634 — general-k reptile shape (each k²-subdivision cell is a ±1/k homothety of the whole)

### DIFF
--- a/proofs/Proofs/Erdos634MedialHomothetyOQ01.lean
+++ b/proofs/Proofs/Erdos634MedialHomothetyOQ01.lean
@@ -1,0 +1,149 @@
+/-
+# Erdős Problem #634 (OQ-01) — Each k²-subdivision cell is a `1/k`-scale homothetic copy
+
+Source: Erdős Problem #634 (erdosproblems.com/634), open question
+`erdos-634-medial-congruence-oq-01`, the general-`k` reptiling of the base entry
+`Proofs.Erdos634MedialCongruence`. Companion to `Erdos634MedialCongruenceOQ01`
+(the general-`k` *congruence* + `k²` count) and to `Erdos634MedialHomothetyOQ02`
+(the `k = 2` *shape* / homothety statement).
+
+## The gap this closes
+
+`Erdos634MedialCongruenceOQ01` proves that the `k`-subdivision of a triangle
+`A B C` — cutting each side into `k` equal parts and drawing the grid of
+parallels — produces `k²` mutually **congruent** sub-triangles (`cong_U0_Up`,
+`cong_U0_Down`, …), each congruent to the single base cell `U0`.
+
+`Erdos634MedialHomothetyOQ02` supplies the complementary **shape** statement, but
+only for the medial `k = 2` case: each of the four medial pieces is the image of
+the *whole* triangle `A B C` under an explicit homothety of ratio `±½`.
+
+This file lifts that shape statement to **all** `k`.  With the grid point
+`P i j = A + (i/k)(B-A) + (j/k)(C-A)`:
+
+* `Up_eq_homothety`   — the upward cell `(P i j, P (i+1) j, P i (j+1))` is exactly
+  the image of `A B C` under the homothety `x ↦ P i j + (1/k)·(x − A)`, ratio
+  `+1/k` (a `(1/k)`-scale copy of the *whole* triangle, translated into the grid);
+* `Down_eq_homothety` — the downward cell `(P (i+1)(j+1), P i (j+1), P (i+1) j)`
+  is the image of `A B C` under `x ↦ P (i+1)(j+1) − (1/k)·(x − A)`, the
+  ratio `−1/k` homothety (a `180°`-rotated `(1/k)`-scale copy).
+
+Together with `Erdos634MedialCongruenceOQ01.card_pieces` (there are exactly `k²`
+cells) this exhibits the classical **square reptiling**: `A B C` is `k²` copies of
+itself scaled by `1/k`.  This is the honest self-similarity content behind the
+"`k²` is dissectable" positive result — every cell is literally the original
+triangle shrunk by `1/k`, not merely congruent to some fixed sub-cell.
+
+## How it is proved
+
+A point of a cell with barycentric coordinates `(a,b,c)` in the cell's three
+vertices, and the point of the whole triangle with the *same* coordinates
+`(a,b,c)` in `A, B, C`, are related by the stated affine map.  Substituting
+`c = 1 − a − b` (the barycentric constraint) turns each inclusion into a pure
+module identity in `A, B, C` with scalar coefficients that are ring expressions
+in `a, b, i, j, k⁻¹`, closed uniformly by `module`.  The `k = 0` degenerate case
+is handled automatically: there `(k:ℝ)⁻¹ = 0` and every `P i j = A`, so both
+sides collapse to `{A}` and the same identity still holds.
+
+Everything is unconditional and axiom-free — no non-degeneracy hypothesis is
+needed, since these are equalities of parametrised images, not disjointness
+facts.  Via `triHull_eq_convexHull` the corollaries `*_eq_homothety_convexHull`
+phrase the same facts with Mathlib's `convexHull`.
+
+Tags: geometry, erdos, dissection, tiling, reptile, homothety, self-similar, barycentric
+-/
+
+import Mathlib
+import Proofs.Erdos634MedialCoveringOQ02
+import Proofs.Erdos634MedialCongruenceOQ01
+
+set_option linter.unusedSectionVars false
+
+namespace Erdos634MedialHomothetyOQ01
+
+open Erdos634MedialCoveringOQ02 Erdos634MedialCongruenceOQ01
+
+variable {V : Type*} [NormedAddCommGroup V] [NormedSpace ℝ V]
+
+/-! ## The two families of grid homotheties -/
+
+/-- **Upward cell as a `+1/k` homothety of the whole.** The upward sub-triangle
+`(P i j, P (i+1) j, P i (j+1))` of the `k`-subdivision is exactly the image of the
+whole triangle `A B C` under `x ↦ P i j + (1/k)·(x − A)`, the homothety of ratio
+`+1/k` carrying `A ↦ P i j`, `B ↦ P (i+1) j`, `C ↦ P i (j+1)`. -/
+theorem Up_eq_homothety (A B C : V) (k i j : ℕ) :
+    triHull (P A B C k i j) (P A B C k (i + 1) j) (P A B C k i (j + 1))
+      = (fun x => P A B C k i j + (k : ℝ)⁻¹ • (x - A)) '' triHull A B C := by
+  apply Set.Subset.antisymm
+  · rintro x ⟨a, b, c, ha, hb, hc, hs, rfl⟩
+    refine ⟨a • A + b • B + c • C, ⟨a, b, c, ha, hb, hc, hs, rfl⟩, ?_⟩
+    obtain rfl : c = 1 - a - b := by linarith
+    simp only [P]; push_cast; module
+  · rintro x ⟨y, ⟨a, b, c, ha, hb, hc, hs, rfl⟩, rfl⟩
+    refine ⟨a, b, c, ha, hb, hc, hs, ?_⟩
+    obtain rfl : c = 1 - a - b := by linarith
+    simp only [P]; push_cast; module
+
+/-- **Downward cell as a `−1/k` homothety of the whole.** The downward
+sub-triangle `(P (i+1)(j+1), P i (j+1), P (i+1) j)` of the `k`-subdivision is the
+image of `A B C` under `x ↦ P (i+1)(j+1) − (1/k)·(x − A)`, the homothety of ratio
+`−1/k` (a `180°`-rotated `(1/k)`-scale copy) carrying `A ↦ P (i+1)(j+1)`,
+`B ↦ P i (j+1)`, `C ↦ P (i+1) j`. -/
+theorem Down_eq_homothety (A B C : V) (k i j : ℕ) :
+    triHull (P A B C k (i + 1) (j + 1)) (P A B C k i (j + 1)) (P A B C k (i + 1) j)
+      = (fun x => P A B C k (i + 1) (j + 1) - (k : ℝ)⁻¹ • (x - A)) '' triHull A B C := by
+  apply Set.Subset.antisymm
+  · rintro x ⟨a, b, c, ha, hb, hc, hs, rfl⟩
+    refine ⟨a • A + b • B + c • C, ⟨a, b, c, ha, hb, hc, hs, rfl⟩, ?_⟩
+    obtain rfl : c = 1 - a - b := by linarith
+    simp only [P]; push_cast; module
+  · rintro x ⟨y, ⟨a, b, c, ha, hb, hc, hs, rfl⟩, rfl⟩
+    refine ⟨a, b, c, ha, hb, hc, hs, ?_⟩
+    obtain rfl : c = 1 - a - b := by linarith
+    simp only [P]; push_cast; module
+
+/-! ## `convexHull`-phrased corollaries -/
+
+/-- The upward cell as a homothety image, phrased with Mathlib's `convexHull`. -/
+theorem Up_eq_homothety_convexHull (A B C : V) (k i j : ℕ) :
+    convexHull ℝ ({P A B C k i j, P A B C k (i + 1) j, P A B C k i (j + 1)} : Set V)
+      = (fun x => P A B C k i j + (k : ℝ)⁻¹ • (x - A)) '' convexHull ℝ ({A, B, C} : Set V) := by
+  rw [← triHull_eq_convexHull, ← triHull_eq_convexHull, Up_eq_homothety]
+
+/-- The downward cell as a homothety image, phrased with Mathlib's `convexHull`. -/
+theorem Down_eq_homothety_convexHull (A B C : V) (k i j : ℕ) :
+    convexHull ℝ
+        ({P A B C k (i + 1) (j + 1), P A B C k i (j + 1), P A B C k (i + 1) j} : Set V)
+      = (fun x => P A B C k (i + 1) (j + 1) - (k : ℝ)⁻¹ • (x - A)) ''
+          convexHull ℝ ({A, B, C} : Set V) := by
+  rw [← triHull_eq_convexHull, ← triHull_eq_convexHull, Down_eq_homothety]
+
+/-! ## The base cell is the vertex-centred homothety -/
+
+/-- **The base cell is the `1/k`-homothety centred at `A`.** The corner cell
+`U0 = (P 0 0, P 1 0, P 0 1)` is the image of the whole triangle under
+`x ↦ A + (1/k)·(x − A)`, i.e. the homothety of ratio `1/k` centred at the vertex
+`A`.  (This is the `Up 0 0` instance, using `P 0 0 = A`.) -/
+theorem U0_eq_homothety (A B C : V) (k : ℕ) :
+    triHull (U0 A B C k).1 (U0 A B C k).2.1 (U0 A B C k).2.2
+      = (fun x => A + (k : ℝ)⁻¹ • (x - A)) '' triHull A B C := by
+  have hP0 : P A B C k 0 0 = A := by simp [P]
+  simpa only [U0, hP0] using Up_eq_homothety A B C k 0 0
+
+/-! ## The packaged statement -/
+
+/-- **Every cell of the `k`-subdivision is a `(±1/k)`-scale homothetic copy of the
+whole triangle.** Each upward cell is the image of `A B C` under the ratio `+1/k`
+homothety `x ↦ P i j + (1/k)(x − A)`, and each downward cell under the ratio
+`−1/k` homothety `x ↦ P (i+1)(j+1) − (1/k)(x − A)`.  Combined with
+`Erdos634MedialCongruenceOQ01.card_pieces` (there are exactly `k²` cells) this is
+the self-similar "square reptiling": `A B C` is `k²` copies of itself scaled by
+`1/k`. -/
+theorem reptile_cells_are_homotheties (A B C : V) (k i j : ℕ) :
+    triHull (P A B C k i j) (P A B C k (i + 1) j) (P A B C k i (j + 1))
+        = (fun x => P A B C k i j + (k : ℝ)⁻¹ • (x - A)) '' triHull A B C ∧
+    triHull (P A B C k (i + 1) (j + 1)) (P A B C k i (j + 1)) (P A B C k (i + 1) j)
+        = (fun x => P A B C k (i + 1) (j + 1) - (k : ℝ)⁻¹ • (x - A)) '' triHull A B C :=
+  ⟨Up_eq_homothety A B C k i j, Down_eq_homothety A B C k i j⟩
+
+end Erdos634MedialHomothetyOQ01

--- a/proofs/Proofs/ShannonChannelCodingAWGNOQ03OQ01EqualNoise.lean
+++ b/proofs/Proofs/ShannonChannelCodingAWGNOQ03OQ01EqualNoise.lean
@@ -368,4 +368,69 @@ theorem rate_equalNoise_tendsto_wideband {c : ℝ} (hc : 0 < c) (P : ℝ) :
     (hmain.const_mul (1 / 2 : ℝ)).congr (fun n => by ring)
   rwa [show (1 / 2 : ℝ) * (P / c) = P / (2 * c) from by ring] at key
 
+/-! ## The wideband limit as an explicit least upper bound
+
+`rate_equalNoise_le_wideband` caps each finite-`n` rate at `P/(2c)` and
+`rate_equalNoise_tendsto_wideband` shows the scalar sequence
+`g(n) = (n/2)·log(1 + P/(n·c))` converges to `P/(2c)`. Together these upgrade the
+"tendsto + pointwise ceiling" pair into the sharp order-theoretic statement that
+`P/(2c)` is the *least* upper bound — the supremum — of the achievable equal-noise
+rates over all channel counts `n`. The "least" direction needs no monotonicity of
+`g`: any upper bound `b` dominates the limit `P/(2c)` by `le_of_tendsto'`. This is
+Shannon's infinite-bandwidth capacity `C_∞ = P/(2c)` expressed as `⨆ₙ Cₙ`. -/
+
+/-- **Per-`n` wideband ceiling (scalar sequence, every `n : ℕ`).**  For `c > 0`,
+    `P ≥ 0` and *every* `n` (including `n = 0`, where the rate is `0`),
+    `(n/2)·log(1 + P/(n·c)) ≤ P/(2c)`.  The scalar-`ℕ` counterpart of
+    `rate_equalNoise_le_wideband` (stated over `Fintype.card ι`), packaged for the
+    range over which the supremum below is taken. -/
+theorem rate_equalNoise_seq_le_wideband {c : ℝ} (hc : 0 < c) {P : ℝ} (hP : 0 ≤ P)
+    (n : ℕ) :
+    (n : ℝ) / 2 * Real.log (1 + P / (n * c)) ≤ P / (2 * c) := by
+  rcases Nat.eq_zero_or_pos n with h0 | hpos
+  · subst h0
+    simp only [Nat.cast_zero, zero_div, zero_mul]
+    exact div_nonneg hP (by positivity)
+  · have hn : (0 : ℝ) < (n : ℝ) := by exact_mod_cast hpos
+    have hcne : c ≠ 0 := hc.ne'
+    have hnne : (n : ℝ) ≠ 0 := hn.ne'
+    have hnc : 0 < (n : ℝ) * c := mul_pos hn hc
+    have hu : (0 : ℝ) < 1 + P / ((n : ℝ) * c) := by
+      have : 0 ≤ P / ((n : ℝ) * c) := div_nonneg hP hnc.le
+      linarith
+    have hlog : Real.log (1 + P / ((n : ℝ) * c)) ≤ P / ((n : ℝ) * c) := by
+      have h := Real.log_le_sub_one_of_pos hu
+      linarith
+    calc (n : ℝ) / 2 * Real.log (1 + P / ((n : ℝ) * c))
+        ≤ (n : ℝ) / 2 * (P / ((n : ℝ) * c)) :=
+          mul_le_mul_of_nonneg_left hlog (by positivity)
+      _ = P / (2 * c) := by field_simp
+
+/-- **`P/(2c)` is the least upper bound of the equal-noise rates.**  For `c > 0` and
+    `P ≥ 0`, the wideband ceiling `P/(2c)` is the *supremum* of the scalar rate
+    sequence `n ↦ (n/2)·log(1 + P/(n·c))` over all `n : ℕ`:
+    `IsLUB (range g) (P/(2c))`.  The upper-bound half is `rate_equalNoise_seq_le_wideband`;
+    the least-upper-bound half is `le_of_tendsto'` applied to
+    `rate_equalNoise_tendsto_wideband` (any upper bound dominates the limit). This is
+    the explicit least-upper-bound statement requested as the next step, upgrading the
+    tendsto+ceiling pair. -/
+theorem rate_equalNoise_wideband_isLUB {c : ℝ} (hc : 0 < c) {P : ℝ} (hP : 0 ≤ P) :
+    IsLUB (Set.range (fun n : ℕ => (n : ℝ) / 2 * Real.log (1 + P / (n * c))))
+      (P / (2 * c)) := by
+  constructor
+  · rintro y ⟨n, rfl⟩
+    exact rate_equalNoise_seq_le_wideband hc hP n
+  · intro b hb
+    exact le_of_tendsto' (rate_equalNoise_tendsto_wideband hc P)
+      (fun n => hb (Set.mem_range_self n))
+
+/-- **Wideband capacity as an explicit supremum.**  For `c > 0` and `P ≥ 0`,
+    `⨆ₙ (n/2)·log(1 + P/(n·c)) = P/(2c)`.  The closed-form supremum of the achievable
+    equal-noise rates over all channel counts — Shannon's infinite-bandwidth AWGN
+    capacity `C_∞ = P/(2c)` nats — stated as a single equality via
+    `rate_equalNoise_wideband_isLUB`. -/
+theorem rate_equalNoise_iSup {c : ℝ} (hc : 0 < c) {P : ℝ} (hP : 0 ≤ P) :
+    ⨆ n : ℕ, (n : ℝ) / 2 * Real.log (1 + P / (n * c)) = P / (2 * c) :=
+  (rate_equalNoise_wideband_isLUB hc hP).csSup_eq (Set.range_nonempty _)
+
 end ShannonWaterFilling

--- a/research/problems/shannon-channel-coding-awgn-oq-03-oq-01/knowledge.md
+++ b/research/problems/shannon-channel-coding-awgn-oq-03-oq-01/knowledge.md
@@ -1,3 +1,30 @@
+## Session 2026-07-12 (researcher-6) — explicit least-upper-bound P/(2c) = ⨆ₙ Cₙ
+
+Closed prior next-step #2 in `ShannonChannelCodingAWGNOQ03OQ01EqualNoise.lean` (3 theorems,
+0 axioms, 0 sorries):
+
+- `rate_equalNoise_seq_le_wideband` — scalar-ℕ per-n ceiling (n/2)·log(1+P/(nc)) ≤ P/(2c) for
+  EVERY n (incl. n=0 where the rate is 0). The ℕ-indexed counterpart of the existing
+  Fintype-card `rate_equalNoise_le_wideband`, packaged for the range the sup runs over.
+- `rate_equalNoise_wideband_isLUB` — IsLUB (range g) (P/(2c)), g(n)=(n/2)log(1+P/(nc)).
+- `rate_equalNoise_iSup` — ⨆ₙ (n/2)log(1+P/(nc)) = P/(2c) (Shannon C_∞ as a closed-form sup).
+
+KEY INSIGHT: the explicit LUB needs NO monotonicity of g. The "least" half is `le_of_tendsto'`
+applied to the EXISTING `rate_equalNoise_tendsto_wideband` (any upper bound b dominates the limit
+P/(2c) = lim g(n)); the "upper bound" half is the per-n ceiling. The prior next-step framing
+("needs monotonicity of n↦(n/2)log(1+P/(nc))") over-specified the requirement — tendsto alone
+suffices for the sup. Monotonicity in n remains a physically-meaningful (more-subchannels-is-
+better) but strictly-stronger refinement, now demoted to an OPTIONAL next step.
+
+`⨆` = `sSup ∘ Set.range` definitionally, so `IsLUB.csSup_eq` + `Set.range_nonempty` closes the
+iSup equality in term mode.
+
+BUILD: typechecked green via main-repo oleans (`cd proofs && LAKE_UNSAFE=1 ./bin/lake env lean
+<worktree-file>`) — 0 errors. Depth-2 slug. Remaining open: operational coding theorem (parent
+oq-04) and continuous infinite-band integral capacity.
+
+---
+
 # Knowledge Base: shannon-channel-coding-awgn-oq-03-oq-01
 
 Insights accumulated during research on this problem.


### PR DESCRIPTION
## Summary
Research session for **erdos-634** (Triangle dissection into congruent pieces, $25 problem).

Adds `proofs/Proofs/Erdos634MedialHomothetyOQ01.lean` (VERIFIED, 0 axioms / 0 sorries, general normed space `V`), closing the last *shape* gap in the general-`k` reptiling line.

## Progress
Prior state of the general-`k` line:
- `Erdos634MedialCongruenceOQ01` — every cell of the `k`-subdivision is **congruent** to the base sub-cell `U0`, and there are exactly `k²` cells (`card_pieces`).
- `Erdos634MedialHomothetyOQ02` — each piece is a **homothety image of the whole triangle**, but only for `k = 2` (ratio ±½).

This file lifts the whole-triangle homothety (shape) statement to **all `k`**, with `P i j = A + (i/k)(B−A) + (j/k)(C−A)`:
- `Up_eq_homothety` — `triHull (P i j) (P (i+1) j) (P i (j+1)) = (x ↦ P i j + (1/k)•(x−A)) '' triHull A B C` (upward cell = ratio `+1/k` homothety of the whole).
- `Down_eq_homothety` — downward cell = ratio `−1/k` homothety `x ↦ P (i+1)(j+1) − (1/k)•(x−A)`.
- `Up_eq_homothety_convexHull` / `Down_eq_homothety_convexHull` — same via Mathlib `convexHull`.
- `U0_eq_homothety` — base cell is the vertex-centred `1/k` homothety `x ↦ A + (1/k)(x−A)`.
- `reptile_cells_are_homotheties` — packaged Up ∧ Down.

Together with `card_pieces` this is the honest **self-similar reptiling**: `A B C` is `k²` copies of *itself* scaled by `1/k` — not merely `k²` mutually congruent pieces.

## Findings
- Mirroring the `k=2` inclusion recipe fails because the coefficients now carry the symbolic `k⁻¹` (`match_scalars <;> linarith` needs concrete rationals). Substituting the barycentric constraint `c = 1 − a − b` *before* `simp only [P]; push_cast; module` collapses each image identity to a pure module identity (with `k⁻¹` an opaque ring atom), discharged uniformly for both cell families and both inclusions.
- The `k = 0` degenerate case needs no branch: `(0:ℝ)⁻¹ = 0`, every `P i j = A`, both sides collapse to `{A}`.

## Verification
`./proofs/scripts/docker-build.sh Proofs.Erdos634MedialHomothetyOQ01` → `Build completed successfully (7746 jobs)`. No `axiom`/`sorry` declarations; imports only `Mathlib` and the two 0-axiom companion files.

## Status
**Outcome**: progress (new verified 0-axiom entry; general-`k` shape gap closed).
**Next Steps**: the base `Erdos634Problem.lean` still has 5 positive-dissection sorries that require a concrete `Tiles` witness — but `Tiles` is an abstract `axiom … : Prop` with no constructor, so those cannot be discharged without either another axiom or making `Tiles` concrete (a separate design decision on the base file). The quantitative area/measure accounting (needs a Mathlib triangle-area input) and #634's own open classification of achievable `N` remain.

🤖 Generated by researcher-6