### PR TITLE
migrate(v4.31): single-proof batch 34 (+3 GREEN, re-verified)

### DIFF
--- a/proofs/Proofs/EulerIdentityOQ01.lean
+++ b/proofs/Proofs/EulerIdentityOQ01.lean
@@ -86,8 +86,8 @@ theorem expTerm_zero (z : ℂ) : expTerm z 0 = 1 := by
 theorem expTerm_succ_div (z : ℂ) (n : ℕ) :
     expTerm z (n + 1) = expTerm z n * z / (n + 1) := by
   simp only [expTerm, pow_succ, Nat.factorial_succ, Nat.cast_mul]
+  push_cast
   field_simp
-  ring
 
 /-- The even-indexed exp term equals the cosine series term.
     (ix)^{2k}/(2k)! = (-1)^k x^{2k}/(2k)! -/
@@ -127,7 +127,7 @@ theorem tsum_even_add_odd {a : ℕ → ℂ} (ha : Summable a) :
 /-- The cosine Taylor series: cos(x) = ∑_k (-1)^k x^{2k} / (2k)!
     Proved via Mathlib's `Complex.cos_eq_tsum` and `ofReal_cos`. -/
 theorem cos_eq_tsum (x : ℝ) :
-    (↑(cos x) : ℂ) = ∑' k, evenTerm x k := by
+    (↑(Real.cos x) : ℂ) = ∑' k, evenTerm x k := by
   rw [ofReal_cos, Complex.cos_eq_tsum]
   apply tsum_congr; intro k
   simp only [evenTerm]
@@ -135,7 +135,7 @@ theorem cos_eq_tsum (x : ℝ) :
 /-- The sine Taylor series: sin(x) * I = ∑_k i·(-1)^k x^{2k+1} / (2k+1)!
     Proved via Mathlib's `Complex.sin_eq_tsum`, `ofReal_sin`, `tsum_mul_right`. -/
 theorem sin_eq_tsum (x : ℝ) :
-    (↑(sin x) : ℂ) * I = ∑' k, oddTerm x k := by
+    (↑(Real.sin x) : ℂ) * I = ∑' k, oddTerm x k := by
   rw [ofReal_sin, Complex.sin_eq_tsum, ← tsum_mul_right]
   apply tsum_congr; intro k
   simp only [oddTerm]; ring
@@ -147,7 +147,8 @@ theorem sin_eq_tsum (x : ℝ) :
 /-- Summability of the exponential series (from Mathlib). -/
 theorem expSeries_summable (z : ℂ) : Summable (expTerm z) := by
   have h := NormedSpace.expSeries_summable (𝕂 := ℂ) z
-  exact h.congr fun n => by simp [expTerm, NormedSpace.expSeries, smul_eq_mul, div_eq_mul_inv]
+  exact h.congr fun n => by
+    simp [expTerm, NormedSpace.expSeries, smul_eq_mul, div_eq_mul_inv, mul_comm]
 
 /-- **Euler's Formula via Taylor Series (OQ-01).**
 
@@ -162,30 +163,31 @@ theorem expSeries_summable (z : ℂ) : Summable (expTerm z) := by
     This proof does NOT use `Complex.exp_mul_I` — it derives Euler's formula
     from first principles (power series). -/
 theorem euler_formula_taylor (x : ℝ) :
-    exp (↑x * I) = ↑(cos x) + ↑(sin x) * I := by
+    exp (↑x * I) = ↑(Real.cos x) + ↑(Real.sin x) * I := by
   -- Step 1: exp(ix) = ∑_n (ix)^n/n!
   have exp_eq : exp (↑x * I) = ∑' n, expTerm (↑x * I) n := by
-    rw [NormedSpace.exp_eq_tsum (𝕂 := ℂ)]
+    rw [Complex.exp_eq_exp_ℂ, NormedSpace.exp_eq_tsum_div (𝔸 := ℂ)]
     apply tsum_congr; intro n
-    simp [expTerm, smul_eq_mul, div_eq_mul_inv]
+    simp [expTerm]
   rw [exp_eq]
   -- Step 2: Split into even and odd terms
   rw [tsum_even_add_odd (expSeries_summable _)]
   -- Step 3: Rewrite even terms as cos, odd terms as i·sin
-  conv_lhs =>
-    arg 1; ext k; rw [expTerm_even]
-  conv_lhs =>
-    arg 2; ext k; rw [expTerm_odd]
+  have e1 : (∑' k, expTerm (↑x * I) (2 * k)) = ∑' k, evenTerm x k :=
+    tsum_congr fun k => expTerm_even x k
+  have e2 : (∑' k, expTerm (↑x * I) (2 * k + 1)) = ∑' k, oddTerm x k :=
+    tsum_congr fun k => expTerm_odd x k
+  rw [e1, e2]
   -- Step 4: Identify with cos and sin
   rw [← cos_eq_tsum, ← sin_eq_tsum]
-  ring
 
 /-- **Euler's Identity** from the Taylor series proof.
     e^{iπ} + 1 = 0. -/
 theorem euler_identity_taylor : exp (↑π * I) + 1 = 0 := by
   have h := euler_formula_taylor π
-  simp [Real.cos_pi, Real.sin_pi] at h
-  linarith
+  rw [h, Real.cos_pi, Real.sin_pi]
+  push_cast
+  ring
 
 -- ============================================================================
 -- § 6. NOTES

--- a/proofs/Proofs/EulerPolyhedralFormula.lean
+++ b/proofs/Proofs/EulerPolyhedralFormula.lean
@@ -976,8 +976,12 @@ theorem schlafli_inequality (R : RegularPolyhedron) :
   have key : (R.E : ℤ) * (2 * R.p + 2 * R.q - R.p * R.q) = 2 * R.p * R.q := by
     have h1 : (R.p : ℤ) * R.F = 2 * R.E := by exact_mod_cast hfc
     have h2 : (R.q : ℤ) * R.V = 2 * R.E := by exact_mod_cast hvc
-    nlinarith
-  have hpq_pos : (0 : ℤ) < R.p * R.q := by positivity
+    linear_combination (R.p : ℤ) * (R.q : ℤ) * heuler - (R.q : ℤ) * h1 - (R.p : ℤ) * h2
+  have hp3 := R.p_ge
+  have hq3 := R.q_ge
+  have hp_pos : (0 : ℤ) < R.p := by exact_mod_cast (by omega : 0 < R.p)
+  have hq_pos : (0 : ℤ) < R.q := by exact_mod_cast (by omega : 0 < R.q)
+  have hpq_pos : (0 : ℤ) < R.p * R.q := mul_pos hp_pos hq_pos
   have hE_pos : (0 : ℤ) < R.E := by exact_mod_cast hE
   have h_diff_pos : (0 : ℤ) < 2 * R.p + 2 * R.q - R.p * R.q := by
     nlinarith
@@ -988,7 +992,8 @@ theorem edge_formula (R : RegularPolyhedron) :
     (R.E : ℤ) * (2 * R.p + 2 * R.q - R.p * R.q) = 2 * R.p * R.q := by
   have h1 : (R.p : ℤ) * R.F = 2 * R.E := by exact_mod_cast R.face_count
   have h2 : (R.q : ℤ) * R.V = 2 * R.E := by exact_mod_cast R.vertex_count
-  nlinarith
+  have heuler := R.euler
+  linear_combination (R.p : ℤ) * (R.q : ℤ) * heuler - (R.q : ℤ) * h1 - (R.p : ℤ) * h2
 
 /-- If p ≥ 3 and q ≥ 6, then pq ≥ 2p + 2q, contradicting the Schläfli inequality -/
 theorem no_large_q (R : RegularPolyhedron) : R.q ≤ 5 := by
@@ -1035,8 +1040,8 @@ theorem platonic_edge_counts (R : RegularPolyhedron) :
     (R.p = 5 ∧ R.q = 3 → R.E = 30) := by
   refine ⟨fun ⟨hp, hq⟩ => ?_, fun ⟨hp, hq⟩ => ?_, fun ⟨hp, hq⟩ => ?_,
           fun ⟨hp, hq⟩ => ?_, fun ⟨hp, hq⟩ => ?_⟩ <;> {
-    subst hp; subst hq
-    have := edge_formula R
+    have hef := edge_formula R
+    rw [hp, hq] at hef
     have := R.E_pos
     omega
   }
@@ -1050,10 +1055,10 @@ theorem platonic_VEF_counts (R : RegularPolyhedron) :
     (R.p = 5 ∧ R.q = 3 → R.V = 20 ∧ R.E = 30 ∧ R.F = 12) := by
   refine ⟨fun ⟨hp, hq⟩ => ?_, fun ⟨hp, hq⟩ => ?_, fun ⟨hp, hq⟩ => ?_,
           fun ⟨hp, hq⟩ => ?_, fun ⟨hp, hq⟩ => ?_⟩ <;> {
-    subst hp; subst hq
     have hef := edge_formula R
     have hfc : (R.p : ℤ) * R.F = 2 * R.E := by exact_mod_cast R.face_count
     have hvc : (R.q : ℤ) * R.V = 2 * R.E := by exact_mod_cast R.vertex_count
+    simp only [hp, hq] at hef hfc hvc
     have := R.E_pos
     omega
   }

--- a/proofs/batch2/STATUS.md
+++ b/proofs/batch2/STATUS.md
@@ -1,3 +1,12 @@
+# DOCTOR SINGLE-PROOF BATCH 34 (5-slot, conflict-proof collect, #38065, 2026-07-15)
+
+**+3 GREEN** (re-verified EXIT=0): EulerIdentityOQ01 (cos/sin ambiguous under open Complex Real ->
+qualify Real.; NormedSpace.exp_eq_tsum doesn't rw-match cexp -> exp_eq_exp_ℂ bridge; conv ext k on tsum
+gone -> tsum_congr), EulerPolyhedralFormula (subst on field-projection now fails outright -> rw into haves;
+nlinarith E*(2p+2q-pq)=2pq needs explicit linear_combination), ErdosMordellInequalityOQ01 (pure cascade off
+merged parent — NOTE: lake env lean doesn't persist olean, must lake build parent). Repairs: none.
+Mordell chord chain fully closed.
+
 # DOCTOR SINGLE-PROOF BATCH 33 (5-slot, conflict-proof collect, #38065, 2026-07-15)
 
 **+2 GREEN** (re-verified EXIT=0): ErdosMordellChordIdentity (grind +splitImp blown up by v4.31 abs/max

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -1942,11 +1942,11 @@ Erdos99Problem	RESIDUAL	type-mismatch
 Erdos9Problem	GREEN	
 ErdosKoRado	RESIDUAL	signature-drift
 ErdosMordellChordIdentity	GREEN	
-ErdosMordellInequalityOQ01	RESIDUAL	proof-drift
+ErdosMordellInequalityOQ01	GREEN	
 ErdosRamseyLowerBound	GREEN	
-EulerIdentityOQ01	RESIDUAL	proof-drift
+EulerIdentityOQ01	GREEN	
 EulerIdentityOQ01OQ02OQ01	RESIDUAL	instance-synth
-EulerPolyhedralFormula	RESIDUAL	proof-drift
+EulerPolyhedralFormula	GREEN	
 EulerPolyhedralFormulaOQ01OQ02	GREEN	
 EulerPolyhedralOQ01OQ04	GREEN	
 EulerTotientOQ01OQ01OQ01	GREEN	


### PR DESCRIPTION
5-slot config, conflict-proof. Mordell chain closed. No loom labels.