### PR TITLE
migrate(v4.31): single-proof batch 36 (+2 GREEN, re-verified)

### DIFF
--- a/proofs/Proofs/FourierSeriesOQ02OQ03.lean
+++ b/proofs/Proofs/FourierSeriesOQ02OQ03.lean
@@ -62,7 +62,7 @@ theorem decayConstant_pos : (0 : ℝ) < decayConstant := by
 
 /-- The decay bound is nonneg for valid parameters -/
 theorem decayBound_nonneg (C : ℝ≥0) (α : ℝ≥0) (n : ℤ) (hn : n ≠ 0) :
-    0 ≤ decayBound C α n := by
+    0 ≤ decayBound (T := T) C α n := by
   simp only [decayBound, decayConstant]
   apply mul_nonneg
   · apply mul_nonneg (by norm_num) (NNReal.coe_nonneg C)
@@ -73,27 +73,31 @@ theorem decayBound_nonneg (C : ℝ≥0) (α : ℝ≥0) (n : ℤ) (hn : n ≠ 0) 
 /-- The bound decreases as |n| increases (for fixed C, α) -/
 theorem decayBound_antitone (C : ℝ≥0) (α : ℝ≥0) (hα : 0 < (α : ℝ))
     (n m : ℤ) (hn : n ≠ 0) (hm : m ≠ 0) (h : |↑n| ≤ |↑m|) :
-    decayBound C α m ≤ decayBound C α n := by
+    decayBound (T := T) C α m ≤ decayBound (T := T) C α n := by
   simp only [decayBound, decayConstant]
   apply mul_le_mul_of_nonneg_left _ (by positivity)
-  apply Real.rpow_le_rpow (by positivity) _ (le_of_lt hα)
-  apply div_le_div_of_nonneg_left hT.out.le (by positivity) (by positivity)
-  linarith
+  apply Real.rpow_le_rpow (div_nonneg hT.out.le (by positivity)) _ (le_of_lt hα)
+  apply div_le_div_of_nonneg_left hT.out.le
+    (mul_pos two_pos (abs_pos.mpr (Int.cast_ne_zero.mpr hn)))
+    (mul_le_mul_of_nonneg_left (by exact_mod_cast h) (by norm_num))
 
 /-- As n → ∞, the bound → 0 (Riemann-Lebesgue consequence) -/
 theorem decayBound_tendsto_zero (C : ℝ≥0) (α : ℝ≥0) (hα : 0 < (α : ℝ)) :
-    Filter.Tendsto (fun n : ℕ => decayBound C α (↑n + 1))
+    Filter.Tendsto (fun n : ℕ => decayBound (T := T) C α (↑n + 1))
     Filter.atTop (nhds 0) := by
-  simp only [decayBound, decayConstant]
+  have habs : ∀ n : ℕ, |(((n : ℤ) + 1 : ℤ) : ℝ)| = (n : ℝ) + 1 := by
+    intro n
+    rw [abs_of_nonneg (by positivity)]
+    push_cast
+    ring
+  simp only [decayBound, decayConstant, habs]
   rw [show (0 : ℝ) = 1 / 2 * ↑C * 0 from by ring]
   apply Filter.Tendsto.mul tendsto_const_nhds
   rw [show (0 : ℝ) = 0 ^ (α : ℝ) from by simp [ne_of_gt hα]]
-  exact Filter.Tendsto.rpow (Filter.Tendsto.div_atTop tendsto_const_nhds
-    (Filter.Tendsto.atTop_nonneg_mul_left (by norm_num : (0 : ℝ) < 2)
-      (Filter.tendsto_natCast_atTop_atTop.comp
-        (Filter.tendsto_atTop_add_nonneg_left (by positivity)
-          Filter.tendsto_id))))
-    (Or.inl (ne_of_gt hα))
+  refine Filter.Tendsto.rpow (Filter.Tendsto.div_atTop tendsto_const_nhds ?_)
+    tendsto_const_nhds (Or.inr hα)
+  exact (Filter.tendsto_atTop_add_const_right Filter.atTop (1 : ℝ)
+    tendsto_natCast_atTop_atTop).const_mul_atTop (by norm_num : (0 : ℝ) < 2)
 
 -- ============================================================
 -- Section 3: Sharpness of the Constant 1/2
@@ -119,14 +123,14 @@ theorem decayBound_tendsto_zero (C : ℝ≥0) (α : ℝ≥0) (hα : 0 < (α : �
 /-- For α very close to 0, the bound becomes vacuous (O(1) decay).
     The constant 1/2 is still sharp but the bound is weak. -/
 theorem small_alpha_bound (C : ℝ≥0) (n : ℤ) (hn : n ≠ 0) :
-    decayBound C 0 n = decayConstant * ↑C := by
+    decayBound (T := T) C 0 n = decayConstant * ↑C := by
   simp [decayBound, decayConstant]
 
 /-- The Lipschitz bound (α = 1) gives the fastest O(1/n) polynomial decay
     achievable from Hölder continuity. Higher regularity (C^k) gives O(1/n^k)
     but requires derivatives, not just Hölder continuity. -/
 theorem lipschitz_gives_linear_decay (C : ℝ≥0) (n : ℤ) (hn : n ≠ 0) :
-    decayBound C 1 n = decayConstant * ↑C * (T / (2 * |↑n|)) := by
+    decayBound (T := T) C 1 n = decayConstant * ↑C * (T / (2 * |↑n|)) := by
   simp [decayBound, decayConstant]
 
 end FourierSharpConstant

--- a/proofs/Proofs/FriendshipTheoremOQ01OQ02.lean
+++ b/proofs/Proofs/FriendshipTheoremOQ01OQ02.lean
@@ -88,6 +88,7 @@ namespace Friendship
 
 variable (R)
 
+set_option backward.isDefEq.respectTransparency false in
 open scoped Classical in
 include hG in
 /-- One characterization of a friendship graph is that there is exactly one walk of length 2
@@ -127,7 +128,7 @@ include hG in
 theorem degree_eq_of_not_adj {v w : V} (hvw : ¬G.Adj v w) : degree G v = degree G w := by
   rw [← Nat.cast_id (G.degree v), ← Nat.cast_id (G.degree w),
     ← adjMatrix_pow_three_of_not_adj ℕ hG hvw,
-    ← adjMatrix_pow_three_of_not_adj ℕ hG fun h => hvw (G.adj_symm h)]
+    ← adjMatrix_pow_three_of_not_adj ℕ hG fun h ↦ hvw h.symm]
   conv_lhs => rw [← transpose_adjMatrix]
   simp only [pow_succ _ 2, sq, ← transpose_mul, transpose_apply]
   simp only [mul_assoc]
@@ -167,7 +168,7 @@ theorem isRegularOf_not_existsPolitician (hG' : ¬ExistsPolitician G) :
   intro x
   by_cases hvx : G.Adj v x; swap; · exact (degree_eq_of_not_adj hG hvx).symm
   dsimp only [Theorems100.ExistsPolitician] at hG'
-  push_neg at hG'
+  push Not at hG'
   rcases hG' v with ⟨w, hvw', hvw⟩
   rcases hG' x with ⟨y, hxy', hxy⟩
   by_cases hxw : G.Adj x w
@@ -185,8 +186,8 @@ theorem isRegularOf_not_existsPolitician (hG' : ¬ExistsPolitician G) :
     rw [h, mem_singleton] at h'
     injection h'
   apply hxy'
-  rw [key ((mem_commonNeighbors G).mpr ⟨hvx, G.adj_symm hxw⟩),
-    key ((mem_commonNeighbors G).mpr ⟨hvy, G.symm hcontra⟩)]
+  rw [key ((mem_commonNeighbors G).mpr ⟨hvx, hxw.symm⟩),
+    key ((mem_commonNeighbors G).mpr ⟨hvy, hcontra.symm⟩)]
 
 open scoped Classical in
 include hG in

--- a/proofs/batch2/STATUS.md
+++ b/proofs/batch2/STATUS.md
@@ -1,3 +1,10 @@
+# DOCTOR SINGLE-PROOF BATCH 36 (5-slot, conflict-proof collect, #38065, 2026-07-15)
+
+**+2 GREEN** (re-verified EXIT=0): FriendshipTheoremOQ01OQ02 (ported upstream Archive fixes: Std.Symm Adj
+needs .symm not G.adj_symm; commonNeighbors simp needs set_option backward.isDefEq.respectTransparency
+false; push_neg->push Not), FourierSeriesOQ02OQ03 (auto-included section var used only in implicit arg needs
+explicit (T:=T) per call; Filter.Tendsto.rpow takes 3 args + x≠0∨0<y). Repairs: none.
+
 # DOCTOR SINGLE-PROOF BATCH 35 (5-slot, conflict-proof collect, #38065, 2026-07-15)
 
 **+2 GREEN** (re-verified EXIT=0): FactorRemainderTheoremOQ01OQ01OQ02 (Finset.range_subset->

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -1994,7 +1994,7 @@ FourierSeriesOQ01	RESIDUAL	rewrite-drift
 FourierSeriesOQ02	GREEN	
 FourierSeriesOQ02Incomplete01	GREEN	
 FourierSeriesOQ02OQ02	RESIDUAL	unclassified
-FourierSeriesOQ02OQ03	RESIDUAL	proof-drift
+FourierSeriesOQ02OQ03	GREEN	
 FourierSeriesOQ02OQ03OQ02	RESIDUAL	unknown-const:Real.exp_le_one_of_nonpos
 FourierSeriesOQ02OQ03WIP01	GREEN	
 FourierSeriesOQ02OQ04	GREEN	
@@ -2007,7 +2007,7 @@ FourthRoot2GaloisClosureOQ03	GREEN
 FourthRoot2SplittingFieldOQ01	GREEN	
 FriendshipTheorem	GREEN	
 FriendshipTheoremOQ01	GREEN	
-FriendshipTheoremOQ01OQ02	RESIDUAL	proof-drift
+FriendshipTheoremOQ01OQ02	GREEN	
 FriendshipTheoremOQ03	GREEN	
 FriendshipTheoremOQ04	GREEN	
 FriendshipTheoremOQ04Amalgam	GREEN	


### PR DESCRIPTION
5-slot config, conflict-proof. No loom labels.