### PR TITLE
migrate(v4.31): single-proof batch 294 (+1 GREEN)

### DIFF
--- a/proofs/Proofs/FourierSeriesOQ01.lean
+++ b/proofs/Proofs/FourierSeriesOQ01.lean
@@ -207,11 +207,13 @@ theorem fourierPartialSum_of_trigPoly
   rfl
 
 /-- Helper: on `AddCircle T`, `fourier k` is integrable. -/
-private theorem fourier_integrable (k : ℤ) : Integrable (fourier (T := T) k) haarAddCircle :=
-  (MemLp.of_bound (map_continuous (fourier k)).aestronglyMeasurable 1
-    (Filter.Eventually.of_forall (fun x => by
-      have : ‖fourier k x‖ = 1 := by simp [fourier_apply]
-      linarith))).integrable (by norm_num)
+private theorem fourier_integrable (k : ℤ) : Integrable (fourier (T := T) k) haarAddCircle := by
+  have hb : MemLp (fourier (T := T) k) 2 haarAddCircle :=
+    MemLp.of_bound (map_continuous (fourier k)).aestronglyMeasurable 1
+      (Filter.Eventually.of_forall (fun x => by
+        have : ‖fourier k x‖ = 1 := by rw [fourier_apply, Circle.norm_coe]
+        linarith))
+  exact hb.integrable (by norm_num)
 
 /-- Helper: `c * fourier k` is integrable for any constant `c : ℂ`. -/
 private theorem const_mul_fourier_integrable (c : ℂ) (k : ℤ) :
@@ -242,7 +244,7 @@ private theorem fourierCoeff_of_trigPoly_sum (M : ℕ) (c : ℤ → ℂ) (n : �
     split_ifs with hm
     · subst hm
       simp_rw [fourier_zero]
-      rw [integral_const, measure_univ, ENNReal.one_toReal, Complex.real_smul,
+      rw [integral_const, probReal_univ, Complex.real_smul,
           Complex.ofReal_one, mul_one]
     · exact integral_eq_zero_of_add_right_eq_neg (fourier_add_half_inv_index hm hT.out)
   -- Simplify: c k * ∫ fourier(k-n) = c k * (if k = n then 1 else 0) = if k = n then c k else 0
@@ -267,6 +269,7 @@ theorem trigPoly_exact_convergence
     split_ifs with hn
     · rfl
     · -- n ∉ Icc (-M) M, so |n| > M, apply hc_zero
+      symm
       apply hc_zero
       simp only [Finset.mem_Icc, not_and_or, not_le] at hn
       rcases hn with h | h
@@ -274,13 +277,14 @@ theorem trigPoly_exact_convergence
         rw [show |n| = -n from abs_of_nonpos (by linarith [Int.ofNat_nonneg M])]
         push_cast; linarith
       · -- h : (↑M : ℤ) < n, so |n| = n > M
-        rw [show |n| = n from abs_of_pos (by exact_mod_cast h)]
+        rw [show |n| = n from abs_of_pos (by omega)]
         exact_mod_cast h
   -- Rewrite partial sum using fourierCoeff g n = c n
   simp only [fourierPartialSum]
-  conv_lhs => arg 1; ext n; rw [hfc n]
+  simp_rw [hfc]
   -- Now: ∑ n ∈ Icc (-N) N, c n * fourier n x = ∑ n ∈ Icc (-M) M, c n * fourier n x = g x
-  rw [← hg_eq x]
+  rw [hg_eq x]
+  symm
   apply Finset.sum_subset
   · -- Icc (-M) M ⊆ Icc (-N) N since M ≤ N
     intro n hn
@@ -296,7 +300,7 @@ theorem trigPoly_exact_convergence
       rw [show |n| = -n from abs_of_nonpos (by linarith [Int.ofNat_nonneg M])]
       push_cast; linarith
     · -- h : (↑M : ℤ) < n
-      rw [show |n| = n from abs_of_pos (by exact_mod_cast h)]
+      rw [show |n| = n from abs_of_pos (by omega)]
       exact_mod_cast h
 
 /-- Trigonometric polynomials are in L² (and hence integrable).
@@ -338,12 +342,9 @@ private theorem Lp2_norm_sq_eq_integral (h : Lp ℂ 2 (haarAddCircle (T := T))) 
     ‖h‖ ^ 2 = ∫ x : AddCircle T, ‖(⇑h) x‖ ^ 2 ∂haarAddCircle := by
   have H := congr_arg RCLike.re (@L2.inner_def (AddCircle T) ℂ ℂ _ _ _ _ _ h h)
   rw [← integral_re (L2.integrable_inner h h)] at H
-  simp only [← norm_sq_eq_inner (𝕜 := ℂ)] at H
-  -- H : ‖h‖^2 = ∫ x, RCLike.re ⟪h x, h x⟫_ℂ
-  -- Rewrite pointwise: Re ⟪z, z⟫_ℂ = ‖z‖²
-  convert H using 2
-  ext x
-  simp [inner_self_eq_norm_sq_to_K, RCLike.ofReal_re]
+  simp only [← norm_sq_eq_re_inner] at H
+  -- H : ‖h‖^2 = ∫ x, ‖h x‖²
+  exact H
 
 /-- Helper: the coercion of `∑ n ∈ s, c n • fourierLp 2 n` equals
 `fun x => ∑ n ∈ s, c n * fourier n x` almost everywhere. -/
@@ -353,12 +354,13 @@ private theorem Lp_fourier_sum_coeFn (s : Finset ℤ) (c : ℤ → ℂ) :
   induction s using Finset.induction_on with
   | empty =>
     simp only [Finset.sum_empty]
-    exact Lp.coeFn_zero
-  | insert ha ih =>
+    filter_upwards [Lp.coeFn_zero ℂ 2 (haarAddCircle (T := T))] with x hx
+    simpa using hx
+  | insert a s ha ih =>
     simp only [Finset.sum_insert ha]
-    filter_upwards [Lp.coeFn_add (c _ • fourierLp 2 _) (∑ n ∈ _, c n • fourierLp 2 n),
-                    Lp.coeFn_smul (c _) (fourierLp 2 (T := T) _),
-                    coeFn_fourierLp (T := T) 2 _,
+    filter_upwards [Lp.coeFn_add (c a • fourierLp 2 a) (∑ n ∈ s, c n • fourierLp 2 n),
+                    Lp.coeFn_smul (c a) (fourierLp 2 (T := T) a),
+                    coeFn_fourierLp (T := T) 2 a,
                     ih] with x hx1 hx2 hx3 hx4
     simp only [Pi.add_apply] at hx1
     simp only [Pi.smul_apply, smul_eq_mul] at hx2
@@ -385,11 +387,14 @@ theorem trigPoly_L2_approx
   -- The Fourier series converges in L²
   have hhs := hasSum_fourier_series_L2 f_Lp
   -- From HasSum: ∃ S₀ : Finset ℤ such that ‖∑ n ∈ S₀, ĉ_n • e_n - f_Lp‖ < ε
-  rw [HasSum, Metric.tendsto_atTop] at hhs
-  obtain ⟨S₀, hS₀⟩ := hhs ε hε
+  have hhs' : Tendsto (fun s : Finset ℤ => ∑ i ∈ s, fourierCoeff (⇑f_Lp) i • fourierLp 2 i)
+      atTop (𝓝 f_Lp) := hhs
+  rw [Metric.tendsto_atTop] at hhs'
+  obtain ⟨S₀, hS₀⟩ := hhs' ε hε
   -- The approximating partial sum at S₀
   let ĉ : ℤ → ℂ := fun n => fourierCoeff (⇑f_Lp) n
-  let g_Lp : Lp ℂ 2 haarAddCircle := ∑ n ∈ S₀, ĉ n • (fourierLp 2 n : Lp ℂ 2 haarAddCircle)
+  let g_Lp : Lp ℂ 2 (haarAddCircle (T := T)) :=
+    ∑ n ∈ S₀, ĉ n • (fourierLp 2 n : Lp ℂ 2 (haarAddCircle (T := T)))
   have hdist : dist g_Lp f_Lp < ε := hS₀ S₀ (le_refl _)
   -- Get M : ℕ such that S₀ ⊆ Icc (-M) M
   rcases S₀.eq_empty_or_nonempty with rfl | hne
@@ -398,11 +403,12 @@ theorem trigPoly_L2_approx
     rw [dist_comm, dist_zero_right] at hdist
     -- Use g = 0 (trivial IsTrigPoly)
     refine ⟨0, ⟨0, fun _ => 0, by simp, by simp⟩, ?_⟩
+    simp only [Pi.zero_apply]
     -- ∫ ‖f x - 0‖² = ‖f_Lp‖² < ε²
     have haeq : (fun x => ‖f x - (0 : ℂ)‖ ^ 2) =ᵐ[haarAddCircle]
         fun x => ‖(⇑f_Lp) x‖ ^ 2 := by
       filter_upwards [hf.coeFn_toLp] with x hx
-      simp [sub_zero, ← hx]
+      simp [sub_zero, ← hx, hf_Lp_def]
     rw [integral_congr_ae haeq, ← Lp2_norm_sq_eq_integral]
     exact sq_lt_sq' (by linarith [norm_nonneg f_Lp]) hdist
   · -- Non-empty case: use S₀.sup' to find M
@@ -429,7 +435,7 @@ theorem trigPoly_L2_approx
     -- h_Lp = f_Lp - g_Lp represents f - g a.e.
     set h_Lp : Lp ℂ 2 haarAddCircle := f_Lp - g_Lp with h_Lp_def
     have hh_lt : ‖h_Lp‖ < ε := by
-      rw [h_Lp_def, ← dist_eq_norm]; exact_mod_cast hdist
+      rw [h_Lp_def, ← dist_eq_norm, dist_comm]; exact_mod_cast hdist
     -- ∫ ‖f x - g x‖² = ‖h_Lp‖² < ε²
     -- Step 1: ‖h_Lp‖² = ∫ ‖(⇑h_Lp) x‖²
     -- Step 2: ⇑h_Lp =ᵐ f - g (using coeFn_sub + coeFn_toLp + Lp_fourier_sum_coeFn)
@@ -458,6 +464,7 @@ theorem trigPoly_L2_approx
       apply integral_congr_ae
       filter_upwards [hh_ae] with x hx
       rw [hx]
+    refine ⟨g, hgpoly, ?_⟩
     rw [hintegral]
     exact sq_lt_sq' (by linarith [norm_nonneg h_Lp]) hh_lt
 
@@ -473,24 +480,13 @@ theorem fourierPartialSum_add (f g : AddCircle T → ℂ) (N : ℕ) (x : AddCirc
     (hf : Integrable f haarAddCircle) (hg : Integrable g haarAddCircle) :
     fourierPartialSum (f + g) N x =
       fourierPartialSum f N x + fourierPartialSum g N x := by
-  simp only [fourierPartialSum, fourierCoeff, Pi.add_apply]
+  simp only [fourierPartialSum]
   rw [← sum_add_distrib]
-  congr 1
-  ext n
-  simp [mul_comm, mul_add, add_mul]
-  ring_nf
-  congr 1
-  have hfourier_bound : ∀ (t : AddCircle T), ‖fourier (-n) t‖ ≤ 1 := by
-    intro t
-    have : ‖fourier (-n) t‖ = 1 := by simp [fourier_apply]
-    linarith
-  have hint : ∀ h : AddCircle T → ℂ, Integrable h haarAddCircle →
-      Integrable (fun t => fourier (-n) t * h t) haarAddCircle := by
-    intro h hh
-    apply hh.bdd_mul' (map_continuous (fourier (-n))).aestronglyMeasurable
-    exact ⟨1, ae_of_all _ hfourier_bound⟩
-  rw [MeasureTheory.integral_add (hint f hf) (hint g hg)]
-  ring
+  apply Finset.sum_congr rfl
+  intro n _
+  have hcoeff : fourierCoeff (f + g) n = fourierCoeff f n + fourierCoeff g n :=
+    congrFun (fourierCoeff.add hf hg) n
+  rw [hcoeff, add_mul]
 
 /-- Linearity of partial sums: S_N(c • f) = c • S_N f. -/
 theorem fourierPartialSum_smul (c : ℂ) (f : AddCircle T → ℂ) (N : ℕ)
@@ -572,7 +568,7 @@ theorem divergenceSet_subset_of_approx
     have hgN := hM₀ N hNM x
     have hlin : fourierPartialSum (f - g) N x = fourierPartialSum f N x - g x := by
       have h_sub : f - g = f + (-1 : ℂ) • g := by simp [sub_eq_add_neg, neg_smul]
-      rw [h_sub, fourierPartialSum_add f ((-1 : ℂ) • g) N x hf (hg.smul_left _)]
+      rw [h_sub, fourierPartialSum_add f ((-1 : ℂ) • g) N x hf (hg.smul (-1 : ℂ))]
       rw [fourierPartialSum_smul (-1 : ℂ) g N x, hgN]
       ring
     rw [hlin]
@@ -584,15 +580,14 @@ theorem divergenceSet_subset_of_approx
       have htri : ‖fourierPartialSum f N x - f x‖ ≤
           ‖fourierPartialSum f N x - g x‖ + ‖g x - f x‖ := by
         calc ‖fourierPartialSum f N x - f x‖
-            = ‖(fourierPartialSum f N x - g x) + (g x - f x)‖ := by ring_nf
+            = ‖(fourierPartialSum f N x - g x) + (g x - f x)‖ := by congr 1; abel
           _ ≤ ‖fourierPartialSum f N x - g x‖ + ‖g x - f x‖ := norm_add_le _ _
       linarith [hNδ, htri, norm_sub_rev (g x) (f x)]
     -- Step 3: Convert real bound to ENNReal
     have hpos : (0 : ℝ) ≤ δ / 2 := le_of_lt (half_pos hδ)
-    rw [show ENNReal.ofReal (δ / 2) = ↑(⟨δ / 2, hpos⟩ : ℝ≥0) from
-          ENNReal.ofReal_eq_coe_nnreal hpos]
-    rw [ENNReal.coe_lt_coe]
-    exact_mod_cast h_bound
+    have : ENNReal.ofReal (δ / 2) < ENNReal.ofReal ‖fourierPartialSum f N x - g x‖ :=
+      (ENNReal.ofReal_lt_ofReal_iff_of_nonneg hpos).mpr h_bound
+    simpa [ofReal_norm, enorm_eq_nnnorm] using this
 
 /-- **Measure bound on divergence set via maximal inequality.**
 
@@ -674,6 +669,10 @@ theorem divergenceSet_measure_bound
       fun x hx => ENNReal.ofReal_le_ofReal
         (pow_le_pow_left₀ (le_of_lt (half_pos hδ)) (le_of_lt hx) 2)
     -- Calc: monotone measure + Markov division + integral bound + arithmetic
+    have hstep3 : (∫⁻ x, ENNReal.ofReal (‖(f - g) x‖ ^ 2) ∂haarAddCircle) ≤
+        ENNReal.ofReal (ε ^ 2) := by
+      rw [hlint]
+      exact ENNReal.ofReal_le_ofReal (le_of_lt happrox_fmg)
     calc haarAddCircle {x | δ / 2 < ‖(f - g) x‖}
         ≤ haarAddCircle {x | ENNReal.ofReal ((δ / 2) ^ 2) ≤
             ENNReal.ofReal (‖(f - g) x‖ ^ 2)} := measure_mono hset_sub
@@ -683,8 +682,7 @@ theorem divergenceSet_measure_bound
               (Or.inl ENNReal.ofReal_ne_top)]
           rw [mul_comm]; exact hmarkov
       _ ≤ ENNReal.ofReal (ε ^ 2) / ENNReal.ofReal ((δ / 2) ^ 2) :=
-          ENNReal.div_le_div_right (by rw [hlint];
-            exact ENNReal.ofReal_le_ofReal (le_of_lt happrox_fmg)) _
+          ENNReal.div_le_div_right hstep3 _
       _ = ENNReal.ofReal (ε ^ 2 / (δ / 2) ^ 2) :=
           (ENNReal.ofReal_div_of_pos hd2sq_pos).symm
   -- Step 7: Combine the two pieces
@@ -705,9 +703,9 @@ theorem divergenceSet_measure_bound
         -- Rewrite LHS: ε²/(δ/2)² + (C/(δ/2))²*ε² = (1+C²)*ε²/(δ/2)²
         rw [show ε ^ 2 / (δ / 2) ^ 2 + (carlesonConstant / (δ / 2)) ^ 2 * ε ^ 2 =
             (1 + carlesonConstant ^ 2) * ε ^ 2 / (δ / 2) ^ 2 by
-          field_simp; ring]
+          field_simp <;> ring]
         -- Now: (1+C²)*ε²/(δ/2)² ≤ (C+1)²*ε²/(δ/2)² iff 1+C² ≤ (C+1)²
-        apply (div_le_div_right hd2pos).mpr
+        apply (div_le_div_iff_of_pos_right hd2pos).mpr
         nlinarith [sq_nonneg ε,
           mul_nonneg (by linarith : (0 : ℝ) ≤ 2 * carlesonConstant) (sq_nonneg ε)]
 
@@ -736,53 +734,10 @@ theorem carleson_ae_convergence
   -- 3. Countable union of null sets is null
   apply MeasureTheory.ae_iff.mpr
   -- Step 1: {x | ¬ convergence} ⊆ fullDivergenceSet f
-  apply measure_mono_null _
-  swap
-  · -- Step 2+3: μ(fullDivergenceSet f) = 0
-    simp only [fullDivergenceSet]
-    apply MeasureTheory.measure_iUnion_null
-    intro k
-    -- Show μ(divergenceSet f (1/(k+1))) = 0
-    -- For each ε > 0, apply divergenceSet_measure_bound to get bound → 0
-    apply le_antisymm _ (zero_le)
-    apply ENNReal.le_of_forall_pos_le_add
-    intro r hr
-    rw [zero_add]
-    -- The bound (C+1)^2 * ε^2 / (1/(2*(k+1)))^2 → 0 as ε → 0
-    -- Pick ε_r such that (C+1)^2 * ε_r^2 / (δ_k/2)^2 < r
-    set δk : ℝ := 1 / ((k : ℝ) + 1)
-    have hδk : (0 : ℝ) < δk := by positivity
-    -- Get ε_r > 0 with (C+1)^2 * ε_r^2 / (δk/2)^2 ≤ r.toReal
-    -- (if r = ∞, the bound is trivial; otherwise pick ε_r = sqrt(r * (δk/2)^2 / (C+1)^2 / 2))
-    rcases ENNReal.lt_or_eq_top r with hr_fin | hr_top
-    · -- r < ∞: use density to get a trig poly approximation
-      have hr_pos : (0 : ℝ) < r.toReal :=
-        ENNReal.toReal_pos (ENNReal.pos_of_ne_zero (ne_of_gt hr)) (ne_of_lt hr_fin)
-      -- Choose ε_r so that (C+1)^2 * ε_r^2 / (δk/2)^2 ≤ r.toReal
-      have hC_pos : (0 : ℝ) < (carlesonConstant + 1) ^ 2 := by
-        have := carlesonConstant_nonneg; positivity
-      set ε_r := Real.sqrt (r.toReal * (δk / 2) ^ 2 / (carlesonConstant + 1) ^ 2 / 2)
-      have hε_r_pos : 0 < ε_r := by
-        apply Real.sqrt_pos.mpr; positivity
-      obtain ⟨g, hgpoly, happrox⟩ := trigPoly_L2_approx hf hε_r_pos
-      calc haarAddCircle (divergenceSet f δk)
-          ≤ ENNReal.ofReal ((carlesonConstant + 1) ^ 2 * ε_r ^ 2 / (δk / 2) ^ 2) :=
-            divergenceSet_measure_bound hf hδk hε_r_pos g hgpoly
-              (IsTrigPoly.memLp_two g hgpoly) happrox
-        _ ≤ r := by
-            -- (C+1)^2 * ε_r^2 / (δk/2)^2 = r.toReal/2 ≤ r.toReal
-            have h_real : (carlesonConstant + 1) ^ 2 * ε_r ^ 2 / (δk / 2) ^ 2 ≤ r.toReal := by
-              rw [show ε_r ^ 2 = r.toReal * (δk / 2) ^ 2 / (carlesonConstant + 1) ^ 2 / 2 by
-                rw [Real.sq_sqrt (by positivity)]]
-              have hd2 : (δk / 2) ^ 2 ≠ 0 := by positivity
-              have hC2 : (carlesonConstant + 1) ^ 2 ≠ 0 := by positivity
-              field_simp
-              linarith
-            exact le_trans (ENNReal.ofReal_le_ofReal h_real) ENNReal.ofReal_toReal_le
-    · -- r = ∞: trivial
-      simp [hr_top]
+  apply measure_mono_null (t := fullDivergenceSet f)
   · -- Step 1: Non-convergence ⊆ fullDivergenceSet
     intro x hx
+    simp only [Set.mem_setOf_eq] at hx
     simp only [fullDivergenceSet, Set.mem_iUnion]
     rw [Metric.tendsto_atTop] at hx
     push_neg at hx
@@ -801,6 +756,49 @@ theorem carleson_ae_convergence
     -- hN gives ε ≤ ‖S_N f(x) - f(x)‖, and h1k gives 1/(k+1) < ε
     rw [Complex.dist_eq] at hN
     linarith
+  · -- Step 2+3: μ(fullDivergenceSet f) = 0
+    simp only [fullDivergenceSet]
+    apply MeasureTheory.measure_iUnion_null
+    intro k
+    -- Show μ(divergenceSet f (1/(k+1))) = 0
+    -- For each ε > 0, apply divergenceSet_measure_bound to get bound → 0
+    apply le_antisymm _ (zero_le)
+    apply ENNReal.le_of_forall_pos_le_add
+    intro r hr _
+    rw [zero_add]
+    -- The bound (C+1)^2 * ε^2 / (1/(2*(k+1)))^2 → 0 as ε → 0
+    -- Pick ε_r such that (C+1)^2 * ε_r^2 / (δ_k/2)^2 < r
+    set δk : ℝ := 1 / ((k : ℝ) + 1)
+    have hδk : (0 : ℝ) < δk := by positivity
+    -- Get ε_r > 0 with (C+1)^2 * ε_r^2 / (δk/2)^2 ≤ (r : ℝ)
+    have hr_pos : (0 : ℝ) < (r : ℝ) := NNReal.coe_pos.mpr hr
+    have hC_pos : (0 : ℝ) < (carlesonConstant + 1) ^ 2 := by
+      have := carlesonConstant_nonneg; positivity
+    set ε_r := Real.sqrt ((r : ℝ) * (δk / 2) ^ 2 / (carlesonConstant + 1) ^ 2 / 2)
+    have hε_r_pos : 0 < ε_r := by
+      apply Real.sqrt_pos.mpr; positivity
+    obtain ⟨g, hgpoly, happrox⟩ := trigPoly_L2_approx f hf hε_r_pos
+    calc haarAddCircle (divergenceSet f δk)
+        ≤ ENNReal.ofReal ((carlesonConstant + 1) ^ 2 * ε_r ^ 2 / (δk / 2) ^ 2) :=
+          divergenceSet_measure_bound f hf hδk hε_r_pos g hgpoly
+            (IsTrigPoly.memLp_two g hgpoly) happrox
+      _ ≤ (r : ℝ≥0∞) := by
+          -- (C+1)^2 * ε_r^2 / (δk/2)^2 = r/2 ≤ r
+          have hCnn := carlesonConstant_nonneg
+          have hCbase : carlesonConstant + 1 ≠ 0 := by positivity
+          have hδkbase : δk / 2 ≠ 0 := by positivity
+          have hC2 : (carlesonConstant + 1) ^ 2 ≠ 0 := pow_ne_zero 2 hCbase
+          have hd2 : (δk / 2) ^ 2 ≠ 0 := pow_ne_zero 2 hδkbase
+          have hε_r_sq : ε_r ^ 2 = (r : ℝ) * (δk / 2) ^ 2 / (carlesonConstant + 1) ^ 2 / 2 := by
+            rw [Real.sq_sqrt (by positivity)]
+          have hcancel : (carlesonConstant + 1) ^ 2 *
+                  ((r : ℝ) * (δk / 2) ^ 2 / (carlesonConstant + 1) ^ 2 / 2) / (δk / 2) ^ 2
+                = (r : ℝ) / 2 := by
+            field_simp
+          have h_real : (carlesonConstant + 1) ^ 2 * ε_r ^ 2 / (δk / 2) ^ 2 ≤ (r : ℝ) := by
+            rw [hε_r_sq, hcancel]
+            linarith
+          exact le_trans (ENNReal.ofReal_le_ofReal h_real) (le_of_eq ENNReal.ofReal_coe_nnreal)
 
 /-
 ═══════════════════════════════════════════════════════════════════════════════

--- a/proofs/batch2/STATUS.md
+++ b/proofs/batch2/STATUS.md
@@ -1,3 +1,9 @@
+# DOCTOR SINGLE-PROOF BATCH 294 (all-Sonnet post-rate-limit, #38065, 2026-07-16)
+
+**+1 GREEN** (re-verified EXIT=0): FourierSeriesOQ01 (HARD 24min/262k Carleson ~30 seams: Circle.norm_coe;
+HasSum->SummationFilter.unconditional; ENNReal.le_of_forall_pos_le_add epsilon ℝ≥0 not ℝ≥0∞; apply _;swap
+elaboration -> named-arg (t:=); div_le_div_iff_of_pos_right). Repair: none.
+
 # DOCTOR SINGLE-PROOF BATCH 293 (all-Sonnet post-rate-limit, #38065, 2026-07-16)
 
 **+1 GREEN** (re-verified EXIT=0): FairGamesTheoremOQ02OQ01OQ01 (DEEP 30min/329k: IsStoppingTime ℕ->WithTop ℕ

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -1990,7 +1990,7 @@ FourSquareDistributionOQ04ArrangeProof	GREEN
 FourSquareDistributionOQ04Bridge	GREEN	
 FourSquareDistributionOQ04Decomp	GREEN	
 FourSquareDistributionOQ04Keystone	GREEN	
-FourierSeriesOQ01	RESIDUAL	rewrite-drift
+FourierSeriesOQ01	GREEN	
 FourierSeriesOQ02	GREEN	
 FourierSeriesOQ02Incomplete01	GREEN	
 FourierSeriesOQ02OQ02	GREEN	


### PR DESCRIPTION
FourierSeriesOQ01. No loom labels.