### PR TITLE
audit: fix erdos-39 axiom undercount + erdos-922 sorry overcount (v4.31 drift)

### DIFF
--- a/src/data/proofs/erdos-39/meta.json
+++ b/src/data/proofs/erdos-39/meta.json
@@ -47,7 +47,7 @@
       "Documentation of known constructions: greedy (N^{1/3}), AKS ((N log N)^{1/3}), Ruzsa (N^{sqrt(2)-1})",
       "Verified computational facts about square roots establishing the gap"
     ],
-    "axiomCount": 1,
+    "axiomCount": 2,
     "lineCount": 186,
     "prerequisites": [
       "Sidon sets (B₂ sequences) and pairwise distinct sums",
@@ -55,7 +55,7 @@
       "Probabilistic method in combinatorics",
       "Basic analytic number theory (square root barriers)"
     ],
-    "assumptions": "1 axiom: erdos_sidon_upper_bound. 0 sorries.",
+    "assumptions": "2 axioms: erdos_sidon_upper_bound, sidon_counting_upper_bound. 0 sorries.",
     "theoremCount": 6,
     "definitionCount": 3
   },
@@ -224,7 +224,7 @@
     ],
     "namespace": "Erdos39",
     "lineCount": 186,
-    "axiomCount": 1,
+    "axiomCount": 2,
     "theoremCount": 6,
     "definitionCount": 3,
     "path": "Proofs/Erdos39Problem.lean",

--- a/src/data/proofs/erdos-922/meta.json
+++ b/src/data/proofs/erdos-922/meta.json
@@ -17,13 +17,13 @@
       "folkman"
     ],
     "badge": "axiom",
-    "sorries": 4,
+    "sorries": 3,
     "erdosNumber": 922,
     "erdosUrl": "https://erdosproblems.com/922",
     "erdosProblemStatus": "solved",
     "axiomCount": 2,
     "lineCount": 220,
-    "assumptions": "2 axioms: folkman_theorem, folkman_bound_tight. 4 sorries.",
+    "assumptions": "2 axioms: folkman_theorem, folkman_bound_tight. 3 sorries.",
     "mathlib_version": "4.31.0",
     "theoremCount": 6,
     "definitionCount": 9,
@@ -157,7 +157,7 @@
     "theoremCount": 6,
     "definitionCount": 9,
     "path": "Proofs/Erdos922Problem.lean",
-    "sorries": 4,
+    "sorries": 3,
     "additionalFiles": [
       "Proofs/Erdos922Aristotle.lean"
     ]
@@ -179,5 +179,5 @@
       "description": "Related Erdős problem sharing themes: chromatic-number, graph-theory"
     }
   ],
-  "sorries": 4
+  "sorries": 3
 }


### PR DESCRIPTION
## Gallery Integrity Audit

Two count drifts flagged by \`find-targets.ts --issues\` and confirmed by grep against the Lean sources at HEAD 97cf65edbd.

### erdos-39 — axiom undercount (overclaim direction)
- **meta claimed**: \`axiomCount: 1\`, assumptions "1 axiom: erdos_sidon_upper_bound"
- **Lean file shows**: \`Proofs/Erdos39Problem.lean\` declares **2** axioms:
  - \`erdos_sidon_upper_bound\` (line 64)
  - \`sidon_counting_upper_bound\` (line 74) — added during the v4.31 \`IsCoboundedUnder\` refactor, load-bearing in \`no_sqrt_growth\` (used line 91)
- **Fix**: \`axiomCount\` 1→2 (meta + leanFile), assumptions string updated.

### erdos-922 — sorry overcount (safe direction, still a mismatch)
- **meta claimed**: \`sorries: 4\`
- **Lean file shows**: \`Proofs/Erdos922Problem.lean\` has exactly **3** sorries (lines 99, 104, 161). The \`Erdos922Aristotle.lean\` companion has only a docstring mention, no real sorry.
- **Fix**: \`sorries\` 4→3 (meta + leanFile + top-level), assumptions string updated.

Both are data-only meta.json corrections; no Lean source changed. JSON validated.

---
Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)