### PR TITLE
Research: tetrahedral-oq02 — S_d as a rational Polynomial ℚ (Faulhaber form)

### DIFF
--- a/proofs/Proofs/TetrahedralNumberFormulaOQ02SumPoly.lean
+++ b/proofs/Proofs/TetrahedralNumberFormulaOQ02SumPoly.lean
@@ -1,0 +1,89 @@
+import Proofs.TetrahedralNumberFormulaOQ02Polynomial
+import Mathlib
+
+/-
+# The Figurate Partial Sum `S_d` as a Rational Polynomial (Faulhaber form)
+
+## Context
+
+`TetrahedralNumberFormulaOQ02` proves the uniform cleared-denominator identity
+`(d+1)! · S_d(n) = ∏_{i<d+1} (n+1+i)` for the running total
+`S_d(n) = ∑_{k≤n} P_d(k)` of the `d`-dimensional figurate row, and
+`TetrahedralNumberFormulaOQ02Polynomial` packages the *cleared* right-hand side
+as a genuine monic `Polynomial ℤ` `figuratePoly d` of degree `d+1` with
+`figuratePoly d (n) = (d+1)! · S_d(n)`.
+
+This file supplies the **remaining `nextStep`** of `OQ02`: expressing `S_d`
+*itself* — not just `(d+1)!·S_d` — as a first-class `Polynomial ℚ`, the
+Faulhaber/Bernoulli viewpoint in which a power-sum / figurate-sum is a rational
+polynomial in the upper limit.
+
+## Result
+
+`figurateSumPoly d : Polynomial ℚ := C ((d+1)!)⁻¹ · (figuratePoly d).map (ℤ→ℚ)`
+is the degree-`d+1` rational polynomial whose value at every natural number `n`
+is exactly the figurate partial sum `S_d(n)`:
+
+* `figurateSumPoly_eval` : `(figurateSumPoly d).eval n = S_d(n)` — the bridge to
+  the arithmetic partial sum, over `ℚ`. This is the sense in which `S_d` *is* a
+  polynomial: a single rational polynomial reproduces the entire sequence
+  `n ↦ ∑_{k≤n} P_d(k)`.
+* `figurateSumPoly_natDegree` : `deg (figurateSumPoly d) = d + 1` — one more than
+  the dimension, matching the closed form `S_d(n) = C(n+d+1, d+1)`.
+* `figurateSumPoly_leadingCoeff` : the leading coefficient is `1/(d+1)!` — the
+  reciprocal factorial that Faulhaber's formula predicts for the top term
+  `n^{d+1}/(d+1)!`.
+
+Together these exhibit `S_d` as a monic-up-to-`1/(d+1)!` rational polynomial of
+degree `d+1`, the exact shape of a Faulhaber summation polynomial.
+
+0 sorries, 0 axioms.
+-/
+
+namespace TetrahedralNumberFormulaOQ02
+
+open Finset Polynomial TetrahedralNumberFormulaOQ01
+
+/-- The **rational figurate-sum polynomial** `S_d` as a `Polynomial ℚ`:
+`figurateSumPoly d = (1/(d+1)!) · Q_d` where `Q_d = figuratePoly d` is the
+integer cleared-form polynomial `∏_{i<d+1}(X+(i+1))`. Dividing the cleared form
+by its sole `(d+1)!` denominator turns the *cleared* figurate sum back into the
+figurate sum itself, now realized as a rational polynomial in the upper limit. -/
+noncomputable def figurateSumPoly (d : ℕ) : Polynomial ℚ :=
+  Polynomial.C ((Nat.factorial (d + 1) : ℚ)⁻¹) *
+    (figuratePoly d).map (Int.castRingHom ℚ)
+
+/-- **Evaluation bridge.** The rational figurate-sum polynomial reproduces the
+arithmetic partial sum at every natural number: `(figurateSumPoly d).eval n = S_d(n)`.
+
+Combines the integer evaluation `figuratePoly d (n) = (d+1)!·S_d(n)` with the
+`(d+1)!` scalar, cancelling exactly because `(d+1)! ≠ 0` in `ℚ`. -/
+theorem figurateSumPoly_eval (d n : ℕ) :
+    (figurateSumPoly d).eval (n : ℚ) = (figurateSum d n : ℚ) := by
+  have hfac : (Nat.factorial (d + 1) : ℚ) ≠ 0 := by
+    exact_mod_cast (Nat.factorial_pos (d + 1)).ne'
+  rw [figurateSumPoly, eval_mul, eval_C, eval_natCast_map, figuratePoly_eval,
+    eq_intCast, Int.cast_natCast, Nat.cast_mul, inv_mul_cancel_left₀ hfac]
+
+/-- **Degree.** `figurateSumPoly d` has degree exactly `d + 1`. Scaling the
+monic degree-`d+1` polynomial `Q_d` by the nonzero constant `1/(d+1)!` preserves
+the degree; mapping `ℤ → ℚ` is injective and so degree-preserving. -/
+theorem figurateSumPoly_natDegree (d : ℕ) :
+    (figurateSumPoly d).natDegree = d + 1 := by
+  have hc : (Nat.factorial (d + 1) : ℚ)⁻¹ ≠ 0 :=
+    inv_ne_zero (by exact_mod_cast (Nat.factorial_pos (d + 1)).ne')
+  rw [figurateSumPoly, natDegree_C_mul hc,
+    natDegree_map_eq_of_injective (Int.castRingHom ℚ).injective_int,
+    figuratePoly_natDegree]
+
+/-- **Leading coefficient.** The top coefficient of `figurateSumPoly d` is
+`1/(d+1)!` — the reciprocal-factorial leading term of Faulhaber's formula,
+`S_d(n) = n^{d+1}/(d+1)! + (lower order)`. It is `1/(d+1)!` times the leading
+coefficient `1` of the monic cleared-form polynomial `Q_d`. -/
+theorem figurateSumPoly_leadingCoeff (d : ℕ) :
+    (figurateSumPoly d).leadingCoeff = (Nat.factorial (d + 1) : ℚ)⁻¹ := by
+  rw [figurateSumPoly, leadingCoeff_mul, leadingCoeff_C,
+    leadingCoeff_map_of_injective (Int.castRingHom ℚ).injective_int,
+    (figuratePoly_monic d).leadingCoeff, map_one, mul_one]
+
+end TetrahedralNumberFormulaOQ02

--- a/src/data/research/problems/tetrahedral-number-formula-oq-02.json
+++ b/src/data/research/problems/tetrahedral-number-formula-oq-02.json
@@ -41,7 +41,8 @@
       "figuratePoly_monic: Q_d is monic (monic_prod_of_monic of monic_X_add_C factors)",
       "figuratePoly_natDegree: Q_d has natDegree exactly d+1 (natDegree_prod_of_monic + sum of unit degrees)",
       "figuratePoly_eval: Q_d.eval (n:ℤ) = (d+1)!·S_d(n) — evaluation bridge back to factorial_mul_sum_simplex",
-      "figuratePoly_factorial_dvd_eval: (d+1)! ∣ Q_d.eval(n) — integrality read off the polynomial"
+      "figuratePoly_factorial_dvd_eval: (d+1)! ∣ Q_d.eval(n) — integrality read off the polynomial",
+      "Proofs/TetrahedralNumberFormulaOQ02SumPoly.lean — S_d as a rational Polynomial ℚ (Faulhaber form): figurateSumPoly, eval bridge, degree d+1, leading coeff 1/(d+1)!; researcher-5, 0/0"
     ],
     "insights": [
       "The oq-02 target (uniform cleared-denominator form of the partial SUM) is an immediate but previously-unrecorded composition of two OQ01 lemmas kept separate there: sum_simplex (hockey stick) and factorial_mul_simplexNumber_prod (cleared closed form). Composing at dimension d+1 gives (d+1)!·S_d(n)=∏(n+1+i).",
@@ -53,10 +54,12 @@
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "Optional: relate figuratePoly to a shifted binomial/Pochhammer Polynomial and derive its coefficients (Stirling numbers of the first kind) explicitly.",
-      "Optional: express S_d itself (not just (d+1)!·S_d) as a Polynomial ℚ of degree d+1 via the (d+1)! scalar, tying to the Bernoulli/Faulhaber viewpoint."
+      "Optional: relate figuratePoly to a shifted binomial/Pochhammer Polynomial and derive its coefficients (Stirling numbers of the first kind) explicitly."
     ],
-    "markdown": "# Knowledge Base: tetrahedral-number-formula-oq-02\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
+    "markdown": "# Knowledge Base: tetrahedral-number-formula-oq-02\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n",
+    "completedThisIter": [
+      "S-ext (researcher-5, 2026-07-12): discharged the remaining nextStep — express S_d ITSELF (not just (d+1)!·S_d) as a Polynomial ℚ (Faulhaber/Bernoulli viewpoint) — in new file Proofs.TetrahedralNumberFormulaOQ02SumPoly.lean. Def figurateSumPoly d = C((d+1)!)⁻¹ · (figuratePoly d).map (ℤ→ℚ) with 3 theorems, 0 sorry/0 axiom: figurateSumPoly_eval (eval n = S_d(n) over ℚ, via eval_natCast_map + figuratePoly_eval + inv_mul_cancel_left₀), figurateSumPoly_natDegree (= d+1, natDegree_C_mul + natDegree_map_eq_of_injective), and figurateSumPoly_leadingCoeff (= 1/(d+1)!, the Faulhaber top-term reciprocal factorial). Offline lake env lean EXIT 0."
+    ]
   },
   "tags": [
     "combinatorics",
@@ -72,7 +75,7 @@
     "mathlib": []
   },
   "started": "2026-07-10T05:15:55.896Z",
-  "lastUpdate": "2026-07-12",
+  "lastUpdate": "2026-07-12T00:00:00.000Z",
   "leanFiles": [
     {
       "path": "Proofs/TetrahedralNumberFormula.lean",


### PR DESCRIPTION
## Summary

Discharges the remaining `nextStep` of `tetrahedral-number-formula-oq-02`: express the figurate partial sum `S_d(n) = ∑_{k≤n} P_d(k)` **itself** (not just the cleared `(d+1)!·S_d`) as a first-class `Polynomial ℚ` — the Faulhaber/Bernoulli viewpoint in which a figurate/power sum is a rational polynomial in its upper limit.

The sibling file `OQ02Polynomial` already packaged the *cleared* form as a monic `Polynomial ℤ` `figuratePoly d` (value `(d+1)!·S_d(n)`). This PR divides by the sole `(d+1)!` denominator over `ℚ`.

## New file `Proofs/TetrahedralNumberFormulaOQ02SumPoly.lean` — 1 def + 3 theorems, 0 sorry, 0 axiom

- `figurateSumPoly d = C((d+1)!)⁻¹ · (figuratePoly d).map (Int.castRingHom ℚ)`.
- `figurateSumPoly_eval`: `(figurateSumPoly d).eval n = S_d(n)` over `ℚ` — a single rational polynomial reproduces the whole partial-sum sequence.
- `figurateSumPoly_natDegree = d + 1` (matching `S_d(n) = C(n+d+1, d+1)`).
- `figurateSumPoly_leadingCoeff = 1/(d+1)!` — Faulhaber's reciprocal-factorial leading term `n^{d+1}/(d+1)!`.

## Verification
- Offline `lake env lean Proofs/TetrahedralNumberFormulaOQ02SumPoly.lean` → EXIT 0.
- `#print axioms` on all three theorems → `[propext, Classical.choice, Quot.sound]` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)