### PR TITLE
migrate(v4.31): single-proof batch 312 (+1 GREEN)

### DIFF
--- a/proofs/Proofs/SzemerediRegularityOQ02OQ02.lean
+++ b/proofs/Proofs/SzemerediRegularityOQ02OQ02.lean
@@ -98,14 +98,16 @@ theorem pair_cut_error_bound_sharp (G : SimpleGraph V) [DecidableRel G.Adj]
       · have hA_eq0 : (A.card : ℚ) = 0 := hnA0.symm
         have he0 : e = 0 := le_antisymm
           (he_bound.trans (by simp [hA_eq0])) he_nonneg
-        simp [hA_eq0, he0]
-        positivity
+        have hz : e - d * (A.card : ℚ) * B.card = 0 := by rw [he0, hA_eq0]; ring
+        rw [hz, abs_zero]
+        exact mul_nonneg (mul_nonneg heps.le hnP) hnQ
       rcases eq_or_lt_of_le hnB with hnB0 | hnB_pos
       · have hB_eq0 : (B.card : ℚ) = 0 := hnB0.symm
         have he0 : e = 0 := le_antisymm
           (he_bound.trans (by simp [hB_eq0])) he_nonneg
-        simp [hB_eq0, he0]
-        positivity
+        have hz : e - d * (A.card : ℚ) * B.card = 0 := by rw [he0, hB_eq0]; ring
+        rw [hz, abs_zero]
+        exact mul_nonneg (mul_nonneg heps.le hnP) hnQ
       have hnAB_pos : (0 : ℚ) < A.card * B.card := mul_pos hnA_pos hnB_pos
       have hnAB_ne : (A.card : ℚ) * B.card ≠ 0 := ne_of_gt hnAB_pos
       have h_dAB : edgeDensity G A B = e / (A.card * B.card) := by

--- a/proofs/batch2/STATUS.md
+++ b/proofs/batch2/STATUS.md
@@ -1,3 +1,9 @@
+# DOCTOR SINGLE-PROOF BATCH 312 (all-Sonnet post-rate-limit, #38065, 2026-07-16)
+
+**+1 GREEN** (re-verified EXIT=0): SzemerediRegularityOQ02OQ02 (parent olean build; simp/positivity maxRecDepth
+on set-bound e/d lets -> explicit rw+ring+mul_nonneg for A.card=0/B.card=0 branches). Repair: none. Closes
+Szemeredi family.
+
 # DOCTOR SINGLE-PROOF BATCH 311 (all-Sonnet post-rate-limit, #38065, 2026-07-16)
 
 **+1 GREEN** (re-verified EXIT=0): SzemerediRegularityOQ02 (A=∅/B=∅ edge cases explicit rw/ring; set-let

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -2540,7 +2540,7 @@ SzemerediRegularity	GREEN
 SzemerediRegularityOQ01	GREEN	
 SzemerediRegularityOQ01Trivial	GREEN	
 SzemerediRegularityOQ02	GREEN	
-SzemerediRegularityOQ02OQ02	RESIDUAL	decide-maxrecdepth
+SzemerediRegularityOQ02OQ02	GREEN	
 SzemerediRegularityOQ03	GREEN	
 SzemerediRegularityOQ04	GREEN	
 SzemerediRegularityOQ04Assembly	GREEN	


### PR DESCRIPTION
SzemerediRegularityOQ02OQ02. No loom labels.