### PR TITLE
Fix: repair never-compiled Erdos856Problem (batch 4 of #39077)

### DIFF
--- a/proofs/Proofs/Erdos856Problem.lean
+++ b/proofs/Proofs/Erdos856Problem.lean
@@ -38,9 +38,8 @@ import Mathlib.Data.Nat.GCD.Basic
 import Mathlib.Data.Finset.Basic
 import Mathlib.Data.Real.Basic
 import Mathlib.Analysis.SpecialFunctions.Log.Basic
+import Mathlib.Analysis.SpecialFunctions.Pow.Real
 import Mathlib.Algebra.Order.BigOperators.Group.Finset
-
-set_option autoImplicit true
 
 open Nat Real Finset BigOperators
 
@@ -105,7 +104,8 @@ noncomputable def harmonicSum (A : Finset ℕ) : ℝ :=
 The maximum harmonic sum over all k-LCM-free subsets of {1,...,N}.
 -/
 noncomputable def f_k (k N : ℕ) : ℝ :=
-  sSup { harmonicSum A | A : Finset ℕ ∧ (∀ a ∈ A, 1 ≤ a ∧ a ≤ N) ∧ IsLCMFree A k }
+  sSup { s : ℝ | ∃ A : Finset ℕ,
+    (∀ a ∈ A, 1 ≤ a ∧ a ≤ N) ∧ IsLCMFree A k ∧ s = harmonicSum A }
 
 /-
 ## Part IV: Erdős's Upper Bound
@@ -148,7 +148,7 @@ There exist constants 0 < b_k ≤ c_k ≤ 1 such that
 A k-sunflower is a collection of k sets where any two have the same
 intersection (the "core").
 -/
-def IsSunflower {α : Type*} (sets : Finset (Finset α)) (k : ℕ) : Prop :=
+def IsSunflower {α : Type*} [DecidableEq α] (sets : Finset (Finset α)) (k : ℕ) : Prop :=
   sets.card = k ∧
   ∃ core : Finset α, ∀ S ∈ sets, ∀ T ∈ sets, S ≠ T → S ∩ T = core
 
@@ -179,7 +179,8 @@ c_k < 1 (non-trivial upper bound) iff sunflower conjecture holds for k.
 Instead of maximizing Σ 1/n, we maximize |A|.
 -/
 noncomputable def g_k (k N : ℕ) : ℕ :=
-  sSup { A.card | A : Finset ℕ ∧ (∀ a ∈ A, 1 ≤ a ∧ a ≤ N) ∧ IsLCMFree A k }
+  sSup { m : ℕ | ∃ A : Finset ℕ,
+    (∀ a ∈ A, 1 ≤ a ∧ a ≤ N) ∧ IsLCMFree A k ∧ m = A.card }
 
 /- 
 **Erdős's Construction (1970):**
@@ -201,7 +202,7 @@ The k=3 case for natural density (Problem #536) remains interesting.
 If A = {d : d | n}, then all pairs have lcm = n (if coprime to core).
 So divisor sets typically have uniform pairwise LCM structure.
 -/
-theorem divisor_set_lcm (n : ℕ) (hn : n > 0) :
+theorem divisor_set_lcm (n : ℕ) (_hn : n > 0) :
     ∀ a b : ℕ, a ∣ n → b ∣ n → a ≠ b → myLcm a b ∣ n := by
   intros a b ha hb _
   exact Nat.lcm_dvd_iff.mpr ⟨ha, hb⟩

--- a/src/data/proofs/erdos-856/meta.json
+++ b/src/data/proofs/erdos-856/meta.json
@@ -23,8 +23,8 @@
     "erdosUrl": "https://erdosproblems.com/856",
     "erdosProblemStatus": "open",
     "axiomCount": 0,
-    "lineCount": 260,
-    "assumptions": "AUDIT (issue #39061): NOT machine-verified. This entry never validly compiled. Even under Lean v4.26 the proof only 'passed' because the old `autoImplicit true` default silently bound the undefined identifier `A` as a free implicit variable, rendering the stated theorem vacuously general; under v4.31 (autoImplicit off by default) the file fails with `unknownIdentifier 'A'` and typically additional genuine proof errors. The verification claims below are therefore retracted pending a Lean-source repair (Class A). ORIGINAL METADATA: None. Fully verified with 0 axioms and 0 sorries. Open conjecture; supporting lemmas fully verified.",
+    "lineCount": 263,
+    "assumptions": "REPAIRED (issue #39077, follow-on to #39061): the Lean file now compiles green on Lean v4.31 (autoImplicit off) with 0 axioms and 0 sorries. The previously-masked defects were fixed: two malformed image set-builders `{ f A | A : Finset ℕ ∧ ... }` (whose `Type ∧ Prop` binder had left `A` silently auto-bound) were rewritten as explicit existential comprehensions; `IsSunflower` gained the `[DecidableEq α]` needed for Finset `∩`; and the missing `Mathlib.Analysis.SpecialFunctions.Pow.Real` import was added for the real-exponent `Real.log N ^ (c ± ε)`. The formalization states the definitions (k-LCM-free sets, harmonic-sum extremal function f_k, sunflowers) and proves supporting lemmas (lcm commutativity/idempotence, divisor-set LCM divisibility). Erdős Problem #856 itself — the precise growth rate of f_k(N) — remains OPEN; it is stated as a Prop, not assumed, so there are no axioms or structure-encoded assumptions.",
     "mathlib_version": "4.31.0",
     "theoremCount": 4,
     "definitionCount": 10
@@ -144,7 +144,7 @@
       "Nat"
     ],
     "namespace": "Erdos856",
-    "lineCount": 260,
+    "lineCount": 263,
     "axiomCount": 0,
     "sorries": 0,
     "definitionCount": 10,


### PR DESCRIPTION
## Summary

Batch 4 of the proof-repair follow-on to #39077 (#39061). Repairs the never-compiled `Erdos856Problem` entry so it compiles green on Lean v4.31.

`Erdos856Problem` never validly compiled: two image set-builders `{ f A | A : Finset ℕ ∧ ... }` had a malformed `Type ∧ Prop` binder, so `A` was only bound via the old `autoImplicit true` default (which the file explicitly set). Removing `autoImplicit` exposed the genuine, previously-masked errors.

## Fixes

- Rewrote both set-builders (`f_k`, `g_k`) as explicit existential comprehensions.
- Added `[DecidableEq α]` to `IsSunflower` for the `Finset` `∩` instance.
- Added missing `import Mathlib.Analysis.SpecialFunctions.Pow.Real` for the real-exponent `Real.log N ^ (c ± ε)` in `openProblem_precise_exponent`.
- Renamed unused hyp `hn` → `_hn`.

## Evidence

Before (v4.31, autoImplicit removed): `Inter (Finset α)` synth failure @152, `HPow ℝ ℝ` synth failures @227/228.

After:
```
✔ [1981/1981] Built Proofs.Erdos856Problem (771ms)
Build completed successfully (1981 jobs).
=== Build succeeded ===
```

0 axioms / 0 sorries. Erdős Problem #856 itself remains **open** — it is stated as a `Prop` (not assumed via axiom), so meta stays `axiomatized`/`wip` (matching sibling open entries erdos-1/10/1003). The stale `assumptions` note claiming the entry "never compiled / fails under v4.31" is corrected to describe the repair.

## Metadata

`src/data/proofs/erdos-856/meta.json`: `lineCount` 260→263, `assumptions` rewritten (retraction removed). Counts verified: theoremCount=4, definitionCount=10, axiomCount=0, sorries=0.

Part of #39077.