### PR TITLE
Research: erdos-117-oq-01-incomplete-01 — liminf/limsup of the growth rate are attained

### DIFF
--- a/proofs/Proofs/Erdos117OQ01Incomplete01.lean
+++ b/proofs/Proofs/Erdos117OQ01Incomplete01.lean
@@ -284,4 +284,53 @@ theorem growthRate_subseq_limit_mem_window {φ : ℕ → ℕ} (hφ : StrictMono 
   exact ⟨c₁, c₂, hc1, hc12,
     Set.mem_Icc.mpr ⟨ge_of_tendsto hx hev1, le_of_tendsto hx hev2⟩⟩
 
+/-! ### The extreme cluster values are attained
+
+`growthRate_subseq_limit_mem_window` shows every subsequential limit lies *inside* Pyber's
+window `[log c₁, log c₂]`.  The converse-flavoured completion below shows the two extreme
+cluster values — `growthRateLimInf` and `growthRateLimSup` — are themselves *attained* as
+subsequential limits: there are index sequences diverging to `∞` along which the growth rate
+converges to each.  So the two abstract `liminf`/`limsup` values are genuine accumulation
+points of the growth rate, not merely formal bounds; together with the window confinement
+this pins the cluster set of `growthRate` down as a nonempty compact subset of
+`[log c₁, log c₂]` with minimum `growthRateLimInf` and maximum `growthRateLimSup`. -/
+
+/-- **The limsup is attained as a subsequential limit.**  There is an index sequence
+`x : ℕ → ℕ` diverging to `∞` (`Tendsto x atTop atTop`) along which
+`growthRate (x k) → growthRateLimSup`.  Thus the *largest* cluster value of the growth rate is
+a genuine accumulation point.  The growth rate is eventually confined to Pyber's window
+`[log c₁, log c₂]` (`growthRate_window`), providing the boundedness and coboundedness
+`exists_seq_tendsto_limsup` requires. -/
+theorem exists_subseq_tendsto_growthRateLimSup :
+    ∃ x : ℕ → ℕ, Filter.Tendsto x atTop atTop ∧
+      Filter.Tendsto (fun k => growthRate (x k)) atTop (nhds growthRateLimSup) := by
+  obtain ⟨c₁, c₂, _, _, hwin⟩ := growthRate_window
+  have hle : ∀ᶠ n in atTop, growthRate n ≤ Real.log c₂ :=
+    Filter.eventually_atTop.mpr ⟨1, fun n hn => (hwin n hn).2⟩
+  have hge : ∀ᶠ n in atTop, Real.log c₁ ≤ growthRate n :=
+    Filter.eventually_atTop.mpr ⟨1, fun n hn => (hwin n hn).1⟩
+  have hb : Filter.IsBoundedUnder (· ≤ ·) atTop growthRate := ⟨Real.log c₂, hle⟩
+  have hc : Filter.IsCoboundedUnder (· ≤ ·) atTop growthRate :=
+    isCoboundedUnder_le_of_eventually_le atTop hge
+  obtain ⟨x, hxlim, hxtop⟩ := exists_seq_tendsto_limsup (u := growthRate) (f := atTop) hc hb
+  exact ⟨x, hxtop, hxlim⟩
+
+/-- **The liminf is attained as a subsequential limit.**  Dual to
+`exists_subseq_tendsto_growthRateLimSup`: an index sequence `x : ℕ → ℕ` diverging to `∞` with
+`growthRate (x k) → growthRateLimInf`, so the *smallest* cluster value of the growth rate is
+also a genuine accumulation point. -/
+theorem exists_subseq_tendsto_growthRateLimInf :
+    ∃ x : ℕ → ℕ, Filter.Tendsto x atTop atTop ∧
+      Filter.Tendsto (fun k => growthRate (x k)) atTop (nhds growthRateLimInf) := by
+  obtain ⟨c₁, c₂, _, _, hwin⟩ := growthRate_window
+  have hle : ∀ᶠ n in atTop, growthRate n ≤ Real.log c₂ :=
+    Filter.eventually_atTop.mpr ⟨1, fun n hn => (hwin n hn).2⟩
+  have hge : ∀ᶠ n in atTop, Real.log c₁ ≤ growthRate n :=
+    Filter.eventually_atTop.mpr ⟨1, fun n hn => (hwin n hn).1⟩
+  have hb : Filter.IsBoundedUnder (· ≥ ·) atTop growthRate := ⟨Real.log c₁, hge⟩
+  have hc : Filter.IsCoboundedUnder (· ≥ ·) atTop growthRate :=
+    isCoboundedUnder_ge_of_eventually_le atTop hle
+  obtain ⟨x, hxlim, hxtop⟩ := exists_seq_tendsto_liminf (u := growthRate) (f := atTop) hc hb
+  exact ⟨x, hxtop, hxlim⟩
+
 end Erdos117OQ01Incomplete01


### PR DESCRIPTION
## Summary

Research session for **erdos-117-oq-01-incomplete-01** (oscillation of the abelian-covering-number growth rate `growthRate n = log(h n)/n`; Erdős #117 OQ-01). Completes the **cluster-set characterization** of the growth rate.

The companion file already proved that every subsequential limit of `growthRate` lies *inside* Pyber's window `[log c₁, log c₂]` (`growthRate_subseq_limit_mem_window` — the ⊆ direction). This adds the converse-flavoured **attainment**:

- **`exists_subseq_tendsto_growthRateLimSup`** — there is an index sequence `x : ℕ → ℕ` diverging to `∞` (`Tendsto x atTop atTop`) with `growthRate (x k) → growthRateLimSup`.
- **`exists_subseq_tendsto_growthRateLimInf`** — the dual, realizing `growthRateLimInf`.

So the two abstract `liminf`/`limsup` values are **genuine accumulation points** of the growth rate, not merely formal bounds. Together with the window confinement this pins the cluster set of `growthRate` down as a **nonempty compact subset of `[log c₁, log c₂]` with minimum `growthRateLimInf` and maximum `growthRateLimSup`**.

## Approach

Mathlib's `exists_seq_tendsto_limsup` / `exists_seq_tendsto_liminf` extract an index sequence tending to `atTop` that realizes the `limsup`/`liminf`, given `IsBoundedUnder` and `IsCoboundedUnder`. Both are furnished by the eventual two-sided confinement `log c₁ ≤ growthRate n ≤ log c₂` (`n ≥ 1`) from the parent's `growthRate_window`: boundedness from the endpoints, coboundedness via `isCoboundedUnder_le_of_eventually_le` / `isCoboundedUnder_ge_of_eventually_le` (`atTop` is `NeBot`).

## Verification

Docker-built green under the repo's `v4.31.0` toolchain (`docker-build.sh Proofs.Erdos117OQ01Incomplete01`, 8577 jobs). `#print axioms` on both new theorems lists `[propext, Classical.choice, Erdos117OQ01.h, Erdos117OQ01.h_pos, Erdos117OQ01.pyber_bounds, Quot.sound]` — i.e. they inherit **only** the parent's three Pyber-bound assumptions (no new axioms, no `sorryAx`), exactly matching the file's stated convention. File 287 → 336 lines.

## Scope

The underlying convergence question — does `lim log(h n)/n` exist (the Pyber `c₁ < c₂` gap)? — is the genuine open content of Erdős #117 OQ-01 and remains untouched and out of scope. This contribution is purely the structural cluster-set picture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)