### PR TITLE
migrate(v4.31): Doctor increment — partition non-Erdos A-K (+3 GREEN)

### DIFF
--- a/proofs/Proofs/ArithmeticSeriesOQ02OQ02OQ03.lean
+++ b/proofs/Proofs/ArithmeticSeriesOQ02OQ02OQ03.lean
@@ -73,7 +73,7 @@ def negBin (k : ℕ) : PowerSeries ℕ := geom ^ (k + 1)
 -- ============================================================
 
 /-- The geometric series has all coefficients equal to 1. -/
-theorem coeff_geom (n : ℕ) : PowerSeries.coeff ℕ n geom = 1 := by
+theorem coeff_geom (n : ℕ) : PowerSeries.coeff n geom = 1 := by
   simp [geom, PowerSeries.coeff_mk]
 
 /-- The n-th coefficient of negBin(k) is the simplicial number C(n+k, k).
@@ -82,7 +82,7 @@ theorem coeff_geom (n : ℕ) : PowerSeries.coeff ℕ n geom = 1 := by
     - Step: g^{k+2} = g^{k+1} · g, Cauchy product gives
       Σ C(i+k,k) = C(n+k+1,k+1) by the hockey stick -/
 theorem coeff_negBin (k n : ℕ) :
-    PowerSeries.coeff ℕ n (negBin k) = simplicial k n := by
+    PowerSeries.coeff n (negBin k) = simplicial k n := by
   induction k generalizing n with
   | zero =>
     simp [negBin, pow_one, coeff_geom, simplicial, Nat.choose_zero_right]
@@ -90,16 +90,17 @@ theorem coeff_negBin (k n : ℕ) :
     -- negBin (k+1) = geom * negBin k
     have hprod : negBin (k + 1) = geom * negBin k := by
       simp only [negBin, pow_succ']
-    rw [hprod, map_mul, Finsupp.sum]
+    rw [hprod]
     -- Cauchy product: Σ coeff_i(geom) · coeff_j(negBin k) over antidiagonal
     simp only [PowerSeries.coeff_mul]
     -- Simplify using known coefficients
     conv_lhs =>
       arg 2; ext p; rw [coeff_geom, ih, one_mul]
     -- Convert antidiagonal sum to range sum
-    rw [Finset.Nat.sum_antidiagonal_eq_sum_range_succ (fun i _ => simplicial k i)]
-    -- This is the hockey stick identity
-    exact hockey_stick k n
+    rw [Finset.Nat.sum_antidiagonal_eq_sum_range_succ (fun _ j => simplicial k j),
+        ← hockey_stick k n]
+    -- Reindex the range (reflection) to match the hockey-stick sum
+    exact Finset.sum_range_reflect (fun i => simplicial k i) (n + 1)
 
 -- ============================================================
 -- Part III: The Algebraic Product Formula
@@ -136,19 +137,19 @@ theorem negBin_mul (a b : ℕ) :
     This is the generating function proof the open question requested:
     the algebraic identity pow_add does all the combinatorial work. -/
 theorem parallel_vandermonde_gf (a b n : ℕ) :
-    ∑ p ∈ Finset.Nat.antidiagonal n, simplicial a p.1 * simplicial b p.2 =
+    ∑ p ∈ Finset.antidiagonal n, simplicial a p.1 * simplicial b p.2 =
     simplicial (a + b + 1) n := by
   -- Step 1: LHS = n-th coefficient of negBin(a) · negBin(b)
-  have lhs_eq : ∑ p ∈ Finset.Nat.antidiagonal n,
+  have lhs_eq : ∑ p ∈ Finset.antidiagonal n,
       simplicial a p.1 * simplicial b p.2 =
-      PowerSeries.coeff ℕ n (negBin a * negBin b) := by
+      PowerSeries.coeff n (negBin a * negBin b) := by
     rw [PowerSeries.coeff_mul]
     apply sum_congr rfl
     intro p _
     rw [coeff_negBin, coeff_negBin]
   -- Step 2: RHS = n-th coefficient of negBin(a+b+1)
   have rhs_eq : simplicial (a + b + 1) n =
-      PowerSeries.coeff ℕ n (negBin (a + b + 1)) := by
+      PowerSeries.coeff n (negBin (a + b + 1)) := by
     rw [coeff_negBin]
   -- Step 3: Connect via negBin_mul
   rw [lhs_eq, rhs_eq, negBin_mul]
@@ -175,7 +176,7 @@ theorem check_gf_a1b1n3 : simplicial 3 3 = 20 := by native_decide
 
 /-- The antidiagonal sum: (1·4) + (2·3) + (3·2) + (4·1) = 4+6+6+4 = 20. -/
 theorem check_gf_convolution :
-    ∑ p ∈ Finset.Nat.antidiagonal 3,
+    ∑ p ∈ Finset.antidiagonal 3,
       simplicial 1 p.1 * simplicial 1 p.2 = 20 := by native_decide
 
 end

--- a/proofs/Proofs/FourColorTheoremOQ01.lean
+++ b/proofs/Proofs/FourColorTheoremOQ01.lean
@@ -104,7 +104,7 @@ theorem free_color_of_degree_lt (G : SimpleGraph V) [DecidableRel G.Adj]
     intro heq
     rw [heq, Finset.card_univ] at hcard
     exact Nat.lt_irrefl _ hcard
-  rw [Finset.ne_univ_iff_exists_notMem] at hne
+  rw [Ne, Finset.eq_univ_iff_forall, not_forall] at hne
   exact hne
 
 -- ============================================================
@@ -218,7 +218,7 @@ theorem chain_interference_obstruction
     w_color_after ≠ c₂ ∧ w_color_after ≠ c₃ := by
   subst hw; subst hswap
   simp [Equiv.swap_apply_right]
-  exact ⟨h12.symm, h13.symm⟩
+  exact ⟨h12, h13⟩
 
 -- ============================================================
 -- PART 7: The Contrast — 5-Color Avoids Interference
@@ -377,7 +377,9 @@ theorem min_counterexample_degree (d : ℕ) (hd : d ≤ 3) (k : ℕ) (hk : k = 4
     And some vertex has degree exactly 4 or 5 (since average degree < 6). -/
 theorem min_counterexample_has_low_degree
     (avgDeg : ℕ) (havg : avgDeg ≤ 5)
-    (minDeg : ℕ) (hmin : minDeg ≥ 4) :
+    (minDeg : ℕ) (hmin : minDeg ≥ 4)
+    -- The minimum degree never exceeds the average degree.
+    (hle : minDeg ≤ avgDeg) :
     -- Some vertex has degree 4 or 5
     minDeg = 4 ∨ minDeg = 5 := by
   omega

--- a/proofs/Proofs/HierholzerAlgorithm.lean
+++ b/proofs/Proofs/HierholzerAlgorithm.lean
@@ -166,7 +166,8 @@ lemma degree_eq_deleteEdges_add (v : V)
     ext w
     simp [mem_neighborFinset, deleteEdges_adj]
   simp only [SimpleGraph.degree, h1]
-  exact (Finset.filter_card_add_filter_neg_card_eq_card (fun w => s(v, w) ∈ S)).symm
+  rw [add_comm]
+  exact (Finset.card_filter_add_card_filter_not (fun w => s(v, w) ∈ S)).symm
 
 /-- The number of deleted neighbors of v (neighbors w such that s(v,w) is in the
     trail's edge set) equals the countP of trail edges incident to v.
@@ -186,7 +187,7 @@ lemma deleted_neighbors_eq_countP
       p.edges.countP (fun e => v ∈ e) := by
   have hnodup := hp.edges_nodup
   -- countP on a list = length of filter
-  rw [← List.countP_eq_length_filter]
+  rw [List.countP_eq_length_filter]
   -- For a nodup list, (l.filter p).length = (l.toFinset.filter p).card
   rw [show (p.edges.filter (fun e => v ∈ e)).length =
       (p.edges.toFinset.filter (fun e => v ∈ e)).card from by
@@ -197,29 +198,29 @@ lemma deleted_neighbors_eq_countP
   apply Finset.card_nbij (fun x => s(v, x))
   · -- MapsTo: if x is a neighbor with s(v,x) in trail, then s(v,x) ∈ trail.filter(v ∈ ·)
     intro x hx
-    simp only [Finset.mem_filter, Set.mem_coe, List.mem_toFinset] at hx ⊢
+    simp only [Finset.mem_filter, Finset.mem_coe, List.mem_toFinset] at hx ⊢
     exact ⟨hx.2, Sym2.mem_mk_left v x⟩
   · -- Injective: s(v,x₁) = s(v,x₂) implies x₁ = x₂ (using looplessness of G)
     intro x₁ hx₁ x₂ _ heq
-    simp only [Finset.mem_filter, mem_neighborFinset] at hx₁
-    rcases Sym2.eq_iff.mp heq with ⟨_, h⟩ | ⟨h₁, _⟩
+    simp only [Finset.mem_coe, Finset.mem_filter, mem_neighborFinset] at hx₁
+    rcases Sym2.eq_iff.mp heq with ⟨_, h⟩ | ⟨_, h₂⟩
     · exact h
-    · rw [h₁] at hx₁; exact absurd rfl (G.ne_of_adj hx₁.1)
+    · rw [h₂] at hx₁; exact absurd rfl (G.ne_of_adj hx₁.1)
   · -- Surjective: every e ∈ trail.toFinset with v ∈ e has form s(v,x) for neighbor x
     intro e he
-    simp only [Finset.mem_filter, List.mem_toFinset] at he
+    simp only [Finset.mem_coe, Finset.mem_filter, List.mem_toFinset] at he
     obtain ⟨hmem, hv⟩ := he
     have hedge : e ∈ G.edgeSet := p.edges_subset_edgeSet hmem
     revert hv hedge hmem
     refine Sym2.ind (fun a b => ?_) e
-    intro hmem hedge hv
+    intro hmem hv hedge
     rw [mem_edgeSet] at hedge
     rw [Sym2.mem_iff] at hv
     rcases hv with rfl | rfl
     · exact ⟨b, by simp [Finset.mem_filter, mem_neighborFinset, hedge,
-        Set.mem_coe, List.mem_toFinset, hmem], rfl⟩
+        Finset.mem_coe, List.mem_toFinset, hmem], rfl⟩
     · refine ⟨a, ?_, Sym2.eq_swap⟩
-      simp only [Finset.mem_filter, mem_neighborFinset, Set.mem_coe, List.mem_toFinset]
+      simp only [Finset.mem_filter, mem_neighborFinset, Finset.mem_coe, List.mem_toFinset]
       exact ⟨hedge.symm, by rwa [show s(v, a) = s(a, v) from Sym2.eq_swap]⟩
 
 /-- **Circuit Removal Preserves Even Degrees** (PROVED):

--- a/proofs/batch2/STATUS.md
+++ b/proofs/batch2/STATUS.md
@@ -1,4 +1,80 @@
-# DOCTOR INCREMENT 72 (deep-rework partition A: A–M + Erdos < 600, #38065, 2026-07-15)
+# DOCTOR INCREMENT 75 (deep-rework partition non-Erdos A–K / lane3, #38065, 2026-07-15)
+
+Container cpuset 12-17, 11g, cache `lean-mathlib-cache-v431-c`, worktree doctor-c, branch
+`feature/issue-38065-inc75` off origin/feature/issue-37508. **+3 GREEN.**
+Every flip verified in-container `lake env lean Proofs.X` exit-0 before ledger flip; pushed per file.
+
+## Flips (failure class in parens)
+- **ArithmeticSeriesOQ02OQ02OQ03** (unknown-const): **`PowerSeries.coeff` dropped its ring
+  argument** — now `PowerSeries.coeff (n : ℕ) : R⟦X⟧ →ₗ[R] R` with `R` implicit, so
+  `PowerSeries.coeff ℕ n f` → `PowerSeries.coeff n f` (RingTheory/PowerSeries/Basic.lean:78).
+  **`Finset.Nat.antidiagonal` def is gone** → unqualified `Finset.antidiagonal` (the
+  `HasAntidiagonal` one); BUT the SUM lemma **`Finset.Nat.sum_antidiagonal_eq_sum_range_succ`
+  still exists** (namespace `Finset.Nat`, Algebra/BigOperators/NatAntidiagonal.lean) — do NOT
+  rename it to `Nat.…`. `coeff_mul` now sums the negBin-coeff over `p.2`, so the hockey-stick
+  reindex needed `(fun _ j => …)` + a `Finset.sum_range_reflect` term (via `← hockey_stick`,
+  `exact` for the `n+1-1` vs `n` defeq the `rw` couldn't see). Also dropped a stale
+  `map_mul, Finsupp.sum` from the `rw` (coeff is linear, not a ring hom).
+- **HierholzerAlgorithm** (type-mismatch): **`Finset.filter_card_add_filter_neg_card_eq_card`
+  → `Finset.card_filter_add_card_filter_not (p)`** (only takes the predicate; s implicit) and it
+  yields `{∈}+{∉}` so the goal (stated `{∉}+{∈}`) needs a `rw [add_comm]` first.
+  **`List.countP_eq_length_filter` arrow flipped** (now `countP p l = (l.filter p).length`) →
+  use forward, not `←`. **`Set.mem_coe` removed → `Finset.mem_coe`** (a ∈ ↑s ↔ a ∈ s;
+  Finset/Defs.lean:126). `Finset.card_nbij` delivers the MapsTo/inj/surj membership hyps in
+  `↑`-coe form, so their `simp only [mem_filter]` sets need `Finset.mem_coe` prepended.
+  Two goal-state repairs unmasked afterwards: the Sym2 injective impossible-branch must rewrite
+  the `x₁ = v` component (not `v = x₂`) to expose the self-loop; and the surjective branch's
+  `revert…; Sym2.ind; intro` reintro order is now `hmem hv hedge` (hedge/hv swapped).
+- **FourColorTheoremOQ01** (unknown-const + **statement repair**): **`Finset.ne_univ_iff_exists_notMem`
+  removed** → derive via `rw [Ne, Finset.eq_univ_iff_forall, not_forall]`. `Ne.symm h12` no longer
+  matched the post-`simp` goal `c₁ ≠ c₂` → use `h12`/`h13` directly. **STATEMENT REPAIR (#38611
+  candidate):** `min_counterexample_has_low_degree` was FALSE as stated —
+  `avgDeg ≤ 5, minDeg ≥ 4 ⊢ minDeg ∈ {4,5}` fails for minDeg=6, avgDeg=3; it silently relied on
+  the unstated fact `minDeg ≤ avgDeg` (min degree ≤ average degree). Added that hypothesis
+  (`hle : minDeg ≤ avgDeg`); no callers, illustrative lemma. omega then closes it.
+
+## New systematic seams (rename-map candidates)
+1. **`PowerSeries.coeff (n : ℕ) : R⟦X⟧ →ₗ[R] R`** — ring arg now IMPLICIT (drop the `ℂ`/`ℕ`/`R`
+   first arg at every call site). Same for `PowerSeries.coeff_mk`.
+2. **`Finset.Nat.antidiagonal` def → `Finset.antidiagonal`** (HasAntidiagonal); but the
+   `Finset.Nat.sum_antidiagonal_eq_sum_range_succ(_mk)` lemmas KEEP the `Finset.Nat.` namespace.
+3. **`List.countP_eq_length_filter` direction flipped** to `countP = (filter).length` (v4.31).
+4. **`Finset.filter_card_add_filter_neg_card_eq_card` → `Finset.card_filter_add_card_filter_not`**
+   (deprecated alias still exists; new one takes only `p`, gives `{p}+{¬p}` — mind the order).
+5. **`Set.mem_coe` removed → `Finset.mem_coe`.**
+6. **`Finset.ne_univ_iff_exists_notMem` removed** → `Ne, Finset.eq_univ_iff_forall, not_forall`.
+7. **`expSeries_div_hasSum_exp` / `NormedSpace.exp` dropped their field (`𝕂`) argument** — now
+   `expSeries_div_hasSum_exp (x)` and `NormedSpace.exp x`; `Complex.exp_eq_exp_ℂ : Complex.exp =
+   NormedSpace.exp` (was `= NormedSpace.exp ℂ ℂ`). (Seen in EulerIdentityOQ01OQ02OQ01 — deferred.)
+
+## Statement repairs (for #38611, gallery-meta re-audit)
+- **FourColorTheoremOQ01** `min_counterexample_has_low_degree` — added missing `minDeg ≤ avgDeg`
+  hypothesis (was false as stated). FLIPPED green.
+- **CevasTheoremOQ01OQ03** (DEFERRED, cannot fix in-partition): the imported `routhRatio` (defined
+  in parent `CevasTheoremOQ01`, OUTSIDE lane3) has buggy denominators
+  `(1-d+de)(1-e+ef)(1-f+fd)` that do NOT match this file's geometry denominators
+  `(1-e+de)(1-f+ef)(1-d+fd)`. Consequently `routh_theorem_std` (signedArea(P,Q,R) = routhRatio·1)
+  is FALSE for asymmetric params: at (d,e,f)=(1/2,1/3,1/4) the true signedArea is **1/10** but
+  routhRatio computes **25/252**. The parent's only test (`routh_medial_thirds`, d=e=f=1/3) masks
+  the bug because the two denominator sets coincide when d=e=f. The child's own docstring documents
+  the intended denominators as the geometry ones (`w₁=1-e+de`, …), confirming the parent def is the
+  bug. **Fix belongs in the parent `CevasTheoremOQ01.routhRatio` (another lane's partition).**
+
+## Good next leads (lane3 partition)
+- **Parent-olean masking:** several `type-mismatch` rows (e.g. BinomialTheoremOQ02OQ01OQ01OQ02)
+  first show only a single `object file …olean does not exist` for a GREEN parent that isn't in
+  the shared cache. I built `Proofs.BinomialTheoremOQ02OQ01.olean` into cache-v431-c
+  (`lake env lean -o …olean`) — its children now show their REAL drift (8 sites for that one).
+  Building green parents' oleans first will unmask/prep the Binomial + other OQ-chain clusters.
+- **EulerIdentityOQ01OQ02OQ01** (deferred): after the `expSeries_div_hasSum_exp`/`NormedSpace.exp`
+  field-arg drop (seam #7), the remaining blocker is that `dsimp [Function.comp_def]` no longer
+  reduces `(Nat.divModEquiv 2).symm x`, so the even/odd fiber regroup (`prod_fiberwise` +
+  `convert hasSum_fintype`) drifts. Needs the right divModEquiv reduction lemma.
+- **CartesianClosed refactor** (CantorDiagonalizationOQ04OQ01OQ01 etc.): `[CartesianClosed C]`
+  "type is not a class instance" — deep category-theory monoidal refactor, defer.
+- AbelRuffini cluster (OQ04/OQ06) is genuine multi-site type-mismatch (~8 sites each), grind later.
+
+
 
 Container `dr72` (cpus 6-11, 11g, cache v431-b), worktree doctor-b, branch
 `feature/issue-38065-inc72` off origin/feature/issue-37508. **+5 GREEN.** PR #38675.

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -2081,7 +2081,7 @@ HermiteLindemann	GREEN
 HermiteSawtoothIdentity	GREEN	
 HermiteSawtoothIdentityOQ02	GREEN	
 HeronsFormulaOQ01	GREEN	
-HierholzerAlgorithm	RESIDUAL	type-mismatch
+HierholzerAlgorithm	GREEN	
 Hilbert11OQ01Aristotle	GREEN	
 Hilbert11_QuadraticFormsAristotle	GREEN	
 Hilbert14Invariants	GREEN	

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -1982,7 +1982,7 @@ FibonacciIdentitiesOQ02	GREEN
 FibonacciIdentitiesOQ02OQ02PrimeIndex	GREEN	
 FiveColorTheorem	GREEN	
 FourColorTheorem	GREEN	
-FourColorTheoremOQ01	RESIDUAL	unknown-const:Finset.ne_univ_iff_exists_notMem
+FourColorTheoremOQ01	GREEN	Finset.ne_univ_iff_exists_notMem
 FourColorTheoremOQ02	GREEN	
 FourSquareDistributionOQ01	GREEN	
 FourSquareDistributionOQ04Arrange	GREEN	

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -1982,7 +1982,7 @@ FibonacciIdentitiesOQ02	GREEN
 FibonacciIdentitiesOQ02OQ02PrimeIndex	GREEN	
 FiveColorTheorem	GREEN	
 FourColorTheorem	GREEN	
-FourColorTheoremOQ01	GREEN	Finset.ne_univ_iff_exists_notMem
+FourColorTheoremOQ01	GREEN	
 FourColorTheoremOQ02	GREEN	
 FourSquareDistributionOQ01	GREEN	
 FourSquareDistributionOQ04Arrange	GREEN	

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -143,7 +143,7 @@ AreaOfCircleOQ07OQ05OQ01OQ02	GREEN
 AreaOfCircleOQ07OQ05OQ02	GREEN	
 ArithmeticSeriesOQ00OQ02	GREEN	
 ArithmeticSeriesOQ00OQ02OQ01	GREEN	instance-synth
-ArithmeticSeriesOQ02OQ02OQ03	RESIDUAL	unknown-const:Finset.Nat.antidiagonal
+ArithmeticSeriesOQ02OQ02OQ03	GREEN	
 ArithmeticSeriesOQ02OQ02OQ03OQ01	GREEN	
 ArithmeticSeriesOQ02OQ03	GREEN	
 ArithmeticSeriesOQ02OQ04OQ01	GREEN	


### PR DESCRIPTION
Deep-rework Doctor increment for the v4.26→v4.31 toolchain migration (epic #37508, tracking #38065). Lane 3 / partition **non-Erdős A–K**. Container cpuset 12-17, cache `lean-mathlib-cache-v431-c`, worktree doctor-c. Each file verified `lake env lean Proofs.X` EXIT=0 in-container before flipping its ledger row; pushed per file. **Do not merge — orchestrator merges.**

## Files flipped RESIDUAL → GREEN (+3)
- **ArithmeticSeriesOQ02OQ02OQ03** (unknown-const) — `PowerSeries.coeff` ring-arg now implicit; `Finset.Nat.antidiagonal` def → `Finset.antidiagonal` (sum lemma keeps `Finset.Nat.` namespace); hockey-stick reindex via `sum_range_reflect`.
- **HierholzerAlgorithm** (type-mismatch) — `card_filter_add_card_filter_not` (+`add_comm`); `List.countP_eq_length_filter` arrow flipped; `Set.mem_coe`→`Finset.mem_coe`; `card_nbij` coe-form membership; two Sym2 goal-state repairs.
- **FourColorTheoremOQ01** (unknown-const + statement repair) — `ne_univ_iff_exists_notMem` removed (derive from `eq_univ_iff_forall`); `Ne.symm` drift; **statement repair**: `min_counterexample_has_low_degree` was false as stated, added missing `minDeg ≤ avgDeg` hypothesis.

## New systematic seams (rename-map candidates)
- `PowerSeries.coeff (n) : R⟦X⟧ →ₗ[R] R` — ring arg now **implicit**.
- `Finset.Nat.antidiagonal` def → `Finset.antidiagonal`; `Finset.Nat.sum_antidiagonal_eq_sum_range_succ` **unchanged**.
- `List.countP_eq_length_filter` direction flipped to `countP = (filter).length`.
- `Finset.filter_card_add_filter_neg_card_eq_card` → `Finset.card_filter_add_card_filter_not` (takes only `p`, gives `{p}+{¬p}`).
- `Set.mem_coe` removed → `Finset.mem_coe`.
- `Finset.ne_univ_iff_exists_notMem` removed.
- `expSeries_div_hasSum_exp` / `NormedSpace.exp` dropped their field (`𝕂`) argument.

## Statement repairs (#38611 gallery-meta re-audit)
- **FourColorTheoremOQ01** `min_counterexample_has_low_degree` — added missing `minDeg ≤ avgDeg` hypothesis (was false as stated). Fixed + flipped green.
- **CevasTheoremOQ01OQ03** (DEFERRED, out-of-partition root cause) — parent `CevasTheoremOQ01.routhRatio` has buggy denominators inconsistent with the child geometry; `routh_theorem_std` is false for asymmetric params (signedArea=1/10 vs routhRatio=25/252 at (1/2,1/3,1/4)); masked because the parent's only test uses symmetric d=e=f=1/3. Fix belongs in the parent (another lane's partition).

Full details, seams, and next leads in `proofs/batch2/STATUS.md` (increment 75).