### PR TITLE
Enrich Finite Arithmetico-Geometric Sum ∑k·xᵏ: docstring section + operator-hierarchy open question

### DIFF
--- a/src/data/proofs/geometric-series-oq-08-oq-01/meta.json
+++ b/src/data/proofs/geometric-series-oq-08-oq-01/meta.json
@@ -80,6 +80,13 @@
   },
   "sections": [
     {
+      "id": "overview-docstring",
+      "title": "Overview: Statement, Motivation, and Proof Roadmap",
+      "startLine": 4,
+      "endLine": 63,
+      "summary": "The module docstring fixes the goal — the finite arithmetico-geometric sum ∑_{k<n} k·xᵏ and its division-free closed form (1 − x)²·∑ = x·(1 − xⁿ) − n·xⁿ·(1 − x) — and situates it against Mathlib, which records the infinite weighted series (tsum_coe_mul_geometric_of_norm_lt_one) and the unweighted finite geometric sum (geom_sum_eq) but not this finite weighted identity. It states why the identity is stronger than the analytic limit (it holds over every commutative ring, with no convergence hypothesis) and lays out the four-step roadmap: the ring identity by induction, the field form by clearing (1 − x)² ≠ 0, the integer specialisation at x = 2, and the infinite-limit consistency check. The closing line records the axiom profile — propext, Classical.choice, Quot.sound only — that certifies the entry as genuinely axiom-free."
+    },
+    {
       "id": "geom-sum-building-block",
       "title": "The Plain Finite Geometric Sum (Building Block)",
       "startLine": 65,
@@ -120,6 +127,11 @@
       "id": "geometric-series-oq-08-oq-01-oq-01",
       "question": "Give the next member of the family: a division-free closed form for the second-moment weighted sum ∑_{k<n} k²·xᵏ over any commutative ring, with field form over (1 − x)³ and the infinite limit x(1 + x)/(1 − x)³.",
       "significance": "low"
+    },
+    {
+      "id": "geometric-series-oq-08-oq-01-oq-02",
+      "question": "Unify the whole moment hierarchy ∑_{k<n} kᵐ·xᵏ through the Euler operator xD = x·(d/dx): since applying xD to the geometric sum sends ∑ xᵏ ↦ ∑ k·xᵏ and (xD)ᵐ ∑ xᵏ = ∑ kᵐ·xᵏ, formalise the operator identity so that each finite moment's closed form — a truncated Eulerian-type numerator Aₘ(x, n) over (1 − x)^{m+1} — is generated mechanically from the geometric sum rather than reproved by a fresh induction for each m. Does the finite (truncated) analogue of the Worpitzky/Eulerian-polynomial identity ∑_{k≥0} kᵐ·xᵏ = Aₘ(x)/(1 − x)^{m+1} admit a division-free ring-level statement uniform in m?",
+      "significance": "medium"
     }
   ],
   "crossReferences": [
@@ -167,7 +179,8 @@
     "summary": "The finite arithmetico-geometric sum ∑_{k<n} k·xᵏ — each geometric term xᵏ weighted by its index k — has the division-free closed form (1 − x)²·∑_{k<n} k·xᵏ = x·(1 − xⁿ) − n·xⁿ·(1 − x) over any commutative ring, equivalently ∑_{k<n} k·xᵏ = (x·(1 − xⁿ) − n·xⁿ·(1 − x))/(1 − x)² for x ≠ 1. It specialises to ∑_{k<n} k·2ᵏ = (n − 2)·2ⁿ + 2 and is consistent with Mathlib's infinite weighted series ∑' k, k·xᵏ = x/(1 − x)² for ‖x‖ < 1, which it recovers as n → ∞. 147 lines, 8 theorems, 0 definitions, 0 axioms, 0 sorries; each result depends only on propext, Classical.choice, Quot.sound.",
     "implications": "Mathlib records the infinite weighted geometric series and the unweighted finite geometric sum, but not the finite arithmetico-geometric closed form — the companion needed whenever a weighted geometric series is truncated (annuity and present-value formulas, expected values of geometric distributions, generating-function coefficient extraction). The ring-level identity (1 − x)²·∑ = … holds with no analysis and over every commutative ring; the field form and the infinite limit follow as specialisations.",
     "openQuestions": [
-      "Extend to the second-moment weighted sum ∑_{k<n} k²·xᵏ (field form over (1 − x)³, infinite limit x(1 + x)/(1 − x)³)."
+      "Extend to the second-moment weighted sum ∑_{k<n} k²·xᵏ (field form over (1 − x)³, infinite limit x(1 + x)/(1 − x)³).",
+      "Unify the whole moment family ∑_{k<n} kᵐ·xᵏ via the Euler operator xD = x·(d/dx): since ∑ kᵐ·xᵏ = (xD)ᵐ ∑ xᵏ, generate each finite closed form — a truncated Eulerian-type numerator over (1 − x)^{m+1} — mechanically from the geometric sum instead of a fresh induction per m."
     ]
   }
 }


### PR DESCRIPTION
Enrichment pass for `geometric-series-oq-08-oq-01`.

Genuine two-part target found via below-minimum sweep (oq=1) + section-coverage gap (64-line docstring header uncovered, sections began at line 65):

1. **Section coverage** — added an *Overview* section (lines 4-63) covering the previously-uncovered module docstring: the goal (finite arithmetico-geometric closed form), the Mathlib gap it fills, the four-step proof roadmap, and the axiom profile (propext/Classical.choice/Quot.sound only).
2. **Open questions** — added a substantive second open question in both the top-level `openQuestions` and `conclusion.openQuestions` (was 1, quality target is 2+): unify the whole moment hierarchy ∑ kᵐ·xᵏ through the Euler operator xD = x·(d/dx), since ∑ kᵐ·xᵏ = (xD)ᵐ ∑ xᵏ, generating each closed form (truncated Eulerian-type numerator over (1−x)^{m+1}) mechanically rather than by fresh induction per m.

Preserves all existing content. meta.json 16.5 KB (well under caps). JSON validates; gallery build data checks (enrichment summary, search index, loading facts) pass — only the unrelated terminal `tsc` step fails on the known missing-node_modules env gap.

axiomCount/status/badge unchanged and consistent with the Lean file (0 axioms, verified, original).