### PR TITLE
migrate(v4.31): single-proof batch 17 (+4 GREEN)

### DIFF
--- a/proofs/Proofs/Erdos1026OQ05Extremal.lean
+++ b/proofs/Proofs/Erdos1026OQ05Extremal.lean
@@ -78,7 +78,7 @@ lemma sval_lt_of_same_block {i j : Fin (k * k)} (hlt : i.val < j.val)
   rw [hblk] at hi
   -- same quotient block term, `i < j` forces the remainders to increase
   have hmod : i.val % k < j.val % k := by omega
-  have hcast : (i.val % k : ℤ) < (j.val % k : ℤ) := by exact_mod_cast hmod
+  have hcast : ((i.val % k : ℕ) : ℤ) < ((j.val % k : ℕ) : ℤ) := by exact_mod_cast hmod
   unfold sval
   rw [hblk]
   linarith
@@ -89,7 +89,7 @@ from the remainder. -/
 lemma sval_lt_of_diff_block {i j : Fin (k * k)} (hk : 0 < k)
     (hblk : i.val / k < j.val / k) : sval k i < sval k j := by
   have hri : (0 : ℤ) ≤ (i.val % k : ℕ) := by positivity
-  have hrj : (j.val % k : ℤ) ≤ (k : ℤ) - 1 := by
+  have hrj : ((j.val % k : ℕ) : ℤ) ≤ (k : ℤ) - 1 := by
     have hjm : j.val % k < k := Nat.mod_lt _ hk
     have hjm' : (j.val % k : ℤ) < (k : ℤ) := by exact_mod_cast hjm
     omega
@@ -146,7 +146,7 @@ theorem staircase_injective (hk : 0 < k) : Function.Injective (staircase k) := b
 /-- Upper bound: any increasing subsequence hits each block at most once, so its length is
 at most the number of blocks, `k`. -/
 theorem staircase_LIS_le (hk : 0 < k) : LIS (staircase k) ≤ k := by
-  apply csSup_le ⟨0, Subsequence.mk Fin.elim0 (fun a => a.elim0), by intro a; exact a.elim0⟩
+  refine csSup_le ⟨0, Subsequence.mk Fin.elim0 (fun a => a.elim0), by intro a; exact a.elim0⟩ ?_
   rintro m ⟨sub, hInc⟩
   -- block of each chosen index
   have hblt : ∀ j : Fin m, (sub.indices j).val / k < k := by
@@ -218,7 +218,7 @@ theorem staircase_LIS (hk : 0 < k) : LIS (staircase k) = k :=
 /-- Upper bound: any decreasing subsequence hits each column (remainder class) at most once,
 so its length is at most `k`. -/
 theorem staircase_LDS_le (hk : 0 < k) : LDS (staircase k) ≤ k := by
-  apply csSup_le ⟨0, Subsequence.mk Fin.elim0 (fun a => a.elim0), by intro a b hab; exact a.elim0⟩
+  refine csSup_le ⟨0, Subsequence.mk Fin.elim0 (fun a => a.elim0), by intro a b hab; exact a.elim0⟩ ?_
   rintro m ⟨sub, hDec⟩
   let col : Fin m → Fin k := fun j => ⟨(sub.indices j).val % k, Nat.mod_lt _ hk⟩
   have hkey : ∀ a b : Fin m, a < b → col a ≠ col b := by

--- a/proofs/Proofs/Erdos1136Problem.lean
+++ b/proofs/Proofs/Erdos1136Problem.lean
@@ -91,8 +91,6 @@ def MullerSet : Set ℕ :=
 theorem zero_not_mem_muller : (0 : ℕ) ∉ MullerSet := by
   intro ⟨i, hi⟩
   simp at hi
-  have : 0 < 3 * 2 ^ i := by positivity
-  omega
 
 /-- 3 is in the Müller set: 3 mod 4 = 3 = 3·2^0. -/
 theorem three_mem_muller : (3 : ℕ) ∈ MullerSet :=
@@ -135,7 +133,9 @@ private lemma b_mod_eq_pow_i {a b k i : ℕ} (hab : a + b = 2 ^ k)
   have hsum_lt : 3 * 2 ^ i + r < 2 * m := by rw [hm_eq]; omega
   -- q must be 1: only multiple of m in (0, 2m) is m
   have hq_pos : 0 < q := by
-    rcases q with _ | q'; · simp [mul_zero] at hq ; · exact Nat.succ_pos _
+    rcases Nat.eq_zero_or_pos q with hq0 | hq0
+    · exfalso; rw [hq0, mul_zero] at hq; omega
+    · exact hq0
   have hq_le : q ≤ 1 := by nlinarith [hm_pos]
   have hq1 : q = 1 := by omega
   -- 3 * 2^i + r = m * 1 = 4 * 2^i, so r = 2^i
@@ -181,6 +181,7 @@ private lemma muller_avoids_ordered {a b i j k : ℕ} (hij : i ≤ j)
     (hai : a % (2 ^ (i + 2)) = 3 * 2 ^ i)
     (hbj : b % (2 ^ (j + 2)) = 3 * 2 ^ j)
     (hab : a + b = 2 ^ k) : False := by
+  have hipos : 0 < 2 ^ i := by positivity
   -- k must be ≥ i+2, otherwise a ≥ 3·2^i > 2^(i+1) ≥ 2^k
   have hk : i + 2 ≤ k := by
     by_contra hlt
@@ -220,7 +221,7 @@ theorem muller_avoids : AvoidsPowerOfTwoSums MullerSet := by
   intro a b ⟨i, hai⟩ ⟨j, hbj⟩ k hab
   rcases le_total i j with h | h
   · exact muller_avoids_ordered h hai hbj hab
-  · exact muller_avoids_ordered h hbj hai (by omega)
+  · exact muller_avoids_ordered h hbj hai (show b + a = 2 ^ k by omega)
 
 -- ## Part IV-B: Density Axioms
 
@@ -270,14 +271,9 @@ theorem density_gap :
 theorem odd_prime_multiples_avoid (p : ℕ) (hp : Nat.Prime p) (hp2 : p ≠ 2)
     (a b k : ℕ) (ha : p ∣ a) (hb : p ∣ b) : a + b ≠ 2 ^ k := by
   intro h
-  have hcop : Nat.Coprime (2 ^ k) p := by
-    apply Nat.Coprime.pow_left
-    exact (Nat.Prime.coprime_iff_not_dvd hp).mpr (fun h2p => hp2 (Nat.dvd_antisymm h2p
-      (hp.dvd_of_dvd_pow (dvd_pow_self 2 (Nat.Prime.pos hp).ne' ▸ h2p.symm ▸
-        dvd_refl (2 ^ 1)))))
-  have hdvd : p ∣ Nat.gcd (2 ^ k) p := Nat.dvd_gcd (h ▸ dvd_add ha hb) dvd_rfl
-  rw [hcop] at hdvd
-  exact absurd hdvd (Nat.Prime.not_dvd_one hp)
+  have hpdvd : p ∣ 2 ^ k := h ▸ dvd_add ha hb
+  have hp2dvd : p ∣ 2 := hp.dvd_of_dvd_pow hpdvd
+  exact hp2 ((Nat.prime_dvd_prime_iff_eq hp Nat.prime_two).mp hp2dvd)
 
 /-
 ## Summary

--- a/proofs/Proofs/Erdos1151OQ04Aristotle.lean
+++ b/proofs/Proofs/Erdos1151OQ04Aristotle.lean
@@ -42,8 +42,10 @@ theorem n_mul_chebyshevAngle (n : ℕ) (hn : 0 < n) (k : Fin n) :
 
 /-- The Chebyshev node angles are positive. -/
 theorem chebyshevAngle_pos (n : ℕ) (k : Fin n) :
-    0 < (2 * k.val + 1 : ℝ) * Real.pi / (2 * n) :=
-  div_pos (mul_pos (by positivity) Real.pi_pos) (by positivity)
+    0 < (2 * k.val + 1 : ℝ) * Real.pi / (2 * n) := by
+  have hn : 0 < n := lt_of_le_of_lt (Nat.zero_le k.val) k.isLt
+  have hn' : (0 : ℝ) < n := Nat.cast_pos.mpr hn
+  exact div_pos (mul_pos (by positivity) Real.pi_pos) (by positivity)
 
 /-- The Chebyshev node angles are less than π, using k.val < n. -/
 theorem chebyshevAngle_lt_pi (n : ℕ) (hn : 0 < n) (k : Fin n) :
@@ -51,7 +53,7 @@ theorem chebyshevAngle_lt_pi (n : ℕ) (hn : 0 < n) (k : Fin n) :
   rw [div_lt_iff₀ (by positivity : (0 : ℝ) < 2 * n)]
   have : k.val + 1 ≤ n := k.isLt
   have hcast : (2 * k.val + 1 : ℝ) < 2 * n := by exact_mod_cast by omega
-  linarith [Real.pi_pos]
+  nlinarith [Real.pi_pos]
 
 /-- The Chebyshev node angles lie in the open interval (0, π). -/
 theorem chebyshevAngle_mem_Ioo (n : ℕ) (hn : 0 < n) (k : Fin n) :
@@ -67,11 +69,11 @@ theorem chebyshevAngle_ne_of_ne (n : ℕ) (hn : 0 < n) (i j : Fin n) (hij : i �
   apply Fin.ext
   have hpos : (0 : ℝ) < 2 * n := by positivity
   have hpi : Real.pi > 0 := Real.pi_pos
-  have h2 : (2 * (i.val : ℝ) + 1) * Real.pi = (2 * j.val + 1) * Real.pi := by
-    field_simp [hpos.ne'] at h; linarith
-  have h3 : (2 * (i.val : ℝ) + 1) = 2 * j.val + 1 :=
-    mul_right_cancel₀ hpi.ne' h2
-  exact_mod_cast by linarith
+  have h2 : (2 * (i.val : ℝ) + 1) = 2 * j.val + 1 := by
+    field_simp [hpos.ne', hpi.ne'] at h
+    linarith
+  have h4 : (i.val : ℝ) = j.val := by linarith
+  exact_mod_cast h4
 
 /-
 ## Section 2: Aristotle Targets
@@ -107,7 +109,6 @@ theorem chebyshevNode_is_root (n : ℕ) (hn : 0 < n) (k : Fin n) :
     push_cast
     have : (n : ℝ) ≠ 0 := Nat.cast_ne_zero.mpr hn.ne'
     field_simp
-    ring
   rw [hmul]
   exact cos_odd_half_pi k.val
 

--- a/proofs/Proofs/Erdos1169Problem.lean
+++ b/proofs/Proofs/Erdos1169Problem.lean
@@ -65,7 +65,7 @@ def negPartitionRel (α β : Ordinal) (k : ℕ) : Prop :=
 
 /-- ω₁: the first uncountable ordinal.
     This is the order type of the set of all countable ordinals. -/
-noncomputable def omega1 : Ordinal := (Cardinal.aleph 1).ord
+noncomputable def omega1 : Ordinal.{0} := (Cardinal.aleph 1).ord
 
 /-- ω₁²: the ordinal square of ω₁, i.e., ω₁ · ω₁ (ordinal multiplication). -/
 noncomputable def omega1Sq : Ordinal := omega1 * omega1
@@ -95,7 +95,7 @@ def erdos_1169_statement : Prop :=
 -- ============================================================
 
 /-- The Continuum Hypothesis: 2^ℵ₀ = ℵ₁. -/
-def CH : Prop := (2 : Cardinal) ^ Cardinal.aleph0 = Cardinal.aleph 1
+def CH : Prop := (2 : Cardinal.{0}) ^ Cardinal.aleph0 = Cardinal.aleph 1
 
 /-- Hajnal's theorem: Under CH, ω₁² → (ω₁², k)² holds for all finite k.
 
@@ -149,7 +149,7 @@ theorem partition_monotone_clique (α β : Ordinal) (k j : ℕ)
 /-- Monotonicity in the ordinal parameter.
 Property of partition relations; not used in proofs below. -/
 def partition_monotone_ordinal_prop : Prop :=
-    ∀ (α β γ : Ordinal) (k : ℕ),
+    ∀ (α β γ : Ordinal.{0}) (k : ℕ),
       γ ≤ β → ordinalPartitionRel α β k → ordinalPartitionRel α γ k
 
 /-- Under CH, ω₁² → (ω₁², 3)² implies ω₁² → (ω₁², 2)² (pairs).
@@ -165,7 +165,7 @@ theorem erdos_1169_implies_pairs (h : erdos_1169_statement) :
 /-- Connection to Problem #592: the countable ordinal partition problem.
     ω² → (ω², 3)² holds (Specker's theorem). Not used in proofs below. -/
 def connection_to_592_prop : Prop :=
-    ordinalPartitionRel (Ordinal.omega ^ (2 : Ordinal)) (Ordinal.omega ^ (2 : Ordinal)) 3
+    ordinalPartitionRel (Ordinal.omega0.{0} ^ (2 : Ordinal)) (Ordinal.omega0.{0} ^ (2 : Ordinal)) 3
 
 /-- Connection to Problem #118: Erdős asked whether α → (α, 3)² implies
     α → (α, n)² for all n. This was DISPROVED (Schipperus/Darby 1999).
@@ -182,10 +182,10 @@ theorem erdos_1169_stronger_than_118_under_ch (h : CH) :
 -- ============================================================
 
 /-- ω₁ is a limit ordinal. Not used in proofs below. -/
-def omega1_is_limit_prop : Prop := Ordinal.IsLimit omega1
+def omega1_is_limit_prop : Prop := Order.IsSuccLimit omega1
 
 /-- ω < ω₁. Not used in proofs below. -/
-def omega_lt_omega1_prop : Prop := Ordinal.omega < omega1
+def omega_lt_omega1_prop : Prop := Ordinal.omega0 < omega1
 
 /-- ω₁ is a regular cardinal. Not used in proofs below. -/
 def omega1_regular_prop : Prop := omega1.card.ord.cof = omega1.card

--- a/proofs/batch2/STATUS.md
+++ b/proofs/batch2/STATUS.md
@@ -1,3 +1,16 @@
+# DOCTOR SINGLE-PROOF BATCH 17 (8-slot, all SONNET, post-/login wave, #38065, 2026-07-15)
+
+**+4 GREEN**: Erdos1026OQ05Extremal ((natExpr:ℤ) pushes cast to leaves -> ((n:ℕ):ℤ); apply f ⟨⟩ ->
+refine f ⟨⟩ ?_ for csSup_le), Erdos1136Problem (simp at h auto-closes -> drop trailing; bare (by omega)
+arg needs show-ascription), Erdos1151OQ04Aristotle (field_simp now cancels π fully -> drop mul_right_cancel₀),
+Erdos1169Problem (universe metavars: pin SOURCE def omega1:Ordinal.{0} not use-sites; Ordinal.omega->omega0,
+Ordinal.IsLimit->Order.IsSuccLimit). Repairs: none.
+
+NOTE: BallotProblemOQ01OQ04OQ01 owned by a live pre-/login agent in worktree mig-ballot-recover —
+NOT re-dispatched (a duplicate slot-0 agent correctly stood down; collision-detection worked). Collect
+mig/BallotProblemOQ01OQ04OQ01 when that agent completes. EQR OQ03OQ02OQ03 deferred behind parent OQ01;
+Erdos100OQ01 deferred behind parent Erdos100OQ01WIP01.
+
 # DOCTOR SINGLE-PROOF BATCH 16 (8-slot, #38065, 2026-07-15)
 
 **+5 GREEN (all Sonnet)**: DesarguesTheoremOQ01OQ01, CombinationsFormulaOQ02 (Nat.choose_symm dir flip

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -855,7 +855,7 @@ Erdos1149Aristotle	RESIDUAL	type-mismatch
 Erdos1149Problem	RESIDUAL	type-mismatch
 Erdos114OQ01Problem	GREEN	proof-drift
 Erdos1150Problem	GREEN	unknown-const:parseval_ratio_ge_one
-Erdos1151OQ04Aristotle	RESIDUAL	proof-drift
+Erdos1151OQ04Aristotle	GREEN	
 Erdos1151Problem	RESIDUAL	proof-drift
 Erdos1153Problem	PRE-EXISTING	never-compiled:k
 Erdos1155OQ01	GREEN	

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -687,7 +687,7 @@ Erdos1023OQ01Problem	GREEN
 Erdos1023Problem	GREEN	
 Erdos1024Problem	GREEN	
 Erdos1025Problem	GREEN	
-Erdos1026OQ05Extremal	RESIDUAL	proof-drift
+Erdos1026OQ05Extremal	GREEN	
 Erdos1026OQ05KMonotonic	GREEN	
 Erdos1026Problem	GREEN	
 Erdos1027OQ01	RESIDUAL	unclassified

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -875,7 +875,7 @@ Erdos1165Problem	GREEN
 Erdos1166Problem	GREEN	
 Erdos1167Problem	GREEN	
 Erdos1168Problem	GREEN	
-Erdos1169Problem	RESIDUAL	proof-drift
+Erdos1169Problem	GREEN	
 Erdos116Problem	GREEN	
 Erdos1170Problem	GREEN	
 Erdos1171Problem	RESIDUAL	unknown-const:Ordinal.mul_lt_mul_iff_left

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -846,7 +846,7 @@ Erdos1132Aristotle	GREEN
 Erdos1132Problem	GREEN	
 Erdos1134Problem	GREEN	
 Erdos1135Problem	GREEN	
-Erdos1136Problem	RESIDUAL	proof-drift
+Erdos1136Problem	GREEN	
 Erdos1138Problem	GREEN	
 Erdos113Problem	GREEN	
 Erdos1142Problem	GREEN	


### PR DESCRIPTION
8-slot, all Sonnet, post-/login. No loom labels.