### PR TITLE
audit: re-serve oldest cohort (13 axiomatized erdos entries) — all clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -17040,56 +17040,56 @@
     },
     "erdos-870": {
       "agentId": "auditor-agent",
-      "auditCount": 5,
-      "lastAudited": "2026-05-16T03:03:24Z",
+      "auditCount": 6,
+      "lastAudited": "2026-07-19T16:50:52Z",
       "result": "clean"
     },
     "erdos-871": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T00:18:39Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-19T16:50:51Z",
       "result": "clean"
     },
     "erdos-872": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T00:18:38Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-19T16:50:51Z",
       "result": "clean"
     },
     "erdos-873": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-05-04T04:04:44Z",
+      "auditCount": 5,
+      "lastAudited": "2026-07-19T16:50:51Z",
       "result": "clean"
     },
     "erdos-874": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T00:18:39Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-19T16:50:51Z",
       "result": "clean"
     },
     "erdos-875": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T00:18:39Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-19T16:50:51Z",
       "result": "clean"
     },
     "erdos-876": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T00:18:20Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-19T16:50:51Z",
       "result": "clean"
     },
     "erdos-877": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-05-08T16:46:43Z",
+      "auditCount": 5,
+      "lastAudited": "2026-07-19T16:50:52Z",
       "result": "clean"
     },
     "erdos-878": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-05-16T02:45:19Z",
+      "auditCount": 5,
+      "lastAudited": "2026-07-19T16:50:52Z",
       "result": "clean"
     },
     "erdos-879": {
@@ -17106,26 +17106,26 @@
     },
     "erdos-880": {
       "agentId": "auditor-agent",
-      "auditCount": 4,
-      "lastAudited": "2026-07-10T08:24:08Z",
+      "auditCount": 5,
+      "lastAudited": "2026-07-19T16:50:52Z",
       "result": "clean"
     },
     "erdos-881": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T00:18:20Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-19T16:50:44Z",
       "result": "clean"
     },
     "erdos-882": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T00:18:20Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-19T16:50:51Z",
       "result": "clean"
     },
     "erdos-883": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T00:18:20Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-19T16:50:51Z",
       "result": "clean"
     },
     "erdos-884": {


### PR DESCRIPTION
## Gallery integrity audit — round-robin re-serve

The unaudited queue is fully drained (4807/4807 audited; only 2 flagged, both already fixed-in-PR: #39082 meta + #39085 tracker). Per the auditor cadence, round-robin re-served the **oldest** cohort (last audited 2026-05-04) and batch-verified meta counts against the actual Lean source — the same v4.31 migration drift that hit erdos-39/922 would surface here first.

## Result: all 13 clean

| slug | status | axiom (meta→src) | sorry (meta→src) | note |
|------|--------|-----------------|------------------|------|
| erdos-870..883 | axiomatized | match | match | line drifts are stale undercounts (harmless) |

- **erdos-875** — axiomCount=1 correctly counts `native_decide`'s `Lean.ofReduceBool`.
- **erdos-873** — `native_decide` in 3 `example` blocks (benign) plus the base cases of helper lemma `consecutiveLcm_powers_of_two`; entry is badged `wip`/`axiomatized` with the two real Erdős–Szemerédi assumptions disclosed in `meta.assumptions` — no verified-overclaim. Consistent with 3 prior clean audits.
- No axiom undercounts, no sorry overclaims, no `verified` claims resting on assumptions.

Tracker-only change (13 entries × auditCount+1 / lastAudited / result=clean). **Disjoint** from pending tracker PR #39085 (erdos-39/922/cevas + corrupt-key purge) — mergeable independently.

---
Discovered during gallery integrity audit.