### PR TITLE
migrate(v4.31): single-proof batch 42 (+3 GREEN, re-verified)

### DIFF
--- a/proofs/Proofs/BoundedPrimeGapsOQ04OQ01Aristotle.lean
+++ b/proofs/Proofs/BoundedPrimeGapsOQ04OQ01Aristotle.lean
@@ -17,19 +17,15 @@ The explicit exponential sum equals the abstract Gauss sum with stdAddChar.
 lemma sum_range_eq_gaussSum (q : ℕ) [NeZero q] (χ : DirichletCharacter ℂ q) :
     ∑ t ∈ Finset.range q, χ t * exp (2 * ↑π * I * ↑(t : ℤ) / ↑q) =
     gaussSum χ (ZMod.stdAddChar (N := q)) := by
-  unfold gaussSum;
-  have h_stdAddChar : ∀ a : ZMod q, ZMod.stdAddChar a = Complex.exp (2 * Real.pi * Complex.I * (a.val : ℝ) / q) := by
-    unfold ZMod.stdAddChar;
-    simp +decide [ ZMod.toCircle, Circle.coeHom ];
-    simp +decide [ AddCircle.toCircle_addChar, ZMod.toAddCircle ];
-    simp +decide [ ZMod.lift ];
-    simp +decide [ AddMonoidHom.liftOfRightInverse ];
-    simp +decide [ AddMonoidHom.liftOfRightInverseAux ];
-    simp +decide [ AddCircle.toCircle, Complex.exp_ne_zero ];
-    exact fun a => by ring;
-  rcases q with ( _ | _ | q ) <;> simp_all +decide [ Finset.sum_range, ZMod ];
-  · exact False.elim <| NeZero.ne 0 rfl;
-  · congr!
+  unfold gaussSum
+  refine Finset.sum_nbij' (fun t : ℕ => (t : ZMod q)) (fun a : ZMod q => a.val)
+    (fun _ _ => Finset.mem_univ _)
+    (fun a _ => Finset.mem_range.mpr (ZMod.val_lt a))
+    (fun t ht => ZMod.val_natCast_of_lt (Finset.mem_range.mp ht))
+    (fun a _ => ZMod.natCast_rightInverse a)
+    (fun t _ => by
+      congr 1
+      rw [show ((t : ℕ) : ZMod q) = ((t : ℤ) : ZMod q) by push_cast; ring, ZMod.stdAddChar_coe])
 
 /-
 For a MulChar on ZMod q valued in ℂ, star of a character value equals the inverse character
@@ -37,20 +33,8 @@ value.
 -/
 lemma star_mulChar_apply (q : ℕ) [NeZero q] (χ : DirichletCharacter ℂ q) (a : ZMod q) :
     starRingEnd ℂ (χ a) = χ⁻¹ a := by
-  nontriviality;
-  have h_conj : ∀ (z : ℂ), z ^ (Nat.totient q) = 1 → starRingEnd ℂ z = Ring.inverse z := by
-    intro z hz
-    have h_conj : starRingEnd ℂ z = 1 / z := by
-      simp +decide [ Complex.normSq_eq_norm_sq, Complex.ext_iff ];
-      have := congr_arg Norm.norm hz ; norm_num at this ; rw [ pow_eq_one_iff_of_nonneg ] at this <;> aesop;
-    aesop;
-  by_cases ha : IsUnit a;
-  · obtain ⟨ u, rfl ⟩ := ha;
-    convert h_conj _ _;
-    rw [ ← map_pow, show ( u : ZMod q ) ^ q.totient = 1 from ?_, map_one ];
-    norm_cast;
-    norm_num;
-  · rw [ χ.map_nonunit, MulChar.map_nonunit ] <;> aesop
+  rw [starRingEnd_apply]
+  exact MulChar.star_apply' χ a
 
 /-
 For stdAddChar on ZMod q, the star of a value equals the inverse character value.
@@ -98,9 +82,9 @@ lemma gaussSum_mul_gaussSum_inv (q : ℕ) [NeZero q] (χ : DirichletCharacter �
     have := ZMod.dft_dft (χ : ZMod q → ℂ)
     -- By Fourier inversion, we have $\tau(\chi) \tau(\chi^{-1}) = q \chi(-1)$ for primitive $\chi$.
     have h_fourier_inv : (𝓕 (fun k => χ⁻¹ (-k) * gaussSum χ (ZMod.stdAddChar (N := q)))) 1 = q * χ (-1) := by
-      convert congr_fun this 1 using 1;
-      rw [ show 𝓕 ( χ : ZMod q → ℂ ) = fun k => χ⁻¹ ( -k ) * gaussSum χ ( ZMod.stdAddChar ( N := q ) ) from funext fun k => ?_ ];
-      convert hprim.fourierTransform_eq_inv_mul_gaussSum k using 1;
+      have heq : (𝓕 (χ : ZMod q → ℂ)) = fun k => χ⁻¹ (-k) * gaussSum χ (ZMod.stdAddChar (N := q)) :=
+        funext fun k => hprim.fourierTransform_eq_inv_mul_gaussSum k
+      rw [← heq, congr_fun this 1, smul_eq_mul]
     convert h_fourier_inv using 1 ; simp +decide [ ZMod.dft, mul_comm ] ; ring!;
     nontriviality;
     erw [ Finset.mul_sum _ _ _ ] ; simp +decide [ mul_assoc, mul_comm, mul_left_comm, ZMod.dft ] ; ring!;
@@ -113,7 +97,7 @@ The norm of a character value at a unit is 1.
 -/
 lemma norm_mulChar_unit (q : ℕ) [NeZero q] (χ : DirichletCharacter ℂ q) (u : (ZMod q)ˣ) :
     ‖χ (u : ZMod q)‖ = 1 := by
-  exact?
+  exact DirichletCharacter.unit_norm_eq_one χ u
 
 /-
 The norm of gaussSum χ⁻¹ stdAddChar equals the norm of gaussSum χ stdAddChar.
@@ -125,7 +109,7 @@ lemma norm_gaussSum_inv_eq (q : ℕ) [NeZero q] (χ : DirichletCharacter ℂ q) 
   rw [ ← this, show ‖χ⁻¹ ( -1 )‖ = 1 from ?_ ];
   · rw [ ← star_gaussSum_eq, Complex.norm_conj ];
     ring;
-  · convert norm_mulChar_unit q χ⁻¹ ( -1 )
+  · simpa using norm_mulChar_unit q χ⁻¹ (-1)
 
 /-
 The norm squared of the Gauss sum of a primitive nontrivial character equals q.

--- a/proofs/Proofs/BuffonsNoodleOQ03OQ01.lean
+++ b/proofs/Proofs/BuffonsNoodleOQ03OQ01.lean
@@ -97,6 +97,7 @@ theorem crossing_numerator (m : ℕ) : crossingIntegral m = 2 / (m + 1) := by
       apply integral_congr
       intro θ hθ
       rw [uIcc_of_le (by positivity : (0 : ℝ) ≤ π / 2)] at hθ
+      dsimp only
       rw [abs_of_nonneg (Real.cos_nonneg_of_mem_Icc ⟨by linarith [Real.pi_pos, hθ.1], hθ.2⟩)]
       ring
     rw [hcongr]
@@ -111,15 +112,17 @@ theorem crossing_numerator (m : ℕ) : crossingIntegral m = 2 / (m + 1) := by
       apply integral_congr
       intro θ hθ
       rw [uIcc_of_le (by linarith [Real.pi_pos] : (π / 2 : ℝ) ≤ π)] at hθ
+      dsimp only
       rw [abs_of_nonpos (Real.cos_nonpos_of_pi_div_two_le_of_le hθ.1
         (by linarith [Real.pi_pos, hθ.2]))]
       ring
-    rw [hcongr, integral_neg]
+    rw [hcongr, intervalIntegral.integral_neg]
     have h := integral_sin_pow_mul_cos_pow_odd (a := π / 2) (b := π) m 0
     simp only [Nat.mul_zero, Nat.zero_add, pow_one, pow_zero, mul_one] at h
     rw [h, Real.sin_pi_div_two, Real.sin_pi, integral_pow]
     have hm : (m : ℝ) + 1 ≠ 0 := by positivity
-    field_simp
+    rw [zero_pow (by omega : m + 1 ≠ 0), one_pow]
+    ring
   rw [crossingIntegral, ← integral_add_adjacent_intervals hab hbc, hL, hR]
   ring
 
@@ -132,6 +135,7 @@ theorem sinPowIntegral_zero : sinPowIntegral 0 = π := by
 /-- Base case `m = 1`: `∫₀^π sin θ dθ = 2`. -/
 theorem sinPowIntegral_one : sinPowIntegral 1 = 2 := by
   simp [sinPowIntegral, integral_sin]
+  norm_num
 
 /-- The Mathlib reduction formula specialised to `0..π`: the boundary term vanishes
 because `sin 0 = sin π = 0`, leaving `D(m+2) = ((m+1)/(m+2))·D(m)`. -/
@@ -171,7 +175,6 @@ theorem integral_sin_pow_eq_Gamma (m : ℕ) :
     push_cast
     rw [e1, e2, Real.Gamma_add_one hm1, Real.Gamma_add_one hm2]
     field_simp
-    ring
 
 /-! ### Main result: the closed form of the crossing factor -/
 
@@ -190,7 +193,6 @@ theorem crossing_factor_eq_Gamma (m : ℕ) :
   have hG2 : Real.Gamma (((m : ℝ) + 1) / 2) ≠ 0 := (Real.Gamma_pos_of_pos (by positivity)).ne'
   rw [e3, Real.Gamma_add_one hm1]
   field_simp
-  ring
 
 /-! ### Consequences matching the parent file -/
 

--- a/proofs/Proofs/CauchySchwarzIntegralOQ01OQ01OQ01OQ02.lean
+++ b/proofs/Proofs/CauchySchwarzIntegralOQ01OQ01OQ01OQ02.lean
@@ -78,7 +78,7 @@ theorem hm_le_gm (a b : ℝ) (ha : 0 < a) (hb : 0 < b) :
   have hm_nonneg : 0 ≤ 2 * a * b / (a + b) := by positivity
   rw [← Real.sqrt_sq hm_nonneg]
   apply Real.sqrt_le_sqrt
-  rw [div_pow, sq_abs]
+  rw [div_pow]
   rw [div_le_iff₀ (pow_pos hab 2)]
   nlinarith [sq_nonneg (a - b), sq_nonneg a, sq_nonneg b,
              mul_pos ha hb]
@@ -108,7 +108,8 @@ theorem am_le_qm (a b : ℝ) (ha : 0 ≤ a) (hb : 0 ≤ b) :
   have ham : 0 ≤ (a + b) / 2 := by linarith
   rw [← Real.sqrt_sq ham]
   apply Real.sqrt_le_sqrt
-  rw [div_le_div_iff₀ (by norm_num : (0:ℝ) < 4) (by norm_num : (0:ℝ) < 2)]
+  rw [div_pow]
+  rw [div_le_div_iff₀ (by norm_num : (0:ℝ) < 2 ^ 2) (by norm_num : (0:ℝ) < 2)]
   nlinarith [sq_nonneg (a - b)]
 
 -- ============================================================
@@ -158,12 +159,11 @@ theorem means_eq_when_eq (a : ℝ) (ha : 0 < a) :
     HM a a = a ∧ GM a a = a ∧ AM a a = a ∧ QM a a = a := by
   constructor
   · -- HM
-    unfold HM; field_simp
+    unfold HM; field_simp; ring
   constructor
   · -- GM
     unfold GM
-    rw [← sq_sqrt (le_of_lt ha)]
-    congr 1; ring
+    exact Real.sqrt_mul_self (le_of_lt ha)
   constructor
   · -- AM
     unfold AM; ring
@@ -198,7 +198,7 @@ theorem gm_le_max (a b : ℝ) (ha : 0 ≤ a) (hb : 0 ≤ b) :
 
 /-- Direct corollary: min ≤ max. -/
 theorem min_le_max' (a b : ℝ) : min a b ≤ max a b :=
-  min_le_max a b
+  min_le_max
 
 /-
   Summary

--- a/proofs/batch2/STATUS.md
+++ b/proofs/batch2/STATUS.md
@@ -1,3 +1,11 @@
+# DOCTOR SINGLE-PROOF BATCH 42 (5-slot, conflict-proof collect, #38065, 2026-07-15)
+
+**+3 GREEN** (re-verified EXIT=0): BoundedPrimeGapsOQ04OQ01Aristotle (Aristotle convert/simp+decide chains
+-> direct Mathlib lemmas: sum_nbij'+ZMod.stdAddChar_coe, MulChar.star_apply'), BuffonsNoodleOQ03OQ01
+(dsimp only beta-reduce before abs_of_nonneg rw; integral_neg ambiguous -> qualify intervalIntegral.),
+CauchySchwarzIntegralOQ01OQ01OQ01OQ02 (div_pow before div_le_div_iff₀; ←sq_sqrt over-matches -> sqrt_mul_self).
+Repairs: none.
+
 # DOCTOR SINGLE-PROOF BATCH 41 (5-slot, conflict-proof collect, #38065, 2026-07-15)
 
 **+2 GREEN** (re-verified EXIT=0): SpernerGridAristotle (pure cascade off SpernerGrid), TestApi1056

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -275,7 +275,7 @@ BoundedPrimeGapsOQ03OQ02	GREEN
 BoundedPrimeGapsOQ03OQ03	GREEN	
 BoundedPrimeGapsOQ04	GREEN	
 BoundedPrimeGapsOQ04OQ01	GREEN	
-BoundedPrimeGapsOQ04OQ01Aristotle	RESIDUAL	rewrite-drift
+BoundedPrimeGapsOQ04OQ01Aristotle	GREEN	
 BoundedPrimeGapsOQ04OQ02	GREEN	
 BrianchonTheorem	GREEN	
 BrianchonTheoremOQ01OQ02	GREEN	
@@ -314,7 +314,7 @@ BuffonsNoodleOQ01	GREEN
 BuffonsNoodleOQ01OQ01	GREEN	
 BuffonsNoodleOQ01OQ02	GREEN	
 BuffonsNoodleOQ02	GREEN	
-BuffonsNoodleOQ03OQ01	RESIDUAL	rewrite-drift
+BuffonsNoodleOQ03OQ01	GREEN	
 BurnsideCountingOQ03Aristotle	GREEN	
 BurnsideCountingOQ03OQ03	GREEN	
 CantorDiagonalizationOQ01OQ01	RESIDUAL	unknown-const:Cardinal.aleph_lt.mpr
@@ -350,7 +350,7 @@ CauchySchwarzIntegralLpDualityGluing	GREEN
 CauchySchwarzIntegralLpDualityIngredients	GREEN	
 CauchySchwarzIntegralLpDualityMaximal	GREEN	
 CauchySchwarzIntegralLpDualitySynthesis	GREEN	
-CauchySchwarzIntegralOQ01OQ01OQ01OQ02	RESIDUAL	rewrite-drift
+CauchySchwarzIntegralOQ01OQ01OQ01OQ02	GREEN	
 CauchySchwarzIntegralOQ01OQ01OQ01OQ02OQ03	GREEN	
 CauchySchwarzIntegralOQ01OQ01OQ02	GREEN	
 CauchySchwarzIntegralOQ01OQ01OQ02OQ01	GREEN	


### PR DESCRIPTION
5-slot config, conflict-proof. No loom labels.