### PR TITLE
migrate(v4.31): batch 58 (+4 GREEN + Bezout reclassify)

### DIFF
--- a/proofs/Proofs/CauchySchwarzIntegralOQ01OQ03OQ01.lean
+++ b/proofs/Proofs/CauchySchwarzIntegralOQ01OQ03OQ01.lean
@@ -53,7 +53,7 @@ private lemma eLpNorm_ofReal_eq {p : ℝ} (hp : 0 < p)
     eLpNorm f (ENNReal.ofReal p) μ =
     (∫⁻ a, ‖f a‖ₑ ^ p ∂μ) ^ (1 / p) := by
   have h0 : (ENNReal.ofReal p) ≠ 0 := (ENNReal.ofReal_pos.mpr hp).ne'
-  rw [eLpNorm_eq_lintegral_rpow_enorm h0 ENNReal.ofReal_ne_top,
+  rw [eLpNorm_eq_lintegral_rpow_enorm_toReal h0 ENNReal.ofReal_ne_top,
       ENNReal.toReal_ofReal hp.le]
 
 -- ============================================================================
@@ -70,20 +70,19 @@ private lemma eLpNorm_ofReal_eq {p : ℝ} (hp : 0 < p)
     Proof: Bridge via `eLpNorm_ofReal_eq` to the lintegral form, then apply
     `ENNReal.lintegral_mul_le_Lp_mul_Lq` after factoring `nnnorm_mul`. -/
 theorem holder_normedField_eLpNorm
-    {𝕜 : Type*} [NormedField 𝕜]
+    {𝕜 : Type*} [NormedField 𝕜] [MeasurableSpace 𝕜] [OpensMeasurableSpace 𝕜]
     {p q : ℝ} (hpq : Real.HolderConjugate p q)
     {f g : α → 𝕜} (hf : AEMeasurable f μ) (hg : AEMeasurable g μ) :
     eLpNorm (fun a => f a * g a) 1 μ ≤
     eLpNorm f (ENNReal.ofReal p) μ * eLpNorm g (ENNReal.ofReal q) μ := by
   -- Bridge eLpNorm to lintegral form
-  rw [eLpNorm_one_eq_lintegral_nnnorm,
+  rw [eLpNorm_one_eq_lintegral_enorm,
       eLpNorm_ofReal_eq hpq.pos,
       eLpNorm_ofReal_eq hpq.symm.pos]
-  -- Factor nnnorm via NormedField multiplicativity: ‖fg‖₊ = ‖f‖₊ · ‖g‖₊
-  simp_rw [nnnorm_mul, ENNReal.coe_mul]
-  -- Apply ENNReal Hölder (‖·‖ₑ = (‖·‖₊ : ℝ≥0∞) definitionally, exact closes)
-  exact ENNReal.lintegral_mul_le_Lp_mul_Lq μ hpq
-    hf.nnnorm.coe_nnreal_ennreal hg.nnnorm.coe_nnreal_ennreal
+  -- Factor enorm via NormedField multiplicativity: ‖fg‖ₑ = ‖f‖ₑ · ‖g‖ₑ
+  simp_rw [enorm_mul]
+  -- Apply ENNReal Hölder
+  exact ENNReal.lintegral_mul_le_Lp_mul_Lq μ hpq hf.enorm hg.enorm
 
 -- ============================================================================
 -- Part 3: Product Membership in L1 — the Practical Consequence
@@ -95,7 +94,7 @@ theorem holder_normedField_eLpNorm
     This is the most directly useful consequence of Hölder's inequality:
     the product of an Lp and Lq function is integrable. -/
 theorem memLp_mul_of_memLp_ofReal
-    {𝕜 : Type*} [NormedField 𝕜]
+    {𝕜 : Type*} [NormedField 𝕜] [MeasurableSpace 𝕜] [BorelSpace 𝕜]
     {p q : ℝ} (hpq : Real.HolderConjugate p q)
     {f g : α → 𝕜}
     (hf : MemLp f (ENNReal.ofReal p) μ) (hg : MemLp g (ENNReal.ofReal q) μ) :
@@ -104,7 +103,7 @@ theorem memLp_mul_of_memLp_ofReal
   calc eLpNorm (fun a => f a * g a) 1 μ
       ≤ eLpNorm f (ENNReal.ofReal p) μ * eLpNorm g (ENNReal.ofReal q) μ :=
           holder_normedField_eLpNorm hpq hf.1.aemeasurable hg.1.aemeasurable
-      _ < ∞ := ENNReal.mul_lt_top hf.2.ne hg.2.ne
+      _ < ∞ := ENNReal.mul_lt_top hf.2 hg.2
 
 -- ============================================================================
 -- Part 4: Real and Complex Specializations

--- a/proofs/Proofs/ContinuumHypothesisOQ02.lean
+++ b/proofs/Proofs/ContinuumHypothesisOQ02.lean
@@ -60,6 +60,7 @@ set_option linter.unusedTactic false
 namespace ContinuumHypothesisOQ02
 
 open Cardinal ContinuumHypothesis
+open scoped Classical
 
 -- ============================================================
 -- PART 1: Regular and Singular Cardinals
@@ -87,9 +88,8 @@ theorem aleph_succ_is_regular (α : Ordinal.{0}) :
   Cardinal.isRegular_aleph_succ α
 
 /-- ℵ₀ is strictly less than ℵ₁ (basic cardinal ordering). -/
-theorem aleph_zero_lt_aleph_one : ℵ₀ < Cardinal.aleph 1 := by
-  rw [Cardinal.aleph_zero]
-  exact Cardinal.aleph_lt_aleph.mpr (by norm_num)
+theorem aleph_zero_lt_aleph_one : ℵ₀ < Cardinal.aleph 1 :=
+  Cardinal.aleph0_lt_aleph_one
 
 /-- ℵ₁ is strictly less than ℵ₂ (basic cardinal ordering). -/
 theorem aleph_one_lt_aleph_two : Cardinal.aleph 1 < Cardinal.aleph 2 :=
@@ -107,24 +107,20 @@ theorem aleph_two_lt_aleph_three : Cardinal.aleph 2 < Cardinal.aleph 3 :=
     Proof: `Cardinal.cof_aleph ω` gives `(aleph ω).ord.cof = ω` as ordinals,
     then `Ordinal.card_omega0` gives `ω.card = ℵ₀` for the cardinal coercion. -/
 theorem aleph_omega_cof_eq_omega :
-    ((Cardinal.aleph (ω : Ordinal.{0})).ord.cof : Cardinal) = ℵ₀ := by
-  rw [Cardinal.cof_aleph]
-  exact Ordinal.card_omega0
+    ((Cardinal.aleph (Ordinal.omega0)).ord.cof : Cardinal) = ℵ₀ := by
+  have hf : Order.IsNormal (Cardinal.ord ∘ Cardinal.aleph : Ordinal.{0} → Ordinal.{0}) :=
+    Cardinal.isNormal_ord.comp Cardinal.isNormal_aleph
+  have h := Ordinal.cof_map_of_isNormal hf Ordinal.isSuccLimit_omega0
+  simpa using h.trans Ordinal.cof_omega0
 
 /-- ℵ_ω is not regular: since cf(ℵ_ω) = ℵ₀ < ℵ_ω, the defining
-    condition cf(κ) = κ for regularity fails. -/
+    condition cf(κ) = κ for regularity fails.
+
+    Proved via `Cardinal.isSingular_aleph_omega0` (ℵ_ω is a Mathlib-recognized
+    singular cardinal). -/
 theorem aleph_omega_is_singular :
-    ¬(Cardinal.aleph (ω : Ordinal.{0})).IsRegular := by
-  intro hreg
-  -- If regular, then cf(ℵ_ω) = ℵ_ω
-  have hcof := hreg.cof_eq
-  -- But cf(ℵ_ω) = ℵ₀
-  rw [aleph_omega_cof_eq_omega] at hcof
-  -- So ℵ₀ = ℵ_ω, contradicting ℵ₀ < ℵ_ω
-  have : ℵ₀ < Cardinal.aleph (ω : Ordinal.{0}) := by
-    rw [Cardinal.aleph_zero]
-    exact Cardinal.aleph_lt_aleph.mpr (Ordinal.pos_iff_ne_zero.mpr (by exact omega_ne_zero))
-  exact absurd hcof.symm (ne_of_lt this)
+    ¬(Cardinal.aleph (Ordinal.omega0)).IsRegular :=
+  Cardinal.isSingular_aleph_omega0.not_isRegular
 
 -- ============================================================
 -- PART 2: König's Cofinality Constraint
@@ -158,7 +154,7 @@ theorem konig_cofinality :
     cf(2^ℵ₀) > ℵ₀ by König. Since 2^ℵ₀ = ℵ_ω would give
     cf(2^ℵ₀) = cf(ℵ_ω) = ℵ₀, contradiction. -/
 theorem continuum_ne_aleph_omega :
-    ContinuumHypothesis.continuum ≠ Cardinal.aleph (ω : Ordinal.{0}) := by
+    ContinuumHypothesis.continuum ≠ Cardinal.aleph (Ordinal.omega0) := by
   intro h
   have hcof := konig_cofinality
   rw [h] at hcof
@@ -174,8 +170,10 @@ theorem ch_consistent_with_konig (h : CH) :
     (Uses the PFA axiom from OQ01.) -/
 theorem pfa_consistent_with_konig
     (hpfa : ContinuumHypothesisOQ01.PFA) :
-    (Cardinal.aleph 2).IsRegular :=
-  aleph_succ_is_regular 1
+    (Cardinal.aleph (2 : Ordinal.{0})).IsRegular := by
+  have h2 : (2 : Ordinal.{0}) = Order.succ (1 : Ordinal.{0}) := by norm_num
+  rw [h2]
+  exact aleph_succ_is_regular 1
 
 -- ============================================================
 -- PART 3: Easton's Theorem — The Spectrum of Possible Values
@@ -216,7 +214,9 @@ theorem successor_alephs_possible (α : Ordinal.{0}) (hα : 0 < α) :
   · -- ℵ₁ ≤ ℵ_{succ α} when α ≥ 1... actually ℵ₁ = ℵ_{succ 0}
     -- and we need ℵ_{succ 0} ≤ ℵ_{succ α}
     unfold ContinuumHypothesis.aleph_one
-    exact Cardinal.aleph_le_aleph.mpr (Ordinal.succ_le_succ hα.le)
+    have h1 : (1 : Ordinal.{0}) = Order.succ 0 := by norm_num
+    rw [h1]
+    exact Cardinal.aleph_le_aleph.mpr (Order.succ_le_succ hα.le)
   · exact aleph_succ_is_regular α
 
 /-- ℵ₁ is a possible value for the continuum (this is CH). -/
@@ -230,7 +230,9 @@ theorem aleph_two_is_possible : IsPossibleContinuumValue (Cardinal.aleph 2) := b
   constructor
   · unfold ContinuumHypothesis.aleph_one
     exact Cardinal.aleph_le_aleph.mpr (by norm_num)
-  · exact aleph_succ_is_regular 1
+  · have h2 : (2 : Ordinal.{0}) = Order.succ (1 : Ordinal.{0}) := by norm_num
+    rw [h2]
+    exact aleph_succ_is_regular 1
 
 /-- ℵ₃ is a possible value for the continuum (consistent via Easton). -/
 theorem aleph_three_is_possible : IsPossibleContinuumValue (Cardinal.aleph 3) := by
@@ -241,7 +243,7 @@ theorem aleph_three_is_possible : IsPossibleContinuumValue (Cardinal.aleph 3) :=
 
 /-- ℵ_ω is NOT a possible value: it is singular (König constraint). -/
 theorem aleph_omega_not_possible :
-    ¬IsPossibleContinuumValue (Cardinal.aleph (ω : Ordinal.{0})) := by
+    ¬IsPossibleContinuumValue (Cardinal.aleph (Ordinal.omega0)) := by
   intro ⟨_, hreg⟩
   exact aleph_omega_is_singular hreg
 
@@ -318,7 +320,7 @@ theorem dominating_le_continuum :
   unfold dominatingNumber
   have hbdd : BddBelow (Set.range fun F : Set (ℕ → ℕ) =>
       if IsDominating F then Cardinal.mk F else ContinuumHypothesis.continuum) :=
-    ⟨0, fun _ ⟨_, hF⟩ => hF ▸ by split <;> exact zero_le⟩
+    ⟨0, fun _ ⟨_, hF⟩ => hF ▸ by dsimp only; split <;> exact zero_le⟩
   calc ⨅ F, _ ≤ (if IsDominating (∅ : Set (ℕ → ℕ)) then Cardinal.mk (∅ : Set (ℕ → ℕ))
         else ContinuumHypothesis.continuum) := ciInf_le hbdd ∅
     _ = ContinuumHypothesis.continuum := by
@@ -336,6 +338,7 @@ theorem dominating_implies_unbounded {F : Set (ℕ → ℕ)}
   refine ⟨h, hh_mem, fun ⟨N₂, hN₂⟩ => ?_⟩
   have h1 := hN₁ (max N₁ N₂) (le_max_left _ _)
   have h2 := hN₂ (max N₁ N₂) (le_max_right _ _)
+  simp only at h1
   omega
 
 /-- The bounding number is at most the dominating number: b ≤ d.
@@ -353,7 +356,7 @@ theorem bounding_le_dominating : boundingNumber ≤ dominatingNumber := by
   -- Helper: boundingNumber infimum is bounded below by 0
   have hbdd : BddBelow (Set.range fun G : Set (ℕ → ℕ) =>
       if IsUnbounded G then Cardinal.mk G else ContinuumHypothesis.continuum) :=
-    ⟨0, by rintro _ ⟨G, rfl⟩; split_ifs <;> exact Cardinal.zero_le _⟩
+    ⟨0, by rintro _ ⟨G, rfl⟩; dsimp only; split_ifs <;> exact Cardinal.zero_le _⟩
   by_cases hdom : IsDominating F
   · -- F dominating → F unbounded → boundingNumber ≤ mk F
     have hunb := dominating_implies_unbounded hdom
@@ -488,8 +491,12 @@ theorem scenarios_distinct :
 /-- In each scenario, the continuum is regular (König-consistent):
     ℵ₁ is regular (successor), and ℵ₂ is regular (successor). -/
 theorem all_scenarios_regular :
-    (Cardinal.aleph 1).IsRegular ∧ (Cardinal.aleph 2).IsRegular :=
-  ⟨aleph_one_is_regular, aleph_succ_is_regular 1⟩
+    (Cardinal.aleph (1 : Ordinal.{0})).IsRegular ∧
+    (Cardinal.aleph (2 : Ordinal.{0})).IsRegular := by
+  refine ⟨aleph_one_is_regular, ?_⟩
+  have h2 : (2 : Ordinal.{0}) = Order.succ (1 : Ordinal.{0}) := by norm_num
+  rw [h2]
+  exact aleph_succ_is_regular 1
 
 -- ============================================================
 -- PART 7: The Complete Picture
@@ -509,7 +516,7 @@ theorem easton_konig_characterization :
     (∃ κ : Cardinal.{0}, ¬IsPossibleContinuumValue κ) := by
   constructor
   · exact ⟨Cardinal.aleph 1, aleph_one_is_possible⟩
-  · exact ⟨Cardinal.aleph (ω : Ordinal.{0}), aleph_omega_not_possible⟩
+  · exact ⟨Cardinal.aleph (Ordinal.omega0), aleph_omega_not_possible⟩
 
 /-- The Cantor-König sandwich: ℵ₁ ≤ 2^ℵ₀ and 2^ℵ₀ has uncountable cofinality.
     These are the ONLY two constraints ZFC places on 2^ℵ₀ (for the ℵ₀ case). -/
@@ -537,9 +544,10 @@ theorem the_open_question :
   · exact ⟨Cardinal.aleph 1, Cardinal.aleph 2,
       aleph_one_is_possible, aleph_two_is_possible,
       ne_of_lt (Cardinal.aleph_lt_aleph.mpr (by norm_num))⟩
-  · refine ⟨Cardinal.aleph (ω : Ordinal.{0}), ?_, aleph_omega_not_possible⟩
+  · refine ⟨Cardinal.aleph (Ordinal.omega0), ?_, aleph_omega_not_possible⟩
     unfold ContinuumHypothesis.aleph_one
-    exact Cardinal.aleph_le_aleph.mpr (by exact Ordinal.one_le_iff_ne_zero.mpr omega_ne_zero)
+    exact Cardinal.aleph_le_aleph.mpr
+      (by exact Ordinal.one_le_iff_ne_zero.mpr Ordinal.omega0_ne_zero)
 
 /-
 ## Conclusion

--- a/proofs/Proofs/Erdos1098Problem.lean
+++ b/proofs/Proofs/Erdos1098Problem.lean
@@ -75,7 +75,8 @@ g ∈ Z(G) iff g commutes with all elements.
 -/
 theorem mem_center_iff (g : G) :
     g ∈ Subgroup.center G ↔ ∀ h : G, commuting g h := by
-  simp [commuting, Subgroup.mem_center_iff]
+  simp only [commuting, Subgroup.mem_center_iff]
+  constructor <;> intro H h <;> exact (H h).symm
 
 /- ## Part II: Non-Commuting Graph
 -/
@@ -87,9 +88,18 @@ This is an undirected graph (symmetric relation).
 -/
 structure NonCommGraph (G : Type*) [Group G] where
   vertices : Set G := Set.univ
-  adj : G → G → Prop := nonCommuting
-  symm : ∀ g h, adj g h ↔ adj h g := fun g h => nonCommuting_symm g h
-  irrefl : ∀ g, ¬adj g g := fun g => by skip
+  adj : G → G → Prop
+  symm : ∀ g h, adj g h ↔ adj h g
+  irrefl : ∀ g, ¬adj g g
+
+/--
+**The canonical non-commuting graph of `G`:**
+adjacency is the non-commuting relation (symmetric and irreflexive).
+-/
+def nonCommGraph (G : Type*) [Group G] : NonCommGraph G where
+  adj := nonCommuting
+  symm := nonCommuting_symm
+  irrefl := fun _ h => h rfl
 
 /--
 **Clique in Non-Commuting Graph:**
@@ -125,15 +135,17 @@ def noInfiniteClique (G : Type*) [Group G] : Prop :=
 /--
 **Finite Index:**
 The center Z(G) has finite index in G.
+(Mathlib's `Subgroup.index : ℕ` returns `0` when the index is infinite,
+so finite index is `index ≠ 0`.)
 -/
 def centerHasFiniteIndex (G : Type*) [Group G] : Prop :=
-  (Subgroup.center G).index ≠ ⊤
+  (Subgroup.center G).index ≠ 0
 
 /--
 **Index Value:**
-If finite, the actual index [G : Z(G)].
+The index [G : Z(G)] as a natural number (`0` if infinite).
 -/
-noncomputable def centerIndex (G : Type*) [Group G] : ℕ∞ :=
+noncomputable def centerIndex (G : Type*) [Group G] : ℕ :=
   (Subgroup.center G).index
 
 /- ## Part IV: Neumann's Theorem
@@ -169,7 +181,7 @@ If S is a clique, distinct elements must be in different cosets of Z(G).
 -/
 theorem clique_different_cosets (S : Set G) (hS : isClique S) :
     ∀ g ∈ S, ∀ h ∈ S, g ≠ h →
-    (Subgroup.center G).quotient.mk g ≠ (Subgroup.center G).quotient.mk h := by
+    (QuotientGroup.mk g : G ⧸ Subgroup.center G) ≠ QuotientGroup.mk h := by
   intro g hg h hh hne heq
   -- Distinct clique members must not commute
   have hnc : nonCommuting g h := hS g hg h hh hne
@@ -179,48 +191,56 @@ theorem clique_different_cosets (S : Set G) (hS : isClique S) :
     use g⁻¹ * h
     refine ⟨?_, by group⟩
     -- g⁻¹ * h ∈ center G from quotient equality
-    have hrel := Quotient.exact heq
-    rwa [QuotientGroup.leftRel_apply] at hrel
+    rwa [QuotientGroup.eq] at heq
   unfold nonCommuting at hnc; unfold commuting at hcomm
   exact hnc hcomm
 
 /--
 **Corollary:**
-|S| ≤ [G : Z(G)] for any clique S.
+|S| ≤ [G : Z(G)] for any clique S, provided Z(G) has finite index.
+(The finiteness hypothesis is needed because Mathlib's `index : ℕ`
+returns `0` for infinite index.)
 -/
-theorem clique_size_bound (S : Set G) (hS : isClique S) (hSfin : S.Finite) :
+theorem clique_size_bound (S : Set G) (hS : isClique S) (_hSfin : S.Finite)
+    (hfin : centerHasFiniteIndex G) :
     S.ncard ≤ (Subgroup.center G).index := by
+  haveI : Finite (G ⧸ Subgroup.center G) :=
+    (Subgroup.index_ne_zero_iff_finite (H := Subgroup.center G)).mp hfin
   -- The quotient map mk : G → G ⧸ Z(G) is injective on cliques
-  have hinj : Set.InjOn (Subgroup.center G).quotient.mk S := by
+  have hinj : Set.InjOn (QuotientGroup.mk : G → G ⧸ Subgroup.center G) S := by
     intro g hg h hh heq
     by_contra hne
     exact clique_different_cosets S hS g hg h hh hne heq
   -- |S| = |mk(S)| ≤ |G ⧸ Z(G)| = [G : Z(G)]
   calc S.ncard
-      = (((Subgroup.center G).quotient.mk) '' S).ncard :=
-          (Set.ncard_image_of_injOn hinj hSfin).symm
-    _ ≤ Set.univ.ncard := Set.ncard_le_ncard (Set.subset_univ _) (hSfin.image _)
-    _ = Nat.card ((Subgroup.center G).quotient) := Set.ncard_univ _
-    _ = (Subgroup.center G).index := (Subgroup.index_eq_card _).symm
+      = ((QuotientGroup.mk : G → G ⧸ Subgroup.center G) '' S).ncard :=
+          hinj.ncard_image.symm
+    _ ≤ (Set.univ : Set (G ⧸ Subgroup.center G)).ncard :=
+          Set.ncard_le_ncard (Set.subset_univ _) Set.finite_univ
+    _ = Nat.card (G ⧸ Subgroup.center G) := Set.ncard_univ _
+    _ = (Subgroup.center G).index := by rw [Subgroup.index_eq_card]
 
 /--
 **Clique Size Bound (with explicit index):**
 If [G : Z(G)] = n < ∞, then Γ(G) has no clique on > n vertices.
 Proved from clique_size_bound (eliminates former axiom). -/
-theorem neumann_bound (G : Type*) [Group G] (n : ℕ)
+theorem neumann_bound (G : Type*) [Group G] (n : ℕ) (hn0 : n ≠ 0)
     (hn : (Subgroup.center G).index = n) :
     ∀ S : Set G, isClique S → S.Finite → S.ncard ≤ n := by
   intro S hS hSfin
+  have hfin : centerHasFiniteIndex G := by
+    unfold centerHasFiniteIndex
+    rw [hn]; exact hn0
   calc S.ncard
-      ≤ (Subgroup.center G).index := clique_size_bound S hS hSfin
+      ≤ (Subgroup.center G).index := clique_size_bound S hS hSfin hfin
     _ = n := hn
 
 /--
 **Corollary: Finite Index implies Finite Clique Number:**
 -/
 theorem finite_index_implies_finite_clique (G : Type*) [Group G]
-    (h : centerHasFiniteIndex G) : hasFiniteCliqueNumber G := by
-  exact ⟨(Subgroup.center G).index, neumann_bound G _ rfl⟩
+    (h : centerHasFiniteIndex G) : hasFiniteCliqueNumber G :=
+  ⟨(Subgroup.center G).index, fun S hS hSfin => clique_size_bound S hS hSfin h⟩
 
 /--
 **Answer to Erdős' Question:**
@@ -244,7 +264,7 @@ theorem abelian_no_edges (G : Type*) [Group G]
   intro g h
   simp [nonCommuting]
   have : g ∈ Subgroup.center G := by simp [habel]
-  exact Subgroup.mem_center_iff.mp this h
+  exact (Subgroup.mem_center_iff.mp this h).symm
 
 /- 
 **Infinite Non-Abelian Groups:**
@@ -269,8 +289,8 @@ Every finite group has finite index center (trivially).
 theorem finite_group_finite_index (G : Type*) [Group G] [Finite G] :
     centerHasFiniteIndex G := by
   unfold centerHasFiniteIndex
-  -- For finite G, index of any subgroup is finite (a natural number, not ⊤)
-  exact Subgroup.index_ne_zero.mpr (inferInstance : Finite (Subgroup.center G).quotient)
+  -- For finite G, the quotient is finite, so the index is a nonzero natural
+  exact Subgroup.index_ne_zero_of_finite (H := Subgroup.center G)
 
 /- ## Part VIII: Generalizations
 -/
@@ -301,7 +321,7 @@ theorem prob_clique_relation (G : Type*) [Group G] [Finite G] :
 Groups with bounded finite conjugacy classes - related concept.
 -/
 def isBFCGroup (G : Type*) [Group G] : Prop :=
-  ∃ n : ℕ, ∀ g : G, (conjugacyClass g).Finite ∧ (conjugacyClass g).ncard ≤ n
+  ∃ n : ℕ, ∀ g : G, (conjugatesOf g).Finite ∧ (conjugatesOf g).ncard ≤ n
 
 /- 
 **Connection to BFC:**

--- a/proofs/Proofs/Erdos1103Problem.lean
+++ b/proofs/Proofs/Erdos1103Problem.lean
@@ -42,6 +42,7 @@ noncomputable def enumSet (A : Set ℕ) (j : ℕ) : ℕ := Nat.nth (· ∈ A) j
 /-- The enumeration is strictly monotone and surjects onto `A`. -/
 theorem enumSet_spec (A : Set ℕ) (hA : A.Infinite) :
     StrictMono (enumSet A) ∧ Set.range (enumSet A) = A := by
+  classical
   constructor
   · exact Nat.nth_strictMono hA
   · ext n; simp only [Set.mem_range, enumSet]
@@ -93,7 +94,8 @@ theorem one_squarefree : Squarefree 1 := squarefree_one
 
 /-- {1} has a squarefree sumset since 1 + 1 = 2 is squarefree. -/
 theorem squarefreeSumset_one : SquarefreeSumset {1} :=
-  (squarefreeSumset_singleton 1).mpr (by decide)
+  (squarefreeSumset_singleton 1).mpr
+    (show Squarefree (1 + 1) from Nat.prime_two.squarefree)
 
 /-- For a two-element set {a, b}, squarefree sumset requires
     2a, a+b, and 2b all squarefree. -/
@@ -130,7 +132,7 @@ theorem subexp_eventually_lt_exp (C : ℝ) (hC : 1 < C) :
   have hlog_tend : Tendsto (fun n : ℕ => Real.log (n : ℝ)) atTop atTop :=
     Real.tendsto_log_atTop.comp tendsto_natCast_atTop_atTop
   -- Eventually log n > 5 / log C
-  have hev_log : ∀ᶠ n in atTop, 5 / Real.log C < Real.log (n : ℝ) :=
+  have hev_log : ∀ᶠ (n : ℕ) in atTop, 5 / Real.log C < Real.log (n : ℝ) :=
     hlog_tend.eventually (eventually_gt_atTop (5 / Real.log C))
   filter_upwards [hev_log, eventually_gt_atTop 2] with j hj_log hj_ge
   -- Derived: log j > 0 and j > 0 (since 5/log C > 0 and log j > 5/log C)

--- a/proofs/batch2/STATUS.md
+++ b/proofs/batch2/STATUS.md
@@ -1,3 +1,17 @@
+# DOCTOR SINGLE-PROOF BATCH 58 (5-slot Sonnet + Fable + Bezout reclassify, #38065, 2026-07-16)
+
+**+4 GREEN + 1 RECLASSIFY**: Erdos1103Problem (FABLE: Nat.count needs explicit DecidablePred; decide on
+Squarefree stuck at minSqFac), ContinuumHypothesisOQ02 (unqualified ω autobinds as implicit -> Ordinal.omega0;
+aleph numeral universe auto-generalizes -> pin Ordinal.{0}), Erdos1098Problem (FABLE #38611: Subgroup.index
+ℕ∞->ℕ, strengthened clique_size_bound+neumann_bound; NonCommGraph.irrefl by-skip unprovable), CauchySchwarz
+IntegralOQ01OQ03OQ01 (MeasurableSpace/BorelSpace on codomain for AEMeasurable; eLpNorm_..._nnnorm->_enorm).
+
+**BezoutIdentityOQ01OQ02OQ02Transitive RESIDUAL->PRE-EXISTING (exempt)**: triage confirmed NEVER-GREEN —
+docstring self-reports "UNVERIFIED — not yet machine-checked", first-ever elaboration (after building parent
+Descent olean, never cached) shows real unsolved-goal/rewrite failures in author-flagged gcdForm_two/cons_gcdForm
++ sln_transitive headBlockNSL inference — genuine incomplete work predating migration, not v4.31 drift.
+PRE-EXISTING 25->26. This is the predicted endpoint class (safe-subset green + hard-core exempt).
+Repairs #38611: Erdos1098. Fable 12/13 hard tail.
 # DOCTOR SINGLE-PROOF BATCH 57 (5-slot Sonnet + Fable, #38065, 2026-07-16)
 
 **+2 GREEN** (re-verified EXIT=0): Erdos1019Problem (later local def no longer shadows earlier ref -> reorder;

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -211,7 +211,7 @@ BetaIntegralRecurrenceOQ01OQ03OQ01	GREEN
 BetaIntegralRecurrenceOQ01OQ03OQ01OQ02	GREEN	
 BezoutIdentity	GREEN	
 BezoutIdentityOQ01OQ02OQ02Descent	GREEN	
-BezoutIdentityOQ01OQ02OQ02Transitive	RESIDUAL	unknown-const:det_headBlockN
+BezoutIdentityOQ01OQ02OQ02Transitive	PRE-EXISTING	never-green: docstring self-reports UNVERIFIED, real unsolved goals predating migration
 BezoutIdentityOQ02OQ01OQ01OQ01OQ01	RESIDUAL	type-mismatch
 BezoutIdentityOQ02OQ01OQ02	GREEN	
 BezoutIdentityOQ02OQ01OQ02OQ02OQ03	GREEN	
@@ -360,7 +360,7 @@ CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01Infra	GREEN
 CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01Loc	GREEN	
 CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01Norm	GREEN	
 CauchySchwarzIntegralOQ01OQ03	GREEN	
-CauchySchwarzIntegralOQ01OQ03OQ01	RESIDUAL	unknown-const:eLpNorm_one_eq_lintegral_nnnorm
+CauchySchwarzIntegralOQ01OQ03OQ01	GREEN	
 CauchySchwarzIntegralOQ02OQ02	RESIDUAL	unknown-const:eLpNorm_mul_le
 CauchySchwarzIntegralOQ02OQ02OQ01	GREEN	
 CauchySchwarzIntegralOQ03	GREEN	
@@ -467,7 +467,7 @@ CombinationsFormulaOQ07OQ04OQ01OQ02OQ01	GREEN
 ComplexityCore	GREEN	
 ConjugacyClassEquationOQ01	GREEN	
 ConjugacyClassEquationOQ0102	GREEN	
-ContinuumHypothesisOQ02	RESIDUAL	unknown-const:Cardinal.cof_aleph
+ContinuumHypothesisOQ02	GREEN	
 ContinuumHypothesisOQ02OQ01	GREEN	
 CoprimeKTupleDensity	GREEN	
 CramersRule	GREEN	
@@ -794,7 +794,7 @@ Erdos1098OQ01	RESIDUAL	type-mismatch
 Erdos1098OQ01OQ01	RESIDUAL	instance-synth
 Erdos1098OQ03	GREEN	proof-drift
 Erdos1098OQ04	GREEN	
-Erdos1098Problem	RESIDUAL	instance-synth
+Erdos1098Problem	GREEN	
 Erdos109OQ01	RESIDUAL	type-mismatch
 Erdos109OQ01Aristotle	GREEN	
 Erdos109Problem	GREEN	
@@ -808,7 +808,7 @@ Erdos1100Problem	PRE-EXISTING	never-compiled:p
 Erdos1100ProblemAristotle	RESIDUAL	unknown-const:p
 Erdos1100ProblemProvable	PRE-EXISTING	never-compiled:p
 Erdos1101Problem	GREEN	
-Erdos1103Problem	RESIDUAL	instance-synth
+Erdos1103Problem	GREEN	
 Erdos1104OQ01	GREEN	
 Erdos1104Problem	RESIDUAL	type-mismatch
 Erdos1107Problem	GREEN	


### PR DESCRIPTION
+4 GREEN. BezoutIdentityTransitive reclassified RESIDUAL->PRE-EXISTING (confirmed never-green, docstring self-reports unverified). 2 Fable greens. No loom labels.