### PR TITLE
Fix: repair never-compiled Erdos719Problem (batch 10 of #39077)

### DIFF
--- a/proofs/Proofs/Erdos719Problem.lean
+++ b/proofs/Proofs/Erdos719Problem.lean
@@ -19,6 +19,8 @@ import Mathlib.Data.Finset.Card
 import Mathlib.Tactic
 import Mathlib.Combinatorics.SimpleGraph.Extremal.Turan
 
+set_option autoImplicit false
+
 -- ## r-Uniform Hypergraphs
 
 /-- An r-uniform hypergraph on a finite vertex set V, represented by a family
@@ -492,10 +494,10 @@ theorem turanHypergraph_graph_le (n : ℕ) :
   · -- For each clique-free H, show H.edges.card ≤ n²/4
     rintro m ⟨H, hcf, rfl⟩
     -- Bridge: build a SimpleGraph with the same edge structure
-    let G : SimpleGraph (Fin n) where
-      Adj v w := ({v, w} : Finset (Fin n)) ∈ H.edges
-      symm := fun h => by rwa [Finset.pair_comm]
-      loopless v h := by have := H.uniform _ h; simp at this
+    let G : SimpleGraph (Fin n) :=
+      { Adj := fun v w => ({v, w} : Finset (Fin n)) ∈ H.edges
+        symm.symm := fun _ _ h => by rwa [Finset.pair_comm]
+        loopless.irrefl := fun v h => by have := H.uniform _ h; simp at this }
     haveI : DecidableRel G.Adj := fun v w => Finset.decidableMem _ _
     -- G is triangle-free (CliqueFree 3)
     have hcf3 : G.CliqueFree 3 := by
@@ -512,7 +514,7 @@ theorem turanHypergraph_graph_le (n : ℕ) :
       intro e he
       obtain ⟨v, w, _, rfl⟩ := Finset.card_eq_two.mp (H.uniform e he)
       exact Finset.mem_image.mpr ⟨s(v, w),
-        SimpleGraph.mem_edgeFinset.mpr (SimpleGraph.mem_edgeSet.mpr he),
+        SimpleGraph.mem_edgeFinset.mpr (show s(v, w) ∈ G.edgeSet from he),
         Sym2.toFinset_mk_eq⟩
     -- Chain: |H.edges| ≤ |image| ≤ |G.edgeFinset| ≤ n²/4
     calc H.edges.card

--- a/src/data/proofs/erdos-719/meta.json
+++ b/src/data/proofs/erdos-719/meta.json
@@ -77,8 +77,8 @@
       }
     ],
     "axiomCount": 1,
-    "lineCount": 546,
-    "assumptions": "AUDIT (issue #39061): NOT machine-verified. This entry never validly compiled. Even under Lean v4.26 the proof only 'passed' because the old `autoImplicit true` default silently bound the undefined identifier `H.edges` as a free implicit variable, rendering the stated theorem vacuously general; under v4.31 (autoImplicit off by default) the file fails with `unknownIdentifier 'H.edges'` and typically additional genuine proof errors. The verification claims below are therefore retracted pending a Lean-source repair (Class A). ORIGINAL METADATA: 1 axiom: erdos_sauer_conjecture (OPEN problem). Turán's theorem for graphs fully proved via Mathlib bridge.",
+    "lineCount": 548,
+    "assumptions": "1 axiom: `erdos_sauer_conjecture` (the OPEN Erdős–Sauer decomposition problem). Every other result is an unconditional theorem — in particular Turán's theorem for graphs ($\\mathrm{ex}_2(n;K_3)=\\lfloor n^2/4\\rfloor$) is fully proved via a bridge to Mathlib's `SimpleGraph.CliqueFree.card_edgeFinset_le`. REPAIR (issue #39077, Class A): the file previously never compiled — the graph-case upper bound built its bridging `SimpleGraph` with the old `let ... where` structure syntax and, absent `set_option autoImplicit false`, the undefined field references were silently auto-bound. Repaired green on Lean v4.31: `set_option autoImplicit false` added; the `SimpleGraph` literal rewritten with the v4.31 `symm.symm`/`loopless.irrefl` field idiom; `SimpleGraph.mem_edgeSet.mpr` replaced by its definitional form. 0 sorries.",
     "theoremCount": 20,
     "definitionCount": 10
   },
@@ -185,7 +185,7 @@
       "id": "turan-axiom-elimination",
       "title": "Turán's Theorem for Graphs — Axiom Elimination Path",
       "startLine": 282,
-      "endLine": 546,
+      "endLine": 548,
       "summary": "Discharges the former `turan_graph` axiom into a proved theorem. Constructs `completeBipartiteHypergraph n` (2-edges between vertices of differing parity), proves it triangle-free (`completeBipartiteHypergraph_cliqueFree`) and that it has $\\lfloor n^2/4 \\rfloor$ edges (`completeBipartiteHypergraph_card`). Combining the lower bound `turanHypergraph_graph_ge` with the upper bound `turanHypergraph_graph_le` yields `turan_graph : turanHypergraph n 2 = n^2/4` (now a theorem, not an axiom), and `graph_case_bound` specializes the decomposition bound to $\\lfloor n^2/4 \\rfloor$ pieces.",
       "mathContext": "The extremal triangle-free construction is the balanced bipartite graph: edges $\\{v,w\\}$ with $v \\bmod 2 \\ne w \\bmod 2$, giving $\\lfloor n/2\\rfloor \\cdot \\lceil n/2\\rceil = \\lfloor n^2/4\\rfloor$ edges. Matching lower and upper bounds prove $\\mathrm{ex}_2(n;K_3) = \\lfloor n^2/4\\rfloor$ unconditionally, eliminating the graph-case axiom and leaving `erdos_sauer_conjecture` as the file's only assumption."
     }
@@ -211,7 +211,7 @@
     ],
     "opens": [],
     "namespace": null,
-    "lineCount": 546,
+    "lineCount": 548,
     "axiomCount": 1,
     "theoremCount": 20,
     "definitionCount": 10,


### PR DESCRIPTION
## Summary

Class A repair (batch 10) for #39077. **Erdos719Problem** now compiles green on Lean **v4.31** with 0 sorries.

## Root cause
The graph-case upper bound `turanHypergraph_graph_le` built its bridging `SimpleGraph (Fin n)` using the old `let ... where` structure syntax. Absent `set_option autoImplicit false`, the undefined field references (`H.edges`, `H.uniform`) were silently auto-bound, and the `let ... where` block failed to parse (`unexpected token 'haveI'`). The entry never validly compiled.

## Fix (verified via `./proofs/scripts/docker-build.sh Proofs.Erdos719Problem` → *Build succeeded*)
- Added `set_option autoImplicit false` so any future free-variable defect surfaces.
- Rewrote the `SimpleGraph` literal with the v4.31 nested-field idiom — `symm.symm := …` / `loopless.irrefl := …` (the fields are now `Std.Symm` / `Std.Irrefl`).
- Replaced `SimpleGraph.mem_edgeSet.mpr he` (qualified `.mpr` failed to resolve) with the definitional form `show s(v, w) ∈ G.edgeSet from he` (`mem_edgeSet` is `Iff.rfl`).

## Metadata
- De-retracted the #39061 audit narrative in `assumptions`.
- `status` stays `axiomatized` / `badge: axiom` — 1 genuine axiom (`erdos_sauer_conjecture`, the OPEN Erdős–Sauer decomposition problem); every other result, incl. Turán's theorem for graphs, is an unconditional theorem.
- `lineCount` 546 → 548.

## Evidence
Before: `error: Unknown identifier 'H.edges'` + `unexpected token 'haveI'` + kernel failures.
After: `Build completed successfully (2995 jobs). === Build succeeded ===`

Part of #39077 (does not close it — ~13 Class A/B/D/E entries remain).