### PR TITLE
Fix: repair never-compiled Erdos476Problem (Erdős-Heilbronn) — batch 17 of #39077

### DIFF
--- a/proofs/Proofs/Erdos476Problem.lean
+++ b/proofs/Proofs/Erdos476Problem.lean
@@ -33,7 +33,7 @@ import Mathlib.Data.ZMod.Basic
 import Mathlib.Data.Finset.Card
 import Mathlib.Algebra.BigOperators.Group.Finset.Basic
 
-set_option autoImplicit true
+set_option autoImplicit false
 
 open Finset BigOperators
 
@@ -53,19 +53,14 @@ This excludes the "diagonal" sums 2a.
 The set of all sums a + b where a and b are distinct elements of A.
 -/
 def restrictedSumset (A : Finset (ZMod p)) : Finset (ZMod p) :=
-  (A.product A).filter (fun ab => ab.1 ≠ ab.2) |>.image (fun ab => ab.1 + ab.2)
-
-/--
-Notation for restricted sumset.
--/
-notation:65 A " +̂ " B => restrictedSumset _ A
+  (A ×ˢ A).filter (fun ab => ab.1 ≠ ab.2) |>.image (fun ab => ab.1 + ab.2)
 
 /--
 **Ordinary Sumset** (A + A):
 The set of all sums a + b (including a = b).
 -/
 def sumset (A : Finset (ZMod p)) : Finset (ZMod p) :=
-  (A.product A).image (fun ab => ab.1 + ab.2)
+  (A ×ˢ A).image (fun ab => ab.1 + ab.2)
 
 /-
 ## Part II: Basic Properties
@@ -169,11 +164,10 @@ theorem AP_restrictedSumset (a d : ZMod p) (n : ℕ) (hd : d ≠ 0) (hn : n ≥ 
       (Finset.Ico 1 (2 * n - 2)).image (fun k : ℕ => 2 * a + (k : ZMod p) * d) := by
     ext x
     simp only [restrictedSumset, arithmeticProgression, Finset.mem_image,
-      Finset.mem_filter, Finset.mem_product, Finset.mem_Ico]
+      Finset.mem_filter, Finset.mem_product, Finset.mem_Ico, Finset.mem_range]
     constructor
     · rintro ⟨⟨ai, aj⟩, ⟨⟨⟨i, hi, rfl⟩, ⟨j, hj, rfl⟩⟩, hne⟩, rfl⟩
-      have hne_nat : i ≠ j := by
-        intro heq; apply hne; subst heq
+      have hne_nat : i ≠ j := fun heq => hne (by rw [heq])
       exact ⟨i + j, ⟨by omega, by omega⟩, by simp only [nsmul_eq_mul]; push_cast; ring⟩
     · rintro ⟨k, ⟨hk1, hk2⟩, rfl⟩
       have hk_lt_p : k < p := by omega
@@ -217,7 +211,7 @@ theorem AP_restrictedSumset (a d : ZMod p) (n : ℕ) (hd : d ≠ 0) (hn : n ≥ 
         Nat.mod_eq_of_lt (by omega : k1 < p),
         Nat.mod_eq_of_lt (by omega : k2 < p)] at hval
     exact hval
-  rw [Finset.card_image_of_injOn hinj, Finset.card_Ico]
+  rw [Finset.card_image_of_injOn hinj, Nat.card_Ico]
   omega
 
 /--
@@ -314,11 +308,11 @@ theorem card_two_case (A : Finset (ZMod p)) (h : A.card = 2) :
       Finset.mem_insert, Finset.mem_singleton]
     constructor
     · rintro ⟨⟨c, d⟩, ⟨⟨hc, hd⟩, hne⟩, rfl⟩
-      rcases hc with rfl | rfl <;> rcases hd with rfl | rfl
-      · exact absurd rfl hne
-      · rfl
-      · exact add_comm b a
-      · exact absurd rfl hne
+      rcases hc with hc | hc <;> rcases hd with hd | hd
+      · exact absurd (hc.trans hd.symm) hne
+      · rw [hc, hd]
+      · rw [hc, hd]; exact add_comm b a
+      · exact absurd (hc.trans hd.symm) hne
     · rintro rfl
       exact ⟨(a, b), ⟨⟨Or.inl rfl, Or.inr rfl⟩, hab⟩, rfl⟩
   simp [heq]
@@ -366,7 +360,7 @@ theorem erdos_476_summary (A : Finset (ZMod p)) (h : 2 ≤ A.card) :
     have hle : A.card ≤ p := by omega
     have hAP_card : (arithmeticProgression p a d A.card).card = A.card := by
       unfold arithmeticProgression
-      have hinj : Set.InjOn (fun i => a + i • d) ↑(Finset.range A.card) := by
+      have hinj : Set.InjOn (fun i : ℕ => a + i • d) ↑(Finset.range A.card) := by
         intro i hi j hj hij
         simp only [Finset.mem_coe, Finset.mem_range] at hi hj
         have h0 : (i : ℕ) • d = (j : ℕ) • d := add_left_cancel hij

--- a/src/data/proofs/erdos-476/meta.json
+++ b/src/data/proofs/erdos-476/meta.json
@@ -55,8 +55,8 @@
       "erdos_476_summary theorem: combines main result with tightness (fully proved)"
     ],
     "axiomCount": 1,
-    "lineCount": 384,
-    "assumptions": "AUDIT (issue #39061): NOT machine-verified. This entry never validly compiled. Even under Lean v4.26 the proof only 'passed' because the old `autoImplicit true` default silently bound the undefined identifier `B` as a free implicit variable, rendering the stated theorem vacuously general; under v4.31 (autoImplicit off by default) the file fails with `unknownIdentifier 'B'` and typically additional genuine proof errors. The verification claims below are therefore retracted pending a Lean-source repair (Class A). ORIGINAL METADATA: 1 axiom: erdos_heilbronn_bound (the Erdős-Heilbronn bound). All other results (AP_restrictedSumset, AP_achieves_bound, card_two_case, etc.) are fully proved theorems. 0 sorries.",
+    "lineCount": 380,
+    "assumptions": "Repaired (issue #39077): machine-checked on Lean v4.31 (autoImplicit off), 0 sorries. The earlier non-compilation was caused by a broken unused `+̂` notation (which declared an identifier `B` its expansion dropped), the two sumset definitions using `A.product A` instead of `A ×ˢ A` (so the `mem_product` simp lemma never fired, breaking every membership `rcases`), a renamed lemma (`Finset.card_Ico` → `Nat.card_Ico`), a `simp` set missing `Finset.mem_range` (leaving `omega` unable to see the range bounds), a `subst`-orientation failure in `card_two_case`, and an unannotated `fun i => …` whose scalar type was ambiguous. Status remains axiomatized: 1 stated axiom, erdos_heilbronn_bound (the Erdős-Heilbronn lower bound |A +̂ A| ≥ min(2|A|−3, p), the deep da Silva-Hamidoune result). All supporting results (AP_restrictedSumset, AP_achieves_bound, card_two_case, etc.) are now fully proved theorems.",
     "theoremCount": 10,
     "definitionCount": 4,
     "additionalFiles": [
@@ -185,7 +185,7 @@
       "BigOperators"
     ],
     "namespace": "Erdos476",
-    "lineCount": 384,
+    "lineCount": 380,
     "axiomCount": 1,
     "theoremCount": 10,
     "definitionCount": 4,


### PR DESCRIPTION
## Summary

Repairs `Proofs/Erdos476Problem.lean` (`erdos-476`, the Erdős-Heilbronn conjecture), one of the 28 never-compiled Class A entries tracked in #39077. This file **never compiled** — the flagged `autoImplicit`-masked identifier (`B`) was only the first of several genuine defects.

## Root causes (all fixed)

1. **Broken unused `+̂` notation** — `notation:65 A " +̂ " B => restrictedSumset _ A` declared `B` but its expansion dropped it (`Unknown identifier B`). The notation was unused in the file; removed it.
2. **`A.product A` instead of `A ×ˢ A`** in `restrictedSumset`/`sumset` — Mathlib's `Finset.mem_product` simp lemma is keyed on `×ˢ` (`SProd.sprod`), so it never fired against `Finset.product`, leaving every membership as a raw `Quot.lift` that `rcases` couldn't destructure (lines 81, 174, 316) and blocking the reverse `⟨…⟩` constructions (183, 193, 323).
3. **`Finset.card_Ico`** — renamed upstream; the ℕ lemma is `Nat.card_Ico`.
4. **`simp` set missing `Finset.mem_range`** in the `hset` proof — `omega` couldn't see the `i ∈ range n` bounds; added it, and restored the `i ≠ j` fact the diagonal-exclusion bounds require.
5. **`subst`-orientation failure** in `card_two_case` — `rcases … with rfl` picked an unsubstitutable orientation; rewrote the four-way case split to use `rw`/`.trans` instead of `subst`.
6. **Unannotated `fun i => a + i • d`** in `erdos_476_summary` — under `autoImplicit off` the scalar type was ambiguous (`Set ℕ` domain vs. `ZMod p` smul); annotated `fun i : ℕ`.

Also flipped `set_option autoImplicit true` → `false` so nothing is silently auto-bound; the build confirmed no other identifiers were being masked.

### Evidence

Before: `build failed` with `Unknown identifier B`, multiple `rcases`/`subst`/`⟨…⟩` failures, `Unknown constant Finset.card_Ico`, and a type mismatch.

After:
```
⚠ [1889/1889] Built Proofs.Erdos476Problem (1.0s)
=== Build succeeded ===
```
(`⚠` = benign unused-hypothesis/simp-arg warnings only.) 0 sorries. Verified via `./proofs/scripts/docker-build.sh Proofs.Erdos476Problem`.

## Metadata

`erdos-476/meta.json` stays **`axiomatized` / `axiom`** — the file carries exactly 1 `axiom` (`erdos_heilbronn_bound`, the deep da Silva-Hamidoune lower bound), so `axiomCount: 1` is already correct and it does **not** qualify for a `verified` badge. All *supporting* lemmas (`AP_restrictedSumset`, `AP_achieves_bound`, `card_two_case`, `card_three_lower_bound`, `erdos_476_summary`, …) are now genuinely proved. Refreshed the stale `assumptions` audit note to reflect the green v4.31 build and corrected `lineCount` 384→380.

Partial progress on #39077 (batch 17). Does not close the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)