### PR TITLE
fix(proofs): unblock Erdos10Incomplete01OQ02 + WIP01OQ03 omega-with-mod-241 hang under v4.31

### DIFF
--- a/proofs/Proofs/Erdos10Incomplete01OQ02.lean
+++ b/proofs/Proofs/Erdos10Incomplete01OQ02.lean
@@ -49,11 +49,11 @@ open Erdos10Incomplete01 Erdos10OQ01Incomplete01
 
 /-- Each of the six covering primes `{3, 5, 7, 13, 17, 241}` is odd. -/
 theorem coveringPrimes_odd {q : ℕ} (hq : q ∈ coveringPrimes) : Odd q := by
-  fin_cases hq <;> decide
+  fin_cases hq <;> simp [Nat.odd_iff]
 
 /-- Each of the six covering primes is at most `241`. -/
 theorem coveringPrimes_le {q : ℕ} (hq : q ∈ coveringPrimes) : q ≤ 241 := by
-  fin_cases hq <;> decide
+  fin_cases hq <;> omega
 
 /-! ## Bridge: `prime_forced_small` restated against `sumPrimeAndTwoPows 1` -/
 
@@ -69,7 +69,9 @@ theorem mem_one_forced {n : ℕ}
   rw [mem_one_iff] at hn
   rcases hn with hp | ⟨p, a, hp, hrep⟩
   · exact Or.inl hp
-  · have hrep' : n = 2 ^ a + p := by omega
+  · -- `omega` would be poisoned by the mod-241 hypothesis in context, so use `ring` for the
+    -- purely commutative rewrite `p + 2^a = 2^a + p` (see below on `not_mem_one_of_even`).
+    have hrep' : n = 2 ^ a + p := by rw [hrep]; ring
     exact Or.inr ⟨a, p, prime_forced_small h3 h7 h5 h17 h13 h241 hp hrep', hrep'⟩
 
 /-! ## The parity refinement: even numbers in the class are outside level 1 -/
@@ -87,20 +89,24 @@ theorem not_mem_one_of_even {n : ℕ}
   rw [mem_one_iff] at hn
   rcases hn with hp | ⟨p, a, hp, hrep⟩
   · -- `n` even and `> 2` cannot be prime.
-    have h2 : (2 : ℕ) ∣ n := Nat.dvd_of_mod_eq_zero heven
-    rcases hp.eq_one_or_self_of_dvd 2 h2 with h | h
-    · exact absurd h (by norm_num)
-    · omega
+    -- NB: `omega` must NOT see the mod-241 residue hypothesis — under the v4.31 toolchain that
+    -- makes omega's decision procedure blow up (100% CPU, no progress). Clear the covering-class
+    -- residue facts (not needed for this branch) before calling omega.
+    clear h3 h7 h5 h17 h13 h241
+    rcases hp.eq_two_or_odd with h | h <;> omega
   · -- `n = p + 2^a`: the covering obstruction forces `p ∈ coveringPrimes` (all odd).
-    have hrep' : n = 2 ^ a + p := by omega
+    -- Commutativity via `ring` (not `omega`) while the mod hypotheses are still needed for
+    -- `prime_forced_small`; then clear them so the parity `omega`s below stay cheap.
+    have hrep' : n = 2 ^ a + p := by rw [hrep]; ring
     have hpc : p ∈ coveringPrimes := prime_forced_small h3 h7 h5 h17 h13 h241 hp hrep'
+    clear h3 h7 h5 h17 h13 h241
     have hpodd : p % 2 = 1 := Nat.odd_iff.mp (coveringPrimes_odd hpc)
     have hple : p ≤ 241 := coveringPrimes_le hpc
     -- Parity of `n = p + 2^a`: `n` even, `p` odd ⟹ `2^a` odd ⟹ `a = 0`.
     have hpow : 2 ^ a % 2 = 1 := by omega
     have ha0 : a = 0 := by
       by_contra ha
-      have : Even (2 ^ a) := by rw [Nat.even_pow]; exact ⟨by decide, ha⟩
+      have : Even (2 ^ a) := by rw [Nat.even_pow]; exact ⟨⟨1, rfl⟩, ha⟩
       rw [Nat.even_iff] at this
       omega
     subst ha0

--- a/proofs/Proofs/Erdos10WIP01OQ03.lean
+++ b/proofs/Proofs/Erdos10WIP01OQ03.lean
@@ -148,18 +148,23 @@ theorem not_isPrimePlusKPowers_one_of_even_covering {n : ℕ}
     (h17 : n % 17 = 8) (h13 : n % 13 = 11) (h241 : n % 241 = 121)
     (heven : n % 2 = 0) (hbig : 242 < n) :
     ¬ IsPrimePlusKPowers 1 n := by
-  refine not_isPrimePlusKPowers_of_even heven (by omega) ?_
+  -- NB: throughout this proof `omega` must NOT run with the mod-241 residue hypothesis in
+  -- context — under the v4.31 toolchain that makes omega's decision procedure blow up (100% CPU,
+  -- no progress).  We keep the residue facts only until `prime_forced_small` consumes them, then
+  -- `clear` them so the parity `omega`s below stay cheap; the `2 < n` bound is derived by term.
+  refine not_isPrimePlusKPowers_of_even heven (lt_of_lt_of_le (by norm_num) hbig.le) ?_
   intro w hwpos hwn hwc hp
   obtain ⟨a, rfl⟩ := eq_two_pow_of_pos_of_popcount_le_one hwpos hwc
   set p := n - 2 ^ a with hpdef
-  have hrep : n = 2 ^ a + p := by omega
+  have hrep : n = 2 ^ a + p := by rw [hpdef, Nat.add_sub_cancel' hwn]
   have hpc : p ∈ coveringPrimes := prime_forced_small h3 h7 h5 h17 h13 h241 hp hrep
+  clear h3 h7 h5 h17 h13 h241
   have hpodd : p % 2 = 1 := Nat.odd_iff.mp (coveringPrimes_odd hpc)
   have hple : p ≤ 241 := coveringPrimes_le hpc
   have hpow : 2 ^ a % 2 = 1 := by omega
   have ha0 : a = 0 := by
     by_contra ha
-    have : Even (2 ^ a) := by rw [Nat.even_pow]; exact ⟨by decide, ha⟩
+    have : Even (2 ^ a) := by rw [Nat.even_pow]; exact ⟨⟨1, rfl⟩, ha⟩
     rw [Nat.even_iff] at this
     omega
   subst ha0


### PR DESCRIPTION
## Summary
`proofs/Proofs/Erdos10Incomplete01OQ02.lean` (and its dependent `Erdos10WIP01OQ03.lean`) hung at 100% CPU under the v4.31 toolchain — prior verify attempts ran **3h41m** and **>22min** with zero progress. Both now build green.

## Root cause (bisected)
The hang was **not** `decide`/`fin_cases` as the ledger class suggested. It was **`omega` running with the six covering-system residue hypotheses in context** — `n % 3 = 1`, `n % 7 = 1`, `n % 5 = 2`, `n % 17 = 8`, `n % 13 = 11`, and especially **`n % 241 = 121`**. Under v4.31 `omega` collects every in-scope arithmetic hypothesis; the mod-241 constraint makes its decision procedure blow up combinatorially.

Bisection (short-timeout docker builds):
- Stubbing the two `fin_cases … <;> decide` theorems did **not** stop the hang.
- Stubbing all bodies → compiles in seconds (rules out imports/statements).
- Restoring only `not_mem_one_of_even` → hang returns.
- `rw [mem_one_iff]` alone → fast; the first (prime) branch's `omega` → hang.
- Adding `clear h3 h7 h5 h17 h13 h241` before that `omega` → **compiles**. Confirmed.

## Fix (targeted; 0 sorries, 0 axioms)
- `clear` the residue hypotheses before every parity `omega` that doesn't need them (they are only required to feed `prime_forced_small`).
- Use `ring` / `Nat.add_sub_cancel'` for the commutativity rewrite `n = 2^a + p`, which must run while the residues are still in scope.
- Derive `2 < n` by term (`lt_of_lt_of_le … hbig.le`) instead of a poisoned `omega`.
- Replace the flagged `fin_cases <;> decide` with `simp [Nat.odd_iff]` / `omega`, and the `Even 2` `decide` with the explicit witness `⟨1, rfl⟩`.

## Dependent — NOT a pure cascade
`Erdos10WIP01OQ03` was expected to cascade green once the parent compiled, but it has the **identical** six-mod-hypothesis + `omega` pattern in `not_isPrimePlusKPowers_one_of_even_covering` and hung on its own. It received the same residue-clear fix.

## Verification
Both build green via the docker wrapper (never bare `lake build`):
- `./proofs/scripts/docker-build.sh Proofs.Erdos10Incomplete01OQ02` → success (2971 jobs)
- `./proofs/scripts/docker-build.sh Proofs.Erdos10WIP01OQ03` → success (2979 jobs, 1.1s)

0 sorries, 0 `axiom` declarations in both files.

Closes #39059

🤖 Generated with [Claude Code](https://claude.com/claude-code)