### PR TITLE
migrate(v4.31): Doctor increment 49 — tm/pd/rewrite (A-M seam) (+3 GREEN)

### DIFF
--- a/proofs/Proofs/DirichletsTheorem.lean
+++ b/proofs/Proofs/DirichletsTheorem.lean
@@ -121,7 +121,7 @@ The main statement from Mathlib: if q is a positive integer and a : ZMod q is a 
 This is the form used in Mathlib's `Nat.infinite_setOf_prime_and_eq_mod`. -/
 theorem dirichlet_zmod {q : ℕ} [NeZero q] (a : ZMod q) (ha : IsUnit a) :
     Set.Infinite {p : ℕ | Nat.Prime p ∧ (p : ZMod q) = a} :=
-  Nat.infinite_setOf_prime_and_eq_mod a ha
+  Nat.infinite_setOf_prime_and_eq_mod ha
 
 /-- **DIRICHLET'S THEOREM (Natural number congruence formulation)**
 
@@ -136,16 +136,19 @@ theorem dirichlet_modEq {a q : ℕ} (hq : q ≠ 0) (ha : Nat.Coprime a q) :
 Given any natural number n, we can find a prime p > n in the arithmetic progression.
 This is the constructive version of the infinitude statement. -/
 theorem dirichlet_constructive {a q : ℕ} (hq : q ≠ 0) (ha : Nat.Coprime a q) (n : ℕ) :
-    ∃ p : ℕ, Nat.Prime p ∧ n < p ∧ p ≡ a [MOD q] :=
-  Nat.forall_exists_prime_gt_and_modEq hq ha n
+    ∃ p : ℕ, Nat.Prime p ∧ n < p ∧ p ≡ a [MOD q] := by
+  obtain ⟨p, hpn, hp, hcong⟩ := Nat.forall_exists_prime_gt_and_modEq n hq ha
+  exact ⟨p, hp, hpn, hcong⟩
 
 /-- **DIRICHLET'S THEOREM (Integer formulation)**
 
 For integers a and q with q ≠ 0 and gcd(a, q) = 1, there are infinitely many
 primes congruent to a modulo q. -/
 theorem dirichlet_int {a : ℤ} {q : ℕ} (hq : q ≠ 0) (ha : Int.gcd a q = 1) (n : ℕ) :
-    ∃ p : ℕ, Nat.Prime p ∧ n < p ∧ (p : ℤ) ≡ a [ZMOD q] :=
-  Nat.forall_exists_prime_gt_and_zmodEq hq ha n
+    ∃ p : ℕ, Nat.Prime p ∧ n < p ∧ (p : ℤ) ≡ a [ZMOD q] := by
+  obtain ⟨p, hpn, hp, hcong⟩ :=
+    Nat.forall_exists_prime_gt_and_zmodEq n hq (Int.isCoprime_iff_gcd_eq_one.mpr ha)
+  exact ⟨p, hp, hpn, hcong⟩
 
 /-- **DIRICHLET'S THEOREM (Filter formulation)**
 
@@ -168,7 +171,7 @@ PART III: DIRICHLET CHARACTERS AND L-FUNCTIONS
     Mathlib defines these in `Mathlib.NumberTheory.DirichletCharacter.Basic`. -/
 example (N : ℕ) [NeZero N] : Type := DirichletCharacter ℂ N
 
-/-- **Dirichlet L-function** associated to a character χ:
+/- **Dirichlet L-function** associated to a character χ:
 
     $$L(s, \chi) = \sum_{n=1}^{\infty} \frac{\chi(n)}{n^s}$$
 
@@ -178,7 +181,7 @@ example (N : ℕ) [NeZero N] : Type := DirichletCharacter ℂ N
     Mathlib provides this in `Mathlib.NumberTheory.LSeries.DirichletContinuation`. -/
 #check DirichletCharacter.LFunction
 
-/-- **Key theorem: L-function non-vanishing at s = 1**
+/- **Key theorem: L-function non-vanishing at s = 1**
 
     For a non-trivial Dirichlet character χ, L(1, χ) ≠ 0.
     This is the heart of Dirichlet's proof.
@@ -200,9 +203,6 @@ theorem infinitely_many_primes_1_mod_4 :
   convert this using 1
   ext p
   simp only [Set.mem_setOf_eq, Nat.ModEq]
-  constructor <;> intro ⟨hp, hmod⟩
-  · exact ⟨hp, hmod⟩
-  · exact ⟨hp, hmod⟩
 
 /-- **Special case: Primes ≡ 3 (mod 4)**
 
@@ -225,7 +225,6 @@ theorem infinitely_many_primes_1_mod_6 :
   convert this using 1
   ext p
   simp only [Set.mem_setOf_eq, Nat.ModEq]
-  constructor <;> intro ⟨hp, hmod⟩ <;> exact ⟨hp, hmod⟩
 
 /-- **Special case: Primes ≡ 5 (mod 6)**
 

--- a/proofs/batch2/STATUS.md
+++ b/proofs/batch2/STATUS.md
@@ -2352,3 +2352,46 @@ ArchimedesMethodOfExhaustion 17, BorsukUlamOQ02 18, AlgebraicNumbersCountableOQ0
 ArithmeticSeriesOQ02OQ02OQ03 13, BinomialTheoremOQ02OQ03 10. Estimate: <10% of remaining
 A–M residuals are mechanical-seam fixable and the seam is thinning; each green now averages
 real proof surgery.
+
+---
+
+## Increment 49 (Doctor-b, A–M seam + Erdos<600)
+
+**+3 GREEN** (one cluster):
+- `DirichletsTheorem` — signature-drift + doc-on-command. Recipes:
+  - `Nat.infinite_setOf_prime_and_eq_mod`: `a` now IMPLICIT → drop explicit `a`, pass only `IsUnit a`.
+  - `Nat.forall_exists_prime_gt_and_modEq` / `_zmodEq`: `n` moved to FIRST explicit arg; result is now
+    `∃ p > n, Nat.Prime p ∧ ...` (i.e. `∃ p, p > n ∧ ...`) not `∃ p, Nat.Prime p ∧ n < p ∧ ...` →
+    adapt via `obtain ⟨p, hpn, hp, hc⟩ := lemma n hq ha; exact ⟨p, hp, hpn, hc⟩`.
+  - `Int.gcd a q = 1` → `IsCoprime a ↑q` via `Int.isCoprime_iff_gcd_eq_one.mpr`.
+  - `/-- docstring -/` immediately before a `#check` COMMAND now hard-errors ("unexpected token '#check'")
+    → convert those `/--` to `/-`.
+  - `convert this using 1; ext p; simp only [...]` now CLOSES the goal in v4.31 → trailing
+    `constructor <;> intro ⟨..⟩ ...` gives "No goals to be solved"; delete the dead tail.
+- `InfinitudePrimes4k3OQ01`, `InfinitudePrimes4k3OQ01Q12Q24` — own files clean, were dep-blocked on
+  DirichletsTheorem; greened for free once the dep greened.
+
+**Probed-and-skipped (deep / not mechanical seam)**:
+- Erdos598Problem — `def`-level universe-metavar on `Set.Iio kappa` used as a type; pinning
+  `kappa : Cardinal.{0}` breaks `Cardinal.mk α ≥ kappa` (α : Type*) and surfaces an unterminated
+  comment. Genuine universe rework. Reverted.
+- Erdos181OQ01 — `Function.id`→`id` is right, but the follow-on `fin_cases … <;> simp_all` now hits
+  maxRecDepth and `id` is reported unused; needs a real proof for the off-diagonal `c` case (uses
+  `hsymm`). Reverted.
+- FeuerbachsTheoremOQ05 — base `FeuerbachsTheorem` never defines `Triangle.feuerbachPoint`;
+  missing-definition, not drift.
+- ChebyshevPNTBridgeOQ01 / KummerTheoremOQ03 — `PartENat` removal cascades into
+  `multiplicity`/`Nat.log_lt`/`prime_dvd_choose_prime_pow` API changes; multi-site.
+- Multi-site proof-drift (4–8 own-file errors, verified deep on inspection):
+  ChineseRemainderNonCoprimeOQ02, Erdos281/301/86, FourColorTheoremOQ01, Erdos437Aristotle,
+  CauchySchwarzOQ01OQ04, DeMoivreOQ02OQ02, DerangementsOQ03OQ01, AreaOfCircleOQ01OQ03,
+  BezoutIdentityOQ02OQ01OQ01OQ01OQ01, AlgebraicNumbersCountableOQ04.
+- Dep-blocked-by-deep-dep: CantorDiagonalizationOQ04OQ01OQ01OQ01 (dep …OQ01OQ01 instance-synth),
+  CantorDiagonalizationOQ04OQ03Aristotle (dep …OQ03 multi-site).
+
+**VERDICT: the A–M mechanical seam is DRY.** Of 16 residuals probed this increment across
+parse-error / signature-drift / elab-drift / unknown-const / instance-synth / type-mismatch /
+decide-maxrecdepth / partenat-removal classes, exactly ONE (the Dirichlet chain) was mechanical.
+Low reported error counts (3–5) reliably explode into multi-site rewrites once the head blocker
+clears. Remaining fixable estimate: a handful (<5%) of the ~400 A–M/Erdos<600 residuals, each
+requiring real proof surgery rather than a rename/seam. Recommend the seam be considered exhausted.

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -548,7 +548,7 @@ DiniTheorem	GREEN
 DiniTheoremOQ01OQ01	GREEN	
 DirichletApproximationOQ02	GREEN	
 DirichletApproximationOQ04OQ02	GREEN	
-DirichletsTheorem	RESIDUAL	parse-error
+DirichletsTheorem	GREEN	
 DirichletsTheoremOQ01OQ01	GREEN	
 DirichletsTheoremOQ03	GREEN	
 DissectionOfCubesOQ01OQ02	GREEN	
@@ -2122,8 +2122,8 @@ InclusionExclusionSecondBonferroni	RESIDUAL	unknown-const:sieveLayer_eq_sum_choo
 InfinitudePrimes	GREEN	
 InfinitudePrimes4k1	GREEN	
 InfinitudePrimes4k1OQ03	GREEN	
-InfinitudePrimes4k3OQ01	RESIDUAL	parse-error
-InfinitudePrimes4k3OQ01Q12Q24	RESIDUAL	parse-error
+InfinitudePrimes4k3OQ01	GREEN	
+InfinitudePrimes4k3OQ01Q12Q24	GREEN	
 InfinitudePrimes4k3OQ03	GREEN	
 InfinitudePrimesOQ01	GREEN	
 IntermediateValueTheoremOQ03	GREEN	


### PR DESCRIPTION
## Doctor increment 49 — A–M seam + Erdos<600

**+3 GREEN** (one mechanical cluster):

| File | Class | Fix |
|------|-------|-----|
| `DirichletsTheorem` | signature-drift + doc-on-command | Mathlib lemma signature changes + `/--`→`/-` on `#check` |
| `InfinitudePrimes4k3OQ01` | (dep-blocked) | greened for free once dep greened |
| `InfinitudePrimes4k3OQ01Q12Q24` | (dep-blocked) | greened for free once dep greened |

### Recipes (new)
- `Nat.infinite_setOf_prime_and_eq_mod`: `a` argument is now **implicit** → drop it, pass only `IsUnit a`.
- `Nat.forall_exists_prime_gt_and_modEq` / `_zmodEq`: `n` moved to **first** explicit arg; result reshaped to `∃ p > n, Nat.Prime p ∧ …` (= `∃ p, p > n ∧ …`) → adapt with `obtain ⟨p, hpn, hp, hc⟩ := lemma n hq ha; exact ⟨p, hp, hpn, hc⟩`.
- `Int.gcd a q = 1` → `IsCoprime a ↑q` via `Int.isCoprime_iff_gcd_eq_one.mpr`.
- **`/--` docstring immediately before a `#check` command now hard-errors** ("unexpected token '#check'") → convert to `/-`.
- `convert … using 1; ext; simp only […]` now fully closes the goal in v4.31 → trailing `constructor <;> …` yields "No goals to be solved"; delete the dead tail.

### Statement repairs
None (no false statements touched; all fixes preserve intended-true statements, no weaken/sorry/axiom).

### Verdict: **A–M mechanical seam is DRY**
Probed 16 residuals this increment (parse-error / signature-drift / elab-drift / unknown-const / instance-synth / type-mismatch / decide-maxrecdepth / partenat-removal). Exactly **one** (the Dirichlet chain) was mechanical. Low reported error counts (3–5) reliably explode into multi-site rewrites once the head blocker clears (Erdos598 universe rework, Erdos181OQ01 maxRecDepth, FeuerbachsTheoremOQ05 missing base definition, PartENat-removal cascades). Estimate <5% of the ~400 A–M/Erdos<600 residuals remain mechanical-seam fixable — each now needs real proof surgery. Recommend the A–M seam be considered exhausted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)