### PR TITLE
migrate(v4.31): single-proof batch 27 (+2 GREEN, re-verified)

### DIFF
--- a/proofs/Proofs/Erdos69Problem.lean
+++ b/proofs/Proofs/Erdos69Problem.lean
@@ -109,38 +109,68 @@ theorem tao_identity : omegaSum = primeSum := by
     simp +decide [ div_eq_mul_inv, Finset.sum_mul _ _ _, omega_eq_card_prime_divisors ];
   -- By Fubini's theorem, we can interchange the order of summation.
   have h_fubini : ∑' n : ℕ, (∑ p ∈ Nat.primeFactors (n + 2), (1 : ℝ) / (2 : ℝ) ^ (n + 2)) = ∑' p : {n : ℕ | n.Prime}, (∑' n : ℕ, if p.val ∣ (n + 2) then (1 : ℝ) / (2 : ℝ) ^ (n + 2) else 0) := by
-    have h_fubini : Summable (fun (n : ℕ × {n : ℕ | n.Prime}) => if n.2.val ∣ (n.1 + 2) then (1 : ℝ) / (2 : ℝ) ^ (n.1 + 2) else 0) := by
-      have h_fubini : Summable (fun (n : ℕ) => (∑ p ∈ Nat.primeFactors (n + 2), (1 : ℝ) / (2 : ℝ) ^ (n + 2))) := by
-        -- We'll use the fact that if the series $\sum_{n=2}^{\infty} \frac{\omega(n)}{2^n}$ converges, then the series $\sum_{n=2}^{\infty} \frac{1}{2^n}$ also converges.
-        have h_summable : Summable (fun n : ℕ => (Nat.primeFactors (n + 2)).card / (2 : ℝ) ^ (n + 2)) := by
-          have : ∀ n : ℕ, (Nat.primeFactors (n + 2)).card ≤ n + 2 := by
-            exact fun n => le_trans ( Finset.card_le_card ( show Nat.primeFactors ( n + 2 ) ⊆ Finset.Icc 1 ( n + 2 ) from fun p hp => Finset.mem_Icc.mpr ⟨ Nat.pos_of_mem_primeFactors hp, Nat.le_of_mem_primeFactors hp ⟩ ) ) ( by simp +arith +decide )
-          have h_summable : Summable (fun n : ℕ => (n + 2 : ℝ) / (2 : ℝ) ^ (n + 2)) := by
-            refine' summable_of_ratio_norm_eventually_le _ _;
-            exact 3 / 4;
-            · norm_num;
-            · filter_upwards [ Filter.eventually_gt_atTop 0 ] with n hn using by rw [ Real.norm_of_nonneg ( by positivity ), Real.norm_of_nonneg ( by positivity ) ] ; rw [ div_mul_eq_mul_div, div_le_iff₀ ] <;> ring_nf <;> norm_num ; induction hn <;> norm_num [ pow_succ' ] at * ; nlinarith;
-          exact Summable.of_nonneg_of_le ( fun n => div_nonneg ( Nat.cast_nonneg _ ) ( pow_nonneg ( by norm_num ) _ ) ) ( fun n => div_le_div_of_nonneg_right ( mod_cast this n ) ( pow_nonneg ( by norm_num ) _ ) ) h_summable;
-        aesop;
-      rw [ summable_prod_of_nonneg ];
-      · refine' ⟨ _, _ ⟩;
-        · intro n;
-          refine' summable_of_ne_finset_zero _;
-          exact Finset.filter ( fun p => p.val ∣ n + 2 ) ( Finset.subtype ( fun p => Nat.Prime p ) ( Nat.divisors ( n + 2 ) ) );
-          aesop;
-        · refine' h_fubini.congr fun n => _;
-          rw [ tsum_eq_sum ];
-          any_goals exact Finset.filter ( fun p : { n : ℕ | Nat.Prime n } => p.val ∣ n + 2 ) ( Finset.subtype ( fun p : ℕ => Nat.Prime p ) ( Nat.primeFactors ( n + 2 ) ) );
-          · refine' Finset.sum_bij ( fun p hp => ⟨ p, Nat.prime_of_mem_primeFactors hp ⟩ ) _ _ _ _ <;> aesop;
-          · aesop;
-      · exact fun _ => by positivity;
-    rw [ ← Summable.tsum_comm ];
-    · refine' tsum_congr fun n => _;
-      rw [ tsum_eq_sum ];
-      any_goals exact Finset.filter ( fun p => p.val ∣ n + 2 ) ( Finset.subtype ( fun p => Nat.Prime p ) ( Nat.primeFactors ( n + 2 ) ) );
-      · refine' Finset.sum_bij ( fun p hp => ⟨ p, Nat.prime_of_mem_primeFactors hp ⟩ ) _ _ _ _ <;> aesop;
-      · aesop;
-    · convert h_fubini.comp_injective ( Prod.swap_injective ) using 1;
+    -- Reindex the Finset sum over primeFactors as a tsum over the prime subtype (indicator form).
+    have hreindex : ∀ n : ℕ,
+        ∑' p : {q : ℕ | q.Prime}, (if p.val ∣ (n + 2) then (1 : ℝ) / (2 : ℝ) ^ (n + 2) else 0)
+          = ∑ p ∈ Nat.primeFactors (n + 2), (1 : ℝ) / (2 : ℝ) ^ (n + 2) := by
+      intro n
+      have hn2 : n + 2 ≠ 0 := by omega
+      have hzero : ∀ p : {q : ℕ | q.Prime},
+          p ∉ Finset.subtype (· ∈ {q : ℕ | q.Prime}) (Nat.primeFactors (n + 2)) →
+          (if p.val ∣ (n + 2) then (1 : ℝ) / (2 : ℝ) ^ (n + 2) else 0) = 0 := by
+        intro p hp
+        rw [if_neg]
+        intro hdvd
+        exact hp (Finset.mem_subtype.mpr (Nat.mem_primeFactors.mpr ⟨p.prop, hdvd, hn2⟩))
+      rw [tsum_eq_sum hzero]
+      have hone : ∀ p ∈ Finset.subtype (· ∈ {q : ℕ | q.Prime}) (Nat.primeFactors (n + 2)),
+          (if p.val ∣ (n + 2) then (1 : ℝ) / (2 : ℝ) ^ (n + 2) else 0) = (1 : ℝ) / (2 : ℝ) ^ (n + 2) :=
+        fun p hp => if_pos (Nat.dvd_of_mem_primeFactors (Finset.mem_subtype.mp hp))
+      have hcard : (Finset.subtype (· ∈ {q : ℕ | q.Prime}) (Nat.primeFactors (n + 2))).card
+          = (Nat.primeFactors (n + 2)).card := by
+        rw [Finset.card_subtype]
+        congr 1
+        exact Finset.filter_true_of_mem (fun x hx => Nat.prime_of_mem_primeFactors hx)
+      rw [Finset.sum_congr rfl hone, Finset.sum_const, Finset.sum_const, hcard]
+    -- Row summability: for each n, only finitely many primes divide n+2.
+    have hrow_summable : ∀ n : ℕ, Summable (fun p : {q : ℕ | q.Prime} =>
+        if p.val ∣ (n + 2) then (1 : ℝ) / (2 : ℝ) ^ (n + 2) else 0) := by
+      intro n
+      have hn2 : n + 2 ≠ 0 := by omega
+      apply summable_of_ne_finset_zero
+        (s := Finset.subtype (· ∈ {q : ℕ | q.Prime}) (Nat.primeFactors (n + 2)))
+      intro p hp
+      rw [if_neg]
+      intro hdvd
+      exact hp (Finset.mem_subtype.mpr (Nat.mem_primeFactors.mpr ⟨p.prop, hdvd, hn2⟩))
+    -- Column summability: the row sums equal ω(n+2)/2^(n+2), which is summable.
+    have hcol_summable : Summable (fun n : ℕ =>
+        ∑' p : {q : ℕ | q.Prime}, if p.val ∣ (n + 2) then (1 : ℝ) / (2 : ℝ) ^ (n + 2) else 0) := by
+      have hfe : (fun n : ℕ => ∑' p : {q : ℕ | q.Prime},
+          if p.val ∣ (n + 2) then (1 : ℝ) / (2 : ℝ) ^ (n + 2) else 0)
+          = (fun n : ℕ => (Nat.primeFactors (n + 2)).card / (2 : ℝ) ^ (n + 2)) := by
+        funext n
+        rw [hreindex n, Finset.sum_const, nsmul_eq_mul, mul_one_div]
+      rw [hfe]
+      have hcardle : ∀ n : ℕ, (Nat.primeFactors (n + 2)).card ≤ n + 2 :=
+        fun n => le_trans ( Finset.card_le_card ( show Nat.primeFactors ( n + 2 ) ⊆ Finset.Icc 1 ( n + 2 ) from fun p hp => Finset.mem_Icc.mpr ⟨ Nat.pos_of_mem_primeFactors hp, Nat.le_of_mem_primeFactors hp ⟩ ) ) ( by simp +arith +decide )
+      have h_summable : Summable (fun n : ℕ => (n + 2 : ℝ) / (2 : ℝ) ^ (n + 2)) := by
+        refine' summable_of_ratio_norm_eventually_le _ _;
+        exact 3 / 4;
+        · norm_num;
+        · filter_upwards [ Filter.eventually_gt_atTop 0 ] with n hn using by rw [ Real.norm_of_nonneg ( by positivity ), Real.norm_of_nonneg ( by positivity ) ] ; rw [ div_mul_eq_mul_div, div_le_iff₀ ] <;> ring_nf <;> norm_num ; induction hn <;> norm_num [ pow_succ' ] at * ; nlinarith;
+      exact Summable.of_nonneg_of_le ( fun n => div_nonneg ( Nat.cast_nonneg _ ) ( pow_nonneg ( by norm_num ) _ ) ) ( fun n => div_le_div_of_nonneg_right ( mod_cast hcardle n ) ( pow_nonneg ( by norm_num ) _ ) ) h_summable;
+    have huncurried : Summable (Function.uncurry (fun (n : ℕ) (p : {q : ℕ | q.Prime}) =>
+        if p.val ∣ (n + 2) then (1 : ℝ) / (2 : ℝ) ^ (n + 2) else 0)) := by
+      rw [summable_prod_of_nonneg (fun x => by dsimp only [Function.uncurry]; split_ifs <;> positivity)]
+      exact ⟨hrow_summable, hcol_summable⟩
+    calc ∑' n : ℕ, (∑ p ∈ Nat.primeFactors (n + 2), (1 : ℝ) / (2 : ℝ) ^ (n + 2))
+        = ∑' n : ℕ, ∑' p : {q : ℕ | q.Prime},
+            (if p.val ∣ (n + 2) then (1 : ℝ) / (2 : ℝ) ^ (n + 2) else 0) :=
+          tsum_congr fun n => (hreindex n).symm
+      _ = ∑' p : {q : ℕ | q.Prime}, ∑' n : ℕ,
+            (if p.val ∣ (n + 2) then (1 : ℝ) / (2 : ℝ) ^ (n + 2) else 0) :=
+          (Summable.tsum_comm huncurried).symm
   -- Let's simplify the inner sum $\sum_{n=0}^{\infty} \frac{1}{2^{n+2}}$ if $p \mid (n+2)$.
   have h_inner : ∀ p : {n : ℕ | n.Prime}, ∑' n : ℕ, (if p.val ∣ (n + 2) then (1 : ℝ) / (2 : ℝ) ^ (n + 2) else 0) = 1 / (2 ^ p.val - 1) := by
     -- Let's simplify the inner sum $\sum_{n=0}^{\infty} \frac{1}{2^{n+2}}$ if $p \mid (n+2)$ using the formula for the sum of a geometric series.

--- a/proofs/Proofs/Erdos798Aristotle.lean
+++ b/proofs/Proofs/Erdos798Aristotle.lean
@@ -48,17 +48,20 @@ noncomputable def t (n : ℕ) : ℕ :=
 theorem latticeGrid_card (n : ℕ) (hn : n ≥ 1) :
     (latticeGrid n).ncard = n ^ 2 := by
   have heq : latticeGrid n = (Set.Icc (1 : ℤ) ↑n) ×ˢ (Set.Icc (1 : ℤ) ↑n) := by
-    ext ⟨x, y⟩; simp [latticeGrid, Set.mem_prod, Set.mem_Icc]
-  rw [heq, Set.ncard_prod (Set.finite_Icc _ _) (Set.finite_Icc _ _)]
+    ext ⟨x, y⟩
+    simp only [latticeGrid, Set.mem_setOf_eq, Set.mem_prod, Set.mem_Icc]
+    tauto
+  rw [heq, Set.ncard_prod]
   suffices h : (Set.Icc (1 : ℤ) ↑n).ncard = n by rw [h]; ring
-  rw [Set.ncard_eq_toFinset_card’ (Set.Icc (1 : ℤ) ↑n)]
-  simp only [Set.toFinset_Icc, Finset.card_Icc]
+  rw [Set.ncard_eq_toFinset_card' (Set.Icc (1 : ℤ) ↑n)]
+  simp only [Set.toFinset_Icc, Int.card_Icc]
   omega
 
 /-- The lattice grid is finite. -/
 theorem latticeGrid_finite (n : ℕ) :
     (latticeGrid n).Finite := by
-  apply Set.Finite.subset (Set.Finite.prod (Set.finite_Icc (1 : ℤ) n) (Set.finite_Icc 1 n))
+  apply Set.Finite.subset
+    (Set.Finite.prod (Set.finite_Icc (1 : ℤ) n) (Set.finite_Icc (1 : ℤ) n))
   intro ⟨x, y⟩ ⟨h1, h2, h3, h4⟩
   exact ⟨⟨h1, h2⟩, ⟨h3, h4⟩⟩
 

--- a/proofs/batch2/STATUS.md
+++ b/proofs/batch2/STATUS.md
@@ -1,3 +1,10 @@
+# DOCTOR SINGLE-PROOF BATCH 27 (5-slot, conflict-proof collect, #38065, 2026-07-15)
+
+**+2 GREEN** (re-verified EXIT=0): Erdos69Problem (Tonelli-swap h_fubini rebuilt explicit vs aesop-soup;
+Finset.subtype predicate must EXACTLY match Subtype/Set-coercion form or defeq apply fails; Summable now
+SummationFilter-parameterized), Erdos798Aristotle (Set.ncard_prod dropped Finite args; untyped numerals to
+Set.finite_Icc default wrong base type). Repairs: none.
+
 # DOCTOR SINGLE-PROOF BATCH 26 (5-slot, conflict-proof collect, #38065, 2026-07-15)
 
 **+3 GREEN** (re-verified EXIT=0): Erdos583Problem (anonymous-Pi-binder-in-structure-field now hits

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -1594,7 +1594,7 @@ Erdos696Problem	GREEN
 Erdos697Problem	GREEN	
 Erdos698Problem	GREEN	
 Erdos699Problem	GREEN	
-Erdos69Problem	RESIDUAL	proof-drift
+Erdos69Problem	GREEN	
 Erdos6Problem	GREEN	
 Erdos700Problem	GREEN	
 Erdos701Problem	PRE-EXISTING	never-compiled:A
@@ -1703,7 +1703,7 @@ Erdos795Problem	GREEN
 Erdos795ProblemAristotle	GREEN	
 Erdos796Problem	RESIDUAL	type-mismatch
 Erdos797Problem	GREEN	
-Erdos798Aristotle	RESIDUAL	proof-drift
+Erdos798Aristotle	GREEN	
 Erdos799Problem	GREEN	
 Erdos79Incomplete01	GREEN	signature-drift
 Erdos79Incomplete01OQ01	GREEN	


### PR DESCRIPTION
5-slot config, conflict-proof collection. No loom labels.