### PR TITLE
migrate(v4.31): single-proof batch 326 (+3 GREEN)

### DIFF
--- a/proofs/Proofs/Erdos1039ProblemAristotle.lean
+++ b/proofs/Proofs/Erdos1039ProblemAristotle.lean
@@ -27,8 +27,10 @@ open Erdos1039 Finset Complex
 /-- For a degree-1 polynomial, eval z = z - roots 0. -/
 theorem eval_degree_one (f : UnitDiscPolynomial) (hf : f.degree = 1) (z : ℂ) :
     f.eval z = z - f.roots ⟨0, hf ▸ Nat.zero_lt_one⟩ := by
-  simp only [UnitDiscPolynomial.eval, hf]
-  skip
+  simp only [UnitDiscPolynomial.eval]
+  rw [show (Finset.univ : Finset (Fin f.degree)) = {⟨0, hf ▸ Nat.zero_lt_one⟩} from by
+        ext i; simp [Fin.ext_iff]; omega]
+  simp [Finset.prod_singleton]
 
 /-- The sublevel set of a degree-1 polynomial is the open disc of radius 1 around the root. -/
 theorem sublevelSet_degree_one (f : UnitDiscPolynomial) (hf : f.degree = 1) :
@@ -36,6 +38,7 @@ theorem sublevelSet_degree_one (f : UnitDiscPolynomial) (hf : f.degree = 1) :
   ext z
   simp only [sublevelSet, Set.mem_setOf_eq]
   rw [eval_degree_one f hf z]
+  simp [Complex.abs]
 
 /-- A disc of radius r centered at c is inscribed in the open disc of radius r centered at c. -/
 theorem isInscribedDisc_self (c : ℂ) (r : ℝ) (hr : r > 0) :
@@ -54,28 +57,34 @@ theorem isInscribedDisc_mono (S T : Set ℂ) (hST : S ⊆ T) (c : ℂ) (r : ℝ)
     (h : isInscribedDisc S c r) : isInscribedDisc T c r := by
   exact ⟨h.1, fun z hz => hST (h.2 z hz)⟩
 
-/-- Monotonicity of inscribed disc radius under set inclusion. -/
-theorem inscribedDiscRadius_mono (S T : Set ℂ) (hST : S ⊆ T) :
+/-- Monotonicity of inscribed disc radius under set inclusion.
+    v4.31 migration note: the original statement quantified over arbitrary `S T : Set ℂ`
+    with no boundedness assumption, which is false in general (e.g. `T = Set.univ` makes
+    `inscribedDiscRadius T` collapse to the junk value `0` via `Real.sSup`'s
+    not-`BddAbove` case, while `inscribedDiscRadius S` can be positive). The genuinely-true
+    form adds the two hypotheses `csSup_le_csSup` actually needs: `T`'s radius set is
+    bounded above, and `S`'s radius set is nonempty. #38611 candidate. -/
+theorem inscribedDiscRadius_mono (S T : Set ℂ) (hST : S ⊆ T)
+    (hbdd : BddAbove {r : ℝ | ∃ c : ℂ, isInscribedDisc T c r})
+    (hne : {r : ℝ | ∃ c : ℂ, isInscribedDisc S c r}.Nonempty) :
     inscribedDiscRadius S ≤ inscribedDiscRadius T := by
-  apply csSup_le_csSup
-  · -- T has an upper bound for inscribed disc radii (bounded by diameter)
-    use 2  -- trivial upper bound for any disc inside ℂ... actually not bounded
-    rintro r ⟨c, hc⟩
-    exact (isInscribedDisc_mono S T hST c r hc).1.le
-  · -- radii for S are contained in radii for T
-    rintro r ⟨c, hc⟩
-    exact ⟨c, isInscribedDisc_mono S T hST c r hc⟩
+  apply csSup_le_csSup hbdd hne
+  rintro r ⟨c, hc⟩
+  exact ⟨c, isInscribedDisc_mono S T hST c r hc⟩
 
 /-- If r is positive and inscribed in S, then r is in the set of inscribed radii. -/
 theorem inscribed_radius_mem (S : Set ℂ) (c : ℂ) (r : ℝ) (h : isInscribedDisc S c r) :
     r ∈ {r : ℝ | ∃ c : ℂ, isInscribedDisc S c r} := ⟨c, h⟩
 
-/-- Positivity: the inscribed disc radius is nonneg when a disc exists. -/
+/-- Positivity: the inscribed disc radius is nonneg (every radius in the candidate set is
+    positive by definition of `isInscribedDisc`, so this holds unconditionally via
+    `Real.sSup_nonneg`, without needing `BddAbove`). -/
 theorem inscribedDiscRadius_nonneg (S : Set ℂ) (c : ℂ) (r : ℝ) (h : isInscribedDisc S c r) :
     0 ≤ inscribedDiscRadius S := by
-  apply le_csSup_of_le
-  · exact ⟨c, h⟩
-  · exact h.1.le
+  unfold inscribedDiscRadius
+  apply Real.sSup_nonneg
+  intro x ⟨c, hpos, _⟩
+  linarith
 
 /-
 ## Supporting lemmas for clustered_implies_large_disc
@@ -88,17 +97,22 @@ theorem abs_sub_lt_of_clustered (z c : ℂ) (zi : ℂ) (ε : ℝ) (hε : 0 < ε)
   have h : Complex.abs (z - zi) ≤ Complex.abs (z - c) + Complex.abs (zi - c) := by
     calc Complex.abs (z - zi)
         = Complex.abs ((z - c) - (zi - c)) := by ring_nf
-      _ ≤ Complex.abs (z - c) + Complex.abs (zi - c) := Complex.abs.sub_le _ _
+      _ ≤ Complex.abs (z - c) + Complex.abs (zi - c) := norm_sub_le _ _
   linarith
 
 /-- Product of values with absolute value < 1 has absolute value < 1. -/
 theorem prod_abs_lt_one_of_each {n : ℕ} (hn : n > 0) (v : Fin n → ℂ)
     (hv : ∀ i, Complex.abs (v i) < 1) :
     Complex.abs (∏ i : Fin n, v i) < 1 := by
-  rw [map_prod]
-  apply Finset.prod_lt_one
-  · intro i _; exact norm_nonneg _
-  · intro i _; exact le_of_lt (hv i)
-  · exact ⟨⟨0, hn⟩, Finset.mem_univ _, hv _⟩
+  show ‖∏ i : Fin n, v i‖ < 1
+  rw [norm_prod]
+  have key : ∀ s : Finset (Fin n), s.Nonempty → ∏ i ∈ s, ‖v i‖ < 1 := by
+    intro s hs
+    induction hs using Finset.Nonempty.cons_induction with
+    | singleton a => simpa [Complex.abs] using hv a
+    | cons a s ha _ ih =>
+        rw [Finset.prod_cons]
+        exact mul_lt_one_of_nonneg_of_lt_one_left (norm_nonneg _) (hv a) ih.le
+  exact key Finset.univ (Finset.univ_nonempty_iff.mpr ⟨⟨0, hn⟩⟩)
 
 end Erdos1039.Aristotle

--- a/proofs/Proofs/Erdos679Aristotle.lean
+++ b/proofs/Proofs/Erdos679Aristotle.lean
@@ -20,7 +20,7 @@ open Nat Finset
 -- ═══════════════════════════════════════════════════════════════════
 
 /-- ω(n) = number of distinct prime divisors of n. -/
-noncomputable def omega (n : ℕ) : ℕ := n.primeFactors.card
+def omega (n : ℕ) : ℕ := n.primeFactors.card
 
 /-- ω(1) = 0. -/
 theorem omega_one : omega 1 = 0 := by
@@ -33,14 +33,14 @@ theorem omega_prime (p : ℕ) (hp : p.Prime) : omega p = 1 := by
 /-- ω(p^k) = 1 for prime p and k ≥ 1. -/
 theorem omega_prime_pow (p k : ℕ) (hp : p.Prime) (hk : k ≥ 1) :
     omega (p ^ k) = 1 := by
-  simp [omega, Nat.primeFactors_prime_pow hp (by omega)]
+  simp [omega, Nat.primeFactors_prime_pow (show k ≠ 0 by omega) hp]
 
 /-- ω is additive on coprime arguments. -/
 theorem omega_mul_coprime (m n : ℕ) (hm : m ≠ 0) (hn : n ≠ 0)
     (hmn : m.Coprime n) :
     omega (m * n) = omega m + omega n := by
   simp [omega]
-  rw [Nat.Coprime.primeFactors_mul hmn hm hn]
+  rw [Nat.Coprime.primeFactors_mul hmn]
   exact Finset.card_union_of_disjoint (Nat.Coprime.disjoint_primeFactors hmn)
 
 -- ═══════════════════════════════════════════════════════════════════
@@ -48,7 +48,7 @@ theorem omega_mul_coprime (m n : ℕ) (hm : m ≠ 0) (hn : n ≠ 0)
 -- ═══════════════════════════════════════════════════════════════════
 
 /-- Ω(n) = number of prime divisors counted with multiplicity. -/
-noncomputable def bigOmega (n : ℕ) : ℕ := n.primeFactorsList.length
+def bigOmega (n : ℕ) : ℕ := n.primeFactorsList.length
 
 /-- Ω(n) ≥ ω(n) always. -/
 theorem bigOmega_ge_omega (n : ℕ) : bigOmega n ≥ omega n := by
@@ -58,9 +58,9 @@ theorem bigOmega_ge_omega (n : ℕ) : bigOmega n ≥ omega n := by
   · calc n.primeFactors.card
         ≤ n.primeFactorsList.toFinset.card := by
           apply Finset.card_le_card; intro p hp
-          exact List.mem_toFinset.mpr ((Nat.mem_primeFactorsList hn).mpr
-            ((Nat.mem_primeFactors hn).mp hp))
-      _ ≤ n.primeFactorsList.length := List.toFinset_card_le_length
+          have h := Nat.mem_primeFactors.mp hp
+          exact List.mem_toFinset.mpr ((Nat.mem_primeFactorsList hn).mpr ⟨h.1, h.2.1⟩)
+      _ ≤ n.primeFactorsList.length := List.toFinset_card_le n.primeFactorsList
 
 /-- Ω(1) = 0. -/
 theorem bigOmega_one : bigOmega 1 = 0 := by
@@ -95,18 +95,18 @@ theorem bigOmega_twelve : bigOmega 12 = 3 := by native_decide
 -- Section 4: Prime Factor Monotonicity
 -- ═══════════════════════════════════════════════════════════════════
 
+/-- primeFactors of a divisor is a subset. -/
+theorem primeFactors_dvd_subset (m n : ℕ) (hn : n ≠ 0) (h : m ∣ n) :
+    m.primeFactors ⊆ n.primeFactors := by
+  intro p hp
+  rw [Nat.mem_primeFactors] at hp
+  rw [Nat.mem_primeFactors]
+  exact ⟨hp.1, hp.2.1.trans h, hn⟩
+
 /-- If m | n and n ≠ 0, then ω(m) ≤ ω(n). -/
 theorem omega_dvd_le (m n : ℕ) (hn : n ≠ 0) (h : m ∣ n) :
     omega m ≤ omega n := by
   simp only [omega]
   exact Finset.card_le_card (primeFactors_dvd_subset m n hn h)
-
-/-- primeFactors of a divisor is a subset. -/
-theorem primeFactors_dvd_subset (m n : ℕ) (hn : n ≠ 0) (h : m ∣ n) :
-    m.primeFactors ⊆ n.primeFactors := by
-  intro p hp
-  rw [Nat.mem_primeFactors (show m ≠ 0 from Nat.ne_zero_of_dvd_ne_zero hn h)] at hp
-  rw [Nat.mem_primeFactors hn]
-  exact ⟨hp.1, hp.2.trans h⟩
 
 end Erdos679Aristotle

--- a/proofs/Proofs/Erdos817Aristotle.lean
+++ b/proofs/Proofs/Erdos817Aristotle.lean
@@ -91,18 +91,22 @@ theorem subsetSums_singleton (a : ℕ) :
     have : B = ∅ ∨ B = {a} := by
       rcases Finset.eq_empty_or_nonempty B with rfl | ⟨b, hb⟩
       · left; rfl
-      · right; ext y; simp only [Finset.mem_singleton]
-        exact ⟨fun hy => (Finset.mem_singleton.mp (hB hy)), fun hy => hy ▸ hb⟩
+      · right
+        have hba : b = a := Finset.mem_singleton.mp (hB hb)
+        ext y; simp only [Finset.mem_singleton]
+        refine ⟨fun hy => Finset.mem_singleton.mp (hB hy), fun hy => ?_⟩
+        rw [hy, ← hba]; exact hb
     rcases this with rfl | rfl <;> simp
-  · rintro (rfl | rfl)
-    · exact ⟨∅, Finset.empty_subset _, by simp⟩
-    · exact ⟨{a}, Finset.Subset.refl _, by simp⟩
+  · rintro (h | h)
+    · exact ⟨∅, Finset.empty_subset _, by simp [h]⟩
+    · exact ⟨{a}, Finset.Subset.refl _, by simp [h]⟩
 
 -- Aristotle target: subsetSums of singleton has cardinality 2 (when a ≠ 0)
 theorem card_subsetSums_singleton (a : ℕ) (ha : a ≠ 0) :
     (subsetSumsLocal {a}).card = 2 := by
   rw [subsetSums_singleton]
-  rw [Finset.card_insert_of_notMem (by simp [ha]), Finset.card_singleton]
+  rw [Finset.card_insert_of_notMem (by simp only [Finset.mem_singleton]; omega),
+    Finset.card_singleton]
 
 -- Aristotle target: subsetSums of singleton has cardinality ≤ 2
 theorem card_subsetSums_singleton_le (a : ℕ) :

--- a/proofs/batch2/STATUS.md
+++ b/proofs/batch2/STATUS.md
@@ -1,3 +1,19 @@
+# DOCTOR SINGLE-PROOF BATCH 326 (all-Sonnet, #38065, 2026-07-16)
+
+**+3 GREEN**:
+- Erdos1039ProblemAristotle (Finset.eq_singleton via omega on Fin; norm_sub_le for removed
+  Complex.abs.sub_le; norm_prod + Nonempty.cons_induction for removed map_prod / missing
+  MulLeftStrictMono ℝ; csSup_le_csSup 3-arg needs Nonempty). #38611 REPAIR: inscribedDiscRadius_mono
+  false without boundedness (T=univ -> junk 0); added BddAbove+Nonempty hyps. Companion-only.
+- Erdos817Aristotle (▸-motive drift -> explicit b=a+rw; `rintro (rfl|rfl)` substitutes theorem-param
+  `a` not local `x` -> rcases (h|h)+simp; `simp[ha]` no longer closes ¬0=a -> mem_singleton+omega).
+- Erdos679Aristotle (drop leftover `noncomputable` that blocked native_decide though def is computable;
+  Nat.primeFactors_prime_pow arg swap; mem_primeFactors now unconditional; toFinset_card_le rename;
+  reorder forward-ref lemma).
+SEAMS: csSup_le_csSup now 3-arg (needs Nonempty) -> csSup_le_csSup'; map_prod no longer fires on
+Complex.abs shim -> norm_prod; `rintro (rfl|rfl)` substitutes theorem-parameter not local var;
+noncomputable on a computable-underlying def silently blocks native_decide.
+
 # DOCTOR SINGLE-PROOF BATCH 325 (all-Sonnet, #38065, 2026-07-16)
 
 **+2 GREEN**:

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -711,7 +711,7 @@ Erdos1038Problem	GREEN
 Erdos1038WIP01	GREEN	
 Erdos1039Aristotle	GREEN	doctor-inc65
 Erdos1039Conformal	GREEN	
-Erdos1039ProblemAristotle	RESIDUAL	type-mismatch
+Erdos1039ProblemAristotle	GREEN	
 Erdos103OQ02Bounds	GREEN	
 Erdos1040Aristotle	GREEN	
 Erdos1040Convex	GREEN	
@@ -1573,7 +1573,7 @@ Erdos676Problem	GREEN
 Erdos677Problem	GREEN	
 Erdos678Aristotle	GREEN	
 Erdos678Problem	GREEN	
-Erdos679Aristotle	RESIDUAL	type-mismatch
+Erdos679Aristotle	GREEN	
 Erdos679Problem	GREEN	
 Erdos679ProblemAristotle	GREEN	
 Erdos67Problem	GREEN	
@@ -1726,7 +1726,7 @@ Erdos812Problem	GREEN
 Erdos813Problem	GREEN	
 Erdos814Problem	GREEN	
 Erdos816Problem	GREEN	
-Erdos817Aristotle	RESIDUAL	type-mismatch
+Erdos817Aristotle	GREEN	
 Erdos817Problem	GREEN	
 Erdos818Aristotle	GREEN	
 Erdos819Problem	GREEN	


### PR DESCRIPTION
Erdos1039ProblemAristotle (#38611: added boundedness to inscribedDiscRadius_mono); Erdos817Aristotle; Erdos679Aristotle. No loom labels.