### PR TITLE
Research: cube-root-3-irrational-oq-02-oq-03 - Xⁿ−3 irreducible over ℚ for all n

### DIFF
--- a/proofs/Proofs/CubeRoot3IrrationalOQ02OQ03.lean
+++ b/proofs/Proofs/CubeRoot3IrrationalOQ02OQ03.lean
@@ -1176,4 +1176,49 @@ theorem cubeRootThree_irrational {x : ℝ} (hx : x ^ 3 = 3) : Irrational x := by
   rintro ⟨q, rfl⟩
   exact three_not_cube_rat q (by exact_mod_cast hx)
 
+/-! ## Concrete `ℚ` instances of the Vahlen–Capelli criterion
+
+`three_not_cube_rat` (the `p = 3` case) generalises verbatim to **every** exponent by the same
+`3`-adic valuation argument: if `bᵖ = 3` then `p · v₃(b) = v₃(3) = 1` in `ℤ`, impossible for
+`p ≥ 2` since then `p ∣ 1`.  This supplies the "clean not-a-perfect-`p`-th-power in `ℚ`" lemma,
+which — fed through `vahlen_capelli_pos` — makes `Xⁿ − 3` irreducible over `ℚ` for **all** `n`,
+generalising the namesake `X³ − 3` instance to arbitrary exponent. -/
+
+/-- **`3` is not a `p`-th power in `ℚ`, for every `p ≥ 2`.**  If `bᵖ = 3` then the `3`-adic
+valuation gives `p · v₃(b) = v₃(3) = 1`, so `p ∣ 1` in `ℤ` — impossible for `p ≥ 2`.  The
+all-exponent generalisation of `three_not_cube_rat` (which is the `p = 3` case). -/
+theorem three_not_pth_power_rat {p : ℕ} (hp : 2 ≤ p) : ∀ b : ℚ, b ^ p ≠ 3 := by
+  intro b hb
+  have hb0 : b ≠ 0 := by
+    rintro rfl; rw [zero_pow (by omega : p ≠ 0)] at hb; norm_num at hb
+  have h1 : padicValRat 3 (3 : ℚ) = 1 := by
+    have := padicValRat.self (p := 3) (by norm_num); simpa using this
+  have key : padicValRat 3 (b ^ p) = 1 := by rw [hb, h1]
+  rw [padicValRat.pow hb0] at key
+  -- `key : ↑p * padicValRat 3 b = 1`, so `↑p ∣ 1`, forcing `↑p ≤ 1` against `p ≥ 2`.
+  have hd : (p : ℤ) ∣ 1 := ⟨padicValRat 3 b, key.symm⟩
+  have hle : (p : ℤ) ≤ 1 := Int.le_of_dvd one_pos hd
+  have hge : (2 : ℤ) ≤ (p : ℤ) := by exact_mod_cast hp
+  omega
+
+/-- **`Xⁿ − 3` is irreducible over `ℚ`, for every `n ≥ 1`.**  Direct instance of the general
+positive-radicand Vahlen–Capelli criterion `vahlen_capelli_pos` (with `a = 3 > 0`): condition (1)
+is `three_not_pth_power_rat` at each prime `p ∣ n`, and condition (2) is vacuous because `3 > 0`.
+Generalises the namesake `X³ − 3` instance to arbitrary exponent — every `n`-th root of `3` is
+irrational, uniformly. -/
+theorem X_pow_sub_C_three_irreducible {n : ℕ} (hn : 1 ≤ n) :
+    Irreducible (X ^ n - C (3 : ℚ)) := by
+  rw [vahlen_capelli_pos hn (by norm_num : (0 : ℚ) < 3)]
+  intro p hp _hpn b
+  exact three_not_pth_power_rat hp.two_le b
+
+/-- **`X^(2ᵏ) − 3` is irreducible over `ℚ`, for every `k ≥ 1`** — the `2`-power-exponent instance
+(the exponents relevant to the `∛3` / quadratic-tower descent of this gallery entry).  A direct
+specialisation of `X_pow_sub_C_three_irreducible`, or of `vahlen_capelli_pos_two_pow` with the
+single square obstruction `three_not_pth_power_rat (p := 2)`. -/
+theorem X_pow_two_pow_sub_C_three_irreducible {k : ℕ} (hk : 1 ≤ k) :
+    Irreducible (X ^ 2 ^ k - C (3 : ℚ)) :=
+  (vahlen_capelli_pos_two_pow hk (by norm_num : (0 : ℚ) < 3)).mpr
+    (three_not_pth_power_rat (by norm_num))
+
 end CubeRoot3IrrationalOQ02OQ03

--- a/src/data/research/problems/cube-root-3-irrational-oq-02-oq-03-incomplete-01.json
+++ b/src/data/research/problems/cube-root-3-irrational-oq-02-oq-03-incomplete-01.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETED (researcher-1, 2026-07-12): closed the SOLE OPEN SORRY (was @707). Retrieved the completed Aristotle proof (project 958405df, task COMPLETE) of two_power_capelli_neg_square — the residual even-case Vahlen–Capelli sub-case (8∣n, −a∈K²) that is an explicit open TODO in Mathlib KummerExtension.lean — repaired 2 v4.28→v4.31 toolchain drifts (a Fin-cardinality vacuous goal and a linear_combination field identity replacing broken grind steps), and inlined it (with helpers quad_repr/quad_indep/descent/two_power_irred) into CubeRoot3IrrationalOQ02OQ03.lean as §VahlenCapelliDescent, closing the sorry with `exact two_power_capelli_neg_square (by omega) h1 h2 hna`. The file is now FULLY 0-sorry / 0-axiom (host-verified via lake env lean): vahlen_capelli (full even+odd iff), two_power_capelli, cubeRootThree_irreducible, and the ∛3 corollaries all depend only on [propext,Classical.choice,Quot.sound]. Updated stale docstrings that claimed a sole remaining sorry; removed the now-redundant StatementOnly companion. The entire Vahlen–Capelli criterion (incl. the even case Mathlib lists as TODO) is machine-checked.",
+    "progressSummary": "COMPLETE (0-sorry/0-axiom Vahlen–Capelli criterion incl. even case). This session added the concrete ℚ instances (nextStep #2): three_not_pth_power_rat (3 is not a p-th power in ℚ for every p≥2, all-exponent generalization of three_not_cube_rat via 3-adic valuation) ⟹ X_pow_sub_C_three_irreducible: Xⁿ−3 is irreducible over ℚ for EVERY n≥1, generalizing the namesake X³−3 instance to arbitrary exponent. Plus the 2-power instance X^(2ᵏ)−3.",
     "builtItems": [
       "neg_not_square_of_pos: a>0 => forall b, b^2 != -a (CubeRoot3IrrationalOQ02OQ03.lean)",
       "capelli_cond_two_of_pos: a>0 => forall b, a != -(4*b^4) (condition 2 vacuous)",
@@ -40,7 +40,8 @@
       "cubeRootThree_irreducible: Irreducible(X^3 - C 3 : ℚ[X]) as instance of vahlen_capelli_pos_prime (p=3,a=3) — the namesake ∛3 instance, SORRY-FREE axiom-free",
       "cubeRootThree_irrational: x^3=3 (x:ℝ) => Irrational x, transport of three_not_cube_rat along ℚ↪ℝ, SORRY-FREE axiom-free",
       "StatementOnly_CubeRoot3...TwoPowerCapelliNegSquare: self-contained Mathlib-only isolation of the sole open sorry (two_power_capelli_neg_square: k≥3, a∉K², a∉−4K⁴, −a∈K² => Irreducible X^(2^k)−C a) submitted to Aristotle project 958405df-8534-4c33-9d40-21529cfa14fa",
-      "two_power_capelli_neg_square + helpers (quad_repr, quad_indep, descent, two_power_irred) inlined into CubeRoot3IrrationalOQ02OQ03.lean §VahlenCapelliDescent — CLOSES the sole open sorry@707 (residual even-case Vahlen–Capelli, 8∣n with −a∈K², an explicit Mathlib KummerExtension.lean TODO). Proved by Aristotle (project 958405df) via Lang VI§9 quadratic descent across K(√a); repaired 2 v4.28→v4.31 grind drifts (Fin-cardinality vacuous goal + linear_combination field identity). File now 0-sorry/0-axiom; vahlen_capelli & cubeRootThree_irreducible depend only on [propext,Classical.choice,Quot.sound]. Removed the now-redundant StatementOnly companion."
+      "two_power_capelli_neg_square + helpers (quad_repr, quad_indep, descent, two_power_irred) inlined into CubeRoot3IrrationalOQ02OQ03.lean §VahlenCapelliDescent — CLOSES the sole open sorry@707 (residual even-case Vahlen–Capelli, 8∣n with −a∈K², an explicit Mathlib KummerExtension.lean TODO). Proved by Aristotle (project 958405df) via Lang VI§9 quadratic descent across K(√a); repaired 2 v4.28→v4.31 grind drifts (Fin-cardinality vacuous goal + linear_combination field identity). File now 0-sorry/0-axiom; vahlen_capelli & cubeRootThree_irreducible depend only on [propext,Classical.choice,Quot.sound]. Removed the now-redundant StatementOnly companion.",
+      "CubeRoot3IrrationalOQ02OQ03.lean concrete ℚ instances (nextStep #2): three_not_pth_power_rat (∀p≥2, ∀b:ℚ, b^p≠3 — all-exponent generalization of three_not_cube_rat via the SAME 3-adic valuation: p·v₃(b)=v₃(3)=1⟹p∣1⟹p≤1 vs p≥2, padicValRat.pow+Int.le_of_dvd+omega) + X_pow_sub_C_three_irreducible (Xⁿ−3 irreducible over ℚ for ALL n≥1 via vahlen_capelli_pos, generalizing the namesake X³−3 to arbitrary exponent) + X_pow_two_pow_sub_C_three_irreducible (X^(2ᵏ)−3, the quadratic-tower exponents). 3 thm, axioms [propext,Classical.choice,Quot.sound]."
     ],
     "insights": [
       "The sole remaining sorry (line 707, two_power_capelli) is the -a in K^2 branch of the pure 2-power base X^(2^k)-C a, k>=3 (8|n): the classical Lang VI section 9 Galois descent over L=K(i). It is EXACTLY Mathlibs open TODO (X_pow_sub_C_irreducible_of_prime_pow restricted to p != 2). Not one-session closeable manually.",
@@ -55,8 +56,8 @@
       "LinearOrderedField was REMOVED from this Mathlib (v4.26.0 era); use [Field K] [LinearOrder K] [IsStrictOrderedRing K]."
     ],
     "nextSteps": [
-      "To close the last sorry: formalize the Lang VI section 9 descent. Via X_pow_mul_sub_C_irreducible reduce to: base root x (x^(2^(k-1))=a) is not a square in K(x); when -a in K^2 the norm argument is inconclusive, and condition (2) forbids x=y^2. Uses L=K(i) (-1 not a square here, already proved as neg_one_not_square_of_not_square_of_neg_square) + Galois/conjugate-factor descent (~150-300 lines). Best delegated to Aristotle when the MCP server is healthy (returned Resource not found all session).",
-      "Optionally add a concrete Q instance of vahlen_capelli_pos (needs a clean not-a-perfect-p-th-power in Q lemma)."
+      "Optional: generalize three_not_pth_power_rat to an arbitrary prime radicand q (∀b:ℚ, b^p≠q via q-adic valuation), giving X^n−q irreducible over ℚ for every prime q — the fully general concrete family.",
+      "Optional: a squarefree-radicand version (q-adic valuation at any prime dividing q with exponent 1)."
     ]
   },
   "tags": [


### PR DESCRIPTION
## Summary
Research session for `cube-root-3-irrational-oq-02-oq-03-incomplete-01`. The Vahlen–Capelli criterion (incl. the even case Mathlib lists as TODO) is already complete and 0-sorry/0-axiom. This PR discharges the standing optional next-step — a **concrete ℚ instance** — and in fact generalizes the namesake result to arbitrary exponent.

## Progress (3 axiom-free theorems in `CubeRoot3IrrationalOQ02OQ03.lean`)
- `three_not_pth_power_rat` — **3 is not a `p`-th power in ℚ for every `p ≥ 2`**. The existing `three_not_cube_rat` (the `p = 3` case) used a `3`-adic valuation argument; it generalizes verbatim: `bᵖ = 3 ⟹ p·v₃(b) = v₃(3) = 1 ⟹ p ∣ 1`, impossible for `p ≥ 2`.
- `X_pow_sub_C_three_irreducible` — **`Xⁿ − 3` is irreducible over ℚ for every `n ≥ 1`**, via the general positive-radicand criterion `vahlen_capelli_pos` (condition (1) at each prime `p ∣ n` is `three_not_pth_power_rat`; condition (2) is vacuous since `3 > 0`). This generalizes the file's namesake `X³ − 3` instance to arbitrary exponent — every `n`-th root of `3` is irrational, uniformly.
- `X_pow_two_pow_sub_C_three_irreducible` — the `2`-power-exponent instance (the exponents in this entry's quadratic-tower descent).

## Verification
- `#print axioms` on both main theorems: `[propext, Classical.choice, Quot.sound]` — no `sorryAx`, no `Lean.ofReduceBool`. Elaboration-clean via `lake env lean` (exit 0; only pre-existing warnings elsewhere in the file).

## Status
**Outcome**: progress (concrete ℚ instances added; namesake `X³ − 3` generalized to `Xⁿ − 3` for all `n`)
**Next Steps**: generalize the radicand from `3` to an arbitrary prime (or squarefree) `q` via the same valuation argument, giving `Xⁿ − q` irreducible over ℚ.

🤖 Generated by researcher-11