### PR TITLE
migrate(v4.31): single-proof batch 54 (+3 GREEN, re-verified)

### DIFF
--- a/proofs/Proofs/CantorDiagonalizationOQ01OQ01.lean
+++ b/proofs/Proofs/CantorDiagonalizationOQ01OQ01.lean
@@ -68,7 +68,7 @@ theorem aleph_one_le_continuum : Cardinal.aleph 1 ≤ (2 : Cardinal.{0}) ^ ℵ�
 /-- The aleph hierarchy is strictly increasing. -/
 theorem aleph_strictly_increasing (α β : Ordinal.{0}) (h : α < β) :
     Cardinal.aleph α < Cardinal.aleph β :=
-  Cardinal.aleph_lt.mpr h
+  Cardinal.aleph_lt_aleph.mpr h
 
 /-
 ═══════════════════════════════════════════════════════════════════════════════
@@ -80,26 +80,27 @@ PART II: UNDER CH — NO INTERMEDIATE CARDINAL
     If CH holds (2^ℵ₀ = ℵ₁), then the only cardinals ≤ ℵ₀ are finite cardinals
     and ℵ₀ itself, and the next cardinal is already ℵ₁ = 2^ℵ₀. -/
 theorem ch_no_intermediate (h : CH) :
-    ¬∃ κ : Cardinal.{0}, ℵ₀ < κ ∧ κ < continuum := by
+    ¬∃ κ : Cardinal.{0}, ℵ₀ < κ ∧ κ < ContinuumHypothesis.continuum := by
   intro ⟨κ, hκ₀, hκc⟩
   exact ch_implies_no_intermediate h κ hκ₀ hκc
 
-/-- Under CH, the continuum is the smallest uncountable cardinal. -/
+/-- Under CH, the ContinuumHypothesis.continuum is the smallest uncountable cardinal. -/
 theorem ch_continuum_is_successor (h : CH) :
-    continuum = Order.succ (ℵ₀ : Cardinal.{0}) := by
+    ContinuumHypothesis.continuum = Order.succ (ℵ₀ : Cardinal.{0}) := by
   unfold CH at h
-  unfold continuum aleph_one at h
+  unfold ContinuumHypothesis.continuum aleph_one at h
+  unfold ContinuumHypothesis.continuum
   rw [h]
   rw [show (1 : Ordinal) = Order.succ 0 from by rw [Order.succ_eq_add_one, zero_add],
       Cardinal.aleph_succ, Cardinal.aleph_zero]
 
-/-- Under CH, every uncountable set of reals has the cardinality of the continuum.
+/-- Under CH, every uncountable set of reals has the cardinality of the ContinuumHypothesis.continuum.
     (Since ℵ₁ = 2^ℵ₀, any set of cardinality > ℵ₀ has cardinality ≥ ℵ₁ = 2^ℵ₀.) -/
 theorem ch_uncountable_sets (h : CH) (κ : Cardinal.{0})
-    (hκ : ℵ₀ < κ) (hle : κ ≤ continuum) :
-    κ = continuum := by
+    (hκ : ℵ₀ < κ) (hle : κ ≤ ContinuumHypothesis.continuum) :
+    κ = ContinuumHypothesis.continuum := by
   by_contra hne
-  have hlt : κ < continuum := lt_of_le_of_ne hle hne
+  have hlt : κ < ContinuumHypothesis.continuum := lt_of_le_of_ne hle hne
   exact ch_implies_no_intermediate h κ hκ hlt
 
 /-
@@ -112,25 +113,25 @@ PART III: UNDER ¬CH — EXPLICIT INTERMEDIATE CARDINALS
     If ¬CH, then 2^ℵ₀ ≠ ℵ₁, hence 2^ℵ₀ > ℵ₁ (since ℵ₁ ≤ 2^ℵ₀ always).
     Therefore ℵ₀ < ℵ₁ < 2^ℵ₀, giving an explicit intermediate cardinal. -/
 theorem not_ch_has_intermediate (h : ¬CH) :
-    ∃ κ : Cardinal.{0}, ℵ₀ < κ ∧ κ < continuum := by
+    ∃ κ : Cardinal.{0}, ℵ₀ < κ ∧ κ < ContinuumHypothesis.continuum := by
   use Cardinal.aleph 1
   constructor
   · exact aleph_one_gt_aleph_zero
-  · -- ¬CH means continuum ≠ aleph_one
-    unfold CH continuum aleph_one at h
+  · -- ¬CH means ContinuumHypothesis.continuum ≠ aleph_one
+    unfold CH ContinuumHypothesis.continuum aleph_one at h
     have hle : Cardinal.aleph 1 ≤ (2 : Cardinal) ^ ℵ₀ := aleph_one_le_continuum
     exact lt_of_le_of_ne hle (Ne.symm h)
 
 /-- Under ¬CH, if 2^ℵ₀ > ℵ₂, then both ℵ₁ and ℵ₂ are intermediate cardinals.
-    (If 2^ℵ₀ = ℵ₂, then ℵ₂ = continuum so it is not strictly intermediate.) -/
+    (If 2^ℵ₀ = ℵ₂, then ℵ₂ = ContinuumHypothesis.continuum so it is not strictly intermediate.) -/
 theorem not_ch_multiple_intermediates (h : ¬CH)
     (h2 : Cardinal.aleph 2 < (2 : Cardinal.{0}) ^ ℵ₀) :
     ∃ κ₁ κ₂ : Cardinal.{0},
-      ℵ₀ < κ₁ ∧ κ₁ < κ₂ ∧ κ₂ < continuum := by
+      ℵ₀ < κ₁ ∧ κ₁ < κ₂ ∧ κ₂ < ContinuumHypothesis.continuum := by
   use Cardinal.aleph 1, Cardinal.aleph 2
   refine ⟨aleph_one_gt_aleph_zero, ?_, ?_⟩
   · exact aleph_strictly_increasing 1 2 (by norm_num)
-  · unfold continuum; exact h2
+  · unfold ContinuumHypothesis.continuum; exact h2
 
 /-
 ═══════════════════════════════════════════════════════════════════════════════
@@ -146,14 +147,14 @@ PART IV: THE INDEPENDENCE RESULT
     This is the definitive answer to the open question. -/
 theorem intermediate_cardinal_independent :
     -- If CH, then no intermediate
-    (CH → ¬∃ κ : Cardinal.{0}, ℵ₀ < κ ∧ κ < continuum) ∧
+    (CH → ¬∃ κ : Cardinal.{0}, ℵ₀ < κ ∧ κ < ContinuumHypothesis.continuum) ∧
     -- If ¬CH, then ℵ₁ is intermediate
-    (¬CH → ∃ κ : Cardinal.{0}, ℵ₀ < κ ∧ κ < continuum) := by
+    (¬CH → ∃ κ : Cardinal.{0}, ℵ₀ < κ ∧ κ < ContinuumHypothesis.continuum) := by
   exact ⟨ch_no_intermediate, not_ch_has_intermediate⟩
 
 /-- The question "is there κ between ℵ₀ and 2^ℵ₀?" is equivalent to ¬CH. -/
 theorem intermediate_iff_not_ch :
-    (∃ κ : Cardinal.{0}, ℵ₀ < κ ∧ κ < continuum) ↔ ¬CH := by
+    (∃ κ : Cardinal.{0}, ℵ₀ < κ ∧ κ < ContinuumHypothesis.continuum) ↔ ¬CH := by
   constructor
   · intro ⟨κ, hκ₀, hκc⟩ hch
     exact ch_implies_no_intermediate hch κ hκ₀ hκc
@@ -168,10 +169,10 @@ PART V: KÖNIG'S CONSTRAINT — WHAT VALUES CAN 2^ℵ₀ TAKE?
     In other words, 2^ℵ₀ ≠ ℵ_ω (and more generally, 2^ℵ₀ ≠ any cardinal
     of countable cofinality).
 
-    This is the strongest ZFC-provable constraint on the value of the continuum.
+    This is the strongest ZFC-provable constraint on the value of the ContinuumHypothesis.continuum.
 
     Stated as: if 2^ℵ₀ = ℵ_α, then cf(ℵ_α) > ℵ₀.
-    Equivalently: the continuum is not the supremum of countably many smaller cardinals. -/
+    Equivalently: the ContinuumHypothesis.continuum is not the supremum of countably many smaller cardinals. -/
 def KonigConstraint : Prop :=
   ∀ α : Ordinal.{0}, (2 : Cardinal.{0}) ^ ℵ₀ = Cardinal.aleph α →
     (Cardinal.aleph α).ord.cof > ℵ₀
@@ -240,17 +241,19 @@ PART VII: CHARACTERIZATION THEOREMS
     This is the definitive answer to the research question. -/
 theorem complete_answer :
     -- (1) Equivalent to ¬CH
-    ((∃ κ : Cardinal.{0}, ℵ₀ < κ ∧ κ < continuum) ↔ ¬CH) ∧
+    ((∃ κ : Cardinal.{0}, ℵ₀ < κ ∧ κ < ContinuumHypothesis.continuum) ↔ ¬CH) ∧
     -- (2) Both CH and ¬CH are consistent with ZFC
     (RelativelyConsistent CH ∧ RelativelyConsistent (¬CH)) ∧
     -- (3) Under ¬CH, ℵ₁ is an explicit intermediate
-    (¬CH → Cardinal.aleph 1 < continuum ∧ (ℵ₀ : Cardinal.{0}) < Cardinal.aleph 1) := by
+    (¬CH → Cardinal.aleph 1 < ContinuumHypothesis.continuum ∧ (ℵ₀ : Cardinal.{0}) < Cardinal.aleph 1) := by
   refine ⟨intermediate_iff_not_ch, ⟨ch_consistent_with_zfc, not_ch_consistent_with_zfc⟩, ?_⟩
   intro h
   constructor
-  · have ⟨κ, hκ₀, hκc⟩ := not_ch_has_intermediate h
-    -- κ = ℵ₁ in the proof of not_ch_has_intermediate
-    exact (not_ch_has_intermediate h).choose_spec.2
+  · -- Same argument as in `not_ch_has_intermediate`, inlined to avoid relying on
+    -- `Exists.choose` being defeq to the witness `Cardinal.aleph 1`.
+    have hle : Cardinal.aleph 1 ≤ (2 : Cardinal) ^ ℵ₀ := aleph_one_le_continuum
+    unfold CH ContinuumHypothesis.continuum aleph_one at h
+    exact lt_of_le_of_ne hle (Ne.symm h)
   · exact aleph_one_gt_aleph_zero
 
 /-
@@ -275,7 +278,7 @@ theorem gch_no_intermediates_anywhere (h : GCH) (α : Ordinal.{0}) :
 /-- Under ¬GCH, some intermediate cardinals must exist.
     Since GCH → CH, ¬CH → ¬GCH. And ¬CH gives intermediate cardinals. -/
 theorem not_gch_from_intermediate
-    (h : ∃ κ : Cardinal.{0}, ℵ₀ < κ ∧ κ < continuum) : ¬GCH := by
+    (h : ∃ κ : Cardinal.{0}, ℵ₀ < κ ∧ κ < ContinuumHypothesis.continuum) : ¬GCH := by
   intro hgch
   have hch := gch_implies_ch hgch
   exact (intermediate_iff_not_ch.mp h) hch

--- a/proofs/Proofs/Erdos476OQ05Aristotle.lean
+++ b/proofs/Proofs/Erdos476OQ05Aristotle.lean
@@ -42,7 +42,7 @@ If some b₀ ∈ B is "non-redundant" (removing it decreases the sumset),
 lemma non_redundant_b_gives_a (A B : Finset (ZMod p)) (b₀ : ZMod p) (hb₀ : b₀ ∈ B)
     (hA : 2 ≤ A.card) (hB : 2 ≤ B.card)
     (h : (A + B).card = A.card + B.card - 1)
-    (hlt : A.card + B.card < p)
+    (hlt : A.card + B.card ≤ p)
     (hcard : (A + B.erase b₀).card = A.card + B.card - 2) :
     ∃ a₀ ∈ A, ((A.erase a₀) + B).card = A.card + B.card - 2 := by
   -- Since A + B = (A + B.erase b₀) ∪ (A + {b₀}) and the sets differ by 1 in cardinality, there is exactly 1 element y in (A + {b₀}) \ (A + B.erase b₀).
@@ -158,7 +158,7 @@ lemma case1_exists (A B : Finset (ZMod p))
     have hlo := erase_add_card_ge A B a haA (by omega) (by omega) (by omega)
     have hhi := erase_add_card_le A B a
     rw [h] at hhi
-    exact Nat.le_antisymm (by omega) (by exact (hall a haA).symm ▸ by omega)
+    exact Nat.le_antisymm (by omega) (by have := hall a haA; omega)
   -- All b ∈ B are also redundant (by non_redundant_b_gives_a contrapositive)
   have hredB : ∀ b ∈ B, (A + (B.erase b)).card = A.card + B.card - 1 := by
     intro b hbB
@@ -171,7 +171,7 @@ lemma case1_exists (A B : Finset (ZMod p))
       skip
       omega
     have hhi : (A + (B.erase b)).card ≤ A.card + B.card - 1 := by
-      have := Finset.card_le_card (Finset.add_subset_add_left (Finset.erase_subset b B))
+      have := Finset.card_le_card (Finset.add_subset_add_left (s := A) (Finset.erase_subset b B))
       omega
     by_contra hne
     have hcard : (A + B.erase b).card = A.card + B.card - 2 := by omega
@@ -199,7 +199,7 @@ lemma case1_exists (A B : Finset (ZMod p))
       rw [hB_eq, Finset.mem_insert, Finset.mem_singleton] at hb'B
       rcases hb'B with rfl | rfl
       · exact absurd (add_right_cancel heq) ha'er.1
-      · have ha'_val : a' = a + (b₁ - b₂) := by linear_combination heq
+      · have ha'_val : a' = a + (b₁ - b') := by linear_combination heq
         rw [← ha'_val]; exact ha'er.2
     obtain ⟨a₀, ha₀A⟩ := Finset.card_pos.mp (by omega : 0 < A.card)
     have horbit_nat : ∀ k : ℕ, a₀ + (k : ZMod p) * (b₁ - b₂) ∈ A := by
@@ -230,7 +230,7 @@ lemma case1_exists (A B : Finset (ZMod p))
       have hpos : 0 < (A.filter (fun a => x - a ∈ B)).card := by
         obtain ⟨a, haA, b, hbB, hxab⟩ := Finset.mem_add.mp hx
         exact Finset.card_pos.mpr ⟨a, Finset.mem_filter.mpr
-          ⟨haA, show x - a ∈ B by rw [show x - a = b from (eq_sub_of_add_eq hxab).symm]; exact hbB⟩⟩
+          ⟨haA, show x - a ∈ B by rw [show x - a = b by linear_combination -hxab]; exact hbB⟩⟩
       have hcard1 : (A.filter (fun a => x - a ∈ B)).card = 1 := by omega
       obtain ⟨a₁, ha₁⟩ := Finset.card_eq_one.mp hcard1
       have ha₁A : a₁ ∈ A := (Finset.mem_filter.mp (ha₁ ▸ Finset.mem_singleton_self a₁)).1
@@ -239,7 +239,8 @@ lemma case1_exists (A B : Finset (ZMod p))
         obtain ⟨a', ha'er, b', hb'B, hsum'⟩ := Finset.mem_add.mp hcontra
         rw [Finset.mem_erase] at ha'er
         have ha'filt : a' ∈ A.filter (fun a => x - a ∈ B) :=
-          Finset.mem_filter.mpr ⟨ha'er.2, (eq_sub_of_add_eq hsum') ▸ hb'B⟩
+          Finset.mem_filter.mpr
+            ⟨ha'er.2, by rw [show x - a' = b' by linear_combination -hsum']; exact hb'B⟩
         rw [ha₁] at ha'filt
         exact ha'er.1 (Finset.mem_singleton.mp ha'filt)
       exact hxnotin (hredA_eq a₁ ha₁A ▸ hx)

--- a/proofs/Proofs/Erdos8Problem.lean
+++ b/proofs/Proofs/Erdos8Problem.lean
@@ -146,6 +146,121 @@ def hough_counterexample_coloring_exists : Prop :=
     (∀ n : ℕ, n < 10^18 → ∀ m : ℕ, m < 10^18 → n ≠ m → c n ≠ c m) ∧
     ∀ cs : CoveringSystem, cs.hasDistinctModuli → ¬cs.hasMonochromaticModuli c
 
+/- ## Why the Counterexample Works
+
+**Key Insight**:
+
+Hough's minimum modulus bound implies that covering systems have a specific
+structure: they must "start small." This creates a bottleneck:
+
+1. Any covering system must include at least one modulus ≤ 616,000
+2. With finitely many colors, we can color small numbers distinctly
+3. The small moduli form a sparse set (at most 616,000 values)
+4. A carefully constructed coloring avoids monochromatic modulus sets
+
+The bound 10^18 >> 616,000 ensures we have enough distinct colors for all
+possible small covering system moduli while keeping them non-monochromatic.
+-/
+
+/--
+A single congruence class with modulus ≥ 2 cannot cover all integers.
+The integer `residue + 1` is not congruent to `residue` mod any modulus ≥ 2.
+-/
+theorem single_class_not_covering (c : CongruenceClass) :
+    ∃ x : ℤ, x ∉ c.toSet := by
+  refine ⟨↑c.residue + 1, ?_⟩
+  simp only [CongruenceClass.toSet, mem_setOf_eq]
+  intro h
+  have hdvd : (c.modulus : ℤ) ∣ ((↑c.residue + 1 : ℤ) - (c.residue : ℤ)) := h.symm.dvd
+  have heq : ((↑c.residue : ℤ) + 1) - (c.residue : ℤ) = 1 := by ring
+  rw [heq] at hdvd
+  have h2 : (c.modulus : ℤ) ≤ 1 := Int.le_of_dvd one_pos hdvd
+  have hm := c.modulus_pos
+  omega
+
+/-- A covering system with distinct moduli has at least 2 congruence classes.
+    A single class with modulus ≥ 2 cannot cover all integers. -/
+theorem covering_distinct_has_ge_two_classes (cs : CoveringSystem)
+    (_ : cs.hasDistinctModuli) : cs.classes.length ≥ 2 := by
+  by_contra h
+  push_neg at h
+  have hn := cs.nonempty
+  have hlen : cs.classes.length = 1 := by omega
+  obtain ⟨c, hc⟩ := List.length_eq_one_iff.mp hlen
+  obtain ⟨x, hx⟩ := single_class_not_covering (cs.classes.head (by simp [hc]))
+  obtain ⟨c', hc', hcov⟩ := cs.covers x
+  rw [hc, List.mem_singleton] at hc'
+  subst hc'
+  exact hx (by simpa [hc] using hcov)
+
+/-- A covering system with distinct moduli has at least 2 distinct moduli. -/
+theorem covering_distinct_moduli_card_ge_two (cs : CoveringSystem)
+    (hd : cs.hasDistinctModuli) : cs.moduli.card ≥ 2 := by
+  have hlen := covering_distinct_has_ge_two_classes cs hd
+  unfold CoveringSystem.moduli CoveringSystem.hasDistinctModuli at *
+  rw [List.toFinset_card_of_nodup hd, List.length_map]
+  exact hlen
+
+/-- The minimum modulus is a member of the moduli finset. -/
+theorem CoveringSystem.minModulus_mem (cs : CoveringSystem) :
+    cs.minModulus ∈ cs.moduli :=
+  Finset.min'_mem _ _
+
+/--
+**Bottleneck argument (PROVED — was axiom):**
+The minimum modulus bound allows constructing colorings that avoid
+monochromatic covering moduli.
+
+**Proof**: Color each n ≤ 616000 with its own color (color n),
+and all n > 616000 with color 0. Any covering system must include
+a modulus m₁ ≤ 616000 (by the bound) and at least one other distinct
+modulus m₂. If m₂ ≤ 616000, color(m₂) = m₂ ≠ m₁ = color(m₁).
+If m₂ > 616000, color(m₂) = 0 ≠ m₁ (since m₁ ≥ 2).
+-/
+theorem bottleneck_counterexample :
+    (∀ cs : CoveringSystem, cs.hasDistinctModuli → cs.minModulus ≤ 616000) →
+    ∃ k : ℕ, k ≥ 2 ∧ ∃ c : Coloring k,
+      ∀ cs : CoveringSystem, cs.hasDistinctModuli → ¬cs.hasMonochromaticModuli c := by
+  intro hbound
+  refine ⟨616001, by omega, fun n => if h : n ≤ 616000 then ⟨n, by omega⟩ else ⟨0, by omega⟩, ?_⟩
+  intro cs hd ⟨color, hcolor⟩
+  set m₁ := cs.minModulus with hm₁_def
+  have hm₁_mem : m₁ ∈ cs.moduli := cs.minModulus_mem
+  have hm₁_le : m₁ ≤ 616000 := hbound cs hd
+  -- m₁ ≥ 2 (all congruence classes have modulus ≥ 2)
+  have hm₁_ge : m₁ ≥ 2 := by
+    have hmem2 : m₁ ∈ cs.moduli := hm₁_mem
+    simp only [CoveringSystem.moduli, List.mem_toFinset, List.mem_map] at hmem2
+    obtain ⟨cc, _, hcc⟩ := hmem2
+    rw [← hcc]; exact cc.modulus_pos
+  -- Color of m₁ = ⟨m₁, _⟩
+  have hcm₁ : (fun n => if h : n ≤ 616000 then (⟨n, by omega⟩ : Fin 616001)
+      else ⟨0, by omega⟩) m₁ = ⟨m₁, by omega⟩ := by simp [hm₁_le]
+  have hm₁_color := hcolor m₁ hm₁_mem
+  rw [hcm₁] at hm₁_color
+  -- There exists another modulus m₂ ≠ m₁ (≥ 2 distinct moduli)
+  have hcard := covering_distinct_moduli_card_ge_two cs hd
+  obtain ⟨m₂, hm₂_mem, hm₂_ne⟩ : ∃ m₂ ∈ cs.moduli, m₂ ≠ m₁ := by
+    by_contra h; push_neg at h
+    have : cs.moduli ⊆ {m₁} := fun x hx => Finset.mem_singleton.mpr (h x hx)
+    have := Finset.card_le_card this; simp at this; omega
+  have hm₂_color := hcolor m₂ hm₂_mem
+  by_cases hm₂_le : m₂ ≤ 616000
+  · -- m₂ ≤ 616000: color(m₂) = ⟨m₂, _⟩ ≠ ⟨m₁, _⟩
+    have hcm₂ : (fun n => if h : n ≤ 616000 then (⟨n, by omega⟩ : Fin 616001)
+        else ⟨0, by omega⟩) m₂ = ⟨m₂, by omega⟩ := by simp [hm₂_le]
+    rw [hcm₂] at hm₂_color
+    have : m₁ = m₂ := Fin.val_eq_of_eq (hm₁_color.trans hm₂_color.symm)
+    exact hm₂_ne this.symm
+  · -- m₂ > 616000: color(m₂) = ⟨0, _⟩ ≠ ⟨m₁, _⟩ (since m₁ ≥ 2)
+    push_neg at hm₂_le
+    have hcm₂ : (fun n => if h : n ≤ 616000 then (⟨n, by omega⟩ : Fin 616001)
+        else ⟨0, by omega⟩) m₂ = ⟨0, by omega⟩ := by
+      simp [show ¬(m₂ ≤ 616000) by omega]
+    rw [hcm₂] at hm₂_color
+    have : m₁ = 0 := Fin.val_eq_of_eq (hm₁_color.trans hm₂_color.symm)
+    omega
+
 /--
 **Resolution of Erdős Problem 8** (PROVED — was axiom):
 The Erdős-Graham conjecture is FALSE.
@@ -189,116 +304,6 @@ def density_conjecture : Prop :=
 
 /-- The density conjecture is false. -/
 axiom density_conjecture_false : ¬density_conjecture
-
-/- ## Why the Counterexample Works
-
-**Key Insight**:
-
-Hough's minimum modulus bound implies that covering systems have a specific
-structure: they must "start small." This creates a bottleneck:
-
-1. Any covering system must include at least one modulus ≤ 616,000
-2. With finitely many colors, we can color small numbers distinctly
-3. The small moduli form a sparse set (at most 616,000 values)
-4. A carefully constructed coloring avoids monochromatic modulus sets
-
-The bound 10^18 >> 616,000 ensures we have enough distinct colors for all
-possible small covering system moduli while keeping them non-monochromatic.
--/
-
-/--
-A single congruence class with modulus ≥ 2 cannot cover all integers.
-The integer `residue + 1` is not congruent to `residue` mod any modulus ≥ 2.
--/
-theorem single_class_not_covering (c : CongruenceClass) :
-    ∃ x : ℤ, x ∉ c.toSet := by
-  use ↑c.residue + 1
-  simp only [CongruenceClass.toSet, mem_setOf_eq, Int.ModEq]
-  have hm := c.modulus_pos  -- modulus ≥ 2
-  have hr := c.residue_valid  -- residue < modulus
-  omega
-
-/-- A covering system with distinct moduli has at least 2 congruence classes.
-    A single class with modulus ≥ 2 cannot cover all integers. -/
-theorem covering_distinct_has_ge_two_classes (cs : CoveringSystem)
-    (_ : cs.hasDistinctModuli) : cs.classes.length ≥ 2 := by
-  by_contra h
-  push_neg at h
-  have hlen : cs.classes.length = 1 := by omega
-  obtain ⟨c, hc⟩ := List.length_eq_one.mp hlen
-  obtain ⟨x, hx⟩ := single_class_not_covering (cs.classes.head (by simp [hc]))
-  obtain ⟨c', hc', hcov⟩ := cs.covers x
-  rw [hc, List.mem_singleton] at hc'
-  subst hc'
-  exact hx (by rwa [List.head_cons] at hcov)
-
-/-- A covering system with distinct moduli has at least 2 distinct moduli. -/
-theorem covering_distinct_moduli_card_ge_two (cs : CoveringSystem)
-    (hd : cs.hasDistinctModuli) : cs.moduli.card ≥ 2 := by
-  have hlen := covering_distinct_has_ge_two_classes cs hd
-  unfold CoveringSystem.moduli CoveringSystem.hasDistinctModuli at *
-  rw [List.toFinset_card_of_nodup hd]
-  exact hlen
-
-/-- The minimum modulus is a member of the moduli finset. -/
-theorem CoveringSystem.minModulus_mem (cs : CoveringSystem) :
-    cs.minModulus ∈ cs.moduli :=
-  Finset.min'_mem _ _
-
-/--
-**Bottleneck argument (PROVED — was axiom):**
-The minimum modulus bound allows constructing colorings that avoid
-monochromatic covering moduli.
-
-**Proof**: Color each n ≤ 616000 with its own color (color n),
-and all n > 616000 with color 0. Any covering system must include
-a modulus m₁ ≤ 616000 (by the bound) and at least one other distinct
-modulus m₂. If m₂ ≤ 616000, color(m₂) = m₂ ≠ m₁ = color(m₁).
-If m₂ > 616000, color(m₂) = 0 ≠ m₁ (since m₁ ≥ 2).
--/
-theorem bottleneck_counterexample :
-    (∀ cs : CoveringSystem, cs.hasDistinctModuli → cs.minModulus ≤ 616000) →
-    ∃ k : ℕ, k ≥ 2 ∧ ∃ c : Coloring k,
-      ∀ cs : CoveringSystem, cs.hasDistinctModuli → ¬cs.hasMonochromaticModuli c := by
-  intro hbound
-  refine ⟨616001, by omega, fun n => if h : n ≤ 616000 then ⟨n, by omega⟩ else ⟨0, by omega⟩, ?_⟩
-  intro cs hd ⟨color, hcolor⟩
-  set m₁ := cs.minModulus with hm₁_def
-  have hm₁_mem : m₁ ∈ cs.moduli := cs.minModulus_mem
-  have hm₁_le : m₁ ≤ 616000 := hbound cs hd
-  -- m₁ ≥ 2 (all congruence classes have modulus ≥ 2)
-  have hm₁_ge : m₁ ≥ 2 := by
-    have hmem := Finset.min'_mem cs.moduli _
-    simp only [CoveringSystem.moduli, List.mem_toFinset, List.mem_map] at hmem
-    obtain ⟨c, _, hc⟩ := hmem
-    rw [← hm₁_def, ← hc]; exact c.modulus_pos
-  -- Color of m₁ = ⟨m₁, _⟩
-  have hcm₁ : (fun n => if h : n ≤ 616000 then (⟨n, by omega⟩ : Fin 616001)
-      else ⟨0, by omega⟩) m₁ = ⟨m₁, by omega⟩ := by simp [hm₁_le]
-  have hm₁_color := hcolor m₁ hm₁_mem
-  rw [hcm₁] at hm₁_color
-  -- There exists another modulus m₂ ≠ m₁ (≥ 2 distinct moduli)
-  have hcard := covering_distinct_moduli_card_ge_two cs hd
-  obtain ⟨m₂, hm₂_mem, hm₂_ne⟩ : ∃ m₂ ∈ cs.moduli, m₂ ≠ m₁ := by
-    by_contra h; push_neg at h
-    have : cs.moduli ⊆ {m₁} := fun x hx => Finset.mem_singleton.mpr (h x hx)
-    have := Finset.card_le_card this; simp at this; omega
-  have hm₂_color := hcolor m₂ hm₂_mem
-  by_cases hm₂_le : m₂ ≤ 616000
-  · -- m₂ ≤ 616000: color(m₂) = ⟨m₂, _⟩ ≠ ⟨m₁, _⟩
-    have hcm₂ : (fun n => if h : n ≤ 616000 then (⟨n, by omega⟩ : Fin 616001)
-        else ⟨0, by omega⟩) m₂ = ⟨m₂, by omega⟩ := by simp [hm₂_le]
-    rw [hcm₂] at hm₂_color
-    have : m₁ = m₂ := Fin.val_eq_of_eq (hm₂_color.symm.trans hm₁_color)
-    exact hm₂_ne this.symm
-  · -- m₂ > 616000: color(m₂) = ⟨0, _⟩ ≠ ⟨m₁, _⟩ (since m₁ ≥ 2)
-    push_neg at hm₂_le
-    have hcm₂ : (fun n => if h : n ≤ 616000 then (⟨n, by omega⟩ : Fin 616001)
-        else ⟨0, by omega⟩) m₂ = ⟨0, by omega⟩ := by
-      simp [show ¬(m₂ ≤ 616000) by omega]
-    rw [hcm₂] at hm₂_color
-    have : m₁ = 0 := Fin.val_eq_of_eq (hm₂_color.symm.trans hm₁_color)
-    omega
 
 /- ## Summary
 

--- a/proofs/batch2/STATUS.md
+++ b/proofs/batch2/STATUS.md
@@ -1,3 +1,10 @@
+# DOCTOR SINGLE-PROOF BATCH 54 (5-slot Sonnet + Fable, #38065, 2026-07-16)
+
+**+3 GREEN** (re-verified EXIT=0): CantorDiagonalizationOQ01OQ01 (Cardinal.aleph_lt->aleph_lt_aleph; bare
+continuum ambiguous vs Cardinal.continuum -> qualify), Erdos8Problem (forward-ref reorder; List.length_eq_one->
+_iff; Int.ModEq keep .dvd/.symm not omega-on-unfold), Erdos476OQ05Aristotle (weakened non_redundant_b_gives_a
+hlt A.card+B.card<p -> ≤p, legitimate Vosper boundary; linear_combination for orientation). Repairs: none.
+
 # DOCTOR SINGLE-PROOF BATCH 53 (5-slot Sonnet + Fable, #38065, 2026-07-16)
 
 **+2 GREEN** (re-verified EXIT=0): MotivicFlagMapsPartialFlags (@[reducible] on private K0Var-instance defs

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -317,7 +317,7 @@ BuffonsNoodleOQ02	GREEN
 BuffonsNoodleOQ03OQ01	GREEN	
 BurnsideCountingOQ03Aristotle	GREEN	
 BurnsideCountingOQ03OQ03	GREEN	
-CantorDiagonalizationOQ01OQ01	RESIDUAL	unknown-const:Cardinal.aleph_lt.mpr
+CantorDiagonalizationOQ01OQ01	GREEN	
 CantorDiagonalizationOQ01OQ01OQ02	RESIDUAL	type-mismatch
 CantorDiagonalizationOQ01OQ01OQ02OQ01	GREEN	
 CantorDiagonalizationOQ01OQ01OQ02OQ01Phase3b	GREEN	
@@ -1305,7 +1305,7 @@ Erdos473Problem	GREEN
 Erdos474Problem	GREEN	
 Erdos475Problem	GREEN	
 Erdos476Aristotle	GREEN	
-Erdos476OQ05Aristotle	RESIDUAL	unknown-const:b₂
+Erdos476OQ05Aristotle	GREEN	
 Erdos476OQ05Problem	GREEN	
 Erdos476Problem	PRE-EXISTING	never-compiled:B
 Erdos477Problem	GREEN	unknown-const:Set.Finite.of_not_infinite
@@ -1826,7 +1826,7 @@ Erdos895ProblemAristotle	GREEN
 Erdos896Problem	GREEN	
 Erdos89Problem	GREEN	
 Erdos8OQ02	GREEN	
-Erdos8Problem	RESIDUAL	unknown-const:bottleneck_counterexample
+Erdos8Problem	GREEN	
 Erdos900Problem	GREEN	
 Erdos901Aristotle	GREEN	
 Erdos901Problem	GREEN	


### PR DESCRIPTION
5-slot Sonnet + Fable. No loom labels.