### PR TITLE
refactor(sperner): converge canonical-cell scaffold onto Base IsCanon + add Kuhn uniqueness

### DIFF
--- a/proofs/Proofs/SpernerGridCell.lean
+++ b/proofs/Proofs/SpernerGridCell.lean
@@ -17,8 +17,10 @@ Reproducing it on the compiling foundation makes the cell geometry — the
 tracking, and the `incDir` complement surjection — available to the "Option C"
 *unoriented* `SpernerTriangulation` instance (`sperner-ndim-oq-02`) without
 importing the broken file. `GridSimplex` is an **oriented chain** encoding; the
-Phase-1 instance quotients out that orientation with a canonicality predicate
-(see `SpernerNDimOQ02Cell.lean`).
+Phase-1 instance quotients out that orientation with the canonicality predicate
+`SpernerGrid.IsCanon` from `SpernerGridBase` (see the canonical-cell subtype
+`CanonCell` in `SpernerNDimOQ02Cell.lean` and the parallel `CanonSimplex`
+development in `SpernerNDimOQ02.lean`).
 
 Namespace is kept as `SpernerGrid` (import-disjoint from the broken file, so no
 module ever sees two `SpernerGrid.GridSimplex`). No new axioms or sorries.

--- a/proofs/Proofs/SpernerNDimOQ02Cell.lean
+++ b/proofs/Proofs/SpernerNDimOQ02Cell.lean
@@ -16,17 +16,25 @@ adjacency involution:
 * `onFace_cellVertices` — the face correspondence at the level of cells, an
   immediate consequence of `SpernerNDimOQ02.onFace_toVertex`. This is what the
   `boundary_face` field will consume once `adj` is defined.
-* `BaryPoint.lexLe` / `IsCanon` / `CanonCell` — the canonicality scaffolding that
-  picks a single encoding per geometry (a `GridSimplex` is an *oriented chain*; the
-  same vertex set admits several `(verts, incDir, miss)` encodings, which is exactly
-  what makes the parent file's oriented `gridAdj` double-count). `IsCanon s` says the
-  chain base `s.verts 0` is lexicographically least among the cell's vertices.
-  Decidability and the (noncomputable) `Fintype` for the subtype are established here.
+* `CanonCell` — the canonical-cell subtype that picks a single encoding per
+  geometry (a `GridSimplex` is an *oriented chain*; the same vertex set admits
+  several `(verts, incDir, miss)` encodings, which is exactly what makes the parent
+  file's oriented `gridAdj` double-count). It is built directly on the canonical
+  foundation `SpernerGrid.IsCanon`/`SpernerGrid.BaryPoint.lexLE` from
+  `SpernerGridBase` (which says the chain base `s.verts 0` is lexicographically least
+  among the cell's vertices), rather than on a private lex-order copy. Decidability
+  and the (noncomputable) `Fintype` for the subtype reuse Base's `IsCanon` instances.
+* `canonCell_eq_of_vertices_range` — **per-geometry uniqueness at the Kuhn level**:
+  two canonical cells with the same Kuhn vertex set are equal. Lifts Base's proved
+  `SpernerGrid.IsCanon.geometry_unique` across the injective bridge `toVertex`.
+
+This converges the earlier private canonicality scaffold onto Base's `IsCanon`
+development (#8998 item 3 / #38578): there is now a single lex order and a single
+`IsCanon` predicate across the Sperner grid files.
 
 Still open (next session): the facet-sharing dual-graph `adj` and its five
-involution fields, plus the per-geometry uniqueness of `IsCanon`. Those complete the
-`SpernerTriangulation` instance; `sperner_ndim` then finishes the proof, transported
-across `SpernerNDimOQ02.isSperner_iff`.
+involution fields. Those complete the `SpernerTriangulation` instance; `sperner_ndim`
+then finishes the proof, transported across `SpernerNDimOQ02.isSperner_iff`.
 
 No new axioms or sorries: every declaration below depends only on the standard
 `propext`/`Classical.choice`/`Quot.sound`.
@@ -71,31 +79,15 @@ theorem onFace_cellVertices (s : SpernerGrid.GridSimplex d N)
 -- Canonicality: one chain encoding per geometric cell
 -- ============================================================
 
-/-- Lexicographic `≤` on barycentric points: `a ≤ b` iff `a = b` or, at the first
-    coordinate where they differ, `a` is smaller. Decidable because both the
-    equality test and the bounded existential range over the finite `Fin (d+1)`. -/
-def _root_.SpernerGrid.BaryPoint.lexLe (a b : SpernerGrid.BaryPoint d N) : Prop :=
-  a = b ∨ ∃ i : Fin (d + 1),
-    (∀ j : Fin (d + 1), j < i → a.coords j = b.coords j) ∧ a.coords i < b.coords i
-
-instance (a b : SpernerGrid.BaryPoint d N) : Decidable (a.lexLe b) := by
-  unfold SpernerGrid.BaryPoint.lexLe; infer_instance
-
-/-- A cell is *canonical* when its chain base `verts 0` is lexicographically least
-    among its `d+1` vertices. Since the chain direction of a Freudenthal cell is
-    geometrically forced once the base is fixed (the `miss` coordinate strictly
-    decreases along the chain, `GridSimplex.miss_coord_at`), pinning the base to the
-    lex-least vertex selects a single encoding per geometry — the device that
-    eliminates the oriented `gridAdj` double-count. -/
-def IsCanon (s : SpernerGrid.GridSimplex d N) : Prop :=
-  ∀ k : Fin (d + 1), (s.verts 0).lexLe (s.verts k)
-
-instance : DecidablePred (IsCanon : SpernerGrid.GridSimplex d N → Prop) :=
-  fun _ => by unfold IsCanon; infer_instance
-
 /-- The `Simplex` type of the Option-C instance: one canonical chain encoding per
-    geometric Freudenthal cell. -/
-def CanonCell (d N : ℕ) : Type := { s : SpernerGrid.GridSimplex d N // IsCanon s }
+    geometric Freudenthal cell. Built on Base's `SpernerGrid.IsCanon` (a cell is
+    *canonical* when its chain base `verts 0` is lexicographically least — under
+    `SpernerGrid.BaryPoint.lexLE` — among its `d+1` vertices). Since the chain
+    direction of a Freudenthal cell is geometrically forced once the base is fixed
+    (the `miss` coordinate strictly decreases along the chain), pinning the base to
+    the lex-least vertex selects a single encoding per geometry — the device that
+    eliminates the oriented `gridAdj` double-count. -/
+def CanonCell (d N : ℕ) : Type := { s : SpernerGrid.GridSimplex d N // SpernerGrid.IsCanon s }
 
 instance : DecidableEq (CanonCell d N) := Subtype.instDecidableEq
 
@@ -109,5 +101,26 @@ def canonVertices (s : CanonCell d N) : Fin (d + 1) → SpernerNDim.Vertex d N :
 theorem canonVertices_injective (s : CanonCell d N) :
     Function.Injective (canonVertices s) :=
   cellVertices_injective s.val
+
+/-- **Per-geometry uniqueness (Kuhn side).** Two canonical cells with the same Kuhn
+    vertex *set* are equal. This lifts Base's proved
+    `SpernerGrid.IsCanon.geometry_unique` (stated over barycentric points) across the
+    injective bridge `toVertex`: equal image-sets under an injection have equal
+    preimage sets, so the underlying grid simplices share a vertex set, geometry
+    uniqueness makes them equal, and `Subtype.ext` finishes. It closes the
+    canonicality scaffold's remaining obligation — there is exactly one canonical
+    cell per geometric Freudenthal simplex — the well-definedness the facet-sharing
+    `adj` will rely on. -/
+theorem canonCell_eq_of_vertices_range {s t : CanonCell d N}
+    (h : Set.range (canonVertices s) = Set.range (canonVertices t)) : s = t := by
+  have key : ∀ u : CanonCell d N,
+      Set.range (canonVertices u) = toVertex '' Set.range u.val.verts := by
+    intro u
+    have hcomp : canonVertices u = toVertex ∘ u.val.verts := rfl
+    rw [hcomp, Set.range_comp]
+  rw [key s, key t] at h
+  have hbary : Set.range s.val.verts = Set.range t.val.verts :=
+    Set.image_injective.mpr toVertex_injective h
+  exact Subtype.ext (SpernerGrid.IsCanon.geometry_unique s.2 t.2 hbary)
 
 end SpernerNDimOQ02


### PR DESCRIPTION
## Summary

Converges the duplicate canonicality scaffold in `SpernerNDimOQ02Cell.lean` onto the canonical `SpernerGrid.IsCanon` / `SpernerGrid.BaryPoint.lexLE` development in `SpernerGridBase`, and closes the file's previously-flagged "per-geometry uniqueness of `IsCanon`" obligation. This is the bounded, self-contained convergence deferred to #8998 as item 3 of the Sperner housekeeping in #38578 — it does **not** touch the open-research pieces (the geometric "both sides" theorem or the 4 adjacency axioms).

Before this change the Sperner grid files carried **two** `IsCanon` predicates over `SpernerGrid.BaryPoint`: Base's `SpernerGrid.IsCanon` (with `lexLE`, plus proved `base_unique` / `geometry_unique`) and a private `SpernerNDimOQ02.IsCanon` (with a private `lexLe`). The two lex orders were definitionally identical but namespaced apart, so the scaffold could not reach Base's uniqueness development.

## Changes

- Remove the duplicate `SpernerGrid.BaryPoint.lexLe` def + its `Decidable` instance.
- Remove the duplicate `SpernerNDimOQ02.IsCanon` def + its `DecidablePred` instance.
- Rebase `CanonCell` directly on Base's `SpernerGrid.IsCanon`; its `DecidableEq` / noncomputable `Fintype` now reuse Base's `IsCanon` instances.
- Add `canonCell_eq_of_vertices_range`: two canonical cells with the same **Kuhn** vertex set are equal, by lifting Base's proved `SpernerGrid.IsCanon.geometry_unique` across the injective bridge `toVertex` (`Set.range_comp` + `Set.image_injective.mpr toVertex_injective` + `Subtype.ext`). This closes the uniqueness obligation the file previously listed as open.
- Update a stale comment in `SpernerGridCell.lean` to point at Base's `IsCanon` and both canonical-cell developments.

## Acceptance Criteria Verification

This PR is a bounded increment on the #8998 epic (labeled `Part of`, not `Closes`). The epic's headline acceptance criteria (general `SimplicialComplex → CellComplex` bridge, the geometric "both sides" theorem, the 4 adjacency axioms) remain **open research** and are explicitly out of scope here.

| Item | Status | Verification |
|------|--------|--------------|
| #38578 item-3 convergence: single `IsCanon` / lex order across the grid files | ✅ | Duplicate `lexLe`/`IsCanon` removed; `CanonCell` now on `SpernerGrid.IsCanon`; repo grep shows no remaining lowercase `lexLe` (outside the unrelated `KnightsTour` file) |
| Per-geometry uniqueness (Kuhn side) for canonical cells | ✅ | New `canonCell_eq_of_vertices_range` proved via Base's `IsCanon.geometry_unique` |
| No sorries / axioms / `native_decide` added | ✅ | Diff adds only docstrings + one lemma built from foundational Mathlib + Base's 0-axiom `geometry_unique` |
| Build verifies | ✅ | `LEAN_MEMORY_LIMIT=16384 ./proofs/scripts/docker-build.sh Proofs.SpernerNDimOQ02Cell` → "Build completed successfully (8580 jobs)", exit 0 |

## Test Plan

- `./proofs/scripts/docker-build.sh Proofs.SpernerNDimOQ02Cell` builds green (8580 jobs, exit 0), both on the unmodified module (feasibility/cache warm-up) and after the edit.
- No other file imports `SpernerNDimOQ02Cell`; grep confirms no code referenced the removed `lexLe` / `SpernerNDimOQ02.IsCanon` names, so the convergence is non-breaking.

Part of #8998

🤖 Generated with [Claude Code](https://claude.com/claude-code)