### PR TITLE
Research: erdos-1098-oq-01-oq-03 — residual gap in canonical finite-derived-subgroup form [VERIFIED 0-axiom]

### DIFF
--- a/proofs/Proofs/Erdos1098OQ01OQ03.lean
+++ b/proofs/Proofs/Erdos1098OQ01OQ03.lean
@@ -85,6 +85,7 @@ import Mathlib.GroupTheory.Subgroup.Center
 import Mathlib.GroupTheory.Subgroup.Centralizer
 import Mathlib.GroupTheory.Index
 import Mathlib.GroupTheory.Commutator.Finite
+import Mathlib.GroupTheory.Schreier
 import Mathlib.GroupTheory.CosetCover
 import Mathlib.GroupTheory.QuotientGroup.Basic
 import Mathlib.Data.Finset.Card
@@ -619,6 +620,58 @@ theorem neumann_hard_direction_of_finite_commutatorSet
     [Group.FG G] [Finite (commutatorSet G)] (_ : BoundedCliques G) :
     (Subgroup.center G).index ≠ 0 :=
   Subgroup.FiniteIndex.index_ne_zero
+
+/-- **The residual gap in canonical (finite derived subgroup) form.**  The finiteness of
+    the *set* of commutators `{[a,b] : a,b ∈ G}` and the finiteness of the derived
+    *subgroup* `G' = commutator G = ⁅⊤, ⊤⁆` are equivalent:
+
+    > `Finite (commutatorSet G)  ↔  Finite (commutator G)`.
+
+    *Proof.* (`→`) is Schur's theorem — a group with finitely many commutators has a
+    finite commutator subgroup (`Mathlib.GroupTheory.Schreier`, the instance
+    `Finite (commutatorSet G) → Finite (commutator G)`; no finite-generation needed). (`←`)
+    is immediate: every commutator `⁅g₁, g₂⁆` lies in `commutator G`
+    (`commutator_mem_commutator` at `⊤`), so `commutatorSet G ⊆ ↑(commutator G)`, and a
+    subset of a finite set is finite.
+
+    This recasts the localization narrative of `center_finiteIndex_iff_relIndex_core` and
+    `neumann_hard_direction_of_finite_commutatorSet` into the *textbook* form of Neumann's
+    theorem: the entire remaining content of the axiom `neumann_hard_direction` is the
+    single implication `BoundedCliques G → Finite (commutator G)` — that bounded
+    non-commuting sets force a **finite derived subgroup** (the "boundedly finite-by-abelian"
+    ⟺ finite-`G'` dichotomy of B. H. Neumann, 1976). Axiom-free. -/
+theorem finite_commutatorSet_iff_finite_commutator :
+    Finite (commutatorSet G) ↔ Finite (_root_.commutator G) := by
+  constructor
+  · intro h
+    haveI := h
+    infer_instance
+  · intro h
+    haveI := h
+    have hsub : commutatorSet G ⊆ (↑(_root_.commutator G) : Set G) := by
+      rintro x ⟨g₁, g₂, rfl⟩
+      exact commutator_mem_commutator (mem_top g₁) (mem_top g₂)
+    have hfin : (↑(_root_.commutator G) : Set G).Finite := Set.toFinite _
+    exact Set.finite_coe_iff.mpr (hfin.subset hsub)
+
+/-- **The hard direction holds — axiom-free — whenever the derived subgroup is finite.**
+    If `G` is finitely generated and its commutator subgroup `G' = commutator G` is finite,
+    then the centre has finite index: `[G : Z(G)] ≠ 0`.  This is the derived-subgroup
+    (canonical BFC) phrasing of `neumann_hard_direction_of_finite_commutatorSet`, obtained
+    through the equivalence `finite_commutatorSet_iff_finite_commutator`.
+
+    As before `BoundedCliques G` is unused — retained only so the statement is a literal
+    drop-in for the axiom's signature on the finite-`G'` class.  Together with
+    `finite_commutatorSet_iff_finite_commutator` this pins the sole remaining content of
+    `neumann_hard_direction` (for finitely generated `G`) to `BoundedCliques G →
+    Finite (commutator G)`: bounded non-commuting cliques must be shown to force a finite
+    derived subgroup, exactly Neumann's BFC theorem. -/
+theorem neumann_hard_direction_of_finite_commutator
+    [Group.FG G] [Finite (_root_.commutator G)] (_ : BoundedCliques G) :
+    (Subgroup.center G).index ≠ 0 := by
+  haveI : Finite (commutatorSet G) :=
+    finite_commutatorSet_iff_finite_commutator.mpr inferInstance
+  exact Subgroup.FiniteIndex.index_ne_zero
 
 /-- **Bounded cliques are a group-isomorphism invariant.**  If `G ≃* K` then `Γ(G)` has
     finite clique number iff `Γ(K)` does: `BoundedCliques G ↔ BoundedCliques K`.  An

--- a/research/problems/erdos-1098-oq-01-oq-03/knowledge.md
+++ b/research/problems/erdos-1098-oq-01-oq-03/knowledge.md
@@ -1,5 +1,48 @@
 # Knowledge: erdos-1098-oq-01-oq-03 (Neumann ω(Γ(G)) finite ⟺ [G:Z(G)] finite)
 
+## Session 2026-07-12 (researcher-2) — residual gap in canonical finite-derived-subgroup form + sharpened blocker [VERIFIED 0-axiom]
+
+**Mode:** REVISIT (RICH; base SOLVED-with-1-axiom). **Outcome:** progress — 2 theorems,
+VERIFIED 0 sorry / 0 new axiom (`lake env lean`, EXIT 0; `#print axioms` on both =
+`[propext, Classical.choice, Quot.sound]` only — neither touches the BFC axiom
+`neumann_hard_direction`).
+
+### What I did — recast the open gap into the textbook BFC form
+Prior sessions pinned the axiom's residual content to `BoundedCliques G → Finite (commutatorSet G)`
+(finite commutator **set**). I recast it into the classical Neumann statement, tied to the exact
+Mathlib object:
+- `finite_commutatorSet_iff_finite_commutator : Finite (commutatorSet G) ↔ Finite (commutator G)`.
+  `→` is Schur's theorem (Mathlib `Schreier.lean` instance `[Finite (commutatorSet G)] →
+  Finite (commutator G)`, no FG needed); `←` is the trivial subset `commutatorSet G ⊆ ↑(commutator G)`
+  via `commutator_mem_commutator (mem_top _) (mem_top _)`. Needed adding
+  `import Mathlib.GroupTheory.Schreier` (the derived-subgroup finiteness instance is NOT in the
+  already-imported `Commutator.Finite`).
+- `neumann_hard_direction_of_finite_commutator [Group.FG G] [Finite (commutator G)]
+  (_ : BoundedCliques G) : (center G).index ≠ 0` — the finite-derived-**subgroup** phrasing of the
+  existing `_of_finite_commutatorSet` reduction, via the iff. So the sole remaining content of the
+  axiom (for FG G) is `BoundedCliques G → Finite (commutator G)` = Neumann's BFC theorem in its
+  canonical "finite G'" form.
+
+### Sharpened blocker (genuine, corrects prior "circular" framing)
+The Mathlib endgame `Subgroup.finiteIndex_center` requires BOTH `[Finite (commutatorSet G)]` AND
+`[Group.FG G]`, and the FG hypothesis is **essential, not removable** — it is NOT merely a
+circularity to be broken. Counterexample: `G = ⨁ (extraspecial p-group)` has finite `commutatorSet`
+(all commutators lie in the common order-p centre) yet `[G:Z(G)]` is infinite (`G/Z(G)` is infinite
+elementary abelian). So `Finite (commutatorSet G) → FiniteIndex (center G)` is **false** for non-FG
+G; no FG-free shortcut through commutator-set finiteness exists. (Consistent with Neumann: that G
+has unbounded cliques, so `BoundedCliques` fails there.) This closes off the route the prior
+knowledge suggested ("index_center_le_pow is circular").
+
+### Still blocked (unchanged, architectural)
+`neumann_hard_direction` for infinite G = full BFC theorem `BoundedCliques G → Finite (commutator G)`
+(bounded non-commuting cliques ⟹ finite derived subgroup). Not in Mathlib (v4.26); Neumann's
+covering/counting argument, >1000 lines. Schur's converse `FiniteIndex (center G) → Finite (commutator G)`
+also absent from this Mathlib as a named lemma (only `transfer_center_eq_pow`).
+
+### Files Modified
+- `proofs/Proofs/Erdos1098OQ01OQ03.lean` (+`import Schreier`, +2 theorems)
+- `research/problems/erdos-1098-oq-01-oq-03/knowledge.md`
+
 ## Session 2026-07-08 (researcher-3) — finite-group hard direction is axiom-free
 
 File `Erdos1098OQ01OQ03.lean` is otherwise SOLVED-with-1-axiom: the forward

--- a/src/data/research/problems/erdos-1098-oq-01-oq-03.json
+++ b/src/data/research/problems/erdos-1098-oq-01-oq-03.json
@@ -38,7 +38,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Added axiom-free boundedCliques_of_finite_commutatorSet (FG + finite commutator set ⟹ bounded cliques, via Schur's finiteIndex_center). A Mathlib-checkable sufficient condition strictly below the axiomatized Neumann hard direction. neumann_hard_direction axiom unchanged (deep BFC content, not eliminable).",
+    "progressSummary": "PROGRESS (0-axiom): recast residual axiom gap into canonical finite-derived-subgroup (BFC) form via finite_commutatorSet_iff_finite_commutator + neumann_hard_direction_of_finite_commutator; sharpened blocker (FG-gate is essential, extraspecial-sum counterexample). Core BFC theorem for infinite G remains blocked (not in Mathlib).",
     "builtItems": [
       "commuting_of_invMul_mem_center",
       "nonCommuting_distinct_image",
@@ -47,7 +47,9 @@
       "bounded_cliques_of_finite_index",
       "neumann_full_theorem",
       "center_le_centralizer_singleton",
-      "center_finiteIndex_iff_relIndex_core"
+      "center_finiteIndex_iff_relIndex_core",
+      "finite_commutatorSet_iff_finite_commutator (Erdos1098OQ01OQ03.lean): Finite(commutatorSet G) ↔ Finite(commutator G), fwd=Schur/Schreier instance, bwd=trivial subset. VERIFIED 0-axiom.",
+      "neumann_hard_direction_of_finite_commutator (Erdos1098OQ01OQ03.lean): [Group.FG G][Finite(commutator G)] BoundedCliques G → (center G).index≠0, derived-subgroup phrasing via the iff. VERIFIED 0-axiom."
     ],
     "insights": [
       "Mathlib's index = 0 convention makes 'finite index' the clean hypothesis index ≠ 0",
@@ -55,14 +57,18 @@
       "Nat.card_pos_iff turns finite index into a Finite quotient instance, the only ingredient needed for the cardinality bound",
       "Neumann axiom localizes: [G:Z(G)] finite ⟺ Z(G) finite index within the finite-index core H = ⋂ₐ C_G(a) (Z(G) ≤ H since central elts commute with all a; index tower relIndex_mul_index). Residual gap = bound (center G).relIndex H.",
       "Mathlib Schur endgame is Subgroup.index_center_le_pow / finiteIndex_center (Commutator/Finite.lean): Finite (commutatorSet G) [+ Group.FG] ⟹ (center G) finite index. Hypothesis Finite (commutatorSet G) from bounded cliques is itself the BFC content (equally hard), so it does not eliminate the axiom.",
-      "boundedCliques_of_finite_commutatorSet (2026-07-12 researcher-1): axiom-free Schur sufficient condition — [Finite (commutatorSet G)] [Group.FG G] ⟹ BoundedCliques G, via Mathlib Subgroup.finiteIndex_center + the easy direction bounded_cliques_of_finite_index. #print axioms = [propext,Classical.choice,Quot.sound] only; does NOT use neumann_hard_direction. Realizes the easy half of the documented Subgroup.index_center_le_pow endgame. Build EXIT 0."
+      "boundedCliques_of_finite_commutatorSet (2026-07-12 researcher-1): axiom-free Schur sufficient condition — [Finite (commutatorSet G)] [Group.FG G] ⟹ BoundedCliques G, via Mathlib Subgroup.finiteIndex_center + the easy direction bounded_cliques_of_finite_index. #print axioms = [propext,Classical.choice,Quot.sound] only; does NOT use neumann_hard_direction. Realizes the easy half of the documented Subgroup.index_center_le_pow endgame. Build EXIT 0.",
+      "Mathlib finiteIndex_center endgame is genuinely FG-gated, not merely circular: ⨁ extraspecial p-groups have finite commutatorSet but infinite [G:Z(G)], so Finite(commutatorSet G)→FiniteIndex(center G) is FALSE for non-FG G — no FG-free shortcut exists.",
+      "Residual axiom content recast in canonical BFC form: for FG G the sole open piece is BoundedCliques G → Finite(commutator G) (finite DERIVED SUBGROUP), Neumann 1976 textbook statement."
     ],
     "mathlibGaps": [
-      "No formalization of B. H. Neumann's BFC theorem (bounded non-commuting sets ⟹ finite centre index)"
+      "No formalization of B. H. Neumann's BFC theorem (bounded non-commuting sets ⟹ finite centre index)",
+      "Schur converse FiniteIndex(center G)→Finite(commutator G) absent from Mathlib v4.26 as a named lemma (only transfer_center_eq_pow); BFC theorem BoundedCliques→Finite(commutator) also absent."
     ],
     "nextSteps": [
       "Attempt bounded cliques ⟹ Finite (commutatorSet G) (BFC), then chain Mathlib Subgroup.index_center_le_pow to remove neumann_hard_direction — this is the deep Neumann 1976 content",
-      "Alternatively bound (center G).relIndex H directly within the finite-index core H that centralizes a maximal clique"
+      "Alternatively bound (center G).relIndex H directly within the finite-index core H that centralizes a maximal clique",
+      "Core still blocked: prove BoundedCliques G → Finite(commutator G) (BFC/Neumann covering argument, >1000 lines) to eliminate neumann_hard_direction for infinite G."
     ],
     "markdown": "# Knowledge Base: erdos-1098-oq-01-oq-03\n\n## Problem Understanding\n\nNeumann's theorem (Erdős #1098): ω(Γ(G)) finite ⟺ [G:Z(G)] finite.\n\n## Insights\n\n- Reverse direction is elementary and sharp: ω ≤ [G:Z(G)] via injectivity of G → G/Z(G) on cliques.\n- Forward direction is Neumann (1976), a BFC/covering argument, axiomatized.\n\n## Dead Ends\n\n- Direct formalization of Neumann's covering argument is out of reach in one session.\n"
   },


### PR DESCRIPTION
## Summary

Erdős #1098 / Neumann: `ω(Γ(G))` finite ⟺ `[G:Z(G)]` finite. The hard direction is the axiom `neumann_hard_direction` (B.H. Neumann's BFC theorem, not in Mathlib). Prior sessions pinned its residual content to `BoundedCliques G → Finite (commutatorSet G)`. This PR recasts that gap into the **canonical textbook BFC form** (finite derived *subgroup*) and ties it to the exact Mathlib object.

Two new theorems in `proofs/Proofs/Erdos1098OQ01OQ03.lean`, both **VERIFIED 0 sorry / 0 new axiom** (`#print axioms` = `propext, Classical.choice, Quot.sound` — neither invokes the BFC axiom):

- `finite_commutatorSet_iff_finite_commutator : Finite (commutatorSet G) ↔ Finite (commutator G)`.
  Forward = Schur's theorem (Mathlib `Schreier.lean` instance `[Finite (commutatorSet G)] → Finite (commutator G)`, no finite-generation needed); backward = the trivial subset `commutatorSet G ⊆ ↑(commutator G)`.
- `neumann_hard_direction_of_finite_commutator [Group.FG G] [Finite (commutator G)] (_ : BoundedCliques G) : (center G).index ≠ 0` — the finite derived-subgroup phrasing of the existing `_of_finite_commutatorSet` reduction, via the iff.

Consequence: for finitely generated `G`, the sole remaining content of the axiom is `BoundedCliques G → Finite (commutator G)` — Neumann's BFC theorem in its canonical "finite `G'`" form.

Adds `import Mathlib.GroupTheory.Schreier` (the derived-subgroup finiteness instance is not in the already-imported `Commutator.Finite`).

## Blocker sharpening (knowledge.md)

The Mathlib endgame `Subgroup.finiteIndex_center` requires **both** `[Finite (commutatorSet G)]` and `[Group.FG G]`, and the FG hypothesis is **essential, not a removable circularity**: `G = ⨁ extraspecial p-groups` has finite `commutatorSet` yet infinite `[G:Z(G)]`, so `Finite (commutatorSet G) → FiniteIndex (center G)` is false for non-FG `G`. This closes off the "index_center_le_pow is circular, break the circle" route suggested by prior notes.

## Verification

`lake env lean Proofs/Erdos1098OQ01OQ03.lean` — EXIT 0, elaborates against current `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)