### PR TITLE
migrate(v4.31): ledger fix Erdos395OQ01 GREEN

### DIFF
--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -1209,7 +1209,7 @@ Erdos390Problem	GREEN
 Erdos391Problem	RESIDUAL	type-mismatch
 Erdos393Problem	GREEN	
 Erdos394Problem	GREEN	
-Erdos395OQ01	RESIDUAL	instance-synth
+Erdos395OQ01	GREEN	
 Erdos395OQ01Incomplete01	RESIDUAL	instance-synth
 Erdos395Problem	GREEN	
 Erdos396OQ04OQ01OQ01	GREEN	


### PR DESCRIPTION
Row missed in batch 127 (bare-name column). Source already merged + verified EXIT=0. No loom labels.