### PR TITLE
Research: basel-problem-oq-01-oq-02 — ℚ-linear independence of distinct even zeta values

### DIFF
--- a/proofs/Proofs/BaselProblemOQ01OQ02LinIndep.lean
+++ b/proofs/Proofs/BaselProblemOQ01OQ02LinIndep.lean
@@ -1,0 +1,115 @@
+/-
+  ℚ-linear independence of distinct even zeta values
+  (basel-problem-oq-01-oq-02)
+
+  The node `BaselProblemOQ01OQ02.lean` develops the full `ℚ·π^(even)` closure algebra of
+  the even zeta values `ζ(2n) = ∑' k, 1/k^(2n)`: single values, ratios, products, powers,
+  finite/weighted products, polynomial evaluations, and pairwise sums/differences are all
+  shown transcendental.  What that development never records is the **linear-algebra**
+  structure over `ℚ`: distinct even zeta values are not merely individually transcendental,
+  they are jointly `ℚ`-linearly independent.  This file supplies that fact for a pair.
+
+    * `zeta_even_no_rational_relation` — for `0 < m < n`, the only rational solution of
+      `a·ζ(2m) + b·ζ(2n) = 0` is `a = b = 0`.  (Strictly stronger than
+      `zeta_even_add_transcendental` / `zeta_even_sub_transcendental`, which only exclude
+      the special coefficients `(1, 1)` and `(1, -1)`.)
+    * `zeta_even_linearIndependent_pair` — the packaged statement
+      `LinearIndependent ℚ ![ζ(2m), ζ(2n)]`.
+    * `zeta_two_zeta_four_linearIndependent` — the concrete Basel instance
+      `LinearIndependent ℚ ![ζ(2), ζ(4)]`.
+
+  Mathematically: `ζ(2m) = qₘ·π^(2m)` and `ζ(2n) = qₙ·π^(2n)` with `qₘ, qₙ ∈ ℚ∖{0}`;
+  a rational relation forces `a·qₘ + b·qₙ·π^(2(n-m)) = 0` after dividing by `π^(2m)`, and
+  the irrationality of `π^(2(n-m))` then kills the `b`-term, hence the `a`-term.  So the even
+  zeta values lie on distinct `ℚ`-lines through the origin of the transcendence-degree-`1`
+  field `ℚ(π)`.
+
+  Uses `hermite_lindemann` only through `π^m` irrationality (`pi_pow_irrational`, from the
+  parent node); the rational-multiple skeleton is axiom-free.
+-/
+import Mathlib
+import Proofs.BaselProblemOQ01OQ02
+
+open Real
+
+namespace BaselProblemOQ01OQ02LinIndep
+
+/-- **No nontrivial rational relation between two distinct even zeta values.**  For
+    `0 < m < n`, the only rational pair `(a, b)` with
+
+      `a · ζ(2m) + b · ζ(2n) = 0`
+
+    is `(0, 0)`.  Equivalently, `ζ(2m)` and `ζ(2n)` are `ℚ`-linearly independent.
+
+    Writing `ζ(2m) = qₘ π^(2m)`, `ζ(2n) = qₙ π^(2n)` (`qₘ, qₙ ≠ 0`, Euler), the relation
+    becomes `π^(2m)·(a qₘ + b qₙ π^(2(n-m))) = 0`; since `π^(2m) ≠ 0` the bracket vanishes,
+    and `b qₙ ≠ 0` would make `π^(2(n-m)) = -(a qₘ)/(b qₙ)` rational, contradicting
+    `pi_pow_irrational`.  Hence `b = 0`, then `a = 0`. -/
+theorem zeta_even_no_rational_relation (n m : ℕ) (hm : 0 < m) (hmn : m < n) (a b : ℚ)
+    (h : (a : ℝ) * (∑' k : ℕ, 1 / (k : ℝ) ^ (2 * m))
+        + (b : ℝ) * (∑' k : ℕ, 1 / (k : ℝ) ^ (2 * n)) = 0) :
+    a = 0 ∧ b = 0 := by
+  obtain ⟨qm, hqm, hm_eq⟩ := BaselProblemOQ01OQ02.zeta_even_eq_rat_mul_pi_pow m hm
+  obtain ⟨qn, hqn, hn_eq⟩ := BaselProblemOQ01OQ02.zeta_even_eq_rat_mul_pi_pow n (by omega)
+  rw [hm_eq, hn_eq] at h
+  -- split off the shared factor π^(2m)
+  have hsplit : (π : ℝ) ^ (2 * n) = π ^ (2 * m) * π ^ (2 * (n - m)) := by
+    rw [← pow_add]; congr 1; omega
+  rw [hsplit] at h
+  have hpine : (π : ℝ) ^ (2 * m) ≠ 0 := pow_ne_zero _ Real.pi_ne_zero
+  -- the bracket after factoring out π^(2m)
+  have hbr : (a : ℝ) * (qm : ℝ) + (b : ℝ) * (qn : ℝ) * π ^ (2 * (n - m)) = 0 := by
+    have factored :
+        (π : ℝ) ^ (2 * m)
+          * ((a : ℝ) * (qm : ℝ) + (b : ℝ) * (qn : ℝ) * π ^ (2 * (n - m))) = 0 := by
+      rw [← h]; ring
+    rcases mul_eq_zero.mp factored with h1 | h2
+    · exact absurd h1 hpine
+    · exact h2
+  -- π^(2(n-m)) is irrational
+  have hirr : Irrational (π ^ (2 * (n - m))) := BaselProblemOQ01OQ02.pi_pow_irrational _ (by omega)
+  -- b·qn = 0, else π^(2(n-m)) would be rational
+  have hbqn : (b * qn : ℚ) = 0 := by
+    by_contra hne
+    have hirrmul : Irrational (((b * qn : ℚ) : ℝ) * π ^ (2 * (n - m))) := hirr.ratCast_mul hne
+    have heq : ((b * qn : ℚ) : ℝ) * π ^ (2 * (n - m)) = ((-(a * qm) : ℚ) : ℝ) := by
+      push_cast; linarith [hbr]
+    rw [heq] at hirrmul
+    exact (Rat.not_irrational _) hirrmul
+  -- hence b = 0
+  have hb : b = 0 := by
+    rcases mul_eq_zero.mp hbqn with h1 | h1
+    · exact h1
+    · exact absurd h1 hqn
+  -- and then a = 0
+  have ha : a = 0 := by
+    rw [hb] at hbr
+    simp only [Rat.cast_zero, zero_mul, zero_mul, add_zero] at hbr
+    rcases mul_eq_zero.mp hbr with h1 | h1
+    · exact_mod_cast h1
+    · exact absurd (by exact_mod_cast h1 : qm = 0) hqm
+  exact ⟨ha, hb⟩
+
+/-- **Two distinct even zeta values are `ℚ`-linearly independent.**  For `0 < m < n`,
+
+      `LinearIndependent ℚ ![ζ(2m), ζ(2n)]`.
+
+    The packaged form of `zeta_even_no_rational_relation` via `LinearIndependent.pair_iff`.
+    (Over `ℝ` as a `ℚ`-vector space, `s • x = (s : ℝ) * x`.) -/
+theorem zeta_even_linearIndependent_pair (n m : ℕ) (hm : 0 < m) (hmn : m < n) :
+    LinearIndependent ℚ
+      ![(∑' k : ℕ, 1 / (k : ℝ) ^ (2 * m)), (∑' k : ℕ, 1 / (k : ℝ) ^ (2 * n))] := by
+  rw [LinearIndependent.pair_iff]
+  intro s t hst
+  refine zeta_even_no_rational_relation n m hm hmn s t ?_
+  rw [Rat.smul_def, Rat.smul_def] at hst
+  exact hst
+
+/-- **The Basel pair `ζ(2), ζ(4)` is `ℚ`-linearly independent.**  Concretely, no rational
+    `a, b` (other than `0, 0`) satisfy `a·(π²/6) + b·(π⁴/90) = 0`. -/
+theorem zeta_two_zeta_four_linearIndependent :
+    LinearIndependent ℚ
+      ![(∑' k : ℕ, 1 / (k : ℝ) ^ 2), (∑' k : ℕ, 1 / (k : ℝ) ^ 4)] := by
+  exact zeta_even_linearIndependent_pair 2 1 one_pos (by norm_num)
+
+end BaselProblemOQ01OQ02LinIndep

--- a/research/problems/basel-problem-oq-01-oq-02/knowledge.md
+++ b/research/problems/basel-problem-oq-01-oq-02/knowledge.md
@@ -216,3 +216,34 @@ VERIFIED: `lake env lean` EXIT 0; `#print axioms` = [propext, Classical.choice, 
 (no `hermite_lindemann`, no `sorryAx`). File 664 → ~710 lines. OQ depth 2; **0 follow-ups** (the
 provable ℚ·π^(even) side is now saturated including the dependence direction; the open frontier is
 odd-zeta irrationality, Apéry/Ball–Rivoal, not session-sized).
+
+## Session 2026-07-12 (researcher-1) — ℚ-linear independence of even zeta values (orthogonal to the closure algebra)
+
+**Mode**: ACT (node `BaselProblemOQ01OQ02.lean` is saturated on transcendence of individual
+values / products / powers / pairwise sums; the LINEAR-ALGEBRA structure over ℚ was missing).
+**Outcome**: progress — new file, no new axioms.
+
+The closure algebra shows every `ζ(2n)` and every algebraic combination is transcendental, and
+pairwise `ζ(2m)±ζ(2n)` transcendental. What it never records is that distinct even zeta values are
+jointly **ℚ-linearly independent** — a strictly stronger, different-kind statement (independence,
+not transcendence). New file `BaselProblemOQ01OQ02LinIndep.lean`:
+- `zeta_even_no_rational_relation (n m) (0<m<n) (a b : ℚ)` : `a·ζ(2m)+b·ζ(2n)=0 → a=0 ∧ b=0`.
+  Proof: ζ=q·π^(2·), factor π^(2m) (≠0) ⟹ `a·qm + b·qn·π^(2(n-m))=0`; `b·qn≠0` ⟹
+  π^(2(n-m))=−(a·qm)/(b·qn) rational, contradicting `pi_pow_irrational`. ★key move:
+  `hirr.ratCast_mul hne` (`Irrational.ratCast_mul`, q IMPLICIT) gives `Irrational (↑(b·qn)·π^…)`,
+  then `heq : …=↑(−(a·qm))` via `push_cast; linarith [hbr]`, then `Rat.not_irrational`.
+- `zeta_even_linearIndependent_pair` : `LinearIndependent ℚ ![ζ(2m),ζ(2n)]` via
+  `LinearIndependent.pair_iff` + `Rat.smul_def` (ℚ-smul on ℝ = ↑·*·).
+- `zeta_two_zeta_four_linearIndependent` : concrete Basel pair (`2*1≡2`, `2*2≡4` defeq, `exact`).
+
+Axioms: [propext, Classical.choice, Quot.sound, HermiteLindemann.hermite_lindemann] on all three —
+SAME as parent (via `pi_pow_irrational`), NO new assumption. VERIFIED `lake env lean` EXIT 0.
+
+★ `norm_num at h` rewrites `1/k^n → (k^n)⁻¹`, breaking a later `exact` against a `1/`-form goal;
+drop it and rely on `2*1`/`2*2` defeq reduction instead.
+
+### Next Steps
+- General `LinearIndependent ℚ (fun k : Fin N => ζ(2(k+1)))` (reduce to distinct π²-powers via
+  `transcendental_iff_injective` on `aeval (π²)`) — the N-family generalization.
+- Odd-zeta irrationality past ζ(3) remains the genuine open frontier (Apéry/Ball–Rivoal), not
+  session-sized.


### PR DESCRIPTION
## Summary

New file `proofs/Proofs/BaselProblemOQ01OQ02LinIndep.lean` supplying the **linear-algebra structure over ℚ** that the parent node's `ℚ·π^(even)` closure algebra never records.

The node `BaselProblemOQ01OQ02.lean` shows every even zeta value `ζ(2n) = ∑' k, 1/k^(2n)` — and every product/power/ratio/finite-product/aeval combination — is transcendental, and that pairwise sums/differences `ζ(2m) ± ζ(2n)` are transcendental. It never establishes that distinct even zeta values are **jointly ℚ-linearly independent**, a strictly stronger, different-kind statement.

## Results

- `zeta_even_no_rational_relation` — for `0 < m < n`, `a·ζ(2m) + b·ζ(2n) = 0` (with `a, b : ℚ`) forces `a = b = 0`. (Generalizes the `(1, ±1)`-coefficient add/sub transcendence lemmas to *all* rational coefficient pairs.)
- `zeta_even_linearIndependent_pair` — the packaged `LinearIndependent ℚ ![ζ(2m), ζ(2n)]`.
- `zeta_two_zeta_four_linearIndependent` — the concrete Basel instance `LinearIndependent ℚ ![ζ(2), ζ(4)]`.

Proof idea: with `ζ(2m) = qₘπ^(2m)`, `ζ(2n) = qₙπ^(2n)` (`qₘ, qₙ ≠ 0`, Euler), a relation factors as `π^(2m)·(a qₘ + b qₙ π^(2(n-m))) = 0`; since `π^(2m) ≠ 0` the bracket vanishes, and `b qₙ ≠ 0` would make `π^(2(n-m))` rational, contradicting `pi_pow_irrational`.

## Verification

Type-checks against built Mathlib via `lake env lean`. `#print axioms` reports `[propext, Classical.choice, Quot.sound, HermiteLindemann.hermite_lindemann]` on all three theorems — the **same** assumption as the parent node (entered only through `pi_pow_irrational`); no new axioms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)