### PR TITLE
migrate(v4.31): single-proof batch 7 (+3 GREEN)

### DIFF
--- a/proofs/Proofs/Erdos813Problem.lean
+++ b/proofs/Proofs/Erdos813Problem.lean
@@ -25,6 +25,7 @@ import Mathlib.Data.Finset.Basic
 import Mathlib.Data.Finset.Card
 import Mathlib.Combinatorics.SimpleGraph.Basic
 import Mathlib.Data.Real.Basic
+import Mathlib.Analysis.SpecialFunctions.Pow.Real
 
 open Finset
 
@@ -77,7 +78,7 @@ axiom erdos_hajnal_upper_bound :
 
 /-- Combined Erdős-Hajnal bounds: n^{1/3} ≪ h(n) ≪ n^{1/2}. -/
 theorem erdos_hajnal_bounds :
-  ∃ c₁ c₂ > 0, ∀ n ≥ 1,
+  ∃ c₁ > 0, ∃ c₂ > 0, ∀ n : ℕ, n ≥ 1 →
     c₁ * (n : ℝ)^(1/3 : ℝ) ≤ (h n : ℝ) ∧
     (h n : ℝ) ≤ c₂ * (n : ℝ)^(1/2 : ℝ) := by
   obtain ⟨c₁, hc₁, hl⟩ := erdos_hajnal_lower_bound
@@ -98,7 +99,7 @@ theorem exponent_gap : (1 : ℝ) / 2 - 5 / 12 = 1 / 12 := by norm_num
 /-- Erdős's conjecture: can both bounds be improved?
 Specifically, do c₁, c₂ > 0 exist with n^{1/3+c₁} ≪ h(n) ≪ n^{1/2-c₂}? -/
 def ErdosConjecture813 : Prop :=
-  ∃ c₁ c₂ > 0,
+  ∃ c₁ > 0, ∃ c₂ > 0,
     (∀ n ≥ 1, (h n : ℝ) ≥ c₁ * (n : ℝ)^(1/3 + c₁ : ℝ)) ∧
     (∀ n ≥ 1, (h n : ℝ) ≤ c₂ * (n : ℝ)^(1/2 - c₂ : ℝ))
 

--- a/proofs/batch2/STATUS.md
+++ b/proofs/batch2/STATUS.md
@@ -1,3 +1,10 @@
+# DOCTOR SINGLE-PROOF BATCH 7 (8-slot, #38065, 2026-07-15)
+
+**+3 GREEN** (2 pure cascades): Erdos715ProblemAristotle (pure cascade, no edit), MinpolyCharpolyOQ03
+(pure cascade off RationalCanonicalFormExists, no edit — unblocks MinpolyCharpolyOQ03OQ01),
+Erdos813Problem (Pow.Real import for ℝ^ℝ rpow; ∃ a b >0 multi-var binder split; ∀n≥1 pin to ℕ).
+Repairs: none.
+
 # DOCTOR SINGLE-PROOF BATCH 6 (8-slot, #38065, 2026-07-15)
 
 **+4 GREEN**: Erdos766Problem (edgeSet.ncard drops vanished Fintype; {f x|x:T//p} subtype set-builder

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -1723,7 +1723,7 @@ Erdos80Problem	GREEN
 Erdos810Problem	GREEN	
 Erdos811Problem	GREEN	
 Erdos812Problem	GREEN	
-Erdos813Problem	RESIDUAL	parse-error
+Erdos813Problem	GREEN	
 Erdos814Problem	RESIDUAL	instance-synth
 Erdos816Problem	GREEN	
 Erdos817Aristotle	RESIDUAL	type-mismatch

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -1613,7 +1613,7 @@ Erdos712Problem	GREEN
 Erdos713Problem	PRE-EXISTING	never-compiled:n
 Erdos714Problem	GREEN	
 Erdos715Problem	GREEN	
-Erdos715ProblemAristotle	RESIDUAL	parse-error
+Erdos715ProblemAristotle	GREEN	
 Erdos716Problem	GREEN	
 Erdos717Problem	GREEN	
 Erdos718Problem	GREEN	

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -2269,7 +2269,7 @@ MinkowskiTheoremOQ02	RESIDUAL	unknown-const:ENNReal.ofReal_lt_ofReal_of_nonneg
 MinkowskiTheoremOQ03	GREEN	
 MinkowskiTheoremOQ04OQ03	GREEN	
 MinpolyCharpolyOQ01	GREEN	
-MinpolyCharpolyOQ03	RESIDUAL	type-mismatch
+MinpolyCharpolyOQ03	GREEN	
 MinpolyCharpolyOQ03OQ01	RESIDUAL	type-mismatch
 MorleysTheorem	RESIDUAL	unknown-const:map_exp_ofReal_mul_I_re
 MotivicFlagMapsPartialFlags	RESIDUAL	rewrite-drift


### PR DESCRIPTION
8-slot collection incl 2 pure cascades. Unblocks MinpolyCharpolyOQ03OQ01. No loom labels.