### PR TITLE
Research: gallery entry for alternating-series-boole-summation-oq-01-oq-01

### DIFF
--- a/research/problems/alternating-series-boole-summation-oq-01-oq-01/knowledge.md
+++ b/research/problems/alternating-series-boole-summation-oq-01-oq-01/knowledge.md
@@ -43,3 +43,30 @@ Consistency check that pins the sign/weight normalisation:
 Remaining open: identify T_K with Mathlib two-sided alternating-series tail bounds for an
 effective error term; and the gallery entry `src/data/proofs/alternating-series-boole-summation-oq-01-oq-01/`
 is missing (proof on main but no gallery presentation).
+
+---
+
+## Session 2026-07-19 (researcher-1) — created the missing gallery entry (nextStep #2 DONE)
+
+The order-K limit passage (`boole_general_tendsto`, `iterate_altSum_tendsto`,
+`boole_general_tendsto_of_antitone`) and the explicit closed form for T_K
+(`iterate_altSum_limit_closed`, ClosedForm companion) have been on `main` and Docker-verified
+(axiom-free) since researcher-10 (2026-07-12), but the proof had **no gallery presentation** —
+all six sibling entries in the family had `src/data/proofs/<slug>/` dirs except this one.
+
+Created `src/data/proofs/alternating-series-boole-summation-oq-01-oq-01/` (meta.json +
+annotations.json) presenting the primary file `AlternatingSeriesBooleSummationOQ01OQ01.lean`
+(234 L, 10 theorems, 0 axioms, 0 sorries) with the ClosedForm companion described in the
+assumptions/description. Full meta: overview (6 keyInsights, 5 prerequisites), 5 sections, 8
+mainTheorems, 6 mathlibDependencies, conclusion (2 openQuestions), 3 crossReferences, 5
+references. 6 annotations, all anchoring cleanly.
+
+**Verified**: `pnpm annotations:build` → entry in `data-manifest.json`, emitted to
+`public/data/proofs/…` and into `listings.json` / `search-index.json`; **zero** anchor
+warnings for this slug (`--strict` reports 4912 pre-existing warnings across the gallery, none
+referencing this entry). `status: verified`, `badge: mathlib`, theoremCount 10, axiomCount 0.
+
+Remaining open (unchanged, genuinely hard): identify T_K with Mathlib two-sided
+alternating-series tail bounds for an effective unconditional error term at general order —
+needs sign/monotonicity control on Δᴷa (e.g. complete monotonicity of a). This is the only
+remaining item; the family is otherwise saturated at the elementary level.

--- a/research/problems/alternating-series-boole-summation-oq-01-oq-01/state.md
+++ b/research/problems/alternating-series-boole-summation-oq-01-oq-01/state.md
@@ -21,5 +21,16 @@ None yet.
 None.
 
 ## Next Action
-Read problem.md thoroughly and acquire full context.
-Then move to ORIENT phase to explore literature and related proofs.
+Gallery entry created (Session 2026-07-19, researcher-1) — nextStep #2 DONE. The only
+remaining item is genuinely hard: identify the remainder T_K with Mathlib two-sided
+alternating-series tail bounds for an effective unconditional error term at general order,
+which needs sign/monotonicity control on the K-th forward difference Δᴷa (e.g. complete
+monotonicity of a). The family is otherwise saturated at the elementary level.
+
+## Session 2026-07-19 (researcher-1) — created the missing gallery presentation
+The order-K limit passage + explicit closed form for T_K have been on `main` (axiom-free,
+Docker-verified) since researcher-10, but had no `src/data/proofs/` gallery entry (all 6
+siblings did). Created `src/data/proofs/alternating-series-boole-summation-oq-01-oq-01/`
+(meta.json + annotations.json) presenting `AlternatingSeriesBooleSummationOQ01OQ01.lean`
+(234 L, 10 thms, 0 axioms). Verified via `pnpm annotations:build` (entry in data-manifest +
+listings + search-index; zero anchor warnings for this slug). status=verified, badge=mathlib.


### PR DESCRIPTION
## Summary

Creates the **missing gallery presentation** for **alternating-series-boole-summation-oq-01-oq-01** (The Order-K Boole Summation Limit). The formalization has been axiom-free on `main` and Docker-verified since 2026-07-12, but this was the **only entry in its family without a `src/data/proofs/<slug>/` directory** — all six siblings have one, so the verified proof was invisible in the gallery.

## What the proof establishes

Passing the finite order-K Boole summation identity `boole_general` to the limit `m → ∞`: for a convergent alternating series of a null sequence,

```
S = ∑_{k=0}^{K-1} ((-1)^k / 2^{k+1})·(-1)^n (Δᵏa)_n + ((-1)^K / 2^K)·T_K
```

where `Δᵏa` is the k-th forward difference and `T_K` is the limit of the alternating series of the K-th differences (`boole_general_tendsto`). Supporting results: every intermediate difference series converges (`iterate_altSum_tendsto`), and an unconditional antitone version via Mathlib's alternating-series test (`boole_general_tendsto_of_antitone`). A companion file gives the explicit closed form for `T_K`.

## What this PR adds

`src/data/proofs/alternating-series-boole-summation-oq-01-oq-01/`:
- **meta.json** — presents `AlternatingSeriesBooleSummationOQ01OQ01.lean` (234 L, 10 theorems, 0 axioms, 0 sorries): overview (6 key insights, 5 prerequisites), 5 sections, 8 main theorems, 6 mathlib dependencies, conclusion (2 open questions), 3 cross-references, 5 references.
- **annotations.json** — 6 line-anchored annotations covering the file's sections.

Plus research-artifact updates (knowledge.md, state.md, tracker JSON) recording nextStep #2 done.

## Verification

`pnpm annotations:build` picks the entry up into `data-manifest.json`, emits it to `public/data/proofs/`, and indexes it in `listings.json` / `search-index.json` — **zero anchor warnings for this slug**. `status: verified`, `badge: mathlib`, `theoremCount: 10`, `axiomCount: 0`.

This is a **presentation-only** change (data files); the underlying Lean proof already lives on `main` and is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)