### PR TITLE
chore(repo): update repo-skills 0.3.0 → 0.4.1

### DIFF
--- a/.claude/commands/repo/all.md
+++ b/.claude/commands/repo/all.md
@@ -1,6 +1,6 @@
 ---
 name: "all"
-description: "The whole hygiene pass in order — audit, tidy, update-tools, reset — each report-first"
+description: "The whole hygiene pass in order — audit, docs, tidy, update-tools, reset — safe fixes by default, destructive steps gated"
 domain: repo
 type: command
 user-invocable: true
@@ -8,11 +8,12 @@ user-invocable: true
 
 # /repo:all — The Whole Hygiene Pass
 
-Run the full sequence of sensible repo work in one go: scan for problems, tidy
-filesystem clutter, refresh installed tool packages, and land back on a clean
-baseline. This is the umbrella command — it orchestrates the other `/repo:*`
-commands in a deliberate order, but changes nothing without the same
-report-first confirmation each of them uses on its own.
+Run the full sequence of sensible repo work in one go: scan for problems, bring
+the docs back in line with reality, tidy filesystem clutter, refresh installed
+tool packages, and land back on a clean baseline. This is the umbrella command
+— it orchestrates the other `/repo:*`
+commands in a deliberate order, applying each one's safe fixes by default and
+keeping the same safety gates on destructive steps that each uses on its own.
 
 It deliberately does **not** launch cloud dev sessions ([[remote]]) — that
 provisions paid infrastructure and is never part of a routine hygiene pass.
@@ -20,9 +21,10 @@ provisions paid infrastructure and is never part of a routine hygiene pass.
 ## Usage
 
 ```
-/repo:all                      # Full repo, every stage, interactive
+/repo:all                      # Full repo — apply safe fixes across stages, report as you go
+/repo:all --ask                # Confirm findings before applying at every stage
 /repo:all packages/core        # Scope the read-only scans to one subtree
-/repo:all --prune              # Auto-delete confirmed-safe branches/worktrees (passed to reset)
+/repo:all --prune              # Also delete confirmed-safe branches/worktrees (passed to reset, after the loss check)
 ```
 
 The optional path argument scopes the scanning stages ([[audit]]) the same way
@@ -31,9 +33,12 @@ it does for those commands. Stages that act on global git or filesystem state
 
 ## Stages
 
-Run these in order. **Between each stage, show what was found and get a yes
-before acting** — do not chain destructive steps silently. If the user declines
-a stage, note it and continue to the next.
+Run these in order. Each stage applies its safe, reversible fixes by default
+and reports them; irreversible removals (Tidy's ASK items, Reset's
+branch/worktree/stash deletion) still require explicit approval and pass the
+permanent-loss check — they are never chained silently. Under `--ask`,
+every stage reverts to report-first: show what was found and get a yes before
+acting. If the user declines a stage, note it and continue to the next.
 
 ### 1. Audit (see [[audit]])
 
@@ -41,25 +46,32 @@ Run the full read-only health sweep: README accuracy, orphaned files, broken
 links, gitignore issues, branch & worktree hygiene. Produce the combined audit
 report. This surfaces everything before anything is touched.
 
-Offer to fix the fixable findings (stale READMEs, broken links, gitignore
-rules) here, since the next stages won't.
+Offer to fix gitignore findings here. Leave README, link, and documentation
+fixes for the Docs stage next — don't apply them twice.
 
-### 2. Tidy (see [[tidy]])
+### 2. Docs (see [[docs]])
+
+Bring the documentation back in line with reality: content accuracy (stale
+prose, out-of-date command/feature tables, CHANGELOG drift), README structure,
+and internal cross-references. This is the explicit, named home for the doc
+fixes the audit surfaced — apply the ones the user approves.
+
+### 3. Tidy (see [[tidy]])
 
 Inventory filesystem clutter — build artifacts, caches, temp files, empty dirs
 — present it grouped with sizes, and remove what the user approves.
 
-### 3. Update tools (see [[update-tools]])
+### 4. Update tools (see [[update-tools]])
 
 Check installed tool packages (Loom, Anvil, Repo itself, …) against their
 sources. Report what's behind and offer to update.
 
-### 4. Reset (see [[reset]])
+### 5. Reset (see [[reset]])
 
 Last, because it changes branch state and syncs with the remote. Run the
 end-of-task baseline ritual: working-tree safety check, stash review, branch &
 worktree pruning, `git fetch --prune`, and return to the default branch. Pass
-`--prune` through if it was given to `/repo:all`.
+`--prune` and `--ask` through if either was given to `/repo:all`.
 
 Do this stage last so the earlier scans and cleanup happen while you're still on
 the working branch, and you finish on a clean default branch.
@@ -72,7 +84,8 @@ forgotten:
 ```
 REPO:ALL COMPLETE
 =================
-Audit:        3 findings (2 fixed, 1 deferred: docs/analysis/ missing README)
+Audit:        3 findings surfaced (gitignore rule fixed)
+Docs:         2 fixed (README table, CHANGELOG entry), 1 deferred: docs/analysis/ missing README
 Tidy:         freed 240 MB (build/, .cache/, 3 empty dirs)
 Tools:        Anvil updated 1.4.0 → 1.5.1; Loom current
 Reset:        on main (up to date), tree clean, 4 branches deleted, 1 stash kept
@@ -84,7 +97,9 @@ UNKNOWN branches — so the user knows exactly what state the repo is in.
 
 ## Principles
 
-Same as every hygiene command: **report first, fix second**; **general by
-design**; **don't be noisy**. `/repo:all` adds only sequencing — each stage
-keeps its own confirmation step, and no stage is skipped or auto-approved just
+Same as every hygiene command: **apply safe fixes, gate destructive ones**
+(reversible fixes apply by default, `--ask` to confirm first, irreversible
+removals always require explicit opt-in); **general by design**; **don't be
+noisy**. `/repo:all` adds only sequencing — each stage keeps its own safety
+gate, and no stage is skipped or its destructive actions auto-approved just
 because it runs under the umbrella.

--- a/.claude/commands/repo/audit.md
+++ b/.claude/commands/repo/audit.md
@@ -24,7 +24,8 @@ findings for discussion.
 Run each of the following checks and compile results into a single report:
 
 ### 1. README Accuracy (see [[readme]])
-- Directories with >5 files that lack a README
+- Browsable directory levels that lack a README (top-level and significant
+  subdirs — so GitHub renders docs at each level someone navigates to)
 - READMEs whose file/folder listings don't match actual contents
 - Stale "gitignored" or "TODO" annotations that are no longer true
 

--- a/.claude/commands/repo/branches.md
+++ b/.claude/commands/repo/branches.md
@@ -116,19 +116,46 @@ STALE WORKTREES (0):
 
 ### 5. If `--prune` flag is set
 
-After presenting the report, delete branches in the SAFE TO DELETE category:
+**Before deleting anything, run the permanent-loss check.** No branch or
+worktree is removed until it passes — irreversible removal of work that exists
+nowhere else is never acceptable, `--prune` or not.
+
+For every branch about to be deleted, list commits that live *only* on that
+branch — not reachable from the default branch and not present on any remote:
 
 ```bash
-git branch -D <branch_name>
+git log --oneline <branch> --not --remotes --not <default>
 ```
 
-For stale worktrees:
+- **Empty** → the work is preserved elsewhere (merged or pushed); safe to delete.
+- **Non-empty** → those commits would be **permanently lost**. Do NOT auto-delete
+  even under `--prune`. Reclassify the branch as UNKNOWN, show the count and the
+  commit subjects, and require an explicit per-branch confirmation.
+
+(A merged PR whose remote branch was already deleted may show commits here after
+a squash-merge — that's the safe direction to err: surface it and let the user
+confirm the work is truly in the PR.)
+
+For each worktree about to be removed, refuse if it has uncommitted changes —
+that work exists nowhere else:
+
 ```bash
-git worktree unlock <path> 2>/dev/null
-git worktree remove --force <path>
+if [ -n "$(git -C <path> status --porcelain)" ]; then
+  echo "SKIP <path>: uncommitted changes — resolve before removing"
+else
+  git worktree remove <path>          # no --force; only remove clean worktrees
+fi
 ```
 
-Report what was deleted and what remains.
+Then delete the branches that passed the loss check:
+
+```bash
+git branch -d <branch_name>           # -d (safe): refuses if not merged
+# escalate to -D only for a branch the loss check proved is pushed/merged
+```
+
+Report what was deleted, what was skipped for potential data loss, and what
+remains.
 
 ### 6. If no `--prune` flag
 
@@ -145,6 +172,9 @@ To investigate unknown branches: git log --oneline -5 <branch>
 3. **NEVER delete branches named as long-lived by the repo's own docs**
 4. **Always report before deleting** — the user must see the full list before `--prune` acts
 5. **When in doubt, classify as UNKNOWN** — let the user decide
+6. **Never destroy unique work** — run the permanent-loss check (step 5) before
+   any deletion; a branch with commits found nowhere else, or a worktree with
+   uncommitted changes, is never removed automatically, regardless of flags
 
 ## Notes
 

--- a/.claude/commands/repo/docs.md
+++ b/.claude/commands/repo/docs.md
@@ -1,0 +1,125 @@
+---
+name: "docs"
+description: "Check documentation against reality — content accuracy, README structure, and cross-references"
+domain: repo
+type: command
+user-invocable: true
+---
+
+# /repo:docs — Documentation Check
+
+The canonical documentation-health command. Verify that the repo's docs still
+describe the repo that exists — not the one that existed three refactors ago.
+
+This is the single entry point for docs work. It covers three layers:
+
+1. **Content accuracy** — does the prose still match how things actually work?
+   (unique to this command)
+2. **README structure** — do file trees and directory listings match disk?
+   (delegates to [[readme]])
+3. **Cross-references** — do internal links and paths still resolve?
+   (delegates to [[links]])
+
+`/repo:readme` and `/repo:links` remain callable on their own when you only
+want that one layer. Reach for `/repo:docs` when you want the whole picture.
+
+## Usage
+
+```
+/repo:docs                     # Full repo — apply safe fixes, report as you go
+/repo:docs docs/               # Scope to one subtree
+/repo:docs README.md           # Check a single doc
+/repo:docs --ask               # Review findings and confirm before applying
+```
+
+The optional path argument scopes every layer the same way, exactly as
+[[readme]] and [[links]] scope on their own.
+
+## What It Checks
+
+### 1. Content Accuracy
+
+This is the semantic layer that structural checks miss — prose that parses
+fine and links that resolve fine, but describes behavior that has since
+changed. Read the docs against the actual repo state and flag drift:
+
+- **Feature / command tables** that list capabilities the repo no longer has,
+  or omit ones it gained. For a repo with `.claude/commands/`, cross-check
+  every documented command against the files that actually exist, in both
+  directions.
+- **CHANGELOG currency** — recent commits (features, breaking changes, renames)
+  that landed with no corresponding CHANGELOG entry. Compare the top entry's
+  date/version against `git log` since then.
+- **Code examples & snippets** in docs that reference symbols, flags, file
+  paths, or commands that no longer exist. Verify each referenced identifier
+  resolves in the current tree.
+- **Described workflows** — step-by-step instructions (install, build, usage)
+  that name scripts, targets, or flags. Confirm they still exist and still take
+  the arguments shown.
+- **Version / count claims** — "supports 12 commands", "requires Node 18",
+  hardcoded numbers that drift as the repo changes.
+
+Content findings are judgment calls — when something looks stale but you can't
+confirm it from the repo, flag it as a question rather than asserting it's
+wrong.
+
+### 2. README Structure (see [[readme]])
+
+Run the full [[readme]] check: ASCII file-tree accuracy, directories missing a
+README, and stale "gitignored"/"TODO" annotations. Fold its findings into this
+report rather than emitting a separate one.
+
+### 3. Cross-References (see [[links]])
+
+Run the full [[links]] check: markdown links, CLAUDE.md path references,
+skill/command wikilinks, and nested CLAUDE.md paths. Fold its findings in the
+same way. Broken CLAUDE.md paths remain **critical** — they're the primary
+navigation paths for agents.
+
+## Output Format
+
+One consolidated report, grouped by layer so it's clear which are mechanical
+(structure, links) and which are judgment calls (content):
+
+```
+## Docs Check — docs/
+
+### Content Accuracy (2 findings)
+| Severity | Location | Issue |
+|----------|----------|-------|
+| warn | README.md:14 | Skills table omits /repo:docs (exists on disk) |
+| info | CHANGELOG.md | No entry since v0.3.0; 4 feature commits since |
+
+### README Structure (1 finding — via readme)
+| warn | docs/analysis/ | No README, 8 files |
+
+### Cross-References (1 finding — via links)
+| critical | CLAUDE.md:42 | Link to docs/setup.md — MISSING |
+
+### Summary
+- 2 content (0 critical, 1 warn, 1 info)
+- 1 structure (0 critical, 1 warn)
+- 1 cross-reference (1 critical)
+```
+
+## Interaction
+
+By default, apply the safe, reversible fixes as you find them — correcting
+stale listings, tables, and factual drift — and report each change (all
+git-reversible). Run with `--ask` to review first: for each finding, offer
+to **fix it**, **skip** it, or **show** the relevant section before deciding.
+
+Content findings are judgment calls; when you can't confirm something is wrong
+from the repo, raise it as a question rather than editing on a guess — even in
+the default apply mode.
+
+Never rewrite prose wholesale to "improve" it — the job is accuracy, not a
+style pass. Fix the factual drift and leave the voice alone.
+
+## Principles
+
+Same as every hygiene command: **apply safe fixes, gate destructive ones**
+(doc edits are reversible, so they apply by default; `--ask` to confirm
+first); **general by design** (no assumptions about doc layout — read what's
+there); **don't be noisy** (a slightly informal sentence isn't a finding; a
+command that no longer exists is).

--- a/.claude/commands/repo/gitignore.md
+++ b/.claude/commands/repo/gitignore.md
@@ -14,8 +14,9 @@ that shouldn't be ignored and build artifacts that should be.
 ## Usage
 
 ```
-/repo:gitignore                  # Full repo
+/repo:gitignore                  # Full repo — apply clear rule fixes, report as you go
 /repo:gitignore data/            # Check one subtree
+/repo:gitignore --ask            # Review findings and confirm before editing
 ```
 
 ## Context First
@@ -69,4 +70,8 @@ For each `.gitignore` file, show:
 - Suggested additions or removals
 - Files affected by changes
 
-Ask before modifying any gitignore.
+By default, apply the clear-cut rule changes (adding an obvious build-artifact
+ignore, removing a rule that hides real content) and report each edit — gitignore
+changes are fully git-reversible. Leave anything ambiguous, or that would change
+whether a **tracked** file stays tracked, as a reported recommendation. Under
+`--ask`, confirm every edit before writing.

--- a/.claude/commands/repo/help.md
+++ b/.claude/commands/repo/help.md
@@ -39,9 +39,10 @@ Structure it like this:
 ```
 ## Repo Skills v<version> (installed <date>)
 
-General repository hygiene and environment tools. Everything is
-**report-first**: commands show findings and wait for your direction
-before changing anything.
+General repository hygiene and environment tools. Commands **apply their
+safe, reversible fixes by default** and report each change; add `--ask`
+to review and confirm first. Irreversible removals (branches, worktrees,
+stashes, untracked files) always need an explicit opt-in.
 
 ### Everyday
 | Command | When to reach for it |
@@ -54,13 +55,17 @@ before changing anything.
 | /repo:audit | Monthly sweep, or after a big refactor/import |
 | /repo:update-tools | Keep Loom/Anvil/Repo Skills installs current |
 
-### Focused checks (audit runs all of these)
+### Focused checks
+| /repo:docs | Documentation health — content, README structure, cross-refs |
 | /repo:branches | ... |
 | /repo:gitignore | ... |
 | /repo:links | ... |
 | /repo:orphans | ... |
 | /repo:readme | ... |
 ```
+
+(`audit` runs the branch/gitignore/links/orphans/readme checks; `docs` is the
+canonical doc command and subsumes `readme` + `links`.)
 
 Group whatever is actually installed into those three buckets (everyday /
 periodic / focused); put unrecognized commands in a fourth "Other" group with
@@ -70,8 +75,9 @@ their frontmatter descriptions.
 
 - Where to start: `/repo:audit` for a first look at repo health, `/repo:reset`
   at the end of a work session
-- Most commands take an optional path to limit scope, and a flag to apply
-  fixes (`--prune`, `--apply`) — without it they only report
+- Most commands take an optional path to limit scope. Safe fixes apply by
+  default; add `--ask` to review first, or `--prune` to also remove
+  confirmed-safe branches/worktrees (after a permanent-loss check)
 - Full details per command: `/repo:help <command>` or the files in
   `.claude/commands/repo/`
 - Updating: `/repo:update-tools` (source: https://github.com/rjwalters/repo)

--- a/.claude/commands/repo/links.md
+++ b/.claude/commands/repo/links.md
@@ -11,12 +11,16 @@ user-invocable: true
 Validate that internal cross-references across the repo actually resolve.
 Catches broken links from reorganization, renames, and deletions.
 
+This is the cross-reference layer of [[docs]]. Use it directly when that's all
+you want to check; use [[docs]] for the full documentation sweep.
+
 ## Usage
 
 ```
-/repo:links                    # Full repo
+/repo:links                    # Full repo — fix unambiguous links, report as you go
 /repo:links CLAUDE.md          # Check one file
 /repo:links .claude/           # Check skill/command files
+/repo:links --ask              # Review findings and confirm before fixing
 ```
 
 ## What It Checks
@@ -62,5 +66,7 @@ Group findings by source file:
 ...
 ```
 
-For each broken link, suggest the most likely correct target (fuzzy match on
-filename) if one exists. Ask before fixing.
+For each broken link, find the most likely correct target (fuzzy match on
+filename). When there's a single confident match, fix the link and report it;
+when the match is ambiguous or no target exists, report it for a human call.
+Under `--ask`, propose every fix and confirm before editing.

--- a/.claude/commands/repo/orphans.md
+++ b/.claude/commands/repo/orphans.md
@@ -54,5 +54,8 @@ Present findings grouped by type. For each orphan, show:
 - What was searched for (e.g., "grepped for `extract.py` — 0 references")
 - Suggested action: delete, move, or add a reference
 
-Ask before taking any action. Some "orphans" are legitimate standalone files —
-the user knows which.
+Deleting an orphan is destructive and a judgment call — an "orphan" is often a
+legitimate standalone file the user keeps deliberately — so unlike the safe-fix
+commands this one never auto-acts. It reports and waits for your decision
+(delete, move, or add a reference), with no `--ask` needed: report-and-wait
+is the only mode.

--- a/.claude/commands/repo/readme.md
+++ b/.claude/commands/repo/readme.md
@@ -12,13 +12,23 @@ Validate that READMEs accurately describe the directories they live in. Catches
 stale file trees, incorrect descriptions, and missing READMEs in significant
 directories.
 
+This is the README-structure layer of [[docs]]. Use it directly when that's all
+you want to check; use [[docs]] for the full documentation sweep.
+
 ## Usage
 
 ```
 /repo:readme                    # Scan all READMEs in repo
 /repo:readme packages/core      # Scope to one subtree
 /repo:readme docs/README.md     # Check a specific README
+/repo:readme --ask              # Review findings and confirm before applying
 ```
+
+By default, apply the safe, reversible fixes as you find them — updating stale
+listings, correcting wrong annotations — and report each change (they're all
+git-reversible). Run with `--ask` to review first: present the findings and
+confirm before touching anything. Writing a brand-new README is a judgment
+call, so it's always proposed, never written unattended, in either mode.
 
 ## What It Checks
 
@@ -30,10 +40,30 @@ compare it against the actual directory listing:
 - Descriptions that are factually wrong (e.g., "gitignored" when it's tracked)
 
 ### 2. Missing READMEs
-Flag directories that probably need one:
-- Any directory with >5 files and no README
-- Any top-level package/project directory without a README
-- Skip: `node_modules/`, `.git/`, `__pycache__/`, virtualenvs, build output dirs
+GitHub renders a directory's `README.md` right below its file listing, so a
+README at each level a person browses to makes the repo read as documented
+instead of a bare file dump. Flag directories that a human would actually
+navigate to in the web UI and that lack one, scaled by how significant the
+directory is:
+
+- **warn** — top-level directories and package/project roots (the first thing a
+  visitor clicks into)
+- **info** — meaningful mid-level groupings: source packages, `docs/`
+  subsections, grouped assets, anything with several files and a clear purpose
+- **skip** — directories where a README would be noise: generated/build output,
+  `node_modules/`, `.git/`, `__pycache__/`, virtualenvs, and trivial leaf dirs
+  that are self-evident from their name and contents (e.g. a flat `images/`)
+
+**Depth cutoff:** limit the browsability check to directories within **two
+levels of the repo root** — the levels a visitor actually clicks through in the
+web UI. Deeper nesting is skipped by default, since nobody browses there
+casually; the one exception is a package/project root found deeper (e.g. a
+monorepo `packages/<name>/`), which is browsable in its own right and still
+warrants a README.
+
+The goal is a clean browsing experience at every level someone would land on —
+not a README in literally every folder. When in doubt on a small directory,
+prefer **info** over **warn**, and don't flag the obviously self-explanatory.
 
 ### 3. Stale Content
 - References to removed files or directories
@@ -42,10 +72,10 @@ Flag directories that probably need one:
 
 ## Interaction
 
-For each finding, show the specific discrepancy and ask whether to:
-1. **Update the README** to match reality (add/remove entries)
-2. **Skip** this finding
-3. **Show me the README** so I can decide
+By default, fix each factual discrepancy (add/remove entries, correct wrong
+annotations) and report what changed. Under `--ask`, show each finding
+first and ask whether to **update**, **skip**, or **show the README** before
+deciding.
 
-When updating, preserve the README's existing style and voice — just fix the
-factual inaccuracies.
+Whether applied or confirmed, preserve the README's existing style and voice —
+just fix the factual inaccuracies, never rewrite prose to "improve" it.

--- a/.claude/commands/repo/release.md
+++ b/.claude/commands/repo/release.md
@@ -46,9 +46,29 @@ CHANGELOG entry — cheap to catch now, expensive to reconstruct later. **No-op 
 `CHANGELOG.md` is absent** (Phase 4 bootstraps it).
 
 ```bash
-[ -f CHANGELOG.md ] || echo "(no CHANGELOG.md — skipping gate)"
-# For each of the last ~5 tags (git tag --sort=-v:refname), check that
-# CHANGELOG.md contains a header for its version (strip a leading 'v').
+if [ ! -f CHANGELOG.md ]; then
+  echo "(no CHANGELOG.md — skipping gate)"
+else
+  # For each of the last ~5 tags, check CHANGELOG.md has a header for its
+  # version. The accepted header shape is format-AGNOSTIC: this repo uses the
+  # bracket-LESS "## 0.4.1 (2026-07-16)" form, but Keep-a-Changelog
+  # "## [0.4.1] - 2026-07-16" is equally valid. Accept BOTH — with an optional
+  # leading 'v' and optional surrounding brackets — and match the version's
+  # dots LITERALLY (escape them) so "0.4.1" cannot spuriously match "0X4X1" or
+  # "0.4.10". This mirrors the optional-bracket extraction Phase 6 uses
+  # (sed "/^## \[\?$NEW/…") and additionally tolerates a leading 'v' on the
+  # header, so the read side (this gate) and the write side (Phase 4 draft /
+  # Phase 6 extract) never disagree about what a version header looks like.
+  for tag in $(git tag --sort=-v:refname | head -5); do
+    ver="${tag#v}"                                     # strip a leading 'v'
+    ver_re="$(printf '%s' "$ver" | sed 's/\./\\./g')"  # escape dots -> literal
+    if grep -Eq "^##[[:space:]]+v?\[?${ver_re}\]?([[:space:]]|\$)" CHANGELOG.md; then
+      echo "ok: $ver"
+    else
+      echo "MISSING: $ver"
+    fi
+  done
+fi
 ```
 
 For any tag missing an entry, surface the gap and offer: **[b]** backfill it now
@@ -60,7 +80,10 @@ release tag), **[c]** continue and leave the gap, or **[a]** abort.
 
 Detect the host repo's bump mechanism. **First match wins**, in this order. An
 explicit `scripts/version.sh` is honored first; a plain `VERSION` file is the
-most-general fallback.
+most-general fallback. Because `npm` is matched on `package.json` alone — before
+the `VERSION` fallback — the result is **provisional** whenever both files
+coexist: reconcile it against the root `VERSION` file (see *Cross-source
+reconciliation* below) before treating `VERSION_TOOL` as final.
 
 ```bash
 VERSION_TOOL="" ; WHY=""
@@ -90,13 +113,60 @@ echo "${VERSION_TOOL:-<none>} — ${WHY:-no tool detected}"
 silently — offer: **[m]** manual (they edit manifests, you commit + tag), or
 **[a]** abort.
 
-### Drift gate (multi-file tools only)
+### Cross-source reconciliation (VERSION vs package.json)
 
-Tools with more than one version-bearing file can disagree, and a blind bump
-would mis-delta the drifted one. Before reading the current version, verify
-agreement — `./scripts/version.sh check` (fatal if it fails), a `bumpversion
---dry-run --allow-dirty` probe (advisory), etc. Single-source tools
-(`cargo` inheritance, `poetry`, `npm`, `version-file`) are drift-free — skip.
+`npm` is matched on the mere presence of `package.json`, so a repo that keeps a
+plain root `VERSION` file **and** a `package.json` detects as `npm` even when
+`VERSION` is the maintained source of truth — a blind `npm version` would then
+bump and tag the wrong line. Whenever the provisional tool is `npm` **and** a
+root `VERSION` file also exists **and** `package.json` carries a `version` field,
+read both and reconcile before finalizing `VERSION_TOOL`:
+
+```bash
+# Runs only when detection landed on npm but a root VERSION file also coexists.
+if [ "$VERSION_TOOL" = "npm" ] && [ -f VERSION ] && grep -q '"version"' package.json; then
+  PKG_VER="$(node -p "require('./package.json').version" 2>/dev/null \
+    || grep -m1 '"version"' package.json | sed -E 's/.*"version"[[:space:]]*:[[:space:]]*"([^"]+)".*/\1/')"
+  FILE_VER="$(head -1 VERSION | tr -d '[:space:]')"
+  TAG_VER="$(git tag --sort=-v:refname | head -1 | sed 's/^v//')"
+  if [ "$PKG_VER" = "$FILE_VER" ]; then
+    echo "VERSION and package.json agree ($FILE_VER) — keeping npm, no change"
+  else
+    echo "DRIFT: package.json=$PKG_VER  VERSION=$FILE_VER  (latest tag: ${TAG_VER:-<none>})"
+    # Do NOT proceed on npm. Recommend the source that matches the latest tag.
+  fi
+fi
+```
+
+- **They agree** → behave exactly as today: keep `VERSION_TOOL="npm"`, no new
+  prompt, no behavior change.
+- **They disagree** → **do not silently select `npm`.** Surface the drift to the
+  operator and confirm which source is authoritative before any bump. Use the
+  **latest git tag as the tie-breaker**: whichever of `package.json` / `VERSION`
+  matches `git tag --sort=-v:refname | head -1` (leading `v` stripped) is the
+  recommended authoritative source — set `VERSION_TOOL` to `version-file` or
+  `npm` accordingly once the operator confirms.
+- **Tie-breaker unavailable** (no tags yet, or neither value matches the latest
+  tag) → present both values and let the operator choose explicitly; never
+  default to `npm`.
+
+This keys off runtime file existence and values only — no repo-specific names or
+numbers — consistent with *General by design* and *report first, act second*.
+
+### Drift gate (multi-source)
+
+Version-bearing state can disagree in two ways, and a blind bump would mis-delta
+the drifted one. Before reading the current version, verify agreement:
+
+- **Within a single tool** — tools with more than one version-bearing file
+  (`./scripts/version.sh check`, fatal if it fails; a `bumpversion --dry-run
+  --allow-dirty` probe, advisory; etc.). `cargo` inheritance and `poetry` keep
+  their version in one place, so this within-tool check is a no-op for them.
+- **Across sources** — `npm`/`package.json` and a plain root `VERSION` file are
+  **separate sources that can disagree** (e.g. a vestigial `package.json` left at
+  a placeholder version). Do **not** treat `npm` or `version-file` as
+  unconditionally drift-free: when both files exist, run the *Cross-source
+  reconciliation* above before bumping.
 
 ## Phase 3 — Gather changes & decide the bump
 
@@ -191,7 +261,8 @@ Release:   GitHub Release created  (or: tag push only — no release workflow)
 
 ## Principles
 
-Same as every repo command: **report first, act second** — nothing is committed,
+Cutting a release is irreversible and outward-facing, so unlike the safe-fix
+hygiene commands it stays **report first, act second** — nothing is committed,
 tagged, or pushed without a yes. **General by design** — the tool and the file
 set are discovered, never assumed. If the repo needs a release-time reminder
 (e.g. "bump the protocol version when the API changes"), keep it in the repo's

--- a/.claude/commands/repo/remote.md
+++ b/.claude/commands/repo/remote.md
@@ -9,123 +9,408 @@ user-invocable: true
 # /repo:remote — Remote Dev Session
 
 Stand up (or reuse) a cloud VM with this repository cloned and synced, then
-hand the user a live SSH session in a new terminal window.
+open a live SSH session in a new terminal window — landing in the repo, ready
+to run `claude` and continue the work on the remote host.
+
+Configuration is read from two layers (see below): shared cloud credentials
+from **`~/.config/repo/remote.env`** (reused across every repo), with the
+target repo's **`.env`** layered on top for per-repo machine settings — and
+free to override any shared value. The provisioning credentials are used
+locally to drive the cloud CLI; they are **never** copied to the VM.
 
 ## Usage
 
 ```
-/repo:remote                   # Interactive: pick provider, instance, size
-/repo:remote gcp               # Skip the provider question
+/repo:remote                   # Read .env, bring up / reuse the host, open SSH
+/repo:remote --configure       # Guided setup: shared creds (~/.config/repo/remote.env) + repo .env (machine)
+/repo:remote gcp               # Override REPO_REMOTE_PROVIDER for this run
 /repo:remote aws
 /repo:remote --status          # List instances created by this command
 /repo:remote --down            # Stop instances created by this command
 /repo:remote --down --delete   # Terminate/delete them
 ```
 
-## Configuration (optional)
+First time in a repo? Run `/repo:remote --configure` to build the `.env` below,
+then `/repo:remote` to launch.
 
-If the consumer repo has `.claude/remote.json`, read defaults from it. All
-fields are optional:
+## Configuration — two layers
 
-```json
-{
-  "provider": "gcp",
-  "gcp": { "project": "my-project", "zone": "us-west1-a", "machineType": "e2-standard-8" },
-  "aws": { "region": "us-west-2", "instanceType": "m5.2xlarge", "keyName": "my-key" },
-  "diskGb": 100,
-  "image": "ubuntu-2404-lts",
-  "idleShutdownMinutes": 120,
-  "setup": "make setup"
-}
+Settings come from two files, loaded in order so the repo can override the
+shared defaults:
+
+1. **`~/.config/repo/remote.env`** — shared cloud identity, reused by every
+   repo. Loaded **first**. This is where the provisioning credentials belong,
+   plus any default you want everywhere (e.g. `REPO_REMOTE_PROVIDER`,
+   `AWS_REGION`, `REPO_REMOTE_SSH_KEY`). Honors `$XDG_CONFIG_HOME` — the exact
+   path is `${XDG_CONFIG_HOME:-$HOME/.config}/repo/remote.env`. Not in any git
+   repo, so it is never at risk of being committed; keep it `chmod 600`.
+2. **`<repo>/.env`** (at the git root) — per-repo machine settings. Loaded
+   **second**, so any variable it sets overrides the shared file. This is where
+   `REPO_REMOTE_INSTANCE_ID` and the hardware/software/session knobs live. A
+   repo that needs a *different* cloud account/region can also override the
+   credentials here.
+
+Variables are namespaced `REPO_REMOTE_*` so they don't collide with the app's
+own vars; the provisioning credentials use their standard cloud names. Either
+file may set any variable — the split below is the recommended home for each,
+not a hard rule.
+
+```bash
+# ── ~/.config/repo/remote.env  (shared across all repos) ─────────────────
+REPO_REMOTE_PROVIDER=aws                  # aws | gcp  (default; a repo or arg can override)
+
+# --- provisioning credentials (used locally; NEVER copied to the VM) ---
+AWS_ACCESS_KEY_ID=...
+AWS_SECRET_ACCESS_KEY=...
+AWS_REGION=us-west-2
+# gcp instead: GCP_PROJECT, GCP_ZONE, GOOGLE_APPLICATION_CREDENTIALS=/abs/sa.json
+
+REPO_REMOTE_SSH_KEY=~/.ssh/id_ed25519     # key used for the SSH session (fine to share)
+
+# --- dev-session auth (optional; used ON the VM) ---
+# Unlike the provisioning creds above, these DO travel to the VM so gh/claude
+# work there. The gh token rides the SSH channel into the container env; the
+# Claude account pool (token FILES) is copied to the VM's .loom/tokens/
+# (chmod 600) so a Loom install there can rotate accounts. Prefer
+# scoped/short-lived tokens.
+REPO_REMOTE_GH_TOKEN=                      # GitHub PAT → gh + git-over-https on the VM.
+                                           # Fine-grained, scoped to the target repo. For Loom-style
+                                           # label workflows grant Contents + Issues + Pull requests
+                                           # (all Read/write): issue labels need Issues:write, PR labels
+                                           # need Pull requests:write. Sets existing labels only — no
+                                           # label *creation* needed (Loom never invents labels).
+
+# Claude Code multi-account pool (the Loom pattern — same triples as
+# lean-genius/.env). Registry lives here; the raw 1-year OAuth tokens live in
+# ~/.config/repo/tokens/<file>. Account 1 becomes the default
+# CLAUDE_CODE_OAUTH_TOKEN for a plain `claude`; the whole pool is copied to the
+# VM for Loom rotation. A current-repo pool (its own .env ACCOUNT_* +
+# .loom/tokens/) OVERRIDES this shared one.
+ACCOUNT_EMAIL_1=you@example.com
+ACCOUNT_KEY_1=<key>
+ACCOUNT_TOKEN_FILE_1=you-example.token    # relative to ~/.config/repo/tokens/
+# ACCOUNT_EMAIL_2 / ACCOUNT_KEY_2 / ACCOUNT_TOKEN_FILE_2 = ...  (add more accounts)
+
+# ── <repo>/.env  (per-repo; overrides the shared file) ───────────────────
+# --- instance (hardware) ---
+REPO_REMOTE_INSTANCE_TYPE=m5.2xlarge      # gcp: machineType; a GPU family (g6e.*, g2-*) implies a GPU host
+REPO_REMOTE_INSTANCE_ID=                  # reuse this exact instance when set (ALWAYS per-repo)
+REPO_REMOTE_DISK_GB=100
+REPO_REMOTE_IMAGE=                         # optional host-image override (else: Ubuntu LTS, or the GPU AMI on GPU hosts)
+REPO_REMOTE_GPU=                          # GCP accelerator (e.g. nvidia-l4:1); AWS infers GPU from the instance family
+
+# --- dev environment (software) ---
+REPO_REMOTE_DOCKERFILE=./Dockerfile       # optional: build & run this checked-in Dockerfile as the dev env (--gpus all on GPU hosts)
+REPO_REMOTE_SETUP="make setup"            # optional first-boot command; fallback when no Dockerfile
+
+# --- session ---
+REPO_REMOTE_IDLE_SHUTDOWN_MIN=120
 ```
 
-Built-in defaults when the file is absent: GCP `e2-standard-4` / AWS
-`m5.xlarge`, 50 GB disk, latest Ubuntu LTS, 120-minute idle shutdown.
+Only `REPO_REMOTE_PROVIDER` (or a provider argument) and that provider's
+credentials are required — from **either** layer. Everything else falls back to
+built-in defaults: GCP `e2-standard-4` / AWS `m5.xlarge`, 50 GB disk, latest
+Ubuntu LTS, no GPU, 120-minute idle shutdown.
+
+**Two classes of secret — treat them differently:**
+- **Provisioning credentials** (`AWS_*`, `GCP_*`) drive the cloud CLI *locally*
+  and are **never** copied to the VM.
+- **Dev-session auth** (`REPO_REMOTE_GH_TOKEN`, the `ACCOUNT_*` Claude pool) is
+  **optional** and, when set, is **placed on the VM by design** so `gh` and
+  `claude` work there. The gh token rides the SSH channel into the container
+  env (no file on disk); the Claude pool's **token files** are copied to the
+  VM's `.loom/tokens/` at `chmod 600` (they must be files for Loom to rotate
+  them). Use scoped/short-lived tokens; the whole set is wiped when the box is
+  terminated. If unset, the VM stays unauthenticated and you log in there
+  interactively.
+
+**Pool resolution (layered, like the config files):** the shared pool is
+`~/.config/repo/remote.env`'s `ACCOUNT_*` registry + `~/.config/repo/tokens/`.
+If the **current repo** already carries its own pool (`.env` `ACCOUNT_*` +
+`.loom/tokens/`, as a Loom repo does), that repo pool **wins** and is the one
+shipped — so remoting a Loom repo carries *its* accounts, not the shared set.
+
+**Credential hygiene — check first, every run:**
+- If the shared file `~/.config/repo/remote.env` exists but is group- or
+  world-readable, warn and offer to `chmod 600` it — it holds secrets.
+- If the repo's `.env` exists but is **not** gitignored, stop and warn: it may
+  hold credentials and must never be committed. Offer to add it to
+  `.gitignore`.
+- If neither layer supplies the provider's credentials, say exactly which
+  variables are needed and point the user at `/repo:remote --configure` — don't
+  silently fall back to ambient cloud auth (that would be non-deterministic
+  across machines).
+
+## `--configure` — guided `.env` setup
+
+An interactive wizard that builds (or updates) the two config files so a plain
+`/repo:remote` just works afterward. Run it on first use, or to change the
+machine.
+
+By default it writes **credentials to the shared `~/.config/repo/remote.env`**
+(so you set them up once for every repo) and **machine settings to the repo's
+`.env`**. Offer to put credentials in the repo `.env` instead only if the user
+wants a repo-specific account/region.
+
+1. **Protect both files first.** Before writing any credential: ensure the
+   repo's `.env` is gitignored (add it and say so if not); and create
+   `~/.config/repo/remote.env` with `chmod 600` (mkdir -p its parent). Never
+   proceed with secrets going into a tracked or world-readable file.
+2. **Read what's already there.** Parse the current values from **both** the
+   shared file and the repo `.env` (repo wins) and use them as defaults so the
+   wizard is non-destructive to unrelated vars in either file.
+3. **Provider.** Ask `aws` or `gcp`.
+4. **Credentials** (written to the shared file by default). Guide, don't
+   mishandle:
+   - If a working CLI session or profile already exists (`aws sts
+     get-caller-identity`, `gcloud auth list`), offer to reuse its
+     account/region/project and derive what you can.
+   - For the secret keys themselves, prompt the user to paste them (or point
+     them at where to generate an IAM key / service-account JSON). **Never echo
+     a secret value back**; confirm by identity check, not by printing.
+5. **Machine (hardware).** Ask instance type (offer a couple of sensible sizes
+   with rough hourly prices), disk size, and idle-shutdown window. A GPU
+   instance family (AWS `g6e.*`, GCP `g2-*`) implies a GPU host — on GCP also
+   ask the accelerator (`REPO_REMOTE_GPU`, e.g. `nvidia-l4:1`) with rough cost.
+6. **Dev environment (software).** Detect a checked-in Dockerfile
+   (`./Dockerfile`, `docker/Dockerfile`, …) and offer to use it as the dev
+   environment (`REPO_REMOTE_DOCKERFILE`) — the recommended path, and what makes
+   GPU work cleanly. If none, offer an optional first-boot `REPO_REMOTE_SETUP`
+   command instead.
+7. **SSH key.** Ask which SSH key to use (`REPO_REMOTE_SSH_KEY`); it goes in
+   the shared file by default (a key path is usually the same everywhere).
+8. **Validate & write.** Run the provider identity check with the entered
+   credentials to prove they work. Then show **both** resulting files (shared
+   creds and repo `.env`, secrets masked), get a yes, and write each — merging
+   into any existing content, preserving unrelated lines. Credentials +
+   shared defaults go to `~/.config/repo/remote.env`; `REPO_REMOTE_*` machine
+   settings go to `<repo>/.env`.
+9. Offer to run `/repo:remote` right away.
 
 ## Steps
 
-### 1. Detect providers
+### 1. Load and validate config
+
+Load both layers and resolve the effective settings (a provider argument
+overrides `REPO_REMOTE_PROVIDER` from either file). Run the credential-hygiene
+checks above. Echo the resolved plan (provider, instance type, disk, GPU,
+region/zone) without printing secret values.
+
+### 2. Authenticate the provider with the resolved credentials
+
+Load the shared file first, then the repo `.env` on top, into the environment
+for the provisioning calls only — scoped to this command, never persisted to
+the VM. Repo values override shared ones because the repo file is sourced last:
 
 ```bash
-gcloud auth list --filter=status:ACTIVE --format='value(account)' 2>/dev/null
-aws sts get-caller-identity --query Account --output text 2>/dev/null
+CONFIG_HOME="${XDG_CONFIG_HOME:-$HOME/.config}/repo/remote.env"
+set -a
+[ -f "$CONFIG_HOME" ] && . "$CONFIG_HOME"                      # shared cloud creds + defaults
+[ -f "$(git rev-parse --show-toplevel)/.env" ] && . "$(git rev-parse --show-toplevel)/.env"  # per-repo (overrides)
+set +a
 ```
 
-- Both authenticated → ask the user which to use (mention the default machine
-  type and rough hourly price for each)
-- One authenticated → use it, say so
-- Neither → help the user authenticate. Do **not** run `gcloud auth login` or
-  `aws sso login` yourself — these need a browser; tell the user to run them
-  in their own terminal (or with a `!` prefix in this session) and wait.
+- **AWS**: the exported `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` /
+  `AWS_REGION` are picked up by the CLI. Confirm identity:
+  `aws sts get-caller-identity`.
+- **GCP**: activate the service account key, then confirm:
+  ```bash
+  gcloud auth activate-service-account --key-file="$GOOGLE_APPLICATION_CREDENTIALS"
+  gcloud config set project "$GCP_PROJECT"
+  ```
 
-### 2. Look for an existing instance
+If authentication fails, report the provider's error and stop — do not fall
+back to a different account.
 
-Instances created by this command carry a label/tag `repo-remote=<repo-name>`
-(repo name = basename of the git root). If one exists:
-- RUNNING → offer to reuse it (skip to step 4)
-- STOPPED → offer to start it (much faster and cheaper than creating)
+### 3. Reuse or find the instance
+
+1. **`REPO_REMOTE_INSTANCE_ID` is set** → target that instance directly.
+   - RUNNING → reuse it (skip to step 5).
+   - STOPPED → offer to start it (faster and cheaper than creating).
+   - Gone/terminated → say so, clear the stale ID, and continue to create.
+2. **No pinned ID** → look for one this command created, labeled/tagged
+   `repo-remote=<repo-name>` (repo name = basename of the git root):
 
 ```bash
-gcloud compute instances list --filter="labels.repo-remote=<name>" \
-  --format="table(name,zone,status,machineType)"
 aws ec2 describe-instances \
   --filters "Name=tag:repo-remote,Values=<name>" "Name=instance-state-name,Values=running,stopped"
+gcloud compute instances list --filter="labels.repo-remote=<name>" \
+  --format="table(name,zone,status,machineType)"
 ```
 
-### 3. Create the instance (with confirmation)
+RUNNING → offer reuse; STOPPED → offer to start.
 
-**Before creating anything**, show the user the exact command, the machine
-spec, and the estimated hourly cost, and get an explicit yes.
+### 4. Create the instance (with confirmation)
+
+**Before creating anything**, show the exact command, the machine spec
+(including any GPU), and the estimated hourly cost, and get an explicit yes.
 
 Requirements for the created instance:
-- Label/tag it `repo-remote=<repo-name>` so `--status`/`--down` only ever
-  touch instances this command created
+- Label/tag it `repo-remote=<repo-name>` so `--status`/`--down` only ever touch
+  instances this command created
 - Ubuntu LTS image, disk size from config
-- Install an idle-shutdown guard (cron that checks SSH sessions + CPU and
-  runs `shutdown -h` after the configured idle window) so a forgotten VM
-  doesn't burn money
-- GCP: prefer OS Login / IAP; AWS: use the configured key pair and a security
-  group that allows SSH from the user's IP only
+- For GPU hosts, see **GPU hosts** below — this needs a GPU-ready image and,
+  on AWS, quota-aware handling.
+- Install an idle-shutdown guard (cron checking SSH sessions + CPU, running
+  `shutdown -h` after `REPO_REMOTE_IDLE_SHUTDOWN_MIN`) so a forgotten VM — GPU
+  ones especially — doesn't burn money
+- AWS: security group allowing SSH from the user's IP only, using
+  `REPO_REMOTE_SSH_KEY`'s public key. GCP: prefer OS Login / IAP.
 
-If the zone/region is stocked out, offer the nearest alternative zone or the
-next machine type down rather than failing.
+If the zone/region is stocked out (common for GPU types), offer the nearest
+alternative zone or the next type down rather than failing.
 
-### 4. Get the repo onto the instance
+#### GPU hosts
 
-Pick based on what exists:
+Treat the host as a GPU box when the instance type is a GPU family (AWS
+`g5`/`g6`/`g6e`/`p4`/`p5`; GCP `g2`/`a2`) **or** `REPO_REMOTE_GPU` is set —
+infer `gpu=true` from the family so the user needn't set a separate flag.
 
-- **Repo has an `origin` remote** and the user's forge auth can be used
-  non-interactively (e.g. `gh auth token` for GitHub over HTTPS): clone it on
-  the VM, check out the current branch.
-- **Then sync uncommitted work** (or when there is no usable remote, sync the
-  whole tree): rsync the working tree over SSH, excluding gitignored content:
+**Image — the key to a *working* GPU box; don't hand-roll a driver install:**
 
-```bash
-# Respect .gitignore; include untracked-but-not-ignored files
-rsync -az --delete \
-  --filter=':- .gitignore' --exclude '.git/' \
-  ./ <host>:~/​<repo-name>/
+- **AWS:** unless `REPO_REMOTE_IMAGE` overrides, default to the latest *Deep
+  Learning Base OSS Nvidia Driver GPU AMI (Ubuntu 22.04)*. It ships the NVIDIA
+  driver, Docker, and `nvidia-container-toolkit`, so `nvidia-smi` and
+  `docker run --gpus all` work out of the box:
+
+  ```bash
+  aws ec2 describe-images --owners amazon \
+    --filters 'Name=name,Values=Deep Learning Base OSS Nvidia Driver GPU AMI (Ubuntu 22.04)*' \
+    --query 'sort_by(Images,&CreationDate)[-1].ImageId' --output text
+  ```
+
+- **GCP:** attach the accelerator (`--accelerator type=<type>,count=<n>` from
+  `REPO_REMOTE_GPU`) and use a GPU-ready image, or add the documented NVIDIA
+  driver + `nvidia-container-toolkit` install as a startup script.
+
+**Quota-aware error (AWS):** the "Running On-Demand G and VT instances" quota
+defaults to **0**, so the first GPU launch fails with `VcpuLimitExceeded`.
+Detect that specific error and print the exact remediation instead of the raw
+message: **Service Quotas → EC2 → quota code `L-DB2E81BA`** → request a limit
+≥ the instance's vCPU count, then retry once approved.
+
+**After a successful create, write the new ID back to the repo's `.env`** (the
+git root, never the shared file — the instance handle is per-repo) so the next
+run reuses it automatically:
+
+```
+REPO_REMOTE_INSTANCE_ID=<new-id>
 ```
 
-Never copy `.env` files, keys, or anything credential-like unless the user
-explicitly asks; call out anything skipped for this reason.
+Update the line in place if present, else append it. Report the edit.
 
-### 5. Bootstrap
+### 5. Get the repo onto the instance
 
-- Install baseline tooling on first boot: git, build-essential, and whatever
-  the repo obviously needs (detect from `pyproject.toml`, `package.json`,
-  `Cargo.toml`, …)
-- If config has a `setup` command, offer to run it
+- **Repo has an `origin` remote** and forge auth can be used non-interactively
+  (e.g. `gh auth token` for GitHub over HTTPS): clone on the VM, check out the
+  current branch.
+- **Then sync uncommitted work** (or, with no usable remote, sync the whole
+  tree): rsync the working tree over SSH, excluding gitignored content:
+
+```bash
+rsync -az --delete \
+  --filter=':- .gitignore' --exclude '.git/' \
+  ./ <host>:~/<repo-name>/
+```
+
+**Never copy the *provisioning* `.env` or cloud keys to the VM** — the
+`.gitignore` filter already excludes a gitignored `.env`; double-check it's
+excluded and call it out. This is the provisioning-credential class (Safety
+Rule 3). The separate, opt-in **dev-session auth** (the gh token and the Claude
+account pool) *is* placed on the VM deliberately — see step 6a; that path
+replaces interactive `gh auth login` / `claude` login when the tokens are
+configured.
+
+### 6. Bootstrap the dev environment
+
+How the repo declares its environment decides the path:
+
+- **`REPO_REMOTE_DOCKERFILE` set (preferred)** — the repo carries its own
+  environment. On the host, build that Dockerfile (context = repo root) and run
+  it as a long-lived dev container with the synced repo mounted, adding
+  `--gpus all` on GPU hosts:
+
+  ```bash
+  docker build -t repo-remote-<name> -f "$REPO_REMOTE_DOCKERFILE" ~/<repo-name>
+  docker run -d --name repo-remote-<name> $GPUS \
+    -e GH_TOKEN -e CLAUDE_CODE_OAUTH_TOKEN \
+    -v ~/<repo-name>:/work -w /work repo-remote-<name> sleep infinity
+  #   GPUS="--gpus all" on GPU hosts, empty otherwise
+  #   GH_TOKEN / CLAUDE_CODE_OAUTH_TOKEN are read from the remote shell env,
+  #   set inline over SSH from the resolved pool (see 6a) — never a file.
+  ```
+
+  This is what makes GPU clean: the **host** (GPU AMI) supplies the driver +
+  `nvidia-container-toolkit`; the **repo's Dockerfile** supplies CUDA and the
+  toolchain — nothing per-repo is guessed or installed by hand.
+
+- **No Dockerfile** — install baseline tooling on first boot (git,
+  build-essential, and what the repo obviously needs from `pyproject.toml`,
+  `package.json`, `Cargo.toml`, …); run `REPO_REMOTE_SETUP` if set.
+
+**GPU sanity check (GPU hosts)** — before handing over, prove the GPU is live
+and surface it; don't let the user find a dead GPU after they start:
+
+```bash
+nvidia-smi                                            # host driver
+docker exec repo-remote-<name> nvidia-smi             # the dev container sees it
+# no container: docker run --rm --gpus all nvidia/cuda:12.4.0-base-ubuntu22.04 nvidia-smi
+```
+
+If it fails, report it (driver/AMI or toolkit mismatch) and stop rather than
+proceeding as if the box were ready.
+
+#### 6a. Wire dev-session auth (gh + Claude account pool)
+
+Only if the corresponding secrets are configured — otherwise skip and leave the
+VM to interactive login.
+
+1. **Resolve the pool (repo wins over shared).** If the current repo carries its
+   own pool (`.env` `ACCOUNT_*` **and** `.loom/tokens/`), use it; else fall back
+   to the shared `~/.config/repo/remote.env` registry + `~/.config/repo/tokens/`.
+
+2. **gh — inline, no file.** Export the resolved `REPO_REMOTE_GH_TOKEN` as
+   `GH_TOKEN` in the remote shell for the `docker run` above, then inside the
+   container `gh auth setup-git` and confirm with `gh auth status`. The token
+   lives only in the container env. **Note:** `gh` infers the repo from the
+   local `.git` remote — so `gh pr/issue` commands need the **clone** path
+   (step 5), not a rsync-only tree (which excludes `.git`). If the VM has no
+   `.git`, pass `-R <owner>/<repo>` explicitly for label/PR/issue operations.
+
+3. **Claude pool — token files (Loom needs them as files).** Copy the resolved
+   `*.token` files to the VM at `~/<repo-name>/.loom/tokens/` (`chmod 600`,
+   `chmod 700` the dir) and append the `ACCOUNT_*` registry to
+   `~/<repo-name>/.env` on the VM, reproducing the Loom layout so a Loom install
+   there rotates accounts. Set `CLAUDE_CODE_OAUTH_TOKEN` (for the `docker run`
+   env) to **account 1's** token so a plain `claude` works immediately.
+
+   ```bash
+   # local -> VM, over the SSH channel; never the provisioning creds.
+   # NOTE: rsync --chmod is GNU-rsync only and fails on macOS's system rsync,
+   # so set the perms in a follow-up ssh step instead of relying on it.
+   rsync -az -e "ssh -i $REPO_REMOTE_SSH_KEY" \
+     "<resolved-tokens-dir>/" <host>:~/<repo-name>/.loom/tokens/
+   ssh -i "$REPO_REMOTE_SSH_KEY" <host> \
+     'chmod 700 ~/<repo-name>/.loom/tokens && chmod 600 ~/<repo-name>/.loom/tokens/*.token'
+   ```
+
+4. **Verify:** `docker exec repo-remote-<name> bash -lc 'claude --version && gh auth status'`.
+   Report which account is active and how many are in the pool.
+
+Then, either path:
+- Claude Code ships **in the Dockerfile** (container path); for the no-Dockerfile
+  path, offer to install it (`curl -fsSL https://claude.ai/install.sh | bash`).
 - Write/refresh a local SSH config entry so the connection is one word:
 
 ```
 Host repo-remote-<name>
     HostName <ip-or-iap-alias>
     User <user>
+    IdentityFile <REPO_REMOTE_SSH_KEY>
     # GCP+IAP: use a ProxyCommand via `gcloud compute start-iap-tunnel`
 ```
 
-### 6. Open the SSH view
+### 7. Open the SSH session
 
 Verify reachability first:
 
@@ -133,36 +418,58 @@ Verify reachability first:
 ssh -o ConnectTimeout=30 repo-remote-<name> 'echo "SSH OK: $(hostname)"'
 ```
 
-Then open a new terminal window with the session. Claude Code cannot host an
-interactive SSH session itself, so hand it to the OS:
+Then open a new terminal window with the session. Where it lands depends on the
+environment path:
 
-- **macOS**: `osascript -e 'tell app "Terminal" to do script "ssh repo-remote-<name>"' -e 'tell app "Terminal" to activate'`
+- **Dev container running** → drop straight into it, at the mounted repo:
+  `ssh -t repo-remote-<name> 'docker exec -it -w /work repo-remote-<name> bash -l'`
+- **No container** → land in the repo dir on the host:
+  `ssh -t repo-remote-<name> 'cd ~/<repo-name>; exec $SHELL -l'`
+
+Claude Code cannot host an interactive SSH session itself, so hand it to the OS
+(substituting the appropriate command above):
+
+- **macOS**: `osascript -e 'tell app "Terminal" to do script "<ssh command>"' -e 'tell app "Terminal" to activate'`
   (if the user runs iTerm2, use the equivalent iTerm AppleScript)
-- **Linux**: try `x-terminal-emulator -e ssh repo-remote-<name>` or the
-  desktop's terminal
-- **Fallback / SSH-only session**: print the command and tell the user to run
-  `ssh repo-remote-<name>` in a separate terminal
+- **Linux**: try `x-terminal-emulator -e <ssh command>`
+- **Fallback**: print the command and tell the user to run it in a separate
+  terminal
 
-### 7. Report
+Tell the user they can start `claude` in that session to continue on the remote.
 
-End with a compact status block: instance name, zone, machine type, hourly
-cost estimate, idle-shutdown window, the SSH alias, and the teardown command
-(`/repo:remote --down`).
+### 8. Report
+
+End with a compact status block: instance name/ID, zone, machine type (and GPU),
+hourly cost estimate, idle-shutdown window, the SSH alias, whether the ID was
+written back to `.env`, and the teardown command (`/repo:remote --down`).
 
 ## `--status` and `--down`
 
 - `--status`: list all instances labeled `repo-remote=<repo-name>` with state
-  and uptime; estimate accumulated cost
+  and uptime; estimate accumulated cost. Uses the resolved credentials (shared
+  file + repo `.env`).
 - `--down`: stop them (confirm first, listing exactly what will stop);
   `--down --delete` terminates/deletes instead — confirm with the instance
-  names spelled out, since disks go with them
+  names spelled out, since disks go with them (the Claude pool token files on
+  the disk go with them too). On delete, offer to clear
+  `REPO_REMOTE_INSTANCE_ID` from `.env` so the next run starts fresh.
 
 ## Safety Rules
 
 1. **Never create, stop, or delete cloud resources without showing the exact
-   plan and getting a yes** — including estimated cost for creation
-2. **Only ever touch instances carrying this repo's `repo-remote` label** —
-   never enumerate-and-guess
-3. **Never copy credentials to the VM** unless explicitly asked
-4. **Always install the idle-shutdown guard** — a VM that outlives the session
+   plan and getting a yes** — including estimated cost for creation (call out
+   GPU pricing especially)
+2. **Only ever touch instances carrying this repo's `repo-remote` label** (or
+   the pinned `REPO_REMOTE_INSTANCE_ID`) — never enumerate-and-guess
+3. **Two secret classes, handled differently** — **provisioning credentials**
+   (`AWS_*`/`GCP_*`) are local-only and **never** reach the VM; **dev-session
+   auth** (`REPO_REMOTE_GH_TOKEN`, the `ACCOUNT_*` Claude pool) is opt-in and
+   goes to the VM *by design* (gh token in the container env; pool token files
+   at `chmod 600` under the VM's `.loom/tokens/`). Never copy the provisioning
+   `.env` wholesale — carry only the resolved dev-session secrets.
+4. **Keep both config files out of harm's way** — refuse to run if the repo's
+   `.env` exists and is not gitignored (it may hold credentials); warn and offer
+   to `chmod 600` the shared `~/.config/repo/remote.env` if it's readable by
+   others
+5. **Always install the idle-shutdown guard** — a VM that outlives the session
    should turn itself off

--- a/.claude/commands/repo/reset.md
+++ b/.claude/commands/repo/reset.md
@@ -9,15 +9,17 @@ user-invocable: true
 # /repo:reset — Back to Baseline
 
 The end-of-task ritual: review and prune stale git state, sync with the
-remote, and land back on the default branch with a clean working tree.
-Report-first — nothing is deleted or dropped without appearing in the report
-and getting a yes.
+remote, and land back on the default branch with a clean working tree. The
+reversible steps (fetch, land on the default branch) run by default; nothing
+irreversible — dropping a stash, deleting a branch or worktree — ever happens
+without an explicit opt-in and the permanent-loss check.
 
 ## Usage
 
 ```
-/repo:reset                    # Interactive: review everything, act on approval
-/repo:reset --prune            # Also delete confirmed-safe branches/worktrees without per-item prompts
+/repo:reset                    # Run the reversible baseline steps; keep all stashes, land on default
+/repo:reset --ask              # Confirm each step before acting
+/repo:reset --prune            # Also delete confirmed-safe branches/worktrees (after the loss check)
 ```
 
 ## Steps
@@ -44,14 +46,19 @@ git stash list --format='%gd %cr %gs'
 ```
 
 For each stash, show what's in it (`git stash show --stat <ref>`) and its age.
-Ask per stash: **apply**, **drop**, or **keep**. Old stashes (>30 days) are
-usually droppable but the user decides — never auto-drop.
+A stash is unique work and dropping it is irreversible, so **keep every stash
+by default** — just report them (flagging any older than 30 days as likely
+droppable). Only under `--ask` ask per stash whether to **apply**, **drop**,
+or **keep**. Never auto-drop, regardless of flags.
 
 ### 3. Branch & worktree review
 
 Run the full [[branches]] classification (PROTECTED / merged-PR / closed-issue
 / orphaned-automation / UNKNOWN, plus stale worktrees). With `--prune`, delete
-the SAFE TO DELETE category after presenting it; otherwise ask.
+the SAFE TO DELETE category after presenting it; otherwise ask. Either way,
+[[branches]]' **permanent-loss check** applies — a branch with commits found
+nowhere else, or a worktree with uncommitted changes, is never removed
+automatically, so nothing here can permanently destroy work.
 
 ### 4. Sync with remote
 

--- a/.claude/commands/repo/tidy.md
+++ b/.claude/commands/repo/tidy.md
@@ -8,17 +8,21 @@ user-invocable: true
 
 # /repo:tidy — Tidy Up
 
-Sweep the working tree for clutter and clean it up. Report-first: inventory
-everything, categorize by confidence, then delete only what the user approves
-(or only the SAFE category with `--apply`).
+Sweep the working tree for clutter and clean it up. Inventory everything,
+categorize by confidence, then by default delete the SAFE category (clutter
+that is regenerable with certainty and holds no unique work) and report what
+was freed. Items that could be real work (ASK) are always presented for a human
+call, never auto-deleted.
 
 ## Usage
 
 ```
-/repo:tidy                    # Inventory + report, then discuss
-/repo:tidy --apply            # Report, then delete the SAFE category without asking per-item
+/repo:tidy                    # Inventory, delete the SAFE category, report; ASK items presented
+/repo:tidy --ask              # Walk every category interactively before deleting anything
 /repo:tidy packages/core      # Scope to one subtree
 ```
+
+(`--apply` is accepted as a synonym for the default, for muscle memory.)
 
 ## Steps
 
@@ -52,13 +56,53 @@ Also look for junk by pattern, wherever it lives:
 
 ### 2. Categorize
 
-- **SAFE** — regenerable with certainty: gitignored build output and caches,
-  OS/editor droppings, `__pycache__`, empty directories. Nothing in this
-  category may be tracked by git or match a source-code extension.
-- **ASK** — probably junk but needs a human call: untracked files that aren't
-  gitignored (could be unsaved work!), large files, stale-looking logs, old
-  `tmp/` contents. Stale worktrees, branches, and stashes are [[reset]]'s
-  job — point there instead of handling them here.
+**Gitignored ≠ safe to delete.** `git clean -ndX` lists *every* gitignored file
+on disk — including secrets (`.env`) and expensive-to-rebuild trees (`.venv/`),
+which are gitignored *precisely because* they're precious and local. Do not
+treat "gitignored" as a synonym for "regenerable." SAFE is an **allowlist** of
+recognized clutter; a **never-delete denylist** overrides it; everything else
+gitignored falls through to ASK.
+
+Apply these tests in order — **denylist first, then the SAFE allowlist, then
+fall through to ASK**:
+
+**Never-delete denylist (always ASK, never SAFE — checked first, overrides
+everything below, regardless of gitignore status):**
+- Secrets / credentials: `.env`, `.env.*` (but **not** `.env.example` /
+  `.env.sample`, which are templates safe to keep), `*.pem`, `*.key`,
+  `*.keystore`, `*.p12`, `*.pfx`, `id_rsa*`
+- Expensive-to-rebuild environments: `.venv/`, `venv/`, `env/`
+- Anything else that looks credential-like or holds unique local state
+  (local SQLite DBs, local-only config, sample-data caches)
+
+A denylist match routes to **ASK** (never auto-deleted) — not KEEP, which is
+reserved for tracked files.
+
+- **SAFE** — regenerable with certainty, matched by an explicit **allowlist** of
+  known build-output/cache/droppings patterns (never "everything `git clean
+  -ndX` lists minus a couple of exclusions"). A file is SAFE only if it does
+  **not** match the denylist above **and** matches one of:
+  - OS/editor droppings: `.DS_Store`, `Thumbs.db`, `*~`, `*.swp`, `.#*`
+  - Python caches: `__pycache__/`, `*.pyc`, `.pytest_cache/`, `.mypy_cache/`,
+    `.ruff_cache/`
+  - Build output: stale `dist/`, `.turbo/`, `.astro/`, `htmlcov/`, `.coverage`,
+    coverage output, `site/dist`
+  - Merge/patch leftovers: `*.orig`, `*.rej`, `*.BACKUP.*`
+  - Empty directories
+
+  Nothing in this category may be tracked by git or match a source-code
+  extension.
+- **ASK** — probably junk but needs a human call. This covers:
+  - Untracked files that aren't gitignored (could be unsaved work!), large
+    files, stale-looking logs, old `tmp/` contents.
+  - **Any gitignored file that matches the never-delete denylist** (secrets,
+    virtualenvs) — surfaced here, never auto-deleted.
+  - **Any gitignored file that does not match the SAFE allowlist** (a novel
+    cache dir, unrecognized local state) — when in doubt, it lands here, not in
+    SAFE.
+
+  Stale worktrees, branches, and stashes are [[reset]]'s job — point there
+  instead of handling them here.
 - **KEEP** — flagged only as information: tracked files that look like they
   don't belong (build output that got committed — point to [[gitignore]]).
 
@@ -74,6 +118,8 @@ SAFE (would free 412 MB):
   6 empty directories
 
 ASK:
+  .env                     gitignored, 1 KB  ← credentials, never auto-deleted
+  .venv/                   gitignored, 240 MB  ← virtualenv, expensive to rebuild
   notes-scratch.md         untracked, 3 KB, modified today  ← might be real work
   sim-output-old/          untracked, 1.2 GB, untouched 60 days
   worktree: ../repo-wt-fix123 (branch merged)
@@ -84,10 +130,16 @@ KEEP (informational):
 
 ### 4. Apply
 
-- Without `--apply`: walk through categories with the user; delete what they
-  approve.
-- With `--apply`: delete the SAFE category immediately, then present ASK items
-  as usual. Never auto-delete anything in ASK, no matter the flags.
+- Default: delete the SAFE category immediately, then present ASK items for a
+  decision. Never auto-delete anything in ASK, no matter the flags.
+- With `--ask`: walk through every category with the user, including SAFE;
+  delete only what they approve.
+
+The default auto-delete is scoped to **SAFE-allowlisted paths only**. Never pass
+a denylisted path (secrets, virtualenvs) or an unrecognized gitignored path to
+`git clean -fdX` — those are ASK items and require an explicit human call. Build
+the explicit `<paths>` list from the SAFE category and nothing else; do **not**
+run a blanket `git clean -fdX` that would sweep whatever `git clean -ndX` lists.
 
 Use `git clean -fdX -- <paths>` for gitignored artifacts and plain `rm` only
 for pattern-matched junk you listed in the report. After deleting, re-run the
@@ -101,3 +153,7 @@ inventory to confirm and report bytes freed.
    unsaved work and always lands in ASK
 4. **Everything deleted must have appeared in the report first**
 5. When scoped to a subtree, do not delete anything outside it
+6. **Gitignored ≠ safe to delete** — the never-delete denylist (secrets like
+   `.env`/`*.pem`/`*.key`, and virtualenvs like `.venv/`/`venv/`) always
+   overrides SAFE and routes to ASK, regardless of what `git clean -ndX` lists.
+   Unrecognized gitignored files fall through to ASK, never SAFE.

--- a/.claude/commands/repo/update-tools.md
+++ b/.claude/commands/repo/update-tools.md
@@ -20,6 +20,11 @@ to update the stale ones.
 /repo:update-tools loom        # Only check/update one tool
 ```
 
+An update runs the tool's own installer (executing code from its source repo
+and rewriting `.claude/`), so unlike the safe-fix hygiene commands this one is
+**not** auto-applied — it reports and confirms before updating. `--check` is
+the report-only form.
+
 ## Steps
 
 ### 1. Discover installed tools

--- a/.claude/skills/repo/SKILL.md
+++ b/.claude/skills/repo/SKILL.md
@@ -9,9 +9,13 @@ user-invocable: false
 # Repo Skills
 
 General-purpose tools for keeping a git repository healthy and productive. The
-hygiene commands are **interactive** — they report findings and discuss fixes
-with the user before making changes. The environment commands (`remote`) stand
-up infrastructure only after showing exactly what they will create and what it
+hygiene commands **apply their safe, reversible fixes by default** and report
+each change; add `--ask` to review findings and confirm first. Anything
+irreversible — deleting a branch, worktree, stash, or untracked file — is never
+automatic: it takes an explicit opt-in and passes a permanent-loss check.
+Commands whose only action is consequential (`orphans`, `update-tools`,
+`release`, `remote`) always confirm first by nature. The environment commands (`remote`) stand up
+infrastructure only after showing exactly what they will create and what it
 costs.
 
 ## Commands
@@ -19,7 +23,7 @@ costs.
 | Command | What it does |
 |---------|--------------|
 | [[help]] | Explain the installed `/repo:*` commands — what each does, where to start |
-| [[all]] | The whole hygiene pass in order — audit, tidy, update-tools, reset — each report-first |
+| [[all]] | The whole hygiene pass in order — audit, docs, tidy, update-tools, reset — safe fixes by default, destructive steps gated |
 | [[audit]] | Full sweep — runs all hygiene checks, produces a summary report |
 | [[reset]] | Back to baseline — review stale worktrees/branches/stashes, sync with remote, return to the default branch |
 | [[tidy]] | Tidy up — build artifacts, caches, temp files, empty dirs |
@@ -28,6 +32,7 @@ costs.
 | [[update-tools]] | Check installed tool packages (Loom, Anvil, …) against their sources and offer updates |
 | [[branches]] | Branch & worktree hygiene — merged PRs, orphaned branches, stale worktrees |
 | [[gitignore]] | Gitignore hygiene — over-ignored files, under-ignored build artifacts |
+| [[docs]] | Documentation health — content accuracy, README structure, cross-references (canonical docs command) |
 | [[links]] | Internal cross-references — markdown links, CLAUDE.md paths, skill graph |
 | [[orphans]] | Files with no references — dead scripts, stale data, outputs without sources |
 | [[readme]] | README accuracy vs actual directory contents |
@@ -35,7 +40,7 @@ costs.
 ## When to Use
 
 - After finishing a task, to get back to a known-good state (`reset`)
-- After a large refactor, consolidation, or import (`audit`, `links`, `readme`)
+- After a large refactor, consolidation, or import (`audit`, `docs`)
 - When the working tree feels messy (`tidy`, `orphans`)
 - When `git branch` output has grown unmanageable (`branches`)
 - When local hardware isn't enough or you need a clean Linux box (`remote`)
@@ -45,14 +50,17 @@ costs.
 
 ## Principles
 
-1. **Report first, fix second.** Never silently change files or create
-   infrastructure. Show findings (or the exact provisioning plan), discuss,
-   then act on what the user approves.
+1. **Apply safe fixes, gate destructive ones.** Reversible fixes (doc/link/
+   gitignore edits, regenerable clutter) apply by default and are reported as
+   they're made; `--ask` restores review-and-confirm. Irreversible actions
+   — deleting branches, worktrees, stashes, untracked files, or creating
+   infrastructure — are never automatic: show the plan (and cost, for cloud
+   resources), run the permanent-loss check, and act only on explicit opt-in.
 2. **Scope matters.** Most hygiene commands accept an optional path argument to
    limit scope (e.g., `/repo:readme docs/`). Without it, they scan the full repo.
 3. **General by design.** These commands make no assumptions about org,
    project structure, or infrastructure. Anything repo-specific is read from
-   the consumer repo's own files (CLAUDE.md conventions, `.claude/remote.json`),
+   the consumer repo's own files (CLAUDE.md conventions, `.env`),
    never hardcoded.
 4. **Don't be noisy.** Only flag things that are actually wrong or confusing.
    A missing README in a tiny utility directory isn't worth flagging.

--- a/.claude/skills/repo/install-metadata.json
+++ b/.claude/skills/repo/install-metadata.json
@@ -1,7 +1,8 @@
 {
-  "version": "0.3.0",
-  "commit": "e3f1ee7",
-  "installed_at": "2026-07-15T17:37:28Z",
-  "source": "/private/tmp/claude-501/-Users-rwalters-GitHub-lean-genius/ffee83ca-090b-4f60-bd0a-cdf8a9630d9f/scratchpad/repo-clean",
-  "commands": ["all","audit","branches","gitignore","help","links","orphans","readme","release","remote","reset","tidy","update-tools"]
+  "version": "0.4.1",
+  "commit": "88188e4",
+  "installed_at": "2026-07-17T17:02:37Z",
+  "dev": false,
+  "source": "/Users/rwalters/GitHub/repo",
+  "commands": ["all","audit","branches","docs","gitignore","help","links","orphans","readme","release","remote","reset","tidy","update-tools"]
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -260,3 +260,10 @@ make status                   # Show all agent claim status
 <!-- BEGIN LOOM ORCHESTRATION -->
 This repository uses [Loom](https://github.com/rjwalters/loom) for AI-powered development orchestration. See `.loom/CLAUDE.md` for the full guide (roles, labels, worktrees, configuration).
 <!-- END LOOM ORCHESTRATION -->
+<!-- BEGIN REPO-SKILLS -->
+This repository has [Repo Skills](https://github.com/rjwalters/repo) v0.4.1 installed —
+general repository hygiene and environment commands invoked as `/repo:<command>`. Run
+`/repo:help` for the command list, or see `.claude/skills/repo/SKILL.md` for the full
+guide. Hygiene commands are report-first: they present findings and wait before changing
+anything. Managed by `install.sh` — edit outside the markers only.
+<!-- END REPO-SKILLS -->


### PR DESCRIPTION
`/repo:all` Stage 3 tool update. Runs the repo-skills v0.4.1 installer:
- Refreshes all `/repo:*` command files; adds new `docs` command.
- Updates `SKILL.md` + `install-metadata.json`.
- Appends the v0.4.1 REPO-SKILLS marker block to `CLAUDE.md` (origin/main didn't have it — the v0.3.0 block lived only in an uncommitted working-tree mod, so #39065 committed the skill files but not the block; this completes it).

Only `.claude/*` and the CLAUDE.md marker region change. 🤖 Generated with [Claude Code](https://claude.com/claude-code)