### PR TITLE
docs: researcher role — close ancestor PRs when a newer head opens (Step 5.6)

### DIFF
--- a/.lean/roles/COMMON.md
+++ b/.lean/roles/COMMON.md
@@ -102,6 +102,13 @@ of tracked files missing on disk and sparse-checkout off (`LAUNCH_ANYWAY=1`
 overrides), and the deployer skips auto-merging PRs with >100 deleted lines or
 >500 changed files (see `deployer.md`).
 
+## PR Hygiene (Stacked Snapshots)
+
+Any agent that opens PRs from a long-lived branch must close the ancestor PR
+when a newer head from the same branch opens (one branch, one open PR). Full
+rule and commands: `researcher.md` Step 5.6 ("Close Ancestor PRs When a Newer
+Head Opens").
+
 ## Honesty Standards
 
 - Do not describe trivial results as significant.

--- a/.lean/roles/researcher.md
+++ b/.lean/roles/researcher.md
@@ -47,7 +47,8 @@ while true:
     2. Claim a problem from the candidate pool
     3. Run one research iteration (following the research skill)
     4. Commit meaningful progress
-    5. Create a PR with findings (run the Supersession Guard first — Step 5.5)
+    5. Create a PR with findings (run the Supersession Guard first — Step 5.5,
+       then close any ancestor PRs from the same branch — Step 5.6)
     6. Update problem status and knowledge
     7. Release claim
     8. Repeat
@@ -467,6 +468,46 @@ if [[ "$verdict" == "SUPERSEDED" ]]; then
 fi
 # verdict is NOT_SUPERSEDED or NO_PROOF_FILES → safe to proceed.
 ```
+
+## Step 5.6: Close Ancestor PRs When a Newer Head Opens (MANDATORY)
+
+The Supersession Guard above catches duplicates against **main**. This step
+catches duplicates against **your own open PRs**. A long-lived branch (e.g.
+`feature/researcher-N`) accumulates commits across sessions, and opening a new
+PR from that branch after each session produces **stacked snapshots**: the new
+PR's commits are a superset of the previous PR's, so the older PRs carry no
+unique content, go CONFLICTING the moment any sibling merges, and each one
+costs a doctor a full statement-level supersession analysis. The 2026-07-13
+backlog drain closed ~49 of 106 open PRs for exactly this reason (4–5 stacked
+snapshots per branch was typical).
+
+Rules, applied **at the moment you open a new PR**:
+
+1. **Check your own open PRs first** — look for ones from the same branch or
+   touching the same `proofs/Proofs/*.lean` files:
+
+   ```bash
+   gh pr list --author @me --state open --json number,headRefName,title
+   # Scoped variant:
+   gh pr list --author @me --state open --search "<file-or-branch>"
+   ```
+
+2. **If the new PR's commits are a superset of an older open PR's** (same
+   branch, newer head — verify with
+   `git merge-base --is-ancestor <old-pr-head-sha> HEAD`), **close the
+   ancestor with a supersession comment** pointing at the new head:
+
+   ```bash
+   gh pr close <old-number> \
+     --comment "Superseded by #<new-number> — same branch, newer head; all commits are included there."
+   ```
+
+3. **Prefer one PR per unit of work from a fresh `origin/main` branch** over
+   accumulating a long-lived branch. If a long-lived branch is unavoidable,
+   keep exactly **one** open PR tracking its head — never two.
+
+Leaving the ancestor open is not a courtesy — it is wasted doctor effort. The
+old snapshot has no unique content; close it yourself when the new head opens.
 
 ## Step 6: Create Pull Request
 


### PR DESCRIPTION
## Summary

Adds a mandatory "close ancestor PRs when a newer head opens" habit to the mathematical researcher role docs. The 2026-07-13 backlog drain closed ~49 of 106 open PRs as stacked snapshots — successive PRs from the same moving branch (4-5 per branch), where only the newest head had unique content and every ancestor went CONFLICTING on the first sibling merge, each costing a doctor a full statement-level supersession analysis.

## Changes

- **`.lean/roles/researcher.md`** — new **Step 5.6: Close Ancestor PRs When a Newer Head Opens (MANDATORY)**, placed directly after the existing Step 5.5 Supersession Guard (Step 5.5 covers add/add duplicates against *main*; Step 5.6 covers duplicates against the researcher's *own open PRs*):
  1. Before opening a PR, check your own open PRs from the same branch or touching the same `proofs/Proofs/*.lean` files (`gh pr list --author @me --state open ...`).
  2. If the new PR's commits are a superset of an older open PR's (verify with `git merge-base --is-ancestor <old-head> HEAD`), close the ancestor with a supersession comment pointing at the new head, at the moment the new PR opens (`gh pr close <old> --comment "Superseded by #<new> ..."`).
  3. Prefer one PR per unit of work from a fresh `origin/main` branch; if a long-lived branch is unavoidable, keep exactly ONE open PR tracking its head.
  - Main Loop step 5 updated to reference both 5.5 and 5.6.
- **`.lean/roles/COMMON.md`** — new two-line "PR Hygiene (Stacked Snapshots)" section cross-referencing researcher.md Step 5.6 (other math agents also PR from long-lived `feature/<agent-id>` branches; full text is not duplicated).

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `.lean/roles/researcher.md` documents the pre-PR ancestor check | ✅ | Step 5.6 rule 1: `gh pr list --author @me --state open` before opening any PR |
| `.lean/roles/researcher.md` documents the close-on-supersede rule | ✅ | Step 5.6 rule 2: ancestor detection via `git merge-base --is-ancestor` + `gh pr close` with supersession comment at the moment the new PR opens |
| COMMON.md cross-reference (issue: "and COMMON.md if shared") | ✅ | Two-line "PR Hygiene (Stacked Snapshots)" section pointing at Step 5.6 |
| (Optional) automated ancestor-pair sweep | ⬜ | Explicitly deferred by the issue as follow-up automation; not in this docs-only PR |

## Test Plan

Docs-only change. Verified the diff renders sensibly: new section slots between Step 5.5 and Step 6, matches the file's existing tone (MANDATORY headers, numbered rules, bash snippets, incident citation), and the COMMON.md section is a pointer, not a duplicate.

Closes #38583

🤖 Generated with [Claude Code](https://claude.com/claude-code)
