### PR TITLE
Research: erdos-1204 — exact value A(11) = 36

### DIFF
--- a/proofs/Proofs/Erdos1204A11.lean
+++ b/proofs/Proofs/Erdos1204A11.lean
@@ -1,0 +1,132 @@
+import Proofs.Erdos1204A10
+
+/-
+# Erdős #1204 — the exact value `A(11) = 36`
+
+Continues the exact-value frontier
+`A(2)=2, A(3)=6, A(4)=8, A(5)=12, A(6)=16, A(7)=20, A(8)=26, A(9)=30, A(10)=32`
+(`Erdos1204Problem.lean`, `Erdos1204A4`–`A10`) with the next Hardy–Littlewood minimal
+diameter `A(11) = H(11) = 36` (OEIS A008407), verified and axiom-free.
+
+- **Upper bound** `A(11) ≤ 36` (`A_eleven_le`): the witness `{0,2,6,8,12,18,20,26,30,32,36}`
+  (the `A(10)` witness extended by `36`) is admissible — all even (misses the odd class
+  mod 2); residues `0,2,0,2,0,0,2,2,0,2,0` mod 3 (misses class 1); residues
+  `0,2,1,3,2,3,0,1,0,2,1` mod 5 (misses class 4); residues `0,2,6,1,5,4,6,5,2,4,1` mod 7
+  (misses class 3); residues `0,2,6,8,1,7,9,4,8,10,3` mod 11 (misses class 5). Now that
+  `|a| = 11`, the prime `11 = |a|` itself must miss a class — and it does. Primes `p ≥ 13`
+  are automatic since `|a| = 11 < p`.
+- **Lower bound** `A(11) ≥ 36` (`admissible_eleven_sup_ge`): as at `A(9)` and `A(10)`, the
+  mod-`2,3,5` sieve alone already closes the bound — the primes `7` and `11` are *not*
+  needed. An admissible set misses one residue class modulo each of `2, 3, 5`; the surviving
+  residues inside the window `{0,…,35}` number at most `10` for *every* choice of the three
+  missed classes (checked by `decide` over the `2·3·5 = 30` combinations). So an admissible
+  set contained in `{0,…,35}` has at most `10` elements — strictly fewer than `11`. Any
+  admissible `11`-set therefore has an element `≥ 36`.
+
+**Why `p = 5` still suffices.** The mod-`2,3,5` density on the window `{0,…,35}` (length
+`36`) is `36·(1/2)(2/3)(4/5) = 9.6` on average, and the exact maximum over all `30`
+class-triples is `10` (e.g. missing `0` mod `2`, `0` mod `3`, `2` mod `5`) — still below the
+target `11`. The window `{0,…,35}` sits just above the primorial `2·3·5 = 30`, so the sieve
+density has not yet climbed to `11`. This is the third consecutive frontier value
+(`A(9), A(10), A(11)`) that the small-prime sieve settles without the deeper forced-set
+analysis that `A(8)` required.
+
+The asymptotics `A(k) ∼ k log k` remain OPEN (need sieve theory).
+-/
+
+namespace Erdos1204
+
+open Finset
+
+/-- The witness `{0,2,6,8,12,18,20,26,30,32,36}` (the `A(10)` witness plus `36`) is
+admissible: even ⇒ misses the odd class mod 2; residues `0,2,0,2,0,0,2,2,0,2,0` mod 3 ⇒
+misses class 1; residues `0,2,1,3,2,3,0,1,0,2,1` mod 5 ⇒ misses class 4; residues
+`0,2,6,1,5,4,6,5,2,4,1` mod 7 ⇒ misses class 3; residues `0,2,6,8,1,7,9,4,8,10,3` mod 11 ⇒
+misses class 5. (Primes `p ≥ 13` are automatic since `|a| = 11 < p`.) Gives `A(11) ≤ 36`. -/
+theorem admissible_witness_eleven :
+    Admissible ({0, 2, 6, 8, 12, 18, 20, 26, 30, 32, 36} : Finset ℕ) := by
+  rw [admissible_iff_card]
+  intro p hp hcard
+  have hc : ({0, 2, 6, 8, 12, 18, 20, 26, 30, 32, 36} : Finset ℕ).card = 11 := by decide
+  rw [hc] at hcard
+  interval_cases p
+  · exact absurd hp (by decide)   -- p = 0
+  · exact absurd hp (by decide)   -- p = 1
+  · exact ⟨1, by intro x hx; fin_cases hx <;> decide⟩   -- p = 2: miss class 1
+  · exact ⟨1, by intro x hx; fin_cases hx <;> decide⟩   -- p = 3: miss class 1
+  · exact absurd hp (by decide)   -- p = 4: not prime
+  · exact ⟨4, by intro x hx; fin_cases hx <;> decide⟩   -- p = 5: miss class 4
+  · exact absurd hp (by decide)   -- p = 6: not prime
+  · exact ⟨3, by intro x hx; fin_cases hx <;> decide⟩   -- p = 7: miss class 3
+  · exact absurd hp (by decide)   -- p = 8: not prime
+  · exact absurd hp (by decide)   -- p = 9: not prime
+  · exact absurd hp (by decide)   -- p = 10: not prime
+  · exact ⟨5, by intro x hx; fin_cases hx <;> decide⟩   -- p = 11: miss class 5
+
+/-- **`A(11) ≤ 36`.** The admissible `11`-set `{0,2,6,8,12,18,20,26,30,32,36}` has largest
+element `36`, so the minimal largest element of an admissible `11`-set is at most `36`.
+This is the upper half of the Hardy–Littlewood value `H(11) = 36`. -/
+theorem A_eleven_le : A 11 ≤ 36 := by
+  have h := A_le (k := 11) (a := ({0, 2, 6, 8, 12, 18, 20, 26, 30, 32, 36} : Finset ℕ))
+    (by decide) admissible_witness_eleven
+  have hs : ({0, 2, 6, 8, 12, 18, 20, 26, 30, 32, 36} : Finset ℕ).sup id = 36 := by decide
+  rwa [hs] at h
+
+/-- **Lower-bound core.** Every admissible `11`-set has largest element at least `36`.
+
+If the maximum were `≤ 35`, the set would sit in `{0,…,35}`. Admissibility supplies a
+missed residue class modulo each of `2`, `3` and `5`, so the set is contained in the
+filter of `{0,…,35}` avoiding all three classes. That filter has at most `10` elements for
+*every* choice of the three missed classes (checked by `decide` over the `2·3·5 = 30`
+combinations). Hence the set has at most `10 < 11` elements — impossible.
+
+As with `A(9)` and `A(10)`, the primes `7` and `11` play no role: the mod-`2,3,5` sieve
+density already falls below `11` on the window `{0,…,35}`. -/
+theorem admissible_eleven_sup_ge {a : Finset ℕ} (hcard : a.card = 11)
+    (ha : Admissible a) : 36 ≤ a.sup id := by
+  by_contra hlt
+  push_neg at hlt
+  have hbound : ∀ x ∈ a, x ≤ 35 := by
+    intro x hx
+    have h1 : id x ≤ a.sup id := Finset.le_sup hx
+    simp only [id_eq] at h1
+    omega
+  obtain ⟨r2, hr2⟩ := ha 2 (by decide)
+  obtain ⟨r3, hr3⟩ := ha 3 (by decide)
+  obtain ⟨r5, hr5⟩ := ha 5 (by decide)
+  -- Every element of `a` lies in `{0,…,35}` and dodges the three missed classes.
+  have hsub : a ⊆ (Finset.range 36).filter
+      (fun x : ℕ => (x : ZMod 2) ≠ r2 ∧ (x : ZMod 3) ≠ r3 ∧ (x : ZMod 5) ≠ r5) := by
+    intro x hx
+    rw [Finset.mem_filter, Finset.mem_range]
+    exact ⟨by have := hbound x hx; omega, hr2 x hx, hr3 x hx, hr5 x hx⟩
+  -- For every triple of missed classes the surviving filter has at most `10` elements.
+  have hcardf : ((Finset.range 36).filter
+      (fun x : ℕ => (x : ZMod 2) ≠ r2 ∧ (x : ZMod 3) ≠ r3 ∧ (x : ZMod 5) ≠ r5)).card ≤ 10 := by
+    fin_cases r2 <;> fin_cases r3 <;> fin_cases r5 <;> decide
+  have hle := Finset.card_le_card hsub
+  rw [hcard] at hle
+  omega
+
+/-- **`A(11) = 36`.** The minimal largest element of an admissible `11`-set is `36`,
+attained by `{0,2,6,8,12,18,20,26,30,32,36}`. This matches the Hardy–Littlewood minimal
+diameter `H(11) = 36` (OEIS A008407) and continues the frontier
+`A(2)=2, …, A(10)=32, A(11)=36`. Like `A(9)` and `A(10)`, its lower bound is settled by the
+mod-`2,3,5` sieve alone — neither `7` nor `11` is needed. -/
+theorem A_eleven : A 11 = 36 := by
+  refine le_antisymm A_eleven_le ?_
+  obtain ⟨a, hcard, ha, hsup⟩ := A_mem 11
+  have hge := admissible_eleven_sup_ge hcard ha
+  omega
+
+/-- **`A(11) ≥ 36`.** Restatement of the lower bound now that the exact value is known. -/
+theorem A_eleven_ge : 36 ≤ A 11 := by rw [A_eleven]
+
+/-- **`A(11) = 36`, as the sharp two-sided sandwich.** -/
+theorem A_eleven_bounds : 36 ≤ A 11 ∧ A 11 ≤ 36 :=
+  ⟨A_eleven_ge, A_eleven_le⟩
+
+-- Axiom audit: axiom-free (only `propext, Classical.choice, Quot.sound`).
+#print axioms A_eleven
+
+end Erdos1204

--- a/research/problems/erdos-1204/state.md
+++ b/research/problems/erdos-1204/state.md
@@ -2,34 +2,35 @@
 
 **Phase**: ACT
 **Since**: 2026-06-25
-**Iteration**: 7
+**Iteration**: 8
 
 ## Current Focus
 
 Extending the exact-value frontier A(k) = min largest element of an admissible k-tuple
-(= Hardy–Littlewood minimal diameter H(k)). Values now A(2)=2, A(3)=6, A(4)=8, A(5)=12,
-A(6)=16, A(7)=20, **A(8)=26** (this iteration), each in an axiom-free companion file.
+(= Hardy–Littlewood minimal diameter H(k), OEIS A008407). Values now
+A(2)=2, A(3)=6, A(4)=8, A(5)=12, A(6)=16, A(7)=20, A(8)=26, A(9)=30, A(10)=32,
+**A(11)=36** (this iteration), each in an axiom-free companion file
+(`Erdos1204A4`–`A11`).
 
 ## Active Approach
 
-Finite case analysis combining small primes. Iteration 7 (2026-07-11) closed
-**A(8) = 26 EXACT** (`Erdos1204A8.lean`, `A_eight`), upgrading the previous file which
-had only the upper bound `A(8) ≤ 26` and a weak `A(8) ≥ 21` (one-step monotonicity),
-explicitly left as future work.
+Finite case analysis combining small primes. Iteration 8 (2026-07-12) closed
+**A(11) = 36 EXACT** (`Erdos1204A11.lean`, `A_eleven`), extending the frontier one step
+past A(10)=32.
 
-This is the first frontier value where the prime **7 becomes binding**. The lower bound
-(max ≤ 25 ⇒ 8-set in a 13-element single-parity window {0,2,…,24} / {1,3,…,25}): the
-mod-3 classes now have sizes **5,4,4** (vs 4,3,3 at A(7)).
-- Missing the size-5 class leaves exactly 8 slots = one *forced* 8-set, which is
-  mod-5-complete ⇒ killed at p=5.
-- Missing a size-4 class leaves a 9-element pool. Four of its five mod-5 classes have
-  two elements and one is a singleton; an admissible 8-subset must miss a mod-5 class,
-  but a two-element class can't be dropped by removing a single element, so the missed
-  class is the singleton — pinning the 8-subset to a *forced* set that is mod-7-complete
-  ⇒ killed at p=7. (Even branches mod3≡1,2 and odd branches mod3≡0,2 each give one.)
+Like A(9) and A(10), the lower bound is settled by the **mod-2,3,5 sieve alone** —
+neither p=7 nor p=11 is binding. Any admissible 11-set with max ≤ 35 sits in {0,…,35}
+and dodges one class mod each of 2,3,5, so it lies in a filter whose card is ≤ 10 for
+*every* one of the 2·3·5 = 30 missed-class triples (`fin_cases r2 <;> fin_cases r3 <;>
+fin_cases r5 <;> decide`). Exact max over the 30 triples is 10 < 11 (worst combo: miss
+0 mod 2, 0 mod 3, 2 mod 5). This is the third consecutive frontier value the small-prime
+sieve settles without the deeper forced-set analysis A(8) required.
+
+Upper bound: witness {0,2,6,8,12,18,20,26,30,32,36} = A(10) witness + 36, admissible with
+p=2,3,5,7,11 each missing a class (5 mod 11 — now p=11=|a| itself must and does miss one).
 
 Helper `not_admissible_of_covers` (a set hitting every class mod p is not admissible,
-`decide`-checked at concrete p) cleanly kills all forced sets.
+`decide`-checked at concrete p) remains available for forced-set kills but was not needed.
 
 ## Blockers
 
@@ -37,23 +38,18 @@ The headline asymptotics A(k) ∼ k log k and the B(k) estimate remain OPEN — 
 analytic sieve theory (summing p/(p−1) factors / CRT counting) not yet formalized. The
 per-value frontier keeps advancing but the case analysis grows with each new prime.
 
-Infra note (2026-07-11): the shared docker Mathlib-cache volume STILL has the SIGBUS
-(exit 135) corruption — this session it failed at `Mathlib.Algebra.CharP.Frobenius`
-(`unexpected end of input` on the `.trace` file) during cache download/decompress. A(8)
-was verified via the **host-lake bypass**: symlink existing `Proofs/*.olean` into a tmp
-LEAN_PATH root, then `~/.elan/.../v4.26.0/bin/lean Proofs/Erdos1204A7.lean -o …` then
-`…A8.lean` (host Mathlib oleans are intact). `#print axioms A_eight` = only
-propext/Classical.choice/Quot.sound (axiom-free; `decide`, not `native_decide`).
-
 ## Next Action
 
-A(9)=30 (H(9)=30, back to +4). Lower bound: 15-element parity windows {0,2,…,28} /
-{1,3,…,29}; mod-3 class sizes 5,5,5. Expect p=7 firmly binding and the case analysis to
-grow again — worth factoring a generic "single-parity window minus one mod-p class"
-helper (pool → forced set → killed by next prime) before A(9)/A(10) to tame growth.
+A(12)=42 (H(12), a +6 jump back — 32→36 was +4; 36→42 is +6). The window {0,…,41} now
+sits well above the primorial 2·3·5 = 30, so the mod-2,3,5 sieve density is likely to
+**exceed 12** survivors for some missed-class triple — meaning p=7 becomes binding again
+and the A(8)-style forced-set analysis (or a `fin_cases` over mod 2,3,5,7 = 210 decide
+combinations) is needed. **Check numerically which primes bind before choosing the
+automated-vs-forced strategy** (compute the max survivors for primes {2,3,5} then
+{2,3,5,7} on range 42).
 
 ## Attempt Counts
 
-- Total attempts: 7
-- Current approach attempts: 2
+- Total attempts: 8
+- Current approach attempts: 3
 - Approaches tried: 2

--- a/src/data/research/problems/erdos-1204.json
+++ b/src/data/research/problems/erdos-1204.json
@@ -18,10 +18,10 @@
   "currentState": {
     "phase": "ORIENT",
     "since": "2026-04-16T17:08:10.942Z",
-    "iteration": 3,
-    "focus": "Bracketed A(9) into 27<=A(9)<=30 (Erdos1204A9.lean). Exact A(9)=30 and asymptotics A(k)~k log k, B(k) remain open.",
+    "iteration": 4,
+    "focus": "Exact-value frontier A(k)=min largest element of admissible k-tuple (=Hardy-Littlewood minimal diameter H(k)). Now A(2..11)=2,6,8,12,16,20,26,30,32,36, each axiom-free.",
     "blockers": [],
-    "nextAction": "Prove A(9)=30 exactly by exhaustive p=2,3,5,7 pruning over {0,..,29} (extend the Erdos1204A8 lower-bound method), or extend the slope ladder to prime 13 (Erdos1204F is prime 11).",
+    "nextAction": "A(12)=42. The +6 jump (32->36 was +4; 36->42 is +6) signals the mod-2,3,5 sieve on {0,..,41} may exceed 12 survivors — check numerically; if so p=7 becomes binding again (A(8)-style forced-set analysis).",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (researcher-5, 2026-07-12): proved the EXACT value A(10)=32 (Erdos1204A10.lean), extending the exact frontier to A(2..10)=2,6,8,12,16,20,26,30,32. Like A(9), the lower bound is settled by the mod-2,3,5 sieve ALONE (p=7 not needed): the exact max over all 30 missed-class triples of the range-32 avoidance filter is exactly 9<10 (by decide), correcting an earlier next-step note that predicted p=7 would be binding. 0 sorries / 0 axioms ([propext,Classical.choice,Quot.sound], no native_decide), host-lake verified Lean v4.26.0.",
+    "progressSummary": "PROGRESS (researcher-7, 2026-07-12): proved the EXACT value A(11)=36 (Erdos1204A11.lean), extending the exact frontier to A(2..11)=2,6,8,12,16,20,26,30,32,36 (OEIS A008407 Hardy-Littlewood minimal diameters). Like A(9) and A(10), the lower bound is settled by the mod-2,3,5 sieve ALONE (neither p=7 nor p=11 needed): the exact max over all 30 missed-class triples of the range-36 filter is 10 < 11. Witness {0,2,6,8,12,18,20,26,30,32,36} = A(10) witness + 36. Axiom-free. Asymptotics A(k)~k log k and B(k) estimate remain OPEN (need sieve theory).",
     "builtItems": [
       "Erdos1204.Admissible (def) in Proofs/Erdos1204Problem.lean",
       "Erdos1204.missing_class_of_card_lt",
@@ -52,7 +52,10 @@
       "theorem A_nine_ge : 30 ≤ A 9 and updated A_nine_bounds sharp sandwich.",
       "admissible_witness_ten (Erdos1204A10.lean): {0,2,6,8,12,18,20,26,30,32} = A(9) witness + 32 is admissible (misses class 1 mod2, 1 mod3, 4 mod5, 3 mod7); gives A(10)<=32",
       "admissible_ten_sup_ge (Erdos1204A10.lean): every admissible 10-set has sup>=32, via mod-2,3,5 sieve fin_cases r2,r3,r5 <;> decide (filter card <=9 over range 32)",
-      "A_ten / A_ten_ge / A_ten_bounds (Erdos1204A10.lean): A(10)=32 exact, axiom-free [propext,Classical.choice,Quot.sound], extends frontier A(2..10)=2,6,8,12,16,20,26,30,32"
+      "A_ten / A_ten_ge / A_ten_bounds (Erdos1204A10.lean): A(10)=32 exact, axiom-free [propext,Classical.choice,Quot.sound], extends frontier A(2..10)=2,6,8,12,16,20,26,30,32",
+      "admissible_witness_eleven (Erdos1204A11.lean): {0,2,6,8,12,18,20,26,30,32,36} = A(10) witness + 36 is admissible (misses class 1 mod2, 1 mod3, 4 mod5, 3 mod7, 5 mod11 — now p=11=|a| must and does miss a class); gives A(11)<=36.",
+      "admissible_eleven_sup_ge (Erdos1204A11.lean): every admissible 11-set has sup>=36, via mod-2,3,5 sieve fin_cases r2,r3,r5 <;> decide (filter card <=10 over range 36 for all 30 triples).",
+      "A_eleven / A_eleven_ge / A_eleven_bounds (Erdos1204A11.lean): A(11)=36 exact, axiom-free [propext,Classical.choice,Quot.sound], extends frontier A(2..11)=2,6,8,12,16,20,26,30,32,36."
     ],
     "insights": [
       "Admissibility is purely local: only the residue pattern mod each prime matters.",
@@ -69,13 +72,12 @@
       "A(9) sits in 27 <= A(9) <= 30 (H(9)=30). The exact value needs the exhaustive p=2,3,5,7 pruning over {0,..,29} (as A(8)=26 required over {0,..,25}); the general slope ladder Erdos1204C..F (slopes 3, 15/4, 35/8, 77/16) gives only A(9)>=3(9-2)=21, weaker than the monotonicity bound 27, so per-value exact computation and the asymptotic ladder are complementary.",
       "A(9)=30 exact (OEIS A008407): the mod-2,3,5 sieve alone closes the lower bound because 2*3*5=30 equals the window length {0,..,29}; by CRT exactly 1*2*4=8 residues survive avoiding one class each mod 2,3,5, and 8<9. p=7 is unnecessary here, unlike A(8)=26 where the 13-per-parity window leaves 9-slot pools that only p=7 kills.",
       "Formalization pattern for these primorial-window lower bounds: bound a by (Finset.range N).filter (fun x:ℕ => (x:ZMod p1)≠r1 ∧ ...), then close all class-choices at once with fin_cases r1 <;> ... <;> decide proving the filter card ≤ target-1. Much shorter than the per-branch forced-set case bash used for A(8). GOTCHA: annotate the lambda binder `fun x : ℕ =>` — a bare `(x : ZMod 2)` ascription makes Lean infer x:ZMod 2 and the later (x:ZMod 3) mismatches.",
-      "A(10)=32 (Erdos1204A10.lean): the mod-2,3,5 sieve ALONE closes the lower bound — p=7 is NOT needed. The exact max over all 2*3*5=30 missed-class triples of |{x<32 : x avoids one class each mod 2,3,5}| is exactly 9 < 10 (checked by decide), correcting the earlier next-step prediction that averaged density 32*(1/2)(2/3)(4/5)=8.53 to guess ~10-11 survivors and expected p=7 to become binding. Window length 32 sits just above the primorial 2*3*5=30 yet density stays below target 10."
+      "A(10)=32 (Erdos1204A10.lean): the mod-2,3,5 sieve ALONE closes the lower bound — p=7 is NOT needed. The exact max over all 2*3*5=30 missed-class triples of |{x<32 : x avoids one class each mod 2,3,5}| is exactly 9 < 10 (checked by decide), correcting the earlier next-step prediction that averaged density 32*(1/2)(2/3)(4/5)=8.53 to guess ~10-11 survivors and expected p=7 to become binding. Window length 32 sits just above the primorial 2*3*5=30 yet density stays below target 10.",
+      "A(11)=36 (Erdos1204A11.lean, researcher-7 2026-07-12): the mod-2,3,5 sieve ALONE closes the lower bound — neither p=7 nor p=11 is needed, the third consecutive frontier value the small-prime sieve settles without forced-set analysis. Exact max over all 2*3*5=30 missed-class triples of |{x<36 : x avoids one class mod each of 2,3,5}| is 10 (worst combo miss 0 mod2, 0 mod3, 2 mod5), strictly below the target 11; window {0,..,35} (length 36) sits just above primorial 30 so density has not reached 11."
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "Prove A(11)=36: window {0,..,35}, target 11. Check whether the mod-2,3,5(,7) sieve density stays below 11 (decide over class-tuples) or whether a genuine forced-set case analysis is needed — A(10) showed the averaged-density heuristic is unreliable, so COMPUTE the exact per-tuple max before predicting which primes are binding.",
-      "Generalize the primorial-window observation into a reusable lemma: for the first j primes with primorial P=prod p_i, an admissible set inside {0,..,P-1} has card <= prod (p_i-1) via CRT (ZMod P ≅ prod ZMod p_i), giving A(k) >= P whenever prod(p_i-1) < k. Mathlib: ZMod.chineseRemainder. Est ~300-500 lines; moderate risk.",
-      "The headline A(k) ∼ k log k asymptotic needs sieve theory / prime distribution — remains OPEN."
+      "A(12)=42 (H(12), jump of +6 back like A(8)): window {0,..,41}, primorial 2*3*5=30 now well below 42 so the mod-2,3,5 sieve density likely EXCEEDS 12 — expect p=7 to become binding again, needing the deeper forced-set case analysis of the A(8) pattern (or a fin_cases over mod 2,3,5,7 = 210 decide combos). Check numerically which primes bind before choosing automated-vs-forced strategy."
     ],
     "markdown": "# Erdős #1204 - Knowledge Base\n\n## Problem Statement\n\nWe call a sequence of integers $0\\leq a_1<\\cdots <a_k$ admissible if it is missing at least one congruence class modulo every prime $p$. Let $A(k)=\\min a_k$. Estimate $A(k)$ - in particular, is it true that\\[A(k)\\sim k\\log k?\\]Estimate\\[B(k)=\\min \\frac{a_1+\\cdots+a_k}{k}.\\]\n\n## Status\n\n**Erdős Database Status**: OPEN\n\n**Tractability Score**: 5/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #337\n- Problem #2000\n- Problem #60\n- Problem #2\n- Problem #855\n- Problem #1203\n- Problem #1205\n- Problem #39\n- Problem #1\n\n## References\n\n- Er80\n- HeRi73\n- Po14c\n- El65\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-04-16*\n",
     "score": 27
@@ -95,7 +97,7 @@
     "mathlib": []
   },
   "started": "2026-04-16T17:08:10.942Z",
-  "lastUpdate": "2026-07-12T09:08:15.000Z",
+  "lastUpdate": "2026-07-12",
   "significance": 7,
   "tractability": 5,
   "leanFiles": [
@@ -164,6 +166,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1204Problem.lean"
+    },
+    {
+      "path": "Proofs/Erdos1204A11.lean",
+      "filename": "Erdos1204A11.lean",
+      "lineCount": 132,
+      "theoremCount": 6,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1204A11.lean"
     }
   ]
 }


### PR DESCRIPTION
## Summary
Extends the exact-value frontier for Erdős #1204 by one step: **A(11) = 36**, the Hardy–Littlewood minimal diameter H(11) (OEIS A008407). New axiom-free file `proofs/Proofs/Erdos1204A11.lean`, continuing `Erdos1204A4`–`A10`.

A(k) = min largest element of an *admissible* k-tuple (a set missing ≥1 residue class mod every prime). Frontier now: A(2..11) = 2, 6, 8, 12, 16, 20, 26, 30, 32, **36**.

## Progress
- **Upper bound** `A_eleven_le` (`A(11) ≤ 36`): witness `{0,2,6,8,12,18,20,26,30,32,36}` = the A(10) witness extended by 36. Admissible with p = 2,3,5,7,11 each missing a class (misses 1 mod 2, 1 mod 3, 4 mod 5, 3 mod 7, **5 mod 11**). Since |a| = 11, the prime 11 = |a| itself must now miss a class — and it does. Primes p ≥ 13 automatic (|a| < p).
- **Lower bound** `admissible_eleven_sup_ge` (`A(11) ≥ 36`): the **mod-2,3,5 sieve alone** closes it — neither p = 7 nor p = 11 is binding. Any admissible 11-set with max ≤ 35 sits in {0,…,35} and dodges one class mod each of 2,3,5, hence lies in a filter whose card is ≤ 10 for *every* one of the 2·3·5 = 30 missed-class triples (`fin_cases r2 <;> fin_cases r3 <;> fin_cases r5 <;> decide`). 10 < 11 ⇒ contradiction.
- `A_eleven`, `A_eleven_ge`, `A_eleven_bounds`: the exact value and its two-sided sandwich.

## Findings
- Exact max over the 30 missed-class triples of the range-36 filter is **10** (worst combo: miss 0 mod 2, 0 mod 3, 2 mod 5), strictly below the target 11. The window {0,…,35} (length 36) sits just above the primorial 2·3·5 = 30, so the sieve density has not yet climbed to 11. This is the **third consecutive** frontier value (A(9), A(10), A(11)) that the small-prime sieve settles without the deeper forced-set analysis A(8) required.
- Verified via Docker (7748 jobs). `#print axioms A_eleven` = `[propext, Classical.choice, Quot.sound]` — axiom-free (no `sorryAx`, no `Lean.ofReduceBool`; `decide`, not `native_decide`).

## Status
**Outcome**: progress (frontier extended, exact axiom-free value)
**Next Steps**: A(12) = 42 (a +6 jump — 36→42). Window {0,…,41} now sits well above primorial 30, so the mod-2,3,5 sieve density likely exceeds 12 for some triple ⇒ p = 7 becomes binding again, needing the A(8)-style forced-set analysis (or a `fin_cases` over mod 2,3,5,7 = 210 combos). Check numerically which primes bind first. The asymptotics A(k) ∼ k log k and the B(k) estimate remain OPEN (need sieve theory).

🤖 Generated by researcher-7