### PR TITLE
migrate(v4.31): Doctor increment 25 — tm/pd/rewrite (A-M partition) (+16 GREEN)

### DIFF
--- a/proofs/Proofs/ArithmeticSeriesOQ02OQ03.lean
+++ b/proofs/Proofs/ArithmeticSeriesOQ02OQ03.lean
@@ -50,11 +50,13 @@ theorem faceCount_top (k : ℕ) : faceCount k k = 1 := by
 
 /-- The 1-faces (edges) of Δ^k: there are C(k+1, 2) = k(k+1)/2 edges. -/
 theorem faceCount_one (k : ℕ) : faceCount k 1 = (k + 1) * k / 2 := by
-  simp [faceCount, Nat.choose_two_middle]
+  show (k + 1).choose 2 = (k + 1) * k / 2
+  rw [Nat.choose_two_right, Nat.add_sub_cancel]
 
 /-- For j > k, there are no j-faces of Δ^k. -/
 theorem faceCount_gt (k j : ℕ) (hj : k < j) : faceCount k j = 0 := by
-  simp [faceCount, Nat.choose_eq_zero_of_lt (by omega)]
+  show (k + 1).choose (j + 1) = 0
+  exact Nat.choose_eq_zero_of_lt (by omega)
 
 /-! ## Connection to Simplicial Numbers
 
@@ -97,12 +99,11 @@ theorem total_faces (k : ℕ) :
     ∑ j ∈ range (k + 1), faceCount k j = 2 ^ (k + 1) - 1 := by
   simp only [faceCount]
   -- Reindex: ∑_{j∈range(k+1)} C(k+1,j+1) = ∑_{i∈range(k+2)} C(k+1,i) - C(k+1,0)
-  have h_split : ∑ i ∈ range (k + 2), Nat.choose (k + 1) i =
-      Nat.choose (k + 1) 0 + ∑ j ∈ range (k + 1), Nat.choose (k + 1) (j + 1) := by
+  have h_split : ∑ i ∈ range (k + 1 + 1), Nat.choose (k + 1) i =
+      1 + ∑ j ∈ range (k + 1), Nat.choose (k + 1) (j + 1) := by
     rw [Finset.sum_range_succ']
-    simp [Nat.zero_add]
+    simp [Nat.choose_zero_right, Nat.add_comm]
   have h_total := Nat.sum_range_choose (k + 1)
-  simp [Nat.choose_zero_right] at h_split
   omega
 
 /-- The Euler characteristic of Δ^k is 1 (since simplices are contractible).
@@ -150,12 +151,12 @@ example : faceCount 3 3 = 1 := by simp [faceCount, Nat.choose_self]
     More precisely: simplicial 2 n = faceCount (n+1) 1. -/
 theorem triangular_counts_edges (n : ℕ) :
     simplicial 2 n = faceCount (n + 1) 1 := by
-  simp [simplicial, faceCount]; ring_nf
+  simp [simplicial, faceCount]
 
 /-- Connection: tetrahedral numbers count triangular faces of simplices.
     simplicial 3 n = faceCount (n+2) 2 = C(n+3, 3). -/
 theorem tetrahedral_counts_faces (n : ℕ) :
     simplicial 3 n = faceCount (n + 2) 2 := by
-  simp [simplicial, faceCount]; ring_nf
+  simp [simplicial, faceCount]
 
 end ArithmeticSeriesOQ02OQ03

--- a/proofs/Proofs/CentralLimitTheorem.lean
+++ b/proofs/Proofs/CentralLimitTheorem.lean
@@ -135,7 +135,7 @@ axiom charFun_deriv_interchange (μ_meas : MeasureTheory.Measure ℝ)
 theorem integral_ofReal_eq_ofReal_integral (μ_meas : MeasureTheory.Measure ℝ)
     [MeasureTheory.IsProbabilityMeasure μ_meas]
     (h_int : MeasureTheory.Integrable id μ_meas) :
-    ∫ x : ℝ, (x : ℂ) ∂μ_meas = (∫ x : ℝ, x ∂μ_meas : ℂ) := by
+    ∫ x : ℝ, (x : ℂ) ∂μ_meas = Complex.ofReal (∫ x : ℝ, x ∂μ_meas) := by
   have := Complex.ofRealCLM.integral_comp_comm h_int
   simp only [Complex.ofRealCLM_apply, id] at this
   exact this
@@ -215,7 +215,7 @@ section LimitComputation
 theorem limit_one_plus_x_over_n (x : ℝ) :
     Filter.Tendsto (fun n : ℕ => (1 + x / n)^n) Filter.atTop (nhds (Real.exp x)) :=
   -- This is a standard result in Mathlib
-  tendsto_one_plus_div_pow_exp x
+  Real.tendsto_one_add_div_pow_exp x
 
 /-- The characteristic function of Sₙ = (X₁ + ... + Xₙ)/√n -/
 theorem normalized_sum_charFun (μ : MeasureTheory.Measure ℝ)

--- a/proofs/Proofs/Erdos156ProblemAristotle.lean
+++ b/proofs/Proofs/Erdos156ProblemAristotle.lean
@@ -3,18 +3,15 @@
   Supporting lemmas for automated proof search.
   See Erdos156Problem.lean for the main formalization.
 
-  Targets:
+  Historical targets (now all discharged in the parent `Erdos156Problem`):
   - diffShadow_ncard_le: |diffShadow A| ≤ |A| * (|A|*(|A|+1)/2)
-    Strategy: diffShadow A ⊆ ⋃ a ∈ A, {σ - a | σ ∈ A+A, σ > a}
-    Each fiber has size ≤ |A+A| = |A|*(|A|+1)/2 (by sidon_sumset_size).
-
   - midShadow_ncard_le: |midShadow A| ≤ |A|*(|A|+1)/2
-    Strategy: midShadow A = {(b+c)/2 | b,c ∈ A, b+c even}
-    This is an image of sumset A, so size ≤ |A+A| = |A|*(|A|+1)/2.
-
   - greedySidon_cube_lower_bound: N ≤ n + n*(n*(n+1)/2) + n*(n+1)/2
-    Strategy: Interval N ⊆ greedySidon N ∪ diffShadow ∪ midShadow
-    using greedySidon_complement_in_shadow. Union bound gives the result.
+
+  These three lemmas are now declared and proven in `Proofs.Erdos156Problem`.
+  Under v4.31, re-declaring them in this same-namespace companion (which imports
+  the parent) is a hard error ("has already been declared"), so the companion is
+  reduced to an import shim that re-exports the parent's results.
 
   Excluded:
   - The main O(N^{1/3}) conjecture (open problem)
@@ -22,27 +19,5 @@
 import Mathlib
 import Proofs.Erdos156Problem
 
-namespace Erdos156
-
-/-- The diffShadow of a Sidon set A has at most |A| * (|A|*(|A|+1)/2) elements.
-    Each element of diffShadow arises as σ - a for some σ ∈ sumset A and a ∈ A,
-    giving a bound of |A| * |sumset A| = |A| * |A|*(|A|+1)/2. -/
-lemma diffShadow_ncard_le (A : Set ℕ) (hA : IsSidonSet A) (hfin : A.Finite) :
-    (diffShadow A).ncard ≤ A.ncard * (A.ncard * (A.ncard + 1) / 2) := by
-  sorry
-
-/-- The midShadow of A has at most |A|*(|A|+1)/2 elements.
-    midShadow A = {x | ∃ b c ∈ A, b + c = 2*x} ⊆ image of (sumset A) under x ↦ x/2. -/
-lemma midShadow_ncard_le (A : Set ℕ) (hfin : A.Finite) :
-    (midShadow A).ncard ≤ A.ncard * (A.ncard + 1) / 2 := by
-  sorry
-
-/-- The greedy Sidon set in {1,...,N} has size ≥ Ω(N^{1/3}).
-    Every element of {1,...,N} not in the greedy set lies in diffShadow or midShadow
-    (by greedySidon_complement_in_shadow), giving N ≤ n + shadow sizes. -/
-theorem greedySidon_cube_lower_bound (N n : ℕ)
-    (hn : n = size (greedySidon N)) (hN : N ≥ 1) :
-    N ≤ n + n * (n * (n + 1) / 2) + n * (n + 1) / 2 := by
-  sorry
-
-end Erdos156
+-- All Aristotle support targets for Erdős #156 now live in `Proofs.Erdos156Problem`
+-- (diffShadow_ncard_le, midShadow_ncard_le, greedySidon_cube_lower_bound).

--- a/proofs/Proofs/Erdos189Problem.lean
+++ b/proofs/Proofs/Erdos189Problem.lean
@@ -40,8 +40,8 @@ def FiniteColoring (n : ℕ) := Plane → Fin n
     three consecutive right angles (which implies the fourth). -/
 def IsRectangle (a b c d : Plane) : Prop :=
   -- a-b perpendicular to b-c and b-c perpendicular to c-d
-  inner (a - b) (c - b) = 0 ∧
-  inner (b - c) (d - c) = 0 ∧
+  inner ℝ (a - b) (c - b) = 0 ∧
+  inner ℝ (b - c) (d - c) = 0 ∧
   -- Form a proper quadrilateral (non-degenerate)
   a ≠ b ∧ b ≠ c ∧ c ≠ d ∧ d ≠ a
 
@@ -122,7 +122,7 @@ def ParallelogramQuestion : Prop :=
       -- Parallelogram: opposite sides parallel
       (a - b) = (d - c) ∧
       -- Area A (using cross product formula)
-      |det ![a - b, a - d]| = A
+      |Matrix.det ![a - b, a - d]| = A
 
 /- ## Historical Notes
 

--- a/proofs/Proofs/Erdos250Problem.lean
+++ b/proofs/Proofs/Erdos250Problem.lean
@@ -93,7 +93,7 @@ theorem sigma_le_sq (n : ℕ) (hn : n ≠ 0) : divisorSum 1 n ≤ n ^ 2 := by
       ≤ ∑ _d ∈ n.divisors, n := by
         apply Finset.sum_le_sum; intro d hd
         simp; exact Nat.le_of_dvd (Nat.pos_of_ne_zero hn) (Nat.dvd_of_mem_divisors hd)
-    _ = n.divisors.card * n := by rw [Finset.sum_const, Nat.smul_eq_mul]
+    _ = n.divisors.card * n := by rw [Finset.sum_const, smul_eq_mul]
     _ ≤ n * n := by
         apply Nat.mul_le_mul_right
         have hsub : n.divisors ⊆ Finset.Icc 1 n := by
@@ -101,7 +101,7 @@ theorem sigma_le_sq (n : ℕ) (hn : n ≠ 0) : divisorSum 1 n ≤ n ^ 2 := by
           exact ⟨Nat.pos_of_dvd_of_pos (Nat.dvd_of_mem_divisors hd) (Nat.pos_of_ne_zero hn),
                  Nat.le_of_dvd (Nat.pos_of_ne_zero hn) (Nat.dvd_of_mem_divisors hd)⟩
         calc n.divisors.card ≤ (Finset.Icc 1 n).card := Finset.card_le_card hsub
-          _ = n := by simp [Nat.card_Icc]; omega
+          _ = n := by simp [Nat.card_Icc]
     _ = n ^ 2 := by ring
 
 /-

--- a/proofs/Proofs/Erdos375Aristotle.lean
+++ b/proofs/Proofs/Erdos375Aristotle.lean
@@ -106,14 +106,14 @@ theorem composite_has_prime_dvd (n : ℕ) (hn : n > 1) (hnotprime : ¬n.Prime) :
   ⟨n.minFac, Nat.minFac_prime (by omega), Nat.minFac_dvd n⟩
 
 -- Consecutive integers are coprime: gcd(n, n+1) = 1
-theorem consecutive_coprime (n : ℕ) : Nat.Coprime n (n + 1) :=
-  Nat.Coprime.symm (Nat.coprime_succ_self n)
+theorem consecutive_coprime (n : ℕ) : Nat.Coprime n (n + 1) := by
+  simpa using (Nat.coprime_self_add_right (m := n) (n := 1)).mpr (Nat.coprime_one_right n)
 
 -- Coprime numbers have no common prime divisors
 theorem coprime_disjoint_primes (a b : ℕ) (h : Nat.Coprime a b)
     (p : ℕ) (hp : p.Prime) (hpa : p ∣ a) (hpb : p ∣ b) : False := by
   have : p ∣ Nat.gcd a b := Nat.dvd_gcd hpa hpb
   rw [h] at this
-  exact Nat.Prime.one_lt hp |>.not_le (Nat.le_of_dvd one_pos this)
+  exact absurd (Nat.le_of_dvd one_pos this) (Nat.not_le.mpr (Nat.Prime.one_lt hp))
 
 end Erdos375Aristotle

--- a/proofs/Proofs/Erdos384Problem.lean
+++ b/proofs/Proofs/Erdos384Problem.lean
@@ -40,7 +40,7 @@ noncomputable def minPrimeDivisor (n : ℕ) : ℕ :=
 theorem minPrimeDivisor_prime (n : ℕ) (hn : n > 1) :
     (minPrimeDivisor n).Prime := by
   simp only [minPrimeDivisor, hn, dite_true]
-  exact minFac_prime (Nat.one_lt_iff_ne_one.mp hn)
+  exact minFac_prime (hn.ne')
 
 /-- minPrimeDivisor divides n for n > 1 -/
 theorem minPrimeDivisor_dvd (n : ℕ) (hn : n > 1) :
@@ -143,14 +143,13 @@ theorem choose_n_1_prime_divisor (n : ℕ) (hn : n > 1) :
     ∃ p : ℕ, p.Prime ∧ p ∣ Nat.choose n 1 := by
   use n.minFac
   constructor
-  · exact minFac_prime (Nat.one_lt_iff_ne_one.mp hn)
+  · exact minFac_prime (hn.ne')
   · rw [choose_n_1 n hn]
     exact minFac_dvd n
 
 /-- C(n, n-1) = n by symmetry -/
 theorem choose_n_nminus1 (n : ℕ) (hn : n > 0) : Nat.choose n (n-1) = n := by
-  rw [Nat.choose_symm_diff]
-  simp [Nat.choose_one_right]
+  rw [Nat.choose_symm (by omega : 1 ≤ n), Nat.choose_one_right]
 
 /-
 ## Part 7: Small Cases Verification

--- a/proofs/Proofs/Erdos476Aristotle.lean
+++ b/proofs/Proofs/Erdos476Aristotle.lean
@@ -36,15 +36,15 @@ theorem card_two_case (A : Finset (ZMod p)) (h : A.card = 2) :
   have hRS : restrictedSumset p {a, b} = {a + b} := by
     ext x
     unfold restrictedSumset
-    simp only [Finset.mem_image, Finset.mem_filter, Finset.mem_product,
+    simp only [Finset.mem_image, Finset.mem_filter, Finset.mem_product, Finset.product_eq_sprod,
                Finset.mem_singleton, Prod.exists, Finset.mem_insert, Finset.mem_singleton]
     constructor
     · rintro ⟨c, d, ⟨⟨hc, hd⟩, hne⟩, rfl⟩
-      rcases hc with rfl | rfl <;> rcases hd with rfl | rfl
-      · exact absurd rfl hne
-      · rfl
-      · exact add_comm b a
-      · exact absurd rfl hne
+      rcases hc with rfl | rfl <;> rcases hd with rfl | rfl <;>
+        first
+          | exact absurd rfl hne
+          | rfl
+          | exact add_comm _ _
     · rintro rfl
       exact ⟨a, b, ⟨⟨Or.inl rfl, Or.inr rfl⟩, hab⟩, rfl⟩
   rw [hRS, Finset.card_singleton]
@@ -55,7 +55,7 @@ theorem card_two_case (A : Finset (ZMod p)) (h : A.card = 2) :
 theorem ap_card_eq_n (a d : ZMod p) (n : ℕ) (hd : d ≠ 0) (hn : n ≤ p) :
     (arithmeticProgression p a d n).card = n := by
   unfold arithmeticProgression
-  apply Finset.card_image_of_injOn
+  rw [Finset.card_image_of_injOn, Finset.card_range]
   intro i hi j hj hij
   simp only [Finset.mem_coe, Finset.mem_range] at hi hj
   have hip : i < p := hi.trans_le hn

--- a/proofs/Proofs/Erdos530Problem.lean
+++ b/proofs/Proofs/Erdos530Problem.lean
@@ -79,24 +79,6 @@ The key results on `ℓ(N)`:
 - Komlós–Sulyok–Szemerédi: `N^{1/2} ≪ ℓ(N)` (improved lower bound)
 -/
 
-/-- Erdős's lower bound: every set of size N has a Sidon subset of
-    size at least c · N^{1/3} for some absolute constant c.
-    Proof: follows immediately from the stronger KSS bound k² ≥ c·N.
-    Since k ≥ 1, we have k³ = k·k² ≥ 1·(c·N) = c·N. -/
-theorem erdos_lower_bound :
-    ∃ c : ℕ, c ≥ 1 ∧
-      ∀ A : Finset ℤ, A.card ≥ 8 →
-        maxSidonSize A * maxSidonSize A * maxSidonSize A ≥ c * A.card := by
-  obtain ⟨c, hc, hkss⟩ := komlos_sulyok_szemeredi
-  refine ⟨c, hc, fun A hA => ?_⟩
-  have h := hkss A (by omega : A.card ≥ 4)
-  -- k³ = k · k² ≥ 1 · (c · |A|) = c · |A|
-  calc c * A.card
-      ≤ maxSidonSize A * maxSidonSize A := h
-    _ ≤ maxSidonSize A * maxSidonSize A * maxSidonSize A :=
-        le_mul_of_one_le_right (Nat.zero_le _)
-          (maxSidonSize_pos (Finset.card_pos.mp (by omega : 0 < A.card)))
-
 /-- Komlós–Sulyok–Szemerédi improved lower bound: every set of size N
     has a Sidon subset of size at least c · N^{1/2}. -/
 axiom komlos_sulyok_szemeredi :
@@ -118,6 +100,24 @@ theorem maxSidonSize_pos {A : Finset ℤ} (hA : A.Nonempty) : 1 ≤ maxSidonSize
     _ ≤ (A.powerset.filter fun S => IsSidon S).sup Finset.card :=
         Finset.le_sup (Finset.mem_filter.mpr ⟨Finset.mem_powerset.mpr
           (Finset.singleton_subset_iff.mpr hx), isSidon_singleton x⟩)
+
+/-- Erdős's lower bound: every set of size N has a Sidon subset of
+    size at least c · N^{1/3} for some absolute constant c.
+    Proof: follows immediately from the stronger KSS bound k² ≥ c·N.
+    Since k ≥ 1, we have k³ = k·k² ≥ 1·(c·N) = c·N. -/
+theorem erdos_lower_bound :
+    ∃ c : ℕ, c ≥ 1 ∧
+      ∀ A : Finset ℤ, A.card ≥ 8 →
+        maxSidonSize A * maxSidonSize A * maxSidonSize A ≥ c * A.card := by
+  obtain ⟨c, hc, hkss⟩ := komlos_sulyok_szemeredi
+  refine ⟨c, hc, fun A hA => ?_⟩
+  have h := hkss A (by omega : A.card ≥ 4)
+  -- k³ = k · k² ≥ 1 · (c · |A|) = c · |A|
+  calc c * A.card
+      ≤ maxSidonSize A * maxSidonSize A := h
+    _ ≤ maxSidonSize A * maxSidonSize A * maxSidonSize A :=
+        le_mul_of_one_le_right (Nat.zero_le _)
+          (maxSidonSize_pos (Finset.card_pos.mp (by omega : 0 < A.card)))
 
 /-- For A with ≥ 2 elements, maxSidonSize A ≥ 2 (any pair is Sidon). -/
 theorem maxSidonSize_ge_two {A : Finset ℤ} (hA : 2 ≤ A.card) : 2 ≤ maxSidonSize A := by
@@ -413,7 +413,7 @@ theorem interval_sidon_upper (N : ℕ) (hN : 1 ≤ N) :
 
 /-- The card of Finset.Icc 1 N equals N for integers. -/
 private theorem icc_one_card (N : ℕ) : (Finset.Icc (1 : ℤ) ↑N).card = N := by
-  simp [Nat.card_Icc]; omega
+  simp
 
 /-- The corrected Erdős Problem 530 is proved: ℓ(N) = Θ(√N).
     Lower bound from KSS axiom; upper bound from interval sum counting (proved).

--- a/proofs/Proofs/Erdos548Aristotle.lean
+++ b/proofs/Proofs/Erdos548Aristotle.lean
@@ -27,17 +27,17 @@ variable {V : Type*} [Fintype V] [DecidableEq V]
 
 /-- Adjacency in the path graph is symmetric: if i→j then j→i. -/
 theorem pathGraph_adj_symm (n : ℕ) (i j : Fin n) :
-    (pathGraph n).Adj i j ↔ (pathGraph n).Adj j i := by
+    (Erdos548.pathGraph n).Adj i j ↔ (Erdos548.pathGraph n).Adj j i := by
   sorry
 
 /-- The center vertex (index 0) is adjacent to every leaf in the star graph. -/
 theorem starGraph_center_adj (k : ℕ) (hk : k ≥ 1) (j : Fin (k + 1))
-    (hj : j.val ≠ 0) : (starGraph k).Adj ⟨0, Nat.zero_lt_succ k⟩ j := by
+    (hj : j.val ≠ 0) : (Erdos548.starGraph k).Adj ⟨0, Nat.zero_lt_succ k⟩ j := by
   sorry
 
 /-- Adjacency in the star graph is symmetric. -/
 theorem starGraph_adj_symm (k : ℕ) (i j : Fin (k + 1)) :
-    (starGraph k).Adj i j ↔ (starGraph k).Adj j i := by
+    (Erdos548.starGraph k).Adj i j ↔ (Erdos548.starGraph k).Adj j i := by
   sorry
 
 /-- The handshaking lemma: sum of degrees equals twice the edge count.

--- a/proofs/Proofs/Erdos571Problem.lean
+++ b/proofs/Proofs/Erdos571Problem.lean
@@ -48,7 +48,7 @@ def IsBipartite {V : Type*} [DecidableEq V] (G : Graph V) : Prop :=
     ∀ u v, G.adj u v → (u ∈ A ∧ v ∈ B) ∨ (u ∈ B ∧ v ∈ A)
 
 /-- The edge count of a finite graph -/
-noncomputable def edgeCount {V : Type*} [Fintype V] [DecidableEq V]
+noncomputable def edgeCount {V : Type*} [Fintype V] [DecidableEq V] [LinearOrder V]
     (G : Graph V) [DecidableRel G.adj] : ℕ :=
   (Finset.filter (fun p : V × V => p.1 < p.2 ∧ G.adj p.1 p.2)
     Finset.univ).card
@@ -83,7 +83,7 @@ computationally.
 -/
 def IsTuranExponent (α : ℚ) : Prop :=
   1 ≤ α ∧ α < 2 ∧
-  ∃ (V : Type*) (_ : Fintype V) (_ : DecidableEq V) (G : Graph V),
+  ∃ (V : Type) (_ : Fintype V) (_ : DecidableEq V) (G : Graph V),
     IsBipartite G ∧
     ∃ (ex : ℕ → ℝ),
       -- ex represents the extremal number for G

--- a/proofs/Proofs/GeometricSeriesOQ02OQ03.lean
+++ b/proofs/Proofs/GeometricSeriesOQ02OQ03.lean
@@ -54,12 +54,13 @@ theorem isUnit_of_near_unit (A : R) (hA : IsUnit A) (B : R)
   -- 1 - T is a unit
   have h1T : IsUnit (1 - T) := one_sub_isUnit T hT_norm
   -- B = A * (1 - T) = ↑u * (1 - T)
+  have hu : (↑u : R) = A := hA.unit_spec
   have hB_eq : B = ↑u * (1 - T) := by
-    simp only [hT_def, sub_mul, mul_sub, one_mul, mul_one]
-    rw [show (↑u⁻¹ : R) * (A - B) = ↑u⁻¹ * A - ↑u⁻¹ * B from mul_sub _ _ _]
-    rw [show (↑u : R) * (↑u⁻¹ * A) = (↑u * ↑u⁻¹) * A from (mul_assoc _ _ _).symm]
-    rw [Units.mul_inv_cancel_right]
-    ring
+    have hcancel : ∀ x : R, (↑u : R) * (↑u⁻¹ * x) = x := by
+      intro x; rw [← mul_assoc, ← Units.val_mul, mul_inv_cancel, Units.val_one, one_mul]
+    have key : (↑u : R) * T = A - B := by
+      rw [hT_def, mul_sub, mul_sub, hcancel, hcancel]
+    rw [mul_sub, mul_one, key, hu]; abel
   rw [hB_eq]
   exact IsUnit.mul hA h1T
 
@@ -79,7 +80,7 @@ theorem isUnit_of_near_one (B : R) (hB : ‖1 - B‖ < 1) : IsUnit B :=
     Every element within distance 1 of the identity is a unit. -/
 theorem isUnit_of_dist_one_lt (B : R) (hB : dist B 1 < 1) : IsUnit B := by
   rw [dist_eq_norm] at hB
-  rw [show B - 1 = -(1 - B) from by ring] at hB
+  rw [show B - 1 = -(1 - B) from (neg_sub 1 B).symm] at hB
   rw [norm_neg] at hB
   exact isUnit_of_near_one B hB
 
@@ -149,8 +150,8 @@ theorem inverse_locally_bounded [NormOneClass R] (ε : ℝ) (hε : 0 < ε) (hε1
 theorem left_inv_near_one (B : R) (hB : ‖1 - B‖ < 1) :
     B * Ring.inverse B = 1 := by
   rw [perturbed_inverse_series B hB]
-  rw [show B = 1 - (1 - B) from (sub_sub_cancel 1 B).symm]
-  exact right_inverse_identity (1 - B) hB
+  have h := left_inverse_identity (1 - B) hB
+  rwa [sub_sub_cancel] at h
 
 /-- **Right inverse identity near 1**
 
@@ -158,7 +159,7 @@ theorem left_inv_near_one (B : R) (hB : ‖1 - B‖ < 1) :
 theorem right_inv_near_one (B : R) (hB : ‖1 - B‖ < 1) :
     Ring.inverse B * B = 1 := by
   rw [perturbed_inverse_series B hB]
-  rw [show B = 1 - (1 - B) from (sub_sub_cancel 1 B).symm]
-  exact left_inverse_identity (1 - B) hB
+  have h := right_inverse_identity (1 - B) hB
+  rwa [sub_sub_cancel] at h
 
 end GeometricSeriesOQ02OQ03

--- a/proofs/Proofs/Hilbert20OQ01OQ03Aristotle.lean
+++ b/proofs/Proofs/Hilbert20OQ01OQ03Aristotle.lean
@@ -36,11 +36,11 @@ is a real number embedded in ℂ, the product is also a real complex number.
 -/
 
 /-- A finite product of complex numbers with zero imaginary parts has zero imaginary part. -/
-theorem prod_im_eq_zero_ari {ι : Type*} (s : Finset ι) (f : ι → ℂ)
+theorem prod_im_eq_zero_ari {ι : Type*} [DecidableEq ι] (s : Finset ι) (f : ι → ℂ)
     (h : ∀ i ∈ s, (f i).im = 0) : (s.prod f).im = 0 := by
   induction s using Finset.induction with
   | empty => simp
-  | insert ha ih =>
+  | @insert a t ha ih =>
     rw [Finset.prod_insert ha, Complex.mul_im,
         ih (fun i hi => h i (Finset.mem_insert_of_mem hi)),
         h _ (Finset.mem_insert_self _ _)]
@@ -61,6 +61,6 @@ theorem monomial_real_ari {n : ℕ} (α : Fin n → ℕ) (ξ : Fin n → ℝ) :
     (Finset.univ.prod fun i => (ξ i : ℂ) ^ α i).im = 0 := by
   apply prod_im_eq_zero_ari
   intro i _
-  skip
+  rw [← Complex.ofReal_pow, Complex.ofReal_im]
 
 end Hilbert20OQ01OQ03Aristotle

--- a/proofs/Proofs/InverseGaloisF20.lean
+++ b/proofs/Proofs/InverseGaloisF20.lean
@@ -80,10 +80,9 @@ theorem gal_card_dvd_120 :
     Subgroup.card_dvd_of_injective _ hinj
   rw [Nat.card_eq_fintype_card, Nat.card_eq_fintype_card] at hdvd
   rw [Fintype.card_perm] at hdvd
-  have hcard : Fintype.card (p.rootSet p.SplittingField) = 5 := by
-    rw [Polynomial.card_rootSet_eq_natDegree x_fifth_sub_2_separable
-        (Polynomial.SplittingField.splits p)]
-    exact x_fifth_sub_2_natDegree
+  have hcard : Fintype.card (p.rootSet p.SplittingField) = 5 :=
+    (Polynomial.card_rootSet_eq_natDegree x_fifth_sub_2_separable
+        (Polynomial.SplittingField.splits p)).trans x_fifth_sub_2_natDegree
   rw [hcard] at hdvd
   simpa [Nat.factorial] using hdvd
 
@@ -382,7 +381,7 @@ theorem adjoin_alpha_zeta_eq_top_f20
     Algebra.adjoin_le (fun x hx => h_roots hx)
   have h_top : Algebra.adjoin ℚ (↑((X ^ 5 - C (2 : ℚ) : ℚ[X]).rootSet
     (X ^ 5 - C (2 : ℚ) : ℚ[X]).SplittingField)) = ⊤ :=
-    IsSplittingField.adjoin_rootSet'
+    Polynomial.SplittingField.adjoin_rootSet _
   have h_K_top : K.toSubalgebra = ⊤ := le_antisymm le_top (h_top ▸ h_sub)
   rw [← IntermediateField.top_toSubalgebra] at h_K_top
   exact (IntermediateField.toSubalgebra_injective h_K_top)
@@ -520,8 +519,8 @@ theorem f20_realizable :
       (_ : IsGalois ℚ K),
       Fintype.card (K ≃ₐ[ℚ] K) = 20 := by
   set p := (X : ℚ[X]) ^ 5 - C 2
-  haveI : Normal ℚ p.SplittingField := inferInstance
-  haveI : Algebra.IsSeparable ℚ p.SplittingField := inferInstance
+  haveI : Normal ℚ p.SplittingField := Polynomial.SplittingField.instNormal p
+  haveI : Algebra.IsSeparable ℚ p.SplittingField := Algebra.IsSeparable.of_integral ℚ _
   exact ⟨p.SplittingField,
     inferInstance, inferInstance, inferInstance, IsGalois.mk,
     x5_sub_2_gal_card⟩

--- a/proofs/Proofs/LagrangeFourSquaresOQ04.lean
+++ b/proofs/Proofs/LagrangeFourSquaresOQ04.lean
@@ -126,7 +126,11 @@ theorem obstructed_not_three_squares (n : ℕ) (h : IsObstructed n) :
       rw [heq]; exact ⟨4 ^ a * (8 * b + 7), by ring⟩
     have ⟨⟨x', hx⟩, ⟨y', hy⟩, ⟨z', hz⟩⟩ := four_dvd_three_sq h4
     rw [hx, hy, hz] at heq
-    have heq' : x' ^ 2 + y' ^ 2 + z' ^ 2 = 4 ^ a * (8 * b + 7) := by nlinarith
+    have heq' : x' ^ 2 + y' ^ 2 + z' ^ 2 = 4 ^ a * (8 * b + 7) := by
+      have hpow : (4 : ℕ) ^ (a + 1) = 4 * 4 ^ a := by rw [pow_succ]; ring
+      have h4eq : 4 * (x' ^ 2 + y' ^ 2 + z' ^ 2) = 4 * (4 ^ a * (8 * b + 7)) := by
+        rw [hpow] at heq; nlinarith [heq]
+      omega
     exact ih ⟨x', y', z', heq'⟩
 
 -- ═══════════════════════════════════════════════════════════════
@@ -172,7 +176,7 @@ theorem three_sq_of_not_7_mod_8 {n : ℕ} (hn : n % 8 ≠ 7) (h4 : ¬(4 ∣ n) �
   | zero => simp at hab; omega
   | succ a =>
     rcases h4 with h4 | rfl
-    · exact h4 ⟨4 ^ a * (8 * b + 7), by ring⟩
+    · exact h4 ⟨4 ^ a * (8 * b + 7), by rw [hab]; ring⟩
     · simp at hab
 
 /-- Numbers ≡ 1 (mod 8) are always three-square (not obstructed since 1 ≠ 7 mod 8). -/

--- a/proofs/batch2/STATUS.md
+++ b/proofs/batch2/STATUS.md
@@ -1,3 +1,82 @@
+# Batch 2/3/4/5 + Doctor verification state (updated Doctor increment 25, #38065, 2026-07-13)
+
+# DOCTOR INCREMENT 25 (type-mismatch + proof-drift + rewrite-drift + unknown-const-mixed + instance-synth, #38065, 2026-07-13)
+
+Container `dr35` (cpus 6-11, 11g, cache v431-b), worktree doctor-b, branch
+`feature/issue-38065-c`, rebased clean onto origin/feature/issue-37508 after
+#38624 merge (all inc-23 follow-up patches already upstream; ledger baseline 1640).
+Partition: A–M basenames + Erdos < 600 (sibling inc-24 = N–Z + Erdos ≥ 600).
+Fresh in-container error probes off warm cache (per-file `lake build Proofs.X`),
+low-error-count candidates worked first.
+
+## Waves (all in-container `lake build` exit-0 confirmed, then ledger-flipped)
+- **DR35a (+3)**: Erdos375Aristotle (`Nat.coprime_succ_self` removed →
+  `coprime_self_add_right`+`coprime_one_right`; `.not_le` proj on ≤ → `absurd`+`not_le.mpr`),
+  Erdos156ProblemAristotle (all 3 lemmas now in imported parent → reduced companion to
+  import shim; v4.31 errors on same-namespace re-declaration across import),
+  ArithmeticSeriesOQ02OQ03 (`Nat.choose_two_middle`→`Nat.choose_two_right`+`add_sub_cancel`;
+  `show`-form for `.choose 2`; align `range (k+1+1)` to `sum_range_choose` for omega;
+  drop self-closing `ring_nf`).
+- **DR35b (+2)**: CentralLimitTheorem (coercion elaboration: goal RHS `(∫ x, x : ℂ)`
+  now pushes cast inside integral → force `Complex.ofReal (∫ …)`;
+  `tendsto_one_plus_div_pow_exp`→`Real.tendsto_one_add_div_pow_exp`),
+  GeometricSeriesOQ02OQ03 (NormedRing `↑u*(↑u⁻¹*x)=x` cancel lemma + `abel` for
+  additive-group goal instead of `ring`; `left/right_inverse_identity` arg
+  `(1-B)` global-rewrite hazard → `rwa [sub_sub_cancel] at h`; `neg_sub` not `ring`).
+- **DR35c (+2)**: Hilbert20OQ01OQ03Aristotle (`Finset.induction` `| insert ha ih`→
+  `| @insert a t ha ih` + `[DecidableEq ι]` for `prod_insert`; `skip`→
+  `← Complex.ofReal_pow, Complex.ofReal_im`), InverseGaloisF20 (`set p` folds
+  `X^5-C 2` so `card_rootSet_eq_natDegree` output doesn't `rw`-match → `.trans`;
+  `IsSplittingField.adjoin_rootSet'` class-field needs instance →
+  `Polynomial.SplittingField.adjoin_rootSet _`; `Normal ℚ …SplittingField` synth
+  through `set` → explicit `Polynomial.SplittingField.instNormal p`).
+- **DR35d (+1)**: Erdos189Problem (**`inner x y`→`inner ℝ x y`** field-first; the
+  `det` and 2nd inner errors were cascades of the first inner mismatch; `det`→`Matrix.det`).
+- **DR35e (+1)**: Erdos571Problem (`edgeCount` `p.1 < p.2` needs `[LinearOrder V]`;
+  `∃ (V : Type*)` in a `Prop def`→`Type` pin fixes universe-metavar in derived thm).
+- **DR35f (+1)**: LagrangeFourSquaresOQ04 (nlinarith for `4^(a+1)(8b+7)` descent:
+  `hpow : 4^(a+1)=4*4^a` + `4*(…)=4*(…)` then `omega`; `⟨…, by ring⟩` divisibility
+  witness needs `rw [hab]; ring` to consume the `4^(a+1)` hypothesis).
+- **DR35g (+2)**: Erdos250Problem (`Nat.smul_eq_mul`→bare `smul_eq_mul`; drop
+  self-closing `omega`), Erdos384Problem (`Nat.one_lt_iff_ne_one.mp hn`→`hn.ne'`;
+  `Nat.choose_symm_diff`→`Nat.choose_symm (1≤n)`+`choose_one_right`).
+- **DR35h (+1)**: Erdos530Problem (**forward-reference to an axiom/lemma declared
+  LATER in the same file now errors in v4.31** — moved `komlos_sulyok_szemeredi`
+  axiom + `maxSidonSize_pos`/`_le_card` lemmas before `erdos_lower_bound`; 2-axiom
+  count unchanged, pure reorder; drop self-closing `omega`).
+- **DR35i (+1)**: Erdos548Aristotle (Mathlib added `SimpleGraph.pathGraph`, making
+  the imported `Erdos548.pathGraph`/`starGraph` **ambiguous** → qualify local refs
+  with `Erdos548.` namespace; theorem-body sorries stay GREEN as warnings).
+- **DR35j (+1)**: Erdos476Aristotle (`Finset.mem_product` alone no longer reduces
+  `A.product A` membership → add `Finset.product_eq_sprod` to the simp set;
+  `rcases … <;> rcases …` with `rfl` eliminates the wrong var → replace 4 explicit
+  branches with `<;> first | exact absurd rfl hne | rfl | exact add_comm _ _`;
+  `apply Finset.card_image_of_injOn` can't unify `#?s`=`n` → `rw [card_image_of_injOn,
+  card_range]`).
+
+Ledger: 1640 → 1656 GREEN (+16). PR pending (base feature/issue-37508).
+Recipes catalogued in rename-map §7v.
+
+## Statement repairs
+- (none this increment — all fixes were faithful migration repairs; the Erdos530
+  reorder and Erdos156 companion-shim preserve axiom/assumption counts.)
+
+## Flagged deep (fix attempted or triaged, did NOT flip, reverted / skipped)
+- FactorRemainderTheoremOQ01OQ01OQ02: `Finset.sum_subset (range_subset.mpr (by omega))`
+  omega now faces `Ring.choose (n:ℚ)` ℚ-cast atoms + `shift_eq_sum_fwdDiff_iter`
+  drift — multi-error, reverted.
+- EulerIdentityOQ01OQ02OQ01: `expSeries_div_hasSum_exp ℂ`→`NormedSpace.expSeries_div_hasSum_exp`
+  (drop field arg) clears :83 and two no-op simp/dsimp deletions clear :86/:88,
+  but `convert hasSum_fintype … using 1` now surfaces an `AddCommMonoid=instAddCommMonoid`
+  instance-congruence goal FIRST (§7s) intertwined with the `Nat.divModEquiv 2` fiber
+  reduction — the fiber `HasSum.prod_fiberwise` value goal needs a genuine
+  divMod-normal-form rewrite. Reverted; deep.
+- Erdos162Problem: `congr 1` on `card X = Nat.choose |S| 2` over-reduces so `ext p`
+  sees `ℕ`; `Bool.true_ne_false` removed — moderate rework, skipped.
+- Erdos40Problem/Erdos104Problem/MathematicalInductionOQ03: 5+ diverse errors each,
+  skipped for velocity.
+
+---
 # Batch 2/3/4/5 + Doctor verification state (updated Doctor increment 23, #38065, 2026-07-13)
 
 # DOCTOR INCREMENT 23 (type-mismatch + proof-drift + rewrite-drift + mixed, #38065, 2026-07-13)

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -2097,7 +2097,7 @@ Hilbert19Regularity	GREEN
 Hilbert20BoundaryValue	GREEN	signature-drift
 Hilbert20LocalSolvability	RESIDUAL	instance-synth
 Hilbert20OQ01OQ03	RESIDUAL	instance-synth
-Hilbert20OQ01OQ03Aristotle	RESIDUAL	type-mismatch
+Hilbert20OQ01OQ03Aristotle	GREEN	
 Hilbert21RiemannHilbert	RESIDUAL	type-mismatch
 Hilbert22OQ01	GREEN	
 Hilbert22OQ01OQ03	GREEN	
@@ -2143,7 +2143,7 @@ InverseGaloisD4OQ02OQ03OQ01OQ01	GREEN
 InverseGaloisD4OQ02OQ03OQ01OQ01OQ01	GREEN	
 InverseGaloisD4OQ02OQ04	GREEN	
 InverseGaloisD4OQ03	GREEN	
-InverseGaloisF20	RESIDUAL	unknown-const:cyclotomic_5_has_root_in_splitting_field
+InverseGaloisF20	GREEN	
 InverseGaloisF20OQ02	GREEN	
 InverseGaloisOQ01	GREEN	
 InverseGaloisOQ02	GREEN	

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -982,7 +982,7 @@ Erdos184ProblemProvable	RESIDUAL	proof-drift
 Erdos185Problem	GREEN	
 Erdos186Problem	GREEN	
 Erdos188Problem	RESIDUAL	instance-synth
-Erdos189Problem	RESIDUAL	unknown-const:det
+Erdos189Problem	GREEN	
 Erdos18OQ01	GREEN	
 Erdos190Problem	RESIDUAL	unknown-const:exists_canonical_threshold
 Erdos191Problem	RESIDUAL	instance-synth

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -1418,7 +1418,7 @@ Erdos567Problem	GREEN
 Erdos568Problem	GREEN	
 Erdos569Problem	GREEN	
 Erdos570Problem	RESIDUAL	type-mismatch
-Erdos571Problem	RESIDUAL	instance-synth
+Erdos571Problem	GREEN	
 Erdos572Problem	GREEN	
 Erdos573Problem	GREEN	
 Erdos575Problem	GREEN	

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -413,7 +413,7 @@ CayleyHamiltonReductionOQ01OQ02	RESIDUAL	type-mismatch
 CayleyHamiltonReductionOQ02	GREEN	
 CayleysTheoremOQ01OQ01OQ02OQ02OQ01	GREEN	
 CayleysTheoremOQ01OQ02OQ02	GREEN	
-CentralLimitTheorem	RESIDUAL	unknown-const:tendsto_one_plus_div_pow_exp
+CentralLimitTheorem	GREEN	
 CentralLimitTheoremOQ01OQ01	GREEN	
 CentralLimitTheoremOQ01OQ01OQ04	GREEN	
 CentralLimitTheoremOQ01OQ02OQ01OQ01	RESIDUAL	instance-synth
@@ -2047,7 +2047,7 @@ GeometricSeries	GREEN
 GeometricSeriesOQ01	GREEN	
 GeometricSeriesOQ01Neumann	GREEN	
 GeometricSeriesOQ01OQ02	GREEN	
-GeometricSeriesOQ02OQ03	RESIDUAL	type-mismatch
+GeometricSeriesOQ02OQ03	GREEN	
 GeometricSeriesOQ02OQ05	RESIDUAL	rewrite-drift
 GeometricSeriesOQ03	RESIDUAL	unknown-const:inv_ne_zero.mpr
 GeometricSeriesOQ07	GREEN	

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -1041,7 +1041,7 @@ Erdos247Problem	RESIDUAL	instance-synth
 Erdos249OQ01	RESIDUAL	proof-drift
 Erdos249Problem	GREEN	
 Erdos24Problem	GREEN	
-Erdos250Problem	RESIDUAL	unknown-const:Nat.smul_eq_mul
+Erdos250Problem	GREEN	
 Erdos251Problem	GREEN	
 Erdos252Problem	RESIDUAL	parse-error
 Erdos254Problem	RESIDUAL	instance-synth
@@ -1200,7 +1200,7 @@ Erdos381Problem	GREEN
 Erdos381ProblemAristotle	GREEN	
 Erdos382Problem	RESIDUAL	type-mismatch
 Erdos383Problem	RESIDUAL	proof-drift
-Erdos384Problem	RESIDUAL	unknown-const:Nat.one_lt_iff_ne_one.mp
+Erdos384Problem	GREEN	
 Erdos385Problem	GREEN	
 Erdos386Problem	RESIDUAL	unknown-const:Nat.Primes.instCountable.toEncodable.decode
 Erdos388Problem	GREEN	

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -1386,7 +1386,7 @@ Erdos543Problem	RESIDUAL	proof-drift
 Erdos545Problem	GREEN	
 Erdos546Problem	GREEN	
 Erdos547Problem	GREEN	
-Erdos548Aristotle	RESIDUAL	instance-synth
+Erdos548Aristotle	GREEN	
 Erdos548Problem	GREEN	
 Erdos548ProblemAristotle	GREEN	
 Erdos549Problem	RESIDUAL	instance-synth

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -1368,7 +1368,7 @@ Erdos527Problem	GREEN
 Erdos528Problem	GREEN	
 Erdos529Problem	PRE-EXISTING	never-compiled:d_2
 Erdos52Problem	GREEN	
-Erdos530Problem	RESIDUAL	unknown-const:komlos_sulyok_szemeredi
+Erdos530Problem	GREEN	
 Erdos531Problem	GREEN	
 Erdos532Problem	GREEN	
 Erdos533Problem	RESIDUAL	type-mismatch

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -145,7 +145,7 @@ ArithmeticSeriesOQ00OQ02	GREEN
 ArithmeticSeriesOQ00OQ02OQ01	RESIDUAL	instance-synth
 ArithmeticSeriesOQ02OQ02OQ03	RESIDUAL	unknown-const:Finset.Nat.antidiagonal
 ArithmeticSeriesOQ02OQ02OQ03OQ01	GREEN	
-ArithmeticSeriesOQ02OQ03	RESIDUAL	unknown-const:Nat.choose_two_middle
+ArithmeticSeriesOQ02OQ03	GREEN	
 ArithmeticSeriesOQ02OQ04OQ01	GREEN	
 ArsinhLogFormulaOQ01OQ01OQ01	GREEN	
 ArsinhLogFormulaOQ01OQ01OQ01OQ01	GREEN	
@@ -948,7 +948,7 @@ Erdos154Problem	GREEN
 Erdos155Problem	GREEN	
 Erdos156Aristotle	RESIDUAL	instance-synth
 Erdos156OQ02	RESIDUAL	unknown-const:x
-Erdos156ProblemAristotle	RESIDUAL	duplicate-decl
+Erdos156ProblemAristotle	GREEN	
 Erdos158Problem	GREEN	
 Erdos159Problem	RESIDUAL	type-mismatch
 Erdos15Problem	GREEN	
@@ -1191,7 +1191,7 @@ Erdos370Problem	RESIDUAL	proof-drift
 Erdos371Problem	GREEN	
 Erdos372Problem	GREEN	
 Erdos374Problem	RESIDUAL	unknown-const:not_le_of_lt
-Erdos375Aristotle	RESIDUAL	unknown-const:Nat.coprime_succ_self
+Erdos375Aristotle	GREEN	
 Erdos375Problem	GREEN	
 Erdos377Problem	GREEN	
 Erdos379Problem	GREEN	

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -2189,7 +2189,7 @@ LHopitalOQ04OQ01	GREEN
 LagrangeFourSquaresOQ01OQ03	RESIDUAL	noncomputable
 LagrangeFourSquaresOQ02	RESIDUAL	proof-drift
 LagrangeFourSquaresOQ02OQ02	GREEN	
-LagrangeFourSquaresOQ04	RESIDUAL	proof-drift
+LagrangeFourSquaresOQ04	GREEN	
 LagrangeFourSquaresOQ05	GREEN	
 LagrangeTheorem	GREEN	
 LagrangeTheoremOQ01	RESIDUAL	type-mismatch

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -1304,7 +1304,7 @@ Erdos472Problem	GREEN
 Erdos473Problem	GREEN	
 Erdos474Problem	GREEN	
 Erdos475Problem	GREEN	
-Erdos476Aristotle	RESIDUAL	elab-drift
+Erdos476Aristotle	GREEN	
 Erdos476OQ05Aristotle	RESIDUAL	unknown-const:b₂
 Erdos476OQ05Problem	RESIDUAL	proof-drift
 Erdos476Problem	PRE-EXISTING	never-compiled:B

--- a/research/toolchain-v4.31-rename-map.md
+++ b/research/toolchain-v4.31-rename-map.md
@@ -1044,3 +1044,30 @@ companions and duplicate-decl / nested-comment / calc-pipe single-issue files.
 | `rw [zpow_neg, …, zpow_natCast, …]` chain after a `ring_nf` that already normalized the exponent → "did not find pattern" | drop `ring_nf`; normalize the exponent first `rw [show -(↑(n+1)) = -↑n - 1 by push_cast; ring]` then `zpow_sub₀ (‹2≠0›), zpow_neg, field_simp, ring` | Erdos350Problem |
 | `rintro (rfl | …)` on disjunction equalities that are not `x = t` (e.g. `2*a+2 = a+1`) fails "subst" | `rintro (h | …)` named + `omega` (unfold nonlinear def on the GOAL first: `simp only [somaniC]` before rintro) | Erdos397Problem |
 | `Finset.prod_insert`/`prod_singleton` builds a RIGHT-associated product; goal is LEFT-associated | append `mul_assoc` (or `ring`) after the rw chain | Erdos397Problem |
+
+## §7v Doctor increment 25 recipes (tm/pd/rewrite + unknown-const + instance-synth, A–M partition, #38065, +16 GREEN)
+
+| Symptom | Fix | Files |
+|---|---|---|
+| `inner x y` (real/complex inner product) "Type mismatch: `a-b` has type Plane but expected Type" — `inner` now takes the **scalar field explicitly first** | `inner ℝ x y` (or `⟪x, y⟫_ℝ`); a `det`/2nd-`inner` error on the same decl is a CASCADE of the first — fix the first and rebuild | Erdos189Problem |
+| `Nat.coprime_succ_self` removed | `(Nat.coprime_self_add_right (n:=1)).mpr (Nat.coprime_one_right _)` (`simpa`) | Erdos375Aristotle |
+| `h.not_le` / `.le` projection on a `≤`-value → "environment does not contain `Nat.le.not_le`" | `absurd (le_proof) (Nat.not_le.mpr h)` (confirms §7u: ≤-values have no `.le`/`.not_le` field) | Erdos375Aristotle |
+| `Nat.choose_two_middle` removed (goal `(k+1).choose 2 = (k+1)*k/2`) | `rw [Nat.choose_two_right, Nat.add_sub_cancel]` (behind a `show (k+1).choose 2 = …` so the `1+1` reduces to `2`) | ArithmeticSeriesOQ02OQ03 |
+| `Nat.smul_eq_mul` removed (after `Finset.sum_const` gives `card • n`) | bare `smul_eq_mul` | Erdos250Problem |
+| `Nat.one_lt_iff_ne_one.mp hn` removed (need `n ≠ 1` from `hn : 1 < n`) | `hn.ne'` | Erdos384Problem |
+| `Nat.choose_symm_diff` removed (goal `C(n, n-1) = n`) | `rw [Nat.choose_symm (by omega : 1 ≤ n), Nat.choose_one_right]` | Erdos384Problem |
+| **Forward reference to an `axiom` (or theorem) declared LATER in the same file now hard-errors** (`Unknown identifier` + `rcases … is not an inductive datatype`) | REORDER: move the axiom/lemma block above its first use (preserves axiom/assumption count — pure reorder, not a repair) | Erdos530Problem |
+| Mathlib **added `SimpleGraph.pathGraph`** → an imported same-named local `Foo.pathGraph`/`starGraph` becomes **"Ambiguous term"** at every bare use | qualify the local refs with the owning namespace, `Foo.pathGraph n` | Erdos548Aristotle |
+| Same-namespace **re-declaration** of a lemma the imported parent now also proves ("has already been declared") AND the companion adds nothing new | reduce the Aristotle companion to an import shim (`import parent` + comment) — all targets live in the parent | Erdos156ProblemAristotle |
+| `Finset.induction … | insert ha ih` case pattern | `| @insert a t ha ih` (name the element+set); `Finset.prod_insert`/`sum_insert` inside also needs `[DecidableEq ι]` on the enclosing decl | Hilbert20OQ01OQ03Aristotle |
+| `Finset.mem_product` alone no longer rewrites membership in `A.product A` (`simp` reports it unused; leaves a raw `Quot.lift` term, breaking a following `rcases`/`⟨⟩`) | add `Finset.product_eq_sprod` to the simp set alongside `Finset.mem_product` | Erdos476Aristotle |
+| `apply Finset.card_image_of_injOn` fails to unify `#?s` with the literal `n` in `#(image f (range n)) = n` | `rw [Finset.card_image_of_injOn, Finset.card_range]` (then discharge the injOn goal) | Erdos476Aristotle |
+| `rcases h with rfl | rfl <;> rcases h' with rfl | rfl` — the `rfl` substitutes the WRONG side, deleting the theorem's bound vars (`a`/`b` → "Unknown identifier") in a later branch | replace the explicit per-branch tactics with `<;> first | exact absurd rfl hne | rfl | exact add_comm _ _` (var-name-agnostic) | Erdos476Aristotle |
+| coercion elaboration: a goal written `(∫ x, x ∂μ : ℂ)` now elaborates by pushing the cast **inside** the integral (`∫ x, ↑x`), so a lemma proving `↑(∫ x, x)` won't `exact` | write the outer cast explicitly: `Complex.ofReal (∫ x, x ∂μ)` | CentralLimitTheorem |
+| `tendsto_one_plus_div_pow_exp` (the `(1+x/n)^n → eˣ` limit) unknown | `Real.tendsto_one_add_div_pow_exp` | CentralLimitTheorem |
+| `expSeries_div_hasSum_exp ℂ x` — the leading algebra arg was dropped (now `(x)` only), and it's namespaced | `NormedSpace.expSeries_div_hasSum_exp x` (confirms DR33m) | EulerIdentity* (partial) |
+| `IsSplittingField.adjoin_rootSet'` is a class FIELD requiring an `IsSplittingField` instance that won't synth through a `set p :=` | use the canonical `Polynomial.SplittingField.adjoin_rootSet _`; likewise `Normal ℚ p.SplittingField` synth → explicit `Polynomial.SplittingField.instNormal p` | InverseGaloisF20 |
+| a `set p := (X^5 - C 2)` folds the polynomial, so a lemma output mentioning `(X^5-C 2).rootSet` won't `rw`-match the folded `p.rootSet` | avoid `rw`; chain with `.trans` (`(lemma …).trans …`) | InverseGaloisF20 |
+| NormedRing (possibly noncommutative) `ring` fails on a purely-additive identity (`B-1 = -(1-B)`, `B = A-(A-B)`) or a `↑u*(↑u⁻¹*x)` unit-cancel | use `neg_sub`/`abel` for additive goals; a reusable `hcancel : ∀ x, ↑u*(↑u⁻¹*x) = x` via `← mul_assoc, ← Units.val_mul, mul_inv_cancel, Units.val_one, one_mul` | GeometricSeriesOQ02OQ03 |
+| `edgeCount` def with `p.1 < p.2` on a bare `V` → "failed to synthesize `LT V`" | add `[LinearOrder V]` to the def; an internal `∃ (V : Type*)` in a `Prop def` also needs `Type`-pinning to kill the derived-thm universe-metavar (§7o) | Erdos571Problem |
+| nlinarith fails on a ℕ descent `(2x)²+(2y)²+(2z)² = 4^(a+1)(8b+7) ⊢ x²+y²+z² = 4^a(8b+7)` | `have hpow : 4^(a+1)=4*4^a := by rw [pow_succ]; ring`, then `have : 4*(sum)=4*(target) := by rw [hpow] at heq; nlinarith [heq]`, then `omega` | LagrangeFourSquaresOQ04 |


### PR DESCRIPTION
## Doctor increment 25 (epic #37508, issue #38065)

Type-mismatch + proof-drift + rewrite-drift + unknown-const-mixed + instance-synth-cascade repairs, **A–M basename + Erdos<600 partition** (disjoint from sibling increment 24's N–Z / Erdos≥600). All fixes verified in-container (`lake build Proofs.X` exit 0, cache v431-b); ledger rows flipped only on PASS.

**Ledger: 1640 → 1656 GREEN (+16).** Branch rebased clean onto the freshly-merged `feature/issue-37508` (#38624) — no duplicated inc-23 commits.

### Per-class before → after (RESIDUAL, my classes)
- unknown-const / rename: Erdos375Aristotle, ArithmeticSeriesOQ02OQ03, Erdos250Problem, Erdos384Problem, Erdos530Problem, Erdos548Aristotle (`coprime_succ_self`, `choose_two_middle`, `Nat.smul_eq_mul`, `one_lt_iff_ne_one`, `choose_symm_diff`, ambiguous `pathGraph`)
- type-mismatch: Erdos189Problem (`inner`→field-first), CentralLimitTheorem (coercion elaboration), Hilbert20OQ01OQ03Aristotle (`Finset.induction` case)
- rewrite-drift: GeometricSeriesOQ02OQ03, InverseGaloisF20 (`set`-fold rw mismatch), Erdos476Aristotle (`mem_product`/`product_eq_sprod`)
- instance-synth: Erdos571Problem (`LinearOrder`), InverseGaloisF20 (`SplittingField` Normal/adjoin_rootSet)
- proof-drift: LagrangeFourSquaresOQ04 (nlinarith descent)

### Waves (each in-container exit-0, then ledger-flipped)
- **DR35a (+3)** Erdos375Aristotle, Erdos156ProblemAristotle, ArithmeticSeriesOQ02OQ03
- **DR35b (+2)** CentralLimitTheorem, GeometricSeriesOQ02OQ03
- **DR35c (+2)** Hilbert20OQ01OQ03Aristotle, InverseGaloisF20
- **DR35d (+1)** Erdos189Problem
- **DR35e (+1)** Erdos571Problem
- **DR35f (+1)** LagrangeFourSquaresOQ04
- **DR35g (+2)** Erdos250Problem, Erdos384Problem
- **DR35h (+1)** Erdos530Problem
- **DR35i (+1)** Erdos548Aristotle
- **DR35j (+1)** Erdos476Aristotle

### Highest-value new recipes (rename-map §7v)
- **`inner x y` → `inner 𝕜 x y`** (scalar field explicit first) — a single fix cascades away follow-on `det`/inner errors.
- **Forward references to axioms/lemmas declared later in the same file now hard-error** — reorder so declarations precede use (axiom count preserved; pure reorder).
- **Mathlib added `SimpleGraph.pathGraph`** → same-named imported local defs become "Ambiguous term"; qualify local refs with their namespace.
- `Finset.mem_product` alone no longer reduces `A.product A` membership → add `Finset.product_eq_sprod` to the simp set.

### Statement repairs
None — all fixes are faithful migration repairs. Erdos530 (axiom reorder) and Erdos156ProblemAristotle (companion→import-shim) preserve axiom/assumption counts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)