### PR TITLE
Fix: repair never-compiled Erdos701Problem (batch 6 of #39077)

### DIFF
--- a/proofs/Proofs/Erdos701Problem.lean
+++ b/proofs/Proofs/Erdos701Problem.lean
@@ -37,6 +37,8 @@ import Mathlib.Data.Finset.Basic
 
 open Set Finset
 
+set_option autoImplicit false
+
 namespace Erdos701
 
 /-
@@ -94,8 +96,8 @@ theorem singleton_intersecting {α : Type*} (A : Set α) (hA : A.Nonempty) :
     IsIntersecting ({A} : Set (Set α)) := by
   intro B hB C hC
   simp only [Set.mem_singleton_iff] at hB hC
-  subst hB hC
-  exact ⟨A, Set.inter_self A ▸ hA⟩
+  rw [hB, hC, Set.inter_self]
+  exact hA
 
 /-
 ## Part III: Stars
@@ -226,16 +228,16 @@ theorem uniform_not_hereditary {α : Type*} [Fintype α] [DecidableEq α]
     ¬IsHereditary (UniformFamily (α := α) k) := by
   intro hhered
   -- Take any proper non-empty subset of X
-  obtain ⟨x, hx⟩ := Set.ncard_pos.mp (by omega : X.ncard > 0)
+  obtain ⟨x, hx⟩ := Set.nonempty_of_ncard_ne_zero (show X.ncard ≠ 0 by omega)
   let B := X \ {x}
   have hBX : B ⊂ X := by
     constructor
     · exact Set.diff_subset
     · intro heq
-      simp [B] at heq
-      exact heq hx
+      have hxB := heq hx
+      simp [B] at hxB
   have hBcard : B.ncard = k - 1 := by
-    rw [Set.ncard_diff_singleton_of_mem hx hXfin, hX]
+    rw [Set.ncard_diff_singleton_of_mem hx, hX]
   have hBF : B ∈ UniformFamily k := hhered X ⟨hXfin, hX⟩ B (Set.diff_subset)
   simp [UniformFamily] at hBF
   omega

--- a/src/data/proofs/erdos-701/meta.json
+++ b/src/data/proofs/erdos-701/meta.json
@@ -28,8 +28,8 @@
       "Hereditary families (downsets / independence systems)",
       "Extremal set theory fundamentals"
     ],
-    "lineCount": 284,
-    "assumptions": "AUDIT (issue #39061): NOT machine-verified. This entry never validly compiled. Even under Lean v4.26 the proof only 'passed' because the old `autoImplicit true` default silently bound the undefined identifier `A` as a free implicit variable, rendering the stated theorem vacuously general; under v4.31 (autoImplicit off by default) the file fails with `unknownIdentifier 'A'` and typically additional genuine proof errors. The verification claims below are therefore retracted pending a Lean-source repair (Class A). ORIGINAL METADATA: 0 axioms. All constructs are definitions and theorems; no axiom declarations or structure-encoded assumptions. Open conjecture; supporting lemmas fully verified.",
+    "lineCount": 286,
+    "assumptions": "0 axioms, 0 sorries — the file compiles green on Lean v4.31. Chvátal's conjecture is an OPEN problem: it is stated as the definition `ChvatalConjecture` and is NOT proven here. What is machine-verified are the supporting lemmas (powerset_hereditary, bounded_card_hereditary, empty/singleton/star_intersecting, star_subset, uniform_not_hereditary, etc.) around hereditary and intersecting families. Status remains `axiomatized` per the Axiom Integrity Policy (open conjectures are never `verified`), with axiomCount 0 since no axiom asserts the conjecture. REPAIRED (issue #39077, batch 6): added `set_option autoImplicit false` and fixed the autoImplicit-masked defect (a `subst` had eliminated the parameter `A` in singleton_intersecting, later reused) plus v4.31 drift in uniform_not_hereditary (Set.ncard_pos.mp → Set.nonempty_of_ncard_ne_zero; dropped the now-autoParam finiteness arg of Set.ncard_diff_singleton_of_mem). The prior #39061 audit retraction (\"never validly compiled\") is resolved.",
     "mathlib_version": "4.31.0",
     "theoremCount": 7,
     "definitionCount": 8


### PR DESCRIPTION
## Summary

Batch 6 of the never-compiled repair effort (#39077). Repairs **Erdos701Problem** (Chvátal's conjecture on hereditary/intersecting families — Class A).

## Fixes

`set_option autoImplicit false` added (this project inherits Lean core's `autoImplicit true`, so the defect was masked — see the root-cause note on #39077). That exposed:

1. **`singleton_intersecting`** — `subst hB hC` eliminated the theorem parameter `A` (the RHS of `B = A` / `C = A`), which was then reused at line 100. autoImplicit had silently re-bound the dangling `A` as a fresh free variable. Rewrote the tail as `rw [hB, hC, Set.inter_self]; exact hA`.
2. **`uniform_not_hereditary`** — genuine v4.31 Mathlib drift:
   - `Set.ncard_pos.mp` no longer resolves as a bare constant → `Set.nonempty_of_ncard_ne_zero`.
   - `Set.ncard_diff_singleton_of_mem` — finiteness is now an autoParam, so the explicit `hXfin` arg caused "function expected"; dropped it.
   - `simp [B] at heq; exact heq hx` restructured to `have hxB := heq hx; simp [B] at hxB` (robust to simp-normal-form changes).

## Evidence

`./proofs/scripts/docker-build.sh Proofs.Erdos701Problem`:
- **Before** (`autoImplicit false` probe): `error: Unknown identifier A` (×2), `Unknown constant Set.ncard_pos.mp`, plus type-mismatch/function-expected at 238/240.
- **After**: `=== Build succeeded ===`, 0 axioms, 0 sorries.

## Metadata

Chvátal's conjecture is an **open problem** — stated as the definition `ChvatalConjecture`, not proven. Per the Axiom Integrity Policy, the entry stays `axiomatized`/`wip` (axiomCount 0; the supporting lemmas are the verified content). Cleared the stale #39061 "never validly compiled / NOT machine-verified" retraction from `assumptions`; refreshed `lineCount` 284→286.

Part of #39077 (does not close it — ~14 Class A/B/D/E entries remain).