### PR TITLE
migrate(v4.31): Doctor increment — partition Erdos<500 (+5 GREEN)

### DIFF
--- a/proofs/Proofs/Erdos203Problem.lean
+++ b/proofs/Proofs/Erdos203Problem.lean
@@ -86,12 +86,12 @@ private lemma dvd_of_pow2_mod_eq {p m k r : ℕ}
     (hmod : 2 ^ k % p = 2 ^ r % p)
     (hdvd : p ∣ (2 ^ r * m + 1)) : p ∣ (2 ^ k * m + 1) := by
   obtain ⟨c, hc⟩ := hdvd
+  have hmul : (2 ^ k * m) % p = (2 ^ r * m) % p := by
+    rw [Nat.mul_mod, hmod, ← Nat.mul_mod]
+  have h : (2 ^ k * m + 1) % p = (2 ^ r * m + 1) % p := by
+    rw [Nat.add_mod, hmul, ← Nat.add_mod]
   apply Nat.dvd_of_mod_eq_zero
-  calc (2 ^ k * m + 1) % p
-      = ((2 ^ k % p) * (m % p) + 1 % p) % p := by rw [Nat.add_mod, Nat.mul_mod]
-    _ = ((2 ^ r % p) * (m % p) + 1 % p) % p := by rw [hmod]
-    _ = (2 ^ r * m + 1) % p := by rw [← Nat.mul_mod, ← Nat.add_mod]
-    _ = 0 := by rw [hc, Nat.mul_mod_right]
+  rw [h, hc, Nat.mul_mod_right]
 
 /-- For each residue r < 36, a covering prime ≤ 73 divides 2^r * 78557 + 1. -/
 private lemma covering_prime (r : ℕ) (hr : r < 36) :
@@ -114,8 +114,10 @@ theorem selfridge_sierpinski_is_sierpinski : IsSierpinskiNumber selfridge_sierpi
   intro hprime
   have hpn := hprime.eq_one_or_self_of_dvd p hdvd
   have hlt := hp_prime.one_lt
-  have hge : 78558 ≤ 2 ^ k * 78557 + 1 := by
-    nlinarith [Nat.one_le_pow k 2 (by omega)]
+  have hge : 78558 ≤ 2 ^ k * selfridge_sierpinski + 1 := by
+    have hpow : (1 : ℕ) ≤ 2 ^ k := Nat.one_le_pow k 2 (by omega)
+    simp only [selfridge_sierpinski]
+    nlinarith [hpow]
   rcases hpn with rfl | rfl <;> omega
 
 -- Sierpinski numbers exist (consequence of the above)
@@ -363,15 +365,19 @@ def IsGeneralizedAvoiding (primes : List ℕ) (m : ℕ) : Prop :=
 theorem candidate_mono_k (m k₁ k₂ l : ℕ) (h : k₁ ≤ k₂) :
     candidateNumber m k₁ l ≤ candidateNumber m k₂ l := by
   unfold candidateNumber
-  have : 2 ^ k₁ ≤ 2 ^ k₂ := Nat.pow_le_pow_right (by omega) h
-  nlinarith [Nat.one_le_pow l 3 (by omega)]
+  have hp : 2 ^ k₁ ≤ 2 ^ k₂ := Nat.pow_le_pow_right (by omega) h
+  have h1 : 2 ^ k₁ * 3 ^ l ≤ 2 ^ k₂ * 3 ^ l := mul_le_mul_right' hp (3 ^ l)
+  have h2 : 2 ^ k₁ * 3 ^ l * m ≤ 2 ^ k₂ * 3 ^ l * m := mul_le_mul_right' h1 m
+  omega
 
 -- candidateNumber with larger l is at least as large
 theorem candidate_mono_l (m k l₁ l₂ : ℕ) (h : l₁ ≤ l₂) :
     candidateNumber m k l₁ ≤ candidateNumber m k l₂ := by
   unfold candidateNumber
-  have : 3 ^ l₁ ≤ 3 ^ l₂ := Nat.pow_le_pow_right (by omega) h
-  nlinarith [Nat.one_le_pow k 2 (by omega)]
+  have hp : 3 ^ l₁ ≤ 3 ^ l₂ := Nat.pow_le_pow_right (by omega) h
+  have h1 : 2 ^ k * 3 ^ l₁ ≤ 2 ^ k * 3 ^ l₂ := mul_le_mul_left' hp (2 ^ k)
+  have h2 : 2 ^ k * 3 ^ l₁ * m ≤ 2 ^ k * 3 ^ l₂ * m := mul_le_mul_right' h1 m
+  omega
 
 /- Part 10: Problem Status
 

--- a/proofs/Proofs/Erdos27Problem.lean
+++ b/proofs/Proofs/Erdos27Problem.lean
@@ -110,7 +110,7 @@ theorem perfect_is_zero_almost (S : CongruenceSystem) (h : IsPerfectCovering S) 
   have htend : Tendsto (fun M => uncoveredDensity S M) atTop (nhds 0) :=
     tendsto_const_nhds.congr'
       ((Filter.eventually_ge_atTop 1).mono fun M hM => (hdens M hM).symm)
-  linarith [htend.liminf_eq]
+  exact le_of_eq htend.liminf_eq
 
 /- ## Part IV: Bounded Moduli Systems -/
 
@@ -128,7 +128,7 @@ def HasModuliInCRange (S : CongruenceSystem) (N : ℕ) (C : ℝ) : Prop :=
     This is the "averaging argument" lower bound: choosing residues uniformly at
     random, the expected fraction of uncovered integers equals this product. -/
 noncomputable def naturalDensity (m₁ m₂ : ℕ) : ℝ :=
-  ∏ m ∈ (Finset.range (m₂ - m₁ + 1)).map ⟨(· + m₁), by intro; omega⟩,
+  ∏ m ∈ (Finset.range (m₂ - m₁ + 1)).map ⟨(· + m₁), add_left_injective m₁⟩,
     (1 - 1 / (m : ℝ))
 
 /-- Telescoping product: ∏_{n=2}^{k} (1 - 1/n) = 1/k.
@@ -150,10 +150,14 @@ private lemma naturalDensity_eq_inv : ∀ n : ℕ, n ≥ 2 → naturalDensity 2 
       simp only [naturalDensity]
       have hrng : m + 1 - 2 + 1 = (m - 2 + 1) + 1 := by omega
       rw [hrng, Finset.range_add_one, Finset.map_insert, Finset.prod_insert]
-      · rw [show m - 2 + 1 + 2 = m + 1 from by omega]
-        simp only [← naturalDensity, ihm]
-        have hm_pos : (0 : ℝ) < m := by exact_mod_cast Nat.lt_of_lt_pred (by omega)
-        have hm1_pos : (0 : ℝ) < m + 1 := by exact_mod_cast Nat.succ_pos m
+      · simp only [Function.Embedding.coeFn_mk]
+        rw [show m - 2 + 1 + 2 = m + 1 from by omega]
+        have hfold : (∏ x ∈ Finset.map ⟨(· + 2), add_left_injective 2⟩ (Finset.range (m - 2 + 1)),
+            (1 - 1 / (x : ℝ))) = naturalDensity 2 m := rfl
+        rw [hfold, ihm]
+        have hm_ne : (m : ℝ) ≠ 0 := by exact_mod_cast (show m ≠ 0 by omega)
+        have hm1_ne : ((m : ℝ) + 1) ≠ 0 := by positivity
+        push_cast
         field_simp
         ring
       · simp only [Finset.mem_map, Finset.mem_range, Function.Embedding.coeFn_mk]
@@ -168,15 +172,15 @@ theorem naturalDensity_vanishes :
   obtain ⟨N, hN⟩ := exists_nat_gt (1 / ε)
   use max 2 N
   rw [naturalDensity_eq_inv (max 2 N) (le_max_left 2 N)]
-  have hmax_pos : (0 : ℝ) < (max 2 N : ℝ) :=
-    by exact_mod_cast Nat.lt_of_lt_of_le (by norm_num) (le_max_left 2 N)
-  rw [div_lt_iff₀ hmax_pos, one_mul]
-  calc (1 : ℝ) < 1 / ε * ε := by rw [div_mul_cancel₀ 1 (ne_of_gt hε)]
-    _ = ε * (1 / ε) := by ring
-    _ ≤ ε * N := by
-        exact mul_le_mul_of_nonneg_left (by exact_mod_cast le_of_lt hN) (le_of_lt hε)
-    _ ≤ ε * (max 2 N : ℝ) := by
-        exact mul_le_mul_of_nonneg_left (by exact_mod_cast le_max_right 2 N) (le_of_lt hε)
+  set K : ℕ := max 2 N with hK
+  have hmax_pos : (0 : ℝ) < (K : ℝ) := by
+    have hpos : 0 < K := by rw [hK]; exact Nat.lt_of_lt_of_le (by norm_num) (le_max_left 2 N)
+    exact_mod_cast hpos
+  rw [div_lt_iff₀ hmax_pos]
+  have hNK : (N : ℝ) ≤ (K : ℝ) := by rw [hK]; exact_mod_cast le_max_right 2 N
+  calc (1 : ℝ) = ε * (1 / ε) := by rw [mul_one_div, div_self (ne_of_gt hε)]
+    _ < ε * (N : ℝ) := mul_lt_mul_of_pos_left hN hε
+    _ ≤ ε * (K : ℝ) := mul_le_mul_of_nonneg_left hNK (le_of_lt hε)
 
 /- ## Part VI: The Main Question -/
 

--- a/proofs/Proofs/Erdos301Problem.lean
+++ b/proofs/Proofs/Erdos301Problem.lean
@@ -70,19 +70,23 @@ theorem halfInterval_egyptFree (N : ℕ) :
       exact_mod_cast show 0 < b by have := (hb_info b (mem_singleton.mpr rfl)).1; omega
     rw [div_eq_div_iff hb_pos.ne' ha_pos.ne'] at hBsum
     simp only [one_mul] at hBsum
-    exact haB (mem_singleton.mpr (by exact_mod_cast hBsum.symm))
+    exact haB (mem_singleton.mpr (by exact_mod_cast hBsum))
   · -- |B| ≥ 2: sum ≥ 2/N > 1/a
     have hcard : 2 ≤ B.card := by
       rcases B.eq_empty_or_nonempty with rfl | hne
-      · exact absurd (Finset.not_nonempty_empty) (not_not.mpr hBne) |>.elim
-      · omega
+      · exact absurd (Finset.not_nonempty_empty) (not_not.mpr hBne)
+      · have hpos := Finset.Nonempty.card_pos hne; omega
     -- Each 1/b ≥ 1/N (since b ≤ N)
     have hsum_lower : (B.card : ℚ) / N ≤ B.sum (fun b => (1 : ℚ) / b) := by
-      rw [div_eq_inv_mul, ← Finset.sum_const]
+      have hrw : (B.card : ℚ) / N = ∑ _b ∈ B, (1 : ℚ) / N := by
+        rw [Finset.sum_const, nsmul_eq_mul]; ring
+      rw [hrw]
       exact Finset.sum_le_sum (fun b hb => by
+        have hbpos : (0 : ℚ) < b := by
+          exact_mod_cast show 0 < b by have := (hb_info b hb).1; omega
+        have hbN : (b : ℚ) ≤ N := by exact_mod_cast (hb_info b hb).2
         rw [one_div, one_div]
-        exact inv_anti₀ (by exact_mod_cast (hb_info b hb).2) (by exact_mod_cast show 0 < b by
-          have := (hb_info b hb).1; omega))
+        exact inv_anti₀ hbpos hbN)
     -- sum ≥ 2/N
     have hsum_ge : 2 / (N : ℚ) ≤ B.sum (fun b => (1 : ℚ) / b) := by
       calc (2 : ℚ) / N ≤ B.card / N := by

--- a/proofs/Proofs/Erdos3LogHarmonic.lean
+++ b/proofs/Proofs/Erdos3LogHarmonic.lean
@@ -277,11 +277,13 @@ theorem summable_one_div_nat_mul_log_mul_const {c δ : ℝ} (hc : 0 < c) (hδ : 
   have hc2 : (0 : ℝ) < c ^ 2 := by positivity
   -- threshold `N₀` above `2`, `2/c` and `1/c²` (so `m·c ≥ 2` and `m·c² ≥ 1` on the tail)
   set N₀ : ℕ := max 2 (⌈2 / c⌉₊ + ⌈1 / c ^ 2⌉₊) with hN₀def
-  have hN₀2 : (2 : ℝ) ≤ (N₀ : ℝ) := by exact_mod_cast le_max_left 2 (⌈2 / c⌉₊ + ⌈1 / c ^ 2⌉₊)
-  have hN₀2c : 2 / c ≤ (N₀ : ℝ) :=
-    le_trans (Nat.le_ceil _) (by exact_mod_cast le_trans (Nat.le_add_right _ _) (le_max_right 2 (⌈2 / c⌉₊ + ⌈1 / c ^ 2⌉₊)))
-  have hN₀c2 : 1 / c ^ 2 ≤ (N₀ : ℝ) :=
-    le_trans (Nat.le_ceil _) (by exact_mod_cast le_trans (Nat.le_add_left _ _) (le_max_right 2 (⌈2 / c⌉₊ + ⌈1 / c ^ 2⌉₊)))
+  have hN₀2 : (2 : ℝ) ≤ (N₀ : ℝ) := by rw [hN₀def]; exact_mod_cast le_max_left 2 _
+  have hN₀2c : 2 / c ≤ (N₀ : ℝ) := by
+    rw [hN₀def]
+    exact le_trans (Nat.le_ceil _) (by exact_mod_cast le_trans (Nat.le_add_right _ _) (le_max_right 2 _))
+  have hN₀c2 : 1 / c ^ 2 ≤ (N₀ : ℝ) := by
+    rw [hN₀def]
+    exact le_trans (Nat.le_ceil _) (by exact_mod_cast le_trans (Nat.le_add_left _ _) (le_max_right 2 _))
   -- dominating series: the constant-free convergent series, shifted and scaled by `2^{1+δ}`
   have hbase : Summable (fun n : ℕ => 1 / ((n : ℝ) * (Real.log n) ^ (1 + δ))) :=
     summable_one_div_nat_mul_log_rpow hδ
@@ -346,13 +348,13 @@ theorem not_summable_one_div_nat_mul_log_mul_const {c : ℝ} (hc : 0 < c) :
   intro hsum
   -- threshold `N₀ ≥ 2`, `≥ c`, `≥ 2/c` (so `m ≥ 2`, `c ≤ m`, `m·c ≥ 2` on the tail)
   set N₀ : ℕ := max 2 (⌈c⌉₊ + ⌈2 / c⌉₊) with hN₀def
-  have hN₀2 : (2 : ℝ) ≤ (N₀ : ℝ) := by exact_mod_cast le_max_left 2 (⌈c⌉₊ + ⌈2 / c⌉₊)
-  have hN₀c : c ≤ (N₀ : ℝ) :=
-    le_trans (Nat.le_ceil _) (by exact_mod_cast le_trans (Nat.le_add_right _ _)
-      (le_max_right 2 (⌈c⌉₊ + ⌈2 / c⌉₊)))
-  have hN₀2c : 2 / c ≤ (N₀ : ℝ) :=
-    le_trans (Nat.le_ceil _) (by exact_mod_cast le_trans (Nat.le_add_left _ _)
-      (le_max_right 2 (⌈c⌉₊ + ⌈2 / c⌉₊)))
+  have hN₀2 : (2 : ℝ) ≤ (N₀ : ℝ) := by rw [hN₀def]; exact_mod_cast le_max_left 2 _
+  have hN₀c : c ≤ (N₀ : ℝ) := by
+    rw [hN₀def]
+    exact le_trans (Nat.le_ceil _) (by exact_mod_cast le_trans (Nat.le_add_right _ _) (le_max_right 2 _))
+  have hN₀2c : 2 / c ≤ (N₀ : ℝ) := by
+    rw [hN₀def]
+    exact le_trans (Nat.le_ceil _) (by exact_mod_cast le_trans (Nat.le_add_left _ _) (le_max_right 2 _))
   -- the given series, shifted past the threshold and scaled by `2`, dominates `1/(n·log n)`
   have hdom : Summable (fun n : ℕ => (2 : ℝ) *
       (1 / (((n + N₀ : ℕ) : ℝ) * Real.log (((n + N₀ : ℕ) : ℝ) * c)))) :=

--- a/proofs/Proofs/Erdos407Problem.lean
+++ b/proofs/Proofs/Erdos407Problem.lean
@@ -84,8 +84,8 @@ w(n) = number of tuples (a, b, c, d) with n = 2^a + 3^b + 2^c·3^d.
 Note: This counts all tuples, not just distinct sums.
 -/
 noncomputable def w (n : ℕ) : ℕ :=
-  Finset.card {x : ℕ × ℕ × ℕ × ℕ | x.1 ≤ n ∧ x.2.1 ≤ n ∧ x.2.2.1 ≤ n ∧ x.2.2.2 ≤ n ∧
-    IsValidRep n x.1 x.2.1 x.2.2.1 x.2.2.2}.toFinset
+  {x : ℕ × ℕ × ℕ × ℕ | x.1 ≤ n ∧ x.2.1 ≤ n ∧ x.2.2.1 ≤ n ∧ x.2.2.2 ≤ n ∧
+    IsValidRep n x.1 x.2.1 x.2.2.1 x.2.2.2}.ncard
 
 /--
 **Alternative: Distinct Representations**
@@ -114,7 +114,7 @@ theorem w_one_zero : ∀ a b c d : ℕ, ¬IsValidRep 1 a b c d := by
   have h3 : 2 ^ c * 3 ^ d ≥ 1 := by
     have hc : 2 ^ c ≥ 1 := Nat.one_le_pow c 2 (by norm_num)
     have hd : 3 ^ d ≥ 1 := Nat.one_le_pow d 3 (by norm_num)
-    exact Nat.one_le_mul hc hd
+    exact Nat.mul_pos hc hd
   omega
 
 /--

--- a/proofs/batch2/STATUS.md
+++ b/proofs/batch2/STATUS.md
@@ -1,3 +1,87 @@
+# DOCTOR INCREMENT 77 (deep-rework partition Erdos<500 / lane1, #38065, 2026-07-15)
+
+Container cpuset 0-5, 11g, cache `lean-mathlib-cache-v431`, worktree issue-38065, branch
+`feature/issue-38065-inc77` off origin/feature/issue-37508. **+5 GREEN.**
+Every flip verified in-container `lake env lean Proofs.X` exit-0 before ledger flip; pushed per file.
+
+## Flips (failure class in parens)
+- **Erdos301Problem** (parse-error→proof-drift): (1) `by_cases`-neg branch omega for `2 ≤ #B`
+  needed `have hpos := Finset.Nonempty.card_pos hne` (omega no longer picks up nonempty→card_pos).
+  (2) `absurd h hn |>.elim` → drop `.elim` (`absurd` already returns any type). (3) sum-lower
+  rewrite `rw [div_eq_inv_mul, ← Finset.sum_const]` no longer matched (nsmul vs mul) → replaced
+  with `have hrw : #B/N = ∑ _∈B, 1/N := by rw [Finset.sum_const, nsmul_eq_mul]; ring` then
+  `Finset.sum_le_sum`. (4) `inv_anti₀` arg types must be pinned first (`have hbpos`/`hbN` before
+  the `exact`, else the ℕ/ℝ metavar defaults wrong). (5) singleton branch `exact_mod_cast hBsum.symm`
+  → drop `.symm` (cast produced `b=a`, needed `a=b`).
+- **Erdos3LogHarmonic** (parse-error/mod_cast): `set N₀ := max 2 (…) with hN₀def` makes N₀ opaque,
+  so `exact_mod_cast le_max_left 2 …` fails to unify `↑N₀` with `max …`. Fix: `rw [hN₀def]` first,
+  then cast. **Also: re-typing the max's argument `⌈1/c^2⌉₊` picks up rpow `c^(2:ℝ)` (mismatch with
+  the def's npow `c^(2:ℕ)`)** — use `le_max_left 2 _` / `le_max_right 2 _` (underscore) so it unifies
+  against the goal's correct powers. (Cascades to **Erdos3Problem** import; that file has its own
+  residual errors — see leads.)
+- **Erdos407Problem** (proof-drift): `Nat.one_le_mul` gone → `Nat.mul_pos` (`1≤x` defeq `0<x` in ℕ).
+  **`Set.toFinset` on `{x : ℕ×ℕ×ℕ×ℕ | …bounded…}` fails `Fintype ↥S` synth** (ambient infinite);
+  since `w` is `noncomputable` and only used in abstract `w n ≤ C` bounds, switched
+  `Finset.card {…}.toFinset` → `{…}.ncard` (Set.ncard needs no Fintype).
+- **Erdos203Problem** (rewrite-drift): (1) mod-arith calc `rw [Nat.add_mod, Nat.mul_mod]` left an
+  extra inner `%p` → rebuilt as two `have`s (`hmul` via `Nat.mul_mod,hmod,←Nat.mul_mod`, then
+  `Nat.add_mod,hmul,←Nat.add_mod`). (2) pow-monotone products: `nlinarith` couldn't derive
+  `2^k₁·3^l·m ≤ 2^k₂·3^l·m` from `2^k₁≤2^k₂` → chain `mul_le_mul_right'`/`mul_le_mul_left'` then
+  omega. (3) **omega def-unfold seam:** after `rcases … with rfl`, `p` carries def
+  `selfridge_sierpinski` but the helper bound `hge` used literal `78557`; omega no longer unfolds
+  the def so the `2^k*_` atoms didn't match → restated `hge` in terms of `selfridge_sierpinski`
+  (`simp only [selfridge_sierpinski]; nlinarith`).
+- **Erdos27Problem** (rewrite-drift): (1) `linarith [htend.liminf_eq]` couldn't equate
+  `asymptoticUncoveredDensity S` (a `liminf` def) with the hint's `liminf …` atom → `exact
+  le_of_eq htend.liminf_eq` (defeq). (2) Finset.map embedding `⟨(·+m₁), by intro; omega⟩`: bare
+  `intro` no longer intros all Injective binders → `add_left_injective m₁`. (3) once the def
+  elaborated, `Finset.map_insert` leaves the embedding **unreduced** `{toFun:=…} y` → prepend
+  `simp only [Function.Embedding.coeFn_mk]` before the `rw [show …]`. (4) `simp only [← naturalDensity]`
+  rejected (can't reverse-unfold a def) → fold via explicit `have hfold : (∏ …) = naturalDensity 2 m
+  := rfl; rw [hfold, ihm]`. (5) `(max 2 N : ℝ)` ascription elaborates to **real-max** `max 2 ↑N`,
+  mismatching the goal's **cast-of-nat-max** `↑(max 2 N)` → `set K : ℕ := max 2 N` unifies both.
+  (6) a broken calc (`1 < 1/ε*ε` is `1<1`; old `div_mul_cancel₀` drift) rebuilt as
+  `1 = ε*(1/ε) < ε*↑N ≤ ε*↑K`. Earlier `sorry` warnings were cascade artifacts of the broken def;
+  final file is genuinely sorry-free.
+
+## New systematic seams (rename-map candidates)
+1. **`set x := <expr> with h` makes `x` opaque to `omega`/`exact_mod_cast`/`simp` unfolding** — when
+   a later tactic needs the body, `rw [h]` first. (Seen twice: Erdos301 sum, Erdos3LogHarmonic N₀,
+   Erdos27 K.) Corollary: `omega` no longer unfolds plain `def`s (Erdos203 `selfridge_sierpinski`).
+2. **Numeric-literal power under a type ascription flips npow↔rpow:** `⌈1/c^2⌉₊` re-typed inside a
+   proof elaborates `c^(2:ℝ)`; leave the argument as `_` to unify against the goal's `c^(2:ℕ)`.
+3. **`Set.toFinset` needs `Fintype ↥S`** which is unsynthesizable for bounded subsets of infinite
+   types → for `noncomputable` counts used only in abstract bounds, use **`Set.ncard`**.
+4. **`Nat.one_le_mul` removed → `Nat.mul_pos`** (`1≤·` defeq `0<·` in ℕ).
+5. **`Finset.map`/`Finset.map_insert` leave the `Function.Embedding` application unreduced** — add
+   `simp only [Function.Embedding.coeFn_mk]` to beta-reduce before matching `f a` patterns.
+6. **`simp only [← <def>]` is rejected** (a def name can only be unfolded forward) → fold via a
+   local `have : … = <def> … := rfl; rw [this]`.
+7. **`absurd h hn |>.elim`** — drop the `.elim`; `absurd` already yields any goal type.
+8. **`X.symm` where `X : a ∈ l`** resolves to the removed `List.Mem.symm` — use `Ne.symm`/`Eq.symm`
+   explicitly or restructure (seen deferred in Erdos86).
+
+## Statement repairs (for #38611)
+- None this increment (no false-as-stated theorems hit; all were genuine v4.31 surface drift).
+
+## Good next leads (lane1, Erdos<500, still RESIDUAL)
+- **Erdos3Problem** (imports Erdos3LogHarmonic — now GREEN, olean built): remaining 4 errors —
+  `522` type-mismatch after simp, `788` typeclass stuck, `840` "no goals", `1225` **unterminated
+  comment** (find the stray `/-`), plus a *pre-existing* `sorry` at 179 (docstring says the
+  implication is not known — keep it).
+- **Erdos86Problem** (parse-error, ~6 err): `List.Mem.symm` gone (L72), `{ … // ∀ [DecidableRel] … }`
+  set-builder `//` parse (L115) — the `f` sSup comprehension needs restated binder syntax, `//` in
+  `{ x | p x // q }` is invalid; `HypercubeSubgraph` synth (L83), linarith L143, rewrite L182.
+- **Erdos20Problem** (2 err): `SunflowerCore := petals.inf id` needs `OrderTop (Finset α)` (only
+  `[DecidableEq α]` in scope, no Fintype) — needs a def redesign (e.g. filter over `petals.sup id`),
+  plus a `not a positivity goal` at L100. Deferred as def-change.
+- **Erdos247Problem** blocked cross-lane on `LiouvilleTheorem.olean` (LiouvilleTheorem is RESIDUAL in
+  another lane) — will cascade GREEN once that lane fixes it.
+- Cheap-ish single/low-blocker rows to try next: Erdos40Problem (5 scattered: omega/positivity/tauto/
+  linarith), Erdos291Problem, Erdos184Problem, Erdos95Problem, Erdos209Problem (all 5 err).
+
+---
+
 # DOCTOR INCREMENT 75 (deep-rework partition non-Erdos A–K / lane3, #38065, 2026-07-15)
 
 Container cpuset 12-17, 11g, cache `lean-mathlib-cache-v431-c`, worktree doctor-c, branch

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -1075,7 +1075,7 @@ Erdos275Problem	RESIDUAL	instance-synth
 Erdos276Problem	GREEN	
 Erdos278Problem	GREEN	
 Erdos279OQ04	RESIDUAL	type-mismatch
-Erdos27Problem	RESIDUAL	rewrite-drift
+Erdos27Problem	GREEN	
 Erdos280Problem	GREEN	
 Erdos281Problem	GREEN	
 Erdos283Problem	GREEN	

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -1000,7 +1000,7 @@ Erdos1OQ04	RESIDUAL	type-mismatch
 Erdos1Wip01	RESIDUAL	type-mismatch
 Erdos201Problem	RESIDUAL	unknown-const:isAPFree_empty
 Erdos202Problem	RESIDUAL	type-mismatch
-Erdos203Problem	RESIDUAL	rewrite-drift
+Erdos203Problem	GREEN	
 Erdos206Problem	GREEN	
 Erdos207Problem	GREEN	
 Erdos207ProblemAristotle	RESIDUAL	rewrite-drift

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -1227,7 +1227,7 @@ Erdos402Problem	RESIDUAL	type-mismatch
 Erdos403Problem	GREEN	
 Erdos404Problem	RESIDUAL	rewrite-drift
 Erdos405Problem	GREEN	
-Erdos407Problem	RESIDUAL	proof-drift
+Erdos407Problem	GREEN	
 Erdos408Problem	GREEN	
 Erdos409Problem	PRE-EXISTING	never-compiled:p
 Erdos40Problem	RESIDUAL	proof-drift

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -1220,7 +1220,7 @@ Erdos396OQ04OQ01OQ01OQ03	GREEN
 Erdos397Problem	GREEN	
 Erdos399Problem	GREEN	
 Erdos39Problem	RESIDUAL	type-mismatch
-Erdos3LogHarmonic	RESIDUAL	parse-error
+Erdos3LogHarmonic	GREEN	
 Erdos3Problem	RESIDUAL	parse-error
 Erdos400Problem	GREEN	
 Erdos402Problem	RESIDUAL	type-mismatch

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -1101,7 +1101,7 @@ Erdos2OQ01	GREEN
 Erdos2OQ01Aristotle	RESIDUAL	proof-drift
 Erdos2Problem	GREEN	
 Erdos300Problem	GREEN	
-Erdos301Problem	RESIDUAL	parse-error
+Erdos301Problem	GREEN	
 Erdos302Aristotle	RESIDUAL	proof-drift
 Erdos302Problem	RESIDUAL	proof-drift
 Erdos304Problem	GREEN	


### PR DESCRIPTION
Doctor lane1 (deep-rework, epic #37508, Lean v4.26→v4.31), partition **RESIDUAL Erdős < 500**.
Container cpuset 0-5, 11g, cache `lean-mathlib-cache-v431`. Each file verified `lake env lean
Proofs.X` exit-0 in-container before flipping its ledger row; pushed per file.

## Flipped RESIDUAL → GREEN (+5)
| File | Class | Key repair |
|------|-------|-----------|
| `Erdos301Problem` | parse/proof-drift | omega+`Finset.Nonempty.card_pos`; drop `.elim` on `absurd`; `sum_const`/`nsmul_eq_mul` sum-lower; pin `inv_anti₀` arg types; drop stale `.symm` |
| `Erdos3LogHarmonic` | parse/mod_cast | `rw [hN₀def]` to un-opaque `set` before cast; `le_max_left/right 2 _` (underscore) to avoid npow↔rpow flip |
| `Erdos407Problem` | proof-drift | `Nat.one_le_mul`→`Nat.mul_pos`; `Set.toFinset`→`Set.ncard` (no Fintype for infinite ambient) |
| `Erdos203Problem` | rewrite-drift | rebuilt mod-arith calc; `mul_le_mul_right'/left'` for pow-monotone products; restate `hge` via def `selfridge_sierpinski` so omega atoms match |
| `Erdos27Problem` | rewrite-drift | `le_of_eq htend.liminf_eq` (defeq); `add_left_injective`; `Embedding.coeFn_mk` beta; `rfl`-fold instead of `simp [← def]`; `set K` to unify real-max vs cast-nat-max; rebuilt broken `1<1/ε*ε` calc |

`Erdos3LogHarmonic`'s fix unblocks the import for `Erdos3Problem` (still RESIDUAL for other reasons).

## New systematic seams (rename-map candidates)
1. `set x := e with h` makes `x` opaque to `omega`/`exact_mod_cast`/`simp` unfolding — `rw [h]` first. `omega` also no longer unfolds plain `def`s.
2. Numeric-literal power under a type ascription can flip npow↔rpow; leave the arg as `_` to unify against the goal.
3. `Set.toFinset` needs `Fintype ↥S` (unsynthesizable for bounded subsets of infinite types) → use `Set.ncard` for noncomputable counts in abstract bounds.
4. `Nat.one_le_mul` removed → `Nat.mul_pos`.
5. `Finset.map`/`map_insert` leave the `Function.Embedding` application unreduced → `simp only [Function.Embedding.coeFn_mk]`.
6. `simp only [← <def>]` rejected → fold via `have : … = <def> … := rfl`.
7. `absurd h hn |>.elim` → drop `.elim`.
8. `X.symm` on `X : a ∈ l` resolves to removed `List.Mem.symm` → use `Ne.symm`/`Eq.symm`.

## Statement repairs (#38611)
None — all were genuine v4.31 surface drift, no false-as-stated theorems.

## Next leads (lane1)
`Erdos3Problem` (import now built; 4 errs incl. unterminated comment at L1225, pre-existing sorry L179 keep), `Erdos86Problem` (`//` set-builder parse + `List.Mem.symm`), `Erdos20Problem` (needs `SunflowerCore` def redesign — no `OrderTop (Finset α)`), `Erdos247Problem` (blocked cross-lane on `LiouvilleTheorem.olean`).

Do not add loom labels (deployer merges math-migration PRs directly).