### PR TITLE
migrate(v4.31): Doctor increment 65 — deep-rework partition B (+6 GREEN)

### DIFF
--- a/proofs/Proofs/Erdos1034Problem.lean
+++ b/proofs/Proofs/Erdos1034Problem.lean
@@ -118,7 +118,7 @@ structure Triangle (G : SimpleGraph V) where
   adj13 : G.Adj v1 v3
 
 /-- The set of triangle vertices. -/
-def Triangle.vertices (T : Triangle G) : Finset V :=
+def Triangle.vertices {G : SimpleGraph V} (T : Triangle G) : Finset V :=
   {T.v1, T.v2, T.v3}
 
 /- Aristotle failed to load this code into its environment. Double check that the syntax is correct.
@@ -131,7 +131,7 @@ but this term has type
 Note: Expected a function because this term is being applied to the argument
   G-/
 /-- Triangle has exactly 3 vertices. -/
-theorem Triangle.card_vertices (T : Triangle G) : T.vertices.card = 3 := by
+theorem Triangle.card_vertices {G : SimpleGraph V} (T : Triangle G) : T.vertices.card = 3 := by
   simp only [Triangle.vertices]
   rw [Finset.card_insert_of_notMem, Finset.card_insert_of_notMem, Finset.card_singleton]
   · exact Finset.notMem_singleton.mpr T.distinct23
@@ -258,7 +258,7 @@ def isValidBound (n : ℕ) (k : ℕ) : Prop :=
 Unknown identifier `isValidBound`-/
 /-- h(n): the extremal function. -/
 noncomputable def h (n : ℕ) : ℕ :=
-  sSup {k : ℕ | isValidBound n k}
+  sSup {k : ℕ | isValidBound.{0} n k}
 
 /- Aristotle failed to load this code into its environment. Double check that the syntax is correct.
 
@@ -279,6 +279,30 @@ def erdos_faudree_conjecture : Prop :=
   ∀ G : SimpleGraph V, ∀ [DecidableRel G.Adj],
   isAboveTuran G →
   ∃ T : Triangle G, (goodNeighborCount G T : ℝ) > (1/2 - ε) * n
+
+/-
+## Ma-Tang Counterexample
+
+Ma and Tang constructed a graph disproving the conjecture.
+-/
+
+/-- The Ma-Tang constant: 2 - √(5/2) ≈ 0.4189. -/
+noncomputable def maTangConstant : ℝ := 2 - Real.sqrt (5/2)
+
+/-- Numerical value verification. -/
+theorem maTang_approx : maTangConstant > 0.418 ∧ maTangConstant < 0.42 := by
+  unfold maTangConstant;
+  constructor <;> nlinarith [ Real.sqrt_nonneg ( 5 / 2 ), Real.sq_sqrt ( show 0 ≤ 5 / 2 by norm_num ) ]
+
+/-- Ma-Tang: There exists a counterexample graph.
+    The bound `+ 1` replaces `+ o(1)` from the original statement. -/
+axiom maTang_counterexample : ∃ N : ℕ, ∀ n ≥ N,
+  ∃ (V : Type*) (_ : DecidableEq V) (_ : Fintype V),
+    Fintype.card V = n ∧
+    ∃ G : SimpleGraph V,
+      ∀ [DecidableRel G.Adj],
+        isAboveTuran G ∧
+        (∀ T : Triangle G, (goodNeighborCount G T : ℝ) ≤ maTangConstant * n + 1)
 
 /- Aristotle found this block to be false. Here is a proof of the negation:
 
@@ -311,41 +335,19 @@ theorem erdos_faudree_false : ¬erdos_faudree_conjecture := by
   -- Get counterexample graph
   obtain ⟨V, hDE, hFT, hcard, G, hprops⟩ := hN_mt n hn_mt
   haveI := hDE; haveI := hFT
-  haveI : DecidableRel G.Adj := Classical.decRel _
+  haveI hDR : DecidableRel G.Adj := Classical.decRel _
   obtain ⟨hAT, hbound⟩ := hprops
   -- Apply the conjecture
-  obtain ⟨T, hT⟩ := hN_conj n hn_conj V hcard G hAT
+  obtain ⟨T, hT⟩ := @hN_conj n hn_conj V hDE hFT hcard G hDR hAT
   -- hT : goodNeighborCount G T > (1/2 - 1/25) * n = 23/50 * n
   -- hbound T : goodNeighborCount G T ≤ maTangConstant * n + 1
   have hT_le := hbound T
   -- maTangConstant < 0.42 (from maTang_approx)
   have h_mc := maTang_approx.2
   -- Contradiction: 23/50 * n > maTangConstant * n + 1 for n ≥ 26
+  have hprod : maTangConstant * (n : ℝ) < 0.42 * n :=
+    mul_lt_mul_of_pos_right h_mc (by linarith)
   linarith
-
-/-
-## Ma-Tang Counterexample
-
-Ma and Tang constructed a graph disproving the conjecture.
--/
-
-/-- The Ma-Tang constant: 2 - √(5/2) ≈ 0.4189. -/
-noncomputable def maTangConstant : ℝ := 2 - Real.sqrt (5/2)
-
-/-- Numerical value verification. -/
-theorem maTang_approx : maTangConstant > 0.418 ∧ maTangConstant < 0.42 := by
-  unfold maTangConstant;
-  constructor <;> nlinarith [ Real.sqrt_nonneg ( 5 / 2 ), Real.sq_sqrt ( show 0 ≤ 5 / 2 by norm_num ) ]
-
-/-- Ma-Tang: There exists a counterexample graph.
-    The bound `+ 1` replaces `+ o(1)` from the original statement. -/
-axiom maTang_counterexample : ∃ N : ℕ, ∀ n ≥ N,
-  ∃ (V : Type*) (_ : DecidableEq V) (_ : Fintype V),
-    Fintype.card V = n ∧
-    ∃ G : SimpleGraph V,
-      ∀ [DecidableRel G.Adj],
-        isAboveTuran G ∧
-        (∀ T : Triangle G, (goodNeighborCount G T : ℝ) ≤ maTangConstant * n + 1)
 
 /-- The upper bound on h(n). -/
 theorem h_upper_bound : ∃ N : ℕ, ∀ n ≥ N,
@@ -421,6 +423,24 @@ but this term has type
 
 Note: Expected a function because this term is being applied to the argument
   G-/
+/-- If y is adjacent to all 3, it's definitely a good neighbor. -/
+theorem fully_adjacent_is_good (G : SimpleGraph V) [DecidableRel G.Adj]
+    (T : Triangle G) (y : V) (h1 : G.Adj y T.v1) (h2 : G.Adj y T.v2) (h3 : G.Adj y T.v3) :
+    adjacentToTriangleCount G T y = 3 := by
+  simp only [adjacentToTriangleCount]
+  have hsub : T.vertices ⊆ T.vertices.filter (fun v => G.Adj y v) := by
+    intro v hv
+    simp only [Triangle.vertices, Finset.mem_insert, Finset.mem_singleton] at hv
+    simp only [Finset.mem_filter, Triangle.vertices, Finset.mem_insert, Finset.mem_singleton]
+    rcases hv with rfl | rfl | rfl
+    · exact ⟨Or.inl rfl, h1⟩
+    · exact ⟨Or.inr (Or.inl rfl), h2⟩
+    · exact ⟨Or.inr (Or.inr rfl), h3⟩
+  have hle := Finset.card_le_card hsub
+  have hge := Finset.card_le_card (Finset.filter_subset (fun v => G.Adj y v) T.vertices)
+  rw [Triangle.card_vertices] at hle hge
+  omega
+
 /-- Book pages are good neighbors (adjacent to all 3 ≥ 2). -/
 theorem book_pages_are_good (G : SimpleGraph V) [DecidableRel G.Adj]
     (T : Triangle G) (pages : Finset V) (hBook : isBook G T pages) :
@@ -501,8 +521,7 @@ noncomputable def k4FreeConstant : ℝ := 2 * Real.sqrt 3 - 3
 /-- K₄-free constant verification. -/
 theorem k4Free_approx : k4FreeConstant > 0.46 ∧ k4FreeConstant < 0.47 := by
   -- Calculate the numerical value of the K₄-free constant.
-  have h_k4FreeConstant : k4FreeConstant = 2 * Real.sqrt 3 - 3 := by
-    exact?;
+  have h_k4FreeConstant : k4FreeConstant = 2 * Real.sqrt 3 - 3 := rfl
   exact ⟨ by norm_num; nlinarith [ Real.sqrt_nonneg 3, Real.sq_sqrt ( show 0 ≤ 3 by norm_num ) ], by norm_num; nlinarith [ Real.sqrt_nonneg 3, Real.sq_sqrt ( show 0 ≤ 3 by norm_num ) ] ⟩
 
 /-  Ma-Tang K₄-free result. The bound `+ 1` replaces `+ o(1)`. -/
@@ -689,24 +708,6 @@ but this term has type
 
 Note: Expected a function because this term is being applied to the argument
   G-/
-/-- If y is adjacent to all 3, it's definitely a good neighbor. -/
-theorem fully_adjacent_is_good (G : SimpleGraph V) [DecidableRel G.Adj]
-    (T : Triangle G) (y : V) (h1 : G.Adj y T.v1) (h2 : G.Adj y T.v2) (h3 : G.Adj y T.v3) :
-    adjacentToTriangleCount G T y = 3 := by
-  simp only [adjacentToTriangleCount]
-  have hsub : T.vertices ⊆ T.vertices.filter (fun v => G.Adj y v) := by
-    intro v hv
-    simp only [Triangle.vertices, Finset.mem_insert, Finset.mem_singleton] at hv
-    simp only [Finset.mem_filter, Triangle.vertices, Finset.mem_insert, Finset.mem_singleton]
-    rcases hv with rfl | rfl | rfl
-    · exact ⟨Or.inl rfl, h1⟩
-    · exact ⟨Or.inr (Or.inl rfl), h2⟩
-    · exact ⟨Or.inr (Or.inr rfl), h3⟩
-  have hle := Finset.card_le_card hsub
-  have hge := Finset.card_le_card (Finset.filter_subset _ T.vertices)
-  rw [Triangle.card_vertices] at hle hge
-  omega
-
 /- Aristotle failed to load this code into its environment. Double check that the syntax is correct.
 
 Function expected at

--- a/proofs/Proofs/Erdos1039Aristotle.lean
+++ b/proofs/Proofs/Erdos1039Aristotle.lean
@@ -74,12 +74,12 @@ theorem inscribedDiscRadius_ge_ari (S : Set ℂ) (c : ℂ) (r : ℝ)
 /-- For a degree-1 polynomial f, the sublevel set equals the open unit disc at f.roots 0.
     Since f.eval z = z - f.roots 0, |f.eval z| < 1 iff |z - f.roots 0| < 1. -/
 theorem degree_one_sublevel_eq_ari (f : UnitDiscPolynomial) (hf : f.degree = 1) :
-    sublevelSet f = {z : ℂ | Erdos1039.Complex.abs (z - f.roots ⟨0, by omega⟩) < 1} := by
+    sublevelSet f = {z : ℂ | Complex.abs (z - f.roots ⟨0, by omega⟩) < 1} := by
   ext z
   simp only [sublevelSet, UnitDiscPolynomial.eval, Set.mem_setOf_eq]
   rw [show (Finset.univ : Finset (Fin f.degree)) = {⟨0, by omega⟩} from by
         ext i; simp [Fin.ext_iff]; omega]
-  simp [Finset.prod_singleton]
+  simp [Finset.prod_singleton, Complex.abs]
 
 /-
 For degree 1, the disc of radius 1 centered at f.roots 0 is inscribed in the sublevel set.
@@ -92,7 +92,7 @@ theorem degree_one_isInscribedDisc_ari (f : UnitDiscPolynomial) (hf : f.degree =
     convert hz using 1;
     rw [ show sublevelSet f = { z : ℂ | Complex.abs ( z - f.roots ⟨ 0, by linarith ⟩ ) < 1 } from ?_ ];
     · rfl;
-    · exact?
+    · exact degree_one_sublevel_eq_ari f hf
 
 /-
 For degree 1, rho f ≥ 1.
@@ -104,7 +104,8 @@ theorem degree_one_rho_ge_one_ari (f : UnitDiscPolynomial) (hf : f.degree = 1) :
   have h_bounded : ∃ M : ℝ, ∀ z ∈ sublevelSet f, ‖z‖ ≤ M := by
     -- For a degree 1 polynomial $f(z) = z - r$, the sublevel set is the open unit disc centered at $r$.
     have h_sublevel_set : sublevelSet f = Metric.ball (f.roots ⟨0, by omega⟩) 1 := by
-      convert degree_one_sublevel_eq_ari f hf using 1;
+      convert degree_one_sublevel_eq_ari f hf using 1
+      ext z; simp [Metric.mem_ball, dist_eq_norm, Complex.abs]
     exact ⟨ ‖f.roots ⟨ 0, by omega ⟩‖ + 1, fun z hz => by rw [ h_sublevel_set ] at hz; exact le_trans ( norm_le_of_mem_closedBall <| by simpa using hz.out.le ) ( by norm_num ) ⟩;
   obtain ⟨ M, hM ⟩ := h_bounded;
   use 2 * M + 1;
@@ -126,9 +127,10 @@ theorem degree_one_rho_le_one_ari (f : UnitDiscPolynomial) (hf : f.degree = 1) :
     rho f ≤ 1 := by
   -- Since $f$ is a degree 1 polynomial, its sublevel set is the open unit disc centered at $f.roots 0$.
   have h_sublevel : sublevelSet f = Metric.ball (f.roots ⟨0, by linarith⟩) 1 := by
-    convert degree_one_sublevel_eq_ari f hf;
+    convert degree_one_sublevel_eq_ari f hf using 1
+    ext z; simp [Metric.mem_ball, dist_eq_norm, Complex.abs]
   refine' csSup_le _ _ <;> norm_num [ h_sublevel ];
-  · exact ⟨ 1, ⟨ f.roots ⟨ 0, by linarith ⟩, ⟨ by norm_num, fun z hz => hz ⟩ ⟩ ⟩;
+  · exact ⟨ 1, ⟨ f.roots ⟨ 0, by linarith ⟩, ⟨ by norm_num, fun z hz => by simpa [Metric.mem_ball, dist_eq_norm] using hz ⟩ ⟩ ⟩;
   · rintro b x ⟨ hb₁, hb₂ ⟩;
     -- By contradiction, assume $b > 1$.
     by_contra hb_gt_one;
@@ -163,8 +165,13 @@ theorem inscribedDiscRadius_mono_ari (S T : Set ℂ) (hST : S ⊆ T)
 /-- The benchmark polynomial zⁿ-1 has all roots on the unit circle.
     Each n-th root of unity has absolute value 1. -/
 theorem rootsOfUnity_abs_ari (n : ℕ) (hn : n > 0) (i : Fin n) :
-    Erdos1039.Complex.abs ((Erdos1039.rootsOfUnity n hn).roots i) = 1 := by
-  simp only [Erdos1039.rootsOfUnity, Erdos1039.Complex.abs]
-  exact Complex.norm_exp_ofReal_mul_I _
+    Complex.abs ((Erdos1039.rootsOfUnity n hn).roots i) = 1 := by
+  simp only [Erdos1039.rootsOfUnity, Complex.abs, Complex.norm_exp]
+  have heq : 2 * ↑Real.pi * Complex.I * ↑↑(i : ℕ) / ↑(n : ℕ) =
+      ↑(2 * Real.pi * (↑(i : ℕ) : ℝ) / (↑n : ℝ)) * Complex.I := by
+    push_cast; ring
+  rw [heq, Complex.mul_re, Complex.ofReal_re, Complex.ofReal_im,
+      Complex.I_re, Complex.I_im]
+  simp [Real.exp_zero]
 
 end Erdos1039Aristotle

--- a/proofs/Proofs/Erdos1182Problem.lean
+++ b/proofs/Proofs/Erdos1182Problem.lean
@@ -126,9 +126,8 @@ lemma graph2_edge_le_one (G : Graph 2) : edgeCount G ≤ 1 := by
   unfold edgeCount
   rw [Finset.card_le_one]
   intro ⟨a₁, b₁⟩ h₁ ⟨a₂, b₂⟩ h₂
-  simp only [Finset.mem_filter, Finset.mem_product, Finset.mem_univ, true_and] at h₁ h₂
-  obtain ⟨hab₁, _⟩ := h₁
-  obtain ⟨hab₂, _⟩ := h₂
+  obtain ⟨-, hab₁, -⟩ := Finset.mem_filter.mp h₁
+  obtain ⟨-, hab₂, -⟩ := Finset.mem_filter.mp h₂
   have := fin2_lt_unique a₁ b₁ hab₁
   have := fin2_lt_unique a₂ b₂ hab₂
   ext <;> simp_all
@@ -141,8 +140,9 @@ lemma edgeCount_completeGraph2 : edgeCount completeGraph2 = 1 := by
   have hmem : ((0 : Fin 2), (1 : Fin 2)) ∈
     ((Finset.univ.product Finset.univ).filter fun (p : Fin 2 × Fin 2) =>
       p.1 < p.2 ∧ completeGraph2.adj p.1 p.2) := by
-    simp only [Finset.mem_filter, Finset.mem_product, Finset.mem_univ, true_and]
-    exact ⟨Fin.zero_lt_one, Fin.zero_ne_one⟩
+    refine Finset.mem_filter.mpr ⟨Finset.mem_univ _, ?_, ?_⟩
+    · decide
+    · exact (show (0 : Fin 2) ≠ 1 by decide)
   exact Finset.card_pos.mpr ⟨_, hmem⟩
 
 /-- K₂ is connected (trivially: the two vertices are adjacent). -/
@@ -151,7 +151,7 @@ lemma completeGraph2_connected : completeGraph2.Connected := by
   fin_cases u <;> fin_cases v
   · exact Relation.ReflTransGen.refl
   · exact Relation.ReflTransGen.single (show completeGraph2.adj 0 1 from Fin.zero_ne_one)
-  · exact Relation.ReflTransGen.single (show completeGraph2.adj 1 0 from Fin.one_ne_zero)
+  · exact Relation.ReflTransGen.single (show completeGraph2.adj 1 0 from (show (1 : Fin 2) ≠ 0 by decide))
   · exact Relation.ReflTransGen.refl
 
 -- ## Part VI: Proved Bounds
@@ -170,7 +170,9 @@ theorem bigF_lower_bound_tree (n : ℕ) (hn : n ≥ 2) :
   · -- n - 1 ∈ the set
     constructor
     · -- n - 1 ≤ n*(n-1)/2 for n ≥ 2
-      omega
+      rw [Nat.le_div_iff_mul_le (by norm_num : (0:ℕ) < 2)]
+      calc (n - 1) * 2 = 2 * (n - 1) := by ring
+        _ ≤ n * (n - 1) := mul_le_mul_right' hn (n - 1)
     · intro G hConn hEdge
       have hge := connected_min_edges G (by omega) hConn
       have heq : edgeCount G = n - 1 := Nat.le_antisymm hEdge hge
@@ -220,7 +222,7 @@ theorem bigF_val_2 : bigF_threshold 2 = 1 := by
   have hbdd : BddAbove { e : ℕ | e ≤ 2 * (2 - 1) / 2 ∧
       ∀ G : Graph 2, G.Connected → edgeCount G ≤ e →
         graphRamseyK3 G = 2 * 2 - 1 } :=
-    ⟨1, fun _ he => by omega⟩
+    ⟨1, fun _ he => by obtain ⟨hle, _⟩ := he; omega⟩
   apply le_antisymm
   · -- sSup ≤ 1
     apply csSup_le ⟨1, hmem_1⟩

--- a/proofs/Proofs/Erdos733Problem.lean
+++ b/proofs/Proofs/Erdos733Problem.lean
@@ -45,6 +45,10 @@ A finite set of n points in the plane ℝ².
 -/
 abbrev PointSet := Finset (ℝ × ℝ)
 
+-- v4.31: `P.filter (· ∈ L)` for a `Set` predicate needs a `DecidablePred` instance
+-- that ambient Classical no longer supplies implicitly.
+attribute [local instance] Classical.propDecidable
+
 /--
 **Line through two points:**
 Given two distinct points, the line through them.
@@ -58,7 +62,7 @@ def lineThrough (p q : ℝ × ℝ) : Set (ℝ × ℝ) :=
 **Points on a line:**
 Given a line (as a set) and a point configuration, count the incidences.
 -/
-def pointsOnLine (P : PointSet) (L : Set (ℝ × ℝ)) : ℕ :=
+noncomputable def pointsOnLine (P : PointSet) (L : Set (ℝ × ℝ)) : ℕ :=
   (P.filter (· ∈ L)).card
 
 /--
@@ -83,7 +87,7 @@ The sequence records the multiplicities of points on lines.
 -/
 def isLineCompatible (seq : List ℕ) (n : ℕ) : Prop :=
   -- The sequence is sorted and entries are in [2, n]
-  seq.Sorted (· ≤ ·) ∧
+  seq.Pairwise (· ≤ ·) ∧
   (∀ x ∈ seq, 2 ≤ x ∧ x ≤ n) ∧
   -- There exists an n-point configuration realizing this sequence
   ∃ P : PointSet, P.card = n ∧
@@ -215,7 +219,7 @@ theorem erdos_733 :
   intro n hn
   constructor
   · exact hlower n hn
-  · exact hupper n (Nat.one_lt_of_ne_one (by omega))
+  · exact hupper n (by omega)
 
 /-
 ## Part VII: The Limit Question
@@ -228,19 +232,19 @@ Erdős asked about the limiting constant.
 Does lim_{n→∞} (log f(n)) / √n exist? If so, what is its value?
 -/
 def limitConstant : Prop :=
-  ∃ λ : ℝ, Filter.Tendsto
+  ∃ L : ℝ, Filter.Tendsto
     (fun n : ℕ => Real.log (countLineCompatible n) / Real.sqrt n)
     Filter.atTop
-    (nhds λ)
+    (nhds L)
 
 /--
 **The Limit Exists:**
 By the tight bounds, the limit (if it exists) is between c and C.
 -/
 theorem limit_bounds :
-  ∀ λ : ℝ, (∃ ε : ℝ, ε > 0 ∧ ∀ n : ℕ, n ≥ 4 →
-    |Real.log (countLineCompatible n) / Real.sqrt n - λ| < ε) →
-  ∃ c C : ℝ, c > 0 ∧ C > 0 ∧ c ≤ λ ∧ λ ≤ C := by
+  ∀ L : ℝ, (∃ ε : ℝ, ε > 0 ∧ ∀ n : ℕ, n ≥ 4 →
+    |Real.log (countLineCompatible n) / Real.sqrt n - L| < ε) →
+  ∃ c C : ℝ, c > 0 ∧ C > 0 ∧ c ≤ L ∧ L ≤ C := by
   sorry
 
 /-

--- a/proofs/Proofs/PtolemysTheoremOQ01Incomplete01.lean
+++ b/proofs/Proofs/PtolemysTheoremOQ01Incomplete01.lean
@@ -1,3 +1,9 @@
+import Proofs.PtolemysTheoremOQ01
+import Proofs.PtolemysComplexProofOQ01
+import Proofs.PtolemysComplexProof
+import Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic
+import Mathlib.Tactic
+
 /-!
 # Completing the Ptolemy Concyclicity Characterization (OQ-01 Incomplete-01)
 
@@ -54,12 +60,6 @@ Given Ptolemy equality for distinct unit-circle points:
   (2) 8-case sign analysis was already in place from prior work
 -/
 
-import Proofs.PtolemysTheoremOQ01
-import Proofs.PtolemysComplexProofOQ01
-import Proofs.PtolemysComplexProof
-import Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic
-import Mathlib.Tactic
-
 /-- v4.31 compat shim: `Complex.abs` was removed from Mathlib (use `‖·‖`). -/
 noncomputable def Complex.abs (z : ℂ) : ℝ := ‖z‖
 
@@ -75,8 +75,7 @@ namespace PtolemysTheoremOQ01Incomplete01
 /-- Every unit-circle point equals exp(i·arg(z)). -/
 private lemma unit_circle_eq_exp_arg (z : ℂ) (hz : ‖z‖ = 1) :
     z = Complex.exp (↑(Complex.arg z) * Complex.I) := by
-  have habs : Complex.abs z = 1 := by rwa [Complex.norm_eq_abs] at hz
-  conv_lhs => rw [← Complex.abs_mul_exp_arg_mul_I z, habs]
+  conv_lhs => rw [← Complex.norm_mul_exp_arg_mul_I z, hz]
   simp
 
 /-- For distinct unit-circle points, their args are distinct. -/
@@ -95,19 +94,22 @@ private lemma sin_half_ne_zero_of_ne {θ φ : ℝ}
     (hbnd : (θ - φ) ∈ Set.Ioo (-(2 * Real.pi)) (2 * Real.pi)) :
     Real.sin ((θ - φ) / 2) ≠ 0 := by
   rw [Real.sin_ne_zero_iff]
-  intro ⟨n, hn⟩
+  intro n hn
   have hpi : 0 < Real.pi := Real.pi_pos
   have : (θ - φ) / 2 ∈ Set.Ioo (-Real.pi) Real.pi := by
     constructor <;> [linarith [hbnd.1]; linarith [hbnd.2]]
   have hn0 : n = 0 := by
     have hlo : -Real.pi < ↑n * Real.pi := by rw [hn]; linarith [this.1]
     have hhi : ↑n * Real.pi < Real.pi := by rw [hn]; linarith [this.2]
-    have : (-1 : ℤ) < n := by
-      apply Int.cast_lt (R := ℝ) |>.mp; push_cast; linarith
-    have : n < (1 : ℤ) := by
-      apply Int.cast_lt (R := ℝ) |>.mp; push_cast; linarith
+    have hlb : (-1 : ℤ) < n := by
+      have : (-1 : ℝ) < (n : ℝ) := by nlinarith [hlo, hhi, hpi]
+      exact_mod_cast this
+    have hub : n < (1 : ℤ) := by
+      have : (n : ℝ) < 1 := by nlinarith [hlo, hhi, hpi]
+      exact_mod_cast this
     omega
-  simp [hn0] at hn; linarith
+  simp only [hn0, Int.cast_zero, zero_mul] at hn
+  exact hne (by linarith)
 
 /-- For args θ, φ ∈ (-π, π] with θ ≠ φ:
     sin((θ-φ)/2) > 0 iff θ > φ,  sin((θ-φ)/2) < 0 iff θ < φ. -/
@@ -125,9 +127,9 @@ private lemma sin_half_sign_iff {θ φ : ℝ}
       by_contra h'
       push_neg at h'
       have : Real.sin ((θ - φ) / 2) ≤ 0 := by
-        apply Real.sin_nonpos_of_nonneg_of_nonpos
-        · linarith [hrange.1]
+        apply Real.sin_nonpos_of_nonpos_of_neg_pi_le
         · linarith
+        · linarith [hrange.1]
       linarith
     · intro h
       apply Real.sin_pos_of_pos_of_lt_pi
@@ -182,9 +184,11 @@ private lemma t_eq_sine_ratio {θ₁ θ₂ θ₃ θ₄ : ℝ} {t : ℝ}
     have h2isin : Complex.exp (↑((a - b) / 2) * Complex.I) -
                   Complex.exp (-(↑((a - b) / 2) * Complex.I)) =
                   2 * Complex.I * ↑(Real.sin ((a - b) / 2)) := by
-      rw [show -(↑((a - b) / 2) : ℂ) * Complex.I = ↑(-((a - b) / 2)) * Complex.I from by push_cast; ring]
-      simp only [Complex.exp_mul_I, Real.cos_neg, Real.sin_neg]
-      push_cast; ring
+      rw [show -(↑((a - b) / 2) * Complex.I) = (-↑((a - b) / 2) : ℂ) * Complex.I from by ring,
+          Complex.exp_mul_I, Complex.exp_mul_I, Complex.cos_neg, Complex.sin_neg]
+      simp only [← Complex.ofReal_sin, ← Complex.ofReal_cos]
+      push_cast
+      ring
     rw [h2isin]; ring
   -- Phase cancellation: E₂₃·E₁₄ = E₁₂·E₃₄
   have hE : Complex.exp (↑((θ₂ + θ₃) / 2) * Complex.I) *
@@ -266,9 +270,11 @@ theorem ptolemy_equality_implies_ccw_or_cw (z₁ z₂ z₃ z₄ : ℂ)
                 ‖z₁ - z₂‖ * ‖z₃ - z₄‖ + ‖z₂ - z₃‖ * ‖z₁ - z₄‖) :
     IsCCWOrder z₁ z₂ z₃ z₄ ∨ IsCCWOrder z₁ z₄ z₃ z₂ := by
   -- Step 1: Ptolemy equality → ∃ t > 0, (z₂-z₃)(z₁-z₄) = t·(z₁-z₂)(z₃-z₄)
-  obtain ⟨t, ht_pos, ht_eq⟩ :=
+  obtain ⟨t, ht_pos, ht_eq0⟩ :=
     ptolemy_equality_implies_proportional z₁ z₂ z₃ z₄
-      hdenom hnumer hptolemy
+      hptolemy hdenom hnumer
+  rw [Complex.real_smul] at ht_eq0
+  have ht_eq := ht_eq0.symm
   -- Step 2: Extract angles θₖ = arg(zₖ) ∈ (-π, π]
   set θ₁ := Complex.arg z₁; set θ₂ := Complex.arg z₂
   set θ₃ := Complex.arg z₃; set θ₄ := Complex.arg z₄
@@ -357,7 +363,7 @@ theorem ptolemy_equality_implies_ccw_or_cw (z₁ z₂ z₃ z₄ : ℂ)
       have hθ₄₃ : θ₄ < θ₃ := hsgn₃₄.1.mp hs₃₄p
       -- θ₄ < θ₃ < θ₂ < θ₁; CW: witnesses (θ₁-2π, θ₄, θ₃, θ₂) for IsCCWOrder z₁ z₄ z₃ z₂
       exact Or.inr ⟨θ₁ - 2 * Real.pi, θ₄, θ₃, θ₂,
-        by linarith, by linarith, by linarith, by linarith,
+        by linarith [hθ₄_bd.1, hθ₁_bd.2, hπ], by linarith, by linarith, by linarith,
         by rw [hexp_sub2pi]; exact hz₁,
         hz₄, hz₃, hz₂⟩
     · -- B: s₂₃>0, s₁₄>0, s₁₂<0, s₃₄<0 → θ₃<θ₄<θ₁<θ₂ → CCW (IsCCWOrder z₁ z₂ z₃ z₄)
@@ -476,13 +482,19 @@ theorem ptolemy_equality_iff_ccw_or_cw (z₁ z₂ z₃ z₄ : ℂ)
   · -- (←) CCW or CW → Ptolemy equality
     rintro (hccw | hcw)
     · -- CCW → Ptolemy (from PtolemysTheoremOQ01)
-      obtain ⟨t, ht_pos, ht_eq⟩ := ptolemy_ratio_pos_of_ccw z₁ z₂ z₃ z₄ hccw
+      obtain ⟨t, ht_pos, ht_eq⟩ :=
+        ptolemy_ratio_pos_of_ccw z₁ z₂ z₃ z₄ h₁ h₂ h₃ h₄ hdenom hnumer hccw
       exact ptolemy_equality_of_proportional z₁ z₂ z₃ z₄ t ht_pos.le ht_eq
     · -- CW → Ptolemy: apply the CCW Ptolemy result to the reversed labeling (z₁ z₄ z₃ z₂)
       -- ptolemy_ratio_pos_of_ccw z₁ z₄ z₃ z₂ gives (z₄-z₃)(z₁-z₂) = t·(z₁-z₄)(z₃-z₂)
       -- ptolemy_equality_of_proportional z₁ z₄ z₃ z₂ gives ‖z₁-z₃‖·‖z₄-z₂‖ = ‖z₁-z₄‖·‖z₃-z₂‖ + ‖z₄-z₃‖·‖z₁-z₂‖
       -- which equals the target by norm_sub_rev and commutativity
-      obtain ⟨t, ht_pos, ht_eq⟩ := ptolemy_ratio_pos_of_ccw z₁ z₄ z₃ z₂ hcw
+      have hdenom' : (z₁ - z₄) * (z₃ - z₂) ≠ 0 :=
+        mul_ne_zero (sub_ne_zero.mpr hdist₁₄) (sub_ne_zero.mpr hdist₂₃.symm)
+      have hnumer' : (z₄ - z₃) * (z₁ - z₂) ≠ 0 :=
+        mul_ne_zero (sub_ne_zero.mpr hdist₃₄.symm) (sub_ne_zero.mpr hdist₁₂)
+      obtain ⟨t, ht_pos, ht_eq⟩ :=
+        ptolemy_ratio_pos_of_ccw z₁ z₄ z₃ z₂ h₁ h₄ h₃ h₂ hdenom' hnumer' hcw
       have h := ptolemy_equality_of_proportional z₁ z₄ z₃ z₂ t ht_pos.le ht_eq
       -- h : ‖z₁-z₃‖*‖z₄-z₂‖ = ‖z₁-z₄‖*‖z₃-z₂‖ + ‖z₄-z₃‖*‖z₁-z₂‖
       rw [norm_sub_rev z₄ z₂, norm_sub_rev z₃ z₂, norm_sub_rev z₄ z₃] at h

--- a/proofs/batch2/STATUS.md
+++ b/proofs/batch2/STATUS.md
@@ -1,4 +1,88 @@
-# DOCTOR INCREMENT 63 (deep-rework partition B: N–Z + Erdos ≥ 600, #38065, 2026-07-15)
+# DOCTOR INCREMENT 65 (deep-rework partition B: N–Z + Erdos ≥ 600, #38065, 2026-07-15)
+
+Container `dr65` (cpus 0-5, 11g, cache v431), worktree issue-38065, branch
+`feature/issue-38065-inc65` off origin/feature/issue-37508 (base 2015 GREEN /
+620 RESIDUAL). Worked the inc-63 warm leads + a low-error family. Every file was
+5–14 real errors (confirms deep-rework). **+6 GREEN.** PR #38668. All flips
+in-container `lake build Proofs.X` exit-0 before ledger flip; pushed per file.
+
+## Flips (failure class in parens)
+- Erdos1034Problem (unknown-const → forward-ref+autobound+universe): reorder
+  maTang* above erdos_faudree_false and fully_adjacent_is_good above
+  book_pages_are_good (in-file forward-refs hard-error); **auto-bound `G` in
+  `def Triangle.vertices (T : Triangle G)` does NOT pull `variable [DecidableEq V]`**
+  → explicit `{G : SimpleGraph V}` binder restores the Finset-singleton instance;
+  **`sSup {k | isValidBound n k}` with `isValidBound : Type*`-polymorphic ⇒
+  universe-level metavariables in `def h`** → pin `isValidBound.{0}`; `exact?`→`rfl`;
+  explicit `Finset.filter_subset` predicate; fully-explicit `@hN_conj` instance
+  application + nlinarith product hint.
+- PtolemysTheoremOQ01Incomplete01 (elab-drift → import-order + API + imported-sig):
+  move imports above the module docstring (import must precede all content);
+  `Complex.abs_mul_exp_arg_mul_I`→`Complex.norm_mul_exp_arg_mul_I`;
+  `Real.sin_nonpos_of_nonneg_of_nonpos`→`Real.sin_nonpos_of_nonpos_of_neg_pi_le`
+  (arg order nonpos-first); **`Real.sin_ne_zero_iff` is now `∀ n:ℤ, (n:ℝ)*π ≠ x`**
+  (a forall, not exists-negation) → `intro n hn` + nlinarith for the n-bound
+  (linarith cannot divide by π); h2isin: keep the negation on the COMPLEX number and
+  use `Complex.cos_neg`/`sin_neg` then bridge via `ofReal_cos`/`ofReal_sin`
+  (push_cast fragments the coerced arg); **imported-lemma signature drift** —
+  `ptolemy_equality_implies_proportional` now takes the equality first and returns
+  `t • X` (add `Complex.real_smul` + `.symm`), `ptolemy_ratio_pos_of_ccw` gained
+  norm+denom/numer hyps before hccw (supply at both call sites; reversed-labeling
+  denom'/numer' for the CW branch).
+- Erdos1039Aristotle (unknown-const; Aristotle companion, 0 pre-existing sorries):
+  `Erdos1039.Complex.abs` removed from the imported problem → local root
+  `Complex.abs` shim; `exact?`→`exact degree_one_sublevel_eq_ari f hf`; **`.abs`
+  (= ‖·‖) defeq gaps**: unfold `Complex.abs` in closing simp, close convert-residual
+  `ball = setOf` via `ext`+`Metric.mem_ball`/`dist_eq_norm`, `simpa` to bridge
+  `‖z-c‖<1` ↔ `z ∈ ball`; `Complex.norm_exp_ofReal_mul_I` no longer matches
+  `2πik/n` → reuse the `norm_exp` + purely-imaginary-re=0 pattern.
+- Erdos733Problem + Erdos733LimitBounds (unknown-const, family; LimitBounds imports
+  the parent so the parent fix clears both): `List.Sorted`→`List.Pairwise`;
+  **`λ` is now a reserved keyword and cannot bind a variable** (`∃/∀ λ : ℝ`) → rename
+  to `L`; `Nat.one_lt_of_ne_one` removed → `(by omega)`; `P.filter (· ∈ L)` for a
+  Set predicate needs `DecidablePred` not supplied by ambient Classical →
+  `attribute [local instance] Classical.propDecidable` (no native_decide in file) +
+  mark `pointsOnLine` noncomputable.
+- Erdos1182Problem (unknown-const → Finset.product mem-drift + Fin/decide + Nat-div):
+  **`Finset.univ.product Finset.univ` no longer matches `Finset.mem_product` simp**
+  (`univ ×ˢ univ` is definitionally `univ`, but the `.product` term is not the `×ˢ`
+  the lemma is stated for) → destructure via `Finset.mem_filter.mp`/`.mpr` +
+  `Finset.mem_univ`, drop `mem_product` from the simp set; **`decide` cannot see
+  through an opaque structure field of `Prop` type** (`Graph.adj : Fin n → Fin n →
+  Prop`, def'd `fun a b => a ≠ b`) — no Decidable instance from the projection →
+  `(show (i:Fin 2) ≠ j by decide)` bridges via defeq; `Fin.one_ne_zero` removed;
+  omega can't do `n-1 ≤ n*(n-1)/2` → `Nat.le_div_iff_mul_le` + `mul_le_mul_right'`;
+  BddAbove-witness omega needs the setOf membership destructured first.
+
+## New systematic seams (rename-map §7ai candidates)
+1. **`Finset.s.product t` ↛ `Finset.mem_product` simp**: `univ.product univ`
+   reduces to `univ` (so `Finset.mem_univ _` proves membership directly), and the
+   `.product` term does not match the `s ×ˢ t`-stated `Finset.mem_product` — a
+   `simp only [Finset.mem_product]` makes NO progress. Fix: `Finset.mem_filter.mp/.mpr`
+   with `Finset.mem_univ`, not the mem_product simp set.
+2. **`decide` can't pierce an opaque `Prop`-valued structure field**: for
+   `structure Graph where adj : … → Prop`, `decide` on `G.adj a b` fails (no
+   Decidable synth from the projection) even when the concrete def is `a ≠ b`. Fix:
+   `show <concrete decidable Prop> by decide` to unify through defeq.
+3. **`λ` is a reserved keyword**: `∃ λ : ℝ, …` / `∀ λ : ℝ, …` now parse-error
+   ("unexpected token 'λ'"). Rename the bound variable.
+4. **`Real.sin_ne_zero_iff` is a `∀`** (`∀ n:ℤ, (n:ℝ)*π ≠ x`), not an exists-negation
+   → `intro n hn`; the n-bound needs nlinarith (linarith cannot divide by π).
+5. **`Complex.abs_mul_exp_arg_mul_I`→`Complex.norm_mul_exp_arg_mul_I`**;
+   **`Real.sin_nonpos_of_nonneg_of_nonpos`→`Real.sin_nonpos_of_nonpos_of_neg_pi_le`**
+   (args: nonpos first, then `-π ≤ x`).
+6. **Auto-bound `G` in `def T.foo (x : Struct G)` drops `variable` instance-binders**:
+   the auto-bound `V` (via `G`) does not inherit `[DecidableEq V]` → write `{G : … V}`
+   explicitly so the declared `variable {V} [DecidableEq V]` is used.
+7. **Universe metavars from `sSup`/set-builder over a `Type*`-polymorphic Prop**
+   (`{k | isValidBound n k}`) → pin the universe at the use site (`isValidBound.{0}`).
+8. **Migrated imported lemmas change signatures** (arg order, `•` vs `*`, added
+   hypotheses) — always re-grep the current signature of any cross-file lemma before
+   trusting an old call.
+
+Ledger after increment 65: 2021 GREEN / 614 RESIDUAL.
+
+
 
 Container `dr63` (cpus 0-5, 11g, cache v431), worktree issue-38065, branch
 `feature/issue-38065-inc63` off origin/feature/issue-37508 (base 2004 GREEN /

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -895,7 +895,7 @@ Erdos1179OQ02Witness	GREEN
 Erdos1179Problem	GREEN	
 Erdos117Problem	GREEN	
 Erdos1181Problem	RESIDUAL	unknown-const:Real.tendsto_log_div_rpow_atTop
-Erdos1182Problem	RESIDUAL	unknown-const:Fin.one_ne_zero
+Erdos1182Problem	GREEN	doctor-inc65
 Erdos1183Problem	GREEN	
 Erdos118Problem	GREEN	
 Erdos1196Problem	GREEN	

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -702,7 +702,7 @@ Erdos1033Aristotle	GREEN
 Erdos1033Problem	RESIDUAL	unknown-const:fan_lower
 Erdos1034Aristotle	GREEN	
 Erdos1034OQ02	GREEN	
-Erdos1034Problem	RESIDUAL	unknown-const:maTang_counterexample
+Erdos1034Problem	GREEN	doctor-inc65
 Erdos1035Problem	RESIDUAL	instance-synth
 Erdos1036OQ01	GREEN	
 Erdos1036OQ01OQ01	GREEN	

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -709,7 +709,7 @@ Erdos1036OQ01OQ01	GREEN
 Erdos1036Problem	GREEN	
 Erdos1038Problem	GREEN	
 Erdos1038WIP01	GREEN	
-Erdos1039Aristotle	RESIDUAL	unknown-const:Erdos1039.Complex.abs
+Erdos1039Aristotle	GREEN	doctor-inc65
 Erdos1039Conformal	GREEN	
 Erdos1039ProblemAristotle	RESIDUAL	type-mismatch
 Erdos103OQ02Bounds	GREEN	

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -2335,7 +2335,7 @@ ProductOfSegmentsOfChordsConverse	GREEN
 ProductOfSegmentsOfChordsOQ01	GREEN	
 PropertyBFirstMomentRecoloring	GREEN	unknown-const:Finset.exists_ne_of_one_lt_card
 PtolemysComplexProofOQ02	RESIDUAL	unknown-const:Real.cos_eq_one_iff.mp
-PtolemysTheoremOQ01Incomplete01	RESIDUAL	elab-drift
+PtolemysTheoremOQ01Incomplete01	GREEN	doctor-inc65
 PtolemysTheoremOQ01OQ01	GREEN	
 PtolemysTheoremOQ01OQ02	GREEN	v4.31-migrated
 PuiseuxTheorem	GREEN	

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -1633,8 +1633,8 @@ Erdos72Problem	GREEN
 Erdos730Problem	RESIDUAL	rewrite-drift
 Erdos731Problem	GREEN	
 Erdos732Problem	RESIDUAL	instance-synth
-Erdos733LimitBounds	RESIDUAL	unknown-const:Nat.one_lt_of_ne_one
-Erdos733Problem	RESIDUAL	unknown-const:Nat.one_lt_of_ne_one
+Erdos733LimitBounds	GREEN	doctor-inc65
+Erdos733Problem	GREEN	doctor-inc65
 Erdos734Problem	GREEN	
 Erdos736Problem	GREEN	
 Erdos737Problem	GREEN	


### PR DESCRIPTION
Deep-rework tail grind (epic #37508, ledger #38065), partition B (N–Z + Erdos≥600).

Each file verified green in-container (`lake build Proofs.X` exit-0) before flipping its ledger row RESIDUAL→GREEN. Base = feature/issue-37508.

## Flips
- **Erdos1034Problem** (unknown-const → forward-refs + autobound + universe): reorder maTang* above erdos_faudree_false & fully_adjacent_is_good above book_pages_are_good; explicit `{G : SimpleGraph V}` binder restores `[DecidableEq V]` for Finset singleton; `isValidBound.{0}` universe pin in `def h`; `exact?`→`rfl`; explicit filter predicate; `@hN_conj` explicit instances + nlinarith product hint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)