### PR TITLE
Gallery integrity: correct axiom/sorry counts for erdos-39 and erdos-922

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -13158,13 +13158,13 @@
     },
     "erdos-39": {
       "agentId": "auditor-2026-05-02-0128",
-      "auditCount": 5,
+      "auditCount": 6,
       "issues": [
         "phantom AKS/Ruzsa axiom claims in proofStrategy step 3 + originalContributions[2] (only erdos_sidon_upper_bound is an axiom; AKS/Ruzsa are docstrings on lines 90-98)",
         "section line drift: [3] 57-73 should extend to 86; [4] startLine 74 should be 88; [6] 134-149 misses line 141 marker and theorem at 165; [7] title 'Verified Examples' should be 'Verified Facts' (Lean line 168), startLine 170 should be 168"
       ],
-      "lastAudited": "2026-05-29T07:21:57Z",
-      "result": "clean",
+      "lastAudited": "2026-07-19T18:56:28Z",
+      "result": "issues-fixed",
       "issueRefs": [
         14434
       ]
@@ -17420,9 +17420,9 @@
     },
     "erdos-922": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-05-16T00:41:09Z",
-      "result": "clean"
+      "auditCount": 5,
+      "lastAudited": "2026-07-19T18:55:14Z",
+      "result": "issues-fixed"
     },
     "erdos-923": {
       "agentId": "auditor-cycle-20-batch",
@@ -29832,6 +29832,12 @@
     "erdos-220-incomplete-01-oq-01": {
       "auditCount": 1,
       "lastAudited": "2026-07-13T04:23:28Z",
+      "result": "clean",
+      "issues": []
+    },
+    "cevas-theorem-oq-01-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-19T18:57:17Z",
       "result": "clean",
       "issues": []
     }

--- a/src/data/proofs/erdos-39/meta.json
+++ b/src/data/proofs/erdos-39/meta.json
@@ -47,7 +47,7 @@
       "Documentation of known constructions: greedy (N^{1/3}), AKS ((N log N)^{1/3}), Ruzsa (N^{sqrt(2)-1})",
       "Verified computational facts about square roots establishing the gap"
     ],
-    "axiomCount": 1,
+    "axiomCount": 2,
     "lineCount": 186,
     "prerequisites": [
       "Sidon sets (B₂ sequences) and pairwise distinct sums",
@@ -55,7 +55,7 @@
       "Probabilistic method in combinatorics",
       "Basic analytic number theory (square root barriers)"
     ],
-    "assumptions": "1 axiom: erdos_sidon_upper_bound. 0 sorries.",
+    "assumptions": "2 axioms: erdos_sidon_upper_bound, sidon_counting_upper_bound. 0 sorries.",
     "theoremCount": 6,
     "definitionCount": 3
   },
@@ -224,7 +224,7 @@
     ],
     "namespace": "Erdos39",
     "lineCount": 186,
-    "axiomCount": 1,
+    "axiomCount": 2,
     "theoremCount": 6,
     "definitionCount": 3,
     "path": "Proofs/Erdos39Problem.lean",

--- a/src/data/proofs/erdos-922/meta.json
+++ b/src/data/proofs/erdos-922/meta.json
@@ -17,13 +17,13 @@
       "folkman"
     ],
     "badge": "axiom",
-    "sorries": 4,
+    "sorries": 3,
     "erdosNumber": 922,
     "erdosUrl": "https://erdosproblems.com/922",
     "erdosProblemStatus": "solved",
     "axiomCount": 2,
     "lineCount": 220,
-    "assumptions": "2 axioms: folkman_theorem, folkman_bound_tight. 4 sorries.",
+    "assumptions": "2 axioms: folkman_theorem, folkman_bound_tight. 3 sorries.",
     "mathlib_version": "4.31.0",
     "theoremCount": 6,
     "definitionCount": 9,
@@ -157,7 +157,7 @@
     "theoremCount": 6,
     "definitionCount": 9,
     "path": "Proofs/Erdos922Problem.lean",
-    "sorries": 4,
+    "sorries": 3,
     "additionalFiles": [
       "Proofs/Erdos922Aristotle.lean"
     ]
@@ -179,5 +179,5 @@
       "description": "Related Erdős problem sharing themes: chromatic-number, graph-theory"
     }
   ],
-  "sorries": 4
+  "sorries": 3
 }


### PR DESCRIPTION
## Integrity fixes

Two metadata mismatches found during gallery integrity audit; reconciled `meta.json` against the Lean sources. No math/source changed.

### erdos-922 — sorry overcount
- **meta claimed**: 4 sorries
- **`Erdos922Problem.lean` shows**: 3 sorries (lines 99, 104, 161)
- **Fix**: set `meta.sorries`, `leanFile.sorries`, top-level `sorries`, and `assumptions` to 3. Axioms (2), `status: axiomatized`, badge `axiom` already correct (Tier C — core `folkman_theorem` is an axiom).

### erdos-39 — axiom undercount
- **meta claimed**: 1 axiom (`erdos_sidon_upper_bound`)
- **`Erdos39Problem.lean` shows**: 2 axioms — `erdos_sidon_upper_bound` (line 64) and `sidon_counting_upper_bound` (line 74, used by `no_sqrt_growth`)
- **Fix**: set `axiomCount` (meta + leanFile) to 2 and list both axioms in `assumptions`. Undercounting axioms understates the assumptions.

Also refreshes `audit-tracker.json` with the audit results.

---
Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)