### PR TITLE
migrate(v4.31): Doctor increment 71 — deep-rework partition B (+6 GREEN)

### DIFF
--- a/proofs/Proofs/WilsonsTheoremOQ01.lean
+++ b/proofs/Proofs/WilsonsTheoremOQ01.lean
@@ -427,12 +427,15 @@ theorem unitsProduct_prime {p : ℕ} (hp : Nat.Prime p) (_hp2 : p ≥ 2) :
   obtain ⟨k, hk⟩ := h_wilson
   have hk_pos : 0 < k := by
     rcases k with _ | k
-    · simp at hk; omega
+    · simp at hk
     · omega
   -- (p-1)! = p * k - 1 = p * (k - 1) + (p - 1)
+  have hexp : p * (k - 1) + p = p * k := by
+    cases k with
+    | zero => omega
+    | succ m => simp [Nat.succ_sub_one, Nat.mul_succ]
   have key : (p - 1).factorial = p * (k - 1) + (p - 1) := by omega
-  rw [key]
-  exact Nat.add_mul_mod_self_left (p - 1) p (k - 1)
+  rw [key, add_comm, Nat.add_mul_mod_self_left, Nat.mod_eq_of_lt (by omega)]
 
 -- Wilson's theorem in product form (from Mathlib)
 theorem wilson_product_form (p : ℕ) [hp : Fact (Nat.Prime p)] :
@@ -640,8 +643,7 @@ We connect the concrete `unitsProduct n % n = n - 1` to the abstract
 private lemma natCast_sub_one_eq_neg_one' {n : ℕ} (hn : n ≥ 1) :
     (↑(n - 1) : ZMod n) = -1 := by
   haveI : NeZero n := ⟨by omega⟩
-  rw [eq_neg_iff_add_eq_zero]
-  rw [← Nat.cast_one, ← Nat.cast_add, Nat.sub_add_cancel hn, ZMod.natCast_self_eq_zero]
+  rw [Nat.cast_sub hn, Nat.cast_one, ZMod.natCast_self, zero_sub]
 
 theorem unitsProduct_eq_neg_one_iff_cyclic {n : ℕ} (hn : n ≥ 3) :
     unitsProduct n % n = n - 1 ↔ IsCyclic (ZMod n)ˣ := by
@@ -657,7 +659,7 @@ theorem unitsProduct_eq_neg_one_iff_cyclic {n : ℕ} (hn : n ≥ 3) :
     intro h
     have hzmod : (↑(unitsProduct n) : ZMod n) = -1 := by
       rw [← natCast_sub_one_eq_neg_one' (show n ≥ 1 by omega)]
-      exact ZMod.val_injective (by
+      exact ZMod.val_injective n (by
         rw [ZMod.val_natCast, ZMod.val_natCast, h, Nat.mod_eq_of_lt (by omega)])
     rw [hcast] at hzmod
     exact (WilsonsTheoremOQ02.gaussWilson_abstract hn).mp hzmod
@@ -667,7 +669,7 @@ theorem unitsProduct_eq_neg_one_iff_cyclic {n : ℕ} (hn : n ≥ 3) :
       (WilsonsTheoremOQ02.gaussWilson_abstract hn).mpr hcyc
     rw [← hcast, ← natCast_sub_one_eq_neg_one' (show n ≥ 1 by omega)] at hzmod
     have hval := congrArg ZMod.val hzmod
-    rwa [ZMod.val_natCast, ZMod.val_natCast, Nat.mod_eq_of_lt (by omega)] at hval
+    rwa [ZMod.val_natCast, ZMod.val_natCast, Nat.mod_eq_of_lt (show n - 1 < n by omega)] at hval
 
 -- The full Gauss-Wilson classification
 -- Reduces to: unitsProduct bridge (above) + isCyclic_units_iff_gaussWilson (Mathlib)
@@ -676,13 +678,11 @@ theorem gaussWilson_classification (n : ℕ) (hn : n ≥ 3) :
     (∃ p k, Nat.Prime p ∧ p ≠ 2 ∧ k ≥ 1 ∧ (n = p ^ k ∨ n = 2 * p ^ k)) ∨ n = 4 := by
   rw [unitsProduct_eq_neg_one_iff_cyclic hn, isCyclic_units_iff_gaussWilson hn]
   constructor
-  · intro h
-    rcases h with rfl | ⟨p, k, hp, hodd, hk, hform⟩
-    · left; rfl
-    · right; exact ⟨p, k, hp, ((prime_odd_iff_ne_two hp).mp hodd), hk, hform⟩
-  · intro h
-    rcases h with ⟨p, k, hp, hne2, hk, hform⟩ | rfl
-    · right; exact ⟨p, k, hp, (prime_odd_iff_ne_two hp).mpr hne2, hk, hform⟩
-    · left; rfl
+  · rintro (rfl | ⟨p, k, hp, hodd, hk, hform⟩)
+    · exact Or.inr rfl
+    · exact Or.inl ⟨p, k, hp, (prime_odd_iff_ne_two hp).mp hodd, hk, hform⟩
+  · rintro (⟨p, k, hp, hne2, hk, hform⟩ | rfl)
+    · exact Or.inr ⟨p, k, hp, (prime_odd_iff_ne_two hp).mpr hne2, hk, hform⟩
+    · exact Or.inl rfl
 
 end WilsonsTheoremGeneralization

--- a/proofs/Proofs/WilsonsTheoremOQ02.lean
+++ b/proofs/Proofs/WilsonsTheoremOQ02.lean
@@ -156,20 +156,24 @@ theorem prod_klein_four {G : Type*} [CommGroup G] [DecidableEq G]
     (hab : a ≠ b) (ha1 : a ≠ 1) (hb1 : b ≠ 1) (hab1 : a * b ≠ 1) :
     ({1, a, b, a * b} : Finset G).prod id = 1 := by
   -- All four elements are distinct
-  have hab_ne_a : a * b ≠ a := fun h => hb1 (mul_left_cancel h)
-  have hab_ne_b : a * b ≠ b := fun h => ha1 (mul_right_cancel h)
+  have hab_ne_a : a * b ≠ a := fun h => hb1 (mul_left_cancel (a := a) (by rw [mul_one]; exact h))
+  have hab_ne_b : a * b ≠ b := fun h => ha1 (mul_right_cancel (b := b) (by rw [one_mul]; exact h))
   have ha_ne_1 : a ≠ 1 := ha1
   have hb_ne_1 : b ≠ 1 := hb1
-  rw [Finset.prod_insert (by simp [Finset.mem_insert, Finset.mem_singleton]; push_neg
-                              exact ⟨ha1, hb1, hab1⟩)]
-  rw [Finset.prod_insert (by simp [Finset.mem_insert, Finset.mem_singleton]; push_neg
-                              exact ⟨hab, hab_ne_b⟩)]
-  rw [Finset.prod_insert (by simp; exact (fun h => hab_ne_a (mul_comm b a ▸ h)))]
+  rw [Finset.prod_insert (by
+    simp only [Finset.mem_insert, Finset.mem_singleton, not_or]
+    exact ⟨fun h => ha1 h.symm, fun h => hb1 h.symm, fun h => hab1 h.symm⟩)]
+  rw [Finset.prod_insert (by
+    simp only [Finset.mem_insert, Finset.mem_singleton, not_or]
+    exact ⟨hab, hab_ne_a.symm⟩)]
+  rw [Finset.prod_insert (by
+    simp only [Finset.mem_singleton]
+    exact hab_ne_b.symm)]
   simp only [Finset.prod_singleton, id]
   -- Goal: 1 * (a * (b * (a * b))) = 1
   rw [one_mul]
   -- a * (b * (a * b)) = a * b * (a * b) = (ab)²
-  have key : a * (b * (a * b)) = (a * b) ^ 2 := by group
+  have key : a * (b * (a * b)) = (a * b) ^ 2 := by rw [sq, mul_assoc]
   rw [key, mul_sq_eq_one_of_sq_eq_one ha hb]
 
 -- ============================================================================
@@ -187,9 +191,7 @@ theorem prod_univ_sq_eq_one (G : Type*) [CommGroup G] [Fintype G] :
   -- But ∏ x⁻¹ = (∏ x)⁻¹
   -- So ∏ x = (∏ x)⁻¹, giving (∏ x)² = 1
   suffices h : (∏ x : G, x)⁻¹ = ∏ x : G, x by
-    rw [sq]
-    conv_lhs => rw [← h]
-    exact inv_mul_cancel _
+    rw [sq_eq_one_iff_eq_inv]; exact h.symm
   rw [← Finset.prod_inv_distrib]
   -- Goal: ∏ x ∈ univ, x⁻¹ = ∏ x ∈ univ, x
   -- The map x ↦ x⁻¹ is a bijection on univ
@@ -212,10 +214,7 @@ theorem prod_eq_prod_sq_eq_one (G : Type*) [CommGroup G] [Fintype G] [DecidableE
     (Finset.prod_filter_mul_prod_filter_not Finset.univ (fun x : G => x ^ 2 = 1) id).symm
   -- The second factor is 1 by involution x ↦ x⁻¹
   have hrest : ∏ x ∈ Finset.univ.filter (fun x : G => ¬(x ^ 2 = 1)), x = 1 := by
-    apply Finset.prod_involution (fun x _ => x⁻¹)
-    · -- x * x⁻¹ = 1
-      intros a _
-      exact mul_inv_cancel a
+    refine Finset.prod_involution (fun x _ => x⁻¹) (fun a _ => mul_inv_cancel a) ?_ ?_ ?_
     · -- x ≠ x⁻¹ when x² ≠ 1
       intro a ha hne
       simp only [Finset.mem_filter, Finset.mem_univ, true_and] at ha
@@ -225,7 +224,7 @@ theorem prod_eq_prod_sq_eq_one (G : Type*) [CommGroup G] [Fintype G] [DecidableE
       simp only [Finset.mem_filter, Finset.mem_univ, true_and] at ha ⊢
       rwa [inv_pow, inv_eq_one]
     · -- Involution: (x⁻¹)⁻¹ = x
-      intros a _
+      intro a _
       exact inv_inv a
   rw [hsplit, hrest, mul_one]
 
@@ -302,23 +301,23 @@ theorem unitsProduct_cast_eq_abstract {n : ℕ} (hn : n ≥ 1) [hne : NeZero n] 
   -- We use prod_bij with the map a ↦ ZMod.unitOfCoprime a (coprime proof)
   -- but first rewrite the RHS to use ↑u for units
   symm
-  apply Finset.prod_nbij (fun u => ZMod.val (u : ZMod n))
+  refine Finset.prod_nbij (fun u => ZMod.val (u : ZMod n)) ?_ ?_ ?_ ?_
   · -- Map sends units into the filtered set
     intro u _
     simp only [Finset.mem_filter, Finset.mem_range]
-    exact ⟨ZMod.val_lt _, ZMod.val_coe_unit_coprime⟩
+    exact ⟨ZMod.val_lt _, ZMod.val_coe_unit_coprime u⟩
   · -- Injective: val is injective on ZMod n, and units coerce injectively
-    intro u₁ u₂ _ _ h
-    have hval : (u₁ : ZMod n) = (u₂ : ZMod n) := ZMod.val_injective h
+    intro u₁ _ u₂ _ h
+    have hval : (u₁ : ZMod n) = (u₂ : ZMod n) := ZMod.val_injective n h
     exact Units.val_injective hval
   · -- Surjective: every coprime natural < n comes from a unit
     intro a ha
-    simp only [Finset.mem_filter, Finset.mem_range] at ha
+    rw [Finset.mem_coe, Finset.mem_filter, Finset.mem_range] at ha
     exact ⟨ZMod.unitOfCoprime a ha.2, Finset.mem_univ _,
-      by rw [Units.val_unitOfCoprime]; exact (ZMod.val_natCast_of_lt ha.1).symm⟩
+      by dsimp only; rw [ZMod.coe_unitOfCoprime]; exact ZMod.val_natCast_of_lt ha.1⟩
   · -- Values agree: casting a through id and casting unit value agree
     intro u _
-    simp [Nat.cast_id]
+    simp [ZMod.natCast_val, Nat.cast_id]
 
 -- ============================================================================
 -- Part 9: Computational Verification

--- a/proofs/Proofs/WilsonsTheoremOQ02Ext.lean
+++ b/proofs/Proofs/WilsonsTheoremOQ02Ext.lean
@@ -66,32 +66,36 @@ theorem even_card_of_fpf_involution {α : Type*} [DecidableEq α]
   | H S ih =>
     by_cases hS : S = ∅
     · subst hS; exact ⟨0, by simp⟩
-    · rw [Finset.nonempty_iff_ne_empty] at hS
-      obtain ⟨a, ha⟩ := Finset.nonempty_of_ne_empty hS
+    · obtain ⟨a, ha⟩ := Finset.nonempty_iff_ne_empty.mpr hS
       have hσa_ne : σ a ≠ a := hσ_ne a ha
-      set T := S \ {a, σ a}
+      set T := S \ {a, σ a} with hT_def
       have hpair_sub : {a, σ a} ⊆ S := by
         intro x hx; simp at hx; rcases hx with rfl | rfl
         · exact ha
         · exact hσ_mem a ha
       have hT_mem : ∀ x ∈ T, σ x ∈ T := by
         intro x hx
+        rw [hT_def] at hx ⊢
         simp only [Finset.mem_sdiff, Finset.mem_insert, Finset.mem_singleton] at hx ⊢
-        refine ⟨hσ_mem x hx.1, ?_, ?_⟩
-        · intro heq; exact hx.2 (Or.inr (by rw [← hσ_inv x hx.1, heq]))
-        · intro heq
-          have : x = a := by rw [← hσ_inv x hx.1, heq, hσ_inv a ha]
-          exact hx.2 (Or.inl this)
+        refine ⟨hσ_mem x hx.1, ?_⟩
+        rintro (heq | heq)
+        · exact hx.2 (Or.inr (by rw [← hσ_inv x hx.1, heq]))
+        · have hxa : x = a := by rw [← hσ_inv x hx.1, heq, hσ_inv a ha]
+          exact hx.2 (Or.inl hxa)
       have hT_inv : ∀ x ∈ T, σ (σ x) = x :=
         fun x hx => hσ_inv x (Finset.mem_sdiff.mp hx).1
       have hT_ne : ∀ x ∈ T, σ x ≠ x :=
         fun x hx => hσ_ne x (Finset.mem_sdiff.mp hx).1
       have hT_lt : T ⊂ S :=
-        Finset.sdiff_ssubset (by exact ⟨a, ha, Finset.mem_insert_self a _⟩)
+        Finset.sdiff_ssubset hpair_sub ⟨a, Finset.mem_insert_self a _⟩
       obtain ⟨k, hk⟩ := ih T hT_lt hT_mem hT_inv hT_ne
       have hcard_pair : ({a, σ a} : Finset α).card = 2 :=
         Finset.card_pair hσa_ne.symm
-      exact ⟨k + 1, by rw [Finset.card_sdiff hpair_sub, hcard_pair] at hk; omega⟩
+      refine ⟨k + 1, ?_⟩
+      have hSge : 2 ≤ S.card := by
+        have h := Finset.card_le_card hpair_sub; rw [hcard_pair] at h; exact h
+      rw [hT_def, Finset.card_sdiff_of_subset hpair_sub, hcard_pair] at hk
+      omega
 
 /-- Product over a Finset with a constant-product FPF involution.
     If σ is an FPF involution on S with x * σ(x) = c for all x ∈ S,
@@ -107,10 +111,9 @@ theorem prod_involution_const {G : Type*} [CommGroup G] [DecidableEq G]
   | H S ih =>
     by_cases hS : S = ∅
     · subst hS; simp
-    · rw [Finset.nonempty_iff_ne_empty] at hS
-      obtain ⟨a, ha⟩ := Finset.nonempty_of_ne_empty hS
+    · obtain ⟨a, ha⟩ := Finset.nonempty_iff_ne_empty.mpr hS
       have hσa_ne : σ a ≠ a := hσ_ne a ha
-      set T := S \ {a, σ a}
+      set T := S \ {a, σ a} with hT_def
       have hpair_sub : {a, σ a} ⊆ S := by
         intro x hx; simp at hx; rcases hx with rfl | rfl
         · exact ha
@@ -119,12 +122,13 @@ theorem prod_involution_const {G : Type*} [CommGroup G] [DecidableEq G]
         Finset.card_pair hσa_ne.symm
       have hT_mem : ∀ x ∈ T, σ x ∈ T := by
         intro x hx
+        rw [hT_def] at hx ⊢
         simp only [Finset.mem_sdiff, Finset.mem_insert, Finset.mem_singleton] at hx ⊢
-        refine ⟨hσ_mem x hx.1, ?_, ?_⟩
-        · intro heq; exact hx.2 (Or.inr (by rw [← hσ_inv x hx.1, heq]))
-        · intro heq
-          have : x = a := by rw [← hσ_inv x hx.1, heq, hσ_inv a ha]
-          exact hx.2 (Or.inl this)
+        refine ⟨hσ_mem x hx.1, ?_⟩
+        rintro (heq | heq)
+        · exact hx.2 (Or.inr (by rw [← hσ_inv x hx.1, heq]))
+        · have hxa : x = a := by rw [← hσ_inv x hx.1, heq, hσ_inv a ha]
+          exact hx.2 (Or.inl hxa)
       have hT_inv : ∀ x ∈ T, σ (σ x) = x :=
         fun x hx => hσ_inv x (Finset.mem_sdiff.mp hx).1
       have hT_ne : ∀ x ∈ T, σ x ≠ x :=
@@ -132,11 +136,11 @@ theorem prod_involution_const {G : Type*} [CommGroup G] [DecidableEq G]
       have hT_prod : ∀ x ∈ T, x * σ x = c :=
         fun x hx => hσ_prod x (Finset.mem_sdiff.mp hx).1
       have hT_lt : T ⊂ S :=
-        Finset.sdiff_ssubset (by exact ⟨a, ha, Finset.mem_insert_self a _⟩)
+        Finset.sdiff_ssubset hpair_sub ⟨a, Finset.mem_insert_self a _⟩
       have hih := ih T hT_lt hT_mem hT_inv hT_ne hT_prod
       -- ∏ S = ∏ {a, σ a} * ∏ T = c * c^(T.card/2)
-      have hsplit : ∏ x ∈ S, x = (∏ x ∈ ({a, σ a} : Finset G), x) * ∏ x ∈ T, x :=
-        (Finset.prod_sdiff hpair_sub).symm
+      have hsplit : ∏ x ∈ S, x = (∏ x ∈ ({a, σ a} : Finset G), x) * ∏ x ∈ T, x := by
+        rw [hT_def, ← Finset.prod_sdiff hpair_sub]; exact mul_comm _ _
       have hprod_pair : ∏ x ∈ ({a, σ a} : Finset G), x = c := by
         rw [Finset.prod_pair hσa_ne.symm]; exact hσ_prod a ha
       rw [hsplit, hprod_pair, hih]
@@ -145,100 +149,15 @@ theorem prod_involution_const {G : Type*} [CommGroup G] [DecidableEq G]
       obtain ⟨k, hk⟩ := hT_even
       rw [show T.card / 2 = k from by omega]
       rw [show S.card / 2 = k + 1 from by
-        rw [Finset.card_sdiff hpair_sub, hcard_pair] at hk; omega]
-      ring
+        have hk2 := hk
+        have hSge : 2 ≤ S.card := by
+          have h := Finset.card_le_card hpair_sub; rw [hcard_pair] at h; exact h
+        rw [hT_def, Finset.card_sdiff_of_subset hpair_sub, hcard_pair] at hk2; omega]
+      rw [pow_succ]; exact mul_comm _ _
 
 -- ============================================================================
 -- Section 3: Non-Cyclic 2-Torsion — Helper Lemmas
 -- ============================================================================
-
-/-- -1 ≠ 1 in ZMod m for m ≥ 3. -/
-private lemma neg_one_ne_one_zmod_aux {m : ℕ} (hm : m ≥ 3) : (-1 : ZMod m) ≠ 1 := by
-  haveI : NeZero m := ⟨by omega⟩
-  intro heq
-  have : (m : ℤ) ∣ (-2 : ℤ) := by
-    rw [← ZMod.intCast_zmod_eq_zero_iff_dvd]
-    have hcast : ((-2 : ℤ) : ZMod m) = -1 - 1 := by push_cast; ring
-    rw [hcast, heq, sub_self]
-  have : m ≤ 2 := by
-    have := Int.natAbs_le.mp (Int.le_of_dvd (by norm_num) (dvd_abs.mpr this))
-    omega
-  omega
-
-/-- CRT construction: for coprime a, b ≥ 3, ZMod (a*b) has a third square root of unity. -/
-private theorem exists_third_sqrt_coprime {a b : ℕ}
-    (hab : Nat.Coprime a b) (ha : a ≥ 3) (hb : b ≥ 3) :
-    ∃ x : ZMod (a * b), x ^ 2 = 1 ∧ x ≠ 1 ∧ x ≠ -1 := by
-  let φ := ZMod.chineseRemainder hab
-  use φ.symm (1, -1)
-  refine ⟨?_, ?_, ?_⟩
-  · rw [← map_one φ.symm, ← map_pow]; congr 1; ext <;> simp [sq]
-  · intro h
-    have : (1 : ZMod a × ZMod b) = ((1, -1) : ZMod a × ZMod b) := by
-      rw [← map_one φ, ← h, φ.apply_symm_apply]
-    simp at this; exact neg_one_ne_one_zmod_aux hb this.symm
-  · intro h
-    have : (-1 : ZMod a × ZMod b) = ((1, -1) : ZMod a × ZMod b) := by
-      rw [← map_neg, ← map_one φ, ← h, φ.apply_symm_apply]
-    simp [Prod.ext_iff, Prod.neg_def] at this
-    exact neg_one_ne_one_zmod_aux ha this.1
-
-/-- 2^k divides (2^(k-1)+1)^2 - 1 for k ≥ 3. -/
-private theorem pow2_sq_sub_one_dvd (k : ℕ) (hk : k ≥ 3) :
-    2 ^ k ∣ ((2 ^ (k - 1) + 1) ^ 2 - 1) := by
-  have h1 : (2 ^ (k - 1) + 1) ^ 2 - 1 = (2 ^ (k - 1) + 1 - 1) * (2 ^ (k - 1) + 1 + 1) := by
-    have : 2 ^ (k - 1) + 1 ≥ 1 := by omega; omega
-  rw [h1]; simp only [add_tsub_cancel_right]
-  have h2 : 2 ^ (k - 1) + 2 = 2 * (2 ^ (k - 2) + 1) := by
-    rw [show k - 1 = (k - 2) + 1 from by omega, pow_succ]; ring
-  rw [h2, show 2 ^ (k - 1) * (2 * (2 ^ (k - 2) + 1)) =
-    2 ^ (k - 1) * 2 * (2 ^ (k - 2) + 1) from by ring,
-    show 2 ^ (k - 1) * 2 = 2 ^ k from by rw [show k = (k - 1) + 1 from by omega, pow_succ]]
-  exact dvd_mul_right _ _
-
-/-- For k ≥ 3, the element 2^(k-1)+1 squares to 1 in ZMod (2^k). -/
-private theorem pow2_cast_sq_eq_one (k : ℕ) (hk : k ≥ 3) :
-    ((2 ^ (k - 1) + 1 : ℕ) : ZMod (2 ^ k)) ^ 2 = 1 := by
-  haveI : NeZero (2 ^ k : ℕ) := ⟨by positivity⟩
-  have hdvd := pow2_sq_sub_one_dvd k hk
-  have : ((2 ^ (k - 1) + 1) ^ 2 - 1 + 1 : ℕ) = (2 ^ (k - 1) + 1) ^ 2 := by omega
-  calc ((2 ^ (k - 1) + 1 : ℕ) : ZMod (2 ^ k)) ^ 2
-      = ((((2 ^ (k - 1) + 1) ^ 2 : ℕ) : ZMod (2 ^ k))) := by push_cast; ring
-    _ = ((((2 ^ (k - 1) + 1) ^ 2 - 1 + 1 : ℕ) : ZMod (2 ^ k))) := by rw [this]
-    _ = ((((2 ^ (k - 1) + 1) ^ 2 - 1 : ℕ) : ZMod (2 ^ k)) + 1) := by push_cast; ring
-    _ = (0 + 1) := by rw [ZMod.natCast_eq_zero_iff.mpr hdvd]
-    _ = 1 := by ring
-
-/-- For k ≥ 3, the element 2^(k-1)+1 is not 1 in ZMod (2^k). -/
-private theorem pow2_cast_ne_one (k : ℕ) (hk : k ≥ 3) :
-    ((2 ^ (k - 1) + 1 : ℕ) : ZMod (2 ^ k)) ≠ 1 := by
-  haveI : NeZero (2 ^ k : ℕ) := ⟨by positivity⟩
-  intro h
-  have hlt : 2 ^ (k - 1) + 1 < 2 ^ k := by
-    calc 2 ^ (k - 1) + 1 < 2 ^ (k - 1) + 2 ^ (k - 1) := by omega
-      _ = 2 ^ k := by rw [show k = (k - 1) + 1 from by omega, pow_succ]; ring
-  have := congr_arg ZMod.val h
-  rw [ZMod.val_natCast, Nat.mod_eq_of_lt hlt, ZMod.val_one (by positivity)] at this
-  omega
-
-/-- For k ≥ 3, the element 2^(k-1)+1 is not -1 in ZMod (2^k). -/
-private theorem pow2_cast_ne_neg_one (k : ℕ) (hk : k ≥ 3) :
-    ((2 ^ (k - 1) + 1 : ℕ) : ZMod (2 ^ k)) ≠ -1 := by
-  haveI : NeZero (2 ^ k : ℕ) := ⟨by positivity⟩
-  intro h
-  have hlt : 2 ^ (k - 1) + 1 < 2 ^ k := by
-    calc 2 ^ (k - 1) + 1 < 2 ^ (k - 1) + 2 ^ (k - 1) := by omega
-      _ = 2 ^ k := by rw [show k = (k - 1) + 1 from by omega, pow_succ]; ring
-  have := congr_arg ZMod.val h
-  rw [ZMod.val_natCast, Nat.mod_eq_of_lt hlt, ZMod.val_neg_one'] at this
-  have : 2 ^ k = 2 * 2 ^ (k - 1) := by
-    rw [show k = (k - 1) + 1 from by omega, pow_succ]
-  omega
-
-/-- For k ≥ 3, ZMod (2^k) has a third square root of unity. -/
-private theorem exists_third_sqrt_pow2 (k : ℕ) (hk : k ≥ 3) :
-    ∃ x : ZMod (2 ^ k), x ^ 2 = 1 ∧ x ≠ 1 ∧ x ≠ -1 :=
-  ⟨_, pow2_cast_sq_eq_one k hk, pow2_cast_ne_one k hk, pow2_cast_ne_neg_one k hk⟩
 
 /-- An element x with x² = 1 is a unit (with inverse x itself). -/
 private noncomputable def unitOfSqEqOne {n : ℕ} [NeZero n] (x : ZMod n) (hx : x ^ 2 = 1) :
@@ -268,6 +187,23 @@ private theorem exists_third_sqrt_of_not_cyclic
     ∃ x : ZMod n, x ^ 2 = 1 ∧ x ≠ 1 ∧ x ≠ -1 :=
   GaussWilsonNonCyclic.exists_third_sqrt_of_not_cyclic hn hncyc
 
+/-- -1 ≠ 1 in (ZMod n)ˣ for n ≥ 3. -/
+private theorem neg_one_ne_one_units' {n : ℕ} (hn : n ≥ 3) :
+    (-1 : (ZMod n)ˣ) ≠ 1 := by
+  haveI : NeZero n := ⟨by omega⟩
+  intro h
+  have h1 : ((-1 : (ZMod n)ˣ) : ZMod n) = ((1 : (ZMod n)ˣ) : ZMod n) := by rw [h]
+  simp only [Units.val_neg, Units.val_one] at h1
+  have h2 : (n : ℤ) ∣ (-1 - 1) := by
+    have := ZMod.intCast_zmod_eq_zero_iff_dvd (-1 - 1) n
+    rw [show ((-1 - 1 : ℤ) : ZMod n) = (-1 : ZMod n) - 1 from by push_cast; ring] at this
+    rw [h1, sub_self] at this; exact this.mp rfl
+  have h3 : (n : ℤ) ∣ 2 := by
+    have : (-1 - 1 : ℤ) = -2 := by ring
+    rw [this] at h2; exact dvd_neg.mp h2
+  have : n ≤ 2 := by have := Int.le_of_dvd (by norm_num : (0 : ℤ) < 2) h3; omega
+  omega
+
 /-- For (ZMod n)ˣ with n ≥ 3 and ¬IsCyclic, the set {x | x²=1} has ≥ 3 elements.
 
     **NOTE**: The general statement for arbitrary CommGroup G is FALSE
@@ -282,10 +218,11 @@ theorem card_sq_eq_one_ge_three_of_not_cyclic_zmod
   -- Lift x to a unit (x² = 1 means x is its own inverse)
   let u := unitOfSqEqOne x hxsq
   have hu_sq : u ^ 2 = 1 := unitOfSqEqOne_sq x hxsq
+  have hval : (u : ZMod n) = x := unitOfSqEqOne_val x hxsq
   have hu_ne_1 : u ≠ 1 := by
-    intro h; apply hxne1; have := congr_arg Units.val h; simpa [unitOfSqEqOne_val] using this
+    intro h; apply hxne1; rw [← hval, h]; simp
   have hu_ne_neg1 : u ≠ -1 := by
-    intro h; apply hxne_neg1; have := congr_arg Units.val h; simpa [unitOfSqEqOne_val] using this
+    intro h; apply hxne_neg1; rw [← hval, h]; simp
   -- {1, -1, u} ⊆ S gives |S| ≥ 3
   set S := Finset.univ.filter (fun x : (ZMod n)ˣ => x ^ 2 = 1)
   have h1_mem : (1 : (ZMod n)ˣ) ∈ S := by simp [S, Finset.mem_filter, sq]
@@ -295,7 +232,7 @@ theorem card_sq_eq_one_ge_three_of_not_cyclic_zmod
   have hsub : ({1, -1, u} : Finset (ZMod n)ˣ) ⊆ S := by
     intro y hy; simp at hy; rcases hy with rfl | rfl | rfl <;> assumption
   have hcard : ({1, -1, u} : Finset (ZMod n)ˣ).card = 3 := by
-    rw [Finset.card_insert_of_notMem (by simp [hne_1_neg1.symm, hu_ne_1.symm])]
+    rw [Finset.card_insert_of_notMem (by simp [hne_1_neg1, hu_ne_1.symm])]
     rw [Finset.card_insert_of_notMem (by simp [hu_ne_neg1.symm])]
     simp
   linarith [Finset.card_le_card hsub]
@@ -306,6 +243,10 @@ theorem card_sq_eq_one_ge_three_of_not_cyclic_zmod
 
 -- Import-free restatements of lemmas from WilsonsTheoremOQ02
 
+/-- x² = 1 ↔ x = x⁻¹ in a commutative group. -/
+private lemma sq_eq_one_iff_eq_inv {G : Type*} [CommGroup G] (x : G) : x ^ 2 = 1 ↔ x = x⁻¹ := by
+  rw [sq, mul_eq_one_iff_eq_inv]
+
 /-- ∏ G = ∏ {x | x² = 1} ∈ any finite commutative group. -/
 theorem prod_eq_prod_sq_eq_one (G : Type*) [CommGroup G] [Fintype G] [DecidableEq G] :
     ∏ x : G, x = ∏ x ∈ Finset.univ.filter (fun x : G => x ^ 2 = 1), x := by
@@ -314,8 +255,7 @@ theorem prod_eq_prod_sq_eq_one (G : Type*) [CommGroup G] [Fintype G] [DecidableE
       (∏ x ∈ Finset.univ.filter (fun x : G => ¬(x ^ 2 = 1)), x) :=
     (Finset.prod_filter_mul_prod_filter_not Finset.univ (fun x : G => x ^ 2 = 1) id).symm
   have hrest : ∏ x ∈ Finset.univ.filter (fun x : G => ¬(x ^ 2 = 1)), x = 1 := by
-    apply Finset.prod_involution (fun x _ => x⁻¹)
-    · intros a _; exact mul_inv_cancel a
+    refine Finset.prod_involution (fun x _ => x⁻¹) (fun a _ => mul_inv_cancel a) ?_ ?_ ?_
     · intro a ha _
       simp only [Finset.mem_filter, Finset.mem_univ, true_and] at ha
       intro heq
@@ -323,11 +263,8 @@ theorem prod_eq_prod_sq_eq_one (G : Type*) [CommGroup G] [Fintype G] [DecidableE
     · intro a ha
       simp only [Finset.mem_filter, Finset.mem_univ, true_and] at ha ⊢
       rwa [inv_pow, inv_eq_one]
-    · intros a _; exact inv_inv a
+    · intro a _; exact inv_inv a
   rw [hsplit, hrest, mul_one]
-  where
-    sq_eq_one_iff_eq_inv {G : Type*} [CommGroup G] (x : G) : x ^ 2 = 1 ↔ x = x⁻¹ := by
-      rw [sq, mul_eq_one_iff_eq_inv]
 
 -- ============================================================================
 -- Section 5: Main Result
@@ -335,7 +272,7 @@ theorem prod_eq_prod_sq_eq_one (G : Type*) [CommGroup G] [Fintype G] [DecidableE
 
 /-- **Involution helper**: For c ∈ S = {x | x² = 1} with c ≠ 1, the map x ↦ cx
     is an FPF involution on S with pair product c. -/
-private theorem mul_involution_on_sq_eq_one {G : Type*} [CommGroup G] [DecidableEq G]
+private theorem mul_involution_on_sq_eq_one {G : Type*} [CommGroup G] [Fintype G] [DecidableEq G]
     {c : G} (hc_sq : c ^ 2 = 1) (hc_ne : c ≠ 1) :
     let S := Finset.univ.filter (fun x : G => x ^ 2 = 1)
     (∀ x ∈ S, c * x ∈ S) ∧
@@ -350,7 +287,10 @@ private theorem mul_involution_on_sq_eq_one {G : Type*} [CommGroup G] [Decidable
   · -- c * (c * x) = x (involution)
     intro x _; rw [← mul_assoc, ← sq, hc_sq, one_mul]
   · -- c * x ≠ x (fixed-point-free)
-    intro x _ h; exact hc_ne (mul_right_cancel h)
+    intro x _ h
+    apply hc_ne
+    have hcx : c * x * x⁻¹ = x * x⁻¹ := by rw [h]
+    simpa [mul_assoc] using hcx
   · -- x * (c * x) = c (constant pair product)
     intro x hx
     simp only [Finset.mem_filter, Finset.mem_univ, true_and] at hx
@@ -372,8 +312,7 @@ theorem prod_units_one_of_not_cyclic_ext {n : ℕ} (hn : n ≥ 3)
   -- Step 2: |S| ≥ 3
   have hS_card : 3 ≤ S.card := card_sq_eq_one_ge_three_of_not_cyclic_zmod hn hncyc
   -- S membership gives x² = 1
-  have hS_mem_sq : ∀ x ∈ S, x ^ 2 = 1 := fun x hx => by
-    simp only [Finset.mem_filter, Finset.mem_univ, true_and] at hx; exact hx
+  have hS_mem_sq : ∀ x ∈ S, x ^ 2 = 1 := fun x hx => (Finset.mem_filter.mp hx).2
   -- Step 3: Pick c ∈ S \ {1}
   have hS_sub1_nonempty : (S \ {1}).Nonempty := by
     rw [Finset.nonempty_iff_ne_empty]; intro hempty
@@ -407,10 +346,10 @@ theorem prod_units_one_of_not_cyclic_ext {n : ℕ} (hn : n ≥ 3)
   have hcd_sq : (c * d) ^ 2 = 1 := mul_sq_eq_one hc_sq hd_sq
   have hcd_ne_1 : c * d ≠ 1 := by
     intro h
-    have : d = c⁻¹ := by rwa [mul_eq_one_iff_eq_inv] at h
-    have : d = c := by
-      rw [this, inv_eq_of_mul_eq_one_right]; rw [← sq]; exact hc_sq
-    exact hd_ne_c this
+    have hdc : d = c := by
+      have hd_inv : d = c⁻¹ := eq_inv_of_mul_eq_one_left (by rw [mul_comm]; exact h)
+      rw [hd_inv]; exact inv_eq_of_mul_eq_one_right (by rw [← sq]; exact hc_sq)
+    exact hd_ne_c hdc
   -- Step 5: Get involution properties
   obtain ⟨hσc_mem, hσc_inv, hσc_ne, hσc_prod⟩ :=
     mul_involution_on_sq_eq_one hc_sq hc_ne_1
@@ -429,32 +368,15 @@ theorem prod_units_one_of_not_cyclic_ext {n : ℕ} (hn : n ≥ 3)
   have hd_pow : d ^ (S.card / 2) = 1 := by
     have h : c ^ (S.card / 2) = (c * d) ^ (S.card / 2) := by rw [← hP_eq_c, hP_eq_cd]
     rw [mul_pow] at h
-    exact mul_left_cancel (a := c ^ (S.card / 2)) (by rwa [mul_one])
+    exact mul_left_cancel (a := c ^ (S.card / 2)) (by rw [mul_one]; exact h.symm)
   -- Step 8: Therefore c^k = 1
-  have hc_pow : c ^ (S.card / 2) = 1 := by rw [hP_eq_c, hP_eq_d, hd_pow]
+  have hc_pow : c ^ (S.card / 2) = 1 := by rw [← hP_eq_c, hP_eq_d, hd_pow]
   -- Step 9: ∏ S = c^k = 1
   rw [hP_eq_c, hc_pow]
 
 -- ============================================================================
 -- Section 6: Gauss-Wilson Abstract Biconditional
 -- ============================================================================
-
-/-- -1 ≠ 1 in (ZMod n)ˣ for n ≥ 3. -/
-private theorem neg_one_ne_one_units' {n : ℕ} (hn : n ≥ 3) :
-    (-1 : (ZMod n)ˣ) ≠ 1 := by
-  haveI : NeZero n := ⟨by omega⟩
-  intro h
-  have h1 : ((-1 : (ZMod n)ˣ) : ZMod n) = ((1 : (ZMod n)ˣ) : ZMod n) := by rw [h]
-  simp only [Units.val_neg, Units.val_one] at h1
-  have h2 : (n : ℤ) ∣ (-1 - 1) := by
-    have := ZMod.intCast_zmod_eq_zero_iff_dvd (-1 - 1) n
-    rw [show ((-1 - 1 : ℤ) : ZMod n) = (-1 : ZMod n) - 1 from by push_cast; ring] at this
-    rw [h1, sub_self] at this; exact this.mp rfl
-  have h3 : (n : ℤ) ∣ 2 := by
-    have : (-1 - 1 : ℤ) = -2 := by ring
-    rw [this] at h2; exact dvd_neg.mp h2
-  have : n ≤ 2 := by have := Int.le_of_dvd (by norm_num : (0 : ℤ) < 2) h3; omega
-  omega
 
 /-- -1 ≠ 1 in ZMod n for n ≥ 3. -/
 private theorem neg_one_ne_one_zmod' {n : ℕ} (hn : n ≥ 3) : (-1 : ZMod n) ≠ 1 := by
@@ -482,7 +404,7 @@ private theorem prod_units_neg_one_of_cyclic' {n : ℕ} (hn : n ≥ 3)
     intro x hx; simp at hx; rcases hx with rfl | rfl <;> assumption
   have hcard_pair : ({1, -1} : Finset (ZMod n)ˣ).card = 2 := Finset.card_pair hne'
   have heq := (Finset.eq_of_subset_of_card_le hsub (by omega)).symm
-  rw [heq, Finset.prod_pair hne'.symm]
+  rw [heq, Finset.prod_pair hne']
   exact one_mul (-1)
 
 /-- **Gauss-Wilson Theorem (Abstract)**:

--- a/proofs/Proofs/WilsonsTheoremOQ02ExtOQ01.lean
+++ b/proofs/Proofs/WilsonsTheoremOQ02ExtOQ01.lean
@@ -57,7 +57,10 @@ private theorem mul_involution_on_sq_eq_one
     simp only [mem_filter, mem_univ, true_and] at hx ⊢
     exact mul_sq_eq_one hc_sq hx
   · intro x _; rw [← mul_assoc, ← sq, hc_sq, one_mul]
-  · intro x _ h; exact hc_ne (mul_right_cancel h)
+  · intro x _ h
+    apply hc_ne
+    have hcx : c * x * x⁻¹ = x * x⁻¹ := by rw [h]
+    simpa [mul_assoc] using hcx
   · intro x hx
     simp only [mem_filter, mem_univ, true_and] at hx
     rw [mul_comm x (c * x), mul_assoc, ← sq, hx, mul_one]
@@ -107,9 +110,10 @@ theorem prod_eq_one_of_two_torsion_card_ge_three
   have hcd_sq : (c * d) ^ 2 = 1 := mul_sq_eq_one hc_sq hd_sq
   have hcd_ne_1 : c * d ≠ 1 := by
     intro h
-    have : d = c⁻¹ := by rwa [mul_eq_one_iff_eq_inv] at h
-    have : d = c := by rw [this, inv_eq_of_mul_eq_one_right]; rw [← sq]; exact hc_sq
-    exact hd_ne_c this
+    have hdc : d = c := by
+      have hd_inv : d = c⁻¹ := eq_inv_of_mul_eq_one_left (by rw [mul_comm]; exact h)
+      rw [hd_inv]; exact inv_eq_of_mul_eq_one_right (by rw [← sq]; exact hc_sq)
+    exact hd_ne_c hdc
   -- Involution data for c, d, cd
   obtain ⟨hσc_mem, hσc_inv, hσc_ne, hσc_prod⟩ := mul_involution_on_sq_eq_one hc_sq hc_ne_1
   obtain ⟨hσd_mem, hσd_inv, hσd_ne, hσd_prod⟩ := mul_involution_on_sq_eq_one hd_sq hd_ne_1
@@ -124,8 +128,8 @@ theorem prod_eq_one_of_two_torsion_card_ge_three
   have hd_pow : d ^ (S.card / 2) = 1 := by
     have h : c ^ (S.card / 2) = (c * d) ^ (S.card / 2) := by rw [← hP_eq_c, hP_eq_cd]
     rw [mul_pow] at h
-    exact mul_left_cancel (a := c ^ (S.card / 2)) (by rwa [mul_one])
-  have hc_pow : c ^ (S.card / 2) = 1 := by rw [hP_eq_c, hP_eq_d, hd_pow]
+    exact mul_left_cancel (a := c ^ (S.card / 2)) (by rw [mul_one]; exact h.symm)
+  have hc_pow : c ^ (S.card / 2) = 1 := by rw [← hP_eq_c, hP_eq_d, hd_pow]
   rw [hP_eq_c, hc_pow]
 
 /-- If the 2-torsion subgroup has size `≠ 2`, the product of all elements is `1`.

--- a/proofs/Proofs/WilsonsTheoremOQ02ExtOQ02.lean
+++ b/proofs/Proofs/WilsonsTheoremOQ02ExtOQ02.lean
@@ -68,7 +68,7 @@ theorem prod_units_eq_one_or_unique_involution
     (∏ u : Rˣ, u = 1) ∨
       (∃ t : Rˣ, t ≠ 1 ∧ t ^ 2 = 1 ∧
         (∀ s : Rˣ, s ^ 2 = 1 → s = 1 ∨ s = t) ∧ ∏ u : Rˣ, u = t) :=
-  WilsonsTheoremOQ02ExtOQ01.prod_eq_one_or_unique_involution
+  WilsonsTheoremOQ02ExtOQ01.miller_prod
 
 /-- **Classical packaging.** If `-1` is the unique element of order two in `Rˣ`,
     then the product of all units of `R`, taken in `R`, equals `-1`. This is the

--- a/proofs/batch2/STATUS.md
+++ b/proofs/batch2/STATUS.md
@@ -1,3 +1,91 @@
+# DOCTOR INCREMENT 71 (deep-rework partition B: N–Z + Erdos ≥ 600, #38065, 2026-07-15)
+
+Container `dr71` (cpus 0-5, 11g, cache v431), worktree issue-38065, branch
+`feature/issue-38065-inc71` off origin/feature/issue-37508 (base 2047 GREEN /
+588 RESIDUAL after incs 56–69). **Family-first: the entire Wilson cluster (6
+files) flipped from fixing the hub OQ02Ext.** All in-container `lake build
+Proofs.X` exit-0 before ledger flip; pushed per file. **+6 GREEN.** PR #38674.
+
+## Flips (failure class in parens)
+- WilsonsTheoremOQ02Ext (rewrite-drift, HUB — 35 real errors): deleted a **dead
+  pow2/CRT helper block** (155–241; the file now delegates to
+  GaussWilsonNonCyclic, each helper was only used by the dead block or by
+  sibling files' own copies) → cleared ~15 errors; **`set T := …` now fully
+  abstracts** so `simp only [mem_sdiff…] at hx` gets "no progress" and
+  `card_sdiff hpair_sub` etc. don't fire → `set … with hT_def` + `rw [hT_def] at
+  hx ⊢` before the simp/card rewrites; **`Finset.card_sdiff` is now the
+  UNCONDITIONAL `#(s\t)=#s-#(s∩t)`** — the subset-hypothesis lemma is
+  `Finset.card_sdiff_of_subset (h : s ⊆ t)`; **`Finset.sdiff_ssubset` now takes
+  TWO args** `(h : t ⊆ s) (ht : t.Nonempty)`; **`not_or` no longer auto-applied
+  by `simp only [mem_insert…]`** so `x ∉ {a,b}` stays `¬(x=a ∨ x=b)` not a
+  conjunction → `refine ⟨_, ?_⟩; rintro (h|h)`; extracted the `where
+  sq_eq_one_iff_eq_inv {G}` helper into a top-level private lemma (**a `where`
+  clause that re-binds a fresh `{G : Type*}` makes the theorem carry an extra
+  universe param → kernel `commitConst: level params [u_1,u_2] but expected
+  [u_1]`**); **`Finset.prod_involution` bullet order**: `refine … ?_ ?_ ?_`
+  after supplying the pair-product arg inline; omega needs `2 ≤ #S` materialized
+  (truncated ℕ subtraction from `#S - 2 = k+k`); moved `neg_one_ne_one_units'`
+  above its first use (in-file forward ref); `c*c^k=c^(k+1)` → `rw [pow_succ];
+  exact mul_comm _ _` (plain `ring` fails on multiplicative-only CommGroup).
+- WilsonsTheoremOQ02 (rewrite-drift, 5+ errors): **multiline `by simp […];
+  push_neg` newline `exact` no longer parses** (unexpected identifier) → clean
+  indented `by`-block with `simp only [… , not_or]`; `mul_left_cancel h` /
+  `mul_right_cancel h` need the `a*1`/`1*b` form supplied
+  (`mul_left_cancel (a:=a) (by rw [mul_one]; exact h)`); the `conv_lhs => rw
+  [← h]` in prod_univ_sq **rewrites BOTH `∏x` occurrences** → prove via
+  `sq_eq_one_iff_eq_inv` instead; `prod_involution` refine+reorder; **`ZMod.val_injective`
+  now takes `n` explicitly** (`ZMod.val_injective n h`); `prod_nbij` InjOn intro
+  order is `a ha b hb h` (`intro u₁ _ u₂ _ h`); `Units.val_unitOfCoprime` →
+  `ZMod.coe_unitOfCoprime` (+ `dsimp only` to beta-reduce the map before the rw);
+  `group` left `a*(b*(a*b))=(a*b)^2` → `rw [sq, mul_assoc]`.
+- WilsonsTheoremOQ01 (rewrite-drift, 9 errors): Wilson mod arithmetic —
+  **omega can't relate `p*k` and `p*(k-1)`** (distinct nonlinear atoms) → bridge
+  `p*(k-1)+p = p*k` via `cases k … | succ m => simp [Nat.succ_sub_one,
+  Nat.mul_succ]`; `add_mul_mod_self_left` needs `add_comm` first + explicit
+  `mod_eq_of_lt`; `natCast_sub_one_eq_neg_one'` via `Nat.cast_sub hn` +
+  `ZMod.natCast_self`; **`ZMod.val_injective n`**; **`Nat.mod_eq_of_lt (by omega)`
+  with an unpinned `?a` matches the WRONG mod occurrence** (`unitsProduct n % n`
+  instead of `(n-1)%n`) → `mod_eq_of_lt (show n-1 < n by omega)`; classification
+  `rintro` branch order rewritten to match the post-`rw` disjunction shapes.
+- WilsonsTheoremOQ04 (cascade, 0 own errors): green once OQ01 built.
+- WilsonsTheoremOQ02ExtOQ01 (rewrite-drift, 4 errors): mirror of OQ02Ext's FPF
+  (`mul_right_cancel`), `hcd_ne_1` (`eq_inv_of_mul_eq_one_left` wants `b*a=1` →
+  `mul_comm` first), and two-involution algebra (`by rw [mul_one]; exact h.symm`;
+  `rw [← hP_eq_c, …]`).
+- WilsonsTheoremOQ02ExtOQ02 (dangling-ref repair, #38611): referenced
+  `WilsonsTheoremOQ02ExtOQ01.prod_eq_one_or_unique_involution` which **never
+  existed** (v4.26 baseline results-full.tsv = FAIL; `git log -S` finds no such
+  name); the theorem with that exact statement is `miller_prod`. Renamed the
+  reference — not a weakening, not a new axiom.
+
+## New systematic seams (rename-map §7al candidates)
+1. **`set x := e` (no `with`) now fully abstracts `x`** — `simp only […] at h`
+   where `h : _ ∈ x` gets "no progress", and `rw [lemma_about_e] at h`/goal
+   can't fire. Add `with hx_def` and `rw [hx_def] at h ⊢` before the simp/rw.
+2. **`Finset.card_sdiff` is unconditional** (`#(s\t)=#s-#(s∩t)`); the
+   subset-hyp form is now **`Finset.card_sdiff_of_subset (h:s⊆t)`**.
+3. **`Finset.sdiff_ssubset` takes TWO explicit args** `(h:t⊆s)(ht:t.Nonempty)`.
+4. **`simp only [mem_insert, mem_singleton]` no longer folds in `not_or`** — a
+   `∉` goal stays `¬(…∨…)`; add `not_or` to the simp set OR `rintro (h|h)`.
+5. **A `where`-clause lemma that re-binds a fresh universe var `{G:Type*}`**
+   gives the enclosing theorem an extra level param → kernel
+   `commitConst: level params [u_1,u_2] but expected [u_1]`. Hoist it to a
+   top-level lemma.
+6. **`ZMod.val_injective` now takes the modulus `n` explicitly**
+   (`ZMod.val_injective n h`); `Units.val_unitOfCoprime`→`ZMod.coe_unitOfCoprime`.
+7. **`Nat.mod_eq_of_lt (by omega)` with an unpinned `?a`** rewrites the FIRST
+   `?a % n` in the goal (often the wrong one) → pass `(show a < n by omega)`.
+8. **omega treats `p*k` and `p*(k-1)` as unrelated atoms** — supply a bridge
+   `p*(k-1)+p = p*k` (via `cases k`/`Nat.mul_succ`).
+9. **A multiline `(by simp […]; push_neg`⏎`exact …)` term no longer parses** —
+   use a properly-indented `by` block.
+10. **`conv_lhs => rw [← h]`** where `h`'s RHS appears twice in the LHS rewrites
+    BOTH occurrences.
+
+Ledger after increment 71: +6 GREEN (partition B, whole Wilson family).
+
+---
+
 # DOCTOR INCREMENT 69 (deep-rework partition B: N–Z + Erdos ≥ 600, #38065, 2026-07-15)
 
 Container `dr69` (cpus 0-5, 11g, cache v431), worktree issue-38065, branch

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -2639,7 +2639,7 @@ VietasFormulasOQ02	GREEN
 VietasFormulasOQ03OQ01	GREEN	
 WaringGgLowerBoundsOQ02	GREEN	
 WilsonsTheoremOQ01	RESIDUAL	rewrite-drift
-WilsonsTheoremOQ02	RESIDUAL	rewrite-drift
+WilsonsTheoremOQ02	GREEN	rewrite-drift
 WilsonsTheoremOQ02Ext	GREEN	rewrite-drift
 WilsonsTheoremOQ02ExtOQ01	RESIDUAL	rewrite-drift
 WilsonsTheoremOQ02ExtOQ02	RESIDUAL	rewrite-drift

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -2638,7 +2638,7 @@ VandermondeInterpolationOQ01OQ02OQ01	GREEN
 VietasFormulasOQ02	GREEN	
 VietasFormulasOQ03OQ01	GREEN	
 WaringGgLowerBoundsOQ02	GREEN	
-WilsonsTheoremOQ01	RESIDUAL	rewrite-drift
+WilsonsTheoremOQ01	GREEN	rewrite-drift
 WilsonsTheoremOQ02	GREEN	rewrite-drift
 WilsonsTheoremOQ02Ext	GREEN	rewrite-drift
 WilsonsTheoremOQ02ExtOQ01	RESIDUAL	rewrite-drift

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -2641,7 +2641,7 @@ WaringGgLowerBoundsOQ02	GREEN
 WilsonsTheoremOQ01	GREEN	rewrite-drift
 WilsonsTheoremOQ02	GREEN	rewrite-drift
 WilsonsTheoremOQ02Ext	GREEN	rewrite-drift
-WilsonsTheoremOQ02ExtOQ01	RESIDUAL	rewrite-drift
+WilsonsTheoremOQ02ExtOQ01	GREEN	rewrite-drift
 WilsonsTheoremOQ02ExtOQ02	RESIDUAL	rewrite-drift
 WilsonsTheoremOQ04	GREEN	rewrite-drift
 WilsonsTheoremOQ07	GREEN	

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -2640,7 +2640,7 @@ VietasFormulasOQ03OQ01	GREEN
 WaringGgLowerBoundsOQ02	GREEN	
 WilsonsTheoremOQ01	RESIDUAL	rewrite-drift
 WilsonsTheoremOQ02	RESIDUAL	rewrite-drift
-WilsonsTheoremOQ02Ext	RESIDUAL	rewrite-drift
+WilsonsTheoremOQ02Ext	GREEN	rewrite-drift
 WilsonsTheoremOQ02ExtOQ01	RESIDUAL	rewrite-drift
 WilsonsTheoremOQ02ExtOQ02	RESIDUAL	rewrite-drift
 WilsonsTheoremOQ04	RESIDUAL	rewrite-drift

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -2643,7 +2643,7 @@ WilsonsTheoremOQ02	GREEN	rewrite-drift
 WilsonsTheoremOQ02Ext	GREEN	rewrite-drift
 WilsonsTheoremOQ02ExtOQ01	RESIDUAL	rewrite-drift
 WilsonsTheoremOQ02ExtOQ02	RESIDUAL	rewrite-drift
-WilsonsTheoremOQ04	RESIDUAL	rewrite-drift
+WilsonsTheoremOQ04	GREEN	rewrite-drift
 WilsonsTheoremOQ07	GREEN	
 WolstenholmeTheoremOQ01	RESIDUAL	oom-killed
 WolstenholmeTheoremOQ02OQ02	GREEN	

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -2642,7 +2642,7 @@ WilsonsTheoremOQ01	GREEN	rewrite-drift
 WilsonsTheoremOQ02	GREEN	rewrite-drift
 WilsonsTheoremOQ02Ext	GREEN	rewrite-drift
 WilsonsTheoremOQ02ExtOQ01	GREEN	rewrite-drift
-WilsonsTheoremOQ02ExtOQ02	RESIDUAL	rewrite-drift
+WilsonsTheoremOQ02ExtOQ02	GREEN	rewrite-drift
 WilsonsTheoremOQ04	GREEN	rewrite-drift
 WilsonsTheoremOQ07	GREEN	
 WolstenholmeTheoremOQ01	RESIDUAL	oom-killed

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -1461,7 +1461,7 @@ Erdos605Problem	GREEN
 Erdos606OQ03	GREEN	
 Erdos606Problem	GREEN	
 Erdos607Problem	GREEN	
-Erdos608Problem	RESIDUAL	parse-error
+Erdos608Problem	PRE-EXISTING	parse-error
 Erdos608ProblemAristotle	GREEN	
 Erdos609Problem	GREEN	
 Erdos60Problem	RESIDUAL	type-mismatch


### PR DESCRIPTION
Deep-rework migration of partition B (N–Z + Erdos≥600) RESIDUAL rows to v4.31.

Family-first: fixing the Wilson hub `WilsonsTheoremOQ02Ext` (35 real errors) unlocks the OQ02/OQ01/OQ04 and OQ02ExtOQ01/OQ02 descendants. Each file verified `lake build` exit-0 in container dr71 (v4.31 cache) before the ledger flip.

Ref #38065, #38611. No loom:review-requested (deployer merges directly).