### PR TITLE
migrate(v4.31): single-proof batch 74 (+2 GREEN, re-verified)

### DIFF
--- a/proofs/Proofs/GreensTheoremOQ01OQ01OQ02OQ03.lean
+++ b/proofs/Proofs/GreensTheoremOQ01OQ01OQ02OQ03.lean
@@ -50,6 +50,19 @@ set_option maxHeartbeats 800000
 namespace GreensTheoremOQ01OQ01OQ02OQ03
 
 variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E] [CompleteSpace E]
+  [MeasurableSpace E] [BorelSpace E]
+
+/-- `MeasureTheory.Measure.prod_mono` was removed from Mathlib (v4.31 drift); this is a
+verbatim reconstruction via `Measure.prod_apply`/`Measure.prod_apply_le` and `lintegral_mono'`. -/
+private theorem prod_mono_E {α β : Type*} [MeasurableSpace α] [MeasurableSpace β]
+    {μ μ' : Measure α} {ν ν' : Measure β} [SFinite ν] [SFinite ν']
+    (hμ : μ ≤ μ') (hν : ν ≤ ν') : μ.prod ν ≤ μ'.prod ν' := by
+  rw [Measure.le_iff]
+  intro s hs
+  calc μ.prod ν s = ∫⁻ x, ν (Prod.mk x ⁻¹' s) ∂μ := Measure.prod_apply hs
+    _ ≤ ∫⁻ x, ν' (Prod.mk x ⁻¹' s) ∂μ' :=
+        lintegral_mono' hμ (fun x => Measure.le_iff'.mp hν _)
+    _ = μ'.prod ν' s := (Measure.prod_apply hs).symm
 
 /-! ### Part I: Ordered Case (fully proved) -/
 
@@ -73,7 +86,7 @@ theorem intervalIntegral_swap_of_le {f : ℝ → ℝ → E}
   simp_rw [integral_of_le hab, integral_of_le hcd]
   have hf_ioc : Integrable (fun p : ℝ × ℝ => f p.1 p.2)
       ((volume.restrict (Ioc a b)).prod (volume.restrict (Ioc c d))) :=
-    hf_int.mono_measure (Measure.prod_mono
+    hf_int.mono_measure (prod_mono_E
       (Measure.restrict_mono Ioc_subset_Icc_self le_rfl)
       (Measure.restrict_mono Ioc_subset_Icc_self le_rfl))
   exact (MeasureTheory.integral_integral_swap hf_ioc).symm
@@ -90,7 +103,7 @@ private theorem flip_bounds_E (f : ℝ → E) (a b : ℝ) :
 Verbatim port of parent's `neg_outside`. -/
 private theorem neg_outside_E (a b : ℝ) (g : ℝ → E) :
     ∫ x in a..b, -g x = -(∫ x in a..b, g x) :=
-  intervalIntegral.integral_neg g
+  intervalIntegral.integral_neg (f := g)
 
 /-! ### Part III: General Case (S3 proven) -/
 
@@ -208,6 +221,10 @@ theorem intervalIntegral_swap_of_continuous {f : ℝ → ℝ → E}
     isCompact_uIcc.prod isCompact_uIcc
   have hint : IntegrableOn (fun p : ℝ × ℝ => f p.1 p.2) (uIcc a b ×ˢ uIcc c d) volume :=
     hf.continuousOn.integrableOn_compact hcpt
-  rwa [restrict_prod_eq_prod_restrict measurableSet_uIcc measurableSet_uIcc] at hint
+  have hmeas : (volume.restrict (uIcc a b)).prod (volume.restrict (uIcc c d))
+      = volume.restrict (uIcc a b ×ˢ uIcc c d) := by
+    rw [Measure.prod_restrict, ← Measure.volume_eq_prod ℝ ℝ]
+  rw [hmeas]
+  exact hint
 
 end GreensTheoremOQ01OQ01OQ02OQ03

--- a/proofs/Proofs/SkolemNoetherMatrixAut.lean
+++ b/proofs/Proofs/SkolemNoetherMatrixAut.lean
@@ -213,20 +213,19 @@ theorem skolemNoether [Nonempty n] (φ : Matrix n n K ≃ₐ[K] Matrix n n K) :
       intro w; ext i
       simp only [Matrix.mulVec, dotProduct, Pmat, Matrix.of_apply,
                   Finset.sum_apply, Pi.smul_apply, smul_eq_mul]
+      exact Finset.sum_congr rfl (fun x _ => mul_comm _ _)
     -- mulVec is injective from linear independence of columns
-    have hinj : Function.Injective (Matrix.mulVecLin Pmat) := by
+    have hinj : Function.Injective Pmat.mulVec := by
       intro u v huv
       have h0 : Pmat.mulVec (u - v) = 0 := by
-        show (Matrix.mulVecLin Pmat) (u - v) = 0
-        rw [map_sub, sub_eq_zero]; exact huv
+        rw [Matrix.mulVec_sub, huv, sub_self]
       rw [hmulvec] at h0
       have hcoeff := (Fintype.linearIndependent_iff.mp hli) (u - v) h0
-      ext j; exact sub_eq_zero.mpr (by simpa using (hcoeff j).symm)
-    -- Injective endomorphism of fin-dim space → surjective → IsUnit
-    have hbij : Function.Bijective (Matrix.mulVecLin Pmat) :=
-      ⟨hinj, (LinearMap.injective_iff_surjective.mp hinj)⟩
-    rw [Matrix.isUnit_iff_isUnit_det]
-    rwa [Matrix.isUnit_det_iff_isUnit_mulVecLin, LinearMap.isUnit_iff_bijective]
+      ext j
+      have hj := hcoeff j
+      simpa [Pi.sub_apply, sub_eq_zero] using hj
+    -- Injective endomorphism of fin-dim space → IsUnit (field case)
+    exact Matrix.mulVec_injective_iff_isUnit.mp hinj
   -- The intertwining: phi(A) * P = P * A for all A
   -- (from phi(E_ij)*P = P*E_ij on generators, extended by K-linearity)
   have hintertwine : ∀ A : Matrix n n K, φ A * Pu.val = Pu.val * A := by
@@ -250,23 +249,20 @@ theorem skolemNoether [Nonempty n] (φ : Matrix n n K ≃ₐ[K] Matrix n n K) :
       rw [hlhs, hrhs]
       have := congr_fun (intertwine_prop φ i₀ v₀ i j b) a
       simp only [p] at this ⊢
-      exact this
+      rw [this]; split_ifs <;> rfl
     -- Step 2: Every matrix decomposes as A = ∑_{i,j} A_ij • E_ij
     have hdecomp : ∀ A : Matrix n n K,
         A = ∑ i : n, ∑ j : n, A i j • Matrix.single i j 1 := by
       intro A; ext a b
-      simp only [Finset.sum_apply, Pi.smul_apply, smul_eq_mul, stdBasis_entry]
-      rw [Finset.sum_eq_single a (fun m _ hm => by simp [Ne.symm hm])
-          (fun h => absurd (Finset.mem_univ _) h)]
-      simp [Finset.sum_eq_single b (fun m _ hm => by simp [Ne.symm hm])
-          (fun h => absurd (Finset.mem_univ _) h)]
+      simp [Matrix.sum_apply, Matrix.smul_apply, Matrix.single_apply, ite_and,
+            Finset.sum_ite_eq']
     -- Step 3: Extend by K-linearity
     intro A
-    conv_lhs => rw [hdecomp A]
-    rw [map_sum]; simp_rw [map_sum, map_smul]
-    simp_rw [Matrix.smul_mul_assoc, Matrix.mul_smul_comm]
+    rw [hdecomp A]
+    simp only [map_sum, map_smul, Finset.sum_mul, Finset.mul_sum, smul_mul_assoc, mul_smul_comm]
     -- Now both sides have ∑∑ A_ij • (φ(E_ij) * P) vs ∑∑ A_ij • (P * E_ij)
-    congr 1; ext i; congr 1; ext j
+    refine Finset.sum_congr rfl (fun i _ => Finset.sum_congr rfl (fun j _ => ?_))
+    congr 1
     rw [hPu]; exact hbasis_intertwine i j
   -- Conclude: phi(A) = P * A * P⁻¹
   refine ⟨Pu⁻¹, fun A => ?_⟩

--- a/proofs/batch2/STATUS.md
+++ b/proofs/batch2/STATUS.md
@@ -1,3 +1,10 @@
+# DOCTOR SINGLE-PROOF BATCH 74 (mixed fleet, #38065, 2026-07-16)
+
+**+2 GREEN** (re-verified EXIT=0): SkolemNoetherMatrixAut (Finset.sum_apply/Pi.smul_apply no longer unify with
+Matrix n n K -> Matrix.sum_apply/smul_apply; Matrix.isUnit_det_iff_isUnit_mulVecLin removed -> mulVec_injective_iff_isUnit;
+unblocks Aristotle child), GreensTheoremOQ01OQ01OQ02OQ03 (Measure.prod_mono removed -> reconstruct via prod_apply/
+lintegral_mono'; Banach-codomain needs explicit [MeasurableSpace E][BorelSpace E]). Repairs: none.
+
 # DOCTOR SINGLE-PROOF BATCH 72 (mixed fleet, #38065, 2026-07-16)
 
 **+1 GREEN** (re-verified EXIT=0): CramersRuleOQ01OQ04 (charpoly_natDegree_eq_dim etc renamed; det_from_power_sums_2x2

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -2062,7 +2062,7 @@ GreensTheoremOQ01OQ01OQ01OQ01	GREEN
 GreensTheoremOQ01OQ01OQ02	GREEN	
 GreensTheoremOQ01OQ01OQ02OQ01	GREEN	
 GreensTheoremOQ01OQ01OQ02OQ02	GREEN	
-GreensTheoremOQ01OQ01OQ02OQ03	RESIDUAL	unknown-const:MeasureTheory.Measure.prod_mono
+GreensTheoremOQ01OQ01OQ02OQ03	GREEN	
 GreensTheoremOQ01OQ01OQ03	GREEN	
 GreensTheoremOQ03OQ04	RESIDUAL	type-mismatch
 GreensTheoremOQ04	RESIDUAL	type-mismatch
@@ -2426,7 +2426,7 @@ ShapleyFolkmanAristotle	GREEN
 ShapleyFolkmanOQ01	GREEN	
 ShapleyFolkmanOQ03	GREEN	
 ShapleyFolkmanOQ04	GREEN	
-SkolemNoetherMatrixAut	RESIDUAL	unknown-const:Matrix.isUnit_det_iff_isUnit_mulVecLin
+SkolemNoetherMatrixAut	GREEN	
 SkolemNoetherMatrixAutAristotle	RESIDUAL	unknown-const:Matrix.isUnit_det_iff_isUnit_mulVecLin
 SolutionOfCubicOQ03OQ01	GREEN	
 SolutionOfCubicOQ03OQ02	GREEN	


### PR DESCRIPTION
Mixed fleet. Unblocks SkolemNoetherMatrixAutAristotle. No loom labels.