### PR TITLE
migrate(v4.31): single-proof batch 120 (+1 GREEN, 1 repair)

### DIFF
--- a/proofs/Proofs/Erdos447Problem.lean
+++ b/proofs/Proofs/Erdos447Problem.lean
@@ -26,6 +26,8 @@ import Mathlib.Data.Finset.Basic
 import Mathlib.Data.Finset.Powerset
 import Mathlib.Data.Nat.Choose.Basic
 import Mathlib.Data.Real.Basic
+import Mathlib.Data.Fintype.Fin
+import Mathlib.Data.Fintype.Powerset
 import Mathlib.Combinatorics.SetFamily.Compression.Down
 
 open scoped Classical
@@ -78,7 +80,7 @@ def IsLittleO (f g : ℕ → ℕ) : Prop :=
 
 /-- The maximum size of a union-free collection over subsets of [n] -/
 noncomputable def maxUnionFreeSize (n : ℕ) : ℕ :=
-  ((powerSet n).filter IsUnionFree).sup Finset.card
+  ((powerSet n).powerset.filter IsUnionFree).sup Finset.card
 
 /-- f(n) ≤ (1+o(1))·g(n): upper bound with asymptotically vanishing error -/
 def AsymptoticUpperBound (f g : ℕ → ℕ) : Prop :=

--- a/proofs/batch2/STATUS.md
+++ b/proofs/batch2/STATUS.md
@@ -1,3 +1,10 @@
+# DOCTOR SINGLE-PROOF BATCH 120 (mixed fleet, #38065, 2026-07-16)
+
+**+1 GREEN** (re-verified EXIT=0): Erdos447Problem (missing Data.Fintype.Fin/Powerset imports; #38611
+REPAIR: maxUnionFreeSize was ill-typed — filtered powerSet n with IsUnionFree [predicate on FAMILIES],
+now filters (powerSet n).powerset; affects axioms kleitman_theorem/lower_bound — flagged for re-audit).
+Repairs: 1 (#38611 Erdos447Problem def-semantics).
+
 # DOCTOR SINGLE-PROOF BATCH 119 (mixed fleet, #38065, 2026-07-16)
 
 **+1 GREEN** (re-verified EXIT=0): Erdos107OQ01 (no edits; stale RESIDUAL from missing-cache cascade,

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -1274,7 +1274,7 @@ Erdos443Problem	GREEN
 Erdos444Problem	GREEN	
 Erdos445Problem	GREEN	
 Erdos446Problem	GREEN	
-Erdos447Problem	RESIDUAL	instance-synth
+Erdos447Problem	GREEN	
 Erdos449Problem	GREEN	
 Erdos44Problem	GREEN	
 Erdos44SidonLowerBound	GREEN	


### PR DESCRIPTION
Erdos447Problem (#38611: maxUnionFreeSize type-fix). No loom labels.