### PR TITLE
Research: erdos-771 — matching general lower bound (exact max n − ⌈m/2⌉)

### DIFF
--- a/proofs/Proofs/Erdos771GeneralLowerBound.lean
+++ b/proofs/Proofs/Erdos771GeneralLowerBound.lean
@@ -1,0 +1,93 @@
+/-
+# Erdős Problem #771 — the matching general lower bound (tight construction)
+
+`Erdos771GeneralUpperBound.lean` proves that for `1 ≤ m ≤ n` every `m`-avoiding subset of
+`{1,…,n}` has size at most `n − ⌈m/2⌉`.  This file supplies the **matching construction**,
+showing that value is achieved: there is an `m`-avoiding `S ⊆ {1,…,n}` with `|S| = n − ⌈m/2⌉`.
+
+The witness is uniform across all `m` (no case analysis):
+
+    S = {⌈m/2⌉, ⌈m/2⌉+1, …, n} \ {m}     (delete the `⌈m/2⌉−1` smallest, and `m` itself).
+
+Every element of `S` is either `≥ ⌈m/2⌉` and `< m`, or `> m`.  A nonempty subset summing to
+`m` cannot use anything `> m`; so it lives in `{⌈m/2⌉,…,m−1}`.  A single such element is `< m`;
+any two distinct ones sum to `≥ ⌈m/2⌉ + (⌈m/2⌉+1) = 2⌈m/2⌉ + 1 > m`.  So no subset of `S` sums
+to `m`, i.e. `S` avoids `m`, and `|S| = (n − ⌈m/2⌉ + 1) − 1 = n − ⌈m/2⌉`.
+
+Together with `avoid_card_le_general` (the upper bound) this pins the exact maximum
+`f_m(n) = n − ⌈m/2⌉` for the whole small-`m` regime `1 ≤ m ≤ n`.
+
+All results are `0`-sorry / `0`-axiom on top of Mathlib and `Erdos771Construction`.
+-/
+import Mathlib
+import Proofs.Erdos771Construction
+
+open Finset
+
+namespace Erdos771GeneralLowerBound
+
+open Erdos771Construction
+
+/-- The uniform witness `{⌈m/2⌉,…,n} \ {m}`.  (`⌈m/2⌉ = (m+1)/2` in `ℕ`.) -/
+def avoider (n m : ℕ) : Finset ℕ := (Finset.Icc ((m + 1) / 2) n).erase m
+
+/-- The witness lies in `{1,…,n}` (for `1 ≤ m`, so `⌈m/2⌉ ≥ 1`). -/
+theorem avoider_subset (n m : ℕ) (hm : 1 ≤ m) : avoider n m ⊆ Icc_n n := by
+  intro x hx
+  rw [avoider, Finset.mem_erase, Finset.mem_Icc] at hx
+  rw [Icc_n, Finset.mem_Icc]
+  omega
+
+/-- The witness has size `n − ⌈m/2⌉`. -/
+theorem avoider_card (n m : ℕ) (hm : 1 ≤ m) (hmn : m ≤ n) :
+    (avoider n m).card = n - (m + 1) / 2 := by
+  have hmem : m ∈ Finset.Icc ((m + 1) / 2) n := by rw [Finset.mem_Icc]; omega
+  rw [avoider, Finset.card_erase_of_mem hmem, Nat.card_Icc]
+  omega
+
+/-- **The witness avoids the sum `m`.**  No nonempty subset of `{⌈m/2⌉,…,n} \ {m}` sums to `m`:
+    a single element is `≠ m`, and two distinct elements each `≥ ⌈m/2⌉` already sum past `m`. -/
+theorem avoider_avoids (n m : ℕ) (hm : 1 ≤ m) (_hmn : m ≤ n) :
+    AvoidSum (avoider n m) m := by
+  intro hmem
+  rw [subsetSums, Finset.mem_filter, Finset.mem_image] at hmem
+  obtain ⟨⟨A, hApow, hAsum⟩, _hpos⟩ := hmem
+  rw [Finset.mem_powerset] at hApow
+  -- Every element of `A` is `≥ ⌈m/2⌉` and `≠ m`.
+  have hAle : ∀ a ∈ A, (m + 1) / 2 ≤ a ∧ a ≠ m := by
+    intro a ha
+    have hmemA := hApow ha
+    rw [avoider, Finset.mem_erase, Finset.mem_Icc] at hmemA
+    exact ⟨hmemA.2.1, hmemA.1⟩
+  -- `A` is nonempty because its sum is `m ≥ 1`.
+  have hAne : A.Nonempty := by
+    rcases Finset.eq_empty_or_nonempty A with rfl | h
+    · simp only [Finset.sum_empty] at hAsum; omega
+    · exact h
+  by_cases hc : 2 ≤ A.card
+  · -- Two distinct elements each `≥ ⌈m/2⌉` sum past `m`.
+    obtain ⟨a, ha, b, hb, hab⟩ := Finset.one_lt_card.mp hc
+    have haK := (hAle a ha).1
+    have hbK := (hAle b hb).1
+    have hsplit : ∑ x ∈ A, x = a + ∑ x ∈ A.erase a, x :=
+      (Finset.add_sum_erase A (fun x => x) ha).symm
+    have hble : b ≤ ∑ x ∈ A.erase a, x :=
+      Finset.single_le_sum (f := fun x => x) (fun _ _ => Nat.zero_le _)
+        (Finset.mem_erase.mpr ⟨hab.symm, hb⟩)
+    omega
+  · -- `A` is a singleton `{a}` with `a = m`, impossible since `a ≠ m`.
+    have h1 : A.card = 1 := by
+      have := Finset.card_pos.mpr hAne; omega
+    rw [Finset.card_eq_one] at h1
+    obtain ⟨a, rfl⟩ := h1
+    simp only [Finset.sum_singleton] at hAsum
+    exact (hAle a (Finset.mem_singleton_self a)).2 hAsum
+
+/-- **Tight lower bound for Erdős #771 (small-`m` regime).**  For `1 ≤ m ≤ n` there is an
+    `m`-avoiding subset of `{1,…,n}` of size exactly `n − ⌈m/2⌉`.  With `avoid_card_le_general`
+    (the upper bound) this shows the maximum is exactly `n − ⌈m/2⌉`. -/
+theorem exists_avoiding_card_eq (n m : ℕ) (hm : 1 ≤ m) (hmn : m ≤ n) :
+    ∃ S : Finset ℕ, S ⊆ Icc_n n ∧ AvoidSum S m ∧ S.card = n - (m + 1) / 2 :=
+  ⟨avoider n m, avoider_subset n m hm, avoider_avoids n m hm hmn, avoider_card n m hm hmn⟩
+
+end Erdos771GeneralLowerBound

--- a/research/problems/erdos-771/knowledge.md
+++ b/research/problems/erdos-771/knowledge.md
@@ -235,3 +235,25 @@ Next ladder rung m=5 first drops to n−3 (reps `{5},{1,4},{2,3}` — two disjoi
 - Deep asymptotics `f(n)=(1/2+o(1))·n/log n` (Erdős–Graham / Alon–Freiman) remain BLOCKED.
 - Matching general LOWER bound (a witness of size `n − ⌈m/2⌉` for every `m ≤ n`) — the tightness
   half; the per-m witnesses `{1,…,n}∖(hitting set)` exist for m=1..4, general construction is next.
+
+## Session 2026-07-12 (researcher-2, cont.) — MATCHING general LOWER bound (exact max n − ⌈m/2⌉)
+
+**Outcome**: progress (0-sorry/0-axiom, VERIFIED `lake env lean`). Added to branch/PR of the
+upper bound (#38524). Together they pin the EXACT maximum `f_m(n) = n − ⌈m/2⌉` for `1 ≤ m ≤ n`.
+
+### What I Did — `Erdos771GeneralLowerBound.lean` (5 decls)
+- Uniform tight witness `avoider n m := (Finset.Icc ((m+1)/2) n).erase m` (delete the ⌈m/2⌉−1
+  smallest AND m itself). No case analysis on m.
+- `avoider_avoids`: a nonempty subset summing to m lives in {⌈m/2⌉,…,m−1} (bigger elements
+  overshoot); a single one is <m, two distinct are ≥ ⌈m/2⌉+(⌈m/2⌉+1)=2⌈m/2⌉+1 > m ⟹ none sums
+  to m. `avoider_card` = n − ⌈m/2⌉; `avoider_subset ⊆ {1,…,n}`; `exists_avoiding_card_eq` packages.
+
+### Key formalization facts
+- Two distinct elements a≠b both ≥K ⟹ a+b ≥ 2K+1 is pure `omega` (feed a≠b, K≤a, K≤b).
+- `Finset.add_sum_erase A (fun x=>x) ha` (= a + Σ_{erase} = Σ) + `Finset.single_le_sum` bound b
+  ≤ Σ_{erase}, then `omega` closes vs Σ=m using 2*((m+1)/2) ≥ m.
+- singleton case: `Finset.card_eq_one` after `card_pos` (nonempty since Σ=m≥1) + a≠m.
+
+### Status
+Small-m regime (1≤m≤n) now EXACTLY resolved: max avoiding-set size = n − ⌈m/2⌉ (upper #38524 +
+this lower). Deep asymptotics f(n)=(1/2+o(1))·n/log n (Erdős–Graham/Alon–Freiman) remain BLOCKED.

--- a/src/data/research/problems/erdos-771.json
+++ b/src/data/research/problems/erdos-771.json
@@ -9,7 +9,7 @@
   "knownResults": "SOLVED: f(n) = (1/2 + o(1))·n/log n (Erdős–Graham lower bound via prime multiples; Alon–Freiman upper bound via LCM).",
   "currentState": "Verified the elementary Erdős–Graham construction in a new self-contained file; the deep asymptotics remain axiomatized in the companion file.",
   "knowledge": {
-    "progressSummary": "PROGRESS: Proved the GENERAL optimality upper bound |S| ≤ n − ⌈m/2⌉ for m-avoiding S⊆{1,…,n} (1≤m≤n) via a disjoint family of m-representations — subsumes the four hand-proved per-m rungs at once and settles the small-m regime. 0-sorry/0-axiom. Deep asymptotics remain blocked.",
+    "progressSummary": "PROGRESS: EXACT maximum for Erdős #771 small-m regime pinned — f_m(n)=n−⌈m/2⌉ for 1≤m≤n, via general upper bound (disjoint m-representation blocks) + matching tight construction avoider=(Icc ⌈m/2⌉ n).erase m. Both 0-sorry/0-axiom. Deep asymptotics f(n)=(1/2+o(1))n/log n remain blocked.",
     "builtItems": [
       "prime_multiples_size in Erdos771Construction.lean:64",
       "prime_multiples_avoid in Erdos771Construction.lean:78",
@@ -27,7 +27,8 @@
       "subsetSums_Icc_n (Erdos771Problem.lean): subsetSums {1,…,n} = Icc 1 (n(n+1)/2)",
       "avoid_full_iff (Erdos771Problem.lean): AvoidSum {1,…,n} m ↔ m=0 ∨ n(n+1)/2 < m (sharp)",
       "maxAvoidingSize_eq_n_iff (Erdos771Problem.lean): maxAvoidingSize n m = n ↔ m=0 ∨ n(n+1)/2 < m",
-      "avoid_card_le_general + supporting blk/blk_sum/blk_subset/blk_disjoint/sum_mem_subsetSums + avoid_card_le_general_matches_ladder in Erdos771GeneralUpperBound.lean (7 decls, 0-sorry/0-axiom)"
+      "avoid_card_le_general + supporting blk/blk_sum/blk_subset/blk_disjoint/sum_mem_subsetSums + avoid_card_le_general_matches_ladder in Erdos771GeneralUpperBound.lean (7 decls, 0-sorry/0-axiom)",
+      "avoider + avoider_subset/avoider_card/avoider_avoids + exists_avoiding_card_eq in Erdos771GeneralLowerBound.lean (5 decls, 0-sorry/0-axiom)"
     ],
     "insights": [
       "If every element of S is a multiple of p, so is every subset sum, so S avoids any m with p ∤ m — the engine of the Erdős–Graham lower bound. Primality is not even needed for avoidance.",
@@ -37,7 +38,8 @@
       "Sharp closed-form lower bound maxAvoidingSize n m >= n - ceil(m/2) (= n-(m+1)/2) for 1<=m<=n, via witness S = {ceil(m/2),...,n} \\ {m}: strictly beats interval_avoiding_lower (n-m) and is TIGHT — matches exact m=1..4 values (n-1,n-1,n-2,n-2). Conjecture (upper bound, follow-up): equality holds via ceil(m/2) pairwise-disjoint sum-m subsets {m},{i,m-i}.",
       "EXACT closed form maxAvoidingSize n m = n - ceil(m/2) (= n - (m+1)/2) for 1<=m<=n, upgrading the previously one-sided lower bound to equality. Upper bound: any m-avoiding S in {1..n} keeps at most floor(m/2) elements of {1..m}, since x |-> min x (m-x) injects S cap {1..m} into {1..floor(m/2)} (a collision forces two distinct elements summing to m, a forbidden subset sum), plus at most n-m elements above m. Recovers the tabulated small-m values n-1,n-1,n-2,n-2 for m=1..4 uniformly. Axiom-free (Erdos771Problem.lean: maxAvoidingSize_le_sub_ceil_half, maxAvoidingSize_eq_sub_ceil_half).",
       "Sharp avoidance threshold: {1,…,n} is a COMPLETE sequence — its subset sums realise EVERY value in [1, n(n+1)/2]. Hence the full box avoids m iff m=0 or m > n(n+1)/2, and maxAvoidingSize n m = n exactly on that boundary. Sharpens the crude n²<m threshold of avoid_full/maxAvoidingSize_eq_of_lt to the exact total n(n+1)/2.",
-      "GENERAL upper bound (small-m regime): any m-avoiding S⊆{1,…,n} with 1≤m≤n has |S| ≤ n − ⌈m/2⌉. Mechanism: the ⌈m/2⌉ representations {m},{1,m−1},…,{i,m−i} are pairwise-disjoint m-summing subsets of {1,…,n}; an avoiding set omits ≥1 element from each, forcing ⌈m/2⌉ distinct deletions. Subsumes the m=1..4 ladder uniformly."
+      "GENERAL upper bound (small-m regime): any m-avoiding S⊆{1,…,n} with 1≤m≤n has |S| ≤ n − ⌈m/2⌉. Mechanism: the ⌈m/2⌉ representations {m},{1,m−1},…,{i,m−i} are pairwise-disjoint m-summing subsets of {1,…,n}; an avoiding set omits ≥1 element from each, forcing ⌈m/2⌉ distinct deletions. Subsumes the m=1..4 ladder uniformly.",
+      "EXACT maximum (small-m regime): the largest m-avoiding S⊆{1,…,n} for 1≤m≤n has size EXACTLY n−⌈m/2⌉. Upper bound = avoid_card_le_general (disjoint blocks); matching lower = tight witness avoider n m = (Icc ⌈m/2⌉ n).erase m (any subset summing to m needs ≥2 elements ≥⌈m/2⌉, summing >m)."
     ],
     "mathlibGaps": [],
     "nextSteps": [


### PR DESCRIPTION
## Summary

Follow-up to the merged upper bound (#38524). New file `Erdos771GeneralLowerBound.lean` (5 declarations, **0-sorry / 0-axiom**, `lake env lean`-verified; `#print axioms` = the 3 foundational axioms only) supplies the **matching tight construction**, so the maximum is now pinned **exactly**:
```
max { |S| : S ⊆ {1,…,n}, S avoids the subset sum m }  =  n − ⌈m/2⌉   (for 1 ≤ m ≤ n).
```

## The construction — a uniform witness, no case analysis
```
avoider n m = (Icc ⌈m/2⌉ n).erase m        -- delete the ⌈m/2⌉−1 smallest elements, and m
```
- `avoider_avoids` — it avoids `m`: a nonempty subset summing to `m` must live in `{⌈m/2⌉,…,m−1}` (anything `> m` overshoots); a single such element is `< m`, and two distinct ones sum to `≥ ⌈m/2⌉ + (⌈m/2⌉+1) = 2⌈m/2⌉+1 > m`, so nothing sums to `m`.
- `avoider_card` — `|avoider n m| = n − ⌈m/2⌉`; `avoider_subset` — `⊆ {1,…,n}`.
- `exists_avoiding_card_eq` — packages the existence of an `m`-avoiding subset of size exactly `n − ⌈m/2⌉`.

Combined with `avoid_card_le_general` (merged in #38524) this settles the exact value across the whole small-`m` regime. The deep asymptotics `f(n) = (1/2 + o(1)) n / log n` remain out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)