### PR TITLE
Research: amgm-inequality-oq-03-oq-02-oq-02 — geometric growth bound for log-concave sequences

### DIFF
--- a/proofs/Proofs/AmgmInequalityOQ03OQ02OQ02.lean
+++ b/proofs/Proofs/AmgmInequalityOQ03OQ02OQ02.lean
@@ -385,6 +385,32 @@ theorem logConcave_root_le_first (p : ℕ → ℝ) (hp0 : p 0 = 1)
   have hanti := logConcave_root_antitone_seq p hp0 hpos hlc
   simpa using hanti (Nat.zero_le k)
 
+/-- **Geometric growth bound.** A positive log-concave sequence with `p 0 = 1` grows at most
+geometrically at rate `p 1`: `p k ≤ (p 1) ^ k` for every `k`.  This is the sequence form of
+`logConcave_root_le_first` (`p (k+1)^{1/(k+1)} ≤ p 1`) cleared of the root — raise both nonnegative
+sides to the `(k+1)`-th power.  It is sharp: geometric `p k = r^k` attains equality
+(`geometric_root_antitone_eq`).  The dual lower bound `(r_last)^k ≤ p k` comes from
+`logConcave_root_ge_last_ratio`. -/
+theorem logConcave_le_first_pow (p : ℕ → ℝ) (hp0 : p 0 = 1)
+    (hpos : ∀ j, 0 < p j)
+    (hlc : ∀ m, p m * p (m + 2) ≤ (p (m + 1)) ^ 2) (k : ℕ) :
+    p k ≤ (p 1) ^ k := by
+  cases k with
+  | zero => simp [hp0]
+  | succ j =>
+    have hroot := logConcave_root_le_first p hp0 hpos hlc j
+    have hpj : (0 : ℝ) < p (j + 1) := hpos (j + 1)
+    have he : ((j : ℝ) + 1) ≠ 0 := by positivity
+    have hbase : (0 : ℝ) ≤ p (j + 1) ^ ((1 : ℝ) / ((j : ℝ) + 1)) :=
+      (Real.rpow_pos_of_pos hpj _).le
+    have hpow := Real.rpow_le_rpow hbase hroot (by positivity : (0 : ℝ) ≤ (j : ℝ) + 1)
+    rw [← Real.rpow_natCast (p 1) (j + 1)]
+    push_cast
+    calc p (j + 1)
+        = (p (j + 1) ^ ((1 : ℝ) / ((j : ℝ) + 1))) ^ ((j : ℝ) + 1) := by
+          rw [← Real.rpow_mul hpj.le, one_div, inv_mul_cancel₀ he, Real.rpow_one]
+      _ ≤ (p 1) ^ ((j : ℝ) + 1) := hpow
+
 /-! ## Lower bound: every root mean is at least the last consecutive ratio
 
 `logConcave_root_le_first` bounds each root mean `p (k+1)^{1/(k+1)}` *above* by the

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-02-oq-02.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-02-oq-02.json
@@ -7,7 +7,7 @@
   "significance": 6,
   "tractability": 6,
   "started": "2026-06-26",
-  "lastUpdate": "2026-06-26",
+  "lastUpdate": "2026-07-19",
   "path": "research/problems/amgm-inequality-oq-03-oq-02-oq-02",
   "tags": [
     "analysis",
@@ -22,8 +22,9 @@
     "The Maclaurin step is derivable from Newton via a discrete log-concavity / prefix-mean argument."
   ],
   "knowledge": {
-    "progressSummary": "COMPLETE (modulo blocked axiom): full non-negative Maclaurin chain M₁≥…≥Mₙ and AM-GM derived axiom-free from the single newton_log_concavity axiom (maclaurin_step is a THEOREM). newton_log_concavity discharged axiom-free for ALL n≤4 (newton_k1, newton_n3_k2, newton_n4_k2, newton_n4_k3). Sole residual = general-n Newton via real-rootedness/Rolle, a >1000-line Mathlib gap (TRULY BLOCKED). Extending to n=5,6,… is enumeration theater, not progress.",
+    "progressSummary": "GEOMETRIC GROWTH BOUND (researcher-1, 2026-07-19, VERIFIED axiom-free): added logConcave_le_first_pow to the MaclaurinLogConcave engine (AmgmInequalityOQ03OQ02OQ02.lean) — a positive log-concave sequence with p 0 = 1 grows at most geometrically at rate p 1: p k <= (p 1)^k for every k. The sequence form of logConcave_root_le_first (p(k+1)^{1/(k+1)} <= p 1) cleared of the root by raising both nonneg sides to the (k+1) power (Real.rpow_le_rpow + Real.rpow_mul/rpow_natCast). Sharp (geometric attains equality); dual lower bound via logConcave_root_ge_last_ratio. Axiom-free [propext,Classical.choice,Quot.sound]. File 720->746 lines, 35->36 theorems. --- COMPLETE (modulo blocked axiom): full non-negative Maclaurin chain M₁≥…≥Mₙ and AM-GM derived axiom-free from the single newton_log_concavity axiom (maclaurin_step is a THEOREM). newton_log_concavity discharged axiom-free for ALL n≤4 (newton_k1, newton_n3_k2, newton_n4_k2, newton_n4_k3). Sole residual = general-n Newton via real-rootedness/Rolle, a >1000-line Mathlib gap (TRULY BLOCKED). Extending to n=5,6,… is enumeration theater, not progress.",
     "builtItems": [
+      "logConcave_le_first_pow (researcher-1, 2026-07-19, VERIFIED axiom-free): geometric growth bound p k <= (p 1)^k for positive log-concave sequences with p 0 = 1; sequence form of logConcave_root_le_first. In AmgmInequalityOQ03OQ02OQ02.lean (MaclaurinLogConcave).",
       "Proofs/MaclaurinStepFromNewton.lean: maclaurin_core — p_{k+1}^k <= p_k^{k+1} by induction on k using only Nat-powers (the key reduction; avoids logs and infinite products).",
       "Proofs/MaclaurinStepFromNewton.lean: rpow_cross — root-extraction lemma b^s<=a^t => b^(1/t)<=a^(1/s) for positive reals/naturals.",
       "Proofs/MaclaurinStepFromNewton.lean: maclaurin_step_pos — M_{k+1}<=M_k for strictly positive inputs, from newton_log_concavity ALONE.",
@@ -498,11 +499,11 @@
     {
       "path": "Proofs/AmgmInequalityOQ03OQ02OQ02.lean",
       "filename": "AmgmInequalityOQ03OQ02OQ02.lean",
-      "lineCount": 272,
-      "theoremCount": 12,
+      "lineCount": 746,
+      "theoremCount": 36,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ03OQ02OQ02.lean"
     },


### PR DESCRIPTION
## Summary

Adds `logConcave_le_first_pow` to the `MaclaurinLogConcave` engine (`AmgmInequalityOQ03OQ02OQ02.lean`): a positive log-concave sequence with `p 0 = 1` grows **at most geometrically** at rate `p 1`:

`p k ≤ (p 1) ^ k` for every `k`.

This is the sequence form of the library's existing `logConcave_root_le_first` (`p(k+1)^{1/(k+1)} ≤ p 1`), cleared of the root by raising both nonnegative sides to the `(k+1)`-th power (`Real.rpow_le_rpow`; `Real.rpow_mul` + `inv_mul_cancel₀` to collapse the LHS; `Real.rpow_natCast` for the RHS ℕ-power).

## Notes

- Axiom-free: `#print axioms` = `[propext, Classical.choice, Quot.sound]`.
- **Sharp**: geometric `p k = r^k` attains equality (`geometric_root_antitone_eq`); the dual lower bound `(r_last)^k ≤ p k` follows from `logConcave_root_ge_last_ratio`.
- The one deep family axiom `newton_log_concavity` (in the sibling `AmgmInequalityOQ02.lean`, requiring real-rootedness/Rolle machinery absent from Mathlib) is untouched.

## Verification

`bin/lake env lean Proofs/AmgmInequalityOQ03OQ02OQ02.lean` against prebuilt Mathlib v4.31.0 oleans — **EXIT 0** (only a pre-existing unused-variable linter warning, not in the new code).

File 720→746 lines, 35→36 theorems, still 0-axiom/0-sorry. Also refreshed the stale research-json `leanFiles` entry for this node (was 272L/12thm) to current 746L/36thm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)