### PR TITLE
research(tetrahedral-number-formula-oq-02): figuratePoly = shifted ascPochhammer [VERIFIED 0-axiom]

### DIFF
--- a/proofs/Proofs/TetrahedralNumberFormulaOQ02Polynomial.lean
+++ b/proofs/Proofs/TetrahedralNumberFormulaOQ02Polynomial.lean
@@ -3,6 +3,7 @@ import Mathlib.Algebra.Polynomial.Monic
 import Mathlib.Algebra.Polynomial.BigOperators
 import Mathlib.Algebra.Polynomial.Degree.Operations
 import Mathlib.Algebra.Polynomial.Eval.Defs
+import Mathlib.RingTheory.Polynomial.Pochhammer
 
 /-
 # The Figurate-Sum Cleared Form as a First-Class Monic Polynomial
@@ -93,5 +94,27 @@ theorem figuratePoly_factorial_dvd_eval (d n : ℕ) :
     ((Nat.factorial (d + 1) : ℤ)) ∣ (figuratePoly d).eval (n : ℤ) := by
   rw [figuratePoly_eval, Nat.cast_mul]
   exact Dvd.intro _ rfl
+
+/-- **Shifted-Pochhammer identity.** The figurate cleared-form polynomial is the rising
+factorial `ascPochhammer ℤ (d+1)` shifted by one: `Q_d(X) = ascPochhammer ℤ (d+1) (X + 1)`.
+Indeed `ascPochhammer ℤ (d+1) = X(X+1)⋯(X+d)`, so composing with `X + 1` sends each factor
+`X + i` to `X + (i+1)`, reproducing `Q_d(X) = (X+1)(X+2)⋯(X+d+1)`.  This realizes the
+`nextStep` of `OQ02` (relate `figuratePoly` to a shifted Pochhammer polynomial): it puts the
+figurate cleared form inside Mathlib's `ascPochhammer` API, from which the coefficient theory
+(Stirling numbers of the first kind) and the factorial-evaluation identities follow. -/
+theorem figuratePoly_eq_ascPochhammer_comp (d : ℕ) :
+    figuratePoly d = (ascPochhammer ℤ (d + 1)).comp (X + 1) := by
+  induction d with
+  | zero =>
+      rw [figuratePoly]
+      simp [ascPochhammer_succ_right, ascPochhammer_zero]
+  | succ d ih =>
+      have hfac : (X + ((d + 1 : ℕ) : Polynomial ℤ)).comp (X + 1)
+          = X + C (((d + 1 : ℕ) : ℤ) + 1) := by
+        rw [add_comp, X_comp, natCast_comp]
+        simp only [map_add, map_natCast, map_one]
+        ring
+      rw [figuratePoly, Finset.prod_range_succ, ← figuratePoly,
+          ascPochhammer_succ_right, mul_comp, hfac, ih]
 
 end TetrahedralNumberFormulaOQ02

--- a/src/data/research/problems/tetrahedral-number-formula-oq-02.json
+++ b/src/data/research/problems/tetrahedral-number-formula-oq-02.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETE (VERIFIED 0-axiom): cleared figurate-sum form upgraded to a first-class monic Polynomial ℤ (figuratePoly) with proved monicity, degree d+1, and evaluation Q_d(n)=(d+1)!·S_d(n); closes the sole remaining Polynomial nextStep of OQ02.",
+    "progressSummary": "COMPLETE + Pochhammer bridge (2026-07-12 researcher-1): figuratePoly = shifted ascPochhammer (figuratePoly_eq_ascPochhammer_comp), connecting the figurate cleared-form polynomial to Mathlib's rising-factorial API. Axiom-free, verified.",
     "builtItems": [
       "factorial_mul_sum_simplex (TetrahedralNumberFormulaOQ02.lean:82): (d+1)!·∑_{k≤n}C(k+d,d) = ∏_{i<d+1}(n+1+i), the uniform cleared-denominator polynomial form for every dimension d",
       "factorial_mul_sum_simplex_asc (TetrahedralNumberFormulaOQ02.lean:88): same via ascending factorial (n+1).ascFactorial (d+1)",
@@ -48,7 +48,8 @@
       "The cleared identity yields the classical integrality fact (d+1)!∣(product of d+1 consecutive integers) for free, since the exact quotient is the natural number S_d(n).",
       "Uses OQ01 simplexNumber convention P_d(k)=C(k+d,d) (so P_2 is triangular T_{k+1}); the d=2/d=3 rungs are the tetrahedral pattern one dimension up from the parent entry, not the parent's index-shifted C(k+1,2) convention.",
       "The OQ02 cleared form ∏(n+1+i) is literally a monic degree-(d+1) Polynomial ℤ; packaging it as figuratePoly makes monicity/degree theorems rather than prose, with eval reproducing (d+1)!·S_d(n).",
-      "simp gotcha: full simp normalizes C(a+b) via C_add/map_add and destroys the X+C _ shape needed by natDegree_X_add_C; use simp only [natDegree_X_add_C, sum_const, card_range, ...]."
+      "simp gotcha: full simp normalizes C(a+b) via C_add/map_add and destroys the X+C _ shape needed by natDegree_X_add_C; use simp only [natDegree_X_add_C, sum_const, card_range, ...].",
+      "figuratePoly_eq_ascPochhammer_comp (2026-07-12 researcher-1): figuratePoly d = (ascPochhammer ℤ (d+1)).comp (X+1). Places the figurate cleared-form polynomial (X+1)(X+2)…(X+d+1) inside Mathlib's ascPochhammer API, from which Stirling-first-kind coefficient theory follows. Induction via ascPochhammer_succ_right + prod_range_succ; axiom-free. Closes the shifted-Pochhammer nextStep of OQ02."
     ],
     "mathlibGaps": [],
     "nextSteps": [
@@ -105,6 +106,13 @@
       "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/TetrahedralNumberFormulaOQ01Absorption.lean"
+    },
+    {
+      "path": "Proofs/TetrahedralNumberFormulaOQ02Polynomial.lean",
+      "lineCount": 120,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "sorryCount": 0
     }
   ]
 }


### PR DESCRIPTION
## Summary
Research session for **tetrahedral-number-formula-oq-02**. Realizes the documented next step by identifying the figurate cleared-form polynomial with Mathlib's rising factorial.

## Progress
- `figuratePoly_eq_ascPochhammer_comp` : `figuratePoly d = (ascPochhammer ℤ (d+1)).comp (X + 1)`.
  Since `ascPochhammer ℤ (d+1) = X(X+1)⋯(X+d)`, composing with `X+1` sends each factor `X+i` to `X+(i+1)`, reproducing `Q_d(X) = (X+1)(X+2)⋯(X+d+1)`. Induction via `ascPochhammer_succ_right` + `Finset.prod_range_succ`.

## Why it matters
Places the figurate cleared-form polynomial inside Mathlib's `ascPochhammer` API, from which the coefficient theory (Stirling numbers of the first kind) and factorial-evaluation identities follow — the shifted-Pochhammer `nextStep` flagged for OQ02.

## Verification
- `LAKE_UNSAFE=1 lake env lean TetrahedralNumberFormulaOQ02Polynomial.lean` → EXIT 0, no errors/warnings.
- `#print axioms figuratePoly_eq_ascPochhammer_comp` → `[propext, Classical.choice, Quot.sound]` only.

## Status
**Outcome**: progress (axiom-free Pochhammer bridge on a completed entry).

🤖 Generated by researcher-1