### PR TITLE
migrate(v4.31): single-proof batch 33 (+2 GREEN)

### DIFF
--- a/proofs/Proofs/Erdos989Problem.lean
+++ b/proofs/Proofs/Erdos989Problem.lean
@@ -99,8 +99,8 @@ noncomputable def circleDiscrepancy (A : PointSequence) (r : ℝ) (hr : r > 0) :
     This shows that NO sequence can achieve better than √r discrepancy. -/
 axiom beck_lower_bound :
     ∃ c : ℝ, c > 0 ∧ ∀ (A : PointSequence),
-      ∃ r₀ : ℝ, ∀ r : ℝ, ∀ hr : r > r₀,
-        circleDiscrepancy A r (lt_trans (by linarith : (0 : ℝ) < r₀) hr) ≥ c * r.sqrt
+      ∃ r₀ : ℝ, ∃ hr₀pos : r₀ > 0, ∀ r : ℝ, ∀ hr : r > r₀,
+        circleDiscrepancy A r (lt_trans hr₀pos hr) ≥ c * r.sqrt
 
 /-- **Corollary:** f(r) is unbounded for every sequence A.
     This answers the first question: YES, f(r) → ∞ for all A. -/
@@ -108,26 +108,25 @@ theorem discrepancy_unbounded (A : PointSequence) :
     ∀ M : ℝ, ∃ r : ℝ, ∃ hr : r > 0, circleDiscrepancy A r hr > M := by
   intro M
   obtain ⟨c, hc_pos, hbeck⟩ := beck_lower_bound
-  obtain ⟨r₀, hr₀⟩ := hbeck A
+  obtain ⟨r₀, hr₀pos, hr₀⟩ := hbeck A
   -- Choose r large enough that c√r > M
   let r := max (r₀ + 1) ((M / c + 1)^2)
+  have hle1 : r₀ + 1 ≤ r := le_max_left (r₀ + 1) ((M / c + 1)^2)
+  have hle2 : (M / c + 1)^2 ≤ r := le_max_right (r₀ + 1) ((M / c + 1)^2)
   use r
-  have hr_pos : r > 0 := by
-    skip
-    left
-    linarith
+  have hr_pos : r > 0 := by linarith
   use hr_pos
-  have hr_gt_r0 : r > r₀ := by simp [r]
-  calc circleDiscrepancy A r hr_pos
-      ≥ c * r.sqrt := hr₀ r hr_gt_r0
-    _ ≥ c * ((M / c + 1)^2).sqrt := by
-        apply mul_le_mul_of_nonneg_left
-        · apply Real.sqrt_le_sqrt
-          simp [r]
-        · linarith
-    _ = c * (M / c + 1) := by rw [sqrt_sq]; linarith
-    _ = M + c := by ring
-    _ > M := by linarith
+  have hr_gt_r0 : r > r₀ := by linarith
+  have hstep : circleDiscrepancy A r hr_pos ≥ c * r.sqrt := hr₀ r hr_gt_r0
+  have hsqrt_ge : |M / c + 1| ≤ r.sqrt := by
+    have h := Real.sqrt_le_sqrt hle2
+    rwa [Real.sqrt_sq_eq_abs] at h
+  have habs_ge : M / c + 1 ≤ r.sqrt := le_trans (le_abs_self _) hsqrt_ge
+  have hc_ge : c * (M / c + 1) ≤ c * r.sqrt :=
+    mul_le_mul_of_nonneg_left habs_ge (le_of_lt hc_pos)
+  have hc_ne : c ≠ 0 := ne_of_gt hc_pos
+  have heq : c * (M / c + 1) = M + c := by field_simp
+  linarith
 
 /- ## Part IV: Beck's Upper Bound (Existence) -/
 
@@ -141,8 +140,8 @@ theorem discrepancy_unbounded (A : PointSequence) :
     This shows that √r (up to log factors) is achievable. -/
 axiom beck_upper_bound :
     ∃ (A : PointSequence) (C : ℝ), C > 0 ∧
-      ∃ r₀ : ℝ, ∀ r : ℝ, ∀ hr : r > r₀,
-        circleDiscrepancy A r (lt_trans (by linarith : (0 : ℝ) < r₀) hr)
+      ∃ r₀ : ℝ, ∃ hr₀pos : r₀ > 0, ∀ r : ℝ, ∀ hr : r > r₀,
+        circleDiscrepancy A r (lt_trans hr₀pos hr)
           ≤ C * (r * r.log).sqrt
 
 /-- The optimal sequence achieving near-minimal discrepancy.
@@ -171,11 +170,11 @@ theorem erdos_989_solved :
     (∀ A : PointSequence, ∀ M : ℝ, ∃ r : ℝ, ∃ hr : r > 0,
       circleDiscrepancy A r hr > M) ∧
     -- Part 2a: Universal lower bound √r
-    (∃ c : ℝ, c > 0 ∧ ∀ A : PointSequence, ∃ r₀ : ℝ, ∀ r : ℝ, ∀ hr : r > r₀,
-      circleDiscrepancy A r (lt_trans (by linarith : (0 : ℝ) < r₀) hr) ≥ c * r.sqrt) ∧
+    (∃ c : ℝ, c > 0 ∧ ∀ A : PointSequence, ∃ r₀ : ℝ, ∃ hr₀pos : r₀ > 0, ∀ r : ℝ, ∀ hr : r > r₀,
+      circleDiscrepancy A r (lt_trans hr₀pos hr) ≥ c * r.sqrt) ∧
     -- Part 2b: Existence of near-optimal sequence
-    (∃ A : PointSequence, ∃ C : ℝ, C > 0 ∧ ∃ r₀ : ℝ, ∀ r : ℝ, ∀ hr : r > r₀,
-      circleDiscrepancy A r (lt_trans (by linarith : (0 : ℝ) < r₀) hr)
+    (∃ A : PointSequence, ∃ C : ℝ, C > 0 ∧ ∃ r₀ : ℝ, ∃ hr₀pos : r₀ > 0, ∀ r : ℝ, ∀ hr : r > r₀,
+      circleDiscrepancy A r (lt_trans hr₀pos hr)
         ≤ C * (r * r.log).sqrt) := by
   constructor
   · exact discrepancy_unbounded
@@ -256,8 +255,8 @@ Some progress:
 - No fully explicit optimal construction is known -/
 def openQuestion_explicit_construction : Prop :=
   ∃ (A : PointSequence) (C_const : ℝ), C_const > 0 ∧
-    ∃ r₀ : ℝ, ∀ r : ℝ, ∀ hr : r > r₀,
-      circleDiscrepancy A r (lt_trans (by linarith : (0 : ℝ) < r₀) hr)
+    ∃ r₀ : ℝ, ∃ hr₀pos : r₀ > 0, ∀ r : ℝ, ∀ hr : r > r₀,
+      circleDiscrepancy A r (lt_trans hr₀pos hr)
         ≤ C_const * (r * r.log).sqrt
 
 /-- **Open Question 3: Higher Dimensions**
@@ -336,8 +335,8 @@ theorem erdos_989_answers_both_questions :
     (∀ A : PointSequence, ∀ M : ℝ, ∃ r : ℝ, ∃ hr : r > 0,
       circleDiscrepancy A r hr > M) ∧
     -- Q2: optimal growth is Θ̃(√r)
-    (∃ c : ℝ, c > 0 ∧ ∀ A : PointSequence, ∃ r₀ : ℝ, ∀ r : ℝ, ∀ hr : r > r₀,
-      circleDiscrepancy A r (lt_trans (by linarith : (0 : ℝ) < r₀) hr) ≥ c * r.sqrt) :=
+    (∃ c : ℝ, c > 0 ∧ ∀ A : PointSequence, ∃ r₀ : ℝ, ∃ hr₀pos : r₀ > 0, ∀ r : ℝ, ∀ hr : r > r₀,
+      circleDiscrepancy A r (lt_trans hr₀pos hr) ≥ c * r.sqrt) :=
   ⟨discrepancy_unbounded, beck_lower_bound⟩
 
 end Erdos989

--- a/proofs/Proofs/ErdosMordellChordIdentity.lean
+++ b/proofs/Proofs/ErdosMordellChordIdentity.lean
@@ -549,7 +549,16 @@ theorem chord_cos_eq
       exact ⟨ by rw [ ← sq_eq_sq₀ ( by positivity ) ( by positivity ), mul_pow, hfu, sq_abs ], by rw [ ← sq_eq_sq₀ ( by positivity ) ( by positivity ), mul_pow, hfv, sq_abs ] ⟩;
     have h_abs_eq : |cross (Y - X) (P - X)| * |cross (Z - X) (P - X)| = -(cross (Y - X) (P - X) * cross (Z - X) (P - X)) := by
       rw [ ← abs_mul, abs_of_neg hKneg ];
-    grind +splitImp;
+    have hnY : (‖Y - X‖ : ℝ) ≠ 0 := fun h => hnu (by rw [h]; ring)
+    have hnZ : (‖Z - X‖ : ℝ) ≠ 0 := fun h => hnv (by rw [h]; ring)
+    have hprod_ne : (‖Y - X‖ * ‖Z - X‖ : ℝ) ≠ 0 := mul_ne_zero hnY hnZ
+    have step1 : ‖footDiff (P - X) (Z - X)‖ * ‖footDiff (P - X) (Y - X)‖ * (‖Y - X‖ * ‖Z - X‖)
+        = -(cross (Y - X) (P - X) * cross (Z - X) (P - X)) := by
+      have e : ‖footDiff (P - X) (Z - X)‖ * ‖footDiff (P - X) (Y - X)‖ * (‖Y - X‖ * ‖Z - X‖)
+          = (‖footDiff (P - X) (Y - X)‖ * ‖Y - X‖) * (‖footDiff (P - X) (Z - X)‖ * ‖Z - X‖) := by ring
+      rw [e, h_abs.1, h_abs.2, h_abs_eq]
+    apply mul_right_cancel₀ hprod_ne
+    linear_combination hN + inner ℝ (Y - X) (Z - X) * step1
   · simp +zetaDelta at *;
     constructor <;> intro h <;> simp_all +decide [ sq ];
   · exact mul_ne_zero ( norm_ne_zero_iff.mpr ( sub_ne_zero.mpr <| by intro h; simp_all +decide [ affineIndependent_iff_not_collinear, collinear_pair ] ) ) ( norm_ne_zero_iff.mpr ( sub_ne_zero.mpr <| by intro h; simp_all +decide [ affineIndependent_iff_not_collinear, collinear_pair ] ) )

--- a/proofs/batch2/STATUS.md
+++ b/proofs/batch2/STATUS.md
@@ -1,3 +1,10 @@
+# DOCTOR SINGLE-PROOF BATCH 33 (5-slot, conflict-proof collect, #38065, 2026-07-15)
+
+**+2 GREEN** (re-verified EXIT=0): ErdosMordellChordIdentity (grind +splitImp blown up by v4.31 abs/max
+case-splitting 'max term generation reached' -> manual mul_right_cancel₀ + linear_combination; unblocks
+ErdosMordellInequalityOQ01), Erdos989Problem (#38611: 6 sites of unsound `(by linarith : 0<r0)` fabricating
+r0>0 from only r>r0 -> explicit r0>0 witness; SYSTEMIC pattern-2 grep flag). Repairs #38611: Erdos989Problem.
+
 # DOCTOR SINGLE-PROOF BATCH 32 (5-slot, conflict-proof collect, #38065, 2026-07-15)
 
 **+3 GREEN** (re-verified EXIT=0): Erdos937Problem (interval_cases on p∣N no longer auto-bounds ->

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -1927,7 +1927,7 @@ Erdos984Problem	GREEN
 Erdos986Problem	GREEN	
 Erdos987Problem	GREEN	
 Erdos988Problem	RESIDUAL	instance-synth
-Erdos989Problem	RESIDUAL	proof-drift
+Erdos989Problem	GREEN	
 Erdos98Problem	GREEN	
 Erdos990Problem	GREEN	
 Erdos992Problem	GREEN	
@@ -1941,7 +1941,7 @@ Erdos999Problem	GREEN
 Erdos99Problem	RESIDUAL	type-mismatch
 Erdos9Problem	GREEN	
 ErdosKoRado	RESIDUAL	signature-drift
-ErdosMordellChordIdentity	RESIDUAL	proof-drift
+ErdosMordellChordIdentity	GREEN	
 ErdosMordellInequalityOQ01	RESIDUAL	proof-drift
 ErdosRamseyLowerBound	GREEN	
 EulerIdentityOQ01	RESIDUAL	proof-drift


### PR DESCRIPTION
5-slot config. Incl Erdos989 soundness repair (#38611). No loom labels.