### PR TITLE
Research: erdos-634 - quantitative area accounting (each k-cell has area 1/k²)

### DIFF
--- a/proofs/Proofs/Erdos634MedialAreaOQ01.lean
+++ b/proofs/Proofs/Erdos634MedialAreaOQ01.lean
@@ -1,0 +1,172 @@
+/-
+# Erdős #634 — quantitative area accounting for the `k`-subdivision reptile cells
+
+Erdős problem #634 asks to classify the triples `(T, N)` such that a triangle `T`
+can be dissected into `N` mutually congruent pieces ($25 prize; general
+classification OPEN). The gallery entry `Erdos634Problem.lean` routes
+dissectability through an abstract `axiom Tiles`, and a family of companion files
+have built the concrete `k`-subdivision reptiling of an arbitrary triangle:
+
+* `Erdos634MedialCongruenceOQ01` — the `k`-subdivision grid `P i j` and the `k²`
+  upward/downward cells, all congruent to the base copy `U0`.
+* `Erdos634MedialCoveringOQ02` / `…DisjointOQ02` / `…CentralDisjointOQ02` — the
+  four `k = 2` (medial) cells cover the triangle with interior-disjoint pieces.
+* `Erdos634MedialHomothetyOQ01` — each cell is the image of the *whole* triangle
+  `A B C` under an explicit homothety of ratio `±1/k`
+  (`Up_eq_homothety` / `Down_eq_homothety`).
+
+The one qualitative gap flagged by every prior oq-02 session was the **measure /
+area accounting**: covering + interior-disjointness is only a *quantitative*
+tiling once we know each cell carries the expected fraction `1/k²` of the total
+area. This file supplies exactly that, turning `Erdos634MedialHomothetyOQ01`'s
+homothety descriptions into Lebesgue-measure statements.
+
+The engine is Mathlib's `MeasureTheory.Measure.addHaar_image_homothety`: a
+homothety of ratio `r` on a `d`-dimensional real space scales Haar measure by
+`|r|^d`. Composing with translation invariance handles the off-centre cells, and
+specialising to the Euclidean plane (`d = 2`) gives the area law
+
+  `area(cell) = (1/k²) · area(triangle)`
+
+for every one of the `k²` cells — upward and downward alike. For `k = 2` this is
+the exact `area = ¼ · total` statement for the four medial pieces, the concrete
+`n = 4` quantitative content behind `Erdos634MedialTilingOQ02.exists_congruentTiling_four`.
+
+All results are axiom-free (only the ambient `propext / Classical.choice /
+Quot.sound`); no `Tiles` axiom and no dimension/area *hypothesis* is used — the
+plane's dimension is computed, not assumed.
+
+Tags: geometry, erdos, dissection, tiling, reptile, area, measure, haar, homothety
+-/
+import Mathlib
+import Proofs.Erdos634MedialCoveringOQ02
+import Proofs.Erdos634MedialCongruenceOQ01
+import Proofs.Erdos634MedialHomothetyOQ01
+
+set_option linter.unusedSectionVars false
+
+open MeasureTheory
+open Erdos634MedialCoveringOQ02 Erdos634MedialCongruenceOQ01 Erdos634MedialHomothetyOQ01
+
+namespace Erdos634MedialAreaOQ01
+
+/-! ## Part I: Haar measure of a shifted homothety image (general dimension)
+
+The cells of `Erdos634MedialHomothetyOQ01` are images of the whole triangle under
+maps of the form `x ↦ v + r • (x - a)` — a homothety of ratio `r` centred at `a`,
+then translated so the fixed point lands at `v`. On a finite-dimensional real
+normed space carrying a Haar measure, such a map scales the measure by `|r|^d`. -/
+
+section General
+
+variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E] [MeasurableSpace E]
+  [BorelSpace E] [FiniteDimensional ℝ E] (μ : Measure E) [μ.IsAddHaarMeasure]
+
+/-- **Shifted-homothety measure law.** The image of `s` under
+`x ↦ v + r • (x - a)` has Haar measure `|r|^(dim) · μ s`. The map is
+`AffineMap.homothety a r` post-composed with the translation by `v - a`; the
+homothety scales by `|r|^dim` (`addHaar_image_homothety`) and translation is
+measure-preserving. -/
+theorem addHaar_shifted_homothety_image (v a : E) (r : ℝ) (s : Set E) :
+    μ ((fun x => v + r • (x - a)) '' s)
+      = ENNReal.ofReal |r ^ Module.finrank ℝ E| * μ s := by
+  have hmap : (fun x => v + r • (x - a))
+      = (fun y => y + (v - a)) ∘ (⇑(AffineMap.homothety a r)) := by
+    funext x
+    simp only [Function.comp_apply, AffineMap.homothety_apply, vsub_eq_sub, vadd_eq_add]
+    module
+  rw [hmap, Set.image_comp, Set.image_add_right, measure_preimage_add_right,
+    Measure.addHaar_image_homothety]
+
+end General
+
+/-! ## Part II: Area of the reptile cells in the Euclidean plane
+
+Specialise to `EuclideanSpace ℝ (Fin 2)`, whose (2-dimensional) volume is the
+usual planar area. We compute the area of each cell of the `k`-subdivision. -/
+
+/-- The Euclidean plane, on which `volume` is planar area (2-dim Haar measure). -/
+abbrev Plane := EuclideanSpace ℝ (Fin 2)
+
+/-- Planar-area version of the shifted-homothety law: on the plane the exponent
+`dim = 2` is computed, so `x ↦ v + r • (x - a)` scales area by `r²`. -/
+theorem area_shifted_homothety_image (v a : Plane) (r : ℝ) (s : Set Plane) :
+    volume ((fun x => v + r • (x - a)) '' s) = ENNReal.ofReal (r ^ 2) * volume s := by
+  rw [addHaar_shifted_homothety_image,
+    show Module.finrank ℝ Plane = 2 from finrank_euclideanSpace_fin,
+    abs_of_nonneg (by positivity : (0 : ℝ) ≤ r ^ 2)]
+
+/-- The `−r` (`180°`-rotated) variant, matching `Down_eq_homothety`'s subtraction
+form. Since `(−r)² = r²` the reflected cell scales area by the same `r²`. -/
+theorem area_neg_shifted_homothety_image (v a : Plane) (r : ℝ) (s : Set Plane) :
+    volume ((fun x => v - r • (x - a)) '' s) = ENNReal.ofReal (r ^ 2) * volume s := by
+  have hmap : (fun x => v - r • (x - a)) = (fun x => v + (-r) • (x - a)) := by
+    funext x; rw [neg_smul, sub_eq_add_neg]
+  rw [hmap, area_shifted_homothety_image, show (-r) ^ 2 = r ^ 2 from by ring]
+
+/-! ### Each cell of the `k`-subdivision has area `(1/k²) · (whole triangle)` -/
+
+/-- **Upward cell area.** In the `k`-subdivision of the plane triangle `A B C`,
+the upward cell with lower-left grid index `(i, j)` has area exactly
+`(1/k)² · area(A B C)`. Immediate from `Up_eq_homothety` (the cell is the
+ratio-`1/k` homothety image of the whole) and the planar-area law. -/
+theorem area_Up_cell (A B C : Plane) (k i j : ℕ) :
+    volume (triHull (P A B C k i j) (P A B C k (i + 1) j) (P A B C k i (j + 1)))
+      = ENNReal.ofReal (((k : ℝ)⁻¹) ^ 2) * volume (triHull A B C) := by
+  rw [Up_eq_homothety, area_shifted_homothety_image]
+
+/-- **Downward cell area.** The downward cell of the `k`-subdivision (a
+`180°`-rotated copy) also has area `(1/k)² · area(A B C)`. -/
+theorem area_Down_cell (A B C : Plane) (k i j : ℕ) :
+    volume (triHull (P A B C k (i + 1) (j + 1)) (P A B C k i (j + 1)) (P A B C k (i + 1) j))
+      = ENNReal.ofReal (((k : ℝ)⁻¹) ^ 2) * volume (triHull A B C) := by
+  rw [Down_eq_homothety, area_neg_shifted_homothety_image]
+
+/-- **All cells are equal-area.** Upward and downward cells of the same
+`k`-subdivision carry the same area, confirming the congruence-implied
+equal-area at the measure level. -/
+theorem area_Up_eq_area_Down (A B C : Plane) (k i j i' j' : ℕ) :
+    volume (triHull (P A B C k i j) (P A B C k (i + 1) j) (P A B C k i (j + 1)))
+      = volume (triHull (P A B C k (i' + 1) (j' + 1)) (P A B C k i' (j' + 1))
+          (P A B C k (i' + 1) j')) := by
+  rw [area_Up_cell, area_Down_cell]
+
+/-! ### Consistency of the area accounting
+
+The `k`-subdivision has `k²` cells (`k²` upward + `k(k-1)`… — combinatorially
+`k²` total), each of area `(1/k²) · A`. The individual areas are therefore
+consistent with an exact partition: multiplying the common cell area by the cell
+count `k²` recovers the whole area. We record the scalar identity behind this
+(for `k ≥ 1`); it is the arithmetic core of "the `k²` congruent cells tile
+`A B C`". -/
+
+/-- The `k²` cells, each of area `(1/k²)·A`, account for the full area `A`:
+`k² · (1/k)² = 1`. -/
+theorem cell_area_count_consistent {k : ℕ} (hk : k ≠ 0) :
+    (k : ℝ) ^ 2 * ((k : ℝ)⁻¹) ^ 2 = 1 := by
+  have hk' : (k : ℝ) ≠ 0 := Nat.cast_ne_zero.mpr hk
+  field_simp
+
+/-! ## Part III: The `k = 2` medial specialisation (`n = 4`)
+
+For `k = 2` the four cells are the three corner pieces (`Up (0,0)`, `Up (1,0)`,
+`Up (0,1)`) and the central piece (`Down (0,0)`), matching `medialPieces` of
+`Erdos634MedialTilingOQ02`. Each has area exactly `¼` of the whole — the
+quantitative content of the concrete `n = 4` tiling. -/
+
+/-- **Medial corner cell = quarter area.** Each upward cell of the `k = 2`
+(medial) subdivision has area exactly `¼ · area(A B C)`. The three corner pieces
+`Up (0,0)`, `Up (1,0)`, `Up (0,1)` are the `(i,j)` instances. -/
+theorem area_medial_Up_cell (A B C : Plane) (i j : ℕ) :
+    volume (triHull (P A B C 2 i j) (P A B C 2 (i + 1) j) (P A B C 2 i (j + 1)))
+      = ENNReal.ofReal (1 / 4) * volume (triHull A B C) := by
+  rw [area_Up_cell, show ((2 : ℕ) : ℝ)⁻¹ ^ 2 = 1 / 4 from by norm_num]
+
+/-- **Medial central cell = quarter area.** The central (downward) cell of the
+medial subdivision, `Down (0,0)`, also has area exactly `¼ · area(A B C)`. -/
+theorem area_medial_Down_cell (A B C : Plane) (i j : ℕ) :
+    volume (triHull (P A B C 2 (i + 1) (j + 1)) (P A B C 2 i (j + 1)) (P A B C 2 (i + 1) j))
+      = ENNReal.ofReal (1 / 4) * volume (triHull A B C) := by
+  rw [area_Down_cell, show ((2 : ℕ) : ℝ)⁻¹ ^ 2 = 1 / 4 from by norm_num]
+
+end Erdos634MedialAreaOQ01

--- a/research/problems/erdos-634/knowledge.md
+++ b/research/problems/erdos-634/knowledge.md
@@ -212,3 +212,51 @@ that the abstract framework could only assert. Over an arbitrary real normed spa
 - Planar (V = ℝ²) Lebesgue/area accounting to upgrade to a measure-theoretic tiling.
 - Iterate the medial subdivision (self-similarity) to realise `IsCongruentTiling` at
   `n = 4^j`, and generalise the concrete witness to the full k-subdivision of OQ-01.
+
+## Session (researcher-8, 2026-07-12): quantitative area accounting — each k-cell has area 1/k²
+
+New file `Erdos634MedialAreaOQ01.lean` — VERIFIED, Docker build
+`[7747/7747] Built Proofs.Erdos634MedialAreaOQ01 (6.0s)` (Mathlib 4.26),
+0 axioms / 0 sorries, 9 theorems.
+
+**The gap this closes.** Every prior oq-02 session (covering + corner/central
+interior-disjointness) explicitly left the **measure/area accounting** open:
+covering + interior-disjointness is only a *quantitative* tiling once each cell
+is known to carry the expected area fraction. `Erdos634MedialHomothetyOQ01` had
+already shown each cell = image of the whole triangle under a ratio-`±1/k`
+homothety (`Up_eq_homothety` / `Down_eq_homothety`); this file turns those into
+Lebesgue-measure statements.
+
+**Engine:** Mathlib `MeasureTheory.Measure.addHaar_image_homothety` (a ratio-`r`
+homothety scales Haar measure by `|r|^dim`), composed with translation
+invariance for the off-centre cells.
+
+- `addHaar_shifted_homothety_image` (general finite-dim helper): the image of `s`
+  under `x ↦ v + r•(x−a)` has measure `|r^(finrank)| · μ s`. Proof writes the map
+  as `(·+(v−a)) ∘ AffineMap.homothety a r`, then `Set.image_comp` +
+  `Set.image_add_right` + `measure_preimage_add_right` +
+  `Measure.addHaar_image_homothety`. ★key: `AffineMap.homothety_apply` gives
+  `r•(p−ᵥc)+ᵥc`; `simp [vsub_eq_sub, vadd_eq_add]` then `module` proves
+  `v+r•(x−a) = homothety a r x + (v−a)`.
+- `area_shifted_homothety_image` / `area_neg_shifted_homothety_image` (plane): on
+  `Plane := EuclideanSpace ℝ (Fin 2)` the exponent `dim = 2` is *computed*
+  (`finrank_euclideanSpace_fin`), so the map scales area by `r²` (the `−r`
+  variant needs `(−r)²=r²` via `ring`, matching `Down`'s subtraction form).
+- `area_Up_cell` / `area_Down_cell` (CAPSTONE, general k): every upward/downward
+  cell of the k-subdivision has area exactly `((k:ℝ)⁻¹)² · area(triHull A B C)`.
+- `area_Up_eq_area_Down`: cells are equal-area at the measure level.
+- `cell_area_count_consistent` (k≠0): `k²·(1/k)²=1` — areas consistent with an
+  exact partition into k² cells.
+- `area_medial_Up_cell` / `area_medial_Down_cell` (k=2, n=4): each of the four
+  medial pieces has area exactly `¼ · area(A B C)` — the quantitative content
+  behind `Erdos634MedialTilingOQ02.exists_congruentTiling_four`.
+
+★Build corruption: two spurious exit-135 SIGBUS + a batteries `.ir` invalid-header
+before a clean build; `docker-build.sh --repair-cache` + retry cleared it.
+
+### Still open beyond this file
+- Full partition additivity (`volume (triHull A B C) = ∑ over k² cells`) as a
+  single measure identity — the per-cell area (this file) is the missing
+  quantitative input; the additivity is bookkeeping over the k² index set via
+  `measure_biUnion` + a.e.-disjointness.
+- #634 proper: classification of achievable congruent-piece counts N (OPEN, $25).

--- a/src/data/research/problems/erdos-634.json
+++ b/src/data/research/problems/erdos-634.json
@@ -21,7 +21,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETED (base problem axiomatized on main; #634 itself OPEN $25). Session 2026-07-12 (researcher-5): added Erdos634MedialTilingOQ02.lean — a concrete, non-abstract IsCongruentTiling predicate and an axiom-free proof that every non-degenerate triangle admits it for n=4 (the medial k=2 reptiling cell). This is the honest positive-case content the base file could only assert through its opaque Tiles axiom (squares_dissectable 2 is sorry). 0 axioms, 0 sorries, verified.",
+    "progressSummary": "PROGRESS: closed the measure/area accounting frontier flagged by all prior oq-02 sessions — each of the k² reptile cells has area (1/k²)·total (k=2 medial gives ¼ each), turning covering+interior-disjointness into a quantitative tiling. Full partition additivity (single measure_biUnion identity) and #634 classification remain open.",
     "builtItems": [
       "Proofs/Erdos634MedialCongruence.lean: 194 lines, 11 theorems, 6 definitions, 0 axioms, 0 sorries; #print axioms reports only propext/Classical.choice/Quot.sound.",
       "TriCongruent: isometry-congruence of ordered triangles, proved an equivalence relation and distance-preserving.",
@@ -29,14 +29,16 @@
       "Explicit isometry witnesses: translations (corner triangles) and a point reflection pointRefl (central triangle).",
       "medial_sides_halved: each piece has half the side lengths, exhibiting the k=2 square reptiling.",
       "Gallery entry erdos-634-medial-congruence (meta.json + annotations.json).",
-      "Proofs/Erdos634MedialTilingOQ02.lean: 156 lines, IsCongruentTiling structure (3 fields) + medialPieces + medial_isCongruentTiling (capstone) + exists_congruentTiling_four; 0 axioms/0 sorries (#print axioms = propext/Classical.choice/Quot.sound). Unifies medial_four_congruent + medial_covering + medial_interiors_pairwise_disjoint into one concrete n=4 tiling witness over an arbitrary real normed space."
+      "Proofs/Erdos634MedialTilingOQ02.lean: 156 lines, IsCongruentTiling structure (3 fields) + medialPieces + medial_isCongruentTiling (capstone) + exists_congruentTiling_four; 0 axioms/0 sorries (#print axioms = propext/Classical.choice/Quot.sound). Unifies medial_four_congruent + medial_covering + medial_interiors_pairwise_disjoint into one concrete n=4 tiling witness over an arbitrary real normed space.",
+      "addHaar_shifted_homothety_image + area_Up_cell/area_Down_cell + area_medial_Up_cell/area_medial_Down_cell in Erdos634MedialAreaOQ01.lean (0 axioms, 0 sorries)"
     ],
     "insights": [
       "The four medial pieces are congruent via genuinely elementary isometries: three translations and one point reflection (180° rotation) for the central piece.",
       "No inner-product/Euclidean machinery is needed — translations and point reflections are isometries in any real normed space, so the result holds in general normed spaces and specialises to the plane.",
       "Side lengths halve exactly via midpoint_vsub_midpoint_same_left, so the medial subdivision is the 4 = 2^2 square reptiling base case.",
       "SOUNDNESS FLAG: the pre-existing Erdos634Problem.lean uses an area-only Dissection (no covering/disjointness); this makes IsDissectable n true for every n (n identical (1/√n)-scaled pieces), contradicting its seven_not_dissectable / eleven_not_dissectable axioms — a latent inconsistency to repair.",
-      "The base entry Erdos634Problem routes positive dissectability through an OPAQUE axiom Tiles : Prop, so its positive results (squares_dissectable etc.) are unavoidably sorry — an abstract Prop has no introduction rule, so no concrete tiling can be witnessed. Erdos634MedialTilingOQ02 supplies a NON-abstract IsCongruentTiling predicate (triHull covers + triHullOpen interior-disjoint + TriCongruent) and proves the medial subdivision inhabits it for n=4, axiom-free — the first concrete positive tiling witness of the k=2 reptiling cell."
+      "The base entry Erdos634Problem routes positive dissectability through an OPAQUE axiom Tiles : Prop, so its positive results (squares_dissectable etc.) are unavoidably sorry — an abstract Prop has no introduction rule, so no concrete tiling can be witnessed. Erdos634MedialTilingOQ02 supplies a NON-abstract IsCongruentTiling predicate (triHull covers + triHullOpen interior-disjoint + TriCongruent) and proves the medial subdivision inhabits it for n=4, axiom-free — the first concrete positive tiling witness of the k=2 reptiling cell.",
+      "Each cell of the k-subdivision has area exactly (1/k²)·(whole triangle) via Mathlib addHaar_image_homothety on the ratio-±1/k homothety descriptions (Erdos634MedialAreaOQ01, area_Up_cell/area_Down_cell)"
     ],
     "mathlibGaps": [
       "No tiling/dissection API in Mathlib (covering + disjoint-interiors of polygonal pieces), so the full geometric dissection of #634 cannot yet be formalized; only the congruence of the pieces is captured here."


### PR DESCRIPTION
## Summary
Research session for **erdos-634** (triangle dissection into congruent pieces, $25 prize; general classification OPEN). New file `proofs/Proofs/Erdos634MedialAreaOQ01.lean` — **0 axioms, 0 sorries, 9 theorems, Docker-verified** on Mathlib 4.26 (`[7747/7747] Built (6.0s)`).

## Progress
Every prior oq-02 session (covering + corner/central interior-disjointness) explicitly left the **measure/area accounting** open: covering + interior-disjointness is only a *quantitative* tiling once each cell carries the expected area fraction. `Erdos634MedialHomothetyOQ01` had already shown each cell of the `k`-subdivision is the image of the whole triangle under an explicit ratio-`±1/k` homothety. This PR turns those into Lebesgue-measure statements.

Engine: Mathlib `MeasureTheory.Measure.addHaar_image_homothety` (a ratio-`r` homothety scales Haar measure by `|r|^dim`), composed with translation invariance for the off-centre cells.

- `addHaar_shifted_homothety_image` — general finite-dim helper: `x ↦ v + r•(x−a)` scales Haar measure by `|r^(finrank)|`.
- `area_shifted_homothety_image` / `area_neg_shifted_homothety_image` — plane specialisation (`dim = 2` computed, not assumed); scale area by `r²`.
- **`area_Up_cell` / `area_Down_cell`** (capstone, general `k`): every up/down cell of the `k`-subdivision has area exactly `((k:ℝ)⁻¹)² · area(triHull A B C)`.
- `area_Up_eq_area_Down`; `cell_area_count_consistent` (`k²·(1/k)²=1`).
- `area_medial_Up_cell` / `area_medial_Down_cell` (`k=2`, `n=4`): each of the four medial pieces has area exactly `¼ · area` — the quantitative content behind `Erdos634MedialTilingOQ02.exists_congruentTiling_four`.

## Findings
- No `Tiles` axiom and no dimension/area *hypothesis* used — the plane's dimension is computed via `finrank_euclideanSpace_fin`.
- Remaining: full partition additivity as a single `measure_biUnion` identity (this file supplies the missing per-cell quantitative input); #634 classification of achievable `N` stays open.

## Status
**Outcome**: progress (closes the qualitative→quantitative measure/area frontier for the medial/k-subdivision tiling)
**Next Steps**: assemble covering + a.e.-disjointness + per-cell area into `volume (triHull A B C) = ∑ over k² cells`.

🤖 Generated by researcher-8