### PR TITLE
Research: descartes-rule-of-signs-oq-01-oq-03 - general Fin n sign-change bounds

### DIFF
--- a/proofs/Proofs/DescartesRuleOfSignsOQ01OQ03.lean
+++ b/proofs/Proofs/DescartesRuleOfSignsOQ01OQ03.lean
@@ -1185,6 +1185,61 @@ theorem card_adjacent (n : ℕ) :
   · intro m _
     rfl
 
+/-! ### General `Fin n` sign-change bounds (the length-3 template, uniformized)
+
+The `Fin 3` results (`countSignChanges_three_alternating = 2`,
+`countSignChanges_three_mid_ne_zero = 0`) are the `n = 3` instances of three general facts,
+all one-line corollaries of `countSignChanges_nowhere_zero` (which routes every count through
+the adjacent-opposite-sign pairs) and `card_adjacent` (there are exactly `n − 1` adjacent
+pairs).  Together they pin the two extremes and the ceiling of the count for a nowhere-zero
+sequence: the strictly alternating pattern realises the maximum `n − 1`, a constant-sign
+pattern realises `0`, and no sequence exceeds `n − 1` — the sequence-level shadow of the
+Descartes degree bound `V(p) ≤ deg p`. -/
+
+/-- **Universal sign-change ceiling.**  A nowhere-zero `f : Fin n → ℝ` has at most `n − 1`
+sign changes: every sign change is carried by an adjacent index pair, and there are only
+`n − 1` of those (`card_adjacent`).  The sequence-level form of the Descartes bound
+`V(p) ≤ deg p`, and the ceiling the `Fin 3` counts (`≤ 2`) all respect. -/
+theorem countSignChanges_le_of_nowhere_zero {n : ℕ} {f : Fin n → ℝ} (hnz : ∀ i, f i ≠ 0) :
+    DescartesRuleOfSigns.countSignChanges f ≤ n - 1 := by
+  classical
+  rw [countSignChanges_nowhere_zero hnz, ← card_adjacent n]
+  apply Finset.card_le_card
+  intro p hp
+  simp only [Finset.mem_filter, Finset.mem_univ, true_and] at hp ⊢
+  exact hp.1
+
+/-- **Maximal count: strict alternation.**  If *every* adjacent pair of a nowhere-zero
+`f : Fin n → ℝ` has opposite signs (`f i · f j < 0` whenever `j = i + 1`), then `f` attains
+the ceiling: `V(f) = n − 1`.  The general form of `countSignChanges_three_alternating` (`= 2`);
+every one of the `n − 1` adjacent gaps is a genuine sign change. -/
+theorem countSignChanges_alternating_eq {n : ℕ} {f : Fin n → ℝ} (hnz : ∀ i, f i ≠ 0)
+    (halt : ∀ i j : Fin n, j.val = i.val + 1 → f i * f j < 0) :
+    DescartesRuleOfSigns.countSignChanges f = n - 1 := by
+  classical
+  rw [countSignChanges_nowhere_zero hnz]
+  have hset : (Finset.univ.filter (fun p : Fin n × Fin n =>
+        p.2.val = p.1.val + 1 ∧ f p.1 * f p.2 < 0))
+      = Finset.univ.filter (fun p : Fin n × Fin n => p.2.val = p.1.val + 1) := by
+    apply Finset.filter_congr
+    rintro ⟨i, j⟩ _
+    constructor
+    · rintro ⟨h, _⟩; exact h
+    · intro h; exact ⟨h, halt i j h⟩
+  rw [hset, card_adjacent]
+
+/-- **Zero count: constant sign.**  If *every* adjacent pair of a nowhere-zero
+`f : Fin n → ℝ` has the same sign (`0 < f i · f j` whenever `j = i + 1`), then `f` has no sign
+changes: `V(f) = 0`.  The general form of `countSignChanges_three_mid_ne_zero` (`= 0`); the
+adjacent-opposite-sign set is empty. -/
+theorem countSignChanges_same_sign_eq_zero {n : ℕ} {f : Fin n → ℝ} (hnz : ∀ i, f i ≠ 0)
+    (hsame : ∀ i j : Fin n, j.val = i.val + 1 → 0 < f i * f j) :
+    DescartesRuleOfSigns.countSignChanges f = 0 := by
+  classical
+  rw [countSignChanges_nowhere_zero hnz, Finset.card_eq_zero, Finset.filter_eq_empty_iff]
+  rintro ⟨i, j⟩ _ ⟨hadj, hopp⟩
+  exact absurd (hsame i j hadj) (by linarith)
+
 /-- **Reflection complementarity (sequence form).**  For a nowhere-zero sequence
 `f : Fin n → ℝ`, the sign changes of `f` and of its sign-alternated version
 `i ↦ (−1)^i · f i` together cover each of the `n − 1` adjacent gaps *exactly once*:

--- a/research/problems/descartes-rule-of-signs-oq-01-oq-03/knowledge.md
+++ b/research/problems/descartes-rule-of-signs-oq-01-oq-03/knowledge.md
@@ -128,3 +128,45 @@ is complete. Only nextStep #3 (prove B1–B3 for GENERAL polynomials, making Stu
 unconditional) remains — that is the deep content behind the 5 standing axioms, not elementary.
 
 **Files Modified:** proofs/Proofs/DescartesRuleOfSignsOQ01OQ03.lean (+3 thms; 1480→1512 lines).
+
+## Session 2026-07-12 (researcher-3) — general Fin n sign-change bounds (uniformizing the Fin 3 template)
+
+**Mode**: REVISIT (RICH, SOLVED-side). **Outcome**: +3 axiom-free theorems, offline EXIT 0.
+
+### What I Did
+Advanced nextStep (c) — the general `Fin n` sign-change count. The `Fin 3` family
+(`countSignChanges_three_alternating = 2`, `..._mid_ne_zero = 0`) are the n=3 instances of
+three general facts, all one-line corollaries of the existing `countSignChanges_nowhere_zero`
+(routes every count through adjacent opposite-sign pairs) + `card_adjacent` (n−1 adjacent
+pairs). Added to `DescartesRuleOfSignsOQ01OQ03.lean` (after `card_adjacent`):
+- `countSignChanges_le_of_nowhere_zero` : `V(f) ≤ n−1` — universal ceiling, the sequence-level
+  form of the Descartes degree bound `V(p) ≤ deg p` (filter ⊆ adjacent, `Finset.card_le_card`).
+- `countSignChanges_alternating_eq` : all adjacent pairs opposite-sign ⟹ `V(f) = n−1` (maximal;
+  `Finset.filter_congr` collapses {adjacent ∧ opp} to {adjacent}).
+- `countSignChanges_same_sign_eq_zero` : all adjacent pairs same-sign ⟹ `V(f) = 0` (the
+  opposite-sign filter is empty; `Finset.filter_eq_empty_iff`).
+
+### Key Findings
+- The nowhere-zero count machinery (`countSignChanges_nowhere_zero` reducing V to an adjacent-
+  pair filter, + `card_adjacent`) makes the two extremes and the ceiling of the general count
+  fall out uniformly — no case analysis, unlike the hand-written `Fin 3` fin_cases proofs.
+- `V(f) ≤ n−1` is the elementary sequence-side shadow of Descartes' degree bound; the strict
+  alternation case shows it is attained.
+
+### Honest status
+- Not new deep mathematics: the deep content (B1–B3 for GENERAL polynomials, making
+  Sturm⟹Descartes unconditional) remains the standing frontier / axiomatized elsewhere. Value:
+  completes the elementary general `Fin n` sign-change theory (extremes + ceiling) that the
+  file only had at n=2,3. Directly reuses in-file infra.
+- Verified: `LAKE_UNSAFE=1 ./bin/lake env lean Proofs/DescartesRuleOfSignsOQ01OQ03.lean` EXIT 0;
+  the 3 warnings in the log are in pre-existing quadratic lemmas (not my code). `#print axioms`
+  on all 3 → `[propext, Classical.choice, Quot.sound]`.
+
+### Files Modified
+- proofs/Proofs/DescartesRuleOfSignsOQ01OQ03.lean (+3 thm, 1510→1565 lines, 0 axioms/sorries)
+- src/data/research/problems/descartes-rule-of-signs-oq-01-oq-03.json (knowledge)
+
+### Next Steps
+- Bridge the sequence-level `countSignChanges_le_of_nowhere_zero` to the polynomial
+  `signChangesInCoeffs p ≤ p.natDegree` for gap-free p (the coefficient sequence is nowhere-zero).
+- The deep B1–B3-for-general-p direction stays axiomatized / out of elementary scope.

--- a/src/data/research/problems/descartes-rule-of-signs-oq-01-oq-03.json
+++ b/src/data/research/problems/descartes-rule-of-signs-oq-01-oq-03.json
@@ -38,7 +38,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "Solved + degree-2 sign-change side COMPLETE. Sturm⟹Descartes formalized (conditional on SturmReduction bridge; unconditional on linear X−c). The coefficient sign-change count V(a·X²+b·X+c) is now determined for EVERY real quadratic in all sign configs of (a,b,c) (§4 X²±1, §12 nonzero-middle, this session b=0 general + tight witness X²−3X+2). 0 sorries; the file carries 5 deep standing axioms for the general Descartes direction (nextStep #3), not elementarily removable.",
+    "progressSummary": "PROGRESS (researcher-3 2026-07-12): general Fin n sign-change extremes + ceiling (V<=n-1, alternating=n-1, same-sign=0) uniformizing the Fin 3 template; axiom-free, offline EXIT 0. Deep B1-B3-for-general-p direction remains axiomatized.",
     "builtItems": [
       "upper_bound_core / parity_core: omega-closed reduction skeleton over N (axiom-free)",
       "SturmReduction structure bridging Sturm's variation count to Descartes' coefficient sign-change count",
@@ -53,7 +53,8 @@
       "signChangesInCoeffs_eq_natDegree_of_alternating (r6): polynomial-level SHARPNESS of Descartes' degree bound — a nowhere-zero, strictly sign-alternating coefficient sequence gives V(p) = natDegree p exactly; lifts the sequence-level countSignChanges_alternating to polynomials, the companion of signChangesInCoeffs_le_natDegree — axiom-free",
       "x3_minus_x2_plus_x_minus_1_signChanges (r6): first concrete degree-3 validation, signChangesInCoeffs (X^3 - X^2 + X - 1) = 3 (coeff sequence [1,-1,1,-1], Descartes-tight cubic), derived from the general sharpness theorem — axiom-free",
       "signChangesInCoeffs_quadratic_mid_zero_one/_mid_zero_no_change: the b=0 general quadratic a·X²+c count (general form of X²∓1), completing V(a·X²+b·X+c) for ALL sign configs of (a,b,c)",
-      "signChanges_x2_sub_3x_add_2: concrete tight witness X²−3X+2=(X−1)(X−2) with V=2 attaining the degree-2 Descartes bound (two distinct positive roots)"
+      "signChanges_x2_sub_3x_add_2: concrete tight witness X²−3X+2=(X−1)(X−2) with V=2 attaining the degree-2 Descartes bound (two distinct positive roots)",
+      "countSignChanges_le_of_nowhere_zero, countSignChanges_alternating_eq, countSignChanges_same_sign_eq_zero (general Fin n bounds) in DescartesRuleOfSignsOQ01OQ03.lean"
     ],
     "insights": [
       "The entire 'exact count => bound + parity' content reduces to two omega lemmas once the count is written as a non-increasing difference hi - lo; the inequality and the parity fall out of upper_bound_core and parity_core respectively.",
@@ -63,7 +64,8 @@
       "The base file's axiomatised concrete counts (example_x2_minus_1_sign_changes = 1, example_x2_plus_1_sign_changes = 0) are removable: with a Fin 3 middle-zero sign-change lemma the coefficient sequences [1,0,-1] and [1,0,1] are counted axiom-free (natDegree via compute_degree!, coefficients via simp on coeffSequence/coeff_X_pow/coeff_one).",
       "The full Fin 3 sign-change count is governed by the two ADJACENT pairs: count = [f0*f1<0] + [f1*f2<0] whenever the middle f1 is nonzero (the jump-over pair (0,2) is impossible once f1 != 0). A zero middle instead activates (0,2) and caps the count at 1; so the value 2 is exactly the nonzero-middle alternating case, matching Descartes' bound being tight for quadratics with two positive roots (r7).",
       "The degree bound V(p) <= natDegree p is SHARP at the polynomial level: any p whose coefficients are all nonzero and strictly alternate in sign attains V(p) = natDegree p (signChangesInCoeffs_eq_natDegree_of_alternating), a direct lift of the sequence-level countSignChanges_alternating via coeffSequence; the cubic X^3-X^2+X-1 realises the degree-3 case (r6).",
-      "§4 (de-axiomatize X²±1) and §12 (general nonzero-middle quadratic sign-change count) were already complete from prior sessions; the stale nextSteps did not reflect §12."
+      "§4 (de-axiomatize X²±1) and §12 (general nonzero-middle quadratic sign-change count) were already complete from prior sessions; the stale nextSteps did not reflect §12.",
+      "General Fin n sign-change bounds (DescartesRuleOfSignsOQ01OQ03.lean): V(f)<=n-1 universal ceiling (sequence form of Descartes degree bound), all-alternating => V=n-1 (maximal), all-same-sign => V=0. One-line corollaries of countSignChanges_nowhere_zero + card_adjacent; generalize the hand-written Fin 3 fin_cases family to arbitrary n."
     ],
     "mathlibGaps": [
       "No packaged Sturm-sequence sign-variation theory in Mathlib connecting sigma_p to the coefficient sign-change count V(p); the comparison facts (B1)-(B3) must be supplied as assumptions."


### PR DESCRIPTION
## Summary
Research session for `descartes-rule-of-signs-oq-01-oq-03` (Sturm ⟹ Descartes; RICH, SOLVED-side). Advances the standing open direction (c) — a **general `Fin n` sign-change count**. The file had the count pinned only at `n = 2, 3` (hand-written `fin_cases` proofs); the `Fin 3` results are the `n=3` instances of three general facts, all one-line corollaries of the existing `countSignChanges_nowhere_zero` (routes every count through adjacent opposite-sign pairs) and `card_adjacent` (`n − 1` adjacent pairs).

## Progress (3 new theorems, all axiom-free)
- `countSignChanges_le_of_nowhere_zero` — **universal ceiling** `V(f) ≤ n − 1`. The sequence-level form of the Descartes degree bound `V(p) ≤ deg p` (opposite-sign filter ⊆ adjacent-pair set, `Finset.card_le_card`).
- `countSignChanges_alternating_eq` — **maximal count**: all adjacent pairs opposite-sign ⟹ `V(f) = n − 1` (general form of `countSignChanges_three_alternating = 2`; `Finset.filter_congr` collapses `{adjacent ∧ opposite}` to `{adjacent}`).
- `countSignChanges_same_sign_eq_zero` — **zero count**: all adjacent pairs same-sign ⟹ `V(f) = 0` (general form of `countSignChanges_three_mid_ne_zero = 0`; the opposite-sign filter is empty).

## Findings
- The nowhere-zero count machinery makes the two extremes and the ceiling fall out uniformly — no case analysis, unlike the `Fin 3` `fin_cases` proofs.
- `V(f) ≤ n − 1` is the elementary sequence-side shadow of Descartes' degree bound; strict alternation attains it.

## Verification
- `LAKE_UNSAFE=1 ./bin/lake env lean Proofs/DescartesRuleOfSignsOQ01OQ03.lean` → **EXIT 0**, verified offline against cached Mathlib v4.26 oleans (dependency oleans present). The 3 warnings in the log are in pre-existing quadratic lemmas, not the new code.
- `#print axioms` on all 3 new theorems → `[propext, Classical.choice, Quot.sound]` only.

## Status
**Outcome**: progress (axiom-free; completes the elementary general `Fin n` sign-change theory). The deep direction — proving the bridge facts B1–B3 for *general* polynomials to make Sturm ⟹ Descartes unconditional — remains axiomatized / out of elementary scope.
**Next Steps**: bridge `countSignChanges_le_of_nowhere_zero` to `signChangesInCoeffs p ≤ p.natDegree` for gap-free `p`.

🤖 Generated by researcher-3