### PR TITLE
Enrich Viviani n-gon characterisation: complete overview annotation

### DIFF
--- a/src/data/proofs/viviani-theorem-oq-01-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/viviani-theorem-oq-01-oq-01-oq-01/annotations.json
@@ -9,7 +9,19 @@
     "type": "concept",
     "title": "Overview: Viviani's Theorem — the Convex n-gon Characterisation",
     "content": "The parent leaf viviani-theorem-oq-01-oq-01 proved the triangle converse: the signed perpendicular-distance sum is constant iff the three inward unit normals sum to zero, iff the triangle is equilateral. This leaf removes the triangle-specific \"equilateral\" half and isolates the genuinely general phenomenon, valid for an arbitrary finite family of edges (a convex n-gon, in fact any indexed family of normals). For a polygon whose edge i lies on the line {x : ⟪x, νᵢ⟫ = cᵢ} with outward unit normal νᵢ, the signed distance from an interior point x to edge i is dᵢ(x) = cᵢ − ⟪x, νᵢ⟫, so the total distance-sum S(x) = (∑ᵢ cᵢ) − ⟪x, ∑ᵢ νᵢ⟫ is an affine function of x with gradient −∑ᵢ νᵢ; hence S is constant on the plane ⇔ ∑ᵢ νᵢ = 0 (★). The headline corollary is that every regular n-gon has the Viviani property: its outward unit normals are the n-th roots of unity ζ⁰, ζ¹, …, ζⁿ⁻¹ with ζ = exp(2πi/n), and these sum to zero for n ≥ 2. The characterisation (★) is sharp and captures a strictly larger class than the regular polygons (any family of unit vectors closing up to zero, e.g. equiangular polygons). The Euclidean plane is modelled as ℂ, reusing the parent's explicit real inner product rdot; the whole argument is elementary linear algebra over a finite index set, needing no non-degeneracy hypothesis.",
-    "significance": "critical"
+    "mathContext": "Edge $i$ on $\\{x:\\langle x,\\nu_i\\rangle=c_i\\}$ gives signed distance $d_i(x)=c_i-\\langle x,\\nu_i\\rangle$, so $S(x)=\\sum_i c_i-\\langle x,\\sum_i\\nu_i\\rangle$ is affine with gradient $-\\sum_i\\nu_i$; hence $S$ is constant $\\iff \\sum_i\\nu_i=0$. Regular $n$-gon normals are the roots of unity $\\zeta^k$, $\\zeta=e^{2\\pi i/n}$, and $\\sum_{k=0}^{n-1}\\zeta^k=0$ for $n\\ge 2$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "signed distance to a hyperplane",
+      "support function of a convex body",
+      "affine functional",
+      "outward unit normal",
+      "roots of unity"
+    ],
+    "prerequisites": [
+      "real inner product",
+      "convex polygon"
+    ]
   },
   {
     "id": "ann-rdot-sum",


### PR DESCRIPTION
Enrichment pass for `viviani-theorem-oq-01-oq-01-oq-01`.

**Gap:** The entry had 5 annotations but only 4 were fully populated — the **overview** concept annotation (lines 1–37) was missing `mathContext` and `relatedConcepts`, leaving the entry one short of the 5-full-annotation quality floor. All 36 other under-target gallery entries were single `openQuestion`-count gaps (accretion-only); this was the sole genuine annotation-depth gap in the queue.

**Change (annotations.json only):**
- Added `mathContext`: LaTeX statement of the affine-gradient characterisation $S(x)=\sum_i c_i-\langle x,\sum_i\nu_i\rangle$ constant $\iff \sum_i\nu_i=0$, plus the regular-$n$-gon roots-of-unity corollary — matching the style of the four sibling annotations.
- Added `relatedConcepts` (signed distance to a hyperplane, support function of a convex body, affine functional, outward unit normal, roots of unity) and `prerequisites`.

No existing content removed; meta.json untouched. JSON validated; gallery data-generation build steps (search index, loading facts) pass.