### PR TITLE
migrate(v4.31): Doctor increment 38 — tm/pd/rewrite (N-Z partition) (+12 GREEN)

### DIFF
--- a/proofs/Proofs/PicksTheoremOQ01.lean
+++ b/proofs/Proofs/PicksTheoremOQ01.lean
@@ -124,11 +124,21 @@ theorem picks_additivity
     (i₁ b₁ i₂ b₂ k : ℕ) (A₁ A₂ : ℚ)
     (h₁ : A₁ = i₁ + b₁ / 2 - 1)
     (h₂ : A₂ = i₂ + b₂ / 2 - 1)
-    (hk : 2 ≤ b₁ ∧ 2 ≤ b₂) :
+    (hk : 2 ≤ b₁ ∧ 2 ≤ b₂)
+    -- Gluing two polygons along k+1 shared boundary points forces this bound;
+    -- required so the ℕ-subtraction below matches the true integer boundary count.
+    (hglue : 2 * k + 2 ≤ b₁ + b₂) :
     -- Union has: i₁+i₂+k interior, b₁+b₂-2k-2 boundary, A₁+A₂ area
     A₁ + A₂ = ((i₁ + i₂ + k : ℕ) : ℚ) + ((b₁ + b₂ - 2 * k - 2 : ℕ) : ℚ) / 2 - 1 := by
   -- This is pure algebra from h₁, h₂
-  push_cast at *
+  have hsub : ((b₁ + b₂ - 2 * k - 2 : ℕ) : ℚ) = (b₁ : ℚ) + b₂ - 2 * k - 2 := by
+    have : 2 * k + 2 ≤ b₁ + b₂ := hglue
+    push_cast [Nat.sub_sub]
+    rw [Nat.cast_sub (by omega)]
+    push_cast
+    ring
+  rw [hsub]
+  push_cast at h₁ h₂ ⊢
   linarith
 
 -- ═══════════════════════════════════════════════════════════════
@@ -148,7 +158,11 @@ theorem primitive_area (x₁ y₁ x₂ y₂ x₃ y₃ : ℤ)
     (h : IsPrimitive x₁ y₁ x₂ y₂ x₃ y₃) :
     shoelaceTriangle x₁ y₁ x₂ y₂ x₃ y₃ = 1 / 2 := by
   unfold shoelaceTriangle IsPrimitive at *
-  rw [h]; norm_num
+  have hcast : ((|x₁ * (y₂ - y₃) + x₂ * (y₃ - y₁) + x₃ * (y₁ - y₂)| : ℤ) : ℚ) = 1 := by
+    rw [h]; norm_num
+  rw [Int.cast_abs] at hcast
+  push_cast at hcast
+  rw [hcast]
 
 /-- Pick's formula holds for every primitive lattice triangle:
     Area = 1/2, i = 0, b = 3, so 0 + 3/2 - 1 = 1/2. -/

--- a/proofs/Proofs/PicksTheoremOQ01OQ01.lean
+++ b/proofs/Proofs/PicksTheoremOQ01OQ01.lean
@@ -64,11 +64,11 @@ theorem IsPrimitive.nonDegenerate {T : LatticeTriangle} (h : T.IsPrimitive) :
 
 /-- Unit triangle {(0,0),(1,0),(0,1)} is primitive. -/
 theorem unit_triangle_primitive :
-    (LatticeTriangle.mk (0, 0) (1, 0) (0, 1)).IsPrimitive := by decide
+    (LatticeTriangle.mk (0, 0) (1, 0) (0, 1)).IsPrimitive := by rfl
 
 /-- {(0,0),(1,0),(1,1)} is primitive. -/
 theorem second_unit_triangle_primitive :
-    (LatticeTriangle.mk (0, 0) (1, 0) (1, 1)).IsPrimitive := by decide
+    (LatticeTriangle.mk (0, 0) (1, 0) (1, 1)).IsPrimitive := by rfl
 
 -- ════════════════════════════════════════════════════════════════
 -- SECTION III: Edge-Splitting Arithmetic
@@ -94,7 +94,9 @@ theorem edge_split_det_add (T : LatticeTriangle) (g : ℤ) (hg : g ≠ 0)
   have hM2 : (T.v2.2 - T.v1.2) / g = k2 :=
     hk2 ▸ Int.mul_ediv_cancel_left k2 hg
   simp only [LatticeTriangle.det, splitLeft, splitRight, hM1, hM2]
-  ring
+  have hv21 : T.v2.1 = T.v1.1 + g * k1 := by linarith [hk1]
+  have hv22 : T.v2.2 = T.v1.2 + g * k2 := by linarith [hk2]
+  rw [hv21, hv22]; ring
 
 /-- **Det sizes under edge splitting**: When g | (v2-v1) and g > 0,
     the split determinants are det(T)/g and det(T)*(g-1)/g,
@@ -131,7 +133,7 @@ theorem exists_reduction (T : LatticeTriangle) (hn : 1 < T.det.natAbs) :
       simp only [LatticeTriangle.det]; ring
     have hna : ((T.det.natAbs:ℤ)-1).natAbs = T.det.natAbs - 1 := by
       have h1 : 1 ≤ T.det.natAbs := by omega
-      zify [h1]; exact Int.natAbs_of_nonneg (by omega)
+      omega
     rw [hT1, hT2det, hna]; omega
   · -- T1 unit triangle: det = 1 > 0
     norm_num [LatticeTriangle.det]
@@ -141,7 +143,7 @@ theorem exists_reduction (T : LatticeTriangle) (hn : 1 < T.det.natAbs) :
       simp only [LatticeTriangle.det]; ring
     have hna : ((T.det.natAbs:ℤ)-1).natAbs = T.det.natAbs - 1 := by
       have h1 : 1 ≤ T.det.natAbs := by omega
-      zify [h1]; exact Int.natAbs_of_nonneg (by omega)
+      omega
     rw [hT2det, hna]; omega
 
 /-- **Main Theorem**: For any n ≥ 1 and any lattice triangle T with |det(T)| = n,
@@ -198,14 +200,14 @@ theorem det2_split_correct :
     let M : ℤ × ℤ := (1, 0)
     (splitLeft T M).det + (splitRight T M).det = T.det ∧
     (splitLeft T M).IsPrimitive ∧ (splitRight T M).IsPrimitive := by
-  decide
+  refine ⟨rfl, rfl, rfl⟩
 
 /-- Edge split formula: for T = {(0,0),(4,0),(0,3)} at g=2, each piece has |det|=6. -/
 theorem det12_two_splits :
     let T := LatticeTriangle.mk (0, 0) (4, 0) (0, 3)
     T.det.natAbs = 12 ∧
     (splitLeft T (2, 0)).det.natAbs + (splitRight T (2, 0)).det.natAbs = 12 := by
-  decide
+  refine ⟨rfl, rfl⟩
 
 /-- The det-additivity lemma works for T={O,(2,0),(0,3)}, g=2. -/
 theorem det_add_example :

--- a/proofs/Proofs/PuiseuxTheorem.lean
+++ b/proofs/Proofs/PuiseuxTheorem.lean
@@ -670,7 +670,7 @@ theorem isPuiseux_add {K : Type*} [AddCommMonoid K] {f g : HahnSeries ℚ K}
   have hn0 : ((n : ℕ) : ℚ) ≠ 0 := by exact_mod_cast n.pos.ne'
   have hm0 : ((m : ℕ) : ℚ) ≠ 0 := by exact_mod_cast m.pos.ne'
   refine ⟨n * m, fun q hq => ?_⟩
-  rcases HahnSeries.support_add_subset hq with h | h
+  rcases HahnSeries.support_add_subset _ _ hq with h | h
   · obtain ⟨k, hk⟩ := hn q h
     refine ⟨k * (m : ℤ), ?_⟩
     rw [hk]; push_cast
@@ -1013,7 +1013,7 @@ theorem isPuiseuxOfRamification_add {K : Type*} [AddCommMonoid K] {n : ℕ+}
     {f g : HahnSeries ℚ K} (hf : IsPuiseuxOfRamification n f)
     (hg : IsPuiseuxOfRamification n g) : IsPuiseuxOfRamification n (f + g) := by
   intro q hq
-  rcases HahnSeries.support_add_subset hq with h | h
+  rcases HahnSeries.support_add_subset _ _ hq with h | h
   · exact hf q h
   · exact hg q h
 

--- a/proofs/Proofs/RamseyHypergraph.lean
+++ b/proofs/Proofs/RamseyHypergraph.lean
@@ -337,17 +337,13 @@ lemma IsRamsey.swap {n k s t : ℕ} : IsRamsey n k s t ↔ IsRamsey n k t s := b
   · -- An `a`-clique monochromatic-`false` under `!χ` is monochromatic-`true` under `χ`.
     refine Or.inr ⟨S, hSc, ?_⟩
     intro T hT
-    have hflip : !(χ T) = false := hSm T hT
-    cases hχ : χ T with
-    | false => simp [hχ] at hflip
-    | true => exact hχ
+    have hflip : Bool.not (χ T) = false := hSm T hT
+    simpa using hflip
   · -- A `b`-clique monochromatic-`true` under `!χ` is monochromatic-`false` under `χ`.
     refine Or.inl ⟨S, hSc, ?_⟩
     intro T hT
-    have hflip : !(χ T) = true := hSm T hT
-    cases hχ : χ T with
-    | false => exact hχ
-    | true => simp [hχ] at hflip
+    have hflip : Bool.not (χ T) = true := hSm T hT
+    simpa using hflip
 
 /-- **`ramseyNumber` collapses when the `false`-target is zero.** With `s = 0` the
 empty set is a trivially monochromatic `false`-clique of size `0`, so
@@ -457,7 +453,7 @@ lemma is_ramsey_self_right (k t : ℕ) (hk : 1 ≤ k) (hkt : k ≤ t) :
       have hχ_ne : χ T ≠ false := fun hχ => h T hTcard hχ
       cases hT_color : χ T with
       | false => exact absurd hT_color hχ_ne
-      | true => exact hT_color
+      | true => rfl
 
 /-- **Boundary case `t = k`.** Symmetric to `is_ramsey_self_right` via
 `IsRamsey.swap`. -/

--- a/proofs/Proofs/Sqrt2MinpolyOQ01.lean
+++ b/proofs/Proofs/Sqrt2MinpolyOQ01.lean
@@ -159,7 +159,7 @@ private lemma irrational_sqrt_of_not_sq {n : ℕ} (hn : 0 < n) (hns : ¬ IsSquar
         rw [← Real.rpow_natCast ((n : ℝ) ^ ((1 : ℝ) / (2 : ℕ))) 2,
             ← Real.rpow_mul (Nat.cast_nonneg n)]
         norm_num
-      rw [← hk] at hrpow
+      rw [hk] at hrpow
       exact_mod_cast hrpow
     refine ⟨k.natAbs, ?_⟩
     have habs : k.natAbs ^ 2 = n := by
@@ -188,26 +188,28 @@ theorem minpoly_sqrt_of_not_sq (n : ℕ) (hn : 0 < n) (hns : ¬ IsSquare n) :
     minpoly.dvd ℚ (Real.sqrt n) hXn_aeval
   have hXn_ne : (X ^ 2 - C (n : ℚ) : ℚ[X]) ≠ 0 := Polynomial.Monic.ne_zero hXn_monic
   have hdeg_le : (minpoly ℚ (Real.sqrt n)).natDegree ≤ 2 := by
+    have hnd : (X ^ 2 - C (n : ℚ) : ℚ[X]).natDegree = 2 := natDegree_X_pow_sub_C
     have := Polynomial.natDegree_le_of_dvd hdvd hXn_ne
-    simpa [Polynomial.natDegree_X_pow_sub_C] using this
+    rwa [hnd] at this
   have hirr : Irrational (Real.sqrt n) := irrational_sqrt_of_not_sq hn hns
   have hdeg_ge : 2 ≤ (minpoly ℚ (Real.sqrt n)).natDegree := by
     by_contra hlt
     push_neg at hlt
     have hdeg1 : (minpoly ℚ (Real.sqrt n)).natDegree = 1 := by
       have hge1 := minpoly.natDegree_pos hintegral; omega
-    obtain ⟨a, b, ha, hfab⟩ := Polynomial.natDegree_eq_one.mp hdeg1
+    obtain ⟨a, ha, b, hfab⟩ := Polynomial.natDegree_eq_one.mp hdeg1
     have hmonic := minpoly.monic hintegral
     have ha1 : a = 1 := by
       have hlc := hmonic.leadingCoeff
-      rw [hfab] at hlc
+      rw [← hfab] at hlc
       simp [Polynomial.leadingCoeff_add_of_degree_lt, Polynomial.degree_C_mul_X ha,
             Polynomial.degree_C, ha] at hlc
       exact hlc
-    rw [ha1, one_mul] at hfab
+    rw [ha1, map_one, one_mul] at hfab
     have heval := minpoly.aeval ℚ (Real.sqrt n)
-    rw [hfab] at heval
+    rw [← hfab] at heval
     simp only [map_add, aeval_X, aeval_C] at heval
+    rw [show (algebraMap ℚ ℝ) b = (b : ℝ) from by simp] at heval
     exact hirr ⟨-b, by push_cast at heval ⊢; linarith⟩
   have hdeg : (minpoly ℚ (Real.sqrt n)).natDegree = 2 := Nat.le_antisymm hdeg_le hdeg_ge
   obtain ⟨c, hc⟩ := hdvd

--- a/proofs/Proofs/SumOfKthPowersOQ03.lean
+++ b/proofs/Proofs/SumOfKthPowersOQ03.lean
@@ -106,8 +106,8 @@ theorem block_eq_cube (i : ℕ) :
       (∑ j ∈ range (T i), (2 * j + 1))
           + (∑ j ∈ Ico (T i) (T (i + 1)), (2 * j + 1))
         = ∑ j ∈ range (T (i + 1)), (2 * j + 1) := by
-    rw [Finset.range_eq_Ico]
-    exact Finset.sum_Ico_consecutive _ (Nat.zero_le _) (T_le_succ i)
+    simp only [Finset.range_eq_Ico]
+    exact Finset.sum_Ico_consecutive (fun j => 2 * j + 1) (Nat.zero_le _) (T_le_succ i)
   rw [sum_odds, sum_odds] at hsplit
   -- hsplit : T i ^ 2 + block = T (i+1) ^ 2
   have hb := block_sq i  -- T i ^ 2 + i ^ 3 = T (i+1) ^ 2
@@ -124,8 +124,9 @@ theorem tiling (n : ℕ) :
   induction n with
   | zero => simp
   | succ k ih =>
-    rw [Finset.sum_range_succ, ih, Finset.range_eq_Ico]
-    exact Finset.sum_Ico_consecutive _ (Nat.zero_le _) (T_le_succ k)
+    rw [Finset.sum_range_succ, ih]
+    simp only [Finset.range_eq_Ico]
+    exact Finset.sum_Ico_consecutive (fun j => 2 * j + 1) (Nat.zero_le _) (T_le_succ k)
 
 /-- **Nicomachus's theorem via the odd-number partition.**
 

--- a/proofs/Proofs/TaxicabNumberOQ01.lean
+++ b/proofs/Proofs/TaxicabNumberOQ01.lean
@@ -44,9 +44,11 @@ theorem rep_two : (9 : ℕ) ^ 3 + 10 ^ 3 = 1729 := by norm_num
 /-- 1729 has exactly two representations as a sum of two positive cubes. -/
 theorem card_reps_1729 : (reps 1729).card = 2 := by decide
 
+set_option maxHeartbeats 4000000 in
 /-- No positive integer below 1729 has two distinct representations as a sum of
 two positive cubes. Combined with `card_reps_1729`, this is `Ta(2) = 1729`. -/
-theorem minimal_below_1729 : ∀ m < 1729, (reps m).card < 2 := by decide
+theorem minimal_below_1729 : ∀ m < 1729, (reps m).card < 2 := by
+  decide
 
 /-- `Ta(2) = 1729`: it is the least `n` with two distinct cube representations. -/
 theorem taxicab_two_eq_1729 :

--- a/proofs/Proofs/TaylorTheorem.lean
+++ b/proofs/Proofs/TaylorTheorem.lean
@@ -88,12 +88,16 @@ theorem taylor_lagrange {f : ℝ → ℝ} {x₀ x : ℝ} {n : ℕ} (hx : x₀ < 
     ∃ x' ∈ Ioo x₀ x,
       f x - taylorWithinEval f n (Icc x₀ x) x₀ x =
         iteratedDerivWithin (n + 1) f (Icc x₀ x) x' * (x - x₀) ^ (n + 1) / (n + 1)! := by
-  have hf_n : ContDiffOn ℝ n f (Icc x₀ x) := hf.of_succ
-  have hdiff : DifferentiableOn ℝ (iteratedDerivWithin n f (Icc x₀ x)) (Ioo x₀ x) := by
-    have hlt : (n : ℕ∞) < n + 1 := by norm_cast; omega
+  have huIcc : uIcc x₀ x = Icc x₀ x := uIcc_of_le hx.le
+  have huIoo : uIoo x₀ x = Ioo x₀ x := uIoo_of_lt hx
+  have hf_n : ContDiffOn ℝ n f (uIcc x₀ x) := by rw [huIcc]; exact hf.of_succ
+  have hdiff : DifferentiableOn ℝ (iteratedDerivWithin n f (uIcc x₀ x)) (uIoo x₀ x) := by
+    rw [huIcc, huIoo]
+    have hlt : (n : WithTop ℕ∞) < n + 1 := by norm_cast; omega
     have h := hf.differentiableOn_iteratedDerivWithin (m := n) hlt (uniqueDiffOn_Icc hx)
     exact h.mono Ioo_subset_Icc_self
-  exact taylor_mean_remainder_lagrange hx hf_n hdiff
+  have := taylor_mean_remainder_lagrange hx.ne hf_n hdiff
+  rwa [huIcc, huIoo] at this
 
 /-! ## Cauchy Remainder Form
 
@@ -113,12 +117,16 @@ theorem taylor_cauchy {f : ℝ → ℝ} {x₀ x : ℝ} {n : ℕ} (hx : x₀ < x)
     ∃ x' ∈ Ioo x₀ x,
       f x - taylorWithinEval f n (Icc x₀ x) x₀ x =
         iteratedDerivWithin (n + 1) f (Icc x₀ x) x' * (x - x') ^ n / n ! * (x - x₀) := by
-  have hf_n : ContDiffOn ℝ n f (Icc x₀ x) := hf.of_succ
-  have hdiff : DifferentiableOn ℝ (iteratedDerivWithin n f (Icc x₀ x)) (Ioo x₀ x) := by
-    have hlt : (n : ℕ∞) < n + 1 := by norm_cast; omega
+  have huIcc : uIcc x₀ x = Icc x₀ x := uIcc_of_le hx.le
+  have huIoo : uIoo x₀ x = Ioo x₀ x := uIoo_of_lt hx
+  have hf_n : ContDiffOn ℝ n f (uIcc x₀ x) := by rw [huIcc]; exact hf.of_succ
+  have hdiff : DifferentiableOn ℝ (iteratedDerivWithin n f (uIcc x₀ x)) (uIoo x₀ x) := by
+    rw [huIcc, huIoo]
+    have hlt : (n : WithTop ℕ∞) < n + 1 := by norm_cast; omega
     have h := hf.differentiableOn_iteratedDerivWithin (m := n) hlt (uniqueDiffOn_Icc hx)
     exact h.mono Ioo_subset_Icc_self
-  exact taylor_mean_remainder_cauchy hx hf_n hdiff
+  have := taylor_mean_remainder_cauchy hx.ne hf_n hdiff
+  rwa [huIcc, huIoo] at this
 
 /-! ## Remainder Bounds
 
@@ -174,7 +182,7 @@ theorem taylor_second_order {f : ℝ → ℝ} {x₀ x : ℝ} (hx : x₀ < x)
       f x - taylorWithinEval f 1 (Icc x₀ x) x₀ x =
         iteratedDerivWithin 2 f (Icc x₀ x) x' * (x - x₀) ^ 2 / 2 := by
   have h := taylor_lagrange (n := 1) hx hf
-  simp only [Nat.factorial_two, Nat.cast_ofNat] at h
+  norm_num [Nat.factorial] at h ⊢
   exact h
 
 /-! ## Existence of Remainder Bound

--- a/proofs/Proofs/TriangleAngleSum.lean
+++ b/proofs/Proofs/TriangleAngleSum.lean
@@ -61,9 +61,9 @@ For any three points p₁, p₂, p₃ in a Euclidean space (with p₂ ≠ p₁ a
   angle(p₁, p₂, p₃) + angle(p₂, p₃, p₁) + angle(p₃, p₁, p₂) = π
 
 This is the fundamental theorem about triangle angles: their sum is always 180°. -/
-theorem triangle_angle_sum {p₁ p₂ p₃ : P} (h₂ : p₂ ≠ p₁) (h₃ : p₃ ≠ p₁) :
+theorem triangle_angle_sum {p₁ p₂ p₃ : P} (h₂ : p₂ ≠ p₁) (_h₃ : p₃ ≠ p₁) :
     ∠ p₁ p₂ p₃ + ∠ p₂ p₃ p₁ + ∠ p₃ p₁ p₂ = Real.pi :=
-  EuclideanGeometry.angle_add_angle_add_angle_eq_pi h₂ h₃
+  EuclideanGeometry.angle_add_angle_add_angle_eq_pi p₃ h₂
 
 /-! ## Non-Degenerate Triangle Version
 

--- a/proofs/Proofs/TriangularReciprocalsFigurate.lean
+++ b/proofs/Proofs/TriangularReciprocalsFigurate.lean
@@ -85,17 +85,25 @@ by comparison with 1/n² (the convergent p-series for p = 2 > 1). -/
 /-- Triangular numbers grow at least as fast as n. -/
 theorem triangular_ge_n (n : ℕ) : triangular n ≥ n := by
   unfold triangular
-  omega
+  rw [ge_iff_le, Nat.le_div_iff_mul_le (by norm_num)]
+  rcases Nat.eq_zero_or_pos n with h | h
+  · simp [h]
+  · exact Nat.mul_le_mul_left n (by omega)
 
 /-- Hexagonal numbers are also triangular numbers (every hexagonal number is triangular).
     Specifically, hexagonal n = triangular (2n - 1). -/
 theorem hexagonal_eq_triangular (n : ℕ) (hn : n ≥ 1) :
     hexagonal n = triangular (2 * n - 1) := by
   unfold hexagonal triangular
-  omega
+  obtain ⟨m, rfl⟩ : ∃ m, n = m + 1 := ⟨n - 1, by omega⟩
+  have h1 : 2 * (m + 1) - 1 = 2 * m + 1 := by omega
+  rw [h1]
+  have h2 : (2 * m + 1) * (2 * m + 1 + 1) = ((m + 1) * (2 * m + 1)) * 2 := by ring
+  rw [h2, Nat.mul_div_cancel _ (by norm_num)]
 
 /-- For n ≥ 1, n(n+1) > 0 (denominator of 1/T_n is positive). -/
-theorem n_succ_mul_pos (n : ℕ) (hn : n ≥ 1) : n * (n + 1) > 0 := by omega
+theorem n_succ_mul_pos (n : ℕ) (hn : n ≥ 1) : n * (n + 1) > 0 :=
+  Nat.mul_pos (by omega) (by omega)
 
 /-- Square reciprocals converge (p-series with p=2 > 1). This implies
     k-gonal reciprocal sums converge for k ≥ 3 by comparison. -/
@@ -103,9 +111,9 @@ theorem square_reciprocals_summable :
     Summable (fun n : ℕ => (1 : ℝ) / (n : ℝ) ^ 2) := by
   have : Summable (fun n : ℕ => ((n : ℝ) ^ (2 : ℝ))⁻¹) := by
     rw [show (fun n : ℕ => ((n : ℝ) ^ (2 : ℝ))⁻¹) = (fun n : ℕ => (n : ℝ) ^ (-2 : ℝ)) by
-      ext n; rw [rpow_neg (Nat.cast_nonneg n)]]
+      ext n; rw [Real.rpow_neg (Nat.cast_nonneg n)]]
     exact Real.summable_nat_rpow.mpr (by norm_num)
   convert this using 1
-  ext n; simp [one_div, sq, rpow_natCast]
+  ext n; simp [one_div, sq, Real.rpow_natCast]
 
 end FigurateReciprocals

--- a/proofs/Proofs/VietasFormulasOQ03OQ01.lean
+++ b/proofs/Proofs/VietasFormulasOQ03OQ01.lean
@@ -60,6 +60,16 @@ theorem aeval_esymm_eq (k : ℕ) (x : Fin n → R) :
     MvPolynomial.aeval x (MvPolynomial.esymm (Fin n) R k) = elemSymm k x := by
   simp only [MvPolynomial.esymm, elemSymm, map_sum, map_prod, MvPolynomial.aeval_X]
 
+/-- `eval`-form bridge for the power sum (simp normalizes `aeval` to `eval` here). -/
+theorem eval_psum_eq (k : ℕ) (x : Fin n → R) :
+    MvPolynomial.eval x (MvPolynomial.psum (Fin n) R k) = powerSum k x := by
+  rw [← MvPolynomial.aeval_eq_eval, aeval_psum_eq]
+
+/-- `eval`-form bridge for the elementary symmetric polynomial. -/
+theorem eval_esymm_eq (k : ℕ) (x : Fin n → R) :
+    MvPolynomial.eval x (MvPolynomial.esymm (Fin n) R k) = elemSymm k x := by
+  rw [← MvPolynomial.aeval_eq_eval, aeval_esymm_eq]
+
 /-
 ## General Newton's Identities
 -/
@@ -79,7 +89,7 @@ theorem newton_identity (k : ℕ) (x : Fin n → R) :
   calc (k : R) * elemSymm k x
       = MvPolynomial.aeval x
           ((k : MvPolynomial (Fin n) R) * MvPolynomial.esymm (Fin n) R k) := by
-        simp [aeval_esymm_eq]
+        rw [map_mul, aeval_esymm_eq, map_natCast]
     _ = MvPolynomial.aeval x ((-1) ^ (k + 1) *
           ∑ a ∈ (Finset.antidiagonal k).filter (fun a => a.1 < k),
             (-1) ^ a.1 * MvPolynomial.esymm (Fin n) R a.1 *
@@ -87,7 +97,7 @@ theorem newton_identity (k : ℕ) (x : Fin n → R) :
         rw [hmv]
     _ = (-1) ^ (k + 1) * ∑ a ∈ (Finset.antidiagonal k).filter (fun a => a.1 < k),
           (-1) ^ a.1 * elemSymm a.1 x * powerSum a.2 x := by
-        simp [aeval_esymm_eq, aeval_psum_eq]
+        simp [aeval_esymm_eq, aeval_psum_eq, eval_esymm_eq, eval_psum_eq]
 
 /-- **Newton's identity (power sum form)** for Fin n → R, k ≥ 1.
 
@@ -108,7 +118,7 @@ theorem newton_identity_psum (k : ℕ) (hk : 0 < k) (x : Fin n → R) :
             (-1) ^ a.1 * MvPolynomial.esymm (Fin n) R a.1 *
             MvPolynomial.psum (Fin n) R a.2) := by
         rw [hmv]
-    _ = _ := by simp [aeval_esymm_eq, aeval_psum_eq]
+    _ = _ := by simp [aeval_esymm_eq, aeval_psum_eq, eval_esymm_eq, eval_psum_eq]
 
 /-
 ## Basic Properties

--- a/proofs/Proofs/WaringGgLowerBoundsOQ02.lean
+++ b/proofs/Proofs/WaringGgLowerBoundsOQ02.lean
@@ -65,8 +65,10 @@ theorem isSumOfKthPowers_mono {s t k n : ℕ} (hk : k ≠ 0) (hst : s ≤ t)
   induction d with
   | zero => simpa using h
   | succ d ih =>
-      have hstep : IsSumOfKthPowers (s + d) k n := ih
-      simpa [Nat.add_succ] using isSumOfKthPowers_succ hk hstep
+      have hstep : IsSumOfKthPowers (s + d) k n := ih (Nat.le_add_right s d)
+      have := isSumOfKthPowers_succ hk hstep
+      rw [Nat.add_succ]
+      exact this
 
 /-- Congruence transport: `a ≡ b (mod n)` gives equal images in `ZMod n`. -/
 theorem natCast_zmod_of_modEq {a b n : ℕ} (h : a ≡ b [MOD n]) :
@@ -76,10 +78,10 @@ theorem natCast_zmod_of_modEq {a b n : ℕ} (h : a ≡ b [MOD n]) :
 /-! ### `G(3) ≥ 4` via cubes modulo `9` -/
 
 /-- Every cube is `≡ 0, 1` or `8 (mod 9)` (i.e. `0` or `±1`). -/
-theorem cube_zmod9 (x : ZMod 9) : x ^ 3 = 0 ∨ x ^ 3 = 1 ∨ x ^ 3 = 8 := by decide
+theorem cube_zmod9 (x : ZMod 9) : x ^ 3 = 0 ∨ x ^ 3 = 1 ∨ x ^ 3 = 8 := by decide +revert
 
 /-- A sum of three cubes is never `≡ 4 (mod 9)`. -/
-theorem three_cubes_ne_four (a b c : ZMod 9) : a ^ 3 + b ^ 3 + c ^ 3 ≠ 4 := by decide
+theorem three_cubes_ne_four (a b c : ZMod 9) : a ^ 3 + b ^ 3 + c ^ 3 ≠ 4 := by decide +revert
 
 /-- Bridge to `ℕ`: any `n ≡ 4 (mod 9)` is not a sum of three cubes. -/
 theorem not_sum_three_cubes_of_mod9 {n : ℕ} (hn : (n : ZMod 9) = 4) :
@@ -121,7 +123,7 @@ which never reaches `15`.  Since `15 (mod 16)` is an infinite residue class, no
 bound `s ≤ 14` is universal, i.e. `G(4) ≥ 15`. -/
 
 /-- Every fourth power is `≡ 0` or `1 (mod 16)`. -/
-theorem fourth_pow_zmod16 (x : ZMod 16) : x ^ 4 = 0 ∨ x ^ 4 = 1 := by decide
+theorem fourth_pow_zmod16 (x : ZMod 16) : x ^ 4 = 0 ∨ x ^ 4 = 1 := by decide +revert
 
 /-- The fourth power of a natural number reduces mod `16` to its parity:
     `a ^ 4 % 16 = a % 2` (`0` for even `a`, `1` for odd `a`). -/

--- a/proofs/batch2/STATUS.md
+++ b/proofs/batch2/STATUS.md
@@ -2042,3 +2042,54 @@ Deferred this batch: Erdos794Problem (genuine universe-polymorphism mismatch —
 and `…Conjecture` fix DIFFERENT `Type u` levels, `@h V` rejects `V : Type u₂`; plus `Fin 9 : Type`
 arg + `erdos_794_origina` typo), Erdos814Problem (HSub ℕ ℚ / LT ℚ instance gaps),
 Erdos732Problem (`Fintype (List ℕ)` ill-defined def), Erdos611Problem (sorry in theorem TYPES).
+
+## Increment 38 (Doctor, N-Z basenames + Erdos≥600, tm/pd/rewrite/unknown-const/instance-synth)
+
++10 GREEN, all own-`lake`-verified in dr48 (11g). Files: TriangleAngleSum, TaylorTheorem,
+TaxicabNumberOQ01, VietasFormulasOQ03OQ01, Sqrt2MinpolyOQ01, PicksTheoremOQ01, SumOfKthPowersOQ03,
+WaringGgLowerBoundsOQ02, RamseyHypergraph, TriangularReciprocalsFigurate.
+
+Recipes:
+- 38-1 TriangleAngleSum — `EuclideanGeometry.angle_add_angle_add_angle_eq_pi` now takes explicit
+  `(p₃ : P)` + single hyp `h : p₂ ≠ p₁` (was two hyps `h₂ h₃`). Pass `p₃ h₂`.
+- 38-2 TaylorTheorem — `taylor_mean_remainder_lagrange`/`_cauchy` API drift: now `uIcc`/`uIoo` +
+  `x₀ ≠ x` (was Icc/Ioo + x₀<x); `ContDiffOn.differentiableOn_iteratedDerivWithin` cast is now
+  `WithTop ℕ∞` (was ℕ∞). Bridge with `uIcc_of_le hx.le`, `uIoo_of_lt hx`, `hx.ne`.
+- 38-3 TaxicabNumberOQ01 — `decide` slow whnf-timeout on ∀ m<1729 bounded-Nat: fix with
+  `set_option maxHeartbeats 4000000 in` (stays axiom-free, no native_decide). ★`set_option … in`
+  must go BEFORE the `/-- … -/` docstring, not between it and the theorem (else "unexpected token").
+- 38-4 VietasFormulasOQ03OQ01 — simp now normalizes `MvPolynomial.aeval x` → `eval x` before
+  `aeval`-stated bridge lemmas fire → unsolved goals. Add `eval`-form companions
+  (`rw [← MvPolynomial.aeval_eq_eval, aeval_…]`) to the simp set. Also `map_natCast` for
+  `aeval` of a natCast constant.
+- 38-5 Sqrt2MinpolyOQ01 — `Polynomial.natDegree_eq_one` now `∃ a, a ≠ 0 ∧ ∃ b, C a*X + C b = p`
+  (destructure `⟨a, ha, b, hfab⟩`, hfab RHS `= p` so use `rw [← hfab]`). After `rw [ha1]` need
+  `map_one` to turn `C 1` into `1` before `one_mul`. `algebraMap ℚ ℝ b` folds to `↑b` via
+  `rw [show (algebraMap ℚ ℝ) b = (b:ℝ) from by simp]`. Also `rw [← hk]` direction bug (→ `rw [hk]`).
+- 38-6 PicksTheoremOQ01 — `(|intExpr| : ℚ)` now elaborates the abs IN ℚ (each var cast) rather than
+  casting an ℤ-abs → `rw [h]` (h over ℤ) fails; bridge via `Int.cast_abs` + `push_cast`.
+  STATEMENT REPAIR: `picks_additivity` was false w/o a bound (ℕ truncated subtraction
+  `b₁+b₂-2k-2`); added `hglue : 2*k+2 ≤ b₁+b₂` (the geometric gluing bound). No callers.
+- 38-7 SumOfKthPowersOQ03 — `Finset.sum_Ico_consecutive` function arg `f` is now EXPLICIT; passing
+  `_` leaves `AddCommMonoid ?m` stuck. Supply the lambda `(fun j => 2*j+1)`. Then use
+  `simp only [Finset.range_eq_Ico]` (rewrite ALL, not first) so the RHS range also converts.
+- 38-8 WaringGgLowerBoundsOQ02 — ★`by decide` over a goal with FREE VARIABLES now errors
+  "Expected type must not contain free variables" → use `by decide +revert`. Also `induction d`
+  where a `≤`-hyp was `obtain`-destructured gives `ih` an EXTRA hypothesis (`s ≤ s+d → …`) — apply
+  `ih (Nat.le_add_right s d)`. `simpa [Nat.add_succ]` recursion-loops → `rw [Nat.add_succ]; exact`.
+- 38-9 RamseyHypergraph — ★in a type ascription `have h : !χ T = false`, `!` now parses as `Not`
+  over the equality Prop (→ `!decide(χ T = false) = true`), NOT `Bool.not` over `χ T`. Write
+  `Bool.not (χ T) = false` explicitly. Also `cases hc : χ T with | true =>` substitutes the
+  scrutinee, so goal becomes `true = true` → close with `rfl` not `exact hc`. (Pre-existing S5
+  `sorry` in `ramsey_existence` body is intentional deferral, compiles green.)
+- 38-10 TriangularReciprocalsFigurate — `rpow_neg`/`rpow_natCast` need `Real.` prefix (no longer
+  root-exported). ★`omega` no longer closes goals with nonlinear products (`n*(n+1)/2 ≥ n`,
+  `n*(2n-1) = …/2`, `n*(n+1) > 0`) → use `Nat.le_div_iff_mul_le` + `Nat.mul_le_mul_left k h`
+  (k explicit!) / `Nat.mul_pos` / `Nat.mul_div_cancel`.
+
+Anomaly: WolstenholmeTheoremOQ01 shows 0 errors in combined build but OOMs (exit 137) on its OWN
+`lake build` at 11g — genuinely memory-intensive to compile; could NOT verify PASS under my limits,
+left RESIDUAL (do not flip). Deferred (multi-error/deep): Sylow cluster (SylowTheoremOQ01/OQ02Orbit/
+OQ04/OQ04OQ03 — 9-16 errors each, MulEquiv.ofInjective/MonoidHom.index_ker unknown, index/ker API),
+ProbMethodSecondMomentOQ01 (dup-decl + ext-on-nonequality), WilsonsTheoremOQ01 (dep OQ02Ext broken,
+37 errors), TriangleAngleSumOQ02 (103 errors).

--- a/proofs/batch2/STATUS.md
+++ b/proofs/batch2/STATUS.md
@@ -2093,3 +2093,16 @@ left RESIDUAL (do not flip). Deferred (multi-error/deep): Sylow cluster (SylowTh
 OQ04/OQ04OQ03 — 9-16 errors each, MulEquiv.ofInjective/MonoidHom.index_ker unknown, index/ker API),
 ProbMethodSecondMomentOQ01 (dup-decl + ext-on-nonequality), WilsonsTheoremOQ01 (dep OQ02Ext broken,
 37 errors), TriangleAngleSumOQ02 (103 errors).
+
+### Increment 38 (continued) — 2 more GREEN (+12 total)
+
+- 38-11 PuiseuxTheorem — `HahnSeries.support_add_subset` now takes `(x y : HahnSeries Γ R)` explicit
+  and RETURNS the `⊆` (was: applied to a membership). Change `support_add_subset hq` →
+  `support_add_subset _ _ hq`. (Note: `support_mul_subset_add_support` deprecated → `support_mul_subset`.)
+- 38-12 PicksTheoremOQ01OQ01 — ★with `open scoped Classical` in the file, `decide` now resolves the
+  `Decidable` instance to `Classical.propDecidable` (noncomputable) → "did not reduce to isTrue/isFalse"
+  even for computable props (`.det.natAbs = 1`). Replace `by decide` with `by rfl` (single concrete
+  eq) / `by refine ⟨rfl, rfl, …⟩` (concrete conjunctions). Also: `edge_split_det_add` `ring` needs the
+  divisibility witnesses — `simp [hM1,hM2]` (folds M-divisions to k) THEN `rw [hv21,hv22]; ring` (feeds
+  v2 = v1 + g·k into det T). And modern `omega` closes `((n:ℤ)-1).natAbs = n-1` DIRECTLY — the old
+  `zify [h1]; Int.natAbs_of_nonneg (by omega)` broke (omega saw a metavar).

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -2311,7 +2311,7 @@ PerfectNumbersOQ03	GREEN
 PiTranscendental	GREEN	
 PicardIterationExplicitOQ0102	RESIDUAL	instance-synth
 PicardLindelofOQ01OQ01OQ01	GREEN	
-PicksTheoremOQ01	RESIDUAL	rewrite-drift
+PicksTheoremOQ01	GREEN	
 PicksTheoremOQ01OQ01	RESIDUAL	proof-drift
 PicksTheoremOQ01OQ01OQ01	RESIDUAL	noncomputable
 PicksTheoremOQ01OQ02	RESIDUAL	proof-drift

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -2622,7 +2622,7 @@ TriangleInequalityOQ04	GREEN
 TriangleInequalityOQ06	RESIDUAL	instance-synth
 TriangularNumberReciprocals	GREEN	
 TriangularReciprocalGeneralized	RESIDUAL	instance-synth
-TriangularReciprocalsFigurate	RESIDUAL	unknown-const:rpow_neg
+TriangularReciprocalsFigurate	GREEN	
 TriangularReciprocalsOQ04OQ01	GREEN	
 TwinPrimesSpecialOQ01	GREEN	
 UnitDistanceIndependence	GREEN	

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -2637,7 +2637,7 @@ VandermondeInterpolationOQ01OQ02	GREEN
 VandermondeInterpolationOQ01OQ02OQ01	GREEN	
 VietasFormulasOQ02	GREEN	
 VietasFormulasOQ03OQ01	GREEN	
-WaringGgLowerBoundsOQ02	RESIDUAL	decide-maxrecdepth
+WaringGgLowerBoundsOQ02	GREEN	
 WilsonsTheoremOQ01	RESIDUAL	rewrite-drift
 WilsonsTheoremOQ02	RESIDUAL	rewrite-drift
 WilsonsTheoremOQ02Ext	RESIDUAL	rewrite-drift

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -2356,7 +2356,7 @@ QuadraticReciprocityOQ03	RESIDUAL	instance-synth
 QuadraticReciprocityOQ03OQ01	RESIDUAL	instance-synth
 QuadraticReciprocityOQ03OQ01Exp	RESIDUAL	instance-synth
 RamanujanSumFallacy	GREEN	
-RamseyHypergraph	RESIDUAL	type-mismatch
+RamseyHypergraph	GREEN	
 RamseyR4kExtensions	GREEN	
 RamseyR4kExtensionsOQ03	GREEN	
 RamseyR4kExtensionsOQ03OQ02	GREEN	

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -2510,7 +2510,7 @@ SubsetCountOQ02	GREEN
 SubsetCountOQ02OQ01	GREEN	unknown-const:Finset.disjoint_comm.mp
 SumOfDivisorsOQ01SpecialPrime	GREEN	unknown-const:not_even_iff_odd
 SumOfKthPowers	RESIDUAL	unknown-const:Finset.sum_range_pow
-SumOfKthPowersOQ03	RESIDUAL	instance-synth
+SumOfKthPowersOQ03	GREEN	
 SumOfKthPowersOQ04	RESIDUAL	type-mismatch
 SumOfKthPowersOQ05	GREEN	
 SumOfKthPowersOQ05OQ01	GREEN	

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -2548,7 +2548,7 @@ SzemerediRegularityOQ04Bridge	GREEN
 SzemerediRegularityOQ04Energy	GREEN	
 SzemerediRegularityOQ04Product	GREEN	
 SzemerediRegularityOQ04Witness	GREEN	
-TaxicabNumberOQ01	RESIDUAL	slow-timeout
+TaxicabNumberOQ01	GREEN	
 TaylorSinCosConvergenceOQ02	RESIDUAL	proof-drift
 TaylorSinCosConvergenceOQ03Aristotle	RESIDUAL	unknown-const:div_le_div
 TaylorSinCosConvergenceOQ04	RESIDUAL	unknown-const:taylorPartialSum_at_zero

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -2636,7 +2636,7 @@ UrysohnsLemmaOQ01OQ01OQ02OQ02	GREEN
 VandermondeInterpolationOQ01OQ02	GREEN	
 VandermondeInterpolationOQ01OQ02OQ01	GREEN	
 VietasFormulasOQ02	GREEN	
-VietasFormulasOQ03OQ01	RESIDUAL	proof-drift
+VietasFormulasOQ03OQ01	GREEN	
 WaringGgLowerBoundsOQ02	RESIDUAL	decide-maxrecdepth
 WilsonsTheoremOQ01	RESIDUAL	rewrite-drift
 WilsonsTheoremOQ02	RESIDUAL	rewrite-drift

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -2552,7 +2552,7 @@ TaxicabNumberOQ01	RESIDUAL	slow-timeout
 TaylorSinCosConvergenceOQ02	RESIDUAL	proof-drift
 TaylorSinCosConvergenceOQ03Aristotle	RESIDUAL	unknown-const:div_le_div
 TaylorSinCosConvergenceOQ04	RESIDUAL	unknown-const:taylorPartialSum_at_zero
-TaylorTheorem	RESIDUAL	type-mismatch
+TaylorTheorem	GREEN	
 TaylorTheoremOQ01	RESIDUAL	type-mismatch
 TaylorTheoremOQ02	RESIDUAL	type-mismatch
 TaylorTheoremOQ03	RESIDUAL	type-mismatch

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -2338,7 +2338,7 @@ PtolemysComplexProofOQ02	RESIDUAL	unknown-const:Real.cos_eq_one_iff.mp
 PtolemysTheoremOQ01Incomplete01	RESIDUAL	elab-drift
 PtolemysTheoremOQ01OQ01	GREEN	
 PtolemysTheoremOQ01OQ02	RESIDUAL	unknown-const:spherical_ptolemy
-PuiseuxTheorem	RESIDUAL	type-mismatch
+PuiseuxTheorem	GREEN	
 PuiseuxTheoremOQ02	RESIDUAL	instance-synth
 PuiseuxTheoremOQ03	RESIDUAL	type-mismatch
 PythagoreanTheorem	GREEN	

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -2312,7 +2312,7 @@ PiTranscendental	GREEN
 PicardIterationExplicitOQ0102	RESIDUAL	instance-synth
 PicardLindelofOQ01OQ01OQ01	GREEN	
 PicksTheoremOQ01	GREEN	
-PicksTheoremOQ01OQ01	RESIDUAL	proof-drift
+PicksTheoremOQ01OQ01	GREEN	
 PicksTheoremOQ01OQ01OQ01	RESIDUAL	noncomputable
 PicksTheoremOQ01OQ02	RESIDUAL	proof-drift
 PicksTheoremOQ02	GREEN	

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -2495,7 +2495,7 @@ SpernerTuckerSimplexBoundaryDoorGraph	GREEN
 SpernerTuckerSimplexBoundaryPseudomanifold	GREEN	
 SpernerTuckerSimplexFacetPair	GREEN	
 Sqrt2Irrational	GREEN	
-Sqrt2MinpolyOQ01	RESIDUAL	type-mismatch
+Sqrt2MinpolyOQ01	GREEN	
 Sqrt2MinpolyOQ01OQ02	RESIDUAL	rewrite-drift
 Sqrt2OQ01	RESIDUAL	unknown-const:square_nonneg_general
 Sqrt2PlusSqrt3Irrational	GREEN	

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -2614,7 +2614,7 @@ ThreeSquaresWitnessObstruction	GREEN
 ThreeSubgroupsLemmaOQ0101	GREEN	
 ThreeSubgroupsLemmaOQ01OQ01	GREEN	
 TractatusQuantifiers	GREEN	
-TriangleAngleSum	RESIDUAL	slow-timeout
+TriangleAngleSum	GREEN	
 TriangleAngleSumOQ02	RESIDUAL	type-mismatch
 TriangleInequality	GREEN	
 TriangleInequalityOQ01	RESIDUAL	unknown-const:MeasureTheory.LpAddConst_of_one_le

--- a/research/toolchain-v4.31-rename-map.md
+++ b/research/toolchain-v4.31-rename-map.md
@@ -1414,3 +1414,11 @@ mismatched HasK4's 6-neq/6-adj conjunction → rewrote destructuring.
 
 Statement repair: PicksTheoremOQ01 `picks_additivity` — added `hglue : 2*k+2 ≤ b₁+b₂` (ℕ truncated
 subtraction made the original statement false; geometric gluing bound). No callers.
+
+### §7ab Increment 38 (continued)
+
+| Symptom | Fix | File |
+|---|---|---|
+| `HahnSeries.support_add_subset hq` app-type-mismatch (hq is Prop, expects HahnSeries) | now `(x y)` explicit + returns `⊆`: `support_add_subset _ _ hq` | PuiseuxTheorem |
+| `by decide` "did not reduce to isTrue/isFalse", instance = `Classical.propDecidable`, file has `open scoped Classical` | replace with `rfl` / `refine ⟨rfl,…⟩` on concrete goals (Classical shadows the computable instance) | PicksTheoremOQ01OQ01 |
+| old `zify [h]; Int.natAbs_of_nonneg (by omega)` breaks (omega sees metavar) | modern `omega` closes `((n:ℤ)-1).natAbs = n-1` directly | PicksTheoremOQ01OQ01 |

--- a/research/toolchain-v4.31-rename-map.md
+++ b/research/toolchain-v4.31-rename-map.md
@@ -1394,3 +1394,23 @@ mismatched HasK4's 6-neq/6-adj conjunction → rewrote destructuring.
 | `simpa`/`convert` type-mismatch on a ℕ index expr (`m+j+2` vs `m+(j+1)+1`) + instLE/instPreorder diamond | add `have : m+j+2 = m+(j+1)+1 := by omega`, rw at hyp before simpa | BetaCentralBinomialExplicitRateOQ02 |
 | `Matrix.charpoly_conj_of_isUnit` removed | `Matrix.charpoly_units_conj' hP.unit N` then `rw [hP.unit_spec]` (its `M.val⁻¹` is already the matrix inverse) | CayleyHamiltonMinpolyOQ02OQ03 |
 | `minpoly_conj_of_isUnit` removed (similar-matrix minpoly invariance) | build conjugation AlgEquiv `MulSemiringAction.toAlgEquiv F _ (ConjAct.toConjAct hP.unit⁻¹)`, prove `e A = P⁻¹AP` via `ConjAct.units_smul_def`+`Matrix.coe_units_inv`, then `minpoly.algEquiv_eq` | CayleyHamiltonMinpolyOQ02OQ03 |
+
+## §7ab Doctor increment 38 recipes (tm/pd/rewrite/unknown-const/instance-synth, N–Z + Erdos≥600, #38065, +10 GREEN)
+
+| Symptom | Fix | File |
+|---|---|---|
+| `by decide` errors "Expected type must not contain free variables" | `by decide +revert` (auto-reverts free vars) | WaringGgLowerBoundsOQ02 |
+| `have h : !χ T = false` type-mismatch → expected `!decide(χ T = false) = true` (`!` parsed as `Not` over the eq, not `Bool.not`) | write `Bool.not (χ T) = false` explicitly | RamseyHypergraph |
+| `cases hc : χ T with \| true =>` leaves goal `true = true`, `exact hc` fails | close with `rfl` (scrutinee substituted) | RamseyHypergraph |
+| `omega` can't close nonlinear-product Nat goals (`n*(n+1)/2 ≥ n`, `n*(n+1) > 0`) — was OK in v4.26 | `Nat.le_div_iff_mul_le` + `Nat.mul_le_mul_left k h` (k explicit) / `Nat.mul_pos` / `Nat.mul_div_cancel` | TriangularReciprocalsFigurate |
+| `rpow_neg` / `rpow_natCast` unknown identifier | `Real.rpow_neg` / `Real.rpow_natCast` (not root-exported) | TriangularReciprocalsFigurate |
+| `Finset.sum_Ico_consecutive _ …` → `AddCommMonoid ?m` stuck | function arg now explicit; pass the lambda `(fun j => …)` | SumOfKthPowersOQ03 |
+| `EuclideanGeometry.angle_add_angle_add_angle_eq_pi h₂ h₃` arg-mismatch | now `(p₃ : P) (h : p₂ ≠ p₁)`: pass `p₃ h₂` | TriangleAngleSum |
+| `taylor_mean_remainder_lagrange`/`_cauchy` type-mismatch (ℕ∞ vs WithTop ℕ∞; Icc vs uIcc; < vs ≠) | now `uIcc`/`uIoo` + `x₀ ≠ x`; `differentiableOn_iteratedDerivWithin` cast is `WithTop ℕ∞`; bridge `uIcc_of_le hx.le`/`uIoo_of_lt hx`/`hx.ne` | TaylorTheorem |
+| `Polynomial.natDegree_eq_one` destructure `⟨a,b,ha,hfab⟩` fails | now `∃ a, a≠0 ∧ ∃ b, C a*X+C b = p` → `⟨a,ha,b,hfab⟩`; hfab RHS is `= p` (use `rw [← hfab]`); after `rw [ha1]` add `map_one` before `one_mul` | Sqrt2MinpolyOQ01 |
+| `simp [aeval_esymm_eq]` unsolved — simp normalizes `MvPolynomial.aeval x`→`eval x` first | add `eval`-form bridge lemmas (`rw [← MvPolynomial.aeval_eq_eval, aeval_…]`) to simp set; `map_natCast` for aeval of natCast | VietasFormulasOQ03OQ01 |
+| `(\|intExpr\| : ℚ)` — abs now elaborates IN ℚ (each var cast), `rw [h]` (h over ℤ) fails | bridge via `Int.cast_abs` + `push_cast` | PicksTheoremOQ01 |
+| `decide` slow whnf-timeout on bounded-Nat ∀ | `set_option maxHeartbeats 4000000 in` (axiom-free; must precede the docstring) | TaxicabNumberOQ01 |
+
+Statement repair: PicksTheoremOQ01 `picks_additivity` — added `hglue : 2*k+2 ≤ b₁+b₂` (ℕ truncated
+subtraction made the original statement false; geometric gluing bound). No callers.


### PR DESCRIPTION
## Doctor increment 38 — v4.26→v4.31 migration (epic #37508, issue #38065)

Partition: **N–Z basenames + Erdos≥600**. Classes: type-mismatch, proof-drift, rewrite-drift, unknown-const, instance-synth. Every file verified by its **own** `lake build` exit 0 in container `dr48` (11g) before flipping the ledger row. Ledger 1832 → **1844 GREEN (+12)**.

### Files greened
| File | Recipe |
|---|---|
| TriangleAngleSum | `angle_add_angle_add_angle_eq_pi` now `(p₃) (h:p₂≠p₁)` |
| TaylorTheorem | `taylor_mean_remainder_*` → `uIcc`/`uIoo` + `x₀≠x`; cast `WithTop ℕ∞` |
| TaxicabNumberOQ01 | `decide` slow-timeout → `maxHeartbeats 4M` (axiom-free) |
| VietasFormulasOQ03OQ01 | simp normalizes `aeval`→`eval`; add `eval`-form bridges |
| Sqrt2MinpolyOQ01 | `natDegree_eq_one` destructure `⟨a,ha,b,hfab⟩`, hfab reversed |
| PicksTheoremOQ01 | `(\|intExpr\|:ℚ)` abs elaborates in ℚ; **statement repair** (hglue) |
| SumOfKthPowersOQ03 | `sum_Ico_consecutive` fn arg now explicit |
| WaringGgLowerBoundsOQ02 | `decide +revert` for free-var goals; induction ih extra hyp |
| RamseyHypergraph | `!χ T = false` parses `!` as `Not`; use `Bool.not`; `cases`→`rfl` |
| TriangularReciprocalsFigurate | `Real.rpow_neg/natCast`; omega no longer does nonlinear |
| PuiseuxTheorem | `HahnSeries.support_add_subset` args now explicit |
| PicksTheoremOQ01OQ01 | `open scoped Classical` shadows `decide` → `rfl` |

### Statement repairs
- **PicksTheoremOQ01** `picks_additivity`: added hypothesis `hglue : 2*k+2 ≤ b₁+b₂` — the original was false because ℕ truncated subtraction `b₁+b₂-2k-2` doesn't match the true integer boundary count without it (geometric gluing bound). No callers affected.

### Notable new recipes (see rename-map §7ab)
- `by decide` over a goal with **free variables** now errors "Expected type must not contain free variables" → `by decide +revert`.
- With `open scoped Classical` in scope, `decide` resolves to `Classical.propDecidable` (noncomputable) and fails even on computable props → use `rfl`/`refine ⟨rfl,…⟩`.
- In a type ascription, `!χ T = false` parses `!` as `Not` over the equality → write `Bool.not (χ T) = false`.
- `omega` no longer closes nonlinear-product Nat goals (`n*(n+1)/2 ≥ n`).

### Anomaly
- **WolstenholmeTheoremOQ01** shows 0 errors in a combined build but **OOMs (exit 137)** on its own `lake build` at 11g — genuinely memory-intensive; could not verify PASS, left RESIDUAL.

Sylow cluster remains mostly open (9–16 errors each: `MulEquiv.ofInjective`/`MonoidHom.index_ker` unknown, index/ker API drift) — deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)