### PR TITLE
migrate(v4.31): single-proof batch 31 (+3 GREEN, re-verified)

### DIFF
--- a/proofs/Proofs/Erdos903Problem.lean
+++ b/proofs/Proofs/Erdos903Problem.lean
@@ -190,16 +190,13 @@ theorem erdos_903_summary (p : ℕ) (hp : IsPrimePower p) :
   · intro D
     have hn : p^2 + p + 1 ≥ 2 := by
       obtain ⟨q, k, hq, hk, heq⟩ := hp
-      subst heq
-      have : q ≥ 2 := Nat.Prime.two_le hq
-      calc p^2 + p + 1 = (q^k)^2 + q^k + 1 := by ring_nf
-        _ ≥ (q^1)^2 + q^1 + 1 := by
-            have hpow : q^k ≥ q^1 := Nat.pow_le_pow_right (Nat.Prime.one_lt hq).le hk
-            omega
-        _ = q^2 + q + 1 := by ring
-        _ ≥ 2^2 + 2 + 1 := by omega
-        _ = 7 := by norm_num
-        _ ≥ 2 := by norm_num
+      have hq2 : q ≥ 2 := Nat.Prime.two_le hq
+      have hple : p ≥ 2 := by
+        rw [heq]
+        calc q ^ k ≥ q ^ 1 := Nat.pow_le_pow_right (Nat.Prime.one_lt hq).le hk
+          _ = q := pow_one q
+          _ ≥ 2 := hq2
+      nlinarith [hple]
     exact de_bruijn_erdos _ hn D
   · exact projective_plane_design p hp
   · intro D hD

--- a/proofs/Proofs/Erdos913Problem.lean
+++ b/proofs/Proofs/Erdos913Problem.lean
@@ -288,17 +288,20 @@ def MersennePrimeExponents : Set ℕ := { k | k ≥ 2 ∧ (2 ^ k - 1).Prime }
 private theorem injective_mersenne : Function.Injective (fun k : ℕ => 2 ^ k - 1) := by
   intro a b hab
   simp only at hab
-  by_contra hne
-  rcases Nat.lt_or_gt_of_ne hne with h | h
-  · have : 2 ^ a < 2 ^ b := Nat.pow_lt_pow_right (by norm_num : 1 < 2) h
-    omega
-  · have : 2 ^ b < 2 ^ a := Nat.pow_lt_pow_right (by norm_num : 1 < 2) h
-    omega
+  have ha : 1 ≤ 2 ^ a := Nat.one_le_two_pow
+  have hb : 1 ≤ 2 ^ b := Nat.one_le_two_pow
+  have heq : 2 ^ a = 2 ^ b := by omega
+  exact Nat.pow_right_injective (le_refl 2) heq
 
 /-- For a Mersenne prime 2^k - 1 with k ≥ 2, n = 2^k - 1 has distinct exponents:
     n(n+1) = (2^k - 1)·2^k with exponents {1, k}. -/
 theorem hasDistinctExponents_mersenne (k : ℕ) (hk : k ≥ 2) (hp : (2 ^ k - 1).Prime) :
     HasDistinctExponents (2 ^ k - 1) := by
+  have hone : 1 ≤ 2 ^ k := Nat.one_le_two_pow
+  have hfour : 4 ≤ 2 ^ k := by
+    have h := Nat.pow_le_pow_right (show 1 ≤ 2 by norm_num) hk
+    norm_num at h
+    exact h
   have hne1 : 2 ^ k - 1 ≠ 0 := hp.ne_zero
   have hne2 : (2 : ℕ) ^ k ≠ 0 := pow_ne_zero k (by norm_num)
   have hm : (2 ^ k - 1) * ((2 ^ k - 1) + 1) = (2 ^ k - 1) * 2 ^ k := by congr 1; omega
@@ -323,7 +326,7 @@ theorem hasDistinctExponents_mersenne (k : ℕ) (hk : k ≥ 2) (hp : (2 ^ k - 1)
   -- Prime factors
   have hpf : m.primeFactors = {2 ^ k - 1, 2} := by
     rw [hm_def, primeFactors_mul hne1 hne2, hp.primeFactors,
-        primeFactors_pow (show (2 : ℕ) ≠ 0 from by norm_num) (show k ≠ 0 from by omega),
+        primeFactors_pow _ (show k ≠ 0 from by omega),
         Nat.prime_two.primeFactors, Finset.singleton_union]
   exact hasDistinctExponents_of_primeFactors_pair hm hpf (by omega)
 

--- a/proofs/Proofs/Erdos915Problem.lean
+++ b/proofs/Proofs/Erdos915Problem.lean
@@ -45,7 +45,7 @@ structure Path (G : SimpleGraph V) (u v : V) where
   edges_valid : vertices.length ≥ 2
   starts_at : vertices.head? = some u
   ends_at : vertices.getLast? = some v
-  is_walk : ∀ i : ℕ, i + 1 < vertices.length →
+  is_walk : ∀ i : ℕ, (h : i + 1 < vertices.length) →
     G.Adj (vertices.get ⟨i, by omega⟩) (vertices.get ⟨i + 1, by omega⟩)
 
 /-- Two paths are vertex-disjoint if they share no internal vertices. -/
@@ -59,8 +59,8 @@ def VertexDisjoint (G : SimpleGraph V) (u v : V)
 def EdgeDisjoint (G : SimpleGraph V) (u v : V)
     (p1 p2 : Path G u v) : Prop :=
   ∀ i j : ℕ,
-    i + 1 < p1.vertices.length →
-    j + 1 < p2.vertices.length →
+    (h1 : i + 1 < p1.vertices.length) →
+    (h2 : j + 1 < p2.vertices.length) →
     let e1 := (p1.vertices.get ⟨i, by omega⟩, p1.vertices.get ⟨i + 1, by omega⟩)
     let e2 := (p2.vertices.get ⟨j, by omega⟩, p2.vertices.get ⟨j + 1, by omega⟩)
     ¬(e1 = e2 ∨ e1 = (e2.2, e2.1))

--- a/proofs/batch2/STATUS.md
+++ b/proofs/batch2/STATUS.md
@@ -1,3 +1,9 @@
+# DOCTOR SINGLE-PROOF BATCH 31 (5-slot, conflict-proof collect, #38065, 2026-07-15)
+
+**+3 GREEN** (re-verified EXIT=0): Erdos903Problem (subst h eliminates b -> avoid via rw+calc+nlinarith),
+Erdos915Problem (anonymous Pi-binder named for omega), Erdos913Problem (Nat.pow_right_injective for 2^a=2^b;
+explicit 2^k lower bounds for omega; primeFactors_pow sig now (n)(hk:k≠0)). Repairs: none.
+
 # DOCTOR SINGLE-PROOF BATCH 30 (5-slot, conflict-proof collect, #38065, 2026-07-15)
 
 **+3 GREEN** (re-verified EXIT=0): Erdos895ProblemAristotle (Fin.val positivity via simp not omega;

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -1832,7 +1832,7 @@ Erdos901Aristotle	GREEN
 Erdos901Problem	GREEN	
 Erdos901ProblemAristotle	GREEN	
 Erdos902Problem	GREEN	
-Erdos903Problem	RESIDUAL	proof-drift
+Erdos903Problem	GREEN	
 Erdos904Problem	GREEN	
 Erdos905Problem	GREEN	
 Erdos906Problem	GREEN	
@@ -1845,9 +1845,9 @@ Erdos910Problem	GREEN
 Erdos910ProblemProvable	GREEN	
 Erdos911Problem	GREEN	proof-drift
 Erdos912Problem	GREEN	
-Erdos913Problem	RESIDUAL	proof-drift
+Erdos913Problem	GREEN	
 Erdos914Problem	GREEN	
-Erdos915Problem	RESIDUAL	proof-drift
+Erdos915Problem	GREEN	
 Erdos916Problem	GREEN	proof-drift
 Erdos917Problem	GREEN	
 Erdos918Problem	GREEN	


### PR DESCRIPTION
5-slot config, conflict-proof. No loom labels.