### PR TITLE
migrate(v4.31): single-proof batch 6 (+4 GREEN)

### DIFF
--- a/proofs/Proofs/Erdos421Problem.lean
+++ b/proofs/Proofs/Erdos421Problem.lean
@@ -256,7 +256,10 @@ theorem total_product_ge_factorial (d : ℕ → ℕ) (hd : IsValidSequence d) (n
   | zero => simp
   | succ n ih =>
     rw [Nat.factorial_succ, Finset.prod_range_succ]
-    exact Nat.mul_le_mul (valid_seq_ge_succ d hd n) ih
+    calc (n + 1) * n !
+        = n ! * (n + 1) := by ring
+      _ ≤ (∏ i ∈ Finset.range n, d i) * d n :=
+          Nat.mul_le_mul ih (valid_seq_ge_succ d hd n)
 
 /-- For distinct products, d(0) ≥ 2. If d(0) = 1, then
     intervalProduct [0,1] = 1 * d(1) = d(1) = intervalProduct [1,1],
@@ -266,7 +269,7 @@ theorem first_term_ge_two (d : ℕ → ℕ) (hd : IsValidSequence d)
   by_contra h
   push_neg at h
   have hd0 : d 0 = 1 := by
-    have := hd.2; omega
+    have h2 : 1 ≤ d 0 := hd.2; omega
   -- intervalProduct [0,1] = d(0) * d(1) = d(1)
   have h01 : productMap d (0, 1) = d 1 := by
     simp only [productMap, intervalProduct]
@@ -277,8 +280,10 @@ theorem first_term_ge_two (d : ℕ → ℕ) (hd : IsValidSequence d)
   have h11 : productMap d (1, 1) = d 1 := by
     simp [productMap]
   -- Same product, different valid pairs → contradiction
-  have hpairs : (0, 1) ≠ (1, 1 : ℕ × ℕ) := by simp
-  exact hpairs (hdist (show (0 : ℕ) ≤ 1 by omega) le_rfl (h01.trans h11.symm))
+  have hpairs : ((0, 1) : ℕ × ℕ) ≠ (1, 1) := by simp
+  have hmem0 : ((0, 1) : ℕ × ℕ) ∈ ValidPairs := Nat.zero_le 1
+  have hmem1 : ((1, 1) : ℕ × ℕ) ∈ ValidPairs := le_refl 1
+  exact hpairs (hdist hmem0 hmem1 (h01.trans h11.symm))
 
 /-- For distinct products, d(i) ≥ i + 2 for all i (strengthening valid_seq_ge_succ).
     Proof: d(0) ≥ 2 and d strictly increasing with d(i) ≥ i+1, so d(i) ≥ i+2. -/
@@ -300,7 +305,10 @@ theorem total_product_ge_shifted_factorial (d : ℕ → ℕ) (hd : IsValidSequen
   | zero => simp
   | succ n ih =>
     rw [Nat.factorial_succ, Finset.prod_range_succ]
-    exact Nat.mul_le_mul (distinct_products_stronger_growth d hd hdist n) ih
+    calc (n + 1 + 1) * (n + 1)!
+        = (n + 1)! * (n + 1 + 1) := by ring
+      _ ≤ (∏ i ∈ Finset.range n, d i) * d n :=
+          Nat.mul_le_mul ih (distinct_products_stronger_growth d hd hdist n)
 
 /-
 # Part 5: The Main Conjecture
@@ -404,15 +412,15 @@ This constrains how small the maximum product (= ∏ all terms) can be.
 /-- The number of valid pairs (u,v) with u ≤ v and both in {0, ..., n-1}
     is exactly n*(n+1)/2. Uses `Finset.range n` for correct n=0 handling. -/
 theorem numValidPairs_eq (n : ℕ) :
-    ((Finset.range n).product (Finset.range n)).filter
-      (fun p => p.1 ≤ p.2) |>.card = n * (n + 1) / 2 := by
+    (((Finset.range n) ×ˢ (Finset.range n)).filter
+      (fun p => p.1 ≤ p.2)).card = n * (n + 1) / 2 := by
   induction n with
   | zero => simp
   | succ n ih =>
     -- Decompose: filtered pairs on range(n+1) = filtered pairs on range(n)
     --   ∪ {(u, n) : u ∈ range(n+1)} (n+1 new pairs with second component = n)
-    set S := ((Finset.range (n + 1)).product (Finset.range (n + 1))).filter (fun p => p.1 ≤ p.2)
-    set S_old := ((Finset.range n).product (Finset.range n)).filter (fun p => p.1 ≤ p.2)
+    set S := ((Finset.range (n + 1)) ×ˢ (Finset.range (n + 1))).filter (fun p => p.1 ≤ p.2)
+    set S_old := ((Finset.range n) ×ˢ (Finset.range n)).filter (fun p => p.1 ≤ p.2)
     set S_new := (Finset.range (n + 1)).image (fun u => (u, n))
     have h_eq : S = S_old ∪ S_new := by
       ext ⟨a, b⟩
@@ -473,7 +481,7 @@ theorem consecutive_product_gt_single (d : ℕ → ℕ) (hd : IsValidSequence d)
   have h := distinct_products_stronger_growth d hd hdist (u + 1)
   have hpos : 0 < d u := Nat.lt_of_lt_of_le Nat.zero_lt_one (valid_seq_pos d hd u)
   calc d u = d u * 1 := (Nat.mul_one _).symm
-    _ < d u * d (u + 1) := Nat.mul_lt_mul_left hpos (by omega)
+    _ < d u * d (u + 1) := (Nat.mul_lt_mul_left hpos).mpr (by omega)
 
 /-- If d has distinct products, single-element products and 2-element products
     never collide: for any w and any u, d(w) ≠ d(u)*d(u+1).
@@ -486,11 +494,13 @@ theorem single_ne_pair_product (d : ℕ → ℕ) (hd : IsValidSequence d)
     intervalProduct d w w ≠ intervalProduct d u (u + 1) := by
   intro heq
   -- In HasDistinctProducts (InjOn), same product forces same pair
-  have hw : w ≤ w := le_refl w
-  have hu : u ≤ u + 1 := Nat.le_succ u
-  have hpairs := hdist hw hu heq
+  have hw : (w, w) ∈ ValidPairs := le_refl w
+  have hu : (u, u + 1) ∈ ValidPairs := Nat.le_succ u
+  have hprod : productMap d (w, w) = productMap d (u, u + 1) := heq
+  have hpairs := hdist hw hu hprod
   -- But (w, w) ≠ (u, u+1) since snd differs
-  simp at hpairs
+  simp only [Prod.mk.injEq] at hpairs
+  omega
 
 /-- Product with a longer interval strictly dominates the shorter one
     extending from the same start: ∏[u,v] < ∏[u,v+1] for valid sequences.
@@ -505,7 +515,7 @@ theorem product_strict_mono_right (d : ℕ → ℕ) (hd : IsValidSequence d)
   calc intervalProduct d u v
       = intervalProduct d u v * 1 := (Nat.mul_one _).symm
     _ < intervalProduct d u v * d (v + 1) :=
-        Nat.mul_lt_mul_left hprod_pos (by omega)
+        (Nat.mul_lt_mul_left hprod_pos).mpr (by omega)
 
 /-- For distinct products, the maximum product among all intervals in [0, n-1]
     (which is ∏[0, n-1]) must be at least n*(n+1)/2, because n*(n+1)/2 distinct
@@ -537,9 +547,11 @@ theorem total_product_lower_from_counting (d : ℕ → ℕ) (hd : IsValidSequenc
           | zero => simp
           | succ k =>
             -- (k+2)*(k+3)/2 ≤ (k+3)*(k+2)!
-            -- Since (k+2)! ≥ (k+2)/2 ≥ 1 for k ≥ 0
-            have : (k + 2) ! ≥ 1 := Nat.one_le_iff_ne_zero.mpr (Nat.factorial_ne_zero _)
-            nlinarith [Nat.factorial_pos (k + 2)]
+            -- Since (k+2)! ≥ (k+2) ≥ 1 for k ≥ 0
+            calc (k + 2) * (k + 3) / 2
+                ≤ (k + 2) * (k + 3) := Nat.div_le_self _ _
+              _ = (k + 3) * (k + 2) := by ring
+              _ ≤ (k + 3) * (k + 2)! := Nat.mul_le_mul le_rfl (Nat.self_le_factorial _)
     _ ≤ ∏ i ∈ Finset.range n, d i := hfact
 
 /-

--- a/proofs/Proofs/Erdos642Problem.lean
+++ b/proofs/Proofs/Erdos642Problem.lean
@@ -41,7 +41,7 @@ structure Cycle (G : SimpleGraph V) where
   vertices : List V
   length_ge_3 : vertices.length ≥ 3
   is_cycle : ∀ i : Fin vertices.length,
-    G.Adj (vertices.get i) (vertices.get ⟨(i.val + 1) % vertices.length, by omega⟩)
+    G.Adj (vertices.get i) (vertices.get ⟨(i.val + 1) % vertices.length, Nat.mod_lt _ (by omega)⟩)
   no_repeated : vertices.Nodup
 
 /-- The length (number of vertices) of a cycle. -/
@@ -65,6 +65,7 @@ def IsDiagonal {G : SimpleGraph V} (C : Cycle G) (e : Sym2 V) : Prop :=
     e = s(C.vertices.get i, C.vertices.get j) ∧
     G.Adj (C.vertices.get i) (C.vertices.get j)
 
+open scoped Classical in
 /-- Count of diagonals in a cycle. -/
 noncomputable def diagonalCount {G : SimpleGraph V} [DecidableEq V] [Fintype V]
     [DecidableRel G.Adj] (C : Cycle G) : ℕ :=
@@ -184,17 +185,17 @@ The key tool in the DMMS improvement.
 -/
 
 /-- A graph is an (n, d, λ)-expander if it's d-regular with spectral gap. -/
-def IsExpander (G : SimpleGraph (Fin n)) (d : ℕ) (λ : ℝ) : Prop :=
+def IsExpander (G : SimpleGraph (Fin n)) [DecidableRel G.Adj] (d : ℕ) (lam : ℝ) : Prop :=
   -- All vertices have degree d
   (∀ v, G.degree v = d) ∧
-  -- Second eigenvalue is at most λ (spectral gap property)
-  λ < d
+  -- Second eigenvalue is at most lam (spectral gap property)
+  lam < d
 
 /-- Sublinear expanders (d = n^ε for some ε < 1). -/
-def IsSublinearExpander (G : SimpleGraph (Fin n)) : Prop :=
+def IsSublinearExpander (G : SimpleGraph (Fin n)) [DecidableRel G.Adj] : Prop :=
   ∃ ε : ℝ, 0 < ε ∧ ε < 1 ∧
     ∃ d : ℕ, d ≥ Nat.floor ((n : ℝ)^ε) ∧
-      ∃ λ : ℝ, IsExpander G d λ
+      ∃ lam : ℝ, IsExpander G d lam
 
 /-  **Key Lemma (DMMS)**: Random walks in expanders find cycles with many diagonals. -/
 /-
@@ -215,7 +216,8 @@ theorem pentagon_all_diags_violates :
 /-- Critical transition at length 5. -/
 theorem critical_length : ∀ k : ℕ, k ≥ 5 → k ≤ k * (k - 3) / 2 := by
   intro k hk
-  omega
+  rw [Nat.le_div_iff_mul_le (by norm_num : 0 < 2)]
+  exact Nat.mul_le_mul (le_refl k) (by omega)
 
 /-
 ## Part XI: Main Results
@@ -252,10 +254,17 @@ def erdos_642_status : String :=
 
 /-- Gap between known bounds. -/
 theorem bounds_gap : ∃ gap : ℝ → ℝ,
-    (∀ n : ℝ, n ≥ 10 → gap n = n * (Real.log n)^8 / n^(3/2)) ∧
-    (∀ n : ℝ, n ≥ 10 → gap n = (Real.log n)^8 / n^(1/2)) := by
+    (∀ n : ℝ, n ≥ 10 → gap n = n * (Real.log n)^8 / n^(3/2 : ℝ)) ∧
+    (∀ n : ℝ, n ≥ 10 → gap n = (Real.log n)^8 / n^(1/2 : ℝ)) := by
   use fun n => (Real.log n)^8 / n^(1/2 : ℝ)
-  constructor <;> intro n hn <;> ring_nf
+  refine ⟨fun n hn => ?_, fun n hn => rfl⟩
+  have hn0 : (0:ℝ) < n := by linarith
+  have hp : n ^ (1/2 : ℝ) ≠ 0 := ne_of_gt (Real.rpow_pos_of_pos hn0 _)
+  have hn' : n ≠ 0 := ne_of_gt hn0
+  have h32 : n ^ (3/2 : ℝ) = n * n ^ (1/2 : ℝ) := by
+    rw [show (3/2 : ℝ) = 1 + 1/2 by norm_num, Real.rpow_add hn0, Real.rpow_one]
+  rw [h32]
+  field_simp
 
 #check erdos_642_bounds
 #check dmms_2024

--- a/proofs/Proofs/Erdos715Problem.lean
+++ b/proofs/Proofs/Erdos715Problem.lean
@@ -64,7 +64,7 @@ def inducedSubgraph {V : Type*} (G : SimpleGraph' V) (S : Set V) : SimpleGraph' 
 
 /-- Does every r-regular graph contain a k-regular subgraph? -/
 def HasRegularSubgraph (r k : ℕ) : Prop :=
-  ∀ (V : Type*) [Fintype V] [DecidableEq V] (G : SimpleGraph' V) [DecidableRel G.adj],
+  ∀ (V : Type) [Fintype V] [DecidableEq V] (G : SimpleGraph' V) [DecidableRel G.adj],
     IsRegular G r →
     ∃ (H : SimpleGraph' V) (_ : DecidableRel H.adj), IsSubgraph H G ∧ IsRegular H k
 
@@ -82,11 +82,11 @@ theorem regular_has_3_regular (r : ℕ) (hr : r ≥ 4) : HasRegularSubgraph r 3 
 theorem alon_friedland_kalai {V : Type*} [Fintype V] [DecidableEq V]
     (G : SimpleGraph' V) [DecidableRel G.adj]
     (hG : IsRegular G 4) (e : V × V) (he : ¬G.adj e.1 e.2) :
-    let G' := { adj := fun u v => G.adj u v ∨ ({u, v} = {e.1, e.2})
-                symm := by constructor; intro u v; simp [Set.pair_comm]; tauto
-                loopless := by constructor; intro v h; cases h with
-                  | inl h => exact G.loopless v h
-                  | inr h => skip
+    let G' : SimpleGraph' V :=
+      { adj := fun u v => G.adj u v ∨ (u ≠ v ∧ ({u, v} : Set V) = {e.1, e.2})
+        symm := fun u v h => h.imp (G.symm u v)
+          (fun hp => ⟨fun huv => hp.1 huv.symm, by rw [Set.pair_comm v u]; exact hp.2⟩)
+        loopless := fun v h => h.elim (G.loopless v) (fun hp => hp.1 rfl) }
     ∃ (H : SimpleGraph' V) (_ : DecidableRel H.adj), IsSubgraph H G' ∧ IsRegular H 3 := by
   sorry -- Alon-Friedland-Kalai (1984)
 
@@ -102,6 +102,8 @@ def K4 : SimpleGraph' (Fin 4) where
   adj u v := u ≠ v
   symm _ _ h := h.symm
   loopless _ h := h rfl
+
+instance : DecidableRel K4.adj := fun u v => inferInstanceAs (Decidable (u ≠ v))
 
 theorem K4_is_3_regular : IsRegular K4 3 := by
   sorry
@@ -132,9 +134,11 @@ theorem berge_sauer_answer : berge_sauer_question := by
 
 /- ## General Regular Subgraph Problem -/
 
+open Classical in
 /-- General question: When does r-regular imply k-regular subgraph? -/
-def RegularSubgraphThreshold (k : ℕ) : ℕ :=
-  Nat.find ⟨k + 1, by sorry⟩ -- The minimum r such that r-regular ⟹ k-regular subgraph
+noncomputable def RegularSubgraphThreshold (k : ℕ) : ℕ :=
+  -- The minimum r such that r-regular ⟹ k-regular subgraph
+  Nat.find (p := fun r => HasRegularSubgraph r k) ⟨k + 1, by sorry⟩
 
 /-- For k = 3, the threshold is 4 -/
 theorem threshold_for_3 : RegularSubgraphThreshold 3 = 4 := by
@@ -160,8 +164,12 @@ def petersenGraph : SimpleGraph' (Fin 10) where
       spoke ⟨v.val, h.2⟩ ⟨u.val - 5, by omega⟩
     else
       False
-  symm := by constructor; intro u v; simp; sorry
-  loopless := by constructor; intro v; simp; sorry
+  symm := by intro u v h; sorry
+  loopless := by intro v h; sorry
+
+open Classical in
+noncomputable instance : DecidableRel petersenGraph.adj :=
+  fun u v => Classical.propDecidable (petersenGraph.adj u v)
 
 theorem petersen_is_3_regular : IsRegular petersenGraph 3 := by
   sorry
@@ -176,7 +184,7 @@ theorem petersen_no_proper_3_subgraph :
 /- ## Edge Counting Arguments -/
 
 /-- In an r-regular graph on n vertices, there are rn/2 edges -/
-theorem regular_edge_count {V : Type*} [Fintype V] [DecidableEq V]
+theorem regular_edge_count {V : Type*} [Fintype V] [DecidableEq V] [LinearOrder V]
     (G : SimpleGraph' V) [DecidableRel G.adj] (r : ℕ) (hG : IsRegular G r) :
     2 * (Finset.filter (fun p : V × V => p.1 < p.2 ∧ G.adj p.1 p.2) Finset.univ).card =
     r * Fintype.card V := by

--- a/proofs/Proofs/Erdos766Problem.lean
+++ b/proofs/Proofs/Erdos766Problem.lean
@@ -33,6 +33,9 @@ import Mathlib.Combinatorics.SimpleGraph.Finite
 import Mathlib.Combinatorics.SimpleGraph.Subgraph
 import Mathlib.Data.Finset.Card
 import Mathlib.Data.Nat.Basic
+import Mathlib.Order.Lattice.Nat
+import Mathlib.Data.Set.Card
+import Mathlib.Data.Real.Basic
 
 open Finset Nat
 
@@ -44,9 +47,8 @@ namespace Erdos766
 abbrev Graph (V : Type*) [Fintype V] := SimpleGraph V
 
 /-- Number of edges in a graph. -/
-noncomputable def numEdges {V : Type*} [Fintype V] [DecidableEq V]
-    (G : Graph V) : ℕ :=
-  Finset.card G.edgeFinset
+noncomputable def numEdges {V : Type*} [Fintype V] (G : Graph V) : ℕ :=
+  G.edgeSet.ncard
 
 /-- A graph G contains H as a subgraph if there's an embedding. -/
 def containsSubgraph {V W : Type*} [Fintype V] [Fintype W]
@@ -60,9 +62,10 @@ def isHFree {V W : Type*} [Fintype V] [Fintype W]
 
 /- ## Part II: The Turán Number ex(n; H) -/
 
-/-- ex(n; H) = maximum edges in an n-vertex H-free graph. -/
-noncomputable def turanNumber (n : ℕ) (H : Graph (Fin n)) : ℕ :=
-  sSup { numEdges G | G : Graph (Fin n) // isHFree G H }
+/-- ex(n; H) = maximum edges in an n-vertex H-free graph, where the
+    forbidden pattern H lives on `k` vertices. -/
+noncomputable def turanNumber (n k : ℕ) (H : Graph (Fin k)) : ℕ :=
+  sSup { numEdges G | (G : Graph (Fin n)) (_ : isHFree G H) }
 
 /- ## Part III: The Function f(n; k, l) -/
 
@@ -72,7 +75,7 @@ def graphsWithEdges (k l : ℕ) : Set (Graph (Fin k)) :=
 
 /-- f(n; k, l) = min ex(n; G) over all graphs G with k vertices and l edges. -/
 noncomputable def f (n k l : ℕ) : ℕ :=
-  sInf { turanNumber n ⟨G, hG⟩ | (G : Graph (Fin k)) (hG : numEdges G = l) }
+  sInf { turanNumber n k H | (H : Graph (Fin k)) (_ : numEdges H = l) }
 
 /- ## Part IV: The Range of Interest: k < l ≤ k²/4 -/
 

--- a/proofs/batch2/STATUS.md
+++ b/proofs/batch2/STATUS.md
@@ -1,3 +1,13 @@
+# DOCTOR SINGLE-PROOF BATCH 6 (8-slot, #38065, 2026-07-15)
+
+**+4 GREEN**: Erdos766Problem (edgeSet.ncard drops vanished Fintype; {f x|x:T//p} subtype set-builder
+->binder form), Erdos642Problem (λ reserved; unascribed n^(3/2) on ℝ silently becomes ℕ npow=1 ->
+ascribe :ℝ), Erdos421Problem (Nat.mul_lt_mul_left now iff; Nat.mul_le_mul result-type-directed;
+(a,b:T) ascription ->((a,b):T)), Erdos715Problem (by constructor on Pi-type struct fields fails ->
+intro/term; Nat.find needs (p:=…); Type* under ∃ -> pin Type). Unblocks Erdos715ProblemAristotle.
+Repairs: none. NEW SEAMS: λ hard keyword; unascribed ^(a/b) on ℝ = npow silent statement change;
+Nat.mul_le_mul factor-order-directed; (a,b:T) tuple ascription reparse.
+
 # DOCTOR SINGLE-PROOF BATCH 5 (8-slot, #38065, 2026-07-15)
 
 **+3 GREEN**: RationalCanonicalFormExists (13-site HUB, hardest of the wave ~22min: Aristotle

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -1612,7 +1612,7 @@ Erdos711Problem	GREEN
 Erdos712Problem	GREEN	
 Erdos713Problem	PRE-EXISTING	never-compiled:n
 Erdos714Problem	GREEN	
-Erdos715Problem	RESIDUAL	parse-error
+Erdos715Problem	GREEN	
 Erdos715ProblemAristotle	RESIDUAL	parse-error
 Erdos716Problem	GREEN	
 Erdos717Problem	GREEN	

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -1528,7 +1528,7 @@ Erdos63Problem	GREEN
 Erdos640Problem	GREEN	
 Erdos641Problem	GREEN	
 Erdos642Aristotle	RESIDUAL	unknown-const:SimpleGraph.edgeFinset_card_le
-Erdos642Problem	RESIDUAL	parse-error
+Erdos642Problem	GREEN	
 Erdos643Problem	RESIDUAL	signature-drift
 Erdos644Problem	GREEN	
 Erdos644ProblemAristotle	GREEN	

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -1243,7 +1243,7 @@ Erdos418Problem	GREEN
 Erdos419Problem	GREEN	
 Erdos41Problem	GREEN	
 Erdos420Problem	GREEN	
-Erdos421Problem	RESIDUAL	parse-error
+Erdos421Problem	GREEN	
 Erdos422Problem	GREEN	
 Erdos423Problem	PRE-EXISTING	never-compiled:n
 Erdos424Problem	RESIDUAL	unknown-const:sequence_monotone

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -1667,7 +1667,7 @@ Erdos762Problem	GREEN
 Erdos763Problem	GREEN	
 Erdos764Problem	GREEN	
 Erdos765Problem	GREEN	
-Erdos766Problem	RESIDUAL	parse-error
+Erdos766Problem	GREEN	
 Erdos767Problem	GREEN	
 Erdos768Problem	GREEN	
 Erdos769Problem	GREEN	


### PR DESCRIPTION
8-slot collection. +4 GREEN: Erdos766/642/421/715. Unblocks Erdos715ProblemAristotle. No loom labels.