### PR TITLE
fix(agents): make Claude token registry honest + add consistency check (#38967)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,61 @@
+# .env.example — placeholder template. Copy to .env and fill in real values.
+#
+#   cp .env.example .env
+#
+# .env is gitignored and holds SECRETS. NEVER commit .env. This template
+# contains only placeholder values and documents the expected variables.
+
+# ── Harmonic Aristotle API ─────────────────────────────────────────────
+ARISTOTLE_API_KEY=arstl_your_key_here
+
+# ── Cloudflare deploy target ───────────────────────────────────────────
+# Create a token at: https://dash.cloudflare.com/profile/api-tokens
+# Template: "Edit Cloudflare Workers" + Pages:Edit + D1:Edit
+CLOUDFLARE_ACCOUNT_ID=your_account_id
+CLOUDFLARE_API_TOKEN=your_api_token
+
+# ── Mathstodon (Mastodon) API — Herald agent ───────────────────────────
+MATHSTODON_TOKEN=your_mastodon_token
+
+# ── Claude Code OAuth token pool — autonomous agents ───────────────────
+# Long-lived (1 year) OAuth tokens. scripts/agents/claude-wrapper.sh selects
+# and rotates among these for autonomous agent sessions.
+#
+# HOW THE POOL ACTUALLY WORKS (read before editing):
+#   * The token FILES in .loom/tokens/*.token are the source of truth the
+#     wrapper reads (it selects by globbing the directory).
+#   * On first run the wrapper BOOTSTRAPS missing tokens by writing each
+#     ACCOUNT_KEY_N value to  .loom/tokens/agent-N.token  — POSITIONALLY,
+#     using the same index N. It does NOT use ACCOUNT_TOKEN_FILE_N.
+#   * Therefore the token file for account N is always  agent-N.token,
+#     and it corresponds to ACCOUNT_EMAIL_N / ACCOUNT_KEY_N.
+#
+# Each account is a parallel triple (same index N):
+#   ACCOUNT_EMAIL_N       human label for the account (for your reference)
+#   ACCOUNT_KEY_N         the OAuth token value                    (SECRET)
+#   ACCOUNT_TOKEN_FILE_N  the token filename on disk — MUST be "agent-N.token"
+#                         so the registry matches what the wrapper creates.
+#
+# Keep ACCOUNT_TOKEN_FILE_N == agent-N.token. Run
+#   ./scripts/agents/check-token-registry.sh
+# to verify the registry agrees with .loom/tokens/, and
+#   ./scripts/agents/sync-token-registry.sh
+# to regenerate the ACCOUNT_TOKEN_FILE_N values if they drift. See #38967.
+
+# Account 1: you@example.com
+ACCOUNT_EMAIL_1=you@example.com
+ACCOUNT_KEY_1=your_oauth_token_here
+ACCOUNT_TOKEN_FILE_1=agent-1.token
+
+# Account 2: another@example.com
+ACCOUNT_EMAIL_2=another@example.com
+ACCOUNT_KEY_2=your_oauth_token_here
+ACCOUNT_TOKEN_FILE_2=agent-2.token
+
+# ...add ACCOUNT_EMAIL_N / ACCOUNT_KEY_N / ACCOUNT_TOKEN_FILE_N=agent-N.token
+# for each additional account, incrementing N.
+
+# ── Single-account fallback ────────────────────────────────────────────
+# If no ACCOUNT_KEY_* / .loom/tokens are present, the wrapper falls back to
+# this single token.
+# CLAUDE_CODE_OAUTH_TOKEN=your_oauth_token_here

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@
 # ── Secrets — never commit ─────────────────────────────────────────────
 .env
 .env.*
+# Exception: the placeholder template carries no secrets and is tracked.
+!.env.example
 .loom/tokens/
 .loom/lean-daemon-state.json
 .loom/usage-cache.json

--- a/scripts/agents/check-token-registry.sh
+++ b/scripts/agents/check-token-registry.sh
@@ -1,0 +1,136 @@
+#!/bin/bash
+#
+# check-token-registry.sh - Verify the .env account registry agrees with
+#                           the actual token files in .loom/tokens/.
+#
+# Background
+# ----------
+# The Claude account pool is declared in .env as parallel triples:
+#
+#     ACCOUNT_EMAIL_N       human label for account N (e.g. robb@example.com)
+#     ACCOUNT_KEY_N         the OAuth token value for account N   (SECRET)
+#     ACCOUNT_TOKEN_FILE_N  the token filename the registry claims for account N
+#
+# But scripts/agents/claude-wrapper.sh bootstraps and rotates tokens
+# POSITIONALLY: it materialises ACCOUNT_KEY_N into ".loom/tokens/agent-N.token"
+# and selects by globbing "*.token". It never reads ACCOUNT_TOKEN_FILE_N.
+#
+# If ACCOUNT_TOKEN_FILE_N holds semantic names (robb-2amlogic.token, ...) that
+# don't exist on disk, the registry's account -> token-file mapping is a dead
+# column: anything that trusts it to locate a specific account's token gets a
+# path that isn't there. See issue #38967.
+#
+# This script makes that rot loud instead of silent. It FAILS (non-zero exit)
+# when any referenced ACCOUNT_TOKEN_FILE_N has no matching file under
+# .loom/tokens/. Wire it into CI / a pre-flight lint so the columns can't
+# drift apart again unnoticed.
+#
+# The honest, wrapper-consistent value for ACCOUNT_TOKEN_FILE_N is
+# "agent-N.token" (see scripts/agents/sync-token-registry.sh to regenerate it).
+#
+# SECURITY: this script never reads, prints, or logs ACCOUNT_KEY_* values or
+# token file contents. It only inspects filenames and existence.
+#
+# Usage:
+#   ./scripts/agents/check-token-registry.sh          # human-readable report
+#   ./scripts/agents/check-token-registry.sh --quiet  # only print on failure
+#
+# Exit codes:
+#   0  every ACCOUNT_TOKEN_FILE_N resolves to an existing token file
+#   1  one or more referenced token files are missing (registry is stale)
+#   2  usage / environment error (no .env, no tokens dir, etc.)
+#
+
+set -uo pipefail
+
+REPO_ROOT="${REPO_ROOT:-$(cd "$(dirname "$0")/../.." && pwd)}"
+ENV_FILE="${ENV_FILE:-$REPO_ROOT/.env}"
+TOKENS_DIR="${TOKENS_DIR:-$REPO_ROOT/.loom/tokens}"
+QUIET=false
+
+for arg in "$@"; do
+    case "$arg" in
+        --quiet|-q) QUIET=true ;;
+        --help|-h)
+            sed -n '2,45p' "$0" | sed 's/^# \{0,1\}//'
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $arg" >&2
+            exit 2
+            ;;
+    esac
+done
+
+say() { $QUIET || echo "$@"; }
+
+if [[ ! -f "$ENV_FILE" ]]; then
+    echo "[check-token-registry] No .env file at $ENV_FILE — nothing to check." >&2
+    # Absence of .env is not a failure (e.g. a fresh clone / CI without secrets).
+    exit 0
+fi
+
+if ! grep -q '^ACCOUNT_TOKEN_FILE_[0-9]\+=' "$ENV_FILE" 2>/dev/null; then
+    say "[check-token-registry] .env declares no ACCOUNT_TOKEN_FILE_* entries — nothing to check."
+    exit 0
+fi
+
+missing=0
+checked=0
+declare -a referenced_basenames=()
+
+# Read each ACCOUNT_TOKEN_FILE_N=value line. Values may be quoted and may be a
+# bare basename or a path; we resolve bare names against $TOKENS_DIR.
+while IFS='=' read -r key val; do
+    n="${key#ACCOUNT_TOKEN_FILE_}"
+    [[ "$n" =~ ^[0-9]+$ ]] || continue
+    # Strip surrounding quotes / whitespace from the value (NOT a secret).
+    val="${val%\"}"; val="${val#\"}"
+    val="${val%\'}"; val="${val#\'}"
+    val="$(printf '%s' "$val" | tr -d '[:space:]')"
+    [[ -z "$val" ]] && continue
+
+    checked=$((checked + 1))
+
+    if [[ "$val" = /* ]]; then
+        resolved="$val"
+    else
+        resolved="$TOKENS_DIR/$val"
+    fi
+    referenced_basenames+=("$(basename "$resolved")")
+
+    if [[ -f "$resolved" ]]; then
+        say "  ok    account $n -> $val"
+    else
+        echo "  MISS  account $n (ACCOUNT_EMAIL_$n) -> $val  [no such file under .loom/tokens/]" >&2
+        missing=$((missing + 1))
+    fi
+done < <(grep '^ACCOUNT_TOKEN_FILE_[0-9]\+=' "$ENV_FILE")
+
+# Report token files on disk that no registry entry points at (orphans). This
+# is informational only and does not affect the exit code — the wrapper globs
+# the directory, so extra files are used, they're just undocumented.
+if [[ -d "$TOKENS_DIR" ]]; then
+    while IFS= read -r tok; do
+        [[ -e "$tok" ]] || continue
+        b="$(basename "$tok")"
+        found=false
+        for ref in "${referenced_basenames[@]:-}"; do
+            [[ "$ref" == "$b" ]] && { found=true; break; }
+        done
+        $found || say "  note  $b exists on disk but no ACCOUNT_TOKEN_FILE_* references it"
+    done < <(find "$TOKENS_DIR" -maxdepth 1 -name '*.token' 2>/dev/null | sort)
+fi
+
+if [[ $missing -gt 0 ]]; then
+    echo "" >&2
+    echo "[check-token-registry] FAIL: $missing of $checked ACCOUNT_TOKEN_FILE_* entries" >&2
+    echo "  point at token files that do not exist under $TOKENS_DIR." >&2
+    echo "  The registry column is stale (see issue #38967)." >&2
+    echo "  Fix: run scripts/agents/sync-token-registry.sh to regenerate the" >&2
+    echo "  ACCOUNT_TOKEN_FILE_* values to the real positional agent-N.token names." >&2
+    exit 1
+fi
+
+say "[check-token-registry] OK: all $checked ACCOUNT_TOKEN_FILE_* entries resolve to existing token files."
+exit 0

--- a/scripts/agents/claude-wrapper.sh
+++ b/scripts/agents/claude-wrapper.sh
@@ -49,6 +49,15 @@ if [[ -z "${CLAUDE_CODE_OAUTH_TOKEN:-}" ]]; then
 
     # Bootstrap: if .loom/tokens is missing/empty/broken-symlink but .env
     # has ACCOUNT_KEY_N entries, materialize them into the tokens dir.
+    #
+    # NOTE (see issue #38967): tokens are written POSITIONALLY as
+    # "agent-N.token" using the index N from ACCOUNT_KEY_N. Selection/rotation
+    # below globs "*.token", so the .token files are the source of truth. The
+    # .env ACCOUNT_TOKEN_FILE_N column is a human-facing label only and is NOT
+    # read here; to stay accurate it must equal "agent-N.token". Verify with
+    # scripts/agents/check-token-registry.sh; regenerate with
+    # scripts/agents/sync-token-registry.sh. Do NOT switch this to
+    # ACCOUNT_TOKEN_FILE_N naming without migrating the live pool first.
     if [[ ! -d "$_tokens_dir" ]] || ! ls "$_tokens_dir"/*.token &>/dev/null 2>&1; then
         _env_file="$_repo_root/.env"
         if [[ -f "$_env_file" ]] && grep -q '^ACCOUNT_KEY_[0-9]\+=' "$_env_file" 2>/dev/null; then

--- a/scripts/agents/sync-token-registry.sh
+++ b/scripts/agents/sync-token-registry.sh
@@ -1,0 +1,101 @@
+#!/bin/bash
+#
+# sync-token-registry.sh - Make the .env account registry honest.
+#
+# Rewrites every ACCOUNT_TOKEN_FILE_N value in .env to the real, positional
+# token filename that scripts/agents/claude-wrapper.sh actually creates and
+# reads: "agent-N.token" (the same N as the account's ACCOUNT_KEY_N /
+# ACCOUNT_EMAIL_N). After running this, the registry's account -> token-file
+# mapping matches what is on disk, and check-token-registry.sh passes.
+#
+# Why this and not a rename of the token files?
+#   The token pool is LIVE. The wrapper bootstraps ACCOUNT_KEY_N into
+#   agent-N.token and rotates by globbing "*.token". Renaming those files (or
+#   changing the wrapper's naming) risks breaking the running pool. The safe
+#   fix is to correct the *documentation* column so it describes reality.
+#   See issue #38967.
+#
+# SECURITY
+#   - Operates ONLY on the ACCOUNT_TOKEN_FILE_N lines (filenames, never secrets).
+#   - Never reads, prints, or modifies ACCOUNT_KEY_N values.
+#   - .env is gitignored and must never be committed. This script edits it in
+#     place (with a timestamped .bak backup); it does not touch git.
+#
+# Usage:
+#   ./scripts/agents/sync-token-registry.sh            # apply (writes .env)
+#   ./scripts/agents/sync-token-registry.sh --dry-run  # preview, write nothing
+#
+# Exit codes:
+#   0  applied (or dry-run completed)
+#   2  usage / environment error
+#
+
+set -uo pipefail
+
+REPO_ROOT="${REPO_ROOT:-$(cd "$(dirname "$0")/../.." && pwd)}"
+ENV_FILE="${ENV_FILE:-$REPO_ROOT/.env}"
+DRY_RUN=false
+
+for arg in "$@"; do
+    case "$arg" in
+        --dry-run|-n) DRY_RUN=true ;;
+        --help|-h)
+            sed -n '2,33p' "$0" | sed 's/^# \{0,1\}//'
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $arg" >&2
+            exit 2
+            ;;
+    esac
+done
+
+if [[ ! -f "$ENV_FILE" ]]; then
+    echo "[sync-token-registry] No .env file at $ENV_FILE" >&2
+    exit 2
+fi
+
+if ! grep -q '^ACCOUNT_TOKEN_FILE_[0-9]\+=' "$ENV_FILE" 2>/dev/null; then
+    echo "[sync-token-registry] .env declares no ACCOUNT_TOKEN_FILE_* entries — nothing to do." >&2
+    exit 0
+fi
+
+changes=0
+tmp="$(mktemp)"
+trap 'rm -f "$tmp"' EXIT
+
+while IFS= read -r line || [[ -n "$line" ]]; do
+    if [[ "$line" =~ ^ACCOUNT_TOKEN_FILE_([0-9]+)= ]]; then
+        n="${BASH_REMATCH[1]}"
+        want="agent-${n}.token"
+        # Current value (strip quotes/space) for reporting — never a secret.
+        cur="${line#*=}"
+        cur="${cur%\"}"; cur="${cur#\"}"; cur="${cur%\'}"; cur="${cur#\'}"
+        cur="$(printf '%s' "$cur" | tr -d '[:space:]')"
+        if [[ "$cur" != "$want" ]]; then
+            echo "  account $n: $cur -> $want"
+            changes=$((changes + 1))
+        fi
+        printf 'ACCOUNT_TOKEN_FILE_%s=%s\n' "$n" "$want" >> "$tmp"
+    else
+        printf '%s\n' "$line" >> "$tmp"
+    fi
+done < "$ENV_FILE"
+
+if [[ $changes -eq 0 ]]; then
+    echo "[sync-token-registry] Registry already honest — no changes needed."
+    exit 0
+fi
+
+if $DRY_RUN; then
+    echo "[sync-token-registry] --dry-run: $changes entr(y/ies) would change; .env left untouched."
+    exit 0
+fi
+
+backup="${ENV_FILE}.bak-$(date +%Y%m%d%H%M%S)"
+cp "$ENV_FILE" "$backup"
+cp "$tmp" "$ENV_FILE"
+echo "[sync-token-registry] Updated $changes ACCOUNT_TOKEN_FILE_* entr(y/ies)."
+echo "[sync-token-registry] Backup written to $backup (also gitignored)."
+echo "[sync-token-registry] Verify with: ./scripts/agents/check-token-registry.sh"
+exit 0


### PR DESCRIPTION
Closes #38967

## Problem

`.env` declares the Claude account pool as `ACCOUNT_EMAIL_N` / `ACCOUNT_KEY_N` / `ACCOUNT_TOKEN_FILE_N` triples, but `scripts/agents/claude-wrapper.sh` bootstraps and rotates tokens **positionally** as `.loom/tokens/agent-N.token` and never resolves `ACCOUNT_TOKEN_FILE_N`. The registry's semantic filenames (`robb-2amlogic.token`, ...) don't exist on disk — verified 13/13 miss, 0 overlap. Rotation works (it globs the dir), but the account to token-file mapping the registry claims to provide is a dead column.

## Approach (safe — the pool is LIVE)

Deliberately **not** the issue's option 1. I did not rename token files, change how the wrapper writes tokens, or change how rotation globs — that risks breaking the running pool. Instead I made the registry honest and added a guard so it can't silently rot again:

- **`scripts/agents/check-token-registry.sh`** (option 3): fails with a non-zero exit when any `ACCOUNT_TOKEN_FILE_N` has no matching file under `.loom/tokens/`. Also reports orphan token files. Never reads, prints, or logs `ACCOUNT_KEY_*` values or token contents — only filenames/existence. Wire into CI/pre-flight lint.
- **`scripts/agents/sync-token-registry.sh`** (option 2): regenerates the `ACCOUNT_TOKEN_FILE_N` values to the real positional `agent-N.token` names. The wrapper writes `ACCOUNT_KEY_N` to `agent-N.token`, so account N's token is always `agent-N.token`, corresponding to `ACCOUNT_EMAIL_N` — the mapping is knowable, the column just had the wrong names. Edits `.env` in place with a timestamped backup; touches only the filename column, never `ACCOUNT_KEY_*`. Supports `--dry-run`.
- **`claude-wrapper.sh`**: comment documenting the positional convention and that `ACCOUNT_TOKEN_FILE_N` is a label-only column that must equal `agent-N.token`.
- **`.env.example`**: placeholder template (no secrets) documenting the pool format with the correct `agent-N.token` convention, plus a `.gitignore` negation so the template is tracked while `.env` / `.env.*` stay ignored.

## Operator action required (manual, local — not committable)

`.env` is gitignored and holds secrets, so this PR cannot correct the live file. After merge, run locally in the repo root:

```bash
./scripts/agents/sync-token-registry.sh          # rewrites ACCOUNT_TOKEN_FILE_N -> agent-N.token (with .env.bak backup)
./scripts/agents/check-token-registry.sh          # should now print OK
```

This only rewrites the filename column; `ACCOUNT_KEY_*` and the live `.loom/tokens/*.token` files are untouched, so the running pool is unaffected.

## Validation

- `check-token-registry.sh` against the real `.env`: correctly flags 13/13 stale entries and exits 1.
- Fixture round-trip: sync rewrites the column, re-check passes, `ACCOUNT_KEY_*` values preserved, sync is idempotent.
- Both new scripts are shellcheck-clean. The two SC2012 infos in `claude-wrapper.sh` are pre-existing and unrelated to the one comment added here.
- No secrets committed: `git check-ignore` confirms `.env` / `.env.bak-*` ignored, `.env.example` tracked and scanned clean of real keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)