### PR TITLE
Fix: Erdos882ProblemOQ03 verified green on v4.31 (batch 11 of #39077)

### DIFF
--- a/proofs/Proofs/Erdos882ProblemOQ03.lean
+++ b/proofs/Proofs/Erdos882ProblemOQ03.lean
@@ -45,6 +45,8 @@ Reference: Erdős Problem #882, https://erdosproblems.com/882
 
 import Mathlib
 
+set_option autoImplicit false
+
 namespace Erdos882OQ03
 
 open Finset BigOperators


### PR DESCRIPTION
## Summary

Batch 11 of #39077 (repair the 28 never-compiled entries from #39061).

**Erdos882ProblemOQ03** — the `:a` flag from #39061 is a **false positive**. With `set_option autoImplicit false` the file builds clean; every identifier is an explicit parameter, no free-variable errors surface.

## Evidence
- `./proofs/scripts/docker-build.sh Proofs.Erdos882ProblemOQ03` → **Build succeeded** (8576 jobs) with `autoImplicit false`.
- 0 sorries, 0 axioms, 0 `native_decide` (verified by grep).
- Committed `set_option autoImplicit false` so the masked-free-var class cannot silently reappear (per the batch-5 root-cause note: `proofs/lakefile.toml` sets no `autoImplicit`, so the project inherits Lean core's `autoImplicit=true`, not mathlib's `false`).

## Metadata
No `meta.json` change needed. This is a **research supporting file** (research problem `erdos-882-oq-03`, status `in-progress`); the gallery `erdos-882` entry maps to the parent `Erdos882Problem.lean`, whose `axiomatized`/`axiom` metadata (2 axioms) is already correct.

Same disposition as Erdos1071 (batch 7). Part of #39077.