### PR TITLE
migrate(v4.31): Doctor increment — partition non-Erdos L-Z (+5 GREEN)

### DIFF
--- a/proofs/Proofs/LawsOfLargeNumbersOQ02.lean
+++ b/proofs/Proofs/LawsOfLargeNumbersOQ02.lean
@@ -127,14 +127,17 @@ theorem variance_sampleMean
   have hvar_sum :
       variance (fun ω => ∑ i ∈ Finset.range n, X i ω) volume
         = ∑ i ∈ Finset.range n, variance (X i) volume := by
-    simpa [Finset.sum_apply] using IndepFun.variance_sum hLp_set hpair
+    have hfun : (fun ω => ∑ i ∈ Finset.range n, X i ω)
+        = (∑ i ∈ Finset.range n, X i) := by
+      funext ω; rw [Finset.sum_apply]
+    rw [hfun]
+    exact IndepFun.variance_sum hLp_set hpair
   have hn0 : (n : ℝ) ≠ 0 := Nat.cast_ne_zero.mpr hn.ne'
   unfold sampleMean
   rw [variance_const_mul, hvar_sum]
   simp_rw [h_var]
   rw [Finset.sum_const, Finset.card_range, nsmul_eq_mul]
   field_simp
-  ring
 
 -- ============================================================
 -- SECTION 3: The Chebyshev Convergence Rate
@@ -192,7 +195,7 @@ theorem chebyshevBound_nonneg (σ_sq : ℝ) (hσ : σ_sq ≥ 0) (n : ℕ) (hn : 
   unfold chebyshevBound
   apply div_nonneg hσ
   apply mul_nonneg
-  · exact Nat.cast_nonneg
+  · exact Nat.cast_nonneg _
   · exact sq_nonneg ε
 
 /-- The Chebyshev bound decreases as n increases (for fixed σ², ε) -/
@@ -322,7 +325,7 @@ theorem chebyshev_rate_implies_convergence
     exact (ENNReal.continuous_ofReal.tendsto 0).comp h
   -- Step 2: Rewrite chebyshevBound as constant/n
   simp only [chebyshevBound]
-  have heq : (fun n : ℕ => σ_sq / (↑n * ε ^ 2)) = fun n => (σ_sq / ε ^ 2) / ↑n := by
+  have heq : (fun n : ℕ => σ_sq / (↑n * ε ^ 2)) = fun n : ℕ => (σ_sq / ε ^ 2) / ↑n := by
     ext n; ring
   rw [heq]
   -- Step 3: c/n → 0 by standard Mathlib lemma

--- a/proofs/Proofs/QuadraticReciprocityOQ03.lean
+++ b/proofs/Proofs/QuadraticReciprocityOQ03.lean
@@ -48,12 +48,13 @@ namespace QRAlgorithm
 /-- **Step 1: Multiplicativity.** Factor and handle each factor separately. -/
 theorem legendreSym_mul_eq (a b : ℤ) (p : ℕ) [Fact p.Prime] :
     legendreSym p (a * b) = legendreSym p a * legendreSym p b :=
-  map_mul (legendreSym p) a b
+  legendreSym.mul p a b
 
 /-- **Step 3a: Handle factor of -1.** Uses the first supplementary law. -/
 theorem legendreSym_neg_one_eq (p : ℕ) [Fact p.Prime] (hp : p ≠ 2) :
-    legendreSym p (-1) = (-1) ^ (p / 2) :=
-  legendreSym.at_neg_one hp
+    legendreSym p (-1) = (-1) ^ (p / 2) := by
+  have hodd : p % 2 = 1 := (Fact.out : p.Prime).eq_two_or_odd.resolve_left hp
+  rw [legendreSym.at_neg_one hp, χ₄_eq_neg_one_pow hodd]
 
 /-- **Step 3: Reciprocity swap.** When a is an odd prime q ≠ p, swap:
 (q/p) = (-1)^((p-1)/2 · (q-1)/2) · (p/q).
@@ -66,6 +67,14 @@ theorem reciprocity_swap {p q : ℕ} [Fact p.Prime] [Fact q.Prime]
 -- ============================================================
 -- PART 2: Verified Example Computations
 -- ============================================================
+
+-- Small-prime `Fact` instances for the `decide` computations below
+-- (v4.31 no longer auto-synthesizes `Fact (Nat.Prime k)` for literals).
+instance : Fact (Nat.Prime 5) := ⟨by norm_num⟩
+instance : Fact (Nat.Prime 7) := ⟨by norm_num⟩
+instance : Fact (Nat.Prime 11) := ⟨by norm_num⟩
+instance : Fact (Nat.Prime 13) := ⟨by norm_num⟩
+instance : Fact (Nat.Prime 17) := ⟨by norm_num⟩
 
 /-- Example: (3/7) = -1 (3 is not a quadratic residue mod 7).
 Proof: By reciprocity, (3/7)(7/3) = (-1)^(3·1) = -1.

--- a/proofs/Proofs/QuadraticReciprocityOQ03OQ01.lean
+++ b/proofs/Proofs/QuadraticReciprocityOQ03OQ01.lean
@@ -97,7 +97,7 @@ theorem legendreSym_two_eq_one_iff (p : ℕ) [Fact p.Prime] (hp : p ≠ 2) :
     rw [ZMod.natCast_eq_zero_iff] at hz
     rw [Nat.prime_dvd_prime_iff_eq (Fact.out : p.Prime) Nat.prime_two] at hz
     exact hp hz
-  rw [legendreSym.eq_one_iff h2]
+  rw [legendreSym.eq_one_iff p h2]
   have e2 : ((2 : ℤ) : ZMod p) = (2 : ZMod p) := by norm_cast
   rw [e2]
   exact ZMod.exists_sq_eq_two_iff hp
@@ -122,6 +122,14 @@ theorem legendreSym_two_eq_neg_one_iff (p : ℕ) [Fact p.Prime] (hp : p ≠ 2) :
 -- ============================================================
 -- Verified example computations of (2/p)
 -- ============================================================
+
+-- Small-prime `Fact` instances for the `decide` computations below
+-- (v4.31 no longer auto-synthesizes `Fact (Nat.Prime k)` for literals).
+instance : Fact (Nat.Prime 3) := ⟨by norm_num⟩
+instance : Fact (Nat.Prime 5) := ⟨by norm_num⟩
+instance : Fact (Nat.Prime 23) := ⟨by norm_num⟩
+instance : Fact (Nat.Prime 31) := ⟨by norm_num⟩
+instance : Fact (Nat.Prime 41) := ⟨by norm_num⟩
 
 /-- (2/3) = -1  (3 ≡ 3 mod 8, so 2 is a non-residue). -/
 example : legendreSym 3 2 = -1 := by decide

--- a/proofs/Proofs/TestWolstenholme.lean
+++ b/proofs/Proofs/TestWolstenholme.lean
@@ -1,13 +1,8 @@
 import Mathlib
 
--- Wilson's theorem: (p-1)! ≡ -1 (mod p)
--- In ZMod p: product of nonzero elements = -1
-#check ZMod.prod_univ_prime
 -- Fermat's little theorem
 #check ZMod.pow_card_sub_one_eq_one
 #check ZMod.units_pow_card_sub_one_eq_one
--- Sum of powers
-#check Finset.sum_pow_eq_pow_sum
 -- ZMod field instance
 #check ZMod.instField
 -- Finite field power sum: for 1 ≤ k < p-1, ∑_{x ∈ (ℤ/pℤ)*} x^k = 0.
@@ -18,7 +13,7 @@ example (p : ℕ) (hp : Fact (Nat.Prime p)) (k : ℕ) (hk : 1 ≤ k) (hkp : k < 
     ∑ x : (ZMod p)ˣ, (x : ZMod p) ^ k = 0 := by
   -- Pick a generator g of (ZMod p)ˣ (which is cyclic since p is prime)
   haveI : IsCyclic (ZMod p)ˣ := inferInstance
-  obtain ⟨g, hg⟩ := IsCyclic.exists_monoid_generator (α := (ZMod p)ˣ)
+  obtain ⟨g, hg⟩ := IsCyclic.exists_generator (α := (ZMod p)ˣ)
   -- g^k ≠ 1 since 0 < k < p-1 = |group| and g is a generator
   have hgk_ne : (g : ZMod p) ^ k ≠ 1 := by
     intro heq
@@ -27,10 +22,12 @@ example (p : ℕ) (hp : Fact (Nat.Prime p)) (k : ℕ) (hk : 1 ≤ k) (hkp : k < 
       ext; simpa using heq
     -- orderOf g = p - 1 (generator of group of order p - 1)
     have hord : orderOf g = Fintype.card (ZMod p)ˣ := by
-      rw [orderOf_eq_card_of_forall_mem_zpowers (fun x => hg x)]
+      rw [orderOf_eq_card_of_forall_mem_zpowers (fun x => hg x), Nat.card_eq_fintype_card]
     rw [ZMod.card_units_eq_totient, Nat.totient_prime hp.out] at hord
     -- k < p - 1 = orderOf g, but g^k = 1 contradicts minimality of order
     have := orderOf_dvd_of_pow_eq_one hunit
+    rw [hord] at this
+    have hle := Nat.le_of_dvd (by omega) this
     omega
   -- The sum is invariant under multiplication by g:
   -- ∑ x^k = ∑ (g·x)^k = g^k · ∑ x^k
@@ -43,6 +40,7 @@ example (p : ℕ) (hp : Fact (Nat.Prime p)) (k : ℕ) (hk : 1 ≤ k) (hkp : k < 
     · intro b _; exact ⟨b * g⁻¹, Finset.mem_univ _, by group⟩
     · intro a _
       simp only [Units.val_mul, mul_pow]
+      ring
   -- From g^k · S = S and g^k ≠ 1, conclude S = 0
   -- Rearrange: (g^k - 1) · S = 0, and g^k - 1 is a unit, so S = 0
   have hsub : ((g : ZMod p) ^ k - 1) * ∑ x : (ZMod p)ˣ, (x : ZMod p) ^ k = 0 := by

--- a/proofs/batch2/STATUS.md
+++ b/proofs/batch2/STATUS.md
@@ -1,3 +1,80 @@
+# DOCTOR INCREMENT 80 (deep-rework partition non-Erdos L–Z / lane4, #38065, 2026-07-15)
+
+Container cpuset 18-23, 11g, cache `lean-mathlib-cache-v431-d`, worktree doctor-d, branch
+`feature/issue-38065-inc80` off origin/feature/issue-37508. **+5 GREEN.**
+Every flip verified in-container `lake env lean Proofs.X` exit-0 before ledger flip; pushed per file.
+(Local-import chains built with in-container `lake build Proofs.X` to materialize dependency oleans.)
+
+## Flips (failure class in parens)
+- **QuadraticReciprocityOQ03** (instance-synth) — HUB. Two seams:
+  (1) **`legendreSym.at_neg_one` now returns `χ₄ ↑p`** (was `(-1)^(p/2)`). Bridge with
+  **`ZMod.χ₄_eq_neg_one_pow (hodd : p % 2 = 1)`** (`ZModChar.lean:77`): `rw [legendreSym.at_neg_one hp,
+  χ₄_eq_neg_one_pow hodd]` where `hodd := (Fact.out : p.Prime).eq_two_or_odd.resolve_left hp`.
+  (2) **`map_mul (legendreSym p)` no longer synthesizes** — `legendreSym p` is a plain `ℤ→ℤ`, not a
+  bundled hom; use **`legendreSym.mul p a b`** (`Basic.lean:154`). (3) **`decide` on `legendreSym k a`
+  needs explicit `instance : Fact (Nat.Prime k)`** for each literal k (v4.31 stopped auto-synthesizing
+  `Fact (Nat.Prime <lit>)`) — added `instance : Fact (Nat.Prime 5/7/11/13/17) := ⟨by norm_num⟩`.
+- **QuadraticReciprocityOQ03OQ01** (instance-synth, dependent of ↑). **`legendreSym.eq_one_iff` now takes
+  `p` EXPLICITLY** (section `variable (p : ℕ)` at `Basic.lean:97`): `legendreSym.eq_one_iff h2` →
+  `legendreSym.eq_one_iff p h2`. Also `IsSquare`-form is unchanged (`exists_sq_eq_two_iff` still
+  `IsSquare (2:ZMod p) ↔ …`). Added `Fact (Nat.Prime 3/5/23/31/41)` instances for the `decide`s.
+- **QuadraticReciprocityOQ03OQ01Exp** (instance-synth, transitive dependent). No own edits — went GREEN
+  once its two-deep local-import chain (OQ03 → OQ03OQ01) built.
+- **LawsOfLargeNumbersOQ02** (type-mismatch). (1) `IndepFun.variance_sum` yields
+  `Var[∑ i, X i]` (function-sum); goal is `Var[fun ω => ∑ i, X i ω]`. Bridge with an explicit
+  `funext ω; rw [Finset.sum_apply]` `have` then `exact` (the old `simpa [Finset.sum_apply] using …`
+  no longer fires — `sum_apply` needs an actual application node). (2) **`Nat.cast_nonneg` stuck on
+  `IsOrderedRing ?m`** metavar → give it the arg: `Nat.cast_nonneg _`. (3) tendsto-lambda `fun n =>
+  C / ↑n` inferred as `ℝ→ℝ`; annotate binder `fun n : ℕ => …`. (4) a trailing `ring` became
+  "no goals" after `field_simp` closed it — dropped.
+- **TestWolstenholme** (unknown-const). (1) removed two dead `#check`s (`ZMod.prod_univ_prime`,
+  `Finset.sum_pow_eq_pow_sum` — neither exists in v4.31, both unused by the proof). (2)
+  **`IsCyclic.exists_monoid_generator` (→ `Submonoid.powers`) vs `orderOf_eq_card_of_forall_mem_zpowers`
+  (wants `Subgroup.zpowers`)** — switch to **`IsCyclic.exists_generator`** which delivers the `zpowers`
+  form directly. (3) `orderOf_eq_card_of_forall_mem_zpowers` now yields **`Nat.card`**, not
+  `Fintype.card` → append `, Nat.card_eq_fintype_card` to the rw. (4) **`omega` cannot use a
+  variable-divisor `(p-1) ∣ k`** — derive `Nat.le_of_dvd (by omega) this : p-1 ≤ k` first, then omega.
+  (5) `Finset.sum_nbij` summand goal `g^k*a^k = a^k*g^k` needs an explicit `ring` after the `simp only`.
+
+## New systematic seams (rename-map candidates)
+- **`Mathlib.Tactic.GeneralizeProofs` namespace moved to `Batteries.Tactic.GeneralizeProofs`** — the
+  `generalize_proofs` tactic (incl. the `MAbs`/`MGen` monads, `abstractProofs`, `MGen.runMAbs`,
+  `MAbs.findProof?/insertProof/withLocal/withRecurse`) migrated Mathlib→Batteries. Affects any file
+  vendoring the Harmonic modified `generalize_proofs` (all `*Aristotle` companions with a
+  `namespace Harmonic.GeneralizeProofs` block). Swap the `open … Mathlib.Tactic.GeneralizeProofs` →
+  `open … Batteries.Tactic.GeneralizeProofs` (NB: a failed `open` on the unknown namespace rejects the
+  WHOLE `open` line, cascading dozens of phantom "unknown identifier MetaM/MAbs/binderIdent" errors —
+  fix the namespace first, re-verify, only then chase real errors).
+- **`legendreSym.at_neg_one : … = χ₄ ↑p`** (character form now) + bridge **`ZMod.χ₄_eq_neg_one_pow`**.
+- **`legendreSym p` is a bare function** — `map_mul`/`map_pow` fail; use `legendreSym.mul`/`.pow`.
+- **`legendreSym.eq_one_iff`/`eq_neg_one_iff` take `p` explicitly** (positional first arg).
+- **`tendsto_inverse_atTop_nhds_zero_nat` → `tendsto_inv_atTop_nhds_zero_nat`** (inverse→inv).
+- **`LT.lt.not_le` → `LT.lt.not_ge`** (the `.not_le` dot-projection; alias of `not_le_of_gt`).
+- **`Fact (Nat.Prime <literal>)` no longer auto-synthesized** — add explicit `instance` per literal.
+
+## Deferred / next leads (my partition, L–Z)
+- **LawsOfLargeNumbersOQ01Aristotle** (HUB for OQ01OQ01/OQ01OQ03) — META BLOCK NOW FIXED (both
+  `open` lines swapped to `Batteries.Tactic.GeneralizeProofs`) + `tendsto_inv…` + `.not_ge` done;
+  partial patch saved at `/tmp/lln01aristotle.partial.patch`. 3 dense Aristotle blobs remain:
+  L435 `aesop` normalization infinite-loop (the `(n+1)/n → 1` `Tendsto.congr'`), L507
+  `integral_add` no longer matches the `A*B - A*μ.real - μ.real*B` subtraction integrand
+  (covariance now unfolds with `μ.real` and as a subtraction chain), L705 unsolved. Needs real
+  reconstruction of the covariance/integral algebra — reserve a full session.
+- **NewtonIndStep2** (proof-drift) — NOT cheap. All THREE `nlinarith` Positivstellensatz certificates
+  (α≥0 L62, γ≥0 L77, discriminant L100) genuinely broke under v4.31 nlinarith normalization (with
+  `maxHeartbeats 1600000` they finish searching and report "linarith failed", i.e. certificate miss,
+  not timeout). Needs new hint sets / SOS certificates.
+- **LawOfSinesOQ06** (WithLp reshape) — bigger than cheap. `EuclideanSpace.inner_apply` →
+  `PiLp.inner_apply` (`⟪x,y⟫ = ∑ i, ⟪x i,y i⟫`, still needs real-inner `x i * y i` bridge), function
+  app `u 0` now normalizes to `u.ofLp 0`, AND a `structure Triangle` elaboration cascade at L110
+  (`cross2D (B - A) (C - A)` → `HSub … ((B:?)→?B→Vec2) Vec2` stuck) that kills all of Part III.
+- **RationalCanonicalFormExists** (type-mismatch) — HUB for MinpolyCharpolyOQ03(+OQ03OQ01); 13
+  errors (unsolved goals, ext, rewrite-pattern, instance). Expensive, not yet started.
+- **WolstenholmeTheoremOQ01** (oom-killed) and **TestApi203** (unclassified) — both OOM at 11g
+  (`lake env lean` EXIT=137); defer to a higher-memory lane like TestApi203.
+- Quick error-count scan of my partition: MathematicalInductionOQ03 (8), TaylorTheoremOQ03 (9),
+  PrimeGapBoundsOQ01 (12) — none are single-blocker; grind as budget allows.
+
 # DOCTOR INCREMENT 75 (deep-rework partition non-Erdos A–K / lane3, #38065, 2026-07-15)
 
 Container cpuset 12-17, 11g, cache `lean-mathlib-cache-v431-c`, worktree doctor-c, branch

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -2352,7 +2352,7 @@ QuadraticReciprocityAlgorithmOQ03FieldBridge	GREEN
 QuadraticReciprocityAlgorithmOQ03M2	GREEN	
 QuadraticReciprocityAlgorithmOQ03M2Capstone	GREEN	rewrite-drift
 QuadraticReciprocityAlgorithmOQ03Zolotarev	GREEN	rewrite-drift
-QuadraticReciprocityOQ03	RESIDUAL	instance-synth
+QuadraticReciprocityOQ03	GREEN	
 QuadraticReciprocityOQ03OQ01	RESIDUAL	instance-synth
 QuadraticReciprocityOQ03OQ01Exp	RESIDUAL	instance-synth
 RamanujanSumFallacy	GREEN	

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -2221,7 +2221,7 @@ LawsOfLargeNumbersOQ01OQ01	RESIDUAL	signature-drift
 LawsOfLargeNumbersOQ01OQ02	GREEN	
 LawsOfLargeNumbersOQ01OQ02OQ01	RESIDUAL	type-mismatch
 LawsOfLargeNumbersOQ01OQ03	RESIDUAL	signature-drift
-LawsOfLargeNumbersOQ02	RESIDUAL	type-mismatch
+LawsOfLargeNumbersOQ02	GREEN	
 LawsOfLargeNumbersOQ03	GREEN	
 LawsOfLargeNumbersOQ03Aristotle	GREEN	
 LebesgueMeasure	GREEN	

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -2353,8 +2353,8 @@ QuadraticReciprocityAlgorithmOQ03M2	GREEN
 QuadraticReciprocityAlgorithmOQ03M2Capstone	GREEN	rewrite-drift
 QuadraticReciprocityAlgorithmOQ03Zolotarev	GREEN	rewrite-drift
 QuadraticReciprocityOQ03	GREEN	
-QuadraticReciprocityOQ03OQ01	RESIDUAL	instance-synth
-QuadraticReciprocityOQ03OQ01Exp	RESIDUAL	instance-synth
+QuadraticReciprocityOQ03OQ01	GREEN	
+QuadraticReciprocityOQ03OQ01Exp	GREEN	
 RamanujanSumFallacy	GREEN	
 RamseyHypergraph	GREEN	
 RamseyR4kExtensions	GREEN	

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -2601,7 +2601,7 @@ TestErdos43Api	GREEN
 TestHLTension	GREEN	
 TestHolderApi	GREEN	
 TestSphereLocEuc	GREEN	
-TestWolstenholme	RESIDUAL	unknown-const:ZMod.prod_univ_prime
+TestWolstenholme	GREEN	
 TestZetaNonzero	GREEN	
 ThreeSquares	GREEN	
 ThreeSquaresGaussEureka	GREEN	


### PR DESCRIPTION
## Doctor migration increment 80 (lane 4, partition non-Erdős L–Z)

Converts 5 RESIDUAL files → GREEN for the Lean v4.26→v4.31 toolchain migration (epic #37508 / #38065).
Each flip verified in-container (`lean4-arm64:v4.31.0`, cpuset 18-23, cache `lean-mathlib-cache-v431-d`)
with `lake env lean Proofs/X.lean` EXIT=0 before flipping its ledger row; pushed per file.

### Files flipped GREEN
- **QuadraticReciprocityOQ03** (instance-synth) — HUB
- **QuadraticReciprocityOQ03OQ01** (instance-synth, dependent)
- **QuadraticReciprocityOQ03OQ01Exp** (transitive dependent — no own edits)
- **LawsOfLargeNumbersOQ02** (type-mismatch)
- **TestWolstenholme** (unknown-const)

### Key seams (see proofs/batch2/STATUS.md increment 80 for full detail)
- `legendreSym.at_neg_one` now returns `χ₄ ↑p`; bridge via `ZMod.χ₄_eq_neg_one_pow`.
- `legendreSym p` is a bare `ℤ→ℤ` (not a bundled hom) → `map_mul` fails, use `legendreSym.mul`.
- `legendreSym.eq_one_iff`/`eq_neg_one_iff` take `p` explicitly (positional first arg).
- `Fact (Nat.Prime <literal>)` no longer auto-synthesized for `decide` — add explicit instances.
- `IndepFun.variance_sum` yields a function-sum `Var[∑ i, X i]`; bridge to `Var[fun ω => ∑ i, X i ω]`
  with `funext; rw [Finset.sum_apply]` (old `simpa [Finset.sum_apply]` no longer fires).
- `Nat.cast_nonneg` stuck on `IsOrderedRing ?m` → `Nat.cast_nonneg _`.
- `IsCyclic.exists_monoid_generator` (`Submonoid.powers`) vs `orderOf_eq_card_of_forall_mem_zpowers`
  (`Subgroup.zpowers`) → use `IsCyclic.exists_generator`; result now `Nat.card` not `Fintype.card`
  (`Nat.card_eq_fintype_card`); `omega` can't use variable-divisor `∣` → `Nat.le_of_dvd` first.
- **New rename-map candidate:** `Mathlib.Tactic.GeneralizeProofs` namespace moved to
  `Batteries.Tactic.GeneralizeProofs` (affects vendored Harmonic `generalize_proofs` blocks in
  `*Aristotle` companions).

### Statement repairs (#38611)
None — no unsound-original files in this batch. `QuadraticReciprocityOQ03.lean`'s
`legendreSym_neg_one_eq` statement is preserved verbatim (`(-1)^(p/2)` form); only the proof changed.

### Deferred (warm leads for next wave, documented in STATUS.md)
LawsOfLargeNumbersOQ01Aristotle (meta block fixed, 3 dense probabilistic blobs remain — partial patch
saved), NewtonIndStep2 (all 3 nlinarith certificates genuinely broke), LawOfSinesOQ06 (WithLp `.ofLp`
reshape + Triangle structure cascade), RationalCanonicalFormExists (13-error hub),
WolstenholmeTheoremOQ01 + TestApi203 (OOM at 11g).

Do not merge — orchestrator merges. No loom labels.