### PR TITLE
migrate(v4.31): single-proof batch 24 (+3 GREEN, re-verified)

### DIFF
--- a/proofs/Proofs/Erdos360Aristotle.lean
+++ b/proofs/Proofs/Erdos360Aristotle.lean
@@ -41,7 +41,8 @@ open Erdos360 Finset
     Proof: Subsets are {} (sum 0) and {1} (sum 1), neither equals 2. -/
 theorem set1_is_2sum_free_ari : IsNSumFree 2 {1} := by
   intro T hT
-  fin_cases h : T using 2 <;> simp_all [IsNSumFree, Finset.subset_singleton_iff] <;> omega
+  have hTsub : T ∈ ({1} : Finset ℕ).powerset := Finset.mem_powerset.mpr hT
+  fin_cases hTsub <;> simp_all
 
 /-- {{1}} is a valid 1-partition of {1,...,1} = {1}.
     Proof: {1} covers {1}, is 2-sum-free, and has 1 class. -/
@@ -66,15 +67,15 @@ theorem f_2_le_1_ari : f 2 ≤ 1 := by
     Proof: 0 classes can't cover {1}. -/
 theorem f_2_ge_1_ari : f 2 ≥ 1 := by
   apply Nat.one_le_iff_ne_zero.mpr
-  intro h
-  have := Nat.sInf_eq_zero.mp h
-  rcases this with ⟨_, h⟩ | h
-  · obtain ⟨parts, hcard, hval⟩ := h
-    have := hval.2.2.1 1 (by omega) (by omega)
-    obtain ⟨P, hP, _⟩ := this
-    have := Finset.card_pos.mpr ⟨P, hP⟩
+  intro hf0
+  rcases Nat.sInf_eq_zero.mp hf0 with ⟨parts, hcard, hval⟩ | hempty
+  · obtain ⟨_, _, hcover, _⟩ := hval
+    obtain ⟨P, hP, _⟩ := hcover 1 (by omega) (by omega)
+    have hpos := Finset.card_pos.mpr ⟨P, hP⟩
     omega
-  · simp [ValidPartitionSizes] at h
+  · have hmem : (1 : ℕ) ∈ ValidPartitionSizes 2 := ⟨{{1}}, rfl, valid_partition_2_ari⟩
+    rw [hempty] at hmem
+    simp at hmem
 
 -- ═══════════════════════════════════════════════════════════════════
 -- PART II: f(4) = 2
@@ -84,14 +85,15 @@ theorem f_2_ge_1_ari : f 2 ≥ 1 := by
     Subsets: {}, {1}, {2}, {1,2}. Sums: 0, 1, 2, 3. None equals 4. -/
 theorem set12_is_4sum_free_ari : IsNSumFree 4 ({1, 2} : Finset ℕ) := by
   intro T hT
-  have hT' : T ⊆ {1, 2} := hT
-  fin_cases h : T using 4 <;> simp_all [Finset.subset_pair_iff] <;> omega
+  have hTsub : T ∈ ({1, 2} : Finset ℕ).powerset := Finset.mem_powerset.mpr hT
+  fin_cases hTsub <;> simp_all
 
 /-- {3} is 4-sum-free: no subset sums to 4.
     Subsets: {}, {3}. Sums: 0, 3. Neither equals 4. -/
 theorem set3_is_4sum_free_ari : IsNSumFree 4 ({3} : Finset ℕ) := by
   intro T hT
-  fin_cases h : T using 2 <;> simp_all [Finset.subset_singleton_iff] <;> omega
+  have hTsub : T ∈ ({3} : Finset ℕ).powerset := Finset.mem_powerset.mpr hT
+  fin_cases hTsub <;> simp_all
 
 /-- {{1,2},{3}} is a valid 2-partition of {1,2,3}.
     Covers: 1 ∈ {1,2}, 2 ∈ {1,2}, 3 ∈ {3}. Both classes are 4-sum-free. -/

--- a/proofs/Proofs/Erdos383Problem.lean
+++ b/proofs/Proofs/Erdos383Problem.lean
@@ -117,8 +117,8 @@ theorem consecutiveSquareProduct_zero (p : ℕ) :
 
 theorem consecutiveSquareProduct_one (p : ℕ) :
     consecutiveSquareProduct p 1 = p ^ 2 * (p ^ 2 + 1) := by
-  simp [consecutiveSquareProduct]
-  ring
+  rw [consecutiveSquareProduct_eq]
+  simp [Finset.prod_range_succ]
 
 /-
 # Part 3: The Main Property
@@ -140,6 +140,7 @@ lemma consecutiveSquareProduct_pos {p k : ℕ} (hp : p.Prime) :
   rw [consecutiveSquareProduct_eq]
   apply Finset.prod_pos
   intro i _
+  have hp2 : 0 < p ^ 2 := pow_pos hp.pos 2
   omega
 
 lemma consecutiveSquareProduct_ne_zero {p k : ℕ} (hp : p.Prime) :
@@ -151,7 +152,7 @@ theorem zero_good (p : ℕ) (hp : p.Prime) : isKGood p 0 := by
   refine ⟨hp, ?_⟩
   rw [consecutiveSquareProduct_zero]
   simp only [hasLargestPrimeFactor, primeDivisors]
-  refine ⟨Nat.mem_primeFactors.mpr ⟨hp, dvd_pow_self p 2, by positivity⟩,
+  refine ⟨Nat.mem_primeFactors.mpr ⟨hp, dvd_pow_self p (by norm_num), (pow_pos hp.pos 2).ne'⟩,
     fun q hq => ?_⟩
   rw [Nat.mem_primeFactors] at hq
   exact le_of_dvd (Nat.Prime.pos hp) (hq.1.dvd_of_dvd_pow hq.2.1)
@@ -170,25 +171,27 @@ theorem conjecture_equiv : ErdosConjecture383 ↔ ErdosConjecture383' := by
   simp only [ErdosConjecture383, ErdosConjecture383', kGoodPrimes]
   apply forall_congr'
   intro k
-  congr 1
-  ext p
-  simp only [Set.mem_setOf_eq, isKGood]
-  constructor
-  · intro ⟨hp, hlpf⟩
-    refine ⟨hp, ?_⟩
-    have hne : (consecutiveSquareProduct p k).primeFactors.Nonempty := ⟨p, hlpf.1⟩
-    exact (hasLargestPrimeFactor_iff_maxPrimeFac hne).mp hlpf
-  · intro ⟨hp, heq⟩
-    refine ⟨hp, ?_⟩
-    have hp_mem : p ∈ (consecutiveSquareProduct p k).primeFactors := by
-      rw [Nat.mem_primeFactors]
-      refine ⟨hp, ?_, consecutiveSquareProduct_ne_zero hp⟩
-      rw [consecutiveSquareProduct_eq]
-      apply dvd_trans (dvd_pow_self p 2)
-      have : p ^ 2 + 0 = p ^ 2 := by ring
-      rw [← this]
-      exact Finset.dvd_prod_of_mem _ (Finset.mem_range.mpr (Nat.zero_lt_succ k))
-    exact (hasLargestPrimeFactor_iff_maxPrimeFac ⟨p, hp_mem⟩).mpr heq
+  have hset : {p | isKGood p k} =
+      {p : ℕ | p.Prime ∧ maxPrimeFac (consecutiveSquareProduct p k) = p} := by
+    ext p
+    simp only [Set.mem_setOf_eq, isKGood]
+    constructor
+    · intro ⟨hp, hlpf⟩
+      refine ⟨hp, ?_⟩
+      have hne : (consecutiveSquareProduct p k).primeFactors.Nonempty := ⟨p, hlpf.1⟩
+      exact (hasLargestPrimeFactor_iff_maxPrimeFac hne).mp hlpf
+    · intro ⟨hp, heq⟩
+      refine ⟨hp, ?_⟩
+      have hp_mem : p ∈ (consecutiveSquareProduct p k).primeFactors := by
+        rw [Nat.mem_primeFactors]
+        refine ⟨hp, ?_, consecutiveSquareProduct_ne_zero hp⟩
+        rw [consecutiveSquareProduct_eq]
+        apply dvd_trans (dvd_pow_self p (n := 2) (by norm_num))
+        have : p ^ 2 + 0 = p ^ 2 := by ring
+        rw [← this]
+        exact Finset.dvd_prod_of_mem _ (Finset.mem_range.mpr (Nat.zero_lt_succ k))
+      exact (hasLargestPrimeFactor_iff_maxPrimeFac ⟨p, hp_mem⟩).mpr heq
+  rw [hset]
 
 /-
 # Part 5: Partial Results
@@ -222,10 +225,12 @@ theorem kGood_one_smooth_p2_plus_1 (p : ℕ) (hp : isKGood p 1) :
   exact dvd_mul_of_dvd_right hqd _
 
 theorem problem383_implies_382 (h : (kGoodPrimes 1).Infinite) : Problem382Part2 := by
-  apply Set.Infinite.mono h
-  intro p hp
-  simp only [kGoodPrimes, Set.mem_setOf_eq] at hp
-  exact ⟨hp.1, kGood_one_smooth_p2_plus_1 p hp⟩
+  unfold Problem382Part2
+  apply Set.Infinite.mono (s := kGoodPrimes 1)
+  · intro p hp
+    simp only [kGoodPrimes, Set.mem_setOf_eq] at hp
+    exact ⟨hp.1, kGood_one_smooth_p2_plus_1 p hp⟩
+  · exact h
 
 /-
 # Part 7: Smooth Numbers
@@ -256,19 +261,20 @@ theorem kGood_iff_smooth (p k : ℕ) (hp : p.Prime) :
     · rw [Nat.mem_primeFactors]
       refine ⟨hp, ?_, consecutiveSquareProduct_ne_zero hp⟩
       rw [consecutiveSquareProduct_eq]
-      apply dvd_trans (dvd_pow_self p 2)
+      apply dvd_trans (dvd_pow_self p (n := 2) (by norm_num))
       have : p ^ 2 + 0 = p ^ 2 := by ring
       rw [← this]
       exact Finset.dvd_prod_of_mem _ (Finset.mem_range.mpr (Nat.zero_lt_succ k))
     · rw [Nat.mem_primeFactors] at hq
       obtain ⟨hq_prime, hq_dvd, _⟩ := hq
       rw [consecutiveSquareProduct_eq] at hq_dvd
-      rw [Prime.dvd_prod_iff hq_prime.prime] at hq_dvd
+      rw [Prime.dvd_finsetProd_iff hq_prime.prime (fun i => p ^ 2 + i)] at hq_dvd
       obtain ⟨i, hi, hq_dvd_i⟩ := hq_dvd
       have hi' : i ≤ k := by simp [Finset.mem_range] at hi; omega
       exact hsmooth i hi' q (Nat.mem_primeFactors.mpr
-        ⟨hq_prime, hq_dvd_i, by positivity⟩)
+        ⟨hq_prime, hq_dvd_i, by have h2 : 0 < p ^ 2 := pow_pos hp.pos 2; omega⟩)
 
+open scoped Classical in
 noncomputable def countSmooth (x y : ℕ) : ℕ :=
   (Finset.filter (fun n => isSmooth n y) (Finset.Icc 1 x)).card
 

--- a/proofs/Proofs/Erdos679ProblemAristotle.lean
+++ b/proofs/Proofs/Erdos679ProblemAristotle.lean
@@ -27,17 +27,17 @@ These structural lemmas expose the inductive structure for Aristotle.
 -/
 
 /-- The primorial of 0 is 1 (empty product). -/
-theorem primorial_zero_ari : primorial 0 = 1 := by
-  simp [primorial]
+theorem primorial_zero_ari : Erdos679.primorial 0 = 1 := by
+  simp [Erdos679.primorial]
 
 /-- The primorial of r+1 equals (r-th prime) times primorial r. -/
 theorem primorial_succ_ari (r : ℕ) :
-    primorial (r + 1) = (Nat.nth Nat.Prime r) * primorial r := by
-  unfold primorial
+    Erdos679.primorial (r + 1) = (Nat.nth Nat.Prime r) * Erdos679.primorial r := by
+  unfold Erdos679.primorial
   rw [Finset.range_add_one, Finset.prod_insert Finset.notMem_range_self]
 
 /-- omega(primorial 0) = 0, since primorial 0 = 1. -/
-theorem omega_primorial_zero_ari : omega (primorial 0) = 0 := by
+theorem omega_primorial_zero_ari : omega (Erdos679.primorial 0) = 0 := by
   rw [primorial_zero_ari]
   simp [omega]
 
@@ -79,11 +79,11 @@ It holds because the r-th prime is strictly larger than all primes in primorial 
     another are equal, forcing `r = i` by injectivity of `Nat.nth Nat.Prime`,
     contradicting `i < r`. Mirrors the coprimality step inside `omega_primorial`. -/
 theorem nth_prime_coprime_primorial_ari (r : ℕ) :
-    Nat.Coprime (Nat.nth Nat.Prime r) (primorial r) := by
+    Nat.Coprime (Nat.nth Nat.Prime r) (Erdos679.primorial r) := by
   have hp : (Nat.nth Nat.Prime r).Prime := nth_prime_is_prime_ari r
   rw [hp.coprime_iff_not_dvd]
   intro hdvd
-  simp only [primorial] at hdvd
+  simp only [Erdos679.primorial] at hdvd
   obtain ⟨i, hi, hdvd_i⟩ := hp.prime.exists_mem_finset_dvd hdvd
   have hpi : (Nat.nth Nat.Prime i).Prime := nth_prime_is_prime_ari i
   have heq : Nat.nth Nat.Prime r = Nat.nth Nat.Prime i :=
@@ -100,7 +100,7 @@ Each step follows from coprimality and the sub-lemmas above.
 -/
 
 /-- omega(primorial r) = r, proved by structural induction. -/
-theorem omega_primorial_ari (r : ℕ) : omega (primorial r) = r := by
+theorem omega_primorial_ari (r : ℕ) : omega (Erdos679.primorial r) = r := by
   induction r with
   | zero => exact omega_primorial_zero_ari
   | succ r ih =>

--- a/proofs/batch2/STATUS.md
+++ b/proofs/batch2/STATUS.md
@@ -1,3 +1,10 @@
+# DOCTOR SINGLE-PROOF BATCH 24 (5-slot, conflict-proof collect, #38065, 2026-07-15)
+
+**+3 GREEN** (re-verified EXIT=0): Erdos383Problem (dvd_pow_self needs n≠0; Prime.dvd_prod_iff->
+dvd_finsetProd_iff; Set.Infinite.mono arg order), Erdos360Aristotle (fin_cases h:T using N removed ->
+powerset+mem_powerset.mpr+fin_cases), Erdos679ProblemAristotle (primorial now in _root_ Mathlib.NumberTheory
+.Primorial -> qualify Erdos679.primorial). Repairs: none. Seam: `primorial` root-name collision.
+
 # DOCTOR SINGLE-PROOF BATCH 23 (4-slot config, conflict-proof collect, #38065, 2026-07-15)
 
 Reduced to 4 slots (doctor-b/d/e/g) + doctor-h collection to cut collision risk. **+3 GREEN** (re-verified

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -1176,7 +1176,7 @@ Erdos358Problem	RESIDUAL	unknown-const:two_mul_sum_Icc
 Erdos359Problem	GREEN	
 Erdos35Problem	RESIDUAL	proof-drift
 Erdos35ProblemAristotle	GREEN	instance-synth
-Erdos360Aristotle	RESIDUAL	proof-drift
+Erdos360Aristotle	GREEN	
 Erdos360Problem	GREEN	
 Erdos361Problem	GREEN	
 Erdos362Problem	RESIDUAL	type-mismatch
@@ -1199,7 +1199,7 @@ Erdos380Problem	RESIDUAL	instance-synth
 Erdos381Problem	GREEN	
 Erdos381ProblemAristotle	GREEN	
 Erdos382Problem	RESIDUAL	type-mismatch
-Erdos383Problem	RESIDUAL	proof-drift
+Erdos383Problem	GREEN	
 Erdos384Problem	GREEN	
 Erdos385Problem	GREEN	
 Erdos386Problem	GREEN	
@@ -1575,7 +1575,7 @@ Erdos678Aristotle	RESIDUAL	unknown-const:Erdos678.intervalLcm_eq_intervalLcm'
 Erdos678Problem	GREEN	
 Erdos679Aristotle	RESIDUAL	type-mismatch
 Erdos679Problem	GREEN	
-Erdos679ProblemAristotle	RESIDUAL	proof-drift
+Erdos679ProblemAristotle	GREEN	
 Erdos67Problem	GREEN	
 Erdos680Problem	GREEN	
 Erdos681Problem	GREEN	


### PR DESCRIPTION
5-slot config, conflict-proof collection. No loom labels.