### PR TITLE
migrate(v4.31): single-proof batch 357 (+1 GREEN deep-rework)

### DIFF
--- a/proofs/Proofs/AreaOfCircleOQ01OQ03OQ01.lean
+++ b/proofs/Proofs/AreaOfCircleOQ01OQ03OQ01.lean
@@ -423,9 +423,9 @@ theorem circumference_reparam_preserved (γ : SmoothClosedCurve)
   -- τ has derivative (1/speed(τ t)) * c at each t (chain rule + IFT)
   have hτ_da : ∀ t, HasDerivAt τ (1 / curveSpeed γ (τ t) * c) t := fun t => by
     have hσ_da := arcLengthInv_hasDerivAt γ hReg hL (c * t)
-    have h := hσ_da.comp t ((hasDerivAt_id t).const_mul c)
-    simp only [Function.comp] at h
-    convert h using 1; ring
+    have hinner : HasDerivAt (fun y => c * y) c t := by
+      have h := (hasDerivAt_id t).const_mul c; simpa [mul_one] using h
+    exact hσ_da.comp t hinner
   -- The integrand equals c pointwise (chain rule + algebraic simplification)
   have hint : ∀ t ∈ Set.uIcc (0 : ℝ) (2 * π),
       Real.sqrt (deriv (γ.x ∘ τ) t ^ 2 + deriv (γ.y ∘ τ) t ^ 2) = c := by
@@ -477,9 +477,9 @@ theorem area_reparam_preserved (γ : SmoothClosedCurve)
   -- τ derivative
   have hτ_da : ∀ t, HasDerivAt τ (1 / curveSpeed γ (τ t) * c) t := fun t => by
     have hσ_da := arcLengthInv_hasDerivAt γ hReg hL (c * t)
-    have h := hσ_da.comp t ((hasDerivAt_id t).const_mul c)
-    simp only [Function.comp] at h
-    convert h using 1; ring
+    have hinner : HasDerivAt (fun y => c * y) c t := by
+      have h := (hasDerivAt_id t).const_mul c; simpa [mul_one] using h
+    exact hσ_da.comp t hinner
   have hτ'_pos : ∀ t, 0 < 1 / curveSpeed γ (τ t) * c := fun t => by
     apply mul_pos _ hc_pos
     apply div_pos one_pos
@@ -664,10 +664,9 @@ theorem exists_arclength_reparam' (γ : SmoothClosedCurve)
       arcLengthInv_hasDerivAt γ hReg hL (c * t)
     -- τ has derivative c/speed(τ(t)) at t
     have hτ_da : HasDerivAt τ (1 / curveSpeed γ (τ t) * c) t := by
-      have := hσ_da.comp t ((hasDerivAt_id t).const_mul c)
-      simp only [Function.comp, hτ_def] at this ⊢
-      convert this using 1
-      ring
+      have hinner : HasDerivAt (fun y => c * y) c t := by
+        have h := (hasDerivAt_id t).const_mul c; simpa [mul_one] using h
+      exact hσ_da.comp t hinner
     -- Chain rule for γ.x ∘ τ and γ.y ∘ τ
     have hx_da : HasDerivAt γ.x (deriv γ.x (τ t)) (τ t) :=
       (γ.smooth_x.differentiable one_ne_zero).differentiableAt.hasDerivAt

--- a/proofs/batch2/STATUS.md
+++ b/proofs/batch2/STATUS.md
@@ -1,3 +1,13 @@
+# DOCTOR SINGLE-PROOF BATCH 357 (Sonnet DEEP-REWORK, #38065, 2026-07-16)
+
+**+1 GREEN (deep-rework)**: AreaOfCircleOQ01OQ03OQ01 (NOT decide-maxrecdepth (stale label) — v4.31
+HasDerivAt.comp instance-diamond: inline hasDerivAt_id.const_mul resolves AddCommGroup ℝ/Module ℝ ℝ via
+NormedField-self-algebra path, no longer defeq to plain-instance goal under convert using 1; fixed 3 sites
+by hoisting inner deriv into explicitly-typed `have hinner : HasDerivAt (fun y=>c*y) c t` then
+hσ_da.comp t hinner (parent pattern); drop 2 dead simp only [Function.comp] on unapplied ∘). Repair: none.
+SEAM: HasDerivAt-comp-instance-diamond -> explicit-type intermediate `have`, avoid bare convert using 1;ring
+on composed HasDerivAt; simp only [Function.comp] no-progress on unapplied f∘g.
+
 # DOCTOR SINGLE-PROOF BATCH 356 (Sonnet DEEP-REWORK, #38065, 2026-07-16)
 
 **+1 GREEN (deep-rework)**: AreaOfCircleOQ01OQ03OQ02 (contDiff_periodic_lipschitz NNReal coe step:

--- a/proofs/batch2/verify-results.tsv
+++ b/proofs/batch2/verify-results.tsv
@@ -116,7 +116,7 @@ AreaOfCircleOQ01OQ02OQ02OQ02OQ02	RESIDUAL	unknown-const:wirtinger_inequality
 AreaOfCircleOQ01OQ02OQ03OQ03	GREEN	
 AreaOfCircleOQ01OQ03	GREEN	
 AreaOfCircleOQ01OQ03Aristotle	GREEN	
-AreaOfCircleOQ01OQ03OQ01	RESIDUAL	decide-maxrecdepth
+AreaOfCircleOQ01OQ03OQ01	GREEN	
 AreaOfCircleOQ01OQ03OQ02	GREEN	
 AreaOfCircleOQ02	GREEN	
 AreaOfCircleOQ02OQ01	GREEN	


### PR DESCRIPTION
AreaOfCircleOQ01OQ03OQ01 (deep-rework). No loom labels.