### PR TITLE
migrate(v4.31): single-proof batch 106 (+1 GREEN)

### DIFF
--- a/proofs/Proofs/Erdos1097OQ01.lean
+++ b/proofs/Proofs/Erdos1097OQ01.lean
@@ -26,6 +26,7 @@ import Mathlib.Tactic
 import Mathlib.Data.Finset.Basic
 
 open scoped Classical
+open scoped Pointwise
 
 open Finset
 
@@ -101,8 +102,8 @@ theorem commonDiffK_subset_mono {A B : Set ℤ} {k : ℕ} (h : A ⊆ B) :
 theorem neg_mem_commonDiffK {A : Set ℤ} {k : ℕ} {d : ℤ}
     (hk : 2 ≤ k) (hd : d ∈ commonDiffK A k) : -d ∈ commonDiffK A k := by
   obtain ⟨a, ha⟩ := hd
-  refine ⟨a + ((k : ���) - 1) * d, fun i hi => ?_⟩
-  have hcast : (��(k - 1 - i) : ℤ) = (k : ℤ) - 1 - (i : ℤ) := by omega
+  refine ⟨a + ((k : ℤ) - 1) * d, fun i hi => ?_⟩
+  have hcast : (↑(k - 1 - i) : ℤ) = (k : ℤ) - 1 - (i : ℤ) := by omega
   have key : a + ((k : ℤ) - 1) * d + (i : ℤ) * (-d) = a + ↑(k - 1 - i) * d := by
     rw [hcast]; ring
   rw [key]
@@ -168,7 +169,7 @@ theorem isKAP_three_iff (A : Set ℤ) (a d : ℤ) :
     · have := h 1 (by omega); simpa using this
     · have := h 2 (by omega); simpa using this
   · intro ⟨h0, h1, h2⟩ i hi
-    interval_cases i <;> simpa using *
+    interval_cases i <;> simp_all
 
 /- ## Main Open Question -/
 

--- a/proofs/batch2/STATUS.md
+++ b/proofs/batch2/STATUS.md
@@ -1,3 +1,9 @@
+# DOCTOR SINGLE-PROOF BATCH 106 (mixed fleet, #38065, 2026-07-16)
+
+**+1 GREEN** (re-verified EXIT=0): Erdos1097OQ01 (fixed literal UTF-8 replacement-char corruption in
+ℤ/↑ glyphs [pre-existing, unrelated to bump]; Finset A-A needs open scoped Pointwise in v4.31;
+simpa using *->simp_all). Repair: none.
+
 # DOCTOR SINGLE-PROOF BATCH 105 (mixed fleet, #38065, 2026-07-16)
 
 **+1 GREEN** (re-verified EXIT=0): CentralLimitTheoremOQ01OQ02OQ01OQ01 (ascribe (expr:ℝ) inside Complex.exp

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -788,7 +788,7 @@ Erdos1091Problem	GREEN
 Erdos1093OQ02FactorialGrowth	GREEN	
 Erdos1095OQ01Problem	RESIDUAL	partenat-removal
 Erdos1096Problem	GREEN	
-Erdos1097OQ01	RESIDUAL	instance-synth
+Erdos1097OQ01	GREEN	
 Erdos1097Problem	GREEN	
 Erdos1098OQ01	RESIDUAL	type-mismatch
 Erdos1098OQ01OQ01	RESIDUAL	instance-synth


### PR DESCRIPTION
Erdos1097OQ01. No loom labels.