### PR TITLE
migrate(v4.31): Doctor increment 64 — deep-rework partition A (+6 GREEN)

### DIFF
--- a/proofs/Proofs/CentralLimitTheoremOQ02OQ02.lean
+++ b/proofs/Proofs/CentralLimitTheoremOQ02OQ02.lean
@@ -124,10 +124,11 @@ theorem iid_satisfies_lindeberg
         (∫ ω, (S.X k ω / Real.sqrt n) ^ 2
               * (if |S.X k ω / Real.sqrt n| > ε then 1 else 0) ∂μ)
           = (∫ ω, (S.X k ω) ^ 2
-                * (if |S.X k ω| > ε * Real.sqrt n then 1 else 0) ∂μ) / n := by
+                * (if |S.X k ω| > ε * Real.sqrt n then 1 else 0) ∂μ) / (n : ℝ) := by
       intro k
       rw [← integral_div]
       refine integral_congr_ae (Eventually.of_forall (fun ω => ?_))
+      simp only []
       have hcond : (|S.X k ω / Real.sqrt n| > ε)
           ↔ (|S.X k ω| > ε * Real.sqrt n) := by
         rw [gt_iff_lt, gt_iff_lt, abs_div, abs_of_nonneg (Real.sqrt_nonneg _),
@@ -139,11 +140,14 @@ theorem iid_satisfies_lindeberg
         (∫ ω, (S.X k ω / Real.sqrt n) ^ 2
               * (if |S.X k ω / Real.sqrt n| > ε then 1 else 0) ∂μ)
           = (∫ ω, (S.X 0 ω) ^ 2
-                * (if |S.X 0 ω| > ε * Real.sqrt n then 1 else 0) ∂μ) / n := by
+                * (if |S.X 0 ω| > ε * Real.sqrt n then 1 else 0) ∂μ) / (n : ℝ) := by
       intro k _
       rw [hterm k, hIdent (ε * Real.sqrt n) k]
-    rw [Finset.sum_congr rfl hsum, Finset.sum_const, Finset.card_range, nsmul_eq_mul,
-      mul_div_assoc', mul_div_cancel_left₀ _ hn_ne]
+    trans (∑ _k ∈ Finset.range n, (∫ ω, (S.X 0 ω) ^ 2
+              * (if |S.X 0 ω| > ε * Real.sqrt n then 1 else 0) ∂μ) / (n : ℝ))
+    · exact Finset.sum_congr rfl hsum
+    · rw [Finset.sum_const, Finset.card_range, nsmul_eq_mul,
+        mul_div_assoc', mul_div_cancel_left₀ _ hn_ne]
   -- Conclude: the collapsed sequence tends to 0 by dominated convergence.
   refine Tendsto.congr' ?_
     (truncated_moment_tendsto_zero (S.X 0) (S.measurable 0) (S.sq_integrable 0)

--- a/proofs/Proofs/ChineseRemainderNonCoprimeOQ02.lean
+++ b/proofs/Proofs/ChineseRemainderNonCoprimeOQ02.lean
@@ -537,10 +537,9 @@ theorem ideal_crt_sufficient {I J : Ideal R} {a b : R}
   rw [Submodule.mem_sup] at h
   obtain ⟨i, hi, j, hj, hij⟩ := h
   refine ⟨a - i, ?_, ?_⟩
-  · show -i ∈ I
+  · rw [show a - i - a = -i from by ring]
     exact I.neg_mem hi
-  · show a - i - b ∈ J
-    have : a - i - b = j := by linarith
+  · have : a - i - b = j := by linear_combination -hij
     rw [this]
     exact hj
 
@@ -585,7 +584,7 @@ theorem ideal_crt_three_unique {I J K : Ideal R} {a b c x₁ x₂ : R}
     (x₁ - x₂) ∈ I ⊓ J ⊓ K := by
   rw [Submodule.mem_inf]
   refine ⟨?_, ?_⟩
-  · exact (ideal_crt_unique ⟨h₁.1, h₁.2.1⟩ ⟨h₂.1, h₂.2.1⟩).1
+  · exact ideal_crt_unique ⟨h₁.1, h₁.2.1⟩ ⟨h₂.1, h₂.2.1⟩
   · have := K.sub_mem h₁.2.2 h₂.2.2
     rwa [show (x₁ - c) - (x₂ - c) = x₁ - x₂ from by ring] at this
 
@@ -605,8 +604,7 @@ variable {R : Type*} [CommRing R]
 /-- Principal ideal membership: x ∈ Ideal.span {m} ↔ m ∣ x. -/
 theorem mem_span_singleton_iff_dvd (m x : R) :
     x ∈ Ideal.span {m} ↔ m ∣ x :=
-  Ideal.mem_span_singleton.trans ⟨fun ⟨c, hc⟩ => ⟨c, hc.symm⟩,
-                                  fun ⟨c, hc⟩ => ⟨c, hc.symm⟩⟩
+  Ideal.mem_span_singleton
 
 /-- Element CRT from ideal CRT: solvability via principal ideals.
     The element-level CRT (Part I for EDs) is a special case of the ideal CRT

--- a/proofs/Proofs/CollatzStructuredOQ03.lean
+++ b/proofs/Proofs/CollatzStructuredOQ03.lean
@@ -19,6 +19,7 @@
 import Mathlib
 
 open Nat Finset
+open scoped Classical
 
 namespace CollatzStoppingTime
 
@@ -49,19 +50,18 @@ noncomputable def stoppingTime (n : ℕ) : ℕ :=
 
 /-- Stopping time of 1 is 0 -/
 theorem stoppingTime_one : stoppingTime 1 = 0 := by
-  unfold stoppingTime
-  simp [reachesOne, reachesOneIn, collatzIter]
-  split
-  · exact Nat.find_eq_zero.mpr rfl
-  · rfl
+  have h : reachesOne 1 := ⟨0, rfl⟩
+  rw [stoppingTime, dif_pos h]
+  simp only [Nat.find_eq_zero]
+  rfl
 
 /-- Stopping time of 2 is 1 -/
 theorem stoppingTime_two : stoppingTime 2 = 1 := by
-  unfold stoppingTime
-  have h : reachesOne 2 := ⟨1, by unfold reachesOneIn collatzIter collatz; norm_num⟩
-  simp [h]
-  exact (Nat.find_eq_iff _).mpr ⟨by unfold reachesOneIn collatzIter collatz; norm_num,
-    fun k hk => by interval_cases k; unfold reachesOneIn collatzIter; norm_num⟩
+  have h : reachesOne 2 := ⟨1, rfl⟩
+  rw [stoppingTime, dif_pos h]
+  refine (Nat.find_eq_iff _).mpr ⟨rfl, fun k hk => ?_⟩
+  interval_cases k
+  simp [reachesOneIn, collatzIter]
 
 /-
 ## Part II: Average Stopping Time
@@ -106,7 +106,7 @@ def collatzConjecture : Prop :=
 axiom terras_density :
     ∀ ε > 0, ∃ N₀ : ℕ, ∀ N ≥ N₀,
       ((range N).filter (fun n => reachesOne (n + 1))).card ≥
-        ((1 - ε) * N : ℝ).toNat
+        ⌊(1 - ε) * N⌋₊
 
 /-
 ## Part V: The Open Question
@@ -139,7 +139,7 @@ def exactConstant : Prop :=
 /-  σ(1) = 0, σ(2) = 1, σ(3) = 7, σ(4) = 2, σ(5) = 5, σ(6) = 8 -/
 -- These can be verified by computation
 
-/-- The average for small N grows roughly logarithmically -/
+/- The average for small N grows roughly logarithmically -/
 -- S(1) = 0, S(2) = 0.5, S(3) = 2.67, S(4) = 2.5, S(5) = 3.0, S(6) = 3.83
 
 #check avgStoppingTimeAsymptotic

--- a/proofs/Proofs/Erdos133Problem.lean
+++ b/proofs/Proofs/Erdos133Problem.lean
@@ -57,7 +57,8 @@ noncomputable def maxDegree {V : Type*} [Fintype V] [DecidableEq V]
 /-- f(n) = minimum k such that every triangle-free diameter-2 graph on n vertices
     has a vertex of degree ≥ k -/
 noncomputable def f (n : ℕ) : ℕ :=
-  Nat.find (⟨1, by trivial⟩ : ∃ k : ℕ, ∀ V : Type*, ∀ _ : Fintype V,
+  Nat.find (⟨0, fun _ _ _ _ _ _ _ hd => ⟨hd.1.nonempty.some, Nat.zero_le _⟩⟩ :
+    ∃ k : ℕ, ∀ V : Type, ∀ _ : Fintype V,
     Fintype.card V = n → ∀ G : SimpleGraph V, [DecidableEq V] → [DecidableRel G.Adj] →
     TriangleFree G → HasDiameter2 G → ∃ v : V, G.degree v ≥ k)
 

--- a/proofs/Proofs/Erdos225Problem.lean
+++ b/proofs/Proofs/Erdos225Problem.lean
@@ -260,25 +260,30 @@ theorem sup_on_circle_eq_trig_sup (p : TrigPoly n) :
   have h_bij_sup : ∀ z : ℂ, ‖z‖ = 1 → ∃ θ ∈ Set.Icc 0 (2 * Real.pi), ‖∑ k : Fin (n + 1), p k * z ^ (k : ℕ)‖ = ‖∑ k : Fin (n + 1), p k * Complex.exp (Complex.I * k * θ)‖ := by
     intro z hz; obtain ⟨ θ, hθ₁, rfl ⟩ := h_bij z hz; use θ; simp +decide [ mul_assoc, mul_left_comm, ← Complex.exp_nat_mul ] ;
     exact hθ₁;
-  have h_bij_sup : ∀ θ ∈ Set.Icc 0 (2 * Real.pi), ∃ z : ℂ, ‖z‖ = 1 ∧ ‖∑ k : Fin (n + 1), p k * Complex.exp (Complex.I * k * θ)‖ = ‖∑ k : Fin (n + 1), p k * z ^ (k : ℕ)‖ := by
+  have h_bij_sup' : ∀ θ ∈ Set.Icc 0 (2 * Real.pi), ∃ z : ℂ, ‖z‖ = 1 ∧ ‖∑ k : Fin (n + 1), p k * Complex.exp (Complex.I * k * θ)‖ = ‖∑ k : Fin (n + 1), p k * z ^ (k : ℕ)‖ := by
     exact fun θ hθ => ⟨ Complex.exp ( Complex.I * θ ), by norm_num [ Complex.norm_exp ], by norm_num [ ← Complex.exp_nat_mul, mul_assoc, mul_comm, mul_left_comm ] ⟩;
+  -- BddAbove facts for the two supremum ranges.
+  have hbdd_icc : BddAbove (Set.range (fun θ : ↥(Set.Icc (0 : ℝ) (2 * Real.pi)) => ‖p.eval ↑θ‖)) := by
+    refine IsCompact.bddAbove (isCompact_range ?_)
+    refine Continuous.norm (continuous_finset_sum _ fun _ _ => Continuous.mul continuous_const ?_)
+    exact Complex.continuous_exp.comp (by continuity)
+  have hbdd_z : BddAbove (Set.range (fun z : {w : ℂ | ‖w‖ = 1} =>
+      ‖∑ k : Fin (n + 1), p k * (z : ℂ) ^ (k : ℕ)‖)) := by
+    refine ⟨ ∑ k : Fin ( n + 1 ), ‖p k‖, Set.forall_mem_range.2 fun z => ?_ ⟩
+    exact le_trans ( norm_sum_le _ _ ) ( Finset.sum_le_sum fun _ _ => by simp +decide [ z.2.out ] )
+  haveI : Nonempty {w : ℂ | ‖w‖ = 1} := ⟨⟨1, by simp⟩⟩
+  haveI : Nonempty (↥(Set.Icc (0 : ℝ) (2 * Real.pi))) :=
+    ⟨⟨0, ⟨le_rfl, by positivity⟩⟩⟩
   apply le_antisymm;
-  · convert ciSup_le _;
-    · exact ⟨ 1, by norm_num ⟩;
-    · intro x;
-      obtain ⟨ θ, hθ₁, hθ₂ ⟩ := ‹∀ z : ℂ, ‖z‖ = 1 → ∃ θ ∈ Set.Icc 0 ( 2 * Real.pi ), ‖∑ k : Fin ( n + 1 ), p k * z ^ ( k : ℕ )‖ = ‖∑ k : Fin ( n + 1 ), p k * Complex.exp ( Complex.I * ( k : ℂ ) * θ )‖› x x.2;
-      refine' le_trans _ ( le_ciSup _ ⟨ θ, hθ₁ ⟩ );
-      · convert hθ₂.le using 1;
-      · refine' IsCompact.bddAbove _;
-        exact isCompact_range ( by exact Continuous.norm <| by exact continuous_finset_sum _ fun _ _ => Continuous.mul ( continuous_const ) <| Complex.continuous_exp.comp <| by continuity );
-  · convert ciSup_le _;
-    · exact ⟨ ⟨ 0, ⟨ by norm_num, by positivity ⟩ ⟩ ⟩;
-    · intro x;
-      obtain ⟨ z, hz₁, hz₂ ⟩ := h_bij_sup x x.2;
-      refine' le_trans _ ( le_ciSup _ ⟨ z, hz₁ ⟩ );
-      · convert hz₂.le using 1;
-      · refine' ⟨ ∑ k : Fin ( n + 1 ), ‖p k‖, Set.forall_mem_range.2 fun z => _ ⟩;
-        exact le_trans ( norm_sum_le _ _ ) ( Finset.sum_le_sum fun _ _ => by simp +decide [ z.2.out ] )
+  · refine ciSup_le (fun x => ?_)
+    obtain ⟨ θ, hθ₁, hθ₂ ⟩ := h_bij_sup x x.2
+    rw [hθ₂]
+    exact le_ciSup hbdd_icc ⟨θ, hθ₁⟩
+  · refine ciSup_le (fun θ => ?_)
+    obtain ⟨ z, hz₁, hz₂ ⟩ := h_bij_sup' θ θ.2
+    show ‖p.eval ↑θ‖ ≤ _
+    rw [show ‖p.eval ↑θ‖ = ‖∑ k : Fin (n + 1), p k * Complex.exp (Complex.I * ↑↑k * ↑(θ : ℝ))‖ from rfl, hz₂]
+    exact le_ciSup hbdd_z ⟨z, hz₁⟩
 
 /- ## The Fejér-Riesz Theorem Connection -/
 

--- a/proofs/Proofs/Erdos353Problem.lean
+++ b/proofs/Proofs/Erdos353Problem.lean
@@ -289,9 +289,10 @@ private lemma hasInfiniteMeasure_inv_smul (c : ℝ) (hc : c ≠ 0)
       from (inv_smul_set_eq_preimage c hc A).symm]
     rw [MeasureTheory.Measure.addHaar_smul volume c⁻¹ A, hA.2]
     -- Goal: ENNReal.ofReal |c⁻¹| ^ finrank ℝ (EuclideanSpace ℝ (Fin 2)) * ⊤ = ⊤
-    have h_pos : (0 : ℝ≥0∞) < ENNReal.ofReal |c⁻¹| ^ FiniteDimensional.finrank ℝ (EuclideanSpace ℝ (Fin 2)) :=
-      pow_pos (ENNReal.ofReal_pos.mpr (abs_pos.mpr (inv_ne_zero.mpr hc))) _
-    simp [ENNReal.mul_top, h_pos.ne']
+    have h_ne : ENNReal.ofReal |c⁻¹ ^ Module.finrank ℝ (EuclideanSpace ℝ (Fin 2))| ≠ 0 := by
+      rw [Ne, ENNReal.ofReal_eq_zero, not_le]
+      exact abs_pos.mpr (pow_ne_zero _ (inv_ne_zero hc))
+    rw [ENNReal.mul_top h_ne]
 
 /-- Scaling preserves the isosceles triangle property. -/
 private lemma isIsoscelesTriangle_smul (c : ℝ) (hc : c ≠ 0)
@@ -313,7 +314,7 @@ private lemma triangleArea_smul_eq (c : ℝ) (hc : c > 0)
     triangleArea (c • p) (c • q) (c • r) = c ^ 2 * triangleArea p q r := by
   unfold triangleArea
   dsimp only
-  simp only [Pi.sub_apply, Pi.smul_apply, smul_eq_mul]
+  simp only [PiLp.sub_apply, PiLp.smul_apply, smul_eq_mul]
   rw [show (c * q 0 - c * p 0) * (c * r 1 - c * p 1) - (c * q 1 - c * p 1) * (c * r 0 - c * p 0) =
       c ^ 2 * ((q 0 - p 0) * (r 1 - p 1) - (q 1 - p 1) * (r 0 - p 0)) from by ring]
   rw [abs_mul, abs_of_pos (pow_pos hc 2)]
@@ -349,9 +350,9 @@ theorem scaling_property (A : Set (EuclideanSpace ℝ (Fin 2)))
   -- Construct the isosceles triangle in A
   refine ⟨c • p, c • q, c • r, hp, hq, hr, ?_, ?_, ?_, ?_, ?_⟩
   -- Distinctness: scaling by c ≠ 0 is injective
-  · exact fun h => hpq (smul_left_cancel₀ hc_ne h)
-  · exact fun h => hqr (smul_left_cancel₀ hc_ne h)
-  · exact fun h => hpr (smul_left_cancel₀ hc_ne h)
+  · exact fun h => hpq ((smul_right_inj hc_ne).mp h)
+  · exact fun h => hqr ((smul_right_inj hc_ne).mp h)
+  · exact fun h => hpr ((smul_right_inj hc_ne).mp h)
   -- Isosceles: scaling preserves distance ratios
   · exact isIsoscelesTriangle_smul c hc_ne hiso
   -- Area: c² · area(p,q,r) = (√t)² · 1 = t

--- a/proofs/batch2/STATUS.md
+++ b/proofs/batch2/STATUS.md
@@ -1,3 +1,105 @@
+# DOCTOR INCREMENT 64 (deep-rework partition A: A–M + Erdos < 600, #38065, 2026-07-15)
+
+Container `dr64` (cpus 6-11, 11g, cache v431-b), worktree doctor-b, branch
+`feature/issue-38065-inc64` off origin/feature/issue-37508. Confirms inc-56/57/60/62:
+partition A is genuine deep-rework — every RESIDUAL file is 4–35 diverse errors,
+ledger class = FIRST error only. All flips in-container per-file `lake build
+Proofs.X` exit-0 before ledger flip; pushed after every file. **+6 GREEN**, PR #38667.
+
+## Flips (failure class in parens)
+- Erdos225Problem (proof-drift): two `convert ciSup_le _` branches — v4.31
+  congruence emits Eq.refl-field + `Nonempty sorry` side goals → rewrote as direct
+  `ciSup_le`/`le_ciSup` with hoisted BddAbove + Nonempty instances (pre-existing
+  sorries retained).
+- Erdos133Problem (elab-drift; STATEMENT REPAIR #38611): (a) `def f` witness
+  `⟨1, by trivial⟩` is FALSE — the single-vertex graph is triangle-free, vacuously
+  diameter-2, but has NO vertex of degree ≥1 → replaced with the always-valid
+  `k=0` witness proved from `Connected.nonempty`. (b) `∀ V : Type*` made `f`
+  universe-polymorphic, so `f n` in OriginalQuestion/AlonConjecture carried
+  universe-level metavariables → pinned `V : Type` (card-n fixes every finite
+  iso-class; triangle-free/diameter-2/degree are iso-invariant → faithful).
+- Erdos353Problem (unknown-const:smul_left_cancel₀): `FiniteDimensional.finrank`→
+  `Module.finrank`; `(0 : ℝ≥0∞)` scoped notation not in scope (no `open scoped
+  ENNReal`) → `(0 : ENNReal)`; `inv_ne_zero` is now an implication not iff → drop
+  `.mpr`; `smul_left_cancel₀` removed → `(smul_right_inj hc).mp`; `Pi.sub_apply`/
+  `Pi.smul_apply` don't fire on EuclideanSpace(WithLp) → `PiLp.sub_apply`/
+  `PiLp.smul_apply`; `pow_pos` instance-synth fails on ENNReal → prove base ≠ 0
+  (`ofReal_eq_zero`+`abs_pos`+`pow_ne_zero`) then `rw [ENNReal.mul_top h]`.
+- CollatzStructuredOQ03 (instance-synth): `Nat.find` on a `dite` over a Prop needs
+  Decidable → `open scoped Classical`; `Real.toNat` does not exist → `⌊·⌋₊`
+  (Nat.floor); `/--` docstring with no following declaration before `#check` →
+  plain `/-` comment; concrete `stoppingTime` proofs: `decide` blocked by
+  `Classical.propDecidable` shadowing the computable instance → `rfl`/`simp`
+  reductions, `(Nat.find_eq_zero).mpr` via `simp only`, `Nat.find_eq_iff` refine.
+- ChineseRemainderNonCoprimeOQ02 (parse-error → ideal-CRT proof drift): `show -i ∈ I`
+  no longer defeq to `(a-i)-a ∈ I` → `rw [show a-i-a = -i from by ring]`; `linarith`
+  on a CommRing (unordered!) → `linear_combination`; `Submodule.mem_sup` yields
+  `i+j = a-b` so sign is `-hij`; stale `.1` on an `ideal_crt_unique` that already
+  returns `∈ I ⊓ J`; `mem_span_singleton_iff_dvd` = exactly `Ideal.mem_span_singleton`
+  (drop the `.trans` with wrong-direction `hc.symm`).
+- CentralLimitTheoremOQ02OQ02 (instance-synth): `(∫…)/n` with `n:ℕ` no longer
+  auto-coerces → the whole equation typed at ℕ (`NormedAddCommGroup ℕ`/`HMul ℝ ℝ ℕ`
+  synth fails) → `/ (n : ℝ)`; `integral_congr_ae` leaves an unapplied lambda
+  `(fun ω => …) ω` → `simp only []` to β-reduce before the `div_pow`/`sq_sqrt` rw;
+  `Finset.sum_congr rfl hsum` — `simp [toMDA]` unfolds the `if` BODY but not the
+  Decidable instance inside it, so `rw` can't syntactically match → `trans` + `exact`
+  (defeq closes the instance gap).
+
+## Statement bug FOUND (NOT flipped — pre-existing false formula, #38611)
+- **CevasTheoremOQ01OQ03** (ledger proof-drift): `routh_asymmetric_example` claims
+  `routhRatio (1/2)(1/3)(1/4) = 1/10`, but the parent `CevasTheoremOQ01.routhRatio`
+  denominator `(1-d+d·e)(1-e+e·f)(1-f+f·d)` is WRONG — it should be the stdP/Q/R
+  denominators `(1-e+d·e)(1-f+e·f)(1-d+f·d)`. Verified numerically: `signedArea(P,Q,R)
+  = 1/10` at (1/2,1/3,1/4) but `routhRatio = 25/252`; they coincide only at the
+  symmetric point (both 1/7), which is why the symmetric tests hid the bug. So
+  `routh_theorem_std`/`routh_area_explicit` are genuinely FALSE — this file was
+  never truly green (a math bug in a *dependency's def*, not v4.31 drift). Fixing it
+  means correcting the parent `routhRatio` denominator + re-verifying the parent and
+  all dependents — out of scope for mechanical migration, DEFERRED.
+
+## Flagged deep (triaged, NOT flipped)
+- Erdos598Problem (elab-drift, 4 err): `kappa : Cardinal` is universe-polymorphic;
+  `∃ c : … Set.Iio kappa` binders fail universe inference. `ErdosProblem598Minimal`
+  applies `ChromaticCompleteness` to `Set.Iio kappa` (one universe ABOVE where kappa
+  lives → `Cardinal.mk X` forces kappa.{w+1} while `c`'s codomain is kappa.{w}) —
+  universe-inconsistent, likely never green. Deep universe rework, deferred.
+- CantorDiagonalizationOQ03OQ01Incomplete01 (9): level-param mismatch [u1,u2,u3] vs
+  [u1,u2] in a Prop/Type-polymorphic Lawvere setup + diagonal type mismatches.
+- ErdosKoRado (11), Erdos560Problem (14, Sym2.Rel projection changes), Erdos461/
+  Erdos153/Erdos483 (23–34): diverse multi-root.
+- AmgmInequality…OQ03 (6): Newton-identity sum re-indexing drift + local
+  `elemSymm_fin_zero` missing. BezoutIdentity…Transitive (6): `Fin.cons` vs
+  `Fin.append` representation change + `headBlockN` SL-group type mismatch.
+
+## New systematic seams (rename-map §7ai candidates)
+1. **`ℝ≥0∞` is scoped notation** — needs `open scoped ENNReal`; a file that used it
+   under an older global export now fails to PARSE (`expected token` at the `∞`).
+   Fix: `open scoped ENNReal` or write `ENNReal`.
+2. **`inv_ne_zero` is an implication, not an iff** (`a ≠ 0 → a⁻¹ ≠ 0`) — drop `.mpr`.
+3. **`smul_left_cancel₀` removed** → `smul_right_inj (hr : r≠0) : r•m₁ = r•m₂ ↔ m₁=m₂`
+   (or `smul_right_injective M hr`), needs `[IsCancelMulZero R] [IsTorsionFree R M]`.
+4. **`Pi.sub_apply`/`Pi.smul_apply` don't fire on EuclideanSpace/PiLp** (WithLp not
+   reducibly Pi) → `PiLp.sub_apply`/`PiLp.smul_apply` (both `@[simp]`).
+5. **`pow_pos` instance-synth fails on ENNReal** (ordered-structure refactor) — prove
+   the base `≠ 0` (`pow_ne_zero`) and `rw [ENNReal.mul_top h]` instead.
+6. **`Real.toNat` does not exist** — use `⌊·⌋₊` (`Nat.floor`).
+7. **`open scoped Classical` shadows computable Decidable instances** — `decide` then
+   fails ("did not reduce to isTrue/isFalse" via `Classical.propDecidable`); replace
+   `decide` on concrete decidable props with `rfl`/`simp [defs]` reductions.
+8. **`linarith` needs an ordered field** — on a bare `CommRing` an equality that was
+   `linarith`-closed on v4.26 now fails; use `linear_combination`.
+9. **`if`-Decidable-instance mismatch defeats `rw`** — `simp only [def]` rewrites the
+   `if` body but NOT the Decidable instance argument, so a subsequent `rw
+   [sum_congr rfl h]` can't syntactically match; switch to `trans`/`exact` (or `calc`)
+   which close by defeq.
+10. **`convert ciSup_le`/congruence golf regenerates side goals** (Eq.refl-field,
+    `Nonempty sorry`) on v4.31 — prefer direct `ciSup_le`/`le_ciSup` with explicit
+    Nonempty + BddAbove over `convert`.
+
+Ledger after increment 64: +6 GREEN (partition A).
+
+---
+
 # DOCTOR INCREMENT 62 (deep-rework partition A: A–M + Erdos < 600, #38065, 2026-07-14)
 
 Container `dr62` (cpus 6-11, 11g, cache v431-b), worktree doctor-b, branch

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -1167,7 +1167,7 @@ Erdos350Problem	GREEN
 Erdos351Problem	GREEN	
 Erdos352Problem	GREEN	
 Erdos353Aristotle	GREEN	instance-synth
-Erdos353Problem	RESIDUAL	unknown-const:smul_left_cancel₀
+Erdos353Problem	GREEN	unknown-const:smul_left_cancel₀
 Erdos354Problem	GREEN	
 Erdos355Problem	GREEN	
 Erdos356Problem	GREEN	

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -448,7 +448,7 @@ ChineseRemainderExplicitOQ04OQ03OQ01	GREEN
 ChineseRemainderNonCoprimeList	GREEN	
 ChineseRemainderNonCoprimeOQ01	GREEN	
 ChineseRemainderNonCoprimeOQ01OQ01	GREEN	
-ChineseRemainderNonCoprimeOQ02	RESIDUAL	parse-error
+ChineseRemainderNonCoprimeOQ02	GREEN	parse-error
 ChineseRemainderNonCoprimeOQ02OQ01	GREEN	instance-synth
 ChineseRemainderNonCoprimeOQ03OQ02	RESIDUAL	type-mismatch
 CircumferenceFromArea	GREEN	

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -421,7 +421,7 @@ CentralLimitTheoremOQ01OQ02OQ01OQ03	GREEN
 CentralLimitTheoremOQ01OQ03	GREEN	
 CentralLimitTheoremOQ02	GREEN	
 CentralLimitTheoremOQ02Aristotle	GREEN	
-CentralLimitTheoremOQ02OQ02	RESIDUAL	instance-synth
+CentralLimitTheoremOQ02OQ02	GREEN	instance-synth
 CentralLimitTheoremOQ02OQ03	GREEN	
 CentralLimitTheoremOQ02OQ04	GREEN	
 CentralLimitTheoremOQ03	GREEN	

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -924,7 +924,7 @@ Erdos12Problem	GREEN
 Erdos130Problem	GREEN	
 Erdos130WIP01	GREEN	
 Erdos132Problem	GREEN	
-Erdos133Problem	RESIDUAL	elab-drift
+Erdos133Problem	GREEN	elab-drift
 Erdos134Problem	GREEN	
 Erdos136Problem	GREEN	
 Erdos13Problem	GREEN	

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -457,7 +457,7 @@ CircumferenceViaDifferentiationOQ02	GREEN
 CircumferenceViaDifferentiationOQ03	GREEN	
 CollatzCyclesOQ04	GREEN	
 CollatzStructuredOQ02OQ01	GREEN	
-CollatzStructuredOQ03	RESIDUAL	instance-synth
+CollatzStructuredOQ03	GREEN	instance-synth
 CombinationsFormulaOQ01OQ04	RESIDUAL	type-mismatch
 CombinationsFormulaOQ02	RESIDUAL	proof-drift
 CombinationsFormulaOQ02Aristotle	GREEN	

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -1020,7 +1020,7 @@ Erdos221Problem	GREEN
 Erdos222Problem	GREEN	
 Erdos223Problem	RESIDUAL	type-mismatch
 Erdos225Aristotle	GREEN	
-Erdos225Problem	RESIDUAL	proof-drift
+Erdos225Problem	GREEN	proof-drift
 Erdos226Problem	GREEN	
 Erdos229Problem	GREEN	
 Erdos230LowerBound	GREEN	


### PR DESCRIPTION
Deep-rework tail grind, partition A (A–M + Erdos<600), epic #37508 / ledger #38065.

Per-file in-container `lake build Proofs.X` exit-0 before each ledger flip.

## GREEN
- Erdos225Problem (proof-drift): rewrote two broken `convert ciSup_le _` branches (v4.31 congruence emits Eq.refl-field + Nonempty-sorry side goals) as direct `ciSup_le`/`le_ciSup` with hoisted BddAbove + Nonempty. Pre-existing sorries retained.

More to come.

🤖 Generated with [Claude Code](https://claude.com/claude-code)