### PR TITLE
Research: inverse-galois-oq-03 - perfectness as universal property + field-side consequence

### DIFF
--- a/proofs/Proofs/InverseGaloisOQ03.lean
+++ b/proofs/Proofs/InverseGaloisOQ03.lean
@@ -571,4 +571,70 @@ theorem Monster_two_le_card_primeFactors :
   calc (2 : ℕ) = ({2, 3} : Finset ℕ).card := by decide
     _ ≤ (Fintype.card Monster).primeFactors.card := Finset.card_le_card hsub
 
+-- ============================================================================
+-- Part VII: Perfectness — no abelian quotient, and its field-side consequence
+-- ============================================================================
+
+/-
+`Monster_commutator_eq_top` says `𝕄` is *perfect* (`[𝕄, 𝕄] = 𝕄`).  Its
+structural meaning is a universal property: a perfect group has **no nontrivial
+abelian quotient**.  We record that here, and then transport perfectness across
+Thompson's isomorphism `𝕄 ≃* Gal(K/ℚ)` to obtain the field-side statement that
+the Monster-realizing field's Galois group is itself perfect — so `K/ℚ` has no
+nontrivial abelian subextension over `ℚ` (its maximal abelian subextension, the
+fixed field of the commutator subgroup, is `ℚ` itself).
+-/
+
+/-- **𝕄 has no nontrivial abelian quotient.**  Any surjective homomorphism from
+    the Monster onto a *commutative* group `A` has trivial image, i.e. `A` is
+    trivial.  This is the universal-property form of perfectness
+    (`Monster_commutator_eq_top`): since `[𝕄, 𝕄] = 𝕄`, the image of `𝕄` in any
+    abelian group is `⁅⊤, ⊤⁆ = ⊥`, so a surjection forces the target to be
+    trivial.  Equivalently, the abelianization of `𝕄` is trivial. -/
+theorem Monster_no_nontrivial_abelian_quotient {A : Type*} [CommGroup A]
+    (φ : Monster →* A) (hφ : Function.Surjective φ) : Subsingleton A := by
+  -- Image of the commutator subgroup: `(commutator 𝕄).map φ = ⁅range φ, range φ⁆`.
+  have hrange : φ.range = ⊤ := MonoidHom.range_eq_top.mpr hφ
+  have hmap : (commutator Monster).map φ = ⁅φ.range, φ.range⁆ := map_commutator_eq Monster φ
+  rw [Monster_commutator_eq_top, Subgroup.map_top_of_surjective _ hφ, hrange] at hmap
+  -- So `commutator A = ⊤`.
+  have hcommA_top : commutator A = ⊤ := by rw [commutator_def]; exact hmap.symm
+  -- But `A` is abelian, so `commutator A = ⊥`.
+  have hcommA_bot : commutator A = ⊥ := by
+    rw [commutator_def, eq_bot_iff, Subgroup.commutator_le]
+    intro g₁ _ g₂ _
+    rw [Subgroup.mem_bot, commutatorElement_eq_one_iff_mul_comm]
+    exact mul_comm g₁ g₂
+  -- `⊤ = ⊥` in `Subgroup A` forces `A` to be a singleton.
+  have htb : (⊤ : Subgroup A) = ⊥ := hcommA_top ▸ hcommA_bot
+  refine ⟨fun a b => ?_⟩
+  have ha : a ∈ (⊥ : Subgroup A) := htb ▸ Subgroup.mem_top a
+  have hb : b ∈ (⊥ : Subgroup A) := htb ▸ Subgroup.mem_top b
+  rw [Subgroup.mem_bot] at ha hb
+  rw [ha, hb]
+
+/-- **The Monster-realizing field's Galois group is perfect.**  For any field `K`
+    with `Gal(K/ℚ) ≅ 𝕄` (Thompson 1984), the commutator subgroup of `Gal(K/ℚ)` is
+    the whole group: `[Gal(K/ℚ), Gal(K/ℚ)] = Gal(K/ℚ)`.  Perfectness transports
+    across the isomorphism `e : 𝕄 ≃* Gal(K/ℚ)` from `Monster_commutator_eq_top`
+    (`map_commutator_eq` sends `[𝕄, 𝕄] = ⊤` to `⁅range e, range e⁆ = ⁅⊤, ⊤⁆`).
+    The field-side counterpart of `Monster_commutator_eq_top`, in the same spirit
+    as `Monster_realizing_field_not_solvable`.  Consequently, by the Galois
+    correspondence, `K/ℚ` has **no nontrivial abelian subextension**: the maximal
+    abelian subextension — the fixed field of the commutator subgroup — is `ℚ`
+    itself. -/
+theorem Monster_realizing_field_gal_commutator_eq_top :
+    ∃ (K : Type) (_ : Field K) (_ : Algebra ℚ K) (_ : FiniteDimensional ℚ K)
+      (_ : IsGalois ℚ K), commutator (K ≃ₐ[ℚ] K) = ⊤ := by
+  obtain ⟨K, fK, aK, fdK, gK, ⟨e⟩⟩ := Monster_realizable_over_Q
+  letI := fK; letI := aK; letI := fdK; letI := gK
+  refine ⟨K, fK, aK, fdK, gK, ?_⟩
+  have hsurj : Function.Surjective e.toMonoidHom := e.surjective
+  have hrange : e.toMonoidHom.range = ⊤ := MonoidHom.range_eq_top.mpr hsurj
+  have hmap : (commutator Monster).map e.toMonoidHom = ⁅e.toMonoidHom.range, e.toMonoidHom.range⁆ :=
+    map_commutator_eq Monster e.toMonoidHom
+  rw [Monster_commutator_eq_top, Subgroup.map_top_of_surjective _ hsurj, hrange] at hmap
+  rw [commutator_def]
+  exact hmap.symm
+
 end InverseGaloisOQ03

--- a/research/problems/inverse-galois-oq-03/state.md
+++ b/research/problems/inverse-galois-oq-03/state.md
@@ -27,3 +27,27 @@ Now compiles clean (exit 0, olean written), **0 sorries, 6 axioms** (unchanged, 
 Monster, Monster_card, Monster_isSimple, Monster_realizable_over_Q + the two Monster instances;
 `#print axioms` shows no sorryAx / ofReduceBool). Gallery meta counts (361 lines / 19 theorems /
 6 axioms) remain accurate. The p-group / Monster-realizability theme is otherwise saturated.
+
+## Session 2026-07-13 (researcher-3) — perfectness as a universal property + field-side (VERIFIED)
+
+SOLVED-state look-outward on a saturated problem. The file had `Monster_commutator_eq_top`
+([𝕄,𝕄]=𝕄, perfect) but only in commutator-subgroup form. Added the two structurally
+meaningful consequences absent from the file:
+
+- `Monster_no_nontrivial_abelian_quotient {A}[CommGroup A](φ:𝕄→*A)(surj) : Subsingleton A`
+  — the universal-property form of perfectness: 𝕄 has NO nontrivial abelian quotient. Proof:
+  `map_commutator_eq Monster φ` sends [𝕄,𝕄]=⊤ (surj⟹range=⊤, map_top_of_surjective) to
+  commutator A = ⊤; but A abelian ⟹ commutator A = ⊥ (commutatorElement_eq_one_iff_mul_comm);
+  ⊤=⊥ in Subgroup A ⟹ Subsingleton A.
+- `Monster_realizing_field_gal_commutator_eq_top` — FIELD-SIDE: for Thompson's realizing K,
+  commutator (K≃ₐ[ℚ]K)=⊤ (Gal(K/ℚ) is perfect). Transports perfectness across e:𝕄≃*Gal via
+  the same map_commutator_eq mechanism. By Galois correspondence ⟹ K/ℚ has NO nontrivial
+  abelian subextension (max abelian subext = fixed field of commutator = ℚ). Field-side
+  counterpart of Monster_commutator_eq_top, mirrors Monster_realizing_field_not_solvable.
+
+★Gotcha: `map_commutator_eq` has G EXPLICIT (`variable (G)` at Commutator/Basic.lean:224) →
+call `map_commutator_eq Monster φ`, NOT `map_commutator_eq φ` (else "expected Type" mismatch).
+★Docker exit-139 SIGSEGV + exit-135 SIGBUS codegen crashes (post-elaboration, no error: line)
+— retry built green (`✔ Built (8.0s)`, 7749 jobs). 6 axioms unchanged (all deep Monster
+inputs, not eliminable), 0 real sorries, no native_decide. 40→42 theorems, 574→640 lines.
+Gallery meta synced (was stale 513/37). Theme remains saturated after this.

--- a/src/data/proofs/inverse-galois-oq-03/meta.json
+++ b/src/data/proofs/inverse-galois-oq-03/meta.json
@@ -39,9 +39,9 @@
         "relationship": "Sister entry on the non-solvable frontier and the solvability divide"
       }
     ],
-    "lineCount": 513,
+    "lineCount": 640,
     "mathlib_version": "4.26.0",
-    "theoremCount": 37,
+    "theoremCount": 42,
     "definitionCount": 0,
     "additionalFiles": []
   },
@@ -145,10 +145,10 @@
   "sorries": 0,
   "leanFile": {
     "path": "Proofs/InverseGaloisOQ03.lean",
-    "lineCount": 513,
+    "lineCount": 640,
     "axiomCount": 6,
     "sorries": 0,
-    "theoremCount": 37,
+    "theoremCount": 42,
     "definitionCount": 0,
     "imports": [
       "Mathlib",

--- a/src/data/research/problems/inverse-galois-oq-03.json
+++ b/src/data/research/problems/inverse-galois-oq-03.json
@@ -26,16 +26,19 @@
     "focus": "Verified deliverable already complete in main: proofs/Proofs/InverseGaloisOQ03.lean and gallery entry inverse-galois-oq-03 (status axiomatized)."
   },
   "knowledge": {
-    "progressSummary": "COMPLETED (axiomatized) in main (261 lines, 14 theorems, 0 sorries, axiomCount 6, badge 'axiom'); the stated assumptions are isolated as named axioms per the axiom-integrity policy. Formalizes the structural group theory of the Monster 𝕄, the largest sporadic simple group, and records Thompson's theorem (1984) that 𝕄 is realizable as a Galois group over ℚ. Proves 𝕄 is non-commutative, perfect ([𝕄,𝕄] = 𝕄), and non-solvable — hence beyond Shafarevich's theorem — yet realized over ℚ via the rigidity method. Includes the order |𝕄| = 2⁴⁶·3²⁰·5⁹·7⁶·11²·13³·17·19·23·29·31·41·47·59·71 and divisibility results. The affirmative counterpart to the open M₂₃ case (OQ-02).",
+    "progressSummary": "PROGRESS: Added the universal-property reading of Monster perfectness (Monster_no_nontrivial_abelian_quotient) and its field-side counterpart (Monster_realizing_field_gal_commutator_eq_top: Gal(K/ℚ) perfect ⟹ K/ℚ has no nontrivial abelian subextension). 6 axioms unchanged, 0 sorries; 40→42 theorems. Theme saturated.",
     "builtItems": [
-      "Gallery entry src/data/proofs/inverse-galois-oq-03 (meta.json + annotations.json); Lean source proofs/Proofs/InverseGaloisOQ03.lean."
+      "Gallery entry src/data/proofs/inverse-galois-oq-03 (meta.json + annotations.json); Lean source proofs/Proofs/InverseGaloisOQ03.lean.",
+      "Monster_no_nontrivial_abelian_quotient (InverseGaloisOQ03.lean:594): universal-property form of perfectness — 𝕄 has no nontrivial abelian quotient (any surjection onto a CommGroup A forces Subsingleton A).",
+      "Monster_realizing_field_gal_commutator_eq_top (:626): field-side perfectness — Gal(K/ℚ) of Thompson's Monster-realizing field is perfect (commutator = ⊤), so K/ℚ has no nontrivial abelian subextension."
     ],
     "insights": [
       "**Size is not difficulty**: The Monster ($\\approx 8\\times10^{53}$ elements) is realized over $\\mathbb{Q}$, while $M_{23}$ ($\\approx 10^7$ elements) is the sole open sporadic case. Realizability is governed by the existence of rigid rational triples of conjugacy classes, not by group order.",
       "**Same skeleton, opposite verdict**: The non-abelian → perfect → non-solvable chain is identical to the M₂₃ analysis of OQ-02; the two entries differ only in the final realizability bit — open for M₂₃, an axiom citing Thompson for 𝕄.",
       "**Beyond Shafarevich, yet realized**: Shafarevich's theorem covers only solvable groups. 𝕄 is non-solvable, so its realization is genuine evidence that the rigidity method reaches deep into the non-solvable frontier.",
       "**No small permutation carrier**: Unlike the Mathieu groups, the Monster has no faithful permutation representation of small degree (the minimum is on the order of $10^{19}$ points), so it is formalized as an abstract finite group rather than a subgroup of some $S_n$.",
-      "**A landmark cited, not re-proved**: Thompson's 1984 realization of the Monster is recorded as an axiom, in the same spirit that the parent entry axiomatizes Shafarevich's theorem. The verified content here is the structural group theory that situates 𝕄 in the program."
+      "**A landmark cited, not re-proved**: Thompson's 1984 realization of the Monster is recorded as an axiom, in the same spirit that the parent entry axiomatizes Shafarevich's theorem. The verified content here is the structural group theory that situates 𝕄 in the program.",
+      "Perfectness [𝕄,𝕄]=𝕄 transports across the Thompson iso 𝕄≃*Gal(K/ℚ) via map_commutator_eq (G explicit) + map_top_of_surjective, giving the Galois group of the realizing field is perfect — the field-side reading is 'no nontrivial abelian subextension of K/ℚ'."
     ],
     "mathlibGaps": [],
     "nextSteps": []


### PR DESCRIPTION
## Summary
Research session for **inverse-galois-oq-03** (the Monster group 𝕄 realized as a Galois group over ℚ, Thompson 1984). The file recorded perfectness only as `Monster_commutator_eq_top` (`[𝕄,𝕄] = 𝕄`). This PR adds its two structurally meaningful readings, one purely group-theoretic and one on the field side of the inverse-Galois problem.

## Progress
- `Monster_no_nontrivial_abelian_quotient` — the **universal-property form** of perfectness: any surjective homomorphism from 𝕄 onto a *commutative* group `A` forces `A` to be trivial. Since `[𝕄,𝕄] = 𝕄`, the image of 𝕄 in any abelian group is `⁅⊤,⊤⁆ = ⊥`. So 𝕄 has no nontrivial abelian quotient (equivalently, its abelianization is trivial).
- `Monster_realizing_field_gal_commutator_eq_top` — the **field-side** counterpart: for Thompson's realizing field `K` (`Gal(K/ℚ) ≅ 𝕄`), the Galois group is itself perfect, `commutator (K ≃ₐ[ℚ] K) = ⊤`. Transports `Monster_commutator_eq_top` across the isomorphism `e : 𝕄 ≃* Gal(K/ℚ)` (`map_commutator_eq` + `map_top_of_surjective`), mirroring the existing `Monster_realizing_field_not_solvable`. By the Galois correspondence this says **`K/ℚ` has no nontrivial abelian subextension** — its maximal abelian subextension (the fixed field of the commutator subgroup) is `ℚ` itself.

## Findings
- Perfectness is a transportable invariant: the same `map_commutator_eq` mechanism moves `[𝕄,𝕄] = ⊤` to the Galois group of any realization.
- `theoremCount` 40 → 42, `lineCount` 574 → 640. Gallery meta synced (was stale at 513 lines / 37 theorems).

## Verification
Docker build (`docker-build.sh Proofs.InverseGaloisOQ03`): **✔ Built (8.0s), 7749 jobs**. **6 axioms unchanged** (all deep Monster inputs — existence, order, simplicity, Thompson realizability — none eliminable from Mathlib), **0 sorries, no `native_decide`**. (The build hit intermittent post-elaboration codegen crashes — exit 139/135 — and built green on retry.)

## Status
**Outcome**: progress (structural theorems added to a RESOLVED/saturated entry)
**Next Steps**: the Monster-realizability / perfectness theme is saturated; the remaining depth (explicit rigid-triple construction, or the open M₂₃ sibling in OQ-02) is out of elementary reach.

🤖 Generated by researcher-3