### PR TITLE
research(erdos-666-incomplete-01): subgraph monotonicity of the cycle predicates

### DIFF
--- a/proofs/Proofs/Erdos666Monotone.lean
+++ b/proofs/Proofs/Erdos666Monotone.lean
@@ -1,0 +1,101 @@
+/-
+# Erdős Problem #666 — subgraph monotonicity of the cycle predicates
+
+Research: erdos-666-incomplete-01
+
+The companion `Erdos666Problem.lean` sets up the `C₂ₖ`-in-hypercube apparatus:
+`HasCycle G k` (a `k`-cycle in `G`), its named cases `HasC4`, `HasC6`, `HasC2k`, the
+`ε`-dense-subgraph predicate, and the refutation of Erdős's conjecture via the deep
+Chung and Conder inputs (recorded as axioms).  The whole framing is about **subgraphs**
+of `Qₙ` — the `DenseSubgraph` structure carries `isSubgraph : ∀ x y, graph.Adj x y →
+G.Adj x y` — yet the elementary structural fact that makes "subgraph" the right notion is
+missing: *cycles are monotone under subgraph inclusion.*
+
+This file supplies it, axiom-free.  A `k`-cycle is a witness `Fin k → V` whose consecutive
+images are adjacent; if `H`'s adjacency is contained in `G`'s, the very same witness is a
+`k`-cycle of `G`.  Consequences:
+
+* `hasCycle_mono` / `hasC4_mono` / `hasC6_mono` / `hasC2k_mono` — a cycle in a subgraph is a
+  cycle in the ambient graph.
+* `not_hasCycle_of_le` / `not_hasC6_of_le` — the contrapositive: `C₂ₖ`-freeness is
+  **hereditary to subgraphs**.  This is exactly the property the Chung/Conder edge-partition
+  arguments rely on — each colour class is a subgraph, so a `C₆`-free ambient graph gives
+  `C₆`-free classes.
+* `not_hasCycle_bot` — the empty graph has no cycle of any length, generalizing the file's
+  `not_hasC6_bot` (which fixed `k = 6` and `V = Fin (2ⁿ)`) to all `k` and all `V`.
+* `DenseSubgraph.not_hasC6` — the packaged application: a dense subgraph of a `C₆`-free graph
+  is itself `C₆`-free.
+
+Everything is `propext`/`Classical.choice`/`Quot.sound`-only; none of the deep Chung/Conder
+axioms are invoked.
+-/
+import Mathlib
+import Proofs.Erdos666Problem
+
+open SimpleGraph
+
+namespace Erdos666
+
+variable {V : Type*}
+
+/-! ### Subgraph monotonicity of `HasCycle` -/
+
+unseal HasCycle in
+/-- **A cycle in a subgraph is a cycle in the ambient graph.**  If every edge of `H` is an
+edge of `G` (`H ≤ G` in adjacency), then any `k`-cycle witness of `H` — an injective
+`Fin k → V` with adjacent consecutive images — has adjacent consecutive images in `G` too, so
+it witnesses `HasCycle G k`. -/
+theorem hasCycle_mono {H G : SimpleGraph V} {k : ℕ}
+    (hle : ∀ x y, H.Adj x y → G.Adj x y) (h : HasCycle H k) : HasCycle G k := by
+  obtain ⟨cycle, hinj, hadj, hk⟩ := h
+  exact ⟨cycle, hinj, fun i => hle _ _ (hadj i), hk⟩
+
+/-- **`C_k`-freeness is hereditary to subgraphs.**  Contrapositive of `hasCycle_mono`: if the
+ambient `G` has no `k`-cycle then neither does any subgraph `H ≤ G`. -/
+theorem not_hasCycle_of_le {H G : SimpleGraph V} {k : ℕ}
+    (hle : ∀ x y, H.Adj x y → G.Adj x y) (h : ¬ HasCycle G k) : ¬ HasCycle H k :=
+  fun hH => h (hasCycle_mono hle hH)
+
+unseal HasCycle in
+/-- **The empty graph has no cycle of any length.**  `⊥` has no edges, so the adjacency
+requirement fails at the first vertex of any putative cycle (`k ≥ 3 > 0` supplies an index).
+Generalizes the file's `not_hasC6_bot` from `k = 6`, `V = Fin (2ⁿ)` to arbitrary `k` and `V`. -/
+theorem not_hasCycle_bot {k : ℕ} : ¬ HasCycle (⊥ : SimpleGraph V) k := by
+  rintro ⟨cycle, -, hadj, hk⟩
+  simpa using hadj ⟨0, by omega⟩
+
+/-! ### The named cases `C₄`, `C₆`, `C₂ₖ` -/
+
+unseal HasC6 in
+/-- **`C₆` monotonicity:** a `C₆` in a subgraph is a `C₆` in the ambient graph. -/
+theorem hasC6_mono {H G : SimpleGraph V}
+    (hle : ∀ x y, H.Adj x y → G.Adj x y) (h : HasC6 H) : HasC6 G :=
+  hasCycle_mono hle h
+
+unseal HasC6 in
+/-- **`C₆`-freeness is hereditary to subgraphs** — the exact property the edge-partition
+refutations use (each colour class is a subgraph of `Qₙ`). -/
+theorem not_hasC6_of_le {H G : SimpleGraph V}
+    (hle : ∀ x y, H.Adj x y → G.Adj x y) (h : ¬ HasC6 G) : ¬ HasC6 H :=
+  fun hH => h (hasC6_mono hle hH)
+
+/-- **`C₄` monotonicity.** -/
+theorem hasC4_mono {H G : SimpleGraph V}
+    (hle : ∀ x y, H.Adj x y → G.Adj x y) (h : HasC4 H) : HasC4 G :=
+  hasCycle_mono hle h
+
+/-- **`C₂ₖ` monotonicity**, uniformly in `k`. -/
+theorem hasC2k_mono {H G : SimpleGraph V} {k : ℕ}
+    (hle : ∀ x y, H.Adj x y → G.Adj x y) (h : HasC2k H k) : HasC2k G k :=
+  hasCycle_mono hle h
+
+/-! ### Application to the dense-subgraph structure -/
+
+/-- **A dense subgraph of a `C₆`-free graph is `C₆`-free.**  Packages `not_hasC6_of_le` with
+the `DenseSubgraph.isSubgraph` field: the underlying graph of any `DenseSubgraph G m` is a
+subgraph of `G`, so `C₆`-freeness of `G` transfers to it regardless of the edge count `m`. -/
+theorem DenseSubgraph.not_hasC6 {G : SimpleGraph V} [Fintype V] [DecidableRel G.Adj] {m : ℕ}
+    (D : DenseSubgraph G m) (hG : ¬ HasC6 G) : ¬ HasC6 D.graph :=
+  not_hasC6_of_le D.isSubgraph hG
+
+end Erdos666

--- a/research/problems/erdos-666-incomplete-01/knowledge.md
+++ b/research/problems/erdos-666-incomplete-01/knowledge.md
@@ -208,3 +208,25 @@ specialization of `conder_no_threshold_le` + monotonicity** — rejected as fill
 role's quality bar. The genuinely-open core (constant-fraction `C₂ₖ`-free for `k ≥ 4`; dense
 `C₄,C₆`-free ⇒ `C₈`; explicit Conder 3-colouring to eliminate the axiom) is all
 open/session-oversized. Frontier unchanged.
+
+## Session (researcher-3): subgraph monotonicity of the cycle predicates
+
+Added `Erdos666Monotone.lean` (8 theorems, 0 axioms — several depend on *no* axioms at all,
+the rest only `[propext, Classical.choice, Quot.sound]`; none invoke Chung/Conder). This is
+the **graph-theoretic layer**, orthogonal to the (saturated) ε-density layer: the file's
+whole framing is about *subgraphs* of Qₙ yet lacked the basic fact that cycles are monotone
+under subgraph inclusion.
+
+- `hasCycle_mono`: `(∀ x y, H.Adj x y → G.Adj x y) → HasCycle H k → HasCycle G k` (same cycle
+  witness lifts). Named cases `hasC4_mono`, `hasC6_mono`, `hasC2k_mono`.
+- `not_hasCycle_of_le` / `not_hasC6_of_le`: **C₂ₖ-freeness is hereditary to subgraphs** — the
+  formal justification for "each colour class is C₆-free" in the Chung/Conder edge-partition
+  refutations.
+- `not_hasCycle_bot`: generalizes the file's `not_hasC6_bot` from `k=6`, `V=Fin(2ⁿ)` to all
+  `k` and all `V`.
+- `DenseSubgraph.not_hasC6`: packaged application — a dense subgraph of a C₆-free graph is
+  C₆-free (uses the `DenseSubgraph.isSubgraph` field, any edge count `m`).
+
+★`unseal HasCycle in` / `unseal HasC6 in` must precede the docstring, not follow it (else
+"unexpected token 'unseal'; expected 'lemma'"). Frontier otherwise unchanged (constant-fraction
+C₂ₖ-free for k≥4, dense C₄,C₆-free ⇒ C₈, explicit Conder 3-colouring remain open).


### PR DESCRIPTION
## Summary

Adds `Erdos666Monotone.lean` to Erdős #666 (C₆ in hypercube subgraphs). The companion `Erdos666Problem.lean` builds the `C₂ₖ`-in-hypercube apparatus and refutes Erdős's conjecture via the deep Chung/Conder inputs (axiomatized). The entire framework is about **subgraphs** of `Qₙ` — `DenseSubgraph` even carries `isSubgraph : ∀ x y, graph.Adj x y → G.Adj x y` — yet the elementary structural fact that makes "subgraph" the right notion was missing: *cycles are monotone under subgraph inclusion*.

This file supplies it, axiom-free. A `k`-cycle is an injective witness `Fin k → V` with adjacent consecutive images; if `H`'s adjacency is contained in `G`'s, the same witness is a `k`-cycle of `G`.

## Theorems (8, axiom-free)

- `hasCycle_mono` — `(∀ x y, H.Adj x y → G.Adj x y) → HasCycle H k → HasCycle G k`; named cases `hasC4_mono`, `hasC6_mono`, `hasC2k_mono`.
- `not_hasCycle_of_le` / `not_hasC6_of_le` — the contrapositive: **`C₂ₖ`-freeness is hereditary to subgraphs**, the exact property the Chung/Conder edge-partition arguments rely on (each colour class is a subgraph, so a `C₆`-free ambient graph gives `C₆`-free classes).
- `not_hasCycle_bot` — the empty graph has no cycle of any length, generalizing the file's `not_hasC6_bot` (fixed `k=6`, `V=Fin(2ⁿ)`) to all `k` and all `V`.
- `DenseSubgraph.not_hasC6` — packaged application: a dense subgraph of a `C₆`-free graph is itself `C₆`-free.

This is the graph-theoretic layer, orthogonal to the ε-density threshold layer (which a prior session recorded as saturated).

## Verification

- Built with `./proofs/scripts/docker-build.sh Proofs.Erdos666Monotone` → `✔ Built`, 0 errors.
- `#print axioms`: `hasCycle_mono` and `not_hasC6_of_le` depend on **no axioms**; `not_hasCycle_bot` and `DenseSubgraph.not_hasC6` on `[propext, Classical.choice, Quot.sound]` only. **No sorry, no native_decide; the deep Chung/Conder axioms are not invoked.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)