### PR TITLE
migrate(v4.31): Doctor increment — partition non-Erdos L-Z (+3 GREEN)

### DIFF
--- a/proofs/Proofs/LawsOfLargeNumbersOQ03.lean
+++ b/proofs/Proofs/LawsOfLargeNumbersOQ03.lean
@@ -54,7 +54,7 @@ variable {Ω : Type*} [MeasurableSpace Ω] {μ : Measure Ω}
     Mathlib's `MeasureTheory.MeasurePreserving` captures this. -/
 example (T : Ω → Ω) (hT : MeasurePreserving T μ μ) :
     ∀ (s : Set Ω), MeasurableSet s → μ (T ⁻¹' s) = μ s :=
-  fun s hs => hT.measure_preimage hs
+  fun s hs => hT.measure_preimage hs.nullMeasurableSet
 
 /-- The iterates T^n form a semigroup action on Ω. For a measure-preserving T,
     each iterate T^n is also measure-preserving. -/
@@ -64,7 +64,7 @@ theorem iterate_measure_preserving (T : Ω → Ω) (hT : MeasurePreserving T μ 
   | zero => exact MeasurePreserving.id μ
   | succ n ih =>
     rw [Function.iterate_succ']
-    exact ih.comp hT
+    exact hT.comp ih
 
 -- ============================================================
 -- PART 2: Ergodicity
@@ -77,7 +77,9 @@ theorem iterate_measure_preserving (T : Ω → Ω) (hT : MeasurePreserving T μ 
     Mathlib's `MeasureTheory.Ergodic` captures this. -/
 example (T : Ω → Ω) (hT : Ergodic T μ) :
     ∀ ⦃s : Set Ω⦄, MeasurableSet s → T ⁻¹' s = s → μ s = 0 ∨ μ s = μ Set.univ :=
-  fun s hs hinv => hT.ae_empty_or_univ hs (MeasureTheory.ae_eq_of_eq hinv)
+  fun s hs hinv => (hT.ae_empty_or_univ hs hinv).imp
+    (fun h => (measure_congr h).trans measure_empty)
+    (fun h => measure_congr h)
 
 -- ============================================================
 -- PART 3: Ergodic Averages (Birkhoff Sums)
@@ -110,7 +112,7 @@ theorem birkhoffSum_add (T : Ω → Ω) (f : Ω → ℝ) (n m : ℕ) (ω : Ω) :
   congr 1
   apply Finset.sum_congr rfl
   intro i _
-  rw [Function.iterate_add_apply]
+  rw [← Function.iterate_add_apply, Nat.add_comm]
 
 -- ============================================================
 -- PART 4: The Birkhoff Ergodic Theorem
@@ -219,7 +221,7 @@ axiom vonNeumann_mean_ergodic
     {Ω : Type*} [MeasurableSpace Ω] {μ : Measure Ω}
     [IsProbabilityMeasure μ]
     (T : Ω → Ω) (hT : MeasurePreserving T μ μ) (hTm : Measurable T)
-    (f : Ω → ℝ) (hf : Integrable f μ) (hf2 : MemLpClass 2 f μ) :
+    (f : Ω → ℝ) (hf : Integrable f μ) (hf2 : MemLp f 2 μ) :
     ∃ f_star : Ω → ℝ,
       Tendsto (fun n => ∫ ω, (birkhoffAverage T f n ω - f_star ω) ^ 2 ∂μ) atTop (nhds 0) ∧
       (∀ᵐ ω ∂μ, f_star (T ω) = f_star ω)
@@ -243,8 +245,8 @@ def IsMixing (T : Ω → Ω) (μ : Measure Ω) : Prop :=
 theorem mixing_implies_ergodic (T : Ω → Ω) (hT : MeasurePreserving T μ μ)
     (hTm : Measurable T) [IsProbabilityMeasure μ]
     (hmix : IsMixing T μ) : Ergodic T μ := by
-  refine ⟨hT, fun s hs hinv => ?_⟩
-  -- hinv : T ⁻¹' s =ᵐ[μ] s. Show μ s = 0 ∨ μ s = μ Set.univ.
+  refine ⟨hT, ⟨fun s hs hinv => ?_⟩⟩
+  -- hinv : T ⁻¹' s = s. Show s =ᵐ[μ] ∅ ∨ s =ᵐ[μ] univ.
   -- All iterates T^[n]⁻¹' s are ae-equal to s
   have haeq : ∀ n, T^[n] ⁻¹' s =ᵐ[μ] s := by
     intro n
@@ -252,27 +254,25 @@ theorem mixing_implies_ergodic (T : Ω → Ω) (hT : MeasurePreserving T μ μ)
     | zero => simp
     | succ n ih =>
       simp only [Function.iterate_succ, Function.comp_apply]
-      exact (hT.quasiMeasurePreserving.preimage_ae_eq ih).trans hinv
+      exact (hT.quasiMeasurePreserving.preimage_ae_eq ih).trans hinv.eventuallyEq
   -- μ (s ∩ T^[n]⁻¹' s) = μ s for all n
-  have hconst : ∀ n, μ (s ∩ T^[n] ⁻¹' s) = μ s := fun n =>
-    measure_congr (((ae_eq_refl s).inter (haeq n)).trans (Set.inter_self s ▸ ae_eq_refl s))
+  have hconst : ∀ n, μ (s ∩ T^[n] ⁻¹' s) = μ s := fun n => by
+    rw [measure_congr ((ae_eq_refl s).inter (haeq n)), Set.inter_self]
   -- Mixing gives limit μs * μs; constant sequence gives limit μs
   have htend_mix := hmix s s hs hs
   have htend_const : Tendsto (fun n => μ (s ∩ T^[n] ⁻¹' s)) atTop (nhds (μ s)) := by
     simp_rw [hconst]; exact tendsto_const_nhds
   have heq : μ s = μ s * μ s := tendsto_nhds_unique htend_const htend_mix
   -- μ s = 0 or μ s = 1 = μ Set.univ
+  refine eventuallyConst_set'.mpr ?_
   rcases eq_or_ne (μ s) 0 with hzero | hpos
-  · exact Or.inl hzero
+  · exact Or.inl ((ae_eq_empty (μ := μ) (s := s)).mpr hzero)
   · right
-    have hle : μ s ≤ 1 := by
-      simpa [IsProbabilityMeasure.measure_univ] using measure_mono (Set.subset_univ s)
-    have htop : μ s ≠ ∞ := (lt_of_le_of_lt hle one_lt_top).ne
-    have h1 : μ s = 1 := by
-      have := heq  -- μ s = μ s * μ s
-      rw [show μ s = μ s * 1 from (mul_one _).symm] at this
-      exact (ENNReal.mul_left_cancel₀ hpos htop this).symm
-    rw [h1, IsProbabilityMeasure.measure_univ]
+    have hle : μ s ≤ 1 := (measure_mono (Set.subset_univ s)).trans_eq measure_univ
+    have htop : μ s ≠ ⊤ := (lt_of_le_of_lt hle ENNReal.one_lt_top).ne
+    have h1 : μ s = 1 := (ENNReal.mul_eq_left hpos htop).mp heq.symm
+    exact (ae_eq_univ_iff_measure_eq hs.nullMeasurableSet).mpr
+      (by rw [h1, measure_univ])
 
 -- ============================================================
 -- PART 9: Examples of Ergodic Systems
@@ -336,7 +336,10 @@ theorem birkhoffAverage_smul (T : Ω → Ω) (f : Ω → ℝ) (c : ℝ) (n : ℕ
     birkhoffAverage T (fun ω => c * f ω) n ω =
     c * birkhoffAverage T f n ω := by
   unfold birkhoffAverage
-  simp [Finset.mul_sum, mul_comm c, mul_assoc, mul_left_comm]
+  simp only [Finset.mul_sum]
+  apply Finset.sum_congr rfl
+  intro i _
+  ring
 
 /-- For a constant function, the Birkhoff average is that constant -/
 theorem birkhoffAverage_const (T : Ω → Ω) (c : ℝ) (n : ℕ) (hn : 0 < n) (ω : Ω) :
@@ -352,7 +355,6 @@ theorem birkhoffSum_shift (T : Ω → Ω) (f : Ω → ℝ) (n : ℕ) (ω : Ω) :
   unfold birkhoffSum
   rw [Finset.sum_range_succ']
   simp [Function.iterate_succ']
-  ring
 
 -- ============================================================
 -- PART 12: Summary

--- a/proofs/Proofs/LawsOfLargeNumbersOQ03Aristotle.lean
+++ b/proofs/Proofs/LawsOfLargeNumbersOQ03Aristotle.lean
@@ -43,29 +43,28 @@ Since μ is a probability measure, μ(Set.univ) = 1, so μ(A) ∈ {0, μ Set.uni
 theorem mixing_implies_ergodic_ari {Ω : Type*} [MeasurableSpace Ω] {μ : Measure Ω}
     (T : Ω → Ω) (hT : MeasurePreserving T μ μ) (hTm : Measurable T)
     [IsProbabilityMeasure μ] (hmix : IsMixing T μ) : Ergodic T μ := by
-  refine ⟨hT, fun s hs hinv => ?_⟩
+  refine ⟨hT, ⟨fun s hs hinv => ?_⟩⟩
   have haeq : ∀ n, T^[n] ⁻¹' s =ᵐ[μ] s := by
     intro n
     induction n with
     | zero => simp
     | succ n ih =>
       simp only [Function.iterate_succ, Function.comp_apply]
-      exact (hT.quasiMeasurePreserving.preimage_ae_eq ih).trans hinv
-  have hconst : ∀ n, μ (s ∩ T^[n] ⁻¹' s) = μ s := fun n =>
-    measure_congr (((ae_eq_refl s).inter (haeq n)).trans (Set.inter_self s ▸ ae_eq_refl s))
+      exact (hT.quasiMeasurePreserving.preimage_ae_eq ih).trans hinv.eventuallyEq
+  have hconst : ∀ n, μ (s ∩ T^[n] ⁻¹' s) = μ s := fun n => by
+    rw [measure_congr ((ae_eq_refl s).inter (haeq n)), Set.inter_self]
   have htend_mix := hmix s s hs hs
   have htend_const : Tendsto (fun n => μ (s ∩ T^[n] ⁻¹' s)) atTop (nhds (μ s)) := by
     simp_rw [hconst]; exact tendsto_const_nhds
   have heq : μ s = μ s * μ s := tendsto_nhds_unique htend_const htend_mix
+  refine eventuallyConst_set'.mpr ?_
   rcases eq_or_ne (μ s) 0 with hzero | hpos
-  · exact Or.inl hzero
+  · exact Or.inl ((ae_eq_empty (μ := μ) (s := s)).mpr hzero)
   · right
-    have hle : μ s ≤ 1 := by
-      simpa [IsProbabilityMeasure.measure_univ] using measure_mono (Set.subset_univ s)
-    have htop : μ s ≠ ∞ := (lt_of_le_of_lt hle one_lt_top).ne
-    have h1 : μ s = 1 := by
-      rw [show μ s = μ s * 1 from (mul_one _).symm] at heq
-      exact (ENNReal.mul_left_cancel₀ hpos htop heq).symm
-    rw [h1, IsProbabilityMeasure.measure_univ]
+    have hle : μ s ≤ 1 := (measure_mono (Set.subset_univ s)).trans_eq measure_univ
+    have htop : μ s ≠ ⊤ := (lt_of_le_of_lt hle ENNReal.one_lt_top).ne
+    have h1 : μ s = 1 := (ENNReal.mul_eq_left hpos htop).mp heq.symm
+    exact (ae_eq_univ_iff_measure_eq hs.nullMeasurableSet).mpr
+      (by rw [h1, measure_univ])
 
 end LawsOfLargeNumbersOQ03Aristotle

--- a/proofs/Proofs/PartitionTheoremOQ03.lean
+++ b/proofs/Proofs/PartitionTheoremOQ03.lean
@@ -23,8 +23,8 @@ namespace OverpartitionTheory
 
 /-- Euler's partition identity: partitions into odd parts = partitions into distinct parts. -/
 theorem euler_partition_identity (n : ℕ) :
-    Nat.Partition.IsOdd.card n = Nat.Partition.IsDistinct.card n :=
-  (Theorems100.partition n).symm
+    (Nat.Partition.odds n).card = (Nat.Partition.distincts n).card :=
+  Nat.Partition.card_odds_eq_card_distincts n
 
 /-! ## Part II: Overpartition Definitions -/
 
@@ -44,12 +44,12 @@ axiom numOverpartitions : ℕ → ℕ
 
 /-  Small values: p̄(0) = 1 (empty partition, no parts to overline). -/
 /-  p̄(1) = 2 (partitions: {1}; overlined choices: ∅ or {1}). -/
-/-- p̄(2) = 4 (partitions: {2}, {1,1}; overlined: 2 + 2 = 4). -/
+/-  p̄(2) = 4 (partitions: {2}, {1,1}; overlined: 2 + 2 = 4). -/
 /-! ## Part III: Key Properties -/
 
 /-- Every distinct partition is an overpartition (with empty overline set). -/
 def distinctToOverpartition (n : ℕ) (p : Nat.Partition n)
-    (_h : p.parts.toFinset.card = p.parts.length) :
+    (_h : p.parts.toFinset.card = p.parts.card) :
     Overpartition n :=
   ⟨p, ∅, Finset.empty_subset _⟩
 

--- a/proofs/batch2/STATUS.md
+++ b/proofs/batch2/STATUS.md
@@ -1,3 +1,74 @@
+# DOCTOR INCREMENT 76 (deep-rework partition: non-Erdos L–Z, #38065, 2026-07-15)
+
+Container cpuset 18-23, 11g, cache `lean-mathlib-cache-v431-d`, worktree doctor-d, branch
+`feature/issue-38065-inc76` off origin/feature/issue-37508. **+3 GREEN.** PR pending.
+Every flip verified in-container `lake env lean Proofs.X` exit-0 before ledger flip; pushed per file.
+
+## Flips (failure class in parens)
+- **LawsOfLargeNumbersOQ03** (unknown-const → **Ergodic/PreErgodic API reshape**): the ledger
+  class undercounted (8 distinct errors). Big seam: **`PreErgodic` field is now
+  `aeconst_set : MeasurableSet s → f⁻¹'s = s → EventuallyConst s (ae μ)`** (was the
+  `μ s = 0 ∨ μ s = μ univ` disjunction taking an *ae-eq* preimage). To CONSTRUCT `Ergodic`
+  from the mixing argument: `refine ⟨hT, ⟨fun s hs hinv => ?_⟩⟩` (extra `⟨⟩` for the PreErgodic
+  wrapper), then `refine eventuallyConst_set'.mpr ?_` and produce the disjunction
+  `s =ᵐ[μ] ∅ ∨ s =ᵐ[μ] univ`. `hinv : f⁻¹'s = s` is now STRICT eq → lift to ae with
+  `hinv.eventuallyEq` (`Eq.eventuallyEq`). Other sites in same file:
+  `MeasureTheory.ae_eq_of_eq h`→`h.eventuallyEq`; `measure_preimage hs`→`hs.nullMeasurableSet`;
+  `MeasurePreserving.comp` arg order flipped (`ih.comp hT`→`hT.comp ih` under `iterate_succ'`);
+  `MemLpClass p f μ`→`MemLp f p μ`; `∞` token→`⊤`; `one_lt_top`→`ENNReal.one_lt_top`;
+  `ENNReal.mul_left_cancel₀` GONE → `(ENNReal.mul_eq_left ha0 hatop).mp` (`a*b=a ↔ b=1`);
+  `ae_eq_empty.mpr` needs explicit `(μ := …) (s := …)` (else `OuterMeasureClass` metavar stuck);
+  `s =ᵐ univ` from `μ s = μ univ` via `(ae_eq_univ_iff_measure_eq hs.nullMeasurableSet).mpr`;
+  `IsProbabilityMeasure.measure_univ` as a simp/rw arg leaves μ meta → use bare `measure_univ`
+  (`(measure_mono …).trans_eq measure_univ`). A dangling `ring` after `simp` closed the goal →
+  drop it ("No goals").
+- **LawsOfLargeNumbersOQ03Aristotle** (same reshape): companion `mixing_implies_ergodic_ari` is
+  a near-clone of OQ03's proof; applied the identical PreErgodic/EventuallyConst rework verbatim.
+  (Was blocked behind OQ03's missing olean; `lake build` in-container seeds the dep olean.)
+- **PartitionTheoremOQ03** (unknown-const → **Euler-partition Archive→mainline**):
+  `Nat.Partition.IsOdd.card`/`IsDistinct.card` + `Theorems100.partition` (Archive, unreachable via
+  `import Mathlib`) → mainline `Nat.Partition.card_odds_eq_card_distincts n : #(odds n) = #(distincts n)`
+  with `Nat.Partition.odds`/`distincts : Finset n.Partition`; drop the `.symm`. Also
+  `Nat.Partition.parts` is a **`Multiset ℕ`** → `.length`→`.card`; an orphan `/-- … -/` doc before a
+  `/-!` section broke parsing → make it a plain `/- … -/` comment.
+
+## New systematic seams (rename-map candidates)
+1. **`PreErgodic`/`Ergodic` reshape:** field `aeconst_set … : EventuallyConst s (ae μ)` (strict
+   preimage eq in, `EventuallyConst` out). Build via `⟨hT, ⟨fun s hs hinv => ?_⟩⟩` +
+   `eventuallyConst_set'.mpr` on the `s =ᵐ ∅ ∨ s =ᵐ univ` disjunction; strict `hinv` → `.eventuallyEq`.
+2. **`ENNReal.mul_left_cancel₀` GONE** → `ENNReal.mul_eq_left (a≠0)(a≠⊤) : a*b=a ↔ b=1`.
+   **`one_lt_top`→`ENNReal.one_lt_top`; `∞` literal→`⊤`.**
+3. **`MemLpClass p f μ`→`MemLp f p μ`** (arg order swap, drops the "Class").
+4. **`ae_eq_empty` / `ae_empty_or_univ` measure metavar:** pass `(μ := …)(s := …)` explicitly;
+   `IsProbabilityMeasure.measure_univ` as simp/rw arg leaves μ unsolved → use bare `measure_univ`.
+5. **Euler partition Archive→mainline** (see inc52 §7af too): `card_odds_eq_card_distincts`,
+   `odds`/`distincts`; `Nat.Partition.parts : Multiset ℕ` (`.length`→`.card`).
+6. **`EuclideanSpace.inner_apply`→`PiLp.inner_apply`** (confirmed; but Vec2 files also hit the
+   `WithLp`/`.ofLp` element-application reshape — see leads).
+7. **`Sylow` cluster:** `card_sylow_dvd_index P`→`P.card_dvd_index` (namespaced `Sylow.card_dvd_index`).
+
+## Deferred / warm leads (non-Erdos L–Z partition, triaged with diagnoses)
+- **LawsOfLargeNumbersOQ02** (4 err): `IndepFun.variance_sum` gives `Var[∑ i, X i]` but goal is
+  `Var[fun ω => ∑ i, X i ω]` → bridge with `Finset.sum_apply`/funext; `IsOrderedRing ?m` stuck at
+  L195 (add type annotation); `fun n => σ_sq/ε^2/n` typed ℝ→ℝ but wants ℕ→ℝ → `(n : ℝ)` cast (L325);
+  a "No goals" trailing tactic (L137). `integral_finset_sum`→`integral_finsetSum` (deprecation).
+- **QuadraticReciprocityOQ03** (9 err; HUB → unblocks OQ03OQ01 + OQ03OQ01Exp): 7× `Fact (Nat.Prime k)`
+  synth failures on `example : legendreSym k a = … := by decide` — add `haveI : Fact (Nat.Prime k) :=
+  ⟨by norm_num⟩`; `map_mul (legendreSym p)` FunLike-fail → use `legendreSym.mul`; **statement drift**
+  `legendreSym.at_neg_one hp` now `= χ₄ ↑p` (was `(-1)^(p/2)`) → bridge via `ZMod.χ₄_eq_neg_one_pow`
+  with the p-odd hyp.
+- **RationalCanonicalFormExists** (13 err; HUB → unblocks MinpolyCharpolyOQ03 → OQ03OQ01): type-mismatch +
+  instance-synth cluster. **LawsOfLargeNumbersOQ01Aristotle** (20 err; HUB → unblocks OQ01OQ01, OQ01OQ03).
+- **NewtonIndStep2** (3 err): `linarith` fails + 2 heartbeat timeouts (v4.31 linarith slower/needs new
+  nlinarith hints; try `set_option maxHeartbeats` + hint tuning).
+- **LawOfSinesOQ06** (multi-cluster): `EuclideanSpace.inner_apply`→`PiLp.inner_apply` is right but the
+  `Vec2 = EuclideanSpace ℝ (Fin 2)` arithmetic hit the **`WithLp`/`.ofLp` reshape** — `u 0` element
+  application and `B - A` in a structure field are stuck; needs `.ofLp` threading + real-inner simp.
+- **TestApi203**: OOM-killed (137) at 11g — memory-heavy (likely native_decide); needs a real argument
+  or a bigger cap.
+
+---
+
 # DOCTOR INCREMENT 72 (deep-rework partition A: A–M + Erdos < 600, #38065, 2026-07-15)
 
 Container `dr72` (cpus 6-11, 11g, cache v431-b), worktree doctor-b, branch

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -2223,7 +2223,7 @@ LawsOfLargeNumbersOQ01OQ02OQ01	RESIDUAL	type-mismatch
 LawsOfLargeNumbersOQ01OQ03	RESIDUAL	signature-drift
 LawsOfLargeNumbersOQ02	RESIDUAL	type-mismatch
 LawsOfLargeNumbersOQ03	GREEN	
-LawsOfLargeNumbersOQ03Aristotle	RESIDUAL	unknown-const:MeasureTheory.ae_eq_of_eq
+LawsOfLargeNumbersOQ03Aristotle	GREEN	
 LebesgueMeasure	GREEN	
 LebesgueMeasureOQ01	GREEN	
 LebesgueMeasureOQ01OQ01	RESIDUAL	type-mismatch

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -2222,7 +2222,7 @@ LawsOfLargeNumbersOQ01OQ02	GREEN
 LawsOfLargeNumbersOQ01OQ02OQ01	RESIDUAL	type-mismatch
 LawsOfLargeNumbersOQ01OQ03	RESIDUAL	signature-drift
 LawsOfLargeNumbersOQ02	RESIDUAL	type-mismatch
-LawsOfLargeNumbersOQ03	RESIDUAL	unknown-const:MeasureTheory.ae_eq_of_eq
+LawsOfLargeNumbersOQ03	GREEN	
 LawsOfLargeNumbersOQ03Aristotle	RESIDUAL	unknown-const:MeasureTheory.ae_eq_of_eq
 LebesgueMeasure	GREEN	
 LebesgueMeasureOQ01	GREEN	

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -2295,7 +2295,7 @@ PappusTheoremOQ02	GREEN
 PartitionTheorem	GREEN	
 PartitionTheoremOQ01	RESIDUAL	unknown-const:Finset.mem_empty
 PartitionTheoremOQ01OQ01	RESIDUAL	unknown-const:Finset.mem_empty
-PartitionTheoremOQ03	RESIDUAL	unknown-const:Nat.Partition.IsOdd.card
+PartitionTheoremOQ03	GREEN	
 PartitionTheoremOQ04	GREEN	
 PartitionTheoremOQ04Aristotle	GREEN	
 PascalsHexagon	GREEN	


### PR DESCRIPTION
## Doctor migration increment (epic #37508, Lean v4.26.0 → v4.31.0)

Lane: **non-Erdős-numbered, name sorts L–Z** (cpuset 18-23, cache `lean-mathlib-cache-v431-d`,
worktree doctor-d). Each file verified in-container (`lake env lean Proofs/X.lean`, EXIT=0)
before flipping its ledger row; pushed per file.

### Files flipped RESIDUAL → GREEN (+3)
- **LawsOfLargeNumbersOQ03** — unknown-const → full **Ergodic/PreErgodic API reshape** (8 real errors).
- **LawsOfLargeNumbersOQ03Aristotle** — same reshape (companion clone of the mixing proof).
- **PartitionTheoremOQ03** — unknown-const → **Euler-partition Archive→mainline** rename.

### New systematic seams (rename-map candidates)
- **`PreErgodic`/`Ergodic` reshape:** field is now `aeconst_set : MeasurableSet s → f⁻¹'s = s →
  EventuallyConst s (ae μ)` (strict preimage eq in, `EventuallyConst` out, was the
  `μ s = 0 ∨ μ s = μ univ` disjunction on an ae-eq preimage). Build via `⟨hT, ⟨fun s hs hinv => ?_⟩⟩`
  + `eventuallyConst_set'.mpr` on `s =ᵐ ∅ ∨ s =ᵐ univ`; lift strict `hinv` with `.eventuallyEq`.
- `ENNReal.mul_left_cancel₀` GONE → `ENNReal.mul_eq_left (a≠0)(a≠⊤) : a*b=a ↔ b=1`;
  `one_lt_top`→`ENNReal.one_lt_top`; `∞` literal→`⊤`.
- `MemLpClass p f μ`→`MemLp f p μ`; `MeasureTheory.ae_eq_of_eq h`→`h.eventuallyEq`;
  `measure_preimage hs`→`hs.nullMeasurableSet`.
- `ae_eq_empty`/`ae_empty_or_univ` need explicit `(μ := …)(s := …)` (else `OuterMeasureClass`
  metavar stuck); `IsProbabilityMeasure.measure_univ` as simp/rw arg leaves μ meta → use bare
  `measure_univ`.
- Euler partition Archive→mainline: `Theorems100.partition`/`Nat.Partition.IsOdd.card` →
  `Nat.Partition.card_odds_eq_card_distincts n` with `odds`/`distincts : Finset n.Partition`;
  `Nat.Partition.parts : Multiset ℕ` (`.length`→`.card`).
- `EuclideanSpace.inner_apply`→`PiLp.inner_apply`; `card_sylow_dvd_index P`→`P.card_dvd_index`.

### Statement repairs (#38611)
None — no unsound-original files touched. All fixes are pure v4.31 surface-drift respellings of
proofs that were genuinely GREEN on the old toolchain.

### Warm leads for the next wave (diagnosed in STATUS.md)
- **QuadraticReciprocityOQ03** (HUB → OQ03OQ01 + OQ03OQ01Exp): 7× `Fact (Nat.Prime k)` synth +
  `legendreSym.at_neg_one` statement drift (`χ₄ ↑p`).
- **RationalCanonicalFormExists** (HUB → MinpolyCharpolyOQ03 → OQ03OQ01), **LawsOfLargeNumbersOQ01Aristotle**
  (HUB → OQ01OQ01, OQ01OQ03) — deeper (13 / 20 errors).
- **LawsOfLargeNumbersOQ02** (4 err), **NewtonIndStep2** (linarith/heartbeat), **LawOfSinesOQ06**
  (`WithLp`/`.ofLp` Vec2 reshape), **TestApi203** (OOM at 11g).

Do NOT merge — orchestrator merges. No loom labels.