### PR TITLE
migrate(v4.31): single-proof batch 1 (+6 GREEN)

### DIFF
--- a/proofs/Proofs/Erdos184Problem.lean
+++ b/proofs/Proofs/Erdos184Problem.lean
@@ -154,10 +154,17 @@ axiom lower_bound_from_bipartite :
 **The Iterated Logarithm:**
 log* n = 0 if n ≤ 1, else 1 + log*(log n)
 -/
-noncomputable def logStar : ℕ → ℕ
+def logStar : ℕ → ℕ
   | 0 => 0
   | 1 => 0
   | n + 2 => 1 + logStar (Nat.log2 (n + 2))
+  termination_by n => n
+  decreasing_by
+    simp_wf
+    have h : (n + 2).log2 < n + 2 := by
+      rw [Nat.log2_lt (by omega)]
+      exact Nat.lt_two_pow_self
+    omega
 
 /--
 **Bucić-Montgomery (2022):**
@@ -176,7 +183,9 @@ axiom bucic_montgomery_bound :
 **Minimum Degree:**
 -/
 noncomputable def minDegree (G : Graph V) : ℕ :=
-  (Finset.univ.image (fun v => G.degree v)).min' (by simp [Finset.image_nonempty])
+  if h : (Finset.univ.image (fun v => G.degree v)).Nonempty then
+    (Finset.univ.image (fun v => G.degree v)).min' h
+  else 0
 
 /--
 **Conlon-Fox-Sudakov (2014):**

--- a/proofs/Proofs/Erdos3Problem.lean
+++ b/proofs/Proofs/Erdos3Problem.lean
@@ -519,7 +519,7 @@ theorem summable_of_strongBound {A : Set ℕ} {C δ : ℝ} (hδ : 0 < δ) (hC : 
       have h1' := (summable_nat_add_iff 1).mpr h1
       simpa using h1'
     rw [hgdef]
-    simpa [mul_one_div] using h2.mul_left K
+    simpa [div_eq_mul_inv] using h2.mul_left K
   -- Threshold beyond which the counting bound holds.
   obtain ⟨N0, hN0⟩ := eventually_atTop.1 hbound
   -- Dyadic block masses.
@@ -785,7 +785,7 @@ theorem summable_of_sharpBound {A : Set ℕ} {C δ : ℝ} (hδ : 0 < δ) (hC : 0
   -- Strong bound: for j ≥ Nthr, block mass ≤ g j.
   have hstrong : ∀ j, Nthr ≤ j → block j ≤ g j := by
     intro j hj
-    have hgj : g j = full j := by rw [hgdef]; exact Set.indicator_of_mem hj
+    have hgj : g j = full j := by rw [hgdef]; exact Set.indicator_of_mem hj full
     rw [hgj]
     have hbe : block j
         = ∑ i ∈ (Finset.Ico (2 ^ j) (2 ^ (j + 1))).filter (· ∈ A), F i := by
@@ -837,7 +837,6 @@ theorem summable_of_sharpBound {A : Set ℕ} {C δ : ℝ} (hδ : 0 < δ) (hC : 0
           have hpw : (Real.log (((j : ℝ) + 1) * Real.log 2)) ^ (1 + δ) ≠ 0 :=
             ne_of_gt (Real.rpow_pos_of_pos hlp _)
           field_simp
-          ring
   -- Combine into a uniform partial-sum bound and conclude summability.
   have hcombine : ∀ j, block j ≤ (if j < Nthr then (1 : ℝ) else 0) + g j := by
     intro j
@@ -921,8 +920,6 @@ theorem sharp_required_bound_implies_conjecture :
           exact_mod_cast countingFunction_le_rothNumber A (max k 3) N hApf
       _ ≤ C * (N : ℝ) / (Real.log N * (Real.log (Real.log N)) ^ (1 + δ)) := hN
   exact hdiv (summable_of_sharpBound hδ hC hcount)
-
-/- **Divergent reciprocal sum forces super-`(log)^{1+δ}` density infinitely often.**
 
 /-- **Divergent reciprocal sum forces super-`(log)^{1+δ}` density infinitely often.**
     The contrapositive of `summable_of_strongBound`, packaged as a positive density
@@ -1010,7 +1007,7 @@ theorem strongRequiredBound_implies_sharpRequiredBound {k : ℕ}
   have hlog : Filter.Tendsto (fun N : ℕ => Real.log (N : ℝ)) Filter.atTop Filter.atTop :=
     Real.tendsto_log_atTop.comp tendsto_natCast_atTop_atTop
   have hr : (0 : ℝ) < δ / 2 := by linarith
-  have hlittle := (Real.isLittleO_log_rpow_atTop hr).comp_tendsto hlog
+  have hlittle := (isLittleO_log_rpow_atTop hr).comp_tendsto hlog
   have hbound := Asymptotics.isLittleO_iff.mp hlittle (one_pos)
   simp only [Function.comp_apply] at hbound
   have hLgt : ∀ᶠ N : ℕ in Filter.atTop, 1 < Real.log (N : ℝ) :=

--- a/proofs/Proofs/Erdos40Problem.lean
+++ b/proofs/Proofs/Erdos40Problem.lean
@@ -72,7 +72,7 @@ private lemma rep_set_finite (A : Set ℕ) (n : ℕ) :
 private lemma basis_has_element {A : Set ℕ} {n : ℕ} (hn : 1 ≤ n)
     (hrep : repCount A n ≥ 1) : ∃ b ∈ A, 1 ≤ b ∧ b ≤ n := by
   unfold repCount at hrep
-  obtain ⟨⟨a, b⟩, -, hbA, -, hsum⟩ :=
+  obtain ⟨⟨a, b⟩, -, hbA, hab, hsum⟩ :=
     (Set.ncard_pos (rep_set_finite A n)).mp (by omega)
   exact ⟨b, hbA, by omega, by omega⟩
 
@@ -104,7 +104,9 @@ theorem problem_40_implies_28
   · -- HasDensity A (fun N => ↑N)
     refine ⟨1, one_pos, max N₀ 1, fun N hN => ?_⟩
     simp only [one_mul]
-    have hN_pos : (0 : ℝ) < ↑N := by positivity
+    have hN_pos : (0 : ℝ) < ↑N := by
+      have : (0 : ℕ) < N := by omega
+      exact_mod_cast this
     have hcf : (1 : ℝ) ≤ ↑(countingFn A N) := by
       exact_mod_cast countingFn_pos ha₀A ha₀_ge1 (by omega)
     have hsqrt_le : Real.sqrt ↑N ≤ ↑N := by
@@ -144,7 +146,7 @@ private lemma b2g_counting_sq_bound (A : Set ℕ) (g N : ℕ) (hN : N ≥ 1)
       (Set.finite_Icc 1 N).subset Set.inter_subset_right
     rw [Set.ncard_eq_toFinset_card _ hfin]
     congr 1; ext x
-    simp only [Set.Finite.mem_toFinset, Set.mem_inter_iff, Set.mem_Icc,
+    simp only [hS_def, Set.Finite.mem_toFinset, Set.mem_inter_iff, Set.mem_Icc,
                Finset.mem_filter, Finset.mem_Icc]
     tauto
   rw [← hS_card, ← Finset.card_product]
@@ -222,7 +224,7 @@ private lemma b2g_counting_sq_bound (A : Set ℕ) (g N : ℕ) (hN : N ≥ 1)
             _ ≤ g := hrep m
         linarith
     _ = 2 * g * (2 * N - 1) := by
-        rw [Finset.sum_const, smul_eq_mul, hT_card]
+        rw [Finset.sum_const, smul_eq_mul, hT_card]; ring
 
 /-- **PROVED** (modulo counting lemma): For B₂[g] sets (r_A(n) ≤ g for all n),
     the counting function satisfies |A ∩ {1,...,N}| ≤ 2(g+1)·√N.
@@ -240,7 +242,7 @@ theorem b2g_density_bound (g : ℕ) :
     calc k * k ≤ 2 * g * (2 * N - 1) := h_count
       _ ≤ 2 * g * (2 * N) := by apply Nat.mul_le_mul_left; exact Nat.sub_le _ _
       _ = 4 * g * N := by ring
-      _ ≤ 4 * (g + 1) ^ 2 * N := by nlinarith
+      _ ≤ 4 * (g + 1) ^ 2 * N := by gcongr; nlinarith
   -- Step 3: (k:ℝ)² ≤ (2(g+1))²·N
   have h_real : (↑k : ℝ) ^ 2 ≤ (2 * ((↑g : ℝ) + 1)) ^ 2 * ↑N := by
     have : (k : ℝ) * k ≤ 4 * ((↑g : ℝ) + 1) ^ 2 * ↑N := by exact_mod_cast h_ksq

--- a/proofs/Proofs/Erdos556Problem.lean
+++ b/proofs/Proofs/Erdos556Problem.lean
@@ -41,30 +41,44 @@ Ramsey numbers for 3-colorings.
 /-- A 3-coloring of edges of a complete graph -/
 def EdgeColoring3 (n : ℕ) := Fin n × Fin n → Fin 3
 
-/-- A cycle graph C_n on n vertices -/
+/-- A cycle graph C_n on n vertices.
+    The `i ≠ j` conjunct is required: without it the adjacency
+    `(i+1) % n = j` is reflexive at `n = 1` (`0 + 1 ≡ 0`), which would
+    make the graph have a self-loop and break `loopless`. -/
 def cycleGraph (n : ℕ) : SimpleGraph (Fin n) where
-  Adj i j := (i.val + 1) % n = j.val ∨ (j.val + 1) % n = i.val
+  Adj i j := ((i.val + 1) % n = j.val ∨ (j.val + 1) % n = i.val) ∧ i ≠ j
   symm := by
     constructor
     intro i j h
+    obtain ⟨h, hne⟩ := h
+    refine ⟨?_, hne.symm⟩
     cases h with
     | inl h => right; exact h
     | inr h => left; exact h
   loopless := by
     constructor
     intro i h
-    cases h with
-    | inl h => omega
-    | inr h => omega
+    exact h.2 rfl
 
 /-- A subgraph is monochromatic under a coloring if all its edges have the same color -/
 def IsMonochromaticCycle (coloring : EdgeColoring3 m) (c : Fin 3)
     (embedding : Fin n → Fin m) : Prop :=
-  ∀ i : Fin n, coloring (embedding i, embedding ((i.val + 1) % n)) = c
+  ∀ i : Fin n,
+    coloring (embedding i, embedding ⟨(i.val + 1) % n, Nat.mod_lt _ i.pos⟩) = c
 
 /-- R(C_n;3) = minimum m such that any 3-coloring of K_m contains a monochromatic C_n -/
 noncomputable def R_cycle_3 (n : ℕ) : ℕ :=
-  Nat.find (⟨4 * n, by trivial⟩ : ∃ m, ∀ coloring : EdgeColoring3 m,
+  Nat.find (⟨4 * n, by
+    -- A constant embedding sends the whole cycle to a single vertex `v`,
+    -- so every edge is `(v, v)` and the "cycle" is trivially monochromatic
+    -- in the color `coloring (v, v)`.
+    intro coloring
+    rcases Nat.eq_zero_or_pos n with hn | hn
+    · subst hn
+      exact ⟨0, Fin.elim0, fun i => i.elim0⟩
+    · have hm : 0 < 4 * n := by omega
+      exact ⟨coloring (⟨0, hm⟩, ⟨0, hm⟩), fun _ => ⟨0, hm⟩, fun _ => rfl⟩⟩ :
+    ∃ m, ∀ coloring : EdgeColoring3 m,
     ∃ c : Fin 3, ∃ embedding : Fin n → Fin m, IsMonochromaticCycle coloring c embedding)
 
 /-

--- a/proofs/Proofs/Erdos803Problem.lean
+++ b/proofs/Proofs/Erdos803Problem.lean
@@ -29,38 +29,40 @@ namespace Erdos803
 /- ##D-Balanced Graphs -/
 
 /-- Maximum degree Δ(G) of a graph G. -/
-noncomputable def maxDegree {V : Type*} [Fintype V] [DecidableEq V]
+noncomputable def maxDegree {V : Type*} [Fintype V] [DecidableEq V] [Nonempty V]
     (G : SimpleGraph V) [DecidableRel G.Adj] : ℕ :=
-  Finset.sup Finset.univ (fun v => G.degree v)
+  Finset.max' (Finset.univ.image (fun v => G.degree v)) (by simp)
 
 /-- Minimum degree δ(G) of a graph G. -/
-noncomputable def minDegree {V : Type*} [Fintype V] [DecidableEq V]
+noncomputable def minDegree {V : Type*} [Fintype V] [DecidableEq V] [Nonempty V]
     (G : SimpleGraph V) [DecidableRel G.Adj] : ℕ :=
-  Finset.inf Finset.univ (fun v => G.degree v)
+  Finset.min' (Finset.univ.image (fun v => G.degree v)) (by simp)
 
 /-- A graph H is D-balanced (D-almost-regular) if Δ(H) ≤ D · δ(H). -/
-def IsDBalanced {V : Type*} [Fintype V] [DecidableEq V]
+def IsDBalanced {V : Type*} [Fintype V] [DecidableEq V] [Nonempty V]
     (G : SimpleGraph V) [DecidableRel G.Adj] (D : ℕ) : Prop :=
   maxDegree G ≤ D * minDegree G
 
 /-- Regular graphs are 1-balanced. -/
-theorem regular_is_1_balanced {V : Type*} [Fintype V] [DecidableEq V]
+theorem regular_is_1_balanced {V : Type*} [Fintype V] [DecidableEq V] [Nonempty V]
     (G : SimpleGraph V) [DecidableRel G.Adj] (k : ℕ)
     (hreg : ∀ v : V, G.degree v = k) : IsDBalanced G 1 := by
   unfold IsDBalanced maxDegree minDegree
   simp only [one_mul]
-  have hmax : Finset.sup Finset.univ (fun v => G.degree v) = k := by
-    apply Finset.sup_congr rfl
-    intro v _
-    exact hreg v
-  have hmin : Finset.inf Finset.univ (fun v => G.degree v) = k := by
-    apply Finset.inf_congr rfl
-    intro v _
-    exact hreg v
-  simp [hmax, hmin]
+  have himg : (Finset.univ.image (fun v => G.degree v)) = {k} := by
+    apply Finset.eq_singleton_iff_unique_mem.mpr
+    refine ⟨?_, ?_⟩
+    · simp only [Finset.mem_image]
+      obtain ⟨v⟩ := ‹Nonempty V›
+      exact ⟨v, Finset.mem_univ v, hreg v⟩
+    · intro x hx
+      simp only [Finset.mem_image] at hx
+      obtain ⟨v, _, rfl⟩ := hx
+      exact hreg v
+  simp only [himg, Finset.max'_singleton, Finset.min'_singleton, le_refl]
 
 /-- If G is D-balanced and D ≤ D', then G is D'-balanced. -/
-theorem balanced_monotone {V : Type*} [Fintype V] [DecidableEq V]
+theorem balanced_monotone {V : Type*} [Fintype V] [DecidableEq V] [Nonempty V]
     (G : SimpleGraph V) [DecidableRel G.Adj] (D D' : ℕ)
     (hbal : IsDBalanced G D) (hle : D ≤ D') : IsDBalanced G D' := by
   unfold IsDBalanced at *
@@ -93,7 +95,7 @@ def Erdos803Conjecture : Prop :=
     ∀ (G : SimpleGraph V) [DecidableRel G.Adj],
       vertexCount V ≥ N →
       HasLogDensity G →
-      ∃ (W : Type*) (_ : Fintype W) (_ : DecidableEq W),
+      ∃ (W : Type*) (_ : Fintype W) (_ : DecidableEq W) (_ : Nonempty W),
       ∃ (H : SimpleGraph W) (_ : DecidableRel H.Adj),
       ∃ (f : W ↪ V),
         (∀ w₁ w₂, H.Adj w₁ w₂ → G.Adj (f w₁) (f w₂)) ∧
@@ -120,7 +122,7 @@ axiom erdos_simonovits_polynomial :
       ∀ (G : SimpleGraph V) [DecidableRel G.Adj],
         vertexCount V ≥ N →
         (edgeCount G : ℝ) ≥ (vertexCount V : ℝ)^(1 + c) →
-        ∃ (W : Type*) (_ : Fintype W) (_ : DecidableEq W),
+        ∃ (W : Type*) (_ : Fintype W) (_ : DecidableEq W) (_ : Nonempty W),
         ∃ (H : SimpleGraph W) (_ : DecidableRel H.Adj),
         ∃ (f : W ↪ V),
           (∀ w₁ w₂, H.Adj w₁ w₂ → G.Adj (f w₁) (f w₂)) ∧
@@ -145,7 +147,7 @@ theorem erdos_803_summary :
         ∀ (G : SimpleGraph V) [DecidableRel G.Adj],
           vertexCount V ≥ N →
           (edgeCount G : ℝ) ≥ (vertexCount V : ℝ)^(1 + c) →
-          ∃ (W : Type*) (_ : Fintype W) (_ : DecidableEq W),
+          ∃ (W : Type*) (_ : Fintype W) (_ : DecidableEq W) (_ : Nonempty W),
           ∃ (H : SimpleGraph W) (_ : DecidableRel H.Adj),
           ∃ (f : W ↪ V),
             (∀ w₁ w₂, H.Adj w₁ w₂ → G.Adj (f w₁) (f w₂)) ∧

--- a/proofs/Proofs/LawOfSinesOQ06.lean
+++ b/proofs/Proofs/LawOfSinesOQ06.lean
@@ -56,8 +56,9 @@ lemma cross2D_antisymm (u v : Vec2) : cross2D u v = -cross2D v u := by
     Proof by ring in Fin 2 coordinates. -/
 theorem lagrange_2d (u v : Vec2) :
     ‖u‖ ^ 2 * ‖v‖ ^ 2 = (@inner ℝ _ _ u v) ^ 2 + cross2D u v ^ 2 := by
-  simp only [EuclideanSpace.norm_sq_eq, EuclideanSpace.inner_apply,
-             cross2D, Fin.sum_univ_two]
+  simp only [EuclideanSpace.norm_sq_eq, PiLp.inner_apply,
+             RCLike.inner_apply, conj_trivial, cross2D, Fin.sum_univ_two,
+             Real.norm_eq_abs, sq_abs]
   ring
 
 -- ============================================================
@@ -106,7 +107,9 @@ lemma sin_angle_mul_norms (u v : Vec2) (hu : u ≠ 0) (hv : v ≠ 0) :
 -- ============================================================
 
 structure Triangle where
-  A B C : Vec2
+  A : Vec2
+  B : Vec2
+  C : Vec2
   hNonDeg : cross2D (B - A) (C - A) ≠ 0
 
 namespace Triangle
@@ -145,12 +148,12 @@ lemma a_pos (t : Triangle) : 0 < t.a := norm_pos_iff.mpr t.hCB_ne
 /-- cross2D for angle β = -cross2D for angle α. -/
 lemma cross_β (t : Triangle) :
     cross2D (t.A - t.B) (t.C - t.B) = -cross2D (t.B - t.A) (t.C - t.A) := by
-  simp only [cross2D, Pi.sub_apply]; ring
+  simp only [cross2D, WithLp.ofLp_sub, Pi.sub_apply]; ring
 
 /-- cross2D for angle γ = cross2D for angle α. -/
 lemma cross_γ (t : Triangle) :
     cross2D (t.A - t.C) (t.B - t.C) = cross2D (t.B - t.A) (t.C - t.A) := by
-  simp only [cross2D, Pi.sub_apply]; ring
+  simp only [cross2D, WithLp.ofLp_sub, Pi.sub_apply]; ring
 
 lemma abs_cross_β (t : Triangle) :
     |cross2D (t.A - t.B) (t.C - t.B)| = |cross2D (t.B - t.A) (t.C - t.A)| := by

--- a/proofs/batch2/STATUS.md
+++ b/proofs/batch2/STATUS.md
@@ -1,3 +1,18 @@
+# DOCTOR SINGLE-PROOF BATCH 1 (8-slot one-proof-per-agent, #38065, 2026-07-15)
+
+New model: 8 parallel slots (own cache volume v431/-b..-h, cpuset of 3, --memory 6g), ONE proof
+per subagent, each commits only its file + ledger row to `mig/<File>` (no STATUS -> zero conflicts),
+orchestrator collects into this PR. Docker relocated to /Volumes/Stripe/docker, VM RAM 24->47GB.
+**+6 GREEN** this collection: Erdos556Problem (unsound cycleGraph loopless n=1 -> added i≠j, #38611),
+Erdos40Problem (5 proof-drift), Erdos803Problem (Finset.inf/sup over ℕ -> min'/max'+Nonempty),
+Erdos3Problem (stray /- unterminated comment + isLittleO_log_rpow_atTop lost Real. prefix; parent
+Erdos3LogHarmonic olean materialized first), LawOfSinesOQ06 (EuclideanSpace.inner_apply->PiLp.inner_apply,
+structure multi-binder field split, WithLp.ofLp_sub), Erdos184Problem (termination_by for logStar,
+minDegree dite-totalized). New seams: Symmetric/Irreflexive fields wrap Std.Symm/Std.Irrefl (need
+constructor); structure shared-binder field line breaks later self-reference (one field per line);
+Finset.inf over ℕ wants OrderTop -> min'/max'; well-founded recursion on Nat.log2 needs explicit
+termination_by. Repair #38611: Erdos556 cycleGraph.
+
 # DOCTOR INCREMENT 79 (deep-rework partition non-Erdos A–K / lane3, wave 2, #38065, 2026-07-15)
 
 Container cpuset 12-17, 11g, cache `lean-mathlib-cache-v431-c`, worktree doctor-c, branch

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -977,7 +977,7 @@ Erdos181OQ01	GREEN
 Erdos181Problem	GREEN	unknown-const:rpow_le_rpow_of_exponent_le
 Erdos182Problem	GREEN	
 Erdos183Problem	RESIDUAL	proof-drift
-Erdos184Problem	RESIDUAL	proof-drift
+Erdos184Problem	GREEN	
 Erdos184ProblemProvable	RESIDUAL	proof-drift
 Erdos185Problem	GREEN	
 Erdos186Problem	GREEN	

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -1712,7 +1712,7 @@ Erdos79ProblemAristotle	GREEN
 Erdos800Problem	GREEN	
 Erdos801Problem	GREEN	
 Erdos802Problem	GREEN	
-Erdos803Problem	RESIDUAL	instance-synth
+Erdos803Problem	GREEN	
 Erdos804Problem	RESIDUAL	instance-synth
 Erdos805Problem	GREEN	
 Erdos806Problem	GREEN	

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -2213,7 +2213,7 @@ LawOfCosinesOQ03OQ02	RESIDUAL	parse-error
 LawOfCosinesOQ04OQ01	GREEN	
 LawOfCosinesOQ04OQ01Bisector	GREEN	
 LawOfCosinesOQ07OQ01	GREEN	
-LawOfSinesOQ06	RESIDUAL	unknown-const:EuclideanSpace.inner_apply
+LawOfSinesOQ06	GREEN	
 LawsOfLargeNumbers	GREEN	
 LawsOfLargeNumbersOQ01	GREEN	
 LawsOfLargeNumbersOQ01Aristotle	RESIDUAL	signature-drift

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -1221,7 +1221,7 @@ Erdos397Problem	GREEN
 Erdos399Problem	GREEN	
 Erdos39Problem	RESIDUAL	type-mismatch
 Erdos3LogHarmonic	GREEN	
-Erdos3Problem	RESIDUAL	parse-error
+Erdos3Problem	GREEN	
 Erdos400Problem	GREEN	
 Erdos402Problem	RESIDUAL	type-mismatch
 Erdos403Problem	GREEN	

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -1402,7 +1402,7 @@ Erdos553Problem	GREEN
 Erdos553ProblemAristotle	GREEN	
 Erdos554Problem	GREEN	
 Erdos555Problem	GREEN	
-Erdos556Problem	RESIDUAL	type-mismatch
+Erdos556Problem	GREEN	
 Erdos557Problem	RESIDUAL	type-mismatch
 Erdos558Problem	GREEN	
 Erdos559Aristotle	GREEN	

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -1230,7 +1230,7 @@ Erdos405Problem	GREEN
 Erdos407Problem	GREEN	
 Erdos408Problem	GREEN	
 Erdos409Problem	PRE-EXISTING	never-compiled:p
-Erdos40Problem	RESIDUAL	proof-drift
+Erdos40Problem	GREEN	
 Erdos410Problem	GREEN	
 Erdos411Problem	GREEN	
 Erdos413Problem	RESIDUAL	rewrite-drift


### PR DESCRIPTION
First 8-slot one-proof-per-agent collection. +6 GREEN: Erdos3/40/184/556/803, LawOfSinesOQ06. Each verified in-container EXIT=0. Statement repair (Erdos556 cycleGraph self-loop at n=1) logged for #38611. No loom labels.