### PR TITLE
migrate(v4.31): Doctor increment 72 — deep-rework partition A (+5 GREEN)

### DIFF
--- a/proofs/Proofs/Erdos334Problem.lean
+++ b/proofs/Proofs/Erdos334Problem.lean
@@ -54,9 +54,7 @@ theorem one_smooth (y : ℕ) : isSmooth 1 y := by
 -/
 theorem prime_power_smooth (p k : ℕ) (hp : p.Prime) : isSmooth (p ^ k) p := by
   intro q hq hdiv
-  have := (Nat.Prime.dvd_prime_pow hp hq).mp hdiv
-  rcases this with ⟨_, rfl⟩
-  exact le_refl p
+  exact ((Nat.prime_dvd_prime_iff_eq hq hp).mp (hq.dvd_of_dvd_pow hdiv)).le
 
 /--
 **Product of smooth numbers is smooth.**
@@ -121,7 +119,7 @@ axiom erdos_cube_root_bound :
 f(n) << n^{4/(9√e)+ε} for all ε > 0.
 The exponent 4/(9√e) ≈ 0.2695 is the current best.
 -/
-noncomputable def balogExponent : ℝ := 4 / (9 * Real.sqrt Real.exp 1)
+noncomputable def balogExponent : ℝ := 4 / (9 * Real.sqrt (Real.exp 1))
 
 theorem balog_exponent_value : balogExponent < 0.27 := by
   unfold balogExponent
@@ -175,16 +173,13 @@ theorem example_10 : hasSmootPairRepr 10 2 := by
   · ring
   constructor
   · intro p hp hdiv
-    have := (Nat.Prime.eq_one_or_self_of_prime_of_dvd hp 2 Nat.Prime.two hdiv)
-    rcases this with h | h
-    · omega
-    · rw [h]
+    have : p = 2 := (Nat.prime_dvd_prime_iff_eq hp Nat.prime_two).mp hdiv
+    omega
   · intro p hp hdiv
     have h8 : (8 : ℕ) = 2^3 := by norm_num
     rw [h8] at hdiv
-    have := (Nat.Prime.dvd_prime_pow Nat.Prime.two hp).mp hdiv
-    rcases this with ⟨_, rfl⟩
-    exact le_refl 2
+    have : p = 2 := (Nat.prime_dvd_prime_iff_eq hp Nat.prime_two).mp (hp.dvd_of_dvd_pow hdiv)
+    omega
 
 /--
 **Example: 100 = 64 + 36**
@@ -200,19 +195,16 @@ theorem example_100 : hasSmootPairRepr 100 3 := by
   · intro p hp hdiv
     have h64 : (64 : ℕ) = 2^6 := by norm_num
     rw [h64] at hdiv
-    have := (Nat.Prime.dvd_prime_pow Nat.Prime.two hp).mp hdiv
-    rcases this with ⟨_, rfl⟩
+    have : p = 2 := (Nat.prime_dvd_prime_iff_eq hp Nat.prime_two).mp (hp.dvd_of_dvd_pow hdiv)
     omega
   · intro p hp hdiv
     have h36 : (36 : ℕ) = 2^2 * 3^2 := by norm_num
     rw [h36] at hdiv
     rcases (Nat.Prime.dvd_mul hp).mp hdiv with h | h
-    · have := (Nat.Prime.dvd_prime_pow Nat.Prime.two hp).mp h
-      rcases this with ⟨_, rfl⟩
+    · have : p = 2 := (Nat.prime_dvd_prime_iff_eq hp Nat.prime_two).mp (hp.dvd_of_dvd_pow h)
       omega
-    · have := (Nat.Prime.dvd_prime_pow (by norm_num : Nat.Prime 3) hp).mp h
-      rcases this with ⟨_, rfl⟩
-      exact le_refl 3
+    · have : p = 3 := (Nat.prime_dvd_prime_iff_eq hp (by norm_num : Nat.Prime 3)).mp (hp.dvd_of_dvd_pow h)
+      omega
 
 /-
 ## Part VII: Connection to Other Problems

--- a/proofs/Proofs/Erdos390Problem.lean
+++ b/proofs/Proofs/Erdos390Problem.lean
@@ -21,7 +21,7 @@ The list `factors` must be strictly increasing, all elements > n,
 and their product equals n!. -/
 structure ValidFactorization (n : ℕ) where
   factors : List ℕ
-  sorted : factors.Sorted (· < ·)
+  sorted : factors.Pairwise (· < ·)
   all_gt : ∀ a ∈ factors, a > n
   nonempty : factors ≠ []
   prod_eq : factors.prod = n.factorial
@@ -29,13 +29,14 @@ structure ValidFactorization (n : ℕ) where
 /-- The maximum element of a valid factorization (the last element
 of the sorted list). -/
 def ValidFactorization.maxFactor {n : ℕ} (vf : ValidFactorization n) : ℕ :=
-  vf.factors.getLast (by exact vf.nonempty)
+  vf.factors.getLastD 0
 
 /-- f(n) is the minimal maximum factor over all valid factorizations. -/
-noncomputable def factorizationMax (n : ℕ) : ℕ :=
-  if h : ∃ vf : ValidFactorization n, True
-  then sInf { vf.maxFactor | vf : ValidFactorization n }
-  else 0
+noncomputable def factorizationMax (n : ℕ) : ℕ := by
+  classical
+  exact if h : ∃ vf : ValidFactorization n, True
+    then sInf { vf.maxFactor | vf : ValidFactorization n }
+    else 0
 
 /- ## Section II: Concrete Values via Explicit Witnesses -/
 
@@ -45,7 +46,7 @@ noncomputable def factorizationMax (n : ℕ) : ℕ :=
 /-- Witness: 3! = 6, factored as [6]. -/
 def vf3 : ValidFactorization 3 where
   factors := [6]
-  sorted := by simp [List.Sorted]
+  sorted := by simp [List.Pairwise]
   all_gt := by simp
   nonempty := by simp
   prod_eq := by native_decide
@@ -68,8 +69,9 @@ theorem factorizationMax_3_ge : ∀ vf : ValidFactorization 3, vf.maxFactor ≥ 
   | cons x xs =>
     cases xs with
     | nil =>
-      simp [List.prod] at hprod
-      simp [List.getLast] at *
+      rw [hf] at hprod
+      simp [List.prod, Nat.factorial] at hprod
+      simp only [List.getLastD_cons, List.getLastD_nil]
       omega
     | cons y ys =>
       exfalso
@@ -77,12 +79,12 @@ theorem factorizationMax_3_ge : ∀ vf : ValidFactorization 3, vf.maxFactor ≥ 
       have hy : y > x := by
         have hsorted := vf.sorted
         rw [hf] at hsorted
-        simp [List.Sorted, List.Pairwise] at hsorted
+        simp [List.Pairwise] at hsorted
         exact hsorted.1.1
       have hy5 : y ≥ 5 := by omega
       have hys_pos : ys.prod ≥ 1 :=
-        (List.prod_pos (fun a ha => by
-          have := hall4 a (by rw [hf]; simp [ha]); omega)).le
+        List.prod_pos (s := ys) (fun a ha => by
+          have := hall4 a (by rw [hf]; simp [ha]); omega)
       have hprod_ge : vf.factors.prod ≥ 4 * 5 := by
         rw [hf]; simp [List.prod]
         calc x * (y * ys.prod) ≥ x * y := by
@@ -97,7 +99,7 @@ theorem factorizationMax_3_ge : ∀ vf : ValidFactorization 3, vf.maxFactor ≥ 
 
 def vf4 : ValidFactorization 4 where
   factors := [24]
-  sorted := by simp [List.Sorted]
+  sorted := by simp [List.Pairwise]
   all_gt := by simp
   nonempty := by simp
   prod_eq := by native_decide
@@ -118,8 +120,9 @@ theorem factorizationMax_4_ge : ∀ vf : ValidFactorization 4, vf.maxFactor ≥ 
   | cons x xs =>
     cases xs with
     | nil =>
-      simp [List.prod] at hprod
-      simp [List.getLast] at *
+      rw [hf] at hprod
+      simp [List.prod, Nat.factorial] at hprod
+      simp only [List.getLastD_cons, List.getLastD_nil]
       omega
     | cons y ys =>
       exfalso
@@ -127,12 +130,12 @@ theorem factorizationMax_4_ge : ∀ vf : ValidFactorization 4, vf.maxFactor ≥ 
       have hy : y > x := by
         have hsorted := vf.sorted
         rw [hf] at hsorted
-        simp [List.Sorted, List.Pairwise] at hsorted
+        simp [List.Pairwise] at hsorted
         exact hsorted.1.1
       have hy6 : y ≥ 6 := by omega
       have hys_pos : ys.prod ≥ 1 :=
-        (List.prod_pos (fun a ha => by
-          have := hall5 a (by rw [hf]; simp [ha]); omega)).le
+        List.prod_pos (s := ys) (fun a ha => by
+          have := hall5 a (by rw [hf]; simp [ha]); omega)
       have hprod_ge : vf.factors.prod ≥ 5 * 6 := by
         rw [hf]; simp [List.prod]
         calc x * (y * ys.prod) ≥ x * y := by
@@ -145,8 +148,8 @@ theorem factorizationMax_4_ge : ∀ vf : ValidFactorization 4, vf.maxFactor ≥ 
 -- For n=5: 5! = 120 = 10 · 12
 def vf5 : ValidFactorization 5 where
   factors := [10, 12]
-  sorted := by simp [List.Sorted, List.Pairwise]
-  all_gt := by simp; omega
+  sorted := by simp [List.Pairwise]
+  all_gt := by decide
   nonempty := by simp
   prod_eq := by native_decide
 
@@ -169,20 +172,21 @@ theorem factorizationMax_5_ge : ∀ vf : ValidFactorization 5, vf.maxFactor ≥ 
     cases xs with
     | nil =>
       -- Single factor: x = 120 ≥ 12
-      simp [List.prod] at hprod
-      simp [List.getLast] at *
+      rw [hf] at hprod
+      simp [List.prod, Nat.factorial] at hprod
+      simp only [List.getLastD_cons, List.getLastD_nil]
       omega
     | cons y ys =>
       have hxy : x < y := by
         have hsorted := vf.sorted; rw [hf] at hsorted
-        simp [List.Sorted, List.Pairwise] at hsorted
+        simp [List.Pairwise] at hsorted
         exact hsorted.1.1
       cases ys with
       | nil =>
         -- Two factors [x, y]: x·y = 120, x ≥ 6, y > x. Need y ≥ 12.
         -- If y ≤ 11 then x ≤ 10, product ≤ 10·11 = 110 < 120.
-        simp [List.getLast]
-        rw [hf] at hprod; simp [List.prod] at hprod
+        simp only [List.getLastD_cons, List.getLastD_nil]
+        rw [hf] at hprod; simp [List.prod, Nat.factorial] at hprod
         by_contra h_lt; push_neg at h_lt
         have : x * y ≤ 10 * 11 := Nat.mul_le_mul (by omega) (by omega)
         omega
@@ -191,11 +195,11 @@ theorem factorizationMax_5_ge : ∀ vf : ValidFactorization 5, vf.maxFactor ≥ 
         exfalso
         have hyz : y < z := by
           have hsorted := vf.sorted; rw [hf] at hsorted
-          simp [List.Sorted, List.Pairwise] at hsorted
+          simp [List.Pairwise] at hsorted
           exact hsorted.2.1.1
         have hzs_pos : zs.prod ≥ 1 :=
-          (List.prod_pos (fun a ha => by
-            have := hgt a (by rw [hf]; simp [ha]); omega)).le
+          List.prod_pos (s := zs) (fun a ha => by
+            have := hgt a (by rw [hf]; simp [ha]); omega)
         have hprod_ge : vf.factors.prod ≥ 6 * 7 * 8 := by
           rw [hf]; simp [List.prod]
           calc x * (y * (z * zs.prod))
@@ -210,8 +214,8 @@ theorem factorizationMax_5_ge : ∀ vf : ValidFactorization 5, vf.maxFactor ≥ 
 -- For n=6: 6! = 720 = 8 · 9 · 10
 def vf6 : ValidFactorization 6 where
   factors := [8, 9, 10]
-  sorted := by simp [List.Sorted, List.Pairwise]; omega
-  all_gt := by simp; omega
+  sorted := by decide
+  all_gt := by decide
   nonempty := by simp
   prod_eq := by native_decide
 
@@ -234,34 +238,35 @@ theorem factorizationMax_6_ge : ∀ vf : ValidFactorization 6, vf.maxFactor ≥ 
     cases xs with
     | nil =>
       -- Single factor: x = 720 ≥ 10
-      simp [List.prod] at hprod
-      simp [List.getLast] at *
+      rw [hf] at hprod
+      simp [List.prod, Nat.factorial] at hprod
+      simp only [List.getLastD_cons, List.getLastD_nil]
       omega
     | cons y ys =>
       have hxy : x < y := by
         have hsorted := vf.sorted; rw [hf] at hsorted
-        simp [List.Sorted, List.Pairwise] at hsorted
+        simp [List.Pairwise] at hsorted
         exact hsorted.1.1
       cases ys with
       | nil =>
         -- Two factors [x, y]: x·y = 720, x ≥ 7, y > x. Need y ≥ 10.
         -- If y ≤ 9 then x ≤ 8, product ≤ 8·9 = 72 < 720.
-        simp [List.getLast]
-        rw [hf] at hprod; simp [List.prod] at hprod
+        simp only [List.getLastD_cons, List.getLastD_nil]
+        rw [hf] at hprod; simp [List.prod, Nat.factorial] at hprod
         by_contra h_lt; push_neg at h_lt
         have : x * y ≤ 8 * 9 := Nat.mul_le_mul (by omega) (by omega)
         omega
       | cons z zs =>
         have hyz : y < z := by
           have hsorted := vf.sorted; rw [hf] at hsorted
-          simp [List.Sorted, List.Pairwise] at hsorted
+          simp [List.Pairwise] at hsorted
           exact hsorted.2.1.1
         cases zs with
         | nil =>
           -- Three factors [x, y, z]: x·y·z = 720. Need z ≥ 10.
           -- If z ≤ 9 then y ≤ 8, x ≤ 7, product ≤ 7·8·9 = 504 < 720.
-          simp [List.getLast]
-          rw [hf] at hprod; simp [List.prod] at hprod
+          simp only [List.getLastD_cons, List.getLastD_nil]
+          rw [hf] at hprod; simp [List.prod, Nat.factorial] at hprod
           by_contra h_lt; push_neg at h_lt
           have : x * (y * z) ≤ 7 * (8 * 9) :=
             Nat.mul_le_mul (by omega) (Nat.mul_le_mul (by omega) (by omega))
@@ -272,11 +277,11 @@ theorem factorizationMax_6_ge : ∀ vf : ValidFactorization 6, vf.maxFactor ≥ 
           exfalso
           have hzw : z < w := by
             have hsorted := vf.sorted; rw [hf] at hsorted
-            simp [List.Sorted, List.Pairwise] at hsorted
+            simp [List.Pairwise] at hsorted
             exact hsorted.2.2.1.1
           have hws_pos : ws.prod ≥ 1 :=
-            (List.prod_pos (fun a ha => by
-              have := hgt a (by rw [hf]; simp [ha]); omega)).le
+            List.prod_pos (s := ws) (fun a ha => by
+              have := hgt a (by rw [hf]; simp [ha]); omega)
           have hprod_ge : vf.factors.prod ≥ 7 * 8 * 9 * 10 := by
             rw [hf]; simp [List.prod]
             calc x * (y * (z * (w * ws.prod)))
@@ -294,8 +299,8 @@ theorem factorizationMax_6_ge : ∀ vf : ValidFactorization 6, vf.maxFactor ≥ 
 -- For n=7: 7! = 5040 = 14 · 18 · 20
 def vf7 : ValidFactorization 7 where
   factors := [14, 18, 20]
-  sorted := by simp [List.Sorted, List.Pairwise]; omega
-  all_gt := by simp; omega
+  sorted := by decide
+  all_gt := by decide
   nonempty := by simp
   prod_eq := by native_decide
 
@@ -320,24 +325,25 @@ theorem factorizationMax_7_ge : ∀ vf : ValidFactorization 7, vf.maxFactor ≥ 
     cases xs with
     | nil =>
       -- Single factor: x = 5040 ≥ 20
-      simp [List.prod] at hprod; simp [List.getLast] at *; omega
+      rw [hf] at hprod; simp [List.prod, Nat.factorial] at hprod
+      simp only [List.getLastD_cons, List.getLastD_nil]; omega
     | cons y ys =>
       have hxy : x < y := by
         have hsorted := vf.sorted; rw [hf] at hsorted
-        simp [List.Sorted, List.Pairwise] at hsorted; exact hsorted.1.1
+        simp [List.Pairwise] at hsorted; exact hsorted.1.1
       cases ys with
       | nil =>
         -- Two factors [x, y]: x·y = 5040, x ≥ 8, y > x. Need y ≥ 20.
         -- If y ≤ 19 then x ≤ 18, product ≤ 18·19 = 342 < 5040.
-        simp [List.getLast]
-        rw [hf] at hprod; simp [List.prod] at hprod
+        simp only [List.getLastD_cons, List.getLastD_nil]
+        rw [hf] at hprod; simp [List.prod, Nat.factorial] at hprod
         by_contra h_lt; push_neg at h_lt
         have : x * y ≤ 18 * 19 := Nat.mul_le_mul (by omega) (by omega)
         omega
       | cons z zs =>
         have hyz : y < z := by
           have hsorted := vf.sorted; rw [hf] at hsorted
-          simp [List.Sorted, List.Pairwise] at hsorted; exact hsorted.2.1.1
+          simp [List.Pairwise] at hsorted; exact hsorted.2.1.1
         cases zs with
         | nil =>
           -- Three factors [x, y, z]: x·y·z = 5040. Need z ≥ 20.
@@ -356,8 +362,8 @@ theorem factorizationMax_7_ge : ∀ vf : ValidFactorization 7, vf.maxFactor ≥ 
           -- z=18: 280 = x·y, x<y<18. 280/8=35. ≥18. No.
           -- (Odd z: 5040/z often not integer. z=9:560, z=11:not int, z=13:not int, z=17:not int, z=19:not int)
           -- So no valid triple with z ≤ 19 exists.
-          simp [List.getLast]
-          rw [hf] at hprod; simp [List.prod] at hprod
+          simp only [List.getLastD_cons, List.getLastD_nil]
+          rw [hf] at hprod; simp [List.prod, Nat.factorial] at hprod
           by_contra h_lt; push_neg at h_lt
           -- h_lt : z < 20, i.e., z ≤ 19
           -- Split: x ≤ 14 → product too small. x ≥ 15 → enumerate.
@@ -378,10 +384,10 @@ theorem factorizationMax_7_ge : ∀ vf : ValidFactorization 7, vf.maxFactor ≥ 
           exfalso
           have hzw : z < w := by
             have hsorted := vf.sorted; rw [hf] at hsorted
-            simp [List.Sorted, List.Pairwise] at hsorted; exact hsorted.2.2.1.1
+            simp [List.Pairwise] at hsorted; exact hsorted.2.2.1.1
           have hws_pos : ws.prod ≥ 1 :=
-            (List.prod_pos (fun a ha => by
-              have := hall8 a (by rw [hf]; simp [ha]); omega)).le
+            List.prod_pos (s := ws) (fun a ha => by
+              have := hall8 a (by rw [hf]; simp [ha]); omega)
           have hprod_ge : vf.factors.prod ≥ 8 * 9 * 10 * 11 := by
             rw [hf]; simp [List.prod]
             calc x * (y * (z * (w * ws.prod)))
@@ -399,8 +405,8 @@ theorem factorizationMax_7_ge : ∀ vf : ValidFactorization 7, vf.maxFactor ≥ 
 -- (four factors give ≤ 32760, five give ≥ 154440). So f(8) = 16.
 def vf8 : ValidFactorization 8 where
   factors := [12, 14, 15, 16]
-  sorted := by simp [List.Sorted, List.Pairwise]; omega
-  all_gt := by simp; omega
+  sorted := by decide
+  all_gt := by decide
   nonempty := by simp
   prod_eq := by native_decide
 
@@ -425,30 +431,31 @@ theorem factorizationMax_8_ge : ∀ vf : ValidFactorization 8, vf.maxFactor ≥ 
     cases xs with
     | nil =>
       -- Single factor: x = 40320 ≥ 16
-      simp [List.prod] at hprod; simp [List.getLast] at *; omega
+      rw [hf] at hprod; simp [List.prod, Nat.factorial] at hprod
+      simp only [List.getLastD_cons, List.getLastD_nil]; omega
     | cons y ys =>
       have hxy : x < y := by
         have hsorted := vf.sorted; rw [hf] at hsorted
-        simp [List.Sorted, List.Pairwise] at hsorted; exact hsorted.1.1
+        simp [List.Pairwise] at hsorted; exact hsorted.1.1
       cases ys with
       | nil =>
         -- Two factors [x, y]: x·y = 40320, x ≥ 9, y > x. Need y ≥ 16.
         -- If y ≤ 15 then x ≤ 14, product ≤ 14·15 = 210 < 40320.
-        simp [List.getLast]
-        rw [hf] at hprod; simp [List.prod] at hprod
+        simp only [List.getLastD_cons, List.getLastD_nil]
+        rw [hf] at hprod; simp [List.prod, Nat.factorial] at hprod
         by_contra h_lt; push_neg at h_lt
         have : x * y ≤ 14 * 15 := Nat.mul_le_mul (by omega) (by omega)
         omega
       | cons z zs =>
         have hyz : y < z := by
           have hsorted := vf.sorted; rw [hf] at hsorted
-          simp [List.Sorted, List.Pairwise] at hsorted; exact hsorted.2.1.1
+          simp [List.Pairwise] at hsorted; exact hsorted.2.1.1
         cases zs with
         | nil =>
           -- Three factors [x, y, z]: x·y·z = 40320. Need z ≥ 16.
           -- If z ≤ 15 then product ≤ 13·14·15 = 2730 < 40320.
-          simp [List.getLast]
-          rw [hf] at hprod; simp [List.prod] at hprod
+          simp only [List.getLastD_cons, List.getLastD_nil]
+          rw [hf] at hprod; simp [List.prod, Nat.factorial] at hprod
           by_contra h_lt; push_neg at h_lt
           have : x * (y * z) ≤ 13 * (14 * 15) :=
             Nat.mul_le_mul (by omega) (Nat.mul_le_mul (by omega) (by omega))
@@ -456,13 +463,13 @@ theorem factorizationMax_8_ge : ∀ vf : ValidFactorization 8, vf.maxFactor ≥ 
         | cons w ws =>
           have hzw : z < w := by
             have hsorted := vf.sorted; rw [hf] at hsorted
-            simp [List.Sorted, List.Pairwise] at hsorted; exact hsorted.2.2.1.1
+            simp [List.Pairwise] at hsorted; exact hsorted.2.2.1.1
           cases ws with
           | nil =>
             -- Four factors [x, y, z, w]: x·y·z·w = 40320. Need w ≥ 16.
             -- If w ≤ 15 then product ≤ 12·13·14·15 = 32760 < 40320.
-            simp [List.getLast]
-            rw [hf] at hprod; simp [List.prod] at hprod
+            simp only [List.getLastD_cons, List.getLastD_nil]
+            rw [hf] at hprod; simp [List.prod, Nat.factorial] at hprod
             by_contra h_lt; push_neg at h_lt
             have : x * (y * (z * w)) ≤ 12 * (13 * (14 * 15)) :=
               Nat.mul_le_mul (by omega) (Nat.mul_le_mul (by omega)
@@ -474,11 +481,11 @@ theorem factorizationMax_8_ge : ∀ vf : ValidFactorization 8, vf.maxFactor ≥ 
             exfalso
             have hwv : w < v := by
               have hsorted := vf.sorted; rw [hf] at hsorted
-              simp [List.Sorted, List.Pairwise] at hsorted
+              simp [List.Pairwise] at hsorted
               exact hsorted.2.2.2.1.1
             have hvs_pos : vs.prod ≥ 1 :=
-              (List.prod_pos (fun a ha => by
-                have := hall9 a (by rw [hf]; simp [ha]); omega)).le
+              List.prod_pos (s := vs) (fun a ha => by
+                have := hall9 a (by rw [hf]; simp [ha]); omega)
             have hprod_ge : vf.factors.prod ≥ 9 * 10 * 11 * 12 * 13 := by
               rw [hf]; simp [List.prod]
               calc x * (y * (z * (w * (v * vs.prod))))
@@ -498,7 +505,7 @@ theorem factorizationMax_7_eq : factorizationMax 7 = 20 := by
   simp only [show ∃ _ : ValidFactorization 7, True from ⟨vf7, trivial⟩, dite_true]
   apply Nat.le_antisymm
   · exact Nat.sInf_le ⟨vf7, by native_decide⟩
-  · apply Nat.le_sInf ⟨vf7.maxFactor, ⟨vf7, rfl⟩⟩
+  · refine le_csInf ⟨vf7.maxFactor, vf7, rfl⟩ ?_
     rintro m ⟨vf, rfl⟩
     exact factorizationMax_7_ge vf
 
@@ -508,7 +515,7 @@ theorem factorizationMax_8_eq : factorizationMax 8 = 16 := by
   simp only [show ∃ _ : ValidFactorization 8, True from ⟨vf8, trivial⟩, dite_true]
   apply Nat.le_antisymm
   · exact Nat.sInf_le ⟨vf8, by native_decide⟩
-  · apply Nat.le_sInf ⟨vf8.maxFactor, ⟨vf8, rfl⟩⟩
+  · refine le_csInf ⟨vf8.maxFactor, vf8, rfl⟩ ?_
     rintro m ⟨vf, rfl⟩
     exact factorizationMax_8_ge vf
 
@@ -517,15 +524,17 @@ theorem factorizationMax_8_eq : factorizationMax 8 = 16 := by
 /-- For any valid factorization of n!, the maximum factor is > n. -/
 theorem maxFactor_gt (n : ℕ) (vf : ValidFactorization n) : vf.maxFactor > n := by
   unfold ValidFactorization.maxFactor
-  exact vf.all_gt _ (List.getLast_mem vf.nonempty)
+  obtain ⟨hd, tl, hf⟩ := List.exists_cons_of_ne_nil vf.nonempty
+  refine vf.all_gt _ ?_
+  rw [hf]; simp only [List.getLastD_cons]; exact List.getLastD_mem_cons
 
 /-- A single-factor factorization [n!] is always valid for n ≥ 3,
 giving an upper bound f(n) ≤ n!. -/
 theorem factorizationMax_le_factorial (n : ℕ) (hn : n ≥ 3) :
     ∃ vf : ValidFactorization n, vf.maxFactor = n.factorial := by
   refine ⟨⟨[n.factorial], ?_, ?_, ?_, ?_⟩, ?_⟩
-  · simp [List.Sorted]
-  · simp; omega
+  · simp [List.Pairwise]
+  · simp only [List.mem_singleton, forall_eq]; exact Nat.lt_factorial_self hn
   · simp
   · simp
   · simp [ValidFactorization.maxFactor]

--- a/proofs/Proofs/Erdos405Problem.lean
+++ b/proofs/Proofs/Erdos405Problem.lean
@@ -117,7 +117,13 @@ theorem wilson_theorem (p : ℕ) (hp : Nat.Prime p) :
   have h := ZMod.wilsons_lemma p
   -- h : ((p-1)! : ZMod p) = -1
   have hval := congr_arg ZMod.val h
-  rw [ZMod.val_natCast, ZMod.val_neg_one'] at hval
+  rw [ZMod.val_natCast] at hval
+  have hneg : (-1 : ZMod p).val = p - 1 := by
+    have hp1 : (p : ℕ) - 1 < p := by have := hp.two_le; omega
+    have hcast : (-1 : ZMod p) = ((p - 1 : ℕ) : ZMod p) := by
+      rw [Nat.cast_sub hp.one_le]; simp
+    rw [hcast, ZMod.val_natCast, Nat.mod_eq_of_lt hp1]
+  rw [hneg] at hval
   exact hval
 
 /-- Fermat's little theorem: a^(p-1) ≡ 1 (mod p) when p ∤ a.
@@ -128,10 +134,8 @@ theorem fermat_little (p a : ℕ) (hp : Nat.Prime p) (ha : ¬p ∣ a) :
   have ha_zmod : (a : ZMod p) ≠ 0 := by
     intro h; apply ha
     rwa [ZMod.natCast_eq_zero_iff] at h
-  have hcard : p - 1 = Fintype.card (ZMod p) - 1 := by
-    rw [ZMod.card p]
-  have key : ((a : ZMod p)) ^ (p - 1) = 1 := by
-    rw [hcard]; exact ZMod.pow_card_sub_one_eq_one ha_zmod
+  have key : ((a : ZMod p)) ^ (p - 1) = 1 :=
+    ZMod.pow_card_sub_one_eq_one ha_zmod
   have h1 : ((a ^ (p - 1) : ℕ) : ZMod p) = ((1 : ℕ) : ZMod p) := by
     push_cast; exact key
   rwa [ZMod.natCast_eq_natCast_iff', Nat.mod_eq_of_lt hp.one_lt] at h1
@@ -144,7 +148,7 @@ theorem sum_divisible_by_p (p a : ℕ) (hp : Nat.Prime p) (hp3 : p ≥ 3) (ha : 
   have hf := fermat_little p a hp ha
   rw [Nat.dvd_iff_mod_eq_zero]
   rw [Nat.add_mod, hw, hf]
-  omega
+  rw [show p - 1 + 1 = p from by omega, Nat.mod_self]
 
 /-
 ## Part 5: The Exceptional Case p ∣ a
@@ -182,13 +186,14 @@ theorem legendre_formula (p n : ℕ) (hp : Nat.Prime p) :
   rcases eq_or_ne n 0 with rfl | hn
   · simp [factorialPadicVal]
   · have hlog : Nat.log p n < n + 1 := by
-      rw [Nat.log_lt hp.one_lt hn]
-      calc n < 2 ^ n := Nat.lt_two_pow n
+      rw [Nat.log_lt_iff_lt_pow hp.one_lt hn]
+      calc n < 2 ^ n := Nat.lt_two_pow_self
         _ ≤ p ^ n := Nat.pow_le_pow_left hp.two_le n
         _ ≤ p ^ (n + 1) := Nat.pow_le_pow_right hp.pos (Nat.le_succ n)
     rw [padicValNat_factorial hlog, Finset.sum_Ico_eq_sum_range]
     unfold factorialPadicVal
-    exact Finset.sum_congr (by omega) fun k _ => by rw [add_comm]
+    refine Finset.sum_congr ?_ (fun k _ => by rw [add_comm])
+    congr 1
 
 /-- For (p-1)!, the p-adic valuation is 0.
     Since (p-1)! is the product of {1,...,p-1}, none divisible by p. -/
@@ -217,25 +222,19 @@ theorem p_equals_3_analysis :
     ∀ a k : ℕ, IsSolution 3 a k →
       (a = 1 ∧ k = 1) ∨ (a = 5 ∧ k = 3) := by
   intro a k h
-  have := yu_liu_1996 3 a k
-  rw [h] at this
+  have := (yu_liu_1996 3 a k).mp h
   simp at this
-  rcases this with ⟨_, ha, hk⟩ | ⟨_, ha, hk⟩ | ⟨hp, _, _⟩
+  rcases this with ⟨ha, hk⟩ | ⟨ha, hk⟩
   · left; exact ⟨ha, hk⟩
   · right; exact ⟨ha, hk⟩
-  · norm_num at hp
 
 /-- For p = 5: 4! = 24, so need 24 + a⁴ = 5^k -/
 theorem p_equals_5_analysis :
     ∀ a k : ℕ, IsSolution 5 a k → a = 1 ∧ k = 2 := by
   intro a k h
-  have := yu_liu_1996 5 a k
-  rw [h] at this
+  have := (yu_liu_1996 5 a k).mp h
   simp at this
-  rcases this with ⟨hp, _, _⟩ | ⟨hp, _, _⟩ | ⟨_, ha, hk⟩
-  · norm_num at hp
-  · norm_num at hp
-  · exact ⟨ha, hk⟩
+  exact this
 
 /-
 ## Part 8: General Perfect Power Question
@@ -249,8 +248,8 @@ def IsPerfectPower (n : ℕ) : Prop :=
 
 /-- Example: 6! + 2⁶ = 720 + 64 = 784 = 28² -/
 theorem example_perfect_power :
-    6.factorial + 2 ^ 6 = 28 ^ 2 := by
-  norm_num
+    Nat.factorial 6 + 2 ^ 6 = 28 ^ 2 := by
+  norm_num [Nat.factorial]
 
 /-
 ## Part 9: Main Problem Statement

--- a/proofs/Proofs/Erdos461Problem.lean
+++ b/proofs/Proofs/Erdos461Problem.lean
@@ -43,16 +43,16 @@ private lemma prime_dvd_list_prod_mem {p : ℕ} (hp : p.Prime) :
   | nil =>
     intro _ hd
     simp at hd
-    exact absurd hd (by omega)
+    exact absurd hd hp.ne_one
   | cons a tl ih =>
     intro hall hd
     simp only [List.prod_cons] at hd
-    have ha_prime := hall a (List.mem_cons_self a tl)
+    have ha_prime := hall a List.mem_cons_self
     rcases hp.dvd_mul.mp hd with hpa | hptl
     · have := ha_prime.eq_one_or_self_of_dvd p hpa
       rcases this with rfl | rfl
       · exact absurd hp.one_lt (by omega)
-      · exact List.mem_cons_self p tl
+      · exact List.mem_cons_self
     · exact List.mem_cons.mpr (Or.inr
         (ih (fun q hq => hall q (List.mem_cons.mpr (Or.inr hq))) hptl))
 
@@ -62,33 +62,33 @@ private lemma prime_dvd_list_prod_mem {p : ℕ} (hp : p.Prime) :
 theorem smoothComponent_dvd (t n : ℕ) (hn : n ≠ 0) : smoothComponent t n ∣ n := by
   unfold smoothComponent
   have h := list_prod_filter_dvd n.primeFactorsList (fun x => decide (x < t))
-  rwa [Nat.prod_factors hn] at h
+  rwa [Nat.prod_primeFactorsList hn] at h
 
 /-- `smoothComponent t n` is `t`-smooth: every prime factor is `< t`. -/
 theorem smoothComponent_smooth (t n p : ℕ) (hp : p.Prime)
     (hd : p ∣ smoothComponent t n) : p < t := by
   unfold smoothComponent at hd
   have hall : ∀ q ∈ n.primeFactorsList.filter (· < t), q.Prime := fun q hq =>
-    Nat.prime_of_mem_factors (List.mem_filter.mp hq).1
+    Nat.prime_of_mem_primeFactorsList (List.mem_filter.mp hq).1
   have hmem := prime_dvd_list_prod_mem hp _ hall hd
-  exact (List.mem_filter.mp hmem).2
+  exact of_decide_eq_true (List.mem_filter.mp hmem).2
 
 /-- `smoothComponent t n` is nonzero (product of primes, all ≥ 2). -/
 theorem smoothComponent_pos (t n : ℕ) : 0 < smoothComponent t n := by
   unfold smoothComponent
   apply List.prod_pos
   intro x hx
-  exact (Nat.prime_of_mem_factors (List.mem_filter.mp hx).1).pos
+  exact (Nat.prime_of_mem_primeFactorsList (List.mem_filter.mp hx).1).pos
 
 /-- No prime `< t` divides the complement part of the factorization. -/
 private lemma no_small_prime_in_complement (t n p : ℕ) (hp : p.Prime)
-    (hpt : p < t) (hd : p ∣ (n.primeFactorsList.filter (fun x => ¬ decide (x < t))).prod) :
+    (hpt : p < t) (hd : p ∣ (n.primeFactorsList.filter (fun x => !decide (x < t))).prod) :
     False := by
-  have hall : ∀ q ∈ n.primeFactorsList.filter (fun x => ¬ decide (x < t)), q.Prime := fun q hq =>
-    Nat.prime_of_mem_factors (List.mem_filter.mp hq).1
+  have hall : ∀ q ∈ n.primeFactorsList.filter (fun x => !decide (x < t)), q.Prime := fun q hq =>
+    Nat.prime_of_mem_primeFactorsList (List.mem_filter.mp hq).1
   have hmem := prime_dvd_list_prod_mem hp _ hall hd
   have := (List.mem_filter.mp hmem).2
-  simp at this
+  simp only [Bool.not_eq_eq_eq_not, Bool.not_true, decide_eq_false_iff_not, not_lt] at this
   omega
 
 /-- Product of filtered list times product of complement equals product of original.
@@ -113,11 +113,12 @@ theorem smoothComponent_largest (t n d : ℕ) (hn : n ≠ 0) :
     d ∣ n → (∀ p : ℕ, p.Prime → p ∣ d → p < t) → d ∣ smoothComponent t n := by
   intro hdn hsmooth
   -- Define the complement part: product of prime factors ≥ t
-  set comp := (n.primeFactorsList.filter (fun x => ¬ x < t)).prod with hcomp_def
+  set comp := (n.primeFactorsList.filter (fun x => !decide (x < t))).prod with hcomp_def
   -- Key fact: n = smoothComponent * comp (partition of prime factorization)
   have hfact : smoothComponent t n * comp = n := by
     unfold smoothComponent
-    rw [list_prod_filter_mul_not, Nat.prod_factors hn]
+    rw [list_prod_filter_mul_not n.primeFactorsList (fun x => decide (x < t)),
+      Nat.prod_primeFactorsList hn]
   -- d and comp are coprime: no prime divides both
   have hcop : Nat.Coprime d comp := by
     rw [Nat.coprime_comm, Nat.coprime_iff_gcd_eq_one]
@@ -126,14 +127,14 @@ theorem smoothComponent_largest (t n d : ℕ) (hn : n ≠ 0) :
     -- gcd > 1 means some prime divides both
     have hgcd := Nat.exists_prime_and_dvd (by omega : Nat.gcd comp d ≠ 1)
     obtain ⟨p, hp, hpg⟩ := hgcd
-    have hpcomp := (Nat.dvd_gcd.mp hpg).1
-    have hpd := (Nat.dvd_gcd.mp hpg).2
+    have hpcomp := (Nat.dvd_gcd_iff.mp hpg).1
+    have hpd := (Nat.dvd_gcd_iff.mp hpg).2
     -- p | d → p < t (by smoothness of d)
     have hpt := hsmooth p hp hpd
     -- p | comp → p ≥ t (all factors of comp are ≥ t)
     exact no_small_prime_in_complement t n p hp hpt hpcomp
   -- d | smoothComponent * comp and coprime d comp → d | smoothComponent
-  have hdn' : d ∣ smoothComponent t n * comp := hfact ▸ hdn
+  have hdn' : d ∣ smoothComponent t n * comp := by rw [hfact]; exact hdn
   exact (Nat.Coprime.dvd_of_dvd_mul_right hcop) hdn'
 
 /- ## Counting distinct smooth components -/
@@ -163,34 +164,33 @@ axiom erdos_graham_lower :
 
 /-- The smooth component of 1 is always 1. -/
 theorem smoothComponent_one (t : ℕ) : smoothComponent t 1 = 1 := by
-  simp [smoothComponent, Nat.factors_one]
+  simp [smoothComponent, Nat.primeFactorsList_one]
 
 /-- For `t ≤ 1`, every smooth component is 1 (no primes below 1). -/
 theorem smoothComponent_t_le_one {t : ℕ} (n : ℕ) (ht : t ≤ 1) :
     smoothComponent t n = 1 := by
   simp only [smoothComponent]
   suffices h : n.primeFactorsList.filter (· < t) = [] by simp [h]
-  apply List.filter_eq_nil.mpr
+  apply List.filter_eq_nil_iff.mpr
   intro p hp
   simp only [decide_eq_true_eq, not_lt]
-  have := (Nat.prime_of_mem_factors hp).two_le
+  have := (Nat.prime_of_mem_primeFactorsList hp).two_le
   omega
 
 /-- The count is at most `t` (there are only `t` values in the interval). -/
 theorem smoothDistinctCount_le (n t : ℕ) : smoothDistinctCount n t ≤ t := by
   unfold smoothDistinctCount
-  have h1 := @Finset.card_image_le _ _ (Finset.Icc (n + 1) (n + t)) (smoothComponent t)
-  have h2 : (Finset.Icc (n + 1) (n + t)).card = t := by
-    simp only [Finset.card_Icc]; omega
-  linarith
+  calc (Finset.image (smoothComponent t) (Finset.Icc (n + 1) (n + t))).card
+      ≤ (Finset.Icc (n + 1) (n + t)).card := Finset.card_image_le
+    _ = t := by rw [Nat.card_Icc]; omega
 
 /-- For `t = 0`, the interval is empty, so the count is 0. -/
 theorem smoothDistinctCount_zero (n : ℕ) : smoothDistinctCount n 0 = 0 := by
-  simp [smoothDistinctCount, Finset.Icc_eq_empty (by omega : ¬(n + 1 ≤ n + 0))]
+  simp [smoothDistinctCount]
 
 /-- Smooth component of 0 is 1 (0 has no prime factors). -/
 theorem smoothComponent_zero (t : ℕ) : smoothComponent t 0 = 1 := by
-  simp [smoothComponent, Nat.factors_zero]
+  simp [smoothComponent, Nat.primeFactorsList_zero]
 
 /-- If n is t-smooth (all prime factors < t), then smoothComponent t n = n. -/
 theorem smoothComponent_eq_self (t n : ℕ) (hn : n ≠ 0)
@@ -201,11 +201,10 @@ theorem smoothComponent_eq_self (t n : ℕ) (hn : n ≠ 0)
 theorem smoothComponent_prime (t p : ℕ) (hp : p.Prime) :
     smoothComponent t p = if p < t then p else 1 := by
   unfold smoothComponent
-  rw [Nat.factors_prime hp]
-  simp only [List.filter_cons, List.filter_nil, List.append_nil]
-  split <;> rename_i h
-  · simp [List.prod_cons]
-  · simp
+  rw [Nat.primeFactorsList_prime hp]
+  by_cases h : p < t
+  · simp [h, List.prod_cons]
+  · simp [h]
 
 /-- For a prime p ≥ t, the smooth component is 1. -/
 theorem smoothComponent_prime_ge (t p : ℕ) (hp : p.Prime) (hpt : t ≤ p) :
@@ -218,14 +217,14 @@ theorem smoothComponent_id_of_smooth (t n : ℕ) (hn : n ≠ 0)
   unfold smoothComponent
   rw [show n.primeFactorsList.filter (· < t) = n.primeFactorsList from
     List.filter_eq_self.mpr (fun x hx => by simpa using h x hx)]
-  exact Nat.prod_factors hn
+  exact Nat.prod_primeFactorsList hn
 
 /-- If n < t (and n > 0), then smoothComponent t n = n
     (all prime factors of n are ≤ n < t). -/
 theorem smoothComponent_id_of_lt (t n : ℕ) (hn : 0 < n) (hnt : n < t) :
     smoothComponent t n = n :=
   smoothComponent_id_of_smooth t n (by omega) fun p hp =>
-    lt_of_le_of_lt (Nat.le_of_dvd hn (Nat.dvd_of_mem_factors hp)) hnt
+    lt_of_le_of_lt (Nat.le_of_dvd hn (Nat.dvd_of_mem_primeFactorsList hp)) hnt
 
 /-- Smooth component is fully multiplicative over factors:
     factors(m*n) is a permutation of factors(m) ++ factors(n),
@@ -233,9 +232,9 @@ theorem smoothComponent_id_of_lt (t n : ℕ) (hn : 0 < n) (hnt : n < t) :
 theorem smoothComponent_mul (t m n : ℕ) (hm : m ≠ 0) (hn : n ≠ 0) :
     smoothComponent t (m * n) = smoothComponent t m * smoothComponent t n := by
   unfold smoothComponent
-  have hperm := (Nat.factors_mul hm hn).filter (· < t)
+  have hperm := (Nat.perm_primeFactorsList_mul hm hn).filter (· < t)
   rw [List.filter_append] at hperm
-  exact hperm.prod_eq.trans (List.prod_append _ _)
+  exact hperm.prod_eq.trans List.prod_append
 
 /-- The smooth component is 1 iff no prime factor of n is less than t. -/
 theorem smoothComponent_eq_one_iff (t n : ℕ) (hn : n ≠ 0) :
@@ -246,11 +245,11 @@ theorem smoothComponent_eq_one_iff (t n : ℕ) (hn : n ≠ 0) :
     have hp_dvd : p ∣ (n.primeFactorsList.filter (· < t)).prod := List.dvd_prod hmem
     unfold smoothComponent at h; rw [h] at hp_dvd
     exact absurd (Nat.le_of_dvd one_pos hp_dvd)
-      (by have := (Nat.prime_of_mem_factors hp).two_le; omega)
+      (by have := (Nat.prime_of_mem_primeFactorsList hp).two_le; omega)
   · intro h
     unfold smoothComponent
     have : n.primeFactorsList.filter (· < t) = [] :=
-      List.filter_eq_nil.mpr (fun p hp => by simpa using h p hp)
+      List.filter_eq_nil_iff.mpr (fun p hp => by simpa using h p hp)
     simp [this]
 
 /-- Smooth component of m divides smooth component of m*n. -/

--- a/proofs/Proofs/Erdos59Problem.lean
+++ b/proofs/Proofs/Erdos59Problem.lean
@@ -71,7 +71,7 @@ theorem odd_cycle_not_bipartite (n : ℕ) (hn : 3 ≤ n) (hodd : Odd n) :
   -- Helper: every vertex is in A or B
   have mem : ∀ v : Fin n, v ∈ A ∨ v ∈ B := by
     intro v; have h : v ∈ (A ∪ B) := by rw [hunion]; exact Set.mem_univ v
-    exact Set.mem_union.mp h
+    exact (Set.mem_union _ _ _).mp h
   -- Consecutive vertices k, k+1 are adjacent (for k+1 < n)
   have consec_adj : ∀ (k : ℕ) (hk : k + 1 < n),
       (cycleGraph n hn).Adj ⟨k, by omega⟩ ⟨k + 1, hk⟩ := by
@@ -80,7 +80,7 @@ theorem odd_cycle_not_bipartite (n : ℕ) (hn : 3 ≤ n) (hodd : Odd n) :
   have closing : (cycleGraph n hn).Adj ⟨n - 1, by omega⟩ ⟨0, by omega⟩ := by
     left; show (n - 1 + 1) % n = 0; rw [Nat.sub_add_cancel (by omega : 1 ≤ n), Nat.mod_self]
   -- n-1 is even since n is odd
-  have hn1_even : Even (n - 1) := by obtain ⟨k, hk⟩ := hodd; omega
+  have hn1_even : Even (n - 1) := by obtain ⟨k, hk⟩ := hodd; exact ⟨k, by omega⟩
   -- Case split on whether vertex 0 is in A or B
   rcases mem ⟨0, by omega⟩ with h0 | h0
   · -- Case: 0 ∈ A. Prove by induction: vertex k ∈ A ↔ Even k
@@ -88,15 +88,15 @@ theorem odd_cycle_not_bipartite (n : ℕ) (hn : 3 ≤ n) (hodd : Odd n) :
       have h_nm1_A := (this (n - 1) (by omega)).mpr hn1_even
       exact hA ⟨n - 1, by omega⟩ h_nm1_A ⟨0, by omega⟩ h0 closing
     intro k; induction k with
-    | zero => intro _; exact ⟨fun _ => even_zero, fun _ => h0⟩
+    | zero => intro _; exact ⟨fun _ => Even.zero, fun _ => h0⟩
     | succ m ih =>
       intro hk
       have hadj := consec_adj m hk
       constructor
-      · intro hsucc_A; rw [Nat.even_succ]; intro hm_even
+      · intro hsucc_A; rw [Nat.even_add_one]; intro hm_even
         exact hA ⟨m, by omega⟩ ((ih (by omega)).mpr hm_even) ⟨m + 1, hk⟩ hsucc_A hadj
       · intro hsucc_even
-        have hm_odd : ¬Even m := by rwa [← Nat.even_succ]
+        have hm_odd : ¬Even m := by rwa [← Nat.even_add_one]
         have hm_not_A : ⟨m, by omega⟩ ∉ A := fun h => hm_odd ((ih (by omega)).mp h)
         have hm_B := (mem ⟨m, by omega⟩).resolve_left hm_not_A
         have hsucc_not_B : ⟨m + 1, hk⟩ ∉ B := fun h => hB ⟨m, by omega⟩ hm_B ⟨m + 1, hk⟩ h hadj
@@ -106,15 +106,15 @@ theorem odd_cycle_not_bipartite (n : ℕ) (hn : 3 ≤ n) (hodd : Odd n) :
       have h_nm1_B := (this (n - 1) (by omega)).mpr hn1_even
       exact hB ⟨n - 1, by omega⟩ h_nm1_B ⟨0, by omega⟩ h0 closing
     intro k; induction k with
-    | zero => intro _; exact ⟨fun _ => even_zero, fun _ => h0⟩
+    | zero => intro _; exact ⟨fun _ => Even.zero, fun _ => h0⟩
     | succ m ih =>
       intro hk
       have hadj := consec_adj m hk
       constructor
-      · intro hsucc_B; rw [Nat.even_succ]; intro hm_even
+      · intro hsucc_B; rw [Nat.even_add_one]; intro hm_even
         exact hB ⟨m, by omega⟩ ((ih (by omega)).mpr hm_even) ⟨m + 1, hk⟩ hsucc_B hadj
       · intro hsucc_even
-        have hm_odd : ¬Even m := by rwa [← Nat.even_succ]
+        have hm_odd : ¬Even m := by rwa [← Nat.even_add_one]
         have hm_not_B : ⟨m, by omega⟩ ∉ B := fun h => hm_odd ((ih (by omega)).mp h)
         have hm_A := (mem ⟨m, by omega⟩).resolve_right hm_not_B
         have hsucc_not_A : ⟨m + 1, hk⟩ ∉ A := fun h => hA ⟨m, by omega⟩ hm_A ⟨m + 1, hk⟩ h hadj
@@ -132,7 +132,7 @@ theorem even_cycle_bipartite (n : ℕ) (hn : 3 ≤ n) (heven : Even n) :
     ext x; simp only [Set.mem_union, Set.mem_setOf_eq, Set.mem_univ, iff_true]
     exact em (Even x.val)
   · -- A ∩ B = ∅
-    ext x; simp only [Set.mem_inter_iff, Set.mem_setOf_eq, Set.mem_empty_iff_false]
+    ext x; simp only [Set.mem_inter_iff, Set.mem_setOf_eq, Set.mem_empty_iff_false, iff_false]
     exact fun ⟨h1, h2⟩ => h2 h1
   · -- No edges within even-parity vertices
     intro u hu v hv hadj

--- a/proofs/batch2/STATUS.md
+++ b/proofs/batch2/STATUS.md
@@ -1,3 +1,82 @@
+# DOCTOR INCREMENT 72 (deep-rework partition A: A–M + Erdos < 600, #38065, 2026-07-15)
+
+Container `dr72` (cpus 6-11, 11g, cache v431-b), worktree doctor-b, branch
+`feature/issue-38065-inc72` off origin/feature/issue-37508. **+5 GREEN.** PR #38675.
+Every flip verified in-container `lake env lean Proofs.X` exit-0 before ledger flip; pushed per file.
+
+## Flips (failure class in parens)
+- **Erdos461Problem** (unknown-const): full `Nat.factors`→`primeFactorsList` rename
+  (`prod_factors`→`prod_primeFactorsList`, `prime_of_mem_factors`→`prime_of_mem_primeFactorsList`,
+  `factors_one/zero/prime`→`primeFactorsList_*`, `dvd_of_mem_factors`→`dvd_of_mem_primeFactorsList`,
+  `factors_mul`→`perm_primeFactorsList_mul`) + **filter-predicate unification**: `¬x<t` /
+  `decide(¬x<t)` / `!decide(x<t)` are no longer defeq at the `List.filter`, so pick ONE canonical
+  Bool complement form `fun x => !decide (x < t)` and thread it through `list_prod_filter_mul_not`,
+  `no_small_prime_in_complement`, and the coprimality arg. Also `List.mem_cons_self` now arg-free;
+  **`List.prod_append` is now an equation, not a fn** (`List.prod_append _ _`→`List.prod_append`);
+  `Nat.dvd_gcd.mp`→`Nat.dvd_gcd_iff.mp`; `Finset.card_Icc`→`Nat.card_Icc`;
+  `List.filter_eq_nil`→`filter_eq_nil_iff`; `of_decide_eq_true` to bridge `decide _ = true` → Prop.
+- **Erdos390Problem** (unknown-const:List.Sorted): **`List.Sorted` REMOVED → `List.Pairwise`**
+  (structure field `factors.Sorted (·<·)`→`factors.Pairwise (·<·)` + every simp site; drop the
+  now-redundant `List.Sorted` from `simp [List.Sorted, List.Pairwise]`). **`getLast` with a
+  nonempty-proof breaks `cases hf : vf.factors`** ("generalize: result is not type correct" —
+  the proof arg's type mentions the scrutinee) → redefine `maxFactor` to `getLastD 0` (no proof
+  arg); membership via `List.getLastD_cons` + `List.getLastD_mem_cons`. `dite` over `∃ vf, True`
+  needs a `Decidable` instance → `noncomputable def … := by classical; exact …`.
+  **`List.prod_pos`: `s` is NOT inferred from a `_ ≥ 1` expected type** (`0<_` vs `1≤_` defeq
+  isn't unified during elab) → pass `(s := ys)` explicitly (and drop the stale `.le`). nil (single
+  factor) branches: `cases` does NOT substitute into pre-existing `hprod`/`hgt` → `rw [hf] at hprod`
+  then `simp [Nat.factorial]` to expose the numeral for omega. `Nat.le_sInf` REMOVED → `le_csInf`
+  (takes `s.Nonempty` + bound; give the nonempty witness via `refine le_csInf ⟨…⟩ ?_`, not
+  `apply`+anon-ctor which can't infer `s`). `Nat.lt_factorial_self` for the `[n!]` witness.
+- **Erdos334Problem** (unknown-const:Nat.Prime.dvd_prime_pow): `Nat.Prime.dvd_prime_pow` /
+  `Nat.Prime.eq_one_or_self_of_prime_of_dvd` REMOVED. For "q prime ∣ p^k ⇒ q ≤ p" use
+  `((Nat.prime_dvd_prime_iff_eq hq hp).mp (hq.dvd_of_dvd_pow hdiv)).le`. Also
+  **`Real.sqrt Real.exp 1` is a real typo** (rexp : ℝ→ℝ needs application) → `Real.sqrt (Real.exp 1)`.
+  (Formalized entry, 3 pre-existing sorries preserved — GREEN = compiles, sorries are orthogonal.)
+- **Erdos405Problem** (unknown-const:ZMod.val_neg_one'): **`ZMod.val_neg_one'` gone** → derive
+  `(-1 : ZMod p).val = p-1` via `(-1) = ((p-1 : ℕ) : ZMod p)` (cast_sub) + `val_natCast` +
+  `mod_eq_of_lt`. **`ZMod.pow_card_sub_one_eq_one` now returns `a^(p-1)` directly** (drop the
+  `Fintype.card`-reindex `hcard`). `Nat.log_lt`→**`Nat.log_lt_iff_lt_pow`**; `Nat.lt_two_pow`→
+  **`Nat.lt_two_pow_self`** (n now implicit). An **iff-axiom `yu_liu_1996` + `rw [h]` on a
+  Prop-proof fails** ("Invalid rewrite argument: `h` is a proof of …") → `(yu_liu_1996 …).mp h`;
+  `simp` then collapses the `3=3`/`5=5` guards so the downstream rcases arity shrinks. `sum_congr`
+  range-eq via `congr 1` (`n+1-1` defeq `n`, so omega after is a No-goals error — drop it).
+  **`6.factorial` parses as `6.` + `factorial`** → `Nat.factorial 6`. `p ∣ p` mod via `Nat.mod_self`.
+- **Erdos59Problem** (unknown-const:Set.mem_union.mp): `Set.mem_union` now takes explicit
+  `(x a b)` → `(Set.mem_union _ _ _).mp h`. `Nat.even_succ`→**`Nat.even_add_one`**;
+  **`even_zero`→`Even.zero`**; omega won't synth an `Even` goal from `Odd n` → give the explicit
+  `⟨k, by omega⟩` witness. **v4.31 `simp` on `A ∩ B = ∅` after `ext` leaves `(P ∧ ¬P) ↔ False`,
+  not `P ∧ ¬P → False`** → add `iff_false` to the `simp only` set (this one refine-`⟨⟩` failure
+  had cascaded as spurious `unterminated comment` / `end` / type-mismatch errors 100+ lines below —
+  fix the real goal and they vanish).
+
+## New systematic seams (rename-map §7al candidates)
+1. **`List.Sorted` REMOVED** → `List.Pairwise` (was `Sorted r = Pairwise r`); `List.sorted_cons`→`pairwise_cons`.
+2. **`getLast` carrying a `≠[]` proof blocks `cases h : theList`** (dependent-proof motive) → switch
+   the def to `getLastD default` (proof-free) and case cleanly; membership via `List.getLastD_mem_cons`.
+3. **`List.prod_pos` won't infer `{s}` from a `_ ≥ 1` expected type** (`0<_` vs `1≤_` not unified) → `(s := …)`.
+4. **`List.prod_append` / `Nat.prod_primeFactorsList` are equations, not fns** — drop trailing `_ _`.
+5. **`Nat.le_sInf` REMOVED → `le_csInf`** (`s.Nonempty` first); anon-ctor nonempty needs `refine`, not `apply`.
+6. **`Nat.log_lt`→`Nat.log_lt_iff_lt_pow`; `Nat.lt_two_pow`→`Nat.lt_two_pow_self` (implicit n);
+   `Nat.even_succ`→`Nat.even_add_one`; `even_zero`→`Even.zero`; `Nat.dvd_gcd.mp`→`Nat.dvd_gcd_iff.mp`;
+   `Nat.Prime.dvd_prime_pow` gone (use `prime_dvd_prime_iff_eq` + `dvd_of_dvd_pow`).**
+7. **A bare numeral dot-projection `6.factorial` now parses `6.` as a float** → `Nat.factorial 6` / `(6:ℕ).factorial`.
+8. **v4.31 `simp` normalizes `_ = ∅`/`_ = univ` membership goals to `P ↔ False`/`P ↔ True`** — add
+   `iff_false`/`iff_true` so a `→`-shaped exact still closes. A refine-`⟨⟩` failure can cascade as
+   spurious lexer/`end` errors far downstream; fix the real subgoal first.
+9. **`Set.mem_union` args now explicit** `(x a b)`; membership in `∪` is still defeq to `∨` (`exact h` often works).
+
+## Deferred (partition A, triaged — good next starting points)
+- **Erdos367Problem** (14 err): `twoFullPart_le` (thm L344) and `van_doorn_lower_bound` (axiom L245)
+  are FORWARD-REFERENCED at L140/157/158/205 → reorder above first use; ALSO `Nat.factorization_prime`
+  gone, `Finset.filter_eq_empty`→`_iff`, unknown-`p` scoping at L267/278, two type-mismatches.
+- **Erdos411Problem** (8 err): `totientStep_ge`/`totientStep_even_of_even` forward-refs; TWO
+  `maxHeartbeats` timeouts at L247/248 (bump `set_option maxHeartbeats` if the proof is just slow on
+  v4.31, else rewrite); two type-mismatches (L380/422).
+- **Erdos358Problem** (14 err, `two_mul_sum_Icc`), **Erdos201Problem** (29 err) — larger multi-root.
+
+---
+
 # DOCTOR INCREMENT 70 (deep-rework partition A: A–M + Erdos < 600, #38065, 2026-07-15)
 
 Container `dr70` (cpus 6-11, 11g, cache v431-b), worktree doctor-b, branch

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -1135,7 +1135,7 @@ Erdos329Problem	GREEN
 Erdos330Problem	GREEN	
 Erdos332Problem	GREEN	
 Erdos333Problem	GREEN	
-Erdos334Problem	RESIDUAL	unknown-const:Nat.Prime.dvd_prime_pow
+Erdos334Problem	GREEN	
 Erdos336Problem	GREEN	
 Erdos337Aristotle	GREEN	
 Erdos337Problem	GREEN	

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -1291,7 +1291,7 @@ Erdos456Problem	RESIDUAL	proof-drift
 Erdos457Problem	GREEN	
 Erdos459Problem	RESIDUAL	type-mismatch
 Erdos45Problem	GREEN	
-Erdos461Problem	RESIDUAL	unknown-const:Nat.prod_factors
+Erdos461Problem	GREEN	
 Erdos464Problem	GREEN	
 Erdos465Problem	GREEN	
 Erdos466Problem	GREEN	

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -1205,7 +1205,7 @@ Erdos385Problem	GREEN
 Erdos386Problem	GREEN	
 Erdos388Problem	GREEN	
 Erdos38Problem	GREEN	
-Erdos390Problem	RESIDUAL	unknown-const:List.Sorted
+Erdos390Problem	GREEN	
 Erdos391Problem	RESIDUAL	type-mismatch
 Erdos393Problem	GREEN	
 Erdos394Problem	GREEN	

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -1226,7 +1226,7 @@ Erdos400Problem	GREEN
 Erdos402Problem	RESIDUAL	type-mismatch
 Erdos403Problem	GREEN	
 Erdos404Problem	RESIDUAL	rewrite-drift
-Erdos405Problem	RESIDUAL	unknown-const:ZMod.val_neg_one'
+Erdos405Problem	GREEN	
 Erdos407Problem	RESIDUAL	proof-drift
 Erdos408Problem	GREEN	
 Erdos409Problem	PRE-EXISTING	never-compiled:p

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -1450,7 +1450,7 @@ Erdos596Problem	GREEN
 Erdos597Problem	GREEN	
 Erdos598Problem	GREEN	elab-drift
 Erdos599Problem	GREEN	
-Erdos59Problem	RESIDUAL	unknown-const:Set.mem_union.mp
+Erdos59Problem	GREEN	
 Erdos5Problem	GREEN	
 Erdos600Problem	GREEN	
 Erdos601Aristotle	GREEN	


### PR DESCRIPTION
Deep-rework tail grind for epic #37508 / ledger #38065, partition A (A–M + Erdos<600).

Every file verified in-container (`lake env lean Proofs.X` exit-0) before ledger flip; pushed per file.

## GREEN this increment
- **Erdos461Problem** (unknown-const → GREEN): `Nat.factors`→`primeFactorsList` full API rename family + genuine filter-predicate unification (canonical Bool `fun x => !decide (x < t)` for the complement, since `¬x<t` / `decide(¬x<t)` / `!decide(x<t)` are no longer defeq at the filter on v4.31), plus `List.mem_cons_self` arg-free, `List.prod_append` now an equation, `Nat.dvd_gcd_iff`, `Nat.card_Icc`, `List.filter_eq_nil_iff`.

No `loom:review-requested`. Do not merge — deployer/operator handles.