### PR TITLE
migrate(v4.31): Doctor increment 13 — type-mismatch/proof-drift/rewrite remainder (+62 GREEN)

### DIFF
--- a/proofs/Proofs/CramersRuleOQ05OQ02.lean
+++ b/proofs/Proofs/CramersRuleOQ05OQ02.lean
@@ -164,6 +164,7 @@ the unit-conjugation form, matching the parent entry). -/
 theorem IsSimilar.charpoly_eq {M N : Matrix n n R} (h : IsSimilar M N) :
     N.charpoly = M.charpoly := by
   obtain ⟨U, rfl⟩ := h
+  rw [CramersRuleOQ05.conj_apply, Matrix.coe_units_inv U]
   exact Matrix.charpoly_units_conj U M
 
 /-- **Capstone.**  If `M ~ N`, then for every polynomial `p` the matrices `p(M)`

--- a/proofs/Proofs/Erdos1060Problem.lean
+++ b/proofs/Proofs/Erdos1060Problem.lean
@@ -382,6 +382,6 @@ theorem f_le_sqrt (n : ℕ) (hn : n > 0) : f n ≤ Nat.sqrt n := by
         rw [Finset.mem_Icc]
         exact ⟨hk.1.1, solution_le_sqrt n k hk.1.1 hk.2⟩
     _ ≤ Nat.sqrt n := by
-        skip; omega
+        rw [Nat.card_Icc]; omega
 
 end Erdos1060

--- a/proofs/Proofs/Erdos230ProblemAristotle.lean
+++ b/proofs/Proofs/Erdos230ProblemAristotle.lean
@@ -43,9 +43,11 @@ theorem supNorm_le_of_ultraflat {n : ℕ} (P : UnimodularPolynomial n) (ε : ℝ
     (hflat : IsUltraflat P ε) :
     supNormOnCircle P ≤ (1 + ε) * Real.sqrt n := by
   unfold supNormOnCircle
-  apply iSup_le; intro z
-  apply iSup_le; intro hz
-  exact (hflat z hz).2
+  -- the bound is nonnegative: z = 1 lies on the circle and ‖evaluate P 1‖ ≥ 0
+  have hb : (0 : ℝ) ≤ (1 + ε) * Real.sqrt n :=
+    le_trans (norm_nonneg _) (hflat 1 (by simp)).2
+  refine Real.iSup_le (fun z => ?_) hb
+  exact Real.iSup_le (fun hz => (hflat z hz).2) hb
 
 /-
   ## Section 3: Main Disproof

--- a/proofs/Proofs/Erdos306Problem.lean
+++ b/proofs/Proofs/Erdos306Problem.lean
@@ -150,11 +150,13 @@ example : ArithmeticFunction.cardDistinctFactors 6 = 2 := by native_decide
 /-- Check: 6 = 2 × 3 has Ω(6) = 2. -/
 example : ArithmeticFunction.cardFactors 6 = 2 := by native_decide
 
-/-- Example: 1/6 + 1/10 + 1/14 + 1/15 + 1/21 + 1/35 = 1
-This shows 1 can be represented with 2-distinct-prime denominators.
-(6 terms: 6=2×3, 10=2×5, 14=2×7, 15=3×5, 21=3×7, 35=5×7) -/
+/-- Example: 1/6 + 1/10 + 1/14 + 1/15 + 1/21 + 1/35 = 101/210
+These 6 denominators (6=2×3, 10=2×5, 14=2×7, 15=3×5, 21=3×7, 35=5×7) are the
+products of two distinct primes drawn from {2,3,5,7}; their reciprocal sum is
+101/210 (the original claim "= 1" was arithmetically incorrect, LCD 210 giving
+35+21+15+14+10+6 = 101). -/
 theorem example_one_representation :
-    (1 : ℚ) / 6 + 1 / 10 + 1 / 14 + 1 / 15 + 1 / 21 + 1 / 35 = 1 := by norm_num
+    (1 : ℚ) / 6 + 1 / 10 + 1 / 14 + 1 / 15 + 1 / 21 + 1 / 35 = 101 / 210 := by norm_num
 
 /-- The first few products of 3 distinct primes. -/
 def threePrimeProducts : List ℕ := [30, 42, 66, 70, 78, 102, 105, 110, 114, 130]

--- a/proofs/Proofs/Erdos465Problem.lean
+++ b/proofs/Proofs/Erdos465Problem.lean
@@ -155,7 +155,7 @@ theorem second_conjecture_holds : SecondConjecture := by
   have hCltXε : C < X ^ ε := by
     have : C + 1 ≤ X ^ ε := calc
       C + 1 = ((C + 1) ^ ((1 : ℝ) / ε)) ^ ε := by
-            rw [← rpow_mul hC1nn]; congr 1; field_simp
+            rw [← rpow_mul hC1nn]; rw [one_div, inv_mul_cancel₀ hε.ne', rpow_one]
         _ ≤ X ^ ε := rpow_le_rpow (rpow_nonneg hC1nn _) hXge hε.le
     linarith
   -- C·X^(1/2) < X^ε · X^(1/2) = X^(1/2+ε)

--- a/proofs/Proofs/Erdos525OQ02.lean
+++ b/proofs/Proofs/Erdos525OQ02.lean
@@ -95,9 +95,10 @@ theorem dimension_effect (d₁ d₂ n : ℕ) (hd : d₁ < d₂) (hn : 1 < n) :
     by concentration of measure.
 
     This gives m(f) ≈ 1/√N where N = n^d. -/
-theorem sqrt_cancellation_terms (d n : ℕ) (hn : 0 < n) :
+theorem sqrt_cancellation_terms (d n : ℕ) (hn : 0 < n) (hd : 0 < d) :
     -- The number of terms N = n^d satisfies √N = n^(d/2)
     -- So the expected minimum modulus scale is n^(-d/2)
+    -- (requires d ≥ 1: at d = 0, n^0 = 1 < n for n ≥ 2)
     n ^ d ≥ n := by
   calc n ^ d ≥ n ^ 1 := Nat.pow_le_pow_right hn (Nat.one_le_iff_ne_zero.mpr
     (by omega))

--- a/proofs/Proofs/Erdos532Problem.lean
+++ b/proofs/Proofs/Erdos532Problem.lean
@@ -251,8 +251,8 @@ Axiomatized because the finite version requires detailed Ramsey bounds.
 -/
 axiom hindman_finite_exists (k : ℕ) :
   ∃ N : ℕ, ∀ c : Fin N → Fin (k + 1),
-    ∃ a b : Fin N, a.val + b.val < N ∧
-      c a = c b ∧ c a = c ⟨a.val + b.val, by omega⟩
+    ∃ a b : Fin N, ∃ hab : a.val + b.val < N,
+      c a = c b ∧ c a = c ⟨a.val + b.val, hab⟩
 
 /--
 **Hindman Numbers (Finite Version):**

--- a/proofs/Proofs/Erdos540Problem.lean
+++ b/proofs/Proofs/Erdos540Problem.lean
@@ -123,7 +123,7 @@ theorem case_N_1 : ∀ A : Finset (ZMod 1), A.Nonempty → HasZeroSumSubset A :=
   · exact Subset.refl A
   constructor
   · exact hA
-  · simp [subsetSum]
+  · exact Subsingleton.elim (subsetSum A) 0
 
 /-  The Davenport constant D(ℤ/Nℤ) = N: the smallest d such that every
     sequence of length ≥ d has a zero-sum subsequence.

--- a/proofs/Proofs/Erdos54Problem.lean
+++ b/proofs/Proofs/Erdos54Problem.lean
@@ -32,7 +32,7 @@ def Colouring2 (A : Set ℕ) := { n : ℕ // n ∈ A } → Bool
 /-- The subset sums from a single colour class. -/
 def monoSubsetSums (A : Set ℕ) (c : Colouring2 A) (colour : Bool) : Set ℕ :=
     { s | ∃ (S : Finset ℕ),
-      (∀ n ∈ S, n ∈ A ∧ c ⟨n, ‹_›⟩ = colour) ∧
+      (∀ n ∈ S, ∃ hn : n ∈ A, c ⟨n, hn⟩ = colour) ∧
       S.sum id = s }
 
 /- ## Ramsey 2-completeness -/

--- a/proofs/Proofs/Erdos674ProblemAristotle.lean
+++ b/proofs/Proofs/Erdos674ProblemAristotle.lean
@@ -84,7 +84,9 @@ theorem mul_pow_self (a b : ℕ) : (a * b) ^ (a * b) = a ^ (a * b) * b ^ (a * b)
 theorem pos_of_sq_eq (a b c : ℕ) (hc : c > 0) (h : 4 * a * b = c ^ 2) : a * b > 0 := by
   by_contra hab
   push_neg at hab
-  interval_cases (a * b)
-  skip; omega
+  have hc2 : c ^ 2 > 0 := pow_pos hc 2
+  have hab0 : a * b = 0 := Nat.le_zero.mp hab
+  rw [mul_assoc, hab0, mul_zero] at h
+  omega
 
 end Erdos674.Aristotle

--- a/proofs/Proofs/Erdos690Problem.lean
+++ b/proofs/Proofs/Erdos690Problem.lean
@@ -97,6 +97,7 @@ theorem d1_unimodal :
     -- hp.two_le gives 2 ≤ p, combined with p ≤ q ≤ 2 forces p = q
     have : p = q := by have := hp.two_le; omega
     subst this
+    exact le_refl _
   · -- Non-increasing for primes ≥ 2
     intro p q hp hq _ hpq
     rcases eq_or_lt_of_le hpq with rfl | hlt

--- a/proofs/Proofs/Erdos712Problem.lean
+++ b/proofs/Proofs/Erdos712Problem.lean
@@ -157,9 +157,8 @@ theorem erdos_712 (r k : ℕ) (hr : r > 2) (hk : k > r) :
     · -- Use Kruskal-Katona bound: π ≤ 1 - 1/k < 1 for k > 1
       have hkk := kruskal_katona_upper r k (by omega) hk
       have hk_pos : (0 : ℝ) < k := by
-        have : k > r := hk
-        have : r > 2 := hr
-        linarith
+        have : 0 < k := by omega
+        exact_mod_cast this
       have h_one_div_k_pos : (0 : ℝ) < 1 / k := by positivity
       calc turanDensity r k ≤ 1 - 1 / k := hkk
         _ < 1 := by linarith

--- a/proofs/Proofs/Erdos73Aristotle.lean
+++ b/proofs/Proofs/Erdos73Aristotle.lean
@@ -95,10 +95,10 @@ theorem K3_almost_bipartite_goal :
     ∃ S : Finset (Fin 3), S.card ≤ 1 ∧
       IsBipartite (triangleGraph.induce (↑Sᶜ : Set (Fin 3))) := by
   refine ⟨{0}, by simp, ?_⟩
-  convert triangleGraph_on_two_vertices_bipartite using 1
-  congr 1
-  ext x
-  simp [Finset.compl_eq_univ_sdiff]
+  have hset : ((↑({0}ᶜ : Finset (Fin 3)) : Set (Fin 3))) = ({(0 : Fin 3)}ᶜ : Set (Fin 3)) := by
+    ext x; simp
+  rw [hset]
+  exact triangleGraph_on_two_vertices_bipartite
 
 /-
   ## Section 3: Independence Arithmetic

--- a/proofs/Proofs/Erdos758Problem.lean
+++ b/proofs/Proofs/Erdos758Problem.lean
@@ -90,6 +90,7 @@ def knownValues : Fin 19 → ℕ
   | ⟨8, _⟩ => 4  | ⟨9, _⟩ => 4  | ⟨10, _⟩ => 4 | ⟨11, _⟩ => 4
   | ⟨12, _⟩ => 5 | ⟨13, _⟩ => 5 | ⟨14, _⟩ => 5
   | ⟨15, _⟩ => 6 | ⟨16, _⟩ => 6 | ⟨17, _⟩ => 6 | ⟨18, _⟩ => 6
+  | ⟨n + 19, h⟩ => absurd h (by omega)
 
 /-- z(n+1) = knownValues(n) for 0 ≤ n ≤ 18. -/
 axiom known_values_correct (i : Fin 19) : z (i.val + 1) = knownValues i

--- a/proofs/Proofs/Erdos760Problem.lean
+++ b/proofs/Proofs/Erdos760Problem.lean
@@ -73,16 +73,17 @@ The chromatic number χ(G) is the minimum number of colors needed.
 def IsProperColoring (G : SimpleGraph V) (c : V → Fin k) : Prop :=
   ∀ u v : V, G.Adj u v → c u ≠ c v
 
+open Classical in
 /--
 **Chromatic Number:**
 The minimum number of colors for a proper coloring.
 -/
 noncomputable def chromaticNumber (G : SimpleGraph V) : ℕ :=
-  Nat.find ⟨Fintype.card V, by
-    intro k hk
-    use fun _ => ⟨0, by omega⟩
-    intro u v _
-    simp⟩
+  Nat.find (p := fun k => ∃ c : V → Fin k, IsProperColoring G c)
+    ⟨Fintype.card V, (Fintype.equivFin V), by
+      -- an injective vertex → colour map is a proper colouring
+      intro u v huv hc
+      exact G.ne_of_adj huv ((Fintype.equivFin V).injective hc)⟩
 
 /--
 **Cochromatic Coloring:**

--- a/proofs/Proofs/Erdos774Problem.lean
+++ b/proofs/Proofs/Erdos774Problem.lean
@@ -197,7 +197,12 @@ axiom nesetril_rodl_sales_theorem : ¬SidonAnalogue
 
 /-- Maximum size of a dissociated subset of {1,...,n}. -/
 noncomputable def maxDissociatedSize (n : ℕ) : ℕ :=
-  Nat.find (⟨0, by trivial⟩ : ∃ k, ∀ D : Finset ℕ,
+  Nat.find (⟨n + 1, fun D hD _ => by
+      -- D ⊆ range (n+1) since every element is ≤ n, so #D ≤ n+1
+      have hsub : D ⊆ Finset.range (n + 1) := fun d hd =>
+        Finset.mem_range.mpr (Nat.lt_succ_of_le (hD d hd))
+      calc D.card ≤ (Finset.range (n + 1)).card := Finset.card_le_card hsub
+        _ = n + 1 := Finset.card_range _⟩ : ∃ k, ∀ D : Finset ℕ,
     (∀ d ∈ D, d ≤ n) → IsDissociated D → D.card ≤ k)
 
 /-

--- a/proofs/Proofs/Erdos80Problem.lean
+++ b/proofs/Proofs/Erdos80Problem.lean
@@ -92,9 +92,9 @@ def hasBook (G : SimpleGraph V) (m : ℕ) : Prop :=
 **Maximum Book Size:**
 The largest book in the graph.
 -/
-noncomputable def maxBookSize (G : SimpleGraph V) : ℕ :=
+noncomputable def maxBookSize [Nonempty V] (G : SimpleGraph V) : ℕ :=
   Finset.sup' (Finset.univ ×ˢ Finset.univ).attach
-    (by simp [Finset.attach_nonempty_iff])
+    (by simp [Finset.attach_nonempty_iff, Finset.univ_nonempty_iff])
     (fun ⟨⟨u, v⟩, _⟩ => if G.Adj u v then bookSize G u v else 0)
 
 /- ## Part II: The f_c(n) Function

--- a/proofs/Proofs/Erdos811Problem.lean
+++ b/proofs/Proofs/Erdos811Problem.lean
@@ -44,7 +44,7 @@ def completeEdgeCount (n : ℕ) : ℕ := n * (n - 1) / 2
 structure EdgeColoring (n m : ℕ) where
   color : Fin n → Fin n → Fin m
   symmetric : ∀ u v, color u v = color v u
-  irrefl : ∀ v, color v v = ⟨0, by omega⟩  -- diagonal doesn't matter
+  irrefl : ∀ v, color v v = ⟨0, (color v v).pos⟩  -- diagonal doesn't matter (Fin m is inhabited via color v v)
 
 /-- Color degree: number of edges of color c incident to vertex v -/
 noncomputable def colorDegree (χ : EdgeColoring n m) (v : Fin n) (c : Fin m) : ℕ :=

--- a/proofs/Proofs/Erdos821Problem.lean
+++ b/proofs/Proofs/Erdos821Problem.lean
@@ -114,7 +114,7 @@ axiom smooth_implies_conjecture :
 
 /-- g(1) = 2 (since φ(1) = φ(2) = 1). -/
 theorem preimage_of_1 : phi 1 = 1 ∧ phi 2 = 1 := by
-  simp [phi, Nat.totient]
+  constructor <;> decide
 
 /- ## Summary
 

--- a/proofs/Proofs/Erdos869Problem.lean
+++ b/proofs/Proofs/Erdos869Problem.lean
@@ -185,8 +185,8 @@ theorem basis_monotone {A B : Set ℕ} (hA : isAdditiveBasis2 A) (hAB : A ⊆ B)
   apply Set.Finite.subset hA
   intro n hn
   simp only [Set.mem_compl_iff, Set.mem_setOf_eq, not_exists] at hn ⊢
-  intro a ha b hb hab
-  exact hn a (hAB ha) b (hAB hb) hab
+  rintro a ⟨ha, b, hb, hab⟩
+  exact hn a ⟨hAB ha, b, hAB hb, hab⟩
 
 /- 
 **Minimal Bases are Thin:**

--- a/proofs/Proofs/Erdos879Problem.lean
+++ b/proofs/Proofs/Erdos879Problem.lean
@@ -170,6 +170,7 @@ theorem primes_admissible (n : ℕ) :
     IsAdmissible (Finset.filter Nat.Prime (Finset.range n)) := by
   intro a ha b hb hab
   simp only [Finset.mem_filter] at ha hb
+  have ha2 := ha.2.two_le
   exact Nat.Prime.coprime_iff_not_dvd ha.2 |>.mpr
     (fun h => hab (hb.2.eq_one_or_self_of_dvd a h |>.resolve_left (by omega)))
 

--- a/proofs/Proofs/Erdos883Problem.lean
+++ b/proofs/Proofs/Erdos883Problem.lean
@@ -80,7 +80,7 @@ A cycle a₁ - a₂ - ... - aₖ - a₁ means each consecutive pair is coprime.
 -/
 def isCoprimeCycle (cycle : List ℕ) : Prop :=
   cycle.length ≥ 3 ∧
-  (∀ i : Fin cycle.length, Nat.Coprime (cycle.get i) (cycle.get ⟨(i.val + 1) % cycle.length, by omega⟩))
+  (∀ i : Fin cycle.length, Nat.Coprime (cycle.get i) (cycle.get ⟨(i.val + 1) % cycle.length, Nat.mod_lt _ i.pos⟩))
 
 /- ## Part III: Erdős-Sárkőzy Theorem on Odd Cycles -/
 

--- a/proofs/Proofs/Erdos8OQ02.lean
+++ b/proofs/Proofs/Erdos8OQ02.lean
@@ -107,7 +107,19 @@ theorem single_class_not_covering (c : CongruenceClass) :
   simp only [CongruenceClass.toSet, mem_setOf_eq, Int.ModEq]
   have hm := c.modulus_pos
   have hr := c.residue_valid
-  omega
+  have hr0 : (0 : ℤ) ≤ (c.residue : ℤ) := Int.natCast_nonneg _
+  have hrm : ((c.residue : ℤ) % c.modulus) = c.residue := by
+    rw [Int.emod_eq_of_lt hr0 (by exact_mod_cast hr)]
+  rcases Nat.lt_or_ge (c.residue + 1) c.modulus with hlt | hge
+  · -- residue + 1 < modulus, so (residue+1) % modulus = residue+1 ≠ residue
+    have h1 : ((c.residue : ℤ) + 1) % c.modulus = c.residue + 1 := by
+      rw [Int.emod_eq_of_lt (by linarith) (by exact_mod_cast hlt)]
+    rw [h1, hrm]; omega
+  · -- residue + 1 = modulus, so (residue+1) % modulus = 0 ≠ residue
+    have heq : c.residue + 1 = c.modulus := by omega
+    have h1 : ((c.residue : ℤ) + 1) % c.modulus = 0 := by
+      rw [show (c.residue : ℤ) + 1 = (c.modulus : ℤ) by exact_mod_cast heq, Int.emod_self]
+    rw [h1, hrm]; omega
 
 /-- A covering system with distinct moduli has at least two classes. -/
 theorem covering_distinct_has_ge_two_classes (cs : CoveringSystem)

--- a/proofs/Proofs/Erdos902Problem.lean
+++ b/proofs/Proofs/Erdos902Problem.lean
@@ -110,6 +110,7 @@ theorem asymptotic_gap :
     push_neg at hC_neg
     have h1 := hc_bound 1 (by omega)
     have h2 := hC_bound 1 (by omega)
+    simp only [Nat.cast_one, mul_one] at h2
     linarith
   · intro n hn
     exact ⟨hc_bound n hn, hC_bound n hn⟩

--- a/proofs/Proofs/Erdos935Problem.lean
+++ b/proofs/Proofs/Erdos935Problem.lean
@@ -60,6 +60,7 @@ theorem powerfulPart_is_powerful (n : ℕ) (p : ℕ) (hp : p.Prime)
   rcases n.eq_zero_or_pos with rfl | hn
   · -- powerfulPart 0 = 1 and p ∤ 1 for prime p
     simp only [powerfulPart, Nat.factorization_zero, Finsupp.prod_zero_index] at hd
+    exact absurd hd hp.not_dvd_one
   -- p divides a Finsupp product; find which factor p divides
   unfold powerfulPart at hd ⊢
   obtain ⟨q, hq_mem, hq_dvd⟩ := (hp.prime.dvd_finsuppProd_iff (g := fun p k =>

--- a/proofs/Proofs/Erdos956Aristotle.lean
+++ b/proofs/Proofs/Erdos956Aristotle.lean
@@ -72,8 +72,13 @@ Show translate C x = (· + x) '' C, then use IsCompact.image with continuity of 
 -/
 theorem translate_compact (C : Set (EuclideanSpace ℝ (Fin 2))) (x : EuclideanSpace ℝ (Fin 2))
     (hC : IsCompact C) : IsCompact (translate C x) := by
-  convert hC.image _ using 1;
-  continuity
+  have himg : translate C x = (fun c => c + x) '' C := by
+    ext y
+    constructor
+    · rintro ⟨c, hc, rfl⟩; exact ⟨c, hc, rfl⟩
+    · rintro ⟨c, hc, rfl⟩; exact ⟨c, hc, rfl⟩
+  rw [himg]
+  exact hC.image (continuous_add_const x)
 
 -- Routine: Translation preserves nonemptiness
 theorem translate_nonempty (C : Set (EuclideanSpace ℝ (Fin 2))) (x : EuclideanSpace ℝ (Fin 2))

--- a/proofs/Proofs/FeuerbachsTheoremOQ04TangentLine.lean
+++ b/proofs/Proofs/FeuerbachsTheoremOQ04TangentLine.lean
@@ -175,6 +175,6 @@ theorem tangentGreatCircle_at_point {O P : E} {ρ : ℝ} (hO : OnSphere O) (hρ0
   have hPin : P ∈ sCircle O ρ ∩ sGreatCircle (tangentPole P O ρ) := ⟨⟨hP, hPscos⟩, hPgc⟩
   rw [hinter] at hPin
   rw [Set.mem_singleton_iff] at hPin
-  rw [hinter, hPin]
+  rw [hinter, ← hPin]
 
 end FeuerbachsTheoremOQ04

--- a/proofs/Proofs/FibonacciIdentitiesOQ02.lean
+++ b/proofs/Proofs/FibonacciIdentitiesOQ02.lean
@@ -71,8 +71,9 @@ theorem fib_dvd_iff {m n : ℕ} (hm : 3 ≤ m) :
     have hle : Nat.gcd m n ≤ m := Nat.le_of_dvd (by omega) hdm
     -- `fib m ≥ fib 3 = 2` since `fib` is monotone and `3 ≤ m`.
     have hfm : 2 ≤ Nat.fib m := by
+      have h3 : Nat.fib 3 = 2 := by decide
       have := Nat.fib_mono hm
-      simpa using this
+      rwa [h3] at this
     -- Rule out the degenerate gcd values `0` and `1`: both force `fib (gcd) ≤ 1`,
     -- contradicting `fib (gcd m n) = fib m ≥ 2`.
     have hd2 : 2 ≤ Nat.gcd m n := by

--- a/proofs/Proofs/FibonacciIdentitiesOQ02OQ02PrimeIndex.lean
+++ b/proofs/Proofs/FibonacciIdentitiesOQ02OQ02PrimeIndex.lean
@@ -68,8 +68,9 @@ theorem fib_prime_imp_index_prime_or_four {n : ℕ}
   -- Its Fibonacci value is a proper divisor of `fib n`.
   have hfd : Nat.fib d ∣ Nat.fib n := Nat.fib_dvd d n hd_dvd
   have h2 : 2 ≤ Nat.fib d := by
+    have h3 : Nat.fib 3 = 2 := by decide
     have : Nat.fib 3 ≤ Nat.fib d := Nat.fib_mono hd3
-    simpa using this
+    rwa [h3] at this
   have hlt : Nat.fib d < Nat.fib n := (Nat.fib_lt_fib (by omega : 2 ≤ d)).mpr hdn
   -- A prime cannot have a divisor strictly between `1` and itself.
   rcases hp.eq_one_or_self_of_dvd (Nat.fib d) hfd with h1 | hself

--- a/proofs/Proofs/FourSquareDistributionOQ01.lean
+++ b/proofs/Proofs/FourSquareDistributionOQ01.lean
@@ -2660,7 +2660,7 @@ def applyPerm (σ : Equiv.Perm (Fin 4)) (v : Fin 4 → ℤ) : Fin 4 → ℤ :=
 @[simp] lemma applyPerm_one (v : Fin 4 → ℤ) :
     applyPerm (1 : Equiv.Perm (Fin 4)) v = v := by
   funext i
-  simp [applyPerm]
+  simp [applyPerm, Equiv.Perm.one_symm]
 
 /-- Left-action composition: `(σ * τ) • v = σ • (τ • v)`. -/
 @[simp] lemma applyPerm_mul (σ τ : Equiv.Perm (Fin 4)) (v : Fin 4 → ℤ) :

--- a/proofs/Proofs/GeometricSeries.lean
+++ b/proofs/Proofs/GeometricSeries.lean
@@ -73,8 +73,7 @@ theorem finite_geom_sum' {R : Type*} [Ring R] (r : R) (n : ℕ) :
 theorem finite_geom_sum_div {R : Type*} [DivisionRing R] (r : R) (n : ℕ) (hr : r ≠ 1) :
     ∑ k ∈ range n, r ^ k = (1 - r ^ n) / (1 - r) := by
   have h1r : 1 - r ≠ 0 := sub_ne_zero.mpr (ne_comm.mpr hr)
-  skip
-  exact _root_.geom_sum_mul_neg r n
+  exact eq_div_of_mul_eq h1r (_root_.geom_sum_mul_neg r n)
 
 /-! ## Infinite Geometric Series
 

--- a/proofs/Proofs/HarmonicDivergence.lean
+++ b/proofs/Proofs/HarmonicDivergence.lean
@@ -138,8 +138,8 @@ theorem group_sum_ge_half (k : ℕ) (hk : k ≥ 1) :
     have h2k_pos : (2 : ℝ)^k > 0 := by positivity
     have h2k1_pos : (2 : ℝ)^(k+1) > 0 := by positivity
     field_simp
-    have : (2 : ℝ)^(k+1) = 2 * 2^k := by ring
-    linarith
+    push_cast
+    ring
   linarith [hsum, hconst, hcard]
 
 /-! ## Contrast with Convergent Series

--- a/proofs/Proofs/HermiteLegendreFactorialOQ02.lean
+++ b/proofs/Proofs/HermiteLegendreFactorialOQ02.lean
@@ -66,7 +66,7 @@ theorem image_mul_eq_filter_dvd {p : ℕ} (hp : 0 < p) (n : ℕ) :
   constructor
   · rintro ⟨j, ⟨hj1, hj2⟩, rfl⟩
     refine ⟨⟨?_, ?_⟩, Dvd.intro j rfl⟩
-    · calc 1 ≤ p * 1 := by simpa using hp
+    · calc 1 ≤ p * 1 := by rw [mul_one]; omega
         _ ≤ p * j := by exact Nat.mul_le_mul_left p hj1
     · rw [mul_comm]; exact (Nat.le_div_iff_mul_le hp).mp hj2
   · rintro ⟨⟨hk1, hk2⟩, ⟨j, rfl⟩⟩

--- a/proofs/Proofs/Hilbert17RobinsonRationalSOS.lean
+++ b/proofs/Proofs/Hilbert17RobinsonRationalSOS.lean
@@ -143,6 +143,7 @@ theorem multiplier_ne_zero : multiplier ≠ 0 := by
   intro h
   have := congrArg (eval (fun i => if i = 0 then (1 : ℝ) else 0)) h
   simp only [multiplier, map_add, map_mul, map_pow, map_ofNat, eval_X, map_zero] at this
+  simp only [show (2 : Fin 3) ≠ 0 by decide, if_false] at this
   norm_num at this
 
 /-- The image of the multiplier in `ℝ(x, y, z)` is nonzero. -/

--- a/proofs/Proofs/Hilbert22OQ01OQ03Pseudohyperbolic.lean
+++ b/proofs/Proofs/Hilbert22OQ01OQ03Pseudohyperbolic.lean
@@ -152,6 +152,7 @@ lemma psh_schwarzPick_center {f : ℂ → ℂ}
     (hmaps : MapsTo f (ball 0 1) (ball 0 1)) (hf0 : f 0 = 0)
     {z : ℂ} (hz : ‖z‖ < 1) : psh (f z) 0 ≤ psh z 0 := by
   rw [psh_zero_right, psh_zero_right]
-  exact Complex.norm_le_norm_of_mapsTo_ball_self hd hmaps hf0 hz
+  exact Complex.norm_le_norm_of_mapsTo_ball_self hd
+    (hmaps.mono_right Metric.ball_subset_closedBall) hf0 hz
 
 end Hilbert22OQ01OQ03

--- a/proofs/Proofs/IncidenceCauchySchwarzDual.lean
+++ b/proofs/Proofs/IncidenceCauchySchwarzDual.lean
@@ -63,7 +63,7 @@ theorem incidences_flip : incidences (flip Inc) = incidences Inc := by
   -- the residual goal closes by reflexivity (the `flip` decidability instance is
   -- definitionally the ambient one).
   unfold incidences deg
-  simp only [Finset.card_filter]
+  simp only [Finset.card_filter, Function.flip_def]
   rw [Finset.sum_comm]
 
 -- ═══════════════════════════════════════════════════

--- a/proofs/Proofs/InfinitudePrimesOQ01.lean
+++ b/proofs/Proofs/InfinitudePrimesOQ01.lean
@@ -110,8 +110,11 @@ theorem isOpenAP_residue (a : ℤ) {d : ℤ} (hd : 0 < d) : IsOpenAP (R a d) := 
   intro x hx
   refine ⟨d, hd, fun y hy => ?_⟩
   -- `d ∣ (y − x)` and `d ∣ (x − a)` give `d ∣ (y − a)`.
-  have : d ∣ ((y - x) + (x - a)) := dvd_add hy hx
-  simpa using this
+  have hthis : d ∣ ((y - x) + (x - a)) := dvd_add hy hx
+  show y ∈ R a d
+  simp only [R, Set.mem_setOf_eq]
+  have heq : (y - x) + (x - a) = y - a := by ring
+  rwa [heq] at hthis
 
 /-- For `d > 0` the residue class `R a d` is closed: its complement is open,
 because *not* being congruent to `a` mod `d` is also stable under shifting by

--- a/proofs/Proofs/InverseGaloisF20OQ02.lean
+++ b/proofs/Proofs/InverseGaloisF20OQ02.lean
@@ -159,8 +159,12 @@ theorem card_F20 : Nat.card F20 = 20 := by
       rintro ⟨g, i, j, rfl⟩
       refine ⟨(⟨i % 5, Nat.mod_lt _ (by norm_num)⟩, ⟨j % 4, Nat.mod_lt _ (by norm_num)⟩), ?_⟩
       apply Subtype.ext
-      have e1 : σ ^ (i % 5) = σ ^ i := by rw [← orderOf_sigma]; exact pow_mod_orderOf σ i
-      have e2 : τ ^ (j % 4) = τ ^ j := by rw [← orderOf_tau]; exact pow_mod_orderOf τ j
+      have e1 : σ ^ (i % 5) = σ ^ i := by
+        have := pow_mod_orderOf σ i
+        rwa [orderOf_sigma] at this
+      have e2 : τ ^ (j % 4) = τ ^ j := by
+        have := pow_mod_orderOf τ j
+        rwa [orderOf_tau] at this
       simp only [Fin.val_mk]
       rw [e1, e2]
     calc Nat.card F20 ≤ Nat.card (Fin 5 × Fin 4) := Nat.card_le_card_of_surjective _ hsurj

--- a/proofs/Proofs/LeibnizPiOQ03.lean
+++ b/proofs/Proofs/LeibnizPiOQ03.lean
@@ -212,7 +212,8 @@ theorem arctan_integral : ∫ t in (0 : ℝ)..1, 1 / (1 + t ^ 2) = π / 4 := by
   have hint : IntervalIntegrable (fun t => 1 / (1 + t ^ 2)) volume 0 1 :=
     ((continuous_const.div
       (continuous_const.add (continuous_id.pow 2))
-      (fun x => by positivity)).continuousOn).intervalIntegrable
+      (fun x => by have : (0:ℝ) < 1 + x ^ 2 := by positivity
+                   exact this.ne')).continuousOn).intervalIntegrable
   rw [integral_eq_sub_of_hasDerivAt hderiv hint]
   simp [arctan_one, arctan_zero]
 

--- a/proofs/Proofs/MeanValueTheoremOQ03.lean
+++ b/proofs/Proofs/MeanValueTheoremOQ03.lean
@@ -358,7 +358,8 @@ theorem antiderivatives_differ_by_constant
     fun y hy => sub_eq_zero.mpr (heq y hy)
   have hC : ∀ y ∈ Ico a b, ‖deriv f y - deriv g y‖ ≤ 0 :=
     fun y hy => by rw [h0 y hy]; simp
-  have hbound := mean_value_inequality hh hC x hx
+  have hbound := norm_image_sub_le_of_norm_deriv_le_segment'
+    (f' := fun y => deriv f y - deriv g y) hh hC x hx
   rw [zero_mul] at hbound
   exact sub_eq_zero.mp (norm_eq_zero.mp (le_antisymm hbound (norm_nonneg _)))
 

--- a/proofs/Proofs/PNPBarriersSound.lean
+++ b/proofs/Proofs/PNPBarriersSound.lean
@@ -671,7 +671,7 @@ theorem P_nontrivial : P ≠ Set.univ := by
   | inl h_none =>
     -- Φ e emptyOracle n = none, but hs says it's some
     rw [h_none] at hs
-    exact Option.noConfusion hs
+    exact absurd hs (by simp)
   | inr h_wrong =>
     -- Φ e emptyOracle n = some (r, s') with r ≠ f n
     obtain ⟨r, s', hrs, hne⟩ := h_wrong

--- a/proofs/Proofs/PascalsHexagonOQ02.lean
+++ b/proofs/Proofs/PascalsHexagonOQ02.lean
@@ -76,7 +76,7 @@ theorem dualConic_symmetric {C : Conic} (h : C.symmetric) :
     rw [Matrix.transpose_apply]
     exact h j i
   have hadj : C.adjugate = (C.adjugate)ᵀ := by
-    have key : (Cᵀ).adjugate = (C.adjugate)ᵀ := Matrix.adjugate_transpose C
+    have key : (Cᵀ).adjugate = (C.adjugate)ᵀ := (Matrix.adjugate_transpose C).symm
     rwa [hCt] at key
   intro i j
   show C.adjugate i j = C.adjugate j i

--- a/proofs/Proofs/SchroederBernsteinOQ03.lean
+++ b/proofs/Proofs/SchroederBernsteinOQ03.lean
@@ -1602,8 +1602,9 @@ theorem fwdOrbit_add_mul_period {f g : ℕ → ℕ} {a : ℕ} (h : OnCycle f g a
 /-- A pure multiple of the period returns the orbit to the anchor. -/
 theorem fwdOrbit_mul_period {f g : ℕ → ℕ} {a : ℕ} (h : OnCycle f g a) (t : ℕ) :
     fwdOrbit f g a (orbitPeriod f g h * t) = a := by
-  have := fwdOrbit_add_mul_period h 0 t
-  simpa using this
+  have hz := fwdOrbit_add_mul_period h 0 t
+  rw [Nat.zero_add] at hz
+  rw [hz]; rfl
 
 /-- Reducing the step count modulo the period leaves the forward orbit unchanged. -/
 theorem fwdOrbit_mod_period {f g : ℕ → ℕ} {a : ℕ} (h : OnCycle f g a) (m : ℕ) :

--- a/proofs/Proofs/ShannonEntropyAristotle.lean
+++ b/proofs/Proofs/ShannonEntropyAristotle.lean
@@ -117,7 +117,10 @@ theorem conditioning_reduces_entropy {α β : Type*} [Fintype α] [Fintype β]
         have h_sum_ineq : ∑ x : α, ∑ y : β, (∑ x', pXY (x', y)) * (∑ y', pXY (x, y')) = (∑ x : α, ∑ y : β, pXY (x, y)) * (∑ x : α, ∑ y : β, pXY (x, y)) := by
           simp +decide only [← Finset.sum_mul, ← Finset.mul_sum _ _ _];
           rw [ Finset.sum_comm ];
-        rw [ h_sum_ineq, show ∑ x : α, ∑ y : β, pXY ( x, y ) = 1 by simpa only [ ← Finset.sum_product' ] using hsum ] ; norm_num;
+        rw [ h_sum_ineq, show ∑ x : α, ∑ y : β, pXY ( x, y ) = 1 by
+          rw [← Finset.sum_product']
+          rw [← Finset.univ_product_univ] at hsum
+          simpa using hsum ] ; norm_num;
       linarith [ show I ≥ ∑ x, ∑ y, pXY ( x, y ) - ∑ x, ∑ y, ( ∑ x', pXY ( x', y ) ) * ∑ y', pXY ( x, y' ) by exact le_trans ( by simp +decide [ Finset.sum_sub_distrib ] ) ( Finset.sum_le_sum fun x _ => Finset.sum_le_sum fun y _ => h_ineq x y ) ]
 
 end InformationTheory.Aristotle

--- a/proofs/Proofs/ShapleyFolkmanOQ01.lean
+++ b/proofs/Proofs/ShapleyFolkmanOQ01.lean
@@ -65,7 +65,7 @@ noncomputable def Decomposition.map {ι : Type*} {S : ι → Set E} {t : Finset 
     rw [← LinearMap.image_convexHull]
     exact Set.mem_image_of_mem f (D.mem_convexHull i hi)
   point_eq_zero i hi := by rw [D.point_eq_zero i hi, map_zero]
-  sum_eq := by rw [← D.sum_eq, map_sum]
+  sum_eq := by rw [← map_sum]; exact congrArg f D.sum_eq
 
 @[simp]
 lemma Decomposition.map_point {ι : Type*} {S : ι → Set E} {t : Finset ι} {x : E}

--- a/proofs/Proofs/SolutionOfCubicOQ03OQ02.lean
+++ b/proofs/Proofs/SolutionOfCubicOQ03OQ02.lean
@@ -71,7 +71,9 @@ theorem cardanoD_neg_of_casus (p q : ℝ) (h : isCasusIrreducibilis p q) :
 theorem p_neg_of_casus (p q : ℝ) (h : isCasusIrreducibilis p q) :
     p < 0 := by
   simp only [isCasusIrreducibilis, discriminant] at h
-  nlinarith [sq_nonneg q]
+  by_contra hp
+  push_neg at hp
+  nlinarith [sq_nonneg q, pow_nonneg hp 3, mul_nonneg hp (mul_nonneg hp hp)]
 
 -- ============================================================
 -- Section 3: Cardano's Formula Involves Complex Numbers

--- a/proofs/Proofs/SolutionOfCubicOQ03OQ03.lean
+++ b/proofs/Proofs/SolutionOfCubicOQ03OQ03.lean
@@ -53,7 +53,6 @@ theorem resolvent_monic_form (p q r m : ℂ)
     m^3 + (5 * p / 2) * m^2 + (2 * p^2 - r) * m +
     (p^3 / 2 - p * r / 2 - q^2 / 8) = 0 := by
   unfold isResolventRoot at h
-  field_simp
   linear_combination h / 8
 
 -- ============================================================

--- a/proofs/Proofs/SpernerNDimOQ06.lean
+++ b/proofs/Proofs/SpernerNDimOQ06.lean
@@ -232,7 +232,7 @@ theorem no_pred_source {v₀ : V} (h : K.IsSource v₀) : ∀ w, K.succ w ≠ so
   intro w hw
   have hp : K.pred v₀ = some w := (K.symm w v₀).mp hw
   rw [show K.pred v₀ = none from h] at hp
-  exact Option.noConfusion hp
+  exact absurd hp (by simp)
 
 /-- **Kuhn's algorithm terminates.**  From any source door, following opposite doors
 reaches a fully-coloured simplex within `Fintype.card V` pivots. -/

--- a/proofs/Proofs/SpernerTuckerEndpointTransport.lean
+++ b/proofs/Proofs/SpernerTuckerEndpointTransport.lean
@@ -148,7 +148,7 @@ theorem hemisphere_interiorEndpoints_count (n : ℕ)
   refine interiorEndpoints_card_congr (hemisphereIso n).symm B
     (fun a => B (hemisphereIso n a)) ?_
   intro v
-  simp
+  rw [RelIso.apply_symm_apply]
 
 #check @interiorEndpoints_card_congr
 #check @boundaryEndpoints_card_congr

--- a/proofs/Proofs/SubsetCountOQ02.lean
+++ b/proofs/Proofs/SubsetCountOQ02.lean
@@ -56,7 +56,8 @@ theorem powerset_empty_card {α : Type*} :
 theorem powerset_cons_card {α : Type*} (a : α) (s : Multiset α) :
     Multiset.card (Multiset.powerset (a ::ₘ s)) =
       2 * Multiset.card (Multiset.powerset s) := by
-  simp [Multiset.card_powerset, pow_succ, mul_comm]
+  simp only [Multiset.card_powerset, Multiset.card_cons]
+  rw [pow_succ]; ring
 
 /-! ## Part II: Fixed-Size Submultisets -/
 

--- a/proofs/Proofs/SylowTheoremOQ02OQ01Nilpotent.lean
+++ b/proofs/Proofs/SylowTheoremOQ02OQ01Nilpotent.lean
@@ -64,7 +64,7 @@ whole group.  Combined with the parent result `n_p = [G : N_G(P)]`, this is the
 reason the Sylow count collapses to one. -/
 theorem normalizer_eq_top_of_nilpotent (h : Group.IsNilpotent G)
     (p : ℕ) [hp : Fact p.Prime] (P : Sylow p G) :
-    Subgroup.normalizer (P : Subgroup G) = ⊤ :=
+    Subgroup.normalizer ((P : Subgroup G) : Set G) = ⊤ :=
   Subgroup.normalizer_eq_top_iff.mpr (sylow_normal_of_nilpotent h p P)
 
 /-- **Counting characterization.**  A finite group is nilpotent iff every Sylow

--- a/proofs/Proofs/SylvesterSequenceOQ01OQ03.lean
+++ b/proofs/Proofs/SylvesterSequenceOQ01OQ03.lean
@@ -125,6 +125,8 @@ theorem syl_odd {n : ℕ} (hn : 1 ≤ n) : Odd (syl n) := by
   have hsub : syl (m + 1) - 1 = syl m * (syl m - 1) := syl_succ_sub_one m
   have hge : 1 ≤ syl (m + 1) := le_trans (by norm_num) (two_le_syl (m + 1))
   rcases heven with ⟨t, ht⟩
+  rw [ht] at hsub
+  simp only [Nat.succ_eq_add_one]
   exact ⟨t, by omega⟩
 
 /-- The `mod 6` invariant propagates: `6 ∣ aₙ - 1` for `n ≥ 2`. -/

--- a/proofs/Proofs/TaylorTheoremOQ03OQ01.lean
+++ b/proofs/Proofs/TaylorTheoremOQ03OQ01.lean
@@ -102,9 +102,14 @@ theorem exp_lagrange_remainder_partialSum (x : ℝ) (hx : 0 < x) (n : ℕ) :
     ∃ ξ ∈ Ioo (0 : ℝ) x,
       Real.exp x - ∑ k ∈ Finset.range (n + 1), x ^ k / (k ! : ℝ) =
         Real.exp ξ * x ^ (n + 1) / (n + 1)! := by
-  have hf : ContDiffOn ℝ (n + 1) Real.exp (Icc 0 x) :=
-    Real.contDiff_exp.contDiffOn.of_le le_top
-  obtain ⟨ξ, hξ, h⟩ := taylor_mean_remainder_lagrange_iteratedDeriv hx hf
+  have huIcc : Set.uIcc (0 : ℝ) x = Icc 0 x := Set.uIcc_of_le hx.le
+  have huIoo : Set.uIoo (0 : ℝ) x = Ioo 0 x := by
+    rw [Set.uIoo, min_eq_left hx.le, max_eq_right hx.le]
+  have hf : ContDiffOn ℝ (n + 1) Real.exp (Set.uIcc 0 x) := by
+    rw [huIcc]; exact Real.contDiff_exp.contDiffOn.of_le le_top
+  obtain ⟨ξ, hξ, h⟩ := taylor_mean_remainder_lagrange_iteratedDeriv hx.ne hf
+  rw [huIoo] at hξ
+  rw [huIcc] at h
   refine ⟨ξ, hξ, ?_⟩
   rw [taylorWithinEval_exp_eq_partialSum x hx n] at h
   rw [h, iteratedDeriv_exp, sub_zero]

--- a/proofs/Proofs/TaylorTheoremOQ03OQ02.lean
+++ b/proofs/Proofs/TaylorTheoremOQ03OQ02.lean
@@ -78,7 +78,9 @@ theorem deriv_neg_sin_fun : deriv (fun x => -Real.sin x) = fun x => -Real.cos x 
 theorem deriv_neg_cos_fun : deriv (fun x => -Real.cos x) = Real.sin := by
   ext x
   have h : HasDerivAt (fun x => -Real.cos x) (Real.sin x) x := by
-    simpa using (Real.hasDerivAt_cos x).neg
+    have h0 : HasDerivAt (fun x => -Real.cos x) (-(-Real.sin x)) x :=
+      (Real.hasDerivAt_cos x).neg
+    rwa [neg_neg] at h0
   exact h.deriv
 
 /-- The `k`-th iterated derivative of `cos` is one of `cos, -sin, -cos, sin`.

--- a/proofs/Proofs/TestApi1148.lean
+++ b/proofs/Proofs/TestApi1148.lean
@@ -7,13 +7,9 @@ namespace Erdos1148Test
 def HasConstRep (n : ℕ) : Prop :=
   ∃ x y z : ℕ, x ^ 2 + y ^ 2 = n + z ^ 2 ∧ x ^ 2 ≤ n ∧ y ^ 2 ≤ n ∧ z ^ 2 ≤ n
 
--- n=23: x,y,z ≤ 4 (5³ = 125 cases). omega should close all goals
--- since after interval_cases all three are concrete numerals.
-theorem not_hasConstRep_23 : ¬ HasConstRep 23 := by
-  intro ⟨x, y, z, heq, hx, hy, hz⟩
-  have : x ≤ 4 := by nlinarith [sq_nonneg x]
-  have : y ≤ 4 := by nlinarith [sq_nonneg y]
-  have : z ≤ 4 := by nlinarith [sq_nonneg z]
-  interval_cases x <;> interval_cases y <;> interval_cases z <;> omega
+-- n=23 DOES have a constrained representation: 4² + 4² = 32 = 23 + 3², with
+-- 16, 16, 9 all ≤ 23. (The original `¬ HasConstRep 23` was false — witness 4,4,3.)
+theorem hasConstRep_23 : HasConstRep 23 :=
+  ⟨4, 4, 3, by norm_num, by norm_num, by norm_num, by norm_num⟩
 
 end Erdos1148Test

--- a/proofs/Proofs/TestApi385.lean
+++ b/proofs/Proofs/TestApi385.lean
@@ -5,9 +5,10 @@ import Mathlib
 #check Nat.minFac_prime
 #check Nat.minFac_dvd
 
--- Test: minFac_sq_le_self
-example (n : ℕ) (hn : n > 1) : n.minFac ^ 2 ≤ n := by
-  exact Nat.minFac_sq_le_self (by omega)
+-- Test: minFac_sq_le_self (v4.31: now takes 0 < n and ¬Prime n — the bound is
+-- false for primes, e.g. n = 5 has minFac 5 and 5² > 5)
+example (n : ℕ) (hn : n > 1) (hcomp : ¬ n.Prime) : n.minFac ^ 2 ≤ n := by
+  exact Nat.minFac_sq_le_self (by omega) hcomp
 
 -- Test: le_sqrt API name
 #check @Nat.le_sqrt'

--- a/proofs/Proofs/TestApi457.lean
+++ b/proofs/Proofs/TestApi457.lean
@@ -25,7 +25,7 @@ open Finset
 
 -- Test: omega for modular arithmetic
 example (n p : ℕ) (hp : p > 0) (h : n % p = 0) : p ∣ (n + p) := by
-  rw [Nat.dvd_iff_mod_eq_zero]; omega
+  rw [Nat.dvd_iff_mod_eq_zero, Nat.add_mod, h, Nat.mod_self]; rfl
 
 -- Test: dvd transitivity with product membership
 example (s : Finset ℕ) (a b : ℕ) (ha : a ∈ s) (hab : b ∣ a) :

--- a/proofs/Proofs/TestApi689.lean
+++ b/proofs/Proofs/TestApi689.lean
@@ -48,4 +48,4 @@ def testCover (m p a : ℕ) : Bool := m % p == a % p
 -- Test: Finset.card_le_card for filter subset
 example (s : Finset ℕ) (p q : ℕ → Prop) [DecidablePred p] [DecidablePred q] (h : ∀ x, p x → q x) :
     (s.filter p).card ≤ (s.filter q).card :=
-  Finset.card_le_card (Finset.filter_subset_filter s h)
+  Finset.card_le_card (Finset.monotone_filter_right s (fun a _ => h a))

--- a/proofs/Proofs/TestApi913.lean
+++ b/proofs/Proofs/TestApi913.lean
@@ -19,7 +19,8 @@ theorem example_n3_913 : HasDistinctExponents913 3 := by
   simp only [show 3 * (3 + 1) = 12 from by norm_num] at *
   have h12pf : (12 : ℕ).primeFactors = {2, 3} := by native_decide
   rw [h12pf] at ha hb
-  skip
+  simp only [Finset.coe_insert, Finset.coe_singleton, Set.mem_insert_iff,
+    Set.mem_singleton_iff, Finset.mem_coe, Finset.mem_insert, Finset.mem_singleton] at ha hb
   have hf2 : (12 : ℕ).factorization 2 = 2 := by native_decide
   have hf3 : (12 : ℕ).factorization 3 = 1 := by native_decide
   rcases ha with rfl | rfl <;> rcases hb with rfl | rfl <;> simp_all

--- a/proofs/Proofs/TestZetaNonzero.lean
+++ b/proofs/Proofs/TestZetaNonzero.lean
@@ -78,7 +78,8 @@ theorem zero_in_strip_of_zero' (s : ℂ)
       have h_ne_one : s ≠ 1 := by
         intro heq
         have : (1 : ℂ).re ≤ 0 := heq ▸ h_not
-        simp at this
+        simp only [Complex.one_re] at this
+        norm_num at this
       have h_fe := riemannZeta_one_sub h_all h_ne_one
       -- ζ(1-s) = 2*(2π)^(-s) * Γ(s) * cos(πs/2) * ζ(s) = 0 (since ζ(s) = 0)
       have h_zero_1ms : riemannZeta (1 - s) = 0 := by

--- a/proofs/Proofs/VietasFormulasOQ02.lean
+++ b/proofs/Proofs/VietasFormulasOQ02.lean
@@ -121,9 +121,7 @@ theorem cube_sum_factorization (x y z : R) :
 /-- When x + y + z = 0, we get x³ + y³ + z³ = 3xyz. -/
 theorem cube_sum_when_sum_zero (x y z : R) (h : x + y + z = 0) :
     x ^ 3 + y ^ 3 + z ^ 3 = 3 * (x * y * z) := by
-  have := cube_sum_factorization x y z
-  linarith [show (x + y + z) * (x ^ 2 + y ^ 2 + z ^ 2 - x * y - x * z - y * z) = 0
-    from by rw [h]; ring]
+  linear_combination (x ^ 2 + y ^ 2 + z ^ 2 - x * y - x * z - y * z) * h
 
 /-- The square of the sum identity: (Σ xᵢ)² = Σ xᵢ² + 2·Σ_{i<j} xᵢxⱼ.
     This is the relationship p₁² = p₂ + 2·e₂. -/

--- a/proofs/Proofs/YangMills2DOQ01.lean
+++ b/proofs/Proofs/YangMills2DOQ01.lean
@@ -149,9 +149,8 @@ theorem wilsonLoop2D_area_law (d casimir g_sq A : ℝ)
     wilsonLoop2D d casimir g_sq A < wilsonLoop2D d casimir g_sq 0 := by
   unfold wilsonLoop2D
   simp only [mul_zero, zero_mul, neg_zero, zero_div, exp_zero, mul_one]
-  apply mul_lt_mul_of_pos_left _ hd
-  rw [exp_lt_one_iff]
-  apply neg_neg_of_neg
+  apply mul_lt_of_lt_one_right hd
+  rw [exp_lt_one_iff, neg_lt_zero]
   apply div_pos
   · exact mul_pos (mul_pos hg hA) hc
   · linarith

--- a/proofs/batch2/STATUS.md
+++ b/proofs/batch2/STATUS.md
@@ -40,8 +40,13 @@ first (highest confidence), one mechanical fix per file.
   Erdos758 Fin-19 exhaustiveness catch-all.
 - **DR23l** (+2): Erdos230 Real.iSup_le twice (ℝ conditionally complete, not
   `iSup_le`!), InverseGaloisF20 pow_mod_orderOf via have+rwa (avoid Fin-5 motive).
+- **DR23m** (+2): Erdos73 explicit Finset↑→Set compl-eq rewrite (avoid convert HEq),
+  Erdos811 irrefl field `⟨0, (color v v).pos⟩` (omega had no `0 < m`).
+- **DR23n** (+5): TestApi probe cluster — 385 minFac_sq_le_self ¬Prime arg,
+  457 add_mod explicit, 689 monotone_filter_right (filter_subset_filter now
+  same-predicate), 913 Set-coe membership simp, 1148 **statement repair**.
 
-**Increment 13 running total: +55 GREEN** (1317 → 1372). Recipes in rename-map §7o.
+**Increment 13 running total: +62 GREEN** (1317 → 1379). Recipes in rename-map §7o.
 
 ### Increment 13 statement repairs (operator policy 2026-07-13: fix false → intended-true)
 
@@ -49,6 +54,8 @@ first (highest confidence), one mechanical fix per file.
 |---|---|---|
 | Erdos525OQ02 | `sqrt_cancellation_terms` | added `hd : 0 < d`: `n^d ≥ n` is false at d=0 (n^0=1 < n for n≥2). No callers. |
 | Erdos306Problem | `example_one_representation` | RHS `= 1` → `= 101/210`: the six 2-distinct-prime unit fractions 1/6+1/10+1/14+1/15+1/21+1/35 sum to 101/210, not 1 (LCD 210 gives 35+21+15+14+10+6). No callers; docstring corrected. |
+| TestApi385 | `example` (minFac_sq_le_self probe) | added `hcomp : ¬ n.Prime`: v4.31 `Nat.minFac_sq_le_self` now requires `0 < n ∧ ¬Prime n`; the bound `minFac n ^ 2 ≤ n` is false for primes (n=5). Probe file. |
+| TestApi1148 | `not_hasConstRep_23` → `hasConstRep_23` | `¬ HasConstRep 23` is FALSE (witness x=4,y=4,z=3: 16+16=32=23+9, all squares ≤23). Repaired to the true `HasConstRep 23` with the explicit witness. Probe file. |
 
 ### Highest-value new recipes (increment 13)
 

--- a/proofs/batch2/STATUS.md
+++ b/proofs/batch2/STATUS.md
@@ -1,4 +1,77 @@
-# Batch 2/3/4/5 + Doctor verification state (updated Doctor increment 12, #38065, 2026-07-13)
+# Batch 2/3/4/5 + Doctor verification state (updated Doctor increment 13, #38065, 2026-07-13)
+
+## DOCTOR INCREMENT 13 (type-mismatch + proof-drift + rewrite-drift remainder, #38065)
+
+Classes at start: type-mismatch(223) + proof-drift(222) + rewrite-drift(101).
+Branch `feature/issue-38065-c`, worktree doctor-b, container dr23, cache volume
+lean-mathlib-cache-v431-b. Worked from the freshest committed diag (diag-DR20a.txt,
+792 files / 3313 own-file errors) — the DR19tm/DR19pd diags were empty ("no error
+lines captured"). Targeted the 76 single-own-error files across my three classes
+first (highest confidence), one mechanical fix per file.
+
+### Waves (all in-container verified, lake exit 0, then ledger-flipped)
+
+- **DR23a** (+7): Fibonacci fib_3 non-reduction, Taylor HasDerivAt.neg module-
+  instance + uIcc-signature drift, Sylow normalizer Set-arg, YangMills
+  mul_lt_of_lt_one_right, Sperner Option.noConfusion motive.
+- **DR23b** (+6): Erdos883/532 Fin-bound scoping (dependent `∃ hab`), Erdos8OQ02
+  emod case-split, Erdos879 prime two_le, Erdos1060 Nat.card_Icc, Erdos525OQ02
+  statement repair.
+- **DR23c** (+4): Erdos674 mul_assoc rewrite, Erdos540 ZMod-1 Subsingleton,
+  Erdos465 rpow inv_mul_cancel, **Erdos306 statement repair** (sum = 101/210).
+- **DR23d** (+5): Erdos821 decide, Vietas linear_combination over CommRing,
+  SolutionOfCubic nlinarith cube hints + linear_combination, Erdos80 Nonempty V.
+- **DR23e** (+8): Erdos690/935 close-goal, Erdos712 cast, GeometricSeries
+  eq_div_of_mul_eq, Erdos774 valid Nat.find witness, Erdos54 anon-binder,
+  Erdos760 proper-coloring witness via equivFin, Erdos869 rintro/not_exists.
+- **DR23f** (+4): SubsetCount pow_succ ring, PascalsHexagon adjugate_transpose
+  `.symm`, HermiteLegendre 0<p→1≤p bridge, CramersRule conj_apply + coe_units_inv.
+- **DR23g** (+4): HarmonicDivergence push_cast/ring, Erdos902 Nat.cast_one,
+  InfinitudePrimes explicit R-unfold, ShannonEntropy univ_product_univ bridge.
+- **DR23h** (+4): Hilbert17 Fin-3 if_false decide, PNPBarriers Option none≠some,
+  Hilbert22 MapsTo mono_right ball_subset_closedBall, Erdos956 explicit image.
+- **DR23i** (+4): MeanValueTheorem direct norm_image_sub w/ explicit f',
+  IncidenceCauchySchwarz Function.flip_def, LeibnizPi explicit ne' from
+  positivity, Feuerbach ← hPin.
+- **DR23j** (+2): Sylvester rw ht into hsub + succ_eq_add_one atom split,
+  SchroederBernstein fwdOrbit 0 def-reduce via rfl.
+- **DR23k** (+5): FourSquare Perm.one_symm, SpernerTucker RelIso.apply_symm_apply,
+  TestZeta one_re, ShapleyFolkman map_sum+congrArg (avoid dependent-var motive),
+  Erdos758 Fin-19 exhaustiveness catch-all.
+- **DR23l** (+2): Erdos230 Real.iSup_le twice (ℝ conditionally complete, not
+  `iSup_le`!), InverseGaloisF20 pow_mod_orderOf via have+rwa (avoid Fin-5 motive).
+
+**Increment 13 running total: +55 GREEN** (1317 → 1372). Recipes in rename-map §7o.
+
+### Increment 13 statement repairs (operator policy 2026-07-13: fix false → intended-true)
+
+| file | declaration | repair |
+|---|---|---|
+| Erdos525OQ02 | `sqrt_cancellation_terms` | added `hd : 0 < d`: `n^d ≥ n` is false at d=0 (n^0=1 < n for n≥2). No callers. |
+| Erdos306Problem | `example_one_representation` | RHS `= 1` → `= 101/210`: the six 2-distinct-prime unit fractions 1/6+1/10+1/14+1/15+1/21+1/35 sum to 101/210, not 1 (LCD 210 gives 35+21+15+14+10+6). No callers; docstring corrected. |
+
+### Highest-value new recipes (increment 13)
+
+- **`∑` over ℝ uses `Real.iSup_le` (conditional-complete), NOT `iSup_le`** — a
+  bare `iSup_le`/`iSup₂_le` on `⨆ z, ⨆ _, (f z : ℝ)` gives "typeclass instance
+  problem is stuck" (ℝ is not a CompleteLattice). Use `Real.iSup_le (hf) (0 ≤ bound)`,
+  nesting it for double sups. (Erdos230)
+- **Fin-bound proofs inside a `∃`-conjunction** — `∃ a b, P ∧ Q ⟨…, by omega using P⟩`
+  fails because omega can't see the conjunct `P` at the Fin-binder position. Rewrite
+  to `∃ a b, ∃ hP : P, Q ⟨…, hP⟩` (dependent existential threads the proof). Same
+  logical content. (Erdos532, Erdos883 via `Nat.mod_lt _ i.pos`)
+- **`rw [h]` where `h` mentions a value the surrounding structure depends on**
+  ("motive is not type correct: `D : Decomposition S t x` expected `… t _a`") —
+  rewrite the OTHER side first (`rw [← map_sum]; exact congrArg f h`), or use
+  `have := lemma; rwa [order_fact] at this` instead of rewriting the literal that
+  also appears in a `Fin n`/dependent type. (ShapleyFolkman, InverseGaloisF20)
+- **`Option.noConfusion h` (h : none = some _) motive-inference failure** →
+  `exact absurd h (by simp)`. Recurs (Sperner, PNPBarriers; sibling of §7k Dihedral).
+- **`decide`/reduction lemmas no longer fire on `Nat.fib k`/`Nat.totient`/`ZMod.re`
+  literals under `simpa`** — supply the value explicitly: `have : Nat.fib 3 = 2 := by
+  decide; rwa […]`. (Fibonacci ×2, Erdos821)
+- **exhaustive `Fin N` pattern-match now needs an explicit out-of-range arm** —
+  add `| ⟨n + N, h⟩ => absurd h (by omega)`. (Erdos758)
 
 ## DOCTOR INCREMENT 12 (parse-error + signature/elab/dot-notation drift, #38065)
 

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -1640,7 +1640,7 @@ Erdos736Problem	RESIDUAL	unknown-const:colorable_of_isEmpty
 Erdos737Problem	RESIDUAL	elab-drift
 Erdos738Problem	RESIDUAL	unclassified
 Erdos739Problem	RESIDUAL	dot-notation-drift
-Erdos73Aristotle	RESIDUAL	proof-drift
+Erdos73Aristotle	GREEN	
 Erdos73Problem	RESIDUAL	type-mismatch
 Erdos740Problem	RESIDUAL	instance-synth
 Erdos740ProblemProvable	RESIDUAL	instance-synth
@@ -1721,7 +1721,7 @@ Erdos808Problem	RESIDUAL	instance-synth
 Erdos809Problem	RESIDUAL	instance-synth
 Erdos80Problem	GREEN	
 Erdos810Problem	GREEN	
-Erdos811Problem	RESIDUAL	proof-drift
+Erdos811Problem	GREEN	
 Erdos812Problem	RESIDUAL	proof-drift
 Erdos813Problem	RESIDUAL	parse-error
 Erdos814Problem	RESIDUAL	instance-synth

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -1105,7 +1105,7 @@ Erdos301Problem	RESIDUAL	parse-error
 Erdos302Aristotle	RESIDUAL	proof-drift
 Erdos302Problem	RESIDUAL	proof-drift
 Erdos304Problem	GREEN	
-Erdos306Problem	RESIDUAL	proof-drift
+Erdos306Problem	GREEN	
 Erdos307Aristotle	GREEN	
 Erdos307OQ02	RESIDUAL	proof-drift
 Erdos308Problem	RESIDUAL	instance-synth
@@ -1293,7 +1293,7 @@ Erdos459Problem	RESIDUAL	type-mismatch
 Erdos45Problem	RESIDUAL	unknown-const:sawhney_upper_bound
 Erdos461Problem	RESIDUAL	unknown-const:Nat.prod_factors
 Erdos464Problem	GREEN	
-Erdos465Problem	RESIDUAL	proof-drift
+Erdos465Problem	GREEN	
 Erdos466Problem	GREEN	
 Erdos468Problem	GREEN	
 Erdos469Problem	GREEN	
@@ -1379,7 +1379,7 @@ Erdos537Problem	RESIDUAL	type-mismatch
 Erdos538Problem	GREEN	
 Erdos539Problem	RESIDUAL	elab-drift
 Erdos53Problem	GREEN	
-Erdos540Problem	RESIDUAL	proof-drift
+Erdos540Problem	GREEN	
 Erdos541Problem	GREEN	
 Erdos542Problem	GREEN	
 Erdos543Problem	RESIDUAL	proof-drift
@@ -1567,7 +1567,7 @@ Erdos673Aristotle	RESIDUAL	unknown-const:Finset.card_insert_of_not_mem
 Erdos673Problem	GREEN	
 Erdos674Aristotle	RESIDUAL	unknown-const:Nat.Prime.dvd_gcd
 Erdos674Problem	GREEN	
-Erdos674ProblemAristotle	RESIDUAL	proof-drift
+Erdos674ProblemAristotle	GREEN	
 Erdos675Problem	GREEN	
 Erdos676Problem	RESIDUAL	instance-synth
 Erdos677Problem	RESIDUAL	type-mismatch

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -1976,7 +1976,7 @@ FermatsLastTheoremOQ03	RESIDUAL	type-mismatch
 FeuerbachsTheoremDefsOQ04	RESIDUAL	type-mismatch
 FeuerbachsTheoremOQ01Aristotle	RESIDUAL	parse-error
 FeuerbachsTheoremOQ01OQ03	RESIDUAL	unknown-const:h1
-FeuerbachsTheoremOQ04TangentLine	RESIDUAL	proof-drift
+FeuerbachsTheoremOQ04TangentLine	GREEN	
 FeuerbachsTheoremOQ05	RESIDUAL	dot-notation-drift
 FibonacciIdentitiesOQ02	GREEN	
 FibonacciIdentitiesOQ02OQ02PrimeIndex	GREEN	
@@ -2116,7 +2116,7 @@ Hilbert9QuadraticSubfield	GREEN
 Hilbert9Reciprocity	GREEN	
 HodgeConjecture	RESIDUAL	proof-drift
 HurwitzTheoremOQ04	RESIDUAL	slow-timeout
-IncidenceCauchySchwarzDual	RESIDUAL	proof-drift
+IncidenceCauchySchwarzDual	GREEN	
 InclusionExclusion	GREEN	
 InclusionExclusionSecondBonferroni	RESIDUAL	unknown-const:sieveLayer_eq_sum_choose
 InfinitudePrimes	GREEN	
@@ -2238,7 +2238,7 @@ LebesgueMeasureOQ06OQ01	RESIDUAL	unknown-const:List.chain'_append.mp
 LeibnizPi	GREEN	
 LeibnizPiOQ02	GREEN	
 LeibnizPiOQ02Aristotle	GREEN	
-LeibnizPiOQ03	RESIDUAL	proof-drift
+LeibnizPiOQ03	GREEN	
 LiouvilleTheorem	RESIDUAL	instance-synth
 LiouvilleTheoremOQ03	GREEN	
 LiouvilleTheoremOQ04	GREEN	
@@ -2261,7 +2261,7 @@ MeanValueTheoremOQ02OQ01OQ02	GREEN
 MeanValueTheoremOQ02OQ02UIcc	GREEN	
 MeanValueTheoremOQ02OQ04	GREEN	
 MeanValueTheoremOQ02OQ04OQ01	RESIDUAL	type-mismatch
-MeanValueTheoremOQ03	RESIDUAL	type-mismatch
+MeanValueTheoremOQ03	GREEN	
 MeanValueTheoremOQ04	RESIDUAL	type-mismatch
 MeanValueTheoremOQ04OQ03	GREEN	
 MinkowskiFundamentalTheoremOQ02	RESIDUAL	proof-drift

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -1024,7 +1024,7 @@ Erdos225Problem	RESIDUAL	proof-drift
 Erdos226Problem	RESIDUAL	unknown-const:Rat.denseRange_ratCast
 Erdos229Problem	GREEN	
 Erdos230LowerBound	GREEN	
-Erdos230ProblemAristotle	RESIDUAL	proof-drift
+Erdos230ProblemAristotle	GREEN	
 Erdos231Problem	GREEN	
 Erdos232Problem	GREEN	
 Erdos233Problem	GREEN	
@@ -2144,7 +2144,7 @@ InverseGaloisD4OQ02OQ03OQ01OQ01OQ01	GREEN
 InverseGaloisD4OQ02OQ04	GREEN	
 InverseGaloisD4OQ03	GREEN	
 InverseGaloisF20	RESIDUAL	unknown-const:cyclotomic_5_has_root_in_splitting_field
-InverseGaloisF20OQ02	RESIDUAL	type-mismatch
+InverseGaloisF20OQ02	GREEN	
 InverseGaloisOQ01	GREEN	
 InverseGaloisOQ02	GREEN	
 InverseGaloisOQ03	GREEN	

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -750,7 +750,7 @@ Erdos1059OQ03	GREEN
 Erdos1059OQ04	RESIDUAL	unknown-const:AllFactorialSubtractionsComposite
 Erdos1059Problem	GREEN	
 Erdos105OQ05	GREEN	
-Erdos1060Problem	RESIDUAL	proof-drift
+Erdos1060Problem	GREEN	
 Erdos1061Problem	RESIDUAL	proof-drift
 Erdos1062OQ04	GREEN	
 Erdos1062Problem	GREEN	
@@ -1361,7 +1361,7 @@ Erdos521Problem	GREEN
 Erdos522Problem	GREEN	
 Erdos523Problem	RESIDUAL	unknown-const:halasz_theorem
 Erdos524Problem	GREEN	
-Erdos525OQ02	RESIDUAL	proof-drift
+Erdos525OQ02	GREEN	
 Erdos525Problem	RESIDUAL	instance-synth
 Erdos526Problem	GREEN	
 Erdos527Problem	GREEN	
@@ -1370,7 +1370,7 @@ Erdos529Problem	PRE-EXISTING	never-compiled:d_2
 Erdos52Problem	RESIDUAL	parse-error
 Erdos530Problem	RESIDUAL	unknown-const:komlos_sulyok_szemeredi
 Erdos531Problem	GREEN	
-Erdos532Problem	RESIDUAL	proof-drift
+Erdos532Problem	GREEN	
 Erdos533Problem	RESIDUAL	type-mismatch
 Erdos534Problem	GREEN	
 Erdos535Problem	GREEN	
@@ -1802,13 +1802,13 @@ Erdos876Problem	GREEN
 Erdos876ProblemAristotle	GREEN	
 Erdos877ProblemAristotle	GREEN	
 Erdos878Problem	RESIDUAL	instance-synth
-Erdos879Problem	RESIDUAL	proof-drift
+Erdos879Problem	GREEN	
 Erdos87Problem	GREEN	
 Erdos880Problem	GREEN	
 Erdos882Problem	RESIDUAL	instance-synth
 Erdos882ProblemOQ03	PRE-EXISTING	never-compiled:a
 Erdos882ProblemOQ03OQ02	GREEN	
-Erdos883Problem	RESIDUAL	proof-drift
+Erdos883Problem	GREEN	
 Erdos884Problem	RESIDUAL	dot-notation-drift
 Erdos885Problem	GREEN	
 Erdos886Problem	GREEN	
@@ -1825,7 +1825,7 @@ Erdos895Problem	GREEN
 Erdos895ProblemAristotle	RESIDUAL	proof-drift
 Erdos896Problem	RESIDUAL	unknown-const:Finset.product_singleton_right
 Erdos89Problem	GREEN	
-Erdos8OQ02	RESIDUAL	proof-drift
+Erdos8OQ02	GREEN	
 Erdos8Problem	RESIDUAL	unknown-const:bottleneck_counterexample
 Erdos900Problem	RESIDUAL	proof-drift
 Erdos901Aristotle	GREEN	

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -1719,7 +1719,7 @@ Erdos806Problem	RESIDUAL	parse-error
 Erdos807Problem	RESIDUAL	dot-notation-drift
 Erdos808Problem	RESIDUAL	instance-synth
 Erdos809Problem	RESIDUAL	instance-synth
-Erdos80Problem	RESIDUAL	proof-drift
+Erdos80Problem	GREEN	
 Erdos810Problem	GREEN	
 Erdos811Problem	RESIDUAL	proof-drift
 Erdos812Problem	RESIDUAL	proof-drift
@@ -1733,7 +1733,7 @@ Erdos819Problem	GREEN
 Erdos81Problem	RESIDUAL	instance-synth
 Erdos820Aristotle	GREEN	
 Erdos820Problem	GREEN	
-Erdos821Problem	RESIDUAL	proof-drift
+Erdos821Problem	GREEN	
 Erdos822Problem	RESIDUAL	instance-synth
 Erdos823Problem	RESIDUAL	unknown-const:ArithmeticFunction.totient
 Erdos824Problem	RESIDUAL	elab-drift
@@ -2429,8 +2429,8 @@ ShapleyFolkmanOQ04	GREEN
 SkolemNoetherMatrixAut	RESIDUAL	unknown-const:Matrix.isUnit_det_iff_isUnit_mulVecLin
 SkolemNoetherMatrixAutAristotle	RESIDUAL	unknown-const:Matrix.isUnit_det_iff_isUnit_mulVecLin
 SolutionOfCubicOQ03OQ01	RESIDUAL	rewrite-drift
-SolutionOfCubicOQ03OQ02	RESIDUAL	proof-drift
-SolutionOfCubicOQ03OQ03	RESIDUAL	proof-drift
+SolutionOfCubicOQ03OQ02	GREEN	
+SolutionOfCubicOQ03OQ03	GREEN	
 SolutionOfCubicOQ03OQ05	RESIDUAL	proof-drift
 SolutionOfCubicOQ05	GREEN	
 SophieGermain	GREEN	
@@ -2635,7 +2635,7 @@ UrysohnsLemmaOQ01OQ01OQ02OQ01	GREEN
 UrysohnsLemmaOQ01OQ01OQ02OQ02	GREEN	
 VandermondeInterpolationOQ01OQ02	GREEN	
 VandermondeInterpolationOQ01OQ02OQ01	GREEN	
-VietasFormulasOQ02	RESIDUAL	proof-drift
+VietasFormulasOQ02	GREEN	
 VietasFormulasOQ03OQ01	RESIDUAL	proof-drift
 WaringGgLowerBoundsOQ02	RESIDUAL	decide-maxrecdepth
 WilsonsTheoremOQ01	RESIDUAL	rewrite-drift

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -478,7 +478,7 @@ CramersRuleOQ03OQ03	RESIDUAL	unknown-const:Quaternion.imI
 CramersRuleOQ04OQ01	RESIDUAL	unknown-const:smul_mulVec_assoc
 CramersRuleOQ05	GREEN	
 CramersRuleOQ05OQ01	GREEN	
-CramersRuleOQ05OQ02	RESIDUAL	type-mismatch
+CramersRuleOQ05OQ02	GREEN	
 CubeRoot10Irrational	GREEN	
 CubeRoot2Irrational	GREEN	
 CubeRoot3Irrational	GREEN	
@@ -2076,7 +2076,7 @@ HermiteFloorIdentityOQ02	GREEN
 HermiteFloorIdentityOQ03	GREEN	
 HermiteLegendreFactorial	GREEN	
 HermiteLegendreFactorialOQ01	GREEN	
-HermiteLegendreFactorialOQ02	RESIDUAL	type-mismatch
+HermiteLegendreFactorialOQ02	GREEN	
 HermiteLindemann	GREEN	
 HermiteSawtoothIdentity	GREEN	
 HermiteSawtoothIdentityOQ02	GREEN	
@@ -2299,7 +2299,7 @@ PartitionTheoremOQ03	RESIDUAL	unknown-const:Nat.Partition.IsOdd.card
 PartitionTheoremOQ04	GREEN	
 PartitionTheoremOQ04Aristotle	GREEN	
 PascalsHexagon	GREEN	
-PascalsHexagonOQ02	RESIDUAL	type-mismatch
+PascalsHexagonOQ02	GREEN	
 PascalsHexagonOQ03	GREEN	
 PascalsHexagonOQ03Incomplete01Derangements	GREEN	
 PellEquationOQ01	RESIDUAL	unknown-const:Int.cast_nonneg.mpr
@@ -2506,7 +2506,7 @@ StirlingExpansionAristotle	GREEN
 StirlingFormula	RESIDUAL	parse-error
 StirlingFormulaOQ02OQ01	RESIDUAL	type-mismatch
 SubsetCount	GREEN	
-SubsetCountOQ02	RESIDUAL	proof-drift
+SubsetCountOQ02	GREEN	
 SubsetCountOQ02OQ01	RESIDUAL	unknown-const:Finset.disjoint_comm.mp
 SumOfDivisorsOQ01SpecialPrime	RESIDUAL	unknown-const:not_even_iff_odd
 SumOfKthPowers	RESIDUAL	unknown-const:Finset.sum_range_pow

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -2390,7 +2390,7 @@ SchauderFixedPointOQ03	RESIDUAL	instance-synth
 SchauderFixedPointOQ03OQ01	GREEN	
 SchroederBernsteinOQ01	RESIDUAL	elab-drift
 SchroederBernsteinOQ02	RESIDUAL	unknown-const:Set.image_subset
-SchroederBernsteinOQ03	RESIDUAL	type-mismatch
+SchroederBernsteinOQ03	GREEN	
 SchursTheorem	GREEN	
 SearchMathlib	RESIDUAL	unknown-const:IsCompact.of_isClosed_isBounded
 ShannonChannelCoding	GREEN	
@@ -2527,7 +2527,7 @@ SylowTheoremOQ04	RESIDUAL	unknown-const:card_sylow_dvd_index
 SylowTheoremOQ04OQ03	RESIDUAL	decide-maxrecdepth
 SylowTheoremOQ05	GREEN	
 SylowTheoremsOQ05	RESIDUAL	slow-timeout
-SylvesterSequenceOQ01OQ03	RESIDUAL	proof-drift
+SylvesterSequenceOQ01OQ03	GREEN	
 SynthesisCurvaturePtolemy	RESIDUAL	unknown-const:spherical_ptolemy
 SynthesisCurvaturePtolemyOQ01	RESIDUAL	unknown-const:spherical_ptolemy
 SynthesisCurvaturePtolemyOQ02	GREEN	

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -1889,7 +1889,7 @@ Erdos950Problem	RESIDUAL	unclassified
 Erdos953Problem	GREEN	
 Erdos954Problem	GREEN	
 Erdos955Problem	GREEN	
-Erdos956Aristotle	RESIDUAL	proof-drift
+Erdos956Aristotle	GREEN	
 Erdos956Problem	GREEN	
 Erdos957Problem	RESIDUAL	proof-drift
 Erdos958Problem	RESIDUAL	instance-synth
@@ -2092,7 +2092,7 @@ Hilbert15SchubertCalculus	RESIDUAL	unknown-const:finrank
 Hilbert15SchubertCalculusOQ01	RESIDUAL	unknown-const:finrank
 Hilbert16	RESIDUAL	type-mismatch
 Hilbert17OQ01	GREEN	
-Hilbert17RobinsonRationalSOS	RESIDUAL	proof-drift
+Hilbert17RobinsonRationalSOS	GREEN	
 Hilbert19Regularity	GREEN	
 Hilbert20BoundaryValue	RESIDUAL	signature-drift
 Hilbert20LocalSolvability	RESIDUAL	instance-synth
@@ -2101,7 +2101,7 @@ Hilbert20OQ01OQ03Aristotle	RESIDUAL	type-mismatch
 Hilbert21RiemannHilbert	RESIDUAL	type-mismatch
 Hilbert22OQ01	GREEN	
 Hilbert22OQ01OQ03	GREEN	
-Hilbert22OQ01OQ03Pseudohyperbolic	RESIDUAL	type-mismatch
+Hilbert22OQ01OQ03Pseudohyperbolic	GREEN	
 Hilbert22OQ01OQ03Universal	RESIDUAL	type-mismatch
 Hilbert22Uniformization	GREEN	
 Hilbert23CalculusVariations	GREEN	
@@ -2289,7 +2289,7 @@ NormEuclideanZsqrtdFamilyOQ03OQ02OQ01	RESIDUAL	instance-synth
 OSBridge	RESIDUAL	instance-synth
 PACLearning	GREEN	
 PNPBarriersLegacy	RESIDUAL	type-mismatch
-PNPBarriersSound	RESIDUAL	type-mismatch
+PNPBarriersSound	GREEN	
 PNPBarriersUnified	GREEN	
 PappusTheoremOQ02	RESIDUAL	proof-drift
 PartitionTheorem	RESIDUAL	unknown-const:Theorems100.partition_theorem

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -1978,8 +1978,8 @@ FeuerbachsTheoremOQ01Aristotle	RESIDUAL	parse-error
 FeuerbachsTheoremOQ01OQ03	RESIDUAL	unknown-const:h1
 FeuerbachsTheoremOQ04TangentLine	RESIDUAL	proof-drift
 FeuerbachsTheoremOQ05	RESIDUAL	dot-notation-drift
-FibonacciIdentitiesOQ02	RESIDUAL	type-mismatch
-FibonacciIdentitiesOQ02OQ02PrimeIndex	RESIDUAL	type-mismatch
+FibonacciIdentitiesOQ02	GREEN	
+FibonacciIdentitiesOQ02OQ02PrimeIndex	GREEN	
 FiveColorTheorem	GREEN	
 FourColorTheorem	GREEN	
 FourColorTheoremOQ01	RESIDUAL	unknown-const:Finset.ne_univ_iff_exists_notMem
@@ -2463,7 +2463,7 @@ SpernerNDimOQ02Obstruction	GREEN
 SpernerNDimOQ03	RESIDUAL	type-mismatch
 SpernerNDimOQ03OQ01	RESIDUAL	type-mismatch
 SpernerNDimOQ04	RESIDUAL	parse-error
-SpernerNDimOQ06	RESIDUAL	type-mismatch
+SpernerNDimOQ06	GREEN	
 SpernerSimplicialBridge	GREEN	
 SpernerSimplicialBridgeOQ01	GREEN	
 SpernerSimplicialBridgeOQ02	GREEN	
@@ -2519,7 +2519,7 @@ SumOfOddsStatementOnly	GREEN
 SylowTheorem	RESIDUAL	unknown-const:card_sylow_dvd_index
 SylowTheoremOQ01	RESIDUAL	rewrite-drift
 SylowTheoremOQ02	GREEN	
-SylowTheoremOQ02OQ01Nilpotent	RESIDUAL	type-mismatch
+SylowTheoremOQ02OQ01Nilpotent	GREEN	
 SylowTheoremOQ02Orbit	RESIDUAL	unknown-const:Sylow.exists_smul_eq
 SylowTheoremOQ03	GREEN	
 SylowTheoremOQ03B	GREEN	
@@ -2556,8 +2556,8 @@ TaylorTheorem	RESIDUAL	type-mismatch
 TaylorTheoremOQ01	RESIDUAL	type-mismatch
 TaylorTheoremOQ02	RESIDUAL	type-mismatch
 TaylorTheoremOQ03	RESIDUAL	type-mismatch
-TaylorTheoremOQ03OQ01	RESIDUAL	type-mismatch
-TaylorTheoremOQ03OQ02	RESIDUAL	type-mismatch
+TaylorTheoremOQ03OQ01	GREEN	
+TaylorTheoremOQ03OQ02	GREEN	
 TestApi1056	RESIDUAL	proof-drift
 TestApi1059	RESIDUAL	dot-notation-drift
 TestApi1061	RESIDUAL	unknown-const:Nat.divisors_prime_eq
@@ -2648,7 +2648,7 @@ WilsonsTheoremOQ07	GREEN
 WolstenholmeTheoremOQ01	RESIDUAL	oom-killed
 WolstenholmeTheoremOQ02OQ02	RESIDUAL	unknown-const:Equiv.mulLeft_apply
 WolstenholmeTheoremOQ03	GREEN	
-YangMills2DOQ01	RESIDUAL	proof-drift
+YangMills2DOQ01	GREEN	
 YangMills2DOQ02	GREEN	
 YangMillsMassGap	RESIDUAL	unknown-const:Real.exp_lt_exp_of_lt
 ZsqrtdNegTwo	GREEN	

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -1659,7 +1659,7 @@ Erdos753Problem	GREEN
 Erdos754Problem	GREEN	
 Erdos756Problem	RESIDUAL	proof-drift
 Erdos757Problem	RESIDUAL	unknown-const:Set.Finite.toFinset_card
-Erdos758Problem	RESIDUAL	proof-drift
+Erdos758Problem	GREEN	
 Erdos75Problem	GREEN	
 Erdos760Problem	GREEN	
 Erdos761Problem	GREEN	
@@ -1984,7 +1984,7 @@ FiveColorTheorem	GREEN
 FourColorTheorem	GREEN	
 FourColorTheoremOQ01	RESIDUAL	unknown-const:Finset.ne_univ_iff_exists_notMem
 FourColorTheoremOQ02	GREEN	
-FourSquareDistributionOQ01	RESIDUAL	proof-drift
+FourSquareDistributionOQ01	GREEN	
 FourSquareDistributionOQ04Arrange	GREEN	
 FourSquareDistributionOQ04ArrangeProof	GREEN	
 FourSquareDistributionOQ04Bridge	GREEN	
@@ -2423,7 +2423,7 @@ ShannonSourceCodingOQ02	RESIDUAL	type-mismatch
 ShannonSourceCodingOQ03	RESIDUAL	unknown-const:Fintype.sum_piFinset_succ
 ShapleyFolkman	GREEN	
 ShapleyFolkmanAristotle	RESIDUAL	proof-drift
-ShapleyFolkmanOQ01	RESIDUAL	type-mismatch
+ShapleyFolkmanOQ01	GREEN	
 ShapleyFolkmanOQ03	GREEN	
 ShapleyFolkmanOQ04	GREEN	
 SkolemNoetherMatrixAut	RESIDUAL	unknown-const:Matrix.isUnit_det_iff_isUnit_mulVecLin
@@ -2487,7 +2487,7 @@ SpernerTuckerCrossPolytopeHemisphereIso	GREEN
 SpernerTuckerCrossPolytopeLabelling	GREEN	
 SpernerTuckerDoorGraph	GREEN	
 SpernerTuckerDoorGraphTower	GREEN	
-SpernerTuckerEndpointTransport	RESIDUAL	proof-drift
+SpernerTuckerEndpointTransport	GREEN	
 SpernerTuckerEquatorMatchingGraph	GREEN	
 SpernerTuckerHexagonDirectedEngine	GREEN	
 SpernerTuckerHexagonPseudomanifold	GREEN	
@@ -2602,7 +2602,7 @@ TestHLTension	RESIDUAL	unknown-const:Finset.card_sdiff_eq_card_sub_card_inter
 TestHolderApi	RESIDUAL	unknown-const:MeasureTheory.snorm
 TestSphereLocEuc	RESIDUAL	proof-drift
 TestWolstenholme	RESIDUAL	unknown-const:ZMod.prod_univ_prime
-TestZetaNonzero	RESIDUAL	proof-drift
+TestZetaNonzero	GREEN	
 ThreeSquares	GREEN	
 ThreeSquaresGaussEureka	GREEN	
 ThreeSquaresRationalBridge	GREEN	

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -1831,7 +1831,7 @@ Erdos900Problem	RESIDUAL	proof-drift
 Erdos901Aristotle	GREEN	
 Erdos901Problem	GREEN	
 Erdos901ProblemAristotle	GREEN	
-Erdos902Problem	RESIDUAL	proof-drift
+Erdos902Problem	GREEN	
 Erdos903Problem	RESIDUAL	unknown-const:p
 Erdos904Problem	GREEN	
 Erdos905Problem	RESIDUAL	instance-synth
@@ -2067,7 +2067,7 @@ GreensTheoremOQ01OQ01OQ03	RESIDUAL	unknown-const:MeasureTheory.Measure.prod_mono
 GreensTheoremOQ03OQ04	RESIDUAL	type-mismatch
 GreensTheoremOQ04	RESIDUAL	type-mismatch
 GroupOrderPrimeSquaredAbelianIsoOQ01OQ01OQ02	RESIDUAL	type-mismatch
-HarmonicDivergence	RESIDUAL	proof-drift
+HarmonicDivergence	GREEN	
 HarmonicDivergenceOQ02	RESIDUAL	type-mismatch
 HarmonicDivergenceOQ04	RESIDUAL	unknown-const:not_summable_const_of_ne_zero
 HermiteFloorIdentity	GREEN	
@@ -2125,7 +2125,7 @@ InfinitudePrimes4k1OQ03	RESIDUAL	unknown-const:Nat.Prime.mod_four_ne_three_of_dv
 InfinitudePrimes4k3OQ01	RESIDUAL	parse-error
 InfinitudePrimes4k3OQ01Q12Q24	RESIDUAL	parse-error
 InfinitudePrimes4k3OQ03	GREEN	
-InfinitudePrimesOQ01	RESIDUAL	type-mismatch
+InfinitudePrimesOQ01	GREEN	
 IntermediateValueTheoremOQ03	RESIDUAL	unknown-const:intermediate_value_zero_of_le
 InverseGalois	GREEN	
 InverseGaloisA5	GREEN	
@@ -2414,7 +2414,7 @@ ShannonChannelCodingOQ03	GREEN
 ShannonChannelCodingOQ03Aristotle	RESIDUAL	signature-drift
 ShannonChannelCodingOQ04OQ01	GREEN	
 ShannonChannelCodingOQ04OQ01OQ01	GREEN	
-ShannonEntropyAristotle	RESIDUAL	type-mismatch
+ShannonEntropyAristotle	GREEN	
 ShannonEntropyOQ01	GREEN	
 ShannonEntropyOQ01OQ01	GREEN	
 ShannonEntropyOQ02	RESIDUAL	rewrite-drift

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -1391,7 +1391,7 @@ Erdos548Problem	RESIDUAL	instance-synth
 Erdos548ProblemAristotle	RESIDUAL	instance-synth
 Erdos549Problem	RESIDUAL	instance-synth
 Erdos549ProblemAristotle	RESIDUAL	type-mismatch
-Erdos54Problem	RESIDUAL	proof-drift
+Erdos54Problem	GREEN	
 Erdos550Problem	GREEN	
 Erdos551Problem	RESIDUAL	instance-synth
 Erdos551ProblemAristotle	RESIDUAL	proof-drift
@@ -1585,7 +1585,7 @@ Erdos684Problem	RESIDUAL	partenat-removal
 Erdos685Problem	GREEN	
 Erdos687Problem	RESIDUAL	type-mismatch
 Erdos688Problem	RESIDUAL	rewrite-drift
-Erdos690Problem	RESIDUAL	proof-drift
+Erdos690Problem	GREEN	
 Erdos691Problem	RESIDUAL	type-mismatch
 Erdos692Problem	GREEN	
 Erdos693Problem	RESIDUAL	unknown-const:Finset.sort_sorted
@@ -1609,7 +1609,7 @@ Erdos70OQ01Problem	RESIDUAL	unknown-const:Ordinal.mul_lt_mul_of_pos_left
 Erdos70Problem	GREEN	
 Erdos710Problem	GREEN	
 Erdos711Problem	GREEN	
-Erdos712Problem	RESIDUAL	proof-drift
+Erdos712Problem	GREEN	
 Erdos713Problem	PRE-EXISTING	never-compiled:n
 Erdos714Problem	GREEN	
 Erdos715Problem	RESIDUAL	parse-error
@@ -1661,7 +1661,7 @@ Erdos756Problem	RESIDUAL	proof-drift
 Erdos757Problem	RESIDUAL	unknown-const:Set.Finite.toFinset_card
 Erdos758Problem	RESIDUAL	proof-drift
 Erdos75Problem	GREEN	
-Erdos760Problem	RESIDUAL	proof-drift
+Erdos760Problem	GREEN	
 Erdos761Problem	GREEN	
 Erdos762Problem	GREEN	
 Erdos763Problem	GREEN	
@@ -1676,7 +1676,7 @@ Erdos770Problem	PRE-EXISTING	never-compiled:X
 Erdos771Problem	GREEN	
 Erdos772Problem	RESIDUAL	dot-notation-drift
 Erdos773Problem	RESIDUAL	unknown-const:pow_lt_pow_left
-Erdos774Problem	RESIDUAL	proof-drift
+Erdos774Problem	GREEN	
 Erdos775Problem	RESIDUAL	instance-synth
 Erdos776Problem	RESIDUAL	instance-synth
 Erdos777Problem	RESIDUAL	instance-synth
@@ -1788,7 +1788,7 @@ Erdos865Problem	GREEN
 Erdos866Aristotle	GREEN	
 Erdos867Problem	RESIDUAL	unknown-const:Finset.card_Ioc
 Erdos868Problem	GREEN	
-Erdos869Problem	RESIDUAL	proof-drift
+Erdos869Problem	GREEN	
 Erdos86Problem	RESIDUAL	parse-error
 Erdos870Aristotle	RESIDUAL	uses-sorry
 Erdos870Problem	GREEN	
@@ -1870,7 +1870,7 @@ Erdos933Problem	GREEN
 Erdos933ProblemAristotle	GREEN	
 Erdos934Problem	RESIDUAL	instance-synth
 Erdos934ProblemAristotle	RESIDUAL	proof-drift
-Erdos935Problem	RESIDUAL	proof-drift
+Erdos935Problem	GREEN	
 Erdos936Problem	RESIDUAL	unknown-const:Nat.pow_dvd_pow_of_dvd
 Erdos937Problem	RESIDUAL	proof-drift
 Erdos939Problem	GREEN	
@@ -2043,7 +2043,7 @@ GcdAlgorithmOQ02OQ01	GREEN
 GelfondSchneider	GREEN	
 GeneralQuartic	GREEN	
 GeneralQuarticAxiomsDischarge	RESIDUAL	type-mismatch
-GeometricSeries	RESIDUAL	type-mismatch
+GeometricSeries	GREEN	
 GeometricSeriesOQ01	GREEN	
 GeometricSeriesOQ01Neumann	GREEN	
 GeometricSeriesOQ01OQ02	GREEN	

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -2563,7 +2563,7 @@ TestApi1059	RESIDUAL	dot-notation-drift
 TestApi1061	RESIDUAL	unknown-const:Nat.divisors_prime_eq
 TestApi1061b	RESIDUAL	unknown-const:Nat.divisors_prime_eq
 TestApi1141	RESIDUAL	dot-notation-drift
-TestApi1148	RESIDUAL	proof-drift
+TestApi1148	GREEN	
 TestApi1159b	RESIDUAL	unknown-const:Configuration.HasLines.mkFinOrder
 TestApi1159c	RESIDUAL	proof-drift
 TestApi203	RESIDUAL	unclassified
@@ -2575,22 +2575,22 @@ TestApi312	RESIDUAL	unknown-const:Real.exp_ge_one_add_of_nonneg
 TestApi321	GREEN	
 TestApi342	RESIDUAL	dot-notation-drift
 TestApi361	GREEN	
-TestApi385	RESIDUAL	proof-drift
+TestApi385	GREEN	
 TestApi417	RESIDUAL	proof-drift
 TestApi423	RESIDUAL	parse-error
-TestApi457	RESIDUAL	proof-drift
+TestApi457	GREEN	
 TestApi472	GREEN	
 TestApi513	RESIDUAL	unknown-const:Real.pi_lt_3141593
 TestApi635	GREEN	
 TestApi654	GREEN	
 TestApi688	RESIDUAL	unknown-const:Nat.not_prime_of_le_one
-TestApi689	RESIDUAL	type-mismatch
+TestApi689	GREEN	
 TestApi693	GREEN	
 TestApi783	RESIDUAL	dot-notation-drift
 TestApi826	RESIDUAL	signature-drift
 TestApi847	GREEN	
 TestApi889	GREEN	
-TestApi913	RESIDUAL	proof-drift
+TestApi913	GREEN	
 TestApi959	GREEN	
 TestApi960	RESIDUAL	unknown-const:Rat.toNat
 TestApi963	RESIDUAL	unknown-const:Finset.sum_pow_eq_pow_sum

--- a/research/toolchain-v4.31-rename-map.md
+++ b/research/toolchain-v4.31-rename-map.md
@@ -630,3 +630,37 @@ tree clean (the parse edit is correct but the row can't go GREEN yet).
 | `∆` (symmetric difference) — `expected token` | `open scoped symmDiff` after imports (notation is now `scoped[symmDiff]`) | Erdos431 flipped; Erdos1123 hit deeper `Set.symmDiff_comm` unknown |
 | `p \| q` where `\|` means divides | `p ∣ q` (`∣` U+2223, not ASCII pipe) | Erdos490Aristotle (had deeper omega drift, didn't flip) |
 | `∂` measure-integral / `⟪_,_⟫` inner-product notation — `expected token` | `open MeasureTheory` / `open scoped RealInnerProductSpace` (notation-scope loss, §7d family) | EgorovTheorem, LebesgueMeasureOQ03 (deeper, not swept) |
+
+### 7o. Doctor increment-13 recipes (#38065, 2026-07-13, type-mismatch + proof-drift + rewrite-drift remainder)
+
+| v4.31 symptom | fix | source |
+|---|---|---|
+| `iSup_le`/`iSup₂_le` on `⨆ z, ⨆ _, (f z : ℝ) ≤ a` → "typeclass instance problem is stuck" | `Real.iSup_le (fun i => …) (0 ≤ a)`, nested for double sups — ℝ is conditionally complete, not a `CompleteLattice`, so `iSup_le` doesn't apply | Erdos230ProblemAristotle |
+| Fin-bound `by omega` inside `∃ a b, P ∧ Q ⟨…, proof-needing-P⟩` — omega can't see the conjunct `P` at binder position | rewrite to dependent existential `∃ a b, ∃ hP : P, Q ⟨…, hP⟩` (same logical content) | Erdos532; also `Nat.mod_lt _ i.pos` for `Fin cycle.length` (Erdos883) |
+| `rw [h]` "motive is not type correct" where `h`'s LHS/RHS appears in a dependent type (`D : Decomposition S t x`, `σ : Perm (Fin 5)`) | rewrite the OTHER operand first (`rw [← map_sum]; exact congrArg f h`), or `have := lemma; rwa [order_fact] at this` — never `rw` a literal that also indexes a `Fin n`/structure param | ShapleyFolkmanOQ01, InverseGaloisF20OQ02 |
+| `Option.noConfusion h` (`h : none = some _`) motive-inference failure | `exact absurd h (by simp)` | SpernerNDimOQ06, PNPBarriersSound (sibling of §7k Dihedral noConfusion) |
+| `simpa using (hasDerivAt_cos x).neg` — `-cos` elaborated via wrong module instance (`RCLike.toInnerProductSpaceReal.toModule` vs `Semiring.toModule`) | build the `HasDerivAt` with the explicit derivative value: `have h0 : HasDerivAt (fun x => -f x) (-(-f' x)) x := (hasDerivAt … ).neg; rwa [neg_neg] at h0` | TaylorTheoremOQ03OQ02 |
+| `taylor_mean_remainder_lagrange_iteratedDeriv hx` — first arg was `0 < x`, now `x₀ ≠ x`; result set is `uIcc`/`uIoo` not `Icc`/`Ioo` | pass `hx.ne` (for `x₀=0`: `0 ≠ x`), and bridge `Set.uIcc 0 x = Icc 0 x` via `Set.uIcc_of_le hx.le` + `uIoo` via `min/max_eq` | TaylorTheoremOQ03OQ01 |
+| `Subgroup.normalizer (P : Subgroup G)` — now takes `Set G` | `Subgroup.normalizer ((P : Subgroup G) : Set G)` (`normalizer_eq_top_iff` still Subgroup-Normal-valued) | SylowTheoremOQ02OQ01Nilpotent (confirms §7b) |
+| `mul_lt_mul_of_pos_left _ hd` on goal `d * e < d` (no `* 1` on RHS) | `mul_lt_of_lt_one_right hd` (needs `e < 1`); then `rw [exp_lt_one_iff, neg_lt_zero]` for `exp(neg) < 1` | YangMills2DOQ01 |
+| `Nat.fib 3` / `Nat.totient` literals no longer reduce under `simpa` (mono-lemma gives `fib 3 ≤ fib m`, want `2 ≤ fib m`) | `have h3 : Nat.fib 3 = 2 := by decide; rwa [h3] at this` | FibonacciIdentitiesOQ02 (×2), Erdos821 (`constructor <;> decide` for totient) |
+| exhaustive `Fin N` `def … | ⟨0,_⟩ => … | ⟨N-1,_⟩ => …` → "Missing cases: Fin.mk (…N…)" | add out-of-range arm `| ⟨n + N, h⟩ => absurd h (by omega)` | Erdos758Problem |
+| `Nat.find ⟨witness, by trivial⟩` where the predicate is a metavariable (`?m (Fintype.card V)`) or the witness makes the pred FALSE | annotate the predicate `Nat.find (p := fun k => ∃ …) ⟨…⟩` AND supply a genuinely-true witness (constant coloring isn't proper — use `Fintype.equivFin V` injective); add `open Classical in` for `DecidablePred` | Erdos760Problem (chromaticNumber), Erdos774 (n+1 card bound) |
+| anonymous `‹_›` proof inside a set-builder conjunction `{s | ∃ S, (∀ n∈S, n∈A ∧ c ⟨n,‹_›⟩=…) ∧ …}` | thread via dependent existential `∃ hn : n ∈ A, c ⟨n, hn⟩ = …` | Erdos54Problem (sibling of §7m Erdos173 anon-binder) |
+| `rw [hinter, hPin]` where `hPin : P = foo P` re-substitutes P inside `foo` (self-referential nesting) | rewrite backward `rw [hinter, ← hPin]` to collapse `foo P → P` | FeuerbachsTheoremOQ04TangentLine |
+| conditionally-completed `positivity` fails on `1 + x^2 ≠ 0` (needs strict, gets ≠0) | `have : (0:ℝ) < 1 + x^2 := by positivity; exact this.ne'` | LeibnizPiOQ03 |
+| `mean_value_inequality hh hC` fails to unify `deriv (f-g)` with the supplied value `deriv f - deriv g` | apply the underlying Mathlib lemma directly with an explicit `(f' := fun y => deriv f y - deriv g y)`: `norm_image_sub_le_of_norm_deriv_le_segment' (f' := …) hh hC` | MeanValueTheoremOQ03 |
+| `Complex.norm_le_norm_of_mapsTo_ball_self hd hmaps …` — `hmaps` now needs `MapsTo f ball closedBall` | `hmaps.mono_right Metric.ball_subset_closedBall` | Hilbert22OQ01OQ03Pseudohyperbolic |
+| `(conj U M).charpoly` vs `charpoly_units_conj` giving `(↑U*M*(↑U)⁻¹)` and `↑U⁻¹`/`(↑U)⁻¹` mismatch | `rw [conj_apply, Matrix.coe_units_inv U]` (unit-inv-cast → matrix-inv-of-cast) | CramersRuleOQ05OQ02 |
+| `flip Inc x y` opaque after `Finset.sum_comm` | add `Function.flip_def` to the `simp only` set | IncidenceCauchySchwarzDual |
+| `(Equiv.symm 1)` / `(iso (iso.symm v))` not simplified | `Equiv.Perm.one_symm` (qualified!) / `RelIso.apply_symm_apply` | FourSquareDistributionOQ01, SpernerTuckerEndpointTransport |
+| omega counterexample missing a product/mod atom: `syl(m+1)-1 = product`, `product = t+t` unlinked; `syl m.succ` vs `syl (m+1)` split | `rw [ht] at hsub` (substitute product) + `simp only [Nat.succ_eq_add_one]` before omega | SylvesterSequenceOQ01OQ03 (confirms §7m succ split) |
+| `Nat.card_Icc`/`Nat.card_range` needed before omega for `card (Icc 1 (sqrt n)) ≤ sqrt n` | `rw [Nat.card_Icc]; omega` | Erdos1060Problem |
+| `Int.ModEq` goal `¬ (r+1) ≡ r [ZMOD m]` where omega can't model `% m` (variable modulus) | case-split `Nat.lt_or_ge (r+1) m`, prove each `(r+1)%m` value via `Int.emod_eq_of_lt`/`Int.emod_self` | Erdos8OQ02 |
+
+**Meta-finding (confirms inc-8/9/10/12):** the dependency backfill already ran —
+these are genuine per-file v4.31 repairs. The 76 single-own-error files across
+type-mismatch/proof-drift/rewrite-drift are the highest-confidence one-edit bucket;
+~40 flipped cleanly this session. Virtiofs truncation ("unexpected end of input",
+`Unknown identifier CramersRuleOQ0`) recurs on /Volumes/Stripe worktrees after host
+edits — `docker restart dr23` before rebuild.


### PR DESCRIPTION
Doctor increment 13 of the Lean v4.26→v4.31 toolchain migration (epic #37508, issue #38065).

## Classes worked
type-mismatch (223) + proof-drift (222) + rewrite-drift (101) remainder, biggest single-own-error clusters first.

## Result: +62 GREEN (ledger 1317 → 1379)

Per-class RESIDUAL before → after:
- **type-mismatch**: 223 → 204 (−19)
- **proof-drift**: 222 → 179 (−43)
- **rewrite-drift**: 101 → 101 (0 — its files' primary errors are dep-masked / not single-own-error; deferred)

## Waves (14, all in-container verified `lake` exit 0, then ledger-flipped)
DR23a (+7) · DR23b (+6) · DR23c (+4) · DR23d (+5) · DR23e (+8) · DR23f (+4) · DR23g (+4) · DR23h (+4) · DR23i (+4) · DR23j (+2) · DR23k (+5) · DR23l (+2) · DR23m (+2) · DR23n (+5).

## Statement repairs (operator policy: fix false → intended-true, never vacuous/sorry)
- **Erdos525OQ02** `sqrt_cancellation_terms`: added `0 < d` (`n^d ≥ n` false at d=0).
- **Erdos306Problem** `example_one_representation`: `= 1` → `= 101/210` (the six 2-distinct-prime unit fractions sum to 101/210, not 1).
- **TestApi385** minFac probe: added `¬ n.Prime` (v4.31 `minFac_sq_le_self` needs it; bound false for primes).
- **TestApi1148** `not_hasConstRep_23` → `hasConstRep_23`: `¬HasConstRep 23` is false (witness 4,4,3); repaired to the true form.

## Key new recipes (full catalog in rename-map §7o, STATUS.md increment 13)
- `∑ over ℝ` uses `Real.iSup_le` (conditionally-complete), NOT `iSup_le` ("typeclass stuck").
- Fin-bound proofs inside `∃`-conjunctions → dependent `∃ hP : P, …`.
- `rw` "motive not type correct" on a value indexing a dependent type → rewrite the other operand / `have`+`rwa`.
- `Option.noConfusion (h : none = some _)` → `absurd h (by simp)`.
- `Nat.find` metavariable/false-witness → annotate `(p := …)` + supply a genuinely-true witness; `open Classical in` for DecidablePred.
- exhaustive `Fin N` match now needs an out-of-range arm.

No `loom:review-requested` label (math-agent PR; deployer merges directly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)