### PR TITLE
migrate(v4.31): single-proof batch 285 (+1 GREEN)

### DIFF
--- a/proofs/Proofs/DescartesRuleOfSignsOQ02OQ01.lean
+++ b/proofs/Proofs/DescartesRuleOfSignsOQ02OQ01.lean
@@ -123,25 +123,29 @@ theorem linear_at_most_one_root (p : ℝ[X]) (hp : p.natDegree = 1) (a b : ℝ) 
   -- A degree-1 polynomial has at most 1 root anywhere, so at most 1 in any interval.
   -- Strategy: show the set is subsingleton (any two elements are equal).
   have hp_ne : p ≠ 0 := by intro h; rw [h] at hp; simp at hp
-  apply Set.Subsingleton.ncard_le_one
-  intro x ⟨_, _, hx⟩ y ⟨_, _, hy⟩
-  -- x and y are both roots of p. Since p has degree 1, it has at most 1 root.
-  -- Two distinct roots would give card(roots) ≥ 2 > 1 = natDegree, contradiction.
-  by_contra hne
-  have hx_mem : x ∈ p.roots := (Polynomial.mem_roots hp_ne).mpr hx
-  have hy_mem : y ∈ p.roots := (Polynomial.mem_roots hp_ne).mpr hy
-  have hcard := Polynomial.card_roots_le_degree p
-  -- {x, y} as a multiset has card ≥ 2 since x ≠ y
-  have h2 : 2 ≤ (p.roots.toFinset).card := by
-    have hx_fs : x ∈ p.roots.toFinset := Multiset.mem_toFinset.mpr hx_mem
-    have hy_fs : y ∈ p.roots.toFinset := Multiset.mem_toFinset.mpr hy_mem
-    calc 2 = ({x, y} : Finset ℝ).card := by rw [Finset.card_pair hne]
-      _ ≤ p.roots.toFinset.card := Finset.card_le_card (by
-          intro z hz
-          rw [Finset.mem_insert, Finset.mem_singleton] at hz
-          rcases hz with rfl | rfl <;> assumption)
-  have h3 : p.roots.toFinset.card ≤ p.roots.card := Multiset.toFinset_card_le_card _
-  rw [hp] at hcard; omega
+  have hsub : Set.Subsingleton {x : ℝ | a < x ∧ x ≤ b ∧ p.eval x = 0} := by
+    intro x hxmem y hymem
+    obtain ⟨_, _, hx⟩ := hxmem
+    obtain ⟨_, _, hy⟩ := hymem
+    -- x and y are both roots of p. Since p has degree 1, it has at most 1 root.
+    -- Two distinct roots would give card(roots) ≥ 2 > 1 = natDegree, contradiction.
+    by_contra hne
+    have hx_mem : x ∈ p.roots := (Polynomial.mem_roots hp_ne).mpr hx
+    have hy_mem : y ∈ p.roots := (Polynomial.mem_roots hp_ne).mpr hy
+    have hcard := Polynomial.card_roots' p
+    -- {x, y} as a multiset has card ≥ 2 since x ≠ y
+    have h2 : 2 ≤ (p.roots.toFinset).card := by
+      have hx_fs : x ∈ p.roots.toFinset := Multiset.mem_toFinset.mpr hx_mem
+      have hy_fs : y ∈ p.roots.toFinset := Multiset.mem_toFinset.mpr hy_mem
+      calc 2 = ({x, y} : Finset ℝ).card := by rw [Finset.card_pair hne]
+        _ ≤ p.roots.toFinset.card := Finset.card_le_card (by
+            intro z hz
+            rw [Finset.mem_insert, Finset.mem_singleton] at hz
+            rcases hz with rfl | rfl <;> assumption)
+    have h3 : p.roots.toFinset.card ≤ p.roots.card := by
+      classical exact Multiset.toFinset_card_le p.roots
+    rw [hp] at hcard; omega
+  rcases hsub.eq_empty_or_singleton with h | ⟨x, h⟩ <;> simp [h]
 
 /-- Rolle's theorem for polynomials: if p has roots at r₁ < r₂,
     then p' has a root in (r₁, r₂).

--- a/proofs/batch2/STATUS.md
+++ b/proofs/batch2/STATUS.md
@@ -1,3 +1,9 @@
+# DOCTOR SINGLE-PROOF BATCH 285 (all-Sonnet post-rate-limit, #38065, 2026-07-16)
+
+**+1 GREEN** (re-verified EXIT=0): DescartesRuleOfSignsOQ02OQ01 (Set.Subsingleton.ncard_le_one gone ->
+eq_empty_or_singleton; card_roots_le_degree->card_roots'; Multiset.toFinset_card_le_card->toFinset_card_le
+classical). Repair: none.
+
 # DOCTOR SINGLE-PROOF BATCH 284 (all-Sonnet post-rate-limit, #38065, 2026-07-16)
 
 **+1 GREEN** (re-verified EXIT=0): SzemerediHypergraphGowers (Finset.mem_powerset no longer defeq-transitive

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -540,7 +540,7 @@ DesarguesTheoremOQ01OQ01	GREEN
 DescartesRuleOfSignsOQ01OQ01	GREEN	
 DescartesRuleOfSignsOQ01OQ02	GREEN	
 DescartesRuleOfSignsOQ02	GREEN	
-DescartesRuleOfSignsOQ02OQ01	RESIDUAL	rewrite-drift
+DescartesRuleOfSignsOQ02OQ01	GREEN	
 DescartesRuleOfSignsOQ02Parity	GREEN	proof-drift
 DescartesRuleOfSignsOQ04	GREEN	
 DiamondImpliesCH	GREEN	


### PR DESCRIPTION
DescartesRuleOfSignsOQ02OQ01. No loom labels.