### PR TITLE
migrate(v4.31): single-proof batch 119 (+1 GREEN)

### DIFF
--- a/proofs/batch2/STATUS.md
+++ b/proofs/batch2/STATUS.md
@@ -1,3 +1,8 @@
+# DOCTOR SINGLE-PROOF BATCH 119 (mixed fleet, #38065, 2026-07-16)
+
+**+1 GREEN** (re-verified EXIT=0): Erdos107OQ01 (no edits; stale RESIDUAL from missing-cache cascade,
+clean once dependency Erdos107OQ01KleinUpperAristotle built). Repair: none. Closes Erdos107 family.
+
 # DOCTOR SINGLE-PROOF BATCH 118 (mixed fleet, #38065, 2026-07-16)
 
 **+1 GREEN** (re-verified EXIT=0): Erdos107OQ01KleinUpperAristotle (hard grind-limit file: replaced ALL

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -769,7 +769,7 @@ Erdos1075Problem	GREEN
 Erdos1076Problem	GREEN	
 Erdos1078Problem	GREEN
 Erdos1079Problem	GREEN	
-Erdos107OQ01	RESIDUAL	instance-synth
+Erdos107OQ01	GREEN	
 Erdos107OQ01KleinUpperAristotle	GREEN	
 Erdos1080OQ03	RESIDUAL	type-mismatch
 Erdos1080Problem	GREEN	


### PR DESCRIPTION
Erdos107OQ01. No loom labels.