### PR TITLE
migrate(v4.31): Doctor increment 27 — tm/pd/rewrite (N-Z partition) (+12 GREEN)

### DIFF
--- a/proofs/Proofs/Erdos1012Problem.lean
+++ b/proofs/Proofs/Erdos1012Problem.lean
@@ -143,16 +143,6 @@ axiom ore_theorem : ∀ n ≥ 1, hasLongCycle n 0
     has an (n-1)-cycle. -/
 axiom bondy_theorem : ∀ n ≥ 1, hasLongCycle n 1
 
-/-- **Theorem**: Woodall's Theorem (1972) — the complete solution.
-    For n ≥ 2k+3 and sufficient edges, the graph has an (n-k)-cycle.
-    PROVED from woodall_pancyclic: pancyclicity up to n-k implies an (n-k)-cycle.
-    (Previously axiom; axiom count reduced 5→4.) -/
-theorem woodall_theorem (n k : ℕ) (hn : n ≥ 2 * k + 3) :
-    hasLongCycle n k := by
-  intro V inst1 inst2 hcard G inst3 hedges
-  have hpan := woodall_pancyclic n k hn V hcard G hedges
-  exact hpan (n - k) (by omega) le_rfl
-
 /-- **Axiom 4**: Woodall's stronger pancyclicity result.
     Under the same conditions, the graph actually has cycles of ALL lengths
     from 3 to n-k. -/
@@ -162,6 +152,16 @@ axiom woodall_pancyclic (n k : ℕ) (hn : n ≥ 2 * k + 3) :
       ∀ (G : SimpleGraph V) [DecidableRel G.Adj],
         edgeCount G ≥ edgeThreshold n k →
         isPancyclicUpTo G (n - k)
+
+/-- **Theorem**: Woodall's Theorem (1972) — the complete solution.
+    For n ≥ 2k+3 and sufficient edges, the graph has an (n-k)-cycle.
+    PROVED from woodall_pancyclic: pancyclicity up to n-k implies an (n-k)-cycle.
+    (Previously axiom; axiom count reduced 5→4.) -/
+theorem woodall_theorem (n k : ℕ) (hn : n ≥ 2 * k + 3) :
+    hasLongCycle n k := by
+  intro V inst1 inst2 hcard G inst3 hedges
+  have hpan := woodall_pancyclic n k hn V hcard G hedges
+  exact hpan (n - k) (by omega) le_rfl
 
 /-- **Axiom 5**: The threshold is tight: extremal graphs exist with
     threshold - 1 edges that lack the required cycle.

--- a/proofs/Proofs/Erdos1026Problem.lean
+++ b/proofs/Proofs/Erdos1026Problem.lean
@@ -102,7 +102,7 @@ theorem erdos_szekeres (r s : ℕ) (n : ℕ) (hn : n = (r - 1) * (s - 1) + 1)
   · -- Increasing case: t has > (r-1) elements, so ≥ r
     left
     have hr : r ≤ t.card := by omega
-    obtain ⟨u, hu_sub, hu_card⟩ := Finset.exists_smaller_set t r hr
+    obtain ⟨u, hu_sub, hu_card⟩ := Finset.exists_subset_card_eq hr
     -- Build Subsequence from the Finset via orderEmbOfFin
     let emb := u.orderEmbOfFin hu_card
     refine ⟨⟨emb, emb.strictMono⟩, fun i j hij => ?_⟩
@@ -114,7 +114,7 @@ theorem erdos_szekeres (r s : ℕ) (n : ℕ) (hn : n = (r - 1) * (s - 1) + 1)
   · -- Decreasing case: t has > (s-1) elements, so ≥ s
     right
     have hs : s ≤ t.card := by omega
-    obtain ⟨u, hu_sub, hu_card⟩ := Finset.exists_smaller_set t s hs
+    obtain ⟨u, hu_sub, hu_card⟩ := Finset.exists_subset_card_eq hs
     let emb := u.orderEmbOfFin hu_card
     refine ⟨⟨emb, emb.strictMono⟩, fun i j hij => ?_⟩
     -- IsDecreasing: seq (emb j) < seq (emb i) for i < j
@@ -129,7 +129,8 @@ theorem erdos_szekeres (r s : ℕ) (n : ℕ) (hn : n = (r - 1) * (s - 1) + 1)
 theorem erdos_szekeres_square (k : ℕ) (n : ℕ) (hn : n = k^2 + 1)
     (seq : RealSeq n) (hDistinct : Function.Injective seq) :
     ∃ (m : ℕ) (sub : Subsequence n m), m ≥ k + 1 ∧ IsMonotonic seq sub := by
-  have hneq : n = (k + 1 - 1) * (k + 1 - 1) + 1 := by omega
+  have hneq : n = (k + 1 - 1) * (k + 1 - 1) + 1 := by
+    rw [Nat.add_sub_cancel, hn, pow_two]
   rcases erdos_szekeres (k + 1) (k + 1) n hneq seq hDistinct with ⟨sub, hInc⟩ | ⟨sub, hDec⟩
   · exact ⟨k + 1, sub, le_refl _, Or.inl hInc⟩
   · exact ⟨k + 1, sub, le_refl _, Or.inr hDec⟩
@@ -268,7 +269,7 @@ theorem lis_lds_bound (n : ℕ) (seq : RealSeq n)
   rcases Theorems100.erdos_szekeres hcard hDistinct with
     ⟨t, ht_card, ht_mono⟩ | ⟨t, ht_card, ht_anti⟩
   · -- Increasing Finset of size ≥ LIS seq + 1 contradicts LIS definition
-    obtain ⟨u, hu_sub, hu_card⟩ := Finset.exists_smaller_set t (LIS seq + 1) ht_card
+    obtain ⟨u, hu_sub, hu_card⟩ := Finset.exists_subset_card_eq ht_card
     let emb := u.orderEmbOfFin hu_card
     have hmono_u : StrictMonoOn seq ↑u := ht_mono.mono (Finset.coe_subset.mpr hu_sub)
     have hmem : LIS seq + 1 ∈ {m | ∃ (sub : Subsequence n m), IsIncreasing seq sub} :=
@@ -278,7 +279,7 @@ theorem lis_lds_bound (n : ℕ) (seq : RealSeq n)
     have : LIS seq + 1 ≤ LIS seq := le_csSup (lis_bddAbove seq) hmem
     omega
   · -- Anti-monotone Finset of size ≥ LDS seq + 1 contradicts LDS definition
-    obtain ⟨u, hu_sub, hu_card⟩ := Finset.exists_smaller_set t (LDS seq + 1) ht_card
+    obtain ⟨u, hu_sub, hu_card⟩ := Finset.exists_subset_card_eq ht_card
     let emb := u.orderEmbOfFin hu_card
     have hanti_u : StrictAntiOn seq ↑u := ht_anti.mono (Finset.coe_subset.mpr hu_sub)
     have hmem : LDS seq + 1 ∈ {m | ∃ (sub : Subsequence n m), IsDecreasing seq sub} :=

--- a/proofs/Proofs/PythagoreanTriplesOQ04OQ01OQ01.lean
+++ b/proofs/Proofs/PythagoreanTriplesOQ04OQ01OQ01.lean
@@ -63,12 +63,12 @@ theorem sum_two_squares_iff (n : ℕ) :
   constructor
   · intro h p hp hp4
     rcases eq_or_ne n 0 with rfl | hn
-    · exact padicValNat.zero.symm ▸ even_zero
+    · exact padicValNat.zero.symm ▸ Even.zero
     · by_cases hmem : p ∈ n.primeFactors
       · exact h p hmem hp4
       · have hnd : ¬ p ∣ n := fun hd => hmem (Nat.mem_primeFactors.mpr ⟨hp, hd, hn⟩)
         rw [padicValNat.eq_zero_of_not_dvd hnd]
-        exact even_zero
+        exact Even.zero
   · intro h q hq hq4
     exact h q (Nat.prime_of_mem_primeFactors hq) hq4
 
@@ -82,7 +82,7 @@ theorem not_sum_two_squares_of_odd_padicValNat {n p : ℕ} (hp : p.Prime)
     ¬ ∃ x y : ℕ, n = x ^ 2 + y ^ 2 := by
   intro h
   have he : Even (padicValNat p n) := (sum_two_squares_iff n).mp h p hp hp4
-  exact (Nat.even_iff_not_odd.mp he) hodd
+  exact (Nat.not_odd_iff_even.mpr he) hodd
 
 /-- **Sufficiency.** If every prime `p ≡ 3 (mod 4)` divides `n` to an even power,
 then `n` is a sum of two squares. -/
@@ -112,7 +112,7 @@ theorem prime_sum_two_squares_iff {p : ℕ} (hp : p.Prime) :
     have hqp : q ≠ p := by rintro rfl; exact hp4 hq4
     have hnd : ¬ q ∣ p := by rw [Nat.prime_dvd_prime_iff_eq hq hp]; exact hqp
     rw [padicValNat.eq_zero_of_not_dvd hnd]
-    exact even_zero
+    exact Even.zero
 
 /-- The prime obstruction: a prime `≡ 3 (mod 4)` is not a sum of two squares. -/
 theorem prime_not_sum_two_squares {p : ℕ} (hp : p.Prime) (hp4 : p % 4 = 3) :

--- a/proofs/Proofs/SchroederBernsteinOQ02.lean
+++ b/proofs/Proofs/SchroederBernsteinOQ02.lean
@@ -58,7 +58,7 @@ def cbsOp (f : α → β) (g : β → α) (S : Set α) : Set α :=
 /-- T is monotone: S ⊆ S' implies T(S) ⊆ T(S'). -/
 theorem cbsOp_mono (f : α → β) (g : β → α) : Monotone (cbsOp f g) := by
   intro S₁ S₂ h
-  exact Set.union_subset_union_right _ (Set.image_subset g (Set.image_subset f h))
+  exact Set.union_subset_union_right _ (Set.image_mono (Set.image_mono h))
 
 /-- T bundled as an order homomorphism, enabling Knaster-Tarski. -/
 def cbsHom (f : α → β) (g : β → α) : Set α →o Set α where
@@ -114,7 +114,7 @@ theorem gf_mem (f : α → β) (g : β → α) {a : α} (ha : a ∈ fixedSet f g
 /-- If g(b) ∈ S*, then b ∈ f '' S*. (Requires injectivity of g.) -/
 theorem gb_mem_implies (f : α → β) (g : β → α) (hg : Function.Injective g)
     {b : β} (hgb : g b ∈ fixedSet f g) : b ∈ f '' fixedSet f g := by
-  have h : g b ∈ cbsOp f g (fixedSet f g) := by rwa [← fixedSet_eq]
+  have h : g b ∈ cbsOp f g (fixedSet f g) := by rw [fixedSet_eq]; exact hgb
   change g b ∈ (Set.range g)ᶜ ∨ g b ∈ g '' (f '' fixedSet f g) at h
   rcases h with h' | ⟨x, hx, hgx⟩
   · exact absurd (Set.mem_range.mpr ⟨b, rfl⟩) h'

--- a/proofs/Proofs/ShannonChannelCodingAWGNOQ03OQ01Monotone.lean
+++ b/proofs/Proofs/ShannonChannelCodingAWGNOQ03OQ01Monotone.lean
@@ -172,7 +172,7 @@ theorem waterBudget_nonneg (N : ι → ℝ) (μ : ℝ) : 0 ≤ waterBudget N μ 
 /-- **A positive budget forces a positive water level.**  If the water level `μ`
 realises a strictly positive budget `P > 0` (with positive noise floors) then
 `μ > 0`: at `μ ≤ 0` every channel is dry (`μ − Nᵢ < 0`) and the budget vanishes. -/
-theorem waterLevel_pos (N : ι → ℝ) (hN : ∀ i, 0 < N i) {μ P : ℝ}
+theorem waterLevel_pos_mono (N : ι → ℝ) (hN : ∀ i, 0 < N i) {μ P : ℝ}
     (hbudget : waterBudget N μ = P) (hP : 0 < P) : 0 < μ := by
   by_contra hcon
   push_neg at hcon
@@ -274,10 +274,8 @@ theorem capacity_mono_budget (N : ι → ℝ) (hN : ∀ i, 0 < N i)
     have hP1 : P₁ = 0 := le_antisymm (hP2 ▸ hP) hP1nonneg
     rw [rate_waterAlloc_eq_zero_of_budget_zero N (h1.trans hP1),
         rate_waterAlloc_eq_zero_of_budget_zero N (h2.trans hP2)]
-    -- both capacities are 0
-    exact le_refl 0
   · -- generic: P₂ > 0, so μ₂ > 0 and optimality at P₂ dominates the P₁ allocation
-    have hμ₂ : 0 < μ₂ := waterLevel_pos N hN h2 hP2pos
+    have hμ₂ : 0 < μ₂ := waterLevel_pos_mono N hN h2 hP2pos
     have hxsum : ∑ i, waterAlloc μ₁ N i ≤ P₂ := by
       have hb : (∑ i, waterAlloc μ₁ N i) = P₁ := h1
       rw [hb]; exact hP

--- a/proofs/Proofs/SzemerediRegularityOQ01Trivial.lean
+++ b/proofs/Proofs/SzemerediRegularityOQ01Trivial.lean
@@ -36,45 +36,18 @@
 import Mathlib
 import Proofs.SzemerediRegularityOQ01
 
+/-
+v4.31 migration note: the three trivial-regularity-threshold theorems
+(`isEpsilonRegular_of_one_le`, `irregularOrderedPairs_eq_empty_of_one_le`,
+`card_irregularOrderedPairs_eq_zero_of_one_le`) are now all provided by the
+imported parent `Proofs.SzemerediRegularityOQ01` in the same namespace
+`Szemeredi.Regularity.OQ01`. Re-declaring them here triggered v4.31's
+"already declared" error, so this companion is reduced to an import shim; all
+three lemmas remain available transitively through the parent import.
+-/
+
 namespace Szemeredi.Regularity.OQ01
 
 open Classical Szemeredi.Core Szemeredi.Regularity
-
-variable {V : Type*} [Fintype V] [DecidableEq V]
-
-/-- **Trivial-regularity threshold.**  If `eps ≥ 1` then *every* pair `(A, B)` is
-ε-regular: for any witnesses `A' ⊆ A`, `B' ⊆ B` the two edge densities lie in
-`[0, 1]`, so their difference has absolute value at most `1 ≤ eps`, and the size
-conditions are irrelevant.  This is the endpoint of `isEpsilonRegular_mono`: at
-`eps = 1` regularity becomes unconditional. -/
-theorem isEpsilonRegular_of_one_le (G : SimpleGraph V) [DecidableRel G.Adj]
-    {eps : ℚ} (heps : 1 ≤ eps) (A B : Finset V) :
-    IsEpsilonRegular G eps A B := by
-  intro A' B' _ _ _ _
-  have h1 := edgeDensity_mem_Icc G A' B'
-  have h2 := edgeDensity_mem_Icc G A B
-  rw [Set.mem_Icc] at h1 h2
-  rw [abs_le]
-  constructor <;> linarith [h1.1, h1.2, h2.1, h2.2]
-
-/-- **No irregular pairs above the threshold.**  For `eps ≥ 1` the ordered
-irregular pairs of any partition form the empty set: every pair is ε-regular by
-`isEpsilonRegular_of_one_le`, so the `¬IsEpsilonRegular` filter keeps nothing. -/
-theorem irregularOrderedPairs_eq_empty_of_one_le (G : SimpleGraph V)
-    [DecidableRel G.Adj] {eps : ℚ} (heps : 1 ≤ eps) (parts : Finset (Finset V)) :
-    irregularOrderedPairs G eps parts = ∅ := by
-  rw [Finset.eq_empty_iff_forall_notMem]
-  rintro ⟨P, Q⟩ hx
-  simp only [irregularOrderedPairs, Finset.mem_filter, Finset.mem_product] at hx
-  exact hx.2.2 (isEpsilonRegular_of_one_le G heps P Q)
-
-/-- **The irregular-pair count vanishes above the threshold.**  Cardinality form:
-`eps ≥ 1 ⟹ card (irregularOrderedPairs G eps parts) = 0`.  This is the value the
-non-increasing count `card_irregularOrderedPairs_antitone` bottoms out at — every
-partition is `1`-regular, so the `IsRegularPartition` threshold is met trivially. -/
-theorem card_irregularOrderedPairs_eq_zero_of_one_le (G : SimpleGraph V)
-    [DecidableRel G.Adj] {eps : ℚ} (heps : 1 ≤ eps) (parts : Finset (Finset V)) :
-    (irregularOrderedPairs G eps parts).card = 0 := by
-  rw [irregularOrderedPairs_eq_empty_of_one_le G heps parts, Finset.card_empty]
 
 end Szemeredi.Regularity.OQ01

--- a/proofs/batch2/STATUS.md
+++ b/proofs/batch2/STATUS.md
@@ -1641,3 +1641,35 @@ Total: +6 GREEN.
 its first error. Fixing the first error (rename/reorder/notation) typically exposes 2-6 more. The
 reliable wins are (a) single-symptom rename files and (b) stale-RESIDUAL rows that already build clean
 off the 37508 base. Per-file isolated verify is mandatory before flipping.
+
+### Increment 27 additional waves (post-doc-commit, +6 more GREEN → 12 total)
+- DR37-5 SchroederBernsteinOQ02: `Set.image_subset`→`Set.image_mono` (2 nested uses); +
+  `rw [← fixedSet_eq]`→`rw [fixedSet_eq]` (the `←` pattern `fixedSet f g` also matched inside
+  `cbsOp f g (fixedSet f g)` → wrong rewrite; forward direction rewrites only the outer). ALSO
+  flipped 3 already-clean stale-RESIDUAL rows: RothTheoremOQ03OQ01OQ01OQ01,
+  RothTheoremOQ03OQ01OQ01OQ01OQ01, RothTheoremQuantitative (+4 total this wave).
+- DR37-6 SzemerediRegularityOQ01Trivial: all 3 threshold theorems now in imported parent
+  SzemerediRegularityOQ01 (same namespace) → reduced companion to import shim (§7v recipe).
+- DR37-7 ShannonChannelCodingAWGNOQ03OQ01Monotone: `waterLevel_pos` now in imported parent (same
+  statement, different arg order `hP`/`hμ` vs `hbudget`/`hP`) → renamed child's to
+  `waterLevel_pos_mono` + updated its one use (can't delete: arg order differs from parent's);
+  dropped redundant `exact le_refl 0` (rw closed the goal → No-goals).
+
+Grand total increment 27: **+12 GREEN** across waves DR37-1..7.
+
+Full triage of the entire partition (403 files: 200 Erdos≥600 in erdos2, 200 in erdos-partial, 137
+non-Erdos) completed. Beyond the 12 flipped, the residual is uniformly multi-error cascade behind
+the first symptom — no further single-fix candidates found. Notable recurring deep blockers:
+`Complex.abs` removal (now a local `def`, breaks `map_mul`/`AbsoluteValue` API — NapoleonsTheorem
+family), Sylow-API renames (`Sylow.exists_smul_eq`/`card_eq_index_normalizer` cascade), and
+`decide`/`native_decide`-noncomputable failures (Erdos1162 SetLike.instFintype).
+
+New v4.31 renames catalogued (rename-map §7x extended): `Set.image_subset`→`Set.image_mono`,
+`even_zero`→`Even.zero`, `Nat.even_iff_not_odd.mp`→`Nat.not_odd_iff_even.mpr`,
+`Finset.exists_smaller_set`→`Finset.exists_subset_card_eq`, `Finset.filter_eq_empty`→
+`Finset.filter_eq_empty_iff`, `Nat.card_pos_of_nonempty`→`Nat.card_pos_iff.mpr ⟨‹Nonempty›,inferInstance⟩`,
+`lt_of_le_not_le`→`lt_of_le_not_ge`, `Nat.divisors_prime_eq`→`Nat.Prime.divisors`,
+`Continuous.if_lt`→(only `Continuous.if_le` survives), `Sylow.exists_smul_eq`→bare `exists_smul_eq`,
+`Finset.sum_range_pow`→bare `sum_range_pow` (root-level in Bernoulli.lean section Faulhaber),
+`∆` symmetric-difference now `scoped[symmDiff]` (needs `open scoped symmDiff`), `/--` dangling
+doc-comment before a section now hard-errors (use `/-`).

--- a/proofs/batch2/STATUS.md
+++ b/proofs/batch2/STATUS.md
@@ -1586,3 +1586,58 @@ Erdos900 (sorry-in-def pathLengthFunction/probHasProperty), Erdos807 (S.card sta
 Erdos608 (known-hard, parse cascade under mod-index fix), Erdos613ProblemAristotle (nonlinear
 ℕ-division choose identity), Erdos874 (k/√N division-nonlinearity needs field rework), Erdos720
 (sizeRamseyCycle proof-arg n≥3 undischarged in ∀n lambda).
+
+---
+
+## Increment 27 (Doctor, tm/pd/rewrite/unknown-const/instance-synth, N-Z + Erdos≥600)
+
+Base: origin/feature/issue-37508 @ 6a3fc43ea0 (ledger 1691 GREEN on branch). Sibling branch
+feature/issue-38065-c did NOT exist on origin during this increment (no overlap risk).
+
+Waves (branch feature/issue-38065):
+- DR37-1 Erdos1012Problem: forward-ref reorder — moved `woodall_pancyclic` axiom above its first
+  consumer `woodall_theorem` (v4.31 forbids forward reference). Flipped Erdos1012Problem +
+  dependent Erdos1012OQ05 (+2).
+- DR37-2 Erdos1026Problem: `Finset.exists_smaller_set s n h` (removed) → `Finset.exists_subset_card_eq h`
+  (4 uses); + omega-on-k^2 fix via `rw [Nat.add_sub_cancel, hn, pow_two]` (+1).
+- DR37-3 PentagonalNumberTheoremOQ01OQ01 + OQ01OQ02: already build clean off v4.31 base (stale
+  RESIDUAL rewrite-drift rows), verified in-container, flipped (+2).
+- DR37-4 PythagoreanTriplesOQ04OQ01OQ01: `even_zero` (removed) → `Even.zero` (3 uses);
+  `Nat.even_iff_not_odd.mp` → `Nat.not_odd_iff_even.mpr` (+1).
+
+Total: +6 GREEN.
+
+### Increment 27 recipes (rename-map §7x)
+| Symptom (v4.31) | Fix |
+|---|---|
+| `Finset.exists_smaller_set s n (h : n ≤ s.card)` "Unknown constant" | `Finset.exists_subset_card_eq (h : n ≤ #s)` (same `∃ t ⊆ s, #t = n`; drop the explicit `s`,`n` args) |
+| `even_zero` "Unknown identifier" | `Even.zero` |
+| `Nat.even_iff_not_odd.mp he` (: ¬Odd) "Unknown constant" | `Nat.not_odd_iff_even.mpr he` |
+| `intermediate_value_zero_of_neg_of_pos` removed | (deferred — needs IVT restructure via `intermediate_value_Icc`) |
+| symmetric-difference `∆` "expected token" | add `open scoped symmDiff` |
+
+### Increment 27 confirmed-deferred (first-error fixed but deeper cascade / genuine gap, reverted)
+- Erdos1002OQ01 (gcongr closes goal → No-goals at L44, but L66/77 `skip` + tendsto errors deeper)
+- Erdos1018OQ04Incomplete01 (`Set.image_subset`→`Set.image_mono` OK, but L161 synth + L178 simp deeper)
+- Erdos1020Problem (`Hypergraph` clashes w/ new Mathlib top-level `Hypergraph`; namespace-wrap exposes
+  universe metavars in `erdosMatchingConjecture` + choose_two_right omega failures)
+- Erdos1039Aristotle (`Erdos1039.Complex.abs`→`Complex.abs` OK, but L77/106/128 unsolved + L131/168 type mismatch)
+- Erdos1054OQ01 (`subst h`→`rw [h]` keeps `p`, but L79 bogus `constructor` on list-eq + native_decide→FALSE L125-130)
+- Erdos1059OQ04 (`open Erdos1059OQ01` + `lt_of_le_not_le`→`lt_of_le_not_ge` OK, but L116
+  `density_one_conjecture` is an AXIOM used as a TYPE — needs hypothesis-restructure, genuine)
+- Erdos1065Problem (forward-ref reorder of erdos_1065b OK, but L197+ `intro ⟨⟩`/decide type mismatches deeper)
+- Erdos1096Problem (`intermediate_value_zero_of_neg_of_pos` removed — IVT restructure)
+- Erdos1123Problem (`open scoped symmDiff` fixes parse, but L67/68/69/75 Setoid-proof errors +
+  `Set.symmDiff_comm` unknown)
+- Erdos1136Problem (No-goals L94 fixable via `simp only [Nat.zero_mod]`, but L137/191/197 deeper)
+- Erdos1145Problem (No-goals L220 `; rfl` drop OK, but L224+ App-type-mismatch cascade)
+- NapoleonsTheorem / NapoleonsTheoremOQ02 (`Complex.norm_def` dup-decl fixable via rename to
+  `Complex.abs_def`, but `map_mul` on the now-plain-def `Complex.abs` fails L177 + nlinarith L155/161 —
+  needs full Complex.abs-is-a-def migration)
+- ProbMethodSecondMomentOQ01 (dup `paley_zygmund_quantitative` — parent+child have DIFFERENT
+  statements; renamed child→`paley_zygmund_quantitative_mul` OK, but L92/116 linarith + L144 No-goals deeper)
+
+**Meta**: this partition is heavily multi-error — nearly every RESIDUAL Erdos file has a cascade behind
+its first error. Fixing the first error (rename/reorder/notation) typically exposes 2-6 more. The
+reliable wins are (a) single-symptom rename files and (b) stale-RESIDUAL rows that already build clean
+off the 37508 base. Per-file isolated verify is mandatory before flipping.

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -640,8 +640,8 @@ Erdos1011OQ03	GREEN
 Erdos1011Problem	GREEN	
 Erdos1012OQ01OQ02	GREEN	unknown-const:n
 Erdos1012OQ03	RESIDUAL	proof-drift
-Erdos1012OQ05	RESIDUAL	unknown-const:woodall_pancyclic
-Erdos1012Problem	RESIDUAL	unknown-const:woodall_pancyclic
+Erdos1012OQ05	GREEN	
+Erdos1012Problem	GREEN	
 Erdos1013ConstantRatio	GREEN	
 Erdos1013Problem	GREEN	
 Erdos1013UnconditionalRatio	GREEN	

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -689,7 +689,7 @@ Erdos1024Problem	GREEN
 Erdos1025Problem	GREEN	
 Erdos1026OQ05Extremal	RESIDUAL	proof-drift
 Erdos1026OQ05KMonotonic	GREEN	
-Erdos1026Problem	RESIDUAL	unknown-const:Finset.exists_smaller_set
+Erdos1026Problem	GREEN	
 Erdos1027OQ01	RESIDUAL	unclassified
 Erdos1027OQ03	GREEN	
 Erdos1028Problem	GREEN	unknown-const:rpow_one

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -2304,8 +2304,8 @@ PascalsHexagonOQ03	GREEN
 PascalsHexagonOQ03Incomplete01Derangements	GREEN	
 PellEquationOQ01	GREEN	unknown-const:Int.cast_nonneg.mpr
 PentagonalNumberTheoremOQ01	GREEN	
-PentagonalNumberTheoremOQ01OQ01	RESIDUAL	rewrite-drift
-PentagonalNumberTheoremOQ01OQ02	RESIDUAL	rewrite-drift
+PentagonalNumberTheoremOQ01OQ01	GREEN	
+PentagonalNumberTheoremOQ01OQ02	GREEN	
 PerfectNumbers	GREEN	
 PerfectNumbersOQ03	RESIDUAL	type-mismatch
 PiTranscendental	GREEN	

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -2379,9 +2379,9 @@ RothTheoremOQ01Reciprocal	GREEN
 RothTheoremOQ01Weighted	GREEN	
 RothTheoremOQ03	RESIDUAL	unknown-const:Finset.sum_eq_add_sum_diff_singleton
 RothTheoremOQ03OQ01OQ01	GREEN	duplicate-decl
-RothTheoremOQ03OQ01OQ01OQ01	RESIDUAL	duplicate-decl
-RothTheoremOQ03OQ01OQ01OQ01OQ01	RESIDUAL	duplicate-decl
-RothTheoremQuantitative	RESIDUAL	unknown-const:Finset.sum_eq_add_sum_diff_singleton
+RothTheoremOQ03OQ01OQ01OQ01	GREEN	
+RothTheoremOQ03OQ01OQ01OQ01OQ01	GREEN	
+RothTheoremQuantitative	GREEN	
 RothTheoremQuantitativeAristotle	RESIDUAL	unknown-const:div_le_div_of_le_left
 RothTriangleRemoval	RESIDUAL	signature-drift
 SchauderFixedPoint	RESIDUAL	instance-synth
@@ -2389,7 +2389,7 @@ SchauderFixedPointOQ01	RESIDUAL	instance-synth
 SchauderFixedPointOQ03	RESIDUAL	instance-synth
 SchauderFixedPointOQ03OQ01	GREEN	
 SchroederBernsteinOQ01	RESIDUAL	elab-drift
-SchroederBernsteinOQ02	RESIDUAL	unknown-const:Set.image_subset
+SchroederBernsteinOQ02	GREEN	
 SchroederBernsteinOQ03	GREEN	
 SchursTheorem	GREEN	
 SearchMathlib	RESIDUAL	unknown-const:IsCompact.of_isClosed_isBounded

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -2398,7 +2398,7 @@ ShannonChannelCodingAWGN	GREEN
 ShannonChannelCodingAWGNOQ01	GREEN	
 ShannonChannelCodingAWGNOQ03	GREEN	
 ShannonChannelCodingAWGNOQ03OQ01EqualNoise	GREEN	
-ShannonChannelCodingAWGNOQ03OQ01Monotone	RESIDUAL	type-mismatch
+ShannonChannelCodingAWGNOQ03OQ01Monotone	GREEN	
 ShannonChannelCodingBEC	GREEN	
 ShannonChannelCodingBECOQ01	GREEN	
 ShannonChannelCodingBECOQ02	GREEN	

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -2538,7 +2538,7 @@ SzemerediHypergraphCore	RESIDUAL	proof-drift
 SzemerediHypergraphGowers	RESIDUAL	proof-drift
 SzemerediRegularity	GREEN	
 SzemerediRegularityOQ01	GREEN	
-SzemerediRegularityOQ01Trivial	RESIDUAL	duplicate-decl
+SzemerediRegularityOQ01Trivial	GREEN	
 SzemerediRegularityOQ02	RESIDUAL	decide-maxrecdepth
 SzemerediRegularityOQ02OQ02	RESIDUAL	decide-maxrecdepth
 SzemerediRegularityOQ03	GREEN	

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -2346,7 +2346,7 @@ PythagoreanTheoremOQ01	GREEN
 PythagoreanTheoremOQ03	GREEN	
 PythagoreanTheoremOQ05	GREEN	
 PythagoreanTriplesOQ02	GREEN	
-PythagoreanTriplesOQ04OQ01OQ01	RESIDUAL	unknown-const:even_zero
+PythagoreanTriplesOQ04OQ01OQ01	GREEN	
 QuadraticReciprocityAlgorithmOQ03	RESIDUAL	rewrite-drift
 QuadraticReciprocityAlgorithmOQ03FieldBridge	RESIDUAL	rewrite-drift
 QuadraticReciprocityAlgorithmOQ03M2	GREEN	

--- a/research/toolchain-v4.31-rename-map.md
+++ b/research/toolchain-v4.31-rename-map.md
@@ -1145,3 +1145,29 @@ native-evaluates to FALSE once Classical is dropped (bad pre-existing test, not 
 | NormedRing (possibly noncommutative) `ring` fails on a purely-additive identity (`B-1 = -(1-B)`, `B = A-(A-B)`) or a `↑u*(↑u⁻¹*x)` unit-cancel | use `neg_sub`/`abel` for additive goals; a reusable `hcancel : ∀ x, ↑u*(↑u⁻¹*x) = x` via `← mul_assoc, ← Units.val_mul, mul_inv_cancel, Units.val_one, one_mul` | GeometricSeriesOQ02OQ03 |
 | `edgeCount` def with `p.1 < p.2` on a bare `V` → "failed to synthesize `LT V`" | add `[LinearOrder V]` to the def; an internal `∃ (V : Type*)` in a `Prop def` also needs `Type`-pinning to kill the derived-thm universe-metavar (§7o) | Erdos571Problem |
 | nlinarith fails on a ℕ descent `(2x)²+(2y)²+(2z)² = 4^(a+1)(8b+7) ⊢ x²+y²+z² = 4^a(8b+7)` | `have hpow : 4^(a+1)=4*4^a := by rw [pow_succ]; ring`, then `have : 4*(sum)=4*(target) := by rw [hpow] at heq; nlinarith [heq]`, then `omega` | LagrangeFourSquaresOQ04 |
+
+## §7x Doctor increment 27 recipes (tm/pd/rewrite/unknown-const, N-Z + Erdos≥600, #38065, +6 GREEN)
+
+| Symptom (v4.31) | Fix | Files |
+|---|---|---|
+| `Finset.exists_smaller_set s n (h : n ≤ s.card)` "Unknown constant" | `Finset.exists_subset_card_eq (h : n ≤ #s)` — same `∃ t ⊆ s, #t = n`, drop the explicit `s`/`n` positional args, pass only the `≤` proof | Erdos1026Problem (4 uses) |
+| `omega` fails on `n = (k+1-1)*(k+1-1)+1` given `hn : n = k^2+1` (omega can't equate `k^2` with `k*k`) | `rw [Nat.add_sub_cancel, hn, pow_two]` | Erdos1026Problem |
+| `even_zero` "Unknown identifier" (removed) | `Even.zero` | PythagoreanTriplesOQ04OQ01OQ01 (3 uses) |
+| `Nat.even_iff_not_odd.mp he` "Unknown constant" (goal `False` from `Even`/`Odd`) | `Nat.not_odd_iff_even.mpr he` (returns `¬Odd`, apply to the `Odd` hyp) | PythagoreanTriplesOQ04OQ01OQ01 |
+| symmetric-difference `∆` "expected token" (notation now `scoped[symmDiff]`) | add `open scoped symmDiff` to the file header | Erdos1123Problem (parse fixed; Setoid-proof cascade deferred) |
+| `Set.image_subset f (h : s⊆t)` "Unknown constant" | `Set.image_mono (h : s⊆t)` (f now implicit) | Erdos1018OQ04Incomplete01 (first-error only; deeper cascade) |
+| `lt_of_le_not_le` "Unknown identifier" | `lt_of_le_not_ge` | Erdos1059OQ04 (first-error only) |
+| child re-declares a lemma the imported parent now also declares (same namespace) BUT the two have
+  DIFFERENT statements | RENAME the child's decl (e.g. `foo`→`foo_mul`) + update its internal uses —
+  do NOT delete (they are genuinely distinct theorems that only collide by name) | ProbMethodSecondMomentOQ01 (`paley_zygmund_quantitative`→`_mul`; first-error only) |
+| top-level local `structure Hypergraph`/`def Foo` clashes with a NEW Mathlib top-level decl of the
+  same name ("has already been declared") | wrap the file's decls in `namespace X … end X` OR rename
+  the local — but CAUTION: namespace-wrapping can expose latent universe-metavariable / defeq errors
+  that the global elaboration had masked | Erdos1020Problem (deferred — universe metavars surfaced) |
+
+**Meta (partition N-Z + Erdos≥600)**: heavily multi-error. First-error rename/reorder/notation fixes
+usually expose 2-6 downstream errors (cascade). Reliable wins: single-symptom rename files, and
+stale-RESIDUAL rows already clean off the 37508 base (PentagonalNumberTheoremOQ01OQ01/OQ01OQ02 flipped
+with zero edits). `Complex.abs` removal (now a local compat `def`, not an `AbsoluteValue` hom) is a
+recurring deep blocker: `map_mul`/`map_add`/`AbsoluteValue`-API on it all fail — needs whole-file
+migration, not a one-line compat (NapoleonsTheorem family deferred).


### PR DESCRIPTION
## Doctor increment 27 — v4.31 migration (epic #37508, issue #38065)

Partition: **N–Z non-Erdos basenames + Erdos ≥ 600**. Classes: type-mismatch, proof-drift, rewrite-drift, unknown-const-mixed, instance-synth-cascades.

**+12 GREEN**, all verified in-container (`lean4-arm64:v4.31.0`, isolated per-file `lake build`, exit 0). No sorries, no axioms added, no statements weakened.

### Waves
| Wave | Files | Fix |
|------|-------|-----|
| DR37-1 | Erdos1012Problem, Erdos1012OQ05 | forward-ref reorder: `woodall_pancyclic` axiom moved above `woodall_theorem` |
| DR37-2 | Erdos1026Problem | `Finset.exists_smaller_set`→`exists_subset_card_eq` (4×); omega-on-`k^2` via `rw [Nat.add_sub_cancel, hn, pow_two]` |
| DR37-3 | PentagonalNumberTheoremOQ01OQ01, OQ01OQ02 | already-clean off v4.31 base (stale RESIDUAL) |
| DR37-4 | PythagoreanTriplesOQ04OQ01OQ01 | `even_zero`→`Even.zero` (3×); `Nat.even_iff_not_odd.mp`→`Nat.not_odd_iff_even.mpr` |
| DR37-5 | SchroederBernsteinOQ02 + 3 Roth | `Set.image_subset`→`Set.image_mono` (2×); `rw` direction fix on `fixedSet_eq`; 3 Roth already-clean stale rows |
| DR37-6 | SzemerediRegularityOQ01Trivial | all 3 threshold theorems now in imported parent → reduced companion to import shim |
| DR37-7 | ShannonChannelCodingAWGNOQ03OQ01Monotone | `waterLevel_pos` dup (diff arg order) → renamed child's to `waterLevel_pos_mono`; dropped redundant `exact le_refl 0` |

### Per-class before/after (RESIDUAL→GREEN)
- unknown-const/identifier: Erdos1026, Pythagorean, SchroederBernstein (Set.image_subset)
- proof-drift/rewrite-drift: Erdos1026 (omega), SchroederBernstein (rw dir), Pentagonal, 3 Roth (stale)
- duplicate-decl (forward-ref/namespace): Erdos1012, SzemerediRegularityOQ01Trivial, ShannonAWGN

### Notes
- Full partition triaged (403 files). Residual is uniformly multi-error cascade behind the first symptom; no further single-fix candidates.
- Recurring deep blockers documented in STATUS.md / rename-map §7x: `Complex.abs` removal (now a `def`, breaks `map_mul`/`AbsoluteValue` API), Sylow-API renames, `decide`/`native_decide`-noncomputable.
- Sibling branch `feature/issue-38065-c` did not exist on origin during this increment (no overlap risk).
- No `loom:review-requested` label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)