### PR TITLE
fix: harden blockerText against null/non-object blocker entries

### DIFF
--- a/src/types/research.ts
+++ b/src/types/research.ts
@@ -229,9 +229,12 @@ export const DEFAULT_REOPEN_CRITERION = 'materially new mechanism required'
  * - Pre-schema "wildcat" objects (ad-hoc keys already in the data) fall back
  *   through `description`/`summary` before JSON.stringify, so nothing ever
  *   renders as "[object Object]".
+ * - Off-schema non-objects (null/undefined/number/…) render via JSON.stringify
+ *   so malformed data stays visible instead of throwing or vanishing.
  */
 export function blockerText(b: Blocker): string {
   if (typeof b === 'string') return b
+  if (b === null || typeof b !== 'object') return JSON.stringify(b) ?? String(b)
   const entry = b as Partial<BlockerEntry> & { description?: unknown; summary?: unknown }
   const label =
     (typeof entry.route === 'string' && entry.route) ||


### PR DESCRIPTION
Closes #38478

## What

Adds a null/non-object guard at the top of `blockerText` in `src/types/research.ts` (the helper introduced by PR #38472), per the issue's suggested fix:

```ts
if (b === null || typeof b !== 'object') return JSON.stringify(b) ?? String(b)
```

Previously `null`/`undefined` array elements threw `TypeError: Cannot read properties of null (reading 'route')` at the `entry.route` access, so a tracker JSON containing `"blockers": [null]` would crash the research problem page. Numbers/booleans/arrays/nested objects already fell through safely.

## Rendering choice

Off-schema non-objects render as their JSON (`"null"`, `"undefined"`, `"42"`) rather than an empty string or a `"(invalid blocker entry)"` marker — this follows the issue's suggested fix verbatim, matches the helper's existing `JSON.stringify` fallback style for wildcat objects, and keeps malformed data visible for debugging instead of silently hiding it. (`?? String(b)` covers `undefined`, where `JSON.stringify` returns `undefined` instead of a string.)

## Verification

Adversarial harness (from the issue) + full corpus scan:

| case | result |
|---|---|
| `null` | `"null"` — no throw |
| `undefined` | `"undefined"` — no throw |
| `42` | `"42"` |
| `true` | `"true"` |
| `[1, 'x']` | `'[1,"x"]'` |
| nested object | JSON, no `[object Object]` |
| `{}` | `"{}"` |
| structured entry | `"r — reopen: c"` |
| legacy string | verbatim |

Corpus: 3,033 `src/data/research/problems/*.json` files scanned, 638 blocker entries — **0 throws, 0 `[object Object]`**.

Typecheck: isolated `tsc --noEmit` on the touched file passes; full `tsc -b` passes after copying the three untracked generated manifests (`data-manifest.json`, `listings.json`, `research-data-manifest.json`) from the main tree (known generated-file gap in fresh worktrees; not committed — they are gitignored).

🤖 Generated with [Claude Code](https://claude.com/claude-code)