### PR TITLE
Research (researcher-1 batch): e-transcendental occurrence enumeration + v4.31 deprecation cleanup across 8 gallery files + roth/erdos-117 integrity

### DIFF
--- a/proofs/Proofs/AbelRuffiniGaloisExtensionsOQ06GaloisDirection.lean
+++ b/proofs/Proofs/AbelRuffiniGaloisExtensionsOQ06GaloisDirection.lean
@@ -137,7 +137,7 @@ theorem normalSubgroup_isTransitive_of_nontrivial
   -- Faithfulness of the `A`-action (`A ≤ H ≤ S_p`) yields a moved point.
   have hmove : ∃ a : ZMod p, g • a ≠ a := by
     by_contra hcon
-    push_neg at hcon
+    push Not at hcon
     exact hg (eq_of_smul_eq_smul (fun a => by rw [hcon a, one_smul]))
   obtain ⟨a₀, ha₀⟩ := hmove
   -- The `A`-orbit of `a₀` is a block (orbit of a normal subgroup).

--- a/proofs/Proofs/AbelRuffiniGaloisExtensionsOQ06GaloisDirectionStep1.lean
+++ b/proofs/Proofs/AbelRuffiniGaloisExtensionsOQ06GaloisDirectionStep1.lean
@@ -157,7 +157,7 @@ theorem normalSubgroup_isTransitive_of_nontrivial
   -- `Perm.applyFaithfulSMul` and the subgroup instance) yields a moved point.
   have hmove : ∃ a : ZMod p, g • a ≠ a := by
     by_contra hcon
-    push_neg at hcon
+    push Not at hcon
     exact hg (eq_of_smul_eq_smul (fun a => by rw [hcon a, one_smul]))
   obtain ⟨a₀, ha₀⟩ := hmove
   -- The `A`-orbit of `a₀` is a block (orbit of a normal subgroup).

--- a/proofs/Proofs/ETranscendentalOQ02.lean
+++ b/proofs/Proofs/ETranscendentalOQ02.lean
@@ -2299,4 +2299,113 @@ theorem e_disjunctive (b k : ℕ) (hb : 2 ≤ b) (s : Fin k → Fin b) :
     ∃ n : ℕ, ∀ i : Fin k, nthDigit b (n + i.val) (Real.exp 1) = (s i : ℤ) :=
   absolutely_normal_imp_disjunctive (Real.exp 1) e_absolutely_normal b k hb s
 
+-- ============================================================
+-- PART IV.9.a: EXPLICIT MONOTONE ENUMERATION OF OCCURRENCES
+-- ============================================================
+
+/-!
+## From effective recurrence to an explicit occurrence sequence
+
+`next_occurrence_lt_of_modulus` guarantees, for every threshold `P`, an
+occurrence of the tuple `s` in the window `[P, N₀(P))` with the explicit bound
+`N₀(P) = max (max (M k (b^{-k}/2)) 1) (2·bᵏ·P + 1)`. Iterating it with
+`P := previous + 1` produces an **explicit strictly increasing** enumeration
+`occSeq 0 < occSeq 1 < …` of positions at which the tuple `s` occurs, each
+successor bounded by the effective gap function of its predecessor. This upgrades
+the qualitative `normal_ktuple_infinitely_often` (an infinite occurrence *set*)
+to a concrete monotone *sequence* with modulus-controlled gaps — the form a
+downstream quantitative argument iterates over.
+-/
+
+/-- The next occurrence position of the tuple `s` at or after the threshold `P`,
+    chosen from `next_occurrence_lt_of_modulus`. -/
+noncomputable def nextOcc (b : ℕ) (hb : 2 ≤ b) (x : ℝ) (M : ℕ → ℝ → ℕ)
+    (hM : EffectivelyNormalWithModulus b x M) (k : ℕ) (s : Fin k → Fin b)
+    (P : ℕ) : ℕ :=
+  (next_occurrence_lt_of_modulus b hb x M hM k s P).choose
+
+/-- `nextOcc` lands at or after its threshold. -/
+theorem nextOcc_ge (b : ℕ) (hb : 2 ≤ b) (x : ℝ) (M : ℕ → ℝ → ℕ)
+    (hM : EffectivelyNormalWithModulus b x M) (k : ℕ) (s : Fin k → Fin b) (P : ℕ) :
+    P ≤ nextOcc b hb x M hM k s P :=
+  (next_occurrence_lt_of_modulus b hb x M hM k s P).choose_spec.1
+
+/-- `nextOcc` obeys the explicit effective gap bound of `next_occurrence_lt_of_modulus`. -/
+theorem nextOcc_lt (b : ℕ) (hb : 2 ≤ b) (x : ℝ) (M : ℕ → ℝ → ℕ)
+    (hM : EffectivelyNormalWithModulus b x M) (k : ℕ) (s : Fin k → Fin b) (P : ℕ) :
+    nextOcc b hb x M hM k s P <
+      max (max (M k ((b : ℝ) ^ (-(k : ℤ)) / 2)) 1) (2 * b ^ k * P + 1) :=
+  (next_occurrence_lt_of_modulus b hb x M hM k s P).choose_spec.2.1
+
+/-- `nextOcc` is a genuine occurrence: the block of digits starting there matches `s`. -/
+theorem nextOcc_isMatch (b : ℕ) (hb : 2 ≤ b) (x : ℝ) (M : ℕ → ℝ → ℕ)
+    (hM : EffectivelyNormalWithModulus b x M) (k : ℕ) (s : Fin k → Fin b) (P : ℕ)
+    (i : Fin k) :
+    nthDigit b (nextOcc b hb x M hM k s P + i.val) x = (s i : ℤ) :=
+  (next_occurrence_lt_of_modulus b hb x M hM k s P).choose_spec.2.2 i
+
+/-- Explicit enumeration of occurrence positions of the tuple `s`: `occSeq 0` is
+    the first occurrence (threshold `0`), and `occSeq (j+1)` is the next
+    occurrence strictly after `occSeq j` (threshold `occSeq j + 1`). -/
+noncomputable def occSeq (b : ℕ) (hb : 2 ≤ b) (x : ℝ) (M : ℕ → ℝ → ℕ)
+    (hM : EffectivelyNormalWithModulus b x M) (k : ℕ) (s : Fin k → Fin b) :
+    ℕ → ℕ
+  | 0 => nextOcc b hb x M hM k s 0
+  | (j + 1) => nextOcc b hb x M hM k s (occSeq b hb x M hM k s j + 1)
+
+/-- Every term of `occSeq` is a genuine occurrence of the tuple `s`. -/
+theorem occSeq_isMatch (b : ℕ) (hb : 2 ≤ b) (x : ℝ) (M : ℕ → ℝ → ℕ)
+    (hM : EffectivelyNormalWithModulus b x M) (k : ℕ) (s : Fin k → Fin b)
+    (j : ℕ) (i : Fin k) :
+    nthDigit b (occSeq b hb x M hM k s j + i.val) x = (s i : ℤ) := by
+  cases j with
+  | zero => exact nextOcc_isMatch b hb x M hM k s 0 i
+  | succ n => exact nextOcc_isMatch b hb x M hM k s (occSeq b hb x M hM k s n + 1) i
+
+/-- The occurrence enumeration is strictly increasing: each next occurrence is
+    taken strictly after its predecessor (threshold `occSeq n + 1`), so
+    `occSeq n < occSeq (n+1)`. -/
+theorem occSeq_strictMono (b : ℕ) (hb : 2 ≤ b) (x : ℝ) (M : ℕ → ℝ → ℕ)
+    (hM : EffectivelyNormalWithModulus b x M) (k : ℕ) (s : Fin k → Fin b) :
+    StrictMono (occSeq b hb x M hM k s) := by
+  apply strictMono_nat_of_lt_succ
+  intro n
+  have h := nextOcc_ge b hb x M hM k s (occSeq b hb x M hM k s n + 1)
+  have heq : occSeq b hb x M hM k s (n + 1)
+      = nextOcc b hb x M hM k s (occSeq b hb x M hM k s n + 1) := rfl
+  omega
+
+/-- The gap between consecutive occurrences is controlled by the modulus: the
+    successor `occSeq (n+1)` lies below the explicit bound
+    `max (max (M k (b^{-k}/2)) 1) (2·bᵏ·(occSeq n + 1) + 1)`. -/
+theorem occSeq_succ_lt (b : ℕ) (hb : 2 ≤ b) (x : ℝ) (M : ℕ → ℝ → ℕ)
+    (hM : EffectivelyNormalWithModulus b x M) (k : ℕ) (s : Fin k → Fin b) (n : ℕ) :
+    occSeq b hb x M hM k s (n + 1) <
+      max (max (M k ((b : ℝ) ^ (-(k : ℤ)) / 2)) 1)
+          (2 * b ^ k * (occSeq b hb x M hM k s n + 1) + 1) := by
+  have h := nextOcc_lt b hb x M hM k s (occSeq b hb x M hM k s n + 1)
+  show nextOcc b hb x M hM k s (occSeq b hb x M hM k s n + 1) <
+      max (max (M k ((b : ℝ) ^ (-(k : ℤ)) / 2)) 1)
+          (2 * b ^ k * (occSeq b hb x M hM k s n + 1) + 1)
+  exact h
+
+/-- **Explicit monotone enumeration of occurrences.** From a modulus of
+    normality there is a strictly increasing sequence `f : ℕ → ℕ` all of whose
+    terms are occurrences of the tuple `s`, with each successor bounded by the
+    effective gap function of its predecessor. This is the sequence-level packaging
+    of `next_occurrence_lt_of_modulus`, making the infinitude of occurrences
+    (`normal_ktuple_infinitely_often`) concrete and quantitatively iterable. -/
+theorem exists_strictMono_occurrence_enumeration (b : ℕ) (hb : 2 ≤ b) (x : ℝ)
+    (M : ℕ → ℝ → ℕ) (hM : EffectivelyNormalWithModulus b x M) (k : ℕ)
+    (s : Fin k → Fin b) :
+    ∃ f : ℕ → ℕ, StrictMono f ∧
+      (∀ (j : ℕ) (i : Fin k), nthDigit b (f j + i.val) x = (s i : ℤ)) ∧
+      (∀ n : ℕ, f (n + 1) <
+        max (max (M k ((b : ℝ) ^ (-(k : ℤ)) / 2)) 1)
+            (2 * b ^ k * (f n + 1) + 1)) :=
+  ⟨occSeq b hb x M hM k s,
+   occSeq_strictMono b hb x M hM k s,
+   occSeq_isMatch b hb x M hM k s,
+   occSeq_succ_lt b hb x M hM k s⟩
+
 end ETranscendentalOQ02

--- a/proofs/Proofs/Erdos1090Problem.lean
+++ b/proofs/Proofs/Erdos1090Problem.lean
@@ -645,7 +645,7 @@ instance : Infinite Point :=
     have hb : EuclideanSpace.single (0 : Fin 2) a = EuclideanSpace.single (0 : Fin 2) b := h
     have h0 : (EuclideanSpace.single (0 : Fin 2) a) 0
             = (EuclideanSpace.single (0 : Fin 2) b) 0 := by rw [hb]
-    simpa [EuclideanSpace.single_apply] using h0)
+    simpa [PiLp.single_apply] using h0)
 
 /--
 **Every size above `R(k)` is realizable.**

--- a/proofs/Proofs/Erdos165Problem.lean
+++ b/proofs/Proofs/Erdos165Problem.lean
@@ -34,7 +34,7 @@
 import Mathlib.Combinatorics.SimpleGraph.Basic
 import Mathlib.Data.Nat.Basic
 import Mathlib.Data.Real.Basic
-import Mathlib.Data.Real.Sqrt
+import Mathlib.Analysis.Real.Sqrt
 import Mathlib.Analysis.SpecialFunctions.Log.Basic
 
 open Real
@@ -250,7 +250,7 @@ theorem asymptotic_constant_le
     (upper : ∀ ε > 0, ∃ k₀ : ℕ, ∀ k : ℕ, k ≥ k₀ → f k ≤ (b + ε) * k^2 / log k) :
     a ≤ b := by
   by_contra h
-  push_neg at h          -- h : b < a
+  push Not at h          -- h : b < a
   set ε := (a - b) / 4 with hε_def
   have hε : ε > 0 := by rw [hε_def]; linarith
   obtain ⟨k₁, hk₁⟩ := lower ε hε
@@ -370,10 +370,10 @@ theorem constantConjecture_forces_bracket (c : ℝ) (h : constantConjecture c) :
     (1:ℝ)/2 ≤ c ∧ c ≤ 1 := by
   refine ⟨?_, ?_⟩
   · by_contra hlt
-    push_neg at hlt
+    push Not at hlt
     exact constantConjecture_refuted_of_lt_half c hlt h
   · by_contra hgt
-    push_neg at hgt
+    push Not at hgt
     exact constantConjecture_refuted_of_one_lt c hgt h
 
 /-- **Uniqueness of the exact asymptotic constant.**  At most one constant can be the

--- a/proofs/Proofs/Erdos3Problem.lean
+++ b/proofs/Proofs/Erdos3Problem.lean
@@ -422,8 +422,8 @@ theorem containsAP_two_of_lt {A : Set ℕ} {a b : ℕ}
 theorem containsAP_two_of_infinite {A : Set ℕ} (h : A.Infinite) :
     ContainsAP A 2 := by
   obtain ⟨a, ha⟩ := h.nonempty
-  obtain ⟨b, hb⟩ := (h.diff (Set.finite_singleton a)).nonempty
-  rw [Set.mem_diff, Set.mem_singleton_iff] at hb
+  obtain ⟨b, hb⟩ := (h.sdiff (Set.finite_singleton a)).nonempty
+  rw [Set.mem_sdiff, Set.mem_singleton_iff] at hb
   obtain ⟨hbA, hbne⟩ := hb
   rcases lt_trichotomy a b with hlt | heq | hgt
   · exact containsAP_two_of_lt ha hbA hlt

--- a/proofs/Proofs/Erdos490Chebyshev.lean
+++ b/proofs/Proofs/Erdos490Chebyshev.lean
@@ -47,7 +47,7 @@ lemma small_prime_prod_le (n : ℕ) (hn : 0 < n) :
     obtain ⟨h1, h2⟩ := Finset.mem_filter.1 hx
     exact Finset.mem_Icc.mpr ⟨(Finset.mem_filter.1 h1).2.one_lt.le, h2⟩
   · -- primes `√(2n) < p ≤ 2n/3`: each has multiplicity `≤ 1`, product `≤ primorial ≤ 4^(2n/3)`.
-    refine le_trans ?_ (primorial_le_4_pow (2 * n / 3))
+    refine le_trans ?_ (primorial_le_four_pow (2 * n / 3))
     refine (Finset.prod_le_prod' fun p hp => (?_ : f p ≤ p)).trans ?_
     · obtain ⟨h1, h2⟩ := Finset.mem_filter.1 hp
       refine (pow_right_mono₀ (Finset.mem_filter.1 h1).2.one_lt.le ?_).trans (pow_one p).le
@@ -83,7 +83,7 @@ theorem centralBinom_le_small_mul_large (n : ℕ) (hn : 2 < n) :
       simp only [Finset.mem_filter, Finset.mem_range] at hx hxnot
       by_cases hxp : x.Prime
       · have hgt : 2 * n / 3 < x := by
-          by_contra h; push_neg at h
+          by_contra h; push Not at h
           exact hxnot ⟨by omega, hxp⟩
         rw [Nat.factorization_centralBinom_of_two_mul_self_lt_three_mul hn (by omega) (by omega),
           pow_zero]
@@ -153,7 +153,7 @@ theorem theta_gap_eq_log_prod (n : ℕ) :
     constructor
     · rintro ⟨⟨⟨hp0, hp2n⟩, hpr⟩, hnot⟩
       refine ⟨by omega, ?_, hpr⟩
-      by_contra h; push_neg at h; exact hnot ⟨⟨hp0, by omega⟩, hpr⟩
+      by_contra h; push Not at h; exact hnot ⟨⟨hp0, by omega⟩, hpr⟩
     · rintro ⟨_, hnp, hpr⟩
       exact ⟨⟨⟨hpr.pos, by omega⟩, hpr⟩, by rintro ⟨⟨_, h2⟩, _⟩; omega⟩
   rw [e1, e2, ← Finset.sum_sdiff_eq_sub hsub, hset, Nat.cast_prod]

--- a/proofs/Proofs/Erdos490OQ01.lean
+++ b/proofs/Proofs/Erdos490OQ01.lean
@@ -266,7 +266,7 @@ theorem limit_in_sandwich :
   · obtain ⟨c, hc_pos, hc_bound⟩ := productRatio_bounded_below
     refine ⟨c, hc_pos, ?_⟩
     by_contra h
-    push_neg at h
+    push Not at h
     have hε : 0 < c - L := by linarith
     obtain ⟨N₀, hN₀⟩ := hL (c - L) hε
     have hN₀_bound := hN₀ (max N₀ 2) (by omega) (by omega)
@@ -276,7 +276,7 @@ theorem limit_in_sandwich :
   · obtain ⟨C, hC_pos, hC_bound⟩ := productRatio_bounded_above
     refine ⟨C, hC_pos, ?_⟩
     by_contra h
-    push_neg at h
+    push Not at h
     have hε : 0 < L - C := by linarith
     obtain ⟨N₀, hN₀⟩ := hL (L - C) hε
     have hN₀_bound := hN₀ (max N₀ 2) (by omega) (by omega)

--- a/proofs/Proofs/Erdos490Problem.lean
+++ b/proofs/Proofs/Erdos490Problem.lean
@@ -306,7 +306,7 @@ theorem theta_gap_eq_sum_optimalB (N : ℕ) :
     constructor
     · rintro ⟨⟨⟨hp0, hpN⟩, hpr⟩, hnot⟩
       refine ⟨by omega, hpr, ?_, hpN⟩
-      by_contra h; push_neg at h
+      by_contra h; push Not at h
       exact hnot ⟨⟨hp0, by omega⟩, hpr⟩
     · rintro ⟨_, hpr, hlt, hle⟩
       exact ⟨⟨⟨hpr.pos, hle⟩, hpr⟩, by rintro ⟨⟨_, h2⟩, _⟩; omega⟩
@@ -501,7 +501,7 @@ theorem optimalB_card_eq_primeCounting (N : ℕ) :
     · rintro ⟨_, hp, hle⟩; exact ⟨by omega, hp⟩
     · rintro ⟨hlt, hp⟩; exact ⟨by omega, hp, by omega⟩
   -- Partition the primes `≤ N` by whether they exceed `N/2`.
-  have hpart := Finset.filter_card_add_filter_neg_card_eq_card
+  have hpart := Finset.card_filter_add_card_filter_not
     (s := (Finset.range (N + 1)).filter Nat.Prime) (p := fun p => N / 2 < p)
   rw [Finset.filter_filter, Finset.filter_filter, ← hB, hlow] at hpart
   rw [hπ N, hπ (N / 2)]
@@ -668,7 +668,7 @@ theorem isMultiplicativeSidon_iff_card_le_one (A : Finset ℕ) :
   constructor
   · intro h
     by_contra hc
-    push_neg at hc
+    push Not at hc
     obtain ⟨a, ha, b, hb, hab⟩ := Finset.one_lt_card.mp hc
     exact hab (h a b b a ha hb hb ha (by ring)).1
   · intro h a₁ a₂ b₁ b₂ ha₁ ha₂ hb₁ hb₂ _

--- a/proofs/Proofs/Erdos659Problem.lean
+++ b/proofs/Proofs/Erdos659Problem.lean
@@ -23,7 +23,7 @@
 
 import Mathlib.Analysis.SpecialFunctions.Log.Basic
 import Mathlib.Analysis.SpecialFunctions.Pow.Real
-import Mathlib.Data.Real.Sqrt
+import Mathlib.Analysis.Real.Sqrt
 import Mathlib.Data.Finset.Card
 import Mathlib.Topology.MetricSpace.Basic
 import Mathlib.Tactic
@@ -603,13 +603,13 @@ theorem thirtyfive_not_representable : 35 ∉ representable_x2_2y2 := by
   rw [representable_iff_nat]
   rintro ⟨a, b, hab⟩
   have ha : a ≤ 5 := by
-    by_contra hcon; push_neg at hcon
+    by_contra hcon; push Not at hcon
     have h36 : 36 ≤ a ^ 2 := by
       calc 36 = 6 ^ 2 := by norm_num
         _ ≤ a ^ 2 := Nat.pow_le_pow_left hcon 2
     omega
   have hb : b ≤ 4 := by
-    by_contra hcon; push_neg at hcon
+    by_contra hcon; push Not at hcon
     have h25 : 25 ≤ b ^ 2 := by
       calc 25 = 5 ^ 2 := by norm_num
         _ ≤ b ^ 2 := Nat.pow_le_pow_left hcon 2
@@ -656,7 +656,7 @@ theorem fourPointProperty_from_avoiding_configs (S : Finset (ℝ × ℝ))
     intro he
     exact hcfg ⟨hT4, he, trivial⟩
   by_contra hContra
-  push_neg at hContra  -- distinctDistances T < 3
+  push Not at hContra  -- distinctDistances T < 3
   omega
 
 /-! ## More closure structure and explicit families of representable numbers

--- a/proofs/Proofs/Erdos666Problem.lean
+++ b/proofs/Proofs/Erdos666Problem.lean
@@ -486,7 +486,7 @@ artifact: the counterexamples occur for arbitrarily large `n`.  Pure logic (De M
 theorem conder_counterexamples_unbounded :
     ∀ N : ℕ, ∃ n, N ≤ n ∧ ¬ DenseForcesC6 n (1/3) := by
   by_contra h
-  push_neg at h
+  push Not at h
   obtain ⟨N, hN⟩ := h
   exact conder_no_threshold ⟨N, hN⟩
 

--- a/proofs/Proofs/Erdos703Problem.lean
+++ b/proofs/Proofs/Erdos703Problem.lean
@@ -1288,7 +1288,7 @@ theorem T_L_eq_pow_iff {n : ℕ} {L : Finset ℕ} :
   constructor
   · intro h
     by_contra hcon
-    push_neg at hcon
+    push Not at hcon
     obtain ⟨r, hrL, hrn⟩ := hcon
     have hle : T_L n L ≤ 2 ^ n - 1 := T_L_le_pow_sub_one hrL hrn
     have hpos : 0 < 2 ^ n := pow_pos (by norm_num) n

--- a/proofs/Proofs/Erdos744Problem.lean
+++ b/proofs/Proofs/Erdos744Problem.lean
@@ -199,7 +199,7 @@ theorem bipartitionNumber_pos_iff {V : Type*} [Fintype V] [LinearOrder V]
   constructor
   · intro h c
     have hc := h c
-    push_neg at hc
+    push Not at hc
     exact hc
   · intro h c hc
     obtain ⟨u, v, hadj, huv⟩ := h c
@@ -292,7 +292,7 @@ theorem monochromaticEdges_add_bichromaticEdges {V : Type*} [Fintype V] [LinearO
           (fun p => ¬ c p.1 = c p.2)).card := by
     rw [bichromaticEdges, Finset.filter_filter]
     congr 1; ext p; simp only [Finset.mem_filter, ne_eq]; tauto
-  rw [hmono, hbi, Finset.filter_card_add_filter_neg_card_eq_card]
+  rw [hmono, hbi, Finset.card_filter_add_card_filter_not]
   rfl
 
 /-- **Max-cut of `G`.** The maximum number of edges separated by a 2-coloring,
@@ -503,7 +503,7 @@ theorem card_colorings_cut {V : Type*} [Fintype V] [LinearOrder V] (u v : V)
   have hpart : (Finset.univ.filter (fun c : V → Bool => c u ≠ c v)).card
       + (Finset.univ.filter (fun c : V → Bool => ¬ c u ≠ c v)).card
       = Fintype.card (V → Bool) := by
-    rw [Finset.filter_card_add_filter_neg_card_eq_card]; rfl
+    rw [Finset.card_filter_add_card_filter_not]; rfl
   have hcard : (Finset.univ.filter (fun c : V → Bool => c u ≠ c v)).card
       = (Finset.univ.filter (fun c : V → Bool => ¬ c u ≠ c v)).card := by
     apply Finset.card_bij'
@@ -834,7 +834,7 @@ theorem monochromaticEdges_add_complement {V : Type*} [Fintype V] [LinearOrder V
     simp only [Finset.mem_filter, Finset.mem_univ, true_and, complement]
     exact ⟨fun ⟨h1, ⟨_, h3⟩, h4⟩ => ⟨⟨h1, h4⟩, h3⟩,
       fun ⟨⟨h1, h4⟩, h3⟩ => ⟨h1, ⟨ne_of_lt h1, h3⟩, h4⟩⟩
-  rw [hbase, hG, hGc, Finset.filter_card_add_filter_neg_card_eq_card]
+  rw [hbase, hG, hGc, Finset.card_filter_add_card_filter_not]
 
 /-- `edgeCount` is the monochromatic count of the constant `true` coloring: every
 edge is monochromatic when all endpoints share a color. -/
@@ -1022,7 +1022,7 @@ shows f_k(n) never exceeds this bound.
 -/
 theorem erdos_conjecture_false : ¬erdosOriginalConjecture := by
   unfold erdosOriginalConjecture
-  push_neg
+  push Not
   use 4
   constructor
   · norm_num

--- a/proofs/Proofs/Erdos771Construction.lean
+++ b/proofs/Proofs/Erdos771Construction.lean
@@ -672,7 +672,7 @@ theorem avoid_low_card_le (n m : ℕ) (hm : 1 ≤ m)
 theorem avoid_card_le_general (n m : ℕ) (hm : 1 ≤ m) (hmn : m ≤ n)
     (S : Finset ℕ) (hS : S ⊆ Icc_n n) (hav : AvoidSum S m) :
     S.card ≤ n - (m + 1) / 2 := by
-  have hsplit := Finset.filter_card_add_filter_neg_card_eq_card (s := S) (p := (· ≤ m))
+  have hsplit := Finset.card_filter_add_card_filter_not (s := S) (p := (· ≤ m))
   have hlow : (S.filter (· ≤ m)).card ≤ m / 2 := avoid_low_card_le n m hm S hS hav
   have hhigh : (S.filter (fun x => ¬ x ≤ m)).card ≤ n - m := by
     have hsub : S.filter (fun x => ¬ x ≤ m) ⊆ Finset.Icc (m + 1) n := by

--- a/proofs/Proofs/Erdos897OQ01.lean
+++ b/proofs/Proofs/Erdos897OQ01.lean
@@ -278,7 +278,7 @@ theorem stronglyAdditive_unboundedOnPrimePowers_iff {f : ℕ → ℝ}
       have hdrop : M * Real.log p ≤ M * ((k : ℝ) * Real.log p) := by
         nlinarith [mul_nonneg (mul_nonneg hM (by linarith : (0 : ℝ) ≤ (k : ℝ) - 1)) hlogp]
       linarith
-    · push_neg at hM
+    · push Not at hM
       obtain ⟨p, k, hp, hk, hpk⟩ := h 0
       refine ⟨p, hp, ?_⟩
       have hfp : f (p ^ k) = f p := hf.2 p k hp hk
@@ -314,7 +314,7 @@ completely-additive reduction it would require some prime with `Ω(p) = 1 > M·l
 every `M`; at `M = 1/log 2` this forces `log p < log 2`, impossible for a prime `p ≥ 2`. -/
 theorem not_unboundedOnPrimePowers_bigOmega : ¬ UnboundedOnPrimePowers bigOmega := by
   rw [completelyAdditive_unboundedOnPrimePowers_iff bigOmega bigOmega_completelyAdditive]
-  push_neg
+  push Not
   refine ⟨1 / Real.log 2, ?_⟩
   intro p hp
   rw [bigOmega_prime hp]
@@ -512,7 +512,7 @@ theorem not_unboundedOnPrimePowers_smul {f : ℕ → ℝ}
     (hf : ¬ UnboundedOnPrimePowers f) {c : ℝ} (hc : 0 ≤ c) :
     ¬ UnboundedOnPrimePowers (fun n => c * f n) := by
   unfold UnboundedOnPrimePowers at hf
-  push_neg at hf
+  push Not at hf
   obtain ⟨M, hM⟩ := hf
   apply not_unboundedOnPrimePowers_of_le_const_mul_log (C := c * M)
   intro p k hp hk
@@ -567,7 +567,7 @@ theorem not_unboundedOnPrimePowers_max {f g : ℕ → ℝ}
     (hf : ¬ UnboundedOnPrimePowers f) (hg : ¬ UnboundedOnPrimePowers g) :
     ¬ UnboundedOnPrimePowers (fun n => max (f n) (g n)) := by
   unfold UnboundedOnPrimePowers at hf hg
-  push_neg at hf hg
+  push Not at hf hg
   obtain ⟨Mf, hMf⟩ := hf
   obtain ⟨Mg, hMg⟩ := hg
   refine not_unboundedOnPrimePowers_of_le_const_mul_log
@@ -662,7 +662,7 @@ theorem not_unboundedOnPrimePowers_add {f g : ℕ → ℝ}
     (hf : ¬ UnboundedOnPrimePowers f) (hg : ¬ UnboundedOnPrimePowers g) :
     ¬ UnboundedOnPrimePowers (fun n => f n + g n) := by
   unfold UnboundedOnPrimePowers at hf hg
-  push_neg at hf hg
+  push Not at hf hg
   obtain ⟨Mf, hMf⟩ := hf
   obtain ⟨Mg, hMg⟩ := hg
   refine not_unboundedOnPrimePowers_of_le_const_mul_log
@@ -764,7 +764,7 @@ theorem not_unboundedOnPrimePowers_iff {f : ℕ → ℝ} :
     ¬ UnboundedOnPrimePowers f ↔
       ∃ M : ℝ, ∀ p k : ℕ, p.Prime → 1 ≤ k → f (p ^ k) ≤ M * Real.log (p ^ k) := by
   unfold UnboundedOnPrimePowers
-  push_neg
+  push Not
   rfl
 
 /-- **Explicit witness value on a prime power.** `logSqWeight (p^k) = (log p)²` for prime

--- a/proofs/Proofs/PuiseuxTheorem.lean
+++ b/proofs/Proofs/PuiseuxTheorem.lean
@@ -703,7 +703,7 @@ theorem isPuiseux_mul {K : Type*} [NonUnitalNonAssocSemiring K] {f g : HahnSerie
   have hn0 : ((n : ℕ) : ℚ) ≠ 0 := by exact_mod_cast n.pos.ne'
   have hm0 : ((m : ℕ) : ℚ) ≠ 0 := by exact_mod_cast m.pos.ne'
   refine ⟨n * m, fun q hq => ?_⟩
-  obtain ⟨a, ha, b, hb, hab⟩ := Set.mem_add.mp (HahnSeries.support_mul_subset_add_support hq)
+  obtain ⟨a, ha, b, hb, hab⟩ := Set.mem_add.mp (HahnSeries.support_mul_subset hq)
   obtain ⟨k, hk⟩ := hn a ha
   obtain ⟨l, hl⟩ := hm b hb
   refine ⟨k * (m : ℤ) + l * (n : ℤ), ?_⟩
@@ -1032,7 +1032,7 @@ theorem isPuiseuxOfRamification_mul {K : Type*} [NonUnitalNonAssocSemiring K] {n
     {f g : HahnSeries ℚ K} (hf : IsPuiseuxOfRamification n f)
     (hg : IsPuiseuxOfRamification n g) : IsPuiseuxOfRamification n (f * g) := by
   intro q hq
-  obtain ⟨a, ha, b, hb, hab⟩ := Set.mem_add.mp (HahnSeries.support_mul_subset_add_support hq)
+  obtain ⟨a, ha, b, hb, hab⟩ := Set.mem_add.mp (HahnSeries.support_mul_subset hq)
   obtain ⟨k, hk⟩ := hf a ha
   obtain ⟨l, hl⟩ := hg b hb
   refine ⟨k + l, ?_⟩

--- a/proofs/Proofs/RothTheoremOQ01Reciprocal.lean
+++ b/proofs/Proofs/RothTheoremOQ01Reciprocal.lean
@@ -529,6 +529,65 @@ theorem exists_height_recip_small (ε : ℝ) (hε : 0 < ε) :
   exact ⟨m, fun A hA hA0 hAmin =>
     (threeAPFree_tsum_reciprocal_le_of_min_ge hA hA0 m hAmin).trans hm.le⟩
 
+/-!
+### Monotone structure of the tail majorant (`recipTail`)
+
+The tail constant `recipTail m = ∑'_k recipMajorant (k + m)` obeys a clean one-step recurrence
+`recipTail m = recipMajorant m + recipTail (m + 1)`: peeling the `k = 0` block off the shifted
+series leaves the next tail.  Equivalently `recipTail (m + 1) = recipTail m − recipMajorant m`.
+Because every block majorant is *strictly* positive, the tail is strictly decreasing in the
+height index `m`, and never exceeds the full absolute constant `recipBound = recipTail 0`.
+This upgrades the qualitative `recipTail_tendsto_zero` into an exact monotone descent — the
+structural prerequisite for an explicit closed-form decay rate (integral comparison for the
+`p`-series tail via `AntitoneOn.sum_le_integral`; see the next-steps note in `state.md`).
+-/
+
+/-- The block majorant is strictly positive. -/
+theorem recipMajorant_pos (k : ℕ) : 0 < recipMajorant k := by
+  unfold recipMajorant
+  exact div_pos (by norm_num) (recipMajorant_denom_pos k)
+
+/-- **One-step recurrence for the tail majorant.**  Peeling the `k = 0` block off the shifted
+series `∑'_k recipMajorant (k + m)` leaves the next tail:
+`recipTail m = recipMajorant m + recipTail (m + 1)`. -/
+theorem recipTail_succ (m : ℕ) :
+    recipTail m = recipMajorant m + recipTail (m + 1) := by
+  have h := (summable_recipMajorant_add m).tsum_eq_zero_add
+  have hcongr : (fun b : ℕ => recipMajorant (b + 1 + m))
+      = (fun b : ℕ => recipMajorant (b + (m + 1))) := by
+    funext b; congr 1; omega
+  unfold recipTail
+  rw [h, zero_add, hcongr]
+
+/-- **Exact one-step decrement.**  `recipTail (m + 1) = recipTail m − recipMajorant m`. -/
+theorem recipTail_succ_eq_sub (m : ℕ) :
+    recipTail (m + 1) = recipTail m - recipMajorant m := by
+  rw [recipTail_succ m]; ring
+
+/-- **The tail majorant is antitone**: `recipTail` decreases (weakly) as the height index grows. -/
+theorem recipTail_antitone : Antitone recipTail := by
+  refine antitone_nat_of_succ_le (fun m => ?_)
+  rw [recipTail_succ_eq_sub m]
+  linarith [recipMajorant_nonneg m]
+
+/-- **The tail majorant is strictly antitone**: each step strictly decreases the tail, since the
+peeled block majorant `recipMajorant m` is strictly positive. -/
+theorem recipTail_strictAnti : StrictAnti recipTail := by
+  refine strictAnti_nat_of_succ_lt (fun m => ?_)
+  rw [recipTail_succ_eq_sub m]
+  linarith [recipMajorant_pos m]
+
+/-- The tail majorant never exceeds the full absolute constant `recipBound = recipTail 0`. -/
+theorem recipTail_le_recipBound (m : ℕ) : recipTail m ≤ recipBound := by
+  rw [← recipTail_zero]
+  exact recipTail_antitone (Nat.zero_le m)
+
+/-- For `m ≥ 1` the tail bound is *strictly* better than the absolute constant `recipBound`:
+forcing a 3-AP-free set up to height `≥ 2^m` genuinely lowers its reciprocal ceiling. -/
+theorem recipTail_lt_recipBound {m : ℕ} (hm : 0 < m) : recipTail m < recipBound := by
+  rw [← recipTail_zero]
+  exact recipTail_strictAnti hm
+
 #check @threeAPFree_summable_reciprocal
 #check @finite_recip_sum_le
 #check @fiber_sum_le
@@ -539,6 +598,10 @@ theorem exists_height_recip_small (ε : ℝ) (hε : 0 < ε) :
 #check @threeAPFree_tsum_reciprocal_le_of_min_ge
 #check @recipTail_tendsto_zero
 #check @exists_height_recip_small
+#check @recipTail_succ
+#check @recipTail_succ_eq_sub
+#check @recipTail_strictAnti
+#check @recipTail_le_recipBound
 
 -- Axiom audit: the reciprocal-sum theorem rests on exactly the single imported Bloom–Sisask
 -- assumption `RothTheoremOQ02.rothNumberNat_bloom_sisask` — no new axiom, no `sorryAx`.
@@ -551,5 +614,7 @@ theorem exists_height_recip_small (ε : ℝ) (hε : 0 < ε) :
 #print axioms dilate_tsum_reciprocal_le
 #print axioms threeAPFree_tsum_reciprocal_le_of_min_ge
 #print axioms exists_height_recip_small
+#print axioms recipTail_succ
+#print axioms recipTail_strictAnti
 
 end RothTheoremOQ01Reciprocal

--- a/research/problems/abel-ruffini-galois-extensions-oq-06-galois-direction/knowledge.md
+++ b/research/problems/abel-ruffini-galois-extensions-oq-06-galois-direction/knowledge.md
@@ -895,3 +895,15 @@ recover the embedding).
 ### Status
 `completed` (unchanged, now re-verified). No PR of Lean content — a session that only audits
 a complete file must not fabricate progress. This PR carries the audit note + follow-up only.
+
+## Session 2026-07-19 (researcher-1) — v4.31 deprecation cleanup (2 push_neg, VERIFIED)
+
+**Triage**: COMPLETE cluster (Galois direction of Galois-1832 primitive-solvable bound;
+main theorem 0-sorry/0-axiom — the many "sorry" grep hits are docstrings). No open PR.
+
+**Genuine action** (migration hygiene): host-verified the cluster GREEN under v4.31.0 (built the
+dep chain AbelRuffiniGaloisExtensions → OQ06 → Step4 host-side). Fixed **2 v4.31 push_neg
+deprecations** → 0: `push_neg at hcon` → `push Not at hcon` in
+`…OQ06GaloisDirectionStep1.lean:160` (pure Mathlib, verified directly) and
+`…OQ06GaloisDirection.lean:140` (verified via the built chain). Both EXIT 0, 0 errors, 0
+deprecations post-fix. Token-only; lineCounts unchanged; 0-sorry/0-axiom unchanged.

--- a/research/problems/area-of-circle-oq-01-oq-02-oq-02-oq-02/knowledge.md
+++ b/research/problems/area-of-circle-oq-01-oq-02-oq-02-oq-02/knowledge.md
@@ -43,3 +43,29 @@ Complex.norm_I, Complex.norm_intCast, one_mul]` collapses ‖i·n·ĉ‖→|n|·
 - **docker-build.sh SIGBUS (exit 135)** on corrupt cache blob `Mathlib/Algebra/Group/Hom/
   Instances.trace` — infra, reproducible 3x. Verified via direct single-file `lean` elaboration
   (LEAN_PATH=main-repo packages+Proofs oleans, `#print axioms` on /tmp copy of WORKTREE file).
+
+## Session 2026-07-19 (researcher-1) — v4.31 integrity + ORIENT: capstone blocker analysis
+
+**Mode**: REVISIT (RICH, depth-4 slug → 0 follow-ups). **Triage**: `AreaOfCircleOQ01OQ02OQ02OQ02.lean`
+host-verified GREEN under v4.31.0 (built the pure-Mathlib dep `Proofs.AreaOfCircleOQ01OQ02OQ02`
+olean, then `lake env lean` the target: EXIT 0, 0 errors, one benign `simpa`→`simp` linter hint
+at :304, NOT a deprecation — left as-is). No v4.31 deprecation debt here.
+
+**Eigenvalue-ladder surface is SATURATED**: 34 theorems already cover the derivative
+Fourier-coefficient magnitudes at orders 1/2/4/m — magnitude identities
+(`norm_fourierCoeffOn_derivᵏ_eq`), strict higher-mode damping (`k²·`, `4·`, `16·`),
+first-harmonic equality cases, and kernel iffs (`fourierCoeffOn_derivᵏ_eq_zero_iff`). Adding
+another mode-wise inequality would be accretion.
+
+**Capstone blocker (why nextSteps 1–3 are a distinct BUILD, not a quick lemma):** every theorem
+here is phrased with **`fourierCoeffOn hab (ofReal ∘ f) n`** (Mathlib's *interval* coefficient on
+`[a,b]`), whereas the three open next steps — reconstruct `f = a·cos t + b·sin t` from
+`∀|n|≠1, ĉₙ f = 0`, and assemble `C² ≥ 4πA` — require **Fourier inversion / `hasSum_fourier_series`
+on `AddCircle T`** (the *summed-series* direction, absent from this file entirely). The missing
+infrastructure is the bridge `fourierCoeffOn` (interval, ℝ→ℝ via `ofReal`) ↔ `fourierCoeff`
+(`AddCircle`, the space where `hasSum_fourier_series` / `fourierCoeff_eq_...` live), plus L²/continuity
+membership and summability side-goals. That bridge is the real next unit of work; it is materially
+new mechanism, not covered by the present ladder. Recorded as a structured blocker.
+
+**Outcome**: no code change (file already v4.31-green + ladder saturated); released with the
+capstone-infrastructure blocker documented for the next session.

--- a/research/problems/e-transcendental-oq-02-oq-06/knowledge.md
+++ b/research/problems/e-transcendental-oq-02-oq-06/knowledge.md
@@ -189,3 +189,53 @@ theory, not the open core.
 - Iterate `next_occurrence_lt_of_modulus` (with `P := previous+1`) to build an
   explicit strictly-increasing enumeration of occurrence positions with
   modulus-controlled gaps.
+
+## Session 2026-07-19 (Researcher-1) — Explicit monotone occurrence enumeration
+
+**Mode**: REVISIT (RICH) | **Outcome**: progress (VERIFIED, 0 sorry, 0 new axiom)
+
+### What I did
+Executed the standing "Next steps" from the 2026-07-11 session: iterated
+`next_occurrence_lt_of_modulus` (with `P := previous + 1`) into an **explicit
+strictly-increasing enumeration** of tuple-occurrence positions. Added PART IV.9.a
+to `ETranscendentalOQ02.lean`:
+
+- `nextOcc` (noncomputable def) — the next occurrence position at/after threshold
+  `P`, extracted from `next_occurrence_lt_of_modulus` via `Classical.choose`; with
+  spec projections `nextOcc_ge` / `nextOcc_lt` / `nextOcc_isMatch`.
+- `occSeq` (noncomputable def) — the enumeration: `occSeq 0 = nextOcc 0`,
+  `occSeq (j+1) = nextOcc (occSeq j + 1)`.
+- `occSeq_isMatch` — every term is a genuine occurrence of `s`.
+- `occSeq_strictMono` — `StrictMono occSeq` (successor taken at threshold
+  `occSeq n + 1 > occSeq n`, so `occSeq n < occSeq (n+1)`).
+- `occSeq_succ_lt` — each successor obeys the effective gap bound
+  `max (max (M k (b^{-k}/2)) 1) (2·bᵏ·(occSeq n + 1) + 1)`.
+- `exists_strictMono_occurrence_enumeration` — headline packaging: a `StrictMono`
+  `f : ℕ → ℕ` all of whose terms are occurrences with modulus-controlled gaps.
+
+### Key findings
+- Upgrades the qualitative `normal_ktuple_infinitely_often` (an infinite occurrence
+  *set*) to a concrete monotone *sequence* — the form a downstream quantitative
+  argument iterates over. All results are corollaries of the already-verified
+  `next_occurrence_lt_of_modulus`; the only tool beyond it is `Classical.choose`,
+  so no new axiom is introduced.
+- Structural recursion in `occSeq` produces the definitional equations by `rfl`,
+  so `occSeq_strictMono` / `occSeq_succ_lt` close by rewriting to `nextOcc` +
+  `omega`.
+
+### Status
+Core axiom `e_absolutely_normal` remains **genuinely open** (no base proved normal
+for `e` as of 2026) — not eliminable. The oq-06 target (`normal_imp_irrational`)
+was long discharged as a theorem. This session sharpens the effective theory into
+a usable enumeration; it does not touch the open core.
+
+### Files modified
+- `proofs/Proofs/ETranscendentalOQ02.lean` (+7 theorems, +2 defs, PART IV.9.a; 2302→2411 lines)
+- `src/data/proofs/e-transcendental-oq-02/meta.json` (lineCount→2411, theoremCount→108; corrected prior drift from stale 2160/92)
+- `src/data/research/problems/e-transcendental-oq-02-oq-06.json` (knowledge)
+
+### Next steps
+- The enumeration is now the natural handle for a *lower bound* on the occurrence
+  count in `[0, N)` via `occSeq`-index counting — an explicit inverse to the gap
+  bound. Only pursue if a downstream consumer needs it; otherwise oq-06 is
+  saturated (core discharged, open core not eliminable).

--- a/research/problems/erdos-1090-incomplete-01/knowledge.md
+++ b/research/problems/erdos-1090-incomplete-01/knowledge.md
@@ -337,3 +337,22 @@ confirmed Sylvester–GALLAI is still NOT in Mathlib (the only `Sylvester` hits 
 the Sylvester *matrix*/resultant and Sylvester's law of inertia, unrelated);
 quantitative NUMERIC upper bound on R(k) (HJ dimension non-explicit); projection-
 body dedup (3 verified copies).
+
+## Session 2026-07-19 (researcher-1) — v4.31 integrity build + EuclideanSpace deprecation fix (VERIFIED)
+
+**Mode**: REVISIT (RICH). **Triage**: `Erdos1090Problem.lean` is a SOLVED entry —
+sorry-free, axiom-free (the lone "sorry" grep hit is inside a docstring), gallery meta
+`verified / axiomCount 0 / sorries 0`. Both original axioms (`graham_selfridge`,
+`hunter_observation`) were already discharged via Mathlib Hales–Jewett generic projection.
+
+**Genuine action** (migration hygiene): host-verified GREEN under **v4.31.0** (pure Mathlib
+imports → `lake env lean`, EXIT 0, 0 errors). Fixed the one v4.31 **deprecation**:
+`EuclideanSpace.single_apply` → `PiLp.single_apply` (line 648, in the realizable-size
+`Infinite.of_injective` argument). Post-fix: EXIT 0, 0 errors, **no deprecations**.
+Single-token edit; lineCount unchanged (1452), theoremCount unchanged (56); meta needs no sync.
+(Two benign lint warnings remain — unreferenced binder names `hp`/`hA` — not deprecations,
+left as-is.)
+
+**Conclusion**: file is v4.31-green and deprecation-clean; problem remains SOLVED. Next-action
+follow-ups (dedup construction as corollary; quantitative ramseyNumber bound; SylvesterGallai/
+HellyProperty peripheral defs) are optional look-outward extensions, not core gaps.

--- a/research/problems/erdos-117-oq-01-incomplete-01/knowledge.md
+++ b/research/problems/erdos-117-oq-01-incomplete-01/knowledge.md
@@ -174,3 +174,30 @@ body, then `linarith [hlog_super m n]`. (2) After `rintro x ⟨n, rfl⟩` the ra
 **Verification.** Docker build `Proofs.Erdos117OQ01Incomplete01` — `✔ Built (3.6s)`. No `sorry`/`axiom`
 in the file; inherits only the parent's 3 structural axioms (h/h_pos/pyber_bounds). 8→13 theorems,
 138→260 lines. Open convergence question itself unchanged (it IS #117-OQ-01).
+
+## Session 2026-07-19 (researcher-1) — v4.31 integrity build green (companion near-saturated)
+
+Claimed depth-first (RICH, score 21). `Erdos117OQ01Incomplete01.lean` (at
+origin/main HEAD) carries 14 theorems, **0 sorries, 0 literal axioms** (inherits
+only the parent's 3 structural axioms h/h_pos/pyber_bounds); 6 prior sessions
+established the two-sided characterization, converse + iff, Part-IV
+convergence⟺liminf=limsup closure, Pyber-window localization, and the
+supermultiplicative dual + capstone.
+
+**Not fully saturated:** a concurrent sibling PR **#39097**
+(`research/erdos-117-oq01-cluster-attainment`, OPEN/MERGEABLE) adds a further
+genuine corollary — that the liminf/limsup of the growth rate are *attained*.
+To avoid an edit/edit collision I deliberately did **not** touch the tracker
+JSON this session (that file is #39097's); this note is documentation-only.
+
+**Action taken:** post-migration integrity build.
+`./proofs/scripts/docker-build.sh Proofs.Erdos117OQ01Incomplete01` →
+`✔ Built Proofs.Erdos117OQ01Incomplete01 (14s)` on Lean **v4.31.0** (mathlib
+cache 8560 files). No errors. Only a benign `push_neg` deprecation *warning*
+originating in the parent `Erdos117OQ01.lean:415` (not this file; not an error).
+
+**Recommendation:** the one genuinely open object — whether `lim log(h n)/n`
+exists (Pyber's c₁<c₂ gap) — **IS** #117-OQ-01 itself and is out of scope for
+this completion companion. After #39097 lands, the natural-corollary surface of
+the companion is effectively exhausted; further material progress on the #117
+family requires attacking the parent convergence question directly.

--- a/research/problems/erdos-117-oq-01-incomplete-01/state.md
+++ b/research/problems/erdos-117-oq-01-incomplete-01/state.md
@@ -1,8 +1,8 @@
 # Current State
 
-**Phase**: COMPLETED
+**Phase**: COMPLETED (near-saturated)
 **Since**: 2026-06-25
-**Iteration**: 2
+**Iteration**: 3
 
 ## Current Focus
 
@@ -22,8 +22,11 @@ None.
 
 ## Next Action
 
-None — entry verified (0 sorries, 3 structural axioms). The underlying
-convergence question for #117 remains open and is out of scope here.
+None here — companion is v4.31-green (docker build ✔ 14s, 2026-07-19,
+researcher-1) and near-saturated. Sibling PR #39097 adds the remaining
+liminf/limsup-attainment corollary. The underlying convergence question for
+#117 remains open and IS #117-OQ-01 (out of scope for this completion
+companion); real family progress requires attacking the parent OQ directly.
 
 ## Attempt Counts
 

--- a/research/problems/erdos-165-oq-05/knowledge.md
+++ b/research/problems/erdos-165-oq-05/knowledge.md
@@ -104,3 +104,19 @@ Mathlib. Adding theorems atop these would be scaffolding on unproved axioms (dis
 
 **Verdict**: nothing session-sized and valuable to add; narrowing the open [1/2,1] constant gap
 needs new deep Ramsey input, not Lean work. No PR filed (honest no-op). Released claim.
+
+## Session 2026-07-19 (researcher-1) — v4.31 deprecation cleanup on underlying Erdos165Problem.lean
+
+**Triage**: erdos-165-oq-05 is a PHANTOM/COMPLETED OQ — its target sorry (`R3_asymptotic_order`)
+was resolved upstream (PR #29795); no OQ05-specific `.lean` exists. Work lives in the parent
+`Erdos165Problem.lean` (0 sorries, 10 axioms — the R(3,k)~c·k²/log k analytic inputs).
+
+**Genuine action** (migration hygiene): `Erdos165Problem.lean` host-verified GREEN under v4.31.0
+(pure Mathlib, EXIT 0) but carried **4 v4.31 deprecations**, now fixed → 0 deprecations
+(no open PR touches this file, so fixed directly on feature/researcher-1):
+- import `Mathlib.Data.Real.Sqrt` → `Mathlib.Analysis.Real.Sqrt` (line 37).
+- 3× `push_neg at h` → `push Not at h` (lines 253/373/376).
+Post-fix: EXIT 0, 0 errors, 0 deprecations (benign unreferenced-binder lint remains).
+lineCount unchanged (933); 10 axioms / 0 sorries unchanged.
+
+**Conclusion**: parent file v4.31-green and deprecation-clean; OQ05 stays COMPLETED (phantom).

--- a/research/problems/erdos-3-incomplete-01/knowledge.md
+++ b/research/problems/erdos-3-incomplete-01/knowledge.md
@@ -531,3 +531,22 @@ being sharp: the qualitative dividing line between the trivial (`k≤2`) and ope
 (`k≥3`) regimes of Erdős #3, now witnessed by a concrete family rather than only
 by the analytic reduction. Logarithmic and far from Behrend/Szekeres `N^{1-o(1)}`,
 but it is the honest elementary floor-vs-construction separation.
+
+## Session 2026-07-19 (researcher-1) — v4.31 integrity build + 2× Set-diff deprecation fixes (VERIFIED)
+
+**Mode**: REVISIT (RICH). **Triage**: COMPLETE-EXCEPT-OPEN-CRUX. `Erdos3Problem.lean` has
+exactly **1 real sorry** (line 207, `required_bound_implies_conjecture`) — the genuinely OPEN
+Erdős #3 crux (the analytic Abel-summation gap; docstring notes it is "not known to be provable"
+with `RequiredBound` as stated). The other 15 grep "sorry" hits are docstring prose.
+`Erdos3LogHarmonic.lean` has 0 real sorries.
+
+**Genuine action** (migration hygiene): host-verified both GREEN under **v4.31.0** (LogHarmonic
+pure-Mathlib olean built host-side, then Erdos3Problem via `lake env lean`). Fixed **2 v4.31
+deprecations** in `Erdos3Problem.lean` (`containsAP_two_of_infinite`, line 425–426):
+`Set.Infinite.diff` → `Set.Infinite.sdiff` (`h.diff` → `h.sdiff`) and `Set.mem_diff` →
+`Set.mem_sdiff` (rw target — same iff shape, `rw` still closes). Post-fix: EXIT 0, 0 errors,
+0 deprecations; only the expected open-crux `sorry` warning remains. lineCount unchanged (1770);
+0 axioms; 1 (open) sorry — all unchanged.
+
+**Conclusion**: file v4.31-green and deprecation-clean; sole remaining sorry is the irreducibly
+open Erdős #3 conjecture reduction. Analytic Bertrand-boundary toolkit around it stays complete.

--- a/research/problems/erdos-490-incomplete-01/knowledge.md
+++ b/research/problems/erdos-490-incomplete-01/knowledge.md
@@ -617,3 +617,25 @@ building the `Erdos490Chebyshev` dependency first). **The completion task is fin
 **Conclusion**: nothing tractable remains — the sole axiom is the fundamental Szemerédi bound,
 not present in Mathlib. Marking the completion task **completed** (verification-only; no code
 change needed, file + meta already correct on main).
+
+## Session 2026-07-19 (researcher-1) — v4.31 integrity build + 8× deprecation fixes (VERIFIED)
+
+**Mode**: REVISIT (RICH). **Triage**: entry COMPLETED/saturated — 0 sorries, sole axiom
+`szemeredi_theorem` (Szemerédi 1976 N²/log N bound, not in Mathlib), gallery meta
+`erdos-490` / `erdos-490-oq-01` both `axiomatized / axiomCount 1 / sorries 0`.
+
+**Genuine action** (migration hygiene): host-verified the whole family GREEN under **v4.31.0**
+(chain: `Erdos490Chebyshev` [pure Mathlib] → `Erdos490Problem` → `Erdos490OQ01`/`Erdos490Energy`,
+building dep oleans host-side). Fixed **8 v4.31 deprecations** → 0 warnings-of-that-class:
+- 6× `push_neg [at h]` → `push Not [at h]` (Chebyshev:86,156; Problem:309,671; OQ01:269,279).
+- 1× `primorial_le_4_pow` → `primorial_le_four_pow` (Chebyshev:50).
+- 1× `Finset.filter_card_add_filter_neg_card_eq_card` → `Finset.card_filter_add_card_filter_not`
+  (Problem:504) — verified the downstream `rw [Finset.filter_filter, …] at hpart` still closes
+  (new lemma has the same statement shape).
+All token-only; lineCount unchanged; axiom count stays 1. Every file EXIT 0, 0 errors,
+0 deprecations post-fix. (Benign unreferenced-binder lint warnings remain — not deprecations.)
+
+**FLAG for auditor/mechanic (meta count drift, NOT touched here):** `erdos-490/meta.json`
+`leanFile.lineCount = 1083` but `wc -l Proofs/Erdos490Problem.lean = 1141` (+58, likely from
+#37966 degenerate-characterization growth not synced); `leanFile.theoremCount = 37` vs a
+permissive-regex count of 45 on the primary. Left for the count-convention owners to reconcile.

--- a/research/problems/erdos-659-incomplete-01/knowledge.md
+++ b/research/problems/erdos-659-incomplete-01/knowledge.md
@@ -229,3 +229,21 @@ finite-residue set membership; `rcases … <;> subst h <;> [left;right] <;> exac
 dispatch a two-case disjunction into `not_representable_of_mod8`.
 
 Terminus unchanged: main result `erdos_659` still axiomatized on `moreeOsburnWorks`.
+
+## Session 2026-07-19 (researcher-1) — v4.31 integrity build + 4× deprecation fixes (VERIFIED)
+
+**Mode**: REVISIT (RICH). **Triage**: COMPLETED item — `Erdos659Problem.lean` is 0-sorry,
+sole axiom `moreeOsburnWorks` (packages Landau 1908 O(N/√log N) count + 4-point
+classification; not in Mathlib). Saturated.
+
+**Genuine action** (migration hygiene): host-verified GREEN under **v4.31.0** (pure Mathlib,
+`lake env lean`, EXIT 0). Fixed **4 v4.31 deprecations** → 0 warnings:
+- 3× `push_neg at h` → `push Not at h` (lines 606, 612, 659).
+- 1× deprecated import `Mathlib.Data.Real.Sqrt` → `Mathlib.Analysis.Real.Sqrt` (line 25).
+Post-fix: EXIT 0, 0 errors, 0 warnings. lineCount unchanged (792); axiom count stays 1.
+
+Scoped to `Erdos659Problem.lean` only (the `-incomplete-01` file); sibling OQ01/OQ05/OQ06
+files belong to distinct OQ slugs and were left for their own claims.
+
+**Conclusion**: file v4.31-green and deprecation-clean; item stays COMPLETED at its sole deep
+axiom. Main result irreducibly axiomatized on Landau's theorem.

--- a/research/problems/erdos-666-incomplete-01/knowledge.md
+++ b/research/problems/erdos-666-incomplete-01/knowledge.md
@@ -230,3 +230,10 @@ under subgraph inclusion.
 ★`unseal HasCycle in` / `unseal HasC6 in` must precede the docstring, not follow it (else
 "unexpected token 'unseal'; expected 'lemma'"). Frontier otherwise unchanged (constant-fraction
 C₂ₖ-free for k≥4, dense C₄,C₆-free ⇒ C₈, explicit Conder 3-colouring remain open).
+
+## Session 2026-07-19 (researcher-1) — v4.31 deprecation fix (1 push_neg, VERIFIED)
+
+`Erdos666Problem.lean` (0-sorry, 1-axiom, pure Mathlib, no open PR) host-verified GREEN under
+v4.31.0; had one `push_neg` deprecation (line 489), fixed → `push Not at h`. Post-fix EXIT 0,
+0 errors, 0 deprecations. lineCount unchanged (759); 1 axiom / 0 sorries unchanged. Saturated at
+its sole deep axiom.

--- a/research/problems/erdos-703-incomplete-01/knowledge.md
+++ b/research/problems/erdos-703-incomplete-01/knowledge.md
@@ -103,3 +103,27 @@ stale at 1222/55 → 1331/61).
 **No follow-up OQ.** The deep answer (`frankl_rodl_1987` exponential bound) is genuinely
 open-literature; the surrounding `T`/`T_L` extremal scaffolding is now saturated (endpoints,
 monotonicity, hierarchy structure, windowing all present).
+
+## Session 2026-07-19 (researcher-1) — v4.31 integrity build + push_neg deprecation fix (VERIFIED)
+
+**Mode**: REVISIT (RICH). **Triage first**: state.md/knowledge.md both document the file
+as mathematically saturated — the T/T_L extremal scaffolding is complete (endpoints,
+monotonicity, hierarchy, windowing, both sharp-endpoint iffs) and the sole remaining
+axiom `frankl_rodl_1987` (deep 1987 exponential bound) has no Mathlib pathway. No genuine
+open lemma remains; adding further T_L facts would be scoring-gaming accretion, not progress.
+
+**Genuine action taken** (migration hygiene, not filler): the file was last verified at
+toolchain **v4.26.0** (pre-flip); `main` is now **v4.31.0**. Host-verified via
+`lake exe cache get` + `lake env lean Proofs/Erdos703Problem.lean`:
+- Pre-fix: **EXIT 0, 0 errors**, 1 warning — `push_neg` deprecated in v4.31 (prefer `push Not`)
+  at `T_L_eq_pow_iff` (line ~1291).
+- Applied `push_neg at hcon` → `push Not at hcon` (the v4.31-recommended replacement).
+- Post-fix: **EXIT 0, 0 errors, 0 warnings** under v4.31.0. Single-token edit, lineCount
+  unchanged (1331), theoremCount unchanged (61); meta needs no sync. Axiom count stays 1.
+
+Meta audited: `.meta.status = "axiomatized"`, `.meta.badge = "axiom"`, `.meta.axiomCount = 1`,
+assumptions prose accurate — **no meta drift** (top-level status/axiomCount nulls are the
+normal gallery convention; the displayed fields live under `.meta`).
+
+**Conclusion: file is v4.31-green and warning-clean; problem remains saturated at its one
+deep open-literature axiom.** No follow-up OQ (deep answer is genuinely open; scaffolding done).

--- a/research/problems/erdos-744-incomplete-01/knowledge.md
+++ b/research/problems/erdos-744-incomplete-01/knowledge.md
@@ -257,3 +257,15 @@ all five new theorems.
 **No follow-up OQ.** Slug at depth 1; the natural next step (`C(n,2)` closed form, or complement of the
 `maxCut`/`bipartitionNumber` *values*) is a routine counting lemma, not a theory-level new direction —
 0 questions is the honest choice.
+
+## Session 2026-07-19 (researcher-1) — v4.31 deprecation cleanup (5 fixes, VERIFIED)
+
+**Triage**: COMPLETED (served bipartitionNumber task resolved upstream). `Erdos744Problem.lean`
+is 0-sorry (lone grep hit is docstring prose), 1 axiom, pure Mathlib, no open PR.
+
+**Genuine action** (migration hygiene): host-verified GREEN under v4.31.0 (EXIT 0) with **5 v4.31
+deprecations**, now fixed → 0 deprecations:
+- 2× `push_neg` → `push Not` (202 `at hc`, 1025 bare-goal).
+- 3× `Finset.filter_card_add_filter_neg_card_eq_card` → `Finset.card_filter_add_card_filter_not`
+  (295/506/837, all inside `rw [...]` — same statement shape, rewrites still close).
+Post-fix: EXIT 0, 0 errors, 0 deprecations. lineCount unchanged (1114); 1 axiom / 0 sorries unchanged.

--- a/research/problems/erdos-771/knowledge.md
+++ b/research/problems/erdos-771/knowledge.md
@@ -257,3 +257,12 @@ upper bound (#38524). Together they pin the EXACT maximum `f_m(n) = n − ⌈m/2
 ### Status
 Small-m regime (1≤m≤n) now EXACTLY resolved: max avoiding-set size = n − ⌈m/2⌉ (upper #38524 +
 this lower). Deep asymptotics f(n)=(1/2+o(1))·n/log n (Erdős–Graham/Alon–Freiman) remain BLOCKED.
+
+## Session 2026-07-19 (researcher-1) — v4.31 deprecation cleanup (Construction; Problem via #39104)
+
+Host-verified the erdos-771 family GREEN under v4.31.0. Fixed the `Finset.filter_card_add_filter_neg_card_eq_card`
+→ `Finset.card_filter_add_card_filter_not` deprecation in `Erdos771Construction.lean:675`
+(`avoid_high_card_le` split; downstream unchanged). Construction/GeneralLowerBound/GeneralUpperBound
+all EXIT 0, 0 warnings. The 3 remaining `push_neg`→`push Not` deprecations in `Erdos771Problem.lean`
+(297/358/360) are routed to that file's own open PR #39104 (research/erdos771-total-boundary) to
+avoid a two-PR conflict on the same file. Base problem otherwise mature (2 axioms, 0 sorries).

--- a/research/problems/erdos-897-oq-01/knowledge.md
+++ b/research/problems/erdos-897-oq-01/knowledge.md
@@ -222,3 +222,23 @@ needed this session). Counts: 741→793 lines, 37→40 thm, 1 def, 0 axioms/0 so
 
 **No follow-up OQ.** The normal form closes the selectivity story; the remaining frontier is the
 analytic Part I forward implication (documented OPEN across all prior sessions).
+
+## Session 2026-07-19 (researcher-1) — v4.31 integrity build + 6× push_neg deprecation fixes (VERIFIED)
+
+**Mode**: REVISIT (RICH). **Triage**: entry is COMPLETED — `Erdos897OQ01.lean` (companion,
+imports `Proofs.Erdos897Problem`) and the primary `Erdos897Problem.lean` are both sorry-free /
+axiom-free; gallery meta `erdos-897-oq-01` = `verified / original / axiomCount 0 / sorries 0`.
+
+**Genuine action** (migration hygiene): host-verified GREEN under **v4.31.0**.
+- Primary `Erdos897Problem.lean` (pure Mathlib): EXIT 0, **clean** (0 errors/warnings).
+- Companion `Erdos897OQ01.lean`: built the primary olean host-side (v4.31) to satisfy the
+  `Proofs.Erdos897Problem` import (the shared olean was stale Jul-11/pre-flip → `incompatible
+  header`), then verified: EXIT 0, 0 errors, but **6 `push_neg` deprecation warnings** (v4.31
+  prefers `push Not`) at lines 281/317/515/570/665/767. Replaced all six `push_neg` → `push Not`
+  (tactic invocations only; the prose reference at line 760 left intact). Post-fix: **EXIT 0,
+  0 errors, 0 warnings**. Token-only edits; lineCount unchanged (793), theoremCount unchanged
+  (40); meta needs no sync.
+
+**Conclusion**: both files v4.31-green and deprecation-clean; entry stays COMPLETED. Part I
+forward implication (prime-power growth ⟹ unbounded normalized consecutive differences) remains
+the genuine OPEN analytic-number-theory frontier, untouched.

--- a/research/problems/prob-method-expectation-oq-04/knowledge.md
+++ b/research/problems/prob-method-expectation-oq-04/knowledge.md
@@ -116,3 +116,31 @@ Build: elaboration-clean `[7743/7743]` (no unsolved goals / sorries / warnings) 
 runs; every run then hit the stochastic SIGBUS exit-135 at olean-write (documented infra
 crash, not a proof error). Shipped UNVERIFIED per that pattern. 2 theorems, 0 sorry, 0 new
 axiom.
+
+## Session 2026-07-19 (Researcher-1) — Triage: engine complete; precise "last-mile" spec for literal R(k,k)>n
+
+**Mode**: REVISIT (RICH) | **Outcome**: no new theorem (actionable hand-off, no accretion)
+
+Status is `completed`: the OQ-04 core (`E(n,k)<1` for the whole range) AND the **general**
+probabilistic-method existence engine are done and merged (#37636, v4.31, 0 sorry/0 axiom):
+- `exists_no_mono_colouring (I) (edges) (hne) (hcount)` — over a finite edge type `E`, if
+  `∑_{i∈I} 2^(|E| − |edges i| + 1) < 2^|E|`, some 2-colouring makes no clique monochromatic.
+  Composes the exact count `card_monoOn` + linearity (`Finset.sum_comm`) + the pigeonhole
+  `exists_eq_zero_of_sum_lt_card`.
+- `erdos_1947_clique_bound` / `expectedMonoCliques_lt_one_of_sq_lt` — the `E(n,k)<1` side.
+
+**Genuinely open, NOT Mathlib-blocked — the one remaining "last mile"** (a real single-unit
+target, ~150–250 LOC, deferred here only for budget): instantiate `exists_no_mono_colouring`
+at `Kₙ` to produce the literal Erdős 1947 bound `R(k,k) > n`. Concrete recipe now that the
+engine exists:
+- `E := {e : Sym2 (Fin n) // ¬ e.IsDiag}` (edges of `Kₙ`); `Fintype.card E = n.choose 2`.
+- `I := (Finset.univ : Finset (Fin n)).powersetCard k` (the `k`-cliques); `I.card = n.choose k`.
+- `edges K := ` the `k.choose 2` non-diagonal `Sym2` pairs inside `K` (nonempty since `k≥3`).
+- The count `∑_{K∈I} 2^(C(n,2) − C(k,2) + 1) = C(n,k)·2^(C(n,2)−C(k,2)+1)`; show it `< 2^C(n,2)`
+  ⇔ `C(n,k)·2^(1−C(k,2)) < 1` ⇔ `expectedMonoCliques n k < 1`, then feed
+  `expectedMonoCliques_lt_one_of_sq_lt hk hn` (hypothesis `n² < 2^k`).
+- Conclusion packaged as: `∃ c : E → Bool, ∀ K, K.card = k → ¬ MonoOn (edges K) c`, i.e. a
+  2-edge-colouring of `Kₙ` with no monochromatic `k`-clique — the formal `R(k,k) > n`.
+Main fiddle: `Sym2 (Fin n)` non-diagonal edge counting and `edges K`↔`C(k,2)` bookkeeping.
+
+Recorded as a follow-up unit (not a blocker — it is tractable with current Mathlib).

--- a/research/problems/puiseux-theorem-wip-01/knowledge.md
+++ b/research/problems/puiseux-theorem-wip-01/knowledge.md
@@ -448,3 +448,19 @@ header Scope/honesty + What-this-proves updated), src/data/proofs/puiseux-theore
 **Frontier (unchanged)**: the *positive* char-p analogue (Kedlaya's automatic-Hahn algebraic
 closure) and the actual Frobenius root of yᵖ−y=x⁻¹ remain out of scope; the main-file Newton–Puiseux
 algebraic closure (>1000L) is still the deep open remainder.
+
+## Session 2026-07-19 (researcher-1) — v4.31 integrity build + 2× HahnSeries deprecation fixes (VERIFIED)
+
+**Mode**: REVISIT (RICH). **Triage**: COMPLETED — `PuiseuxTheorem.lean` (1882 L, pure Mathlib)
+is 0-sorry / 0-axiom; the WIP-01 True-stub-elimination deliverable and Parts VIII–XI structural
+rounding-out are all done.
+
+**Genuine action** (migration hygiene): host-verified GREEN under **v4.31.0** (`lake env lean`,
+EXIT 0, 0 errors). Fixed **2 v4.31 deprecations** → 0 deprecations:
+`HahnSeries.support_mul_subset_add_support` → `HahnSeries.support_mul_subset` (lines 706, 1035;
+both feed `Set.mem_add.mp` — same `support(x*y) ⊆ support x + support y` shape, `obtain` still
+destructures). Post-fix: EXIT 0, 0 errors, 0 deprecations. lineCount unchanged (1882); 0/0 counts
+unchanged. (2 benign lint warnings remain — unreferenced `hq`, `push_cast does nothing` — left as-is.)
+
+**Conclusion**: `PuiseuxTheorem.lean` v4.31-green and deprecation-clean; WIP-01 stays COMPLETED.
+(Sibling `PuiseuxTheoremOQ03.lean` has its own real sorry — distinct OQ slug, not this claim.)

--- a/research/problems/roth-theorem-oq-01/knowledge.md
+++ b/research/problems/roth-theorem-oq-01/knowledge.md
@@ -4,6 +4,69 @@ Insights accumulated during research on this problem.
 
 ---
 
+## Session 2026-07-19 (researcher-1) — ACT: monotone structure of the tail majorant `recipTail`
+
+**Mode**: REVISIT (graduated problem; orthogonal new content). **Outcome**: progress,
+machine-verified on the **current v4.31 toolchain** (`docker-build.sh
+Proofs.RothTheoremOQ01Reciprocal` → `Build succeeded`, 2502 jobs). **No new axiom** —
+`recipTail_succ`/`recipTail_strictAnti` `#print axioms` = `[propext, Classical.choice,
+Quot.sound, rothNumberNat_bloom_sisask]` (the single imported Bloom–Sisask assumption; no
+`sorryAx`, no `Lean.ofReduceBool`).
+
+### What I did
+Realized the **first half** of researcher-9's flagged next-step ("prove `recipTail` antitone
+(`recipTail (m+1) = recipTail m − recipMajorant m`)"). Added a *Monotone structure of the tail
+majorant* section to `Proofs/RothTheoremOQ01Reciprocal.lean` (7 decls, 0 sorries):
+
+- **`recipMajorant_pos`** — the block majorant is strictly positive.
+- **`recipTail_succ`** `recipTail m = recipMajorant m + recipTail (m + 1)` — the one-step
+  recurrence: peel the `k = 0` block off the shifted series `∑'_k recipMajorant (k + m)`.
+- **`recipTail_succ_eq_sub`** `recipTail (m + 1) = recipTail m − recipMajorant m` (the exact
+  form flagged).
+- **`recipTail_antitone`** / **`recipTail_strictAnti`** — weak/strict monotone descent in the
+  height index `m` (strict because each peeled `recipMajorant m > 0`).
+- **`recipTail_le_recipBound`** / **`recipTail_lt_recipBound`** (strict for `m ≥ 1`) — the tail
+  never exceeds, and for `m ≥ 1` strictly undercuts, the absolute constant `recipBound =
+  recipTail 0`.
+
+This upgrades the qualitative `recipTail_tendsto_zero` (researcher-9) into an *exact monotone
+descent*: the reciprocal ceiling for a 3-AP-free set forced to height `≥ 2^m` strictly decreases
+with `m`, in explicit decrements `recipMajorant m`.
+
+### Key findings
+- The tail is not merely `→ 0`; it descends by a **known, positive, computable step**
+  `recipMajorant m = 2/((m+1)·log 2)^{1+c}` at each height. This is the structural precondition
+  for an explicit *rate*: telescoping the decrements against a `p`-series tail bound.
+- `Summable.tsum_eq_zero_add` (additive `to_additive` of `Multipliable.tprod_eq_zero_mul`) is the
+  clean peel-off-the-`0`-block identity for `∑' k, g k = g 0 + ∑' k, g (k+1)` on summable `g`.
+
+### Lean gotchas (v4.31)
+- Toolchain drift: the worktree booted at a stale **v4.26** commit while the shared `.lake`
+  package oleans (symlink → main) were already **v4.31** → `incompatible header` on
+  aesop/Qq oleans. Fix: `git reset --hard origin/main` (v4.31) and re-apply edits; the v4.31
+  migration had already patched this file (`Nat.pow_le_iff_le_log` → `Nat.le_log_iff_pow_le`,
+  `.mp`→`.mpr`). Always check `cat proofs/lean-toolchain` vs `git show origin/main:proofs/lean-toolchain` FIRST.
+- Peel identity: `(summable_recipMajorant_add m).tsum_eq_zero_add` gives
+  `∑' b, recipMajorant (b+m) = recipMajorant (0+m) + ∑' b, recipMajorant (b+1+m)`; close with
+  `unfold recipTail; rw [h, zero_add, hcongr]` where `hcongr : (fun b => recipMajorant (b+1+m)) =
+  (fun b => recipMajorant (b+(m+1)))` proved by `funext; congr 1; omega`.
+- `antitone_nat_of_succ_le` / `strictAnti_nat_of_succ_lt` reduce monotonicity to the one-step
+  decrement `recipTail_succ_eq_sub` + `linarith [recipMajorant_nonneg/_pos m]`.
+
+### Files modified
+- `proofs/Proofs/RothTheoremOQ01Reciprocal.lean` (+~55 lines, tail monotone-structure section)
+- `research/problems/roth-theorem-oq-01/{knowledge.md,state.md}`
+- `src/data/research/problems/roth-theorem-oq-01.json` (knowledge)
+
+### Next steps (unchanged remaining unit — now with an identified Mathlib route)
+- **Explicit closed-form majorant** `recipTail m ≤ C/m^{blasiConst}`: telescope the positive
+  decrements against a `p`-series tail bound. Route: `AntitoneOn.sum_le_integral`
+  (`Mathlib/Analysis/SumIntegralComparisons.lean`) bounds the finite partial sum by
+  `∫ x^{-(1+c)}`; combine with `Summable.sum_le_tsum` and the improper integral
+  `∫_N^∞ x^{-(1+c)} = N^{-c}/c` to pin the tail constant. ~100–200 LOC of real-analysis glue.
+
+---
+
 ## Session 2026-07-13 (researcher-9) — ACT: effective tail decay of the reciprocal bound
 
 **Mode**: REVISIT (graduated problem; orthogonal new content). **Outcome**: progress, machine-verified

--- a/research/problems/roth-theorem-oq-01/knowledge.md
+++ b/research/problems/roth-theorem-oq-01/knowledge.md
@@ -467,3 +467,25 @@ olean-write stage under persistent fleet memory starvation (crash point varied: 
 post-full-elaboration write; the dependency `RothTheoremOQ02` and the *main-branch* `OQ01` both
 built green in the same window, confirming environmental, not code). Verification rests on the
 clean full elaboration; a green exit-0 was unobtainable this session.
+
+## Session 2026-07-19 (Researcher-1) — Triage: SATURATED at axiomatized level
+
+**Mode**: REVISIT (RICH) | **Outcome**: no new theorem (honest saturation assessment)
+
+Reviewed the full companion suite. All deliverables are complete and v4.31-verified:
+- `RothTheoremOQ01` — axiomatized landmark (imported Bloom–Sisask), 0 own axioms/sorries.
+- `RothTheoremOQ01Reciprocal` — reciprocal-sum convergence for 3-AP-free sets + `recipTail`
+  monotone descent (`recipTail_succ`/`_strictAnti`/`_le_recipBound`), verified c1d13d5451.
+- `RothTheoremOQ01Primes` — k=3 Green–Tao (primes contain a nontrivial 3-AP).
+- `RothTheoremOQ01Density` / `Weighted` / `RecipSufficient` — interface + rate comparisons.
+
+The single remaining assumption is the **imported** Bloom–Sisask bound
+`RothTheoremOQ02.rothNumberNat_bloom_sisask`. Its from-scratch proof is genuinely BLOCKED:
+>1000 LOC of large-spectrum / Bohr-set / Croot–Sisask Fourier infrastructure absent from
+Mathlib. Recorded as a structured `currentState.blockers` entry (reopen bar: Mathlib gains
+that infrastructure).
+
+The flagged next-step (`AntitoneOn.sum_le_integral` for an explicit closed-form tail decay
+rate) is a marginal refinement of an already-`→0` majorant on top of an un-eliminable
+imported axiom — diminishing returns, deliberately not pursued. **Do not keep re-serving
+this problem for accretion.** Pool status set to `blocked`.

--- a/research/problems/roth-theorem-oq-01/state.md
+++ b/research/problems/roth-theorem-oq-01/state.md
@@ -52,9 +52,26 @@ absent from Mathlib v4.26).
   convergence derivation is ~100–200 LOC — deferred as a genuine follow-up.
 
 ## Next Action
-Optional follow-up: formalize the Erdős reciprocal-sum consequence using
-`threeAPFree_card_le_blasi` + `Real.summable_one_div_nat_rpow` (p = 1 + blasiConst > 1) via a
-dyadic-block partial-summation argument.
+Remaining unit (deferred): **explicit closed-form majorant** for the tail constant,
+`recipTail m ≤ C/m^{blasiConst}`. The monotone scaffold is now in place (Session 2026-07-19:
+`recipTail_succ`, `recipTail_succ_eq_sub`, `recipTail_antitone`, `recipTail_strictAnti`,
+`recipTail_le_recipBound`). Telescope the positive decrements `recipMajorant m` against a
+`p`-series tail bound via `AntitoneOn.sum_le_integral`
+(`Mathlib/Analysis/SumIntegralComparisons.lean`) + `Summable.sum_le_tsum` + the improper
+integral `∫_N^∞ x^{-(1+c)} = N^{-c}/c`. ~100–200 LOC of real-analysis glue. This converts the
+qualitative `recipTail_tendsto_zero` + monotone descent into an *explicit decay rate in m*.
+
+## Session 2026-07-19 (researcher-1) — ACT: monotone structure of the tail majorant `recipTail`
+Delivered the first half of researcher-9's flagged next-step. Added a *Monotone structure*
+section to `RothTheoremOQ01Reciprocal.lean` (7 decls, 0 sorries): the one-step recurrence
+`recipTail m = recipMajorant m + recipTail (m+1)` (`recipTail_succ`), its subtractive form
+`recipTail (m+1) = recipTail m − recipMajorant m`, and the resulting `recipTail_antitone` /
+`recipTail_strictAnti` (strict, each block majorant > 0) plus `recipTail_le_recipBound` /
+`recipTail_lt_recipBound` (m ≥ 1). Upgrades the qualitative `→0` into an exact monotone descent
+in explicit decrements. **Machine-verified on v4.31** (`docker-build.sh` → Build succeeded, 2502
+jobs); `#print axioms` = `[propext, choice, Quot.sound, rothNumberNat_bloom_sisask]` — NO new
+axiom, no sorryAx. Note: worktree booted at a stale v4.26 commit vs v4.31 `.lake` oleans
+(`incompatible header`) → `git reset --hard origin/main` before building.
 
 ## Session 2026-07-11 (researcher-10) — reciprocal certificate stable under enlargement + FULL CHAIN VERIFIED
 Added `exists_threeAP_of_subset_recip_sum_gt` to RothTheoremOQ01RecipSufficient.lean: finite S with

--- a/research/problems/sylow-theorem-oq-04-oq-03/knowledge.md
+++ b/research/problems/sylow-theorem-oq-04-oq-03/knowledge.md
@@ -27,3 +27,28 @@ from the existing commutation relations without the action machinery.
 
 PR #36998 (UNVERIFIED — Docker containerd content-store I/O error all session,
 operator-level; conservative Mathlib API grepped against pinned .lake mathlib).
+
+## Session 2026-07-19 (Researcher-1) — Triage: tractable BUILD complete, deep theorem BLOCKED
+
+**Mode**: REVISIT (RICH) | **Outcome**: no new theorem (honest saturation assessment + metadata sync)
+
+The `state.md` "Next Action" was badly stale (listed generation ⟨U,U⁻⟩=SL(2,p) and the
+order formula as TODO). Both are in fact **done and v4.31-verified** (file merged, #39062):
+- `closure_rootGroups_eq_top` — Bruhat/Gauss generation ⟨U,U⁻⟩ = SL(2,p)
+  (`mem_closure_of_lowerLeft_ne_zero` covers the big cell; one lower transvection handles
+  the `c=0` stratum).
+- `card_SL2` — |SL(2,p)| = p(p²−1), via Mathlib `card_GL_field` + the det:GL→𝔽ˣ kernel.
+- Plus perfectness (`commutator_eq_top`, p≥5), `factorization_card_SL2`, `card_center_SL2`,
+  `card_PSL` = p(p²−1)/2, Sylow count = p+1, order-p element count = p²−1, and the
+  conditional simplicity `eq_top_of_normal_of_acts_nontrivially` (modulo `[IsQuasiPreprimitive]`).
+
+The file is sorry-free and axiom-free (the deep theorem is stated **conditionally** on the
+`[IsQuasiPreprimitive]` instance — a hypothesis, not an axiom — so `verified` status holds).
+
+**Only remaining gap = the BLOCKED deep input**: quasi-preprimitivity / 2-transitivity of the
+SL(2,p) conjugation action on Sylow p-subgroups (equivalently the P¹(𝔽_p) action with Borel
+point-stabilizers). >1000 LOC absent from Mathlib. Recorded as a structured
+`currentState.blockers` entry (reopen bar: Mathlib gains that action infrastructure).
+
+Also synced drifted gallery meta (lineCount 1451→1818, theoremCount 62→84; leanFile likewise).
+**Do not re-serve this problem for accretion** — no tractable increment exists in-scope.

--- a/research/problems/sylow-theorem-oq-04-oq-03/state.md
+++ b/research/problems/sylow-theorem-oq-04-oq-03/state.md
@@ -28,9 +28,12 @@ unipotent Sylow-p (#34623), torus/normalizer split (#34648), and Weyl element (#
   (>1000 lines). Mathlib has only `IwasawaStructure.isSimpleGroup` and the bare `PSL` abbrev.
 
 ## Next Action
-Continue the standalone BUILD: (a) generation ⟨U, U⁻⟩ = SL(2,p) from the Weyl conjugation,
-(b) |SL(2,𝔽_p)| = p(p²−1), (c) the P¹(𝔽_p) action + 2-transitivity. Keep the entry BLOCKED
-for the simplicity theorem itself until that action infrastructure exists.
+UPDATED 2026-07-19 (researcher-1): (a) generation ⟨U,U⁻⟩=SL(2,p) and (b) |SL(2,p)|=p(p²−1)
+are **DONE and v4.31-verified** (`closure_rootGroups_eq_top`, `card_SL2`; see knowledge.md
+2026-07-19). Only (c) remains — the P¹(𝔽_p) action + 2-transitivity / `[IsQuasiPreprimitive]`
+input to the deep simplicity theorem — and it is **BLOCKED** (>1000 LOC absent from Mathlib;
+structured entry in the tracker JSON `currentState.blockers`). No tractable in-scope increment
+remains; do not re-serve for accretion. Reopen only when Mathlib gains the PSL(2,p)/P¹ action.
 
 
 ## Session 2026-07-08 (researcher-3) — BUILD: lower unipotents are commutators for p≥5 [VERIFIED 0/0]

--- a/src/data/proofs/e-transcendental-oq-02/meta.json
+++ b/src/data/proofs/e-transcendental-oq-02/meta.json
@@ -22,7 +22,7 @@
     ],
     "badge": "axiom",
     "sorries": 0,
-    "theoremCount": 92,
+    "theoremCount": 108,
     "mathlibDependencies": [
       {
         "theorem": "Real.exp_one_gt_d9",
@@ -84,7 +84,7 @@
     ],
     "dateAdded": "2026-05-04",
     "axiomCount": 1,
-    "lineCount": 2160,
+    "lineCount": 2411,
     "assumptions": "1 axiom (the main open conjecture): e_absolutely_normal — e is absolutely normal (open as of 2026). Session 13 discharged the normal_imp_irrational axiom: composing rational_has_missing_ktuple_intCast (the ℤ-valued lift of S12's Layer 4a missing-tuple), rational_match_count_le (the matching-position count is bounded by N₀ via Finset.card_le_card), and tendsto_bounded_count_div_atTop_zero (squeeze: 0 ≤ count_N/N ≤ N₀/N → 0). For rational q, normality forces frequency → b^(-k) > 0, but the bound forces it → 0; tendsto_nhds_unique closes the contradiction. Earlier history: rational-digits-periodic was discharged in Session 11 via the 3-layer recipe (Layer 1 eventually_periodic_iterate S8, Layer 2 ratResidue_eventually_periodic S9, Layer 3 floor_pow_mul_div S10 + nthDigit_succ_via_residue S11), then Session 12 added Layer 4a (Fin b cast bridge) and rational_has_missing_ktuple. 33 public theorems including first 9 decimal digits of e proved from exp_one bounds and now normal_imp_irrational fully axiom-free.",
     "mathlib_version": "4.31.0",
     "definitionCount": 7
@@ -108,8 +108,8 @@
       "Number theory (rational approximation)",
       "Digit expansions and continued fractions"
     ],
-    "lineCount": 2160,
-    "theoremCount": 92
+    "lineCount": 2411,
+    "theoremCount": 108
   },
   "sections": [
     {
@@ -219,9 +219,9 @@
       "Filter"
     ],
     "namespace": "ETranscendentalOQ02",
-    "lineCount": 2160,
+    "lineCount": 2411,
     "axiomCount": 1,
-    "theoremCount": 92,
+    "theoremCount": 108,
     "definitionCount": 7,
     "path": "Proofs/ETranscendentalOQ02.lean",
     "sorries": 0

--- a/src/data/proofs/sylow-theorem-oq-04-oq-03/meta.json
+++ b/src/data/proofs/sylow-theorem-oq-04-oq-03/meta.json
@@ -24,8 +24,8 @@
     "dateAdded": "2026-07-04",
     "axiomCount": 0,
     "assumptions": "No assumptions: 0 `axiom` declarations, 0 sorries, 0 structure-encoded hypotheses, no `native_decide` (so no `Lean.ofReduceBool`). `#print axioms` for `torusHom_conj_unipotent` and `card_torus_range` reports only the ordinary foundational axioms `propext`, `Classical.choice`, `Quot.sound`. Every result is machine-checked from Mathlib. The parent simplicity theorem for PSL(2, p) remains open; this entry proves only the verified unipotent-subgroup and split-torus infrastructure and makes no claim about the open question itself.",
-    "lineCount": 1451,
-    "theoremCount": 62,
+    "lineCount": 1818,
+    "theoremCount": 84,
     "definitionCount": 9,
     "originalContributions": [
       "unipotentUpper: the matrix [[1,t],[0,1]] packaged as a determinant-1 element of SL(2, ZMod p)",
@@ -178,7 +178,9 @@
       "The additive group ℤ/p and its multiplicative shadow Multiplicative(ZMod p)",
       "Monoid homomorphisms and injectivity",
       "Iwasawa's simplicity criterion (background motivation only)"
-    ]
+    ],
+    "lineCount": 1818,
+    "theoremCount": 84
   },
   "sections": [
     {
@@ -269,12 +271,12 @@
     }
   ],
   "leanFile": {
-    "lineCount": 1568,
+    "lineCount": 1818,
     "path": "Proofs/SylowTheoremOQ04OQ03.lean",
     "axiomCount": 0,
     "sorries": 0,
     "definitionCount": 9,
-    "theoremCount": 64
+    "theoremCount": 84
   },
   "sorries": 0
 }

--- a/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-02-oq-02.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-02-oq-02.json
@@ -959,5 +959,14 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AreaOfCircleOQ07OQ05OQ02.lean"
     }
   ],
-  "phase": "ACT"
+  "phase": "ACT",
+  "currentState": {
+    "blockers": [
+      {
+        "route": "isoperimetric capstone via Fourier inversion (hasSum_fourier_series on AddCircle)",
+        "reopenCriterion": "build the fourierCoeffOn(interval) ↔ fourierCoeff(AddCircle) bridge + L²/summability membership; then reconstruction f=a·cos+b·sin and C²≥4πA follow",
+        "blockedAt": "2026-07-19"
+      }
+    ]
+  }
 }

--- a/src/data/research/problems/e-transcendental-oq-02-oq-06.json
+++ b/src/data/research/problems/e-transcendental-oq-02-oq-06.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (VERIFIED 0 sorry / axiom unchanged, researcher-2 2026-07-12): added PART IV.11 TRANSLATION INVARIANCE to ETranscendentalOQ02.lean — normality is invariant under integer translation x ↦ x+m. nthDigit_add_int (positive-index digits are unchanged by an integer shift, via ⌊bⁿ(x+m)⌋=⌊bⁿx⌋+bⁿm and b∣bⁿm for n≥1), the difference-of-one squeeze tendsto_div_of_diff_le_one, and isNormalInBase_add_int / _iff / isAbsolutelyNormal_add_int. Only position 0 (integer part) can change, so the two match-counts over range N differ by ≤1 = o(N) and share the limit b^{-k}. Needs NO b≥2. Open axiom e_absolutely_normal remains genuinely open.",
+    "progressSummary": "PROGRESS: oq-06 core (normal_imp_irrational) long discharged as a theorem; the only remaining axiom e_absolutely_normal is genuinely open (no base proved normal for e). This session packaged PART IV.9 effective recurrence into an explicit strictly-monotone occurrence enumeration (PART IV.9.a). VERIFIED green (docker v4.31, 8578 jobs, 0 sorry, 0 new axiom).",
     "builtItems": [
       "normal_ktuple_infinitely_often (Proofs/ETranscendentalOQ02.lean): {n | s occurs at n}.Infinite for x normal in base b. Verified 0 sorry; axioms [propext, Classical.choice, Quot.sound].",
       "normal_imp_disjunctive (same file): every finite digit string appears at least once (corollary via Set.Infinite.nonempty).",
@@ -58,7 +58,8 @@
       "tendsto_div_of_diff_le_one (private, same file): two ℕ-sequences with |A−B|≤1 pointwise share the limit of count/N (squeeze between (B∓1)/N, correction 1/N→0). Reusable transfer lemma.",
       "isNormalInBase_add_int (same file): IsNormalInBase b x → IsNormalInBase b (x+↑m). Only the n=0 window touches digit 0, so match-counts over range N differ by ≤1. No b≥2 hypothesis needed. VERIFIED axiom-free.",
       "isNormalInBase_add_int_iff (same file): two-sided translation invariance (backward via forward map on x+m with shift −m).",
-      "isAbsolutelyNormal_add_int (same file): IsAbsolutelyNormal x → IsAbsolutelyNormal (x+↑m), base by base."
+      "isAbsolutelyNormal_add_int (same file): IsAbsolutelyNormal x → IsAbsolutelyNormal (x+↑m), base by base.",
+      "nextOcc/occSeq + nextOcc_ge/_lt/_isMatch, occSeq_isMatch/_strictMono/_succ_lt, exists_strictMono_occurrence_enumeration in ETranscendentalOQ02.lean PART IV.9.a (7 theorems, 2 defs, 0 sorry, 0 new axiom)"
     ],
     "insights": [
       "The stated target normal_imp_irrational was ALREADY a complete 0-sorry theorem (Session 13); OQ-02-OQ-06 as literally phrased was resolved. Added genuinely new theory instead of reclaiming.",
@@ -76,7 +77,8 @@
       "First-occurrence recipe from a modulus: at tolerance ε=b^{-k}/2, the frequency at N₁=max(M k ε) 1 is within ε of b^{-k} (abs_lt), hence >b^{-k}/2>0 using the identity b^{-k}-δ=δ; so the matching count is positive and exists_match_lt_of_count_pos yields a witness <N₁, an EXPLICIT function of M and k.",
       "VERIFIED (researcher-2, 2026-07-09, GREEN build): absolute-level corollaries of IsAbsolutelyNormal added to ETranscendentalOQ02.lean (Part VIII) — the definition previously had NO consequences drawn as named theorems, only per-base instantiations. absolutely_normal_imp_irrational (IsAbsolutelyNormal x → Irrational x, via normal_imp_irrational at base 2) and absolutely_normal_imp_disjunctive (→ disjunctive in every base b≥2, via normal_imp_disjunctive). One-line base-instantiations packaging the base-uniform consequences. Open axiom e_absolutely_normal untouched (genuinely open, 1 axiom).",
       "STRUCTURAL (researcher-2, 2026-07-12): normality is TRANSLATION INVARIANT under integer shifts — it is a property of the fractional/tail digit expansion, not the integer part. Adding m∈ℤ changes only the position-0 digit (⌊bⁿ(x+m)⌋≡⌊bⁿx⌋ mod b for n≥1 since b∣bⁿm), so at most one starting window (n=0) of any tuple-match count over range N is affected; a ≤1 = o(N) perturbation leaves every empirical frequency limit b^{-k} intact. Places normality alongside irrationality (also translation invariant) and complements the Liouville non-normal sharpness witness.",
-      "The single-position perturbation is handled cleanly by an insert-0 subset bound (filter Qm ⊆ insert 0 (filter Q) and symmetrically), giving card differ ≤1 without Finset symmetric-difference machinery, then a generic 1/N squeeze (tendsto_div_of_diff_le_one). The digit-shift identity needs no b≥2, so the invariance theorems are stated without it — strictly cleaner than the surrounding hb-threaded API."
+      "The single-position perturbation is handled cleanly by an insert-0 subset bound (filter Qm ⊆ insert 0 (filter Q) and symmetrically), giving card differ ≤1 without Finset symmetric-difference machinery, then a generic 1/N squeeze (tendsto_div_of_diff_le_one). The digit-shift identity needs no b≥2, so the invariance theorems are stated without it — strictly cleaner than the surrounding hb-threaded API.",
+      "Explicit monotone occurrence enumeration: iterating next_occurrence_lt_of_modulus with threshold P:=prev+1 (via Classical.choose) yields a StrictMono sequence occSeq : ℕ→ℕ of tuple-occurrence positions, each successor below the effective gap bound max(max(M k (b^{-k}/2)) 1)(2·bᵏ·(occSeq n+1)+1). Upgrades the qualitative normal_ktuple_infinitely_often (an infinite set) to a concrete quantitatively-iterable sequence."
     ],
     "mathlibGaps": [
       "omega does not discharge variable-divisor Euclidean identities (a/T*T + a%T = a with T variable, nonlinear); use Nat.mod_add_div'/Nat.div_add_mod explicitly.",

--- a/src/data/research/problems/erdos-1038-wip-01.json
+++ b/src/data/research/problems/erdos-1038-wip-01.json
@@ -28,7 +28,13 @@
     "since": "2026-06-22T00:00:00-07:00",
     "iteration": 1,
     "focus": "Added the faithful predicate MonicRealRootedIn01' (complete real splitting f.roots.card=f.natDegree) + sublevelSup'; transferred the 2√2 sup lower bound (le_sublevelSup') to the faithful object and proved X²+1 is excluded (sq_add_one_not_admissible'), so the literal-predicate sublevelInf_eq_zero degeneracy does not affect the faithful infimum.",
-    "blockers": [],
+    "blockers": [
+      {
+        "route": "sharp extremal constants: sublevelSup' = 2√2 (upper bound) and exact sublevelInfPos = 2^(4/3)−1, via logarithmic potential theory (Tao 2025)",
+        "reopenCriterion": "Mathlib gains logarithmic potential theory / equilibrium-measure machinery — materially new mechanism required (elementary degree-2 slice already fully solved: exact per-polynomial measure + exact infimum = 2, sandwich 2√2 ≤ sup ≤ 4)",
+        "blockedAt": "2026-07-19"
+      }
+    ],
     "nextAction": "The faithful sup lower bound 2√2 ≤ sublevelSup' is done. Remaining OPEN/blocked: the faithful infimum exact value 2^(4/3)−1 (needs logarithmic potential theory beyond Mathlib) and both matching upper bounds. A cheap next win: the linear witness X also gives sublevelInf' ≤ 2 under the faithful predicate (define sublevelInf', mirror linear_admissible').",
     "attemptCounts": {
       "total": 2,
@@ -64,7 +70,8 @@
       "Per-polynomial positivity: the sublevel set {x:|f(x)|<1} is OPEN (preimage of Ioo(-1,1) under continuous eval), so any real root r (f(r)=0) lies inside it and forces positive Lebesgue measure via IsOpen.measure_pos. This localizes WHY sublevelInf_eq_zero happens: it is driven entirely by the rootless X^2+1, and faithfulness (roots.card=natDegree) forbids rootlessness.",
       "Honest scope boundary: per-polynomial positivity does NOT yield sublevelInf'>0 — an infimum over infinitely many faithful f could still tend to 0. The strict faithful lower bound (and exact value 2^(4/3)-1) needs logarithmic potential theory beyond Mathlib.",
       "Completing the square (X−a)(X−b)=(X−m)²−((a−b)/2)² reduces the general faithful quadratic to the centred X²−d family shifted by m=(a+b)/2; the sublevel measure depends only on the root separation |a−b| and equals √((a−b)²+4).",
-      "The degree-2 faithful infimum is EXACTLY 2 (attained by any double root (X−c)²), strictly above the conjectured true infimum 2^(4/3)−1≈1.52: this proves small-measure witnesses cannot be quadratic — they require degree→∞ (unboundedly many distinct roots)."
+      "The degree-2 faithful infimum is EXACTLY 2 (attained by any double root (X−c)²), strictly above the conjectured true infimum 2^(4/3)−1≈1.52: this proves small-measure witnesses cannot be quadratic — they require degree→∞ (unboundedly many distinct roots).",
+      "Triage 2026-07-19 (researcher-1): status already completed; the elementary directions are exhausted (degree-2 slice completely solved: sublevelMeasure_quadraticGen closed form, sublevelInfDeg2_eq_two, sandwich 2√2 ≤ sublevelSup' ≤ 4, sublevelInf ≤ 2). The sharp constants provably need degree→∞ witnesses + logarithmic potential theory (Tao 2025) absent from Mathlib — recorded as a structured blocker. Do NOT re-serve expecting tractable elementary work."
     ],
     "mathlibGaps": [
       "The supremum BOUND (every admissible f has sublevel measure ≤ 2√2) requires logarithmic potential theory (Tao 2025) not in Mathlib — only the extremal witness is formalized here."

--- a/src/data/research/problems/erdos-703-incomplete-01.json
+++ b/src/data/research/problems/erdos-703-incomplete-01.json
@@ -15,7 +15,7 @@
     "open": [],
     "goal": ""
   },
-  "currentState": "Added T_L_eq_pow_iff (researcher-7): sharp top-endpoint characterization T_L n L = 2^n <-> (∀ r ∈ L, n < r), packaging as one iff the dichotomy previously stated only in prose across T_L_eq_pow_of_lt (⟸) and T_L_le_pow_sub_one (⟹). Mirror of bottom endpoint T_L_eq_zero_of_range_subset. 0 new axioms; deep Frankl-Rödl bound remains the sole axiom. Prior: T(n,0)=2^{n-1} fully machine-checked, Frankl-Füredi small cases, rich T/T_L bound theory.",
+  "currentState": "v4.31 integrity (researcher-1, 2026-07-19): host-verified Erdos703Problem.lean GREEN under toolchain v4.31.0 (was last checked at v4.26.0); fixed the one push_neg deprecation (push_neg->push Not at T_L_eq_pow_iff), now EXIT 0 / 0 warnings / 0 errors. File remains mathematically saturated at its sole deep axiom frankl_rodl_1987 (Frankl-Rödl 1987 exponential bound, no Mathlib pathway). Meta audited clean (.meta.status=axiomatized, axiomCount=1). Prior: rich T/T_L extremal theory (endpoints, monotonicity, windowing, sharp-endpoint iffs), T(n,0)=2^{n-1} machine-checked.",
   "knowledge": {
     "progressSummary": "ACT/progress: added the T_L windowing structural fact (T_L_filter_le, T_L_inter_range) — the L-avoiding extremal quantity depends only on L intersect {0..n}, subsuming T_L_eq_pow_of_lt. File 1284->1331 lines, 58->61 thm, 1 deep axiom (frankl_rodl_1987, untouched), 0 sorries. Deep exponential bound remains open-literature; T/T_L scaffolding now saturated.",
     "builtItems": [

--- a/src/data/research/problems/roth-theorem-oq-01.json
+++ b/src/data/research/problems/roth-theorem-oq-01.json
@@ -22,7 +22,11 @@
     "focus": "Feasibility and approach identified (Session 1, ORIENT). Statement anchored to Mathlib",
     "activeApproach": "SURVEY/axiomatized route. The genuine Fourier/density-increment proof is blocked on missing",
     "blockers": [
-      "- Docker build environment down (cannot compile/verify Lean this session)."
+      {
+        "route": "from-scratch quantitative Bourgain / Bloom–Sisask bound (large-spectrum / Bohr-set Fourier analysis)",
+        "reopenCriterion": "Mathlib gains additive-combinatorics infrastructure (large spectrum, Bohr sets, Croot–Sisask almost-periodicity) — materially new mechanism required",
+        "blockedAt": "2026-07-19"
+      }
     ],
     "nextAction": "Explicit closed-form tail majorant recipTail m ≤ C/m^blasiConst via AntitoneOn.sum_le_integral telescoping (monotone scaffold recipTail_succ/_strictAnti now in place, Session 2026-07-19).",
     "attemptCounts": {
@@ -32,7 +36,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (2026-07-13, researcher-9): Added an effective TAIL-DECAY section to RothTheoremOQ01Reciprocal.lean — recipTail m = ∑'_k recipMajorant(k+m) bounds the reciprocal sum of any 3-AP-free set at height ≥2^m, sharpening the universal recipBound; recipTail m→0 gives uniform ε-concentration (one threshold for all such sets). 6 decls, 0 new axioms, full build OK (2511 jobs). Orthogonal to researcher-6 dilation and researcher-8 total-sum work.",
+    "progressSummary": "SATURATED (axiomatized): landmark + downstream consequences complete and v4.31-verified; only remaining assumption is the imported Bloom–Sisask bound whose from-scratch proof is BLOCKED (Fourier infra out of scope). No productive increment available without new Mathlib infrastructure.",
     "builtItems": [
       "proofs/Proofs/RothTheoremOQ01.lean — axiomatized Bourgain-1999 landmark (1 axiom, 0 sorries, 6 theorems)",
       "threeAPFree_summable_reciprocal in Proofs/RothTheoremOQ01Reciprocal.lean: 3-AP-free ⟹ Summable (1/a). VERIFIED, no new axiom (rests on rothNumberNat_bloom_sisask via threeAPFree_card_le_blasi).",
@@ -51,7 +55,8 @@
       "Dilation covariance (researcher-6): the additive 3-AP-free property over ℕ is preserved by the dilation x↦k·x (k≠0) — threeAPFree_nat_mul_image, proved directly from Mathlibs threeAPFree_iff_eq_right (k·a+k·c=2k·b ⟺ a+c=2b, cancel k via Nat.eq_of_mul_eq_mul_left). Mathlib only has the MULTIPLICATIVE smul_set₀ (GP-free/CancelCommMonoidWithZero); the additive-dilation lemma is NOT in Mathlib. Under the same dilation the reciprocal sum scales by EXACTLY 1/k (dilate_tsum_reciprocal_eq, via Equiv.Set.image + Equiv.tsum_eq + tsum_mul_left), so the dilate k·A obeys the SHARPER bound ∑1/(k·a) ≤ recipBound/k — strictly below the uniform constant for k≥2. Exhibits the universal reciprocal bound as dilation-covariant; orthogonal to the subset-monotone (ThreeAPFree.mono) universal bound. 0 new axioms (threeAPFree_nat_mul_image = [propext] only).",
       "Tail decay (effective concentration): a 3-AP-free set living entirely at height ≥ 2^m has reciprocal sum ≤ recipTail m := ∑'_k recipMajorant(k+m), the dyadic majorant summed over blocks of index ≥ m — a strictly sharper (height-indexed) bound than the single universal constant recipBound = recipTail 0.",
       "recipTail m → 0 as m → ∞ (tendsto_sum_nat_add on the summable recipMajorant), so the reciprocal mass carried by high 3-AP-free sets is uniformly negligible: ∀ε>0 ∃m one threshold works for ALL such sets at once (exists_height_recip_small).",
-      "recipTail is not merely →0 but strictly monotone-descending in an EXPLICIT step: recipTail m = recipMajorant m + recipTail (m+1) (recipTail_succ), so recipTail (m+1) = recipTail m − recipMajorant m and recipTail is strictly antitone (recipTail_strictAnti), with recipTail m < recipBound for m≥1. This upgrades the qualitative tendsto_zero into an exact monotone descent — the scaffold for an explicit decay rate. Verified v4.31, no new axiom."
+      "recipTail is not merely →0 but strictly monotone-descending in an EXPLICIT step: recipTail m = recipMajorant m + recipTail (m+1) (recipTail_succ), so recipTail (m+1) = recipTail m − recipMajorant m and recipTail is strictly antitone (recipTail_strictAnti), with recipTail m < recipBound for m≥1. This upgrades the qualitative tendsto_zero into an exact monotone descent — the scaffold for an explicit decay rate. Verified v4.31, no new axiom.",
+      "SATURATED at the axiomatized level (2026-07-19, researcher-1 triage): landmark RothTheoremOQ01 + downstream consequences all delivered and v4.31-verified — reciprocal-sum convergence for 3-AP-free sets (RothTheoremOQ01Reciprocal), k=3 Green–Tao / primes 3-AP (RothTheoremOQ01Primes), recipTail monotone descent, density interface. The only remaining assumption is the IMPORTED Bloom–Sisask bound (rothNumberNat_bloom_sisask); its from-scratch proof is genuinely BLOCKED (>1000 LOC Fourier infra absent from Mathlib). Further tail-majorant sharpening is diminishing returns — do NOT keep re-serving for accretion."
     ],
     "mathlibGaps": [],
     "nextSteps": [

--- a/src/data/research/problems/roth-theorem-oq-01.json
+++ b/src/data/research/problems/roth-theorem-oq-01.json
@@ -18,13 +18,13 @@
   "currentState": {
     "phase": "ORIENT",
     "since": "2026-06-14T17:42:10-07:00",
-    "iteration": 2,
+    "iteration": 3,
     "focus": "Feasibility and approach identified (Session 1, ORIENT). Statement anchored to Mathlib",
     "activeApproach": "SURVEY/axiomatized route. The genuine Fourier/density-increment proof is blocked on missing",
     "blockers": [
       "- Docker build environment down (cannot compile/verify Lean this session)."
     ],
-    "nextAction": "When Docker is up: create `proofs/Proofs/RothTheoremOQ01.lean` with the M1 deliverable —",
+    "nextAction": "Explicit closed-form tail majorant recipTail m ≤ C/m^blasiConst via AntitoneOn.sum_le_integral telescoping (monotone scaffold recipTail_succ/_strictAnti now in place, Session 2026-07-19).",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -50,10 +50,12 @@
       "Uniform (absolute-constant) reciprocal bound: Summable.tsum_le_of_sum_le reduces the infinite-set tsum bound to a finite partial-sum bound over any Finset ↥A; map it injectively (Subtype.val_injective.injOn + Finset.sum_image) to a finite 3-AP-free T⊆ℕ and apply the already-verified finite_recip_sum_le. Positivity of B=∑'_k recipMajorant k via Summable.tsum_pos (k=0 term > 0). This is strictly stronger than threeAPFree_summable_reciprocal: one constant works for all 3-AP-free sets at once.",
       "Dilation covariance (researcher-6): the additive 3-AP-free property over ℕ is preserved by the dilation x↦k·x (k≠0) — threeAPFree_nat_mul_image, proved directly from Mathlibs threeAPFree_iff_eq_right (k·a+k·c=2k·b ⟺ a+c=2b, cancel k via Nat.eq_of_mul_eq_mul_left). Mathlib only has the MULTIPLICATIVE smul_set₀ (GP-free/CancelCommMonoidWithZero); the additive-dilation lemma is NOT in Mathlib. Under the same dilation the reciprocal sum scales by EXACTLY 1/k (dilate_tsum_reciprocal_eq, via Equiv.Set.image + Equiv.tsum_eq + tsum_mul_left), so the dilate k·A obeys the SHARPER bound ∑1/(k·a) ≤ recipBound/k — strictly below the uniform constant for k≥2. Exhibits the universal reciprocal bound as dilation-covariant; orthogonal to the subset-monotone (ThreeAPFree.mono) universal bound. 0 new axioms (threeAPFree_nat_mul_image = [propext] only).",
       "Tail decay (effective concentration): a 3-AP-free set living entirely at height ≥ 2^m has reciprocal sum ≤ recipTail m := ∑'_k recipMajorant(k+m), the dyadic majorant summed over blocks of index ≥ m — a strictly sharper (height-indexed) bound than the single universal constant recipBound = recipTail 0.",
-      "recipTail m → 0 as m → ∞ (tendsto_sum_nat_add on the summable recipMajorant), so the reciprocal mass carried by high 3-AP-free sets is uniformly negligible: ∀ε>0 ∃m one threshold works for ALL such sets at once (exists_height_recip_small)."
+      "recipTail m → 0 as m → ∞ (tendsto_sum_nat_add on the summable recipMajorant), so the reciprocal mass carried by high 3-AP-free sets is uniformly negligible: ∀ε>0 ∃m one threshold works for ALL such sets at once (exists_height_recip_small).",
+      "recipTail is not merely →0 but strictly monotone-descending in an EXPLICIT step: recipTail m = recipMajorant m + recipTail (m+1) (recipTail_succ), so recipTail (m+1) = recipTail m − recipMajorant m and recipTail is strictly antitone (recipTail_strictAnti), with recipTail m < recipBound for m≥1. This upgrades the qualitative tendsto_zero into an exact monotone descent — the scaffold for an explicit decay rate. Verified v4.31, no new axiom."
     ],
     "mathlibGaps": [],
     "nextSteps": [
+      "Explicit closed-form tail majorant recipTail m ≤ C/m^blasiConst: telescope the positive decrements recipMajorant m against a p-series tail bound via AntitoneOn.sum_le_integral (Mathlib/Analysis/SumIntegralComparisons.lean) + Summable.sum_le_tsum + ∫_N^∞ x^{-(1+c)} = N^{-c}/c. ~100–200 LOC real-analysis glue → explicit decay rate in m.",
       "A genuine from-scratch Bourgain proof needs Bohr-set density-increment Fourier analysis (>1000 LOC) not in Mathlib v4.26.0 — BLOCKED, not attemptable in a session.",
       "Optional follow-up: conditional analytic envelope (assume a numeric bound on bourgainConst) proving Behrend ≤ Bourgain RHS directly, analogous to OQ-02 analytic_envelope_conditional.",
       "Optional: state the contrapositive/Erdős form explicitly — if Σ_{a∈A}1/a diverges then A contains a nontrivial 3-term AP (needs the not-summable ⟹ ¬ThreeAPFree direction, a direct contrapositive of threeAPFree_summable_reciprocal).",
@@ -77,7 +79,7 @@
     "mathlib": []
   },
   "started": "2026-06-15T02:22:21.995Z",
-  "lastUpdate": "2026-07-10",
+  "lastUpdate": "2026-07-19",
   "significance": 6,
   "tractability": 4,
   "leanFiles": [
@@ -106,10 +108,10 @@
     {
       "path": "Proofs/RothTheoremOQ01Reciprocal.lean",
       "filename": "RothTheoremOQ01Reciprocal.lean",
-      "lineCount": 316,
-      "theoremCount": 12,
+      "lineCount": 620,
+      "theoremCount": 32,
       "axiomCount": 1,
-      "defCount": 2,
+      "defCount": 3,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/RothTheoremOQ01Reciprocal.lean"

--- a/src/data/research/problems/sylow-theorem-oq-04-oq-03.json
+++ b/src/data/research/problems/sylow-theorem-oq-04-oq-03.json
@@ -56,7 +56,7 @@
     ]
   },
   "knowledge": {
-    "progressSummary": "BUILD (researcher-7): constructed the actual Mathlib MulAction.IwasawaStructure object (sylowIwasawaStructure) for the SL(2,p) conjugation action on its p+1 Sylow p-subgroups — the abelian-normal-generating half of Iwasawa's criterion, incl. the new generation theorem iSup_sylowP_eq_top. Conditional payoff eq_top_of_normal_of_acts_nontrivially (quasi-simplicity modulo quasi-preprimitivity). 3 new decls, 0 new axioms (propext/Classical/Quot). Remaining: IsQuasiPreprimitive + faithful PSL action.",
+    "progressSummary": "SATURATED at the tractable BUILD level (v4.31-verified, 0 axiom/sorry): generation, order |SL(2,p)|=p(p²−1), |PSL|, perfectness, Sylow counts all complete. Deep simplicity theorem BLOCKED on the P¹(𝔽_p)-action quasi-preprimitivity input (>1000 LOC, absent from Mathlib). No productive increment available without that infrastructure.",
     "insights": [
       "The 'Sylow counting argument' framing of the problem is directly realisable as a LOWER BOUND without the full Iwasawa/P^1 machinery: (1) U=range unipotentHom is a Sylow p-subgroup (unipotentSylow); (2) U is NOT normal because its normal closure is all of SL(2,p) (unipotent_normalClosure_eq_top) while |U|=p<|SL|; (3) a unique Sylow would be normal (Sylow.normal_of_subsingleton), so n_p != 1; (4) Sylow III forces n_p ≡ 1 (mod p), and n_p != 1 then gives n_p >= p+1 — the classical p+1 Borels / points of P^1(F_p). The non-normality of U (not raw counting) is the crux; Sylow III supplies the arithmetic jump from >1 to >=p+1.",
       "Perfectness lifts cleanly from the cover to the quotient: for any surjective φ:G↠H, map φ (commutator G) = commutator H (Subgroup.map_commutator + map_top_of_surjective), so a perfect group has perfect quotients. Applied to mk':SL(2,p)↠PSL(2,p)=SL/Z this turns commutator (SL)=⊤ into commutator (PSL)=⊤ — the Iwasawa perfectness hypothesis for the actual simple-group candidate PSL(2,p), not just its cover.",
@@ -72,7 +72,8 @@
       "Order-p element count via disjoint Sylow blocks: order-p elements of SL(2,p) = Finset.univ.biUnion (fun P:Sylow => (univ.filter (·∈P)).erase 1); PairwiseDisjoint from sylowP_eq_of_mem (unique Sylow of a nontrivial element); each block has p−1 elements (card_erase_of_mem + Fintype.card_subtype/Nat.card_eq_fintype_card + card_sylowP); Fintype.card(Sylow p G)=p+1 from card_sylow_eq. Arithmetic (p+1)(p−1)=p²−1 via obtain p=n+1, (n+2)*n+1=(n+1)^2 by ring then omega (treats n²/(n+1)² as atoms). This realises the classical count the file's docstrings advertised as the next ingredient.",
       "The abelian-normal-generating half of Iwasawa's simplicity criterion for PSL(2,p) can be packaged directly over the conjugation action on Sylow p-subgroups (α = Sylow p (SL(2,p)), |α| = p+1): T P = ↑P is abelian (cyclic order p), equivariant (Sylow.coe_subgroup_smul is rfl), and generating. No P¹(F_p) coordinate construction is needed for THIS half.",
       "Remaining gap to isSimpleGroup: [IsQuasiPreprimitive (SL(2,p)) (Sylow p …)] (primitivity of the Sylow-conjugation action = 2-transitivity of PSL on P¹) and FaithfulSMul (fails for SL since centre {±1} acts trivially → must pass to PSL(2,p)). These are the genuinely hard/open pieces.",
-      "Lean gotcha: Subgroup.iSup_induction is NOT elab_as_elim for the multiplicative version (only the to_additive copy got the attr) → `induction h using Subgroup.iSup_induction` fails with 'Too many targets'; apply it as a term via `refine Subgroup.iSup_induction S (C := …) h ?_ ?_ ?_`. Also `group` failed on g*(x*y)*g⁻¹=(g*x*g⁻¹)*(g*y*g⁻¹) in SL(2,p); use MulAut.conj g + map_mul/map_one instead."
+      "Lean gotcha: Subgroup.iSup_induction is NOT elab_as_elim for the multiplicative version (only the to_additive copy got the attr) → `induction h using Subgroup.iSup_induction` fails with 'Too many targets'; apply it as a term via `refine Subgroup.iSup_induction S (C := …) h ?_ ?_ ?_`. Also `group` failed on g*(x*y)*g⁻¹=(g*x*g⁻¹)*(g*y*g⁻¹) in SL(2,p); use MulAut.conj g + map_mul/map_one instead.",
+      "Triage 2026-07-19 (researcher-1): the tractable standalone BUILD is COMPLETE and v4.31-verified (merged, #39062). Both items the stale state.md lists as next-actions are already done: (a) generation closure_rootGroups_eq_top : ⟨U,U⁻⟩=SL(2,p) via Bruhat/Gauss (mem_closure_of_lowerLeft_ne_zero), and (b) the order card_SL2 : |SL(2,p)|=p(p²−1) from Mathlib card_GL_field via the det:GL→𝔽ˣ kernel. Also done: perfectness (commutator_eq_top, p≥5), factorization_card_SL2, card_center_SL2, card_PSL=p(p²−1)/2, Sylow count = p+1, order-p element count = p²−1, and the conditional simplicity eq_top_of_normal_of_acts_nontrivially (modulo the [IsQuasiPreprimitive] hypothesis). Only the deep P¹-action primitivity input remains — BLOCKED (absent from Mathlib). Do NOT re-serve for accretion."
     ],
     "mathlibGaps": [
       "No cardinality of SL(2,𝔽_p) or PSL(2,p) in Mathlib (need |SL(2,𝔽_p)| = p(p²−1)).",
@@ -314,5 +315,14 @@
     "sylow-theorems-oq-02",
     "sylow-theorems-oq-04",
     "sylow-theorems-oq-05"
-  ]
+  ],
+  "currentState": {
+    "blockers": [
+      {
+        "route": "PSL(2,p) simplicity via the P¹(𝔽_p) action: quasi-preprimitivity / 2-transitivity of the conjugation action on Sylow p-subgroups (the [IsQuasiPreprimitive] instance the conditional simplicity theorem assumes)",
+        "reopenCriterion": "Mathlib gains the PSL(2,p) action on P¹(𝔽_p) with Borel point-stabilizers + 2-transitivity, or a direct IsQuasiPreprimitive instance — materially new mechanism (>1000 LOC) required",
+        "blockedAt": "2026-07-19"
+      }
+    ]
+  }
 }


### PR DESCRIPTION
## Summary

Advances **roth-theorem-oq-01** (Bourgain-strength quantitative Roth) by adding the **monotone structure of the reciprocal tail majorant** `recipTail` to `proofs/Proofs/RothTheoremOQ01Reciprocal.lean`. This realizes the *first half* of the flagged next-step (researcher-9, 2026-07-13): "prove `recipTail` antitone (`recipTail (m+1) = recipTail m − recipMajorant m`)".

Where prior sessions proved the reciprocal mass is *finite* (`recipBound`), *dilation-covariant* (`recipBound/k`), and *vanishes at infinity* (`recipTail_tendsto_zero`), this pins down the **exact rate of descent**: the tail constant strictly decreases with the height index `m` in explicit, positive, computable decrements.

## New declarations (7, 0 sorries, no new axiom)

| Theorem | Statement |
|---|---|
| `recipMajorant_pos` | `0 < recipMajorant k` |
| `recipTail_succ` | `recipTail m = recipMajorant m + recipTail (m + 1)` (peel the `k=0` block) |
| `recipTail_succ_eq_sub` | `recipTail (m + 1) = recipTail m − recipMajorant m` |
| `recipTail_antitone` | `Antitone recipTail` |
| `recipTail_strictAnti` | `StrictAnti recipTail` (each peeled majorant `> 0`) |
| `recipTail_le_recipBound` | `recipTail m ≤ recipBound = recipTail 0` |
| `recipTail_lt_recipBound` | `m ≥ 1 → recipTail m < recipBound` |

## Verification

- `./proofs/scripts/docker-build.sh Proofs.RothTheoremOQ01Reciprocal` → **Build succeeded (2502 jobs)** on the current **v4.31** toolchain.
- `#print axioms recipTail_succ` / `recipTail_strictAnti` = `[propext, Classical.choice, Quot.sound, rothNumberNat_bloom_sisask]` — **no new axiom**, no `sorryAx`, no `Lean.ofReduceBool`. The entry's axiom status (the single imported Bloom–Sisask assumption) is unchanged.

## Honest status

Still **axiomatized** overall — this is consequence-layer structure resting on the one imported Bloom–Sisask bound. The from-scratch quantitative Bourgain proof remains BLOCKED (large-spectrum / Bohr-set Fourier infra absent from Mathlib). The remaining unit — an **explicit closed-form majorant** `recipTail m ≤ C/m^{c}` via `AntitoneOn.sum_le_integral` telescoping — is documented in `state.md` next-steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)