### PR TITLE
migrate(v4.31): Doctor increment 44 — tm/pd/rewrite (N-Z deep-cluster) (+4 GREEN)

### DIFF
--- a/proofs/Proofs/Erdos1045Problem.lean
+++ b/proofs/Proofs/Erdos1045Problem.lean
@@ -79,7 +79,7 @@ axiom cambie_even_not_optimal (n : ℕ) (hn : n ≥ 4) (heven : Even n) :
 
 /-- The maximum Δ over all valid configurations -/
 noncomputable def MaxDelta (n : ℕ) : ℝ :=
-  sSup { Delta z | z : Configuration n ∧ DiameterAtMost2 z }
+  sSup { x : ℝ | ∃ z : Configuration n, DiameterAtMost2 z ∧ Delta z = x }
 
 /-- Cambie-Dong-Tang: C ≈ 1.269 for all even n -/
 axiom cambie_dong_tang_even :
@@ -90,7 +90,7 @@ axiom cambie_dong_tang_even :
 
 /-- Conjecture: Regular polygon is optimal for odd n (OPEN) -/
 def RegularPolygonOptimalOdd : Prop :=
-  ∀ n : ℕ, n ≥ 3 → Odd n → ∀ z : Configuration n, DiameterAtMost2 z →
+  ∀ n : ℕ, (hn3 : n ≥ 3) → Odd n → ∀ z : Configuration n, DiameterAtMost2 z →
     Delta z ≤ Delta (RegularPolygon n (by omega))
 
 /- ## Part VIII: Summary -/
@@ -104,7 +104,7 @@ For odd n, the regular polygon may still be optimal (open).
 -/
 theorem erdos_1045_summary :
     -- For even n: regular polygon is NOT optimal
-    (∀ n : ℕ, n ≥ 4 → Even n →
+    (∀ n : ℕ, (hn4 : n ≥ 4) → Even n →
       ∃ z : Configuration n, DiameterAtMost2 z ∧
         Delta z > Delta (RegularPolygon n (by omega))) ∧
     -- Lower bound: max Δ / n^n ≥ 1.269 for even n

--- a/proofs/Proofs/Erdos1055Problem.lean
+++ b/proofs/Proofs/Erdos1055Problem.lean
@@ -154,21 +154,21 @@ theorem class_of_factor_lt (p q : ℕ) (hp : Nat.Prime p) (hq : Nat.Prime q)
     exact ⟨hq_in_pfl, by simp [hq2, hq3]⟩
   -- Unfold primeClass p to expose the 1 + foldl structure
   show primeClass q < primeClass p
-  unfold primeClass
-  simp only [hp, dite_true]
   -- Show nonSmooth is nonempty
   have h_not_empty : ((p + 1).primeFactorsList.dedup.filter
       (fun r => r != 2 && r != 3)).isEmpty = false := by
     cases hlist : (p + 1).primeFactorsList.dedup.filter (fun r => r != 2 && r != 3) with
     | nil => simp [hlist] at hq_in_ns
     | cons _ _ => rfl
-  simp only [h_not_empty, ite_false]
-  -- The foldl includes a `have` proof term; use `change` (definitional equality)
-  -- to replace with the simpler form that matches our helper lemma
   set ns := (p + 1).primeFactorsList.dedup.filter (fun r => r != 2 && r != 3) with hns
-  change primeClass q < 1 + ns.attach.foldl (fun acc y => max acc (primeClass y.val)) 0
-  have h_bound := foldl_max_ge_of_mem (List.mem_attach ns ⟨q, hns ▸ hq_in_ns⟩)
-    (fun y => primeClass y.val) 0
+  -- Unfold ONLY primeClass p (the RHS) to expose the 1 + foldl structure
+  have hpeq : primeClass p = 1 + ns.attach.foldl (fun acc y => max acc (primeClass y.val)) 0 := by
+    conv_lhs => rw [primeClass]
+    simp only [hp, dite_true, ← hns, h_not_empty, Bool.false_eq_true, if_false]
+    rfl
+  rw [hpeq]
+  have h_bound : ns.attach.foldl (fun acc y => max acc (primeClass y.val)) 0 ≥ primeClass q :=
+    foldl_max_ge_of_mem (List.mem_attach ns ⟨q, hns ▸ hq_in_ns⟩) (fun y => primeClass y.val) 0
   omega
 
 theorem class_one_iff_smooth (p : ℕ) (hp : Nat.Prime p) :

--- a/proofs/Proofs/Erdos726Problem.lean
+++ b/proofs/Proofs/Erdos726Problem.lean
@@ -77,7 +77,6 @@ theorem residue_bound (n p : ℕ) (hp : p > 0) : n % p < p :=
 theorem zero_not_upper_half (p : ℕ) (hp : p ≥ 2) : ¬isUpperHalfResidue 0 p := by
   unfold isUpperHalfResidue
   simp
-  omega
 
 /-- If n % p = 0 (i.e., p | n), then n is not an upper half residue. -/
 theorem dvd_not_upper_half (n p : ℕ) (h : p ∣ n) : ¬isUpperHalfResidue n p := by
@@ -179,10 +178,13 @@ theorem heuristic_half_fraction (p : ℕ) (hp : p.Prime) (hp3 : 3 ≤ p) :
   rw [upper_half_count p hp hp3]
   have hp1 : (p : ℝ) - 1 ≠ 0 := by
     have : (3 : ℝ) ≤ (p : ℝ) := Nat.ofNat_le_cast.mpr hp3; linarith
-  have hodd : ¬ 2 ∣ p := Nat.Prime.not_dvd_of_lt hp (by omega)
+  have hodd : ¬ 2 ∣ p := by
+    have := Nat.odd_iff.mp (hp.odd_of_ne_two (by omega)); omega
   have heven : 2 ∣ (p - 1) := by omega
   rw [Nat.cast_div heven (by norm_num)]
   field_simp
+  push_cast [Nat.cast_sub (show 1 ≤ p by omega)]
+  ring
 
 /-
 ## Sum Partition and Implications
@@ -279,7 +281,7 @@ theorem ratio_converges_to_half :
   -- |u/m − 1/2| = |2u − m|/(2m) < ε/(2m) ≤ ε (since 2m > 1)
   have h2m_pos : (0 : ℝ) < 2 * m := by linarith
   rw [show u / m - 1 / 2 = (2 * u - m) / (2 * m) from by
-    have : m ≠ 0 := ne_of_gt hm_pos; field_simp; ring]
+    have : m ≠ 0 := ne_of_gt hm_pos; field_simp]
   rw [abs_div, abs_of_pos h2m_pos, div_lt_iff₀ h2m_pos]
   calc |2 * u - m| < ε := h_num
     _ ≤ ε * (2 * m) := le_mul_of_one_le_right (le_of_lt hε) (by linarith)
@@ -301,10 +303,13 @@ theorem mertensSum_mono (m n : ℕ) (h : m ≤ n) : mertensSum m ≤ mertensSum 
 /-- For n ≥ 2, the Mertens sum is positive (at least 1/2 from p=2). -/
 theorem mertensSum_pos (n : ℕ) (hn : n ≥ 2) : 0 < mertensSum n := by
   unfold mertensSum primesUpTo
-  apply lt_of_lt_of_le _ (Finset.single_le_sum (fun p _ => by positivity) _)
-  · simp
-  · simp only [Finset.mem_filter, Finset.mem_Icc]
-    exact ⟨⟨le_refl 2, hn⟩, Nat.prime_iff.mpr ⟨by omega, fun d hd => by omega⟩⟩
+  have hmem : (2 : ℕ) ∈ Finset.filter Nat.Prime (Finset.Icc 2 n) := by
+    simp only [Finset.mem_filter, Finset.mem_Icc]
+    exact ⟨⟨le_refl 2, hn⟩, Nat.prime_two⟩
+  have hle := Finset.single_le_sum (f := fun p : ℕ => (1 : ℝ) / p)
+    (fun p _ => one_div_nonneg.mpr (Nat.cast_nonneg _)) hmem
+  have h2 : (0 : ℝ) < (1 : ℝ) / ((2 : ℕ) : ℝ) := by norm_num
+  exact lt_of_lt_of_le h2 hle
 
 /-
 ## Problem Status

--- a/proofs/Proofs/TaylorSinCosConvergenceOQ03Aristotle.lean
+++ b/proofs/Proofs/TaylorSinCosConvergenceOQ03Aristotle.lean
@@ -67,11 +67,11 @@ theorem sinTermAbs_antitone (x : ℝ) (hx : |x| ≤ 1) :
     Antitone (sinTermAbs x) := by
   intro m n hmn
   unfold sinTermAbs
-  apply div_le_div
+  apply div_le_div₀
   · exact pow_nonneg (abs_nonneg x) _
   · exact pow_le_pow_of_le_one (abs_nonneg x) hx (by omega)
   · exact Nat.cast_pos.mpr (Nat.factorial_pos _)
-  · exact Nat.cast_le.mpr (Nat.factorial_mono (by omega))
+  · exact Nat.cast_le.mpr (Nat.factorial_le (by omega))
 
 /-- Sin series terms tend to 0 for any fixed x.
     PROVED in main file via composition with tendsto_pow_div_factorial_atTop. -/
@@ -79,8 +79,7 @@ theorem sinTermAbs_tendsto (x : ℝ) :
     Filter.Tendsto (sinTermAbs x) Filter.atTop (nhds 0) := by
   have hg : Filter.Tendsto (fun n => |x| ^ n / (Nat.factorial n : ℝ))
       Filter.atTop (nhds 0) := by
-    have := Real.tendsto_pow_div_factorial_atTop |x|
-    simp only [Nat.cast_ofNat] at this ⊢
+    have := FloorSemiring.tendsto_pow_div_factorial_atTop |x|
     exact this
   have hf : Filter.Tendsto (fun k => 2 * k + 1) Filter.atTop Filter.atTop :=
     Filter.tendsto_atTop_atTop.mpr fun n => ⟨n, by omega⟩

--- a/proofs/batch2/STATUS.md
+++ b/proofs/batch2/STATUS.md
@@ -2155,3 +2155,45 @@ Deferred (multi-error, >5 genuine fixes): BezoutIdentityOQ01OQ02OQ02Transitive (
 natAdd API churn + headBlockNSL SpecialLinearGroup→Matrix .val coercion), CauchySchwarzOQ01OQ02
 (inner needs `inner 𝕜` annots at 8+ sites + `residual_orthogonal`/`gs_pythagoras` unknown-ident
 forward-refs), Erdos106OQ02/Erdos109OQ01/Erdos140Problem/Erdos171Problem (8-36 errors each).
+
+## Increment 44 (Doctor, N-Z + Erdos≥600, deep-cluster tail) — +4 GREEN
+
+- 44-1 Erdos1045Problem — set-builder `{ Delta z | z : Configuration n ∧ DiameterAtMost2 z }` no
+  longer parses (binder can't carry a `∧` predicate) → `{ x : ℝ | ∃ z, DiameterAtMost2 z ∧ Delta z = x }`.
+  ★Term-mode `by omega` proving `n > 0` inside a `∀ n, n ≥ 3 → …` Prop reports "No usable
+  constraints" — the preceding ANONYMOUS `n ≥ 3` binder isn't visible; NAME it (`(hn3 : n ≥ 3)`).
+- 44-2 TaylorSinCosConvergenceOQ03Aristotle — `div_le_div (0≤c)(a≤c)(0<d)(d≤b)` → `div_le_div₀`
+  (identical 4-arg signature). `Real.tendsto_pow_div_factorial_atTop` →
+  `FloorSemiring.tendsto_pow_div_factorial_atTop`. `Nat.factorial_mono` → `Nat.factorial_le`.
+  (sorries in theorem bodies compile green.)
+- 44-3 Erdos726Problem — `Nat.Prime.not_dvd_of_lt` gone; `¬ 2 ∣ p` (p prime ≥3) via
+  `Nat.odd_iff.mp (hp.odd_of_ne_two (by omega)); omega`. `↑(p-1)` needs
+  `push_cast [Nat.cast_sub (show 1 ≤ p …)]` then `ring`. `Finset.single_le_sum` now needs explicit
+  `(f := fun p : ℕ => …)` AND the nonneg lambda types `p:ℕ` (use `one_div_nonneg.mpr (Nat.cast_nonneg _)`).
+  ★When `simp`/`field_simp` self-closes, trailing `omega`/`ring`/`ring_nf` error "No goals" → delete.
+- 44-4 Erdos1055Problem (was KNOWN-HARD skip, actually 1 error) — a `change primeClass q < 1 + …`
+  failed def-eq because a global `unfold primeClass` had expanded `primeClass q` too, and the def's
+  foldl closure carries a `have : q<p` proof term. FIX: don't unfold globally; prove
+  `hpeq : primeClass p = 1 + ns.attach.foldl … := by conv_lhs => rw [primeClass]; simp only […]; rfl`
+  then `rw [hpeq]`. `if (…).isEmpty = false substituted → if false = true` reduces via
+  `simp only [h_not_empty, Bool.false_eq_true, if_false]`. Annotate `foldl_max_ge_of_mem` result as
+  `≥ primeClass q` (def-eq collapses `↑⟨q,_⟩.val` to `q`) so omega sees a shared atom.
+
+FALSE-STATEMENT / PRE-EXISTING-BROKEN residuals (reverted, NOT weakened — flagged for math repair):
+- Erdos1123Problem — the density-quotient `Setoid` transitivity is mathematically FALSE as stated
+  (`hasDensityZero` uses `card < ε*n`; not closed under `A ∆ C ⊆ (A∆B)∪(B∆C)` doubling). Only ever
+  "compiled" via a fake `intro _ _; trivial` that a pre-4.31 `simp` accepted. Needs a corrected
+  density definition, not a migration fix.
+- Erdos1112Problem — the `B 0 < 5` branch of `r2_23_equals_2` claims `A n = 2n+1` (even sumset)
+  avoids an ARBITRARY lacunary B — false. Old `simp_all` masked it.
+- Erdos1125Problem — `kemperman_equiv` is FALSE: `satisfiesKempermanAlt` has a sign typo
+  (`f x - f(x+h) ≤ f(x+h) - f(x+2h)` ⇒ `a+c ≤ 2b`) that is NOT equivalent to Kemperman
+  (`2a ≤ b+c`). The CORRECT rearrangement is in `kemperman_interpretation` (L116). Repairable by
+  fixing the Alt def to `f x - f(x+h) ≤ f(x+2h) - f x`, but that is a math-content change — deferred.
+- Erdos724Problem — `def latinSquare3_M` has an EMPTY body (blank line then a comment) = pre-existing
+  incomplete def, plus `1/14.8 : ℝ` supplied where `ℕ∞` expected. Not a migration issue.
+
+HONEST N-Z tail assessment (inc 44): confirms inc43 — easy 1-2-error N-Z files are exhausted.
+Of ~30 residuals sampled, only ~1 in 6 is catalog-fixable; the rest are ≥5-error mixed clusters,
+genuine deep-rework, or (notably) files whose ORIGINAL statements are unsound/incomplete and merely
+compiled by luck pre-4.31. Remaining N-Z GREEN yield is low and increasingly requires math judgment.

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -1625,7 +1625,7 @@ Erdos722Problem	GREEN
 Erdos723Problem	GREEN	
 Erdos724Problem	RESIDUAL	parse-error
 Erdos725Problem	GREEN	
-Erdos726Problem	RESIDUAL	unknown-const:Nat.Prime.not_dvd_of_lt
+Erdos726Problem	GREEN	
 Erdos727Problem	GREEN	
 Erdos728Problem	GREEN	proof-drift
 Erdos72Aristotle	GREEN	

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -721,7 +721,7 @@ Erdos1041Problem	GREEN
 Erdos1042Problem	GREEN	
 Erdos1043Aristotle	GREEN	
 Erdos1044Problem	GREEN	
-Erdos1045Problem	RESIDUAL	unknown-const:z
+Erdos1045Problem	GREEN	
 Erdos1046Problem	GREEN	
 Erdos1048Aristotle	RESIDUAL	unknown-const:Complex.continuous_abs.comp
 Erdos1048Problem	GREEN	

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -2550,7 +2550,7 @@ SzemerediRegularityOQ04Product	GREEN
 SzemerediRegularityOQ04Witness	GREEN	
 TaxicabNumberOQ01	GREEN	
 TaylorSinCosConvergenceOQ02	RESIDUAL	proof-drift
-TaylorSinCosConvergenceOQ03Aristotle	RESIDUAL	unknown-const:div_le_div
+TaylorSinCosConvergenceOQ03Aristotle	GREEN	
 TaylorSinCosConvergenceOQ04	RESIDUAL	unknown-const:taylorPartialSum_at_zero
 TaylorTheorem	GREEN	
 TaylorTheoremOQ01	RESIDUAL	type-mismatch

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -741,7 +741,7 @@ Erdos1054ConstructionD	RESIDUAL	unknown-const:p
 Erdos1054OQ01	RESIDUAL	unknown-const:p
 Erdos1054OQ02	PRE-EXISTING	never-compiled:q
 Erdos1054Problem	GREEN	
-Erdos1055Problem	RESIDUAL	elab-drift
+Erdos1055Problem	GREEN	
 Erdos1056Aristotle	GREEN	
 Erdos1056Problem	RESIDUAL	instance-synth
 Erdos1057Problem	GREEN	


### PR DESCRIPTION
Doctor increment 44 of the Lean v4.26→v4.31 migration (epic #37508, issue #38065). Partition: N–Z basenames + Erdos≥600, deep-cluster tail phase.

## Files flipped RESIDUAL → GREEN (+4)

| File | Fixes |
|------|-------|
| `Erdos1045Problem` | set-builder `{Delta z \| z : T ∧ P z}` → `{x \| ∃ z, P z ∧ Delta z = x}`; named `∀`-binders (`hn3`/`hn4`) so term-mode `by omega` sees `n ≥ 3`/`n ≥ 4` |
| `TaylorSinCosConvergenceOQ03Aristotle` | `div_le_div` → `div_le_div₀`; `Real.tendsto_pow_div_factorial_atTop` → `FloorSemiring.tendsto_pow_div_factorial_atTop`; `Nat.factorial_mono` → `Nat.factorial_le` |
| `Erdos726Problem` | `Nat.Prime.not_dvd_of_lt` → `Prime.odd_of_ne_two` + `Nat.odd_iff` + omega; `Nat.cast_sub` push_cast for `↑(p-1)`; `single_le_sum` needs explicit `(f := …)` + `one_div_nonneg`; removed omega-after-simp (No goals); field_simp self-closes |
| `Erdos1055Problem` | replaced def-eq-failing `change` with an `hpeq` rewrite of `primeClass p`; `if false = true` → `Bool.false_eq_true, if_false`; annotated `foldl_max_ge_of_mem` result to `≥ primeClass q` for omega |

`Erdos1055` was on the KNOWN-HARD skip list but turned out to be a single `change`→`rw` fix.

## Recipes added
- Set-builder `{ f z | z : T ∧ P z }` no longer parses; rewrite to `{ x | ∃ z, P z ∧ f z = x }`.
- Term-mode `by omega` inside a `∀`-quantified Prop loses access to a preceding anonymous `n ≥ k` binder → give the binder a name.
- `div_le_div (0≤c)(a≤c)(0<d)(d≤b)` → `div_le_div₀` (identical signature).
- `Real.tendsto_pow_div_factorial_atTop` → `FloorSemiring.tendsto_pow_div_factorial_atTop`; `Nat.factorial_mono` → `Nat.factorial_le`.
- `Nat.Prime.not_dvd_of_lt` gone; for `¬ 2 ∣ p` (p prime ≥3) use `Nat.odd_iff.mp (hp.odd_of_ne_two _)` + omega.
- `Finset.single_le_sum` now often needs `(f := …)` explicit or the element is inferred as `sorry`.
- When `simp`/`field_simp` self-closes, trailing `omega`/`ring` errors "No goals to be solved" → delete them.

## Statement repairs
None (Erdos1045 binder-naming is logically identical). Reverted `Erdos1123Problem` (unsound density setoid transitivity — mathematically false as stated, only ever compiled via a fake `trivial`) and `Erdos1112Problem` (the `B 0 < 5` branch claims `A n = 2n+1` avoids an arbitrary lacunary set — false).

## Honest residual assessment (N-Z tail)
Confirms increment 43's finding: the easy 1–2-error N-Z files are exhausted. Sampled ~30 residuals; the overwhelming majority are ≥5-error mixed clusters, and several "low error" files hide **unsound original statements** (Erdos1123, 1112) or **incomplete `def`s** (Erdos724 has an empty `latinSquare3_M` body) that predate the migration. Genuinely fixable-by-catalog files are now rare (~1 in 6 sampled); most remaining work is deep-rework or math-gap repair, not rename application.

🤖 Generated with [Claude Code](https://claude.com/claude-code)