### PR TITLE
migrate(v4.31): single-proof batch 347 (+1 GREEN)

### DIFF
--- a/proofs/Proofs/TriangleAngleSumOQ02.lean
+++ b/proofs/Proofs/TriangleAngleSumOQ02.lean
@@ -76,7 +76,9 @@ This encapsulates the local Gauss-Bonnet theorem.
     The local Gauss-Bonnet formula `gb_local` is the key axiom. -/
 structure GeodesicTriangle where
   /-- The three interior angles (radians) -/
-  α β γ : ℝ
+  α : ℝ
+  β : ℝ
+  γ : ℝ
   /-- The area of the triangle -/
   area : ℝ
   /-- Integrated Gaussian curvature ∫_T K dA over the triangle -/
@@ -110,7 +112,7 @@ theorem excess_eq_curvature (T : GeodesicTriangle) :
 /-- The angle sum equals π plus the excess. -/
 theorem angleSum_eq_pi_add_excess (T : GeodesicTriangle) :
     T.angleSum = π + T.excess := by
-  simp [GeodesicTriangle.angleSum, GeodesicTriangle.excess]; ring
+  simp [GeodesicTriangle.angleSum, GeodesicTriangle.excess]
 
 /-- The angle sum equals π plus the integrated curvature. -/
 theorem angleSum_eq_pi_add_curvature (T : GeodesicTriangle) :
@@ -141,7 +143,6 @@ theorem flat_angle_sum (T : FlatTriangle) :
 theorem flat_excess_zero (T : FlatTriangle) :
     T.excess = 0 := by
   simp [GeodesicTriangle.excess, flat_angle_sum T]
-  ring
 
 /-- The angleSum of a flat triangle is π. -/
 theorem flat_angleSum_eq_pi (T : FlatTriangle) :
@@ -181,7 +182,8 @@ theorem spherical_area_eq_radius_sq_excess (T : SphericalTriangle) :
     T.area = T.radius ^ 2 * (T.α + T.β + T.γ - π) := by
   have h := girard_theorem T
   have hr2 : T.radius ^ 2 ≠ 0 := pow_ne_zero _ T.radius_pos.ne'
-  field_simp [hr2] at h ⊢; linarith
+  rw [eq_div_iff hr2] at h
+  linear_combination -h
 
 /-- Spherical triangles have angle sum **strictly greater than** π. -/
 theorem spherical_angle_sum_gt_pi (T : SphericalTriangle) :
@@ -276,7 +278,7 @@ theorem total_curvature_eq (T : RiemannianTriangulation) :
     (∑ i, (T.triangles i).integratedCurvature) = 2 * π * T.eulerChar := by
   rw [show (∑ i, (T.triangles i).integratedCurvature) =
       (∑ i, (T.triangles i).excess) from
-    Finset.sum_congr rfl fun i _ => ((T.triangles i).excess_eq_curvature).symm]
+    Finset.sum_congr rfl fun i _ => (excess_eq_curvature (T.triangles i)).symm]
   exact T.discrete_gb
 
 /-- For a triangulation of the 2-sphere (χ = 2), total curvature is 4π. -/

--- a/proofs/batch2/STATUS.md
+++ b/proofs/batch2/STATUS.md
@@ -1,3 +1,12 @@
+# DOCTOR SINGLE-PROOF BATCH 347 (all-Sonnet, #38065, 2026-07-16)
+
+**+1 GREEN**: TriangleAngleSumOQ02 (v4.31 parser regression: `α β γ : ℝ` multi-name struct field
+misparsed -> trailing names auto-bound as implicit Sort vars; split to one-name-per-line; drop
+redundant ring after simp; field_simp+linarith -> rw[eq_div_iff]+linear_combination; fix dot-notation
+excess_eq_curvature). Repair: none.
+SEAM: `structure ... where n1 n2 n3 : T` multi-binder field with Greek names silently mis-elaborates
+in v4.31 -> split into separate one-name-per-line fields.
+
 # DOCTOR SINGLE-PROOF BATCH 346 (all-Sonnet, #38065, 2026-07-16)
 
 **+1 GREEN**: SpernerNDimOQ03OQ01 (right_mem_Icc.mpr le_rfl->zero_le_one; mul_lt_of_lt_one_right 3-arg

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -2615,7 +2615,7 @@ ThreeSubgroupsLemmaOQ0101	GREEN
 ThreeSubgroupsLemmaOQ01OQ01	GREEN	
 TractatusQuantifiers	GREEN	
 TriangleAngleSum	GREEN	
-TriangleAngleSumOQ02	RESIDUAL	type-mismatch
+TriangleAngleSumOQ02	GREEN	
 TriangleInequality	GREEN	
 TriangleInequalityOQ01	GREEN	
 TriangleInequalityOQ04	GREEN	


### PR DESCRIPTION
TriangleAngleSumOQ02. No loom labels.