### PR TITLE
migrate(v4.31): single-proof batch 44 (+3 GREEN, re-verified)

### DIFF
--- a/proofs/Proofs/AbelRuffiniGaloisExtensionsOQ06GaloisDirectionAssembly.lean
+++ b/proofs/Proofs/AbelRuffiniGaloisExtensionsOQ06GaloisDirectionAssembly.lean
@@ -70,7 +70,7 @@ theorem padicValNat_factorial_self (hp : p.Prime) :
     have hi2 : 2 ≤ i := by
       rcases Finset.mem_Ico.mp hi with ⟨h1, _⟩; omega
     calc p < p ^ 2 := by nlinarith [hp.two_le]
-      _ ≤ p ^ i := Nat.pow_le_pow_right hp.pos.le hi2
+      _ ≤ p ^ i := Nat.pow_le_pow_right hp.pos hi2
   · intro h
     exact absurd (Finset.mem_Ico.mpr ⟨le_refl 1, hp.one_lt⟩) h
 
@@ -98,13 +98,15 @@ theorem sylow_p_is_pcycle_strong
   haveI : MulAction.IsPretransitive H (ZMod p) := _hPrim.toIsPretransitive
   have horbit : Nat.card (MulAction.orbit H (0 : ZMod p)) = p := by
     have huniv : MulAction.orbit H (0 : ZMod p) = Set.univ :=
-      MulAction.orbit_eq_univ (0 : ZMod p)
+      MulAction.orbit_eq_univ (↥H) (0 : ZMod p)
     rw [huniv, Nat.card_congr (Equiv.Set.univ (ZMod p)),
         Nat.card_eq_fintype_card, ZMod.card]
   have hpH : p ∣ Nat.card H := by
     have hos := MulAction.card_orbit_mul_card_stabilizer_eq_card_group
       H (0 : ZMod p)
-    exact ⟨Nat.card (MulAction.stabilizer H (0 : ZMod p)), by rw [← hos, horbit]⟩
+    refine ⟨Nat.card (MulAction.stabilizer H (0 : ZMod p)), ?_⟩
+    simp only [Nat.card_eq_fintype_card] at horbit ⊢
+    rw [← hos, horbit]
   -- Step B:  Nat.card ↥P = p.
   have hkpos : 0 < (Nat.card H).factorization p :=
     Nat.Prime.factorization_pos_of_dvd hp Nat.card_pos.ne' hpH
@@ -130,15 +132,17 @@ theorem sylow_p_is_pcycle_strong
   haveI hcyc : IsCyclic (P : Subgroup H) := isCyclic_of_prime_card hcardP
   obtain ⟨a, ha⟩ := hcyc.exists_generator
   have horda : orderOf a = p := by
-    rw [orderOf_eq_card_of_forall_mem_zpowers ha, hcardP_ft]
+    rw [orderOf_eq_card_of_forall_mem_zpowers ha]
+    exact hcardP
   have hords : orderOf (ι a) = p := by
     rw [orderOf_injective ι hι_inj a, horda]
   have hcycσ : (ι a).IsCycle := by
-    have hprime : (orderOf (ι a)).Prime := hords ▸ hp
+    have hprime : (orderOf (ι a)).Prime := by rw [hords]; exact hp
     have hsupp_lt : (ι a).support.card < 2 * orderOf (ι a) := by
       have hle : (ι a).support.card ≤ Fintype.card (ZMod p) :=
         Finset.card_le_univ _
       rw [ZMod.card] at hle
+      have h2 : 2 ≤ p := hp.two_le
       rw [hords]; omega
     exact Equiv.Perm.isCycle_of_prime_order hprime hsupp_lt
   refine ⟨ι a, hcycσ, ?_, ?_, ?_⟩

--- a/proofs/Proofs/BorsukUlamOQ03OQ01.lean
+++ b/proofs/Proofs/BorsukUlamOQ03OQ01.lean
@@ -862,9 +862,14 @@ theorem tucker_cycle (m : ℕ) (L : Fin (2 * (m + 1)) → ℤ)
     linarith
   obtain ⟨i, hi⟩ := tucker_path_pm1_complementary m L' h_labels' h_compl
   -- The complementary edge in L' corresponds to an edge in L
-  exact ⟨⟨i.val, by omega⟩, by
-    simp only [L'] at hi
-    convert hi using 2 <;> omega⟩
+  refine ⟨⟨i.val, by omega⟩, ?_⟩
+  simp only [L'] at hi
+  have e1 : ((⟨i.val, by omega⟩ : Fin (2 * (m + 1) - 1)).castSucc : Fin (2 * (m + 1))) =
+      (⟨(i.castSucc : Fin (m + 2)).val, by omega⟩ : Fin (2 * (m + 1))) := Fin.ext rfl
+  have e2 : ((⟨i.val, by omega⟩ : Fin (2 * (m + 1) - 1)).succ : Fin (2 * (m + 1))) =
+      (⟨(i.succ : Fin (m + 2)).val, by omega⟩ : Fin (2 * (m + 1))) := Fin.ext rfl
+  rw [e1, e2]
+  exact hi
 
 /-
 ## Section XXII: Tucker 2D — Parity Foundation
@@ -921,16 +926,16 @@ private noncomputable def signChangeCount (L : ℕ → ℤ) (hL : ∀ k, L k ≠
     equals whether endpoint signs differ. -/
 private lemma sign_change_parity_nat (n : ℕ) (L : ℕ → ℤ) (hL : ∀ k, L k ≠ 0) :
     (signZ (L 0) (hL 0) ≠ signZ (L (n + 1)) (hL _)) ↔ Odd (signChangeCount L hL (n + 1)) := by
-  induction n with
+  induction n generalizing L hL with
   | zero =>
     -- One edge: sign change iff endpoints differ
-    simp only [signChangeCount, Finset.range_one]
+    simp only [signChangeCount, zero_add, Finset.range_one]
     constructor
     · intro h
       have : ({0} : Finset ℕ).filter (fun i =>
           signZ (L i) (hL i) ≠ signZ (L (i + 1)) (hL _)) = {0} := by
         simp [Finset.filter_singleton, h]
-      rw [this]; exact ⟨0, by ring⟩
+      rw [this]; exact ⟨0, by simp⟩
     · intro ⟨k, hk⟩
       by_contra h
       skip
@@ -943,21 +948,28 @@ private lemma sign_change_parity_nat (n : ℕ) (L : ℕ → ℤ) (hL : ∀ k, L 
     have hrange : Finset.range (m + 2) = Finset.range (m + 1) ∪ {m + 1} := by
       ext i; simp [Finset.mem_range, Finset.mem_union, Finset.mem_singleton]; omega
     -- The sign change count splits
-    set P := fun i => signZ (L i) (hL i) ≠ signZ (L (i + 1)) (hL _)
+    set P := fun i => signZ (L i) (hL i) ≠ signZ (L (i + 1)) (hL _) with hP_def
     have hdisj : Disjoint (Finset.range (m + 1)) {m + 1} := by
-      simp [Finset.disjoint_singleton_right, Finset.mem_range]; omega
+      simp [Finset.disjoint_singleton_right, Finset.mem_range]
     have hcard : signChangeCount L hL (m + 2) =
         signChangeCount L hL (m + 1) + if P (m + 1) then 1 else 0 := by
       simp only [signChangeCount, hrange]
       rw [Finset.filter_union, Finset.card_union_of_disjoint (Finset.disjoint_filter_filter hdisj)]
-      congr 1
-      simp [Finset.filter_singleton]
+      have hstep : (({m + 1} : Finset ℕ).filter
+          (fun i => signZ (L i) (hL i) ≠ signZ (L (i + 1)) (hL _))) =
+          if P (m + 1) then ({m + 1} : Finset ℕ) else ∅ :=
+        Finset.filter_singleton _ _
+      rw [hstep]
+      by_cases hP : P (m + 1)
+      · simp [hP]
+      · simp [hP]
     -- By IH: signZ(L 0) ≠ signZ(L (m+1)) ↔ Odd(prefix count)
     have ih_applied := ih L hL
     -- Case split on whether there's a sign change at the last edge
     by_cases hlast : P (m + 1)
     · -- Sign change at last edge: count = prefix + 1
       rw [hcard, if_pos hlast]
+      simp only [hP_def] at hlast
       constructor
       · intro hne
         -- signZ ∈ {1,-1}, so L(0) ≠ L(m+2) and L(m+1) ≠ L(m+2) → L(0) = L(m+1)
@@ -969,7 +981,7 @@ private lemma sign_change_parity_nat (n : ℕ) (L : ℕ → ℤ) (hL : ∀ k, L 
         have heven : ¬Odd (signChangeCount L hL (m + 1)) := by
           rwa [← ih_applied, not_not]
         -- Even + 1 = odd
-        obtain ⟨j, hj⟩ := Nat.even_iff_not_odd.mpr heven
+        obtain ⟨j, hj⟩ := Nat.not_odd_iff_even.mp heven
         exact ⟨j, by omega⟩
       · intro ⟨k, hk⟩
         -- prefix + 1 odd → prefix even → L(0) = L(m+1)
@@ -982,19 +994,14 @@ private lemma sign_change_parity_nat (n : ℕ) (L : ℕ → ℤ) (hL : ∀ k, L 
         rcases signZ_val (L (m + 1)) (hL _) with h1 | h1 <;>
         rcases signZ_val (L (m + 2)) (hL _) with h2 | h2 <;> simp_all
     · -- No sign change at last edge: count = prefix
-      rw [hcard, if_neg hlast, Nat.add_zero]
+      rw [hcard, if_neg hlast]
+      simp only [Nat.add_zero]
+      simp only [hP_def] at hlast
       -- signZ(L (m+1)) = signZ(L (m+2))
       push_neg at hlast
-      rw [ih_applied]
-      constructor
-      · intro hne
-        -- signZ(L 0) ≠ signZ(L (m+2)) and signZ(L (m+1)) = signZ(L (m+2))
-        -- So signZ(L 0) ≠ signZ(L (m+1)), hence prefix is odd
-        rwa [hlast] at hne
-      · intro hodd
-        -- Prefix odd, so signZ(L 0) ≠ signZ(L (m+1))
-        -- signZ(L (m+1)) = signZ(L (m+2)), so signZ(L 0) ≠ signZ(L (m+2))
-        rwa [hlast]
+      -- Rewrite the L(m+2) occurrence to L(m+1) using hlast, then apply the IH directly.
+      rw [← hlast]
+      exact ih_applied
 
 /-- Bridge: convert ℕ-indexed sign change count to Fin-indexed filter card. -/
 private lemma signChangeCount_eq_filter_card (n : ℕ) (L : Fin (n + 2) → ℤ)
@@ -1008,16 +1015,41 @@ private lemma signChangeCount_eq_filter_card (n : ℕ) (L : Fin (n + 2) → ℤ)
   -- The ℕ version uses Finset.range (n+1), the Fin version uses Finset.univ (Fin (n+1))
   -- They biject via i ↦ ⟨i, ...⟩
   simp only [signChangeCount]
-  apply Finset.card_filter_congr_bij (fun i => ⟨i.1, by have := i.2; simp [Finset.mem_range] at this; exact this⟩)
-    (fun i _ => Finset.mem_univ _) (fun i j _ _ h => by ext; exact Fin.mk.inj h)
-    (fun j _ => ⟨⟨j, by simp [Finset.mem_range]; exact j.isLt⟩, Finset.mem_range.mpr j.isLt, by ext; simp⟩)
-  intro i hi
-  -- Need: signZ (L' i) = signZ (L i.castSucc) and signZ (L' (i+1)) = signZ (L i.succ)
-  -- L' i = L ⟨min i (n+1), ...⟩ and for i < n+1: min i (n+1) = i
-  -- i.castSucc = ⟨i, ...⟩ (same value)
-  simp only [Finset.mem_range] at hi
-  have hi' : i < n + 1 := hi
-  congr 1 <;> congr 1 <;> ext <;> simp [Fin.castSucc, Fin.succ, Nat.min_eq_left (by omega)]
+  have hcorr : ∀ a : ℕ, a < n + 1 →
+      ((signZ (L ⟨min a (n + 1), by omega⟩) (hnonzero _) ≠
+          signZ (L ⟨min (a + 1) (n + 1), by omega⟩) (hnonzero _)) ↔
+        signZ (L ((⟨min a n, by omega⟩ : Fin (n + 1)).castSucc)) (hnonzero _) ≠
+          signZ (L ((⟨min a n, by omega⟩ : Fin (n + 1)).succ)) (hnonzero _)) := by
+    intro a ha
+    have e1 : (⟨min a (n + 1), by omega⟩ : Fin (n + 2)) =
+        (⟨min a n, by omega⟩ : Fin (n + 1)).castSucc := by
+      apply Fin.ext; simp [show min a (n + 1) = a by omega, show min a n = a by omega]
+    have e2 : (⟨min (a + 1) (n + 1), by omega⟩ : Fin (n + 2)) =
+        (⟨min a n, by omega⟩ : Fin (n + 1)).succ := by
+      apply Fin.ext
+      simp [show min (a + 1) (n + 1) = a + 1 by omega, show min a n = a by omega]
+    rw [e1, e2]
+  apply Finset.card_nbij' (fun a => (⟨min a n, by omega⟩ : Fin (n + 1))) (fun b => (b : Fin (n + 1)).val)
+  · intro a ha
+    simp only [Finset.mem_coe, Finset.mem_filter, Finset.mem_range] at ha
+    simp only [Finset.mem_coe, Finset.mem_filter, Finset.mem_univ, true_and]
+    exact (hcorr a ha.1).mp ha.2
+  · intro b hb
+    simp only [Finset.mem_coe, Finset.mem_filter, Finset.mem_univ, true_and] at hb
+    simp only [Finset.mem_coe, Finset.mem_filter, Finset.mem_range]
+    have hbval : b.val < n + 1 := b.isLt
+    have hbeq : (⟨min b.val n, by omega⟩ : Fin (n + 1)) = b := by
+      apply Fin.ext; simp [show min b.val n = b.val by omega]
+    refine ⟨hbval, ?_⟩
+    have hmp := (hcorr b.val hbval).mpr
+    rw [hbeq] at hmp
+    exact hmp hb
+  · intro a ha
+    simp only [Finset.mem_coe, Finset.mem_filter, Finset.mem_range] at ha
+    simp [show min a n = a by omega]
+  · intro b hb
+    apply Fin.ext
+    simp [show min b.val n = b.val by omega]
 
 /-- **Sign product telescope**: On a path of nonzero integers, the product
     of signs of adjacent pairs telescopes to sign(first) * sign(last).
@@ -1038,9 +1070,12 @@ theorem sign_change_count_parity (n : ℕ) (L : Fin (n + 2) → ℤ)
   apply (sign_change_parity_nat n L' hL').mp
   -- Need: signZ(L' 0) ≠ signZ(L' (n+1))
   -- L' 0 = L 0 and L' (n+1) = L (Fin.last (n+1))
-  have hL'0 : L' 0 = L 0 := by simp [L', Nat.min_eq_left (by omega)]
+  have hL'0 : L' 0 = L 0 := by
+    have hm : min 0 (n + 1) = 0 := by omega
+    simp [L', hm]
   have hL'last : L' (n + 1) = L (Fin.last (n + 1)) := by
-    simp [L', Fin.last, Nat.min_self]
+    have hm : min (n + 1) (n + 1) = n + 1 := by omega
+    simp [L', Fin.last, hm]
   -- Endpoints are complementary, so signs differ
   intro h_eq
   have h_prod := compl_opposite_sign (hL' 0) (hL' (n + 1)) (by rw [hL'0, hL'last]; exact hcompl)

--- a/proofs/Proofs/Erdos207ProblemAristotle.lean
+++ b/proofs/Proofs/Erdos207ProblemAristotle.lean
@@ -48,16 +48,29 @@ Key Mathlib lemmas:
 theorem sts_has_girth_at_least_2_ari {V : Type*} [Fintype V] [DecidableEq V]
     (H : Hypergraph3 V) (hSTS : IsSteinerTripleSystem H) :
     HasGirthAtLeast H 2 := by
-  intro S hS₁ hS₂
-  obtain ⟨e₁, e₂, he₁, he₂, h_distinct⟩ : ∃ e₁ e₂ : Finset V,
+  intro S hS₁ hS₂ hS₃
+  obtain ⟨e₁, e₂, he₁, he₂, h_distinct, rfl⟩ : ∃ e₁ e₂ : Finset V,
       e₁ ∈ H.edges ∧ e₂ ∈ H.edges ∧ e₁ ≠ e₂ ∧ S = {e₁, e₂} := by
-    rw [Finset.card_eq_two] at hS₂; obtain ⟨e₁, e₂, hne, rfl⟩ := hS₂; use e₁, e₂; aesop
+    have hScard : S.card = 2 := le_antisymm hS₃ hS₂
+    rw [Finset.card_eq_two] at hScard
+    obtain ⟨e₁, e₂, hne, rfl⟩ := hScard
+    exact ⟨e₁, e₂, hS₁ (by simp), hS₁ (by simp), hne, rfl⟩
   have h_inter : (e₁ ∩ e₂).card ≤ 1 := by
     contrapose! h_distinct
     obtain ⟨a, ha, b, hb, hab⟩ := Finset.one_lt_card.mp h_distinct
-    have := hSTS a b hab
-    exact fun h => False.elim (h (this.unique ⟨he₁, by aesop⟩ ⟨he₂, by aesop⟩))
-  have := H.edge_card e₁ he₁; have := H.edge_card e₂ he₂; simp_all +decide
-  have := Finset.card_union_add_card_inter e₁ e₂; simp_all +decide [vertexSpan]; omega
+    have hUniq := hSTS a b hab
+    have h1 : edgeContainsPair e₁ a b :=
+      ⟨(Finset.mem_inter.mp ha).1, (Finset.mem_inter.mp hb).1, hab⟩
+    have h2 : edgeContainsPair e₂ a b :=
+      ⟨(Finset.mem_inter.mp ha).2, (Finset.mem_inter.mp hb).2, hab⟩
+    exact hUniq.unique ⟨he₁, h1⟩ ⟨he₂, h2⟩
+  have hc1 : e₁.card = 3 := H.uniform e₁ he₁
+  have hc2 : e₂.card = 3 := H.uniform e₂ he₂
+  have hcard := Finset.card_union_add_card_inter e₁ e₂
+  have hScard2 : ({e₁, e₂} : Finset (Finset V)).card = 2 := Finset.card_pair h_distinct
+  have hspan : vertexSpan ({e₁, e₂} : Finset (Finset V)) = (e₁ ∪ e₂).card := by
+    simp [vertexSpan, Finset.biUnion_insert, Finset.singleton_biUnion]
+  rw [hspan, hScard2]
+  omega
 
 end Erdos207ProblemAristotle

--- a/proofs/batch2/STATUS.md
+++ b/proofs/batch2/STATUS.md
@@ -1,3 +1,14 @@
+# DOCTOR SINGLE-PROOF BATCH 44 (5-slot + Fable experiment, #38065, 2026-07-15)
+
+**+3 GREEN** (re-verified EXIT=0): BorsukUlamOQ03OQ01 (SONNET 17min/184k: Fin.ext reindex; card_filter_congr_bij
+gone->card_nbij'; Nat.even_iff_not_odd gone->not_odd_iff_even), Erdos207ProblemAristotle (HasGirthAtLeast 4
+curried hyps; Hypergraph3.edge_card->.uniform), **AbelRuffiniGaloisExtensionsOQ06GaloisDirectionAssembly
+(FABLE-5, 4.2min/60k: 6 shallow drift sites, orderOf_eq_card_of_forall_mem_zpowers Fintype->Nat.card; omega
+no positivity from NeZero -> hp.two_le)**. Repairs: none.
+
+FABLE EXPERIMENT result-1: Fable GREEN'd a hard type-mismatch file cleanly (60k/4.2min/20 tools), comparable
+to Sonnet on hard files. Second Fable file (Erdos1017Problem) + third (Erdos1056Problem) in flight.
+
 # DOCTOR SINGLE-PROOF BATCH 43 (5-slot + Fable experiment, #38065, 2026-07-15)
 
 **+3 GREEN** (re-verified EXIT=0): DedekindFrobeniusBridge (Ideal.Quotient.ker_stabilizerHom kernel now

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -13,7 +13,7 @@ AbelRuffiniGaloisExtensionsOQ05	GREEN
 AbelRuffiniGaloisExtensionsOQ05OQ01	GREEN	
 AbelRuffiniGaloisExtensionsOQ06	GREEN	
 AbelRuffiniGaloisExtensionsOQ06GaloisDirection	GREEN	
-AbelRuffiniGaloisExtensionsOQ06GaloisDirectionAssembly	RESIDUAL	type-mismatch
+AbelRuffiniGaloisExtensionsOQ06GaloisDirectionAssembly	GREEN	
 AbelRuffiniGaloisExtensionsOQ06GaloisDirectionMainAssembly	GREEN	
 AbelRuffiniGaloisExtensionsOQ06GaloisDirectionStep4	GREEN	
 AbelRuffiniGaloisExtensionsOQ10	GREEN	
@@ -262,7 +262,7 @@ BorsukUlamOQ02OQ01OQ04OQ01	GREEN
 BorsukUlamOQ02OQ02	GREEN
 BorsukUlamOQ02OQ03	GREEN	
 BorsukUlamOQ03	GREEN	
-BorsukUlamOQ03OQ01	RESIDUAL	rewrite-drift
+BorsukUlamOQ03OQ01	GREEN	
 BorsukUlamOQ03OQ02	GREEN	
 BorsukUlamOQ03OQ03	GREEN	
 BorsukUlamOQ04OQ03	GREEN	
@@ -1003,7 +1003,7 @@ Erdos202Problem	RESIDUAL	type-mismatch
 Erdos203Problem	GREEN	
 Erdos206Problem	GREEN	
 Erdos207Problem	GREEN	
-Erdos207ProblemAristotle	RESIDUAL	rewrite-drift
+Erdos207ProblemAristotle	GREEN	
 Erdos208Problem	GREEN	
 Erdos209Problem	RESIDUAL	instance-synth
 Erdos20Problem	RESIDUAL	instance-synth


### PR DESCRIPTION
5-slot + Fable. Incl AbelRuffini Galois assembly via Fable-5. No loom labels.