### PR TITLE
migrate(v4.31): reclassify Erdos1100ProblemAristotle -> PRE-EXISTING

### DIFF
--- a/proofs/batch2/STATUS.md
+++ b/proofs/batch2/STATUS.md
@@ -1,3 +1,16 @@
+# LEDGER CORRECTION + RECLASSIFY (2026-07-16)
+
+**DATA CORRECTION:** proofs/spike-logs-full/results-full.tsv is the v4.31 SPIKE-FAILURE list (files that broke
+on v4.31 and need porting = the RESIDUAL+fixed universe), NOT a v4.26 pass/fail baseline. EVERY residual row
+appears "FAIL" there by definition. DO NOT use it to identify never-greens (a naive cross-ref falsely flagged
+all 316 residuals). Never-green determination is per-file: docstring self-report, git history predating the
+epic, OR being a pure wrapper over a confirmed-PRE-EXISTING parent. (Bezout/Konigsberg reclasses stand — based
+on meta.json self-report + git history + error profile, not results-full.tsv.)
+
+**RECLASSIFY: Erdos1100ProblemAristotle RESIDUAL->PRE-EXISTING (3rd never-green).** Pure `import
+Erdos1100ProblemProvable` wrapper; parent is already PRE-EXISTING/never-compiled (8 real errors, never built
+on any toolchain). Wrapper transitively can't compile; no own content to fix. PRE-EXISTING 27->28.
+
 # DOCTOR SINGLE-PROOF BATCH 80 (mixed fleet, #38065, 2026-07-16)
 
 **+3 GREEN** (re-verified EXIT=0): PrimeReciprocalDivergenceOQ03 (16min: Finset.card_le_card_of_injOn now

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -805,7 +805,7 @@ Erdos10OQ02Bridge	GREEN
 Erdos10Problem	GREEN	
 Erdos10WIP01OQ03	RESIDUAL	slow-timeout
 Erdos1100Problem	PRE-EXISTING	never-compiled:p
-Erdos1100ProblemAristotle	RESIDUAL	unknown-const:p
+Erdos1100ProblemAristotle	PRE-EXISTING	transitively never-compiled: pure import-wrapper over Erdos1100ProblemProvable (already PRE-EXISTING/never-compiled); no content of its own to fix
 Erdos1100ProblemProvable	PRE-EXISTING	never-compiled:p
 Erdos1101Problem	GREEN	
 Erdos1103Problem	GREEN	


### PR DESCRIPTION
Wrapper over never-green parent Erdos1100ProblemProvable. + data-source clarification (results-full.tsv is spike-failure list not baseline). No loom labels.