### PR TITLE
migrate(v4.31): Doctor increment 52 cont. — deriving/termination/TestApi241 (+3 GREEN)

### DIFF
--- a/proofs/Proofs/Erdos628Aristotle.lean
+++ b/proofs/Proofs/Erdos628Aristotle.lean
@@ -22,25 +22,25 @@ variable {V : Type*} [Fintype V] [DecidableEq V]
 /-- Perfect graphs satisfy cliqueNumber G < chromaticNumber G + 1.
     Follows because IsPerfect implies chromaticNumber G = cliqueNumber G. -/
 theorem perfect_clique_free (G : SimpleGraph V) (hperf : IsPerfect G) :
-    IsCliqueFree G (chromaticNumber G + 1) := by
+    IsCliqueFree G (GraphCore.chromaticNumber G + 1) := by
   sorry
 
 /-- For a perfect graph with chromaticNumber k, G is not K_k-free.
     Perfect graphs contain K_k when χ(G) = k. -/
 theorem perfect_tihany_vacuous (G : SimpleGraph V) (hperf : IsPerfect G)
-    (k : ℕ) (hχ : chromaticNumber G = k) :
+    (k : ℕ) (hχ : GraphCore.chromaticNumber G = k) :
     ¬IsCliqueFree G k := by
   sorry
 
 /-- Bipartite graphs have chromatic number ≤ 2. -/
 theorem bipartite_chi_le_2 (G : SimpleGraph V) (hbip : G.IsBipartite) :
-    chromaticNumber G ≤ 2 := by
+    GraphCore.chromaticNumber G ≤ 2 := by
   sorry
 
 /-- Every perfect graph is χ = ω (chromatic number equals clique number).
     Specialization of IsPerfect to the full vertex set. -/
 theorem perfect_chi_eq_omega (G : SimpleGraph V) (hperf : IsPerfect G) :
-    chromaticNumber G = cliqueNumber G := by
+    GraphCore.chromaticNumber G = cliqueNumber G := by
   sorry
 
 end Erdos628Aristotle

--- a/proofs/Proofs/Erdos838Problem.lean
+++ b/proofs/Proofs/Erdos838Problem.lean
@@ -39,7 +39,10 @@ Points in ℝ² in general position (no three collinear) and convex subsets.
 structure Point2D where
   x : ℝ
   y : ℝ
-deriving DecidableEq
+
+/-- `Point2D` has decidable equality (noncomputably, via `Classical` — the real
+    coordinates make the derived instance noncomputable in v4.31). -/
+noncomputable instance : DecidableEq Point2D := Classical.decEq _
 
 /-- Three points are collinear if they lie on a common line -/
 def collinear (p q r : Point2D) : Prop :=

--- a/proofs/Proofs/Erdos870Aristotle.lean
+++ b/proofs/Proofs/Erdos870Aristotle.lean
@@ -33,9 +33,11 @@ theorem nat_has_one_rep (n : ℕ) : Nonempty (KRep (Set.univ : Set ℕ) 1 n) := 
 theorem singleton_sum_eq (a : ℕ) (f : ℕ → ℕ) : ({a} : Finset ℕ).sum f = f a := by
   sorry
 
-/-- Any k-representation in B is also one in A when B ⊆ A. -/
-theorem lift_rep (A B : Set ℕ) (k n : ℕ) (h : B ⊆ A) (rep : KRep B k n) : KRep A k n := by
-  sorry
+/-- Any k-representation in B is also one in A when B ⊆ A.
+    (Data-carrying: `KRep` is a structure, so this must be a `def`, not a `theorem`.) -/
+def lift_rep (A B : Set ℕ) (k n : ℕ) (h : B ⊆ A) (rep : KRep B k n) : KRep A k n :=
+  { terms := rep.terms, count := rep.count, sum_eq := rep.sum_eq, bound := rep.bound,
+    subset := fun a ha => h (rep.subset a ha) }
 
 /-- If B ⊆ A and B has k-representations, then A does too. -/
 theorem basis_subset_inherit (A B : Set ℕ) (k n : ℕ) (h : B ⊆ A)

--- a/proofs/Proofs/Erdos927Problem.lean
+++ b/proofs/Proofs/Erdos927Problem.lean
@@ -118,6 +118,8 @@ noncomputable def logStar : ℕ → ℕ
   | n + 2 =>
     if Nat.log 2 (n + 2) ≤ 1 then 1
     else 1 + logStar (Nat.log 2 (n + 2))
+  termination_by n => n
+  decreasing_by exact Nat.log_lt_self 2 (by omega)
 
 /- 
 **log*(n) is very slowly growing:**

--- a/proofs/Proofs/PartitionTheorem.lean
+++ b/proofs/Proofs/PartitionTheorem.lean
@@ -127,7 +127,7 @@ example (n : ℕ) : Finset (Nat.Partition n) := Nat.Partition.odds n
 /-- A partition is odd iff all its parts are odd numbers. -/
 theorem odd_iff_all_odd {n : ℕ} (p : Nat.Partition n) :
     p ∈ Nat.Partition.odds n ↔ ∀ i ∈ p.parts, ¬Even i := by
-  simp [Nat.Partition.odds]
+  simp [Nat.Partition.odds, Nat.Partition.restricted]
 
 /-! ## Part IV: The Partition Theorem -/
 
@@ -148,7 +148,7 @@ These are equal because:
 -/
 theorem partition_theorem (n : ℕ) :
     (Nat.Partition.distincts n).card = (Nat.Partition.odds n).card :=
-  (Theorems100.partition_theorem n).symm
+  (Nat.Partition.card_odds_eq_card_distincts n).symm
 
 /-! ## Part V: Concrete Examples
 

--- a/proofs/Proofs/ShannonChannelCodingOQ03Aristotle.lean
+++ b/proofs/Proofs/ShannonChannelCodingOQ03Aristotle.lean
@@ -15,6 +15,7 @@
   - gibbs_inequality (already proved in main file)
 -/
 import Mathlib
+import Proofs.ShannonChannelCodingOQ04
 
 open Real Finset InformationTheory.BinaryEntropy
 

--- a/proofs/Proofs/TestApi241.lean
+++ b/proofs/Proofs/TestApi241.lean
@@ -5,9 +5,9 @@ import Mathlib.Data.Finset.Card
 import Mathlib.Data.Finset.Image
 import Mathlib.Tactic
 
-open scoped Classical
-
--- IsB3 definition from the problem file
+-- IsB3 definition from the problem file.
+-- A set A is B₃ (a Sidon set of order 3) if every sorted triple of elements
+-- has a distinct sum: equal 3-element sums force equal (sorted) triples.
 def IsB3 (A : Finset ℕ) : Prop :=
   ∀ a₁ ∈ A, ∀ b₁ ∈ A, ∀ c₁ ∈ A,
   ∀ a₂ ∈ A, ∀ b₂ ∈ A, ∀ c₂ ∈ A,
@@ -15,6 +15,8 @@ def IsB3 (A : Finset ℕ) : Prop :=
     a₁ + b₁ + c₁ = a₂ + b₂ + c₂ →
     a₁ = a₂ ∧ b₁ = b₂ ∧ c₁ = c₂
 
--- Test with native_decide
-theorem test_b3 : IsB3 {1, 2, 4, 8} := by native_decide
-
+-- `{1, 2, 4, 8}` is NOT B₃ (e.g. 1+1+4 = 6 = 2+2+2, distinct sorted triples,
+-- same sum), so the correct positive witness uses powers of a base > 3.
+-- Powers of 4 are B₃: a 3-element multiset sum is a base-4 numeral with all
+-- digits ≤ 3, hence uniquely determined by its value.
+theorem test_b3 : IsB3 {1, 4, 16, 64} := by unfold IsB3; decide

--- a/proofs/Proofs/TriangleInequalityOQ01.lean
+++ b/proofs/Proofs/TriangleInequalityOQ01.lean
@@ -90,14 +90,14 @@ precise that `1 ≤ p` is exactly the threshold at which Minkowski (constant
 /-- The general quasi-triangle inequality valid for **every** exponent `p`:
     `‖f + g‖_p ≤ C_p · (‖f‖_p + ‖g‖_p)` where `C_p = LpAddConst p`. -/
 theorem eLpNorm_add_le_const (hf : AEStronglyMeasurable f μ) (hg : AEStronglyMeasurable g μ) :
-    eLpNorm (f + g) p μ ≤ LpAddConst p * (eLpNorm f p μ + eLpNorm g p μ) :=
+    eLpNorm (f + g) p μ ≤ ENNReal.LpAddConst p * (eLpNorm f p μ + eLpNorm g p μ) :=
   MeasureTheory.eLpNorm_add_le' hf hg p
 
 /-- On the Minkowski range `1 ≤ p` the constant collapses to `1`, recovering
     the honest triangle inequality. This pins down `1 ≤ p` as the exact
     convexity threshold. -/
-theorem LpAddConst_eq_one (hp1 : 1 ≤ p) : LpAddConst p = 1 :=
-  MeasureTheory.LpAddConst_of_one_le hp1
+theorem LpAddConst_eq_one (hp1 : 1 ≤ p) : ENNReal.LpAddConst p = 1 :=
+  ENNReal.LpAddConst_of_one_le hp1
 
 -- ══════════════════════════════════════════════════════════════════
 -- § Part III: L^p is closed under addition (Minkowski as closure)
@@ -141,8 +141,8 @@ variable [hp : Fact (1 ≤ p)]
 theorem lp_norm_add_le (f g : Lp E p μ) : ‖f + g‖ ≤ ‖f‖ + ‖g‖ :=
   norm_add_le f g
 
-/-- The L^p norm relates to the seminorm by `‖f‖ = (eLpNorm f p μ).toReal`. -/
 omit hp in
+/-- The L^p norm relates to the seminorm by `‖f‖ = (eLpNorm f p μ).toReal`. -/
 theorem lp_norm_def (f : Lp E p μ) : ‖f‖ = (eLpNorm f p μ).toReal :=
   Lp.norm_def f
 

--- a/proofs/batch2/STATUS.md
+++ b/proofs/batch2/STATUS.md
@@ -2594,3 +2594,32 @@ enforcement, and (f) FREE-GREENS as deps clear (2 this increment). The hard resi
 Mathlib regressions needing surgery (`Nontrivial (ℤ√d)` instance loss, positivity/simp
 maxRecDepth loops, native_decide-on-noncomputable, scalar-form lemma removals). Estimate ~5-10
 more single-recipe N–Z/Erdos≥600 files remain harvestable.
+
+### Increment 52 (continued) — +3 more GREEN (total +10, ledger 1908→1918)
+
+- **Erdos838Problem** (deriving-DecidableEq on ℝ-field struct): v4.31 `deriving DecidableEq` on a
+  structure with `ℝ` fields (`Point2D`) fails to COMPILE the derived instance (`DecidableEq ℝ` is
+  noncomputable). Replace with `noncomputable instance : DecidableEq Point2D := Classical.decEq _`
+  — still gives `Finset Point2D` the instance, without a compiled decision procedure.
+- **Erdos927Problem** (termination): v4.31 no longer auto-infers well-founded recursion for
+  `logStar` (recursive call `logStar (Nat.log 2 (n+2))`). Add `termination_by n => n` +
+  `decreasing_by exact Nat.log_lt_self 2 (by omega)` (`Nat.log_lt_self : log b x < x` for `x≠0`).
+- **TestApi241** (STATEMENT REPAIR, #38611): the original `test_b3 : IsB3 {1,2,4,8}` was UNSOUND
+  ({1,2,4,8} is not B₃ — 1+1+4 = 6 = 2+2+2). Repaired to the intended-true witness
+  `IsB3 {1,4,16,64}` (powers of 4 are B₃: a 3-element multiset sum is a base-4 numeral, all digits
+  ≤ 3 ⇒ unique). Dropped `open scoped Classical` (made IsB3 noncomputable) and proved via
+  `unfold IsB3; decide` — kernel decide, NO `Lean.ofReduceBool` (fully verified, 0 axioms).
+
+**Additional probed-and-skipped**:
+- **Erdos807Problem** — UNSOUND (like TestApi241 but not repairable as a seam): `ERW_conjecture := True`
+  placeholder makes `erw_conjecture_false : ¬∀n, ERW_conjecture n` = `¬True` = provably false. Every
+  theorem is a `True`-placeholder; a real repair needs the actual probabilistic statement formalized.
+  Reverted.
+- **Erdos807/874/625/611, Ptolemy** — Ptolemy confirmed deep (import `/-!`→`/-` fix surfaces 14
+  errors: `Complex.abs_mul_exp_arg_mul_I` unknown, `Real.sin_nonpos_of_nonneg_of_nonpos` unknown,
+  ℤ-anon-constructor, rcases/type-mismatch). Erdos874 linarith drift. Multi-site.
+
+**Free-green note**: the LOW(0) residuals in both partitions (Wilsons/Sperner/Szemeredi/YangMills
+clusters, TestApi203, NormEuclidean…OQ01) are all DEP-BLOCKED (own=0 but tot>0), not free-green —
+their deps still fail. Only 2 genuine free-greens this increment
+(QuadraticReciprocityAlgorithmOQ03FieldBridge, Erdos620ProblemAristotle).

--- a/proofs/batch2/STATUS.md
+++ b/proofs/batch2/STATUS.md
@@ -2519,3 +2519,78 @@ clusters, the Sylow-API cluster *partially* yielded (OQ02Orbit: normalizer-signa
 1-binder swap. But `native_decide`-on-noncomputable-Fintype (SylowTheoremOQ04) is a hard model
 change, and the remaining N–Z residuals are genuine multi-site proof surgery. The statement-repair
 targets (Erdos724, Erdos1123, RamseysTheoremOQ04) all yielded to real intended-true fixes.
+
+## Increment 52 (Doctor, N–Z / Erdos≥600, deep-rework clusters) — +7 GREEN
+
+**+7 GREEN**:
+- **TriangleInequalityOQ01** (namespace move + parser): `LpAddConst` /
+  `LpAddConst_of_one_le` moved into the `ENNReal` namespace (were unqualified /
+  `MeasureTheory.*`) → qualify `ENNReal.LpAddConst[_of_one_le]`. Plus a v4.31 parser change:
+  a `/-- docstring -/` immediately before `omit hp in` orphans the docstring
+  (`unexpected token 'omit'; expected 'lemma'`) → put `omit hp in` FIRST, docstring second.
+- **PartitionTheorem** (Archive→mainline relocation): `Theorems100.partition_theorem`
+  (Archive/Wiedijk100Theorems — NOT in `import Mathlib`) moved into mainline as
+  `Nat.Partition.card_odds_eq_card_distincts` (Combinatorics.Enumerative.Partition.Glaisher),
+  stated `#(odds n) = #(distincts n)` → use `.symm`. Also `Nat.Partition.odds` now unfolds to
+  `restricted n (¬Even ·)`; the membership `simp` needs `[Nat.Partition.odds,
+  Nat.Partition.restricted]` and must KEEP `¬Even` (do NOT rewrite to `Odd`).
+- **QuadraticReciprocityAlgorithmOQ03FieldBridge** (free-green): dep cleared upstream; no edit.
+- **Erdos628Aristotle** (name ambiguity): `chromaticNumber` is now ambiguous —
+  `SimpleGraph.chromaticNumber : ℕ∞` vs project `GraphCore.chromaticNumber : ℕ`, both opened
+  via `open GraphCore SimpleGraph`. Qualify all 4 uses as `GraphCore.chromaticNumber`
+  (the ℕ one, paired with `cliqueNumber : ℕ`). sorry bodies are pre-existing Aristotle stubs.
+- **ShannonChannelCodingOQ03Aristotle** (missing project import): `open
+  InformationTheory.BinaryEntropy` refers to a PROJECT namespace (defined in
+  `ShannonChannelCodingOQ04.lean`, where `h` = binary entropy lives) — Mathlib REMOVED its own
+  `binaryEntropy`. The companion opened the namespace but imported only `Mathlib`, so `h` was
+  unresolved (`unknown namespace` + `Function expected`). Add `import
+  Proofs.ShannonChannelCodingOQ04`.
+- **Erdos620ProblemAristotle** (free-green): dep chain greened upstream; no edit.
+- **Erdos870Aristotle** (Type-valued theorem → def): v4.31 rejects a `theorem` whose statement
+  is Type-valued (`type of theorem … is not a proposition`). `lift_rep` returns `KRep A k n`
+  (a structure). Convert `theorem`→`def` and supply a REAL body (lift re-uses the same
+  terms/count/sum/bound and composes the subset field: `fun a ha => h (rep.subset a ha)`),
+  discharging the former `sorry` with an actual proof.
+
+**Statement repairs**: none this increment. The named targets Erdos1112/Erdos1125 were ALREADY
+greened by sibling increment 50 (skip). TestApi241 remains genuinely-false (`{1,2,4,8}` not B3).
+
+**New recipes** (see rename-map §7af):
+- `ENNReal.LpAddConst` / `ENNReal.LpAddConst_of_one_le` namespace move.
+- `omit … in` must PRECEDE (not follow) a docstring.
+- Archive→mainline: `Theorems100.partition_theorem` → `Nat.Partition.card_odds_eq_card_distincts`;
+  `Nat.Partition.odds = restricted n (¬Even ·)`.
+- `chromaticNumber` ℕ∞ (SimpleGraph) vs ℕ (project GraphCore) ambiguity → qualify.
+- Project-namespace `open X` needs the file defining `X` imported (Shannon `h` in OQ04).
+- **Type-valued `theorem` now rejected** → make it a `def` (v4.31 enforcement).
+
+**Probed-and-skipped (genuine regressions / multi-site, NOT mechanical seam)**:
+- **NormEuclideanZsqrtdFamilyOQ03OQ02** — `isPrincipalIdealRing` yields via
+  `EuclideanDomain.to_principal_ideal_domain`, but the UFD half is blocked by a real Mathlib
+  regression: `Nontrivial (ℤ√d)` LOST its instance in v4.31, so `IsDomain (ℤ√d)` no longer
+  synthesizes (globally or via the EuclideanDomain letI) — breaks `to_uniqueFactorizationMonoid`
+  and the whole PID/UFD/prime chain. Needs `Nontrivial (ℤ√d)` reconstructed throughout. Reverted.
+- **SzemerediRegularityOQ02** — `simp [hCard_eq0]`/`positivity` hit `maximum recursion depth`
+  (already `maxRecDepth 40000`); the loop is inside `positivity`'s internal simp, a v4.31
+  regression, not a rename. Surgical `rw` on the trans-branch clears but `positivity` still loops.
+  Reverted.
+- **Erdos608Problem** — `O(1)` pseudo-syntax in a theorem statement (`unexpected token '('`) +
+  `_ % (2*k+1)` omega failures on Fin-coerced mod. Statement-repair + drift. Deferred.
+- **Erdos680Problem** — `Real.tendsto_pow_mul_exp_neg_atTop_nhds n c hc` (scalar-`c` form)
+  REMOVED; only `tendsto_pow_mul_exp_neg_atTop_nhds_zero n` (coefficient 1) survives — needs the
+  `c`-scaled version reconstructed by composing with `x ↦ c*x`. Genuine, not a rename.
+- **Erdos662Problem / PicksTheoremOQ01OQ01OQ01** — `native_decide` on noncomputable
+  Fintype/`realInteriorCount` (the SetLike/noncomputable model change). Stuck.
+- **Erdos613Aristotle** — 3 omega failures rooted in `Nat.choose_two_right`'s `/2` truncated
+  division; needs per-theorem nlinarith surgery on the even-numerator facts (nonlinear). Deep.
+- **TestApi1056** — omega-in-`def` + `decide` failures (per skip-list). PNPBarriersLegacy —
+  `Computability.FinEncoding` API mismatch in a 5800-line file. Both deep.
+
+**VERDICT (N–Z / Erdos≥600 seam):** thinning but **NOT fully dry**. Single-recipe wins still
+surface reliably in a few recognizable classes: (a) Mathlib namespace MOVES (ENNReal.LpAddConst),
+(b) Archive→mainline theorem RELOCATIONS (partition), (c) name-AMBIGUITY qualifications
+(chromaticNumber), (d) missing PROJECT-namespace imports (Shannon h), (e) Type-valued-theorem→def
+enforcement, and (f) FREE-GREENS as deps clear (2 this increment). The hard residuals are genuine
+Mathlib regressions needing surgery (`Nontrivial (ℤ√d)` instance loss, positivity/simp
+maxRecDepth loops, native_decide-on-noncomputable, scalar-form lemma removals). Estimate ~5-10
+more single-recipe N–Z/Erdos≥600 files remain harvestable.

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -1501,7 +1501,7 @@ Erdos626ProblemAristotle	GREEN
 Erdos627Aristotle	GREEN	
 Erdos627Problem	GREEN	
 Erdos627ProblemAristotle	GREEN	
-Erdos628Aristotle	RESIDUAL	instance-synth
+Erdos628Aristotle	GREEN	
 Erdos628Problem	GREEN	
 Erdos628ProblemAristotle	GREEN	
 Erdos629Aristotle	RESIDUAL	unknown-const:Nat.sInf

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -2292,7 +2292,7 @@ PNPBarriersLegacy	RESIDUAL	type-mismatch
 PNPBarriersSound	GREEN	
 PNPBarriersUnified	GREEN	
 PappusTheoremOQ02	GREEN	
-PartitionTheorem	RESIDUAL	unknown-const:Theorems100.partition_theorem
+PartitionTheorem	GREEN	
 PartitionTheoremOQ01	RESIDUAL	unknown-const:Finset.mem_empty
 PartitionTheoremOQ01OQ01	RESIDUAL	unknown-const:Finset.mem_empty
 PartitionTheoremOQ03	RESIDUAL	unknown-const:Nat.Partition.IsOdd.card

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -2568,7 +2568,7 @@ TestApi1159b	GREEN
 TestApi1159c	GREEN	
 TestApi203	RESIDUAL	unclassified
 TestApi234	GREEN	
-TestApi241	RESIDUAL	noncomputable
+TestApi241	GREEN	
 TestApi249	GREEN	
 TestApi301	GREEN	
 TestApi312	GREEN	

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -2617,7 +2617,7 @@ TractatusQuantifiers	GREEN
 TriangleAngleSum	GREEN	
 TriangleAngleSumOQ02	RESIDUAL	type-mismatch
 TriangleInequality	GREEN	
-TriangleInequalityOQ01	RESIDUAL	unknown-const:MeasureTheory.LpAddConst_of_one_le
+TriangleInequalityOQ01	GREEN	
 TriangleInequalityOQ04	GREEN	
 TriangleInequalityOQ06	GREEN
 TriangularNumberReciprocals	GREEN	

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -1750,7 +1750,7 @@ Erdos833Problem	GREEN
 Erdos834Problem	GREEN	
 Erdos835Problem	GREEN	
 Erdos836Problem	GREEN	
-Erdos838Problem	RESIDUAL	noncomputable
+Erdos838Problem	GREEN	
 Erdos839Problem	GREEN	
 Erdos841Problem	GREEN	
 Erdos842Problem	GREEN	

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -2411,7 +2411,7 @@ ShannonChannelCodingOQ02OQ01Aristotle	GREEN
 ShannonChannelCodingOQ02OQ03	GREEN	
 ShannonChannelCodingOQ02OQ04	GREEN	
 ShannonChannelCodingOQ03	GREEN	
-ShannonChannelCodingOQ03Aristotle	RESIDUAL	signature-drift
+ShannonChannelCodingOQ03Aristotle	GREEN	
 ShannonChannelCodingOQ04OQ01	GREEN	
 ShannonChannelCodingOQ04OQ01OQ01	GREEN	
 ShannonEntropyAristotle	GREEN	

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -2348,7 +2348,7 @@ PythagoreanTheoremOQ05	GREEN
 PythagoreanTriplesOQ02	GREEN	
 PythagoreanTriplesOQ04OQ01OQ01	GREEN	
 QuadraticReciprocityAlgorithmOQ03	GREEN	
-QuadraticReciprocityAlgorithmOQ03FieldBridge	RESIDUAL	rewrite-drift
+QuadraticReciprocityAlgorithmOQ03FieldBridge	GREEN	
 QuadraticReciprocityAlgorithmOQ03M2	GREEN	
 QuadraticReciprocityAlgorithmOQ03M2Capstone	GREEN	rewrite-drift
 QuadraticReciprocityAlgorithmOQ03Zolotarev	GREEN	rewrite-drift

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -1790,7 +1790,7 @@ Erdos867Problem	GREEN	unknown-const:Finset.card_Ioc
 Erdos868Problem	GREEN	
 Erdos869Problem	GREEN	
 Erdos86Problem	RESIDUAL	parse-error
-Erdos870Aristotle	RESIDUAL	uses-sorry
+Erdos870Aristotle	GREEN	
 Erdos870Problem	GREEN	
 Erdos871Problem	GREEN	
 Erdos872Problem	GREEN	

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -1485,7 +1485,7 @@ Erdos619Problem	RESIDUAL	instance-synth
 Erdos61Problem	GREEN	
 Erdos620Aristotle	GREEN	
 Erdos620Problem	GREEN	
-Erdos620ProblemAristotle	RESIDUAL	type-mismatch
+Erdos620ProblemAristotle	GREEN	
 Erdos621Problem	GREEN	
 Erdos622OQ04	RESIDUAL	instance-synth
 Erdos622Problem	RESIDUAL	instance-synth

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -1861,7 +1861,7 @@ Erdos923Problem	GREEN
 Erdos924Problem	GREEN	
 Erdos925Problem	GREEN	
 Erdos926Problem	GREEN	
-Erdos927Problem	RESIDUAL	termination-drift
+Erdos927Problem	GREEN	
 Erdos928Problem	GREEN	
 Erdos92Problem	GREEN	
 Erdos930Problem	GREEN	

--- a/research/toolchain-v4.31-rename-map.md
+++ b/research/toolchain-v4.31-rename-map.md
@@ -1504,3 +1504,41 @@ subtraction made the original statement false; geometric gluing bound). No calle
   per decl; clearing it can surface a cluster of genuine drift (AmgmInequalityOQ02OQ01OQ02OQ01OQ03:
   4 reported → 6+ real induction-drift sites). Probe by fixing the head error and re-counting
   before committing to a file.
+
+## §7af — Increment 52 recipes (N–Z / Erdos≥600 deep-rework)
+
+- **`LpAddConst` / `LpAddConst_of_one_le` moved to the `ENNReal` namespace.** Unqualified or
+  `MeasureTheory.LpAddConst*` now fail (`Function expected` / `unknown-const`). Qualify:
+  `ENNReal.LpAddConst`, `ENNReal.LpAddConst_of_one_le`. (`eLpNorm_add_le'` stays
+  `MeasureTheory.eLpNorm_add_le'`.) The Mathlib file that uses them just does `open … ENNReal`.
+- **`omit … in` must PRECEDE a docstring, not follow it.** In v4.31 `/-- doc -/` immediately
+  before `omit h in theorem …` errors `unexpected token 'omit'; expected 'lemma'` (the docstring
+  is orphaned). Reorder to `omit h in` then `/-- doc -/` then the declaration.
+- **Euler partition theorem moved Archive→mainline.** `Theorems100.partition_theorem` lived in
+  `Archive/Wiedijk100Theorems/Partition.lean` (NOT reachable via `import Mathlib`). Now mainline:
+  `Nat.Partition.card_odds_eq_card_distincts (n) : #(odds n) = #(distincts n)`
+  (Mathlib.Combinatorics.Enumerative.Partition.Glaisher). For `#(distincts n) = #(odds n)` use
+  `.symm`. Related: `Nat.Partition.odds n = restricted n (¬Even ·)`; to reduce membership to
+  `∀ i ∈ p.parts, ¬Even i`, `simp [Nat.Partition.odds, Nat.Partition.restricted]` — do NOT rewrite
+  `¬Even`→`Odd` (the def is stated with `¬Even`, so it re-loops).
+- **`chromaticNumber` ambiguity.** With `open GraphCore SimpleGraph`, `chromaticNumber` resolves
+  to both `SimpleGraph.chromaticNumber : ℕ∞` and the project's `GraphCore.chromaticNumber : ℕ`
+  (`Ambiguous term`). Qualify to the intended one (usually `GraphCore.chromaticNumber`, matched to
+  `cliqueNumber : ℕ`).
+- **Project-namespace `open` needs the defining file imported.** `open InformationTheory.BinaryEntropy`
+  is a PROJECT namespace (Mathlib removed its own binaryEntropy); `h` (binary entropy) lives in
+  `Proofs.ShannonChannelCodingOQ04`. Companions that only `import Mathlib` get `unknown namespace`
+  + `Function expected` on `h`; add `import Proofs.ShannonChannelCodingOQ04`.
+- **Type-valued `theorem` now rejected.** `theorem f … : T` where `T : Type _` (e.g. returns a
+  `structure` like `KRep A k n`) errors `type of theorem … is not a proposition`. Make it a `def`.
+  (Often the body can be a real term, discharging any sorry — e.g. re-bundle the structure fields
+  and thread the hypothesis through the `Prop`-valued fields.)
+- **`Nontrivial (ℤ√d)` lost its instance (regression, NOT a rename).** `IsDomain (ℤ√d)` no longer
+  synthesizes (the global `Zsqrtd` instance calls `NoZeroDivisors.to_isDomain _` which needs
+  `Nontrivial`). Blocks `PrincipalIdealRing.to_uniqueFactorizationMonoid` and any UFD/prime chain
+  on `ℤ√d`. `EuclideanDomain.to_principal_ideal_domain` (PID half) still works under a local
+  `letI := euclideanDomain …`. Full fix needs `Nontrivial (ℤ√d)` reconstructed — deep.
+- **FREE-GREENS:** re-probe RESIDUAL files whose ONLY errors were in deps (own=0) — several now
+  build clean as earlier increments greened their deps (this increment:
+  QuadraticReciprocityAlgorithmOQ03FieldBridge, Erdos620ProblemAristotle). A `PASS` with no source
+  edit is a legitimate flip.

--- a/research/toolchain-v4.31-rename-map.md
+++ b/research/toolchain-v4.31-rename-map.md
@@ -1542,3 +1542,17 @@ subtraction made the original statement false; geometric gluing bound). No calle
   build clean as earlier increments greened their deps (this increment:
   QuadraticReciprocityAlgorithmOQ03FieldBridge, Erdos620ProblemAristotle). A `PASS` with no source
   edit is a legitimate flip.
+
+### §7af addenda (inc52 second half)
+
+- **`deriving DecidableEq` on a struct with `ℝ` (or other noncomputable-DecidableEq) fields now
+  fails to COMPILE.** `deriving DecidableEq` errors `failed to compile definition, consider marking
+  it as 'noncomputable' … depends on 'decidableEq'`. Fix: drop the `deriving` clause and add
+  `noncomputable instance : DecidableEq T := Classical.decEq _`. Downstream `Finset T` still works.
+- **Well-founded recursion no longer auto-inferred for `Nat.log`-style descent.** A `def f : ℕ → ℕ`
+  with a recursive call `f (Nat.log b (n+…))` errors `fail to show termination`. Add
+  `termination_by n => n` and `decreasing_by exact Nat.log_lt_self b (by omega)`.
+- **UNSOUND-placeholder files are NOT migration seams** (skip, don't force-green): e.g. Erdos807
+  (`ERW_conjecture := True` ⇒ `¬∀n, True` unprovable), TestApi241's original `{1,2,4,8}` B3 claim.
+  For TestApi241 the fix was a genuine STATEMENT REPAIR to a true witness `{1,4,16,64}` — do that only
+  when a true correction is clear; otherwise leave the file RESIDUAL.


### PR DESCRIPTION
Increment 52's second half beyond the early PR #38656: +3 verified GREEN (Erdos838Problem [deriving-DecidableEq→noncomputable Classical.decEq], Erdos927Problem [termination_by Nat.log-descent], TestApi241 [statement repair: false IsB3 {1,2,4,8} → intended-true {1,4,16,64}, 0 axioms]) + §7af recipes. All in-container lake-exit-0 verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)