### PR TITLE
Aristotle v4.28→v4.31 translation at the integration boundary (#38622)

### DIFF
--- a/research/ARISTOTLE-WORKFLOW.md
+++ b/research/ARISTOTLE-WORKFLOW.md
@@ -167,19 +167,78 @@ Aristotle caches project results ~30 days server-side, so re-submitting the
 exact same file within that window returns the prior result quickly without
 burning fresh solver budget.
 
-## Toolchain caveat (Mathlib v4.28)
+## Boundary translation (Mathlib v4.28 ↔ our v4.31 pin)
 
-Aristotle's backend vendors **Mathlib v4.28.0** and **rewrites submitted
-projects' `lean-toolchain` to v4.28.0** (observed in issue #38098; tracked
-against the toolchain flip in #38066). Our repo pins
-`proofs/lean-toolchain` (currently `leanprover/lean4:v4.26.0`), so:
+Aristotle's backend vendors **Mathlib v4.28.0** and **rewrites every submitted
+project's `lean-toolchain` to v4.28.0** (issue #38098). Our `main` pins
+`proofs/lean-toolchain` at **`leanprover/lean4:v4.31.0`** (flip #38066). The
+operator decision (2026-07-13) was NOT to wait for the backend to move off its
+pin, but to **translate at the boundary** — submit-side and integration-side —
+because "they will eventually update too" (issue #38622).
 
-- A proof that Aristotle verified on v4.28 may not elaborate unchanged on our
-  toolchain (and vice versa). **Always rebuild retrieved proofs locally**
-  before counting them as integrated — `retrieve-integrate.sh` compares
-  against the original but does not replace a local verification build.
-- Do not commit a `lean-toolchain` that came back inside an Aristotle result
-  bundle.
+Concretely, three rules govern the boundary:
+
+**1. Submission side — the v4.28 rewrite is EXPECTED, not an error.**
+`submit-batch.sh` / `preprocess-for-aristotle.sh` ship our pin's
+`lean-toolchain` (v4.31.0) inside the temp project. The backend normalizes it
+to v4.28 before elaborating. That is correct and requires no action. Do **not**
+commit a `lean-toolchain` that came back inside an Aristotle result bundle.
+
+**2. Integration side — drift-repair v4.28 → v4.31, automatically.**
+Every returned proof is **v4.28-era Lean** and will not necessarily elaborate
+on our v4.31 pin. `retrieve-integrate.sh` runs each retrieved solution through
+`scripts/aristotle/drift-repair.sh` **before** integrating it:
+
+- Applies the confident pure-rename subset of
+  `research/toolchain-v4.31-rename-map.md` (§1), curated into the
+  machine-readable table `scripts/aristotle/v428-to-v431-renames.tsv`
+  (e.g. `le_or_lt`→`le_or_gt`, `div_le_div_iff`→`div_le_div_iff₀`,
+  `not_mem`→`notMem` wave, `Set.mem_diff`→`Set.mem_sdiff`).
+- Whole-identifier matching with Unicode-aware boundaries, so
+  qualification-adds and `₀`-suffix adds are idempotent (safe to run on a file
+  that is already partly v4.31).
+- **Flags** — but does not blindly rewrite — names whose fix also changes a
+  signature / argument order / field layout / RHS (rename-map §5), listed in
+  `scripts/aristotle/v428-to-v431-flags.tsv` (e.g. `IsSolvableByRad`,
+  `IsCyclic.commutative`, `AdjoinRoot.liftHom`). These need a human/Doctor.
+
+Run it standalone to inspect drift on any file:
+
+```bash
+scripts/aristotle/drift-repair.sh --check proofs/Proofs/Foo.lean   # report only
+scripts/aristotle/drift-repair.sh proofs/Proofs/Foo.lean           # repair in place (+.drift.bak)
+```
+
+**3. Verification side — gate on an in-container v4.31 build.**
+Renaming makes a proof *elaborate-able*; it does not prove it GOES GREEN. Do
+**not** trust the backend's own v4.28 success signal across the version gap. A
+returned proof is only **verified** once it passes the same in-container v4.31
+build gate as migration increments:
+
+```bash
+scripts/aristotle/verify-v431-build.sh proofs/Proofs/Foo.lean
+#   exit 0 -> may mark verified   exit 1 -> do NOT mark verified   exit 3 -> pending (gate skipped)
+```
+
+This delegates to `./proofs/scripts/docker-build.sh` (NEVER bare `lake build`)
+and targets whatever pin `main` carries, so it is automatically "the current
+pin". `retrieve-integrate.sh` records the result on each job as
+`v431_verified` (true only on exit-0) and `v431_verification`
+(`verified` / `failed` / `pending`).
+
+By default the heavy build gate is **not** run inline (a 60-min build per proof
+would stall the integrate loop): retrieved proofs are integrated but left
+`pending`. Set `ARISTOTLE_VERIFY_BUILD=1` on `retrieve-integrate.sh` to gate
+inline, or run `verify-v431-build.sh` later (Aristotle agent / daemon) before
+any gallery `meta.json` is marked `verified`. `ARISTOTLE_SKIP_BUILD_GATE=1`
+forces the standalone gate to return `pending` without building.
+
+> **Drift probe (follow-up).** Characterizing the *typical* v4.28→v4.31 drift by
+> submitting a small live prove job and elaborating its output (originally gate
+> (b) of #38066) is left to the Aristotle agent — it costs live API quota and is
+> not needed to build the translation mechanism. The rename catalog (§1) already
+> seeds the repair table from the #38065 burn-down; extend
+> `v428-to-v431-renames.tsv` (and the map) as new drift is observed.
 
 ## Job tracking
 

--- a/research/SORRY-CLASSIFICATION.md
+++ b/research/SORRY-CLASSIFICATION.md
@@ -167,6 +167,17 @@ sorry, so batching unrelated sorries dilutes the search budget. Existing
 companion files remain a working fallback; the batch agent still picks
 them up.
 
+> **Boundary translation (v4.28 → v4.31).** The Aristotle backend vendors
+> Mathlib **v4.28** and returns **v4.28-era Lean**; our pin is **v4.31**. A
+> returned proof is therefore *not* automatically GREEN on our pin. The
+> `retrieve-integrate.sh` path handles this automatically — it drift-repairs
+> each solution (`scripts/aristotle/drift-repair.sh`, driven by
+> `v428-to-v431-renames.tsv` from rename-map §1) and gates verification on an
+> in-container v4.31 build (`scripts/aristotle/verify-v431-build.sh`); the
+> backend's own success signal is **not** trusted across the version gap. Full
+> workflow: `research/ARISTOTLE-WORKFLOW.md` → "Boundary translation". This is
+> the ongoing operational job owned by issue #38622.
+
 ## Aristotle Companion Files (DEPRECATED — early multi-sorry pattern)
 
 > **Status (2026-06-05):** This multi-sorry companion-file pattern is **superseded** by the

--- a/scripts/aristotle/drift-repair.sh
+++ b/scripts/aristotle/drift-repair.sh
@@ -1,0 +1,184 @@
+#!/bin/bash
+#
+# drift-repair.sh - Translate v4.28-era Aristotle output to the v4.31 pin
+#
+# The Aristotle proof-search backend vendors Mathlib v4.28 and normalizes every
+# submission (and therefore every returned proof) to v4.28-era Lean. Our `main`
+# pin is v4.31. Before an Aristotle solution can go GREEN in the gallery it must
+# be drift-repaired to v4.31. This script applies the confident, pure-rename
+# subset of research/toolchain-v4.31-rename-map.md (§1) to a Lean file and
+# WARNS about names that need human/Doctor attention (v428-to-v431-flags.tsv).
+#
+# It does NOT verify the build — that is verify-v431-build.sh's job (the
+# in-container v4.31 exit-0 gate). Renaming makes the proof *elaborate-able*;
+# only the build gate proves it actually GOES GREEN. See issue #38622 and
+# research/ARISTOTLE-WORKFLOW.md ("Boundary translation").
+#
+# Usage:
+#   ./drift-repair.sh <file.lean>            # repair in place (writes <file>.bak)
+#   ./drift-repair.sh --check <file.lean>    # report only, do not modify (exit 0)
+#   ./drift-repair.sh --stdout <file.lean>   # write repaired file to stdout
+#   ./drift-repair.sh --no-backup <file>     # repair in place without a .bak
+#   ./drift-repair.sh --quiet <file>         # suppress the per-rule log
+#
+# Exit codes:
+#   0  success (repairs applied, or nothing to do)
+#   1  usage / IO error
+#   2  --check found flagged names needing manual review (advisory; the
+#      retrieve/integrate path treats this as "integrate but do not mark
+#      verified" rather than a hard failure)
+#
+# Matching semantics: each old identifier is matched only as a whole token that
+# is not preceded by a word char or `.` and not followed by a word char, `.`,
+# `'`, or subscript-zero. This makes qualification-adds (bare -> Namespaced)
+# and `₀`-suffix adds idempotent and protects primed sibling lemmas, so the
+# script is safe to run on a file that is already partly v4.31.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RENAMES_FILE="$SCRIPT_DIR/v428-to-v431-renames.tsv"
+FLAGS_FILE="$SCRIPT_DIR/v428-to-v431-flags.tsv"
+
+# Colors (disabled when stdout is not a tty)
+if [[ -t 1 ]]; then
+    RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; CYAN='\033[0;36m'; NC='\033[0m'
+else
+    RED=''; GREEN=''; YELLOW=''; CYAN=''; NC=''
+fi
+
+MODE="inplace"     # inplace | check | stdout
+BACKUP=true
+QUIET=false
+INPUT=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --check)     MODE="check"; shift ;;
+        --stdout)    MODE="stdout"; shift ;;
+        --no-backup) BACKUP=false; shift ;;
+        --quiet)     QUIET=true; shift ;;
+        -h|--help)
+            sed -n '2,40p' "$0"; exit 0 ;;
+        --) shift; break ;;
+        -*) echo "Unknown option: $1" >&2; exit 1 ;;
+        *)  INPUT="$1"; shift ;;
+    esac
+done
+[[ -z "$INPUT" && $# -gt 0 ]] && INPUT="$1"
+
+if [[ -z "$INPUT" ]]; then
+    echo "Usage: $0 [--check|--stdout|--no-backup|--quiet] <file.lean>" >&2
+    exit 1
+fi
+if [[ ! -f "$INPUT" ]]; then
+    echo -e "${RED}ERROR:${NC} file not found: $INPUT" >&2
+    exit 1
+fi
+if [[ ! -f "$RENAMES_FILE" ]]; then
+    echo -e "${RED}ERROR:${NC} rename table missing: $RENAMES_FILE" >&2
+    exit 1
+fi
+
+log() { [[ "$QUIET" == true ]] && return 0; echo -e "$@" >&2; }
+
+# Apply one whole-identifier rename to a file, in place. Idempotent for
+# qualification-adds and ₀-suffix adds. Uses perl for portable Unicode-aware
+# lookbehind/lookahead (BSD sed on macOS lacks \b and PCRE lookaround).
+apply_rename() {
+    local file="$1" old="$2" new="$3"
+    OLD="$old" NEW="$new" perl -CSD -MEncode -i -pe '
+        BEGIN { $o = decode_utf8($ENV{OLD}); $n = decode_utf8($ENV{NEW}); }
+        s/(?<![\w.])\Q$o\E(?![\w.\x{2080}\x{27}])/$n/g;
+    ' "$file"
+}
+
+# Count whole-identifier occurrences of a name in a file (same boundaries as
+# apply_rename), so we can report only genuine hits.
+count_occurrences() {
+    local file="$1" name="$2"
+    NAME="$name" perl -CSD -MEncode -0777 -ne '
+        BEGIN { $n = decode_utf8($ENV{NAME}); }
+        my $c = () = /(?<![\w.])\Q$n\E(?![\w.\x{2080}\x{27}])/g;
+        print $c;
+    ' "$file"
+}
+
+# --- Work on a scratch copy so --check / --stdout never touch the input ---
+work="$(mktemp "${TMPDIR:-/tmp}/drift-repair-XXXXXX.lean")"
+cleanup() { rm -f "$work"; }
+trap cleanup EXIT
+cp "$INPUT" "$work"
+
+applied_total=0
+declare -a applied_lines=()
+
+# --- Pass 1: apply the safe pure renames ---
+while IFS=$'\t' read -r old new || [[ -n "$old" ]]; do
+    # strip comments / blanks / whitespace
+    old="${old%%$'\r'}"
+    [[ -z "$old" || "$old" == \#* ]] && continue
+    new="${new%%$'\r'}"
+    # trim surrounding whitespace
+    old="$(printf '%s' "$old" | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//')"
+    new="$(printf '%s' "$new" | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//')"
+    [[ -z "$old" || -z "$new" ]] && continue
+
+    local_hits="$(count_occurrences "$work" "$old")"
+    if [[ "${local_hits:-0}" -gt 0 ]]; then
+        apply_rename "$work" "$old" "$new"
+        applied_total=$((applied_total + local_hits))
+        applied_lines+=("  ${GREEN}rename${NC} ($local_hits) $old ${CYAN}->${NC} $new")
+    fi
+done < "$RENAMES_FILE"
+
+# --- Pass 2: scan for flagged names (manual review) ---
+flagged_total=0
+declare -a flagged_lines=()
+if [[ -f "$FLAGS_FILE" ]]; then
+    while IFS=$'\t' read -r name reason || [[ -n "$name" ]]; do
+        name="${name%%$'\r'}"
+        [[ -z "$name" || "$name" == \#* ]] && continue
+        name="$(printf '%s' "$name" | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//')"
+        [[ -z "$name" ]] && continue
+        reason="$(printf '%s' "$reason" | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//')"
+        local_hits="$(count_occurrences "$work" "$name")"
+        if [[ "${local_hits:-0}" -gt 0 ]]; then
+            flagged_total=$((flagged_total + 1))
+            flagged_lines+=("  ${YELLOW}review${NC} ($local_hits) $name — ${reason:-see rename-map §5}")
+        fi
+    done < "$FLAGS_FILE"
+fi
+
+# --- Report ---
+log "${CYAN}drift-repair${NC} $(basename "$INPUT"): applied ${applied_total} rename-hit(s), ${flagged_total} flag(s)"
+if [[ "${#applied_lines[@]}" -gt 0 ]]; then
+    for l in "${applied_lines[@]}"; do log "$l"; done
+fi
+if [[ "${#flagged_lines[@]}" -gt 0 ]]; then
+    log "${YELLOW}Manual review needed (v4.28->v4.31 changes beyond a blind rename):${NC}"
+    for l in "${flagged_lines[@]}"; do log "$l"; done
+    log "${YELLOW}Recipes: research/toolchain-v4.31-rename-map.md (§2/§3/§4/§5)${NC}"
+fi
+
+# --- Emit result per mode ---
+case "$MODE" in
+    check)
+        # report-only; never modify input
+        [[ "$flagged_total" -gt 0 ]] && exit 2
+        exit 0
+        ;;
+    stdout)
+        cat "$work"
+        [[ "$flagged_total" -gt 0 ]] && exit 2
+        exit 0
+        ;;
+    inplace)
+        if [[ "$applied_total" -gt 0 ]]; then
+            [[ "$BACKUP" == true ]] && cp "$INPUT" "$INPUT.drift.bak"
+            cp "$work" "$INPUT"
+        fi
+        [[ "$flagged_total" -gt 0 ]] && exit 2
+        exit 0
+        ;;
+esac

--- a/scripts/aristotle/preprocess-for-aristotle.sh
+++ b/scripts/aristotle/preprocess-for-aristotle.sh
@@ -105,7 +105,13 @@ trap cleanup_tmp_dir EXIT
 
 cp "$INPUT_FILE" "$tmp_file"
 
-# Copy Lean project files so aristotlelib recognizes it as a valid project
+# Copy Lean project files so aristotlelib recognizes it as a valid project.
+# We ship our current pin's lean-toolchain (v4.31.0 post-flip #38066). The
+# Aristotle backend NORMALIZES the submitted lean-toolchain to its vendored
+# Mathlib v4.28 before elaborating — this rewrite is EXPECTED, not an error
+# (issue #38622). The returned proof therefore comes back as v4.28-era Lean and
+# is drift-repaired to v4.31 on integration by scripts/aristotle/drift-repair.sh.
+# See research/ARISTOTLE-WORKFLOW.md ("Boundary translation").
 cp "$PROJECT_ROOT/proofs/lakefile.toml" "$tmp_dir/"
 cp "$PROJECT_ROOT/proofs/lean-toolchain" "$tmp_dir/"
 

--- a/scripts/aristotle/retrieve-integrate.sh
+++ b/scripts/aristotle/retrieve-integrate.sh
@@ -24,6 +24,19 @@ RESULTS_DIR="$PROJECT_ROOT/aristotle-results/new"
 PROCESSED_DIR="$PROJECT_ROOT/aristotle-results/processed"
 PROOFS_DIR="$PROJECT_ROOT/proofs/Proofs"
 
+# Boundary translation (issue #38622): the Aristotle backend vendors Mathlib
+# v4.28 and returns v4.28-era Lean. Every retrieved proof is drift-repaired to
+# the v4.31 pin before integration, and (optionally) gated on an in-container
+# v4.31 build before it is treated as verified — we do NOT trust the backend's
+# own v4.28 success signal across the version gap.
+DRIFT_REPAIR="$SCRIPT_DIR/drift-repair.sh"
+VERIFY_BUILD="$SCRIPT_DIR/verify-v431-build.sh"
+# Run the heavy in-container build gate inline? Default 0: integrate the
+# improved proof but leave it verification-pending (the standalone gate — or the
+# Aristotle agent/daemon — runs verify-v431-build.sh later, before any gallery
+# entry is marked verified). Set ARISTOTLE_VERIFY_BUILD=1 to gate inline.
+VERIFY_BUILD_INLINE="${ARISTOTLE_VERIFY_BUILD:-0}"
+
 # Colors
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -219,6 +232,52 @@ count_theorems_proved() {
     echo "$proved"
 }
 
+# Drift-repair a retrieved solution in place (v4.28 -> v4.31). Non-fatal:
+# drift-repair.sh returns 2 when it finds names needing manual review, which we
+# treat as advisory (integrate the improvement, but the build gate below decides
+# verification). Renames never change sorry counts, so this is safe to run
+# before the sorry-count comparison.
+drift_repair_file() {
+    local f="$1"
+    [[ -x "$DRIFT_REPAIR" && -f "$f" ]] || return 0
+    "$DRIFT_REPAIR" --no-backup "$f" || true
+}
+
+# Run the v4.31 build gate on an integrated proof and echo a verification token:
+#   verified | failed | pending
+# Always returns 0; the caller records the token. "pending" means the heavy
+# build was not run inline (default) — the proof is integrated but NOT verified.
+run_v431_gate() {
+    local module_arg="$1"
+    if [[ "$VERIFY_BUILD_INLINE" != "1" ]]; then
+        echo "pending"; return 0
+    fi
+    [[ -x "$VERIFY_BUILD" ]] || { echo "pending"; return 0; }
+    local rc=0
+    "$VERIFY_BUILD" "$module_arg" >&2 || rc=$?
+    case "$rc" in
+        0) echo "verified" ;;
+        3) echo "pending" ;;
+        *) echo "failed" ;;
+    esac
+}
+
+# Record the v4.31 verification result on a job. `v431_verified` is true ONLY
+# when the in-container build passed; "pending"/"failed" leave it false so no
+# downstream step treats an unbuilt v4.28 proof as verified (#38622).
+update_job_verification() {
+    local project_id="$1"
+    local verification="$2"
+
+    local tmp_file
+    tmp_file=$(mktemp)
+    jq --arg pid "$project_id" --arg v "$verification" '
+        .jobs |= map(if .project_id == $pid then
+            .v431_verified = ($v == "verified") | .v431_verification = $v
+        else . end)
+    ' "$JOBS_FILE" > "$tmp_file" && mv "$tmp_file" "$JOBS_FILE"
+}
+
 # Integrate a solution
 integrate_solution() {
     local job="$1"
@@ -296,6 +355,10 @@ integrate_solution() {
         fi
 
         echo -e "  ${GREEN}Retrieved${NC}"
+
+        # Boundary translation (#38622): rewrite v4.28-era output to the v4.31
+        # pin before comparing/integrating.
+        drift_repair_file "$solution_file"
     fi
 
     if [[ "$RETRIEVE_ONLY" == true ]]; then
@@ -345,10 +408,23 @@ integrate_solution() {
                 # Move to processed
                 mv "$solution_file" "$PROCESSED_DIR/"
 
+                # Boundary verification (#38622): gate on an in-container v4.31
+                # build before treating the proof as verified. "pending" (the
+                # default) integrates the improvement but leaves it unverified.
+                local verification
+                verification=$(run_v431_gate "$original_path")
+                if [[ "$verification" == "failed" ]]; then
+                    echo -e "  ${RED}v4.31 build gate FAILED${NC} — integrated as UNVERIFIED (residual v4.28->v4.31 drift needs manual repair)"
+                elif [[ "$verification" == "verified" ]]; then
+                    echo -e "  ${GREEN}v4.31 build gate PASSED${NC} — verified on our pin"
+                fi
+
                 # Update job status with theorems_proved
                 local outcome_note="$new_sorries sorries remaining"
                 [[ "$is_companion" == "true" ]] && outcome_note="$new_sorries sorries remaining (companion file — merge into ${basename/Aristotle/Problem}.lean)"
+                [[ "$verification" != "verified" ]] && outcome_note="$outcome_note [v4.31: $verification]"
                 update_job_status_with_theorems "$project_id" "integrated" "$outcome_note" "$theorems_proved"
+                update_job_verification "$project_id" "$verification"
 
                 # Create completion signal for daemon stats tracking
                 local completions_dir="$PROJECT_ROOT/.loom/signals/completions"
@@ -636,6 +712,10 @@ recover_server_completed() {
 
         echo -e "  ${GREEN}Mapped to:${NC} $target_file"
 
+        # Boundary translation (#38622): rewrite v4.28-era output to the v4.31
+        # pin before comparing/integrating.
+        drift_repair_file "$tmp_solution"
+
         # Compare sorry counts
         local orig_sorries new_sorries
         orig_sorries=$(count_sorries "$target_file")
@@ -663,20 +743,31 @@ recover_server_completed() {
             cp "$tmp_solution" "$target_file"
             mv "$tmp_solution" "$PROCESSED_DIR/recovered-${pid}.lean"
 
+            # Boundary verification (#38622): gate on an in-container v4.31 build
+            # before treating the recovered proof as verified.
+            local rec_verification
+            rec_verification=$(run_v431_gate "$target_file")
+            if [[ "$rec_verification" == "failed" ]]; then
+                echo -e "  ${RED}v4.31 build gate FAILED${NC} — recovered as UNVERIFIED"
+            fi
+
             # Track in jobs.json
             local tmp_jq
             tmp_jq=$(mktemp)
             jq --arg pid "$pid" --arg file "proofs/Proofs/${target_basename}.lean" \
                --arg prob "$problem_id" --arg now "$now" \
-               --argjson proved "$theorems_proved" '
+               --argjson proved "$theorems_proved" \
+               --arg verification "$rec_verification" '
                 .jobs += [{
                     project_id: $pid,
                     file: $file,
                     problem_id: $prob,
                     submitted: "unknown",
                     status: "integrated",
-                    outcome: ("\($proved) theorems proved via server recovery"),
+                    outcome: ("\($proved) theorems proved via server recovery [v4.31: " + $verification + "]"),
                     theorems_proved: $proved,
+                    v431_verified: ($verification == "verified"),
+                    v431_verification: $verification,
                     notes: ("Recovered and integrated from server at " + $now)
                 }]
             ' "$JOBS_FILE" > "$tmp_jq" && mv "$tmp_jq" "$JOBS_FILE"

--- a/scripts/aristotle/submit-batch.sh
+++ b/scripts/aristotle/submit-batch.sh
@@ -379,7 +379,12 @@ submit_file() {
     if [[ -n "$preprocessed_tmp" && -f "$preprocessed_tmp" ]]; then
         project_dir="$(dirname "$preprocessed_tmp")"
     else
-        # Create a temp project dir with the file and Lean project metadata
+        # Create a temp project dir with the file and Lean project metadata.
+        # We submit our current pin's lean-toolchain (v4.31.0). The Aristotle
+        # backend normalizes it to its vendored Mathlib v4.28 — that rewrite is
+        # EXPECTED (issue #38622); returned proofs are v4.28-era and are
+        # drift-repaired to v4.31 on integration (retrieve-integrate.sh ->
+        # drift-repair.sh). See research/ARISTOTLE-WORKFLOW.md.
         project_dir=$(mktemp -d "${TMPDIR:-/tmp}/aristotle-submit-XXXXXX")
         cp "$submit_file" "$project_dir/"
         cp "$PROJECT_ROOT/proofs/lakefile.toml" "$project_dir/"

--- a/scripts/aristotle/v428-to-v431-flags.tsv
+++ b/scripts/aristotle/v428-to-v431-flags.tsv
@@ -1,0 +1,39 @@
+# v428-to-v431-flags.tsv
+#
+# Names that appear in v4.28-era Aristotle output and DRIFT on the v4.31 pin,
+# but must NOT be blind-renamed: the fix also changes a signature, argument
+# order, field layout, statement (RHS), or is an import-move rather than a
+# rename. drift-repair.sh only WARNS when it sees these, pointing at the recipe
+# in research/toolchain-v4.31-rename-map.md (§2/§3/§4/§5) so a human / Doctor
+# adapts the proof.
+#
+# FORMAT
+#   old_name<TAB>reason (one line; keep the map section reference)
+#   Blank lines and lines starting with `#` are ignored.
+
+# --- §5 API / signature changes (rename-map §5) ---
+IsSolvableByRad	§5: replacement `solvableByRad` is an IntermediateField, not a predicate; every use-site changes (x ∈ solvableByRad F E)
+solvableByRad.isSolvable'	§5: -> isSolvable_gal_of_irreducible swaps argument roles (Irreducible q vs root hypothesis)
+IsCyclic.commutative	§5: -> IsCyclic.isMulCommutative returns IsMulCommutative with no .comm field; use mul_comm / .is_comm.comm
+AdjoinRoot.liftHom	§5: -> AdjoinRoot.liftAlgHom now takes an R ->ₐ[S] T argument; .toRingHom projections break
+List.Sorted	§5: definition changed from Pairwise r to Monotone l.get; sortedness proofs need adaptation
+mul_le_mul_right'	§1b/§5: -> _root_.mul_le_mul_left is a left/right convention swap; check each use-site
+setIntegral_const	§5: RHS changed from (μ s).toReal • c to μ.real s • c (rename ok, proof body may drift)
+set_integral_congr	§1e/§5: -> setIntegral_congr_fun; NullMeasurableSet uses the ₀ variant
+pow_eq_zero	§1b: -> eq_zero_of_pow_eq_zero adds an [IsReduced R] hypothesis
+isUnit_of_mul_eq_one	§1b: -> IsUnit.of_mul_eq_one needs [IsDedekindFiniteMonoid M] (auto for comm monoids)
+div_le_div_right	§1b: -> div_le_div_iff_of_pos_right is an iff, not the ₀ implication form; usage changes
+div_lt_div_right	§1b: -> div_lt_div_iff_of_pos_right is an iff, not the ₀ implication form; usage changes
+Nat.Prime.multiplicity_choose	§1f: -> emultiplicity_choose result type is ℕ∞, not ℕ
+Polynomial.aeval_pow	§1f: dedicated lemma gone; use generic map_pow (aeval is an AlgHom)
+Finset.toSet	§1f: no rename; use the coercion (↑s : Set α) and the coe API (mem_coe, coe_inj)
+List.get?	§1f: removed in v4.28+; use List.getElem? or l[i]? (indexing form differs)
+
+# --- §5 import-move (still exists under same name; add the explicit import) ---
+alternatingGroup.isSimpleGroup_five	§1a/§5: NOT removed — import Mathlib.GroupTheory.SpecificGroups.Alternating.Simple
+
+# --- §4 pre-existing removals (NOT a migration rename; modern spelling noted) ---
+Complex.abs	§4: removed pre-pin; use norm / ‖·‖ and the Complex.norm_* lemma family
+
+# --- §1g tactic deprecation (warning-only today; safe to defer) ---
+push_neg	§1g: -> push Not is warning-only in v4.31 but slated for removal (93 files)

--- a/scripts/aristotle/v428-to-v431-renames.tsv
+++ b/scripts/aristotle/v428-to-v431-renames.tsv
@@ -1,0 +1,99 @@
+# v428-to-v431-renames.tsv
+#
+# Machine-readable subset of research/toolchain-v4.31-rename-map.md (§1
+# "Confident renames"), curated for BLIND, safe application to Aristotle
+# proof-search output.
+#
+# WHY THIS FILE EXISTS
+#   The Aristotle backend vendors Mathlib v4.28 and normalizes every submission
+#   (and therefore every returned proof) to v4.28-era Lean. Our `main` pin is
+#   v4.31. drift-repair.sh applies these renames to a retrieved proof before it
+#   is integrated + gated on an in-container v4.31 build. See
+#   research/ARISTOTLE-WORKFLOW.md ("Boundary translation") and issue #38622.
+#
+# FORMAT
+#   old_name<TAB>new_name         (a literal identifier rename)
+#   Blank lines and lines starting with `#` are ignored.
+#   Whitespace around each field is trimmed.
+#
+# MATCHING SEMANTICS (see drift-repair.sh)
+#   Each old_name is matched as a whole identifier: it must not be preceded by
+#   a word char or `.` and must not be followed by a word char, `.`, `'`, or a
+#   subscript-zero. This makes qualification-adds (bare -> Namespaced) and
+#   `₀`-suffix adds idempotent, and protects primed sibling lemmas.
+#
+# SCOPE / SAFETY
+#   ONLY pure identifier renames whose semantics are unchanged live here.
+#   Renames that also change a signature, argument order, field layout, or the
+#   statement (RHS) are NOT here — they are in v428-to-v431-flags.tsv so a human
+#   / Doctor handles them. Provenance for every row: rename-map §1a-§1f.
+#
+# HOW TO EXTEND
+#   When Aristotle output reveals a new v4.28->v4.31 drift, first record it in
+#   research/toolchain-v4.31-rename-map.md (with evidence), then add the safe
+#   pure-rename subset here. Keep the two in sync.
+
+# --- §1a Galois / group theory (pure renames only; the type-changing
+#         IsSolvableByRad / IsCyclic.commutative pair lives in the flags file) ---
+commutative_of_cyclic_center_quotient	MonoidHom.isMulCommutative_of_isCyclic_of_ker_le_center
+nilpotent_of_mulEquiv	Group.nilpotent_of_mulEquiv
+nilpotent_of_surjective	Group.nilpotent_of_surjective
+isNilpotent_of_ker_le_center	Subgroup.isNilpotent_of_ker_le_center
+
+# --- §1b Order / algebra basics ---
+le_or_lt	le_or_gt
+Ne.lt_or_lt	Ne.lt_or_gt
+eq_or_gt_of_le	eq_or_lt_of_le'
+div_le_div_iff	div_le_div_iff₀
+div_lt_div_iff	div_lt_div_iff₀
+pow_le_pow_right	pow_le_pow_right₀
+pow_le_pow_left	pow_le_pow_left₀
+pow_lt_pow_left	pow_lt_pow_left₀
+one_lt_pow_of_one_lt_of_ne_zero	one_lt_pow₀
+abs_add	abs_add_le
+pi_lt_four	Real.pi_lt_four
+tendsto_const_div_atTop_nhds_0_nat	tendsto_const_div_atTop_nhds_zero_nat
+
+# --- §1c not_mem -> notMem wave ---
+Finset.card_insert_of_not_mem	Finset.card_insert_of_notMem
+Finset.not_mem_empty	Finset.notMem_empty
+Set.not_mem_empty	Set.notMem_empty
+Finset.eq_empty_iff_forall_not_mem	Finset.eq_empty_iff_forall_notMem
+Set.eq_empty_iff_forall_not_mem	Set.eq_empty_iff_forall_notMem
+Finset.ne_univ_iff_exists_not_mem	Finset.ne_univ_iff_exists_notMem
+
+# --- §1d diff -> sdiff wave (Set / measure) ---
+Set.mem_diff	Set.mem_sdiff
+Set.diff_empty	Set.sdiff_empty
+MeasureTheory.measure_diff_null	MeasureTheory.measure_sdiff_null
+Convex.mem_extremePoints_iff_mem_diff_convexHull_diff	Convex.mem_extremePoints_iff_mem_sdiff_convexHull_sdiff
+
+# --- §1e Analysis / measure theory (setIntegral_const/_congr changed their RHS
+#         and live in the flags file; the rows below are pure renames) ---
+Filter.eventually_of_forall	Filter.Eventually.of_forall
+continuous_finset_prod	continuous_finsetProd
+continuous_finset_sum	continuous_finsetSum
+MeasureTheory.integral_finset_sum	MeasureTheory.integral_finsetSum
+MeasureTheory.Integrable.bdd_mul'	MeasureTheory.Integrable.bdd_mul
+integral_mul_left	MeasureTheory.integral_const_mul
+MeasureTheory.Lp.memℒp	MeasureTheory.Lp.memLp
+Memℒp.of_bound	MemLp.of_bound
+memℒp_two_iff_integrable_sq_norm	memLp_two_iff_integrable_sq_norm
+norm_sq_eq_inner	norm_sq_eq_re_inner
+tsum_pos	Summable.tsum_pos
+
+# --- §1f Data / number theory / misc ---
+ZMod.natCast_zmod_eq_zero_iff_dvd	ZMod.natCast_eq_zero_iff
+Matrix.smul_mulVec_assoc	Matrix.smul_mulVec
+Finset.range_succ	Finset.range_add_one
+Nat.dvd_sub'	Nat.dvd_sub
+Algebra.id.map_eq_id	Algebra.algebraMap_self
+List.Chain'	List.IsChain
+Fin.coe_sub	Fin.val_sub
+Fin.coe_castSucc	Fin.val_castSucc
+Nat.twoPowSum_bitIndices	Nat.sum_map_two_pow_bitIndices
+Finset.toFinset_bitIndices_twoPowSum	Finset.toFinset_bitIndices_sum_two_pow
+Finset.filter_card_add_filter_neg_card_eq_card	Finset.card_filter_add_card_filter_not
+SimpleGraph.chromaticNumber_pos	SimpleGraph.Colorable.chromaticNumber_pos
+Set.ncard_image_of_injOn	Set.InjOn.ncard_image
+Real.geom_mean_eq_arith_mean_weighted_iff'	Real.geom_mean_eq_arith_mean_weighted_iff_of_pos'

--- a/scripts/aristotle/verify-v431-build.sh
+++ b/scripts/aristotle/verify-v431-build.sh
@@ -1,0 +1,105 @@
+#!/bin/bash
+#
+# verify-v431-build.sh - Gate an Aristotle-integrated proof on an in-container
+#                        v4.31 build (exit-0), the same gate migration
+#                        increments used.
+#
+# WHY: the Aristotle backend elaborates against its vendored Mathlib v4.28 and
+# reports its OWN success signal. We do NOT trust that signal across the version
+# gap (#38622). A returned proof only counts as verified once it builds against
+# our v4.31 pin inside the sanctioned Docker wrapper. This script is that gate.
+#
+# It delegates to ./proofs/scripts/docker-build.sh (NEVER bare `lake build`,
+# which can OOM the host — see CLAUDE.md). docker-build.sh targets whatever pin
+# `main` currently carries (v4.31.0 post-flip #38066), so this gate is
+# automatically "the current pin" with no hard-coded version here.
+#
+# Usage:
+#   ./verify-v431-build.sh proofs/Proofs/Foo.lean   # accepts a file path
+#   ./verify-v431-build.sh Proofs.Foo               # or a module target
+#
+# Exit codes:
+#   0  build succeeded (exit-0) -> caller may mark the proof verified
+#   1  build FAILED               -> caller must NOT mark verified
+#   3  gate skipped (ARISTOTLE_SKIP_BUILD_GATE=1) -> caller marks "pending",
+#      never "verified"
+#
+# Environment:
+#   ARISTOTLE_SKIP_BUILD_GATE=1  Skip the heavy build and return 3 (pending).
+#                                Used by the retrieve/integrate loop when a
+#                                60-min build per proof is not wanted inline;
+#                                the standalone gate is then run later by the
+#                                Aristotle agent / daemon before the gallery
+#                                entry is marked verified.
+#   LEAN_MEMORY_LIMIT, LEAN_BUILD_TIMEOUT  Passed through to docker-build.sh.
+#   ARISTOTLE_VERIFY_LOG         Optional path to append the build log tail to.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+DOCKER_BUILD="$PROJECT_ROOT/proofs/scripts/docker-build.sh"
+
+if [[ -t 1 ]]; then
+    RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; CYAN='\033[0;36m'; NC='\033[0m'
+else
+    RED=''; GREEN=''; YELLOW=''; CYAN=''; NC=''
+fi
+
+if [[ $# -lt 1 ]]; then
+    echo "Usage: $0 <proofs/Proofs/Foo.lean | Proofs.Foo>" >&2
+    exit 1
+fi
+
+arg="$1"
+
+# Derive the Lake module target `Proofs.<Stem>` from a path or accept a target.
+target=""
+if [[ "$arg" == *.lean ]]; then
+    stem="$(basename "$arg" .lean)"
+    target="Proofs.$stem"
+elif [[ "$arg" == Proofs.* ]]; then
+    target="$arg"
+else
+    target="Proofs.$arg"
+fi
+
+# Skip escape: return "pending" without running the heavy build.
+if [[ "${ARISTOTLE_SKIP_BUILD_GATE:-0}" == "1" ]]; then
+    echo -e "${YELLOW}v4.31 build gate SKIPPED${NC} for $target (ARISTOTLE_SKIP_BUILD_GATE=1)" >&2
+    echo -e "${YELLOW}Proof is UNVERIFIED on the v4.31 pin — run this gate before marking verified.${NC}" >&2
+    exit 3
+fi
+
+if [[ ! -x "$DOCKER_BUILD" ]]; then
+    echo -e "${RED}ERROR:${NC} docker-build wrapper not found/executable: $DOCKER_BUILD" >&2
+    echo -e "${YELLOW}Refusing to mark verified without the sanctioned build wrapper.${NC}" >&2
+    exit 1
+fi
+
+echo -e "${CYAN}v4.31 build gate:${NC} $DOCKER_BUILD $target" >&2
+
+log_tmp="$(mktemp "${TMPDIR:-/tmp}/aristotle-v431-build-XXXXXX.log")"
+rc=0
+"$DOCKER_BUILD" "$target" >"$log_tmp" 2>&1 || rc=$?
+
+if [[ -n "${ARISTOTLE_VERIFY_LOG:-}" ]]; then
+    {
+        echo "=== $(date -u +%FT%TZ) $target rc=$rc ==="
+        tail -40 "$log_tmp"
+    } >> "$ARISTOTLE_VERIFY_LOG" 2>/dev/null || true
+fi
+
+if [[ "$rc" -eq 0 ]]; then
+    echo -e "${GREEN}v4.31 build PASSED${NC} for $target" >&2
+    rm -f "$log_tmp"
+    exit 0
+fi
+
+echo -e "${RED}v4.31 build FAILED${NC} for $target (rc=$rc)" >&2
+echo -e "${YELLOW}--- build log tail ---${NC}" >&2
+tail -25 "$log_tmp" >&2 || true
+echo -e "${YELLOW}Do NOT mark this proof verified. Repair remaining v4.28->v4.31 drift" >&2
+echo -e "${YELLOW}(research/toolchain-v4.31-rename-map.md §2/§3/§5) and re-run the gate.${NC}" >&2
+rm -f "$log_tmp"
+exit 1


### PR DESCRIPTION
Closes #38622.

Follow-on to epic #37508 / infra flip #38066. The Aristotle backend vendors Mathlib **v4.28** and returns **v4.28-era Lean**; our `main` pin is **v4.31**. This wires the *translation-at-the-boundary* mechanism so Aristotle-assisted proofs no longer silently reintroduce v4.28→v4.31 drift.

## What landed

**Integration-time drift repair** — `scripts/aristotle/drift-repair.sh`
- perl-driven, whole-identifier, Unicode-aware, **idempotent** rename engine (safe to run on a file that is already partly v4.31: qualification-adds and `₀`-suffix adds don't double-apply; primed sibling lemmas are protected).
- Data-driven by `scripts/aristotle/v428-to-v431-renames.tsv` — the confident pure-rename subset curated from `research/toolchain-v4.31-rename-map.md` §1 (`not_mem`→`notMem` wave, `diff`→`sdiff` wave, `le_or_lt`→`le_or_gt`, `div_le_div_iff`→`div_le_div_iff₀`, …).
- **Flags** (does not blind-rewrite) names whose fix also changes a signature / arg order / field layout / RHS / import (rename-map §5): `scripts/aristotle/v428-to-v431-flags.tsv` (`IsSolvableByRad`, `IsCyclic.commutative`, `AdjoinRoot.liftHom`, …) → routed to a human/Doctor.
- Modes: `--check` (report-only), `--stdout`, in-place (`.drift.bak`).

**Verification gate** — `scripts/aristotle/verify-v431-build.sh`
- Gates a proof on an in-container **v4.31 build** via `./proofs/scripts/docker-build.sh` (never bare `lake build`). exit 0=verified, 1=failed, 3=pending. The backend's own v4.28 success signal is **not** trusted across the gap.

**Wiring** — `retrieve-integrate.sh`
- Drift-repairs every retrieved solution before integrating (main + server-recovery paths) and records `v431_verified` (true only on exit-0) + `v431_verification` (`verified`/`failed`/`pending`) on each job. Heavy build gate is opt-in via `ARISTOTLE_VERIFY_BUILD=1` (default: integrate as `pending`, so the daemon loop isn't stalled by a 60-min build per proof; the standalone gate / Aristotle agent runs it before any gallery entry is marked verified).

**Submission side** — `submit-batch.sh` / `preprocess-for-aristotle.sh`
- Documented that the backend rewriting the submitted `lean-toolchain` to v4.28 is **expected, not an error**.

**Docs** — `research/ARISTOTLE-WORKFLOW.md` gains a "Boundary translation" section; `research/SORRY-CLASSIFICATION.md` a pointer — so the Aristotle agent applies this automatically.

## Acceptance criteria
- [x] Retrieve/integrate path drift-repairs v4.28 output to v4.31 automatically (or flags what it can't).
- [x] Integrated proofs pass an in-container v4.31 build gate before being marked verified (`v431_verified` true only on exit-0; opt-in inline via env, standalone otherwise).
- [x] Submission path confirmed compatible with the backend's v4.28 normalization (documented in code + workflow doc).
- [x] Documented in `research/SORRY-CLASSIFICATION.md` / the Aristotle workflow section.

## Follow-up (not in this PR)
The live **drift probe** (submit a small prove job, elaborate its output, characterize typical drift) — originally gate (b) of #38066 — is left to the Aristotle agent: it costs live API quota and isn't needed to build the mechanism. The repair table is seeded from the #38065 burn-down catalog and is extended as new drift is observed.

## Validation
- `bash -n` + `shellcheck` clean on all touched scripts (only pre-existing SC2155 warnings remain).
- `drift-repair.sh --check` reports **0 false renames** on already-v4.31 proof files, flags §5 names correctly, and never modifies its input.
- jq record-update logic validated on sample job JSON.
- No heavy Lean build was run in this session (gate wired, not exercised); no gallery data touched (no `pnpm build` needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)