### PR TITLE
migrate(v4.31): single-proof batch 45 (+2 GREEN, re-verified)

### DIFF
--- a/proofs/Proofs/DescartesRuleOfSignsOQ02.lean
+++ b/proofs/Proofs/DescartesRuleOfSignsOQ02.lean
@@ -7,6 +7,7 @@ import Mathlib.Algebra.Polynomial.Derivative
 import Mathlib.Data.Real.Basic
 import Mathlib.Tactic
 import Mathlib.Analysis.Calculus.LocalExtr.Rolle
+import Mathlib.Analysis.Calculus.Deriv.Polynomial
 
 set_option maxHeartbeats 800000
 
@@ -427,10 +428,9 @@ theorem iterDeriv_eval_zero (p : ℝ[X]) (k : ℕ) :
 
 /-- Two lists with the same zero/sign pattern produce identical sign lists,
     hence the same signChangesInList count. Proved by induction on the lists. -/
-private theorem signList_eq_of_same_signs : ∀ (l₁ l₂ : List ℝ),
-    l₁.length = l₂.length →
-    (∀ i, (h₁ : i < l₁.length) → (l₁[i] = 0 ↔ l₂[i]'(by omega) = 0)) →
-    (∀ i, (h₁ : i < l₁.length) → (l₁[i] > 0 ↔ l₂[i]'(by omega) > 0)) →
+private theorem signList_eq_of_same_signs : ∀ (l₁ l₂ : List ℝ) (hlen : l₁.length = l₂.length),
+    (∀ i, (h₁ : i < l₁.length) → (l₁[i] = 0 ↔ l₂[i]'(hlen ▸ h₁) = 0)) →
+    (∀ i, (h₁ : i < l₁.length) → (l₁[i] > 0 ↔ l₂[i]'(hlen ▸ h₁) > 0)) →
     (l₁.filter (· ≠ 0)).map (fun x => if x > 0 then (1 : ℤ) else -1) =
     (l₂.filter (· ≠ 0)).map (fun x => if x > 0 then (1 : ℤ) else -1)
   | [], [], _, _, _ => by simp
@@ -446,18 +446,16 @@ private theorem signList_eq_of_same_signs : ∀ (l₁ l₂ : List ℝ),
       fun i hi => hsign (i + 1) (by simp; omega)
     by_cases h0 : hd₁ = 0
     · have h0' : hd₂ = 0 := hzero0.mp h0
-      simp only [List.filter_cons]
-      rw [show (fun x : ℝ => decide (x ≠ 0)) hd₁ = false from by simp [h0]]
-      rw [show (fun x : ℝ => decide (x ≠ 0)) hd₂ = false from by simp [h0']]
-      simp only [Bool.false_eq_true, ↓reduceIte]
+      rw [List.filter_cons_of_neg (by simp [h0]), List.filter_cons_of_neg (by simp [h0'])]
       exact signList_eq_of_same_signs tl₁ tl₂ hlen' hzero' hsign'
     · have h0' : hd₂ ≠ 0 := fun he => h0 (hzero0.mpr he)
-      simp only [List.filter_cons]
-      rw [show (fun x : ℝ => decide (x ≠ 0)) hd₁ = true from by simp [h0]]
-      rw [show (fun x : ℝ => decide (x ≠ 0)) hd₂ = true from by simp [h0']]
-      simp only [↓reduceIte, List.map_cons]
+      rw [List.filter_cons_of_pos (by simp [h0]), List.filter_cons_of_pos (by simp [h0'])]
+      simp only [List.map_cons]
       congr 1
-      · rw [show (hd₁ > 0) = (hd₂ > 0) from propext hsign0]
+      · by_cases hp : hd₁ > 0
+        · simp [hp, hsign0.mp hp]
+        · have hp2 : ¬ hd₂ > 0 := fun h => hp (hsign0.mpr h)
+          simp [hp, not_lt.mp hp2]
       · exact signList_eq_of_same_signs tl₁ tl₂ hlen' hzero' hsign'
 
 /-- If two lists have the same zero/sign pattern, signChangesInList is equal. -/
@@ -485,18 +483,27 @@ theorem budanCount_zero_eq_coeff_sign_changes (p : ℝ[X]) (hp : p ≠ 0) :
   rw [hseq]
   -- The two lists are (range (n+1)).map (fun k => k! * a_k) and (range (n+1)).map a_k
   -- They have the same length and same zero/sign pattern since k! > 0
-  apply signChangesInList_congr
-  · simp
-  · intro i hi
+  have hlen : ((List.range (p.natDegree + 1)).map (fun k => (k.factorial : ℝ) * p.coeff k)).length =
+      ((List.range (p.natDegree + 1)).map p.coeff).length := by simp
+  have hzero : ∀ i,
+      (h₁ : i < ((List.range (p.natDegree + 1)).map (fun k => (k.factorial : ℝ) * p.coeff k)).length) →
+      (((List.range (p.natDegree + 1)).map (fun k => (k.factorial : ℝ) * p.coeff k))[i] = 0 ↔
+        ((List.range (p.natDegree + 1)).map p.coeff)[i]'(by omega) = 0) := by
+    intro i hi
     simp only [List.length_map, List.length_range] at hi
     simp only [List.getElem_map, List.getElem_range]
     constructor
     · intro h; exact (mul_eq_zero.mp h).resolve_left (Nat.cast_ne_zero.mpr (Nat.factorial_ne_zero _))
     · intro h; simp [h]
-  · intro i hi
+  have hsign : ∀ i,
+      (h₁ : i < ((List.range (p.natDegree + 1)).map (fun k => (k.factorial : ℝ) * p.coeff k)).length) →
+      (((List.range (p.natDegree + 1)).map (fun k => (k.factorial : ℝ) * p.coeff k))[i] > 0 ↔
+        ((List.range (p.natDegree + 1)).map p.coeff)[i]'(by omega) > 0) := by
+    intro i hi
     simp only [List.length_map, List.length_range] at hi
     simp only [List.getElem_map, List.getElem_range]
     exact mul_pos_iff_of_pos_left (Nat.cast_pos.mpr (Nat.factorial_pos _))
+  exact signChangesInList_congr _ _ hlen hzero hsign
 
 /-
 ## Part IX: Structural Theorems
@@ -524,31 +531,26 @@ private theorem countAdjacentDiffs_neg : ∀ (l : List ℤ),
   | [] => by simp
   | [_] => by simp
   | a :: b :: rest => by
+    have ih : countAdjacentDiffs ((-b) :: rest.map (-·)) = countAdjacentDiffs (b :: rest) := by
+      simpa using countAdjacentDiffs_neg (b :: rest)
     change (if -a ≠ -b then 1 else 0) + countAdjacentDiffs ((-b) :: rest.map (-·)) =
            (if a ≠ b then 1 else 0) + countAdjacentDiffs (b :: rest)
-    rw [show (-a ≠ -b) = (a ≠ b) from propext (by constructor <;> intro h he <;> exact h (neg_inj.mpr he))]
+    rw [ih]
     congr 1
-    exact countAdjacentDiffs_neg (b :: rest)
+    by_cases h : a = b <;> simp [h]
 
 /-- Filter commutes with constant nonzero multiplication. -/
 private theorem filter_ne_zero_map_mul (l : List ℝ) (c : ℝ) (hc : c ≠ 0) :
     (l.map (c * ·)).filter (· ≠ (0 : ℝ)) =
     (l.filter (· ≠ (0 : ℝ))).map (c * ·) := by
-  induction l with
-  | nil => simp
-  | cons hd tl ih =>
-    simp only [List.map_cons, List.filter_cons]
-    by_cases h : hd = 0
-    · rw [show (fun x : ℝ => decide (x ≠ 0)) (c * hd) = false from by simp [h]]
-      rw [show (fun x : ℝ => decide (x ≠ 0)) hd = false from by simp [h]]
-      simp only [Bool.false_eq_true, ↓reduceIte]
-      exact ih
-    · have hne : c * hd ≠ 0 := mul_ne_zero hc h
-      rw [show (fun x : ℝ => decide (x ≠ 0)) (c * hd) = true from by simp [hne]]
-      rw [show (fun x : ℝ => decide (x ≠ 0)) hd = true from by simp [h]]
-      simp only [↓reduceIte, List.map_cons]
-      congr 1
-      exact ih
+  rw [List.filter_map]
+  congr 1
+  apply List.filter_congr
+  intro x _
+  simp only [Function.comp]
+  by_cases h : x = 0
+  · simp [h]
+  · simp [h, mul_ne_zero hc h]
 
 /-- signChangesInList is invariant under nonzero scalar multiplication.
     Uses filter commutation and sign analysis (positive preserves, negative flips + negation invariance). -/
@@ -568,12 +570,12 @@ private theorem signChangesInList_map_mul (l : List ℝ) (c : ℝ) (hc : c ≠ 0
       rw [List.map_map]
       apply List.map_congr_left
       intro x hx
-      have hxne : x ≠ 0 := of_decide_eq_true (List.of_mem_filter hx)
+      have hxne : x ≠ 0 := by simpa using (List.mem_filter.mp hx).2
       simp only [Function.comp]
       by_cases hxp : x > 0
       · have : c * x < 0 := mul_neg_of_neg_of_pos hcn hxp
         simp [show ¬(c * x > 0) from not_lt.mpr (le_of_lt this), hxp]
-      · have hxn : x < 0 := lt_of_le_of_ne (not_lt.mp hxp) (Ne.symm hxne)
+      · have hxn : x < 0 := lt_of_le_of_ne (not_lt.mp hxp) hxne
         have : c * x > 0 := mul_pos_of_neg_of_neg hcn hxn
         simp [this, hxp]
     rw [key, countAdjacentDiffs_neg]
@@ -581,11 +583,11 @@ private theorem signChangesInList_map_mul (l : List ℝ) (c : ℝ) (hc : c ≠ 0
     congr 1
     apply List.map_congr_left
     intro x hx
-    have hxne : x ≠ 0 := of_decide_eq_true (List.of_mem_filter hx)
+    have hxne : x ≠ 0 := by simpa using (List.mem_filter.mp hx).2
     simp only [Function.comp]
     by_cases hxp : x > 0
     · simp [mul_pos hcp hxp, hxp]
-    · have hxn : x < 0 := lt_of_le_of_ne (not_lt.mp hxp) (Ne.symm hxne)
+    · have hxn : x < 0 := lt_of_le_of_ne (not_lt.mp hxp) hxne
       have : ¬(c * x > 0) := not_lt.mpr (le_of_lt (mul_neg_of_pos_of_neg hcp hxn))
       simp [this, hxp]
 

--- a/proofs/Proofs/Erdos288Problem.lean
+++ b/proofs/Proofs/Erdos288Problem.lean
@@ -69,9 +69,10 @@ axiom erdos_288 : ErdosConjecture288
 theorem example_sum_one :
     harmonicInterval ⟨3, by omega⟩ ⟨6, by omega⟩ +
     harmonicInterval ⟨20, by omega⟩ ⟨20, by omega⟩ = 1 := by
-  unfold harmonicInterval
+  show (∑ n ∈ Finset.Icc (3 : ℕ) (6 : ℕ), if h : n > 0 then (n : ℚ)⁻¹ else 0) +
+       (∑ n ∈ Finset.Icc (20 : ℕ) (20 : ℕ), if h : n > 0 then (n : ℚ)⁻¹ else 0) = 1
   -- Reduce the finite sums
-  have h36 : Finset.Icc 3 6 = {3, 4, 5, 6} := by decide
+  have h36 : Finset.Icc (3 : ℕ) 6 = {3, 4, 5, 6} := by decide
   rw [h36, Finset.Icc_self]
   simp only [Finset.sum_singleton, Finset.sum_cons, Finset.sum_empty,
     show (3 : ℕ) > 0 from by omega, show (4 : ℕ) > 0 from by omega,
@@ -84,8 +85,9 @@ theorem example_sum_one :
 theorem example_sum_one_v2 :
     harmonicInterval ⟨2, by omega⟩ ⟨3, by omega⟩ +
     harmonicInterval ⟨6, by omega⟩ ⟨6, by omega⟩ = 1 := by
-  unfold harmonicInterval
-  have h23 : Finset.Icc 2 3 = {2, 3} := by decide
+  show (∑ n ∈ Finset.Icc (2 : ℕ) (3 : ℕ), if h : n > 0 then (n : ℚ)⁻¹ else 0) +
+       (∑ n ∈ Finset.Icc (6 : ℕ) (6 : ℕ), if h : n > 0 then (n : ℚ)⁻¹ else 0) = 1
+  have h23 : Finset.Icc (2 : ℕ) 3 = {2, 3} := by decide
   rw [h23, Finset.Icc_self]
   simp only [Finset.sum_singleton, Finset.sum_cons, Finset.sum_empty,
     show (2 : ℕ) > 0 from by omega, show (3 : ℕ) > 0 from by omega,
@@ -132,13 +134,13 @@ theorem harmonicInterval_pos (a b : ℕ+) (h : a ≤ b) :
     harmonicInterval a b > 0 := by
   unfold harmonicInterval
   apply Finset.sum_pos
-  · -- Icc is nonempty since a ≤ b
-    exact ⟨(a : ℕ), Finset.mem_Icc.mpr ⟨le_refl _, h⟩⟩
   · intro k hk
     have hk_pos : k > 0 := by
       have := (Finset.mem_Icc.mp hk).1; exact lt_of_lt_of_le (PNat.pos a) this
     simp only [dif_pos hk_pos]
     exact inv_pos.mpr (Nat.cast_pos.mpr hk_pos)
+  · -- Icc is nonempty since a ≤ b
+    exact ⟨(a : ℕ), Finset.mem_Icc.mpr ⟨le_refl _, h⟩⟩
 
 /-- The harmonic sum over [1, n] is the n-th harmonic number. -/
 theorem harmonicInterval_from_one (n : ℕ+) :
@@ -147,7 +149,9 @@ theorem harmonicInterval_from_one (n : ℕ+) :
   apply Finset.sum_congr rfl
   intro k hk
   have hk_pos : k > 0 := by
-    have := (Finset.mem_Icc.mp hk).1; omega
+    have h1 := (Finset.mem_Icc.mp hk).1
+    norm_num at h1
+    omega
   simp only [dif_pos hk_pos]
 
 /-- The harmonic sum H(a,b) is at least 1/a when a ≤ b.

--- a/proofs/batch2/STATUS.md
+++ b/proofs/batch2/STATUS.md
@@ -1,3 +1,10 @@
+# DOCTOR SINGLE-PROOF BATCH 45 (5-slot + Fable, #38065, 2026-07-15)
+
+**+2 GREEN** (re-verified EXIT=0): Erdos288Problem (PNat-coe-vs-Subtype show-normalization; Finset.sum_pos
+arg order flipped), DescartesRuleOfSignsOQ02 (11.8min: List.filter_cons decide-normal-form churn ->
+filter_cons_of_pos/neg; anonymous-Pi-hyp invisible to omega in a theorem TYPE signature -> name+▸; unblocks
+DescartesRuleOfSignsOQ02OQ01). Repairs: none.
+
 # DOCTOR SINGLE-PROOF BATCH 44 (5-slot + Fable experiment, #38065, 2026-07-15)
 
 **+3 GREEN** (re-verified EXIT=0): BorsukUlamOQ03OQ01 (SONNET 17min/184k: Fin.ext reindex; card_filter_congr_bij

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -539,7 +539,7 @@ DesarguesTheorem	RESIDUAL	type-mismatch
 DesarguesTheoremOQ01OQ01	GREEN
 DescartesRuleOfSignsOQ01OQ01	GREEN	
 DescartesRuleOfSignsOQ01OQ02	RESIDUAL	unknown-const:Even.add_even
-DescartesRuleOfSignsOQ02	RESIDUAL	rewrite-drift
+DescartesRuleOfSignsOQ02	GREEN	
 DescartesRuleOfSignsOQ02OQ01	RESIDUAL	rewrite-drift
 DescartesRuleOfSignsOQ02Parity	GREEN	proof-drift
 DescartesRuleOfSignsOQ04	RESIDUAL	unknown-const:Multiset.countP_singleton
@@ -1083,7 +1083,7 @@ Erdos284Problem	GREEN
 Erdos285Problem	GREEN	
 Erdos286Problem	GREEN	
 Erdos287Problem	GREEN	
-Erdos288Problem	RESIDUAL	rewrite-drift
+Erdos288Problem	GREEN	
 Erdos289Problem	GREEN	
 Erdos28AdditiveBases	GREEN	
 Erdos28Problem	GREEN	


### PR DESCRIPTION
5-slot + Fable. Unblocks DescartesRuleOfSignsOQ02OQ01. No loom labels.