### PR TITLE
Research: basel-problem-oq-01-oq-02 — ℚ-linear independence of the even zeta values

### DIFF
--- a/proofs/Proofs/BaselProblemOQ01OQ02.lean
+++ b/proofs/Proofs/BaselProblemOQ01OQ02.lean
@@ -694,6 +694,65 @@ theorem zeta_two_inv_transcendental :
   have := zeta_even_inv_transcendental 1 one_pos
   simpa using this
 
+/-- **ℚ-linear independence of the even zeta values.**  An arbitrary finite ℚ-linear
+    combination of *distinct* even zeta values is transcendental over ℚ as soon as one
+    coefficient is nonzero: for a finite index set `s`, an index map `f` that is injective
+    on `s` with `f i ≥ 1`, and rationals `c i` not all zero on `s`, the value
+    `∑_{i∈s} c i · ζ(2 f i)` is transcendental.
+
+    This is the *additive* capstone matching the multiplicative
+    `zeta_even_finset_prod_transcendental`, and it strictly generalises the two-term
+    `zeta_even_add_transcendental` / `zeta_even_sub_transcendental` to any number of terms.
+    Writing each `ζ(2 f i) = q_{f i}·π^(2 f i)` (Euler, axiom-free), the combination equals
+    `aeval π (∑_{i∈s} C(c i · q_{f i})·X^(2 f i))`.  Because `f` is injective on `s` the
+    monomials have pairwise-distinct degrees `2 f i`, so no two can cancel; picking any `j`
+    with `c j ≠ 0` the coefficient at degree `2 f j` is `c j · q_{f j} ≠ 0` with `2 f j > 0`,
+    so the polynomial is nonconstant and `transcendental_aeval_pi` applies.  In particular no
+    nontrivial rational relation `∑ c i · ζ(2 f i) = 0` holds — the even zeta values
+    `ζ(2), ζ(4), ζ(6), …` are **ℚ-linearly independent** (the additive counterpart of the
+    algebraic *dependence* recorded by `zeta_even_cross_pow_ratio_rational`).
+
+    **Assumption:** `hermite_lindemann` (transcendence of π). -/
+theorem zeta_even_linearCombo_transcendental {ι : Type*} (f : ι → ℕ) (c : ι → ℚ)
+    (s : Finset ι) (hf_pos : ∀ i ∈ s, 0 < f i) (hf_inj : Set.InjOn f s)
+    (hc : ∃ j ∈ s, c j ≠ 0) :
+    Transcendental ℚ (∑ i ∈ s, (c i : ℝ) * (∑' k : ℕ, 1 / (k : ℝ) ^ (2 * f i))) := by
+  classical
+  -- Euler's axiom-free closed form for each index: ζ(2 f i) = q i · π^(2 f i), q i ≠ 0.
+  have hex : ∀ i ∈ s, ∃ r : ℚ, r ≠ 0 ∧
+      (∑' k : ℕ, 1 / (k : ℝ) ^ (2 * f i)) = (r : ℝ) * π ^ (2 * f i) :=
+    fun i hi => zeta_even_eq_rat_mul_pi_pow (f i) (hf_pos i hi)
+  choose! q hq_ne hq_eq using hex
+  -- The rational polynomial whose evaluation at π is the combination.
+  set p : Polynomial ℚ :=
+    ∑ i ∈ s, Polynomial.C (c i * q i) * Polynomial.X ^ (2 * f i) with hp
+  -- aeval π p reproduces ∑ c i · ζ(2 f i).
+  have haeval : Polynomial.aeval π p
+      = ∑ i ∈ s, (c i : ℝ) * (∑' k : ℕ, 1 / (k : ℝ) ^ (2 * f i)) := by
+    rw [hp, map_sum]
+    refine Finset.sum_congr rfl fun i hi => ?_
+    rw [map_mul, map_pow, Polynomial.aeval_C, Polynomial.aeval_X, hq_eq i hi, eq_ratCast]
+    push_cast; ring
+  -- p is nonconstant: pick j with c j ≠ 0; the coefficient at degree 2·f j survives.
+  obtain ⟨j, hjs, hcj⟩ := hc
+  have hcoeff : p.coeff (2 * f j) = c j * q j := by
+    rw [hp, Polynomial.finsetSum_coeff, Finset.sum_eq_single j]
+    · rw [Polynomial.coeff_C_mul, Polynomial.coeff_X_pow, if_pos rfl, mul_one]
+    · intro i hi hij
+      have hne : ¬ (2 * f j = 2 * f i) := by
+        intro heq
+        exact hij (hf_inj (Finset.mem_coe.mpr hi) (Finset.mem_coe.mpr hjs) (by omega))
+      rw [Polynomial.coeff_C_mul, Polynomial.coeff_X_pow, if_neg hne, mul_zero]
+    · intro hjs'; exact absurd hjs hjs'
+  have hpne : p.natDegree ≠ 0 := by
+    have hcq : c j * q j ≠ 0 := mul_ne_zero hcj (hq_ne j hjs)
+    have hle : 2 * f j ≤ p.natDegree :=
+      Polynomial.le_natDegree_of_ne_zero (by rw [hcoeff]; exact hcq)
+    have hpos : 0 < f j := hf_pos j hjs
+    omega
+  rw [← haeval]
+  exact transcendental_aeval_pi p hpne
+
 /-!
 ## The open odd case (documentation only)
 

--- a/src/data/research/problems/basel-problem-oq-01-oq-02.json
+++ b/src/data/research/problems/basel-problem-oq-01-oq-02.json
@@ -44,7 +44,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: added the cross-power algebraic-DEPENDENCE layer to BaselProblemOQ01OQ02.lean — ζ(2n)^m/ζ(2m)^n ∈ ℚ (zeta_even_cross_pow_ratio_rational) and its proportionality form (zeta_even_cross_pow_proportional). Both axiom-free (NO hermite_lindemann; π cancels exactly), complementing the existing π-power-incommensurability of plain ratios and showing all even zeta values lie in the transcendence-degree-1 field ℚ(π).",
+    "progressSummary": "PROGRESS: added additive capstone zeta_even_linearCombo_transcendental — any finite ℚ-linear combination of distinct even zeta values is transcendental, establishing ℚ-LINEAR INDEPENDENCE of ζ(2),ζ(4),ζ(6),… (additive analogue of the multiplicative finset-product capstone; generalizes pairwise add/sub to n terms). Docker-verified green, single hermite_lindemann assumption.",
     "builtItems": [
       "basel_hasSum : HasSum (fun n => 1/n^2) (pi^2/6) — Euler's Basel identity via Mathlib hasSum_zeta_two (Wiedijk #14).",
       "basel_tsum : tsum form of the Basel identity.",
@@ -57,7 +57,8 @@
       "BaselProblemOQ01OQ02.lean (researcher-6, 2026-07-11): subtraction family completing the ± frontier — zeta_even_sub_transcendental (ζ(2n)−ζ(2m), m<n; polynomial C qn·X^2n + C(−qm)·X^2m, natDegree 2n≠0 via natDegree_add_eq_left_of_natDegree_lt, aeval via map_neg+eq_ratCast+ring), zeta_four_sub_zeta_two_transcendental, transcendental_sub_ratCast (axiom-free, via transcendental_add_ratCast(−q)), zeta_even_sub_ratCast_transcendental. 3 carry only hermite_lindemann, engine is 0-axiom; VERIFIED green lake env lean v4.26.0.",
       "BaselProblemOQ01OQ02.lean: zeta_even_cross_pow_ratio_rational — ζ(2n)^m/ζ(2m)^n ∈ ℚ (π cancels exactly), axiom-free.",
       "BaselProblemOQ01OQ02.lean: zeta_even_cross_pow_proportional — ∃ q≠0, ζ(2n)^m = q·ζ(2m)^n (proportionality form), axiom-free.",
-      "Proofs/BaselProblemOQ01OQ02Graded.lean — graded multiplicativity ζ(2n)ζ(2m)=q·ζ(2(n+m)) + ratio form; researcher-5, axiom-free"
+      "Proofs/BaselProblemOQ01OQ02Graded.lean — graded multiplicativity ζ(2n)ζ(2m)=q·ζ(2(n+m)) + ratio form; researcher-5, axiom-free",
+      "BaselProblemOQ01OQ02.lean: zeta_even_linearCombo_transcendental — finite ℚ-linear combination ∑_{i∈s} cᵢ·ζ(2 f i) (f injective on s, f i≥1, some cᵢ≠0) transcendental over ℚ, i.e. even zeta values are ℚ-linearly independent. Docker-VERIFIED green v4.31.0 (8578 jobs); axioms=[propext,Classical.choice,hermite_lindemann,Quot.sound], no sorryAx. Modernized deprecated finset_sum_coeff→finsetSum_coeff. File 706→765 lines, 42 thm."
     ],
     "insights": [
       "The odd-zeta question asked by this slug is OPEN; it cannot be closed, only framed/contrasted with the even case.",
@@ -69,7 +70,9 @@
       "The n=0 term is 0 by the 1/0=0 convention, so the natural-number-indexed sum agrees with the classical n>=1 sum.",
       "Classical clean extensions are saturated in siblings: pi^2/8 (odd), pi^2/12 (alternating), zeta(6); a new brick here would be pure accretion.",
       "Transcendence over ℚ is preserved when scaling a transcendental by a nonzero rational: q·x algebraic ⟹ x = q⁻¹·(q·x) algebraic. This upgrades ζ(2n) from irrational to transcendental with no extra axiom, since π^(2n) is already transcendental (pi_transcendental_over_rationals.pow).",
-      "Even zeta values are algebraically DEPENDENT (commensurable after crossing exponents): ζ(2n)^m/ζ(2m)^n ∈ ℚ, since both equal (rational)·π^(2nm) with the identical π-power. This is axiom-free (no hermite_lindemann — π cancels), complementing the incommensurability of plain ratios, and shows all even zetas lie in ℚ(π)."
+      "Even zeta values are algebraically DEPENDENT (commensurable after crossing exponents): ζ(2n)^m/ζ(2m)^n ∈ ℚ, since both equal (rational)·π^(2nm) with the identical π-power. This is axiom-free (no hermite_lindemann — π cancels), complementing the incommensurability of plain ratios, and shows all even zetas lie in ℚ(π).",
+      "Additive capstone / ℚ-linear independence: the even zeta values ζ(2),ζ(4),ζ(6),… are ℚ-LINEARLY INDEPENDENT — any finite ℚ-linear combination ∑cᵢ·ζ(2 f i) over distinct indices (f injective on the support, f i≥1) with some cᵢ≠0 is transcendental over ℚ (zeta_even_linearCombo_transcendental). Additive analogue of the multiplicative finset-product capstone zeta_even_finset_prod_transcendental; strictly generalizes two-term zeta_even_add/sub_transcendental to arbitrarily many terms. Complements the algebraic DEPENDENCE (zeta_even_cross_pow_ratio_rational): the values are algebraically dependent (all in ℚ(π)) yet ℚ-linearly independent.",
+      "Proof mechanism: ∑cᵢ·ζ(2 f i) = aeval π (∑ᵢ C(cᵢ·qᵢ)·X^(2 f i)) via Euler ζ(2n)=qₙπ^(2n) (axiom-free); f injective on support ⟹ monomials have distinct degrees 2 f i, so for any j with cⱼ≠0 the coeff at 2 f j is cⱼ·qⱼ≠0 (finsetSum_coeff+coeff_C_mul+coeff_X_pow via Finset.sum_eq_single), le_natDegree_of_ne_zero ⟹ nonconstant ⟹ master engine transcendental_aeval_pi. choose! extracts per-index Euler rationals over the Finset."
     ],
     "mathlibGaps": [
       "No 0-axiom route to Irrational(π^n) for n≥2: Mathlib has irrational_pi (does NOT lift to powers) but no Irrational(π^2)/Irrational(π^n) lemma.",
@@ -246,8 +249,8 @@
     {
       "path": "Proofs/BaselProblemOQ01OQ02.lean",
       "filename": "BaselProblemOQ01OQ02.lean",
-      "lineCount": 314,
-      "theoremCount": 18,
+      "lineCount": 765,
+      "theoremCount": 42,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,


### PR DESCRIPTION
## Summary

Research session for **basel-problem-oq-01-oq-02** (even zeta values / the odd-zeta open question). Adds the one genuinely-missing structural result to the otherwise-saturated `BaselProblemOQ01OQ02.lean`: the **additive capstone**.

**`zeta_even_linearCombo_transcendental`** — for a finite index set `s`, an index map `f` injective on `s` with `f i ≥ 1`, and rationals `c i` not all zero on `s`, the value `∑_{i∈s} c i · ζ(2 f i)` is transcendental over ℚ. Equivalently, the even zeta values `ζ(2), ζ(4), ζ(6), …` are **ℚ-linearly independent** — no nontrivial rational relation holds among them.

### Why this is new (not accretion)

The file already had the *multiplicative* capstone (`zeta_even_finset_prod_transcendental`, arbitrary finite products) and the *pairwise* additive results (`zeta_even_add_transcendental`, `zeta_even_sub_transcendental`), plus the single-value polynomial engine (`zeta_even_aeval_transcendental`). It did **not** have the general finite ℚ-**linear combination**. This new theorem:

- is the additive analogue of the existing multiplicative finset-product capstone;
- strictly generalizes the two-term `add`/`sub` results to arbitrarily many terms;
- establishes a qualitatively distinct fact — **ℚ-linear independence** — that is the additive counterpart to the algebraic *dependence* (`zeta_even_cross_pow_ratio_rational`, all values lie in the transcendence-degree-1 field ℚ(π)).

### Proof

Each `ζ(2n) = qₙ·π^(2n)` (Euler's closed form `zeta_even_eq_rat_mul_pi_pow`, axiom-free; the per-index rationals are extracted over the `Finset` with `choose!`). Hence the combination is `aeval π (∑_{i∈s} C(c i · q_{f i})·X^(2 f i))`. Injectivity of `f` on the support makes the monomial degrees `2 f i` pairwise distinct, so for any `j` with `c j ≠ 0` the polynomial's coefficient at degree `2 f j` is `c j · q_{f j} ≠ 0` (via `Polynomial.finsetSum_coeff` + `coeff_C_mul` + `coeff_X_pow`, collapsed by `Finset.sum_eq_single`). By `Polynomial.le_natDegree_of_ne_zero` the polynomial is nonconstant, so the file's master engine `transcendental_aeval_pi` applies.

## Verification

Docker-built green under the repo's `v4.31.0` toolchain (`docker-build.sh Proofs.BaselProblemOQ01OQ02`, 8578 jobs). `#print axioms` on the new theorem lists `[propext, Classical.choice, HermiteLindemann.hermite_lindemann, Quot.sound]` — the single `hermite_lindemann` (transcendence of π) assumption shared by every transcendence result in this file, and **no** `sorryAx`. This entry is therefore `axiomatized` (badge `axiom`), consistent with the rest of the file. Also modernized the deprecated `Polynomial.finset_sum_coeff` → `finsetSum_coeff`. File 706 → 765 lines, 42 theorems.

## Scope note

The odd case `ζ(2n+1)` (the parent open question) remains untouched and undocumented-as-provable, exactly as before — the genuine frontier there (Ball–Rivoal / Nesterenko linear independence) is out of session scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)