### PR TITLE
Research: euler-polyhedral-formula-oq-02-oq-02 — Künneth convolution associativity

### DIFF
--- a/proofs/Proofs/EulerPolyhedralOQ02OQ02.lean
+++ b/proofs/Proofs/EulerPolyhedralOQ02OQ02.lean
@@ -1187,6 +1187,44 @@ theorem kunnethBetti_pointBetti_right (b : ℕ → ℕ) (k : ℕ) :
     kunnethBetti b pointBetti k = b k := by
   rw [kunnethBetti_comm, kunnethBetti_pointBetti_left]
 
+/-- **The Künneth convolution is associative: `(a ⋆ b) ⋆ c = a ⋆ (b ⋆ c)`.**  The Cauchy
+    product `(b ⋆ c)(k) = ∑_{i+j=k} bᵢcⱼ` over `ℕ` is associative — both sides expand to the
+    triple sum `∑_{i+j+l=k} aᵢbⱼcₗ`.  Formally, after distributing the outer factor into each
+    convolution (`Finset.sum_mul` / `Finset.mul_sum`) both sides become double sums over the
+    triangular index sets `{(m,i) : i ≤ m ≤ k}` and `{(i,j) : i+j ≤ k}`, matched by the
+    reindexing bijection `(m,i) ↦ (i, m−i)` with inverse `(i,j) ↦ (i+j, i)` (`Finset.sum_bij'`).
+    Together with `kunnethBetti_comm` and the two-sided unit `pointBetti`
+    (`kunnethBetti_pointBetti_left`/`_right`), this makes `⋆` a commutative-monoid operation on
+    Betti sequences — the homological shadow of the associativity of the Cartesian product
+    `(M × N) × P ≅ M × (N × P)`. -/
+theorem kunnethBetti_assoc (a b c : ℕ → ℕ) (k : ℕ) :
+    kunnethBetti (kunnethBetti a b) c k = kunnethBetti a (kunnethBetti b c) k := by
+  unfold kunnethBetti
+  simp_rw [Finset.sum_mul, Finset.mul_sum]
+  rw [Finset.sum_sigma', Finset.sum_sigma']
+  refine Finset.sum_bij'
+    (fun x _ => (⟨x.2, x.1 - x.2⟩ : (_ : ℕ) × ℕ))
+    (fun y _ => (⟨y.1 + y.2, y.1⟩ : (_ : ℕ) × ℕ)) ?_ ?_ ?_ ?_ ?_
+  · rintro ⟨m, i⟩ hx
+    simp only [Finset.mem_sigma, Finset.mem_range] at hx ⊢
+    omega
+  · rintro ⟨i, j⟩ hy
+    simp only [Finset.mem_sigma, Finset.mem_range] at hy ⊢
+    omega
+  · rintro ⟨m, i⟩ hx
+    simp only [Finset.mem_sigma, Finset.mem_range] at hx
+    have hm : i + (m - i) = m := by omega
+    simp only [hm]
+  · rintro ⟨i, j⟩ hy
+    simp only [Finset.mem_sigma, Finset.mem_range] at hy
+    have hj : i + j - i = j := by omega
+    simp only [hj]
+  · rintro ⟨m, i⟩ hx
+    simp only [Finset.mem_sigma, Finset.mem_range] at hx
+    have hc : k - i - (m - i) = k - m := by omega
+    simp only [hc]
+    ring
+
 /-- **The product-surface Betti table is symmetric in its genera: `bₖ(Σ_g × Σ_h) =
     bₖ(Σ_h × Σ_g)` for `k ≤ 4`.**  A concrete consequence of the commutativity of the Künneth
     convolution (`kunnethBetti_comm`) applied to `prodSurfaceBetti_kunneth`: the palindrome

--- a/research/problems/euler-polyhedral-formula-oq-02-oq-02/knowledge.md
+++ b/research/problems/euler-polyhedral-formula-oq-02-oq-02/knowledge.md
@@ -230,3 +230,35 @@ invoked). File: 102 `^theorem` + 17 def, 0 sorries, 0 axiom decls.
 Unchanged: core BLOCKED on Mathlib v4.26 (no Pfaffian / characteristic-form integration /
 manifold χ). Convolution associativity would complete the commutative-monoid claim on Betti
 sequences — a self-contained next elementary increment (Cauchy-product associativity over ℕ).
+
+## Session 2026-07-19 (researcher-1) — Künneth convolution associativity (VERIFIED axiom-free)
+
+**Mode:** REVISIT (mature axiomatized entry; the elementary `kunnethBetti` convolution algebra).
+**Outcome:** +1 theorem, 0 axioms — closes the named frontier.
+
+Parts XVIII–XIX built the Künneth convolution `kunnethBetti b c k = ∑_{i∈range(k+1)} bᵢ·c_{k−i}`
+on Betti sequences and proved its **commutativity** (`kunnethBetti_comm`) and **two-sided unit**
+`pointBetti = δ` (`kunnethBetti_pointBetti_left`/`_right`). The stated remaining increment was
+**associativity** (Cauchy-product associativity over ℕ). Added:
+
+- `kunnethBetti_assoc (a b c k) : kunnethBetti (kunnethBetti a b) c k = kunnethBetti a (kunnethBetti b c) k`.
+  Both sides expand to `∑_{i+j+l=k} aᵢbⱼcₗ`. Proof: `unfold`, distribute the outer factor into each
+  convolution (`simp_rw [Finset.sum_mul, Finset.mul_sum]`), flatten both double sums with
+  `Finset.sum_sigma'`, then match the triangular index sets `{(m,i):i≤m≤k}` and `{(i,j):i+j≤k}`
+  by the reindexing bijection `(m,i) ↦ (i, m−i)` / inverse `(i,j) ↦ (i+j, i)` via `Finset.sum_bij'`.
+
+With comm + unit this makes `⋆` a **commutative-monoid** operation on Betti sequences — the
+homological shadow of associativity of the Cartesian product `(M×N)×P ≅ M×(N×P)`.
+
+Reusable idiom (Cauchy-product associativity over ℕ): distribute with `sum_mul`/`mul_sum`, flatten
+nested sums with `Finset.sum_sigma'`, then `Finset.sum_bij'` between the two triangular sigma
+finsets — **all five `sum_bij'` obligations (both membership, both inverses, the term equality)
+close by `simp only [Finset.mem_sigma, Finset.mem_range] at …` followed by `omega` (with `ring` for
+the term)**. Key: `simp only [mem_sigma, mem_range]` reduces the `Sigma.mk` projections so `omega`
+sees the raw naturals; the sigma-equality inverse goals close by `simp only [<omega-fact>]` rewriting
+the single differing first component (the second components are already syntactically equal).
+
+**Build: VERIFIED** host-elab vs prebuilt Mathlib v4.31.0 oleans (`bin/lake env lean`, EXIT 0, no
+errors/warnings in the new code). `#print axioms ChernGaussBonnet.kunnethBetti_assoc`
+= `[propext, Classical.choice, Quot.sound]`. File 1302→1340 lines, +1 theorem; node stays 0-axiom
+(the deep CGB core assumptions live in sibling files and are not invoked here).

--- a/src/data/proofs/euler-polyhedral-formula-oq-02-oq-02/meta.json
+++ b/src/data/proofs/euler-polyhedral-formula-oq-02-oq-02/meta.json
@@ -157,9 +157,9 @@
       "Real"
     ],
     "namespace": "ChernGaussBonnet",
-    "lineCount": 1302,
+    "lineCount": 1340,
     "axiomCount": 0,
-    "theoremCount": 131,
+    "theoremCount": 132,
     "definitionCount": 14,
     "path": "Proofs/EulerPolyhedralOQ02OQ02.lean",
     "sorries": 0

--- a/src/data/research/problems/euler-polyhedral-formula-oq-02-oq-02.json
+++ b/src/data/research/problems/euler-polyhedral-formula-oq-02-oq-02.json
@@ -29,8 +29,9 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Part XIX abstracts Part XVIII's one Künneth table into the algebraic laws of the kunnethBetti convolution — commutativity + point-as-unit (two-sided), yielding prodSurfaceBetti symmetry. Core still BLOCKED on Mathlib v4.26 (no Pfaffian). Elementary/homological calculus now includes the convolution monoid structure. 0-axiom, host-lean elab EXIT 0.",
+    "progressSummary": "KUNNETH CONVOLUTION ASSOCIATIVITY (researcher-1, 2026-07-19, VERIFIED axiom-free): added kunnethBetti_assoc to EulerPolyhedralOQ02OQ02.lean — the Kunneth/Cauchy convolution (b*c)(k)=sum_{i+j=k} b_i c_j on Betti sequences is associative, (a*b)*c = a*(b*c). This was the explicit named frontier: combined with the existing kunnethBetti_comm and two-sided unit pointBetti (kunnethBetti_pointBetti_left/_right), it makes * a commutative-MONOID operation on Betti sequences (homological shadow of associativity of the Cartesian product). Proof: distribute (Finset.sum_mul/mul_sum), flatten both double sums with Finset.sum_sigma', and match the triangular index sets {(m,i):i<=m<=k} and {(i,j):i+j<=k} by the reindexing bijection (m,i)->(i,m-i) / inverse (i,j)->(i+j,i) via Finset.sum_bij' (membership+inverse+term goals all by omega/ring after simp only [mem_sigma,mem_range]). Axiom-free. File 1302->1340 lines. --- PROGRESS: Part XIX abstracts Part XVIII's one Künneth table into the algebraic laws of the kunnethBetti convolution — commutativity + point-as-unit (two-sided), yielding prodSurfaceBetti symmetry. Core still BLOCKED on Mathlib v4.26 (no Pfaffian). Elementary/homological calculus now includes the convolution monoid structure. 0-axiom, host-lean elab EXIT 0.",
     "builtItems": [
+      "kunnethBetti_assoc (researcher-1, 2026-07-19, VERIFIED axiom-free): associativity of the Kunneth/Cauchy convolution on Betti sequences; with comm + unit completes the commutative-monoid structure. In EulerPolyhedralOQ02OQ02.lean.",
       "CGBManifold structure encoding the Chern-Gauss-Bonnet identity ∫_M Pf(Ω)=(2π)^n·χ(M) with derived even-dimensionality, normalized integral, χ=0⇒∫Pf=0, sign matching, and Euler-number integrality.",
       "Verified sphere Euler characteristics (sphereEulerChar), (2π)^n normalization lemmas (cgbConst), and the 2×2 Pfaffian/determinant identity (pf2_sq_eq_det2).",
       "Functorial constructions sphereCGB / prodCGB / torusCGB and ClosedOddManifold, plus two_dim_gauss_bonnet recovering the n=1 classical case.",
@@ -55,7 +56,9 @@
       "No integration of characteristic forms over manifolds",
       "No manifold Euler characteristic"
     ],
-    "nextSteps": [],
+    "nextSteps": [
+      "DONE (2026-07-19): kunnethBetti_assoc — convolution associativity, completing the commutative-monoid structure on Betti sequences."
+    ],
     "markdown": "# Knowledge Base: euler-polyhedral-formula-oq-02-oq-02\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },
   "tags": [],
@@ -71,8 +74,19 @@
     "mathlib": []
   },
   "started": "2026-03-30T18:39:05.245Z",
-  "lastUpdate": "2026-07-11T00:00:00.000Z",
+  "lastUpdate": "2026-07-19",
   "leanFiles": [
+    {
+      "path": "Proofs/EulerPolyhedralOQ02OQ02.lean",
+      "filename": "EulerPolyhedralOQ02OQ02.lean",
+      "lineCount": 1340,
+      "theoremCount": 132,
+      "axiomCount": 0,
+      "defCount": 14,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/EulerPolyhedralOQ02OQ02.lean"
+    },
     {
       "path": "Proofs/EulerPolyhedralFormula.lean",
       "filename": "EulerPolyhedralFormula.lean",


### PR DESCRIPTION
## Summary

Adds `kunnethBetti_assoc`: the Künneth/Cauchy convolution `(b ⋆ c)(k) = ∑_{i+j=k} bᵢcⱼ` on Betti sequences is **associative**, `(a ⋆ b) ⋆ c = a ⋆ (b ⋆ c)`. This was the file's explicitly named remaining frontier.

Combined with the existing `kunnethBetti_comm` and the two-sided unit `pointBetti` (`kunnethBetti_pointBetti_left`/`_right`), it makes `⋆` a **commutative-monoid** operation on Betti sequences — the homological shadow of the associativity of the Cartesian product `(M × N) × P ≅ M × (N × P)`.

## Proof

Both sides expand to the triple sum `∑_{i+j+l=k} aᵢbⱼcₗ`. Distribute the outer factor into each convolution (`Finset.sum_mul` / `Finset.mul_sum`), flatten both double sums with `Finset.sum_sigma'`, then match the triangular index sets `{(m,i) : i ≤ m ≤ k}` and `{(i,j) : i+j ≤ k}` by the reindexing bijection `(m,i) ↦ (i, m−i)` with inverse `(i,j) ↦ (i+j, i)` (`Finset.sum_bij'`); all obligations close by `omega`/`ring` after `simp only [Finset.mem_sigma, Finset.mem_range]`.

## Verification

`bin/lake env lean Proofs/EulerPolyhedralOQ02OQ02.lean` against prebuilt Mathlib v4.31.0 oleans — **EXIT 0**, no errors/warnings in the new code. `#print axioms ChernGaussBonnet.kunnethBetti_assoc` = `[propext, Classical.choice, Quot.sound]`.

File 1302→1340 lines, +1 theorem; node stays **0-axiom / 0-sorry**. Gallery + research metadata refreshed (leanFile 131→132 thm, 1302→1340 L).

🤖 Generated with [Claude Code](https://claude.com/claude-code)