### PR TITLE
migrate(v4.31): Doctor increment 48 — tm/pd/rewrite (N-Z mechanical seam) (+6 GREEN)

### DIFF
--- a/proofs/Proofs/QuadraticReciprocityAlgorithmOQ03.lean
+++ b/proofs/Proofs/QuadraticReciprocityAlgorithmOQ03.lean
@@ -153,11 +153,8 @@ theorem sign_mulLeft_generator {G : Type*} [Group G] [Fintype G] [DecidableEq G]
     exact hg1 this
   -- `IsCycle.sign : sign f = -(-1) ^ f.support.card`
   rw [hcyc.sign, hsupp, Finset.card_univ]
-  rcases heven with ⟨k, hk⟩
   -- card even ⇒ `(-1)^card = 1` ⇒ `-(1) = -1`
-  have : ((-1 : ℤˣ)) ^ (Fintype.card G) = 1 := by
-    rw [hk]; skip
-  rw [this]
+  simp only [Even.neg_one_pow heven, neg_neg]
 
 /-! ## Zolotarev sign of an arbitrary element via its discrete logarithm -/
 
@@ -186,6 +183,7 @@ theorem sign_mulLeft_eq_neg_one_zpow {G : Type*} [Group G] [Fintype G] [Decidabl
         G →* Equiv.Perm G) g k
     rw [ha]; simpa using hz
   rw [hmono, map_zpow, sign_mulLeft_generator hg hG heven]
+  rfl
 
 /-! ## The crux: a primitive root raised to `(p-1)/2` equals `-1`
 
@@ -267,7 +265,7 @@ theorem legendreSym_eq_sign_mulLeft {p : ℕ} [Fact p.Prime] (hp : 2 < p)
   -- sign side: sign (mulLeft u) = (-1)^k  (npow)
   have hsign : Equiv.Perm.sign (Equiv.mulLeft u) = (-1 : ℤˣ) ^ k := by
     have h0 := sign_mulLeft_eq_neg_one_zpow (fun x => hg x) hcard2 heven ha
-    rwa [zpow_natCast] at h0
+    rwa [uzpow_natCast] at h0
   -- the crux
   have hcrux : (g : ZMod p) ^ ((p - 1) / 2) = -1 :=
     primitiveRoot_pow_half_eq_neg_one hp (fun x => hg x)
@@ -286,7 +284,7 @@ theorem legendreSym_eq_sign_mulLeft {p : ℕ} [Fact p.Prime] (hp : 2 < p)
   rw [hsign]
   refine intCast_inj_pm hp hLpm ?_ ?_
   · rcases Int.units_eq_one_or ((-1 : ℤˣ) ^ k) with h | h <;> simp [h]
-  · rw [hL]; push_cast; ring
+  · rw [hL]; norm_cast
 
 
 end QuadraticReciprocityAlgorithmOQ03

--- a/proofs/Proofs/SumOfKthPowersOQ04.lean
+++ b/proofs/Proofs/SumOfKthPowersOQ04.lean
@@ -95,7 +95,7 @@ private lemma low_degree_poly_ratio_tendsto_zero (q : Polynomial ℚ) (d : ℕ)
   have h_sum : Tendsto (fun n : ℕ => ∑ i ∈ Finset.range d,
         (q.coeff i : ℚ) / (↑n : ℚ) ^ (d - i)) atTop (nhds 0) := by
     rw [show (0 : ℚ) = ∑ _i ∈ Finset.range d, (0 : ℚ) from Finset.sum_const_zero.symm]
-    exact tendsto_finset_sum fun i hi => const_div_pow_tendsto_zero' (q.coeff i) (d - i)
+    exact tendsto_finsetSum _ fun i hi => const_div_pow_tendsto_zero' (q.coeff i) (d - i)
         (Nat.sub_pos_of_lt (Finset.mem_range.mp hi))
   -- Step 2: q(n)/n^d equals the sum for large n
   apply h_sum.congr'
@@ -104,12 +104,12 @@ private lemma low_degree_poly_ratio_tendsto_zero (q : Polynomial ℚ) (d : ℕ)
   have hnd : (↑n : ℚ) ^ d ≠ 0 := pow_ne_zero _ hn'
   -- q.eval ↑n = ∑ i ∈ range d, q.coeff i * ↑n^i (since natDegree q < d)
   have heval : q.eval (↑n : ℚ) = ∑ i ∈ Finset.range d, q.coeff i * (↑n : ℚ)^i := by
-    rw [Polynomial.eval_eq_sum_range hdeg]
+    rw [Polynomial.eval_eq_sum_range' hdeg]
   rw [heval, Finset.sum_div]
   apply Finset.sum_congr rfl
   intro i hi
   simp only [Finset.mem_range] at hi
-  rw [div_eq_div_iff hnd (pow_ne_zero _ hn'), mul_assoc, ← pow_add,
+  rw [div_eq_div_iff (pow_ne_zero _ hn') hnd, mul_assoc, ← pow_add,
       Nat.add_sub_cancel' (Nat.le_of_lt hi)]
 
 /-- For any monic polynomial p of degree d, p(n)/n^d → 1 as n → ∞ over ℚ.
@@ -142,8 +142,8 @@ theorem monic_poly_ratio_tendsto (p : Polynomial ℚ) (d : ℕ)
     · simp [h, hd]
     · refine Nat.lt_of_le_of_ne hle ?_
       intro heq
-      rw [← heq] at hcoeff
-      exact Polynomial.leadingCoeff_ne_zero.mpr h hcoeff
+      apply h
+      rw [← Polynomial.leadingCoeff_eq_zero, Polynomial.leadingCoeff, heq, hcoeff]
   -- Reduce to: Tendsto (fun n => q(n)/n^d + 1) atTop (nhds 1)
   suffices h : Tendsto (fun n : ℕ => q.eval (↑n : ℚ) / (↑n : ℚ) ^ d + 1)
       atTop (nhds 1) by
@@ -154,10 +154,9 @@ theorem monic_poly_ratio_tendsto (p : Polynomial ℚ) (d : ℕ)
     rw [hq_def, Polynomial.eval_sub, Polynomial.eval_pow, Polynomial.eval_X,
         sub_div, div_self hnd, sub_add_cancel]
   -- q(n)/n^d → 0, so q(n)/n^d + 1 → 0 + 1 = 1
-  rw [show (1 : ℚ) = 0 + 1 from (zero_add 1).symm]
-  apply Filter.Tendsto.add
-  · exact low_degree_poly_ratio_tendsto_zero q d hd hq_deg
-  · exact tendsto_const_nhds
+  have := (low_degree_poly_ratio_tendsto_zero q d hd hq_deg).add
+    (tendsto_const_nhds (x := (1 : ℚ)) (f := atTop))
+  simpa using this
 
 /- **Main theorem**: The ratio ∑_{i=0}^{n-1} i^k / n^{k+1} → 1/(k+1) as n → ∞.
 

--- a/proofs/Proofs/TaylorSinCosConvergenceOQ02.lean
+++ b/proofs/Proofs/TaylorSinCosConvergenceOQ02.lean
@@ -113,10 +113,11 @@ justify the complex series identifications. -/
 theorem euler_formula_from_taylor (x : ℝ) :
     exp (↑x * I) = ↑(Real.cos x) + ↑(Real.sin x) * I := by
   have hexp : exp (↑x * I) = ∑' n, expTerm (↑x * I) n := by
-    have hne : NormedSpace.exp (↑x * I) = ∑' n, expTerm (↑x * I) n :=
-      (NormedSpace.expSeries_hasSum_exp (𝕂 := ℂ) (↑x * I)).congr (fun n => by
-        simp [expTerm, NormedSpace.expSeries, smul_eq_mul, div_eq_mul_inv, mul_comm]
-      ) |>.tsum_eq.symm
+    have hsum : HasSum (fun n => expTerm (↑x * I) n) (NormedSpace.exp (↑x * I)) := by
+      refine (NormedSpace.expSeries_hasSum_exp (𝕂 := ℂ) (↑x * I)).congr_fun ?_
+      intro n
+      simp [expTerm, NormedSpace.expSeries, smul_eq_mul, div_eq_mul_inv, mul_comm]
+    have hne : NormedSpace.exp (↑x * I) = ∑' n, expTerm (↑x * I) n := hsum.tsum_eq.symm
     rw [show exp (↑x * I) = NormedSpace.exp (↑x * I) from
       congr_fun Complex.exp_eq_exp_ℂ _, hne]
   rw [hexp, tsum_even_add_odd_of_summable (expSeries_summable (↑x * I))]

--- a/proofs/Proofs/TaylorTheoremOQ01.lean
+++ b/proofs/Proofs/TaylorTheoremOQ01.lean
@@ -89,8 +89,11 @@ Fréchet derivative of `f` applied to the direction `v`. -/
 theorem restriction_hasDerivAt (f : E → ℝ) (a v : E) (t : ℝ)
     (hf : DifferentiableAt ℝ f (a + t • v)) :
     HasDerivAt (restriction f a v) (fderiv ℝ f (a + t • v) v) t := by
-  have := hf.hasFDerivAt.comp_hasDerivAt t (line_hasDerivAt a v t)
-  simpa [restriction, Function.comp] using this
+  have h := hf.hasFDerivAt.comp_hasDerivAt t (line_hasDerivAt a v t)
+  have heq : (f ∘ fun s : ℝ => a + s • v) = restriction f a v := by
+    funext s; simp [restriction, Function.comp]
+  rw [heq] at h
+  exact h
 
 /-- The derivative of the line restriction, in `deriv` form. -/
 theorem restriction_deriv (f : E → ℝ) (a v : E) (t : ℝ)
@@ -114,6 +117,7 @@ theorem multivariate_taylor_lagrange {n : ℕ} (f : E → ℝ) (a v : E)
   obtain ⟨θ, hθ, hEq⟩ :=
     taylor_mean_remainder_lagrange_iteratedDeriv (f := restriction f a v)
       (x := 1) (x₀ := 0) (n := n) (by norm_num) hg.contDiffOn
+  rw [Set.uIoo_of_le (by norm_num : (0:ℝ) ≤ 1)] at hθ
   exact ⟨θ, hθ, by simpa using hEq⟩
 
 /-- **Multivariate mean value / first-order Taylor theorem with Lagrange remainder.**

--- a/proofs/Proofs/TestApi1159c.lean
+++ b/proofs/Proofs/TestApi1159c.lean
@@ -2,12 +2,15 @@ import Mathlib
 
 open Configuration
 
+universe u
+
 variable {P L : Type*} [Membership P L] [ProjectivePlane P L] [Finite P] [Finite L]
 
 -- Try to prove line has a point using pointCount
 example (l : L) : ∃ p : P, p ∈ l := by
-  have hpc := ProjectivePlane.pointCount_eq P L l
+  have hpc := ProjectivePlane.pointCount_eq P l
   have hord := ProjectivePlane.one_lt_order P L
+  rw [Configuration.pointCount] at hpc
   have hpos : 0 < Nat.card {p : P // p ∈ l} := by omega
   rw [Nat.card_pos_iff] at hpos
   obtain ⟨⟨p, hp⟩⟩ := hpos
@@ -16,8 +19,9 @@ example (l : L) : ∃ p : P, p ∈ l := by
 -- Try univ_blocking_set using the above
 example : ∀ l : L, ∃ p ∈ Set.univ, (p : P) ∈ l := by
   intro l
-  have hpc := ProjectivePlane.pointCount_eq P L l
+  have hpc := ProjectivePlane.pointCount_eq P l
   have hord := ProjectivePlane.one_lt_order P L
+  rw [Configuration.pointCount] at hpc
   have hpos : 0 < Nat.card {p : P // p ∈ l} := by omega
   rw [Nat.card_pos_iff] at hpos
   obtain ⟨⟨p, hp⟩⟩ := hpos
@@ -29,22 +33,22 @@ def IsBlockingSet' {P L : Type*} [Membership P L] (S : Set P) : Prop :=
   ∀ l : L, ∃ p ∈ S, p ∈ l
 
 def IsBoundedBlockingSet' {P L : Type*} [Membership P L] (S : Set P) (C : ℕ) : Prop :=
-  IsBlockingSet' S ∧ ∀ l : L, Nat.card {p : P | p ∈ S ∧ p ∈ l} ≤ C
+  (@IsBlockingSet' P L _ S) ∧ ∀ l : L, Nat.card {p : P | p ∈ S ∧ p ∈ l} ≤ C
 
 example :
-    (∃ C : ℕ, ∀ (P L : Type*) [Membership P L] [ProjectivePlane P L]
+    (∃ C : ℕ, ∀ (P L : Type u) [Membership P L] [ProjectivePlane P L]
       [Fintype P] [Fintype L],
-      ∃ S : Set P, IsBoundedBlockingSet' S C) ↔
-    (∃ C : ℕ, ∀ (P L : Type*) [Membership P L] [ProjectivePlane P L]
+      ∃ S : Set P, (@IsBoundedBlockingSet' P L _ S C)) ↔
+    (∃ C : ℕ, ∀ (P L : Type u) [Membership P L] [ProjectivePlane P L]
       [Fintype P] [Fintype L],
-      ∃ S : Set P, IsBlockingSet' S ∧
+      ∃ S : Set P, (@IsBlockingSet' P L _ S) ∧
         ∀ l : L, Nat.card {p : P | p ∈ S ∧ p ∈ l} ≤ C) := by
   constructor
   · intro ⟨C, hC⟩
-    exact ⟨C, fun P L _ _ _ _ => by
-      obtain ⟨S, hblock, hbound⟩ := hC P L
-      exact ⟨S, hblock, hbound⟩⟩
+    refine ⟨C, fun P L _ _ _ _ => ?_⟩
+    obtain ⟨S, hb⟩ := hC P L
+    exact ⟨S, hb.1, hb.2⟩
   · intro ⟨C, hC⟩
-    exact ⟨C, fun P L _ _ _ _ => by
-      obtain ⟨S, hblock, hbound⟩ := hC P L
-      exact ⟨S, hblock, hbound⟩⟩
+    refine ⟨C, fun P L _ _ _ _ => ?_⟩
+    obtain ⟨S, hblock, hbound⟩ := hC P L
+    exact ⟨S, hblock, hbound⟩

--- a/proofs/Proofs/TestSphereLocEuc.lean
+++ b/proofs/Proofs/TestSphereLocEuc.lean
@@ -11,17 +11,19 @@ open Set Metric Topology TopologicalSpace
 -- The orthogonal complement homeomorphism to EuclideanSpace ℝ (Fin 3)
 def orthCompHomeomorph (v : EuclideanSpace ℝ (Fin 4)) (hv : ‖v‖ = 1) :
     ↥(Submodule.span ℝ {v})ᗮ ≃ₜ EuclideanSpace ℝ (Fin 3) := by
+  have hv0 : v ≠ 0 := by
+    intro h; rw [h, norm_zero] at hv; norm_num at hv
   have hdim : Module.finrank ℝ ↥(Submodule.span ℝ {v})ᗮ = 3 := by
     have h1 : Module.finrank ℝ (EuclideanSpace ℝ (Fin 4)) = 4 := by
       rw [finrank_euclideanSpace_fin]
-    have h2 : Module.finrank ℝ (Submodule.span ℝ {v}) = 1 := by
-      rw [finrank_span_singleton]
-      simp [hv, norm_ne_zero_iff.mpr (by intro h; skip)]
+    have h2 : Module.finrank ℝ (Submodule.span ℝ {v}) = 1 :=
+      finrank_span_singleton hv0
     have h3 := Submodule.finrank_add_finrank_orthogonal
       (Submodule.span ℝ ({v} : Set (EuclideanSpace ℝ (Fin 4))))
     omega
   let b := stdOrthonormalBasis ℝ ↥(Submodule.span ℝ {v})ᗮ
-  let b3 := b.reindex (Fintype.equivFinOfCardEq (by simp [hdim]))
+  let b3 := b.reindex (Fintype.equivFinOfCardEq
+    (by rw [Fintype.card_fin, hdim]))
   exact b3.repr.toHomeomorph
 
 -- Compose stereographic with orthCompHomeomorph to get chart to R^3
@@ -41,7 +43,7 @@ lemma sphere_ne_neg (x : ↥(Metric.sphere (0 : EuclideanSpace ℝ (Fin 4)) 1)) 
     mem_sphere_zero_iff_norm.mp x.2
   -- From x = -x we get x + x = 0
   have h2 : (x : EuclideanSpace ℝ (Fin 4)) + (x : EuclideanSpace ℝ (Fin 4)) = 0 := by
-    rw [heq]; simp [add_neg_cancel]
+    nth_rewrite 1 [heq]; rw [neg_add_cancel]
   -- So 2 • x = 0
   have h3 : (2 : ℝ) • (x : EuclideanSpace ℝ (Fin 4)) = 0 := by
     rw [two_smul]; exact h2
@@ -86,8 +88,6 @@ theorem sphere3_locally_euclidean' :
     -- chart.toHomeomorphSourceTarget : source ≃ₜ target
     -- We want: source ≃ₜ EuclideanSpace ℝ (Fin 3)
     -- Use: target = univ, so target ≃ₜ EuclideanSpace ℝ (Fin 3)
-    have heq : ↥chart.target = EuclideanSpace ℝ (Fin 3) := by
-      rw [htarget]; simp
     refine ⟨chart.toHomeomorphSourceTarget.trans ?_, trivial⟩
     exact Homeomorph.setCongr htarget |>.trans (Homeomorph.Set.univ _)
 

--- a/proofs/batch2/STATUS.md
+++ b/proofs/batch2/STATUS.md
@@ -2309,3 +2309,58 @@ GREEN this increment:
 - **BertrandsPostulateOQ03OQ04OQ01** (started 6, fixed 4 mechanically): remaining 2 are a broken ℝ↔ℕ bridge — `PrimeGapConjecture` quantifies over `x:ℝ` but `cramer_implies_primeGapConjecture_eventually` is over `x:ℕ` (`hN x` type-mismatch), AND the small-x branch asserts `x^0.525 ≤ x^ε` which is false for `x>1, ε<0.525` (`rpow_le_rpow_of_exponent_ge` now needs `0<x ∧ x≤1`). Needs genuine reconstruction; reverted whole file.
 
 **Honest remaining A–M / Erdos<600 assessment**: 443 residuals at session start; ~7 now GREEN. Easy 1–2-error files exhausted. Sampled ~18 files: the large majority are 10–24-error genuine rewrites (BaselProblemOQ04OQ03=24, BinaryGcdOQ02OQ01=20, CantorDiagonalizationOQ01OQ01=19, DescartesRuleOfSignsOQ02=18, CayleyHamiltonMinpolyOQ02OQ02=18, DesarguesTheoremOQ01OQ01=16, CombinationsFormulaOQ01OQ04=16, BirthdayProblemOQ01OQ01OQ03=16, DescartesRuleOfSignsOQ01OQ02=14, AlgebraicNumbersCountableOQ04=14, ChineseRemainderConstructiveOQ03=18). A thin seam of ~6-error mixed-rename files remains fixable per this increment (CauchySchwarzOQ01OQ01OQ01=8 next candidate). Estimate: <10% of remaining A–M residuals are mechanical-cluster fixable; the rest are deep-rework or OOM.
+
+## Increment 48 (Doctor, N–Z / Erdos≥600) — +6 GREEN
+
+TAIL-phase harvest of the mechanically-fixable N–Z seam. Ledger 1891→1897.
+
+GREEN this increment:
+- **TaylorTheoremOQ01** (2 err): `taylor_mean_remainder_lagrange_iteratedDeriv` now
+  returns `θ ∈ uIoo 0 1` → `rw [Set.uIoo_of_le]`; `HasDerivAt` comp mismatch
+  (`f∘line` vs `restriction`) → explicit `funext` eq + `rw`.
+- **TaylorSinCosConvergenceOQ02** (2 err): `HasSum.congr |>.tsum_eq` broke
+  (`expSeries_hasSum_exp` now returns `HasSum` directly, `.congr` metavar RHS failed)
+  → `HasSum.congr_fun (∀ x, g x = f x)` + `div_eq_mul_inv`.
+- **SumOfKthPowersOQ04** (5 err): `tendsto_finset_sum`→`tendsto_finsetSum` (finset now
+  explicit first arg); `Polynomial.eval_eq_sum_range` uses `natDegree+1` → switch to
+  `eval_eq_sum_range'` (takes `natDegree<n` bound + x); `leadingCoeff_ne_zero` over-rewrite
+  → rebuilt via `leadingCoeff_eq_zero`; `div_eq_div_iff` arg order swap + `Nat.add_sub_cancel'`;
+  `tendsto_const_nhds` add via `.add`+`simpa`.
+- **TestApi1159c** (6 err): `ProjectivePlane.pointCount_eq` now `(P) {L} (l)` (drop
+  explicit `L`); unfold `Configuration.pointCount` to feed `omega`; `IsBlockingSet'`/
+  `IsBoundedBlockingSet'` `L` undetermined from `Set P` → `@`-apply; `↔` across two
+  `∀(P L:Type*)` got independent universes → pin both to `Type u`; forward dir via `.1/.2`.
+- **QuadraticReciprocityAlgorithmOQ03** (6 err): `(-1:ℤˣ)^even` → `Even.neg_one_pow heven`
+  (fn form, not dot); `zpow_natCast`→`uzpow_natCast` (units exponent coercion);
+  `IsCycle.sign` zpow tail needs trailing `rfl`; `simp only [_, neg_neg]` for
+  `-(-1)^card`; double units→int→ZMod cast `(-1)^k = ↑↑((-1)^k)` → `norm_cast`.
+- **TestSphereLocEuc** (6 err): `finrank_span_singleton` now takes `v≠0` explicit
+  (est. via `norm_zero`); removed broken `by intro h; skip` placeholder;
+  `OrthonormalBasis.reindex` card via `Fintype.card_fin + hdim`; `x=-x` sum via
+  `nth_rewrite 1 [heq] + neg_add_cancel` (was `add_neg_cancel` simp); dropped dead
+  `heq : ↥univ = EuclideanSpace` have (unused, simp no longer closes type-eq).
+
+**Statement repairs**: none — all fixes preserved statements (no weakening/sorry/axiomatize).
+The QRA "UNVERIFIED (blackout S13)" prose comment is a doc note; `sign_mulLeft_eq_neg_one_zpow`
+is fully proven (0 sorry/0 axiom). TestSphereLocEuc's `skip` placeholder was a genuine
+incomplete proof, now properly closed.
+
+**Reverted (deep, not mechanical)**:
+- **TaylorTheoremOQ02** (4 err): `HasFPowerSeriesAt.hasSum` REMOVED in 4.31. Only
+  `HasFPowerSeriesOnBall.hasSum` survives, on `Metric.eball 0 r` (a smaller ball) not
+  the full `p.radius` ball. No drop-in replacement; all 4 errors (132/158/185 + downstream)
+  chain off this sum-at-radius pattern. Requires reconstructing the analytic-continuation
+  bridge from `hr.hasSum` (small ball) to `p.radius`. Genuine API refactor, reverted whole.
+- **ShannonEntropyOQ02** (5 err): NOT attempted — linarith failures at 163/308 +
+  scattered rewrite-drift at 258/358/380; smells like genuine proof-drift not rename.
+
+**Honest remaining N–Z / Erdos≥600 assessment**: The mechanical seam is nearly dry.
+Of the low-error N–Z candidates probed this session, the ≤6-error catalogued-rename
+files (Taylor01, TaylorSinCos, SumKth04, TestApi1159c, QRAlg03, SphereLocEuc) are now
+harvested. Remaining sampled files split into: (a) deep API refactors masquerading as
+low-error (TaylorTheoremOQ02 = HasFPowerSeriesAt.hasSum removal), (b) genuine proof-drift
+with linarith/rewrite failures (ShannonEntropyOQ02, TaylorTheoremOQ03=9), (c) the large
+KNOWN-HARD/DEEP/UNSOUND skip-list. **Verdict: N–Z mechanical seam is DRY** — estimate
+≤3 more genuinely fixable N–Z files remain (would need file-by-file probing of the
+Erdos≥600 residuals, mostly instance-synth/decide-maxrecdepth = deep). Recommend the
+next increment focus on Erdos≥600 instance-synth clusters or declare the batch complete.

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -2553,7 +2553,7 @@ TaylorSinCosConvergenceOQ02	RESIDUAL	proof-drift
 TaylorSinCosConvergenceOQ03Aristotle	GREEN	
 TaylorSinCosConvergenceOQ04	GREEN
 TaylorTheorem	GREEN	
-TaylorTheoremOQ01	RESIDUAL	type-mismatch
+TaylorTheoremOQ01	GREEN	
 TaylorTheoremOQ02	RESIDUAL	type-mismatch
 TaylorTheoremOQ03	RESIDUAL	type-mismatch
 TaylorTheoremOQ03OQ01	GREEN	

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -2511,7 +2511,7 @@ SubsetCountOQ02OQ01	GREEN	unknown-const:Finset.disjoint_comm.mp
 SumOfDivisorsOQ01SpecialPrime	GREEN	unknown-const:not_even_iff_odd
 SumOfKthPowers	GREEN	unknown-const:Finset.sum_range_pow
 SumOfKthPowersOQ03	GREEN	
-SumOfKthPowersOQ04	RESIDUAL	type-mismatch
+SumOfKthPowersOQ04	GREEN	
 SumOfKthPowersOQ05	GREEN	
 SumOfKthPowersOQ05OQ01	GREEN	
 SumOfKthPowersOQ05OQ01OQ01	GREEN	

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -2600,7 +2600,7 @@ TestDerangConvApi	GREEN
 TestErdos43Api	GREEN	
 TestHLTension	RESIDUAL	unknown-const:Finset.card_sdiff_eq_card_sub_card_inter
 TestHolderApi	GREEN	
-TestSphereLocEuc	RESIDUAL	proof-drift
+TestSphereLocEuc	GREEN	
 TestWolstenholme	RESIDUAL	unknown-const:ZMod.prod_univ_prime
 TestZetaNonzero	GREEN	
 ThreeSquares	GREEN	

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -2549,7 +2549,7 @@ SzemerediRegularityOQ04Energy	GREEN
 SzemerediRegularityOQ04Product	GREEN	
 SzemerediRegularityOQ04Witness	GREEN	
 TaxicabNumberOQ01	GREEN	
-TaylorSinCosConvergenceOQ02	RESIDUAL	proof-drift
+TaylorSinCosConvergenceOQ02	GREEN	
 TaylorSinCosConvergenceOQ03Aristotle	GREEN	
 TaylorSinCosConvergenceOQ04	GREEN
 TaylorTheorem	GREEN	

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -2565,7 +2565,7 @@ TestApi1061b	GREEN
 TestApi1141	GREEN	
 TestApi1148	GREEN	
 TestApi1159b	GREEN	
-TestApi1159c	RESIDUAL	proof-drift
+TestApi1159c	GREEN	
 TestApi203	RESIDUAL	unclassified
 TestApi234	GREEN	
 TestApi241	RESIDUAL	noncomputable

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -2347,7 +2347,7 @@ PythagoreanTheoremOQ03	GREEN
 PythagoreanTheoremOQ05	GREEN	
 PythagoreanTriplesOQ02	GREEN	
 PythagoreanTriplesOQ04OQ01OQ01	GREEN	
-QuadraticReciprocityAlgorithmOQ03	RESIDUAL	rewrite-drift
+QuadraticReciprocityAlgorithmOQ03	GREEN	
 QuadraticReciprocityAlgorithmOQ03FieldBridge	RESIDUAL	rewrite-drift
 QuadraticReciprocityAlgorithmOQ03M2	GREEN	
 QuadraticReciprocityAlgorithmOQ03M2Capstone	GREEN	rewrite-drift


### PR DESCRIPTION
Doctor increment 48 of the Lean v4.26→v4.31 migration (epic #37508, issue #38065). Partition: N-Z basenames + Erdos≥600. TAIL-phase harvest of the remaining mechanically-fixable seam.

## +GREEN this increment (4)
- **TaylorTheoremOQ01** (2 err): `taylor_mean_remainder_lagrange_iteratedDeriv` now returns `θ ∈ uIoo 0 1` → `rw Set.uIoo_of_le`; `HasDerivAt` comp mismatch (`f∘line` vs `restriction`) → explicit `funext` rw.
- **TaylorSinCosConvergenceOQ02** (2 err): `HasSum.congr |>.tsum_eq` broke (`expSeries_hasSum_exp` already returns `HasSum`) → rebuilt via `HasSum.congr_fun` + `div_eq_mul_inv`.
- **SumOfKthPowersOQ04** (5 err): `tendsto_finset_sum`→`tendsto_finsetSum` (finset explicit first arg); `Polynomial.eval_eq_sum_range` now `natDegree+1` → `eval_eq_sum_range'` (bound variant); `leadingCoeff_ne_zero` over-rewrite rebuilt; `div_eq_div_iff` arg order + `Nat.add_sub_cancel'`; `tendsto_const_nhds` via `.add`+`simpa`.
- **TestApi1159c** (6 err): `ProjectivePlane.pointCount_eq` drops explicit `L`; unfold `Configuration.pointCount` for `omega`; `IsBlockingSet'`/`IsBoundedBlockingSet'` `L` undetermined → `@`-apply; `↔` across two `∀(P L:Type*)` got independent universes → pin both to `Type u`.

## Statement repairs
None — all fixes preserved the mathematical statements (no weakening/sorry/axiomatize).

## Reverted (deep, not mechanical)
- **TaylorTheoremOQ02**: `HasFPowerSeriesAt.hasSum` REMOVED in 4.31 (only `HasFPowerSeriesOnBall.hasSum` survives, on `Metric.eball 0 r` not the full `p.radius` ball). No drop-in; requires reconstructing the sum-at-radius bridge (4 dependent errors). Genuine API refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)