### PR TITLE
migrate(v4.31): single-proof batch 269 (+1 GREEN)

### DIFF
--- a/proofs/Proofs/MathematicalInductionOQ03.lean
+++ b/proofs/Proofs/MathematicalInductionOQ03.lean
@@ -52,11 +52,11 @@ theorem cyclic_induction {n : ℕ} [NeZero n] {P : ZMod n → Prop}
     ∀ k : ZMod n, P k := by
   have key : ∀ m : ℕ, P (m : ZMod n) := fun m => by
     induction m with
-    | zero => exact h0
-    | succ m ih => exact hsucc (m : ZMod n) ih
+    | zero => simpa using h0
+    | succ m ih => simpa using hsucc (m : ZMod n) ih
   intro k
   have := key (ZMod.val k)
-  rwa [ZMod.natCast_val] at this
+  rwa [ZMod.natCast_rightInverse k] at this
 
 /-! ## Part II: Modular Arithmetic Applications -/
 
@@ -68,7 +68,7 @@ theorem zmod_generated_by_one {n : ℕ} [NeZero n] :
   · exact ⟨0, by simp⟩
   · intro k hk
     obtain ⟨j, hj⟩ := hk
-    exact ⟨j + 1, by rw [succ_nsmul, one_smul, ← hj]⟩
+    exact ⟨j + 1, by rw [succ_nsmul, ← hj]⟩
 
 /-- The wraparound law: k + n = k in ZMod n.
     Adding n (which equals 0) is the identity. -/
@@ -124,22 +124,23 @@ theorem zmod_sum_neg_involution {n : ℕ} [NeZero n] :
     (Since 2 is invertible for odd n and 2S = 0 implies S = 0.) -/
 theorem zmod_sum_odd_eq_zero {n : ℕ} [NeZero n] (hn : Odd n) :
     ∑ k : ZMod n, k = 0 := by
+  have hS_eq := zmod_sum_neg_involution (n := n)
   set S := ∑ k : ZMod n, k with hS_def
-  -- From zmod_sum_neg_involution: S = -S, so S + S = 0
+  -- hS_eq : S = -S, so S + S = 0
   have hSS : S + S = 0 := by
-    calc S + S = S + (-S) := by rw [zmod_sum_neg_involution]
+    calc S + S = S + (-S) := by nth_rewrite 2 [hS_eq]; rfl
       _ = 0 := add_neg_cancel S
   -- 2 * S = 0
   have h2S : (2 : ZMod n) * S = 0 := by rwa [two_mul]
   -- n is odd → gcd(2,n) = 1 → 2 is a unit in ZMod n
-  have hcop : Nat.Coprime 2 n := Nat.coprime_two_left.mpr (Nat.Odd.not_even hn)
+  have hcop : Nat.Coprime 2 n := Nat.coprime_two_left.mpr hn
   -- Cancel 2 using its unit inverse
   obtain ⟨u, hu⟩ : IsUnit (2 : ZMod n) := (ZMod.unitOfCoprime 2 hcop).isUnit
   -- From 2 * S = 0 and 2 = ↑u (a unit), derive S = 0
   -- Multiply both sides by u⁻¹: u⁻¹ * (u * S) = u⁻¹ * 0 = 0
   -- u⁻¹ * u * S = 1 * S = S
   calc S = 1 * S := (one_mul S).symm
-    _ = (↑u⁻¹ * ↑u) * S := by rw [Units.val_inv_mul]
+    _ = (↑u⁻¹ * ↑u) * S := by rw [Units.inv_mul]
     _ = ↑u⁻¹ * (↑u * S) := mul_assoc _ _ _
     _ = ↑u⁻¹ * ((2 : ZMod n) * S) := by rw [hu]
     _ = ↑u⁻¹ * 0 := by rw [h2S]

--- a/proofs/batch2/STATUS.md
+++ b/proofs/batch2/STATUS.md
@@ -1,3 +1,9 @@
+# DOCTOR SINGLE-PROOF BATCH 269 (all-Sonnet + Opus, #38065, 2026-07-16)
+
+**+1 GREEN** (re-verified EXIT=0): MathematicalInductionOQ03 (ZMod.natCast_val now ZMod.cast i not i ->
+natCast_rightInverse; nth_rewrite vs set rw-both-occurrences; Nat.coprime_two_left↔Odd; Units.inv_mul).
+Repair: none.
+
 # DOCTOR SINGLE-PROOF BATCH 268 (all-Sonnet + Opus, #38065, 2026-07-16)
 
 **+1 GREEN** (re-verified EXIT=0): MeanValueTheoremOQ02OQ04OQ01 (ContinuousLinearMap.id.analyticAt ->

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -2251,7 +2251,7 @@ MaschkeLocalRingOQ010102	GREEN
 MaschkeModularCounterexampleOQ01	GREEN	
 MaschkeTheoremOQ01	GREEN	
 MathematicalInductionOQ01	GREEN	
-MathematicalInductionOQ03	RESIDUAL	type-mismatch
+MathematicalInductionOQ03	GREEN	
 MatrixSimilarityInvariantsOQ01	GREEN	
 MeanValueTheorem	GREEN	
 MeanValueTheoremOQ02	GREEN	


### PR DESCRIPTION
MathematicalInductionOQ03. No loom labels.