### PR TITLE
Enrich Triangle Angle Sum OQ-04 (Werner/Dirichlet kernel): overview section + annotation mathContext

### DIFF
--- a/src/data/proofs/triangle-angle-sum-oq-04/annotations.json
+++ b/src/data/proofs/triangle-angle-sum-oq-04/annotations.json
@@ -9,6 +9,19 @@
     "type": "concept",
     "title": "Overview: Werner Product-to-Sum Identities and the Finite Dirichlet Kernel",
     "content": "The four Werner product-to-sum identities convert a product of two sinusoids into a sum (e.g. 2·cos x·cos y = cos(x−y) + cos(x+y)). These are the building blocks; the substantive content is their telescoping application — the closed forms of the finite cosine and sine sums, the Dirichlet kernel / Lagrange trigonometric identity: 2·sin(x/2)·∑_{k=1}^{n} cos(kx) = sin((n+½)x) − sin(x/2), its sine analogue, and the kernel form ½ + ∑_{k=1}^{n} cos(kx) = sin((n+½)x)/(2·sin(x/2)) when sin(x/2) ≠ 0. Mathlib supplies the Werner identities (Real.two_mul_cos_mul_cos etc.) and the sum-to-product identities, but records no finite telescoped trigonometric sums — only the infinite power series Real.cos_eq_tsum, not the finite ∑ cos(kx) closed form. Those finite identities, the heart of classical Fourier analysis (partial sums of Fourier series are convolutions with the Dirichlet kernel Dₙ), are the original content here. The crux: each summand is a telescoping difference produced by a single Werner identity, 2·sin(x/2)·cos((k+1)x) = sin((k+1+½)x) − sin((k+½)x), so summing collapses to the endpoints. Verified: 0 sorries, 0 axiom declarations, no native_decide.",
+    "mathContext": "The telescoping engine is the summation-by-parts identity $2\\sin\\tfrac{x}{2}\\sum_{k=1}^{n}\\cos(kx) = \\sin\\!\\big((n+\\tfrac12)x\\big) - \\sin\\tfrac{x}{2}$, whose kernel form $D_n(x) = \\tfrac12 + \\sum_{k=1}^{n}\\cos(kx) = \\dfrac{\\sin((n+\\tfrac12)x)}{2\\sin\\tfrac{x}{2}}$ is the classical Dirichlet kernel — the $n$-th partial sum of a Fourier series equals convolution against $D_n$. The factor $\\sin\\tfrac{x}{2}$ in the denominator is a removable singularity: at $x \\to 0$ the kernel tends to $n+\\tfrac12$, matching $D_n(0) = \\tfrac12 + n$ from the raw sum.",
+    "prerequisites": [
+      "The four Werner product-to-sum identities (the algebraic building blocks proved in the first section)",
+      "Finite induction over Finset.range n with Finset.sum_range_succ",
+      "The notion of a summation kernel and the removable singularity at sin(x/2) = 0"
+    ],
+    "relatedConcepts": [
+      "Dirichlet kernel",
+      "Lagrange trigonometric identity",
+      "Fourier partial sums",
+      "telescoping sums",
+      "summation by parts"
+    ],
     "significance": "critical"
   },
   {

--- a/src/data/proofs/triangle-angle-sum-oq-04/meta.json
+++ b/src/data/proofs/triangle-angle-sum-oq-04/meta.json
@@ -73,6 +73,14 @@
   },
   "sections": [
     {
+      "id": "overview-and-goal",
+      "title": "Overview: What Mathlib Has and What This Adds",
+      "startLine": 1,
+      "endLine": 51,
+      "mathContext": "Goal: the finite Dirichlet kernel $\\tfrac12 + \\sum_{k=1}^{n}\\cos(kx) = \\sin((n+\\tfrac12)x)/(2\\sin\\tfrac{x}{2})$, absent from Mathlib (which records only the infinite series $\\texttt{Real.cos\\_eq\\_tsum}$).",
+      "summary": "The module docstring states the four Werner product-to-sum identities and the two finite telescoped sums they generate (the cosine and sine Dirichlet/Lagrange identities), then the kernel closed form ½ + ∑ cos(kx) = sin((n+½)x)/(2·sin(x/2)) valid when sin(x/2) ≠ 0. It scopes the contribution against Mathlib: the Werner and sum-to-product identities exist upstream (Real.two_mul_cos_mul_cos, Real.cos_add_cos, …) but the finite telescoped trigonometric sums — the heart of classical Fourier analysis, since a Fourier partial sum is convolution against the Dirichlet kernel Dₙ — do not; Mathlib records only the infinite power series Real.cos_eq_tsum. The stated crux is that each summand, multiplied by 2·sin(x/2), is a telescoping difference produced by one Werner identity. The file is verified with 0 sorries, 0 axiom declarations and no native_decide."
+    },
+    {
       "id": "werner-identities",
       "title": "The Four Werner Product-to-Sum Identities",
       "startLine": 52,


### PR DESCRIPTION
Enrichment pass for `triangle-angle-sum-oq-04` (below minimum: 4/5 annotations had `mathContext`; sections omitted the docstring).

**Changes**
- **Sections now cover the whole file (1–176, was 52–176):** added an `Overview: What Mathlib Has and What This Adds` section summarising the module docstring — the Werner→telescoping strategy, the Dirichlet-kernel goal, and the Mathlib gap (only `Real.cos_eq_tsum` upstream, no finite `∑ cos(kx)` closed form).
- **Overview annotation reached the mathContext minimum (5/5):** backfilled its `mathContext` (Dirichlet kernel closed form + the removable singularity at `sin(x/2)=0`, where `Dₙ(0)=n+½`), plus `prerequisites` and `relatedConcepts`.

No existing content removed; `meta.json` 17 KB (well under the 60 KB cap); keyInsights unchanged at 4. Build validates all gallery/JSON steps (fails only at terminal `tsc`, a known env gap).