### PR TITLE
migrate(v4.31): Doctor increment 26 — tm/pd/rewrite/instance-synth (A-M partition) (+21 GREEN)

### DIFF
--- a/proofs/Proofs/AlgebraicNumbersCountableOQ01OQ01OQ01.lean
+++ b/proofs/Proofs/AlgebraicNumbersCountableOQ01OQ01OQ01.lean
@@ -47,6 +47,14 @@ open AlgebraicNumbersCountableOQ01OQ01
 
 namespace AlgebraicNumbersCountableOQ01OQ01OQ01
 
+/-- v4.31 compat (#38065): the parent's `Algebra.IsAlgebraic K (algebraicIntermediateField K L)`
+instance no longer unifies through the `algebraicNumbersField` abbreviation during
+instance search. Re-expose it directly at the specialized `ℚ ⊆ ℂ` so downstream
+`inferInstance`/`perfectField` calls resolve. -/
+instance instAlgebraicNumbersFieldIsAlgebraic :
+    Algebra.IsAlgebraic ℚ algebraicNumbersField :=
+  AlgebraicNumbersCountableOQ01OQ01.algebraicIntermediateField_isAlgebraic (K := ℚ) (L := ℂ)
+
 /- ============================================================
    § 1 : ℚ is perfect; its algebraic extensions are separable
    ============================================================ -/

--- a/proofs/Proofs/AlgebraicNumbersCountableOQ01OQ03.lean
+++ b/proofs/Proofs/AlgebraicNumbersCountableOQ01OQ03.lean
@@ -75,7 +75,15 @@ construction supplies the second (every algebraic number is, by definition,
 algebraic over `ℚ`). -/
 instance instIsAlgClosure : IsAlgClosure ℚ algebraicNumbersField where
   isAlgClosed := inferInstance
-  isAlgebraic := inferInstance
+  isAlgebraic := AlgebraicNumbersCountableOQ01OQ01.algebraicIntermediateField_isAlgebraic (K := ℚ) (L := ℂ)
+
+/-- v4.31 compat (#38065): `IsAlgClosure ℚ (AlgebraicClosure ℚ)` no longer
+synthesizes automatically — the `Algebra.IsAlgebraic` half is not an instance for
+`AlgebraicClosure`. Re-assemble it from `IsAlgClosed` (still an instance) and
+`AlgebraicClosure.isAlgebraic`. -/
+instance instIsAlgClosureAbstract : IsAlgClosure ℚ (AlgebraicClosure ℚ) where
+  isAlgClosed := inferInstance
+  isAlgebraic := AlgebraicClosure.isAlgebraic ℚ
 
 /- ============================================================
    § 2 : Identification with the abstract `AlgebraicClosure ℚ`

--- a/proofs/Proofs/BaselProblemOQ01OQ01.lean
+++ b/proofs/Proofs/BaselProblemOQ01OQ01.lean
@@ -43,8 +43,8 @@ theorem zetaFive_partial_nonneg (k : ℕ) : 0 ≤ zetaFivePartialSum k := by
 theorem zetaFive_partial_mono {j k : ℕ} (h : j ≤ k) :
     zetaFivePartialSum j ≤ zetaFivePartialSum k := by
   unfold zetaFivePartialSum
-  apply Finset.sum_le_sum_of_subset
-  exact Finset.range_mono h
+  apply Finset.sum_le_sum_of_subset_of_nonneg (Finset.range_mono h)
+  intro i _ _; positivity
 
 /-- ζ(5) ≥ 1/1^5 = 1 (from the first term). -/
 theorem zetaFive_ge_one_from_partial :
@@ -71,9 +71,9 @@ theorem zetaFive_ge_1_03 : 1 + 1 / 32 = (33 : ℝ) / 32 := by norm_num
     This gives a crude but useful upper bound on the tail. -/
 theorem tail_term_le_inverse_sq (n : ℕ) :
     1 / ((n + 1 : ℝ) ^ 5) ≤ 1 / ((n + 1 : ℝ) ^ 2) := by
-  apply div_le_div_of_nonneg_left one_pos
-  · positivity
-  · exact pow_le_pow_left (by positivity) (by linarith) (by omega)
+  gcongr
+  · norm_num
+  · nlinarith [Nat.cast_nonneg (α := ℝ) n]
 
 /-- The tail from index k is bounded by the tail of 1/n^2 from index k.
     Since ∑_{n≥k} 1/n^2 ≤ 2/k (integral comparison), this gives
@@ -82,7 +82,9 @@ theorem tail_bounded_by_harmonic_sq (k : ℕ) :
     -- Each tail term of ζ(5) is bounded by the corresponding term of ζ(2)
     ∀ n : ℕ, 1 / ((k + n + 1 : ℝ) ^ 5) ≤ 1 / ((k + n + 1 : ℝ) ^ 2) := by
   intro n
-  exact tail_term_le_inverse_sq (k + n)
+  have := tail_term_le_inverse_sq (k + n)
+  push_cast at this ⊢
+  convert this using 3 <;> ring
 
 -- ============================================================
 -- Part III: Irrationality Measure

--- a/proofs/Proofs/BorsukUlamOQ02OQ01OQ01OQ02OQ03OQ01.lean
+++ b/proofs/Proofs/BorsukUlamOQ02OQ01OQ01OQ02OQ03OQ01.lean
@@ -77,7 +77,7 @@ theorem buDim_crt_semiprime_proved (p q d : ℕ)
   have heq : buDimFormula (p * q) d = buDim p d ⊔ buDim q d := by
     rw [buDimFormula, Nat.primeFactors_mul hp.ne_zero hq.ne_zero,
         Nat.Prime.primeFactors hp, Nat.Prime.primeFactors hq]
-    simp only [Finset.sup_insert, Finset.sup_singleton]
+    rw [Finset.sup_union, Finset.sup_singleton, Finset.sup_singleton]
   exact hle.trans heq.le
 
 -- ============================================================
@@ -97,11 +97,11 @@ theorem buDim_semiprime_eq_max_proved (p q d : ℕ)
 theorem not_exotic_semiprime_proved (p q d : ℕ)
     (hp : Nat.Prime p) (hq : Nat.Prime q) (hpq : p ≠ q) :
     ¬ IsExotic (p * q) d := by
-  intro ⟨hexot⟩
+  intro hexot
   have hle : buDim (p * q) d ≤ buDimFormula (p * q) d := by
     have h2 : 2 ≤ p * q := by nlinarith [hp.two_le, hq.two_le]
     exact buDim_le_formula _ _ h2
-  exact absurd hle hexot
+  exact absurd hle (not_le.mpr hexot)
 
 -- ============================================================
 -- PART 3: Concrete Instances

--- a/proofs/Proofs/BorsukUlamOQ03OQ02.lean
+++ b/proofs/Proofs/BorsukUlamOQ03OQ02.lean
@@ -78,8 +78,9 @@ theorem degreeOfEnd_conj (e : G ≃+ ℤ) (f : G →+ G) (n : ℤ) :
   have hcn : c n = e (f (e.symm n)) := rfl
   have hc1 : c 1 = degreeOfEnd e f := rfl
   have key : c n = c 1 * n := by
-    have := c.map_zsmul 1 n
-    simpa [mul_comm] using this
+    conv_lhs => rw [show n = n • (1:ℤ) by simp]
+    rw [c.map_zsmul]
+    simp [mul_comm]
   rw [hcn, hc1] at key
   simpa using key
 
@@ -96,7 +97,7 @@ theorem degreeOfEnd_comp (e : G ≃+ ℤ) (g f : G →+ G) :
   rw [hf]
   -- now `e (g (e⁻¹ (deg f))) = deg g * deg f` is exactly the conjugation identity at `n = deg f`
   have := degreeOfEnd_conj e g (degreeOfEnd e f)
-  simpa using this
+  simpa [degreeOfEnd] using this
 
 /-- The degree does **not** depend on the chosen identification `e : G ≃+ ℤ`.  This is the
 well-definedness of the Brouwer degree: any two identifications of `Hₙ` with `ℤ` give the same
@@ -120,7 +121,7 @@ theorem degreeOfEnd_indep (e₁ e₂ : G ≃+ ℤ) (f : G →+ G) :
     simp only [hψ, AddMonoidHom.comp_apply, AddEquiv.coe_toAddMonoidHom, ha,
       e₁.symm_apply_apply, e₂.apply_symm_apply]
   have hlin : ψ (d * a) = d * ψ a := by
-    have := ψ.map_zsmul a d
+    have := ψ.map_zsmul d a
     simpa [smul_eq_mul] using this
   -- Conclude `degreeOfEnd e₂ f = d`.
   have : degreeOfEnd e₂ f = ψ (d * a) := by

--- a/proofs/Proofs/CayleyHamiltonMinpolyOQ05OQ02.lean
+++ b/proofs/Proofs/CayleyHamiltonMinpolyOQ05OQ02.lean
@@ -73,7 +73,7 @@ theorem minpoly_natDegree_dvd_finrank (x : L) (hx : IsIntegral K x) :
 theorem finrank_eq_minpoly_mul (x : L) (hx : IsIntegral K x) :
     finrank K L = (minpoly K x).natDegree * finrank (↥K⟮x⟯) L := by
   rw [← simple_extension_dim x hx]
-  exact finrank_mul_finrank K (↥K⟮x⟯) L
+  exact (finrank_mul_finrank K (↥K⟮x⟯) L).symm
 
 /-- The minimal polynomial degree is at most the extension degree. -/
 theorem minpoly_natDegree_le_finrank (x : L) (hx : IsIntegral K x)
@@ -173,13 +173,16 @@ degree drop to concrete factorization.
 theorem irred_degree_dvd_splitting_finrank (p : K[X])
     (hirr : Irreducible p) (hmonic : p.Monic) :
     p.natDegree ∣ finrank K p.SplittingField := by
-  -- p has a root α in its splitting field
+  -- p has a root α in its splitting field (separability-free existence: v4.31
+  -- compat #38065 — `Irreducible.separable` needs a perfect/char-zero base field,
+  -- which is not assumed here, so obtain the root directly from `Splits`).
   have hsplit := SplittingField.splits p
-  have hsep := hirr.separable
-  have hcard : Fintype.card (p.rootSet p.SplittingField) = p.natDegree :=
-    Polynomial.card_rootSet_eq_natDegree hsep hsplit
-  obtain ⟨⟨α, hα_mem⟩⟩ := Fintype.card_pos_iff.mp (by rw [hcard]; exact hirr.natDegree_pos)
-  have hα_root : aeval α p = 0 := (Polynomial.mem_rootSet.mp hα_mem).2
+  have hα_root_exists : ∃ α : p.SplittingField, aeval α p = 0 := by
+    have hdeg : (p.map (algebraMap K p.SplittingField)).degree ≠ 0 := by
+      rw [degree_map]; exact (degree_pos_of_irreducible hirr).ne'
+    obtain ⟨x, hx⟩ := hsplit.exists_eval_eq_zero hdeg
+    exact ⟨x, by rw [aeval_def, ← eval_map]; exact hx⟩
+  obtain ⟨α, hα_root⟩ := hα_root_exists
   have hα_int : IsIntegral K α := .of_finite K α
   have hminp : minpoly K α = p :=
     (minpoly.eq_of_irreducible_of_monic hirr hα_root hmonic).symm

--- a/proofs/Proofs/ChebyshevBoundsOQ03OQ02.lean
+++ b/proofs/Proofs/ChebyshevBoundsOQ03OQ02.lean
@@ -55,8 +55,8 @@ open scoped Topology
 theorem log_le_six_mul_rpow {x : ℝ} (hx : 0 < x) :
     Real.log x ≤ 6 * x ^ ((1 : ℝ) / 6) := by
   have h := Real.log_le_rpow_div hx.le (by norm_num : (0 : ℝ) < 1 / 6)
-  rw [div_div_eq_mul_div, one_mul] at h  -- x ^ (1/6) / (1/6)
-  simpa using h
+  calc Real.log x ≤ x ^ ((1:ℝ)/6) / (1/6) := h
+    _ = 6 * x ^ ((1:ℝ)/6) := by ring
 
 /-- `log x · x^{1/3} ≤ 6·√x` for `x > 0`: the key `log`-eating step. -/
 theorem logx_mul_rpow_third_le {x : ℝ} (hx : 0 < x) :
@@ -88,8 +88,7 @@ theorem psi_sub_theta_le_const_mul_sqrt {x : ℝ} (hx : 2 ≤ x) :
     positivity
   · -- 2 ≤ K : peel off the dominant n = 2 term
     have h2mem : (2 : ℕ) ∈ Finset.Icc 2 K := by rw [Finset.mem_Icc]; omega
-    rw [← Finset.add_sum_erase _ (fun n => θ (x ^ ((1 : ℝ) / (n : ℝ)))) h2mem,
-      Finset.Icc_erase_left]
+    rw [← Finset.add_sum_erase _ _ h2mem, Finset.Icc_erase_left]
     -- goal: θ (x ^ (1/2)) + Σ_{n ∈ Ioc 2 K} θ (x ^ (1/n)) ≤ (log 4 + 12) √x
     -- bound the n = 2 term: θ(√x) ≤ log 4 · √x
     have hn2 : θ (x ^ ((1 : ℝ) / ((2 : ℕ) : ℝ))) ≤ Real.log 4 * Real.sqrt x := by
@@ -122,7 +121,8 @@ theorem psi_sub_theta_le_const_mul_sqrt {x : ℝ} (hx : 2 ≤ x) :
               (mul_nonneg hlog4 (Real.rpow_nonneg hx0.le _))
             -- (K - 2 : ℕ) ≤ K ≤ log x / log 2
             have hKle : (K : ℝ) ≤ Real.log x / Real.log 2 :=
-              Nat.floor_le (by positivity)
+              Nat.floor_le (div_nonneg (Real.log_nonneg hx1)
+                (Real.log_nonneg (by norm_num)))
             have : ((K - 2 : ℕ) : ℝ) ≤ (K : ℝ) := by
               exact_mod_cast Nat.sub_le K 2
             linarith

--- a/proofs/Proofs/ContinuumHypothesisOQ02OQ01.lean
+++ b/proofs/Proofs/ContinuumHypothesisOQ02OQ01.lean
@@ -109,7 +109,7 @@ theorem general_konig_cofinality {κ : Cardinal.{0}} (hκ : ℵ₀ ≤ κ) :
 
 /-- The parent's special case recovered: cf(2^ℵ₀) > ℵ₀. -/
 theorem konig_cofinality_aleph0 :
-    (ℵ₀ : Cardinal.{0}) < (2 ^ (ℵ₀ : Cardinal.{0})).ord.cof :=
+    (ℵ₀ : Cardinal.{0}) < ((2 : Cardinal.{0}) ^ (ℵ₀ : Cardinal.{0})).ord.cof :=
   general_konig_cofinality le_rfl
 
 -- ============================================================
@@ -127,7 +127,9 @@ theorem diagonal_dominates (e : ℕ → ℕ → ℕ) (j : ℕ) :
       (fun k => (Finset.range (k + 1)).sup (fun i => e i k) + 1) := by
   refine ⟨j, fun k hk => ?_⟩
   have hmem : j ∈ Finset.range (k + 1) := Finset.mem_range.mpr (by omega)
-  have hle : e j k ≤ (Finset.range (k + 1)).sup (fun i => e i k) := Finset.le_sup hmem
+  have hle : e j k ≤ (Finset.range (k + 1)).sup (fun i => e i k) :=
+    Finset.le_sup (f := fun i => e i k) hmem
+  show e j k ≤ (Finset.range (k + 1)).sup (fun i => e i k) + 1
   omega
 
 /-- **An unbounded family is uncountable: ℵ₁ ≤ #F.**

--- a/proofs/Proofs/Erdos370Problem.lean
+++ b/proofs/Proofs/Erdos370Problem.lean
@@ -91,7 +91,10 @@ theorem gpf_prime (p : ℕ) (hp : p.Prime) : gpf p = p := by
 
 /-- gpf of a prime power is the prime. -/
 theorem gpf_prime_pow (p : ℕ) (hp : p.Prime) (k : ℕ) (hk : k ≥ 1) : gpf (p ^ k) = p := by
-  simp [gpf, Nat.Prime.primeFactorsList_pow hp]
+  simp only [gpf, Nat.Prime.primeFactorsList_pow hp]
+  rcases k with _ | k
+  · omega
+  · simp [List.getLast?_replicate]
 
 /-- gpf of a product is at most the max of the gpfs. -/
 axiom gpf_mul_le (m n : ℕ) (hm : m > 1) (hn : n > 1) :
@@ -126,7 +129,7 @@ def SteinerbergerConstruction (m : ℕ) : ℕ := m ^ 2 - 1
 theorem steinerberger_factorization (m : ℕ) (hm : m ≥ 2) :
     SteinerbergerConstruction m = (m - 1) * (m + 1) := by
   unfold SteinerbergerConstruction
-  zify [show 1 ≤ m ^ 2 from by positivity, show 1 ≤ m from by omega]
+  zify [show 1 ≤ m ^ 2 by nlinarith, show 1 ≤ m by omega]
   ring
 
 /-- For the construction, n + 1 = m². -/

--- a/proofs/Proofs/Erdos441Aristotle.lean
+++ b/proofs/Proofs/Erdos441Aristotle.lean
@@ -98,8 +98,7 @@ theorem sqrt_2N_bound (N : ℕ) : Nat.sqrt (2 * N) ≤ 2 * Nat.sqrt N + 1 := by
 -/
 
 /-- lcm(a, a) = a. -/
-theorem lcm_self_eq (a : ℕ) : Nat.lcm a a = a := by
-  simp [Nat.lcm]
+theorem lcm_self_eq (a : ℕ) : Nat.lcm a a = a := Nat.lcm_self a
 
 /-- lcm(a, b) ≤ a * b for positive a, b. -/
 theorem lcm_le_mul (a b : ℕ) : Nat.lcm a b ≤ a * b := by
@@ -118,7 +117,8 @@ theorem lcm_le_sq (a b k : ℕ) (ha : a ≤ k) (hb : b ≤ k) : Nat.lcm a b ≤ 
 theorem erdosFirstPart_le_N (N x : ℕ) (hN : N ≥ 1) (hx : x ∈ ErdosFirstPart N) : x ≤ N := by
   have h1 := erdosFirstPart_le_sqrt N x hx
   have h2 : Nat.sqrt (N / 2) ≤ N := by
-    apply Nat.sqrt_le_self
+    calc Nat.sqrt (N / 2) ≤ N / 2 := Nat.sqrt_le_self _
+      _ ≤ N := Nat.div_le_self _ _
   omega
 
 /-- LCM of two elements in ErdosFirstPart is at most N.

--- a/proofs/Proofs/Erdos445Problem.lean
+++ b/proofs/Proofs/Erdos445Problem.lean
@@ -42,8 +42,8 @@ def OpenInterval (n L : ℕ) : Finset ℕ :=
 
 /-- There exist inverse pairs in the interval (n, n + p^c) -/
 def HasInversePairInInterval (p : ℕ) [Fact (Nat.Prime p)] (n : ℕ) (c : ℝ) : Prop :=
-  ∃ a b : ℕ, a ∈ OpenInterval n (Nat.floor (p ^ c)) ∧
-             b ∈ OpenInterval n (Nat.floor (p ^ c)) ∧
+  ∃ a b : ℕ, a ∈ OpenInterval n (Nat.floor ((p : ℝ) ^ c)) ∧
+             b ∈ OpenInterval n (Nat.floor ((p : ℝ) ^ c)) ∧
              HasInverse p a b
 
 /- ## Part 2: The Main Conjecture -/
@@ -113,7 +113,7 @@ theorem current_knowledge :
     constructor
     · exact hx.1
     · calc x ≤ 3/4 := hx.2
-           _ < 1 := by norm_num
+           _ ≤ 1 := by norm_num
 
 /- ## Part 6: Summary -/
 

--- a/proofs/Proofs/Erdos453OQ02.lean
+++ b/proofs/Proofs/Erdos453OQ02.lean
@@ -54,7 +54,7 @@ gives that elements of Nat.nth over an infinite set satisfy the predicate.
 -/
 theorem nthPrime_is_prime (n : ℕ) (hn : n ≥ 1) : (nthPrime n).Prime := by
   unfold nthPrime
-  skip
+  rw [if_neg (by omega : n ≠ 0)]
   exact Nat.nth_mem_of_infinite Nat.infinite_setOf_prime (n - 1)
 
 /--
@@ -91,13 +91,13 @@ theorem nthPrime_values :
     nthPrime 1 = 2 ∧ nthPrime 2 = 3 ∧ nthPrime 3 = 5 ∧ nthPrime 4 = 7 := by
   refine ⟨?_, ?_, ?_, ?_⟩
   · -- nthPrime 1 = Nat.nth Nat.Prime 0 = 2
-    unfold nthPrime; simp; exact Nat.nth_prime_zero_eq_two
+    unfold nthPrime; simp
   · -- nthPrime 2 = Nat.nth Nat.Prime 1 = 3
-    unfold nthPrime; simp; exact Nat.nth_prime_one_eq_three
+    unfold nthPrime; simp
   · -- nthPrime 3 = Nat.nth Nat.Prime 2 = 5
-    unfold nthPrime; simp; exact Nat.nth_prime_two_eq_five
+    unfold nthPrime; simp
   · -- nthPrime 4 = Nat.nth Nat.Prime 3 = 7
-    unfold nthPrime; simp; exact nth_prime_three_eq_seven
+    unfold nthPrime; simp
 
 /-
 ## Part II: Remaining Axioms (Deep Results)

--- a/proofs/Proofs/Erdos499Problem.lean
+++ b/proofs/Proofs/Erdos499Problem.lean
@@ -220,13 +220,11 @@ theorem two_by_two_diagonals (a : ℝ) (ha : 0 ≤ a) (ha' : a ≤ 1) :
     (∃ σ : Equiv.Perm (Fin 2), diagonalProduct M σ = (1-a) * (1-a)) := by
   refine ⟨?_, ?_⟩
   · -- Identity permutation: M 0 0 * M 1 1 = a * a
-    simp only [diagonalProduct, Fin.prod_univ_two, Equiv.Perm.one_apply,
-      Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.head_cons, Matrix.head_fin_const]
+    simp [diagonalProduct, Fin.prod_univ_two, Equiv.Perm.one_apply]
   · -- Swap permutation: M 0 1 * M 1 0 = (1-a) * (1-a)
     refine ⟨Equiv.swap (0 : Fin 2) 1, ?_⟩
-    simp only [diagonalProduct, Fin.prod_univ_two, Equiv.swap_apply_left,
-      Equiv.swap_apply_right, Matrix.cons_val_zero, Matrix.cons_val_one,
-      Matrix.head_cons, Matrix.head_fin_const]
+    simp [diagonalProduct, Fin.prod_univ_two, Equiv.swap_apply_left,
+      Equiv.swap_apply_right]
 
 /- 
 For a 2×2 doubly stochastic matrix, max(a², (1-a)²) ≥ 1/4.
@@ -276,7 +274,8 @@ Key results:
 theorem erdos_499_summary :
     (∀ n (hn : n ≠ 0) M (hM : IsDoublyStochastic M),
       ∃ σ : Equiv.Perm (Fin n), (n : ℝ)⁻¹ ^ n ≤ diagonalProduct M σ) ∧
-    (∀ n (hn : n ≠ 0) M (hM : IsDoublyStochastic M),
+    (∀ (n : ℕ) (hn : n ≠ 0) (M : Matrix (Fin n) (Fin n) ℝ)
+      (hM : IsDoublyStochastic M),
       (n : ℝ)⁻¹ ^ n * n ! ≤ perm' M) :=
   ⟨fun n hn M hM => marcus_minc_theorem hn M hM,
    fun n hn M hM => van_der_waerden hn M hM⟩

--- a/proofs/Proofs/Erdos500Problem.lean
+++ b/proofs/Proofs/Erdos500Problem.lean
@@ -26,7 +26,7 @@ import Mathlib.Tactic
 /- ## Core Definitions -/
 
 /-- A 3-uniform hypergraph on vertex set Fin n: a collection of 3-element subsets. -/
-def Hypergraph3 (n : ℕ) := Finset (Finset (Fin n))
+abbrev Hypergraph3 (n : ℕ) := Finset (Finset (Fin n))
 
 /-- A hypergraph is 3-uniform if every edge has exactly 3 vertices. -/
 def IsThreeUniform (n : ℕ) (H : Hypergraph3 n) : Prop :=

--- a/proofs/Proofs/Erdos543Problem.lean
+++ b/proofs/Proofs/Erdos543Problem.lean
@@ -118,15 +118,7 @@ def ErdosCounterConjecture : Prop :=
 theorem conjectures_complementary : LittleOConjecture ↔ ¬ErdosCounterConjecture := by
   unfold LittleOConjecture ErdosCounterConjecture
   push_neg
-  constructor <;> intro h
-  · intro ⟨ε, hε, hN⟩
-    obtain ⟨N₀, hN₀⟩ := h ε hε
-    obtain ⟨N, hNge, hNgt⟩ := hN N₀
-    exact (hNgt.trans_le (hN₀ N hNge)).false
-  · intro ε hε
-    by_contra hc
-    push_neg at hc
-    exact h ε hε (fun N₀ => ⟨N₀, le_refl _, hc N₀⟩)
+  rfl
 
 /-- **ChatGPT-Tang Theorem:** The little-o conjecture is FALSE.
 

--- a/proofs/Proofs/Erdos592Problem.lean
+++ b/proofs/Proofs/Erdos592Problem.lean
@@ -41,7 +41,7 @@ def IsPartitionOrdinal (α : Ordinal) : Prop :=
 
 /-- β has the partition property if ω^β → (ω^β, 3)². -/
 def HasPartitionProperty (β : Ordinal) : Prop :=
-  IsPartitionOrdinal (Ordinal.omega ^ β)
+  IsPartitionOrdinal (Ordinal.omega0 ^ β)
 
 /- ## Specker's Results (1957) -/
 
@@ -52,7 +52,7 @@ def HasPartitionProperty (β : Ordinal) : Prop :=
 /-- An ordinal is additively indecomposable if it equals ω^γ for some ordinal γ.
     Equivalently, for all δ₁ δ₂ < β, δ₁ + δ₂ < β. -/
 def IsAdditivelyIndecomposable (β : Ordinal) : Prop :=
-  ∃ γ : Ordinal, β = Ordinal.omega ^ γ
+  ∃ γ : Ordinal, β = Ordinal.omega0 ^ γ
 
 /- ## Schipperus Classification (2010) -/
 

--- a/proofs/Proofs/EulerTotientOQ01OQ01OQ01.lean
+++ b/proofs/Proofs/EulerTotientOQ01OQ01OQ01.lean
@@ -15,7 +15,7 @@ theorem".
 The literal factorization identity is **already in Mathlib** as
 `ArithmeticFunction.carmichael_factorization`:
 
-    Carmichael n = n.primeFactors.lcm (fun p ↦ Carmichael (p ^ n.factorization p))
+    carmichael n = n.primeFactors.lcm (fun p ↦ carmichael (p ^ n.factorization p))
 
 together with the per-prime-power closed forms
 `carmichael_pow_of_prime_ne_two` (λ(p^k) = φ(p^k) for odd p) and
@@ -31,10 +31,10 @@ these would be a thin wrapper, so this file does **not** reprove them — it
    is not stated there.
 
 2. **Concrete evaluations** that are genuinely absent from Mathlib, including
-   the first Carmichael number 561 = 3·11·17:
+   the first carmichael number 561 = 3·11·17:
        λ(561) = lcm(2, 10, 16) = 80,  and  80 ∣ 560,
    the Korselt-style divisibility λ(561) ∣ (561 − 1) that makes 561 a
-   Carmichael number.
+   carmichael number.
 
 `Carmichael` is Mathlib's reduced totient (the exponent of (ℤ/nℤ)ˣ), the same
 function the parent file defines locally as `Monoid.exponent (ZMod n)ˣ`.
@@ -50,7 +50,7 @@ namespace EulerTotientOQ01OQ01OQ01
 `(ℤ/pℤ)ˣ` is cyclic of order `p − 1`).  Specialises Mathlib's
 `carmichael_pow_of_prime_ne_two` at exponent 1. -/
 theorem carmichael_odd_prime {p : ℕ} (hp : p.Prime) (hp2 : p ≠ 2) :
-    Carmichael p = p - 1 := by
+    carmichael p = p - 1 := by
   have h := carmichael_pow_of_prime_ne_two 1 hp hp2
   rwa [pow_one, Nat.totient_prime hp] at h
 
@@ -58,7 +58,7 @@ theorem carmichael_odd_prime {p : ℕ} (hp : p.Prime) (hp2 : p ≠ 2) :
 closed form `λ(p^k) = p^{k-1}·(p-1) = φ(p^k)`.  Combines Mathlib's
 `carmichael_pow_of_prime_ne_two` with `Nat.totient_prime_pow`. -/
 theorem carmichael_odd_prime_pow {p k : ℕ} (hp : p.Prime) (hp2 : p ≠ 2)
-    (hk : 0 < k) : Carmichael (p ^ k) = p ^ (k - 1) * (p - 1) := by
+    (hk : 0 < k) : carmichael (p ^ k) = p ^ (k - 1) * (p - 1) := by
   rw [carmichael_pow_of_prime_ne_two k hp hp2, Nat.totient_prime_pow hp hk]
 
 /-! ## The explicit closed form for odd `n` -/
@@ -74,7 +74,7 @@ reduces `λ(n)` to the lcm of the per-prime-power values `λ(p^{k_p})`, and each
 of those collapses to `p^{k_p-1}(p-1)` because every prime factor of an odd
 number is itself odd. -/
 theorem carmichael_odd_eq_lcm_explicit {n : ℕ} (hn : n ≠ 0) (hodd : Odd n) :
-    Carmichael n
+    carmichael n
       = n.primeFactors.lcm (fun p => p ^ (n.factorization p - 1) * (p - 1)) := by
   haveI : NeZero n := ⟨hn⟩
   rw [carmichael_factorization n]
@@ -97,11 +97,11 @@ them here as the headline corollaries that motivate the Carmichael function. -/
 `ℤ/nℤ` is killed by `λ(n)`, i.e. `a^{λ(n)} = 1`.  This is the sharp form of
 Euler's theorem `a^{φ(n)} ≡ 1`. -/
 theorem pow_carmichael_eq_one {n : ℕ} (a : (ZMod n)ˣ) :
-    a ^ Carmichael n = 1 := pow_carmichael a
+    a ^ carmichael n = 1 := pow_carmichael a
 
 /-- `λ(n) ∣ φ(n)` (Mathlib `carmichael_dvd_totient`): the Carmichael exponent
 divides Euler's totient, so `λ(n)` is never larger than `φ(n)` and refines it. -/
-theorem carmichael_dvd_totient' (n : ℕ) : Carmichael n ∣ n.totient :=
+theorem carmichael_dvd_totient' (n : ℕ) : carmichael n ∣ n.totient :=
   carmichael_dvd_totient n
 
 /-! ## Concrete evaluations
@@ -110,15 +110,15 @@ These specific values are not in Mathlib.  They exercise the multiplicative law
 on genuinely distinct primes. -/
 
 /-- `λ(15) = lcm(λ(3), λ(5)) = lcm(2, 4) = 4`. -/
-theorem carmichael_15 : Carmichael 15 = 4 := by
+theorem carmichael_15 : carmichael 15 = 4 := by
   rw [show (15 : ℕ) = 3 * 5 from rfl, carmichael_mul (by decide),
       carmichael_odd_prime (p := 3) (by norm_num) (by norm_num),
       carmichael_odd_prime (p := 5) (by norm_num) (by norm_num)]
   decide
 
-/-- **The first Carmichael number.** `561 = 3 · 11 · 17`, and
+/-- **The first carmichael number.** `561 = 3 · 11 · 17`, and
 `λ(561) = lcm(λ(3), λ(11), λ(17)) = lcm(2, 10, 16) = 80`. -/
-theorem carmichael_561 : Carmichael 561 = 80 := by
+theorem carmichael_561 : carmichael 561 = 80 := by
   rw [show (561 : ℕ) = 3 * (11 * 17) from rfl,
       carmichael_mul (by decide), carmichael_mul (by decide),
       carmichael_odd_prime (p := 3) (by norm_num) (by norm_num),
@@ -128,9 +128,9 @@ theorem carmichael_561 : Carmichael 561 = 80 := by
 
 /-- **Korselt's criterion witness for 561.** Since `λ(561) = 80` divides
 `561 − 1 = 560`, every `a` coprime to 561 satisfies `a^{560} ≡ 1 (mod 561)`,
-which is exactly why 561 is a Carmichael (Fermat-pseudoprime-to-every-base)
+which is exactly why 561 is a carmichael (Fermat-pseudoprime-to-every-base)
 number. -/
-theorem carmichael_561_dvd_560 : Carmichael 561 ∣ 560 := by
+theorem carmichael_561_dvd_560 : carmichael 561 ∣ 560 := by
   rw [carmichael_561]; decide
 
 end EulerTotientOQ01OQ01OQ01

--- a/proofs/Proofs/LawOfCosinesOQ04OQ01.lean
+++ b/proofs/Proofs/LawOfCosinesOQ04OQ01.lean
@@ -152,15 +152,15 @@ theorem angle_bisector_length_inner (A B C : V) (s : ℝ)
     `(w − bc)·(s(b+c) − c)`. -/
 theorem angle_bisector_ratio_inner (A B C : V) (s : ℝ)
     (hs : s * (‖A - C‖ + ‖A - B‖) = ‖A - B‖) :
-    ‖A - C‖ * ⟪B - A, ((1 - s) • B + s • C) - A⟫_ℝ
-      = ‖A - B‖ * ⟪C - A, ((1 - s) • B + s • C) - A⟫_ℝ := by
+    ‖A - C‖ * ⟪B - A, ((1 - s) • B + s • C) - A⟫
+      = ‖A - B‖ * ⟪C - A, ((1 - s) • B + s • C) - A⟫ := by
   have hD : ((1 - s) • B + s • C) - A = (1 - s) • (B - A) + s • (C - A) := by
     module
   rw [hD, inner_add_right, inner_add_right, real_inner_smul_right, real_inner_smul_right,
     real_inner_smul_right, real_inner_smul_right, real_inner_self_eq_norm_sq,
     real_inner_self_eq_norm_sq, real_inner_comm (C - A) (B - A), norm_sub_rev B A,
     norm_sub_rev C A]
-  linear_combination (⟪B - A, C - A⟫_ℝ - ‖A - C‖ * ‖A - B‖) * hs
+  linear_combination (⟪C - A, B - A⟫ - ‖A - C‖ * ‖A - B‖) * hs
 
 /-
 ## Summary

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -256,14 +256,14 @@ BirthdayProblemOQ03OQ03	RESIDUAL	proof-drift
 BorsukUlamOQ02	RESIDUAL	unknown-const:EuclideanSpace.equiv_symm_pi_lp_apply
 BorsukUlamOQ02OQ01OQ01OQ02	GREEN	
 BorsukUlamOQ02OQ01OQ01OQ02OQ03	GREEN	
-BorsukUlamOQ02OQ01OQ01OQ02OQ03OQ01	RESIDUAL	type-mismatch
+BorsukUlamOQ02OQ01OQ01OQ02OQ03OQ01	GREEN	
 BorsukUlamOQ02OQ01OQ04	GREEN	
 BorsukUlamOQ02OQ01OQ04OQ01	GREEN	
 BorsukUlamOQ02OQ02	RESIDUAL	instance-synth
 BorsukUlamOQ02OQ03	GREEN	
 BorsukUlamOQ03	GREEN	
 BorsukUlamOQ03OQ01	RESIDUAL	rewrite-drift
-BorsukUlamOQ03OQ02	RESIDUAL	type-mismatch
+BorsukUlamOQ03OQ02	GREEN	
 BorsukUlamOQ03OQ03	GREEN	
 BorsukUlamOQ04OQ03	RESIDUAL	instance-synth
 BoundedPrimeGapsOQ01OQ02	GREEN	

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -1949,7 +1949,7 @@ EulerIdentityOQ01OQ02OQ01	RESIDUAL	instance-synth
 EulerPolyhedralFormula	RESIDUAL	proof-drift
 EulerPolyhedralFormulaOQ01OQ02	RESIDUAL	unknown-const:SimpleGraph.Colorable.mk
 EulerPolyhedralOQ01OQ04	GREEN	
-EulerTotientOQ01OQ01OQ01	RESIDUAL	rewrite-drift
+EulerTotientOQ01OQ01OQ01	GREEN	
 EulerTotientOQ01OQ02OQ01	GREEN	
 EulerTotientOQ01OQ02OQ02	GREEN	
 EulerTotientOQ01OQ02OQ03	GREEN	

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -177,7 +177,7 @@ BallotProblemOQ03OQ02OQ03	RESIDUAL	proof-drift
 BallotProblemOQ03OQ03	RESIDUAL	unknown-const:Nat.one_le_succ
 BallotProblemOQ04OQ02	GREEN	
 BallotProblemOQ04OQ02OQ01	GREEN	
-BaselProblemOQ01OQ01	RESIDUAL	instance-synth
+BaselProblemOQ01OQ01	GREEN	
 BaselProblemOQ01OQ01OQ02	GREEN	
 BaselProblemOQ01OQ01OQ02Aristotle	GREEN	
 BaselProblemOQ01OQ01OQ02OQ03	GREEN	
@@ -468,7 +468,7 @@ ComplexityCore	GREEN
 ConjugacyClassEquationOQ01	GREEN	
 ConjugacyClassEquationOQ0102	GREEN	
 ContinuumHypothesisOQ02	RESIDUAL	unknown-const:Cardinal.cof_aleph
-ContinuumHypothesisOQ02OQ01	RESIDUAL	instance-synth
+ContinuumHypothesisOQ02OQ01	GREEN	
 CoprimeKTupleDensity	GREEN	
 CramersRule	GREEN	
 CramersRuleOQ01OQ02OQ03	GREEN	

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -1272,7 +1272,7 @@ Erdos441Aristotle	RESIDUAL	proof-drift
 Erdos442Problem	GREEN	
 Erdos443Problem	GREEN	
 Erdos444Problem	GREEN	
-Erdos445Problem	RESIDUAL	instance-synth
+Erdos445Problem	GREEN	
 Erdos446Problem	GREEN	
 Erdos447Problem	RESIDUAL	instance-synth
 Erdos449Problem	GREEN	
@@ -1336,7 +1336,7 @@ Erdos497Problem	GREEN
 Erdos498Problem	GREEN	
 Erdos499Problem	RESIDUAL	type-mismatch
 Erdos49Problem	GREEN	
-Erdos500Problem	RESIDUAL	instance-synth
+Erdos500Problem	GREEN	
 Erdos501Aristotle	RESIDUAL	instance-synth
 Erdos501Problem	RESIDUAL	unknown-const:independent_subset
 Erdos501ProblemProvable	RESIDUAL	unknown-const:independent_subset
@@ -1442,7 +1442,7 @@ Erdos588Problem	GREEN
 Erdos58Problem	GREEN	
 Erdos590Problem	GREEN	
 Erdos591Problem	GREEN	
-Erdos592Problem	RESIDUAL	instance-synth
+Erdos592Problem	GREEN	
 Erdos593Problem	GREEN	
 Erdos594Problem	GREEN	
 Erdos595Problem	GREEN	

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -1281,7 +1281,7 @@ Erdos44SidonLowerBound	GREEN
 Erdos450Problem	GREEN	
 Erdos451Problem	PRE-EXISTING	never-compiled:hp
 Erdos452Problem	GREEN	
-Erdos453OQ02	RESIDUAL	type-mismatch
+Erdos453OQ02	GREEN	
 Erdos453Problem	RESIDUAL	type-mismatch
 Erdos454Aristotle	GREEN	
 Erdos454Problem	RESIDUAL	type-mismatch

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -1268,7 +1268,7 @@ Erdos438Problem	GREEN
 Erdos439Problem	GREEN	
 Erdos43Problem	RESIDUAL	rewrite-drift
 Erdos440Problem	GREEN	
-Erdos441Aristotle	RESIDUAL	proof-drift
+Erdos441Aristotle	GREEN	
 Erdos442Problem	GREEN	
 Erdos443Problem	GREEN	
 Erdos444Problem	GREEN	

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -41,8 +41,8 @@ AbelRuffiniOQ11	GREEN
 AbelRuffiniObstructionOQ06	GREEN	
 AbundantNumberOQ0102	GREEN	
 AlgebraicNumbersCountableOQ01OQ01	GREEN	
-AlgebraicNumbersCountableOQ01OQ01OQ01	RESIDUAL	instance-synth
-AlgebraicNumbersCountableOQ01OQ03	RESIDUAL	instance-synth
+AlgebraicNumbersCountableOQ01OQ01OQ01	GREEN	
+AlgebraicNumbersCountableOQ01OQ03	GREEN	
 AlgebraicNumbersCountableOQ02	GREEN	
 AlgebraicNumbersCountableOQ02OQ02	GREEN	
 AlgebraicNumbersCountableOQ02OQ02OQ01	GREEN	

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -397,7 +397,7 @@ CayleyHamiltonMinpolyOQ05OQ01OQ01	RESIDUAL	unknown-const:isUnit_of_natDegree_eq_
 CayleyHamiltonMinpolyOQ05OQ01OQ02	RESIDUAL	unknown-const:dvd_of_mem_normalizedFactors
 CayleyHamiltonMinpolyOQ05OQ01OQ04WIP01	RESIDUAL	proof-drift
 CayleyHamiltonMinpolyOQ05OQ01OQ04WIP03	GREEN	
-CayleyHamiltonMinpolyOQ05OQ02	RESIDUAL	instance-synth
+CayleyHamiltonMinpolyOQ05OQ02	GREEN	
 CayleyHamiltonMinpolyOQ05OQ02OQ03	RESIDUAL	instance-synth
 CayleyHamiltonOQ01	GREEN	
 CayleyHamiltonOQ01OQ01	GREEN	
@@ -436,7 +436,7 @@ CevasTheoremNonEuclideanOQ02	GREEN
 CevasTheoremNonEuclideanOQ03	GREEN	
 CevasTheoremOQ01OQ03	RESIDUAL	proof-drift
 ChebyshevBoundsOQ03	GREEN	
-ChebyshevBoundsOQ03OQ02	RESIDUAL	type-mismatch
+ChebyshevBoundsOQ03OQ02	GREEN	
 ChebyshevBoundsOQ04Aristotle	GREEN	
 ChebyshevBoundsOQ0601	GREEN	
 ChebyshevPNTBridgeOQ01	RESIDUAL	partenat-removal

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -2210,8 +2210,8 @@ LawOfCosinesOQ01OQ01OQ01	GREEN
 LawOfCosinesOQ01OQ01OQ03	RESIDUAL	type-mismatch
 LawOfCosinesOQ01OQ04	RESIDUAL	type-mismatch
 LawOfCosinesOQ03OQ02	RESIDUAL	parse-error
-LawOfCosinesOQ04OQ01	RESIDUAL	type-mismatch
-LawOfCosinesOQ04OQ01Bisector	RESIDUAL	type-mismatch
+LawOfCosinesOQ04OQ01	GREEN	
+LawOfCosinesOQ04OQ01Bisector	GREEN	
 LawOfCosinesOQ07OQ01	GREEN	
 LawOfSinesOQ06	RESIDUAL	unknown-const:EuclideanSpace.inner_apply
 LawsOfLargeNumbers	GREEN	

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -1187,7 +1187,7 @@ Erdos367Problem	RESIDUAL	unknown-const:twoFullPart_le
 Erdos368Problem	GREEN	
 Erdos369Problem	RESIDUAL	unknown-const:Nat.dvd_of_dvd_of_dvd
 Erdos36Problem	RESIDUAL	unknown-const:white_lower
-Erdos370Problem	RESIDUAL	proof-drift
+Erdos370Problem	GREEN	
 Erdos371Problem	GREEN	
 Erdos372Problem	GREEN	
 Erdos374Problem	RESIDUAL	unknown-const:not_le_of_lt
@@ -1334,7 +1334,7 @@ Erdos495Problem	GREEN
 Erdos496Problem	GREEN	
 Erdos497Problem	GREEN	
 Erdos498Problem	GREEN	
-Erdos499Problem	RESIDUAL	type-mismatch
+Erdos499Problem	GREEN	
 Erdos49Problem	GREEN	
 Erdos500Problem	GREEN	
 Erdos501Aristotle	RESIDUAL	instance-synth
@@ -1382,7 +1382,7 @@ Erdos53Problem	GREEN
 Erdos540Problem	GREEN	
 Erdos541Problem	GREEN	
 Erdos542Problem	GREEN	
-Erdos543Problem	RESIDUAL	proof-drift
+Erdos543Problem	GREEN	
 Erdos545Problem	GREEN	
 Erdos546Problem	GREEN	
 Erdos547Problem	GREEN	


### PR DESCRIPTION
Doctor increment 26 of the Lean v4.26→v4.31 migration (epic #37508, issue #38065). A–M / Erdos<600 partition (disjoint complement of sibling increment 24/25 on N–Z / Erdos≥600).

## Waves (all verified by in-container `docker exec dr36 lake build Proofs.X` exit 0)
- DR36-1 (+2): AlgebraicNumbersCountableOQ01OQ03, OQ01OQ01OQ01
- DR36-2 (+2): CayleyHamiltonMinpolyOQ05OQ02, ChebyshevBoundsOQ03OQ02
- DR36-3 (+3): Erdos445, Erdos592, Erdos500
- DR36-4 (+3): Erdos499, Erdos370, Erdos543
- DR36-5 (+2): ContinuumHypothesisOQ02OQ01, BaselProblemOQ01OQ01
- DR36-6 (+2): BorsukUlamOQ03OQ02, BorsukUlamOQ02OQ01OQ01OQ02OQ03OQ01
- DR36-7 (+1): Erdos453OQ02
- DR36-8 (+1): Erdos441Aristotle
- DR36-9 (+1): EulerTotientOQ01OQ01OQ01
- DR36-10 (+2): LawOfCosinesOQ04OQ01 (+ Bisector transitively)
- DR36-11 (+1): GCDAlgorithmOQ01OQ03OQ01OQ01

## Per-class (RESIDUAL → GREEN this increment)
- type-mismatch: 9
- instance-synth: 8
- proof-drift: 3
- rewrite-drift: 1

Own ledger contribution 1683 → 1704 (+21). (Branch also merges base feature/issue-37508 so the live count reads higher.)

## Highlight recipes (full set in rename-map §7x)
- `Ordinal.omega` → `Ordinal.omega0` (`omega` is now the ↪o normal-fn embedding)
- `(2 : Cardinal) ^ ℵ₀` / `(p:ℝ)^c` — annotate base to avoid `HPow ℕ …`
- type-alias `def` → `abbrev` so `∈`/`.card`/`∅` resolve
- push_neg now makes ∀/∃ complementary statements defeq → `rfl`
- `IsAlgClosure ℚ (AlgebraicClosure ℚ)` no longer auto-synths → reassemble from `IsAlgClosed` + `AlgebraicClosure.isAlgebraic`
- `Irreducible.separable` needs perfect/char-0 base → splitting-field root via `Splits.exists_eval_eq_zero`
- `Finset.sum_le_sum_of_subset` needs CanonicallyOrderedAdd → `_of_subset_of_nonneg` on ℝ
- `ArithmeticFunction.Carmichael` deprecated alias ≠ `carmichael` head for rw
- `⟪..⟫_ℝ` suffix removed → plain `⟪..⟫` under `open scoped RealInnerProductSpace`
- Nat `primeFactors_mul` yields `{p} ∪ {q}` (was `insert`) → `sup_union`

## Statement repairs (1, no weakening)
- Erdos499Problem `erdos_499_summary`: made `M : Matrix (Fin n) (Fin n) ℝ` type explicit so its dimension infers (same proposition; the second conjunct never mentioned `Fin n`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)