### PR TITLE
migrate(v4.31): single-proof batch 37 (+3 GREEN, re-verified)

### DIFF
--- a/proofs/Proofs/GreensTheoremOQ01OQ01OQ01OQ01.lean
+++ b/proofs/Proofs/GreensTheoremOQ01OQ01OQ01OQ01.lean
@@ -464,7 +464,7 @@ theorem iteratedIntervalIntegral_order_independent {n : ℕ} {a b : Fin n → �
     -- so that `a ∘ (τ * swap) = (a ∘ τ) ∘ swap` pointwise.
     induction σ using Equiv.Perm.swap_induction_on' with
     | one =>
-      simp
+      simp [Equiv.Perm.one_def]
     | mul_swap τ x y hxy hPτ =>
       -- hPτ : integral a b f = integral (a∘τ) (b∘τ) (fun v => f(v∘τ.symm))
       -- Goal: integral a b f = integral (a∘(τ*swap)) (b∘(τ*swap)) (fun v => f(v∘(τ*swap).symm))

--- a/proofs/Proofs/HodgeConjecture.lean
+++ b/proofs/Proofs/HodgeConjecture.lean
@@ -1444,7 +1444,9 @@ def directSum_inl {k : ℕ} (H₁ H₂ : PureHodgeStructure k) :
   rationalMap := LinearMap.inl ℚ H₁.VQ H₂.VQ
   complexMap := LinearMap.inl ℂ H₁.VC H₂.VC
   compatible := fun v => by
-    simp only [directSumHodge, LinearMap.prodMap_apply, LinearMap.inl_apply, map_zero]
+    show (H₁.complexify.prodMap H₂.complexify) (LinearMap.inl ℚ H₁.VQ H₂.VQ v) =
+      LinearMap.inl ℂ H₁.VC H₂.VC (H₁.complexify v)
+    simp [LinearMap.inl_apply, LinearMap.prodMap_apply]
   hodge_preserve := fun p q hpq x hx => by
     simp only [directSumHodge, LinearMap.inl_apply]
     exact Submodule.mem_prod.mpr ⟨hx, Submodule.zero_mem _⟩
@@ -1457,7 +1459,9 @@ def directSum_inr {k : ℕ} (H₁ H₂ : PureHodgeStructure k) :
   rationalMap := LinearMap.inr ℚ H₁.VQ H₂.VQ
   complexMap := LinearMap.inr ℂ H₁.VC H₂.VC
   compatible := fun v => by
-    simp only [directSumHodge, LinearMap.prodMap_apply, LinearMap.inr_apply, map_zero]
+    show (H₁.complexify.prodMap H₂.complexify) (LinearMap.inr ℚ H₁.VQ H₂.VQ v) =
+      LinearMap.inr ℂ H₁.VC H₂.VC (H₂.complexify v)
+    simp [LinearMap.inr_apply, LinearMap.prodMap_apply]
   hodge_preserve := fun p q hpq x hx => by
     simp only [directSumHodge, LinearMap.inr_apply]
     exact Submodule.mem_prod.mpr ⟨Submodule.zero_mem _, hx⟩
@@ -1473,7 +1477,10 @@ def directSum_fst {k : ℕ} (H₁ H₂ : PureHodgeStructure k) :
   rationalMap := LinearMap.fst ℚ H₁.VQ H₂.VQ
   complexMap := LinearMap.fst ℂ H₁.VC H₂.VC
   compatible := fun v => by
-    simp only [directSumHodge, LinearMap.prodMap_apply, LinearMap.fst_apply]
+    obtain ⟨v₁, v₂⟩ := v
+    show H₁.complexify (LinearMap.fst ℚ H₁.VQ H₂.VQ (v₁, v₂)) =
+      LinearMap.fst ℂ H₁.VC H₂.VC ((H₁.complexify.prodMap H₂.complexify) (v₁, v₂))
+    simp [LinearMap.fst_apply, LinearMap.prodMap_apply]
   hodge_preserve := fun p q hpq x hx => by
     simp only [directSumHodge, LinearMap.fst_apply] at hx ⊢
     exact (Submodule.mem_prod.mp hx).1
@@ -1486,7 +1493,10 @@ def directSum_snd {k : ℕ} (H₁ H₂ : PureHodgeStructure k) :
   rationalMap := LinearMap.snd ℚ H₁.VQ H₂.VQ
   complexMap := LinearMap.snd ℂ H₁.VC H₂.VC
   compatible := fun v => by
-    simp only [directSumHodge, LinearMap.prodMap_apply, LinearMap.snd_apply]
+    obtain ⟨v₁, v₂⟩ := v
+    show H₂.complexify (LinearMap.snd ℚ H₁.VQ H₂.VQ (v₁, v₂)) =
+      LinearMap.snd ℂ H₁.VC H₂.VC ((H₁.complexify.prodMap H₂.complexify) (v₁, v₂))
+    simp [LinearMap.snd_apply, LinearMap.prodMap_apply]
   hodge_preserve := fun p q hpq x hx => by
     simp only [directSumHodge, LinearMap.snd_apply] at hx ⊢
     exact (Submodule.mem_prod.mp hx).2
@@ -1556,8 +1566,10 @@ def directSum_universal {k : ℕ} {H₁ H₂ H₃ : PureHodgeStructure k}
   complexMap := f₁.complexMap.coprod f₂.complexMap
   compatible := fun v => by
     obtain ⟨v₁, v₂⟩ := v
-    simp only [directSumHodge, LinearMap.prodMap_apply, LinearMap.coprod_apply,
-               map_add, f₁.compatible, f₂.compatible]
+    show H₃.complexify ((f₁.rationalMap.coprod f₂.rationalMap) (v₁, v₂)) =
+      (f₁.complexMap.coprod f₂.complexMap) ((H₁.complexify.prodMap H₂.complexify) (v₁, v₂))
+    simp [LinearMap.prodMap_apply, LinearMap.coprod_apply,
+          map_add, f₁.compatible, f₂.compatible]
   hodge_preserve := fun p q hpq x hx => by
     obtain ⟨x₁, x₂⟩ := x
     simp only [directSumHodge, LinearMap.coprod_apply] at hx ⊢
@@ -4243,7 +4255,8 @@ theorem pure_from_smooth_complete.{v} (k : ℕ) (H : PureHodgeStructure.{v} k) :
     and W_k = ⊤. We prove this from the PureHodgeStructure.toMixed construction. -/
 theorem weight_spectral_sequence (k : ℕ) (H : PureHodgeStructure k) :
     H.toMixed.W k = ⊤ := by
-  simp [PureHodgeStructure.toMixed]
+  show (if k < k then (⊥ : Submodule ℚ H.VQ) else ⊤) = ⊤
+  rw [if_neg (lt_irrefl k)]
 
 /-- Strict morphisms: morphisms of MHS are strictly compatible with both
     filtrations. This is a key structural result of Deligne's theory.
@@ -4270,7 +4283,9 @@ theorem mhs_category_abelian :
     where W_k = ⊤ (the mixed structure "forgets" to pure at weight k). -/
 theorem ext_mixed_hodge (k : ℕ) (H : PureHodgeStructure k) :
     ∃ (M : MixedHodgeStructure), M.VQ = H.VQ ∧ M.W k = ⊤ :=
-  ⟨H.toMixed, rfl, by simp [PureHodgeStructure.toMixed]⟩
+  ⟨H.toMixed, rfl, by
+    show (if k < k then (⊥ : Submodule ℚ H.VQ) else ⊤) = ⊤
+    rw [if_neg (lt_irrefl k)]⟩
 
 /-- Carlson's theorem: for two pure HS, Ext¹ in MHS computes
     the intermediate Jacobian J^p(X).

--- a/proofs/Proofs/KonigsbergOQ02OQ01Aristotle.lean
+++ b/proofs/Proofs/KonigsbergOQ02OQ01Aristotle.lean
@@ -147,7 +147,11 @@ theorem nodup_circuit_exists_Aristotle {V : Type*} [Fintype V] [DecidableEq V]
     have h_extend : ∃ w' : D.Walk u x, w'.arcs.Nodup ∧ w'.arcs.length = m + 1 := by
       refine' ⟨ ⟨ w.arcs ++ [ ( v, x ) ], _, _, _, _, _ ⟩, _, _ ⟩ <;> simp_all +decide [ List.nodup_append ];
       · rintro a b ( h | ⟨ rfl, rfl ⟩ ) <;> [ exact w.arcs_valid _ h; exact hx ];
-      · grind +splitImp;
+      · by_cases hwe : w.arcs = []
+        · have huv : u = v := w.empty_at hwe
+          simp [hwe, huv]
+        · rw [List.head_append_of_ne_nil hwe]
+          exact w.starts_at hwe
       · refine' List.isChain_append.mpr ⟨ _, _, _ ⟩;
         · exact w.consecutive;
         · exact List.isChain_singleton _;

--- a/proofs/batch2/STATUS.md
+++ b/proofs/batch2/STATUS.md
@@ -1,3 +1,11 @@
+# DOCTOR SINGLE-PROOF BATCH 37 (5-slot, conflict-proof collect, #38065, 2026-07-15)
+
+**+3 GREEN** (re-verified EXIT=0): GreensTheoremOQ01OQ01OQ01OQ01 (simp no longer unfolds (Equiv.symm 1) i
+-> add Equiv.Perm.one_def), KonigsbergOQ02OQ01Aristotle (grind +splitImp brittle -> explicit by_cases +
+List.head_append_of_ne_nil), HodgeConjecture (Millennium-Prize, axiomatized structure INTACT: directSumHodge
+biproduct instance-diamond Prod.instModule vs module_VQ field opaque to simp/rw at instances transparency ->
+show goal in fully-unfolded native form first). Repairs: none.
+
 # DOCTOR SINGLE-PROOF BATCH 36 (5-slot, conflict-proof collect, #38065, 2026-07-15)
 
 **+2 GREEN** (re-verified EXIT=0): FriendshipTheoremOQ01OQ02 (ported upstream Archive fixes: Std.Symm Adj

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -2058,7 +2058,7 @@ GeometricSeriesOQ10	GREEN
 GoemansWilliamsonMaxCut	GREEN	
 GraphCore	GREEN	
 GreensTheorem	GREEN	
-GreensTheoremOQ01OQ01OQ01OQ01	RESIDUAL	proof-drift
+GreensTheoremOQ01OQ01OQ01OQ01	GREEN	
 GreensTheoremOQ01OQ01OQ02	GREEN	
 GreensTheoremOQ01OQ01OQ02OQ01	GREEN	
 GreensTheoremOQ01OQ01OQ02OQ02	GREEN	
@@ -2114,7 +2114,7 @@ Hilbert6PhysicsAxioms	GREEN	type-mismatch
 Hilbert9CyclotomicReciprocity	GREEN	
 Hilbert9QuadraticSubfield	GREEN	
 Hilbert9Reciprocity	GREEN	
-HodgeConjecture	RESIDUAL	proof-drift
+HodgeConjecture	GREEN	
 HurwitzTheoremOQ04	RESIDUAL	slow-timeout
 IncidenceCauchySchwarzDual	GREEN	
 InclusionExclusion	GREEN	
@@ -2171,7 +2171,7 @@ KonigsbergOQ01OQ02	RESIDUAL	unknown-const:Finset.card_eq_sum_ones.symm
 KonigsbergOQ01OQ02Recipe	GREEN	
 KonigsbergOQ02	GREEN	
 KonigsbergOQ02OQ01	RESIDUAL	type-mismatch
-KonigsbergOQ02OQ01Aristotle	RESIDUAL	proof-drift
+KonigsbergOQ02OQ01Aristotle	GREEN	
 KonigsbergOQ02OQ01OQ02OQ01Splice	GREEN	
 KonigsbergOQ03	GREEN	
 KonigsbergOQ04	GREEN	


### PR DESCRIPTION
5-slot config. Incl HodgeConjecture (Millennium-Prize, axiomatized status preserved). No loom labels.