### PR TITLE
migrate(v4.31): reclassify KonigsbergOQ01OQ02 -> PRE-EXISTING

### DIFF
--- a/proofs/batch2/STATUS.md
+++ b/proofs/batch2/STATUS.md
@@ -1,3 +1,11 @@
+# LEDGER RECLASSIFY (2026-07-16): KonigsbergOQ01OQ02 RESIDUAL->PRE-EXISTING (2nd never-green)
+
+Was FAIL on v4.26 spike baseline (results-full.tsv) too — never compiled on the old pin. meta.json self-documents
+"does not build under latest Mathlib ... pre-existing from PR #16675". ~90 error sites, needs a multi-hour
+REARCHITECTURE (transcribe the already-GREEN companion KonigsbergOQ01OQ02Recipe.lean's Option-based get?/getD
+approach to avoid Fin-index proof obligations), NOT single-proof migration drift. Routed to #38612 deep-rework.
+PRE-EXISTING 26->27. Endpoint class growing as tail thins (Bezout Transitive was 1st).
+
 # DOCTOR SINGLE-PROOF BATCH 63 (mixed fleet, #38065, 2026-07-16)
 
 **+3 GREEN** (re-verified EXIT=0): Erdos780Aristotle (#38611: threshold_k2 FALSE at t=0 -> add 1≤t;

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -2167,7 +2167,7 @@ KnightsTourObliqueOQ02ReverseCount	GREEN
 KnightsTourObliqueOQ03	GREEN	
 Konigsberg	GREEN	
 KonigsbergOQ01	GREEN	
-KonigsbergOQ01OQ02	RESIDUAL	unknown-const:Finset.card_eq_sum_ones.symm
+KonigsbergOQ01OQ02	PRE-EXISTING	FAIL on v4.26 baseline too; ~90-site rearchitecture needed (transcribe KonigsbergOQ01OQ02Recipe.lean), pre-existing per meta.json+PR#16675, not migration drift
 KonigsbergOQ01OQ02Recipe	GREEN	
 KonigsbergOQ02	GREEN	
 KonigsbergOQ02OQ01	RESIDUAL	type-mismatch


### PR DESCRIPTION
FAIL on v4.26 baseline, needs rearchitecture (#38612), not migration drift. No loom labels.