### PR TITLE
Fix: repair never-compiled Erdos713Problem (false positive + autoImplicit guard) — batch 14 of #39077

### DIFF
--- a/proofs/Proofs/Erdos713Problem.lean
+++ b/proofs/Proofs/Erdos713Problem.lean
@@ -36,6 +36,8 @@ import Mathlib.Analysis.Asymptotics.Defs
 import Mathlib.Analysis.SpecialFunctions.Pow.Real
 import Mathlib.Data.Rat.Defs
 
+set_option autoImplicit false
+
 open SimpleGraph Asymptotics
 
 namespace Erdos713


### PR DESCRIPTION
## Summary

Batch 14 of the #39077 proof-repair follow-on. Repairs the `Erdos713Problem` entry from the 28 never-compiled list.

**Finding: this entry was a false positive in the #39061 audit.** The audit claimed the file was autoImplicit-masked and would fail under `autoImplicit false` with `unknownIdentifier 'n'`. In fact the file has no undefined `n` — its type parameter is `variable {V : Type*}` — and it compiles clean under Lean v4.31.0 **even with** `set_option autoImplicit false`, with 0 sorries (only unused-variable lint warnings).

## Changes

- **`proofs/Proofs/Erdos713Problem.lean`**: add `set_option autoImplicit false` guard.
- **`src/data/proofs/erdos-713/meta.json`**: correct the `assumptions` field — remove the now-false "NOT machine-verified / fails with unknownIdentifier 'n'" retraction and document the verified state. `status`/`badge` already correctly `axiomatized`/`axiom` (2 axioms `extremalNumber`, `erdos_simonovits_counterexample`); counts (2 axioms, 2 theorems, 8 defs) already match the source, unchanged.

## Evidence

- **After**: `./proofs/scripts/docker-build.sh Proofs.Erdos713Problem` with `set_option autoImplicit false` → `✔ Built Proofs.Erdos713Problem`, 0 errors, 0 sorries.

Per the Axiom Integrity Policy, status stays `axiomatized` (2 stated axioms).

Part of #39077.