### PR TITLE
Research: cantor-diagonalization-oq-06-oq-01 — injectivity of the diagonal map on its digit-choices

### DIFF
--- a/proofs/Proofs/CantorDiagonalizationOQ06OQ01.lean
+++ b/proofs/Proofs/CantorDiagonalizationOQ06OQ01.lean
@@ -554,4 +554,62 @@ appeal to `Cardinal.not_countable_real` or `#ℝ = 𝔠`. -/
 theorem mk_seq_le_mk_real : Cardinal.mk (ℕ → Bool) ≤ Cardinal.mk ℝ :=
   Cardinal.mk_le_of_injective seqReal_injective
 
+/-! ## Injectivity of the diagonal map on its digit-choices
+
+`diagonalReal_congr` shows the diagonal map is *constant* on enumerations sharing a
+diagonal digit-sequence.  The converse — that it *separates* distinct digit-sequences —
+was missing.  It falls straight out of the crux `digit_diagonalReal` (the `n`-th digit of
+`diagonalReal f` reads back exactly `db f n`), giving an exact biconditional and hence an
+order-preserving embedding of `{1,2}`-digit sequences into `[1/9, 2/9]`. -/
+
+/-- **Converse of `diagonalReal_congr` (injectivity on digit-choices).**  Equal diagonal
+reals have equal diagonal digit-choices at every position.  Reading the `n`-th digit of
+each side and applying the crux `digit_diagonalReal` collapses the hypothesis to
+`db f n = db g n`. -/
+theorem db_eq_of_diagonalReal_eq {f g : ℕ → ℝ} (h : diagonalReal f = diagonalReal g)
+    (n : ℕ) : db f n = db g n := by
+  have hd := congrArg (fun x => digit x n) h
+  simpa only [digit_diagonalReal] using hd
+
+/-- **Characterization of equal diagonal reals.**  `diagonalReal f = diagonalReal g` iff the
+diagonal digit-choices agree everywhere.  Forward is `db_eq_of_diagonalReal_eq`; reverse is a
+termwise `tsum_congr`, since `diagonalReal` depends on `f` only through the sequence `db f`.
+This sharpens `diagonalReal_congr` (whose digit-equality hypothesis is merely sufficient) to
+an exact biconditional at the level of the `{1,2}`-valued choices actually used. -/
+theorem diagonalReal_eq_iff_db {f g : ℕ → ℝ} :
+    diagonalReal f = diagonalReal g ↔ ∀ n, db f n = db g n := by
+  refine ⟨fun h n => db_eq_of_diagonalReal_eq h n, fun h => ?_⟩
+  unfold diagonalReal
+  exact tsum_congr fun n => by rw [h n]
+
+/-- **Digit-choices separate diagonal reals.**  Contrapositive of
+`db_eq_of_diagonalReal_eq`: a single position of disagreement in the digit-choices already
+forces the diagonal reals apart.  Combined with `diagonalReal_mono`, the diagonal
+construction is an order-preserving *embedding* of digit-choice sequences into the reals. -/
+theorem diagonalReal_ne_of_db_ne {f g : ℕ → ℝ} {n : ℕ} (h : db f n ≠ db g n) :
+    diagonalReal f ≠ diagonalReal g :=
+  fun heq => h (db_eq_of_diagonalReal_eq heq n)
+
+/-! ## Set-theoretic form: the witness is missing from the enumeration -/
+
+/-- **The diagonal real is missing from the enumeration** — the set-theoretic form of
+`diagonalReal_ne` and of this problem's title.  `diagonalReal f` lies outside `Set.range f`,
+so no enumeration `f : ℕ → ℝ` lists it. -/
+theorem diagonalReal_notMem_range (f : ℕ → ℝ) : diagonalReal f ∉ Set.range f := by
+  rintro ⟨n, hn⟩
+  exact diagonalReal_ne f n hn.symm
+
+/-- **The range of any enumeration is a proper subset of `ℝ`.**  `Set.range f ≠ Set.univ`,
+exhibited by the explicit missing witness `diagonalReal f`; the `Set.range` restatement of
+`not_surjective_nat_real`. -/
+theorem range_ne_univ (f : ℕ → ℝ) : Set.range f ≠ Set.univ := by
+  intro h
+  apply diagonalReal_notMem_range f
+  rw [h]
+  exact Set.mem_univ _
+
+-- Axiom audit: the new results are axiom-free (only propext/Classical.choice/Quot.sound).
+#print axioms diagonalReal_eq_iff_db
+#print axioms diagonalReal_notMem_range
+
 end CantorDiagonalizationOQ06OQ01

--- a/research/problems/cantor-diagonalization-oq-06-oq-01/state.md
+++ b/research/problems/cantor-diagonalization-oq-06-oq-01/state.md
@@ -1,16 +1,46 @@
 # Research State: cantor-diagonalization-oq-06-oq-01
 
 ## Current State
-**Phase**: OBSERVE
+**Phase**: ACT
 **Path**: full
 **Since**: 2026-07-09T16:43:20-07:00
-**Iteration**: 1
+**Iteration**: 2
 
 ## Current Focus
-Initial problem understanding. Read problem.md and gather context.
+Core goal COMPLETE on main: `CantorDiagonalizationOQ06OQ01.lean` defines the explicit
+`diagonalReal : (ℕ → ℝ) → ℝ` with `diagonalReal_ne`, `uncountable_real`, all cardinality-free,
+0 sorry / 0 axiom. Now extending the structural theory around the construction.
+
+## Iteration 2 (researcher-7, 2026-07-12) — injectivity on digit-choices + set-form [VERIFIED, axiom-free]
+The file had `diagonalReal_congr` (the diagonal map is *constant* on enumerations sharing
+a diagonal digit-sequence) but not its converse. Added the separating direction and the
+set-theoretic "missing from the enumeration" form (docker build OK, 7743 jobs; new
+capstones `[propext, Classical.choice, Quot.sound]`):
+- `db_eq_of_diagonalReal_eq`: `diagonalReal f = diagonalReal g → ∀ n, db f n = db g n` —
+  converse of `diagonalReal_congr`, straight from the crux `digit_diagonalReal` (reading
+  the n-th digit back off each side).
+- `diagonalReal_eq_iff_db`: the exact biconditional `= ↔ ∀ n, db f n = db g n`; sharpens
+  `diagonalReal_congr` (sufficient digit-equality hypothesis) to the `{1,2}`-choice level.
+- `diagonalReal_ne_of_db_ne`: contrapositive separation — one differing choice forces
+  distinct reals; with `diagonalReal_mono` the map is an order-preserving embedding.
+- `diagonalReal_notMem_range` / `range_ne_univ`: `Set.range`-level forms matching the
+  problem title ("missing from any listed enumeration"); previously only pointwise `≠` and
+  `¬ Surjective` were present.
 
 ## Active Approach
-None yet.
+Structural theory of the explicit diagonal map (locality ↔ injectivity, range forms).
+
+Note (concurrent work): a parallel researcher independently landed the explicit
+`(ℕ → Bool) ↪ ℝ` injection (`seqReal`, `seqReal_injective`, `seqEmbedding`,
+`mk_seq_le_mk_real`) on `main` — the "large side" (`𝔠 ≤ #ℝ`) direction I had flagged as
+next. My contribution merged cleanly alongside it (no name/def collisions) and is in fact
+the more general reason their `seqReal_injective` holds: it is the `s = indicator listing`
+instance of `db_eq_of_diagonalReal_eq` / `diagonalReal_eq_iff_db`.
+
+Remaining candidates: refactor `seqReal_injective` to go through `db_eq_of_diagonalReal_eq`;
+surjectivity of the diagonal map onto the `{1,2}`-digit Cantor set (`Set.range diagonalReal
+= {Σ cₙ/10^{n+1} : cₙ ∈ {1,2}}`); a decimal analogue avoiding 0/9 with a full 10-symbol
+alphabet.
 
 ## Attempt Count
 - Total attempts: 0


### PR DESCRIPTION
## Summary
Adds the **converse of `diagonalReal_congr`** and the set-theoretic "missing from the enumeration" forms to `CantorDiagonalizationOQ06OQ01.lean`. The file's explicit constructive diagonal (`diagonalReal`, `diagonalReal_ne`, `uncountable_real`, all cardinality-free) already had the *locality* half — the diagonal map is constant on enumerations sharing a diagonal digit-sequence (`diagonalReal_congr`) — but not the *separating* half. This PR supplies it.

Purely additive (5 new theorems); merges cleanly alongside the concurrently-landed `(ℕ → Bool) ↪ ℝ` injection (`seqReal`/`seqEmbedding`) on main — no name or definition collisions.

## Progress
- `db_eq_of_diagonalReal_eq` : `diagonalReal f = diagonalReal g → ∀ n, db f n = db g n` — the converse of `diagonalReal_congr`, straight from the crux `digit_diagonalReal` (each side's `n`-th digit reads back `db · n`).
- `diagonalReal_eq_iff_db` : the exact biconditional `diagonalReal f = diagonalReal g ↔ ∀ n, db f n = db g n`; sharpens `diagonalReal_congr` (whose digit-equality hypothesis is merely *sufficient*) to the `{1,2}`-digit-choice level. This is the general reason the concurrent `seqReal_injective` holds — the latter is its indicator-listing instance.
- `diagonalReal_ne_of_db_ne` : contrapositive separation — one differing choice forces distinct reals; with `diagonalReal_mono` the construction is an order-preserving embedding of digit-choice sequences.
- `diagonalReal_notMem_range` / `range_ne_univ` : `Set.range`-level forms matching the problem's title ("missing from any listed enumeration"); the file previously had only the pointwise `≠` and `¬ Surjective` forms.

## Findings
- Verified via Docker (7743 jobs). New capstones `diagonalReal_eq_iff_db`, `diagonalReal_notMem_range` depend only on `[propext, Classical.choice, Quot.sound]` — axiom-free, no cardinality, consistent with the file's constructive theme.

## Status
**Outcome**: progress (structural theory around the explicit diagonal map)
**Next Steps**: refactor `seqReal_injective` through `db_eq_of_diagonalReal_eq`; surjectivity of `diagonalReal` onto the `{1,2}`-digit Cantor set; a full 10-symbol decimal analogue avoiding 0/9.

🤖 Generated by researcher-7