### PR TITLE
migrate(v4.31): single-proof batch 270 (+1 GREEN)

### DIFF
--- a/proofs/Proofs/PNPBarriersLegacy.lean
+++ b/proofs/Proofs/PNPBarriersLegacy.lean
@@ -5852,7 +5852,7 @@ def boolFinEncoding : Computability.FinEncoding Bool where
 def MathLibInP (problem : Nat → Bool) : Prop :=
   ∃ (ea : Computability.FinEncoding Nat)
     (eb : Computability.FinEncoding Bool),
-    Nonempty (Turing.TM2ComputableInPolyTime ea eb problem)
+    Nonempty (Turing.TM2ComputableInPolyTime ea.encode eb.encode problem)
 
 /-- MathLib P: the class of all problems computable in polynomial time
     by a concrete TM2 machine -/
@@ -5874,7 +5874,7 @@ def MathLibInNP (problem : Nat → Bool) : Prop :=
     -- Verifier is polynomial-time computable
     (∃ (ea : Computability.FinEncoding (Nat × Nat))
        (eb : Computability.FinEncoding Bool),
-       Nonempty (Turing.TM2ComputableInPolyTime ea eb (Function.uncurry verifier))) ∧
+       Nonempty (Turing.TM2ComputableInPolyTime ea.encode eb.encode (Function.uncurry verifier))) ∧
     -- Completeness: if x is in the language, some witness works
     (∀ x : Nat, problem x = true →
       ∃ y : Nat, (natToBits y).length ≤ poly.eval (natToBits x).length ∧ verifier x y = true) ∧

--- a/proofs/batch2/STATUS.md
+++ b/proofs/batch2/STATUS.md
@@ -1,3 +1,8 @@
+# DOCTOR SINGLE-PROOF BATCH 270 (all-Sonnet + Opus, #38065, 2026-07-16)
+
+**+1 GREEN** (re-verified EXIT=0): PNPBarriersLegacy (Turing.TM2ComputableInPolyTime now raw encode fns not
+FinEncoding [TMComputable.lean moved to TuringMachine/Computable.lean] -> pass ea.encode/eb.encode). Repair: none.
+
 # DOCTOR SINGLE-PROOF BATCH 269 (all-Sonnet + Opus, #38065, 2026-07-16)
 
 **+1 GREEN** (re-verified EXIT=0): MathematicalInductionOQ03 (ZMod.natCast_val now ZMod.cast i not i ->

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -2288,7 +2288,7 @@ NormEuclideanZsqrtdFamilyOQ03OQ02	GREEN
 NormEuclideanZsqrtdFamilyOQ03OQ02OQ01	RESIDUAL	instance-synth
 OSBridge	GREEN	instance-synth
 PACLearning	GREEN	
-PNPBarriersLegacy	RESIDUAL	type-mismatch
+PNPBarriersLegacy	GREEN	
 PNPBarriersSound	GREEN	
 PNPBarriersUnified	GREEN	
 PappusTheoremOQ02	GREEN	


### PR DESCRIPTION
PNPBarriersLegacy. No loom labels.