### PR TITLE
Research: erdos-1018 — repair Erdos1018OQ04 build + sub-hypergraph monotonicity of embeddability

### DIFF
--- a/proofs/Proofs/Erdos1018OQ04.lean
+++ b/proofs/Proofs/Erdos1018OQ04.lean
@@ -73,11 +73,13 @@ def completeHypergraph (t r : ℕ) : Hypergraph (Fin t) r where
 /-- The complete r-uniform hypergraph on t vertices has C(t,r) edges. -/
 theorem completeHypergraph_edgeCount (t r : ℕ) :
     (completeHypergraph t r).edgeCount = t.choose r := by
-  unfold Hypergraph.edgeCount completeHypergraph
-  have h : (Finset.univ.filter (fun s : Finset (Fin t) => s.card = r)) =
+  have h : (completeHypergraph t r).edges =
       (Finset.univ : Finset (Fin t)).powersetCard r := by
-    ext s; simp [Finset.mem_powersetCard, Finset.mem_filter, Finset.subset_univ]
-  rw [h, Finset.card_powersetCard, Finset.card_univ, Fintype.card_fin]
+    ext s
+    simp only [completeHypergraph, Finset.mem_filter, Finset.mem_univ, true_and,
+      Finset.mem_powersetCard, Finset.subset_univ]
+  simp only [Hypergraph.edgeCount, h, Finset.card_powersetCard, Finset.card_univ,
+    Fintype.card_fin]
 
 /-- When r = 2, the complete 2-uniform hypergraph on t vertices has
     C(t,2) = t*(t-1)/2 edges, matching the complete graph. -/

--- a/proofs/Proofs/Erdos1018OQ04Mono.lean
+++ b/proofs/Proofs/Erdos1018OQ04Mono.lean
@@ -1,0 +1,75 @@
+/-
+# Erdős #1018 (OQ-04) — sub-hypergraph monotonicity of geometric embeddability
+
+`Erdos1018OQ04.lean` defines the linear embeddability predicate `isEmbeddable H d`
+(`∃` an injective placement `φ : V → ℝ^d` under which the convex hulls of distinct edges
+meet only in the hull of their shared vertices), the higher-dimensional generalisation of
+graph planarity used in the van Kampen–Flores obstruction.  It records that a hypergraph
+`H` has a *small non-embeddable* induced piece (`hasSmallNonEmbeddable`), the shape of the
+Kostochka–Pyber conclusion — but it does not prove that non-embeddability of a piece actually
+obstructs the whole graph.
+
+This file supplies that missing structural fact: embeddability is closed under passing to
+**sub-hypergraphs**.  Any `H₁` whose edge set is contained in that of an embeddable `H₂` is
+itself embeddable — the *same* placement `φ` works, since the convex-hull separation is then
+required of fewer edge pairs.  Its contrapositive,
+
+    a non-embeddable sub-hypergraph obstructs the whole graph,
+
+is exactly the logical mechanism behind Erdős #1018 / Kostochka–Pyber: to certify that a
+dense (hyper)graph contains a non-embeddable (for `r = 2`, non-planar) subgraph it suffices to
+exhibit one small non-embeddable piece.  As a capstone we discharge exactly that reduction:
+`hasSmallNonEmbeddable H k → isNonEmbeddable H (criticalDim r)`.  The vertex-induced case is
+recovered as the special case where the sub-edge-set is `H.edges.filter (· ⊆ S)`.
+
+All results are `0`-sorry / `0`-axiom on top of Mathlib and `Erdos1018OQ04`; they do not invoke
+any of the deep axioms (`vanKampen_Flores`, `triangle_planar`, `K4_planar`, …) declared there.
+-/
+import Mathlib
+import Proofs.Erdos1018OQ04
+
+namespace Erdos1018OQ04
+
+variable {V : Type*} [Fintype V] [DecidableEq V]
+
+/-- **Embeddability is sub-hypergraph closed.**  If every edge of `H₁` is an edge of `H₂`
+    and `H₂` embeds in `ℝ^d`, then `H₁` embeds in `ℝ^d`: the same injective placement `φ`
+    works, because the convex-hull separation condition for `H₁` ranges over a subset of the
+    edge pairs it holds for in `H₂`. -/
+theorem isEmbeddable_of_edges_subset {r d : ℕ}
+    {H₁ H₂ : Hypergraph V r} (hsub : H₁.edges ⊆ H₂.edges)
+    (hE : isEmbeddable H₂ d) : isEmbeddable H₁ d := by
+  obtain ⟨φ, hinj, hsep⟩ := hE
+  exact ⟨φ, hinj, fun e₁ he₁ e₂ he₂ hne => hsep e₁ (hsub he₁) e₂ (hsub he₂) hne⟩
+
+/-- **A non-embeddable sub-hypergraph obstructs the whole graph.**  Contrapositive of
+    `isEmbeddable_of_edges_subset`: if `H₁ ⊆ H₂` (edge-wise) and `H₁` is non-embeddable in
+    `ℝ^d`, then so is `H₂`.  This is the precise logical shape of "a dense (hyper)graph
+    containing a non-embeddable subgraph is itself non-embeddable". -/
+theorem isNonEmbeddable_of_edges_subset {r d : ℕ}
+    {H₁ H₂ : Hypergraph V r} (hsub : H₁.edges ⊆ H₂.edges)
+    (hne : isNonEmbeddable H₁ d) : isNonEmbeddable H₂ d :=
+  fun hE => hne (isEmbeddable_of_edges_subset hsub hE)
+
+/-- The vertex-induced sub-hypergraph is an edge-subset: `(H.induced S).edges ⊆ H.edges`. -/
+theorem induced_edges_subset {r : ℕ} (H : Hypergraph V r) (S : Finset V) :
+    (H.induced S).edges ⊆ H.edges := by
+  unfold Hypergraph.induced
+  exact Finset.filter_subset _ _
+
+/-- **Embeddability is inherited by vertex-induced subgraphs.**  Special case of
+    `isEmbeddable_of_edges_subset` for `H.induced S`. -/
+theorem isEmbeddable_induced {r d : ℕ} {H : Hypergraph V r} (S : Finset V)
+    (hE : isEmbeddable H d) : isEmbeddable (H.induced S) d :=
+  isEmbeddable_of_edges_subset (induced_edges_subset H S) hE
+
+/-- **A small non-embeddable induced piece is exactly a whole-graph obstruction.**  Unfolds
+    `hasSmallNonEmbeddable H k` (an induced `S`, `|S| ≤ k`, with `H.induced S` non-embeddable
+    at the critical dimension) into the conclusion that `H` itself is non-embeddable there —
+    closing the gap between "has a small non-embeddable piece" and "is non-embeddable". -/
+theorem isNonEmbeddable_of_hasSmallNonEmbeddable {r k : ℕ} {H : Hypergraph V r}
+    (h : hasSmallNonEmbeddable H k) : isNonEmbeddable H (criticalDim r) := by
+  obtain ⟨S, _, hS⟩ := h
+  exact isNonEmbeddable_of_edges_subset (induced_edges_subset H S) hS
+
+end Erdos1018OQ04

--- a/research/problems/erdos-1018-incomplete-01/knowledge.md
+++ b/research/problems/erdos-1018-incomplete-01/knowledge.md
@@ -287,3 +287,40 @@ The 2 remaining axioms `kostochka_pyber` (1988) and `planar_linear_bound` (Euler
 are genuine deep results; no Mathlib planar-graph theory exists to discharge them. This
 addition is honest supporting structure around the definitional Kuratowski planarity, not
 progress on the deep blockers.
+
+## Session 2026-07-12 (researcher-2): compile-repair Erdos1018OQ04 + sub-hypergraph monotonicity [VERIFIED docker]
+
+**Mode**: ACT — genuine compile-repair (the problem's stated goal) + new structural content.
+**Outcome**: PROGRESS. Docker build `Proofs.Erdos1018OQ04Mono` = SUCCESS; all 4 new thms
+`#print axioms` = [propext, Classical.choice, Quot.sound] (0 extra axioms; none of OQ04's deep
+axioms invoked). Branch feature/researcher-2-1018.
+
+### Compile repair (Erdos1018OQ04.lean was BROKEN on origin/main)
+- `completeHypergraph_edgeCount` (line ~76) failed: `rw [h, …]` gave "motive is not type
+  correct" — the filter, after `unfold completeHypergraph`, carries a `DecidablePred` instance
+  that mismatches the freshly-stated `h`. Fix: rewrite `.edges` (not the unfolded filter) and use
+  `simp only [Hypergraph.edgeCount, h, …]` instead of `rw` (simp's congruence sidesteps the
+  motive check). File now builds (only its pre-existing `turanNumber` def-sorry warning remains).
+
+### New content — Erdos1018OQ04Mono.lean (5 thms, 0-axiom)
+Sub-hypergraph monotonicity of `isEmbeddable` (OQ04's convex-hull embeddability), which OQ04
+lacked (it only had `Hypergraph.induced` + edge-count bound):
+- `isEmbeddable_of_edges_subset`: H₁.edges ⊆ H₂.edges ∧ embeddable H₂ ⟹ embeddable H₁ (same φ).
+- `isNonEmbeddable_of_edges_subset`: contrapositive — non-embeddable subgraph obstructs whole.
+- `induced_edges_subset` + `isEmbeddable_induced`: vertex-induced special case.
+- `isNonEmbeddable_of_hasSmallNonEmbeddable`: **capstone** — closes the gap
+  `hasSmallNonEmbeddable H k → isNonEmbeddable H (criticalDim r)` (the Kostochka–Pyber reduction
+  shape: a small non-embeddable induced piece certifies the whole graph is non-embeddable).
+
+### STILL BROKEN (out of scope this session): Erdos1018OQ04Incomplete01.lean
+Massively drift-broken under v4.26 (~20 errors, NOT session-fixable quickly):
+- Parse errors: docstring `/--` after non-command at 642/701; malformed
+  `axiom kostochka_pyber_r2 : ∀ ε : ℝ, ε > 0,` (line 707 — `ε > 0,` isn't `ε > 0 → …`).
+- Unknown constants: `Real.tendsto_rpow_atTop`, `Nat.le_of_max_le_left/right` (renamed/moved).
+- Heartbeat timeouts at 194, 319 (`isDefEq` / tactic exec > 200000) — proofs need reworking.
+- Several `rw` "pattern not found" (128/182/293/303/313).
+My Mono content was re-based onto OQ04's `isEmbeddable` (identical predicate) to avoid this file.
+The lone deep sorry `planar_graphs_edge_bound` (line 676, needs Euler `3n−6`) remains blocked.
+
+### Files
+- `proofs/Proofs/Erdos1018OQ04.lean` (repaired), `proofs/Proofs/Erdos1018OQ04Mono.lean` (new).


### PR DESCRIPTION
## Summary

Two contributions to Erdős #1018 (OQ-04, hypergraph non-embeddability), **docker-VERIFIED** (`docker-build.sh Proofs.Erdos1018OQ04Mono` succeeds; all new theorems `#print axioms` = the 3 foundational axioms only).

### 1. Compile repair — `Erdos1018OQ04.lean` was broken on `origin/main`
`completeHypergraph_edgeCount` failed to build: `rw [h, …]` raised **"motive is not type correct"** because, after `unfold completeHypergraph`, the edge filter carries a `DecidablePred` instance that no longer matches the freshly-stated rewrite lemma `h`. Fixed by rewriting `.edges` directly and replacing the `rw` with `simp only [Hypergraph.edgeCount, h, …]` (simp's congruence machinery sidesteps the motive check). The file now builds (only its pre-existing `turanNumber` def-sorry warning remains).

### 2. New content — `Erdos1018OQ04Mono.lean` (5 theorems, 0-axiom)
Sub-hypergraph monotonicity of `isEmbeddable` (OQ04's convex-hull embeddability predicate), which the file lacked:
- `isEmbeddable_of_edges_subset` — `H₁.edges ⊆ H₂.edges` and `H₂` embeddable ⟹ `H₁` embeddable (same placement `φ`).
- `isNonEmbeddable_of_edges_subset` — contrapositive: a non-embeddable subgraph obstructs the whole graph.
- `induced_edges_subset`, `isEmbeddable_induced` — the vertex-induced special case.
- `isNonEmbeddable_of_hasSmallNonEmbeddable` — **capstone** closing `hasSmallNonEmbeddable H k → isNonEmbeddable H (criticalDim r)`, the exact Kostochka–Pyber reduction shape (a *small* non-embeddable induced piece certifies the *whole* graph is non-embeddable).

None of OQ04's deep axioms (`vanKampen_Flores`, `triangle_planar`, `K4_planar`, …) are invoked.

## Scope
`Erdos1018OQ04Incomplete01.lean` remains heavily drift-broken (~20 errors: parse errors incl. a malformed `axiom` statement, renamed constants `Real.tendsto_rpow_atTop` / `Nat.le_of_max_le_left/right`, heartbeat timeouts) — a larger separate repair, documented in `knowledge.md`. The deep sorry `planar_graphs_edge_bound` (needs Euler's `3n−6`, absent from Mathlib) is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)