### PR TITLE
migrate(v4.31): Doctor increment 69 — deep-rework partition B (+6 GREEN)

### DIFF
--- a/proofs/Proofs/Erdos1052Problem.lean
+++ b/proofs/Proofs/Erdos1052Problem.lean
@@ -156,15 +156,15 @@ private lemma gcd_mul_left_eq {d₁ d₂ m : ℕ} (hd₁ : d₁ ∣ m) (hcop : d
 private lemma div_gcd_dvd_right {m n d : ℕ} (hm : 0 < m) (hcop : m.Coprime n) (hd : d ∣ m * n) :
     d / d.gcd m ∣ n := by
   have hg_pos : 0 < d.gcd m := by
-    rcases Nat.eq_or_lt_of_le (Nat.zero_le (d.gcd m)) with h | h
-    · rw [← h, Nat.gcd_eq_zero_iff] at *; omega
-    · exact h
+    rcases Nat.eq_zero_or_pos (d.gcd m) with hz | hpos
+    · rw [Nat.gcd_eq_zero_iff] at hz; omega
+    · exact hpos
   have hcop_quot := Nat.coprime_div_gcd_div_gcd hg_pos
   have hdg : d.gcd m ∣ d := Nat.gcd_dvd_left d m
   have hgm : d.gcd m ∣ m := Nat.gcd_dvd_right d m
   have h1 : d / d.gcd m ∣ (m / d.gcd m) * n := by
     have : d.gcd m * (d / d.gcd m) ∣ d.gcd m * ((m / d.gcd m) * n) := by
-      rw [Nat.mul_div_cancel' hgm, ← mul_assoc, Nat.mul_div_cancel' hdg]
+      rw [← mul_assoc, Nat.mul_div_cancel' hgm, Nat.mul_div_cancel' hdg]
       exact hd
     exact (Nat.mul_dvd_mul_iff_left hg_pos).mp this
   exact hcop_quot.dvd_of_dvd_mul_left h1
@@ -175,14 +175,14 @@ private lemma gcd_coprime_div_of_unitary {m n d : ℕ} (hm : 0 < m) (hn : 0 < n)
     (hcop : m.Coprime n) (hd : d ∣ m * n) (hunit : d.Coprime (m * n / d)) :
     (d.gcd m).Coprime (m / d.gcd m) := by
   have hg_pos : 0 < d.gcd m := by
-    rcases Nat.eq_or_lt_of_le (Nat.zero_le (d.gcd m)) with h | h
-    · rw [← h, Nat.gcd_eq_zero_iff] at *; omega
-    · exact h
+    rcases Nat.eq_zero_or_pos (d.gcd m) with hz | hpos
+    · rw [Nat.gcd_eq_zero_iff] at hz; omega
+    · exact hpos
   have h1 : (d.gcd m).Coprime (m * n / d) :=
     hunit.coprime_dvd_left (Nat.gcd_dvd_left d m)
   have h_div_n := div_gcd_dvd_right hm hcop hd
   have h2 : m / d.gcd m ∣ m * n / d := by
-    conv_lhs => rw [show d = d.gcd m * (d / d.gcd m) from
+    conv_rhs => rw [show d = d.gcd m * (d / d.gcd m) from
       (Nat.mul_div_cancel' (Nat.gcd_dvd_left d m)).symm]
     rw [Nat.mul_div_mul_comm (Nat.gcd_dvd_right d m) h_div_n]
     exact dvd_mul_right _ _
@@ -194,14 +194,14 @@ private lemma div_gcd_coprime_div_of_unitary {m n d : ℕ} (hm : 0 < m) (hn : 0 
     (hcop : m.Coprime n) (hd : d ∣ m * n) (hunit : d.Coprime (m * n / d)) :
     (d / d.gcd m).Coprime (n / (d / d.gcd m)) := by
   have hg_pos : 0 < d.gcd m := by
-    rcases Nat.eq_or_lt_of_le (Nat.zero_le (d.gcd m)) with h | h
-    · rw [← h, Nat.gcd_eq_zero_iff] at *; omega
-    · exact h
+    rcases Nat.eq_zero_or_pos (d.gcd m) with hz | hpos
+    · rw [Nat.gcd_eq_zero_iff] at hz; omega
+    · exact hpos
   have h1 : (d / d.gcd m).Coprime (m * n / d) :=
     hunit.coprime_dvd_left (Nat.div_dvd_of_dvd (Nat.gcd_dvd_left d m))
   have h_div_n := div_gcd_dvd_right hm hcop hd
   have h2 : n / (d / d.gcd m) ∣ m * n / d := by
-    conv_lhs => rw [show d = d.gcd m * (d / d.gcd m) from
+    conv_rhs => rw [show d = d.gcd m * (d / d.gcd m) from
       (Nat.mul_div_cancel' (Nat.gcd_dvd_left d m)).symm]
     rw [Nat.mul_div_mul_comm (Nat.gcd_dvd_right d m) h_div_n]
     exact dvd_mul_left _ _
@@ -275,6 +275,7 @@ theorem unitaryDivisorSum_prime_pow {p k : ℕ} (hp : p.Prime) (hk : 0 < k) :
   unfold unitaryDivisorSum
   rw [unitaryDivisors_primePow hp hk,
     Finset.sum_pair (ne_of_lt (Nat.one_lt_pow hk.ne' hp.one_lt))]
+  simp
 
 /-- The unitary divisor sum is multiplicative for coprime arguments.
     Proof via bijection: unitary divisors of m*n biject with pairs of
@@ -288,8 +289,8 @@ theorem unitaryDivisorSum_mul_coprime {m n : ℕ} (hm : 0 < m) (hn : 0 < n) (hco
   -- Step 1: Bijection: S_mn.sum id = (S_m ×ˢ S_n).sum (fun p => p.1 * p.2)
   -- Step 2: Algebra: (S_m ×ˢ S_n).sum (fun p => p.1 * p.2) = S_m.sum id * S_n.sum id
   suffices h : S_mn.sum id = (S_m ×ˢ S_n).sum (fun p : ℕ × ℕ => p.1 * p.2) by
-    rw [h, Finset.sum_product']; simp only [id]
-    simp_rw [← Finset.mul_sum, ← Finset.sum_mul]
+    rw [h, Finset.sum_product', Finset.sum_mul_sum]
+    simp only [id]
   -- Establish bijection
   apply Finset.sum_nbij' (fun d => (d.gcd m, d / d.gcd m)) (fun p => p.1 * p.2)
   · -- Forward: d ∈ S_mn → (gcd(d,m), d/gcd(d,m)) ∈ S_m ×ˢ S_n
@@ -298,9 +299,9 @@ theorem unitaryDivisorSum_mul_coprime {m n : ℕ} (hm : 0 < m) (hn : 0 < n) (hco
     obtain ⟨⟨hd_pos, hd_le⟩, hd_dvd, hd_cop⟩ := hd
     rw [Finset.mem_product]
     have hg_pos : 0 < d.gcd m := by
-      rcases Nat.eq_or_lt_of_le (Nat.zero_le (d.gcd m)) with h | h
-      · rw [← h, Nat.gcd_eq_zero_iff] at *; omega
-      · exact h
+      rcases Nat.eq_zero_or_pos (d.gcd m) with hz | hpos
+      · rw [Nat.gcd_eq_zero_iff] at hz; omega
+      · exact hpos
     have h_div_n := div_gcd_dvd_right hm hcop hd_dvd
     have h_gcd_cop := gcd_coprime_div_of_unitary hm hn hcop hd_dvd hd_cop
     have h_div_cop := div_gcd_coprime_div_of_unitary hm hn hcop hd_dvd hd_cop
@@ -323,7 +324,8 @@ theorem unitaryDivisorSum_mul_coprime {m n : ℕ} (hm : 0 < m) (hn : 0 < n) (hco
     obtain ⟨⟨hd₂_pos, hd₂_le⟩, hd₂_dvd, hd₂_cop⟩ := hd₂_mem
     simp only [S_mn, Finset.mem_filter, Finset.mem_Ico]
     have hd₁d₂_dvd : d₁ * d₂ ∣ m * n := Nat.mul_dvd_mul hd₁_dvd hd₂_dvd
-    refine ⟨⟨by omega, Nat.lt_succ_of_le (Nat.le_of_dvd (by omega) hd₁d₂_dvd)⟩,
+    refine ⟨⟨Nat.mul_pos hd₁_pos hd₂_pos,
+        Nat.lt_succ_of_le (Nat.le_of_dvd (Nat.mul_pos hm hn) hd₁d₂_dvd)⟩,
       hd₁d₂_dvd, ?_⟩
     rw [Nat.mul_div_mul_comm hd₁_dvd hd₂_dvd]
     have hd₁_cop_n : d₁.Coprime (n / d₂) :=
@@ -385,7 +387,9 @@ private lemma coprime_pow_factorization_div {p n : ℕ} (hp : p.Prime) (hn : n �
       (Nat.mul_div_cancel' hpow).symm
     have h_dvd : p ^ (n.factorization p + 1) ∣ n := by
       obtain ⟨k, hk⟩ := hp_dvd
-      exact ⟨k, by conv_lhs => rw [hdecomp, hk]; rw [pow_succ]; ring⟩
+      refine ⟨k, ?_⟩
+      rw [pow_succ, mul_assoc, ← hk]
+      exact hdecomp
     exact absurd ((Nat.Prime.pow_dvd_iff_le_factorization hp hn).mp h_dvd) (by omega)
   exact hbase.pow_left _
 
@@ -403,7 +407,7 @@ private lemma unitaryDivisorSum_eq_proper_add (n : ℕ) (hn : 0 < n) :
   have h_not_mem : n ∉ (Finset.Ico 1 n).filter (fun d => d ∣ n ∧ d.Coprime (n / d)) := by
     intro h; have := (Finset.mem_filter.mp h).1; rw [Finset.mem_Ico] at this; omega
   rw [h_eq, Finset.filter_insert, if_pos h_sat, Finset.sum_insert h_not_mem]
-  omega
+  simp only [id_eq]; omega
 
 /-- σ*(m) is even for any odd m > 1: m has an odd prime factor p,
     and σ*(p^a) = 1 + p^a is even, making the product even via multiplicativity. -/
@@ -490,9 +494,11 @@ theorem even_of_isUnitaryPerfect (n : ℕ) (hn : IsUnitaryPerfect n) : Even n :=
     obtain ⟨r, hr⟩ := hpa_odd; exact ⟨r + 1, by omega⟩
   by_cases hm1 : m = 1
   · -- n = p^a: (1 + p^a) * 1 = 2 * p^a, so p^a = 1, impossible
-    rw [hm1, unitaryDivisorSum_one, mul_one, hn_eq, hm1, mul_one] at h_eq
-    have : 2 ≤ p ^ (n.factorization p) :=
-      le_trans hp_prime.two_le (le_self_pow ha_pos.ne' p)
+    set P := p ^ (n.factorization p) with hP
+    rw [hm1, unitaryDivisorSum_one, mul_one] at h_eq
+    have hn1 : n = P := by rw [hn_eq, hm1, mul_one]
+    rw [hn1] at h_eq
+    have hP2 : 2 ≤ P := le_trans hp_prime.two_le (Nat.le_self_pow ha_pos.ne' p)
     omega
   · -- m > 1 and odd: both factors even, so 4 | 2n, hence 2 | n
     have hm_gt1 : 1 < m := by omega

--- a/proofs/Proofs/Erdos1061Problem.lean
+++ b/proofs/Proofs/Erdos1061Problem.lean
@@ -61,7 +61,7 @@ theorem sigma_val_21 : sigma 1 21 = 32 := by native_decide
 
 /-- sigma(p) = p + 1 for prime p -/
 theorem sigma_prime' (p : ℕ) (hp : p.Prime) : sigma 1 p = p + 1 := by
-  simp [sigma_apply, hp.divisors]
+  rw [sigma_one_apply, hp.divisors, Finset.sum_pair hp.one_lt.ne]
   omega
 
 /-
@@ -141,10 +141,8 @@ this family alone contributes linearly many solutions.
 theorem sigma_add_eq_coprime6 (a : ℕ) (ha : a ≠ 0)
     (hcop2 : Nat.Coprime 2 a) (hcop3 : Nat.Coprime 3 a) :
     sigma 1 a + sigma 1 (2 * a) = sigma 1 (3 * a) := by
-  have hmul2 := ArithmeticFunction.IsMultiplicative.map_mul_of_coprime
-    isMultiplicative_sigma hcop2
-  have hmul3 := ArithmeticFunction.IsMultiplicative.map_mul_of_coprime
-    isMultiplicative_sigma hcop3
+  have hmul2 := (isMultiplicative_sigma (k := 1)).map_mul_of_coprime hcop2
+  have hmul3 := (isMultiplicative_sigma (k := 1)).map_mul_of_coprime hcop3
   rw [hmul2, hmul3]
   have hs2 : sigma 1 2 = 3 := by native_decide
   have hs3 : sigma 1 3 = 4 := by native_decide
@@ -191,6 +189,7 @@ theorem sigma_add_eq_of_prime (p : ℕ) (hp : p.Prime) (h2 : p ≠ 2) (h3 : p �
 /-- (p, 2p) is a solution for every prime p >= 5. -/
 theorem solution_prime_2p (p : ℕ) (hp : p.Prime) (h2 : p ≠ 2) (h3 : p ≠ 3) :
     IsAdditiveDivisorPair p (2 * p) := by
+  have hp2 := hp.two_le
   refine ⟨hp.one_le, by omega, ?_⟩
   have heq : p + 2 * p = 3 * p := by ring
   rw [heq]
@@ -275,6 +274,7 @@ theorem twentyone_in_A110177 : 21 ∈ A110177 :=
 /-- For every prime p >= 5, 3p is in A110177. -/
 theorem three_p_in_A110177 (p : ℕ) (hp : p.Prime) (h2 : p ≠ 2) (h3 : p ≠ 3) :
     3 * p ∈ A110177 := by
+  have hp2 := hp.two_le
   refine ⟨p, 2 * p, hp.one_le, by omega, by ring, ?_⟩
   show sigma 1 p + sigma 1 (2 * p) = sigma 1 (3 * p)
   exact sigma_add_eq_of_prime p hp h2 h3
@@ -296,7 +296,7 @@ theorem solution_symmetric (a b : ℕ) (h : IsAdditiveDivisorPair a b) :
     IsAdditiveDivisorPair b a := by
   obtain ⟨ha, hb, heq⟩ := h
   refine ⟨hb, ha, ?_⟩
-  rw [add_comm]
+  rw [add_comm b a]
   linarith
 
 /-
@@ -339,6 +339,7 @@ theorem prime_solution_counted (p x : ℕ) (hp : p.Prime) (h2 : p ≠ 2) (h3 : p
     (hle : 3 * p ≤ x) :
     (p, 2 * p) ∈ (Finset.Icc 1 x ×ˢ Finset.Icc 1 x).filter
       fun (a, b) => a + b ≤ x ∧ sigma 1 a + sigma 1 b = sigma 1 (a + b) := by
+  have hp2 := hp.two_le
   simp only [Finset.mem_filter, Finset.mem_product, Finset.mem_Icc]
   refine ⟨⟨⟨hp.one_le, by omega⟩, ⟨by omega, by omega⟩⟩, ⟨by omega, ?_⟩⟩
   have heq : p + 2 * p = 3 * p := by ring

--- a/proofs/Proofs/Erdos730Problem.lean
+++ b/proofs/Proofs/Erdos730Problem.lean
@@ -20,6 +20,7 @@ have the same set of prime divisors?
 
 import Mathlib.Data.Nat.Choose.Central
 import Mathlib.Data.Nat.Prime.Basic
+import Mathlib.Data.Nat.Prime.Factorial
 import Mathlib.Data.Nat.Factors
 import Mathlib.Tactic
 
@@ -72,11 +73,12 @@ theorem two_divides_central (n : ℕ) (hn : n ≥ 1) : 2 ∣ centralBinom n := b
   unfold centralBinom
   have key : Nat.choose (2 * n) n = 2 * Nat.choose (2 * n - 1) (n - 1) := by
     have h1 := Nat.choose_succ_succ (2 * n - 1) (n - 1)
+    simp only [Nat.succ_eq_add_one] at h1
     rw [show 2 * n - 1 + 1 = 2 * n from by omega,
         show n - 1 + 1 = n from by omega] at h1
     have hsymm : Nat.choose (2 * n - 1) n = Nat.choose (2 * n - 1) (n - 1) := by
-      rw [Nat.choose_symm (show n ≤ 2 * n - 1 by omega)]
-      congr 1; omega
+      rw [show n - 1 = (2 * n - 1) - n from by omega,
+          Nat.choose_symm (show n ≤ 2 * n - 1 by omega)]
     rw [hsymm] at h1; linarith
   rw [key]; exact dvd_mul_right 2 _
 
@@ -90,10 +92,11 @@ theorem large_prime_not_dividing (p n : ℕ) (hp : Nat.Prime p) (hgt : p > 2 * n
   intro hdvd
   -- C(2n, n) * n! * (2n - n)! = (2n)!
   have hfact := Nat.choose_mul_factorial_mul_factorial (show n ≤ 2 * n by omega)
+  rw [show 2 * n - n = n from by omega] at hfact
   -- p | C(2n,n) implies p | C(2n,n) * n! * n!
-  have hdvd_prod : p ∣ Nat.choose (2 * n) n * n.factorial * (2 * n - n).factorial := by
-    exact dvd_mul_of_dvd_left (dvd_mul_of_dvd_left hdvd _) _
-  rw [show 2 * n - n = n from by omega, hfact] at hdvd_prod
+  have hdvd_prod : p ∣ Nat.choose (2 * n) n * n.factorial * n.factorial :=
+    dvd_mul_of_dvd_left (dvd_mul_of_dvd_left hdvd _) _
+  rw [hfact] at hdvd_prod
   -- But p ∤ (2n)! since p > 2n
   have hnotdvd : ¬(p ∣ (2 * n).factorial) := by
     rw [hp.dvd_factorial]; omega
@@ -113,7 +116,7 @@ theorem middle_primes_divide (p n : ℕ) (hp : Nat.Prime p) (h1 : n < p) (h2 : p
   have hndvd : ¬(p ∣ n.factorial) := by
     intro h; exact absurd (hp.dvd_factorial.mp h) (by omega)
   -- C(2n,n) * n! * n! = (2n)! and p | (2n)!
-  rw [← hfact, mul_assoc] at hdvd
+  rw [← hfact] at hdvd
   -- Factor out n! twice using primality
   have h3 : p ∣ Nat.choose (2 * n) n * n.factorial :=
     (hp.prime.dvd_mul.mp hdvd).resolve_right hndvd
@@ -127,10 +130,14 @@ theorem middle_primes_divide (p n : ℕ) (hp : Nat.Prime p) (h1 : n < p) (h2 : p
 theorem spacing1_implies_main
     (h : Set.Infinite {n : ℕ | SamePrimeDivisors (centralBinom n) (centralBinom (n + 1))}) :
     Set.Infinite CentralBinomPairs := by
-  apply Set.Infinite.mono _ (Set.Infinite.image (fun n => (n, n + 1)) h (by
-    intro a b hab; simp at hab; omega))
-  intro ⟨a, b⟩ ⟨n, hn, heq⟩
-  simp at heq
+  have hinj : Set.InjOn (fun n => (n, n + 1))
+      {n : ℕ | SamePrimeDivisors (centralBinom n) (centralBinom (n + 1))} := by
+    intro a _ b _ hab
+    simp only [Prod.mk.injEq] at hab
+    exact hab.1
+  apply Set.Infinite.mono _ (Set.Infinite.image hinj h)
+  rintro ⟨a, b⟩ ⟨n, hn, heq⟩
+  simp only [Prod.mk.injEq] at heq
   obtain ⟨rfl, rfl⟩ := heq
   exact ⟨by omega, hn⟩
 

--- a/proofs/Proofs/Erdos741Problem.lean
+++ b/proofs/Proofs/Erdos741Problem.lean
@@ -194,6 +194,38 @@ theorem syndetic_infinite {S : Set ℕ} (h : IsSyndetic S) : S.Infinite := by
 ## Density Properties (Axiomatized)
 -/
 
+/-- The density ratio is always nonneg. -/
+theorem density_ratio_nonneg (A : Set ℕ) (n : ℕ) :
+    (0 : ℝ) ≤ ((A ∩ Set.Iic n).ncard : ℝ) / (↑n + 1) := by positivity
+
+/-- The density ratio is always at most 1. -/
+theorem density_ratio_le_one (A : Set ℕ) (n : ℕ) :
+    ((A ∩ Set.Iic n).ncard : ℝ) / (↑n + 1) ≤ 1 := by
+  rw [div_le_one (by positivity)]
+  have hsub : (A ∩ Set.Iic n).ncard ≤ (Set.Iic n).ncard :=
+    Set.ncard_le_ncard Set.inter_subset_right (Set.finite_Iic n)
+  have hIic : (Set.Iic n : Set ℕ).ncard = n + 1 := by
+    rw [show (Set.Iic n : Set ℕ) = ↑(Finset.range (n + 1)) from by
+          ext m; simp [Finset.mem_range, Nat.lt_succ_iff]]
+    rw [Set.ncard_coe_finset, Finset.card_range]
+  calc ((A ∩ Set.Iic n).ncard : ℝ) ≤ ((Set.Iic n).ncard : ℝ) := by exact_mod_cast hsub
+    _ = ↑n + 1 := by rw [hIic]; push_cast; ring
+
+/-- The density ratio sequence is bounded above (by 1). -/
+theorem density_ratio_isBoundedUnder (A : Set ℕ) :
+    Filter.IsBoundedUnder (· ≤ ·) Filter.atTop
+      (fun n : ℕ => ((A ∩ Set.Iic n).ncard : ℝ) / (↑n + 1)) := by
+  refine ⟨1, ?_⟩
+  rw [Filter.eventually_map]
+  exact Filter.Eventually.of_forall (density_ratio_le_one A)
+
+/-- The density ratio sequence is coboundedUnder ≤ (bounded below by 0). -/
+theorem density_ratio_isCoboundedUnder (A : Set ℕ) :
+    Filter.IsCoboundedUnder (· ≤ ·) Filter.atTop
+      (fun n : ℕ => ((A ∩ Set.Iic n).ncard : ℝ) / (↑n + 1)) :=
+  Filter.isCoboundedUnder_le_of_eventually_le Filter.atTop
+    (Filter.Eventually.of_forall (density_ratio_nonneg A))
+
 /-- The empty set has zero density. -/
 theorem density_empty : upperDensity ∅ = 0 := by
   simp only [upperDensity, Set.empty_inter, Set.ncard_empty, Nat.cast_zero, zero_div]
@@ -216,12 +248,15 @@ theorem density_univ : upperDensity Set.univ = 1 := by
 /-- Density is monotone: A ⊆ B implies upperDensity A ≤ upperDensity B. -/
 theorem density_mono {A B : Set ℕ} (h : A ⊆ B) : upperDensity A ≤ upperDensity B := by
   unfold upperDensity
-  apply Filter.limsup_le_limsup
-  · apply Filter.Eventually.of_forall
-    intro n
-    apply div_le_div_of_nonneg_right _ (by positivity : (0 : ℝ) ≤ (n : ℝ) + 1)
+  refine Filter.limsup_le_limsup ?_ (density_ratio_isCoboundedUnder A)
+    (density_ratio_isBoundedUnder B)
+  apply Filter.Eventually.of_forall
+  intro n
+  have hle : ((A ∩ Set.Iic n).ncard : ℝ) ≤ ((B ∩ Set.Iic n).ncard : ℝ) := by
     exact_mod_cast Set.ncard_le_ncard (Set.inter_subset_inter_left _ h)
-        ((Set.Iic n).toFinite.subset Set.inter_subset_right)
+      ((Set.Iic n).toFinite.subset Set.inter_subset_right)
+  dsimp only
+  gcongr
 
 /-- Upper density is at most 1 for any set. -/
 theorem density_le_one (A : Set ℕ) : upperDensity A ≤ 1 :=
@@ -249,6 +284,7 @@ theorem basis_infinite {A : Set ℕ} (h : IsBasisOrder2 A) : A.Infinite := by
     have := hA_bound b hb
     omega
   -- But h says all large enough numbers are in sumset A A
+  unfold IsBasisOrder2 at h
   rw [Filter.eventually_atTop] at h
   obtain ⟨N, hN⟩ := h
   -- Take m = max(N, 2*n + 1)
@@ -282,32 +318,31 @@ theorem cofinite_density_one {S : Set ℕ} (h : ∀ᶠ n in atTop, n ∈ S) :
       (1 : ℝ) - N₀ / (↑n + 1) ≤ ((S ∩ Set.Iic n).ncard : ℝ) / (↑n + 1) := by
     filter_upwards [Filter.eventually_ge_atTop N₀] with n hn
     have hn_pos : (0 : ℝ) < n + 1 := by positivity
-    rw [div_le_div_iff₀ hn_pos hn_pos]  -- both as cross-multiply
-    have hc := Nat.cast_le.mpr (hcard n hn)
-    push_cast [Nat.sub_add_cancel hn] at hc ⊢
+    have hc : ((n - N₀ + 1 : ℕ) : ℝ) ≤ ((S ∩ Set.Iic n).ncard : ℝ) := by
+      exact_mod_cast hcard n hn
+    push_cast [Nat.cast_sub hn] at hc
+    rw [le_div_iff₀ hn_pos, sub_mul, one_mul, div_mul_cancel₀ _ (ne_of_gt hn_pos)]
     linarith
   -- 1 - N₀/(n+1) → 1 as n → ∞
   have htend_lb : Filter.Tendsto (fun n : ℕ => (1 : ℝ) - N₀ / (↑n + 1))
       Filter.atTop (nhds 1) := by
-    rw [show (1 : ℝ) = 1 - 0 from by ring]
-    apply Filter.Tendsto.sub tendsto_const_nhds
-    -- N₀/(n+1) → 0: write as N₀ * (n+1)⁻¹ → N₀ * 0 = 0
-    simp_rw [div_eq_mul_inv]
-    rw [show (0 : ℝ) = N₀ * 0 from (mul_zero _).symm]
-    apply Filter.Tendsto.const_mul
-    -- (n+1)⁻¹ → 0 since n+1 → ∞
-    apply Filter.Tendsto.inv_tendsto_atTop
-    apply Filter.tendsto_atTop_atTop.mpr
-    intro b; refine ⟨⌈b⌉₊, fun n hn => ?_⟩
-    have hb : b ≤ (⌈b⌉₊ : ℝ) := Nat.le_ceil b
-    have hn_cast : (⌈b⌉₊ : ℝ) ≤ (n : ℝ) := Nat.cast_le.mpr hn
-    linarith
+    have hden : Filter.Tendsto (fun n : ℕ => (↑n + 1 : ℝ)) Filter.atTop Filter.atTop :=
+      Filter.tendsto_atTop_mono (fun n => by linarith) tendsto_natCast_atTop_atTop
+    have h0 : Filter.Tendsto (fun n : ℕ => (N₀ : ℝ) / (↑n + 1))
+        Filter.atTop (nhds 0) :=
+      Filter.Tendsto.div_atTop tendsto_const_nhds hden
+    have hconst : Filter.Tendsto (fun _ : ℕ => (1 : ℝ)) Filter.atTop (nhds 1) :=
+      tendsto_const_nhds
+    have hsub := hconst.sub h0
+    rw [sub_zero] at hsub
+    exact hsub
   -- limsup ≥ lim of lower bound = 1
-  calc (1 : ℝ) = atTop.limsup (fun n : ℕ => 1 - ↑N₀ / (↑n + 1)) := by
-          exact (htend_lb.limsup_eq ⟨1, by
-            filter_upwards [] with n; apply sub_le_self; positivity⟩).symm
-      _ ≤ atTop.limsup (fun n : ℕ => ((S ∩ Set.Iic n).ncard : ℝ) / (↑n + 1)) :=
-          Filter.limsup_le_limsup hlb
+  have hcob := htend_lb.isCoboundedUnder_le
+  have hbdd := density_ratio_isBoundedUnder S
+  have heq := htend_lb.limsup_eq
+  have hmain := Filter.limsup_le_limsup hlb hcob hbdd
+  rw [heq] at hmain
+  exact hmain
 
 /-- A basis of order 2 has positive density sumset. -/
 theorem basis_has_pos_density_sumset {A : Set ℕ} (h : IsBasisOrder2 A) :

--- a/proofs/Proofs/Erdos964Problem.lean
+++ b/proofs/Proofs/Erdos964Problem.lean
@@ -52,10 +52,11 @@ def tau (n : ℕ) : ℕ :=
 τ(1) = 1, τ(p) = 2 for prime p, τ(p^k) = k+1
 -/
 theorem tau_one : tau 1 = 1 := by
-  simp [tau, Nat.divisors]
+  rw [tau, Nat.divisors_one, Finset.card_singleton]
 
 theorem tau_prime (p : ℕ) (hp : Nat.Prime p) : tau p = 2 := by
-  simp [tau, Nat.Prime.divisors hp]
+  rw [tau, hp.divisors]
+  exact Finset.card_pair_eq_two_iff.mpr hp.one_lt.ne
 
 theorem tau_prime_power (p k : ℕ) (hp : Nat.Prime p) :
     tau (p ^ k) = k + 1 := by
@@ -67,7 +68,8 @@ theorem tau_prime_power (p k : ℕ) (hp : Nat.Prime p) :
 -/
 theorem tau_multiplicative (m n : ℕ) (h : Nat.Coprime m n) :
     tau (m * n) = tau m * tau n := by
-  simp only [tau, h.divisors_mul, Finset.card_product]
+  simp only [tau]
+  exact h.card_divisors_mul
 
 /-
 ## Part II: Ratios of Consecutive Values
@@ -161,12 +163,12 @@ theorem rationals_dense_in_positives :
   refine ⟨⟨p, q, hp_ge, hq_ge, rfl⟩, ?_⟩
   -- |p/q - r| = p/q - r (since p/q ≥ r) and p/q - r < 1/q < ε
   have h_nonneg : (↑p : ℝ) / ↑q - r ≥ 0 := by
-    rw [sub_nonneg, le_div_iff₀ hq_pos]
+    rw [ge_iff_le, sub_nonneg, le_div_iff₀ hq_pos]
     exact hceil_ge
   rw [abs_of_nonneg h_nonneg]
   calc (↑p : ℝ) / ↑q - r
       < (r * ↑q + 1) / ↑q - r := by
-        exact sub_lt_sub_right ((div_lt_div_right hq_pos).mpr hceil_lt) r
+        gcongr
     _ = 1 / ↑q := by field_simp; ring
     _ < ε := h_inv_lt
 
@@ -329,7 +331,9 @@ theorem erdos_964 : ErdosConjecture964 := erdos_964_true
 **The answer:**
 -/
 theorem erdos_964_answer :
-    ∀ r : ℝ, r > 0 → ∀ ε > 0, ∃ n : ℕ, n ≥ 1 ∧ |divisorRatio n - r| < ε :=
-  erdos_964
+    ∀ r : ℝ, r > 0 → ∀ ε > 0, ∃ n : ℕ, n ≥ 1 ∧ |divisorRatio n - r| < ε := by
+  intro r hr ε hε
+  obtain ⟨s, ⟨n, hn, hs⟩, hdist⟩ := erdos_964 r hr ε hε
+  exact ⟨n, hn, by rw [hs]; exact hdist⟩
 
 end Erdos964

--- a/proofs/Proofs/SylowTheoremOQ01.lean
+++ b/proofs/Proofs/SylowTheoremOQ01.lean
@@ -55,7 +55,7 @@ private lemma factorization_pq_at_q (h : IsPQGroup G) :
       Finsupp.add_apply]
   have h1 : h.p.factorization h.q = 0 := by
     rw [h.hp.factorization, Finsupp.single_apply,
-        if_neg (Ne.symm h.hpq)]
+        if_neg h.hpq]
   have h2 : h.q.factorization h.q = 1 := by
     rw [h.hq.factorization, Finsupp.single_apply, if_pos rfl]
   omega
@@ -109,11 +109,8 @@ private lemma sylow_normal_of_card_one {p : ℕ} [Fact p.Prime]
     ∃ P : Sylow p G, (P : Subgroup G).Normal := by
   haveI : Subsingleton (Sylow p G) :=
     Fintype.card_le_one_iff_subsingleton.mp (by omega)
-  obtain ⟨P⟩ := Sylow.nonempty p G
-  exact ⟨P, by
-    rw [← normalizer_eq_top, eq_top_iff]
-    intro g _
-    exact Sylow.smul_eq_iff_mem_normalizer.mp (Subsingleton.elim _ _)⟩
+  obtain ⟨P⟩ := (Sylow.nonempty : Nonempty (Sylow p G))
+  exact ⟨P, Sylow.normal_of_subsingleton P⟩
 
 /-
 ## Part II: Sylow q-subgroup is Unique
@@ -129,10 +126,10 @@ theorem sylow_q_count_constraint (h : IsPQGroup G)
       n ∣ h.p ∧ n % h.q = 1 := by
   haveI : Fact h.q.Prime := ⟨h.hq⟩
   intro n hn; subst hn
-  obtain ⟨Q⟩ := Sylow.nonempty h.q G
+  obtain ⟨Q⟩ := (Sylow.nonempty : Nonempty (Sylow h.q G))
   constructor
   · -- n_q | index Q = p
-    have hdvd := card_sylow_dvd_index Q
+    have hdvd := Q.card_dvd_index
     rw [sylow_q_index h Q] at hdvd
     rwa [← Nat.card_eq_fintype_card]
   · -- n_q ≡ 1 (mod q)
@@ -169,8 +166,8 @@ n_p = q requires q ≡ 1 (mod p), i.e., p | (q - 1).
 theorem sylow_p_count (h : IsPQGroup G) (hpq : h.p < h.q) :
     Fintype.card (Sylow h.p G) = 1 ∨ Fintype.card (Sylow h.p G) = h.q := by
   haveI : Fact h.p.Prime := ⟨h.hp⟩
-  obtain ⟨P⟩ := Sylow.nonempty h.p G
-  have hdvd := card_sylow_dvd_index P
+  obtain ⟨P⟩ := (Sylow.nonempty : Nonempty (Sylow h.p G))
+  have hdvd := P.card_dvd_index
   rw [sylow_p_index h P] at hdvd
   rw [← Nat.card_eq_fintype_card]
   exact h.hq.eq_one_or_self_of_dvd _ hdvd
@@ -231,8 +228,8 @@ private theorem cyclic_of_both_sylow_normal (h : IsPQGroup G) (hpq : h.p < h.q)
       rwa [hQ_card, Subgroup.orderOf_mk] at this
     have hcop : Nat.Coprime h.p h.q :=
       (h.hp.coprime_iff_not_dvd).mpr (fun hdvd =>
-        absurd (Nat.Prime.eq_of_dvd_of_prime h.hp h.hq hdvd) h.hpq)
-    exact (orderOf_eq_one_iff_eq_one).mp (Nat.eq_one_of_dvd_coprimes hcop h1 h2)
+        absurd ((Nat.prime_dvd_prime_iff_eq h.hp h.hq).mp hdvd) h.hpq)
+    exact orderOf_eq_one_iff.mp (Nat.eq_one_of_dvd_coprimes hcop h1 h2)
   -- Step 2: Elements of P and Q commute (commutator argument)
   have hcommute : ∀ g : G, g ∈ (P : Subgroup G) →
       ∀ k : G, k ∈ (Q : Subgroup G) → Commute g k := by
@@ -251,19 +248,17 @@ private theorem cyclic_of_both_sylow_normal (h : IsPQGroup G) (hpq : h.p < h.q)
     -- Both are the same element (by associativity), and it's in P ∩ Q = {1}
     have hc_one : g⁻¹ * (k⁻¹ * g * k) = 1 := by
       have : g⁻¹ * k⁻¹ * g * k = g⁻¹ * (k⁻¹ * g * k) := by group
-      exact Subgroup.disjoint_def.mp hdisjoint _ hc_in_P (this ▸ hc_in_Q)
+      exact Subgroup.disjoint_def.mp hdisjoint hc_in_P (this ▸ hc_in_Q)
     -- From g⁻¹ * (k⁻¹ * g * k) = 1, derive g = k⁻¹ * g * k
-    have h_conj_eq : k⁻¹ * g * k = g := by rwa [inv_mul_eq_one] at hc_one
+    have h_conj_eq : k⁻¹ * g * k = g := (inv_mul_eq_one.mp hc_one).symm
     -- Therefore g * k = k * g
     show g * k = k * g
     calc g * k = k * (k⁻¹ * g * k) := by group
       _ = k * g := by rw [h_conj_eq]
   -- Step 3: Get generators of P and Q
   -- P is cyclic (prime order)
-  haveI : IsCyclic (P : Subgroup G) := isCyclic_of_prime_card (by
-    rw [← Nat.card_eq_fintype_card]; exact hP_card)
-  haveI : IsCyclic (Q : Subgroup G) := isCyclic_of_prime_card (by
-    rw [← Nat.card_eq_fintype_card]; exact hQ_card)
+  haveI : IsCyclic (P : Subgroup G) := isCyclic_of_prime_card hP_card
+  haveI : IsCyclic (Q : Subgroup G) := isCyclic_of_prime_card hQ_card
   -- Get generators
   obtain ⟨⟨g, hg_mem⟩, hg_gen⟩ := IsCyclic.exists_generator (α := (P : Subgroup G))
   obtain ⟨⟨k, hk_mem⟩, hk_gen⟩ := IsCyclic.exists_generator (α := (Q : Subgroup G))
@@ -271,30 +266,31 @@ private theorem cyclic_of_both_sylow_normal (h : IsPQGroup G) (hpq : h.p < h.q)
   have hg_ord : orderOf g = h.p := by
     have h1 : orderOf (⟨g, hg_mem⟩ : (P : Subgroup G)) = h.p := by
       rw [orderOf_eq_card_of_forall_mem_zpowers (fun x => hg_gen x)]
-      rw [← Nat.card_eq_fintype_card]; exact hP_card
+      exact hP_card
     rwa [Subgroup.orderOf_mk] at h1
   -- orderOf k = q
   have hk_ord : orderOf k = h.q := by
     have h1 : orderOf (⟨k, hk_mem⟩ : (Q : Subgroup G)) = h.q := by
       rw [orderOf_eq_card_of_forall_mem_zpowers (fun x => hk_gen x)]
-      rw [← Nat.card_eq_fintype_card]; exact hQ_card
+      exact hQ_card
     rwa [Subgroup.orderOf_mk] at h1
   -- g and k commute
   have hgk_comm : Commute g k := hcommute g hg_mem k hk_mem
   -- Step 4: orderOf (g * k) = p * q = |G|
   have hcop_pq : Nat.Coprime h.p h.q :=
     (h.hp.coprime_iff_not_dvd).mpr (fun hdvd =>
-      absurd (Nat.Prime.eq_of_dvd_of_prime h.hp h.hq hdvd) h.hpq)
+      absurd ((Nat.prime_dvd_prime_iff_eq h.hp h.hq).mp hdvd) h.hpq)
   have hord_mul : orderOf (g * k) = h.p * h.q := by
     have := hgk_comm.orderOf_mul_eq_mul_orderOf_of_coprime (by rwa [hg_ord, hk_ord])
     rwa [hg_ord, hk_ord] at this
   -- G is cyclic: zpowers (g * k) has cardinality pq = |G|, so it's all of G
   refine ⟨⟨g * k, fun x => ?_⟩⟩
   have h_card_zpow : Nat.card (Subgroup.zpowers (g * k)) = Nat.card G := by
-    rw [Subgroup.card_zpowers, hord_mul, Nat.card_eq_fintype_card, h.hcard]
+    rw [Nat.card_zpowers, hord_mul, Nat.card_eq_fintype_card, h.hcard]
   have h_top : Subgroup.zpowers (g * k) = ⊤ :=
-    Subgroup.eq_top_of_card_eq h_card_zpow
-  rw [h_top]; exact Subgroup.mem_top x
+    Subgroup.eq_top_of_card_eq _ h_card_zpow
+  have hx : x ∈ Subgroup.zpowers (g * k) := by rw [h_top]; exact Subgroup.mem_top x
+  exact hx
 
 /-- When p ∤ (q-1), G is cyclic of order pq -/
 theorem cyclic_when_coprime (h : IsPQGroup G) (hpq : h.p < h.q)

--- a/proofs/batch2/STATUS.md
+++ b/proofs/batch2/STATUS.md
@@ -1,3 +1,84 @@
+# DOCTOR INCREMENT 69 (deep-rework partition B: N–Z + Erdos ≥ 600, #38065, 2026-07-15)
+
+Container `dr69` (cpus 0-5, 11g, cache v431), worktree issue-38065, branch
+`feature/issue-38065-inc69` off origin/feature/issue-37508 (base 2037 GREEN /
+598 RESIDUAL). Warm leads from inc-67 + rewrite-drift family. Every file was
+6–17 real errors (deep-rework confirmed, 0 free flips). **+6 GREEN.** PR #38672.
+All flips in-container `lake build Proofs.X` exit-0 before ledger flip; pushed per file.
+
+## Flips (failure class in parens)
+- Erdos1061Problem (proof-drift): sigma_prime' `simp[sigma_apply]` no longer closes →
+  `rw[sigma_one_apply, hp.divisors, Finset.sum_pair hp.one_lt.ne]`;
+  `isMultiplicative_sigma` needs explicit `(k := 1)`; **omega no longer derives
+  `1 ≤ p` from `Prime`** → materialize `hp.two_le` (×3 sites); `rw[add_comm]` →
+  `rw[add_comm b a]` to align the sigma atom for linarith.
+- SylowTheoremOQ01 (rewrite-drift): `Finsupp.single_apply` now `if a = a'` (flip
+  `if_neg` arg); **`Sylow.nonempty` is an instance** (no `p G` args) → type-ascribe
+  `(Sylow.nonempty : Nonempty (Sylow p G))`; `card_sylow_dvd_index` →
+  `Sylow.card_dvd_index` (now `Nat.card (Sylow p G) ∣ P.index`);
+  `Nat.Prime.eq_of_dvd_of_prime` → `(Nat.prime_dvd_prime_iff_eq h h').mp`;
+  `orderOf_eq_one_iff_eq_one` → `orderOf_eq_one_iff`; **`Subgroup.disjoint_def` x
+  now IMPLICIT** → drop the `_`; manual normalizer proof → `Sylow.normal_of_subsingleton`;
+  `inv_mul_eq_one` gives symm form → `.symm`; `orderOf_eq_card_of_forall_mem_zpowers`
+  now returns `Nat.card` → drop follow-up `rw[← Nat.card_eq_fintype_card]`;
+  `Subgroup.card_zpowers` → `Nat.card_zpowers`; **`eq_top_of_card_eq` H now explicit**
+  → pass `_`; IsCyclic generator goal unfolds to `∃ a, g^a = x` → intermediate typed
+  membership `have`.
+- Erdos964Problem (rewrite-drift): `tau_one`/`tau_prime` `simp[Nat.divisors]` no longer
+  closes → `rw` divisors_one/`hp.divisors` + `card_singleton`/`card_pair_eq_two_iff.mpr`;
+  `tau_multiplicative`: `divisors_mul` now yields map/attach form → `Nat.Coprime.card_divisors_mul`;
+  **`sub_nonneg` won't rw through `≥ 0`** → prepend `ge_iff_le`; `div_lt_div_right`
+  removed → `gcongr`; `erdos_964_answer` no longer defeq to the set-based conjecture →
+  destructure ratioSet membership explicitly.
+- Erdos730Problem (rewrite-drift): `Nat.choose_succ_succ` now emits `.succ` form →
+  `simp[Nat.succ_eq_add_one]` before rw; hsymm via `rw show n-1=(2n-1)-n` +
+  `Nat.choose_symm`; **`Nat.Prime` dot-notation for `dvd_factorial` resolves to
+  `Irreducible` unless `Data.Nat.Prime.Factorial` is imported** → add import;
+  `choose_mul_factorial`: rewrite `2n-n=n` in hfact BEFORE matching hdvd_prod; drop
+  stale `mul_assoc`; **`Set.Infinite.image` now needs `InjOn` (not the map fn)** →
+  hoist `hinj`; `rintro` for image membership.
+- Erdos741Problem (rewrite-drift): **Filter/limsup API rework** — `limsup_le_limsup`
+  now takes explicit `IsCoboundedUnder` + `IsBoundedUnder` args (`isBoundedDefault`
+  can't discharge on ℝ) → reusable `density_ratio_isBoundedUnder`/`isCoboundedUnder`
+  helpers (`eventually_map` / `isCoboundedUnder_le_of_eventually_le`);
+  `Tendsto.limsup_eq` lost its boundedness arg; `IsBasisOrder2` needs `unfold` before
+  `eventually_atTop` rw; `div_le_div_iff₀` mismatch (LHS not a single div) →
+  `le_div_iff₀`+`sub_mul`+`div_mul_cancel₀`; `Nat.cast_le` target metavar → pin ℝ via
+  typed `have`; `N₀/(n+1)→0` via `Tendsto.div_atTop`+`tendsto_atTop_mono`; `gcongr`
+  replaces removed `div_le_div_right`; **a `calc` restating the limsup functions
+  triggers a whnf heartbeat loop on the coercions → use explicit `have`+`rw [heq]`.**
+- Erdos1052Problem (rewrite-drift): gcd-positivity fragile `rcases`+`rw[←h,gcd_eq_zero_iff]
+  at *` → clean `eq_zero_or_pos` + `gcd_eq_zero_iff at hz` (×5); `mul_div_cancel'` rw
+  needs `← mul_assoc` FIRST to expose `gcd*(m/gcd)`; **`conv_lhs`→`conv_rhs`** (rewrite
+  `d` in the `m*n/d` denominator, not the `m/gcd` numerator); sum over `{1,p^k}` leaves
+  `id` → append `simp`; `sum_product'`+`simp_rw mul_sum/sum_mul` → `Finset.sum_mul_sum`;
+  omega can't prove `1≤d₁*d₂` or `0<m*n` → `Nat.mul_pos`; `pow_succ` proof reorder to
+  avoid rewriting `n` inside `n.factorization p`; `id_eq` before omega; `le_self_pow`
+  → `Nat.le_self_pow`; **`n.factorization p` contains `n`, so `rw[n=…]` corrupts the
+  exponent → `set P` first.**
+
+## New systematic seams (rename-map §7ak candidates)
+1. **`Sylow.nonempty` is an instance** (no explicit `p G`) — apply args → "function
+   expected"; type-ascribe `(Sylow.nonempty : Nonempty (Sylow p G))`.
+2. **`card_sylow_dvd_index`→`Sylow.card_dvd_index`** (returns `Nat.card (Sylow p G) ∣
+   P.index`); **`Subgroup.card_zpowers`→`Nat.card_zpowers`**; **`Subgroup.eq_top_of_card_eq`
+   H now explicit**; **`Subgroup.disjoint_def` bound var now implicit** (drop the `_`).
+3. **`Nat.Prime.dvd_factorial` dot-notation** silently resolves the head to `Irreducible`
+   (unknown const) when `Mathlib.Data.Nat.Prime.Factorial` isn't imported → add the import.
+4. **`limsup_le_limsup` now takes explicit `IsCoboundedUnder`/`IsBoundedUnder`** (auto
+   `isBoundedDefault` fails on ℝ); **`Tendsto.limsup_eq` dropped its boundedness arg**.
+5. **A `calc` step restating a `limsup (fun n => …coercions…)` deterministically
+   whnf-loops** past the heartbeat cap → prove `limsup_le_limsup` into a `have` and
+   `rw [tendsto.limsup_eq]` instead of stating the functions inside `calc`.
+6. **`rw [h : n = …]` corrupts `n.factorization p`** (the exponent literally contains
+   `n`) → `set P := p^(n.factorization p)` before rewriting `n`.
+7. **`conv_lhs` on `a ∣ b` targets `a`** — for a denominator rewrite in `b` use `conv_rhs`.
+8. **omega no longer derives products** (`1≤a*b`, `0<m*n`, `1≤p` from `Prime`) → supply
+   `Nat.mul_pos` / materialize `hp.two_le`.
+
+Ledger after increment 69: +6 GREEN (partition B).
+
+
 # DOCTOR INCREMENT 67 (deep-rework partition B: N–Z + Erdos ≥ 600, #38065, 2026-07-15)
 
 Container `dr67` (cpus 0-5, 11g, cache v431), worktree issue-38065, branch

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -1630,7 +1630,7 @@ Erdos727Problem	GREEN
 Erdos728Problem	GREEN	proof-drift
 Erdos72Aristotle	GREEN	
 Erdos72Problem	GREEN	
-Erdos730Problem	RESIDUAL	rewrite-drift
+Erdos730Problem	GREEN	
 Erdos731Problem	GREEN	
 Erdos732Problem	RESIDUAL	instance-synth
 Erdos733LimitBounds	GREEN	doctor-inc65

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -1644,7 +1644,7 @@ Erdos73Aristotle	GREEN
 Erdos73Problem	RESIDUAL	type-mismatch
 Erdos740Problem	RESIDUAL	instance-synth
 Erdos740ProblemProvable	RESIDUAL	instance-synth
-Erdos741Problem	RESIDUAL	rewrite-drift
+Erdos741Problem	GREEN	
 Erdos741ProblemAPNPartI	RESIDUAL	unknown-const:ingleton
 Erdos742Problem	GREEN	
 Erdos743Problem	GREEN	

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -1900,7 +1900,7 @@ Erdos961Problem	GREEN
 Erdos962Problem	GREEN	
 Erdos963Problem	GREEN	
 Erdos964Aristotle	GREEN	unknown-const:Nat.divisors_prime
-Erdos964Problem	RESIDUAL	rewrite-drift
+Erdos964Problem	GREEN	
 Erdos965Problem	GREEN	
 Erdos966Problem	GREEN	
 Erdos967Problem	GREEN	proof-drift

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -751,7 +751,7 @@ Erdos1059OQ04	GREEN
 Erdos1059Problem	GREEN	
 Erdos105OQ05	GREEN	
 Erdos1060Problem	GREEN	
-Erdos1061Problem	RESIDUAL	proof-drift
+Erdos1061Problem	GREEN	
 Erdos1062OQ04	GREEN	
 Erdos1062Problem	GREEN	
 Erdos1065CunninghamChains	RESIDUAL	type-mismatch

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -2517,7 +2517,7 @@ SumOfKthPowersOQ05OQ01	GREEN
 SumOfKthPowersOQ05OQ01OQ01	GREEN	
 SumOfOddsStatementOnly	GREEN	
 SylowTheorem	GREEN	
-SylowTheoremOQ01	RESIDUAL	rewrite-drift
+SylowTheoremOQ01	GREEN	
 SylowTheoremOQ02	GREEN	
 SylowTheoremOQ02OQ01Nilpotent	GREEN	
 SylowTheoremOQ02Orbit	GREEN	

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -733,7 +733,7 @@ Erdos1050Aristotle	GREEN
 Erdos1050Problem	RESIDUAL	type-mismatch
 Erdos1050ProblemAristotle	GREEN	
 Erdos1051Problem	RESIDUAL	type-mismatch
-Erdos1052Problem	RESIDUAL	rewrite-drift
+Erdos1052Problem	GREEN	
 Erdos1053Problem	GREEN	
 Erdos1054AlmostAllOQ01	GREEN	
 Erdos1054AlmostAllOQ0103	GREEN	


### PR DESCRIPTION
Doctor increment 69, deep-rework partition B (files N–Z + Erdos ≥ 600) of the v4.26→v4.31 toolchain migration (epic #37508, ledger #38065).

Each RESIDUAL file is genuine deep-rework (5–10+ real errors); ledger class = first error only. Every flip verified in-container (`lake build Proofs.X` exit-0) before flipping the ledger row and committing. Pushed per file.

## Flips
- **Erdos1061Problem** (proof-drift): sigma_prime' simp no longer closes → rw[sigma_one_apply, hp.divisors, Finset.sum_pair]; isMultiplicative_sigma needs explicit (k:=1); omega no longer derives 1≤p from Prime → materialize hp.two_le at 3 sites; rw[add_comm] → rw[add_comm b a] to align the sigma atom for linarith.

Base: `feature/issue-37508` (NOT main). No loom:review-requested.