### PR TITLE
migrate(v4.31): single-proof batch 308 (+1 GREEN)

### DIFF
--- a/proofs/Proofs/NewtonIndStep2.lean
+++ b/proofs/Proofs/NewtonIndStep2.lean
@@ -14,7 +14,13 @@ namespace NewtonIndStep2
     (ek + t·ekm1)² · (b+a)(d+c) ≥ (ekm1+t·ekm2)(ekp1+t·ek) · (c+b)²
     where a=C(m,k-2), b=C(m,k-1), c=C(m,k), d=C(m,k+1).
 
-    Proof: express LHS-RHS as quadratic αt²+βt+γ and apply quadratic_nonneg. -/
+    Proof: express LHS-RHS as quadratic αt²+βt+γ. α ≥ 0 and γ ≥ 0 follow by chaining
+    the "inductive hypothesis" bounds `h_ih_k`/`h_ih_km1` with the dual binomial
+    inequalities `binom_ineq_dual`/`binom_ineq` (both proved in `NewtonInductiveStep`
+    via the absorption identities) and dividing out `b² > 0` / `c² > 0`. When β ≤ 0
+    the discriminant condition `4αγ ≥ β²` is exactly `newton_disc_of_beta_nonpos`
+    from `NewtonInductiveStep`; when β > 0 the quadratic is trivially non-negative
+    for `t ≥ 0` since α, γ, β, t are all non-negative. -/
 theorem newton_ind_step (m k : ℕ) (hk : 2 ≤ k) (hkm : k + 1 ≤ m)
     (ek ekm1 ekp1 ekm2 t : ℝ)
     (ht : 0 ≤ t) (hek : 0 ≤ ek) (hekm1 : 0 ≤ ekm1)
@@ -40,78 +46,90 @@ theorem newton_ind_step (m k : ℕ) (hk : 2 ≤ k) (hkm : k + 1 ≤ m)
     (h_binom_km1 : b ^ 2 ≥ a * c) :
     (ek + t * ekm1) ^ 2 * ((b + a) * (d + c)) ≥
     (ekm1 + t * ekm2) * (ekp1 + t * ek) * (c + b) ^ 2 := by
-  -- Define the quadratic coefficients
-  set γ := ek ^ 2 * ((b + a) * (d + c)) - ekm1 * ekp1 * (c + b) ^ 2
-  set α := ekm1 ^ 2 * ((b + a) * (d + c)) - ekm2 * ek * (c + b) ^ 2
-  set β := 2 * ek * ekm1 * ((b + a) * (d + c)) - (ek * ekm1 + ekm2 * ekp1) * (c + b) ^ 2
-  -- The goal is equivalent to α*t² + β*t + γ ≥ 0
-  suffices hsuff : α * t ^ 2 + β * t + γ ≥ 0 by nlinarith [hsuff]
-  apply quadratic_nonneg α β γ t ht
-  · -- α ≥ 0: ekm1²*(b+a)(d+c) ≥ ekm2*ek*(c+b)²
-    -- Use h_ih_km1 (ekm1²*ac ≥ ekm2*ek*b²) and binom coefficient structure
-    -- Key: (b+a)(d+c) = bd+bc+ad+ac and (c+b)² = c²+2bc+b²
-    -- α = ekm1²*(bd+bc+ad+ac) - ekm2*ek*(c²+2bc+b²)
-    --   = (ekm1²*ac - ekm2*ek*b²) + ekm1²*bd + ekm1²*bc + ekm1²*ad
-    --     - ekm2*ek*c² - 2*ekm2*ek*bc
-    --   ≥ 0 + ekm1²*bd + bc*(ekm1²-2*ekm2*ek) + ekm1²*ad - ekm2*ek*c²
-    -- From h_unn_km1: ekm1² ≥ ekm2*ek, so ekm1²-2*ekm2*ek could be negative.
-    -- Better: use (ekm1²-ekm2*ek)*bd ≥ 0 and (ekm1²-ekm2*ek)*bc ≥ 0
-    -- Then: α = (ekm1²*ac-ekm2*ek*b²) + (ekm1²-ekm2*ek)*(bd+bc)
-    --          + ekm1²*ad - ekm2*ek*(c²+bc)
-    -- Still messy. Try nlinarith with products.
-    nlinarith [h_ih_km1, h_unn_km1,
-               mul_nonneg hekm1 hekm1,
-               mul_nonneg hekm2 hek,
-               mul_nonneg hb_nn hd_nn,
-               mul_nonneg ha_nn hd_nn,
-               mul_nonneg hb_nn hc_nn,
-               mul_nonneg ha_nn hc_nn,
-               sq_nonneg ekm1,
-               sq_nonneg (ekm1 * c - ekm2 * b),
-               sq_nonneg (ekm1 * d),
-               mul_self_nonneg (ekm1 * b - ek * a),
-               mul_nonneg (mul_nonneg hekm1 hekm1) (mul_nonneg hb_nn hd_nn),
-               mul_nonneg (mul_nonneg hekm1 hekm1) (mul_nonneg ha_nn hd_nn)]
-  · -- γ ≥ 0: ek²*(b+a)(d+c) ≥ ekm1*ekp1*(c+b)²
-    -- Analogous to α using h_ih_k
-    nlinarith [h_ih_k, h_unn_k,
-               mul_nonneg hek hek,
-               mul_nonneg hekm1 hekp1,
-               mul_nonneg hb_nn hc_nn,
-               mul_nonneg ha_nn hd_nn,
-               mul_nonneg ha_nn hc_nn,
-               sq_nonneg (ek * c - ekm1 * b),
-               sq_nonneg (ek * b - ekp1 * a),
-               sq_nonneg (ek * d),
-               mul_nonneg (mul_nonneg hek hek) (mul_nonneg ha_nn hd_nn),
-               mul_nonneg (mul_nonneg hek hek) (mul_nonneg hb_nn hc_nn),
-               mul_nonneg (mul_nonneg hek hek) (mul_nonneg ha_nn hc_nn)]
-  · -- 4αγ ≥ β²: the discriminant condition
-    -- This is the hardest part. Use Cauchy-Schwarz style argument.
-    -- 4αγ = 4*(ekm1²*(b+a)(d+c) - ekm2*ek*(c+b)²)*(ek²*(b+a)(d+c) - ekm1*ekp1*(c+b)²)
-    -- β² = (2*ek*ekm1*(b+a)(d+c) - (ek*ekm1+ekm2*ekp1)*(c+b)²)²
-    -- Let P = (b+a)(d+c), Q = (c+b)²
-    -- 4αγ = 4*(ekm1²*P - ekm2*ek*Q)*(ek²*P - ekm1*ekp1*Q)
-    -- β = 2*ek*ekm1*P - (ek*ekm1+ekm2*ekp1)*Q = ek*ekm1*(2P-Q) - ekm2*ekp1*Q
-    -- β² ≤ ... need Cauchy-Schwarz on the "mixed" term
-    --
-    -- Alternative: 4αγ - β² after expansion. This is degree 4 in elem symms × degree 2 in binom coeffs.
-    -- Try nlinarith with many hints.
-    nlinarith [h_ih_k, h_ih_km1, h_unn_k, h_unn_km1, h_cross,
-               h_binom_k, h_binom_km1,
-               sq_nonneg (ek * ekm1 * (b + a) * (d + c) - ekm2 * ekp1 * (c + b) ^ 2),
-               sq_nonneg (ek ^ 2 * ekm1 * d - ekm1 * ekp1 * ek * b),
-               sq_nonneg (ekm1 ^ 2 * ek * c - ekm2 * ek ^ 2 * b),
-               sq_nonneg (ek * ekm1 * c - ekm1 * ekp1 * b),
-               sq_nonneg (ekm1 ^ 2 * c - ekm2 * ek * b),
-               sq_nonneg (ek * c - ekm1 * b),
-               sq_nonneg (ekm1 * c - ekm2 * b),
-               mul_nonneg (sub_nonneg.mpr h_unn_k) (sub_nonneg.mpr h_unn_km1),
-               mul_nonneg (sub_nonneg.mpr h_unn_k) (mul_nonneg hb_nn hd_nn),
-               mul_nonneg (sub_nonneg.mpr h_unn_km1) (mul_nonneg ha_nn hc_nn),
-               mul_nonneg (sub_nonneg.mpr h_cross) (sub_nonneg.mpr h_cross),
-               mul_nonneg (sub_nonneg.mpr h_ih_k) (sub_nonneg.mpr h_ih_km1),
-               mul_self_nonneg (ek * ekm1 * b * d - ekm2 * ekp1 * b * c),
-               mul_self_nonneg (ek * ekm1 * a * c - ekm2 * ekp1 * a * b)]
+  -- Strict positivity of the four binomial coefficients (needed by NewtonInductiveStep
+  -- lemmas, which require `0 < a` etc. rather than merely `0 ≤ a`).
+  have ha_pos : 0 < a := by rw [ha]; exact_mod_cast Nat.choose_pos (show k - 2 ≤ m by omega)
+  have hb_pos : 0 < b := by rw [hb]; exact_mod_cast Nat.choose_pos (show k - 1 ≤ m by omega)
+  have hc_pos : 0 < c := by rw [hc]; exact_mod_cast Nat.choose_pos (show k ≤ m by omega)
+  have hd_pos : 0 < d := by rw [hd]; exact_mod_cast Nat.choose_pos (show k + 1 ≤ m by omega)
+  -- Dual binomial inequalities, proved exactly (via `linear_combination` against the
+  -- absorption identities) in `NewtonInductiveStep`.
+  have hdualb : b ^ 2 * ((b + a) * (d + c)) ≥ a * c * (c + b) ^ 2 := by
+    rw [ha, hb, hc, hd]; exact binom_ineq_dual m k hk hkm
+  have hccbd : c ^ 2 * ((b + a) * (d + c)) ≥ b * d * (c + b) ^ 2 := by
+    have hbi : b * c ^ 3 + a * d * c ^ 2 + a * c ^ 3 ≥ 2 * b ^ 2 * c * d + b ^ 3 * d := by
+      rw [ha, hb, hc, hd]; exact binom_ineq m k hk hkm
+    nlinarith [hbi]
+  -- α ≥ 0: chain h_ih_km1 with hdualb (each multiplied by a nonneg factor), then
+  -- divide out b² > 0.
+  have hα : 0 ≤ ekm1 ^ 2 * ((b + a) * (d + c)) - ekm2 * ek * (c + b) ^ 2 := by
+    have hb2 : 0 < b ^ 2 := pow_pos hb_pos 2
+    have t1 : 0 ≤ ekm1 ^ 2 * (b ^ 2 * ((b + a) * (d + c)) - a * c * (c + b) ^ 2) :=
+      mul_nonneg (sq_nonneg ekm1) (by linarith [hdualb])
+    have t2 : 0 ≤ (ekm1 ^ 2 * (a * c) - ekm2 * ek * b ^ 2) * (c + b) ^ 2 :=
+      mul_nonneg (by linarith [h_ih_km1]) (sq_nonneg (c + b))
+    have heq : ekm1 ^ 2 * (b ^ 2 * ((b + a) * (d + c)) - a * c * (c + b) ^ 2) +
+        (ekm1 ^ 2 * (a * c) - ekm2 * ek * b ^ 2) * (c + b) ^ 2 =
+        b ^ 2 * (ekm1 ^ 2 * ((b + a) * (d + c)) - ekm2 * ek * (c + b) ^ 2) := by ring
+    have key : 0 ≤ b ^ 2 * (ekm1 ^ 2 * ((b + a) * (d + c)) - ekm2 * ek * (c + b) ^ 2) := by
+      rw [← heq]; linarith [t1, t2]
+    by_contra hcon
+    push_neg at hcon
+    exact absurd key (by linarith [mul_neg_of_pos_of_neg hb2 hcon])
+  -- γ ≥ 0: chain h_ih_k with hccbd, then divide out c² > 0.
+  have hγ : 0 ≤ ek ^ 2 * ((b + a) * (d + c)) - ekm1 * ekp1 * (c + b) ^ 2 := by
+    have hc2 : 0 < c ^ 2 := pow_pos hc_pos 2
+    have t1 : 0 ≤ ek ^ 2 * (c ^ 2 * ((b + a) * (d + c)) - b * d * (c + b) ^ 2) :=
+      mul_nonneg (sq_nonneg ek) (by linarith [hccbd])
+    have t2 : 0 ≤ (ek ^ 2 * (b * d) - ekm1 * ekp1 * c ^ 2) * (c + b) ^ 2 :=
+      mul_nonneg (by linarith [h_ih_k]) (sq_nonneg (c + b))
+    have heq : ek ^ 2 * (c ^ 2 * ((b + a) * (d + c)) - b * d * (c + b) ^ 2) +
+        (ek ^ 2 * (b * d) - ekm1 * ekp1 * c ^ 2) * (c + b) ^ 2 =
+        c ^ 2 * (ek ^ 2 * ((b + a) * (d + c)) - ekm1 * ekp1 * (c + b) ^ 2) := by ring
+    have key : 0 ≤ c ^ 2 * (ek ^ 2 * ((b + a) * (d + c)) - ekm1 * ekp1 * (c + b) ^ 2) := by
+      rw [← heq]; linarith [t1, t2]
+    by_contra hcon
+    push_neg at hcon
+    exact absurd key (by linarith [mul_neg_of_pos_of_neg hc2 hcon])
+  suffices hsuff :
+      (ekm1 ^ 2 * ((b + a) * (d + c)) - ekm2 * ek * (c + b) ^ 2) * t ^ 2 +
+      (2 * ek * ekm1 * ((b + a) * (d + c)) -
+        (ek * ekm1 + ekm2 * ekp1) * (c + b) ^ 2) * t +
+      (ek ^ 2 * ((b + a) * (d + c)) - ekm1 * ekp1 * (c + b) ^ 2) ≥ 0 by
+    nlinarith [hsuff]
+  by_cases hβ :
+      2 * ek * ekm1 * ((b + a) * (d + c)) - (ek * ekm1 + ekm2 * ekp1) * (c + b) ^ 2 ≤ 0
+  · -- β ≤ 0: the discriminant condition 4αγ ≥ β² is exactly
+    -- `newton_disc_of_beta_nonpos` after transporting the absorption identities
+    -- to the normalized `r = m - k + 1` form it expects.
+    have hk' : (2 : ℝ) ≤ (k : ℝ) := by exact_mod_cast hk
+    have hkm' : (k : ℝ) + 1 ≤ (m : ℝ) := by exact_mod_cast hkm
+    set r : ℝ := (m : ℝ) - (k : ℝ) + 1 with hr_def
+    have hr' : (2 : ℝ) ≤ r := by rw [hr_def]; linarith
+    have h1 : (k : ℝ) * c = r * b := by rw [hr_def]; linear_combination abs1
+    have h2 : ((k : ℝ) + 1) * d = (r - 1) * c := by rw [hr_def]; linear_combination abs2
+    have h3 : (r + 1) * a = ((k : ℝ) - 1) * b := by rw [hr_def]; linear_combination -abs3
+    have hbeta : 2 * ek * ekm1 * ((b + a) * (d + c)) ≤
+        (ek * ekm1 + ekm2 * ekp1) * (c + b) ^ 2 := by linarith [hβ]
+    have hdisc := newton_disc_of_beta_nonpos
+      (k : ℝ) r a b c d hk' hr' ha_pos hb_pos hc_pos hd_pos h1 h2 h3
+      ekm2 ekm1 ek ekp1 hekm2 hekm1 hek hekp1 h_ih_k h_ih_km1 h_cross hbeta
+    have := quadratic_nonneg
+      (ekm1 ^ 2 * ((b + a) * (d + c)) - ekm2 * ek * (c + b) ^ 2)
+      (2 * ek * ekm1 * ((b + a) * (d + c)) - (ek * ekm1 + ekm2 * ekp1) * (c + b) ^ 2)
+      (ek ^ 2 * ((b + a) * (d + c)) - ekm1 * ekp1 * (c + b) ^ 2)
+      t ht hα hγ hdisc
+    linarith [this]
+  · -- β > 0: the quadratic is trivially non-negative for t ≥ 0, without needing
+    -- the discriminant at all.
+    push_neg at hβ
+    have e1 : 0 ≤
+        (ekm1 ^ 2 * ((b + a) * (d + c)) - ekm2 * ek * (c + b) ^ 2) * t ^ 2 :=
+      mul_nonneg hα (sq_nonneg t)
+    have e2 : 0 ≤
+        (2 * ek * ekm1 * ((b + a) * (d + c)) -
+          (ek * ekm1 + ekm2 * ekp1) * (c + b) ^ 2) * t :=
+      mul_nonneg hβ.le ht
+    linarith [e1, e2, hγ]
 
 end NewtonIndStep2

--- a/proofs/batch2/STATUS.md
+++ b/proofs/batch2/STATUS.md
@@ -1,3 +1,9 @@
+# DOCTOR SINGLE-PROOF BATCH 308 (all-Sonnet post-rate-limit, #38065, 2026-07-16)
+
+**+1 GREEN** (re-verified EXIT=0): NewtonIndStep2 (α≥0/γ≥0 via dividing binom_ineq by b²/c²; nlinarith->explicit
+β-sign case split; le_or_lt gone -> by_cases+push_neg; deep nlinarith 9-var deg-4 heartbeat -> explicit chains).
+Repair: none.
+
 # DOCTOR SINGLE-PROOF BATCH 307 (all-Sonnet post-rate-limit, #38065, 2026-07-16)
 
 **+1 GREEN** (re-verified EXIT=0): ProbMethodSecondMomentOQ01 (parent now declares paley_zygmund_quantitative

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -2277,7 +2277,7 @@ NapoleonsTheorem	GREEN
 NapoleonsTheoremOQ02	GREEN	
 NapoleonsTheoremOQ03	GREEN	
 NavierStokes	GREEN	
-NewtonIndStep2	RESIDUAL	proof-drift
+NewtonIndStep2	GREEN	
 NewtonInductiveStepOQ01	GREEN	
 NewtonInductiveStepOQ01Aristotle	GREEN	
 NewtonInductiveStepOQ02	GREEN	


### PR DESCRIPTION
NewtonIndStep2. No loom labels.