### PR TITLE
Fix: repair never-compiled Erdos1015Problem (false positive + autoImplicit guard) — batch 13 of #39077

### DIFF
--- a/proofs/Proofs/Erdos1015Problem.lean
+++ b/proofs/Proofs/Erdos1015Problem.lean
@@ -40,6 +40,8 @@
 
 import Mathlib
 
+set_option autoImplicit false
+
 open Finset
 
 /-


### PR DESCRIPTION
## Summary

Batch 13 of the #39077 proof-repair follow-on. Repairs the `Erdos1015Problem` entry from the 28 never-compiled list.

**Finding: this entry was a false positive in the #39061 audit.** The audit claimed the file was autoImplicit-masked and would fail under `autoImplicit false` with `unknownIdentifier 'n'`. In fact `n` is properly declared via `variable {n : ℕ}` at the top of the file, and it compiles clean under Lean v4.31.0 **even with** `set_option autoImplicit false`, with 0 sorries.

## Changes

- **`proofs/Proofs/Erdos1015Problem.lean`**: add `set_option autoImplicit false` guard so the file cannot silently reintroduce masked free variables (matches the batch repair pattern used elsewhere in #39077).
- **`src/data/proofs/erdos-1015/meta.json`**: correct the `assumptions` field — remove the now-false "NOT machine-verified / fails with unknownIdentifier 'n'" retraction and document the verified state. `status`/`badge` were already correctly `axiomatized`/`axiom` (2 axioms `ramseyNumber`, `burr_erdos_spencer`); counts (2 axioms, 2 theorems, 10 defs) already match the source, unchanged.

## Evidence

- **After**: `./proofs/scripts/docker-build.sh Proofs.Erdos1015Problem` with `set_option autoImplicit false` → `✔ Built Proofs.Erdos1015Problem`, 0 errors, 0 sorries.

Per the Axiom Integrity Policy, status stays `axiomatized` (2 stated axioms) — no premature badge-up.

Part of #39077.