### PR TITLE
migrate(v4.31): Doctor increment 57 — deep-rework partition B (+18 GREEN)

### DIFF
--- a/proofs/Proofs/Erdos1050ProblemAristotle.lean
+++ b/proofs/Proofs/Erdos1050ProblemAristotle.lean
@@ -135,7 +135,7 @@ theorem abs_term_bound (n : ℕ) (hn : n ≥ 3) :
 /-- The geometric series ∑ 1/2^n converges. -/
 theorem inv_two_pow_summable :
     Summable (fun n : ℕ => (1 : ℝ) / 2 ^ n) := by
-  apply Summable.congr (summable_geometric_of_lt_one (by norm_num) (by norm_num : 1/2 < 1))
+  apply Summable.congr (summable_geometric_of_lt_one (r := 1/2) (by norm_num) (by norm_num))
   intro n; simp [one_div, pow_succ]
 
 /-
@@ -162,7 +162,7 @@ Used when proving summability by comparison with geometric series.
 /-- For q ≥ 2, 1/q^n → 0. -/
 theorem inv_q_pow_tendsto_zero (q : ℕ) (hq : q ≥ 2) :
     Tendsto (fun n : ℕ => (1 : ℝ) / (q : ℝ) ^ n) atTop (nhds 0) := by
-  have hq_gt : (1 : ℝ) < q := by exact_mod_cast Nat.lt_of_lt_pred hq
+  have hq_gt : (1 : ℝ) < q := by exact_mod_cast (show 1 < q by omega)
   have : Tendsto (fun n : ℕ => ((1 : ℝ) / q) ^ n) atTop (nhds 0) :=
     tendsto_pow_atTop_nhds_zero_of_lt_one (by positivity) (by rw [div_lt_one (by positivity)]; linarith)
   simpa [div_pow]
@@ -170,9 +170,9 @@ theorem inv_q_pow_tendsto_zero (q : ℕ) (hq : q ≥ 2) :
 /-- For q ≥ 2, ∑ 1/q^n is summable. -/
 theorem inv_q_pow_summable (q : ℕ) (hq : q ≥ 2) :
     Summable (fun n : ℕ => (1 : ℝ) / (q : ℝ) ^ n) := by
-  apply summable_of_summable_norm
+  apply Summable.of_norm
   simp only [norm_div, norm_pow, Real.norm_ofNat]
-  apply Summable.congr (summable_geometric_of_lt_one (by positivity)
+  apply Summable.congr (summable_geometric_of_lt_one (r := 1/(q:ℝ)) (by positivity)
     (by rw [div_lt_one (by exact_mod_cast (show 0 < q by omega))];
         exact_mod_cast (show 1 < q by omega)))
   intro n; simp [div_pow]
@@ -187,7 +187,7 @@ theorem add_neg_self (r : ℝ) : r + (-r) = 0 := add_neg_cancel r
 /-- q^n + r ≠ 0 when r > 0 and q ≥ 2. -/
 theorem q_pow_add_pos_ne_zero (q : ℕ) (n : ℕ) (hq : q ≥ 2) (r : ℝ) (hr : r > 0) :
     (q : ℝ) ^ n + r ≠ 0 := by
-  have hq_pos : (0 : ℝ) < q := by exact_mod_cast Nat.lt_of_lt_pred hq
+  have hq_pos : (0 : ℝ) < q := by exact_mod_cast (show 0 < q by omega)
   have := pow_pos hq_pos n
   linarith
 

--- a/proofs/Proofs/Erdos1065Problem.lean
+++ b/proofs/Proofs/Erdos1065Problem.lean
@@ -34,12 +34,8 @@ def IsTwoThreeTimePrimePlusOne (p : ℕ) : Prop :=
 axiom erdos_1065a :
   Set.Infinite {p : ℕ | IsTwoTimePrimePlusOne p}
 
-/-- **Erdős Problem #1065b**: infinitely many primes p = 2^k · 3^l · q + 1.
-    PROVED from erdos_1065a: every Form A prime is Form B (take l = 0).
-    (Previously axiom; axiom count reduced 2→1.) -/
-theorem erdos_1065b :
-    Set.Infinite {p : ℕ | IsTwoThreeTimePrimePlusOne p} :=
-  conjecture_a_implies_b erdos_1065a
+-- (erdos_1065b is stated after `conjecture_a_implies_b` below —
+-- v4.31 no longer allows forward references within a file.)
 
 -- ## Verified Form A Examples
 
@@ -200,7 +196,7 @@ theorem not_form_a_37 : ¬ IsTwoTimePrimePlusOne 37 := by
   have h36 : 2 ^ k * q = 36 := by omega
   have hk : k ≤ 4 := by
     by_contra hk; push_neg at hk
-    have := Nat.pow_le_pow_right (show 1 < 2 from by norm_num) hk
+    have := Nat.pow_le_pow_right (show 0 < 2 from by norm_num) hk
     nlinarith [hq.two_le]
   interval_cases k
   · have : q = 36 := by omega
@@ -218,7 +214,7 @@ theorem not_form_a_61 : ¬ IsTwoTimePrimePlusOne 61 := by
   have h60 : 2 ^ k * q = 60 := by omega
   have hk : k ≤ 4 := by
     by_contra hk; push_neg at hk
-    have := Nat.pow_le_pow_right (show 1 < 2 from by norm_num) hk
+    have := Nat.pow_le_pow_right (show 0 < 2 from by norm_num) hk
     nlinarith [hq.two_le]
   interval_cases k
   · have : q = 60 := by omega
@@ -236,7 +232,7 @@ theorem not_form_a_71 : ¬ IsTwoTimePrimePlusOne 71 := by
   have h70 : 2 ^ k * q = 70 := by omega
   have hk : k ≤ 5 := by
     by_contra hk; push_neg at hk
-    have := Nat.pow_le_pow_right (show 1 < 2 from by norm_num) hk
+    have := Nat.pow_le_pow_right (show 0 < 2 from by norm_num) hk
     nlinarith [hq.two_le]
   interval_cases k
   · have : q = 70 := by omega
@@ -255,16 +251,24 @@ theorem not_form_b_71 : ¬ IsTwoThreeTimePrimePlusOne 71 := by
   have h70 : 2 ^ k * 3 ^ l * q = 70 := by omega
   have hk : k ≤ 5 := by
     by_contra hk; push_neg at hk
-    have := Nat.pow_le_pow_right (show 1 < 2 from by norm_num) hk
-    nlinarith [hq.two_le, Nat.one_le_pow l 3 (by norm_num)]
+    have h2k := Nat.pow_le_pow_right (show 0 < 2 from by norm_num) hk
+    have hprod := Nat.mul_le_mul (Nat.mul_le_mul h2k
+      (Nat.one_le_pow l 3 (by norm_num))) hq.two_le
+    rw [h70] at hprod
+    norm_num at hprod
   have hl : l ≤ 3 := by
     by_contra hl; push_neg at hl
-    have := Nat.pow_le_pow_right (show 1 < 3 from by norm_num) hl
-    nlinarith [hq.two_le, Nat.one_le_pow k 2 (by norm_num)]
+    have h3l := Nat.pow_le_pow_right (show 0 < 3 from by norm_num) hl
+    have hprod := Nat.mul_le_mul (Nat.mul_le_mul
+      (Nat.one_le_pow k 2 (by norm_num)) h3l) hq.two_le
+    rw [h70] at hprod
+    norm_num at hprod
   interval_cases k <;> interval_cases l <;> simp_all <;>
     first
     | omega
-    | (have : q = _ := by omega; subst this; exact absurd hq (by decide))
+    | exact absurd hq (by decide)
+    | (have hq35 : q = 35 := by omega
+       subst hq35; exact absurd hq (by decide))
 
 /-- p = 19 is NOT Form A: 18 = 2 · 9 and 9 = 3² is not prime. -/
 theorem not_form_a_19 : ¬ IsTwoTimePrimePlusOne 19 := by
@@ -272,7 +276,7 @@ theorem not_form_a_19 : ¬ IsTwoTimePrimePlusOne 19 := by
   have h18 : 2 ^ k * q = 18 := by omega
   have hk : k ≤ 4 := by
     by_contra hk; push_neg at hk
-    have := Nat.pow_le_pow_right (show 1 < 2 from by norm_num) hk
+    have := Nat.pow_le_pow_right (show 0 < 2 from by norm_num) hk
     nlinarith [hq.two_le]
   interval_cases k
   · have : q = 18 := by omega
@@ -289,7 +293,7 @@ theorem not_form_a_31 : ¬ IsTwoTimePrimePlusOne 31 := by
   have h30 : 2 ^ k * q = 30 := by omega
   have hk : k ≤ 4 := by
     by_contra hk; push_neg at hk
-    have := Nat.pow_le_pow_right (show 1 < 2 from by norm_num) hk
+    have := Nat.pow_le_pow_right (show 0 < 2 from by norm_num) hk
     nlinarith [hq.two_le]
   interval_cases k
   · have : q = 30 := by omega
@@ -306,7 +310,7 @@ theorem not_form_a_43 : ¬ IsTwoTimePrimePlusOne 43 := by
   have h42 : 2 ^ k * q = 42 := by omega
   have hk : k ≤ 4 := by
     by_contra hk; push_neg at hk
-    have := Nat.pow_le_pow_right (show 1 < 2 from by norm_num) hk
+    have := Nat.pow_le_pow_right (show 0 < 2 from by norm_num) hk
     nlinarith [hq.two_le]
   interval_cases k
   · have : q = 42 := by omega
@@ -323,7 +327,7 @@ theorem not_form_a_67 : ¬ IsTwoTimePrimePlusOne 67 := by
   have h66 : 2 ^ k * q = 66 := by omega
   have hk : k ≤ 6 := by
     by_contra hk; push_neg at hk
-    have := Nat.pow_le_pow_right (show 1 < 2 from by norm_num) hk
+    have := Nat.pow_le_pow_right (show 0 < 2 from by norm_num) hk
     nlinarith [hq.two_le]
   interval_cases k
   · have : q = 66 := by omega
@@ -342,7 +346,7 @@ theorem not_form_a_73 : ¬ IsTwoTimePrimePlusOne 73 := by
   have h72 : 2 ^ k * q = 72 := by omega
   have hk : k ≤ 6 := by
     by_contra hk; push_neg at hk
-    have := Nat.pow_le_pow_right (show 1 < 2 from by norm_num) hk
+    have := Nat.pow_le_pow_right (show 0 < 2 from by norm_num) hk
     nlinarith [hq.two_le]
   interval_cases k
   · have : q = 72 := by omega
@@ -363,7 +367,7 @@ theorem not_form_a_79 : ¬ IsTwoTimePrimePlusOne 79 := by
   have h78 : 2 ^ k * q = 78 := by omega
   have hk : k ≤ 6 := by
     by_contra hk; push_neg at hk
-    have := Nat.pow_le_pow_right (show 1 < 2 from by norm_num) hk
+    have := Nat.pow_le_pow_right (show 0 < 2 from by norm_num) hk
     nlinarith [hq.two_le]
   interval_cases k
   · have : q = 78 := by omega
@@ -455,6 +459,13 @@ theorem conjecture_a_implies_b :
   intro p hp
   exact form_a_implies_b p hp
 
+/-- **Erdős Problem #1065b**: infinitely many primes p = 2^k · 3^l · q + 1.
+    PROVED from erdos_1065a: every Form A prime is Form B (take l = 0).
+    (Previously axiom; axiom count reduced 2→1.) -/
+theorem erdos_1065b :
+    Set.Infinite {p : ℕ | IsTwoThreeTimePrimePlusOne p} :=
+  conjecture_a_implies_b erdos_1065a
+
 /-- p = 2 is NOT Form A: 2 - 1 = 1 = 2^0 · 1, but 1 is not prime. -/
 theorem not_form_a_2 : ¬ IsTwoTimePrimePlusOne 2 := by
   intro ⟨_, q, k, hq, heq⟩
@@ -467,10 +478,10 @@ theorem not_form_a_2 : ¬ IsTwoTimePrimePlusOne 2 := by
 theorem not_form_b_2 : ¬ IsTwoThreeTimePrimePlusOne 2 := by
   intro ⟨_, q, k, l, hq, heq⟩
   have h1 : 2 ^ k * 3 ^ l * q = 1 := by omega
-  have := hq.two_le
-  have := Nat.one_le_pow k 2 (by norm_num)
-  have := Nat.one_le_pow l 3 (by norm_num)
-  nlinarith
+  have hprod := Nat.mul_le_mul (Nat.mul_le_mul
+    (Nat.one_le_pow k 2 (by norm_num)) (Nat.one_le_pow l 3 (by norm_num))) hq.two_le
+  rw [h1] at hprod
+  norm_num at hprod
 
 /-- **Complete Form B census ≤ 100**: all 23 Form B primes.
     These are all primes ≤ 100 except p = 2 and p = 71.

--- a/proofs/Proofs/Erdos1134Problem.lean
+++ b/proofs/Proofs/Erdos1134Problem.lean
@@ -66,6 +66,7 @@ theorem A_closed_f₃ {x : ℕ} (hx : x ∈ A) : f₃ x ∈ A := InA.step3 hx
 Lower and upper asymptotic density.
 -/
 
+open Classical in
 /-- Counting function: |A ∩ [1, X]| -/
 noncomputable def countingFunction (S : Set ℕ) (X : ℕ) : ℕ :=
   (Finset.range (X + 1)).filter (fun n => n ∈ S ∧ n ≥ 1) |>.card
@@ -99,13 +100,14 @@ theorem sum_reciprocals_eq_one : (1/2 : ℝ) + 1/3 + 1/6 = 1 := by norm_num
 The key is that the operations have special structure.
 -/
 
-/-- The Crampin-Hilton exponent τ ≈ 0.900626 -/
-noncomputable def τ : ℝ := Classical.choose crampin_hilton_tau_exists
-
 /-- τ exists and satisfies 6^{-τ} + Σ_{k≥0} (3·2^k)^{-τ} = 1 -/
 axiom crampin_hilton_tau_exists : ∃ τ : ℝ,
     0 < τ ∧ τ < 1 ∧
     (6 : ℝ) ^ (-τ) + ∑' k : ℕ, ((3 : ℝ) * 2 ^ k) ^ (-τ) = 1
+
+/-- The Crampin-Hilton exponent τ ≈ 0.900626 -/
+noncomputable def τ : ℝ := Classical.choose crampin_hilton_tau_exists
+
 
 /-- Numerical value of τ -/
 axiom tau_approx : τ > 0.900 ∧ τ < 0.901
@@ -147,7 +149,7 @@ theorem elements_have_representation {n : ℕ} (hn : n ∈ A) :
       n = ops.foldl (fun x f => f x) 1 := by
   change InA n at hn
   induction hn with
-  | base => exact ⟨[], fun _ h => absurd h (List.not_mem_nil _), rfl⟩
+  | base => exact ⟨[], fun _ h => (List.not_mem_nil h).elim, rfl⟩
   | step1 _ ih =>
     obtain ⟨ops, hops, heq⟩ := ih
     refine ⟨ops ++ [f₁], fun f hf => ?_, ?_⟩
@@ -241,8 +243,7 @@ theorem erdos_1134_statement :
   · intro ε hε
     obtain ⟨_, C₂, _, hC₂pos, hbound⟩ := crampin_hilton_theorem ε hε
     exact ⟨C₂, hC₂pos, fun X hX => (hbound X hX).2⟩
-  · obtain ⟨_, htau_lt, _⟩ := crampin_hilton_tau_exists
-    exact htau_lt
+  · exact (Classical.choose_spec crampin_hilton_tau_exists).2.1
 
 /-- Summary of Erdős Problem #1134 -/
 theorem erdos_1134_summary :

--- a/proofs/Proofs/Erdos1157Problem.lean
+++ b/proofs/Proofs/Erdos1157Problem.lean
@@ -45,11 +45,23 @@ def achievableEdgeCounts (r n k s : ℕ) : Set ℕ :=
   {m : ℕ | ∃ E : Finset (Finset (Fin n)), IsValidHypergraph r n k s E ∧ E.card = m}
 
 /-- The achievable set is always nonempty (the empty hypergraph is valid). -/
-private theorem achievable_nonempty (r n k s : ℕ) :
-    (achievableEdgeCounts r n k s).Nonempty :=
-  ⟨0, ∅, ⟨fun _ h => absurd h (Finset.notMem_empty _),
-    fun F hF hFs => absurd (Finset.card_eq_zero.mpr (Finset.subset_empty.mp hF) ▸ hFs)
-      (by omega)⟩, rfl⟩
+private theorem achievableEdgeCounts_eq_empty_of_s_zero (r n k : ℕ) :
+    achievableEdgeCounts r n k 0 = ∅ := by
+  ext m
+  simp only [achievableEdgeCounts, Set.mem_setOf_eq, Set.mem_empty_iff_false, iff_false]
+  rintro ⟨E, ⟨-, hspan⟩, -⟩
+  have h := hspan ∅ (Finset.empty_subset E) (by omega)
+  simp only [Finset.biUnion_empty, Finset.card_empty] at h
+  omega
+
+/-- Statement repair (#38611): the original claim (for all s) is FALSE at s = 0 —
+    with s = 0 the empty edge-family F = ∅ has F.card ≥ 0, forcing 0 > k, so NO
+    hypergraph is valid and the achievable set is empty. Added `1 ≤ s`. -/
+private theorem achievable_nonempty (r n k s : ℕ) (hs : 1 ≤ s) :
+    (achievableEdgeCounts r n k s).Nonempty := by
+  refine ⟨0, ∅, ⟨fun _ h => absurd h (Finset.notMem_empty _), fun F hF hFs => ?_⟩, rfl⟩
+  have hF0 : F.card = 0 := Finset.card_eq_zero.mpr (Finset.subset_empty.mp hF)
+  omega
 
 /-- The achievable set is bounded above (by the number of all possible edges). -/
 private theorem achievable_bddAbove (r n k s : ℕ) :
@@ -70,10 +82,13 @@ noncomputable def extremalNumber (r n k s : ℕ) : ℕ :=
     set for k₂ ⊆ valid set for k₁. -/
 theorem extremalNumber_mono_k (r n s k₁ k₂ : ℕ) (h : k₁ ≤ k₂) :
     extremalNumber r n k₂ s ≤ extremalNumber r n k₁ s := by
-  unfold extremalNumber
-  apply csSup_le_csSup (achievable_bddAbove r n k₁ s) (achievable_nonempty r n k₂ s)
-  intro m ⟨E, ⟨hunif, hspan⟩, hcard⟩
-  exact ⟨E, ⟨hunif, fun F hF hFs => lt_of_le_of_lt h (hspan F hF hFs)⟩, hcard⟩
+  rcases Nat.eq_zero_or_pos s with rfl | hs
+  · unfold extremalNumber
+    rw [achievableEdgeCounts_eq_empty_of_s_zero, achievableEdgeCounts_eq_empty_of_s_zero]
+  · unfold extremalNumber
+    apply csSup_le_csSup (achievable_bddAbove r n k₁ s) (achievable_nonempty r n k₂ s hs)
+    intro m ⟨E, ⟨hunif, hspan⟩, hcard⟩
+    exact ⟨E, ⟨hunif, fun F hF hFs => lt_of_le_of_lt h (hspan F hF hFs)⟩, hcard⟩
 
 /-- Monotonicity in s: requiring more forbidden edges (s₂ ≥ s₁) makes it harder
     to find violations, so the extremal number increases.
@@ -81,10 +96,14 @@ theorem extremalNumber_mono_k (r n s k₁ k₂ : ℕ) (h : k₁ ≤ k₂) :
     also satisfy this (since F.card ≥ s₂ ≥ s₁ triggers the s₁ condition). -/
 theorem extremalNumber_mono_s (r n k s₁ s₂ : ℕ) (h : s₁ ≤ s₂) :
     extremalNumber r n k s₁ ≤ extremalNumber r n k s₂ := by
-  unfold extremalNumber
-  apply csSup_le_csSup (achievable_bddAbove r n k s₂) (achievable_nonempty r n k s₁)
-  intro m ⟨E, ⟨hunif, hspan⟩, hcard⟩
-  exact ⟨E, ⟨hunif, fun F hF hFs => hspan F hF (le_trans h hFs)⟩, hcard⟩
+  rcases Nat.eq_zero_or_pos s₁ with rfl | hs1
+  · unfold extremalNumber
+    rw [achievableEdgeCounts_eq_empty_of_s_zero, csSup_empty]
+    exact bot_le
+  · unfold extremalNumber
+    apply csSup_le_csSup (achievable_bddAbove r n k s₂) (achievable_nonempty r n k s₁ hs1)
+    intro m ⟨E, ⟨hunif, hspan⟩, hcard⟩
+    exact ⟨E, ⟨hunif, fun F hF hFs => hspan F hF (le_trans h hFs)⟩, hcard⟩
 
 /-
 ## Part II: The Brown-Erdős-Sós Lower Bound (1973)
@@ -158,6 +177,11 @@ theorem erdos1076_beyond_bes (s : ℕ) (hs : s ≥ 3) :
 ## Part V: Known Partial Results
 -/
 
+/-- **Delcourt-Postle (2024):** The full 3-uniform BES conjecture.
+    For all s ≥ 3 and k ≥ s + 3: f^(3)(n; k, s) = o(n²). -/
+axiom delcourt_postle_theorem (s k : ℕ) (hs : s ≥ 3) (hk : k ≥ s + 3) :
+  IsLittleO (fun n => (extremalNumber 3 n k s : ℝ)) (fun n => (n : ℝ) ^ 2)
+
 /-- The BES conjecture for the (6,3)-case (Problem #716).
     Originally proved by Ruzsa-Szemerédi (1978) via the Triangle Removal Lemma.
     Now follows from the full 3-uniform result of Delcourt-Postle (2024). -/
@@ -171,10 +195,7 @@ theorem glock_bes_k4 :
     IsLittleO (fun n => (extremalNumber 3 n 7 4 : ℝ)) (fun n => (n : ℝ) ^ 2) :=
   delcourt_postle_theorem 4 7 (by omega) (by omega)
 
-/-- **Delcourt-Postle (2024):** The full 3-uniform BES conjecture.
-    For all s ≥ 3 and k ≥ s + 3: f^(3)(n; k, s) = o(n²). -/
-axiom delcourt_postle_theorem (s k : ℕ) (hs : s ≥ 3) (hk : k ≥ s + 3) :
-  IsLittleO (fun n => (extremalNumber 3 n k s : ℝ)) (fun n => (n : ℝ) ^ 2)
+-- (delcourt_postle_theorem moved above its first use — forward refs now error.)
 
 /-
 ## Part VI: Structural Properties of the BES Exponent
@@ -216,13 +237,19 @@ theorem besExponent_lt_two_at_bes_threshold (r s : ℕ) (hr : r ≥ 3) (hs : s �
   · push_cast
     have hr' : (3 : ℝ) ≤ (r : ℝ) := Nat.ofNat_le_cast.mpr hr
     have hs' : (3 : ℝ) ≤ (s : ℝ) := Nat.ofNat_le_cast.mpr hs
-    nlinarith [Nat.cast_sub (show 2 ≤ r by omega)]
+    have hsub : ((r - 2 : ℕ) : ℝ) = (r : ℝ) - 2 := by
+      have h2 := Nat.cast_sub (R := ℝ) (show 2 ≤ r by omega)
+      push_cast at h2
+      exact h2
+    rw [hsub]
+    nlinarith
   · have : (3 : ℝ) ≤ (s : ℝ) := Nat.ofNat_le_cast.mpr hs
     linarith
 
 /-- The zero function is little-o of any eventually positive function. -/
 theorem isLittleO_zero (g : ℕ → ℝ) : IsLittleO (fun _ => (0 : ℝ)) g := by
-  intro ε _; exact ⟨0, fun n _ => by simp⟩
+  intro ε hε
+  exact ⟨0, fun n _ => by simpa using mul_nonneg (le_of_lt hε) (abs_nonneg (g n))⟩
 
 /-- If f ≤ g pointwise eventually and g = o(h), then f = o(h). -/
 theorem isLittleO_of_eventually_le {f g h : ℕ → ℝ}
@@ -235,12 +262,13 @@ theorem isLittleO_of_eventually_le {f g h : ℕ → ℝ}
     have := hN₁ n (le_of_max_le_left hn)
     exact le_trans this (hN₂ n (le_of_max_le_right hn))⟩
 
-/-- BES conjecture is monotone in s: if it holds for s₁ edges,
-    it holds for s₂ ≥ s₁ edges (fewer forbidden configurations). -/
+/-- BES conjecture transfers DOWNWARD in s (statement repair #38611: the
+    original upward claim was false — extremalNumber is increasing in s, so
+    o(n²) for s₂ implies it for s₁ ≤ s₂, not conversely). -/
 theorem bes_monotone_in_s {k s₁ s₂ : ℕ} (hs : s₁ ≤ s₂)
-    (h : IsLittleO (fun n => (extremalNumber 3 n k s₁ : ℝ)) (fun n => (n : ℝ) ^ 2)) :
-    IsLittleO (fun n => (extremalNumber 3 n k s₂ : ℝ)) (fun n => (n : ℝ) ^ 2) := by
-  apply isLittleO_of_eventually_le
+    (h : IsLittleO (fun n => (extremalNumber 3 n k s₂ : ℝ)) (fun n => (n : ℝ) ^ 2)) :
+    IsLittleO (fun n => (extremalNumber 3 n k s₁ : ℝ)) (fun n => (n : ℝ) ^ 2) := by
+  apply isLittleO_of_eventually_le (g := fun n => (extremalNumber 3 n k s₂ : ℝ))
   · exact ⟨0, fun n _ => by
       rw [abs_of_nonneg (Nat.cast_nonneg _), abs_of_nonneg (Nat.cast_nonneg _)]
       exact Nat.cast_le.mpr (extremalNumber_mono_s 3 n k s₁ s₂ hs)⟩
@@ -295,14 +323,13 @@ theorem bes_monotone_in_k_general (t : ℕ) {s k₁ k₂ : ℕ} (hk : k₁ ≤ k
   rw [abs_of_nonneg h2]
   exact le_trans (le_trans h1 (le_abs_self _)) (hN n hn)
 
-/-- General monotonicity in s: if f^(t)(n; k, s₁) = o(n^t) and s₁ ≤ s₂,
-    then f^(t)(n; k, s₂) = o(n^t). Requiring more forbidden edges makes
-    violations harder to find, so the extremal number can only increase,
-    but the o(n^t) bound transfers via comparison. -/
+/-- General downward transfer in s (statement repair #38611: extremalNumber is
+    increasing in s — the valid-hypergraph family grows with s — so the o(n^t)
+    bound transfers from s₂ down to s₁ ≤ s₂). -/
 theorem bes_monotone_in_s_general (t : ℕ) {k s₁ s₂ : ℕ} (hs : s₁ ≤ s₂)
-    (h : IsLittleO (fun n => (extremalNumber t n k s₁ : ℝ)) (fun n => (n : ℝ) ^ t)) :
-    IsLittleO (fun n => (extremalNumber t n k s₂ : ℝ)) (fun n => (n : ℝ) ^ t) := by
-  apply isLittleO_of_eventually_le
+    (h : IsLittleO (fun n => (extremalNumber t n k s₂ : ℝ)) (fun n => (n : ℝ) ^ t)) :
+    IsLittleO (fun n => (extremalNumber t n k s₁ : ℝ)) (fun n => (n : ℝ) ^ t) := by
+  apply isLittleO_of_eventually_le (g := fun n => (extremalNumber t n k s₂ : ℝ))
   · exact ⟨0, fun n _ => by
       rw [abs_of_nonneg (Nat.cast_nonneg _), abs_of_nonneg (Nat.cast_nonneg _)]
       exact Nat.cast_le.mpr (extremalNumber_mono_s t n k s₁ s₂ hs)⟩

--- a/proofs/Proofs/Erdos1168Problem.lean
+++ b/proofs/Proofs/Erdos1168Problem.lean
@@ -43,7 +43,6 @@ noncomputable def aleph_omega_succ : Cardinal := Cardinal.aleph (Ordinal.omega0 
     This follows from aleph being order-preserving and ω+1 = succ ω. -/
 theorem aleph_omega_succ_eq : aleph_omega_succ = Cardinal.aleph (Order.succ Ordinal.omega0) := by
   unfold aleph_omega_succ
-  congr 1
   rw [Order.succ_eq_add_one]
 
 /-- ℵ_{ω+1} is a successor aleph, hence regular. -/
@@ -54,18 +53,18 @@ theorem aleph_omega_succ_regular : aleph_omega_succ.IsRegular := by
 /-- ℵ_ω is singular: cf(ℵ_ω) = ℵ₀. -/
 theorem aleph_omega_cof : (aleph_omega.ord.cof : Cardinal) = ℵ₀ := by
   unfold aleph_omega
-  rw [Cardinal.cof_aleph]
-  exact Ordinal.card_omega0
+  rw [Cardinal.ord_aleph, Ordinal.cof_omega Ordinal.isSuccLimit_omega0]
+  exact Ordinal.cof_omega0
 
 /-- ℵ_ω < ℵ_{ω+1}: the strict ordering. -/
 theorem aleph_omega_lt_succ : aleph_omega < aleph_omega_succ :=
-  Cardinal.aleph_lt_aleph.mpr (Ordinal.lt_add_of_pos_right _ Ordinal.one_pos)
+  Cardinal.aleph_lt_aleph.mpr (lt_add_of_pos_right _ zero_lt_one)
 
 /-- ℵ₀ < ℵ_ω: omega is strictly less than aleph_omega. -/
 theorem aleph0_lt_aleph_omega : ℵ₀ < aleph_omega := by
   unfold aleph_omega
-  rw [Cardinal.aleph_zero]
-  exact Cardinal.aleph_lt_aleph.mpr (Ordinal.pos_iff_ne_zero.mpr omega_ne_zero)
+  rw [← Cardinal.aleph_zero]
+  exact Cardinal.aleph_lt_aleph.mpr Ordinal.omega0_pos
 
 /-- ℵ_n < ℵ_ω for all n : ℕ. -/
 theorem aleph_n_lt_aleph_omega (n : ℕ) : Cardinal.aleph n < aleph_omega :=
@@ -109,7 +108,7 @@ noncomputable def targets : ℕ → Cardinal
     and each other color has no monochromatic triangle.
 
     The challenge is to prove this in ZFC without assuming GCH. -/
-def erdos_1168_conjecture : Prop := ¬ partitionRelation aleph_omega_succ targets
+def erdos_1168_conjecture : Prop := ¬ partitionRelation.{0} aleph_omega_succ targets
 
 /- ## Part IV: GCH Stepping-Up Framework
 
@@ -176,8 +175,8 @@ theorem stepping_up (hbase : ∀ n : ℕ,
     Replaces the previous opaque axiom with a structured decomposition. -/
 theorem erdos_1168_under_gch
     (hgch : ∀ κ : Cardinal.{0}, 2 ^ κ = Order.succ κ) :
-    ¬ partitionRelation aleph_omega_succ targets :=
-  stepping_up (fun n => base_case_under_gch n hgch)
+    ¬ partitionRelation.{0} aleph_omega_succ targets :=
+  stepping_up.{0, 0} (fun n => base_case_under_gch.{0} n hgch)
 
 /-- Under GCH, the open conjecture holds. -/
 theorem gch_implies_conjecture (hgch : ∀ κ : Cardinal.{0}, 2 ^ κ = Order.succ κ) :

--- a/proofs/Proofs/Erdos1172Problem.lean
+++ b/proofs/Proofs/Erdos1172Problem.lean
@@ -206,10 +206,8 @@ theorem q3_first_target_large : omega1 < omega1 ^ (omegaOrd + 2) + 2 := by
         apply Ordinal.opow_le_opow_right omega1_pos
         calc (1 : Ordinal) ≤ omegaOrd := le_of_lt (by unfold omegaOrd; exact Ordinal.one_lt_omega0)
           _ ≤ omegaOrd + 2 := le_self_add
-    _ < omega1 ^ (omegaOrd + 2) + 2 := by
-        apply Ordinal.lt_add_of_limit_left
-        · exact Ordinal.isLimit_iff_omega0_dvd.mpr ⟨by omega, ⟨omega1 ^ (omegaOrd + 1), by ring⟩⟩
-        · exact Ordinal.pos_iff_ne_zero.mp (by norm_num)
+    _ < omega1 ^ (omegaOrd + 2) + 2 :=
+        lt_add_of_pos_right _ (by norm_num : (0 : Ordinal) < 2)
 
 /-- ω₂ + ω₁ < ω₃ and ω₂ + ω < ω₃. -/
 theorem q2_targets_lt_omega3 :
@@ -220,7 +218,7 @@ theorem q2_targets_lt_omega3 :
     rw [show omega3 = (Cardinal.aleph 3).ord from rfl]
     rw [Cardinal.lt_ord]
     calc (omega2 + omega1).card
-        ≤ omega2.card + omega1.card := Ordinal.card_add_le_card_add_card omega2 omega1
+        ≤ omega2.card + omega1.card := (Ordinal.card_add omega2 omega1).le
       _ = Cardinal.aleph 2 + Cardinal.aleph 1 := by
           simp [omega2, omega1, Cardinal.card_ord]
       _ = Cardinal.aleph 2 := by
@@ -231,9 +229,9 @@ theorem q2_targets_lt_omega3 :
     rw [show omega3 = (Cardinal.aleph 3).ord from rfl]
     rw [Cardinal.lt_ord]
     calc (omega2 + omegaOrd).card
-        ≤ omega2.card + omegaOrd.card := Ordinal.card_add_le_card_add_card omega2 omegaOrd
+        ≤ omega2.card + omegaOrd.card := (Ordinal.card_add omega2 omegaOrd).le
       _ = Cardinal.aleph 2 + ℵ₀ := by
-          simp [omega2, omegaOrd, Cardinal.card_ord, Cardinal.card_omega0]
+          simp [omega2, omegaOrd, Cardinal.card_ord, Ordinal.card_omega0]
       _ = Cardinal.aleph 2 := by
           rw [Cardinal.add_eq_max (Cardinal.aleph0_le_aleph 2)]
           exact max_eq_left (Cardinal.aleph0_le_aleph 2)

--- a/proofs/Proofs/Erdos601Aristotle.lean
+++ b/proofs/Proofs/Erdos601Aristotle.lean
@@ -21,35 +21,35 @@ open Ordinal Cardinal
 theorem transfinite_induction (P : Ordinal → Prop)
     (h0 : P 0)
     (hS : ∀ α, P α → P (α + 1))
-    (hL : ∀ α, α.IsLimit → (∀ β < α, P β) → P α) :
+    (hL : ∀ α, Order.IsSuccLimit α → (∀ β < α, P β) → P α) :
     ∀ α, P α := by
   intro α
   induction α using Ordinal.induction with
   | h α ih =>
-    rcases Ordinal.zero_or_succ_or_limit α with rfl | ⟨β, rfl⟩ | hα
+    rcases Ordinal.zero_or_succ_or_isSuccLimit α with rfl | ⟨β, rfl⟩ | hα
     · exact h0
-    · exact hS β (ih β (Ordinal.lt_succ β))
+    · exact hS β (ih β (Order.lt_succ β))
     · exact hL α hα ih
 
 /-- The ordinal hierarchy: ω < ω₁. -/
-theorem omega_lt_omega1 : ω < Ordinal.omega1 :=
-  Ordinal.omega0_lt_omega1
+theorem omega_lt_omega1 : ω < ω₁ :=
+  Ordinal.omega0_lt_omega_one
 
-private theorem one_lt_omega1 : (1 : Ordinal) < Ordinal.omega1 :=
-  Ordinal.one_lt_omega.trans Ordinal.omega0_lt_omega1
+private theorem one_lt_omega1 : (1 : Ordinal) < ω₁ :=
+  Ordinal.one_lt_omega0.trans Ordinal.omega0_lt_omega_one
 
 /-- ω₁ < ω₁ ^ ω (ordinal exponentiation). -/
-theorem omega1_lt_omega1_pow_omega : Ordinal.omega1 < Ordinal.omega1 ^ ω := by
-  conv_lhs => rw [← Ordinal.opow_one Ordinal.omega1]
-  exact Ordinal.opow_lt_opow_right one_lt_omega1 Ordinal.one_lt_omega
+theorem omega1_lt_omega1_pow_omega : ω₁ < ω₁ ^ ω := by
+  conv_lhs => rw [← Ordinal.opow_one ω₁]
+  exact (Ordinal.opow_lt_opow_iff_right one_lt_omega1).mpr Ordinal.one_lt_omega0
 
 /-- ω₁ ^ ω < ω₁ ^ (ω + 1). -/
-theorem omega1_pow_omega_lt_succ : Ordinal.omega1 ^ ω < Ordinal.omega1 ^ (ω + 1) :=
-  Ordinal.opow_lt_opow_right one_lt_omega1 (Ordinal.lt_succ ω)
+theorem omega1_pow_omega_lt_succ : ω₁ ^ ω < ω₁ ^ (ω + 1) :=
+  (Ordinal.opow_lt_opow_iff_right one_lt_omega1).mpr (by simpa [Order.succ_eq_add_one] using Order.lt_succ ω)
 
 /-- ω₁ ^ (ω + 1) < ω₁ ^ (ω + 2). -/
-theorem omega1_pow_succ_lt : Ordinal.omega1 ^ (ω + 1) < Ordinal.omega1 ^ (ω + 2) :=
-  Ordinal.opow_lt_opow_right one_lt_omega1 (Ordinal.lt_succ (ω + 1))
+theorem omega1_pow_succ_lt : ω₁ ^ (ω + 1) < ω₁ ^ (ω + 2) :=
+  (Ordinal.opow_lt_opow_iff_right one_lt_omega1).mpr (by simpa [Order.succ_eq_add_one, add_assoc, one_add_one_eq_two] using Order.lt_succ (ω + 1))
 
 /-- A disjunction P ∨ Q is equivalent to (¬P → Q) when decidable. -/
 theorem or_iff_not_imp {P Q : Prop} : (P ∨ Q) ↔ (¬P → Q) :=
@@ -76,20 +76,20 @@ theorem ordinal_lt_ne {α β : Ordinal} (h : α < β) : α ≠ β :=
   ne_of_lt h
 
 /-- ω + 1 > ω (successor ordinal). -/
-theorem omega_lt_omega_succ : ω < ω + 1 :=
-  Ordinal.lt_succ ω
+theorem omega_lt_omega_succ : ω < ω + 1 := by
+  simpa [Order.succ_eq_add_one] using Order.lt_succ ω
 
 /-- ω + 2 = (ω + 1) + 1. -/
 theorem omega_add_two : ω + 2 = (ω + 1) + 1 := by
-  omega
+  rw [add_assoc, one_add_one_eq_two]
 
 /-- ω + 1 < ω + 2 (strict ordinal inequality). -/
-theorem omega_succ_lt_omega_add_two : ω + 1 < ω + 2 :=
-  Ordinal.lt_succ (ω + 1)
+theorem omega_succ_lt_omega_add_two : ω + 1 < ω + 2 := by
+  simpa [Order.succ_eq_add_one, add_assoc, one_add_one_eq_two] using Order.lt_succ (ω + 1)
 
 /-- If a property holds for all β < α and α is a limit ordinal,
     then the property is determined by its values below α. -/
-theorem limit_determined_by_below (α : Ordinal) (hα : α.IsLimit)
+theorem limit_determined_by_below (α : Ordinal) (hα : Order.IsSuccLimit α)
     (P : Ordinal → Prop) (h : ∀ β < α, P β) : ∀ β < α, P β :=
   h
 

--- a/proofs/Proofs/Erdos623Problem.lean
+++ b/proofs/Proofs/Erdos623Problem.lean
@@ -42,21 +42,16 @@ open Cardinal Set Ordinal
 noncomputable def aleph_omega : Cardinal := ℵ_ ω
 
 /-- ℵ_ω is a limit cardinal (supremum of smaller alephs). -/
-theorem aleph_omega_is_limit : aleph_omega.IsLimit := by
-  exact Cardinal.isLimit_aleph ω
+theorem aleph_omega_is_limit : Order.IsSuccLimit aleph_omega :=
+  Cardinal.isSingular_aleph_omega0.isSuccLimit
 
 /-- ℵ_ω is singular (its cofinality is ω, not itself). -/
-theorem aleph_omega_is_singular : ¬aleph_omega.IsRegular := by
-  intro h
-  have := h.cof_eq
-  simp [aleph_omega] at this
-  -- The cofinality of ℵ_ω is ω, not ℵ_ω
-  sorry
+theorem aleph_omega_is_singular : ¬aleph_omega.IsRegular := fun h =>
+  h.not_isSingular Cardinal.isSingular_aleph_omega0
 
 /-- ℵ_n < ℵ_ω for all finite n. -/
-theorem aleph_n_lt_omega (n : ℕ) : ℵ_ n < aleph_omega := by
-  simp [aleph_omega]
-  exact Cardinal.aleph_lt_aleph.mpr (Ordinal.nat_lt_omega0 n)
+theorem aleph_n_lt_omega (n : ℕ) : ℵ_ n < aleph_omega :=
+  Cardinal.aleph_lt_aleph.mpr (Ordinal.nat_lt_omega0 n)
 
 /- ## Part II: Free Functions -/
 
@@ -72,9 +67,8 @@ theorem exists_free_function (X : Type*) [Infinite X] [Nonempty X] :
   -- For any finite A, X \ A is nonempty (X is infinite)
   have key : ∀ A : Finset X, ∃ x : X, x ∉ A := by
     intro A
-    by_contra h
-    push_neg at h
-    exact absurd ⟨⟨A, h⟩⟩ (not_finite X)
+    obtain ⟨x, hx⟩ := (A.finite_toSet.infinite_compl).nonempty
+    exact ⟨x, by simpa using hx⟩
   exact ⟨fun A => (key A).choose, fun A => (key A).choose_spec⟩
 
 /- ## Part III: Independent Sets -/
@@ -161,9 +155,10 @@ def potentially_undecidable : Prop :=
   True  -- Placeholder - actual formalization would require metamathematics
 
 /-- The cofinality of ℵ_ω plays a key role. -/
-theorem cofinality_aleph_omega : aleph_omega.ord.cof = ω := by
-  simp [aleph_omega]
-  exact Cardinal.cof_aleph ω
+theorem cofinality_aleph_omega : aleph_omega.ord.cof = ℵ₀ := by
+  rw [show aleph_omega.ord = ω_ ω from Cardinal.ord_aleph ω,
+    Ordinal.cof_omega Ordinal.isSuccLimit_omega0]
+  exact Ordinal.cof_omega0
 
 /- ## Part VII: Related Concepts -/
 
@@ -189,7 +184,7 @@ theorem countable_case_no (X : Type*) (hX : #X = ℵ₀) :
     ∃ f : Finset X → X, IsFreeFunction f ∧
       ∀ Y : Set X, Y.Infinite → ¬IsIndependent f Y := by
   have hlt : #X < aleph_omega := by
-    rw [hX]
+    rw [hX, ← Cardinal.aleph_zero]
     exact aleph_n_lt_omega 0
   exact erdos_hajnal_below_aleph_omega X hlt
 

--- a/proofs/Proofs/Erdos629Aristotle.lean
+++ b/proofs/Proofs/Erdos629Aristotle.lean
@@ -66,9 +66,11 @@ lemma pow_factor (k : ℕ) : 2 ^ k + k * 2 ^ k = (k + 1) * 2 ^ k := by ring
 
 /-- (k+1) * 2^k ≤ k^2 * 2^(k+2) for k ≥ 2 -/
 lemma k_plus_one_pow_le (k : ℕ) (hk : k ≥ 2) : (k + 1) * 2 ^ k ≤ k ^ 2 * 2 ^ (k + 2) := by
-  have hpow : 0 < 2 ^ k := pow_pos (by norm_num) k
   have hk2 : 2 ^ (k + 2) = 4 * 2 ^ k := by ring
-  nlinarith [hk2, hpow, hk]
+  rw [hk2]
+  have h1 : k + 1 ≤ k ^ 2 * 4 := by nlinarith
+  calc (k + 1) * 2 ^ k ≤ (k ^ 2 * 4) * 2 ^ k := Nat.mul_le_mul_right _ h1
+    _ = k ^ 2 * (4 * 2 ^ k) := by ring
 
 /-
   ## Section 3: Csínf / sInf Monotonicity
@@ -76,7 +78,7 @@ lemma k_plus_one_pow_le (k : ℕ) (hk : k ≥ 2) : (k + 1) * 2 ^ k ≤ k ^ 2 * 2
 
 /-- sInf of a subset is at least sInf of superset (for naturals) -/
 lemma sInf_mono_subset (S T : Set ℕ) (h : T ⊆ S) (hS : S.Nonempty) :
-    Nat.sInf S ≤ Nat.sInf T := by
+    sInf S ≤ sInf T := by
   sorry
 
 /-- n(k) is monotone: n(k₁) ≤ n(k₂) for k₁ ≤ k₂ -/
@@ -104,7 +106,7 @@ lemma K11_card_adj : ∀ (u v : Fin 1 ⊕ Fin 1),
 
 /-- Sum.inl and Sum.inr are always different -/
 lemma inl_ne_inr {α β : Type*} (a : α) (b : β) : Sum.inl a ≠ (Sum.inr b : α ⊕ β) :=
-  fun h => Sum.noConfusion h
+  Sum.inl_ne_inr
 
 /-
   ## Section 5: List Chromatic Ceiling

--- a/proofs/Proofs/Erdos674Aristotle.lean
+++ b/proofs/Proofs/Erdos674Aristotle.lean
@@ -69,9 +69,11 @@ theorem swap_preserves_eq (x y z : ℕ) :
 theorem coprime_prime_div (x y p : ℕ) (hcop : x.gcd y = 1)
     (hp : p.Prime) (hdvd : p ∣ x) : ¬(p ∣ y) := by
   intro hdy
-  have := Nat.Prime.dvd_gcd hp hdvd hdy
+  have := Nat.dvd_gcd hdvd hdy
   rw [hcop] at this
-  exact Nat.Prime.one_lt hp |>.not_le (Nat.le_of_dvd (by omega) this)
+  have hle := Nat.le_of_dvd (by omega) this
+  have := hp.one_lt
+  omega
 
 /-- gcd(x, y) > 1 ↔ gcd(x, y) ≠ 1 for x, y > 1. -/
 theorem gcd_gt_one_iff (x y : ℕ) (hx : x > 1) (hy : y > 1) :
@@ -79,7 +81,10 @@ theorem gcd_gt_one_iff (x y : ℕ) (hx : x > 1) (hy : y > 1) :
   constructor
   · intro h; omega
   · intro h
-    have hpos : x.gcd y > 0 := Nat.pos_of_ne_zero (by intro h0; simp [h0] at h)
+    have hpos : x.gcd y > 0 := Nat.pos_of_ne_zero (by
+      intro h0
+      have := Nat.eq_zero_of_gcd_eq_zero_left h0
+      omega)
     omega
 
 -- ═══════════════════════════════════════════════════════════════════
@@ -101,6 +106,6 @@ theorem solution_z_gt_one (a b c : ℕ) (ha : a > 1) (hb : b > 1)
   push_neg at hc
   interval_cases c
   · simp at heq; have := mul_pos (Nat.pos_of_ne_zero (by positivity)) (Nat.pos_of_ne_zero (by positivity)); omega
-  · simp at heq; have h1 := Nat.one_lt_pow ha; have h2 := Nat.one_lt_pow hb; nlinarith
+  · simp at heq; have h1 := Nat.one_lt_pow (by omega : a ≠ 0) ha; have h2 := Nat.one_lt_pow (by omega : b ≠ 0) hb; omega
 
 end Erdos674Aristotle

--- a/proofs/Proofs/Erdos680Problem.lean
+++ b/proofs/Proofs/Erdos680Problem.lean
@@ -19,6 +19,8 @@ Reference: https://erdosproblems.com/680
 
 import Mathlib
 
+open Filter Topology
+
 /- ## Least Prime Factor and the Main Conjecture -/
 
 /-- Erdős Problem 680 (main): For all sufficiently large n, there exists
@@ -75,19 +77,33 @@ theorem quadratic_weaker_than_exponential (ε : ℝ) (hε : 0 < ε) :
       (k ^ 2 + 1 : ℝ) < Real.exp ((1 + ε) * Real.sqrt k) := by
   have hc : 0 < 1 + ε := by linarith
   -- x^4 * exp(-(1+ε)*x) → 0 as x → ∞
-  have h_tend := Real.tendsto_pow_mul_exp_neg_atTop_nhds 4 (1 + ε) hc
+  have h_tend : Tendsto (fun x : ℝ => x ^ 4 * Real.exp (-(1 + ε) * x)) atTop (𝓝 0) := by
+    have h0 := (Real.tendsto_pow_mul_exp_neg_atTop_nhds_zero 4).const_mul ((1 / (1 + ε)) ^ 4)
+    rw [mul_zero] at h0
+    have h1 := h0.comp (tendsto_id.const_mul_atTop hc)
+    refine h1.congr fun x => ?_
+    show (1 / (1 + ε)) ^ 4 * (((1 + ε) * x) ^ 4 * Real.exp (-((1 + ε) * x)))
+        = x ^ 4 * Real.exp (-(1 + ε) * x)
+    rw [neg_mul, ← mul_assoc, ← mul_pow, one_div, inv_mul_cancel_left₀ (ne_of_gt hc)]
   -- Compose with √· : ℕ → ℝ (which tends to atTop)
   have h_sqrt_atTop : Tendsto (fun k : ℕ => Real.sqrt (↑k)) atTop atTop :=
     (Real.tendsto_sqrt_atTop).comp tendsto_natCast_atTop_atTop
   have h_comp := h_tend.comp h_sqrt_atTop
   -- h_comp : (√k)^4 * exp(-(1+ε)*√k) → 0
   -- Eventually < 1/2
-  have h_ev : ∀ᶠ k in atTop, (Real.sqrt (↑k)) ^ 4 * Real.exp (-(1 + ε) * Real.sqrt (↑k)) < 1/2 :=
+  have h_ev : ∀ᶠ k : ℕ in atTop, (Real.sqrt (↑k)) ^ 4 * Real.exp (-(1 + ε) * Real.sqrt (↑k)) < 1/2 :=
     h_comp.eventually (Iio_mem_nhds (by norm_num : (0:ℝ) < 1/2))
   -- exp((1+ε)*√k) → ∞, so eventually > 2
-  have h_exp_large : ∀ᶠ k in atTop, 2 < Real.exp ((1 + ε) * Real.sqrt (↑k)) := by
+  have h_exp_large : ∀ᶠ k : ℕ in atTop, 2 < Real.exp ((1 + ε) * Real.sqrt (↑k)) := by
     have : Tendsto (fun k : ℕ => (1 + ε) * Real.sqrt (↑k)) atTop atTop :=
-      (tendsto_atTop_atTop_of_monotone (fun a b h => by nlinarith [Real.sqrt_le_sqrt (by exact_mod_cast h : (a:ℝ) ≤ b)]) ⟨0, fun b => ⟨⌈(b / (1 + ε))^2⌉₊, by nlinarith [Real.sq_sqrt (Nat.cast_nonneg ⌈(b / (1 + ε))^2⌉₊)]⟩⟩)
+      (tendsto_atTop_atTop_of_monotone (fun a b h => by nlinarith [Real.sqrt_le_sqrt (by exact_mod_cast h : (a:ℝ) ≤ b)]) (fun b => ⟨⌈(b / (1 + ε))^2⌉₊, by
+        have h2 : |b / (1 + ε)| ≤ Real.sqrt ↑⌈(b / (1 + ε))^2⌉₊ := by
+          rw [← Real.sqrt_sq_eq_abs]
+          exact Real.sqrt_le_sqrt (Nat.le_ceil _)
+        have h3 : b / (1 + ε) ≤ Real.sqrt ↑⌈(b / (1 + ε))^2⌉₊ := (le_abs_self _).trans h2
+        calc b = (1 + ε) * (b / (1 + ε)) := by field_simp
+          _ ≤ (1 + ε) * Real.sqrt ↑⌈(b / (1 + ε))^2⌉₊ :=
+              mul_le_mul_of_nonneg_left h3 (le_of_lt hc)⟩))
     exact (Real.tendsto_exp_atTop.comp this).eventually (Ioi_mem_atTop 2)
   -- Extract K₀ from both eventually conditions
   obtain ⟨K₀, hK₀⟩ := (h_ev.and h_exp_large).exists_forall_of_atTop
@@ -100,10 +116,9 @@ theorem quadratic_weaker_than_exponential (ε : ℝ) (hε : 0 < ε) :
   -- From h1: k² * exp(-c√k) < 1/2, so k² < (1/2) * exp(c√k)
   have hexp_pos : 0 < Real.exp ((1 + ε) * Real.sqrt ↑k) := Real.exp_pos _
   have hk2_bound : (↑k : ℝ) ^ 2 < (1/2) * Real.exp ((1 + ε) * Real.sqrt ↑k) := by
-    rw [← h_sq] at h1
     have : (Real.sqrt ↑k) ^ 4 < (1/2) * Real.exp ((1 + ε) * Real.sqrt ↑k) := by
       rw [show Real.exp (-(1 + ε) * Real.sqrt ↑k) = (Real.exp ((1 + ε) * Real.sqrt ↑k))⁻¹ from
-        by rw [Real.exp_neg]] at h1
+        by rw [neg_mul, Real.exp_neg]] at h1
       rwa [mul_inv_lt_iff₀ hexp_pos] at h1
     rwa [h_sq] at this
   -- From h2: exp(c√k) > 2, so 1 < (1/2) * exp(c√k)

--- a/proofs/Proofs/Erdos827Problem.lean
+++ b/proofs/Proofs/Erdos827Problem.lean
@@ -94,15 +94,7 @@ lemma nkProperty_nonempty (k : ℕ) (hk : 3 ≤ k) : {n : ℕ | NkProperty k n}.
 theorem minimalNk_valid (k : ℕ) (hk : 3 ≤ k) : NkProperty k (minimalNk k) :=
   Nat.sInf_mem (nkProperty_nonempty k hk)
 
-/-- minimalNk k is minimal: n_k - 1 fails the threshold property.
-
-    Proof: if minimalNk k - 1 were valid, sInf ≤ minimalNk k - 1,
-    contradicting sInf = minimalNk k. -/
-theorem minimalNk_sharp (k : ℕ) (hk : 3 ≤ k) : ¬ NkProperty k (minimalNk k - 1) := by
-  intro h
-  have hle : minimalNk k ≤ minimalNk k - 1 :=
-    Nat.sInf_le (show (minimalNk k - 1) ∈ {n : ℕ | NkProperty k n} from h)
-  omega
+-- (minimalNk_sharp moved below nk_ge_k — its omega now needs the k ≤ minimalNk k fact.)
 
 /- ## Main Problem -/
 
@@ -182,6 +174,17 @@ theorem nk_ge_k (k : ℕ) (hk : 3 ≤ k) : k ≤ minimalNk k := by
   rw [parabolaSet_card] at this
   omega
 
+/-- minimalNk k is minimal: n_k - 1 fails the threshold property.
+
+    Proof: if minimalNk k - 1 were valid, sInf ≤ minimalNk k - 1,
+    contradicting sInf = minimalNk k (which is ≥ k ≥ 3 > 0). -/
+theorem minimalNk_sharp (k : ℕ) (hk : 3 ≤ k) : ¬ NkProperty k (minimalNk k - 1) := by
+  intro h
+  have hle : minimalNk k ≤ minimalNk k - 1 :=
+    Nat.sInf_le (show (minimalNk k - 1) ∈ {n : ℕ | NkProperty k n} from h)
+  have hge := nk_ge_k k hk
+  omega
+
 /- ## Trivial Cases -/
 
 /-- AllDistinctCircumradii is vacuously true for 3-element sets:
@@ -225,6 +228,12 @@ theorem nk_three : minimalNk 3 = 3 := by
   obtain ⟨T, hTS, hTcard⟩ := Finset.exists_subset_card_eq hCard
   exact ⟨T, hTS, hTcard, allDistinctCircumradii_of_card_three hTcard⟩
 
+/-- AllDistinctCircumradii is hereditary: subsets inherit the property. -/
+theorem allDistinctCircumradii_subset {S T : Finset Point} (hTS : T ⊆ S)
+    (h : AllDistinctCircumradii S) : AllDistinctCircumradii T :=
+  fun p₁ hp₁ q₁ hq₁ r₁ hr₁ p₂ hp₂ q₂ hq₂ r₂ hr₂ =>
+    h p₁ (hTS hp₁) q₁ (hTS hq₁) r₁ (hTS hr₁) p₂ (hTS hp₂) q₂ (hTS hq₂) r₂ (hTS hr₂)
+
 /- ## Monotonicity -/
 
 /-- n_k is monotone non-decreasing.
@@ -238,7 +247,7 @@ theorem nk_monotone (k₁ k₂ : ℕ) (h : k₁ ≤ k₂) (hk : 3 ≤ k₁) :
   intro S hGP hCard
   have hk2 : 3 ≤ k₂ := le_trans hk h
   obtain ⟨T, hTS, hTcard, hTgood⟩ := minimalNk_valid k₂ hk2 S hGP hCard
-  obtain ⟨T', hT'T, hT'card⟩ := Finset.exists_subset_card_eq (by omega)
+  obtain ⟨T', hT'T, hT'card⟩ := Finset.exists_subset_card_eq (n := k₁) (s := T) (by omega)
   exact ⟨T', Finset.Subset.trans hT'T hTS, hT'card, allDistinctCircumradii_subset hT'T hTgood⟩
 
 /- ## Structural Properties -/
@@ -273,11 +282,7 @@ theorem generalPosition_subset {S T : Finset Point} (hTS : T ⊆ S)
     (hGP : GeneralPosition S) : GeneralPosition T :=
   fun p hp q hq r hr => hGP p (hTS hp) q (hTS hq) r (hTS hr)
 
-/-- AllDistinctCircumradii is hereditary: subsets inherit the property. -/
-theorem allDistinctCircumradii_subset {S T : Finset Point} (hTS : T ⊆ S)
-    (h : AllDistinctCircumradii S) : AllDistinctCircumradii T :=
-  fun p₁ hp₁ q₁ hq₁ r₁ hr₁ p₂ hp₂ q₂ hq₂ r₂ hr₂ =>
-    h p₁ (hTS hp₁) q₁ (hTS hq₁) r₁ (hTS hr₁) p₂ (hTS hp₂) q₂ (hTS hq₂) r₂ (hTS hr₂)
+-- (allDistinctCircumradii_subset moved above nk_monotone — forward refs now error.)
 
 /-- NkExists is proved for all k ≥ 3 using the axioms. -/
 theorem nkExists_of_axioms (k : ℕ) (hk : 3 ≤ k) : NkExists k :=

--- a/proofs/Proofs/Erdos875Problem.lean
+++ b/proofs/Proofs/Erdos875Problem.lean
@@ -115,7 +115,7 @@ private lemma pow2_subset_sum_inj : ∀ (N : ℕ) (S T : Finset ℕ),
           (2 : ℕ) ^ i = 2 ^ j → i = j := by
         intro i _ j _ h
         by_contra hne
-        rcases Ne.lt_or_lt hne with hlt | hlt
+        rcases lt_or_gt_of_ne hne with hlt | hlt
         · exact absurd h (Nat.pow_lt_pow_right (by omega) hlt).ne
         · exact absurd h (Nat.pow_lt_pow_right (by omega) hlt).ne'
       rw [Finset.sum_image h_inj]
@@ -125,8 +125,10 @@ private lemma pow2_subset_sum_inj : ∀ (N : ℕ) (S T : Finset ℕ),
       have hS' := to_smaller_erase hS hnS
       have hT' := to_smaller_erase hT hnT
       have heq' : (S.erase (2 ^ n)).sum id = (T.erase (2 ^ n)).sum id := by
-        have := Finset.add_sum_erase S id hnS
-        have := Finset.add_sum_erase T id hnT
+        have h1 : 2 ^ n + (S.erase (2 ^ n)).sum id = S.sum id :=
+          Finset.add_sum_erase S id hnS
+        have h2 : 2 ^ n + (T.erase (2 ^ n)).sum id = T.sum id :=
+          Finset.add_sum_erase T id hnT
         omega
       rw [← Finset.insert_erase hnS, ← Finset.insert_erase hnT, ih _ _ hS' hT' heq']
     · -- S has 2^n, T doesn't: T.sum ≤ 2^n - 1 < 2^n ≤ S.sum, contradiction
@@ -138,7 +140,8 @@ private lemma pow2_subset_sum_inj : ∀ (N : ℕ) (S T : Finset ℕ),
                 (fun _ _ _ => Nat.zero_le _)
           _ = 2 ^ n - 1 := sum_bound
       have h2 : 2 ^ n ≤ S.sum id :=
-        Finset.single_le_sum (fun _ _ => Nat.zero_le _) hnS
+        Finset.single_le_sum (f := id) (fun _ _ => Nat.zero_le _) hnS
+      have hp : 0 < 2 ^ n := Nat.two_pow_pos n
       omega
     · -- T has 2^n, S doesn't: symmetric
       exfalso
@@ -149,7 +152,8 @@ private lemma pow2_subset_sum_inj : ∀ (N : ℕ) (S T : Finset ℕ),
                 (fun _ _ _ => Nat.zero_le _)
           _ = 2 ^ n - 1 := sum_bound
       have h2 : 2 ^ n ≤ T.sum id :=
-        Finset.single_le_sum (fun _ _ => Nat.zero_le _) hnT
+        Finset.single_le_sum (f := id) (fun _ _ => Nat.zero_le _) hnT
+      have hp : 0 < 2 ^ n := Nat.two_pow_pos n
       omega
     · -- Neither has 2^n: both ⊆ (range n).image, apply IH
       exact ih S T (to_smaller hS hnS) (to_smaller hT hnT) heq

--- a/proofs/Proofs/Erdos936Problem.lean
+++ b/proofs/Proofs/Erdos936Problem.lean
@@ -62,16 +62,15 @@ def Powerful (n : ℕ) : Prop :=
 
 /-- 1 is powerful (vacuously true). -/
 theorem one_powerful : Powerful 1 := by
-  intro p _ hp_div
-  have : p ∣ 1 := hp_div
-  interval_cases p <;> simp_all
+  intro p hp hp_div
+  exact absurd (Nat.dvd_one.mp hp_div) hp.ne_one
 
 /-- Perfect squares are powerful. -/
 theorem sq_powerful (n : ℕ) : Powerful (n^2) := by
   intro p hp hp_div
   have : p ∣ n^2 := hp_div
   have hp_div_n : p ∣ n := hp.dvd_of_dvd_pow this
-  exact Nat.pow_dvd_pow_of_dvd hp_div_n 2
+  exact pow_dvd_pow_of_dvd hp_div_n 2
 
 /-- 4 is powerful. -/
 theorem four_powerful : Powerful 4 := sq_powerful 2
@@ -90,10 +89,9 @@ theorem prime_not_powerful (p : ℕ) (hp : p.Prime) : ¬Powerful p := by
   intro h
   have h_self := h p hp (dvd_refl p)
   have : p^2 ∣ p := h_self
-  have : p^2 ≤ p := Nat.le_of_dvd hp.pos this
-  have : p * p ≤ p := this
+  have h2 : p^2 ≤ p := Nat.le_of_dvd hp.pos this
   have hp_ge : p ≥ 2 := hp.two_le
-  omega
+  nlinarith
 
 /-- 2 is not powerful. -/
 theorem two_not_powerful : ¬Powerful 2 := prime_not_powerful 2 Nat.prime_two

--- a/proofs/Proofs/Erdos963Problem.lean
+++ b/proofs/Proofs/Erdos963Problem.lean
@@ -84,33 +84,7 @@ private lemma gt_add_pow3_of_lt_log (n j : ℕ) (hn : n ≥ 1) (hj : j < Nat.log
   have h2 : 3 ^ Nat.log 3 n ≤ n := Nat.pow_log_le_self 3 hne
   exact lt_of_lt_of_le (add_pow3_lt_pow3_succ j) (le_trans h1 h2)
 
-/-- **PROVED** (was axiom): **Erdős's greedy bound**: f(n) ≥ ⌊log₃ n⌋.
-    The greedy algorithm produces a dissociated subset of this size:
-    at each step, a new element can be added unless all remaining elements
-    are sums or differences of existing subset sums, which limits
-    exclusions to at most 3^k − 1 values after choosing k elements. -/
-theorem greedy_lower_bound :
-    ∀ n : ℕ, n ≥ 1 → maxDissociatedSize n ≥ Nat.log 3 n := by
-  intro n hn
-  -- We show every n-element set has a dissociated subset of size ≥ log₃ n
-  -- This means log₃ n is in the set whose sSup is maxDissociatedSize n
-  unfold maxDissociatedSize
-  apply le_csSup
-  · -- BddAbove: bounded by n
-    refine ⟨n, fun k (hk : ∀ A : Finset ℝ, A.card = n →
-        ∃ B, IsDissociatedSubset A B ∧ B.card ≥ k) => ?_⟩
-    have ⟨A, hA⟩ : ∃ A : Finset ℝ, A.card = n :=
-      ⟨(Finset.range n).image ((↑) : ℕ → ℝ), by
-        rw [Finset.card_image_of_injOn]
-        · exact Finset.card_range n
-        · intro a _ b _ hab; exact_mod_cast hab⟩
-    obtain ⟨B, ⟨hBsub, _⟩, hBcard⟩ := hk A hA
-    exact le_trans hBcard (le_trans (Finset.card_le_card hBsub) (le_of_eq hA))
-  · -- Nat.log 3 n ∈ the set: for any A with |A| = n, greedy_dissociated gives a
-    -- dissociated subset of size = log₃ n ≥ log₃ n
-    intro A hA
-    exact greedy_dissociated A (Nat.log 3 n)
-      (fun j hj => by rw [hA]; exact gt_add_pow3_of_lt_log n j hn hj)
+-- (greedy_lower_bound moved below greedy_dissociated — forward refs now error.)
 
 /- ## Upper Bound (proved below in `trivial_upper_bound`, after structural lemmas) -/
 
@@ -243,8 +217,8 @@ theorem dissociated_insert {A B : Finset ℝ} {a : ℝ}
   by_cases haS : a ∈ S <;> by_cases haT : a ∈ T
   · -- Both contain a: erase a from both, reduce to original property
     have heq : (S.erase a).sum id = (T.erase a).sum id := by
-      have := Finset.sum_erase_add S id haS
-      have := Finset.sum_erase_add T id haT
+      have h1 : (S.erase a).sum id + a = S.sum id := Finset.sum_erase_add S id haS
+      have h2 : (T.erase a).sum id + a = T.sum id := Finset.sum_erase_add T id haT
       linarith
     have := hB.2 _ _ (erase_sub S hS) (erase_sub T hT) heq
     calc S = insert a (S.erase a) := (Finset.insert_erase haS).symm
@@ -253,12 +227,14 @@ theorem dissociated_insert {A B : Finset ℝ} {a : ℝ}
   · -- a ∈ S, a ∉ T: contradicts hforbid
     exfalso
     exact absurd (show a = T.sum id - (S.erase a).sum id by
-      have := Finset.sum_erase_add S id haS; linarith)
+      have h1 : (S.erase a).sum id + a = S.sum id := Finset.sum_erase_add S id haS
+      linarith)
       (hforbid _ _ (erase_sub S hS) (not_mem_sub T hT haT))
   · -- a ∉ S, a ∈ T: symmetric contradiction
     exfalso
     exact absurd (show a = S.sum id - (T.erase a).sum id by
-      have := Finset.sum_erase_add T id haT; linarith)
+      have h1 : (T.erase a).sum id + a = T.sum id := Finset.sum_erase_add T id haT
+      linarith)
       (hforbid _ _ (erase_sub T hT) (not_mem_sub S hS haS))
   · -- Neither contains a: both subsets of B
     exact hB.2 S T (not_mem_sub S hS haS) (not_mem_sub T hT haT) hsum
@@ -303,10 +279,12 @@ theorem dissociated_extend {A B : Finset ℝ}
     it equals (T\S).sum - (S\T).sum since the intersection cancels. -/
 private lemma sum_factor_disjoint {S T : Finset ℝ} :
     T.sum id - S.sum id = (T \ S).sum id - (S \ T).sum id := by
-  have hS := (Finset.sum_sdiff_add_sum_inter S T id).symm
-  have hT := (Finset.sum_sdiff_add_sum_inter T S id).symm
-  have : (S ∩ T).sum id = (T ∩ S).sum id := by
-    congr 1; exact Finset.inter_comm S T
+  have hS : (S ∩ T).sum id + (S \ T).sum id = S.sum id :=
+    Finset.sum_inter_add_sum_sdiff S T id
+  have hT : (T ∩ S).sum id + (T \ S).sum id = T.sum id :=
+    Finset.sum_inter_add_sum_sdiff T S id
+  have hcomm : (S ∩ T).sum id = (T ∩ S).sum id := by
+    rw [Finset.inter_comm]
   linarith
 
 /-- The number of ordered disjoint pairs (S, T) with S, T ⊆ B is 3^|B|.
@@ -404,7 +382,7 @@ private lemma disjoint_pairs_card (B : Finset ℝ) :
       obtain ⟨⟨S₂, T₂⟩, _, heq₂⟩ := Finset.mem_image.mp h₂
       simp only [f₁, id, f₂, Prod.mk.injEq] at heq₁ heq₂
       have := (not_mem_of_P hST₁).1
-      rw [← heq₁.1, ← heq₂.1] at this
+      rw [heq₁.1, ← heq₂.1] at this
       exact this (Finset.mem_insert_self a S₂)
     have hdisj₁₃ : Disjoint I₁ I₃ := by
       rw [Finset.disjoint_left]; intro ⟨S, T⟩ h₁ h₃
@@ -412,18 +390,17 @@ private lemma disjoint_pairs_card (B : Finset ℝ) :
       obtain ⟨⟨S₃, T₃⟩, _, heq₃⟩ := Finset.mem_image.mp h₃
       simp only [f₁, id, f₃, Prod.mk.injEq] at heq₁ heq₃
       have := (not_mem_of_P hST₁).2
-      rw [← heq₁.2, ← heq₃.2] at this
+      rw [heq₁.2, ← heq₃.2] at this
       exact this (Finset.mem_insert_self a T₃)
     have hdisj₂₃ : Disjoint I₂ I₃ := by
       rw [Finset.disjoint_left]; intro ⟨S, T⟩ h₂ h₃
       obtain ⟨⟨S₂, T₂⟩, hST₂, heq₂⟩ := Finset.mem_image.mp h₂
       obtain ⟨⟨S₃, T₃⟩, hST₃, heq₃⟩ := Finset.mem_image.mp h₃
       simp only [f₂, f₃, Prod.mk.injEq] at heq₂ heq₃
-      -- a ∈ S (from f₂), but Disjoint S T, and a ∈ T (from f₃) — contradiction
-      rw [mem_P] at h₂
-      have haS : a ∈ S := heq₂.1 ▸ Finset.mem_insert_self a S₂
-      have haT : a ∈ T := heq₃.2 ▸ Finset.mem_insert_self a T₃
-      exact Finset.disjoint_left.mp h₂.2.2 haS haT
+      -- a ∉ T₂ = T (from P s), but T = insert a T₃ (from f₃) — contradiction
+      have hnotT : a ∉ T₂ := (not_mem_of_P hST₂).2
+      rw [heq₂.2, ← heq₃.2] at hnotT
+      exact hnotT (Finset.mem_insert_self a T₃)
     -- P (insert a s) ⊆ I₁ ∪ I₂ ∪ I₃ (covering)
     have hcover : P (insert a s) ⊆ I₁ ∪ I₂ ∪ I₃ := by
       intro ⟨S, T⟩ hST
@@ -437,8 +414,8 @@ private lemma disjoint_pairs_card (B : Finset ℝ) :
         have hT' : T ⊆ s := fun x hx =>
           (Finset.mem_insert.mp (hST.2.1 hx)).elim (fun h => absurd (h ▸ hx) haT) id
         have hdisj' : Disjoint (S.erase a) T := Finset.disjoint_of_subset_left
-          Finset.erase_subset hST.2.2
-        have hpre : (S.erase a, T) ∈ P s := mem_P.mpr ⟨hS', hT', hdisj'⟩
+          (Finset.erase_subset _ _) hST.2.2
+        have hpre : (S.erase a, T) ∈ P s := (mem_P _ _).mpr ⟨hS', hT', hdisj'⟩
         apply Finset.mem_union_left
         apply Finset.mem_union_right
         rw [Finset.mem_image]
@@ -451,8 +428,8 @@ private lemma disjoint_pairs_card (B : Finset ℝ) :
             intro x hx; have ⟨hne, hxT⟩ := Finset.mem_erase.mp hx
             exact (Finset.mem_insert.mp (hST.2.1 hxT)).elim (fun h => absurd h hne) id
           have hdisj' : Disjoint S (T.erase a) := Finset.disjoint_of_subset_right
-            Finset.erase_subset hST.2.2
-          have hpre : (S, T.erase a) ∈ P s := mem_P.mpr ⟨hS', hT', hdisj'⟩
+            (Finset.erase_subset _ _) hST.2.2
+          have hpre : (S, T.erase a) ∈ P s := (mem_P _ _).mpr ⟨hS', hT', hdisj'⟩
           apply Finset.mem_union_right
           rw [Finset.mem_image]
           exact ⟨(S, T.erase a), hpre, by simp [f₃, Finset.insert_erase haT]⟩
@@ -461,7 +438,7 @@ private lemma disjoint_pairs_card (B : Finset ℝ) :
             (Finset.mem_insert.mp (hST.1 hx)).elim (fun h => absurd (h ▸ hx) haS) id
           have hT' : T ⊆ s := fun x hx =>
             (Finset.mem_insert.mp (hST.2.1 hx)).elim (fun h => absurd (h ▸ hx) haT) id
-          have hpre : (S, T) ∈ P s := mem_P.mpr ⟨hS', hT', hST.2.2⟩
+          have hpre : (S, T) ∈ P s := (mem_P _ _).mpr ⟨hS', hT', hST.2.2⟩
           apply Finset.mem_union_left; apply Finset.mem_union_left
           exact Finset.mem_image.mpr ⟨(S, T), hpre, rfl⟩
     -- Now compute the cardinality
@@ -474,8 +451,11 @@ private lemma disjoint_pairs_card (B : Finset ℝ) :
         rcases Finset.mem_union.mp hx with h₁ | h₂
         · exact Finset.disjoint_left.mp hdisj₁₃ h₁ hx₃
         · exact Finset.disjoint_left.mp hdisj₂₃ h₂ hx₃
+    show (P (insert a s)).card = 3 * 3 ^ s.card
     rw [heq, Finset.card_union_of_disjoint hdisj_outer,
         Finset.card_union_of_disjoint hdisj₁₂, hcard₁, hcard₂, hcard₃]
+    have hP : (P s).card = 3 ^ s.card := ih
+    rw [hP]
     ring
 
 theorem diffSumFinset_card_le (B : Finset ℝ) :
@@ -500,8 +480,8 @@ theorem diffSumFinset_card_le (B : Finset ℝ) :
     Finset.mem_filter.mpr ⟨Finset.mem_product.mpr
       ⟨Finset.mem_powerset.mpr (Finset.sdiff_subset.trans hS),
        Finset.mem_powerset.mpr (Finset.sdiff_subset.trans hT)⟩,
-      Finset.disjoint_sdiff_sdiff⟩,
-    sum_factor_disjoint⟩
+      disjoint_sdiff_sdiff⟩,
+    sum_factor_disjoint.symm⟩
 
 /- ## Greedy Construction -/
 
@@ -517,9 +497,11 @@ theorem greedy_dissociated (A : Finset ℝ) (k : ℕ)
     -- By IH, get a dissociated B of size k
     obtain ⟨B, hB, hBcard⟩ := ih (fun j hj => hk j (Nat.lt_succ_of_lt hj))
     -- We need (diffSumFinset B).card < (A \ B).card to extend
-    have hAB : (A \ B).card = A.card - B.card := Finset.card_sdiff hB.1
+    have hAB : (A \ B).card = A.card - B.card := by
+      rw [Finset.card_sdiff, Finset.inter_eq_left.mpr hB.1]
     have h3k : (diffSumFinset B).card < (A \ B).card := by
       have hbound := diffSumFinset_card_le B
+      rw [hBcard] at hbound
       rw [hAB, hBcard]
       have := hk k (Nat.lt_succ_iff.mpr le_rfl)
       omega
@@ -527,6 +509,36 @@ theorem greedy_dissociated (A : Finset ℝ) (k : ℕ)
     obtain ⟨a, haAB, hins⟩ := dissociated_extend hB h3k
     exact ⟨insert a B, hins,
       by rw [Finset.card_insert_of_notMem (Finset.mem_sdiff.mp haAB).2, hBcard]⟩
+
+/-- **PROVED** (was axiom): **Erdős's greedy bound**: f(n) ≥ ⌊log₃ n⌋.
+    The greedy algorithm produces a dissociated subset of this size:
+    at each step, a new element can be added unless all remaining elements
+    are sums or differences of existing subset sums, which limits
+    exclusions to at most 3^k − 1 values after choosing k elements. -/
+theorem greedy_lower_bound :
+    ∀ n : ℕ, n ≥ 1 → maxDissociatedSize n ≥ Nat.log 3 n := by
+  intro n hn
+  -- We show every n-element set has a dissociated subset of size ≥ log₃ n
+  -- This means log₃ n is in the set whose sSup is maxDissociatedSize n
+  unfold maxDissociatedSize
+  apply le_csSup
+  · -- BddAbove: bounded by n
+    refine ⟨n, fun k (hk : ∀ A : Finset ℝ, A.card = n →
+        ∃ B, IsDissociatedSubset A B ∧ B.card ≥ k) => ?_⟩
+    have ⟨A, hA⟩ : ∃ A : Finset ℝ, A.card = n :=
+      ⟨(Finset.range n).image ((↑) : ℕ → ℝ), by
+        rw [Finset.card_image_of_injOn]
+        · exact Finset.card_range n
+        · intro a _ b _ hab; exact_mod_cast hab⟩
+    obtain ⟨B, ⟨hBsub, _⟩, hBcard⟩ := hk A hA
+    exact le_trans hBcard (le_trans (Finset.card_le_card hBsub) (le_of_eq hA))
+  · -- Nat.log 3 n ∈ the set: for any A with |A| = n, greedy_dissociated gives a
+    -- dissociated subset of size = log₃ n ≥ log₃ n
+    intro A hA
+    obtain ⟨B, hB, hBcard⟩ := greedy_dissociated A (Nat.log 3 n)
+      (fun j hj => by rw [hA]; exact gt_add_pow3_of_lt_log n j hn hj)
+    exact ⟨B, hB, ge_of_eq hBcard⟩
+
 
 /-- Auxiliary: ∑_{i<k} 2^i = 2^k - 1 (geometric series for ℕ). -/
 private lemma sum_range_pow_two (k : ℕ) :
@@ -579,7 +591,7 @@ private lemma binary_uniqueness_nat :
         have := Finset.sum_erase_add T (fun i => (2 : ℕ) ^ i) hnT
         omega
       have := ih (S.erase n) (T.erase n) hS' hT' hsum'
-      exact Finset.erase_injOn_of_mem hnS hnT this
+      rw [← Finset.insert_erase hnS, ← Finset.insert_erase hnT, this]
     · -- n ∈ S, n ∉ T: contradiction (S sum ≥ 2^n, T sum < 2^n)
       exfalso
       have hT' : T ⊆ Finset.range n := by
@@ -661,7 +673,7 @@ theorem maxDissociatedSize_mono :
         ∃ B, IsDissociatedSubset A B ∧ B.card ≥ k)
     intro A (hA : A.card = n)
     -- A has n ≥ m elements; extract an m-element subset A'
-    obtain ⟨A', hA'sub, hA'card⟩ := Finset.exists_smaller_set A m (hA ▸ hmn)
+    obtain ⟨A', hA'sub, hA'card⟩ := Finset.exists_subset_card_eq (show m ≤ A.card from hA ▸ hmn)
     -- A' has a dissociated subset B of size ≥ k
     obtain ⟨B, ⟨hBsub, hBdiss⟩, hBcard⟩ := hk A' hA'card
     -- B ⊆ A' ⊆ A, and dissociatedness depends only on B

--- a/proofs/Proofs/Erdos969Problem.lean
+++ b/proofs/Proofs/Erdos969Problem.lean
@@ -46,17 +46,26 @@ def isSquarefree (n : ℕ) : Prop := Squarefree n
 
 /-- Examples of squarefree numbers -/
 example : Squarefree 1 := squarefree_one
-example : Squarefree 2 := Nat.Prime.squarefree (Nat.prime_two)
-example : Squarefree 3 := Nat.Prime.squarefree (Nat.prime_three)
-example : Squarefree 6 := by decide
-example : Squarefree 10 := by decide
-example : Squarefree 30 := by decide
+example : Squarefree 2 := Nat.prime_two.prime.squarefree
+example : Squarefree 3 := Nat.prime_three.prime.squarefree
+example : Squarefree 6 := by
+  rw [show (6:ℕ) = 2 * 3 from rfl, Nat.squarefree_mul_iff]
+  exact ⟨by norm_num, Nat.prime_two.prime.squarefree, Nat.prime_three.prime.squarefree⟩
+example : Squarefree 10 := by
+  rw [show (10:ℕ) = 2 * 5 from rfl, Nat.squarefree_mul_iff]
+  exact ⟨by norm_num, Nat.prime_two.prime.squarefree, (by norm_num : Nat.Prime 5).prime.squarefree⟩
+example : Squarefree 30 := by
+  rw [show (30:ℕ) = 2 * (3 * 5) from rfl, Nat.squarefree_mul_iff, Nat.squarefree_mul_iff]
+  refine ⟨by norm_num, Nat.prime_two.prime.squarefree, by norm_num,
+    Nat.prime_three.prime.squarefree, (by norm_num : Nat.Prime 5).prime.squarefree⟩
 
 /-- 4 is not squarefree (divisible by 2²) -/
-example : ¬Squarefree 4 := by decide
+example : ¬Squarefree 4 := fun h => by
+  simpa [Nat.isUnit_iff] using h 2 (by norm_num)
 
 /-- 12 is not squarefree (divisible by 2²) -/
-example : ¬Squarefree 12 := by decide
+example : ¬Squarefree 12 := fun h => by
+  simpa [Nat.isUnit_iff] using h 2 (by norm_num)
 
 /-
 ## Part 2: The Squarefree Counting Function Q(x)
@@ -97,13 +106,14 @@ theorem density_eq_zeta_inverse : squarefreeDensity = 1 / (Real.pi^2 / 6) := by
 /-- Approximate value of the density -/
 theorem density_approx : 0.607 < squarefreeDensity ∧ squarefreeDensity < 0.609 := by
   unfold squarefreeDensity
+  have hpi : 3.1415 < Real.pi := Real.pi_gt_d4
+  have hpi2 : Real.pi < 3.1416 := Real.pi_lt_d4
+  have hpos : (0:ℝ) < Real.pi ^ 2 := by positivity
   constructor
-  · have hpi : 3.14 < Real.pi := Real.pi_gt_d2
-    have hpi2 : Real.pi < 3.15 := Real.pi_lt_d2
-    nlinarith [sq_nonneg Real.pi, sq_nonneg 3.14, sq_nonneg 3.15]
-  · have hpi : 3.14 < Real.pi := Real.pi_gt_d2
-    have hpi2 : Real.pi < 3.15 := Real.pi_lt_d2
-    nlinarith [sq_nonneg Real.pi, sq_nonneg 3.14, sq_nonneg 3.15]
+  · rw [lt_div_iff₀ hpos]
+    nlinarith [Real.pi_pos]
+  · rw [div_lt_iff₀ hpos]
+    nlinarith [Real.pi_pos]
 
 /-
 ## Part 4: The Error Term E(x)
@@ -179,7 +189,7 @@ The squarefree counting is related to the Möbius function μ(n):
 def μ : ℕ → ℤ := ArithmeticFunction.moebius
 
 /-- μ(1) = 1 -/
-theorem mu_one : μ 1 = 1 := by rfl
+theorem mu_one : μ 1 = 1 := by simp [μ]
 
 /-- μ(p) = -1 for prime p -/
 theorem mu_prime (p : ℕ) (hp : Nat.Prime p) : μ p = -1 := by
@@ -195,8 +205,8 @@ Better zero-free regions give better error bounds.
 
 /-- The classical zero-free region: σ > 1 - c/log(t) for some c > 0 -/
 theorem classical_zero_free_region :
-  ∃ c : ℝ, c > 0 ∧ ∀ s : ℂ, s.re > 1 - c / Real.log s.im.abs →
-    s.im.abs > 2 → True :=  -- ζ(s) ≠ 0
+  ∃ c : ℝ, c > 0 ∧ ∀ s : ℂ, s.re > 1 - c / Real.log |s.im| →
+    |s.im| > 2 → True :=  -- ζ(s) ≠ 0
   ⟨1, by norm_num, fun _ _ _ => trivial⟩
 
 /-  Wider zero-free regions would improve E(x) bounds -/

--- a/proofs/Proofs/TestHLTension.lean
+++ b/proofs/Proofs/TestHLTension.lean
@@ -37,27 +37,22 @@ theorem count_primes_in_range (S : Finset ℕ) (a b : ℕ) (hab : a ≤ b + 1)
     rw [Nat.count_eq_card_filter_range, Nat.count_eq_card_filter_range]
     have hsub : S ⊆ (Finset.range (b + 1)).filter Nat.Prime \ (Finset.range a).filter Nat.Prime := by
       intro s hs
+      have hs' := hS s hs
       rw [Finset.mem_sdiff, Finset.mem_filter, Finset.mem_range,
           Finset.mem_filter, Finset.mem_range]
-      exact ⟨⟨by omega, hprime s hs⟩, fun ⟨hlt, _⟩ => by have := (hS s hs).1; omega⟩
+      exact ⟨⟨by omega, hprime s hs⟩, fun ⟨hlt, _⟩ => by omega⟩
+    have hsubset : (Finset.range a).filter Nat.Prime ⊆
+                  (Finset.range (b + 1)).filter Nat.Prime := by
+      intro i hi
+      rw [Finset.mem_filter, Finset.mem_range] at hi ⊢
+      exact ⟨by omega, hi.2⟩
     calc S.card ≤ ((Finset.range (b + 1)).filter Nat.Prime \
                    (Finset.range a).filter Nat.Prime).card := Finset.card_le_card hsub
       _ = ((Finset.range (b + 1)).filter Nat.Prime).card -
-          ((Finset.range a).filter Nat.Prime ∩
-           (Finset.range (b + 1)).filter Nat.Prime).card := by
-            rw [Finset.card_sdiff_eq_card_sub_card_inter]
-      _ ≤ ((Finset.range (b + 1)).filter Nat.Prime).card -
           ((Finset.range a).filter Nat.Prime).card := by
-            have hsubset : (Finset.range a).filter Nat.Prime ⊆
-                          (Finset.range (b + 1)).filter Nat.Prime := by
-              intro i hi
-              rw [Finset.mem_filter, Finset.mem_range] at hi ⊢
-              exact ⟨by omega, hi.2⟩
-            have hinter : (Finset.range a).filter Nat.Prime ∩
-                          (Finset.range (b + 1)).filter Nat.Prime =
-                          (Finset.range a).filter Nat.Prime :=
-              Finset.inter_eq_left.mpr hsubset
-            rw [hinter]
+            rw [Finset.card_sdiff, Finset.inter_eq_left.mpr hsubset]
+  have hmono : Nat.count Nat.Prime a ≤ Nat.count Nat.Prime (b + 1) :=
+    Nat.count_monotone Nat.Prime (by omega)
   omega
 
 /-- Corrected version: π(d+1) ≥ k (not π(d) ≥ k).
@@ -83,13 +78,13 @@ theorem hl_conjectures_tension_corrected (hHL1 : HardyLittlewoodConjecture)
   rw [heq] at hhl2
   -- The primes {n+h : h ∈ H} are all in [n, n+d]
   -- Build the Finset of these primes
-  have hprimes_range : ∀ h ∈ H, n ≤ n + h ∧ n + h ≤ n + d := by
+  have hprimes_range : ∀ h ∈ H, n ≤ h + n ∧ h + n ≤ n + d := by
     intro h hh
-    exact ⟨by omega, by have := hle h hh; omega⟩
+    have := hle h hh
+    omega
   -- The map h ↦ n+h is injective on H
-  have hinj : (H.image (· + n)).card = H.card := by
-    rw [Finset.card_image_of_injective]
-    intro a b hab; omega
+  have hinj : (H.image (· + n)).card = H.card :=
+    Finset.card_image_of_injective H (fun a b hab => by omega)
   -- count(n+d+1) ≥ count(n) + |H|
   have hcount : Nat.count Nat.Prime (n + d + 1) ≥ Nat.count Nat.Prime n + H.card := by
     rw [← hinj]
@@ -111,9 +106,10 @@ theorem hl_conjectures_tension_corrected (hHL1 : HardyLittlewoodConjecture)
   -- So count(d+2) ≥ |H|
   -- primeCounting(d+1) = count(d+2) ≥ |H|
   unfold Nat.primeCounting Nat.primeCounting'
+  have hn' : n - 1 + 1 = n := by omega
+  rw [hn'] at hhl2
   have hpc : Nat.count Nat.Prime (n + d + 1) ≤
-      Nat.count Nat.Prime n + Nat.count Nat.Prime (d + 2) := by
-    convert hhl2 using 2 <;> omega
+      Nat.count Nat.Prime n + Nat.count Nat.Prime (d + 1 + 1) := hhl2
   omega
 
 end TestHLTension

--- a/proofs/batch2/STATUS.md
+++ b/proofs/batch2/STATUS.md
@@ -1,3 +1,131 @@
+# DOCTOR INCREMENT 57 (deep-rework partition B: N–Z + Erdos ≥ 600, #38065, 2026-07-14)
+
+Container `dr57` (cpus 0-5, 11g, cache v431), worktree issue-38065, branch
+`feature/issue-38065-inc57` off origin/feature/issue-37508. Partition B pool =
+286 RESIDUAL rows. Worked cheapest-first: unknown-const singletons, then the
+ordinal/aleph API cluster, then the **in-file forward-reference** seam (highest
+yield this increment — v4.31 rejects references to axioms/lemmas declared later
+in the same file; 5 files flipped on reorder + drift cleanup).
+**+18 GREEN this increment** (all in-container `lake build Proofs.X` exit-0
+before each ledger flip; pushed after every file). PR #38660.
+
+## Flips (failure class in parens)
+- Erdos680Problem (unknown-const): tendsto_pow_mul_exp_neg_atTop_nhds coefficient
+  form removed -> bridge via _nhds_zero + const_mul_atTop; root `Tendsto`/`𝓝`
+  aliases gone -> open Filter Topology; ∀ᶠ-binder needs : ℕ annotation;
+  tendsto_atTop_atTop_of_monotone arg-2 is now ∀ b, ∃ a.
+- Erdos875Problem (unknown-const): Ne.lt_or_lt -> lt_or_gt_of_ne; typed
+  Finset.add_sum_erase haves (∑-notation vs .sum atom split breaks omega);
+  single_le_sum (f := id); omega no longer knows 0 < 2^n -> Nat.two_pow_pos.
+- Erdos936Problem (unknown-const): Nat.pow_dvd_pow_of_dvd -> root
+  pow_dvd_pow_of_dvd; interval_cases can't bound p from p ∣ 1 -> Nat.dvd_one;
+  p^2/p*p defeq have rejected -> nlinarith.
+- Erdos1050ProblemAristotle (unknown-const): summable_of_summable_norm ->
+  Summable.of_norm; summable_geometric_of_lt_one ratio side-goal now eager ->
+  pin (r := ...); Nat.lt_of_lt_pred signature changed -> show+omega.
+- Erdos969Problem (unknown-const): Nat.Prime.squarefree -> hp.prime.squarefree;
+  decide on Squarefree stuck on WF minSqFac -> Nat.squarefree_mul_iff decomposition
+  (6/10/30) + direct witness for ¬4/¬12; Float literal nlinarith hints -> (:ℝ);
+  density_approx pi_gt_d2/lt_d2 mathematically insufficient -> d4 + lt_div_iff₀;
+  Real.abs removed -> |s.im|.
+- Erdos674Aristotle (unknown-const): Nat.Prime.dvd_gcd -> Nat.dvd_gcd; .not_le
+  projection gone -> omega; Nat.one_lt_pow takes n ≠ 0 first; simp [h0] at h
+  closes h to True -> eq_zero_of_gcd_eq_zero_left.
+- Erdos601Aristotle (unknown-const): ordinal API sweep — IsLimit -> Order.IsSuccLimit,
+  zero_or_succ_or_limit -> zero_or_succ_or_isSuccLimit, Ordinal.omega1 -> ω₁ (ω_ 1),
+  omega0_lt_omega1 -> omega0_lt_omega_one, one_lt_omega -> one_lt_omega0,
+  opow_lt_opow_right -> (opow_lt_opow_iff_right h).mpr, Ordinal.lt_succ ->
+  Order.lt_succ + succ_eq_add_one simpa bridges.
+- Erdos623Problem + Erdos623ProblemAristotle free-flip (unknown-const):
+  Cardinal.IsLimit removed -> IsSuccLimit via isSingular_aleph_omega0.isSuccLimit;
+  Cardinal.cof_aleph removed -> ord_aleph + Ordinal.cof_omega isSuccLimit_omega0 +
+  cof_omega0; ℵ_ 0 vs ℵ₀ rw needs ← aleph_zero; SORRY ELIMINATED in
+  aleph_omega_is_singular (h.not_isSingular isSingular_aleph_omega0).
+- Erdos1172Problem (unknown-const): lt_add_of_limit_left -> generic
+  lt_add_of_pos_right; card_add_le_card_add_card -> (Ordinal.card_add _ _).le;
+  Cardinal.card_omega0 -> Ordinal.card_omega0.
+- Erdos1168Problem (unknown-const): cof_aleph route as above; universe metavars
+  in Prop defs -> partitionRelation.{0} / stepping_up.{0,0} pins; congr 1 now
+  self-closes succ-vs-+1.
+- Erdos629Aristotle (unknown-const): Nat.sInf -> root sInf; Sum.noConfusion
+  signature -> Sum.inl_ne_inr; nlinarith 2^(k+2) atom split -> rw + linear calc.
+- TestHLTension (unknown-const): **Finset.card_sdiff is now the UNCONDITIONAL
+  #(s\t) = #s - #(t ∩ s)** (subset-hypothesis form gone) -> rw + inter_eq_left;
+  omega ∀-hyp materialization; Nat.count_monotone fact; convert-on-count-atoms
+  stall -> rw n-1+1=n at hhl2.
+- Erdos1065Problem (unknown-const): FORWARD-REF reorder (erdos_1065b after
+  conjecture_a_implies_b); Nat.pow_le_pow_right takes 0 < x (was 1 ≤/1 <), 10
+  sites; nlinarith 2^k*3^l*q triple products -> Nat.mul_le_mul chains + norm_num;
+  interval_cases 'have : q = _ := by omega' placeholder no longer synthesized.
+- Erdos827Problem (unknown-const): forward-ref reorders (allDistinctCircumradii_subset,
+  minimalNk_sharp needs nk_ge_k); exists_subset_card_eq metavar -> pin (n :=) (s :=).
+- Erdos1157Problem (unknown-const): see statement repairs below + forward-ref
+  axiom move + isLittleO_of_eventually_le (g :=) pin + Nat.cast_sub (R := ℝ).
+- Erdos1134Problem (unknown-const): axiom forward-ref move; Set-membership filter
+  needs open Classical in (docstring AFTER the open line); List.not_mem_nil now
+  takes the membership proof; wrong obtain on axiom -> Classical.choose_spec.
+- Erdos963Problem (unknown-const): forward-ref move (greedy_lower_bound below
+  greedy_dissociated); sum_erase_add/sum_inter_add_sum_sdiff typed haves;
+  Prod.mk.injEq orientation flip in rw; projection-reduction loss ->
+  sum_factor_disjoint.symm; erase_subset explicit args; card_sdiff unconditional
+  form; disjoint_sdiff_sdiff root; erase_injOn_of_mem -> insert_erase rw;
+  exists_smaller_set -> exists_subset_card_eq; let-bound P defeq bridges.
+
+## Statement repairs (#38611)
+| file | declaration | repair |
+|---|---|---|
+| Erdos1157Problem | `achievable_nonempty` | was FALSE at s = 0 (empty edge-family F has card ≥ 0, forcing 0 > k, so NO hypergraph is (k,0)-valid). Added `1 ≤ s`; added `achievableEdgeCounts_eq_empty_of_s_zero` and s = 0 case splits in `extremalNumber_mono_k/_s` so their (true) statements are unchanged. |
+| Erdos1157Problem | `bes_monotone_in_s`, `bes_monotone_in_s_general` | claimed UPWARD transfer of o(n^t) in s — false: extremalNumber is increasing in s (valid family grows), e.g. k=6, s₂ > C(6,3) gives extremal = C(n,3) ≠ o(n²). Repaired to the true DOWNWARD transfer (holds for s₂ ⇒ holds for s₁ ≤ s₂), which is what the comparison proof establishes. No other callers. |
+| Erdos623Problem | `cofinality_aleph_omega` | RHS `ω` (Ordinal) never type-checks against `Ordinal.cof : Cardinal` on v4.31 — restated as `= ℵ₀` (identical intended content). |
+
+## New systematic seams worth cataloging (rename-map §7aa candidates)
+1. **In-file forward references now hard-error** (was: worked for axioms/some
+   decls). Highest-yield seam in partition B: grep `Unknown identifier` where
+   the name IS declared later in the same file; fix = pure reorder. (5 files.)
+2. **Finset.card_sdiff changed to unconditional form** `#(s \ t) = #s - #(t ∩ s)`
+   — the `t ⊆ s` hypothesis form is gone; `card_sdiff_eq_card_sub_card_inter`
+   also gone (it IS the new card_sdiff). Fix: `rw [Finset.card_sdiff,
+   Finset.inter_eq_left.mpr hsub]`.
+3. **omega atom hygiene regressions**: (a) `have := Finset.add_sum_erase …`
+   anonymous haves now yield ∑-notation atoms that don't match `.sum id` goals —
+   use TYPED haves in .sum form; (b) omega no longer derives `0 < 2^n` /
+   `0 < minimalNk` for opaque atoms — materialize positivity facts; (c) omega
+   never instantiates ∀-hypotheses — `have := h x hx` first.
+4. **nlinarith lost multi-factor product reasoning** (2^k * 3^l * q ≥ c):
+   replace with explicit `Nat.mul_le_mul` chains + `rw [heq]` + norm_num.
+5. **Prod.mk.injEq / anonymous-constructor orientation flips**: simp now yields
+   `S₁ = S` (component = target) where v4.26 gave the reverse — `rw [← h.1]`
+   sites need the arrow dropped/added; Prod projections `(a,b).2` no longer
+   reduce during unification (supply `.symm`/`show`).
+6. **Metavar pinning wave** (continuation of §7s): `summable_geometric_of_lt_one`
+   ratio, `exists_subset_card_eq` n/s, `isLittleO_of_eventually_le` g,
+   `Nat.cast_sub` target ring — all need explicit (x := …) pins now.
+
+## Flagged deep (triaged, NOT flipped, one-line diagnosis)
+- YangMillsMassGap: 51 errors across 22k-line Proofs/YangMills/Exploration.lean
+  (exp_lt_exp_of_lt sweep + ~15 varied tactic-drift sites + 1 parse) — budget.
+- Erdos1171Problem: ω₁/ω_ OrderEmbedding coercion drift + universe metavars in
+  ordinalPartitionRelMulti Prop defs + ℕ-literal successor mismatches (12+ err).
+- Erdos1166Problem: biUnion singleton/union rewrite drift + calc-step self-eq
+  goals + AlmostSurely combination linarith (10 err).
+- Erdos635Problem: forward-refs (f_set_nonempty/bddAbove) are easy BUT tail has
+  Tendsto have-elaboration restructuring (Tendsto.const_mul term becomes Type-
+  level mismatch) + Finset.card_Icc removal + f N 1 rw-into-metavar (12+ err).
+- Erdos1162Problem: native_decide × noncomputable SetLike.instFintype (Sylow-
+  catalog class) + Equiv.Perm.subsingleton removal — axiom-status-adjacent.
+- Erdos1116Problem: 8+ diverse (noncomputable compile failures on exp/DivInvMonoid
+  defs + stuck instances + root Tendsto loss).
+- Erdos1096Problem (intermediate_value_zero_of_neg_of_pos removal + Polynomial
+  parse drift), Erdos896Problem (product_singleton_right/eq_of_mul_eq_left
+  removals + le_sup unify), WolstenholmeTheoremOQ02OQ02 (Equiv.mulLeft_apply +
+  factorial_mul_choose removals + ZMod rewrites), Erdos700Problem
+  (Prime.multiplicity_choose + interval_cases upper-bound loss + rw drift),
+  Erdos1059OQ04 (unfold-local-let regression + Function-expected cascade),
+  Erdos693/749/961/980/940/857 — 5-7 mixed errors each, second-pass targets.
+
+Ledger after increment 57: 1948 GREEN / 687 RESIDUAL.
+
+
 # Batch 2/3/4/5 + Doctor verification state (updated Doctor increment 34, #38065, 2026-07-14)
 
 # DOCTOR INCREMENT 34 (type-mismatch + proof-drift + rewrite-drift + unknown-const-mixed + instance-synth, A–M partition, #38065, 2026-07-14)

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -1453,7 +1453,7 @@ Erdos599Problem	GREEN
 Erdos59Problem	RESIDUAL	unknown-const:Set.mem_union.mp
 Erdos5Problem	GREEN	
 Erdos600Problem	GREEN	
-Erdos601Aristotle	RESIDUAL	unknown-const:Ordinal.zero_or_succ_or_limit
+Erdos601Aristotle	GREEN	
 Erdos601Problem	RESIDUAL	instance-synth
 Erdos603Problem	GREEN	
 Erdos604Problem	GREEN	parse-error

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -1490,8 +1490,8 @@ Erdos621Problem	GREEN
 Erdos622OQ04	RESIDUAL	instance-synth
 Erdos622Problem	RESIDUAL	instance-synth
 Erdos623Aristotle	GREEN	
-Erdos623Problem	RESIDUAL	unknown-const:Cardinal.isLimit_aleph
-Erdos623ProblemAristotle	RESIDUAL	unknown-const:Cardinal.isLimit_aleph
+Erdos623Problem	GREEN	
+Erdos623ProblemAristotle	GREEN	
 Erdos625Aristotle	RESIDUAL	instance-synth
 Erdos625Problem	RESIDUAL	instance-synth
 Erdos625ProblemAristotle	RESIDUAL	instance-synth

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -1577,7 +1577,7 @@ Erdos679Aristotle	RESIDUAL	type-mismatch
 Erdos679Problem	GREEN	
 Erdos679ProblemAristotle	RESIDUAL	proof-drift
 Erdos67Problem	GREEN	
-Erdos680Problem	RESIDUAL	unknown-const:Real.tendsto_pow_mul_exp_neg_atTop_nhds
+Erdos680Problem	GREEN	
 Erdos681Problem	GREEN	
 Erdos682Problem	RESIDUAL	type-mismatch
 Erdos683Problem	GREEN	

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -1504,7 +1504,7 @@ Erdos627ProblemAristotle	GREEN
 Erdos628Aristotle	GREEN	
 Erdos628Problem	GREEN	
 Erdos628ProblemAristotle	GREEN	
-Erdos629Aristotle	RESIDUAL	unknown-const:Nat.sInf
+Erdos629Aristotle	GREEN	
 Erdos629Problem	RESIDUAL	type-mismatch
 Erdos630Aristotle	GREEN	
 Erdos630Problem	GREEN	

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -874,7 +874,7 @@ Erdos1162Problem	RESIDUAL	unknown-const:Nat.card_pos_of_nonempty
 Erdos1165Problem	GREEN	
 Erdos1166Problem	RESIDUAL	unknown-const:Finset.filter_eq_empty
 Erdos1167Problem	RESIDUAL	parse-error
-Erdos1168Problem	RESIDUAL	unknown-const:Cardinal.cof_aleph
+Erdos1168Problem	GREEN	
 Erdos1169Problem	RESIDUAL	proof-drift
 Erdos116Problem	GREEN	
 Erdos1170Problem	GREEN	

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -1905,7 +1905,7 @@ Erdos965Problem	GREEN
 Erdos966Problem	GREEN	
 Erdos967Problem	GREEN	proof-drift
 Erdos968Problem	RESIDUAL	noncomputable
-Erdos969Problem	RESIDUAL	unknown-const:Nat.Prime.squarefree
+Erdos969Problem	GREEN	
 Erdos96Problem	GREEN	
 Erdos970Problem	GREEN	
 Erdos971Problem	GREEN	

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -2598,7 +2598,7 @@ TestConvexHull	GREEN
 TestCovByApi	GREEN	
 TestDerangConvApi	GREEN	
 TestErdos43Api	GREEN	
-TestHLTension	RESIDUAL	unknown-const:Finset.card_sdiff_eq_card_sub_card_inter
+TestHLTension	GREEN	
 TestHolderApi	GREEN	
 TestSphereLocEuc	GREEN	
 TestWolstenholme	RESIDUAL	unknown-const:ZMod.prod_univ_prime

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -864,7 +864,7 @@ Erdos1155OQ01OQ07	GREEN
 Erdos1155OQ02	RESIDUAL	type-mismatch
 Erdos1155Problem	GREEN	
 Erdos1156Problem	GREEN	
-Erdos1157Problem	RESIDUAL	unknown-const:delcourt_postle_theorem
+Erdos1157Problem	GREEN	
 Erdos1158Problem	GREEN	
 Erdos1159Problem	RESIDUAL	signature-drift
 Erdos115OQ01Problem	GREEN	

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -879,7 +879,7 @@ Erdos1169Problem	RESIDUAL	proof-drift
 Erdos116Problem	GREEN	
 Erdos1170Problem	GREEN	
 Erdos1171Problem	RESIDUAL	unknown-const:Ordinal.mul_lt_mul_iff_left
-Erdos1172Problem	RESIDUAL	unknown-const:Ordinal.lt_add_of_limit_left
+Erdos1172Problem	GREEN	
 Erdos1173Problem	RESIDUAL	instance-synth
 Erdos1174Problem	GREEN	
 Erdos1175Problem	GREEN	

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -731,7 +731,7 @@ Erdos1049Problem	GREEN
 Erdos104Problem	RESIDUAL	unknown-const:zero_rpow
 Erdos1050Aristotle	GREEN	
 Erdos1050Problem	RESIDUAL	type-mismatch
-Erdos1050ProblemAristotle	RESIDUAL	unknown-const:summable_of_summable_norm
+Erdos1050ProblemAristotle	GREEN	
 Erdos1051Problem	RESIDUAL	type-mismatch
 Erdos1052Problem	RESIDUAL	rewrite-drift
 Erdos1053Problem	GREEN	

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -1740,7 +1740,7 @@ Erdos824Problem	GREEN
 Erdos824ProblemProvable	RESIDUAL	type-mismatch
 Erdos825Problem	GREEN	
 Erdos826Problem	GREEN	
-Erdos827Problem	RESIDUAL	unknown-const:allDistinctCircumradii_subset
+Erdos827Problem	GREEN	
 Erdos829Problem	GREEN	unknown-const:hardy_ramanujan_1729
 Erdos82Problem	GREEN	
 Erdos830Problem	GREEN	

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -1797,7 +1797,7 @@ Erdos872Problem	GREEN
 Erdos873Problem	GREEN	
 Erdos873ProblemProvable	GREEN	proof-drift
 Erdos874Problem	RESIDUAL	proof-drift
-Erdos875Problem	RESIDUAL	unknown-const:Ne.lt_or_lt
+Erdos875Problem	GREEN	
 Erdos876Problem	GREEN	
 Erdos876ProblemAristotle	GREEN	
 Erdos877ProblemAristotle	GREEN	

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -755,7 +755,7 @@ Erdos1061Problem	RESIDUAL	proof-drift
 Erdos1062OQ04	GREEN	
 Erdos1062Problem	GREEN	
 Erdos1065CunninghamChains	RESIDUAL	type-mismatch
-Erdos1065Problem	RESIDUAL	unknown-const:conjecture_a_implies_b
+Erdos1065Problem	GREEN	
 Erdos1066OQ04	GREEN	
 Erdos1066Problem	PRE-EXISTING	never-compiled:n
 Erdos1067Problem	RESIDUAL	partenat-removal

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -844,7 +844,7 @@ Erdos1131OQ01	RESIDUAL	rewrite-drift
 Erdos1131Problem	RESIDUAL	rewrite-drift
 Erdos1132Aristotle	GREEN	
 Erdos1132Problem	GREEN	
-Erdos1134Problem	RESIDUAL	unknown-const:crampin_hilton_tau_exists
+Erdos1134Problem	GREEN	
 Erdos1135Problem	GREEN	
 Erdos1136Problem	RESIDUAL	proof-drift
 Erdos1138Problem	GREEN	

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -1898,7 +1898,7 @@ Erdos95Problem	RESIDUAL	type-mismatch
 Erdos960Problem	GREEN	unknown-const:p
 Erdos961Problem	RESIDUAL	unknown-const:Nat.primFactors
 Erdos962Problem	GREEN	
-Erdos963Problem	RESIDUAL	unknown-const:greedy_dissociated
+Erdos963Problem	GREEN	
 Erdos964Aristotle	GREEN	unknown-const:Nat.divisors_prime
 Erdos964Problem	RESIDUAL	rewrite-drift
 Erdos965Problem	GREEN	

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -1871,7 +1871,7 @@ Erdos933ProblemAristotle	GREEN
 Erdos934Problem	GREEN	
 Erdos934ProblemAristotle	RESIDUAL	proof-drift
 Erdos935Problem	GREEN	
-Erdos936Problem	RESIDUAL	unknown-const:Nat.pow_dvd_pow_of_dvd
+Erdos936Problem	GREEN	
 Erdos937Problem	RESIDUAL	proof-drift
 Erdos939Problem	GREEN	
 Erdos940Problem	RESIDUAL	unknown-const:Finset.card_Ioc

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -1565,7 +1565,7 @@ Erdos671ProblemAristotle	GREEN
 Erdos672Problem	GREEN	
 Erdos673Aristotle	GREEN	type-mismatch
 Erdos673Problem	GREEN	
-Erdos674Aristotle	RESIDUAL	unknown-const:Nat.Prime.dvd_gcd
+Erdos674Aristotle	GREEN	
 Erdos674Problem	GREEN	
 Erdos674ProblemAristotle	GREEN	
 Erdos675Problem	GREEN	


### PR DESCRIPTION
Doctor increment 57 (#38065, epic #37508) — deep-rework tail grind, partition B (N–Z basenames + Erdos ≥ 600), pool 286 RESIDUAL rows.

Container dr57 (cpus 0-5, 11g, cache lean-mathlib-cache-v431), worktree issue-38065. **Every flip verified by in-container `lake build Proofs.X` exit-0 before its ledger row changed; committed+pushed per file.** Ledger: 1930 → 1948 GREEN.

## +18 GREEN
Erdos680Problem, Erdos875Problem, Erdos936Problem, Erdos1050ProblemAristotle, Erdos969Problem, Erdos674Aristotle, Erdos601Aristotle, Erdos623Problem, Erdos623ProblemAristotle (free-flip), Erdos1172Problem, Erdos1168Problem, Erdos629Aristotle, TestHLTension, Erdos1065Problem, Erdos827Problem, Erdos1157Problem, Erdos1134Problem, Erdos963Problem.

Full per-file recipes in the new STATUS.md increment-57 section.

## Statement repairs (#38611)
- **Erdos1157Problem `achievable_nonempty`**: FALSE at s = 0 (empty family forces 0 > k; no (k,0)-valid hypergraph exists) → added `1 ≤ s` + `achievableEdgeCounts_eq_empty_of_s_zero` + s = 0 case splits so the mono lemma statements stay unchanged.
- **Erdos1157Problem `bes_monotone_in_s(_general)`**: upward o(n^t) transfer in s is false (extremalNumber is increasing in s; k=6, s₂ > C(6,3) gives extremal = C(n,3)) → repaired to the true downward transfer. No other callers.
- **Erdos623Problem `cofinality_aleph_omega`**: RHS `ω` (Ordinal) can't type-check against `cof : Cardinal` → restated `= ℵ₀` (same content).

Bonus: eliminated a pre-existing `sorry` in Erdos623Problem `aleph_omega_is_singular`.

## New systematic seams (catalogued in STATUS.md)
1. **In-file forward references now hard-error** — 5 flips were pure reorders (+ drift cleanup): Erdos1065/827/1157/1134/963.
2. **`Finset.card_sdiff` is now unconditional** `#(s\t) = #s − #(t ∩ s)` (subset-hyp form gone).
3. omega atom-hygiene regressions (∑-notation vs .sum atoms, no 0 < 2^n derivation, no ∀-instantiation).
4. nlinarith lost multi-factor product bounding → explicit Nat.mul_le_mul chains.
5. Prod.mk.injEq orientation flip + projection-reduction loss in unification.
6. Metavar-pinning wave: summable_geometric ratio, exists_subset_card_eq, isLittleO helpers, Nat.cast_sub (R :=).

Part of #38065 / epic #37508.

🤖 Generated with [Claude Code](https://claude.com/claude-code)