### PR TITLE
chore(hooks): register guard-loom-workflow.sh (canonical v0.10.10 split)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -7,6 +7,10 @@
           {
             "type": "command",
             "command": "${CLAUDE_PROJECT_DIR}/.loom/hooks/guard-destructive.sh"
+          },
+          {
+            "type": "command",
+            "command": "${CLAUDE_PROJECT_DIR}/.loom/hooks/guard-loom-workflow.sh"
           }
         ]
       }


### PR DESCRIPTION
## What

Register `guard-loom-workflow.sh` as a second PreToolUse/Bash hook, after
`guard-destructive.sh`.

## Why

Loom **v0.10.10** (upstream #3604) split the two Loom-workflow-specific guards
— the PR-merge redirect and the editable-pip-install worktree block — out of
`guard-destructive.sh` into a standalone `guard-loom-workflow.sh`, registered as
its own hook.

This host has migrated `.loom/hooks/guard-destructive.sh` back to the **canonical
v0.10.10** version (retiring a long-standing local fork; see upstream
rjwalters/loom #3624 / #3625 / #3626). The canonical guard no longer carries
those two checks inline, so without this registration the redirect/worktree
guards are inactive.

This matches the canonical `defaults/.claude/settings.json` layout exactly (two
hooks in one `Bash` matcher, `guard-destructive.sh` first).

## Verification

- `.claude/settings.json` is valid JSON; PreToolUse Bash matcher now lists both hooks.
- Functional test harness (10 cases) against the migrated hooks: catastrophic
  denies, repo-scoped `rm` allow/deny, `/tmp` + Claude-scratchpad ephemeral
  allowlist (fixes the prior #39064 regression), force-push main deny, and the
  workflow redirect all behave as expected.

Note: `.loom/hooks/*` are machine-local (gitignored); `guard-loom-workflow.sh`
is provided by the Loom v0.10.10 install on each host, same pattern as the
already-registered `guard-destructive.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
