### PR TITLE
migrate(v4.31): Doctor increment 20 — tm/pd/rewrite + mixed (+26 GREEN)

### DIFF
--- a/proofs/Proofs/AbelRuffiniOQ06OQ01.lean
+++ b/proofs/Proofs/AbelRuffiniOQ06OQ01.lean
@@ -65,10 +65,10 @@ theorem alternatingFinFour_isSolvable : IsSolvable (alternatingGroup (Fin 4)) :=
   -- A₄ / V₄ is abelian because V₄ is the commutator subgroup of A₄.
   have hcomm_le : commutator (alternatingGroup (Fin 4)) ≤ N :=
     le_of_eq (alternatingGroup.kleinFour_eq_commutator hα4).symm
-  have hQcomm : Std.Commutative (· * · : (alternatingGroup (Fin 4) ⧸ N) → _ → _) :=
+  haveI hQcomm : IsMulCommutative (alternatingGroup (Fin 4) ⧸ N) :=
     Subgroup.Normal.quotient_commutative_iff_commutator_le.mpr hcomm_le
   haveI hQsolv : IsSolvable (alternatingGroup (Fin 4) ⧸ N) :=
-    isSolvable_of_comm (fun a b => hQcomm.comm a b)
+    isSolvable_of_comm (fun a b => hQcomm.is_comm.comm a b)
   -- The short exact sequence  1 → V₄ → A₄ → A₄/V₄ → 1.
   exact solvable_of_ker_le_range N.subtype (QuotientGroup.mk' N)
     (le_of_eq (by rw [QuotientGroup.ker_mk', Subgroup.range_subtype]))

--- a/proofs/Proofs/ArsinhLogFormulaOQ01OQ01OQ01OQ01.lean
+++ b/proofs/Proofs/ArsinhLogFormulaOQ01OQ01OQ01OQ01.lean
@@ -80,11 +80,14 @@ theorem hasDerivAt_coshSqAntideriv (x : ℝ) :
       (Real.cosh x * Real.cosh x + Real.sinh x * Real.sinh x) x :=
     (Real.hasDerivAt_sinh x).mul (Real.hasDerivAt_cosh x)
   have hsum := ((hasDerivAt_id x).add hprod).div_const 2
-  convert hsum using 1
   -- value equality: cosh²x = (1 + (cosh·cosh + sinh·sinh))/2
-  rw [← pow_two, ← pow_two]
-  have := Real.cosh_sq x
-  linarith
+  have hval : Real.cosh x ^ 2 = (1 + (Real.cosh x * Real.cosh x + Real.sinh x * Real.sinh x)) / 2 := by
+    nlinarith [Real.cosh_sq x]
+  rw [hval]
+  have hfun : (fun u : ℝ => (u + Real.sinh u * Real.cosh u) / 2)
+      = (fun u : ℝ => (id u + Real.sinh u * Real.cosh u) / 2) := rfl
+  rw [hfun]
+  exact hsum
 
 /-- The `cosh²` integrand is continuous, hence interval-integrable. -/
 theorem continuous_cosh_sq : Continuous (fun x : ℝ => Real.cosh x ^ 2) :=

--- a/proofs/Proofs/BallotProblemOQ02OQ03.lean
+++ b/proofs/Proofs/BallotProblemOQ02OQ03.lean
@@ -106,18 +106,19 @@ theorem arcsineCDF_hasDerivAt {x : ℝ} (hx0 : 0 < x) (hx1 : x < 1) :
   have hfun : arcsineCDF = fun y => (2 / π) * (arcsin ∘ fun y => Real.sqrt y) y := by
     funext y; simp [arcsineCDF, Function.comp]
   rw [hfun]
-  -- Now identify the derivative value with `arcsineDensity x`.
-  convert hscaled using 1
-  -- Goal: arcsineDensity x = (2/π) * ((1/√(1-(√x)^2)) * (1/(2√x)))
+  -- Identify the derivative value with `arcsineDensity x`, then transport `hscaled`.
   have hsq : (Real.sqrt x) ^ 2 = x := Real.sq_sqrt hx0.le
-  rw [hsq]
   have h1x : (0 : ℝ) < 1 - x := by linarith
   have hs1x_pos : (0 : ℝ) < Real.sqrt (1 - x) := Real.sqrt_pos.mpr h1x
   have hpi : (0 : ℝ) < π := Real.pi_pos
   have hprod : Real.sqrt (x * (1 - x)) = Real.sqrt x * Real.sqrt (1 - x) :=
     Real.sqrt_mul hx0.le _
-  rw [arcsineDensity, hprod]
-  field_simp
+  have hval : arcsineDensity x
+      = 2 / π * (1 / Real.sqrt (1 - (Real.sqrt x) ^ 2) * (1 / (2 * Real.sqrt x))) := by
+    rw [hsq, arcsineDensity, hprod]
+    field_simp
+  rw [hval]
+  exact hscaled
 
 /-! ### Continuity and interval integrability of the density -/
 

--- a/proofs/Proofs/BuffonsNeedleOQ01OQ01OQ04OQ01Beta.lean
+++ b/proofs/Proofs/BuffonsNeedleOQ01OQ01OQ04OQ01Beta.lean
@@ -48,9 +48,10 @@ theorem integral_cos_mul_sin_pow (m : ℕ) :
     rw [Nat.add_sub_cancel] at hp
     have hd := hp.div_const ((m : ℝ) + 1)
     have hne : ((m : ℝ) + 1) ≠ 0 := by positivity
-    convert hd using 1
-    push_cast
-    skip
+    have hval : Real.cos θ * Real.sin θ ^ m
+        = (↑(m + 1) : ℝ) * Real.sin θ ^ m * Real.cos θ / ((m : ℝ) + 1) := by
+      push_cast; field_simp
+    rw [hval]; exact hd
   have hcont : Continuous (fun θ : ℝ => Real.cos θ * Real.sin θ ^ m) :=
     Real.continuous_cos.mul (Real.continuous_sin.pow m)
   rw [intervalIntegral.integral_eq_sub_of_hasDerivAt hderiv

--- a/proofs/Proofs/BurnsideCountingOQ03OQ03.lean
+++ b/proofs/Proofs/BurnsideCountingOQ03OQ03.lean
@@ -49,6 +49,7 @@ lemma mem_fixedBy_iff (r : ZMod n) (c : Coloring n k) :
     c ∈ MulAction.fixedBy (Coloring n k) (Multiplicative.ofAdd r) ↔
     IsFixedByRotation r c := by
   simp only [MulAction.mem_fixedBy, IsFixedByRotation]
+  rfl
 
 /-- Cardinality of `fixedBy (Multiplicative.ofAdd r)` equals cardinality of
     `{c | IsFixedByRotation r c}`. -/
@@ -102,8 +103,10 @@ theorem burnside_necklace_count_zmod :
     Fintype.card (MulAction.orbitRel.Quotient (Multiplicative (ZMod n)) (Coloring n k)) * n := by
   -- Rewrite each term via card_fixedBy_eq, then close with burnside_necklace_count.
   -- Note: Multiplicative (ZMod n) = ZMod n by def, so 'exact' unifies the sum domains.
-  refine (Finset.sum_congr rfl fun r _ => (card_fixedBy_eq r).symm).trans ?_
-  exact burnside_necklace_count
+  rw [← burnside_necklace_count (n := n) (k := k),
+    ← Equiv.sum_comp Multiplicative.ofAdd
+      (fun g => Fintype.card (MulAction.fixedBy (Coloring n k) g))]
+  exact Finset.sum_congr rfl fun r _ => (card_fixedBy_eq r).symm
 
 /-! ## Section V: Consequences -/
 

--- a/proofs/Proofs/CayleyHamiltonCyclicVectorAllFieldsOQ03Bridge.lean
+++ b/proofs/Proofs/CayleyHamiltonCyclicVectorAllFieldsOQ03Bridge.lean
@@ -101,7 +101,7 @@ theorem aeval_cyclic_iff_krylov_span_top [FiniteDimensional K V] (T : Module.End
     congr 1
     funext n
     rw [Function.comp_apply, Module.AEval'.X_pow_smul_of, Module.End.smul_def]
-  rw [hset, ← Submodule.map_span, Submodule.map_eq_top_iff]
+  rw [hset, Submodule.span_image_linearEquiv, Submodule.map_eq_top_iff]
 
 /-! ## Recognizing the PID structure theorem -/
 

--- a/proofs/Proofs/Erdos1026OQ05KMonotonic.lean
+++ b/proofs/Proofs/Erdos1026OQ05KMonotonic.lean
@@ -311,6 +311,7 @@ theorem IsKMonotonic.mono {k k' : ℕ} (hk : 0 < k) (hkk' : k ≤ k') {seq : Rea
   -- The clamp sends the slot `⟨j, _⟩ : Fin k'` back to `j`, so its run is `runs j`.
   have hfj : f ⟨j.val, hj'lt⟩ = j := by
     apply Fin.ext; simp only [hf, Fin.val_mk]; omega
+  show ∃ b, (runs (f ⟨j.val, hj'lt⟩)).snd.indices b = sub.indices a
   rw [hfj]
   exact ⟨b, hjb⟩
 

--- a/proofs/Proofs/Erdos1049Aristotle.lean
+++ b/proofs/Proofs/Erdos1049Aristotle.lean
@@ -24,7 +24,7 @@ def tau (n : ℕ) : ℕ := n.divisors.card
 -- as Nat.card_divisors_mul_of_coprime or similar.
 theorem tau_multiplicative (m n : ℕ) (hmn : m.Coprime n) :
     tau (m * n) = tau m * tau n := by
-  simp only [tau, hmn.divisors_mul, Finset.card_product]
+  simp only [tau, hmn.card_divisors_mul]
 
 -- Routine: Geometric series ∑_{m≥1} x^m = x/(1-x) for |x| < 1
 -- Applied to x = 1/t^d where t > 1, d ≥ 1.
@@ -48,9 +48,13 @@ theorem geometric_inverse_pow (t : ℝ) (d : ℕ) (ht : t > 1) (hd : d ≥ 1) :
       (fun m : ℕ => if m = 0 then (0 : ℝ) else r ^ m) := by
     ext m; split_ifs with hm <;> simp
   rw [h_eq] at h_diff
-  -- Show (1-r)⁻¹ - 1 = 1/(t^d - 1)
-  convert h_diff using 1
-  rw [hr_def]; field_simp; ring
+  -- Show 1/(t^d - 1) = (1-r)⁻¹ - 1, then transport `h_diff`.
+  have htd0 : t ^ d ≠ 0 := by positivity
+  have htd1 : t ^ d - 1 ≠ 0 := by
+    have : (1 : ℝ) < t ^ d := htd; linarith
+  have hval : (1 : ℝ) / (t ^ d - 1) = (1 - r)⁻¹ - 1 := by
+    rw [hr_def]; field_simp; ring
+  rw [hval]; exact h_diff
 
 -- Routine: The series ∑ 1/t^n converges for t > 1
 theorem inv_pow_summable (t : ℝ) (ht : t > 1) :

--- a/proofs/Proofs/Erdos1208Problem.lean
+++ b/proofs/Proofs/Erdos1208Problem.lean
@@ -77,8 +77,8 @@ theorem distance_sidon_size_bound {α : Type*} [MetricSpace α]
   -- Suffices: Q.card*(Q.card-1) ≤ 2 * |image of Q×Q|, then omega handles the /2
   suffices h : Q.card * (Q.card - 1) ≤
       2 * ((Q ×ˢ Q).image fun pq => dist pq.1 pq.2).card by omega
-  -- Rewrite LHS as Q.offDiag.card (since card_offDiag gives s.card*(s.card-1))
-  rw [← Finset.offDiag_card]
+  -- Rewrite LHS as Q.offDiag.card (since card_offDiag gives s.card*s.card - s.card)
+  rw [Nat.mul_sub_one, ← Finset.offDiag_card]
   -- Each distance value in the offDiag image appears for at most 2 pairs (a,b) and (b,a)
   have hfiber : ∀ d ∈ Q.offDiag.image (fun pq => dist pq.1 pq.2),
       (Q.offDiag.filter (fun pq => dist pq.1 pq.2 = d)).card ≤ 2 := by

--- a/proofs/Proofs/Erdos25Abel.lean
+++ b/proofs/Proofs/Erdos25Abel.lean
@@ -105,12 +105,13 @@ theorem weightedCount_abel (A : Set ℕ) : ∀ N : ℕ, 1 ≤ N →
       split_ifs with h
       · -- N+1 ∈ A: need c(n)/n + Σ + 1/(n+1) = (c(n)+1)/(n+1) + Σ + c(n)/(n·(n+1))
         field_simp
+        push_cast
         ring
       · -- N+1 ∉ A: need c(n)/n + Σ = c(n)/(n+1) + Σ + c(n)/(n·(n+1))
         -- i.e., c(n)/n = c(n)/(n+1) + c(n)/(n·(n+1))  [partial fractions]
         simp only [add_zero]
-        ring_nf
         field_simp
+        push_cast
         ring
 
 end Erdos25Abel

--- a/proofs/Proofs/Erdos338Aristotle.lean
+++ b/proofs/Proofs/Erdos338Aristotle.lean
@@ -38,7 +38,7 @@ theorem squares_order_four_aristotle : IsBasisOfOrder squares 4 := by
     rcases hx with rfl | rfl | rfl | rfl
     all_goals exact ⟨_, by ring⟩
   · simp [Multiset.card_coe]
-  · simp only [Multiset.coe_sum, List.sum_cons, List.sum_nil, add_zero]
+  · simp only [Multiset.sum_coe, List.sum_cons, List.sum_nil, add_zero]
     linarith
 
 end Erdos338

--- a/proofs/Proofs/Erdos491Problem.lean
+++ b/proofs/Proofs/Erdos491Problem.lean
@@ -136,7 +136,6 @@ theorem non_example_bounded_diff :
   · norm_num
   · intro n
     simp [nonExample]
-    norm_num
 
 /- ## Part VIII: Connection to Prime Factorization
 
@@ -168,8 +167,9 @@ theorem erdos_491_summary :
     -- Erdős's 1946 results are special cases
     (∀ f : ℕ → ℝ, IsAdditive f → DifferencesTendToZero f →
       ∃ c : ℝ, ∀ n : ℕ, n ≥ 1 → f n = c * Real.log n) ∧
-    -- The coefficient c' is unique
-    (∀ f : ℕ → ℝ, ∀ c' c'' : ℝ, IsLogPlusO1 f c' → IsLogPlusO1 f c'' → c' = c'') := by
+    -- The coefficient c' is unique (for additive f)
+    (∀ f : ℕ → ℝ, IsAdditive f → ∀ c' c'' : ℝ,
+      IsLogPlusO1 f c' → IsLogPlusO1 f c'' → c' = c'') := by
   exact ⟨wirsing_theorem, erdos_1946_o1, wirsing_constant_unique⟩
 
 /-- Erdős Problem #491: SOLVED by Wirsing (1970)

--- a/proofs/Proofs/Erdos812Problem.lean
+++ b/proofs/Proofs/Erdos812Problem.lean
@@ -25,6 +25,9 @@ References:
 import Mathlib.Data.Nat.Basic
 import Mathlib.Data.Real.Basic
 import Mathlib.Combinatorics.SimpleGraph.Basic
+import Mathlib.Tactic.NormNum.Basic
+import Mathlib.Tactic.NormNum.DivMod
+import Mathlib.Data.Rat.Cast.Defs
 
 namespace Erdos812
 

--- a/proofs/Proofs/Erdos974Problem.lean
+++ b/proofs/Proofs/Erdos974Problem.lean
@@ -82,13 +82,12 @@ def hasInfinitelyManyZeroTuples {n : ℕ} (z : Configuration n) : Prop :=
 
 /-- A configuration has z₁ = 1. -/
 def hasFirstElementOne {n : ℕ} (z : Configuration n) : Prop :=
-  n > 0 → z ⟨0, by omega⟩ = 1
+  ∀ (h : n > 0), z ⟨0, h⟩ = 1
 
 /-- For the standard roots of unity, z₀ = e(0/n) = 1. -/
 theorem standard_roots_first_is_one (n : ℕ) (hn : n > 0) :
     (standardRootsOfUnity n) ⟨0, hn⟩ = 1 := by
   simp [standardRootsOfUnity, nthRootOfUnity]
-  simp [Complex.exp_zero]
 
 /- ## Part IV: The Main Theorems (Tijdeman 1966)
 -/

--- a/proofs/Proofs/FactorRemainderTheoremOQ02.lean
+++ b/proofs/Proofs/FactorRemainderTheoremOQ02.lean
@@ -55,7 +55,7 @@ If p ∈ ℤ[X] is monic and r ∈ ℚ is a root of p, then r ∈ ℤ.
 This is a direct consequence of the Rational Root Theorem: since the leading
 coefficient is 1, the denominator must divide 1, so r is an integer. -/
 theorem monic_rational_root_is_integer {p : ℤ[X]} (hp : p.Monic) {r : ℚ}
-    (hr : aeval r p = 0) : IsInteger ℤ r :=
+    (hr : aeval r p = 0) : IsLocalization.IsInteger ℤ r :=
   isInteger_of_is_root_of_monic hp hr
 
 /-- For monic polynomials, rational roots are integers that divide the constant term. -/
@@ -69,8 +69,8 @@ theorem monic_root_dvd_constant {p : ℤ[X]} (hp : p.Monic) {r : ℚ}
 f(x) = (x - r) · g(x) over ℚ[X]. -/
 theorem factor_of_rational_root {f : ℤ[X]} {r : ℚ} (hr : aeval r f = 0) :
     (X - C r) ∣ (f.map (algebraMap ℤ ℚ)) := by
-  rw [dvd_iff_isRoot]
-  simp [IsRoot, eval_map, ← aeval_def, hr]
+  rw [dvd_iff_isRoot, IsRoot, eval_map, ← aeval_def]
+  exact hr
 
 /-! ## Contrapositive: Proving Irrationality
 

--- a/proofs/Proofs/GCDAlgorithmOQ01OQ03OQ01.lean
+++ b/proofs/Proofs/GCDAlgorithmOQ01OQ03OQ01.lean
@@ -153,9 +153,9 @@ theorem fib_le_of_euclidSteps (a : ℕ) :
         rw [hr0, euclidSteps_zero_right] at hsteps'
         subst hsteps'
         -- need fib 2 ≤ b and fib 3 ≤ a, i.e. 1 ≤ b and 2 ≤ a
-        refine ⟨by simpa using hb, ?_⟩
-        have : 2 ≤ a := by omega
-        simpa using this
+        refine ⟨by rw [show Nat.fib 2 = 1 from rfl]; omega, ?_⟩
+        rw [show Nat.fib 3 = 2 from rfl]
+        omega
       · -- a % b > 0: apply IH to (b, a % b) with b < a.
         obtain ⟨hr_fib, hb_fib⟩ := ih b hba (a % b) m hrpos hr_lt hsteps'
         -- hr_fib : fib (m+1) ≤ a % b,  hb_fib : fib (m+2) ≤ b

--- a/proofs/Proofs/LagrangeFourSquaresOQ05.lean
+++ b/proofs/Proofs/LagrangeFourSquaresOQ05.lean
@@ -177,7 +177,7 @@ theorem quaternion_normSq_mul (p q : ℍ[ℤ]) :
 theorem euler_via_quaternion (a b c d x y z w : ℤ) :
     (a ^ 2 + b ^ 2 + c ^ 2 + d ^ 2) * (x ^ 2 + y ^ 2 + z ^ 2 + w ^ 2) =
       Quaternion.normSq ((⟨a, b, c, d⟩ : ℍ[ℤ]) * (⟨x, y, z, w⟩ : ℍ[ℤ])) := by
-  rw [quaternion_normSq_mul]
-  simp only [Quaternion.normSq_def']
+  simp only [Quaternion.normSq_def', QuaternionAlgebra.mk_mul_mk]
+  ring
 
 end LagrangeFourSquaresOQ05

--- a/proofs/Proofs/LagrangeTheoremOQ05.lean
+++ b/proofs/Proofs/LagrangeTheoremOQ05.lean
@@ -31,14 +31,15 @@ This is the foundation that makes orbit-stabilizer work. -/
 
 /-- Lagrange's theorem: the order of a subgroup divides the order of the group. -/
 theorem lagrange_divides (H : Subgroup G) [Fintype H] :
-    Fintype.card H ∣ Fintype.card G :=
-  Subgroup.card_subgroup_dvd_card H
+    Fintype.card H ∣ Fintype.card G := by
+  simpa only [Nat.card_eq_fintype_card] using Subgroup.card_subgroup_dvd_card H
 
 /-- Lagrange's theorem: |G| = [G : H] · |H|. -/
 theorem lagrange_index (H : Subgroup G) [Fintype H]
     [Fintype (G ⧸ H)] :
-    Fintype.card G = Fintype.card (G ⧸ H) * Fintype.card H :=
-  (Subgroup.card_eq_card_quotient_mul_card_subgroup H).symm
+    Fintype.card G = Fintype.card (G ⧸ H) * Fintype.card H := by
+  simpa only [Nat.card_eq_fintype_card] using
+    (Subgroup.card_eq_card_quotient_mul_card_subgroup H)
 
 /-! ## Part II: Orbit-Stabilizer Theorem
 

--- a/proofs/Proofs/LawOfCosinesOQ01OQ01OQ01.lean
+++ b/proofs/Proofs/LawOfCosinesOQ01OQ01OQ01.lean
@@ -45,12 +45,12 @@ theorem spherical_law_of_sines_angle_over_side (t : SphericalTriangle)
   -- h2 : sin(a)/sin(A) = sin(c)/sin(C)
   constructor
   · -- A/a = B/b  iff  sin(A)*sin(b) = sin(B)*sin(a)
-    rw [div_eq_div_iff (ne_of_gt hA) (ne_of_gt hB)]
-    rw [div_eq_div_iff (ne_of_gt ha) (ne_of_gt hb)] at h1
+    rw [div_eq_div_iff (ne_of_gt ha) (ne_of_gt hb)]
+    rw [div_eq_div_iff (ne_of_gt hA) (ne_of_gt hB)] at h1
     linear_combination -h1
   · -- A/a = C/c  iff  sin(A)*sin(c) = sin(C)*sin(a)
-    rw [div_eq_div_iff (ne_of_gt hA) (ne_of_gt hC)]
-    rw [div_eq_div_iff (ne_of_gt ha) (ne_of_gt hc)] at h2
+    rw [div_eq_div_iff (ne_of_gt ha) (ne_of_gt hc)]
+    rw [div_eq_div_iff (ne_of_gt hA) (ne_of_gt hC)] at h2
     linear_combination -h2
 
 /-- The B/b = C/c part follows by transitivity. -/

--- a/proofs/Proofs/MaschkeModularCounterexampleOQ01.lean
+++ b/proofs/Proofs/MaschkeModularCounterexampleOQ01.lean
@@ -95,8 +95,13 @@ theorem g_sub_one_pow_card : (g p - 1) ^ p = 0 := by
 theorem g_ne_one : g p ≠ 1 := by
   intro hg
   rw [show g p = MonoidAlgebra.single (Multiplicative.ofAdd (1 : ZMod p)) (1 : ZMod p) from rfl,
-    MonoidAlgebra.one_def, Finsupp.single_eq_single_iff] at hg
-  rcases hg with ⟨ha, -⟩ | ⟨hb, -⟩
+    MonoidAlgebra.one_def] at hg
+  -- v4.31: `MonoidAlgebra.single` no longer syntactically unfolds to `Finsupp.single`,
+  -- so retype the equality at the `Finsupp` level before applying the injectivity lemma.
+  have hg2 : (Finsupp.single (Multiplicative.ofAdd (1 : ZMod p)) (1 : ZMod p)
+      : G p →₀ ZMod p) = Finsupp.single 1 1 := hg
+  rw [Finsupp.single_eq_single_iff] at hg2
+  rcases hg2 with ⟨ha, -⟩ | ⟨hb, -⟩
   · exact one_ne_zero (ofAdd_eq_one.mp ha)
   · exact one_ne_zero hb
 

--- a/proofs/Proofs/MinkowskiFundamentalTheoremOQ02.lean
+++ b/proofs/Proofs/MinkowskiFundamentalTheoremOQ02.lean
@@ -63,7 +63,7 @@ open NumberField
     This is the main consequence of the Minkowski bound argument:
     since every class contains a representative of norm ≤ M(K), and there are
     only finitely many ideals of bounded norm, Cl(K) is finite. -/
-theorem classGroup_finite (K : Type*) [Field K] [NumberField K] :
+noncomputable def classGroup_finite (K : Type*) [Field K] [NumberField K] :
     Fintype (ClassGroup (RingOfIntegers K)) :=
   inferInstance
 
@@ -101,7 +101,9 @@ theorem rat_classNumber_eq_one : classNumber ℚ = 1 :=
 /-- **ℤ is a PID** (corollary):
     The ring of integers ℤ = 𝒪_ℚ is a principal ideal domain.
     This is immediate from class number 1. -/
-theorem rat_integers_isPID : IsPrincipalIdealRing (RingOfIntegers ℚ) := by
+theorem rat_integers_isPID : IsPrincipalIdealRing (RingOfIntegers ℚ) :=
+  IsPrincipalIdealRing.of_surjective (Rat.ringOfIntegersEquiv).symm.toRingHom
+    (Rat.ringOfIntegersEquiv).symm.surjective
 
 end MinkowskiClassNumberBound
 

--- a/proofs/Proofs/PappusTheoremOQ02.lean
+++ b/proofs/Proofs/PappusTheoremOQ02.lean
@@ -405,6 +405,7 @@ example : collinear_K (qvec 1 0 1) (qvec 0 1 1) (qvec 1 1 2) := by
   unfold collinear_K threeVecMat
   simp [Matrix.det_fin_three, Matrix.of_apply, qvec,
         Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.head_cons, Matrix.head_fin_const]
+  ring
 
 -- Pappus conclusion for Configuration 2
 example : collinear_K
@@ -426,6 +427,7 @@ example : collinear_K (qvec 1 2 1) (qvec 2 1 1) (qvec 3 3 2) := by
   unfold collinear_K threeVecMat
   simp [Matrix.det_fin_three, Matrix.of_apply, qvec,
         Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.head_cons, Matrix.head_fin_const]
+  ring
 
 -- Pappus conclusion for Configuration 3
 example : collinear_K

--- a/proofs/Proofs/PentagonalNumberTheoremOQ01.lean
+++ b/proofs/Proofs/PentagonalNumberTheoremOQ01.lean
@@ -478,7 +478,8 @@ theorem genFun_pent_eq_tprod :
     · intro b hb
       simp only [pentChar]
       rw [if_neg (show ¬ (b + 1 = 1) by omega), zero_smul]
-  rw [hsingle]; ring
+  rw [sub_eq_add_neg, ← hsingle]
+  rfl
 
 /-- **Coefficient side of Euler's identity.**  The `n`-th coefficient of the same
 generating function is the signed count of partitions of `n` into distinct parts,

--- a/proofs/Proofs/PythagoreanTriplesOQ02.lean
+++ b/proofs/Proofs/PythagoreanTriplesOQ02.lean
@@ -53,12 +53,12 @@ theorem norm_multiplicative (a₁ b₁ a₂ b₂ : ℤ) :
 /-- The square of a Gaussian integer: (a + bi)² = (a² - b²) + (2ab)i. -/
 theorem gaussSq_formula (a b : ℤ) :
     gaussSq a b = (a ^ 2 - b ^ 2, 2 * a * b) := by
-  simp only [gaussSq, gaussMul]; constructor <;> ring
+  simp only [gaussSq, gaussMul]; refine Prod.ext ?_ ?_ <;> ring
 
 /-- z · conj(z) = N(z): a Gaussian integer times its conjugate equals the norm. -/
 theorem mul_conj_eq_norm (a b : ℤ) :
     gaussMul a b a (-b) = (gaussNorm a b, 0) := by
-  simp only [gaussMul, gaussNorm]; constructor <;> ring
+  simp only [gaussMul, gaussNorm]; refine Prod.ext ?_ ?_ <;> ring
 
 -- ============================================================
 -- Part III: Pythagorean Triples from Gaussian Squaring

--- a/proofs/Proofs/QuadraticReciprocityAlgorithmOQ03M2.lean
+++ b/proofs/Proofs/QuadraticReciprocityAlgorithmOQ03M2.lean
@@ -146,8 +146,17 @@ theorem choose_two_mod_two {n : ℕ} (hn : Odd n) :
 derive it directly from `neg_one_sq : (-1)^2 = 1` (which holds for any
 `[Monoid R] [HasDistribNeg R]`, in particular `ℤˣ`). -/
 theorem neg_one_units_pow_mod_two (n : ℕ) : (-1 : ℤˣ) ^ n = (-1 : ℤˣ) ^ (n % 2) := by
-  nth_rewrite 1 [← Nat.mod_add_div n 2]
-  rw [pow_add, pow_mul, neg_one_sq, one_pow, mul_one]
+  -- v4.31: `rw [pow_add]`/`rw [pow_mul]` no longer unify against the `ℤˣ` `Monoid.npow`
+  -- power (the metavariable elaboration stalls); drive the computation term-mode instead.
+  have h2 : (-1 : ℤˣ) ^ 2 = 1 := by decide
+  have e1 : (-1 : ℤˣ) ^ (2 * (n / 2)) = 1 :=
+    calc (-1 : ℤˣ) ^ (2 * (n / 2)) = ((-1 : ℤˣ) ^ 2) ^ (n / 2) := pow_mul _ _ _
+      _ = (1 : ℤˣ) ^ (n / 2) := congrArg (· ^ (n / 2)) h2
+      _ = 1 := one_pow _
+  calc (-1 : ℤˣ) ^ n = (-1 : ℤˣ) ^ (2 * (n / 2) + n % 2) := by rw [Nat.div_add_mod]
+    _ = (-1 : ℤˣ) ^ (2 * (n / 2)) * (-1 : ℤˣ) ^ (n % 2) := pow_add _ _ _
+    _ = 1 * (-1 : ℤˣ) ^ (n % 2) := by rw [e1]
+    _ = (-1 : ℤˣ) ^ (n % 2) := one_mul _
 
 /-- **Parity reduction** (the verified elementary step of Milestone 2).
 For odd `p, q`, `(-1)^(C(p,2)·C(q,2)) = (-1)^((p-1)/2 · (q-1)/2)`. -/
@@ -257,7 +266,9 @@ theorem sign_gridTranspose_eq_choose (p q : ℕ) :
       rw [(divNat_modNat_fpfe u t).1, (divNat_modNat_fpfe v s).1,
           (divNat_modNat_fpfe v s).2, (divNat_modNat_fpfe u t).2]
   rw [Equiv.Perm.sign_eq_prod_prod_Ioi (gridTranspose p q), Finset.prod_sigma']
-  rw [Finset.prod_ite, Finset.prod_const_one, one_mul, Finset.prod_const, ← hD, hcard]
+  rw [Finset.prod_ite, Finset.prod_const_one, one_mul, Finset.prod_const, ← hD]
+  -- v4.31: `rw [hcard]` leaves the reflexive `(-1)^X = (-1)^X`; close it explicitly.
+  exact congrArg (fun k => (-1 : ℤˣ) ^ k) hcard
 
 /-- **Milestone 2 core lemma.**  For odd `p, q`, the sign of the grid-transpose
 permutation is the quadratic-reciprocity factor `(-1) ^ ((p-1)/2 · (q-1)/2)`.

--- a/proofs/Proofs/ShapleyFolkmanAristotle.lean
+++ b/proofs/Proofs/ShapleyFolkmanAristotle.lean
@@ -54,8 +54,12 @@ theorem not_affineIndependent_of_card_gt [FiniteDimensional ℝ E]
     {f : Fin n → E} :
     ¬AffineIndependent ℝ f := by
   intro haf
-  have hcard := haf.fintype_card_le_finrank_succ
+  have hcard := haf.card_le_finrank_succ
   simp [Fintype.card_fin] at hcard
+  -- v4.31: `card_le_finrank_succ` now bounds by `finrank (vectorSpan …)`, which is
+  -- ≤ `finrank E`; bridge that before omega.
+  have hle : Module.finrank ℝ (vectorSpan ℝ (Set.range f)) ≤ Module.finrank ℝ E :=
+    Submodule.finrank_le _
   omega
 
 /-- The convex hull of the empty set is empty. -/

--- a/proofs/Proofs/SolutionOfCubicOQ03OQ01.lean
+++ b/proofs/Proofs/SolutionOfCubicOQ03OQ01.lean
@@ -51,9 +51,9 @@ theorem discriminant_eq_root_form (p q x₁ x₂ x₃ : R)
   unfold discriminant rootDiscriminant
   -- Substitute p = x₁x₂ + x₁x₃ + x₂x₃ and q = -(x₁x₂x₃)
   -- using x₁ + x₂ + x₃ = 0, then verify by ring
-  rw [← h.sum_products, ← show q = -(x₁ * x₂ * x₃) from by linarith [h.product]]
+  rw [← h.sum_products, show q = -(x₁ * x₂ * x₃) from by linear_combination h.product]
   -- With x₃ = -(x₁ + x₂) from sum_zero:
-  have hx₃ : x₃ = -(x₁ + x₂) := by linarith [h.sum_zero]
+  have hx₃ : x₃ = -(x₁ + x₂) := by linear_combination h.sum_zero
   rw [hx₃]
   ring
 

--- a/proofs/batch2/STATUS.md
+++ b/proofs/batch2/STATUS.md
@@ -1,3 +1,73 @@
+# Batch 2/3/4/5 + Doctor verification state (updated Doctor increment 20, #38065, 2026-07-13)
+
+# DOCTOR INCREMENT 20 (type-mismatch + proof-drift + rewrite-drift + mixed, #38065, 2026-07-13)
+
+Classes worked: type-mismatch + proof-drift + rewrite-drift + unknown-const-mixed.
+Container `dr30` (cpus 6-11, 11g, cache v431-b), worktree doctor-b, branch
+`feature/issue-38065-c`. Fresh single/two-error diags generated in-container off the
+warm cache (369 sorry-free candidates from 469 my-class rows; 100 pre-filtered as
+sorry-holed). **+24 GREEN this increment** (type-mismatch 230→225 −5, proof-drift
+159→148 −11, rewrite-drift 80→70 −10, wait — many flips are mixed-class rows).
+
+## Waves (all in-container `lake build` exit-0 confirmed, then ledger-flipped)
+- **DR30a (+10)** single-error: AbelRuffiniOQ06OQ01, ArsinhLogFormula…OQ01×4-deep,
+  BuffonsNeedle…Beta, BallotProblemOQ02OQ03, SolutionOfCubicOQ03OQ01,
+  LagrangeFourSquaresOQ05, MaschkeModularCounterexampleOQ01,
+  CayleyHamilton…OQ03Bridge, PentagonalNumberTheoremOQ01, Erdos1026OQ05KMonotonic.
+- **DR30b (+5)** two-error: Erdos338Aristotle, LawOfCosinesOQ01OQ01OQ01,
+  Erdos974Problem, ShapleyFolkmanAristotle, PythagoreanTriplesOQ02.
+- **DR30c (+4)**: LagrangeTheoremOQ05, FactorRemainderTheoremOQ02,
+  GCDAlgorithmOQ01OQ03OQ01 (PythagoreanTriplesOQ02 counted DR30b).
+- **DR30d (+3)**: Erdos812Problem, Erdos491Problem (statement repair),
+  Erdos25Abel.
+- **DR30e (+2)**: PappusTheoremOQ02, MinkowskiFundamentalTheoremOQ02.
+- **DR30f (+1)**: BurnsideCountingOQ03OQ03.
+- **DR30g (+1)**: QuadraticReciprocityAlgorithmOQ03M2 (0-axiom verified file saved).
+- **DR30h (+1)**: Erdos1049Aristotle.
+
+## Per-class before → after (RESIDUAL, my classes)
+- type-mismatch: 230 → 225
+- proof-drift: 159 → 148
+- rewrite-drift: 80 → 70
+- (Of 443 remaining my-class RESIDUAL rows, **99 are sorry-holed / un-greenable**.)
+
+## Increment 20 statement repairs (operator policy 2026-07-13)
+| file | declaration | repair |
+|---|---|---|
+| Erdos491Problem | wirsing summary uniqueness clause | added the `IsAdditive f` hypothesis that axiom `wirsing_constant_unique` requires (the claimed uniqueness-without-additivity was stronger than what is proven — intended-true form) |
+| CevasTheoremOQ01OQ03 | `routh_asymmetric_example` | `1/10` → `25/252`: recomputed with the def's true `w₃ = 1-f+f·d` (num 25/576, denom (2/3)(3/4)(7/8)=7/16, ratio 25/252). The `1/10` used the wrong `w₃` spelling. (File later reverted — routh_theorem_std ring identity is deep cross-file rework; the corrected value stands as the finding.) |
+
+## Highest-value new recipes (increment 20 — see rename-map §7s)
+- **`rw [pow_add]`/`rw [pow_mul]` no longer unify against `ℤˣ` (`Units Int`) `Monoid.npow`** — the rewrite metavar elaboration stalls even though the target has `a^(m+n)` and `exact pow_add _ _ _` works TERM-mode. Drive the computation via `calc` + term-mode `pow_add _ _ _` / `pow_mul _ _ _`, and use `congrArg (·^k) h` for the `(-1:ℤˣ)^2 = 1 (by decide)` collapse. (QuadraticReciprocityAlgorithmOQ03M2 — a 0-axiom file worth this effort.)
+- **`convert x using 1` on a `HasDerivAt`/value goal surfaces an instance-congruence goal FIRST** (`instAddCommGroup = …toAddCommGroup`), blocking the value-side `rw`/`nlinarith`. **Value-first pattern**: prove `have hval : <value goal> := by …` then `rw [hval]; exact x` — sidesteps convert entirely. (BallotProblemOQ02OQ03, BuffonsNeedle…Beta, Arsinh…, Erdos1049Aristotle). `using 2` does NOT reliably skip past it.
+- **`Subgroup.card_subgroup_dvd_card` / `card_eq_card_quotient_mul_card_subgroup` now return `Nat.card`** (was `Fintype.card`) → `simpa only [Nat.card_eq_fintype_card] using …` (and drop the now-wrong `.symm`). (LagrangeTheoremOQ05)
+- **`Subgroup.Normal.quotient_commutative_iff_commutator_le` now yields `IsMulCommutative`** (was `Std.Commutative (·*·)`) → `haveI … : IsMulCommutative …`; access the comm proof via `h.is_comm.comm a b` (NOT `h.comm` — `IsMulCommutative.comm` doesn't exist). (AbelRuffiniOQ06OQ01)
+- **`MonoidAlgebra.single` no longer syntactically unfolds to `Finsupp.single`** — `rw [Finsupp.single_eq_single_iff]` fails. Retype the equality at the Finsupp level: `have hg2 : (Finsupp.single a b : …) = Finsupp.single c d := hg` then `rw [Finsupp.single_eq_single_iff] at hg2`. `Multiplicative.ofAdd_eq_one` is bare `ofAdd_eq_one` (`↔ x = 0`). (MaschkeModularCounterexampleOQ01)
+- **`Submodule.map_span` needs a `LinearMap`; for a `LinearEquiv` use `Submodule.span_image_linearEquiv`** (`span R (e '' s) = map e (span R s)`), then `Submodule.map_eq_top_iff`. (CayleyHamilton…OQ03Bridge)
+- **`AffineIndependent.fintype_card_le_finrank_succ` → `card_le_finrank_succ`, now bounded by `finrank (vectorSpan …)`** (not `finrank E`) → bridge `Submodule.finrank_le _` before omega. (ShapleyFolkmanAristotle)
+- **`Multiset.coe_sum` → `Multiset.sum_coe`**; **`Nat.Coprime.divisors_mul` now yields a `Finset.map` form** → use `Nat.Coprime.card_divisors_mul` for the card. (Erdos338Aristotle, Erdos1049Aristotle)
+- **`IsInteger` (bare) → `IsLocalization.IsInteger`** (namespace lost). (FactorRemainderTheoremOQ02)
+- **`div_eq_div_iff` denominator args must match the goal EXACTLY** (v4.31 stricter unify) — a swapped `(ne_of_gt hA)` vs `(ne_of_gt ha)` fails "did not find pattern". (LawOfCosinesOQ01OQ01OQ01)
+- **`Nat.fib k` no longer simp-reduces to a literal** → `rw [show Nat.fib 3 = 2 from rfl]`; `0<b` vs `1≤b` no longer bridged by `simpa` → `omega`. (GCDAlgorithmOQ01OQ03OQ01)
+- **`theorem` on a `Fintype …` (Sort, not Prop) is rejected** → `noncomputable def`. (MinkowskiFundamentalTheoremOQ02 classGroup_finite; also `IsPrincipalIdealRing (𝓞 ℚ)` via `IsPrincipalIdealRing.of_surjective (Rat.ringOfIntegersEquiv).symm.toRingHom …surjective`)
+- **`QuaternionAlgebra.mk_mul_mk` + `Quaternion.normSq_def' + ring`** replaces a `Quaternion.normSq (p*q)` rewrite that no longer type-checks (the `map_mul normSq` rewrite fails on the anonymous-constructor product). (LagrangeFourSquaresOQ05)
+- **narrow-import files lose norm_num's ℚ-division extension** (`(6:ℚ)/2 = 3` leaves `⊢ 6/2=3`) → add `import Mathlib.Tactic.NormNum.DivMod` (+ `Data.Rat.Cast.Defs`). (Erdos812Problem)
+- **`field_simp` no longer self-finishes cast normalization inside a sum** → `field_simp; push_cast; ring`. (Erdos25Abel). And field_simp matches denominators up to SYNTACTIC order — supply commuted `1-e+e*d ≠ 0` haves. (Cevas — deferred)
+- **`det_fin_three` simp leaves a numeric residual `2-1-1=0`** → append `ring`. (PappusTheoremOQ02)
+- **`BurnsideCounting`: `Multiplicative.ofAdd r • c = c ↔ r +ᵥ c = c` closes by `rfl`** (defeq via AddAction→MulAction); ZMod n vs Multiplicative (ZMod n) sum-domain → re-index with `Equiv.sum_comp Multiplicative.ofAdd`.
+- **`rw [pow_add]` picks the wrong occurrence** — confirmed §7l `nth_rewrite`→`conv_lhs` migration.
+
+## Flagged deep-rework (deferred this increment)
+- CevasTheoremOQ01OQ03 (routh_theorem_std ring identity spans imported `routhRatio`
+  def; found + repaired the false `1/10`→`25/252` numeric claim en route).
+- QuadRecip's ℤˣ pow-rewrite is documented above (SAVED).
+- HierholzerAlgorithm (4-error cascade after 2 valid fixes: `Set.mem_coe`,
+  `Finset.card_nbij` sig, simp-no-progress — axiomatized file).
+- Erdos407Problem (PRIMARY error = `Fintype` on a ℕ⁴ set-builder = instance-synth
+  sibling's territory; the `Nat.one_le_mul` rename alone won't flip it).
+- BurnsideCountingOQ03OQ03 SOLVED (was flagged, then closed via Equiv.sum_comp).
+
+---
 # Batch 2/3/4/5 + Doctor verification state (updated Doctor increment 17, #38065, 2026-07-13)
 
 # DOCTOR INCREMENT 17 (structured remainder + deep-rework clusters, #38065, 2026-07-13)

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -1139,7 +1139,7 @@ Erdos334Problem	RESIDUAL	unknown-const:Nat.Prime.dvd_prime_pow
 Erdos336Problem	GREEN	
 Erdos337Aristotle	GREEN	elab-drift
 Erdos337Problem	GREEN	elab-drift
-Erdos338Aristotle	RESIDUAL	proof-drift
+Erdos338Aristotle	GREEN	
 Erdos338Problem	GREEN	
 Erdos339Aristotle	RESIDUAL	instance-synth
 Erdos339Problem	RESIDUAL	instance-synth
@@ -1910,7 +1910,7 @@ Erdos96Problem	GREEN
 Erdos970Problem	GREEN	
 Erdos971Problem	GREEN	
 Erdos973Problem	RESIDUAL	instance-synth
-Erdos974Problem	RESIDUAL	proof-drift
+Erdos974Problem	GREEN	
 Erdos975Problem	GREEN	
 Erdos976Problem	GREEN	
 Erdos977Aristotle	GREEN	
@@ -2206,7 +2206,7 @@ LagrangeTheoremOQ03	GREEN
 LagrangeTheoremOQ03OQ02	GREEN	
 LagrangeTheoremOQ05	RESIDUAL	type-mismatch
 LawOfCosines	GREEN	
-LawOfCosinesOQ01OQ01OQ01	RESIDUAL	rewrite-drift
+LawOfCosinesOQ01OQ01OQ01	GREEN	
 LawOfCosinesOQ01OQ01OQ03	RESIDUAL	type-mismatch
 LawOfCosinesOQ01OQ04	RESIDUAL	type-mismatch
 LawOfCosinesOQ03OQ02	RESIDUAL	parse-error
@@ -2345,7 +2345,7 @@ PythagoreanTheorem	RESIDUAL	type-mismatch
 PythagoreanTheoremOQ01	GREEN	
 PythagoreanTheoremOQ03	GREEN	
 PythagoreanTheoremOQ05	GREEN	
-PythagoreanTriplesOQ02	RESIDUAL	proof-drift
+PythagoreanTriplesOQ02	GREEN	
 PythagoreanTriplesOQ04OQ01OQ01	RESIDUAL	unknown-const:even_zero
 QuadraticReciprocityAlgorithmOQ03	RESIDUAL	rewrite-drift
 QuadraticReciprocityAlgorithmOQ03FieldBridge	RESIDUAL	rewrite-drift
@@ -2422,7 +2422,7 @@ ShannonSourceCodingOQ01	RESIDUAL	unknown-const:InformationTheory.mutualInformati
 ShannonSourceCodingOQ02	RESIDUAL	type-mismatch
 ShannonSourceCodingOQ03	RESIDUAL	unknown-const:Fintype.sum_piFinset_succ
 ShapleyFolkman	GREEN	
-ShapleyFolkmanAristotle	RESIDUAL	proof-drift
+ShapleyFolkmanAristotle	GREEN	
 ShapleyFolkmanOQ01	GREEN	
 ShapleyFolkmanOQ03	GREEN	
 ShapleyFolkmanOQ04	GREEN	

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -2349,7 +2349,7 @@ PythagoreanTriplesOQ02	GREEN
 PythagoreanTriplesOQ04OQ01OQ01	RESIDUAL	unknown-const:even_zero
 QuadraticReciprocityAlgorithmOQ03	RESIDUAL	rewrite-drift
 QuadraticReciprocityAlgorithmOQ03FieldBridge	RESIDUAL	rewrite-drift
-QuadraticReciprocityAlgorithmOQ03M2	RESIDUAL	rewrite-drift
+QuadraticReciprocityAlgorithmOQ03M2	GREEN	
 QuadraticReciprocityAlgorithmOQ03M2Capstone	RESIDUAL	rewrite-drift
 QuadraticReciprocityAlgorithmOQ03Zolotarev	RESIDUAL	rewrite-drift
 QuadraticReciprocityOQ03	RESIDUAL	instance-synth

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -316,7 +316,7 @@ BuffonsNoodleOQ01OQ02	GREEN
 BuffonsNoodleOQ02	GREEN	
 BuffonsNoodleOQ03OQ01	RESIDUAL	rewrite-drift
 BurnsideCountingOQ03Aristotle	GREEN	
-BurnsideCountingOQ03OQ03	RESIDUAL	proof-drift
+BurnsideCountingOQ03OQ03	GREEN	
 CantorDiagonalizationOQ01OQ01	RESIDUAL	unknown-const:Cardinal.aleph_lt.mpr
 CantorDiagonalizationOQ01OQ01OQ02	RESIDUAL	type-mismatch
 CantorDiagonalizationOQ01OQ01OQ02OQ01	GREEN	

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -31,7 +31,7 @@ AbelRuffiniOQ04OQ04	RESIDUAL	unknown-const:cyclotomic_5_has_root_in_splitting_fi
 AbelRuffiniOQ04OQ07OQ02	GREEN	
 AbelRuffiniOQ04OQ09Cyclic	GREEN	
 AbelRuffiniOQ06	GREEN	
-AbelRuffiniOQ06OQ01	RESIDUAL	type-mismatch
+AbelRuffiniOQ06OQ01	GREEN	
 AbelRuffiniOQ06OQ01OQ03	RESIDUAL	dot-notation-drift
 AbelRuffiniOQ07NotSolvable	GREEN	
 AbelRuffiniOQ07Order6	RESIDUAL	rewrite-drift
@@ -148,7 +148,7 @@ ArithmeticSeriesOQ02OQ02OQ03OQ01	GREEN
 ArithmeticSeriesOQ02OQ03	RESIDUAL	unknown-const:Nat.choose_two_middle
 ArithmeticSeriesOQ02OQ04OQ01	GREEN	
 ArsinhLogFormulaOQ01OQ01OQ01	GREEN	
-ArsinhLogFormulaOQ01OQ01OQ01OQ01	RESIDUAL	rewrite-drift
+ArsinhLogFormulaOQ01OQ01OQ01OQ01	GREEN	
 ArsinhLogFormulaOQ01OQ01OQ02	GREEN	
 BallVolumeSurfaceDuality	GREEN	
 BallotProblem	RESIDUAL	signature-drift
@@ -163,7 +163,7 @@ BallotProblemOQ01OQ04Core	GREEN
 BallotProblemOQ01OQ04OQ01	RESIDUAL	proof-drift
 BallotProblemOQ02OQ02	RESIDUAL	signature-drift
 BallotProblemOQ02OQ02OQ05	RESIDUAL	signature-drift
-BallotProblemOQ02OQ03	RESIDUAL	rewrite-drift
+BallotProblemOQ02OQ03	GREEN	
 BallotProblemOQ03	GREEN	
 BallotProblemOQ03OQ01OQ01	RESIDUAL	type-mismatch
 BallotProblemOQ03OQ01OQ01OQ01	RESIDUAL	type-mismatch
@@ -299,7 +299,7 @@ BuffonsNeedleOQ01OQ01OQ01	GREEN
 BuffonsNeedleOQ01OQ01OQ02	GREEN	
 BuffonsNeedleOQ01OQ01OQ04	RESIDUAL	rewrite-drift
 BuffonsNeedleOQ01OQ01OQ04OQ01	RESIDUAL	rewrite-drift
-BuffonsNeedleOQ01OQ01OQ04OQ01Beta	RESIDUAL	proof-drift
+BuffonsNeedleOQ01OQ01OQ04OQ01Beta	GREEN	
 BuffonsNeedleOQ01OQ01OQ04OQ01OQ01OQ01	RESIDUAL	proof-drift
 BuffonsNeedleOQ01OQ01OQ05	GREEN	
 BuffonsNeedleOQ01OQ02	RESIDUAL	unknown-const:pi_gt_3141592
@@ -382,7 +382,7 @@ CayleyHamiltonCyclicVectorAllFieldsOQ02OQ02Masa	GREEN
 CayleyHamiltonCyclicVectorAllFieldsOQ02OQ02Range	GREEN	
 CayleyHamiltonCyclicVectorAllFieldsOQ02OQ02Scalar	GREEN	
 CayleyHamiltonCyclicVectorAllFieldsOQ03	RESIDUAL	unknown-const:Basis
-CayleyHamiltonCyclicVectorAllFieldsOQ03Bridge	RESIDUAL	rewrite-drift
+CayleyHamiltonCyclicVectorAllFieldsOQ03Bridge	GREEN	
 CayleyHamiltonCyclicVectorAllFieldsOQ03Converse	RESIDUAL	unknown-const:Basis
 CayleyHamiltonCyclicVectorAllFieldsOQ03OQ02	RESIDUAL	unknown-const:Basis
 CayleyHamiltonMinpolyOQ01OQ01	GREEN	
@@ -688,7 +688,7 @@ Erdos1023Problem	GREEN
 Erdos1024Problem	GREEN	
 Erdos1025Problem	GREEN	
 Erdos1026OQ05Extremal	RESIDUAL	proof-drift
-Erdos1026OQ05KMonotonic	RESIDUAL	rewrite-drift
+Erdos1026OQ05KMonotonic	GREEN	
 Erdos1026Problem	RESIDUAL	unknown-const:Finset.exists_smaller_set
 Erdos1027OQ01	RESIDUAL	unclassified
 Erdos1027OQ03	GREEN	
@@ -2190,7 +2190,7 @@ LagrangeFourSquaresOQ01OQ03	RESIDUAL	noncomputable
 LagrangeFourSquaresOQ02	RESIDUAL	proof-drift
 LagrangeFourSquaresOQ02OQ02	GREEN	
 LagrangeFourSquaresOQ04	RESIDUAL	proof-drift
-LagrangeFourSquaresOQ05	RESIDUAL	type-mismatch
+LagrangeFourSquaresOQ05	GREEN	
 LagrangeTheorem	GREEN	
 LagrangeTheoremOQ01	RESIDUAL	type-mismatch
 LagrangeTheoremOQ01OQ01	RESIDUAL	rewrite-drift
@@ -2248,7 +2248,7 @@ LovaszLocalLemmaOQ01StrongInduction	GREEN
 LovaszLocalLemmaOQ01SymmetricStep	GREEN	
 MaschkeAugmentationNoSplitOQ010101	RESIDUAL	instance-synth
 MaschkeLocalRingOQ010102	RESIDUAL	instance-synth
-MaschkeModularCounterexampleOQ01	RESIDUAL	rewrite-drift
+MaschkeModularCounterexampleOQ01	GREEN	
 MaschkeTheoremOQ01	RESIDUAL	parse-error
 MathematicalInductionOQ01	RESIDUAL	unknown-const:Ordinal.IsLimit
 MathematicalInductionOQ03	RESIDUAL	type-mismatch
@@ -2303,7 +2303,7 @@ PascalsHexagonOQ02	GREEN
 PascalsHexagonOQ03	GREEN	
 PascalsHexagonOQ03Incomplete01Derangements	GREEN	
 PellEquationOQ01	RESIDUAL	unknown-const:Int.cast_nonneg.mpr
-PentagonalNumberTheoremOQ01	RESIDUAL	rewrite-drift
+PentagonalNumberTheoremOQ01	GREEN	
 PentagonalNumberTheoremOQ01OQ01	RESIDUAL	rewrite-drift
 PentagonalNumberTheoremOQ01OQ02	RESIDUAL	rewrite-drift
 PerfectNumbers	GREEN	
@@ -2428,7 +2428,7 @@ ShapleyFolkmanOQ03	GREEN
 ShapleyFolkmanOQ04	GREEN	
 SkolemNoetherMatrixAut	RESIDUAL	unknown-const:Matrix.isUnit_det_iff_isUnit_mulVecLin
 SkolemNoetherMatrixAutAristotle	RESIDUAL	unknown-const:Matrix.isUnit_det_iff_isUnit_mulVecLin
-SolutionOfCubicOQ03OQ01	RESIDUAL	rewrite-drift
+SolutionOfCubicOQ03OQ01	GREEN	
 SolutionOfCubicOQ03OQ02	GREEN	
 SolutionOfCubicOQ03OQ03	GREEN	
 SolutionOfCubicOQ03OQ05	RESIDUAL	proof-drift

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -726,7 +726,7 @@ Erdos1046Problem	GREEN	elab-drift
 Erdos1048Aristotle	RESIDUAL	unknown-const:Complex.continuous_abs.comp
 Erdos1048Problem	GREEN	
 Erdos1048ProblemAristotle	GREEN	
-Erdos1049Aristotle	RESIDUAL	rewrite-drift
+Erdos1049Aristotle	GREEN	
 Erdos1049Problem	RESIDUAL	type-mismatch
 Erdos104Problem	RESIDUAL	unknown-const:zero_rpow
 Erdos1050Aristotle	GREEN	

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -1051,7 +1051,7 @@ Erdos257Problem	GREEN
 Erdos258OQ01	GREEN	
 Erdos258Problem	GREEN	
 Erdos259Problem	GREEN	
-Erdos25Abel	RESIDUAL	proof-drift
+Erdos25Abel	GREEN	
 Erdos25LogDensity	RESIDUAL	type-mismatch
 Erdos25Problem	RESIDUAL	type-mismatch
 Erdos260Aristotle	RESIDUAL	unknown-const:Real.tendsto_log_nat_atTop
@@ -1327,7 +1327,7 @@ Erdos48Problem	GREEN
 Erdos490Aristotle	RESIDUAL	parse-error
 Erdos490OQ01	GREEN	
 Erdos490ProblemAristotle	RESIDUAL	unknown-const:Nat.eq_zero_of_mul_eq_zero_left
-Erdos491Problem	RESIDUAL	type-mismatch
+Erdos491Problem	GREEN	
 Erdos492Problem	RESIDUAL	unknown-const:Int.frac
 Erdos494Problem	GREEN	
 Erdos495Problem	GREEN	
@@ -1722,7 +1722,7 @@ Erdos809Problem	GREEN
 Erdos80Problem	GREEN	
 Erdos810Problem	GREEN	
 Erdos811Problem	GREEN	
-Erdos812Problem	RESIDUAL	proof-drift
+Erdos812Problem	GREEN	
 Erdos813Problem	RESIDUAL	parse-error
 Erdos814Problem	RESIDUAL	instance-synth
 Erdos816Problem	GREEN	

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -1961,7 +1961,7 @@ FactorRemainderNullstellensatzOQ01	RESIDUAL	instance-synth
 FactorRemainderNullstellensatzOQ02	RESIDUAL	unknown-const:card_roots_le_degree
 FactorRemainderTheorem	RESIDUAL	parse-error
 FactorRemainderTheoremOQ01OQ01OQ02	RESIDUAL	proof-drift
-FactorRemainderTheoremOQ02	RESIDUAL	proof-drift
+FactorRemainderTheoremOQ02	GREEN	
 FactorRemainderTheoremOQ03	RESIDUAL	unknown-const:Polynomial.card_roots_le_degree
 FairGamesTheorem	RESIDUAL	type-mismatch
 FairGamesTheoremOQ02	RESIDUAL	proof-drift
@@ -2036,7 +2036,7 @@ FundamentalTheoremCalculusStokesAristotle	RESIDUAL	unclassified
 FurstenbergCorrespondence	RESIDUAL	type-mismatch
 FurstenbergCorrespondenceOQ01	RESIDUAL	instance-synth
 FurstenbergCorrespondenceOQ02	RESIDUAL	parse-error
-GCDAlgorithmOQ01OQ03OQ01	RESIDUAL	type-mismatch
+GCDAlgorithmOQ01OQ03OQ01	GREEN	
 GCDAlgorithmOQ01OQ03OQ01OQ01	RESIDUAL	type-mismatch
 GcdAlgorithmOQ02	GREEN	
 GcdAlgorithmOQ02OQ01	GREEN	
@@ -2204,7 +2204,7 @@ LagrangeTheoremOQ02OQ02	RESIDUAL	unknown-const:ConjClasses.mem_carrier_iff_isCon
 LagrangeTheoremOQ02OQ02OQ01	RESIDUAL	unknown-const:ConjClasses.mem_carrier_iff_isConj
 LagrangeTheoremOQ03	GREEN	
 LagrangeTheoremOQ03OQ02	GREEN	
-LagrangeTheoremOQ05	RESIDUAL	type-mismatch
+LagrangeTheoremOQ05	GREEN	
 LawOfCosines	GREEN	
 LawOfCosinesOQ01OQ01OQ01	GREEN	
 LawOfCosinesOQ01OQ01OQ03	RESIDUAL	type-mismatch

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -2264,7 +2264,7 @@ MeanValueTheoremOQ02OQ04OQ01	RESIDUAL	type-mismatch
 MeanValueTheoremOQ03	GREEN	
 MeanValueTheoremOQ04	RESIDUAL	type-mismatch
 MeanValueTheoremOQ04OQ03	GREEN	
-MinkowskiFundamentalTheoremOQ02	RESIDUAL	proof-drift
+MinkowskiFundamentalTheoremOQ02	GREEN	
 MinkowskiTheoremOQ02	RESIDUAL	unknown-const:ENNReal.ofReal_lt_ofReal_of_nonneg
 MinkowskiTheoremOQ03	GREEN	
 MinkowskiTheoremOQ04OQ03	GREEN	
@@ -2291,7 +2291,7 @@ PACLearning	GREEN
 PNPBarriersLegacy	RESIDUAL	type-mismatch
 PNPBarriersSound	GREEN	
 PNPBarriersUnified	GREEN	
-PappusTheoremOQ02	RESIDUAL	proof-drift
+PappusTheoremOQ02	GREEN	
 PartitionTheorem	RESIDUAL	unknown-const:Theorems100.partition_theorem
 PartitionTheoremOQ01	RESIDUAL	unknown-const:Finset.mem_empty
 PartitionTheoremOQ01OQ01	RESIDUAL	unknown-const:Finset.mem_empty

--- a/research/toolchain-v4.31-rename-map.md
+++ b/research/toolchain-v4.31-rename-map.md
@@ -875,3 +875,29 @@ CLEARED; GeneralizeProofs vendored-block 1/3; SimpleGraph-field cluster 3/6 + Ro
 | `Nat.find ⟨…⟩` "expected type could not be determined" | give the predicate explicitly `Nat.find (p := fun m => …)` + `haveI : DecidablePred _ := Classical.decPred _` + a full-arity witness | Erdos91 |
 | `∆` symmDiff "expected token" | `open scoped symmDiff` (notation is `scoped[symmDiff]`) — but this only fixes the parse; a Setoid built on it may then hit `symmDiff_comm` rename + real transitivity obligations | Erdos1123 (reverted — transitivity is a real theorem) |
 | Mathlib now defines root-level `Hypergraph` (`Mathlib.Combinatorics.Hypergraph.Basic`) → "already been declared" | namespace-wrap the project file's own declarations | Erdos1020 (namespace fix ready but 10+ deeper errors — reverted) |
+
+### §7s Doctor increment 20 recipes (tm/pd/rewrite + mixed, 2026-07-13)
+
+| symptom | fix | files |
+|---|---|---|
+| `rw [pow_add]` / `rw [pow_mul]` fail to unify against `ℤˣ` (`Units Int`) `Monoid.npow` (rewrite metavar stalls, though `exact pow_add _ _ _` works term-mode) | drive via `calc` + TERM-mode `pow_add _ _ _`/`pow_mul _ _ _`; `congrArg (·^k) h` for `(-1:ℤˣ)^2=1 (by decide)` | QuadraticReciprocityAlgorithmOQ03M2 |
+| `convert x using 1` on a value/HasDerivAt goal surfaces an instance-congruence goal FIRST (`instAddCommGroup = …toAddCommGroup`), blocking the value `rw`/`nlinarith` | value-first: `have hval : <goal> := by …; rw [hval]; exact x` (sidestep convert; `using 2` does NOT reliably skip it) | BallotProblemOQ02OQ03, BuffonsNeedleOQ01OQ01OQ04OQ01Beta, ArsinhLogFormula…, Erdos1049Aristotle |
+| `Subgroup.card_subgroup_dvd_card` / `card_eq_card_quotient_mul_card_subgroup` return `Nat.card` (was `Fintype.card`) | `simpa only [Nat.card_eq_fintype_card] using …` + drop the now-wrong `.symm` | LagrangeTheoremOQ05 |
+| `Subgroup.Normal.quotient_commutative_iff_commutator_le` yields `IsMulCommutative` (was `Std.Commutative (·*·)`) | `haveI : IsMulCommutative …`; comm proof via `h.is_comm.comm a b` (NOT `h.comm`) | AbelRuffiniOQ06OQ01 |
+| `MonoidAlgebra.single` no longer unfolds to `Finsupp.single` → `rw [Finsupp.single_eq_single_iff]` fails | retype: `have hg2 : (Finsupp.single a b : …) = Finsupp.single c d := hg; rw [Finsupp.single_eq_single_iff] at hg2`; `Multiplicative.ofAdd_eq_one` is bare `ofAdd_eq_one` (`↔ x=0`) | MaschkeModularCounterexampleOQ01 |
+| `Submodule.map_span` needs a `LinearMap`; a `LinearEquiv` coercion doesn't match | `Submodule.span_image_linearEquiv` then `Submodule.map_eq_top_iff` | CayleyHamiltonCyclicVectorAllFieldsOQ03Bridge |
+| `AffineIndependent.fintype_card_le_finrank_succ` → `card_le_finrank_succ`, now over `finrank (vectorSpan …)` not `finrank E` | bridge `Submodule.finrank_le _` before omega | ShapleyFolkmanAristotle |
+| `Multiset.coe_sum` → `Multiset.sum_coe` | rename | Erdos338Aristotle |
+| `Nat.Coprime.divisors_mul` now yields a `Finset.map` form | use `Nat.Coprime.card_divisors_mul` for the card | Erdos1049Aristotle |
+| `IsInteger` (bare) → `IsLocalization.IsInteger` | namespace-qualify | FactorRemainderTheoremOQ02 |
+| `div_eq_div_iff` denominator `ne` args must match the goal EXACTLY (stricter unify) | pass the denominators that actually appear (swapped hA↔ha) | LawOfCosinesOQ01OQ01OQ01 |
+| `Nat.fib k` no longer simp-reduces to a literal; `0<b` ↮ `1≤b` under simpa | `rw [show Nat.fib 3 = 2 from rfl]`; `omega` | GCDAlgorithmOQ01OQ03OQ01 |
+| `theorem` on `Fintype …` (Sort, not Prop) rejected | `noncomputable def`; `IsPrincipalIdealRing (𝓞 ℚ)` via `IsPrincipalIdealRing.of_surjective (Rat.ringOfIntegersEquiv).symm.toRingHom …surjective` | MinkowskiFundamentalTheoremOQ02 |
+| `Quaternion.normSq (p*q)` rewrite (`map_mul normSq`) no longer type-checks on anonymous-constructor product | `simp only [Quaternion.normSq_def', QuaternionAlgebra.mk_mul_mk]; ring` | LagrangeFourSquaresOQ05 |
+| narrow-import file: `(6:ℚ)/2=3` leaves `⊢ 6/2=3` (norm_num ℚ-division extension not imported) | `import Mathlib.Tactic.NormNum.DivMod` (+ `Data.Rat.Cast.Defs`) | Erdos812Problem |
+| `field_simp` no longer self-finishes cast normalization inside a `∑` | `field_simp; push_cast; ring` (both split_ifs branches) | Erdos25Abel |
+| `det_fin_three` simp leaves numeric residual `2-1-1=0` | append `ring` | PappusTheoremOQ02 |
+| AddAction→MulAction: `Multiplicative.ofAdd r • c = c ↔ r +ᵥ c = c` closes by `rfl`; `∑ ZMod n` vs `∑ Multiplicative (ZMod n)` domain | `rfl`; re-index via `Equiv.sum_comp Multiplicative.ofAdd` | BurnsideCountingOQ03OQ03 |
+| `field_simp` matches denominators up to SYNTACTIC order only | supply commuted `1-e+e*d ≠ 0` haves via `rw [mul_comm]; exact …` | CevasTheoremOQ01OQ03 (denominators fixed; ring identity deferred) |
+
+**Meta**: single/two-own-error triage off the warm cache is the fast finder — build all sorry-free my-class candidates in ONE `lake build`, `grep -oE '^error: Proofs/…\.lean' | uniq -c | sort -n`; single-error rows are highest-confidence. Files with `grep -w sorry` are formalized and CANNOT go GREEN (pre-filter them: 100 of 469 my-class rows). Statement-repair a genuinely false numeric claim to the intended-true value (Cevas `1/10`→`25/252`), never weaken.


### PR DESCRIPTION
## Doctor increment 20 (issue #38065, epic #37508)

Type-mismatch + proof-drift + rewrite-drift + unknown-const-mixed pass. All flips
verified in-container (`dr30`, cpus 6-11, cache `v431-b`) by `lake build` exit 0,
then ledger-flipped in `proofs/batch2/verify-results.tsv`.

**+26 GREEN** (26 distinct files, verified vs fork point 8426f92722).

### Per-class before → after (RESIDUAL)
| class | before | after |
|---|---|---|
| type-mismatch | 230 | 225 |
| proof-drift | 159 | 148 |
| rewrite-drift | 80 | 70 |

Of the 443 remaining my-class RESIDUAL rows, **99 are sorry-holed (un-greenable)**.

### Waves
- **DR30a (+10)** single-error: AbelRuffiniOQ06OQ01, ArsinhLogFormula…, BuffonsNeedle…Beta, BallotProblemOQ02OQ03, SolutionOfCubicOQ03OQ01, LagrangeFourSquaresOQ05, MaschkeModularCounterexampleOQ01, CayleyHamilton…OQ03Bridge, PentagonalNumberTheoremOQ01, Erdos1026OQ05KMonotonic.
- **DR30b–e (+14)** two-error: Erdos338Aristotle, LawOfCosinesOQ01OQ01OQ01, Erdos974Problem, ShapleyFolkmanAristotle, PythagoreanTriplesOQ02, LagrangeTheoremOQ05, FactorRemainderTheoremOQ02, GCDAlgorithmOQ01OQ03OQ01, Erdos812Problem, Erdos491Problem, Erdos25Abel, PappusTheoremOQ02, MinkowskiFundamentalTheoremOQ02.
- **DR30f–h (+3)**: BurnsideCountingOQ03OQ03, QuadraticReciprocityAlgorithmOQ03M2 (0-axiom verified file saved), Erdos1049Aristotle.

### Statement repairs (operator policy)
- **Erdos491Problem** — added the `IsAdditive f` hypothesis to the uniqueness summary clause (axiom `wirsing_constant_unique` requires it; the claimed uniqueness-without-additivity was stronger than what is proven).
- **CevasTheoremOQ01OQ03** — found the false `routhRatio (1/2)(1/3)(1/4) = 1/10` (true value `25/252`; the `1/10` used the wrong `w₃` spelling). File later reverted (`routh_theorem_std` ring identity is deep cross-file rework) but the corrected value stands.

### Highest-value new recipes (rename-map §7s)
- `rw [pow_add]`/`rw [pow_mul]` no longer unify against `ℤˣ` `Monoid.npow` (rewrite stalls; `exact pow_add _ _ _` works term-mode) → calc + term-mode.
- `convert … using 1` on a value goal surfaces an instance-congruence goal FIRST → value-first `have hval … ; rw [hval]; exact x`.
- `Subgroup.card_subgroup_dvd_card`/`…quotient_mul…` now return `Nat.card`; `quotient_commutative_iff_commutator_le` → `IsMulCommutative` (`.is_comm.comm`); `MonoidAlgebra.single` no longer unfolds to `Finsupp.single`; `Submodule.map_span` → `span_image_linearEquiv` for a LinearEquiv; `AffineIndependent.card_le_finrank_succ` over `vectorSpan`; `Multiset.coe_sum`→`sum_coe`; `IsInteger`→`IsLocalization.IsInteger`; `theorem` on `Fintype …`→`noncomputable def`; narrow-import norm_num ℚ-division loss.

Full detail in `proofs/batch2/STATUS.md` (increment 20) and rename-map §7s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)