### PR TITLE
migrate(v4.31): Doctor increment 56 — deep-rework partition A (+30 GREEN)

### DIFF
--- a/proofs/Proofs/CayleyHamiltonCyclicVectorAllFieldsOQ03.lean
+++ b/proofs/Proofs/CayleyHamiltonCyclicVectorAllFieldsOQ03.lean
@@ -147,7 +147,7 @@ theorem matrix_nonderog_of_minpoly_natDegree {n : ℕ}
     multiplying the matrix of `f` by the coordinate vector:
       `(toMatrix b b f).mulVec (b.repr x) = b.repr (f x)`.
     Proved from the definitional `LinearMap.toMatrix_apply`. -/
-theorem toMatrix_mulVec_repr {n : ℕ} (b : Basis (Fin n) K V)
+theorem toMatrix_mulVec_repr {n : ℕ} (b : Module.Basis (Fin n) K V)
     (f : Module.End K V) (x : V) :
     (LinearMap.toMatrix b b f).mulVec (fun i => b.repr x i) = fun i => b.repr (f x) i := by
   funext i
@@ -176,13 +176,13 @@ theorem operator_nonderogatory_has_cyclic_vector [FiniteDimensional K V]
   · -- finrank 0: the degree bound `< 0` is unsatisfiable, so any vector is cyclic.
     exact ⟨0, fun p hp _ => absurd hp (by rw [hn0]; exact Nat.not_lt_zero _)⟩
   -- Canonical basis and the matrix of T.
-  set b : Basis (Fin (Module.finrank K V)) K V := Module.finBasis K V with hb
+  set b : Module.Basis (Fin (Module.finrank K V)) K V := Module.finBasis K V with hb
   set M : Matrix (Fin (Module.finrank K V)) (Fin (Module.finrank K V)) K :=
     LinearMap.toMatrix b b T with hM
   -- (1) Minpoly transport: minpoly K M = minpoly K T.
   have hmin : minpoly K M = minpoly K T := by
     have := minpoly.algEquiv_eq (LinearMap.toMatrixAlgEquiv b) T
-    rwa [LinearMap.toMatrixAlgEquiv_apply] at this
+    exact this
   have hMdeg : (minpoly K M).natDegree = Module.finrank K V := by
     rw [hmin]; exact h
   -- (2) M is nonderogatory.
@@ -197,7 +197,7 @@ theorem operator_nonderogatory_has_cyclic_vector [FiniteDimensional K V]
   -- Coordinates of `b.equivFun.symm w` are exactly `w`.
   have hcoord : (fun i => b.repr (b.equivFun.symm w) i) = w := by
     funext i
-    rw [← Basis.equivFun_apply, LinearEquiv.apply_symm_apply]
+    rw [← Module.Basis.equivFun_apply, LinearEquiv.apply_symm_apply]
   -- toMatrix b b (aeval T p) = aeval M p.
   have hpoly : LinearMap.toMatrix b b (aeval T p) = aeval M p := by
     have key := Polynomial.aeval_algHom_apply
@@ -229,19 +229,18 @@ theorem krylov_linearIndependent_op [FiniteDimensional K V]
     LinearIndependent K (fun k : Fin (Module.finrank K V) => (T ^ (k : ℕ)) v) := by
   rw [Fintype.linearIndependent_iff]
   intro c hc i
-  set n := Module.finrank K V with hn
-  have hnpos : 0 < n := lt_of_le_of_lt (Nat.zero_le (i : ℕ)) i.isLt
-  set p := ∑ k : Fin n, C (c k) * X ^ (k : ℕ) with hp_def
-  have hp_aeval : aeval T p = ∑ k : Fin n, c k • T ^ (k : ℕ) := by
+  have hnpos : 0 < Module.finrank K V := lt_of_le_of_lt (Nat.zero_le (i : ℕ)) i.isLt
+  set p := ∑ k : Fin (Module.finrank K V), C (c k) * X ^ (k : ℕ) with hp_def
+  have hp_aeval : aeval T p = ∑ k : Fin (Module.finrank K V), c k • T ^ (k : ℕ) := by
     simp only [p, map_sum, map_mul, map_pow, aeval_C, aeval_X,
                Algebra.algebraMap_eq_smul_one, smul_mul_assoc, one_mul]
   have hp_ann : (aeval T p) v = 0 := by
     rw [hp_aeval]
-    have hsum : (∑ k : Fin n, c k • T ^ (k : ℕ)) v
-        = ∑ k : Fin n, c k • (T ^ (k : ℕ)) v := by
+    have hsum : (∑ k : Fin (Module.finrank K V), c k • T ^ (k : ℕ)) v
+        = ∑ k : Fin (Module.finrank K V), c k • (T ^ (k : ℕ)) v := by
       simp only [LinearMap.sum_apply, LinearMap.smul_apply]
     rw [hsum, hc]
-  have hp_deg : p.natDegree < n := by
+  have hp_deg : p.natDegree < Module.finrank K V := by
     apply lt_of_le_of_lt (natDegree_sum_le _ _)
     apply (Finset.sup_lt_iff hnpos).mpr
     intro k _; exact lt_of_le_of_lt (natDegree_C_mul_X_pow_le (c k) ↑k) k.isLt
@@ -266,8 +265,7 @@ theorem cyclicSubspace_eq_top_of_isCyclicVectorOp [FiniteDimensional K V]
   have hspan :
       Submodule.span K
           (Set.range fun k : Fin (Module.finrank K V) => (T ^ (k : ℕ)) v) = ⊤ := by
-    have hb := (basisOfLinearIndependentOfCardEqFinrank hli hcard).span_eq
-    simpa only [coe_basisOfLinearIndependentOfCardEqFinrank] using hb
+    exact hli.span_eq_top_of_card_eq_finrank' hcard
   rw [eq_top_iff, ← hspan]
   exact NonderogatoryModule.finiteSpan_le_cyclicSubspace T v (Module.finrank K V)
 

--- a/proofs/Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ02.lean
+++ b/proofs/Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ02.lean
@@ -177,7 +177,7 @@ theorem non_cyclic_mem_cofactorKernel (M : Matrix (Fin n) (Fin n) ℝ) (hn : 0 <
   -- s has a normalized irreducible factor q₀
   obtain ⟨q₀, hq₀_mem_s⟩ :=
     UniqueFactorizationMonoid.exists_mem_normalizedFactors hs_ne hs_not_unit
-  have hq₀_dvd_s : q₀ ∣ s := dvd_of_mem_normalizedFactors hq₀_mem_s
+  have hq₀_dvd_s : q₀ ∣ s := UniqueFactorizationMonoid.dvd_of_mem_normalizedFactors hq₀_mem_s
   have hq₀_irr : Irreducible q₀ :=
     (UniqueFactorizationMonoid.prime_of_normalized_factor q₀ hq₀_mem_s).irreducible
   have hq₀_dvd_μ : q₀ ∣ μ := dvd_trans hq₀_dvd_s ⟨d, by rw [hs_eq]; ring⟩
@@ -186,7 +186,7 @@ theorem non_cyclic_mem_cofactorKernel (M : Matrix (Fin n) (Fin n) ℝ) (hn : 0 <
     UniqueFactorizationMonoid.exists_mem_normalizedFactors_of_dvd hμ_ne hq₀_irr hq₀_dvd_μ
   have hq'_in_nf : q' ∈ (UniqueFactorizationMonoid.normalizedFactors μ).toFinset :=
     Multiset.mem_toFinset.mpr hq'_mem
-  have hq'_ne : q' ≠ 0 := ne_zero_of_mem_normalizedFactors hq'_mem
+  have hq'_ne : q' ≠ 0 := UniqueFactorizationMonoid.ne_zero_of_mem_normalizedFactors hq'_mem
   have hq'_dvd_q₀ : q' ∣ q₀ := hq'_assoc.symm.dvd
   have hq'_dvd_s : q' ∣ s := dvd_trans hq'_dvd_q₀ hq₀_dvd_s
   -- Show v ∈ cofactorKernel M q'
@@ -244,18 +244,19 @@ theorem non_cyclic_measure_zero (hn : 0 < n)
     intro q hq
     have hq_mem : q ∈ UniqueFactorizationMonoid.normalizedFactors μ :=
       Multiset.mem_toFinset.mp hq
-    have hq_dvd : q ∣ μ := dvd_of_mem_normalizedFactors hq_mem
-    have hq_ne : q ≠ 0 := ne_zero_of_mem_normalizedFactors hq_mem
+    have hq_dvd : q ∣ μ := UniqueFactorizationMonoid.dvd_of_mem_normalizedFactors hq_mem
+    have hq_ne : q ≠ 0 := UniqueFactorizationMonoid.ne_zero_of_mem_normalizedFactors hq_mem
     have hq_irr : Irreducible q :=
       (UniqueFactorizationMonoid.prime_of_normalized_factor q hq_mem).irreducible
     exact volume_submodule_eq_zero _ (cofactorKernel_ne_top M hn hM q hq_dvd hq_ne hq_irr)
   -- Finite union of null sets is null
+  refine le_antisymm ?_ zero_le
   calc volume {v : Fin n → ℝ | ¬IsCyclicVector M v}
       ≤ volume (⋃ q ∈ nf, (cofactorKernel M q : Set (Fin n → ℝ))) :=
         measure_mono h_subset
     _ ≤ ∑ q ∈ nf, volume (cofactorKernel M q : Set (Fin n → ℝ)) :=
         measure_biUnion_finset_le nf _
-    _ = 0 := by simp [h_zero]
+    _ = 0 := Finset.sum_eq_zero h_zero
 
 /-- Cyclic vectors for a nonderogatory real matrix have full Lebesgue measure.
     This is the positive formulation: the complement of cyclic vectors is null. -/

--- a/proofs/Proofs/ElementaryQuadraticReciprocityOQ03OQ03.lean
+++ b/proofs/Proofs/ElementaryQuadraticReciprocityOQ03OQ03.lean
@@ -36,7 +36,8 @@ open ZMod
 theorem legendre_characterizes_qr (p : ℕ) [hp : Fact p.Prime] (a : ℤ)
     (ha : ¬(↑p : ℤ) ∣ a) :
     legendreSym p a = 1 ↔ IsSquare (a : ZMod p) := by
-  exact legendreSym.eq_one_iff_isSquare ha
+  exact legendreSym.eq_one_iff p
+    (by rwa [Ne, ZMod.intCast_zmod_eq_zero_iff_dvd])
 
 -- ============================================================
 -- SECTION II: Product Formula as Reciprocity
@@ -48,13 +49,15 @@ theorem legendre_characterizes_qr (p : ℕ) [hp : Fact p.Prime] (a : ℤ)
 theorem qr_legendre (p q : ℕ) [hp : Fact p.Prime] [hq : Fact q.Prime]
     (hp2 : p ≠ 2) (hq2 : q ≠ 2) (hpq : p ≠ q) :
     legendreSym p q * legendreSym q p =
-    (-1) ^ ((p / 2) * (q / 2)) :=
-  legendreSym.quadratic_reciprocity hp2 hq2 hpq
+    (-1) ^ ((p / 2) * (q / 2)) := by
+  rw [mul_comm (legendreSym p (q : ℤ)) (legendreSym q (p : ℤ))]
+  exact legendreSym.quadratic_reciprocity hp2 hq2 hpq
 
 /-- First supplement to QR: (-1/p) = (-1)^((p-1)/2). -/
 theorem first_supplement (p : ℕ) [hp : Fact p.Prime] (hp2 : p ≠ 2) :
     legendreSym p (-1) = (-1) ^ (p / 2) :=
-  legendreSym.at_neg_one hp2
+  (legendreSym.at_neg_one hp2).trans
+    (ZMod.χ₄_eq_neg_one_pow (Nat.odd_iff.mp (hp.out.odd_of_ne_two hp2)))
 
 -- ============================================================
 -- SECTION III: The Hilbert Symbol (Definition)

--- a/proofs/Proofs/Erdos162Problem.lean
+++ b/proofs/Proofs/Erdos162Problem.lean
@@ -54,58 +54,66 @@ theorem colourEdgeCount_total {n : ℕ} (c : EdgeColouring n) (S : Finset (Fin n
   -- Partition: {(i,j) ∈ S×S | i<j ∧ colour=true} ⊔ {... ∧ colour=false} = {(i,j) ∈ S×S | i<j}
   rw [← Finset.card_union_of_disjoint]
   · -- Union = {(i,j) ∈ S×S | i < j}, and its card = C(|S|, 2)
-    congr 1
-    · ext p
+    have hset : ((S ×ˢ S).filter fun p => p.1 < p.2 ∧ c.colour p.1 p.2 = true) ∪
+        ((S ×ˢ S).filter fun p => p.1 < p.2 ∧ c.colour p.1 p.2 = false) =
+        (S ×ˢ S).filter fun p : Fin n × Fin n => p.1 < p.2 := by
+      ext p
       simp only [Finset.mem_union, Finset.mem_filter, Finset.mem_product]
       constructor
       · rintro (⟨h1, h2, _⟩ | ⟨h1, h2, _⟩) <;> exact ⟨h1, h2⟩
       · rintro ⟨h1, h2⟩
-        rcases Bool.eq_true_or_eq_false (c.colour p.1 p.2) with h | h
-        · exact Or.inl ⟨h1, h2, h⟩
-        · exact Or.inr ⟨h1, h2, h⟩
-    · -- |{(i,j) ∈ S×S | i < j}| = C(|S|, 2)
-      -- Proof: strict-order pairs = half of off-diagonal pairs.
-      -- offDiag.card = n*(n-1), and C(n,2) = n*(n-1)/2.
-      rw [Nat.choose_two_right]
-      suffices h : 2 * ((S ×ˢ S).filter fun p : Fin n × Fin n => p.1 < p.2).card =
-          S.card * (S.card - 1) by omega
-      rw [← S.card_offDiag]
-      -- offDiag = filter(<) ∪ filter(>), disjoint, equal halves
-      have hlt_eq : (S ×ˢ S).filter (fun p : Fin n × Fin n => p.2 < p.1) =
-          ((S ×ˢ S).filter (fun p : Fin n × Fin n => p.1 < p.2)).image Prod.swap := by
-        ext ⟨a, b⟩
-        simp only [Finset.mem_filter, Finset.mem_product, Finset.mem_image, Prod.swap,
-          Prod.exists, Prod.mk.injEq]
-        constructor
-        · rintro ⟨⟨ha, hb⟩, hab⟩; exact ⟨b, a, ⟨⟨hb, ha⟩, hab⟩, rfl, rfl⟩
-        · rintro ⟨c, d, ⟨⟨hc, hd⟩, hcd⟩, rfl, rfl⟩; exact ⟨⟨hd, hc⟩, hcd⟩
-      have hcard_eq : ((S ×ˢ S).filter (fun p : Fin n × Fin n => p.1 < p.2)).card =
-          ((S ×ˢ S).filter (fun p : Fin n × Fin n => p.2 < p.1)).card := by
-        rw [hlt_eq, Finset.card_image_of_injective _ Prod.swap_injective]
-      have hunion : (S ×ˢ S).filter (fun p : Fin n × Fin n => p.1 < p.2) ∪
-          (S ×ˢ S).filter (fun p : Fin n × Fin n => p.2 < p.1) = S.offDiag := by
-        ext ⟨a, b⟩
-        simp only [Finset.mem_union, Finset.mem_filter, Finset.mem_product, Finset.mem_offDiag]
-        constructor
-        · rintro (⟨⟨ha, hb⟩, hab⟩ | ⟨⟨ha, hb⟩, hab⟩)
-          · exact ⟨ha, hb, ne_of_lt hab⟩
-          · exact ⟨ha, hb, ne_of_gt hab⟩
-        · rintro ⟨ha, hb, hab⟩
-          rcases lt_or_gt_of_ne hab with h | h
-          · exact Or.inl ⟨⟨ha, hb⟩, h⟩
-          · exact Or.inr ⟨⟨ha, hb⟩, h⟩
-      have hdisj : Disjoint
-          ((S ×ˢ S).filter (fun p : Fin n × Fin n => p.1 < p.2))
-          ((S ×ˢ S).filter (fun p : Fin n × Fin n => p.2 < p.1)) := by
-        rw [Finset.disjoint_filter]
-        intro ⟨a, b⟩ _ h1 h2; exact absurd (lt_trans h1 h2) (lt_irrefl _)
-      have h_union_card := Finset.card_union_of_disjoint hdisj
-      rw [hunion] at h_union_card
-      linarith
+        cases h : c.colour p.1 p.2
+        · exact Or.inr ⟨h1, h2, rfl⟩
+        · exact Or.inl ⟨h1, h2, rfl⟩
+    rw [hset]
+    -- |{(i,j) ∈ S×S | i < j}| = C(|S|, 2)
+    -- Proof: strict-order pairs = half of off-diagonal pairs.
+    -- offDiag.card = n*(n-1), and C(n,2) = n*(n-1)/2.
+    rw [Nat.choose_two_right]
+    suffices h : 2 * ((S ×ˢ S).filter fun p : Fin n × Fin n => p.1 < p.2).card =
+        S.card * (S.card - 1) by omega
+    have hoff : S.offDiag.card = S.card * (S.card - 1) := by
+      rw [Finset.offDiag_card]
+      cases S.card with
+      | zero => simp
+      | succ k => rw [Nat.mul_succ]; simp
+    rw [← hoff]
+    -- offDiag = filter(<) ∪ filter(>), disjoint, equal halves
+    have hlt_eq : (S ×ˢ S).filter (fun p : Fin n × Fin n => p.2 < p.1) =
+        ((S ×ˢ S).filter (fun p : Fin n × Fin n => p.1 < p.2)).image Prod.swap := by
+      ext ⟨a, b⟩
+      simp only [Finset.mem_filter, Finset.mem_product, Finset.mem_image, Prod.swap,
+        Prod.exists, Prod.mk.injEq]
+      constructor
+      · rintro ⟨⟨ha, hb⟩, hab⟩; exact ⟨b, a, ⟨⟨hb, ha⟩, hab⟩, rfl, rfl⟩
+      · rintro ⟨c, d, ⟨⟨hc, hd⟩, hcd⟩, rfl, rfl⟩; exact ⟨⟨hd, hc⟩, hcd⟩
+    have hcard_eq : ((S ×ˢ S).filter (fun p : Fin n × Fin n => p.1 < p.2)).card =
+        ((S ×ˢ S).filter (fun p : Fin n × Fin n => p.2 < p.1)).card := by
+      rw [hlt_eq, Finset.card_image_of_injective _ Prod.swap_injective]
+    have hunion : (S ×ˢ S).filter (fun p : Fin n × Fin n => p.1 < p.2) ∪
+        (S ×ˢ S).filter (fun p : Fin n × Fin n => p.2 < p.1) = S.offDiag := by
+      ext ⟨a, b⟩
+      simp only [Finset.mem_union, Finset.mem_filter, Finset.mem_product, Finset.mem_offDiag]
+      constructor
+      · rintro (⟨⟨ha, hb⟩, hab⟩ | ⟨⟨ha, hb⟩, hab⟩)
+        · exact ⟨ha, hb, ne_of_lt hab⟩
+        · exact ⟨ha, hb, ne_of_gt hab⟩
+      · rintro ⟨ha, hb, hab⟩
+        rcases lt_or_gt_of_ne hab with h | h
+        · exact Or.inl ⟨⟨ha, hb⟩, h⟩
+        · exact Or.inr ⟨⟨ha, hb⟩, h⟩
+    have hdisj : Disjoint
+        ((S ×ˢ S).filter (fun p : Fin n × Fin n => p.1 < p.2))
+        ((S ×ˢ S).filter (fun p : Fin n × Fin n => p.2 < p.1)) := by
+      rw [Finset.disjoint_filter]
+      intro ⟨a, b⟩ _ h1 h2; exact absurd (lt_trans h1 h2) (lt_irrefl _)
+    have h_union_card := Finset.card_union_of_disjoint hdisj
+    rw [hunion] at h_union_card
+    linarith
   · -- Disjoint: true ≠ false
     simp only [Finset.disjoint_filter]
     intro p _ ⟨_, htrue⟩ ⟨_, hfalse⟩
-    exact absurd (htrue.symm.trans hfalse) Bool.true_ne_false
+    exact absurd (htrue.symm.trans hfalse) (by decide)
 
 -- Part II: α-Balanced colourings
 

--- a/proofs/Proofs/Erdos195Problem.lean
+++ b/proofs/Proofs/Erdos195Problem.lean
@@ -33,7 +33,7 @@ def IsPermutation (f : ℤ → ℤ) : Prop :=
     a, a+d, a+2d, ..., a+(k-1)d -/
 def IsAP (xs : List ℤ) : Prop :=
   xs.length ≥ 2 ∧ ∃ d : ℤ, d ≠ 0 ∧ ∀ i : ℕ, i + 1 < xs.length →
-    xs.get! (i + 1) - xs[i]! = d
+    xs[i + 1]! - xs[i]! = d
 
 /-- A monotone arithmetic progression (MAP) in a permutation f:
     An AP x₁ < x₂ < ... < xₖ such that the positions of these values
@@ -90,6 +90,16 @@ def OpenQuestion : Prop :=
 
 /- ## Part VI: Adenwalla's Bound Implies Geneson's -/
 
+/-- `getElem!` commutes with `take` below the cutoff. -/
+private lemma getElem!_take_of_lt (xs : List ℤ) (n i : ℕ) (h : i < n) :
+    (xs.take n)[i]! = xs[i]! := by
+  rcases Nat.lt_or_ge i xs.length with hx | hx
+  · have h1 : i < (xs.take n).length := by simp [List.length_take]; omega
+    rw [getElem!_pos (xs.take n) i h1, getElem!_pos xs i hx]
+    simp [List.getElem_take]
+  · have h1 : ¬ i < (xs.take n).length := by simp [List.length_take]; omega
+    rw [getElem!_neg (xs.take n) i h1, getElem!_neg xs i (by omega)]
+
 /-- Adenwalla's result implies Geneson's: if we can avoid 5-MAPs, we certainly
     avoid 6-MAPs (since any 6-MAP contains a 5-MAP as a subsequence). -/
 theorem adenwalla_implies_geneson :
@@ -101,19 +111,19 @@ theorem adenwalla_implies_geneson :
     apply havoid
     obtain ⟨⟨hlen2, d, hd, hAP⟩, hchain, hpos⟩ := hmap
     refine ⟨xs.take 5, by simp [List.length_take, hlen], ?_⟩
-    refine ⟨⟨by simp [List.length_take, hlen]; omega, d, hd, fun i hi => ?_⟩,
-            List.Chain'.take hchain, fun i j hij hjlen => ?_⟩
+    refine ⟨⟨by simp [List.length_take, hlen], d, hd, fun i hi => ?_⟩,
+            List.IsChain.take hchain 5, fun i j hij hjlen => ?_⟩
     · -- AP property preserved under take
       have hi' : i + 1 < xs.length := by
         simp [List.length_take, hlen] at hi; omega
-      rw [List.get!_take (by simp [List.length_take, hlen] at hi ⊢; omega),
-          List.get!_take (by simp [List.length_take, hlen] at hi ⊢; omega)]
+      rw [getElem!_take_of_lt xs 5 (i + 1) (by simp [List.length_take, hlen] at hi; omega),
+          getElem!_take_of_lt xs 5 i (by simp [List.length_take, hlen] at hi; omega)]
       exact hAP i hi'
     · -- Position monotonicity preserved under take
       have hjlen' : j < xs.length := by
         simp [List.length_take, hlen] at hjlen; omega
-      rw [List.get!_take (by simp [List.length_take, hlen] at hjlen ⊢; omega),
-          List.get!_take (by simp [List.length_take, hlen] at hjlen ⊢; omega)]
+      rw [getElem!_take_of_lt xs 5 i (by simp [List.length_take, hlen] at hjlen; omega),
+          getElem!_take_of_lt xs 5 j (by simp [List.length_take, hlen] at hjlen; omega)]
       exact hpos i j hij hjlen'⟩
 
 /- ## Part VII: Examples -/

--- a/proofs/Proofs/Erdos19OQ01Problem.lean
+++ b/proofs/Proofs/Erdos19OQ01Problem.lean
@@ -30,6 +30,7 @@
 -/
 
 import Mathlib
+import Proofs.GraphCore
 
 open Finset SimpleGraph Classical
 
@@ -105,8 +106,9 @@ theorem efl_holds_above_threshold :
     EFL does not hold (unless the threshold is 0). -/
 theorem efl_threshold_minimal (h : eflThreshold ≠ 0) :
     ∃ n < eflThreshold, ¬ (∀ m ≥ n, EFLHoldsAt m) := by
-  have hmin := Nat.find_min kang_kelly_kuhn_methuku_osthus_asymptotic
-  exact ⟨eflThreshold - 1, by omega, hmin (by omega)⟩
+  refine ⟨eflThreshold - 1, by omega, ?_⟩
+  have hlt : eflThreshold - 1 < eflThreshold := by omega
+  exact Nat.find_min kang_kelly_kuhn_methuku_osthus_asymptotic hlt
 
 /-
 ## Part IV: Hindman's Small Cases

--- a/proofs/Proofs/Erdos226Problem.lean
+++ b/proofs/Proofs/Erdos226Problem.lean
@@ -78,7 +78,7 @@ def IsCountableDense (S : Set ℝ) : Prop :=
 theorem rationals_countable_dense : IsCountableDense (Set.range (↑· : ℚ → ℝ)) := by
   constructor
   · exact Set.countable_range _
-  · exact Rat.denseRange_ratCast
+  · exact Rat.denseRange_cast
 
 /- ## Part III: The Rationality Preservation Property -/
 
@@ -165,21 +165,15 @@ theorem erdos_question_affirmative : ErdosQuestion := by
   constructor
   · -- f is non-linear (transcendental implies non-linear)
     intro ⟨a, b, hlin⟩
-    have : ¬∃ n p, ∀ z, f z = p.eval z := hf_trans.2
+    have : ¬∃ (n : ℕ) (p : Polynomial ℂ), ∀ z, f z = p.eval z := hf_trans.2
     apply this
     use 1, Polynomial.C b + Polynomial.C a * Polynomial.X
     intro z
     simp only [Polynomial.eval_add, Polynomial.eval_C, Polynomial.eval_mul, Polynomial.eval_X]
-    ring_nf
-    exact hlin z
+    rw [hlin z]; ring
   · -- f preserves rationality
     intro x
-    rw [hf_preserves x]
-    constructor
-    · intro ⟨q, hq⟩
-      exact ⟨q, hq⟩
-    · intro ⟨q, hq⟩
-      exact ⟨q, hq⟩
+    simpa [Set.mem_range] using hf_preserves x
 
 /--
 **The General Question is Also Answered:**

--- a/proofs/Proofs/Erdos252Problem.lean
+++ b/proofs/Proofs/Erdos252Problem.lean
@@ -149,7 +149,7 @@ The divisors of p are {1, p}, so σ_k(p) = 1^k + p^k = 1 + p^k.
 -/
 theorem sigma_prime (p : ℕ) (hp : p.Prime) (k : ℕ) :
     sigma k p = 1 + p ^ k := by
-  simp only [sigma_apply, Nat.Prime.divisors hp, Finset.sum_pair hp.one_lt.ne', one_pow]
+  rw [sigma_apply, Nat.Prime.divisors hp, Finset.sum_pair hp.one_lt.ne, one_pow]
 
 /- ## Convergence
 
@@ -168,7 +168,7 @@ theorem sigma_le_pow (n k : ℕ) : sigma k n ≤ n ^ (k + 1) := by
     simp [sigma]
   · -- n ≥ 1: bound each term and count
     unfold sigma
-    rw [pow_succ]
+    rw [pow_succ']
     -- σ_k(n) = ∑ d ∈ n.divisors, d^k
     -- Each d ≤ n, so d^k ≤ n^k. Sum ≤ |n.divisors| · n^k ≤ n · n^k
     calc Finset.sum (Nat.divisors n) (· ^ k)
@@ -184,10 +184,10 @@ theorem sigma_le_pow (n k : ℕ) : sigma k n ≤ n ^ (k + 1) := by
                 apply Finset.card_le_card
                 intro d hd
                 simp only [Finset.mem_Icc]
-                exact ⟨Nat.pos_of_mem_divisors hd, Nat.divisor_le (Nat.mem_divisors.mp hd).1⟩
-            _ = n := by simp [Nat.card_Icc]; omega
+                exact ⟨Nat.pos_of_mem_divisors hd, Nat.divisor_le hd⟩
+            _ = n := by simp [Nat.card_Icc]
 
-/-- The series converges (proof sketch via comparison test).
+/- The series converges (proof sketch via comparison test).
 
 By sigma_le_pow, σ_k(n)/n! ≤ n^(k+1)/n!, and Σ n^(k+1)/n! converges
 since n^(k+1)/n! → 0 faster than any geometric sequence.

--- a/proofs/Proofs/Erdos260Aristotle.lean
+++ b/proofs/Proofs/Erdos260Aristotle.lean
@@ -65,8 +65,7 @@ theorem strictMono_telescope (f : ℕ → ℕ) (hf : StrictMono f) (n : ℕ) :
   induction n with
   | zero => simp
   | succ n ih =>
-    rw [Finset.sum_range_succ, ← Nat.add_sub_cancel (f (n + 1)),
-        show f (n + 1) - f (n + 1) + f (n + 1) = f (n + 1) from by omega]
+    rw [Finset.sum_range_succ]
     have : f n < f (n + 1) := hf (by omega)
     omega
 
@@ -76,7 +75,7 @@ theorem finset_sum_ge_of_ge {M : ℝ} {f : ℕ → ℝ} {n : ℕ}
     ∑ i ∈ Finset.range n, f i ≥ M * n := by
   calc ∑ i ∈ Finset.range n, f i ≥ ∑ _ ∈ Finset.range n, M :=
         Finset.sum_le_sum hf
-    _ = M * n := by simp [Finset.sum_const, Finset.card_range, nsmul_eq_mul]
+    _ = M * n := by simp [Finset.sum_const, Finset.card_range, nsmul_eq_mul, mul_comm]
 
 -- Aristotle target: constant / n -> 0
 theorem const_div_n_tendsto_zero (c : ℝ) :
@@ -90,14 +89,14 @@ theorem const_div_n_tendsto_zero (c : ℝ) :
 -- Aristotle target: log n -> infinity
 theorem real_log_tendsto_atTop :
     Tendsto (fun n : ℕ => Real.log (n : ℝ)) atTop atTop :=
-  Real.tendsto_log_nat_atTop
+  Real.tendsto_log_atTop.comp tendsto_natCast_atTop_atTop
 
 -- Aristotle target: if f -> infty and g -> infty then f * g -> infty (for eventually positive)
 theorem tendsto_mul_atTop_of_pos {f g : ℕ → ℝ}
     (hf : Tendsto f atTop atTop) (hg : ∀ᶠ n in atTop, g n > 0)
     (hg' : Tendsto g atTop atTop) :
     Tendsto (fun n => f n * g n) atTop atTop :=
-  Filter.Tendsto.atTop_mul_atTop hf hg'
+  Filter.Tendsto.atTop_mul_atTop₀ hf hg'
 
 -- Aristotle target: sqrt is monotone on nonneg reals
 theorem sqrt_mono {a b : ℝ} (ha : 0 ≤ a) (hab : a ≤ b) :

--- a/proofs/Proofs/Erdos266Problem.lean
+++ b/proofs/Proofs/Erdos266Problem.lean
@@ -102,13 +102,13 @@ theorem harmonic_diverges : ¬Summable (fun n : ℕ => (1 : ℝ) / (n + 1)) := b
   -- The p-series ∑ 1/n^p diverges for p ≤ 1. Here p = 1.
   intro h
   have h1 : Summable (fun n : ℕ => (↑(n + 1) : ℝ)⁻¹) := by
-    simp_rw [one_div] at h; exact h
+    simp_rw [one_div] at h
+    exact h.congr (fun n => by norm_cast)
   -- Summability of f ∘ (· + 1) implies summability of f (adding one term)
   have h2 : Summable (fun n : ℕ => ((n : ℝ))⁻¹) := by
-    rw [summable_nat_add_iff 1] at h1 ⊢
-    convert h1 using 1
-    ext n; push_cast; ring_nf
-  exact Real.not_summable_nat_of_tendsto_nat tendsto_harmonic h2
+    rw [← summable_nat_add_iff 1]
+    exact h1
+  exact Real.not_summable_natCast_inv h2
 
 /-- Sums like ∑ 1/n² converge, so are candidates for Stolarsky's conjecture -/
 theorem sum_reciprocal_squares_summable : Summable (fun n : ℕ => (1 : ℝ) / (n + 1)^2) := by
@@ -116,12 +116,8 @@ theorem sum_reciprocal_squares_summable : Summable (fun n : ℕ => (1 : ℝ) / (
   have h : Summable (fun n : ℕ => ((n : ℝ))⁻¹ ^ 2) :=
     (Real.summable_nat_rpow_inv.mpr (by norm_num : (1 : ℝ) < 2)).congr (fun n => by
       simp [inv_pow])
-  rw [summable_nat_add_iff 1] at h ⊢
-  apply h.of_nonneg_of_le (fun n => by positivity) (fun n => by positivity)
-  intro n
-  simp only [one_div, inv_pow]
-  apply inv_le_inv_of_le (by positivity : (0 : ℝ) < (↑(n + 1))^2)
-  push_cast; nlinarith [show (0:ℝ) ≤ n from Nat.cast_nonneg n]
+  have h2 : Summable (fun n : ℕ => ((↑(n + 1) : ℝ))⁻¹ ^ 2) := (summable_nat_add_iff 1).mpr h
+  exact h2.congr (fun n => by push_cast; rw [inv_pow, one_div])
 
 /-- The geometric series ∑ 1/2ⁿ converges to 2 -/
 example : ∑' n : ℕ, (1 : ℝ) / 2^n = 2 := by
@@ -132,14 +128,13 @@ example : ∑' n : ℕ, (1 : ℝ) / 2^n = 2 := by
 
 /-- Shifted geometric: ∑ 1/(2ⁿ + 1) also converges -/
 example : Summable (fun n : ℕ => (1 : ℝ) / (2^n + 1)) := by
-  apply Summable.of_nonneg_of_le (fun n => by positivity)
-  · intro n
-    rw [one_div]
-    exact inv_le_inv_of_le (by positivity : (0:ℝ) < 2^n)
-      (le_add_of_nonneg_right (by positivity))
-  · have : (fun n : ℕ => (1 : ℝ) / 2 ^ n) = (fun n : ℕ => ((1 : ℝ) / 2) ^ n) := by
+  have hg : Summable (fun n : ℕ => (1 : ℝ) / 2 ^ n) := by
+    have : (fun n : ℕ => (1 : ℝ) / 2 ^ n) = (fun n : ℕ => ((1 : ℝ) / 2) ^ n) := by
       ext n; rw [one_div, one_div, inv_pow]
     rw [this]
     exact summable_geometric_of_lt_one (by positivity) (by norm_num : (1:ℝ)/2 < 1)
+  refine Summable.of_nonneg_of_le (fun n => by positivity) (fun n => ?_) hg
+  have h2 : (0:ℝ) < 2 ^ n := by positivity
+  exact one_div_le_one_div_of_le h2 (by linarith)
 
 end Erdos266

--- a/proofs/Proofs/Erdos289Problem.lean
+++ b/proofs/Proofs/Erdos289Problem.lean
@@ -66,6 +66,8 @@ theorem interval_block_has_two (I : IntervalBlock) :
     I.toFinset.card ≥ 2 := by
   unfold IntervalBlock.toFinset
   simp [Nat.card_Icc]
+  have h1 := I.hle
+  have h2 := I.hsize
   omega
 
 /-- Non-adjacency implies disjointness. -/
@@ -98,13 +100,13 @@ theorem interval_recipsum_upper (I : IntervalBlock) :
       ≤ ∑ _n ∈ Icc I.lo I.hi, (1 : ℚ) / (I.lo : ℚ) := by
         apply Finset.sum_le_sum; intro n hn
         simp only [mem_Icc] at hn
-        have hn_pos : (0 : ℚ) < (n : ℚ) :=
-          Nat.cast_pos.mpr (Nat.pos_of_ne_zero (by omega))
-        exact div_le_div_of_le_left (by positivity) hlo_pos hn_pos
-              (Nat.cast_le.mpr hn.1)
+        exact one_div_le_one_div_of_le hlo_pos (Nat.cast_le.mpr hn.1)
     _ = (Icc I.lo I.hi).card • ((1 : ℚ) / (I.lo : ℚ)) := sum_const _
     _ = ((I.hi - I.lo + 1 : ℕ) : ℚ) / (I.lo : ℚ) := by
-        rw [Nat.card_Icc]; simp [nsmul_eq_mul]
+        rw [Nat.card_Icc]; simp only [nsmul_eq_mul]
+        rw [show I.hi + 1 - I.lo = I.hi - I.lo + 1 from by have := I.hle; omega]
+        push_cast
+        ring
 
 /-- Each interval block contributes at least (hi-lo+1)/hi.
     Proof: each term 1/n ≥ 1/hi since n ≤ hi for n ∈ [lo, hi]. -/
@@ -112,18 +114,20 @@ theorem interval_recipsum_lower (I : IntervalBlock) :
     I.recipSum ≥ ((I.hi - I.lo + 1 : ℕ) : ℚ) / (I.hi : ℚ) := by
   unfold IntervalBlock.recipSum IntervalBlock.toFinset
   have hhi_pos : (0 : ℚ) < (I.hi : ℚ) :=
-    Nat.cast_pos.mpr (Nat.pos_of_ne_zero (by omega))
+    Nat.cast_pos.mpr (Nat.pos_of_ne_zero (by have h1 := I.hlo; have h2 := I.hle; omega))
   calc ((I.hi - I.lo + 1 : ℕ) : ℚ) / (I.hi : ℚ)
       = (Icc I.lo I.hi).card • ((1 : ℚ) / (I.hi : ℚ)) := by
-        rw [Nat.card_Icc]; simp [nsmul_eq_mul]
+        rw [Nat.card_Icc]; simp only [nsmul_eq_mul]
+        rw [show I.hi + 1 - I.lo = I.hi - I.lo + 1 from by have := I.hle; omega]
+        push_cast
+        ring
     _ = ∑ _n ∈ Icc I.lo I.hi, (1 : ℚ) / (I.hi : ℚ) := (sum_const _).symm
     _ ≤ ∑ n ∈ Icc I.lo I.hi, (1 : ℚ) / (n : ℚ) := by
         apply Finset.sum_le_sum; intro n hn
         simp only [mem_Icc] at hn
         have hn_pos : (0 : ℚ) < (n : ℚ) :=
-          Nat.cast_pos.mpr (Nat.pos_of_ne_zero (by omega))
-        exact div_le_div_of_le_left (by positivity) hn_pos hhi_pos
-              (Nat.cast_le.mpr hn.2)
+          Nat.cast_pos.mpr (Nat.pos_of_ne_zero (by have := I.hlo; omega))
+        exact one_div_le_one_div_of_le hn_pos (Nat.cast_le.mpr hn.2)
 
 /-  To achieve exactly 1 with many small-contribution blocks, we need
     blocks at large values of n. The gap constraint forces intervals

--- a/proofs/Proofs/Erdos296Problem.lean
+++ b/proofs/Proofs/Erdos296Problem.lean
@@ -69,8 +69,8 @@ A collection of disjoint sets, each summing to 1.
 
 /-- A collection of sets is pairwise disjoint -/
 def arePairwiseDisjoint (sets : List (Finset ℕ)) : Prop :=
-  ∀ i j, i < sets.length → j < sets.length → i ≠ j →
-    Disjoint (sets.get ⟨i, by omega⟩) (sets.get ⟨j, by omega⟩)
+  ∀ i j (hi : i < sets.length) (hj : j < sets.length), i ≠ j →
+    Disjoint (sets.get ⟨i, hi⟩) (sets.get ⟨j, hj⟩)
 
 /-- A valid packing: disjoint unit sets within {1, ..., N} -/
 structure UnitSetPacking (N : ℕ) where
@@ -135,7 +135,7 @@ theorem k_not_sublogarithmic :
   -- k(N)/log N → 1 by erdos_296_main, so it can't also → 0
   have h1 := erdos_296_main
   -- Two different limits in a Hausdorff space is a contradiction
-  have : (0 : ℝ) = 1 := Filter.Tendsto.unique h h1
+  have : (0 : ℝ) = 1 := tendsto_nhds_unique h h1
   norm_num at this
 
 /-- Corollary: For any ε > 0, k(N) > ε·log N for infinitely many N -/
@@ -143,17 +143,17 @@ theorem k_infinitely_often_large (ε : ℝ) (hε : 0 < ε) (hε1 : ε < 1) :
   ∀ N₀ : ℕ, ∃ N > N₀, (k N : ℝ) > ε * Real.log N := by
   intro N₀
   have ⟨N₁, hN₁⟩ := hunter_sawhney_lower ((1 - ε) / 2) (by linarith)
-  use max N₀ N₁ + 1
-  constructor
-  · omega
-  · have h := hN₁ (max N₀ N₁ + 1) (by omega)
-    calc (k (max N₀ N₁ + 1) : ℝ)
-        ≥ (1 - (1 - ε) / 2) * Real.log (max N₀ N₁ + 1) := h
-      _ = ((1 + ε) / 2) * Real.log (max N₀ N₁ + 1) := by ring
-      _ > ε * Real.log (max N₀ N₁ + 1) := by
-          apply mul_lt_mul_of_pos_right
-          · linarith
-          · apply Real.log_pos; simp; omega
+  refine ⟨max (max N₀ N₁ + 1) 2, by omega, ?_⟩
+  have h := hN₁ (max (max N₀ N₁ + 1) 2) (by omega)
+  have h2 : (2 : ℝ) ≤ ((max (max N₀ N₁ + 1) 2 : ℕ) : ℝ) := by
+    exact_mod_cast (by omega : 2 ≤ max (max N₀ N₁ + 1) 2)
+  have hlog : 0 < Real.log ((max (max N₀ N₁ + 1) 2 : ℕ) : ℝ) :=
+    Real.log_pos (by linarith)
+  calc ((k (max (max N₀ N₁ + 1) 2) : ℕ) : ℝ)
+      ≥ (1 - (1 - ε) / 2) * Real.log ((max (max N₀ N₁ + 1) 2 : ℕ) : ℝ) := h
+    _ = ((1 + ε) / 2) * Real.log ((max (max N₀ N₁ + 1) 2 : ℕ) : ℝ) := by ring
+    _ > ε * Real.log ((max (max N₀ N₁ + 1) 2 : ℕ) : ℝ) :=
+        mul_lt_mul_of_pos_right (by linarith) hlog
 
 #check erdos_296_main
 #check k_not_sublogarithmic

--- a/proofs/Proofs/Erdos320Problem.lean
+++ b/proofs/Proofs/Erdos320Problem.lean
@@ -80,6 +80,18 @@ noncomputable def log₃ (x : ℝ) : ℝ := Real.log (Real.log (Real.log x))
 noncomputable def iterLogProduct (N : ℝ) (k : ℕ) : ℝ :=
   ∏ i ∈ Finset.Icc 3 k, iterLog i N
 
+/-- The problem remains open - the constant c is unknown. -/
+axiom erdos_320_open_bounds (N : ℕ) (hN : N ≥ 16) :
+    (N : ℝ) / Real.log N ≤ Real.log (S N : ℝ) ∧
+    Real.log (S N : ℝ) ≤ (N : ℝ) / Real.log N * Real.log (Real.log N)
+
+/-- First values of S(N) (OEIS A072207):
+    S(1)=2, S(2)=4, S(3)=8, S(4)=16, S(5)=32, S(6)=64, S(7)=128,
+    S(8)=255 (first collision!), ... -/
+axiom oeis_A072207 :
+    S 1 = 2 ∧ S 2 = 4 ∧ S 3 = 8 ∧ S 4 = 16 ∧
+    S 5 = 32 ∧ S 6 = 64 ∧ S 7 = 128 ∧ S 8 = 255
+
 /- ## Part III: Bleicher-Erdős Lower Bound (1975)
 -/
 
@@ -118,9 +130,12 @@ theorem bgms_improves_bleicher_erdos (N : ℕ) (k : ℕ) (hk : k ≥ 4)
     2 * Real.log 2 * (1 - 3 / (2 * iterLog k N)) > Real.log 2 := by
   have h1 : iterLog k N ≥ 4 := h_valid
   have h2 : 1 - 3 / (2 * iterLog k N) > 1/2 := by
-    have : 3 / (2 * iterLog k N) < 1/2 := by nlinarith
+    have : 3 / (2 * iterLog k N) < 1/2 := by
+      rw [div_lt_iff₀ (by linarith)]
+      nlinarith
     linarith
-  nlinarith
+  have hlog : (0:ℝ) < Real.log 2 := Real.log_pos (by norm_num)
+  nlinarith [mul_pos hlog (show (0:ℝ) < 1 - 3 / (2 * iterLog k N) - 1/2 by linarith)]
 
 /- ## Part VI: The Main Problem
 -/
@@ -134,11 +149,6 @@ def ErdosProblem320 : Prop :=
     |Real.log (S N : ℝ) - c * (N : ℝ) / Real.log N * iterLogProduct N 3| ≤
       (N : ℝ) / (Real.log N)^2
 
-/-- The problem remains open - the constant c is unknown. -/
-axiom erdos_320_open_bounds (N : ℕ) (hN : N ≥ 16) :
-    (N : ℝ) / Real.log N ≤ Real.log (S N : ℝ) ∧
-    Real.log (S N : ℝ) ≤ (N : ℝ) / Real.log N * Real.log (Real.log N)
-
 /- ## Part VII: Connection to Egyptian Fractions
 -/
 
@@ -146,10 +156,11 @@ axiom erdos_320_open_bounds (N : ℕ) (hN : N ≥ 16) :
 def IsEgyptianFraction (q : ℚ) (A : Finset ℕ) : Prop :=
   subsetSum A = q ∧ ∀ n ∈ A, n > 0
 
+open Classical in
 /-- The number of Egyptian fraction representations of q using {1,...,N}. -/
 noncomputable def egyptianCount (q : ℚ) (N : ℕ) : ℕ :=
   ((Finset.range N).powerset.filter
-    (fun A => IsEgyptianFraction q (A.image (· + 1)))).card
+    (fun (A : Finset ℕ) => IsEgyptianFraction q (A.image (· + 1)))).card
 
 /-  **Problem #321 Connection:**
     Related to counting Egyptian fraction representations. -/
@@ -170,19 +181,11 @@ theorem S_three : S 3 = 8 := oeis_A072207.2.2.1
 /- ## Part IX: OEIS Sequence A072207
 -/
 
-/-- First values of S(N) (OEIS A072207):
-    S(1)=2, S(2)=4, S(3)=8, S(4)=16, S(5)=32, S(6)=64, S(7)=128,
-    S(8)=255 (first collision!), ... -/
-axiom oeis_A072207 :
-    S 1 = 2 ∧ S 2 = 4 ∧ S 3 = 8 ∧ S 4 = 16 ∧
-    S 5 = 32 ∧ S 6 = 64 ∧ S 7 = 128 ∧ S 8 = 255
-
 /-- The first collision occurs at N = 8:
     1/6 + 1/7 + 1/8 = 73/168 = 1/3 + 1/56 (different representations). -/
 theorem first_collision : S 8 < 2^8 := by
   have h := oeis_A072207
   simp [h.2.2.2.2.2.2.2]
-  norm_num
 
 /- ## Part X: Growth Rate Analysis
 -/
@@ -197,7 +200,9 @@ theorem log_S_leading_term (N : ℕ) (hN : N ≥ 100) :
       c₁ * (N : ℝ) / Real.log N ≤ Real.log (S N : ℝ) ∧
       Real.log (S N : ℝ) ≤ c₂ * (N : ℝ) / Real.log N * Real.log (Real.log N) := by
   have ⟨hlb, hub⟩ := erdos_320_open_bounds N (by omega)
-  exact ⟨1, 1, one_pos, one_pos, by linarith, by linarith⟩
+  refine ⟨1, 1, one_pos, one_pos, ?_, ?_⟩
+  · simpa using hlb
+  · simpa using hub
 
 /- ## Part XI: Summary
 -/

--- a/proofs/Proofs/Erdos323Problem.lean
+++ b/proofs/Proofs/Erdos323Problem.lean
@@ -24,6 +24,8 @@ import Mathlib.Data.Nat.Basic
 import Mathlib.Data.Finset.Basic
 import Mathlib.Tactic
 
+open scoped Classical
+
 /- ## Sums of k-th powers -/
 
 /-- An integer n is a sum of m nonnegative k-th powers. -/
@@ -78,7 +80,7 @@ theorem IsSumOfPowers_one_iff (n k : ℕ) :
 
 /-- Every perfect k-th power is a sum of 1 k-th power. -/
 lemma isSumOfPowers_pow_self (a k : ℕ) : IsSumOfPowers (a ^ k) k 1 :=
-  IsSumOfPowers_one_iff.mpr ⟨a, rfl⟩
+  (IsSumOfPowers_one_iff _ _).mpr ⟨a, rfl⟩
 
 /-- Lower bound for 1-sum count: f_{k,1}(n^k) ≥ n+1, since the n+1 values
     {0^k, 1^k, ..., n^k} are distinct elements of [0, n^k].
@@ -117,7 +119,7 @@ axiom landau_two_squares :
 def ErdosProblem323_part1 : Prop :=
     ∀ (k : ℕ) (hk : 2 ≤ k) (ε : ℚ) (hε : 0 < ε),
       ∃ c : ℚ, 0 < c ∧ ∃ x₀ : ℕ, ∀ x : ℕ, x₀ ≤ x →
-        c * (x : ℚ) ≤ (powerSumCount k k x : ℚ) * (x : ℚ) ^ ε
+        (c : ℝ) * (x : ℝ) ≤ (powerSumCount k k x : ℝ) * (x : ℝ) ^ (ε : ℝ)
 
 /-- Conjecture 2: for m < k, f_{k,m}(x) ≫ x^{m/k}.
     Formally: for every k ≥ 2 and 1 ≤ m < k, there exist c > 0 and x₀
@@ -125,7 +127,7 @@ def ErdosProblem323_part1 : Prop :=
 def ErdosProblem323_part2 : Prop :=
     ∀ (k m : ℕ) (hk : 2 ≤ k) (hm : 1 ≤ m) (hmk : m < k),
       ∃ c : ℚ, 0 < c ∧ ∃ x₀ : ℕ, ∀ x : ℕ, x₀ ≤ x →
-        c * (x : ℚ) ^ ((m : ℚ) / (k : ℚ)) ≤ (powerSumCount k m x : ℚ)
+        (c : ℝ) * (x : ℝ) ^ ((m : ℝ) / (k : ℝ)) ≤ (powerSumCount k m x : ℝ)
 
 /-- Erdős Problem 323: both parts combined. -/
 def ErdosProblem323 : Prop := ErdosProblem323_part1 ∧ ErdosProblem323_part2

--- a/proofs/Proofs/Erdos347Problem.lean
+++ b/proofs/Proofs/Erdos347Problem.lean
@@ -95,7 +95,7 @@ theorem subsetSums_insert (A : Set ℕ) (S : Finset ℕ) (a : ℕ)
     (hS : (↑S : Set ℕ) ⊆ A) (ha : a ∈ A) (hna : a ∉ S) :
     S.sum id + a ∈ subsetSums A :=
   ⟨insert a S, by simpa [Set.insert_subset_iff] using ⟨ha, hS⟩,
-   by rw [Finset.sum_insert hna]; ring⟩
+   by rw [Finset.sum_insert hna]; simp [id_eq, add_comm]⟩
 
 /-- If `A ⊆ B`, then `P(A) ⊆ P(B)`. -/
 theorem subsetSums_mono (A B : Set ℕ) (h : A ⊆ B) :
@@ -134,14 +134,14 @@ theorem isCofiniteSubseq_id (a : ℕ → ℕ) : IsCofiniteSubseq a id :=
 theorem countIn_mono (A B : Set ℕ) (h : A ⊆ B) (N : ℕ) :
     countIn A N ≤ countIn B N := by
   apply Finset.card_le_card
-  apply Finset.filter_subset_filter
-  intro x _
-  exact h
+  apply Finset.monotone_filter_right
+  intro x _ hx
+  exact h hx
 
 /-- The count is bounded by N: countIn S N ≤ N. -/
 theorem countIn_le (S : Set ℕ) (N : ℕ) : countIn S N ≤ N := by
   apply le_trans (Finset.card_filter_le _ _)
-  simp [Finset.card_Icc]
+  simp [Nat.card_Icc]
 
 /-- Density is monotone upward: if A ⊆ B and A has density 1, then B also has density 1.
     Proof: sandwich countIn A N / N ≤ countIn B N / N ≤ 1 with countIn A N / N → 1. -/
@@ -157,9 +157,9 @@ theorem hasDensity_one_of_superset (A B : Set ℕ) (hAB : A ⊆ B)
   have step1 : (countIn A N : ℚ) / N ≤ (countIn B N : ℚ) / N :=
     (div_le_div_iff_of_pos_right hNpos).mpr (by exact_mod_cast countIn_mono A B hAB N)
   have step2 : (countIn B N : ℚ) / N ≤ 1 :=
-    div_le_one_of_le (by exact_mod_cast countIn_le B N) hNpos.le
+    div_le_one_of_le₀ (by exact_mod_cast countIn_le B N) hNpos.le
   have step3 : (countIn A N : ℚ) / N ≤ 1 :=
-    div_le_one_of_le (by exact_mod_cast countIn_le A N) hNpos.le
+    div_le_one_of_le₀ (by exact_mod_cast countIn_le A N) hNpos.le
   rw [abs_sub_comm, abs_of_nonneg (by linarith)] at hA_close
   rw [abs_sub_comm, abs_of_nonneg (by linarith)]
   linarith

--- a/proofs/Proofs/Erdos393Problem.lean
+++ b/proofs/Proofs/Erdos393Problem.lean
@@ -51,7 +51,7 @@ def IsStrictlyIncreasing (factors : List ℕ) : Prop :=
 def span (factors : List ℕ) : ℕ :=
   match factors with
   | [] => 0
-  | a :: rest => (factors.getLast (by simp)) - a
+  | a :: rest => ((a :: rest).getLast (by simp)) - a
 
 /-- A valid factorization for our problem:
     n! = a₁ · ... · aₜ with a₁ < ... < aₜ and span m -/
@@ -69,6 +69,7 @@ def IsValidFactorization (n m : ℕ) (factors : List ℕ) : Prop :=
 axiom f_exists (n : ℕ) :
     ∃ m, ∃ factors : List ℕ, IsValidFactorization n m factors
 
+open Classical in
 /-- f(n) = minimal m such that n! has a valid factorization with span m -/
 noncomputable def f (n : ℕ) : ℕ :=
   Nat.find (f_exists n)
@@ -83,7 +84,7 @@ def IsProductOfConsecutive (n : ℕ) : Prop :=
 
 /-  f(n) = 1 iff n! is a product of two consecutive integers -/
 /-- Example: 3! = 6 = 2 · 3, so f(3) ≤ 1 -/
-theorem example_3_factorial : 3.factorial = 2 * 3 := by
+theorem example_3_factorial : (3 : ℕ).factorial = 2 * 3 := by
   native_decide
 
 /-- The open question: Is f(n) = 1 for infinitely many n? -/
@@ -117,7 +118,7 @@ theorem power_saving : (33 : ℝ) / 34 < 1 := by norm_num
 def ABCConjecture : Prop :=
   ∀ ε > 0, ∃ K : ℝ, K > 0 ∧
     ∀ a b c : ℕ, a + b = c → Nat.Coprime a b →
-      (c : ℝ) ≤ K * (Nat.radical (a * b * c) : ℝ)^(1 + ε)
+      (c : ℝ) ≤ K * (UniqueFactorizationMonoid.radical (a * b * c) : ℝ)^(1 + ε)
 
 /-- Luca (2002): Assuming ABC, f(n) → ∞ as n → ∞ -/
 axiom luca_2002 : ABCConjecture →

--- a/proofs/Proofs/Erdos432Problem.lean
+++ b/proofs/Proofs/Erdos432Problem.lean
@@ -26,6 +26,8 @@ import Mathlib
 
 namespace Erdos432
 
+open scoped Classical
+
 /- ## Part I: Sumsets -/
 
 /--
@@ -114,7 +116,7 @@ theorem prime_divides_at_most_one :
   have hpg : p ∣ Nat.gcd x y := Nat.dvd_gcd hpx hpy
   rw [hxy] at hpg
   -- p ∣ 1 contradicts p ≥ 2
-  exact absurd hpg (Nat.Prime.one_lt hp |>.not_le ∘ Nat.le_of_dvd one_pos)
+  exact absurd (Nat.le_of_dvd one_pos hpg) (Nat.not_le.mpr (Nat.Prime.one_lt hp))
 
 /--
 A pairwise coprime set S ⊆ {1, …, n} has at most π(n) + 1
@@ -130,7 +132,7 @@ theorem coprime_set_bound :
   unfold countingFn
   calc ((Finset.range (n + 1)).filter (fun m => m ∈ S ∧ m ≥ 1)).card
       ≤ ((Finset.range (n + 1)).filter (fun m => m ≥ 1)).card :=
-        Finset.card_filter_le_card_filter _ _ _ (fun m _ h => h.2)
+        Finset.card_le_card (Finset.monotone_filter_right _ (fun m _ h => h.2))
     _ ≤ ((Finset.range n).image (· + 1)).card := by
         apply Finset.card_le_card
         intro m hm

--- a/proofs/Proofs/Erdos437Aristotle.lean
+++ b/proofs/Proofs/Erdos437Aristotle.lean
@@ -24,7 +24,7 @@ namespace Erdos437.Aristotle
 
 /-- 4^k is a perfect square (= (2^k)^2) -/
 lemma isSquare_pow_four (k : ℕ) : IsSquare (4 ^ k) :=
-  ⟨2 ^ k, by ring⟩
+  ⟨2 ^ k, by rw [show (4:ℕ) = 2 * 2 from rfl, mul_pow]⟩
 
 /-- Product of two squares is a square -/
 lemma isSquare_mul (a b : ℕ) (ha : IsSquare a) (hb : IsSquare b) : IsSquare (a * b) := by
@@ -48,7 +48,7 @@ private lemma foldl_mul_acc (xs : List ℕ) (acc : ℕ) :
   induction xs generalizing acc with
   | nil => simp
   | cons h t ih =>
-    simp only [List.foldl_cons]
+    simp only [List.foldl_cons, one_mul]
     rw [ih (acc * h), ih h]
     ring
 
@@ -78,6 +78,7 @@ lemma pow_four_range_product (k : ℕ) :
       rcases Nat.even_or_odd n with ⟨m, hm⟩ | ⟨m, hm⟩
       · exact ⟨(n + 1) * (m + 1), by subst hm; ring⟩
       · exact ⟨(m + 1) * (n + 2), by subst hm; ring⟩
+    show n * (n + 1) / 2 + (n + 1) = (n + 1) * (n + 2) / 2
     linarith [Nat.div_mul_cancel heven, Nat.div_mul_cancel heven2,
               show n * (n + 1) + 2 * (n + 1) = (n + 1) * (n + 2) from by ring]
 
@@ -99,7 +100,7 @@ lemma cast_pos_of_ge_one (x : ℕ) (hx : x ≥ 1) : (x : ℝ) > 0 :=
 
 /-- (L x : ℝ) / x is in [0, 1] when L x ≤ x -/
 lemma div_L_le_one (L x : ℕ) (h : L ≤ x) (hx : x ≥ 1) : (L : ℝ) / x ≤ 1 :=
-  div_le_one_of_le (by exact_mod_cast h) (by exact_mod_cast (show 0 ≤ x from by omega))
+  div_le_one_of_le₀ (by exact_mod_cast h) (by exact_mod_cast (show 0 ≤ x from by omega))
 
 /-
   ## Section 4: u(x) = sqrt(log x * log log x) Properties

--- a/proofs/Proofs/Erdos490ProblemAristotle.lean
+++ b/proofs/Proofs/Erdos490ProblemAristotle.lean
@@ -87,7 +87,7 @@ Key Mathlib lemmas:
 /-- Products a·p are distinct when p is a prime exceeding all elements of A.
     This justifies the construction in the optimal example for Problem #490. -/
 theorem optimal_works_because_primes_ari (N a₁ a₂ p₁ p₂ : ℕ)
-    (ha₁ : a₁ ≤ N / 2) (ha₂ : a₂ ≤ N / 2)
+    (ha₁ : a₁ ≤ N / 2) (ha₂ : a₂ ≤ N / 2) (ha₂pos : 0 < a₂)
     (hp₁ : Nat.Prime p₁) (hp₂ : Nat.Prime p₂)
     (hp₁_large : N / 2 < p₁) (hp₂_large : N / 2 < p₂)
     (heq : a₁ * p₁ = a₂ * p₂) : a₁ = a₂ ∧ p₁ = p₂ := by
@@ -96,13 +96,12 @@ theorem optimal_works_because_primes_ari (N a₁ a₂ p₁ p₂ : ℕ)
   -- Since p₁ is prime: p₁ | a₂ ∨ p₁ | p₂
   rcases hp₁.dvd_mul.mp hdvd with h | h
   · -- Case p₁ | a₂: but then a₂ ≥ p₁ > N/2 ≥ a₂, contradiction
-    have : p₁ ≤ a₂ := Nat.le_of_dvd (Nat.pos_of_ne_zero (by
-      intro ha₂z; simp [ha₂z] at heq; exact hp₁.ne_zero (Nat.eq_zero_of_mul_eq_zero_left heq))) h
+    have : p₁ ≤ a₂ := Nat.le_of_dvd ha₂pos h
     omega
   · -- Case p₁ | p₂: since both are prime, p₁ = p₂
-    have heqp : p₁ = p₂ := (hp₁.eq_of_dvd_of_prime hp₂ h).symm ▸ rfl
+    have heqp : p₁ = p₂ := (Nat.prime_dvd_prime_iff_eq hp₁ hp₂).mp h
+    subst heqp
     -- Cancel to get a₁ = a₂
-    have heqa : a₁ = a₂ := Nat.eq_of_mul_eq_mul_right hp₁.pos (heqp ▸ heq)
-    exact ⟨heqa, heqp⟩
+    exact ⟨Nat.eq_of_mul_eq_mul_right hp₁.pos heq, rfl⟩
 
 end Erdos490Aristotle

--- a/proofs/Proofs/Erdos523Problem.lean
+++ b/proofs/Proofs/Erdos523Problem.lean
@@ -52,7 +52,7 @@ noncomputable def randomPolynomial (s : SignVector n) (z : ℂ) : ℂ :=
 
 /-- The maximum modulus on the unit circle. -/
 noncomputable def maxModulus (s : SignVector n) : ℝ :=
-  ⨆ (θ : ℝ), abs (randomPolynomial s (exp (I * θ)))
+  ⨆ (θ : ℝ), ‖randomPolynomial s (exp (I * θ))‖
 
 /-- The polynomial evaluated at a point on the unit circle. -/
 noncomputable def evalOnCircle (s : SignVector n) (θ : ℝ) : ℂ :=
@@ -143,7 +143,7 @@ def AlmostSureConvergence (C : ℝ) : Prop :=
 /-- The L² norm on the circle. -/
 noncomputable def L2Norm (s : SignVector n) : ℝ :=
   Real.sqrt ((1 / (2 * Real.pi)) * ∫ θ in (0 : ℝ)..(2 * Real.pi),
-    (abs (evalOnCircle s θ))^2)
+    ‖evalOnCircle s θ‖^2)
 
 /-  The L² norm is exactly √(n+1). -/
 /-  The max is much larger than the L² norm (by √(log n) factor). -/
@@ -197,7 +197,7 @@ def RudinConjecture : Prop :=
 /-- The Mahler measure of random polynomials. -/
 noncomputable def mahlerMeasure (s : SignVector n) : ℝ :=
   Real.exp ((1 / (2 * Real.pi)) * ∫ θ in (0 : ℝ)..(2 * Real.pi),
-    Real.log (abs (evalOnCircle s θ)))
+    Real.log ‖evalOnCircle s θ‖)
 
 /-- Connection to Szegő's theorem. -/
 def szegoConnection : Prop :=
@@ -230,7 +230,7 @@ theorem erdos_523_constant : ∃ C : ℝ, C = 1 ∧ ErdosQuestion523 := by
 /-- Main result: max = (1 + o(1))√(n log n) almost surely. -/
 theorem erdos_523_main :
     ∀ ε : ℝ, ε > 0 → True := -- Probability statement
-  halasz_theorem
+  fun _ _ => trivial
 
 /-- The problem is completely solved. -/
 theorem erdos_523_solved : ErdosQuestion523 := erdos_523

--- a/proofs/Proofs/FourierSeriesOQ02OQ04.lean
+++ b/proofs/Proofs/FourierSeriesOQ02OQ04.lean
@@ -140,6 +140,8 @@ private theorem wFunc_fourierCoeff (α : ℝ) (hα : 0 < α) (k₀ : ℕ) :
       fun x => ∑' k : ℕ, fourier (-(2:ℤ)^k₀) x * ((geomRatio α : ℝ)^k • fourier ((2:ℤ)^k) x)
     from funext fun x => by rw [← tsum_mul_left]]
   rw [integral_tsum
+    (f := fun (k : ℕ) (x : AddCircle T) =>
+      fourier (-(2:ℤ)^k₀) x * ((geomRatio α : ℝ)^k • fourier ((2:ℤ)^k) x))
     (fun k => (((fourier (-(2:ℤ)^k₀)).continuous.mul
       ((continuous_const.smul (fourier ((2:ℤ)^k)).continuous))).aestronglyMeasurable))
     (wFunc_norm_tsum_ne_top α hα _)]

--- a/proofs/Proofs/FundamentalArithmeticOQ01.lean
+++ b/proofs/Proofs/FundamentalArithmeticOQ01.lean
@@ -48,8 +48,9 @@ theorem factorization_mul_apply (m n : ℕ) (hm : m ≠ 0) (hn : n ≠ 0) (p : �
     This is the content of Nat.coprime: gcd(m,n) = 1 iff no prime
     divides both, iff the factorizations have disjoint support. -/
 theorem factorization_disjoint_of_coprime (m n : ℕ) (hcop : Nat.Coprime m n) :
-    Disjoint m.factorization.support n.factorization.support :=
-  Nat.coprime_iff_disjoint.mp hcop
+    Disjoint m.factorization.support n.factorization.support := by
+  rw [Nat.support_factorization, Nat.support_factorization]
+  exact Nat.Coprime.disjoint_primeFactors hcop
 
 /-- For coprime m, n: for each prime p, at most one of v_p(m) and v_p(n)
     is nonzero. This is the pointwise consequence of disjoint support. -/
@@ -59,7 +60,7 @@ theorem coprime_valuation_exclusive (m n : ℕ) (hcop : Nat.Coprime m n) (p : �
   push_neg at h
   have hm : p ∈ m.factorization.support := Finsupp.mem_support_iff.mpr (Nat.pos_of_ne_zero h.1).ne'
   have hn : p ∈ n.factorization.support := Finsupp.mem_support_iff.mpr (Nat.pos_of_ne_zero h.2).ne'
-  exact (factorization_disjoint_of_coprime m n hcop).ne_of_mem hm hn rfl
+  exact (Finset.disjoint_left.mp (factorization_disjoint_of_coprime m n hcop) hm) hn
 
 -- ============================================================
 -- Part III: Concrete Examples
@@ -99,13 +100,13 @@ theorem factorization_420_split :
     the sum of their individual factorizations.
     Proof: induction using Nat.factorization_mul at each step. -/
 theorem factorization_prod_eq (l : List ℕ) (hpos : ∀ x ∈ l, x ≠ 0) :
-    l.prod.factorization = l.map Nat.factorization |>.sum := by
+    l.prod.factorization = (l.map Nat.factorization).sum := by
   induction l with
   | nil => simp
   | cons a l ih =>
     simp only [List.prod_cons, List.map_cons, List.sum_cons]
-    rw [Nat.factorization_mul (hpos a (List.mem_cons_self a l))
-      (List.prod_ne_zero (fun x hx => hpos x (List.mem_cons_of_mem a hx)))]
+    rw [Nat.factorization_mul (hpos a List.mem_cons_self)
+      (List.prod_ne_zero (fun h0 => hpos 0 (List.mem_cons_of_mem a h0) rfl))]
     rw [ih (fun x hx => hpos x (List.mem_cons_of_mem a hx))]
 
 end FundamentalArithmeticOQ01

--- a/proofs/Proofs/Hilbert15SchubertCalculus.lean
+++ b/proofs/Proofs/Hilbert15SchubertCalculus.lean
@@ -86,7 +86,7 @@ Key examples:
 
 /-- The Grassmannian Gr(k,n) over a field K: the set of k-dimensional subspaces of Kⁿ -/
 def Grassmannian (k n : ℕ) (K : Type*) [DivisionRing K] :=
-  { V : Submodule K (Fin n → K) // finrank K V = k }
+  { V : Submodule K (Fin n → K) // Module.finrank K V = k }
 
 /-- A point in the Grassmannian is a subspace of the correct dimension -/
 instance (k n : ℕ) (K : Type*) [DivisionRing K] :
@@ -95,7 +95,7 @@ instance (k n : ℕ) (K : Type*) [DivisionRing K] :
 
 /-- The dimension of a Grassmannian point equals k by definition -/
 theorem grassmannian_rank {k n : ℕ} {K : Type*} [DivisionRing K]
-    (V : Grassmannian k n K) : finrank K (V : Submodule K (Fin n → K)) = k :=
+    (V : Grassmannian k n K) : Module.finrank K (V : Submodule K (Fin n → K)) = k :=
   V.property
 
 /-! ═══════════════════════════════════════════════════════════════════════════════
@@ -129,7 +129,7 @@ def LinesMeet {K : Type*} [DivisionRing K] (L₁ L₂ : LineInP3 K) : Prop :=
 
 /-- Equivalent condition: lines meet iff their span has dimension < 4 -/
 def LinesMeet' {K : Type*} [DivisionRing K] (L₁ L₂ : LineInP3 K) : Prop :=
-  finrank K (L₁.val ⊔ L₂.val : Submodule K (Fin 4 → K)) < 4
+  Module.finrank K (L₁.val ⊔ L₂.val : Submodule K (Fin 4 → K)) < 4
 
 /-- The two definitions of lines meeting are equivalent.
 
@@ -141,16 +141,16 @@ theorem linesMeet_iff_linesMeet' {K : Type*} [Field K] (L₁ L₂ : LineInP3 K) 
   simp only [LinesMeet, LinesMeet', SubspacesMeet]
   have hdim := Submodule.finrank_sup_add_finrank_inf_eq L₁.val L₂.val
   rw [L₁.property, L₂.property] at hdim
-  -- hdim : finrank K ↥(L₁.val ⊔ L₂.val) + finrank K ↥(L₁.val ⊓ L₂.val) = 2 + 2
+  -- hdim : Module.finrank K ↥(L₁.val ⊔ L₂.val) + Module.finrank K ↥(L₁.val ⊓ L₂.val) = 2 + 2
   constructor
   · -- (V ∩ W ≠ ⊥) → (dim(V + W) < 4)
     intro hne
-    suffices h : 0 < finrank K ↥(L₁.val ⊓ L₂.val) by omega
+    suffices h : 0 < Module.finrank K ↥(L₁.val ⊓ L₂.val) by omega
     rw [Nat.pos_iff_ne_zero, ne_eq, Submodule.finrank_eq_zero]
     exact hne
   · -- (dim(V + W) < 4) → (V ∩ W ≠ ⊥)
     intro hlt hbot
-    have : finrank K ↥(L₁.val ⊓ L₂.val) = 0 := Submodule.finrank_eq_zero.mpr hbot
+    have : Module.finrank K ↥(L₁.val ⊓ L₂.val) = 0 := Submodule.finrank_eq_zero.mpr hbot
     omega
 
 /-! ═══════════════════════════════════════════════════════════════════════════════
@@ -391,12 +391,12 @@ This confirms schubertNumber_FourLines = 2.
 /-- The partition (1) representing σ₁ in Gr(2,4) -/
 def partition_1 : Partition where
   parts := [1]
-  decreasing := List.chain'_singleton _
+  decreasing := List.isChain_singleton _
 
 /-- The partition (2,2) representing the point class in Gr(2,4) -/
 def partition_22 : Partition where
   parts := [2, 2]
-  decreasing := by simp [List.Chain', List.chain'_cons']
+  decreasing := List.Chain.cons (le_refl 2) List.Chain.nil
 
 /-- σ₁⁴ = 2 · σ₂₂ in Gr(2,4) (the four lines formula)
 

--- a/proofs/Proofs/Hilbert15SchubertCalculusOQ01.lean
+++ b/proofs/Proofs/Hilbert15SchubertCalculusOQ01.lean
@@ -68,14 +68,14 @@ namespace Hilbert15OQ01
 
 /-- The Grassmannian Gr(k,n) over a field K -/
 def Grassmannian (k n : ℕ) (K : Type*) [DivisionRing K] :=
-  { V : Submodule K (Fin n → K) // finrank K V = k }
+  { V : Submodule K (Fin n → K) // Module.finrank K V = k }
 
 instance (k n : ℕ) (K : Type*) [DivisionRing K] :
     CoeSort (Grassmannian k n K) (Submodule K (Fin n → K)) where
   coe := Subtype.val
 
 theorem grassmannian_rank {k n : ℕ} {K : Type*} [DivisionRing K]
-    (V : Grassmannian k n K) : finrank K (V : Submodule K (Fin n → K)) = k :=
+    (V : Grassmannian k n K) : Module.finrank K (V : Submodule K (Fin n → K)) = k :=
   V.property
 
 /-- A line in P³ = Gr(2,4) -/
@@ -92,7 +92,7 @@ def LinesMeet {K : Type*} [DivisionRing K] (L₁ L₂ : LineInP3 K) : Prop :=
 
 /-- Lines meet via span dimension < 4 -/
 def LinesMeet' {K : Type*} [DivisionRing K] (L₁ L₂ : LineInP3 K) : Prop :=
-  finrank K (L₁.val ⊔ L₂.val : Submodule K (Fin 4 → K)) < 4
+  Module.finrank K (L₁.val ⊔ L₂.val : Submodule K (Fin 4 → K)) < 4
 
 -- ============================================================
 -- Part II: AXIOM ELIMINATION 1 — linesMeet_iff_linesMeet'
@@ -113,35 +113,35 @@ This is the submodule dimension formula (Grassmann's formula).
 /-- **Proved (was axiom)**: Lines meet iff their span has dimension < 4.
 
     Uses the submodule dimension formula:
-    finrank(V ⊔ W) + finrank(V ⊓ W) = finrank(V) + finrank(W) = 2 + 2 = 4
+    Module.finrank(V ⊔ W) + Module.finrank(V ⊓ W) = Module.finrank(V) + Module.finrank(W) = 2 + 2 = 4
 
-    V ⊓ W ≠ ⊥ ↔ finrank(V ⊓ W) ≥ 1 ↔ finrank(V ⊔ W) ≤ 3 < 4. -/
+    V ⊓ W ≠ ⊥ ↔ Module.finrank(V ⊓ W) ≥ 1 ↔ Module.finrank(V ⊔ W) ≤ 3 < 4. -/
 theorem linesMeet_iff_linesMeet' {K : Type*} [Field K] (L₁ L₂ : LineInP3 K) :
     LinesMeet L₁ L₂ ↔ LinesMeet' L₁ L₂ := by
   unfold LinesMeet LinesMeet' SubspacesMeet
   set V := (L₁ : Submodule K (Fin 4 → K))
   set W := (L₂ : Submodule K (Fin 4 → K))
-  have hV : finrank K V = 2 := L₁.property
-  have hW : finrank K W = 2 := L₂.property
-  -- The dimension formula: finrank(V ⊔ W) + finrank(V ⊓ W) = finrank(V) + finrank(W)
-  have hdim : finrank K ↥(V ⊔ W) + finrank K ↥(V ⊓ W) = 4 := by
+  have hV : Module.finrank K V = 2 := L₁.property
+  have hW : Module.finrank K W = 2 := L₂.property
+  -- The dimension formula: Module.finrank(V ⊔ W) + Module.finrank(V ⊓ W) = Module.finrank(V) + Module.finrank(W)
+  have hdim : Module.finrank K ↥(V ⊔ W) + Module.finrank K ↥(V ⊓ W) = 4 := by
     have := Submodule.finrank_sup_add_finrank_inf_eq V W
     rw [hV, hW] at this
     exact this
   constructor
-  · -- V ⊓ W ≠ ⊥ → finrank(V ⊔ W) < 4
+  · -- V ⊓ W ≠ ⊥ → Module.finrank(V ⊔ W) < 4
     intro hne
     -- V ⊓ W ≠ ⊥ means it has positive dimension
-    have hpos : 0 < finrank K ↥(V ⊓ W) := by
-      rw [finrank_pos_iff]
-      exact Submodule.nontrivial_of_ne_bot _ hne
+    have hpos : 0 < Module.finrank K ↥(V ⊓ W) := by
+      rw [Module.finrank_pos_iff]
+      exact Submodule.nontrivial_iff_ne_bot.mpr hne
     omega
-  · -- finrank(V ⊔ W) < 4 → V ⊓ W ≠ ⊥
+  · -- Module.finrank(V ⊔ W) < 4 → V ⊓ W ≠ ⊥
     intro hlt
-    -- finrank(V ⊓ W) ≥ 1, so V ⊓ W is nontrivial
-    have hpos : 0 < finrank K ↥(V ⊓ W) := by omega
-    rw [finrank_pos_iff] at hpos
-    exact Submodule.ne_bot_of_nontrivial (V ⊓ W)
+    -- Module.finrank(V ⊓ W) ≥ 1, so V ⊓ W is nontrivial
+    have hpos : 0 < Module.finrank K ↥(V ⊓ W) := by omega
+    rw [Module.finrank_pos_iff] at hpos
+    exact Submodule.nontrivial_iff_ne_bot.mp hpos
 
 -- ============================================================
 -- Part III: Four Lines Infrastructure (from parent, axiomatized)
@@ -241,11 +241,11 @@ def schubertNumber_FiveConics : ℕ := 3264
 
 def partition_1 : Partition where
   parts := [1]
-  decreasing := List.chain'_singleton _
+  decreasing := List.isChain_singleton _
 
 def partition_22 : Partition where
   parts := [2, 2]
-  decreasing := by simp [List.Chain', List.chain'_cons']
+  decreasing := List.Chain.cons (le_refl 2) List.Chain.nil
 
 axiom sigma1_fourth_power :
     littlewoodRichardsonCoeff partition_1 partition_1 partition_22 = 2
@@ -261,7 +261,7 @@ theorem four_lines_via_schubert : schubertNumber_FourLines = 2 := rfl
 
 ### What CAN be formalized today (0 new Mathlib infrastructure needed)
 
-1. **Grassmannian Gr(k,n)** via finrank subtypes ✓
+1. **Grassmannian Gr(k,n)** via Module.finrank subtypes ✓
 2. **Line intersection conditions** via submodule dimension formula ✓ (proved here)
 3. **Transversal counting** from geometric axioms ✓ (proved here)
 4. **Partition arithmetic** (size, containment, fitsIn) ✓

--- a/proofs/Proofs/Hilbert23CalculusVariationsOQ01.lean
+++ b/proofs/Proofs/Hilbert23CalculusVariationsOQ01.lean
@@ -72,7 +72,7 @@ lemma firstVariation_le_sub {J : E → ℝ} (hJ : ConvexOn ℝ univ J)
     simp only [smul_eq_mul] at hc
     nlinarith [hc]
   -- Pass to the limit `t → 0⁺`: the right derivative is `≤` every such slope bound.
-  rw [hasDerivWithinAt_iff_tendsto_slope, Ici_diff_left] at hd
+  rw [hasDerivWithinAt_iff_tendsto_slope, Ici_sdiff_left] at hd
   refine le_of_tendsto hd ?_
   have hlt1 : ∀ᶠ t in 𝓝[Ioi (0:ℝ)] 0, t < 1 := by
     have hmem : Iio (1 : ℝ) ∈ 𝓝 (0 : ℝ) := isOpen_Iio.mem_nhds (by norm_num)
@@ -89,7 +89,7 @@ lemma firstVariation_nonneg_of_isMinOn {J : E → ℝ} {y₀ y : E} {d : ℝ}
     (hmin : ∀ z, J y₀ ≤ J z)
     (hd : HasDerivWithinAt (segPath J y₀ y) d (Ici 0) 0) :
     0 ≤ d := by
-  rw [hasDerivWithinAt_iff_tendsto_slope, Ici_diff_left] at hd
+  rw [hasDerivWithinAt_iff_tendsto_slope, Ici_sdiff_left] at hd
   refine ge_of_tendsto hd ?_
   filter_upwards [self_mem_nhdsWithin] with t ht0
   have ht0' : 0 < t := ht0

--- a/proofs/Proofs/MathematicalInductionOQ01.lean
+++ b/proofs/Proofs/MathematicalInductionOQ01.lean
@@ -27,6 +27,7 @@ principle: if a property holds for all ordinals less than α (the
 -/
 
 open Ordinal
+open scoped Classical
 
 namespace TransfiniteInduction
 
@@ -70,11 +71,11 @@ theorem transfinite_induction (P : Ordinal → Prop)
 theorem transfinite_induction_cases (P : Ordinal → Prop)
     (hzero : P 0)
     (hsucc : ∀ α, P α → P (Order.succ α))
-    (hlimit : ∀ α, Ordinal.IsLimit α → (∀ β, β < α → P β) → P α) :
+    (hlimit : ∀ α, Order.IsSuccLimit α → (∀ β, β < α → P β) → P α) :
     ∀ α, P α := by
   apply transfinite_induction
   intro α ih
-  rcases Ordinal.zero_or_succ_or_limit α with rfl | ⟨β, rfl⟩ | hlim
+  rcases Ordinal.zero_or_succ_or_isSuccLimit α with rfl | ⟨β, rfl⟩ | hlim
   · exact hzero
   · exact hsucc β (ih β (Order.lt_succ β))
   · exact hlimit α hlim ih
@@ -91,7 +92,7 @@ theorem transfinite_induction_cases (P : Ordinal → Prop)
 theorem course_of_values (P : ℕ → Prop)
     (h : ∀ n, (∀ m, m < n → P m) → P n) :
     ∀ n, P n :=
-  Nat.strongRecOn h
+  fun n => Nat.strongRecOn n h
 
 /-- Standard (weak) induction follows from course-of-values:
     From P(0) and P(n) → P(n+1), derive P(n) for all n. -/

--- a/proofs/batch2/STATUS.md
+++ b/proofs/batch2/STATUS.md
@@ -1,6 +1,103 @@
-# Batch 2/3/4/5 + Doctor verification state (updated Doctor increment 34, #38065, 2026-07-14)
+# Batch 2/3/4/5 + Doctor verification state (updated Doctor increment 56, #38065, 2026-07-14)
 
-# DOCTOR INCREMENT 34 (type-mismatch + proof-drift + rewrite-drift + unknown-const-mixed + instance-synth, A–M partition, #38065, 2026-07-14)
+# DOCTOR INCREMENT 56 (deep-rework partition A: unknown-const/parse/cheap-first, #38065, 2026-07-14)
+
+Container `dr56` (cpus 6-11, 11g, cache v431-b), worktree doctor-b, branch
+`feature/issue-38065-inc56` (fresh off origin/feature/issue-37508). Partition A
+(basenames A–M + Erdos < 600), 419 RESIDUAL rows, 334 sorry-free. Whole-pool
+bulk probe of the 140 cheap-class rows (unknown-const/parse/sig/elab/dot) in one
+combined `lake build`, then cheapest-first per-file fix loop. **+30 GREEN**
+(PR #38659). All flips in-container per-file `lake build` exit-0.
+
+## Waves
+- **Free-flip harvest (+3)**: EisensteinCriterionOQ01OQ03OQ02OQ01, Erdos2OQ01,
+  FourierSeriesOQ02 (no own errors in probe; exit-code verified).
+- **Forward-reference seam (+4)**: Erdos320Problem (2 axioms moved before first
+  use), Erdos29Problem (JPSZ_representation_bound/JPSZ_size_optimal moved after
+  JPSZ_is_basis), Erdos428-style lemma-after-use in Erdos428 NOT flipped (see
+  deep). Pattern: v4.31 rejects forward refs; 9 of 10 sampled unknown-const
+  project-local names were forward refs.
+- **Rename/API singles (+18)**: Erdos490ProblemAristotle (STATEMENT REPAIR
+  #38611: optimal_works_because_primes_ari FALSE for a₂=0 — added 0 < a₂),
+  FourierSeriesOQ02OQ04 (integral_tsum f-pin), EQR-OQ03OQ03 (legendreSym API),
+  Erdos523 (dangling halasz_theorem + ℂ |.|→‖.‖), Erdos226 (denseRange_cast,
+  mem_range simpa), Erdos437Aristotle (4=2*2 mul_pow, foldl one_mul, div-atom
+  show-align, div_le_one_of_le₀), Hilbert23 (Ici_diff_left→Ici_sdiff_left),
+  Erdos260Aristotle (tendsto_log_atTop.comp natCast, atTop_mul_atTop₀),
+  Erdos162 (congr-1 hoist + offDiag_card + Bool decide), FundamentalArithmeticOQ01
+  (Coprime.disjoint_primeFactors, statement-pipe parens, prod_ne_zero 0∉l),
+  Erdos393 (match-arm getLast, numeral-dot parse, UFM.radical), Erdos347
+  (monotone_filter_right, Nat.card_Icc, id_eq simp), Erdos432 (open scoped
+  Classical, not_le, monotone_filter_right), Erdos195 (get!→getElem! + private
+  getElem!_take_of_lt helper, IsChain.take), Erdos252 (sum_pair .ne order,
+  pow_succ', divisor_le, orphan docstring), Erdos266 (summable_nat_add_iff ←rw,
+  not_summable_natCast_inv), Erdos296 (named def binders for omega, tendsto_nhds_unique,
+  cast-shape witness rework), Erdos323 (open scoped Classical + ℚ^ℚ conjecture
+  defs respelled to ℝ rpow — no HPow ℚ ℚ), MathematicalInductionOQ01
+  (Order.IsSuccLimit, zero_or_succ_or_isSuccLimit, strongRecOn arg order).
+- **CayleyHamilton Basis cluster (+3)**: CayleyHamiltonMinpolyOQ05OQ01OQ02 (UFM
+  namespace + le_antisymm zero_le + sum_eq_zero), CayleyHamiltonCyclicVectorAllFieldsOQ03
+  (SEAM: `Basis` → `Module.Basis`, no alias; span_eq_top_of_card_eq_finrank';
+  `set` after intro makes hypotheses reference inaccessible c✝ — drop set),
+  +OQ03OQ02 dep free-flip.
+- **Hilbert15 pair (+2) + Erdos19OQ01 (+1)**: bare finrank → Module.finrank
+  (open FiniteDimensional no longer exports it); chain'_singleton→isChain_singleton,
+  Chain' [2,2] decidability gone → explicit List.Chain.cons term;
+  Submodule.nontrivial_iff_ne_bot; Erdos19OQ01 missing `import Proofs.GraphCore`
+  + Nat.find_min goal-first.
+
+## Statement repairs (#38611)
+- **Erdos490ProblemAristotle.optimal_works_because_primes_ari**: FALSE as stated
+  (a₁=a₂=0, p₁=3, p₂=5 satisfies all hypotheses but concludes p₁=p₂). Added
+  missing `(ha₂pos : 0 < a₂)` — intended-true form (construction elements ≥ 1).
+- **Erdos323Problem** conjecture defs: `(x : ℚ) ^ (ε : ℚ)` no longer elaborates
+  (no HPow ℚ ℚ); the two open-conjecture Prop defs now state the exponent bound
+  in ℝ (rpow) — the intended reading; nothing proves these Props.
+- **Erdos296Problem.k_infinitely_often_large**: witness changed max N₀ N₁ + 1 →
+  max (max N₀ N₁ + 1) 2 — the old proof's log_pos side goal was unprovable for
+  N₀ = N₁ = 0 (latent); new witness keeps the statement, repairs the proof.
+
+## New systematic seams worth cataloging (rename-map candidates)
+- **Forward-reference harvest**: `awk unknown-const rows` × `decl-line > first-use-line`
+  finds them mechanically; ~9/10 project-local unknown-consts in partition A were this.
+- **`Basis` → `Module.Basis`** (no alias/export); also `Basis.equivFun_apply` etc.
+- **bare `finrank` via `open FiniteDimensional` is gone** → `Module.finrank`;
+  `finrank_pos_iff` → `Module.finrank_pos_iff`.
+- **`List.Chain'` family → `List.IsChain`** (isChain_singleton, IsChain.take,
+  IsChain.prefix; Chain' [a,b] lost its Decidable instance — use explicit
+  List.Chain.cons terms); `List.get!` field removed → `xs[i]!` (getElem!);
+  no getElem!/take lemma — bridge via getElem!_pos/neg + getElem_take (pass the
+  container explicitly or the unifier binds cont := ℕ from the bound proof).
+- **`diff` → `sdiff` rename family (2026-06)**: Ici_diff_left → Ici_sdiff_left
+  (some members have deprecated aliases, this one does not).
+- **omega no longer sees structure-field facts or anonymous ∀-antecedents in
+  def bodies** → materialize `have := I.hle` / name the binders.
+- **`Nat.find_min` / getElem!_pos-style lemmas**: positional `_` can unify the
+  WRONG instantiation (cont := ℕ) — pass values explicitly or goal-first.
+- **normalizedFactors lemmas moved into UniqueFactorizationMonoid namespace**
+  (dvd_of_mem_normalizedFactors, ne_zero_of_mem_normalizedFactors).
+- **`Nat.radical` never existed**: NatInt.lean lemmas are in namespace Nat but
+  the def is `UniqueFactorizationMonoid.radical`.
+
+## Flagged deep (triaged, did NOT flip, reverted where edited)
+- Erdos428Problem: `Filter.le_limsup_of_le` now demands `IsBoundedUnder (≤)`
+  (autoParam); the file's cobounded-only route is gone and primeDensityRatio is
+  not obviously bounded above — needs a boundedness argument or statement work.
+- AmgmInequalityOQ02OQ01OQ02OQ01OQ03: sum-reindex/Nat-sub normalization drift
+  through a long Newton–Girard double induction (fixing the first two exposes
+  4 deeper); reverted.
+- CayleyHamiltonMinpolyOQ05OQ01OQ01: fintypeBiUnion' motive-not-type-correct +
+  natDegree_multiset_prod arg change — deep.
+- Erdos512Problem: 15 errors (cast-shape drift × intervalIntegral removals) —
+  tractable but long; left for next increment.
+- FundamentalTheoremCalculusLebesgueOQ04 (import-order + removed-const cascade,
+  prior triage), Erdos598 (universe metavars, prior triage), Erdos133 (universe
+  metavar + Prop-def), DenumerabilityRationalsOQ02OQ02 (InducedMap namespace),
+  Erdos274 (leftCoset removed), CauchySchwarzOQ02 (HolderConjugate API +
+  inner_mul_le_norm_mul_sq), Erdos281/301/29OQ02/86/3LogHarmonic (5-10 mixed).
+
+---
+# HISTORY: DOCTOR INCREMENT 34 (type-mismatch + proof-drift + rewrite-drift + unknown-const-mixed + instance-synth, A–M partition, #38065, 2026-07-14)
 
 Container `dr44` (cpus 6-11, 11g, cache v431-b), worktree doctor-b, branch
 `feature/issue-38065-c`. Partition A–M basenames + Erdos < 600. Whole-partition

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -1084,7 +1084,7 @@ Erdos285Problem	GREEN
 Erdos286Problem	GREEN	
 Erdos287Problem	GREEN	
 Erdos288Problem	RESIDUAL	rewrite-drift
-Erdos289Problem	RESIDUAL	unknown-const:div_le_div_of_le_left
+Erdos289Problem	GREEN	
 Erdos28AdditiveBases	GREEN	
 Erdos28Problem	GREEN	
 Erdos291Problem	RESIDUAL	proof-drift

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -989,7 +989,7 @@ Erdos191Problem	RESIDUAL	instance-synth
 Erdos192Problem	GREEN	
 Erdos193Problem	RESIDUAL	unknown-const:p
 Erdos194Problem	GREEN	
-Erdos195Problem	RESIDUAL	unknown-const:List.Chain'.take
+Erdos195Problem	GREEN	
 Erdos196Problem	GREEN	
 Erdos199Problem	GREEN	
 Erdos19OQ01Problem	RESIDUAL	unknown-const:GraphCore.IsKColorable
@@ -1254,7 +1254,7 @@ Erdos428Problem	RESIDUAL	unknown-const:primeDensityRatio_nonneg
 Erdos429Problem	RESIDUAL	type-mismatch
 Erdos42Problem	GREEN	
 Erdos431Problem	GREEN	
-Erdos432Problem	RESIDUAL	unknown-const:Finset.card_filter_le_card_filter
+Erdos432Problem	GREEN	
 Erdos433Aristotle	GREEN	
 Erdos433Problem	GREEN	
 Erdos434Aristotle	GREEN	

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -992,7 +992,7 @@ Erdos194Problem	GREEN
 Erdos195Problem	GREEN	
 Erdos196Problem	GREEN	
 Erdos199Problem	GREEN	
-Erdos19OQ01Problem	RESIDUAL	unknown-const:GraphCore.IsKColorable
+Erdos19OQ01Problem	GREEN	
 Erdos19Problem	GREEN	
 Erdos1OQ03	RESIDUAL	type-mismatch
 Erdos1OQ03Aristotle	RESIDUAL	type-mismatch
@@ -2088,7 +2088,7 @@ Hilbert14Invariants	GREEN
 Hilbert14InvariantsOQ01	GREEN	type-mismatch
 Hilbert14NonReductive	RESIDUAL	type-mismatch
 Hilbert15OQ02OQ03OQ01	RESIDUAL	rewrite-drift
-Hilbert15SchubertCalculus	RESIDUAL	unknown-const:finrank
+Hilbert15SchubertCalculus	GREEN	
 Hilbert15SchubertCalculusOQ01	RESIDUAL	unknown-const:finrank
 Hilbert16	GREEN	
 Hilbert17OQ01	GREEN	

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -2089,7 +2089,7 @@ Hilbert14InvariantsOQ01	GREEN	type-mismatch
 Hilbert14NonReductive	RESIDUAL	type-mismatch
 Hilbert15OQ02OQ03OQ01	RESIDUAL	rewrite-drift
 Hilbert15SchubertCalculus	GREEN	
-Hilbert15SchubertCalculusOQ01	RESIDUAL	unknown-const:finrank
+Hilbert15SchubertCalculusOQ01	GREEN	
 Hilbert16	GREEN	
 Hilbert17OQ01	GREEN	
 Hilbert17RobinsonRationalSOS	GREEN	

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -1124,7 +1124,7 @@ Erdos320Problem	GREEN
 Erdos321Problem	GREEN	
 Erdos321ProblemR1	GREEN	
 Erdos322Problem	GREEN	
-Erdos323Problem	RESIDUAL	unknown-const:IsSumOfPowers_one_iff.mpr
+Erdos323Problem	GREEN	
 Erdos324Problem	GREEN	
 Erdos325Problem	GREEN	
 Erdos326Problem	GREEN	

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -599,7 +599,7 @@ ElementaryQuadraticReciprocityOQ03OQ01	GREEN
 ElementaryQuadraticReciprocityOQ03OQ01OQ02	GREEN	
 ElementaryQuadraticReciprocityOQ03OQ02OQ01	RESIDUAL	proof-drift
 ElementaryQuadraticReciprocityOQ03OQ02OQ03	RESIDUAL	proof-drift
-ElementaryQuadraticReciprocityOQ03OQ03	RESIDUAL	unknown-const:legendreSym.eq_one_iff_isSquare
+ElementaryQuadraticReciprocityOQ03OQ03	GREEN	
 Erdos1000OQ01	RESIDUAL	rewrite-drift
 Erdos1000OQ02	GREEN	type-mismatch
 Erdos1000Problem	GREEN	
@@ -1326,7 +1326,7 @@ Erdos489Problem	GREEN
 Erdos48Problem	GREEN	
 Erdos490Aristotle	GREEN	parse-error
 Erdos490OQ01	GREEN	
-Erdos490ProblemAristotle	RESIDUAL	unknown-const:Nat.eq_zero_of_mul_eq_zero_left
+Erdos490ProblemAristotle	GREEN	
 Erdos491Problem	GREEN	
 Erdos492Problem	RESIDUAL	unknown-const:Int.frac
 Erdos494Problem	GREEN	
@@ -1997,7 +1997,7 @@ FourierSeriesOQ02OQ02	RESIDUAL	unclassified
 FourierSeriesOQ02OQ03	RESIDUAL	proof-drift
 FourierSeriesOQ02OQ03OQ02	RESIDUAL	unknown-const:Real.exp_le_one_of_nonpos
 FourierSeriesOQ02OQ03WIP01	GREEN	
-FourierSeriesOQ02OQ04	RESIDUAL	unclassified
+FourierSeriesOQ02OQ04	GREEN	
 FourierSeriesOQ04	GREEN	
 FourierSeriesOQ04OQ01	RESIDUAL	type-mismatch
 FourierSeriesOQ04OQ01Incomplete01	RESIDUAL	type-mismatch

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -953,7 +953,7 @@ Erdos158Problem	GREEN
 Erdos159Problem	GREEN
 Erdos15Problem	GREEN	
 Erdos161Problem	GREEN	
-Erdos162Problem	RESIDUAL	unknown-const:Bool.true_ne_false
+Erdos162Problem	GREEN	
 Erdos163Problem	GREEN	
 Erdos164Problem	GREEN	
 Erdos166Problem	GREEN
@@ -1054,7 +1054,7 @@ Erdos259Problem	GREEN
 Erdos25Abel	GREEN	
 Erdos25LogDensity	RESIDUAL	type-mismatch
 Erdos25Problem	RESIDUAL	type-mismatch
-Erdos260Aristotle	RESIDUAL	unknown-const:Real.tendsto_log_nat_atTop
+Erdos260Aristotle	GREEN	
 Erdos261Problem	GREEN	
 Erdos262Problem	GREEN	
 Erdos263Aristotle	GREEN	
@@ -2022,7 +2022,7 @@ FrobeniusNumberOQ02OQ01	GREEN
 FrobeniusNumberOQ02OQ02	GREEN	
 FrobeniusNumberOQ03	GREEN	
 FundamentalArithmetic	GREEN	
-FundamentalArithmeticOQ01	RESIDUAL	unknown-const:Nat.coprime_iff_disjoint.mp
+FundamentalArithmeticOQ01	GREEN	
 FundamentalArithmeticOQ02	RESIDUAL	unknown-const:Zsqrtd.mul_def
 FundamentalTheoremAlgebra	RESIDUAL	type-mismatch
 FundamentalTheoremAlgebraOQ04OQ03OQ01OQ01	GREEN	

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -381,10 +381,10 @@ CayleyHamiltonCyclicVectorAllFieldsOQ02OQ02	GREEN
 CayleyHamiltonCyclicVectorAllFieldsOQ02OQ02Masa	GREEN	
 CayleyHamiltonCyclicVectorAllFieldsOQ02OQ02Range	GREEN	
 CayleyHamiltonCyclicVectorAllFieldsOQ02OQ02Scalar	GREEN	
-CayleyHamiltonCyclicVectorAllFieldsOQ03	RESIDUAL	unknown-const:Basis
+CayleyHamiltonCyclicVectorAllFieldsOQ03	GREEN	
 CayleyHamiltonCyclicVectorAllFieldsOQ03Bridge	GREEN	
 CayleyHamiltonCyclicVectorAllFieldsOQ03Converse	RESIDUAL	unknown-const:Basis
-CayleyHamiltonCyclicVectorAllFieldsOQ03OQ02	RESIDUAL	unknown-const:Basis
+CayleyHamiltonCyclicVectorAllFieldsOQ03OQ02	GREEN	
 CayleyHamiltonMinpolyOQ01OQ01	GREEN	
 CayleyHamiltonMinpolyOQ02OQ01OQ02	GREEN	
 CayleyHamiltonMinpolyOQ02OQ02	RESIDUAL	proof-drift
@@ -394,7 +394,7 @@ CayleyHamiltonMinpolyOQ04Backward	RESIDUAL	type-mismatch
 CayleyHamiltonMinpolyOQ04BackwardAristotle	GREEN	
 CayleyHamiltonMinpolyOQ05	GREEN	
 CayleyHamiltonMinpolyOQ05OQ01OQ01	RESIDUAL	unknown-const:isUnit_of_natDegree_eq_zero
-CayleyHamiltonMinpolyOQ05OQ01OQ02	RESIDUAL	unknown-const:dvd_of_mem_normalizedFactors
+CayleyHamiltonMinpolyOQ05OQ01OQ02	GREEN	
 CayleyHamiltonMinpolyOQ05OQ01OQ04WIP01	RESIDUAL	proof-drift
 CayleyHamiltonMinpolyOQ05OQ01OQ04WIP03	GREEN	
 CayleyHamiltonMinpolyOQ05OQ02	GREEN	
@@ -1043,7 +1043,7 @@ Erdos249Problem	GREEN
 Erdos24Problem	GREEN	
 Erdos250Problem	GREEN	
 Erdos251Problem	GREEN	
-Erdos252Problem	RESIDUAL	parse-error
+Erdos252Problem	GREEN	
 Erdos254Problem	GREEN	
 Erdos255Problem	GREEN	
 Erdos256Problem	GREEN	

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -580,7 +580,7 @@ EgorovTheorem	GREEN
 EgorovTheoremOQ01OQ02	GREEN	
 EgorovTheoremOQ01OQ03	GREEN	
 EhrhartCrossPolytope	GREEN	
-EisensteinCriterionOQ01OQ03OQ02OQ01	RESIDUAL	unclassified
+EisensteinCriterionOQ01OQ03OQ02OQ01	GREEN	
 ElementaryQuadraticReciprocityOQ01	RESIDUAL	unknown-const:generator_orderOf
 ElementaryQuadraticReciprocityOQ01OQ01OQ03	RESIDUAL	instance-synth
 ElementaryQuadraticReciprocityOQ01OQ03	GREEN	
@@ -1097,7 +1097,7 @@ Erdos298Problem	GREEN
 Erdos299Problem	RESIDUAL	unknown-const:Nat.not_eq_zero_of_lt
 Erdos29OQ02	RESIDUAL	parse-error
 Erdos29Problem	RESIDUAL	unknown-const:JPSZ_representation_bound
-Erdos2OQ01	RESIDUAL	unknown-const:balister_bound
+Erdos2OQ01	GREEN	
 Erdos2OQ01Aristotle	RESIDUAL	proof-drift
 Erdos2Problem	GREEN	
 Erdos300Problem	GREEN	
@@ -1991,7 +1991,7 @@ FourSquareDistributionOQ04Bridge	GREEN
 FourSquareDistributionOQ04Decomp	GREEN	
 FourSquareDistributionOQ04Keystone	GREEN	
 FourierSeriesOQ01	RESIDUAL	rewrite-drift
-FourierSeriesOQ02	RESIDUAL	unclassified
+FourierSeriesOQ02	GREEN	
 FourierSeriesOQ02Incomplete01	GREEN	
 FourierSeriesOQ02OQ02	RESIDUAL	unclassified
 FourierSeriesOQ02OQ03	RESIDUAL	proof-drift

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -1160,7 +1160,7 @@ Erdos343Problem	GREEN
 Erdos344Problem	GREEN	
 Erdos345Problem	GREEN	parse-error
 Erdos346Problem	GREEN	
-Erdos347Problem	RESIDUAL	unknown-const:Finset.card_Icc
+Erdos347Problem	GREEN	
 Erdos348Problem	RESIDUAL	type-mismatch
 Erdos349Problem	GREEN	
 Erdos350Problem	GREEN	
@@ -1207,7 +1207,7 @@ Erdos388Problem	GREEN
 Erdos38Problem	GREEN	
 Erdos390Problem	RESIDUAL	unknown-const:List.Sorted
 Erdos391Problem	RESIDUAL	type-mismatch
-Erdos393Problem	RESIDUAL	unknown-const:Nat.radical
+Erdos393Problem	GREEN	
 Erdos394Problem	GREEN	
 Erdos395OQ01	RESIDUAL	instance-synth
 Erdos395OQ01Incomplete01	RESIDUAL	instance-synth

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -1021,7 +1021,7 @@ Erdos222Problem	GREEN
 Erdos223Problem	RESIDUAL	type-mismatch
 Erdos225Aristotle	GREEN	
 Erdos225Problem	RESIDUAL	proof-drift
-Erdos226Problem	RESIDUAL	unknown-const:Rat.denseRange_ratCast
+Erdos226Problem	GREEN	
 Erdos229Problem	GREEN	
 Erdos230LowerBound	GREEN	
 Erdos230ProblemAristotle	GREEN	
@@ -1262,7 +1262,7 @@ Erdos434Frobenius	GREEN
 Erdos434Problem	RESIDUAL	unknown-const:sylvester_frobenius
 Erdos435Problem	GREEN	
 Erdos436Problem	GREEN	
-Erdos437Aristotle	RESIDUAL	unknown-const:div_le_one_of_le
+Erdos437Aristotle	GREEN	
 Erdos437Problem	GREEN	
 Erdos438Problem	GREEN	
 Erdos439Problem	GREEN	
@@ -2105,7 +2105,7 @@ Hilbert22OQ01OQ03Pseudohyperbolic	GREEN
 Hilbert22OQ01OQ03Universal	GREEN	
 Hilbert22Uniformization	GREEN	
 Hilbert23CalculusVariations	GREEN	
-Hilbert23CalculusVariationsOQ01	RESIDUAL	unknown-const:Ici_diff_left
+Hilbert23CalculusVariationsOQ01	GREEN	
 Hilbert3ScissorsCongruence	GREEN	
 Hilbert4Geodesics	RESIDUAL	instance-synth
 Hilbert5LieGroups	GREEN	elab-drift

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -1120,7 +1120,7 @@ Erdos318Aristotle	GREEN
 Erdos318Problem	GREEN	
 Erdos319Problem	RESIDUAL	proof-drift
 Erdos31Problem	GREEN	
-Erdos320Problem	RESIDUAL	unknown-const:erdos_320_open_bounds
+Erdos320Problem	GREEN	
 Erdos321Problem	GREEN	
 Erdos321ProblemR1	GREEN	
 Erdos322Problem	GREEN	
@@ -1359,7 +1359,7 @@ Erdos51Problem	GREEN
 Erdos520Problem	GREEN	
 Erdos521Problem	GREEN	
 Erdos522Problem	GREEN	
-Erdos523Problem	RESIDUAL	unknown-const:halasz_theorem
+Erdos523Problem	GREEN	
 Erdos524Problem	GREEN	
 Erdos525OQ02	GREEN	
 Erdos525Problem	RESIDUAL	instance-synth

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -2250,7 +2250,7 @@ MaschkeAugmentationNoSplitOQ010101	GREEN
 MaschkeLocalRingOQ010102	RESIDUAL	instance-synth
 MaschkeModularCounterexampleOQ01	GREEN	
 MaschkeTheoremOQ01	RESIDUAL	parse-error
-MathematicalInductionOQ01	RESIDUAL	unknown-const:Ordinal.IsLimit
+MathematicalInductionOQ01	GREEN	
 MathematicalInductionOQ03	RESIDUAL	type-mismatch
 MatrixSimilarityInvariantsOQ01	GREEN	
 MeanValueTheorem	GREEN	

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -1061,7 +1061,7 @@ Erdos263Aristotle	GREEN
 Erdos263Problem	RESIDUAL	proof-drift
 Erdos264Problem	GREEN	
 Erdos265Problem	GREEN
-Erdos266Problem	RESIDUAL	unknown-const:Real.not_summable_nat_of_tendsto_nat
+Erdos266Problem	GREEN	
 Erdos267Problem	GREEN	
 Erdos268Aristotle	RESIDUAL	unknown-const:summable_of_finite
 Erdos268Problem	RESIDUAL	proof-drift
@@ -1091,7 +1091,7 @@ Erdos291Problem	RESIDUAL	proof-drift
 Erdos292Problem	GREEN	
 Erdos293Problem	GREEN	
 Erdos294Problem	GREEN	
-Erdos296Problem	RESIDUAL	unknown-const:Filter.Tendsto.unique
+Erdos296Problem	GREEN	
 Erdos297Problem	GREEN	
 Erdos298Problem	GREEN	
 Erdos299Problem	RESIDUAL	unknown-const:Nat.not_eq_zero_of_lt


### PR DESCRIPTION
Doctor increment 56 (#38065, epic #37508). Partition A (basenames A–M + Erdos<600), worktree doctor-b, container dr56 (cpus 6-11, 11g, cache lean-mathlib-cache-v431-b). Every flip verified by in-container per-file `lake build Proofs.X` exit 0. Ledger now 1960 GREEN.

## +30 GREEN this increment
**Free flips (3)**: EisensteinCriterionOQ01OQ03OQ02OQ01, Erdos2OQ01, FourierSeriesOQ02 — no own errors in bulk probe (prior increments' dep fixes), exit-code verified.

**Fixed (27)**: Erdos490ProblemAristotle, FourierSeriesOQ02OQ04, ElementaryQuadraticReciprocityOQ03OQ03, Erdos320Problem, Erdos523Problem, Erdos226Problem, Erdos437Aristotle, Hilbert23CalculusVariationsOQ01, Erdos260Aristotle, Erdos162Problem, FundamentalArithmeticOQ01, Erdos393Problem, Erdos347Problem, Erdos432Problem, Erdos195Problem, CayleyHamiltonMinpolyOQ05OQ01OQ02, CayleyHamiltonCyclicVectorAllFieldsOQ03 (+OQ03OQ02 dep free-flip), Erdos252Problem, Erdos266Problem, Erdos296Problem, Hilbert15SchubertCalculus, Hilbert15SchubertCalculusOQ01, Erdos19OQ01Problem, Erdos289Problem, Erdos323Problem, MathematicalInductionOQ01.

## Statement repairs (#38611, noted in STATUS.md)
- **Erdos490ProblemAristotle.optimal_works_because_primes_ari** was FALSE as stated (a₁=a₂=0, p₁=3, p₂=5 satisfies all hypotheses but p₁≠p₂): added missing `0 < a₂` (intended-true form).
- **Erdos323Problem** conjecture Prop defs: `(x : ℚ) ^ (ε : ℚ)` no longer elaborates (no HPow ℚ ℚ) — respelled exponent bound in ℝ rpow (intended reading; nothing proves these Props).
- **Erdos296Problem.k_infinitely_often_large**: proof witness max N₀ N₁ + 1 → max (… ) 2; the old log_pos side goal was unprovable at N₀=N₁=0 (latent).

## New seams cataloged (STATUS.md § increment 56)
`Basis`→`Module.Basis` (no alias); bare `finrank` via `open FiniteDimensional` gone; `List.Chain'`→`IsChain` family + `get!`→`getElem!` (no take-lemma — bridge via getElem!_pos/neg + getElem_take); `diff`→`sdiff` (Ici_diff_left has NO alias); forward-reference mechanical harvest (9/10 project-local unknown-consts in partition A); omega no longer sees structure fields / anonymous ∀-antecedents; normalizedFactors lemmas moved into UFM namespace.

## Deferred deep (triaged, reverted where edited)
Erdos428Problem (le_limsup_of_le now requires IsBoundedUnder (≤) — cobounded route gone), AmgmInequality…OQ03 (Newton–Girard sum-reindex cascade), CayleyHamiltonMinpolyOQ05OQ01OQ01, Erdos512Problem (15 tractable-but-long), Erdos29Problem (forward-ref fix valid but exposes rpow drift ×10).

Part of #38065 / epic #37508.

🤖 Generated with [Claude Code](https://claude.com/claude-code)