### PR TITLE
migrate(v4.31): Doctor increment — partition Erdos<500 (+4 GREEN)

### DIFF
--- a/proofs/Proofs/Erdos281Problem.lean
+++ b/proofs/Proofs/Erdos281Problem.lean
@@ -29,6 +29,7 @@ import Mathlib.Data.Finset.Card
 import Mathlib.Tactic
 
 open Finset
+open scoped Classical
 
 /- ## Core Definitions -/
 
@@ -80,17 +81,17 @@ theorem uncoveredCount_antitone {moduli : ℕ → ℕ} {choice : CongruenceChoic
     uncoveredCount moduli choice k₂ N ≤ uncoveredCount moduli choice k₁ N := by
   unfold uncoveredCount
   apply card_le_card
-  apply Finset.filter_subset_filter
-  intro m hm hncov
-  exact hncov (isCoveredByFirst_mono h hm)
+  intro m hm
+  simp only [Finset.mem_filter] at hm ⊢
+  exact ⟨hm.1, fun hcov1 => hm.2 (isCoveredByFirst_mono h hcov1)⟩
 
 /-- Trivial upper bound: at most N integers in [1, N] are uncovered. -/
 theorem uncoveredCount_le (moduli : ℕ → ℕ) (choice : CongruenceChoice moduli)
     (k N : ℕ) : uncoveredCount moduli choice k N ≤ N := by
   unfold uncoveredCount
-  calc (Finset.Icc (1 : ℤ) N).filter _ |>.card
-      ≤ (Finset.Icc (1 : ℤ) N).card := card_filter_le _ _
-    _ ≤ N := by simp [Finset.card_Icc]; omega
+  refine le_trans (Finset.card_filter_le _ _) ?_
+  simp only [Int.card_Icc]
+  omega
 
 /-- With zero classes, all N integers in [1, N] are uncovered (for N ≥ 1). -/
 theorem uncoveredCount_zero_classes (moduli : ℕ → ℕ) (choice : CongruenceChoice moduli)
@@ -103,8 +104,8 @@ theorem uncoveredCount_zero_classes (moduli : ℕ → ℕ) (choice : CongruenceC
     simp only [Finset.mem_filter, and_iff_left_iff_imp]
     intro _
     exact not_isCoveredByFirst_zero moduli choice m
-  rw [hfilt]
-  simp [Finset.card_Icc]; omega
+  rw [hfilt, Int.card_Icc]
+  omega
 
 /-- The density is at most 1. -/
 theorem uncoveredDensity_le_one (moduli : ℕ → ℕ) (choice : CongruenceChoice moduli)
@@ -136,8 +137,8 @@ theorem uncoveredDensity_antitone {moduli : ℕ → ℕ} {choice : CongruenceCho
     the set of uncovered integers has upper density 0. -/
 def HasFullCovering (moduli : ℕ → ℕ) : Prop :=
   ∀ choice : CongruenceChoice moduli,
-    ∀ ε : ℚ, 0 < ε → ∃ N₀ : ℕ, ∀ N : ℕ, N₀ ≤ N → 0 < N →
-      uncoveredDensity moduli choice (N + 1) N (by omega) < ε
+    ∀ ε : ℚ, 0 < ε → ∃ N₀ : ℕ, ∀ N : ℕ, N₀ ≤ N → ∀ hN : 0 < N,
+      uncoveredDensity moduli choice (N + 1) N hN < ε
 
 /-- Strictly increasing moduli. -/
 def IsStrictlyIncreasing (moduli : ℕ → ℕ) : Prop :=
@@ -160,8 +161,8 @@ def PairwiseCoprime (moduli : ℕ → ℕ) : Prop :=
 def HasUniformFiniteCoverage (moduli : ℕ → ℕ) : Prop :=
   ∀ ε : ℚ, 0 < ε → ∃ k : ℕ,
     ∀ choice : CongruenceChoice moduli,
-      ∃ N₀ : ℕ, ∀ N : ℕ, N₀ ≤ N → 0 < N →
-        uncoveredDensity moduli choice k N (by omega) < ε
+      ∃ N₀ : ℕ, ∀ N : ℕ, N₀ ≤ N → ∀ hN : 0 < N,
+        uncoveredDensity moduli choice k N hN < ε
 
 /-- **Easy direction (proved)**: Uniform finite ε-coverage implies full
     covering. This is the trivial direction: if finitely many classes

--- a/proofs/Proofs/Erdos367Problem.lean
+++ b/proofs/Proofs/Erdos367Problem.lean
@@ -57,6 +57,17 @@ noncomputable def twoFullPart (n : ℕ) : ℕ :=
   else n
 
 /--
+**Upper Bound: B₂(n) ≤ n**
+
+The 2-full part never exceeds n itself.
+-/
+theorem twoFullPart_le (n : ℕ) : twoFullPart n ≤ n := by
+  unfold twoFullPart
+  split
+  next _ => exact Nat.div_le_self n _
+  next _ => exact le_refl n
+
+/--
 **Alternative Definition via Prime Factorization**
 
 B₂(n) = ∏_{v_p(n) ≥ 2} p^{v_p(n)}.
@@ -151,7 +162,8 @@ theorem strong_bound_k2 : strongBound 2 := by
   unfold productTwoFullParts
   have hIco : Finset.Ico n (n + 2) = {n, n + 1} := by
     ext m; simp only [Finset.mem_Ico, Finset.mem_insert, Finset.mem_singleton]; omega
-  rw [hIco, Finset.prod_insert (show n ∉ ({n + 1} : Finset ℕ) by simp; omega),
+  rw [hIco, Finset.prod_insert (show n ∉ ({n + 1} : Finset ℕ) by
+        simp only [Finset.mem_singleton]; omega),
       Finset.prod_singleton]
   simp only [Nat.cast_mul]
   have h1 : (twoFullPart n : ℝ) ≤ (n : ℝ) := by exact_mod_cast twoFullPart_le n
@@ -175,8 +187,8 @@ lemma strongBound_implies_weakBound {k : ℕ} (h : strongBound k) : weakBound k 
   refine ⟨C, hC, fun n hn => ?_⟩
   have hn1 : (1 : ℝ) ≤ (n : ℝ) := by exact_mod_cast hn
   have h_rpow : (n : ℝ) ^ 2 ≤ (n : ℝ) ^ (2 + ε) := by
-    rw [← Real.rpow_natCast (n : ℝ) 2]
-    exact Real.rpow_le_rpow_of_exponent_le hn1 (le_add_of_nonneg_right hε.le)
+    apply pow_le_pow_right₀ hn1
+    omega
   exact (hbound n hn).trans (mul_le_mul_of_nonneg_left h_rpow hC.le)
 
 /-- Erdős conjecture holds for k = 1: ∏B₂(m) ≤ n^{2+ε} for all ε > 0. -/
@@ -190,6 +202,16 @@ theorem weak_bound_k2 : weakBound 2 := strongBound_implies_weakBound strong_boun
 
 van Doorn showed the strong bound fails for k ≥ 3.
 -/
+
+/--
+**van Doorn's Lower Bound**
+
+For k = 3, there exist infinitely many n where the product
+of 2-full parts exceeds n² by a logarithmic factor.
+-/
+axiom van_doorn_lower_bound :
+    ∃ c : ℝ, c > 0 ∧ ∀ N : ℕ, ∃ n ≥ N,
+      (productTwoFullParts n 3 : ℝ) ≥ c * (n : ℝ) ^ 2 * Real.log n
 
 /--
 **Strong Bound Fails for k = 3**
@@ -236,16 +258,6 @@ theorem strong_bound_fails_k3 : ¬ strongBound 3 := by
     linarith [mul_div_cancel₀ C (ne_of_gt hc)]
   linarith
 
-/--
-**van Doorn's Lower Bound**
-
-For k = 3, there exist infinitely many n where the product
-of 2-full parts exceeds n² by a logarithmic factor.
--/
-axiom van_doorn_lower_bound :
-    ∃ c : ℝ, c > 0 ∧ ∀ N : ℕ, ∃ n ≥ N,
-      (productTwoFullParts n 3 : ℝ) ≥ c * (n : ℝ) ^ 2 * Real.log n
-
 /-
 # Part 7: Properties of the 2-Full Part
 
@@ -264,7 +276,7 @@ private lemma primeFactors_prime_eq (p : ℕ) (hp : p.Prime) :
   · rintro ⟨hq, hqp, -⟩
     exact (hp.eq_one_or_self_of_dvd q hqp).resolve_left hq.one_lt.ne'
   · rintro rfl
-    exact ⟨hp, dvd_refl p, hp.ne_zero⟩
+    exact ⟨hp, dvd_refl _, hp.ne_zero⟩
 
 /- Helper: For a prime p, (p^2).primeFactors = {p} -/
 private lemma primeFactors_prime_sq_eq (p : ℕ) (hp : p.Prime) :
@@ -275,7 +287,7 @@ private lemma primeFactors_prime_sq_eq (p : ℕ) (hp : p.Prime) :
   · rintro ⟨hq, hqp2, -⟩
     exact (hp.eq_one_or_self_of_dvd q (hq.dvd_of_dvd_pow hqp2)).resolve_left hq.one_lt.ne'
   · rintro rfl
-    exact ⟨hp, dvd_pow_self p (by omega), pow_ne_zero 2 hp.ne_zero⟩
+    exact ⟨hp, dvd_pow_self _ (by omega), pow_ne_zero 2 hp.ne_zero⟩
 
 /- Helper: squarefreePart of a prime equals the prime itself -/
 private lemma squarefreePart_prime_eq (p : ℕ) (hp : p.Prime) :
@@ -286,9 +298,8 @@ private lemma squarefreePart_prime_eq (p : ℕ) (hp : p.Prime) :
     apply Finset.filter_true_of_mem
     intro q hq
     rw [Finset.mem_singleton.mp hq]
-    simp [Nat.factorization_prime hp, Finsupp.single_eq_same]
-  rw [hfilt]
-  exact Finset.prod_singleton
+    simp [hp.factorization, Finsupp.single_eq_same]
+  rw [hfilt, Finset.prod_singleton]
 
 /- Helper: squarefreePart of p² is 1 (no primes with exponent exactly 1) -/
 private lemma squarefreePart_prime_sq_eq (p : ℕ) (hp : p.Prime) :
@@ -297,10 +308,10 @@ private lemma squarefreePart_prime_sq_eq (p : ℕ) (hp : p.Prime) :
   rw [primeFactors_prime_sq_eq p hp]
   have hfilt : ({p} : Finset ℕ).filter
       (fun q => (p ^ 2).factorization q = 1) = ∅ := by
-    rw [Finset.filter_eq_empty]
+    rw [Finset.filter_eq_empty_iff]
     intro q hq
     rw [Finset.mem_singleton.mp hq]
-    simp [Nat.factorization_prime_pow hp, Finsupp.single_eq_same]
+    simp [Nat.Prime.factorization_pow hp, Finsupp.single_eq_same]
   rw [hfilt]
   exact Finset.prod_empty
 
@@ -335,17 +346,6 @@ theorem twoFullPart_prime_sq (p : ℕ) (hp : p.Prime) :
 
 /- Note: twoFullPart_mul_coprime (B₂(mn) = B₂(m)·B₂(n) for coprime m,n)
    was removed as it was unused in any proof. The fact is true but not needed. -/
-
-/--
-**Upper Bound: B₂(n) ≤ n**
-
-The 2-full part never exceeds n itself.
--/
-theorem twoFullPart_le (n : ℕ) : twoFullPart n ≤ n := by
-  unfold twoFullPart
-  split
-  next _ => exact Nat.div_le_self n _
-  next _ => exact le_refl n
 
 /--
 **Divisibility: B₂(n) | n**

--- a/proofs/Proofs/Erdos411Problem.lean
+++ b/proofs/Proofs/Erdos411Problem.lean
@@ -74,6 +74,19 @@ theorem totientStep_triple {m : ℕ} (hm : 3 ∣ m) (hm_pos : 0 < m) :
   rw [Nat.totient_mul_of_prime_of_dvd (by decide : Nat.Prime 3) hm]
   ring
 
+/-- For even n, g(n) = n + φ(n) is always even, so the iterates
+stay even. This is relevant since all known solutions are even. -/
+theorem totientStep_even_of_even {n : ℕ} (hn : 2 ∣ n) (hn2 : n > 2) :
+    2 ∣ totientStep n := by
+  unfold totientStep
+  have hφ : 2 ∣ n.totient := (Nat.totient_even hn2).two_dvd
+  exact dvd_add hn hφ
+
+/-- The iteration g(n) = n + φ(n) always produces a value ≥ n. -/
+theorem totientStep_ge (n : ℕ) : totientStep n ≥ n := by
+  unfold totientStep
+  omega
+
 /-- The iterates are always ≥ the starting value. -/
 theorem iteratedTotientStep_ge_start (n k : ℕ) :
     iteratedTotientStep k n ≥ n := by
@@ -165,6 +178,7 @@ private theorem ratio3_738_aux :
         have h_ak : iteratedTotientStep k 738 =
             totientStep (iteratedTotientStep (k - 1) 738) := by
           conv_lhs => rw [show k = (k - 1) + 1 from by omega]
+          rfl
         -- Chain: a_{k+4} = g(a_{k+3}) = g(3·a_{k-1}) = 3·g(a_{k-1}) = 3·a_k
         calc iteratedTotientStep (k + 4) 738
             = totientStep (iteratedTotientStep (k + 3) 738) := rfl
@@ -217,6 +231,7 @@ private theorem ratio4_148646_aux :
         have h_ak : iteratedTotientStep k 148646 =
             totientStep (iteratedTotientStep (k - 1) 148646) := by
           conv_lhs => rw [show k = (k - 1) + 1 from by omega]
+          rfl
         calc iteratedTotientStep (k + 4) 148646
             = totientStep (iteratedTotientStep (k + 3) 148646) := rfl
           _ = totientStep (4 * iteratedTotientStep (k - 1) 148646) := by rw [h_ratio]
@@ -230,6 +245,7 @@ private theorem ratio4_148646_aux :
 theorem cambie_ratio4_148646 : GeneralRatioRelation 148646 4 4 :=
   ⟨1, fun k hk => (ratio4_148646_aux k hk).2⟩
 
+set_option maxHeartbeats 1000000 in
 private theorem ratio4_4325798_aux :
     ∀ k, 1 ≤ k →
       4 ∣ iteratedTotientStep k 4325798 ∧
@@ -256,6 +272,7 @@ private theorem ratio4_4325798_aux :
         have h_ak : iteratedTotientStep k 4325798 =
             totientStep (iteratedTotientStep (k - 1) 4325798) := by
           conv_lhs => rw [show k = (k - 1) + 1 from by omega]
+          rfl
         calc iteratedTotientStep (k + 4) 4325798
             = totientStep (iteratedTotientStep (k + 3) 4325798) := rfl
           _ = totientStep (4 * iteratedTotientStep (k - 1) 4325798) := by rw [h_ratio]
@@ -372,26 +389,12 @@ theorem doubling_r2_n70 : DoublingRelation 70 2 :=
 ## Section VII: Structural Properties
 -/
 
-/-- For even n, g(n) = n + φ(n) is always even, so the iterates
-stay even. This is relevant since all known solutions are even. -/
-theorem totientStep_even_of_even {n : ℕ} (hn : 2 ∣ n) (hn2 : n > 2) :
-    2 ∣ totientStep n := by
-  unfold totientStep
-  have hφ : 2 ∣ n.totient := Nat.totient_even hn2
-  exact dvd_add hn hφ
-
 /-- Cambie conjectures all r = 2 solutions have form n = 2^l · p
 where l ≥ 1 and p ∈ {2, 3, 5, 7, 35, 47}. -/
 def CambieConjecture : Prop :=
   ∀ n : ℕ, DoublingRelation n 2 →
     ∃ l : ℕ, l ≥ 1 ∧
       ∃ p ∈ ({2, 3, 5, 7, 35, 47} : Finset ℕ), n = 2 ^ l * p
-
-/-- The iteration g(n) = n + φ(n) always produces an even number
-when n ≥ 3, since φ(n) is even for n ≥ 3. -/
-theorem totientStep_ge (n : ℕ) : totientStep n ≥ n := by
-  unfold totientStep
-  omega
 
 /-
 ## Section VIII: Cambie Family Doubling Tower
@@ -419,7 +422,7 @@ theorem steinerberger_eq_lift {n : ℕ} (hn_even : 2 ∣ n) (hn_gt : n > 2)
     (h_eq : n.totient + (n + n.totient).totient = n) :
     (2 * n).totient + (2 * n + (2 * n).totient).totient = 2 * n := by
   have hn_pos : 0 < n := by omega
-  have hφn_even : 2 ∣ n.totient := Nat.totient_even hn_gt
+  have hφn_even : 2 ∣ n.totient := (Nat.totient_even hn_gt).two_dvd
   have h_phi2n : (2 * n).totient = 2 * n.totient :=
     totient_double_even hn_even hn_pos
   have hsum_even : 2 ∣ (n + n.totient) := dvd_add hn_even hφn_even

--- a/proofs/Proofs/Erdos471Problem.lean
+++ b/proofs/Proofs/Erdos471Problem.lean
@@ -124,12 +124,9 @@ def vinogradovQ₀ : Set ℕ :=
 There are finitely many primes ≤ N.
 -/
 theorem vinogradovQ₀_finite : vinogradovQ₀.Finite := by
-  apply Set.Finite.of_finset
-  · exact Finset.filter (fun p => Nat.Prime p) (Finset.range (Classical.choose vinogradov_smaller_primes + 1))
-  · intro x
-    simp only [Finset.mem_filter, Finset.mem_range, Set.mem_setOf_eq]
-    intro ⟨hp, hx⟩
-    exact ⟨Nat.lt_add_one_iff.mpr hx, hp⟩
+  apply Set.Finite.subset (Set.finite_Iic (Classical.choose vinogradov_smaller_primes))
+  intro x hx
+  exact hx.2
 
 /--
 **All primes appear in Q∞:**
@@ -173,15 +170,8 @@ def ulamQ₀ : Set ℕ := {3, 5, 7, 11}
 -/
 theorem Q1_contains_19 : 19 ∈ QSeq ulamQ₀ 1 := by
   right
-  constructor
-  · exact Nat.prime_def_lt''.mpr ⟨by norm_num, fun m hm h => by interval_cases m <;> simp_all⟩
-  · use 3, 5, 11
-    simp [ulamQ₀]
-    constructor; · exact Nat.prime_three
-    constructor; · exact Nat.prime_five
-    constructor
-    · exact Nat.prime_def_lt''.mpr ⟨by norm_num, fun m hm h => by interval_cases m <;> simp_all⟩
-    · norm_num
+  exact ⟨by norm_num, 3, 5, 11, by simp [QSeq, ulamQ₀], by simp [QSeq, ulamQ₀], by simp [QSeq, ulamQ₀],
+    by norm_num, by norm_num, by norm_num, by norm_num, by norm_num, by norm_num, by norm_num⟩
 
 /--
 **Q₁ includes 23:**
@@ -189,16 +179,8 @@ theorem Q1_contains_19 : 19 ∈ QSeq ulamQ₀ 1 := by
 -/
 theorem Q1_contains_23 : 23 ∈ QSeq ulamQ₀ 1 := by
   right
-  constructor
-  · exact Nat.prime_def_lt''.mpr ⟨by norm_num, fun m hm h => by interval_cases m <;> simp_all⟩
-  · use 5, 7, 11
-    simp [ulamQ₀]
-    constructor; · exact Nat.prime_five
-    constructor
-    · exact Nat.prime_def_lt''.mpr ⟨by norm_num, fun m hm h => by interval_cases m <;> simp_all⟩
-    constructor
-    · exact Nat.prime_def_lt''.mpr ⟨by norm_num, fun m hm h => by interval_cases m <;> simp_all⟩
-    · norm_num
+  exact ⟨by norm_num, 5, 7, 11, by simp [QSeq, ulamQ₀], by simp [QSeq, ulamQ₀], by simp [QSeq, ulamQ₀],
+    by norm_num, by norm_num, by norm_num, by norm_num, by norm_num, by norm_num, by norm_num⟩
 
 /- 
 **Does Q∞ contain all primes starting from {3,5,7,11}?**

--- a/proofs/batch2/STATUS.md
+++ b/proofs/batch2/STATUS.md
@@ -1,4 +1,79 @@
-# DOCTOR INCREMENT 72 (deep-rework partition A: A–M + Erdos < 600, #38065, 2026-07-15)
+# DOCTOR INCREMENT 73 (deep-rework LANE 1: residual Erdős < 500, #38065, 2026-07-15)
+
+Container `lean4-arm64:v4.31.0` (cpuset 0-5, 11g, cache `lean-mathlib-cache-v431`,
+packages `lean-mathlib-packages-v431`), worktree `issue-38065`, branch
+`feature/issue-38065-inc73` off origin/feature/issue-37508. **+4 GREEN.**
+Every flip verified in-container `lake env lean Proofs/X.lean` exit-0 before ledger flip; pushed per file.
+
+## Flips (failure class in parens)
+- **Erdos367Problem** (unknown-const:twoFullPart_le): two **forward-reference** blockers —
+  `twoFullPart_le` (used L140/157/158, defined L344) and axiom `van_doorn_lower_bound`
+  (used L205, defined L245); moved both above first use. Renames: `Nat.factorization_prime hp`
+  → `hp.factorization`; `Nat.factorization_prime_pow hp` → `Nat.Prime.factorization_pow hp`;
+  `Finset.filter_eq_empty` → `Finset.filter_eq_empty_iff`; `exact Finset.prod_singleton` (no longer
+  a bare fn for the goal) → `rw [Finset.prod_singleton]`. **`rintro rfl` on `q ∈ {p}` (i.e. `q = p`)
+  now substitutes AWAY `p`** (the lemma arg) not `q` → replace explicit `p` with `_` in the witness
+  (`dvd_refl _`, `dvd_pow_self _`). **`ε` in `weakBound` is `ℕ` not `ℝ`** so `(n:ℝ)^(2+ε)` is a
+  Nat-power (npow), not rpow — the old `Real.rpow_le_rpow_of_exponent_le` approach mismatched;
+  replaced with `pow_le_pow_right₀ hn1 (by omega)`. `by simp; omega` where simp now closes the goal
+  → `by simp only [Finset.mem_singleton]; omega` (drops the "No goals" from the orphan omega).
+- **Erdos411Problem** (unknown-const:totientStep_ge): two **forward-refs** —
+  `totientStep_even_of_even` (used L96, def L377) and `totientStep_ge` (used L84, def L392) moved
+  above `iteratedTotientStep_ge_start`. **`Nat.totient_even` now returns `Even n.totient`, not
+  `2 ∣ n.totient`** → `(Nat.totient_even h).two_dvd`. `conv_lhs => rw [show k = (k-1)+1 …]` no longer
+  auto-closes the residual defeq goal → append explicit `rfl` (3 sites). Bumped
+  `set_option maxHeartbeats 1000000 in` on `ratio4_4325798_aux` (two `interval_cases <;> native_decide`
+  timeouts on the 4325798 tower).
+- **Erdos281Problem** (parse-error): **`Finset.filter` now needs `DecidablePred`** for the
+  `¬IsCoveredByFirst` predicate → added `open scoped Classical` (fixes both synth failures).
+  `Finset.filter_subset_filter` no longer matches same-set/different-predicate subset → prove the
+  subset directly (`intro m hm; simp only [Finset.mem_filter] …`). **`Finset.card_Icc` gone for ℤ**
+  → `Int.card_Icc`. Old multi-line `calc EXPR` / `≤ … := …` with a bare `_` filter predicate broke
+  the parser → rewrote as `refine le_trans (Finset.card_filter_le _ _) ?_`. **`(by omega : 0 < N)`
+  under an anonymous `0 < N →` binder failed ("no usable constraints")** → named the binder
+  `∀ hN : 0 < N` and passed `hN` (defs `HasFullCovering`, `HasUniformFiniteCoverage`; statement
+  unchanged up to binder name).
+- **Erdos471Problem** (unknown-const:Set.Finite.of_finset): `Set.Finite.of_finset` gone →
+  `Set.Finite.subset (Set.finite_Iic N)` + `exact hx.2`. **`Nat.prime_def_lt''.mpr ⟨…⟩` removed**
+  (6 sites) → `by norm_num`. `Q1_contains_19/23` membership goals were `x ∈ QSeq ulamQ₀ 0`
+  (not literal `ulamQ₀`) so `simp [ulamQ₀]` couldn't discharge → `simp [QSeq, ulamQ₀]`; rewrote both
+  as one flat anonymous constructor over `IsSumOfThreeDistinctPrimes`.
+
+## New systematic seams (rename-map candidates)
+1. **`Nat.totient_even h : Even n.totient`** (was `2 ∣ n.totient`) → `.two_dvd` to recover divisibility.
+2. **`Finset.card_Icc` unavailable for ℤ** → `Int.card_Icc` (`(Icc a b).card = (b+1-a).toNat`).
+3. **`Finset.filter_eq_empty` → `Finset.filter_eq_empty_iff`** (paralleling `filter_eq_nil_iff`).
+4. **`Nat.factorization_prime` / `Nat.factorization_prime_pow` → `Nat.Prime.factorization` /
+   `Nat.Prime.factorization_pow`** (dot-notation on the primality hyp).
+5. **`Set.Finite.of_finset` removed** → `Set.Finite.subset (Set.finite_Iic …)` for `{p | … ∧ p ≤ N}`.
+6. **`Nat.prime_def_lt''` removed** → `by norm_num` / `by decide` for concrete primes.
+7. **`rintro rfl` on `a ∈ {b}` (= `a = b`) now substitutes the RHS var `b`** — swap explicit `b` for `_`.
+8. **v4.31 `simp` closes membership/`∉ {x}` goals fully** → a trailing `; omega`/`ring` becomes
+   "No goals to be solved"; use `simp only […]` and let omega finish, or drop the trailing tactic.
+9. **Anonymous `0 < N →` Pi binders no longer feed `by omega`** in def bodies → name the binder.
+10. **`Finset.filter` requires `DecidablePred`** for non-decidable Props → `open scoped Classical`.
+
+## Statement repairs (#38611 candidates)
+- None. No unsound-original / vacuous statements found in the 4 flipped files. The `Erdos367.weakBound`
+  ε:ℕ (not ℝ) is a pre-existing semantic choice (weaker but non-vacuous; strongBound ⇒ weakBound holds),
+  left as-is; the proof was corrected to match the actual (Nat-power) statement, not weakened.
+
+## Deferred / warm leads for the next LANE-1 wave (residual Erdős < 500)
+- **Erdos358Problem** (unknown-const:two_mul_sum_Icc): STARTED then reverted — fixed forward-refs
+  (`two_mul_sum_Icc`, `odd_dvd_two_pow_eq_one`, `power_of_two_obstruction` moved up), `dvd_add hd hd`
+  for `Even`-as-`m+m`, `Nat.mul_div_cancel'`, `Finset.card_bij` needs a leading `symm` (proves
+  `s.card=t.card` with s=domain), `Nat.not_even_iff_odd`. BUT the surjective bijection block (L385-455)
+  has deep cascading breakage: `Nat.max_add_min` gone, `Nat.odd_iff_not_even`/`Nat.not_eq_zero_of_lt`
+  gone, `(¬Odd _).symm.even` is now ill-typed, `split_ifs <;> [t1; t2]` combinator syntax rejected
+  ("too many tactics"), and ~8 downstream omega/linarith failures. ~30-min file on its own.
+- **Erdos301Problem** (parse-error): `show P by tac` term syntax rejected (needs `show P from by tac`),
+  `inv_anti₀`, `div_le_div_of_nonneg_right`, `|>.elim` on an `absurd` result.
+- **Erdos86Problem**: `List.Mem.symm` invalid, a `//` set-builder parse error (L115), synth + linarith + rewrite.
+- **Erdos153Problem** (elab-drift), **Erdos201Problem** (unknown-const:isAPFree_empty, 29 err) — not yet probed.
+
+---
+
+
 
 Container `dr72` (cpus 6-11, 11g, cache v431-b), worktree doctor-b, branch
 `feature/issue-38065-inc72` off origin/feature/issue-37508. **+5 GREEN.** PR #38675.

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -1077,7 +1077,7 @@ Erdos278Problem	GREEN
 Erdos279OQ04	RESIDUAL	type-mismatch
 Erdos27Problem	RESIDUAL	rewrite-drift
 Erdos280Problem	GREEN	
-Erdos281Problem	RESIDUAL	parse-error
+Erdos281Problem	GREEN	
 Erdos283Problem	GREEN	
 Erdos284Problem	GREEN	
 Erdos285Problem	GREEN	

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -1183,7 +1183,7 @@ Erdos362Problem	RESIDUAL	type-mismatch
 Erdos363Problem	GREEN	
 Erdos364Problem	GREEN	
 Erdos365Problem	RESIDUAL	proof-drift
-Erdos367Problem	RESIDUAL	unknown-const:twoFullPart_le
+Erdos367Problem	GREEN	
 Erdos368Problem	GREEN	
 Erdos369Problem	GREEN	
 Erdos36Problem	RESIDUAL	unknown-const:white_lower

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -1299,7 +1299,7 @@ Erdos468Problem	GREEN
 Erdos469Problem	GREEN	
 Erdos46Problem	GREEN	
 Erdos470Problem	RESIDUAL	noncomputable
-Erdos471Problem	RESIDUAL	unknown-const:Set.Finite.of_finset
+Erdos471Problem	GREEN	
 Erdos472Problem	GREEN	
 Erdos473Problem	GREEN	
 Erdos474Problem	GREEN	

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -1232,7 +1232,7 @@ Erdos408Problem	GREEN
 Erdos409Problem	PRE-EXISTING	never-compiled:p
 Erdos40Problem	RESIDUAL	proof-drift
 Erdos410Problem	GREEN	
-Erdos411Problem	RESIDUAL	unknown-const:totientStep_ge
+Erdos411Problem	GREEN	
 Erdos413Problem	RESIDUAL	rewrite-drift
 Erdos414Problem	GREEN	
 Erdos415Problem	GREEN	


### PR DESCRIPTION
## Doctor increment 73 — LANE 1 (residual Erdős < 500)

Base `feature/issue-37508`. Container `lean4-arm64:v4.31.0`, cpuset 0-5, cache `lean-mathlib-cache-v431`. Each file verified `lake env lean Proofs/X.lean` EXIT=0 in-container before flipping the ledger; pushed per file.

**+4 GREEN** (RESIDUAL → GREEN):

| File | Class | Key fixes |
|------|-------|-----------|
| `Erdos367Problem` | unknown-const:twoFullPart_le | 2 forward-refs moved up; `hp.factorization` / `Nat.Prime.factorization_pow`; `filter_eq_empty_iff`; `rintro rfl` now kills `p` → use `_`; `weakBound` ε is ℕ so `pow_le_pow_right₀` not rpow |
| `Erdos411Problem` | unknown-const:totientStep_ge | 2 forward-refs moved up; `(Nat.totient_even h).two_dvd`; `conv_lhs …; rfl` (3×); `maxHeartbeats` bump on the 4325798 tower |
| `Erdos281Problem` | parse-error | `open scoped Classical` (filter decidability); direct filter-subset proof; `Int.card_Icc`; calc→`le_trans`; named `0<N` binder for `by omega` |
| `Erdos471Problem` | unknown-const:Set.Finite.of_finset | `Set.Finite.subset (Set.finite_Iic …)`; `Nat.prime_def_lt''` → `norm_num` (6×); `simp [QSeq, ulamQ₀]` membership |

### New systematic seams (rename-map candidates)
- `Nat.totient_even h : Even n.totient` (was `2 ∣ …`) → `.two_dvd`
- `Finset.card_Icc` unavailable for ℤ → `Int.card_Icc`
- `Finset.filter_eq_empty` → `Finset.filter_eq_empty_iff`
- `Nat.factorization_prime[_pow]` → `Nat.Prime.factorization[_pow]` (dot-notation)
- `Set.Finite.of_finset` removed → `Set.Finite.subset (Set.finite_Iic …)`
- `Nat.prime_def_lt''` removed → `norm_num`/`decide`
- `rintro rfl` on `a ∈ {b}` now substitutes the RHS var `b` → use `_`
- v4.31 `simp` fully closes membership goals → trailing `omega`/`ring` becomes "No goals"
- Anonymous `0 < N →` Pi binders no longer feed `by omega` in def bodies → name the binder
- `Finset.filter` on non-decidable Props needs `open scoped Classical`

### Statement repairs (#38611)
None — no unsound/vacuous statements in these 4 files. `Erdos367.weakBound` ε:ℕ is a pre-existing (non-vacuous) semantic choice; the proof was corrected to match it, not weakened.

### Warm leads for next LANE-1 wave
`Erdos358Problem` (started+reverted; forward-refs & card_bij fixed, but surjective bijection block is a ~30-min deep grind: `Nat.max_add_min`/`Nat.odd_iff_not_even`/`Nat.not_eq_zero_of_lt` gone, `(¬Odd).symm.even` ill-typed, `split_ifs <;> [t1;t2]` rejected), `Erdos301Problem` (`show P by tac`, `inv_anti₀`), `Erdos86Problem`, `Erdos153Problem`, `Erdos201Problem`.

Do NOT merge — orchestrator merges.