### PR TITLE
audit: cevas-theorem-oq-01-oq-01 clean; refresh erdos-39/922 tracker flags

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -13158,13 +13158,13 @@
     },
     "erdos-39": {
       "agentId": "auditor-2026-05-02-0128",
-      "auditCount": 5,
+      "auditCount": 6,
       "issues": [
         "phantom AKS/Ruzsa axiom claims in proofStrategy step 3 + originalContributions[2] (only erdos_sidon_upper_bound is an axiom; AKS/Ruzsa are docstrings on lines 90-98)",
         "section line drift: [3] 57-73 should extend to 86; [4] startLine 74 should be 88; [6] 134-149 misses line 141 marker and theorem at 165; [7] title 'Verified Examples' should be 'Verified Facts' (Lean line 168), startLine 170 should be 168"
       ],
-      "lastAudited": "2026-05-29T07:21:57Z",
-      "result": "clean",
+      "lastAudited": "2026-07-19T15:03:20Z",
+      "result": "issues-found",
       "issueRefs": [
         14434
       ]
@@ -17420,9 +17420,9 @@
     },
     "erdos-922": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-05-16T00:41:09Z",
-      "result": "clean"
+      "auditCount": 5,
+      "lastAudited": "2026-07-19T15:03:02Z",
+      "result": "issues-found"
     },
     "erdos-923": {
       "agentId": "auditor-cycle-20-batch",
@@ -29832,6 +29832,12 @@
     "erdos-220-incomplete-01-oq-01": {
       "auditCount": 1,
       "lastAudited": "2026-07-13T04:23:28Z",
+      "result": "clean",
+      "issues": []
+    },
+    "cevas-theorem-oq-01-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-19T15:04:12Z",
       "result": "clean",
       "issues": []
     }

--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -98,12 +98,6 @@
       "result": "clean",
       "issues": []
     },
-    "abel-ruffini-obstruction-oq-06 burnside-counting-oq-06 chebyshev-bounds-oq-02-oq-01-oq-01 chinese-remainder-non-coprime-oq-02-oq-01 combinations-formula-oq-08-oq-01 descartes-rule-of-signs-oq-01-oq-03 frobenius-number-oq-02-oq-01 lucas-sum-oq-01 odd-cubes-sum-oq-01 odd-squares-sum-oq-01 stars-and-bars-weak-compositions-oq-03 twin-primes-special-oq-02": {
-      "auditCount": 1,
-      "lastAudited": "2026-06-25T21:23:26Z",
-      "result": "clean",
-      "issues": []
-    },
     "abel-ruffini-oq-03": {
       "agentId": "auditor-agent",
       "auditCount": 1,
@@ -2243,12 +2237,6 @@
     "basel-problem-oq-05-oq-03": {
       "auditCount": 1,
       "lastAudited": "2026-06-25T15:53:59Z",
-      "result": "clean",
-      "issues": []
-    },
-    "basel-problem-oq-05-oq-03 bezout-identity-oq-02-oq-02-oq-03 binomial-theorem-oq-03-oq-03 buffons-needle-oq-01-oq-01-oq-05 buffons-noodle-oq-03-oq-01 cevas-theorem-oq-04-oq-04-oq-02 collatz-cycles-oq-02 combinations-formula-oq-04 erdos-1098-oq-01-oq-03 erdos-19-oq-02 erdos-247-oq-01-oq-02 factor-remainder-theorem-oq-01-oq-01-oq-02 fourier-series-oq-04-oq-01-incomplete-01 gamma-reflection-formula-oq-01-oq-03-oq-01-oq-01 godel-incompleteness-oq-02 intermediate-value-theorem-oq-03-oq-01 jacobi-symbol-oq-01-oq-01 law-of-cosines-oq-03-oq-01": {
-      "auditCount": 1,
-      "lastAudited": "2026-06-25T15:53:53Z",
       "result": "clean",
       "issues": []
     },
@@ -5643,12 +5631,6 @@
       "issues": [
         "stale meta counts fixed by PR #24621; counts now match source"
       ]
-    },
-    "central-limit-theorem-oq-02 issues-found": {
-      "auditCount": 1,
-      "lastAudited": "2026-06-15T15:05:05Z",
-      "result": "clean",
-      "issues": []
     },
     "central-limit-theorem-oq-02-oq-03": {
       "auditCount": 1,
@@ -10054,12 +10036,6 @@
       "issues": [
         "r+1-law density argument stated only in prose docstrings was framed as Establishes/prove; 10^7 stability is external (non-Lean). Reworded in PR #24616."
       ]
-    },
-    "erdos-1107-oq-02-oq-01 clean": {
-      "auditCount": 1,
-      "lastAudited": "2026-06-15T15:05:04Z",
-      "result": "clean",
-      "issues": []
     },
     "erdos-1108": {
       "agentId": "auditor-cycle-20-batch",
@@ -18305,12 +18281,6 @@
         "Carmichael dependency/status repaired by PR #24706; counts match source"
       ]
     },
-    "euler-totient-oq-01-oq-03 issues-found": {
-      "auditCount": 1,
-      "lastAudited": "2026-06-15T15:05:05Z",
-      "result": "clean",
-      "issues": []
-    },
     "euler-totient-oq-02": {
       "auditCount": 3,
       "issues": [],
@@ -23242,12 +23212,6 @@
       "result": "clean",
       "issues": []
     },
-    "nth-root-irrational-oq-01-oq-01 clean": {
-      "auditCount": 1,
-      "lastAudited": "2026-06-15T15:05:04Z",
-      "result": "clean",
-      "issues": []
-    },
     "nth-root-irrational-oq-02": {
       "auditCount": 2,
       "lastAudited": "2026-06-18T08:30:11Z",
@@ -25766,12 +25730,6 @@
       "issues": [
         "stray \"-/\" closing the block comment was fixed by PR #24603; file compiles cleanly"
       ]
-    },
-    "sum-of-kth-powers-oq-03 clean": {
-      "auditCount": 1,
-      "lastAudited": "2026-06-15T15:05:05Z",
-      "result": "clean",
-      "issues": []
     },
     "sum-of-kth-powers-oq-04": {
       "auditCount": 4,
@@ -29837,11 +29795,11 @@
     },
     "cevas-theorem-oq-01-oq-01": {
       "auditCount": 1,
-      "lastAudited": "2026-07-19T15:04:12Z",
+      "lastAudited": "2026-07-19T15:12:00Z",
       "result": "clean",
       "issues": []
     }
   },
   "version": 1,
-  "lastUpdated": "2026-07-11T05:31:34Z"
+  "lastUpdated": "2026-07-19T15:12:00Z"
 }


### PR DESCRIPTION
## Gallery integrity audit — tracker consolidation

Queue is fully drained: **4807/4807 audited, 0 critical issues.** This PR consolidates the two overlapping open auditor tracker PRs (this one + #39086) into a single change to avoid a self-conflict on merge.

### cevas-theorem-oq-01-oq-01 — CLEAN ✅
Last unaudited proof in the gallery. Verified against `proofs/Proofs/CevasTheoremOQ01OQ01.lean`:
- 4 theorems, **0 sorries, 0 axioms**, no `native_decide`, no `True` stubs.
- `trig_ceva_product` is **derived** by the file from Mathlib's law of sines (`dist_eq_dist_mul_sin_angle_div_sin_angle`) + supplementary-angle/betweenness lemmas — not a thin wrapper, so `badge: original` / `status: verified` is accurate (Mathlib dependence disclosed in docstring + `assumptions`).
- Claims correctly scoped ("trigonometric ingredient", combined with the affine file) — no pipeline inflation.

### erdos-39 / erdos-922 — refreshed to `issues-found`
v4.31 migration drift, both **already fixed** by open+mergeable PR #39082:
- erdos-39: `axiomCount` 1→2 (`erdos_sidon_upper_bound`, `sidon_counting_upper_bound`; 0 sorries).
- erdos-922: `sorries` 4→3 (lines 99/104/161), `lineCount` 220→216.

### Purge 7 corrupt space-joined tracker keys (folded from #39086)
Malformed `claim-target.sh complete` calls accreted concatenated keys (e.g. `"<slug> <result>"` and multi-slug blobs). Removal is **lossless** — every constituent slug keeps its own entry. Purged: 2 multi-slug blobs + `central-limit-theorem-oq-02 issues-found`, `erdos-1107-oq-02-oq-01 clean`, `euler-totient-oq-01-oq-03 issues-found`, `nth-root-irrational-oq-01-oq-01 clean`, `sum-of-kth-powers-oq-03 clean`.

**Supersedes #39086.** JSON validated (4813 → 4806 entries; 0 space-keys remain).

---
Discovered during gallery integrity audit.