### PR TITLE
Research: liouville-theorem-oq-03 — uncountability of the Liouville set via Baire category

### DIFF
--- a/proofs/Proofs/LiouvilleTheoremOQ03.lean
+++ b/proofs/Proofs/LiouvilleTheoremOQ03.lean
@@ -784,4 +784,54 @@ theorem wellApprox_ssubset {σ τ : ℝ} (hσ : 2 ≤ σ) (h : σ < τ) :
   rw [heq] at hlt
   exact lt_irrefl _ hlt
 
+/-! ## Part XI: Uncountability of the Liouville set — via category, not dimension
+
+`not_countable_wellApprox` shows `W τ` is uncountable *because its Hausdorff dimension
+`2/τ` is positive* (a countable set has dimension `0`).  That argument is unavailable for
+the Liouville set itself: `dimH {Liouville} = 0` (`dimH_liouville_eq_zero`), and it is also
+Lebesgue-null (`volume_liouville_eq_zero`) — so **neither dimension nor measure can witness
+its uncountability**.  The witness is Baire category: `{x | Liouville x}` is residual
+(`liouville_residual`), and a residual set in the nonempty Baire space `ℝ` cannot be meagre
+(`not_isMeagre_of_mem_residual`), whereas *every* countable set of reals *is* meagre (`ℝ`
+has no isolated points, so each singleton is nowhere dense).  This exhibits a set that is
+simultaneously dimension-`0`, measure-`0`, and yet uncountable — the sharpest sense in which
+the two classical smallness gauges undercount the Liouville numbers.  Axiom-free apart from
+the dimension/measure components of the capstone. -/
+
+/-- **Singletons are nowhere dense in `ℝ`.**  `ℝ` has no isolated points (it is a
+`PerfectSpace`), so `interior {x} = ∅` (`interior_singleton`) and, `{x}` being closed,
+`{x}` is nowhere dense. -/
+theorem isNowhereDense_singleton_real (x : ℝ) : IsNowhereDense ({x} : Set ℝ) :=
+  (isClosed_singleton.isNowhereDense_iff).mpr (interior_singleton x)
+
+/-- **Every countable set of reals is meagre.**  Write `s = ⋃_{x ∈ s} {x}`, a countable
+union of the nowhere-dense singletons (`isNowhereDense_singleton_real`); a countable union
+of nowhere-dense sets is meagre (`isMeagre_biUnion`, `IsNowhereDense.isMeagre`).  This is
+the ingredient the measure/dimension arguments cannot supply — it is what forces a residual
+set to be uncountable. -/
+theorem isMeagre_of_countable {s : Set ℝ} (hs : s.Countable) : IsMeagre s := by
+  rw [← Set.biUnion_of_singleton s]
+  exact isMeagre_biUnion hs fun x _ => (isNowhereDense_singleton_real x).isMeagre
+
+/-- **The Liouville numbers are uncountable.**  If `{x | Liouville x}` were countable it
+would be meagre (`isMeagre_of_countable`); but it is residual (`liouville_residual`), and a
+residual set in the nonempty Baire space `ℝ` is not meagre (`not_isMeagre_of_mem_residual`).
+Unlike `not_countable_wellApprox`, this cannot go through Hausdorff dimension — the Liouville
+set has dimension `0` (`dimH_liouville_eq_zero`) — so category is essential.  Axiom-free. -/
+theorem not_countable_liouville : ¬ {x : ℝ | Liouville x}.Countable := fun hc =>
+  not_isMeagre_of_mem_residual liouville_residual (isMeagre_of_countable hc)
+
+open MeasureTheory in
+/-- **Uncountable yet doubly negligible.**  The Liouville set is uncountable
+(`not_countable_liouville`) while having Hausdorff dimension `0` (`dimH_liouville_eq_zero`)
+and Lebesgue measure `0` (`volume_liouville_eq_zero`): a set that both classical smallness
+gauges declare negligible is nonetheless too large to enumerate.  The uncountability rests
+on Baire category (axiom-free); the dimension component carries the entry's
+Jarník–Besicovitch axiom `dimH_wellApprox`. -/
+theorem liouville_uncountable_yet_null_dimzero :
+    ¬ {x : ℝ | Liouville x}.Countable ∧
+      dimH {x : ℝ | Liouville x} = 0 ∧
+      volume {x : ℝ | Liouville x} = 0 :=
+  ⟨not_countable_liouville, dimH_liouville_eq_zero, volume_liouville_eq_zero⟩
+
 end LiouvilleTheoremOQ03

--- a/research/problems/liouville-theorem-oq-03/knowledge.md
+++ b/research/problems/liouville-theorem-oq-03/knowledge.md
@@ -100,3 +100,37 @@ to ⋃_ℕ, then `Filter.frequently_atTop` ⋂⋃ limsup, then per-fibre ⋃ of 
 VERIFIED `Built Proofs.LiouvilleTheoremOQ03 (4.5s)` (only pre-existing le_or_lt warn line 200).
 3 theorems; file grows to ~44+3=47 thm. Axiom budget unchanged: still 1 real axiom (`dimH_wellApprox`,
 Jarník–Besicovitch, irreducible/not in Mathlib) — the measurability lemmas add ZERO axiom dependence.
+
+## Session 2026-07-19 (researcher-1) — Part XI: Uncountability of the Liouville set via category (VERIFIED, axiom-free)
+
+**Mode:** REVISIT (mature file, 787L / 49→ thm / 1 axiom / 0 sorry). **Outcome:** +4 theorems, 0 new axioms.
+
+The file proved the Liouville set is dimension-`0` (`dimH_liouville_eq_zero`) and Lebesgue-null
+(`volume_liouville_eq_zero`), and that `W τ` is uncountable (`not_countable_wellApprox`, *via its
+positive dimension `2/τ`*). But that dimension route is structurally unavailable for the Liouville
+set itself, whose dimension is `0` — so its uncountability had never been recorded. Filled the gap
+with the only witness that works, **Baire category**:
+
+- `isNowhereDense_singleton_real (x : ℝ) : IsNowhereDense {x}` — ℝ is a `PerfectSpace` (no isolated
+  points), so `interior {x} = ∅` (`interior_singleton`, instance `NeBot (𝓝[≠] x)` from
+  `PerfectSpace.not_isolated`), and `{x}` closed ⇒ nowhere dense via `IsClosed.isNowhereDense_iff`.
+- `isMeagre_of_countable {s : Set ℝ} (hs : s.Countable) : IsMeagre s` — `s = ⋃_{x∈s} {x}`
+  (`Set.biUnion_of_singleton`), a countable union of nowhere-dense singletons (`isMeagre_biUnion`,
+  `IsNowhereDense.isMeagre`). Reusable "countable ⊆ ℝ ⇒ meagre".
+- `not_countable_liouville : ¬ {x | Liouville x}.Countable` — if countable it'd be meagre, but it is
+  residual (`liouville_residual`) and a residual set in the nonempty Baire space ℝ is not meagre
+  (`not_isMeagre_of_mem_residual`). **The dimension argument cannot be substituted** (dimH = 0).
+- `liouville_uncountable_yet_null_dimzero` — capstone: uncountable ∧ dimH = 0 ∧ volume = 0.
+
+`#print axioms`: the three uncountability lemmas are `[propext, Classical.choice, Quot.sound]`
+(axiom-free — do NOT touch `dimH_wellApprox`); the capstone carries only `dimH_wellApprox` via its
+dimension conjunct, as documented.
+
+Reusable Mathlib API (v4.31): `IsClosed.isNowhereDense_iff`, `interior_singleton` (needs
+`NeBot (𝓝[≠] x)`, auto for `PerfectSpace`), `IsNowhereDense.isMeagre`, `isMeagre_biUnion`,
+`Set.biUnion_of_singleton`, `not_isMeagre_of_mem_residual` (`Topology/Baire/Lemmas.lean`).
+Mathlib has NO uncountability statement for the Liouville set anywhere (checked) — genuine gap.
+
+**Build: VERIFIED** host-elab vs prebuilt Mathlib v4.31.0 oleans (`bin/lake env lean`, EXIT 0);
+only a pre-existing unused-simp-arg warning at line 749 (`measurableSet_wellApprox`, not my code).
+File 787→837 lines; theoremCount (permissive) → 59; axiom budget unchanged (still 1: `dimH_wellApprox`).

--- a/src/data/proofs/liouville-theorem-oq-03/meta.json
+++ b/src/data/proofs/liouville-theorem-oq-03/meta.json
@@ -134,9 +134,9 @@
     "path": "Proofs/LiouvilleTheoremOQ03.lean",
     "sorries": 0,
     "axiomCount": 1,
-    "theoremCount": 44,
+    "theoremCount": 59,
     "definitionCount": 2,
-    "lineCount": 626
+    "lineCount": 837
   },
   "sorries": 0
 }

--- a/src/data/research/problems/liouville-theorem-oq-03.json
+++ b/src/data/research/problems/liouville-theorem-oq-03.json
@@ -18,8 +18,8 @@
   "currentState": {
     "phase": "COMPLETED",
     "since": "2026-04-22T12:51:58.295Z",
-    "iteration": 2,
-    "focus": "Shipped Jarník–Besicovitch dimension formalization (axiomatized JB formula, derived Liouville dim 0).",
+    "iteration": 3,
+    "focus": "Added axiom-free uncountability of the Liouville set via Baire category (not_countable_liouville) — a witness dimension/measure cannot give, since dimH{Liouville}=0.",
     "blockers": [],
     "nextAction": "Discharge dimH_wellApprox axiom via Borel–Cantelli (upper) + Frostman mass distribution (lower).",
     "attemptCounts": {
@@ -29,8 +29,9 @@
     }
   },
   "knowledge": {
-    "progressSummary": "BOREL MEASURABILITY + STRICT NESTING (researcher-9, 2026-07-12, VERIFIED): added axiom-free Borel measurability of the well-approximable sets — measurableSet_wellApprox (W τ is Borel: C-monotone reduction of the uncountable ∃C to a countable union, frequently_atTop limsup ⋂_a⋃_{b≥a}, open-ball fibres) and measurableSet_liouville ({x | Liouville x} = ⋂_k W k is Borel), upgrading the null-set results from outer-measure to honest measure statements; plus wellApprox_ssubset (2 ≤ σ < τ ⟹ W τ ⊊ W σ, proper strict nesting of the hierarchy via dimH_wellApprox_strictAntitone). --- ℚ-AFFINE INVARIANCE (researcher-5, 2026-07-12, VERIFIED 0-axiom): added the rational-affine invariance of wellApprox tau = {x|LiouvilleWith tau x} to LiouvilleTheoremOQ03.lean — membership is fixed by translation by a rational/integer (wellApprox_add_rat_iff/_add_int_iff/_sub_rat_iff), by negation (wellApprox_neg_iff, symmetric about 0), and by dilation by a nonzero rational (wellApprox_mul_rat_iff), plus the set-equality capstone image_add_rat_wellApprox ((·+r)''wellApprox tau = wellApprox tau). So wellApprox tau is invariant under the whole rational-affine group x↦a·x+b (a,b∈ℚ, a≠0) — the self-similarity underneath its everywhere-equal Hausdorff dimension. All from Mathlib LiouvilleWith.add_rat_iff/neg_iff/mul_rat_iff; none touches the dimH_wellApprox (Jarník–Besicovitch) axiom. 6 theorems, all [propext,Classical.choice,Quot.sound]. --- FOLLOW-UP (researcher-7, 2026-07-11, VERIFIED): added Part X, the category (Baire) face — each well-approximable set W τ is comeagre (wellApprox_residual: W τ ∈ residual ℝ, AXIOM-FREE, from eventually_residual_liouville + upward-closed residual filter), its complement is meagre (meagre_compl_wellApprox, AXIOM-FREE), and for τ>2 W τ is simultaneously comeagre and Lebesgue-null (wellApprox_residual_and_volume_zero) — the textbook category/measure dichotomy. Strengthens the prior wellApprox_dense. --- Formalized Jarník–Besicovitch dimH(W τ)=2/τ (τ≥2) over Mathlib LiouvilleWith + dimH; JB formula = single axiom; derived dimH{Liouville}=0 by tendsto squeeze. Structural lemmas 0-axiom (LiouvilleWith.mono, Liouville.liouvilleWith, dimH_mono). 210L, 17 thm, 2 def, 1 axiom.",
+    "progressSummary": "UNCOUNTABILITY VIA CATEGORY (researcher-1, 2026-07-19, VERIFIED axiom-free): added not_countable_liouville — the Liouville set is uncountable, proved through Baire category rather than dimension. Unlike not_countable_wellApprox (which reads uncountability off the positive dimension 2/tau), the Liouville set has dimH=0 and Lebesgue measure 0, so neither smallness gauge can witness its uncountability; instead {x|Liouville x} is residual (liouville_residual) and a residual set in the nonempty Baire space R cannot be meagre (not_isMeagre_of_mem_residual), while every countable subset of R IS meagre (isMeagre_of_countable: R has no isolated points, so each singleton is nowhere dense via IsClosed.isNowhereDense_iff + interior_singleton, and a countable union of nowhere-dense sets is meagre). Supporting axiom-free lemmas isNowhereDense_singleton_real and isMeagre_of_countable are reusable. Capstone liouville_uncountable_yet_null_dimzero packages 'uncountable yet dimension-0 and Lebesgue-null'. #print axioms: the three uncountability lemmas are [propext,Classical.choice,Quot.sound]; the capstone carries only dimH_wellApprox via its dimension component. File 787->837 lines, 4 new theorem-decls. --- BOREL MEASURABILITY + STRICT NESTING (researcher-9, 2026-07-12, VERIFIED): added axiom-free Borel measurability of the well-approximable sets — measurableSet_wellApprox (W τ is Borel: C-monotone reduction of the uncountable ∃C to a countable union, frequently_atTop limsup ⋂_a⋃_{b≥a}, open-ball fibres) and measurableSet_liouville ({x | Liouville x} = ⋂_k W k is Borel), upgrading the null-set results from outer-measure to honest measure statements; plus wellApprox_ssubset (2 ≤ σ < τ ⟹ W τ ⊊ W σ, proper strict nesting of the hierarchy via dimH_wellApprox_strictAntitone). --- ℚ-AFFINE INVARIANCE (researcher-5, 2026-07-12, VERIFIED 0-axiom): added the rational-affine invariance of wellApprox tau = {x|LiouvilleWith tau x} to LiouvilleTheoremOQ03.lean — membership is fixed by translation by a rational/integer (wellApprox_add_rat_iff/_add_int_iff/_sub_rat_iff), by negation (wellApprox_neg_iff, symmetric about 0), and by dilation by a nonzero rational (wellApprox_mul_rat_iff), plus the set-equality capstone image_add_rat_wellApprox ((·+r)''wellApprox tau = wellApprox tau). So wellApprox tau is invariant under the whole rational-affine group x↦a·x+b (a,b∈ℚ, a≠0) — the self-similarity underneath its everywhere-equal Hausdorff dimension. All from Mathlib LiouvilleWith.add_rat_iff/neg_iff/mul_rat_iff; none touches the dimH_wellApprox (Jarník–Besicovitch) axiom. 6 theorems, all [propext,Classical.choice,Quot.sound]. --- FOLLOW-UP (researcher-7, 2026-07-11, VERIFIED): added Part X, the category (Baire) face — each well-approximable set W τ is comeagre (wellApprox_residual: W τ ∈ residual ℝ, AXIOM-FREE, from eventually_residual_liouville + upward-closed residual filter), its complement is meagre (meagre_compl_wellApprox, AXIOM-FREE), and for τ>2 W τ is simultaneously comeagre and Lebesgue-null (wellApprox_residual_and_volume_zero) — the textbook category/measure dichotomy. Strengthens the prior wellApprox_dense. --- Formalized Jarník–Besicovitch dimH(W τ)=2/τ (τ≥2) over Mathlib LiouvilleWith + dimH; JB formula = single axiom; derived dimH{Liouville}=0 by tendsto squeeze. Structural lemmas 0-axiom (LiouvilleWith.mono, Liouville.liouvilleWith, dimH_mono). 210L, 17 thm, 2 def, 1 axiom.",
     "builtItems": [
+      "not_countable_liouville + isMeagre_of_countable + isNowhereDense_singleton_real + liouville_uncountable_yet_null_dimzero (researcher-1, 2026-07-19, VERIFIED): uncountability of the Liouville set via Baire category (residual not meagre) — axiom-free, the route dimension/measure cannot supply since dimH{Liouville}=0.",
       "wellApprox ℚ-affine invariance block (researcher-5, 2026-07-12, 0-axiom VERIFIED): wellApprox_add_rat_iff, wellApprox_add_int_iff, wellApprox_sub_rat_iff, wellApprox_neg_iff, wellApprox_mul_rat_iff, and set-equality image_add_rat_wellApprox. wellApprox tau invariant under x↦a·x+b (a,b∈ℚ,a≠0), via Mathlib LiouvilleWith iff-API. In LiouvilleTheoremOQ03.lean.",
       "wellApprox τ := {x | LiouvilleWith τ x} + antitonicity (LiouvilleWith.mono) and {Liouville}⊆W τ (Liouville.liouvilleWith), 0-axiom",
       "dimH_mono transport: dimH(W τ) antitone, dimH{Liouville} ≤ dimH(W τ)",
@@ -46,7 +47,8 @@
       "Only the dimension VALUE dimH(W τ)=2/τ is missing from Mathlib (needs Borel–Cantelli covering + Frostman mass distribution); isolate as one axiom, prove the rest unconditionally.",
       "Dimension zero sharpens the sibling's Lebesgue-measure-zero result; dimH is a finer gauge than cardinality or measure.",
       "The whole family dimH(W τ)=2/τ decays to 0 (dimH_wellApprox_tendsto_zero) — this is the family-level driver that forces the Liouville set (⊆ every W τ) to dimension 0; strict antitonicity comes from the formula, not just the set inclusion (which gives only ≤).",
-      "The well-approximable sets W(τ) are Borel measurable (measurableSet_wellApprox), as is the Liouville set (measurableSet_liouville) — proved axiom-free by C-monotone reduction to a countable union, frequently_atTop limsup, and open-ball fibres. Upgrades the null-set results from outer-measure to honest measure statements."
+      "The well-approximable sets W(τ) are Borel measurable (measurableSet_wellApprox), as is the Liouville set (measurableSet_liouville) — proved axiom-free by C-monotone reduction to a countable union, frequently_atTop limsup, and open-ball fibres. Upgrades the null-set results from outer-measure to honest measure statements.",
+      "The Liouville set's uncountability CANNOT come from dimension or measure (both are 0) — it is witnessed by Baire category: a residual set in a nonempty perfect Baire space is uncountable, because every countable set of reals is meagre (singletons are nowhere dense in a space with no isolated points)."
     ],
     "mathlibGaps": [
       "No Jarník–Besicovitch / Hausdorff-measure estimates for well-approximable sets; no irrationality-measure def; no mass transference principle."
@@ -73,7 +75,7 @@
     "mathlib": []
   },
   "started": "2026-04-22T12:51:58.295Z",
-  "lastUpdate": "2026-07-12",
+  "lastUpdate": "2026-07-19",
   "significance": 7,
   "tractability": 4,
   "leanFiles": [
@@ -91,8 +93,8 @@
     {
       "path": "Proofs/LiouvilleTheoremOQ03.lean",
       "filename": "LiouvilleTheoremOQ03.lean",
-      "lineCount": 787,
-      "theoremCount": 49,
+      "lineCount": 837,
+      "theoremCount": 59,
       "axiomCount": 1,
       "defCount": 2,
       "sorryCount": 0,


### PR DESCRIPTION
## Summary

Adds **Part XI** to `LiouvilleTheoremOQ03.lean`: the Liouville numbers are **uncountable**, proved through **Baire category** rather than dimension or measure.

The existing `not_countable_wellApprox` reads uncountability off the *positive* Hausdorff dimension `2/τ` of `W τ`. That route is structurally unavailable for the Liouville set itself, whose dimension is **0** (`dimH_liouville_eq_zero`) and which is Lebesgue-**null** (`volume_liouville_eq_zero`). So neither classical smallness gauge can witness its uncountability — category can: `{x | Liouville x}` is residual, and a residual set in the nonempty Baire space `ℝ` cannot be meagre, whereas every countable set of reals *is* meagre.

Mathlib has **no** uncountability statement for the Liouville set anywhere (checked).

## New theorems

Axiom-free (`#print axioms` = `[propext, Classical.choice, Quot.sound]`):
- `isNowhereDense_singleton_real` — singletons are nowhere dense in `ℝ` (`PerfectSpace`, no isolated points: `interior_singleton` + `IsClosed.isNowhereDense_iff`)
- `isMeagre_of_countable` — every countable subset of `ℝ` is meagre (countable union of nowhere-dense singletons); reusable
- `not_countable_liouville` — `¬ {x | Liouville x}.Countable`, via `not_isMeagre_of_mem_residual liouville_residual`

Capstone (carries only `dimH_wellApprox` via its dimension conjunct):
- `liouville_uncountable_yet_null_dimzero` — uncountable ∧ `dimH = 0` ∧ `volume = 0`

## Axioms

Budget **unchanged**: still 1 (`dimH_wellApprox`, the Jarník–Besicovitch formula, irreducible / not in Mathlib). The three uncountability lemmas add zero axiom dependence.

## Verification

`bin/lake env lean Proofs/LiouvilleTheoremOQ03.lean` against prebuilt Mathlib v4.31.0 oleans — **EXIT 0**, no errors (only a pre-existing unused-simp-arg warning at line 749 in `measurableSet_wellApprox`, not touched here). `#print axioms` confirmed for all four new theorems.

Metadata reconciled: 787→837 lines, `theoremCount`→59; also corrects stale gallery `leanFile` drift (was 626L/44thm).

🤖 Generated with [Claude Code](https://claude.com/claude-code)