### PR TITLE
migrate(v4.31): single-proof batch 256 (+1 GREEN)

### DIFF
--- a/proofs/Proofs/FourierSeriesOQ04OQ01.lean
+++ b/proofs/Proofs/FourierSeriesOQ04OQ01.lean
@@ -547,11 +547,23 @@ theorem sphPartialSum_L2_norm_converge
             fun x => multiFourierCoeff f k *
               (fourier (k 0) (x 0) * fourier (k 1) (x 1)) := by
           simp only [hgdef]
-          have h1 := Lp.coeFn_smul (UnitAddTorus.mFourierCoeff (fhat : T2 → ℂ) k)
-            (UnitAddTorus.mFourierLp 2 k)
-          have h2 := UnitAddTorus.coeFn_mFourierLp (d := Fin 2) 2 k
+          -- Pin these facts' stated filter to `haarT2` explicitly (rather than letting them
+          -- elaborate over `mFourierLp`'s "native" `volume`): although `haarT2` and that native
+          -- measure are definitionally equal, they are not *syntactically* equal after `import
+          -- Mathlib`'s current elaboration of `UnitAddTorus.mFourierLp`'s ambient measure, so a
+          -- bare `rw` below would fail to find the pattern (v4.31 drift). Ascribing the type here
+          -- forces the unification once, up front, instead of relying on `rw`'s stricter matching.
+          have h1 : (⇑(UnitAddTorus.mFourierCoeff (fhat : T2 → ℂ) k • UnitAddTorus.mFourierLp 2 k)
+              : T2 → ℂ) =ᵐ[haarT2]
+              (UnitAddTorus.mFourierCoeff (fhat : T2 → ℂ) k) •
+                (⇑(UnitAddTorus.mFourierLp (d := Fin 2) 2 k) : T2 → ℂ) :=
+            Lp.coeFn_smul (UnitAddTorus.mFourierCoeff (fhat : T2 → ℂ) k)
+              (UnitAddTorus.mFourierLp 2 k)
+          have h2 : (⇑(UnitAddTorus.mFourierLp (d := Fin 2) 2 k) : T2 → ℂ) =ᵐ[haarT2]
+              ⇑(UnitAddTorus.mFourier k) :=
+            UnitAddTorus.coeFn_mFourierLp (d := Fin 2) 2 k
           filter_upwards [h1, h2] with x hx1 hx2
-          rw [hx1]
+          erw [hx1]
           simp only [Pi.smul_apply, hx2, smul_eq_mul]
           rw [mFourier_fin2, mFourierCoeff_eq_multiFourierCoeff f fhat hfhat k]
         filter_upwards [hk, ih] with x hxk hxs

--- a/proofs/batch2/STATUS.md
+++ b/proofs/batch2/STATUS.md
@@ -1,3 +1,8 @@
+# DOCTOR SINGLE-PROOF BATCH 256 (all-Sonnet + Opus, #38065, 2026-07-16)
+
+**+1 GREEN** (re-verified EXIT=0): FourierSeriesOQ04OQ01 (mFourierLp ambient measure defeq-not-syntactic vs
+local haarT2 -> erw not rw at coercion-application step). Repair: none. Unblocks Incomplete01 child.
+
 # DOCTOR SINGLE-PROOF BATCH 255 (all-Sonnet + Opus, #38065, 2026-07-16)
 
 **+1 GREEN** (re-verified EXIT=0): FundamentalTheoremCalculusStokes (integral_symm arg order; hasFDerivAt_id

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -1999,7 +1999,7 @@ FourierSeriesOQ02OQ03OQ02	GREEN
 FourierSeriesOQ02OQ03WIP01	GREEN	
 FourierSeriesOQ02OQ04	GREEN	
 FourierSeriesOQ04	GREEN	
-FourierSeriesOQ04OQ01	RESIDUAL	type-mismatch
+FourierSeriesOQ04OQ01	GREEN	
 FourierSeriesOQ04OQ01Incomplete01	RESIDUAL	type-mismatch
 FourthRoot2Degree4OQ02	GREEN	
 FourthRoot2GaloisClosure	GREEN	


### PR DESCRIPTION
FourierSeriesOQ04OQ01. No loom labels.