### PR TITLE
research(erdos-1064-oq-03): symbolic-landing master form of the prime-triple reversal family [VERIFIED 0 axioms]

### DIFF
--- a/proofs/Proofs/EulerTotientOQ04OQ03.lean
+++ b/proofs/Proofs/EulerTotientOQ04OQ03.lean
@@ -3325,6 +3325,140 @@ theorem reversal_gap_primeTriple_ge {m : ℕ} (hm : 1 ≤ m)
     _ ≤ (2 * m + 2) * 2 ^ k := by gcongr; omega
 
 -- ----------------------------------------------------------------------------
+-- Master (symbolic-landing) form of the prime-triple reversal family
+-- ----------------------------------------------------------------------------
+-- `reversal_gap_primeTriple` computes the exact reversal gap `(2m+2)·2^k` but *requires*
+-- the landing `14m+3` to be prime (it evaluates `φ(14m+3) = 14m+2`).  The forward family
+-- already has a symbolic-landing master form `forward_gap_fiveTimes_eq_totient`, with the
+-- totient of its landing left symbolic; the reversal family lacked the mirror.  Here we
+-- supply it: the two totients along `n = (18m+3)·2^(k+1)` are `φ(n) = 12m·2^k` and
+-- `φ(D(n)) = φ(14m+3)·2^k`, needing only `4m+1`, `6m+1` prime (NOT the landing).  From
+-- these one line each: the signed gap `(φ(14m+3) − 12m)·2^k`, its unconditional `2^k`
+-- divisibility, the exact reversal criterion `12m < φ(14m+3)`, and — specialising the
+-- landing to a prime — a re-derivation of `reversal_gap_primeTriple`.
+-- ----------------------------------------------------------------------------
+
+/-- **Master totient values of the prime-triple reversal family (symbolic landing).**
+    For a seed `a = 18m+3 = 3·(6m+1)` with only the *family* primes `4m+1`, `6m+1` prime
+    (`m ≥ 1`) — and **no** assumption on the landing `14m+3` — both totients along
+    `n = (18m+3)·2^(k+1)` have closed forms `φ(n) = 12m·2^k` and `φ(D(n)) = φ(14m+3)·2^k`,
+    with the landing's totient left *symbolic*.  This is the reversal-side analogue of the
+    computation underneath `forward_gap_fiveTimes_eq_totient`; every quantitative statement
+    about the family below is a one-line consequence. -/
+theorem primeTriple_totient_values {m : ℕ} (hm : 1 ≤ m)
+    (hp : (4 * m + 1).Prime) (hq : (6 * m + 1).Prime) (k : ℕ) :
+    Nat.totient ((18 * m + 3) * 2 ^ (k + 1)) = 12 * m * 2 ^ k ∧
+      Nat.totient (dblIter ((18 * m + 3) * 2 ^ (k + 1)))
+        = Nat.totient (14 * m + 3) * 2 ^ k := by
+  have hcopa : Nat.Coprime 3 (6 * m + 1) :=
+    (Nat.coprime_primes (by norm_num) hq).mpr (by omega)
+  have hcopb : Nat.Coprime 3 (4 * m + 1) :=
+    (Nat.coprime_primes (by norm_num) hp).mpr (by omega)
+  have hφa : Nat.totient (18 * m + 3) = 12 * m := by
+    rw [show 18 * m + 3 = 3 * (6 * m + 1) from by ring, Nat.totient_mul hcopa,
+        show Nat.totient 3 = 2 from by decide, Nat.totient_prime hq]; omega
+  have hφb : Nat.totient (12 * m + 3) = 8 * m := by
+    rw [show 12 * m + 3 = 3 * (4 * m + 1) from by ring, Nat.totient_mul hcopb,
+        show Nat.totient 3 = 2 from by decide, Nat.totient_prime hp]; omega
+  have ha_odd : Odd (18 * m + 3) := Nat.odd_iff.mpr (by omega)
+  have hb_odd : Odd (12 * m + 3) := Nat.odd_iff.mpr (by omega)
+  have hp2 : Nat.totient (2 ^ (k + 1)) = 2 ^ k := by
+    rw [Nat.totient_prime_pow Nat.prime_two (Nat.succ_pos k)]; simp
+  -- φ(n) = φ(18m+3)·2^k = 12m·2^k
+  have copa : Nat.Coprime (18 * m + 3) (2 ^ (k + 1)) :=
+    ((Nat.prime_two.coprime_iff_not_dvd).mpr (by omega)).symm.pow_right (k + 1)
+  have hφn : Nat.totient ((18 * m + 3) * 2 ^ (k + 1)) = 12 * m * 2 ^ k := by
+    rw [Nat.totient_mul copa, hp2, hφa]
+  -- transport: D(n) = (2a − φ(b))·2^k = (14m+3)·2^(k+1)
+  have hstep : 2 * (18 * m + 3) - Nat.totient (18 * m + 3) = 2 * (12 * m + 3) := by
+    rw [hφa]; omega
+  have hD : dblIter ((18 * m + 3) * 2 ^ (k + 1)) = (14 * m + 3) * 2 ^ (k + 1) := by
+    rw [dblIter_transport ha_odd hb_odd hstep k, hφb,
+        show 2 * (18 * m + 3) - 8 * m = (14 * m + 3) * 2 from by omega]
+    ring
+  -- φ(D(n)) = φ(14m+3)·2^k, keeping φ(14m+3) SYMBOLIC (no primality of the landing)
+  have cope : Nat.Coprime (14 * m + 3) (2 ^ (k + 1)) :=
+    ((Nat.prime_two.coprime_iff_not_dvd).mpr (by omega)).symm.pow_right (k + 1)
+  have hφD : Nat.totient (dblIter ((18 * m + 3) * 2 ^ (k + 1)))
+      = Nat.totient (14 * m + 3) * 2 ^ k := by
+    rw [hD, Nat.totient_mul cope, hp2]
+  exact ⟨hφn, hφD⟩
+
+/-- **Master exact reversal gap (symbolic landing) — the reversal mirror of
+    `forward_gap_fiveTimes_eq_totient`.**  For a seed `a = 18m+3` with only `4m+1`, `6m+1`
+    prime (`m ≥ 1`) and **no** assumption on the landing `14m+3`, the signed reversal gap
+    along `n = (18m+3)·2^(k+1)` is exactly `φ(D(n)) − φ(n) = (φ(14m+3) − 12m)·2^k`.  The ℕ
+    subtraction distributes over `2^k` (`Nat.sub_mul`) regardless of sign, so no primality
+    of the landing is needed; specialising `φ(14m+3) = 14m+2` when the landing is prime
+    recovers `reversal_gap_primeTriple`'s exact `(2m+2)·2^k` (see
+    `reversal_gap_primeTriple_of_prime_landing`). -/
+theorem reversal_gap_primeTriple_eq_totient {m : ℕ} (hm : 1 ≤ m)
+    (hp : (4 * m + 1).Prime) (hq : (6 * m + 1).Prime) (k : ℕ) :
+    Nat.totient (dblIter ((18 * m + 3) * 2 ^ (k + 1)))
+        - Nat.totient ((18 * m + 3) * 2 ^ (k + 1))
+      = (Nat.totient (14 * m + 3) - 12 * m) * 2 ^ k := by
+  obtain ⟨hφn, hφD⟩ := primeTriple_totient_values hm hp hq k
+  rw [hφD, hφn, ← Nat.sub_mul]
+
+/-- **Unconditional 2-adic structure of the prime-triple reversal gap.**  Immediate from
+    `reversal_gap_primeTriple_eq_totient`: the whole family gap scales by `2^k`, so
+    `2^k ∣ (φ(D(n)) − φ(n))` for every `k` with **no** condition on the landing `14m+3`.
+    The reversal mirror of `forward_gap_fiveTimes_pow_dvd`. -/
+theorem reversal_gap_primeTriple_pow_dvd {m : ℕ} (hm : 1 ≤ m)
+    (hp : (4 * m + 1).Prime) (hq : (6 * m + 1).Prime) (k : ℕ) :
+    2 ^ k ∣ (Nat.totient (dblIter ((18 * m + 3) * 2 ^ (k + 1)))
+        - Nat.totient ((18 * m + 3) * 2 ^ (k + 1))) := by
+  rw [reversal_gap_primeTriple_eq_totient hm hp hq k]
+  exact ⟨Nat.totient (14 * m + 3) - 12 * m, by ring⟩
+
+/-- **Reversal criterion for the prime-triple family (symbolic landing).**  For a seed
+    `a = 18m+3` with `4m+1`, `6m+1` prime (`m ≥ 1`), the entire family `(18m+3)·2^(k+1)`
+    lies in the reversal regime `φ(n) < φ(D(n))` **iff** the landing's totient exceeds
+    `12m`: `(18m+3)·2^(k+1) ∈ ReversalSet ↔ 12m < φ(14m+3)`.  This pins reversal of the
+    family entirely on the single arithmetic quantity `φ(14m+3)`, `k`-freely: a prime
+    landing (`φ(14m+3) = 14m+2 > 12m`) forces reversal — recovering the hypothesis of
+    `reversal_gap_primeTriple` — while a composite landing with `φ(14m+3) ≤ 12m` (e.g.
+    `m = 3`, landing `45`, `φ(45) = 24 < 36`, see `primeTriple_shape_not_reversal_57`) puts
+    the *same* seed shape outside the reversal regime. -/
+theorem reversal_primeTriple_iff_totient_landing {m : ℕ} (hm : 1 ≤ m)
+    (hp : (4 * m + 1).Prime) (hq : (6 * m + 1).Prime) (k : ℕ) :
+    (18 * m + 3) * 2 ^ (k + 1) ∈ ReversalSet ↔ 12 * m < Nat.totient (14 * m + 3) := by
+  obtain ⟨hφn, hφD⟩ := primeTriple_totient_values hm hp hq k
+  have h2k : 0 < 2 ^ k := pow_pos (by norm_num) k
+  rw [ReversalSet, Set.mem_setOf_eq, hφn, hφD]
+  exact Nat.mul_lt_mul_right h2k
+
+/-- **Consistency: the master form re-derives `reversal_gap_primeTriple`.**  Specialising
+    the symbolic-landing gap `reversal_gap_primeTriple_eq_totient` to a *prime* landing
+    (`φ(14m+3) = 14m+2`) recovers the exact reversal gap `(2m+2)·2^k`, confirming the
+    master form subsumes the prime-landing computation. -/
+theorem reversal_gap_primeTriple_of_prime_landing {m : ℕ} (hm : 1 ≤ m)
+    (hp : (4 * m + 1).Prime) (hq : (6 * m + 1).Prime) (he : (14 * m + 3).Prime) (k : ℕ) :
+    Nat.totient (dblIter ((18 * m + 3) * 2 ^ (k + 1)))
+      - Nat.totient ((18 * m + 3) * 2 ^ (k + 1)) = (2 * m + 2) * 2 ^ k := by
+  rw [reversal_gap_primeTriple_eq_totient hm hp hq k, Nat.totient_prime he,
+      show 14 * m + 3 - 1 = 14 * m + 2 from by omega,
+      show 14 * m + 2 - 12 * m = 2 * m + 2 from by omega]
+
+/-- **A prime-triple *shape* need not reverse — landing primality in
+    `reversal_gap_primeTriple` is essential.**  At `m = 3` the family primes `4m+1 = 13`
+    and `6m+1 = 19` are prime, so the seed `18·3+3 = 57` has the prime-triple shape, yet
+    the landing `14·3+3 = 45 = 3²·5` is composite with `φ(45) = 24 ≤ 36 = 12m`.  By
+    `reversal_primeTriple_iff_totient_landing` the whole family `57·2^(k+1)` therefore does
+    **not** reverse — the identical seed shape that reverses at `m = 1` (`a = 21`) fails to
+    reverse at `m = 3`. -/
+theorem primeTriple_shape_not_reversal_57 (k : ℕ) :
+    57 * 2 ^ (k + 1) ∉ ReversalSet := by
+  have h := reversal_primeTriple_iff_totient_landing (m := 3) (by norm_num)
+    (by norm_num) (by norm_num) k
+  have h45 : Nat.totient (14 * 3 + 3) = 24 := by
+    rw [show 14 * 3 + 3 = 9 * 5 from by norm_num, Nat.totient_mul (by norm_num),
+        totient_9, totient_5]
+  rw [show (18 * 3 + 3) = 57 from by norm_num] at h
+  rw [h, h45]
+  omega
+
+-- ----------------------------------------------------------------------------
 -- Quantitative sharpening: a divergent FORWARD margin of the fiveTimes family
 -- ----------------------------------------------------------------------------
 -- `mem_ForwardSet_fiveTimes` shows the family `n = 5·(4m+1)·2^(k+1)` is forward

--- a/src/data/research/problems/erdos-1064-oq-03.json
+++ b/src/data/research/problems/erdos-1064-oq-03.json
@@ -35,7 +35,7 @@
     }
   ],
   "knowledge": {
-    "progressSummary": "PROGRESS: Structural side COMPLETE/VERIFIED (0/0, 214 thm). Added prime-power-landing reversal engine (generalises prime engine to seedE a=p^m) with proper-prime-power witness a=561 (landing 19²), covering reversal seeds outside all prior closed-form engines. Only remaining open direction: density-1 forward statement (Luca-Pomerance), not session-sized.",
+    "progressSummary": "PROGRESS: Structural side COMPLETE/VERIFIED (0/0). §7 added the symbolic-landing MASTER form of the prime-triple reversal family (previously only the forward family had one), yielding the sharp reversal criterion 12m<φ(14m+3) and a concrete non-reversing prime-triple-shape witness (seed 57). Only remaining open direction: density-1 forward statement (Luca–Pomerance), not session-sized.",
     "builtItems": [
       "dblIter (EulerTotientOQ04OQ03.lean) — the double cototient iterate D(n) = n − φ(n − φ(n)), the object of OQ-03.",
       "dblIter_prime — collapse lemma: for EVERY prime p, D(p) = p − 1 exactly (φ(p)=p−1 ⟹ p−φ(p)=1 ⟹ φ(1)=1 ⟹ D(p)=p−1).",
@@ -118,7 +118,8 @@
       "dblIter_seed1097/1137/1179 landings; totient_1097/1137/1179/549/759/789/917 helpers (factorisation, no kernel decide)",
       "classifySeed_eq_compare_of_seedS_one_seedE_primePow in EulerTotientOQ04OQ03.lean (prime-power-landing trichotomy criterion)",
       "classifySeed_{lt,eq,gt}_iff_of_seedS_one_seedE_primePow + primePow_landing_family_reversal",
-      "Witnesses: totient_401/361/561, classifySeed_561, seedE_561 (=19²), seedE_561_not_prime, mem_ReversalSet_561, reversal_seed_primePow_landing"
+      "Witnesses: totient_401/361/561, classifySeed_561, seedE_561 (=19²), seedE_561_not_prime, mem_ReversalSet_561, reversal_seed_primePow_landing",
+      "primeTriple_totient_values / reversal_gap_primeTriple_eq_totient / reversal_gap_primeTriple_pow_dvd / reversal_primeTriple_iff_totient_landing / reversal_gap_primeTriple_of_prime_landing / primeTriple_shape_not_reversal_57 (EulerTotientOQ04OQ03.lean, after reversal_gap_primeTriple_ge ~L3326): symbolic-landing master form of the prime-triple reversal family (reversal mirror of forward_gap_fiveTimes_eq_totient), giving the exact reversal criterion 12m<φ(14m+3) and a concrete non-reversing prime-triple-shape witness (seed 57). All 6 theorems 0-axiom/0-sorry, host-lean v4.26.0 verified (docker still SIGBUS-135)."
     ],
     "insights": [
       "On primes the higher iterate is trivial: D(p) = p − 1 for all primes p, because the first cototient step p − φ(p) = 1 and φ(1) = 1. So φ(D(p)) = φ(p−1), and φ(p−1) < p−1 = φ(p) for every p ≥ 3 (with equality only at p = 2). This gives the forward direction on an infinite explicit family with a one-line reduction to Nat.totient_lt — no density machinery needed.",
@@ -161,12 +162,14 @@
       "Prime-power-landing engine: for seedS a=1 and seedE a=p^m (p prime, m>=1), classifySeed a = compare (φ(seedB a)+p^(m-1)·2^seedT a) (2·(a-φ(a))). Generalises the prime-landing engine (m=1 case, p^(m-1)=1).",
       "Reversal seeds with PROPER prime-power landings exist and were uncovered by prior engines: a=561 (landing 19²=361), a=1225 (31²), a=1595 (11³). Enumeration a<4000: 154 reversal seeds = 72 prime / 79 general-composite / 3 proper-prime-power landings.",
       "a=561 (smallest Carmichael number) reverses its whole family 561·2^(k+1): b=401 prime, landing e=361=19²; certified by prime-power engine via φ(401)+19·2=438 < 482=2·(561-320).",
-      "Lean/omega gotcha: keep the totient identity LINEAR as φ(e)=e-p^(m-1) (not p^(m-1)·(p-1)); clear the nonlinear seedE a=p^(m-1)·p / =p^m facts before the classifier trichotomy so omega keeps seedE a·2^{…} as opaque atoms."
+      "Lean/omega gotcha: keep the totient identity LINEAR as φ(e)=e-p^(m-1) (not p^(m-1)·(p-1)); clear the nonlinear seedE a=p^(m-1)·p / =p^m facts before the classifier trichotomy so omega keeps seedE a·2^{…} as opaque atoms.",
+      "§7 (researcher-7, 2026-07-12): the prime-triple REVERSAL family 18m+3 = 3·(6m+1) now has the symbolic-landing MASTER form that the forward family already had (forward_gap_fiveTimes_eq_totient). primeTriple_totient_values proves φ(n)=12m·2^k and φ(D(n))=φ(14m+3)·2^k needing only 4m+1,6m+1 prime — NOT the landing 14m+3. Consequences: reversal_gap_primeTriple_eq_totient (signed gap (φ(14m+3)−12m)·2^k via Nat.sub_mul, sign-free), reversal_gap_primeTriple_pow_dvd (2^k | gap unconditionally on landing), and the sharp criterion reversal_primeTriple_iff_totient_landing: the WHOLE family reverses ⟺ 12m<φ(14m+3), k-freely. Landing primality (φ=14m+2>12m) forces reversal (recovers reversal_gap_primeTriple); a composite landing with φ(14m+3)≤12m does NOT reverse — concretely primeTriple_shape_not_reversal_57 (m=3, seed 57, landing 45=3²·5, φ(45)=24<36) shows the identical seed SHAPE that reverses at m=1 (a=21) fails at m=3."
     ],
     "mathlibGaps": [
       "Kernel `decide` on Nat.totient of a seed (e.g. totient 21) blows the stack → SIGBUS (Lean exit 135, line-less); must prove totient values by factorisation (Nat.totient_mul + Nat.totient_prime). Reconfirms the file's existing note."
     ],
     "nextSteps": [
+      "The reversal criterion reversal_primeTriple_iff_totient_landing (family 18m+3 reverses ⟺ 12m<φ(14m+3)) reduces 'infinitely many reversal seeds in the prime-triple shape' to a totient lower bound on the landing 14m+3 over the (conjecturally infinite) set of m with 4m+1,6m+1 both prime. An analogous symbolic-landing criterion for the fiveTimes/other seed shapes would unify the reversal-seed census.",
       "ONLY remaining open direction of Erdős 1064 OQ-03: the density-1 forward statement φ(n)>φ(D(n)) for almost all n. Needs ψ(x,y) smooth-number density / Luca–Pomerance analytic input — a real Mathlib gap, not session-sized, not Aristotle-suitable. The elementary structural side (which seeds reverse, and that reversals live only in the seedS=1 regime) is now COMPLETE.",
       "Possible follow-up (elementary): characterise WHICH transport-admissible seeds (seedS a=1) reverse — i.e. describe {odd a : seedS a=1 ∧ classifySeed a=.lt} beyond its least element a=21. This is the natural next structural question now that the excluded regime is fully closed.",
       "Possible follow-up: is the reversal-seed set (seedS=1, classify=.lt) infinite with positive density among transport-admissible seeds? (21·2^(k+1) family already gives infinitely-often.)",


### PR DESCRIPTION
## Summary

Erdős #1064 OQ-03 (double totient iterate `D(n) = n − φ(n − φ(n))`, comparing `φ(n)` vs `φ(D(n))`). The structural side of this problem is complete and machine-checked; the only open direction is the density-1 forward statement (Luca–Pomerance), which is not session-sized.

This PR fills a specific **structural asymmetry** in `EulerTotientOQ04OQ03.lean`. The forward family already had a *symbolic-landing master form* (`forward_gap_fiveTimes_eq_totient`): a single hypothesis-free computation from which the exact gap, its `2^k` divisibility, and the prime-landing specialisation all follow. The reversal family lacked this mirror — `reversal_gap_primeTriple` *required* the landing `14m+3` to be prime.

## What's added (all 0-sorry / 0-axiom)

For the prime-triple reversal family `n = (18m+3)·2^(k+1)`, `18m+3 = 3·(6m+1)`:

| Theorem | Statement |
|---|---|
| `primeTriple_totient_values` | `φ(n)=12m·2^k` and `φ(D(n))=φ(14m+3)·2^k`, needing only `4m+1,6m+1` prime — **not** the landing |
| `reversal_gap_primeTriple_eq_totient` | signed gap `(φ(14m+3)−12m)·2^k` (via `Nat.sub_mul`, sign-free) — the reversal mirror of `forward_gap_fiveTimes_eq_totient` |
| `reversal_gap_primeTriple_pow_dvd` | `2^k ∣ gap` unconditionally on the landing |
| `reversal_primeTriple_iff_totient_landing` | the whole family reverses **iff** `12m < φ(14m+3)`, `k`-freely |
| `reversal_gap_primeTriple_of_prime_landing` | re-derives the exact `(2m+2)·2^k` from the master when the landing is prime (consistency) |
| `primeTriple_shape_not_reversal_57` | concrete `m=3` seed `57` (landing `45=3²·5`, `φ(45)=24<36`) — the same seed shape that reverses at `m=1` (`a=21`) does **not** reverse when the landing is composite |

The criterion `reversal_primeTriple_iff_totient_landing` is the substantive result: it pins reversal of an entire family on the single arithmetic quantity `φ(14m+3)`, and the concrete witness shows the prime-triple *shape* alone does not force reversal — landing primality is essential.

## Verification

- Host `lean` v4.26.0 against the project Mathlib cache: **exit 0**, no errors/sorries (only pre-existing deprecation warnings elsewhere in the file).
- `docker-build.sh` still crashes with SIGBUS (exit 135) on this file — a pre-existing environment issue documented in the problem's knowledge tracker (crashes on the pristine file too), unrelated to this change.

File remains **0 sorry / 0 axiom**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)