### PR TITLE
Enrich Burnside to the Dihedral Group: Index-2 Orbit Folding

### DIFF
--- a/src/data/proofs/burnside-counting-oq-04/meta.json
+++ b/src/data/proofs/burnside-counting-oq-04/meta.json
@@ -70,7 +70,8 @@
       "Adding reflections to Burnside is, abstractly, nothing more than splitting the Burnside sum along an index-2 subgroup: the rotation part re-sums to the necklace count, the reflection part is the leftover complement sum",
       "The restricted action of a subgroup H ≤ G fixes a point iff the underlying element of G does, so fixedBy X (h:G) = fixedBy X h definitionally; only the Fintype instances differ, which Fintype.card_congr absorbs",
       "The result is stated for an arbitrary subgroup, not just index 2 — the dihedral case is the motivating instance, obtained by also assuming |G| = 2|H|",
-      "Combined with the rotation count k^gcd(n,r) (oq-03) and the reflection count k^((n+1)/2) (oq-05), this folding theorem is the assembly step those entries leave open: it is exactly what turns per-symmetry fixed-point counts into the dihedral bracelet number"
+      "Combined with the rotation count k^gcd(n,r) (oq-03) and the reflection count k^((n+1)/2) (oq-05), this folding theorem is the assembly step those entries leave open: it is exactly what turns per-symmetry fixed-point counts into the dihedral bracelet number",
+      "The reflections form a coset G∖H, not a subgroup — which is precisely why folding, and not a second application of Burnside, is the right tool. The complement G∖H (the n reflections in D_n) is not closed under multiplication, so Σ_{g∉H}|Fix(g)| is not itself the orbit-count of any group action and cannot be simplified by Burnside's lemma. Folding sidesteps this entirely: it subtracts the rotation-subgroup Burnside instance from the full-group one, leaving the reflection contribution as a raw fixed-point sum that never has to be a Burnside total. This is exactly why the theorem hypothesises only H ≤ G and demands no structure on the complement"
     ],
     "prerequisites": [
       "Group actions, orbits, and the orbit-counting (Burnside/Cauchy–Frobenius) lemma",
@@ -99,9 +100,17 @@
       "id": "doubling",
       "title": "The Dihedral Doubling Form",
       "startLine": 101,
-      "endLine": 127,
-      "summary": "When |G| = 2|H| (the dihedral size relation), folding rearranges to 2·|X/G|·|H| = |X/H|·|H| + Σ_{g ∉ H} |Fix(g)|; |DihedralGroup n| = 2n anchors the instance.",
-      "mathContext": "$2\\,|X/G|\\,|H| = |X/H|\\,|H| + \\sum_{g \\notin H} |\\mathrm{Fix}(g)|,\\quad |D_n| = 2n$."
+      "endLine": 121,
+      "summary": "dihedral_doubling: when |G| = 2|H| (the dihedral size relation), folding rearranges by `ring` to 2·|X/G|·|H| = |X/H|·|H| + Σ_{g ∉ H} |Fix(g)|, i.e. bracelets·2|H| = necklaces·|H| + (reflection fixed points).",
+      "mathContext": "$2\\,|X/G|\\,|H| = |X/H|\\,|H| + \\sum_{g \\notin H} |\\mathrm{Fix}(g)|$."
+    },
+    {
+      "id": "dihedral-order",
+      "title": "The Order Relation |D_n| = 2n",
+      "startLine": 122,
+      "endLine": 128,
+      "summary": "dihedralGroup_card: re-export of Mathlib's DihedralGroup.card giving |DihedralGroup n| = 2n for NeZero n. This is the concrete size relation that places the cyclic rotation subgroup at index 2 inside D_n, turning the abstract |G| = 2|H| hypothesis of dihedral_doubling into the genuine dihedral instance.",
+      "mathContext": "$|D_n| = 2n = 2\\,|\\mathbb{Z}/n\\mathbb{Z}|$ (index-2 rotation subgroup)."
     },
     {
       "id": "numeric",


### PR DESCRIPTION
Enrichment pass for `burnside-counting-oq-04` (quality 96 → 100, passes 0).

**What changed** (meta.json only):
- Added a substantive 5th `keyInsight`: the reflections form a *coset* G∖H, not a subgroup, so Σ_{g∉H}|Fix(g)| is not itself any group's orbit-count and can't be simplified by Burnside — which is exactly *why* folding (subtracting the two Burnside instances) is the right tool and why the theorem needs only H ≤ G with no structure on the complement.
- Split the over-bundled `doubling` section (was lines 101–127, containing two distinct theorems) at the real theorem boundary: `doubling` now covers `dihedral_doubling` (101–121), and a new `dihedral-order` section covers `dihedralGroup_card` / |D_n| = 2n (122–128). Sections now tile the file 1–67, 68–99, 101–121, 122–128, 129–157.

No existing content deleted. File 14.6 KB (well under 60 KB cap); keyInsights 5 (≤12), crossReferences 3, references 2. JSON validated. Axiom integrity unchanged and confirmed against source: status verified, axiomCount 0, no native_decide (the numeric corollary takes the necklace/reflection counts as hypotheses — an exact algebraic reduction, accurately disclosed in the existing prose).