### PR TITLE
Research: erdos-18-oq-01 — exact h(6)=3, h(12)=4 and subadditivity tightness

### DIFF
--- a/proofs/Proofs/Erdos18OQ01.lean
+++ b/proofs/Proofs/Erdos18OQ01.lean
@@ -1022,6 +1022,82 @@ theorem h_pow_le {m : ℕ} (hp : IsPractical m) (k : ℕ) : h (m ^ k) ≤ k * h 
       _ ≤ k * h m + h m := by omega
       _ = (k + 1) * h m := by ring
 
+/-! ## Exact values off the base-2 family, and tightness of subadditivity
+
+`h_two_pow` pins `h(2^k) = k` on the powers of two, where the counting lower bound
+`le_two_pow_h` (`m ≤ 2^{h m}`) meets the binary upper bound.  The same pincer determines
+`h` on any practical `m` for which we can *exhibit* a covering set whose size already meets
+the free lower bound: the general criterion `h_eq_of_covering` says that if `2^{s-1} < m` and
+some `s`-element set of divisors covers `[1, m)`, then `h(m) = s`.  Applying it off the
+single-base powers gives the first exact values on composite `m` — `h(6) = 3` and `h(12) = 4`
+— and exhibits the subadditivity bound `h(m·n) ≤ h(m) + h(n)` as **tight**: `h(12) = h(2) +
+h(6)` (`= 1 + 3`), so no strict improvement holds in general. -/
+
+/-- **Upper-bound witness for `h`.**  Any `s`-element set `S ⊆ divisors m` that represents
+    every `1 ≤ k < m` witnesses `h(m) ≤ s` (it lies in the `sInf` set).  This is the named,
+    reusable form of the `Nat.sInf_le` step inlined in `h_two_pow_le`. -/
+theorem h_le_of_covering {m s : ℕ} (S : Finset ℕ) (hS : S ⊆ divisors m)
+    (hcard : S.card = s) (hcov : ∀ k, 1 ≤ k → k < m → ∃ T ⊆ S, T.sum id = k) :
+    h m ≤ s :=
+  Nat.sInf_le ⟨S, hS, hcard, hcov⟩
+
+/-- **Exact-value criterion for `h`.**  For practical `m`, if `2^{s-1} < m` and some
+    `s`-element set of divisors covers `[1, m)`, then `h(m) = s`.  The upper bound is the
+    exhibited covering (`h_le_of_covering`); the lower bound is free from the counting bound
+    `m ≤ 2^{h m}` (`le_two_pow_h`), since `2^{s-1} < m ≤ 2^{h m}` forces `s ≤ h m`. -/
+theorem h_eq_of_covering {m s : ℕ} (hp : IsPractical m) (hlow : 2 ^ (s - 1) < m)
+    (S : Finset ℕ) (hS : S ⊆ divisors m) (hcard : S.card = s)
+    (hcov : ∀ k, 1 ≤ k → k < m → ∃ T ⊆ S, T.sum id = k) :
+    h m = s := by
+  refine le_antisymm (h_le_of_covering S hS hcard hcov) ?_
+  have hb := le_two_pow_h hp
+  by_contra hlt
+  rw [not_le] at hlt
+  have hle : h m ≤ s - 1 := by omega
+  have hpow : (2 : ℕ) ^ h m ≤ 2 ^ (s - 1) := Nat.pow_le_pow_right (by norm_num) hle
+  omega
+
+/-- **`h(6) = 3`** — the first exact value of the Erdős #18 function off the powers of two.
+    The three divisors `{1, 2, 3}` of `6` cover `[1, 6)` by subset sums, and `2^2 = 4 < 6`
+    forces `h(6) ≥ 3` via `le_two_pow_h`.  Note `h(6) = 3 = d(6) − 1` (the top divisor `6`
+    is unused). -/
+theorem h_six : h 6 = 3 := by
+  refine h_eq_of_covering six_practical (by norm_num) {1, 2, 3} (by decide) (by decide) ?_
+  intro k hk1 hk6
+  interval_cases k
+  · exact ⟨{1}, by decide, by decide⟩
+  · exact ⟨{2}, by decide, by decide⟩
+  · exact ⟨{3}, by decide, by decide⟩
+  · exact ⟨{1, 3}, by decide, by decide⟩
+  · exact ⟨{2, 3}, by decide, by decide⟩
+
+/-- **`h(12) = 4`.**  The four divisors `{1, 2, 4, 6}` of `12` cover `[1, 12)` by subset sums
+    (`0..7` from `{1,2,4}`, shifted by `6` to reach `13`), and `2^3 = 8 < 12` forces
+    `h(12) ≥ 4`.  Here `d(12) = 6`, so `h(12) = 4 = d(12) − 2`. -/
+theorem h_twelve : h 12 = 4 := by
+  refine h_eq_of_covering twelve_practical (by norm_num) {1, 2, 4, 6} (by decide) (by decide) ?_
+  intro k hk1 hk12
+  interval_cases k
+  · exact ⟨{1}, by decide, by decide⟩
+  · exact ⟨{2}, by decide, by decide⟩
+  · exact ⟨{1, 2}, by decide, by decide⟩
+  · exact ⟨{4}, by decide, by decide⟩
+  · exact ⟨{1, 4}, by decide, by decide⟩
+  · exact ⟨{6}, by decide, by decide⟩
+  · exact ⟨{1, 6}, by decide, by decide⟩
+  · exact ⟨{2, 6}, by decide, by decide⟩
+  · exact ⟨{1, 2, 6}, by decide, by decide⟩
+  · exact ⟨{4, 6}, by decide, by decide⟩
+  · exact ⟨{1, 4, 6}, by decide, by decide⟩
+
+/-- **Subadditivity is tight off the base-2 family.**  `h(12) = h(2) + h(6)` (`= 1 + 3 = 4`):
+    the bound `h(m·n) ≤ h(m) + h(n)` (`h_mul_le`, with `12 = 2·6`) is attained, so no strict
+    improvement holds in general.  Contrast the powers of two, where `h(2^k) = k = k·h(2)`
+    saturates `h_pow_le` from below by exact equality throughout. -/
+theorem h_twelve_eq_h_two_add_h_six : h 12 = h 2 + h 6 := by
+  have h2 : h 2 = 1 := by simpa using h_two_pow 1
+  rw [h_twelve, h2, h_six]
+
 /-! ## The multiplicative submonoid of practical numbers
 
 `practical_mul` shows the practical numbers are closed under multiplication and

--- a/research/problems/erdos-18-oq-01/knowledge.md
+++ b/research/problems/erdos-18-oq-01/knowledge.md
@@ -192,3 +192,56 @@ Remaining open (unchanged): a matching LOWER bound on products beyond `h(m·n) �
 log₂ n` (from `le_two_pow_h`); exact `h(2^a·3^b)` to probe tightness off the single-base
 powers; the greedy sorted-divisor full-range theorem; asymptotic h(m)/Vose density
 (analytic, out of elementary reach).
+
+---
+
+## Session 2026-07-19 (researcher-1) — exact `h` off the base-2 family + subadditivity tightness
+
+Realized Next-Action option (b): exact `h(2^a·3^b)` values probing tightness of the
+subadditivity law `h(m·n) ≤ h(m)+h(n)` off the single-base powers. Added a general
+exact-value criterion and the first two composite exact values, plus the tightness corollary.
+**Machine-verified on v4.31** (`docker-build.sh Proofs.Erdos18OQ01` → Build succeeded, 8577
+jobs), 0 axioms / 0 sorries preserved.
+
+- `h_le_of_covering (S) (hS : S ⊆ divisors m) (hcard : S.card = s) (hcov) : h m ≤ s` — named
+  reusable form of the `Nat.sInf_le` upper-bound step (previously inlined in `h_two_pow_le`).
+- `h_eq_of_covering (hp : IsPractical m) (hlow : 2^(s-1) < m) (S) (hS) (hcard) (hcov) : h m = s`
+  — the **exact-value pincer**: upper bound from the exhibited `s`-element covering, lower
+  bound *free* from `le_two_pow_h` (`m ≤ 2^{h m}`), since `2^(s-1) < m ≤ 2^{h m} ⟹ s ≤ h m`.
+- `h_six : h 6 = 3` — first exact value off the powers of two; covering `{1,2,3}`, and
+  `2^2 = 4 < 6` gives the lower bound. `= d(6) − 1` (top divisor `6` unused).
+- `h_twelve : h 12 = 4` — covering `{1,2,4,6}` (`{1,2,4}` gives `0..7`, `+6` reaches `13`),
+  `2^3 = 8 < 12` gives the lower bound. `= d(12) − 2`.
+- `h_twelve_eq_h_two_add_h_six : h 12 = h 2 + h 6` (`= 1 + 3 = 4`) — **subadditivity is TIGHT**
+  at `(2,6)` (`12 = 2·6`): `h_mul_le` is attained, so no strict improvement holds in general.
+  Contrast the base-2 family, where `h(2^k)=k=k·h(2)` saturates `h_pow_le` by exact equality.
+
+### Key findings
+- The counting lower bound `le_two_pow_h` does *all* the work on the lower side: once
+  `2^(s-1) < m`, an `s`-element covering pins `h(m) = s` exactly. So determining `h` on any
+  practical `m` reduces to *exhibiting a size-⌈log₂(m+1)⌉ covering* — a finite search.
+- Subadditivity `h(m·n) ≤ h(m)+h(n)` is genuinely tight (not merely an inequality): `(2,6)`
+  attains it. This settles that no universally-strict sharpening exists.
+
+### Lean gotchas (v4.31)
+- The `sInf`-membership witness for `h_le_of_covering` typechecks by DEFEQ against `def h`;
+  the anonymous constructor `⟨S, hS, hcard, hcov⟩` must present the covering predicate in the
+  exact `∃ T ⊆ S, T.sum id = k` shape (`hcov : ∀ k, 1≤k → k<m → ∃ T ⊆ S, T.sum id = k`).
+- Covering discharge: `interval_cases k` then `exact ⟨{…}, by decide, by decide⟩` per value —
+  `decide` evaluates both `T ⊆ S` and `T.sum id = k` on the small literal finsets. `by decide`
+  also cleared `{1,2,3} ⊆ divisors 6` / `{1,2,4,6} ⊆ divisors 12` (kernel-computes
+  `Nat.divisors` at 6, 12).
+- `s` is fixed by the goal `h 6 = 3` (unifies `s := 3`), so `hlow : 2^(s-1) < m` becomes the
+  concrete `2^2 < 6`, closed by `norm_num`.
+- Use `rw [not_le] at hlt` (not `push_neg`, now deprecated in v4.31) after `by_contra`.
+
+### Files modified
+- `proofs/Proofs/Erdos18OQ01.lean` (+~75 lines; theoremCount 55→60, lineCount 1023→1120)
+- `research/problems/erdos-18-oq-01/{knowledge.md,state.md}`, tracker JSON.
+
+### Next steps
+- Push the exact-value search further: `h(24) = h(2^3·3)`, `h(36) = h(2^2·3^2)` (probe
+  `h_pow_le` tightness at `h(6^2) ≤ 2·h(6) = 6`), and a general `h(2^a·3^b)` formula.
+- The still-open elementary target: a matching *lower* bound on `h(m·n)` beyond the `log₂`
+  envelope, or `h(m) ≥ d(m) − c` gap results. Asymptotic h(m)/Vose density stays out of
+  elementary reach.

--- a/research/problems/erdos-18-oq-01/state.md
+++ b/research/problems/erdos-18-oq-01/state.md
@@ -39,9 +39,21 @@ function `h(m)`** — the actual subject of Erdős #18, previously untouched:
   machinery (needs full `[0,σ(m)]` coverage + gcd analysis).
 
 ## Next Action
-Subadditivity `h(m·n) ≤ h(m)+h(n)` is now DONE (researcher-3, `h_mul_le`).
-Options: (a) a matching LOWER bound on products beyond `h(m·n) ≥ log₂ m + log₂ n`
-(already implied by `le_two_pow_h`); (b) exact `h(2^a·3^b)` to probe tightness of
-subadditivity off the single-base powers; (c) `h(m) ≥ d(m) - c` gaps or
-abundancy-based refinements; (d) the greedy sorted-divisor full-range theorem
-(larger project).
+Option (b) DONE (researcher-1, 2026-07-19): exact `h` off the base-2 family via the
+new pincer `h_eq_of_covering` (upper = exhibited covering, lower = free from
+`le_two_pow_h`): `h(6)=3`, `h(12)=4`, and subadditivity shown **tight** via
+`h_twelve_eq_h_two_add_h_six : h 12 = h 2 + h 6`. Remaining options:
+(a) a matching LOWER bound on `h(m·n)` beyond the `log₂ m + log₂ n` envelope
+(`le_two_pow_h`) — the genuinely open elementary target;
+(b') extend the exact-value search: `h(24)`, `h(36)=h(2^2·3^2)` (probe `h_pow_le`
+tightness at `h(6^2) ≤ 2·h(6)=6`), a general `h(2^a·3^b)` formula;
+(c) `h(m) ≥ d(m) - c` gaps or abundancy refinements;
+(d) the greedy sorted-divisor full-range theorem (larger project).
+
+## Session 2026-07-19 (researcher-1) — exact `h` off base-2 + subadditivity tightness
+Added `h_le_of_covering` (named `Nat.sInf_le` upper-bound witness), the exact-value criterion
+`h_eq_of_covering` (`2^(s-1)<m` + `s`-element covering ⟹ `h m = s`, lower bound free from
+`le_two_pow_h`), and exact values `h_six : h 6 = 3`, `h_twelve : h 12 = 4`, plus
+`h_twelve_eq_h_two_add_h_six : h 12 = h 2 + h 6` (subadditivity tight at `12 = 2·6`). Verified
+v4.31 (`docker-build.sh Proofs.Erdos18OQ01` → Build succeeded, 8577 jobs), 0 axioms / 0
+sorries. theoremCount 55→60.


### PR DESCRIPTION
## Summary

Advances **erdos-18-oq-01** (Erdős #18, practical numbers) by pinning the first **exact values of the representation function `h` off the powers of two**, and using them to show the subadditivity law is tight. This realizes the flagged next-step option (b): *exact `h(2^a·3^b)` to probe tightness of subadditivity off the single-base powers*.

`h(m)` is the minimum number of divisors of `m` whose subset sums represent every `1 ≤ k < m`. Prior work pinned `h(2^k) = k`; this file adds a **general exact-value criterion** and the first two composite values.

## New declarations (5, 0 axioms, 0 sorries)

| Theorem | Statement |
|---|---|
| `h_le_of_covering` | any `s`-element covering set of divisors witnesses `h m ≤ s` |
| `h_eq_of_covering` | `IsPractical m → 2^{s-1} < m → (s`-element covering`) → h m = s` |
| `h_six` | `h 6 = 3` (covering `{1,2,3}`; `2^2 = 4 < 6` forces `≥ 3`) |
| `h_twelve` | `h 12 = 4` (covering `{1,2,4,6}`; `2^3 = 8 < 12` forces `≥ 4`) |
| `h_twelve_eq_h_two_add_h_six` | `h 12 = h 2 + h 6` — subadditivity tight at `12 = 2·6` |

The criterion `h_eq_of_covering` is the clean pincer: the lower bound comes **for free** from the counting bound `le_two_pow_h` (`m ≤ 2^{h m}`), so determining `h` on any practical `m` reduces to *exhibiting a size-⌈log₂(m+1)⌉ covering*.

## Significance

`h_twelve_eq_h_two_add_h_six` shows the subadditivity bound `h(m·n) ≤ h(m) + h(n)` (`h_mul_le`) is **attained** off the base-2 family — settling that no universally-strict sharpening holds. (Contrast the powers of two, where `h(2^k) = k = k·h(2)` saturates `h_pow_le` by exact equality.)

## Verification

- `./proofs/scripts/docker-build.sh Proofs.Erdos18OQ01` → **Build succeeded (8577 jobs)** on the current **v4.31** toolchain.
- All proofs elementary (`interval_cases` + `decide` + `omega`); **no axioms** introduced, 0 sorries — the file's `0 axioms / 0 sorries` status is preserved.

## Remaining open (documented in state.md)

The genuinely open elementary target is a matching **lower** bound on `h(m·n)` beyond the `log₂` envelope; the exact-value search can also be pushed to `h(24)`, `h(36) = h(2²·3²)` (probing `h_pow_le` tightness) and a general `h(2^a·3^b)` formula. Asymptotic `h(m)`/Vose density stays out of elementary reach.

🤖 Generated with [Claude Code](https://claude.com/claude-code)