### PR TITLE
migrate(v4.31): Doctor increment — partition Erdős≥500 (+4 GREEN)

### DIFF
--- a/proofs/Proofs/Erdos1035Problem.lean
+++ b/proofs/Proofs/Erdos1035Problem.lean
@@ -337,17 +337,17 @@ private lemma hypercubeBitCount_xor_pow_parity (n k : ℕ) (hk : k < n) (v : ℕ
     hypercubeBitCount n (v ^^^ 2 ^ k) % 2 ≠ hypercubeBitCount n v % 2 := by
   simp only [hypercubeBitCount]
   -- The erase-k sum is identical for v and v ^^^ 2^k (bits j ≠ k are unchanged)
-  have h_rest : ∑ j ∈ Finset.univ.erase (⟨k, hk⟩ : Fin n),
-      if (v ^^^ 2 ^ k).testBit j.val then 1 else 0 =
-      ∑ j ∈ Finset.univ.erase (⟨k, hk⟩ : Fin n),
-      if v.testBit j.val then 1 else 0 := by
+  have h_rest : (∑ j ∈ Finset.univ.erase (⟨k, hk⟩ : Fin n),
+      if (v ^^^ 2 ^ k).testBit j.val then 1 else 0) =
+      (∑ j ∈ Finset.univ.erase (⟨k, hk⟩ : Fin n),
+      if v.testBit j.val then 1 else 0) := by
     apply Finset.sum_congr rfl
     intro ⟨j, _⟩ hmem
     simp only [Finset.mem_erase, ne_eq, Fin.mk.injEq] at hmem
-    rw [Nat.testBit_xor, Nat.testBit_two_pow_of_ne hmem.1, Bool.xor_false]
+    rw [Nat.testBit_xor, Nat.testBit_two_pow_of_ne (Ne.symm hmem.1), Bool.xor_false]
   -- The k-th bit flips: testBit (v ^^^ 2^k) k = !testBit v k
   have h_flip : (v ^^^ 2 ^ k).testBit k = !(v.testBit k) := by
-    rw [Nat.testBit_xor, Nat.testBit_two_pow_self, Bool.true_xor]
+    rw [Nat.testBit_xor, Nat.testBit_two_pow_self, Bool.xor_true]
   -- Expand both sums: isolate k-th term + erase sum
   rw [← Finset.add_sum_erase _ _ (Finset.mem_univ (⟨k, hk⟩ : Fin n)),
       show (⟨k, hk⟩ : Fin n).val = k from rfl, h_flip, h_rest,
@@ -358,10 +358,10 @@ private lemma hypercubeBitCount_xor_pow_parity (n k : ℕ) (hk : k < n) (v : ℕ
   -- Case split: bit k is false or true
   cases hb : v.testBit k
   · -- bit k = false → !bit k = true → sum_new = 1 + X, sum_old = 0 + X
-    simp only [hb, Bool.not_false, ite_true, ite_false, zero_add]
+    simp only [hb, Bool.not_false, Bool.false_eq_true, if_false, if_true, ite_true]
     omega
   · -- bit k = true → !bit k = false → sum_new = 0 + X, sum_old = 1 + X
-    simp only [hb, Bool.not_true, ite_true, ite_false, zero_add]
+    simp only [hb, Bool.not_true, Bool.false_eq_true, if_false, if_true, ite_true]
     omega
 
 /-- **Q_n is bipartite** (2-colorable): the vertex set splits into two independent sets
@@ -379,5 +379,5 @@ theorem hypercube_bipartite (n : ℕ) : (hypercubeGraph n).IsBipartite :=
         have h1 : u.val ^^^ (u.val ^^^ v.val) = u.val ^^^ 2 ^ k.val := by rw [hk]
         rw [← Nat.xor_assoc, Nat.xor_self, Nat.zero_xor] at h1
         exact h1
-      simp only [hypercubeColor, Fin.mk.injEq, hv]
-      exact hypercubeBitCount_xor_pow_parity n k.val k.isLt u.val)⟩
+      simp only [hypercubeColor, ne_eq, Fin.mk.injEq, hv]
+      exact (hypercubeBitCount_xor_pow_parity n k.val k.isLt u.val).symm)⟩

--- a/proofs/Proofs/Erdos559Problem.lean
+++ b/proofs/Proofs/Erdos559Problem.lean
@@ -57,7 +57,7 @@ structure FiniteGraph (V : Type*) [Fintype V] where
   dec : DecidableRel adj := by infer_instance
 
 /-- The number of edges in a graph -/
-noncomputable def edgeCount {V : Type*} [Fintype V] [DecidableEq V]
+noncomputable def edgeCount {V : Type*} [Fintype V] [DecidableEq V] [LinearOrder V]
     (G : FiniteGraph V) : ℕ :=
   (Finset.filter (fun p : V × V => p.1 < p.2 ∧ G.adj p.1 p.2)
     Finset.univ).card
@@ -89,8 +89,8 @@ def IsRamseyFor {V W : Type*} [Fintype V] [Fintype W] [DecidableEq V] [Decidable
 noncomputable def sizeRamsey {V : Type*} [Fintype V] [DecidableEq V]
     (G : FiniteGraph V) : ℕ :=
   Nat.find (⟨Fintype.card V * (Fintype.card V - 1) / 2,
-    ⟨(⟨fun u v => u ≠ v, fun _ _ h => h.symm, fun _ h => h rfl⟩ :
-      FiniteGraph V), by sorry⟩⟩ :
+    ⟨⟨fun u v => u ≠ v, fun _ _ h => h.symm, fun _ h => h rfl, inferInstance⟩,
+      by sorry⟩⟩ :
     ∃ m, ∃ (H : FiniteGraph (Fin m)), IsRamseyFor H G)
 
 /- ## The Conjecture (Disproved) -/
@@ -127,7 +127,7 @@ theorem beck_paths (n : ℕ) (hn : n ≥ 2) :
   sorry -- Beck (1983)
 
 /-- A graph is a tree if it is connected and has n-1 edges -/
-def IsTree {V : Type*} [Fintype V] [DecidableEq V] (G : FiniteGraph V) : Prop :=
+def IsTree {V : Type*} [Fintype V] [DecidableEq V] [LinearOrder V] (G : FiniteGraph V) : Prop :=
   edgeCount G = Fintype.card V - 1 ∧
   -- Connected: any two vertices are reachable
   True -- Simplified; full connectivity definition omitted
@@ -140,7 +140,7 @@ theorem friedman_pippenger_trees (n : ℕ) (hn : n ≥ 2) :
   sorry -- Friedman-Pippenger (1987)
 
 /-- A graph is a cycle if it has n vertices and n edges forming a ring -/
-def IsCycle {V : Type*} [Fintype V] [DecidableEq V] (G : FiniteGraph V) : Prop :=
+def IsCycle {V : Type*} [Fintype V] [DecidableEq V] [LinearOrder V] (G : FiniteGraph V) : Prop :=
   edgeCount G = Fintype.card V ∧
   ∀ v : V, degree G v = 2
 

--- a/proofs/Proofs/Erdos625Problem.lean
+++ b/proofs/Proofs/Erdos625Problem.lean
@@ -92,7 +92,7 @@ def ErdosRenyi (n : ℕ) : Type := RandomGraph n (1/2)
 
 /-- Almost sure property for random graphs. -/
 def AlmostSurely (P : ∀ n, RandomGraph n (1/2) → Prop) : Prop :=
-  ∀ ε > 0, ∃ N, ∀ n ≥ N, True  -- Placeholder for measure-theoretic statement
+  ∀ ε > (0:ℝ), ∃ N : ℕ, ∀ n ≥ N, True  -- Placeholder for measure-theoretic statement
 
 /- ## Part IV: Known Bounds -/
 
@@ -195,13 +195,13 @@ theorem cochromatic_clique_independence (G : SimpleGraph V) :
 /-- χ(G) is concentrated in an interval of width O(n/log²n). -/
 theorem chromatic_concentration :
     AlmostSurely (fun n G =>
-      ∃ χ₀ : ℕ, |chromaticNumber G.graph - χ₀| ≤ n / (Real.log n)^2) := by
+      ∃ χ₀ : ℕ, |(chromaticNumber G.graph : ℝ) - χ₀| ≤ n / (Real.log n)^2) := by
   sorry
 
 /-- ζ(G) is also concentrated (less is known). -/
 theorem cochromatic_concentration :
     AlmostSurely (fun n G =>
-      ∃ ζ₀ : ℕ, |cochromaticNumber G.graph - ζ₀| ≤ n / Real.log n) := by
+      ∃ ζ₀ : ℕ, |(cochromaticNumber G.graph : ℝ) - ζ₀| ≤ n / Real.log n) := by
   sorry
 
 /- ## Part X: Special Graph Classes -/
@@ -242,8 +242,10 @@ theorem known_summary :
 
 /-- The problem remains open despite recent progress. -/
 theorem problem_status :
-    heckel_steiner_unbounded 1 →  -- Difference grows
-    ¬(∀ n G, chromaticNumber G.graph = cochromaticNumber G.graph) := by  -- Not always equal
+    -- Difference grows (statement of `heckel_steiner_unbounded` at M = 1)
+    AlmostSurely (fun n G => chromaticNumber G.graph - cochromaticNumber G.graph ≥ 1) →
+    ¬(∀ (n : ℕ) (G : RandomGraph n (1/2)),
+      chromaticNumber G.graph = cochromaticNumber G.graph) := by  -- Not always equal
   sorry
 
 end Erdos625

--- a/proofs/Proofs/Erdos751Problem.lean
+++ b/proofs/Proofs/Erdos751Problem.lean
@@ -39,28 +39,28 @@ namespace Erdos751
 Basic definitions for graphs, cycles, and chromatic number.
 -/
 
-variable {V : Type*} [Fintype V] [DecidableEq V]
+variable {V : Type*} [Fintype V] [DecidableEq V] [Nonempty V]
 
 /--
 **Minimum Degree:**
 The minimum degree δ(G) is the smallest vertex degree in G.
 -/
-noncomputable def minDegree (G : SimpleGraph V) : ℕ :=
-  Finset.min' (Finset.univ.image G.degree) (by simp)
+noncomputable def minDegree (G : SimpleGraph V) [DecidableRel G.Adj] : ℕ :=
+  Finset.min' (Finset.univ.image (fun v => G.degree v)) (by simp)
 
 /--
 **Maximum Degree:**
 The maximum degree Δ(G) is the largest vertex degree in G.
 -/
-noncomputable def maxDegree (G : SimpleGraph V) : ℕ :=
-  Finset.max' (Finset.univ.image G.degree) (by simp)
+noncomputable def maxDegree (G : SimpleGraph V) [DecidableRel G.Adj] : ℕ :=
+  Finset.max' (Finset.univ.image (fun v => G.degree v)) (by simp)
 
 /--
 **Chromatic Number:**
 The chromatic number χ(G) is the minimum number of colors needed to properly
 color the vertices of G (no two adjacent vertices have the same color).
 -/
-axiom chromaticNumber (G : SimpleGraph V) : ℕ
+axiom chromaticNumber (G : SimpleGraph V) [DecidableRel G.Adj] : ℕ
 
 /--
 **Girth:**
@@ -68,14 +68,14 @@ The girth of G is the length of the shortest cycle in G.
 If G is acyclic (a forest), the girth is defined as ∞ (we use 0).
 Axiomatized since cycle enumeration infrastructure is required.
 -/
-axiom girth (G : SimpleGraph V) : ℕ
+axiom girth (G : SimpleGraph V) [DecidableRel G.Adj] : ℕ
 
 /--
 **Cycle Lengths:**
 The set of all cycle lengths present in G.
 Axiomatized since walk/cycle infrastructure is required.
 -/
-axiom cycleLengths (G : SimpleGraph V) : Set ℕ
+axiom cycleLengths (G : SimpleGraph V) [DecidableRel G.Adj] : Set ℕ
 
 /--
 **Cycle Length Gap:**
@@ -101,7 +101,7 @@ More importantly for us:
 Every graph with chromatic number 4 contains a subgraph of minimum degree 3.
 In fact, for χ(G) = 4, we need minimum degree at least 3.
 -/
-axiom four_chromatic_minDeg (G : SimpleGraph V) :
+axiom four_chromatic_minDeg (G : SimpleGraph V) [DecidableRel G.Adj] :
     chromaticNumber G = 4 → minDegree G ≥ 3
 
 /-
@@ -118,7 +118,7 @@ differ by at most 2.
 More precisely: if G has δ(G) ≥ 3, then there exist cycle lengths
 m, m' in G with |m - m'| ≤ 2.
 -/
-axiom bondy_vince_theorem (G : SimpleGraph V) :
+axiom bondy_vince_theorem (G : SimpleGraph V) [DecidableRel G.Adj] :
     minDegree G ≥ 3 →
     ∃ m m' : ℕ, m ∈ cycleLengths G ∧ m' ∈ cycleLengths G ∧ m ≠ m' ∧
       (m : ℤ) - m' ≤ 2 ∧ (m' : ℤ) - m ≤ 2
@@ -140,7 +140,7 @@ cycle lengths cannot be arbitrarily large.
 
 In fact, the gap is always at most 2.
 -/
-theorem erdos_751_chromatic_4 (G : SimpleGraph V) :
+theorem erdos_751_chromatic_4 (G : SimpleGraph V) [DecidableRel G.Adj] :
     chromaticNumber G = 4 →
     ∃ m m' : ℕ, m ∈ cycleLengths G ∧ m' ∈ cycleLengths G ∧ m ≠ m' ∧
       (m : ℤ) - m' ≤ 2 ∧ (m' : ℤ) - m ≤ 2 := by
@@ -153,7 +153,7 @@ theorem erdos_751_chromatic_4 (G : SimpleGraph V) :
 The answer is NO even if we require large girth.
 Having large girth doesn't help because minimum degree ≥ 3 is the key.
 -/
-theorem erdos_751_with_girth (G : SimpleGraph V) (k : ℕ) :
+theorem erdos_751_with_girth (G : SimpleGraph V) [DecidableRel G.Adj] (k : ℕ) :
     chromaticNumber G = 4 → girth G ≥ k →
     ∃ m m' : ℕ, m ∈ cycleLengths G ∧ m' ∈ cycleLengths G ∧ m ≠ m' ∧
       (m : ℤ) - m' ≤ 2 ∧ (m' : ℤ) - m ≤ 2 := by
@@ -166,7 +166,7 @@ theorem erdos_751_with_girth (G : SimpleGraph V) (k : ℕ) :
 Can min(mᵢ₊₁ - mᵢ) be arbitrarily large for χ(G) = 4?
 Answer: NO, the gap is always ≤ 2.
 -/
-theorem erdos_751 (G : SimpleGraph V) :
+theorem erdos_751 (G : SimpleGraph V) [DecidableRel G.Adj] :
     chromaticNumber G = 4 →
     ¬(∀ n : ℕ, minCycleLengthGap (cycleLengths G) > n) := by
   intro hchi hcontra
@@ -188,7 +188,7 @@ theorem erdos_751 (G : SimpleGraph V) :
 **Generalization:**
 The result holds for any graph with minimum degree ≥ 3, not just χ(G) = 4.
 -/
-theorem min_degree_3_cycle_gap (G : SimpleGraph V) :
+theorem min_degree_3_cycle_gap (G : SimpleGraph V) [DecidableRel G.Adj] :
     minDegree G ≥ 3 →
     ∃ m m' : ℕ, m ∈ cycleLengths G ∧ m' ∈ cycleLengths G ∧ m ≠ m' ∧
       (m : ℤ) - m' ≤ 2 ∧ (m' : ℤ) - m ≤ 2 :=
@@ -200,7 +200,7 @@ A graph with χ(G) = 4 must have a vertex of degree ≥ 3.
 Actually, it must have minimum degree ≥ 3 (otherwise we could
 color greedily with fewer colors).
 -/
-theorem chromatic_4_implies_min_deg_3 (G : SimpleGraph V) :
+theorem chromatic_4_implies_min_deg_3 (G : SimpleGraph V) [DecidableRel G.Adj] :
     chromaticNumber G = 4 → minDegree G ≥ 3 :=
   four_chromatic_minDeg G
 
@@ -219,7 +219,7 @@ Summary of results:
 The answer is NO - the gap cannot be arbitrarily large, and large
 girth doesn't help either.
 -/
-theorem erdos_751_summary (G : SimpleGraph V) :
+theorem erdos_751_summary (G : SimpleGraph V) [DecidableRel G.Adj] :
     -- Main result: 4-chromatic implies close cycles
     (chromaticNumber G = 4 →
       ∃ m m' : ℕ, m ∈ cycleLengths G ∧ m' ∈ cycleLengths G ∧ m ≠ m' ∧

--- a/proofs/batch2/STATUS.md
+++ b/proofs/batch2/STATUS.md
@@ -1,3 +1,88 @@
+# DOCTOR INCREMENT 78 (deep-rework partition Erdős ≥ 500 / lane2, #38065, 2026-07-15)
+
+Container cpuset 6-11, 11g, cache `lean-mathlib-cache-v431-b`, worktree doctor-b, branch
+`feature/issue-38065-inc78` off origin/feature/issue-37508. **+5 GREEN.**
+Every flip verified in-container `lake env lean Proofs.X` exit-0 before ledger flip; pushed per file.
+
+## Flips (failure class in parens)
+- **Erdos1035Problem** (instance-synth): four seams in the popcount-parity lemma /
+  hypercube-bipartite proof. (1) **Big-operator `∑ x ∈ s, f` now parses greedily over a
+  trailing `= …`** — `have h : ∑ … = ∑ … := by` elaborated the `= ∑…` INTO the first sum body
+  (→ `AddCommMonoid Prop` / `OfNat (Sort) 1`); fix = parenthesize each sum. (2) `Bool.true_xor`
+  → **`Bool.xor_true`** after `Nat.testBit_two_pow_self` puts the literal on the RIGHT
+  (`b ^^ true`). (3) `Nat.testBit_two_pow_of_ne hmem.1` wrong orientation → **`(Ne.symm hmem.1)`**
+  (lemma wants `k ≠ j`, mem_erase gives `j ≠ k`). (4) `Fin.mk.injEq` didn't fire on the `≠` goal
+  (add **`ne_eq`**) and the resulting Nat-`≠` is the reverse of the lemma → **`.symm`**. Also the
+  `cases hb`/`omega` branches left `if false = true then 1 else 0` opaque to omega — reduced with
+  `Bool.false_eq_true, if_false, if_true, ite_true` in the `simp only`.
+- **Erdos625Problem** (instance-synth): (1) placeholder `AlmostSurely := ∀ ε > 0, ∃ N, ∀ n ≥ N,
+  True` had **untyped ε and N** → `LE (?m ε)` stuck; annotate `∀ ε > (0:ℝ), ∃ N : ℕ`. (2) abs of a
+  ℕ subtraction: `|chromaticNumber G.graph - χ₀|` needs `AddGroup ℕ` → coerce inside abs
+  `|(chromaticNumber G.graph : ℝ) - χ₀|` (same for cochromatic). (3) **statement repair**
+  (#38611 cand.): `problem_status` used `heckel_steiner_unbounded 1` (a *proof term* of type
+  `AlmostSurely …`) in `→`-hypothesis position (type expected, got term) — replaced with the
+  statement `AlmostSurely (fun n G => … ≥ 1)`; and its conclusion `∀ n G, … G.graph …` had
+  unconstrained binders → annotated `∀ (n : ℕ) (G : RandomGraph n (1/2))`. (pre-existing sorries
+  kept — file is a survey of an open problem.)
+- **Erdos559Problem** (elab-drift): (1) `edgeCount`'s `fun p : V×V => p.1 < p.2` needs
+  **`LT V`** — the v4.26-green source only had `[Fintype V][DecidableEq V]`, so an implicit order
+  instance is gone in v4.31; added `[LinearOrder V]` to `edgeCount`/`IsTree`/`IsCycle` (all
+  concrete callers use `Fin n`, which has it). (2) anonymous `⟨…⟩` for `FiniteGraph.mk` no longer
+  auto-fills the **default-valued `dec` field** — provide 4th field `inferInstance`. (3) the
+  `Nat.find` witness graph was annotated `: FiniteGraph V` but the existential needs
+  `FiniteGraph (Fin m)`; dropped the wrong annotation so expected-type drives it (complete-graph
+  ctor works for any DecidableEq type).
+- **Erdos751Problem** (instance-synth): `minDegree`/`maxDegree` via `Finset.min'`/`max'` of
+  `Finset.univ.image G.degree`. Two fixes: (a) **`G.degree` carries an instance binder**
+  `[Fintype ↑(G.neighborSet v)]` so bare `Finset.image G.degree` fails — wrap `(fun v => G.degree v)`
+  and add `[DecidableRel G.Adj]`; (b) `min'`/`max'` nonempty obligation `Finset.univ.Nonempty`
+  needs `[Nonempty V]` (added to the section `variable` line; auto-included into every
+  `minDegree G` statement). Blanket-added `[DecidableRel G.Adj]` after each `(G : SimpleGraph V)`.
+
+## New systematic seams (rename-map candidates)
+- **Big-operator notation `∑ x ∈ s, f` / `∏` binds greedily over a trailing binary relation**
+  (`= …`, `≤ …`) in v4.31 — any `have h : ∑ … = ∑ … := by` where the sums are written without
+  surrounding parens now folds the RHS into the first summand (yields bogus `AddCommMonoid Prop`
+  / `OfNat (Sort ?u) 1`). Fix: parenthesize each big-operator term.
+- **`Bool.true_xor` vs `Bool.xor_true`** — pick by which side the literal ends up on after
+  `Nat.testBit_two_pow_self`; the self-rewrite yields `b ^^ true` → `Bool.xor_true`.
+- **Anonymous-constructor `⟨…⟩` no longer auto-fills structure fields with `:= by …`/`:=` defaults**
+  — must supply every explicit field (e.g. a `DecidableRel`-valued `dec := by infer_instance` field
+  now needs an explicit `inferInstance` arg). (Recurred across Erdos559 + others in-wave.)
+- **min-over-ℕ seam:** `Finset.inf` over ℕ now demands `OrderTop ℕ` (absent); `Finset.min'`/`max'`
+  demand `[Nonempty V]`; and `SimpleGraph.degree` needs `[DecidableRel G.Adj]` to shed its
+  `[Fintype (neighborSet v)]` binder before use in `Finset.image`. (Erdos751 fixed; Erdos803 same
+  shape, deferred.)
+
+## Statement repairs (for #38611, gallery-meta re-audit)
+- **Erdos625Problem.problem_status** — was type-incorrect (proof term in `→`-hyp position);
+  restated hypothesis as the statement `AlmostSurely (fun n G => χ − ζ ≥ 1)`. Not a soundness
+  change (proof is a pre-existing `sorry`), but the gallery meta should reflect the corrected form.
+- **Erdos807Problem.erw_conjecture_false** (NOT flipped — deferred): with the placeholder
+  `def ERW_conjecture n := True`, the theorem `¬∀ n, ERW_conjecture n` is genuinely FALSE and
+  `intro _; trivial` cannot close `⊢ False`. This is an unsound placeholder formalization
+  (a `True` stand-in makes the "conjecture is false" corollary unprovable). Needs a real
+  (dis)provable formalization or restructuring — flagged as a #38611 re-audit candidate, not a
+  mechanical migration flip.
+
+## Next leads for this partition (Erdős ≥ 500)
+- **Erdos1007Problem.olean was BUILT into cache lean-mathlib-cache-v431-b** (green parent) to
+  unmask children — but Erdos1007OQ05 is NOT a pure cascade (own drift: line 70 `Finset.add_sum_erase`
+  rewrite + a `|>.sum … = 0` parse error at 78) and Erdos1007OQ01 is heavy (whnf timeout, unknown
+  `K5_unit_embedding`, `open` token). Erdos1014Problem is the real cascade hub (21 err) — fixing it
+  unmasks **pure missing-olean** children Erdos1014OQ02 + Erdos1014OQ03Concrete (each a single
+  "object file … .olean does not exist" error, so they'll go green the moment the parent olean lands
+  in the cache).
+- **Cheap-ish (single seam family):** Erdos803Problem (3 err, `Finset.inf`→`min'`+Nonempty, same as
+  Erdos751), Erdos556Problem (4 err — but has an unsound edge case: `cycleGraph` loopless is FALSE
+  for n=1; fix by adding `i ≠ j` to `Adj`; plus a `by trivial` on a Ramsey existence that needs a
+  real constant-embedding witness — #38611 candidate).
+- **Error-count survey (this wave, uncached-sibling counts):** 559✓ 625✓ 751✓ 807(2,deferred)
+  803(3) 556(4) 720(5,all omega) 732(5) 766(5) 796(5) 537/525/505/1040(6) 781/782/794/738(6)
+  1056/515/533(10-11) 1019(11) — lower is cheaper.
+
+---
+
 # DOCTOR INCREMENT 75 (deep-rework partition non-Erdos A–K / lane3, #38065, 2026-07-15)
 
 Container cpuset 12-17, 11g, cache `lean-mathlib-cache-v431-c`, worktree doctor-c, branch

--- a/proofs/batch2/STATUS.md
+++ b/proofs/batch2/STATUS.md
@@ -1,7 +1,7 @@
 # DOCTOR INCREMENT 78 (deep-rework partition Erdős ≥ 500 / lane2, #38065, 2026-07-15)
 
 Container cpuset 6-11, 11g, cache `lean-mathlib-cache-v431-b`, worktree doctor-b, branch
-`feature/issue-38065-inc78` off origin/feature/issue-37508. **+5 GREEN.**
+`feature/issue-38065-inc78` off origin/feature/issue-37508. **+4 GREEN.**
 Every flip verified in-container `lake env lean Proofs.X` exit-0 before ledger flip; pushed per file.
 
 ## Flips (failure class in parens)

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -1406,7 +1406,7 @@ Erdos556Problem	RESIDUAL	type-mismatch
 Erdos557Problem	RESIDUAL	type-mismatch
 Erdos558Problem	GREEN	
 Erdos559Aristotle	GREEN	
-Erdos559Problem	RESIDUAL	instance-synth
+Erdos559Problem	GREEN	
 Erdos55Problem	GREEN	
 Erdos560Problem	RESIDUAL	elab-drift
 Erdos561Problem	GREEN	

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -1493,7 +1493,7 @@ Erdos623Aristotle	GREEN
 Erdos623Problem	GREEN	
 Erdos623ProblemAristotle	GREEN	
 Erdos625Aristotle	RESIDUAL	instance-synth
-Erdos625Problem	RESIDUAL	instance-synth
+Erdos625Problem	GREEN	
 Erdos625ProblemAristotle	RESIDUAL	instance-synth
 Erdos626Aristotle	GREEN	
 Erdos626Problem	GREEN	

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -703,7 +703,7 @@ Erdos1033Problem	RESIDUAL	unknown-const:fan_lower
 Erdos1034Aristotle	GREEN	
 Erdos1034OQ02	GREEN	
 Erdos1034Problem	GREEN	doctor-inc65
-Erdos1035Problem	RESIDUAL	instance-synth
+Erdos1035Problem	GREEN	
 Erdos1036OQ01	GREEN	
 Erdos1036OQ01OQ01	GREEN	
 Erdos1036Problem	GREEN	

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -1653,7 +1653,7 @@ Erdos747Problem	GREEN
 Erdos749Problem	RESIDUAL	unknown-const:le_liminf_of_le
 Erdos74Problem	GREEN	
 Erdos750Problem	GREEN	
-Erdos751Problem	RESIDUAL	type-mismatch
+Erdos751Problem	GREEN	
 Erdos752Problem	RESIDUAL	instance-synth
 Erdos753Problem	GREEN	
 Erdos754Problem	GREEN	


### PR DESCRIPTION
Doctor lane 2 (partition Erdős ≥ 500) burning down the v4.31 residual ledger. **+4 GREEN**, each verified in-container (`lake env lean Proofs.X` EXIT=0, cpuset 6-11, cache `lean-mathlib-cache-v431-b`) before flipping its ledger row; pushed per file.

## Files flipped RESIDUAL → GREEN
- `Erdos1035Problem` (instance-synth) — big-operator `∑ … = ∑ …` greedy-parse (parenthesize sums); `Bool.true_xor`→`Bool.xor_true`; `Nat.testBit_two_pow_of_ne` needs `Ne.symm`; `Fin.mk.injEq` needs `ne_eq` + result `.symm`; `if false = true` reduced for omega.
- `Erdos625Problem` (instance-synth) — typed the `AlmostSurely` placeholder (`ε : ℝ`, `N : ℕ`); ℝ-coercion inside `|·|` (ℕ has no `AddGroup`); **statement repair** in `problem_status` (proof term used as `→`-hypothesis → use the statement; annotate unconstrained `∀ n G` binders). Pre-existing survey `sorry`s kept.
- `Erdos559Problem` (elab-drift) — `[LinearOrder V]` for `p.1 < p.2` in `edgeCount`/`IsTree`/`IsCycle` (concrete callers use `Fin n`); explicit 4th `inferInstance` field for `FiniteGraph.mk` default; corrected `Nat.find` witness graph type (`FiniteGraph (Fin m)`).
- `Erdos751Problem` (instance-synth) — `min'`/`max'` of `image G.degree`: wrap `(fun v => G.degree v)`, add `[DecidableRel G.Adj]`, add `[Nonempty V]` for the nonempty obligation.

## New systematic seams (rename-map candidates)
- **`∑ x ∈ s, f` / `∏` now bind greedily over a trailing `= …`/`≤ …`** — parenthesize each big-operator term in `have h : ∑… = ∑… := …`.
- `Bool.true_xor` vs `Bool.xor_true` (literal side depends on `testBit_two_pow_self`).
- **Anonymous `⟨…⟩` no longer auto-fills default-valued structure fields** — supply every explicit field.
- **min-over-ℕ family:** `Finset.inf`/ℕ wants `OrderTop ℕ` (absent); `min'`/`max'` want `[Nonempty V]`; `SimpleGraph.degree` needs `[DecidableRel G.Adj]` before use in `Finset.image`.

## Statement repairs (#38611 re-audit candidates)
- `Erdos625Problem.problem_status` — restated a type-incorrect hypothesis (not a soundness change; proof is pre-existing `sorry`).
- `Erdos807Problem.erw_conjecture_false` (**deferred, not flipped**) — with placeholder `ERW_conjecture := True`, `¬∀ n, True` is genuinely false and `trivial` can't close `⊢ False`; needs real formalization.

## Notes / next leads
- Built `Erdos1007Problem.olean` (green parent) into the lane cache. `Erdos1014Problem` (21 err) is the real cascade hub — fixing it unmasks pure missing-olean children `Erdos1014OQ02` + `Erdos1014OQ03Concrete`.
- Cheap-ish next: `Erdos803Problem` (same min'/Nonempty shape), `Erdos556Problem` (has an unsound `cycleGraph` loopless edge case at n=1 + a `by trivial` Ramsey existence — #38611 candidate).

Full per-file seam notes in `proofs/batch2/STATUS.md` (increment 78). Do not merge — orchestrator merges.