### PR TITLE
audit: cevas-theorem-oq-01-oq-01 clean; purge 7 corrupt tracker keys

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -98,12 +98,6 @@
       "result": "clean",
       "issues": []
     },
-    "abel-ruffini-obstruction-oq-06 burnside-counting-oq-06 chebyshev-bounds-oq-02-oq-01-oq-01 chinese-remainder-non-coprime-oq-02-oq-01 combinations-formula-oq-08-oq-01 descartes-rule-of-signs-oq-01-oq-03 frobenius-number-oq-02-oq-01 lucas-sum-oq-01 odd-cubes-sum-oq-01 odd-squares-sum-oq-01 stars-and-bars-weak-compositions-oq-03 twin-primes-special-oq-02": {
-      "auditCount": 1,
-      "lastAudited": "2026-06-25T21:23:26Z",
-      "result": "clean",
-      "issues": []
-    },
     "abel-ruffini-oq-03": {
       "agentId": "auditor-agent",
       "auditCount": 1,
@@ -2243,12 +2237,6 @@
     "basel-problem-oq-05-oq-03": {
       "auditCount": 1,
       "lastAudited": "2026-06-25T15:53:59Z",
-      "result": "clean",
-      "issues": []
-    },
-    "basel-problem-oq-05-oq-03 bezout-identity-oq-02-oq-02-oq-03 binomial-theorem-oq-03-oq-03 buffons-needle-oq-01-oq-01-oq-05 buffons-noodle-oq-03-oq-01 cevas-theorem-oq-04-oq-04-oq-02 collatz-cycles-oq-02 combinations-formula-oq-04 erdos-1098-oq-01-oq-03 erdos-19-oq-02 erdos-247-oq-01-oq-02 factor-remainder-theorem-oq-01-oq-01-oq-02 fourier-series-oq-04-oq-01-incomplete-01 gamma-reflection-formula-oq-01-oq-03-oq-01-oq-01 godel-incompleteness-oq-02 intermediate-value-theorem-oq-03-oq-01 jacobi-symbol-oq-01-oq-01 law-of-cosines-oq-03-oq-01": {
-      "auditCount": 1,
-      "lastAudited": "2026-06-25T15:53:53Z",
       "result": "clean",
       "issues": []
     },
@@ -5643,12 +5631,6 @@
       "issues": [
         "stale meta counts fixed by PR #24621; counts now match source"
       ]
-    },
-    "central-limit-theorem-oq-02 issues-found": {
-      "auditCount": 1,
-      "lastAudited": "2026-06-15T15:05:05Z",
-      "result": "clean",
-      "issues": []
     },
     "central-limit-theorem-oq-02-oq-03": {
       "auditCount": 1,
@@ -10054,12 +10036,6 @@
       "issues": [
         "r+1-law density argument stated only in prose docstrings was framed as Establishes/prove; 10^7 stability is external (non-Lean). Reworded in PR #24616."
       ]
-    },
-    "erdos-1107-oq-02-oq-01 clean": {
-      "auditCount": 1,
-      "lastAudited": "2026-06-15T15:05:04Z",
-      "result": "clean",
-      "issues": []
     },
     "erdos-1108": {
       "agentId": "auditor-cycle-20-batch",
@@ -18305,12 +18281,6 @@
         "Carmichael dependency/status repaired by PR #24706; counts match source"
       ]
     },
-    "euler-totient-oq-01-oq-03 issues-found": {
-      "auditCount": 1,
-      "lastAudited": "2026-06-15T15:05:05Z",
-      "result": "clean",
-      "issues": []
-    },
     "euler-totient-oq-02": {
       "auditCount": 3,
       "issues": [],
@@ -23242,12 +23212,6 @@
       "result": "clean",
       "issues": []
     },
-    "nth-root-irrational-oq-01-oq-01 clean": {
-      "auditCount": 1,
-      "lastAudited": "2026-06-15T15:05:04Z",
-      "result": "clean",
-      "issues": []
-    },
     "nth-root-irrational-oq-02": {
       "auditCount": 2,
       "lastAudited": "2026-06-18T08:30:11Z",
@@ -25766,12 +25730,6 @@
       "issues": [
         "stray \"-/\" closing the block comment was fixed by PR #24603; file compiles cleanly"
       ]
-    },
-    "sum-of-kth-powers-oq-03 clean": {
-      "auditCount": 1,
-      "lastAudited": "2026-06-15T15:05:05Z",
-      "result": "clean",
-      "issues": []
     },
     "sum-of-kth-powers-oq-04": {
       "auditCount": 4,
@@ -29834,8 +29792,14 @@
       "lastAudited": "2026-07-13T04:23:28Z",
       "result": "clean",
       "issues": []
+    },
+    "cevas-theorem-oq-01-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-19T15:12:00Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,
-  "lastUpdated": "2026-07-11T05:31:34Z"
+  "lastUpdated": "2026-07-19T15:12:00Z"
 }


### PR DESCRIPTION
## Gallery Integrity Audit Cycle

### Audit result: `cevas-theorem-oq-01-oq-01` — CLEAN ✓
Status `verified/original` confirmed accurate against `Proofs/CevasTheoremOQ01OQ01.lean`:
- 4 theorems, **0 sorries, 0 axioms, 0 `native_decide`, 0 `True` stubs**
- Genuinely proves the trigonometric Ceva product identity by assembling Mathlib's law of sines over the two sub-triangles (supplementary-angle sines + `field_simp` cancellation) — not a single-Mathlib-call wrapper.
- Docstring credits "Mathlib's Euclidean geometry" and the law of sines up front → no delegation opacity.
- Scope honest: title "Trigonometric Form" = the product identity actually proved; the concurrency-iff is correctly framed as requiring combination with the affine Ceva file.

### Tracker corruption cleanup
`audit-tracker.json` carried **7 corrupted entry keys** from malformed `complete` calls where the `id` argument absorbed extra tokens:
- 5 keys of form `"<slug> <result>"` (id + result string joined, e.g. `"erdos-1107-oq-02-oq-01 clean"`)
- 2 keys that are space-joined lists of 12 and 18 slugs

Every constituent slug already has its own proper entry, so removal is **lossless** (4819 → 4813 keys). Restores accurate `find-targets` counts (Unaudited 1 → 0).

### Not touched here
`erdos-922` (sorries 4→3) and `erdos-39` (axiomCount 1→2) meta drift from the v4.31 flip are already fixed in open PR #39082.

---
Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)