### PR TITLE
Fix: repair never-compiled RamseysTheoremOQ04 (batch 5 of #39077)

### DIFF
--- a/proofs/Proofs/RamseysTheoremOQ04.lean
+++ b/proofs/Proofs/RamseysTheoremOQ04.lean
@@ -19,6 +19,8 @@ principle. Higher k values require significantly larger Ramsey numbers.
 
 import Mathlib
 
+set_option autoImplicit false
+
 open Finset
 
 namespace HypergraphRamsey
@@ -36,7 +38,7 @@ abbrev Coloring (s : Finset α) (k : ℕ) (r : ℕ) [DecidableEq α] : Type _ :=
   kSubsets s k → Fin r
 
 /-- A subset is monochromatic for a coloring if all its k-element subsets have the same color. -/
-def IsMonochromatic [DecidableEq α] (s t : Finset α) (k : ℕ) (c : Coloring s k r)
+def IsMonochromatic [DecidableEq α] (s t : Finset α) (k r : ℕ) (c : Coloring s k r)
     (color : Fin r) (ht : t ⊆ s) : Prop :=
   ∀ e ∈ kSubsets t k, ∀ (he : e ∈ kSubsets s k), c ⟨e, he⟩ = color
 
@@ -52,7 +54,7 @@ def HypergraphRamseyProperty (k r n N : ℕ) : Prop :=
 
 /-- k = 1 is the pigeonhole principle: coloring singletons with r colors
     among enough elements forces some color to appear many times. -/
-theorem k1_is_pigeonhole : HypergraphRamseyProperty 1 r n N →
+theorem k1_is_pigeonhole {r n N : ℕ} : HypergraphRamseyProperty 1 r n N →
     ∀ (S : Finset ℕ), S.card = N →
       ∀ (c : kSubsets S 1 → Fin r),
         ∃ (T : Finset ℕ) (i : Fin r), T ⊆ S ∧ T.card ≥ n ∧
@@ -198,7 +200,7 @@ theorem kSubsets_subset [DecidableEq α] {s t : Finset α} (h : t ⊆ s) (k : �
   exact Finset.powersetCard_mono h
 
 /-- A k-subset of T is a k-subset of S when T ⊆ S. -/
-theorem kSubsets_mem_of_subset [DecidableEq α] {s t : Finset α} {e : Finset α}
+theorem kSubsets_mem_of_subset [DecidableEq α] {k : ℕ} {s t : Finset α} {e : Finset α}
     (h : t ⊆ s) (he : e ∈ kSubsets t k) : e ∈ kSubsets s k :=
   kSubsets_subset h k he
 

--- a/src/data/proofs/ramseys-theorem-oq-04/meta.json
+++ b/src/data/proofs/ramseys-theorem-oq-04/meta.json
@@ -32,8 +32,8 @@
       "pigeonhole_ramsey: k=1 proved via Finset.exists_lt_card_fiber_of_nsmul_lt_card"
     ],
     "axiomCount": 1,
-    "assumptions": "AUDIT (issue #39061): NOT machine-verified. This entry never validly compiled. Even under Lean v4.26 the proof only 'passed' because the old `autoImplicit true` default silently bound the undefined identifier `n` as a free implicit variable, rendering the stated theorem vacuously general; under v4.31 (autoImplicit off by default) the file fails with `unknownIdentifier 'n'` and typically additional genuine proof errors. The verification claims below are therefore retracted pending a Lean-source repair (Class A). ORIGINAL METADATA: 1 axiom: hypergraph_ramsey_k2 (k ≥ 2 existence requiring the stepping-up lemma). All infrastructure, special cases, both base cases (n ≤ k and k=1 pigeonhole), and monotonicity are fully proved. The axiom isolates exactly the inductive step of the k-uniform stepping-up argument.",
-    "lineCount": 301,
+    "assumptions": "1 axiom: hypergraph_ramsey_k2 (k ≥ 2 existence requiring the stepping-up lemma). All infrastructure, special cases, both base cases (n ≤ k and k=1 pigeonhole), and monotonicity are fully proved. The axiom isolates exactly the inductive step of the k-uniform stepping-up argument. REPAIRED (issue #39077, batch 5): the file compiles green on Lean v4.31 with `set_option autoImplicit false` and the previously auto-bound free variables (r in IsMonochromatic, r/n/N in k1_is_pigeonhole, k in kSubsets_mem_of_subset) now explicitly bound. Verified via docker-build: 0 sorries, 1 axiom; every proved theorem (pigeonhole_ramsey, ramsey_property_mono, classical_ramsey_is_k2, hypergraph_ramsey_exists\\''s k=1 branch) depends only on the foundational axioms propext/Classical.choice/Quot.sound — no sorryAx, no native_decide. The prior #39061 audit retraction (\"never validly compiled\") is resolved.",
+    "lineCount": 262,
     "mathlibDependencies": [
       {
         "theorem": "Finset.powersetCard",


### PR DESCRIPTION
## Summary

Batch 5 of the never-compiled repair effort (#39077, follow-on to #39061). Repairs **RamseysTheoremOQ04** (Class A — autoImplicit-masked free identifiers).

## Root cause

This project's `proofs/lakefile.toml` sets no `autoImplicit` option, so it inherits Lean core's default (`autoImplicit true`) — mathlib's own `false` setting does not propagate to downstream projects. The file therefore *appeared* to compile on v4.31, but only because three declarations referenced undefined identifiers that were silently auto-bound as free implicits:

- `IsMonochromatic` — free `r`
- `k1_is_pigeonhole` — free `r`, `n`, `N`  (the `:n` the auditor flagged)
- `kSubsets_mem_of_subset` — free `k` (cascaded a `sorryAx` into `ramsey_property_mono`)

Adding `set_option autoImplicit false` exposes all of these as `unknown identifier` errors.

## Fix

- `set_option autoImplicit false` after the import (so the defect can't reappear).
- Explicitly bind the previously auto-bound variables: `(k r : ℕ)` in `IsMonochromatic`, `{r n N : ℕ}` in `k1_is_pigeonhole`, `{k : ℕ}` in `kSubsets_mem_of_subset`.

## Evidence

`./proofs/scripts/docker-build.sh Proofs.RamseysTheoremOQ04`:
- **Before** (`autoImplicit false` probe): `error: Unknown identifier n` / `k`, plus a cascaded `declaration uses sorry`.
- **After**: `=== Build succeeded ===`, 0 sorries, only cosmetic warnings (pre-existing unused `ht`, deprecated `push_neg`).
- `#print axioms`: `pigeonhole_ramsey`, `ramsey_property_mono`, `classical_ramsey_is_k2`, and the k=1 branch of `hypergraph_ramsey_exists` depend only on `propext / Classical.choice / Quot.sound` — no `sorryAx`, no `Lean.ofReduceBool`. The single declared axiom `hypergraph_ramsey_k2` (k≥2 stepping-up) is the only assumption.

## Metadata

Status was already `axiomatized`/`axiom`/`axiomCount: 1` (correct — 1 genuine axiom). Cleared the now-stale #39061 audit retraction ("never validly compiled / NOT machine-verified") from `assumptions`, and refreshed `lineCount` 301→262.

Part of #39077 (does not close it — ~15 Class A/B/D/E entries remain).