### PR TITLE
migrate(v4.31): single-proof batch 4 (+4 GREEN)

### DIFF
--- a/proofs/Proofs/Erdos1014OQ02.lean
+++ b/proofs/Proofs/Erdos1014OQ02.lean
@@ -97,7 +97,7 @@ theorem rate_of_convergence_k3 :
         apply div_le_div_of_nonneg_right _ (by positivity)
         exact mul_le_mul_of_nonneg_right (by linarith) (le_of_lt hlog)
     _ = 2 / c * Real.log (l : ℝ) / (l : ℝ) := by
-        field_simp; ring
+        field_simp
 
 -- ══════════════════════════════════════════════════════════════════
 -- § Step 2: log l / l is faster than 1/log l
@@ -111,8 +111,9 @@ theorem log_over_l_faster_than_inv_log :
     ∃ L₀ : ℕ, ∀ l : ℕ, l > L₀ →
       Real.log (l : ℝ) / (l : ℝ) < 1 / Real.log (l : ℝ) := by
   -- Use log² x = o(x): (log x)² / x → 0
-  have ho := Real.isLittleO_log_rpow_atTop (show (0 : ℝ) < 1/2 by norm_num)
-  have hev := ho.bound (show (0 : ℝ) < 1 by norm_num)
+  have ho := isLittleO_log_rpow_atTop (show (0 : ℝ) < 1/2 by norm_num)
+  -- Use constant 1/2 so the resulting bound gives a *strict* inequality below.
+  have hev := ho.bound (show (0 : ℝ) < 1/2 by norm_num)
   obtain ⟨N, hN⟩ := Filter.eventually_atTop.mp hev
   -- Choose L₀ large enough that l > N and l > 2
   use max (⌈N⌉₊ + 1) 2
@@ -124,20 +125,20 @@ theorem log_over_l_faster_than_inv_log :
   rw [div_lt_div_iff₀ hl_pos hlog_pos]
   -- (log l)² < l, i.e., log l · log l < 1 · l
   rw [one_mul]
-  -- From little-o: ‖log l‖ ≤ 1 · ‖l^(1/2)‖, i.e., log l ≤ l^(1/2)
+  -- From little-o: ‖log l‖ ≤ (1/2) · ‖l^(1/2)‖, i.e., log l ≤ (1/2) · l^(1/2)
   have hl_ge_N : N ≤ (l : ℝ) :=
     le_trans (Nat.le_ceil N) (by exact_mod_cast (show ⌈N⌉₊ ≤ l by omega))
   have hb := hN (l : ℝ) hl_ge_N
-  rw [one_mul, Real.norm_eq_abs, Real.norm_eq_abs,
+  rw [Real.norm_eq_abs, Real.norm_eq_abs,
       abs_of_pos hlog_pos, abs_of_pos (rpow_pos_of_pos hl_pos _)] at hb
-  -- log l ≤ l^(1/2), so (log l)² ≤ l
-  have h_sq : Real.log (l : ℝ) * Real.log (l : ℝ) ≤ (l : ℝ) := by
+  -- log l ≤ (1/2) · l^(1/2), so (log l)² ≤ (1/4) · l < l
+  have h_sq : Real.log (l : ℝ) * Real.log (l : ℝ) ≤ (1/4 : ℝ) * (l : ℝ) := by
     calc Real.log (l : ℝ) * Real.log (l : ℝ)
-        ≤ (l : ℝ) ^ ((1:ℝ)/2) * (l : ℝ) ^ ((1:ℝ)/2) := mul_le_mul hb (le_of_lt hb)
-            (le_of_lt hlog_pos) (le_of_lt (rpow_pos_of_pos hl_pos _))
-      _ = (l : ℝ) ^ ((1:ℝ)/2 + (1:ℝ)/2) := (rpow_add hl_pos _ _).symm
-      _ = (l : ℝ) ^ (1:ℝ) := by norm_num
-      _ = (l : ℝ) := rpow_one _
+        ≤ (1/2 * (l : ℝ) ^ ((1:ℝ)/2)) * (1/2 * (l : ℝ) ^ ((1:ℝ)/2)) :=
+          mul_le_mul hb hb (le_of_lt hlog_pos) (by positivity)
+      _ = (1/4 : ℝ) * ((l : ℝ) ^ ((1:ℝ)/2) * (l : ℝ) ^ ((1:ℝ)/2)) := by ring
+      _ = (1/4 : ℝ) * (l : ℝ) := by
+          rw [← rpow_add hl_pos, show (1:ℝ)/2 + 1/2 = 1 by norm_num, rpow_one]
   linarith
 
 -- ══════════════════════════════════════════════════════════════════

--- a/proofs/Proofs/Erdos29OQ02.lean
+++ b/proofs/Proofs/Erdos29OQ02.lean
@@ -55,8 +55,10 @@ noncomputable def basisRestriction (A : Set ℕ) (N : ℕ) : Finset ℕ :=
 /-- Elements of basisRestriction are in A and ≤ N. -/
 theorem mem_basisRestriction (A : Set ℕ) (N : ℕ) (a : ℕ) :
     a ∈ basisRestriction A N ↔ a ∈ A ∧ a ≤ N := by
-  simp [basisRestriction, Finset.mem_filter, Finset.mem_range]
-  omega
+  simp only [basisRestriction, Finset.mem_filter, Finset.mem_range]
+  constructor
+  · rintro ⟨h1, h2⟩; exact ⟨h2, by omega⟩
+  · rintro ⟨h1, h2⟩; exact ⟨by omega, h1⟩
 
 -- ============================================================
 -- Part III: Counting Argument
@@ -70,7 +72,7 @@ noncomputable def pairSumImage (S : Finset ℕ) : Finset ℕ :=
 theorem pairSumImage_card_le (S : Finset ℕ) :
     (pairSumImage S).card ≤ S.card * S.card := by
   unfold pairSumImage
-  calc (S ×ˢ S).image (fun p => p.1 + p.2) |>.card
+  calc (Finset.image (fun p => p.1 + p.2) (S ×ˢ S)).card
       ≤ (S ×ˢ S).card := Finset.card_image_le
     _ = S.card * S.card := Finset.card_product S S
 
@@ -86,7 +88,7 @@ theorem range_subset_pairSum (A : Set ℕ) (hA : IsAdditiveBasis A) (N : ℕ) :
   rw [Finset.mem_image]
   exact ⟨(a, b), Finset.mem_product.mpr
     ⟨(mem_basisRestriction A N a).mpr ⟨ha, haN⟩,
-     (mem_basisRestriction A N b).mpr ⟨hb, hbN⟩⟩, hab⟩
+     (mem_basisRestriction A N b).mpr ⟨hb, hbN⟩⟩, hab.symm⟩
 
 /-- **Corrected lower bound**: For any additive basis A,
     |A ∩ [0,N]|² ≥ N + 1.
@@ -105,12 +107,11 @@ theorem basis_size_squared_lower_bound (A : Set ℕ) (hA : IsAdditiveBasis A) (N
     This is the corrected version of the false `basis_size_lower_bound`. -/
 theorem basis_size_lower_bound_correct (A : Set ℕ) (hA : IsAdditiveBasis A) (N : ℕ) :
     Real.sqrt (N + 1 : ℝ) ≤ ((basisRestriction A N).card : ℝ) := by
-  rw [Real.sqrt_le_left]
-  right
-  constructor
-  · exact Nat.cast_nonneg _
-  · rw [sq]
-    exact_mod_cast basis_size_squared_lower_bound A hA N
+  have h : (N + 1 : ℝ) ≤ ((basisRestriction A N).card : ℝ) ^ 2 := by
+    rw [sq]; exact_mod_cast basis_size_squared_lower_bound A hA N
+  calc Real.sqrt (N + 1 : ℝ)
+      ≤ Real.sqrt (((basisRestriction A N).card : ℝ) ^ 2) := Real.sqrt_le_sqrt h
+    _ = ((basisRestriction A N).card : ℝ) := Real.sqrt_sq (by positivity)
 
 -- ============================================================
 -- Part IV: Consistency with Counterexample

--- a/proofs/Proofs/Erdos910ProblemProvable.lean
+++ b/proofs/Proofs/Erdos910ProblemProvable.lean
@@ -52,7 +52,7 @@ open Set Topology Cardinal
 Basic definitions for connected subspaces.
 -/
 
-variable {X : Type*} [TopologicalSpace X]
+variable {X : Type} [TopologicalSpace X]
 
 /-- The set of all connected subsets of a topological space -/
 def connectedSubsets (X : Type*) [TopologicalSpace X] : Set (Set X) :=
@@ -98,7 +98,7 @@ def HasDiverseConnectedSubset (S : Set X) : Prop :=
 
 /-- Erdős's first conjecture: every connected set has diverse subsets -/
 def erdosFirstConjecture : Prop :=
-  ∀ (X : Type*) [TopologicalSpace X] (S : Set X),
+  ∀ (X : Type) [TopologicalSpace X] (S : Set X),
     IsConnected S → HasDiverseConnectedSubset S
 
 /-
@@ -118,7 +118,7 @@ noncomputable def continuum : Cardinal := #ℝ
 /-- Erdős's second conjecture: connected sets in ℝⁿ have > 2^ℵ₀ connected subsets -/
 def erdosSecondConjecture : Prop :=
   ∀ (n : ℕ) (hn : n ≥ 2) (S : Set (Fin n → ℝ)),
-    IsConnected S → connectedSubsetCardinality S > continuum
+    IsConnected S → connectedSubsetCardinality S > _root_.continuum
 
 /-
 ## The Rudin Set (Counterexample)
@@ -127,7 +127,7 @@ Under CH, Rudin constructed a connected planar set with special properties.
 -/
 
 /-- The Continuum Hypothesis: ℵ₁ = 2^ℵ₀ -/
-def ContinuumHypothesis : Prop := aleph 1 = 2 ^ aleph 0
+def ContinuumHypothesis : Prop := (aleph 1 : Cardinal.{0}) = 2 ^ (aleph 0 : Cardinal.{0})
 
 /-- A "Rudin set" is a connected set where every proper connected subset
     is either a point or homeomorphic to the whole -/
@@ -138,7 +138,7 @@ def IsRudinSet (S : Set X) : Prop :=
 
 /-- A Rudin set has exactly continuum-many connected subsets -/
 def HasExactlyContinuumConnectedSubsets (S : Set X) : Prop :=
-  connectedSubsetCardinality S = continuum
+  connectedSubsetCardinality S = _root_.continuum
 
 /-
 ## Rudin's Theorem (Main Result)
@@ -159,7 +159,7 @@ theorem rudin_theorem :
 
 /-- Rudin sets disprove Erdős's first conjecture -/
 theorem rudin_set_no_diverse_subset (S : Set X) (hS : IsRudinSet S)
-    (hcard : S.nontrivial) : ¬HasDiverseConnectedSubset S := by
+    (hcard : S.Nontrivial) : ¬HasDiverseConnectedSubset S := by
   intro ⟨T, hTsub, hTne, hTconn, ⟨x, y, hx, hy, hxy⟩, hnotHomeo⟩
   -- T is a proper connected subset with more than one point
   have := hS.2 T hTsub hTne hTconn
@@ -184,7 +184,7 @@ theorem erdos_first_conjecture_false :
   -- Apply the conjecture to get a diverse subset
   have hdiv := hconj (ℝ × ℝ) S hconn
   -- But Rudin sets have no diverse subsets
-  have hnontriv : S.nontrivial := by
+  have hnontriv : S.Nontrivial := by
     -- Rudin set is nontrivial (it's connected and has continuum-many subsets)
     sorry
   exact rudin_set_no_diverse_subset S hRudin hnontriv hdiv

--- a/proofs/batch2/STATUS.md
+++ b/proofs/batch2/STATUS.md
@@ -1,3 +1,12 @@
+# DOCTOR SINGLE-PROOF BATCH 4 (8-slot, #38065, 2026-07-15)
+
+**+4 GREEN** (2 cascade children harvested): Erdos1014OQ03Concrete (PURE missing-olean cascade,
+zero .lean edit — just built parent olean), Erdos1014OQ02 (cascade + own drift: isLittleO_log_rpow_atTop
+root ns, IsLittleO.bound ≤-vs-strict gap -> smaller little-o const), Erdos29OQ02 (mem_basisRestriction
+explicit constructor, de-pipe |>.card, Real.sqrt_le_sqrt+sqrt_sq), Erdos910ProblemProvable (cascade +
+Cardinal Type-0 pin, continuum->_root_.continuum, aleph universe pin; pre-existing sorries preserved).
+CASCADE PATTERN CONFIRMED: fix+merge a hub parent, then children flip cheaply. Repairs: none.
+
 # DOCTOR SINGLE-PROOF BATCH 3 (8-slot, #38065, 2026-07-15)
 
 **+4 GREEN**: Erdos910Problem (Cardinal/universe: continuum collision -> _root_.continuum, whole-file

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -646,7 +646,7 @@ Erdos1013ConstantRatio	GREEN
 Erdos1013Problem	GREEN	
 Erdos1013UnconditionalRatio	GREEN	
 Erdos1014OQ01	GREEN	
-Erdos1014OQ02	RESIDUAL	type-mismatch
+Erdos1014OQ02	GREEN	
 Erdos1014OQ03	GREEN	
 Erdos1014OQ03Concrete	RESIDUAL	type-mismatch
 Erdos1014OQ03LogIncrement	GREEN	

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -1095,7 +1095,7 @@ Erdos296Problem	GREEN
 Erdos297Problem	GREEN	
 Erdos298Problem	GREEN	
 Erdos299Problem	GREEN	
-Erdos29OQ02	RESIDUAL	parse-error
+Erdos29OQ02	GREEN	
 Erdos29Problem	GREEN	
 Erdos2OQ01	GREEN	
 Erdos2OQ01Aristotle	RESIDUAL	proof-drift

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -1842,7 +1842,7 @@ Erdos909OQ01Problem	GREEN
 Erdos909Problem	GREEN	
 Erdos90Problem	GREEN	
 Erdos910Problem	GREEN	
-Erdos910ProblemProvable	RESIDUAL	dot-notation-drift
+Erdos910ProblemProvable	GREEN	
 Erdos911Problem	GREEN	proof-drift
 Erdos912Problem	GREEN	
 Erdos913Problem	RESIDUAL	proof-drift

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -648,7 +648,7 @@ Erdos1013UnconditionalRatio	GREEN
 Erdos1014OQ01	GREEN	
 Erdos1014OQ02	RESIDUAL	type-mismatch
 Erdos1014OQ03	GREEN	
-Erdos1014OQ03Concrete	RESIDUAL	type-mismatch
+Erdos1014OQ03Concrete	GREEN	
 Erdos1014OQ03LogIncrement	GREEN	
 Erdos1014OQ03Obstruction	GREEN	
 Erdos1014OQ04	GREEN	


### PR DESCRIPTION
8-slot collection. +4 GREEN incl 2 Erdos1014 cascade children + Erdos910ProblemProvable. No loom labels.