### PR TITLE
fix: guard-destructive merge hint — resolve real merge-pr.sh path + document verify false-negative

### DIFF
--- a/.loom/hooks/guard-destructive.sh
+++ b/.loom/hooks/guard-destructive.sh
@@ -310,7 +310,21 @@ done
 # =============================================================================
 
 if echo "$COMMAND" | grep -qE 'gh\s+pr\s+merge'; then
-    deny "Use ./.loom/scripts/merge-pr.sh <PR_NUMBER> instead of 'gh pr merge'. The script merges via the GitHub API without local checkout, which avoids worktree errors."
+    # .loom/scripts/ is gitignored runtime state and is not installed in this
+    # repo, so resolve the merge script from the loom checkout as a fallback
+    # rather than pointing agents at a path that doesn't exist.
+    MERGE_PR_SCRIPT="./.loom/scripts/merge-pr.sh"
+    if [[ ! -x "$MERGE_PR_SCRIPT" ]]; then
+        for candidate in \
+            "${LOOM_HOME:-$HOME/GitHub/loom}/defaults/scripts/merge-pr.sh" \
+            "$HOME/GitHub/loom/defaults/scripts/merge-pr.sh"; do
+            if [[ -x "$candidate" ]]; then
+                MERGE_PR_SCRIPT="$candidate"
+                break
+            fi
+        done
+    fi
+    deny "Use $MERGE_PR_SCRIPT <PR_NUMBER> instead of 'gh pr merge'. The script merges via the GitHub API without local checkout, which avoids worktree errors. Known issue: on this host the script's post-merge verify false-negatives ('Merge API call returned but PR is not merged') even when the merge succeeded — always confirm with 'gh pr view <PR_NUMBER> --json state' before retrying."
 fi
 
 # =============================================================================


### PR DESCRIPTION
## Problem

The `gh pr merge` guard in `.loom/hooks/guard-destructive.sh` tells agents to use `./.loom/scripts/merge-pr.sh`, but that path does not exist in this repo — `.loom/scripts/` is gitignored runtime state and is not installed on this host. During the 2026-07-13 backlog drain (106 PRs), every doctor/deployer agent hitting the guard had to independently rediscover the real script at `~/GitHub/loom/defaults/scripts/merge-pr.sh`, and then also independently discover that the script's post-merge verify reports a false-negative ("Merge API call returned but PR is not merged") on every successful merge.

## Fix

- The deny message now resolves the script path dynamically: in-repo `./.loom/scripts/merge-pr.sh` if installed, else `$LOOM_HOME/defaults/scripts/merge-pr.sh`, else the `~/GitHub/loom` checkout.
- The message documents the known verify false-negative and instructs agents to confirm with `gh pr view <n> --json state` instead of retry-looping.

## Root cause of the false-negative (filed upstream at rjwalters/loom)

`merge-pr.sh` falls back to plain `gh` when `.loom/scripts/gh-cached` is absent, but `forge_get_pr_nocache` (lib/forge-helpers.sh) unconditionally passes the `gh-cached`-only `--no-cache` flag. Plain `gh` errors, stderr is swallowed by `2>/dev/null`, the caller substitutes `{}`, and `.merged // false` reads false — deterministically, on every merge.

## Testing

- `bash -n` clean.
- Fed the hook a PreToolUse payload containing `gh pr merge 123 --squash` on stdin: deny fires with the resolved absolute path and the false-negative warning (verified on this host, where the loom checkout path is picked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
