### PR TITLE
migrate(v4.31): single-proof batch 38 (+2 GREEN)

### DIFF
--- a/proofs/Proofs/LagrangeFourSquaresOQ02.lean
+++ b/proofs/Proofs/LagrangeFourSquaresOQ02.lean
@@ -220,7 +220,7 @@ theorem trivialType_contribution (k : ℕ) (hk : 0 < k) :
   -- Need: product of factorial-of-counts for [0,0,0,k] = same for [0,0,0,1]
   -- Both equal 3! * 1! = 6
   have hne : k ≠ 0 := by omega
-  simp [List.dedup, List.count, hne]
+  simp [List.dedup_cons_of_mem, List.dedup_cons_of_notMem, List.count_cons, hne, Ne.symm hne]
 
 -- Computational verification
 theorem trivialType_check_1 : (trivialType 1).contribution = 8 := by native_decide
@@ -370,7 +370,7 @@ theorem allEqualType_contribution (k : ℕ) (hk : 0 < k) :
     linarith
   unfold RepType.permutations allEqualType; simp only
   congr 1
-  simp [List.dedup, List.count]
+  simp [List.dedup_cons_of_mem, List.dedup_cons_of_notMem, List.count_cons]
 
 -- Computational verification
 theorem allEqualType_check_1 : (allEqualType 1).contribution = 16 := by native_decide
@@ -406,7 +406,7 @@ theorem threeEqualType_contribution (k : ℕ) (hk : 0 < k) :
   unfold RepType.permutations threeEqualType; simp only
   congr 1
   have hne : k ≠ 0 := by omega
-  simp [List.dedup, List.count, hne]
+  simp [List.dedup_cons_of_mem, List.dedup_cons_of_notMem, List.count_cons, hne, Ne.symm hne]
 
 theorem threeEqualType_check_1 : (threeEqualType 1).contribution = 32 := by native_decide
 theorem threeEqualType_check_2 : (threeEqualType 2).contribution = 32 := by native_decide
@@ -431,10 +431,21 @@ theorem twoPairType_signFactor (a b : ℕ) (ha : 0 < a) (hab : a < b) :
     (twoPairType a b ha hab).signFactor = 16 := by
   simp only [RepType.signFactor, twoPairType_nonzeroCount a b ha hab]; norm_num
 
+-- Computational verification (proved first, at top level with no ambient free
+-- variables, so that `twoPairType_contribution` below can reuse it as `h1`
+-- instead of re-running `native_decide` inside a context that carries `a b ha
+-- hab` — v4.31's `native_decide` rejects targets whose elaborated proof terms
+-- reference such ambient locals with "Expected type must not contain free
+-- variables").
+theorem twoPairType_check_1_2 : (twoPairType 1 2 (by omega) (by omega)).contribution = 96 := by
+  native_decide
+theorem twoPairType_check_2_3 : (twoPairType 2 3 (by omega) (by omega)).contribution = 96 := by
+  native_decide
+
 /-- **General Two-Pair Type Theorem**: contribution = 96 for all 0 < a < b. -/
 theorem twoPairType_contribution (a b : ℕ) (ha : 0 < a) (hab : a < b) :
     (twoPairType a b ha hab).contribution = 96 := by
-  have h1 : (twoPairType 1 2 (by omega) (by omega)).contribution = 96 := by native_decide
+  have h1 : (twoPairType 1 2 (by omega) (by omega)).contribution = 96 := twoPairType_check_1_2
   suffices hp : (twoPairType a b ha hab).permutations =
       (twoPairType 1 2 (by omega) (by omega)).permutations by
     simp only [RepType.contribution, hp, twoPairType_signFactor a b ha hab,
@@ -444,12 +455,7 @@ theorem twoPairType_contribution (a b : ℕ) (ha : 0 < a) (hab : a < b) :
   unfold RepType.permutations twoPairType; simp only
   congr 1
   have hab' : a ≠ b := by omega
-  simp [List.dedup, List.count, hab', Ne.symm hab']
-
-theorem twoPairType_check_1_2 : (twoPairType 1 2 (by omega) (by omega)).contribution = 96 := by
-  native_decide
-theorem twoPairType_check_2_3 : (twoPairType 2 3 (by omega) (by omega)).contribution = 96 := by
-  native_decide
+  simp [List.dedup_cons_of_mem, List.dedup_cons_of_notMem, List.count_cons, hab', Ne.symm hab']
 
 /-
 ## Part 15: General Two-Equal Type (0,0,k,k) Theorem
@@ -480,7 +486,7 @@ theorem twoEqualType_contribution (k : ℕ) (hk : 0 < k) :
   unfold RepType.permutations twoEqualType; simp only
   congr 1
   have hne : k ≠ 0 := by omega
-  simp [List.dedup, List.count, hne]
+  simp [List.dedup_cons_of_mem, List.dedup_cons_of_notMem, List.count_cons, hne, Ne.symm hne]
 
 /-
 ## Part 16: General Two-Nonzero-Distinct Type (0,0,a,b) Theorem
@@ -502,10 +508,19 @@ theorem twoNonzeroDistinct_signFactor (a b : ℕ) (ha : 0 < a) (hab : a < b) :
     (twoNonzeroDistinct a b ha hab).signFactor = 4 := by
   simp only [RepType.signFactor, twoNonzeroDistinct_nonzeroCount a b ha hab]; norm_num
 
+-- Computational verification, proved first at top level (no ambient free
+-- variables) so the general theorem below can reuse it as `h1` instead of
+-- calling `native_decide` inside a context carrying `a b ha hab` (v4.31's
+-- `native_decide` rejects such targets with "Expected type must not contain
+-- free variables").
+theorem twoNonzeroDistinct_check_1_2 :
+    (twoNonzeroDistinct 1 2 (by omega) (by omega)).contribution = 48 := by native_decide
+
 /-- **General Two-Nonzero-Distinct Theorem**: contribution = 48 for all 0 < a < b. -/
 theorem twoNonzeroDistinct_contribution (a b : ℕ) (ha : 0 < a) (hab : a < b) :
     (twoNonzeroDistinct a b ha hab).contribution = 48 := by
-  have h1 : (twoNonzeroDistinct 1 2 (by omega) (by omega)).contribution = 48 := by native_decide
+  have h1 : (twoNonzeroDistinct 1 2 (by omega) (by omega)).contribution = 48 :=
+    twoNonzeroDistinct_check_1_2
   suffices hp : (twoNonzeroDistinct a b ha hab).permutations =
       (twoNonzeroDistinct 1 2 (by omega) (by omega)).permutations by
     simp only [RepType.contribution, hp, twoNonzeroDistinct_signFactor a b ha hab,
@@ -517,7 +532,8 @@ theorem twoNonzeroDistinct_contribution (a b : ℕ) (ha : 0 < a) (hab : a < b) :
   have ha' : a ≠ 0 := by omega
   have hab' : a ≠ b := by omega
   have hb' : b ≠ 0 := by omega
-  simp [List.dedup, List.count, ha', hab', hb', Ne.symm ha', Ne.symm hab', Ne.symm hb']
+  simp [List.dedup_cons_of_mem, List.dedup_cons_of_notMem, List.count_cons, ha', hab', hb',
+    Ne.symm ha', Ne.symm hab', Ne.symm hb']
 
 /-
 ## Part 17: Nonzero Count Lower Bound

--- a/proofs/Proofs/PlatonicSolidsOQ02.lean
+++ b/proofs/Proofs/PlatonicSolidsOQ02.lean
@@ -111,7 +111,7 @@ theorem all_archimedean_valid :
     truncatedCuboctahedron_valid, snubCube_valid, icosidodecahedron_valid,
     truncatedDodecahedron_valid, truncatedIcosahedron_valid,
     rhombicosidodecahedron_valid, truncatedIcosidodecahedron_valid,
-    snubDodecahedron_valid, List.Forall.nil⟩
+    snubDodecahedron_valid⟩
 
 -- ============================================================
 -- Section 4: Face Counts and Euler's Formula
@@ -124,7 +124,12 @@ structure ArchimedeanData where
   vertices : ℕ               -- V
   edges : ℕ                  -- E
   faces : ℕ                  -- F
-  euler : vertices - edges + faces = 2  -- V - E + F = 2
+  -- V - E + F = 2, stated as `V + F = E + 2` to avoid ℕ truncated subtraction
+  -- (E > V for every Archimedean solid, so `vertices - edges` would silently
+  -- truncate to 0 and make the naive `vertices - edges + faces = 2` statement
+  -- false; this addition form is equivalent for nonnegative integers and is
+  -- exact).
+  euler : vertices + faces = edges + 2
 
 def mkTruncTetra : ArchimedeanData :=
   ⟨"Truncated Tetrahedron", [3, 6, 6], 12, 18, 8, by omega⟩

--- a/proofs/batch2/STATUS.md
+++ b/proofs/batch2/STATUS.md
@@ -1,3 +1,11 @@
+# DOCTOR SINGLE-PROOF BATCH 38 (5-slot, conflict-proof collect, #38065, 2026-07-15)
+
+**+2 GREEN** (re-verified EXIT=0): LagrangeFourSquaresOQ02 (List.dedup_cons_of_not_mem->_of_notMem;
+native_decide inside ctx w/ unused ambient locals fails -> hoist concrete fact to top-level thm),
+PlatonicSolidsOQ02 (#38611: euler field V-E+F=2 in ℕ trunc-sub reduces FALSE 12-18+8=8≠2 when E>V, old
+omega accepted -> restated V+F=E+2). Repairs #38611: PlatonicSolidsOQ02 euler (pattern-3 ℕ-trunc-sub
+false-numeral class logged for systemic gallery grep).
+
 # DOCTOR SINGLE-PROOF BATCH 37 (5-slot, conflict-proof collect, #38065, 2026-07-15)
 
 **+3 GREEN** (re-verified EXIT=0): GreensTheoremOQ01OQ01OQ01OQ01 (simp no longer unfolds (Equiv.symm 1) i

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -2187,7 +2187,7 @@ LHopitalOQ03	GREEN
 LHopitalOQ04	GREEN	
 LHopitalOQ04OQ01	GREEN	
 LagrangeFourSquaresOQ01OQ03	RESIDUAL	noncomputable
-LagrangeFourSquaresOQ02	RESIDUAL	proof-drift
+LagrangeFourSquaresOQ02	GREEN	
 LagrangeFourSquaresOQ02OQ02	GREEN	
 LagrangeFourSquaresOQ04	GREEN	
 LagrangeFourSquaresOQ05	GREEN	
@@ -2317,7 +2317,7 @@ PicksTheoremOQ01OQ01OQ01	RESIDUAL	noncomputable
 PicksTheoremOQ01OQ02	GREEN	proof-drift
 PicksTheoremOQ02	GREEN	
 PicksTheoremOQ03	GREEN	
-PlatonicSolidsOQ02	RESIDUAL	proof-drift
+PlatonicSolidsOQ02	GREEN	
 PoincareConjecture	RESIDUAL	type-mismatch
 PowerMeanLimitOQ	GREEN	
 PrimeGapBoundsOQ01	RESIDUAL	unknown-const:Real.log_le_sub_one_of_le


### PR DESCRIPTION
5-slot config. Incl PlatonicSolids euler-field soundness repair (#38611, ℕ-trunc-sub pattern). No loom labels.