### PR TITLE
migrate(v4.31): Doctor increment 59 — deep-rework partition B (+3 GREEN)

### DIFF
--- a/proofs/Proofs/Erdos1096Problem.lean
+++ b/proofs/Proofs/Erdos1096Problem.lean
@@ -104,22 +104,24 @@ def IsPisot (q : ℝ) : Prop :=
     the unique real root > 1 of x³ - x - 1 = 0.
     Existence: f(1) = -1 < 0, f(2) = 5 > 0, so by IVT there is a root in (1,2).
     Uniqueness: f is strictly increasing on (1,∞) since f'(x) = 3x² - 1 > 2 > 0. -/
+private lemma smallestPisot_exists : ∃ q : ℝ, 1 < q ∧ q < 2 ∧ q ^ 3 = q + 1 := by
+  -- By IVT: f(x) = x³ - x - 1 satisfies f(1) = -1 < 0 and f(2) = 5 > 0
+  have h_cont : Continuous (fun x : ℝ => x ^ 3 - x - 1) := by fun_prop
+  have hsub := intermediate_value_Ioo (show (1 : ℝ) ≤ 2 by norm_num) h_cont.continuousOn
+  have hmem : (0 : ℝ) ∈ Set.Ioo ((fun x : ℝ => x ^ 3 - x - 1) 1)
+      ((fun x : ℝ => x ^ 3 - x - 1) 2) := by
+    simp only [Set.mem_Ioo]
+    norm_num
+  obtain ⟨c, hc_mem, hc_eq⟩ := hsub hmem
+  simp only at hc_eq
+  exact ⟨c, hc_mem.1, hc_mem.2, by linarith⟩
+
 noncomputable def smallestPisot : ℝ :=
-  Classical.choose (show ∃ q : ℝ, 1 < q ∧ q < 2 ∧ q ^ 3 = q + 1 by
-    -- By IVT: f(x) = x³ - x - 1 satisfies f(1) = -1 < 0 and f(2) = 5 > 0
-    have h_cont : Continuous (fun x : ℝ => x ^ 3 - x - 1) := by fun_prop
-    have h_f1 : (1 : ℝ) ^ 3 - 1 - 1 = -1 := by norm_num
-    have h_f2 : (2 : ℝ) ^ 3 - 2 - 1 = 5 := by norm_num
-    obtain ⟨c, hc_mem, hc_eq⟩ := intermediate_value_zero_of_neg_of_pos
-      (show (1 : ℝ) ≤ 2 from by norm_num)
-      (h_cont.continuousOn)
-      (by linarith) (by linarith)
-    exact ⟨c, by linarith [hc_mem.1], by linarith [hc_mem.2],
-      by linarith [hc_eq]⟩)
+  Classical.choose smallestPisot_exists
 
 private lemma smallestPisot_spec :
     1 < smallestPisot ∧ smallestPisot < 2 ∧ smallestPisot ^ 3 = smallestPisot + 1 :=
-  Classical.choose_spec _
+  Classical.choose_spec smallestPisot_exists
 
 /-- The smallest Pisot number lies in (1.324, 1.325). -/
 theorem smallestPisot_value : 1.324 < smallestPisot ∧ smallestPisot < 1.325 := by
@@ -137,17 +139,19 @@ theorem smallestPisot_value : 1.324 < smallestPisot ∧ smallestPisot < 1.325 :=
     -- This expands to 1.324³ - 1.324 - q³ + q ≥ 0
     -- With q³ = q + 1: 1.324³ - 1.324 - 1 ≥ 0, but 1.324³ < 2.324
     have hmono : 0 ≤ (1.324 - smallestPisot) *
-        (1.324 ^ 2 + 1.324 * smallestPisot + smallestPisot ^ 2 - 1) :=
-      mul_nonneg (by linarith) (by nlinarith [sq_nonneg smallestPisot,
-        sq_nonneg (smallestPisot - 1)])
+        (1.324 ^ 2 + 1.324 * smallestPisot + smallestPisot ^ 2 - 1) := by
+      have hs1 := sq_nonneg smallestPisot
+      have hs2 := sq_nonneg (smallestPisot - 1)
+      exact mul_nonneg (by linarith) (by nlinarith)
     nlinarith [hcubic]
   · -- q < 1.325: same argument, f(1.325) > 1 but f(q) = 1
     by_contra h
     push_neg at h
     have hmono : 0 ≤ (smallestPisot - 1.325) *
-        (smallestPisot ^ 2 + 1.325 * smallestPisot + 1.325 ^ 2 - 1) :=
-      mul_nonneg (by linarith) (by nlinarith [sq_nonneg smallestPisot,
-        sq_nonneg (smallestPisot - 1)])
+        (smallestPisot ^ 2 + 1.325 * smallestPisot + 1.325 ^ 2 - 1) := by
+      have hs1 := sq_nonneg smallestPisot
+      have hs2 := sq_nonneg (smallestPisot - 1)
+      exact mul_nonneg (by linarith) (by nlinarith)
     nlinarith [hcubic]
 
 /-- The smallest Pisot number satisfies its defining polynomial. -/
@@ -165,8 +169,7 @@ theorem smallestPisot_is_pisot : IsPisot smallestPisot := by
     apply lt_of_le_of_lt (Polynomial.degree_add_le _ _)
     apply max_lt <;> simp [Polynomial.degree_X_pow, Polynomial.degree_X, Polynomial.degree_one]
   · -- smallestPisot is a root
-    simp only [Polynomial.aeval_sub, Polynomial.aeval_pow, Polynomial.aeval_X,
-      Polynomial.aeval_one, map_one]
+    simp only [map_sub, map_pow, Polynomial.aeval_X, Polynomial.aeval_one, map_one]
     linarith [hcubic]
   · -- Other complex roots have |z| < 1
     -- x³ - x - 1 = (x - q₀)(x² + q₀x + q₀² - 1)
@@ -211,12 +214,10 @@ theorem smallestPisot_is_pisot : IsPisot smallestPisot := by
       -- If z = conj(z), z is real. Then z² + q₀z + (q₀² - 1) = 0 has a real root.
       -- But discriminant = q₀² - 4(q₀² - 1) = 4 - 3q₀² < 0 (for q₀ > 1.324)
       have hz_real : z = algebraMap ℝ ℂ z.re := by
-        ext
-        · simp
-        · have : z.im = 0 := by
-            have := Complex.conj_eq_iff_im.mp heq
-            exact this
-          simp [this]
+        have him : z.im = 0 := Complex.conj_eq_iff_im.mp heq.symm
+        apply Complex.ext
+        · simp [Complex.coe_algebraMap]
+        · simp [Complex.coe_algebraMap, him]
       -- z.re satisfies z² + q₀·z + q₀² - 1 = 0
       rw [hz_real, hq_def] at hquad
       simp only [← map_pow, ← map_mul, ← map_add, ← map_sub, ← map_one] at hquad
@@ -232,8 +233,8 @@ theorem smallestPisot_is_pisot : IsPisot smallestPisot := by
     -- So z·conj(z) = q² - 1
     have hprod : z * starRingEnd ℂ z = q ^ 2 - 1 := by
       rcases mul_eq_zero.mp hkey with h | h
-      · exact absurd (sub_eq_zero.mp h).symm hz_ne_conj
-      · linear_combination -h
+      · exact absurd (sub_eq_zero.mp h) hz_ne_conj
+      · linear_combination h
     -- normSq z = q₀² - 1
     have hnorm : Complex.normSq z = smallestPisot ^ 2 - 1 := by
       have h : (Complex.normSq z : ℂ) = q ^ 2 - 1 := by
@@ -241,8 +242,10 @@ theorem smallestPisot_is_pisot : IsPisot smallestPisot := by
         exact hprod
       rw [hq_def] at h
       simp only [← map_pow, ← map_one (algebraMap ℝ ℂ), ← map_sub] at h
+      simp only [Complex.coe_algebraMap] at h
       exact_mod_cast h
     -- Complex.abs z < 1
+    show ‖z‖ < 1
     rw [Complex.norm_def, hnorm]
     have hpos : 0 ≤ smallestPisot ^ 2 - 1 := by nlinarith [hgt1]
     have hlt : smallestPisot ^ 2 - 1 < 1 := by nlinarith [hcubic, hgt1]
@@ -286,8 +289,7 @@ theorem goldenRatio_is_pisot : IsPisot goldenRatio := by
     apply lt_of_le_of_lt (Polynomial.degree_add_le _ _)
     apply max_lt <;> simp [Polynomial.degree_X_pow, Polynomial.degree_X, Polynomial.degree_one]
   · -- φ is a root: φ² - φ - 1 = 0
-    simp only [Polynomial.aeval_sub, Polynomial.aeval_pow, Polynomial.aeval_X,
-      Polynomial.aeval_one, map_one]
+    simp only [map_sub, map_pow, Polynomial.aeval_X, Polynomial.aeval_one, map_one]
     unfold goldenRatio
     have h5 : Real.sqrt 5 ^ 2 = 5 := Real.sq_sqrt (by norm_num : (5:ℝ) ≥ 0)
     nlinarith
@@ -296,7 +298,7 @@ theorem goldenRatio_is_pisot : IsPisot goldenRatio := by
     -- Factor: (z - φ)(z + φ - 1) = 0. Since z ≠ φ, z = 1 - φ.
     -- |1 - φ| = φ - 1 < 1 since φ < 2.
     intro z hz hne
-    set φ := algebraMap ℝ ℂ goldenRatio with hφ_def
+    set gr := algebraMap ℝ ℂ goldenRatio with hgr_def
     -- z is a root of X² - X - 1 over ℂ
     have hzroot : z ^ 2 - z - 1 = 0 := by
       have := hz
@@ -304,8 +306,8 @@ theorem goldenRatio_is_pisot : IsPisot goldenRatio := by
                   Polynomial.eval₂_pow, Polynomial.eval₂_X, Polynomial.eval₂_one,
                   Polynomial.eval₂_C, map_one] at this
       linear_combination this
-    -- φ satisfies φ² - φ - 1 = 0 (embed from ℝ to ℂ)
-    have hφroot : φ ^ 2 - φ - 1 = 0 := by
+    -- gr satisfies gr² - gr - 1 = 0 (embed from ℝ to ℂ)
+    have hgrroot : gr ^ 2 - gr - 1 = 0 := by
       have hreal : goldenRatio ^ 2 - goldenRatio - 1 = 0 := by
         unfold goldenRatio
         have h5 : Real.sqrt 5 ^ 2 = 5 := Real.sq_sqrt (by norm_num : (5 : ℝ) ≥ 0)
@@ -313,22 +315,24 @@ theorem goldenRatio_is_pisot : IsPisot goldenRatio := by
       have h := congr_arg (algebraMap ℝ ℂ) hreal
       simp only [map_sub, map_pow, map_one, map_zero] at h
       exact h
-    -- (z - φ)(z + φ - 1) = z² - z - (φ² - φ) = 0
-    have hfactor : (z - φ) * (z + φ - 1) = 0 := by linear_combination hzroot - hφroot
-    -- Since z ≠ φ, we get z = 1 - φ
-    have hz_val : z = 1 - φ := by
+    -- (z - gr)(z + gr - 1) = z² - z - (gr² - gr) = 0
+    have hfactor : (z - gr) * (z + gr - 1) = 0 := by linear_combination hzroot - hgrroot
+    -- Since z ≠ gr, we get z = 1 - gr
+    have hz_val : z = 1 - gr := by
       rcases mul_eq_zero.mp hfactor with h | h
       · exact absurd (sub_eq_zero.mp h) hne
-      · linear_combination -h
-    -- |z| = |1 - φ| = φ - 1 < 1
-    rw [hz_val, hφ_def]
+      · linear_combination h
+    -- |z| = |1 - gr| = gr - 1 < 1
+    rw [hz_val, hgr_def]
     rw [show (1 : ℂ) - algebraMap ℝ ℂ goldenRatio =
         algebraMap ℝ ℂ (1 - goldenRatio) from by push_cast; ring]
     -- Complex.abs of a real number = |·|
+    show ‖algebraMap ℝ ℂ (1 - goldenRatio)‖ < 1
     rw [Complex.norm_def]
     rw [show Complex.normSq (algebraMap ℝ ℂ (1 - goldenRatio)) =
         (1 - goldenRatio) ^ 2 from by
-      simp [Complex.normSq_apply, Complex.ofReal_re, Complex.ofReal_im]]
+      simp [Complex.normSq_apply, Complex.ofReal_re, Complex.ofReal_im]
+      ring]
     rw [Real.sqrt_sq_eq_abs, abs_of_neg (by linarith [goldenRatio_gt_one])]
     linarith [goldenRatio_lt_two]
 

--- a/proofs/Proofs/Erdos1166Problem.lean
+++ b/proofs/Proofs/Erdos1166Problem.lean
@@ -90,7 +90,7 @@ theorem maxVisitCount_is_max (ω : RandomWalk) (k : ℕ) (x : LatticePoint) :
   · exact Finset.le_sup hx
   · -- x not visited in first k+1 steps: visitCount = 0
     suffices visitCount ω k x = 0 by omega
-    unfold visitCount; rw [Finset.card_eq_zero, Finset.filter_eq_empty]
+    unfold visitCount; rw [Finset.card_eq_zero, Finset.filter_eq_empty_iff]
     intro n hn heq
     exact hx (Finset.mem_image.mpr ⟨n, hn, heq⟩)
 
@@ -126,7 +126,8 @@ theorem maxVisitCount_le_of_le (ω : RandomWalk) {a b : ℕ} (h : a ≤ b) :
   obtain ⟨d, rfl⟩ := Nat.exists_eq_add_of_le h
   induction d with
   | zero => exact le_rfl
-  | succ n ih => exact le_trans ih (maxVisitCount_mono_succ ω (a + n))
+  | succ n ih =>
+    exact le_trans (ih (Nat.le_add_right a n)) (maxVisitCount_mono_succ ω (a + n))
 
 -- ## Set of Most-Visited Points
 
@@ -175,15 +176,16 @@ theorem mostVisited_nesting_range (ω : RandomWalk) (a b : ℕ) (hab : a ≤ b)
     mostVisitedSet ω a ⊆ mostVisitedSet ω b := by
   obtain ⟨d, rfl⟩ := Nat.exists_eq_add_of_le hab
   induction d with
-  | zero => exact Subset.rfl
+  | zero => exact Finset.Subset.rfl
   | succ n ih =>
     have hTn : maxVisitCount ω a = maxVisitCount ω (a + n) := by
       apply le_antisymm (maxVisitCount_le_of_le ω (Nat.le_add_right a n))
       have := maxVisitCount_le_of_le ω (show a + n ≤ a + (n + 1) by omega)
       omega
-    exact Subset.trans (ih hTn) (mostVisited_nesting ω (a + n) (by
+    exact Finset.Subset.trans (ih (Nat.le_add_right a n) hTn) (mostVisited_nesting ω (a + n) (by
       apply le_antisymm (maxVisitCount_mono_succ ω (a + n))
-      have := maxVisitCount_le_of_le ω (show a ≤ a + n by omega)
+      have h1 := maxVisitCount_le_of_le ω (show a ≤ a + n by omega)
+      have hT' : maxVisitCount ω a = maxVisitCount ω (a + n + 1) := hT
       omega))
 
 -- ## Cumulative Most-Visited Points
@@ -205,7 +207,7 @@ theorem cumulativeMostVisited_subset (ω : RandomWalk) (n : ℕ)
     (x : LatticePoint) (hx : x ∈ cumulativeMostVisited ω n) :
     ∃ k : ℕ, k ≤ n ∧ x ∈ mostVisitedSet ω k := by
   obtain ⟨k, hk, hxk⟩ := Finset.mem_biUnion.mp hx
-  exact ⟨k, by omega, hxk⟩
+  exact ⟨k, Nat.lt_succ_iff.mp (Finset.mem_range.mp hk), hxk⟩
 
 /-- Monotonicity: the cumulative set grows with n. -/
 theorem cumulativeMostVisited_mono (ω : RandomWalk) (m n : ℕ) (h : m ≤ n) :
@@ -225,7 +227,7 @@ theorem biUnion_subset_last_of_constant_T (ω : RandomWalk) (a b : ℕ) (hab : a
   intro x hx
   obtain ⟨k, hk, hxk⟩ := Finset.mem_biUnion.mp hx
   have hak : a ≤ k := (Finset.mem_Ico.mp hk).1
-  have hkb : k ≤ b := by omega
+  have hkb : k ≤ b := Nat.lt_succ_iff.mp (Finset.mem_Ico.mp hk).2
   have hTk : maxVisitCount ω k = maxVisitCount ω b := by
     apply le_antisymm (maxVisitCount_le_of_le ω hkb)
     calc maxVisitCount ω b = maxVisitCount ω a := hT.symm
@@ -266,7 +268,7 @@ theorem cumulative_card_bound (ω : RandomWalk) (a b : ℕ) (hab : a ≤ b)
     subst hab'
     have hIco : Finset.Ico a (a + 1) = {a} := by
       ext k; simp only [Finset.mem_Ico, Finset.mem_singleton]; omega
-    rw [hIco, Finset.biUnion_singleton]
+    rw [hIco, Finset.singleton_biUnion]
     have := hcard a le_rfl le_rfl; omega
   | succ n ih =>
     intro a b hlen hab hcard
@@ -283,7 +285,7 @@ theorem cumulative_card_bound (ω : RandomWalk) (a b : ℕ) (hab : a ≤ b)
         lt_of_le_of_ne (maxVisitCount_le_of_le ω hab) hT
       have hIco : Finset.Ico a (b + 1) = {a} ∪ Finset.Ico (a + 1) (b + 1) := by
         ext k; simp only [Finset.mem_Ico, Finset.mem_union, Finset.mem_singleton]; omega
-      rw [hIco, Finset.biUnion_union, Finset.biUnion_singleton]
+      rw [hIco, Finset.union_biUnion, Finset.singleton_biUnion]
       -- IH on [a+1, b]
       have ih_ab : ((Finset.Ico (a + 1) (b + 1)).biUnion (mostVisitedSet ω)).card ≤
           3 * (maxVisitCount ω b - maxVisitCount ω (a + 1) + 1) :=
@@ -295,7 +297,7 @@ theorem cumulative_card_bound (ω : RandomWalk) (a b : ℕ) (hab : a ≤ b)
           intro x hx
           have hx' := mostVisited_nesting ω a hTstep hx
           exact Finset.mem_biUnion.mpr ⟨a + 1, Finset.mem_Ico.mpr ⟨le_rfl, by omega⟩, hx'⟩
-        rw [sup_eq_right.mpr hFa_sub]
+        rw [Finset.union_eq_right.mpr hFa_sub]
         calc ((Finset.Ico (a + 1) (b + 1)).biUnion (mostVisitedSet ω)).card
             ≤ 3 * (maxVisitCount ω b - maxVisitCount ω (a + 1) + 1) := ih_ab
           _ = 3 * (maxVisitCount ω b - maxVisitCount ω a + 1) := by omega
@@ -353,49 +355,6 @@ axiom mostVisited_bounded_eventually :
 -- [Formerly axiom erdosTaylor_upper_bound — now derived from
 --  erdosTaylor_constant via erdosTaylor_implies_bound below.]
 
--- ## Main Theorem: Erdős Problem #1166
-
-/-- **Erdős Problem #1166 (PROVED)**:
-    Almost surely, for all but finitely many n,
-    |⋃_{k ≤ n} F(k)| ≤ O((log n)²).
-
-    The key idea: since |F(k)| ≤ 3 for large k, and the maximum visit count
-    T_n ≤ C · (log n)², only O((log n)²) different "regimes" of most-visited
-    points can occur, bounding the cumulative set size. -/
-theorem erdos1166_main :
-    AlmostSurely (fun ω =>
-      ∃ C : ℝ, C > 0 ∧ ∃ N : ℕ, ∀ n ≥ N,
-        ((cumulativeMostVisited ω n).card : ℝ) ≤ C * (Real.log n) ^ 2) :=
-  erdos1166_from_ingredients mostVisited_bounded_eventually
-    (erdosTaylor_implies_bound erdosTaylor_constant)
-
-/-- The bound in explicit polylogarithmic form:
-    |⋃_{k ≤ n} F(k)| ≤ (log n)^{O(1)} a.s.
-    Follows from erdos1166_main since C · (log n)² ≤ (log n)³ for large n. -/
-theorem erdos1166_polylog :
-    AlmostSurely (fun ω =>
-      ∃ α : ℝ, α > 0 ∧ ∃ N : ℕ, ∀ n ≥ N,
-        ((cumulativeMostVisited ω n).card : ℝ) ≤ (Real.log n) ^ α) := by
-  apply almostSurely_mono _ erdos1166_main
-  intro ω ⟨C, hC, N, hN⟩
-  -- Choose N' large enough that log n ≥ C for all n ≥ N'
-  -- Then C * (log n)² ≤ (log n)³ = (log n)^3
-  refine ⟨3, by norm_num, max N (Nat.ceil (Real.exp C) + 1), fun n hn => ?_⟩
-  have hN' : N ≤ n := (le_max_left _ _).trans hn
-  have hexp : Nat.ceil (Real.exp C) + 1 ≤ n := (le_max_right _ _).trans hn
-  have hn_large : (Real.exp C : ℝ) < n := by
-    calc Real.exp C ≤ ↑(Nat.ceil (Real.exp C)) := Nat.le_ceil _
-      _ < ↑(Nat.ceil (Real.exp C) + 1) := by exact_mod_cast Nat.lt_succ_of_le le_rfl
-      _ ≤ (n : ℝ) := by exact_mod_cast hexp
-  have hlog_ge : C ≤ Real.log n := by
-    rw [← Real.log_exp C]
-    exact Real.log_le_log (Real.exp_pos C) (le_of_lt hn_large)
-  have hlog_pos : 0 < Real.log n :=
-    lt_of_lt_of_le (by positivity) hlog_ge
-  calc ((cumulativeMostVisited ω n).card : ℝ) ≤ C * (Real.log ↑n) ^ 2 := hN n hN'
-    _ ≤ Real.log ↑n * (Real.log ↑n) ^ 2 := by nlinarith [sq_nonneg (Real.log (n : ℝ))]
-    _ = (Real.log ↑n) ^ 3 := by ring
-
 -- ## Proof Structure
 
 /-- The proof combines two key ingredients:
@@ -433,7 +392,7 @@ theorem erdos1166_from_ingredients :
   refine ⟨3 * C + 1, by linarith, max (max N₁ N₂) N₃, fun n hn => ?_⟩
   have hN₁n : N₁ ≤ n := le_trans (le_max_left _ _) (le_trans (le_max_left _ _) hn)
   have hN₂n : N₂ ≤ n := le_trans (le_max_right _ _) (le_trans (le_max_left _ _) hn)
-  have hN₃n : N₃ ≤ n := le_trans (le_max_right _ _) hn
+  have hN₃n : Nat.ceil (Real.exp (↑N₁ + 4)) + 1 ≤ n := le_trans (le_max_right _ _) hn
   -- T_n is bounded by C * (log n)²
   have hTn : (maxVisitCount ω n : ℝ) ≤ C * (Real.log ↑n) ^ 2 := hN₂ n hN₂n
   -- n > exp(N₁ + 4), so log n > N₁ + 4, so (log n)² > (N₁ + 4)² ≥ N₁ + 3
@@ -447,7 +406,9 @@ theorem erdos1166_from_ingredients :
   have hlog_pos : (0 : ℝ) < Real.log ↑n := by linarith
   -- (log n)² ≥ N₁ + 4 > N₁ + 3
   have hlog_sq_ge : (↑N₁ + 3 : ℝ) ≤ (Real.log ↑n) ^ 2 := by
-    have h1 : (1 : ℝ) ≤ ↑N₁ + 4 := by positivity
+    have h1 : (1 : ℝ) ≤ ↑N₁ + 4 := by
+      have : (0 : ℝ) ≤ ↑N₁ := Nat.cast_nonneg N₁
+      linarith
     nlinarith [sq_nonneg (Real.log (↑n : ℝ) - 1)]
   -- The cumulative set card bound (combines early + late parts)
   -- This is the key step using the nesting argument infrastructure
@@ -455,13 +416,15 @@ theorem erdos1166_from_ingredients :
       ↑N₁ + 3 * ↑(maxVisitCount ω n) + 3 := by
     -- Suffices to prove in ℕ: card ≤ N₁ + 3*(T_n + 1)
     suffices hnat : (cumulativeMostVisited ω n).card ≤ N₁ + 3 * (maxVisitCount ω n + 1) by
-      push_cast [Nat.cast_le] at hnat ⊢; linarith
+      have hcast := (Nat.cast_le (α := ℝ)).mpr hnat
+      push_cast at hcast
+      linarith
     -- Split range(n+1) = range(N₁) ∪ Ico(N₁, n+1)
     have hrange : Finset.range (n + 1) = Finset.range N₁ ∪ Finset.Ico N₁ (n + 1) := by
       rw [Finset.range_eq_Ico, Finset.range_eq_Ico]
       exact (Finset.Ico_union_Ico_eq_Ico (Nat.zero_le N₁) (by omega)).symm
     unfold cumulativeMostVisited
-    rw [hrange, Finset.biUnion_union]
+    rw [hrange, Finset.union_biUnion]
     -- Card of union ≤ sum of cards
     calc ((Finset.range N₁).biUnion (mostVisitedSet ω) ∪
             (Finset.Ico N₁ (n + 1)).biUnion (mostVisitedSet ω)).card
@@ -477,6 +440,8 @@ theorem erdos1166_from_ingredients :
                   obtain ⟨k, hk, hxk⟩ := Finset.mem_biUnion.mp hx
                   have hxv := mostVisited_subset_trajectory ω k hxk
                   obtain ⟨j, hj, hjx⟩ := Finset.mem_image.mp hxv
+                  have hj' := Finset.mem_range.mp hj
+                  have hk' := Finset.mem_range.mp hk
                   exact Finset.mem_image.mpr ⟨j, Finset.mem_range.mpr (by omega), hjx⟩
               _ ≤ (Finset.range N₁).card := Finset.card_image_le
               _ = N₁ := Finset.card_range N₁
@@ -491,6 +456,11 @@ theorem erdos1166_from_ingredients :
     _ = (↑N₁ + 3) + 3 * C * (Real.log ↑n) ^ 2 := by ring
     _ ≤ (Real.log ↑n) ^ 2 + 3 * C * (Real.log ↑n) ^ 2 := by linarith [hlog_sq_ge]
     _ = (3 * C + 1) * (Real.log ↑n) ^ 2 := by ring
+
+-- ## Main Theorem: Erdős Problem #1166
+-- (placed after its ingredients: erdos1166_from_ingredients,
+--  erdosTaylor_implies_bound, erdosTaylor_constant — v4.31 rejects
+--  in-file forward references)
 
 -- ## Connection to Erdős Problem #1165
 
@@ -543,5 +513,51 @@ theorem erdosTaylor_implies_bound :
   have h2 : (maxVisitCount ω n : ℝ) < (1 / Real.pi + 1) * (Real.log ↑n) ^ 2 :=
     (div_lt_iff₀ hlog2_pos).mp h1
   linarith
+
+-- ## Main Theorem: Erdős Problem #1166
+
+/-- **Erdős Problem #1166 (PROVED)**:
+    Almost surely, for all but finitely many n,
+    |⋃_{k ≤ n} F(k)| ≤ O((log n)²).
+
+    The key idea: since |F(k)| ≤ 3 for large k, and the maximum visit count
+    T_n ≤ C · (log n)², only O((log n)²) different "regimes" of most-visited
+    points can occur, bounding the cumulative set size. -/
+theorem erdos1166_main :
+    AlmostSurely (fun ω =>
+      ∃ C : ℝ, C > 0 ∧ ∃ N : ℕ, ∀ n ≥ N,
+        ((cumulativeMostVisited ω n).card : ℝ) ≤ C * (Real.log n) ^ 2) :=
+  erdos1166_from_ingredients mostVisited_bounded_eventually
+    (erdosTaylor_implies_bound erdosTaylor_constant)
+
+/-- The bound in explicit polylogarithmic form:
+    |⋃_{k ≤ n} F(k)| ≤ (log n)^{O(1)} a.s.
+    Follows from erdos1166_main since C · (log n)² ≤ (log n)³ for large n. -/
+theorem erdos1166_polylog :
+    AlmostSurely (fun ω =>
+      ∃ α : ℝ, α > 0 ∧ ∃ N : ℕ, ∀ n ≥ N,
+        ((cumulativeMostVisited ω n).card : ℝ) ≤ (Real.log n) ^ α) := by
+  apply almostSurely_mono _ erdos1166_main
+  intro ω ⟨C, hC, N, hN⟩
+  -- Choose N' large enough that log n ≥ C for all n ≥ N'
+  -- Then C * (log n)² ≤ (log n)³ = (log n)^3
+  refine ⟨3, by norm_num, max N (Nat.ceil (Real.exp C) + 1), fun n hn => ?_⟩
+  have hN' : N ≤ n := (le_max_left _ _).trans hn
+  have hexp : Nat.ceil (Real.exp C) + 1 ≤ n := (le_max_right _ _).trans hn
+  have hn_large : (Real.exp C : ℝ) < n := by
+    calc Real.exp C ≤ ↑(Nat.ceil (Real.exp C)) := Nat.le_ceil _
+      _ < ↑(Nat.ceil (Real.exp C) + 1) := by exact_mod_cast Nat.lt_succ_of_le le_rfl
+      _ ≤ (n : ℝ) := by exact_mod_cast hexp
+  have hlog_ge : C ≤ Real.log n := by
+    rw [← Real.log_exp C]
+    exact Real.log_le_log (Real.exp_pos C) (le_of_lt hn_large)
+  have hlog_pos : 0 < Real.log n :=
+    lt_of_lt_of_le (by positivity) hlog_ge
+  calc ((cumulativeMostVisited ω n).card : ℝ) ≤ C * (Real.log ↑n) ^ 2 := hN n hN'
+    _ ≤ Real.log ↑n * (Real.log ↑n) ^ 2 := by nlinarith [sq_nonneg (Real.log (n : ℝ))]
+    _ = (Real.log ↑n) ^ (3 : ℕ) := by ring
+    _ = (Real.log ↑n) ^ (3 : ℝ) := by
+        rw [← Real.rpow_natCast (Real.log ↑n) 3]
+        norm_num
 
 end Erdos1166

--- a/proofs/Proofs/Erdos635Problem.lean
+++ b/proofs/Proofs/Erdos635Problem.lean
@@ -124,7 +124,7 @@ theorem oddSet_card (N : ℕ) : (oddSet N).card = (N + 1) / 2 := by
 private lemma no_consecutive_in_admissible (A : Finset ℕ) (N : ℕ)
     (hA : IsAdmissible A N 1) (a : ℕ) (ha : a ∈ A) (ha1 : a + 1 ∈ A) : False := by
   have := hA.2 a (a + 1) ha ha1 (by omega) (by omega)
-  exact this ⟨a + 1, by omega⟩
+  exact this ⟨a + 1, by simp⟩
 
 /-- Upper bound: any 1-admissible set in {1,...,N} has at most (N+1)/2 elements.
     Proof: the map a ↦ (a-1)/2 is injective on A (no consecutive elements
@@ -133,11 +133,11 @@ private lemma no_consecutive_in_admissible (A : Finset ℕ) (N : ℕ)
 private theorem admissible_card_upper (A : Finset ℕ) (N : ℕ) (hA : IsAdmissible A N 1) :
     A.card ≤ (N + 1) / 2 := by
   -- Injection: a ↦ (a - 1) / 2
-  let φ : ℕ → ℕ := fun a => (a - 1) / 2
-  -- Show φ is injective on A
-  have hinj : Set.InjOn φ ↑A := by
+  let phi : ℕ → ℕ := fun a => (a - 1) / 2
+  -- Show phi is injective on A
+  have hinj : Set.InjOn phi ↑A := by
     intro a ha b hb heq
-    simp only [φ] at heq
+    simp only [phi] at heq
     have ha1 : 1 ≤ a := (hA.1 a (Finset.mem_coe.mp ha)).1
     have hb1 : 1 ≤ b := (hA.1 b (Finset.mem_coe.mp hb)).1
     -- From (a-1)/2 = (b-1)/2, derive a and b are in the same {2k+1, 2k+2}
@@ -154,21 +154,34 @@ private theorem admissible_card_upper (A : Finset ℕ) (N : ℕ) (hA : IsAdmissi
         (Finset.mem_coe.mp hb) (Finset.mem_coe.mp ha)
     · exact no_consecutive_in_admissible A N hA a
         (Finset.mem_coe.mp ha) (Finset.mem_coe.mp hb)
-  -- Show φ(A) ⊆ Finset.range ((N+1)/2)
-  have hrange : A.image φ ⊆ Finset.range ((N + 1) / 2) := by
+  -- Show phi(A) ⊆ Finset.range ((N+1)/2)
+  have hrange : A.image phi ⊆ Finset.range ((N + 1) / 2) := by
     intro x hx
     simp only [Finset.mem_image] at hx
     obtain ⟨a, ha, rfl⟩ := hx
-    simp only [Finset.mem_range, φ]
+    simp only [Finset.mem_range, phi]
     have ha_le : a ≤ N := (hA.1 a ha).2
     have ha_ge : a ≥ 1 := (hA.1 a ha).1
     -- (a-1)/2 < (N+1)/2 since a ≤ N
     have : a - 1 < N + 1 := by omega
     exact Nat.div_lt_of_lt_mul (by omega)
-  -- Combine: |A| = |φ(A)| ≤ |range((N+1)/2)| = (N+1)/2
-  calc A.card = (A.image φ).card := (Finset.card_image_of_injOn hinj).symm
+  -- Combine: |A| = |phi(A)| ≤ |range((N+1)/2)| = (N+1)/2
+  calc A.card = (A.image phi).card := (Finset.card_image_of_injOn hinj).symm
     _ ≤ (Finset.range ((N + 1) / 2)).card := Finset.card_le_card hrange
     _ = (N + 1) / 2 := Finset.card_range _
+
+/-- The set of achievable cardinalities is nonempty (∅ is always admissible). -/
+theorem f_set_nonempty (N t : ℕ) :
+    {k | ∃ A : Finset ℕ, A.card = k ∧ IsAdmissible A N t}.Nonempty :=
+  ⟨0, ∅, rfl, ⟨fun _ h => absurd h (Finset.notMem_empty _),
+    fun _ _ h => absurd h (Finset.notMem_empty _)⟩⟩
+
+/-- The set of achievable cardinalities is bounded above by N. -/
+theorem f_set_bddAbove (N t : ℕ) :
+    BddAbove {k | ∃ A : Finset ℕ, A.card = k ∧ IsAdmissible A N t} :=
+  ⟨N, fun _ ⟨A, hcard, hAdm⟩ => hcard ▸
+    le_trans (Finset.card_le_card (fun x hx => Finset.mem_Icc.mpr (hAdm.1 x hx)))
+      (by rw [Nat.card_Icc]; omega)⟩
 
 /-- For t = 1, the maximum is exactly ⌊(N+1)/2⌋.
 
@@ -225,26 +238,13 @@ theorem IsAdmissible_mono_t {A : Finset ℕ} {N t t' : ℕ} (h : t ≤ t')
     (hA : IsAdmissible A N t) : IsAdmissible A N t' :=
   ⟨hA.1, fun a b ha hb hab hd => hA.2 a b ha hb hab (le_trans h hd)⟩
 
-/-- The set of achievable cardinalities is nonempty (∅ is always admissible). -/
-theorem f_set_nonempty (N t : ℕ) :
-    {k | ∃ A : Finset ℕ, A.card = k ∧ IsAdmissible A N t}.Nonempty :=
-  ⟨0, ∅, rfl, ⟨fun _ h => absurd h (Finset.notMem_empty _),
-    fun _ _ h => absurd h (Finset.notMem_empty _)⟩⟩
-
-/-- The set of achievable cardinalities is bounded above by N. -/
-theorem f_set_bddAbove (N t : ℕ) :
-    BddAbove {k | ∃ A : Finset ℕ, A.card = k ∧ IsAdmissible A N t} :=
-  ⟨N, fun _ ⟨A, hcard, hAdm⟩ => hcard ▸
-    le_trans (Finset.card_le_card (fun x hx => Finset.mem_Icc.mpr (hAdm.1 x hx)))
-      (by simp [Finset.card_Icc]; omega)⟩
-
 /-- Trivial upper bound: f(N, t) ≤ N for all t.
     Proof: A ⊆ {1,...,N} implies |A| ≤ N. -/
 theorem f_upper_trivial (N t : ℕ) : f N t ≤ N := by
   unfold f
   exact csSup_le (f_set_nonempty N t) fun _ ⟨A, hcard, hAdm⟩ => hcard ▸
     le_trans (Finset.card_le_card (fun x hx => Finset.mem_Icc.mpr (hAdm.1 x hx)))
-      (by simp [Finset.card_Icc]; omega)
+      (by rw [Nat.card_Icc]; omega)
 
 /-- Monotonicity: f(N, t) ≤ f(N, t') when t ≤ t'.
     Proof: Larger t means fewer restricted pairs, so more admissible sets. -/
@@ -272,36 +272,37 @@ theorem f_lower_half (N t : ℕ) (hN : N ≥ 1) (ht : t ≥ 1) :
 theorem f_t1_density :
     Filter.Tendsto (fun N => (f N 1 : ℝ) / N) Filter.atTop (nhds (1 / 2)) := by
   -- Squeeze: constant 1/2 ≤ f(N,1)/N ≤ 1/2 + 1/(2N) → 1/2
-  apply tendsto_of_tendsto_of_tendsto_of_le_of_le tendsto_const_nhds
-  · -- Upper bound function: 1/2 + 1/(2N) → 1/2
-    have h0 : Filter.Tendsto (fun N : ℕ => (1 : ℝ) / (2 * (N : ℝ))) Filter.atTop (nhds 0) := by
-      have := Filter.Tendsto.const_mul
-        (show Filter.Tendsto (fun n : ℕ => (n : ℝ)⁻¹) Filter.atTop (nhds 0) from
-          tendsto_inv_atTop_zero.comp tendsto_natCast_atTop_atTop) (1 / 2 : ℝ)
-      simp only [mul_zero] at this
-      convert this using 1
-      ext n; ring
-    convert h0.const_add (1 / 2) using 1
-    · ext; ring
-    · ring
+  have hupper : Filter.Tendsto (fun N : ℕ => (1 / 2 : ℝ) + 1 / (2 * (N : ℝ)))
+      Filter.atTop (nhds (1 / 2)) := by
+    have h1 : Filter.Tendsto (fun n : ℕ => (n : ℝ)⁻¹) Filter.atTop (nhds 0) :=
+      tendsto_inv_atTop_zero.comp tendsto_natCast_atTop_atTop
+    have h2 := h1.const_mul ((2 : ℝ)⁻¹)
+    rw [mul_zero] at h2
+    have h3 := h2.const_add (1 / 2 : ℝ)
+    rw [add_zero] at h3
+    exact h3.congr fun n => by ring
+  refine tendsto_of_tendsto_of_tendsto_of_le_of_le' tendsto_const_nhds hupper ?_ ?_
   · -- Lower bound: 1/2 ≤ f(N,1)/N eventually
-    exact Filter.eventually_atTop.mpr ⟨2, fun N hN => by
-      rw [f_t1 N (by omega : N ≥ 1)]
-      rw [le_div_iff₀ (by positivity : (0 : ℝ) < ↑N)]
-      have : N ≤ ((N + 1) / 2) * 2 := by omega
-      exact_mod_cast this⟩
+    refine Filter.eventually_atTop.mpr ⟨2, fun N hN => ?_⟩
+    rw [f_t1 N (by omega : N ≥ 1),
+      le_div_iff₀ (by positivity : (0 : ℝ) < (N : ℝ))]
+    have h1 : N ≤ ((N + 1) / 2) * 2 := by omega
+    calc (1 / 2 : ℝ) * N = (N : ℝ) / 2 := by ring
+      _ ≤ (((N + 1) / 2 : ℕ) : ℝ) := by
+          rw [div_le_iff₀ (two_pos)]
+          exact_mod_cast h1
   · -- Upper bound: f(N,1)/N ≤ 1/2 + 1/(2N) eventually
-    exact Filter.eventually_atTop.mpr ⟨2, fun N hN => by
-      rw [f_t1 N (by omega : N ≥ 1)]
-      have hNpos : (0 : ℝ) < ↑N := by positivity
-      rw [div_le_iff₀ hNpos]
-      have hdiv : ((N + 1) / 2 : ℕ) * 2 ≤ N + 1 := Nat.div_mul_le_self (N + 1) 2
-      have : (((N + 1) / 2 : ℕ) : ℝ) ≤ ((N : ℝ) + 1) / 2 := by
-        rw [div_le_iff₀ (two_pos)]
-        exact_mod_cast hdiv
-      calc (((N + 1) / 2 : ℕ) : ℝ) ≤ ((N : ℝ) + 1) / 2 := this
-        _ = (1 / 2 + 1 / (2 * ↑N)) * ↑N := by field_simp; ring
-      ⟩
+    refine Filter.eventually_atTop.mpr ⟨2, fun N hN => ?_⟩
+    rw [f_t1 N (by omega : N ≥ 1)]
+    have hNpos : (0 : ℝ) < (N : ℝ) := by positivity
+    have hN0 : (N : ℝ) ≠ 0 := ne_of_gt hNpos
+    rw [div_le_iff₀ hNpos]
+    have hdiv : ((N + 1) / 2 : ℕ) * 2 ≤ N + 1 := Nat.div_mul_le_self (N + 1) 2
+    have hle : (((N + 1) / 2 : ℕ) : ℝ) ≤ ((N : ℝ) + 1) / 2 := by
+      rw [le_div_iff₀ (two_pos)]
+      exact_mod_cast hdiv
+    calc (((N + 1) / 2 : ℕ) : ℝ) ≤ ((N : ℝ) + 1) / 2 := hle
+      _ = (1 / 2 + 1 / (2 * (N : ℝ))) * (N : ℝ) := by field_simp
 
 /- ## Part VII: Structural Observations
 

--- a/proofs/Proofs/Erdos896Problem.lean
+++ b/proofs/Proofs/Erdos896Problem.lean
@@ -192,7 +192,7 @@ theorem reprCount_zero_of_not_mem (A B : Finset ℕ) (m : ℕ)
 theorem uniqueProductCount_singletons (a b : ℕ) :
     uniqueProductCount {a} {b} = 1 := by
   unfold uniqueProductCount reprCount
-  simp [Finset.product_singleton_right, Finset.product_singleton_left,
+  simp [Finset.singleton_product_singleton,
         Finset.filter_singleton, Finset.image_singleton]
 
 /-- F({a}, B) = |B| for a ≥ 1: the map b ↦ ab is injective, so each product
@@ -215,10 +215,10 @@ theorem uniqueProductCount_singleton_left (a : ℕ) (B : Finset ℕ) (ha : 0 < a
     ext ⟨x, y⟩
     simp only [Finset.mem_filter, Finset.mem_product, Finset.mem_singleton, Prod.mk.injEq]
     constructor
-    · rintro ⟨⟨rfl, hy⟩, hxy⟩; exact ⟨rfl, Nat.eq_of_mul_eq_left ha hxy⟩
+    · rintro ⟨⟨rfl, hy⟩, hxy⟩; exact ⟨rfl, Nat.eq_of_mul_eq_mul_left ha hxy⟩
     · rintro ⟨rfl, rfl⟩; exact ⟨⟨rfl, hb⟩, rfl⟩
   rw [h_img, Finset.filter_true_of_mem h_repr,
-      Finset.card_image_of_injective B (fun _ _ h => Nat.eq_of_mul_eq_left ha h)]
+      Finset.card_image_of_injective B (fun _ _ h => Nat.eq_of_mul_eq_mul_left ha h)]
 
 /-- F(A, {b}) = |A| for b ≥ 1, by commutativity. -/
 theorem uniqueProductCount_singleton_right (A : Finset ℕ) (b : ℕ) (hb : 0 < b) :
@@ -229,13 +229,16 @@ theorem uniqueProductCount_singleton_right (A : Finset ℕ) (b : ℕ) (hb : 0 < 
 theorem maxUniqueProducts_pos (N : ℕ) (hN : 1 ≤ N) :
     1 ≤ maxUniqueProducts N := by
   unfold maxUniqueProducts
-  apply Finset.le_sup
-    (Finset.mem_product.mpr
+  have hmem : (({1} : Finset ℕ), ({1} : Finset ℕ)) ∈
+      (Finset.Icc 1 N).powerset ×ˢ (Finset.Icc 1 N).powerset :=
+    Finset.mem_product.mpr
       ⟨Finset.mem_powerset.mpr (Finset.singleton_subset_iff.mpr
         (Finset.mem_Icc.mpr ⟨le_refl 1, hN⟩)),
        Finset.mem_powerset.mpr (Finset.singleton_subset_iff.mpr
-        (Finset.mem_Icc.mpr ⟨le_refl 1, hN⟩))⟩)
-  exact le_of_eq (uniqueProductCount_singletons 1 1).symm
+        (Finset.mem_Icc.mpr ⟨le_refl 1, hN⟩))⟩
+  calc 1 = uniqueProductCount {1} {1} := (uniqueProductCount_singletons 1 1).symm
+    _ ≤ _ := Finset.le_sup (f := fun p : Finset ℕ × Finset ℕ =>
+        uniqueProductCount p.1 p.2) hmem
 
 /-- F(Icc 1 N, {1}) = card(Icc 1 N): for B = {1}, every product a·1 = a
     has exactly one representation, so all products are unique. -/
@@ -263,22 +266,27 @@ theorem uniqueProductCount_range_one (N : ℕ) :
       Finset.mem_singleton, Prod.mk.injEq]
     constructor
     · rintro ⟨⟨hx, rfl⟩, hxy⟩; exact ⟨by omega, rfl⟩
-    · rintro ⟨rfl, rfl⟩; exact ⟨⟨hm, rfl⟩, by simp⟩
+    · rintro ⟨rfl, rfl⟩; exact ⟨⟨Finset.mem_Icc.mp hm, rfl⟩, by simp⟩
   rw [h_img, Finset.filter_true_of_mem h_repr]
 
+set_option maxHeartbeats 1600000 in
 /-- maxUniqueProducts N ≥ N for N ≥ 1: the pair A = {1,...,N}, B = {1}
     gives F(A,{1}) = N since each product a·1 = a is unique. -/
 theorem maxUniqueProducts_ge_range (N : ℕ) (hN : 1 ≤ N) :
     N ≤ maxUniqueProducts N := by
-  have hcard : (Finset.Icc 1 N).card = N := by rw [Finset.card_Icc]; omega
+  have hcard : (Finset.Icc 1 N).card = N := by rw [Nat.card_Icc]; omega
   calc N = (Finset.Icc 1 N).card := hcard.symm
     _ = uniqueProductCount (Finset.Icc 1 N) {1} := (uniqueProductCount_range_one N).symm
     _ ≤ maxUniqueProducts N := by
         unfold maxUniqueProducts
-        exact Finset.le_sup (Finset.mem_product.mpr
-          ⟨Finset.mem_powerset.mpr le_rfl,
-           Finset.mem_powerset.mpr (Finset.singleton_subset_iff.mpr
-            (Finset.mem_Icc.mpr ⟨le_refl 1, hN⟩))⟩)
+        have hmem2 : ((Finset.Icc 1 N), ({1} : Finset ℕ)) ∈
+            (Finset.Icc 1 N).powerset ×ˢ (Finset.Icc 1 N).powerset :=
+          Finset.mk_mem_product
+            (Finset.mem_powerset.mpr (Finset.Subset.refl _))
+            (Finset.mem_powerset.mpr (Finset.singleton_subset_iff.mpr
+              (Finset.mem_Icc.mpr ⟨le_refl 1, hN⟩)))
+        exact Finset.le_sup (f := fun p : Finset ℕ × Finset ℕ =>
+          uniqueProductCount p.1 p.2) hmem2
 
 /-
 ## Monotonicity and Bounds
@@ -325,8 +333,9 @@ theorem reprCount_le_card_left (A B : Finset ℕ) (m : ℕ) (hm : 0 < m) :
     have hm₁ : a₁ * b₁ = m := (Finset.mem_filter.mp h₁).2
     have hm₂ : a₂ * b₂ = m := (Finset.mem_filter.mp h₂).2
     have ha : a₁ ≠ 0 := by rintro rfl; simp at hm₁; omega
+    have heq' : a₁ = a₂ := heq
     have hb : b₁ = b₂ :=
-      mul_left_cancel₀ ha (hm₁.trans (by rw [← heq]; exact hm₂.symm))
+      mul_left_cancel₀ ha (hm₁.trans (by rw [heq']; exact hm₂.symm))
     exact Prod.ext heq hb
 
 /-- reprCount A B m ≤ |B| for m > 0, by commutativity. -/
@@ -346,7 +355,7 @@ theorem maxUniqueProducts_le_sq (N : ℕ) :
       ≤ A.card * B.card := uniqueProductCount_le_product A B
     _ ≤ (Finset.Icc 1 N).card * (Finset.Icc 1 N).card :=
         Nat.mul_le_mul (Finset.card_le_card hmem.1) (Finset.card_le_card hmem.2)
-    _ = N * N := by rw [Finset.card_Icc]; ring_nf; omega
+    _ = N * N := by rw [Nat.card_Icc]; simp
     _ = N ^ 2 := by ring
 
 /-- The image of A × B under multiplication has at most |A|·|B| elements

--- a/proofs/Proofs/WolstenholmeTheoremOQ02OQ02.lean
+++ b/proofs/Proofs/WolstenholmeTheoremOQ02OQ02.lean
@@ -39,13 +39,13 @@ g^m · S = S by reindexing via x ↦ g·x. Since g^m ≠ 1, S = 0.
 lemma sum_units_pow_eq_zero (m : ℕ) (hm : ¬((p - 1) ∣ m)) (hp2 : 2 ≤ p) :
     ∑ x : (ZMod p)ˣ, (x : ZMod p) ^ m = 0 := by
   -- Get a generator g of the cyclic group (ZMod p)ˣ
-  obtain ⟨g, hg⟩ := IsCyclic.exists_monoid_generator (α := (ZMod p)ˣ)
+  obtain ⟨g, hg⟩ := IsCyclic.exists_generator (α := (ZMod p)ˣ)
   -- g^m ≠ 1 since orderOf g = |group| = p-1 and (p-1) ∤ m
   have hgm : g ^ m ≠ 1 := by
     intro heq
     apply hm
-    rw [← ZMod.card_units_eq_totient p, ← Nat.totient_prime hp.out,
-        ← orderOf_eq_card_of_forall_mem_zpowers hg]
+    rw [← Nat.totient_prime hp.out, ← ZMod.card_units_eq_totient p,
+        Fintype.card_eq_nat_card, ← orderOf_eq_card_of_forall_mem_zpowers hg]
     exact orderOf_dvd_of_pow_eq_one heq
   -- Key: (↑g)^m * S = S by reindexing x ↦ g*x
   set S := ∑ x : (ZMod p)ˣ, (x : ZMod p) ^ m with hS_def
@@ -54,7 +54,7 @@ lemma sum_units_pow_eq_zero (m : ℕ) (hm : ¬((p - 1) ∣ m)) (hp2 : 2 ≤ p) :
     conv_rhs => rw [show (Finset.univ : Finset (ZMod p)ˣ) =
       Finset.univ.map (Equiv.mulLeft g).toEmbedding from
       (Finset.map_univ_equiv _).symm]
-    simp only [Finset.sum_map, Equiv.toEmbedding_apply, Equiv.mulLeft_apply,
+    simp only [Finset.sum_map, Equiv.toEmbedding_apply, Equiv.coe_mulLeft,
                Units.val_mul, mul_pow]
   -- (↑g)^m ≠ 1 in ZMod p (from g^m ≠ 1 as a unit)
   have hne : (↑g : ZMod p) ^ m ≠ 1 := by
@@ -84,7 +84,7 @@ lemma choose_pred_neg_one_pow (k : ℕ) (hk : k ≤ p - 1) (hp5 : 5 ≤ p) :
       exact fun hdvd => absurd (hp.out.dvd_factorial.mp hdvd) (by omega)
     exact mul_left_cancel₀ hne h
   -- Cast the ℕ identity k! * C(n, k) = n.descFactorial k
-  rw [← Nat.cast_mul, Nat.factorial_mul_choose hk]
+  rw [← Nat.cast_mul, ← Nat.descFactorial_eq_factorial_mul_choose]
   -- Now show: ((p-1).descFactorial k : ZMod p) = (k! : ZMod p) * (-1)^k
   rw [mul_comm]
   -- Prove by induction on k
@@ -96,7 +96,7 @@ lemma choose_pred_neg_one_pow (k : ℕ) (hk : k ≤ p - 1) (hp5 : 5 ≤ p) :
     -- Need: (p - 1 - k : ℕ) cast to ZMod p equals -(k + 1 : ℕ)
     have h_sum : (p - 1 - k) + (k + 1) = p := by omega
     have : ((p - 1 - k : ℕ) : ZMod p) = -((k + 1 : ℕ) : ZMod p) := by
-      have hp0 : ((p : ℕ) : ZMod p) = 0 := ZMod.natCast_self_eq_zero
+      have hp0 : ((p : ℕ) : ZMod p) = 0 := ZMod.natCast_self p
       have h_add : ((p - 1 - k : ℕ) : ZMod p) + ((k + 1 : ℕ) : ZMod p) = 0 := by
         rw [← Nat.cast_add, h_sum, hp0]
       exact eq_neg_of_add_eq_zero_left h_add
@@ -143,7 +143,7 @@ private lemma b_sq_eq_inv_sq (hp' : Nat.Prime p) (h5 : 5 ≤ p) (k : ℕ)
       (-1) ^ (k - 1) := by
     exact_mod_cast congrArg (Nat.cast : ℕ → ZMod p) h_mul ▸ h_choose
   have h_b : ((Nat.choose p k / p : ℕ) : ZMod p) = (-1) ^ (k - 1) * ((k : ℕ) : ZMod p)⁻¹ := by
-    rw [← h_zmod, mul_comm, mul_assoc, mul_inv_cancel₀ hk_ne, mul_one]
+    rw [← h_zmod, mul_comm, ← mul_assoc, inv_mul_cancel₀ hk_ne, one_mul]
   rw [h_b, mul_pow, ← pow_mul, show (k - 1) * 2 = 2 * (k - 1) from by ring]
   simp [neg_one_sq, one_pow, pow_mul, one_mul]
 
@@ -165,37 +165,45 @@ lemma p_dvd_sum_b_sq (hp' : Nat.Prime p) (h5 : 5 ≤ p) :
   have h_fermat : ∑ k ∈ Finset.Ico 1 p, ((k : ℕ) : ZMod p)⁻¹ ^ 2 =
       ∑ k ∈ Finset.Ico 1 p, ((k : ℕ) : ZMod p) ^ (2 * (p - 2)) := by
     apply Finset.sum_congr rfl; intro k hk
-    rw [inv_pow, ← pow_mul]
-    congr 1
     -- a⁻¹ = a^(p-2) via Fermat's little theorem
     have hflt := ZMod.pow_card_sub_one_eq_one (h_ne k hk)
-    rw [ZMod.card p] at hflt
-    have : ((k : ℕ) : ZMod p) * ((k : ℕ) : ZMod p) ^ (p - 2) = 1 := by
-      rw [← pow_succ, show p - 2 + 1 = p - 1 from by omega, hflt]
-    calc ((k : ℕ) : ZMod p)⁻¹
-        = ((k : ℕ) : ZMod p)⁻¹ * 1 := (mul_one _).symm
-      _ = ((k : ℕ) : ZMod p)⁻¹ * (((k : ℕ) : ZMod p) * ((k : ℕ) : ZMod p) ^ (p - 2)) := by
-            rw [this]
-      _ = ((k : ℕ) : ZMod p) ^ (p - 2) := by
-            rw [← mul_assoc, inv_mul_cancel₀ (h_ne k hk), one_mul]
+    have hmul : ((k : ℕ) : ZMod p) * ((k : ℕ) : ZMod p) ^ (p - 2) = 1 := by
+      rw [mul_comm, ← pow_succ, show p - 2 + 1 = p - 1 from by omega, hflt]
+    have hkinv : ((k : ℕ) : ZMod p)⁻¹ = ((k : ℕ) : ZMod p) ^ (p - 2) := by
+      calc ((k : ℕ) : ZMod p)⁻¹
+          = ((k : ℕ) : ZMod p)⁻¹ * 1 := (mul_one _).symm
+        _ = ((k : ℕ) : ZMod p)⁻¹ * (((k : ℕ) : ZMod p) * ((k : ℕ) : ZMod p) ^ (p - 2)) := by
+              rw [hmul]
+        _ = ((k : ℕ) : ZMod p) ^ (p - 2) := by
+              rw [← mul_assoc, inv_mul_cancel₀ (h_ne k hk), one_mul]
+    rw [hkinv, ← pow_mul, Nat.mul_comm (p - 2) 2]
   rw [h_fermat]
   -- Relate Ico sum to units sum via bijection Units.mk0
   have h_bij : ∑ k ∈ Finset.Ico 1 p, ((k : ℕ) : ZMod p) ^ (2 * (p - 2)) =
       ∑ x : (ZMod p)ˣ, (x : ZMod p) ^ (2 * (p - 2)) := by
     symm
-    apply Finset.sum_nbij' (fun x _ => (x : ZMod p).val) (fun k hk =>
-      Units.mk0 ((k : ℕ) : ZMod p) (h_ne k hk))
-    · intro x _; exact Finset.mem_Ico.mpr
-        ⟨Nat.pos_of_ne_zero (ZMod.val_ne_zero.mpr (Units.ne_zero x)), ZMod.val_lt _⟩
-    · intro _ _; exact Finset.mem_univ _
-    · intro x _; ext; simp [ZMod.natCast_zmod_val]
-    · intro k hk; simp [ZMod.val_natCast_of_lt (show k < p from (Finset.mem_Ico.mp hk).2)]
-    · intro x _; simp [ZMod.natCast_zmod_val]
+    exact Finset.sum_bij'
+      (fun (x : (ZMod p)ˣ) (_ : x ∈ Finset.univ) => (x : ZMod p).val)
+      (fun k hk => Units.mk0 ((k : ℕ) : ZMod p) (h_ne k hk))
+      (fun x _ => Finset.mem_Ico.mpr
+        ⟨Nat.pos_of_ne_zero ((ZMod.val_ne_zero _).mpr (Units.ne_zero x)), ZMod.val_lt _⟩)
+      (fun _ _ => Finset.mem_univ _)
+      (fun x _ => by ext; simp [ZMod.natCast_zmod_val])
+      (fun k hk => by
+        simp [Units.val_mk0,
+          ZMod.val_natCast_of_lt (show k < p from (Finset.mem_Ico.mp hk).2)])
+      (fun x _ => by simp [ZMod.natCast_zmod_val])
   rw [h_bij]
   -- Apply sum_units_pow_eq_zero with m = 2(p-2)
   -- Need: (p-1) ∤ 2(p-2). Since p ≥ 5: 2(p-2) = 2p-4, and
   -- 2p-4 = (p-1) + (p-3), so 2(p-2) mod (p-1) = p-3 ≠ 0.
-  exact sum_units_pow_eq_zero p (2 * (p - 2)) (by omega) (by omega)
+  refine sum_units_pow_eq_zero p (2 * (p - 2)) ?_ (by omega)
+  intro hdvd
+  obtain ⟨c, hc⟩ := hdvd
+  rcases Nat.lt_or_ge c 2 with hc2 | hc2
+  · interval_cases c <;> omega
+  · have h2 : (p - 1) * 2 ≤ (p - 1) * c := Nat.mul_le_mul_left _ hc2
+    omega
 
 /-
 ## Section 4: Wolstenholme's Theorem

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -872,7 +872,7 @@ Erdos115Problem	GREEN
 Erdos1161Problem	GREEN	
 Erdos1162Problem	RESIDUAL	unknown-const:Nat.card_pos_of_nonempty
 Erdos1165Problem	GREEN	
-Erdos1166Problem	RESIDUAL	unknown-const:Finset.filter_eq_empty
+Erdos1166Problem	GREEN	
 Erdos1167Problem	RESIDUAL	parse-error
 Erdos1168Problem	GREEN	
 Erdos1169Problem	RESIDUAL	proof-drift

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -1515,7 +1515,7 @@ Erdos631ProblemAristotle	GREEN
 Erdos632Aristotle	GREEN	
 Erdos634Aristotle	GREEN	
 Erdos634Problem	GREEN	
-Erdos635Problem	RESIDUAL	unknown-const:f_set_nonempty
+Erdos635Problem	GREEN	
 Erdos636Aristotle	GREEN	
 Erdos636Problem	GREEN	
 Erdos636ProblemAristotle	GREEN	

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -1823,7 +1823,7 @@ Erdos895CounterexampleFin18	GREEN
 Erdos895OQ01Problem	GREEN	
 Erdos895Problem	GREEN	
 Erdos895ProblemAristotle	RESIDUAL	proof-drift
-Erdos896Problem	RESIDUAL	unknown-const:Finset.product_singleton_right
+Erdos896Problem	GREEN	
 Erdos89Problem	GREEN	
 Erdos8OQ02	GREEN	
 Erdos8Problem	RESIDUAL	unknown-const:bottleneck_counterexample

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -2646,7 +2646,7 @@ WilsonsTheoremOQ02ExtOQ02	RESIDUAL	rewrite-drift
 WilsonsTheoremOQ04	RESIDUAL	rewrite-drift
 WilsonsTheoremOQ07	GREEN	
 WolstenholmeTheoremOQ01	RESIDUAL	oom-killed
-WolstenholmeTheoremOQ02OQ02	RESIDUAL	unknown-const:Equiv.mulLeft_apply
+WolstenholmeTheoremOQ02OQ02	GREEN	
 WolstenholmeTheoremOQ03	GREEN	
 YangMills2DOQ01	GREEN	
 YangMills2DOQ02	GREEN	

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -787,7 +787,7 @@ Erdos1089Problem	RESIDUAL	unknown-const:PiLp.equiv_symm_apply
 Erdos1091Problem	RESIDUAL	instance-synth
 Erdos1093OQ02FactorialGrowth	GREEN	
 Erdos1095OQ01Problem	RESIDUAL	partenat-removal
-Erdos1096Problem	RESIDUAL	unknown-const:intermediate_value_zero_of_neg_of_pos
+Erdos1096Problem	GREEN	
 Erdos1097OQ01	RESIDUAL	instance-synth
 Erdos1097Problem	RESIDUAL	instance-synth
 Erdos1098OQ01	RESIDUAL	type-mismatch


### PR DESCRIPTION
Doctor increment 59 (epic #37508, ledger #38065). Partition B (N–Z + Erdos≥600), deep-rework tail grind per operator option (b).

Flips so far (each verified green in-container, cpus 0-5, v431 volumes):
- Erdos635Problem — φ/totient notation collision, forward-ref reorder, Nat.card_Icc, Tendsto squeeze restructure
- Erdos1166Problem — union_biUnion/singleton_biUnion orientation flips, induction-generalized hyps, omega membership blindness
- Erdos1096Problem — intermediate_value_Ioo route, choose_spec metavar, Complex.coe_algebraMap casts, local-shim show-unfolds

More flips incoming; count updated at the end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)