### PR TITLE
migrate(v4.31): ledger fix — restore 4 clobbered rows

### DIFF
--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -901,7 +901,7 @@ Erdos118Problem	GREEN
 Erdos1196Problem	GREEN	
 Erdos119Problem	GREEN	
 Erdos11Problem	GREEN	
-Erdos1201Problem	RESIDUAL	type-mismatch
+Erdos1201Problem	GREEN	
 Erdos1202Problem	GREEN	
 Erdos1206Problem	GREEN	
 Erdos1208Problem	GREEN	v4.31-migrated
@@ -941,7 +941,7 @@ Erdos14Problem	GREEN
 Erdos14UniqueSums	GREEN	
 Erdos150Problem	GREEN	
 Erdos152OQ01	RESIDUAL	type-mismatch
-Erdos152Problem	RESIDUAL	type-mismatch
+Erdos152Problem	GREEN	
 Erdos152ProblemAPN	GREEN	
 Erdos153Problem	GREEN	
 Erdos154Problem	GREEN	
@@ -962,7 +962,7 @@ Erdos168Problem	GREEN
 Erdos169Problem	GREEN	
 Erdos16Problem	GREEN	
 Erdos170Problem	GREEN	
-Erdos171Problem	RESIDUAL	type-mismatch
+Erdos171Problem	GREEN	
 Erdos173Problem	GREEN	
 Erdos174Problem	GREEN	
 Erdos176Problem	GREEN	
@@ -1018,7 +1018,7 @@ Erdos220Problem	GREEN
 Erdos220ProblemProvable	GREEN	
 Erdos221Problem	GREEN	
 Erdos222Problem	GREEN	
-Erdos223Problem	RESIDUAL	type-mismatch
+Erdos223Problem	GREEN	
 Erdos225Aristotle	GREEN	
 Erdos225Problem	GREEN	proof-drift
 Erdos226Problem	GREEN	


### PR DESCRIPTION
Batch 209's whole-file tsv checkout from a stale mig branch reverted Erdos1201/152/171/223Problem flips (their .lean already merged). Restored. No loom labels.