### PR TITLE
migrate(v4.31): Doctor increment 51 — deep-rework clusters (N-Z) (+4 GREEN)

### DIFF
--- a/proofs/Proofs/Erdos1123Problem.lean
+++ b/proofs/Proofs/Erdos1123Problem.lean
@@ -30,22 +30,71 @@ import Mathlib.Data.Set.Basic
 import Mathlib.Data.Real.Basic
 import Mathlib.Topology.Basic
 
-open scoped Classical
+open scoped Classical symmDiff
 
 namespace Erdos1123
 
 /- ## Part I: Density Definitions -/
 
+/-- Counting function: |A ∩ {0,...,n-1}|. -/
+noncomputable def countUpTo (A : Set ℕ) (n : ℕ) : ℕ :=
+  (Finset.filter (· ∈ A) (Finset.range n)).card
+
 /-- A set has natural density zero: |A ∩ {0,...,n-1}| / n → 0 as n → ∞. -/
 def hasDensityZero (A : Set ℕ) : Prop :=
-  ∀ ε > 0, ∃ N, ∀ n ≥ N, (Finset.filter (· ∈ A) (Finset.range n)).card < ε * n
+  ∀ ε : ℝ, ε > 0 → ∃ N, ∀ n ≥ N, (countUpTo A n : ℝ) < ε * n
 
 /-- A set has logarithmic density zero:
     (1/log n) · Σ_{k ∈ A, k ≤ n} (1/k) → 0 as n → ∞. -/
 def hasLogDensityZero (A : Set ℕ) : Prop :=
-  ∀ ε > 0, ∃ N : ℕ, ∀ n ≥ N,
-    (Finset.filter (· ∈ A) (Finset.range n)).card < ε * n
+  ∀ ε : ℝ, ε > 0 → ∃ N : ℕ, ∀ n ≥ N,
+    (countUpTo A n : ℝ) < ε * n
     -- Simplified: actual definition involves harmonic partial sums
+
+/-- The counting function is subadditive under union of sets. -/
+theorem countUpTo_union_le (A B : Set ℕ) (n : ℕ) :
+    countUpTo (A ∪ B) n ≤ countUpTo A n + countUpTo B n := by
+  classical
+  unfold countUpTo
+  refine le_trans (Finset.card_le_card ?_) (Finset.card_union_le _ _)
+  intro x hx
+  simp only [Finset.mem_filter, Finset.mem_range, Set.mem_union] at hx ⊢
+  rcases hx.2 with h | h
+  · exact Finset.mem_union_left _ (by simp [hx.1, h])
+  · exact Finset.mem_union_right _ (by simp [hx.1, h])
+
+/-- The counting function is monotone in the set. -/
+theorem countUpTo_mono {A B : Set ℕ} (h : A ⊆ B) (n : ℕ) :
+    countUpTo A n ≤ countUpTo B n := by
+  classical
+  unfold countUpTo
+  apply Finset.card_le_card
+  intro x hx
+  simp only [Finset.mem_filter, Finset.mem_range] at hx ⊢
+  exact ⟨hx.1, h hx.2⟩
+
+/-- Density zero is monotone: a subset of a density-zero set is density zero. -/
+theorem hasDensityZero_mono {A B : Set ℕ} (h : A ⊆ B) (hB : hasDensityZero B) :
+    hasDensityZero A := by
+  intro ε hε
+  obtain ⟨N, hN⟩ := hB ε hε
+  exact ⟨N, fun n hn => lt_of_le_of_lt
+    (by exact_mod_cast countUpTo_mono h n) (hN n hn)⟩
+
+/-- Density zero is closed under union. -/
+theorem hasDensityZero_union {A B : Set ℕ}
+    (hA : hasDensityZero A) (hB : hasDensityZero B) : hasDensityZero (A ∪ B) := by
+  intro ε hε
+  obtain ⟨N₁, hN₁⟩ := hA (ε / 2) (by linarith)
+  obtain ⟨N₂, hN₂⟩ := hB (ε / 2) (by linarith)
+  refine ⟨max N₁ N₂, fun n hn => ?_⟩
+  have h1 := hN₁ n (le_trans (le_max_left _ _) hn)
+  have h2 := hN₂ n (le_trans (le_max_right _ _) hn)
+  have hu : (countUpTo (A ∪ B) n : ℝ) ≤ (countUpTo A n : ℝ) + (countUpTo B n : ℝ) := by
+    exact_mod_cast countUpTo_union_le A B n
+  calc (countUpTo (A ∪ B) n : ℝ) ≤ (countUpTo A n : ℝ) + (countUpTo B n : ℝ) := hu
+    _ < ε / 2 * n + ε / 2 * n := by linarith
+    _ = ε * n := by ring
 
 /-- Natural density zero implies logarithmic density zero.
     The converse is false: there exist sets with δ(A) = 0 but d(A) > 0. -/
@@ -60,21 +109,52 @@ axiom log_density_ideal_strictly_larger :
 
 /- ## Part II: The Boolean Algebras -/
 
-/-- B₁ = P(ℕ) / I₁ where I₁ = {A : d(A) = 0}.
-    Two sets are equivalent iff their symmetric difference has density 0. -/
-def B1 : Type := Quotient (Setoid.mk
-  (fun A B : Set ℕ => hasDensityZero (A ∆ B))
-  ⟨fun _ => by simp [hasDensityZero],
-   fun h => by simp [Set.symmDiff_comm] at h ⊢; exact h,
-   fun _ _ => by simp [hasDensityZero]; intro _ _; trivial⟩)
+/- B₁ = P(ℕ) / I₁ where I₁ = {A : d(A) = 0}.
+   Two sets are equivalent iff their symmetric difference has density 0. -/
+/-- The empty set has density zero. -/
+theorem hasDensityZero_empty : hasDensityZero (∅ : Set ℕ) := by
+  intro ε hε
+  refine ⟨1, fun n hn => ?_⟩
+  have : countUpTo (∅ : Set ℕ) n = 0 := by
+    simp [countUpTo]
+  rw [this]
+  have hn1 : (1 : ℝ) ≤ (n : ℝ) := by exact_mod_cast hn
+  have hnpos : (0 : ℝ) < (n : ℝ) := by linarith
+  simpa using mul_pos hε hnpos
 
-/-- B₂ = P(ℕ) / I₂ where I₂ = {A : δ(A) = 0}.
-    Two sets are equivalent iff their symmetric difference has log-density 0. -/
-def B2 : Type := Quotient (Setoid.mk
-  (fun A B : Set ℕ => hasLogDensityZero (A ∆ B))
-  ⟨fun _ => by simp [hasLogDensityZero],
-   fun h => by simp [Set.symmDiff_comm] at h ⊢; exact h,
-   fun _ _ => by simp [hasLogDensityZero]; intro _ _; trivial⟩)
+/-- The density-zero symmetric-difference relation is an equivalence.
+    Reflexivity: A ∆ A = ∅ has density zero. Symmetry: A ∆ B = B ∆ A.
+    Transitivity: A ∆ C ⊆ (A ∆ B) ∪ (B ∆ C), density zero is subset- and
+    union-closed. -/
+def densityZeroSetoid : Setoid (Set ℕ) where
+  r A B := hasDensityZero (A ∆ B)
+  iseqv := {
+    refl := fun A => by simpa [symmDiff_self] using hasDensityZero_empty
+    symm := fun {A B} h => by rwa [symmDiff_comm] at h
+    trans := fun {A B C} hAB hBC =>
+      hasDensityZero_mono (symmDiff_triangle A B C)
+        (by simpa [Set.sup_eq_union] using hasDensityZero_union hAB hBC)
+  }
+
+def B1 : Type := Quotient densityZeroSetoid
+
+/- B₂ = P(ℕ) / I₂ where I₂ = {A : δ(A) = 0}.
+   Two sets are equivalent iff their symmetric difference has log-density 0. -/
+/-- `hasLogDensityZero` and `hasDensityZero` share the same (simplified) body,
+    so the log-density symmetric-difference relation is likewise an equivalence. -/
+def logDensityZeroSetoid : Setoid (Set ℕ) where
+  r A B := hasLogDensityZero (A ∆ B)
+  iseqv := {
+    refl := fun A => by
+      show hasDensityZero _
+      simpa [symmDiff_self] using hasDensityZero_empty
+    symm := fun {A B} h => by rwa [symmDiff_comm] at h
+    trans := fun {A B C} hAB hBC =>
+      hasDensityZero_mono (symmDiff_triangle A B C)
+        (by simpa [Set.sup_eq_union] using hasDensityZero_union hAB hBC)
+  }
+
+def B2 : Type := Quotient logDensityZeroSetoid
 
 /-- The Erdős-Ulam question: are B₁ and B₂ isomorphic? -/
 def erdos_ulam_question : Prop := ∃ f : B1 → B2, Function.Bijective f

--- a/proofs/Proofs/Erdos724Problem.lean
+++ b/proofs/Proofs/Erdos724Problem.lean
@@ -101,7 +101,8 @@ Key values:
 - f(p^k) = p^k - 1 for prime powers (projective plane construction)
 -/
 noncomputable def maxMOLS (n : ℕ) : ℕ∞ :=
-  ⨆ (S : Finset (Fin n → Fin n → Fin n)) (hS : MutuallyOrthogonal (S : Set _)), (S.card : ℕ∞)
+  ⨆ (S : Finset (Fin n → Fin n → Fin n))
+    (_ : MutuallyOrthogonal (↑S : Set (Fin n → Fin n → Fin n))), (S.card : ℕ∞)
 
 /-- Notation for the MOLS function -/
 notation "f(" n ")" => maxMOLS n
@@ -172,7 +173,7 @@ f(n) ≫ n^(1/14.8).
 This is the current best known lower bound exponent.
 -/
 axiom beth_1983 : ∃ C : ℝ, C > 0 ∧
-    ∀ n : ℕ, n ≥ 2 → (f(n) : ℕ∞) ≥ C * (n : ℝ) ^ (1 / 14.8 : ℝ)
+    ∀ n : ℕ, n ≥ 2 → ((f(n) : ENNReal).toReal) ≥ C * (n : ℝ) ^ (1 / 14.8 : ℝ)
 
 /-
 ## Part VI: The Erdős Conjecture
@@ -193,7 +194,7 @@ The gap between the best known exponent (1/14.8 ≈ 0.068) and the
 conjectured exponent (1/2 = 0.5) is substantial.
 -/
 def erdos_724_conjecture : Prop :=
-  ∃ C : ℝ, C > 0 ∧ ∀ n : ℕ, n ≥ 2 → (f(n) : ℕ∞) ≥ C * (n : ℝ) ^ (1 / 2 : ℝ)
+  ∃ C : ℝ, C > 0 ∧ ∀ n : ℕ, n ≥ 2 → ((f(n) : ENNReal).toReal) ≥ C * (n : ℝ) ^ (1 / 2 : ℝ)
 
 /-
 ## Part VII: Examples and Constructions
@@ -209,9 +210,11 @@ def latinSquare3_L : Fin 3 → Fin 3 → Fin 3 :=
   fun i j => ⟨(i.val + j.val) % 3, Nat.mod_lt _ (by decide)⟩
 
 def latinSquare3_M : Fin 3 → Fin 3 → Fin 3 :=
+  fun i j => ⟨(2 * i.val + j.val) % 3, Nat.mod_lt _ (by decide)⟩
 
-/- 
+/-
 f(3) = 2, achieved by the construction above.
+The mate M(i,j) = (2i + j) mod 3 is orthogonal to L(i,j) = (i + j) mod 3.
 -/
 
 /- 
@@ -292,7 +295,7 @@ theorem erdos_724_status :
 The best known result is f(n) ≫ n^(1/14.8) by Beth (1983).
 -/
 theorem current_best_lower_bound : ∃ C : ℝ, C > 0 ∧
-    ∀ n : ℕ, n ≥ 2 → (f(n) : ℕ∞) ≥ C * (n : ℝ) ^ (1 / 14.8 : ℝ) :=
+    ∀ n : ℕ, n ≥ 2 → ((f(n) : ENNReal).toReal) ≥ C * (n : ℝ) ^ (1 / 14.8 : ℝ) :=
   beth_1983
 
 /--

--- a/proofs/Proofs/RamseysTheoremOQ04.lean
+++ b/proofs/Proofs/RamseysTheoremOQ04.lean
@@ -32,7 +32,7 @@ def kSubsets (s : Finset α) (k : ℕ) [DecidableEq α] : Finset (Finset α) :=
   s.powersetCard k
 
 /-- An r-coloring of k-element subsets. -/
-def Coloring (s : Finset α) (k : ℕ) (r : ℕ) [DecidableEq α] : Type :=
+abbrev Coloring (s : Finset α) (k : ℕ) (r : ℕ) [DecidableEq α] : Type _ :=
   kSubsets s k → Fin r
 
 /-- A subset is monochromatic for a coloring if all its k-element subsets have the same color. -/
@@ -66,8 +66,8 @@ theorem classical_ramsey_is_k2 (n₁ n₂ N : ℕ)
     ∀ (S : Finset ℕ), S.card = N →
       ∀ (c : kSubsets S 2 → Fin 2),
         ∃ (T : Finset ℕ), T ⊆ S ∧ T.card ≥ max n₁ n₂ ∧
-          (∀ e ∈ kSubsets T 2, ∀ he, c ⟨e, he⟩ = 0) ∨
-          (∀ e ∈ kSubsets T 2, ∀ he, c ⟨e, he⟩ = 1) := by
+          ((∀ e ∈ kSubsets T 2, ∀ he, c ⟨e, he⟩ = 0) ∨
+           (∀ e ∈ kSubsets T 2, ∀ he, c ⟨e, he⟩ = 1)) := by
   intro S hS c
   obtain ⟨T, i, hTS, hTn, hmono⟩ := hN S hS c
   exact ⟨T, hTS, hTn, by fin_cases i <;> [left; right] <;> exact hmono⟩
@@ -162,20 +162,12 @@ theorem tower_2_2 : tower 2 2 = 4 := by simp [tower]
 
 /-- The tower function grows strictly. -/
 theorem tower_strictMono (b : ℕ) (hb : b ≥ 2) : StrictMono (tower b) := by
-  intro m n hmn
-  induction n with
-  | zero => omega
-  | succ n ih =>
-    rcases eq_or_lt_of_le (Nat.lt_succ_iff.mp hmn) with rfl | hlt
-    · -- m = n case: tower b n < tower b (n+1) = b ^ tower b n
-      simp only [tower]
-      calc tower b n < 2 ^ tower b n := Nat.lt_two_pow (tower b n)
-        _ ≤ b ^ tower b n := Nat.pow_le_pow_left (by omega) (tower b n)
-    · -- m < n case: use IH
-      exact lt_trans (ih hlt) (by
-        simp only [tower]
-        calc tower b n < 2 ^ tower b n := Nat.lt_two_pow _
-          _ ≤ b ^ tower b n := Nat.pow_le_pow_left (by omega) _)
+  -- It suffices to show tower b n < tower b (n+1) = b ^ tower b n for all n.
+  apply strictMono_nat_of_lt_succ
+  intro n
+  simp only [tower]
+  calc tower b n < 2 ^ tower b n := Nat.lt_two_pow_self
+    _ ≤ b ^ tower b n := Nat.pow_le_pow_left (by omega) (tower b n)
 
 /-! ## Part V: Infrastructure for Proving the Hypergraph Ramsey Theorem
 
@@ -215,7 +207,8 @@ theorem kSubsets_eq_empty_of_lt [DecidableEq α] {s : Finset α} {k : ℕ}
     (h : s.card < k) : kSubsets s k = ∅ := by
   ext e; simp only [kSubsets, Finset.mem_powersetCard, Finset.notMem_empty, iff_false]
   intro ⟨he_sub, he_card⟩
-  exact absurd (le_trans (Finset.card_le_card he_sub) h.le) (by omega)
+  have : e.card ≤ s.card := Finset.card_le_card he_sub
+  omega
 
 /-- Tower(b, n) is positive when b ≥ 1. -/
 theorem tower_pos (b : ℕ) (hb : b ≥ 1) (n : ℕ) : tower b n ≥ 1 := by
@@ -229,11 +222,11 @@ theorem ramsey_property_mono {k r n N : ℕ} (N' : ℕ) (hNN : N ≤ N')
     HypergraphRamseyProperty k r n N' := by
   intro S hS c
   have hNS : N ≤ S.card := hS ▸ hNN
-  obtain ⟨S', hS'sub, hS'card⟩ := Finset.exists_subset_card_le hNS
+  obtain ⟨S', hS'sub, hS'card⟩ := Finset.exists_subset_card_eq hNS
   obtain ⟨T, i, hTS', hTn, hmono⟩ := h S' hS'card (fun ⟨e, he⟩ =>
     c ⟨e, kSubsets_mem_of_subset hS'sub he⟩)
-  exact ⟨T, Finset.Subset.trans hTS' hS'sub, hTn, fun e he_T _ =>
-    hmono e he_T (kSubsets_mem_of_subset hS'sub he_T)⟩
+  exact ⟨T, i, Finset.Subset.trans hTS' hS'sub, hTn, fun e he_T _ =>
+    hmono e he_T (kSubsets_mem_of_subset hTS' he_T)⟩
 
 /-- Base case: when n ≤ k, N = n works.
     When n < k: no k-subsets exist, so monochromaticity holds vacuously.
@@ -261,41 +254,7 @@ theorem ramsey_base (k r n : ℕ) (hr : r ≥ 1) (hn : n ≤ k) :
 For k = 1, coloring singletons is equivalent to coloring elements.
 By the pigeonhole principle, if |S| ≥ r*(n-1)+1, some color appears ≥ n times. -/
 
-/-- **Pigeonhole Ramsey**: the k = 1 base case of the Hypergraph Ramsey Theorem.
-    When we color elements (= singletons) with r colors, N = r*(n-1)+1 suffices
-    to find n elements of the same color. This is the pigeonhole principle. -/
-theorem pigeonhole_ramsey (r n : ℕ) (hr : r ≥ 1) (hn : n ≥ 1) :
-    HypergraphRamseyProperty 1 r n (r * (n - 1) + 1) := by
-  intro S hS c
-  -- Singleton membership: for a ∈ S, {a} is a 1-subset of S
-  have h_sing : ∀ a ∈ S, {a} ∈ kSubsets S 1 := fun a ha => by
-    simp only [kSubsets, Finset.mem_powersetCard]
-    exact ⟨Finset.singleton_subset_iff.mpr ha, Finset.card_singleton a⟩
-  -- Define element coloring: map each element to the color of its singleton
-  let f : ℕ → Fin r := fun a =>
-    if h : a ∈ S then c ⟨{a}, h_sing a h⟩ else ⟨0, by omega⟩
-  -- Pigeonhole: r • (n-1) < |S| = r*(n-1)+1, so some color fiber has > n-1 elements
-  have h_pig : (Finset.univ : Finset (Fin r)).card • (n - 1) < S.card := by
-    rw [Finset.card_univ, Fintype.card_fin, hS, smul_eq_mul]; omega
-  obtain ⟨i, _, h_fib⟩ := Finset.exists_lt_card_fiber_of_nsmul_lt_card
-    (f := f) (fun _ _ => Finset.mem_univ _) h_pig
-  -- The monochromatic set: elements of S whose singleton has color i
-  refine ⟨S.filter (f · = i), i, Finset.filter_subset _ _, ?_, ?_⟩
-  · -- Size: fiber has > n-1 elements, so ≥ n
-    omega
-  · -- Monochromaticity: every 1-subset {a} of the filter has color i
-    intro e he_T he_S
-    -- e is a 1-element subset of our filter, so e = {a} for some a
-    simp only [kSubsets, Finset.mem_powersetCard] at he_T
-    obtain ⟨he_sub, he_card⟩ := he_T
-    obtain ⟨a, rfl⟩ := Finset.card_eq_one.mp he_card
-    -- a is in the color-i filter, so f a = i, so c ⟨{a}, _⟩ = i
-    have ha_filt := Finset.singleton_subset_iff.mp he_sub
-    have ha_S : a ∈ S := Finset.filter_subset _ _ ha_filt
-    have ha_color : f a = i := (Finset.mem_filter.mp ha_filt).2
-    -- f a = c ⟨{a}, h_sing a ha_S⟩ when a ∈ S (by dif_pos)
-    simp only [f, dif_pos ha_S] at ha_color
-    -- Goal: c ⟨{a}, he_S⟩ = i. By proof irrelevance, he_S = h_sing a ha_S
-    exact ha_color
+/- The k = 1 pigeonhole base case `pigeonhole_ramsey` is proved above in Part II
+   (a duplicate re-declaration was removed here to avoid a name collision). -/
 
 end HypergraphRamsey

--- a/proofs/Proofs/SchroederBernsteinOQ01.lean
+++ b/proofs/Proofs/SchroederBernsteinOQ01.lean
@@ -331,7 +331,9 @@ but is **narrow**: `(forget C).Full` essentially forces `C` to be a
 full subcategory of `Type`. See the module-level docstring above for
 the instance-space catalogue and the comparison with `hasSBP_Type` /
 `hasSBP_of_isDiscrete` / `hasSBP_of_isGroupoid`. -/
-theorem hasSBP_of_fullFaithful_forget (C : Type*) [Category C] [HasForget C]
+theorem hasSBP_of_fullFaithful_forget (C : Type*) [Category C]
+    {FC : C → C → Type*} {CC : C → Type*} [∀ X Y, FunLike (FC X Y) (CC X) (CC Y)]
+    [ConcreteCategory C FC]
     [(forget C).Full] [(forget C).Faithful]
     [(forget C).PreservesMonomorphisms] : HasSBP C := by
   intro X Y ⟨m, hm⟩ ⟨n, hn⟩

--- a/proofs/Proofs/SylowTheoremOQ02Orbit.lean
+++ b/proofs/Proofs/SylowTheoremOQ02Orbit.lean
@@ -60,7 +60,7 @@ theorem sylow_orbit_is_all [Finite (Sylow p G)] (P : Sylow p G) :
 /-- Every Sylow p-subgroup Q is conjugate to P: there exists g ∈ G with g • P = Q.
     This is the direct corollary of the orbit covering all of Sylow p G. -/
 theorem exists_conj_eq (P Q : Sylow p G) : ∃ g : G, g • P = Q :=
-  Sylow.exists_smul_eq G P Q
+  MulAction.exists_smul_eq G P Q
 
 /-- Conjugation by any g gives an isomorphism P ≅ g • P as groups. -/
 noncomputable def conj_iso (P : Sylow p G) (g : G) : P ≃* (g • P : Sylow p G) :=
@@ -95,7 +95,7 @@ Combining the orbit = ⊤ fact with orbit-stabilizer gives the count formula:
     3. stab G P = N_G(P)          (by stabilizer_eq_normalizer)
     4. Therefore |Sylow p G| = [G : N_G(P)] -/
 theorem sylow_count_eq_normalizer_index [Finite (Sylow p G)] (P : Sylow p G) :
-    Nat.card (Sylow p G) = (Subgroup.normalizer P).index :=
+    Nat.card (Sylow p G) = (Subgroup.normalizer (P : Set G)).index :=
   Sylow.card_eq_index_normalizer P
 
 /-- **Bijective enumeration**: There is an explicit bijection between the set of
@@ -124,9 +124,9 @@ The orbit-stabilizer theorem, specialized to Sylow subgroups:
     This is the group-theoretic version of the orbit-stabilizer theorem:
       |G| = |orbit G P| × |stabilizer G P| = n_p × |N_G(P)| -/
 theorem sylow_orbit_stabilizer_formula [Finite (Sylow p G)] (P : Sylow p G) :
-    Nat.card G = Nat.card (Sylow p G) * Nat.card (Subgroup.normalizer P) := by
+    Nat.card G = Nat.card (Sylow p G) * Nat.card (Subgroup.normalizer (P : Set G)) := by
   rw [sylow_count_eq_normalizer_index P, mul_comm]
-  exact (Subgroup.normalizer P).card_mul_index.symm
+  exact (Subgroup.normalizer (P : Set G)).card_mul_index.symm
 
 /-!
 ## Part V: Normality Criterion
@@ -151,9 +151,9 @@ theorem sylow_unique_iff_normal [Finite (Sylow p G)] (P : Sylow p G) :
 theorem sylow_unique_of_normal [Finite (Sylow p G)] (P : Sylow p G)
     (hN : (P : Subgroup G).Normal) : ∀ Q : Sylow p G, Q = P := by
   have h1 : Nat.card (Sylow p G) = 1 := (sylow_unique_iff_normal P).mpr hN
-  have := Nat.card_eq_one.mp h1
+  obtain ⟨u⟩ := Nat.card_eq_one_iff_unique.mp h1
   intro Q
-  exact Unique.uniq (α := Sylow p G) ⟨⟩ Q
+  exact Subsingleton.elim Q P
 
 /-- A normal Sylow p-subgroup is fixed under every conjugation. -/
 theorem smul_eq_of_normal (P : Sylow p G) (g : G) [h : P.Normal] :

--- a/proofs/batch2/STATUS.md
+++ b/proofs/batch2/STATUS.md
@@ -2449,3 +2449,73 @@ decide-maxrecdepth / partenat-removal classes, exactly ONE (the Dirichlet chain)
 Low reported error counts (3–5) reliably explode into multi-site rewrites once the head blocker
 clears. Remaining fixable estimate: a handful (<5%) of the ~400 A–M/Erdos<600 residuals, each
 requiring real proof surgery rather than a rename/seam. Recommend the seam be considered exhausted.
+
+---
+
+## Increment 51 (Doctor, N–Z / Erdos≥600, deep-rework clusters) — +4 GREEN + 1 statement repair
+
+**+4 GREEN**:
+- **SylowTheoremOQ02Orbit** (Sylow-API cluster): three-part rename:
+  - `Sylow.exists_smul_eq G P Q` → `MulAction.exists_smul_eq G P Q` (the const moved to the
+    pretransitivity API; `Sylow` no longer carries it).
+  - `Subgroup.normalizer P` → `Subgroup.normalizer (P : Set G)` — **`Subgroup.normalizer` now
+    takes a `Set G`, not a `Subgroup G`**. Only breaks in type positions (`.index`, `Nat.card …`);
+    in `stabilizer G P = Subgroup.normalizer P` it still unifies via the Sylow coercion.
+  - `Nat.card_eq_one.mp` (gone) → `Nat.card_eq_one_iff_unique.mp` (returns `Nonempty (Unique α)`);
+    then `Subsingleton.elim` for `Q = P` (dot-notation `.uniq` resolves to `Subsingleton.uniq` and
+    fails — use `Subsingleton.elim`).
+- **SchroederBernsteinOQ01** (concrete-category refactor): **`HasForget C` removed in v4.31**.
+  Replace the class binder with the new bundle that `forget C` requires:
+  `{FC : C → C → Type*} {CC : C → Type*} [∀ X Y, FunLike (FC X Y) (CC X) (CC Y)] [ConcreteCategory C FC]`.
+  Clean 1-binder swap; the proof body (FullyFaithful.preimageIso etc.) was unchanged.
+- **Erdos724Problem** (statement repair): empty `latinSquare3_M` def body supplied with the
+  intended orthogonal mate `(2i+j)%3` (mate of `L=(i+j)%3`). ALSO fixed pre-existing latent
+  ℕ∞-vs-ℝ type errors (masked by the parse-error head): `f(n) : ℕ∞` cannot be `≥` a real, so
+  coerce via `(f(n) : ENNReal).toReal` in `beth_1983` / `erdos_724_conjecture` /
+  `current_best_lower_bound`. `ℝ≥0∞` notation was "expected token" (scope not open) → use spelled
+  `ENNReal`. Pinned the `⨆` binder's `Set _` coercion element type.
+- **Erdos1123Problem** (statement repair — genuine intended-true transitivity): the density-zero
+  symmetric-difference setoid had a **fake** transitivity proof (`by simp [hasDensityZero]; intro _ _; trivial`).
+  The relation IS a true equivalence; supplied the real proof: `hasDensityZero` is subset-closed
+  (`hasDensityZero_mono`) and union-closed (`hasDensityZero_union`, via ε/2 split + `countUpTo`
+  subadditivity `countUpTo_union_le`), so `symmDiff_triangle` (`A∆C ⊆ (A∆B)∪(B∆C)`) gives
+  transitivity. Also fixed the type-degenerate def (**ε was ℕ**, making refl unprovable → made it
+  `ℝ` with `(countUpTo:ℝ)`), and `∆` notation now needs `open scoped symmDiff`. Both `B1`/`B2`
+  now use proper named `Setoid` instances.
+
+**Statement repair (row stays PRE-EXISTING, not flipped) — RamseysTheoremOQ04** — now fully
+compiles. Fixes per #38611:
+- Misparenthesized `(A∧B∧C)∨D` → `A∧B∧(C∨D)` in `classical_ramsey_is_k2` (the ∨ ranges over the
+  two monochromatic colorings, not the whole conjunction — the `⟨…⟩` "more than one constructor"
+  error pinpoints it).
+- Removed duplicate `pigeonhole_ramsey` declaration (Part VI copy; the Part II one is the referenced one).
+- `Finset.exists_subset_card_le` → `Finset.exists_subset_card_eq` (now returns `#t = n`, was `≤`).
+- `Nat.lt_two_pow` → `Nat.lt_two_pow_self` (implicit `n`).
+- `def Coloring … : Type := …` → `abbrev … : Type _` (universe drift `Type u_1` vs `Type`, plus
+  needs reducibility so `c ⟨e,he⟩` application elaborates).
+- `tower_strictMono`: `induction n` (with `hmn`/`m` depending on `n`) is broken → rewrite via
+  `strictMono_nat_of_lt_succ` (suffices `tower b n < tower b (n+1)`).
+- `ramsey_property_mono`: restored the missing `i` witness in the final `⟨T, i, …⟩` and fixed the
+  subset direction (`hTS' : T ⊆ S'`, not `hS'sub`).
+
+**Probed-and-skipped (deep / genuinely stuck, NOT mechanical seam)**:
+- **SylowTheoremOQ04** — `native_decide` on `Fintype.card (Sylow p G) = 5/10/6` now FAILS:
+  `SetLike.instFintype` is **noncomputable** in v4.31, so `native_decide` can't compile the Sylow
+  count. This is a computability-model change, not a rename; the whole simplicity-of-A₅ argument
+  rests on those three computed counts. Reverted.
+- **SylowTheoremOQ01** — 14-site rewrite-drift (`rw` pattern misses, rcases on non-inductive,
+  `Nat.Prime.eq_of_dvd_of_prime`/`orderOf_eq_one_iff_eq_one` renames). Deep.
+- **Wilsons cluster** (OQ01/OQ02/OQ02Ext/…) — all dep-blocked on `WilsonsTheoremOQ02Ext`, which has
+  ~8 independent errors incl. a v4.31 hygiene bug (`Invalid pattern variable … Nat.totient._@…_hyg`
+  multi-component name), `rw` pattern misses, `Int.natAbs_le.mp` gone, omega drift. Deep.
+- SkolemNoetherMatrixAut, ShannonSourceCodingOQ03, RandomizedMaxcutOQ04, PartitionTheorem,
+  SpernerNDimOQ04, StirlingFormula — all multi-site (unknown-const + unsolved-goals + type-mismatch
+  mixed). The parse-error heads (SpernerNDimOQ04 `unexpected '|'`, StirlingFormula `/-!` doc-command)
+  mask 5+ real proof-drift sites each.
+
+**VERDICT (N–Z seam):** matches the A–M finding — **the mechanical seam is dry**. Of the deep
+clusters, the Sylow-API cluster *partially* yielded (OQ02Orbit: normalizer-signature + const-move +
+`card_eq_one` renames), and the concrete-category refactor (SchroederBernsteinOQ01) was a clean
+1-binder swap. But `native_decide`-on-noncomputable-Fintype (SylowTheoremOQ04) is a hard model
+change, and the remaining N–Z residuals are genuine multi-site proof surgery. The statement-repair
+targets (Erdos724, Erdos1123, RamseysTheoremOQ04) all yielded to real intended-true fixes.

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -2520,7 +2520,7 @@ SylowTheorem	GREEN
 SylowTheoremOQ01	RESIDUAL	rewrite-drift
 SylowTheoremOQ02	GREEN	
 SylowTheoremOQ02OQ01Nilpotent	GREEN	
-SylowTheoremOQ02Orbit	RESIDUAL	unknown-const:Sylow.exists_smul_eq
+SylowTheoremOQ02Orbit	GREEN	
 SylowTheoremOQ03	GREEN	
 SylowTheoremOQ03B	GREEN	
 SylowTheoremOQ04	RESIDUAL	unknown-const:card_sylow_dvd_index

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -831,7 +831,7 @@ Erdos111Problem	GREEN
 Erdos1120Problem	RESIDUAL	instance-synth
 Erdos1121Problem	RESIDUAL	instance-synth
 Erdos1122Problem	GREEN	
-Erdos1123Problem	RESIDUAL	parse-error
+Erdos1123Problem	GREEN	
 Erdos1124Problem	GREEN	
 Erdos1125Problem	RESIDUAL	proof-drift
 Erdos1126Problem	GREEN	unknown-const:measurable_additive_is_linear

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -1623,7 +1623,7 @@ Erdos720Problem	RESIDUAL	proof-drift
 Erdos721Problem	GREEN	
 Erdos722Problem	GREEN	
 Erdos723Problem	GREEN	
-Erdos724Problem	RESIDUAL	parse-error
+Erdos724Problem	GREEN	
 Erdos725Problem	GREEN	
 Erdos726Problem	GREEN	
 Erdos727Problem	GREEN	

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -2388,7 +2388,7 @@ SchauderFixedPoint	RESIDUAL	instance-synth
 SchauderFixedPointOQ01	GREEN	instance-synth
 SchauderFixedPointOQ03	RESIDUAL	instance-synth
 SchauderFixedPointOQ03OQ01	GREEN	
-SchroederBernsteinOQ01	RESIDUAL	elab-drift
+SchroederBernsteinOQ01	GREEN	
 SchroederBernsteinOQ02	GREEN	
 SchroederBernsteinOQ03	GREEN	
 SchursTheorem	GREEN	


### PR DESCRIPTION
Doctor increment 51 of the Lean v4.26→v4.31 migration (epic #37508, issue #38065). Partition: N–Z basenames + Erdős≥600. Deep-rework clusters.

## +4 GREEN
- **SylowTheoremOQ02Orbit** — Sylow-API cluster: `Sylow.exists_smul_eq`→`MulAction.exists_smul_eq`; `Subgroup.normalizer P`→`Subgroup.normalizer (P : Set G)` (normalizer now takes `Set G`) in type positions; `Nat.card_eq_one.mp`→`Nat.card_eq_one_iff_unique.mp` + `Subsingleton.elim`.
- **Erdos724Problem** — statement repair: supplied the empty `latinSquare3_M` body (intended orthogonal mate `(2i+j)%3`), plus fixed pre-existing ℕ∞-vs-ℝ type errors by coercing `f(n)` via `(· : ENNReal).toReal`, and pinned the `⨆` coercion element type.
- **Erdos1123Problem** — statement repair: the density-zero symmetric-difference relation had a **fake** transitivity proof (`simp; intro; trivial`). Supplied the genuine intended-true equivalence: `hasDensityZero` is subset-closed and union-closed, so via `symmDiff_triangle` (A∆C ⊆ (A∆B)∪(B∆C)) the relation is really transitive. Also fixed the type-degenerate def (ε now ℝ) and the scoped `∆` notation (`open scoped symmDiff`).
- **SchroederBernsteinOQ01** — concrete-category refactor: `HasForget C` removed → `{FC}{CC}[FunLike…][ConcreteCategory C FC]` bundle.

## Statement repair (row stays PRE-EXISTING, not flipped)
- **RamseysTheoremOQ04** — now fully compiles. Fixes: misparenthesized `(A∧B∧C)∨D`→`A∧B∧(C∨D)`; removed duplicate `pigeonhole_ramsey`; `Finset.exists_subset_card_le`→`exists_subset_card_eq`; `Nat.lt_two_pow`→`Nat.lt_two_pow_self`; `abbrev Coloring`; `tower_strictMono` via `strictMono_nat_of_lt_succ`; `ramsey_property_mono` restored `i` witness + correct subset direction.

## Honest read on the deep clusters
The Sylow-API cluster **partially yields**: single-root unknown-const + normalizer-signature drift greened OQ02Orbit cleanly, but `SylowTheoremOQ04` is genuinely stuck (`native_decide` on `Fintype.card (Sylow p G)` now fails — `SetLike.instFintype` is noncomputable in v4.31, not a rename), and `SylowTheoremOQ01` is 14-site rewrite-drift. The statement-repair targets all yielded to real fixes. `SchroederBernsteinOQ01` was a clean 1-binder refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)