### PR TITLE
migrate(v4.31): single-proof batch 47 (+4 GREEN)

### DIFF
--- a/proofs/Proofs/Erdos1079Problem.lean
+++ b/proofs/Proofs/Erdos1079Problem.lean
@@ -44,10 +44,8 @@ def neighborhood {V : Type*} (G : SimpleGraph V) (v : V) : Set V :=
   {u : V | G.Adj v u}
 
 /-- Induced subgraph on a vertex set -/
-def inducedSubgraph {V : Type*} (G : SimpleGraph V) (S : Set V) : SimpleGraph S where
-  Adj := fun ⟨u, _⟩ ⟨v, _⟩ => G.Adj u v
-  symm.symm := fun ⟨u, _⟩ ⟨v, _⟩ h => G.symm h
-  loopless.irrefl := fun ⟨v, _⟩ => G.loopless v
+def inducedSubgraph {V : Type*} (G : SimpleGraph V) (S : Set V) : SimpleGraph S :=
+  G.comap Subtype.val
 
 /-- Number of edges in a finite simple graph -/
 noncomputable def numEdges {V : Type*} [Fintype V] [DecidableEq V]
@@ -120,12 +118,10 @@ graphs necessarily have locally dense neighborhoods.
 axiom erdos_1079_summary :
   (∀ r : ℕ, r ≥ 4 →
     ∃ c : ℝ, c > 0 ∧
-      ∀ n : ℕ, ∀ V : Finset ℕ, V.card = n →
-        ∀ G : SimpleGraph ℕ, ∀ [DecidableRel G.Adj],
-          (∀ e : ℕ × ℕ, G.Adj e.1 e.2 → e.1 ∈ V ∧ e.2 ∈ V) →
-          numEdges G ≥ turanNumber n r →
-          ∃ v ∈ V, (G.degree v : ℝ) ≥ c * n ∧
-            neighborhoodEdges G v ≥ turanNumber (G.degree v) (r - 1)) ∧
+      ∀ n : ℕ, ∀ G : SimpleGraph (Fin n), ∀ [DecidableRel G.Adj],
+        numEdges G ≥ turanNumber n r →
+        ∃ v : Fin n, (G.degree v : ℝ) ≥ c * n ∧
+          neighborhoodEdges G v ≥ turanNumber (G.degree v) (r - 1)) ∧
   (∀ n r : ℕ, r ≥ 2 → n ≥ r →
     ∀ G : SimpleGraph (Fin n), ∀ [DecidableRel G.Adj],
       G.CliqueFree r →
@@ -137,12 +133,10 @@ axiom erdos_1079_summary :
 theorem erdos_1079 :
     (∀ r : ℕ, r ≥ 4 →
       ∃ c : ℝ, c > 0 ∧
-        ∀ n : ℕ, ∀ V : Finset ℕ, V.card = n →
-          ∀ G : SimpleGraph ℕ, ∀ [DecidableRel G.Adj],
-            (∀ e : ℕ × ℕ, G.Adj e.1 e.2 → e.1 ∈ V ∧ e.2 ∈ V) →
-            numEdges G ≥ turanNumber n r →
-            ∃ v ∈ V, (G.degree v : ℝ) ≥ c * n ∧
-              neighborhoodEdges G v ≥ turanNumber (G.degree v) (r - 1)) ∧
+        ∀ n : ℕ, ∀ G : SimpleGraph (Fin n), ∀ [DecidableRel G.Adj],
+          numEdges G ≥ turanNumber n r →
+          ∃ v : Fin n, (G.degree v : ℝ) ≥ c * n ∧
+            neighborhoodEdges G v ≥ turanNumber (G.degree v) (r - 1)) ∧
     (∀ n r : ℕ, r ≥ 2 → n ≥ r →
       ∀ G : SimpleGraph (Fin n), ∀ [DecidableRel G.Adj],
         G.CliqueFree r →

--- a/proofs/Proofs/Erdos404Problem.lean
+++ b/proofs/Proofs/Erdos404Problem.lean
@@ -31,7 +31,7 @@ namespace Erdos404
 structure StrictIncSeq (a : ℕ) where
   length : ℕ
   seq : Fin length → ℕ
-  starts_at_a : length > 0 → seq ⟨0, by omega⟩ = a
+  starts_at_a : (h : length > 0) → seq ⟨0, by omega⟩ = a
   strictly_increasing : ∀ i j : Fin length, i < j → seq i < seq j
 
 noncomputable def factorialSum (s : StrictIncSeq a) : ℕ :=
@@ -123,7 +123,7 @@ private theorem sum_telescope_nat (f : ℕ → ℕ) (hf : ∀ k, f (k + 1) ≤ f
   | zero => simp
   | succ m ih =>
     rw [Finset.sum_range_succ, ih]
-    have h1 : f (m + 2) ≤ f (m + 1) := hf (m + 1)
+    have h1 : f (m + 1 + 1) ≤ f (m + 1) := hf (m + 1)
     have h2 : f (m + 1) ≤ f 0 := by
       clear ih h1; induction m with
       | zero => exact hf 0
@@ -145,17 +145,18 @@ theorem legendreSum_digitSum_identity (n p : ℕ) (hp : 2 ≤ p) :
     have h_div_alg := Nat.div_add_mod (n / p ^ k) p
     -- n/p^k/p = n/p^(k+1)
     have h_eq_div : n / p ^ k / p = n / p ^ (k + 1) := by
-      rw [Nat.div_div_eq_div_mul]
-      congr 1
-      exact (pow_succ p k).symm
+      rw [Nat.div_div_eq_div_mul, ← pow_succ]
     -- Monotonicity: n/p^k ≥ n/p^(k+1)
     have h_mono : n / p ^ (k + 1) ≤ n / p ^ k := div_pow_antitone n p (by omega) k
-    -- From h_div_alg: p * (n/p^k/p) + n/p^k%p = n/p^k
-    -- Rewrite n/p^k/p = n/p^(k+1):
+    -- Rewrite n/p^k/p = n/p^(k+1) inside h_div_alg:
     -- p * (n/p^(k+1)) + n/p^k%p = n/p^k
-    -- So: n/p^(k+1)*(p-1) + n/p^k%p + n/p^(k+1) = n/p^k
-    -- Therefore: n/p^(k+1)*(p-1) + n/p^k%p = n/p^k - n/p^(k+1)
-    rw [← h_eq_div] at h_div_alg
+    rw [h_eq_div] at h_div_alg
+    obtain ⟨q, hq⟩ : ∃ q, p = q + 1 := ⟨p - 1, by omega⟩
+    have hsub : p - 1 = q := by omega
+    rw [hsub]
+    -- n/p^(k+1)*q + n/p^(k+1) = p*(n/p^(k+1)), matching h_div_alg's atom
+    have hcomm : n / p ^ (k + 1) * q + n / p ^ (k + 1) = p * (n / p ^ (k + 1)) := by
+      rw [hq]; ring
     omega
   rw [Finset.sum_congr rfl h_eq,
       sum_telescope_nat (fun k => n / p ^ k) (div_pow_antitone n p (by omega)) L]
@@ -183,23 +184,25 @@ theorem padic_val_factorial_lower (n p : ℕ) (hp : p.Prime) (hn : 1 ≤ n) :
     calc ∑ k ∈ Finset.range (Nat.log p n + 1), n / p ^ k % p
         ≤ ∑ _ ∈ Finset.range (Nat.log p n + 1), (p - 1) := by
           apply Finset.sum_le_sum; intro k _
-          have := Nat.mod_lt (n / p ^ k) (show 0 < p by omega); omega
+          have := Nat.mod_lt (n / p ^ k) hp.pos; omega
       _ = (p - 1) * (Nat.log p n + 1) := by
-          rw [Finset.sum_const, Finset.card_range, smul_eq_mul]
+          rw [Finset.sum_const, Finset.card_range, smul_eq_mul, mul_comm]
   omega
 
 /-- ν_p(n!)/n → 1/(p-1) as n → ∞.
     Proof by squeeze theorem using the Nat-valued bounds. -/
 theorem padic_val_factorial_asymp (p : ℕ) (hp : p.Prime) :
-    Tendsto (fun n => (padicValNat p n.factorial : ℝ) / n) atTop (nhds (1/(p-1))) := by
+    Tendsto (fun n : ℕ => (padicValNat p n.factorial : ℝ) / n) atTop (nhds (1/(p-1))) := by
   haveI : Fact p.Prime := ⟨hp⟩
   have hp_one_lt : (1 : ℝ) < p := by exact_mod_cast hp.one_lt
   have hpp1 : (0 : ℝ) < (p : ℝ) - 1 := by linarith
   -- Upper bound: ν/n ≤ 1/(p-1)
-  have h_upper : ∀ᶠ n in atTop, (padicValNat p n.factorial : ℝ) / n ≤ 1 / ((p : ℝ) - 1) := by
+  have h_upper : ∀ᶠ n : ℕ in atTop, (padicValNat p n.factorial : ℝ) / n ≤ 1 / ((p : ℝ) - 1) := by
     filter_upwards [Filter.eventually_ge_atTop 1] with n hn
     have hn_pos : (0 : ℝ) < n := Nat.cast_pos.mpr (by omega)
-    rw [div_le_div_iff₀ hn_pos hpp1, one_mul]
+    have h_cast : (((p - 1 : ℕ)) : ℝ) = (p : ℝ) - 1 := by
+      simpa using Nat.cast_sub (R := ℝ) hp.one_lt.le
+    rw [div_le_div_iff₀ hn_pos hpp1, one_mul, ← h_cast]
     exact_mod_cast padic_val_factorial_upper n p hp (by omega)
   -- Lower bound limit: 1/(p-1) - (L+1)/n → 1/(p-1)
   have h_lower_lim : Tendsto (fun n : ℕ =>
@@ -226,29 +229,35 @@ theorem padic_val_factorial_asymp (p : ℕ) (hp : p.Prime) :
       have h2 : Real.log ↑n ≤ ε * Real.log ↑p / 2 * ↑n := by
         have h := hR ↑n (le_trans (Nat.le_ceil R)
           (by exact_mod_cast le_trans (le_max_left _ _) hn))
-        simp only [rpow_one, Real.norm_eq_abs] at h
+        simp only [Real.rpow_one, Real.norm_eq_abs] at h
         rwa [abs_of_nonneg (Real.log_nonneg (by exact_mod_cast hn1)),
              abs_of_nonneg hn_pos.le] at h
       -- Step 3: Nat.log p n / n ≤ ε/2 (dividing combined bound by log p)
       have h3 : (Nat.log p n : ℝ) / ↑n ≤ ε / 2 := by
+        have hcomb : (Nat.log p n : ℝ) * Real.log ↑p ≤ (ε / 2 * ↑n) * Real.log ↑p :=
+          calc (Nat.log p n : ℝ) * Real.log ↑p ≤ Real.log ↑n := h1
+            _ ≤ ε * Real.log ↑p / 2 * ↑n := h2
+            _ = (ε / 2 * ↑n) * Real.log ↑p := by ring
+        have hle : (Nat.log p n : ℝ) ≤ ε / 2 * ↑n := le_of_mul_le_mul_right hcomb hlogp
         rw [div_le_iff₀ hn_pos]
-        exact (mul_le_mul_right hlogp).mp
-          ((le_trans h1 h2).trans_eq (by ring))
+        linarith
       -- Step 4: 1/n < ε/2 (since n > 2/ε)
       have h4 : 1 / (↑n : ℝ) < ε / 2 := by
         rw [div_lt_div_iff₀ hn_pos (by norm_num : (0 : ℝ) < 2), one_mul]
-        have : (⌈2 / ε⌉₊ : ℝ) + 1 ≤ ↑n := by
+        have hle : (⌈2 / ε⌉₊ : ℝ) + 1 ≤ ↑n := by
           exact_mod_cast le_trans (le_max_right _ _) hn
-        nlinarith [Nat.le_ceil (2 / ε)]
+        have hceil : (2 : ℝ) / ε ≤ (⌈2 / ε⌉₊ : ℝ) := Nat.le_ceil _
+        have hgt : (2 : ℝ) / ε < ↑n := by linarith
+        have hmul := (div_lt_iff₀ hε).mp hgt
+        nlinarith [hmul]
       -- Combine
       calc ((Nat.log p n : ℝ) + 1) / ↑n
           = (Nat.log p n : ℝ) / ↑n + 1 / ↑n := add_div ..
         _ < ε / 2 + ε / 2 := add_lt_add_of_le_of_lt h3 h4
         _ = ε := by ring
-    rw [show (1 : ℝ) / ((p : ℝ) - 1) = 1 / ((p : ℝ) - 1) - 0 from by ring]
-    exact Tendsto.sub tendsto_const_nhds this
+    simpa using tendsto_const_nhds.sub this
   -- Lower bound pointwise: ν/n ≥ 1/(p-1) - (L+1)/n
-  have h_lower : ∀ᶠ n in atTop, 1 / ((p : ℝ) - 1) - ((Nat.log p n : ℝ) + 1) / n ≤
+  have h_lower : ∀ᶠ n : ℕ in atTop, 1 / ((p : ℝ) - 1) - ((Nat.log p n : ℝ) + 1) / n ≤
       (padicValNat p n.factorial : ℝ) / n := by
     filter_upwards [Filter.eventually_ge_atTop 1] with n hn
     have hn_pos : (0 : ℝ) < n := Nat.cast_pos.mpr (by omega)
@@ -259,9 +268,9 @@ theorem padic_val_factorial_asymp (p : ℕ) (hp : p.Prime) :
       calc ∑ k ∈ Finset.range (Nat.log p n + 1), n / p ^ k % p
           ≤ ∑ _ ∈ Finset.range (Nat.log p n + 1), (p - 1) := by
             apply Finset.sum_le_sum; intro k _
-            have := Nat.mod_lt (n / p ^ k) (show 0 < p by omega); omega
+            have := Nat.mod_lt (n / p ^ k) hp.pos; omega
         _ = (p - 1) * (Nat.log p n + 1) := by
-            rw [Finset.sum_const, Finset.card_range, smul_eq_mul]
+            rw [Finset.sum_const, Finset.card_range, smul_eq_mul, mul_comm]
     rw [legendre_formula n p hp (by omega)]
     -- Goal: 1/(p-1) - (L+1)/n ≤ (legendreSum n p : ℝ) / n
     -- From h_id: (legendreSum : ℝ) * (p-1) = n - (baseDigitSum : ℝ)
@@ -270,23 +279,25 @@ theorem padic_val_factorial_asymp (p : ℕ) (hp : p.Prime) :
     -- Since ds ≤ (p-1)*(L+1): ds/(n*(p-1)) ≤ (L+1)/n
     -- Therefore legendreSum/n ≥ 1/(p-1) - (L+1)/n
     have h_id_real : (legendreSum n p : ℝ) * ((p : ℝ) - 1) + (baseDigitSum n p : ℝ) = (n : ℝ) := by
-      have h1 : (legendreSum n p * (p - 1) + baseDigitSum n p : ℕ) = n := h_id
-      push_cast [Nat.cast_sub hp.one_lt.le] at h1
+      have h1 : ((legendreSum n p * (p - 1) + baseDigitSum n p : ℕ) : ℝ) = (n : ℝ) := by
+        exact_mod_cast h_id
+      rw [Nat.cast_add, Nat.cast_mul, Nat.cast_sub hp.one_lt.le, Nat.cast_one] at h1
       linarith
     have h_ds_real : (baseDigitSum n p : ℝ) ≤ ((p : ℝ) - 1) * ((Nat.log p n : ℝ) + 1) := by
-      push_cast [Nat.cast_sub hp.one_lt.le] at h_ds
+      have h2 : ((baseDigitSum n p : ℕ) : ℝ) ≤ (((p - 1) * (Nat.log p n + 1) : ℕ) : ℝ) :=
+        Nat.cast_le.mpr h_ds
+      rw [Nat.cast_mul, Nat.cast_sub hp.one_lt.le, Nat.cast_add, Nat.cast_one] at h2
       linarith
     -- Now do the algebra
     have h_leg : (legendreSum n p : ℝ) * ((p : ℝ) - 1) ≥
         (n : ℝ) - ((p : ℝ) - 1) * ((Nat.log p n : ℝ) + 1) := by linarith
-    rw [ge_iff_le, ← sub_nonneg]
+    rw [← sub_nonneg]
     rw [ge_iff_le, ← sub_nonneg] at h_leg
-    rw [sub_div]
     have : (legendreSum n p : ℝ) / (n : ℝ) - (1 / ((p : ℝ) - 1) - ((Nat.log p n : ℝ) + 1) / (n : ℝ)) =
         ((legendreSum n p : ℝ) * ((p : ℝ) - 1) - ((n : ℝ) - ((p : ℝ) - 1) * ((Nat.log p n : ℝ) + 1))) /
         ((n : ℝ) * ((p : ℝ) - 1)) := by field_simp
     linarith [div_nonneg h_leg (mul_pos hn_pos hpp1).le]
-  exact tendsto_of_tendsto_of_tendsto_of_le_of_le h_lower_lim tendsto_const_nhds h_lower h_upper
+  exact tendsto_of_tendsto_of_tendsto_of_le_of_le' h_lower_lim tendsto_const_nhds h_lower h_upper
 
 /- ## Part V: Structure of Factorial Sums -/
 

--- a/proofs/Proofs/Erdos413Problem.lean
+++ b/proofs/Proofs/Erdos413Problem.lean
@@ -127,7 +127,7 @@ theorem primeFactors_prod_dvd (n : ℕ) (hn : n ≠ 0) :
 /-- 2^(number of distinct prime factors) ≤ n for n ≥ 1 -/
 theorem two_pow_omega_le (n : ℕ) (hn : n ≥ 1) :
     2 ^ omega n ≤ n := by
-  rcases hn.eq_or_gt with rfl | hn2
+  rcases eq_or_lt_of_le hn with rfl | hn2
   · simp [omega_one]
   · have hne : n ≠ 0 := by omega
     have hprod : 2 ^ n.primeFactors.card ≤ n.primeFactors.prod id := by
@@ -181,13 +181,12 @@ theorem prime_totient_sum (p : ℕ) (hp : p.Prime) :
 
 /-- φ(n) ≥ 2 for n ≥ 3: since φ(n) = 1 iff n ∈ {1, 2} -/
 theorem totient_ge_two (n : ℕ) (hn : n ≥ 3) : Nat.totient n ≥ 2 := by
+  have hpos : 0 < Nat.totient n := Nat.totient_pos.mpr (by omega)
   by_contra h
   push_neg at h
-  interval_cases h : n.totient
-  · have := Nat.totient_pos (by omega : 0 < n)
-    omega
-  · rw [Nat.totient_eq_one_iff] at h
-    omega
+  have h1 : Nat.totient n = 1 := by omega
+  rw [Nat.totient_eq_one_iff] at h1
+  omega
 
 /-- φ has no barriers beyond 3: for any n ≥ 4, (n-1) + φ(n-1) > n.
     Since n-1 ≥ 3, φ(n-1) ≥ 2, giving (n-1) + 2 = n+1 > n. -/
@@ -230,7 +229,7 @@ theorem bigOmega_barrier_implies_omega_barrier (n : ℕ)
 /-- ω of a prime power is 1 -/
 theorem omega_prime_pow (p k : ℕ) (hp : p.Prime) (hk : k ≥ 1) :
     omega (p ^ k) = 1 := by
-  simp [omega, Nat.primeFactors_prime_pow hp (by omega : k ≠ 0)]
+  simp [omega, Nat.primeFactors_prime_pow (by omega : k ≠ 0) hp]
 
 /-- At any barrier n > 0, the predecessor has ω(n-1) ≤ 1 -/
 theorem omega_pred_le_one_at_barrier (n : ℕ) (hn : n > 0)
@@ -358,6 +357,7 @@ end DecidableBarriers
 /-- If n is not a barrier for f, there exists a witness m < n with m + f(m) > n -/
 theorem not_barrier_witness (f : ℕ → ℕ) (n : ℕ) (h : ¬IsBarrier f n) :
     ∃ m, m < n ∧ m + f m > n := by
+  unfold IsBarrier at h
   push_neg at h
   obtain ⟨m, hm, hgt⟩ := h
   exact ⟨m, hm, by omega⟩
@@ -371,16 +371,18 @@ theorem barrier_pred_is_prime_power_or_one (n : ℕ) (hn : n ≥ 2)
   have hpred := omega_pred_le_one_at_barrier n (by omega) hb
   rcases Nat.eq_or_lt_of_le (Nat.zero_le (omega (n - 1))) with h0 | h1
   · -- ω(n-1) = 0 means n-1 has no prime factors, so n-1 ≤ 1
-    rw [omega, Finset.card_eq_zero] at h0
+    have h0' : (n - 1).primeFactors = ∅ := by
+      have hcard : (n - 1).primeFactors.card = 0 := by unfold omega at h0; omega
+      exact Finset.card_eq_zero.mp hcard
     have : n - 1 ≤ 1 := by
       by_contra hgt
       push_neg at hgt
       have hne : n - 1 ≠ 0 := by omega
-      have : (n - 1).minFac ∈ (n - 1).primeFactors := by
+      have hmem : (n - 1).minFac ∈ (n - 1).primeFactors := by
         rw [Nat.mem_primeFactors]
         exact ⟨Nat.minFac_prime (by omega), Nat.minFac_dvd _, hne⟩
-      rw [h0] at this
-      exact Finset.notMem_empty _ this
+      rw [h0'] at hmem
+      exact Finset.notMem_empty _ hmem
     left; omega
   · -- ω(n-1) = 1 means exactly one prime factor
     have h_eq : omega (n - 1) = 1 := by omega
@@ -389,22 +391,26 @@ theorem barrier_pred_is_prime_power_or_one (n : ℕ) (hn : n ≥ 2)
     have hp_mem : p ∈ (n - 1).primeFactors := by rw [hp]; exact Finset.mem_singleton.mpr rfl
     have hp_prime : p.Prime := Nat.prime_of_mem_primeFactors hp_mem
     have hne : n - 1 ≠ 0 := by omega
+    have hp_supp : p ∈ (n - 1).factorization.support := by
+      rw [Nat.support_factorization, hp]; exact Finset.mem_singleton.mpr rfl
     right
     refine ⟨p, (n - 1).factorization p, hp_prime, ?_, ?_⟩
-    · rw [Nat.one_le_iff_ne_zero, Finsupp.mem_support_iff.mp]
-      rw [Nat.support_factorization, hp]
-      exact Finset.mem_singleton.mpr rfl
-    · rw [← Nat.factorization_prod_pow_eq_self hne]
-      rw [Finsupp.prod]
-      rw [Nat.support_factorization, hp]
-      simp
+    · exact Nat.pos_of_ne_zero (Finsupp.mem_support_iff.mp hp_supp)
+    · have h_prod := Nat.factorization_prod_pow_eq_self hne
+      rw [Finsupp.prod, Nat.support_factorization, hp] at h_prod
+      simp at h_prod
+      exact h_prod.symm
 
 -- ## Barrier Spacing Properties
 
-/-- If n ≥ 2 is a barrier and n + 2 is a barrier, then ω(n) ≤ 1 and ω(n+1) ≤ 1 -/
+/-- If n ≥ 2 is a barrier and n + 2 is a barrier, then ω(n) ≤ 2 and ω(n+1) ≤ 1.
+    (Corrected from an original false claim of ω(n) ≤ 1: from n + 2 being a barrier,
+    applying the barrier condition at m = n only yields n + ω(n) ≤ n + 2, i.e. ω(n) ≤ 2 —
+    e.g. n = 6 is a counterexample to the stronger ≤ 1 bound, since ω(6) = 2 while both
+    6 and 8 are ω-barriers. #38611 candidate: unsound-original bound tightened.) -/
 theorem barrier_gap_two (n : ℕ) (hn : n ≥ 2)
     (hb : IsBarrier omega n) (hb2 : IsBarrier omega (n + 2)) :
-    omega n ≤ 1 ∧ omega (n + 1) ≤ 1 := by
+    omega n ≤ 2 ∧ omega (n + 1) ≤ 1 := by
   constructor
   · have := hb2 n (by omega)
     omega
@@ -429,6 +435,7 @@ theorem barrier_succ_iff (n : ℕ) (hn : n ≥ 2) (hb : IsBarrier omega n) :
 theorem barrier_implies_zero_barrier (f : ℕ → ℕ) (n : ℕ) (hb : IsBarrier f n) :
     IsBarrier (fun _ => 0) n := by
   intro m hm
+  dsimp only
   omega
 
 -- ## Why σ (Sum of Divisors) Has No Barriers
@@ -475,6 +482,7 @@ theorem sigma1_no_barriers (n : ℕ) (hn : n ≥ 3) :
 theorem barrier_of_le (f g : ℕ → ℕ) (n : ℕ)
     (hle : ∀ m, g m ≤ f m) (hf : IsBarrier f n) : IsBarrier g n := by
   intro m hm
+  have hlem := hle m
   calc m + g m ≤ m + f m := by omega
     _ ≤ n := hf m hm
 
@@ -495,6 +503,7 @@ theorem no_barriers_of_eventually_large (f : ℕ → ℕ) (N : ℕ)
 theorem barriers_subset_of_le (f g : ℕ → ℕ) (hle : ∀ m, f m ≤ g m) :
     barriers g ⊆ barriers f := by
   intro n hn m hm
+  have hlem := hle m
   calc m + f m ≤ m + g m := by omega
     _ ≤ n := hn m hm
 
@@ -510,9 +519,11 @@ theorem barrier_const_iff (c : ℕ) (n : ℕ) (hn : n ≥ 2) :
     IsBarrier (fun _ => c) n ↔ c ≤ 1 := by
   constructor
   · intro hb
-    have := hb (n - 1) (by omega)
+    have h := hb (n - 1) (by omega)
+    dsimp only at h
     omega
   · intro hc m hm
+    dsimp only
     omega
 
 /-- If f ≤ 1 everywhere, then every n is a barrier for f -/
@@ -529,10 +540,12 @@ theorem barrier_sum_implies_components (f g : ℕ → ℕ) (n : ℕ)
     IsBarrier f n ∧ IsBarrier g n := by
   constructor
   · intro m hm
-    have := hb m hm
+    have h := hb m hm
+    dsimp only at h
     omega
   · intro m hm
-    have := hb m hm
+    have h := hb m hm
+    dsimp only at h
     omega
 
 -- ## Barrier Density Analysis
@@ -583,12 +596,9 @@ theorem iterOmega_strictly_increasing (n : ℕ) (hn : n ≥ 2) :
     n < iterOmega n := by
   unfold iterOmega
   have : omega n ≥ 1 := by
-    have h2 := two_pow_omega_le n (by omega)
     by_contra h
     push_neg at h
     simp [omega] at h
-    rw [Finset.card_eq_zero.mp h] at h2
-    simp at h2
     omega
   omega
 
@@ -597,28 +607,20 @@ noncomputable def orbit (n : ℕ) : ℕ → ℕ
   | 0 => n
   | k + 1 => iterOmega (orbit n k)
 
+/-- The orbit stays above the starting value (helper for monotonicity) -/
+private theorem orbit_ge_start (n : ℕ) (hn : n ≥ 2) (j : ℕ) : n ≤ orbit n j := by
+  induction j with
+  | zero => simp [orbit]
+  | succ j ih =>
+    simp only [orbit]
+    have := iterOmega_strictly_increasing (orbit n j) (by omega)
+    omega
+
 /-- The orbit is monotonically increasing for starting values ≥ 2 -/
 theorem orbit_strictly_increasing (n : ℕ) (hn : n ≥ 2) (k : ℕ) :
     orbit n k < orbit n (k + 1) := by
-  induction k with
-  | zero =>
-    simp [orbit]
-    exact iterOmega_strictly_increasing n hn
-  | succ k ih =>
-    simp only [orbit]
-    apply iterOmega_strictly_increasing
-    calc 2 ≤ n := hn
-      _ = orbit n 0 := by simp [orbit]
-      _ ≤ orbit n (k + 1) := by
-          induction k with
-          | zero => exact Nat.le_of_lt (by simp [orbit]; exact iterOmega_strictly_increasing n hn)
-          | succ k' ih' =>
-            calc orbit n 0 ≤ orbit n (k' + 1) := ih'
-              _ < orbit n (k' + 2) := by
-                  simp only [orbit]
-                  apply iterOmega_strictly_increasing
-                  calc 2 ≤ orbit n 0 := by simp [orbit]; exact hn
-                    _ ≤ orbit n (k' + 1) := ih'
+  simp only [orbit]
+  exact iterOmega_strictly_increasing (orbit n k) (by have := orbit_ge_start n hn k; omega)
 
 /-- If b is a barrier for ω, then any orbit starting from m < b passes through b
     or reaches it: orbit m 1 ≤ b -/

--- a/proofs/Proofs/EulerTotientOQ02OQ02OQ01.lean
+++ b/proofs/Proofs/EulerTotientOQ02OQ02OQ01.lean
@@ -69,19 +69,19 @@ theorem modEq_one_iff_cast_pow {a m : ℕ} :
 This is the number-theoretic shadow of Mathlib's group-level `pow_carmichael`:
 a coprime residue is a unit, and every unit is killed by the group exponent λ(n). -/
 theorem carmichael_modEq {a : ℕ} (h : Nat.Coprime a n) :
-    a ^ Carmichael n ≡ 1 [MOD n] := by
+    a ^ carmichael n ≡ 1 [MOD n] := by
   rw [modEq_one_iff_cast_pow]
   have hu : IsUnit (a : ZMod n) := (ZMod.isUnit_iff_coprime a n).mpr h
   rw [← hu.unit_spec, ← Units.val_pow_eq_pow_val, pow_carmichael, Units.val_one]
 
 /-- **λ(n) is nonzero** (for `n ≠ 0`): the unit group is finite, so its exponent
 is positive. -/
-theorem carmichael_ne_zero [NeZero n] : Carmichael n ≠ 0 := by
+theorem carmichael_ne_zero [NeZero n] : carmichael n ≠ 0 := by
   rw [carmichael_eq_exponent']
   exact Monoid.exponent_ne_zero_of_finite
 
 /-- **λ(n) is positive** (for `n ≠ 0`). -/
-theorem carmichael_pos [NeZero n] : 0 < Carmichael n :=
+theorem carmichael_pos [NeZero n] : 0 < carmichael n :=
   Nat.pos_of_ne_zero carmichael_ne_zero
 
 -- ============================================================
@@ -96,7 +96,7 @@ This is the sharp upgrade of the parent entry, where `φ(n)` is shown to be *one
 universal exponent. Here every universal exponent — `φ(n)` included — is forced
 to be a multiple of `λ(n)`. -/
 theorem carmichael_dvd_iff [NeZero n] {m : ℕ} :
-    Carmichael n ∣ m ↔ ∀ a : ℕ, Nat.Coprime a n → a ^ m ≡ 1 [MOD n] := by
+    carmichael n ∣ m ↔ ∀ a : ℕ, Nat.Coprime a n → a ^ m ≡ 1 [MOD n] := by
   rw [carmichael_eq_exponent']
   constructor
   · -- Multiples of the exponent kill every unit, hence every coprime residue.
@@ -119,7 +119,7 @@ theorem carmichael_dvd_iff [NeZero n] {m : ℕ} :
 
 /-- **Minimality.** Any *positive* universal exponent is `≥ λ(n)`. -/
 theorem carmichael_le_of_universal [NeZero n] {m : ℕ} (hm : 0 < m)
-    (h : ∀ a : ℕ, Nat.Coprime a n → a ^ m ≡ 1 [MOD n]) : Carmichael n ≤ m :=
+    (h : ∀ a : ℕ, Nat.Coprime a n → a ^ m ≡ 1 [MOD n]) : carmichael n ≤ m :=
   Nat.le_of_dvd hm (carmichael_dvd_iff.mpr h)
 
 /-- **λ(n) is the TRUE universal exponent.** It is the *least* element of the set
@@ -128,7 +128,7 @@ divides — hence is `≤` — every other one (`carmichael_le_of_universal`). T
 the precise sense in which λ(n), not φ(n), is the canonical exponent of `ℤ/nℤ`. -/
 theorem carmichael_isLeast_universal [NeZero n] :
     IsLeast {m : ℕ | 0 < m ∧ ∀ a : ℕ, Nat.Coprime a n → a ^ m ≡ 1 [MOD n]}
-      (Carmichael n) := by
+      (carmichael n) := by
   refine ⟨⟨carmichael_pos, fun a ha => carmichael_modEq ha⟩, ?_⟩
   rintro m ⟨hm, h⟩
   exact carmichael_le_of_universal hm h
@@ -140,7 +140,7 @@ theorem carmichael_isLeast_universal [NeZero n] :
 /-- **The order of a unit divides λ(n)** — the group-level refinement, sharper
 than the parent's `orderOf a ∣ φ(n)` because `λ(n) ∣ φ(n)`. -/
 theorem orderOf_unit_dvd_carmichael [NeZero n] (a : (ZMod n)ˣ) :
-    orderOf a ∣ Carmichael n := by
+    orderOf a ∣ carmichael n := by
   rw [carmichael_eq_exponent']
   exact Monoid.order_dvd_exponent a
 
@@ -156,14 +156,14 @@ theorem orderOf_unit_dvd_totient_via_carmichael [NeZero n] (a : (ZMod n)ˣ) :
 reduction modulo `φ(n)`, since `λ(n) ∣ φ(n)`: it is the *smallest* period of the
 sequence `k ↦ a^k (mod n)` guaranteed uniformly over all coprime bases. -/
 theorem pow_mod_carmichael_modEq {a : ℕ} (h : Nat.Coprime a n) (k : ℕ) :
-    a ^ k ≡ a ^ (k % Carmichael n) [MOD n] := by
-  conv_lhs => rw [← Nat.mod_add_div k (Carmichael n)]
-  calc a ^ (k % Carmichael n + Carmichael n * (k / Carmichael n))
-      = a ^ (k % Carmichael n) * (a ^ Carmichael n) ^ (k / Carmichael n) := by
+    a ^ k ≡ a ^ (k % carmichael n) [MOD n] := by
+  conv_lhs => rw [← Nat.mod_add_div k (carmichael n)]
+  calc a ^ (k % carmichael n + carmichael n * (k / carmichael n))
+      = a ^ (k % carmichael n) * (a ^ carmichael n) ^ (k / carmichael n) := by
         rw [pow_add, pow_mul]
-    _ ≡ a ^ (k % Carmichael n) * 1 ^ (k / Carmichael n) [MOD n] :=
+    _ ≡ a ^ (k % carmichael n) * 1 ^ (k / carmichael n) [MOD n] :=
         (Nat.ModEq.refl _).mul ((carmichael_modEq h).pow _)
-    _ = a ^ (k % Carmichael n) := by rw [one_pow, mul_one]
+    _ = a ^ (k % carmichael n) := by rw [one_pow, mul_one]
 
 -- ============================================================
 -- SECTION V: The sharp boundary  λ(n) = φ(n) ⟺ (ℤ/nℤ)ˣ cyclic
@@ -174,7 +174,7 @@ theorem pow_mod_carmichael_modEq {a : ℕ} (h : Nat.Coprime a n) (k : ℕ) :
 whose exponent equals their order, so the Carmichael function collapses onto
 Euler's totient precisely on the moduli with primitive roots. -/
 theorem carmichael_eq_totient_iff_isCyclic [NeZero n] :
-    Carmichael n = n.totient ↔ IsCyclic (ZMod n)ˣ := by
+    carmichael n = n.totient ↔ IsCyclic (ZMod n)ˣ := by
   rw [carmichael_eq_exponent',
     show n.totient = Nat.card (ZMod n)ˣ from by
       rw [← ZMod.card_units_eq_totient, Fintype.card_eq_nat_card]]
@@ -185,8 +185,8 @@ Carmichael function is *strictly* smaller than Euler's totient: `λ(n) < φ(n)`.
 This is why λ, not φ, is the sharp universal exponent — φ is genuinely wasteful
 whenever `n` has no primitive root. -/
 theorem carmichael_lt_totient_of_not_isCyclic [NeZero n]
-    (h : ¬ IsCyclic (ZMod n)ˣ) : Carmichael n < n.totient := by
-  have hne : Carmichael n ≠ n.totient := fun heq =>
+    (h : ¬ IsCyclic (ZMod n)ˣ) : carmichael n < n.totient := by
+  have hne : carmichael n ≠ n.totient := fun heq =>
     h (carmichael_eq_totient_iff_isCyclic.mp heq)
   have hpos : 0 < n.totient := Nat.totient_pos.mpr (Nat.pos_of_ne_zero (NeZero.ne n))
   exact lt_of_le_of_ne
@@ -198,26 +198,26 @@ theorem carmichael_lt_totient_of_not_isCyclic [NeZero n]
 
 /-- **λ(p) = φ(p) at every prime.** The unit group of a prime field is cyclic, so
 the Carmichael function agrees with Euler's totient on primes: `λ(p) = φ(p)`. -/
-theorem carmichael_prime {p : ℕ} (hp : p.Prime) : Carmichael p = p.totient := by
+theorem carmichael_prime {p : ℕ} (hp : p.Prime) : carmichael p = p.totient := by
   rcases eq_or_ne p 2 with rfl | h2
   · simpa using carmichael_two_pow_of_le_two_eq_totient (n := 1) (by norm_num)
   · simpa using carmichael_pow_of_prime_ne_two 1 hp h2
 
 /-- Explicit prime value: `λ(p) = p - 1`. -/
 theorem carmichael_prime_eq_sub_one {p : ℕ} (hp : p.Prime) :
-    Carmichael p = p - 1 := by
+    carmichael p = p - 1 := by
   rw [carmichael_prime hp, Nat.totient_prime hp]
 
 /-- **λ(8) = 2** — strictly below `φ(8) = 4`. The group `(ℤ/8ℤ)ˣ ≅ ℤ/2 × ℤ/2`
 is non-cyclic (`8` has no primitive root), so every unit already squares to `1`. -/
-theorem carmichael_eight : Carmichael 8 = 2 := by
+theorem carmichael_eight : carmichael 8 = 2 := by
   rw [show (8 : ℕ) = 2 ^ 3 by norm_num, carmichael_two_pow_of_ne_two (by norm_num)]
   norm_num
 
 /-- **The witness of strictness.** `λ(8) = 2 < 4 = φ(8)`: the Carmichael function
 genuinely improves on Euler's exponent, obtained here from the abstract
 `carmichael_lt_totient_of_not_isCyclic` and the non-cyclicity of `(ℤ/8ℤ)ˣ`. -/
-theorem carmichael_eight_lt_totient : Carmichael 8 < Nat.totient 8 :=
+theorem carmichael_eight_lt_totient : carmichael 8 < Nat.totient 8 :=
   carmichael_lt_totient_of_not_isCyclic ZMod.not_isCyclic_units_eight
 
 end EulerTotientOQ02OQ02OQ01

--- a/proofs/batch2/STATUS.md
+++ b/proofs/batch2/STATUS.md
@@ -1,3 +1,12 @@
+# DOCTOR SINGLE-PROOF BATCH 47 (5-slot Sonnet + Fable, #38065, 2026-07-16)
+
+**+4 GREEN** (re-verified EXIT=0): Erdos413Problem (#38611: barrier_gap_two claimed ω(n)≤1 FALSE at n=6 ->
+ω(n)≤2; omega no longer auto-specializes ∀-hyps -> have first), EulerTotientOQ02OQ02OQ01 (ArithmeticFunction
+.Carmichael deprecated -> lowercase carmichael), Erdos404Problem (12min: mul_le_mul_right iff gone ->
+le_of_mul_le_mul_right; tendsto_..._le_of_le split strict vs eventually '-variant), Erdos1079Problem (FABLE
+#38611: numEdges over SimpleGraph ℕ needs nonexistent Fintype ℕ -> restated Fin n; SimpleGraph symm/loopless
+-> Std.Symm/Std.Irrefl or comap). Repairs #38611: Erdos413 (ω≤2), Erdos1079 (Fin n). Fable now 4/4 on hard tail.
+
 # DOCTOR SINGLE-PROOF BATCH 46 (Fable experiment greens, #38065, 2026-07-15)
 
 **+2 GREEN, both FABLE-5** (re-verified EXIT=0): Erdos1056Problem (Chain'->IsChain Decidable; List.get+by-omega

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -768,7 +768,7 @@ Erdos1073Problem	GREEN
 Erdos1075Problem	GREEN	
 Erdos1076Problem	GREEN	
 Erdos1078Problem	GREEN
-Erdos1079Problem	RESIDUAL	instance-synth
+Erdos1079Problem	GREEN	
 Erdos107OQ01	RESIDUAL	instance-synth
 Erdos107OQ01KleinUpperAristotle	RESIDUAL	instance-synth
 Erdos1080OQ03	RESIDUAL	type-mismatch
@@ -1225,7 +1225,7 @@ Erdos3Problem	GREEN
 Erdos400Problem	GREEN	
 Erdos402Problem	RESIDUAL	type-mismatch
 Erdos403Problem	GREEN	
-Erdos404Problem	RESIDUAL	rewrite-drift
+Erdos404Problem	GREEN	
 Erdos405Problem	GREEN	
 Erdos407Problem	GREEN	
 Erdos408Problem	GREEN	
@@ -1233,7 +1233,7 @@ Erdos409Problem	PRE-EXISTING	never-compiled:p
 Erdos40Problem	GREEN	
 Erdos410Problem	GREEN	
 Erdos411Problem	GREEN	
-Erdos413Problem	RESIDUAL	rewrite-drift
+Erdos413Problem	GREEN	
 Erdos414Problem	GREEN	
 Erdos415Problem	GREEN	
 Erdos415ProblemAristotle	GREEN	
@@ -1955,7 +1955,7 @@ EulerTotientOQ01OQ02OQ02	GREEN
 EulerTotientOQ01OQ02OQ03	GREEN	
 EulerTotientOQ02	GREEN	
 EulerTotientOQ02OQ01	GREEN	
-EulerTotientOQ02OQ02OQ01	RESIDUAL	rewrite-drift
+EulerTotientOQ02OQ02OQ01	GREEN	
 EulerTotientOQ06OQ02	GREEN	
 FactorRemainderNullstellensatzOQ01	RESIDUAL	instance-synth
 FactorRemainderNullstellensatzOQ02	GREEN	


### PR DESCRIPTION
5-slot Sonnet + Fable. 2 soundness repairs (#38611: Erdos413 ω≤2, Erdos1079 Fin-n). No loom labels.