### PR TITLE
Research: shannon-entropy-oq-03-incomplete-01 - per-conditioning-value refinement of SSA

### DIFF
--- a/proofs/Proofs/ShannonEntropySSAEq.lean
+++ b/proofs/Proofs/ShannonEntropySSAEq.lean
@@ -568,6 +568,148 @@ theorem ssa_inequality {α β γ : Type*}
   linarith
 
 -- ═══════════════════════════════════════════════════════════════
+-- PART IV′: The per-conditioning-value refinement of SSA
+--
+-- `cmiSum` aggregates the deficit over all values of `Y`.  The natural
+-- strengthening is that the contribution of **each individual** value `y` is
+-- already nonnegative: `I(X;Z | Y=y) ≥ 0`, so SSA holds "locally" at every
+-- conditioning value, not merely on average.  The averaged `cmiSum_nonneg` is
+-- then the sum of these per-slice nonnegativities.
+-- ═══════════════════════════════════════════════════════════════
+
+/-- The **per-`y` slice** of the conditional mutual information: the inner
+    `(x, z)`-sum of `cmiSum` at a fixed value `y` of the conditioning variable.
+    Equals `p_Y(y) · I(X;Z | Y = y)` (a relative entropy weighted by the mass of
+    `y`), with the same zero-probability convention as `cmiSum`. -/
+noncomputable def cmiSlice {α β γ : Type*}
+    [Fintype α] [Fintype β] [Fintype γ]
+    (pXYZ : α × β × γ → ℝ) (y : β) : ℝ :=
+  ∑ x : α, ∑ z : γ,
+    (if pXYZ (x, y, z) = 0 then (0 : ℝ)
+     else pXYZ (x, y, z) * Real.log (pXYZ (x, y, z) *
+       (∑ x' : α, ∑ z' : γ, pXYZ (x', y, z')) /
+       ((∑ z' : γ, pXYZ (x, y, z')) * (∑ x' : α, pXYZ (x', y, z)))))
+
+/-- **The CMI is the sum of its per-`y` slices.**  `I(X;Z|Y) = ∑_y (slice at y)`
+    — purely a reordering of `cmiSum`'s triple sum (`Finset.sum_comm` on the
+    `x`,`y` axes). -/
+theorem cmiSum_eq_sum_cmiSlice {α β γ : Type*}
+    [Fintype α] [Fintype β] [Fintype γ]
+    (pXYZ : α × β × γ → ℝ) :
+    cmiSum pXYZ = ∑ y : β, cmiSlice pXYZ y := by
+  unfold cmiSum cmiSlice
+  rw [Finset.sum_comm]
+
+/-- **Local (per-conditioning-value) strong subadditivity.**  For *every* value
+    `y` of the conditioning variable, the slice `p_Y(y) · I(X;Z | Y=y)` is
+    nonnegative.  This strengthens `cmiSum_nonneg` (which only bounds the average
+    over `y`): SSA is not merely nonnegative on aggregate, it is nonnegative at
+    each conditioning value separately.  Proof: the same Gibbs bound
+    `p − q ≤ p·log(p/q)` used in `cmiSum_nonneg`, summed over just `(x, z)` at the
+    fixed `y`; the reference kernel `q` has the same `(x,z)`-mass as `p` at that
+    `y`, so the linear lower bound telescopes to `0`. -/
+theorem cmiSlice_nonneg {α β γ : Type*}
+    [Fintype α] [Fintype β] [Fintype γ]
+    [DecidableEq α] [DecidableEq β] [DecidableEq γ]
+    {pXYZ : α × β × γ → ℝ} (hp : ∀ xyz, 0 ≤ pXYZ xyz) (y : β) :
+    0 ≤ cmiSlice pXYZ y := by
+  set q := fun x z => (∑ z' : γ, pXYZ (x, y, z')) * (∑ x' : α, pXYZ (x', y, z)) /
+    (∑ x' : α, ∑ z' : γ, pXYZ (x', y, z')) with hq_def
+  have hq_nn : ∀ x z, 0 ≤ q x z := fun x z => by
+    simp only [hq_def]
+    exact div_nonneg
+      (mul_nonneg (Finset.sum_nonneg fun z' _ => hp _) (Finset.sum_nonneg fun x' _ => hp _))
+      (Finset.sum_nonneg fun x' _ => Finset.sum_nonneg fun z' _ => hp _)
+  have hmarg_pos : ∀ x z, pXYZ (x, y, z) ≠ 0 →
+      0 < (∑ z' : γ, pXYZ (x, y, z')) ∧ 0 < (∑ x' : α, pXYZ (x', y, z)) ∧
+      0 < (∑ x' : α, ∑ z' : γ, pXYZ (x', y, z')) := by
+    intro x z hne
+    have hpos : 0 < pXYZ (x, y, z) := lt_of_le_of_ne (hp _) (Ne.symm hne)
+    have hpXY : 0 < ∑ z', pXYZ (x, y, z') :=
+      lt_of_lt_of_le hpos (Finset.single_le_sum (fun z' _ => hp (x, y, z')) (Finset.mem_univ z))
+    have hpYZ : 0 < ∑ x', pXYZ (x', y, z) :=
+      lt_of_lt_of_le hpos (Finset.single_le_sum (fun x' _ => hp (x', y, z)) (Finset.mem_univ x))
+    have hpY : 0 < ∑ x' : α, ∑ z' : γ, pXYZ (x', y, z') :=
+      lt_of_lt_of_le hpXY (Finset.single_le_sum
+        (fun x' _ => Finset.sum_nonneg fun z' _ => hp (x', y, z')) (Finset.mem_univ x))
+    exact ⟨hpXY, hpYZ, hpY⟩
+  have hq_pos_of : ∀ x z, pXYZ (x, y, z) ≠ 0 → 0 < q x z := by
+    intro x z hne
+    obtain ⟨hpXY, hpYZ, hpY⟩ := hmarg_pos x z hne
+    simp only [hq_def]; exact div_pos (mul_pos hpXY hpYZ) hpY
+  have hq_sum : ∑ x : α, ∑ z : γ, q x z = ∑ x, ∑ z, pXYZ (x, y, z) := by
+    simp only [hq_def]
+    by_cases hpy : (∑ x' : α, ∑ z' : γ, pXYZ (x', y, z')) = 0
+    · have hall : ∀ x z, pXYZ (x, y, z) = 0 := by
+        have h2 := (Finset.sum_eq_zero_iff_of_nonneg
+          (fun x _ => Finset.sum_nonneg fun z _ => hp (x, y, z))).mp hpy
+        intro x z
+        exact (Finset.sum_eq_zero_iff_of_nonneg
+          (fun z _ => hp (x, y, z))).mp (h2 x (Finset.mem_univ x)) z (Finset.mem_univ z)
+      simp [hall]
+    · have hD : (∑ x' : α, ∑ z' : γ, pXYZ (x', y, z')) ≠ 0 := hpy
+      have step1 : ∀ x : α, (∑ z : γ,
+            (∑ z' : γ, pXYZ (x, y, z')) * (∑ x' : α, pXYZ (x', y, z))
+              / (∑ x' : α, ∑ z' : γ, pXYZ (x', y, z')))
+          = (∑ z' : γ, pXYZ (x, y, z')) * (∑ z : γ, ∑ x' : α, pXYZ (x', y, z))
+              / (∑ x' : α, ∑ z' : γ, pXYZ (x', y, z')) := by
+        intro x
+        rw [← Finset.sum_div, ← Finset.mul_sum]
+      simp_rw [step1]
+      rw [← Finset.sum_div, ← Finset.sum_mul]
+      rw [show (∑ z : γ, ∑ x' : α, pXYZ (x', y, z)) = ∑ x' : α, ∑ z : γ, pXYZ (x', y, z) from
+        Finset.sum_comm]
+      rw [mul_div_assoc, div_self hD, mul_one]
+  have hcmi_q : cmiSlice pXYZ y = ∑ x : α, ∑ z : γ,
+      (if pXYZ (x, y, z) = 0 then (0 : ℝ)
+       else pXYZ (x, y, z) * Real.log (pXYZ (x, y, z) / q x z)) := by
+    unfold cmiSlice
+    refine Finset.sum_congr rfl (fun x _ => Finset.sum_congr rfl (fun z _ => ?_))
+    by_cases hpxyz : pXYZ (x, y, z) = 0
+    · simp [hpxyz]
+    · rw [if_neg hpxyz, if_neg hpxyz]
+      obtain ⟨hpXY, hpYZ, hpY⟩ := hmarg_pos x z hpxyz
+      have hlog_eq : pXYZ (x, y, z) * (∑ x' : α, ∑ z' : γ, pXYZ (x', y, z')) /
+          ((∑ z' : γ, pXYZ (x, y, z')) * (∑ x' : α, pXYZ (x', y, z))) =
+          pXYZ (x, y, z) / q x z := by
+        simp only [hq_def]
+        field_simp
+      rw [hlog_eq]
+  rw [hcmi_q]
+  have hbound : ∀ x z, pXYZ (x, y, z) - q x z ≤
+      (if pXYZ (x, y, z) = 0 then (0 : ℝ)
+       else pXYZ (x, y, z) * Real.log (pXYZ (x, y, z) / q x z)) := by
+    intro x z
+    by_cases hpxyz : pXYZ (x, y, z) = 0
+    · rw [if_pos hpxyz]; have := hq_nn x z; linarith
+    · rw [if_neg hpxyz]
+      have hpos : 0 < pXYZ (x, y, z) := lt_of_le_of_ne (hp _) (Ne.symm hpxyz)
+      exact kl_lb hpos (hq_pos_of x z hpxyz)
+  have hsum_pq : ∑ x : α, ∑ z : γ, (pXYZ (x, y, z) - q x z) = 0 := by
+    simp only [Finset.sum_sub_distrib]
+    linarith [hq_sum]
+  calc (0 : ℝ) = ∑ x : α, ∑ z : γ, (pXYZ (x, y, z) - q x z) := hsum_pq.symm
+    _ ≤ ∑ x : α, ∑ z : γ,
+          (if pXYZ (x, y, z) = 0 then (0 : ℝ)
+           else pXYZ (x, y, z) * Real.log (pXYZ (x, y, z) / q x z)) :=
+      Finset.sum_le_sum fun x _ => Finset.sum_le_sum fun z _ => hbound x z
+
+/-- **The SSA deficit decomposes into nonnegative per-`y` contributions.**  The
+    entropy deficit `H(X,Y) + H(Y,Z) − H(X,Y,Z) − H(Y)` equals `∑_y (slice at y)`,
+    a sum of terms each `≥ 0` by `cmiSlice_nonneg`.  This is a strictly finer
+    account of *why* SSA holds than `ssa_inequality`: the deficit is not just
+    nonnegative, it is a nonnegative combination indexed by the conditioning
+    value, and it vanishes iff every slice vanishes. -/
+theorem ssa_deficit_eq_sum_cmiSlice {α β γ : Type*}
+    [Fintype α] [Fintype β] [Fintype γ]
+    [DecidableEq α] [DecidableEq β] [DecidableEq γ]
+    {pXYZ : α × β × γ → ℝ} (hp : ∀ xyz, 0 ≤ pXYZ xyz) :
+    shannonEntropy' (marginalXY pXYZ) + shannonEntropy' (marginalYZ pXYZ)
+      - shannonEntropy' pXYZ - shannonEntropy' (marginalY_3 pXYZ)
+    = ∑ y : β, cmiSlice pXYZ y :=
+  (ssa_deficit_eq_cmi hp).trans (cmiSum_eq_sum_cmiSlice pXYZ)
+
+-- ═══════════════════════════════════════════════════════════════
 -- PART V: Equality condition for "conditioning reduces entropy"
 -- ═══════════════════════════════════════════════════════════════
 

--- a/research/problems/shannon-entropy-oq-03-incomplete-01/knowledge.md
+++ b/research/problems/shannon-entropy-oq-03-incomplete-01/knowledge.md
@@ -98,3 +98,27 @@ confirmed correct. No bug (unlike 5 breakages found by verification elsewhere th
 
 Terminus unchanged: the one open direction is a Pinsker-type QUANTITATIVE/STABILITY SSA
 (`cmiSum ≥ ½‖p−q‖₁²`), needing Pinsker's inequality — larger than one session. Marked completed.
+
+## Session 2026-07-12 (researcher-10) — per-conditioning-value refinement of SSA (VERIFIED)
+
+`ShannonEntropySSAEq.lean` was COMPLETE (0-axiom/0-sorry): SSA inequality (`cmiSum_nonneg`),
+equality/Markov characterization, reflectXZ symmetry. Genuine non-cosmetic increment: the
+existing `cmiSum_nonneg` only bounds the deficit AVERAGED over the conditioning variable `Y`.
+Added the **per-`y` refinement** — SSA holds locally at every conditioning value:
+
+- `cmiSlice pXYZ y` (def) — the inner `(x,z)`-sum of `cmiSum` at fixed `y` = `p_Y(y)·I(X;Z|Y=y)`.
+- `cmiSum_eq_sum_cmiSlice : cmiSum pXYZ = ∑ y, cmiSlice pXYZ y` — pure reorder (`Finset.sum_comm`
+  on the x,y axes; after `unfold cmiSum cmiSlice`, one `rw [Finset.sum_comm]`).
+- `cmiSlice_nonneg : 0 ≤ cmiSlice pXYZ y` — the strengthening. Same Gibbs `kl_lb` bound
+  `p−q ≤ p·log(p/q)` as `cmiSum_nonneg`, but summed over just `(x,z)` at the fixed `y`; the
+  reference kernel `q x z = p_XY·p_YZ/p_Y` has the same `(x,z)`-mass as `p` at that `y`
+  (`hq_sum`, the fixed-`y` specialization of the parent proof's `hq_sum_y`), so the linear lower
+  bound telescopes to 0. Proof is `cmiSum_nonneg` with `y` fixed and the `q` kernel 2-ary.
+- `ssa_deficit_eq_sum_cmiSlice` — entropy deficit `H(XY)+H(YZ)−H(XYZ)−H(Y) = ∑_y cmiSlice y`,
+  a nonneg combination indexed by conditioning value (finer account than `ssa_inequality`).
+
+VERIFICATION. ★Docker build of ShannonEntropySSAEq FIRST attempt crashed with **exit 135 = SIGBUS
+during codegen** (no `error:` line printed — the `.ir` C-emission crash noted by researcher-9);
+**a plain retry built green** (`✔ Built (39s)`). File 0 axioms / 0 sorries. 13→16 theorems,
+6→7 defs, ~741→863 lines. Gallery meta shannon-entropy-oq-03-oq-01 synced (lineCount→863,
+theoremCount→16; was stale at 674/12). Open direction unchanged (Pinsker-type quantitative SSA).

--- a/src/data/proofs/shannon-entropy-oq-03-oq-01/meta.json
+++ b/src/data/proofs/shannon-entropy-oq-03-oq-01/meta.json
@@ -146,9 +146,9 @@
       "Finset"
     ],
     "namespace": "InformationTheory",
-    "lineCount": 674,
+    "lineCount": 863,
     "axiomCount": 0,
-    "theoremCount": 12,
+    "theoremCount": 16,
     "definitionCount": 6,
     "path": "Proofs/ShannonEntropySSAEq.lean",
     "sorries": 0

--- a/src/data/research/problems/shannon-entropy-oq-03-incomplete-01.json
+++ b/src/data/research/problems/shannon-entropy-oq-03-incomplete-01.json
@@ -35,10 +35,11 @@
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETE (main SSA inequality + equality/Markov characterization proven axiom-free). This session added the structural SYMMETRY of conditional mutual information I(X;Z|Y)=I(Z;X|Y) (cmiSum_reflectXZ) and its entropy-side deficit form (ssa_deficit_reflectXZ) to gallery oq-03-oq-01. Only remaining open direction is a quantitative/stability (Pinsker-type) SSA, blocked on Mathlib Pinsker usability.",
+    "progressSummary": "COMPLETE (main SSA inequality + equality/Markov characterization axiom-free). Session (researcher-10, 2026-07-12) added the per-conditioning-value REFINEMENT of SSA to ShannonEntropySSAEq.lean: cmiSlice (per-y I(X;Z|Y=y) slice), cmiSum_eq_sum_cmiSlice (CMI = ∑_y slice), cmiSlice_nonneg (each slice ≥0 — SSA holds locally at every y, strengthening cmiSum_nonneg which only bounds the average), and ssa_deficit_eq_sum_cmiSlice (entropy deficit = sum of nonneg per-y contributions). 4 new decls, still 0 axioms/0 sorries. Only remaining open direction is quantitative/stability (Pinsker-type) SSA, blocked on Mathlib Pinsker usability.",
     "builtItems": [
       "cmiSum def + ssa_deficit_eq_cmi + ssa_cmi_eq_zero_iff + strong_subadditivity_eq_iff + cmiSum_nonneg + ssa_inequality (#35820) in Proofs/ShannonEntropySSAEq.lean (self-contained, 0 sorry/0 axiom)",
-      "reflectXZ def + cmiSum_reflectXZ (I(X;Z|Y)=I(Z;X|Y), symmetry of CMI) + ssa_deficit_reflectXZ (SSA deficit symmetric in X,Z on entropy side) in Proofs/ShannonEntropySSAEq.lean (axiom-free [propext,Classical.choice,Quot.sound]); helper private lemma triple_sum_prod flattens triple Finset-sum to product for equiv reindexing"
+      "reflectXZ def + cmiSum_reflectXZ (I(X;Z|Y)=I(Z;X|Y), symmetry of CMI) + ssa_deficit_reflectXZ (SSA deficit symmetric in X,Z on entropy side) in Proofs/ShannonEntropySSAEq.lean (axiom-free [propext,Classical.choice,Quot.sound]); helper private lemma triple_sum_prod flattens triple Finset-sum to product for equiv reindexing",
+      "cmiSlice (def), cmiSum_eq_sum_cmiSlice, cmiSlice_nonneg, ssa_deficit_eq_sum_cmiSlice in ShannonEntropySSAEq.lean"
     ],
     "insights": [
       "Suggested proof route: rewrite the entropy deficit as conditional mutual information and discharge nonnegativity via KL divergence.",
@@ -46,7 +47,9 @@
       "SSA deficit = conditional mutual information I(X;Z|Y) exactly (ssa_deficit_eq_cmi).",
       "I(X;Z|Y)=0 iff the division-free Markov factorization p·p_Y = p_XY·p_YZ holds everywhere; forward via the STRICT KL bound, backward by substitution.",
       "v4.26.0: `hp _` underscore fails to infer in single_le_sum hint lists (need explicit triples); local universe-poly `have` leaks a 4th universe param (extract top-level); conv `ext y` fails on Finset.sum.",
-      "Conditional mutual information is symmetric in its outer arguments: I(X;Z|Y) = I(Z;X|Y). Formalized as cmiSum_reflectXZ — reflecting the joint law by (z,y,x)↦(x,y,z) leaves cmiSum invariant. The defining summand is invariant because its numerator p·p_Y is symmetric and its denominator p_XY·p_YZ merely commutes; proof reindexes the triple sum by the X↔Z coordinate transposition (Fintype.sum_equiv over α×β×γ ≃ γ×β×α)."
+      "Conditional mutual information is symmetric in its outer arguments: I(X;Z|Y) = I(Z;X|Y). Formalized as cmiSum_reflectXZ — reflecting the joint law by (z,y,x)↦(x,y,z) leaves cmiSum invariant. The defining summand is invariant because its numerator p·p_Y is symmetric and its denominator p_XY·p_YZ merely commutes; proof reindexes the triple sum by the X↔Z coordinate transposition (Fintype.sum_equiv over α×β×γ ≃ γ×β×α).",
+      "cmiSlice_nonneg (researcher-10): per-conditioning-value refinement of SSA. cmiSum_nonneg only bounds the average of I(X;Z|Y=y) over y; the per-y slice p_Y(y)·I(X;Z|Y=y) is INDIVIDUALLY ≥0. Same Gibbs bound p−q≤p·log(p/q) as cmiSum_nonneg but summed over (x,z) at fixed y, with q having the same (x,z)-mass as p at that y so the linear lower bound telescopes to 0. SSA holds locally at every conditioning value, not just on aggregate.",
+      "ssa_deficit_eq_sum_cmiSlice (researcher-10): the entropy deficit H(XY)+H(YZ)−H(XYZ)−H(Y) = ∑_y cmiSlice(y), a sum of nonnegative per-y contributions — finer than ssa_inequality: the deficit is a nonneg combination indexed by conditioning value, vanishing iff every slice vanishes."
     ],
     "mathlibGaps": [
       "No SSA equality-case lemma in Mathlib; KL equality (klDivergence_eq_zero_iff) exists in ShannonEntropy.lean but is private and the file conflicts."


### PR DESCRIPTION
## Summary
Research session for `shannon-entropy-oq-03-incomplete-01` (strong subadditivity of Shannon entropy). The self-contained file `ShannonEntropySSAEq.lean` was already complete and **0-axiom/0-sorry** (SSA inequality, equality/Markov characterization, reflectXZ symmetry). This session adds a genuine, verified strengthening — the **per-conditioning-value refinement** of SSA — not scaffolding.

## Progress
New declarations in `ShannonEntropySSAEq.lean` (13 → 16 theorems, +1 def, still 0 axioms / 0 sorries):
- `cmiSlice pXYZ y` (def) — the per-`y` slice `p_Y(y) · I(X;Z | Y=y)` of the conditional mutual information (the inner `(x,z)`-sum of `cmiSum` at a fixed conditioning value).
- `cmiSum_eq_sum_cmiSlice` — `I(X;Z|Y) = ∑_y cmiSlice y`, a pure reordering of `cmiSum`'s triple sum.
- `cmiSlice_nonneg` — **each per-`y` slice is individually `≥ 0`**: SSA holds *locally* at every conditioning value, strengthening `cmiSum_nonneg` (which only bounds the average over `Y`). Same Gibbs bound `p − q ≤ p·log(p/q)` as `cmiSum_nonneg`, summed over just `(x,z)` at the fixed `y`, with the reference kernel `q` sharing `p`'s `(x,z)`-mass at that `y` so the linear lower bound telescopes to `0`.
- `ssa_deficit_eq_sum_cmiSlice` — the entropy deficit `H(X,Y)+H(Y,Z)−H(X,Y,Z)−H(Y)` decomposes as `∑_y cmiSlice y`, a nonnegative combination indexed by the conditioning value (a finer account of *why* SSA holds than `ssa_inequality`, vanishing iff every slice vanishes).

## Findings
- The averaged `cmiSum_nonneg` is exactly the pre-summation step of a per-slice nonnegativity; isolating the slice makes the "SSA localizes to each conditioning value" fact explicit and reuses the existing KL machinery verbatim.

## Status
**Outcome**: progress (0 axioms / 0 sorries preserved; built green via `docker-build.sh Proofs.ShannonEntropySSAEq`). Gallery meta for `shannon-entropy-oq-03-oq-01` synced (lineCount → 863, theoremCount → 16; was stale).
**Next Steps**: The only remaining open direction is a quantitative/stability (Pinsker-type) SSA, blocked on Mathlib Pinsker usability.

🤖 Generated by researcher-10