### PR TITLE
migrate(v4.31): single-proof batch 35 (+2 GREEN, re-verified)

### DIFF
--- a/proofs/Proofs/FactorRemainderTheoremOQ01OQ01OQ02.lean
+++ b/proofs/Proofs/FactorRemainderTheoremOQ01OQ01OQ02.lean
@@ -89,8 +89,8 @@ theorem fwdDiff_iter_eval_eq_sum_taylor (p : ℚ[X]) (a : ℚ) (m : ℕ) :
     rw [add_comm a r, ← taylor_eval a p r, eval_eq_sum_range, natDegree_taylor]
   rw [funext hfun]
   simp_rw [← Finset.sum_apply _ _ (fun j x => (taylor a p).coeff j * x ^ j),
-    fwdDiff_iter_finset_sum, ← smul_eq_mul, ← Pi.smul_def, fwdDiff_iter_const_smul, Pi.smul_apply,
-    smul_eq_mul]
+    fwdDiff_iter_finsetSum, ← smul_eq_mul, ← Pi.smul_def, fwdDiff_iter_const_smul,
+    Finset.sum_apply, Pi.smul_apply]
 
 /-- **Diagonal corollary (leading coefficient as a top forward difference).** Only the top
 Taylor coefficient survives the `N`-th forward difference, so
@@ -149,14 +149,14 @@ theorem eval_add_natCast_eq_sum_fwdDiff_choose (p : ℚ[X]) (a : ℚ) (n : ℕ) 
         Δ_[1]^[k] (fun r => p.eval (a + r)) 0 * Ring.choose (n : ℚ) k
       = ∑ k ∈ range (n + p.natDegree + 1),
         Δ_[1]^[k] (fun r => p.eval (a + r)) 0 * Ring.choose (n : ℚ) k := by
-    refine Finset.sum_subset (range_subset.mpr (by omega)) (fun k _ hk => ?_)
+    refine Finset.sum_subset (range_subset_range.mpr (by omega)) (fun k _ hk => ?_)
     have hnk : n < k := by simp only [mem_range, not_lt] at hk; omega
     rw [Ring.choose_natCast, Nat.choose_eq_zero_of_lt hnk, Nat.cast_zero, mul_zero]
   have hbig_N : ∑ m ∈ range (p.natDegree + 1),
         Δ_[1]^[m] (fun r => p.eval (a + r)) 0 * Ring.choose (n : ℚ) m
       = ∑ m ∈ range (n + p.natDegree + 1),
         Δ_[1]^[m] (fun r => p.eval (a + r)) 0 * Ring.choose (n : ℚ) m := by
-    refine Finset.sum_subset (range_subset.mpr (by omega)) (fun m _ hm => ?_)
+    refine Finset.sum_subset (range_subset_range.mpr (by omega)) (fun m _ hm => ?_)
     have hNm : p.natDegree < m := by simp only [mem_range, not_lt] at hm; omega
     rw [fwdDiff_iter_eval_eq_zero hNm, zero_mul]
   rw [hshift, hbig_n, ← hbig_N]
@@ -188,7 +188,7 @@ theorem eval_add_eq_sum_fwdDiff_choose (p : ℚ[X]) (a : ℚ) (x : ℚ) :
   have hQeval : ∀ y : ℚ, Q.eval y
       = ∑ m ∈ range (p.natDegree + 1), Δ_[1]^[m] (fun r => p.eval (a + r)) 0 * Ring.choose y m := by
     intro y
-    rw [hQ, eval_finset_sum]
+    rw [hQ, eval_finsetSum]
     refine Finset.sum_congr rfl (fun m _ => ?_)
     rw [eval_mul, eval_C, newtonPoly_eval]
   -- `taylor a p` and `Q` agree on all of `ℕ ⊆ ℚ`, hence are equal as polynomials.

--- a/proofs/Proofs/FairGamesTheoremOQ02.lean
+++ b/proofs/Proofs/FairGamesTheoremOQ02.lean
@@ -13,6 +13,7 @@
 -/
 
 import Mathlib
+import Proofs.FairGamesTheoremOQ01
 
 namespace FairGamesOQ02
 
@@ -51,7 +52,7 @@ def game_1_10 : GamblersRuin where
 
 /-- The underdog (1 vs 9) has only 10% chance of winning. -/
 theorem game_1_10_win_prob : ruinProbWin game_1_10 = 1 / 10 := by
-  simp [ruinProbWin, game_1_10]; norm_num
+  simp [ruinProbWin, game_1_10] <;> norm_num
 
 /-- The underdog game has expected duration 9. -/
 theorem game_1_10_expected_time : expectedRuinTime game_1_10 = 9 := by
@@ -84,14 +85,14 @@ theorem doubling_total_invested (k : ℕ) : ∑ i ∈ Finset.range k, doublingBe
   induction k with
   | zero => simp [doublingBet]
   | succ n ih =>
-    rw [Finset.sum_range_succ, ih, doublingBet]
+    rw [Finset.sum_range_succ, ih, doublingBet, pow_succ]
     omega
 
 /-- If you win after k consecutive losses, your net gain is exactly 1.
     Invested 2^k - 1, received 2^k from the winning bet, net = +1. -/
 theorem doubling_win_gain (k : ℕ) :
     (doublingBet k : ℤ) - (2 ^ k - 1 : ℤ) = 1 := by
-  simp [doublingBet]; omega
+  simp [doublingBet] <;> omega
 
 /-- Maximum number of doublings possible with bankroll B: ⌊log₂(B+1)⌋ rounds. -/
 def maxDoublings (B : ℕ) : ℕ := Nat.log 2 (B + 1)
@@ -101,13 +102,14 @@ def maxDoublings (B : ℕ) : ℕ := Nat.log 2 (B + 1)
 theorem doubling_bankroll_limit (B : ℕ) (hB : 0 < B) :
     2 ^ maxDoublings B - 1 ≤ B := by
   unfold maxDoublings
-  have h := Nat.pow_log_le_self 2 (B + 1)
+  have h := Nat.pow_log_le_self 2 (x := B + 1) (by omega)
   omega
 
 /-- With bankroll B = 2^n - 1, exactly n doublings are possible. -/
 theorem maxDoublings_power_of_two_minus_one (n : ℕ) (hn : 0 < n) :
     maxDoublings (2 ^ n - 1) = n := by
   unfold maxDoublings
+  have hpow : 1 ≤ 2 ^ n := Nat.one_le_two_pow
   have h : 2 ^ n - 1 + 1 = 2 ^ n := by omega
   rw [h, Nat.log_pow (by norm_num)]
 
@@ -130,9 +132,9 @@ The Fair Games Theorem guarantees this without computing!
     is exactly 0. This is a direct computation confirming the Fair Games Theorem. -/
 theorem doubling_expected_value_zero (n : ℕ) (hn : 0 < n) :
     (1 - (1 / 2 : ℝ) ^ n) * 1 + (1 / 2 : ℝ) ^ n * (-(2 ^ n - 1 : ℝ)) = 0 := by
-  have h2 : (2 : ℝ) ≠ 0 := by norm_num
-  field_simp
-  ring
+  have hpow : (1 / 2 : ℝ) ^ n * 2 ^ n = 1 := by
+    rw [← mul_pow]; norm_num
+  nlinarith [hpow]
 
 end FairGamesOQ02
 

--- a/proofs/batch2/STATUS.md
+++ b/proofs/batch2/STATUS.md
@@ -1,3 +1,10 @@
+# DOCTOR SINGLE-PROOF BATCH 35 (5-slot, conflict-proof collect, #38065, 2026-07-15)
+
+**+2 GREEN** (re-verified EXIT=0): FactorRemainderTheoremOQ01OQ01OQ02 (Finset.range_subset->
+range_subset_range; fwdDiff_iter_finset_sum->finsetSum; eval_finset_sum->eval_finsetSum),
+FairGamesTheoremOQ02 (missing sibling import collapsed file to autoImplicit; Nat.pow_log_le_self now
+(b){x}(hx:x≠0); simp;tac -> simp<;>tac; field_simp;ring no longer closes (1/2)^n*2^n=1). Repairs: none.
+
 # DOCTOR SINGLE-PROOF BATCH 34 (5-slot, conflict-proof collect, #38065, 2026-07-15)
 
 **+3 GREEN** (re-verified EXIT=0): EulerIdentityOQ01 (cos/sin ambiguous under open Complex Real ->

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -1960,11 +1960,11 @@ EulerTotientOQ06OQ02	GREEN
 FactorRemainderNullstellensatzOQ01	RESIDUAL	instance-synth
 FactorRemainderNullstellensatzOQ02	GREEN	
 FactorRemainderTheorem	GREEN	parse-error
-FactorRemainderTheoremOQ01OQ01OQ02	RESIDUAL	proof-drift
+FactorRemainderTheoremOQ01OQ01OQ02	GREEN	
 FactorRemainderTheoremOQ02	GREEN	
 FactorRemainderTheoremOQ03	RESIDUAL	unknown-const:Polynomial.card_roots_le_degree
 FairGamesTheorem	RESIDUAL	type-mismatch
-FairGamesTheoremOQ02	RESIDUAL	proof-drift
+FairGamesTheoremOQ02	GREEN	
 FairGamesTheoremOQ02OQ01	RESIDUAL	type-mismatch
 FairGamesTheoremOQ02OQ01OQ01	RESIDUAL	type-mismatch
 FairGamesTheoremOQ03	RESIDUAL	type-mismatch


### PR DESCRIPTION
5-slot config, conflict-proof. No loom labels.