### PR TITLE
migrate(v4.31): Doctor increment 28 — tm/pd/rewrite (A-M partition) (+6 GREEN)

### DIFF
--- a/proofs/Proofs/AngleTrisectionOQ02OQ03Ext.lean
+++ b/proofs/Proofs/AngleTrisectionOQ02OQ03Ext.lean
@@ -38,11 +38,11 @@ theorem pow2_of_half_pow2 {m : ℕ} (hm : 2 ∣ m) {k : ℕ} (h : m / 2 = 2 ^ k)
     m = 2 ^ (k + 1) := by
   have hm2 : m = 2 * (m / 2) := (Nat.mul_div_cancel' hm).symm
   rw [h] at hm2
-  rw [hm2, pow_succ]
+  rw [hm2, pow_succ]; ring
 
 /-- Conversely, if m = 2^{k+1} then m / 2 = 2^k. -/
 theorem half_pow2_of_pow2 {k : ℕ} : 2 ^ (k + 1) / 2 = 2 ^ k := by
-  rw [pow_succ, Nat.mul_div_cancel_left _ (by norm_num : 0 < 2)]
+  rw [pow_succ, Nat.mul_div_cancel _ (by norm_num : 0 < 2)]
 
 /-- A power of 2 ≥ 2 is even. -/
 theorem even_of_pow2_ge_two {k : ℕ} (hk : 1 ≤ k) : 2 ∣ 2 ^ k := by
@@ -53,7 +53,7 @@ theorem even_of_pow2_ge_two {k : ℕ} (hk : 1 ≤ k) : 2 ∣ 2 ^ k := by
 theorem totient_even_of_ge_three {n : ℕ} (hn : 3 ≤ n) : 2 ∣ Nat.totient n := by
   have h1 : 0 < n := by omega
   have h2 : 2 ≤ n := by omega
-  exact Nat.totient_even (by omega)
+  exact (Nat.totient_even (by omega : 2 < n)).two_dvd
 
 /-- The key arithmetic bridge: φ(n) is a power of 2 iff φ(n)/2 is a power of 2
     (for n ≥ 3, where φ(n) is even). -/
@@ -67,10 +67,12 @@ theorem totient_pow2_iff_half_pow2 {n : ℕ} (hn : 3 ≤ n) :
       push_neg at h
       interval_cases k
       simp at hk
-      have := Nat.totient_pos (by omega : 0 < n)
+      have := totient_even_of_ge_three hn
       omega
-    exact ⟨k - 1, by rw [hk, pow_succ, Nat.mul_div_cancel_left _ (by norm_num : 0 < 2)];
-           congr 1; omega⟩
+    refine ⟨k - 1, ?_⟩
+    rw [hk]
+    conv_lhs => rw [show k = (k - 1) + 1 by omega, pow_succ,
+      Nat.mul_div_cancel _ (by norm_num : 0 < 2)]
   · rintro ⟨j, hj⟩
     exact ⟨j + 1, pow2_of_half_pow2 (totient_even_of_ge_three hn) hj⟩
 

--- a/proofs/Proofs/AngleTrisectionOQ02OQ04.lean
+++ b/proofs/Proofs/AngleTrisectionOQ02OQ04.lean
@@ -93,8 +93,10 @@ def degree_strictly_weaker_than_galois : Prop :=
 to the tower criterion: a solvable Galois group means the extension can be
 decomposed into a chain of abelian (in fact cyclic of prime order) extensions. -/
 theorem isPGroup_two_solvable {G : Type*} [Group G] [Fintype G] (h : IsPGroup 2 G) :
-    Group.IsSolvable G :=
-  IsPGroup.isSolvable h
+    IsSolvable G :=
+  haveI : Fact (Nat.Prime 2) := ⟨Nat.prime_two⟩
+  haveI : Group.IsNilpotent G := h.isNilpotent
+  IsNilpotent.to_isSolvable
 
 /-- Subgroups of 2-groups are 2-groups. This ensures the hierarchy is preserved
 when passing to subfields. -/
@@ -103,7 +105,7 @@ theorem isPGroup_two_subgroup {G : Type*} [Group G] [Fintype G] (h : IsPGroup 2 
   h.to_subgroup H
 
 /-- The trivial group is a 2-group. Base case for induction on the tower. -/
-theorem isPGroup_two_trivial : IsPGroup 2 (⊤ : Subgroup (Fin 1 → Fin 1)) := by
+theorem isPGroup_two_trivial : IsPGroup 2 (⊤ : Subgroup PUnit) := by
   rw [IsPGroup.iff_card]
   use 0
   simp
@@ -154,7 +156,7 @@ from Mathlib, which is available but connecting it to the constructibility
 definitions requires substantial glue code (~500+ lines).
 -/
 
-#check IsPGroup.isSolvable
+#check IsPGroup.isNilpotent
 #check IsPGroup.to_subgroup
 #check IsPGroup.iff_card
 

--- a/proofs/Proofs/BezoutIdentityOQ02OQ02.lean
+++ b/proofs/Proofs/BezoutIdentityOQ02OQ02.lean
@@ -152,13 +152,13 @@ every irreducible element is prime. This gives the abstract prime version of Euc
 /-- **Irreducible ↔ Prime in DecompositionMonoids**:
     In a `CancelCommMonoidWithZero` that is also a `DecompositionMonoid`
     (which ℤ, k[X], ℤ[i] all are), irreducible and prime coincide. -/
-theorem irred_iff_prime_decomp {M : Type*} [CancelCommMonoidWithZero M]
+theorem irred_iff_prime_decomp {M : Type*} [CommMonoidWithZero M] [IsCancelMulZero M]
     [DecompositionMonoid M] {p : M} : Irreducible p ↔ Prime p :=
   irreducible_iff_prime
 
 /-- **Abstract Euclid's Lemma for Irreducibles** (in CancelCommMonoidWithZero + DecompositionMonoid):
     If p is irreducible and p | a * b, then p | a or p | b. -/
-theorem euclids_lemma_irreducible {M : Type*} [CancelCommMonoidWithZero M]
+theorem euclids_lemma_irreducible {M : Type*} [CommMonoidWithZero M] [IsCancelMulZero M]
     [DecompositionMonoid M] {p a b : M}
     (hirr : Irreducible p) (hdvd : p ∣ a * b) : p ∣ a ∨ p ∣ b :=
   (irreducible_iff_prime.mp hirr).dvd_or_dvd hdvd

--- a/proofs/Proofs/CauchySchwarz.lean
+++ b/proofs/Proofs/CauchySchwarz.lean
@@ -48,6 +48,8 @@ This is #78 on Wiedijk's list of 100 theorems.
 
 namespace CauchySchwarz
 
+open scoped RealInnerProductSpace
+
 /-! ## Inner Product Space Form
 
 The most general form of Cauchy-Schwarz in an abstract inner product space.
@@ -61,7 +63,7 @@ For vectors u, v in a real inner product space:
 This is the abstract, coordinate-free version of the inequality. -/
 theorem cauchy_schwarz_inner {E : Type*} [NormedAddCommGroup E]
     [InnerProductSpace ℝ E] (u v : E) :
-    |⟪u, v⟫_ℝ| ≤ ‖u‖ * ‖v‖ :=
+    |⟪u, v⟫| ≤ ‖u‖ * ‖v‖ :=
   abs_real_inner_le_norm u v
 
 /-- **Cauchy-Schwarz Squared Form**
@@ -69,14 +71,14 @@ theorem cauchy_schwarz_inner {E : Type*} [NormedAddCommGroup E]
 Equivalent formulation: ⟨u, v⟩² ≤ ⟨u, u⟩ · ⟨v, v⟩ -/
 theorem cauchy_schwarz_inner_sq {E : Type*} [NormedAddCommGroup E]
     [InnerProductSpace ℝ E] (u v : E) :
-    ⟪u, v⟫_ℝ ^ 2 ≤ ⟪u, u⟫_ℝ * ⟪v, v⟫_ℝ := by
+    ⟪u, v⟫ ^ 2 ≤ ⟪u, u⟫ * ⟪v, v⟫ := by
   have h := abs_real_inner_le_norm u v
   have h_nonneg : 0 ≤ ‖u‖ * ‖v‖ := mul_nonneg (norm_nonneg _) (norm_nonneg _)
-  have h_sq := sq_le_sq' (by linarith [abs_nonneg ⟪u, v⟫_ℝ]) h
+  have h_sq := sq_le_sq' (by linarith [abs_nonneg ⟪u, v⟫]) h
   rw [sq_abs] at h_sq
-  calc ⟪u, v⟫_ℝ ^ 2 ≤ (‖u‖ * ‖v‖) ^ 2 := h_sq
+  calc ⟪u, v⟫ ^ 2 ≤ (‖u‖ * ‖v‖) ^ 2 := h_sq
     _ = ‖u‖ ^ 2 * ‖v‖ ^ 2 := by ring
-    _ = ⟪u, u⟫_ℝ * ⟪v, v⟫_ℝ := by rw [real_inner_self_eq_norm_sq, real_inner_self_eq_norm_sq]
+    _ = ⟪u, u⟫ * ⟪v, v⟫ := by rw [real_inner_self_eq_norm_sq, real_inner_self_eq_norm_sq]
 
 /-! ## Two-Variable Algebraic Form
 
@@ -127,18 +129,18 @@ This follows from viewing the sequences as vectors in Euclidean space. -/
 theorem cauchy_schwarz_sum {n : ℕ} (a b : Fin n → ℝ) :
     (∑ i, a i * b i) ^ 2 ≤ (∑ i, a i ^ 2) * (∑ i, b i ^ 2) := by
   -- Interpret as vectors in Euclidean space
-  let u : EuclideanSpace ℝ (Fin n) := a
-  let v : EuclideanSpace ℝ (Fin n) := b
+  let u : EuclideanSpace ℝ (Fin n) := (EuclideanSpace.equiv (Fin n) ℝ).symm a
+  let v : EuclideanSpace ℝ (Fin n) := (EuclideanSpace.equiv (Fin n) ℝ).symm b
   -- Apply the inner product Cauchy-Schwarz
   have h := cauchy_schwarz_inner_sq u v
   -- The inner product is the dot product for EuclideanSpace
-  have inner_eq : ⟪u, v⟫_ℝ = ∑ i, a i * b i := by
+  have inner_eq : ⟪u, v⟫ = ∑ i, a i * b i := by
     simp only [EuclideanSpace.inner_eq_star_dotProduct, dotProduct]
-    simp [u, v]
-  have norm_u_sq : ⟪u, u⟫_ℝ = ∑ i, a i ^ 2 := by
+    simp [u, v, mul_comm]
+  have norm_u_sq : ⟪u, u⟫ = ∑ i, a i ^ 2 := by
     simp only [EuclideanSpace.inner_eq_star_dotProduct, dotProduct]
     simp [u, sq]
-  have norm_v_sq : ⟪v, v⟫_ℝ = ∑ i, b i ^ 2 := by
+  have norm_v_sq : ⟪v, v⟫ = ∑ i, b i ^ 2 := by
     simp only [EuclideanSpace.inner_eq_star_dotProduct, dotProduct]
     simp [v, sq]
   rw [inner_eq, norm_u_sq, norm_v_sq] at h
@@ -163,15 +165,15 @@ theorem cauchy_schwarz_sum_abs {n : ℕ} (a b : Fin n → ℝ) :
 If |⟨u, v⟩| = ‖u‖ · ‖v‖, then u and v are linearly dependent. -/
 theorem cauchy_schwarz_eq_iff_parallel {E : Type*} [NormedAddCommGroup E]
     [InnerProductSpace ℝ E] (u v : E) (hu : u ≠ 0) (hv : v ≠ 0) :
-    |⟪u, v⟫_ℝ| = ‖u‖ * ‖v‖ ↔ ∃ c : ℝ, u = c • v := by
+    |⟪u, v⟫| = ‖u‖ * ‖v‖ ↔ ∃ c : ℝ, u = c • v := by
   constructor
   · intro h
     -- Use the standard Mathlib result for norm equality
-    have h' : ‖⟪u, v⟫_ℝ‖ = ‖u‖ * ‖v‖ := by rwa [Real.norm_eq_abs]
+    have h' : ‖⟪u, v⟫‖ = ‖u‖ * ‖v‖ := by rwa [Real.norm_eq_abs]
     obtain ⟨r, hr_ne, hr⟩ := (norm_inner_eq_norm_iff hu hv).mp h'
     refine ⟨r⁻¹, ?_⟩
     rw [hr, smul_smul]
-    simp [inv_mul_cancel hr_ne]
+    simp [inv_mul_cancel₀ hr_ne]
   · intro ⟨c, hc⟩
     rw [hc, inner_smul_left, real_inner_self_eq_norm_sq, norm_smul, Real.norm_eq_abs]
     simp only [starRingEnd_apply, star_trivial]
@@ -205,10 +207,10 @@ theorem triangle_sq_via_cauchy_schwarz {E : Type*} [NormedAddCommGroup E]
     [InnerProductSpace ℝ E] (u v : E) :
     ‖u + v‖ ^ 2 ≤ (‖u‖ + ‖v‖) ^ 2 := by
   have h_cs := cauchy_schwarz_inner u v
-  have h_expand : ‖u + v‖ ^ 2 = ‖u‖ ^ 2 + 2 * ⟪u, v⟫_ℝ + ‖v‖ ^ 2 := norm_add_sq_real u v
+  have h_expand : ‖u + v‖ ^ 2 = ‖u‖ ^ 2 + 2 * ⟪u, v⟫ + ‖v‖ ^ 2 := norm_add_sq_real u v
   have h_target : (‖u‖ + ‖v‖) ^ 2 = ‖u‖ ^ 2 + 2 * (‖u‖ * ‖v‖) + ‖v‖ ^ 2 := by ring
   rw [h_expand, h_target]
-  have : ⟪u, v⟫_ℝ ≤ |⟪u, v⟫_ℝ| := le_abs_self _
+  have : ⟪u, v⟫ ≤ |⟪u, v⟫| := le_abs_self _
   linarith
 
 /-- **Covariance Bound**
@@ -218,7 +220,7 @@ coefficient is bounded by 1. This is a probabilistic interpretation of
 Cauchy-Schwarz. -/
 theorem covariance_bound {E : Type*} [NormedAddCommGroup E]
     [InnerProductSpace ℝ E] (u v : E) (hu : u ≠ 0) (hv : v ≠ 0) :
-    |⟪u, v⟫_ℝ| / (‖u‖ * ‖v‖) ≤ 1 := by
+    |⟪u, v⟫| / (‖u‖ * ‖v‖) ≤ 1 := by
   have h_pos : 0 < ‖u‖ * ‖v‖ := mul_pos (norm_pos_iff.mpr hu) (norm_pos_iff.mpr hv)
   rw [div_le_one h_pos]
   exact cauchy_schwarz_inner u v

--- a/proofs/Proofs/ChineseRemainderNonCoprimeOQ02OQ01.lean
+++ b/proofs/Proofs/ChineseRemainderNonCoprimeOQ02OQ01.lean
@@ -77,7 +77,7 @@ we transport distributivity from the `FactorSet` (multiset) model.
 
 section Distrib
 
-variable {R : Type*} [CancelCommMonoidWithZero R] [UniqueFactorizationMonoid R]
+variable {R : Type*} [CommMonoidWithZero R] [IsCancelMulZero R] [UniqueFactorizationMonoid R]
 
 /-- The lattice `Associates R` of a UFD is distributive (the nontrivial direction
 `(A ⊔ B) ⊓ C ≤ (A ⊓ C) ⊔ (B ⊓ C)`).  Proved by pushing the inequality through the

--- a/proofs/Proofs/Erdos181Problem.lean
+++ b/proofs/Proofs/Erdos181Problem.lean
@@ -105,8 +105,10 @@ the number of vertices.
 This would mean there exists a constant C such that R(Q_n) ≤ C · 2^n
 for all n. This is OPEN.
 -/
-axiom erdos_181_conjecture :
+def Erdos181Conjecture : Prop :=
   ∃ C : ℝ, C > 0 ∧ ∀ n : ℕ, (ramseyNumber n : ℝ) ≤ C * 2 ^ n
+
+axiom erdos_181_conjecture : Erdos181Conjecture
 
 /--
 **Tikhomirov (2022):**
@@ -161,13 +163,13 @@ theorem trivial_upper_bound :
     _ ≤ C₀ * (2 : ℝ) ^ (2 * (↑n : ℝ)) := by
         -- rpow monotonicity: (2-c)·n ≤ 2·n since c > 0, and base 2 ≥ 1
         apply mul_le_mul_of_nonneg_left _ (le_of_lt hC₀)
-        exact rpow_le_rpow_of_exponent_le (by norm_num : (1 : ℝ) ≤ 2)
+        exact Real.rpow_le_rpow_of_exponent_le (by norm_num : (1 : ℝ) ≤ 2)
           (mul_le_mul_of_nonneg_right (by linarith) (Nat.cast_nonneg n))
     _ = C₀ * (4 : ℝ) ^ n := by
         -- Convert 2^{2n} (rpow) to 4^n (pow)
         congr 1
         have hcast : (2 : ℝ) * (↑n : ℝ) = (↑(2 * n) : ℝ) := by push_cast; ring
-        rw [hcast, rpow_natCast, pow_mul]
+        rw [hcast, Real.rpow_natCast, pow_mul]
         norm_num
     _ ≤ D * D ^ n := by
         -- C₀ ≤ D and 4^n ≤ D^n (since 4 ≤ D)
@@ -226,7 +228,7 @@ This question is OPEN. Note:
 
 /-- The conjecture answers Erdős-Sós negatively: R(Q_n)/2^n is bounded. -/
 theorem conjecture_implies_bounded_ratio :
-    erdos_181_conjecture → ∃ C : ℝ, C > 0 ∧ ∀ n : ℕ,
+    Erdos181Conjecture → ∃ C : ℝ, C > 0 ∧ ∀ n : ℕ,
       (ramseyNumber n : ℝ) / 2 ^ n ≤ C := by
   intro ⟨C, hC, hbound⟩
   exact ⟨C, hC, fun n => by
@@ -357,9 +359,11 @@ theorem tikhomirov_subquadratic :
   intro ⟨c, hc, C, hC, hbound⟩
   exact ⟨c, hc, C, hC, fun n => by
     have : (2 : ℝ) ^ ((2 - c) * n) = ((2 : ℝ) ^ n) ^ (2 - c) := by
-      rw [← Real.rpow_natCast 2 n, ← Real.rpow_natCast 2 ((2 - c) * ↑n)]
-      simp [Real.rpow_mul (by positivity : (0 : ℝ) ≤ 2)]
-    linarith [hbound n]⟩
+      rw [← Real.rpow_natCast (2 : ℝ) n, ← Real.rpow_mul (by positivity : (0 : ℝ) ≤ 2),
+        mul_comm]
+    have hb := hbound n
+    rw [this] at hb
+    exact hb⟩
 
 /-- The conjecture contradicts the possibility that R(Q_n)/2^n → ∞. -/
 theorem conjecture_contradicts_divergence :
@@ -371,8 +375,8 @@ theorem conjecture_contradicts_divergence :
   have h := hN N₀ le_rfl
   have hle := hbound N₀
   have hpos : (0 : ℝ) < 2 ^ N₀ := by positivity
-  rw [div_gt_iff hpos] at h
-  linarith
+  rw [gt_iff_lt, lt_div_iff₀ hpos] at h
+  nlinarith [hle]
 
 theorem erdos_181 :
     ∃ C : ℝ, C > 0 ∧ ∀ n : ℕ, (ramseyNumber n : ℝ) ≤ C * 2 ^ n :=

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -974,7 +974,7 @@ Erdos179ProblemAristotle	RESIDUAL	proof-drift
 Erdos17Problem	GREEN	
 Erdos180Problem	RESIDUAL	instance-synth
 Erdos181OQ01	RESIDUAL	unknown-const:Function.id
-Erdos181Problem	RESIDUAL	unknown-const:rpow_le_rpow_of_exponent_le
+Erdos181Problem	GREEN	unknown-const:rpow_le_rpow_of_exponent_le
 Erdos182Problem	GREEN	
 Erdos183Problem	RESIDUAL	proof-drift
 Erdos184Problem	RESIDUAL	proof-drift

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -449,7 +449,7 @@ ChineseRemainderNonCoprimeList	GREEN
 ChineseRemainderNonCoprimeOQ01	GREEN	
 ChineseRemainderNonCoprimeOQ01OQ01	GREEN	
 ChineseRemainderNonCoprimeOQ02	RESIDUAL	parse-error
-ChineseRemainderNonCoprimeOQ02OQ01	RESIDUAL	instance-synth
+ChineseRemainderNonCoprimeOQ02OQ01	GREEN	instance-synth
 ChineseRemainderNonCoprimeOQ03OQ02	RESIDUAL	type-mismatch
 CircumferenceFromArea	GREEN	
 CircumferenceViaDifferentiationOQ01	GREEN	

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -85,7 +85,7 @@ AngleTrisectionOQ02OQ01OQ02	RESIDUAL	rewrite-drift
 AngleTrisectionOQ02OQ01OQ02Aristotle	GREEN	
 AngleTrisectionOQ02OQ01OQ02Incomplete01	RESIDUAL	instance-synth
 AngleTrisectionOQ02OQ03	GREEN	
-AngleTrisectionOQ02OQ03Ext	RESIDUAL	rewrite-drift
+AngleTrisectionOQ02OQ03Ext	GREEN	rewrite-drift
 AngleTrisectionOQ02OQ03OQ01	GREEN	
 AngleTrisectionOQ02OQ04	GREEN	unknown-const:Group.IsSolvable
 AngleTrisectionOQ02OQ04OQ01	GREEN	

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -216,7 +216,7 @@ BezoutIdentityOQ02OQ01OQ01OQ01OQ01	RESIDUAL	type-mismatch
 BezoutIdentityOQ02OQ01OQ02	GREEN	
 BezoutIdentityOQ02OQ01OQ02OQ02OQ03	RESIDUAL	parse-error
 BezoutIdentityOQ02OQ01OQ02OQ03	RESIDUAL	type-mismatch
-BezoutIdentityOQ02OQ02	RESIDUAL	unknown-const:euclids_lemma_irreducible
+BezoutIdentityOQ02OQ02	GREEN	unknown-const:euclids_lemma_irreducible
 BezoutIdentityOQ02OQ02OQ01OQ03	GREEN	
 BezoutIdentityOQ02OQ04	RESIDUAL	instance-synth
 BezoutIdentityOQ03OQ01OQ01OQ02OQ02	GREEN	

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -87,7 +87,7 @@ AngleTrisectionOQ02OQ01OQ02Incomplete01	RESIDUAL	instance-synth
 AngleTrisectionOQ02OQ03	GREEN	
 AngleTrisectionOQ02OQ03Ext	RESIDUAL	rewrite-drift
 AngleTrisectionOQ02OQ03OQ01	GREEN	
-AngleTrisectionOQ02OQ04	RESIDUAL	unknown-const:Group.IsSolvable
+AngleTrisectionOQ02OQ04	GREEN	unknown-const:Group.IsSolvable
 AngleTrisectionOQ02OQ04OQ01	GREEN	
 AngleTrisectionOQ02OQ04OQ01Aristotle	GREEN	
 AngleTrisectionOQ03	GREEN	

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -345,7 +345,7 @@ CauchyInterlacingOQ01OQ01OQ01	RESIDUAL	unknown-const:List.eq_of_perm_of_sorted
 CauchyInterlacingOQ01OQ01OQ01OQ01	RESIDUAL	unknown-const:List.eq_of_perm_of_sorted
 CauchyInterlacingPoincareCompression	RESIDUAL	unknown-const:LinearMap.mul_apply
 CauchyInterlacingWeylDual	GREEN	
-CauchySchwarz	RESIDUAL	type-mismatch
+CauchySchwarz	GREEN	type-mismatch
 CauchySchwarzIntegralLpDualityGluing	GREEN	
 CauchySchwarzIntegralLpDualityIngredients	GREEN	
 CauchySchwarzIntegralLpDualityMaximal	GREEN	


### PR DESCRIPTION
Salvaged from increment 28 (session-limit interrupted): +6 verified GREEN (AngleTrisection OQ02OQ03Ext/OQ02OQ04, BezoutIdentityOQ02OQ02, CauchySchwarz, ChineseRemainderNonCoprimeOQ02OQ01, Erdos181Problem) + §7x recipes. All in-container lake-exit-0 verified before push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)