### PR TITLE
Research: erdos-18-oq-01 - subadditivity h(m·n) ≤ h(m)+h(n) of the representation function

### DIFF
--- a/proofs/Proofs/Erdos18OQ01.lean
+++ b/proofs/Proofs/Erdos18OQ01.lean
@@ -893,4 +893,133 @@ theorem h_two_pow (k : ℕ) : h (2 ^ k) = k := by
   have hbound := le_two_pow_h (two_pow_practical k)
   exact (Nat.pow_le_pow_iff_right (by norm_num)).mp hbound
 
+/-! ## Subadditivity of the representation function `h`
+
+The function `h(m)` counts the *fewest* divisors of `m` needed to represent every
+`1 ≤ k < m`.  This section proves it is **subadditive along products**:
+`h(m·n) ≤ h(m) + h(n)` for practical `m, n`.  The witness is the concatenation of a
+minimal covering set `S_m` of `m` with the `m`-scaled copy `m·S_n` of a minimal
+covering set of `n` — exactly the divisor construction of `practical_mul`, but now
+tracking cardinalities.  Writing `k = m·q + r` (`0 ≤ r < m`, `0 ≤ q < n`), the low
+part `r` is covered inside `S_m` (elements `< m`) and the high part `m·q` inside
+`m·S_n` (elements `≥ m`); the two are disjoint, so the union covers `[1, m·n)` using
+`|S_m| + |S_n| = h(m) + h(n)` divisors.  Iterating gives `h(m^k) ≤ k·h(m)`. -/
+
+/-- **A minimal covering set is attained.**  For practical `m` the `sInf` defining
+    `h(m)` is over a nonempty set (the full divisor set `divisors m` covers `[1, m)`),
+    so it is attained: there is a set `S ⊆ divisors m` of cardinality exactly `h(m)`
+    that still represents every `1 ≤ k < m`.  This is the `Nat.sInf_mem` extraction
+    inlined in `le_two_pow_h`, named here for reuse. -/
+theorem exists_h_covering {m : ℕ} (hp : IsPractical m) :
+    ∃ S : Finset ℕ, S ⊆ divisors m ∧ S.card = h m ∧
+      ∀ k, 1 ≤ k → k < m → ∃ T : Finset ℕ, T ⊆ S ∧ T.sum id = k := by
+  have hne : {s : ℕ | ∃ S : Finset ℕ, S ⊆ divisors m ∧ S.card = s ∧
+      ∀ k, 1 ≤ k → k < m → ∃ T : Finset ℕ, T ⊆ S ∧ T.sum id = k}.Nonempty := by
+    refine ⟨(divisors m).card, divisors m, Finset.Subset.refl _, rfl, ?_⟩
+    intro k hk1 hkm
+    exact hp.2 k hk1 hkm
+  exact Nat.sInf_mem hne
+
+/-- **Subadditivity `h(m·n) ≤ h(m) + h(n)`.**  Take minimal covering sets `S_m` of
+    `m` (size `h(m)`) and `S_n` of `n` (size `h(n)`), guaranteed by
+    `exists_h_covering`.  The set `S = S_m ∪ m·S_n ⊆ divisors (m·n)` has at most
+    `h(m) + h(n)` elements and still covers `[1, m·n)`: for `1 ≤ k < m·n`, split
+    `k = m·(k/m) + k%m`; represent the remainder `k%m` inside `S_m` (all such
+    elements are `< m`) and the scaled quotient `m·(k/m)` inside `m·S_n` (all such
+    elements are `≥ m`), disjointly.  Hence `h(m·n) ≤ |S| ≤ h(m) + h(n)`.  This is the
+    counting refinement of `practical_mul`: not only is `m·n` practical, its
+    representation cost is at most the sum of the factors' costs. -/
+theorem h_mul_le {m n : ℕ} (hpm : IsPractical m) (hpn : IsPractical n) :
+    h (m * n) ≤ h m + h n := by
+  have hm1 : 1 ≤ m := hpm.1
+  have hn1 : 1 ≤ n := hpn.1
+  have hmn0 : m * n ≠ 0 := Nat.mul_ne_zero (by omega) (by omega)
+  obtain ⟨Sm, hSmsub, hSmcard, hSmcov⟩ := exists_h_covering hpm
+  obtain ⟨Sn, hSnsub, hSncard, hSncov⟩ := exists_h_covering hpn
+  -- Scaled copy `A = m · Sn ⊆ divisors (m·n)`, elements `≥ m`, injective image.
+  have hminj : ∀ a ∈ Sn, ∀ b ∈ Sn, m * a = m * b → a = b :=
+    fun a _ b _ hab => Nat.eq_of_mul_eq_mul_left (by omega) hab
+  set A := Sn.image (m * ·) with hAdef
+  have hAsub : A ⊆ divisors (m * n) := by
+    intro x hx
+    rw [hAdef, Finset.mem_image] at hx
+    obtain ⟨d, hdSn, rfl⟩ := hx
+    have hdvd : d ∣ n := Nat.dvd_of_mem_divisors (hSnsub hdSn)
+    exact Nat.mem_divisors.mpr ⟨Nat.mul_dvd_mul_left m hdvd, hmn0⟩
+  have hAcard : A.card = Sn.card := by
+    rw [hAdef]
+    exact Finset.card_image_of_injOn
+      (fun a _ b _ hab => Nat.eq_of_mul_eq_mul_left (by omega) hab)
+  -- `Sm` embeds into `divisors (m·n)` since `m ∣ m·n`.
+  have hSmsub' : Sm ⊆ divisors (m * n) :=
+    hSmsub.trans (Nat.divisors_subset_of_dvd hmn0 ⟨n, rfl⟩)
+  set S := Sm ∪ A with hSdef
+  have hSsub : S ⊆ divisors (m * n) := Finset.union_subset hSmsub' hAsub
+  have hScard : S.card ≤ h m + h n := by
+    calc S.card ≤ Sm.card + A.card := Finset.card_union_le _ _
+      _ = h m + h n := by rw [hSmcard, hAcard, hSncard]
+  -- `S` covers `[1, m·n)`.
+  have hcov : ∀ k, 1 ≤ k → k < m * n → ∃ T ⊆ S, T.sum id = k := by
+    intro k _hk1 hkmn
+    have hrm : k % m < m := Nat.mod_lt k (by omega)
+    have hqn : k / m < n :=
+      (Nat.div_lt_iff_lt_mul (by omega)).mpr (by rw [Nat.mul_comm]; exact hkmn)
+    have hdecomp : m * (k / m) + k % m = k := Nat.div_add_mod k m
+    -- Represent remainder `r = k % m` inside `Sm` (empty subset if `r = 0`).
+    obtain ⟨Tr, hTrsub, hTrsum⟩ : ∃ Tr ⊆ Sm, Tr.sum id = k % m := by
+      rcases Nat.eq_zero_or_pos (k % m) with h0 | hpos
+      · exact ⟨∅, Finset.empty_subset _, by simp [h0]⟩
+      · exact hSmcov (k % m) hpos hrm
+    -- Represent quotient `q = k / m` inside `Sn` (empty subset if `q = 0`).
+    obtain ⟨Tq', hTq'sub, hTq'sum⟩ : ∃ Tq' ⊆ Sn, Tq'.sum id = k / m := by
+      rcases Nat.eq_zero_or_pos (k / m) with h0 | hpos
+      · exact ⟨∅, Finset.empty_subset _, by simp [h0]⟩
+      · exact hSncov (k / m) hpos hqn
+    -- Scale the quotient representation by `m`.
+    have hTqinj : ∀ a ∈ Tq', ∀ b ∈ Tq', m * a = m * b → a = b :=
+      fun a _ b _ hab => Nat.eq_of_mul_eq_mul_left (by omega) hab
+    set Tq := Tq'.image (m * ·) with hTqdef
+    have hTqsub : Tq ⊆ A := by
+      rw [hTqdef, hAdef]
+      exact Finset.image_subset_image hTq'sub
+    have hTqsum : Tq.sum id = m * (k / m) := by
+      rw [hTqdef, Finset.sum_image hTqinj]
+      calc ∑ d ∈ Tq', id (m * d) = m * ∑ d ∈ Tq', d := by
+            simp only [id_eq]; rw [Finset.mul_sum]
+        _ = m * Tq'.sum id := rfl
+        _ = m * (k / m) := by rw [hTq'sum]
+    -- Low part `< m`, high part `≥ m`, hence disjoint.
+    have hdisj : Disjoint Tr Tq := by
+      rw [Finset.disjoint_left]
+      intro a haTr haTq
+      have hle : a ≤ Tr.sum id :=
+        Finset.single_le_sum (f := id) (fun i _ => Nat.zero_le _) haTr
+      rw [hTrsum] at hle
+      rw [hTqdef, Finset.mem_image] at haTq
+      obtain ⟨d, hdTq', rfl⟩ := haTq
+      have hd1 : 1 ≤ d := Nat.pos_of_mem_divisors (hSnsub (hTq'sub hdTq'))
+      have hage : m ≤ m * d := le_mul_of_one_le_right (by omega) hd1
+      omega
+    refine ⟨Tr ∪ Tq, ?_, ?_⟩
+    · rw [hSdef]
+      exact Finset.union_subset (hTrsub.trans Finset.subset_union_left)
+        (hTqsub.trans Finset.subset_union_right)
+    · rw [Finset.sum_union hdisj, hTrsum, hTqsum]; omega
+  calc h (m * n) ≤ S.card := Nat.sInf_le ⟨S, hSsub, rfl, hcov⟩
+    _ ≤ h m + h n := hScard
+
+/-- **`h(m^k) ≤ k · h(m)`.**  Iterating subadditivity `h_mul_le` over the practical
+    powers `m^0, m^1, …` (each practical by `practical_pow`): `h(m^{k+1}) = h(m·m^k)
+    ≤ h(m) + h(m^k) ≤ h(m) + k·h(m) = (k+1)·h(m)`.  So the representation cost of a
+    number in the multiplicative family generated by a single practical base grows at
+    most linearly in the exponent — a concrete upper envelope for `h` on `{m^k}`. -/
+theorem h_pow_le {m : ℕ} (hp : IsPractical m) (k : ℕ) : h (m ^ k) ≤ k * h m := by
+  induction k with
+  | zero => simpa using le_of_eq h_one
+  | succ k ih =>
+    calc h (m ^ (k + 1)) = h (m ^ k * m) := by rw [pow_succ]
+      _ ≤ h (m ^ k) + h m := h_mul_le (practical_pow hp k) hp
+      _ ≤ k * h m + h m := by omega
+      _ = (k + 1) * h m := by ring
+
 end Erdos18OQ01

--- a/research/problems/erdos-18-oq-01/knowledge.md
+++ b/research/problems/erdos-18-oq-01/knowledge.md
@@ -150,3 +150,45 @@ Remaining open (unchanged): abundancy ≥ 4 full range needs the greedy sorted-d
 characterization (d_{i+1} ≤ σ_i+1); asymptotic h(m)/Vose density out of elementary reach.
 The `dₖ` chain could continue (`5,6` representable ⇒ further constraints) but grows in
 subset-enumeration complexity.
+
+## Session 2026-07-12 (researcher-3) — subadditivity of `h`: h(m·n) ≤ h(m)+h(n)
+
+SOLVED-state look-outward. The file had the first bounds/exact values of the Erdős #18
+function `h` (`h_le_card_divisors`, `le_two_pow_h`, `h_two_pow`) but no *structural*
+(multiplicative) law relating `h` on a product to `h` on the factors. Added the
+subadditivity law and its power corollary — the counting refinement of the already-present
+`practical_mul` closure:
+
+- `exists_h_covering : IsPractical m → ∃ S ⊆ divisors m, |S| = h(m) ∧ (S covers [1,m))`
+  — names the `Nat.sInf_mem` extraction (the sInf set is nonempty via the full divisor
+  set, since `m` practical). Reused twice below; factors the boilerplate out of `le_two_pow_h`.
+- `h_mul_le : IsPractical m → IsPractical n → h(m·n) ≤ h(m) + h(n)` — take minimal
+  covering sets `S_m` (size h m), `S_n` (size h n); the witness `S = S_m ∪ m·S_n ⊆
+  divisors(m·n)` has `|S| ≤ h m + h n` and covers `[1,m·n)`. For `1 ≤ k < m·n` split
+  `k = m·(k/m) + k%m`; cover `k%m` inside `S_m` (elements `< m` by `single_le_sum`) and
+  `m·(k/m)` inside `m·S_n` (elements `≥ m`); the two subsets are disjoint, union sums to k.
+  `Nat.sInf_le` on the witness closes it. EXACT same divisor construction as `practical_mul`
+  (lines 493-537) but tracking `Finset.card_union_le` + `card_image_of_injOn`.
+- `h_pow_le : IsPractical m → h(m^k) ≤ k·h(m)` — induction on k via `h_mul_le` +
+  `practical_pow`; base `h_one`. TIGHT on the base-2 family: `h(2^k) = k = k·h(2)` since
+  `h(2)=1`, so subadditivity is sharp there.
+
+★Gotchas (v4.26, built first try, 7744 jobs, `⚠ Built (10s)`, 0 axioms / 0 sorries):
+- `exists_h_covering`'s conclusion `S.card = h m` typechecks against `Nat.sInf_mem hne`
+  purely by DEFEQ (`h m` unfolds to that exact `sInf {...}`); write the set literal
+  IDENTICALLY to `def h` or the `exact Nat.sInf_mem hne` fails.
+- `Finset.single_le_sum (f := id) …` typed as `a ≤ Tr.sum id` (not `id a ≤ …`) lets the
+  later `rw [hTrsum]; omega` see `a ≤ k%m` without an `id`-unfolding step (same trick as
+  `practical_mul`'s `m*d ≤ Sr.sum id`).
+- `Finset.card_union_le _ _` (needs both args), `Finset.subset_union_left/right` (no explicit
+  args in v4.26), `Finset.image_subset_image` for `Tq ⊆ A`.
+- The empty-subset branches (`k%m=0` / `k/m=0`) keep the invariant `T.sum id = k%m` (resp.
+  `= k/m`) uniform via `⟨∅, empty_subset, by simp [h0]⟩`, so disjointness/sum work in one path.
+
+Two pre-existing warnings untouched (unused `n` Erdos18Problem:47, `le_or_lt` deprecation
+Erdos18OQ01:318). theoremCount 52→55, lineCount 896→1023.
+
+Remaining open (unchanged): a matching LOWER bound on products beyond `h(m·n) ≥ log₂ m +
+log₂ n` (from `le_two_pow_h`); exact `h(2^a·3^b)` to probe tightness off the single-base
+powers; the greedy sorted-divisor full-range theorem; asymptotic h(m)/Vose density
+(analytic, out of elementary reach).

--- a/research/problems/erdos-18-oq-01/state.md
+++ b/research/problems/erdos-18-oq-01/state.md
@@ -2,13 +2,19 @@
 
 **Phase**: ACT
 **Since**: 2026-07-12T00:00:00Z
-**Attempts**: 6
+**Attempts**: 7
 **Status**: available
 
 ## Current Focus
-`Proofs/Erdos18OQ01.lean` (now 53 theorems, 0 axioms, 0 sorries). Session
-2026-07-12 (researcher-9) opened the first work on the **representation function
-`h(m)`** — the actual subject of Erdős #18, previously untouched in the gallery:
+`Proofs/Erdos18OQ01.lean` (now 55 theorems, 0 axioms, 0 sorries). Session
+2026-07-12 (researcher-3) added the first **multiplicative structural law** for
+the representation function `h`: subadditivity `h(m·n) ≤ h(m) + h(n)` (`h_mul_le`,
+the counting refinement of `practical_mul`) and its power corollary `h(m^k) ≤
+k·h(m)` (`h_pow_le`), via the reusable minimal-covering extractor
+`exists_h_covering`. Tight on the base-2 family (`h(2^k)=k=k·h(2)`).
+
+Session 2026-07-12 (researcher-9) opened the first work on the **representation
+function `h(m)`** — the actual subject of Erdős #18, previously untouched:
 
 - `card_le_two_pow_card_of_covers`: a finite set `S` whose subset sums cover the
   initial segment `[0, N)` satisfies `N ≤ 2^|S|` (inject the `N` values into
@@ -33,7 +39,9 @@
   machinery (needs full `[0,σ(m)]` coverage + gcd analysis).
 
 ## Next Action
-Options: (a) exact `h` for other structured families — `h(2^a · 3^b)` or
-`h(m·n)` sub-additivity (`h(m·n) ≤ h(m) + h(n)`?, from concatenating covering
-sets); (b) `h(m) ≥ d(m) - c` type gaps or abundancy-based refinements; (c) the
-greedy sorted-divisor full-range theorem (larger project).
+Subadditivity `h(m·n) ≤ h(m)+h(n)` is now DONE (researcher-3, `h_mul_le`).
+Options: (a) a matching LOWER bound on products beyond `h(m·n) ≥ log₂ m + log₂ n`
+(already implied by `le_two_pow_h`); (b) exact `h(2^a·3^b)` to probe tightness of
+subadditivity off the single-base powers; (c) `h(m) ≥ d(m) - c` gaps or
+abundancy-based refinements; (d) the greedy sorted-divisor full-range theorem
+(larger project).

--- a/src/data/research/problems/erdos-18-oq-01.json
+++ b/src/data/research/problems/erdos-18-oq-01.json
@@ -32,7 +32,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: first theorems about the h(m) representation function (the actual subject of Erdős #18) — upper bound h(m) ≤ d(m), counting lower bound m ≤ 2^h(m), and the exact value h(2^k) = k; 53 theorems, 0 axioms, 0 sorries.",
+    "progressSummary": "PROGRESS: Added subadditivity of the Erdős #18 function h — h(m·n) ≤ h(m)+h(n) (h_mul_le) and its power corollary h(m^k) ≤ k·h(m) (h_pow_le), plus the reusable minimal-covering extractor exists_h_covering. 0 axioms / 0 sorries; theoremCount 52→55. h_pow_le is tight on 2^k (matches h_two_pow). Asymptotic h(m)/Vose density remains out of elementary reach.",
     "builtItems": [
       "Erdos18OQ01.lean: 7 theorems, 0 axioms, 0 sorries. Imports Proofs.Erdos18Problem for the definitions.",
       "zero_representable (∅), mem_divisors_representable (singleton {d}), one_representable (1∣m), self_representable ({m}).",
@@ -42,7 +42,10 @@
       "sigma_representable, representable_compl, practical_top_segment (3 theorems, 0 axioms): complement symmetry k↦σ(m)−k of the representability algebra + its consequence for the top segment of a practical number.",
       "practical_three_or_four_dvd (4<m -> IsPractical m -> 3|m or 4|m) in Erdos18OQ01.lean:680",
       "practical_four_or_six_dvd (4<m -> IsPractical m -> 4|m or 6|m, via practical_even + Nat.Coprime 2 3) in Erdos18OQ01.lean:715",
-      "h(m) representation-function bounds (researcher-9, 2026-07-12): card_le_two_pow_card_of_covers (a set S covering [0,N) as subset sums has N ≤ 2^|S|, via injection of the N values into S.powerset), h_le_card_divisors (practical m ⟹ h(m) ≤ d(m), the full divisor set covers), le_two_pow_h (practical m ⟹ m ≤ 2^h(m), i.e. h(m) ≥ log₂ m — the sInf is attained via Nat.sInf_mem then the counting bound), one_le_h, h_one=0, powers_subset_sum (binary covering of [0,2^k) by {1,2,…,2^{k-1}}), h_two_pow_le (h(2^k) ≤ k), and h_two_pow (h(2^k) = k EXACTLY — first exact value of the Erdős #18 function). 0 axioms, 0 sorries."
+      "h(m) representation-function bounds (researcher-9, 2026-07-12): card_le_two_pow_card_of_covers (a set S covering [0,N) as subset sums has N ≤ 2^|S|, via injection of the N values into S.powerset), h_le_card_divisors (practical m ⟹ h(m) ≤ d(m), the full divisor set covers), le_two_pow_h (practical m ⟹ m ≤ 2^h(m), i.e. h(m) ≥ log₂ m — the sInf is attained via Nat.sInf_mem then the counting bound), one_le_h, h_one=0, powers_subset_sum (binary covering of [0,2^k) by {1,2,…,2^{k-1}}), h_two_pow_le (h(2^k) ≤ k), and h_two_pow (h(2^k) = k EXACTLY — first exact value of the Erdős #18 function). 0 axioms, 0 sorries.",
+      "exists_h_covering (Erdos18OQ01.lean:913): for practical m, the sInf defining h(m) is attained by a covering set S ⊆ divisors m with |S| = h(m).",
+      "h_mul_le (Erdos18OQ01.lean:932): SUBADDITIVITY h(m·n) ≤ h(m)+h(n) for practical m,n — the counting refinement of practical_mul (witness S_m ∪ m·S_n, disjoint low/high split k=m·q+r).",
+      "h_pow_le (Erdos18OQ01.lean:1016): h(m^k) ≤ k·h(m), iterating h_mul_le over practical_pow."
     ],
     "insights": [
       "IsRepresentable k m = ∃ S ⊆ divisors m, S.sum id = k; the bounded form ∃ S ∈ (divisors m).powerset (via Finset.mem_powerset) is DECIDABLE, so IsPractical m reduces to a finite decidable check and small cases follow by `decide`.",
@@ -52,14 +55,15 @@
       "The representable range of m is exactly [0, σ(m)]: 0 is representable (empty set), σ(m) is the max (representable_le_sigma), and disjoint divisor subsets add (representable_union). This is the elementary closure structure underlying every practical-number argument.",
       "Complement symmetry (researcher-4, 2026-07-08): the representable set of m is symmetric under k↦σ(m)−k. sigma_representable: σ(m) itself is representable (all divisors). representable_compl: if S⊆divisors m sums to k, the unused divisors divisors m\\S sum to σ(m)−k (Finset.sum_sdiff + omega), so σ(m)−k is representable. practical_top_segment: reflecting practical_represents_le ([0,m] representable) through this symmetry gives the TOP block [σ(m)−m, σ(m)] representable — a practical number represents both width-m ends of [0,σ(m)]. All elementary, 0 axioms.",
       "Requiring 4 to be a sum of distinct divisors forces d3<=4: the only such sums are {4} and {1,3}, so a practical m>4 has 3|m or 4|m (the third-smallest-divisor constraint, next after practical_even d2=2).",
-      "The h(m) function (the actual subject of Erdős #18) is bracketed elementarily: log₂ m ≤ h(m) ≤ d(m). The lower bound is pure counting — a covering set of size s produces ≤ 2^s distinct subset sums but must hit the m values 0..m-1, so m ≤ 2^s (card_le_two_pow_card_of_covers). The upper bound is trivial (the whole divisor set covers). For m = 2^k both collapse: the lower bound gives h ≥ k and the binary digits {1,…,2^{k-1}} (a k-element covering set) give h ≤ k, so h(2^k) = k exactly — one fewer than d(2^k) = k+1 since the top divisor 2^k is never needed. This is the first exact h-value; the open questions concern how much smaller than d(m) the function h(m) can be for structured m (e.g. m = n!)."
+      "The h(m) function (the actual subject of Erdős #18) is bracketed elementarily: log₂ m ≤ h(m) ≤ d(m). The lower bound is pure counting — a covering set of size s produces ≤ 2^s distinct subset sums but must hit the m values 0..m-1, so m ≤ 2^s (card_le_two_pow_card_of_covers). The upper bound is trivial (the whole divisor set covers). For m = 2^k both collapse: the lower bound gives h ≥ k and the binary digits {1,…,2^{k-1}} (a k-element covering set) give h ≤ k, so h(2^k) = k exactly — one fewer than d(2^k) = k+1 since the top divisor 2^k is never needed. This is the first exact h-value; the open questions concern how much smaller than d(m) the function h(m) can be for structured m (e.g. m = n!).",
+      "h is subadditive along products: representation cost of m·n is at most the sum of the factors' costs. Consistent with the exact value h(2^k)=k = k·h(2) (h(2)=1), i.e. h_pow_le is TIGHT on the base-2 family.",
+      "The practical_mul divisor construction (S_m ∪ m·S_n) also controls cardinality once minimal covering sets are used; disjointness holds because low-part elements are < m and scaled high-part elements are ≥ m."
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "Stewart–Sierpiński characterization of practical numbers via prime factorization (the route to denser families and the deep structural theorem).",
-      "Multiplicative closure: if gcd(a,b)=1 and both practical (with a ≥ ...), conditions under which a*b is practical (a step toward Stewart–Sierpiński).",
-      "Contiguity: every representable set of consecutive integers [0,σ(m)] when m is practical — i.e. practicality ⟺ divisor sums cover an initial segment (Stewart's condition σ(d_{i+1}) ≤ 1 + Σ_{j≤i} d_j).",
-      "Continue the dk divisor chain (5,6 representable give further divisibility constraints, but subset-enumeration grows), or attempt the greedy sorted-divisor full-range [0,sigma(m)] theorem for arbitrary abundancy."
+      "Lower bounds for h on products: is h(m·n) ≥ max(h(m),h(n)) or a log-based bound? (h(m·n) ≥ log₂(m·n) = log₂ m + log₂ n already from le_two_pow_h).",
+      "Exact h for h(2^a·3^b) or other two-prime families to test tightness of subadditivity beyond powers of a single base.",
+      "Greedy sorted-divisor full-range characterization (d_{i+1} ≤ σ_i + 1) — larger project enabling abundancy ≥ 4."
     ]
   },
   "tags": [


### PR DESCRIPTION
## Summary
Research session for **erdos-18-oq-01** (practical numbers / Erdős Problem #18, the $250 open problem on the representation function `h(m)`).

Added the first **multiplicative structural law** for `h(m)` — the minimum number of divisors of `m` that suffice to represent every `1 ≤ k < m` as a sum of distinct divisors. The file previously had the elementary bracket `log₂ m ≤ h(m) ≤ d(m)` and the exact value `h(2^k) = k`, but no law relating `h` on a product to `h` on the factors.

## Progress
- `exists_h_covering` — for practical `m` the `sInf` defining `h(m)` is attained: a set `S ⊆ divisors m` with `|S| = h(m)` still covers `[1, m)`. Names the `Nat.sInf_mem` extraction (previously inlined in `le_two_pow_h`) for reuse.
- `h_mul_le` — **`h(m·n) ≤ h(m) + h(n)`** for practical `m, n`. The counting refinement of the existing `practical_mul` closure: the witness `S = S_m ∪ m·S_n ⊆ divisors(m·n)` has `|S| ≤ h(m)+h(n)` and covers `[1, m·n)`. For `1 ≤ k < m·n` split `k = m·(k/m) + k%m`; cover the remainder `k%m` inside `S_m` (all elements `< m`) and the scaled quotient `m·(k/m)` inside `m·S_n` (all elements `≥ m`), disjointly.
- `h_pow_le` — **`h(m^k) ≤ k·h(m)`**, iterating `h_mul_le` over `practical_pow`. Tight on the base-2 family since `h(2^k) = k = k·h(2)` (`h(2)=1`).

## Findings
- The `practical_mul` divisor construction (`S_m ∪ m·S_n`) also controls cardinality once minimal covering sets are used; disjointness is automatic because low-part elements are `< m` and scaled high-part elements are `≥ m`.
- Subadditivity is **sharp** on `{2^k}`, so no constant can be shaved off in general.
- `theoremCount` 52 → 55, `lineCount` 896 → 1023.

## Verification
Docker build (`docker-build.sh Proofs.Erdos18OQ01`): **✔ Built (10s), 7744 jobs**. **0 axioms, 0 sorries, no `native_decide`.** Only pre-existing warnings (unused `n` in Erdos18Problem:47; `le_or_lt` deprecation at Erdos18OQ01:318) untouched.

## Status
**Outcome**: progress (structural theorem added to a SOLVED-state RICH problem)
**Next Steps**: matching lower bound on products beyond `h(m·n) ≥ log₂ m + log₂ n`; exact `h(2^a·3^b)` to probe tightness off single-base powers; greedy sorted-divisor full-range theorem. Asymptotic `h(m)`/Vose density remains out of elementary reach.

🤖 Generated by researcher-3