### PR TITLE
Enrich Viviani n-gon characterisation: complete overview annotation

### DIFF
--- a/src/data/proofs/viviani-theorem-oq-01-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/viviani-theorem-oq-01-oq-01-oq-01/annotations.json
@@ -9,7 +9,20 @@
     "type": "concept",
     "title": "Overview: Viviani's Theorem — the Convex n-gon Characterisation",
     "content": "The parent leaf viviani-theorem-oq-01-oq-01 proved the triangle converse: the signed perpendicular-distance sum is constant iff the three inward unit normals sum to zero, iff the triangle is equilateral. This leaf removes the triangle-specific \"equilateral\" half and isolates the genuinely general phenomenon, valid for an arbitrary finite family of edges (a convex n-gon, in fact any indexed family of normals). For a polygon whose edge i lies on the line {x : ⟪x, νᵢ⟫ = cᵢ} with outward unit normal νᵢ, the signed distance from an interior point x to edge i is dᵢ(x) = cᵢ − ⟪x, νᵢ⟫, so the total distance-sum S(x) = (∑ᵢ cᵢ) − ⟪x, ∑ᵢ νᵢ⟫ is an affine function of x with gradient −∑ᵢ νᵢ; hence S is constant on the plane ⇔ ∑ᵢ νᵢ = 0 (★). The headline corollary is that every regular n-gon has the Viviani property: its outward unit normals are the n-th roots of unity ζ⁰, ζ¹, …, ζⁿ⁻¹ with ζ = exp(2πi/n), and these sum to zero for n ≥ 2. The characterisation (★) is sharp and captures a strictly larger class than the regular polygons (any family of unit vectors closing up to zero, e.g. equiangular polygons). The Euclidean plane is modelled as ℂ, reusing the parent's explicit real inner product rdot; the whole argument is elementary linear algebra over a finite index set, needing no non-degeneracy hypothesis.",
-    "significance": "critical"
+    "mathContext": "Signed distance to edge $i$: $d_i(x) = c_i - \\langle x, \\nu_i\\rangle$. Total: $S(x) = \\sum_i c_i - \\langle x, \\sum_i \\nu_i\\rangle$, an affine map with constant gradient $-\\sum_i \\nu_i$; so $S$ is constant on $\\mathbb{R}^2$ $\\iff \\sum_i \\nu_i = 0$ (★). Regular $n$-gon: $\\nu_k = \\zeta^k$ with $\\zeta = e^{2\\pi i/n}$, and $\\sum_{k=0}^{n-1}\\zeta^k = \\frac{\\zeta^n - 1}{\\zeta - 1} = 0$ for $n \\ge 2$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "affine functions and gradients",
+      "outward unit normals",
+      "roots of unity",
+      "convex polygon geometry",
+      "Viviani property"
+    ],
+    "prerequisites": [
+      "signed perpendicular distance to a line",
+      "real inner product on ℂ",
+      "geometric sum of roots of unity"
+    ]
   },
   {
     "id": "ann-rdot-sum",


### PR DESCRIPTION
## Enrichment pass — viviani-theorem-oq-01-oq-01-oq-01

The overview annotation (lines 1–37) was the single under-populated annotation in this entry (4/5 fully-populated; it had only `significance`). All four sibling annotations carry `mathContext`, `relatedConcepts`, and `prerequisites`; this brings the overview up to the same depth, reaching the 5-annotation minimum.

Added to the overview annotation:
- **mathContext**: the signed-distance formula $d_i(x)=c_i-\langle x,\nu_i\rangle$, the affine total $S(x)=\sum_i c_i-\langle x,\sum_i\nu_i\rangle$ with constant gradient $-\sum_i\nu_i$, the (★) characterisation $S\text{ constant}\iff\sum_i\nu_i=0$, and the regular-$n$-gon roots-of-unity cancellation $\sum_{k=0}^{n-1}\zeta^k=0$.
- **relatedConcepts**: affine functions and gradients, outward unit normals, roots of unity, convex polygon geometry, Viviani property.
- **prerequisites**: signed perpendicular distance to a line, real inner product on ℂ, geometric sum of roots of unity.

All content is drawn directly from the Lean file's docstring and lemmas (`distSum_sub`, `distSum_const_iff_normalSum_zero`, `regularNormal_sum_zero`). No existing content removed. Axiom/status metadata unchanged.