### PR TITLE
migrate(v4.31): single-proof batch 104 (+3 GREEN, 1 repair)

### DIFF
--- a/proofs/Proofs/CantorDiagonalizationOQ04OQ01OQ01OQ01.lean
+++ b/proofs/Proofs/CantorDiagonalizationOQ04OQ01OQ01OQ01.lean
@@ -14,36 +14,40 @@ instances and a fixed-point-free `t`."
 
 The parent entry (`cantor-diagonalization-oq-04-oq-01-oq-01`) proves
 `LawvereCCC.lawvere_fixedPoint` at full categorical generality: in *any* cartesian
-closed category, a point-surjective `φ : A ⟶ (A ⟹ B)` forces every endomorphism
-`t : B ⟶ B` to have a fixed global point.  This file cashes that abstract theorem
-out in the two standard models.
+closed category (Mathlib's `MonoidalClosed` over a `CartesianMonoidalCategory`), a
+point-surjective `φ : A ⟶ (A ⟹ B)` forces every endomorphism `t : B ⟶ B` to have a
+fixed global point.  This file cashes that abstract theorem out in the two standard
+models.
 
 ### The bridge: categorical point-surjectivity is honest surjectivity in `Type`
 
 The only real work is translating the categorical vocabulary into set-theoretic
-language for `C = Type u`, where Mathlib supplies `CartesianClosed (Type u)`:
+language for `C = Type u`, where Mathlib supplies `MonoidalClosed (Type u)`:
 
 * the monoidal unit is `𝟙_ (Type u) = PUnit`, so a **global point** `𝟙_ ⟶ A` is
-  literally a function `PUnit → A`, i.e. an element `a PUnit.unit : A`;
-* the exponential is `A ⟹ B = (A → B)`, and **evaluation** `exp.ev` is honest
-  function application `(a, h) ↦ h a` (`ev_apply`);
-* hence `uncurry g (a, y) = g y a` (`uncurry_apply`), and the *name* of `f : A → B`
-  evaluates to `f` itself: `name f PUnit.unit = f` (`name_apply`).
+  (the wrapper of) a function `PUnit → A`, i.e. an element `a PUnit.unit : A`;
+* the internal hom is the hom-type itself: `A ⟹ B` is definitionally `A ⟶ B`
+  (Mathlib's `TypeCat.Hom`, a structure wrapping `A → B`); the definitional
+  bridges `elemToHom` / `homToElem` make this identification explicit;
+* **evaluation** `ihom.ev` is honest function application `(a, h) ↦ h a`
+  (`ev_apply`); hence `uncurry g (a, y) = g y a` (`uncurry_apply`), and the *name*
+  of `f : A ⟶ B` evaluates to `f` itself: `name f PUnit.unit = f` (`name_apply`).
 
-These collapse `LawvereCCC.PointSurjective φ` to `Function.Surjective φ`
-(`pointSurjective_iff_surjective`).  Feeding a **fixed-point-free** endomorphism
-through `lawvere_cantor` then yields the diagonal theorems.
+These collapse `LawvereCCC.PointSurjective φ` to `Function.Surjective` of the
+underlying map (`pointSurjective_iff_surjective`).  Feeding a **fixed-point-free**
+endomorphism through `lawvere_cantor` then yields the diagonal theorems.
 
 ### Results
 * `ev_apply`, `uncurry_apply`, `name_apply` — the computational bridge in `Type`.
-* `pointSurjective_iff_surjective` — `PointSurjective φ ↔ Function.Surjective φ`.
+* `pointSurjective_iff_surjective` — `PointSurjective φ ↔ Function.Surjective` of
+  the underlying map `a ↦ φ a`.
 * `no_surjective_of_fixedPointFree` — for any `t : B → B` with no fixed point there
   is no surjection `A → (A → B)`.  This is Lawvere's diagonal in `Type`.
 * `cantor_no_surjective` — **Cantor**: no surjection `A → (A → Bool)`, from the
   fixed-point-free `t = (!·)`.
 * `lawvere_fixedPoint_presheaf`, `lawvere_cantor_presheaf` — the fixed-point form
   and its contrapositive in a presheaf topos `C ⥤ Type u`, using Mathlib's
-  `CartesianClosed (C ⥤ Type u)` instance.
+  `MonoidalClosed (C ⥤ Type u)` instance.
 
 Everything is machine-checked with no `sorry` and no new axioms.
 -/
@@ -52,7 +56,8 @@ universe u v
 
 open CategoryTheory CategoryTheory.Category CategoryTheory.Limits
 open CategoryTheory.MonoidalCategory CategoryTheory.CartesianMonoidalCategory
-open CategoryTheory.CartesianClosed
+open CategoryTheory.MonoidalClosed
+open scoped CategoryTheory.CartesianClosed
 open LawvereCCC
 
 namespace LawvereType
@@ -61,63 +66,93 @@ section TypeBridge
 
 variable {A B X Y : Type u}
 
+/-- **The internal hom of `Type` is the hom-type.**  An element of the exponential
+object `A ⟹ X` *is*, definitionally, a morphism `A ⟶ X` (Mathlib's `TypeCat.Hom`
+wrapper around `A → X`).  This definitional bridge makes the identification
+explicit for the elaborator. -/
+def elemToHom (h : A ⟹ X) : A ⟶ X := h
+
+/-- The inverse definitional bridge: a morphism `A ⟶ X` as an element of the
+exponential object `A ⟹ X`. -/
+def homToElem (h : A ⟶ X) : A ⟹ X := h
+
+@[simp] lemma elemToHom_homToElem (h : A ⟶ X) : elemToHom (homToElem h) = h := rfl
+
+@[simp] lemma homToElem_elemToHom (h : A ⟹ X) : homToElem (elemToHom h) = h := rfl
+
+lemma elemToHom_injective :
+    Function.Injective (elemToHom : (A ⟹ X) → (A ⟶ X)) := fun _ _ h => h
+
 /-- **Evaluation in `Type` is honest application.**  The cartesian-closed
-evaluation `exp.ev A` is, on the model `A ⟹ X = (A → X)`, the map
+evaluation `ihom.ev A` is, on the model `A ⟹ X ≃ (A → X)`, the map
 `(a, h) ↦ h a`. -/
-lemma ev_apply (a : A) (h : A ⟹ X) : (exp.ev A).app X (a, h) = h a := rfl
+lemma ev_apply (a : A) (h : A ⟹ X) : (ihom.ev A).app X (a, h) = elemToHom h a := rfl
 
 /-- **Uncurrying in `Type` is honest application.**  For `g : Y ⟶ (A ⟹ X)`,
 `uncurry g (a, y) = g y a`. -/
 lemma uncurry_apply (g : Y ⟶ (A ⟹ X)) (a : A) (y : Y) :
-    (CartesianClosed.uncurry g) (a, y) = g y a := by
-  rw [CartesianClosed.uncurry_eq, types_comp_apply, whiskerLeft_apply, ev_apply]
+    (MonoidalClosed.uncurry g) (a, y) = elemToHom (g y) a := rfl
 
 /-- **The name of `f` evaluates to `f`.**  In `Type`, the categorical *name*
-`name f : 𝟙_ ⟶ (A ⟹ B)` of a function `f : A → B` is the global point picking out
+`name f : 𝟙_ ⟶ (A ⟹ B)` of a morphism `f : A ⟶ B` is the global point picking out
 `f` itself: `name f PUnit.unit = f`. -/
-lemma name_apply (f : A ⟶ B) : (name f) PUnit.unit = f := by
-  funext a
-  have h1 : CartesianClosed.uncurry (name f) = (ρ_ A).hom ≫ f := by
+lemma name_apply (f : A ⟶ B) : elemToHom ((name f) PUnit.unit) = f := by
+  have h1 : MonoidalClosed.uncurry (name f) = (ρ_ A).hom ≫ f := by
     rw [name_def, uncurry_curry]
-  have h2 := congrFun h1 (a, PUnit.unit)
+  ext a
+  have h2 := types_congr_hom h1 (a, PUnit.unit)
   rw [uncurry_apply] at h2
   rw [types_comp_apply, rightUnitor_hom_apply] at h2
   exact h2
 
 /-- **Categorical point-surjectivity is honest surjectivity in `Type`.**  For a
-function `φ : A → (A → B)`, viewed as a morphism `A ⟶ (A ⟹ B)`, the categorical
-`PointSurjective φ` is equivalent to `Function.Surjective φ`. -/
+morphism `φ : A ⟶ (A ⟹ B)`, the categorical `PointSurjective φ` is equivalent to
+`Function.Surjective` of the underlying map `a ↦ φ a : A → (A ⟶ B)`. -/
 theorem pointSurjective_iff_surjective (φ : A ⟶ (A ⟹ B)) :
-    PointSurjective φ ↔ Function.Surjective φ := by
+    PointSurjective φ ↔ Function.Surjective (fun a => elemToHom (φ a)) := by
   constructor
   · intro hφ h
     obtain ⟨a, ha⟩ := hφ h
     refine ⟨a PUnit.unit, ?_⟩
-    have := congrFun ha PUnit.unit
-    rwa [types_comp_apply, name_apply] at this
+    have hpt := types_congr_hom ha PUnit.unit
+    rw [types_comp_apply] at hpt
+    show elemToHom (φ (a PUnit.unit)) = h
+    rw [hpt]
+    exact name_apply h
   · intro hsurj f
     obtain ⟨a, ha⟩ := hsurj f
-    refine ⟨fun _ => a, ?_⟩
-    funext u
+    refine ⟨TypeCat.ofHom fun _ => a, ?_⟩
+    have key : φ a = name f PUnit.unit :=
+      elemToHom_injective (ha.trans (name_apply f).symm)
+    ext u
+    show φ ((TypeCat.ofHom fun _ => a) u) = (name f) u
     have hu : u = PUnit.unit := rfl
-    rw [types_comp_apply, hu, name_apply]
-    exact ha
+    rw [hu]
+    exact key
+
+end TypeBridge
 
 /-- **Lawvere's diagonal argument in `Type`.**  If `t : B → B` has no fixed point,
 then there is no surjection `A → (A → B)`.  This is the decategorification of
 `lawvere_cantor`: the diagonal `f a = t (φ a a)` would be a value `φ a` of a
 surjection, but then `t` would fix `f a`. -/
-theorem no_surjective_of_fixedPointFree {t : B → B} (ht : ∀ b, t b ≠ b)
+theorem no_surjective_of_fixedPointFree {A B : Type u} {t : B → B} (ht : ∀ b, t b ≠ b)
     (φ : A → (A → B)) : ¬ Function.Surjective φ := by
-  have hcat : ∀ s : 𝟙_ (Type u) ⟶ B, ¬ IsFixedPoint (t : B ⟶ B) s := by
-    intro s hs
-    have h := congrFun hs PUnit.unit
-    rw [types_comp_apply] at h
-    exact ht (s PUnit.unit) h
   intro hsurj
-  exact lawvere_cantor hcat φ ((pointSurjective_iff_surjective φ).mpr hsurj)
-
-end TypeBridge
+  -- package the data categorically
+  set Φ : A ⟶ (A ⟹ B) := TypeCat.ofHom fun a => homToElem (TypeCat.ofHom (φ a)) with hΦ
+  have hcat : ∀ s : 𝟙_ (Type u) ⟶ B, ¬ IsFixedPoint (TypeCat.ofHom t) s := by
+    intro s hs
+    have h := types_congr_hom hs PUnit.unit
+    rw [types_comp_apply, TypeCat.ofHom_apply] at h
+    exact ht (s PUnit.unit) h
+  have hΦsurj : Function.Surjective (fun a => elemToHom (Φ a)) := by
+    intro g
+    obtain ⟨a, ha⟩ := hsurj (g : A → B)
+    refine ⟨a, ?_⟩
+    show elemToHom (Φ a) = g
+    rw [hΦ, TypeCat.ofHom_apply, elemToHom_homToElem, ha, TypeCat.ofHom_eq]
+  exact lawvere_cantor hcat Φ ((pointSurjective_iff_surjective Φ).mpr hΦsurj)
 
 /-- **Cantor's theorem, as a corollary of Lawvere.**  There is no surjection
 `A → (A → Bool)`, because `t = (!·)` is a fixed-point-free endomorphism of `Bool`.
@@ -132,7 +167,7 @@ some `g : A → Bool` lies outside its image — the diagonal complement. -/
 theorem cantor_exists_missed (A : Type) (φ : A → (A → Bool)) :
     ∃ g : A → Bool, ∀ a, φ a ≠ g := by
   by_contra h
-  push_neg at h
+  push Not at h
   exact cantor_no_surjective A φ h
 
 section Presheaf
@@ -140,7 +175,7 @@ section Presheaf
 variable {C : Type u} [SmallCategory C] {A B : C ⥤ Type u}
 
 /-- **Lawvere's fixed-point theorem in a presheaf topos.**  Mathlib provides
-`CartesianClosed (C ⥤ Type u)`, so the abstract theorem applies verbatim: a
+`MonoidalClosed (C ⥤ Type u)`, so the abstract theorem applies verbatim: a
 point-surjective `φ : A ⟶ (A ⟹ B)` of presheaves forces every endomorphism
 `t : B ⟶ B` to have a fixed global point. -/
 theorem lawvere_fixedPoint_presheaf {φ : A ⟶ (A ⟹ B)} (hφ : PointSurjective φ)

--- a/proofs/Proofs/ElementaryQuadraticReciprocityOQ01OQ01OQ03.lean
+++ b/proofs/Proofs/ElementaryQuadraticReciprocityOQ01OQ01OQ03.lean
@@ -76,20 +76,21 @@ variable {F R : Type*} [Field F] [Fintype F] [CommRing R]
     - n=4 (quartic): J(χ,χ)·g(χ²) = g(χ)²
 
     Source: `jacobiSum_mul_nontrivial` in Mathlib.NumberTheory.JacobiSum.Basic -/
-theorem jacobiSum_gaussSum_relation
+theorem jacobiSum_gaussSum_relation [IsDomain R]
     {χ φ : MulChar F R} (h : χ * φ ≠ 1) (ψ : AddChar F R) :
     gaussSum (χ * φ) ψ * jacobiSum χ φ = gaussSum χ ψ * gaussSum φ ψ :=
   jacobiSum_mul_nontrivial h ψ
 
-/-- Ratio form: J(χ, φ) = g(χ)·g(φ)/g(χφ), when #F ≠ 0 in the target ring. -/
+/-- Ratio form: J(χ, φ) = g(χ)·g(φ)/g(χφ), when #F ≠ 0 in the target field. -/
 theorem jacobiSum_ratio_form
-    (h : (Fintype.card F : R) ≠ 0) {χ φ : MulChar F R} (hχφ : χ * φ ≠ 1)
-    {ψ : AddChar F R} (hψ : ψ.IsPrimitive) :
+    {F' : Type*} [Field F']
+    (h : (Fintype.card F : F') ≠ 0) {χ φ : MulChar F F'} (hχφ : χ * φ ≠ 1)
+    {ψ : AddChar F F'} (hψ : ψ.IsPrimitive) :
     jacobiSum χ φ = gaussSum χ ψ * gaussSum φ ψ / gaussSum (χ * φ) ψ :=
   jacobiSum_eq_gaussSum_mul_gaussSum_div_gaussSum h hχφ hψ
 
 /-- J(1, χ) = -1 for any nontrivial χ (trivial-nontrivial boundary case). -/
-theorem jacobiSum_trivial_left {χ : MulChar F R} (hχ : χ ≠ 1) :
+theorem jacobiSum_trivial_left [IsDomain R] {χ : MulChar F R} (hχ : χ ≠ 1) :
     jacobiSum 1 χ = -1 := jacobiSum_one_nontrivial hχ
 
 /-- **Complementary Pair**: J(χ, χ⁻¹) = -χ(-1) for nontrivial χ.
@@ -97,7 +98,7 @@ theorem jacobiSum_trivial_left {χ : MulChar F R} (hχ : χ ≠ 1) :
     For quadratic χ (where χ⁻¹ = χ): J(χ, χ) = -χ(-1) = ∓1.
     This shows the quadratic Jacobi sum is trivial — the substantive result
     is the Gauss sum norm τ² = χ(-1)·p, not the Jacobi sum directly. -/
-theorem jacobiSum_self_inv {χ : MulChar F R} (hχ : χ ≠ 1) :
+theorem jacobiSum_self_inv [IsDomain R] {χ : MulChar F R} (hχ : χ ≠ 1) :
     jacobiSum χ χ⁻¹ = -χ (-1) := jacobiSum_nontrivial_inv hχ
 
 /-- Commutativity: J(χ, φ) = J(φ, χ). -/
@@ -210,7 +211,7 @@ variable {p : ℕ} [hp : Fact p.Prime]
     This is why the quadratic case is DEGENERATE: the product `χ * χ = 1` is
     trivial, violating the hypothesis of `jacobiSum_algebraic_norm`.
     The interesting object for quadratic QR is the Gauss sum, not the Jacobi sum. -/
-theorem quadratic_jacobi_is_sign {F R : Type*} [Field F] [Fintype F] [CommRing R]
+theorem quadratic_jacobi_is_sign {F R : Type*} [Field F] [Fintype F] [CommRing R] [IsDomain R]
     {χ : MulChar F R} (hχ : χ ≠ 1) :
     jacobiSum χ χ⁻¹ = -χ (-1) :=
   jacobiSum_nontrivial_inv hχ

--- a/proofs/Proofs/Erdos1022OQ01.lean
+++ b/proofs/Proofs/Erdos1022OQ01.lean
@@ -40,10 +40,14 @@ def HasPropertyBK [Fintype α] (F : Finset (Finset α)) (k : ℕ) : Prop :=
 
 /- ## Basic Properties -/
 
-/-- The empty family has Property B_k for all k. -/
-theorem hasPropertyBK_empty [Fintype α] (k : ℕ) :
+/-- The empty family has Property B_k for all k ≥ 1.
+    (A coloring `χ : α → Fin k` must exist; for `k = 0` and nonempty `α` no such
+    function exists, so the positivity hypothesis is genuinely needed — the
+    original v4.26 proof's bare `0 : Fin k` silently relied on an instance that
+    no longer type-checks for unconstrained `k`.) -/
+theorem hasPropertyBK_empty [Fintype α] {k : ℕ} (hk : 1 ≤ k) :
     HasPropertyBK (∅ : Finset (Finset α)) k :=
-  ⟨fun _ => 0, fun f hf => absurd hf (Finset.notMem_empty f)⟩
+  ⟨fun _ => ⟨0, by omega⟩, fun f hf => absurd hf (Finset.notMem_empty f)⟩
 
 /-- Property B_k is monotone: subsets of Property B_k families have Property B_k. -/
 theorem hasPropertyBK_subset [Fintype α] {F G : Finset (Finset α)} {k : ℕ}
@@ -64,7 +68,7 @@ theorem hasPropertyBK_singleton [Fintype α] {f : Finset α} {k : ℕ}
   have hb : b ∈ f := Finset.mem_of_mem_erase hb_era
   have hba : b ≠ a := Finset.ne_of_mem_erase hb_era
   -- Color a with 0, everything else with 1
-  refine ⟨fun x => if x = a then 0 else ⟨1, by omega⟩, fun g hg hgne => ?_⟩
+  refine ⟨fun x => if x = a then ⟨0, by omega⟩ else ⟨1, by omega⟩, fun g hg hgne => ?_⟩
   rw [Finset.mem_singleton] at hg; subst hg
   exact ⟨a, b, ha, hb, by simp [hba]⟩
 
@@ -121,7 +125,11 @@ theorem propertyB_iff_propertyBK_two [Fintype α] {F : Finset (Finset α)}
     · constructor
       · have h1 : χ b ≠ χ a := Ne.symm hab
         have hb0 : χ b = 0 := by
-          fin_cases (χ a) <;> fin_cases (χ b) <;> simp_all
+          have h0v : (χ a).val ≠ 0 := fun h => h0 (Fin.ext h)
+          have h1v : (χ b).val ≠ (χ a).val := fun h => h1 (Fin.ext h)
+          have hav : (χ a).val < 2 := (χ a).isLt
+          have hbv : (χ b).val < 2 := (χ b).isLt
+          exact Fin.ext (by omega)
         exact ⟨b, Finset.mem_inter.mpr ⟨hb, Finset.mem_filter.mpr ⟨Finset.mem_univ _, hb0⟩⟩⟩
       · refine ⟨a, Finset.mem_sdiff.mpr ⟨ha, fun hmem => ?_⟩⟩
         rw [Finset.mem_filter] at hmem
@@ -134,7 +142,7 @@ theorem hasPropertyBK_card_le_one [Fintype α] {F : Finset (Finset α)} {k : ℕ
     (hsize : ∀ f ∈ F, 2 ≤ f.card) (hk : 2 ≤ k)
     (hF : F.card ≤ 1) : HasPropertyBK F k := by
   rcases Nat.eq_or_lt_of_le (Nat.zero_le F.card) with h | h
-  · rw [Finset.card_eq_zero.mp h]; exact hasPropertyBK_empty k
+  · rw [Finset.card_eq_zero.mp h.symm]; exact hasPropertyBK_empty (by omega)
   · obtain ⟨f, hf⟩ := Finset.card_eq_one.mp (by omega : F.card = 1)
     rw [hf]; exact hasPropertyBK_singleton (hsize f (hf ▸ Finset.mem_singleton_self f)) hk
 

--- a/proofs/batch2/STATUS.md
+++ b/proofs/batch2/STATUS.md
@@ -1,3 +1,11 @@
+# DOCTOR SINGLE-PROOF BATCH 104 (mixed fleet, #38065, 2026-07-16)
+
+**+3 GREEN** (re-verified EXIT=0): ElementaryQuadraticReciprocityOQ01OQ01OQ03 (JacobiSum.Basic now gates
+lemmas behind [IsDomain R]; ratio/norm lemmas need [Field F']), Erdos1022OQ01 (OfNat(Fin k) 0 needs NeZero;
+#38611 REPAIR added 1≤k to hasPropertyBK_empty — k=0 unsound), CantorDiagonalizationOQ04OQ01OQ01OQ01
+(TypeCat.Hom now a struct — element-application no longer elaborates; identity bridges elemToHom/homToElem;
+CartesianClosed->MonoidalClosed, exp.ev->ihom.ev). Repairs: 1 (#38611 Erdos1022OQ01). Closes Cantor family.
+
 # DOCTOR SINGLE-PROOF BATCH 103 (mixed fleet, #38065, 2026-07-16)
 
 **+1 GREEN** (re-verified EXIT=0): Erdos1007OQ05 (Finset.add_sum_erase chained double-erase rewrite no

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -328,7 +328,7 @@ CantorDiagonalizationOQ03OQ01Incomplete01	RESIDUAL	type-mismatch
 CantorDiagonalizationOQ04	GREEN	
 CantorDiagonalizationOQ04OQ01	GREEN	
 CantorDiagonalizationOQ04OQ01OQ01	GREEN	
-CantorDiagonalizationOQ04OQ01OQ01OQ01	RESIDUAL	instance-synth
+CantorDiagonalizationOQ04OQ01OQ01OQ01	GREEN	
 CantorDiagonalizationOQ04OQ03	GREEN	
 CantorDiagonalizationOQ04OQ03Aristotle	GREEN	
 CantorsTheoremOQ01	GREEN	
@@ -582,7 +582,7 @@ EgorovTheoremOQ01OQ03	GREEN
 EhrhartCrossPolytope	GREEN	
 EisensteinCriterionOQ01OQ03OQ02OQ01	GREEN	
 ElementaryQuadraticReciprocityOQ01	GREEN	
-ElementaryQuadraticReciprocityOQ01OQ01OQ03	RESIDUAL	instance-synth
+ElementaryQuadraticReciprocityOQ01OQ01OQ03	GREEN	
 ElementaryQuadraticReciprocityOQ01OQ03	GREEN	
 ElementaryQuadraticReciprocityOQ01OQ03OQ01	GREEN	
 ElementaryQuadraticReciprocityOQ01OQ03OQ01OQ01	GREEN	
@@ -679,7 +679,7 @@ Erdos1021OQ01Incomplete01	GREEN
 Erdos1021Problem	GREEN	v4.31-migrated
 Erdos1021Wip01	GREEN	
 Erdos1021Wip02	GREEN	
-Erdos1022OQ01	RESIDUAL	instance-synth
+Erdos1022OQ01	GREEN	
 Erdos1022OQ03	GREEN	
 Erdos1022Problem	GREEN	
 Erdos1023OQ01	GREEN	


### PR DESCRIPTION
ElementaryQuadraticReciprocity + Erdos1022OQ01 (#38611: 1≤k) + CantorDiagonalizationOQ04OQ01OQ01OQ01. No loom labels.