### PR TITLE
fix(deploy): never let the deployer steal the main ref; self-heal branch drift

### DIFF
--- a/scripts/clean-branches.sh
+++ b/scripts/clean-branches.sh
@@ -335,6 +335,12 @@ trap 'rm -f "$PR_MAP_FILE" "${PR_MAP_FILE}.open" "${PR_MAP_FILE}.closed" "$PROTE
 # main is always protected (master was retired via #13577)
 echo "main" >> "$PROTECTED_BRANCHES_FILE"
 
+# The deployer's long-lived worktree branch is always protected, even if the
+# worktree has temporarily drifted off it (2026-07-11: a deploy cycle left the
+# worktree on `main`, and the orphaned feature/deployer was swept, making the
+# drift unrecoverable by relaunch).
+echo "feature/deployer" >> "$PROTECTED_BRANCHES_FILE"
+
 # Branches checked out in worktrees are protected
 git worktree list --porcelain 2>/dev/null | grep "^branch refs/heads/" | sed 's|^branch refs/heads/||' >> "$PROTECTED_BRANCHES_FILE"
 

--- a/scripts/deploy/launch-agent.sh
+++ b/scripts/deploy/launch-agent.sh
@@ -97,9 +97,14 @@ create_worktree() {
             git fetch origin main 2>/dev/null || true
             git stash 2>/dev/null || true
 
-            # Deployer works on main, so reset to origin/main
-            if git reset --hard origin/main 2>/dev/null; then
-                print_success "Synced with origin/main"
+            # Reset the deployer branch to origin/main. `checkout -B` (rather
+            # than a plain reset of whatever is checked out) also self-heals a
+            # worktree that drifted onto the wrong branch: on 2026-07-11 a
+            # deploy cycle checked out `main` here, which blocked every other
+            # checkout of main for two days and left feature/deployer orphaned
+            # for the branch sweeper.
+            if git checkout -B "$BRANCH_NAME" origin/main 2>/dev/null; then
+                print_success "Synced $BRANCH_NAME with origin/main"
             else
                 print_warning "Could not sync with origin/main"
             fi
@@ -180,9 +185,20 @@ You are the **deployer** agent. Your mission is to keep the website current.
 
 ## Environment
 
-- REPO_ROOT: $REPO_ROOT
+- WORKTREE (your working directory): $WORKTREE_PATH
+- REPO_ROOT (shared — do NOT work here): $REPO_ROOT
 - INTERVAL: $INTERVAL minutes
 - LOG_FILE: $LOG_FILE
+
+## Critical Rules
+
+- Do ALL work from your worktree: \`cd $WORKTREE_PATH\` before every cycle.
+  NEVER run the pipeline from $REPO_ROOT — that checkout is shared by every
+  concurrently-running agent, and cycles run there clobber their state
+  (incident 2026-07-11: a cycle in the wrong directory ended with the
+  deployer worktree squatting on \`main\` for two days).
+- Never check out \`main\` in your worktree. It stays on \`feature/deployer\`;
+  the pipeline fast-forwards it to origin/main automatically.
 
 ## Your Workflow (Repeat Every $INTERVAL Minutes)
 
@@ -194,9 +210,9 @@ You are the **deployer** agent. Your mission is to keep the website current.
    fi
    \`\`\`
 
-2. **Run the deploy pipeline**
+2. **Run the deploy pipeline** (always from the worktree)
    \`\`\`bash
-   ./scripts/deploy/sync-and-deploy.sh
+   cd $WORKTREE_PATH && ./scripts/deploy/sync-and-deploy.sh
    \`\`\`
 
 3. **Report results**

--- a/scripts/deploy/sync-and-deploy.sh
+++ b/scripts/deploy/sync-and-deploy.sh
@@ -141,6 +141,42 @@ if $ONLY_DEPLOY; then run_sync_branch=false; run_merge=false; run_sync=false; ru
 [[ "${SKIP_BUILD:-}" == "1" ]] && run_build=false
 [[ "${SKIP_DEPLOY:-}" == "1" ]] && run_deploy=false
 
+# The deployer's long-lived worktree lives on this branch, never on `main`
+# (launch-agent.sh BRANCH_NAME must match).
+DEPLOYER_BRANCH="${DEPLOYER_BRANCH:-feature/deployer}"
+
+# True when this checkout is the deployer's long-lived worktree (a linked
+# worktree whose directory is named "deployer").
+in_deployer_worktree() {
+    [[ "$(basename "$(pwd -P)")" == "deployer" ]] &&
+        [[ "$(git rev-parse --git-dir 2>/dev/null)" != "$(git rev-parse --git-common-dir 2>/dev/null)" ]]
+}
+
+# Bring the working tree to origin/main WITHOUT stealing the `main` ref from
+# another worktree. On 2026-07-11 the old `git checkout main` here ran inside
+# the deployer worktree, moved it off feature/deployer, and squatted on `main`
+# for two days — blocking every other checkout of main, after which the
+# orphaned feature/deployer branch was swept by clean-branches.sh. It also had
+# a latent footgun: when `checkout main` failed (main held elsewhere), the
+# follow-up `reset --hard origin/main` nuked whatever branch was checked out.
+sync_tree_to_main() {
+    local cur
+    cur=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "HEAD")
+    if in_deployer_worktree; then
+        if [[ "$cur" != "$DEPLOYER_BRANCH" ]]; then
+            print_warning "Deployer worktree is on '$cur' — self-healing to $DEPLOYER_BRANCH"
+        fi
+        git checkout -B "$DEPLOYER_BRANCH" origin/main
+    elif [[ "$cur" == "main" || "$cur" == "$DEPLOYER_BRANCH" ]]; then
+        git reset --hard origin/main
+    elif git checkout main 2>/dev/null; then
+        git reset --hard origin/main
+    else
+        print_warning "'main' is checked out in another worktree — using detached origin/main instead"
+        git checkout --detach origin/main
+    fi
+}
+
 # ============================================================================
 # Step 0a: Sync current branch to origin/main (fast-forward only)
 # ============================================================================
@@ -168,6 +204,14 @@ sync_branch() {
     fi
 
     if [[ "$current_branch" == "main" ]]; then
+        if in_deployer_worktree; then
+            # Drifted state (see sync_tree_to_main): the deployer worktree
+            # must never occupy the `main` ref. Heal it now, before merge.
+            print_warning "Deployer worktree has 'main' checked out — self-healing to $DEPLOYER_BRANCH"
+            git fetch origin main --quiet || print_warning "git fetch origin main failed"
+            git checkout -B "$DEPLOYER_BRANCH" origin/main
+            return 0
+        fi
         # merge_prs already handles main directly via reset --hard; nothing
         # to do here. We still fetch so subsequent steps see fresh refs.
         print_info "On main — fetching only (merge step will reset to origin/main)"
@@ -370,8 +414,7 @@ merge_prs() {
     git fetch origin main --quiet || git fetch origin main --quiet || true
     # Stash before checkout — dirty files block branch switch
     git stash 2>/dev/null || true
-    git checkout main 2>/dev/null || git checkout -b main origin/main 2>/dev/null || true
-    git reset --hard origin/main
+    sync_tree_to_main
 
     local merged=0
     local failed=0
@@ -1129,9 +1172,8 @@ EOF
         else
             print_warning "Could not push sync branch"
         fi
-        # Return to main
-        git checkout main 2>/dev/null || true
-        git reset --hard origin/main 2>/dev/null || true
+        # Return to the pipeline branch (never steal `main` from another worktree)
+        sync_tree_to_main
         git branch -D "$sync_branch" 2>/dev/null || true
     else
         print_info "No staged changes to commit"
@@ -1158,6 +1200,16 @@ main() {
     echo "  Build:       $run_build"
     echo "  Deploy:      $run_deploy"
     echo "  Dry Run:     $DRY_RUN"
+
+    # The primary checkout is shared by every concurrently-running agent:
+    # cycles run here dirty the tree others read, and past cycles left it
+    # stuck on chore/sync-data branches when `checkout main` failed. The
+    # deployer agent must run from its worktree (.loom/worktrees/deployer).
+    if [[ "$(git rev-parse --git-dir 2>/dev/null)" == "$(git rev-parse --git-common-dir 2>/dev/null)" ]]; then
+        print_warning "Running in the PRIMARY checkout, not a worktree."
+        print_warning "  Deployer agents: cd to your worktree (.loom/worktrees/deployer) first."
+        print_warning "  Ad-hoc/manual runs: this is allowed but concurrent agents share this tree."
+    fi
 
     $run_sync_branch && sync_branch
     $run_merge && merge_prs


### PR DESCRIPTION
## Incident

On **2026-07-11 15:15** a deploy cycle's `merge_prs` ran `git checkout main` inside the deployer's long-lived worktree (`.loom/worktrees/deployer`), moving it off `feature/deployer`. The worktree then held the `main` ref for two days, blocking every other checkout of `main` (including the primary repo), and the orphaned `feature/deployer` branch was deleted by the branch sweeper — so a relaunch could not recover. Reflog evidence: `checkout: moving from feature/deployer to main` followed by per-cycle `reset: moving to origin/main`.

Three tolerances let the drift persist silently: `sync_branch`'s on-main fast path, `create_worktree`'s reset-whatever-is-checked-out refresh, and the generated deployer prompt never pinning the agent to its worktree (it advertised `REPO_ROOT`, and cycles have been observed running in the shared primary checkout).

## Guardrails

- **`sync-and-deploy.sh`**: new `sync_tree_to_main` helper replaces the raw `checkout main + reset --hard` at both call sites (`merge_prs`, `sync_data`):
  - already on `main` or `feature/deployer` → `reset --hard origin/main` in place
  - deployer worktree on any other branch → self-heal via `checkout -B feature/deployer origin/main`
  - elsewhere → take `main` only if it's free, otherwise **detach** at `origin/main` with a warning
  - This also fixes a latent footgun: when `checkout main` failed (main held elsewhere), the old follow-up `reset --hard origin/main` nuked whatever branch was checked out.
- **`sync_branch`**: detects a deployer worktree sitting on `main` and heals it before the merge phase.
- **`main()`**: loud warning when the pipeline runs in the shared primary checkout instead of a worktree.
- **`launch-agent.sh`**: worktree refresh uses `checkout -B feature/deployer origin/main` (heals drift at every launch); generated prompt now lists the worktree as the working directory, forbids working from `REPO_ROOT`, and forbids checking out `main`.
- **`clean-branches.sh`**: `feature/deployer` is always protected, so the long-lived branch can't be swept while the worktree is temporarily off it.

## State already repaired manually

The deployer worktree has been put back on `feature/deployer` and the primary checkout reclaimed `main`; this PR prevents recurrence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)