### PR TITLE
chore(sperner): quarantine non-compiling legacy SpernerGrid.lean (Part of #38578)

### DIFF
--- a/proofs/Proofs/SpernerGrid.lean
+++ b/proofs/Proofs/SpernerGrid.lean
@@ -6,6 +6,33 @@ Authors: RJ Walters
 import Mathlib
 
 /-
+# ⚠ DEPRECATED / QUARANTINED — does not compile (see #38578, #8998)
+
+This legacy file **does not compile**. Its errors are confined to the
+*oriented* `gridAdj` / `interiorFlip` / `boundary_doors_odd` block, whose
+`boundary_doors_odd` claim is mathematically **false** as stated for `d = 1`
+because of a structural double-counting in the `GridSimplex` / `gridAdj`
+representation. That defect predates — and is unaffected by — the v4.26 → v4.31
+toolchain migration (#37508); it can only be resolved by the `GridSimplex` /
+`gridAdj` redesign tracked in #8998 (see also #9044).
+
+Do **not** repair this file in place: the oriented adjacency machinery here is
+exactly the code the #8998 redesign replaces. It is deliberately excluded from
+`proofs/scripts/build-safe-subset.sh` so the safe-subset build is not polluted
+with its known failures.
+
+**Canonical replacement:** the compiling `BaryPoint` / `GridSimplex` foundation
+now lives in `Proofs.SpernerGridBase` (the unoriented cell geometry, canonicality
+`IsCanon`, and lexicographic order), extended by `Proofs.SpernerGridCell` and
+`Proofs.SpernerNDimOQ02Cell` for the "Option C" unoriented `SpernerTriangulation`
+instance. New work should build on those, not on this file.
+
+The gallery's `sperner-mathlib4` verified badge applies to the *abstract* proof
+in `Proofs.SpernerMathlib4`, **not** to this file — so no verification overclaim
+exists today.
+
+--------------------------------------------------------------------------------
+
 # Grid Triangulation Instance for Abstract Sperner's Lemma
 
 We construct a concrete `CellComplex` instance from the standard

--- a/proofs/scripts/build-safe-subset.sh
+++ b/proofs/scripts/build-safe-subset.sh
@@ -1,17 +1,28 @@
 #!/usr/bin/env bash
 #
-# Build all Lean proofs EXCEPT memory-intensive ones
+# Build all Lean proofs EXCEPT memory-intensive or known-broken ones
 #
 # Some proofs (like Erdos728FactorialDivisibility) have tactics that can
-# consume unbounded memory. This script builds everything else.
+# consume unbounded memory. Others are legacy files that are known not to
+# compile and are pending a redesign rather than a repair. This script builds
+# everything else.
 #
 set -euo pipefail
 
 cd "$(dirname "$0")/.."
 
-# Files to exclude (known memory hogs)
+# Files to exclude:
+#   - known memory hogs (unbounded-memory tactics)
+#   - known-broken legacy files awaiting redesign (do NOT repair in place)
 EXCLUDE=(
-    "Erdos728FactorialDivisibility"
+    "Erdos728FactorialDivisibility"   # memory hog
+    # Legacy oriented-adjacency file; the false `boundary_doors_odd` block does
+    # not compile and is slated for replacement by the #8998 GridSimplex/gridAdj
+    # redesign. Canonical foundation: Proofs.SpernerGridBase. See #38578 / #8998.
+    "SpernerGrid"
+    # Content-free placeholder whose only `import` is the broken SpernerGrid, so
+    # it can never build while that file is quarantined. See #38578 / #8998.
+    "SpernerGridAristotle"
 )
 
 echo "=== Building Safe Subset of Proofs ==="


### PR DESCRIPTION
## Summary

Sperner housekeeping (#38578), three items — **item 1 delivered**, item 2 already resolved upstream, item 3 deferred to the #8998 redesign. This is a **documentation + build-tooling only** change (no proof or gallery edits).

### Item 1 — legacy `SpernerGrid.lean` (DELIVERED)

`proofs/Proofs/SpernerGrid.lean` does not compile. Its errors are confined to the oriented `interiorFlip`/`gridAdj`/`boundary_doors_odd` block, whose `boundary_doors_odd` claim is mathematically **false** for `d = 1` — exactly the code the #8998 `GridSimplex`/`gridAdj` redesign replaces. The defect predates and is unaffected by the v4.26→v4.31 migration (#37508); it is not in any migration repair/deferral ledger.

Per the issue's own sequencing ("the redesign determines what survives"), the correct low-risk action is to **quarantine/deprecate**, not repair code slated for replacement:

- Added a prominent `DEPRECATED` notice to the file header pointing to the canonical compiling foundation `Proofs.SpernerGridBase` (+ `SpernerGridCell` / `SpernerNDimOQ02Cell` for the Option-C instance) and to #8998.
- Excluded `SpernerGrid` from `proofs/scripts/build-safe-subset.sh` (exact-match, so `SpernerGridBase`/`Cell`/`FaithfulD1` are untouched). Also excluded `SpernerGridAristotle` — a content-free placeholder whose only `import` is the broken file, so it can never build while `SpernerGrid` is quarantined.

No overclaim exists today: the gallery's `sperner-mathlib4` verified badge applies to `Proofs.SpernerMathlib4`, not this file.

### Item 2 — duplicate `GridSimplex` in `SpernerGridCell.lean` (ALREADY RESOLVED)

Already fixed on `main` by the v4.31 migration (#38065). `SpernerGridCell.lean` no longer redeclares `GridSimplex`; it now retains only the `BaryPoint.transfer*` helpers and relies on Base's canonical copy, with an in-file comment documenting the dedup. Nothing to do.

### Item 3 — second `IsCanon` scaffold in `SpernerNDimOQ02Cell.lean` (DEFERRED to #8998)

This is **not** a trivial duplicate and is **not** safe to force-converge:

- `SpernerNDimOQ02.IsCanon` uses its own lex order `SpernerGrid.BaryPoint.lexLe`; Base's `SpernerGrid.IsCanon` uses `SpernerGrid.BaryPoint.lexLE` — different predicates in different namespaces, no hard conflict, so both compile independently.
- Converging them requires proving the two lex orders agree (or rewriting the scaffold onto Base's `IsCanon`/`lexLE` and its `IsCanon.base_unique` uniqueness development) — a semantic/architectural change, not mechanical dedup.
- `SpernerNDimOQ02Cell.lean`'s own docstring flags "per-geometry uniqueness of `IsCanon`" as **open next-session work** completing the Option-C `SpernerTriangulation` instance.

That makes item 3 a #8998 increment-2 decision ("the redesign determines what survives"), so it is deferred with this note rather than forced.

## Testing

- `bash -n proofs/scripts/build-safe-subset.sh` passes; exclusion matching simulated (only `SpernerGrid` + `SpernerGridAristotle` excluded, Base/Cell/FaithfulD1 unaffected).
- No Lean build required: the SpernerGrid.lean change is a comment added to an already-non-compiling file; no proof, meta, or gallery files change.

Part of #38578 (items 2/3 tracked above; issue remains open for item 3 under #8998).

🤖 Generated with [Claude Code](https://claude.com/claude-code)