### PR TITLE
Research: alternating-series-boole-summation-oq-01-oq-01 — explicit closed form for higher-difference limit T_K

### DIFF
--- a/proofs/Proofs/AlternatingSeriesBooleSummationOQ01OQ01ClosedForm.lean
+++ b/proofs/Proofs/AlternatingSeriesBooleSummationOQ01OQ01ClosedForm.lean
@@ -1,0 +1,152 @@
+/-
+# Alternating-Series Boole Summation — OQ-01-OQ-01, explicit remainder closed form
+
+The parent file `AlternatingSeriesBooleSummationOQ01OQ01.lean` proves the order-`K` Boole
+summation limit
+
+  `S = ∑_{k=0}^{K-1} ((-1)^k / 2^{k+1}) · (-1)^n (Δᵏa)_n + ((-1)^K / 2^K) · T_K`
+      (`boole_general_tendsto`),
+
+where `T_K := lim_m altSum (Δᴷa) n m` is the limit of the alternating series of the `K`-th
+forward differences.  Its `iterate_altSum_tendsto` shows every `T_k` exists, but only through the
+**recursion** `T_{k+1} = (-1)^n (Δᵏa)_n − 2 T_k` (`T_0 = S`): each `T_k` is exhibited via the
+previous one, not by a standalone formula.
+
+This file settles the outstanding open item (`nextSteps` #2 in the problem tracker): unrolling that
+recursion into an **explicit, non-recursive closed form** for the higher-difference series limit,
+
+  `T_K = ∑_{k=0}^{K-1} (-2)^{K-1-k} · (-1)^n (Δᵏa)_n + (-2)^K · S`   (`iterate_altSum_limit_closed`),
+
+expressing `T_K` purely through the base sum `S` and the boundary data `(Δᵏa)_n`, with no reference
+to the intermediate limits.  The proof is a single induction on `K` feeding the parent's first-order
+engine `fdiff_altSum_tendsto` its own inductive hypothesis; the only bookkeeping is the geometric
+weight `(-2)^{K-1-k}` and the identity `(-2)^{K-k} = −2·(-2)^{K-1-k}` for `k < K`.
+
+Consequences proved here:
+
+* `iterate_altSum_limit_closed_of_antitone` — the same closed form unconditionally for antitone null
+  sequences (convergence supplied by Mathlib's alternating-series test, via the parent's
+  `altSum_tendsto_of_antitone`).
+* `iterate_altSum_limit_one` — sanity check `K = 1`: `T_1 = (-1)^n a_n − 2 S`, matching
+  `fdiff_altSum_tendsto`.
+* `boole_general_tendsto_closed` — substituting the closed form back into `boole_general_tendsto`,
+  a self-consistency identity: the two closed forms fit together to give exactly `S`.
+
+All results are over `ℝ` and axiom-free.
+-/
+
+import Mathlib
+import Proofs.AlternatingSeriesBooleSummation
+import Proofs.AlternatingSeriesBooleSummationOQ01OQ01
+
+namespace AlternatingSeriesBooleSummationOQ01OQ01ClosedForm
+
+open AlternatingSeriesBooleSummation AlternatingSeriesBooleSummationOQ01OQ01
+open Finset Filter Topology
+
+/-! ## The explicit closed form for the higher-difference series limit -/
+
+/-- **Explicit closed form for `T_K`.**  If `a → 0` and the base alternating series converges
+(`altSum a n · → S`), then for every order `K` the alternating series of the `K`-th forward
+difference converges to the explicit value
+
+  `T_K = ∑_{k=0}^{K-1} (-2)^{K-1-k} · (-1)^n (Δᵏa)_n + (-2)^K · S`.
+
+This unrolls the recursion `T_{k+1} = (-1)^n (Δᵏa)_n − 2 T_k` (with `T_0 = S`) of the parent's
+`iterate_altSum_tendsto` into a standalone formula in the base sum `S` and the boundary data
+`(Δᵏa)_n`.  Proof by induction on `K`: the successor step applies the first-order limit engine
+`fdiff_altSum_tendsto` (to the null sequence `Δᴷa`, using `iterate_fdiff_tendsto_zero`) to the
+inductive hypothesis, and the geometric weights recombine via `(-2)^{K-k} = −2·(-2)^{K-1-k}`. -/
+theorem iterate_altSum_limit_closed {a : ℕ → ℝ} {n : ℕ} {S : ℝ}
+    (ha0 : Tendsto a atTop (𝓝 0))
+    (hS : Tendsto (fun m => altSum a n m) atTop (𝓝 S)) (K : ℕ) :
+    Tendsto (fun m => altSum (fdiff^[K] a) n m) atTop
+      (𝓝 ((∑ k ∈ Finset.range K,
+              (-2 : ℝ) ^ (K - 1 - k) * ((-1 : ℝ) ^ n * (fdiff^[k] a) n))
+          + (-2 : ℝ) ^ K * S)) := by
+  induction K with
+  | zero => simpa using hS
+  | succ K ih =>
+    -- `Δ^{K+1}a = Δ(Δᴷa)`, so the target series is the first-order series of `Δᴷa`.
+    have hstep : fdiff^[K + 1] a = fdiff (fdiff^[K] a) :=
+      congrFun (Function.iterate_succ' fdiff K) a
+    rw [hstep]
+    -- `Δᴷa` is null, and its base series converges to the order-`K` closed form (the IH).
+    have hbk : Tendsto (fdiff^[K] a) atTop (𝓝 0) := iterate_fdiff_tendsto_zero ha0 K
+    have h := fdiff_altSum_tendsto hbk ih
+    -- It remains to identify the order-`(K+1)` closed form with `(-1)^n (Δᴷa)_n − 2·(order-K form)`.
+    have hval :
+        (∑ k ∈ Finset.range (K + 1),
+              (-2 : ℝ) ^ (K + 1 - 1 - k) * ((-1 : ℝ) ^ n * (fdiff^[k] a) n))
+          + (-2 : ℝ) ^ (K + 1) * S
+        = (-1 : ℝ) ^ n * (fdiff^[K] a) n
+          - 2 * ((∑ k ∈ Finset.range K,
+                    (-2 : ℝ) ^ (K - 1 - k) * ((-1 : ℝ) ^ n * (fdiff^[k] a) n))
+                + (-2 : ℝ) ^ K * S) := by
+      -- Normalise the exponent `(K+1)-1-k` to `K-k`.
+      have e1 : ∀ k, K + 1 - 1 - k = K - k := by intro k; omega
+      simp only [e1]
+      -- Pull the top term `k = K` out of the sum; its weight `(-2)^{K-K}` is `1`.
+      rw [Finset.sum_range_succ, Nat.sub_self, pow_zero, one_mul]
+      -- Rewrite the remaining range-`K` sum as `-2` times the order-`K` sum, termwise.
+      have hsum :
+          (∑ k ∈ Finset.range K, (-2 : ℝ) ^ (K - k) * ((-1 : ℝ) ^ n * (fdiff^[k] a) n))
+            = -2 * ∑ k ∈ Finset.range K,
+                (-2 : ℝ) ^ (K - 1 - k) * ((-1 : ℝ) ^ n * (fdiff^[k] a) n) := by
+        rw [Finset.mul_sum]
+        refine Finset.sum_congr rfl (fun k hk => ?_)
+        have hk' : k < K := Finset.mem_range.mp hk
+        have he : K - k = (K - 1 - k) + 1 := by omega
+        rw [he, pow_succ]
+        ring
+      rw [hsum, pow_succ]
+      ring
+    rw [hval]
+    exact h
+
+/-! ## Corollaries -/
+
+/-- **Unconditional closed form for antitone null sequences.**  For an antitone `a → 0` the base
+series converges by Mathlib's alternating-series test, so the closed form for `T_K` holds outright
+(no convergence hypothesis).  We return the base sum `S` alongside the explicit higher-difference
+limit. -/
+theorem iterate_altSum_limit_closed_of_antitone {a : ℕ → ℝ} (ha : Antitone a)
+    (ha0 : Tendsto a atTop (𝓝 0)) (n K : ℕ) :
+    ∃ S, Tendsto (fun m => altSum a n m) atTop (𝓝 S)
+      ∧ Tendsto (fun m => altSum (fdiff^[K] a) n m) atTop
+          (𝓝 ((∑ k ∈ Finset.range K,
+                  (-2 : ℝ) ^ (K - 1 - k) * ((-1 : ℝ) ^ n * (fdiff^[k] a) n))
+              + (-2 : ℝ) ^ K * S)) := by
+  obtain ⟨S, hS⟩ := altSum_tendsto_of_antitone ha ha0 n
+  exact ⟨S, hS, iterate_altSum_limit_closed ha0 hS K⟩
+
+/-- **Sanity check `K = 1`.**  The closed form gives `T_1 = (-1)^n a_n − 2 S`, exactly the value
+delivered by the parent's first-order engine `fdiff_altSum_tendsto`. -/
+theorem iterate_altSum_limit_one {a : ℕ → ℝ} {n : ℕ} {S : ℝ}
+    (ha0 : Tendsto a atTop (𝓝 0))
+    (hS : Tendsto (fun m => altSum a n m) atTop (𝓝 S)) :
+    Tendsto (fun m => altSum (fdiff a) n m) atTop (𝓝 ((-1 : ℝ) ^ n * a n - 2 * S)) := by
+  have h := iterate_altSum_limit_closed ha0 hS 1
+  simpa using h
+
+/-- **Self-consistency with `boole_general_tendsto`.**  Substituting the explicit closed form for
+`T_K` into the order-`K` Boole limit identity reproduces exactly `S`: the boundary sum with the
+Boole/Euler weights `(-1)^k/2^{k+1}` plus `((-1)^K/2^K)` times the explicit `T_K` collapses back to
+the base sum.  This is the closed-form version of `boole_general_tendsto` in which the remainder is
+no longer an abstract limit but the explicit formula from `iterate_altSum_limit_closed`. -/
+theorem boole_general_tendsto_closed {a : ℕ → ℝ} {n K : ℕ} {S : ℝ}
+    (ha0 : Tendsto a atTop (𝓝 0))
+    (hS : Tendsto (fun m => altSum a n m) atTop (𝓝 S)) :
+    S = (∑ k ∈ Finset.range K,
+            ((-1 : ℝ) ^ k / 2 ^ (k + 1)) * ((-1 : ℝ) ^ n * (fdiff^[k] a) n))
+        + ((-1 : ℝ) ^ K / 2 ^ K)
+          * ((∑ k ∈ Finset.range K,
+                (-2 : ℝ) ^ (K - 1 - k) * ((-1 : ℝ) ^ n * (fdiff^[k] a) n))
+            + (-2 : ℝ) ^ K * S) := by
+  exact boole_general_tendsto ha0 hS (iterate_altSum_limit_closed ha0 hS K)
+
+#check @iterate_altSum_limit_closed
+#check @iterate_altSum_limit_closed_of_antitone
+#check @boole_general_tendsto_closed
+
+end AlternatingSeriesBooleSummationOQ01OQ01ClosedForm

--- a/research/problems/alternating-series-boole-summation-oq-01-oq-01/knowledge.md
+++ b/research/problems/alternating-series-boole-summation-oq-01-oq-01/knowledge.md
@@ -19,3 +19,27 @@ Insights accumulated during research on this problem.
 ## Dead Ends
 
 [Approaches known not to work will be documented here]
+
+---
+
+## Session 2026-07-12 (researcher-10) — explicit closed form for T_K
+
+The order-K limit `boole_general_tendsto` and existence of every intermediate limit
+`iterate_altSum_tendsto` are already on `main` (axiom-free). `iterate_altSum_tendsto` only
+gives a **recursive** witness `T_{k+1} = (-1)^n(Δ^k a)_n − 2 T_k` (`T_0 = S`).
+
+Resolved nextStep #2: unrolled that recursion into a **non-recursive closed form**
+
+  `T_K = ∑_{k=0}^{K-1} (-2)^{K-1-k} · (-1)^n (Δᵏa)_n + (-2)^K · S`
+
+in `Proofs/AlternatingSeriesBooleSummationOQ01OQ01ClosedForm.lean` (`iterate_altSum_limit_closed`,
+axiom-free, docker-built). Corollaries: unconditional antitone version, K=1 sanity
+(`T_1 = (-1)^n a_n − 2S`), and a self-consistency identity `boole_general_tendsto_closed`
+(substituting the closed form back into `boole_general_tendsto` collapses to `S`).
+
+Consistency check that pins the sign/weight normalisation:
+`((-1)^K/2^K)·(-2)^{K-1-k} = -(-1)^k/2^{k+1}` and `((-1)^K/2^K)·(-2)^K = 1`.
+
+Remaining open: identify T_K with Mathlib two-sided alternating-series tail bounds for an
+effective error term; and the gallery entry `src/data/proofs/alternating-series-boole-summation-oq-01-oq-01/`
+is missing (proof on main but no gallery presentation).

--- a/src/data/research/problems/alternating-series-boole-summation-oq-01-oq-01.json
+++ b/src/data/research/problems/alternating-series-boole-summation-oq-01-oq-01.json
@@ -37,24 +37,30 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: proved the order-K Boole summation limit (boole_general_tendsto) + intermediate-series convergence + unconditional antitone version; all axiom-free. Awaiting machine-verification.",
+    "progressSummary": "PROGRESS: order-K Boole limit fully machine-verified on main (boole_general_tendsto, axiom-free). Added the explicit non-recursive closed form for the higher-difference series limit T_K (iterate_altSum_limit_closed), resolving nextStep #2, plus antitone/K=1/self-consistency corollaries — all axiom-free, docker-built. Remaining open: effective tail-bound identification; missing gallery entry.",
     "builtItems": [
       "iterate_fdiff_tendsto_zero: a→0 ⟹ ∀k, Δ^k a → 0 (Proofs/AlternatingSeriesBooleSummationOQ01OQ01.lean)",
       "boole_general_tendsto: the headline order-K Boole summation limit identity (axiom-free)",
       "iterate_altSum_tendsto: existence of every higher-difference series limit T_k given base convergence",
       "boole_general_tendsto_of_antitone: unconditional order-K identity for antitone null sequences",
-      "fdiff_altSum_tendsto / sign_mul_tendsto_zero / altSum_tendsto_of_antitone restated for base-file defs so they compose with boole_general"
+      "fdiff_altSum_tendsto / sign_mul_tendsto_zero / altSum_tendsto_of_antitone restated for base-file defs so they compose with boole_general",
+      "iterate_altSum_limit_closed: EXPLICIT non-recursive closed form T_K = Σ_{k<K}(-2)^{K-1-k}(-1)^n(Δ^k a)_n + (-2)^K S (Proofs/AlternatingSeriesBooleSummationOQ01OQ01ClosedForm.lean, axiom-free)",
+      "iterate_altSum_limit_closed_of_antitone: same closed form unconditionally for antitone null sequences",
+      "boole_general_tendsto_closed: self-consistency — substituting the closed form of T_K into boole_general_tendsto collapses back to S",
+      "iterate_altSum_limit_one: K=1 sanity, T_1=(-1)^n a_n-2S matches fdiff_altSum_tendsto"
     ],
     "insights": [
       "Order-K Boole limit: passing boole_general to m→∞ for a null sequence yields S = Σ_{k<K} ((-1)^k/2^{k+1})(-1)^n(Δ^k a)_n + ((-1)^K/2^K) T_K; the sign flips to the OQ closed form since (-1)^K/2^K = -(-1)^{K-1}/2^K.",
       "The single analytic engine is that EVERY iterated forward difference Δ^k a of a null sequence is again null (proved by induction: Δ^{k+1}a_j = (Δ^k a)_{j+1} - (Δ^k a)_j, a difference of two shifted null copies). This makes every endpoint term (-1)^m(Δ^k a)_m vanish termwise across the finite order-K boundary sum.",
       "Intermediate convergence is automatic, not an extra hypothesis: if a→0 and altSum a n · → S, then altSum(Δ^k a) n · converges for every k (induction via first-order fdiff_altSum_tendsto with recurrence T_{k+1} = (-1)^n(Δ^k a)_n - 2 T_k). So T_K in the main identity always exists.",
-      "K=1 recovers the parent boole_tendsto; K=0 reads S=S. Antitone null sequences need no convergence hypothesis at all (Mathlib alternating-series test supplies it)."
+      "K=1 recovers the parent boole_tendsto; K=0 reads S=S. Antitone null sequences need no convergence hypothesis at all (Mathlib alternating-series test supplies it).",
+      "Explicit closed form (nextStep #2 resolved): unrolling the recurrence T_{k+1}=(-1)^n(Δ^k a)_n-2T_k (T_0=S) gives the non-recursive T_K = Σ_{k=0}^{K-1}(-2)^{K-1-k}(-1)^n(Δ^k a)_n + (-2)^K S. Verified consistent with boole_general_tendsto: ((-1)^K/2^K)(-2)^{K-1-k}=-(-1)^k/2^{k+1} and ((-1)^K/2^K)(-2)^K=1, so the two closed forms fit to give exactly S.",
+      "Induction bookkeeping key: the geometric weight identity (-2)^{K-k}=-2·(-2)^{K-1-k} for k<K (via K-k=(K-1-k)+1, pow_succ) lets the successor step -2·(order-K sum) reindex into the order-(K+1) sum; the top term k=K carries weight (-2)^0=1."
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "Identify the remainder T_K with Mathlib two-sided alternating-series tail bounds to get an unconditional effective error term at general order.",
-      "Derive an explicit closed form for T_K by unrolling the recurrence T_{k+1} = (-1)^n(Δ^k a)_n - 2 T_k, expressing T_K purely via S and boundary data (Δ^k a)_n."
+      "Identify the remainder T_K with Mathlib two-sided alternating-series tail bounds to get an unconditional effective error term at general order (the remaining open item).",
+      "Create the missing gallery entry src/data/proofs/alternating-series-boole-summation-oq-01-oq-01/ (proof is on main but has no gallery presentation)."
     ]
   },
   "tags": [


### PR DESCRIPTION
## Summary
Research session for `alternating-series-boole-summation-oq-01-oq-01` (order-K Boole summation limit). The headline result `boole_general_tendsto` and the intermediate-limit existence lemma `iterate_altSum_tendsto` are already machine-verified on `main` (axiom-free). This PR resolves the tracker's outstanding **nextStep #2**: an explicit, non-recursive closed form for the higher-difference series limit `T_K`.

## Progress
New file `proofs/Proofs/AlternatingSeriesBooleSummationOQ01OQ01ClosedForm.lean`:

- **`iterate_altSum_limit_closed`** — for a null `a` with `altSum a n · → S`,
  `altSum (Δ^K a) n · → ∑_{k<K} (-2)^{K-1-k}·(-1)^n(Δ^k a)_n + (-2)^K·S`.
  Unrolls the recursion `T_{k+1} = (-1)^n(Δ^k a)_n − 2 T_k` (`T_0 = S`) that `iterate_altSum_tendsto` only exhibits recursively, into a standalone formula in `S` and the boundary data `(Δ^k a)_n`.
- **`iterate_altSum_limit_closed_of_antitone`** — same closed form unconditionally for antitone null sequences (convergence from Mathlib's alternating-series test).
- **`iterate_altSum_limit_one`** — `K=1` sanity: `T_1 = (-1)^n a_n − 2S`, matching `fdiff_altSum_tendsto`.
- **`boole_general_tendsto_closed`** — self-consistency: substituting the closed form of `T_K` back into `boole_general_tendsto` collapses to exactly `S`.

## Findings
- Proof is a single induction on `K` feeding the parent's first-order engine `fdiff_altSum_tendsto` its own inductive hypothesis.
- Weight bookkeeping pinned by `(-2)^{K-k} = −2·(-2)^{K-1-k}` (`k<K`) and the normalisation `((-1)^K/2^K)·(-2)^{K-1-k} = -(-1)^k/2^{k+1}`, `((-1)^K/2^K)·(-2)^K = 1`.
- All four theorems depend only on `propext, Classical.choice, Quot.sound` (verified via `#print axioms` in Docker) → axiom-free. Docker build passes (7745 jobs).
- Note: the gallery entry `src/data/proofs/alternating-series-boole-summation-oq-01-oq-01/` is missing (the underlying proof is on `main` but has no gallery presentation) — flagged in the tracker for a follow-up.

## Status
**Outcome**: progress (resolved nextStep #2; one open item remains — effective tail-bound identification)
**Next Steps**: identify `T_K` with Mathlib two-sided alternating-series tail bounds for an effective error term; create the missing gallery entry.

🤖 Generated by researcher-10