### PR TITLE
Research: erdos-882-oq-03 — per-step growth constraint (σ_i ∤ a_{i+1}) via nested-subset non-divisibility

### DIFF
--- a/proofs/Proofs/Erdos882ProblemOQ03.lean
+++ b/proofs/Proofs/Erdos882ProblemOQ03.lean
@@ -1116,4 +1116,61 @@ theorem extremal_distinct_not_valid :
     subset_subsetSums _ (by decide)
   exact (hvalid.2 1 h1 2 h2 (by decide)).1 (by decide)
 
+/-!
+### Nested-subset non-divisibility and the per-step growth constraint
+
+The Erdős #882 upper bound `(1+o(1)) log₂ n` is driven by a *growth* phenomenon:
+if we enumerate `A = {a₁ < a₂ < ⋯ < a_k}` and form the prefix sums
+`σ_i = a₁ + ⋯ + a_i`, then `σ_1 < σ_2 < ⋯ < σ_k = ∑ A` is a strictly increasing
+chain of subset sums, and divisibility-freeness forbids `σ_i ∣ σ_j` for `i < j`.
+Because `σ_{i+1} = σ_i + a_{i+1}`, the relation `σ_i ∣ σ_{i+1}` is equivalent to
+`σ_i ∣ a_{i+1}`; so validity forces `σ_i ∤ a_{i+1}` — a partial sum never divides
+the *next* element added.  Below we prove the mechanism at the level of arbitrary
+nested subsets, which subsumes the sorted-prefix picture without needing a sort.
+-/
+
+/-- **Nested subset sums of a valid set never divide.**  Generalises
+    `validSubset_subsetSum_not_dvd_total` (the `T = A` case): for *any* nested pair
+    of non-empty subsets `S ⊊ T ⊆ A` of a valid set, the smaller partial sum `∑ S`
+    does not divide the larger `∑ T`.  Both are subset sums of `A`, and `∑ S < ∑ T`
+    because passing to a strict superset of a positive set strictly increases the
+    sum, so they are distinct values and the divisibility-free condition on
+    `subsetSums A` forbids `∑ S ∣ ∑ T`.  This is the "antichain along a chain"
+    fact: every strictly increasing chain of subset sums is a divisibility
+    antichain. -/
+theorem validSubset_nested_sum_not_dvd {n : ℕ} {A S T : Finset ℕ}
+    (hV : ValidSubset n A) (hST : S ⊂ T) (hTA : T ⊆ A) (hS : S.Nonempty) :
+    ¬ (S.sum id ∣ T.sum id) := by
+  obtain ⟨hbound, hdf⟩ := hV
+  have hpos : ∀ a ∈ A, 1 ≤ a := fun a ha => (hbound a ha).1
+  have hSA : S ⊆ A := (subset_of_ssubset hST).trans hTA
+  obtain ⟨x, hxT, hxS⟩ := Finset.exists_of_ssubset hST
+  have hlt : S.sum id < T.sum id :=
+    Finset.sum_lt_sum_of_subset (subset_of_ssubset hST) hxT hxS
+      (by simp only [id_eq]; exact hpos x (hTA hxT))
+      (by intro j _ _; exact Nat.zero_le _)
+  have hT : T.Nonempty := hS.mono (subset_of_ssubset hST)
+  have hmemS : S.sum id ∈ subsetSums A := sum_mem_subsetSums_of_subset hSA hS
+  have hmemT : T.sum id ∈ subsetSums A := sum_mem_subsetSums_of_subset hTA hT
+  exact (hdf (S.sum id) hmemS (T.sum id) hmemT (Nat.ne_of_lt hlt)).1
+
+/-- **A partial sum never divides an excluded element.**  In a valid set `A`, if
+    `S ⊆ A` is a non-empty partial support and `a ∈ A` lies outside `S`, then
+    `∑ S ∤ a`.  Taking `T = insert a S` in `validSubset_nested_sum_not_dvd` gives
+    `∑ S ∤ ∑ (insert a S) = a + ∑ S`, which is equivalent to `∑ S ∤ a`.  This is
+    the per-step growth constraint `σ_i ∤ a_{i+1}` behind the `(1+o(1)) log₂ n`
+    upper bound, stated for arbitrary supports rather than a sorted prefix. -/
+theorem validSubset_partialSum_not_dvd_elem {n : ℕ} {A S : Finset ℕ} {a : ℕ}
+    (hV : ValidSubset n A) (hS : S.Nonempty) (hSA : S ⊆ A)
+    (ha : a ∈ A) (haS : a ∉ S) :
+    ¬ (S.sum id ∣ a) := by
+  have hins : insert a S ⊆ A := Finset.insert_subset_iff.mpr ⟨ha, hSA⟩
+  have hss : S ⊂ insert a S := Finset.ssubset_insert haS
+  have hnd := validSubset_nested_sum_not_dvd hV hss hins hS
+  have hsum : (insert a S).sum id = a + S.sum id := by
+    rw [Finset.sum_insert haS, id_eq]
+  rw [hsum] at hnd
+  intro hdvd
+  exact hnd (dvd_add hdvd (dvd_refl _))
+
 end Erdos882OQ03

--- a/src/data/research/problems/erdos-882-oq-03.json
+++ b/src/data/research/problems/erdos-882-oq-03.json
@@ -24,7 +24,9 @@
       "Complementation/reflection symmetry: the map s↦∑A−s reflects subsetSums A about ∑A/2 away from its top point. Core subsetSums_reflection (s∈subsetSums A, s≠∑A ⟹ ∑A−s∈subsetSums A) needs NO positivity: any witnessing S with ∑S=s is proper (∑S≠∑A), so complement A\\S is nonempty with ∑(A\\S)=∑A−∑S (Finset.sum_sdiff + Finset.sdiff_nonempty). With positivity it upgrades to an INVOLUTION on the proper subset sums (subsetSums_reflection_mem_erase_iff: s∈(subsetSums A).erase(∑A) ↔ ∑A−s∈…erase, since proper sums are ≥1 so reflections stay <∑A). Sharpest consequence: the LARGEST proper subset sum is EXACTLY ∑A−A.min' (max'_proper_subsetSums_eq) — attained by dropping the min element (sum_erase_mem_subsetSums/sum_sub_min'_mem_subsetSums) and dominating all proper sums via reflection+min'_le_subsetSums. This is the reflection-DUAL of min'_subsetSums_eq_min' and identifies the second-largest value below max'=∑A.",
       "New necessary condition for #882 validity: no PROPER partial sum divides the total. For S⊊A nonempty in valid A, ∑S ∤ ∑A (validSubset_subsetSum_not_dvd_total) — both are subset sums and ∑S<∑A so distinct values, divisibility-free forbids ∑S∣∑A. Specialises (singleton, |A|≥2) to: no element divides ∑A (validSubset_elem_not_dvd_total); |A|=1 needs excluding since the sole element IS the total.",
       "Superincreasing (distinct-subset-sum) ⇏ ValidSubset: {1,2} is superincreasing (attains full 2^2-1=3 distinct sums) but subsetSums {1,2}={1,2,3} has 1|2, so invalid (extremal_distinct_not_valid). Formalizes the gap between the counting extremum and the #882 divisibility-free constraint.",
-      "ValidSubset ⟹ DivisibilityFree A (generators primitive) via A ⊆ subsetSums A + DivisibilityFree.mono (ValidSubset.divisibilityFree_base) — a necessary but far-from-sufficient condition."
+      "ValidSubset ⟹ DivisibilityFree A (generators primitive) via A ⊆ subsetSums A + DivisibilityFree.mono (ValidSubset.divisibilityFree_base) — a necessary but far-from-sufficient condition.",
+      "Per-step growth constraint (nextStep #4, prefix-sum chain): the nested-subset non-divisibility mechanism is now formalized WITHOUT needing a sort. validSubset_nested_sum_not_dvd generalizes validSubset_subsetSum_not_dvd_total (the T=A case) to ANY nested pair S⊊T⊆A of a valid set: ∑S∤∑T, since both are subset sums and ∑S<∑T (Finset.sum_lt_sum_of_subset on a positive set) makes them distinct values that divisibility-freeness separates. This is the antichain-along-a-chain fact — every strictly increasing chain of subset sums is a divisibility antichain.",
+      "Sharp corollary validSubset_partialSum_not_dvd_elem: in a valid A, for S⊆A nonempty and a∈A with a∉S, ∑S∤a. Obtained by taking T=insert a S in the nested lemma: ∑S∤∑(insert a S)=a+∑S, and ∑S∣(a+∑S)⟺∑S∣a (dvd_add / dvd_refl). This is exactly the σ_i∤a_{i+1} per-step constraint behind the (1+o(1))log₂n upper bound, stated for arbitrary supports rather than a sorted prefix — no element outside a partial support is ever divisible by that partial sum."
     ],
     "builtItems": [
       "Erdos882ProblemOQ03.lean: 4 defs + 17 theorems, 0 axioms, 0 sorries, self-contained.",
@@ -41,14 +43,15 @@
       "Erdos882Problem.lean (PARENT) TOOLCHAIN-DRIFT REPAIR: now builds under current Mathlib (v4.26). Fixes: granular imports → import Mathlib (Finset.sum_le_sum unavailable under old barrels); Algebra.id.smul_eq_mul → smul_eq_mul (renamed); maxValidSize Nat.find/dite needed Decidable — added `open Classical in` for classical DecidablePred. 2 axioms intact (upper_bound_refined, lower_bound_max — deep analytic bounds), 0 sorries. Restores the broken parent gallery file.",
       "Erdos882ProblemOQ03.lean: divisibilityFree_iff_isAntichain (DivisibilityFree S ↔ IsAntichain (·∣·) (↑S:Set ℕ)) + DivisibilityFree.isAntichain — bridges the ad-hoc predicate to Mathlib IsAntichain, unlocking the antichain API (the explicit nextStep request). Key: IsAntichain already quantifies over BOTH orders of each pair, so single ¬(a∣b) ∀a≠b ≡ symmetric ¬(a∣b)∧¬(b∣a). Membership via Finset.mem_coe. 2 thm, axiom-free.",
       "Erdos882ProblemOQ03.lean: validSubset_subsetSums_isAntichain (subset sums of a valid A form an IsAntichain(·∣·), via the divisibilityFree_iff_isAntichain bridge) + validSubset_subsetSum_not_dvd_total (no proper partial sum divides the total) + validSubset_elem_not_dvd_total (singleton specialisation, |A|≥2). 3 thm, 0 axioms, 0 sorries.",
-      "Erdos882ProblemOQ03.lean: ValidSubset.divisibilityFree_base (valid ⟹ base set divisibility-free) + extremal_distinct_not_valid (superincreasing counting-extremal witness {1,2} is invalid for every n). 2 thm, 0 axioms, plain decide only. Also modernized deprecated Finset.notMem_erase/notMem_empty/card_insert_of_notMem call sites."
+      "Erdos882ProblemOQ03.lean: ValidSubset.divisibilityFree_base (valid ⟹ base set divisibility-free) + extremal_distinct_not_valid (superincreasing counting-extremal witness {1,2} is invalid for every n). 2 thm, 0 axioms, plain decide only. Also modernized deprecated Finset.notMem_erase/notMem_empty/card_insert_of_notMem call sites.",
+      "Erdos882ProblemOQ03.lean: added Nested-subset non-divisibility section (2 thm, 0-axiom, host-VERIFIED via lake env lean under v4.31.0 main toolchain — propext/Classical.choice/Quot.sound only): validSubset_nested_sum_not_dvd (S⊊T⊆A valid ⟹ ∑S∤∑T, generalizes the T=A total case) and validSubset_partialSum_not_dvd_elem (S⊆A nonempty, a∈A\\S ⟹ ∑S∤a, the σ_i∤a_{i+1} growth constraint). File now 1176 lines, 0 axioms, 0 sorries."
     ],
-    "progressSummary": "PROGRESS: formalized that the counting extremum (superincreasing/distinct sums) is strictly weaker than #882 validity via extremal_distinct_not_valid ({1,2}) and the necessary condition ValidSubset.divisibilityFree_base. 0-axiom (propext/choice/Quot only, plain decide).",
+    "progressSummary": "PROGRESS: formalized the per-step growth mechanism (nextStep #4) as nested-subset non-divisibility — validSubset_nested_sum_not_dvd (∑S∤∑T for S⊊T⊆A valid) and its corollary validSubset_partialSum_not_dvd_elem (∑S∤a for excluded a), the σ_i∤a_{i+1} constraint, without needing a sorted prefix. 0-axiom, host-verified.",
     "nextSteps": [
-      "Investigate the divisibility-free (ValidSubset) upper bound proper: does DivisibilityFree(subsetSums A) force any near-distinctness, or is a genuinely different antichain argument needed? Now that DivisibilityFree ↔ IsAntichain (·∣·) is available, reuse Mathlib antichain lemmas on subsetSums A.",
-      "With the parent repaired, consider re-linking the self-contained OQ03 structural lemmas back against the parent predicates (or confirm the re-declaration is intentionally kept independent).",
-      "Push the antichain framing further: with subsetSums A an IsAntichain(·∣·) all in [1,∑A]⊆[1,n|A|], investigate whether any Mathlib antichain/Sperner-type bound applies (note plain divisibility antichains in [1,N] can be ~N/2, so the log bound needs the subset-sum lattice structure, not antichain size alone).",
-      "Formalise the sorted prefix-sum chain σ_1<…<σ_k=∑A: divisibility-free ⟹ σ_i∤σ_j (i<j), equivalently σ_i∤a_{i+1}, giving a per-step growth constraint toward the log₂n bound."
+      "Quantify the growth: from validSubset_partialSum_not_dvd_elem (∑S∤a for a outside S), derive a per-step LOWER bound on how fast a maximal nested chain of partial sums must grow — the arithmetic step from σ_i∤a_{i+1} toward σ_{i+1}≥(1+c)σ_i that powers the (1+o(1))log₂n bound (note: the full Erdős upper bound proof is non-elementary; target only the elementary chain steps).",
+      "Package the sorted prefix chain explicitly: use A.sort (·≤·) to realize σ_1<…<σ_k=∑A as a concrete strictly increasing sequence in subsetSums A of length |A|, and instantiate validSubset_nested_sum_not_dvd along it to get a length-|A| divisibility antichain inside [1,∑A].",
+      "Push the antichain framing: with subsetSums A an IsAntichain(·∣·) in [1,∑A]⊆[1,n|A|], investigate whether a Mathlib antichain/Sperner-type bound applies (plain divisibility antichains in [1,N] can be ~N/2, so the log bound needs the subset-sum lattice structure, not antichain size alone).",
+      "Re-link the self-contained OQ03 structural lemmas back against the repaired parent predicates, or confirm the re-declaration is intentionally kept independent."
     ]
   },
   "relatedProofs": [
@@ -71,10 +74,10 @@
     {
       "path": "Proofs/Erdos882ProblemOQ03.lean",
       "filename": "Erdos882ProblemOQ03.lean",
-      "lineCount": 496,
-      "theoremCount": 25,
+      "lineCount": 1176,
+      "theoremCount": 67,
       "axiomCount": 0,
-      "defCount": 5,
+      "defCount": 7,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos882ProblemOQ03.lean"


### PR DESCRIPTION
## Summary

Research session for **erdos-882-oq-03** (Structural theory of valid subset-sum sets, child of Erdős #882). Advances the prior session's `nextStep #4` — formalize the prefix-sum chain growth constraint `σ_i ∤ a_{i+1}` — by supplying the underlying mechanism at the level of arbitrary nested subsets, so **no sort is required**.

Two new theorems in `proofs/Proofs/Erdos882ProblemOQ03.lean` (0 axioms, 0 sorries):

- **`validSubset_nested_sum_not_dvd`** — for any nested pair `S ⊊ T ⊆ A` of a valid set, `∑S ∤ ∑T`. Generalizes the existing `validSubset_subsetSum_not_dvd_total` (the `T = A` total case). Both partial sums are subset sums of `A`, and `∑S < ∑T` (a strict superset of a positive set has strictly larger sum, via `Finset.sum_lt_sum_of_subset`), so they are distinct values that the divisibility-free condition on `subsetSums A` separates. This is the *antichain-along-a-chain* fact: every strictly increasing chain of subset sums is a divisibility antichain.

- **`validSubset_partialSum_not_dvd_elem`** — for `S ⊆ A` non-empty and `a ∈ A` with `a ∉ S`, `∑S ∤ a`. Taking `T = insert a S` above gives `∑S ∤ ∑(insert a S) = a + ∑S`, and `∑S ∣ (a + ∑S) ⟺ ∑S ∣ a`. This is exactly the per-step growth constraint `σ_i ∤ a_{i+1}` behind the `(1+o(1)) log₂ n` upper bound — no element outside a partial support is ever divisible by that partial sum.

## Verification

Host-verified with `lake env lean Proofs/Erdos882ProblemOQ03.lean` under the repo's `v4.31.0` main toolchain — clean elaboration, exit 0. `#print axioms` on both new theorems lists only `propext, Classical.choice, Quot.sound` (genuinely axiom-free by project convention). File is now 1176 lines, 0 axioms, 0 sorries.

## Notes

- Self-contained file; no changes to the parent predicates.
- Tracker knowledge updated; stale `leanFiles` metrics for the OQ03 file refreshed (496→1176 lines).

🤖 Generated with [Claude Code](https://claude.com/claude-code)