### PR TITLE
Enrich Dirichlet eta at even integers: add odd-argument open question

### DIFF
--- a/src/data/proofs/basel-problem-oq-11-oq-01/meta.json
+++ b/src/data/proofs/basel-problem-oq-11-oq-01/meta.json
@@ -153,6 +153,11 @@
         "id": "basel-problem-oq-11-oq-01-oq-01",
         "question": "Package the generic relation against Mathlib's hasSum_zeta_nat to obtain η(2m) = (1 − 2^{1−2m})·(−1)^{m+1} B_{2m} (2π)^{2m} / (2·(2m)!) as a closed form in the Bernoulli numbers for all m ≥ 1.",
         "significance": "medium"
+      },
+      {
+        "id": "basel-problem-oq-11-oq-01-oq-02",
+        "question": "The generic relation η(e) = (1 − 2^{1−e})ζ(e) is proved at an arbitrary natural exponent e, so it applies verbatim to odd arguments — e.g. η(3) = (3/4)ζ(3). Unlike the even case, however, no elementary closed form is known for ζ(2m+1): ζ(3) (Apéry's constant) was proved irrational by Apéry (1979), but its transcendence is open, and the irrationality of ζ(5), ζ(7), … remains unknown (only that infinitely many ζ(2m+1) are irrational, Ball–Rivoal 2001). What, if anything, can be said constructively about the odd-index eta/zeta values beyond reducing η(2m+1) to ζ(2m+1) — and does the parity split that closes the even case leave any exploitable structure at odd exponents?",
+        "significance": "high"
       }
     ]
   },


### PR DESCRIPTION
Enrichment pass for `basel-problem-oq-11-oq-01` (*Dirichlet eta at even integers: η(2m) = (1 − 2^{1−2m})ζ(2m)*).

## Gap
A below-minimum sweep flagged this entry with only **1 openQuestion** in its conclusion — below the 2+ minimum. (Annotations 5/5 rich, keyInsights 5, historicalContext all fine; the sole deficiency was the open-questions count.)

## Change
Added one substantive second open question on the **odd-argument case**. The generic relation $\eta(e) = (1 - 2^{1-e})\zeta(e)$ is proved at an *arbitrary* natural exponent $e$, so it applies verbatim to odd arguments (e.g. $\eta(3) = \tfrac34\zeta(3)$) — but, unlike the even case, no elementary closed form for $\zeta(2m+1)$ is known: Apéry's irrationality of $\zeta(3)$ (1979), the still-open transcendence question, and Ball–Rivoal (2001, infinitely many $\zeta(2m+1)$ irrational). This is a genuine open direction the entry naturally raises but did not list.

## Guardrails
- meta.json ~13.4 KB → 13.8 KB (far under the 60 KB cap)
- conclusion.openQuestions 1 → 2 (reaches the minimum; not inflated)
- Single-file change; no content deleted
- Mathematically accurate; history verified (Apéry 1979, Ball–Rivoal 2001)