### PR TITLE
migrate(v4.31): Doctor increment 45 — tm/pd/rewrite (A-M deep-cluster) (+7 GREEN)

### DIFF
--- a/proofs/Proofs/BinomialTheoremOQ01.lean
+++ b/proofs/Proofs/BinomialTheoremOQ01.lean
@@ -25,6 +25,7 @@
 import Mathlib
 
 open Real Finset
+open scoped ENNReal
 
 /-- The generalized binomial coefficient: C(alpha, k) = alpha*(alpha-1)*...*(alpha-k+1)/k!
     For natural n, this agrees with Nat.choose n k. -/
@@ -151,15 +152,15 @@ theorem genBinom_ode_coeff (α : ℝ) (k : ℕ) :
     This connects Pochhammer theory (used in Ring.choose) to the product formula
     used in genBinom. Key: use aeval_eq_smeval to access richer aeval API. -/
 private lemma smeval_descPochhammer_int_eq_prod (n : ℕ) (α : ℝ) :
-    (Polynomial.descPochhammer ℤ n).smeval α =
+    (descPochhammer ℤ n).smeval α =
     ∏ j ∈ Finset.range n, (α - (j : ℝ)) := by
   induction n with
   | zero => simp
   | succ n ih =>
-    rw [← Polynomial.aeval_eq_smeval, Polynomial.descPochhammer_succ_right,
+    rw [← Polynomial.aeval_eq_smeval] at ih
+    rw [← Polynomial.aeval_eq_smeval, descPochhammer_succ_right,
         map_mul, map_sub, Polynomial.aeval_X, map_natCast,
-        ← Polynomial.aeval_eq_smeval, ih, Finset.prod_range_succ]
-    push_cast; ring
+        ih, Finset.prod_range_succ]
 
 /-- Auxiliary: Ring.choose α k = genBinom α k.
     Both equal the falling factorial α*(α-1)*...*(α-k+1) divided by k!
@@ -184,11 +185,10 @@ private lemma ring_choose_eq_genBinom (α : ℝ) (k : ℕ) :
 theorem newton_generalized_binomial (α x : ℝ) (hx : ‖x‖ < 1) :
     HasSum (fun k => genBinom α k * x ^ k) ((1 + x) ^ α) := by
   -- Step 1: Place x in the extended metric unit ball
-  have hball : x ∈ EMetric.ball (0 : ℝ) 1 := by
-    rw [EMetric.mem_ball, edist_zero_right]
-    rw [show (1 : ℝ≥0∞) = ((1 : NNReal) : ℝ≥0∞) from ENNReal.coe_one.symm,
-        ENNReal.coe_lt_coe]
-    exact_mod_cast hx
+  have hball : x ∈ Metric.eball (0 : ℝ) 1 := by
+    rw [Metric.mem_eball, edist_zero_right]
+    simpa [enorm_eq_nnnorm, ← ENNReal.coe_one, ENNReal.coe_lt_coe,
+           ← NNReal.coe_lt_coe] using hx
   -- Step 2: Extract HasSum from HasFPowerSeriesOnBall
   have key : HasFPowerSeriesOnBall (fun y : ℝ => (1 + y) ^ α) (binomialSeries ℝ α) 0 1 :=
     Real.one_add_rpow_hasFPowerSeriesOnBall_zero
@@ -197,11 +197,12 @@ theorem newton_generalized_binomial (α x : ℝ) (hx : ‖x‖ < 1) :
     simp only [zero_add] at this
     exact this
   -- Step 3: Rewrite binomialSeries coefficients as genBinom α k * x^k
-  apply h1.congr
-  intro k
-  simp only [binomialSeries_apply, List.ofFn_const, List.prod_replicate, smul_eq_mul]
-  congr 1
-  exact ring_choose_eq_genBinom α k
+  have hfun : (fun n => binomialSeries ℝ α n (fun _ => x)) =
+      (fun k => genBinom α k * x ^ k) := by
+    funext k
+    simp only [binomialSeries_apply, List.ofFn_const, List.prod_replicate, smul_eq_mul]
+    rw [ring_choose_eq_genBinom]
+  rwa [hfun] at h1
 
 /-- Newton's theorem for the square root: Sum C(1/2, k) x^k = sqrt(1+x). -/
 theorem sqrt_series (x : ℝ) (hx : ‖x‖ < 1) :

--- a/proofs/Proofs/BoundedPrimeGapsOQ04.lean
+++ b/proofs/Proofs/BoundedPrimeGapsOQ04.lean
@@ -65,19 +65,19 @@ open Nat Finset BoundedPrimeGaps ArithmeticFunction Filter
 -/
 
 /-- The von Mangoldt function Λ(n): equals log p when n = p^k for prime p, else 0. -/
-noncomputable abbrev Λ := ArithmeticFunction.vonMangoldt
+noncomputable abbrev vonM := ArithmeticFunction.vonMangoldt
 
 /-- The Chebyshev ψ function: ψ(x) = Σ_{n ≤ x} Λ(n).
     By the prime number theorem, ψ(x) ~ x. -/
 noncomputable def chebyshevPsi (x : ℕ) : ℝ :=
-  ∑ n ∈ Finset.range (x + 1), (Λ n : ℝ)
+  ∑ n ∈ Finset.range (x + 1), (vonM n : ℝ)
 
 /-- The Chebyshev function restricted to an arithmetic progression:
     ψ(x; q, a) = Σ_{n ≤ x, n ≡ a mod q} Λ(n).
     Counts prime powers in the progression a, a+q, a+2q, ... up to x,
     weighted by log p. -/
 noncomputable def chebyshevPsiAP (x q a : ℕ) : ℝ :=
-  ∑ n ∈ (Finset.range (x + 1)).filter (fun n => n % q = a % q), (Λ n : ℝ)
+  ∑ n ∈ (Finset.range (x + 1)).filter (fun n => n % q = a % q), (vonM n : ℝ)
 
 /-- π(x; q, a) counts primes p ≤ x with p ≡ a mod q. -/
 noncomputable def primeCountAP (x q a : ℕ) : ℕ :=
@@ -94,7 +94,6 @@ noncomputable def expectedMainTerm (x q : ℕ) : ℝ :=
 /-- ψ(0) = 0. -/
 theorem chebyshevPsi_zero : chebyshevPsi 0 = 0 := by
   simp [chebyshevPsi, Finset.sum_range_one]
-  exact ArithmeticFunction.vonMangoldt_apply_one
 
 /-- ψ(x; q, a) is nonneg since Λ(n) ≥ 0 for all n. -/
 theorem chebyshevPsiAP_nonneg (x q a : ℕ) : 0 ≤ chebyshevPsiAP x q a := by
@@ -105,7 +104,7 @@ theorem chebyshevPsiAP_nonneg (x q a : ℕ) : 0 ≤ chebyshevPsiAP x q a := by
 /-- For coprime a,q: the full sum ψ(x) = Σ_{a coprime to q} ψ(x;q,a) + error from non-coprime.
     When q = 1, ψ(x;1,0) = ψ(x). -/
 theorem chebyshevPsiAP_q_one (x : ℕ) : chebyshevPsiAP x 1 0 = chebyshevPsi x := by
-  simp [chebyshevPsiAP, chebyshevPsi]
+  simp [chebyshevPsiAP, chebyshevPsi, Nat.mod_one]
 
 /-- π(x;q,a) counts at most x primes. -/
 theorem primeCountAP_le (x q a : ℕ) : primeCountAP x q a ≤ x + 1 := by
@@ -123,7 +122,7 @@ theorem totient_prime' (p : ℕ) (hp : p.Prime) : Nat.totient p = p - 1 :=
 
 /-- φ(q) > 0 for q ≥ 1. -/
 theorem totient_pos' (q : ℕ) (hq : 0 < q) : 0 < Nat.totient q :=
-  Nat.totient_pos hq
+  Nat.totient_pos.mpr hq
 
 /-
 ## Part II: The Bombieri-Vinogradov Theorem

--- a/proofs/Proofs/BoundedPrimeGapsOQ04OQ02.lean
+++ b/proofs/Proofs/BoundedPrimeGapsOQ04OQ02.lean
@@ -105,9 +105,9 @@ theorem chebyshevPsiAP_le_chebyshevPsi (x q a : ℕ) :
 theorem expectedMainTerm_pos {x q : ℕ} (hx : 0 < x) (hq : 0 < q) :
     0 < expectedMainTerm x q := by
   unfold expectedMainTerm
-  apply div_pos
+  apply _root_.div_pos
   · exact Nat.cast_pos.mpr hx
-  · exact Nat.cast_pos.mpr (Nat.totient_pos hq)
+  · exact Nat.cast_pos.mpr (Nat.totient_pos.mpr hq)
 
 /-- For q = 1, the expected main term equals x (since φ(1) = 1). -/
 theorem expectedMainTerm_q_one (x : ℕ) :
@@ -122,7 +122,7 @@ theorem bv_error_nonneg_terms (x q a : ℕ) :
     0 ≤ chebyshevPsiAP x q a ∧
     0 ≤ expectedMainTerm x q :=
   ⟨chebyshevPsiAP_nonneg x q a,
-   div_nonneg (Nat.cast_nonneg) (Nat.cast_nonneg)⟩
+   div_nonneg (Nat.cast_nonneg _) (Nat.cast_nonneg _)⟩
 
 /-
 ## Part II: The 6 Minimal Additions — Precise Lean 4 Types

--- a/proofs/Proofs/CentralLimitTheoremOQ03OQ01.lean
+++ b/proofs/Proofs/CentralLimitTheoremOQ03OQ01.lean
@@ -74,7 +74,7 @@ theorem isSlowlyVarying_inv {L : ℝ → ℝ} (hL : IsSlowlyVarying L) :
     IsSlowlyVarying (fun x => (L x)⁻¹) := by
   intro t ht
   have : (fun x => (L (t * x))⁻¹ / (L x)⁻¹) = (fun x => L x / L (t * x)) := by
-    ext x; simp [div_eq_mul_inv, inv_inv]
+    ext x; rw [div_eq_mul_inv, inv_inv, div_eq_mul_inv, mul_comm]
   rw [this]
   -- L(x)/L(tx) → 1/1 = 1 since L(tx)/L(x) → 1
   have h := hL t ht
@@ -83,7 +83,6 @@ theorem isSlowlyVarying_inv {L : ℝ → ℝ} (hL : IsSlowlyVarying L) :
   simp [inv_one] at this
   -- Need to show L(x)/L(tx) → 1, which is the reciprocal of L(tx)/L(x) → 1
   convert this using 1
-  ext x; ring
 
 -- ============================================================================
 -- § 2. Regular Variation — Properties
@@ -103,12 +102,13 @@ theorem isRegularlyVarying_zero_iff_slowlyVarying {f : ℝ → ℝ}
   · rintro ⟨L, hL, hev⟩
     intro t ht
     -- f(tx)/f(x) = (tx)^0 · L(tx) / (x^0 · L(x)) = L(tx)/L(x) → 1
+    have htends : Filter.Tendsto (fun x => t * x) Filter.atTop Filter.atTop :=
+      (tendsto_const_mul_atTop_of_pos ht).mpr tendsto_id
     have : ∀ᶠ x in Filter.atTop, f (t * x) / f x = L (t * x) / L x := by
-      filter_upwards [hev, hev.comp_tendsto (tendsto_const_mul_atTop_of_pos ht tendsto_id)]
-        with x hfx hftx
+      filter_upwards [hev, htends.eventually hev] with x hfx hftx
       rw [hfx, hftx]
       simp [rpow_zero]
-    exact (Filter.Tendsto.congr' this.symm (hL t ht))
+    exact (Filter.Tendsto.congr' (Filter.EventuallyEq.symm this) (hL t ht))
   · intro hf
     exact ⟨f, hf, by filter_upwards with x; simp [rpow_zero]⟩
 

--- a/proofs/Proofs/CombinationsFormulaOQ02Aristotle.lean
+++ b/proofs/Proofs/CombinationsFormulaOQ02Aristotle.lean
@@ -44,17 +44,35 @@ theorem centralBinom_ge_two_pow (n : ℕ) (hn : 1 ≤ n) : 2 ^ n ≤ centralBino
       -- = (C(2m,m)+C(2m,m-1)) + (C(2m,m)+C(2m,m+1))... complex
       -- Use C(2(m+1), m+1) ≥ 2*C(2m, m) via the two-step bound
       simp only [centralBinom, show 2 * (m + 1) = 2 * m + 2 from by ring]
-      rw [show m + 1 + 1 = m + 1 + 1 from rfl]  -- tautology, real proof below
       -- C(2m+2, m+1) = C(2m+1,m+1) + C(2m+1,m) by Pascal
       -- C(2m+1, m+1) = C(2m, m+1) + C(2m, m) by Pascal
       -- C(2m+1, m) = C(2m, m-1) + C(2m, m) by Pascal (for m ≥ 1)
       -- So C(2m+2, m+1) = 2*C(2m, m) + C(2m, m+1) + C(2m, m-1) ≥ 2*C(2m, m)
       have h1 : Nat.choose (2*m+2) (m+1) ≥ 2 * Nat.choose (2*m) m := by
-        have := @Nat.choose_succ_succ (2*m+1) m
-        have := @Nat.choose_succ_succ (2*m) m
-        have := @Nat.choose_succ_succ (2*m) (m-1)
+        have e1 : Nat.choose (2*m+2) (m+1) =
+            Nat.choose (2*m+1) m + Nat.choose (2*m+1) (m+1) :=
+          Nat.choose_succ_succ' (2*m+1) m
+        have e2 : Nat.choose (2*m+1) (m+1) =
+            Nat.choose (2*m) m + Nat.choose (2*m) (m+1) :=
+          Nat.choose_succ_succ' (2*m) m
+        have e3 : Nat.choose (2*m+1) (m-1+1) =
+            Nat.choose (2*m) (m-1) + Nat.choose (2*m) (m-1+1) :=
+          Nat.choose_succ_succ' (2*m) (m-1)
+        have hm1 : m - 1 + 1 = m := by omega
+        rw [hm1] at e3
         omega
-      linarith [pow_pos (by norm_num : 0 < 2) m]
+      have hpow : (2 : ℕ) ^ (m + 1) = 2 * 2 ^ m := by rw [pow_succ]; ring
+      have ihm' : 2 ^ m ≤ Nat.choose (2 * m) m := ihm
+      omega
+
+/-- C(2n, n+1) * (n+1) = C(2n, n) * n (divisibility relationship). -/
+theorem choose_2n_succ (n : ℕ) :
+    Nat.choose (2 * n) (n + 1) * (n + 1) = Nat.choose (2 * n) n * n := by
+  -- From Nat.choose_succ_right_eq: C(N, k+1) * (k+1) = (N-k) * C(N, k)
+  -- Apply with N=2n, k=n: C(2n,n+1)*(n+1) = (2n-n)*C(2n,n) = n*C(2n,n)
+  have h := Nat.choose_succ_right_eq (2 * n) n
+  simp only [show 2 * n - n = n from by omega] at h
+  linarith [mul_comm (Nat.choose (2 * n) n) n]
 
 /-- The divisibility fact: (n+1) divides C(2n, n).
     Proof by induction using choose_2n_succ + coprimality. -/
@@ -76,7 +94,9 @@ theorem succ_dvd_centralBinom (n : ℕ) : (n + 1) ∣ centralBinom n := by
       ⟨Nat.choose (2 * m + 2) (m + 2), by linarith⟩
     -- gcd(m+2, m+1)=1 → (m+2) | C(2m+2,m+1)
     have hcop : Nat.Coprime (m + 2) (m + 1) := by
-      rw [Nat.coprime_comm]; exact Nat.coprime_succ_self (m + 1)
+      rw [Nat.coprime_comm, show m + 2 = (m + 1) + 1 from rfl,
+          Nat.coprime_self_add_right]
+      exact Nat.coprime_one_right _
     exact hcop.dvd_of_dvd_mul_right hdvd
 
 /-- **Fundamental Catalan identity**: C_n * (n+1) = C(2n, n).
@@ -93,18 +113,7 @@ theorem catalan_mul_succ (n : ℕ) :
     have h := Nat.choose_succ_right_eq (2 * n) n
     simp only [show 2 * n - n = n from by omega] at h
     linarith [mul_comm (Nat.choose (2 * n) n) n]
-  rw [hcs]
-  have hbound : Nat.choose (2 * n) n * n ≤ Nat.choose (2 * n) n * (n + 1) :=
-    Nat.mul_le_mul_left _ (Nat.le_succ n)
+  rw [hcs, Nat.mul_succ]
   omega
-
-/-- C(2n, n+1) * (n+1) = C(2n, n) * n (divisibility relationship). -/
-theorem choose_2n_succ (n : ℕ) :
-    Nat.choose (2 * n) (n + 1) * (n + 1) = Nat.choose (2 * n) n * n := by
-  -- From Nat.choose_succ_right_eq: C(N, k+1) * (k+1) = (N-k) * C(N, k)
-  -- Apply with N=2n, k=n: C(2n,n+1)*(n+1) = (2n-n)*C(2n,n) = n*C(2n,n)
-  have h := Nat.choose_succ_right_eq (2 * n) n
-  simp only [show 2 * n - n = n from by omega] at h
-  linarith [mul_comm (Nat.choose (2 * n) n) n]
 
 end CatalanNumbers

--- a/proofs/Proofs/DerangementsConvergenceOQ03.lean
+++ b/proofs/Proofs/DerangementsConvergenceOQ03.lean
@@ -39,7 +39,6 @@ private lemma factorial_mul_one_div_factorial_succ (n : ℕ) :
   rw [Nat.factorial_succ]
   push_cast
   field_simp
-  ring
 
 /-- For n ≥ 2, the number of derangements equals the nearest integer to n!/e.
 
@@ -67,13 +66,14 @@ theorem derangements_eq_round (n : ℕ) (hn : 2 ≤ n) :
     have hn3 : (2 : ℝ) < n + 1 := by exact_mod_cast (show 2 < n + 1 by omega)
     have hlt3 : 1 / (n + 1 : ℝ) < 1 / 2 := one_div_lt_one_div_of_lt (by norm_num) hn3
     calc |(numDerangements n : ℝ) - x|
-        ≤ (n.factorial : ℝ) * (1 / ((n + 1).factorial : ℝ)) := hrate
+        ≤ (n.factorial : ℝ) * (1 / ((n + 1).factorial : ℝ)) := by
+            rw [mul_comm]; exact hrate
       _ = 1 / (n + 1 : ℝ) := factorial_mul_one_div_factorial_succ n
       _ < 1 / 2 := hlt3
   -- Step 2: D(n) = ⌊x + 1/2⌋ = round x
   rw [round_eq]
   symm
-  apply floor_eq_iff.mpr
+  apply Int.floor_eq_iff.mpr
   have habs := abs_lt.mp hlt
   -- habs.1 : -(1/2) < D - x, i.e., x - 1/2 < D, i.e., x + 1/2 < D + 1
   -- habs.2 : D - x < 1/2, i.e., D < x + 1/2, i.e., D ≤ x + 1/2

--- a/proofs/batch2/STATUS.md
+++ b/proofs/batch2/STATUS.md
@@ -2189,3 +2189,24 @@ inv_ne_zero/smul_left_cancel₀ + simp drift, 8 errors post-ENNReal-fix), FairGa
 LawsOfLargeNumbersOQ01Aristotle metaprogramming file: `Mathlib.Tactic.GeneralizeProofs` namespace +
 `Expr`/`Function expected` — Aristotle meta file needs its own repair), LawsOfLargeNumbersOQ02
 (mixed type-mismatch/instance-stuck), BinomialTheoremOQ01 (Polynomial.descPochhammer unknown).
+
+## Increment 45 (Doctor-b, A–M / Erdos<600) — +7 GREEN
+
+Recipes catalogued in rename-map §7ad. TAIL phase: worked whole ≥3-error clusters of catalogued renames mixed with genuine proof-drift.
+
+GREEN this increment:
+- **BoundedPrimeGapsOQ04** (4 err): `Λ` reserved-token → rename abbrev to `vonM`; `Nat.totient_pos` Iff; `Nat.mod_one` trivial filter; drop redundant `exact`.
+- **BoundedPrimeGapsOQ04OQ02** (2 err): `_root_.div_pos` disambig; `totient_pos` Iff; `Nat.cast_nonneg _`.
+- **BinomialTheoremOQ01** (7 err): `descPochhammer` out of `Polynomial` ns; `open scoped ENNReal`; `Metric.eball`/`Metric.mem_eball`; `edist_zero_right`→enorm; `HasSum.congr` finset-form → funext+`rwa`.
+- **DerangementsConvergenceOQ03** (4 err): `Int.floor_eq_iff`; `div_le_iff₀` mul-order; drop `ring`.
+- **CombinationsFormulaOQ02Aristotle** (6 err): forward-ref reorder of `choose_2n_succ`; `coprime_self_add_right` for consecutive coprime; `choose_succ_succ'` Pascal omega; `Nat.mul_succ`.
+- **CentralLimitTheoremOQ03OQ01** (7 err): `Filter.Eventually.comp_tendsto` REMOVED → `htends.eventually hev`; `tendsto_const_mul_atTop_of_pos` Iff; `Filter.EventuallyEq.symm` dot-fix; `inv_inv`+`mul_comm`; drop `ring`.
+- **CentralLimitTheoremOQ03OQ01Aristotle**: FREE-GREEN (builds EXIT 0, no edit).
+
+**Statement repairs**: none (all fixes preserved the mathematical statements; no weakening/sorry/axiomatize).
+
+**Reverted (deep-rework, NOT mechanical)**:
+- **AbelRuffiniOQ10** (3 err): `native_decide` on `orderOf` (now noncomputable) — `decide` too deep; needs an `Equiv.Perm.lcm_cycleType` bridge to the already-proven `cycleType`-based counts. Genuine math, not migration.
+- **BertrandsPostulateOQ03OQ04OQ01** (started 6, fixed 4 mechanically): remaining 2 are a broken ℝ↔ℕ bridge — `PrimeGapConjecture` quantifies over `x:ℝ` but `cramer_implies_primeGapConjecture_eventually` is over `x:ℕ` (`hN x` type-mismatch), AND the small-x branch asserts `x^0.525 ≤ x^ε` which is false for `x>1, ε<0.525` (`rpow_le_rpow_of_exponent_ge` now needs `0<x ∧ x≤1`). Needs genuine reconstruction; reverted whole file.
+
+**Honest remaining A–M / Erdos<600 assessment**: 443 residuals at session start; ~7 now GREEN. Easy 1–2-error files exhausted. Sampled ~18 files: the large majority are 10–24-error genuine rewrites (BaselProblemOQ04OQ03=24, BinaryGcdOQ02OQ01=20, CantorDiagonalizationOQ01OQ01=19, DescartesRuleOfSignsOQ02=18, CayleyHamiltonMinpolyOQ02OQ02=18, DesarguesTheoremOQ01OQ01=16, CombinationsFormulaOQ01OQ04=16, BirthdayProblemOQ01OQ01OQ03=16, DescartesRuleOfSignsOQ01OQ02=14, AlgebraicNumbersCountableOQ04=14, ChineseRemainderConstructiveOQ03=18). A thin seam of ~6-error mixed-rename files remains fixable per this increment (CauchySchwarzOQ01OQ01OQ01=8 next candidate). Estimate: <10% of remaining A–M residuals are mechanical-cluster fixable; the rest are deep-rework or OOM.

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -228,7 +228,7 @@ BezoutIdentityOQ04OQ01OQ01	GREEN
 BinaryGcdOQ02	GREEN	
 BinaryGcdOQ02OQ01	RESIDUAL	unknown-const:a
 BinomialTheorem	GREEN	
-BinomialTheoremOQ01	RESIDUAL	unknown-const:Polynomial.descPochhammer
+BinomialTheoremOQ01	GREEN	
 BinomialTheoremOQ02OQ01	RESIDUAL	type-mismatch
 BinomialTheoremOQ02OQ01OQ01OQ02	RESIDUAL	type-mismatch
 BinomialTheoremOQ02OQ01OQ02OQ03	GREEN	

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -426,7 +426,7 @@ CentralLimitTheoremOQ02OQ03	GREEN
 CentralLimitTheoremOQ02OQ04	GREEN	
 CentralLimitTheoremOQ03	GREEN	
 CentralLimitTheoremOQ03OQ01	GREEN	
-CentralLimitTheoremOQ03OQ01Aristotle	RESIDUAL	rewrite-drift
+CentralLimitTheoremOQ03OQ01Aristotle	GREEN	
 CevasTheorem	GREEN	
 CevasTheoremNonEuclidean	GREEN	
 CevasTheoremNonEuclideanOQ01	GREEN	

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -460,7 +460,7 @@ CollatzStructuredOQ02OQ01	GREEN
 CollatzStructuredOQ03	RESIDUAL	instance-synth
 CombinationsFormulaOQ01OQ04	RESIDUAL	type-mismatch
 CombinationsFormulaOQ02	RESIDUAL	proof-drift
-CombinationsFormulaOQ02Aristotle	RESIDUAL	unknown-const:choose_2n_succ
+CombinationsFormulaOQ02Aristotle	GREEN	
 CombinationsFormulaOQ03OQ06	GREEN	
 CombinationsFormulaOQ07OQ04OQ01OQ02	GREEN	
 CombinationsFormulaOQ07OQ04OQ01OQ02OQ01	GREEN	

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -276,7 +276,7 @@ BoundedPrimeGapsOQ03OQ03	GREEN
 BoundedPrimeGapsOQ04	GREEN	
 BoundedPrimeGapsOQ04OQ01	GREEN	
 BoundedPrimeGapsOQ04OQ01Aristotle	RESIDUAL	rewrite-drift
-BoundedPrimeGapsOQ04OQ02	RESIDUAL	lambda-reserved-token
+BoundedPrimeGapsOQ04OQ02	GREEN	
 BrianchonTheorem	GREEN	
 BrianchonTheoremOQ01OQ02	GREEN	
 BrouwerFixedPointOQ01OQ02OQ03OQ01	RESIDUAL	unknown-const:Metric.mem_closedBall_zero_iff.mpr

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -522,7 +522,7 @@ DerangementsConvergenceOQ01	GREEN
 DerangementsConvergenceOQ01OQ01	GREEN	
 DerangementsConvergenceOQ02	GREEN	
 DerangementsConvergenceOQ02OQ01	GREEN	
-DerangementsConvergenceOQ03	RESIDUAL	unknown-const:Nat.floor_eq_iff.mpr
+DerangementsConvergenceOQ03	GREEN	
 DerangementsConvergenceOQ03OQ01	GREEN	
 DerangementsConvergenceOQ03OQ01OQ02	GREEN	
 DerangementsConvergenceOQ03OQ03	GREEN	

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -425,7 +425,7 @@ CentralLimitTheoremOQ02OQ02	RESIDUAL	instance-synth
 CentralLimitTheoremOQ02OQ03	GREEN	
 CentralLimitTheoremOQ02OQ04	GREEN	
 CentralLimitTheoremOQ03	GREEN	
-CentralLimitTheoremOQ03OQ01	RESIDUAL	rewrite-drift
+CentralLimitTheoremOQ03OQ01	GREEN	
 CentralLimitTheoremOQ03OQ01Aristotle	RESIDUAL	rewrite-drift
 CevasTheorem	GREEN	
 CevasTheoremNonEuclidean	GREEN	

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -273,7 +273,7 @@ BoundedPrimeGapsOQ03OQ01OQ01OQ01	GREEN
 BoundedPrimeGapsOQ03OQ01OQ04	GREEN	
 BoundedPrimeGapsOQ03OQ02	GREEN	
 BoundedPrimeGapsOQ03OQ03	GREEN	
-BoundedPrimeGapsOQ04	RESIDUAL	lambda-reserved-token
+BoundedPrimeGapsOQ04	GREEN	
 BoundedPrimeGapsOQ04OQ01	GREEN	
 BoundedPrimeGapsOQ04OQ01Aristotle	RESIDUAL	rewrite-drift
 BoundedPrimeGapsOQ04OQ02	RESIDUAL	lambda-reserved-token

--- a/research/toolchain-v4.31-rename-map.md
+++ b/research/toolchain-v4.31-rename-map.md
@@ -1451,3 +1451,27 @@ subtraction made the original statement false; geometric gluing bound). No calle
 | after `ring_nf`, `rw [mul_div_mul_left …]` "did not find pattern a*?/(a*?)" (ring_nf turned `/` into `⁻¹`) | avoid ring_nf; pre-rewrite numerator & denominator into `a*(…)` form via `show … from by ring`, then `mul_div_mul_left` | Erdos120Problem |
 | `push_neg at h` where `h : ¬ (someDef …)` → "push Not made no progress" | `unfold someDef at h` (or `simp only [someDef] at h`) before `push_neg` | Erdos120Problem |
 | `not_not (avoidable A)` "Function expected" (not_not is now an `Iff`) | `rw [← not_not (a := avoidable A)]` (named implicit) or bare `rw [← not_not]` | Erdos120Problem |
+
+### §7ad Doctor increment 45 recipes (Doctor-b A–M / Erdos<600, #38065, +7 GREEN)
+
+| Symptom | Fix | Files |
+|---------|-----|-------|
+| `Λ` (capital lambda) as a user abbrev name → `unexpected token 'Λ'; expected identifier` | `Λ` is now a RESERVED token like `λ`; rename the abbrev (e.g. `abbrev vonM := ArithmeticFunction.vonMangoldt`) and every code use-site (leave comments) | BoundedPrimeGapsOQ04 |
+| `Nat.totient_pos hq` "Function expected" | `Nat.totient_pos` is now an `Iff` (`0 < φ n ↔ 0 < n`); use `Nat.totient_pos.mpr hq` | BoundedPrimeGapsOQ04, BoundedPrimeGapsOQ04OQ02 |
+| `div_pos` "ambiguous [_root_.div_pos, Nat.div_pos]" on ℝ goal | `_root_.div_pos` | BoundedPrimeGapsOQ04OQ02 |
+| `Nat.cast_nonneg` (no arg) type-mismatch `∀ n, 0 ≤ ↑n` vs `0 ≤ ↑x` | supply the arg: `Nat.cast_nonneg _` | BoundedPrimeGapsOQ04OQ02 |
+| `Polynomial.descPochhammer` / `Polynomial.descPochhammer_succ_right` "Unknown constant" | `descPochhammer` moved OUT of the `Polynomial` namespace to top-level; drop the prefix (`descPochhammer`, `descPochhammer_succ_right`) | BinomialTheoremOQ01 |
+| `EMetric.ball` / `EMetric.mem_ball` deprecated; `rw [EMetric.mem_ball]` "did not find pattern Metric.eball" | rename to `Metric.eball` and `Metric.mem_eball` (both `eball`/`mem_eball` live in the `Metric` namespace, NOT `EMetric`) | BinomialTheoremOQ01 |
+| `rw [edist_zero_right]` then old NNReal-coe proof fails; goal is now `‖x‖ₑ < ↑1` | `edist_zero_right` now yields `‖·‖ₑ` (enorm); close with `simpa [enorm_eq_nnnorm, ← ENNReal.coe_one, ENNReal.coe_lt_coe, ← NNReal.coe_lt_coe] using hx` | BinomialTheoremOQ01 |
+| `apply h1.congr; intro k` where `HasSum.congr` now gives a Finset-partial-sum goal (`k : Finset ℕ`, `∑ x_1 ∈ k, …`) | avoid `.congr`; prove the two summand functions equal via `have hfun : (fun n => …) = (fun k => …) := by funext k; …` then `rwa [hfun] at h1` | BinomialTheoremOQ01 |
+| `floor_eq_iff.mpr` "Unknown constant" for ℤ floor (`round_eq` → `⌊x + 1/2⌋`) | `Int.floor_eq_iff.mpr` (no side condition; the ℤ version is `⌊a⌋ = z ↔ ↑z ≤ a ∧ a < z+1`) | DerangementsConvergenceOQ03 |
+| `div_le_iff₀` rewrite produces `≤ 1/b * a` but calc/target wants `≤ a * (1/b)` | insert `by rw [mul_comm]; exact hrate` at the calc step | DerangementsConvergenceOQ03 |
+| local `theorem foo` used BEFORE its definition in the same file → "Unknown identifier `foo`" | reorder: move the definition above its first use-site (forward refs are hard errors) | CombinationsFormulaOQ02Aristotle (moved `choose_2n_succ`) |
+| `Nat.coprime_succ_self` removed | consecutive coprimality: `rw [show m+2=(m+1)+1 from rfl, Nat.coprime_self_add_right]; exact Nat.coprime_one_right _` | CombinationsFormulaOQ02Aristotle |
+| `omega` fails on a `Nat.choose (2m+2) …` Pascal identity: `@Nat.choose_succ_succ` produces `succ`-form atoms omega can't unify with `2*m+2` | state each Pascal step as an explicit `have` using `Nat.choose_succ_succ'` (the `+1` form), normalize `m-1+1=m` via `rw`, then `omega` | CombinationsFormulaOQ02Aristotle |
+| `Nat.mul_le_mul_left _ (Nat.le_succ n)` produces a `sorry` metavar (arg-shape drift) | for `a*(n+1) - a*n = a`: `rw [Nat.mul_succ]; omega` | CombinationsFormulaOQ02Aristotle |
+| `hev.comp_tendsto htends` "Invalid field notation" (`Filter.Eventually.comp_tendsto` REMOVED; type shows as `atTop.1 {x | …}`) | pull back along the tendsto: `have htends : Tendsto (fun x => t*x) atTop atTop; filter_upwards [hev, htends.eventually hev] with …` | CentralLimitTheoremOQ03OQ01 |
+| `tendsto_const_mul_atTop_of_pos ht tendsto_id` "Function expected" | now an `Iff`; `(tendsto_const_mul_atTop_of_pos ht).mpr tendsto_id` | CentralLimitTheoremOQ03OQ01 |
+| `this.symm` on a `=ᶠ[l]` (EventuallyEq) value "Invalid field notation" (shows as `atTop.1 {…}`) | dot-notation can't find the `EventuallyEq` namespace through the reduced `Eventually`; use `Filter.EventuallyEq.symm this` explicitly | CentralLimitTheoremOQ03OQ01 |
+| after `convert … using 1` closes fully, trailing `ext x; ring` → "No goals to be solved" | drop the trailing tactic (convert now discharges) | CentralLimitTheoremOQ03OQ01, DerangementsConvergenceOQ03 (drop `ring`), BinomialTheoremOQ01 |
+| FREE-GREEN: sibling `*Aristotle` companion RESIDUAL but builds EXIT 0 (transitive dep already fixed) | flip ledger with no edit | CentralLimitTheoremOQ03OQ01Aristotle |


### PR DESCRIPTION
Doctor increment 45 of the Lean v4.26→v4.31 migration (epic #37508, issue #38065). Partition: A–M basenames + Erdos<600. Every remaining residual is a ≥3-error cluster; worked whole clusters of catalogued renames.

## +5 GREEN

| File | Errors fixed | Key recipes |
|------|-------------|-------------|
| BoundedPrimeGapsOQ04 | 4 | `Λ` reserved-token → rename abbrev to `vonM`; `Nat.totient_pos` now an `Iff` → `.mpr`; `x % 1 = 0` filter trivial via `Nat.mod_one`; drop redundant `exact` after closing `simp` |
| BoundedPrimeGapsOQ04OQ02 | 2 | `div_pos` ambiguous → `_root_.div_pos`; `totient_pos` Iff; `Nat.cast_nonneg` needs explicit arg |
| BinomialTheoremOQ01 | 7 | `Polynomial.descPochhammer` → top-level `descPochhammer` (+`_succ_right`); `open scoped ENNReal`; `EMetric.ball`/`mem_ball` → `Metric.eball`/`Metric.mem_eball`; `edist_zero_right` now yields `‖·‖ₑ` enorm; `HasSum.congr` finset-form → funext+`rwa` |
| DerangementsConvergenceOQ03 | 4 | `floor_eq_iff` → `Int.floor_eq_iff`; `div_le_iff₀` mul-order → `mul_comm`; drop redundant `ring` |
| CombinationsFormulaOQ02Aristotle | 6 | forward-ref: moved `choose_2n_succ` above its use; `Nat.coprime_succ_self` removed → `coprime_self_add_right`+`coprime_one_right`; Pascal omega via `choose_succ_succ'` normal form; `Nat.mul_succ` |

## New recipes (rename-map §7ac/§7ad)
- `Λ` (capital Lambda) is now a reserved token like `λ` — rename any user abbrev named `Λ`.
- `Nat.totient_pos` is now an `Iff` (`0 < φ n ↔ 0 < n`); old `Nat.totient_pos hq` → `.mpr hq`.
- `descPochhammer` moved OUT of the `Polynomial` namespace (top-level); `descPochhammer_succ_right` likewise.
- `EMetric.ball`/`EMetric.mem_ball` deprecated → `Metric.eball` / `Metric.mem_eball` (note: `eball`/`mem_eball` live in the `Metric` namespace, not `EMetric`). `edist_zero_right` now produces `‖x‖ₑ` (enorm).
- `floor_eq_iff` for ℤ floor is `Int.floor_eq_iff`.
- `Nat.coprime_succ_self` removed → use `coprime_self_add_right` + `coprime_one_right` for consecutive coprimality.

## Honest remaining assessment (A–M / Erdos<600)
443 residuals in partition at session start. Easy 1–2-error files are exhausted; every remaining is a ≥3-error cluster. Sampled a dozen: most are 10–24-error genuine rewrites (BaselProblemOQ04OQ03=24, CantorDiagonalizationOQ01OQ01=19, BinaryGcdOQ02OQ01=20). A minority (~6-error) mix catalogued renames with genuine proof-drift and are fixable per this increment. Deep-rework/OOM: AbelRuffiniOQ10 (`native_decide` on noncomputable `orderOf` — needs `lcm_cycleType` bridge, not mechanical); BertrandsPostulateOQ03OQ04OQ01 (ℝ↔ℕ `PrimeGapConjecture` bridge broken + false exponent-direction inequality — genuine math rework, reverted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)