### PR TITLE
Enrich Finite Arithmetico-Geometric Sum: cover header docstring + 2nd open question

### DIFF
--- a/src/data/proofs/geometric-series-oq-08-oq-01/meta.json
+++ b/src/data/proofs/geometric-series-oq-08-oq-01/meta.json
@@ -80,6 +80,13 @@
   },
   "sections": [
     {
+      "id": "file-overview",
+      "title": "File Overview: What Is Proved and Why It Is Not in Mathlib",
+      "startLine": 4,
+      "endLine": 58,
+      "summary": "The header docstring states the goal and situates it. It records the division-free target (1 − x)²·∑_{k<n} k·xᵏ = x(1 − xⁿ) − n·xⁿ(1 − x) valid over any commutative ring, its field specialisation for x ≠ 1, the integer case ∑_{k<n} k·2ᵏ = (n − 2)·2ⁿ + 2, and the recovery of Mathlib's infinite weighted series x/(1 − x)² as n → ∞. It explains the gap being filled: Mathlib has the infinite weighted series (tsum_coe_mul_geometric_of_norm_lt_one) and the unweighted finite geometric sum (geom_sum_eq), but not the finite arithmetico-geometric closed form — the purely algebraic truncation that weighted-series applications actually need. It positions the entry as the linear-weight (m = 1) refinement of the parent's unweighted partial sums and previews the four-step strategy (ring identity by induction → field form → specialisations → infinite limit)."
+    },
+    {
       "id": "geom-sum-building-block",
       "title": "The Plain Finite Geometric Sum (Building Block)",
       "startLine": 65,
@@ -120,6 +127,11 @@
       "id": "geometric-series-oq-08-oq-01-oq-01",
       "question": "Give the next member of the family: a division-free closed form for the second-moment weighted sum ∑_{k<n} k²·xᵏ over any commutative ring, with field form over (1 − x)³ and the infinite limit x(1 + x)/(1 − x)³.",
       "significance": "low"
+    },
+    {
+      "id": "geometric-series-oq-08-oq-01-oq-02",
+      "question": "Unify the whole hierarchy ∑_{k<n} kᵐ·xᵏ into a single master closed form rather than proving each m by a fresh induction. Applying the operator (x·d/dx)ᵐ to the geometric sum (1 − xⁿ)/(1 − x) produces a numerator that is a polynomial in n and xⁿ whose coefficients are the Eulerian numbers, over the denominator (1 − x)^{m+1}; the present entry is the m = 1 case. Can this operator identity — and the corresponding infinite limit ∑' k, kᵐ·xᵏ = Aₘ(x)/(1 − x)^{m+1} with Aₘ the Eulerian polynomial — be formalised over an arbitrary commutative ring so that every m specialises from one lemma?",
+      "significance": "medium"
     }
   ],
   "crossReferences": [
@@ -167,7 +179,8 @@
     "summary": "The finite arithmetico-geometric sum ∑_{k<n} k·xᵏ — each geometric term xᵏ weighted by its index k — has the division-free closed form (1 − x)²·∑_{k<n} k·xᵏ = x·(1 − xⁿ) − n·xⁿ·(1 − x) over any commutative ring, equivalently ∑_{k<n} k·xᵏ = (x·(1 − xⁿ) − n·xⁿ·(1 − x))/(1 − x)² for x ≠ 1. It specialises to ∑_{k<n} k·2ᵏ = (n − 2)·2ⁿ + 2 and is consistent with Mathlib's infinite weighted series ∑' k, k·xᵏ = x/(1 − x)² for ‖x‖ < 1, which it recovers as n → ∞. 147 lines, 8 theorems, 0 definitions, 0 axioms, 0 sorries; each result depends only on propext, Classical.choice, Quot.sound.",
     "implications": "Mathlib records the infinite weighted geometric series and the unweighted finite geometric sum, but not the finite arithmetico-geometric closed form — the companion needed whenever a weighted geometric series is truncated (annuity and present-value formulas, expected values of geometric distributions, generating-function coefficient extraction). The ring-level identity (1 − x)²·∑ = … holds with no analysis and over every commutative ring; the field form and the infinite limit follow as specialisations.",
     "openQuestions": [
-      "Extend to the second-moment weighted sum ∑_{k<n} k²·xᵏ (field form over (1 − x)³, infinite limit x(1 + x)/(1 − x)³)."
+      "Extend to the second-moment weighted sum ∑_{k<n} k²·xᵏ (field form over (1 − x)³, infinite limit x(1 + x)/(1 − x)³).",
+      "Unify the whole hierarchy ∑_{k<n} kᵐ·xᵏ into one master identity via the operator (x·d/dx)ᵐ applied to the geometric sum, whose numerator carries the Eulerian-number coefficients over the denominator (1 − x)^{m+1}, so that each m (this entry is m = 1) specialises from a single lemma instead of a fresh induction."
     ]
   }
 }


### PR DESCRIPTION
Enrichment pass for `geometric-series-oq-08-oq-01` closing two genuine, below-target gaps found by a section-coverage + open-question sweep.

## Gaps closed
1. **Uncovered header docstring.** The Lean file's 55-line motivational docstring (lines 4–58: *What This Proves / Why This Is Not Already in Mathlib / Relation to the parent / Proof Strategy*) was spanned by no `section` — the first section began at line 65. Added a **File Overview** section (startLine 4, endLine 58) summarising the goal, the Mathlib gap being filled, and the four-step strategy.
2. **Below-minimum open questions.** `conclusion.openQuestions` (and the top-level `openQuestions` array) held only 1 item; the quality target is 2+. Added a substantive second question: unify the whole hierarchy $\sum_{k<n} k^m x^k$ into one master identity via the operator $(x\,d/dx)^m$ applied to the geometric sum, whose numerator carries the **Eulerian-number** coefficients over $(1-x)^{m+1}$ (this entry is the $m=1$ case).

## Verification
- meta.json parses; 16.5 KB (well under the 60 KB cap), 6 sections, both open-question fields now at 2.
- `pnpm build` passes all data-validation and search-index checks; it stops only at the terminal `tsc` step (`tsc: command not found`, missing node_modules) — a pre-existing env gap unrelated to this change.
- No existing content deleted; axiom/status fields untouched (`verified`, 0 axioms — consistent with the Lean file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)