### PR TITLE
migrate(v4.31): single-proof batch 2 (+3 GREEN)

### DIFF
--- a/proofs/Proofs/DenumerabilityRationalsOQ02OQ02.lean
+++ b/proofs/Proofs/DenumerabilityRationalsOQ02OQ02.lean
@@ -45,15 +45,18 @@ explicit in 20th-century algebra. It is now standard in analysis textbooks.
 
 namespace DenumerabilityRationalsOQ02OQ02
 
--- Open the induced map namespace to access `inducedOrderRingIso` and `uniqueOrderRingIso`
-open ConditionallyCompleteLinearOrderedField.InducedMap
+-- Open the namespace to access `inducedOrderRingIso` and activate the `uniqueOrderRingIso` instance
+open ConditionallyCompleteLinearOrderedField
 
 -- ============================================================================
 -- Section 1: ℝ as a Complete Ordered Field
 -- ============================================================================
 
-/-- ℝ is a complete ordered field: the `ConditionallyCompleteLinearOrderedField` instance. -/
-example : ConditionallyCompleteLinearOrderedField ℝ := inferInstance
+/-- ℝ is a complete ordered field: it carries `Field`, `ConditionallyCompleteLinearOrder`,
+    and `IsStrictOrderedRing` instances (the unbundled form of a complete ordered field). -/
+noncomputable example : Field ℝ := inferInstance
+noncomputable example : ConditionallyCompleteLinearOrder ℝ := inferInstance
+example : IsStrictOrderedRing ℝ := inferInstance
 
 /-- ℝ is Archimedean: for any x : ℝ, there exists n : ℕ with x < n. -/
 theorem real_archimedean : Archimedean ℝ := inferInstance
@@ -77,17 +80,17 @@ theorem real_lub (S : Set ℝ) (hne : S.Nonempty) (hbdd : BddAbove S) :
     - **Ring homomorphism**: Preserved by the algebraic structure of cuts.
     - **Order-preserving**: x ≤ y implies {q | q ≤ x} ⊆ {q | q ≤ y}.
     - **Bijective**: Surjective (every real is a cut), injective (cuts determine elements). -/
-noncomputable def isoToReal (F : Type*) [ConditionallyCompleteLinearOrderedField F] :
+noncomputable def isoToReal (F : Type*) [Field F] [ConditionallyCompleteLinearOrder F] [IsStrictOrderedRing F] :
     F ≃+*o ℝ :=
   inducedOrderRingIso F ℝ
 
 /-- The Dedekind cut isomorphism is order-preserving. -/
-theorem isoToReal_mono (F : Type*) [ConditionallyCompleteLinearOrderedField F] :
+theorem isoToReal_mono (F : Type*) [Field F] [ConditionallyCompleteLinearOrder F] [IsStrictOrderedRing F] :
     Monotone (isoToReal F) :=
-  (isoToReal F).monotone
+  (isoToReal F).toOrderIso.monotone
 
 /-- The isomorphism fixes rationals: φ((q : F)) = (q : ℝ). -/
-theorem isoToReal_ratCast (F : Type*) [ConditionallyCompleteLinearOrderedField F] (q : ℚ) :
+theorem isoToReal_ratCast (F : Type*) [Field F] [ConditionallyCompleteLinearOrder F] [IsStrictOrderedRing F] (q : ℚ) :
     isoToReal F (q : F) = (q : ℝ) :=
   map_ratCast (isoToReal F) q
 
@@ -100,15 +103,15 @@ theorem isoToReal_ratCast (F : Type*) [ConditionallyCompleteLinearOrderedField F
 
     Proof: Two such isomorphisms agree on ℚ (both fix rationals), and by density
     of ℚ in F and continuity (i.e., order-preservation), they agree everywhere. -/
-theorem iso_to_real_unique (F : Type*) [ConditionallyCompleteLinearOrderedField F]
+theorem iso_to_real_unique (F : Type*) [Field F] [ConditionallyCompleteLinearOrder F] [IsStrictOrderedRing F]
     (f g : F ≃+*o ℝ) : f = g := by
   haveI : Unique (F ≃+*o ℝ) := inferInstance
   exact Unique.eq_default f |>.trans (Unique.eq_default g).symm
 
 /-- **Existence and Uniqueness**: there is exactly one ordered ring isomorphism F ≃+*o ℝ. -/
-theorem iso_to_real_exists_unique (F : Type*) [ConditionallyCompleteLinearOrderedField F] :
+theorem iso_to_real_exists_unique (F : Type*) [Field F] [ConditionallyCompleteLinearOrder F] [IsStrictOrderedRing F] :
     ∃! f : F ≃+*o ℝ, True :=
-  ⟨isoToReal F, trivial, fun g _ => (iso_to_real_unique F g (isoToReal F)).symm⟩
+  ⟨isoToReal F, trivial, fun g _ => iso_to_real_unique F g (isoToReal F)⟩
 
 -- ============================================================================
 -- Section 4: Categoricity
@@ -117,15 +120,15 @@ theorem iso_to_real_exists_unique (F : Type*) [ConditionallyCompleteLinearOrdere
 /-- **Categoricity**: Any two complete ordered fields are isomorphic as ordered rings.
     ℝ is the unique model of "complete ordered field" up to isomorphism. -/
 noncomputable def completeOrderedFieldIso (F G : Type*)
-    [ConditionallyCompleteLinearOrderedField F]
-    [ConditionallyCompleteLinearOrderedField G] :
+    [Field F] [ConditionallyCompleteLinearOrder F] [IsStrictOrderedRing F]
+    [Field G] [ConditionallyCompleteLinearOrder G] [IsStrictOrderedRing G] :
     F ≃+*o G :=
   inducedOrderRingIso F G
 
 /-- The isomorphism between any two complete ordered fields is unique. -/
 theorem complete_ordered_fields_iso_unique (F G : Type*)
-    [ConditionallyCompleteLinearOrderedField F]
-    [ConditionallyCompleteLinearOrderedField G]
+    [Field F] [ConditionallyCompleteLinearOrder F] [IsStrictOrderedRing F]
+    [Field G] [ConditionallyCompleteLinearOrder G] [IsStrictOrderedRing G]
     (f g : F ≃+*o G) : f = g := by
   haveI : Unique (F ≃+*o G) := inferInstance
   exact Unique.eq_default f |>.trans (Unique.eq_default g).symm
@@ -140,17 +143,17 @@ theorem complete_ordered_fields_iso_unique (F G : Type*)
 
     This shows there is no non-Archimedean complete ordered field. -/
 theorem complete_ordered_field_archimedean (F : Type*)
-    [ConditionallyCompleteLinearOrderedField F] : Archimedean F :=
+    [Field F] [ConditionallyCompleteLinearOrder F] [IsStrictOrderedRing F] : Archimedean F :=
   inferInstance
 
 /-- ℕ is cofinal in every complete ordered field. -/
-theorem nat_cofinal (F : Type*) [ConditionallyCompleteLinearOrderedField F]
+theorem nat_cofinal (F : Type*) [Field F] [ConditionallyCompleteLinearOrder F] [IsStrictOrderedRing F]
     (x : F) : ∃ n : ℕ, x < n :=
   exists_nat_gt x
 
 /-- ℤ is cofinal in both directions: for any x in a complete ordered field,
     there exists a negative integer less than x. -/
-theorem int_below (F : Type*) [ConditionallyCompleteLinearOrderedField F]
+theorem int_below (F : Type*) [Field F] [ConditionallyCompleteLinearOrder F] [IsStrictOrderedRing F]
     (x : F) : ∃ m : ℤ, (m : F) < x := by
   obtain ⟨n, hn⟩ := exists_nat_gt (-x)
   exact ⟨-n, by push_cast; linarith⟩
@@ -161,12 +164,12 @@ theorem int_below (F : Type*) [ConditionallyCompleteLinearOrderedField F]
 
 /-- ℚ is order-dense in every complete ordered field: between any two elements
     of F there is a rational. This mirrors the density of ℚ in ℝ. -/
-theorem rat_dense (F : Type*) [ConditionallyCompleteLinearOrderedField F]
+theorem rat_dense (F : Type*) [Field F] [ConditionallyCompleteLinearOrder F] [IsStrictOrderedRing F]
     (x y : F) (h : x < y) : ∃ q : ℚ, x < q ∧ (q : F) < y :=
   exists_rat_btwn h
 
 /-- The rational cast ℚ → F is strictly order-preserving. -/
-theorem ratCast_strictMono (F : Type*) [ConditionallyCompleteLinearOrderedField F] :
+theorem ratCast_strictMono (F : Type*) [Field F] [ConditionallyCompleteLinearOrder F] [IsStrictOrderedRing F] :
     StrictMono ((↑) : ℚ → F) :=
   Rat.cast_strictMono
 
@@ -192,7 +195,7 @@ theorem real_automorphism_unique (f : ℝ ≃+*o ℝ) : f = OrderRingIso.refl �
 
     This is the categorical characterization of the real numbers. -/
 theorem real_unique_complete_ordered_field (F : Type*)
-    [ConditionallyCompleteLinearOrderedField F] :
+    [Field F] [ConditionallyCompleteLinearOrder F] [IsStrictOrderedRing F] :
     ∃! f : F ≃+*o ℝ, True :=
   iso_to_real_exists_unique F
 
@@ -209,8 +212,8 @@ theorem real_unique_complete_ordered_field (F : Type*)
 theorem categoricity_parallel :
     (∀ (A : Type*) [LinearOrder A] [Countable A] [DenselyOrdered A]
        [NoMinOrder A] [NoMaxOrder A] [Nonempty A], Nonempty (A ≃o ℚ)) ∧
-    (∀ (F : Type*) [ConditionallyCompleteLinearOrderedField F], Nonempty (F ≃+*o ℝ)) := by
-  exact ⟨fun A _ _ _ _ _ _ => ⟨Order.iso_of_countable_dense A ℚ⟩,
-         fun F _ => ⟨isoToReal F⟩⟩
+    (∀ (F : Type*) [Field F] [ConditionallyCompleteLinearOrder F] [IsStrictOrderedRing F], Nonempty (F ≃+*o ℝ)) := by
+  exact ⟨fun A _ _ _ _ _ _ => Order.iso_of_countable_dense A ℚ,
+         fun F _ _ _ => ⟨isoToReal F⟩⟩
 
 end DenumerabilityRationalsOQ02OQ02

--- a/proofs/Proofs/Erdos1014Problem.lean
+++ b/proofs/Proofs/Erdos1014Problem.lean
@@ -64,8 +64,9 @@ private theorem ramsey_mono_left_ge2 (k l : ℕ) (hk : k ≥ 2) :
     by_cases hn : n ≥ 2
     · exact (ih hn).trans (ramsey_monotone_left' n l)
     · -- n < 2 and n + 1 ≥ 2, so n = 1 and k = n + 1 = 2
-      have : n = 1 := by omega
-      subst this
+      have hn1 : n = 1 := by omega
+      subst hn1
+      exact le_refl _
 
 /-- R(k, l) ≥ 1 for all k ≥ 2, l ≥ 1. Proved from R(2,l)=l and iterated
     left-monotonicity: R(2,l) ≤ R(k,l) for k ≥ 2. -/
@@ -110,8 +111,10 @@ private lemma tendsto_succ_div_pow (a : ℕ) :
   have h : Tendsto (fun n : ℕ => 1 + (n : ℝ)⁻¹) atTop (nhds (1 + 0)) :=
     tendsto_const_nhds.add (tendsto_inv_atTop_zero.comp tendsto_natCast_atTop_atTop)
   rw [add_zero] at h
-  exact h.congr (eventually_atTop.mpr ⟨1, fun n hn => by
-    have : (n : ℝ) ≠ 0 := Nat.cast_ne_zero.mpr (by omega); skip⟩)
+  refine h.congr' (eventually_atTop.mpr ⟨1, fun n hn => ?_⟩)
+  have hn0 : (n : ℝ) ≠ 0 := Nat.cast_ne_zero.mpr (by omega)
+  show 1 + (n : ℝ)⁻¹ = ((n : ℝ) + 1) / (n : ℝ)
+  rw [add_div, div_self hn0, one_div]
 
 /-- For any fixed b : ℕ, (log n / log(n+1))^b → 1 as n → ∞.
     Uses squeeze: for n ≥ 2, 1 - 1/(n·log 2) ≤ log n/log(n+1) ≤ 1, and both → 1. -/
@@ -120,12 +123,13 @@ private lemma tendsto_log_ratio_pow (b : ℕ) :
   conv_rhs => rw [show (1 : ℝ) = 1 ^ b from (one_pow b).symm]
   apply Tendsto.pow
   -- Squeeze: 1 - (n⁻¹/log 2) ≤ log(n)/log(n+1) ≤ 1, both bounds → 1
-  apply tendsto_of_tendsto_of_tendsto_of_le_of_le
+  apply tendsto_of_tendsto_of_tendsto_of_le_of_le'
     -- Lower bound → 1
     (show Tendsto (fun n : ℕ => 1 - (n : ℝ)⁻¹ / log 2) atTop (nhds 1) from by
-      rw [show (1 : ℝ) = 1 - 0 / log 2 from by simp]
-      exact tendsto_const_nhds.sub
-        ((tendsto_inv_atTop_zero.comp tendsto_natCast_atTop_atTop).div_const _))
+      have h0 : Tendsto (fun n : ℕ => (n : ℝ)⁻¹ / log 2) atTop (nhds 0) := by
+        rw [show (0 : ℝ) = 0 / log 2 from by simp]
+        exact (tendsto_inv_atTop_zero.comp tendsto_natCast_atTop_atTop).div_const (log 2)
+      simpa using tendsto_const_nhds.sub h0)
     -- Upper bound → 1
     tendsto_const_nhds
     -- f(n) ≥ lower bound eventually
@@ -152,11 +156,12 @@ private lemma tendsto_log_ratio_pow (b : ℕ) :
         rw [div_le_div_iff₀ hlog_n1 hlog2]
         calc (log ((n : ℝ) + 1) - log (n : ℝ)) * log 2
             ≤ (n : ℝ)⁻¹ * log 2 := by nlinarith [h_log_diff]
-          _ ≤ (n : ℝ)⁻¹ * log ((n : ℝ) + 1) := by nlinarith [hlog2_le]
+          _ ≤ (n : ℝ)⁻¹ * log ((n : ℝ) + 1) :=
+              mul_le_mul_of_nonneg_left hlog2_le (inv_nonneg.mpr hn_pos.le)
       rw [h_eq]; linarith⟩)
     -- f(n) ≤ 1 eventually (log is increasing)
     (eventually_atTop.mpr ⟨2, fun n hn => by
-      exact div_le_one_of_le
+      exact div_le_one_of_le₀
         (log_le_log (by exact_mod_cast (show 0 < n by omega))
           (by exact_mod_cast (show n ≤ n + 1 by omega)))
         (le_of_lt (log_pos (by exact_mod_cast (show 1 < n + 1 by omega))))⟩)
@@ -170,11 +175,13 @@ private lemma growth_ratio_close (a b : ℕ) (δ : ℝ) (hδ : δ > 0) :
   have ht : Tendsto (fun n : ℕ =>
       (((n : ℝ) + 1) / (n : ℝ)) ^ a *
       (log (n : ℝ) / log ((n : ℝ) + 1)) ^ b) atTop (nhds 1) := by
-    rw [show (1 : ℝ) = 1 * 1 from (mul_one 1).symm]
-    exact (tendsto_succ_div_pow a).mul (tendsto_log_ratio_pow b)
+    have h := (tendsto_succ_div_pow a).mul (tendsto_log_ratio_pow b)
+    simpa using h
   rw [Metric.tendsto_atTop] at ht
   obtain ⟨N, hN⟩ := ht δ hδ
-  exact ⟨N, fun l hl => by rwa [Real.dist_eq] at hN l (by omega)⟩
+  refine ⟨N, fun l hl => ?_⟩
+  have hd := hN l (by omega)
+  rwa [Real.dist_eq] at hd
 
 end GrowthRatioHelpers
 
@@ -219,8 +226,17 @@ theorem ratio_from_asymptotics (k : ℕ) (hk : k ≥ 3) :
   have hα : |(ramseyNumber k (l + 1) : ℝ) / g' - 1| < δ := by
     convert hL₁ (l + 1) (by omega) using 2; push_cast; ring
   have hβ : |g' / g - 1| < δ := by
-    convert hL₂ l hl2 using 2
-    simp only [g, g']; field_simp; ring
+    have hcne : c ≠ 0 := ne_of_gt hc
+    have hlp : ((l : ℝ)) ^ (k - 1) ≠ 0 := pow_ne_zero _ (ne_of_gt hl_pos)
+    have hLp : (Real.log (l : ℝ)) ^ (k - 2) ≠ 0 := pow_ne_zero _ (ne_of_gt hlog_l)
+    have hMp : (Real.log ((l : ℝ) + 1)) ^ (k - 2) ≠ 0 := pow_ne_zero _ (ne_of_gt hlog_l1)
+    have key : g' / g =
+        (((l : ℝ) + 1) / (l : ℝ)) ^ (k - 1) *
+        (Real.log (l : ℝ) / Real.log ((l : ℝ) + 1)) ^ (k - 2) := by
+      simp only [g, g', div_pow]
+      field_simp
+    rw [key]
+    exact hL₂ l hl2
   have hζ : |(ramseyNumber k l : ℝ) / g - 1| < δ := hL₁ l hl1
   -- R(k,l) > 0 from sandwich
   set R := (ramseyNumber k l : ℝ)
@@ -256,7 +272,7 @@ theorem ratio_from_asymptotics (k : ℕ) (hk : k ≥ 3) :
     -- γ = g/R = 1/(R/g), |1/x - 1| = |x-1|/x when x > 0
     have hRg_pos : 0 < R / g := by linarith
     have hγ_eq : γ - 1 = -(R / g - 1) / (R / g) := by
-      simp only [γ]; field_simp
+      simp only [γ]; field_simp; ring
     rw [hγ_eq, abs_div, abs_neg, abs_of_pos hRg_pos]
     -- Need: |R/g-1| / (R/g) ≤ 4δ/3, i.e., |R/g-1| ≤ (4δ/3)·(R/g)
     rw [div_le_iff₀ hRg_pos]
@@ -271,10 +287,23 @@ theorem ratio_from_asymptotics (k : ℕ) (hk : k ≥ 3) :
     _ = |α| * |β| * |γ - 1| + |α| * |β - 1| + |α - 1| := by
         rw [abs_mul, abs_mul, abs_mul]
     _ ≤ (1 + δ) * (1 + δ) * (4 * δ / 3) + (1 + δ) * δ + δ := by
-        have := abs_nonneg α; have := abs_nonneg β; have := abs_nonneg (γ - 1)
-        have := abs_nonneg (β - 1); have := abs_nonneg (α - 1)
-        nlinarith [hα_abs, hβ_abs, hγ_abs, le_of_lt hα, le_of_lt hβ]
-    _ ≤ (5/4) * (5/4) * (4 * δ / 3) + (5/4) * δ + δ := by nlinarith
+        have h1 : |α| * |β| ≤ (1 + δ) * (1 + δ) :=
+          mul_le_mul hα_abs hβ_abs (abs_nonneg β) (by linarith)
+        have h2 : |α| * |β| * |γ - 1| ≤ (1 + δ) * (1 + δ) * (4 * δ / 3) :=
+          mul_le_mul h1 hγ_abs (abs_nonneg _)
+            (mul_nonneg (by linarith) (by linarith))
+        have h3 : |α| * |β - 1| ≤ (1 + δ) * δ :=
+          mul_le_mul hα_abs (le_of_lt hβ) (abs_nonneg _) (by linarith)
+        have h4 : |α - 1| ≤ δ := le_of_lt hα
+        linarith
+    _ ≤ (5/4) * (5/4) * (4 * δ / 3) + (5/4) * δ + δ := by
+        have hb : (1 : ℝ) + δ ≤ 5 / 4 := by linarith
+        have hsq : (1 + δ) * (1 + δ) ≤ (5 / 4) * (5 / 4) := by nlinarith [hδ, hδ14]
+        have ht1 : (1 + δ) * (1 + δ) * (4 * δ / 3) ≤ (5 / 4) * (5 / 4) * (4 * δ / 3) :=
+          mul_le_mul_of_nonneg_right hsq (by linarith)
+        have ht2 : (1 + δ) * δ ≤ (5 / 4) * δ :=
+          mul_le_mul_of_nonneg_right hb (by linarith)
+        linarith
     _ = 52 * δ / 12 := by ring
     _ = 13 * δ / 3 := by ring
     _ ≤ 13 * (ε / 6) / 3 := by nlinarith
@@ -365,19 +394,7 @@ theorem R22 : ramseyNumber 2 2 = 2 := ramsey_k2 2 (by norm_num)
 theorem diagonal_ramsey_lower (k : ℕ) (hk : k ≥ 2) :
     k ≤ ramseyNumber k k := by
   calc k = ramseyNumber 2 k := (ramsey_k2 k (by omega)).symm
-    _ ≤ ramseyNumber k k := by
-        have h1 : ramseyNumber 2 k ≤ ramseyNumber k k := by
-          induction k with
-          | zero => omega
-          | succ n ih =>
-            by_cases hn : n ≥ 2
-            · calc ramseyNumber 2 (n + 1)
-                  ≤ ramseyNumber (n + 1) (n + 1) := by
-                    calc ramseyNumber 2 (n + 1)
-                        = ramseyNumber (n + 1) 2 := ramsey_symm 2 (n + 1)
-                      _ ≤ ramseyNumber (n + 1) (n + 1) := ramsey_monotone_right (n + 1) 2
-            · interval_cases n <;> simp_all [R22, ramsey_k2, ramsey_symm]
-        exact h1
+    _ ≤ ramseyNumber k k := ramsey_mono_left_ge2 k k hk
 
 /- ## General Increment Bound -/
 
@@ -419,7 +436,7 @@ theorem R3_ratio_convergence :
   intro ε hε
   obtain ⟨c, hc, L₁, hL₁⟩ := R3_lower
   -- Find L₂ where (l+1)·log l / (c·l²) < ε, via log = o(x)
-  have ho := Real.isLittleO_log_rpow_atTop (show (0 : ℝ) < 1 by norm_num)
+  have ho := isLittleO_log_rpow_atTop (show (0 : ℝ) < 1 by norm_num)
   have hev := ho.bound (show (0 : ℝ) < c * ε / 4 by positivity)
   obtain ⟨N, hN⟩ := Filter.eventually_atTop.mp hev
   use max (max L₁ (⌈N⌉₊ + 1)) 2

--- a/proofs/Proofs/Erdos95Problem.lean
+++ b/proofs/Proofs/Erdos95Problem.lean
@@ -44,8 +44,14 @@ open Finset
 /-- A point in the Euclidean plane R². -/
 abbrev Point := EuclideanSpace ℝ (Fin 2)
 
-/-- The Euclidean distance between two points. -/
-noncomputable def dist (p q : Point) : ℝ := ‖p - q‖
+/-- The Euclidean distance between two points.
+
+    Marked `irreducible`: it is used only structurally (inside `distanceSet` and
+    `multiplicity`), never unfolded in any proof.  Under the v4.31 `WithLp`
+    refactor, leaving it reducible makes `whnf` unfold the `‖·‖` coercion chain
+    on `EuclideanSpace` during decidable-equality defeq checks, blowing up
+    elaboration of `sum_multiplicities`. -/
+@[irreducible] noncomputable def dist (p q : Point) : ℝ := ‖p - q‖
 
 /-- A finite point configuration in R². -/
 structure PointConfig where
@@ -76,13 +82,11 @@ noncomputable def multiplicity (P : PointConfig) (d : ℝ) : ℕ :=
 theorem sum_multiplicities (P : PointConfig) :
     (distanceSet P).sum (multiplicity P) = P.points.card * (P.points.card - 1) := by
   -- Fibre decomposition: `offDiag.card = ∑_{d ∈ distanceSet} (fibre over d).card`.
-  have hmem : ∀ pq ∈ P.points.offDiag, dist pq.1 pq.2 ∈ distanceSet P :=
-    fun pq hpq => Finset.mem_image_of_mem _ hpq
   -- The fibre sum over the distance set recovers `offDiag.card` (each `multiplicity P d`
-  -- is, by definition, the size of the fibre over `d`).
+  -- is, by definition, the size of the fibre over `d`).  `card_eq_sum_card_image` needs
+  -- no `MapsTo` hypothesis and matches `distanceSet`/`multiplicity` definitionally.
   have hfib : P.points.offDiag.card = (distanceSet P).sum (multiplicity P) :=
-    Finset.card_eq_sum_card_fiberwise (f := fun pq => dist pq.1 pq.2)
-      (t := distanceSet P) hmem
+    Finset.card_eq_sum_card_image (fun pq : Point × Point => dist pq.1 pq.2) P.points.offDiag
   rw [← hfib, Finset.offDiag_card]
   -- `offDiag_card` gives the `n*n - n` form; bridge to `n*(n-1)`.
   cases h : P.points.card with
@@ -105,7 +109,7 @@ noncomputable def sumSquaredMultiplicities (P : PointConfig) : ℕ :=
 
     This says distance multiplicities cannot be too concentrated. -/
 def ErdosConjecture : Prop :=
-  ∀ ε > 0, ∃ C > 0, ∀ P : PointConfig,
+  ∀ ε : ℝ, ε > 0 → ∃ C > 0, ∀ P : PointConfig,
     (sumSquaredMultiplicities P : ℝ) ≤ C * (P.points.card : ℝ)^(3 + ε)
 
 /-

--- a/proofs/batch2/STATUS.md
+++ b/proofs/batch2/STATUS.md
@@ -1,3 +1,14 @@
+# DOCTOR SINGLE-PROOF BATCH 2 (8-slot, #38065, 2026-07-15)
+
+**+3 GREEN**: DenumerabilityRationalsOQ02OQ02 (ConditionallyCompleteLinearOrderedField class
+deprecated -> unbundle to Field+ConditionallyCompleteLinearOrder+IsStrictOrderedRing; induced-map
+lemmas moved under its namespace; Order.iso_of_countable_dense returns Nonempty), Erdos95Problem
+(card_eq_sum_card_fiberwise H-arg now Set.MapsTo -> use card_eq_sum_card_image; WithLp-coercion whnf
+blowup in EuclideanSpace Finset filter -> mark dist @[irreducible]; ^(3+ε) no longer forces ε:ℝ),
+Erdos1014Problem (~21-site real-analysis HUB: Tendsto.congr->.congr', squeeze lemma primed,
+div_le_one_of_le₀, isLittleO_log_rpow_atTop root ns; parent olean now unblocks children
+Erdos1014OQ02 + Erdos1014OQ03Concrete). Repairs: none.
+
 # DOCTOR SINGLE-PROOF BATCH 1 (8-slot one-proof-per-agent, #38065, 2026-07-15)
 
 New model: 8 parallel slots (own cache volume v431/-b..-h, cpuset of 3, --memory 6g), ONE proof

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -1894,7 +1894,7 @@ Erdos956Problem	GREEN
 Erdos957Problem	RESIDUAL	proof-drift
 Erdos958Problem	GREEN	
 Erdos959Problem	GREEN	
-Erdos95Problem	RESIDUAL	type-mismatch
+Erdos95Problem	GREEN	
 Erdos960Problem	GREEN	unknown-const:p
 Erdos961Problem	GREEN	
 Erdos962Problem	GREEN	

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -652,7 +652,7 @@ Erdos1014OQ03Concrete	RESIDUAL	type-mismatch
 Erdos1014OQ03LogIncrement	GREEN	
 Erdos1014OQ03Obstruction	GREEN	
 Erdos1014OQ04	GREEN	
-Erdos1014Problem	RESIDUAL	type-mismatch
+Erdos1014Problem	GREEN	
 Erdos1015OQ05	GREEN	
 Erdos1015Problem	PRE-EXISTING	never-compiled:n
 Erdos1017OQ01	RESIDUAL	type-mismatch

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -515,7 +515,7 @@ DeMoivreOQ03OQ01	GREEN
 DeMoivreOQ06	GREEN	
 DedekindFrobeniusBridge	RESIDUAL	rewrite-drift
 DenumerabilityRationalsOQ01	GREEN	elab-drift
-DenumerabilityRationalsOQ02OQ02	RESIDUAL	elab-drift
+DenumerabilityRationalsOQ02OQ02	GREEN	
 DenumerabilityRationalsOQ04	RESIDUAL	unknown-const:Polynomial.setOf_isRoot_finite
 DerangementsConvergence	GREEN	
 DerangementsConvergenceOQ01	GREEN	


### PR DESCRIPTION
8-slot collection. +3 GREEN: DenumerabilityRationalsOQ02OQ02, Erdos95Problem, Erdos1014Problem (21-err hub, unblocks 2 children). No loom labels.