### PR TITLE
Research: erdos-729-oq-02 - sharp two-sided quantitative Legendre bound at p=2

### DIFF
--- a/proofs/Proofs/Erdos729LegendreGeneral.lean
+++ b/proofs/Proofs/Erdos729LegendreGeneral.lean
@@ -128,6 +128,54 @@ theorem padicValNat_factorial_le_div (p n : ℕ) (hp : p.Prime) :
   rw [padicValNat_factorial_eq_div p n hp]
   exact Nat.div_le_div_right (Nat.sub_le n ((p.digits n).sum))
 
+/-! ### Sharp digit-sum upper bound and the matching lower bound on `v_p(n!)`
+
+The bounds above (`sub_one_mul_padicValNat_factorial_le`, `padicValNat_factorial_le_div`)
+control `v_p(n!)` from *above*, with the digit-sum defect `s_p(n)` measuring the shortfall
+below the heuristic `n/(p-1)`.  The complementary *lower* bound needs an **upper** bound on
+that defect: each base-`p` digit is at most `p - 1`, so `s_p(n) ≤ (p-1)·(#base-p digits)`,
+and the digit count is `⌊log_p n⌋ + 1`.  This makes `s_p(n)` logarithmically small in `n`,
+so `(p-1)·v_p(n!) = n - s_p(n)` is within `(p-1)(⌊log_p n⌋+1)` of `n` — i.e. `v_p(n!)` tracks
+`n/(p-1)` up to a `O(log n)` correction.  Below the general multiplied-form lower bound, then
+the clean two-sided sandwich at `p = 2`, where `p - 1 = 1` gives `n - ⌊log₂ n⌋ - 1 ≤ v₂(n!) ≤
+n - 1`, hence `v₂(n!)/n → 1`. -/
+
+/-- **Digit-sum bounded by the digit count.**  Every base-`p` digit is `< p`, hence `≤ p-1`,
+so the digit sum is at most `(p-1)` times the number of digits.  The elementary upper bound
+complementing `digitSum_pos`; the input to the sharp lower bound on `v_p(n!)`. -/
+theorem digitSum_le_length_mul {p : ℕ} (hp : 1 < p) (n : ℕ) :
+    digitSum p n ≤ (p.digits n).length * (p - 1) := by
+  have h := List.sum_le_card_nsmul (p.digits n) (p - 1)
+    (fun d hd => by have := Nat.digits_lt_base hp hd; omega)
+  simpa [digitSum, smul_eq_mul] using h
+
+/-- **Digit sum is logarithmically small.**  Since a positive `n` has exactly `⌊log_p n⌋ + 1`
+base-`p` digits (`Nat.digits_len`), `s_p(n) ≤ (p-1)·(⌊log_p n⌋ + 1)`.  For `p = 2` this is the
+Hamming weight bound `s_2(n) ≤ ⌊log₂ n⌋ + 1` (at most one 1-bit per bit position). -/
+theorem digitSum_le_log_succ_mul {p : ℕ} (hp : 1 < p) {n : ℕ} (hn : n ≠ 0) :
+    digitSum p n ≤ (Nat.log p n + 1) * (p - 1) := by
+  have h := digitSum_le_length_mul hp n
+  rwa [Nat.digits_len p n hp hn] at h
+
+/-- **Sharp lower bound on `v_p(n!)`, multiplied form.**  From Legendre's identity
+`(p-1)·v_p(n!) = n - s_p(n)` and the logarithmic bound on the defect,
+`n - (p-1)(⌊log_p n⌋+1) ≤ (p-1)·v_p(n!)`.  Together with
+`sub_one_mul_padicValNat_factorial_le` (`≤ n`) this pins `(p-1)·v_p(n!)` into the window
+`[n - (p-1)(⌊log_p n⌋+1), n]`: the valuation matches `n/(p-1)` up to an `O(log n)` term. -/
+theorem sub_one_mul_padicValNat_factorial_ge {p n : ℕ} (hp : p.Prime) (hn : n ≠ 0) :
+    n - (Nat.log p n + 1) * (p - 1) ≤ (p - 1) * padicValNat p n.factorial := by
+  rw [sub_one_mul_padicValNat_factorial_digitSum p n hp]
+  have h := digitSum_le_log_succ_mul hp.one_lt hn
+  omega
+
+/-- **Sharp lower bound on `v_2(n!)`.**  At `p = 2` the leading factor `p - 1 = 1` disappears:
+`n - (⌊log₂ n⌋ + 1) ≤ v_2(n!)`.  The number of factors of `2` in `n!` is within `⌊log₂ n⌋ + 1`
+of the trivial ceiling `n`. -/
+theorem padicValNat_factorial_two_ge {n : ℕ} (hn : n ≠ 0) :
+    n - (Nat.log 2 n + 1) ≤ padicValNat 2 n.factorial := by
+  have h := sub_one_mul_padicValNat_factorial_ge (p := 2) Nat.prime_two hn
+  simpa using h
+
 /-- **The exact zero-locus of `v_p(n!)`.**  For every prime `p`,
 
   `v_p(n!) = 0  ↔  n < p`.
@@ -325,6 +373,25 @@ theorem digitSum_pos {p n : ℕ} (hn : n ≠ 0) : 0 < digitSum p n := by
   have hle : (p.digits n).getLast hne ≤ (p.digits n).sum := List.le_sum_of_mem hmem
   show 0 < (p.digits n).sum
   omega
+
+/-- **Sharp upper bound on `v_2(n!)`.**  Since `s_2(n) ≥ 1` for `n ≥ 1` (`digitSum_pos`),
+Legendre gives `v_2(n!) = n - s_2(n) ≤ n - 1`.  The complementary half of the sandwich; its
+lower half `padicValNat_factorial_two_ge` sits with the digit-count bounds above. -/
+theorem padicValNat_factorial_two_le {n : ℕ} (hn : n ≠ 0) :
+    padicValNat 2 n.factorial ≤ n - 1 := by
+  have hid := sub_one_mul_padicValNat_factorial_digitSum 2 n Nat.prime_two
+  have hpos := digitSum_pos (p := 2) hn
+  omega
+
+/-- **Two-sided quantitative Legendre bound at `p = 2`.**
+`n - (⌊log₂ n⌋ + 1) ≤ v_2(n!) ≤ n - 1`.  The `2`-adic valuation of `n!` sits within
+`⌊log₂ n⌋ + 1` of `n`, so `v_2(n!) = n - O(log n)` and `v_2(n!)/n → 1`.  Sharpens the
+one-sided `padicValNat_factorial_le_div` (which at `p = 2` reads `v_2(n!) ≤ n`) to a matching
+pair of bounds squeezing the valuation to a logarithmic-width window. -/
+theorem padicValNat_factorial_two_sandwich {n : ℕ} (hn : n ≠ 0) :
+    n - (Nat.log 2 n + 1) ≤ padicValNat 2 n.factorial ∧
+      padicValNat 2 n.factorial ≤ n - 1 :=
+  ⟨padicValNat_factorial_two_ge hn, padicValNat_factorial_two_le hn⟩
 
 /-- **Digit-sum invariance under multiplication by the base.**  For every base
 `p > 1`, `s_p(p · n) = s_p(n)`: writing `p · n` in base `p` appends a least-significant

--- a/research/problems/erdos-729-oq-02/knowledge.md
+++ b/research/problems/erdos-729-oq-02/knowledge.md
@@ -276,3 +276,46 @@ sorryAx, no ofReduceBool). File 539 → ~600 L. Parent axiom `barreto_leeham_the
 The elementary base-2/base-p p-adic theory (Legendre, Kummer additive/carry-count defect,
 central binomial `v_2 = s_2`, and now the power-of-two locus of `v_2(C(2n,n))=1`) is
 complete and axiom-free. Only the deep parent `barreto_leeham_theorem` remains.
+
+## Session 2026-07-12 (researcher-3) — sharp two-sided quantitative Legendre bound at p=2
+
+**Mode**: REVISIT (RICH, core solved / DONE). **Outcome**: progress — 6 axiom-free theorems,
+full-file offline EXIT 0.
+
+### What I Did
+The theory had `digitSum_pos` (s_p ≥ 1) and the upper bounds `sub_one_mul_padicValNat_factorial_le`
+(`(p-1)v_p(n!) ≤ n`), `padicValNat_factorial_le_div`. Missing: the SHARP upper bound on the
+digit-sum defect — `s_p(n) ≤ (p-1)·(#digits) = (p-1)·(⌊log_p n⌋+1)` — and the resulting lower
+bound on the valuation. Added to `Erdos729LegendreGeneral.lean`:
+- `digitSum_le_length_mul` : `s_p(n) ≤ (#base-p digits)·(p-1)` (each digit < p via
+  `Nat.digits_lt_base`; `List.sum_le_card_nsmul`).
+- `digitSum_le_log_succ_mul` : `s_p(n) ≤ (⌊log_p n⌋+1)·(p-1)` (`Nat.digits_len`).
+- `sub_one_mul_padicValNat_factorial_ge` : `n − (⌊log_p n⌋+1)·(p-1) ≤ (p-1)·v_p(n!)` (general-p
+  lower bound; complements the existing `_le`).
+- `padicValNat_factorial_two_ge` / `_two_le` / `_two_sandwich` : the clean p=2 sandwich
+  `n − (⌊log₂ n⌋+1) ≤ v_2(n!) ≤ n − 1`.
+
+### Key Findings
+- The defect `s_2(n)` is the Hamming weight, ≤ bit length ≤ ⌊log₂ n⌋+1. So Legendre's
+  `v_2(n!) = n − s_2(n)` puts v_2(n!) within ⌊log₂ n⌋+1 of the trivial ceiling n:
+  `v_2(n!) = n − O(log n)`, hence `v_2(n!)/n → 1`. This is the two-sided sharpening of the
+  file's one-sided `≤ n/(p-1)` bounds — the valuation squeezed to a logarithmic-width window.
+- `padicValNat_factorial_two_le` and `_two_sandwich` must be placed AFTER `digitSum_pos`
+  (forward-reference); the digit-count bounds + `_two_ge` live with the upper-bound family.
+
+### Honest status
+- Not new mathematics about the deep OQ (parent `barreto_leeham_theorem` untouched, out of
+  scope). Value: the sharp digit-count upper bound on `s_p(n)` (general-purpose, Mathlib-gap-
+  adjacent) and the two-sided quantitative Legendre bound the file was missing — the natural
+  complement of its one-sided upper bounds.
+- Verified: `LAKE_UNSAFE=1 ./bin/lake env lean Proofs/Erdos729LegendreGeneral.lean` EXIT 0,
+  0 errors/warnings. `#print axioms` on all 6 → `[propext, Classical.choice, Quot.sound]` only.
+
+### Files Modified
+- proofs/Proofs/Erdos729LegendreGeneral.lean (+6 thm, ~600→668 lines, 0 axioms, 0 sorries)
+- src/data/research/problems/erdos-729-oq-02.json (leanFiles counts synced 183L/10thm →
+  668L/37thm [prior r5/r10 additions were never synced]; +2 insights, +3 builtItems)
+
+### Next Steps
+- General-p division-form lower bound `n/(p-1) − (⌊log_p n⌋+1) ≤ v_p(n!)` (from the multiplied
+  form, minor). The deep parent `barreto_leeham_theorem` remains BLOCKED / out of scope.

--- a/src/data/research/problems/erdos-729-oq-02.json
+++ b/src/data/research/problems/erdos-729-oq-02.json
@@ -60,7 +60,10 @@
       "Erdos729LegendreGeneral.lean: padicValNat_centralBinom_two_eq_digitSum — SHARP v_2(C(2n,n))=s_2(n) (classical Kummer specialisation, was missing)",
       "Erdos729LegendreGeneral.lean: one_le_padicValNat_centralBinom_two — 1≤v_2(C(2n,n)) for n≥1 (sharpens centralBinom_even)",
       "Erdos729LegendreGeneral.lean: digitSum_two_pow — s_2(2^k)=1",
-      "Erdos729LegendreGeneral.lean: padicValNat_centralBinom_two_pow — v_2(C(2·2^k,2^k))=1 (C(2^{k+1},2^k)≡2 mod 4)"
+      "Erdos729LegendreGeneral.lean: padicValNat_centralBinom_two_pow — v_2(C(2·2^k,2^k))=1 (C(2^{k+1},2^k)≡2 mod 4)",
+      "digitSum_le_length_mul, digitSum_le_log_succ_mul (sharp digit-sum upper bounds by digit count / log) in Erdos729LegendreGeneral.lean",
+      "sub_one_mul_padicValNat_factorial_ge (general-p sharp lower bound on (p-1)*v_p(n!))",
+      "padicValNat_factorial_two_ge / _two_le / _two_sandwich (two-sided quantitative Legendre bound n - log2 n - 1 <= v_2(n!) <= n - 1)"
     ],
     "insights": [
       "The 2-adic doubling recurrence v_2((2n)!)=n+v_2(n!) is the p=2 shadow of a general-prime law: for EVERY prime p and residue 0<=r<p, v_p((p*n+r)!) = n + v_p(n!), the increment n being INDEPENDENT of r. So all p consecutive arguments pn, pn+1, ..., pn+(p-1) share one valuation step. Proof: (p-1)*v_p(m!)=m-s_p(m) (Mathlib) plus s_p(p*n+r)=s_p(n)+r and (p-1)*n+n=p*n, then cancel p-1>0. Not a named Mathlib lemma.",
@@ -76,7 +79,9 @@
       "Central binomial C(2n,n)=Nat.centralBinom n is the m=n case of the Kummer digit-sum machinery: v_p(C(2n,n))=(2*s_p(n)-s_p(2n))/(p-1) counts carries of n+n base p. digitSum_pos (n!=0 => s_p(n)>0) from getLast_digit_ne_zero (top base-p digit nonzero) + List.le_sum_of_mem.",
       "The sharp 2-adic valuation v_2(C(2n,n))=s_2(n) follows because doubling never carries in base 2 (s_2(2n)=s_2(n) via digitSum_base_mul), cancelling one of the two s_2(n) terms in the m=n Kummer identity.",
       "At n=2^k the central binomial coefficient is exactly ≡2 mod 4 (v_2=1) since s_2(2^k)=1.",
-      "Part: power-of-2 characterization — digitSum_two_eq_one_imp_two_pow (converse s_2(n)=1⟹∃k,n=2^k via strong induction on digit recurrence s_2(n)=n%2+s_2(n/2)), digitSum_two_eq_one_iff (full iff), padicValNat_centralBinom_two_eq_one_iff (v_2(C(2n,n))=1 ↔ n=2^k, sharp form of ..two_pow). 3 axiom-free thm, host-lean EXIT 0. Closes the open converse from PR#38419."
+      "Part: power-of-2 characterization — digitSum_two_eq_one_imp_two_pow (converse s_2(n)=1⟹∃k,n=2^k via strong induction on digit recurrence s_2(n)=n%2+s_2(n/2)), digitSum_two_eq_one_iff (full iff), padicValNat_centralBinom_two_eq_one_iff (v_2(C(2n,n))=1 ↔ n=2^k, sharp form of ..two_pow). 3 axiom-free thm, host-lean EXIT 0. Closes the open converse from PR#38419.",
+      "Sharp two-sided quantitative Legendre bound at p=2 (Erdos729LegendreGeneral.lean): n - (log2 n + 1) <= v_2(n!) <= n - 1. The theory had digitSum_pos (lower bound on s_p) and used s_p(n)<=n, but lacked the SHARP upper bound s_p(n) <= (p-1)*(digit count) = (p-1)*(floor(log_p n)+1). That bound makes the Legendre defect logarithmically small, so v_2(n!) = n - O(log n) and v_2(n!)/n -> 1.",
+      "Key API: each base-p digit < p (Nat.digits_lt_base), digit count = floor(log_p n)+1 (Nat.digits_len), List.sum_le_card_nsmul for sum <= length*(p-1). General multiplied lower bound sub_one_mul_padicValNat_factorial_ge: n - (log_p n + 1)*(p-1) <= (p-1)*v_p(n!), complementing the existing sub_one_mul_padicValNat_factorial_le (<= n)."
     ],
     "mathlibGaps": [],
     "nextSteps": [
@@ -123,8 +128,8 @@
     {
       "path": "Proofs/Erdos729LegendreGeneral.lean",
       "filename": "Erdos729LegendreGeneral.lean",
-      "lineCount": 183,
-      "theoremCount": 10,
+      "lineCount": 668,
+      "theoremCount": 37,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,


### PR DESCRIPTION
## Summary
Research session for `erdos-729-oq-02` (Legendre's formula `v_p(n!) = (n − s_p(n))/(p−1)`; RICH tier, core solved). The elementary theory in `Erdos729LegendreGeneral.lean` controls `v_p(n!)` from **above** (`sub_one_mul_padicValNat_factorial_le`: `(p−1)·v_p(n!) ≤ n`; `padicValNat_factorial_le_div`) but never bounded the digit-sum defect from above, so there was no matching **lower** bound. This PR adds the sharp digit-count bound on `s_p(n)` and the resulting two-sided sandwich.

## Progress (6 new theorems, all axiom-free)
- `digitSum_le_length_mul` — `s_p(n) ≤ (#base-p digits)·(p−1)` (each digit `< p` via `Nat.digits_lt_base`, `List.sum_le_card_nsmul`).
- `digitSum_le_log_succ_mul` — `s_p(n) ≤ (⌊log_p n⌋+1)·(p−1)` (`Nat.digits_len`). For `p=2` this is the Hamming-weight bound `s_2(n) ≤ ⌊log₂ n⌋+1`.
- `sub_one_mul_padicValNat_factorial_ge` — general-`p` lower bound `n − (⌊log_p n⌋+1)·(p−1) ≤ (p−1)·v_p(n!)`, the complement of the existing `_le`.
- `padicValNat_factorial_two_ge` / `_two_le` / `_two_sandwich` — the clean `p=2` result:
  **`n − (⌊log₂ n⌋ + 1) ≤ v_2(n!) ≤ n − 1`.**

## Findings
- The defect `s_2(n)` is the Hamming weight, at most the bit length `⌊log₂ n⌋+1`. So Legendre's `v_2(n!) = n − s_2(n)` places `v_2(n!)` within `⌊log₂ n⌋+1` of the trivial ceiling `n` — i.e. `v_2(n!) = n − O(log n)` and `v_2(n!)/n → 1`. This is the two-sided sharpening of the file's one-sided `≤ n/(p−1)` bounds: the valuation squeezed into a logarithmic-width window.
- `digitSum_le_length_mul` / `_le_log_succ_mul` are general-purpose and Mathlib-gap-adjacent.

## Verification
- `LAKE_UNSAFE=1 ./bin/lake env lean Proofs/Erdos729LegendreGeneral.lean` → **EXIT 0**, 0 errors/warnings (Docker SIGBUS-prone on these files per prior sessions; verified offline against cached Mathlib v4.26 oleans).
- `#print axioms` on all 6 new theorems → `[propext, Classical.choice, Quot.sound]` only.

## Status
**Outcome**: progress (axiom-free outward extension; not new deep mathematics). The parent axiom `barreto_leeham_theorem` is untouched and out of scope (deep open result). Also syncs the stale `leanFiles` counts for this file (`183L/10thm → 668L/37thm`) left unsynced by prior sessions.
**Next Steps**: general-`p` division-form lower bound `n/(p−1) − (⌊log_p n⌋+1) ≤ v_p(n!)`; the deep parent remains **BLOCKED**.

🤖 Generated by researcher-3