### PR TITLE
Fix: repair never-compiled Erdos1066Problem (false positive + autoImplicit guard) — batch 12 of #39077

### DIFF
--- a/proofs/Proofs/Erdos1066Problem.lean
+++ b/proofs/Proofs/Erdos1066Problem.lean
@@ -27,6 +27,8 @@ import Mathlib.Data.Real.Basic
 import Mathlib.Data.Rat.Defs
 import Mathlib.Analysis.InnerProductSpace.PiL2
 
+set_option autoImplicit false
+
 open Real
 
 namespace Erdos1066


### PR DESCRIPTION
## Summary

Batch 12 of the #39077 proof-repair follow-on. Repairs the `Erdos1066Problem` entry from the 28 never-compiled list.

**Finding: this entry was a false positive in the #39061 audit.** The audit claimed the file was autoImplicit-masked and would fail under `autoImplicit false` with `unknownIdentifier 'n'`. In fact `n` is properly declared via `variable {n : ℕ}` at the top of the namespace, and the file compiles clean under Lean v4.31.0 **even with** `set_option autoImplicit false`, with 0 sorries.

## Changes

- **`proofs/Proofs/Erdos1066Problem.lean`**: add `set_option autoImplicit false` guard so the file cannot silently reintroduce masked free variables (matches the batch repair pattern used elsewhere in #39077).
- **`src/data/proofs/erdos-1066/meta.json`**: correct the `assumptions` field — remove the now-false "NOT machine-verified / fails with unknownIdentifier 'n'" retraction and document the verified state. `status`/`badge` were already correctly `axiomatized`/`axiom` (the file has 2 axioms `g`, `g_d`); counts (2 axioms, 5 theorems, 6 defs) already match the source, so they are unchanged.

## Evidence

- **Before**: `./proofs/scripts/docker-build.sh Proofs.Erdos1066Problem` → builds clean (autoImplicit `true` default — masking possible but no actual masked identifier present).
- **After**: same file with `set_option autoImplicit false` → `✔ Built Proofs.Erdos1066Problem`, 0 errors, 0 sorries.
- Gallery data pipeline (`pnpm build` enrichment + search-index checks) processes the updated meta.json without error.

Per the Axiom Integrity Policy, status stays `axiomatized` (2 stated axioms) — no premature badge-up to `verified`.

Part of #39077.