### PR TITLE
Research: erdos-1110-oq-01 — non-coprime regime infinitude (subsumes base-power family)

### DIFF
--- a/proofs/Proofs/Erdos1110OQ01.lean
+++ b/proofs/Proofs/Erdos1110OQ01.lean
@@ -588,4 +588,142 @@ theorem powerForm_moebius {p q : ℕ} (hp : p.Prime) (hq : q.Prime) (hpq : p ≠
   · exact powerForm_moebius_of_squarefree hp hq hpq h.1 h.2
   · exact powerForm_moebius_eq_zero hp hq hpq h
 
+/-! ### Non-coprime bases: the power-form monoid avoids the class `1 mod d`
+
+The submonoid identification `IsPowerForm p q n ↔ n ∈ Submonoid.closure {p, q}`
+(`isPowerForm_iff_mem_closure`) has a sharp arithmetic consequence when the two bases
+share a common factor `d ≥ 2`: since `d ∣ p` and `d ∣ q`, every generator (hence every
+non-identity element) of the monoid is divisible by `d`, so
+
+    ⟨p, q⟩ ⊆ {1} ∪ d·ℕ.
+
+This lets us settle the **entire non-coprime regime** of Erdős–Lewin unconditionally.
+In any admissible representation `n = ∑ S` (an antichain of power forms), the identity `1`
+can occur only as the *sole* summand — otherwise it would divide another summand — so a
+representation of length `> 1` has all summands `> 1`, hence all divisible by `d`, forcing
+`d ∣ n`. Consequently a number that is **neither a power form nor divisible by `d`** is
+non-representable, and the residue class `n ≡ 1 (mod d)` supplies infinitely many such
+numbers.
+
+This generalises the parent file's base-power family `infinite_nonRepresentable_base_pow`
+(the case `p = q^k`, `d = q`) to *all* non-coprime pairs — including ones where neither
+base is a power of the other, e.g. `(p, q) = (6, 4)` with `d = 2` — and is exactly the
+complement of the coprimality hypothesis of the deep axiom `erdos_lewin_infinite`. -/
+
+/-- **A common divisor of the bases divides every non-trivial power form.** If `d ∣ p` and
+`d ∣ q` then any power form `p^k q^l` is either `1` (the case `k = l = 0`) or divisible by
+`d`. Monoid-theoretically: the generators `p, q` of `powerFormSubmonoid p q` both lie in
+`d·ℕ`, so the whole submonoid sits inside `{1} ∪ d·ℕ`. -/
+theorem isPowerForm_one_or_common_dvd {p q d n : ℕ} (hdp : d ∣ p) (hdq : d ∣ q)
+    (h : IsPowerForm p q n) : n = 1 ∨ d ∣ n := by
+  obtain ⟨k, l, rfl⟩ := h
+  rcases Nat.eq_zero_or_pos k with hk | hk
+  · subst hk
+    rcases Nat.eq_zero_or_pos l with hl | hl
+    · subst hl; left; simp
+    · right; simpa using dvd_pow hdq hl.ne'
+  · right; exact (dvd_pow hdp hk.ne').mul_right _
+
+/-- **A representation of a non-`d`-divisible number is a single power form.** With `d ∣ p`
+and `d ∣ q`, every representable `n` is either itself a power form (a length-one antichain)
+or divisible by `d`. Indeed, if the identity `1` appears in the representing antichain `S`
+it must be the only member (it divides everything), giving `n = 1`; otherwise every summand
+exceeds `1`, so `d` divides each summand (`isPowerForm_one_or_common_dvd`) and hence their
+sum `n`. -/
+theorem isPowerForm_or_common_dvd_of_representable {p q d n : ℕ}
+    (hdp : d ∣ p) (hdq : d ∣ q) (hrep : IsRepresentable p q n) :
+    IsPowerForm p q n ∨ d ∣ n := by
+  obtain ⟨S, hSne, hSpf, hSanti, hSsum⟩ := hrep
+  by_cases h1 : (1 : ℕ) ∈ S
+  · -- `1 ∈ S` forces `S = {1}` (it divides everything), so `n = 1` is a power form.
+    left
+    have hsub : S = {1} := by
+      refine Finset.eq_singleton_iff_unique_mem.mpr ⟨h1, ?_⟩
+      intro x hx
+      by_contra hx1
+      exact hSanti 1 h1 x hx (Ne.symm hx1) (one_dvd x)
+    rw [hsub] at hSsum
+    simp only [Finset.sum_singleton, id_eq] at hSsum
+    rw [← hSsum]
+    exact ⟨0, 0, by simp⟩
+  · -- `1 ∉ S`: every summand exceeds `1`, hence is divisible by `d`, hence so is the sum.
+    right
+    rw [← hSsum]
+    apply Finset.dvd_sum
+    intro s hs
+    have hs1 : s ≠ 1 := fun h => h1 (h ▸ hs)
+    rcases isPowerForm_one_or_common_dvd hdp hdq (hSpf s hs) with h | h
+    · exact absurd h hs1
+    · simpa using h
+
+/-- **Non-representability test for non-coprime bases.** If `d ∣ p`, `d ∣ q`, and `n` is
+neither a power form nor divisible by `d`, then `n` is non-representable — no admissible
+antichain of `p^k q^l` sums to it (`isPowerForm_or_common_dvd_of_representable`). -/
+theorem not_isRepresentable_of_not_common_dvd {p q d n : ℕ}
+    (hdp : d ∣ p) (hdq : d ∣ q) (hpf : ¬ IsPowerForm p q n) (hn : ¬ d ∣ n) :
+    ¬ IsRepresentable p q n := fun hrep =>
+  (isPowerForm_or_common_dvd_of_representable hdp hdq hrep).elim hpf hn
+
+/-- **Infinitely many non-representables for every non-coprime pair — elementary, 0-axiom.**
+If the bases share a common divisor `d ≥ 2` (`d ∣ p`, `d ∣ q`), the arithmetic progression
+`n = d(m+1)+1` (i.e. `n ≡ 1 (mod d)`, `n > 1`) consists entirely of non-representables:
+each such `n` is not divisible by `d`, and — being `> 1` and not a multiple of `d` — is not
+a power form (`isPowerForm_one_or_common_dvd`), so it is non-representable
+(`not_isRepresentable_of_not_common_dvd`). The injection `m ↦ d(m+1)+1` embeds `ℕ` into
+`NonRepresentable p q`. This is the full non-coprime regime of the Erdős–Lewin phenomenon,
+subsuming the base-power family `infinite_nonRepresentable_base_pow`. -/
+theorem infinite_nonRepresentable_of_common_dvd {p q d : ℕ}
+    (hdp : d ∣ p) (hdq : d ∣ q) (hd : 2 ≤ d) :
+    Set.Infinite (NonRepresentable p q) := by
+  refine Set.infinite_of_injective_forall_mem
+    (f := fun m : ℕ => d * (m + 1) + 1) ?_ ?_
+  · intro a b hab
+    change d * (a + 1) + 1 = d * (b + 1) + 1 at hab
+    have h1 : d * (a + 1) = d * (b + 1) := by omega
+    have := Nat.eq_of_mul_eq_mul_left (by omega : 0 < d) h1
+    omega
+  · intro m
+    show (d * (m + 1) + 1) ∈ NonRepresentable p q
+    rw [NonRepresentable, Set.mem_setOf_eq]
+    have hnd : ¬ d ∣ (d * (m + 1) + 1) := by
+      intro hdvd
+      have h1 : d ∣ 1 := (Nat.dvd_add_right (dvd_mul_right d (m + 1))).mp hdvd
+      have := Nat.le_of_dvd one_pos h1
+      omega
+    have hnpf : ¬ IsPowerForm p q (d * (m + 1) + 1) := by
+      intro h
+      rcases isPowerForm_one_or_common_dvd hdp hdq h with h1 | h2
+      · have : 0 < d * (m + 1) := Nat.mul_pos (by omega) (by omega)
+        omega
+      · exact hnd h2
+    exact not_isRepresentable_of_not_common_dvd hdp hdq hnpf hnd
+
+/-- **Non-coprimality alone gives infinitely many non-representables.** For `p ≥ 1` with
+`p, q` not coprime, `d := gcd p q ≥ 2` is a common divisor, so
+`infinite_nonRepresentable_of_common_dvd` applies. The full complement of the coprime
+hypothesis of `erdos_lewin_infinite`, proved with no axiom. -/
+theorem infinite_nonRepresentable_of_not_coprime {p q : ℕ}
+    (hp : 1 ≤ p) (hcop : ¬ Nat.Coprime p q) :
+    Set.Infinite (NonRepresentable p q) := by
+  have hdp : Nat.gcd p q ∣ p := Nat.gcd_dvd_left p q
+  have hdq : Nat.gcd p q ∣ q := Nat.gcd_dvd_right p q
+  have hne1 : Nat.gcd p q ≠ 1 := hcop
+  have hne0 : Nat.gcd p q ≠ 0 := by
+    intro h; rw [Nat.gcd_eq_zero_iff] at h; omega
+  exact infinite_nonRepresentable_of_common_dvd hdp hdq (by omega)
+
+/-- **The base-power family, re-derived.** `infinite_nonRepresentable_base_pow` (the parent
+file's `p = q^k` result) is the special case `d = q` of
+`infinite_nonRepresentable_of_common_dvd`: `q ∣ q^k` and `q ∣ q`. -/
+theorem infinite_nonRepresentable_base_pow' {q k : ℕ} (hq : 2 ≤ q) (hk : 1 ≤ k) :
+    Set.Infinite (NonRepresentable (q ^ k) q) :=
+  infinite_nonRepresentable_of_common_dvd (dvd_pow_self q (by omega : k ≠ 0)) dvd_rfl hq
+
+/-- **A genuinely new non-coprime pair.** `(p, q) = (6, 4)` has `gcd 6 4 = 2 ≥ 2`, yet
+neither base is a power of the other — so it lies outside the base-power family
+`infinite_nonRepresentable_base_pow` but is covered by
+`infinite_nonRepresentable_of_common_dvd` (`d = 2`). -/
+example : Set.Infinite (NonRepresentable 6 4) :=
+  infinite_nonRepresentable_of_common_dvd (d := 2) (by norm_num) (by norm_num) (by norm_num)
+
 end Erdos1110


### PR DESCRIPTION
## Summary

Erdős Problem #1110 (representability by antichain sums of power forms `p^k q^l`) has one genuinely hard direction — the axiom `erdos_lewin_infinite` (infinitely many non-representables when `{p,q}≠{2,3}`, **coprime**). The parent file had characterized only one slice of the *non*-coprime complement: the base-power family `p = q^k` (`infinite_nonRepresentable_base_pow`).

This PR settles the **entire non-coprime regime** unconditionally, subsuming that slice.

### Mechanism
If `d = gcd(p,q) ≥ 2` then `d ∣ p` and `d ∣ q`, so every power form `p^k q^l > 1` is divisible by `d` (the submonoid `⟨p,q⟩ ⊆ {1} ∪ d·ℕ`). In any admissible representation, the identity `1` can only be a *lone* summand (it divides everything, breaking the antichain), so a length-`>1` representation has all summands divisible by `d`, forcing `d ∣ n`. Hence any `n` that is **neither a power form nor divisible by `d`** is non-representable — and the residue class `n ≡ 1 (mod d)` supplies infinitely many.

### New theorems (all 0-axiom, 0-sorry)
| Lemma | Statement |
|-------|-----------|
| `isPowerForm_one_or_common_dvd` | `d∣p, d∣q ⟹ powerForm = 1 ∨ d∣it` |
| `isPowerForm_or_common_dvd_of_representable` | representable `n` is a power form or `d∣n` |
| `not_isRepresentable_of_not_common_dvd` | non-representability test |
| `infinite_nonRepresentable_of_common_dvd` | common divisor `d≥2` ⟹ `Set.Infinite (NonRepresentable p q)` |
| `infinite_nonRepresentable_of_not_coprime` | `¬Coprime p q ⟹` infinitely many non-representables |
| `infinite_nonRepresentable_base_pow'` | re-derives the parent's `p=q^k` result as `d=q` |
| `example (6,4)` | new pair where neither base is a power of the other |

This is exactly the complement of the coprimality hypothesis in `erdos_lewin_infinite`.

### Verification
`lake env lean Proofs.Erdos1110OQ01` elaborates cleanly (0 sorries). `#print axioms` on every main theorem = `[propext, Classical.choice, Quot.sound]` (foundational only; no `native_decide`, no `sorryAx`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)