### PR TITLE
migrate(v4.31): single-proof batch 157 (+1 GREEN)

### DIFF
--- a/proofs/Proofs/MaschkeLocalRingOQ010102.lean
+++ b/proofs/Proofs/MaschkeLocalRingOQ010102.lean
@@ -64,7 +64,7 @@ noncomputable def g : A p := MonoidAlgebra.of (ZMod p) (G p) (Multiplicative.ofA
 
 /-- The **augmentation map** `ε : 𝔽_p[ℤ/p] → 𝔽_p`, `∑ a_h h ↦ ∑ a_h`. -/
 noncomputable def ε : A p →ₐ[ZMod p] ZMod p :=
-  MonoidAlgebra.lift (ZMod p) (G p) (ZMod p) 1
+  MonoidAlgebra.lift (ZMod p) (ZMod p) (G p) 1
 
 @[simp] theorem ε_of (a : G p) : ε p (MonoidAlgebra.of (ZMod p) (G p) a) = 1 := by
   simp [ε]

--- a/proofs/batch2/STATUS.md
+++ b/proofs/batch2/STATUS.md
@@ -1,3 +1,8 @@
+# DOCTOR SINGLE-PROOF BATCH 157 (mixed fleet, #38065, 2026-07-16)
+
+**+1 GREEN** (re-verified EXIT=0): MaschkeLocalRingOQ010102 (MonoidAlgebra.lift arg order R M A -> R A M).
+Repair: none.
+
 # DOCTOR SINGLE-PROOF BATCH 156 (mixed fleet, #38065, 2026-07-16)
 
 **+1 GREEN** (re-verified EXIT=0): Hilbert4Geodesics (HARD 14min: haveI->letI instance diamond for

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -2247,7 +2247,7 @@ LovaszLocalLemmaOQ01	GREEN
 LovaszLocalLemmaOQ01StrongInduction	GREEN	
 LovaszLocalLemmaOQ01SymmetricStep	GREEN	
 MaschkeAugmentationNoSplitOQ010101	GREEN	
-MaschkeLocalRingOQ010102	RESIDUAL	instance-synth
+MaschkeLocalRingOQ010102	GREEN	
 MaschkeModularCounterexampleOQ01	GREEN	
 MaschkeTheoremOQ01	GREEN	
 MathematicalInductionOQ01	GREEN	


### PR DESCRIPTION
MaschkeLocalRingOQ010102. No loom labels.