### PR TITLE
migrate(v4.31): Doctor increment 21 — structured remainder + deep-rework (+12 GREEN)

### DIFF
--- a/proofs/Proofs/DenumerabilityRationalsOQ01.lean
+++ b/proofs/Proofs/DenumerabilityRationalsOQ01.lean
@@ -127,7 +127,7 @@ theorem aleph_one_le_continuum : (Cardinal.aleph 1 : Cardinal.{0}) ≤ 𝔠 :=
 /-- ℵ₀ < ℵ₁: the smallest uncountable cardinal strictly exceeds ℵ₀.
     This is ZFC-provable: ℵ₁ is defined as the successor of ℵ₀. -/
 theorem aleph_zero_lt_aleph_one : (ℵ₀ : Cardinal.{0}) < Cardinal.aleph 1 := by
-  have h : Cardinal.aleph 0 < Cardinal.aleph 1 :=
+  have h : (Cardinal.aleph 0 : Cardinal.{0}) < Cardinal.aleph 1 :=
     Cardinal.aleph_lt_aleph.mpr (by norm_num)
   simpa [Cardinal.aleph_zero] using h
 

--- a/proofs/Proofs/Erdos345Problem.lean
+++ b/proofs/Proofs/Erdos345Problem.lean
@@ -25,6 +25,8 @@ import Mathlib.Tactic
 
 namespace Erdos345
 
+open scoped Classical
+
 /- ## Subset sums and completeness -/
 
 /-- The set of finite nonempty subset sums of `A ⊆ ℕ`.
@@ -42,7 +44,6 @@ def IsCompleteSeq (A : Set ℕ) : Prop :=
 
 /-- The threshold of completeness `T(A)`: the least `m` such that all
     `n ≥ m` are in `P(A)`. Defined via `Nat.find` when `A` is complete. -/
-open Classical in
 noncomputable def threshold (A : Set ℕ) : ℕ :=
     if h : IsCompleteSeq A then Nat.find h else 0
 
@@ -106,7 +107,7 @@ def powerSeq (k : ℕ) : Set ℕ :=
 theorem powerSeq_subset_powerSeq_1 (k : ℕ) (hk : 1 ≤ k) :
     powerSeq k ⊆ powerSeq 1 := by
   intro m ⟨n, hn, hm⟩
-  exact ⟨m, by rw [hm]; exact Nat.one_le_pow k n hn, pow_one m⟩
+  exact ⟨m, by rw [hm]; exact Nat.one_le_pow k n hn, (pow_one m).symm⟩
 
 /-- Combining monotonicity with powerSeq_1_complete: every powerSeq k
     (k ≥ 1) is complete, assuming powerSeq 1 completeness. -/
@@ -131,7 +132,11 @@ theorem threshold_powerSeq_1 : threshold (powerSeq 1) = 1 := by
   apply (Nat.find_eq_iff _).mpr
   constructor
   · -- All n ≥ 1 are in subsetSums(powerSeq 1)
-    exact fun n hn => (powerSeq_1_complete).choose_spec n hn
+    intro n hn
+    refine ⟨{n}, Finset.singleton_nonempty n, ?_, ?_⟩
+    · simp only [Finset.coe_singleton, Set.singleton_subset_iff]
+      exact ⟨n, hn, (pow_one n).symm⟩
+    · simp
   · -- For m = 0: not all n ≥ 0 are in subsetSums(powerSeq 1)
     intro m hm
     interval_cases m
@@ -146,8 +151,11 @@ theorem threshold_powerSeq_1 : threshold (powerSeq 1) = 1 := by
     have hx_in : x ∈ (↑S : Set ℕ) := Finset.mem_coe.mpr hx_mem
     have ⟨n, hn_pos, hn_eq⟩ := hS_sub hx_in
     have hx_pos : 1 ≤ x := by rw [hn_eq, pow_one]; exact hn_pos
-    have := Finset.single_le_sum (fun a _ => Nat.zero_le a) hx_mem
-    simp [id] at this
+    have hle := Finset.single_le_sum (fun a _ => Nat.zero_le a) hx_mem
+    have hx_le : x ≤ 0 := by
+      calc x = id x := rfl
+        _ ≤ S.sum id := hle
+        _ = 0 := hS_sum
     omega
 
 /- ## Known threshold values -/
@@ -174,26 +182,30 @@ axiom threshold_fifth : threshold (powerSeq 5) = 67898772
     by definition, contradicting `threshold_squares = 129`. -/
 theorem powerSeq_2_complete : IsCompleteSeq (powerSeq 2) := by
   by_contra h
-  simp only [threshold, dif_neg h] at threshold_squares
-  norm_num at threshold_squares
+  have hts := threshold_squares
+  simp only [threshold, dif_neg h] at hts
+  norm_num at hts
 
 /-- `powerSeq 3` is complete: derived from `threshold_cubes = 12759`. -/
 theorem powerSeq_3_complete : IsCompleteSeq (powerSeq 3) := by
   by_contra h
-  simp only [threshold, dif_neg h] at threshold_cubes
-  norm_num at threshold_cubes
+  have htc := threshold_cubes
+  simp only [threshold, dif_neg h] at htc
+  norm_num at htc
 
 /-- `powerSeq 4` is complete: derived from `threshold_fourth = 5134241`. -/
 theorem powerSeq_4_complete : IsCompleteSeq (powerSeq 4) := by
   by_contra h
-  simp only [threshold, dif_neg h] at threshold_fourth
-  norm_num at threshold_fourth
+  have htf := threshold_fourth
+  simp only [threshold, dif_neg h] at htf
+  norm_num at htf
 
 /-- `powerSeq 5` is complete: derived from `threshold_fifth = 67898772`. -/
 theorem powerSeq_5_complete : IsCompleteSeq (powerSeq 5) := by
   by_contra h
-  simp only [threshold, dif_neg h] at threshold_fifth
-  norm_num at threshold_fifth
+  have htf := threshold_fifth
+  simp only [threshold, dif_neg h] at htf
+  norm_num at htf
 
 /- ## Completeness of power sequences (general) -/
 

--- a/proofs/Proofs/Erdos490Aristotle.lean
+++ b/proofs/Proofs/Erdos490Aristotle.lean
@@ -44,14 +44,11 @@ theorem trivial_product_bound (A B : Finset ℕ) (N : ℕ)
 -- Section 2: Prime Divisibility for Distinct Products
 -- ═══════════════════════════════════════════════════════════════════
 
-/-- If p is prime, p > a, and p | a * q, then p | q. -/
+/-- If p is prime, 0 < a < p, and p | a * q, then p | q. -/
 theorem prime_dvd_of_dvd_mul_lt (p a q : ℕ) (hp : Nat.Prime p)
-    (hpa : a < p) (h : p ∣ a * q) : p | q := by
-  have hna : ¬(p ∣ a) := by
-    intro hdvd
-    rcases Nat.eq_zero_or_pos a with rfl | hpos
-    · simp at h; rcases h with rfl | rfl <;> omega
-    · exact Nat.not_lt.mpr (Nat.le_of_dvd hpos hdvd) hpa
+    (ha : 0 < a) (hpa : a < p) (h : p ∣ a * q) : p ∣ q := by
+  have hna : ¬(p ∣ a) := fun hdvd =>
+    Nat.not_lt.mpr (Nat.le_of_dvd ha hdvd) hpa
   exact (hp.dvd_mul.mp h).resolve_left hna
 
 /-- If a₁ * p₁ = a₂ * p₂ with p₁, p₂ prime and p₁ > a₂, p₂ > a₁,
@@ -61,8 +58,8 @@ theorem unique_product_large_primes (a₁ a₂ p₁ p₂ : ℕ)
     (hlt₁ : a₁ < p₁) (hlt₂ : a₂ < p₂)
     (ha₁ : a₁ > 0) (ha₂ : a₂ > 0)
     (heq : a₁ * p₁ = a₂ * p₂) : a₁ = a₂ ∧ p₁ = p₂ := by
-  have hp₁_dvd : p₁ ∣ a₂ * p₂ := ⟨a₁, by omega⟩
-  have hp₂_dvd : p₂ ∣ a₁ * p₁ := ⟨a₂, by omega⟩
+  have hp₁_dvd : p₁ ∣ a₂ * p₂ := ⟨a₁, by rw [← heq]; ring⟩
+  have hp₂_dvd : p₂ ∣ a₁ * p₁ := ⟨a₂, by rw [heq]; ring⟩
   rcases hp₁.dvd_mul.mp hp₁_dvd with h₁ | h₁
   · -- p₁ | a₂
     rcases hp₂.dvd_mul.mp hp₂_dvd with h₂ | h₂
@@ -71,13 +68,21 @@ theorem unique_product_large_primes (a₁ a₂ p₁ p₂ : ℕ)
       have : p₂ ≤ a₁ := Nat.le_of_dvd (by omega) h₂
       omega
     · -- p₂ | p₁: both prime, so p₁ = p₂
-      rcases hp₂.eq_one_or_self_of_dvd p₁ h₂ with h | h
-      · omega
-      · subst h; exact ⟨by nlinarith, rfl⟩
+      rcases hp₁.eq_one_or_self_of_dvd p₂ h₂ with h | h
+      · have := hp₂.two_le; omega
+      · have hpp : p₁ = p₂ := h.symm
+        subst hpp
+        refine ⟨?_, rfl⟩
+        have hp₁_pos : 0 < p₁ := hp₁.pos
+        exact Nat.eq_of_mul_eq_mul_right hp₁_pos heq
   · -- p₁ | p₂: both prime, so p₁ = p₂
-    rcases hp₁.eq_one_or_self_of_dvd p₂ h₁ with h | h
-    · omega
-    · subst h; exact ⟨by nlinarith, rfl⟩
+    rcases hp₂.eq_one_or_self_of_dvd p₁ h₁ with h | h
+    · have := hp₁.two_le; omega
+    · have hpp : p₁ = p₂ := h
+      subst hpp
+      refine ⟨?_, rfl⟩
+      have hp₁_pos : 0 < p₁ := hp₁.pos
+      exact Nat.eq_of_mul_eq_mul_right hp₁_pos heq
 
 -- ═══════════════════════════════════════════════════════════════════
 -- Section 3: Product Set Properties
@@ -108,15 +113,21 @@ theorem prime_product_unique (p₁ p₂ q₁ q₂ : ℕ)
     (hq₁ : Nat.Prime q₁) (hq₂ : Nat.Prime q₂)
     (h : p₁ * q₁ = p₂ * q₂) :
     (p₁ = p₂ ∧ q₁ = q₂) ∨ (p₁ = q₂ ∧ q₁ = p₂) := by
-  have hp₁_dvd : p₁ ∣ p₂ * q₂ := ⟨q₁, by linarith⟩
+  have hp₁_dvd : p₁ ∣ p₂ * q₂ := ⟨q₁, by rw [← h]⟩
   rcases hp₁.dvd_mul.mp hp₁_dvd with h₁ | h₁
   · -- p₁ | p₂: both prime, so p₁ = p₂
     rcases hp₂.eq_one_or_self_of_dvd p₁ h₁ with heq | heq
-    · omega
-    · left; subst heq; exact ⟨rfl, by nlinarith⟩
+    · have := hp₁.two_le; omega
+    · left; refine ⟨heq, ?_⟩
+      subst heq
+      exact Nat.eq_of_mul_eq_mul_left hp₁.pos h
   · -- p₁ | q₂: both prime, so p₁ = q₂
     rcases hq₂.eq_one_or_self_of_dvd p₁ h₁ with heq | heq
-    · omega
-    · right; subst heq; exact ⟨rfl, by nlinarith⟩
+    · have := hp₁.two_le; omega
+    · right; refine ⟨heq, ?_⟩
+      subst heq
+      -- h : p₁ * q₁ = p₂ * p₁, so q₁ = p₂
+      have h' : p₁ * q₁ = p₁ * p₂ := by rw [h]; ring
+      exact Nat.eq_of_mul_eq_mul_left hp₁.pos h'
 
 end Erdos490Aristotle

--- a/proofs/Proofs/Erdos79Incomplete01.lean
+++ b/proofs/Proofs/Erdos79Incomplete01.lean
@@ -55,7 +55,7 @@ def K4MinusEdge (p q : ℕ) : SimpleGraph ℕ where
   loopless := by
     constructor
     rintro u ⟨h1, -⟩
-    exact (completeGraphN 4).loopless u h1
+    exact (completeGraphN 4).loopless.irrefl u h1
 
 @[simp] theorem K4MinusEdge_adj (p q u v : ℕ) :
     (K4MinusEdge p q).Adj u v ↔

--- a/proofs/Proofs/FactorRemainderTheorem.lean
+++ b/proofs/Proofs/FactorRemainderTheorem.lean
@@ -120,7 +120,7 @@ theorem remainder_divides {R : Type*} [CommRing R] (p : R[X]) (a : R) :
 theorem division_algorithm {R : Type*} [CommRing R] (p : R[X]) (a : R) :
     p = (X - C a) * (p /ₘ (X - C a)) + C (p.eval a) := by
   have h : (X - C a).Monic := monic_X_sub_C a
-  conv_lhs => rw [← modByMonic_add_div p h]
+  conv_lhs => rw [← modByMonic_add_div p (X - C a)]
   rw [remainder_theorem, add_comm]
 
 /-! ## Connection Between the Two Theorems

--- a/proofs/Proofs/Hilbert20BoundaryValue.lean
+++ b/proofs/Proofs/Hilbert20BoundaryValue.lean
@@ -114,7 +114,7 @@ section WeakFormulation
 variable {V : Type*} [NormedAddCommGroup V] [InnerProductSpace ℝ V] [CompleteSpace V]
 
 /-- A bilinear form on a Hilbert space -/
-def BilinearForm (V : Type*) [NormedAddCommGroup V] [InnerProductSpace ℝ V] :=
+abbrev BilinearForm (V : Type*) [NormedAddCommGroup V] [InnerProductSpace ℝ V] :=
   V →ₗ[ℝ] V →ₗ[ℝ] ℝ
 
 /-- A bilinear form is bounded (continuous) if |a(u,v)| ≤ M‖u‖‖v‖ -/

--- a/proofs/Proofs/Hilbert5LieGroups.lean
+++ b/proofs/Proofs/Hilbert5LieGroups.lean
@@ -95,7 +95,7 @@ A topological group is a group with a topology making multiplication and
 inversion continuous. These are the "continuous symmetries" Hilbert asked about.
 -/
 
-variable {G : Type*} [Group G] [TopologicalSpace G] [TopologicalGroup G]
+variable {G : Type*} [Group G] [TopologicalSpace G] [IsTopologicalGroup G]
 
 /-- A topological group has **no small subgroups** if there exists a neighborhood
     of the identity containing no nontrivial subgroups. This is a key property
@@ -142,7 +142,7 @@ locally compact groups.
     - Deep structure theory of locally compact groups
 
     Proven by Gleason in 1952. -/
-axiom gleason_lemma_1 (G : Type*) [Group G] [TopologicalSpace G] [TopologicalGroup G]
+axiom gleason_lemma_1 (G : Type*) [Group G] [TopologicalSpace G] [IsTopologicalGroup G]
     [LocallyCompactSpace G] (h : HasNoSmallSubgroups G) :
     ∃ U : Set G, IsOpen U ∧ (1 : G) ∈ U ∧
       ∃ (n : ℕ) (φ : U → Fin n → ℝ), Continuous φ ∧ Function.Injective φ
@@ -159,7 +159,7 @@ axiom gleason_lemma_1 (G : Type*) [Group G] [TopologicalSpace G] [TopologicalGro
     careful handling of totally disconnected components.
 
     Proven by Gleason in 1952. -/
-axiom gleason_lemma_2 (G : Type*) [Group G] [TopologicalSpace G] [TopologicalGroup G]
+axiom gleason_lemma_2 (G : Type*) [Group G] [TopologicalSpace G] [IsTopologicalGroup G]
     [LocallyCompactSpace G] [LocallyConnectedSpace G] :
     ∀ U : Set G, IsOpen U → (1 : G) ∈ U →
       ∃ V : Subgroup G, IsOpen (V : Set G) ∧ (V : Set G) ⊆ U
@@ -192,7 +192,7 @@ local diffeomorphism to the Lie algebra (a vector space).
 
     This is a standard result in Lie theory. -/
 theorem lie_group_no_small_subgroups (G : Type*) [Group G] [TopologicalSpace G]
-    [TopologicalGroup G] [LocallyCompactSpace G] :
+    [IsTopologicalGroup G] [LocallyCompactSpace G] :
     -- Placeholder: in a proper formalization, we'd require G to be a Lie group
     -- For now, we state this as a property that Lie groups satisfy
     HasNoSmallSubgroups G → True := fun _ => trivial
@@ -207,7 +207,7 @@ theorem lie_group_no_small_subgroups (G : Type*) [Group G] [TopologicalSpace G]
 
     Proven by Gleason, Montgomery, and Zippin in 1952. -/
 axiom no_small_subgroups_suggests_lie_structure
-    (G : Type*) [Group G] [TopologicalSpace G] [TopologicalGroup G]
+    (G : Type*) [Group G] [TopologicalSpace G] [IsTopologicalGroup G]
     [LocallyCompactSpace G] (h : HasNoSmallSubgroups G) :
     IsLocallyEuclidean G
 
@@ -243,7 +243,7 @@ that locally Euclidean topological groups are exactly the Lie groups.
     - Careful topological arguments
 
     The proof spans over 100 pages in Montgomery-Zippin's book. -/
-axiom montgomery_zippin_theorem (G : Type*) [Group G] [TopologicalSpace G] [TopologicalGroup G]
+axiom montgomery_zippin_theorem (G : Type*) [Group G] [TopologicalSpace G] [IsTopologicalGroup G]
     [LocallyCompactSpace G] [LocallyConnectedSpace G] :
     HasNoSmallSubgroups G ↔ IsLocallyEuclidean G
 
@@ -273,7 +273,7 @@ Before the full solution, von Neumann proved the special case for compact groups
 
     Proven by von Neumann in 1933. -/
 axiom von_neumann_compact_groups (G : Type*) [Group G] [TopologicalSpace G]
-    [TopologicalGroup G] [CompactSpace G] :
+    [IsTopologicalGroup G] [CompactSpace G] :
     -- G admits a Lie group structure compatible with its topology
     ∃ (n : ℕ) (φ : G → Matrix (Fin n) (Fin n) ℝ),
       Continuous φ ∧ Function.Injective φ
@@ -357,7 +357,7 @@ abbrev LieAlgebraOf (G : Type*) [Group G] [TopologicalSpace G] :=
     This connects the infinitesimal structure (Lie algebra) to the
     global structure (Lie group). -/
 theorem one_parameter_subgroups_are_exponentials
-    (G : Type*) [Group G] [TopologicalSpace G] [TopologicalGroup G] :
+    (G : Type*) [Group G] [TopologicalSpace G] [IsTopologicalGroup G] :
     -- In a Lie group, one-parameter subgroups come from exponentials
     True := by trivial
 
@@ -376,7 +376,7 @@ The resolution of Hilbert's 5th problem has profound implications.
     For Lie groups, smooth and real analytic are equivalent. This is
     because the group structure forces analyticity. -/
 theorem lie_group_analytic
-    (G : Type*) [Group G] [TopologicalSpace G] [TopologicalGroup G] :
+    (G : Type*) [Group G] [TopologicalSpace G] [IsTopologicalGroup G] :
     -- Smooth Lie groups are automatically real analytic
     True := by trivial
 
@@ -387,7 +387,7 @@ theorem lie_group_analytic
 theorem automatic_smoothness
     (G H : Type*) [Group G] [Group H]
     [TopologicalSpace G] [TopologicalSpace H]
-    [TopologicalGroup G] [TopologicalGroup H] :
+    [IsTopologicalGroup G] [IsTopologicalGroup H] :
     -- Measurable homomorphisms G → H are smooth
     True := by trivial
 
@@ -398,7 +398,7 @@ theorem automatic_smoothness
 
     This extends Montgomery-Zippin to groups that aren't quite Lie groups. -/
 theorem yamabe_approximation
-    (G : Type*) [Group G] [TopologicalSpace G] [TopologicalGroup G]
+    (G : Type*) [Group G] [TopologicalSpace G] [IsTopologicalGroup G]
     [LocallyCompactSpace G] [ConnectedSpace G] [LocallyConnectedSpace G] :
     -- G is a projective limit of Lie groups
     True := by trivial

--- a/proofs/Proofs/InverseGaloisA5OQ02.lean
+++ b/proofs/Proofs/InverseGaloisA5OQ02.lean
@@ -190,8 +190,7 @@ input `trinks_gal_embeds_simple168` and the cycle-type divisibility
 eliminated: an index-2 subgroup of a simple group cannot exist. -/
 theorem trinks_gal_card : Nat.card trinks.Gal = 168 := by
   obtain ⟨P, instGP, instFP, hsimple, hPcard, φ, hφ⟩ := trinks_gal_embeds_simple168
-  haveI := instGP
-  haveI := instFP
-  exact card_eq_168_of_embeds_in_simple168 hsimple hPcard φ hφ trinks_gal_84_dvd
+  exact @card_eq_168_of_embeds_in_simple168 _ P _ _ instGP instFP hsimple hPcard φ hφ
+    trinks_gal_84_dvd
 
 end InverseGaloisA5OQ02

--- a/proofs/Proofs/LittleWedderburnOQ01OQ02.lean
+++ b/proofs/Proofs/LittleWedderburnOQ01OQ02.lean
@@ -45,7 +45,6 @@ variable (D : Type*) [DivisionRing D] [Finite D]
 
 /-! ## The center is a field -/
 
-omit [Finite D] in
 /-- **The center of a finite division ring is a field.** Mathlib equips the
 center of *any* division ring with a `Field` structure (`Subring.instField`); we
 expose it as the structural predicate `IsField`, which is the input the class

--- a/proofs/Proofs/ZsqrtdNegTwoOQ03.lean
+++ b/proofs/Proofs/ZsqrtdNegTwoOQ03.lean
@@ -433,7 +433,8 @@ noncomputable instance instLT : LT Eisenstein :=
 /-- `Eisenstein = ℤ[ω]` is a Euclidean domain, with Euclidean function
 `(norm ·).natAbs` and division by rounding. -/
 noncomputable instance instEuclideanDomain : EuclideanDomain Eisenstein :=
-  { inferInstanceAs (CommRing Eisenstein) with
+  let _cr : CommRing Eisenstein := inferInstanceAs (CommRing Eisenstein)
+  { _cr with
     quotient := (· / ·)
     remainder := (· % ·)
     quotient_zero := by

--- a/proofs/batch2/STATUS.md
+++ b/proofs/batch2/STATUS.md
@@ -1,5 +1,80 @@
-# Batch 2/3/4/5 + Doctor verification state (updated Doctor increment 19, #38065, 2026-07-13)
+# Batch 2/3/4/5 + Doctor verification state (updated Doctor increment 21, #38065, 2026-07-13)
 
+# DOCTOR INCREMENT 21 (structured remainder: parse/sig/elab/dot + deep-rework, #38065, 2026-07-13)
+
+Container `dr31` (cpus 0-5, 11g, cache v431). Worked the parse/sig/elab/dot structured
+remainder. **+12 GREEN** (all in-container `lake build` exit-0). Ledger at close: 1587.
+
+## Per-class before → after (RESIDUAL)
+- parse-error: 48 → 46 (−2: Erdos490Aristotle, Erdos345Problem, FactorRemainderTheorem — but FRT was mis-classified parse; net parse rows −2)
+- signature-drift: 20 → 19 (−1: Hilbert20BoundaryValue)
+- elab-drift: 20 → 14 (−6: ZsqrtdNegTwoOQ03 ×3, LittleWedderburnOQ01OQ02, InverseGaloisA5OQ02, DenumerabilityRationalsOQ01, Hilbert5LieGroups, Erdos79Incomplete01)
+- dot-notation-drift: 5 → 5 (0 — Erdos807/910 are modeling defects / instance-diamonds, deferred)
+
+## Waves (all in-container `lake build` exit-0, then ledger-flipped)
+- **DR31a (+2)**: Erdos490Aristotle (`p | q` ASCII-pipe divides → `p ∣ q`; added `0 < a`
+  hyp to `prime_dvd_of_dvd_mul_lt` (FALSE for a=0); divisibility witnesses `by omega`→
+  `rw+ring`; `eq_one_or_self_of_dvd` direction), Erdos345Problem (docstring before
+  `open Classical in`→reorder; `open scoped Classical` for `Nat.find` DecidablePred;
+  `pow_one m`→`.symm`; `simp … at <axiom>`→materialize via `have h := axiom`).
+- **DR31b (+3)**: ZsqrtdNegTwoOQ03 (+2 dependents OQ03OQ01/OQ03OQ06 share root):
+  `{ inferInstanceAs (CommRing …) with … }`→`let _cr : CommRing … := inferInstanceAs …; { _cr with … }`.
+- **DR31c (+3)**: LittleWedderburnOQ01OQ02 (drop `omit [Finite D] in` — body references it),
+  InverseGaloisA5OQ02 (`haveI := instGP` not defeq to obtained → `@lemma _ P _ _ instGP instFP …`),
+  DenumerabilityRationalsOQ01 (pin `(Cardinal.aleph 0 : Cardinal.{0})`).
+- **DR31d (+2)**: Erdos79Incomplete01 (`G.loopless u h`→`G.loopless.irrefl u h` — loopless is
+  now `Std.Irrefl`), Hilbert20BoundaryValue (`def BilinearForm := …`→`abbrev` for `a u v` app).
+- **DR31e (+1)**: FactorRemainderTheorem (`modByMonic_add_div p h`→`… p (X - C a)` — takes divisor).
+- **DR31f (+1)**: Hilbert5LieGroups (`TopologicalGroup`→`IsTopologicalGroup`, all 11 sites).
+
+## Statement repairs
+- **Erdos490Aristotle.prime_dvd_of_dvd_mul_lt**: added `(ha : 0 < a)` — theorem was FALSE
+  for a=0 (`p ∣ 0*q = p∣0` always holds but `p ∣ q` need not). Faithful Euclid form.
+
+## Key recipes (new for rename-map §7t)
+- ASCII `|` for divides is now a parse error in binders/types: `a : … | b`→`a : … ∣ b`.
+- SimpleGraph `.loopless` is a bundled `Std.Irrefl` (not a fn): `G.loopless u h`→`G.loopless.irrefl u h`.
+- Mathlib class rename `TopologicalGroup`→`IsTopologicalGroup` ('invalid binder annotation,
+  type is not a class instance' on every `[TopologicalGroup G]`).
+- `{ inferInstanceAs (P X) with … }` → 'inferInstanceAs failed, expected type contains
+  metavariables': bind `let _i : P X := inferInstanceAs (P X)` first, then `{ _i with … }`.
+- `omit [Cls X] in` before a decl whose body *uses* that instance now errors ('cannot omit
+  referenced section variable'): drop the `omit` line.
+- `haveI := hInst` (from an `obtain`) can create an anonymous instance NOT defeq to the one
+  used to type earlier hyps → apply the lemma with explicit `@lemma … hInst …` instead.
+- docstring `/-- … -/` immediately before `open … in` / `omit … in` now parse-errors
+  ('unexpected token open/omit; expected lemma') — put the `open/omit … in` line FIRST,
+  then the docstring, then the decl. An ORPHAN `/-- … -/` (no following decl) → use `/- … -/`.
+- structure fields separated by `;` on one line no longer parse: one field per line.
+- `simp/rw/rwa … at <axiom-or-projection-term>` no longer allowed ('Unexpected term …;
+  expected single reference to variable') — materialize with `have h := <term>` first.
+- `def Foo := V →ₗ[R] W` used in application position (`f x`) fails ('Function expected')
+  because v4.31 won't unfold a plain `def`; use `abbrev`.
+- `open scoped Classical` at namespace top restores `DecidablePred`/`Nat.find` synthesis
+  when a `Prop`-body predicate lost its decidability instance.
+- Virtiofs truncation FALSE-POSITIVES: apparent `end <NamespaceTruncated>` /
+  `Unknown identifier <name-truncated>` — `docker restart dr31`, re-verify by exit code.
+
+## Flagged deep (left for sibling / dedicated pass)
+- Erdos1006OQ01OQ02: `_root_.GraphOrientation.hasShortcut/isHasse` fix clears the dot-notation
+  cluster (4 errors) BUT residual `k3_not_cover_graph` is a full LT/Preorder instance-DIAMOND
+  (the existential `PartialOrder (Fin 3)` vs default `instLTFin`) threaded through no_chain/cov
+  + 8 rcases branches — reverted. (DecidableEq add on `cover_search_space_bound` was valid.)
+- DeMoivreOQ02OQ02: pervasive v4.31 variable-inclusion cascade — `def P/Q : Prop` reference
+  section `variable {R}[CommRing R](n)` only in their BODY, so R is an unconstrained metavar at
+  every use site (`Q n 0`, …). 12 errors; needs file-wide R-threading rework.
+- CayleyHamiltonOQ01OQ03: `(M ^ m) ⟨i⟩ ⟨j⟩` matrix-power-application precedence (`^ m ⟨…⟩`
+  parses `m ⟨…⟩`) fixed with parens at one site, but 22 residual (9 more `^ m ⟨` + tm/synth).
+- Erdos301Problem: parse (`by … show 0<b by\n have…` line-break) fixed but 4 residual
+  mod_cast/field/omega/rewrite (proof-drift). LawOfCosinesOQ03OQ02: `;`-fields + `rwa … at
+  <projection>` fixed but 7 residual linarith/unknown-const (`Real.cos_injOn_Icc`,
+  `div_left_inj'`). MaschkeTheoremOQ01: docstring/omit fixed but instance-synth cascade.
+  StirlingFormula: orphan `/--`→`/-` fixed but tm/linarith residual.
+- Erdos133 (malformed `[DecidableEq V] →`-in-Prop predicate + trivial), Derangements/DeMoivre
+  removed-helper `altFactTerm`/`derangements_div_factorial`, Erdos153/560 (Sym2.Rel/Quot
+  projection restructure), ErdosKoRado (10+ diverse), Erdos807 (`Finset.univ.sup` modeling defect).
+
+---
 # DOCTOR INCREMENT 19 (structured remainder: parse/sig/elab/dot, #38065, 2026-07-13)
 
 Container `dr29` (cpus 0-5, 11g, cache v431). Worked the parse-error / elab-drift /

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -2108,7 +2108,7 @@ Hilbert23CalculusVariations	GREEN
 Hilbert23CalculusVariationsOQ01	RESIDUAL	unknown-const:Ici_diff_left
 Hilbert3ScissorsCongruence	GREEN	
 Hilbert4Geodesics	RESIDUAL	instance-synth
-Hilbert5LieGroups	RESIDUAL	elab-drift
+Hilbert5LieGroups	GREEN	elab-drift
 Hilbert5OQ02	RESIDUAL	instance-synth
 Hilbert6PhysicsAxioms	RESIDUAL	type-mismatch
 Hilbert9CyclotomicReciprocity	GREEN	

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -1705,7 +1705,7 @@ Erdos796Problem	RESIDUAL	type-mismatch
 Erdos797Problem	GREEN	
 Erdos798Aristotle	RESIDUAL	proof-drift
 Erdos799Problem	GREEN	
-Erdos79Incomplete01	RESIDUAL	signature-drift
+Erdos79Incomplete01	GREEN	signature-drift
 Erdos79Incomplete01OQ01	RESIDUAL	signature-drift
 Erdos79Problem	GREEN	
 Erdos79ProblemAristotle	GREEN	
@@ -2094,7 +2094,7 @@ Hilbert16	RESIDUAL	type-mismatch
 Hilbert17OQ01	GREEN	
 Hilbert17RobinsonRationalSOS	GREEN	
 Hilbert19Regularity	GREEN	
-Hilbert20BoundaryValue	RESIDUAL	signature-drift
+Hilbert20BoundaryValue	GREEN	signature-drift
 Hilbert20LocalSolvability	RESIDUAL	instance-synth
 Hilbert20OQ01OQ03	RESIDUAL	instance-synth
 Hilbert20OQ01OQ03Aristotle	RESIDUAL	type-mismatch

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -514,7 +514,7 @@ DeMoivreOQ02OQ02	RESIDUAL	signature-drift
 DeMoivreOQ03OQ01	GREEN	
 DeMoivreOQ06	GREEN	
 DedekindFrobeniusBridge	RESIDUAL	rewrite-drift
-DenumerabilityRationalsOQ01	RESIDUAL	elab-drift
+DenumerabilityRationalsOQ01	GREEN	elab-drift
 DenumerabilityRationalsOQ02OQ02	RESIDUAL	elab-drift
 DenumerabilityRationalsOQ04	RESIDUAL	unknown-const:Polynomial.setOf_isRoot_finite
 DerangementsConvergence	GREEN	
@@ -2132,7 +2132,7 @@ InverseGaloisA5	GREEN
 InverseGaloisA5Dedekind	GREEN	
 InverseGaloisA5DedekindInstantiation	RESIDUAL	instance-synth
 InverseGaloisA5DedekindMod7	GREEN	
-InverseGaloisA5OQ02	RESIDUAL	elab-drift
+InverseGaloisA5OQ02	GREEN	elab-drift
 InverseGaloisD4	GREEN	
 InverseGaloisD4OQ01	GREEN	
 InverseGaloisD4OQ01External	GREEN	
@@ -2242,7 +2242,7 @@ LeibnizPiOQ03	GREEN
 LiouvilleTheorem	RESIDUAL	instance-synth
 LiouvilleTheoremOQ03	GREEN	
 LiouvilleTheoremOQ04	GREEN	
-LittleWedderburnOQ01OQ02	RESIDUAL	elab-drift
+LittleWedderburnOQ01OQ02	GREEN	elab-drift
 LovaszLocalLemmaOQ01	GREEN	
 LovaszLocalLemmaOQ01StrongInduction	GREEN	
 LovaszLocalLemmaOQ01SymmetricStep	GREEN	

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -2653,7 +2653,7 @@ YangMills2DOQ02	GREEN
 YangMillsMassGap	RESIDUAL	unknown-const:Real.exp_lt_exp_of_lt
 ZsqrtdNegTwo	GREEN	
 ZsqrtdNegTwoOQ01	GREEN	
-ZsqrtdNegTwoOQ03	RESIDUAL	elab-drift
-ZsqrtdNegTwoOQ03OQ01	RESIDUAL	elab-drift
-ZsqrtdNegTwoOQ03OQ06	RESIDUAL	elab-drift
+ZsqrtdNegTwoOQ03	GREEN	elab-drift
+ZsqrtdNegTwoOQ03OQ01	GREEN	elab-drift
+ZsqrtdNegTwoOQ03OQ06	GREEN	elab-drift
 eTranscendental	GREEN	

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -1158,7 +1158,7 @@ Erdos341Problem	RESIDUAL	rewrite-drift
 Erdos342Problem	GREEN	
 Erdos343Problem	GREEN	
 Erdos344Problem	GREEN	
-Erdos345Problem	RESIDUAL	parse-error
+Erdos345Problem	GREEN	parse-error
 Erdos346Problem	RESIDUAL	duplicate-decl
 Erdos347Problem	RESIDUAL	unknown-const:Finset.card_Icc
 Erdos348Problem	RESIDUAL	type-mismatch
@@ -1324,7 +1324,7 @@ Erdos487Problem	RESIDUAL	type-mismatch
 Erdos488Problem	RESIDUAL	type-mismatch
 Erdos489Problem	GREEN	
 Erdos48Problem	GREEN	
-Erdos490Aristotle	RESIDUAL	parse-error
+Erdos490Aristotle	GREEN	parse-error
 Erdos490OQ01	GREEN	
 Erdos490ProblemAristotle	RESIDUAL	unknown-const:Nat.eq_zero_of_mul_eq_zero_left
 Erdos491Problem	RESIDUAL	type-mismatch

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -1959,7 +1959,7 @@ EulerTotientOQ02OQ02OQ01	RESIDUAL	rewrite-drift
 EulerTotientOQ06OQ02	GREEN	
 FactorRemainderNullstellensatzOQ01	RESIDUAL	instance-synth
 FactorRemainderNullstellensatzOQ02	RESIDUAL	unknown-const:card_roots_le_degree
-FactorRemainderTheorem	RESIDUAL	parse-error
+FactorRemainderTheorem	GREEN	parse-error
 FactorRemainderTheoremOQ01OQ01OQ02	RESIDUAL	proof-drift
 FactorRemainderTheoremOQ02	RESIDUAL	proof-drift
 FactorRemainderTheoremOQ03	RESIDUAL	unknown-const:Polynomial.card_roots_le_degree

--- a/research/toolchain-v4.31-rename-map.md
+++ b/research/toolchain-v4.31-rename-map.md
@@ -907,3 +907,36 @@ free-flips. Per-class residual: parse-error 52→49, signature-drift 21→20, el
 **Skipped as deep/multi-class (documented for later pass):** Erdos807 (placeholder `True` conjecture makes the "refutation" vacuously false — pre-existing modeling defect, not a v4.31 drift); Erdos910/910Provable (ambiguous `aleph` + universe metavars + `Continuous.prod_mk` removed); Erdos483 (namespace-wrap CLEARS the `schurNumber` `[_root_.schurNumber, SchursTheorem.schurNumber]` ambiguity — via `import Proofs.SchursTheorem` + `open SchursTheorem` + own root `schurNumber` — but 6+ residual native_decide-synth/tm/omega errors remain); FTCLebesgueOQ04 & PtolemysTheoremOQ01Incomplete01 (imports-after-docstring is a 1-line move, but each has 10+ residual removed-const/rewrite/linarith errors); SchroederBernsteinOQ01 & many category files (`HasForget` removed → `ConcreteCategory C FC` overhaul, 21 sites); Ballot cluster (`condCount`/`Probability.CondCount.lean` removed entirely → conditional-probability reconstruction, #38612 item 1); Derangements/BuffonsNeedle (removed helper lemmas `derangements_div_factorial`, `factorial_cast_pos`); Erdos766 (SimpleGraph.mk now 3-field + `{ f x | x : T // p x }` set-builder-with-predicate parse change + odd `⟨G, hG⟩`-as-Graph constructs).
 
 **Namespace-wrap recipe (reusable):** for a file whose OWN root-level `def foo` now collides (`[_root_.foo, OtherNS.foo]`) because it `open OtherNS` (a `Proofs.*` import that also defines `foo`) — insert `namespace ThisFile` right after the `open` and `end ThisFile` at EOF. Unqualified references then resolve to the current-namespace `foo` (current namespace wins over `open`ed), clearing all the ambiguity errors at once.
+
+---
+
+## §7t Doctor increment 21 recipes (parse/sig/elab/dot structured remainder, #38065, +12 GREEN)
+
+| Symptom | Fix | Examples |
+|---|---|---|
+| binder/type `x : … | y` "unexpected token ':='/'|'" | ASCII `|` is no longer `∣` (divides) in these positions → use `∣` | Erdos490Aristotle |
+| `G.loopless u h` "Function expected at G.loopless (has type Std.Irrefl …Adj)" | `.loopless` is a bundled `Std.Irrefl` now → `G.loopless.irrefl u h` | Erdos79Incomplete01 |
+| `[TopologicalGroup G]` "invalid binder annotation, type is not a class instance" | class renamed → `[IsTopologicalGroup G]` | Hilbert5LieGroups |
+| `{ inferInstanceAs (P X) with … }` "inferInstanceAs failed, expected type contains metavariables" | bind first: `let _i : P X := inferInstanceAs (P X)` then `{ _i with … }` | ZsqrtdNegTwoOQ03 |
+| `omit [Cls X] in` before decl "cannot omit referenced section variable inst✝" | body actually uses the instance → delete the `omit … in` line | LittleWedderburnOQ01OQ02 |
+| `haveI := hInst` after `obtain` "synthesized instance not defeq to inferred (this✝ vs hInst)" | apply the lemma with explicit `@lemma _ … hInst₁ hInst₂ …` (don't re-`haveI`) | InverseGaloisA5OQ02 |
+| docstring `/-- … -/` before `open … in` / `omit … in` "unexpected token open/omit; expected lemma" | put `open/omit … in` FIRST, then docstring, then decl | Erdos345Problem, MaschkeTheoremOQ01 |
+| orphan `/-- … -/` (no following declaration) "unexpected token '/-!'/…; expected lemma" | change `/--` → `/-` (plain comment) | StirlingFormula |
+| structure fields `a : ℝ; b : ℝ; c : ℝ` on one line "unexpected token ';'" | one field per line | LawOfCosinesOQ03OQ02 |
+| `simp/rw/rwa […] at <axiom | t.field | proj>` "Unexpected term …; expected single reference to variable" | materialize first: `have h := <term>; simp […] at h` | Erdos345Problem (axioms), LawOfCosinesOQ03OQ02 (`t.law_sines`) |
+| `def Foo := V →ₗ[R] W` then `f x` "Function expected at f" | v4.31 won't unfold plain `def` in app position → `abbrev Foo := …` | Hilbert20BoundaryValue |
+| `Nat.find`/DecidablePred synthesis fails in theorems using a `Prop`-body predicate | add `open scoped Classical` at namespace top | Erdos345Problem |
+| `Cardinal.aleph 0 < Cardinal.aleph 1` "failed to infer universe levels" | pin `(Cardinal.aleph 0 : Cardinal.{0})` | DenumerabilityRationalsOQ01 |
+| `Polynomial.modByMonic_add_div p hMonic` "Application type mismatch" | now `(p q : R[X])` — pass the DIVISOR poly, not the Monic proof: `modByMonic_add_div p (X - C a)` | FactorRemainderTheorem (same as inc-17 CayleyHamilton) |
+| `pow_one m` where `m = m^1` expected | `(pow_one m).symm` | Erdos345Problem |
+
+**A namespaced `def _root_.T.method` recipe (dot-notation across imports):** when a child file
+inside `namespace Child` defines `def T.method` for a type `T` imported from a parent, dot-notation
+`x.method` (x : T, T at root) now FAILS to find `Child.T.method` — declare it as
+`def _root_.T.method` so it lands in T's own namespace. (Cleared 4 errors in Erdos1006OQ01OQ02;
+that file's residual is a separate LT/Preorder instance-diamond — deferred.)
+
+**Virtiofs truncation FALSE-POSITIVES (re-confirmed):** apparent `Invalid name after 'end':
+Expected X, but found X-truncated` or `Unknown identifier <name>-truncated` at EOF → the mount
+truncated the file mid-read. `docker restart dr31`, rebuild, verify by exit code (hit 4× this
+increment: ZsqrtdNegTwoOQ03, DenumerabilityRationalsOQ01, Erdos79Incomplete01, FactorRemainderTheorem).


### PR DESCRIPTION
Doctor increment 21 of the Lean v4.26→v4.31 migration (epic #37508, issue #38065).
Focus: parse-error / signature-drift / elab-drift / dot-notation-drift structured
remainder + tractable deep-rework attempts. **+12 GREEN** (all in-container `lake build`
exit-0; final 12-file joint rebuild exit 0). 0 regressions.

## Per-class before → after (RESIDUAL)
- parse-error: 48 → 46
- signature-drift: 20 → 19
- elab-drift: 20 → 14
- dot-notation-drift: 5 → 5 (residuals are modeling defects / instance-diamonds)

## Waves (each verified in-container, exit 0)
- **DR31a (+2)**: Erdos490Aristotle (`p | q`→`p ∣ q`; statement repair `0 < a`; witness fixes), Erdos345Problem (docstring/`open Classical in` reorder; `open scoped Classical`; `simp … at <axiom>`→materialize).
- **DR31b (+3)**: ZsqrtdNegTwoOQ03 (+2 shared-root dependents): `{ inferInstanceAs (CommRing …) with … }`→`let _cr := … ; { _cr with … }`.
- **DR31c (+3)**: LittleWedderburnOQ01OQ02 (drop referenced `omit`), InverseGaloisA5OQ02 (explicit `@` instances vs `haveI`), DenumerabilityRationalsOQ01 (pin `Cardinal.{0}`).
- **DR31d (+2)**: Erdos79Incomplete01 (`.loopless`→`.loopless.irrefl`), Hilbert20BoundaryValue (`def`→`abbrev BilinearForm`).
- **DR31e (+1)**: FactorRemainderTheorem (`modByMonic_add_div p h`→`… p (X - C a)`).
- **DR31f (+1)**: Hilbert5LieGroups (`TopologicalGroup`→`IsTopologicalGroup` ×11).

## Statement repairs
- **Erdos490Aristotle.prime_dvd_of_dvd_mul_lt**: added `(ha : 0 < a)` — was FALSE for a=0 (`p ∣ 0*q` always holds but `p ∣ q` need not). Faithful Euclid form, no weakening.

## Deferred deep (documented in STATUS.md / rename-map §7t, left for sibling)
Erdos1006OQ01OQ02 (dot-notation cleared via `_root_.` but residual LT/Preorder instance-diamond),
DeMoivreOQ02OQ02 (pervasive v4.31 variable-inclusion metavar cascade), CayleyHamiltonOQ01OQ03
(`^ m ⟨…⟩` precedence + matrix drift), Erdos301/LawOfCosines/Maschke/Stirling (parse fixed but
tm/synth/linarith residual), Erdos133/153/560/Derangements/ErdosKoRado/Erdos807.

New recipes recorded in `research/toolchain-v4.31-rename-map.md` §7t.

🤖 Generated with [Claude Code](https://claude.com/claude-code)