### PR TITLE
migrate(v4.31): single-proof batch 41 (+2 GREEN, re-verified)

### DIFF
--- a/proofs/Proofs/TestApi1056.lean
+++ b/proofs/Proofs/TestApi1056.lean
@@ -7,18 +7,21 @@ import Mathlib.Data.Nat.GCD.Basic
 import Mathlib.Data.Finset.Basic
 import Mathlib.Tactic
 
-open scoped Classical
-
 def intervalProd' (a b : ℕ) : ℕ :=
   (Finset.Ico a b).prod id
 
 def IsValidBoundary' (boundaries : List ℕ) (k : ℕ) : Prop :=
-  boundaries.length = k + 1 ∧ boundaries.Chain' (· < ·)
+  boundaries.length = k + 1 ∧ boundaries.IsChain (· < ·)
 
+/-- Uses `getD` (default `0` out of range) instead of `get` with an inline
+`by omega` index proof: with only `i : Fin k` in scope there is no hypothesis
+relating `k` to `boundaries.length`, so an index-bound proof is not derivable
+in general at definition time (it only holds once `IsValidBoundary'` is also
+known, which callers supply). `getD`/`get` agree on all in-range indices, so
+this is definitionally faithful whenever `IsValidBoundary'` holds. -/
 def AllProductsCongruentOne' (p : ℕ) (boundaries : List ℕ) (k : ℕ) : Prop :=
   IsValidBoundary' boundaries k ∧
-  ∀ i : Fin k, intervalProd' (boundaries.get ⟨i.val, by omega⟩)
-    (boundaries.get ⟨i.val + 1, by omega⟩) % p = 1
+  ∀ i : Fin k, intervalProd' (boundaries.getD i.val 0) (boundaries.getD (i.val + 1) 0) % p = 1
 
 def HasSolution' (k : ℕ) : Prop :=
   ∃ p : ℕ, p.Prime ∧ ∃ boundaries : List ℕ,

--- a/proofs/batch2/STATUS.md
+++ b/proofs/batch2/STATUS.md
@@ -1,3 +1,9 @@
+# DOCTOR SINGLE-PROOF BATCH 41 (5-slot, conflict-proof collect, #38065, 2026-07-15)
+
+**+2 GREEN** (re-verified EXIT=0): SpernerGridAristotle (pure cascade off SpernerGrid), TestApi1056
+(List.Chain'->List.IsChain (only latter has Decidable in v4.31); stray open scoped Classical blocked decide;
+.get ⟨i.val,by omega⟩ unprovable index -> .getD, pattern-4 logged). Repairs: none new.
+
 # DOCTOR SINGLE-PROOF BATCH 40 (5-slot, conflict-proof collect, #38065, 2026-07-15)
 
 **+1 GREEN** (re-verified EXIT=0): SpernerGrid (SONNET 72min/623k marathon, 1766-line hub: Prod.mk.injEq

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -2442,7 +2442,7 @@ SpectralTraceDetEigenvaluesOQ02	GREEN
 SpernerFreudenthal	GREEN	
 SpernerFreudenthalSimplex	RESIDUAL	type-mismatch
 SpernerGrid	GREEN	
-SpernerGridAristotle	RESIDUAL	proof-drift
+SpernerGridAristotle	GREEN	
 SpernerGridBase	GREEN	
 SpernerGridCell	GREEN	
 SpernerMathlib	GREEN	
@@ -2558,7 +2558,7 @@ TaylorTheoremOQ02	RESIDUAL	type-mismatch
 TaylorTheoremOQ03	RESIDUAL	type-mismatch
 TaylorTheoremOQ03OQ01	GREEN	
 TaylorTheoremOQ03OQ02	GREEN	
-TestApi1056	RESIDUAL	proof-drift
+TestApi1056	GREEN	
 TestApi1059	GREEN	
 TestApi1061	GREEN	
 TestApi1061b	GREEN	


### PR DESCRIPTION
5-slot config. No loom labels.