### PR TITLE
Research: erdos-101-oq-04 — exact collinearity bound for polynomial graphs (degree-general no-collinear)

### DIFF
--- a/proofs/Proofs/Erdos101OQ04PolyDegree.lean
+++ b/proofs/Proofs/Erdos101OQ04PolyDegree.lean
@@ -1,0 +1,155 @@
+import Proofs.Erdos101OQ04
+
+/-!
+# Erdős #101 OQ-04 — the exact collinearity bound for a polynomial graph (companion)
+
+The mother module `Proofs.Erdos101OQ04` proves `noFiveCollinear_of_onPolyGraph`: a point set
+lying on the graph `y = Poly.eval x` of a polynomial with `2 ≤ deg Poly ≤ 4` has no five
+collinear points.  That lemma is capped twice — at the fixed count *five* and at degree *four*
+— which are artefacts of the specific quartic construction `y = x⁴ − 5x²`, not of the geometry.
+
+This companion removes both caps.  The underlying fact is the **exact** one:
+
+> a non-vertical line meets the graph `y = Poly.eval x` where the polynomial
+> `q = C(Δx)·Poly − C(Δy)·X − C(const)` vanishes, and (since `deg Poly ≥ 2` keeps the linear
+> correction from touching the top term) `deg q = deg Poly`, so the line carries **at most
+> `deg Poly`** graph points.
+
+Hence *any* collinear subset of a degree-`d` polynomial-graph point set has cardinality `≤ d`
+— for every `d ≥ 2`, with no ceiling.  The `noFiveCollinear` result is exactly the `d ≤ 4`
+reading (`d ≤ 4 < 5`); a quintic graph is no-six-collinear, a degree-`d` graph is
+no-`(d+1)`-collinear, etc.  This is the honest structural content behind the quartic
+construction, in the form that scales with the degree — directly relevant to the
+higher-degree / higher-dimensional line-count question of Erdős #101.
+
+Self-contained beyond the mother module (`onPolyGraph`, `onPolyGraph_fst_ne`, `collinear`,
+`PlanarPointSet`, `NoFiveCollinear` are reused as-is).  Axiom-free (no `decide`, no new axiom).
+-/
+
+namespace Erdos101OQ04
+
+open Classical
+
+/-- **Exact collinearity bound for a polynomial graph.**  Let `Poly` have `deg Poly ≥ 2`, let
+`a, b` span a non-vertical line (`a.1 ≠ b.1`), and let `S` be a finite set of points that all
+lie on the graph `y = Poly.eval x` and are all collinear with `a, b`.  Then `S.card ≤ deg Poly`.
+
+The line `a–b` meets the graph exactly at the roots of
+`q = C(b.1−a.1)·Poly − C(b.2−a.2)·X − C((b.1−a.1)·a.2 − (b.2−a.2)·a.1)`, whose degree equals
+`deg Poly` (the `deg ≥ 2` hypothesis keeps the degree-`≤1` correction from cancelling the top
+coefficient `(b.1−a.1)·leadingCoeff ≠ 0`).  Mapping `S` into `q.roots` by first coordinate is
+injective (distinct graph points have distinct abscissae), so `S.card ≤ #q.roots ≤ deg q =
+deg Poly`. -/
+theorem card_collinear_on_polyGraph_le (Poly : Polynomial ℝ) (hd : 2 ≤ Poly.natDegree)
+    {a b : ℝ × ℝ} (hab : a.1 ≠ b.1) {S : Finset (ℝ × ℝ)}
+    (hSg : ∀ p ∈ S, onPolyGraph Poly p) (hScol : ∀ p ∈ S, collinear a b p) :
+    S.card ≤ Poly.natDegree := by
+  have hA0 : b.1 - a.1 ≠ 0 := sub_ne_zero.mpr (Ne.symm hab)
+  set q : Polynomial ℝ :=
+      Polynomial.C (b.1 - a.1) * Poly
+        - Polynomial.C (b.2 - a.2) * Polynomial.X
+        - Polynomial.C ((b.1 - a.1) * a.2 - (b.2 - a.2) * a.1) with hq
+  -- `deg q ≤ deg Poly`: the `C·Poly` term dominates; the correction has degree `≤ 1 ≤ deg Poly`.
+  have hqdeg : q.natDegree ≤ Poly.natDegree := by
+    rw [hq]
+    refine (Polynomial.natDegree_sub_le _ _).trans (max_le ?_ ?_)
+    · refine (Polynomial.natDegree_sub_le _ _).trans (max_le ?_ ?_)
+      · exact Polynomial.natDegree_C_mul_le _ _
+      · calc (Polynomial.C (b.2 - a.2) * Polynomial.X).natDegree
+              ≤ (Polynomial.X : Polynomial ℝ).natDegree := Polynomial.natDegree_C_mul_le _ _
+            _ = 1 := Polynomial.natDegree_X
+            _ ≤ Poly.natDegree := by omega
+    · rw [Polynomial.natDegree_C]; omega
+  -- `q ≠ 0`: its coefficient at index `deg Poly (≥ 2)` is `(b.1−a.1)·leadingCoeff ≠ 0`.
+  have hpne : Poly ≠ 0 := fun h => by rw [h, Polynomial.natDegree_zero] at hd; omega
+  have hlead : Poly.leadingCoeff ≠ 0 := Polynomial.leadingCoeff_ne_zero.mpr hpne
+  have hne1 : ¬ (1 : ℕ) = Poly.natDegree := by omega
+  have hne0 : ¬ Poly.natDegree = 0 := by omega
+  have hcoeff : q.coeff Poly.natDegree = (b.1 - a.1) * Poly.leadingCoeff := by
+    rw [hq]
+    simp only [Polynomial.coeff_sub, Polynomial.coeff_C_mul, Polynomial.coeff_X,
+      Polynomial.coeff_C, if_neg hne1, if_neg hne0, mul_zero, sub_zero]
+    rw [Polynomial.leadingCoeff]
+  have hq0 : q ≠ 0 := by
+    intro h
+    rw [h, Polynomial.coeff_zero] at hcoeff
+    exact (mul_ne_zero hA0 hlead) hcoeff.symm
+  have hqeval : ∀ x : ℝ, q.eval x
+      = (b.1 - a.1) * Poly.eval x - (b.2 - a.2) * x
+        - ((b.1 - a.1) * a.2 - (b.2 - a.2) * a.1) := by
+    intro x
+    simp only [hq, Polynomial.eval_sub, Polynomial.eval_mul, Polynomial.eval_C,
+      Polynomial.eval_X]
+  -- Every graph point collinear with `a, b` has its abscissa a root of `q`.
+  have hisroot : ∀ p : ℝ × ℝ, onPolyGraph Poly p → collinear a b p → p.1 ∈ q.roots := by
+    intro p hpg hcol
+    rw [Polynomial.mem_roots hq0]
+    show q.eval p.1 = 0
+    rw [hqeval]
+    have hcol' : (b.1 - a.1) * (p.2 - a.2) = (p.1 - a.1) * (b.2 - a.2) := hcol
+    rw [hpg] at hcol'
+    linear_combination hcol'
+  -- The first-coordinate map is injective on `S` (a graph is a function of `x`).
+  have hinj : Set.InjOn (fun p : ℝ × ℝ => p.1) S := by
+    intro p hp p' hp' he
+    by_contra hne
+    exact onPolyGraph_fst_ne (hSg p hp) (hSg p' hp') hne he
+  have hsub : S.image (fun p : ℝ × ℝ => p.1) ⊆ q.roots.toFinset := by
+    intro x hx
+    simp only [Finset.mem_image] at hx
+    obtain ⟨p, hp, rfl⟩ := hx
+    rw [Multiset.mem_toFinset]
+    exact hisroot p (hSg p hp) (hScol p hp)
+  calc S.card = (S.image (fun p : ℝ × ℝ => p.1)).card := (Finset.card_image_of_injOn hinj).symm
+    _ ≤ q.roots.toFinset.card := Finset.card_le_card hsub
+    _ ≤ Multiset.card q.roots := Multiset.toFinset_card_le _
+    _ ≤ q.natDegree := Polynomial.card_roots' q
+    _ ≤ Poly.natDegree := hqdeg
+
+/-- **No `(d+1)` collinear on a degree-`d` graph** (the general count generalising
+`noFiveCollinear_of_onPolyGraph`).  If a set of `k` distinct points all lie on the graph
+`y = Poly.eval x` (`deg Poly ≥ 2`) and are mutually collinear along the non-vertical line
+`a–b`, then `k ≤ deg Poly`.  Stated with the points supplied as a `Finset` this is exactly
+`card_collinear_on_polyGraph_le`; the point of the name is that a **quartic** graph is
+no-five-collinear, a **quintic** graph is no-six-collinear, and generally a degree-`d` graph
+carries no `d+1` collinear points. -/
+theorem not_succ_natDegree_collinear_on_polyGraph (Poly : Polynomial ℝ) (hd : 2 ≤ Poly.natDegree)
+    {a b : ℝ × ℝ} (hab : a.1 ≠ b.1) {S : Finset (ℝ × ℝ)}
+    (hSg : ∀ p ∈ S, onPolyGraph Poly p) (hScol : ∀ p ∈ S, collinear a b p)
+    (hcard : Poly.natDegree < S.card) : False :=
+  absurd (card_collinear_on_polyGraph_le Poly hd hab hSg hScol) (by omega)
+
+/-- **`noFiveCollinear_of_onPolyGraph` as a corollary of the exact bound.**  For `2 ≤ deg ≤ 4`,
+five collinear points would form a 5-element collinear subset, but the exact bound caps such a
+subset at `deg ≤ 4 < 5`.  This re-derives the mother module's headline from the degree-general
+`card_collinear_on_polyGraph_le`, confirming the two are the same fact read at `d ≤ 4`. -/
+theorem noFiveCollinear_of_onPolyGraph_via_card (Poly : Polynomial ℝ)
+    (h2 : 2 ≤ Poly.natDegree) (h4 : Poly.natDegree ≤ 4)
+    (P : PlanarPointSet) (hP : ∀ p ∈ P.points, onPolyGraph Poly p) :
+    NoFiveCollinear P := by
+  intro a b c d e ha hb hc hd he hab hac had hae hbc hbd hbe hcd hce hde
+  rintro ⟨hcol_c, hcol_d, hcol_e⟩
+  have hab1 : a.1 ≠ b.1 := onPolyGraph_fst_ne (hP a ha) (hP b hb) hab
+  have hSg : ∀ p ∈ ({a, b, c, d, e} : Finset (ℝ × ℝ)), onPolyGraph Poly p := by
+    intro p hp
+    simp only [Finset.mem_insert, Finset.mem_singleton] at hp
+    rcases hp with h | h | h | h | h <;> rw [h]
+    exacts [hP a ha, hP b hb, hP c hc, hP d hd, hP e he]
+  have hScol : ∀ p ∈ ({a, b, c, d, e} : Finset (ℝ × ℝ)), collinear a b p := by
+    intro p hp
+    simp only [Finset.mem_insert, Finset.mem_singleton] at hp
+    rcases hp with h | h | h | h | h <;> rw [h]
+    · unfold collinear; ring
+    · unfold collinear; ring
+    · exact hcol_c
+    · exact hcol_d
+    · exact hcol_e
+  have hcard : ({a, b, c, d, e} : Finset (ℝ × ℝ)).card = 5 := by
+    rw [Finset.card_insert_of_notMem (by simp [hab, hac, had, hae]),
+        Finset.card_insert_of_notMem (by simp [hbc, hbd, hbe]),
+        Finset.card_insert_of_notMem (by simp [hcd, hce]),
+        Finset.card_insert_of_notMem (by simp [hde]),
+        Finset.card_singleton]
+  exact not_succ_natDegree_collinear_on_polyGraph Poly h2 hab1 hSg hScol (by omega)
+
+end Erdos101OQ04

--- a/research/problems/erdos-101-oq-04/knowledge.md
+++ b/research/problems/erdos-101-oq-04/knowledge.md
@@ -66,3 +66,48 @@ session-sized, not Aristotle-suitable. The 3536-line mother file is also under a
 Released the claim with no code change — the honest outcome. Next genuine progress requires the
 actual Solymosi–Stojaković construction (Path A projected grid or Path B parabola), a research
 frontier, not incremental scaffolding.
+
+## Session 2026-07-13 (researcher-1) — exact collinearity bound for polynomial graphs
+
+**Mode**: REVISIT (RICH, active multi-researcher). **Outcome**: progress — axiom-free,
+build-verified (`LAKE_UNSAFE=1 ./bin/lake env lean`, EXIT 0, no warnings; `#print axioms`
+on all three new results = `[propext, Classical.choice, Quot.sound]`).
+
+### What I Did
+Independent route (no collision with the active Grünbaum/Solymosi–Stojaković count sorries,
+nor the Infinite/Rational/Similarity companions). The mother module's `noFiveCollinear_of_onPolyGraph`
+is capped twice — at the fixed count *five* and at degree ≤ 4, both artefacts of the quartic
+`y = x⁴ − 5x²`. New companion `Erdos101OQ04PolyDegree.lean` removes both, proving the **exact**
+fact behind the quartic construction:
+- `card_collinear_on_polyGraph_le` — for `deg Poly ≥ 2` and a non-vertical line `a–b`, any
+  `Finset` of points lying on `y = Poly.eval x` and collinear with `a, b` has `card ≤ deg Poly`.
+  Proof: the line meets the graph at the roots of `q = C(Δx)·Poly − C(Δy)·X − C(const)`;
+  `deg q = deg Poly` (the `deg ≥ 2` hypothesis keeps the degree-≤1 correction from cancelling
+  the top coefficient `(Δx)·leadingCoeff ≠ 0`), and the first-coordinate map injects the subset
+  into `q.roots`, so `card ≤ #roots ≤ deg q = deg Poly`.
+- `not_succ_natDegree_collinear_on_polyGraph` — the "no `deg+1` collinear" reading.
+- `noFiveCollinear_of_onPolyGraph_via_card` — re-derives the mother module's five-collinear
+  lemma from the exact bound at `d ≤ 4 < 5`, confirming subsumption.
+
+### Key Findings
+- The geometry has NO ceiling at five or at degree four: a quartic graph is no-five-collinear,
+  a **quintic** graph is no-six-collinear, and generally a degree-`d` graph is
+  no-`(d+1)`-collinear. This is the honest structural content — the degree-general version
+  directly relevant to the higher-degree / higher-dimensional line-count theme of Erdős #101.
+- Does NOT touch the open count sorries (`grunbaum_lower_bound_three_halves`,
+  `solymosi_stojakovic_lower_bound`); those remain the analytic frontier.
+
+### GOTCHA / process
+- `collinear_self p q : collinear p p q` (NOT `collinear p q p`); for `collinear a b a`/`a b b`
+  use `unfold collinear; ring`.
+- `rcases hp with rfl | …` on `p = a` can substitute the WRONG variable (kills `a`, not `p`,
+  when both are local); use `rcases hp with h | … <;> rw [h]` to stay direction-agnostic.
+
+### Files Modified
+- proofs/Proofs/Erdos101OQ04PolyDegree.lean (NEW, 155 lines, 3 thm, 0 axioms, 0 sorries)
+- src/data/research/problems/erdos-101-oq-04.json (insights/builtItems)
+
+### Next Steps (unchanged, hard)
+- The open growth bounds Ω(n^{3/2}) and n^{2−o(1)} remain the frontier; the no-five-collinear
+  certificate for a *growing* non-grid family is the bridge. This companion supplies the
+  degree-general no-collinear principle any higher-degree witness would rely on.

--- a/src/data/research/problems/erdos-101-oq-04.json
+++ b/src/data/research/problems/erdos-101-oq-04.json
@@ -37,7 +37,10 @@
       "Erdos101OQ04.fourPointLineCount_ge_of_subset: Finset T of four-point collinear subsets -> T.card <= fourPointLineCount P (VERIFIED, 0-axiom)",
       "Erdos101OQ04.fourPointLineCount_ge_of_injOn_family: injective L : Fin k -> Finset four-point collinear subsets -> k <= fourPointLineCount P (VERIFIED, 0-axiom)",
       "conic_slice_neg_eq_circle + oblique_triple_on_ternary_conic : formalize the two explicit surface-point remarks in the quartic_quadruple_family docstring — (1) the conic Q=p²+q²+r²+pq+qr+rp collapses to the circle p²+r² on the slice q=−p (algebraic core of the symmetric-family=slice claim); (2) the oblique witness (−8/3,1/3,1) is a point of Q=5 (=45/9), the oblique twin of symmetric_triple_on_ternary_conic. [proofs machine-checked standalone, ring/norm_num, axiom-free]",
-      "Erdos101OQ04Infinite.lean (companion): quartic_four_point_lines_infinite — quartic y=x^4-5x^2 carries INFINITELY MANY distinct four-point lines. symmetricAbs p := {p,-p,sqrt(5-p^2),-sqrt(5-p^2)} (symmetric slice q=-p of surface Q=5); symmetricAbs_onQuartic_collinear certifies each a genuine 4-point line via mother quartic_quadruple_family_onQuartic_collinear; symmetricAbs_injOn injective on (0,1) via two_lt_sqrt; infinite image of Ioo 0 1. Axiom-free [propext,Classical.choice,Quot.sound]."
+      "Erdos101OQ04Infinite.lean (companion): quartic_four_point_lines_infinite — quartic y=x^4-5x^2 carries INFINITELY MANY distinct four-point lines. symmetricAbs p := {p,-p,sqrt(5-p^2),-sqrt(5-p^2)} (symmetric slice q=-p of surface Q=5); symmetricAbs_onQuartic_collinear certifies each a genuine 4-point line via mother quartic_quadruple_family_onQuartic_collinear; symmetricAbs_injOn injective on (0,1) via two_lt_sqrt; infinite image of Ioo 0 1. Axiom-free [propext,Classical.choice,Quot.sound].",
+      "card_collinear_on_polyGraph_le in Erdos101OQ04PolyDegree.lean (exact bound: collinear subset of degree-d poly graph has card <= d, all d>=2)",
+      "not_succ_natDegree_collinear_on_polyGraph (no d+1 collinear on a degree-d graph)",
+      "noFiveCollinear_of_onPolyGraph_via_card (mother five-collinear lemma re-derived as the d<=4 case)"
     ],
     "insights": [
       "The realParabolaSet arc has fourPointLineCount=0, so the file only inhabited IsLowerBoundConstruction _ 0 before this session; the four collinear x-axis points of W give the first positive four-point-line count witness (>=1) with no five collinear.",
@@ -46,7 +49,8 @@
       "The injective-family form is the natural interface for a GROWING construction: it produces one four-point line per index i : Fin k, and the only combinatorial obligation beyond per-line geometry is that distinct indices name distinct lines (Function.Injective L).",
       "The solution surface Σx=0∧Σx²=10 for four-point lines on y=x⁴−5x² is the fixed ternary conic Q=5; its named special cases are exactly (a) the q=−p slice = circle p²+r²=5 (symmetric family) and (b) surface points like (−8/3,1/3,1) (oblique). Both are pure ring/norm_num identities once the conic form is fixed — the OPEN content is purely SELECTING super-linearly many with pairwise-distinct abscissa sets, never existence.",
       "GAP FILLED: mother file proved boundedness/sharpness of FIXED surface Q=5 + 2 witnesses but never infinitude of distinct lines (only prose continuum). Formalized cleanly on symmetric circular slice; injectivity on (0,1) is 4-way Finset-mem split closed by nlinarith using 2<sqrt(5-p^2) and sqrt_nonneg.",
-      "Lean gotchas: nlinarith CANNOT prove != goal — use show A<B then .ne/.ne, or exfalso;nlinarith[eq]. Avoid set s:=sqrt.. when later using Real.sq_sqrt (abstraction wont fold new occurrences); write sqrt literally."
+      "Lean gotchas: nlinarith CANNOT prove != goal — use show A<B then .ne/.ne, or exfalso;nlinarith[eq]. Avoid set s:=sqrt.. when later using Real.sq_sqrt (abstraction wont fold new occurrences); write sqrt literally.",
+      "New companion Erdos101OQ04PolyDegree.lean removes BOTH caps in noFiveCollinear_of_onPolyGraph (fixed count five + degree<=4): card_collinear_on_polyGraph_le proves the EXACT bound — any collinear subset of a degree-d polynomial-graph point set (d>=2, non-vertical line) has card <= d. A quartic is no-five-collinear, a quintic no-six-collinear, generally a degree-d graph is no-(d+1)-collinear. Proof: line a-b meets y=Poly(x) at roots of q = C(dx)*Poly - C(dy)*X - C(const) with deg q = deg Poly (deg>=2 keeps the linear correction from cancelling the top coeff (dx)*leadingCoeff != 0); first-coordinate map injects the subset into q.roots. Includes noFiveCollinear_of_onPolyGraph_via_card re-deriving the mother lemma at d<=4, confirming subsumption."
     ],
     "mathlibGaps": [
       "No mathlib gap for the witness; the OPEN Path A (Solymosi-Stojakovic) needs a measure-zero certificate for algebraic varieties in projection-parameter space, not currently in Mathlib in usable form."
@@ -122,7 +126,7 @@
     "mathlib": []
   },
   "started": "2026-03-30T16:34:54.971Z",
-  "lastUpdate": "2026-03-30T16:34:54.971Z",
+  "lastUpdate": "2026-07-13",
   "significance": 7,
   "tractability": 5,
   "leanFiles": [


### PR DESCRIPTION
## Summary
Research session for `erdos-101-oq-04` (Erdős #101, higher-dimensional / higher-degree point-set line count). New self-contained companion `Erdos101OQ04PolyDegree.lean`.

## Progress
The mother module's `noFiveCollinear_of_onPolyGraph` is capped twice — at the fixed count **five** and at degree **≤ 4** — both artefacts of the specific quartic `y = x⁴ − 5x²`, not of the geometry. This companion removes both caps, proving the **exact** fact:

- **`card_collinear_on_polyGraph_le`** — for `deg Poly ≥ 2` and a non-vertical line `a–b`, any `Finset` of points lying on `y = Poly.eval x` and collinear with `a, b` has `card ≤ deg Poly`. The line meets the graph at the roots of `q = C(Δx)·Poly − C(Δy)·X − C(const)`, whose degree equals `deg Poly` (the `deg ≥ 2` hypothesis keeps the degree-≤1 correction from cancelling the top coefficient `(Δx)·leadingCoeff ≠ 0`); the first-coordinate map injects the subset into `q.roots`.
- **`not_succ_natDegree_collinear_on_polyGraph`** — the "no `deg+1` collinear" reading.
- **`noFiveCollinear_of_onPolyGraph_via_card`** — re-derives the mother module's five-collinear lemma from the exact bound at `d ≤ 4 < 5`, confirming subsumption.

## Findings
- No ceiling at five or at degree four: a quartic graph is no-five-collinear, a **quintic** graph is no-six-collinear, and generally a degree-`d` graph is no-`(d+1)`-collinear. This is the honest degree-general structural content behind the quartic construction — directly on-theme for the higher-degree line-count question.
- **Independent route**: does not touch the open count sorries (`grunbaum_lower_bound_three_halves`, `solymosi_stojakovic_lower_bound`) nor the existing Infinite/Rational/Similarity companions; those remain the analytic frontier.

## Verification
Offline build `LAKE_UNSAFE=1 ./bin/lake env lean Proofs/Erdos101OQ04PolyDegree.lean` → EXIT 0, no warnings. `#print axioms` on all three results = `[propext, Classical.choice, Quot.sound]` only.

## Status
**Outcome**: progress (axiom-free degree-general structure theorem)
**Next Steps**: the open Ω(n^{3/2}) and n^{2−o(1)} growth bounds remain; the no-collinear certificate for a growing non-grid family is the bridge, and this companion supplies the degree-general no-collinear principle a higher-degree witness would rely on.

🤖 Generated by researcher-1