### PR TITLE
Research: puiseux-theorem-wip-01 — Part XVI: orderTop as a Mathlib AddValuation

### DIFF
--- a/proofs/Proofs/PuiseuxTheorem.lean
+++ b/proofs/Proofs/PuiseuxTheorem.lean
@@ -1,6 +1,7 @@
 import Mathlib.RingTheory.HahnSeries.Basic
 import Mathlib.RingTheory.HahnSeries.Multiplication
 import Mathlib.RingTheory.HahnSeries.Summable
+import Mathlib.RingTheory.HahnSeries.Valuation
 import Mathlib.RingTheory.PowerSeries.Basic
 import Mathlib.FieldTheory.IsAlgClosed.Basic
 import Mathlib.FieldTheory.IsAlgClosed.AlgebraicClosure
@@ -1614,6 +1615,151 @@ theorem ramificationValueSubgroup_sup (n m : ℕ+) :
     linear_combination (-(k : ℚ)) * hbez
 
 end ValueGroupSubgroup
+
+/-! ═══════════════════════════════════════════════════════════════════════════════
+PART XVI: THE ORDER VALUATION AS A MATHLIB `AddValuation`
+═══════════════════════════════════════════════════════════════════════════════ -/
+
+/-!
+### Part XVI: `orderTop` is a genuine `HahnSeries.addVal` on the Puiseux field
+
+Parts XIII–XV computed the **value group** — the image of `orderTop` — as a raw set, an
+`AddSubgroup ℚ`, and a directed tower. But `orderTop` is not merely a function with a nice
+image: it is an **additive valuation** in the sense of Mathlib's `AddValuation`, carrying
+the two defining axioms
+
+* `v(fg) = v(f) + v(g)` (multiplicativity), and
+* `min (v f) (v g) ≤ v(f+g)` (the ultrametric / strong-triangle inequality).
+
+Because `HahnSeries ℚ K` is itself a **field** (Mathlib `HahnSeries.instField`, since `ℚ`
+is a `LinearOrderedAddCommGroup` and `K` is a field), the valuation additionally satisfies
+the field laws `v(f⁻¹) = -v(f)` and `v(f/g) = v(f) - v(g)`, and is nondegenerate
+(`v(f) = ⊤ ↔ f = 0`).  This part records that upgrade: the ad-hoc `orderTop` bookkeeping of
+Parts XIII–XV *is* the Mathlib valuation `HahnSeries.addVal ℚ K`, whose value group was
+already computed to be all of `ℚ`.
+
+* `puiseuxAddVal` — `HahnSeries.addVal ℚ K`, the order valuation, as a first-class object;
+* `puiseuxAddVal_apply` — it agrees with `orderTop`, the bridge back to Parts XIII–XV;
+* `puiseuxAddVal_mul` / `puiseuxAddVal_add` — the two valuation axioms
+  (multiplicativity + ultrametric) — facts the `orderTop`-only work never stated;
+* `puiseuxAddVal_inv` / `puiseuxAddVal_div` / `puiseuxAddVal_pow` — the field/power laws;
+* `puiseuxAddVal_eq_top_iff` — nondegeneracy;
+* `puiseuxAddVal_surjective` / `puiseux_puiseuxAddVal_range` — the value group is **all** of
+  `WithTop ℚ` (every value, `⊤` included, is attained), the valuation-object form of
+  `puiseux_orderTop_range`;
+* `exists_puiseux_puiseuxAddVal_eq` — every finite value is attained by a *Puiseux* series
+  (ties the valuation to the subfield, reusing `exists_puiseux_orderTop_eq`);
+* `ramification_puiseuxAddVal_range` — restricted to level `n`, the value group is exactly
+  `(1/n)ℤ` (reuses `ramification_orderTop_range`).
+-/
+
+section OrderValuation
+
+/-- **The order valuation on the Puiseux field.**  `HahnSeries.addVal ℚ K` is Mathlib's
+additive valuation sending a Hahn series to its `orderTop` (least exponent, `⊤` for `0`).
+Over a field `K` it is an honest `AddValuation` on the field `HahnSeries ℚ K = K⦃⦃x⦄⦄`,
+supplying the valuation axioms behind the raw `orderTop` value-group computations of
+Parts XIII–XV. -/
+noncomputable def puiseuxAddVal (K : Type*) [Field K] :
+    AddValuation (HahnSeries ℚ K) (WithTop ℚ) :=
+  HahnSeries.addVal ℚ K
+
+/-- The order valuation is `orderTop`: the bridge from Part XVI back to the value-group
+computations of Parts XIII–XV. -/
+@[simp] theorem puiseuxAddVal_apply {K : Type*} [Field K] (f : HahnSeries ℚ K) :
+    puiseuxAddVal K f = f.orderTop :=
+  HahnSeries.addVal_apply
+
+/-- **Multiplicativity of the valuation:** `v(fg) = v(f) + v(g)`.  Equivalently
+`orderTop (f*g) = orderTop f + orderTop g` — the first valuation axiom, never recorded by
+the `orderTop`-only Parts XIII–XV. -/
+theorem puiseuxAddVal_mul {K : Type*} [Field K] (f g : HahnSeries ℚ K) :
+    puiseuxAddVal K (f * g) = puiseuxAddVal K f + puiseuxAddVal K g :=
+  (puiseuxAddVal K).map_mul f g
+
+/-- **The ultrametric (strong triangle) inequality:** `min (v f) (v g) ≤ v(f+g)`.  The
+second valuation axiom. -/
+theorem puiseuxAddVal_add {K : Type*} [Field K] (f g : HahnSeries ℚ K) :
+    min (puiseuxAddVal K f) (puiseuxAddVal K g) ≤ puiseuxAddVal K (f + g) :=
+  (puiseuxAddVal K).map_add f g
+
+/-- `v(1) = 0`. -/
+@[simp] theorem puiseuxAddVal_one {K : Type*} [Field K] :
+    puiseuxAddVal K (1 : HahnSeries ℚ K) = 0 :=
+  (puiseuxAddVal K).map_one
+
+/-- `v(0) = ⊤`. -/
+@[simp] theorem puiseuxAddVal_zero {K : Type*} [Field K] :
+    puiseuxAddVal K (0 : HahnSeries ℚ K) = ⊤ :=
+  (puiseuxAddVal K).map_zero
+
+/-- **Power law:** `v(fⁿ) = n • v(f)`. -/
+theorem puiseuxAddVal_pow {K : Type*} [Field K] (f : HahnSeries ℚ K) (n : ℕ) :
+    puiseuxAddVal K (f ^ n) = n • puiseuxAddVal K f :=
+  (puiseuxAddVal K).map_pow f n
+
+/-- **Inversion negates the valuation:** `v(f⁻¹) = -v(f)`.  A field law, available because
+`HahnSeries ℚ K` is a field. -/
+theorem puiseuxAddVal_inv {K : Type*} [Field K] (f : HahnSeries ℚ K) :
+    puiseuxAddVal K f⁻¹ = -(puiseuxAddVal K f) :=
+  (puiseuxAddVal K).map_inv
+
+/-- **Quotient law:** `v(f/g) = v(f) - v(g)`. -/
+theorem puiseuxAddVal_div {K : Type*} [Field K] (f g : HahnSeries ℚ K) :
+    puiseuxAddVal K (f / g) = puiseuxAddVal K f - puiseuxAddVal K g :=
+  (puiseuxAddVal K).map_div
+
+/-- **Nondegeneracy:** the valuation is `⊤` only on `0` — the maximal-ideal / support
+characterization for the order valuation of the Puiseux field. -/
+@[simp] theorem puiseuxAddVal_eq_top_iff {K : Type*} [Field K] {f : HahnSeries ℚ K} :
+    puiseuxAddVal K f = ⊤ ↔ f = 0 :=
+  (puiseuxAddVal K).top_iff
+
+/-- **Every finite value is attained by a Puiseux series.**  For each rational `q` the
+single-term series `single q 1` is a nonzero Puiseux series whose valuation is `q`.  The
+valuation-object form of `exists_puiseux_orderTop_eq`, tying `puiseuxAddVal` to the Puiseux
+subfield. -/
+theorem exists_puiseux_puiseuxAddVal_eq {K : Type*} [Field K] (q : ℚ) :
+    ∃ f : HahnSeries ℚ K, IsPuiseuxSeries f ∧ f ≠ 0 ∧
+      puiseuxAddVal K f = (q : WithTop ℚ) := by
+  obtain ⟨f, hf, hf0, hfv⟩ := exists_puiseux_orderTop_eq (K := K) q
+  exact ⟨f, hf, hf0, by rw [puiseuxAddVal_apply]; exact hfv⟩
+
+/-- **The value group of the Puiseux valuation is all of `ℚ`.**  The set of finite valuation
+values attained by nonzero Puiseux series is precisely `{v : WithTop ℚ | v ≠ ⊤}`.  This is
+`puiseux_orderTop_range` transported along `puiseuxAddVal_apply` — the value-group statement
+phrased for the genuine `AddValuation`. -/
+theorem puiseux_puiseuxAddVal_range {K : Type*} [Field K] :
+    {v : WithTop ℚ |
+        ∃ f : HahnSeries ℚ K, IsPuiseuxSeries f ∧ f ≠ 0 ∧ puiseuxAddVal K f = v}
+      = {v : WithTop ℚ | v ≠ ⊤} := by
+  simp only [puiseuxAddVal_apply]
+  exact puiseux_orderTop_range
+
+/-- **The order valuation is surjective.**  Every value in `WithTop ℚ` — including `⊤`
+(attained only by `0`) — is hit: the valuation realises the full value group `ℚ` plus the
+`⊤` of the zero series.  Capstone of the value-group computation at the `AddValuation`
+level. -/
+theorem puiseuxAddVal_surjective {K : Type*} [Field K] :
+    Function.Surjective (puiseuxAddVal K) := by
+  intro v
+  rcases eq_or_ne v ⊤ with rfl | hv
+  · exact ⟨0, puiseuxAddVal_zero⟩
+  · obtain ⟨q, rfl⟩ := WithTop.ne_top_iff_exists.mp hv
+    obtain ⟨f, _, _, hfv⟩ := exists_puiseux_puiseuxAddVal_eq (K := K) q
+    exact ⟨f, hfv⟩
+
+/-- **The value group of the level-`n` Laurent subfield is exactly `(1/n)ℤ`.**  The set of
+valuation values attained by nonzero `(1/n)`-ramified series is precisely `{k/n : k ∈ ℤ}` —
+`ramification_orderTop_range` transported to `puiseuxAddVal`. -/
+theorem ramification_puiseuxAddVal_range {K : Type*} [Field K] (n : ℕ+) :
+    {v : WithTop ℚ |
+        ∃ f : HahnSeries ℚ K, IsPuiseuxOfRamification n f ∧ f ≠ 0 ∧ puiseuxAddVal K f = v}
+      = {v : WithTop ℚ | ∃ k : ℤ, v = (((k : ℚ) / (n : ℚ) : ℚ) : WithTop ℚ)} := by
+  simp only [puiseuxAddVal_apply]
+  exact ramification_orderTop_range n
+
+end OrderValuation
 
 /-! ═══════════════════════════════════════════════════════════════════════════════
 SUMMARY

--- a/research/problems/cauchy-schwarz-integral-lp-duality-synthesis/knowledge.md
+++ b/research/problems/cauchy-schwarz-integral-lp-duality-synthesis/knowledge.md
@@ -1536,3 +1536,14 @@ actual, small resolution and it landed. No researcher-shaped Lean work remains h
 
 **Recommendation (unchanged from S28/S29/S30):** this synthesis entry is COMPLETE — stop re-serving
 it for ACT work. The axiom is eliminated; the gallery now presents it honestly on both source and meta.
+
+## Session 2026-07-12 (researcher-8) — RE-CONFIRM COMPLETE, no filler (ASSESS)
+
+**Mode**: ASSESS. Re-verified the S28–S31 consensus. The base file
+`CauchySchwarzIntegralOQ01OQ01OQ02.lean` has **0 `axiom` declarations** and re-exports the
+discharge: `theorem riesz_lp_surjective … := RieszLpDualitySynthesis.riesz_lp_surjective_general …`.
+The 8 "sorry" tokens in `CauchySchwarzIntegralLpDualitySynthesis.lean` are all historical
+docstring/comment notes explicitly stating the file is sorry-free (lines 23/27/29/31/33/39/417/470),
+NOT live proof terms. `riesz_lp_surjective_general` was kernel-checked sorryAx-free by S30.
+Goal (eliminate `axiom riesz_lp_surjective`) remains DONE. Released without adding filler —
+this synthesis strand is COMPLETE; recommend Seeker stop re-serving it for ACT work.

--- a/src/data/proofs/puiseux-theorem/meta.json
+++ b/src/data/proofs/puiseux-theorem/meta.json
@@ -53,15 +53,18 @@
       "Characteristic-zero requirement noted as an informal String descriptor (char_zero_required, Artin-Schreier obstruction), not formalized",
       "Binomial root lifted to an honest Polynomial.IsRoot (puiseux_binomial_isRoot): the Puiseux series c^(1/n)·x^(m/n) is a genuine root of the polynomial Xⁿ - C(single m c) over the Hahn/Puiseux field, the polynomial-level form of a single Newton-polygon edge",
       "ramificationValueSubgroup_le_iff: (1/n)ℤ ≤ (1/n′)ℤ ↔ n ∣ n′ — the value-subgroup tower is an ORDER EMBEDDING of the divisibility poset (ℕ⁺,∣) into AddSubgroup ℚ (converse of ramificationValueSubgroup_mono)",
-      "ramificationValueSubgroup_injective: distinct ramification levels give distinct value subgroups, so the exhausting filtration iSup=⊤ is faithful (every level genuinely new)"
+      "ramificationValueSubgroup_injective: distinct ramification levels give distinct value subgroups, so the exhausting filtration iSup=⊤ is faithful (every level genuinely new)",
+      "puiseuxAddVal (Part XVI): the order valuation on the Puiseux field packaged as Mathlib's genuine HahnSeries.addVal ℚ K : AddValuation (HahnSeries ℚ K) (WithTop ℚ) — upgrading the ad-hoc orderTop value-group computations of Parts XIII–XV to the first-class AddValuation object, with the valuation axioms puiseuxAddVal_mul (v(fg)=v f+v g) and puiseuxAddVal_add (ultrametric min(v f,v g)≤v(f+g)) that the orderTop-only work never stated",
+      "puiseuxAddVal_inv/div/eq_top_iff (Part XVI): the field laws v(f⁻¹)=−v f, v(f/g)=v f−v g and nondegeneracy v(f)=⊤ ↔ f=0, available because HahnSeries ℚ K is itself a field (HahnSeries.instField)",
+      "puiseuxAddVal_surjective / puiseux_puiseuxAddVal_range / ramification_puiseuxAddVal_range (Part XVI): the value group of the genuine AddValuation is all of WithTop ℚ (every value, ⊤ included, attained), with the level-n Laurent subfield value group exactly (1/n)ℤ — the AddValuation-object form of puiseux_orderTop_range and ramification_orderTop_range"
     ],
     "dateAdded": "2025-12-29",
     "axiomCount": 0,
-    "lineCount": 1553,
+    "lineCount": 1786,
     "assumptions": "No axiom declarations, no sorries, no native_decide (all theorems depend only on propext/Classical.choice/Quot.sound). The two headline placeholders (puiseux_theorem, puiseux_is_algebraic_closure) were replaced by genuine, fully computed Hahn-series theorems puiseux_binomial_root and puiseux_binomial_ramification, which establish the binomial base case of Puiseux's theorem (every binomial Yⁿ = c·xᵐ has a Puiseux root of ramification n over an algebraically closed field). Four narrative theorems remain as String-literal descriptors carrying no formal content (curve_branches_are_puiseux, newton_polygon_tropicalization, galois_group_is_profinite_integers, char_zero_required); each merely asserts ∃ desc : String, desc = \"…\" and marks an informal application/connection rather than a machine-checked result. This is a rigorously verified FRAGMENT: the full Newton–Puiseux theorem for arbitrary polynomials over the Puiseux field (assembling binomial roots term by term, with its char-0 convergence argument) is not formalized here — the required infrastructure is absent from Mathlib. Badge remains 'wip' to reflect that the headline algebraic-closure theorem is not fully proven.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 50,
-    "definitionCount": 9
+    "theoremCount": 63,
+    "definitionCount": 10
   },
   "overview": {
     "historicalContext": "Newton discovered the algorithm for computing fractional power series roots of polynomials in 1676. Puiseux gave the first rigorous proof in 1850 that these series provide the algebraic closure of the Laurent series field, establishing that allowing fractional exponents suffices to solve all polynomial equations over formal power series (in characteristic 0). The study of algebraic curves via local parametrization goes back to Newton who introduced the Newton polygon method to compute the branches of an algebraic curve at a singular point. The formal algebraic closure result was refined in the 20th century by Hironaka and others in connection with resolution of singularities, and the characteristic-0 hypothesis is essential: in characteristic p, the Artin-Schreier phenomenon means p-th power extensions cannot be captured by Puiseux series.",
@@ -166,6 +169,7 @@
   "leanFile": {
     "imports": [
       "Mathlib.RingTheory.HahnSeries.Basic",
+      "Mathlib.RingTheory.HahnSeries.Valuation",
       "Mathlib.RingTheory.PowerSeries.Basic",
       "Mathlib.FieldTheory.IsAlgClosed.Basic",
       "Mathlib.FieldTheory.IsAlgClosed.AlgebraicClosure",
@@ -175,10 +179,10 @@
       "Polynomial"
     ],
     "namespace": "PuiseuxTheorem",
-    "lineCount": 1553,
+    "lineCount": 1786,
     "axiomCount": 0,
-    "theoremCount": 55,
-    "definitionCount": 9,
+    "theoremCount": 68,
+    "definitionCount": 10,
     "path": "Proofs/PuiseuxTheorem.lean",
     "sorries": 0
   },


### PR DESCRIPTION
## Summary
Research session for `puiseux-theorem-wip-01` (Wiedijk #41). Parts XIII–XV of
`PuiseuxTheorem.lean` computed the **value group** of the Puiseux field (the image of
`orderTop`) as a raw set, an `AddSubgroup ℚ`, and a directed tower — but treated `orderTop`
as a bare function. **Part XVI upgrades it to Mathlib's genuine `AddValuation`.**

The order function on the Puiseux field is `HahnSeries.addVal ℚ K : AddValuation (HahnSeries ℚ K) (WithTop ℚ)`
(from `Mathlib.RingTheory.HahnSeries.Valuation`). This part imports it, names it `puiseuxAddVal`,
and records the valuation structure the `orderTop`-only work never stated.

## Progress (13 theorems + 1 def, all 0-axiom)
- **`puiseuxAddVal`** + `puiseuxAddVal_apply` (`@[simp]` bridge `= orderTop`).
- **Valuation axioms:** `puiseuxAddVal_mul` (`v(fg)=v f+v g`, multiplicativity),
  `puiseuxAddVal_add` (ultrametric `min(v f,v g)≤v(f+g)`), `_one`/`_zero`/`_pow`.
- **Field laws** (valid since `HahnSeries ℚ K` is itself a field via `HahnSeries.instField`):
  `puiseuxAddVal_inv` (`v(f⁻¹)=−v f`), `puiseuxAddVal_div`, and nondegeneracy
  `puiseuxAddVal_eq_top_iff` (`v f=⊤ ↔ f=0`).
- **Value group via the valuation object:** `puiseuxAddVal_surjective` (hits **every** value
  in `WithTop ℚ`, `⊤` included), `puiseux_puiseuxAddVal_range` and
  `ramification_puiseuxAddVal_range` (transport `puiseux_orderTop_range` /
  `ramification_orderTop_range` along `puiseuxAddVal_apply`), `exists_puiseux_puiseuxAddVal_eq`
  (ties finite values to the Puiseux subfield).

## Files Modified
- `proofs/Proofs/PuiseuxTheorem.lean` (+`import Mathlib.RingTheory.HahnSeries.Valuation`,
  +Part XVI `OrderValuation` section; 1640→1786 lines)
- `src/data/proofs/puiseux-theorem/meta.json` (lineCount→1786, theoremCount 50→63 & 55→68,
  definitionCount 9→10, +import, +3 originalContributions)
- `research/problems/puiseux-theorem-wip-01/{knowledge.md}` and tracker JSON

## Findings
- `HahnSeries.addVal` needs only the coefficient ring to be a domain; `[Field K]` supplies it.
  Every rational value is realized by a *Puiseux* single-term `single q 1`, so the value group
  over nonzero Puiseux series is all of ℚ.
- Every valuation-axiom lemma is a one-line `AddValuation` dot-notation application; the range
  lemmas close in one `simp only [puiseuxAddVal_apply]` + `exact`.

## Verification
`#print axioms` on the new results = `[propext, Classical.choice, Quot.sound]` only — no
`sorryAx`, no `ofReduceBool`. Genuinely **0-axiom / 0-sorry**. Verified by direct local
lean 4.26.0 elaboration (EXIT 0, only two pre-existing warnings at lines 354/381); the Docker
build hit exit 135 on an **unrelated** corrupted Mathlib cache file (`Analysis.Normed.Ring.InfiniteSum`,
not a transitive dependency of this file).

## Status
**Outcome**: progress — the valuation axis is now first-class. Frontier remains deep
Newton–Puiseux algebraic closure (>1000L, absent from Mathlib).

🤖 Generated by researcher-8