### PR TITLE
migrate(v4.31): Doctor increment 50 — deep-rework clusters (A-M) (+5 GREEN)

### DIFF
--- a/proofs/Proofs/BertrandsPostulateOQ03OQ04OQ01.lean
+++ b/proofs/Proofs/BertrandsPostulateOQ03OQ04OQ01.lean
@@ -102,7 +102,8 @@ lemma log_sq_lt_rpow_eventually (C : ℝ) (hC : C > 0) (ε : ℝ) (hε : ε > 0)
     have hCexp_real : C ^ (2 / ε) ≤ (v : ℝ) :=
       le_trans (Nat.le_ceil _) (by exact_mod_cast hCexp_le)
     calc C = (C ^ (2 / ε)) ^ (ε / 2) := by
-            rw [← rpow_mul hC.le]; congr 1; field_simp
+            rw [← rpow_mul hC.le]
+            rw [show (2 / ε) * (ε / 2) = 1 by field_simp, rpow_one]
       _ ≤ (v : ℝ) ^ (ε / 2) := rpow_le_rpow (rpow_nonneg hC.le _) hCexp_real hε2.le
   calc C * (Real.log (v : ℝ)) ^ 2
       ≤ C * (1 / 4 * (v : ℝ) ^ (ε / 2)) :=
@@ -127,7 +128,8 @@ lemma nextPrimeFrom_prime (x : ℕ) : Nat.Prime (nextPrimeFrom x) :=
 
 /-- nextPrimeFrom x ≥ x. -/
 lemma nextPrimeFrom_ge (x : ℕ) : x ≤ nextPrimeFrom x := by
-  have := (Nat.find_spec (Nat.infinite_setOf_prime.exists_gt (x - 1))).2
+  have h : x - 1 < nextPrimeFrom x :=
+    (Nat.find_spec (Nat.infinite_setOf_prime.exists_gt (x - 1))).2
   omega
 
 /-- **Bridge Axiom**: Cramér's gap bound implies nextPrime(x) ≤ x + C · log(x)².
@@ -185,34 +187,18 @@ theorem cramer_implies_primeGapConjecture_eventually (ε : ℝ) (hε : 0 < ε) :
 -- PART 4: Full PrimeGapConjecture via BHP for Small x
 -- ============================================================
 
-/-- **Cramér's conjecture implies PrimeGapConjecture(ε) for all ε > 0.**
+/-- **Cramér's conjecture implies the prime-gap existence property for all ε > 0.**
 
-    For ε ≥ 0.525: use BHP (2001), which is unconditional.
-    For ε < 0.525: use the eventual result + BHP for small x.
-
-    The combination gives PrimeGapConjecture(ε) for ALL x ≥ 2. -/
+    For ε ≥ 0.525 this holds unconditionally (BHP 2001) for every x ≥ 2, and we
+    package that as an eventual statement. For ε < 0.525 the content of Cramér is
+    genuinely *asymptotic*: only for sufficiently large x is the Cramér gap
+    C·log(x)² smaller than x^ε (for small x with ε < 0.525 the interval [x, x+x^ε]
+    is strictly narrower than the BHP interval [x, x+x^0.525], so BHP does **not**
+    supply a prime there — the exponents point the wrong way). Hence the honest,
+    intended-true conclusion is the eventual existence of a prime in [x, x+x^ε]. -/
 theorem cramer_implies_primeGapConjecture (ε : ℝ) (hε : 0 < ε) :
-    PrimeGapConjecture ε := by
-  by_cases h : ε ≥ 0.525
-  · exact prime_gap_conjecture_monotone h BertrandsPostulateOQ03.prime_gap_conjecture_bhp
-  · push_neg at h
-    intro x hx
-    obtain ⟨N, hN⟩ := Filter.eventually_atTop.mp
-                        (cramer_implies_primeGapConjecture_eventually ε hε)
-    by_cases hxN : x ≥ N
-    · obtain ⟨p, hp, hle, hub⟩ := hN x hxN
-      exact ⟨p, hp, by exact_mod_cast hle, hub⟩
-    · push_neg at hxN
-      obtain ⟨p, hp, hle, hub⟩ :=
-        BertrandsPostulateOQ03.prime_gap_conjecture_bhp x hx
-      exact ⟨p, hp, hle, by
-        have hx1 : (x : ℝ) ≥ 1 := by linarith
-        calc (p : ℝ) ≤ x + x ^ (0.525 : ℝ) := hub
-          _ ≤ x + x ^ ε := by
-              have : x ^ ε ≥ x ^ (0.525 : ℝ) := by
-                apply Real.rpow_le_rpow_of_exponent_ge hx1
-                linarith
-              linarith⟩
+    ∀ᶠ x : ℕ in atTop, ∃ p : ℕ, Nat.Prime p ∧ x ≤ p ∧ (p : ℝ) ≤ (x : ℝ) + (x : ℝ) ^ ε :=
+  cramer_implies_primeGapConjecture_eventually ε hε
 
 -- ============================================================
 -- PART 5: The Density Gap — Why ShortIntervalPNT Needs More
@@ -237,14 +223,15 @@ theorem existence_is_weaker_than_density {ε : ℝ} (hε : 0 < ε) :
 /-- **Summary**: The Cramér conjecture bridges the existence hierarchy.
 
     Known: PrimeGapConjecture(0.525) unconditionally (BHP).
-    Cramér: PrimeGapConjecture(ε) for all ε > 0 (this file).
+    Cramér: existence in [x, x+x^ε] for all ε > 0 *eventually* (this file).
     Open: PrimeGapConjecture(0) — even constant-size gaps are unknown.
     Open: ShortIntervalPNT(ε) — density for any ε < 1 (even under Cramér). -/
 theorem cramer_hierarchy :
-    -- (1) Unconditional: existence in [x, x + x^0.525]
+    -- (1) Unconditional: existence in [x, x + x^0.525] for all x ≥ 2
     PrimeGapConjecture 0.525 ∧
-    -- (2) Under Cramér: existence in [x, x + x^ε] for ALL ε > 0 (this file's main result)
-    (∀ ε : ℝ, 0 < ε → PrimeGapConjecture ε) ∧
+    -- (2) Under Cramér: existence in [x, x + x^ε] for ALL ε > 0, eventually
+    (∀ ε : ℝ, 0 < ε →
+      ∀ᶠ x : ℕ in atTop, ∃ p : ℕ, Nat.Prime p ∧ x ≤ p ∧ (p : ℝ) ≤ (x : ℝ) + (x : ℝ) ^ ε) ∧
     -- (3) Under RH: density in [x, x + x^(1/2+ε)] (from parent, not Cramér)
     (PrimeNumberTheorem.RiemannHypothesis →
       ∀ ε : ℝ, 0 < ε → ShortIntervalPNT (1/2 + ε)) :=

--- a/proofs/Proofs/Erdos1112Problem.lean
+++ b/proofs/Proofs/Erdos1112Problem.lean
@@ -101,11 +101,17 @@ For k = 2 and gaps [2, 3], r = 2 suffices.
 -/
 
 /-- **Erdős-Graham Theorem (1980):**
-If B is 2-lacunary starting from b₁ ≥ 5, then there exists A
-with gaps in [2, 3] such that (A + A) ∩ B = ∅.
-This shows r₂(2, 3) = 2. -/
+If B is 2-lacunary, then there exists A with gaps in [2, 3] such that
+(A + A) ∩ B = ∅. This shows r₂(2, 3) = 2.
+
+(The original starting condition b₁ ≥ 5 is not needed for the avoidance
+conclusion: a bounded-gap A can always be shifted past the finitely many small
+elements of any lacunary B. Requiring it left the b₁ < 5 case of r2_23_equals_2
+without a valid witness — the constructive fallback A n = 2n+1 does NOT avoid an
+arbitrary lacunary B, since {odd}+{odd} = evens can meet B. We therefore state
+the axiom in its intended-true full form.) -/
 axiom erdos_graham_1980 :
-    ∀ B : ℕ → ℕ, IsLacunary 2 B → B 0 ≥ 5 →
+    ∀ B : ℕ → ℕ, IsLacunary 2 B →
       ∃ A : ℕ → ℕ, HasBoundedGaps 2 3 A ∧
         (TwoFoldSumset (SeqRange A)) ∩ (SeqRange B) = ∅
 
@@ -120,15 +126,10 @@ theorem r2_23_equals_2 : RkExists 2 2 3 := by
   constructor
   · omega
   · intro B hB
-    have h := erdos_graham_1980 B hB
-    by_cases hB0 : B 0 ≥ 5
-    · obtain ⟨A, hA, hDisj⟩ := h hB0
-      use A
-      constructor
-      · exact hA
-      · rw [← twofold_eq_kfold]
-        exact hDisj
-    · exact ⟨fun n => 2 * n + 1, ⟨by intro i; omega, by intro i; omega, by intro i; omega⟩, by simp [KFoldSumset, SeqRange]; ext; constructor <;> intro h <;> simp_all⟩
+    obtain ⟨A, hA, hDisj⟩ := erdos_graham_1980 B hB
+    refine ⟨A, hA, ?_⟩
+    rw [← twofold_eq_kfold]
+    exact hDisj
 
 /- ##Part V: Bollobás-Hegyvári-Jin Result (1997)
 

--- a/proofs/Proofs/Erdos1125Problem.lean
+++ b/proofs/Proofs/Erdos1125Problem.lean
@@ -47,9 +47,14 @@ The condition 2f(x) ≤ f(x+h) + f(x+2h) for all x and h > 0.
 def satisfiesKemperman (f : ℝ → ℝ) : Prop :=
   ∀ x : ℝ, ∀ h : ℝ, h > 0 → 2 * f x ≤ f (x + h) + f (x + 2*h)
 
-/-- **Alternative formulation:** f(x) - f(x+h) ≤ f(x+h) - f(x+2h). -/
+/-- **Alternative formulation:** f(x) - f(x+h) ≤ f(x+2h) - f(x).
+
+    This is the correct rearrangement of 2f(x) ≤ f(x+h) + f(x+2h): moving one
+    copy of f(x) to each side gives f(x) - f(x+h) ≤ f(x+2h) - f(x). (The earlier
+    right-hand side f(x+h) - f(x+2h) was a sign typo — it is not equivalent to
+    the Kemperman inequality.) -/
 def satisfiesKempermanAlt (f : ℝ → ℝ) : Prop :=
-  ∀ x : ℝ, ∀ h : ℝ, h > 0 → f x - f (x + h) ≤ f (x + h) - f (x + 2*h)
+  ∀ x : ℝ, ∀ h : ℝ, h > 0 → f x - f (x + h) ≤ f (x + 2*h) - f x
 
 /-- The two formulations are equivalent. -/
 theorem kemperman_equiv (f : ℝ → ℝ) :
@@ -109,11 +114,12 @@ theorem kemperman_question_resolved : kemperman_question :=
 
 /- ## Part VI: Interpretation and Context -/
 
-/-- The Kemperman inequality prevents certain "local maximum" patterns.
-    Specifically, we cannot have f(x+h) < f(x) and f(x+h) < f(x+2h) too strongly. -/
+/-- The Kemperman inequality prevents certain "local maximum" patterns:
+    the increment f(x+h) - f(x) is at least as large as the deficit f(x) - f(x+2h).
+    Equivalently, f(x) - f(x+h) ≤ f(x+2h) - f(x). -/
 theorem kemperman_interpretation (f : ℝ → ℝ) (hf : satisfiesKemperman f)
     (x h : ℝ) (hh : h > 0) :
-    f x - f (x + h) ≤ f (x + 2*h) - f (x + h) := by
+    f x - f (x + h) ≤ f (x + 2*h) - f x := by
   have := hf x h hh
   linarith
 
@@ -122,23 +128,41 @@ theorem kemperman_interpretation (f : ℝ → ℝ) (hf : satisfiesKemperman f)
 /-- Constant functions satisfy Kemperman. -/
 theorem constant_satisfies (c : ℝ) : satisfiesKemperman (fun _ => c) := by
   intro x h _
-  ring_nf
+  simp only
+  linarith
 
-/-- Linear functions f(x) = ax + b satisfy Kemperman. -/
-theorem linear_satisfies (a b : ℝ) : satisfiesKemperman (fun x => a * x + b) := by
+/-- Non-decreasing linear functions f(x) = ax + b (with a ≥ 0) satisfy Kemperman.
+
+    The `0 ≤ a` hypothesis is required: the Kemperman inequality
+    2f(x) ≤ f(x+h) + f(x+2h) reduces here to 0 ≤ 3·a·h, which fails when a < 0.
+    (This corrects an earlier version that dropped the sign hypothesis.) -/
+theorem linear_satisfies (a b : ℝ) (ha : 0 ≤ a) :
+    satisfiesKemperman (fun x => a * x + b) := by
   intro x h hh
-  ring_nf
+  have : (0 : ℝ) ≤ 3 * a * h := by positivity
+  simp only
+  nlinarith [this]
 
-/-- Convex functions satisfy Kemperman. -/
-axiom convex_satisfies (f : ℝ → ℝ) :
-    (∀ x y t : ℝ, 0 ≤ t → t ≤ 1 → f (t * x + (1 - t) * y) ≤ t * f x + (1 - t) * f y) →
-    satisfiesKemperman f
-
-/-- The function f(x) = x² satisfies Kemperman (it's convex). -/
-theorem square_satisfies : satisfiesKemperman (fun x => x^2) := by
+/-- Any non-decreasing function satisfies Kemperman: if f x ≤ f (x+h) ≤ f (x+2h)
+    then 2 f x ≤ f x + f (x+2h) ≤ f (x+h) + f (x+2h). This is the correct
+    general source of examples (the Kemperman inequality is a one-sided condition
+    that forbids local-maximum patterns, so monotone-up functions trivially
+    satisfy it — whereas arbitrary convex functions such as x² do NOT). -/
+theorem nonDecreasing_satisfies (f : ℝ → ℝ) (hf : isNonDecreasing f) :
+    satisfiesKemperman f := by
   intro x h hh
-  ring_nf
-  nlinarith [sq_nonneg h]
+  have h1 : f x ≤ f (x + h) := hf x (x + h) (by linarith)
+  have h2 : f x ≤ f (x + 2 * h) := hf x (x + 2 * h) (by linarith)
+  linarith
+
+/-- The function f(x) = x² does **not** satisfy the Kemperman inequality:
+    at x = -2h the second point pattern violates 2f(x) ≤ f(x+h) + f(x+2h).
+    (Kemperman's 2f(x) ≤ f(x+h)+f(x+2h) is a one-sided condition, *not* midpoint
+    convexity, so convex functions need not satisfy it.) -/
+theorem square_not_satisfies : ¬ satisfiesKemperman (fun x => x ^ 2) := by
+  intro h
+  have := h (-2) 1 (by norm_num)
+  norm_num at this
 
 /- ## Part VIII: Summary
 

--- a/proofs/Proofs/FermatsLastTheoremOQ03.lean
+++ b/proofs/Proofs/FermatsLastTheoremOQ03.lean
@@ -38,11 +38,14 @@ axiom flt_over_Q (n : ℕ) (hn : n ≥ 3) : ¬ FermatEquation ℚ n
 -- Part II: Small Exponents Always Have Solutions
 -- ============================================================
 
-/-- For n = 1, x + y = z always has nontrivial solutions. -/
-theorem fermat_n1 (K : Type*) [CommRing K] [Nontrivial K] :
+/-- For n = 1, x + y = z has the nontrivial solution (1, 1, 2), provided the
+    characteristic is not 2 (otherwise 1 + 1 = 0 and z = 0 is excluded).
+    The `NeZero (2 : K)` hypothesis records exactly the char ≠ 2 requirement. -/
+theorem fermat_n1 (K : Type*) [CommRing K] [Nontrivial K] [NeZero (2 : K)] :
     FermatEquation K 1 := by
   refine ⟨1, 1, 1 + 1, one_ne_zero, one_ne_zero, ?_, ?_⟩
-  · intro h; exact two_ne_zero (add_left_cancel (show (1 : K) + 1 = 1 + 0 from by rw [h, add_zero]))
+  · have : (1 : K) + 1 = (2 : K) := by norm_num
+    rw [this]; exact NeZero.ne (2 : K)
   · simp [pow_one]
 
 /-- For n = 2, x² + y² = z² has solutions (Pythagorean triples). -/

--- a/proofs/Proofs/KummerTheoremOQ03.lean
+++ b/proofs/Proofs/KummerTheoremOQ03.lean
@@ -22,6 +22,8 @@ open Finset Nat
 
 namespace KummerTheoremOQ03
 
+open KummerTheorem
+
 -- ══════════════════════════════════════════════════════════════════
 -- § Part I: Divisibility by p^m via Carry Count
 -- ══════════════════════════════════════════════════════════════════
@@ -39,9 +41,7 @@ theorem choose_dvd_prime_pow_iff {p n k b m : ℕ} (hp : p.Prime) (hkn : k ≤ n
     (hnb : Nat.log p n < b) :
     m ≤ carryCount p n k b ↔
     (p ^ m : ℕ) ∣ Nat.choose n k := by
-  unfold carryCount
-  rw [← PartENat.coe_le_coe, ← kummer hp hkn hnb]
-  exact (multiplicity.pow_dvd_iff_le_multiplicity hp.prime (Nat.choose_pos hkn).ne').symm
+  rw [pow_dvd_iff_le_emultiplicity, kummer hp hkn hnb, Nat.cast_le, carryCount]
 
 -- ══════════════════════════════════════════════════════════════════
 -- § Part II: Row of Pascal's Triangle at p^n
@@ -65,8 +65,9 @@ theorem pascal_row_prime_power_div (p n k : ℕ) (hp : p.Prime)
     Special case of the prime power row result with n = 1. -/
 theorem choose_prime_div (p k : ℕ) (hp : p.Prime) (hk : k ≠ 0) (hkp : k < p) :
     p ∣ Nat.choose p k := by
-  have : k ≠ p ^ 1 := by simp; omega
-  exact pascal_row_prime_power_div p 1 k hp hk this (by omega)
+  have : k ≠ p ^ 1 := by rw [pow_one]; omega
+  have h := pascal_row_prime_power_div p 1 k hp hk this (by rw [pow_one]; omega)
+  rwa [pow_one] at h
 
 /-- C(p^2, k) for 0 < k < p^2 is divisible by p.
     Pattern in the p²-th row. -/
@@ -85,7 +86,7 @@ theorem choose_coprime_of_no_carries {p n k b : ℕ} (hp : p.Prime) (hkn : k ≤
     ¬(p ∣ Nat.choose n k) := by
   intro hdvd
   have h1 : 1 ≤ carryCount p n k b := by
-    rw [(choose_dvd_prime_pow_iff hp hkn hnb).symm]
+    rw [choose_dvd_prime_pow_iff hp hkn hnb]
     simpa using hdvd
   omega
 

--- a/proofs/batch2/STATUS.md
+++ b/proofs/batch2/STATUS.md
@@ -2449,3 +2449,70 @@ decide-maxrecdepth / partenat-removal classes, exactly ONE (the Dirichlet chain)
 Low reported error counts (3–5) reliably explode into multi-site rewrites once the head blocker
 clears. Remaining fixable estimate: a handful (<5%) of the ~400 A–M/Erdos<600 residuals, each
 requiring real proof surgery rather than a rename/seam. Recommend the seam be considered exhausted.
+
+---
+
+## Increment 50 (Doctor-b, deep-rework clusters, A–M + Erdos<600)
+
+**+5 GREEN**. All 4 operator-assigned statement-repair files fixed to intended-true form,
+plus one partenat-cluster file.
+
+### Statement repairs (intended-true, never weakened/sorried)
+- **BertrandsPostulateOQ03OQ04OQ01** — false exponent inequality. `cramer_implies_primeGapConjecture`
+  small-x branch asserted `x^0.525 ≤ x^ε` for ε<0.525, base x≥2 (FALSE: BHP's interval is strictly
+  WIDER, cannot supply a prime in the narrower target). Corrected to the genuine asymptotic
+  (eventual) conclusion; updated `cramer_hierarchy` clause (2) to match. Plus rpow
+  `(2/ε)*(ε/2)=1` via `show ... by field_simp; rpow_one`; `nextPrimeFrom_ge` bind find_spec.2 to
+  a typed hyp so omega sees the same opaque term.
+- **FermatsLastTheoremOQ03** — `fermat_n1` (solution (1,1,1+1)) false in char 2 (1+1=0⇒z=0). Added
+  `[NeZero (2:K)]` (the intended char≠2 hypothesis), proved z=2≠0.
+- **Erdos1125Problem** — `kemperman_equiv` sign typo (`satisfiesKempermanAlt` RHS `f(x+h)-f(x+2h)`
+  should be `f(x+2h)-f(x)`); matched `kemperman_interpretation` to the same true RHS. Follow-through:
+  the example theorems were also false vs the literal one-sided Kemperman inequality — `linear_satisfies`
+  needs `0≤a`; `square_satisfies` (x² convex ⇒ Kemperman) is FALSE (violated at x=-2h) → replaced with
+  true `square_not_satisfies` + `nonDecreasing_satisfies`; removed the false `convex_satisfies` axiom.
+- **Erdos1112Problem** — `r2_23_equals_2` b₁<5 fallback used `A n=2n+1` (FALSE: {odd}+{odd}=evens can
+  meet lacunary B). Dropped the artefactual `B 0 ≥ 5` hyp from `erdos_graham_1980` axiom (avoidance
+  holds for all 2-lacunary B) and removed the bogus branch.
+
+### partenat/emultiplicity cluster — RECIPE + one green
+- **KummerTheoremOQ03** (+GREEN). Parent KummerTheorem already migrated `kummer` to
+  `emultiplicity p _ = (_ : ℕ∞)`. Recipe:
+  - `multiplicity.pow_dvd_iff_le_multiplicity` → `pow_dvd_iff_le_emultiplicity`
+    (`p^k ∣ b ↔ (↑k : ℕ∞) ≤ emultiplicity p b`).
+  - `PartENat.coe_le_coe` → `Nat.cast_le` (on ℕ∞).
+  - qualify parent lemmas: `open KummerTheorem` (prime_dvd_choose_prime_pow, kummer were unqualified).
+  - `p^1` no longer defeq for omega: `rw [pow_one]` before omega, `rwa [pow_one]` to bridge
+    `(p^1).choose` vs `p.choose`.
+  - `.symm` on a fresh iff rewrote the wrong side — drop it.
+  - Also useful (from Chebyshev probe): `Nat.factorization_factorial hp (log p n < b)` gives
+    `(n!).factorization p = ∑ i∈Ico 1 b, n/p^i` DIRECTLY over ℕ (bypasses the whole
+    PartENat/multiplicity_eq_factorization detour). `Nat.log_lt` → `Nat.log_lt_self p (x≠0)`.
+
+**Probed-and-reverted (genuinely deep, NOT the clean recipe)**:
+- **ChebyshevPNTBridgeOQ01** (partenat). The `factorization_factorial`/`log_lt_self` head cleared
+  (2 lemmas), but the file has ~10 independent downstream sites: div-carry `2n/p^i - 2(n/p^i) ≤ 1`
+  (omega can't do div; needs manual `Nat.add_mul_div_right` decomposition and it fought back on
+  `set d`), `Nat.div_eq_zero_iff` arity change, two Type mismatches, an `unterminated comment` near
+  L199. Real multi-site surgery.
+- **GeneralizeProofs cluster** (Erdos643Problem, LawsOfLargeNumbersOQ01Aristotle): the "delete
+  vendored block" recipe is NOT clean here — these files have NO active `import Mathlib` (the only
+  one is commented inside the header `/- ```lean ``` -/`), so the vendored `namespace
+  Harmonic.GeneralizeProofs` block was anchoring resolution. Fix = PREPEND a real `import Mathlib`
+  AND delete the block (lines 94–296 / 78–280). That gets Erdos643 to deep proof timeouts
+  (heartbeat/whnf, kernel unknown constant — reverted) and LawsOfLargeNumbers to just 5 errors, of
+  which 3 greened cheaply (`tendsto_inverse_atTop_nhds_zero_nat`→`tendsto_one_div_atTop_nhds_zero_nat`
+  with `(𝕜:=ℝ)` pin; `LT.lt.not_le`→`.not_ge`; an aesop-loop congr' rewritten explicitly) but the
+  last 2 are deep probability API drift (`integral_add` pattern in a covariance unfolding;
+  `Kernel.indepFun/indepSet_iff_measure...`) — reverted.
+
+**decide-maxrecdepth cluster**: in my partition only AreaOfCircleOQ01OQ03 and ErdosMordellChordIdentity
+carry `set_option maxRecDepth`; both fail on proof drift (simp/rewrite/grind), NOT recursion budget.
+Not a bump-the-number cluster here.
+
+**VERDICT**: the statement-repair files were the highest-yield deep targets (4/4 greened — each a
+genuine content bug: false direction / missing char hyp / sign typo / unsound constructive branch).
+The partenat cluster is deep EXCEPT where a green parent already did the emultiplicity migration
+(KummerTheoremOQ03). The GeneralizeProofs and decide clusters are NOT mechanical in this partition —
+they bottom out in domain proof-drift (probability/measure, div arithmetic) after the seam layer
+clears. Recipes above are reusable; new greens now require real proof surgery.

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -202,7 +202,7 @@ BernoulliInequalityOQ01OQ02OQ01	GREEN
 BertrandsPostulateOQ03	GREEN	
 BertrandsPostulateOQ03OQ04	GREEN	
 BertrandsPostulateOQ03OQ04Aristotle	GREEN	
-BertrandsPostulateOQ03OQ04OQ01	RESIDUAL	proof-drift
+BertrandsPostulateOQ03OQ04OQ01	GREEN	
 BertrandsPostulateOQ03OQ04OQ03	GREEN	
 BetaCentralBinomialExplicitRate	GREEN	
 BetaCentralBinomialExplicitRateOQ02	GREEN	

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -818,7 +818,7 @@ Erdos110HigherCardinals	GREEN
 Erdos110Problem	RESIDUAL	unknown-const:lambie_hanson_counterexample
 Erdos1110OQ01	GREEN	
 Erdos1111Problem	GREEN	
-Erdos1112Problem	RESIDUAL	proof-drift
+Erdos1112Problem	GREEN	
 Erdos1113Problem	GREEN	
 Erdos1114Problem	GREEN	
 Erdos1115Problem	GREEN	

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -1972,7 +1972,7 @@ FairGamesTheoremOQ03Aristotle	RESIDUAL	type-mismatch
 FatouLemmaOQ01OQ02	GREEN	
 FermatTwoSquaresOQ04	GREEN	
 FermatTwoSquaresOQ04OQ01	GREEN	
-FermatsLastTheoremOQ03	RESIDUAL	type-mismatch
+FermatsLastTheoremOQ03	GREEN	
 FeuerbachsTheoremDefsOQ04	GREEN	type-mismatch
 FeuerbachsTheoremOQ01Aristotle	GREEN	
 FeuerbachsTheoremOQ01OQ03	RESIDUAL	unknown-const:h1

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -833,7 +833,7 @@ Erdos1121Problem	RESIDUAL	instance-synth
 Erdos1122Problem	GREEN	
 Erdos1123Problem	RESIDUAL	parse-error
 Erdos1124Problem	GREEN	
-Erdos1125Problem	RESIDUAL	proof-drift
+Erdos1125Problem	GREEN	
 Erdos1126Problem	GREEN	unknown-const:measurable_additive_is_linear
 Erdos1127Problem	RESIDUAL	instance-synth
 Erdos1128Problem	RESIDUAL	proof-drift

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -2181,7 +2181,7 @@ KroneckersJugendtraumStarkRankOne	GREEN
 KummerTheorem	GREEN	
 KummerTheoremOQ01OQ01	GREEN	
 KummerTheoremOQ02	PRE-EXISTING	never-compiled:n
-KummerTheoremOQ03	RESIDUAL	partenat-removal
+KummerTheoremOQ03	GREEN	
 LHopitalOQ02Incomplete01	GREEN	
 LHopitalOQ03	GREEN	
 LHopitalOQ04	GREEN	


### PR DESCRIPTION
Doctor increment 50 — deep-rework phase (A–M basenames + Erdos<600 partition).

## Statement repairs (operator-directed; fixed to intended-true, not weakened/sorried)
All 4 assigned statement-repair files greened:

- **BertrandsPostulateOQ03OQ04OQ01** — small-x branch asserted `x^0.525 ≤ x^ε` for ε<0.525 with base x≥2 (FALSE; BHP's interval is strictly wider, so it can't supply a prime in the narrower target). Corrected `cramer_implies_primeGapConjecture` to the genuine asymptotic (eventual) conclusion; updated `cramer_hierarchy` clause (2) to match. Plus v4.31 rpow/omega seam fixes.
- **FermatsLastTheoremOQ03** — `fermat_n1` (solution (1,1,1+1) over any Nontrivial CommRing) is false in char 2 (1+1=0 ⇒ z=0). Added `[NeZero (2:K)]` (the intended char≠2 hypothesis) and proved z=2≠0.
- **Erdos1125Problem** — `kemperman_equiv` sign typo (`satisfiesKempermanAlt` RHS wrong); corrected to the true rearrangement `f(x)-f(x+h) ≤ f(x+2h)-f(x)` and matched `kemperman_interpretation`. Also the example theorems were false against the literal (one-sided) Kemperman inequality: `linear_satisfies` needed `0≤a`; `square_satisfies` (x² convex ⇒ Kemperman) is FALSE (x² violates it at x=-2h) → replaced with true `square_not_satisfies` + `nonDecreasing_satisfies`; removed the false `convex_satisfies` axiom.
- **Erdos1112Problem** — `r2_23_equals_2` b₁<5 fallback used `A n=2n+1` as an avoidance witness, but {odd}+{odd}=evens can meet an arbitrary lacunary B (FALSE branch). Corrected to the intended-true form: dropped the artefactual `B 0 ≥ 5` hypothesis from the `erdos_graham_1980` axiom (avoidance holds for all 2-lacunary B) and removed the bogus branch.

## Honest read on the deep clusters
The mechanical A–M seam is confirmed dry (per inc 49). The statement-repair files were the highest-yield deep targets and all 4 greened cleanly — each was a genuine content/statement bug (false direction / missing char hypothesis / sign typo / unsound constructive branch) rather than a mechanical rename. Continuing into the partenat / GeneralizeProofs / decide-maxrecdepth clusters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)