### PR TITLE
migrate(v4.31): Doctor increment 53 — deep-rework clusters (A-M) (+7 GREEN)

### DIFF
--- a/proofs/Proofs/BallotProblem.lean
+++ b/proofs/Proofs/BallotProblem.lean
@@ -143,12 +143,12 @@ This is proved by:
 2. "Staying positive" means all suffix sums are positive
 3. Using induction on p and q with the reflection principle -/
 theorem ballot_theorem (p q : ℕ) (h : q < p) :
-    condCount (countedSequence p q) staysPositive = (p - q) / (p + q) :=
+    uniformOn (countedSequence p q) staysPositive = (p - q) / (p + q) :=
   ballot_problem q p h
 
 /-- The real-valued version of the ballot theorem. -/
 theorem ballot_theorem_real (p q : ℕ) (h : q < p) :
-    (condCount (countedSequence p q) staysPositive).toReal = (p - q) / (p + q) :=
+    (uniformOn (countedSequence p q) staysPositive).toReal = (p - q) / (p + q) :=
   ballot_problem' q p h
 
 /-! ## Part IV: Edge Cases and Special Values -/
@@ -156,13 +156,13 @@ theorem ballot_theorem_real (p q : ℕ) (h : q < p) :
 /-- When q = 0 (A receives all votes), the probability is 1.
 This makes sense: if B gets no votes, A is always ahead! -/
 theorem ballot_unanimous (p : ℕ) :
-    condCount (countedSequence (p + 1) 0) staysPositive = 1 :=
+    uniformOn (countedSequence (p + 1) 0) staysPositive = 1 :=
   ballot_edge p
 
 /-- When p = q (a tie), the probability that A leads throughout is 0.
 This is because at some point the running totals must be equal. -/
 theorem ballot_tie (p : ℕ) :
-    condCount (countedSequence (p + 1) (p + 1)) staysPositive = 0 :=
+    uniformOn (countedSequence (p + 1) (p + 1)) staysPositive = 0 :=
   ballot_same p
 
 /-! ## Part V: Concrete Probability Values

--- a/proofs/Proofs/BinomialTheoremOQ02OQ04.lean
+++ b/proofs/Proofs/BinomialTheoremOQ02OQ04.lean
@@ -129,24 +129,26 @@ theorem multinomial_by_induction {α : Type*} {R : Type*} [CommSemiring R]
     have hjle : j ≤ n := Nat.lt_succ_iff.mp hj
     -- For i ∈ s: i ≠ a (since a ∉ s), so (if i = a then j else 0) = 0
     have hshift : ∀ i ∈ s, (if i = a then (j : ℕ) else 0) = 0 :=
-      fun i hi => if_neg (fun h => ha (h ▸ hi))
+      fun i hi => if_neg (fun h => ha (by rw [← h]; exact hi))
     -- Simplify: ∑_s (g i + if i = a then j else 0) = ∑_s g i = n - j
     have hsum : ∑ i ∈ s, (g i + if i = a then j else 0) = n - j := by
       rw [Finset.sum_add_distrib,
           Finset.sum_eq_zero (fun i hi => hshift i hi),
           add_zero, hg.1]
     -- Simplify: multinomial s (g + shift_a j) = multinomial s g
-    have hmn : Nat.multinomial s (fun i => g i + if i = a then j else 0) =
+    have hmn : Nat.multinomial s (g + fun t => if t = a then j else 0) =
                Nat.multinomial s g := by
       apply Nat.multinomial_congr
-      intro i hi; simp [hshift i hi]
+      intro i hi; simp [Pi.add_apply, hshift i hi]
     -- Simplify: ∏_s f^(g + shift_a j) = ∏_s f^g
     have hprod : ∏ i ∈ s, f i ^ (g i + if i = a then j else 0) = ∏ i ∈ s, f i ^ g i := by
       apply Finset.prod_congr rfl
       intro i hi; simp [hshift i hi]
     -- Combine: g a + j = j, j + (n - j) = n, multinomial simplifies, product simplifies
     -- Both sides are now: C(n, j) * multinomial s g * (f a^j * ∏_s f^g)
-    rw [hga, zero_add, hsum, hmn, hprod, Nat.add_sub_cancel' hjle]
+    rw [hmn]
+    simp only [Pi.add_apply, if_true]
+    rw [hga, zero_add, hsum, hprod, Nat.add_sub_cancel' hjle]
     push_cast; ring
 
 /-! ## Part 3: Equivalence with Mathlib's Theorem -/
@@ -171,8 +173,12 @@ of the binomial theorem, one per variable added to the index set. -/
 theorem multinomial_needs_k_minus_one_binomials {n : ℕ} :
     (∑ i ∈ (Finset.univ : Finset (Fin 3)), (![1, 1, 1] : Fin 3 → ℕ) i) ^ n =
     ∑ k ∈ (Finset.univ : Finset (Fin 3)).piAntidiag n,
-      (Nat.multinomial Finset.univ k : ℕ) * ∏ i ∈ Finset.univ, (1 : ℕ) ^ k i :=
-  multinomial_by_induction Finset.univ (![1, 1, 1]) n
+      (Nat.multinomial Finset.univ k : ℕ) * ∏ i ∈ Finset.univ, (1 : ℕ) ^ k i := by
+  have h := multinomial_by_induction Finset.univ (![1, 1, 1]) n
+  refine h.trans (Finset.sum_congr (by congr 1; exact Subsingleton.elim _ _) (fun k _ => ?_))
+  rw [Nat.cast_id]
+  refine congrArg _ (Finset.prod_congr rfl (fun i _ => ?_))
+  fin_cases i <;> simp
 
 /-! ## Part 5: Examples -/
 

--- a/proofs/Proofs/Erdos10OQ01.lean
+++ b/proofs/Proofs/Erdos10OQ01.lean
@@ -259,20 +259,13 @@ theorem gallagher_does_not_imply_oq01_in_principle :
     have hcsq_le : ((Finset.filter (fun n => ∃ m : ℕ, m * m = n) (Finset.range N)).card : ℝ) ≤
         ε * N := le_trans hsq_real hsqrt_bound
     rw [ge_iff_le, le_div_iff₀ hN_real, show (1 - ε) * (N : ℝ) = N - ε * N from by ring]
-    -- Capture the goal's filter with 'set' to bind its exact DecidablePred instance
-    set nonsq_fin := Finset.filter (· ∈ ({n | ¬∃ m : ℕ, m * m = n} : Set ℕ)) (Finset.range N)
-      with hF
-    -- Goal is now: (N : ℝ) - ε * N ≤ ↑nonsq_fin.card
-    -- Prove nonsq_fin equals the explicit-lambda filter (same elements, via finset ext)
-    have hfilt_eq : nonsq_fin = Finset.filter (fun n => ¬∃ m : ℕ, m * m = n) (Finset.range N) := by
-      rw [hF]; ext x; simp only [Finset.mem_filter, Finset.mem_range, Set.mem_setOf_eq]
+    -- Unfold the goal's inner set-membership `x ∈ {n | P n}` to `P x`.
+    simp only [Set.mem_setOf_eq]
     -- Step-by-step calc to avoid linarith cast issues
     calc (N : ℝ) - ε * ↑N
         ≤ ↑N - ↑(Finset.filter (fun n => ∃ m : ℕ, m * m = n) (Finset.range N)).card := by
             linarith [hcsq_le]
       _ = ↑(Finset.filter (fun n => ¬∃ m : ℕ, m * m = n) (Finset.range N)).card := hcast.symm
-      _ = ↑nonsq_fin.card := by
-            exact_mod_cast (congr_arg Finset.card hfilt_eq).symm
   · -- The non-squares miss all perfect squares (infinitely many large squares exist)
     intro N
     use (N + 1) * (N + 1)

--- a/proofs/Proofs/Erdos121Problem.lean
+++ b/proofs/Proofs/Erdos121Problem.lean
@@ -23,14 +23,14 @@ open scoped Classical
 /- ## Square-free product sets -/
 
 /-- A number is a perfect square. -/
-def IsSquare (n : ℕ) : Prop :=
+def IsPerfectSq (n : ℕ) : Prop :=
     ∃ m : ℕ, n = m * m
 
 /-- A finset `A` is `k`-square-free: no product of `k` distinct
 elements is a perfect square. -/
 def IsKSquareFree (A : Finset ℕ) (k : ℕ) : Prop :=
     ∀ S : Finset ℕ, S ⊆ A → S.card = k →
-      ¬IsSquare (S.prod id)
+      ¬IsPerfectSq (S.prod id)
 
 /-- `F_k(N)`: the maximum size of a `k`-square-free subset of
 `{1,…,N}`. -/

--- a/proofs/Proofs/Erdos181OQ01.lean
+++ b/proofs/Proofs/Erdos181OQ01.lean
@@ -98,6 +98,7 @@ theorem ramseyNumberSymm_ge (n : ℕ) (hne : (symmRamseySet n).Nonempty) :
 ## Part IV: R_sym(Q_1) = 2
 -/
 
+set_option maxRecDepth 2000 in
 /-- 2 is in the symmetric Ramsey set for Q_1. -/
 theorem two_in_symm_ramsey_set : (2 : ℕ) ∈ symmRamseySet 1 := by
   unfold symmRamseySet
@@ -106,7 +107,11 @@ theorem two_in_symm_ramsey_set : (2 : ℕ) ∈ symmRamseySet 1 := by
   refine ⟨id, Function.injective_id, c ⟨0, by norm_num⟩ ⟨1, by norm_num⟩, ?_⟩
   intro x y hxy
   rw [hypercubeAdj_one_iff] at hxy
-  fin_cases x <;> fin_cases y <;> simp_all [Function.id]
+  fin_cases x <;> fin_cases y <;>
+    first
+    | exact absurd rfl hxy
+    | rfl
+    | exact hsymm _ _
 
 /-- R_sym(Q_1) ≤ 2 since 2 is in the symmetric Ramsey set. -/
 theorem ramseyNumberSymm_one_le : ramseyNumberSymm 1 ≤ 2 := by

--- a/proofs/Proofs/Erdos346Problem.lean
+++ b/proofs/Proofs/Erdos346Problem.lean
@@ -30,18 +30,18 @@ def subsetSums (A : Set ℕ) : Set ℕ :=
     { s | ∃ (S : Finset ℕ), (↑S : Set ℕ) ⊆ A ∧ S.sum id = s }
 
 /-- A set is complete if it represents all sufficiently large integers. -/
-def IsComplete (A : Set ℕ) : Prop :=
+def IsCompleteSet (A : Set ℕ) : Prop :=
     ∃ m : ℕ, ∀ n : ℕ, m ≤ n → n ∈ subsetSums A
 
 /- ## Strong completeness and fragility -/
 
 /-- A is strongly complete: removing any finite subset preserves completeness. -/
 def IsStronglyComplete (A : Set ℕ) : Prop :=
-    ∀ B : Finset ℕ, IsComplete (A \ (↑B : Set ℕ))
+    ∀ B : Finset ℕ, IsCompleteSet (A \ (↑B : Set ℕ))
 
 /-- A is fragile: removing any infinite subset destroys completeness. -/
 def IsFragile (A : Set ℕ) : Prop :=
-    ∀ B : Set ℕ, Set.Infinite B → ¬IsComplete (A \ B)
+    ∀ B : Set ℕ, Set.Infinite B → ¬IsCompleteSet (A \ B)
 
 /- ## Lacunary sequences -/
 

--- a/proofs/Proofs/Konigsberg.lean
+++ b/proofs/Proofs/Konigsberg.lean
@@ -153,7 +153,9 @@ lemma not_even_degree_iff (w : Verts) :
 lemma setOf_odd_degree_eq :
     {v | Odd (graph.degree v)} = {Verts.V1, Verts.V2, Verts.V3, Verts.V4} := by
   ext w
-  simp [not_even_degree_iff, Nat.odd_iff_not_even]
+  simp only [Set.mem_setOf_eq, Set.mem_insert_iff, Set.mem_singleton_iff,
+    degree_eq_degree, ← Nat.not_even_iff_odd]
+  exact not_even_degree_iff w
 
 /-!
 ## Part 6: The Main Theorem

--- a/proofs/batch2/STATUS.md
+++ b/proofs/batch2/STATUS.md
@@ -2583,3 +2583,67 @@ clusters, the Sylow-API cluster *partially* yielded (OQ02Orbit: normalizer-signa
 1-binder swap. But `native_decide`-on-noncomputable-Fintype (SylowTheoremOQ04) is a hard model
 change, and the remaining N–Z residuals are genuine multi-site proof surgery. The statement-repair
 targets (Erdos724, Erdos1123, RamseysTheoremOQ04) all yielded to real intended-true fixes.
+
+## Increment 53 (Doctor, A–M / Erdos<600, deep-rework clusters) — +7 GREEN
+
+Method: built an in-target error-count probe (`grep -cE "error: Proofs/<F>.lean:"`) over all
+426 RED files in the A–M + Erdos<600 partition, then attacked the 1–4-error files (most likely
+single-recipe). The greens were exactly the genuinely single-cause files; everything ≥5 sites (and
+several ≤2-site files whose head error MASKED a multi-error tail) bottomed out in real proof surgery.
+
+**+7 GREEN**:
+- **BallotProblem** — `ProbabilityTheory.condCount` → `uniformOn` (whole-file rename; the Archive
+  lemmas `ballot_problem`/`ballot_problem'`/`ballot_edge`/`ballot_same` are now stated via `uniformOn`).
+- **BinomialTheoremOQ02OQ04** — (1) `h ▸ hi` elaboration drift → `by rw [← h]; exact hi`; (2) goal
+  carries the un-beta-reduced Pi-add form `(g + fun t => …)`, so restate `hmn` in `+`-function form
+  and normalize with `Pi.add_apply`/`if_true`; (3) stale terminal theorem hit a `DecidableEq (Fin 3)`
+  instance diamond (`Classical.propDecidable` vs `instDecidableEqFin`) — bridge with
+  `Finset.sum_congr (by congr 1; exact Subsingleton.elim _ _)` + per-summand `prod_congr`.
+- **Erdos121Problem** — local `def IsSquare` now collides with Mathlib `IsSquare` → rename `IsPerfectSq`.
+- **Erdos346Problem** — local `def IsComplete` collides with Mathlib `IsComplete` → rename `IsCompleteSet`.
+- **Erdos181OQ01** — `simp_all [Function.id]` (`Function.id` identifier gone; plain `simp_all` also
+  blows the recursion budget) → explicit `fin_cases … <;> first | exact absurd rfl hxy | rfl | exact hsymm _ _`.
+- **Erdos10OQ01** — `set … with hF` no longer FOLDS the goal's filter (regression) so the calc chain
+  ended at `nonsq_fin.card` while the goal kept the set-builder form; dropped `set` and normalized the
+  goal directly with `simp only [Set.mem_setOf_eq]`.
+- **Konigsberg** — `Nat.odd_iff_not_even` REMOVED → `Nat.not_even_iff_odd` (reversed direction);
+  also needed `Set.mem_setOf_eq` unfold + `degree_eq_degree` to bridge `graph.degree` vs local `degree`.
+
+**Reusable recipes (for rename-map)**:
+- `ProbabilityTheory.condCount` → `uniformOn` (Archive Ballot lemmas restated).
+- `Function.id` identifier removed → `id` / `id_eq`, or drop & prove finite cases explicitly.
+- `Nat.odd_iff_not_even` removed → `Nat.not_even_iff_odd` (direction reversed).
+- Local `IsSquare` / `IsComplete` defs now SHADOW Mathlib `IsSquare` / `IsComplete` → rename the local.
+- `set x := … with hF` may no longer fold the goal (only the `have`s) → normalize goal with
+  `simp only [Set.mem_setOf_eq]` instead of relying on `set` folding.
+- `DecidableEq` instance diamond from `piAntidiag`/classical defs → `Subsingleton.elim` under `congr 1`.
+
+**Probed-and-skipped (deep / not mechanical seam)**:
+- **AbelRuffiniOQ10** — `native_decide` on `orderOf` (noncomputable in v4.31); same hard model change
+  as inc51's SylowTheoremOQ04. Reverted.
+- **Erdos39Problem** — `frequently_lt_of_liminf_lt` now takes an `IsCoboundedUnder (· ≥ ·)` autoParam
+  (was `IsBoundedUnder (· ≥ ·)`); cobounded-ge is NOT cleanly derivable from the nonneg lower bound
+  (needs an upper-bound-frequently). Real surgery. Reverted.
+- **Erdos490ProblemAristotle** — two clean renames (`Nat.eq_zero_of_mul_eq_zero_left`,
+  `Nat.Prime.eq_of_dvd_of_prime` → `Nat.prime_dvd_prime_iff_eq`) BUT the `a₂ = 0` branch is a genuine
+  LATENT logic gap (a₁=a₂=0 with p₁≠p₂ satisfies the hypotheses) that old simp masked. Reverted.
+- **Erdos598Problem** — universe-inference on `Set.Iio kappa` as a codomain type; pinning `kappa` to
+  `Cardinal.{0}` breaks the `α : Type*` universe-poly defs downstream. Multi-def universe surgery. Reverted.
+- **FundamentalTheoremCalculusLebesgueOQ04** — imports were after the `/-!` docstring
+  (`invalid 'import' command`); moving them to the top is correct but MASKED 10+ downstream errors
+  (`dist_norm`, `eVariationOn.eq_zero_iff`, rewrite misses). Reverted — genuinely deep.
+- **CevasTheoremOQ01OQ03** — `field_simp` no longer clears all `⁻¹` denominators (leaves
+  `(1-e+e*d)⁻¹ * 7` etc.), so the `ring` polynomial identity fails. field_simp normalization drift.
+- Fintype-synthesis-on-set-comprehension cluster (**Erdos395/407/559**, **Hilbert20LocalSolvability**,
+  **MaschkeLocalRingOQ010102**): `Fintype {x | P x}` / `Fintype (MultiIndex n)` no longer auto-synthesizes.
+- `generalize_proofs` auto-name churn (**Erdos124CompleteSequences**: `i_1` unknown) — GeneralizeProofs
+  API drift, matches inc50's stuck list. `grind`-fail cluster (**Erdos152ProblemAPN**,
+  **KonigsbergOQ02OQ01Aristotle**). `greedyCount` counting-set mismatch (**Erdos340**) = content gap.
+
+**VERDICT (A–M seam, inc53):** confirms inc50/51 — **A–M deep-rework is nearly tapped out.** The only
+reliably-yielding veins left are (a) local-def-shadows-Mathlib name collisions and (b) single-symbol
+API renames (`condCount`→`uniformOn`, `Function.id`, `Nat.odd_iff_not_even`), both of which the
+error-count probe exhausted in this partition. The remaining RED files are dominated by genuine
+multi-site proof surgery, Fintype-synthesis drift, `field_simp`/`ring` normalization drift,
+`native_decide`-on-noncomputable, universe-polymorphism, and a couple of latent logic gaps. Several
+"1-error" files were parse-error-masked multi-error files. New greens now require real content work.

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -912,7 +912,7 @@ Erdos1213Problem	GREEN
 Erdos1214Problem	RESIDUAL	proof-drift
 Erdos1216Problem	GREEN	
 Erdos1217Problem	GREEN	
-Erdos121Problem	RESIDUAL	duplicate-decl
+Erdos121Problem	GREEN	
 Erdos124CompleteSequences	RESIDUAL	unknown-const:i_1
 Erdos124Problem	GREEN	
 Erdos125Problem	GREEN	

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -799,7 +799,7 @@ Erdos109OQ01	RESIDUAL	type-mismatch
 Erdos109OQ01Aristotle	GREEN	
 Erdos109Problem	GREEN	
 Erdos10Incomplete01OQ02	RESIDUAL	slow-timeout
-Erdos10OQ01	RESIDUAL	proof-drift
+Erdos10OQ01	GREEN	
 Erdos10OQ01Incomplete01	RESIDUAL	slow-timeout
 Erdos10OQ02Bridge	GREEN	
 Erdos10Problem	GREEN	

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -1159,7 +1159,7 @@ Erdos342Problem	GREEN
 Erdos343Problem	GREEN	
 Erdos344Problem	GREEN	
 Erdos345Problem	GREEN	parse-error
-Erdos346Problem	RESIDUAL	duplicate-decl
+Erdos346Problem	GREEN	
 Erdos347Problem	RESIDUAL	unknown-const:Finset.card_Icc
 Erdos348Problem	RESIDUAL	type-mismatch
 Erdos349Problem	GREEN	

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -2165,7 +2165,7 @@ KnightsTourObliqueOQ02Palindrome	GREEN
 KnightsTourObliqueOQ02Reverse	GREEN	
 KnightsTourObliqueOQ02ReverseCount	GREEN	
 KnightsTourObliqueOQ03	GREEN	
-Konigsberg	RESIDUAL	unknown-const:Nat.odd_iff_not_even
+Konigsberg	GREEN	
 KonigsbergOQ01	GREEN	
 KonigsbergOQ01OQ02	RESIDUAL	unknown-const:Finset.card_eq_sum_ones.symm
 KonigsbergOQ01OQ02Recipe	GREEN	

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -973,7 +973,7 @@ Erdos179Problem	GREEN
 Erdos179ProblemAristotle	RESIDUAL	proof-drift
 Erdos17Problem	GREEN	
 Erdos180Problem	GREEN	instance-synth
-Erdos181OQ01	RESIDUAL	unknown-const:Function.id
+Erdos181OQ01	GREEN	
 Erdos181Problem	GREEN	unknown-const:rpow_le_rpow_of_exponent_le
 Erdos182Problem	GREEN	
 Erdos183Problem	RESIDUAL	proof-drift

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -151,7 +151,7 @@ ArsinhLogFormulaOQ01OQ01OQ01	GREEN
 ArsinhLogFormulaOQ01OQ01OQ01OQ01	GREEN	
 ArsinhLogFormulaOQ01OQ01OQ02	GREEN	
 BallVolumeSurfaceDuality	GREEN	
-BallotProblem	RESIDUAL	signature-drift
+BallotProblem	GREEN	
 BallotProblemOQ01OQ02OQ01	RESIDUAL	unknown-const:Set.ncard_biUnion
 BallotProblemOQ01OQ02OQ01Aristotle	RESIDUAL	unknown-const:Set.ncard_biUnion
 BallotProblemOQ01OQ02OQ01OQ01	RESIDUAL	unknown-const:Set.ncard_biUnion

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -236,7 +236,7 @@ BinomialTheoremOQ02OQ01OQ03	GREEN
 BinomialTheoremOQ02OQ01OQ04	GREEN	
 BinomialTheoremOQ02OQ02	GREEN
 BinomialTheoremOQ02OQ03	RESIDUAL	type-mismatch
-BinomialTheoremOQ02OQ04	RESIDUAL	type-mismatch
+BinomialTheoremOQ02OQ04	GREEN	
 BinomialTheoremOQ02OQ04OQ02	GREEN	
 BinomialTheoremOQ03OQ02OQ03	GREEN	
 BinomialTheoremOQ04	GREEN	


### PR DESCRIPTION
Doctor increment 53 of the Lean v4.26→v4.31 migration (epic #37508, issue #38065). Partition: A–M basenames + Erdos<600. DEEP-REWORK phase.

Method: built an in-target error-count probe over all 426 RED files in the partition, then attacked the 1–4-error files (most likely single-recipe). The greens were exactly the genuinely single-cause files.

## +7 GREEN
- **BallotProblem** — `ProbabilityTheory.condCount` → `uniformOn` (Archive Ballot lemmas restated). 4-site rename.
- **BinomialTheoremOQ02OQ04** — `h ▸ hi` elaboration drift → `by rw [← h]; exact hi`; goal carries un-beta-reduced `(g + fun t => …)` Pi-add form → restate `hmn` in `+`-form + `Pi.add_apply`/`if_true`; stale terminal theorem hit a `DecidableEq (Fin 3)` instance diamond → `Finset.sum_congr (by congr 1; exact Subsingleton.elim _ _)`.
- **Erdos121Problem** — local `def IsSquare` shadows Mathlib `IsSquare` → `IsPerfectSq`.
- **Erdos346Problem** — local `def IsComplete` shadows Mathlib `IsComplete` → `IsCompleteSet`.
- **Erdos181OQ01** — `simp_all [Function.id]` (`Function.id` gone; plain `simp_all` overflows recursion) → explicit `fin_cases … <;> first | exact absurd rfl hxy | rfl | exact hsymm _ _`.
- **Erdos10OQ01** — `set … with hF` no longer folds the goal filter → dropped `set`, normalized goal with `simp only [Set.mem_setOf_eq]`.
- **Konigsberg** — `Nat.odd_iff_not_even` removed → `Nat.not_even_iff_odd` + `Set.mem_setOf_eq` + `degree_eq_degree`.

## Reusable recipes
- `ProbabilityTheory.condCount` → `uniformOn`
- `Function.id` identifier removed → `id`/`id_eq`
- `Nat.odd_iff_not_even` removed → `Nat.not_even_iff_odd` (direction reversed)
- Local `IsSquare`/`IsComplete` defs now shadow Mathlib → rename
- `set x := … with hF` may not fold the goal anymore → `simp only [Set.mem_setOf_eq]`
- `DecidableEq` instance diamond → `Subsingleton.elim` under `congr 1`

## Honest yield read
**A–M deep-rework is nearly tapped out**, confirming inc50/51. The only reliably-yielding veins left are local-def-shadows-Mathlib name collisions and single-symbol API renames — the error-count probe exhausted both in this partition. Remaining RED files are dominated by genuine multi-site proof surgery: Fintype-synthesis-on-set-comprehension drift (Erdos395/407/559, Hilbert20, Maschke), `field_simp`/`ring` normalization drift (CevasOQ01OQ03), `native_decide`-on-noncomputable-`orderOf` (AbelRuffiniOQ10), `frequently_lt_of_liminf_lt` cobounded-autoParam surgery (Erdos39), universe-polymorphism (Erdos598), `generalize_proofs` auto-name churn (Erdos124), and a couple of latent logic gaps (Erdos490Aristotle). Several apparent '1-error' files were parse-error-masked multi-error files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)