### PR TITLE
Fix: repair 2 never-compiled entries — Erdos409 + Erdos451 (batch 3 of #39077)

### DIFF
--- a/proofs/Proofs/Erdos409Problem.lean
+++ b/proofs/Proofs/Erdos409Problem.lean
@@ -154,8 +154,8 @@ theorem erdos_409_density :
 theorem totientPlusOne_eq_self_iff_prime (n : ℕ) (hn : n > 1) :
     totientPlusOne n = n ↔ n.Prime := by
   constructor
-  · intro h; by_contra hnp; exact absurd h (ne_of_gt (iterate_decreasing n hn hnp))
-  · intro hp; unfold totientPlusOne; rw [hp.totient]; omega
+  · intro h; by_contra hnp; exact absurd h (ne_of_lt (iterate_decreasing n hn hnp))
+  · intro hp; unfold totientPlusOne; rw [Nat.totient_prime hp]; omega
 
 /-- Helper: totientIterate n 0 = n (zero iterations is identity). -/
 theorem totientIterate_zero (n : ℕ) : totientIterate n 0 = n := rfl
@@ -265,14 +265,9 @@ theorem sigma_growing :
 theorem sigma_prime_fixed (p : ℕ) (hp : p.Prime) :
     p.divisors.sum id - 1 = p := by
   suffices h : p.divisors.sum id = 1 + p by omega
-  have h_div : p.divisors = {1, p} := by
-    ext d; simp only [Nat.mem_divisors, Finset.mem_insert, Finset.mem_singleton]
-    constructor
-    · rintro ⟨hd, _⟩; exact hp.eq_one_or_self_of_dvd d hd
-    · rintro (rfl | rfl)
-      · exact ⟨one_dvd p, hp.ne_zero⟩
-      · exact ⟨dvd_refl p, hp.ne_zero⟩
-  rw [h_div, Finset.sum_insert (by simp; omega), Finset.sum_singleton]
+  have h_div : p.divisors = {1, p} := Nat.Prime.divisors hp
+  rw [h_div, Finset.sum_insert (by rw [Finset.mem_singleton]; exact hp.one_lt.ne),
+      Finset.sum_singleton]
   simp [id]
 
 /-- Composites strictly grow under σ-iteration: σ(n) − 1 ≥ n + 1 for composite n > 1.
@@ -304,7 +299,7 @@ theorem sigma_composite_growth (n : ℕ) (hn : n > 1) (hnp : ¬n.Prime) :
     rw [Finset.sum_insert (by simp; omega),
         Finset.sum_insert (by rw [Finset.mem_singleton]; omega),
         Finset.sum_singleton]
-    simp [id]
+    simp only [id_eq]; ring
   have hge : n.divisors.sum id ≥ 1 + n.minFac + n := by
     calc n.divisors.sum id
         ≥ ({1, n.minFac, n} : Finset ℕ).sum id :=
@@ -317,7 +312,7 @@ theorem sigma_composite_growth (n : ℕ) (hn : n > 1) (hnp : ¬n.Prime) :
 /-- φ(n) ≥ 2 for n ≥ 3: φ(n) is even (Nat.totient_even) and positive
     (Nat.totient_pos), hence ≥ 2. -/
 theorem totient_ge_two (n : ℕ) (hn : n ≥ 3) : n.totient ≥ 2 := by
-  have hpos : 0 < n.totient := Nat.totient_pos (by omega)
+  have hpos : 0 < n.totient := Nat.totient_pos.mpr (by omega)
   have heven : Even n.totient := Nat.totient_even (by omega : 2 < n)
   obtain ⟨k, hk⟩ := heven
   omega
@@ -339,7 +334,7 @@ theorem iteration_reaches_prime_in :
     · -- n > 1 and not prime, so n ≥ 4
       have hn4 : n ≥ 4 := by
         by_contra h; push_neg at h
-        interval_cases n <;> simp_all [Nat.Prime]
+        interval_cases n <;> exact hp (show Nat.Prime _ by norm_num)
       have hdec := iterate_decreasing n (by omega) hp
       -- totientPlusOne n > 1: φ(n) ≥ 2 for n ≥ 3, so φ(n)+1 ≥ 3
       have hm_gt1 : totientPlusOne n > 1 := by
@@ -371,7 +366,7 @@ theorem iteration_reaches_prime_half :
     · exact ⟨0, Nat.zero_le _, hp⟩
     · have hn4 : n ≥ 4 := by
         by_contra h; push_neg at h
-        interval_cases n <;> simp_all [Nat.Prime]
+        interval_cases n <;> exact hp (show Nat.Prime _ by norm_num)
       have hdec := iterate_decreasing n (by omega) hp
       have hm_gt1 : totientPlusOne n > 1 := by
         unfold totientPlusOne; have := totient_ge_two n (by omega); omega
@@ -407,18 +402,20 @@ theorem one_iteration_infinite :
     {n : ℕ | n > 1 ∧ (totientPlusOne n).Prime}.Infinite := by
   -- The set of odd primes {p prime | p ≠ 2} is infinite
   have h_odd_inf : (setOf Nat.Prime \ {2}).Infinite :=
-    Nat.infinite_setOf_prime.diff (Set.finite_singleton 2)
+    Nat.infinite_setOf_prime.sdiff (Set.finite_singleton 2)
   -- Map odd primes to our target set via p ↦ 2p (injective on ℕ)
-  apply Set.Infinite.mono _
-    (Set.Infinite.image (2 * ·) h_odd_inf (fun a _ b _ h => by omega))
+  have hinj : Set.InjOn (2 * ·) (setOf Nat.Prime \ {2}) :=
+    fun a _ b _ h => by dsimp only at h; omega
+  apply Set.Infinite.mono _ (Set.Infinite.image hinj h_odd_inf)
   -- Show {2p | p odd prime} ⊆ {n > 1 | (totientPlusOne n).Prime}
   rintro n ⟨p, hp_mem, rfl⟩
-  have hp : p.Prime := (Set.mem_diff _).mp hp_mem |>.1
-  have hp2 : p ≠ 2 := fun h =>
-    (Set.mem_diff _).mp hp_mem |>.2 (Set.mem_singleton_iff.mpr h)
+  simp only [Set.mem_setOf_eq]
+  have hp : p.Prime := hp_mem.1
+  have hp2 : p ≠ 2 := hp_mem.2
+  have hp2le := hp.two_le
   refine ⟨by omega, ?_⟩
   -- Key computation: totientPlusOne (2*p) = p
-  suffices h : totientPlusOne (2 * p) = p from h ▸ hp
+  suffices h : totientPlusOne (2 * p) = p by rw [h]; exact hp
   unfold totientPlusOne
   have hcop : Nat.Coprime 2 p :=
     Nat.coprime_two_left.mpr (hp.odd_of_ne_two hp2)

--- a/src/data/proofs/erdos-409/meta.json
+++ b/src/data/proofs/erdos-409/meta.json
@@ -16,14 +16,14 @@
       "primes",
       "dynamical-systems"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 409,
     "erdosUrl": "https://erdosproblems.com/409",
     "erdosProblemStatus": "open",
-    "axiomCount": 0,
-    "assumptions": "AUDIT (issue #39061): NOT machine-verified. This entry never validly compiled. Even under Lean v4.26 the proof only 'passed' because the old `autoImplicit true` default silently bound the undefined identifier `p` as a free implicit variable, rendering the stated theorem vacuously general; under v4.31 (autoImplicit off by default) the file fails with `unknownIdentifier 'p'` and typically additional genuine proof errors. The verification claims below are therefore retracted pending a Lean-source repair (Class A). ORIGINAL METADATA: None. All results are fully proved. 19 theorems including: iterate_decreasing, iteration_terminates, iteration_reaches_prime_in (F(n) ≤ n−2), iteration_reaches_prime_half (F(n) ≤ n/2), sigma_prime_fixed (σ(p)−1=p), sigma_composite_growth (σ(n)−1>n for composite), one_iteration_infinite, and more. Open conjecture; supporting lemmas fully verified.",
-    "lineCount": 424,
+    "axiomCount": 1,
+    "assumptions": "Compiles green on Lean v4.31.0 (mathlib 4.31.0) with 0 sorries and 0 `axiom` declarations (repaired under #39077 from the never-compiled state flagged in #39061). Three supporting facts are discharged by `native_decide` (two_fixed_point: phi(2)+1=2; four_to_three: phi(4)+1=3; and the n=1 base case of iteration_terminates), so the build depends on the `Lean.ofReduceBool` axiom -- hence axiomatized rather than fully verified. Erdos #409 is an OPEN problem: the main quantitative questions (sharp bounds on F(n), whether infinitely many n reach the same prime, the density of n reaching a fixed prime) are stated but not resolved; only the supporting lemmas are proved. Fully-proved supporting results (18 theorems) include iterate_decreasing, iteration_terminates, iteration_reaches_prime_in (F(n) <= n-2), iteration_reaches_prime_half (F(n) <= n/2), one_iteration_infinite (F(n)=1 infinitely often), sigma_prime_fixed (sigma(p)-1=p), and sigma_composite_growth.",
+    "lineCount": 423,
     "mathlib_version": "4.31.0",
     "theoremCount": 18,
     "definitionCount": 3
@@ -45,7 +45,7 @@
       "Number theory (primes, divisibility)"
     ]
   },
-  "sections":   [
+  "sections": [
     {
       "id": "header",
       "title": "Header, Context, and Imports",
@@ -122,7 +122,7 @@
       "Nat"
     ],
     "namespace": null,
-    "lineCount": 424,
+    "lineCount": 423,
     "axiomCount": 0,
     "theoremCount": 18,
     "definitionCount": 3,


### PR DESCRIPTION
Repairs two of the 28 never-compiled Lean entries from #39061 so they compile green on v4.31 (proof-repair half of #39077). Continues batch 1 (#39078) and batch 2 (#39084).

## Erdos409Problem — Totient Iteration to Primes (`erdos-409`)
Class A (flagged `:p`). Real defects beyond the autoImplicit mask:
- `ne_of_gt` → `ne_of_lt` (`iterate_decreasing` yields `<`)
- `hp.totient` → `Nat.totient_prime hp`; hand-rolled divisor set → `Nat.Prime.divisors hp`
- `Nat.totient_pos` is now an iff → `.mpr`
- `Set.Infinite.diff` → `.sdiff`; `Set.Infinite.image` signature update + explicit `InjOn` with beta-reduce
- `interval_cases` prime discharge via type-pinned `norm_num` (elaboration-order fix)

Green build, 0 sorries. Uses `native_decide` in substantive theorems (incl. the `iteration_terminates` base case) → depends on `Lean.ofReduceBool`, so **axiomatized** (also an open Erdős problem). meta: `badge` wip→axiom, `axiomCount` 0→1, assumptions refreshed, lineCount 424→423.

## Erdos451Problem — Bertrand-range avoidance (`erdos-451`)
Class A (flagged `:hp`). Line 135 destructured `hp` before its reuse at line 140; the old `autoImplicit true` silently bound the freed identifier. Fixed by preserving `hp` via `id hp`.

Green build, 0 sorries. Retains its 3 `axiom` declarations (n_k / nk_gt_2k / nk_minimal) → **axiomatized** (unchanged). meta: assumptions retraction cleared, lineCount 185→187.

## Evidence
Both compile via `./proofs/scripts/docker-build.sh` (v4.31.0 image): `Built Proofs.Erdos409Problem`, `Built Proofs.Erdos451Problem`, `Build succeeded`.

Remaining Class A (485OQ01, 529, …) and Class B/C/D/E left for follow-on batches — 485/529 carry heavier multi-defect grinds (ring failures, renamed `Finset.antidiagonal`, systematic parse errors).

Part of #39077.