### PR TITLE
Research: erdos-1138-oq-03-oq-01 — multiplicative closeness of consecutive primes (p/q → 1)

### DIFF
--- a/proofs/Proofs/Erdos1138OQ03OQ01.lean
+++ b/proofs/Proofs/Erdos1138OQ03OQ01.lean
@@ -533,4 +533,82 @@ theorem consecutive_gap_le_eps_of_bound {θ : ℝ} {x p q : ℕ} (ε : ℝ)
       show (1 : ℝ) - θ + θ = 1 by ring, Real.rpow_one] at hstep
   exact le_trans h1 h2
 
+/-! ### Multiplicative closeness: consecutive primes have ratio tending to `1`
+
+The results above are all *additive* (`q - p = o(x)`).  Their multiplicative
+shadow is that **consecutive primes are close in ratio**: applying the sup-level
+bound at `x = q` (the pair `p < q ≤ q` always qualifies) gives
+`(q - p) / q ≤ q^(-0.475)`, so
+
+    (p : ℝ) / q  =  1 - (q - p)/q  ≥  1 - q^(-0.475)  →  1,
+
+and, taking reciprocals, `q / p ≤ (1 - q^(-0.475))⁻¹ → 1`.  Thus consecutive
+primes satisfy `p / q → 1`; this is the multiplicative form of sublinearity,
+orthogonal to the additive `o(x)` layer. -/
+
+/-- **Lower ratio bound for consecutive primes.**  For consecutive primes
+`p < q` with `q ≥ 25`, the smaller prime is at least `(1 - q^(-0.475))` times the
+larger: `1 - q^(-0.475) ≤ p / q`.  Obtained by applying
+`consecutive_gap_div_le_rpow_neg` at `x = q` (so `(q - p)/q ≤ q^(-0.475)`) and
+rewriting `(q - p)/q = 1 - p/q`.  As `q → ∞` the envelope `q^(-0.475) → 0`, so
+`p / q → 1`. -/
+theorem consecutive_ratio_ge {p q : ℕ} (hq25 : 25 ≤ q)
+    (hp : Nat.Prime p) (hq : Nat.Prime q) (hpq : p < q)
+    (hcons : ∀ r, Nat.Prime r → p < r → q ≤ r) :
+    1 - (q : ℝ) ^ (-(0.475 : ℝ)) ≤ (p : ℝ) / q := by
+  have hqR : (0 : ℝ) < (q : ℝ) := by
+    have : (0 : ℕ) < q := lt_of_lt_of_le (by norm_num) hq25
+    exact_mod_cast this
+  have hgap : ((q - p : ℕ) : ℝ) / q ≤ (q : ℝ) ^ (-(0.475 : ℝ)) :=
+    consecutive_gap_div_le_rpow_neg hq25 hp hq hpq (le_refl q) hcons
+  have hcast : ((q - p : ℕ) : ℝ) = (q : ℝ) - (p : ℝ) := by
+    rw [Nat.cast_sub (le_of_lt hpq)]
+  rw [hcast, sub_div, div_self (ne_of_gt hqR)] at hgap
+  linarith
+
+/-- **Upper ratio bound for consecutive primes.**  Reciprocal companion of
+`consecutive_ratio_ge`: for consecutive primes `p < q` with `q ≥ 25`,
+`q / p ≤ (1 - q^(-0.475))⁻¹`.  Since `q ≥ 25 > 1` the base satisfies
+`q^(-0.475) < 1`, so `1 - q^(-0.475) > 0` and reciprocals reverse the lower
+bound `1 - q^(-0.475) ≤ p/q`.  As `q → ∞` the right-hand side `→ 1`, giving the
+matching upper half of `p/q → 1`. -/
+theorem consecutive_ratio_le {p q : ℕ} (hq25 : 25 ≤ q)
+    (hp : Nat.Prime p) (hq : Nat.Prime q) (hpq : p < q)
+    (hcons : ∀ r, Nat.Prime r → p < r → q ≤ r) :
+    (q : ℝ) / p ≤ (1 - (q : ℝ) ^ (-(0.475 : ℝ)))⁻¹ := by
+  have hppos : (0 : ℝ) < (p : ℝ) := by exact_mod_cast hp.pos
+  have hqR : (0 : ℝ) < (q : ℝ) := by
+    have : (0 : ℕ) < q := lt_of_lt_of_le (by norm_num) hq25
+    exact_mod_cast this
+  have hlow : 1 - (q : ℝ) ^ (-(0.475 : ℝ)) ≤ (p : ℝ) / q :=
+    consecutive_ratio_ge hq25 hp hq hpq hcons
+  have hbase : (q : ℝ) ^ (-(0.475 : ℝ)) < 1 := by
+    apply Real.rpow_lt_one_of_one_lt_of_neg
+    · have : (1 : ℕ) < q := lt_of_lt_of_le (by norm_num) hq25
+      exact_mod_cast this
+    · norm_num
+  have hpos : (0 : ℝ) < 1 - (q : ℝ) ^ (-(0.475 : ℝ)) := by linarith
+  have hinv : (q : ℝ) / p = 1 / ((p : ℝ) / q) := by rw [one_div, inv_div]
+  rw [hinv, ← one_div ((1 : ℝ) - (q : ℝ) ^ (-(0.475 : ℝ)))]
+  exact one_div_le_one_div_of_le hpos hlow
+
+/-- **θ-generic lower ratio bound.**  The exponent-parametric form of
+`consecutive_ratio_ge`: from *any* sup-level power bound `maxPrimeGap q ≤ q^θ`
+at `q > 0`, consecutive primes `p < q` satisfy `1 - q^(θ-1) ≤ p / q`.  For
+`θ < 1` the envelope `q^(θ-1) → 0`, so `p/q → 1`; the BHP instance
+`consecutive_ratio_ge` is `θ = 0.525` (with `θ - 1 = -0.475`).  Any future
+strengthening of BHP plugs straight in. -/
+theorem consecutive_ratio_ge_of_bound {θ : ℝ} {p q : ℕ}
+    (hqpos : 0 < q) (hbound : (maxPrimeGap q : ℝ) ≤ (q : ℝ) ^ θ)
+    (hp : Nat.Prime p) (hq : Nat.Prime q) (hpq : p < q)
+    (hcons : ∀ r, Nat.Prime r → p < r → q ≤ r) :
+    1 - (q : ℝ) ^ (θ - 1) ≤ (p : ℝ) / q := by
+  have hqR : (0 : ℝ) < (q : ℝ) := by exact_mod_cast hqpos
+  have hgap : ((q - p : ℕ) : ℝ) / q ≤ (q : ℝ) ^ (θ - 1) :=
+    consecutive_gap_div_le_rpow_sub_one_of_bound hqpos hbound hp hq hpq (le_refl q) hcons
+  have hcast : ((q - p : ℕ) : ℝ) = (q : ℝ) - (p : ℝ) := by
+    rw [Nat.cast_sub (le_of_lt hpq)]
+  rw [hcast, sub_div, div_self (ne_of_gt hqR)] at hgap
+  linarith
+
 end Erdos1138OQ03

--- a/src/data/research/problems/erdos-1138-oq-03-oq-01.json
+++ b/src/data/research/problems/erdos-1138-oq-03-oq-01.json
@@ -30,7 +30,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETE + generalized further (researcher-5 2026-07-12): the power-envelope engines are now subsumed by a FULLY GENERAL envelope engine gap_littleo_of_littleo_envelope — any eventual envelope f with f x/x→0 forces sublinearity, removing the power assumption entirely (captures both x^θ and the non-power Cramér (log x)² branch). Added =o id form and a subsumption proof re-deriving the rpow engine. 3 new theorems, 0 new axioms. Only assumption remains the deep parent axiom baker_harman_pintz (BHP theorem).",
+    "progressSummary": "PROGRESS (multiplicative-closeness section, 3 thm VERIFIED, no new axioms): added the MULTIPLICATIVE shadow of the additive sublinearity — consecutive primes p<q satisfy p/q→1 (consecutive_ratio_ge/le two-sided sandwich + θ-generic axiom-free consecutive_ratio_ge_of_bound). Orthogonal to the additive o(x) gap trilogy. Only axiom remains parent's deep baker_harman_pintz; the OQ01 sublinearity engine is otherwise 0-axiom/0-sorry.",
     "builtItems": [
       "gap_div_le_rpow_neg (Erdos1138OQ03OQ01.lean:37): maxPrimeGap x / x <= x^(-0.475) for x >= 25",
       "bhp_implies_gap_littleo (Erdos1138OQ03OQ01.lean:57): Tendsto (maxPrimeGap x / x) atTop (nhds 0)",
@@ -40,7 +40,8 @@
       "gap_div_isBigO_rpow_sub_one_of_rpow_bound (Erdos1138OQ03OQ01.lean, VERIFIED axiom-free [propext,choice,Quot.sound]): abstract normalised-decay-rate engine, any eventual envelope maxPrimeGap x≤x^θ ⟹ maxPrimeGap x/x = O(x^(θ-1)); source-parametric twin of the concrete decay-rate result.",
       "Erdos1138OQ03OQ01.lean: gap_littleo_of_littleo_envelope — fully general engine: ANY envelope maxPrimeGap x≤f x with f x/x→0 ⟹ maxPrimeGap x/x→0 (no power assumption)",
       "Erdos1138OQ03OQ01.lean: gap_isLittleO_id_of_littleo_envelope — =o[atTop] id form",
-      "Erdos1138OQ03OQ01.lean: gap_littleo_of_rpow_bound_via_envelope — re-derives the power engine as an instance (subsumption proof)"
+      "Erdos1138OQ03OQ01.lean: gap_littleo_of_rpow_bound_via_envelope — re-derives the power engine as an instance (subsumption proof)",
+      "Erdos1138OQ03OQ01.lean: multiplicative-closeness section (3 thm, VERIFIED via lake env lean, no NEW axioms beyond parent baker_harman_pintz): consecutive_ratio_ge (1−q^(−0.475)≤p/q, BHP), consecutive_ratio_le (q/p≤(1−q^(−0.475))⁻¹, BHP), consecutive_ratio_ge_of_bound (θ-generic 1−q^(θ−1)≤p/q, AXIOM-FREE — plugs any future BHP strengthening). p/q→1 as q→∞."
     ],
     "insights": [
       "BHP exponent 0.525 < 1: one division by x yields a negative power x^(-0.475) that vanishes at infinity - no finer analysis needed",
@@ -48,7 +49,8 @@
       "tendsto_rpow_neg_atTop is root-namespace (not Real.); the earlier survey mis-quoted it",
       "Abstract sublinearity engine: the specific BHP exponent 0.525 is inessential — ANY eventual power envelope maxPrimeGap x ≤ x^θ with θ<1 forces maxPrimeGap x / x → 0 (envelope x^θ/x = x^(θ-1) = x^(-(1-θ)) → 0 since 1-θ>0). gap_littleo_of_rpow_bound {θ} (hθ:θ<1) (H: ∀ᶠ x, gap ≤ x^θ). bhp_implies_gap_littleo is the θ=0.525 instance; future BHP tightenings (0.5+ε) plug in with no re-proof.",
       "Added the explicit decay RATE of the normalised gap (previously only the qualitative Tendsto→0 was recorded): concrete gap_div_isBigO_rpow_neg = O(x^(-0.475)) and abstract gap_div_isBigO_rpow_sub_one_of_rpow_bound = O(x^(θ-1)). Also cleaned two dead `gcongr <;> exact hx` linter warnings. File VERIFIED via lake env lean (built parent olean first), EXIT 0, 0 warnings; 18→20 theorems.",
-      "The power structure x^θ is genuinely irrelevant to sublinearity: only f x/x→0 matters. The general envelope engine gap_littleo_of_littleo_envelope subsumes BOTH the x^θ branch (θ<1) AND the parent conditional Cramér (log x)² branch (not a power of x) under one squeeze. gap_littleo_of_rpow_bound is now provably its f x=x^θ instance."
+      "The power structure x^θ is genuinely irrelevant to sublinearity: only f x/x→0 matters. The general envelope engine gap_littleo_of_littleo_envelope subsumes BOTH the x^θ branch (θ<1) AND the parent conditional Cramér (log x)² branch (not a power of x) under one squeeze. gap_littleo_of_rpow_bound is now provably its f x=x^θ instance.",
+      "Multiplicative shadow of additive sublinearity: consecutive primes have RATIO→1. Applying the sup-level BHP bound at x=q (pair p<q≤q always qualifies) gives (q−p)/q≤q^(−0.475), so p/q=1−(q−p)/q≥1−q^(−0.475)→1. Reciprocal (q≥25>1 ⟹ q^(−0.475)<1 ⟹ 1−q^(−0.475)>0) gives q/p≤(1−q^(−0.475))⁻¹→1. Orthogonal to the additive o(x) trilogy — this is the multiplicative form p/q→1. ★ℕ-sub cast: Nat.cast_sub (le_of_lt hpq) then sub_div + div_self to get (q−p)/q=1−p/q; reciprocal via one_div_le_one_div_of_le (inv_le_inv_of_le is GONE in current Mathlib); Real.rpow_lt_one_of_one_lt_of_neg for base<1."
     ],
     "mathlibGaps": [],
     "nextSteps": [],


### PR DESCRIPTION
## Summary

Erdős #1138 (prime-gap bounds), OQ-03·OQ-01. The existing file proves the **additive** sublinearity of prime gaps (`q - p = o(x)`) in many forms. This adds the **multiplicative** shadow: consecutive primes have ratio tending to 1.

Applying the sup-level Baker–Harman–Pintz bound at `x = q` (the pair `p < q ≤ q` always qualifies) gives `(q - p)/q ≤ q^(-0.475)`, so `p/q = 1 - (q-p)/q ≥ 1 - q^(-0.475) → 1`, and reciprocals give the matching upper half.

## New theorems (3)

- `consecutive_ratio_ge` — `1 - q^(-0.475) ≤ p/q` for consecutive primes `p < q ≤ 25`.
- `consecutive_ratio_le` — `q/p ≤ (1 - q^(-0.475))⁻¹` (reciprocal companion; `q ≥ 25 > 1` forces `1 - q^(-0.475) > 0`).
- `consecutive_ratio_ge_of_bound` — θ-generic `1 - q^(θ-1) ≤ p/q` from any bound `maxPrimeGap q ≤ q^θ`. **Axiom-free**; any future BHP strengthening plugs straight in.

Together the first two give a two-sided multiplicative sandwich: `p/q → 1` as `q → ∞` — orthogonal to the additive `o(x)` gap trilogy.

## Verification

Elaborated via `lake env lean` (0 errors). `#print axioms`: the two BHP-specific results depend only on the parent's `baker_harman_pintz` (+ `propext / Classical.choice / Quot.sound`) — **no new axioms**; the θ-generic form is fully axiom-free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)