### PR TITLE
migrate(v4.31): single-proof batch 29 (+3 GREEN, re-verified)

### DIFF
--- a/proofs/Proofs/Erdos476OQ05Problem.lean
+++ b/proofs/Proofs/Erdos476OQ05Problem.lean
@@ -145,7 +145,7 @@ private lemma add_isAP_eq {A B : Finset (ZMod p)} {a b d : ZMod p}
       · simp [Nat.min_eq_left h]; exact Finset.card_pos.mp hBpos
       · have : min k (A.card - 1) = A.card - 1 := Nat.min_eq_right (by omega)
         simp [this]; omega
-    have h_ij : i + j = k := Nat.min_add_sub_cancel' (by omega)
+    have h_ij : i + j = k := by simp only [i, j]; omega
     simp only [Finset.mem_add]
     refine ⟨a + (i : ZMod p) * d, ?_, b + (j : ZMod p) * d, ?_, ?_⟩
     · rw [hA]; simp only [Finset.mem_image, Finset.mem_range]; exact ⟨i, hi, rfl⟩
@@ -190,7 +190,9 @@ private lemma isAP_sdiff_card {A : Finset (ZMod p)} {a d : ZMod p}
         calc a + ((i - 1 : ℕ) : ZMod p) * d + d
             = a + (((i - 1 : ℕ) : ZMod p) + 1) * d := by rw [add_mul]; ring
           _ = a + (i : ZMod p) * d := by rw [hcast]
-  · rintro rfl
+  · intro hxeq
+    have hxeq' := hxeq.symm
+    subst hxeq'
     refine ⟨?_, ?_⟩
     · rw [hA]; simp only [Finset.mem_image, Finset.mem_range]
       exact ⟨0, hApos, by simp⟩
@@ -238,7 +240,7 @@ private lemma vosper_ap_sdiff_card
   have hAP_a₀B : IsArithmeticProgression ({a₀} + B : Finset (ZMod p)) (a₀ + b₀) d :=
     isAP_sum (isAP_singleton a₀ d) hAP_B (by simp) hBpos (by rw [hcard_a₀B]; simp)
   -- |{a₀}+B \ (A'+B)| = 1: follows from |A+B| = |A'+B| + 1
-  have h_sdiff_one : ({a₀} + B \ ((A.erase a₀) + B) : Finset (ZMod p)).card = 1 := by
+  have h_sdiff_one : (({a₀} + B) \ ((A.erase a₀) + B) : Finset (ZMod p)).card = 1 := by
     have hunion : A + B = (A.erase a₀ + B) ∪ ({a₀} + B) := by
       ext x
       simp only [Finset.mem_add, Finset.mem_union]
@@ -262,6 +264,7 @@ private lemma vosper_ap_sdiff_card
     -- Unfold AP definitions to use index-set representation
     unfold IsArithmeticProgression at hAP_a₀B hAP_A'B
     rw [hcard_a₀B] at hAP_a₀B
+    rw [hcase1'] at hAP_A'B
     -- Bounds needed for injectivity of nat-cast
     have hBlt : B.card < p := by omega
     have hn₂lt : (A.erase a₀).card + B.card - 1 < p := by rw [hA'card]; omega
@@ -287,7 +290,7 @@ private lemma vosper_ap_sdiff_card
     -- Extract the unique missing element y
     obtain ⟨y, hy⟩ := Finset.card_eq_one.mp h_sdiff_one
     have hy_AP₁ : y ∈ ({a₀} + B : Finset _) :=
-      Finset.mem_of_mem_sdiff (hy ▸ Finset.mem_singleton_self y)
+      (Finset.mem_sdiff.mp (hy ▸ Finset.mem_singleton_self y)).1
     have hy_notAP₂ : y ∉ (A.erase a₀) + B :=
       (Finset.mem_sdiff.mp (hy ▸ Finset.mem_singleton_self y)).2
     -- All other elements of AP₁ are in AP₂
@@ -310,11 +313,11 @@ private lemma vosper_ap_sdiff_card
     have hy_notAP₂_idx : ∀ j < (A.erase a₀).card + B.card - 1,
         a₁ + b₀ + (j : ZMod p) * d ≠ y := by
       intro j hj heq
-      exact hy_notAP₂ (by rw [hAP_A'B]; exact Finset.mem_image.mpr ⟨j, Finset.mem_range.mpr hj, heq.symm⟩)
+      exact hy_notAP₂ (by rw [hAP_A'B]; exact Finset.mem_image.mpr ⟨j, Finset.mem_range.mpr hj, heq⟩)
     -- Case split: m = 0, m = B.card-1, or interior
     rcases Nat.lt_or_eq_of_le (Nat.zero_le m) with hm_pos | rfl
     · -- m ≥ 1 case
-      rcases Nat.lt_or_eq_of_le (Nat.lt_succ_iff.mp hm_range) with hm_int | rfl
+      rcases Nat.lt_or_eq_of_le (show m ≤ B.card - 1 from by omega) with hm_int | rfl
       · -- 0 < m < B.card-1: INTERIOR CASE → contradiction
         -- (proof: both (m-1) and (m+1) are non-missing indices, giving j=n₂-1 and k=0,
         --  then linear combination yields (|A'|+|B|)*d = 0, contradicting n₂+1 < p and d≠0)
@@ -322,7 +325,7 @@ private lemma vosper_ap_sdiff_card
         -- index m-1 not missing → a₀+b₀+(m-1)*d ∈ AP₂ at some j with j = n₂-1
         have hpred_ne : a₀ + b₀ + ((m - 1 : ℕ) : ZMod p) * d ≠ y := by
           intro heq
-          exact absurd (hAP₁_inj _ _ (by omega) hm_range heq.symm) (by omega)
+          exact absurd (hAP₁_inj _ _ (by omega) hm_range (heq.trans hm_eq.symm)) (by omega)
         have hpred_AP₁ : a₀ + b₀ + ((m - 1 : ℕ) : ZMod p) * d ∈ ({a₀} + B : Finset _) := by
           rw [hAP_a₀B]; exact Finset.mem_image.mpr ⟨m - 1, Finset.mem_range.mpr (by omega), rfl⟩
         obtain ⟨j, hj_lt, hj_eq⟩ := inAP₂ _ (hothers _ hpred_AP₁ hpred_ne)
@@ -334,13 +337,13 @@ private lemma vosper_ap_sdiff_card
             rw [← hm_eq]
             have hcast : ((j + 1 : ℕ) : ZMod p) = (j : ZMod p) + 1 := by push_cast; ring
             have hm_cast : (m : ZMod p) = ((m - 1 : ℕ) : ZMod p) + 1 := by
-              push_cast [Nat.sub_add_cancel hm_pos]; ring
-            linear_combination hj_eq + hm_cast * d - hcast * d
+              rw [Nat.cast_sub (by omega : 1 ≤ m), Nat.cast_one]; ring
+            linear_combination -hj_eq + hcast * d - hm_cast * d
           exact hy_notAP₂_idx _ hj_lt' hym_eq
         -- index m+1 not missing → a₀+b₀+(m+1)*d ∈ AP₂ at some k with k = 0
         have hsucc_ne : a₀ + b₀ + ((m + 1 : ℕ) : ZMod p) * d ≠ y := by
           intro heq
-          exact absurd (hAP₁_inj _ _ (by omega) hm_range heq.symm) (by omega)
+          exact absurd (hAP₁_inj _ _ (by omega) hm_range (heq.trans hm_eq.symm)) (by omega)
         have hsucc_AP₁ : a₀ + b₀ + ((m + 1 : ℕ) : ZMod p) * d ∈ ({a₀} + B : Finset _) := by
           rw [hAP_a₀B]; exact Finset.mem_image.mpr ⟨m + 1, Finset.mem_range.mpr (by omega), by push_cast; ring⟩
         obtain ⟨k, hk_lt, hk_eq⟩ := inAP₂ _ (hothers _ hsucc_AP₁ hsucc_ne)
@@ -350,29 +353,31 @@ private lemma vosper_ap_sdiff_card
           have hym_eq2 : a₁ + b₀ + ((k - 1 : ℕ) : ZMod p) * d = y := by
             rw [← hm_eq]
             have hcast : ((k - 1 : ℕ) : ZMod p) = (k : ZMod p) - 1 := by
-              push_cast [Nat.sub_add_cancel (Nat.pos_of_ne_zero hk_ne)]; ring
+              rw [Nat.cast_sub (by omega : 1 ≤ k), Nat.cast_one]
             have hm_cast : (m : ZMod p) = ((m + 1 : ℕ) : ZMod p) - 1 := by push_cast; ring
-            linear_combination hk_eq + hm_cast * d - hcast * d
+            linear_combination -hk_eq + hcast * d - hm_cast * d
           exact hy_notAP₂_idx _ (by omega) hym_eq2
         -- From j = n₂-1 and k = 0: derive (|A'|+|B|)*d = 0
         rw [hj_max] at hj_eq; rw [hk_zero] at hk_eq
         -- hj_eq : a₁+b₀+((n₂-1):ZMod p)*d = a₀+b₀+((m-1):ℕ)*d
         -- hk_eq : a₁+b₀+(0:ZMod p)*d = a₀+b₀+((m+1):ℕ)*d
         have hderiv : ((A.erase a₀).card + B.card : ZMod p) * d = 0 := by
-          have hcast_n₂ : ((A.erase a₀).card + B.card - 2 : ℕ) + 2 = (A.erase a₀).card + B.card := by
-            rw [hA'card]; omega
-          have : ((A.erase a₀).card + B.card - 2 + 2 : ℕ) = (A.erase a₀).card + B.card := hcast_n₂
           have hcast_sum : ((A.erase a₀).card + B.card : ZMod p) =
               ((A.erase a₀).card + B.card - 2 : ℕ) + (2 : ZMod p) := by
-            push_cast [← hcast_n₂]; ring
+            have h2 : 2 ≤ (A.erase a₀).card + B.card := by omega
+            rw [Nat.cast_sub h2]; push_cast; ring
+          have hcast_mp1 : ((m + 1 : ℕ) : ZMod p) = (m : ZMod p) + 1 := by push_cast; ring
+          have hcast_mm1 : ((m - 1 : ℕ) : ZMod p) = (m : ZMod p) - 1 := by
+            rw [Nat.cast_sub (by omega : 1 ≤ m), Nat.cast_one]
           rw [hcast_sum]
-          linear_combination hj_eq - hk_eq
+          linear_combination -hj_eq + hk_eq - hcast_mp1 * d + hcast_mm1 * d
         -- (|A'|+|B|)*d = 0 with d≠0 implies p ∣ (|A'|+|B|), but |A'|+|B| < p
         have hlt' : (A.erase a₀).card + B.card < p := by rw [hA'card]; omega
         have hne : ((A.erase a₀).card + B.card : ZMod p) ≠ 0 := by
-          rw [ZMod.natCast_eq_zero_iff]
-          intro hdvd
-          have := Nat.le_of_dvd (by omega) hdvd
+          rw [← Nat.cast_add]
+          intro hzero
+          rw [ZMod.natCast_eq_zero_iff] at hzero
+          have := Nat.le_of_dvd (by omega) hzero
           omega
         exact hne (mul_right_cancel₀ hd (by rw [hderiv, zero_mul]))
       · -- m = B.card-1: LAST ELEMENT missing → a₀ = a₁+|A'|*d
@@ -380,7 +385,7 @@ private lemma vosper_ap_sdiff_card
         -- index m-1 = B.card-2 not missing (since m = B.card-1 and B.card ≥ 2)
         have hpred_ne : a₀ + b₀ + ((B.card - 2 : ℕ) : ZMod p) * d ≠ y := by
           intro heq
-          exact absurd (hAP₁_inj _ _ (by omega) hm_range heq.symm) (by omega)
+          exact absurd (hAP₁_inj _ _ (by omega) hm_range (heq.trans hm_eq.symm)) (by omega)
         have hpred_AP₁ : a₀ + b₀ + ((B.card - 2 : ℕ) : ZMod p) * d ∈ ({a₀} + B : Finset _) := by
           rw [hAP_a₀B]
           exact Finset.mem_image.mpr ⟨B.card - 2, Finset.mem_range.mpr (by omega), rfl⟩
@@ -392,22 +397,26 @@ private lemma vosper_ap_sdiff_card
           have hym_eq : a₁ + b₀ + ((j + 1 : ℕ) : ZMod p) * d = y := by
             rw [← hm_eq]
             have hcast_j : ((j + 1 : ℕ) : ZMod p) = (j : ZMod p) + 1 := by push_cast; ring
-            have hcast_m : (B.card - 1 : ZMod p) = ((B.card - 2 : ℕ) : ZMod p) + 1 := by
-              push_cast [Nat.sub_add_cancel (by omega : 2 ≤ B.card)]; ring
-            linear_combination hj_eq + hcast_m * d - hcast_j * d
+            have hcast_m : ((B.card - 1 : ℕ) : ZMod p) = ((B.card - 2 : ℕ) : ZMod p) + 1 := by
+              have hnat : B.card - 1 = (B.card - 2) + 1 := by omega
+              rw [hnat]; push_cast; ring
+            linear_combination -hj_eq + hcast_j * d - hcast_m * d
           exact hy_notAP₂_idx _ hj_lt' hym_eq
         -- From hj_eq with j = n₂-1: a₀+b₀+(B.card-2)*d = a₁+b₀+(|A'|+|B|-2)*d
         rw [hj_max] at hj_eq
         -- Conclusion: a₀ = a₁+|A'|*d
         have hcast_n : (A.erase a₀).card + B.card - 2 = (A.erase a₀).card + (B.card - 2) := by omega
-        linear_combination hj_eq
+        have hcast_n' : (((A.erase a₀).card + B.card - 2 : ℕ) : ZMod p) =
+            ((A.erase a₀).card : ZMod p) + ((B.card - 2 : ℕ) : ZMod p) := by
+          rw [hcast_n]; push_cast; ring
+        linear_combination hj_eq + hcast_n' * d
     · -- m = 0: FIRST ELEMENT missing → a₀ = a₁-d
       left
       -- index 1 is not missing (B.card ≥ 2)
       have h1_ne : a₀ + b₀ + (1 : ZMod p) * d ≠ y := by
         rw [← hm_eq]
         simp only [Nat.cast_zero, zero_mul, add_zero, one_mul]
-        intro h; exact hd (add_left_cancel h)
+        intro h; exact hd (by linear_combination h)
       have h1_AP₁ : a₀ + b₀ + (1 : ZMod p) * d ∈ ({a₀} + B : Finset _) := by
         rw [hAP_a₀B]
         exact Finset.mem_image.mpr ⟨1, Finset.mem_range.mpr (by omega), by push_cast; ring⟩
@@ -415,7 +424,7 @@ private lemma vosper_ap_sdiff_card
       rcases Nat.eq_zero_or_pos j with rfl | hj_pos
       · -- j = 0: a₁+b₀ = a₀+b₀+d → a₀ = a₁-d
         simp only [Nat.cast_zero, zero_mul, add_zero] at hj_eq
-        linear_combination -hj_eq
+        linear_combination hj_eq
       · -- j ≥ 1: a₁+b₀+(j-1)*d = a₀+b₀ ∈ AP₂, contradicting a₀+b₀ ∉ AP₂
         exfalso
         -- a₀+b₀ = y (since m = 0, y = a₀+b₀+0*d = a₀+b₀)
@@ -424,8 +433,8 @@ private lemma vosper_ap_sdiff_card
         have hpred_eq_y : a₁ + b₀ + ((j - 1 : ℕ) : ZMod p) * d = y := by
           rw [hy_val]
           have hcast_j : ((j - 1 : ℕ) : ZMod p) = (j : ZMod p) - 1 := by
-            push_cast [Nat.sub_add_cancel hj_pos]; ring
-          linear_combination hj_eq - hcast_j * d
+            rw [Nat.cast_sub (by omega : 1 ≤ j), Nat.cast_one]
+          linear_combination -hj_eq + hcast_j * d
         exact hy_notAP₂_idx _ (by omega) hpred_eq_y
   -- In each case A is an AP with diff d, so |A \ A.image(·+d)| = 1 by isAP_sdiff_card
   rcases hpos with ha₀_pred | ha₀_succ
@@ -433,7 +442,8 @@ private lemma vosper_ap_sdiff_card
     have hAP_A : IsArithmeticProgression A a₀ d := by
       have hA_card : A.card = (A.erase a₀).card + 1 := by omega
       unfold IsArithmeticProgression
-      rw [hA_card, ← Finset.insert_erase ha₀A]
+      rw [hA_card]
+      conv_lhs => rw [← Finset.insert_erase ha₀A]
       ext x
       simp only [Finset.mem_insert, Finset.mem_image, Finset.mem_range]
       constructor
@@ -458,27 +468,27 @@ private lemma vosper_ap_sdiff_card
             have h := Nat.sub_add_cancel hi_pos
             have := congrArg (Nat.cast (R := ZMod p)) h
             rwa [Nat.cast_add, Nat.cast_one] at this
-          rw [ha₁]
-          calc a₀ + (↑i : ZMod p) * d
-              = a₀ + ((↑(i - 1 : ℕ) : ZMod p) + 1) * d := by rw [hcast]
-            _ = a₀ + d + (↑(i - 1 : ℕ) : ZMod p) * d := by ring
+          rw [ha₁, ← hcast]; ring
     rw [isAP_sdiff_card hAP_A hd (by omega) hA_lt_p, Finset.card_singleton]
   · -- Case: a₀ = a₁ + |A'|*d (successor of AP A'); A = AP(a₁, d, |A|)
     have hAP_A : IsArithmeticProgression A a₁ d := by
       have hA_card : A.card = (A.erase a₀).card + 1 := by omega
       unfold IsArithmeticProgression
-      rw [hA_card, ← Finset.insert_erase ha₀A]
+      rw [hA_card]
+      conv_lhs => rw [← Finset.insert_erase ha₀A]
       ext x
       simp only [Finset.mem_insert, Finset.mem_image, Finset.mem_range]
       constructor
-      · rintro (rfl | hx)
-        · exact ⟨(A.erase a₀).card, by omega, by rw [← ha₀_succ]⟩
+      · rintro (hxeq | hx)
+        · have hxeq' := hxeq.symm
+          subst hxeq'
+          exact ⟨(A.erase a₀).card, by omega, by rw [← ha₀_succ]⟩
         · rw [hAP_A'] at hx
           simp only [Finset.mem_image, Finset.mem_range] at hx
           obtain ⟨i, hi, rfl⟩ := hx
           exact ⟨i, by omega, rfl⟩
       · rintro ⟨i, hi, rfl⟩
-        rcases Nat.lt_or_eq_of_le (Nat.lt_succ_iff.mp hi) with hi' | rfl
+        rcases Nat.lt_or_eq_of_le (show i ≤ (A.erase a₀).card from by omega) with hi' | rfl
         · right; rw [hAP_A']
           simp only [Finset.mem_image, Finset.mem_range]
           exact ⟨i, hi', rfl⟩
@@ -545,8 +555,7 @@ lemma ap_of_near_periodic {B : Finset (ZMod p)} {d : ZMod p}
       -- k = m: b₀ + m*d ∈ B (proved by orbit-cardinality contradiction)
       · by_contra hnot
         -- T_m = {b₀, b₀+d, ..., b₀+(m-1)*d} ⊆ B
-        let T : Finset (ZMod p) :=
-          (Finset.range k).image (fun j => b₀ + (j : ZMod p) * d)
+        let T := (Finset.range k).image (fun j : ℕ => b₀ + (j : ZMod p) * d)
         have hT_sub : T ⊆ B := by
           intro x hx
           simp only [T, Finset.mem_image, Finset.mem_range] at hx
@@ -562,7 +571,7 @@ lemma ap_of_near_periodic {B : Finset (ZMod p)} {d : ZMod p}
                          heq
         -- S = B \ T is nonempty (|B| > m = |T|)
         have hS_pos : 0 < (B \ T).card := by
-          rw [Finset.card_sdiff hT_sub, hT_card]; omega
+          rw [Finset.card_sdiff_of_subset hT_sub, hT_card]; omega
         obtain ⟨x₀, hx₀_S⟩ := Finset.card_pos.mp hS_pos
         -- S is closed under b ↦ b - d
         have hσ : ∀ b ∈ B \ T, b - d ∈ B \ T := by
@@ -572,8 +581,15 @@ lemma ap_of_near_periodic {B : Finset (ZMod p)} {d : ZMod p}
           refine ⟨hpred b hbB ?_, ?_⟩
           · -- b ≠ b₀: since b₀ ∈ T ⊆ B and b ∉ T
             intro hbb₀
+            have hkpos : 0 < k := by
+              by_contra hk0
+              have hk0' : k = 0 := by omega
+              rw [hk0'] at hnot
+              simp at hnot
+              exact hnot hb₀_mem
             apply hbT
-            simp [T, hbb₀]
+            simp only [T, Finset.mem_image, Finset.mem_range]
+            exact ⟨0, hkpos, by rw [hbb₀]; simp⟩
           · -- b - d ∉ T: if b-d = b₀+j*d for j < m, then b = b₀+(j+1)*d
             intro hbdT
             simp only [T, Finset.mem_image, Finset.mem_range] at hbdT
@@ -587,7 +603,7 @@ lemma ap_of_near_periodic {B : Finset (ZMod p)} {d : ZMod p}
             · -- j+1 < m: b ∈ T, contradiction
               exact hbT (by
                 simp only [T, Finset.mem_image, Finset.mem_range]
-                exact ⟨j + 1, hj1, hb_eq⟩)
+                exact ⟨j + 1, hj1, hb_eq.symm⟩)
             · -- j+1 = k: b = b₀+k*d, contradicts hnot (b₀+k*d ∉ B)
               apply hnot
               rw [← hj1]
@@ -609,11 +625,7 @@ lemma ap_of_near_periodic {B : Finset (ZMod p)} {d : ZMod p}
           intro ⟨j₁, hj₁⟩ ⟨j₂, hj₂⟩ heq
           simp only at heq
           -- From x₀ - j₁*d = x₀ - j₂*d, derive j₁*d = j₂*d
-          have h_neg : -(j₁ : ZMod p) * d = -(j₂ : ZMod p) * d :=
-            add_left_cancel (show x₀ + -(j₁ : ZMod p) * d = x₀ + -(j₂ : ZMod p) * d by
-              rwa [← sub_eq_add_neg, ← sub_eq_add_neg])
-          have hmul : (j₁ : ZMod p) * d = (j₂ : ZMod p) * d := by
-            rwa [neg_mul, neg_mul, neg_inj] at h_neg
+          have hmul : (j₁ : ZMod p) * d = (j₂ : ZMod p) * d := by linear_combination -heq
           have h_eq : (j₁ : ZMod p) = (j₂ : ZMod p) := mul_right_cancel₀ hd hmul
           ext
           have := congrArg ZMod.val h_eq
@@ -631,6 +643,7 @@ lemma ap_of_near_periodic {B : Finset (ZMod p)} {d : ZMod p}
   -- Conclude B = (range B.card).image (j ↦ b₀ + j*d)
   refine ⟨b₀, ?_⟩
   unfold IsArithmeticProgression
+  symm
   apply Finset.eq_of_subset_of_card_le
   · intro x hx
     simp only [Finset.mem_image, Finset.mem_range] at hx
@@ -670,14 +683,15 @@ lemma vosper_base (A B : Finset (ZMod p)) (hA : A.card = 2) (hB : 2 ≤ B.card)
           rw [Finset.mem_add] at hxA hxBb
           obtain ⟨y₁, hy₁, z₁, hz₁, h₁⟩ := hxA
           obtain ⟨y₂, hy₂, z₂, hz₂, h₂⟩ := hxBb
-          rw [Finset.mem_singleton] at hy₁ hy₂; subst hy₁; subst hy₂
+          rw [Finset.mem_singleton] at hy₁ hy₂
+          rw [hy₁] at h₁; rw [hy₂] at h₂
           rw [Finset.mem_image]
           refine ⟨z₁, ?_, by rw [add_comm]; exact h₁⟩
           rw [Finset.mem_inter, Finset.mem_image]
           exact ⟨hz₁, z₂, hz₂, by
             calc z₂ + (b - a) = b + z₂ - a := by ring
-              _ = x - a := by rw [← h₂]; ring
-              _ = a + z₁ - a := by rw [← h₁]; ring
+              _ = x - a := by rw [← h₂]
+              _ = a + z₁ - a := by rw [← h₁]
               _ = z₁ := by ring⟩
         · intro x hx
           rw [Finset.mem_image] at hx
@@ -738,7 +752,8 @@ theorem vosper (A B : Finset (ZMod p)) (hA : 2 ≤ A.card) (hB : 2 ≤ B.card)
             ZMod.cauchy_davenport hp.1
               (Finset.card_pos.mp (by rw [Finset.card_erase_of_mem haA]; omega))
               (Finset.card_pos.mp (by omega))
-          simp only [Finset.card_erase_of_mem haA, Nat.inf_eq_min] at hCD
+          simp only [Finset.card_erase_of_mem haA] at hCD
+          have hCD' : min p (A.card - 1 + B.card - 1) ≤ (A.erase a + B).card := hCD
           omega
         have hhi : (A.erase a + B).card ≤ A.card + B.card - 1 :=
           (Finset.card_le_card (Finset.add_subset_add_right (Finset.erase_subset _ _))).trans_eq h
@@ -764,9 +779,9 @@ theorem vosper (A B : Finset (ZMod p)) (hA : 2 ≤ A.card) (hB : 2 ≤ B.card)
           obtain ⟨a', ha'er, b', hb'B, heq⟩ := Finset.mem_add.mp hmem
           rw [Finset.mem_erase] at ha'er
           rw [hB_eq, Finset.mem_insert, Finset.mem_singleton] at hb'B
-          rcases hb'B with rfl | rfl
-          · exact absurd (add_right_cancel heq) ha'er.1
-          · have ha'_val : a' = a + (b₁ - b₂) := by linear_combination heq
+          rcases hb'B with h1 | h2
+          · rw [h1] at heq; exact absurd (add_right_cancel heq) ha'er.1
+          · have ha'_val : a' = a + (b₁ - b₂) := by rw [h2] at heq; linear_combination heq
             rw [← ha'_val]; exact ha'er.2
         -- The d-orbit of any a₀ ∈ A has p distinct elements all in A → |A| ≥ p
         obtain ⟨a₀, ha₀A⟩ := Finset.card_pos.mp (by omega : 0 < A.card)
@@ -799,7 +814,7 @@ theorem vosper (A B : Finset (ZMod p)) (hA : 2 ≤ A.card) (hB : 2 ≤ B.card)
             obtain ⟨a, haA, b, hbB, hxab⟩ := Finset.mem_add.mp hx
             apply Finset.card_pos.mpr
             exact ⟨a, Finset.mem_filter.mpr ⟨haA, show x - a ∈ B by
-              have : x - a = b := (eq_sub_of_add_eq hxab).symm
+              have : x - a = b := by rw [← hxab]; ring
               rw [this]; exact hbB⟩⟩
           have hcard1 : (A.filter (fun a => x - a ∈ B)).card = 1 := by omega
           obtain ⟨a₁, ha₁⟩ := Finset.card_eq_one.mp hcard1
@@ -809,8 +824,9 @@ theorem vosper (A B : Finset (ZMod p)) (hA : 2 ≤ A.card) (hB : 2 ≤ B.card)
             intro hcontra
             obtain ⟨a', ha'er, b', hb'B, hsum'⟩ := Finset.mem_add.mp hcontra
             rw [Finset.mem_erase] at ha'er
+            have hxa' : x - a' = b' := by rw [← hsum']; ring
             have ha'filt : a' ∈ A.filter (fun a => x - a ∈ B) :=
-              Finset.mem_filter.mpr ⟨ha'er.2, (eq_sub_of_add_eq hsum') ▸ hb'B⟩
+              Finset.mem_filter.mpr ⟨ha'er.2, hxa' ▸ hb'B⟩
             rw [ha₁] at ha'filt
             exact ha'er.1 (Finset.mem_singleton.mp ha'filt)
           exact hxnotin (hredA a₁ ha₁A ▸ hx)

--- a/proofs/Proofs/Erdos817Problem.lean
+++ b/proofs/Proofs/Erdos817Problem.lean
@@ -165,19 +165,24 @@ This is a partial result toward the main conjecture. -/
 /-- ∑_{j∈S} 3^j mod 3 equals 1 if 0 ∈ S, else 0 (all terms j≥1 are divisible by 3). -/
 private lemma sum_pow3_mod3 (S : Finset ℕ) :
     S.sum (fun j => (3 : ℕ)^j) % 3 = if 0 ∈ S then 1 else 0 := by
-  conv_lhs =>
-    rw [← Finset.filter_union_filter_neg_eq (· = 0) S]
-  rw [Finset.sum_union (Finset.disjoint_filter.mpr fun a _ h1 h2 => h2 h1)]
-  have hzero : (S.filter (· = 0)).sum (fun j => (3 : ℕ)^j) = if 0 ∈ S then 1 else 0 := by
-    simp [Finset.filter_eq', Finset.sum_ite_eq']
-  have hrest : 3 ∣ (S.filter (fun j => ¬(j = 0))).sum (fun j => (3 : ℕ)^j) := by
+  have hsplit : (S.filter (fun j => j = 0)).sum (fun j => (3 : ℕ)^j) +
+      (S.filter (fun j => j ≠ 0)).sum (fun j => (3 : ℕ)^j) = S.sum (fun j => (3 : ℕ)^j) :=
+    Finset.sum_filter_add_sum_filter_not S (fun j => j = 0) _
+  have hzero : (S.filter (fun j => j = 0)).sum (fun j => (3 : ℕ)^j) = if 0 ∈ S then 1 else 0 := by
+    simp only [Finset.filter_eq']
+    split_ifs <;> simp
+  have hrest : 3 ∣ (S.filter (fun j => j ≠ 0)).sum (fun j => (3 : ℕ)^j) := by
     apply Finset.dvd_sum
     intro j hj
-    simp [Finset.mem_filter] at hj
+    simp only [Finset.mem_filter] at hj
     exact dvd_pow_self 3 hj.2
   obtain ⟨k, hk⟩ := hrest
-  rw [hk, hzero]
-  split_ifs with h <;> omega
+  rw [hzero, hk] at hsplit
+  by_cases h0 : 0 ∈ S
+  · rw [if_pos h0] at hsplit ⊢
+    omega
+  · rw [if_neg h0] at hsplit ⊢
+    omega
 
 /-- Shifting: if all j ∈ S satisfy j ≥ 1, then ∑_S 3^j = 3 * ∑_{j-1 : j∈S} 3^j. -/
 private lemma sum_pow3_shift (S : Finset ℕ) (hS : ∀ j ∈ S, 1 ≤ j) :
@@ -188,8 +193,10 @@ private lemma sum_pow3_shift (S : Finset ℕ) (hS : ∀ j ∈ S, 1 ≤ j) :
       = S.sum (fun j => 3 * (3:ℕ)^(j - 1)) := by
           apply Finset.sum_congr rfl; intro j hj
           have hj1 := hS j hj
-          rw [show j = j - 1 + 1 from (Nat.sub_add_cancel hj1).symm, pow_succ]
-          ring
+          have hjeq : j - 1 + 1 = j := Nat.sub_add_cancel hj1
+          calc (3:ℕ)^j = 3^(j - 1 + 1) := by rw [hjeq]
+            _ = 3^(j - 1) * 3 := pow_succ 3 (j - 1)
+            _ = 3 * 3^(j - 1) := by ring
     _ = 3 * S.sum (fun j => (3:ℕ)^(j - 1)) := by rw [← Finset.mul_sum]
     _ = 3 * (S.image (· - 1)).sum (fun j => (3:ℕ)^j) := by
           congr 1; exact (Finset.sum_image hinj).symm
@@ -230,12 +237,17 @@ private lemma pow3sum_AP_forced (n : ℕ) :
         X.sum (fun j => (3:ℕ)^j) =
         (if 0 ∈ X then 1 else 0) + (X.filter (fun j => j ≠ 0)).sum (fun j => (3:ℕ)^j) := by
       intro X
-      rw [← Finset.filter_union_filter_neg_eq (· = 0) X,
-          Finset.sum_union (Finset.disjoint_filter.mpr fun a _ h1 h2 => h2 h1)]
-      congr 1
-      simp [Finset.filter_eq', Finset.sum_ite_eq']
+      have hsplit : (X.filter (fun j => j = 0)).sum (fun j => (3:ℕ)^j) +
+          (X.filter (fun j => j ≠ 0)).sum (fun j => (3:ℕ)^j) = X.sum (fun j => (3:ℕ)^j) :=
+        Finset.sum_filter_add_sum_filter_not X (fun j => j = 0) _
+      have hzero : (X.filter (fun j => j = 0)).sum (fun j => (3:ℕ)^j) = if 0 ∈ X then 1 else 0 := by
+        simp only [Finset.filter_eq']
+        split_ifs <;> simp
+      rw [hzero] at hsplit
+      exact hsplit.symm
     have heq' : S'.sum (fun j => (3:ℕ)^j) + U'.sum (fun j => (3:ℕ)^j) =
                 2 * T'.sum (fun j => (3:ℕ)^j) := by
+      simp only [S', T', U']
       rw [hdecomp S, hdecomp T, hdecomp U] at heq
       have hST : (if 0 ∈ S then (1:ℕ) else 0) = if 0 ∈ T then 1 else 0 := by
         simp only [show (0 ∈ S) = (0 ∈ T) from propext hmem0.1]
@@ -250,8 +262,10 @@ private lemma pow3sum_AP_forced (n : ℕ) :
         X.image (· - 1) ⊆ Finset.range n := by
       intro X hXpos hXn j hj
       obtain ⟨k, hk, rfl⟩ := Finset.mem_image.mp hj
-      simp only [Finset.mem_range] at hXn ⊢
-      have := hXpos k hk; have := hXn hk; omega
+      simp only [Finset.mem_range]
+      have h1 := hXpos k hk
+      have h2 : k < n + 1 := Finset.mem_range.mp (hXn hk)
+      omega
     obtain ⟨hST'', hUT''⟩ := ih
       (S'.image (· - 1)) (T'.image (· - 1)) (U'.image (· - 1))
       (img_range S' hS'pos ((Finset.filter_subset _ _).trans hS))
@@ -271,19 +285,31 @@ private lemma pow3sum_AP_forced (n : ℕ) :
         have := hXpos k hk; have := hYpos j hj; rwa [show k = j from by omega] at hk
     have hS'T' : S' = T' := hlift S' T' hS'pos hT'pos hST''
     have hU'T' : U' = T' := hlift U' T' hU'pos hT'pos hUT''
-    constructor <;> (ext j; by_cases hj : j = 0)
-    · subst hj; exact hmem0.1
-    · constructor
-      · intro hjX
-        exact (Finset.mem_filter.mp (hS'T' ▸ Finset.mem_filter.mpr ⟨hjX, hj⟩)).1
-      · intro hjX
-        exact (Finset.mem_filter.mp (hS'T'.symm ▸ Finset.mem_filter.mpr ⟨hjX, hj⟩)).1
-    · subst hj; exact hmem0.2
-    · constructor
-      · intro hjX
-        exact (Finset.mem_filter.mp (hU'T' ▸ Finset.mem_filter.mpr ⟨hjX, hj⟩)).1
-      · intro hjX
-        exact (Finset.mem_filter.mp (hU'T'.symm ▸ Finset.mem_filter.mpr ⟨hjX, hj⟩)).1
+    refine ⟨?_, ?_⟩
+    · ext j
+      by_cases hj : j = 0
+      · subst hj; exact hmem0.1
+      · constructor
+        · intro hjS
+          have hmemS : j ∈ S' := Finset.mem_filter.mpr ⟨hjS, hj⟩
+          rw [hS'T'] at hmemS
+          exact (Finset.mem_filter.mp hmemS).1
+        · intro hjT
+          have hmemT : j ∈ T' := Finset.mem_filter.mpr ⟨hjT, hj⟩
+          rw [← hS'T'] at hmemT
+          exact (Finset.mem_filter.mp hmemT).1
+    · ext j
+      by_cases hj : j = 0
+      · subst hj; exact hmem0.2
+      · constructor
+        · intro hjU
+          have hmemU : j ∈ U' := Finset.mem_filter.mpr ⟨hjU, hj⟩
+          rw [hU'T'] at hmemU
+          exact (Finset.mem_filter.mp hmemU).1
+        · intro hjT
+          have hmemT : j ∈ T' := Finset.mem_filter.mpr ⟨hjT, hj⟩
+          rw [← hU'T'] at hmemT
+          exact (Finset.mem_filter.mp hmemT).1
 
 /-
 ## Basic Properties
@@ -303,7 +329,7 @@ private lemma apFree3_of_apFree_le (k : ℕ) (hk : k ≥ 3) (S : Set ℕ)
 /-- The trivial lower bound: g_k(n) ≥ n since we need n distinct elements. -/
 theorem g_ge_n (k n : ℕ) (hk : k ≥ 3) (hn : n ≥ 1) : g k n ≥ n := by
   unfold g
-  apply Nat.le_sInf
+  apply le_csInf
   · -- ValidNs k n is nonempty: use A = {1,3,...,3^(n-1)} ⊆ Icc 1 (3^n).
     -- It is 3-AP-free (proved below), hence k-AP-free for k ≥ 3.
     let A := (Finset.range n).image (fun i => (3:ℕ)^i)
@@ -329,28 +355,34 @@ theorem g_ge_n (k n : ℕ) (hk : k ≥ 3) (hn : n ≥ 1) : g k n ≥ n := by
       -- membership characterization (same as in g3_le_exp)
       have hmem : ∀ x : ℕ, x ∈ (subsetSums A : Set ℕ) ↔
           ∃ J ⊆ Finset.range n, x = J.sum (fun j => (3:ℕ)^j) := by
-        intro x; simp only [Set.mem_coe, subsetSums, Finset.mem_image, Finset.mem_powerset, A]
+        intro x; simp only [Finset.mem_coe, subsetSums, Finset.mem_image, Finset.mem_powerset, A]
         constructor
         · rintro ⟨B, hB_sub, rfl⟩
-          refine ⟨(Finset.range n).filter (fun j => (3:ℕ)^j ∈ B),
-                  Finset.filter_subset _ _, ?_⟩
-          apply Finset.sum_nbij (fun j => (3:ℕ)^j)
-          · intro j hj; exact (Finset.mem_filter.mp hj).2
-          · exact fun a _ b _ h => pow3_strictMono.injective h
-          · intro b hb
-            obtain ⟨j, hj, rfl⟩ := Finset.mem_image.mp (hB_sub hb)
-            exact ⟨j, Finset.mem_filter.mpr ⟨Finset.mem_range.mpr hj, hb⟩, rfl⟩
-          · intro j _; simp
+          let J := (Finset.range n).filter (fun j => (3:ℕ)^j ∈ B)
+          have hBJ : B = J.image (fun j => (3:ℕ)^j) := by
+            apply Finset.Subset.antisymm
+            · intro y hyB
+              obtain ⟨j, hjn, hjy⟩ := Finset.mem_image.mp (hB_sub hyB)
+              exact Finset.mem_image.mpr ⟨j, Finset.mem_filter.mpr ⟨hjn,
+                by rw [hjy]; exact hyB⟩, hjy⟩
+            · intro y hy
+              obtain ⟨j, hj, rfl⟩ := Finset.mem_image.mp hy
+              exact (Finset.mem_filter.mp hj).2
+          refine ⟨J, Finset.filter_subset _ _, ?_⟩
+          rw [hBJ]
+          exact Finset.sum_image (fun a _ b _ h => pow3_strictMono.injective h)
         · rintro ⟨J, hJ, rfl⟩
-          exact ⟨J.image (fun j => (3:ℕ)^j),
-                 fun x hx => by obtain ⟨j, hj, rfl⟩ := Finset.mem_image.mp hx
-                                exact Finset.mem_image.mpr ⟨j, hJ hj, rfl⟩,
-                 (Finset.sum_image (fun a _ b _ h => pow3_strictMono.injective h)).symm⟩
+          refine ⟨J.image (fun j => (3:ℕ)^j), ?_, ?_⟩
+          · intro x hx
+            obtain ⟨j, hj, rfl⟩ := Finset.mem_image.mp hx
+            exact Finset.mem_image.mpr ⟨j, hJ hj, rfl⟩
+          · simp [Finset.sum_image (fun a _ b _ h => pow3_strictMono.injective h)]
       rw [hmem] at h0 h1 h2
       obtain ⟨S, hS, rfl⟩ := h0; obtain ⟨T, hT, hT_eq⟩ := h1
       obtain ⟨U, hU, hU_eq⟩ := h2
       obtain ⟨hST, _⟩ := pow3sum_AP_forced n S T U hS hT hU (by linarith)
-      linarith
+      rw [hST] at hT_eq
+      omega
     exact ⟨3^n, ⟨A, hA_sub, hA_card, apFree3_of_apFree_le k hk _ hA_free3⟩⟩
   · -- Every N ∈ ValidNs k n satisfies N ≥ n
     intro N ⟨A, hA_sub, hA_card, _⟩
@@ -387,27 +419,32 @@ theorem g3_le_exp (n : ℕ) (hn : n ≥ 1) : g 3 n ≤ 3^n := by
   have hmem : ∀ x : ℕ, x ∈ (subsetSums A : Set ℕ) ↔
       ∃ J ⊆ Finset.range n, x = J.sum (fun j => (3:ℕ)^j) := by
     intro x
-    simp only [Set.mem_coe, subsetSums, Finset.mem_image, Finset.mem_powerset, A]
+    simp only [Finset.mem_coe, subsetSums, Finset.mem_image, Finset.mem_powerset, A]
     constructor
     · rintro ⟨B, hB_sub, rfl⟩
       -- B ⊆ image(3^·)(range n); use J = preimage of B under 3^·
       let J := (Finset.range n).filter (fun j => (3:ℕ)^j ∈ B)
+      have hBJ : B = J.image (fun j => (3:ℕ)^j) := by
+        apply Finset.Subset.antisymm
+        · intro y hyB
+          have hyA := hB_sub hyB
+          simp only [A, Finset.mem_image, Finset.mem_range] at hyA
+          obtain ⟨j, hjn, hjy⟩ := hyA
+          exact Finset.mem_image.mpr ⟨j, Finset.mem_filter.mpr ⟨Finset.mem_range.mpr hjn,
+            by rw [hjy]; exact hyB⟩, hjy⟩
+        · intro y hy
+          obtain ⟨j, hj, rfl⟩ := Finset.mem_image.mp hy
+          exact (Finset.mem_filter.mp hj).2
       refine ⟨J, Finset.filter_subset _ _, ?_⟩
       -- B.sum id = J.sum(3^·): every b ∈ B is 3^j for unique j ∈ J
-      apply Finset.sum_nbij (fun j => (3:ℕ)^j)
-      · intro j hj; exact (Finset.mem_filter.mp hj).2
-      · exact fun a _ b _ h => pow3_strictMono.injective h
-      · intro b hb
-        have := hB_sub hb
-        simp only [A, Finset.mem_image, Finset.mem_range] at this
-        obtain ⟨j, hj, rfl⟩ := this
-        exact ⟨j, Finset.mem_filter.mpr ⟨Finset.mem_range.mpr hj, hb⟩, rfl⟩
-      · intro j _; simp
+      rw [hBJ]
+      exact Finset.sum_image (fun a _ b _ h => pow3_strictMono.injective h)
     · rintro ⟨J, hJ, rfl⟩
-      refine ⟨J.image (fun j => (3:ℕ)^j), fun x hx => ?_, ?_⟩
-      · obtain ⟨j, hj, rfl⟩ := Finset.mem_image.mp hx
+      refine ⟨J.image (fun j => (3:ℕ)^j), ?_, ?_⟩
+      · intro x hx
+        obtain ⟨j, hj, rfl⟩ := Finset.mem_image.mp hx
         exact Finset.mem_image.mpr ⟨j, hJ hj, rfl⟩
-      · rw [Finset.sum_image (fun a _ b _ h => pow3_strictMono.injective h)]
+      · simp [Finset.sum_image (fun a _ b _ h => pow3_strictMono.injective h)]
   have hA_free : IsAPFreeOfLength 3 (subsetSums A : Set ℕ) := by
     intro a d hd
     by_contra hall
@@ -422,7 +459,7 @@ theorem g3_le_exp (n : ℕ) (hn : n ≥ 1) : g 3 n ≤ 3^n := by
     have heq_ap : S.sum (fun j => (3:ℕ)^j) + U.sum (fun j => (3:ℕ)^j) =
         2 * T.sum (fun j => (3:ℕ)^j) := by linarith
     obtain ⟨hST, _⟩ := pow3sum_AP_forced n S T U hS hT hU heq_ap
-    have : d = 0 := by linarith
+    rw [hST] at hT_eq
     omega
   exact Nat.sInf_le ⟨A, hA_sub, hA_card, hA_free⟩
 
@@ -455,7 +492,7 @@ theorem g3_one : g 3 1 = 1 := by
   -- Step 5: g 3 1 = 1
   apply Nat.le_antisymm
   · exact Nat.sInf_le h1valid
-  · apply Nat.le_sInf ⟨1, h1valid⟩
+  · apply le_csInf ⟨1, h1valid⟩
     intro N ⟨A, hA_sub, hA_card, _⟩
     have : A.card ≤ N := by
       calc A.card ≤ (Finset.Icc 1 N).card := Finset.card_le_card hA_sub
@@ -521,7 +558,7 @@ theorem g3_two : g 3 2 = 3 := by
   · -- g 3 2 ≤ 3
     exact Nat.sInf_le h3valid
   · -- g 3 2 ≥ 3: all N ∈ ValidNs 3 2 satisfy N ≥ 3
-    apply Nat.le_sInf ⟨3, h3valid⟩
+    apply le_csInf ⟨3, h3valid⟩
     intro N hN
     -- If N ≤ 2, then N ∉ ValidNs 3 2
     by_contra hlt
@@ -529,12 +566,16 @@ theorem g3_two : g 3 2 = 3 := by
     interval_cases N
     · -- N = 0: Icc 1 0 = ∅, no 2-element subset
       obtain ⟨A, hA_sub, hA_card, _⟩ := hN
-      have : A.card ≤ (Finset.Icc 1 0).card := Finset.card_le_card hA_sub
-      simp at this; omega
+      have hcard0 : (Finset.Icc 1 0 : Finset ℕ).card = 0 := by decide
+      have hle : A.card ≤ (Finset.Icc 1 0).card := Finset.card_le_card hA_sub
+      rw [hcard0] at hle
+      omega
     · -- N = 1: Icc 1 1 = {1}, only 1-element subsets
       obtain ⟨A, hA_sub, hA_card, _⟩ := hN
-      have : A.card ≤ (Finset.Icc 1 1).card := Finset.card_le_card hA_sub
-      simp at this; omega
+      have hcard1 : (Finset.Icc 1 1 : Finset ℕ).card = 1 := by decide
+      have hle : A.card ≤ (Finset.Icc 1 1).card := Finset.card_le_card hA_sub
+      rw [hcard1] at hle
+      omega
     · -- N = 2: only valid set is {1,2}, which fails
       exact hfail2 hN
 

--- a/proofs/Proofs/Erdos893Problem.lean
+++ b/proofs/Proofs/Erdos893Problem.lean
@@ -63,7 +63,7 @@ theorem tau_255 : tau 255 = 8 := by native_decide
 
 /-- Mersenne primes have exactly 2 divisors. -/
 theorem tau_prime_eq_two {p : ℕ} (hp : Nat.Prime p) : tau p = 2 := by
-  simp [tau, Nat.Prime.divisors hp]
+  simp [tau, Nat.Prime.divisors hp, Finset.card_pair hp.ne_one.symm]
 
 /-- τ(n) > 0 for n ≥ 1: every positive number has at least one divisor. -/
 theorem tau_pos {n : ℕ} (hn : 0 < n) : 0 < tau n :=
@@ -161,14 +161,14 @@ theorem f_lower_bound {n : ℕ} (hn : 1 ≤ n) : 2 * n - 1 ≤ f n := by
   | zero => omega
   | succ m ih =>
     cases m with
-    | zero => have := f_one; omega
+    | zero => have h : f (0 + 1) = 1 := f_one; omega
     | succ k =>
       have hf := f_succ (k + 1)
       have ih' : 2 * (k + 1) - 1 ≤ f (k + 1) := ih (by omega)
-      have hpow : 4 ≤ 2 ^ (k + 2) := by
+      have hpow : 4 ≤ 2 ^ (k + 1 + 1) := by
         calc (4 : ℕ) = 2 ^ 2 := by norm_num
-          _ ≤ 2 ^ (k + 2) := Nat.pow_le_pow_right (by norm_num) (by omega)
-      have htau : 2 ≤ tau (2 ^ (k + 2) - 1) := tau_ge_two (by omega)
+          _ ≤ 2 ^ (k + 1 + 1) := Nat.pow_le_pow_right (by norm_num) (by omega)
+      have htau : 2 ≤ tau (2 ^ (k + 1 + 1) - 1) := tau_ge_two (by omega)
       omega
 
 /-- f(2n) splits into f(n) plus the contribution from k ∈ [n+1, 2n]. -/
@@ -214,7 +214,7 @@ theorem mersenne_dvd {a b : ℕ} (h : a ∣ b) : (2 ^ a - 1) ∣ (2 ^ b - 1) := 
   induction m with
   | zero => simp
   | succ m ih =>
-    rw [mul_succ, pow_add]
+    rw [Nat.mul_succ, pow_add]
     have h2a : 1 ≤ 2 ^ a := Nat.one_le_pow _ 2 (by norm_num)
     have h2am : 1 ≤ 2 ^ (a * m) := Nat.one_le_pow _ 2 (by norm_num)
     have h_prod : 1 ≤ 2 ^ (a * m) * 2 ^ a := by rw [← pow_add]; exact Nat.one_le_pow _ 2 (by norm_num)
@@ -243,7 +243,8 @@ theorem tau_mersenne_ge_tau {k : ℕ} (hk : 1 ≤ k) : tau k ≤ tau (2 ^ k - 1)
   apply Finset.card_le_card_of_injOn (fun d => 2 ^ d - 1)
   · -- The map sends k.divisors into (2^k - 1).divisors
     intro d hd
-    rw [Nat.mem_divisors] at hd ⊢
+    rw [Finset.mem_coe, Nat.mem_divisors] at hd
+    rw [Finset.mem_coe, Nat.mem_divisors]
     refine ⟨mersenne_dvd hd.1, ?_⟩
     have : 2 ≤ 2 ^ k := by
       calc 2 = 2 ^ 1 := by norm_num

--- a/proofs/batch2/STATUS.md
+++ b/proofs/batch2/STATUS.md
@@ -1,3 +1,11 @@
+# DOCTOR SINGLE-PROOF BATCH 29 (5-slot, conflict-proof collect, #38065, 2026-07-15)
+
+**+3 GREEN** (re-verified EXIT=0): Erdos476OQ05Problem (SONNET 28min/293k Vosper's-thm induction ~40 sites:
+Finset \ now higher-prec than +; rw+←insert_erase self-corrupts -> conv scope; push_cast[Nat.sub_add_cancel];
+ring unreliable -> rw[Nat.cast_sub]), Erdos893Problem (omega treats f(a+b+c) opaque per syntactic arg form
+-> normalize exponent spelling), Erdos817Problem (Nat.le_sInf->le_csInf; Finset.sum_nbij now InjOn/SurjOn
+-> prefer sum_image). Repairs: none.
+
 # DOCTOR SINGLE-PROOF BATCH 28 (5-slot, conflict-proof collect, #38065, 2026-07-15)
 
 **+2 GREEN** (re-verified EXIT=0): Erdos859Problem (Finset.filter_true_of_mem + Set.mem_univ simp defeat

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -1306,7 +1306,7 @@ Erdos474Problem	GREEN
 Erdos475Problem	GREEN	
 Erdos476Aristotle	GREEN	
 Erdos476OQ05Aristotle	RESIDUAL	unknown-const:b₂
-Erdos476OQ05Problem	RESIDUAL	proof-drift
+Erdos476OQ05Problem	GREEN	
 Erdos476Problem	PRE-EXISTING	never-compiled:B
 Erdos477Problem	GREEN	unknown-const:Set.Finite.of_not_infinite
 Erdos478Problem	RESIDUAL	type-mismatch
@@ -1727,7 +1727,7 @@ Erdos813Problem	GREEN
 Erdos814Problem	RESIDUAL	instance-synth
 Erdos816Problem	GREEN	
 Erdos817Aristotle	RESIDUAL	type-mismatch
-Erdos817Problem	RESIDUAL	proof-drift
+Erdos817Problem	GREEN	
 Erdos818Aristotle	RESIDUAL	instance-synth
 Erdos819Problem	GREEN	
 Erdos81Problem	RESIDUAL	instance-synth
@@ -1817,7 +1817,7 @@ Erdos888Problem	GREEN
 Erdos889Problem	GREEN	
 Erdos88Problem	RESIDUAL	type-mismatch
 Erdos890Problem	RESIDUAL	unknown-const:p
-Erdos893Problem	RESIDUAL	proof-drift
+Erdos893Problem	GREEN	
 Erdos894Problem	GREEN	
 Erdos895CounterexampleFin18	GREEN	
 Erdos895OQ01Problem	GREEN	


### PR DESCRIPTION
5-slot config, conflict-proof. Incl Erdos476OQ05Problem (Vosper's thm, 28min). No loom labels.