### PR TITLE
feat(hooks): allow docker container lifecycle ops; ignore ask-patterns inside quoted strings

### DIFF
--- a/.loom/hooks/guard-destructive.sh
+++ b/.loom/hooks/guard-destructive.sh
@@ -348,11 +348,15 @@ ASK_PATTERNS=(
     'aws lambda'
 
     # Docker operations
-    'docker rm'
+    # Container lifecycle ops (rm/stop/kill/restart) are intentionally NOT
+    # listed — containers are disposable and agents routinely manage their
+    # own build containers. Images and volumes stay guarded: images are
+    # shared and volumes hold multi-hour mathlib cache builds.
     'docker rmi'
-    'docker stop'
-    'docker kill'
-    'docker restart'
+    'docker image rm'
+    'docker image prune'
+    'docker volume rm'
+    'docker volume prune'
 
     # Service management
     'systemctl restart'
@@ -376,8 +380,15 @@ ASK_PATTERNS=(
     'cat.*/\.aws/credentials'
 )
 
+# Match ask-patterns against the command with quoted strings removed, so a
+# pattern appearing only inside a string argument (grep "docker rmi" file,
+# echo 'gh pr close', a commit message mentioning a command) doesn't prompt.
+# Real invocations are unquoted at command position and still match. The
+# deny tier above intentionally keeps matching the raw text (fail-safe).
+COMMAND_UNQUOTED=$(printf '%s' "$COMMAND" | sed -E "s/'[^']*'/ /g; s/\"[^\"]*\"/ /g" 2>/dev/null) || COMMAND_UNQUOTED="$COMMAND"
+
 for pattern in "${ASK_PATTERNS[@]}"; do
-    if echo "$COMMAND" | grep -qE "$pattern"; then
+    if echo "$COMMAND_UNQUOTED" | grep -qE "$pattern"; then
         ask "Command requires confirmation: $COMMAND"
     fi
 done


### PR DESCRIPTION
## Summary

Two guard-hook relaxations prompted by background-agent stalls during the #37508 migration:

1. **Docker container lifecycle ops no longer prompt** — restart/stop/kill/rm of containers are routine for agents managing their own build containers, and a prompt silently kills a background agent. Still guarded: rmi, image rm, image prune, volume rm, volume prune (ask — images are shared, cache volumes cost hours to rebuild); the system-wide prune remains on the deny tier, unchanged.

2. **Quoted-string false positives eliminated in the ask tier** — patterns are now matched against the command with single/double-quoted spans stripped, so grepping the hook file for a guarded phrase or mentioning one in a commit message no longer prompts. Real invocations are unquoted at command position and still match. Deny tier unchanged (raw-text matching, fail-safe).

## Test plan
- [x] bash -n clean
- [x] 18-case matrix: lifecycle-allow ×4, image/volume-ask ×4, system-prune-deny, quoted-FP-allow ×4, real-invocation-ask ×3, PR #38597 force-push behavior unchanged ×2 — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)