### PR TITLE
migrate(v4.31): single-proof batch 5 (+3 GREEN)

### DIFF
--- a/proofs/Proofs/Erdos515Problem.lean
+++ b/proofs/Proofs/Erdos515Problem.lean
@@ -79,7 +79,7 @@ def PathToInfinity (γ : ℝ → ℂ) : Prop :=
 A path that has finite length on each bounded segment.
 -/
 def LocallyRectifiable (γ : ℝ → ℂ) : Prop :=
-  ∀ a b : ℝ, 0 ≤ a → a < b → ∃ L : ℝ, L < ⊤ ∧ True  -- Placeholder for arc length
+  ∀ a b : ℝ, 0 ≤ a → a < b → ∃ L : ENNReal, L < ⊤ ∧ True  -- Placeholder for arc length
 
 /--
 **Good Path:**
@@ -97,15 +97,15 @@ def IsGoodPath (γ : ℝ → ℂ) : Prop :=
 The integral ∫_C |f(z)|^{-λ} dz along a path.
 (We define this as an integral along a parametrized path.)
 -/
-noncomputable def pathIntegralInversePower (f : ℂ → ℂ) (γ : ℝ → ℂ) (λ : ℝ) : ℝ :=
-  ∫ t in Set.Ici 0, ‖f (γ t)‖ ^ (-λ) * ‖deriv γ t‖
+noncomputable def pathIntegralInversePower (f : ℂ → ℂ) (γ : ℝ → ℂ) (lam : ℝ) : ENNReal :=
+  ∫⁻ t in Set.Ici 0, ENNReal.ofReal (‖f (γ t)‖ ^ (-lam) * ‖deriv γ t‖)
 
 /--
 **Integral is Finite:**
 The path integral converges to a finite value.
 -/
-def IntegralIsFinite (f : ℂ → ℂ) (γ : ℝ → ℂ) (λ : ℝ) : Prop :=
-  pathIntegralInversePower f γ λ < ⊤
+def IntegralIsFinite (f : ℂ → ℂ) (γ : ℝ → ℂ) (lam : ℝ) : Prop :=
+  pathIntegralInversePower f γ lam < ⊤
 
 /-
 ## Part IV: The Questions
@@ -118,8 +118,8 @@ such that ∫_{C_λ} |f|^{-λ} dz is finite?
 -/
 def HuberQuestion (f : ℂ → ℂ) : Prop :=
   IsTranscendental f →
-  ∀ λ : ℝ, λ > 0 →
-    ∃ γ : ℝ → ℂ, IsGoodPath γ ∧ IntegralIsFinite f γ λ
+  ∀ lam : ℝ, lam > 0 →
+    ∃ γ : ℝ → ℂ, IsGoodPath γ ∧ IntegralIsFinite f γ lam
 
 /--
 **Erdős's Question (Strong Form):**
@@ -129,7 +129,7 @@ Does there exist a SINGLE path C such that, for ALL λ > 0,
 def ErdosQuestion (f : ℂ → ℂ) : Prop :=
   IsTranscendental f →
   ∃ γ : ℝ → ℂ, IsGoodPath γ ∧
-    ∀ λ : ℝ, λ > 0 → IntegralIsFinite f γ λ
+    ∀ lam : ℝ, lam > 0 → IntegralIsFinite f γ lam
 
 /--
 **The Universal Question:**
@@ -138,7 +138,7 @@ Does this hold for ALL transcendental entire functions?
 def UniversalQuestion : Prop :=
   ∀ f : ℂ → ℂ, IsTranscendental f →
     ∃ γ : ℝ → ℂ, IsGoodPath γ ∧
-      ∀ λ : ℝ, λ > 0 → IntegralIsFinite f γ λ
+      ∀ lam : ℝ, lam > 0 → IntegralIsFinite f γ lam
 
 /-
 ## Part V: Partial Results
@@ -151,8 +151,8 @@ For each λ > 0, there exists a path C_λ such that ∫_{C_λ} |f|^{-λ} dz < �
 -/
 axiom huber_1957 :
   ∀ f : ℂ → ℂ, IsTranscendental f →
-    ∀ λ : ℝ, λ > 0 →
-      ∃ γ : ℝ → ℂ, IsGoodPath γ ∧ IntegralIsFinite f γ λ
+    ∀ lam : ℝ, lam > 0 →
+      ∃ γ : ℝ → ℂ, IsGoodPath γ ∧ IntegralIsFinite f γ lam
 
 /--
 **Zhang's Theorem (1977):**
@@ -161,7 +161,7 @@ If f has finite order, then a single path works for all λ.
 axiom zhang_1977 :
   ∀ f : ℂ → ℂ, IsTranscendental f → HasFiniteOrder f →
     ∃ γ : ℝ → ℂ, IsGoodPath γ ∧
-      ∀ λ : ℝ, λ > 0 → IntegralIsFinite f γ λ
+      ∀ lam : ℝ, lam > 0 → IntegralIsFinite f γ lam
 
 /-
 ## Part VI: The Main Result
@@ -254,7 +254,7 @@ theorem erdos_515_summary :
     (∀ f : ℂ → ℂ, IsTranscendental f → HuberQuestion f) ∧
     -- Zhang's intermediate result (1977): single path for finite-order functions
     (∀ f : ℂ → ℂ, IsTranscendental f → HasFiniteOrder f →
-      ∃ γ : ℝ → ℂ, IsGoodPath γ ∧ ∀ λ : ℝ, λ > 0 → IntegralIsFinite f γ λ) := by
+      ∃ γ : ℝ → ℂ, IsGoodPath γ ∧ ∀ lam : ℝ, lam > 0 → IntegralIsFinite f γ lam) := by
   constructor
   · exact lewis_rossi_weitsman_1984
   constructor
@@ -277,7 +277,7 @@ For every transcendental entire function, a single path works for all λ.
 theorem erdos_515_answer :
     ∀ f : ℂ → ℂ, IsTranscendental f →
       ∃ γ : ℝ → ℂ, IsGoodPath γ ∧
-        ∀ λ : ℝ, λ > 0 → IntegralIsFinite f γ λ :=
+        ∀ lam : ℝ, lam > 0 → IntegralIsFinite f γ lam :=
   lewis_rossi_weitsman_1984
 
 end Erdos515

--- a/proofs/Proofs/Erdos552Aristotle.lean
+++ b/proofs/Proofs/Erdos552Aristotle.lean
@@ -97,7 +97,7 @@ theorem exact_value_q2_minus_t_ari (q t : ℕ) (ht : t ≤ q)
     H is C₄-free and the complement of H contains no S_{q²}. -/
 theorem parsons_construction_ari (q : ℕ) (hq : Nat.Prime q) :
     ∃ G : SimpleGraph (Fin (q ^ 2 + q + 1)),
-      ¬ContainsSubgraph G C4 ∧ ¬ContainsSubgraph (complement G) (starGraph (q ^ 2)) := by
+      ¬ContainsSubgraph G C4 ∧ ¬ContainsSubgraph (complement G) (Erdos552.starGraph (q ^ 2)) := by
   sorry
 
 -- ═══════════════════════════════════════════════════════════════════
@@ -110,7 +110,7 @@ theorem parsons_construction_ari (q : ℕ) (hq : Nat.Prime q) :
     Proof sketch: Any two vertices u, v of high degree share ≥ 2 common
     neighbors by pigeonhole (degrees sum to ≥ n, so intersection ≥ 2), giving
     a 4-cycle u—w₁—v—w₂—u. -/
-theorem c4_minimum_degree_ari (n : ℕ) (G : SimpleGraph (Fin n)) (hn : n ≥ 4) :
+theorem c4_minimum_degree_ari (n : ℕ) (G : SimpleGraph (Fin n)) [DecidableRel G.Adj] (hn : n ≥ 4) :
     (∀ v : Fin n, G.degree v ≥ n / 2) → ContainsSubgraph G C4 := by
   sorry
 

--- a/proofs/Proofs/RationalCanonicalFormExists.lean
+++ b/proofs/Proofs/RationalCanonicalFormExists.lean
@@ -73,8 +73,10 @@ lemma charpoly_mulX_aeval' {W : Type*} [AddCommGroup W] [Module F W]
     (mulX F (Module.AEval' f)).charpoly = f.charpoly := by
   -- By definition of $AEval'$, we know that $mulX F (Module.AEval' f)$ is conjugate to $f$.
   have h_conj : (mulX F (Module.AEval' f)) = (LinearEquiv.conj (Module.AEval'.of f) f) := by
-    ext m;
-    convert Module.AEval'.of_symm_X_smul f ( ( Module.AEval'.of f ).symm m ) using 1;
+    ext m
+    show (X : F[X]) • m = (Module.AEval'.of f) (f ((Module.AEval'.of f).symm m))
+    conv_lhs => rw [← (Module.AEval'.of f).apply_symm_apply m]
+    rw [Module.AEval'.X_smul_of]
   rw [ h_conj, LinearEquiv.charpoly_conj ]
 
 /-
@@ -127,7 +129,7 @@ lemma det_blockDiagonal' {R : Type*} [CommRing R] {ι : Type*} [Fintype ι] [Dec
       rw [ ← Matrix.det_submatrix_equiv_self e ];
       exact congr_arg Matrix.det ( by ext x y; exact he x y );
     rw [ h_det, Matrix.det_fromBlocks_zero₂₁, ih ];
-    · rw [ Finset.prod_eq_mul_prod_diff_singleton ( Finset.mem_univ i ) ];
+    · rw [ Finset.prod_eq_mul_prod_sdiff_singleton_of_mem ( Finset.mem_univ i ) ];
       refine' congr rfl ( Finset.prod_bij ( fun j _ => j ) _ _ _ _ ) <;> simp +decide;
       · exact fun x hx => hx;
       · exact fun j hj => hj;
@@ -140,10 +142,9 @@ lemma charpoly_blockDiagonal' {R : Type*} [CommRing R] {ι : Type*} [Fintype ι]
     {m : ι → Type*} [∀ i, Fintype (m i)] [∀ i, DecidableEq (m i)]
     (Mat : (i : ι) → Matrix (m i) (m i) R) :
     (Matrix.blockDiagonal' Mat).charpoly = ∏ i, (Mat i).charpoly := by
-  convert det_blockDiagonal' _ using 1;
-  all_goals try infer_instance;
   unfold Matrix.charpoly;
-  congr;
+  rw [← det_blockDiagonal' (fun i => Matrix.charmatrix (Mat i))];
+  congr 1;
   ext ⟨ i, a ⟩ ⟨ j, b ⟩ ; by_cases hij : i = j <;> simp +decide [ hij, Matrix.charmatrix ] ;
   · subst hij; simp +decide [ Matrix.diagonal ] ;
   · simp +decide [ hij, blockDiagonal' ]
@@ -159,9 +160,11 @@ lemma charpoly_mulX_isInternal {ι : Type*} [Fintype ι] [DecidableEq ι]
     (hmap : ∀ i, ∀ x ∈ S i, mulX F W x ∈ S i)
     (h : DirectSum.IsInternal S) :
     (mulX F W).charpoly = ∏ i, ((mulX F W).restrict (fun x hx => hmap i x hx)).charpoly := by
-  convert ( RCF.charpoly_blockDiagonal' fun i => LinearMap.toMatrix ( Module.Free.chooseBasis F ( S i ) ) ( Module.Free.chooseBasis F ( S i ) ) ( ( mulX F W ).restrict ( hmap i ) ) ) using 1;
-  convert ( LinearMap.charpoly_toMatrix ( mulX F W ) ( h.collectedBasis ( fun i => Module.Free.chooseBasis F ( S i ) ) ) ) |> Eq.symm using 1;
-  rw [ LinearMap.toMatrix_directSum_collectedBasis_eq_blockDiagonal' ]
+  rw [← LinearMap.charpoly_toMatrix (mulX F W)
+        (h.collectedBasis (fun i => Module.Free.chooseBasis F (S i))),
+      LinearMap.toMatrix_directSum_collectedBasis_eq_blockDiagonal' h h _ _ (fun i => hmap i),
+      RCF.charpoly_blockDiagonal']
+  exact Finset.prod_congr rfl fun i _ => LinearMap.charpoly_toMatrix _ _
 
 /-
 The canonical component submodules of an external direct sum form an internal direct sum
@@ -192,23 +195,23 @@ lemma charpoly_mulX_directSum {ι : Type*} [Fintype ι] [DecidableEq ι]
     [∀ i, Module F (W i)] [∀ i, IsScalarTower F F[X] (W i)]
     [∀ i, Module.Finite F (W i)] [∀ i, Module.Free F (W i)] :
     (mulX F (DirectSum ι W)).charpoly = ∏ i, (mulX F (W i)).charpoly := by
-  convert RCF.charpoly_mulX_isInternal _ _;
-  any_goals try exact fun i => ( LinearMap.range ( DirectSum.lof F[X] ι W i ) ).restrictScalars F;
-  any_goals exact RCF.directSum_components_isInternal W;
-  swap;
-  intro i x hx;
-  obtain ⟨ y, rfl ⟩ := hx;
-  exact ⟨ ( X : F[X] ) • y, by simp +decide [ mulX ] ⟩;
-  convert RCF.charpoly_mulX_congr _;
-  · infer_instance;
-  · infer_instance;
-  · infer_instance;
-  · refine' LinearEquiv.ofBijective _ ⟨ _, _ ⟩;
-    refine' { toFun := fun x => ⟨ DirectSum.lof F[X] ι W _ x, _ ⟩, map_add' := _, map_smul' := _ };
-    all_goals simp +decide [ Function.Injective, Function.Surjective ];
-    · aesop;
-    · intro x y hxy;
-      replace hxy := congr_arg ( fun f => f ‹_› ) hxy ; aesop
+  classical
+  have hmap : ∀ i, ∀ x ∈ (LinearMap.range (DirectSum.lof F[X] ι W i)).restrictScalars F,
+      mulX F (DirectSum ι W) x ∈ (LinearMap.range (DirectSum.lof F[X] ι W i)).restrictScalars F := by
+    intro i x hx
+    obtain ⟨y, rfl⟩ := hx
+    exact ⟨(X : F[X]) • y, by simp [mulX]⟩
+  have hinj : ∀ i, Function.Injective (DirectSum.lof F[X] ι W i) :=
+    fun i => Function.LeftInverse.injective (g := DirectSum.component F[X] ι W i)
+      (fun b => DirectSum.component.lof_self F i b)
+  have e : ∀ i, W i ≃ₗ[F[X]] ↥((LinearMap.range (DirectSum.lof F[X] ι W i)).restrictScalars F) :=
+    fun i => (LinearEquiv.ofInjective (DirectSum.lof F[X] ι W i) (hinj i)).trans
+      (Submodule.restrictScalarsEquiv (R := F[X]) (M := DirectSum ι W) F
+        (LinearMap.range (DirectSum.lof F[X] ι W i))).symm
+  rw [RCF.charpoly_mulX_isInternal hmap (RCF.directSum_components_isInternal W)]
+  refine Finset.prod_congr rfl fun i _ => ?_
+  rw [RCF.charpoly_mulX_congr (e i)]
+  rfl
 
 /-
 The charpoly of multiplication-by-`X` on the cyclic module `F[X] ⧸ (g)` is `g`
@@ -224,11 +227,8 @@ lemma charpoly_mulX_quotient (g : F[X]) (hg : g.Monic)
       intro p
       have h_aeval : ∀ w : F[X] ⧸ Ideal.span {g}, (aeval (mulX F (F[X] ⧸ Ideal.span {g})) p) w = p • w := by
         induction p using Polynomial.induction_on <;> simp_all +decide [ Polynomial.aeval_add, Polynomial.aeval_X, Polynomial.aeval_C ];
-        · intro w; exact (by
-          convert rfl;
-          ext; simp [HSMul.hSMul];
-          simp +decide [ SMul.smul ];
-          simp +decide [ Algebra.smul_def ]);
+        · intro w
+          simp only [← Polynomial.algebraMap_eq, algebraMap_smul];
         · simp +decide [ add_smul ];
         · simp_all +decide [ pow_succ, mulX ];
           simp +decide [ ← mul_assoc, ← smul_assoc ];
@@ -270,7 +270,7 @@ The quotient of `F[X]` by the span of a nonzero polynomial is finite-dimensional
 -/
 lemma finite_quotient_span (g : F[X]) (hg : g ≠ 0) :
     Module.Finite F (F[X] ⧸ Ideal.span {g}) := by
-  convert ( AdjoinRoot.powerBasis hg ).finite
+  exact ( AdjoinRoot.powerBasis hg ).finite
 
 /-- The monic associate of a polynomial. -/
 noncomputable def monicAssoc (g : F[X]) : F[X] := g * Polynomial.C (g.leadingCoeff)⁻¹
@@ -323,11 +323,11 @@ lemma decomp_charpoly_minpoly {n : Type*} [Fintype n] [DecidableEq n] (M : Matri
         (RCF.monicAssoc_monic (pow_ne_zero _ (hp i).ne_zero))]
   · have h_annihilator : Ideal.span {minpoly F M} = ⨅ i, Ideal.span {p i ^ ev i} := by
       have h_annihilator : Module.annihilator F[X] (DirectSum ι' (fun i => F[X] ⧸ Ideal.span {p i ^ ev i})) = ⨅ i, Ideal.span {p i ^ ev i} := by
-        have h_annihilator : ∀ i, Module.annihilator F[X] (F[X] ⧸ Ideal.span {p i ^ ev i}) = Ideal.span {p i ^ ev i} := by
-          intro i;
-          exact Ideal.annihilator_quotient;
-        convert Module.annihilator_dfinsupp;
-        rw [ h_annihilator ];
+        have h1 : Module.annihilator F[X] (DirectSum ι' (fun i => F[X] ⧸ Ideal.span {p i ^ ev i}))
+            = ⨅ i, Module.annihilator F[X] (F[X] ⧸ Ideal.span {p i ^ ev i}) :=
+          Module.annihilator_dfinsupp
+        rw [h1];
+        exact iInf_congr fun i => Ideal.annihilator_quotient;
       rw [ ← h_annihilator, ← e.annihilator_eq ];
       rw [ ← minpoly_toLin', Polynomial.span_minpoly_eq_annihilator ];
     intro c; rw [ Ideal.ext_iff ] at h_annihilator; specialize h_annihilator c; simp_all +decide [ Ideal.mem_span_singleton, Submodule.mem_iInf ] ;
@@ -446,9 +446,7 @@ lemma exists_chain_aux {ι : Type*} [DecidableEq ι]
       by_cases ha : a.val < L'.length <;> by_cases hb : b.val < L'.length <;> simp +decide [ ha, hb ] at hab ⊢;
       · exact hL'chain ⟨ a, ha ⟩ ⟨ b, hb ⟩ hab;
       · have h_div : L'[a] ∣ L'.getLast?.getD 1 := by
-          convert hL'chain ⟨ a, ha ⟩ ⟨ L'.length - 1, Nat.sub_lt ( by linarith ) zero_lt_one ⟩ _ using 1;
-          · grind;
-          · exact Nat.le_pred_of_lt ha;
+          convert hL'chain ⟨ a, ha ⟩ ⟨ L'.length - 1, Nat.sub_lt ( by linarith ) zero_lt_one ⟩ ( Nat.le_pred_of_lt ha ) using 1 <;> grind;
         refine' dvd_trans h_div _;
         grind;
       · exact False.elim ( ha ( lt_of_le_of_lt hab hb ) );

--- a/proofs/batch2/STATUS.md
+++ b/proofs/batch2/STATUS.md
@@ -1,3 +1,13 @@
+# DOCTOR SINGLE-PROOF BATCH 5 (8-slot, #38065, 2026-07-15)
+
+**+3 GREEN**: RationalCanonicalFormExists (13-site HUB, hardest of the wave ~22min: Aristotle
+convert-chains decayed -> explicit rw/term proofs w/ LinearMap.charpoly_toMatrix +
+toMatrix_directSum_collectedBasis_eq_blockDiagonal'; Finset.prod_eq_mul_prod_diff_singleton alias
+retargets a DIFFERENT sig -> use ..._sdiff_singleton_of_mem; unblocks MinpolyCharpolyOQ03),
+Erdos515Problem (λ is now a hard keyword -> rename bound var; <⊤ on ℝ fails Top synth -> ENNReal),
+Erdos552Aristotle (SimpleGraph.starGraph now in Mathlib -> qualify local; degree needs DecidableRel).
+Repairs: none.
+
 # DOCTOR SINGLE-PROOF BATCH 4 (8-slot, #38065, 2026-07-15)
 
 **+4 GREEN** (2 cascade children harvested): Erdos1014OQ03Concrete (PURE missing-olean cascade,

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -1352,7 +1352,7 @@ Erdos510Problem	GREEN
 Erdos512Aristotle	RESIDUAL	unknown-const:MeasureTheory.integrableOn_const.mpr
 Erdos512Problem	GREEN	
 Erdos514Problem	GREEN	
-Erdos515Problem	RESIDUAL	parse-error
+Erdos515Problem	GREEN	
 Erdos516Problem	GREEN	
 Erdos519Problem	GREEN	
 Erdos51Problem	GREEN	

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -2368,7 +2368,7 @@ RandomizedMaxCutOQ03	GREEN
 RandomizedMaxCutOQ05	GREEN	
 RandomizedMaxcutOQ02	GREEN	
 RandomizedMaxcutOQ04	RESIDUAL	unknown-const:Finset.disjoint_compl_right
-RationalCanonicalFormExists	RESIDUAL	type-mismatch
+RationalCanonicalFormExists	GREEN	
 RiemannHypothesis	GREEN	
 RiemannHypothesisConsequences	GREEN	
 RothTheorem	GREEN	

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -1395,7 +1395,7 @@ Erdos54Problem	GREEN
 Erdos550Problem	GREEN	
 Erdos551Problem	RESIDUAL	instance-synth
 Erdos551ProblemAristotle	RESIDUAL	proof-drift
-Erdos552Aristotle	RESIDUAL	parse-error
+Erdos552Aristotle	GREEN	
 Erdos552Problem	GREEN	
 Erdos553Aristotle	GREEN	
 Erdos553Problem	GREEN	


### PR DESCRIPTION
8-slot collection. +3 GREEN incl RationalCanonicalFormExists hub (unblocks MinpolyCharpolyOQ03). No loom labels.