### PR TITLE
Research: abel-ruffini-oq06 metabelian corollary (primitive solvable H ≤ S_p has derived length ≤ 2)

### DIFF
--- a/proofs/Proofs/AbelRuffiniGaloisExtensionsOQ06Metabelian.lean
+++ b/proofs/Proofs/AbelRuffiniGaloisExtensionsOQ06Metabelian.lean
@@ -1,0 +1,132 @@
+/-
+  Primitive Solvable Permutation Groups of Prime Degree — Metabelian corollary
+  (downstream of sub-OQ-06 Galois direction)
+
+  The parent file `Proofs.AbelRuffiniGaloisExtensionsOQ06GaloisDirection`
+  proves Galois's 1832 structure theorem: every primitive solvable subgroup
+  `H ≤ S_p = Equiv.Perm (ZMod p)` embeds into the affine group
+  `AGL(1, p) = ℤ/pℤ ⋊ (ℤ/pℤ)ˣ` via an injective homomorphism
+  `φ : H →* AGL1Z p` (`primitive_solvable_subgroup_embeds_AGL1Z`).
+
+  This file records the **metabelian** structural consequence of that
+  embedding — a materially weaker structural corollary flagged as a valid
+  child OQ in the parent's `nextSteps`:
+
+    every primitive solvable subgroup `H ≤ S_p` is metabelian
+    (its derived length is at most `2`, i.e. `derivedSeries ↥H 2 = ⊥`).
+
+  The proof has two ingredients, both self-contained here:
+
+  1. `AGL1Z_derivedSeries_two_eq_bot` — `AGL(1, p)` is itself metabelian.
+     The scale projection `scaleHom : AGL1Z p →* (ZMod p)ˣ` has commutative
+     codomain, so the first derived subgroup lands in its kernel (the pure
+     translations `K = ker scaleHom`); and `K` is commutative (translations
+     `(a, 1)` commute), so `⁅K, K⁆ = ⊥`.  Hence
+     `derivedSeries (AGL1Z p) 2 = ⁅derivedSeries 1, derivedSeries 1⁆
+        ≤ ⁅K, K⁆ = ⊥`.
+
+  2. Transfer along the injective embedding: derived series are functorial
+     (`map_derivedSeries_le_derivedSeries`), so
+     `(derivedSeries ↥H 2).map φ ≤ derivedSeries (AGL1Z p) 2 = ⊥`, and
+     injectivity of `φ` (`φ.ker = ⊥`) pulls the bound back to
+     `derivedSeries ↥H 2 = ⊥`.
+
+  This is *strictly weaker* than the embedding theorem it is derived from
+  (metabelian-ness does not recover the affine embedding), so it is a
+  legitimate downstream corollary rather than an equivalent-strength
+  restatement.  No new `sorry`, no axiom.
+-/
+
+import Proofs.AbelRuffiniGaloisExtensionsOQ06GaloisDirection
+import Mathlib
+
+namespace AbelRuffiniGaloisExtensionsOQ06GaloisDirection
+
+open AbelRuffiniGaloisExtensionsOQ06
+
+variable {p : ℕ} [Fact p.Prime]
+
+/-- **The translation kernel of `AGL(1, p)` is commutative.**  The kernel of
+    the scale projection `scaleHom : AGL1Z p →* (ZMod p)ˣ` is the subgroup of
+    pure translations `(a, 1)`; any two such elements commute, so the
+    subgroup-commutator `⁅K, K⁆` is trivial.
+
+    Concretely `(a, 1)·(b, 1) = (a + b, 1) = (b, 1)·(a, 1)` because the scale
+    factor is `1`, collapsing the semidirect-product twist to ordinary
+    addition of translations. -/
+theorem AGL1Z_scaleHom_ker_commutator_eq_bot :
+    ⁅(AGL1Z.scaleHom p).ker, (AGL1Z.scaleHom p).ker⁆ = ⊥ := by
+  rw [Subgroup.commutator_eq_bot_iff_le_centralizer]
+  intro g hg
+  rw [Subgroup.mem_centralizer_iff]
+  intro h hh
+  -- `g, h` are pure translations: their scale factors are `1`.
+  have hgs : g.scale = 1 := MonoidHom.mem_ker.mp hg
+  have hhs : h.scale = 1 := MonoidHom.mem_ker.mp hh
+  apply AGL1Z.ext
+  · -- translation coordinate: `h.trans + 1·g.trans = g.trans + 1·h.trans`
+    rw [AGL1Z.mul_trans, AGL1Z.mul_trans, hgs, hhs]
+    push_cast
+    ring
+  · -- scale coordinate: `1 · 1 = 1 · 1`
+    rw [AGL1Z.mul_scale, AGL1Z.mul_scale, hgs, hhs]
+
+/-- **`AGL(1, p)` is metabelian.**  Its second derived subgroup is trivial:
+    `derivedSeries (AGL1Z p) 2 = ⊥`, i.e. the derived length is at most `2`.
+
+    This sharpens the parent file's `AGL1Z_isSolvable` (which only asserts
+    solvability, with no length bound) to the exact derived length of the
+    abelian-by-abelian extension
+    `1 → ℤ/pℤ → AGL(1, p) → (ℤ/pℤ)ˣ → 1`.
+
+    Route: the first derived subgroup lands in `K = ker scaleHom` (the
+    quotient `(ℤ/pℤ)ˣ` is abelian, so every commutator maps to `1`), and
+    `K` is commutative (`AGL1Z_scaleHom_ker_commutator_eq_bot`), so
+    `derivedSeries 2 = ⁅derivedSeries 1, derivedSeries 1⁆ ≤ ⁅K, K⁆ = ⊥`. -/
+theorem AGL1Z_derivedSeries_two_eq_bot :
+    derivedSeries (AGL1Z p) 2 = ⊥ := by
+  -- (1) The first derived subgroup lands in the translation kernel `K`.
+  have h1 : derivedSeries (AGL1Z p) 1 ≤ (AGL1Z.scaleHom p).ker := by
+    rw [derivedSeries_succ, derivedSeries_zero, Subgroup.commutator_le]
+    intro g₁ _ g₂ _
+    rw [MonoidHom.mem_ker, map_commutatorElement, commutatorElement_eq_one_iff_commute]
+    exact mul_comm _ _
+  -- (2) `derivedSeries 2 = ⁅derivedSeries 1, derivedSeries 1⁆`.
+  have e2 : derivedSeries (AGL1Z p) 2
+      = ⁅derivedSeries (AGL1Z p) 1, derivedSeries (AGL1Z p) 1⁆ :=
+    derivedSeries_succ (AGL1Z p) 1
+  rw [e2]
+  -- (3) Bound by `⁅K, K⁆ = ⊥` via monotonicity of the commutator.
+  exact le_bot_iff.mp
+    ((Subgroup.commutator_mono h1 h1).trans
+      (le_of_eq AGL1Z_scaleHom_ker_commutator_eq_bot))
+
+/-- **Corollary (Galois metabelian structure).**  Every primitive solvable
+    subgroup `H ≤ S_p = Equiv.Perm (ZMod p)` is **metabelian**: its derived
+    length is at most `2`, i.e. `derivedSeries ↥H 2 = ⊥`.
+
+    Equivalently, the commutator subgroup `⁅H, H⁆` is abelian.  This is the
+    structural refinement of the qualitative fact that `H` is solvable
+    (`hSolv`): the affine embedding `φ : H ↪ AGL(1, p)`
+    (`primitive_solvable_subgroup_embeds_AGL1Z`) into the metabelian group
+    `AGL(1, p)` (`AGL1Z_derivedSeries_two_eq_bot`) pins the derived length to
+    at most `2`, since derived series are functorial and `φ` is injective.
+
+    It is strictly weaker than the embedding theorem (metabelian-ness does not
+    reconstruct the affine embedding), a genuine downstream corollary of
+    Galois's 1832 classification.  No new `sorry`, no axiom. -/
+theorem primitive_solvable_subgroup_metabelian
+    (H : Subgroup (Equiv.Perm (ZMod p)))
+    (hPrim : MulAction.IsPreprimitive H (ZMod p))
+    (hSolv : IsSolvable H) :
+    derivedSeries (H : Type _) 2 = ⊥ := by
+  obtain ⟨φ, hφ⟩ := primitive_solvable_subgroup_embeds_AGL1Z H hPrim hSolv
+  -- Functoriality: the second derived subgroup maps into `AGL(1,p)`'s, which is `⊥`.
+  have hmap : (derivedSeries (H : Type _) 2).map φ ≤ derivedSeries (AGL1Z p) 2 :=
+    map_derivedSeries_le_derivedSeries φ 2
+  rw [AGL1Z_derivedSeries_two_eq_bot] at hmap
+  have hbot : (derivedSeries (H : Type _) 2).map φ = ⊥ := le_bot_iff.mp hmap
+  rw [Subgroup.map_eq_bot_iff, φ.ker_eq_bot_iff.mpr hφ] at hbot
+  exact le_bot_iff.mp hbot
+
+end AbelRuffiniGaloisExtensionsOQ06GaloisDirection

--- a/src/data/research/problems/abel-ruffini-galois-extensions-oq-06-galois-direction.json
+++ b/src/data/research/problems/abel-ruffini-galois-extensions-oq-06-galois-direction.json
@@ -75,7 +75,8 @@
       "BUILD DIAGNOSIS CORRECTED (researcher-1, 2026-06-18 S19): the long-standing 'dual blackout — proofs/.lake self-symlink breaks all builds (git-128 multi-GB re-clone)' claim is WRONG for Docker. The tracked self-referential symlink proofs/.lake (-> its own abs path, committed in #22746) does NOT prevent docker-build.sh: the cache-volume bind-mount at /workspace/proofs/.lake/build shadows the link inside the container, so .lake is a real dir there. Empirical proof: a full 7743-job Docker build (mantel-theorem-oq-01) succeeded earlier today WITH the symlink present on main. The per-build re-clone of dep git repos (proofwidgets/aesop/Qq/batteries) seen in build logs is NORMAL — only .lake/build (oleans) is volume-mounted, not .lake/packages. The symlink only breaks HOST-side tooling (pnpm/lake/IDE). Fix shipped: PR #25509 removes the tracked symlink fleet-wide.",
       "REAL blockers this session (researcher-1 S19): (1) Aristotle still 404 — mcp-smoke-test.sh hits HTTPStatusError 404 on https://aristotle.harmonic.fun/api/v1/project?project_type=2, so prove()/prove_file() unusable; (2) host IO-load severe (load avg 17+, 10+ concurrent lean-build-* containers, docker volume `du` probes time out >25s) — Docker builds run but are brutally slow and at risk of daemon-restart kill. Builds are POSSIBLE, not blocked; they are just slow + contended right now.",
       "Step-3 verification attempt (researcher-1 S19): launched a properly-detached (nohup+disown+sentinel) Docker build of the complete Step3 orphan AbelRuffiniGaloisExtensionsOQ06GaloisDirectionStep3 (0 real sorries) -> /tmp/r1-step3-verify.{log,done}. If green, fold sylow_p_is_pcycle body verbatim into the registered file (signatures match) to take the frontier 4 sorries -> 3 (Steps 1/4 + main remain). Next session: check the sentinel before relaunching.",
-      "AUDIT 2026-07-12 (researcher-1): the registered file AbelRuffiniGaloisExtensionsOQ06GaloisDirection.lean is genuinely COMPLETE. Offline `lake env lean` EXIT 0 (only a benign unused-section-variable warning), 0 real `sorry` tokens. `#print axioms primitive_solvable_subgroup_embeds_AGL1Z` = [propext, Classical.choice, Quot.sound] only — no sorryAx, no Lean.ofReduceBool. The main theorem signature matches the pinned formal target verbatim (H : Subgroup (Equiv.Perm (ZMod p)), IsPreprimitive, IsSolvable ⟹ ∃ φ : H →* AGL1Z p, Injective φ). The long-standing lone Step-4 sorry (normalizer_iso_AGL1Z, ~19 sessions) was discharged; corollary primitive_solvable_subgroup_card_dvd (Nat.card H ∣ p*(p-1)) is also axiom-free."
+      "AUDIT 2026-07-12 (researcher-1): the registered file AbelRuffiniGaloisExtensionsOQ06GaloisDirection.lean is genuinely COMPLETE. Offline `lake env lean` EXIT 0 (only a benign unused-section-variable warning), 0 real `sorry` tokens. `#print axioms primitive_solvable_subgroup_embeds_AGL1Z` = [propext, Classical.choice, Quot.sound] only — no sorryAx, no Lean.ofReduceBool. The main theorem signature matches the pinned formal target verbatim (H : Subgroup (Equiv.Perm (ZMod p)), IsPreprimitive, IsSolvable ⟹ ∃ φ : H →* AGL1Z p, Injective φ). The long-standing lone Step-4 sorry (normalizer_iso_AGL1Z, ~19 sessions) was discharged; corollary primitive_solvable_subgroup_card_dvd (Nat.card H ∣ p*(p-1)) is also axiom-free.",
+      "S28 (researcher-5, 2026-07-12): the metabelian follow-up flagged in nextSteps is DISCHARGED. Key: AGL(1,p) metabelian = commutator lands in ker scaleHom (abelian translations) so derivedSeries 2 ≤ ⁅ker,ker⁆ = ⊥ (via commutator_eq_bot_iff_le_centralizer); transfer to any subgroup H along an injective hom uses map_derivedSeries_le_derivedSeries + Subgroup.map_eq_bot_iff + φ.ker_eq_bot_iff.mpr. Note map_eq_bot_iff_of_injective takes hf explicit but H implicit — prefer the two-rw route."
     ],
     "nextSteps": [
       "S2 ORIENT: author Lean file skeleton with ~6 file-level + step sorries.",
@@ -89,7 +90,11 @@
       "research/problems/abel-ruffini-galois-extensions-oq-06-galois-direction/state.md",
       "src/data/research/problems/abel-ruffini-galois-extensions-oq-06-galois-direction.json",
       "verify_step1_sylow_unique.py — sympy verify-before-assert for Step 1 of the Galois-direction structure theorem (fills the gap; Steps 4/5 already had scripts)",
-      "primitive_solvable_subgroup_card_eq_prime_mul (|H| = p*m, m | (p-1); researcher-8 S27, VERIFIED 0/0)"
+      "primitive_solvable_subgroup_card_eq_prime_mul (|H| = p*m, m | (p-1); researcher-8 S27, VERIFIED 0/0)",
+      "Proofs/AbelRuffiniGaloisExtensionsOQ06Metabelian.lean — metabelian corollary (AGL(1,p) & every primitive solvable H ≤ S_p have derived length ≤ 2); researcher-5 S28, 0/0"
+    ],
+    "completedThisIter": [
+      "S28 ACT (researcher-5, 2026-07-12): added the metabelian downstream corollary in new file Proofs.AbelRuffiniGaloisExtensionsOQ06Metabelian.lean — flagged as a valid child OQ in nextSteps. Three theorems, 0 sorry, 0 axiom (only propext/Classical.choice/Quot.sound): AGL1Z_scaleHom_ker_commutator_eq_bot (pure-translation kernel is commutative), AGL1Z_derivedSeries_two_eq_bot (AGL(1,p) is metabelian: derivedSeries 2 = ⊥, sharpening the parent AGL1Z_isSolvable's length-free claim to derived length ≤ 2), and primitive_solvable_subgroup_metabelian (every primitive solvable H ≤ S_p has derivedSeries ↥H 2 = ⊥, transferred along the injective affine embedding via map_derivedSeries_le_derivedSeries + φ.ker = ⊥). Offline lake env lean EXIT 0."
     ]
   },
   "references": [
@@ -114,7 +119,7 @@
       "citation": "abel-ruffini-galois-extensions-oq-06 (forward direction, Docker-verified at 1884 jobs by S7 ACT PR #19071)."
     }
   ],
-  "lastUpdate": "2026-07-09T00:00:00.000Z",
+  "lastUpdate": "2026-07-12T00:00:00.000Z",
   "relatedProofs": [
     "abel-ruffini",
     "abel-ruffini-galois-extensions"


### PR DESCRIPTION
## Summary

Discharges the **metabelian** follow-up flagged in the `abel-ruffini-galois-extensions-oq-06-galois-direction` problem's `nextSteps` as a valid child OQ.

The parent file proves Galois's 1832 structure theorem: every primitive solvable subgroup `H ≤ S_p = Equiv.Perm (ZMod p)` embeds into the affine group `AGL(1,p)` via an injective `φ : H →* AGL1Z p`. This PR records the structural consequence: such `H` is **metabelian** (derived length ≤ 2).

## New file `Proofs/AbelRuffiniGaloisExtensionsOQ06Metabelian.lean` — 3 theorems, 0 sorry, 0 axiom

- `AGL1Z_scaleHom_ker_commutator_eq_bot` — the pure-translation kernel `K = ker(scaleHom)` is commutative, so `⁅K,K⁆ = ⊥` (translations `(a,1)·(b,1)=(a+b,1)` commute).
- `AGL1Z_derivedSeries_two_eq_bot` — `AGL(1,p)` is metabelian: `derivedSeries (AGL1Z p) 2 = ⊥`. Sharpens the parent's `AGL1Z_isSolvable` (length-free) to derived length ≤ 2, using that the first derived subgroup lands in `K` (quotient `(ℤ/pℤ)ˣ` abelian) and `K` is abelian.
- `primitive_solvable_subgroup_metabelian` — every primitive solvable `H ≤ S_p` has `derivedSeries ↥H 2 = ⊥`. Transferred along the injective embedding via `map_derivedSeries_le_derivedSeries` + `φ.ker = ⊥`.

Strictly weaker than the embedding theorem it derives from (metabelian-ness does not reconstruct the affine embedding), so a legitimate downstream corollary rather than an equivalent-strength restatement.

## Verification
- Offline `lake env lean Proofs/AbelRuffiniGaloisExtensionsOQ06Metabelian.lean` → EXIT 0 (no errors).
- `#print axioms` on both metabelian theorems → `[propext, Classical.choice, Quot.sound]` only — no `sorryAx`, no `Lean.ofReduceBool`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)