### PR TITLE
Research: combinations-formula-oq-03-oq-04 — coefficient palindromy of Gaussian polynomials over ℤ[X]

### DIFF
--- a/proofs/Proofs/CombinationsFormulaOQ03OQ04.lean
+++ b/proofs/Proofs/CombinationsFormulaOQ03OQ04.lean
@@ -259,6 +259,99 @@ theorem qBinom_X_extreme_coeffs {n k : ℕ} (h : k ≤ n) :
     (qBinom (X : ℤ[X]) n k).coeff (k * (n - k)) = 1 :=
   ⟨qBinom_X_coeff_zero n k h, qBinom_X_coeff_top h⟩
 
+/-! ### Coefficient palindromy over `ℤ[X]`
+
+The self-reciprocity `qBinom_reciprocal` lives over a *field* (it divides by `q`).  Its
+coefficient-level shadow — that the coefficient array of the Gaussian polynomial reads the same
+forwards and backwards — is an integral statement, cleanly captured by `Polynomial.reflect`:
+`reflect (k(n-k)) (qBinom X n k) = qBinom X n k`.  We prove it directly over `ℤ[X]`, with no field
+hypothesis, by induction on the `q`-Pascal recurrence.  The mechanism mirrors the field proof:
+reflecting the **first** Pascal expansion `qBinom X n k + X^{k+1}·qBinom X n (k+1)` term-by-term
+(`reflect_add`, `reflect_mul`) turns it into `X^{n-k}·qBinom X n k + qBinom X n (k+1)`, which is
+exactly the **second** Pascal expansion `qBinom_pascal'` of the same polynomial.  This is the
+rigorous "symmetric" half of Sylvester's symmetric-unimodal theorem; the unimodal half stays open. -/
+
+open Polynomial in
+/-- **Coefficient palindromy of the Gaussian polynomial.**  For `k ≤ n`, `qBinom X n k : ℤ[X]` is
+its own reflection at its degree `k(n-k)`:
+
+    reflect (k * (n - k)) (qBinom X n k) = qBinom X n k.
+
+Equivalently its coefficient sequence is a palindrome.  This is the integral, coefficient-level
+form of the field identity `qBinom_reciprocal`.  Induction on the `q`-Pascal recurrence: reflecting
+the first Pascal expansion `A + X^{k+1}·B` gives `X^{n-k}·A + B`, the second Pascal expansion
+(`qBinom_pascal'`) of the same polynomial. -/
+theorem qBinom_X_reflect :
+    ∀ (n k : ℕ), k ≤ n →
+      reflect (k * (n - k)) (qBinom (X : ℤ[X]) n k) = qBinom (X : ℤ[X]) n k
+  | n, 0, _ => by
+      simp only [Nat.zero_mul, qBinom_zero_right]
+      rw [show (1 : ℤ[X]) = C 1 * X ^ 0 by simp, reflect_C_mul_X_pow]; simp
+  | 0, k + 1, h => by omega
+  | n + 1, k + 1, h => by
+      rw [show (n + 1) - (k + 1) = n - k from by omega]
+      rcases eq_or_lt_of_le h with heq | hlt
+      · -- diagonal `k = n`: the polynomial is `1`, degree `0`
+        have hkn : k = n := by omega
+        subst hkn
+        rw [show k - k = 0 from Nat.sub_self k, Nat.mul_zero, qBinom_self]
+        rw [show (1 : ℤ[X]) = C 1 * X ^ 0 by simp, reflect_C_mul_X_pow]; simp
+      · -- interior `k < n`
+        have hk1n : k + 1 ≤ n := by omega
+        have hkn : k ≤ n := by omega
+        obtain ⟨_, dA⟩ := qBinom_X_monic_natDegree n k hkn
+        obtain ⟨_, dB⟩ := qBinom_X_monic_natDegree n (k + 1) hk1n
+        have ihA := qBinom_X_reflect n k hkn
+        have ihB := qBinom_X_reflect n (k + 1) hk1n
+        rw [show n - (k + 1) = n - k - 1 from by omega] at dB ihB
+        -- reflect of the first summand `A`: `reflect (k+1)(n-k) A = X^{n-k} · A`
+        have hPA : reflect ((k + 1) * (n - k)) (qBinom (X : ℤ[X]) n k)
+            = X ^ (n - k) * qBinom (X : ℤ[X]) n k := by
+          have hm := reflect_mul (1 : ℤ[X]) (qBinom (X : ℤ[X]) n k)
+            (show (1 : ℤ[X]).natDegree ≤ n - k by simp)
+            (show (qBinom (X : ℤ[X]) n k).natDegree ≤ k * (n - k) from le_of_eq dA)
+          rw [one_mul, ihA] at hm
+          rw [show (k + 1) * (n - k) = (n - k) + k * (n - k) from by ring, hm]
+          congr 1
+          rw [show (1 : ℤ[X]) = X ^ 0 from (pow_zero X).symm, reflect_monomial,
+            revAt_le (Nat.zero_le _), Nat.sub_zero]
+        -- reflect of the second summand `X^{k+1}·B`: `reflect (k+1)(n-k) (X^{k+1}·B) = B`
+        have hPB : reflect ((k + 1) * (n - k))
+            ((X : ℤ[X]) ^ (k + 1) * qBinom (X : ℤ[X]) n (k + 1))
+            = qBinom (X : ℤ[X]) n (k + 1) := by
+          have hm := reflect_mul ((X : ℤ[X]) ^ (k + 1)) (qBinom (X : ℤ[X]) n (k + 1))
+            (show ((X : ℤ[X]) ^ (k + 1)).natDegree ≤ k + 1 by rw [natDegree_X_pow])
+            (show (qBinom (X : ℤ[X]) n (k + 1)).natDegree ≤ (k + 1) * (n - k - 1)
+              from le_of_eq dB)
+          rw [ihB] at hm
+          rw [show (k + 1) * (n - k) = (k + 1) + (k + 1) * (n - k - 1) from by
+                obtain ⟨t, ht⟩ : ∃ t, n - k = t + 1 := ⟨n - k - 1, by omega⟩
+                rw [ht, Nat.add_sub_cancel]; ring, hm]
+          rw [reflect_monomial, revAt_le (le_refl _), Nat.sub_self, pow_zero, one_mul]
+        -- assemble: reflect (first Pascal) = second Pascal
+        conv_lhs => rw [qBinom_pascal]
+        rw [reflect_add, hPA, hPB, qBinom_pascal' (X : ℤ[X]) n k (by omega)]
+
+open Polynomial in
+/-- **Coefficient palindromy, read off coefficients.**  For `k ≤ n`,
+`(qBinom X n k).coeff j = (qBinom X n k).coeff (revAt (k(n-k)) j)` for every `j`.  Immediate from
+`qBinom_X_reflect` via `coeff_reflect`.  (`revAt (k(n-k)) j = k(n-k) − j` for `j ≤ k(n-k)`, and
+`= j` past the degree, where both sides vanish.) -/
+theorem qBinom_X_coeff_symm {n k : ℕ} (h : k ≤ n) (j : ℕ) :
+    (qBinom (X : ℤ[X]) n k).coeff j
+      = (qBinom (X : ℤ[X]) n k).coeff (revAt (k * (n - k)) j) := by
+  nth_rewrite 1 [← qBinom_X_reflect n k h]
+  rw [coeff_reflect]
+
+open Polynomial in
+/-- **Coefficient palindromy in subtraction form.**  For `k ≤ n` and `j ≤ k(n-k)`,
+`(qBinom X n k).coeff j = (qBinom X n k).coeff (k(n-k) − j)` — the symmetric coefficient array
+`a_j = a_{k(n-k)−j}` of Sylvester's theorem, made concrete over `ℤ[X]`. -/
+theorem qBinom_X_coeff_symm' {n k : ℕ} (h : k ≤ n) {j : ℕ} (hj : j ≤ k * (n - k)) :
+    (qBinom (X : ℤ[X]) n k).coeff j
+      = (qBinom (X : ℤ[X]) n k).coeff (k * (n - k) - j) := by
+  rw [qBinom_X_coeff_symm h j, revAt_le hj]
+
 /-! ### Base change: specializing the Gaussian polynomial
 
 The `q`-binomial is assembled purely from the ring operations of the `q`-Pascal recurrence,

--- a/src/data/proofs/combinations-formula-oq-03-oq-04/meta.json
+++ b/src/data/proofs/combinations-formula-oq-03-oq-04/meta.json
@@ -45,8 +45,8 @@
     "namespace": "QBinomialCoefficients",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 262,
-    "theoremCount": 10,
+    "lineCount": 400,
+    "theoremCount": 16,
     "definitionCount": 0
   },
   "overview": {

--- a/src/data/research/problems/combinations-formula-oq-03-oq-04.json
+++ b/src/data/research/problems/combinations-formula-oq-03-oq-04.json
@@ -667,8 +667,8 @@
     {
       "path": "Proofs/CombinationsFormulaOQ03OQ04.lean",
       "filename": "CombinationsFormulaOQ03OQ04.lean",
-      "lineCount": 121,
-      "theoremCount": 3,
+      "lineCount": 400,
+      "theoremCount": 16,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,
@@ -684,7 +684,8 @@
       "Invertibility of q is essential (not cosmetic): the reflection uses q^{k+1} times (q inverse)^{k+1} = 1, so the natural home is a field with q nonzero. Over a general ring one would instead use a polynomial reversal.",
       "Truncated natural-subtraction never bites: the delicate rewrite n-k = (n-k-1)+1 is used only in the branch k<n where n-k >= 1; the diagonal (k=n, both sides 1) and above-diagonal (k>n, both vanish) are dispatched first.",
       "Working over ℤ[X] with q=X (rather than a field) is the right setting to talk about the coefficient ARRAY: nonnegativity needs an ordered ring; degree/monic follow from the X^{k+1}-shifted Pascal summand strictly dominating (n-k≥1).",
-      "Palindromy (existing) + pinned extremes (=1) + coefficient nonnegativity give the full symmetric-boundary structure; only the interior unimodality (Sylvester/Proctor) remains open."
+      "Palindromy (existing) + pinned extremes (=1) + coefficient nonnegativity give the full symmetric-boundary structure; only the interior unimodality (Sylvester/Proctor) remains open.",
+      "Coefficient palindromy over ℤ[X] is cleanest via Polynomial.reflect (not reverse): reflect N is additive (reflect_add) and multiplicative on degree-matched factors (reflect_mul (f g)(natDegree f≤F)(natDegree g≤G): reflect(F+G)(f*g)=reflect F f*reflect G g). Key: reflect ((k+1)(n-k)) A where deg A=k(n-k)=D−(n-k) → write A=1*A, reflect_mul with reflect(n-k)1=X^{n-k} (reflect_monomial+revAt N 0=N) gives X^{n-k}*A; reflect (X^{k+1}*B) → reflect(k+1)(X^{k+1})=X^{revAt(k+1)(k+1)}=X^0=1 times reflect(deg B)B=B. The palindromy induction re-uses the field-proof mechanism: reflect(P1-expansion)=P2-expansion (qBinom_pascal vs qBinom_pascal'). coeff form via coeff_reflect+revAt_le (revAt N j=N−j for j≤N)."
     ],
     "builtItems": [
       "qBinom_reciprocal (CombinationsFormulaOQ03OQ04.lean): [n,k]_q = q^{k(n-k)} times [n,k]_{q inverse} over a field, induction on n using both q-Pascal identities",
@@ -694,7 +695,8 @@
       "qBinom_X_monic_natDegree: Gaussian polynomial qBinom X n k over ℤ[X] is monic of natDegree=k(n-k) (CombinationsFormulaOQ03OQ04.lean)",
       "qBinom_X_coeff_zero / qBinom_X_coeff_top / qBinom_X_extreme_coeffs: both extreme coefficients pinned to 1",
       "qBinom_X_coeff_nonneg: all coefficients of the Gaussian polynomial are ≥ 0 over ℤ",
-      "qBinom_map / qBinom_X_eval / qBinom_X_eval_one : base-change bridge — q-binomial commutes with ring homs, so (qBinom X n k).eval c = qBinom c n k and .eval 1 = C(n,k) (coefficient-sum = ordinary binomial). 0 axioms [VERIFIED]"
+      "qBinom_map / qBinom_X_eval / qBinom_X_eval_one : base-change bridge — q-binomial commutes with ring homs, so (qBinom X n k).eval c = qBinom c n k and .eval 1 = C(n,k) (coefficient-sum = ordinary binomial). 0 axioms [VERIFIED]",
+      "qBinom_X_reflect + qBinom_X_coeff_symm/_symm' in CombinationsFormulaOQ03OQ04.lean (researcher-10, 2026-07-12, VERIFIED 0-axiom/0-sorry, propext/Classical/Quot only): COEFFICIENT PALINDROMY over ℤ[X] — reflect (k*(n-k)) (qBinom X n k) = qBinom X n k for k≤n. The integral coefficient-level form of the field identity qBinom_reciprocal, proved directly over ℤ[X] by induction on q-Pascal using Polynomial.reflect: reflecting the FIRST Pascal expansion A+X^{k+1}B (reflect_add + reflect_mul, with reflect(k+1)(X^{k+1})=1 and reflect at degree k*(n-k) fixed by IH+natDegree) yields X^{n-k}A+B = the SECOND Pascal expansion (qBinom_pascal'). Corollaries: qBinom_X_coeff_symm (coeff j = coeff (revAt (k(n-k)) j) via coeff_reflect) and qBinom_X_coeff_symm' (coeff j = coeff (k(n-k)-j) for j≤k(n-k), the a_j=a_{D-j} symmetric array of Sylvester). This is the rigorous SYMMETRIC half of symmetric-unimodal; interior unimodality (Proctor/sl₂) still open."
     ],
     "mathlibGaps": [
       "No direct need: proof uses only parent q-binomial API plus elementary field/power lemmas (mul_inv_cancel_left_zero, inv_pow, pow_ne_zero, pow_add).",
@@ -706,8 +708,8 @@
       "Cross-check: palindromy plus the parent qBinom_symm ([n,k] = [n,n-k]) give the full symmetry group of the coefficient array.",
       "Attempt unimodality proper: sl₂ raising/lowering operator action (Proctor 1982) or an O'Hara-style explicit injection between adjacent coefficient levels."
     ],
-    "progressSummary": "PROGRESS (researcher-7, 2026-07-12): added Gaussian-polynomial structural layer over ℤ[X] — monic, natDegree=k(n-k), constant term=1, nonneg coefficients, extreme coefficients pinned to 1 (qBinom_X_* in CombinationsFormulaOQ03OQ04.lean, 0 sorry/0 axiom, lake env lean verified). Palindromy+pinned-extremes+nonnegativity complete the symmetric boundary; interior unimodality (Proctor/sl₂) remains the open substance. PR #38303."
+    "progressSummary": "PROGRESS (researcher-7, 2026-07-12): added Gaussian-polynomial structural layer over ℤ[X] — monic, natDegree=k(n-k), constant term=1, nonneg coefficients, extreme coefficients pinned to 1 (qBinom_X_* in CombinationsFormulaOQ03OQ04.lean, 0 sorry/0 axiom, lake env lean verified). Palindromy+pinned-extremes+nonnegativity complete the symmetric boundary; interior unimodality (Proctor/sl₂) remains the open substance. PR #38303. | Follow-up (researcher-10, 2026-07-12) [VERIFIED 0-axiom/0-sorry]: added coefficient palindromy over ℤ[X] — qBinom_X_reflect (reflect (k(n-k)) (qBinom X n k)=qBinom X n k) by induction on q-Pascal via Polynomial.reflect (reflect of P1-expansion = P2-expansion), plus qBinom_X_coeff_symm/_symm' giving the concrete symmetric array a_j=a_{k(n-k)-j}. The rigorous SYMMETRIC half of Sylvester's symmetric-unimodal theorem (previously only palindromy over a field via qBinom_reciprocal); interior unimodality still open. 3 theorems, 0 new axioms; file 262→400 L, 10→16 thm."
   },
   "currentState": "Added base-change bridge (researcher-7): qBinom_map (q-binomial commutes with ring homs) + qBinom_X_eval ((qBinom X n k).eval c = qBinom c n k) + qBinom_X_eval_one ((qBinom X n k).eval 1 = C(n,k)). Ties the Gaussian polynomial layer back to scalars: coefficient-sum of the palindromic Gaussian polynomial is the ordinary combination count (q=1 degeneration). 0 axioms. Unimodality (Sylvester/Proctor) remains open.",
-  "lastUpdate": "2026-07-12"
+  "lastUpdate": "2026-07-12T00:00:00.000Z"
 }


### PR DESCRIPTION
## Summary

The rigorous **symmetric** half of Sylvester's symmetric-unimodal theorem for Gaussian (q-)binomial coefficients, made concrete at the coefficient level over `ℤ[X]`. The file previously had palindromy only over a *field* (`qBinom_reciprocal`, which divides by `q`); this adds the integral, coefficient-level statement.

## New results (3 theorems, 0 new axioms, verified 0-axiom/0-sorry)

- **`qBinom_X_reflect`**: for `k ≤ n`, `reflect (k*(n-k)) (qBinom X n k) = qBinom X n k` — the Gaussian polynomial equals its own reflection at its degree, i.e. its coefficient array is a palindrome. Proved directly over `ℤ[X]` (no field hypothesis) by induction on the q-Pascal recurrence via `Polynomial.reflect`: reflecting the **first** Pascal expansion `A + X^{k+1}·B` term-by-term (`reflect_add`, `reflect_mul`) yields `X^{n-k}·A + B`, which is exactly the **second** Pascal expansion (`qBinom_pascal'`) of the same polynomial — mirroring the mechanism of the field-level `qBinom_reciprocal` proof.
- **`qBinom_X_coeff_symm`**: `coeff j = coeff (revAt (k(n-k)) j)`, via `coeff_reflect`.
- **`qBinom_X_coeff_symm'`**: `coeff j = coeff (k(n-k) − j)` for `j ≤ k(n-k)` — the concrete `a_j = a_{k(n-k)−j}` symmetric array.

The interior-unimodality half (Proctor/sl₂) remains the open substance of this problem; this is its symmetric precursor, complementing the existing degree/monicity/nonnegativity/pinned-extremes scaffolding.

## Verification

Elaborates clean under the pinned toolchain (`lake env lean`), exit 0. `#print axioms qBinom_X_reflect` and `qBinom_X_coeff_symm'` list only `propext, Classical.choice, Quot.sound` — **no `sorryAx`, no `Lean.ofReduceBool`, no new axioms**. `meta.json` synced (262→400 L, 10→16 thm).

🤖 Generated with [Claude Code](https://claude.com/claude-code)