### PR TITLE
Fix: repair never-compiled Erdos423Problem (false positive + native_decide disclosure) — batch 15 of #39077

### DIFF
--- a/proofs/Proofs/Erdos423Problem.lean
+++ b/proofs/Proofs/Erdos423Problem.lean
@@ -26,6 +26,8 @@ import Mathlib.Data.List.Range
 import Mathlib.Order.Filter.Basic
 import Mathlib.Tactic
 
+set_option autoImplicit false
+
 open Nat Finset
 
 namespace Erdos423


### PR DESCRIPTION
## Summary

Batch 15 of the #39077 proof-repair follow-on. Repairs the `Erdos423Problem` entry from the 28 never-compiled list.

**Finding: this entry was a false positive in the #39061 audit.** The audit claimed `unknownIdentifier 'n'` under `autoImplicit false`. In fact every `n` in the file is a bound match/pattern variable; it compiles clean under Lean v4.31.0 **even with** `set_option autoImplicit false`, 0 sorries.

## Changes

- **`proofs/Proofs/Erdos423Problem.lean`**: add `set_option autoImplicit false` guard.
- **`src/data/proofs/erdos-423/meta.json`**:
  - Correct the `assumptions` field — remove the now-false "NOT machine-verified" retraction; document the verified state.
  - **Axiom Integrity Policy / `native_decide`**: this entry uses `native_decide` (17×) to verify substantive concrete facts (OEIS A005243 values `consSeq 0..7` and consecutive-sum witnesses), so it depends on `Lean.ofReduceBool`. Disclosed in `assumptions` and counted: `meta.axiomCount` 3 → 4 (3 literal `axiom` declarations + `Lean.ofReduceBool`). `leanFile.axiomCount` stays 3 (literal declarations only), per policy. `status`/`badge` already correctly `axiomatized`/`axiom`.

## Evidence

- **After**: `./proofs/scripts/docker-build.sh Proofs.Erdos423Problem` with `set_option autoImplicit false` → `✔ Built Proofs.Erdos423Problem`, 0 errors, 0 sorries.

Part of #39077.