### PR TITLE
migrate(v4.31): single-proof batch 127 (+2 GREEN)

### DIFF
--- a/proofs/Proofs/Erdos395OQ01.lean
+++ b/proofs/Proofs/Erdos395OQ01.lean
@@ -55,6 +55,29 @@ axiom extremal_example_tight (n : ℕ) (hn : n ≥ 4) :
     probSmallSum (extremal_example n) ≤ C / n
 
 -- ══════════════════════════════════════════════════════════════════
+-- § 0b. v4.31 migration compat: local Fintype instances
+--
+-- The parent `Erdos395Problem` was reshaped to use `Set.ncard` and no
+-- longer provides `Fintype` instances for `{ε | isSignVector ε}` (and
+-- refinements thereof). We recover them here from `Set.Finite`.
+-- ══════════════════════════════════════════════════════════════════
+
+theorem isSignVector_setFinite (n : ℕ) : {ε : Fin n → ℤ | isSignVector ε}.Finite := by
+  have heq : {ε : Fin n → ℤ | isSignVector ε} =
+      {f : Fin n → ℤ | ∀ i, f i ∈ ({1, -1} : Set ℤ)} := by
+    ext ε
+    simp only [Set.mem_setOf_eq, isSignVector, Set.mem_insert_iff, Set.mem_singleton_iff]
+  rw [heq]
+  exact Set.Finite.pi' (fun _ => Set.toFinite _)
+
+noncomputable instance signVectorFintype (n : ℕ) : Fintype {ε : Fin n → ℤ | isSignVector ε} :=
+  (isSignVector_setFinite n).fintype
+
+noncomputable instance signVectorAndFintype (n : ℕ) (p : (Fin n → ℤ) → Prop) :
+    Fintype {ε : Fin n → ℤ | isSignVector ε ∧ p ε} :=
+  ((isSignVector_setFinite n).subset (fun _ h => h.1)).fintype
+
+-- ══════════════════════════════════════════════════════════════════
 -- § 1. The Optimal Constant
 -- ══════════════════════════════════════════════════════════════════
 
@@ -91,6 +114,7 @@ theorem valid_constants_bddAbove :
   rw [div_le_one (by positivity : (0 : ℝ) < (2 : ℝ) ^ 1)]
   -- Goal: ↑(countSmallSums ...) ≤ 2^1 = 2
   unfold countSmallSums
+  rw [Set.ncard_eq_toFinset_card']
   -- The filtered set is a subset of the sign vector set
   -- For n = 1, sign vectors are {fun _ => 1, fun _ => -1} (2 elements)
   -- So card of any subset ≤ 2
@@ -161,8 +185,9 @@ theorem erdos_original_is_false_proved :
     set z := carnielli_carolino_counterexample 2 ⟨1, rfl⟩ (by omega)
     have hz : isUnitVector z := by
       intro i
-      show Complex.abs (carnielli_carolino_counterexample 2 ⟨1, rfl⟩ (by omega) i) = 1
-      fin_cases i <;> simp [carnielli_carolino_counterexample, Complex.abs]
+      show Complex.abs (if i.val = 0 then (1 : ℂ) else Complex.I) = 1
+      simp only [Complex.abs]
+      fin_cases i <;> simp
     -- All sign vectors give |sum| > 1 (from counterexample_exceeds_one)
     have hexceed : ∀ ε : Fin 2 → ℤ, isSignVector ε → ¬(signedSumAbs z ε ≤ 1) := by
       intro ε hε hle
@@ -175,8 +200,10 @@ theorem erdos_original_is_false_proved :
       simp only [Set.mem_toFinset, Set.mem_setOf_eq, not_and]
       exact hexceed ε
     -- Apply the bound: card / 4 ≥ c / 2, but card = 0
+    have hncard : {ε : Fin 2 → ℤ | isSignVector ε ∧ signedSumAbs z ε ≤ 1}.ncard = 0 := by
+      rw [Set.ncard_eq_toFinset_card', hempty, Finset.card_empty]
     have h0 := hbound z hz
-    rw [hempty, Finset.card_empty, Nat.cast_zero, zero_div] at h0
+    rw [hncard, Nat.cast_zero, zero_div] at h0
     -- h0 : 0 ≥ c / 2, but c > 0 → contradiction
     linarith
 
@@ -223,10 +250,10 @@ theorem rate_is_tight (n : ℕ) (hn : n ≥ 4) :
 /-- The extremal example has unit vectors (1 and i both have |z| = 1). -/
 theorem extremal_is_unit (n : ℕ) : isUnitVector (extremal_example n) := by
   intro i
-  simp only [extremal_example]
+  simp only [extremal_example, Complex.abs]
   split
-  · simp [Complex.abs]
-  · simp [Complex.abs]
+  · exact norm_one
+  · exact Complex.norm_I
 
 -- ══════════════════════════════════════════════════════════════════
 -- § 6. Summary

--- a/proofs/Proofs/Erdos485OQ02.lean
+++ b/proofs/Proofs/Erdos485OQ02.lean
@@ -41,6 +41,7 @@ set_option maxHeartbeats 800000
 namespace Erdos485OQ02
 
 open Polynomial Finset BigOperators
+open scoped Pointwise
 
 /-
 ## Part I: Definitions
@@ -140,14 +141,16 @@ theorem sumset_elem_in_sq_support_of_nonneg (P : Polynomial ℚ)
     {a b : ℕ} (ha : a ∈ P.support) (hb : b ∈ P.support) :
     a + b ∈ (P ^ 2).support := by
   rw [Polynomial.mem_support_iff, coeff_sq_convolution]
-  -- The single term c_a · c_b > 0, and all terms are ≥ 0, so the sum > 0
   have hab_pos : 0 < P.coeff a * P.coeff b :=
     mul_pos (lt_of_le_of_ne (hP a) (Ne.symm (Polynomial.mem_support_iff.mp ha)))
             (lt_of_le_of_ne (hP b) (Ne.symm (Polynomial.mem_support_iff.mp hb)))
   have hle : P.coeff a * P.coeff b ≤
-      ∑ ij ∈ Finset.antidiagonal (a + b), P.coeff ij.1 * P.coeff ij.2 :=
-    Finset.single_le_sum (fun ij _ => mul_nonneg (hP ij.1) (hP ij.2))
-      (Finset.mem_antidiagonal.mpr rfl)
+      ∑ ij ∈ Finset.antidiagonal (a + b), P.coeff ij.1 * P.coeff ij.2 := by
+    have hmem : (a, b) ∈ Finset.antidiagonal (a + b) := Finset.mem_antidiagonal.mpr rfl
+    have := Finset.single_le_sum (s := Finset.antidiagonal (a + b))
+      (f := fun ij : ℕ × ℕ => P.coeff ij.1 * P.coeff ij.2)
+      (fun ij _ => mul_nonneg (hP ij.1) (hP ij.2)) hmem
+    simpa using this
   exact (lt_of_lt_of_le hab_pos hle).ne'
 
 /-- For nonneg-coefficient polynomials, support(P²) equals the sumset exactly.
@@ -283,10 +286,11 @@ theorem cancellation_positions_bound (P : Polynomial ℚ) :
 theorem termCount_sq_upper (P : Polynomial ℚ) (k : ℕ)
     (htc : termCount P = k) :
     termCount (P ^ 2) ≤ k ^ 2 := by
+  have htc' : P.support.card = k := htc
   calc termCount (P ^ 2)
       ≤ (P.support + P.support).card := termCount_sq_le_sumset P
     _ ≤ P.support.card ^ 2 := cancellation_positions_bound P
-    _ = k ^ 2 := by rw [htc]
+    _ = k ^ 2 := by rw [htc']
 
 /-
 ## Summary

--- a/proofs/batch2/STATUS.md
+++ b/proofs/batch2/STATUS.md
@@ -1,3 +1,11 @@
+# DOCTOR SINGLE-PROOF BATCH 127 (mixed fleet, #38065, 2026-07-16)
+
+**+2 GREEN** (re-verified EXIT=0): Erdos485OQ02 (open scoped Pointwise for Finset +; termCount unfold
+before rw; Finset.single_le_sum explicit args vs whnf-timeout), Erdos395OQ01 (RE-FIX vs reshaped parent:
+local Fintype instances via Set.Finite since parent now Set.ncard; ncard_eq_toFinset_card' bridge;
+Complex.abs_one/abs_I->norm_one/norm_I). Repairs: none in this batch. Erdos395OQ01 supersedes stale branch.
+Unblocks Erdos395OQ01Incomplete01 grandchild.
+
 # DOCTOR SINGLE-PROOF BATCH 126 (mixed fleet, #38065, 2026-07-16)
 
 **+1 GREEN** (re-verified EXIT=0): Erdos501Aristotle (ℝ≥0∞ scoped notation needs open scoped ENNReal;

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -1317,7 +1317,7 @@ Erdos483OQ02	GREEN	elab-drift
 Erdos483Problem	GREEN	elab-drift
 Erdos484Problem	GREEN	
 Erdos485OQ01	PRE-EXISTING	never-compiled:d
-Erdos485OQ02	RESIDUAL	instance-synth
+Erdos485OQ02	GREEN	
 Erdos485Problem	GREEN	
 Erdos486Problem	GREEN	
 Erdos487Problem	RESIDUAL	type-mismatch


### PR DESCRIPTION
Erdos485OQ02 + Erdos395OQ01 (re-fix vs reshaped parent). No loom labels.