### PR TITLE
fix(migration): restore corrupted verify-results.tsv ledger (1619 GREEN)

### DIFF
--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -1,1 +1,2659 @@
-
+AMGMInequality	GREEN	
+AMGMOperatorMeans	GREEN	
+AbelRuffini	GREEN	
+AbelRuffiniGaloisExtensions	GREEN	
+AbelRuffiniGaloisExtensionsOQ01	GREEN	
+AbelRuffiniGaloisExtensionsOQ02	GREEN	
+AbelRuffiniGaloisExtensionsOQ02OQ01	GREEN	
+AbelRuffiniGaloisExtensionsOQ03	GREEN	
+AbelRuffiniGaloisExtensionsOQ03OQ01	GREEN	
+AbelRuffiniGaloisExtensionsOQ04	RESIDUAL	type-mismatch
+AbelRuffiniGaloisExtensionsOQ04OQ03	RESIDUAL	rewrite-drift
+AbelRuffiniGaloisExtensionsOQ05	GREEN	
+AbelRuffiniGaloisExtensionsOQ05OQ01	GREEN	
+AbelRuffiniGaloisExtensionsOQ06	GREEN	
+AbelRuffiniGaloisExtensionsOQ06GaloisDirection	GREEN	
+AbelRuffiniGaloisExtensionsOQ06GaloisDirectionAssembly	RESIDUAL	type-mismatch
+AbelRuffiniGaloisExtensionsOQ06GaloisDirectionMainAssembly	GREEN	
+AbelRuffiniGaloisExtensionsOQ06GaloisDirectionStep4	GREEN	
+AbelRuffiniGaloisExtensionsOQ10	GREEN	
+AbelRuffiniOQ03	GREEN	
+AbelRuffiniOQ04	GREEN	
+AbelRuffiniOQ04OQ01	GREEN	
+AbelRuffiniOQ04OQ01OQ03	RESIDUAL	rewrite-drift
+AbelRuffiniOQ04OQ01OQ03Sharp	RESIDUAL	rewrite-drift
+AbelRuffiniOQ04OQ01OQ03Sharpness	GREEN	
+AbelRuffiniOQ04OQ02	GREEN	
+AbelRuffiniOQ04OQ02OQ01	GREEN	
+AbelRuffiniOQ04OQ02OQ02OQ06	GREEN	
+AbelRuffiniOQ04OQ03	GREEN	
+AbelRuffiniOQ04OQ04	RESIDUAL	unknown-const:cyclotomic_5_has_root_in_splitting_field
+AbelRuffiniOQ04OQ07OQ02	GREEN	
+AbelRuffiniOQ04OQ09Cyclic	GREEN	
+AbelRuffiniOQ06	GREEN	
+AbelRuffiniOQ06OQ01	GREEN	
+AbelRuffiniOQ06OQ01OQ03	GREEN	
+AbelRuffiniOQ07NotSolvable	GREEN	
+AbelRuffiniOQ07Order6	RESIDUAL	rewrite-drift
+AbelRuffiniOQ09	GREEN	
+AbelRuffiniOQ10	RESIDUAL	noncomputable
+AbelRuffiniOQ11	GREEN	
+AbelRuffiniObstructionOQ06	GREEN	
+AbundantNumberOQ0102	GREEN	
+AlgebraicNumbersCountableOQ01OQ01	GREEN	
+AlgebraicNumbersCountableOQ01OQ01OQ01	RESIDUAL	instance-synth
+AlgebraicNumbersCountableOQ01OQ03	RESIDUAL	instance-synth
+AlgebraicNumbersCountableOQ02	GREEN	
+AlgebraicNumbersCountableOQ02OQ02	RESIDUAL	proof-drift
+AlgebraicNumbersCountableOQ02OQ02OQ01	RESIDUAL	proof-drift
+AlgebraicNumbersCountableOQ02OQ03	GREEN	
+AlgebraicNumbersCountableOQ02OQ04	GREEN	
+AlgebraicNumbersCountableOQ02OQ04OQ01	GREEN	
+AlgebraicNumbersCountableOQ04	RESIDUAL	type-mismatch
+AlgebraicPointsNull	GREEN	
+AlgebraicRealsNull	GREEN	
+AmgmInequalityOQ02	GREEN	
+AmgmInequalityOQ02Aristotle	GREEN	
+AmgmInequalityOQ02Defs	GREEN	
+AmgmInequalityOQ02OQ01OQ02	GREEN	
+AmgmInequalityOQ02OQ01OQ02OQ01Aristotle	GREEN	
+AmgmInequalityOQ02OQ01OQ02OQ01OQ01OQ01OQ01	GREEN	
+AmgmInequalityOQ02OQ01OQ02OQ01OQ01OQ01OQ01OQ01	GREEN	
+AmgmInequalityOQ02OQ01OQ02OQ01OQ03	RESIDUAL	unknown-const:elemSymm_fin_zero
+AmgmInequalityOQ02OQ02	GREEN	
+AmgmInequalityOQ02OQ02OQ02	GREEN	
+AmgmInequalityOQ02OQ03	GREEN	
+AmgmInequalityOQ02OQ03OQ03	GREEN	
+AmgmInequalityOQ02OQ03OQ03OQ01	GREEN	
+AmgmInequalityOQ02OQ03OQ03OQ02	GREEN	
+AmgmInequalityOQ03OQ02OQ01OQ02	GREEN	
+AmgmInequalityOQ03OQ04	GREEN	
+AmgmInequalityOQ03OQ04OQ02	GREEN	
+AmgmInequalityOQ04OQ02	GREEN	
+AmgmInequalityOQ05OQ01	GREEN	
+AngleTrisection	GREEN	
+AngleTrisectionCos20Gal	GREEN	
+AngleTrisectionCos20GalOQ01	GREEN	
+AngleTrisectionCos20GalOQ01OQ01	GREEN	
+AngleTrisectionCos20GalOQ01OQ02	GREEN	
+AngleTrisectionCos20GalOQ01OQ02OQ02	RESIDUAL	instance-synth
+AngleTrisectionCos20GalOQ03	GREEN	
+AngleTrisectionCos20GalOQ03OQ01	RESIDUAL	type-mismatch
+AngleTrisectionEmbedding	GREEN	
+AngleTrisectionOQ02	GREEN	
+AngleTrisectionOQ02OQ01OQ02	RESIDUAL	rewrite-drift
+AngleTrisectionOQ02OQ01OQ02Aristotle	GREEN	
+AngleTrisectionOQ02OQ01OQ02Incomplete01	RESIDUAL	instance-synth
+AngleTrisectionOQ02OQ03	GREEN	
+AngleTrisectionOQ02OQ03Ext	RESIDUAL	rewrite-drift
+AngleTrisectionOQ02OQ03OQ01	GREEN	
+AngleTrisectionOQ02OQ04	RESIDUAL	unknown-const:Group.IsSolvable
+AngleTrisectionOQ02OQ04OQ01	GREEN	
+AngleTrisectionOQ02OQ04OQ01Aristotle	GREEN	
+AngleTrisectionOQ03	GREEN	
+AngleTrisectionOQ03OQ01	GREEN	
+AngleTrisectionOQ03OQ02	GREEN	
+AngleTrisectionOQ03OQ02OQ03	GREEN	
+AngleTrisectionOQ05OQ02	GREEN	
+AngleTrisectionOQ05OQ03	RESIDUAL	proof-drift
+ArchimedesMethodOfExhaustion	RESIDUAL	instance-synth
+AreaFromCircumferenceIntegral	GREEN	
+AreaOfCircleOQ01OQ02OQ01	GREEN	
+AreaOfCircleOQ01OQ02OQ01OQ01	GREEN	
+AreaOfCircleOQ01OQ02OQ01OQ01OQ01	GREEN	
+AreaOfCircleOQ01OQ02OQ01OQ03	RESIDUAL	unknown-const:pi_lt_3141593
+AreaOfCircleOQ01OQ02OQ02	GREEN	
+AreaOfCircleOQ01OQ02OQ02OQ01OQ01	GREEN	
+AreaOfCircleOQ01OQ02OQ02OQ01OQ01Fourier	RESIDUAL	decide-maxrecdepth
+AreaOfCircleOQ01OQ02OQ02OQ01OQ01IFT	GREEN	
+AreaOfCircleOQ01OQ02OQ02OQ01OQ01Iso	RESIDUAL	type-mismatch
+AreaOfCircleOQ01OQ02OQ02OQ01OQ01OQ01	RESIDUAL	decide-maxrecdepth
+AreaOfCircleOQ01OQ02OQ02OQ01OQ01OQ02	RESIDUAL	type-mismatch
+AreaOfCircleOQ01OQ02OQ02OQ01OQ01Reparam	GREEN	
+AreaOfCircleOQ01OQ02OQ02OQ02	GREEN	
+AreaOfCircleOQ01OQ02OQ02OQ02OQ01	GREEN	
+AreaOfCircleOQ01OQ02OQ02OQ02OQ02	RESIDUAL	unknown-const:wirtinger_inequality
+AreaOfCircleOQ01OQ02OQ03OQ03	RESIDUAL	unknown-const:Filter.eventually_nhdsWithin_of_forall
+AreaOfCircleOQ01OQ03	RESIDUAL	decide-maxrecdepth
+AreaOfCircleOQ01OQ03Aristotle	GREEN	
+AreaOfCircleOQ01OQ03OQ01	RESIDUAL	decide-maxrecdepth
+AreaOfCircleOQ01OQ03OQ02	RESIDUAL	decide-maxrecdepth
+AreaOfCircleOQ02	RESIDUAL	proof-drift
+AreaOfCircleOQ02OQ01	RESIDUAL	proof-drift
+AreaOfCircleOQ02OQ04	GREEN	
+AreaOfCircleOQ03OQ01	GREEN	
+AreaOfCircleOQ03OQ02OQ01	GREEN	
+AreaOfCircleOQ03OQ02OQ02	RESIDUAL	proof-drift
+AreaOfCircleOQ03OQ02OQ02OQ01	RESIDUAL	proof-drift
+AreaOfCircleOQ03OQ03	GREEN	
+AreaOfCircleOQ03OQ03OQ02	GREEN	
+AreaOfCircleOQ05OQ01	RESIDUAL	unknown-const:MeasureTheory.Measure.restrict_prod_eq_prod_restrict
+AreaOfCircleOQ05OQ01Aristotle	GREEN	
+AreaOfCircleOQ05OQ01Incomplete01	RESIDUAL	unknown-const:MeasureTheory.Measure.restrict_prod_eq_prod_restrict
+AreaOfCircleOQ05OQ03OQ05	RESIDUAL	type-mismatch
+AreaOfCircleOQ05OQ04	GREEN	
+AreaOfCircleOQ07OQ02OQ02	GREEN	
+AreaOfCircleOQ07OQ03OQ02	GREEN	
+AreaOfCircleOQ07OQ04OQ01	RESIDUAL	rewrite-drift
+AreaOfCircleOQ07OQ04OQ01OQ01	GREEN	
+AreaOfCircleOQ07OQ05	RESIDUAL	type-mismatch
+AreaOfCircleOQ07OQ05OQ01	RESIDUAL	type-mismatch
+AreaOfCircleOQ07OQ05OQ01OQ01	RESIDUAL	type-mismatch
+AreaOfCircleOQ07OQ05OQ01OQ02	RESIDUAL	type-mismatch
+AreaOfCircleOQ07OQ05OQ02	RESIDUAL	type-mismatch
+ArithmeticSeriesOQ00OQ02	GREEN	
+ArithmeticSeriesOQ00OQ02OQ01	RESIDUAL	instance-synth
+ArithmeticSeriesOQ02OQ02OQ03	RESIDUAL	unknown-const:Finset.Nat.antidiagonal
+ArithmeticSeriesOQ02OQ02OQ03OQ01	GREEN	
+ArithmeticSeriesOQ02OQ03	RESIDUAL	unknown-const:Nat.choose_two_middle
+ArithmeticSeriesOQ02OQ04OQ01	GREEN	
+ArsinhLogFormulaOQ01OQ01OQ01	GREEN	
+ArsinhLogFormulaOQ01OQ01OQ01OQ01	GREEN	
+ArsinhLogFormulaOQ01OQ01OQ02	GREEN	
+BallVolumeSurfaceDuality	GREEN	
+BallotProblem	RESIDUAL	signature-drift
+BallotProblemOQ01OQ02OQ01	RESIDUAL	unknown-const:Set.ncard_biUnion
+BallotProblemOQ01OQ02OQ01Aristotle	RESIDUAL	unknown-const:Set.ncard_biUnion
+BallotProblemOQ01OQ02OQ01OQ01	RESIDUAL	unknown-const:Set.ncard_biUnion
+BallotProblemOQ01OQ02OQ01OQ02	RESIDUAL	unknown-const:Set.ncard_biUnion
+BallotProblemOQ01OQ02OQ01OQ02OQ01	RESIDUAL	unknown-const:Set.ncard_biUnion
+BallotProblemOQ01OQ02OQ04	RESIDUAL	proof-drift
+BallotProblemOQ01OQ04	RESIDUAL	proof-drift
+BallotProblemOQ01OQ04Core	GREEN	
+BallotProblemOQ01OQ04OQ01	RESIDUAL	proof-drift
+BallotProblemOQ02OQ02	RESIDUAL	signature-drift
+BallotProblemOQ02OQ02OQ05	RESIDUAL	signature-drift
+BallotProblemOQ02OQ03	GREEN	
+BallotProblemOQ03	GREEN	
+BallotProblemOQ03OQ01OQ01	RESIDUAL	type-mismatch
+BallotProblemOQ03OQ01OQ01OQ01	RESIDUAL	type-mismatch
+BallotProblemOQ03OQ01OQ01OQ01Aristotle	RESIDUAL	type-mismatch
+BallotProblemOQ03OQ01OQ02	RESIDUAL	type-mismatch
+BallotProblemOQ03OQ01OQ02Aristotle	RESIDUAL	type-mismatch
+BallotProblemOQ03OQ01OQ02Helpers	RESIDUAL	type-mismatch
+BallotProblemOQ03OQ02	RESIDUAL	type-mismatch
+BallotProblemOQ03OQ02OQ01	RESIDUAL	proof-drift
+BallotProblemOQ03OQ02OQ03	RESIDUAL	proof-drift
+BallotProblemOQ03OQ03	RESIDUAL	unknown-const:Nat.one_le_succ
+BallotProblemOQ04OQ02	GREEN	
+BallotProblemOQ04OQ02OQ01	GREEN	
+BaselProblemOQ01OQ01	RESIDUAL	instance-synth
+BaselProblemOQ01OQ01OQ02	GREEN	
+BaselProblemOQ01OQ01OQ02Aristotle	GREEN	
+BaselProblemOQ01OQ01OQ02OQ03	GREEN	
+BaselProblemOQ01OQ02	GREEN	
+BaselProblemOQ02	GREEN	
+BaselProblemOQ02Aristotle	GREEN	
+BaselProblemOQ03OQ01	GREEN	
+BaselProblemOQ04OQ03	RESIDUAL	type-mismatch
+BaselProblemOQ05	GREEN	
+BaselProblemOQ09	GREEN	
+BaselProblemOQ0901	GREEN	
+BaselProblemOQ09OQ01	GREEN	
+BaselProblemOQ10OQ01	GREEN	
+BaselProblemOQ10OQ03	GREEN	
+BaselProblemOQ11	GREEN	
+BaselProblemOQ13	GREEN	
+BaselProblemOQ13OQ01	GREEN	
+BaselProblemOQ13OQ02	GREEN	
+BaselProblemOQ14	GREEN	
+BernoulliInequalityOQ01OQ02	RESIDUAL	proof-drift
+BernoulliInequalityOQ01OQ02OQ01	GREEN	
+BertrandsPostulateOQ03	GREEN	
+BertrandsPostulateOQ03OQ04	GREEN	
+BertrandsPostulateOQ03OQ04Aristotle	GREEN	
+BertrandsPostulateOQ03OQ04OQ01	RESIDUAL	proof-drift
+BertrandsPostulateOQ03OQ04OQ03	GREEN	
+BetaCentralBinomialExplicitRate	GREEN	
+BetaCentralBinomialExplicitRateOQ02	RESIDUAL	type-mismatch
+BetaCentralBinomialOGF	GREEN	
+BetaIntegralRecurrenceOQ01OQ03OQ01	GREEN	
+BetaIntegralRecurrenceOQ01OQ03OQ01OQ02	GREEN	
+BezoutIdentity	GREEN	
+BezoutIdentityOQ01OQ02OQ02Descent	RESIDUAL	unknown-const:det_headBlockN
+BezoutIdentityOQ01OQ02OQ02Transitive	RESIDUAL	unknown-const:det_headBlockN
+BezoutIdentityOQ02OQ01OQ01OQ01OQ01	RESIDUAL	type-mismatch
+BezoutIdentityOQ02OQ01OQ02	GREEN	
+BezoutIdentityOQ02OQ01OQ02OQ02OQ03	RESIDUAL	parse-error
+BezoutIdentityOQ02OQ01OQ02OQ03	RESIDUAL	type-mismatch
+BezoutIdentityOQ02OQ02	RESIDUAL	unknown-const:euclids_lemma_irreducible
+BezoutIdentityOQ02OQ02OQ01OQ03	GREEN	
+BezoutIdentityOQ02OQ04	RESIDUAL	instance-synth
+BezoutIdentityOQ03OQ01OQ01OQ02OQ02	GREEN	
+BezoutIdentityOQ03OQ02OQ01	GREEN	
+BezoutIdentityOQ03OQ03	RESIDUAL	unknown-const:Int.coe_nat_dvd.mpr
+BezoutIdentityOQ03OQ04	RESIDUAL	unknown-const:Int.Coprime.mul_dvd_of_dvd_of_dvd
+BezoutIdentityOQ04OQ01	RESIDUAL	rewrite-drift
+BezoutIdentityOQ04OQ01OQ01	RESIDUAL	type-mismatch
+BinaryGcdOQ02	GREEN	
+BinaryGcdOQ02OQ01	RESIDUAL	unknown-const:a
+BinomialTheorem	GREEN	
+BinomialTheoremOQ01	RESIDUAL	unknown-const:Polynomial.descPochhammer
+BinomialTheoremOQ02OQ01	RESIDUAL	type-mismatch
+BinomialTheoremOQ02OQ01OQ01OQ02	RESIDUAL	type-mismatch
+BinomialTheoremOQ02OQ01OQ02OQ03	GREEN	
+BinomialTheoremOQ02OQ01OQ03	GREEN	
+BinomialTheoremOQ02OQ01OQ04	GREEN	
+BinomialTheoremOQ02OQ02	RESIDUAL	type-mismatch
+BinomialTheoremOQ02OQ03	RESIDUAL	type-mismatch
+BinomialTheoremOQ02OQ04	RESIDUAL	type-mismatch
+BinomialTheoremOQ02OQ04OQ02	GREEN	
+BinomialTheoremOQ03OQ02OQ03	GREEN	
+BinomialTheoremOQ04	GREEN	
+BirchSwinnertonDyer	GREEN	
+BirchSwinnertonDyerOQ01	GREEN	
+BirchSwinnertonDyerOQ06	GREEN	
+BirchSwinnertonDyerOQ06OQ02	GREEN	
+BirthdayProblem	GREEN	
+BirthdayProblemOQ01	GREEN	
+BirthdayProblemOQ01OQ01	RESIDUAL	parse-error
+BirthdayProblemOQ01OQ01Aristotle	RESIDUAL	parse-error
+BirthdayProblemOQ01OQ01OQ03	RESIDUAL	parse-error
+BirthdayProblemOQ02OQ01	RESIDUAL	unknown-const:Finset.sum_range_id_eq_sum_range_succ_div_two
+BirthdayProblemOQ03OQ01	GREEN	
+BirthdayProblemOQ03OQ01OQ02	GREEN	
+BirthdayProblemOQ03OQ03	RESIDUAL	proof-drift
+BorsukUlamOQ02	RESIDUAL	unknown-const:EuclideanSpace.equiv_symm_pi_lp_apply
+BorsukUlamOQ02OQ01OQ01OQ02	GREEN	
+BorsukUlamOQ02OQ01OQ01OQ02OQ03	RESIDUAL	type-mismatch
+BorsukUlamOQ02OQ01OQ01OQ02OQ03OQ01	RESIDUAL	type-mismatch
+BorsukUlamOQ02OQ01OQ04	GREEN	
+BorsukUlamOQ02OQ01OQ04OQ01	GREEN	
+BorsukUlamOQ02OQ02	RESIDUAL	instance-synth
+BorsukUlamOQ02OQ03	GREEN	
+BorsukUlamOQ03	GREEN	
+BorsukUlamOQ03OQ01	RESIDUAL	rewrite-drift
+BorsukUlamOQ03OQ02	RESIDUAL	type-mismatch
+BorsukUlamOQ03OQ03	GREEN	
+BorsukUlamOQ04OQ03	RESIDUAL	instance-synth
+BoundedPrimeGapsOQ01OQ02	GREEN	
+BoundedPrimeGapsOQ03OQ01	GREEN	
+BoundedPrimeGapsOQ03OQ01OQ01	GREEN	
+BoundedPrimeGapsOQ03OQ01OQ01OQ01	GREEN	
+BoundedPrimeGapsOQ03OQ01OQ04	GREEN	
+BoundedPrimeGapsOQ03OQ02	GREEN	
+BoundedPrimeGapsOQ03OQ03	GREEN	
+BoundedPrimeGapsOQ04	RESIDUAL	lambda-reserved-token
+BoundedPrimeGapsOQ04OQ01	GREEN	
+BoundedPrimeGapsOQ04OQ01Aristotle	RESIDUAL	rewrite-drift
+BoundedPrimeGapsOQ04OQ02	RESIDUAL	lambda-reserved-token
+BrianchonTheorem	GREEN	
+BrianchonTheoremOQ01OQ02	GREEN	
+BrouwerFixedPointOQ01OQ02OQ03OQ01	RESIDUAL	unknown-const:Metric.mem_closedBall_zero_iff.mpr
+BrouwerFixedPointOQ01OQ03	GREEN	
+BrouwerFixedPointOQ01OQ03OQ01	GREEN	
+BrouwerFixedPointOQ01OQ03OQ01OQ01	GREEN	
+BrouwerFixedPointOQ02	RESIDUAL	type-mismatch
+BrouwerFixedPointOQ02OQ01	RESIDUAL	type-mismatch
+BrouwerFixedPointOQ02OQ02	GREEN	
+BrouwerFixedPointOQ02OQ02OQ01	GREEN	
+BrouwerFixedPointOQ02OQ02OQ01Iteration	GREEN	
+BrouwerFixedPointOQ02OQ03	RESIDUAL	type-mismatch
+BrouwerFixedPointOQ04OQ02	GREEN	
+BrouwerFixedPointOQ04OQ03	GREEN	
+BrouwerFixedPointOQ04OQ04	RESIDUAL	type-mismatch
+BuffonConstantAsymptotic	GREEN	
+BuffonsNeedleOQ01	GREEN	
+BuffonsNeedleOQ01OQ01	GREEN	
+BuffonsNeedleOQ01OQ01OQ01	GREEN	
+BuffonsNeedleOQ01OQ01OQ02	GREEN	
+BuffonsNeedleOQ01OQ01OQ04	RESIDUAL	rewrite-drift
+BuffonsNeedleOQ01OQ01OQ04OQ01	RESIDUAL	rewrite-drift
+BuffonsNeedleOQ01OQ01OQ04OQ01Beta	GREEN	
+BuffonsNeedleOQ01OQ01OQ04OQ01OQ01OQ01	RESIDUAL	proof-drift
+BuffonsNeedleOQ01OQ01OQ05	GREEN	
+BuffonsNeedleOQ01OQ02	RESIDUAL	unknown-const:pi_gt_3141592
+BuffonsNeedleOQ01OQ04	GREEN	
+BuffonsNeedleOQ02	GREEN	
+BuffonsNeedleOQ02OQ01	GREEN	
+BuffonsNeedleOQ02OQ01OQ01	GREEN	
+BuffonsNeedleOQ02OQ02	RESIDUAL	signature-drift
+BuffonsNeedleOQ02OQ03	RESIDUAL	proof-drift
+BuffonsNoodle	GREEN	
+BuffonsNoodleOQ01	GREEN	
+BuffonsNoodleOQ01OQ01	GREEN	
+BuffonsNoodleOQ01OQ02	GREEN	
+BuffonsNoodleOQ02	GREEN	
+BuffonsNoodleOQ03OQ01	RESIDUAL	rewrite-drift
+BurnsideCountingOQ03Aristotle	GREEN	
+BurnsideCountingOQ03OQ03	GREEN	
+CantorDiagonalizationOQ01OQ01	RESIDUAL	unknown-const:Cardinal.aleph_lt.mpr
+CantorDiagonalizationOQ01OQ01OQ02	RESIDUAL	type-mismatch
+CantorDiagonalizationOQ01OQ01OQ02OQ01	GREEN	
+CantorDiagonalizationOQ01OQ01OQ02OQ01Phase3b	GREEN	
+CantorDiagonalizationOQ01OQ01OQ02OQ03	RESIDUAL	instance-synth
+CantorDiagonalizationOQ02OQ03	GREEN	
+CantorDiagonalizationOQ03	GREEN	
+CantorDiagonalizationOQ03OQ01Incomplete01	RESIDUAL	type-mismatch
+CantorDiagonalizationOQ04	GREEN	
+CantorDiagonalizationOQ04OQ01	GREEN	
+CantorDiagonalizationOQ04OQ01OQ01	RESIDUAL	instance-synth
+CantorDiagonalizationOQ04OQ01OQ01OQ01	RESIDUAL	instance-synth
+CantorDiagonalizationOQ04OQ03	RESIDUAL	instance-synth
+CantorDiagonalizationOQ04OQ03Aristotle	RESIDUAL	instance-synth
+CantorsTheoremOQ01	GREEN	
+CantorsTheoremOQ01OQ01	GREEN	
+CantorsTheoremOQ01OQ02	GREEN	
+CantorsTheoremOQ01OQ03	GREEN	
+CantorsTheoremOQ01OQ03OQ04	GREEN	
+CatalanNumbersOQ01OQ01OQ02OQ04	GREEN	
+CatalanNumbersOQ01OQ04OQ02	GREEN	
+CatalanNumbersOQ05OQ02OQ01	GREEN	
+CauchyInterlacingIsometryConj	RESIDUAL	unknown-const:List.eq_of_perm_of_sorted
+CauchyInterlacingMajorizationPositivity	GREEN	
+CauchyInterlacingOQ01OQ01OQ01	RESIDUAL	unknown-const:List.eq_of_perm_of_sorted
+CauchyInterlacingOQ01OQ01OQ01OQ01	RESIDUAL	unknown-const:List.eq_of_perm_of_sorted
+CauchyInterlacingPoincareCompression	RESIDUAL	unknown-const:LinearMap.mul_apply
+CauchyInterlacingWeylDual	GREEN	
+CauchySchwarz	RESIDUAL	type-mismatch
+CauchySchwarzIntegralLpDualityGluing	GREEN	
+CauchySchwarzIntegralLpDualityIngredients	GREEN	
+CauchySchwarzIntegralLpDualityMaximal	GREEN	
+CauchySchwarzIntegralLpDualitySynthesis	GREEN	
+CauchySchwarzIntegralOQ01OQ01OQ01OQ02	RESIDUAL	rewrite-drift
+CauchySchwarzIntegralOQ01OQ01OQ01OQ02OQ03	RESIDUAL	proof-drift
+CauchySchwarzIntegralOQ01OQ01OQ02	GREEN	
+CauchySchwarzIntegralOQ01OQ01OQ02OQ01	GREEN	
+CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01	GREEN	
+CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01	GREEN	
+CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01Infra	GREEN	
+CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01Loc	GREEN	
+CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01Norm	GREEN	
+CauchySchwarzIntegralOQ01OQ03	RESIDUAL	instance-synth
+CauchySchwarzIntegralOQ01OQ03OQ01	RESIDUAL	unknown-const:eLpNorm_one_eq_lintegral_nnnorm
+CauchySchwarzIntegralOQ02OQ02	RESIDUAL	unknown-const:eLpNorm_mul_le
+CauchySchwarzIntegralOQ02OQ02OQ01	GREEN	
+CauchySchwarzIntegralOQ03	RESIDUAL	proof-drift
+CauchySchwarzOQ01OQ01OQ01	RESIDUAL	proof-drift
+CauchySchwarzOQ01OQ01OQ02	GREEN	
+CauchySchwarzOQ01OQ01OQ02OQ01	GREEN	
+CauchySchwarzOQ01OQ02	RESIDUAL	instance-synth
+CauchySchwarzOQ01OQ03	RESIDUAL	unknown-const:inner_mul_le_norm_mul_sq
+CauchySchwarzOQ01OQ04	RESIDUAL	instance-synth
+CauchySchwarzOQ02	RESIDUAL	unknown-const:Finset.inner_mul_le_norm_mul_sq
+CauchySchwarzOQ03	GREEN	
+CauchySchwarzOQ03OQ02	GREEN	
+CauchySchwarzOQ03OQ02OQ01	GREEN	
+CauchySchwarzOQ07OQ01	GREEN	
+CayleyHamiltonCyclicVectorAllFieldsOQ01OQ02	RESIDUAL	type-mismatch
+CayleyHamiltonCyclicVectorAllFieldsOQ02OQ01	GREEN	
+CayleyHamiltonCyclicVectorAllFieldsOQ02OQ02	GREEN	
+CayleyHamiltonCyclicVectorAllFieldsOQ02OQ02Masa	GREEN	
+CayleyHamiltonCyclicVectorAllFieldsOQ02OQ02Range	GREEN	
+CayleyHamiltonCyclicVectorAllFieldsOQ02OQ02Scalar	GREEN	
+CayleyHamiltonCyclicVectorAllFieldsOQ03	RESIDUAL	unknown-const:Basis
+CayleyHamiltonCyclicVectorAllFieldsOQ03Bridge	GREEN	
+CayleyHamiltonCyclicVectorAllFieldsOQ03Converse	RESIDUAL	unknown-const:Basis
+CayleyHamiltonCyclicVectorAllFieldsOQ03OQ02	RESIDUAL	unknown-const:Basis
+CayleyHamiltonMinpolyOQ01OQ01	GREEN	
+CayleyHamiltonMinpolyOQ02OQ01OQ02	GREEN	
+CayleyHamiltonMinpolyOQ02OQ02	RESIDUAL	proof-drift
+CayleyHamiltonMinpolyOQ02OQ03	RESIDUAL	unknown-const:Matrix.charpoly_conj_of_isUnit
+CayleyHamiltonMinpolyOQ03OQ01	RESIDUAL	unknown-const:Matrix.mul_mulVec
+CayleyHamiltonMinpolyOQ04Backward	RESIDUAL	type-mismatch
+CayleyHamiltonMinpolyOQ04BackwardAristotle	GREEN	
+CayleyHamiltonMinpolyOQ05	GREEN	
+CayleyHamiltonMinpolyOQ05OQ01OQ01	RESIDUAL	unknown-const:isUnit_of_natDegree_eq_zero
+CayleyHamiltonMinpolyOQ05OQ01OQ02	RESIDUAL	unknown-const:dvd_of_mem_normalizedFactors
+CayleyHamiltonMinpolyOQ05OQ01OQ04WIP01	RESIDUAL	proof-drift
+CayleyHamiltonMinpolyOQ05OQ01OQ04WIP03	GREEN	
+CayleyHamiltonMinpolyOQ05OQ02	RESIDUAL	instance-synth
+CayleyHamiltonMinpolyOQ05OQ02OQ03	RESIDUAL	instance-synth
+CayleyHamiltonOQ01	GREEN	
+CayleyHamiltonOQ01OQ01	GREEN	
+CayleyHamiltonOQ01OQ01OQ01	GREEN	
+CayleyHamiltonOQ01OQ01OQ01OQ01	GREEN	
+CayleyHamiltonOQ01OQ02	GREEN	
+CayleyHamiltonOQ01OQ03	RESIDUAL	parse-error
+CayleyHamiltonOQ02	GREEN	
+CayleyHamiltonOQ02OQ01Analytic	GREEN	
+CayleyHamiltonOQ04OQ02	GREEN	
+CayleyHamiltonReductionOQ01	GREEN	
+CayleyHamiltonReductionOQ01OQ02	RESIDUAL	type-mismatch
+CayleyHamiltonReductionOQ02	GREEN	
+CayleysTheoremOQ01OQ01OQ02OQ02OQ01	GREEN	
+CayleysTheoremOQ01OQ02OQ02	GREEN	
+CentralLimitTheorem	RESIDUAL	unknown-const:tendsto_one_plus_div_pow_exp
+CentralLimitTheoremOQ01OQ01	GREEN	
+CentralLimitTheoremOQ01OQ01OQ04	GREEN	
+CentralLimitTheoremOQ01OQ02OQ01OQ01	RESIDUAL	instance-synth
+CentralLimitTheoremOQ01OQ02OQ01OQ03	GREEN	
+CentralLimitTheoremOQ01OQ03	GREEN	
+CentralLimitTheoremOQ02	GREEN	
+CentralLimitTheoremOQ02Aristotle	GREEN	
+CentralLimitTheoremOQ02OQ02	RESIDUAL	instance-synth
+CentralLimitTheoremOQ02OQ03	GREEN	
+CentralLimitTheoremOQ02OQ04	GREEN	
+CentralLimitTheoremOQ03	GREEN	
+CentralLimitTheoremOQ03OQ01	RESIDUAL	rewrite-drift
+CentralLimitTheoremOQ03OQ01Aristotle	RESIDUAL	rewrite-drift
+CevasTheorem	GREEN	
+CevasTheoremNonEuclidean	GREEN	
+CevasTheoremNonEuclideanOQ01	GREEN	
+CevasTheoremNonEuclideanOQ01OQ01	GREEN	
+CevasTheoremNonEuclideanOQ01OQ02	GREEN	
+CevasTheoremNonEuclideanOQ02	GREEN	
+CevasTheoremNonEuclideanOQ03	GREEN	
+CevasTheoremOQ01OQ03	RESIDUAL	proof-drift
+ChebyshevBoundsOQ03	GREEN	
+ChebyshevBoundsOQ03OQ02	RESIDUAL	type-mismatch
+ChebyshevBoundsOQ04Aristotle	GREEN	
+ChebyshevBoundsOQ0601	GREEN	
+ChebyshevPNTBridgeOQ01	RESIDUAL	partenat-removal
+ChebyshevPNTBridgeOQ04	GREEN	
+ChineseRemainderConstructiveOQ03	RESIDUAL	unknown-const:Nat.Prime.minFac
+ChineseRemainderConstructiveOQ03OQ03	RESIDUAL	unknown-const:Nat.Prime.minFac
+ChineseRemainderConstructiveOQ04OQ03	GREEN	
+ChineseRemainderExplicitOQ04OQ03OQ01	GREEN	
+ChineseRemainderNonCoprimeList	GREEN	
+ChineseRemainderNonCoprimeOQ01	GREEN	
+ChineseRemainderNonCoprimeOQ01OQ01	GREEN	
+ChineseRemainderNonCoprimeOQ02	RESIDUAL	parse-error
+ChineseRemainderNonCoprimeOQ02OQ01	RESIDUAL	instance-synth
+ChineseRemainderNonCoprimeOQ03OQ02	RESIDUAL	type-mismatch
+CircumferenceFromArea	GREEN	
+CircumferenceViaDifferentiationOQ01	GREEN	
+CircumferenceViaDifferentiationOQ02	GREEN	
+CircumferenceViaDifferentiationOQ03	GREEN	
+CollatzCyclesOQ04	GREEN	
+CollatzStructuredOQ02OQ01	GREEN	
+CollatzStructuredOQ03	RESIDUAL	instance-synth
+CombinationsFormulaOQ01OQ04	RESIDUAL	type-mismatch
+CombinationsFormulaOQ02	RESIDUAL	proof-drift
+CombinationsFormulaOQ02Aristotle	RESIDUAL	unknown-const:choose_2n_succ
+CombinationsFormulaOQ03OQ06	GREEN	
+CombinationsFormulaOQ07OQ04OQ01OQ02	GREEN	
+CombinationsFormulaOQ07OQ04OQ01OQ02OQ01	RESIDUAL	unknown-const:lt_or_le
+ComplexityCore	GREEN	
+ConjugacyClassEquationOQ01	GREEN	
+ConjugacyClassEquationOQ0102	GREEN	
+ContinuumHypothesisOQ02	RESIDUAL	unknown-const:Cardinal.cof_aleph
+ContinuumHypothesisOQ02OQ01	RESIDUAL	instance-synth
+CoprimeKTupleDensity	GREEN	
+CramersRule	GREEN	
+CramersRuleOQ01OQ02OQ03	GREEN	
+CramersRuleOQ01OQ03	GREEN	
+CramersRuleOQ01OQ04	RESIDUAL	unknown-const:Matrix.charpoly_natDegree_eq_card
+CramersRuleOQ03OQ03	RESIDUAL	unknown-const:Quaternion.imI
+CramersRuleOQ04OQ01	RESIDUAL	unknown-const:smul_mulVec_assoc
+CramersRuleOQ05	GREEN	
+CramersRuleOQ05OQ01	GREEN	
+CramersRuleOQ05OQ02	GREEN	
+CubeRoot10Irrational	GREEN	
+CubeRoot2Irrational	GREEN	
+CubeRoot3Irrational	GREEN	
+CubeRoot3IrrationalOQ02	GREEN	
+CubeRoot3IrrationalOQ02OQ01	GREEN	
+CubeRoot3IrrationalOQ02OQ02	GREEN	
+CubeRoot3IrrationalOQ03	GREEN	
+CubeRoot3IrrationalOQ03OQ01	GREEN	
+CubeRoot3IrrationalOQ03OQ02	GREEN	
+CubeRoot3IrrationalOQ03OQ03	RESIDUAL	rewrite-drift
+CubeRoot3IrrationalOQ04	GREEN	
+CubeRoot3IrrationalOQ04A12	GREEN	
+CubeRoot3IrrationalOQ04Degree	GREEN	
+CubeRoot3IrrationalOQ04Helpers	GREEN	
+CubeRoot3IrrationalOQ04Mobius	GREEN	
+CubeRoot3IrrationalOQ04NotQuadratic	GREEN	
+CubeRoot3IrrationalOQ04Stream	GREEN	
+CubeRoot3IrrationalOQ04StreamCanonical	GREEN	
+CubeRoot5Irrational	GREEN	
+CubeRoot6Irrational	GREEN	
+CubeRoot7Irrational	GREEN	
+CubeRoot9Irrational	GREEN	
+CyclotomicPolynomialsOQ02OQ04	GREEN	
+CyclotomicPolynomialsOQ02OQ06	GREEN	
+DeMoivre	GREEN	
+DeMoivreOQ01OQ03	GREEN	
+DeMoivreOQ01OQ03OQ01	GREEN	
+DeMoivreOQ01OQ03OQ01OQ01	GREEN	
+DeMoivreOQ01OQ03OQ01OQ01OQ01	GREEN	
+DeMoivreOQ01OQ03OQ01OQ01OQ02	GREEN	
+DeMoivreOQ01OQ03OQ02	GREEN	
+DeMoivreOQ02OQ02	RESIDUAL	signature-drift
+DeMoivreOQ03OQ01	GREEN	
+DeMoivreOQ06	GREEN	
+DedekindFrobeniusBridge	RESIDUAL	rewrite-drift
+DenumerabilityRationalsOQ01	GREEN	elab-drift
+DenumerabilityRationalsOQ02OQ02	RESIDUAL	elab-drift
+DenumerabilityRationalsOQ04	RESIDUAL	unknown-const:Polynomial.setOf_isRoot_finite
+DerangementsConvergence	GREEN	
+DerangementsConvergenceOQ01	GREEN	
+DerangementsConvergenceOQ01OQ01	GREEN	
+DerangementsConvergenceOQ02	GREEN	
+DerangementsConvergenceOQ02OQ01	GREEN	
+DerangementsConvergenceOQ03	RESIDUAL	unknown-const:Nat.floor_eq_iff.mpr
+DerangementsConvergenceOQ03OQ01	GREEN	
+DerangementsConvergenceOQ03OQ01OQ02	GREEN	
+DerangementsConvergenceOQ03OQ03	GREEN	
+DerangementsConvergenceOQ05	GREEN	
+DerangementsConvergenceOQ05OQ01	RESIDUAL	type-mismatch
+DerangementsConvergenceOQ06	GREEN	
+DerangementsConvergenceOQ06OQ01	GREEN	
+DerangementsOQ03	GREEN	
+DerangementsOQ03OQ01	RESIDUAL	signature-drift
+DerangementsOQ03OQ01OQ02	GREEN	
+DerangementsOQ03OQ02	GREEN	
+DerangementsOQ04OQ01OQ01	GREEN	
+DesarguesTheorem	RESIDUAL	type-mismatch
+DesarguesTheoremOQ01OQ01	RESIDUAL	proof-drift
+DescartesRuleOfSignsOQ01OQ01	GREEN	
+DescartesRuleOfSignsOQ01OQ02	RESIDUAL	unknown-const:Even.add_even
+DescartesRuleOfSignsOQ02	RESIDUAL	rewrite-drift
+DescartesRuleOfSignsOQ02OQ01	RESIDUAL	rewrite-drift
+DescartesRuleOfSignsOQ02Parity	RESIDUAL	proof-drift
+DescartesRuleOfSignsOQ04	RESIDUAL	unknown-const:Multiset.countP_singleton
+DiamondImpliesCH	RESIDUAL	proof-drift
+DiniTheorem	GREEN	
+DiniTheoremOQ01OQ01	GREEN	
+DirichletApproximationOQ02	GREEN	
+DirichletApproximationOQ04OQ02	GREEN	
+DirichletsTheorem	RESIDUAL	parse-error
+DirichletsTheoremOQ01OQ01	GREEN	
+DirichletsTheoremOQ03	GREEN	
+DissectionOfCubesOQ01OQ02	GREEN	
+DissectionOfCubesOQ02OQ02	RESIDUAL	type-mismatch
+DissectionOfCubesOQ03	GREEN	
+DissectionOfCubesOQ03OQ02	RESIDUAL	rewrite-drift
+DissectionOfCubesOQ04	RESIDUAL	type-mismatch
+DissectionOfCubesOQ04Aristotle	RESIDUAL	type-mismatch
+DivisibilityBy3	GREEN	
+DivisibilityBy3OQ03	RESIDUAL	unknown-const:Nat.sum_digits_lt
+DivisibilityBy3OQ03OQ02	GREEN	
+DivisibilityByThreeOQ01OQ02Aristotle	GREEN	
+DivisibilityByThreeOQ02	GREEN	
+DivisibilityRules	GREEN	
+DivisibilityRulesOQ01	GREEN	
+DivisibilityRulesOQ02	GREEN	
+DivisibilityTruncationGeneralOQ01OQ01	GREEN	
+DivisibilityTruncationGeneralOQ03	GREEN	
+DyckCatalanCountOQ01OQ01	RESIDUAL	type-mismatch
+ETranscendentalOQ01	GREEN	
+ETranscendentalOQ01OQ01	GREEN	
+ETranscendentalOQ02	GREEN	
+ETranscendentalOQ02OQ06	GREEN	
+ETranscendentalOQ02Rational	GREEN	
+ETranscendentalOQ03	GREEN	
+ETranscendentalOQ03OQ01	RESIDUAL	unknown-const:n
+ETranscendentalOQ03Reduction	GREEN	
+EgorovTheorem	GREEN	
+EgorovTheoremOQ01OQ02	GREEN	
+EgorovTheoremOQ01OQ03	GREEN	
+EhrhartCrossPolytope	GREEN	
+EisensteinCriterionOQ01OQ03OQ02OQ01	RESIDUAL	unclassified
+ElementaryQuadraticReciprocityOQ01	RESIDUAL	unknown-const:generator_orderOf
+ElementaryQuadraticReciprocityOQ01OQ01OQ03	RESIDUAL	instance-synth
+ElementaryQuadraticReciprocityOQ01OQ03	GREEN	
+ElementaryQuadraticReciprocityOQ01OQ03OQ01	GREEN	
+ElementaryQuadraticReciprocityOQ01OQ03OQ01OQ01	GREEN	
+ElementaryQuadraticReciprocityOQ01OQ03OQ01OQ01OQ01	GREEN	
+ElementaryQuadraticReciprocityOQ01OQ03OQ01OQ01OQ01OQ01	GREEN	
+ElementaryQuadraticReciprocityOQ01OQ03OQ01OQ01OQ01OQ01OQ01	GREEN	
+ElementaryQuadraticReciprocityOQ01OQ03OQ01OQ01OQ01OQ01OQ01OQ01	GREEN	
+ElementaryQuadraticReciprocityOQ01OQ03OQ01OQ01OQ01OQ01OQ01OQ01OQ02	GREEN	
+ElementaryQuadraticReciprocityOQ01OQ03OQ01OQ01OQ01OQ01OQ01OQ02	GREEN	
+ElementaryQuadraticReciprocityOQ01OQ03OQ01OQ01OQ01OQ01OQ01OQ02OQ01	GREEN	
+ElementaryQuadraticReciprocityOQ01OQ03OQ01OQ01OQ01OQ01OQ01OQ02OQ02	GREEN	
+ElementaryQuadraticReciprocityOQ02OQ01	RESIDUAL	proof-drift
+ElementaryQuadraticReciprocityOQ03OQ01	GREEN	
+ElementaryQuadraticReciprocityOQ03OQ01OQ02	GREEN	
+ElementaryQuadraticReciprocityOQ03OQ02OQ01	RESIDUAL	proof-drift
+ElementaryQuadraticReciprocityOQ03OQ02OQ03	RESIDUAL	proof-drift
+ElementaryQuadraticReciprocityOQ03OQ03	RESIDUAL	unknown-const:legendreSym.eq_one_iff_isSquare
+Erdos1000OQ01	RESIDUAL	rewrite-drift
+Erdos1000OQ02	RESIDUAL	type-mismatch
+Erdos1000Problem	GREEN	
+Erdos1001OQ02OQ01	GREEN	
+Erdos1002OQ01	RESIDUAL	type-mismatch
+Erdos1002OQ01OQ01	RESIDUAL	type-mismatch
+Erdos1002OQ01OQ01Aristotle	GREEN	
+Erdos1003OQ02	GREEN	
+Erdos1005Problem	RESIDUAL	proof-drift
+Erdos1005ProblemOQ02	GREEN	
+Erdos1006OQ01	GREEN	
+Erdos1006OQ01OQ02	RESIDUAL	signature-drift
+Erdos1006OQ02	RESIDUAL	elab-drift
+Erdos1006OQ03	GREEN	
+Erdos1006OQ04	GREEN	
+Erdos1006OQ04Decidability	RESIDUAL	unclassified
+Erdos1006Problem	RESIDUAL	instance-synth
+Erdos1007OQ01	RESIDUAL	proof-drift
+Erdos1007OQ01OQ01	RESIDUAL	proof-drift
+Erdos1007OQ04	GREEN	
+Erdos1007OQ05	RESIDUAL	instance-synth
+Erdos1007Problem	RESIDUAL	instance-synth
+Erdos1008OQ01	GREEN	
+Erdos1008OQ02	GREEN	
+Erdos1008Problem	GREEN	
+Erdos1008ProblemProvable	RESIDUAL	instance-synth
+Erdos1009OQ01	GREEN	
+Erdos1009OQ02Problem	GREEN	
+Erdos1009Problem	GREEN	
+Erdos100OQ01	RESIDUAL	proof-drift
+Erdos100OQ01WIP01	RESIDUAL	proof-drift
+Erdos100OQ02	GREEN	
+Erdos100OQ02OQ02	GREEN	
+Erdos1010OQ01	GREEN	
+Erdos1010OQ02Problem	GREEN	
+Erdos1010Problem	GREEN	
+Erdos1011OQ03	GREEN	
+Erdos1011Problem	GREEN	
+Erdos1012OQ01OQ02	RESIDUAL	unknown-const:n
+Erdos1012OQ03	RESIDUAL	proof-drift
+Erdos1012OQ05	RESIDUAL	unknown-const:woodall_pancyclic
+Erdos1012Problem	RESIDUAL	unknown-const:woodall_pancyclic
+Erdos1013ConstantRatio	GREEN	
+Erdos1013Problem	GREEN	
+Erdos1013UnconditionalRatio	GREEN	
+Erdos1014OQ01	GREEN	
+Erdos1014OQ02	RESIDUAL	type-mismatch
+Erdos1014OQ03	RESIDUAL	type-mismatch
+Erdos1014OQ03Concrete	RESIDUAL	type-mismatch
+Erdos1014OQ03LogIncrement	RESIDUAL	type-mismatch
+Erdos1014OQ03Obstruction	RESIDUAL	type-mismatch
+Erdos1014OQ04	GREEN	
+Erdos1014Problem	RESIDUAL	type-mismatch
+Erdos1015OQ05	GREEN	
+Erdos1015Problem	PRE-EXISTING	never-compiled:n
+Erdos1017OQ01	RESIDUAL	type-mismatch
+Erdos1017OQ04	GREEN	
+Erdos1017Problem	RESIDUAL	type-mismatch
+Erdos1018Aristotle	RESIDUAL	proof-drift
+Erdos1018OQ01	GREEN	
+Erdos1018OQ01OQ01	GREEN	
+Erdos1018OQ01OQ01OQ01	GREEN	
+Erdos1018OQ01OQ01OQ01OQ01	GREEN	
+Erdos1018OQ04	GREEN	
+Erdos1018OQ04Incomplete01	RESIDUAL	type-mismatch
+Erdos1018OQ04Incomplete01Aristotle	GREEN	
+Erdos1018Problem	RESIDUAL	rewrite-drift
+Erdos1019Problem	RESIDUAL	unknown-const:completeBipartite
+Erdos101OQ01	GREEN	
+Erdos101OQ01OQ02	GREEN	
+Erdos101OQ04	GREEN	
+Erdos101OQ04OQ01	GREEN	
+Erdos1020Problem	RESIDUAL	signature-drift
+Erdos1021Aristotle	GREEN	
+Erdos1021OQ01	RESIDUAL	rewrite-drift
+Erdos1021OQ01Incomplete01	GREEN	
+Erdos1021Problem	RESIDUAL	rewrite-drift
+Erdos1021Wip01	GREEN	
+Erdos1021Wip02	GREEN	
+Erdos1022OQ01	RESIDUAL	instance-synth
+Erdos1022OQ03	GREEN	
+Erdos1022Problem	GREEN	
+Erdos1023OQ01	GREEN	
+Erdos1023OQ01Problem	GREEN	
+Erdos1023Problem	GREEN	
+Erdos1024Problem	GREEN	
+Erdos1025Problem	GREEN	
+Erdos1026OQ05Extremal	RESIDUAL	proof-drift
+Erdos1026OQ05KMonotonic	GREEN	
+Erdos1026Problem	RESIDUAL	unknown-const:Finset.exists_smaller_set
+Erdos1027OQ01	RESIDUAL	unclassified
+Erdos1027OQ03	GREEN	
+Erdos1028Problem	RESIDUAL	unknown-const:rpow_one
+Erdos1029LowerBound	GREEN	
+Erdos1029Problem	RESIDUAL	rewrite-drift
+Erdos102Problem	GREEN	
+Erdos1031Problem	GREEN	
+Erdos1032Problem	GREEN	
+Erdos1033Aristotle	GREEN	
+Erdos1033Problem	RESIDUAL	unknown-const:fan_lower
+Erdos1034Aristotle	GREEN	
+Erdos1034OQ02	GREEN	
+Erdos1034Problem	RESIDUAL	unknown-const:maTang_counterexample
+Erdos1035Problem	RESIDUAL	instance-synth
+Erdos1036OQ01	GREEN	
+Erdos1036OQ01OQ01	GREEN	
+Erdos1036Problem	GREEN	
+Erdos1038Problem	GREEN	
+Erdos1038WIP01	GREEN	
+Erdos1039Aristotle	RESIDUAL	unknown-const:Erdos1039.Complex.abs
+Erdos1039Conformal	GREEN	
+Erdos1039ProblemAristotle	RESIDUAL	type-mismatch
+Erdos103OQ02Bounds	GREEN	
+Erdos1040Aristotle	GREEN	
+Erdos1040Convex	GREEN	
+Erdos1040OQ03	RESIDUAL	unknown-const:isBounded_iUnion.mpr
+Erdos1040Problem	RESIDUAL	type-mismatch
+Erdos1041Problem	GREEN	
+Erdos1042Problem	GREEN	
+Erdos1043Aristotle	GREEN	
+Erdos1044Problem	GREEN	
+Erdos1045Problem	RESIDUAL	unknown-const:z
+Erdos1046Problem	GREEN	
+Erdos1048Aristotle	RESIDUAL	unknown-const:Complex.continuous_abs.comp
+Erdos1048Problem	GREEN	
+Erdos1048ProblemAristotle	GREEN	
+Erdos1049Aristotle	GREEN	
+Erdos1049Problem	RESIDUAL	type-mismatch
+Erdos104Problem	RESIDUAL	unknown-const:zero_rpow
+Erdos1050Aristotle	GREEN	
+Erdos1050Problem	RESIDUAL	type-mismatch
+Erdos1050ProblemAristotle	RESIDUAL	unknown-const:summable_of_summable_norm
+Erdos1051Problem	RESIDUAL	type-mismatch
+Erdos1052Problem	RESIDUAL	rewrite-drift
+Erdos1053Problem	GREEN	
+Erdos1054AlmostAllOQ01	GREEN	
+Erdos1054AlmostAllOQ0103	GREEN	
+Erdos1054ConstructionD	RESIDUAL	unknown-const:p
+Erdos1054OQ01	RESIDUAL	unknown-const:p
+Erdos1054OQ02	PRE-EXISTING	never-compiled:q
+Erdos1054Problem	GREEN	
+Erdos1055Problem	RESIDUAL	elab-drift
+Erdos1056Aristotle	GREEN	
+Erdos1056Problem	RESIDUAL	instance-synth
+Erdos1057Problem	GREEN	
+Erdos1059OQ02OQ01	RESIDUAL	unknown-const:Nat.factorial_le_factorial
+Erdos1059OQ03	GREEN	
+Erdos1059OQ04	RESIDUAL	unknown-const:AllFactorialSubtractionsComposite
+Erdos1059Problem	GREEN	
+Erdos105OQ05	GREEN	
+Erdos1060Problem	GREEN	
+Erdos1061Problem	RESIDUAL	proof-drift
+Erdos1062OQ04	GREEN	
+Erdos1062Problem	GREEN	
+Erdos1065CunninghamChains	RESIDUAL	type-mismatch
+Erdos1065Problem	RESIDUAL	unknown-const:conjecture_a_implies_b
+Erdos1066OQ04	GREEN	
+Erdos1066Problem	PRE-EXISTING	never-compiled:n
+Erdos1067Problem	RESIDUAL	partenat-removal
+Erdos1068Problem	GREEN	
+Erdos106OQ02	RESIDUAL	rewrite-drift
+Erdos106Problem	RESIDUAL	unknown-const:f_perfect_square
+Erdos1070Problem	GREEN	
+Erdos1071Problem	PRE-EXISTING	never-compiled:s
+Erdos1073Problem	GREEN	
+Erdos1075Problem	GREEN	
+Erdos1076Problem	GREEN	
+Erdos1078Problem	RESIDUAL	instance-synth
+Erdos1079Problem	RESIDUAL	instance-synth
+Erdos107OQ01	RESIDUAL	instance-synth
+Erdos107OQ01KleinUpperAristotle	RESIDUAL	instance-synth
+Erdos1080OQ03	RESIDUAL	type-mismatch
+Erdos1080Problem	GREEN	
+Erdos1081Problem	RESIDUAL	proof-drift
+Erdos1082Problem	GREEN	
+Erdos1083OQ02	GREEN	
+Erdos1083Problem	GREEN	
+Erdos1084OQ01	GREEN	
+Erdos1084Problem	GREEN	
+Erdos1085Problem	GREEN	
+Erdos1086Problem	GREEN	
+Erdos1087Problem	RESIDUAL	instance-synth
+Erdos1088Problem	GREEN	
+Erdos1089Problem	RESIDUAL	unknown-const:PiLp.equiv_symm_apply
+Erdos1091Problem	RESIDUAL	instance-synth
+Erdos1093OQ02FactorialGrowth	GREEN	
+Erdos1095OQ01Problem	RESIDUAL	partenat-removal
+Erdos1096Problem	RESIDUAL	unknown-const:intermediate_value_zero_of_neg_of_pos
+Erdos1097OQ01	RESIDUAL	instance-synth
+Erdos1097Problem	RESIDUAL	instance-synth
+Erdos1098OQ01	RESIDUAL	type-mismatch
+Erdos1098OQ01OQ01	RESIDUAL	instance-synth
+Erdos1098OQ03	RESIDUAL	proof-drift
+Erdos1098OQ04	GREEN	
+Erdos1098Problem	RESIDUAL	instance-synth
+Erdos109OQ01	RESIDUAL	type-mismatch
+Erdos109OQ01Aristotle	GREEN	
+Erdos109Problem	GREEN	
+Erdos10Incomplete01OQ02	RESIDUAL	slow-timeout
+Erdos10OQ01	RESIDUAL	proof-drift
+Erdos10OQ01Incomplete01	RESIDUAL	slow-timeout
+Erdos10OQ02Bridge	GREEN	
+Erdos10Problem	GREEN	
+Erdos10WIP01OQ03	RESIDUAL	slow-timeout
+Erdos1100Problem	PRE-EXISTING	never-compiled:p
+Erdos1100ProblemAristotle	RESIDUAL	unknown-const:p
+Erdos1100ProblemProvable	PRE-EXISTING	never-compiled:p
+Erdos1101Problem	GREEN	
+Erdos1103Problem	RESIDUAL	instance-synth
+Erdos1104OQ01	GREEN	
+Erdos1104Problem	RESIDUAL	type-mismatch
+Erdos1107Problem	GREEN	
+Erdos1108Problem	GREEN	
+Erdos1109Problem	RESIDUAL	proof-drift
+Erdos110HigherCardinals	GREEN	
+Erdos110Problem	RESIDUAL	unknown-const:lambie_hanson_counterexample
+Erdos1110OQ01	GREEN	
+Erdos1111Problem	GREEN	
+Erdos1112Problem	RESIDUAL	proof-drift
+Erdos1113Problem	GREEN	
+Erdos1114Problem	GREEN	
+Erdos1115Problem	GREEN	
+Erdos1116Problem	RESIDUAL	unknown-const:not_lt_of_le
+Erdos1117Problem	GREEN	
+Erdos1118OQ02	GREEN	
+Erdos1118Problem	RESIDUAL	instance-synth
+Erdos1119Problem	PRE-EXISTING	never-compiled:ι
+Erdos111Problem	GREEN	
+Erdos1120Problem	RESIDUAL	instance-synth
+Erdos1121Problem	RESIDUAL	instance-synth
+Erdos1122Problem	GREEN	
+Erdos1123Problem	RESIDUAL	parse-error
+Erdos1124Problem	GREEN	
+Erdos1125Problem	RESIDUAL	proof-drift
+Erdos1126Problem	RESIDUAL	unknown-const:measurable_additive_is_linear
+Erdos1127Problem	RESIDUAL	instance-synth
+Erdos1128Problem	RESIDUAL	proof-drift
+Erdos1129OQ02	GREEN	
+Erdos112Problem	GREEN	
+Erdos1130Problem	RESIDUAL	type-mismatch
+Erdos1131OQ01	RESIDUAL	rewrite-drift
+Erdos1131Problem	RESIDUAL	rewrite-drift
+Erdos1132Aristotle	GREEN	
+Erdos1132Problem	GREEN	
+Erdos1134Problem	RESIDUAL	unknown-const:crampin_hilton_tau_exists
+Erdos1135Problem	GREEN	
+Erdos1136Problem	RESIDUAL	proof-drift
+Erdos1138Problem	GREEN	
+Erdos113Problem	GREEN	
+Erdos1142Problem	GREEN	
+Erdos1145Problem	RESIDUAL	type-mismatch
+Erdos1149Aristotle	RESIDUAL	type-mismatch
+Erdos1149Problem	RESIDUAL	type-mismatch
+Erdos114OQ01Problem	RESIDUAL	proof-drift
+Erdos1150Problem	RESIDUAL	unknown-const:parseval_ratio_ge_one
+Erdos1151OQ04Aristotle	RESIDUAL	proof-drift
+Erdos1151Problem	RESIDUAL	proof-drift
+Erdos1153Problem	PRE-EXISTING	never-compiled:k
+Erdos1155OQ01	GREEN	
+Erdos1155OQ01OQ01	GREEN	
+Erdos1155OQ01OQ07	GREEN	
+Erdos1155OQ02	RESIDUAL	type-mismatch
+Erdos1155Problem	GREEN	
+Erdos1156Problem	GREEN	
+Erdos1157Problem	RESIDUAL	unknown-const:delcourt_postle_theorem
+Erdos1158Problem	GREEN	
+Erdos1159Problem	RESIDUAL	signature-drift
+Erdos115OQ01Problem	GREEN	
+Erdos115Problem	GREEN	
+Erdos1161Problem	GREEN	
+Erdos1162Problem	RESIDUAL	unknown-const:Nat.card_pos_of_nonempty
+Erdos1165Problem	GREEN	
+Erdos1166Problem	RESIDUAL	unknown-const:Finset.filter_eq_empty
+Erdos1167Problem	RESIDUAL	parse-error
+Erdos1168Problem	RESIDUAL	unknown-const:Cardinal.cof_aleph
+Erdos1169Problem	RESIDUAL	proof-drift
+Erdos116Problem	GREEN	
+Erdos1170Problem	GREEN	
+Erdos1171Problem	RESIDUAL	unknown-const:Ordinal.mul_lt_mul_iff_left
+Erdos1172Problem	RESIDUAL	unknown-const:Ordinal.lt_add_of_limit_left
+Erdos1173Problem	RESIDUAL	instance-synth
+Erdos1174Problem	GREEN	
+Erdos1175Problem	GREEN	
+Erdos1176Problem	RESIDUAL	type-mismatch
+Erdos1177Problem	GREEN	
+Erdos1178Problem	RESIDUAL	type-mismatch
+Erdos1179OQ01OQ02	GREEN	
+Erdos1179OQ02	GREEN	
+Erdos1179OQ02Extremal	GREEN	
+Erdos1179OQ02Rigidity	GREEN	
+Erdos1179OQ02Upper	GREEN	
+Erdos1179OQ02Witness	GREEN	
+Erdos1179Problem	GREEN	
+Erdos117Problem	GREEN	
+Erdos1181Problem	RESIDUAL	unknown-const:Real.tendsto_log_div_rpow_atTop
+Erdos1182Problem	RESIDUAL	unknown-const:Fin.one_ne_zero
+Erdos1183Problem	GREEN	
+Erdos118Problem	GREEN	
+Erdos1196Problem	GREEN	
+Erdos119Problem	GREEN	
+Erdos11Problem	GREEN	
+Erdos1201Problem	RESIDUAL	type-mismatch
+Erdos1202Problem	GREEN	
+Erdos1206Problem	RESIDUAL	proof-drift
+Erdos1208Problem	RESIDUAL	rewrite-drift
+Erdos120Problem	RESIDUAL	unknown-const:pow_lt_pow_of_lt_one
+Erdos1211Problem	GREEN	
+Erdos1212Problem	GREEN	
+Erdos1213Problem	GREEN	
+Erdos1214Problem	RESIDUAL	proof-drift
+Erdos1216Problem	GREEN	
+Erdos1217Problem	GREEN	
+Erdos121Problem	RESIDUAL	duplicate-decl
+Erdos124CompleteSequences	RESIDUAL	unknown-const:i_1
+Erdos124Problem	GREEN	
+Erdos125Problem	GREEN	
+Erdos126Problem	GREEN	
+Erdos127Problem	GREEN	
+Erdos128Problem	GREEN	
+Erdos129Problem	RESIDUAL	proof-drift
+Erdos12Problem	GREEN	
+Erdos130Problem	GREEN	
+Erdos130WIP01	RESIDUAL	proof-drift
+Erdos132Problem	GREEN	
+Erdos133Problem	RESIDUAL	elab-drift
+Erdos134Problem	GREEN	
+Erdos136Problem	GREEN	
+Erdos13Problem	GREEN	
+Erdos140Problem	RESIDUAL	type-mismatch
+Erdos141Problem	GREEN	
+Erdos142Problem	GREEN	
+Erdos144Problem	GREEN	
+Erdos145Problem	GREEN	
+Erdos146Problem	GREEN	
+Erdos147Problem	GREEN	
+Erdos148Problem	GREEN	
+Erdos149Problem	GREEN	
+Erdos14Problem	GREEN	
+Erdos14UniqueSums	RESIDUAL	proof-drift
+Erdos150Problem	GREEN	
+Erdos152OQ01	RESIDUAL	type-mismatch
+Erdos152Problem	RESIDUAL	type-mismatch
+Erdos152ProblemAPN	RESIDUAL	proof-drift
+Erdos153Problem	RESIDUAL	elab-drift
+Erdos154Problem	GREEN	
+Erdos155Problem	GREEN	
+Erdos156Aristotle	RESIDUAL	instance-synth
+Erdos156OQ02	RESIDUAL	unknown-const:x
+Erdos156ProblemAristotle	RESIDUAL	duplicate-decl
+Erdos158Problem	GREEN	
+Erdos159Problem	RESIDUAL	type-mismatch
+Erdos15Problem	GREEN	
+Erdos161Problem	GREEN	
+Erdos162Problem	RESIDUAL	unknown-const:Bool.true_ne_false
+Erdos163Problem	GREEN	
+Erdos164Problem	GREEN	
+Erdos166Problem	RESIDUAL	type-mismatch
+Erdos167Problem	RESIDUAL	type-mismatch
+Erdos168Problem	GREEN	
+Erdos169Problem	GREEN	
+Erdos16Problem	GREEN	
+Erdos170Problem	GREEN	
+Erdos171Problem	RESIDUAL	type-mismatch
+Erdos173Problem	GREEN	
+Erdos174Problem	RESIDUAL	instance-synth
+Erdos176Problem	GREEN	
+Erdos177Problem	GREEN	
+Erdos178Problem	GREEN	
+Erdos179Aristotle	RESIDUAL	proof-drift
+Erdos179Problem	GREEN	
+Erdos179ProblemAristotle	RESIDUAL	proof-drift
+Erdos17Problem	GREEN	
+Erdos180Problem	RESIDUAL	instance-synth
+Erdos181OQ01	RESIDUAL	unknown-const:Function.id
+Erdos181Problem	RESIDUAL	unknown-const:rpow_le_rpow_of_exponent_le
+Erdos182Problem	GREEN	
+Erdos183Problem	RESIDUAL	proof-drift
+Erdos184Problem	RESIDUAL	proof-drift
+Erdos184ProblemProvable	RESIDUAL	proof-drift
+Erdos185Problem	GREEN	
+Erdos186Problem	GREEN	
+Erdos188Problem	RESIDUAL	instance-synth
+Erdos189Problem	RESIDUAL	unknown-const:det
+Erdos18OQ01	GREEN	
+Erdos190Problem	RESIDUAL	unknown-const:exists_canonical_threshold
+Erdos191Problem	RESIDUAL	instance-synth
+Erdos192Problem	GREEN	
+Erdos193Problem	RESIDUAL	unknown-const:p
+Erdos194Problem	GREEN	
+Erdos195Problem	RESIDUAL	unknown-const:List.Chain'.take
+Erdos196Problem	GREEN	
+Erdos199Problem	GREEN	
+Erdos19OQ01Problem	RESIDUAL	unknown-const:GraphCore.IsKColorable
+Erdos19Problem	GREEN	
+Erdos1OQ03	RESIDUAL	type-mismatch
+Erdos1OQ03Aristotle	RESIDUAL	type-mismatch
+Erdos1OQ04	RESIDUAL	type-mismatch
+Erdos1Wip01	RESIDUAL	type-mismatch
+Erdos201Problem	RESIDUAL	unknown-const:isAPFree_empty
+Erdos202Problem	RESIDUAL	type-mismatch
+Erdos203Problem	RESIDUAL	rewrite-drift
+Erdos206Problem	GREEN	
+Erdos207Problem	GREEN	
+Erdos207ProblemAristotle	RESIDUAL	rewrite-drift
+Erdos208Problem	GREEN	
+Erdos209Problem	RESIDUAL	instance-synth
+Erdos20Problem	RESIDUAL	instance-synth
+Erdos210Problem	RESIDUAL	instance-synth
+Erdos211Problem	RESIDUAL	instance-synth
+Erdos215Problem	GREEN	
+Erdos216Problem	RESIDUAL	instance-synth
+Erdos217Problem	GREEN	
+Erdos21Problem	GREEN	
+Erdos220Aristotle	GREEN	
+Erdos220Problem	GREEN	
+Erdos220ProblemProvable	GREEN	
+Erdos221Problem	GREEN	
+Erdos222Problem	GREEN	
+Erdos223Problem	RESIDUAL	type-mismatch
+Erdos225Aristotle	GREEN	
+Erdos225Problem	RESIDUAL	proof-drift
+Erdos226Problem	RESIDUAL	unknown-const:Rat.denseRange_ratCast
+Erdos229Problem	GREEN	
+Erdos230LowerBound	GREEN	
+Erdos230ProblemAristotle	GREEN	
+Erdos231Problem	GREEN	
+Erdos232Problem	GREEN	
+Erdos233Problem	GREEN	
+Erdos234Problem	RESIDUAL	type-mismatch
+Erdos235Problem	RESIDUAL	proof-drift
+Erdos236Problem	GREEN	
+Erdos237Problem	GREEN	
+Erdos239Problem	GREEN	
+Erdos240Aristotle	GREEN	
+Erdos241Problem	GREEN	
+Erdos242Problem	RESIDUAL	type-mismatch
+Erdos246Problem	GREEN	
+Erdos247Problem	RESIDUAL	instance-synth
+Erdos249OQ01	RESIDUAL	proof-drift
+Erdos249Problem	GREEN	
+Erdos24Problem	GREEN	
+Erdos250Problem	RESIDUAL	unknown-const:Nat.smul_eq_mul
+Erdos251Problem	GREEN	
+Erdos252Problem	RESIDUAL	parse-error
+Erdos254Problem	RESIDUAL	instance-synth
+Erdos255Problem	GREEN	
+Erdos256Problem	GREEN	
+Erdos257Problem	GREEN	
+Erdos258OQ01	GREEN	
+Erdos258Problem	GREEN	
+Erdos259Problem	GREEN	
+Erdos25Abel	GREEN	
+Erdos25LogDensity	RESIDUAL	type-mismatch
+Erdos25Problem	RESIDUAL	type-mismatch
+Erdos260Aristotle	RESIDUAL	unknown-const:Real.tendsto_log_nat_atTop
+Erdos261Problem	GREEN	
+Erdos262Problem	GREEN	
+Erdos263Aristotle	RESIDUAL	proof-drift
+Erdos263Problem	RESIDUAL	proof-drift
+Erdos264Problem	GREEN	
+Erdos265Problem	RESIDUAL	unknown-const:Finset.sum_eq_sum_diff_singleton_add
+Erdos266Problem	RESIDUAL	unknown-const:Real.not_summable_nat_of_tendsto_nat
+Erdos267Problem	RESIDUAL	unknown-const:Real.one_lt_sqrt
+Erdos268Aristotle	RESIDUAL	unknown-const:summable_of_finite
+Erdos268Problem	RESIDUAL	proof-drift
+Erdos268ProblemAristotle	RESIDUAL	unknown-const:one_nonneg
+Erdos26Problem	GREEN	
+Erdos270Problem	GREEN	
+Erdos271Problem	GREEN	
+Erdos272Problem	GREEN	
+Erdos274Problem	RESIDUAL	unknown-const:ExactCovering
+Erdos275Problem	RESIDUAL	instance-synth
+Erdos276Problem	GREEN	
+Erdos278Problem	GREEN	
+Erdos279OQ04	RESIDUAL	type-mismatch
+Erdos27Problem	RESIDUAL	rewrite-drift
+Erdos280Problem	GREEN	
+Erdos281Problem	RESIDUAL	parse-error
+Erdos283Problem	GREEN	
+Erdos284Problem	GREEN	
+Erdos285Problem	GREEN	
+Erdos286Problem	GREEN	
+Erdos287Problem	GREEN	
+Erdos288Problem	RESIDUAL	rewrite-drift
+Erdos289Problem	RESIDUAL	unknown-const:div_le_div_of_le_left
+Erdos28AdditiveBases	GREEN	
+Erdos28Problem	GREEN	
+Erdos291Problem	RESIDUAL	proof-drift
+Erdos292Problem	GREEN	
+Erdos293Problem	GREEN	
+Erdos294Problem	GREEN	
+Erdos296Problem	RESIDUAL	unknown-const:Filter.Tendsto.unique
+Erdos297Problem	GREEN	
+Erdos298Problem	GREEN	
+Erdos299Problem	RESIDUAL	unknown-const:Nat.not_eq_zero_of_lt
+Erdos29OQ02	RESIDUAL	parse-error
+Erdos29Problem	RESIDUAL	unknown-const:JPSZ_representation_bound
+Erdos2OQ01	RESIDUAL	unknown-const:balister_bound
+Erdos2OQ01Aristotle	RESIDUAL	proof-drift
+Erdos2Problem	RESIDUAL	unknown-const:balister_bound
+Erdos300Problem	GREEN	
+Erdos301Problem	RESIDUAL	parse-error
+Erdos302Aristotle	RESIDUAL	proof-drift
+Erdos302Problem	RESIDUAL	proof-drift
+Erdos304Problem	GREEN	
+Erdos306Problem	GREEN	
+Erdos307Aristotle	GREEN	
+Erdos307OQ02	RESIDUAL	proof-drift
+Erdos308Problem	RESIDUAL	instance-synth
+Erdos309Problem	RESIDUAL	proof-drift
+Erdos30Problem	GREEN	
+Erdos310Problem	GREEN	
+Erdos312Problem	GREEN	
+Erdos313Problem	GREEN	
+Erdos314Problem	RESIDUAL	type-mismatch
+Erdos315Problem	RESIDUAL	proof-drift
+Erdos318Aristotle	GREEN	
+Erdos318Problem	GREEN	
+Erdos319Problem	RESIDUAL	proof-drift
+Erdos31Problem	GREEN	
+Erdos320Problem	RESIDUAL	unknown-const:erdos_320_open_bounds
+Erdos321Problem	GREEN	
+Erdos321ProblemR1	GREEN	
+Erdos322Problem	GREEN	
+Erdos323Problem	RESIDUAL	unknown-const:IsSumOfPowers_one_iff.mpr
+Erdos324Problem	GREEN	
+Erdos325Problem	GREEN	
+Erdos326Problem	GREEN	
+Erdos327OQ01	RESIDUAL	unknown-const:Nat.eq_of_mul_eq_left
+Erdos327OQ01OQ04	RESIDUAL	unknown-const:Nat.eq_of_mul_eq_left
+Erdos328Problem	GREEN	
+Erdos329Problem	GREEN	
+Erdos330Problem	GREEN	
+Erdos332Problem	GREEN	
+Erdos333Problem	GREEN	
+Erdos334Problem	RESIDUAL	unknown-const:Nat.Prime.dvd_prime_pow
+Erdos336Problem	GREEN	
+Erdos337Aristotle	GREEN	
+Erdos337Problem	GREEN	
+Erdos338Aristotle	GREEN	
+Erdos338Problem	GREEN	
+Erdos339Aristotle	RESIDUAL	instance-synth
+Erdos339Problem	RESIDUAL	instance-synth
+Erdos33Problem	GREEN	
+Erdos340BhUpperBound	GREEN	
+Erdos340GreedyCountUpper	RESIDUAL	type-mismatch
+Erdos340GreedyExtension	GREEN	
+Erdos340GreedyGrowth	GREEN	
+Erdos340GreedyRpowBound	GREEN	
+Erdos340GreedySidon	GREEN	
+Erdos340GreedySidonExtension	GREEN	
+Erdos340GreedySidonOQ02	GREEN	
+Erdos340GreedySidonOQ05	GREEN	
+Erdos340SidonErdosTuran	GREEN	
+Erdos341Problem	RESIDUAL	rewrite-drift
+Erdos342Problem	GREEN	
+Erdos343Problem	GREEN	
+Erdos344Problem	GREEN	
+Erdos345Problem	GREEN	parse-error
+Erdos346Problem	RESIDUAL	duplicate-decl
+Erdos347Problem	RESIDUAL	unknown-const:Finset.card_Icc
+Erdos348Problem	RESIDUAL	type-mismatch
+Erdos349Problem	GREEN	
+Erdos350Problem	RESIDUAL	type-mismatch
+Erdos351Problem	GREEN	
+Erdos352Problem	GREEN	
+Erdos353Aristotle	RESIDUAL	instance-synth
+Erdos353Problem	RESIDUAL	unknown-const:smul_left_cancel₀
+Erdos354Problem	GREEN	
+Erdos355Problem	GREEN	
+Erdos356Problem	RESIDUAL	unknown-const:Finset.range'
+Erdos357Problem	GREEN	
+Erdos358Problem	RESIDUAL	unknown-const:two_mul_sum_Icc
+Erdos359Problem	GREEN	
+Erdos35Problem	RESIDUAL	proof-drift
+Erdos35ProblemAristotle	RESIDUAL	instance-synth
+Erdos360Aristotle	RESIDUAL	proof-drift
+Erdos360Problem	GREEN	
+Erdos361Problem	GREEN	
+Erdos362Problem	RESIDUAL	type-mismatch
+Erdos363Problem	GREEN	
+Erdos364Problem	GREEN	
+Erdos365Problem	RESIDUAL	proof-drift
+Erdos367Problem	RESIDUAL	unknown-const:twoFullPart_le
+Erdos368Problem	GREEN	
+Erdos369Problem	RESIDUAL	unknown-const:Nat.dvd_of_dvd_of_dvd
+Erdos36Problem	RESIDUAL	unknown-const:white_lower
+Erdos370Problem	RESIDUAL	proof-drift
+Erdos371Problem	GREEN	
+Erdos372Problem	GREEN	
+Erdos374Problem	RESIDUAL	unknown-const:not_le_of_lt
+Erdos375Aristotle	RESIDUAL	unknown-const:Nat.coprime_succ_self
+Erdos375Problem	GREEN	
+Erdos377Problem	GREEN	
+Erdos379Problem	GREEN	
+Erdos380Problem	RESIDUAL	instance-synth
+Erdos381Problem	GREEN	
+Erdos381ProblemAristotle	GREEN	
+Erdos382Problem	RESIDUAL	type-mismatch
+Erdos383Problem	RESIDUAL	proof-drift
+Erdos384Problem	RESIDUAL	unknown-const:Nat.one_lt_iff_ne_one.mp
+Erdos385Problem	GREEN	
+Erdos386Problem	RESIDUAL	unknown-const:Nat.Primes.instCountable.toEncodable.decode
+Erdos388Problem	GREEN	
+Erdos38Problem	GREEN	
+Erdos390Problem	RESIDUAL	unknown-const:List.Sorted
+Erdos391Problem	RESIDUAL	type-mismatch
+Erdos393Problem	RESIDUAL	unknown-const:Nat.radical
+Erdos394Problem	GREEN	
+Erdos395OQ01	RESIDUAL	instance-synth
+Erdos395OQ01Incomplete01	RESIDUAL	instance-synth
+Erdos395Problem	RESIDUAL	instance-synth
+Erdos396OQ04OQ01OQ01	GREEN	
+Erdos396OQ04OQ01OQ01OQ02	GREEN	
+Erdos396OQ04OQ01OQ01OQ02OQ01	GREEN	
+Erdos396OQ04OQ01OQ01OQ02OQ02	GREEN	
+Erdos396OQ04OQ01OQ01OQ03	GREEN	
+Erdos397Problem	RESIDUAL	proof-drift
+Erdos399Problem	GREEN	
+Erdos39Problem	RESIDUAL	type-mismatch
+Erdos3LogHarmonic	RESIDUAL	parse-error
+Erdos3Problem	RESIDUAL	parse-error
+Erdos400Problem	GREEN	
+Erdos402Problem	RESIDUAL	type-mismatch
+Erdos403Problem	GREEN	
+Erdos404Problem	RESIDUAL	rewrite-drift
+Erdos405Problem	RESIDUAL	unknown-const:ZMod.val_neg_one'
+Erdos407Problem	RESIDUAL	proof-drift
+Erdos408Problem	GREEN	
+Erdos409Problem	PRE-EXISTING	never-compiled:p
+Erdos40Problem	RESIDUAL	proof-drift
+Erdos410Problem	GREEN	
+Erdos411Problem	RESIDUAL	unknown-const:totientStep_ge
+Erdos413Problem	RESIDUAL	rewrite-drift
+Erdos414Problem	GREEN	
+Erdos415Problem	GREEN	
+Erdos415ProblemAristotle	GREEN	
+Erdos416Problem	GREEN	
+Erdos417Problem	GREEN	
+Erdos418Problem	GREEN	
+Erdos419Problem	GREEN	
+Erdos41Problem	GREEN	
+Erdos420Problem	GREEN	
+Erdos421Problem	RESIDUAL	parse-error
+Erdos422Problem	GREEN	
+Erdos423Problem	PRE-EXISTING	never-compiled:n
+Erdos424Problem	RESIDUAL	unknown-const:sequence_monotone
+Erdos425Problem	GREEN	
+Erdos426Problem	GREEN	
+Erdos427Problem	GREEN	
+Erdos428Problem	RESIDUAL	unknown-const:primeDensityRatio_nonneg
+Erdos429Problem	RESIDUAL	type-mismatch
+Erdos42Problem	GREEN	
+Erdos431Problem	GREEN	
+Erdos432Problem	RESIDUAL	unknown-const:Finset.card_filter_le_card_filter
+Erdos433Aristotle	GREEN	
+Erdos433Problem	GREEN	
+Erdos434Aristotle	GREEN	
+Erdos434Frobenius	GREEN	
+Erdos434Problem	RESIDUAL	unknown-const:sylvester_frobenius
+Erdos435Problem	GREEN	
+Erdos436Problem	GREEN	
+Erdos437Aristotle	RESIDUAL	unknown-const:div_le_one_of_le
+Erdos437Problem	GREEN	
+Erdos438Problem	GREEN	
+Erdos439Problem	GREEN	
+Erdos43Problem	RESIDUAL	rewrite-drift
+Erdos440Problem	GREEN	
+Erdos441Aristotle	RESIDUAL	proof-drift
+Erdos442Problem	GREEN	
+Erdos443Problem	GREEN	
+Erdos444Problem	GREEN	
+Erdos445Problem	RESIDUAL	instance-synth
+Erdos446Problem	GREEN	
+Erdos447Problem	RESIDUAL	instance-synth
+Erdos449Problem	GREEN	
+Erdos44Problem	GREEN	
+Erdos44SidonLowerBound	GREEN	
+Erdos450Problem	GREEN	
+Erdos451Problem	PRE-EXISTING	never-compiled:hp
+Erdos452Problem	GREEN	
+Erdos453OQ02	RESIDUAL	type-mismatch
+Erdos453Problem	RESIDUAL	type-mismatch
+Erdos454Aristotle	GREEN	
+Erdos454Problem	RESIDUAL	type-mismatch
+Erdos454ProblemAristotle	RESIDUAL	type-mismatch
+Erdos456Aristotle	RESIDUAL	unknown-const:Finset.card_Ico
+Erdos456Problem	RESIDUAL	proof-drift
+Erdos457Problem	GREEN	
+Erdos459Problem	RESIDUAL	type-mismatch
+Erdos45Problem	RESIDUAL	unknown-const:sawhney_upper_bound
+Erdos461Problem	RESIDUAL	unknown-const:Nat.prod_factors
+Erdos464Problem	GREEN	
+Erdos465Problem	GREEN	
+Erdos466Problem	GREEN	
+Erdos468Problem	GREEN	
+Erdos469Problem	GREEN	
+Erdos46Problem	GREEN	
+Erdos470Problem	RESIDUAL	noncomputable
+Erdos471Problem	RESIDUAL	unknown-const:Set.Finite.of_finset
+Erdos472Problem	GREEN	
+Erdos473Problem	GREEN	
+Erdos474Problem	GREEN	
+Erdos475Problem	GREEN	
+Erdos476Aristotle	RESIDUAL	elab-drift
+Erdos476OQ05Aristotle	RESIDUAL	unknown-const:b₂
+Erdos476OQ05Problem	RESIDUAL	proof-drift
+Erdos476Problem	PRE-EXISTING	never-compiled:B
+Erdos477Problem	RESIDUAL	unknown-const:Set.Finite.of_not_infinite
+Erdos478Problem	RESIDUAL	type-mismatch
+Erdos479Problem	RESIDUAL	unknown-const:fermat_little
+Erdos47Problem	GREEN	
+Erdos481Problem	GREEN	
+Erdos483OQ02	RESIDUAL	elab-drift
+Erdos483Problem	RESIDUAL	elab-drift
+Erdos484Problem	GREEN	
+Erdos485OQ01	PRE-EXISTING	never-compiled:d
+Erdos485OQ02	RESIDUAL	instance-synth
+Erdos485Problem	GREEN	
+Erdos486Problem	GREEN	
+Erdos487Problem	RESIDUAL	type-mismatch
+Erdos488Problem	RESIDUAL	type-mismatch
+Erdos489Problem	GREEN	
+Erdos48Problem	GREEN	
+Erdos490Aristotle	GREEN	parse-error
+Erdos490OQ01	GREEN	
+Erdos490ProblemAristotle	RESIDUAL	unknown-const:Nat.eq_zero_of_mul_eq_zero_left
+Erdos491Problem	GREEN	
+Erdos492Problem	RESIDUAL	unknown-const:Int.frac
+Erdos494Problem	GREEN	
+Erdos495Problem	GREEN	
+Erdos496Problem	GREEN	
+Erdos497Problem	GREEN	
+Erdos498Problem	GREEN	
+Erdos499Problem	RESIDUAL	type-mismatch
+Erdos49Problem	GREEN	
+Erdos500Problem	RESIDUAL	instance-synth
+Erdos501Aristotle	RESIDUAL	instance-synth
+Erdos501Problem	RESIDUAL	unknown-const:independent_subset
+Erdos501ProblemProvable	RESIDUAL	unknown-const:independent_subset
+Erdos502Problem	GREEN	
+Erdos503Problem	GREEN	
+Erdos505Problem	RESIDUAL	instance-synth
+Erdos506Problem	GREEN	
+Erdos507Problem	GREEN	
+Erdos508Problem	GREEN	
+Erdos509Problem	RESIDUAL	unknown-const:Complex.abs.map_zero
+Erdos50Problem	GREEN	
+Erdos510Problem	GREEN	
+Erdos512Aristotle	RESIDUAL	unknown-const:MeasureTheory.integrableOn_const.mpr
+Erdos512Problem	RESIDUAL	unknown-const:MeasureTheory.integrableOn_const.mpr
+Erdos514Problem	GREEN	
+Erdos515Problem	RESIDUAL	parse-error
+Erdos516Problem	GREEN	
+Erdos519Problem	GREEN	
+Erdos51Problem	GREEN	
+Erdos520Problem	GREEN	
+Erdos521Problem	GREEN	
+Erdos522Problem	GREEN	
+Erdos523Problem	RESIDUAL	unknown-const:halasz_theorem
+Erdos524Problem	GREEN	
+Erdos525OQ02	GREEN	
+Erdos525Problem	RESIDUAL	instance-synth
+Erdos526Problem	GREEN	
+Erdos527Problem	GREEN	
+Erdos528Problem	GREEN	
+Erdos529Problem	PRE-EXISTING	never-compiled:d_2
+Erdos52Problem	GREEN	
+Erdos530Problem	RESIDUAL	unknown-const:komlos_sulyok_szemeredi
+Erdos531Problem	GREEN	
+Erdos532Problem	GREEN	
+Erdos533Problem	RESIDUAL	type-mismatch
+Erdos534Problem	GREEN	
+Erdos535Problem	GREEN	
+Erdos536Problem	GREEN	
+Erdos537Problem	RESIDUAL	type-mismatch
+Erdos538Problem	GREEN	
+Erdos539Problem	GREEN	
+Erdos53Problem	GREEN	
+Erdos540Problem	GREEN	
+Erdos541Problem	GREEN	
+Erdos542Problem	GREEN	
+Erdos543Problem	RESIDUAL	proof-drift
+Erdos545Problem	GREEN	
+Erdos546Problem	GREEN	
+Erdos547Problem	GREEN	
+Erdos548Aristotle	RESIDUAL	instance-synth
+Erdos548Problem	GREEN	
+Erdos548ProblemAristotle	GREEN	
+Erdos549Problem	RESIDUAL	instance-synth
+Erdos549ProblemAristotle	RESIDUAL	type-mismatch
+Erdos54Problem	GREEN	
+Erdos550Problem	GREEN	
+Erdos551Problem	RESIDUAL	instance-synth
+Erdos551ProblemAristotle	RESIDUAL	proof-drift
+Erdos552Aristotle	RESIDUAL	parse-error
+Erdos552Problem	RESIDUAL	parse-error
+Erdos553Aristotle	GREEN	
+Erdos553Problem	GREEN	
+Erdos553ProblemAristotle	GREEN	
+Erdos554Problem	GREEN	
+Erdos555Problem	GREEN	
+Erdos556Problem	RESIDUAL	type-mismatch
+Erdos557Problem	RESIDUAL	type-mismatch
+Erdos558Problem	GREEN	
+Erdos559Aristotle	GREEN	
+Erdos559Problem	RESIDUAL	instance-synth
+Erdos55Problem	GREEN	
+Erdos560Problem	RESIDUAL	elab-drift
+Erdos561Problem	GREEN	
+Erdos562Problem	GREEN	
+Erdos563Problem	GREEN	
+Erdos565Problem	GREEN	
+Erdos566Problem	GREEN	
+Erdos567Problem	GREEN	
+Erdos568Problem	GREEN	
+Erdos569Problem	GREEN	
+Erdos570Problem	RESIDUAL	type-mismatch
+Erdos571Problem	RESIDUAL	instance-synth
+Erdos572Problem	GREEN	
+Erdos573Problem	GREEN	
+Erdos575Problem	GREEN	
+Erdos576Problem	GREEN	
+Erdos577Problem	GREEN	
+Erdos578Problem	GREEN	
+Erdos579Problem	GREEN	
+Erdos57OddClosedWalk	GREEN	
+Erdos57OddGirthBound	GREEN	
+Erdos57Problem	GREEN	
+Erdos57ProblemAristotle	GREEN	
+Erdos580Problem	RESIDUAL	type-mismatch
+Erdos581Problem	GREEN	
+Erdos582Problem	GREEN	
+Erdos583Problem	RESIDUAL	proof-drift
+Erdos584Problem	GREEN	
+Erdos585Problem	GREEN	
+Erdos586Problem	GREEN	
+Erdos587Problem	GREEN	
+Erdos588Problem	GREEN	
+Erdos58Problem	GREEN	
+Erdos590Problem	GREEN	
+Erdos591Problem	GREEN	
+Erdos592Problem	RESIDUAL	instance-synth
+Erdos593Problem	GREEN	
+Erdos594Problem	GREEN	
+Erdos595Problem	GREEN	
+Erdos596Problem	GREEN	
+Erdos597Problem	GREEN	
+Erdos598Problem	RESIDUAL	elab-drift
+Erdos599Problem	GREEN	
+Erdos59Problem	RESIDUAL	unknown-const:Set.mem_union.mp
+Erdos5Problem	GREEN	
+Erdos600Problem	GREEN	
+Erdos601Aristotle	RESIDUAL	unknown-const:Ordinal.zero_or_succ_or_limit
+Erdos601Problem	RESIDUAL	instance-synth
+Erdos603Problem	GREEN	
+Erdos604Problem	RESIDUAL	parse-error
+Erdos605Problem	GREEN	
+Erdos606OQ03	RESIDUAL	unknown-const:Nat.lt_choose_self
+Erdos606Problem	GREEN	
+Erdos607Problem	GREEN	
+Erdos608Problem	RESIDUAL	parse-error
+Erdos608ProblemAristotle	GREEN	
+Erdos609Problem	GREEN	
+Erdos60Problem	RESIDUAL	type-mismatch
+Erdos610Aristotle	RESIDUAL	instance-synth
+Erdos610Problem	RESIDUAL	instance-synth
+Erdos610ProblemAristotle	RESIDUAL	instance-synth
+Erdos611Aristotle	RESIDUAL	instance-synth
+Erdos611Problem	RESIDUAL	instance-synth
+Erdos611ProblemAristotle	RESIDUAL	instance-synth
+Erdos612Problem	GREEN	
+Erdos612ProblemAristotle	RESIDUAL	unknown-const:Filter.Tendsto.const_mul_zero
+Erdos613Aristotle	RESIDUAL	instance-synth
+Erdos613Problem	GREEN	
+Erdos613ProblemAristotle	RESIDUAL	instance-synth
+Erdos614Problem	RESIDUAL	instance-synth
+Erdos615Problem	GREEN	
+Erdos616Problem	GREEN	
+Erdos617Problem	GREEN	
+Erdos618Problem	GREEN	
+Erdos619Problem	RESIDUAL	instance-synth
+Erdos61Problem	GREEN	
+Erdos620Aristotle	GREEN	
+Erdos620Problem	RESIDUAL	type-mismatch
+Erdos620ProblemAristotle	RESIDUAL	type-mismatch
+Erdos621Problem	GREEN	
+Erdos622OQ04	RESIDUAL	instance-synth
+Erdos622Problem	RESIDUAL	instance-synth
+Erdos623Aristotle	GREEN	
+Erdos623Problem	RESIDUAL	unknown-const:Cardinal.isLimit_aleph
+Erdos623ProblemAristotle	RESIDUAL	unknown-const:Cardinal.isLimit_aleph
+Erdos625Aristotle	RESIDUAL	instance-synth
+Erdos625Problem	RESIDUAL	instance-synth
+Erdos625ProblemAristotle	RESIDUAL	instance-synth
+Erdos626Aristotle	GREEN	
+Erdos626Problem	GREEN	
+Erdos626ProblemAristotle	GREEN	
+Erdos627Aristotle	GREEN	
+Erdos627Problem	GREEN	
+Erdos627ProblemAristotle	GREEN	
+Erdos628Aristotle	RESIDUAL	instance-synth
+Erdos628Problem	GREEN	
+Erdos628ProblemAristotle	GREEN	
+Erdos629Aristotle	RESIDUAL	unknown-const:Nat.sInf
+Erdos629Problem	RESIDUAL	type-mismatch
+Erdos630Aristotle	GREEN	
+Erdos630Problem	GREEN	
+Erdos630ProblemAristotle	GREEN	
+Erdos631Aristotle	GREEN	
+Erdos631Problem	GREEN	
+Erdos631ProblemAristotle	GREEN	
+Erdos632Aristotle	GREEN	
+Erdos634Aristotle	GREEN	
+Erdos634Problem	GREEN	
+Erdos635Problem	RESIDUAL	unknown-const:f_set_nonempty
+Erdos636Aristotle	GREEN	
+Erdos636Problem	GREEN	
+Erdos636ProblemAristotle	GREEN	
+Erdos637Aristotle	GREEN	
+Erdos637Problem	GREEN	
+Erdos637ProblemAristotle	GREEN	
+Erdos638Problem	GREEN	
+Erdos639Problem	GREEN	
+Erdos63Problem	GREEN	
+Erdos640Problem	RESIDUAL	type-mismatch
+Erdos641Problem	GREEN	
+Erdos642Aristotle	RESIDUAL	unknown-const:SimpleGraph.edgeFinset_card_le
+Erdos642Problem	RESIDUAL	parse-error
+Erdos643Problem	RESIDUAL	signature-drift
+Erdos644Problem	GREEN	
+Erdos644ProblemAristotle	GREEN	
+Erdos645Problem	GREEN	
+Erdos646Problem	GREEN	
+Erdos648Problem	GREEN	
+Erdos649Problem	GREEN	
+Erdos64Problem	GREEN	
+Erdos650Problem	GREEN	
+Erdos651Problem	GREEN	
+Erdos652Problem	RESIDUAL	unknown-const:Real.lt_top
+Erdos654Problem	GREEN	
+Erdos655Problem	GREEN	
+Erdos656Problem	GREEN	
+Erdos657Problem	GREEN	
+Erdos658Problem	GREEN	
+Erdos65OQ03	GREEN	
+Erdos65Problem	GREEN	
+Erdos660Aristotle	RESIDUAL	proof-drift
+Erdos661Problem	RESIDUAL	unknown-const:q
+Erdos662Problem	RESIDUAL	noncomputable
+Erdos663Problem	GREEN	
+Erdos664Problem	GREEN	
+Erdos665Problem	GREEN	
+Erdos666Problem	GREEN	
+Erdos667Aristotle	GREEN	
+Erdos667Problem	RESIDUAL	instance-synth
+Erdos668Problem	GREEN	
+Erdos669Problem	RESIDUAL	instance-synth
+Erdos66Problem	GREEN	
+Erdos670Problem	RESIDUAL	instance-synth
+Erdos671Problem	GREEN	
+Erdos671ProblemAristotle	GREEN	
+Erdos672Problem	GREEN	
+Erdos673Aristotle	RESIDUAL	type-mismatch
+Erdos673Problem	GREEN	
+Erdos674Aristotle	RESIDUAL	unknown-const:Nat.Prime.dvd_gcd
+Erdos674Problem	GREEN	
+Erdos674ProblemAristotle	GREEN	
+Erdos675Problem	GREEN	
+Erdos676Problem	GREEN	
+Erdos677Problem	GREEN	
+Erdos678Aristotle	RESIDUAL	unknown-const:Erdos678.intervalLcm_eq_intervalLcm'
+Erdos678Problem	GREEN	
+Erdos679Aristotle	RESIDUAL	type-mismatch
+Erdos679Problem	GREEN	
+Erdos679ProblemAristotle	RESIDUAL	proof-drift
+Erdos67Problem	GREEN	
+Erdos680Problem	RESIDUAL	unknown-const:Real.tendsto_pow_mul_exp_neg_atTop_nhds
+Erdos681Problem	GREEN	
+Erdos682Problem	RESIDUAL	type-mismatch
+Erdos683Problem	GREEN	
+Erdos684Problem	RESIDUAL	partenat-removal
+Erdos685Problem	GREEN	
+Erdos687Problem	RESIDUAL	type-mismatch
+Erdos688Problem	GREEN	
+Erdos690Problem	GREEN	
+Erdos691Problem	GREEN	
+Erdos692Problem	GREEN	
+Erdos693Problem	RESIDUAL	unknown-const:Finset.sort_sorted
+Erdos694Problem	GREEN	
+Erdos696Problem	GREEN	
+Erdos697Problem	GREEN	
+Erdos698Problem	GREEN	
+Erdos699Problem	GREEN	
+Erdos69Problem	RESIDUAL	proof-drift
+Erdos6Problem	GREEN	
+Erdos700Problem	RESIDUAL	unknown-const:Nat.Prime.multiplicity_choose
+Erdos701Problem	PRE-EXISTING	never-compiled:A
+Erdos702Problem	GREEN	
+Erdos704Problem	RESIDUAL	type-mismatch
+Erdos705Problem	GREEN	
+Erdos706Problem	GREEN	
+Erdos707Problem	GREEN	
+Erdos708Problem	GREEN	
+Erdos709Problem	GREEN	
+Erdos70OQ01Problem	RESIDUAL	unknown-const:Ordinal.mul_lt_mul_of_pos_left
+Erdos70Problem	GREEN	
+Erdos710Problem	GREEN	
+Erdos711Problem	GREEN	
+Erdos712Problem	GREEN	
+Erdos713Problem	PRE-EXISTING	never-compiled:n
+Erdos714Problem	GREEN	
+Erdos715Problem	RESIDUAL	parse-error
+Erdos715ProblemAristotle	RESIDUAL	parse-error
+Erdos716Problem	GREEN	
+Erdos717Problem	GREEN	
+Erdos718Problem	GREEN	
+Erdos719Problem	PRE-EXISTING	never-compiled:H.edges
+Erdos71Problem	GREEN	
+Erdos720Problem	RESIDUAL	proof-drift
+Erdos721Problem	GREEN	
+Erdos722Problem	GREEN	
+Erdos723Problem	RESIDUAL	proof-drift
+Erdos724Problem	RESIDUAL	parse-error
+Erdos725Problem	GREEN	
+Erdos726Problem	RESIDUAL	unknown-const:Nat.Prime.not_dvd_of_lt
+Erdos727Problem	GREEN	
+Erdos728Problem	RESIDUAL	proof-drift
+Erdos72Aristotle	GREEN	
+Erdos72Problem	GREEN	
+Erdos730Problem	RESIDUAL	rewrite-drift
+Erdos731Problem	GREEN	
+Erdos732Problem	RESIDUAL	instance-synth
+Erdos733LimitBounds	RESIDUAL	unknown-const:Nat.one_lt_of_ne_one
+Erdos733Problem	RESIDUAL	unknown-const:Nat.one_lt_of_ne_one
+Erdos734Problem	GREEN	
+Erdos736Problem	GREEN	
+Erdos737Problem	GREEN	
+Erdos738Problem	RESIDUAL	unclassified
+Erdos739Problem	GREEN	
+Erdos73Aristotle	GREEN	
+Erdos73Problem	RESIDUAL	type-mismatch
+Erdos740Problem	RESIDUAL	instance-synth
+Erdos740ProblemProvable	RESIDUAL	instance-synth
+Erdos741Problem	RESIDUAL	rewrite-drift
+Erdos741ProblemAPNPartI	RESIDUAL	unknown-const:ingleton
+Erdos742Problem	GREEN	
+Erdos743Problem	GREEN	
+Erdos745Problem	GREEN	
+Erdos747Problem	GREEN	
+Erdos749Problem	RESIDUAL	unknown-const:le_liminf_of_le
+Erdos74Problem	GREEN	
+Erdos750Problem	GREEN	
+Erdos751Problem	RESIDUAL	type-mismatch
+Erdos752Problem	RESIDUAL	instance-synth
+Erdos753Problem	GREEN	
+Erdos754Problem	GREEN	
+Erdos756Problem	GREEN	
+Erdos757Problem	RESIDUAL	unknown-const:Set.Finite.toFinset_card
+Erdos758Problem	GREEN	
+Erdos75Problem	GREEN	
+Erdos760Problem	GREEN	
+Erdos761Problem	GREEN	
+Erdos762Problem	GREEN	
+Erdos763Problem	GREEN	
+Erdos764Problem	GREEN	
+Erdos765Problem	GREEN	
+Erdos766Problem	RESIDUAL	parse-error
+Erdos767Problem	GREEN	
+Erdos768Problem	GREEN	
+Erdos769Problem	GREEN	
+Erdos76OQ02	GREEN	
+Erdos770Problem	PRE-EXISTING	never-compiled:X
+Erdos771Problem	GREEN	
+Erdos772Problem	GREEN	
+Erdos773Problem	RESIDUAL	unknown-const:pow_lt_pow_left
+Erdos774Problem	GREEN	
+Erdos775Problem	RESIDUAL	instance-synth
+Erdos776Problem	RESIDUAL	instance-synth
+Erdos777Problem	GREEN	
+Erdos778Problem	GREEN	
+Erdos779Problem	GREEN	
+Erdos77Problem	GREEN	
+Erdos780Aristotle	RESIDUAL	unknown-const:Finset.disjoint_compl_right
+Erdos780Problem	RESIDUAL	signature-drift
+Erdos781Problem	RESIDUAL	proof-drift
+Erdos782Problem	RESIDUAL	type-mismatch
+Erdos783Problem	RESIDUAL	instance-synth
+Erdos784Problem	GREEN	
+Erdos785Problem	GREEN	
+Erdos786Problem	GREEN	
+Erdos787Problem	GREEN	
+Erdos788Problem	GREEN	
+Erdos789Problem	GREEN	
+Erdos790Problem	GREEN	
+Erdos791Problem	GREEN	
+Erdos792Problem	GREEN	
+Erdos794Problem	RESIDUAL	type-mismatch
+Erdos795Aristotle	GREEN	
+Erdos795Problem	GREEN	
+Erdos795ProblemAristotle	GREEN	
+Erdos796Problem	RESIDUAL	type-mismatch
+Erdos797Problem	GREEN	
+Erdos798Aristotle	RESIDUAL	proof-drift
+Erdos799Problem	GREEN	
+Erdos79Incomplete01	GREEN	signature-drift
+Erdos79Incomplete01OQ01	GREEN	
+Erdos79Problem	GREEN	
+Erdos79ProblemAristotle	GREEN	
+Erdos800Problem	GREEN	
+Erdos801Problem	GREEN	
+Erdos802Problem	GREEN	
+Erdos803Problem	RESIDUAL	instance-synth
+Erdos804Problem	RESIDUAL	instance-synth
+Erdos805Problem	GREEN	
+Erdos806Problem	GREEN	
+Erdos807Problem	RESIDUAL	dot-notation-drift
+Erdos808Problem	GREEN	
+Erdos809Problem	GREEN	
+Erdos80Problem	GREEN	
+Erdos810Problem	GREEN	
+Erdos811Problem	GREEN	
+Erdos812Problem	GREEN	
+Erdos813Problem	RESIDUAL	parse-error
+Erdos814Problem	RESIDUAL	instance-synth
+Erdos816Problem	GREEN	
+Erdos817Aristotle	RESIDUAL	type-mismatch
+Erdos817Problem	RESIDUAL	proof-drift
+Erdos818Aristotle	RESIDUAL	instance-synth
+Erdos819Problem	GREEN	
+Erdos81Problem	RESIDUAL	instance-synth
+Erdos820Aristotle	GREEN	
+Erdos820Problem	GREEN	
+Erdos821Problem	GREEN	
+Erdos822Problem	RESIDUAL	instance-synth
+Erdos823Problem	RESIDUAL	unknown-const:ArithmeticFunction.totient
+Erdos824Problem	GREEN	
+Erdos824ProblemProvable	RESIDUAL	type-mismatch
+Erdos825Problem	GREEN	
+Erdos826Problem	GREEN	
+Erdos827Problem	RESIDUAL	unknown-const:allDistinctCircumradii_subset
+Erdos829Problem	RESIDUAL	unknown-const:hardy_ramanujan_1729
+Erdos82Problem	GREEN	
+Erdos830Problem	GREEN	
+Erdos831Problem	PRE-EXISTING	never-compiled:p_e1
+Erdos832Problem	PRE-EXISTING	never-compiled:V
+Erdos833Problem	GREEN	
+Erdos834Problem	GREEN	
+Erdos835Problem	GREEN	
+Erdos836Problem	GREEN	
+Erdos838Problem	RESIDUAL	noncomputable
+Erdos839Problem	GREEN	
+Erdos841Problem	GREEN	
+Erdos842Problem	GREEN	
+Erdos843Problem	GREEN	
+Erdos844Problem	GREEN	
+Erdos845Problem	GREEN	
+Erdos846Problem	RESIDUAL	type-mismatch
+Erdos846ProblemAPN	GREEN	
+Erdos847Problem	RESIDUAL	proof-drift
+Erdos848Problem	GREEN	
+Erdos848ProblemOQ01	GREEN	
+Erdos849Problem	GREEN	
+Erdos84Problem	GREEN	
+Erdos850Problem	RESIDUAL	noncomputable
+Erdos851Problem	GREEN	
+Erdos852Problem	GREEN	
+Erdos853Problem	GREEN	
+Erdos854Problem	RESIDUAL	type-mismatch
+Erdos855Problem	GREEN	
+Erdos856Problem	PRE-EXISTING	never-compiled:A
+Erdos857Problem	RESIDUAL	unknown-const:mem_empty_iff_false
+Erdos858Problem	GREEN	
+Erdos859Aristotle	RESIDUAL	instance-synth
+Erdos859Problem	RESIDUAL	proof-drift
+Erdos859ProblemAristotle	RESIDUAL	proof-drift
+Erdos85Problem	GREEN	
+Erdos860Problem	GREEN	
+Erdos860ProblemAristotle	GREEN	
+Erdos861Problem	RESIDUAL	instance-synth
+Erdos862Problem	GREEN	
+Erdos863Aristotle	RESIDUAL	parse-error
+Erdos863Problem	RESIDUAL	type-mismatch
+Erdos864Problem	RESIDUAL	unknown-const:sumRepCount_le_of_subset
+Erdos865Problem	GREEN	
+Erdos866Aristotle	GREEN	
+Erdos867Problem	RESIDUAL	unknown-const:Finset.card_Ioc
+Erdos868Problem	GREEN	
+Erdos869Problem	GREEN	
+Erdos86Problem	RESIDUAL	parse-error
+Erdos870Aristotle	RESIDUAL	uses-sorry
+Erdos870Problem	GREEN	
+Erdos871Problem	GREEN	
+Erdos872Problem	GREEN	
+Erdos873Problem	GREEN	
+Erdos873ProblemProvable	RESIDUAL	proof-drift
+Erdos874Problem	RESIDUAL	proof-drift
+Erdos875Problem	RESIDUAL	unknown-const:Ne.lt_or_lt
+Erdos876Problem	GREEN	
+Erdos876ProblemAristotle	GREEN	
+Erdos877ProblemAristotle	GREEN	
+Erdos878Problem	RESIDUAL	instance-synth
+Erdos879Problem	GREEN	
+Erdos87Problem	GREEN	
+Erdos880Problem	GREEN	
+Erdos882Problem	GREEN	
+Erdos882ProblemOQ03	PRE-EXISTING	never-compiled:a
+Erdos882ProblemOQ03OQ02	GREEN	
+Erdos883Problem	GREEN	
+Erdos884Problem	GREEN	
+Erdos885Problem	GREEN	
+Erdos886Problem	GREEN	
+Erdos887Problem	GREEN	
+Erdos888Problem	GREEN	
+Erdos889Problem	GREEN	
+Erdos88Problem	RESIDUAL	type-mismatch
+Erdos890Problem	RESIDUAL	unknown-const:p
+Erdos893Problem	RESIDUAL	proof-drift
+Erdos894Problem	GREEN	
+Erdos895CounterexampleFin18	GREEN	
+Erdos895OQ01Problem	GREEN	
+Erdos895Problem	GREEN	
+Erdos895ProblemAristotle	RESIDUAL	proof-drift
+Erdos896Problem	RESIDUAL	unknown-const:Finset.product_singleton_right
+Erdos89Problem	GREEN	
+Erdos8OQ02	GREEN	
+Erdos8Problem	RESIDUAL	unknown-const:bottleneck_counterexample
+Erdos900Problem	RESIDUAL	proof-drift
+Erdos901Aristotle	GREEN	
+Erdos901Problem	GREEN	
+Erdos901ProblemAristotle	GREEN	
+Erdos902Problem	GREEN	
+Erdos903Problem	RESIDUAL	proof-drift
+Erdos904Problem	GREEN	
+Erdos905Problem	GREEN	
+Erdos906Problem	GREEN	
+Erdos907Problem	GREEN	
+Erdos908Problem	GREEN	
+Erdos909OQ01Problem	GREEN	
+Erdos909Problem	GREEN	
+Erdos90Problem	GREEN	
+Erdos910Problem	RESIDUAL	dot-notation-drift
+Erdos910ProblemProvable	RESIDUAL	dot-notation-drift
+Erdos911Problem	RESIDUAL	proof-drift
+Erdos912Problem	GREEN	
+Erdos913Problem	RESIDUAL	proof-drift
+Erdos914Problem	GREEN	
+Erdos915Problem	RESIDUAL	proof-drift
+Erdos916Problem	RESIDUAL	proof-drift
+Erdos917Problem	GREEN	
+Erdos918Problem	GREEN	
+Erdos919Problem	RESIDUAL	proof-drift
+Erdos91Problem	GREEN	
+Erdos920Problem	GREEN	
+Erdos921Problem	RESIDUAL	type-mismatch
+Erdos922Aristotle	RESIDUAL	unknown-const:Nat.le_or_lt
+Erdos922Problem	RESIDUAL	instance-synth
+Erdos923Problem	GREEN	
+Erdos924Problem	GREEN	
+Erdos925Problem	GREEN	
+Erdos926Problem	GREEN	
+Erdos927Problem	RESIDUAL	termination-drift
+Erdos928Problem	GREEN	
+Erdos92Problem	GREEN	
+Erdos930Problem	GREEN	
+Erdos932Problem	GREEN	
+Erdos933Problem	GREEN	
+Erdos933ProblemAristotle	GREEN	
+Erdos934Problem	GREEN	
+Erdos934ProblemAristotle	RESIDUAL	proof-drift
+Erdos935Problem	GREEN	
+Erdos936Problem	RESIDUAL	unknown-const:Nat.pow_dvd_pow_of_dvd
+Erdos937Problem	RESIDUAL	proof-drift
+Erdos939Problem	GREEN	
+Erdos940Problem	RESIDUAL	unknown-const:Finset.card_Ioc
+Erdos942Problem	GREEN	
+Erdos943Problem	RESIDUAL	type-mismatch
+Erdos944Problem	GREEN	
+Erdos945Problem	GREEN	
+Erdos946Problem	GREEN	
+Erdos947Problem	GREEN	
+Erdos948Problem	GREEN	
+Erdos949Problem	GREEN	
+Erdos94OQ02	RESIDUAL	instance-synth
+Erdos94Problem	GREEN	
+Erdos950Problem	GREEN	
+Erdos953Problem	GREEN	
+Erdos954Problem	GREEN	
+Erdos955Problem	GREEN	
+Erdos956Aristotle	GREEN	
+Erdos956Problem	GREEN	
+Erdos957Problem	RESIDUAL	proof-drift
+Erdos958Problem	GREEN	
+Erdos959Problem	GREEN	
+Erdos95Problem	RESIDUAL	type-mismatch
+Erdos960Problem	RESIDUAL	unknown-const:p
+Erdos961Problem	RESIDUAL	unknown-const:Nat.primFactors
+Erdos962Problem	GREEN	
+Erdos963Problem	RESIDUAL	unknown-const:greedy_dissociated
+Erdos964Aristotle	RESIDUAL	unknown-const:Nat.divisors_prime
+Erdos964Problem	RESIDUAL	rewrite-drift
+Erdos965Problem	GREEN	
+Erdos966Problem	RESIDUAL	type-mismatch
+Erdos967Problem	RESIDUAL	proof-drift
+Erdos968Problem	RESIDUAL	noncomputable
+Erdos969Problem	RESIDUAL	unknown-const:Nat.Prime.squarefree
+Erdos96Problem	GREEN	
+Erdos970Problem	GREEN	
+Erdos971Problem	GREEN	
+Erdos973Problem	RESIDUAL	instance-synth
+Erdos974Problem	GREEN	
+Erdos975Problem	GREEN	
+Erdos976Problem	GREEN	
+Erdos977Aristotle	GREEN	
+Erdos977Problem	GREEN	
+Erdos977ProblemAristotle	RESIDUAL	rewrite-drift
+Erdos978Problem	RESIDUAL	parse-error
+Erdos979Problem	GREEN	
+Erdos97Problem	GREEN	
+Erdos980Problem	RESIDUAL	unknown-const:Nat.Prime.nthPrime
+Erdos981Problem	GREEN	
+Erdos982Problem	GREEN	
+Erdos983Problem	GREEN	
+Erdos984Problem	GREEN	
+Erdos986Problem	GREEN	
+Erdos987Problem	GREEN	
+Erdos988Problem	RESIDUAL	instance-synth
+Erdos989Problem	RESIDUAL	proof-drift
+Erdos98Problem	GREEN	
+Erdos990Problem	GREEN	
+Erdos992Problem	GREEN	
+Erdos993Problem	GREEN	
+Erdos994Problem	GREEN	
+Erdos995Problem	GREEN	
+Erdos996Problem	GREEN	
+Erdos997Problem	RESIDUAL	unknown-const:sub_floor_div_mul_nonneg
+Erdos998Problem	GREEN	
+Erdos999Problem	GREEN	
+Erdos99Problem	RESIDUAL	type-mismatch
+Erdos9Problem	GREEN	
+ErdosKoRado	RESIDUAL	signature-drift
+ErdosMordellChordIdentity	RESIDUAL	proof-drift
+ErdosMordellInequalityOQ01	RESIDUAL	proof-drift
+ErdosRamseyLowerBound	GREEN	
+EulerIdentityOQ01	RESIDUAL	proof-drift
+EulerIdentityOQ01OQ02OQ01	RESIDUAL	instance-synth
+EulerPolyhedralFormula	RESIDUAL	proof-drift
+EulerPolyhedralFormulaOQ01OQ02	RESIDUAL	unknown-const:SimpleGraph.Colorable.mk
+EulerPolyhedralOQ01OQ04	GREEN	
+EulerTotientOQ01OQ01OQ01	RESIDUAL	rewrite-drift
+EulerTotientOQ01OQ02OQ01	GREEN	
+EulerTotientOQ01OQ02OQ02	GREEN	
+EulerTotientOQ01OQ02OQ03	GREEN	
+EulerTotientOQ02	GREEN	
+EulerTotientOQ02OQ01	GREEN	
+EulerTotientOQ02OQ02OQ01	RESIDUAL	rewrite-drift
+EulerTotientOQ06OQ02	GREEN	
+FactorRemainderNullstellensatzOQ01	RESIDUAL	instance-synth
+FactorRemainderNullstellensatzOQ02	RESIDUAL	unknown-const:card_roots_le_degree
+FactorRemainderTheorem	GREEN	parse-error
+FactorRemainderTheoremOQ01OQ01OQ02	RESIDUAL	proof-drift
+FactorRemainderTheoremOQ02	GREEN	
+FactorRemainderTheoremOQ03	RESIDUAL	unknown-const:Polynomial.card_roots_le_degree
+FairGamesTheorem	RESIDUAL	type-mismatch
+FairGamesTheoremOQ02	RESIDUAL	proof-drift
+FairGamesTheoremOQ02OQ01	RESIDUAL	type-mismatch
+FairGamesTheoremOQ02OQ01OQ01	RESIDUAL	type-mismatch
+FairGamesTheoremOQ03	RESIDUAL	type-mismatch
+FairGamesTheoremOQ03Aristotle	RESIDUAL	type-mismatch
+FatouLemmaOQ01OQ02	GREEN	
+FermatTwoSquaresOQ04	GREEN	
+FermatTwoSquaresOQ04OQ01	GREEN	
+FermatsLastTheoremOQ03	RESIDUAL	type-mismatch
+FeuerbachsTheoremDefsOQ04	RESIDUAL	type-mismatch
+FeuerbachsTheoremOQ01Aristotle	GREEN	
+FeuerbachsTheoremOQ01OQ03	RESIDUAL	unknown-const:h1
+FeuerbachsTheoremOQ04TangentLine	GREEN	
+FeuerbachsTheoremOQ05	RESIDUAL	dot-notation-drift
+FibonacciIdentitiesOQ02	GREEN	
+FibonacciIdentitiesOQ02OQ02PrimeIndex	GREEN	
+FiveColorTheorem	GREEN	
+FourColorTheorem	GREEN	
+FourColorTheoremOQ01	RESIDUAL	unknown-const:Finset.ne_univ_iff_exists_notMem
+FourColorTheoremOQ02	GREEN	
+FourSquareDistributionOQ01	GREEN	
+FourSquareDistributionOQ04Arrange	GREEN	
+FourSquareDistributionOQ04ArrangeProof	GREEN	
+FourSquareDistributionOQ04Bridge	GREEN	
+FourSquareDistributionOQ04Decomp	GREEN	
+FourSquareDistributionOQ04Keystone	GREEN	
+FourierSeriesOQ01	RESIDUAL	rewrite-drift
+FourierSeriesOQ02	RESIDUAL	unclassified
+FourierSeriesOQ02Incomplete01	GREEN	
+FourierSeriesOQ02OQ02	RESIDUAL	unclassified
+FourierSeriesOQ02OQ03	RESIDUAL	proof-drift
+FourierSeriesOQ02OQ03OQ02	RESIDUAL	unknown-const:Real.exp_le_one_of_nonpos
+FourierSeriesOQ02OQ03WIP01	GREEN	
+FourierSeriesOQ02OQ04	RESIDUAL	unclassified
+FourierSeriesOQ04	GREEN	
+FourierSeriesOQ04OQ01	RESIDUAL	type-mismatch
+FourierSeriesOQ04OQ01Incomplete01	RESIDUAL	type-mismatch
+FourthRoot2Degree4OQ02	RESIDUAL	unknown-const:FourthRoot2Degree4OQ02.finrank_adjoin_eq
+FourthRoot2GaloisClosure	GREEN	
+FourthRoot2GaloisClosureOQ03	GREEN	
+FourthRoot2SplittingFieldOQ01	GREEN	
+FriendshipTheorem	GREEN	
+FriendshipTheoremOQ01	GREEN	
+FriendshipTheoremOQ01OQ02	RESIDUAL	proof-drift
+FriendshipTheoremOQ03	GREEN	
+FriendshipTheoremOQ04	GREEN	
+FriendshipTheoremOQ04Amalgam	GREEN	
+FriendshipTheoremOQ04Universal	GREEN	
+FrobeniusNumber	GREEN	
+FrobeniusNumberOQ01	RESIDUAL	type-mismatch
+FrobeniusNumberOQ01OQ03	GREEN	
+FrobeniusNumberOQ01OQ03OQ01	GREEN	
+FrobeniusNumberOQ01OQ04	GREEN	
+FrobeniusNumberOQ02	GREEN	
+FrobeniusNumberOQ02OQ01	GREEN	
+FrobeniusNumberOQ02OQ02	GREEN	
+FrobeniusNumberOQ03	GREEN	
+FundamentalArithmetic	GREEN	
+FundamentalArithmeticOQ01	RESIDUAL	unknown-const:Nat.coprime_iff_disjoint.mp
+FundamentalArithmeticOQ02	RESIDUAL	unknown-const:Zsqrtd.mul_def
+FundamentalTheoremAlgebra	RESIDUAL	type-mismatch
+FundamentalTheoremAlgebraOQ04OQ03OQ01OQ01	GREEN	
+FundamentalTheoremAlgebraOQ04OQ03OQ01OQ02	GREEN	
+FundamentalTheoremAlgebraOQ04OQ04	RESIDUAL	parse-error
+FundamentalTheoremCalculus	GREEN	
+FundamentalTheoremCalculusLebesgueOQ04	RESIDUAL	elab-drift
+FundamentalTheoremCalculusOQ04	GREEN	
+FundamentalTheoremCalculusStokes	RESIDUAL	type-mismatch
+FundamentalTheoremCalculusStokesAristotle	RESIDUAL	unclassified
+FurstenbergCorrespondence	RESIDUAL	type-mismatch
+FurstenbergCorrespondenceOQ01	RESIDUAL	instance-synth
+FurstenbergCorrespondenceOQ02	RESIDUAL	parse-error
+GCDAlgorithmOQ01OQ03OQ01	GREEN	
+GCDAlgorithmOQ01OQ03OQ01OQ01	RESIDUAL	type-mismatch
+GcdAlgorithmOQ02	GREEN	
+GcdAlgorithmOQ02OQ01	GREEN	
+GelfondSchneider	GREEN	
+GeneralQuartic	GREEN	
+GeneralQuarticAxiomsDischarge	RESIDUAL	type-mismatch
+GeometricSeries	GREEN	
+GeometricSeriesOQ01	GREEN	
+GeometricSeriesOQ01Neumann	GREEN	
+GeometricSeriesOQ01OQ02	GREEN	
+GeometricSeriesOQ02OQ03	RESIDUAL	type-mismatch
+GeometricSeriesOQ02OQ05	RESIDUAL	rewrite-drift
+GeometricSeriesOQ03	RESIDUAL	unknown-const:inv_ne_zero.mpr
+GeometricSeriesOQ07	GREEN	
+GeometricSeriesOQ07OQ01OQ01OQ01OQ06OQ01	GREEN	
+GeometricSeriesOQ07OQ02	GREEN	
+GeometricSeriesOQ08	GREEN	
+GeometricSeriesOQ10	GREEN	
+GoemansWilliamsonMaxCut	GREEN	
+GraphCore	GREEN	
+GreensTheorem	GREEN	
+GreensTheoremOQ01OQ01OQ01OQ01	RESIDUAL	proof-drift
+GreensTheoremOQ01OQ01OQ02	GREEN	
+GreensTheoremOQ01OQ01OQ02OQ01	GREEN	
+GreensTheoremOQ01OQ01OQ02OQ02	GREEN	
+GreensTheoremOQ01OQ01OQ02OQ03	RESIDUAL	unknown-const:MeasureTheory.Measure.prod_mono
+GreensTheoremOQ01OQ01OQ03	GREEN	
+GreensTheoremOQ03OQ04	RESIDUAL	type-mismatch
+GreensTheoremOQ04	RESIDUAL	type-mismatch
+GroupOrderPrimeSquaredAbelianIsoOQ01OQ01OQ02	RESIDUAL	type-mismatch
+HarmonicDivergence	GREEN	
+HarmonicDivergenceOQ02	RESIDUAL	type-mismatch
+HarmonicDivergenceOQ04	RESIDUAL	unknown-const:not_summable_const_of_ne_zero
+HermiteFloorIdentity	GREEN	
+HermiteFloorIdentityOQ01	GREEN	
+HermiteFloorIdentityOQ02	GREEN	
+HermiteFloorIdentityOQ03	GREEN	
+HermiteLegendreFactorial	GREEN	
+HermiteLegendreFactorialOQ01	GREEN	
+HermiteLegendreFactorialOQ02	GREEN	
+HermiteLindemann	GREEN	
+HermiteSawtoothIdentity	GREEN	
+HermiteSawtoothIdentityOQ02	GREEN	
+HeronsFormulaOQ01	GREEN	
+HierholzerAlgorithm	RESIDUAL	type-mismatch
+Hilbert11OQ01Aristotle	GREEN	
+Hilbert11_QuadraticFormsAristotle	GREEN	
+Hilbert14Invariants	GREEN	
+Hilbert14InvariantsOQ01	RESIDUAL	type-mismatch
+Hilbert14NonReductive	RESIDUAL	type-mismatch
+Hilbert15OQ02OQ03OQ01	RESIDUAL	rewrite-drift
+Hilbert15SchubertCalculus	RESIDUAL	unknown-const:finrank
+Hilbert15SchubertCalculusOQ01	RESIDUAL	unknown-const:finrank
+Hilbert16	RESIDUAL	type-mismatch
+Hilbert17OQ01	GREEN	
+Hilbert17RobinsonRationalSOS	GREEN	
+Hilbert19Regularity	GREEN	
+Hilbert20BoundaryValue	GREEN	signature-drift
+Hilbert20LocalSolvability	RESIDUAL	instance-synth
+Hilbert20OQ01OQ03	RESIDUAL	instance-synth
+Hilbert20OQ01OQ03Aristotle	RESIDUAL	type-mismatch
+Hilbert21RiemannHilbert	RESIDUAL	type-mismatch
+Hilbert22OQ01	GREEN	
+Hilbert22OQ01OQ03	GREEN	
+Hilbert22OQ01OQ03Pseudohyperbolic	GREEN	
+Hilbert22OQ01OQ03Universal	RESIDUAL	type-mismatch
+Hilbert22Uniformization	GREEN	
+Hilbert23CalculusVariations	GREEN	
+Hilbert23CalculusVariationsOQ01	RESIDUAL	unknown-const:Ici_diff_left
+Hilbert3ScissorsCongruence	GREEN	
+Hilbert4Geodesics	RESIDUAL	instance-synth
+Hilbert5LieGroups	GREEN	elab-drift
+Hilbert5OQ02	RESIDUAL	instance-synth
+Hilbert6PhysicsAxioms	RESIDUAL	type-mismatch
+Hilbert9CyclotomicReciprocity	GREEN	
+Hilbert9QuadraticSubfield	GREEN	
+Hilbert9Reciprocity	GREEN	
+HodgeConjecture	RESIDUAL	proof-drift
+HurwitzTheoremOQ04	RESIDUAL	slow-timeout
+IncidenceCauchySchwarzDual	GREEN	
+InclusionExclusion	GREEN	
+InclusionExclusionSecondBonferroni	RESIDUAL	unknown-const:sieveLayer_eq_sum_choose
+InfinitudePrimes	GREEN	
+InfinitudePrimes4k1	GREEN	
+InfinitudePrimes4k1OQ03	GREEN	
+InfinitudePrimes4k3OQ01	RESIDUAL	parse-error
+InfinitudePrimes4k3OQ01Q12Q24	RESIDUAL	parse-error
+InfinitudePrimes4k3OQ03	GREEN	
+InfinitudePrimesOQ01	GREEN	
+IntermediateValueTheoremOQ03	RESIDUAL	unknown-const:intermediate_value_zero_of_le
+InverseGalois	GREEN	
+InverseGaloisA5	GREEN	
+InverseGaloisA5Dedekind	GREEN	
+InverseGaloisA5DedekindInstantiation	RESIDUAL	instance-synth
+InverseGaloisA5DedekindMod7	GREEN	
+InverseGaloisA5OQ02	GREEN	elab-drift
+InverseGaloisD4	GREEN	
+InverseGaloisD4OQ01	GREEN	
+InverseGaloisD4OQ01External	GREEN	
+InverseGaloisD4OQ02	GREEN	
+InverseGaloisD4OQ02OQ03	GREEN	
+InverseGaloisD4OQ02OQ03OQ01	GREEN	
+InverseGaloisD4OQ02OQ03OQ01OQ01	GREEN	
+InverseGaloisD4OQ02OQ03OQ01OQ01OQ01	GREEN	
+InverseGaloisD4OQ02OQ04	GREEN	
+InverseGaloisD4OQ03	GREEN	
+InverseGaloisF20	RESIDUAL	unknown-const:cyclotomic_5_has_root_in_splitting_field
+InverseGaloisF20OQ02	GREEN	
+InverseGaloisOQ01	GREEN	
+InverseGaloisOQ02	GREEN	
+InverseGaloisOQ03	GREEN	
+InverseGaloisOQ06OQ01	GREEN	
+InverseGaloisOQ06OQ02	GREEN	
+InverseGaloisOQ06OQ02GalBridge	GREEN	
+InverseGaloisOQ06OQ02GapChar	GREEN	
+InverseGaloisOQ06OQ02P11	GREEN	
+IsoperimetricTheorem	RESIDUAL	unknown-const:IsoperimetricTheorem.equality_iff_circle
+IsoperimetricTheoremOQ01	RESIDUAL	unknown-const:cos_lt_one_of_ne_zero
+IsoperimetricTheoremOQ02	GREEN	
+KnightsTourOblique	GREEN	
+KnightsTourObliqueOQ01	GREEN	
+KnightsTourObliqueOQ01OQ02	GREEN	
+KnightsTourObliqueOQ02	GREEN	
+KnightsTourObliqueOQ02Order16	GREEN	
+KnightsTourObliqueOQ02Palindrome	GREEN	
+KnightsTourObliqueOQ02Reverse	GREEN	
+KnightsTourObliqueOQ02ReverseCount	GREEN	
+KnightsTourObliqueOQ03	GREEN	
+Konigsberg	RESIDUAL	unknown-const:Nat.odd_iff_not_even
+KonigsbergOQ01	GREEN	
+KonigsbergOQ01OQ02	RESIDUAL	unknown-const:Finset.card_eq_sum_ones.symm
+KonigsbergOQ01OQ02Recipe	GREEN	
+KonigsbergOQ02	GREEN	
+KonigsbergOQ02OQ01	RESIDUAL	type-mismatch
+KonigsbergOQ02OQ01Aristotle	RESIDUAL	proof-drift
+KonigsbergOQ02OQ01OQ02OQ01Splice	GREEN	
+KonigsbergOQ03	GREEN	
+KonigsbergOQ04	GREEN	
+KroneckersJugendtraum	GREEN	
+KroneckersJugendtraumRealQuadAbelian	GREEN	
+KroneckersJugendtraumStarkRankOne	GREEN	
+KummerTheorem	GREEN	
+KummerTheoremOQ01OQ01	GREEN	
+KummerTheoremOQ02	PRE-EXISTING	never-compiled:n
+KummerTheoremOQ03	RESIDUAL	partenat-removal
+LHopitalOQ02Incomplete01	GREEN	
+LHopitalOQ03	GREEN	
+LHopitalOQ04	GREEN	
+LHopitalOQ04OQ01	GREEN	
+LagrangeFourSquaresOQ01OQ03	RESIDUAL	noncomputable
+LagrangeFourSquaresOQ02	RESIDUAL	proof-drift
+LagrangeFourSquaresOQ02OQ02	GREEN	
+LagrangeFourSquaresOQ04	RESIDUAL	proof-drift
+LagrangeFourSquaresOQ05	GREEN	
+LagrangeTheorem	GREEN	
+LagrangeTheoremOQ01	RESIDUAL	type-mismatch
+LagrangeTheoremOQ01OQ01	RESIDUAL	rewrite-drift
+LagrangeTheoremOQ01OQ01OQ01	RESIDUAL	rewrite-drift
+LagrangeTheoremOQ01OQ01OQ01ApproachB	RESIDUAL	instance-synth
+LagrangeTheoremOQ01OQ02	RESIDUAL	instance-synth
+LagrangeTheoremOQ01OQ03	RESIDUAL	type-mismatch
+LagrangeTheoremOQ01OQ03OQ01	RESIDUAL	instance-synth
+LagrangeTheoremOQ02OQ01OQ01	GREEN	
+LagrangeTheoremOQ02OQ02	RESIDUAL	unknown-const:ConjClasses.mem_carrier_iff_isConj
+LagrangeTheoremOQ02OQ02OQ01	RESIDUAL	unknown-const:ConjClasses.mem_carrier_iff_isConj
+LagrangeTheoremOQ03	GREEN	
+LagrangeTheoremOQ03OQ02	GREEN	
+LagrangeTheoremOQ05	GREEN	
+LawOfCosines	GREEN	
+LawOfCosinesOQ01OQ01OQ01	GREEN	
+LawOfCosinesOQ01OQ01OQ03	RESIDUAL	type-mismatch
+LawOfCosinesOQ01OQ04	RESIDUAL	type-mismatch
+LawOfCosinesOQ03OQ02	RESIDUAL	parse-error
+LawOfCosinesOQ04OQ01	RESIDUAL	type-mismatch
+LawOfCosinesOQ04OQ01Bisector	RESIDUAL	type-mismatch
+LawOfCosinesOQ07OQ01	GREEN	
+LawOfSinesOQ06	RESIDUAL	unknown-const:EuclideanSpace.inner_apply
+LawsOfLargeNumbers	GREEN	
+LawsOfLargeNumbersOQ01	RESIDUAL	type-mismatch
+LawsOfLargeNumbersOQ01Aristotle	RESIDUAL	signature-drift
+LawsOfLargeNumbersOQ01OQ01	RESIDUAL	signature-drift
+LawsOfLargeNumbersOQ01OQ02	RESIDUAL	type-mismatch
+LawsOfLargeNumbersOQ01OQ02OQ01	RESIDUAL	type-mismatch
+LawsOfLargeNumbersOQ01OQ03	RESIDUAL	signature-drift
+LawsOfLargeNumbersOQ02	RESIDUAL	type-mismatch
+LawsOfLargeNumbersOQ03	RESIDUAL	unknown-const:MeasureTheory.ae_eq_of_eq
+LawsOfLargeNumbersOQ03Aristotle	RESIDUAL	unknown-const:MeasureTheory.ae_eq_of_eq
+LebesgueMeasure	RESIDUAL	unknown-const:integral_mul_left
+LebesgueMeasureOQ01	GREEN	
+LebesgueMeasureOQ01OQ01	RESIDUAL	type-mismatch
+LebesgueMeasureOQ01OQ01OQ01OQ02	GREEN	
+LebesgueMeasureOQ01OQ01OQ02	RESIDUAL	type-mismatch
+LebesgueMeasureOQ01OQ01OQ02Riemann	RESIDUAL	type-mismatch
+LebesgueMeasureOQ03	GREEN	
+LebesgueMeasureOQ03OQ01	RESIDUAL	parse-error
+LebesgueMeasureOQ04	GREEN	
+LebesgueMeasureOQ06	RESIDUAL	unknown-const:List.chain'_append.mp
+LebesgueMeasureOQ06OQ01	RESIDUAL	unknown-const:List.chain'_append.mp
+LeibnizPi	GREEN	
+LeibnizPiOQ02	GREEN	
+LeibnizPiOQ02Aristotle	GREEN	
+LeibnizPiOQ03	GREEN	
+LiouvilleTheorem	RESIDUAL	instance-synth
+LiouvilleTheoremOQ03	GREEN	
+LiouvilleTheoremOQ04	GREEN	
+LittleWedderburnOQ01OQ02	GREEN	elab-drift
+LovaszLocalLemmaOQ01	GREEN	
+LovaszLocalLemmaOQ01StrongInduction	GREEN	
+LovaszLocalLemmaOQ01SymmetricStep	GREEN	
+MaschkeAugmentationNoSplitOQ010101	RESIDUAL	instance-synth
+MaschkeLocalRingOQ010102	RESIDUAL	instance-synth
+MaschkeModularCounterexampleOQ01	GREEN	
+MaschkeTheoremOQ01	RESIDUAL	parse-error
+MathematicalInductionOQ01	RESIDUAL	unknown-const:Ordinal.IsLimit
+MathematicalInductionOQ03	RESIDUAL	type-mismatch
+MatrixSimilarityInvariantsOQ01	GREEN	
+MeanValueTheorem	GREEN	
+MeanValueTheoremOQ02	GREEN	
+MeanValueTheoremOQ02OQ01	GREEN	
+MeanValueTheoremOQ02OQ01OQ01	GREEN	
+MeanValueTheoremOQ02OQ01OQ02	GREEN	
+MeanValueTheoremOQ02OQ02UIcc	GREEN	
+MeanValueTheoremOQ02OQ04	GREEN	
+MeanValueTheoremOQ02OQ04OQ01	RESIDUAL	type-mismatch
+MeanValueTheoremOQ03	GREEN	
+MeanValueTheoremOQ04	RESIDUAL	type-mismatch
+MeanValueTheoremOQ04OQ03	GREEN	
+MinkowskiFundamentalTheoremOQ02	GREEN	
+MinkowskiTheoremOQ02	RESIDUAL	unknown-const:ENNReal.ofReal_lt_ofReal_of_nonneg
+MinkowskiTheoremOQ03	GREEN	
+MinkowskiTheoremOQ04OQ03	GREEN	
+MinpolyCharpolyOQ01	RESIDUAL	type-mismatch
+MinpolyCharpolyOQ03	RESIDUAL	type-mismatch
+MinpolyCharpolyOQ03OQ01	RESIDUAL	type-mismatch
+MorleysTheorem	RESIDUAL	unknown-const:map_exp_ofReal_mul_I_re
+MotivicFlagMapsPartialFlags	RESIDUAL	rewrite-drift
+NapoleonsTheorem	RESIDUAL	rewrite-drift
+NapoleonsTheoremOQ02	RESIDUAL	rewrite-drift
+NapoleonsTheoremOQ03	GREEN	
+NavierStokes	GREEN	
+NewtonIndStep2	RESIDUAL	proof-drift
+NewtonInductiveStepOQ01	GREEN	
+NewtonInductiveStepOQ01Aristotle	GREEN	
+NewtonInductiveStepOQ02	RESIDUAL	type-mismatch
+NewtonInductiveStepOQ03	RESIDUAL	proof-drift
+NewtonLogConcavity	GREEN	
+NewtonSignedInputs	GREEN	
+NormEuclideanZsqrtdFamilyOQ03OQ02	RESIDUAL	instance-synth
+NormEuclideanZsqrtdFamilyOQ03OQ02OQ01	RESIDUAL	instance-synth
+OSBridge	RESIDUAL	instance-synth
+PACLearning	GREEN	
+PNPBarriersLegacy	RESIDUAL	type-mismatch
+PNPBarriersSound	GREEN	
+PNPBarriersUnified	GREEN	
+PappusTheoremOQ02	GREEN	
+PartitionTheorem	RESIDUAL	unknown-const:Theorems100.partition_theorem
+PartitionTheoremOQ01	RESIDUAL	unknown-const:Finset.mem_empty
+PartitionTheoremOQ01OQ01	RESIDUAL	unknown-const:Finset.mem_empty
+PartitionTheoremOQ03	RESIDUAL	unknown-const:Nat.Partition.IsOdd.card
+PartitionTheoremOQ04	GREEN	
+PartitionTheoremOQ04Aristotle	GREEN	
+PascalsHexagon	GREEN	
+PascalsHexagonOQ02	GREEN	
+PascalsHexagonOQ03	GREEN	
+PascalsHexagonOQ03Incomplete01Derangements	GREEN	
+PellEquationOQ01	RESIDUAL	unknown-const:Int.cast_nonneg.mpr
+PentagonalNumberTheoremOQ01	GREEN	
+PentagonalNumberTheoremOQ01OQ01	RESIDUAL	rewrite-drift
+PentagonalNumberTheoremOQ01OQ02	RESIDUAL	rewrite-drift
+PerfectNumbers	GREEN	
+PerfectNumbersOQ03	RESIDUAL	type-mismatch
+PiTranscendental	GREEN	
+PicardIterationExplicitOQ0102	RESIDUAL	instance-synth
+PicardLindelofOQ01OQ01OQ01	GREEN	
+PicksTheoremOQ01	RESIDUAL	rewrite-drift
+PicksTheoremOQ01OQ01	RESIDUAL	proof-drift
+PicksTheoremOQ01OQ01OQ01	RESIDUAL	noncomputable
+PicksTheoremOQ01OQ02	RESIDUAL	proof-drift
+PicksTheoremOQ02	RESIDUAL	type-mismatch
+PicksTheoremOQ03	GREEN	
+PlatonicSolidsOQ02	RESIDUAL	proof-drift
+PoincareConjecture	RESIDUAL	type-mismatch
+PowerMeanLimitOQ	RESIDUAL	proof-drift
+PrimeGapBoundsOQ01	RESIDUAL	unknown-const:Real.log_le_sub_one_of_le
+PrimeNumberTheoremOQ01OQ01	GREEN	
+PrimeReciprocalDivergenceOQ03	RESIDUAL	unknown-const:Nat.squarefree_iff_factorization_le_one.mp
+PrimitiveRoots	RESIDUAL	type-mismatch
+PrimitiveRootsOQ02	RESIDUAL	instance-synth
+PrimitiveRootsOQ03	GREEN	
+ProbMethodAlterationOQ03	GREEN	
+ProbMethodExpectationOQ01	GREEN	
+ProbMethodExpectationOQ04	GREEN	
+ProbMethodSecondMomentOQ01	RESIDUAL	duplicate-decl
+ProbMethodSecondMomentOQ04OQ03	GREEN	
+ProductOfSegmentsOfChordsConverse	GREEN	
+ProductOfSegmentsOfChordsOQ01	RESIDUAL	unknown-const:chord_quadratic_sphere
+PropertyBFirstMomentRecoloring	RESIDUAL	unknown-const:Finset.exists_ne_of_one_lt_card
+PtolemysComplexProofOQ02	RESIDUAL	unknown-const:Real.cos_eq_one_iff.mp
+PtolemysTheoremOQ01Incomplete01	RESIDUAL	elab-drift
+PtolemysTheoremOQ01OQ01	GREEN	
+PtolemysTheoremOQ01OQ02	RESIDUAL	unknown-const:spherical_ptolemy
+PuiseuxTheorem	RESIDUAL	type-mismatch
+PuiseuxTheoremOQ02	RESIDUAL	instance-synth
+PuiseuxTheoremOQ03	RESIDUAL	type-mismatch
+PythagoreanTheorem	RESIDUAL	type-mismatch
+PythagoreanTheoremOQ01	GREEN	
+PythagoreanTheoremOQ03	GREEN	
+PythagoreanTheoremOQ05	GREEN	
+PythagoreanTriplesOQ02	GREEN	
+PythagoreanTriplesOQ04OQ01OQ01	RESIDUAL	unknown-const:even_zero
+QuadraticReciprocityAlgorithmOQ03	RESIDUAL	rewrite-drift
+QuadraticReciprocityAlgorithmOQ03FieldBridge	RESIDUAL	rewrite-drift
+QuadraticReciprocityAlgorithmOQ03M2	GREEN	
+QuadraticReciprocityAlgorithmOQ03M2Capstone	RESIDUAL	rewrite-drift
+QuadraticReciprocityAlgorithmOQ03Zolotarev	RESIDUAL	rewrite-drift
+QuadraticReciprocityOQ03	RESIDUAL	instance-synth
+QuadraticReciprocityOQ03OQ01	RESIDUAL	instance-synth
+QuadraticReciprocityOQ03OQ01Exp	RESIDUAL	instance-synth
+RamanujanSumFallacy	GREEN	
+RamseyHypergraph	RESIDUAL	type-mismatch
+RamseyR4kExtensions	GREEN	
+RamseyR4kExtensionsOQ03	GREEN	
+RamseyR4kExtensionsOQ03OQ02	GREEN	
+RamseysTheorem	GREEN	
+RamseysTheoremOQ02	GREEN	
+RamseysTheoremOQ04	PRE-EXISTING	never-compiled:n
+RandomizedMaxCut	GREEN	
+RandomizedMaxCutOQ03	GREEN	
+RandomizedMaxCutOQ05	GREEN	
+RandomizedMaxcutOQ02	GREEN	
+RandomizedMaxcutOQ04	RESIDUAL	unknown-const:Finset.disjoint_compl_right
+RationalCanonicalFormExists	RESIDUAL	type-mismatch
+RiemannHypothesis	GREEN	
+RiemannHypothesisConsequences	GREEN	
+RothTheorem	GREEN	
+RothTheoremOQ01	GREEN	
+RothTheoremOQ01Primes	GREEN	
+RothTheoremOQ01RecipSufficient	GREEN	
+RothTheoremOQ01Reciprocal	GREEN	
+RothTheoremOQ01Weighted	GREEN	
+RothTheoremOQ03	RESIDUAL	unknown-const:Finset.sum_eq_add_sum_diff_singleton
+RothTheoremOQ03OQ01OQ01	RESIDUAL	duplicate-decl
+RothTheoremOQ03OQ01OQ01OQ01	RESIDUAL	duplicate-decl
+RothTheoremOQ03OQ01OQ01OQ01OQ01	RESIDUAL	duplicate-decl
+RothTheoremQuantitative	RESIDUAL	unknown-const:Finset.sum_eq_add_sum_diff_singleton
+RothTheoremQuantitativeAristotle	RESIDUAL	unknown-const:div_le_div_of_le_left
+RothTriangleRemoval	RESIDUAL	signature-drift
+SchauderFixedPoint	RESIDUAL	instance-synth
+SchauderFixedPointOQ01	RESIDUAL	instance-synth
+SchauderFixedPointOQ03	RESIDUAL	instance-synth
+SchauderFixedPointOQ03OQ01	GREEN	
+SchroederBernsteinOQ01	RESIDUAL	elab-drift
+SchroederBernsteinOQ02	RESIDUAL	unknown-const:Set.image_subset
+SchroederBernsteinOQ03	GREEN	
+SchursTheorem	GREEN	
+SearchMathlib	RESIDUAL	unknown-const:IsCompact.of_isClosed_isBounded
+ShannonChannelCoding	GREEN	
+ShannonChannelCodingAWGN	GREEN	
+ShannonChannelCodingAWGNOQ01	GREEN	
+ShannonChannelCodingAWGNOQ03	GREEN	
+ShannonChannelCodingAWGNOQ03OQ01EqualNoise	GREEN	
+ShannonChannelCodingAWGNOQ03OQ01Monotone	RESIDUAL	type-mismatch
+ShannonChannelCodingBEC	GREEN	
+ShannonChannelCodingBECOQ01	GREEN	
+ShannonChannelCodingBECOQ02	GREEN	
+ShannonChannelCodingBECOQ04	GREEN	
+ShannonChannelCodingOQ01	GREEN	
+ShannonChannelCodingOQ01OQ01	GREEN	
+ShannonChannelCodingOQ02	GREEN	
+ShannonChannelCodingOQ02OQ01	GREEN	
+ShannonChannelCodingOQ02OQ01Aristotle	GREEN	
+ShannonChannelCodingOQ02OQ03	GREEN	
+ShannonChannelCodingOQ02OQ04	GREEN	
+ShannonChannelCodingOQ03	GREEN	
+ShannonChannelCodingOQ03Aristotle	RESIDUAL	signature-drift
+ShannonChannelCodingOQ04OQ01	GREEN	
+ShannonChannelCodingOQ04OQ01OQ01	GREEN	
+ShannonEntropyAristotle	GREEN	
+ShannonEntropyOQ01	GREEN	
+ShannonEntropyOQ01OQ01	GREEN	
+ShannonEntropyOQ02	RESIDUAL	rewrite-drift
+ShannonSourceCodingOQ01	RESIDUAL	unknown-const:InformationTheory.mutualInformation
+ShannonSourceCodingOQ02	RESIDUAL	type-mismatch
+ShannonSourceCodingOQ03	RESIDUAL	unknown-const:Fintype.sum_piFinset_succ
+ShapleyFolkman	GREEN	
+ShapleyFolkmanAristotle	GREEN	
+ShapleyFolkmanOQ01	GREEN	
+ShapleyFolkmanOQ03	GREEN	
+ShapleyFolkmanOQ04	GREEN	
+SkolemNoetherMatrixAut	RESIDUAL	unknown-const:Matrix.isUnit_det_iff_isUnit_mulVecLin
+SkolemNoetherMatrixAutAristotle	RESIDUAL	unknown-const:Matrix.isUnit_det_iff_isUnit_mulVecLin
+SolutionOfCubicOQ03OQ01	GREEN	
+SolutionOfCubicOQ03OQ02	GREEN	
+SolutionOfCubicOQ03OQ03	GREEN	
+SolutionOfCubicOQ03OQ05	RESIDUAL	proof-drift
+SolutionOfCubicOQ05	GREEN	
+SophieGermain	GREEN	
+SophieGermainOQ01	GREEN	
+SophieGermainOQ02	GREEN	
+SpectralTraceDetEigenvaluesOQ01OQ01	GREEN	
+SpectralTraceDetEigenvaluesOQ01OQ01OQ02OQ02	GREEN	
+SpectralTraceDetEigenvaluesOQ02	RESIDUAL	rewrite-drift
+SpernerFreudenthal	GREEN	
+SpernerFreudenthalSimplex	RESIDUAL	type-mismatch
+SpernerGrid	RESIDUAL	proof-drift
+SpernerGridAristotle	RESIDUAL	proof-drift
+SpernerGridBase	GREEN	
+SpernerGridCell	GREEN	
+SpernerMathlib	GREEN	
+SpernerMathlib4	GREEN	
+SpernerMathlib4OQ03	GREEN	
+SpernerMathlibHyper	GREEN	
+SpernerMathlibOQ02	GREEN	
+SpernerMathlibOQ03	GREEN	
+SpernerNDim	GREEN	
+SpernerNDimMathlib	GREEN	
+SpernerNDimMathlibOQ01	RESIDUAL	type-mismatch
+SpernerNDimMathlibOQ01OQ04	GREEN	
+SpernerNDimMathlibOQ02	RESIDUAL	type-mismatch
+SpernerNDimOQ01	RESIDUAL	unknown-const:List.get?_eq_get
+SpernerNDimOQ02	GREEN	
+SpernerNDimOQ02Cell	GREEN	
+SpernerNDimOQ02Obstruction	GREEN	
+SpernerNDimOQ03	RESIDUAL	type-mismatch
+SpernerNDimOQ03OQ01	RESIDUAL	type-mismatch
+SpernerNDimOQ04	RESIDUAL	parse-error
+SpernerNDimOQ06	GREEN	
+SpernerSimplicialBridge	GREEN	
+SpernerSimplicialBridgeOQ01	GREEN	
+SpernerSimplicialBridgeOQ02	GREEN	
+SpernerSimplicialBridgeOQ03	GREEN	
+SpernerSimplicialInstance	GREEN	
+SpernerSimplicialInstanceOQ01	GREEN	
+SpernerSimplicialInstanceOQ03	GREEN	
+SpernerSimplicialInstanceOQ03Tower	GREEN	
+SpernerSimplicialInstanceOQ04	GREEN	
+SpernerSimplicialInstanceOQ05	GREEN	
+SpernerSimplicialInstanceOQ05Scarf1d	GREEN	
+SpernerTuckerAntipodalMatchingSeed	GREEN	
+SpernerTuckerAntipodalParityEngine	GREEN	
+SpernerTuckerCrossPolytopeBoundary	GREEN	
+SpernerTuckerCrossPolytopeConnected	GREEN	
+SpernerTuckerCrossPolytopeEdgeCount	GREEN	
+SpernerTuckerCrossPolytopeEquator	GREEN	
+SpernerTuckerCrossPolytopeEquatorAut	GREEN	
+SpernerTuckerCrossPolytopeHemisphere	GREEN	
+SpernerTuckerCrossPolytopeHemisphereIso	GREEN	
+SpernerTuckerCrossPolytopeLabelling	GREEN	
+SpernerTuckerDoorGraph	GREEN	
+SpernerTuckerDoorGraphTower	GREEN	
+SpernerTuckerEndpointTransport	GREEN	
+SpernerTuckerEquatorMatchingGraph	GREEN	
+SpernerTuckerHexagonDirectedEngine	GREEN	
+SpernerTuckerHexagonPseudomanifold	GREEN	
+SpernerTuckerSimplexBoundaryDoorGraph	GREEN	
+SpernerTuckerSimplexBoundaryPseudomanifold	GREEN	
+SpernerTuckerSimplexFacetPair	GREEN	
+Sqrt2Irrational	GREEN	
+Sqrt2MinpolyOQ01	RESIDUAL	type-mismatch
+Sqrt2MinpolyOQ01OQ02	RESIDUAL	rewrite-drift
+Sqrt2OQ01	RESIDUAL	unknown-const:square_nonneg_general
+Sqrt2PlusSqrt3Irrational	GREEN	
+Sqrt2PlusSqrt3PlusSqrt5IrrationalOQ01	GREEN	
+Sqrt2PlusSqrt3PlusSqrt5IrrationalOQ02	GREEN	
+StirlingExpansion	GREEN	
+StirlingExpansionAristotle	GREEN	
+StirlingFormula	RESIDUAL	parse-error
+StirlingFormulaOQ02OQ01	RESIDUAL	type-mismatch
+SubsetCount	GREEN	
+SubsetCountOQ02	GREEN	
+SubsetCountOQ02OQ01	RESIDUAL	unknown-const:Finset.disjoint_comm.mp
+SumOfDivisorsOQ01SpecialPrime	RESIDUAL	unknown-const:not_even_iff_odd
+SumOfKthPowers	RESIDUAL	unknown-const:Finset.sum_range_pow
+SumOfKthPowersOQ03	RESIDUAL	instance-synth
+SumOfKthPowersOQ04	RESIDUAL	type-mismatch
+SumOfKthPowersOQ05	GREEN	
+SumOfKthPowersOQ05OQ01	GREEN	
+SumOfKthPowersOQ05OQ01OQ01	GREEN	
+SumOfOddsStatementOnly	GREEN	
+SylowTheorem	RESIDUAL	unknown-const:card_sylow_dvd_index
+SylowTheoremOQ01	RESIDUAL	rewrite-drift
+SylowTheoremOQ02	GREEN	
+SylowTheoremOQ02OQ01Nilpotent	GREEN	
+SylowTheoremOQ02Orbit	RESIDUAL	unknown-const:Sylow.exists_smul_eq
+SylowTheoremOQ03	GREEN	
+SylowTheoremOQ03B	GREEN	
+SylowTheoremOQ04	RESIDUAL	unknown-const:card_sylow_dvd_index
+SylowTheoremOQ04OQ03	RESIDUAL	decide-maxrecdepth
+SylowTheoremOQ05	GREEN	
+SylowTheoremsOQ05	RESIDUAL	slow-timeout
+SylvesterSequenceOQ01OQ03	GREEN	
+SynthesisCurvaturePtolemy	RESIDUAL	unknown-const:spherical_ptolemy
+SynthesisCurvaturePtolemyOQ01	RESIDUAL	unknown-const:spherical_ptolemy
+SynthesisCurvaturePtolemyOQ02	GREEN	
+SzemerediCoreOQ01	GREEN	
+SzemerediCoreOQ01Aristotle	RESIDUAL	proof-drift
+SzemerediCounting	GREEN	
+SzemerediHypergraphCore	RESIDUAL	proof-drift
+SzemerediHypergraphGowers	RESIDUAL	proof-drift
+SzemerediRegularity	GREEN	
+SzemerediRegularityOQ01	GREEN	
+SzemerediRegularityOQ01Trivial	RESIDUAL	duplicate-decl
+SzemerediRegularityOQ02	RESIDUAL	decide-maxrecdepth
+SzemerediRegularityOQ02OQ02	RESIDUAL	decide-maxrecdepth
+SzemerediRegularityOQ03	GREEN	
+SzemerediRegularityOQ04	GREEN	
+SzemerediRegularityOQ04Assembly	GREEN	
+SzemerediRegularityOQ04Bridge	GREEN	
+SzemerediRegularityOQ04Energy	GREEN	
+SzemerediRegularityOQ04Product	GREEN	
+SzemerediRegularityOQ04Witness	GREEN	
+TaxicabNumberOQ01	RESIDUAL	slow-timeout
+TaylorSinCosConvergenceOQ02	RESIDUAL	proof-drift
+TaylorSinCosConvergenceOQ03Aristotle	RESIDUAL	unknown-const:div_le_div
+TaylorSinCosConvergenceOQ04	RESIDUAL	unknown-const:taylorPartialSum_at_zero
+TaylorTheorem	RESIDUAL	type-mismatch
+TaylorTheoremOQ01	RESIDUAL	type-mismatch
+TaylorTheoremOQ02	RESIDUAL	type-mismatch
+TaylorTheoremOQ03	RESIDUAL	type-mismatch
+TaylorTheoremOQ03OQ01	GREEN	
+TaylorTheoremOQ03OQ02	GREEN	
+TestApi1056	RESIDUAL	proof-drift
+TestApi1059	GREEN	
+TestApi1061	RESIDUAL	unknown-const:Nat.divisors_prime_eq
+TestApi1061b	RESIDUAL	unknown-const:Nat.divisors_prime_eq
+TestApi1141	GREEN	
+TestApi1148	GREEN	
+TestApi1159b	RESIDUAL	unknown-const:Configuration.HasLines.mkFinOrder
+TestApi1159c	RESIDUAL	proof-drift
+TestApi203	RESIDUAL	unclassified
+TestApi234	RESIDUAL	unknown-const:Continuous.if_lt
+TestApi241	RESIDUAL	noncomputable
+TestApi249	GREEN	
+TestApi301	GREEN	
+TestApi312	RESIDUAL	unknown-const:Real.exp_ge_one_add_of_nonneg
+TestApi321	GREEN	
+TestApi342	GREEN	
+TestApi361	GREEN	
+TestApi385	GREEN	
+TestApi417	GREEN	
+TestApi423	GREEN	
+TestApi457	GREEN	
+TestApi472	GREEN	
+TestApi513	RESIDUAL	unknown-const:Real.pi_lt_3141593
+TestApi635	GREEN	
+TestApi654	GREEN	
+TestApi688	RESIDUAL	unknown-const:Nat.not_prime_of_le_one
+TestApi689	GREEN	
+TestApi693	GREEN	
+TestApi783	GREEN	
+TestApi826	GREEN	
+TestApi847	GREEN	
+TestApi889	GREEN	
+TestApi913	GREEN	
+TestApi959	GREEN	
+TestApi960	RESIDUAL	unknown-const:Rat.toNat
+TestApi963	RESIDUAL	unknown-const:Finset.sum_pow_eq_pow_sum
+TestConvexHull	RESIDUAL	unknown-const:isCompact_isClosed_isBounded
+TestCovByApi	GREEN	
+TestDerangConvApi	GREEN	
+TestErdos43Api	RESIDUAL	unknown-const:Int.Icc_toFinset_card
+TestHLTension	RESIDUAL	unknown-const:Finset.card_sdiff_eq_card_sub_card_inter
+TestHolderApi	RESIDUAL	unknown-const:MeasureTheory.snorm
+TestSphereLocEuc	RESIDUAL	proof-drift
+TestWolstenholme	RESIDUAL	unknown-const:ZMod.prod_univ_prime
+TestZetaNonzero	GREEN	
+ThreeSquares	GREEN	
+ThreeSquaresGaussEureka	GREEN	
+ThreeSquaresRationalBridge	GREEN	
+ThreeSquaresRationalNecessity	GREEN	
+ThreeSquaresSquarefreeReduction	GREEN	
+ThreeSquaresSufficiency	GREEN	
+ThreeSquaresSufficiencyCorrected	GREEN	
+ThreeSquaresWitnessObstruction	GREEN	
+ThreeSubgroupsLemmaOQ0101	GREEN	
+ThreeSubgroupsLemmaOQ01OQ01	GREEN	
+TractatusQuantifiers	GREEN	
+TriangleAngleSum	RESIDUAL	slow-timeout
+TriangleAngleSumOQ02	RESIDUAL	type-mismatch
+TriangleInequality	GREEN	
+TriangleInequalityOQ01	RESIDUAL	unknown-const:MeasureTheory.LpAddConst_of_one_le
+TriangleInequalityOQ04	GREEN	
+TriangleInequalityOQ06	RESIDUAL	instance-synth
+TriangularNumberReciprocals	RESIDUAL	unknown-const:Finset.sum_eq_sum_diff_singleton_add
+TriangularReciprocalGeneralized	RESIDUAL	instance-synth
+TriangularReciprocalsFigurate	RESIDUAL	unknown-const:rpow_neg
+TriangularReciprocalsOQ04OQ01	GREEN	
+TwinPrimesSpecialOQ01	GREEN	
+UnitDistanceIndependence	GREEN	
+UnitDistanceIndependenceOQ04	GREEN	
+UnitDistanceIndependenceOQ04Embed	GREEN	
+UrysohnsLemmaOQ01OQ01OQ01	GREEN	
+UrysohnsLemmaOQ01OQ01OQ01OQ01	GREEN	
+UrysohnsLemmaOQ01OQ01OQ02	GREEN	
+UrysohnsLemmaOQ01OQ01OQ02OQ01	GREEN	
+UrysohnsLemmaOQ01OQ01OQ02OQ02	GREEN	
+VandermondeInterpolationOQ01OQ02	GREEN	
+VandermondeInterpolationOQ01OQ02OQ01	GREEN	
+VietasFormulasOQ02	GREEN	
+VietasFormulasOQ03OQ01	RESIDUAL	proof-drift
+WaringGgLowerBoundsOQ02	RESIDUAL	decide-maxrecdepth
+WilsonsTheoremOQ01	RESIDUAL	rewrite-drift
+WilsonsTheoremOQ02	RESIDUAL	rewrite-drift
+WilsonsTheoremOQ02Ext	RESIDUAL	rewrite-drift
+WilsonsTheoremOQ02ExtOQ01	RESIDUAL	rewrite-drift
+WilsonsTheoremOQ02ExtOQ02	RESIDUAL	rewrite-drift
+WilsonsTheoremOQ04	RESIDUAL	rewrite-drift
+WilsonsTheoremOQ07	GREEN	
+WolstenholmeTheoremOQ01	RESIDUAL	oom-killed
+WolstenholmeTheoremOQ02OQ02	RESIDUAL	unknown-const:Equiv.mulLeft_apply
+WolstenholmeTheoremOQ03	GREEN	
+YangMills2DOQ01	GREEN	
+YangMills2DOQ02	GREEN	
+YangMillsMassGap	RESIDUAL	unknown-const:Real.exp_lt_exp_of_lt
+ZsqrtdNegTwo	GREEN	
+ZsqrtdNegTwoOQ01	GREEN	
+ZsqrtdNegTwoOQ03	GREEN	elab-drift
+ZsqrtdNegTwoOQ03OQ01	GREEN	elab-drift
+ZsqrtdNegTwoOQ03OQ06	GREEN	elab-drift
+eTranscendental	GREEN	


### PR DESCRIPTION
Recovery PR. An orchestrator merge script clobbered `proofs/batch2/verify-results.tsv` (wrote empty content when the file auto-merged with no conflict stages); the 1-line corrupt ledger got squash-merged in #38620. This restores the correct 3-way union (1619 GREEN / 2659 rows, verified 0 greens lost). No .lean or docs changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)