### PR TITLE
Research (researcher-10): erdos-165 asymptotic constants + SL(2,p) order-p element count

### DIFF
--- a/proofs/Proofs/AlternatingSeriesBooleSummationOQ01OQ01ClosedForm.lean
+++ b/proofs/Proofs/AlternatingSeriesBooleSummationOQ01OQ01ClosedForm.lean
@@ -1,0 +1,152 @@
+/-
+# Alternating-Series Boole Summation — OQ-01-OQ-01, explicit remainder closed form
+
+The parent file `AlternatingSeriesBooleSummationOQ01OQ01.lean` proves the order-`K` Boole
+summation limit
+
+  `S = ∑_{k=0}^{K-1} ((-1)^k / 2^{k+1}) · (-1)^n (Δᵏa)_n + ((-1)^K / 2^K) · T_K`
+      (`boole_general_tendsto`),
+
+where `T_K := lim_m altSum (Δᴷa) n m` is the limit of the alternating series of the `K`-th
+forward differences.  Its `iterate_altSum_tendsto` shows every `T_k` exists, but only through the
+**recursion** `T_{k+1} = (-1)^n (Δᵏa)_n − 2 T_k` (`T_0 = S`): each `T_k` is exhibited via the
+previous one, not by a standalone formula.
+
+This file settles the outstanding open item (`nextSteps` #2 in the problem tracker): unrolling that
+recursion into an **explicit, non-recursive closed form** for the higher-difference series limit,
+
+  `T_K = ∑_{k=0}^{K-1} (-2)^{K-1-k} · (-1)^n (Δᵏa)_n + (-2)^K · S`   (`iterate_altSum_limit_closed`),
+
+expressing `T_K` purely through the base sum `S` and the boundary data `(Δᵏa)_n`, with no reference
+to the intermediate limits.  The proof is a single induction on `K` feeding the parent's first-order
+engine `fdiff_altSum_tendsto` its own inductive hypothesis; the only bookkeeping is the geometric
+weight `(-2)^{K-1-k}` and the identity `(-2)^{K-k} = −2·(-2)^{K-1-k}` for `k < K`.
+
+Consequences proved here:
+
+* `iterate_altSum_limit_closed_of_antitone` — the same closed form unconditionally for antitone null
+  sequences (convergence supplied by Mathlib's alternating-series test, via the parent's
+  `altSum_tendsto_of_antitone`).
+* `iterate_altSum_limit_one` — sanity check `K = 1`: `T_1 = (-1)^n a_n − 2 S`, matching
+  `fdiff_altSum_tendsto`.
+* `boole_general_tendsto_closed` — substituting the closed form back into `boole_general_tendsto`,
+  a self-consistency identity: the two closed forms fit together to give exactly `S`.
+
+All results are over `ℝ` and axiom-free.
+-/
+
+import Mathlib
+import Proofs.AlternatingSeriesBooleSummation
+import Proofs.AlternatingSeriesBooleSummationOQ01OQ01
+
+namespace AlternatingSeriesBooleSummationOQ01OQ01ClosedForm
+
+open AlternatingSeriesBooleSummation AlternatingSeriesBooleSummationOQ01OQ01
+open Finset Filter Topology
+
+/-! ## The explicit closed form for the higher-difference series limit -/
+
+/-- **Explicit closed form for `T_K`.**  If `a → 0` and the base alternating series converges
+(`altSum a n · → S`), then for every order `K` the alternating series of the `K`-th forward
+difference converges to the explicit value
+
+  `T_K = ∑_{k=0}^{K-1} (-2)^{K-1-k} · (-1)^n (Δᵏa)_n + (-2)^K · S`.
+
+This unrolls the recursion `T_{k+1} = (-1)^n (Δᵏa)_n − 2 T_k` (with `T_0 = S`) of the parent's
+`iterate_altSum_tendsto` into a standalone formula in the base sum `S` and the boundary data
+`(Δᵏa)_n`.  Proof by induction on `K`: the successor step applies the first-order limit engine
+`fdiff_altSum_tendsto` (to the null sequence `Δᴷa`, using `iterate_fdiff_tendsto_zero`) to the
+inductive hypothesis, and the geometric weights recombine via `(-2)^{K-k} = −2·(-2)^{K-1-k}`. -/
+theorem iterate_altSum_limit_closed {a : ℕ → ℝ} {n : ℕ} {S : ℝ}
+    (ha0 : Tendsto a atTop (𝓝 0))
+    (hS : Tendsto (fun m => altSum a n m) atTop (𝓝 S)) (K : ℕ) :
+    Tendsto (fun m => altSum (fdiff^[K] a) n m) atTop
+      (𝓝 ((∑ k ∈ Finset.range K,
+              (-2 : ℝ) ^ (K - 1 - k) * ((-1 : ℝ) ^ n * (fdiff^[k] a) n))
+          + (-2 : ℝ) ^ K * S)) := by
+  induction K with
+  | zero => simpa using hS
+  | succ K ih =>
+    -- `Δ^{K+1}a = Δ(Δᴷa)`, so the target series is the first-order series of `Δᴷa`.
+    have hstep : fdiff^[K + 1] a = fdiff (fdiff^[K] a) :=
+      congrFun (Function.iterate_succ' fdiff K) a
+    rw [hstep]
+    -- `Δᴷa` is null, and its base series converges to the order-`K` closed form (the IH).
+    have hbk : Tendsto (fdiff^[K] a) atTop (𝓝 0) := iterate_fdiff_tendsto_zero ha0 K
+    have h := fdiff_altSum_tendsto hbk ih
+    -- It remains to identify the order-`(K+1)` closed form with `(-1)^n (Δᴷa)_n − 2·(order-K form)`.
+    have hval :
+        (∑ k ∈ Finset.range (K + 1),
+              (-2 : ℝ) ^ (K + 1 - 1 - k) * ((-1 : ℝ) ^ n * (fdiff^[k] a) n))
+          + (-2 : ℝ) ^ (K + 1) * S
+        = (-1 : ℝ) ^ n * (fdiff^[K] a) n
+          - 2 * ((∑ k ∈ Finset.range K,
+                    (-2 : ℝ) ^ (K - 1 - k) * ((-1 : ℝ) ^ n * (fdiff^[k] a) n))
+                + (-2 : ℝ) ^ K * S) := by
+      -- Normalise the exponent `(K+1)-1-k` to `K-k`.
+      have e1 : ∀ k, K + 1 - 1 - k = K - k := by intro k; omega
+      simp only [e1]
+      -- Pull the top term `k = K` out of the sum; its weight `(-2)^{K-K}` is `1`.
+      rw [Finset.sum_range_succ, Nat.sub_self, pow_zero, one_mul]
+      -- Rewrite the remaining range-`K` sum as `-2` times the order-`K` sum, termwise.
+      have hsum :
+          (∑ k ∈ Finset.range K, (-2 : ℝ) ^ (K - k) * ((-1 : ℝ) ^ n * (fdiff^[k] a) n))
+            = -2 * ∑ k ∈ Finset.range K,
+                (-2 : ℝ) ^ (K - 1 - k) * ((-1 : ℝ) ^ n * (fdiff^[k] a) n) := by
+        rw [Finset.mul_sum]
+        refine Finset.sum_congr rfl (fun k hk => ?_)
+        have hk' : k < K := Finset.mem_range.mp hk
+        have he : K - k = (K - 1 - k) + 1 := by omega
+        rw [he, pow_succ]
+        ring
+      rw [hsum, pow_succ]
+      ring
+    rw [hval]
+    exact h
+
+/-! ## Corollaries -/
+
+/-- **Unconditional closed form for antitone null sequences.**  For an antitone `a → 0` the base
+series converges by Mathlib's alternating-series test, so the closed form for `T_K` holds outright
+(no convergence hypothesis).  We return the base sum `S` alongside the explicit higher-difference
+limit. -/
+theorem iterate_altSum_limit_closed_of_antitone {a : ℕ → ℝ} (ha : Antitone a)
+    (ha0 : Tendsto a atTop (𝓝 0)) (n K : ℕ) :
+    ∃ S, Tendsto (fun m => altSum a n m) atTop (𝓝 S)
+      ∧ Tendsto (fun m => altSum (fdiff^[K] a) n m) atTop
+          (𝓝 ((∑ k ∈ Finset.range K,
+                  (-2 : ℝ) ^ (K - 1 - k) * ((-1 : ℝ) ^ n * (fdiff^[k] a) n))
+              + (-2 : ℝ) ^ K * S)) := by
+  obtain ⟨S, hS⟩ := altSum_tendsto_of_antitone ha ha0 n
+  exact ⟨S, hS, iterate_altSum_limit_closed ha0 hS K⟩
+
+/-- **Sanity check `K = 1`.**  The closed form gives `T_1 = (-1)^n a_n − 2 S`, exactly the value
+delivered by the parent's first-order engine `fdiff_altSum_tendsto`. -/
+theorem iterate_altSum_limit_one {a : ℕ → ℝ} {n : ℕ} {S : ℝ}
+    (ha0 : Tendsto a atTop (𝓝 0))
+    (hS : Tendsto (fun m => altSum a n m) atTop (𝓝 S)) :
+    Tendsto (fun m => altSum (fdiff a) n m) atTop (𝓝 ((-1 : ℝ) ^ n * a n - 2 * S)) := by
+  have h := iterate_altSum_limit_closed ha0 hS 1
+  simpa using h
+
+/-- **Self-consistency with `boole_general_tendsto`.**  Substituting the explicit closed form for
+`T_K` into the order-`K` Boole limit identity reproduces exactly `S`: the boundary sum with the
+Boole/Euler weights `(-1)^k/2^{k+1}` plus `((-1)^K/2^K)` times the explicit `T_K` collapses back to
+the base sum.  This is the closed-form version of `boole_general_tendsto` in which the remainder is
+no longer an abstract limit but the explicit formula from `iterate_altSum_limit_closed`. -/
+theorem boole_general_tendsto_closed {a : ℕ → ℝ} {n K : ℕ} {S : ℝ}
+    (ha0 : Tendsto a atTop (𝓝 0))
+    (hS : Tendsto (fun m => altSum a n m) atTop (𝓝 S)) :
+    S = (∑ k ∈ Finset.range K,
+            ((-1 : ℝ) ^ k / 2 ^ (k + 1)) * ((-1 : ℝ) ^ n * (fdiff^[k] a) n))
+        + ((-1 : ℝ) ^ K / 2 ^ K)
+          * ((∑ k ∈ Finset.range K,
+                (-2 : ℝ) ^ (K - 1 - k) * ((-1 : ℝ) ^ n * (fdiff^[k] a) n))
+            + (-2 : ℝ) ^ K * S) := by
+  exact boole_general_tendsto ha0 hS (iterate_altSum_limit_closed ha0 hS K)
+
+#check @iterate_altSum_limit_closed
+#check @iterate_altSum_limit_closed_of_antitone
+#check @boole_general_tendsto_closed
+
+end AlternatingSeriesBooleSummationOQ01OQ01ClosedForm

--- a/proofs/Proofs/Erdos165Problem.lean
+++ b/proofs/Proofs/Erdos165Problem.lean
@@ -748,4 +748,148 @@ theorem mainConjecture_imp_isLeast_validUpperConstant (h : mainConjecture) :
   ⟨mainConjecture_iff_validUpperConstant_half.mp h,
    fun b hb => ValidUpperConstant_ge_half hb⟩
 
+/- ## Part XII: The exact asymptotic constants exist unconditionally
+
+Part XI closed with a *conditional* headline (`mainConjecture_imp_isLeast_validUpperConstant`):
+**under** the Erdős conjecture, `1/2` is the least valid upper constant.  This section removes
+the hypothesis.  The set `{b | ValidUpperConstant b}` is nonempty (`1 ∈`, Shearer) and bounded
+below (`≥ 1/2`, the HHKP fence), so its infimum `c⁺ := sInf {b | ValidUpperConstant b}` exists —
+and, crucially, is **attained**: `c⁺` is itself a valid upper constant.  Hence, with *no*
+conjecture assumed, `R(3,k)` has a genuine least first-order upper constant `c⁺ ∈ [1/2, 1]`, the
+true asymptotic upper constant.  Dually the valid lower constants have a greatest element
+`c⁻ := sSup {a | ValidLowerConstant a} ∈ [1/2, 1]`, with `c⁻ ≤ c⁺`.  The Erdős conjecture then
+collapses to the crisp scalar equation `c⁺ = 1/2` — an *iff*, upgrading the conditional
+one-directional Part XI result to a genuine characterisation.
+
+The one non-formal step is attainment of the infimum, `validUpperConstant_sInf_mem`: for any
+`δ > 0`, since `c⁺ < c⁺ + δ` there is a valid upper constant `b < c⁺ + δ` (`exists_lt_of_csInf_lt`),
+and feeding `ε' = c⁺ + δ − b > 0` into `ValidUpperConstant b` yields `R(3,k) ≤ (c⁺ + δ)·k²/log k`
+eventually.  This is exactly the statement that the up-set of valid upper constants is *closed at
+its infimum*.  No new axioms; the two sharp Ramsey bounds enter only through Part XI. -/
+
+/-- The valid first-order upper constants are bounded below (by `1/2`, the HHKP fence). -/
+theorem bddBelow_validUpperConstant : BddBelow {b : ℝ | ValidUpperConstant b} :=
+  ⟨1/2, fun b hb => ValidUpperConstant_ge_half hb⟩
+
+/-- The valid first-order upper constants form a nonempty set (`1`, Shearer). -/
+theorem nonempty_validUpperConstant : {b : ℝ | ValidUpperConstant b}.Nonempty :=
+  ⟨1, shearer_validUpperConstant_one⟩
+
+/-- The valid first-order lower constants are bounded above (by `1`, the Shearer fence). -/
+theorem bddAbove_validLowerConstant : BddAbove {a : ℝ | ValidLowerConstant a} :=
+  ⟨1, fun a ha => ValidLowerConstant_le_one ha⟩
+
+/-- The valid first-order lower constants form a nonempty set (`1/2`, HHKP). -/
+theorem nonempty_validLowerConstant : {a : ℝ | ValidLowerConstant a}.Nonempty :=
+  ⟨1/2, hhkp_validLowerConstant_half⟩
+
+/-- **The infimum of the valid upper constants is attained.**  `sInf {b | ValidUpperConstant b}`
+    is itself a valid upper constant.  This is the key structural fact upgrading the conditional
+    least-element result of Part XI to an unconditional one: the up-set of valid upper constants
+    is closed at its infimum.  Proof: for any `δ > 0`, `sInf < sInf + δ`, so some valid upper
+    constant `b` satisfies `b < sInf + δ`; feeding `ε' = sInf + δ − b > 0` into `b`'s validity
+    gives `R(3,k) ≤ (sInf + δ)·k²/log k` eventually. -/
+theorem validUpperConstant_sInf_mem :
+    ValidUpperConstant (sInf {b : ℝ | ValidUpperConstant b}) := by
+  intro δ hδ
+  obtain ⟨b, hbmem, hb⟩ :=
+    exists_lt_of_csInf_lt nonempty_validUpperConstant
+      (show sInf {b : ℝ | ValidUpperConstant b} < sInf {b : ℝ | ValidUpperConstant b} + δ by
+        linarith)
+  have hb' : ValidUpperConstant b := hbmem
+  have hε' : sInf {b : ℝ | ValidUpperConstant b} + δ - b > 0 := by linarith
+  obtain ⟨k₀, hk₀⟩ := hb' _ hε'
+  refine ⟨k₀, fun k hk => ?_⟩
+  have hval := hk₀ k hk
+  have heq : b + (sInf {b : ℝ | ValidUpperConstant b} + δ - b)
+      = sInf {b : ℝ | ValidUpperConstant b} + δ := by ring
+  rwa [heq] at hval
+
+/-- **The supremum of the valid lower constants is attained** (dual of
+    `validUpperConstant_sInf_mem`).  `sSup {a | ValidLowerConstant a}` is itself a valid lower
+    constant: the down-set of valid lower constants is closed at its supremum. -/
+theorem validLowerConstant_sSup_mem :
+    ValidLowerConstant (sSup {a : ℝ | ValidLowerConstant a}) := by
+  intro δ hδ
+  obtain ⟨a, hamem, ha⟩ :=
+    exists_lt_of_lt_csSup nonempty_validLowerConstant
+      (show sSup {a : ℝ | ValidLowerConstant a} - δ < sSup {a : ℝ | ValidLowerConstant a} by
+        linarith)
+  have ha' : ValidLowerConstant a := hamem
+  have hε' : a - (sSup {a : ℝ | ValidLowerConstant a} - δ) > 0 := by linarith
+  obtain ⟨k₀, hk₀⟩ := ha' _ hε'
+  refine ⟨k₀, fun k hk => ?_⟩
+  have hval := hk₀ k hk
+  have heq : a - (a - (sSup {a : ℝ | ValidLowerConstant a} - δ))
+      = sSup {a : ℝ | ValidLowerConstant a} - δ := by ring
+  rwa [heq] at hval
+
+/-- **Unconditionally, `R(3,k)` has a least valid first-order upper constant.**  The infimum
+    `sInf {b | ValidUpperConstant b}` is a member (`validUpperConstant_sInf_mem`) and a lower
+    bound (`csInf_le`), so it is the least element — no conjecture required.  This is the
+    unconditional strengthening of `mainConjecture_imp_isLeast_validUpperConstant`, which only
+    identified that least element *as* `1/2` under the Erdős conjecture. -/
+theorem isLeast_validUpperConstant :
+    IsLeast {b : ℝ | ValidUpperConstant b} (sInf {b : ℝ | ValidUpperConstant b}) :=
+  ⟨validUpperConstant_sInf_mem, fun b hb => csInf_le bddBelow_validUpperConstant hb⟩
+
+/-- **Unconditionally, `R(3,k)` has a greatest valid first-order lower constant** (dual). -/
+theorem isGreatest_validLowerConstant :
+    IsGreatest {a : ℝ | ValidLowerConstant a} (sSup {a : ℝ | ValidLowerConstant a}) :=
+  ⟨validLowerConstant_sSup_mem, fun a ha => le_csSup bddAbove_validLowerConstant ha⟩
+
+/-- **The true asymptotic upper constant of `R(3,k)`.**  `c⁺ := sInf {b | ValidUpperConstant b}`,
+    the least real `b` for which `R(3,k) ≤ (b + ε)·k²/log k` holds eventually for every `ε > 0`.
+    By `isLeast_validUpperConstant` this infimum is attained; by `asymptoticUpperConstant_mem_Icc`
+    it lies in `[1/2, 1]`; and Erdős #165's conjecture is exactly `c⁺ = 1/2`. -/
+noncomputable def asymptoticUpperConstant : ℝ := sInf {b : ℝ | ValidUpperConstant b}
+
+/-- **The true asymptotic lower constant of `R(3,k)`.**  `c⁻ := sSup {a | ValidLowerConstant a}`,
+    the greatest real `a` for which `R(3,k) ≥ (a − ε)·k²/log k` holds eventually for every
+    `ε > 0`.  Attained (`isGreatest_validLowerConstant`) and in `[1/2, 1]`. -/
+noncomputable def asymptoticLowerConstant : ℝ := sSup {a : ℝ | ValidLowerConstant a}
+
+/-- **`c⁺ ∈ [1/2, 1]` unconditionally.**  The Shearer fence bounds it above (`1` is a valid upper
+    constant, so the infimum is `≤ 1`) and the HHKP fence below (every valid upper constant is
+    `≥ 1/2`, so their infimum is `≥ 1/2`).  This brackets the exact asymptotic upper constant
+    with no conjecture assumed. -/
+theorem asymptoticUpperConstant_mem_Icc :
+    (1:ℝ)/2 ≤ asymptoticUpperConstant ∧ asymptoticUpperConstant ≤ 1 :=
+  ⟨le_csInf nonempty_validUpperConstant (fun b hb => ValidUpperConstant_ge_half hb),
+   csInf_le bddBelow_validUpperConstant shearer_validUpperConstant_one⟩
+
+/-- **`c⁻ ∈ [1/2, 1]` unconditionally** (dual of `asymptoticUpperConstant_mem_Icc`). -/
+theorem asymptoticLowerConstant_mem_Icc :
+    (1:ℝ)/2 ≤ asymptoticLowerConstant ∧ asymptoticLowerConstant ≤ 1 :=
+  ⟨le_csSup bddAbove_validLowerConstant hhkp_validLowerConstant_half,
+   csSup_le nonempty_validLowerConstant (fun a ha => ValidLowerConstant_le_one ha)⟩
+
+/-- **`c⁻ ≤ c⁺`.**  The greatest valid lower constant does not exceed the least valid upper
+    constant — a direct application of `validLowerConstant_le_validUpperConstant` to the two
+    attained extremal members.  Together with the two brackets this says both exact asymptotic
+    constants live in `[1/2, 1]` with `c⁻ ≤ c⁺`; the Erdős answer `R(3,k) ~ c·k²/log k` would be
+    the collapse `c⁻ = c⁺`. -/
+theorem asymptoticLowerConstant_le_asymptoticUpperConstant :
+    asymptoticLowerConstant ≤ asymptoticUpperConstant :=
+  validLowerConstant_le_validUpperConstant validLowerConstant_sSup_mem validUpperConstant_sInf_mem
+
+/-- **The Erdős conjecture ⟺ `c⁺ = 1/2`.**  The crisp scalar form of Erdős #165: the exact
+    asymptotic upper constant equals `1/2` *iff* the main conjecture holds.  Forward: the
+    conjecture makes `1/2` a valid upper constant, so `c⁺ ≤ 1/2`, and the fence gives `c⁺ ≥ 1/2`.
+    Backward: `c⁺` is attained (`validUpperConstant_sInf_mem`), so `c⁺ = 1/2` makes `1/2` itself a
+    valid upper constant — which is the conjecture (`mainConjecture_iff_validUpperConstant_half`).
+    This is the *unconditional* upgrade of `mainConjecture_imp_isLeast_validUpperConstant`. -/
+theorem mainConjecture_iff_asymptoticUpperConstant_eq_half :
+    mainConjecture ↔ asymptoticUpperConstant = 1/2 := by
+  rw [mainConjecture_iff_validUpperConstant_half]
+  constructor
+  · intro h
+    have h1 : asymptoticUpperConstant ≤ 1/2 := csInf_le bddBelow_validUpperConstant h
+    have h2 : (1:ℝ)/2 ≤ asymptoticUpperConstant := asymptoticUpperConstant_mem_Icc.1
+    linarith
+  · intro h
+    have hmem := validUpperConstant_sInf_mem
+    rw [← h]
+    exact hmem
+
 end Erdos165

--- a/proofs/Proofs/SylowTheoremOQ04OQ03.lean
+++ b/proofs/Proofs/SylowTheoremOQ04OQ03.lean
@@ -1444,8 +1444,125 @@ theorem sylowP_inf_eq_bot {P Q : Sylow p (Matrix.SpecialLinearGroup (Fin 2) (ZMo
       Subgroup.eq_of_le_of_card_ge inf_le_right (le_of_eq (by rw [card_sylowP, hpc]))
     exact hPQ (Sylow.ext (hPeq.symm.trans hQeq))
 
+/-- **A non-identity element lies in a unique Sylow `p`-subgroup.**  If `g ≠ 1` lies in two
+Sylow `p`-subgroups `P` and `Q`, then `g ∈ P ⊓ Q`, which is `⊥` unless `P = Q`
+(`sylowP_inf_eq_bot`); as `g ≠ 1` this forces `P = Q`.  This is the injectivity fact behind the
+classical order-`p` element count: the `p + 1` Sylow `p`-subgroups partition the non-identity
+`p`-elements. -/
+theorem sylowP_eq_of_mem
+    {P Q : Sylow p (Matrix.SpecialLinearGroup (Fin 2) (ZMod p))}
+    {g : Matrix.SpecialLinearGroup (Fin 2) (ZMod p)} (hg : g ≠ 1)
+    (hP : g ∈ (P : Subgroup (Matrix.SpecialLinearGroup (Fin 2) (ZMod p))))
+    (hQ : g ∈ (Q : Subgroup (Matrix.SpecialLinearGroup (Fin 2) (ZMod p)))) :
+    P = Q := by
+  by_contra h
+  have hmem : g ∈ (P : Subgroup (Matrix.SpecialLinearGroup (Fin 2) (ZMod p)))
+      ⊓ (Q : Subgroup (Matrix.SpecialLinearGroup (Fin 2) (ZMod p))) :=
+    Subgroup.mem_inf.mpr ⟨hP, hQ⟩
+  rw [sylowP_inf_eq_bot h] at hmem
+  exact hg (Subgroup.mem_bot.mp hmem)
+
+/-! ### The classical order-`p` element count: `SL(2, p)` has exactly `p² − 1` elements of order `p`
+
+The `p + 1` Sylow `p`-subgroups (`card_sylow_eq`) each have order `p` (`card_sylowP`), meet only in
+the identity (`sylowP_inf_eq_bot`), and jointly exhaust the elements of order `p` (a non-identity
+element generates a cyclic group of order `p`, a `p`-subgroup, hence sits inside some Sylow, and by
+`sylowP_eq_of_mem` inside a *unique* one).  So the elements of order `p` are partitioned into
+`p + 1` blocks of `p − 1` non-identity elements each, giving `(p + 1)(p − 1) = p² − 1`.  This is the
+classical count underlying the original Sylow-counting approach to the simplicity of `PSL(2, p)`. -/
+
+/-- **`SL(2, p)` has exactly `p² − 1` elements of order `p`** (for `p ≥ 5`).  The elements of order
+`p` are exactly the non-identity elements of the Sylow `p`-subgroups, and the `p + 1` Sylow
+`p`-subgroups (`card_sylow_eq`), each of order `p` (`card_sylowP`), partition them (distinct Sylows
+meet only in `1`, `sylowP_eq_of_mem`).  Counting: `(p + 1) · (p − 1) = p² − 1`. -/
+theorem card_orderOf_eq_p (hp : 5 ≤ p) :
+    (Finset.univ.filter
+        (fun g : Matrix.SpecialLinearGroup (Fin 2) (ZMod p) => orderOf g = p)).card
+      = p ^ 2 - 1 := by
+  classical
+  have hp' : Nat.Prime p := Fact.out
+  -- the elementary arithmetic `(p + 1)(p − 1) = p² − 1`
+  have harith : (p + 1) * (p - 1) = p ^ 2 - 1 := by
+    obtain ⟨n, rfl⟩ : ∃ n, p = n + 1 := ⟨p - 1, by omega⟩
+    simp only [Nat.add_sub_cancel]
+    have e : (n + 1 + 1) * n + 1 = (n + 1) ^ 2 := by ring
+    omega
+  -- for each Sylow `P`, the non-identity elements of `P`
+  set f : Sylow p (Matrix.SpecialLinearGroup (Fin 2) (ZMod p))
+      → Finset (Matrix.SpecialLinearGroup (Fin 2) (ZMod p)) :=
+    fun P => (Finset.univ.filter
+        (fun g => g ∈ (P : Subgroup (Matrix.SpecialLinearGroup (Fin 2) (ZMod p))))).erase 1
+    with hf
+  -- (a) each block has `p − 1` elements
+  have hmemcard : ∀ P : Sylow p (Matrix.SpecialLinearGroup (Fin 2) (ZMod p)),
+      (Finset.univ.filter
+        (fun g : Matrix.SpecialLinearGroup (Fin 2) (ZMod p) =>
+          g ∈ (P : Subgroup (Matrix.SpecialLinearGroup (Fin 2) (ZMod p))))).card = p := by
+    intro P
+    have hsub : (Finset.univ.filter
+        (fun g : Matrix.SpecialLinearGroup (Fin 2) (ZMod p) =>
+          g ∈ (P : Subgroup (Matrix.SpecialLinearGroup (Fin 2) (ZMod p))))).card
+        = Fintype.card {x : Matrix.SpecialLinearGroup (Fin 2) (ZMod p)
+            // x ∈ (P : Subgroup (Matrix.SpecialLinearGroup (Fin 2) (ZMod p)))} :=
+      (Fintype.card_subtype _).symm
+    rw [hsub, ← Nat.card_eq_fintype_card]
+    exact card_sylowP P
+  have hcardf : ∀ P : Sylow p (Matrix.SpecialLinearGroup (Fin 2) (ZMod p)),
+      (f P).card = p - 1 := by
+    intro P
+    have h1 : (1 : Matrix.SpecialLinearGroup (Fin 2) (ZMod p))
+        ∈ Finset.univ.filter
+          (fun g => g ∈ (P : Subgroup (Matrix.SpecialLinearGroup (Fin 2) (ZMod p)))) := by
+      simp [Subgroup.one_mem]
+    simp only [hf]
+    rw [Finset.card_erase_of_mem h1, hmemcard P]
+  -- (b) distinct Sylows give disjoint blocks
+  have hdisj : (↑(Finset.univ : Finset (Sylow p
+      (Matrix.SpecialLinearGroup (Fin 2) (ZMod p)))) :
+      Set (Sylow p (Matrix.SpecialLinearGroup (Fin 2) (ZMod p)))).PairwiseDisjoint f := by
+    intro P _ Q _ hPQ
+    simp only [Function.onFun]
+    rw [Finset.disjoint_left]
+    intro g hgP hgQ
+    simp only [hf, Finset.mem_erase, Finset.mem_filter] at hgP hgQ
+    exact hPQ (sylowP_eq_of_mem hgP.1 hgP.2.2 hgQ.2.2)
+  -- (c) the order-`p` elements are exactly the union of the blocks
+  have hset : Finset.univ.filter
+      (fun g : Matrix.SpecialLinearGroup (Fin 2) (ZMod p) => orderOf g = p)
+      = Finset.univ.biUnion f := by
+    ext g
+    simp only [hf, Finset.mem_filter, Finset.mem_univ, true_and, Finset.mem_biUnion,
+      Finset.mem_erase]
+    constructor
+    · intro hord
+      have hg1 : g ≠ 1 := by
+        intro h; rw [h, orderOf_one] at hord; omega
+      have hpg : IsPGroup p (Subgroup.zpowers g) := by
+        apply IsPGroup.of_card (n := 1)
+        rw [Nat.card_zpowers, hord, pow_one]
+      obtain ⟨P, hP⟩ := hpg.exists_le_sylow
+      exact ⟨P, hg1, hP (Subgroup.mem_zpowers g)⟩
+    · rintro ⟨P, hg1, hgP⟩
+      have hdvd : orderOf g ∣ p := by
+        have h := orderOf_dvd_natCard
+          (⟨g, hgP⟩ : (P : Subgroup (Matrix.SpecialLinearGroup (Fin 2) (ZMod p))))
+        rw [← Subgroup.orderOf_coe, card_sylowP] at h
+        exact h
+      rcases (Nat.dvd_prime hp').mp hdvd with h1 | hpp
+      · exact absurd (orderOf_eq_one_iff.mp h1) hg1
+      · exact hpp
+  -- assemble the count
+  have hfc : Fintype.card (Sylow p (Matrix.SpecialLinearGroup (Fin 2) (ZMod p))) = p + 1 := by
+    rw [← Nat.card_eq_fintype_card]; exact card_sylow_eq hp
+  have hsum : ∑ P : Sylow p (Matrix.SpecialLinearGroup (Fin 2) (ZMod p)), (f P).card
+      = ∑ _P : Sylow p (Matrix.SpecialLinearGroup (Fin 2) (ZMod p)), (p - 1) :=
+    Finset.sum_congr rfl (fun P _ => hcardf P)
+  rw [hset, Finset.card_biUnion hdisj, hsum, Finset.sum_const, Finset.card_univ,
+    smul_eq_mul, hfc, harith]
+
 end SylowOQ04OQ03
 
 #print axioms SylowOQ04OQ03.sylow_count_arith
 #print axioms SylowOQ04OQ03.index_unipotentSylow
 #print axioms SylowOQ04OQ03.card_sylow_eq
+#print axioms SylowOQ04OQ03.card_orderOf_eq_p

--- a/research/problems/alternating-series-boole-summation-oq-01-oq-01/knowledge.md
+++ b/research/problems/alternating-series-boole-summation-oq-01-oq-01/knowledge.md
@@ -19,3 +19,27 @@ Insights accumulated during research on this problem.
 ## Dead Ends
 
 [Approaches known not to work will be documented here]
+
+---
+
+## Session 2026-07-12 (researcher-10) — explicit closed form for T_K
+
+The order-K limit `boole_general_tendsto` and existence of every intermediate limit
+`iterate_altSum_tendsto` are already on `main` (axiom-free). `iterate_altSum_tendsto` only
+gives a **recursive** witness `T_{k+1} = (-1)^n(Δ^k a)_n − 2 T_k` (`T_0 = S`).
+
+Resolved nextStep #2: unrolled that recursion into a **non-recursive closed form**
+
+  `T_K = ∑_{k=0}^{K-1} (-2)^{K-1-k} · (-1)^n (Δᵏa)_n + (-2)^K · S`
+
+in `Proofs/AlternatingSeriesBooleSummationOQ01OQ01ClosedForm.lean` (`iterate_altSum_limit_closed`,
+axiom-free, docker-built). Corollaries: unconditional antitone version, K=1 sanity
+(`T_1 = (-1)^n a_n − 2S`), and a self-consistency identity `boole_general_tendsto_closed`
+(substituting the closed form back into `boole_general_tendsto` collapses to `S`).
+
+Consistency check that pins the sign/weight normalisation:
+`((-1)^K/2^K)·(-2)^{K-1-k} = -(-1)^k/2^{k+1}` and `((-1)^K/2^K)·(-2)^K = 1`.
+
+Remaining open: identify T_K with Mathlib two-sided alternating-series tail bounds for an
+effective error term; and the gallery entry `src/data/proofs/alternating-series-boole-summation-oq-01-oq-01/`
+is missing (proof on main but no gallery presentation).

--- a/src/data/proofs/erdos-165/meta.json
+++ b/src/data/proofs/erdos-165/meta.json
@@ -167,10 +167,10 @@
       "Real"
     ],
     "namespace": "Erdos165",
-    "lineCount": 655,
+    "lineCount": 895,
     "axiomCount": 10,
-    "theoremCount": 26,
-    "definitionCount": 4,
+    "theoremCount": 48,
+    "definitionCount": 8,
     "path": "Proofs/Erdos165Problem.lean",
     "sorries": 0,
     "additionalFiles": [

--- a/src/data/proofs/sylow-theorem-oq-04-oq-03/meta.json
+++ b/src/data/proofs/sylow-theorem-oq-04-oq-03/meta.json
@@ -269,12 +269,12 @@
     }
   ],
   "leanFile": {
-    "lineCount": 1451,
+    "lineCount": 1568,
     "path": "Proofs/SylowTheoremOQ04OQ03.lean",
     "axiomCount": 0,
     "sorries": 0,
     "definitionCount": 9,
-    "theoremCount": 62
+    "theoremCount": 64
   },
   "sorries": 0
 }

--- a/src/data/research/problems/alternating-series-boole-summation-oq-01-oq-01.json
+++ b/src/data/research/problems/alternating-series-boole-summation-oq-01-oq-01.json
@@ -37,24 +37,30 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: proved the order-K Boole summation limit (boole_general_tendsto) + intermediate-series convergence + unconditional antitone version; all axiom-free. Awaiting machine-verification.",
+    "progressSummary": "PROGRESS: order-K Boole limit fully machine-verified on main (boole_general_tendsto, axiom-free). Added the explicit non-recursive closed form for the higher-difference series limit T_K (iterate_altSum_limit_closed), resolving nextStep #2, plus antitone/K=1/self-consistency corollaries — all axiom-free, docker-built. Remaining open: effective tail-bound identification; missing gallery entry.",
     "builtItems": [
       "iterate_fdiff_tendsto_zero: a→0 ⟹ ∀k, Δ^k a → 0 (Proofs/AlternatingSeriesBooleSummationOQ01OQ01.lean)",
       "boole_general_tendsto: the headline order-K Boole summation limit identity (axiom-free)",
       "iterate_altSum_tendsto: existence of every higher-difference series limit T_k given base convergence",
       "boole_general_tendsto_of_antitone: unconditional order-K identity for antitone null sequences",
-      "fdiff_altSum_tendsto / sign_mul_tendsto_zero / altSum_tendsto_of_antitone restated for base-file defs so they compose with boole_general"
+      "fdiff_altSum_tendsto / sign_mul_tendsto_zero / altSum_tendsto_of_antitone restated for base-file defs so they compose with boole_general",
+      "iterate_altSum_limit_closed: EXPLICIT non-recursive closed form T_K = Σ_{k<K}(-2)^{K-1-k}(-1)^n(Δ^k a)_n + (-2)^K S (Proofs/AlternatingSeriesBooleSummationOQ01OQ01ClosedForm.lean, axiom-free)",
+      "iterate_altSum_limit_closed_of_antitone: same closed form unconditionally for antitone null sequences",
+      "boole_general_tendsto_closed: self-consistency — substituting the closed form of T_K into boole_general_tendsto collapses back to S",
+      "iterate_altSum_limit_one: K=1 sanity, T_1=(-1)^n a_n-2S matches fdiff_altSum_tendsto"
     ],
     "insights": [
       "Order-K Boole limit: passing boole_general to m→∞ for a null sequence yields S = Σ_{k<K} ((-1)^k/2^{k+1})(-1)^n(Δ^k a)_n + ((-1)^K/2^K) T_K; the sign flips to the OQ closed form since (-1)^K/2^K = -(-1)^{K-1}/2^K.",
       "The single analytic engine is that EVERY iterated forward difference Δ^k a of a null sequence is again null (proved by induction: Δ^{k+1}a_j = (Δ^k a)_{j+1} - (Δ^k a)_j, a difference of two shifted null copies). This makes every endpoint term (-1)^m(Δ^k a)_m vanish termwise across the finite order-K boundary sum.",
       "Intermediate convergence is automatic, not an extra hypothesis: if a→0 and altSum a n · → S, then altSum(Δ^k a) n · converges for every k (induction via first-order fdiff_altSum_tendsto with recurrence T_{k+1} = (-1)^n(Δ^k a)_n - 2 T_k). So T_K in the main identity always exists.",
-      "K=1 recovers the parent boole_tendsto; K=0 reads S=S. Antitone null sequences need no convergence hypothesis at all (Mathlib alternating-series test supplies it)."
+      "K=1 recovers the parent boole_tendsto; K=0 reads S=S. Antitone null sequences need no convergence hypothesis at all (Mathlib alternating-series test supplies it).",
+      "Explicit closed form (nextStep #2 resolved): unrolling the recurrence T_{k+1}=(-1)^n(Δ^k a)_n-2T_k (T_0=S) gives the non-recursive T_K = Σ_{k=0}^{K-1}(-2)^{K-1-k}(-1)^n(Δ^k a)_n + (-2)^K S. Verified consistent with boole_general_tendsto: ((-1)^K/2^K)(-2)^{K-1-k}=-(-1)^k/2^{k+1} and ((-1)^K/2^K)(-2)^K=1, so the two closed forms fit to give exactly S.",
+      "Induction bookkeeping key: the geometric weight identity (-2)^{K-k}=-2·(-2)^{K-1-k} for k<K (via K-k=(K-1-k)+1, pow_succ) lets the successor step -2·(order-K sum) reindex into the order-(K+1) sum; the top term k=K carries weight (-2)^0=1."
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "Identify the remainder T_K with Mathlib two-sided alternating-series tail bounds to get an unconditional effective error term at general order.",
-      "Derive an explicit closed form for T_K by unrolling the recurrence T_{k+1} = (-1)^n(Δ^k a)_n - 2 T_k, expressing T_K purely via S and boundary data (Δ^k a)_n."
+      "Identify the remainder T_K with Mathlib two-sided alternating-series tail bounds to get an unconditional effective error term at general order (the remaining open item).",
+      "Create the missing gallery entry src/data/proofs/alternating-series-boole-summation-oq-01-oq-01/ (proof is on main but has no gallery presentation)."
     ]
   },
   "tags": [

--- a/src/data/research/problems/erdos-165-oq-05.json
+++ b/src/data/research/problems/erdos-165-oq-05.json
@@ -29,21 +29,23 @@
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETED: Proved pgm_conjecture_refuted : not pgmConjecture, backed by the axiom-free incompatibility lemma asymptotic_constant_le and the general obstruction R3_upper_constant_ge_half. Added 0 new axioms. Also repaired a pre-existing Mathlib-drift build failure in erdos_165 (line 161): linarith could not widen 5/4 to 2 without k^2/log k >= 0; fixed by threading log-positivity via max k0 2 and mul_div_assoc. Follow-up (researcher-1, 2026-07-08): added the symmetric obstruction R3_lower_constant_le_one (Shearer's c≤1 ⟹ any valid lower constant ≤1) and the general constantConjecture def + constantConjecture_refuted_of_one_lt (any exact constant >1 refuted). With pgm_conjecture_refuted this brackets the true constant to [1/2,1]. 0 new axioms; still 10 deep-Ramsey axioms, none Mathlib-eliminable.",
+    "progressSummary": "COMPLETED: Proved pgm_conjecture_refuted : not pgmConjecture, backed by the axiom-free incompatibility lemma asymptotic_constant_le and the general obstruction R3_upper_constant_ge_half. Added 0 new axioms. Also repaired a pre-existing Mathlib-drift build failure in erdos_165 (line 161): linarith could not widen 5/4 to 2 without k^2/log k >= 0; fixed by threading log-positivity via max k0 2 and mul_div_assoc. Follow-up (researcher-1, 2026-07-08): added the symmetric obstruction R3_lower_constant_le_one (Shearer's c≤1 ⟹ any valid lower constant ≤1) and the general constantConjecture def + constantConjecture_refuted_of_one_lt (any exact constant >1 refuted). With pgm_conjecture_refuted this brackets the true constant to [1/2,1]. 0 new axioms; still 10 deep-Ramsey axioms, none Mathlib-eliminable. Follow-up (researcher-10, 2026-07-12): added Part XII — the exact asymptotic constants exist UNCONDITIONALLY. Proved the infimum of valid upper constants (and sup of valid lower constants) is ATTAINED (up-set closed at its infimum, via exists_lt_of_csInf_lt), giving unconditional least/greatest elements and real-number invariants c⁺=sInf, c⁻=sSup, both bracketed to [1/2,1] with c⁻≤c⁺. Upgraded the conditional Part XI IsLeast(1/2) to the unconditional IsLeast(sInf) plus the crisp iff mainConjecture ↔ c⁺=1/2. 12 theorems + 2 defs, 0 new axioms (still 2 genuine Ramsey axioms hhkp_bound, shearer_upper_bound used).",
     "builtItems": [
       "asymptotic_constant_le in Erdos165Problem.lean (axiom-free incompatibility lemma)",
       "R3_upper_constant_ge_half in Erdos165Problem.lean (HHKP obstruction)",
       "pgm_conjecture_refuted in Erdos165Problem.lean (not pgmConjecture)",
       "Repaired erdos_165 proof (Mathlib-drift fix)",
       "R3_lower_constant_le_one (researcher-1): Shearer's upper bound (c≤1) as an obstruction — any valid first-order LOWER constant for R(3,k) is ≤ 1. Mirror of R3_upper_constant_ge_half; reuses axiom-free asymptotic_constant_le.",
-      "constantConjecture c (general def) + constantConjecture_refuted_of_one_lt: any conjectured exact constant c>1 is refuted from above by Shearer. With pgm_conjecture_refuted (c<1/2 refuted from below) this pins the true constant to [1/2,1]. 0 new axioms."
+      "constantConjecture c (general def) + constantConjecture_refuted_of_one_lt: any conjectured exact constant c>1 is refuted from above by Shearer. With pgm_conjecture_refuted (c<1/2 refuted from below) this pins the true constant to [1/2,1]. 0 new axioms.",
+      "Part XII (researcher-10): UNCONDITIONAL existence of the exact asymptotic constants. validUpperConstant_sInf_mem / validLowerConstant_sSup_mem (the inf/sup of valid upper/lower constants is ATTAINED, via exists_lt_of_csInf_lt / exists_lt_of_lt_csSup — the up-set is closed at its infimum); isLeast_validUpperConstant / isGreatest_validLowerConstant (unconditional least/greatest, upgrading the Part XI conditional mainConjecture_imp_isLeast); defs asymptoticUpperConstant c⁺ := sInf, asymptoticLowerConstant c⁻ := sSup; _mem_Icc brackets both to [1/2,1] unconditionally; asymptoticLowerConstant_le_asymptoticUpperConstant (c⁻ ≤ c⁺); mainConjecture_iff_asymptoticUpperConstant_eq_half (crisp scalar iff: Erdős #165 ⟺ c⁺ = 1/2). 12 theorems, 2 defs, 0 new axioms."
     ],
     "insights": [
       "The erdos-165 file on origin/main did NOT compile (linarith failure in erdos_165) despite meta claiming 0 sorries / axiomatized -- latent Mathlib drift.",
       "linarith treats c*k^2/log k as opaque unless mul_div_assoc factors out k^2/log k as a single atom; supplying 0 <= k^2/log k then lets it scale constants.",
       "The mathematical core of conjectured-constant-refuted-by-a-better-bound is a pure real-analysis fact (asymptotic_constant_le), fully axiom-free; only hhkp_bound is Ramsey input.",
       "oq-05 (complete sorry in R3_asymptotic_order) was stale: no such sorry exists in the current file.",
-      "asymptotic_constant_le is two-sided infrastructure: instantiated with (lower=HHKP, b=variable) it gives upper-constant≥1/2; with (lower=variable, upper=Shearer, b=1) it gives lower-constant≤1. The two obstructions bracket the exact constant to [1/2,1] using only the two Ramsey axioms hhkp_bound and shearer_upper_bound."
+      "asymptotic_constant_le is two-sided infrastructure: instantiated with (lower=HHKP, b=variable) it gives upper-constant≥1/2; with (lower=variable, upper=Shearer, b=1) it gives lower-constant≤1. The two obstructions bracket the exact constant to [1/2,1] using only the two Ramsey axioms hhkp_bound and shearer_upper_bound.",
+      "The set of valid first-order upper constants is a nonempty (1∈, Shearer) bounded-below (≥1/2, HHKP) up-set of reals, so sInf exists AND is attained: closed at its infimum. This upgrades the Part XI conditional IsLeast(1/2) result to an unconditional IsLeast(sInf) and constructs the actual real-number invariant c⁺ = the true asymptotic upper constant. The Erdős conjecture then becomes the single scalar equation c⁺=1/2 (a genuine iff, since the inf is attained — the backward direction needs attainment). Dually c⁻=sSup is the greatest valid lower constant; both in [1/2,1], c⁻≤c⁺, and R(3,k)~c·k²/logk would be the collapse c⁻=c⁺."
     ],
     "mathlibGaps": [],
     "nextSteps": [],
@@ -65,15 +67,15 @@
     "mathlib": []
   },
   "started": "2026-04-04T09:42:47.007Z",
-  "lastUpdate": "2026-06-25T00:00:00.000Z",
+  "lastUpdate": "2026-07-12T00:00:00.000Z",
   "leanFiles": [
     {
       "path": "Proofs/Erdos165Problem.lean",
       "filename": "Erdos165Problem.lean",
-      "lineCount": 397,
-      "theoremCount": 10,
+      "lineCount": 895,
+      "theoremCount": 48,
       "axiomCount": 10,
-      "defCount": 4,
+      "defCount": 8,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos165Problem.lean"

--- a/src/data/research/problems/sylow-theorem-oq-04-oq-03.json
+++ b/src/data/research/problems/sylow-theorem-oq-04-oq-03.json
@@ -6,7 +6,7 @@
   "path": "full",
   "tier": "MODERATE",
   "started": "2026-04-05T03:59:25.465Z",
-  "lastUpdate": "2026-07-11T00:00:00.000Z",
+  "lastUpdate": "2026-07-12T00:00:00.000Z",
   "significance": 7,
   "tractability": 2,
   "tags": [
@@ -56,7 +56,7 @@
     ]
   },
   "knowledge": {
-    "progressSummary": "BUILD (researcher-10, 2026-07-11) [VERIFIED host-lean 0-sorry/0-axiom, propext/Classical/Quot only]: sharpened the Sylow count from lower bound n_p>=p+1 (card_sylow_ge, researcher-6) to EXACT n_p=p+1 (card_sylow_eq). Route is purely arithmetic, avoiding the normalizer=Borel matrix computation: index_unipotentSylow gives [SL(2,p):U]=p^2-1 (Subgroup.card_mul_index), Sylow.card_dvd_index gives n_p | p^2-1, card_sylow_modEq_one gives n_p=1 mod p, and sylow_count_arith closes n_p=p+1 (a second divisor m of p^2-1 forces p | m+1 hence m>=p-1, incompatible with n_p>=2p+1). Matches classical n_p=|P1(F_p)|=p+1. File 1279->1360 L, 53->56 thm. Remaining toward PSL(2,p) simple: SL(2,p)-action on P1, 2-transitivity, Borel stabilizer, then assemble IwasawaStructure.",
+    "progressSummary": "BUILD (researcher-10, 2026-07-11) [VERIFIED host-lean 0-sorry/0-axiom, propext/Classical/Quot only]: sharpened the Sylow count from lower bound n_p>=p+1 (card_sylow_ge, researcher-6) to EXACT n_p=p+1 (card_sylow_eq). Route is purely arithmetic, avoiding the normalizer=Borel matrix computation: index_unipotentSylow gives [SL(2,p):U]=p^2-1 (Subgroup.card_mul_index), Sylow.card_dvd_index gives n_p | p^2-1, card_sylow_modEq_one gives n_p=1 mod p, and sylow_count_arith closes n_p=p+1 (a second divisor m of p^2-1 forces p | m+1 hence m>=p-1, incompatible with n_p>=2p+1). Matches classical n_p=|P1(F_p)|=p+1. File 1279->1360 L, 53->56 thm. Remaining toward PSL(2,p) simple: SL(2,p)-action on P1, 2-transitivity, Borel stabilizer, then assemble IwasawaStructure. | Follow-up (researcher-10, 2026-07-12) [VERIFIED 0-axiom/0-sorry]: added the classical order-p element count. sylowP_eq_of_mem (a nontrivial element is in a UNIQUE Sylow) + card_orderOf_eq_p (SL(2,p) has exactly p²−1 elements of order p): the p+1 Sylows partition the order-p elements into (p−1)-blocks, (p+1)(p−1)=p²−1, via Finset.card_biUnion with PairwiseDisjoint. Realises the count advertised in the file docstrings. 2 theorems, 0 new axioms; file 1451→1568 L, 62→64 thm.",
     "insights": [
       "The 'Sylow counting argument' framing of the problem is directly realisable as a LOWER BOUND without the full Iwasawa/P^1 machinery: (1) U=range unipotentHom is a Sylow p-subgroup (unipotentSylow); (2) U is NOT normal because its normal closure is all of SL(2,p) (unipotent_normalClosure_eq_top) while |U|=p<|SL|; (3) a unique Sylow would be normal (Sylow.normal_of_subsingleton), so n_p != 1; (4) Sylow III forces n_p ≡ 1 (mod p), and n_p != 1 then gives n_p >= p+1 — the classical p+1 Borels / points of P^1(F_p). The non-normality of U (not raw counting) is the crux; Sylow III supplies the arithmetic jump from >1 to >=p+1.",
       "Perfectness lifts cleanly from the cover to the quotient: for any surjective φ:G↠H, map φ (commutator G) = commutator H (Subgroup.map_commutator + map_top_of_surjective), so a perfect group has perfect quotients. Applied to mk':SL(2,p)↠PSL(2,p)=SL/Z this turns commutator (SL)=⊤ into commutator (PSL)=⊤ — the Iwasawa perfectness hypothesis for the actual simple-group candidate PSL(2,p), not just its cover.",
@@ -68,7 +68,8 @@
       "The range p≥5 in the simplicity theorem is exactly the range where the perfectness engine fires: a=2 gives a²−1=3, a unit iff p∉{2,3}. This pins the failure at p=2,3 to the non-invertibility of 3 (=2²−1) mod p, matching PSL(2,2)≅S₃ and PSL(2,3)≅A₄ being non-simple.",
       "The generation ⟨U,U⁻⟩ = SL(2,p) is the concrete Bruhat/Gauss decomposition and needs no P¹ action: (i) w = u(-1)·l(1)·u(-1) and diag(a) = u(a)·l(-a⁻¹)·u(a)·w are explicit words in the root groups, so w and the entire torus T lie in ⟨U,U⁻⟩; (ii) any g with lower-left c≠0 factors as u(ac⁻¹)·w·diag(c)·u(dc⁻¹) (the top-right entry closes via ad-bc=1); (iii) g with c=0 has g₀₀≠0, and l(1)·g has lower-left g₀₀≠0, so l(-1)·(l(1)·g) pulls it into the Bruhat cell. This is the missing 'PSL-conjugates of U generate' clause of Iwasawa, obtained entirely inside SL(2,ZMod p).",
       "n_p=p+1 EXACTLY is reachable by pure arithmetic, bypassing the normalizer=Borel matrix computation the prior nextStep assumed necessary: Sylow.card_dvd_index gives n_p | [SL:U]=p^2-1, and among divisors of (p-1)(p+1) that are =1 mod p and >=p+1, only p+1 survives (a second factor m of p^2-1 must satisfy p | m+1, forcing m>=p-1, too large unless n_p=p+1). Much cheaper than computing N_SL(U)=upper-triangular Borel of order p(p-1).",
-      "Nontriviality/order-floor of the target group: |PSL(2,p)|=p(p²-1)/2 ≥ 60 for p≥5 (equality at p=5, PSL(2,5)≅A₅). Nontrivial (PSL2) is a definitional prerequisite of the simplicity theorem, now established. Derived purely arithmetically from card_PSL2."
+      "Nontriviality/order-floor of the target group: |PSL(2,p)|=p(p²-1)/2 ≥ 60 for p≥5 (equality at p=5, PSL(2,5)≅A₅). Nontrivial (PSL2) is a definitional prerequisite of the simplicity theorem, now established. Derived purely arithmetically from card_PSL2.",
+      "Order-p element count via disjoint Sylow blocks: order-p elements of SL(2,p) = Finset.univ.biUnion (fun P:Sylow => (univ.filter (·∈P)).erase 1); PairwiseDisjoint from sylowP_eq_of_mem (unique Sylow of a nontrivial element); each block has p−1 elements (card_erase_of_mem + Fintype.card_subtype/Nat.card_eq_fintype_card + card_sylowP); Fintype.card(Sylow p G)=p+1 from card_sylow_eq. Arithmetic (p+1)(p−1)=p²−1 via obtain p=n+1, (n+2)*n+1=(n+1)^2 by ring then omega (treats n²/(n+1)² as atoms). This realises the classical count the file's docstrings advertised as the next ingredient."
     ],
     "mathlibGaps": [
       "No cardinality of SL(2,𝔽_p) or PSL(2,p) in Mathlib (need |SL(2,𝔽_p)| = p(p²−1)).",
@@ -96,7 +97,8 @@
       "card_sylow_eq in SylowTheoremOQ04OQ03.lean — EXACT Sylow count n_p=p+1 for SL(2,p), p>=5. Sharpens card_sylow_ge (>=) to equality via Sylow.card_dvd_index (n_p | p^2-1) + card_sylow_modEq_one (n_p=1 mod p) + sylow_count_arith. Matches classical n_p=|P1(F_p)| WITHOUT the normalizer-is-Borel matrix computation. VERIFIED 0/0.",
       "SylowTheoremOQ04OQ03.lean: card_PSL2_ge_sixty — |PSL(2,p)| ≥ 60 for p≥5 (matches PSL(2,5)≅A₅, smallest nonabelian simple group)",
       "SylowTheoremOQ04OQ03.lean: one_lt_card_PSL2 — |PSL(2,p)| > 1 for p≥5",
-      "SylowTheoremOQ04OQ03.lean: nontrivial_PSL2 — Nontrivial (PSL(2,p)) for p≥5 (prerequisite of the simplicity statement)"
+      "SylowTheoremOQ04OQ03.lean: nontrivial_PSL2 — Nontrivial (PSL(2,p)) for p≥5 (prerequisite of the simplicity statement)",
+      "SylowTheoremOQ04OQ03.lean sylowP_eq_of_mem + card_orderOf_eq_p (researcher-10, 2026-07-12, VERIFIED 0-axiom/0-sorry, propext/Classical/Quot only): the classical order-p element count. sylowP_eq_of_mem — a non-identity element lies in a UNIQUE Sylow p-subgroup (from sylowP_inf_eq_bot). card_orderOf_eq_p — SL(2,p) has EXACTLY p²−1 elements of order p for p≥5: the order-p elements = ⋃ (P non-identity) over the p+1 Sylows (card_sylow_eq), a disjoint union of (p−1)-blocks (Finset.card_biUnion + PairwiseDisjoint via sylowP_eq_of_mem), giving (p+1)(p−1)=p²−1. Forward inclusion: g order p ⟹ IsPGroup.of_card on zpowers g ⟹ exists_le_sylow. Reverse: orderOf_dvd_natCard ⟨g,hgP⟩ + Subgroup.orderOf_coe + card_sylowP ⟹ orderOf g ∣ p prime."
     ]
   },
   "leanFiles": [
@@ -246,8 +248,8 @@
     {
       "path": "Proofs/SylowTheoremOQ04OQ03.lean",
       "filename": "SylowTheoremOQ04OQ03.lean",
-      "lineCount": 1279,
-      "theoremCount": 53,
+      "lineCount": 1568,
+      "theoremCount": 64,
       "axiomCount": 0,
       "defCount": 9,
       "sorryCount": 0,


### PR DESCRIPTION
Two independent, self-contained research contributions from researcher-10 (each 0 new axioms, verified clean).

---

## 1. erdos-165-oq-05 — R(3,k)'s exact asymptotic constants exist unconditionally

Part XII of `Erdos165Problem.lean` removes the hypothesis from Part XI's *conditional* headline (`mainConjecture_imp_isLeast_validUpperConstant`: **under** the Erdős conjecture, `1/2` is the least valid upper constant).

The set `{b | ValidUpperConstant b}` is nonempty (`1 ∈`, Shearer), bounded below (`≥ 1/2`, HHKP), so its infimum exists — and is **attained**: `validUpperConstant_sInf_mem` (via `exists_lt_of_csInf_lt`). So `R(3,k)` has a genuine least valid upper constant `c⁺ := sInf ∈ [1/2, 1]`, unconditionally; dually `c⁻ := sSup ∈ [1/2, 1]` with `c⁻ ≤ c⁺`.

Highlights: `isLeast_validUpperConstant`/`isGreatest_validLowerConstant` (unconditional), `asymptoticUpperConstant`/`asymptoticLowerConstant` (defs), `*_mem_Icc`, `asymptoticLowerConstant_le_asymptoticUpperConstant`, and **`mainConjecture_iff_asymptoticUpperConstant_eq_half`** (Erdős #165 ⟺ `c⁺ = 1/2`; the iff's backward direction relies on attainment). 12 theorems, 2 defs.

## 2. sylow-theorem-oq-04-oq-03 — SL(2,p) has exactly p²−1 elements of order p

The classical order-`p` element count that `SylowTheoremOQ04OQ03.lean`'s docstrings advertised as the next Sylow-counting ingredient toward the simplicity of PSL(2,p).

- `sylowP_eq_of_mem`: a non-identity element lies in a **unique** Sylow `p`-subgroup (from `sylowP_inf_eq_bot`).
- `card_orderOf_eq_p`: for `p ≥ 5`, `|{g ∈ SL(2,p) : orderOf g = p}| = p²−1`. The `p+1` Sylows (`card_sylow_eq`), each of order `p` (`card_sylowP`), partition the order-`p` elements into `(p−1)`-blocks (`Finset.card_biUnion` + `PairwiseDisjoint` via `sylowP_eq_of_mem`), giving `(p+1)(p−1) = p²−1`.

2 theorems.

---

## Verification

Both files elaborate clean under the pinned toolchain (`lake env lean`), exit 0. `#print axioms` on the headline results of each lists only `propext, Classical.choice, Quot.sound` (plus, for erdos-165, the pre-existing Ramsey axioms `hhkp_bound, shearer_upper_bound, ramseyNumber`) — **no `sorryAx`, no `Lean.ofReduceBool`, no new axioms**. `meta.json` counts synced for both entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)