### PR TITLE
migrate(v4.31): Doctor increment 46 — tm/pd/rewrite (N-Z deep-cluster) (+3 GREEN)

### DIFF
--- a/proofs/Proofs/Erdos1071Problem.lean
+++ b/proofs/Proofs/Erdos1071Problem.lean
@@ -198,7 +198,7 @@ theorem packing_singleton (s : UnitSegment) (h : SegmentInSquare s) :
   constructor
   · intro t ht; rwa [Set.mem_singleton_iff.mp ht]
   · intro a ha b hb hab
-    exact absurd ((Set.mem_singleton_iff.mp ha).symm.trans (Set.mem_singleton_iff.mp hb)) hab
+    exact absurd ((Set.mem_singleton_iff.mp ha).trans (Set.mem_singleton_iff.mp hb).symm) hab
 
 /-- There exists a non-empty packing (witness: horizontal mid-segment) -/
 theorem exists_nonempty_packing :
@@ -274,13 +274,13 @@ theorem exists_maximal_packing : ∃ S : Set UnitSegment, IsMaximalPacking S := 
     · rcases Set.mem_insert_iff.mp ht with rfl | ht
       · exact hs_sq
       · exact hmax.1.1 t ht
-    · rcases Set.mem_insert_iff.mp ha with rfl | ha
-      · rcases Set.mem_insert_iff.mp hb with rfl | hb
+    · rcases Set.mem_insert_iff.mp ha with rfl | ham
+      · rcases Set.mem_insert_iff.mp hb with rfl | hbm
         · exact absurd rfl hab
-        · exact hall b hb
-      · rcases Set.mem_insert_iff.mp hb with rfl | hb
-        · exact disjoint_symm s a (hall a ha)
-        · exact hmax.1.2 a ha b hb hab
+        · exact hall b hbm
+      · rcases Set.mem_insert_iff.mp hb with rfl | hbm
+        · exact disjoint_symm _ _ (hall a ham)
+        · exact hmax.1.2 a ham b hbm hab
   -- By Zorn maximality, insert s m ⊆ m, so s ∈ m — contradiction
   exact hs_nm (hmax.2 h_ins (Set.subset_insert s m) (Set.mem_insert s m))
 

--- a/proofs/Proofs/Erdos1078Problem.lean
+++ b/proofs/Proofs/Erdos1078Problem.lean
@@ -41,12 +41,15 @@ structure RPartiteGraph (r n : ℕ) where
   edges_between_parts : ∀ u v : Fin (r * n),
     edges.Adj u v → ∃ i j : Fin r, i ≠ j ∧ u ∈ parts i ∧ v ∈ parts j
 
+open Classical in
 /--
 **Minimum Degree:**
 The minimum degree of a graph.
 -/
 noncomputable def minDegree (G : SimpleGraph V) : ℕ :=
-  Finset.inf' Finset.univ ⟨Classical.arbitrary V, Finset.mem_univ _⟩ G.degree
+  if h : (Finset.univ : Finset V).Nonempty then
+    Finset.inf' Finset.univ h (fun v => G.degree v)
+  else 0
 
 /--
 **Contains K_r:**
@@ -141,7 +144,6 @@ Any edge gives K_2, so threshold is trivial.
 theorem r2_trivial :
     sharpThreshold 2 n = n - n := by
   simp [sharpThreshold]
-  ring
 
 /--
 **Case r = 3 (Tripartite):**
@@ -150,7 +152,6 @@ For r=3, s = 1, threshold = 2n - ⌈n/1⌉ = 2n - n = n.
 theorem r3_threshold (n : ℕ) (hn : n ≥ 1) :
     sharpThreshold 3 n = 2 * n - n := by
   simp [sharpThreshold]
-  ring
 
 /--
 **Case r = 4 (4-partite):**

--- a/proofs/Proofs/TaylorSinCosConvergenceOQ04.lean
+++ b/proofs/Proofs/TaylorSinCosConvergenceOQ04.lean
@@ -116,6 +116,15 @@ theorem remainder_bound_pos (f : ℝ → ℝ) (C : ℝ)
             exact hbound _ _)
     _ = C * x ^ (n + 1) / ↑n ! := by ring
 
+/-- T_n(0) = f(0) for all n: higher-order terms vanish since 0^k = 0 for k ≥ 1. -/
+theorem taylorPartialSum_at_zero (f : ℝ → ℝ) (n : ℕ) :
+    taylorPartialSum f n 0 = f 0 := by
+  simp only [taylorPartialSum]
+  rw [Finset.sum_eq_single 0
+    (fun k _ hk => by simp [zero_pow hk])
+    (fun h => absurd (Finset.mem_range.mpr n.succ_pos) h)]
+  simp [iteratedDeriv_zero]
+
 /-- **General Taylor Remainder Bound** (fully proved):
     ‖f(x) - T_n(x)‖ ≤ C · |x|^{n+1} / n!
 
@@ -210,14 +219,8 @@ theorem taylorPartialSum_tendsto (f : ℝ → ℝ) (C : ℝ) (hC : 0 ≤ C)
 -- SECTION V: Values at Zero
 -- ═══════════════════════════════════════════════════════════════
 
-/-- T_n(0) = f(0) for all n: higher-order terms vanish since 0^k = 0 for k ≥ 1. -/
-theorem taylorPartialSum_at_zero (f : ℝ → ℝ) (n : ℕ) :
-    taylorPartialSum f n 0 = f 0 := by
-  simp only [taylorPartialSum]
-  rw [Finset.sum_eq_single 0
-    (fun k _ hk => by simp [zero_pow hk])
-    (fun h => absurd (Finset.mem_range.mpr n.succ_pos) h)]
-  simp [iteratedDeriv_zero]
+-- (`taylorPartialSum_at_zero` moved earlier — it is used by
+-- `general_taylor_remainder_bound`.)
 
 -- ═══════════════════════════════════════════════════════════════
 -- SECTION VI: Instantiation — Sin and Cos
@@ -286,10 +289,11 @@ theorem linear_combo_bound (a b : ℝ) (n : ℕ) (x : ℝ) :
     (Real.contDiff_sin.of_le le_top).contDiffAt
   have hcos : ContDiffAt ℝ (n : ℕ∞) Real.cos x :=
     (Real.contDiff_cos.of_le le_top).contDiffAt
-  rw [show (fun x => a * Real.sin x + b * Real.cos x) = a • Real.sin + b • Real.cos from by
+  rw [show (fun x => a * Real.sin x + b * Real.cos x)
+        = (fun y => a • Real.sin y) + (fun y => b • Real.cos y) from by
       funext z; simp [smul_eq_mul]]
   rw [iteratedDeriv_add (hsin.const_smul a) (hcos.const_smul b)]
-  rw [iteratedDeriv_const_smul hsin a, iteratedDeriv_const_smul hcos b]
+  rw [iteratedDeriv_fun_const_smul hsin a, iteratedDeriv_fun_const_smul hcos b]
   simp only [smul_eq_mul]
   calc ‖a * iteratedDeriv n Real.sin x + b * iteratedDeriv n Real.cos x‖
       ≤ ‖a * iteratedDeriv n Real.sin x‖ + ‖b * iteratedDeriv n Real.cos x‖ :=

--- a/proofs/Proofs/TriangleInequalityOQ06.lean
+++ b/proofs/Proofs/TriangleInequalityOQ06.lean
@@ -79,12 +79,12 @@ theorem dist_continuous_right (x : α) : Continuous (dist x) :=
 /-! ## The seminorm reverse triangle inequality -/
 
 /-- Norm reverse triangle inequality. -/
-theorem reverse_triangle_norm {E : Type*} [SeminormedAddGroup E] (a b : E) :
+theorem reverse_triangle_norm {E : Type*} [SeminormedAddCommGroup E] (a b : E) :
     |‖a‖ - ‖b‖| ≤ ‖a - b‖ :=
   abs_norm_sub_norm_le a b
 
 /-- One-sided seminorm form. -/
-theorem norm_sub_norm_le' {E : Type*} [SeminormedAddGroup E] (a b : E) :
+theorem norm_sub_norm_le' {E : Type*} [SeminormedAddCommGroup E] (a b : E) :
     ‖a‖ - ‖b‖ ≤ ‖a - b‖ :=
   norm_sub_norm_le a b
 

--- a/proofs/batch2/STATUS.md
+++ b/proofs/batch2/STATUS.md
@@ -2230,3 +2230,62 @@ inv_ne_zero/smul_left_cancel₀ + simp drift, 8 errors post-ENNReal-fix), FairGa
 LawsOfLargeNumbersOQ01Aristotle metaprogramming file: `Mathlib.Tactic.GeneralizeProofs` namespace +
 `Expr`/`Function expected` — Aristotle meta file needs its own repair), LawsOfLargeNumbersOQ02
 (mixed type-mismatch/instance-stuck), BinomialTheoremOQ01 (Polynomial.descPochhammer unknown).
+
+## Increment 46 (N-Z deep-cluster + Erdos≥600) — +3 GREEN, +1 file-only fix
+
+TAIL PHASE confirmed: ~1-in-6 residuals are catalog-fixable; rest are ≥5-error
+deep-rework, dep-blocked, or unsound originals. Verified fixes:
+
+- **TriangleInequalityOQ06** (instance-synth → GREEN): `abs_norm_sub_norm_le` /
+  `norm_sub_norm_le` moved to the `SeminormedCommGroup` section in Mathlib (their
+  `to_additive` lemmas need commutativity), so `SeminormedAddGroup E` →
+  `SeminormedAddCommGroup E`.
+- **Erdos1078Problem** (instance-synth → GREEN): `Classical.arbitrary V` needed
+  `Nonempty V` (absent) and `G.degree` now carries a `Fintype (neighborSet)` arg.
+  Rewrote `minDegree` as a total function (`if h : univ.Nonempty then inf' … else 0`,
+  eta-expanded `G.degree` under `open Classical in`) — avoids propagating
+  `[DecidableRel G.Adj]` to every call site over `Fin (r*n)`. Also two self-closing
+  `simp`s: dropped trailing `ring`.
+- **TaylorSinCosConvergenceOQ04** (unknown-const → GREEN): forward-reference —
+  `taylorPartialSum_at_zero` was defined AFTER its use in
+  `general_taylor_remainder_bound`; moved it earlier. `linear_combo_bound`: rewrote
+  `show` to a `Pi.add` of two lambdas and switched
+  `iteratedDeriv_const_smul` → `iteratedDeriv_fun_const_smul` so the rewrite patterns
+  match the lambda form (keep plain `iteratedDeriv_add` for the `+`-of-lambdas).
+- **Erdos1071Problem** (PRE-EXISTING never-compiled:s — file compiles green now but
+  NOT flipped per rule): `packing_singleton` Eq.trans chain was reversed
+  (`(mp ha).symm.trans (mp hb)` doesn't chain) → `(mp ha).trans (mp hb).symm`.
+  `exists_maximal_packing` insert-packing: `rcases … with rfl | ha` reused the lambda
+  binder names, leaving membership un-narrowed after the rfl subst → renamed to
+  ham/hbm.
+
+Statement repairs: none (all preserve intended-true statements).
+
+Rename/recipe additions:
+- `SeminormedAddGroup` → `SeminormedAddCommGroup` when using
+  `abs_norm_sub_norm_le` / `norm_sub_norm_le` (moved to CommGroup section).
+- `iteratedDeriv_const_smul` (LHS `c • f`, HSMul form) vs
+  `iteratedDeriv_fun_const_smul` (LHS `fun y => c • f y`, lambda form): pick by goal
+  shape after simp. `iteratedDeriv_add` matches `f + g` (Pi.add of two lambdas);
+  `iteratedDeriv_fun_add` matches a single merged lambda `fun i => f i + g i`.
+- `SimpleGraph.degree v` now needs `[Fintype (G.neighborSet v)]`; over a generic
+  `[Fintype V]` vertex type with no decidability, wrap the def in `open Classical in`.
+
+Skipped/deep (own-file errors ≥5 or unsound):
+- TestApi241 (`{1,2,4,8}` is genuinely NOT a B3/Sidon set — `decide` proves the goal
+  FALSE; unsound original, not force-greened).
+- PtolemysTheoremOQ01Incomplete01 (import-order was the only *blocking* error; once
+  fixed, 10+ deep errors surface: `Complex.abs_mul_exp_arg_mul_I`,
+  `Real.sin_nonpos_of_nonneg_of_nonpos` unknown, etc.).
+- SchroederBernsteinOQ01 (concrete-category API fully refactored: `HasForget` removed,
+  `forget` now needs `{FC}{CC}[FunLike…][ConcreteCategory C FC]` — deep API migration).
+- YangMillsMassGap / SpernerNDimMathlibOQ01 (dep-blocked: `Proofs.YangMills.Exploration`
+  and sibling deps fail, not own file).
+- NewtonIndStep2 (linarith/heartbeat-timeout), TestApi1056 (def-level `by omega` index
+  proofs lack the length hypothesis), Erdos1066Problem (structure auto-bound `n` term-level
+  scoping + downstream), Erdos1005/1040/1061/1005/1035/1050/1051/1052 (≥10 mixed).
+
+HONEST remaining-N-Z fixable count: of ~80 N-Z non-Erdos + ~200 Erdos≥600 residuals
+tested by sampling, roughly 1-in-6 to 1-in-8 remain catalog-fixable; most sampled
+low-error files (≤5) turned out to be either dep-blocked, unsound, or deceptively deep
+(a single blocking error masking many). Estimate ~10-15 more genuinely fixable N-Z/Erdos≥600.

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -767,7 +767,7 @@ Erdos1071Problem	PRE-EXISTING	never-compiled:s
 Erdos1073Problem	GREEN	
 Erdos1075Problem	GREEN	
 Erdos1076Problem	GREEN	
-Erdos1078Problem	RESIDUAL	instance-synth
+Erdos1078Problem	GREEN
 Erdos1079Problem	RESIDUAL	instance-synth
 Erdos107OQ01	RESIDUAL	instance-synth
 Erdos107OQ01KleinUpperAristotle	RESIDUAL	instance-synth

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -2551,7 +2551,7 @@ SzemerediRegularityOQ04Witness	GREEN
 TaxicabNumberOQ01	GREEN	
 TaylorSinCosConvergenceOQ02	RESIDUAL	proof-drift
 TaylorSinCosConvergenceOQ03Aristotle	GREEN	
-TaylorSinCosConvergenceOQ04	RESIDUAL	unknown-const:taylorPartialSum_at_zero
+TaylorSinCosConvergenceOQ04	GREEN
 TaylorTheorem	GREEN	
 TaylorTheoremOQ01	RESIDUAL	type-mismatch
 TaylorTheoremOQ02	RESIDUAL	type-mismatch

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -2619,7 +2619,7 @@ TriangleAngleSumOQ02	RESIDUAL	type-mismatch
 TriangleInequality	GREEN	
 TriangleInequalityOQ01	RESIDUAL	unknown-const:MeasureTheory.LpAddConst_of_one_le
 TriangleInequalityOQ04	GREEN	
-TriangleInequalityOQ06	RESIDUAL	instance-synth
+TriangleInequalityOQ06	GREEN
 TriangularNumberReciprocals	GREEN	
 TriangularReciprocalGeneralized	RESIDUAL	instance-synth
 TriangularReciprocalsFigurate	GREEN	


### PR DESCRIPTION
## Doctor increment 46 — v4.26→v4.31 migration (epic #37508, issue #38065)

Partition: N–Z basenames + Erdos≥600. TAIL PHASE — hunting the ~1-in-6 catalog-fixable residuals.

### +3 GREEN (ledger flips)
- **TriangleInequalityOQ06** (instance-synth): `SeminormedAddGroup E` → `SeminormedAddCommGroup E` — `abs_norm_sub_norm_le` / `norm_sub_norm_le` moved to the `SeminormedCommGroup` section (their `to_additive` lemmas need commutativity).
- **Erdos1078Problem** (instance-synth): `minDegree` rewritten as a total function — `Classical.arbitrary V` needed `Nonempty V` (absent) and `G.degree` now carries a `Fintype (neighborSet)` arg; guarded `univ.Nonempty` with `dif` and eta-expanded under `open Classical in` (avoids propagating `[DecidableRel G.Adj]` to every `Fin (r*n)` call site). Dropped two `ring`s after now-self-closing `simp`.
- **TaylorSinCosConvergenceOQ04** (unknown-const): forward-reference — moved `taylorPartialSum_at_zero` before its use in `general_taylor_remainder_bound`; `linear_combo_bound` switched `iteratedDeriv_const_smul` → `iteratedDeriv_fun_const_smul` and used a `Pi.add`-of-lambdas `show` so rewrite patterns match.

### +1 file-only fix (NOT ledger-flipped)
- **Erdos1071Problem** — file now compiles green but the row is `PRE-EXISTING never-compiled:s`, so left unflipped per rule. Fixed reversed `Eq.trans` chain in `packing_singleton` and `rcases` binder-name reuse in `exists_maximal_packing`.

### Recipes added (see STATUS.md)
- `SeminormedAddGroup` → `SeminormedAddCommGroup` for the reverse-triangle norm lemmas.
- `iteratedDeriv_const_smul` (HSMul `c • f`) vs `iteratedDeriv_fun_const_smul` (lambda form); `iteratedDeriv_add` (Pi.add of two lambdas) vs `iteratedDeriv_fun_add` (merged lambda).
- `SimpleGraph.degree v` now needs `[Fintype (G.neighborSet v)]`; over generic `[Fintype V]`, wrap the def in `open Classical in`.

### Statement repairs
None — all fixes preserve intended-true statements.

### Notable skips (deep / unsound / dep-blocked)
- **TestApi241** — `{1,2,4,8}` is genuinely NOT a B3/Sidon set (`decide` proves the goal FALSE). Unsound original; not force-greened.
- **SchroederBernsteinOQ01** — concrete-category API refactor (`HasForget` removed).
- **PtolemysTheoremOQ01Incomplete01** — import-order was only the *blocking* error; 10+ deep errors underneath.
- YangMillsMassGap / SpernerNDimMathlibOQ01 dep-blocked.

### Honest remaining fixable count
~1-in-6 to 1-in-8 N-Z/Erdos≥600 residuals remain catalog-fixable; estimate ~10–15 more genuinely fixable (many low-error files were deceptively deep, dep-blocked, or unsound).

🤖 Generated with [Claude Code](https://claude.com/claude-code)