### PR TITLE
Enrich three geometric-series leaf entries: docstring sections + open questions

### DIFF
--- a/src/data/proofs/geometric-series-oq-08-oq-01-oq-01-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/geometric-series-oq-08-oq-01-oq-01-oq-01-oq-02-oq-01/meta.json
@@ -89,6 +89,13 @@
   },
   "sections": [
     {
+      "id": "overview-setup",
+      "title": "Overview: Closing the Loop between infMoment and the Eulerian Closed Form",
+      "startLine": 1,
+      "endLine": 64,
+      "summary": "Imports (Mathlib, the parent infMoment file, and the Eulerian-polynomial sibling GeometricSeriesOQ07OQ01OQ01) and the docstring. The parent defines the infinite moment infMoment m x = ∑_{k≥0} kᵐ·xᵏ (|x|<1) and proves the binomial-convolution recurrence (★∞); the sibling defines the Eulerian polynomial eulerPoly m by its differential recurrence and proves the Frobenius closed form HasSum(kᵐ·rᵏ, Eₘ(r)/(1−r)^{m+1}). This entry closes the loop: infMoment_eq_eulerPoly (infMoment m x = Eₘ(x)/(1−x)^{m+1}), eulerPoly_recurrence (the NEW polynomial identity that the Eulerian polynomials satisfy the (★∞) binomial-convolution recurrence over ℝ[X], proved by eq_of_infinite_eval_eq — equality at infinitely many r ∈ (−1,1) forces polynomial equality), and infMoment_three (∑ k³xᵏ = x(1+4x+x²)/(1−x)⁴). Honest scope: the closed form reuses the gallery's analytic Eulerian identity, not a from-scratch induction on (★∞); the genuinely new content is eulerPoly_recurrence and the third moment. 0-axiom, sorry-free. Opens namespace ...OQ02OQ01, Polynomial Finset, and the two parent namespaces."
+    },
+    {
       "id": "headline-closed-form",
       "title": "Part 1: The Headline Closed Form",
       "startLine": 65,
@@ -155,7 +162,8 @@
     "summary": "For a real ratio x with |x| < 1, the infinite m-th moment infMoment m x = ∑'_{k} kᵐ·xᵏ — characterised in the parent by the binomial-convolution recurrence (★∞) — is solved in closed form: infMoment m x = Eₘ(x)/(1 − x)^{m+1}, with Eₘ the gallery's Eulerian polynomial. This identifies the tsum-defined recurrence object with the Frobenius/Eulerian closed form of the sibling line. The recurrence (★∞) is then shown to hold for the Eulerian polynomials themselves as a polynomial identity over ℝ[X], (1 − X)·Eₘ = 0ᵐ·(1 − X)^{m+1} + X·∑_{i<m} C(m,i)·Eᵢ·(1 − X)^{m−i}, proved by evaluating both sides on the infinite set (−1,1). Specialising the closed form recovers the first and second moments and yields the new explicit third moment ∑ k³·xᵏ = (x + 4x² + x³)/(1 − x)⁴. 145 lines, 5 theorems, 0 definitions, 0 axioms, 0 sorries; every result depends only on propext, Classical.choice, Quot.sound.",
     "implications": "The entry closes the loop between the gallery's two complementary descriptions of the infinite geometric moments: the derivative-free binomial-convolution recurrence (★∞) and the differential Eulerian-polynomial recurrence. The new polynomial identity eulerPoly_recurrence records, in Mathlib-free form, that the Eulerian polynomials satisfy the Pascal-weighted convolution recursion — a relation absent from Mathlib. Honest scope: the headline closed form reuses the gallery's analytic Frobenius identity rather than re-deriving it by strong induction on (★∞); the genuinely new content is the polynomial recurrence identity and the explicit third-moment closed form.",
     "openQuestions": [
-      "Prove eulerPoly_recurrence purely algebraically by induction on m from the differential recurrence and Pascal's rule, giving an analysis-free derivation of the Eulerian closed form directly from (★∞)."
+      "Prove eulerPoly_recurrence purely algebraically by induction on m from the differential recurrence and Pascal's rule, giving an analysis-free derivation of the Eulerian closed form directly from (★∞).",
+      "Give the promised analysis-free derivation: prove eulerPoly_recurrence purely algebraically by induction on m from the differential recurrence E_{m+1} = X(1−X)E'ₘ + (m+1)X·Eₘ and Pascal's rule, then read the fourth moment ∑ k⁴xᵏ = x(1+11x+11x²+x³)/(1−x)⁵ off eulerPoly_four to continue the moment ladder beyond the third."
     ]
   }
 }

--- a/src/data/proofs/geometric-series-oq-08-oq-03-oq-01-oq-01/meta.json
+++ b/src/data/proofs/geometric-series-oq-08-oq-03-oq-01-oq-01/meta.json
@@ -34,6 +34,14 @@
   },
   "sections": [
     {
+      "id": "overview-setup",
+      "title": "Overview: Identifying the Limit via Completeness and the Truncation Defect",
+      "startLine": 1,
+      "endLine": 58,
+      "summary": "Imports (the sibling GeometricSeriesOQ08OQ03OQ01) and the docstring. The sibling proved the partial sums S n = ∑_{k<n} rᵏ form a CauchySeq and are Summable from the tail-block bound rᵐ/(1−r) alone, deliberately without quoting hasSum_geometric — leaving the VALUE of the limit open. This entry closes that arc, pinning the limit to (1−r)⁻¹: geometric_truncation_defect (S n = (1−r)⁻¹ − rⁿ/(1−r), pure geom_sum_eq), geometric_partialSum_tendsto (S n → (1−r)⁻¹ since the defect → 0), geometric_limit_from_completeness (the abstract route: cauchySeq_tendsto_of_complete gives SOME limit L, then tendsto_nhds_unique identifies L = (1−r)⁻¹), and geometric_hasSum / geometric_tsum recovered via Summable.hasSum_iff_tendsto_nat — never invoking hasSum_geometric. Opens namespace GeometricSeriesOQ08OQ03OQ01OQ01, Finset Filter, variable {r : ℝ}.",
+      "mathContext": "$\\sum_{k<n} r^k = (1-r)^{-1} - \\dfrac{r^n}{1-r} \\to (1-r)^{-1}$; existence of the limit from completeness, its value from the truncation defect."
+    },
+    {
       "id": "defect-and-limit",
       "title": "The Truncation Defect and the Partial-Sum Limit",
       "startLine": 59,
@@ -166,7 +174,8 @@
     "summary": "For 0 ≤ r < 1 the limit of the geometric series is identified as (1 − r)⁻¹ from first principles. The truncation defect ∑_{k<n} rᵏ = (1 − r)⁻¹ − rⁿ/(1 − r) (a geom_sum_eq rearrangement) gives geometric_partialSum_tendsto: the partial sums converge to (1 − r)⁻¹ because rⁿ/(1 − r) → 0. The sibling's geometric_partialSum_cauchySeq plus completeness of ℝ (cauchySeq_tendsto_of_complete) yield a limit L abstractly, which tendsto_nhds_unique pins to (1 − r)⁻¹ (geometric_limit_from_completeness). Combined with the sibling's geometric_summable via Summable.hasSum_iff_tendsto_nat this gives HasSum (fun n ↦ rⁿ) (1 − r)⁻¹ and ∑' n, rⁿ = (1 − r)⁻¹. 125 lines, 5 theorems, 0 definitions, 0 axioms, 0 sorries; each result depends only on propext, Classical.choice, Quot.sound.",
     "implications": "This closes the lineage geometric-series-oq-08-oq-03 → …-oq-01 → …-oq-01-oq-01, which rebuilds the geometric series' convergence theory from the Cauchy criterion upward: first the ε–N block estimate, then the abstract CauchySeq/Summable predicates, and now the limit value. Completeness of ℝ supplies the existence of a limit knowing only that the partial sums are Cauchy; the truncation defect supplies its identity. Together they reproduce Mathlib's hasSum_geometric_of_lt_one and tsum_geometric_of_lt_one along an independent path that never assumes the closed form it concludes — the sum (1 − r)⁻¹ is earned, not quoted.",
     "openQuestions": [
-      "Extend the from-first-principles limit identification from 0 ≤ r < 1 to the full signed disc |r| < 1, recovering summability by absolute convergence and re-identifying (1 − r)⁻¹ through the (already field-valid) truncation defect."
+      "Extend the from-first-principles limit identification from 0 ≤ r < 1 to the full signed disc |r| < 1, recovering summability by absolute convergence and re-identifying (1 − r)⁻¹ through the (already field-valid) truncation defect.",
+      "Make the convergence quantitative: extract an explicit modulus N(ε) — the least n with rⁿ/(1−r) < ε — from the truncation defect, turning the from-first-principles limit identification into an effective rate of convergence rather than a bare tendsto statement."
     ]
   }
 }

--- a/src/data/proofs/geometric-series-oq-08-oq-03-oq-01/meta.json
+++ b/src/data/proofs/geometric-series-oq-08-oq-03-oq-01/meta.json
@@ -36,6 +36,14 @@
   },
   "sections": [
     {
+      "id": "overview-setup",
+      "title": "Overview: Promoting the Slice Bound to CauchySeq and Summable",
+      "startLine": 1,
+      "endLine": 64,
+      "summary": "Imports (GeomSum, SpecificLimits.Basic, InfiniteSum.Real) and the docstring. The sibling GeometricSeriesOQ08OQ03 gave the bespoke ε–N estimate geometric_slice_cauchy (every middle block ∑_{k∈Ico m n} rᵏ ≤ ε past a threshold). This entry translates that hand-rolled inequality into Mathlib's abstract predicates so it plugs into the library's convergence machinery: geometric_partialSum_dist / _dist_le (the block IS the metric distance between partial sums, ≤ r^{min m n}/(1−r)), geometric_partialSum_cauchySeq (the headline CauchySeq via Metric.cauchySeq_iff), geometric_partialSum_le (bounded by (1−r)⁻¹), geometric_summable (via summable_of_sum_range_le), and geometric_cauchySeq_finset (the Mathlib-native net over finsets, summable_iff_cauchySeq_finset). All route around hasSum_geometric — the closed form is a consequence, not a premise. Opens namespace GeometricSeriesOQ08OQ03OQ01, Finset, variable {r : ℝ}.",
+      "mathContext": "$\\mathrm{dist}(S_m, S_n) = \\sum_{k\\in[m,n)} r^k \\le \\dfrac{r^{\\min(m,n)}}{1-r}$; hence CauchySeq and Summable, without the closed form."
+    },
+    {
       "id": "metric-slice",
       "title": "The Metric Reading of the Slice",
       "startLine": 65,
@@ -175,7 +183,8 @@
     "summary": "For 0 ≤ r < 1 the geometric series is shown to converge as a Cauchy sequence and to be summable, from first principles. The Ico-slice bound rᵐ/(1 − r) is read metrically — dist (∑_{k<m} rᵏ) (∑_{k<n} rᵏ) ≤ r^{min m n}/(1 − r) — and fed to Metric.cauchySeq_iff to give geometric_partialSum_cauchySeq; the m = 0 bound ∑_{k<n} rᵏ ≤ (1 − r)⁻¹ feeds summable_of_sum_range_le to give geometric_summable; and summable_iff_cauchySeq_finset yields the finset-net CauchySeq. 152 lines, 7 theorems, 0 definitions, 0 axioms, 0 sorries; each result depends only on propext, Classical.choice, Quot.sound.",
     "implications": "The sibling geometric-series-oq-08-oq-03 stated the Cauchy property as a bespoke inequality; this entry is the translation into Mathlib's convergence vocabulary (CauchySeq, Summable, cauchySeq over finsets), so the geometric series can be dropped into the library's general theorems. Conceptually it closes a loop: the series is exhibited as convergent/summable using only bounded blocks and bounded monotone partial sums, with the closed form (1 − r)⁻¹ appearing as a consequence of convergence rather than as the premise — a derivation that deliberately routes around hasSum_geometric.",
     "openQuestions": [
-      "Combine geometric_partialSum_cauchySeq with completeness (cauchySeq_tendsto_of_complete) and the truncation defect rⁿ/(1 − r) → 0 to identify the limit as (1 − r)⁻¹, recovering hasSum_geometric independently."
+      "Combine geometric_partialSum_cauchySeq with completeness (cauchySeq_tendsto_of_complete) and the truncation defect rⁿ/(1 − r) → 0 to identify the limit as (1 − r)⁻¹, recovering hasSum_geometric independently.",
+      "Abstract the pattern into a reusable comparison lemma: any real series whose tail blocks satisfy a geometric-type bound ∑_{k∈Ico m n} aₖ ≤ C·ρᵐ (0 ≤ ρ < 1) is CauchySeq and Summable by the same Metric.cauchySeq_iff argument, so the geometric case here becomes one instance of a general tail-block convergence test."
     ]
   }
 }


### PR DESCRIPTION
## Enrichment pass — three geometric-series leaf entries

Same two below-target gaps in each sibling entry, addressed together:

- **Section coverage.** In all three, `sections` began at line 59/65, leaving the imports, file docstring (theorem statements + strategy), and namespace/variable setup uncovered. Added an `overview-setup` section spanning the uncovered opening lines with a substantive summary (and `mathContext` where the sibling sections carry it).
- **Open questions.** Each had a single open question (below the 2+ minimum). Added a second, entry-specific one:
  - `…oq-08-oq-03-oq-01-oq-01` (limit from completeness + truncation defect): an **effective modulus N(ε)** for a quantitative convergence rate.
  - `…oq-08-oq-03-oq-01` (slice bound → CauchySeq/Summable): a **general tail-block comparison test** abstracting the geometric case.
  - `…oq-08-oq-01-oq-01-oq-01-oq-02-oq-01` (infMoment ↔ Eulerian closed form): the **analysis-free algebraic derivation** of `eulerPoly_recurrence` and the fourth-moment ladder step.

All summaries drawn from the Lean files' docstrings and lemmas; no existing content removed; axiom/status metadata unchanged.