### PR TITLE
migrate(v4.31): single-proof batch 19 (+4 GREEN)

### DIFF
--- a/proofs/Proofs/Erdos152ProblemAPN.lean
+++ b/proofs/Proofs/Erdos152ProblemAPN.lean
@@ -252,7 +252,7 @@ lemma num_isolated_Z_rel (A : Set ℕ) :
   by_cases h:{M|M-1 ∉A+A∧M ∈A+A∧M+1 ∉A+A}.Finite
   · use(Nat.card_mono (h.image (↑) |>.insert 0) ? _).trans (.trans (Set.ncard_insert_le _ _) (by rw [Set.ncard_image_of_injective _ Nat.cast_injective]))
     refine fun and⟨ ⟨a, A, I⟩,R, L⟩=>by cases I with use a.eq_zero_or_pos.imp ↑(congr_arg _) (by use a, ⟨ fun and=>(R _) ⟨and,Nat.cast_pred ·⟩,A,(L _ ⟨ ·, rfl⟩)⟩)
-  · exact (Set.Infinite.ncard (h.comp (·.preimage Nat.cast_injective.injOn|>.insert 0|>.subset ↑ fun and⟨A, B, C⟩=>and.eq_zero_or_pos.imp_right fun and' =>⟨⟨ _,B, rfl⟩,by grind⟩))).trans_le bot_le
+  · exact (Set.Infinite.ncard (h.comp (·.preimage Nat.cast_injective.injOn|>.insert 0|>.subset ↑ fun and⟨A, B, C⟩=>and.eq_zero_or_pos.imp_right fun and' =>⟨⟨ _,B, rfl⟩,by grind (splits := 40)⟩))).trans_le bot_le
 
 lemma N_k_Z_rel_1 (A : Set ℕ) : N_k_Z (Z_S (A + A)) (1 : ℤ) = N_k_N (A + A) 1 := by
   -- Explicit replacement for an AlphaProof `grind` call that fails under Mathlib v4.26.0:

--- a/proofs/Proofs/Erdos179ProblemAristotle.lean
+++ b/proofs/Proofs/Erdos179ProblemAristotle.lean
@@ -40,7 +40,10 @@ def ContainsAP (A : Finset ℕ) (k : ℕ) : Prop :=
 theorem mem_ap_iff (a d k x : ℕ) :
     x ∈ arithmeticProgression a d k ↔ ∃ i, i < k ∧ x = a + i * d := by
   unfold arithmeticProgression
-  simp [Finset.mem_image, Finset.mem_range]
+  simp only [Finset.mem_image, Finset.mem_range]
+  constructor
+  · rintro ⟨i, hi, h⟩; exact ⟨i, hi, h.symm⟩
+  · rintro ⟨i, hi, h⟩; exact ⟨i, hi, h.symm⟩
 
 /-- The first element a is in arithmeticProgression a d k for k ≥ 1. -/
 theorem ap_mem_first (a d k : ℕ) (hk : k ≥ 1) :
@@ -68,6 +71,7 @@ theorem ap_mem_third (a d k : ℕ) (hk : k ≥ 3) :
 theorem ap_map_injective (a d : ℕ) (hd : 0 < d) :
     Function.Injective (fun i => a + i * d) := by
   intro i j h
+  simp only at h
   have : i * d = j * d := by omega
   exact Nat.eq_of_mul_eq_mul_right hd this
 
@@ -82,13 +86,14 @@ theorem ap_card_of_pos (a d k : ℕ) (hd : 0 < d) :
 theorem ap_card_zero_diff (a k : ℕ) (hk : k ≥ 1) :
     (arithmeticProgression a 0 k).card = 1 := by
   unfold arithmeticProgression
-  have : Finset.image (fun i => a + i * 0) (Finset.range k) = {a} := by
-    ext x
-    simp [Finset.mem_image, Finset.mem_range]
+  have heq : Finset.image (fun i => a + i * 0) (Finset.range k) = {a} := by
+    apply Finset.eq_singleton_iff_unique_mem.mpr
     constructor
-    · rintro ⟨i, hi, rfl⟩; simp
-    · rintro rfl; exact ⟨0, hk, by simp⟩
-  rw [this]
+    · exact Finset.mem_image.mpr ⟨0, Finset.mem_range.mpr hk, by ring⟩
+    · intro x hx
+      obtain ⟨i, _, rfl⟩ := Finset.mem_image.mp hx
+      ring
+  rw [heq]
   simp
 
 /-- AP of length 0 is empty. -/

--- a/proofs/Proofs/Erdos291Problem.lean
+++ b/proofs/Proofs/Erdos291Problem.lean
@@ -815,19 +815,19 @@ theorem prime_dvd_gcd_pm1_pow (p k : ℕ) (hp : Nat.Prime p) (hp3 : p ≥ 3) (hk
 
     Verified computationally for p = 3, 5, 7, 11, 13. -/
 theorem sum_inv_ZMod_eq_zero_3 :
-    ∑ i ∈ Finset.range 2, ((i + 1 : ℕ) : ZMod 3)⁻¹ = 0 := by decide
+    ∑ i ∈ Finset.range 2, ((i + 1 : ℕ) : ZMod 3)⁻¹ = 0 := by native_decide
 
 theorem sum_inv_ZMod_eq_zero_5 :
-    ∑ i ∈ Finset.range 4, ((i + 1 : ℕ) : ZMod 5)⁻¹ = 0 := by decide
+    ∑ i ∈ Finset.range 4, ((i + 1 : ℕ) : ZMod 5)⁻¹ = 0 := by native_decide
 
 theorem sum_inv_ZMod_eq_zero_7 :
-    ∑ i ∈ Finset.range 6, ((i + 1 : ℕ) : ZMod 7)⁻¹ = 0 := by decide
+    ∑ i ∈ Finset.range 6, ((i + 1 : ℕ) : ZMod 7)⁻¹ = 0 := by native_decide
 
 theorem sum_inv_ZMod_eq_zero_11 :
-    ∑ i ∈ Finset.range 10, ((i + 1 : ℕ) : ZMod 11)⁻¹ = 0 := by decide
+    ∑ i ∈ Finset.range 10, ((i + 1 : ℕ) : ZMod 11)⁻¹ = 0 := by native_decide
 
 theorem sum_inv_ZMod_eq_zero_13 :
-    ∑ i ∈ Finset.range 12, ((i + 1 : ℕ) : ZMod 13)⁻¹ = 0 := by decide
+    ∑ i ∈ Finset.range 12, ((i + 1 : ℕ) : ZMod 13)⁻¹ = 0 := by native_decide
 
 /-- The sum of all elements of ZMod p equals zero for p ≥ 3.
     Since ∑_{k=0}^{p-1} k = p(p-1)/2 and p is odd (p ≥ 3), this is 0 mod p. -/

--- a/proofs/batch2/STATUS.md
+++ b/proofs/batch2/STATUS.md
@@ -1,3 +1,12 @@
+# DOCTOR SINGLE-PROOF BATCH 19 (8-slot, all SONNET, #38065, 2026-07-15)
+
+**+4 GREEN**: BallotProblemOQ01OQ04 (pure cascade, wrapper flips off OQ01OQ04OQ01), Erdos179ProblemAristotle
+(Finset.mem_image result orientation flip; lambda-app not beta-reducing before omega), Erdos152ProblemAPN
+(grind splits budget 9->40), Erdos291Problem (decide->native_decide x5 on sum_inv_ZMod_eq_zero_* — ZMod
+inverse no longer kernel-reduces). **META-AUDIT FLAG: Erdos291Problem now uses native_decide (was decide)
+-> introduces Lean.ofReduceBool; gallery meta axiomCount/status needs re-audit (logged scratchpad/
+native-decide-introductions.txt; feeds #38611-adjacent gallery re-audit).** Repairs: none.
+
 # DOCTOR SINGLE-PROOF BATCH 18 (8-slot, #38065, 2026-07-15)
 
 **+7 GREEN**: BallotProblemOQ01OQ04OQ01 (OPUS 48min/385k — the recovered file: List.get? fully removed

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -158,7 +158,7 @@ BallotProblemOQ01OQ02OQ01OQ01	RESIDUAL	unknown-const:Set.ncard_biUnion
 BallotProblemOQ01OQ02OQ01OQ02	RESIDUAL	unknown-const:Set.ncard_biUnion
 BallotProblemOQ01OQ02OQ01OQ02OQ01	RESIDUAL	unknown-const:Set.ncard_biUnion
 BallotProblemOQ01OQ02OQ04	GREEN	
-BallotProblemOQ01OQ04	RESIDUAL	proof-drift
+BallotProblemOQ01OQ04	GREEN	
 BallotProblemOQ01OQ04Core	GREEN	
 BallotProblemOQ01OQ04OQ01	GREEN	
 BallotProblemOQ02OQ02	GREEN	

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -1087,7 +1087,7 @@ Erdos288Problem	RESIDUAL	rewrite-drift
 Erdos289Problem	GREEN	
 Erdos28AdditiveBases	GREEN	
 Erdos28Problem	GREEN	
-Erdos291Problem	RESIDUAL	proof-drift
+Erdos291Problem	GREEN	
 Erdos292Problem	GREEN	
 Erdos293Problem	GREEN	
 Erdos294Problem	GREEN	

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -942,7 +942,7 @@ Erdos14UniqueSums	GREEN
 Erdos150Problem	GREEN	
 Erdos152OQ01	RESIDUAL	type-mismatch
 Erdos152Problem	RESIDUAL	type-mismatch
-Erdos152ProblemAPN	RESIDUAL	proof-drift
+Erdos152ProblemAPN	GREEN	
 Erdos153Problem	GREEN	
 Erdos154Problem	GREEN	
 Erdos155Problem	GREEN	

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -970,7 +970,7 @@ Erdos177Problem	GREEN
 Erdos178Problem	GREEN	
 Erdos179Aristotle	GREEN	
 Erdos179Problem	GREEN	
-Erdos179ProblemAristotle	RESIDUAL	proof-drift
+Erdos179ProblemAristotle	GREEN	
 Erdos17Problem	GREEN	
 Erdos180Problem	GREEN	instance-synth
 Erdos181OQ01	GREEN	


### PR DESCRIPTION
8-slot, all Sonnet. Note: Erdos291Problem decide->native_decide (meta re-audit flag). No loom labels.