### PR TITLE
Research: pythagorean-theorem-oq-01 — right-triangle inradius and Area=r·s identity

### DIFF
--- a/proofs/Proofs/PythagoreanTheoremOQ01.lean
+++ b/proofs/Proofs/PythagoreanTheoremOQ01.lean
@@ -405,6 +405,37 @@ theorem inverse_pythagorean (hAC : A ≠ C) (hBC : B ≠ C)
   field_simp
   ring
 
+/-- The **inradius** of the right triangle `A B C` (right angle at `C`):
+`r = (|CA| + |CB| − |AB|)/2`.  For a right triangle the inscribed-circle radius has this
+classical closed form — the legs' sum minus the hypotenuse, halved. -/
+noncomputable def inradius (A B C : F) : ℝ := (‖A - C‖ + ‖B - C‖ - ‖A - B‖) / 2
+
+omit [InnerProductSpace ℝ F] in
+/-- **The inradius is nonnegative.**  Immediate from the triangle inequality
+`|AB| ≤ |CA| + |CB|` (writing `A - B = (A - C) - (B - C)` and applying `norm_sub_le`); no right
+angle is needed. -/
+theorem inradius_nonneg (A B C : F) : 0 ≤ inradius A B C := by
+  unfold inradius
+  have h : ‖A - B‖ ≤ ‖A - C‖ + ‖B - C‖ := by
+    have hrw : A - B = (A - C) - (B - C) := by abel
+    rw [hrw]; exact norm_sub_le _ _
+  linarith
+
+/-- **Area–inradius identity (`Area = r·s`), pinned to the right-triangle inradius.**
+Twice the area of the right triangle (`|CA|·|CB|`) equals the inradius times the perimeter:
+
+  `2 · Area = r · (|CA| + |CB| + |AB|)`,
+
+i.e. `Area = r · s` with `s` the semiperimeter — the general triangle identity, here made
+completely explicit because for a right angle at `C` the inradius takes the closed form
+`r = (a + b − c)/2` (`inradius`).  The proof is pure algebra from `pythagorean_core`:
+`(a + b − c)(a + b + c) = (a + b)² − c² = 2ab` once `c² = a² + b²`. -/
+theorem two_area_eq_inradius_mul_perimeter (hperp : ⟪A - C, B - C⟫ = (0 : ℝ)) :
+    2 * triArea ‖A - C‖ ‖B - C‖
+      = inradius A B C * (‖A - C‖ + ‖B - C‖ + ‖A - B‖) := by
+  unfold triArea inradius
+  linear_combination (1 / 2 : ℝ) * pythagorean_core A B C hperp
+
 include hAB in
 /-- **The foot divides the hypotenuse in the ratio of the squared legs.**  The altitude foot
 `H` splits the hypotenuse `AB` into segments `|AH|` and `|HB|` whose lengths are proportional

--- a/research/problems/pythagorean-theorem-oq-01/knowledge.md
+++ b/research/problems/pythagorean-theorem-oq-01/knowledge.md
@@ -118,3 +118,33 @@ Insights accumulated during research on this problem.
 ### Next Steps
 - Family is mathematically complete; remaining 3 axioms in OQ01 need Gauss-circle / lattice-point
   counting infrastructure (>1000 lines) not in Mathlib. No session-sized axiom elimination remains.
+
+## Session 2026-07-19 (researcher-1) — right-triangle inradius + Area=r·s (VERIFIED axiom-free)
+
+**Mode:** REVISIT (mature, essentially-complete geometry file: 740L / ~36 thm / 0 axiom / 0 sorry).
+**Outcome:** +1 def, +2 theorems, 0 axioms.
+
+`PythagoreanTheoremOQ01.lean` (the Einstein-dissection + inner-product geometry entry) already
+covered altitude foot, both geometric-mean/leg theorems, inverse-Pythagoras (1/h²=1/a²+1/b²),
+Euclid VI.31, semicircles/Hippocrates' lunes, Thales, law of cosines, Apollonius median, Stewart's
+cevian, acute/obtuse characterizations. The one classic right-triangle metric relation missing was
+the **inradius**. Added:
+
+- `inradius (A B C : F) : ℝ := (‖A-C‖ + ‖B-C‖ - ‖A-B‖)/2` — the closed form for a right
+  triangle's inscribed-circle radius (legs' sum minus hypotenuse, halved).
+- `inradius_nonneg` — `0 ≤ inradius` from the triangle inequality `‖A-B‖ ≤ ‖A-C‖+‖B-C‖`
+  (`A-B = (A-C)-(B-C)`, `norm_sub_le`); no right angle needed (`omit [InnerProductSpace ℝ F] in`).
+- `two_area_eq_inradius_mul_perimeter` — the classical **Area = r·s**: `2·triArea(legs) =
+  inradius · (‖A-C‖+‖B-C‖+‖A-B‖)`. Pure algebra from `pythagorean_core` (`c²=a²+b²`):
+  `(a+b−c)(a+b+c) = (a+b)²−c² = 2ab`. One-liner `linear_combination (1/2:ℝ) * pythagorean_core A B C hperp`.
+
+Idiom notes (this file): legs/hyp are `‖A-C‖`,`‖B-C‖`,`‖A-B‖`; `triArea b t = b*t/2`;
+`pythagorean_core A B C hperp : ‖A-B‖²=‖A-C‖²+‖B-C‖²`. Section `Geometric` has
+`variable (A B C : F) (hAB : A ≠ B)` — lemmas not using `hAB` simply don't reference it (no
+`include`); a lemma using only norms should `omit [InnerProductSpace ℝ F] in` to avoid the
+unused-section-var linter.
+
+**Build: VERIFIED** host-elab vs prebuilt Mathlib v4.31.0 oleans (`bin/lake env lean`, EXIT 0, no
+errors/warnings). `#print axioms` on both new theorems = `[propext, Classical.choice, Quot.sound]`.
+File 740→771 lines. NOTE: research-json leanFiles entry for this file was badly stale (300L/12thm);
+reconciled to 771L/38thm/3def alongside the gallery meta.

--- a/src/data/proofs/pythagorean-theorem-oq-01/meta.json
+++ b/src/data/proofs/pythagorean-theorem-oq-01/meta.json
@@ -76,10 +76,10 @@
   },
   "leanFile": {
     "namespace": "PythagoreanEinstein",
-    "lineCount": 740,
+    "lineCount": 771,
     "axiomCount": 0,
-    "theoremCount": 36,
-    "definitionCount": 2,
+    "theoremCount": 38,
+    "definitionCount": 3,
     "path": "Proofs/PythagoreanTheoremOQ01.lean",
     "imports": [
       "Mathlib.Analysis.InnerProductSpace.Basic",

--- a/src/data/research/problems/pythagorean-theorem-oq-01.json
+++ b/src/data/research/problems/pythagorean-theorem-oq-01.json
@@ -30,7 +30,7 @@
     "phase": "OBSERVE",
     "since": "2026-04-05T23:12:43-07:00",
     "iteration": 1,
-    "focus": "Initial problem understanding. Read problem.md and gather context.",
+    "focus": "Added the right-triangle inradius r=(a+b-c)/2 and the Area=r*s identity (2*Area = r*perimeter) to the geometry file — axiom-free, pure algebra from pythagorean_core.",
     "blockers": [],
     "nextAction": "Read problem.md thoroughly and acquire full context.",
     "attemptCounts": {
@@ -40,8 +40,9 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (researcher-1, 2026-07-12): added stewart_cevian — Stewart's theorem (the cevian-length formula), a named classical generalization of the existing median_apollonius from the median to an ARBITRARY cevian. Clean vector form for D=A+t*(B-A): (1-t)||A-C||^2 + t||B-C||^2 = t(1-t)||A-B||^2 + ||D-C||^2. Cross terms +/-2t(1-t)<D-C,A-B> cancel by weighting the two norm_add/sub_sq_real expansions by (1-t) and t (same mechanism as Apollonius); t=1/2 recovers median_apollonius, endpoints t=0,1 give |CD|=|CA|/|CB|. Multiplying by c=|AB| with m=tc, n=(1-t)c recovers the classical b^2 n + a^2 m = c(d^2 + mn). File now 36 theorems / 740 lines, 0 sorry / 0 axiom ([propext,Classical.choice,Quot.sound]), docker-verified Lean v4.26.0. (Prior researcher-8: repaired Mathlib drift + added euclid_VI_31, semicircles.)",
+    "progressSummary": "INRADIUS / AREA=r*s (researcher-1, 2026-07-19, VERIFIED axiom-free): added to PythagoreanTheoremOQ01.lean the right-triangle inscribed-circle radius inradius A B C = (|CA|+|CB|-|AB|)/2 with inradius_nonneg (triangle inequality, no right angle needed) and the classical Area=r*s identity two_area_eq_inradius_mul_perimeter: 2*triArea(legs) = inradius*(|CA|+|CB|+|AB|). Proof is pure algebra from pythagorean_core via linear_combination (1/2)*hc, since (a+b-c)(a+b+c)=(a+b)^2-c^2=2ab when c^2=a^2+b^2. Fills the one classic right-triangle metric relation the otherwise-complete geometry file lacked (it already had altitude/geometric-mean/inverse-Pythagoras/Stewart/Apollonius/Euclid-VI.31/Thales/lunes). File 740->771 lines. All [propext,Classical.choice,Quot.sound]. --- PROGRESS (researcher-1, 2026-07-12): added stewart_cevian — Stewart's theorem (the cevian-length formula), a named classical generalization of the existing median_apollonius from the median to an ARBITRARY cevian. Clean vector form for D=A+t*(B-A): (1-t)||A-C||^2 + t||B-C||^2 = t(1-t)||A-B||^2 + ||D-C||^2. Cross terms +/-2t(1-t)<D-C,A-B> cancel by weighting the two norm_add/sub_sq_real expansions by (1-t) and t (same mechanism as Apollonius); t=1/2 recovers median_apollonius, endpoints t=0,1 give |CD|=|CA|/|CB|. Multiplying by c=|AB| with m=tc, n=(1-t)c recovers the classical b^2 n + a^2 m = c(d^2 + mn). File now 36 theorems / 740 lines, 0 sorry / 0 axiom ([propext,Classical.choice,Quot.sound]), docker-verified Lean v4.26.0. (Prior researcher-8: repaired Mathlib drift + added euclid_VI_31, semicircles.)",
     "builtItems": [
+      "inradius + inradius_nonneg + two_area_eq_inradius_mul_perimeter (researcher-1, 2026-07-19, VERIFIED axiom-free): right-triangle inradius (a+b-c)/2 and the Area=r*s identity, in PythagoreanTheoremOQ01.lean.",
       "sin_eq_sinc_mul, tendsto_one_sub_cos_mul_div_sq, tendsto_cos_mul_one, tendsto_one_sub_cos_prod_div_sq, spherical_flat_limit in Proofs/PythagoreanTheoremOQ05.lean (0 sorry, 0 axioms, verified via lake env lean 4.26.0)",
       "Removed 3 unused axioms from Proofs/PythagoreanTriplesOQ01.lean (r2_average_order [false as stated], landau_two_squares, primitive_by_leg_density), reducing 6→3; content retained as documented targets. Updated meta.json axiomCount 6→3 in both stat blocks + assumptions/keyStatements/annotations.",
       "PythagoreanTheoremOQ01.lean: Einstein's similar-triangles proof, verified (0 axioms, 0 sorries, 13 theorems) via docker-build Lean 4.26.0. Three layers: triArea_scale (area-square law), einstein_pythagorean (coordinate-free cancel-the-shape-constant skeleton), and an inner-product altitude decomposition (altitudeFoot, foot_perp, geometric_mean_A/B, segments_sum, pythagorean_via_altitude, einstein_matches_core). Gallery entry src/data/proofs/pythagorean-theorem-oq-01. PR #36241.",
@@ -94,7 +95,7 @@
     "mathlib": []
   },
   "started": "2026-04-06T06:37:41.264Z",
-  "lastUpdate": "2026-07-12T09:26:18.000Z",
+  "lastUpdate": "2026-07-19",
   "significance": 7,
   "tractability": 7,
   "leanFiles": [
@@ -112,10 +113,10 @@
     {
       "path": "Proofs/PythagoreanTheoremOQ01.lean",
       "filename": "PythagoreanTheoremOQ01.lean",
-      "lineCount": 300,
-      "theoremCount": 12,
+      "lineCount": 771,
+      "theoremCount": 38,
       "axiomCount": 0,
-      "defCount": 2,
+      "defCount": 3,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/PythagoreanTheoremOQ01.lean"


### PR DESCRIPTION
## Summary

Adds the one classic right-triangle metric relation missing from the (otherwise complete) inner-product geometry entry `PythagoreanTheoremOQ01.lean`: the **inscribed-circle radius**.

The file already covered the altitude foot, both geometric-mean/leg theorems, inverse-Pythagoras (`1/h² = 1/a² + 1/b²`), Euclid VI.31, semicircles/Hippocrates' lunes, Thales, law of cosines, Apollonius' median, Stewart's cevian, and acute/obtuse characterizations — but not the inradius.

## New (axiom-free: `[propext, Classical.choice, Quot.sound]`)

- `inradius A B C := (‖A-C‖ + ‖B-C‖ - ‖A-B‖)/2` — the closed form for a right triangle's inradius (legs' sum minus hypotenuse, halved)
- `inradius_nonneg` — `0 ≤ inradius`, from the triangle inequality `‖A-B‖ ≤ ‖A-C‖ + ‖B-C‖` (no right angle needed)
- `two_area_eq_inradius_mul_perimeter` — the classical **Area = r·s**: `2·triArea(legs) = inradius·(perimeter)`. Pure algebra from `pythagorean_core`: `(a+b−c)(a+b+c) = (a+b)² − c² = 2ab` once `c² = a² + b²`; a one-line `linear_combination (1/2)·pythagorean_core`.

## Verification

`bin/lake env lean Proofs/PythagoreanTheoremOQ01.lean` against prebuilt Mathlib v4.31.0 oleans — **EXIT 0, no errors/warnings**. `#print axioms` confirms both new theorems are axiom-free.

File 740→771 lines, +2 theorems +1 def, still **0 axiom / 0 sorry**. Also reconciled the stale research-json `leanFiles` entry for this file (was 300L/12thm) to current values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)