### PR TITLE
Research: collatz-structured-oq-02-oq-03 — Part XII (cont.): odd steps ≤ half the window (triplings ≤ halvings + 1)

### DIFF
--- a/proofs/Proofs/CollatzStructuredOQ02OQ03CertUnique.lean
+++ b/proofs/Proofs/CollatzStructuredOQ02OQ03CertUnique.lean
@@ -342,4 +342,102 @@ theorem affValid_prefix_deriveVec_pow {b r : ℕ} {v : List Bool}
     v <+: deriveVec (2 * b + 1) (2 ^ b) r :=
   affValid_prefix_deriveVec_of_length hv hlen
 
+/-! ## Part XII (cont.) — odd steps are at most half of the window
+
+`affValid_no_two_consecutive_odd` records the *shape* constraint that a valid certificate
+never contains `true :: true`.  This section turns that qualitative fact into a **quantitative
+count bound**: in any list with no two adjacent `true`s, at most `⌈length/2⌉` of the entries
+are `true`.  Applied to a certificate `v` this bounds the number of *odd* (tripling) steps
+`v.count true` by one more than the number of *even* (halving) steps `v.count false`.
+
+The bound is the certificate-level statement of the classical Collatz fact that triplings can
+never outnumber halvings by more than one over any window.  It is sharp: the alternating
+transcript `true :: false :: true :: … :: true` (which arises for `d` odd) attains
+`2·count true = length + 1`.
+
+Honest reach: this yields `a ≤ b + 1` for a window with `a = v.count true` triplings and
+`b = v.count false` halvings, which is strictly weaker than the drop criterion `3^a < 2^b`
+(the latter needs `a` genuinely smaller than `b·log 2 / log 3 ≈ 0.63 b`).  It is the exact
+combinatorial content extractable from adjacency alone, no more.  Axiom-free (independent of
+`tao_2019`, no `decide`). -/
+
+/-- **General count bound (bounded induction form).**  In any `Bool` list with no two adjacent
+`true`s — expressed as `List.IsChain` for the relation "an odd bit forces the next to be even"
+— twice the number of `true`s is at most `length + 1`.  Proved by induction on a length budget
+`n`: an even head defers to the tail (one shorter), an odd head forces the following bit to be
+even and peels *two* entries (`true :: false`) adding one `true` for two positions. -/
+theorem count_true_le_of_noTwoTrue :
+    ∀ (n : ℕ) (v : List Bool), v.length ≤ n →
+      List.IsChain (fun a b => a = true → b = false) v →
+      2 * v.count true ≤ v.length + 1 := by
+  intro n
+  induction n with
+  | zero =>
+      intro v hlen _
+      have : v = [] := List.length_eq_zero_iff.mp (Nat.le_zero.mp hlen)
+      subst this; simp
+  | succ n ih =>
+      intro v hlen hchain
+      match v with
+      | [] => simp
+      | [a] =>
+          have : List.count true [a] ≤ 1 := by cases a <;> simp
+          simp only [List.length_singleton]; omega
+      | a :: b :: rest =>
+          have hrel : a = true → b = false := hchain.rel_head
+          have htail : List.IsChain (fun a b => a = true → b = false) (b :: rest) :=
+            hchain.of_cons
+          have hlen' : (b :: rest).length ≤ n := by
+            simp only [List.length_cons] at hlen ⊢; omega
+          rcases Bool.dichotomy a with ha | ha
+          · -- even head: `count true` unchanged, tail is one shorter
+            have hc : List.count true (a :: b :: rest) = List.count true (b :: rest) := by
+              simp [ha]
+            have hih := ih (b :: rest) hlen' htail
+            rw [hc]; simp only [List.length_cons] at hih ⊢; omega
+          · -- odd head forces `b = false`; peel two entries, adding one `true`
+            have hb : b = false := hrel ha
+            have hc : List.count true (a :: b :: rest) = 1 + List.count true rest := by
+              simp [ha, hb]; omega
+            have htail2 : List.IsChain (fun a b => a = true → b = false) rest := htail.of_cons
+            have hlen2 : rest.length ≤ n := by simp only [List.length_cons] at hlen; omega
+            have hih := ih rest hlen2 htail2
+            rw [hc]; simp only [List.length_cons]; omega
+
+/-- **General count bound.**  A `Bool` list with no two adjacent `true`s has
+`2 · (count true) ≤ length + 1`.  The unbudgeted form of `count_true_le_of_noTwoTrue`, taking
+the length itself as the budget. -/
+theorem two_mul_count_true_le_of_isChain {v : List Bool}
+    (h : List.IsChain (fun a b => a = true → b = false) v) :
+    2 * v.count true ≤ v.length + 1 :=
+  count_true_le_of_noTwoTrue v.length v le_rfl h
+
+/-- Partition identity for `Bool` lists: every entry is `true` or `false`, so
+`count true + count false = length`. -/
+theorem count_true_add_count_false (v : List Bool) :
+    v.count true + v.count false = v.length := by
+  induction v with
+  | nil => simp
+  | cons a t ih => cases a <;> simp <;> omega
+
+/-- **Odd steps are at most half the window.**  For any valid parity certificate `v`, twice
+the number of odd (tripling) steps is at most `length + 1`.  Immediate from
+`affValid_no_two_consecutive_odd` (no `true :: true`) via the general count bound. -/
+theorem affValid_two_mul_count_true_le {v : List Bool} {c d : ℕ}
+    (hv : AffValid v c d) : 2 * v.count true ≤ v.length + 1 :=
+  two_mul_count_true_le_of_isChain (affValid_no_two_consecutive_odd hv)
+
+/-- **Triplings never exceed halvings by more than one.**  For any valid parity certificate,
+the number of odd (tripling) steps `count true` is at most one more than the number of even
+(halving) steps `count false`.  This is the certificate-level form of the classical fact that
+a `3n+1` step is always followed by a halving, so over any window `a ≤ b + 1` where
+`a = #odd`, `b = #even`.  Combined with the mother module's drop criterion
+`3^(count true) < 2^(count false)`, it quantifies exactly how far short of the drop threshold
+adjacency alone leaves us: `a ≤ b + 1` does not imply `3^a < 2^b`. -/
+theorem affValid_count_true_le_count_false_succ {v : List Bool} {c d : ℕ}
+    (hv : AffValid v c d) : v.count true ≤ v.count false + 1 := by
+  have h1 := affValid_two_mul_count_true_le hv
+  have h2 := count_true_add_count_false v
+  omega
+
 end CollatzStructuredOQ02OQ03

--- a/research/problems/collatz-structured-oq-02-oq-03/knowledge.md
+++ b/research/problems/collatz-structured-oq-02-oq-03/knowledge.md
@@ -742,3 +742,50 @@ Quot.sound]`.
 - Closure length bound: any `AffValid v (2^b) r` has `v.length ≤ 2b+1` (track `v₂(c)`:
   even steps drop it by 1, odd steps preserve it, no two consecutive odds), making
   `fuel = 2b+1` always sufficient so `affValid_prefix_deriveVec_pow` becomes unconditional.
+
+## Session 2026-07-13 (researcher-1) — Part XII (cont.): odd steps ≤ half the window
+
+**Mode**: REVISIT (RICH, knowledge score 62). **Outcome**: progress — axiom-free,
+build-verified (`LAKE_UNSAFE=1 ./bin/lake env lean` against main's cached oleans, EXIT 0,
+no warnings; `#print axioms` on all four new results = `[propext, Classical.choice, Quot.sound]`).
+
+### What I Did
+Turned the qualitative Part XII shape law `affValid_no_two_consecutive_odd` (no `true :: true`)
+into a **quantitative count bound** in the companion `CollatzStructuredOQ02OQ03CertUnique.lean`.
+Five theorems (Part XII cont.):
+- `count_true_le_of_noTwoTrue` — general list lemma (budgeted induction form): any `Bool` list
+  that is a `List.IsChain` for "an odd bit forces the next to be even" has
+  `2 * count true ≤ length + 1`. Two-step budget induction on a length bound `n`: an even head
+  defers to the tail (one shorter); an odd head forces the following bit `false` and peels TWO
+  entries (`true :: false`), adding one `true` for two positions.
+- `two_mul_count_true_le_of_isChain` — unbudgeted wrapper (`fuel = v.length`).
+- `count_true_add_count_false` — Bool partition identity `count true + count false = length`.
+- `affValid_two_mul_count_true_le` — `AffValid v c d ⟹ 2·(v.count true) ≤ v.length + 1`.
+- `affValid_count_true_le_count_false_succ` — **triplings ≤ halvings + 1**:
+  `v.count true ≤ v.count false + 1` over every certified window.
+
+### Key Findings
+- The bound is SHARP: the alternating transcript `true :: false :: … :: true` (arising when `d`
+  is odd) attains `2·count true = length + 1`.
+- **Honest reach (not a density push).** `a ≤ b + 1` (with `a = #odd`, `b = #even`) is strictly
+  weaker than the mother module's drop criterion `3^a < 2^b` (which needs `a < b·log2/log3 ≈
+  0.63 b`). Adjacency alone does NOT force a drop — this is the *exact* combinatorial content
+  extractable from odd/even adjacency, no more, and it explains precisely why Part XII could not
+  reach the drop criterion. Floor unchanged (115/128), `tao_2019` BLOCKED.
+
+### Files Modified
+- proofs/Proofs/CollatzStructuredOQ02OQ03CertUnique.lean (+5 thm, 345→443 lines; 0 axioms)
+- src/data/research/problems/collatz-structured-oq-02-oq-03.json (insights/builtItems/progressSummary)
+
+### GOTCHA / process
+- `cases ha : a` (Bool) substitutes into the GOAL, breaking a `rw [hc]` whose `hc` still
+  mentions `a`; use `rcases Bool.dichotomy a with ha | ha` to keep `a` un-substituted in the goal.
+- The CertUnique *olean* on disk was stale (predated Part XII), so a scratch that *imports*
+  CertUnique could not see `affValid_no_two_consecutive_odd`; building the CertUnique *source*
+  file directly against the (current) mother olean works. Add new companion theorems in-file.
+
+### Next Steps (unchanged, genuinely hard)
+- Closure length bound `AffValid v (2^b) r ⟹ v.length ≤ 2b+1` via tracking `v₂(leadCoeff)`
+  (even steps drop it by 1, odd steps preserve it) — would make `affValid_prefix_deriveVec_pow`
+  unconditional. My count bound is a partial ingredient (bounds #odd, not yet the length).
+- Terras natural-density-1 remains the only real lever; `tao_2019` BLOCKED.

--- a/src/data/research/problems/collatz-structured-oq-02-oq-03.json
+++ b/src/data/research/problems/collatz-structured-oq-02-oq-03.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (researcher-3 2026-07-12, axiom-free, offline EXIT 0): Part XIII (ConstBound.lean) adds the first bound on the constant term of a certified affine window (D+1 <= 3^(#odd)*(d+1)) plus the uniform eventual-drop theorem: the leading criterion 3^a<2^b alone forces every class member past an explicit threshold to attain below itself, dropping the hand-checked D<r boundary condition. tao_2019 stays BLOCKED.",
+    "progressSummary": "PROGRESS (researcher-1 2026-07-13, axiom-free, offline EXIT 0 [propext/Classical.choice/Quot.sound only]): Part XII (cont.) in CertUnique.lean quantifies the no-two-consecutive-odd shape law into a sharp count bound 2*(count true) <= length+1, i.e. triplings <= halvings+1 over every certified window (affValid_count_true_le_count_false_succ). This is the exact combinatorial content of odd/even adjacency but stays strictly weaker than the drop criterion 3^a<2^b. tao_2019 stays BLOCKED.",
     "builtItems": [
       "collatz_odd helper (collatz n = 3n+1 for odd n) in CollatzStructuredOQ02OQ03.lean",
       "mod_four_one_attainsBelow: n≡1 mod 4, n≥5 ⇒ AttainsBelow n (axiom-free)",
@@ -69,7 +69,11 @@
       "affValid_length_le_deriveVec (CertUnique.lean): length maximality v.length <= (deriveVec fuel c d).length, axiom-free",
       "deriveVec_prefix_mono (CertUnique.lean): fuel <= fuel2 implies deriveVec fuel c d prefix of deriveVec fuel2 c d, axiom-free",
       "affValid_prefix_deriveVec_pow (CertUnique.lean): dyadic prefix maximality with intrinsic bound v.length <= 2b+1 (drops self-referential hypothesis of affValid_prefix_deriveVec), axiom-free",
-      "CollatzStructuredOQ02OQ03ExceptionalSet.lean (imports ConstBound, VERIFIED): affValid_attainsBelow_of_ge (division-free threshold m≥3^a(d+1)⟹drop, choice-free), affValid_not_attainsBelow_lt (¬drop⟹m<B), affValid_exceptional_subset_range (exceptional set ⊆ range B), affValid_exceptional_card_le (|exceptional ∩ range N| ≤ 3^(#odd)·(d+1) uniformly in N). 4 thm, only foundational axioms."
+      "CollatzStructuredOQ02OQ03ExceptionalSet.lean (imports ConstBound, VERIFIED): affValid_attainsBelow_of_ge (division-free threshold m≥3^a(d+1)⟹drop, choice-free), affValid_not_attainsBelow_lt (¬drop⟹m<B), affValid_exceptional_subset_range (exceptional set ⊆ range B), affValid_exceptional_card_le (|exceptional ∩ range N| ≤ 3^(#odd)·(d+1) uniformly in N). 4 thm, only foundational axioms.",
+      "count_true_le_of_noTwoTrue / two_mul_count_true_le_of_isChain in CollatzStructuredOQ02OQ03CertUnique.lean (general: IsChain no-true-true => 2*count true <= length+1)",
+      "count_true_add_count_false (Bool partition identity count true + count false = length)",
+      "affValid_two_mul_count_true_le : AffValid v c d => 2*(v.count true) <= v.length+1",
+      "affValid_count_true_le_count_false_succ : AffValid v c d => v.count true <= v.count false + 1"
     ],
     "insights": [
       "The odd residue class n ≡ 1 (mod 4), n ≥ 5, deterministically drops below itself in 3 Collatz steps: 4m+1 → 12m+4 → 6m+2 → 3m+1, with 3m+1 < 4m+1 iff m ≥ 1. First elementary family exercising the 3n+1 branch (even/powers-of-two only touch the n/2 branch).",
@@ -90,17 +94,8 @@
       "EXACT CHARACTERIZATION (uniqueness/completeness thread CLOSED): the valid certificates for a residue class r (mod 2^b) are EXACTLY the prefixes of the canonical deriveVec. Prior parts gave only the forward containment (valid ⟹ prefix, affValid_prefix_deriveVec); the converse is prefix-closure of AffValid, which holds structurally because AffValid consumes bits from the FRONT (each constructor pins the head parity and recurses into the tail with the class advanced one Collatz step), so truncating the tail only ends the derivation earlier at nil while every surviving head condition is unchanged. Two containments ⟹ the valid-certificate set is a single chain = initial segments of one vector, never a branching family. affValid_prefix_closed uses NO axioms whatsoever.",
       "Constant-term bound (Part XIII, ConstBound.lean): D+1 <= 3^(#odd)*(d+1) for the certified affine window. The mother module never bounded the constant D=(affOrbit v (c,d)).2. Odd fold d->3d+1 multiplies by 3 (the +1 absorbed by the (d+1) slack), even fold d->floor(d/2) shrinks; short structural induction generalized over both coordinates.",
       "This closes the gap that forced affine_residue_attainsBelow / parityVector_attainsBelow to carry a hand-checked D<r side condition, which only forces the drop at the boundary member m=0. With the constant bound, the leading criterion A<c ALONE gives a closed-form threshold 3^(#odd)*(d+1) <= (c-A)*m past which every class member drops (affValid_attainsBelow_of_large). So 3^a<2^b implies the class drops for cofinitely many members, no boundary caveat (affValid_attainsBelow_of_large_pow, classical 3^a<2^b headline).",
-      "Part XIV (ExceptionalSet.lean): the non-dropping set of a determined-drop class (A<c) is EXPLICITLY FINITE, bounded by B=3^(#odd)·(d+1). Packaged Part XIII's division threshold B≤(c−A)·m into division-free m≥B (since A<c ⟹ c−A≥1 ⟹ (c−A)m≥m), then contrapositive: ¬AttainsBelow(c·m+d) ⟹ m<B, so the exceptional set ⊆ range B, card ≤ B uniformly in N. Answers the standing nextStep 'pin the exact finite set of non-dropping members per class' — it's a subset of [0,3^a(d+1)) of size ≤3^a(d+1). ★Built by IMPORTING the light companion ConstBound (NOT re-declaring): its olean builds green via targeted `LAKE_UNSAFE=1 ./bin/lake build Proofs.CollatzStructuredOQ02OQ03ConstBound` (64s, Mathlib cached) — the mother module is the only one at the SIGBUS ceiling. ★Finset.filter over a Prop pred needs `open scoped Classical`."
-    ],
-    "mathlibGaps": [],
-    "nextSteps": [
-      "Fuel-sufficiency for the 2^b window: show deriveVec (2b+1) (2^b) r reaches its odd-modulus halt within 2b+1 fuel for every r, so the length side-condition in affValid_iff_prefix_deriveVec is automatically satisfied (v_2(c) drops by 1 per even-step, stays on odd-steps — needs bounding the odd-step count).",
-      "Mechanize certificate GENERATION as a tactic/decision procedure now that affValid_eq_deriveVec_self identifies the generator as deriveVec v.length c d.",
-      "Attempt the unconditional density→1 (Terras/Korec) milestone toward tao_2019, rather than more finite residue levels (enumeration theater).",
-      "Tao axiom genuinely blocked (deep analytic, >>1000 lines).",
-      "Sharpen the Part XIII eventual-drop threshold: the bound D+1<=3^a(d+1) is worst-case (all triples first); a tighter constant estimate would shrink the m-threshold and could pin the exact finite set of non-dropping members per determined-drop class.",
-      "Part XI maximality (researcher-11 2026-07-12, VERIFIED axiom-free): deriveVec produces the MAXIMAL valid certificate. Both AffValid constructors (odd/even) require c%2=0 -- exactly the branch deriveVec takes before emitting a bit -- so the certificate recursion and the engine recursion stay in lockstep. affValid_prefix_deriveVec_of_length: AffValid v c d and v.length <= fuel imply v is a prefix of deriveVec fuel c d, by induction on the AffValid derivation. This DISCHARGES the self-referential hypothesis v.length <= (deriveVec ...).length that affValid_prefix_deriveVec assumed, replacing it with the intrinsic fuel budget v.length <= fuel (met by fuel = v.length).",
-      "deriveVec_length_le: (deriveVec fuel c d).length <= fuel unconditionally (induction on fuel; each recorded bit consumes one fuel). Gives affValid_length_le_deriveVec: v.length <= (deriveVec fuel c d).length -- the length-maximality capstone: no valid certificate is strictly longer than the window the fuel reaches. Also deriveVec_prefix_mono: fuel <= fuel2 implies deriveVec fuel c d is a prefix of deriveVec fuel2 c d (the shorter derived window is itself AffValid with length <= fuel <= fuel2, so the prefix lemma applies) -- the derived certificates for a fixed class form a CHAIN under prefix, converging to the maximal transcript once the window closes."
+      "Part XIV (ExceptionalSet.lean): the non-dropping set of a determined-drop class (A<c) is EXPLICITLY FINITE, bounded by B=3^(#odd)·(d+1). Packaged Part XIII's division threshold B≤(c−A)·m into division-free m≥B (since A<c ⟹ c−A≥1 ⟹ (c−A)m≥m), then contrapositive: ¬AttainsBelow(c·m+d) ⟹ m<B, so the exceptional set ⊆ range B, card ≤ B uniformly in N. Answers the standing nextStep 'pin the exact finite set of non-dropping members per class' — it's a subset of [0,3^a(d+1)) of size ≤3^a(d+1). ★Built by IMPORTING the light companion ConstBound (NOT re-declaring): its olean builds green via targeted `LAKE_UNSAFE=1 ./bin/lake build Proofs.CollatzStructuredOQ02OQ03ConstBound` (64s, Mathlib cached) — the mother module is the only one at the SIGBUS ceiling. ★Finset.filter over a Prop pred needs `open scoped Classical`.",
+      "Part XII (cont.): the \"no two consecutive odd steps\" shape constraint quantifies to a sharp count bound 2*(v.count true) <= v.length + 1 for any valid certificate (general list lemma: any IsChain for \"true forces next false\" has at most ceil(len/2) trues, two-step budget induction). Corollary affValid_count_true_le_count_false_succ: #odd(triplings) <= #even(halvings) + 1 over every certified window. HONEST REACH: a <= b+1 is strictly weaker than the drop criterion 3^a < 2^b, so adjacency alone does NOT force a drop; this is the exact combinatorial content of odd/even adjacency, no more."
     ],
     "mathlibGaps": [],
     "nextSteps": [
@@ -128,7 +123,7 @@
     "mathlib": []
   },
   "started": "2026-03-30T18:39:05.245Z",
-  "lastUpdate": "2026-07-09",
+  "lastUpdate": "2026-07-13",
   "leanFiles": [
     {
       "path": "Proofs/CollatzStructured.lean",


### PR DESCRIPTION
## Summary
Research session for `collatz-structured-oq-02-oq-03` (OQ-03, Tao 2019 almost-all / logarithmic-density-1). Extends the certificate algebra in the companion module `CollatzStructuredOQ02OQ03CertUnique.lean` (Part XII continuation).

## Progress
Turns the qualitative Part XII shape law `affValid_no_two_consecutive_odd` (a valid parity certificate never contains `true :: true`) into a **quantitative count bound**. Five theorems, axiom-free:

- `count_true_le_of_noTwoTrue` — general list lemma: any `Bool` list that is a `List.IsChain` for "an odd bit forces the next to be even" satisfies `2 · (count true) ≤ length + 1`. Two-step budget induction (even head → tail; odd head forces `false` and peels `true :: false`).
- `two_mul_count_true_le_of_isChain` — unbudgeted wrapper.
- `count_true_add_count_false` — Bool partition identity `count true + count false = length`.
- `affValid_two_mul_count_true_le` — `AffValid v c d ⟹ 2·(v.count true) ≤ v.length + 1`.
- `affValid_count_true_le_count_false_succ` — **triplings ≤ halvings + 1**: `v.count true ≤ v.count false + 1` over every certified window.

Files:
- `proofs/Proofs/CollatzStructuredOQ02OQ03CertUnique.lean` (+5 thm, 345→443 lines, 0 axioms)
- `src/data/research/problems/collatz-structured-oq-02-oq-03.json` (knowledge)
- `research/problems/collatz-structured-oq-02-oq-03/knowledge.md` (session note)

## Findings
- The bound is **sharp**: the alternating transcript `true :: false :: … :: true` (arising when `d` is odd) attains `2·count true = length + 1`.
- **Honest reach (not a density push).** `a ≤ b + 1` (with `a = #odd`, `b = #even`) is strictly weaker than the mother module's drop criterion `3^a < 2^b`. Adjacency alone does **not** force a drop — this is the exact combinatorial content of odd/even adjacency, and it explains precisely why Part XII stops short of the drop criterion. Density floor unchanged (115/128); `tao_2019` stays BLOCKED (deep analytic, >>1000 lines).

## Verification
Offline build `LAKE_UNSAFE=1 ./bin/lake env lean Proofs/CollatzStructuredOQ02OQ03CertUnique.lean` → EXIT 0, no warnings. `#print axioms` on all four new supporting results = `[propext, Classical.choice, Quot.sound]` only.

## Status
**Outcome**: progress (axiom-free structure theorem)
**Next Steps**: Closure length bound `AffValid v (2^b) r ⟹ v.length ≤ 2b+1` via tracking `v₂(leadCoeff)` (this count bound is a partial ingredient — bounds `#odd`, not yet the length). Terras natural-density-1 remains the only real lever toward `tao_2019`.

🤖 Generated by researcher-1