### PR TITLE
fix: restore + track .loom/hooks (settings.json hook scripts, incl. guard-destructive safety hook)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ aristotle-results/llm-mapping-cache.json
 # The secrets lines above are belt-and-suspenders on top of this.
 .loom/*
 !.loom/roles/
+!.loom/hooks/
 .loom-managed
 research/*.pid
 research/*.log

--- a/.loom/hooks/example-context
+++ b/.loom/hooks/example-context
@@ -1,5 +1,0 @@
-tree dc9fdffa30^:.loom/hooks/example-context
-
-roles/
-topics/
-universal.md

--- a/.loom/hooks/example-context
+++ b/.loom/hooks/example-context
@@ -1,0 +1,5 @@
+tree dc9fdffa30^:.loom/hooks/example-context
+
+roles/
+topics/
+universal.md

--- a/.loom/hooks/example-context/roles/builder.md
+++ b/.loom/hooks/example-context/roles/builder.md
@@ -1,0 +1,9 @@
+# Builder Context
+
+Additional context injected when LOOM_ROLE=builder or the /builder command is used.
+
+## Example Content
+
+- Always run `pnpm test` before creating a PR
+- Keep PRs under 300 lines of diff when possible
+- Include JSDoc comments on exported functions

--- a/.loom/hooks/example-context/topics/release.md
+++ b/.loom/hooks/example-context/topics/release.md
@@ -1,0 +1,44 @@
+# Release Reminders (example)
+
+This file is injected when a prompt mentions release-related keywords (default
+pattern: filename "release"). Use it for project-specific reminders, conventions,
+and procedural overrides that must execute at the named seams in `/loom:release`.
+
+## Advisory reminders (any phase)
+
+- Bump the protocol version constant when the wire format changes.
+- Update the migration guide for any deletion-class change.
+- Verify the CI badge in README.md still points at the right branch.
+
+## Procedural overrides at named seams
+
+The `/loom:release` skill exposes named seams (HTML-comment markers) at
+well-chosen phase boundaries. To inject content at a specific seam, write the
+override in prose and reference the seam name. The agent reading the skill and
+this topic file will compose them at runtime.
+
+Available seams (see the "Operator extension points" section at the bottom of
+`/loom:release` for the authoritative list):
+
+- `pre-changelog-style` — before Phase 1.5 (CHANGELOG style overrides).
+- `pre-push` — before Phase 6 (irreversibility prompts, final gates).
+- `post-push` — inside Phase 6 after `git push --tags` (post-push polling).
+- `pre-github-release` — inside Phase 6 before `gh release create` (release
+  gating on external workflows).
+- `post-summary` — after Phase 7 (project-specific follow-ups).
+
+### Example: override CHANGELOG style at `pre-changelog-style`
+
+> At extension point `pre-changelog-style`: this project does NOT follow
+> Keep-a-Changelog "Added/Changed/Fixed/Removed" grouping. Instead, group
+> entries under thematic headers: "User-facing", "Internals", "Docs". Match
+> the existing CHANGELOG.md for examples.
+
+### Example: gate release on multiple workflows at `pre-github-release`
+
+> At extension point `pre-github-release`: do NOT run `gh release create` until
+> BOTH of the following workflows succeed for the just-pushed tag:
+>   - `.github/workflows/publish-crate.yml`
+>   - `.github/workflows/publish-npm.yml`
+> Poll with `gh run list --workflow=<file> --limit 1 --json conclusion` until
+> both report `success`. Time out after 15 minutes and ask the operator.

--- a/.loom/hooks/example-context/topics/security.md
+++ b/.loom/hooks/example-context/topics/security.md
@@ -1,0 +1,11 @@
+# Security Guidelines
+
+This file is injected when a prompt mentions security-related keywords.
+The default pattern matches the filename ("security"). For custom patterns,
+create a sidecar file (e.g., topics/security.pattern) containing a regex.
+
+## Example Content
+
+- Never log secrets or tokens
+- Use parameterized queries for all database access
+- Validate and sanitize all user input

--- a/.loom/hooks/example-context/topics/security.pattern
+++ b/.loom/hooks/example-context/topics/security.pattern
@@ -1,0 +1,1 @@
+security|auth|token|credential|password|secret|encrypt

--- a/.loom/hooks/example-context/universal.md
+++ b/.loom/hooks/example-context/universal.md
@@ -1,0 +1,11 @@
+# Project Context
+
+This file is injected into every agent session when `.loom/context/` exists.
+Use it for project-wide rules, conventions, and domain knowledge.
+
+## Example Content
+
+- **Language**: TypeScript with strict mode
+- **Framework**: React 18 with Server Components
+- **Testing**: Vitest for unit tests, Playwright for E2E
+- **Style**: Follow existing patterns; prefer composition over inheritance

--- a/.loom/hooks/guard-destructive.sh
+++ b/.loom/hooks/guard-destructive.sh
@@ -1,0 +1,338 @@
+#!/usr/bin/env bash
+# guard-destructive.sh - PreToolUse hook to block destructive agent commands
+#
+# Claude Code PreToolUse hook that intercepts Bash commands before execution.
+# Receives JSON on stdin with tool_input.command and cwd fields.
+#
+# IMPORTANT: This hook only fires when Claude Code is invoked with:
+#   --dangerously-skip-permissions  ← hooks FIRE (used by Loom agents)
+#
+# It does NOT fire with:
+#   --permission-mode bypassPermissions  ← hooks SKIPPED entirely
+#
+# If you have a shell alias like 'alias claude="claude --permission-mode bypassPermissions"',
+# this safety hook will be silently disabled in interactive sessions.
+# Use --dangerously-skip-permissions instead for automation that needs hooks.
+#
+# Decisions:
+#   - Block (deny): Dangerous commands that should never run
+#   - Ask: Commands that need human confirmation
+#   - Allow: Everything else (exit 0, no output)
+#
+# Output format (Claude Code hooks spec):
+#   { "hookSpecificOutput": { "permissionDecision": "deny|ask", "permissionDecisionReason": "..." } }
+#
+# Error handling: This script MUST never exit with a non-zero code or produce
+# invalid output. Any internal error is caught by the trap, logged for
+# diagnostics, and results in an "allow" decision to prevent infinite retry
+# loops in Claude Code.
+
+# Determine log directory relative to this script's location
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd 2>/dev/null || echo ".")"
+HOOK_ERROR_LOG="${SCRIPT_DIR}/../logs/hook-errors.log"
+
+# Log a diagnostic error message (best-effort, never fails the script)
+log_hook_error() {
+    local msg="$1"
+    # Ensure log directory exists
+    mkdir -p "$(dirname "$HOOK_ERROR_LOG")" 2>/dev/null || true
+    echo "[$(date -u '+%Y-%m-%dT%H:%M:%SZ')] [guard-destructive] $msg" >> "$HOOK_ERROR_LOG" 2>/dev/null || true
+}
+
+# Top-level error trap: on ANY unexpected error, output valid JSON "allow"
+# and log the failure for debugging. This prevents Claude Code from showing
+# "PreToolUse:Bash hook error" which causes infinite retry loops.
+trap 'log_hook_error "Unexpected error on line ${LINENO}: ${BASH_COMMAND:-unknown} (exit=$?)"; exit 0' ERR
+
+# Read stdin safely — if cat or jq fails, the ERR trap fires and we allow
+INPUT=$(cat 2>/dev/null) || INPUT=""
+
+# Verify jq is available before attempting to parse
+if ! command -v jq &>/dev/null; then
+    log_hook_error "jq not found in PATH — allowing command (cannot parse input)"
+    exit 0
+fi
+
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null) || COMMAND=""
+CWD=$(echo "$INPUT" | jq -r '.cwd // empty' 2>/dev/null) || CWD=""
+
+# If no command to check, allow
+if [[ -z "$COMMAND" ]]; then
+    exit 0
+fi
+
+# Resolve repo root from cwd (handles worktree paths safely)
+REPO_ROOT=""
+if [[ -n "$CWD" ]] && [[ -d "$CWD" ]]; then
+    REPO_ROOT=$(git -C "$CWD" rev-parse --show-toplevel 2>/dev/null || true)
+elif [[ -n "$CWD" ]]; then
+    # CWD doesn't exist (e.g., deleted worktree) — log but continue without repo root
+    log_hook_error "cwd does not exist: $CWD — skipping repo root resolution"
+fi
+
+# Helper: output a deny decision and exit
+deny() {
+    local reason="$1"
+    if jq -n --arg reason "$reason" '{
+        hookSpecificOutput: {
+            permissionDecision: "deny",
+            permissionDecisionReason: $reason
+        }
+    }' 2>/dev/null; then
+        exit 0
+    fi
+    # jq failed — emit raw JSON as fallback
+    local escaped_reason
+    escaped_reason=$(echo "$reason" | sed 's/\\/\\\\/g; s/"/\\"/g; s/\t/\\t/g; s/\n/\\n/g')
+    echo "{\"hookSpecificOutput\":{\"permissionDecision\":\"deny\",\"permissionDecisionReason\":\"${escaped_reason}\"}}"
+    exit 0
+}
+
+# Helper: output an ask decision and exit
+ask() {
+    local reason="$1"
+    if jq -n --arg reason "$reason" '{
+        hookSpecificOutput: {
+            permissionDecision: "ask",
+            permissionDecisionReason: $reason
+        }
+    }' 2>/dev/null; then
+        exit 0
+    fi
+    # jq failed — emit raw JSON as fallback
+    local escaped_reason
+    escaped_reason=$(echo "$reason" | sed 's/\\/\\\\/g; s/"/\\"/g; s/\t/\\t/g; s/\n/\\n/g')
+    echo "{\"hookSpecificOutput\":{\"permissionDecision\":\"ask\",\"permissionDecisionReason\":\"${escaped_reason}\"}}"
+    exit 0
+}
+
+# =============================================================================
+# ALWAYS BLOCK - Catastrophic commands that should never execute
+# =============================================================================
+
+ALWAYS_BLOCK_PATTERNS=(
+    # GitHub destructive operations
+    'gh repo delete'
+    'gh repo archive'
+
+    # Force push to main/master (various flag forms)
+    'git push --force origin main'
+    'git push --force origin master'
+    'git push -f origin main'
+    'git push -f origin master'
+    'git push --force-with-lease origin main'
+    'git push --force-with-lease origin master'
+
+    # Filesystem destruction
+    'rm -rf /'
+    'rm -rf /\*'
+    'rm -rf ~'
+    'rm -rf \$HOME'
+
+    # Fork bombs
+    ':\(\)\{ :\|:& \};:'
+
+    # Pipe to shell (supply chain risk)
+    'curl .* \| .*sh'
+    'curl .* \| bash'
+    'wget .* \| .*sh'
+    'wget .* -O- \| sh'
+
+    # Cloud infrastructure destruction
+    'aws s3 rm.*--recursive'
+    'aws s3 rb'
+    'aws ec2 terminate'
+    'aws iam delete'
+    'aws cloudformation delete-stack'
+    'gcloud.*delete'
+    'az.*delete'
+    'az group delete'
+
+    # Docker mass destruction
+    'docker system prune'
+
+    # System reboot/shutdown
+    'reboot'
+    'shutdown'
+    'halt'
+    'poweroff'
+    'init 0'
+    'init 6'
+
+    # Database destruction
+    'DROP DATABASE'
+    'DROP TABLE'
+    'DROP SCHEMA'
+    'TRUNCATE TABLE'
+)
+
+for pattern in "${ALWAYS_BLOCK_PATTERNS[@]}"; do
+    if echo "$COMMAND" | grep -qiE "$pattern"; then
+        deny "BLOCKED: Command matches dangerous pattern: $pattern"
+    fi
+done
+
+# =============================================================================
+# rm -rf SCOPE CHECK - Block rm with recursive/force flags outside repo
+# =============================================================================
+
+# Match rm commands with -r or -f flags (in any combination: -rf, -r -f, -fr, etc.)
+if echo "$COMMAND" | grep -qE 'rm\s+(-[a-zA-Z]*[rf][a-zA-Z]*\s+)+' || \
+   echo "$COMMAND" | grep -qE 'rm\s+-[a-zA-Z]*r[a-zA-Z]*\s' || \
+   echo "$COMMAND" | grep -qE 'rm\s+-[a-zA-Z]*f[a-zA-Z]*\s+-[a-zA-Z]*r[a-zA-Z]*\s'; then
+
+    # Extract target paths from the rm command (skip flags)
+    TARGETS=$(echo "$COMMAND" | sed 's/rm\s\+//' | tr ' ' '\n' | grep -v '^-' | head -20)
+
+    for target in $TARGETS; do
+        # Skip empty targets
+        [[ -z "$target" ]] && continue
+
+        # Skip known-safe patterns (allowlist)
+        case "$target" in
+            node_modules|./node_modules|*/node_modules)
+                continue ;;
+            target|./target|*/target)
+                continue ;;
+            dist|./dist|*/dist)
+                continue ;;
+            build|./build|*/build)
+                continue ;;
+            .loom/worktrees/*|*/.loom/worktrees/*)
+                continue ;;
+            .next|./.next|*/.next)
+                continue ;;
+            __pycache__|./__pycache__|*/__pycache__)
+                continue ;;
+            .pytest_cache|./.pytest_cache|*/.pytest_cache)
+                continue ;;
+            *.pyc)
+                continue ;;
+        esac
+
+        # Resolve path to absolute
+        ABS_PATH=""
+        if [[ "$target" = /* ]]; then
+            ABS_PATH="$target"
+        elif [[ -n "$CWD" ]]; then
+            ABS_PATH=$(cd "$CWD" 2>/dev/null && realpath -m "$target" 2>/dev/null || echo "$CWD/$target")
+        fi
+
+        # Block dangerous absolute paths
+        if [[ "$ABS_PATH" == "/" ]] || [[ "$ABS_PATH" == "/home" ]] || \
+           [[ "$ABS_PATH" == "$HOME" ]] || [[ "$ABS_PATH" == "/tmp" ]] || \
+           [[ "$ABS_PATH" == "/usr" ]] || [[ "$ABS_PATH" == "/var" ]] || \
+           [[ "$ABS_PATH" == "/etc" ]] || [[ "$ABS_PATH" == "/opt" ]]; then
+            deny "BLOCKED: rm on protected system path: $ABS_PATH"
+        fi
+
+        # Block if outside repo root (when we know the repo root)
+        if [[ -n "$REPO_ROOT" ]] && [[ -n "$ABS_PATH" ]]; then
+            if [[ "$ABS_PATH" != "$REPO_ROOT"* ]]; then
+                deny "BLOCKED: rm target outside repository: $ABS_PATH (repo: $REPO_ROOT)"
+            fi
+        fi
+    done
+fi
+
+# =============================================================================
+# DELETE without WHERE - Database safety
+# =============================================================================
+
+if echo "$COMMAND" | grep -qiE 'DELETE\s+FROM\s+' && \
+   ! echo "$COMMAND" | grep -qiE 'WHERE\s+'; then
+    deny "BLOCKED: DELETE FROM without WHERE clause"
+fi
+
+# =============================================================================
+# REQUIRE CONFIRMATION - Potentially dangerous but sometimes legitimate
+# =============================================================================
+
+ASK_PATTERNS=(
+    # Git destructive operations (not on main/master - those are blocked above)
+    'git push --force'
+    'git push -f '
+    'git reset --hard'
+    'git clean -fd'
+    'git checkout \.'
+    'git restore \.'
+
+    # GitHub operations that modify shared state
+    'gh pr close'
+    'gh issue close'
+    'gh release delete'
+    'gh label delete'
+
+    # Cloud CLI operations
+    'aws s3'
+    'aws ec2'
+    'aws lambda'
+
+    # Docker operations
+    'docker rm'
+    'docker rmi'
+    'docker stop'
+    'docker kill'
+    'docker restart'
+
+    # Service management
+    'systemctl restart'
+    'systemctl stop'
+    'systemctl disable'
+
+    # Kubernetes operations
+    'kubectl delete'
+    'kubectl rollout restart'
+    'kubectl drain'
+
+    # SkyPilot infrastructure
+    'sky down'
+    'sky stop'
+
+    # Credential exposure
+    'printenv.*SECRET'
+    'printenv.*TOKEN'
+    'printenv.*KEY'
+    'cat.*/\.ssh/'
+    'cat.*/\.aws/credentials'
+)
+
+for pattern in "${ASK_PATTERNS[@]}"; do
+    if echo "$COMMAND" | grep -qE "$pattern"; then
+        ask "Command requires confirmation: $COMMAND"
+    fi
+done
+
+# =============================================================================
+# LOOM: Prefer merge-pr.sh over gh pr merge
+# =============================================================================
+
+if echo "$COMMAND" | grep -qE 'gh\s+pr\s+merge'; then
+    deny "Use ./.loom/scripts/merge-pr.sh <PR_NUMBER> instead of 'gh pr merge'. The script merges via the GitHub API without local checkout, which avoids worktree errors."
+fi
+
+# =============================================================================
+# LOOM: Block pip install -e inside worktrees (issue #2495)
+#
+# Editable pip installs overwrite a global .pth file in site-packages.
+# When multiple builders run in parallel worktrees, each 'pip install -e .'
+# clobbers the .pth to point at its own worktree, causing all other Python
+# processes to import from the wrong source tree.
+#
+# PYTHONPATH is already set by agent-spawn.sh and _build_worktree_env()
+# so editable installs are unnecessary inside worktrees.
+# =============================================================================
+
+WORKTREE_PATH="${LOOM_WORKTREE_PATH:-}"
+if [[ -n "$WORKTREE_PATH" ]]; then
+    if echo "$COMMAND" | grep -qE '(pip|pip3|uv pip)\s+install\s+.*-e\s' || \
+       echo "$COMMAND" | grep -qE '(pip|pip3|uv pip)\s+install\s+.*--editable\s'; then
+        deny "BLOCKED: 'pip install -e' is not allowed inside worktrees. Editable installs overwrite the global .pth file, breaking parallel builders (see issue #2495). PYTHONPATH is already configured for this worktree — imports resolve correctly without editable installs."
+    fi
+fi
+
+# =============================================================================
+# ALLOW - Everything else passes through
+# =============================================================================
+
+exit 0

--- a/.loom/hooks/guard-readonly-dirs.sh.template
+++ b/.loom/hooks/guard-readonly-dirs.sh.template
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+# guard-readonly-dirs.sh - PreToolUse hook to block edits to protected directories
+#
+# TEMPLATE: Copy this file, remove the .template suffix, and customize
+# the PROTECTED_DIRS array for your project:
+#
+#   cp defaults/hooks/guard-readonly-dirs.sh.template .loom/hooks/guard-readonly-dirs.sh
+#   chmod +x .loom/hooks/guard-readonly-dirs.sh
+#   # Edit PROTECTED_DIRS in the copied file
+#
+# Then register it in .claude/settings.json:
+#
+#   {
+#     "hooks": {
+#       "PreToolUse": [
+#         {
+#           "matcher": "Edit|Write",
+#           "hooks": [{ "type": "command", "command": ".loom/hooks/guard-readonly-dirs.sh" }]
+#         }
+#       ]
+#     }
+#   }
+#
+# This hook intercepts Edit and Write tool calls and blocks any that target
+# files within the protected directories. It follows the Claude Code hooks
+# spec: exit 0 with JSON deny output to block, exit 0 with no output to allow.
+#
+# Error handling: This script MUST never exit with a non-zero code or produce
+# invalid output. Any internal error is caught by the trap, logged for
+# diagnostics, and results in an "allow" decision to prevent infinite retry
+# loops in Claude Code.
+
+# ============================================================================
+# CUSTOMIZE: Add your protected directory patterns below.
+# Each entry is a directory path relative to the repository root.
+# Any Edit/Write whose file_path falls within a listed directory is blocked.
+# ============================================================================
+PROTECTED_DIRS=(
+    # Examples — uncomment and adapt for your project:
+    # "vendor/"
+    # "third_party/"
+    # "generated/"
+    # "external/"
+    # "pdk/"
+)
+
+# ============================================================================
+# Hook boilerplate — generally no need to edit below this line
+# ============================================================================
+
+# Determine log directory relative to this script's location
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd 2>/dev/null || echo ".")"
+HOOK_ERROR_LOG="${SCRIPT_DIR}/../logs/hook-errors.log"
+
+# Log a diagnostic error message (best-effort, never fails the script)
+log_hook_error() {
+    local msg="$1"
+    mkdir -p "$(dirname "$HOOK_ERROR_LOG")" 2>/dev/null || true
+    echo "[$(date -u '+%Y-%m-%dT%H:%M:%SZ')] [guard-readonly-dirs] $msg" >> "$HOOK_ERROR_LOG" 2>/dev/null || true
+}
+
+# Top-level error trap: on ANY unexpected error, output valid JSON "allow"
+# and log the failure for debugging. This prevents Claude Code from showing
+# "PreToolUse hook error" which causes infinite retry loops.
+trap 'log_hook_error "Unexpected error on line ${LINENO}: ${BASH_COMMAND:-unknown} (exit=$?)"; exit 0' ERR
+
+# If no protected dirs configured, nothing to do
+if [[ ${#PROTECTED_DIRS[@]} -eq 0 ]]; then
+    exit 0
+fi
+
+# Read stdin safely
+INPUT=$(cat 2>/dev/null) || INPUT=""
+
+# Verify jq is available before attempting to parse
+if ! command -v jq &>/dev/null; then
+    log_hook_error "jq not found in PATH — allowing (cannot parse input)"
+    exit 0
+fi
+
+# Extract file_path from tool input
+FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty' 2>/dev/null) || FILE_PATH=""
+CWD=$(echo "$INPUT" | jq -r '.cwd // empty' 2>/dev/null) || CWD=""
+
+if [[ -z "$FILE_PATH" ]]; then
+    exit 0
+fi
+
+# Resolve to absolute path if relative
+if [[ "$FILE_PATH" != /* ]]; then
+    if [[ -n "$CWD" ]]; then
+        FILE_PATH="${CWD}/${FILE_PATH}"
+    fi
+fi
+
+# Normalize the path (resolve .. and . components)
+NORM_PATH=$(printf '%s' "$FILE_PATH" | python3 -c "import os,sys; print(os.path.normpath(sys.stdin.read()))" 2>/dev/null) || NORM_PATH="$FILE_PATH"
+
+# Resolve repo root from cwd (handles worktree paths)
+REPO_ROOT=""
+if [[ -n "$CWD" ]] && [[ -d "$CWD" ]]; then
+    REPO_ROOT=$(git -C "$CWD" rev-parse --show-toplevel 2>/dev/null || true)
+fi
+
+# Helper: output a deny decision and exit
+deny() {
+    local reason="$1"
+    if jq -n --arg reason "$reason" '{
+        hookSpecificOutput: {
+            permissionDecision: "deny",
+            permissionDecisionReason: $reason
+        }
+    }' 2>/dev/null; then
+        exit 0
+    fi
+    # jq failed — emit raw JSON as fallback
+    local escaped_reason
+    escaped_reason=$(echo "$reason" | sed 's/\\/\\\\/g; s/"/\\"/g; s/\t/\\t/g; s/\n/\\n/g')
+    echo "{\"hookSpecificOutput\":{\"permissionDecision\":\"deny\",\"permissionDecisionReason\":\"${escaped_reason}\"}}"
+    exit 0
+}
+
+# Check each protected directory
+for dir_pattern in "${PROTECTED_DIRS[@]}"; do
+    # Skip empty entries
+    [[ -z "$dir_pattern" ]] && continue
+
+    # Strip trailing slash for consistent matching
+    dir_pattern="${dir_pattern%/}"
+
+    # Build absolute path for the protected directory
+    if [[ "$dir_pattern" == /* ]]; then
+        # Already absolute
+        PROTECTED_ABS="$dir_pattern"
+    elif [[ -n "$REPO_ROOT" ]]; then
+        PROTECTED_ABS="${REPO_ROOT}/${dir_pattern}"
+    else
+        # No repo root available — try relative to cwd
+        if [[ -n "$CWD" ]]; then
+            PROTECTED_ABS="${CWD}/${dir_pattern}"
+        else
+            continue
+        fi
+    fi
+
+    # Check if the file path falls within the protected directory
+    if [[ "$NORM_PATH" == "$PROTECTED_ABS"/* ]] || [[ "$NORM_PATH" == "$PROTECTED_ABS" ]]; then
+        deny "BLOCKED: '${NORM_PATH}' is in read-only directory '${dir_pattern}/'. This directory is protected from edits."
+    fi
+done
+
+# No match — allow
+exit 0

--- a/.loom/hooks/methodology-inject.sh
+++ b/.loom/hooks/methodology-inject.sh
@@ -1,0 +1,231 @@
+#!/usr/bin/env bash
+# methodology-inject.sh - UserPromptSubmit hook for project-specific context injection
+#
+# Claude Code UserPromptSubmit hook that injects domain-specific context from
+# .loom/context/ files into agent sessions as additionalContext.
+#
+# Receives JSON on stdin with { "prompt": "...", "session_id": "...", "cwd": "..." }
+#
+# Behavior:
+#   1. Check for .loom/context/ directory — exit silently if absent (opt-in)
+#   2. Always inject universal.md if it exists
+#   3. Inject roles/<LOOM_ROLE>.md if LOOM_ROLE env var is set
+#   4. Inject topics/<name>.md when prompt matches filename or sidecar .pattern file
+#   5. Cap total output at configurable max (default 8000 chars)
+#
+# Output format (Claude Code hooks spec):
+#   { "hookSpecificOutput": { "hookEventName": "UserPromptSubmit", "additionalContext": "..." } }
+#
+# Opt-in: Only activates when .loom/context/ directory exists.
+# If the directory is missing, the hook exits silently (no context injected).
+#
+# Error handling: This script MUST never exit with a non-zero code or produce
+# invalid output. Any internal error results in a silent exit 0.
+
+set -o pipefail
+
+# Determine main repo root via git-common-dir (works from worktrees)
+MAIN_ROOT="$(cd "$(git rev-parse --git-common-dir 2>/dev/null)/.." 2>/dev/null && pwd)" || \
+MAIN_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." 2>/dev/null && pwd 2>/dev/null || echo ".")"
+
+HOOK_ERROR_LOG="${MAIN_ROOT}/.loom/logs/hook-errors.log"
+
+# Log a diagnostic error message (best-effort, never fails the script)
+log_hook_error() {
+    local msg="$1"
+    mkdir -p "$(dirname "$HOOK_ERROR_LOG")" 2>/dev/null || true
+    echo "[$(date -u '+%Y-%m-%dT%H:%M:%SZ')] [methodology-inject] $msg" >> "$HOOK_ERROR_LOG" 2>/dev/null || true
+}
+
+# Top-level error trap: on ANY unexpected error, exit silently
+trap 'log_hook_error "Unexpected error on line ${LINENO}: ${BASH_COMMAND:-unknown} (exit=$?)"; exit 0' ERR
+
+# Read stdin safely
+INPUT=$(cat 2>/dev/null) || INPUT=""
+
+# Verify jq is available
+if ! command -v jq &>/dev/null; then
+    log_hook_error "jq not found in PATH"
+    exit 0
+fi
+
+# Extract prompt
+PROMPT=$(echo "$INPUT" | jq -r '.prompt // empty' 2>/dev/null) || PROMPT=""
+
+# If no prompt, nothing to do
+if [[ -z "$PROMPT" ]]; then
+    exit 0
+fi
+
+# Skip orchestrator pulse prompts (start with /self)
+if [[ "$PROMPT" == /self* ]]; then
+    exit 0
+fi
+
+# =============================================================================
+# OPT-IN CHECK
+# =============================================================================
+
+CONTEXT_DIR="${MAIN_ROOT}/.loom/context"
+
+# Exit silently if context directory does not exist
+if [[ ! -d "$CONTEXT_DIR" ]]; then
+    exit 0
+fi
+
+# =============================================================================
+# CONFIGURATION
+# =============================================================================
+
+CONFIG_FILE="${CONTEXT_DIR}/config.json"
+MAX_CONTEXT_CHARS=8000
+INJECT_UNIVERSAL=true
+INJECT_ROLE=true
+INJECT_TOPICS=true
+
+# Read config if it exists
+if [[ -f "$CONFIG_FILE" ]] && jq empty "$CONFIG_FILE" 2>/dev/null; then
+    # Check enabled flag (jq // is alternative-on-null, not default-on-missing,
+    # so we use if/then/else to handle explicit false correctly)
+    ENABLED=$(jq -r 'if .enabled == false then "false" else "true" end' "$CONFIG_FILE" 2>/dev/null) || ENABLED=true
+    if [[ "$ENABLED" == "false" ]]; then
+        exit 0
+    fi
+
+    MAX_CONTEXT_CHARS=$(jq -r '.max_context_chars // 8000' "$CONFIG_FILE" 2>/dev/null) || MAX_CONTEXT_CHARS=8000
+    INJECT_UNIVERSAL=$(jq -r 'if .inject_universal == false then "false" else "true" end' "$CONFIG_FILE" 2>/dev/null) || INJECT_UNIVERSAL=true
+    INJECT_ROLE=$(jq -r 'if .inject_role == false then "false" else "true" end' "$CONFIG_FILE" 2>/dev/null) || INJECT_ROLE=true
+    INJECT_TOPICS=$(jq -r 'if .inject_topics == false then "false" else "true" end' "$CONFIG_FILE" 2>/dev/null) || INJECT_TOPICS=true
+fi
+
+# =============================================================================
+# CONTEXT COLLECTION
+# =============================================================================
+
+COLLECTED_CONTEXT=""
+
+# Helper: append content with a separator, respecting max chars
+append_context() {
+    local label="$1"
+    local content="$2"
+
+    if [[ -z "$content" ]]; then
+        return
+    fi
+
+    local new_section
+    if [[ -n "$COLLECTED_CONTEXT" ]]; then
+        new_section=$'\n\n---\n\n'"[${label}]"$'\n'"${content}"
+    else
+        new_section="[${label}]"$'\n'"${content}"
+    fi
+
+    local current_len=${#COLLECTED_CONTEXT}
+    local new_len=${#new_section}
+
+    if (( current_len + new_len > MAX_CONTEXT_CHARS )); then
+        # Truncate to fit within budget
+        local remaining=$(( MAX_CONTEXT_CHARS - current_len ))
+        if (( remaining > 50 )); then
+            COLLECTED_CONTEXT="${COLLECTED_CONTEXT}${new_section:0:$remaining}... [truncated]"
+        fi
+        return
+    fi
+
+    COLLECTED_CONTEXT="${COLLECTED_CONTEXT}${new_section}"
+}
+
+# --- Universal context ---
+if [[ "$INJECT_UNIVERSAL" == "true" ]] && [[ -f "${CONTEXT_DIR}/universal.md" ]]; then
+    UNIVERSAL_CONTENT=$(cat "${CONTEXT_DIR}/universal.md" 2>/dev/null) || UNIVERSAL_CONTENT=""
+    append_context "Project Context" "$UNIVERSAL_CONTENT"
+fi
+
+# --- Role-specific context ---
+if [[ "$INJECT_ROLE" == "true" ]]; then
+    ROLE="${LOOM_ROLE:-}"
+
+    # Fallback: detect role from prompt preamble (slash commands)
+    if [[ -z "$ROLE" ]]; then
+        case "$PROMPT" in
+            /builder*) ROLE="builder" ;;
+            /judge*)   ROLE="judge" ;;
+            /curator*) ROLE="curator" ;;
+            /doctor*)  ROLE="doctor" ;;
+            /architect*) ROLE="architect" ;;
+            /hermit*)  ROLE="hermit" ;;
+            /champion*) ROLE="champion" ;;
+            /guide*)   ROLE="guide" ;;
+            /auditor*) ROLE="auditor" ;;
+            /loom:sweep*) ROLE="sweep" ;;
+        esac
+    fi
+
+    if [[ -n "$ROLE" ]]; then
+        # Normalize to lowercase
+        ROLE_LOWER=$(echo "$ROLE" | tr '[:upper:]' '[:lower:]')
+        ROLE_FILE="${CONTEXT_DIR}/roles/${ROLE_LOWER}.md"
+
+        if [[ -f "$ROLE_FILE" ]]; then
+            ROLE_CONTENT=$(cat "$ROLE_FILE" 2>/dev/null) || ROLE_CONTENT=""
+            append_context "Role Context: ${ROLE_LOWER}" "$ROLE_CONTENT"
+        fi
+    fi
+fi
+
+# --- Topic-specific context ---
+if [[ "$INJECT_TOPICS" == "true" ]] && [[ -d "${CONTEXT_DIR}/topics" ]]; then
+    PROMPT_LOWER=$(echo "$PROMPT" | tr '[:upper:]' '[:lower:]')
+
+    for topic_file in "${CONTEXT_DIR}/topics/"*.md; do
+        # Skip if glob didn't match anything
+        [[ -f "$topic_file" ]] || continue
+
+        # Check if we've already hit the max
+        if (( ${#COLLECTED_CONTEXT} >= MAX_CONTEXT_CHARS )); then
+            break
+        fi
+
+        TOPIC_NAME=$(basename "$topic_file" .md)
+        PATTERN=""
+
+        # Check for sidecar .pattern file first
+        PATTERN_FILE="${CONTEXT_DIR}/topics/${TOPIC_NAME}.pattern"
+        if [[ -f "$PATTERN_FILE" ]]; then
+            PATTERN=$(cat "$PATTERN_FILE" 2>/dev/null) || PATTERN=""
+        fi
+
+        # Fall back to using filename as the regex pattern
+        if [[ -z "$PATTERN" ]]; then
+            PATTERN="$TOPIC_NAME"
+        fi
+
+        # Match pattern case-insensitively against prompt
+        if echo "$PROMPT_LOWER" | grep -qiE "$PATTERN" 2>/dev/null; then
+            TOPIC_CONTENT=$(cat "$topic_file" 2>/dev/null) || TOPIC_CONTENT=""
+            append_context "Topic: ${TOPIC_NAME}" "$TOPIC_CONTENT"
+        fi
+    done
+fi
+
+# =============================================================================
+# OUTPUT
+# =============================================================================
+
+# If no context was collected, exit silently
+if [[ -z "$COLLECTED_CONTEXT" ]]; then
+    exit 0
+fi
+
+# Output valid JSON
+jq -n --arg context "$COLLECTED_CONTEXT" '{
+    hookSpecificOutput: {
+        hookEventName: "UserPromptSubmit",
+        additionalContext: $context
+    }
+}' 2>/dev/null || {
+    log_hook_error "Failed to produce JSON output"
+    exit 0
+}
+
+exit 0

--- a/.loom/hooks/skill-router.sh
+++ b/.loom/hooks/skill-router.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+# skill-router.sh - UserPromptSubmit hook for agent routing suggestions
+#
+# Claude Code UserPromptSubmit hook that injects agent routing context.
+# Receives JSON on stdin with { "prompt": "...", "session_id": "...", "cwd": "..." }
+#
+# Behavior:
+#   1. Always injects a compact agent routing table as additionalContext
+#   2. Optionally emits an AGENT_ROUTE directive when prompt strongly matches
+#      a domain pattern (first match wins)
+#
+# Output format (Claude Code hooks spec):
+#   { "hookSpecificOutput": { "hookEventName": "UserPromptSubmit", "additionalContext": "..." } }
+#
+# Opt-in: Only activates when .loom/config/skill-routes.json exists.
+# If the config file is missing, the hook exits silently (no context injected).
+#
+# Error handling: This script MUST never exit with a non-zero code or produce
+# invalid output. Any internal error results in a silent exit 0.
+
+set -o pipefail
+
+# Determine main repo root via git-common-dir (works from worktrees)
+MAIN_ROOT="$(cd "$(git rev-parse --git-common-dir 2>/dev/null)/.." 2>/dev/null && pwd)" || \
+MAIN_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." 2>/dev/null && pwd 2>/dev/null || echo ".")"
+
+HOOK_ERROR_LOG="${MAIN_ROOT}/.loom/logs/hook-errors.log"
+
+# Log a diagnostic error message (best-effort, never fails the script)
+log_hook_error() {
+    local msg="$1"
+    mkdir -p "$(dirname "$HOOK_ERROR_LOG")" 2>/dev/null || true
+    echo "[$(date -u '+%Y-%m-%dT%H:%M:%SZ')] [skill-router] $msg" >> "$HOOK_ERROR_LOG" 2>/dev/null || true
+}
+
+# Top-level error trap: on ANY unexpected error, exit silently
+trap 'log_hook_error "Unexpected error on line ${LINENO}: ${BASH_COMMAND:-unknown} (exit=$?)"; exit 0' ERR
+
+# Read stdin safely
+INPUT=$(cat 2>/dev/null) || INPUT=""
+
+# Verify jq is available
+if ! command -v jq &>/dev/null; then
+    log_hook_error "jq not found in PATH"
+    exit 0
+fi
+
+# Extract prompt
+PROMPT=$(echo "$INPUT" | jq -r '.prompt // empty' 2>/dev/null) || PROMPT=""
+
+# If no prompt, nothing to do
+if [[ -z "$PROMPT" ]]; then
+    exit 0
+fi
+
+# Skip orchestrator pulse prompts (start with /self)
+if [[ "$PROMPT" == /self* ]]; then
+    exit 0
+fi
+
+# =============================================================================
+# ROUTING CONFIG
+# =============================================================================
+
+ROUTES_FILE="${MAIN_ROOT}/.loom/config/skill-routes.json"
+ROUTES_LOCAL="${MAIN_ROOT}/.loom/config/skill-routes.local.json"
+
+# Opt-in check: if no config file exists, exit silently
+if [[ ! -f "$ROUTES_FILE" ]]; then
+    exit 0
+fi
+
+# Validate config file is valid JSON
+if ! jq empty "$ROUTES_FILE" 2>/dev/null; then
+    log_hook_error "Invalid JSON in $ROUTES_FILE"
+    exit 0
+fi
+
+# Merge routes: local routes first (higher priority), then main routes
+# Local routes file is optional
+ROUTES_JSON=""
+if [[ -f "$ROUTES_LOCAL" ]] && jq empty "$ROUTES_LOCAL" 2>/dev/null; then
+    # Merge: local routes prepended to main routes
+    ROUTES_JSON=$(jq -s '.[0].routes + .[1].routes' "$ROUTES_LOCAL" "$ROUTES_FILE" 2>/dev/null) || ROUTES_JSON=""
+fi
+
+if [[ -z "$ROUTES_JSON" ]]; then
+    ROUTES_JSON=$(jq '.routes' "$ROUTES_FILE" 2>/dev/null) || ROUTES_JSON=""
+fi
+
+if [[ -z "$ROUTES_JSON" ]] || [[ "$ROUTES_JSON" == "null" ]]; then
+    log_hook_error "No routes found in config"
+    exit 0
+fi
+
+# =============================================================================
+# BUILD AGENT TABLE
+# =============================================================================
+
+# Build compact agent routing table from config
+AGENT_TABLE=$(echo "$ROUTES_JSON" | jq -r '.[] | "\(.agent) — \(.description)"' 2>/dev/null) || AGENT_TABLE=""
+
+if [[ -z "$AGENT_TABLE" ]]; then
+    log_hook_error "Failed to build agent table"
+    exit 0
+fi
+
+# =============================================================================
+# PATTERN MATCHING
+# =============================================================================
+
+PROMPT_LOWER=$(echo "$PROMPT" | tr '[:upper:]' '[:lower:]')
+MATCHED_AGENT=""
+MATCHED_DESC=""
+
+# Iterate routes in order (first match wins)
+ROUTE_COUNT=$(echo "$ROUTES_JSON" | jq 'length' 2>/dev/null) || ROUTE_COUNT=0
+
+for (( i=0; i<ROUTE_COUNT; i++ )); do
+    PATTERN=$(echo "$ROUTES_JSON" | jq -r ".[$i].pattern // empty" 2>/dev/null) || continue
+    AGENT=$(echo "$ROUTES_JSON" | jq -r ".[$i].agent // empty" 2>/dev/null) || continue
+    DESC=$(echo "$ROUTES_JSON" | jq -r ".[$i].description // empty" 2>/dev/null) || continue
+
+    if [[ -z "$PATTERN" ]] || [[ -z "$AGENT" ]]; then
+        continue
+    fi
+
+    # Match pattern case-insensitively against prompt
+    if echo "$PROMPT_LOWER" | grep -qiE "$PATTERN" 2>/dev/null; then
+        MATCHED_AGENT="$AGENT"
+        MATCHED_DESC="$DESC"
+        break
+    fi
+done
+
+# =============================================================================
+# OUTPUT
+# =============================================================================
+
+# Build the additionalContext string
+CONTEXT="Available Loom agents:
+${AGENT_TABLE}"
+
+if [[ -n "$MATCHED_AGENT" ]]; then
+    CONTEXT="${CONTEXT}
+
+AGENT_ROUTE: ${MATCHED_AGENT} — ${MATCHED_DESC}
+(This is a suggestion based on prompt keywords. Use the Skill tool to invoke if appropriate.)"
+fi
+
+# Output valid JSON
+jq -n --arg context "$CONTEXT" '{
+    hookSpecificOutput: {
+        hookEventName: "UserPromptSubmit",
+        additionalContext: $context
+    }
+}' 2>/dev/null || {
+    log_hook_error "Failed to produce JSON output"
+    exit 0
+}
+
+exit 0


### PR DESCRIPTION
Completes a known gap of #38398: the mass deletion removed `.loom/hooks/*`; R1 (#38423) excluded them as gitignored runtime, but `.claude/settings.json` (restored the same day) wires three of them as live hooks — so every prompt/tool-use since has fired missing-file hook errors, and the `guard-destructive.sh` PreToolUse safety hook has been silently offline.

- Restores all 5 files byte-identical from `dc9fdffa30^` (exec bits preserved, smoke-tested: both UserPromptSubmit hooks exit 0 on sample JSON)
- Adds `!.loom/hooks/` gitignore exception (same engine-config rationale as `!.loom/roles/`)
- Working copies already restored to the operator's main checkout to stop the error noise immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)