### PR TITLE
migrate(v4.31): Doctor increment 70 — deep-rework partition A (+5 GREEN)

### DIFF
--- a/proofs/Proofs/BirthdayProblemOQ01OQ01.lean
+++ b/proofs/Proofs/BirthdayProblemOQ01OQ01.lean
@@ -70,16 +70,15 @@ def collisionIndicator (f : Fin n → Fin d) (i j : Fin n) : ℕ :=
 /-- X(f) = 0 iff f is injective (no two people share a birthday). -/
 theorem collisionCount_eq_zero_iff {f : Fin n → Fin d} :
     collisionCount f = 0 ↔ Function.Injective f := by
-  simp only [collisionCount, Finset.card_eq_zero, Finset.filter_eq_empty,
-             Finset.mem_univ, forall_true_left, not_and]
+  rw [collisionCount, Finset.card_eq_zero, Finset.filter_eq_empty_iff]
   constructor
   · intro h a b hab
     by_contra hne
     rcases lt_or_gt_of_ne hne with hlt | hlt
-    · exact absurd hab (h (a, b) hlt)
-    · exact absurd hab.symm (h (b, a) hlt)
-  · intro hinj ⟨a, b⟩ hlt heq
-    exact absurd (hinj heq) (ne_of_lt hlt)
+    · exact h (Finset.mem_univ (a, b)) ⟨hlt, hab⟩
+    · exact h (Finset.mem_univ (b, a)) ⟨hlt, hab.symm⟩
+  · intro hinj x _ hp
+    exact absurd (hinj hp.2) (ne_of_lt hp.1)
 
 theorem injective_of_zero {f : Fin n → Fin d} (h : collisionCount f = 0) :
     Function.Injective f := collisionCount_eq_zero_iff.mp h
@@ -139,11 +138,8 @@ theorem collisionCount_eq_sum_indicators (f : Fin n → Fin d) :
     collisionCount f =
     ∑ p ∈ Finset.univ.filter (fun p : Fin n × Fin n => p.1 < p.2),
       collisionIndicator f p.1 p.2 := by
-  simp only [collisionCount, collisionIndicator, Finset.card_filter, ← Finset.sum_filter]
-  apply Finset.sum_congr rfl
-  intro ⟨i, j⟩ _
-  by_cases h1 : i < j <;> by_cases h2 : f i = f j <;>
-    simp [h1, h2, and_comm (a := i < j)]
+  unfold collisionCount collisionIndicator
+  rw [Finset.sum_boole, Finset.filter_filter, Nat.cast_id]
 
 -- ============================================================
 -- PART VI: Distributional Upper Bound
@@ -158,12 +154,12 @@ theorem card_ordered_pairs (n : ℕ) :
     have hset : (Finset.univ : Finset (Fin n × Fin n)).filter (fun p => p.1 ≠ p.2) =
         (Finset.univ : Finset (Fin n)).offDiag := by
       ext ⟨a, b⟩; simp [Finset.mem_offDiag]
-    rw [hset, Finset.card_offDiag, Finset.card_univ, Fintype.card_fin]
+    rw [hset, Finset.offDiag_card, Finset.card_univ, Fintype.card_fin, Nat.mul_sub_one]
   have h_symm : ((Finset.univ : Finset (Fin n × Fin n)).filter (fun p => p.1 < p.2)).card =
       ((Finset.univ : Finset (Fin n × Fin n)).filter (fun p => p.2 < p.1)).card :=
     Finset.card_bij (fun p _ => (p.2, p.1))
       (fun ⟨a, b⟩ h => by simp_all)
-      (fun ⟨a₁, b₁⟩ ⟨a₂, b₂⟩ _ _ h => by simp [Prod.ext_iff] at h; exact Prod.ext h.2 h.1)
+      (fun ⟨a₁, b₁⟩ _ ⟨a₂, b₂⟩ _ h => by simp [Prod.ext_iff] at h; exact Prod.ext h.2 h.1)
       (fun ⟨a, b⟩ h => ⟨(b, a), by simp_all, by simp⟩)
   have h_disj : Disjoint ((Finset.univ : Finset (Fin n × Fin n)).filter (fun p => p.1 < p.2))
       ((Finset.univ : Finset (Fin n × Fin n)).filter (fun p => p.2 < p.1)) := by
@@ -172,7 +168,9 @@ theorem card_ordered_pairs (n : ℕ) :
   have h_union : (Finset.univ : Finset (Fin n × Fin n)).filter (fun p => p.1 ≠ p.2) =
       (Finset.univ.filter (fun p : Fin n × Fin n => p.1 < p.2)) ∪
       (Finset.univ.filter (fun p : Fin n × Fin n => p.2 < p.1)) := by
-    ext ⟨a, b⟩; simp [ne_iff_lt_or_gt]
+    ext ⟨a, b⟩
+    simp only [Finset.mem_filter, Finset.mem_univ, Finset.mem_union, true_and]
+    exact ne_iff_lt_or_gt
   rw [h_union, Finset.card_union_of_disjoint h_disj] at h_offDiag
   omega
 
@@ -183,8 +181,9 @@ theorem collisionCount_le_choose_two (f : Fin n → Fin d) :
   calc (Finset.univ.filter (fun p : Fin n × Fin n => p.1 < p.2 ∧ f p.1 = f p.2)).card
       ≤ (Finset.univ.filter (fun p : Fin n × Fin n => p.1 < p.2)).card := by
         apply Finset.card_le_card
-        apply Finset.filter_subset_filter
-        intro p _; tauto
+        intro x hx
+        simp only [Finset.mem_filter] at hx ⊢
+        exact ⟨hx.1, hx.2.1⟩
     _ = n.choose 2 := card_ordered_pairs n
 
 -- ============================================================
@@ -207,10 +206,10 @@ theorem card_funs_shared_birthday (n d : ℕ) (i j : Fin n) (hij : i ≠ j) :
     Fintype.card_congr {
       toFun := fun ⟨f, _⟩ ⟨k, _⟩ => f k
       invFun := fun g => ⟨fun k => if h : k = j then g ⟨i, hij⟩ else g ⟨k, h⟩, by
-        simp only [dif_neg hij, dif_pos rfl]⟩
+        simp [hij]⟩
       left_inv := fun ⟨f, hfij⟩ => Subtype.ext (funext fun k => by
         by_cases h : k = j
-        · subst h; simp [hfij]
+        · subst h; simpa using hfij
         · simp [h])
       right_inv := fun g => funext fun ⟨k, hk⟩ => by simp [hk]
     }]
@@ -219,7 +218,7 @@ theorem card_funs_shared_birthday (n d : ℕ) (i j : Fin n) (hij : i ≠ j) :
   -- Fintype.card {k : Fin n // k ≠ j} = n - 1
   rw [Fintype.card_subtype]
   rw [show Finset.univ.filter (fun k : Fin n => k ≠ j) =
-         ({j} : Finset (Fin n)).compl from by ext k; simp [Finset.mem_compl]]
+         ({j} : Finset (Fin n))ᶜ from by ext k; simp [Finset.mem_compl]]
   rw [Finset.card_compl, Fintype.card_fin, Finset.card_singleton]
 
 /-- **Σ_f X(f) = C(n,2) · d^{n-1}** (double counting, proved):
@@ -253,7 +252,6 @@ theorem mean_collisionCount (n d : ℕ) (hd : 0 < d) :
   | zero => simp
   | succ n =>
     push_cast
-    rw [Nat.succ_sub_one]
     field_simp
     ring
 

--- a/proofs/Proofs/BirthdayProblemOQ01OQ01OQ03.lean
+++ b/proofs/Proofs/BirthdayProblemOQ01OQ01OQ03.lean
@@ -50,12 +50,11 @@ noncomputable def expectedCollisions (n : ℕ) : ℝ :=
 /-- (T1) Recovery of the parent uniform model: with `p ≡ 1/d` the
     coincidence index is `∑ (1/d)² = d · 1/d² = 1/d`. -/
 theorem collisionProb_uniform (hd : 0 < d) :
-    collisionProb (fun _ => (1 : ℝ) / d) = 1 / d := by
+    collisionProb (fun _ : Fin d => (1 : ℝ) / d) = 1 / d := by
   have hd' : (d : ℝ) ≠ 0 := Nat.cast_ne_zero.mpr hd.ne'
   simp only [collisionProb, Finset.sum_const, Finset.card_univ, Fintype.card_fin,
     nsmul_eq_mul]
   field_simp
-  ring
 
 /-- The exact sum-of-squares identity: the squared deviation of `p` from
     uniform equals the excess of the coincidence index over `1/d`.  This
@@ -116,7 +115,7 @@ theorem expectedCollisions_ge (n : ℕ) (hsum : ∑ k, p k = 1) (hd : 0 < d) :
 
 /-- The uniform expected collision count is the parent's `C(n,2)/d`. -/
 theorem expectedCollisions_uniform (n : ℕ) (hd : 0 < d) :
-    expectedCollisions (fun _ => (1 : ℝ) / d) n = (n.choose 2 : ℝ) / (d : ℝ) := by
+    expectedCollisions (fun _ : Fin d => (1 : ℝ) / d) n = (n.choose 2 : ℝ) / (d : ℝ) := by
   unfold expectedCollisions
   rw [collisionProb_uniform hd, mul_one_div]
 

--- a/proofs/Proofs/Erdos483OQ02.lean
+++ b/proofs/Proofs/Erdos483OQ02.lean
@@ -18,7 +18,7 @@ References:
 
 import Proofs.Erdos483Problem
 
-open SchursTheorem
+open SchursTheorem hiding schurNumber
 
 namespace Erdos483OQ02
 

--- a/proofs/Proofs/Erdos483Problem.lean
+++ b/proofs/Proofs/Erdos483Problem.lean
@@ -25,7 +25,7 @@ Axioms: 5 (schurNumber_4, schurNumber_5, schur_lower_bound, schur_upper_bound, e
 Reference: https://erdosproblems.com/483
 -/
 
-open SchursTheorem
+open SchursTheorem hiding schurNumber
 
 -- ## Defining the Schur Number
 
@@ -178,15 +178,17 @@ def sumFreeColoring13 : IntegerColoring 13 3 := fun i =>
 
 /-- The witness coloring has no monochromatic Schur triple. -/
 theorem sumFreeColoring13_no_triple : ¬HasMonochromaticSchurTriple sumFreeColoring13 := by
-  native_decide
+  unfold HasMonochromaticSchurTriple; native_decide
 
 /-- S(3) > 13: some 3-coloring of {1,...,13} avoids monochromatic triples. -/
 theorem not_schurProp_13_3 : ¬SchurProp 13 3 := by
   intro h
   exact sumFreeColoring13_no_triple (h sumFreeColoring13)
 
-/-- S(3) ≤ 14: every 3-coloring of {1,...,14} has a monochromatic Schur triple. -/
-theorem schurProp_14_3 : SchurProp 14 3 := by native_decide
+/-- S(3) ≤ 14: every 3-coloring of {1,...,14} has a monochromatic Schur triple.
+    This is `SchursTheorem.schur_3_upper` (verified externally by SAT; native_decide over
+    the 3^14 colorings is infeasible, so it is axiomatized upstream in SchursTheorem). -/
+theorem schurProp_14_3 : SchurProp 14 3 := schur_3_upper
 
 /-- S(3) = 14. -/
 theorem schurNumber_3 : schurNumber 3 = 14 := by
@@ -228,8 +230,9 @@ axiom schur_upper_bound :
 /-- castSucc is injective. -/
 private theorem castSucc_inj {m : ℕ} {a b : Fin m}
     (h : a.castSucc = b.castSucc) : a = b :=
-  Fin.ext (congr_arg Fin.val h)
+  Fin.castSucc_inj.mp h
 
+open Classical in
 /-- Recursive lower bound on Schur numbers.
 
     Given a Schur-free k-coloring c of {1,...,S(k)-1}, construct a Schur-free
@@ -237,11 +240,10 @@ private theorem castSucc_inj {m : ℕ} {a b : Fin m}
     - Region A (indices < n): original colors (castSucc)
     - Region B (n ≤ index ≤ 2n): new color (Fin.last k)
     - Region C (index > 2n): mirror of original colors (castSucc) -/
-open Classical in
 theorem schurNumber_recursive_lower (k : ℕ) (hk : k ≥ 1) :
     schurNumber (k + 1) ≥ 3 * schurNumber k - 1 := by
   have hm : schurNumber k ≥ 2 :=
-    le_trans (schurNumber_1 ▸ le_refl 2) (schurNumber_nondecreasing (by omega) hk)
+    le_trans schurNumber_1.ge (schurNumber_nondecreasing (by omega) hk)
   set n := schurNumber k - 1 with hn_def
   have hn : n ≥ 1 := by omega
   -- By minimality, ∃ Schur-free k-coloring of {1,...,n}
@@ -287,10 +289,12 @@ theorem schurNumber_recursive_lower (k : ℕ) (hk : k ≥ 1) :
     have hca := val_B a ha_B.1 ha_B.2
     have hcb : (c' b).val = k := by have := congr_arg Fin.val hab; omega
     have hb_B : n ≤ b.val ∧ b.val ≤ 2 * n := by
-      by_contra h; push_neg at h; exact absurd hcb (val_AC b h).ne
+      by_contra h
+      exact absurd hcb (val_AC b (by omega)).ne
     have hcd : (c' d).val = k := by have := congr_arg Fin.val hbd; omega
     have hd_B : n ≤ d.val ∧ d.val ≤ 2 * n := by
-      by_contra h; push_neg at h; exact absurd hcd (val_AC d h).ne
+      by_contra h
+      exact absurd hcd (val_AC d (by omega)).ne
     -- All in B: (a+1)+(b+1) ≥ 2(n+1) > 2n+1 ≥ d+1. Contradiction.
     omega
   · -- a in A∪C: color value < k. Same for b and d.
@@ -314,14 +318,14 @@ theorem schurNumber_recursive_lower (k : ℕ) (hk : k ≥ 1) :
     · omega
     -- (A,C,C): reduce (a, b-2n-1, d-2n-1) to triple in c
     · exact ⟨⟨a.val, ha⟩, ⟨b.val - (2*n+1), by omega⟩, ⟨d.val - (2*n+1), by omega⟩,
-        by omega,
+        by show (a.val + 1) + (b.val - (2*n+1) + 1) = d.val - (2*n+1) + 1; omega,
         castSucc_inj (by rw [← c'_A a ha, ← c'_C b hb]; exact hab),
         castSucc_inj (by rw [← c'_C b hb, ← c'_C d hd]; exact hbd)⟩
     -- (C,A,A): a+1 ≥ 2n+2, sum ≥ 2n+3 > n ≥ d+1. Contradiction.
     · omega
     -- (C,A,C): reduce (a-2n-1, b, d-2n-1) to triple in c
     · exact ⟨⟨a.val - (2*n+1), by omega⟩, ⟨b.val, hb⟩, ⟨d.val - (2*n+1), by omega⟩,
-        by omega,
+        by show (a.val - (2*n+1) + 1) + (b.val + 1) = d.val - (2*n+1) + 1; omega,
         castSucc_inj (by rw [← c'_C a ha, ← c'_A b hb]; exact hab),
         castSucc_inj (by rw [← c'_A b hb, ← c'_C d hd]; exact hbd)⟩
     -- (C,C,A): sum ≥ 4n+4, d+1 ≤ n. Contradiction.

--- a/proofs/batch2/STATUS.md
+++ b/proofs/batch2/STATUS.md
@@ -1,3 +1,86 @@
+# DOCTOR INCREMENT 70 (deep-rework partition A: A–M + Erdos < 600, #38065, 2026-07-15)
+
+Container `dr70` (cpus 6-11, 11g, cache v431-b), worktree doctor-b, branch
+`feature/issue-38065-inc70` off origin/feature/issue-37508. **+5 GREEN.** PR #38673.
+Every flip verified in-container `lake build Proofs.X` exit-0 before ledger flip; pushed
+per file. Two coherent families cleared.
+
+## Flips (failure class in parens)
+- **Erdos483Problem + Erdos483OQ02** (elab-drift, family — OQ02 imports parent):
+  `open SchursTheorem` now collides with the file's own root `schurNumber` def (v4.31 makes
+  a root decl + opened-namespace decl of the same name AMBIGUOUS rather than root-wins) →
+  `open SchursTheorem hiding schurNumber` (both files). **native_decide over 3^14 colorings
+  is INFEASIBLE on v4.31** (`schurProp_14_3 : SchurProp 14 3`; observed 34+ min CPU, climbing
+  RAM, OOM-risk) — but SchursTheorem already **axiomatizes this exact fact** as
+  `axiom schur_3_upper : ∀ c : IntegerColoring 14 3, HasMonochromaticSchurTriple c` (SAT-verified
+  upstream). `SchurProp 14 3` is defeq to `schur_3_upper` → `theorem schurProp_14_3 := schur_3_upper`
+  (no NEW axiom; reuses the existing dependency axiom, swaps Lean.ofReduceBool for a stated one).
+  Concrete-single-coloring native_decide (`sumFreeColoring13_no_triple`, 13^3) kept — cheap.
+  Also: `Fin.ext (congr_arg Fin.val h)` → `Fin.castSucc_inj.mp h`; a docstring immediately
+  before `open Classical in` is a v4.31 PARSE ERROR → move `open Classical in` above the
+  docstring; `schurNumber_1 ▸ le_refl 2` triangle → `schurNumber_1.ge`; **push_neg on
+  ¬(a∧b) yields the IMPLICATION form `a → ¬b`, not a disjunction** → route the `val_AC`
+  disjunction argument through `(by omega)`; **omega could not connect `hsum`'s `(↑a : Fin).val`
+  atom with the goal's `(⟨↑a, _⟩ : Fin).val` mk-projection atom** → `show` the reduced ℕ
+  equation (defeq collapses the Fin.mk `.val` projections) then `omega`.
+- **BirthdayProblemOQ01OQ01 + …Aristotle + …OQ03** (parse-error class, 3-file family; root
+  imported by both siblings): `Finset.filter_eq_empty` → `filter_eq_empty_iff` (now
+  `∀ ⦃x⦄, x∈s → ¬p x`; rewrote `collisionCount_eq_zero_iff` to consume the mem-form via
+  `Finset.mem_univ`); `←sum_filter` + `sum_congr rfl` no longer unifies the nested-filter
+  index sets → `unfold` + `Finset.sum_boole` + `Finset.filter_filter` + `Nat.cast_id`;
+  **`Finset.card_offDiag` → `Finset.offDiag_card`** (now yields `s.card*s.card − s.card`, NOT
+  `s.card*(s.card−1)`) → append `Nat.mul_sub_one` to close `n*n−n = n*(n−1)`; **`Finset.card_bij`
+  `i_inj` arg order is now interleaved `a₁ ha₁ a₂ ha₂`** (was `a₁ a₂ ha₁ ha₂`) → insert the `_`;
+  `ne_iff_lt_or_gt` AS A SIMP ARG loops to maxRecDepth → `ext` + `simp only` mem-lemmas +
+  `exact ne_iff_lt_or_gt` (term-mode, no loop); `Finset.filter_subset_filter` no longer proves
+  same-set pred-implication subset → direct `intro x hx; mem_filter; ⟨hx.1, hx.2.1⟩`;
+  `({j}:Finset).compl` field removed → `{j}ᶜ`; `Nat.succ_sub_one` rw now a no-op (push_cast
+  pre-reduced) → drop; `Fintype.card_congr` equiv obligations `simp [hij]` / `simpa using hfij`.
+  OQ03: `collisionProb (fun _ => 1/d)` can't infer implicit `{d}` from an unannotated binder →
+  pin `fun _ : Fin d => …`; `field_simp` now fully closes → drop trailing `ring` (the reported
+  `end`-name mismatch was a cascade of the `No goals` error).
+
+## Deferred (partition A, triaged this increment)
+- **Erdos461Problem** (unknown-const): the `Nat.factors`→`primeFactorsList` rename family is
+  clean and clears ~9 errors (`prod_factors`→`prod_primeFactorsList`,
+  `prime_of_mem_factors`→`prime_of_mem_primeFactorsList`, `factors_one/zero`→`primeFactorsList_one/zero`,
+  `factors_prime`→`primeFactorsList_prime`, `dvd_of_mem_factors`→`dvd_of_mem_primeFactorsList`,
+  `factors_mul`→`perm_primeFactorsList_mul`; also `List.filter_eq_nil.mpr`→`filter_eq_nil_iff.mpr`,
+  `Nat.dvd_gcd.mp`→`Nat.dvd_gcd_iff.mp`, `Finset.card_Icc`→`Nat.card_Icc`,
+  `List.mem_cons_self a l`→`List.mem_cons.mpr (Or.inl rfl)`, nil-case omega→`hp.ne_one`). BUT the
+  file has a GENUINE predicate-encoding inconsistency v4.31 no longer bridges: `comp` is
+  `(…filter (fun x => ¬ x < t)).prod` while `smoothComponent`/`no_small_prime_in_complement` use
+  `fun x => decide (x < t)` / `fun x => ¬ decide (x < t)`, and the `list_prod_filter_mul_not`
+  helper is stated with Bool `!?P`. `¬ x < t` vs `!decide (x<t)` vs `decide (¬ x<t)` are no longer
+  defeq at the filter, breaking `list_prod_filter_mul_not` rw + `no_small_prime_in_complement`
+  application + a linarith-under-DecidableEq + two `dif` unsolved goals. Needs a real filter-predicate
+  unification refactor (make every filter `fun x => decide (x < t)`), not renames. ~8 residual errors.
+  Renames alone were discarded (can't commit a non-green file); redo them first next attempt.
+
+## New systematic seams (rename-map §7ak candidates)
+1. **root-decl vs opened-namespace-decl of the same name is now AMBIGUOUS** (was root-wins):
+   `open Ns hiding foo` when the file also declares `_root_.foo` and Ns exports `foo`.
+2. **native_decide over a `∀ c : (Fin n → Fin k)` Fintype is infeasible for n·log k large**
+   (3^14 hangs 30+ min / OOM-risk). If an imported module axiomatizes the same ∀-statement
+   (SAT-verified upstream), discharge by `:= that_axiom` (defeq) instead — no new axiom.
+3. **push_neg on `¬(a ∧ b)` gives `a → ¬b`** (implication De Morgan), never a disjunction —
+   downstream that wanted `a' ∨ b'` must go through `omega`/explicit, not the push_neg output.
+4. **omega can't see through a `(⟨v, h⟩ : Fin n).val` mk-projection atom** to identify it with a
+   plain `v` atom used elsewhere (e.g. in a hypothesis) → `show` the defeq-reduced ℕ goal first.
+5. **a docstring `/-- … -/` immediately followed by `open X in decl` is a parse error** ("unexpected
+   token 'open'; expected 'lemma'") → put `open X in` ABOVE the docstring.
+6. **`Finset.card_offDiag` → `Finset.offDiag_card`**, subtraction shape `s.card*s.card − s.card`.
+7. **`Finset.card_bij` `i_inj` arg order is interleaved** `a₁ (h₁) a₂ (h₂)`.
+8. **`ne_iff_lt_or_gt` / `Finset.filter_eq_empty` families as SIMP ARGS loop / are gone** —
+   use term-mode `exact ne_iff_lt_or_gt`, and `filter_eq_empty_iff` for the iff.
+9. **`Nat.factors`→`Nat.primeFactorsList` full API rename** (catalog in Erdos461 defer note above).
+10. **unannotated `fun _ => body` at a call site can no longer back-infer an implicit type arg**
+    from the enclosing expected type in some positions → pin the binder (`fun _ : Fin d => …`).
+
+Ledger after increment 70: +5 GREEN (partition A: Erdos483×2, Birthday×3).
+
+---
+
 # DOCTOR INCREMENT 68 (deep-rework partition A: A–M + Erdos < 600, #38065, 2026-07-15)
 
 Container `dr68` (cpus 6-11, 11g, cache v431-b), worktree doctor-b, branch

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -1313,8 +1313,8 @@ Erdos478Problem	RESIDUAL	type-mismatch
 Erdos479Problem	GREEN	
 Erdos47Problem	GREEN	
 Erdos481Problem	GREEN	
-Erdos483OQ02	RESIDUAL	elab-drift
-Erdos483Problem	RESIDUAL	elab-drift
+Erdos483OQ02	GREEN	elab-drift
+Erdos483Problem	GREEN	elab-drift
 Erdos484Problem	GREEN	
 Erdos485OQ01	PRE-EXISTING	never-compiled:d
 Erdos485OQ02	RESIDUAL	instance-synth

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -248,7 +248,7 @@ BirthdayProblem	GREEN
 BirthdayProblemOQ01	GREEN	
 BirthdayProblemOQ01OQ01	GREEN	parse-error
 BirthdayProblemOQ01OQ01Aristotle	GREEN	parse-error
-BirthdayProblemOQ01OQ01OQ03	RESIDUAL	parse-error
+BirthdayProblemOQ01OQ01OQ03	GREEN	parse-error
 BirthdayProblemOQ02OQ01	RESIDUAL	unknown-const:Finset.sum_range_id_eq_sum_range_succ_div_two
 BirthdayProblemOQ03OQ01	GREEN	
 BirthdayProblemOQ03OQ01OQ02	GREEN	

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -246,8 +246,8 @@ BirchSwinnertonDyerOQ06	GREEN
 BirchSwinnertonDyerOQ06OQ02	GREEN	
 BirthdayProblem	GREEN	
 BirthdayProblemOQ01	GREEN	
-BirthdayProblemOQ01OQ01	RESIDUAL	parse-error
-BirthdayProblemOQ01OQ01Aristotle	RESIDUAL	parse-error
+BirthdayProblemOQ01OQ01	GREEN	parse-error
+BirthdayProblemOQ01OQ01Aristotle	GREEN	parse-error
 BirthdayProblemOQ01OQ01OQ03	RESIDUAL	parse-error
 BirthdayProblemOQ02OQ01	RESIDUAL	unknown-const:Finset.sum_range_id_eq_sum_range_succ_div_two
 BirthdayProblemOQ03OQ01	GREEN	


### PR DESCRIPTION
Deep-rework tail grind for epic #37508 (ledger #38065), partition A (A–M + Erdos<600). Container dr70 (cpus 6-11, cache v431-b). Every file verified green in-container before ledger flip; pushed per file.

## Files flipped GREEN
- **Erdos483Problem** (elab-drift) + **Erdos483OQ02** (imports parent) — Schur-number growth. Root cause `open SchursTheorem` colliding with the file's root `schurNumber` def; plus native_decide over 3^14 colorings infeasible on v4.31 (routed to the existing upstream `schur_3_upper` axiom, defeq), Fin.castSucc_inj, docstring/open parse order, push_neg implication-form, and omega Fin.mk-projection atom hygiene. See commit for full seam list.

No `loom:review-requested`. Do not merge (deployer handles).