### PR TITLE
migrate(v4.31): Doctor increment — partition Erdos>=500 (+3 GREEN)

### DIFF
--- a/proofs/Proofs/Erdos1006Problem.lean
+++ b/proofs/Proofs/Erdos1006Problem.lean
@@ -47,19 +47,28 @@ open SimpleGraph
 
 variable {V : Type*} [Fintype V] [DecidableEq V]
 
+namespace Erdos1006
+
+variable {G : SimpleGraph V}
+
 /-
 ## Graph Girth
 
 The girth of a graph is the length of its shortest cycle.
 -/
 
+/-- A `List V` describes a cycle in `G`: consecutive vertices are adjacent, the
+    list is closed (first vertex equals last), and it has length at least 3. -/
+def isCycleIn (G : SimpleGraph V) (cycle : List V) : Prop :=
+  cycle.Chain' G.Adj ∧ cycle.head? = cycle.getLast? ∧ 3 ≤ cycle.length
+
 /-- A graph has girth at least g if it contains no cycles of length < g -/
 def hasGirthAtLeast (G : SimpleGraph V) (g : ℕ) : Prop :=
-  ∀ (cycle : List V), cycle.length < g → ¬G.IsCycle cycle
+  ∀ (cycle : List V), cycle.length < g → ¬isCycleIn G cycle
 
 /-- A graph has girth exactly g if g is the length of its shortest cycle -/
 def hasGirth (G : SimpleGraph V) (g : ℕ) : Prop :=
-  hasGirthAtLeast G g ∧ ∃ (cycle : List V), cycle.length = g ∧ G.IsCycle cycle
+  hasGirthAtLeast G g ∧ ∃ (cycle : List V), cycle.length = g ∧ isCycleIn G cycle
 
 /-
 ## Directed Graphs and Orientations
@@ -77,7 +86,8 @@ structure Orientation (G : SimpleGraph V) where
 
 /-- A directed path in an orientation -/
 def Orientation.hasDirectedPath (O : Orientation G) (path : List V) : Prop :=
-  path.length ≥ 2 ∧ ∀ i, i + 1 < path.length → O.directed (path.get ⟨i, by omega⟩) (path.get ⟨i+1, by omega⟩)
+  path.length ≥ 2 ∧ ∀ i (h : i + 1 < path.length),
+    O.directed (path.get ⟨i, by omega⟩) (path.get ⟨i+1, by omega⟩)
 
 /-- An orientation is acyclic if it has no directed cycles -/
 def Orientation.isAcyclic (O : Orientation G) : Prop :=
@@ -118,13 +128,13 @@ def oresConjecture : Prop :=
 
 /-- The Grötzsch graph has girth 4 and no robustly acyclic orientation -/
 axiom grotzsch_counterexample :
-  ∃ (V : Type) (_ : Fintype V) (_ : DecidableEq V) (G : SimpleGraph V) (_ : DecidableRel G.Adj),
+  ∃ (V : Type*) (_ : Fintype V) (_ : DecidableEq V) (G : SimpleGraph V) (_ : DecidableRel G.Adj),
     hasGirth G 4 ∧ ¬admitsRobustlyAcyclicOrientation G
 
 /-- Nešetřil-Rödl theorem: For every g ≥ 3, there exists a graph with girth g
     that has no robustly acyclic orientation -/
 axiom nesetril_rodl_1978 (g : ℕ) (hg : g ≥ 3) :
-  ∃ (V : Type) (_ : Fintype V) (_ : DecidableEq V) (G : SimpleGraph V) (_ : DecidableRel G.Adj),
+  ∃ (V : Type*) (_ : Fintype V) (_ : DecidableEq V) (G : SimpleGraph V) (_ : DecidableRel G.Adj),
     hasGirth G g ∧ ¬admitsRobustlyAcyclicOrientation G
 
 /-- Corollary: Ore's conjecture is false -/
@@ -139,3 +149,5 @@ theorem ores_conjecture_false : ¬oresConjecture := by
 
 #check ores_conjecture_false
 #check @nesetril_rodl_1978
+
+end Erdos1006

--- a/proofs/Proofs/Erdos1018Aristotle.lean
+++ b/proofs/Proofs/Erdos1018Aristotle.lean
@@ -14,6 +14,7 @@ import Mathlib.Data.Real.Basic
 import Mathlib.Data.Fintype.Basic
 import Mathlib.Data.Nat.Basic
 import Mathlib.Algebra.Order.Field.Basic
+import Mathlib.Data.Real.Archimedean
 
 namespace Erdos1018.Aristotle
 
@@ -105,11 +106,11 @@ theorem edgecount_dense_exceeds_planar (e n : ℕ) (hn : n ≥ 4)
 
 -- ε² > 0 when ε > 0
 theorem sq_pos (ε : ℝ) (hε : ε > 0) : ε ^ 2 > 0 := by
-  positivity
+  exact pow_pos hε 2
 
 -- 1/ε² > 0 when ε > 0
 theorem inv_sq_pos (ε : ℝ) (hε : ε > 0) : 1 / ε ^ 2 > 0 := by
-  positivity
+  exact div_pos one_pos (pow_pos hε 2)
 
 -- 1/ε² ≥ 1 when 0 < ε ≤ 1
 theorem inv_sq_ge_one (ε : ℝ) (hε : ε > 0) (hε1 : ε ≤ 1) : 1 / ε ^ 2 ≥ 1 := by

--- a/proofs/Proofs/Erdos552Problem.lean
+++ b/proofs/Proofs/Erdos552Problem.lean
@@ -39,14 +39,7 @@ open SimpleGraph Finset
 
 /-- The cycle graph C_n on n vertices. -/
 def cycleGraph (n : ℕ) : SimpleGraph (Fin n) where
-  Adj := fun i j => (i.val + 1) % n = j.val ∨ (j.val + 1) % n = i.val
-  symm := by constructor; intro i j h; cases h <;> (right; assumption) <|> (left; assumption)
-  loopless := by
-    constructor
-    intro i h
-    cases h with
-    | inl h => simp at h; omega
-    | inr h => simp at h; omega
+  Adj := fun i j => i ≠ j ∧ ((i.val + 1) % n = j.val ∨ (j.val + 1) % n = i.val)
 
 /-- The 4-cycle C₄. -/
 def C4 : SimpleGraph (Fin 4) := cycleGraph 4
@@ -54,8 +47,6 @@ def C4 : SimpleGraph (Fin 4) := cycleGraph 4
 /-- The star graph S_n = K_{1,n} on n+1 vertices (center + n leaves). -/
 def starGraph (n : ℕ) : SimpleGraph (Fin (n + 1)) where
   Adj := fun i j => (i.val = 0 ∧ j.val ≠ 0) ∨ (j.val = 0 ∧ i.val ≠ 0)
-  symm := by constructor; intro i j h; cases h <;> (right; exact ⟨‹_›.1, ‹_›.2⟩) <|> (left; exact ⟨‹_›.1, ‹_›.2⟩)
-  loopless := by constructor; intro i h; cases h <;> omega
 
 /- ## Part II: Ramsey Numbers -/
 
@@ -186,7 +177,8 @@ def polarityGraph (q : ℕ) : SimpleGraph (Fin (q ^ 2 + q + 1)) := by
 /- ## Part IX: Related Results -/
 
 /-- The minimum degree condition for C₄. -/
-theorem c4_minimum_degree (n : ℕ) (G : SimpleGraph (Fin n)) (hn : n ≥ 4) :
+theorem c4_minimum_degree (n : ℕ) (G : SimpleGraph (Fin n)) [DecidableRel G.Adj]
+    (hn : n ≥ 4) :
     (∀ v : Fin n, G.degree v ≥ n / 2) → ContainsSubgraph G C4 := by
   sorry
 

--- a/proofs/batch2/STATUS.md
+++ b/proofs/batch2/STATUS.md
@@ -1,3 +1,86 @@
+# DOCTOR INCREMENT 74 (deep-rework LANE 2 / partition Erdos >= 500, #38065, 2026-07-15)
+
+Container `dr-b` (cpus 6-11, 11g, cache v431-b), worktree doctor-b, branch
+`feature/issue-38065-inc74` off origin/feature/issue-37508. **+3 GREEN.** PR (below).
+Every flip verified in-container `lake env lean Proofs.X` exit-0 before ledger flip; pushed per file.
+
+## Flips (failure class in parens)
+- **Erdos1006Problem** (instance-synth): (1) `structure Orientation` at root now COLLIDES
+  with Mathlib's `_root_.Orientation` (linear-algebra module orientations) — v4.31 rejects the
+  redeclaration and it cascades into ~8 `synthInstanceFailed` on `Orientation G`. Fix: wrap the
+  whole file in `namespace Erdos1006`. (2) `G.IsCycle (cycle : List V)` uses a projection
+  `SimpleGraph.IsCycle` that does not exist (cycles are `Walk.IsCycle`); replaced with a local
+  `isCycleIn G cycle := cycle.Chain' G.Adj ∧ head?=getLast? ∧ 3 ≤ length` predicate. (3) the
+  `Orientation.*` methods autobound a fresh vertex type `V✝` while `reverseEdge`'s `(u v : V)`
+  used the `variable V` → two vertex types; added `variable {G : SimpleGraph V}` to pin them.
+  (4) `by omega` inside `path.get ⟨i, by omega⟩` couldn't see the anonymous arrow hypothesis →
+  name it `∀ i (h : i+1 < path.length), …`. (5) universe mismatch: `oresConjecture` quantifies
+  `∀ (V : Type*)` but the counterexample axioms fixed `V : Type` (Type 0), so `hconj V` couldn't
+  unify — made `grotzsch_counterexample` / `nesetril_rodl_1978` universe-polymorphic (`Type*`),
+  preserving the full-strength negation.
+- **Erdos1018Aristotle** (proof-drift; **minimal-import file**): the file imports a handful of
+  specific `Mathlib.*` modules (not `import Mathlib`). The ceiling notation `⌈ ⌉` and the
+  `FloorRing ℝ` instance used to come in transitively but no longer do on v4.31 → `⌈x⌉` fails to
+  lex ("expected token" at U+2308). Fix: `import Mathlib.Data.Real.Archimedean` (provides both the
+  Floor notation and the `FloorRing ℝ` instance). Also two `positivity` proofs of `ε^2>0` /
+  `1/ε^2>0` from `ε>0` now fail (positivity won't mine `ε>0` for the `ε≠0` side-condition) →
+  explicit `pow_pos hε 2` / `div_pos one_pos (pow_pos hε 2)`. Pre-existing `sorry`s preserved.
+- **Erdos552Problem** (parse-error + **statement repair #38611**): (1) the SimpleGraph field
+  proofs `symm := by constructor; … <;> (right; assumption) <|> (left; assumption)` no longer
+  parse (`;` inside the `( )` tactic group) AND explicit `intro`/`rintro` on the reduced
+  `Symmetric Adj` / `Irreflexive Adj` field goal fails with `introN` ("no additional binders").
+  Fix: **delete the explicit `symm`/`loopless` fields and let SimpleGraph's default `aesop_graph`
+  discharge them** (verified: the same `where`-def with the fields omitted compiles). (2)
+  **STATEMENT REPAIR**: `cycleGraph n` had `Adj i j := (i+1)%n=j ∨ (j+1)%n=i`, which for n=1 gives
+  `Adj 0 0 = ((0+1)%1 = 0) = True` — a SELF-LOOP — so `loopless` was genuinely false for n=1 (the
+  old `simp at h; omega` masked it; on v4.31 `simp` errors "no progress" and omega can't refute the
+  i+1=n=1 case). Added the missing `i ≠ j` conjunct → genuinely-correct cycle graph, unchanged for
+  n≥2. (3) `c4_minimum_degree` uses `G.degree v` on an arbitrary `G` → added `[DecidableRel G.Adj]`.
+
+## New systematic seams (rename-map §7al candidates)
+1. **A root `structure`/`def` whose name collides with a Mathlib `_root_` decl** (`Orientation`,
+   possibly `Coloring`, `Path`, …) is now rejected as "already declared" and cascades into
+   `synthInstanceFailed` on every use → wrap the file in a `namespace`.
+2. **Minimal-import files that used `⌈ ⌉`/`⌊ ⌋`/`FloorRing`/`Int.ceil` via a now-dropped
+   transitive import** fail to LEX the notation ("expected token" at the ceil/floor glyph) → add
+   `import Mathlib.Data.Real.Archimedean` (notation + `FloorRing ℝ` instance). Likely affects other
+   minimal-import Erdos files: candidates seen this session = Erdos1012OQ03, Erdos1035Problem,
+   Erdos1155OQ02, Erdos583/570/551/625/662/780/552/766 (grep: uses ⌈/floor, no bare `import Mathlib`).
+3. **`positivity` no longer mines a `0 < x` hypothesis for the `x ≠ 0` side-condition of `x^2`** →
+   use `pow_pos` / `div_pos` explicitly.
+4. **SimpleGraph `where`-def field proofs**: on v4.31 explicit `intro`/`rintro` on the `symm`/
+   `loopless` field goal fails with `introN` (the field's expected type is presented reduced, not as
+   a `∀`-Pi). Prefer OMITTING the fields and letting the default `aesop_graph` prove them; only give
+   explicit proofs in plain term form (`fun _ _ h => h.symm`) when aesop can't.
+5. **A `(t1; t2)` tactic group with `;` inside parens** no longer parses in some positions → use
+   `<;>` / `first | … | …` / a `by` block.
+
+## Statement repairs logged for #38611
+- **Erdos552Problem / cycleGraph**: added `i ≠ j` to the cycle-graph adjacency; the old definition
+  admitted a self-loop at n=1 (loopless was false there). Not a weakening — the fix restores the
+  intended loop-free cycle graph. Gallery meta for erdos-552 may want a re-audit.
+- **Erdos807Problem (DEFERRED, candidate)**: `ERW_conjecture n := True` (placeholder) yet
+  `erw_conjecture_false : ¬∀ n, ERW_conjecture n` claims to prove `¬(∀n, True)`, which is genuinely
+  unprovable — the old "green" via `trivial` could not have been legitimate. Needs a real
+  formalization of the τ = n − α equality to refute, not a mechanical drift fix. Left RESIDUAL.
+
+## Deferred (LANE 2, triaged — good next leads)
+- **Erdos1067Problem / Erdos910Problem(+Provable)** (Cardinal/universe): `chromaticNumber` uses
+  `κ.toPartENat` (removed → `Cardinal.toENat`) AND `∃ (c : V → κ)` treats a Cardinal `κ` as a type,
+  plus "universe level metavariables" in `hasAleph1ChromaticNumber` and `V→κ` Ambiguous-term. Real
+  universe-polymorphism rework; defer.
+- **Erdos560Problem** (elab-drift): `Sym2.Rel` projections / `Quot (Sym2.Rel V)` `⟨…⟩` no longer
+  valid + synthInstance + `invalid atom`. Multi-root.
+- **Erdos1014Problem** (21 err, real-analysis): `Real.isLittleO_log_rpow_atTop` gone,
+  `div_le_one_of_le` gone, linarith/rpow drift — cascade-parent of Erdos1014OQ02 &
+  Erdos1014OQ03Concrete (both are 1-error missing-olean cascades that flip once 1014Problem builds).
+- **Import-cascade families**: Erdos1007OQ05/OQ01 (parent Erdos1007Problem), Erdos1017Problem
+  (parent Erdos1017OQ01, 24 err) — fix the parent, build its olean into the cache, siblings cascade.
+- **Cheap 2-error leads not yet done**: Erdos1035Problem (synthInstance ×2), Erdos625Problem
+  (typeclass stuck ×2). Erdos662Problem is a native_decide-on-noncomputable case (rule-2, deeper).
+
+---
+
 # DOCTOR INCREMENT 72 (deep-rework partition A: A–M + Erdos < 600, #38065, 2026-07-15)
 
 Container `dr72` (cpus 6-11, 11g, cache v431-b), worktree doctor-b, branch

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -658,7 +658,7 @@ Erdos1015Problem	PRE-EXISTING	never-compiled:n
 Erdos1017OQ01	RESIDUAL	type-mismatch
 Erdos1017OQ04	GREEN	
 Erdos1017Problem	RESIDUAL	type-mismatch
-Erdos1018Aristotle	RESIDUAL	proof-drift
+Erdos1018Aristotle	GREEN	
 Erdos1018OQ01	GREEN	
 Erdos1018OQ01OQ01	GREEN	
 Erdos1018OQ01OQ01OQ01	GREEN	

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -1396,7 +1396,7 @@ Erdos550Problem	GREEN
 Erdos551Problem	RESIDUAL	instance-synth
 Erdos551ProblemAristotle	RESIDUAL	proof-drift
 Erdos552Aristotle	RESIDUAL	parse-error
-Erdos552Problem	RESIDUAL	parse-error
+Erdos552Problem	GREEN	
 Erdos553Aristotle	GREEN	
 Erdos553Problem	GREEN	
 Erdos553ProblemAristotle	GREEN	

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -616,7 +616,7 @@ Erdos1006OQ02	GREEN
 Erdos1006OQ03	GREEN	
 Erdos1006OQ04	GREEN	
 Erdos1006OQ04Decidability	GREEN	unclassified
-Erdos1006Problem	RESIDUAL	instance-synth
+Erdos1006Problem	GREEN	
 Erdos1007OQ01	RESIDUAL	proof-drift
 Erdos1007OQ01OQ01	GREEN	
 Erdos1007OQ04	GREEN	


### PR DESCRIPTION
## Doctor migration increment 74 — LANE 2 (partition Erdős ≥ 500), epic #37508 / #38065

Base branch `feature/issue-37508`. **+3 RESIDUAL→GREEN.** Each file verified in-container (`lake env lean Proofs/X.lean` EXIT=0, cpuset 6-11, cache lean-mathlib-cache-v431-b) before flipping its ledger row; pushed per file. Not merged — orchestrator merges.

### Files flipped GREEN
| File | Class | Key fix |
|------|-------|---------|
| `Erdos1006Problem` | instance-synth | namespace-wrap (root `Orientation` collided with Mathlib `_root_.Orientation`); local `isCycleIn` for nonexistent `G.IsCycle`; `variable {G}` to pin vertex type; named arrow-hyp for omega; universe-polymorphic counterexample axioms |
| `Erdos1018Aristotle` | proof-drift | minimal-import file lost transitive Floor/ceiling import → `import Mathlib.Data.Real.Archimedean`; `positivity`→`pow_pos`/`div_pos`; sorries preserved |
| `Erdos552Problem` | parse-error + statement repair | drop unparseable `symm`/`loopless` field proofs → default `aesop_graph`; **cycleGraph adjacency now requires `i ≠ j`** (n=1 self-loop bug); `[DecidableRel G.Adj]` for `G.degree` |

### Statement repairs (candidates for #38611)
- **Erdos552Problem / cycleGraph**: old `Adj i j := (i+1)%n=j ∨ (j+1)%n=i` gives `Adj 0 0 = True` for n=1 (a self-loop) so `loopless` was genuinely false there; the old `simp;omega` masked it. Added `i ≠ j` → genuinely-correct cycle graph, unchanged for n≥2. Suggest gallery re-audit of erdos-552.
- **Erdos807Problem (DEFERRED, not in this PR)**: `ERW_conjecture := True` placeholder makes `erw_conjecture_false : ¬∀n, True` genuinely unprovable — needs a real τ=n−α formalization to refute, not a drift fix. Left RESIDUAL, flagged.

### New systematic seams (see proofs/batch2/STATUS.md increment 74)
1. Root decl colliding with a Mathlib `_root_` name (e.g. `Orientation`) now errors + cascades to synthInstance → wrap in a namespace.
2. Minimal-import files using `⌈⌉`/`⌊⌋`/`FloorRing` fail to LEX the glyph now that the transitive import is gone → add `import Mathlib.Data.Real.Archimedean`. Likely affects several sibling Erdős files.
3. `positivity` no longer mines `0<x` for the `x≠0` side-condition of `x^2` → `pow_pos`/`div_pos`.
4. SimpleGraph `where`-def: explicit `intro` on `symm`/`loopless` fields fails (`introN`); prefer default `aesop_graph`.

### Warm leads for next wave (partition Erdős ≥ 500)
- Cardinal/universe: Erdos1067Problem, Erdos910Problem(+Provable) (`toPartENat`→`toENat`, `V→κ` type-vs-cardinal, universe metavars).
- Erdos560Problem (Sym2.Rel projections). Erdos1014Problem (real-analysis, 21 err) → cascade-parent of Erdos1014OQ02/OQ03Concrete.
- Import-cascade parents: Erdos1007Problem (→OQ05), Erdos1017OQ01 (→Erdos1017Problem).
- Cheap 2-error: Erdos1035Problem, Erdos625Problem.