### PR TITLE
migrate(v4.31): Doctor increment — partition non-Erdos A-K (+4 GREEN)

### DIFF
--- a/proofs/Proofs/BallotProblemOQ01OQ02OQ01.lean
+++ b/proofs/Proofs/BallotProblemOQ01OQ02OQ01.lean
@@ -26,8 +26,11 @@
 -/
 
 import Proofs.BallotProblemOQ01OQ02
+-- v4.31: `Set.ncard_biUnion` was replaced by `Set.Finite.ncard_biUnion`,
+-- which lives in this (newer) module not transitively imported by the parent.
+import Mathlib.Data.Set.Card.Arithmetic
 
-open Ballot ProbabilityTheory Set
+open Ballot ProbabilityTheory Set MultiBallot
 
 namespace BallotFiberTransfer
 
@@ -50,12 +53,13 @@ theorem ncard_biUnion_eq_of_uniform {α ι : Type*}
     (hdisj : ∀ i ∈ I, ∀ j ∈ I, i ≠ j → Disjoint (S i) (S j))
     (k : ℕ) (hk : ∀ i ∈ I, (S i).ncard = k) :
     (⋃ i ∈ I, S i).ncard = k * I.ncard := by
-  rw [Set.ncard_biUnion hI hdisj (fun i hi => hfin i hi)]
+  rw [Set.Finite.ncard_biUnion hI (fun i hi => hfin i hi) hdisj, ← hI.coe_toFinset,
+      finsum_mem_coe_finset]
   -- Goal: ∑ i ∈ hI.toFinset, (S i).ncard = k * I.ncard
   have hmem : ∀ i ∈ hI.toFinset, (S i).ncard = k :=
     fun i hi => hk i (hI.mem_toFinset.mp hi)
   rw [Finset.sum_congr rfl hmem, Finset.sum_const, smul_eq_mul,
-      mul_comm, hI.toFinset_card]
+      mul_comm, Set.ncard_coe_finset]
 
 -- ═══════════════════════════════════════════════════════════════
 -- PART II: FIBER PARTITION PROPERTIES
@@ -114,6 +118,18 @@ end FiberPartition
 -- PART III: THE ENNReal RATIO CANCELLATION
 -- ═══════════════════════════════════════════════════════════════
 
+/-- v4.31: `uniformOn` is `Measure.count[|s]` (a `cond` measure); this expresses
+    its value as the ncard ratio `↑(s ∩ t).ncard / ↑s.ncard` for finite `s`. -/
+lemma uniformOn_eq_ncard_div {α : Type*} [MeasurableSpace α] [MeasurableSingletonClass α]
+    {s t : Set α} (hs : s.Finite) :
+    uniformOn s t = ((s ∩ t).ncard : ENNReal) / s.ncard := by
+  have hst : (s ∩ t).Finite := hs.inter_of_left t
+  rw [uniformOn, ProbabilityTheory.cond_apply hs.measurableSet,
+      MeasureTheory.Measure.count_apply_finite s hs,
+      MeasureTheory.Measure.count_apply_finite _ hst,
+      ← Set.ncard_eq_toFinset_card s hs, ← Set.ncard_eq_toFinset_card _ hst,
+      ENNReal.div_eq_inv_mul]
+
 /-- If both numerator and denominator are k times the respective values,
     the ratio is the same (for k > 0 and finite values). -/
 theorem ENNReal.div_eq_div_of_mul_eq {a b c d : ℕ} {k : ℕ} (hk : 0 < k)
@@ -122,8 +138,8 @@ theorem ENNReal.div_eq_div_of_mul_eq {a b c d : ℕ} {k : ℕ} (hk : 0 < k)
   rw [ha, hb]
   simp only [Nat.cast_mul]
   rw [ENNReal.mul_div_mul_left]
-  · exact ENNReal.natCast_ne_top
-  · exact Nat.cast_ne_zero.mpr (Nat.pos_of_ne_zero (by omega))
+  · exact Nat.cast_ne_zero.mpr hk.ne'
+  · exact ENNReal.natCast_ne_top k
 
 -- ═══════════════════════════════════════════════════════════════
 -- PART IV: MAIN THEOREM
@@ -163,15 +179,15 @@ theorem uniformOn_fiber_transfer' (m : ℕ) (hm : 2 ≤ m) (a b : ℕ)
   have hMCS_ne : (multiCountedSequence m hm1 a b).Nonempty := by
     refine ⟨List.replicate a (leader m hm1) ++ List.replicate b ⟨1, by omega⟩, ?_, ?_⟩
     · simp only [List.count_append, List.count_replicate, leader]
-      have hne : (⟨0, by omega⟩ : Fin m) ≠ ⟨1, by omega⟩ := by
-        intro h; exact absurd (Fin.val_eq_of_eq h) (by omega)
+      have hne : (⟨0, by omega⟩ : Fin m) ≠ ⟨1, by omega⟩ :=
+        Fin.ne_of_val_ne (by norm_num)
       simp [hne]
     · simp
   -- Positive ncard
   have hMCS_pos : 0 < (multiCountedSequence m hm1 a b).ncard :=
-    Set.ncard_pos hMCS_fin ⟨_, hMCS_ne.choose_spec⟩
+    (Set.ncard_pos hMCS_fin).mpr ⟨_, hMCS_ne.choose_spec⟩
   have hCS_pos : 0 < (Ballot.countedSequence a b).ncard :=
-    Set.ncard_pos hCS_fin ⟨_, hCS_ne.choose_spec⟩
+    (Set.ncard_pos hCS_fin).mpr ⟨_, hCS_ne.choose_spec⟩
   -- Reference target and fiber witness
   obtain ⟨t0, ht0⟩ := hCS_ne
   obtain ⟨s0, hs0⟩ := hMCS_ne
@@ -185,8 +201,8 @@ theorem uniformOn_fiber_transfer' (m : ℕ) (hm : 2 ≤ m) (a b : ℕ)
   -- Fiber over t0 is nonempty (since fiber over project(s0) is nonempty)
   set k := (multiProjectionFiber m hm1 a b t0).ncard with hk_def
   have hk_pos : 0 < k := by
-    rw [hk_def, ← fiber_card_uniform m hm a b t0 (project (leader m hm1) s0) ht0 ht1]
-    exact Set.ncard_pos (multiProjectionFiber_finite m hm1 a b _)
+    rw [hk_def, fiber_card_uniform m hm a b t0 (project (leader m hm1) s0) ht0 ht1]
+    exact (Set.ncard_pos (multiProjectionFiber_finite m hm1 a b _)).mpr
       ⟨s0, hs0, rfl⟩
   -- ncard(MCS) = k * ncard(CS)
   have hMCS_ncard : (multiCountedSequence m hm1 a b).ncard =
@@ -212,20 +228,8 @@ theorem uniformOn_fiber_transfer' (m : ℕ) (hm : 2 ≤ m) (a b : ℕ)
       k (fun t ht => hk_uniform t ht.1)
   -- Assemble via ENNReal ratio: simp [uniformOn] gives ncard ratio,
   -- div_eq_div_iff reduces to cross-multiplication, fiber counting closes it.
-  simp only [ProbabilityTheory.uniformOn]
-  rw [ENNReal.div_eq_div_iff
-    (by exact_mod_cast hMCS_pos.ne' :
-      (↑(multiCountedSequence m hm1 a b).ncard : ENNReal) ≠ 0)
-    (ENNReal.natCast_ne_top _)
-    (by exact_mod_cast hCS_pos.ne' :
-      (↑(Ballot.countedSequence a b).ncard : ENNReal) ≠ 0)
-    (ENNReal.natCast_ne_top _)]
-  exact_mod_cast (show
-      (multiCountedSequence m hm1 a b ∩ multiStaysPositive m hm1).ncard *
-        (Ballot.countedSequence a b).ncard =
-      (Ballot.countedSequence a b ∩ Ballot.staysPositive).ncard *
-        (multiCountedSequence m hm1 a b).ncard by
-    rw [hMCS_pos_ncard, hMCS_ncard]; ring)
+  rw [uniformOn_eq_ncard_div hMCS_fin, uniformOn_eq_ncard_div hCS_fin]
+  exact ENNReal.div_eq_div_of_mul_eq hk_pos hMCS_pos_ncard hMCS_ncard hCS_pos
 
 /-! ## Summary
 

--- a/proofs/Proofs/BallotProblemOQ01OQ02OQ01Aristotle.lean
+++ b/proofs/Proofs/BallotProblemOQ01OQ02OQ01Aristotle.lean
@@ -59,7 +59,7 @@ theorem ncard_sum_eq {α ι : Type*}
   have hmem : ∀ i ∈ hI.toFinset, (S i).ncard = k :=
     fun i hi => hk i (hI.mem_toFinset.mp hi)
   rw [Finset.sum_congr rfl hmem, Finset.sum_const, smul_eq_mul,
-      mul_comm, hI.toFinset_card]
+      mul_comm, Set.ncard_eq_toFinset_card I hI]
 
 /-
 TARGET 2 (Mathlib API: Set.ncard_biUnion + uniform sum)
@@ -78,8 +78,12 @@ theorem ncard_biUnion_eq_of_uniform {α ι : Type*}
     (hdisj : ∀ i ∈ I, ∀ j ∈ I, i ≠ j → Disjoint (S i) (S j))
     (k : ℕ) (hk : ∀ i ∈ I, (S i).ncard = k) :
     (⋃ i ∈ I, S i).ncard = k * I.ncard := by
-  rw [Set.ncard_biUnion hI hdisj (fun i hi => hfin i hi)]
-  exact ncard_sum_eq S I hI k hk
+  rw [Set.Finite.ncard_biUnion hI (fun i hi => hfin i hi) hdisj, ← hI.coe_toFinset,
+      finsum_mem_coe_finset]
+  have hmem : ∀ i ∈ hI.toFinset, (S i).ncard = k :=
+    fun i hi => hk i (hI.mem_toFinset.mp hi)
+  rw [Finset.sum_congr rfl hmem, Finset.sum_const, smul_eq_mul, mul_comm,
+      Set.ncard_coe_finset]
 
 /-
 TARGET 3 (ENNReal assembly: uniformOn = condCount = ncard ratio)

--- a/proofs/Proofs/BinomialTheoremOQ02OQ01OQ01OQ02.lean
+++ b/proofs/Proofs/BinomialTheoremOQ02OQ01OQ01OQ02.lean
@@ -153,7 +153,7 @@ private lemma multinomialProb_n1_indicator {α : Type*} [DecidableEq α]
       apply Finset.prod_eq_one
       intro i _
       split_ifs <;> simp [Nat.factorial_zero, Nat.factorial_one]
-    rw [hprod, mul_one] at h
+    rw [hprod, one_mul] at h
     omega
   rw [show (Nat.multinomial s (fun i => if i = j then 1 else 0) : ℝ) = 1 from by
     exact_mod_cast hmulti]
@@ -181,6 +181,7 @@ theorem multinomialEntropy_n1_eq_source {α : Type*} [DecidableEq α]
   simp only [multinomialEntropy]
   congr 1
   -- Reindex piAntidiag s 1 ↔ s via j ↦ δ_j = (fun i => if i = j then 1 else 0)
+  symm
   apply Finset.sum_nbij (fun j => fun i => if i = j then 1 else 0)
   · -- Membership: δ_j ∈ s.piAntidiag 1 for j ∈ s
     intro j hj
@@ -192,34 +193,35 @@ theorem multinomialEntropy_n1_eq_source {α : Type*} [DecidableEq α]
       · exact h ▸ hj
       · simp [h] at hi
   · -- Injectivity: δ_{j₁} = δ_{j₂} → j₁ = j₂
-    intro j1 hj1 j2 hj2 heq
-    have h := congr_fun heq j1
-    simp only [if_pos rfl] at h
-    split_ifs at h with h12
-    · exact h12
-    · exact absurd h one_ne_zero
+    intro j1 _ j2 _ heq
+    by_contra hne
+    have h := congr_fun heq j2
+    dsimp only at h
+    rw [if_neg (fun he : j2 = j1 => hne he.symm), if_pos rfl] at h
+    exact absurd h (by norm_num)
   · -- Surjectivity: every k ∈ piAntidiag s 1 equals some δ_j
     intro k hk
-    rw [Finset.mem_piAntidiag] at hk
+    rw [Finset.mem_coe, Finset.mem_piAntidiag] at hk
     obtain ⟨hksum, hksupp⟩ := hk
+    rw [Set.mem_image]
     -- Find j ∈ s with k j ≥ 1
     have hpos : ∃ j ∈ s, 0 < k j := by
       by_contra h
       push_neg at h
-      have : ∑ i ∈ s, k i = 0 :=
+      have hz : s.sum k = 0 :=
         Finset.sum_eq_zero (fun i hi => Nat.le_zero.mp (h i hi))
-      omega
+      rw [hz] at hksum
+      exact absurd hksum (by norm_num)
     obtain ⟨j, hj, hjpos⟩ := hpos
-    refine ⟨j, hj, funext fun i => ?_⟩
+    refine ⟨j, Finset.mem_coe.mpr hj, funext fun i => ?_⟩
     by_cases h : i = j
-    · -- i = j: show k j = 1
-      subst h
-      simp only [if_pos rfl]
+    · -- i = j: show δ_j i = k i = 1
+      rw [if_pos h, h]
       have hle : k j ≤ 1 :=
-        (Finset.single_le_sum (fun l _ => Nat.zero_le _) _ hj).trans hksum.le
+        (Finset.single_le_sum (fun l _ => Nat.zero_le _) hj).trans hksum.le
       exact (Nat.le_antisymm hle hjpos).symm
     · -- i ≠ j: show k i = 0
-      simp only [h, if_false]
+      rw [if_neg h]
       by_contra hne
       have hkpos : 0 < k i := Nat.pos_of_ne_zero (Ne.symm hne)
       have his : i ∈ s := hksupp i (Ne.symm hne)
@@ -292,7 +294,7 @@ theorem multinomialEntropy_upper_bound {α : Type*} [DecidableEq α]
          else multinomialProb s p n k * Real.log (multinomialProb s p n k)) := by
     intro k _
     by_cases h : multinomialProb s p n k = 0
-    · simp [h]; exact neg_nonpos.mpr (inv_nonneg.mpr (le_of_lt hNR))
+    · simp [h]
     · simp only [h, if_false]
       have hPpos : 0 < multinomialProb s p n k :=
         lt_of_le_of_ne (hPnn k) (Ne.symm h)
@@ -303,7 +305,7 @@ theorem multinomialEntropy_upper_bound {α : Type*} [DecidableEq α]
         rw [Real.log_mul (ne_of_gt hNR) (ne_of_gt hPpos)]; ring]
       rw [show multinomialProb s p n k - (N : ℝ)⁻¹ =
               multinomialProb s p n k * (1 - ((N : ℝ) * multinomialProb s p n k)⁻¹) from by
-        field_simp [hNR.ne', ne_of_gt hPpos]; ring]
+        field_simp [hNR.ne', ne_of_gt hPpos]]
       exact mul_le_mul_of_nonneg_left (log_lb _ hNPpos) (le_of_lt hPpos)
   -- Sum the per-term bounds: ∑(P k - 1/N) ≤ ∑(log N * P k + entropy term)
   have sum_lb : (0 : ℝ) ≤
@@ -313,8 +315,8 @@ theorem multinomialEntropy_upper_bound {α : Type*} [DecidableEq α]
            else multinomialProb s p n k * Real.log (multinomialProb s p n k))) := by
     have hzero : ∑ k ∈ s.piAntidiag n,
         (multinomialProb s p n k - (N : ℝ)⁻¹) = 0 := by
-      rw [Finset.sum_sub_distrib, hPsum, Finset.sum_const, nsmul_eq_mul]
-      field_simp [hNR.ne']
+      rw [Finset.sum_sub_distrib, hPsum, Finset.sum_const, nsmul_eq_mul,
+        mul_inv_cancel₀ hNR.ne', sub_self]
     linarith [Finset.sum_le_sum per_term, hzero.symm.le]
   -- Conclude: H(P) ≤ log N
   -- The sum in sum_lb equals log N + ∑ entropy_term, so 0 ≤ log N + ∑ entropy_term,
@@ -346,9 +348,8 @@ theorem multinomialEntropy_binomial (p : ℝ) (n : ℕ)
   · intro i _
     by_cases hb : i = true
     · simp [hb, hp0]
-    · simp [Bool.not_eq_true.mp hb]; linarith
+    · rw [eq_false_of_ne_true hb]; simp only [Bool.false_eq_true, if_false]; linarith
   · simp [Finset.sum_pair Bool.false_ne_true]
-    ring
 
 -- ============================================================
 -- PART 7: Summary

--- a/proofs/Proofs/DivisibilityBy3OQ03.lean
+++ b/proofs/Proofs/DivisibilityBy3OQ03.lean
@@ -33,14 +33,23 @@ def digitSum (n : ℕ) : ℕ := (Nat.digits 10 n).sum
 
 /-- Sum of digits is at most n for all n. -/
 private theorem digitSum_le_self (n : ℕ) : digitSum n ≤ n := by
-  unfold digitSum
-  rcases le_or_gt 10 n with h | h
-  · exact le_of_lt (Nat.sum_digits_lt n 10 (by omega) h)
-  · interval_cases n <;> native_decide
+  unfold digitSum; exact Nat.digit_sum_le 10 n
 
 /-- digitSum n < n for n ≥ 10. -/
 private theorem digitSum_lt_of_ge_ten (n : ℕ) (h : 10 ≤ n) : digitSum n < n := by
-  unfold digitSum; exact Nat.sum_digits_lt n 10 (by omega) h
+  unfold digitSum
+  -- v4.31: `Nat.sum_digits_lt` was removed; derive strictness from the
+  -- `(p-1)·∑ = n - digitSum` identity (the log-sum is ≥ 1 when n ≥ base).
+  have hle := Nat.digit_sum_le 10 n
+  have key := Nat.sub_one_mul_sum_log_div_pow_eq_sub_sum_digits (p := 10) n
+  have h0 : (0 : ℕ) ∈ Finset.range (Nat.log 10 n).succ :=
+    Finset.mem_range.mpr (Nat.succ_pos _)
+  have hpos : 1 ≤ ∑ i ∈ Finset.range (Nat.log 10 n).succ, n / 10 ^ i.succ := by
+    refine le_trans ?_ (Finset.single_le_sum (f := fun i => n / 10 ^ i.succ)
+      (fun i _ => Nat.zero_le _) h0)
+    simp only [Nat.succ_eq_add_one, zero_add, pow_one]
+    omega
+  omega
 
 /-- The digital root: iterate digit summation until single digit -/
 noncomputable def digitalRoot : ℕ → ℕ
@@ -52,7 +61,7 @@ noncomputable def digitalRoot : ℕ → ℕ
   decreasing_by
     simp_wf
     have h_le := digitSum_le_self (n + 1)
-    exact digitSum_lt_of_ge_ten (n + 1) (by omega)
+    exact Nat.lt_succ_iff.mp (digitSum_lt_of_ge_ten (n + 1) (by omega))
 
 /-
 ## Part II: Closed-Form Formula
@@ -70,7 +79,7 @@ theorem digitalRoot_mod9 (n : ℕ) (hn : n > 0) :
     digitalRootFormula n = if n % 9 = 0 then 9 else n % 9 := by
   unfold digitalRootFormula
   simp only [show n ≠ 0 by omega, ↓reduceIte]
-  omega
+  split_ifs with h <;> omega
 
 /-- Digital root is always 0-9 -/
 theorem digitalRoot_range (n : ℕ) : digitalRootFormula n ≤ 9 := by
@@ -119,14 +128,8 @@ private theorem mod9_pred_eq {n m : ℕ} (hn : 0 < n) (hm : 0 < m)
   set b := (m - 1) % 9 with hb_def
   have ha : a < 9 := Nat.mod_lt _ (by omega)
   have hb : b < 9 := Nat.mod_lt _ (by omega)
-  have h1 : n % 9 = (a + 1) % 9 := by
-    have h := Nat.add_mod (n - 1) 1 9
-    rw [Nat.sub_add_cancel (show 1 ≤ n by omega)] at h
-    simpa using h
-  have h2 : m % 9 = (b + 1) % 9 := by
-    have h := Nat.add_mod (m - 1) 1 9
-    rw [Nat.sub_add_cancel (show 1 ≤ m by omega)] at h
-    simpa using h
+  have h1 : n % 9 = (a + 1) % 9 := by omega
+  have h2 : m % 9 = (b + 1) % 9 := by omega
   have h3 : (a + 1) % 9 = (b + 1) % 9 := by rw [← h1, ← h2]; exact hmod
   interval_cases a <;> interval_cases b <;> omega
 
@@ -152,7 +155,7 @@ theorem digitalRoot_idempotent (n : ℕ) :
   rcases n with _ | n
   · simp [digitalRootFormula]
   · have h : digitalRootFormula (n + 1) ≥ 1 := by
-      unfold digitalRootFormula; simp; omega
+      unfold digitalRootFormula; split <;> omega
     have h9 : digitalRootFormula (n + 1) ≤ 9 := digitalRoot_range (n + 1)
     exact digitalRoot_single _ h h9
 
@@ -211,11 +214,11 @@ theorem digitalRoot_mul (a b : ℕ) :
       _ = (digitalRootFormula a * digitalRootFormula b) % 9 := (Nat.mul_mod _ _ 9).symm
   · constructor
     · intro h
-      rcases mul_eq_zero.mp h with ha | hb
+      rcases Nat.mul_eq_zero.mp h with ha | hb
       · simp [show digitalRootFormula a = 0 from (digitalRootFormula_eq_zero_iff a).mpr ha]
       · simp [show digitalRootFormula b = 0 from (digitalRootFormula_eq_zero_iff b).mpr hb]
     · intro h
-      rcases mul_eq_zero.mp h with ha | hb
+      rcases Nat.mul_eq_zero.mp h with ha | hb
       · simp [(digitalRootFormula_eq_zero_iff a).mp ha]
       · simp [(digitalRootFormula_eq_zero_iff b).mp hb]
 

--- a/proofs/batch2/STATUS.md
+++ b/proofs/batch2/STATUS.md
@@ -1,3 +1,79 @@
+# DOCTOR INCREMENT 79 (deep-rework partition non-Erdos A–K / lane3, wave 2, #38065, 2026-07-15)
+
+Container cpuset 12-17, 11g, cache `lean-mathlib-cache-v431-c`, worktree doctor-c, branch
+`feature/issue-38065-inc79` off origin/feature/issue-37508. **+4 GREEN.**
+Every flip verified in-container `lake env lean Proofs.X` exit-0 before ledger flip; pushed per file.
+(Note: an osxfs mount-cache race can make a freshly-built parent olean read as "does not exist" on
+the next container; warming with `cat .lake/build/lib/lean/Proofs/*.olean >/dev/null` and/or a retry
+clears it — a false EXIT=1, not a real error.)
+
+## Flips (failure class in parens)
+- **BinomialTheoremOQ02OQ01OQ01OQ02** (type-mismatch): built green parent
+  `Proofs.BinomialTheoremOQ02OQ01` into cache first (unmasked the real sites). **`Finset.sum_nbij`
+  now takes `Set.InjOn`/`Set.SurjOn` (was elementwise), and its conclusion is `∑ s = ∑ t` with the
+  map `s→t`** — the reindex here needed a `symm` before `apply` (goal orientation was `∑ t = ∑ s`).
+  SurjOn's membership is in `↑s`/`↑t` coe form → `rw [Finset.mem_coe, Finset.mem_piAntidiag]` and
+  `rw [Set.mem_image]`, and the witness needs `Finset.mem_coe.mpr hj`. **`Nat.multinomial_spec`
+  multiplication order flipped** (`rw [hprod, one_mul]` not `mul_one`). **`subst h` with `h : i = j`
+  now eliminates `j`** (the RHS var), breaking later `k j` refs → use `rw [if_pos h, h]` instead of
+  `subst`. **`Finset.single_le_sum` dropped its explicit index arg** (now implicit `{a}`):
+  `single_le_sum h hj` not `single_le_sum h _ hj`. **`Bool.not_eq_true.mp` → `eq_false_of_ne_true`**.
+- **BallotProblemOQ01OQ02OQ01** (unknown-const:`Set.ncard_biUnion`): the child imports selectively,
+  so first had to build green parent `Proofs.BallotProblemOQ01OQ02` into cache AND add
+  `open MultiBallot` (parent defs `multiCountedSequence`/… are now in that namespace; without it
+  every use reads as autoImplicit "function expected"). **`Set.ncard_biUnion` → `Set.Finite.ncard_biUnion`**
+  (dot-method on `hI : s.Finite`; arg order `(hfin) (hdisj : PairwiseDisjoint)`; result is a **finsum**
+  `∑ᶠ i ∈ t, …` not a Finset sum) — convert with `← hI.coe_toFinset, finsum_mem_coe_finset` then close
+  the toFinset sum with `Set.ncard_coe_finset`. It lives in the NEW module
+  **`Mathlib.Data.Set.Card.Arithmetic`** which the parent didn't transitively import → had to add that
+  import. **`Set.ncard_pos hs` is now an Iff** (`0 < s.ncard ↔ s.Nonempty`) → `(Set.ncard_pos hs).mpr`.
+  **`ProbabilityTheory.uniformOn s` is now `Measure.count[|s]`** (a `cond` measure); `simp only [uniformOn]`
+  no longer yields the ncard ratio → added a local lemma `uniformOn_eq_ncard_div (hs : s.Finite) :
+  uniformOn s t = ↑(s∩t).ncard / ↑s.ncard` via `uniformOn`, `ProbabilityTheory.cond_apply`
+  (was `Measure.cond_apply`), `MeasureTheory.Measure.count_apply_finite`, `Set.ncard_eq_toFinset_card`,
+  `ENNReal.div_eq_inv_mul`. **`ENNReal.mul_div_mul_left` side-goal order swapped** (`≠ 0` then `≠ ⊤`).
+  **`Fin.val_eq_of_eq`-style ne proof → `Fin.ne_of_val_ne (by norm_num)`**. Final cross-mult reuses the
+  file's own `ENNReal.div_eq_div_of_mul_eq` instead of the fragile `ENNReal.div_eq_div_iff` rw.
+- **BallotProblemOQ01OQ02OQ01Aristotle** (unknown-const:`Set.ncard_biUnion`): same `Set.Finite.ncard_biUnion`
+  finsum-conversion fix in the file's own copy of `ncard_biUnion_eq_of_uniform`, plus `hI.toFinset_card`
+  (gone) → `Set.ncard_eq_toFinset_card I hI` in the helper `ncard_sum_eq`.
+- **DivisibilityBy3OQ03** (unknown-const:`Nat.sum_digits_lt`): **`Nat.sum_digits_lt` removed.** For the
+  `≤` use `Nat.digit_sum_le 10 n`; for the strict `digitSum n < n` (n ≥ 10, needed for `digitalRoot`
+  termination) derive it from `Nat.sub_one_mul_sum_log_div_pow_eq_sub_sum_digits (p := 10) n`
+  (the log-sum ≥ 1 via `Finset.single_le_sum` on the i=0 term, then `omega`). Also **`mul_eq_zero.mp`
+  ambiguous** (`Nat.mul_eq_zero` vs `_root_.mul_eq_zero`) → qualify `Nat.mul_eq_zero.mp`; two `simp;omega`
+  / `simpa`-normal-form drifts → `split_ifs/split <;> omega` and `omega` directly; `< n+1` vs `≤ n`
+  defeq gap in `decreasing_by` → `Nat.lt_succ_iff.mp`.
+
+## New systematic seams (rename-map candidates)
+- `Set.ncard_biUnion (hI) (hdisj) (hfin)` → `Set.Finite.ncard_biUnion (hI) (hfin) (hdisj:PairwiseDisjoint)`,
+  result now **finsum**; in module `Mathlib.Data.Set.Card.Arithmetic` (add import if selectively-importing).
+- `Set.ncard_pos hs` : now an **Iff**, add `.mpr`/`.mp`.
+- `ProbabilityTheory.uniformOn s = Measure.count[|s]`; no ncard-ratio simp — use the `cond_apply`/
+  `count_apply_finite` unfolding (see `uniformOn_eq_ncard_div` in BallotProblemOQ01OQ02OQ01).
+- `ProbabilityTheory.cond_apply` (was `Measure.cond_apply`).
+- `Finset.sum_nbij`/`Finset.card_nbij`: InjOn/SurjOn hyps in `↑`-coe form; conclusion `∑ s = ∑ t`.
+- `Finset.single_le_sum`: explicit index arg dropped (implicit `{a}`).
+- `subst h` (h : a = b) eliminates **b** now — avoid when later code names `b`.
+- `Bool.not_eq_true.mp` → `eq_false_of_ne_true`; `Fin.val_eq_of_eq` ne-proof → `Fin.ne_of_val_ne`.
+- `Nat.sum_digits_lt` removed (only `Nat.digit_sum_le` for `≤`).
+- `hI.toFinset_card` / `Finite.toFinset_card` gone → `Set.ncard_eq_toFinset_card I hI` (+ `Set.ncard_coe_finset`).
+
+## Warm leads (next wave, my partition)
+- **BallotProblemOQ01OQ02OQ01OQ02** — reuse `BallotFiberTransfer.uniformOn_eq_ncard_div` +
+  `ENNReal.div_eq_div_of_mul_eq`, `Set.ncard_pos … .mpr`. BUT line 66 `surjOn_fiber_decomp` looks
+  **unsound as stated**: `A = ⋃ t∈T, A ∩ f⁻¹'{t}` needs `MapsTo f A T`, not `SurjOn` (the ⊆ direction
+  is false without it). **Candidate for #38611** (add the missing `MapsTo` hypothesis / thread it from
+  callers). `BallotProblemOQ01OQ02OQ01OQ02OQ01` depends on this one.
+- **BallotProblemOQ01OQ02OQ01OQ01** — mechanical but many small sites: `Set.finite_pair` renamed,
+  `Pairwise (Disjoint on s)` `on`-notation (needs `open Function`?), Finset-vs-Set `biUnion` coe,
+  `PairwiseDisjoint ↑I` vs `I` coe mismatch, plus the standard `Set.Finite.ncard_biUnion` finsum fix.
+- **AbelRuffiniGaloisExtensionsOQ04** (~8 sites) — second-isomorphism / JordanHolderLattice instance:
+  `inclusion_mk` renamed, `QuotientGroup` `inductionOn'` field-notation, several `.right.right`
+  projection type-mismatches, `(H ⊓ K).subgroupOf K` rewrite needs inf-comm. Deep.
+
+---
+
 # DOCTOR INCREMENT 75 (deep-rework partition non-Erdos A–K / lane3, #38065, 2026-07-15)
 
 Container cpuset 12-17, 11g, cache `lean-mathlib-cache-v431-c`, worktree doctor-c, branch

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -153,7 +153,7 @@ ArsinhLogFormulaOQ01OQ01OQ02	GREEN
 BallVolumeSurfaceDuality	GREEN	
 BallotProblem	GREEN	
 BallotProblemOQ01OQ02OQ01	GREEN	
-BallotProblemOQ01OQ02OQ01Aristotle	RESIDUAL	unknown-const:Set.ncard_biUnion
+BallotProblemOQ01OQ02OQ01Aristotle	GREEN	
 BallotProblemOQ01OQ02OQ01OQ01	RESIDUAL	unknown-const:Set.ncard_biUnion
 BallotProblemOQ01OQ02OQ01OQ02	RESIDUAL	unknown-const:Set.ncard_biUnion
 BallotProblemOQ01OQ02OQ01OQ02OQ01	RESIDUAL	unknown-const:Set.ncard_biUnion

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -152,7 +152,7 @@ ArsinhLogFormulaOQ01OQ01OQ01OQ01	GREEN
 ArsinhLogFormulaOQ01OQ01OQ02	GREEN	
 BallVolumeSurfaceDuality	GREEN	
 BallotProblem	GREEN	
-BallotProblemOQ01OQ02OQ01	RESIDUAL	unknown-const:Set.ncard_biUnion
+BallotProblemOQ01OQ02OQ01	GREEN	
 BallotProblemOQ01OQ02OQ01Aristotle	RESIDUAL	unknown-const:Set.ncard_biUnion
 BallotProblemOQ01OQ02OQ01OQ01	RESIDUAL	unknown-const:Set.ncard_biUnion
 BallotProblemOQ01OQ02OQ01OQ02	RESIDUAL	unknown-const:Set.ncard_biUnion

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -230,7 +230,7 @@ BinaryGcdOQ02OQ01	RESIDUAL	unknown-const:a
 BinomialTheorem	GREEN	
 BinomialTheoremOQ01	GREEN	
 BinomialTheoremOQ02OQ01	GREEN
-BinomialTheoremOQ02OQ01OQ01OQ02	RESIDUAL	type-mismatch
+BinomialTheoremOQ02OQ01OQ01OQ02	GREEN	
 BinomialTheoremOQ02OQ01OQ02OQ03	GREEN	
 BinomialTheoremOQ02OQ01OQ03	GREEN	
 BinomialTheoremOQ02OQ01OQ04	GREEN	

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -558,7 +558,7 @@ DissectionOfCubesOQ03OQ02	RESIDUAL	rewrite-drift
 DissectionOfCubesOQ04	RESIDUAL	type-mismatch
 DissectionOfCubesOQ04Aristotle	RESIDUAL	type-mismatch
 DivisibilityBy3	GREEN	
-DivisibilityBy3OQ03	RESIDUAL	unknown-const:Nat.sum_digits_lt
+DivisibilityBy3OQ03	GREEN	
 DivisibilityBy3OQ03OQ02	GREEN	
 DivisibilityByThreeOQ01OQ02Aristotle	GREEN	
 DivisibilityByThreeOQ02	GREEN	


### PR DESCRIPTION
Doctor lane 3 (wave 2) increment for the v4.26→v4.31 toolchain/Mathlib migration (epic #37508).
Converts 4 RESIDUAL files in the non-Erdős A–K partition to GREEN. Each verified in-container
(`lake env lean Proofs.X`, exit-0) before flipping its ledger row; pushed per file.

## Files flipped RESIDUAL → GREEN
- `BinomialTheoremOQ02OQ01OQ01OQ02` (type-mismatch)
- `BallotProblemOQ01OQ02OQ01` (unknown-const: `Set.ncard_biUnion`)
- `BallotProblemOQ01OQ02OQ01Aristotle` (unknown-const: `Set.ncard_biUnion`)
- `DivisibilityBy3OQ03` (unknown-const: `Nat.sum_digits_lt`)

## Key v4.31 seams repaired (see proofs/batch2/STATUS.md increment 79 for full detail)
- `Set.ncard_biUnion (hI)(hdisj)(hfin)` → `Set.Finite.ncard_biUnion (hI)(hfin)(hdisj:PairwiseDisjoint)`;
  result is now a **finsum** `∑ᶠ` (convert via `← hI.coe_toFinset, finsum_mem_coe_finset`); lemma moved
  to new module `Mathlib.Data.Set.Card.Arithmetic` (added the import to the child).
- `Set.ncard_pos hs` is now an **Iff** → `.mpr`.
- `ProbabilityTheory.uniformOn s` is now `Measure.count[|s]` (a `cond` measure); added a local
  `uniformOn_eq_ncard_div` helper (`cond_apply` + `count_apply_finite` + `ncard_eq_toFinset_card`).
- `ProbabilityTheory.cond_apply` (was `Measure.cond_apply`).
- `Finset.sum_nbij` now uses `Set.InjOn`/`Set.SurjOn` (coe-form membership); conclusion `∑ s = ∑ t`.
- `Finset.single_le_sum` dropped its explicit index arg; `Nat.multinomial_spec` mul-order flipped;
  `subst h` (h : a = b) now eliminates `b`; `Bool.not_eq_true.mp` → `eq_false_of_ne_true`;
  `Fin.val_eq_of_eq` ne-proof → `Fin.ne_of_val_ne`.
- `Nat.sum_digits_lt` removed → `Nat.digit_sum_le` (≤) + strict via
  `Nat.sub_one_mul_sum_log_div_pow_eq_sub_sum_digits`; `mul_eq_zero.mp` ambiguity → `Nat.mul_eq_zero.mp`.
- Cross-file: child files with selective imports needed `open MultiBallot` (parent defs now namespaced)
  and the green parent olean built into cache to unmask real errors.

## Statement-repair candidates (#38611)
- `BallotProblemOQ01OQ02OQ01OQ02` `surjOn_fiber_decomp` appears **unsound as stated**:
  `A = ⋃ t∈T, A ∩ f⁻¹'{t}` requires `MapsTo f A T`, not `SurjOn`. Deferred; flagged for re-audit.

No statement weakenings, no sorries, no new axioms. No loom labels (deployer merges migration PRs).