### PR TITLE
research(liouville-theorem-oq-03): ℚ-affine invariance of the well-approximable set [VERIFIED 0-axiom]

### DIFF
--- a/proofs/Proofs/LiouvilleTheoremOQ03.lean
+++ b/proofs/Proofs/LiouvilleTheoremOQ03.lean
@@ -623,4 +623,66 @@ theorem dense_compl_liouville : Dense {x : ℝ | Liouville x}ᶜ :=
   (interior_eq_empty_iff_dense_compl).mp
     (MeasureTheory.Measure.interior_eq_empty_of_null volume_liouville_eq_zero)
 
+/-! ### ℚ-affine invariance of the well-approximable set
+
+The irrationality-measure exponent `τ` of a real number is unchanged by adding a rational,
+by negation, and by multiplying by a nonzero rational — this is exactly the content of
+Mathlib's `LiouvilleWith.add_rat_iff`, `LiouvilleWith.neg_iff`, `LiouvilleWith.mul_rat_iff`.
+Lifted to the level sets, the well-approximable set `wellApprox τ = {x | LiouvilleWith τ x}`
+is therefore invariant under the whole rational-affine group `x ↦ a·x + b` (`a, b ∈ ℚ`,
+`a ≠ 0`).  This is the structural reason `wellApprox τ` is a *dense* set of the same
+Hausdorff dimension everywhere — the rich self-similarity underneath the Jarník–Besicovitch
+dimension formula — and complements the measure/category/density facts above.  All results
+are elementary consequences of the Mathlib `LiouvilleWith` invariance API; none touches the
+`dimH_wellApprox` axiom. -/
+
+/-- **Translation by a rational fixes membership.** `x + r ∈ wellApprox τ ↔ x ∈ wellApprox τ`
+for `r : ℚ` (`LiouvilleWith.add_rat_iff`). -/
+theorem wellApprox_add_rat_iff (τ : ℝ) (x : ℝ) (r : ℚ) :
+    x + (r : ℝ) ∈ wellApprox τ ↔ x ∈ wellApprox τ := by
+  simp only [wellApprox, Set.mem_setOf_eq]
+  exact LiouvilleWith.add_rat_iff
+
+/-- **Translation by an integer fixes membership.** `x + m ∈ wellApprox τ ↔ x ∈ wellApprox τ`
+for `m : ℤ` (`LiouvilleWith.add_int_iff`). -/
+theorem wellApprox_add_int_iff (τ : ℝ) (x : ℝ) (m : ℤ) :
+    x + (m : ℝ) ∈ wellApprox τ ↔ x ∈ wellApprox τ := by
+  simp only [wellApprox, Set.mem_setOf_eq]
+  exact LiouvilleWith.add_int_iff
+
+/-- **Subtraction of a rational fixes membership.** `x - r ∈ wellApprox τ ↔ x ∈ wellApprox τ`
+(`LiouvilleWith.sub_rat_iff`). -/
+theorem wellApprox_sub_rat_iff (τ : ℝ) (x : ℝ) (r : ℚ) :
+    x - (r : ℝ) ∈ wellApprox τ ↔ x ∈ wellApprox τ := by
+  simp only [wellApprox, Set.mem_setOf_eq]
+  exact LiouvilleWith.sub_rat_iff
+
+/-- **Negation fixes membership.** `-x ∈ wellApprox τ ↔ x ∈ wellApprox τ`
+(`LiouvilleWith.neg_iff`); `wellApprox τ` is symmetric about the origin. -/
+theorem wellApprox_neg_iff (τ : ℝ) (x : ℝ) :
+    -x ∈ wellApprox τ ↔ x ∈ wellApprox τ := by
+  simp only [wellApprox, Set.mem_setOf_eq]
+  exact LiouvilleWith.neg_iff
+
+/-- **Dilation by a nonzero rational fixes membership.** `x · r ∈ wellApprox τ ↔ x ∈ wellApprox τ`
+for `r : ℚ`, `r ≠ 0` (`LiouvilleWith.mul_rat_iff`). -/
+theorem wellApprox_mul_rat_iff (τ : ℝ) (x : ℝ) {r : ℚ} (hr : r ≠ 0) :
+    x * (r : ℝ) ∈ wellApprox τ ↔ x ∈ wellApprox τ := by
+  simp only [wellApprox, Set.mem_setOf_eq]
+  exact LiouvilleWith.mul_rat_iff hr
+
+/-- **Rational-translation invariance as a set equality.** The image of `wellApprox τ` under
+`x ↦ x + r` (`r : ℚ`) is `wellApprox τ` itself — the level set is a genuine union of its own
+rational translates.  Forward from `wellApprox_add_rat_iff`, backward via the preimage point
+`y - r` (`wellApprox_sub_rat_iff`). -/
+theorem image_add_rat_wellApprox (τ : ℝ) (r : ℚ) :
+    (fun x => x + (r : ℝ)) '' wellApprox τ = wellApprox τ := by
+  ext y
+  simp only [Set.mem_image]
+  constructor
+  · rintro ⟨x, hx, rfl⟩
+    exact (wellApprox_add_rat_iff τ x r).mpr hx
+  · intro hy
+    exact ⟨y - (r : ℝ), (wellApprox_sub_rat_iff τ y r).mpr hy, by ring⟩
+
 end LiouvilleTheoremOQ03

--- a/src/data/research/problems/liouville-theorem-oq-03.json
+++ b/src/data/research/problems/liouville-theorem-oq-03.json
@@ -29,8 +29,9 @@
     }
   },
   "knowledge": {
-    "progressSummary": "FOLLOW-UP (researcher-7, 2026-07-11, VERIFIED): added Part X, the category (Baire) face — each well-approximable set W τ is comeagre (wellApprox_residual: W τ ∈ residual ℝ, AXIOM-FREE, from eventually_residual_liouville + upward-closed residual filter), its complement is meagre (meagre_compl_wellApprox, AXIOM-FREE), and for τ>2 W τ is simultaneously comeagre and Lebesgue-null (wellApprox_residual_and_volume_zero) — the textbook category/measure dichotomy. Strengthens the prior wellApprox_dense. --- Formalized Jarník–Besicovitch dimH(W τ)=2/τ (τ≥2) over Mathlib LiouvilleWith + dimH; JB formula = single axiom; derived dimH{Liouville}=0 by tendsto squeeze. Structural lemmas 0-axiom (LiouvilleWith.mono, Liouville.liouvilleWith, dimH_mono). 210L, 17 thm, 2 def, 1 axiom.",
+    "progressSummary": "ℚ-AFFINE INVARIANCE (researcher-5, 2026-07-12, VERIFIED 0-axiom): added the rational-affine invariance of wellApprox tau = {x|LiouvilleWith tau x} to LiouvilleTheoremOQ03.lean — membership is fixed by translation by a rational/integer (wellApprox_add_rat_iff/_add_int_iff/_sub_rat_iff), by negation (wellApprox_neg_iff, symmetric about 0), and by dilation by a nonzero rational (wellApprox_mul_rat_iff), plus the set-equality capstone image_add_rat_wellApprox ((·+r)''wellApprox tau = wellApprox tau). So wellApprox tau is invariant under the whole rational-affine group x↦a·x+b (a,b∈ℚ, a≠0) — the self-similarity underneath its everywhere-equal Hausdorff dimension. All from Mathlib LiouvilleWith.add_rat_iff/neg_iff/mul_rat_iff; none touches the dimH_wellApprox (Jarník–Besicovitch) axiom. 6 theorems, all [propext,Classical.choice,Quot.sound]. --- FOLLOW-UP (researcher-7, 2026-07-11, VERIFIED): added Part X, the category (Baire) face — each well-approximable set W τ is comeagre (wellApprox_residual: W τ ∈ residual ℝ, AXIOM-FREE, from eventually_residual_liouville + upward-closed residual filter), its complement is meagre (meagre_compl_wellApprox, AXIOM-FREE), and for τ>2 W τ is simultaneously comeagre and Lebesgue-null (wellApprox_residual_and_volume_zero) — the textbook category/measure dichotomy. Strengthens the prior wellApprox_dense. --- Formalized Jarník–Besicovitch dimH(W τ)=2/τ (τ≥2) over Mathlib LiouvilleWith + dimH; JB formula = single axiom; derived dimH{Liouville}=0 by tendsto squeeze. Structural lemmas 0-axiom (LiouvilleWith.mono, Liouville.liouvilleWith, dimH_mono). 210L, 17 thm, 2 def, 1 axiom.",
     "builtItems": [
+      "wellApprox ℚ-affine invariance block (researcher-5, 2026-07-12, 0-axiom VERIFIED): wellApprox_add_rat_iff, wellApprox_add_int_iff, wellApprox_sub_rat_iff, wellApprox_neg_iff, wellApprox_mul_rat_iff, and set-equality image_add_rat_wellApprox. wellApprox tau invariant under x↦a·x+b (a,b∈ℚ,a≠0), via Mathlib LiouvilleWith iff-API. In LiouvilleTheoremOQ03.lean.",
       "wellApprox τ := {x | LiouvilleWith τ x} + antitonicity (LiouvilleWith.mono) and {Liouville}⊆W τ (Liouville.liouvilleWith), 0-axiom",
       "dimH_mono transport: dimH(W τ) antitone, dimH{Liouville} ≤ dimH(W τ)",
       "dimH_wellApprox axiom (Jarník–Besicovitch formula) + derived dimH_liouville_eq_zero via ge_of_tendsto squeeze (n→∞)",
@@ -69,7 +70,7 @@
     "mathlib": []
   },
   "started": "2026-04-22T12:51:58.295Z",
-  "lastUpdate": "2026-07-11T00:00:00.000Z",
+  "lastUpdate": "2026-07-12",
   "significance": 7,
   "tractability": 4,
   "leanFiles": [
@@ -87,8 +88,8 @@
     {
       "path": "Proofs/LiouvilleTheoremOQ03.lean",
       "filename": "LiouvilleTheoremOQ03.lean",
-      "lineCount": 558,
-      "theoremCount": 40,
+      "lineCount": 688,
+      "theoremCount": 46,
       "axiomCount": 1,
       "defCount": 2,
       "sorryCount": 0,


### PR DESCRIPTION
## Summary

Adds the **rational-affine invariance** of `wellApprox τ = {x | LiouvilleWith τ x}` to `LiouvilleTheoremOQ03.lean`. The irrationality-measure exponent `τ` is unchanged by rational translation, negation, and nonzero-rational dilation (Mathlib's `LiouvilleWith.add_rat_iff` / `neg_iff` / `mul_rat_iff`), so the level set is invariant under the whole rational-affine group `x ↦ a·x + b` (`a, b ∈ ℚ`, `a ≠ 0`):

- `wellApprox_add_rat_iff`, `wellApprox_add_int_iff`, `wellApprox_sub_rat_iff`
- `wellApprox_neg_iff` — symmetric about the origin
- `wellApprox_mul_rat_iff` — dilation by nonzero `r : ℚ`
- `image_add_rat_wellApprox` — the set-equality capstone `(· + r) '' wellApprox τ = wellApprox τ`

This is the self-similarity underneath the everywhere-equal Hausdorff dimension of `wellApprox τ`, complementing the measure/category/density facts already in the file.

## Verification

- `#print axioms` on all six → `[propext, Classical.choice, Quot.sound]` (0 extra axioms).
- Builds green via `lake env lean` against Mathlib v4.26.
- **None** touches the deep `dimH_wellApprox` (Jarník–Besicovitch) axiom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)