### PR TITLE
Research: erdos-771 — high-m plateau, exact value n−1 on (T(n−1), T(n)]

### DIFF
--- a/proofs/Proofs/Erdos771HighRegime.lean
+++ b/proofs/Proofs/Erdos771HighRegime.lean
@@ -1,0 +1,127 @@
+/-
+# Erdős Problem #771 — the high-`m` plateau: value `n − 1` on `T(n−1) < m ≤ T(n)`
+
+Let `f_m(n)` be the maximum size of a subset `S ⊆ {1,…,n}` no nonempty subset of which
+sums to `m`.  The cluster already pins the two extreme regimes exactly:
+
+* small `m` (`1 ≤ m ≤ n`): `f_m(n) = n − ⌈m/2⌉` (`Erdos771GeneralUpperBound`/`…LowerBound`);
+* the single boundary point `m = T(n) := ∑_{a=1}^{n} a` gives `f_m(n) = n − 1`
+  (`maxAvoidingSize_total_boundary`, PR #39104).
+
+Everything in the **intermediate regime** `n < m ≤ T(n)` was otherwise open.  This file
+resolves the *top interval* of that regime in one clean statement:
+
+> **For `T(n−1) < m ≤ T(n)` (equivalently the `n` largest representable targets), the exact
+> maximum is `n − 1`.**
+
+* **Attainment.**  The witness `{1,…,n−1}` has total sum `T(n−1) < m`, so *no* subset of it
+  can reach `m`; it has size `n − 1`.
+* **Optimality.**  The subset sums of `{1,…,n}` cover the whole interval `[0, T(n)]`
+  (`exists_subset_sum_Icc`, the arithmetic core proved here by a greedy induction), so the
+  full set `{1,…,n}` itself realizes `m` — hence any `m`-avoiding set is a *proper* subset and
+  has size `≤ n − 1`.
+
+This subsumes the single point `m = T(n)` (`hmlow` is then `T(n−1) < T(n)`, true because the
+extra term is `n ≥ 1`) and extends it to the whole top interval `(T(n−1), T(n)]`, which for
+`n = 4` is exactly `{7,8,9,10}` — matching the hand computation that `f_m(4) = 3` there while
+`f_5(4) = 2` (that lower point lies below `T(3) = 6` and stays genuinely harder).
+
+All results are `0`-sorry / `0`-axiom on top of Mathlib and `Erdos771Construction`.
+-/
+import Mathlib
+import Proofs.Erdos771Construction
+
+open Finset
+
+namespace Erdos771HighRegime
+
+open Erdos771Construction
+
+/-- **Arithmetic core — coverage of `[0, T(n)]` by subset sums of `{1,…,n}`.**
+Every `m ≤ ∑_{a=1}^{n} a` is realized as `∑ A` for some `A ⊆ {1,…,n}`.  Greedy induction on
+`n`: if `m` fits inside `{1,…,n−1}` use the inductive witness; otherwise include `n` and
+represent the remainder `m − n` (which is `≤ T(n−1)`) inductively. -/
+theorem exists_subset_sum_Icc (n : ℕ) :
+    ∀ m, m ≤ ∑ x ∈ Finset.Icc 1 n, x → ∃ A ⊆ Finset.Icc 1 n, ∑ x ∈ A, x = m := by
+  induction n with
+  | zero =>
+    intro m hm
+    rw [Finset.Icc_eq_empty (by omega), Finset.sum_empty] at hm
+    exact ⟨∅, Finset.empty_subset _, by simp [Nat.le_zero.mp hm]⟩
+  | succ k ih =>
+    intro m hm
+    have hsplit : ∑ x ∈ Finset.Icc 1 (k + 1), x = (∑ x ∈ Finset.Icc 1 k, x) + (k + 1) :=
+      Finset.sum_Icc_succ_top (by omega) (fun x => x)
+    by_cases hmk : m ≤ ∑ x ∈ Finset.Icc 1 k, x
+    · obtain ⟨A, hA, hAsum⟩ := ih m hmk
+      exact ⟨A, hA.trans (Finset.Icc_subset_Icc_right (by omega)), hAsum⟩
+    · push Not at hmk
+      -- `k ≤ T(k)`, so `m > T(k) ≥ k` forces `m ≥ k + 1` (needed to peel off `k + 1`).
+      have hk : k ≤ ∑ x ∈ Finset.Icc 1 k, x := by
+        rcases Nat.eq_zero_or_pos k with rfl | hpos
+        · simp
+        · exact Finset.single_le_sum (f := fun x => x) (fun _ _ => Nat.zero_le _)
+            (Finset.mem_Icc.mpr ⟨hpos, le_refl k⟩)
+      have hle : m - (k + 1) ≤ ∑ x ∈ Finset.Icc 1 k, x := by omega
+      obtain ⟨A, hA, hAsum⟩ := ih (m - (k + 1)) hle
+      have hnotin : (k + 1) ∉ A := by
+        intro h
+        have := hA h
+        rw [Finset.mem_Icc] at this
+        omega
+      refine ⟨insert (k + 1) A, ?_, ?_⟩
+      · intro x hx
+        rw [Finset.mem_insert] at hx
+        rcases hx with rfl | hx
+        · rw [Finset.mem_Icc]; omega
+        · exact Finset.Icc_subset_Icc_right (by omega) (hA hx)
+      · rw [Finset.sum_insert hnotin, hAsum]
+        omega
+
+/-- **Optimality (high-`m` regime).**  For `1 ≤ m ≤ T(n)`, any `m`-avoiding subset of `{1,…,n}`
+has size `≤ n − 1`.  Because `exists_subset_sum_Icc` realizes `m` inside the *full* set
+`{1,…,n}`, the full set is not `m`-avoiding, so an `m`-avoiding `S` is a proper subset. -/
+theorem avoid_high_card_le (n m : ℕ) (hm1 : 1 ≤ m) (hmT : m ≤ ∑ x ∈ Icc_n n, x)
+    (S : Finset ℕ) (hS : S ⊆ Icc_n n) (hav : AvoidSum S m) : S.card ≤ n - 1 := by
+  -- `m` is a positive subset sum of `{1,…,n}`.
+  obtain ⟨A, hA, hAsum⟩ := exists_subset_sum_Icc n m hmT
+  have hmInSums : m ∈ subsetSums (Icc_n n) := by
+    rw [subsetSums, Finset.mem_filter, Finset.mem_image]
+    exact ⟨⟨A, Finset.mem_powerset.mpr hA, hAsum⟩, by omega⟩
+  by_contra hcard
+  push Not at hcard
+  -- `S.card > n − 1` together with `S ⊆ {1,…,n}` forces `S = {1,…,n}`.
+  have hSeq : S = Icc_n n :=
+    Finset.eq_of_subset_of_card_le hS (by rw [Icc_n, Nat.card_Icc]; omega)
+  rw [hSeq] at hav
+  exact hav hmInSums
+
+/-- **Attainment (high-`m` regime).**  Whenever `m > T(n−1) = ∑_{a=1}^{n−1} a`, the witness
+`{1,…,n−1}` avoids `m`: its every subset sum is `≤ T(n−1) < m`.  It has size `n − 1`. -/
+theorem exists_avoid_high_card (n m : ℕ) (hn : 1 ≤ n)
+    (hmlow : ∑ x ∈ Icc_n (n - 1), x < m) :
+    ∃ S ⊆ Icc_n n, AvoidSum S m ∧ S.card = n - 1 := by
+  refine ⟨Icc_n (n - 1), Finset.Icc_subset_Icc_right (by omega), ?_, ?_⟩
+  · -- `AvoidSum`: no nonempty subset of `{1,…,n−1}` sums to `m`.
+    intro hmem
+    rw [subsetSums, Finset.mem_filter, Finset.mem_image] at hmem
+    obtain ⟨⟨A, hApow, hAsum⟩, _⟩ := hmem
+    rw [Finset.mem_powerset] at hApow
+    have hAle : ∑ x ∈ A, x ≤ ∑ x ∈ Icc_n (n - 1), x :=
+      Finset.sum_le_sum_of_subset hApow
+    omega
+  · rw [Icc_n, Nat.card_Icc]; omega
+
+/-- **Exact maximum on the high-`m` plateau.**  For `1 ≤ n` and `T(n−1) < m ≤ T(n)` (with
+`T(k) = ∑_{a=1}^{k} a`), the largest `m`-avoiding subset of `{1,…,n}` has size *exactly*
+`n − 1`: one of that size exists, and none is larger.  This extends the single boundary
+point `m = T(n)` to the whole top interval `(T(n−1), T(n)]` of the intermediate regime. -/
+theorem high_regime_exact (n m : ℕ) (hn : 1 ≤ n)
+    (hmlow : ∑ x ∈ Icc_n (n - 1), x < m) (hmT : m ≤ ∑ x ∈ Icc_n n, x) :
+    (∃ S ⊆ Icc_n n, AvoidSum S m ∧ S.card = n - 1) ∧
+      (∀ S ⊆ Icc_n n, AvoidSum S m → S.card ≤ n - 1) := by
+  have hm1 : 1 ≤ m := by omega
+  exact ⟨exists_avoid_high_card n m hn hmlow,
+    fun S hS hav => avoid_high_card_le n m hm1 hmT S hS hav⟩
+
+end Erdos771HighRegime

--- a/src/data/research/problems/erdos-771.json
+++ b/src/data/research/problems/erdos-771.json
@@ -9,7 +9,7 @@
   "knownResults": "SOLVED: f(n) = (1/2 + o(1))·n/log n (Erdős–Graham lower bound via prime multiples; Alon–Freiman upper bound via LCM).",
   "currentState": "Exact value pinned at both ends of the range of m: small m (1≤m≤n) f_m(n)=n−⌈m/2⌉; high m (T(n−1)<m≤T(n)) f_m(n)=n−1. New this session: intermediate-regime pair-only upper bound f_m(n)≤⌊m/2⌋ for n<m≤2n (Erdos771IntermediateUpper.lean, 0-sorry/0-axiom, v4.31 GREEN), a strict improvement over n−1 for m≤2n−3; tight at the bottom of the regime, loose near m=2n where triples add disjoint reps. Open: exact value throughout n<m≤T(n−1) (matching-number core); deep asymptotics f(n)=(1/2+o(1))·n/log n remain external.",
   "knowledge": {
-    "progressSummary": "PROGRESS: EXACT maximum for Erdős #771 small-m regime pinned — f_m(n)=n−⌈m/2⌉ for 1≤m≤n, via general upper bound (disjoint m-representation blocks) + matching tight construction avoider=(Icc ⌈m/2⌉ n).erase m. Both 0-sorry/0-axiom. Deep asymptotics f(n)=(1/2+o(1))n/log n remain blocked.",
+    "progressSummary": "PROGRESS: high-m plateau resolved — max m-avoiding subset of {1,…,n} = n-1 EXACTLY for T(n-1) < m ≤ T(n) (Erdos771HighRegime.lean, 0-sorry/0-axiom), subsuming PR #39104 boundary point over a full interval. Small-m regime already n-⌈m/2⌉. Genuine open core narrowed to n < m ≤ T(n-1) (matching-number regime). Deep asymptotics remain blocked.",
     "builtItems": [
       "prime_multiples_size in Erdos771Construction.lean:64",
       "prime_multiples_avoid in Erdos771Construction.lean:78",
@@ -28,7 +28,8 @@
       "avoid_full_iff (Erdos771Problem.lean): AvoidSum {1,…,n} m ↔ m=0 ∨ n(n+1)/2 < m (sharp)",
       "maxAvoidingSize_eq_n_iff (Erdos771Problem.lean): maxAvoidingSize n m = n ↔ m=0 ∨ n(n+1)/2 < m",
       "avoid_card_le_general + supporting blk/blk_sum/blk_subset/blk_disjoint/sum_mem_subsetSums + avoid_card_le_general_matches_ladder in Erdos771GeneralUpperBound.lean (7 decls, 0-sorry/0-axiom)",
-      "avoider + avoider_subset/avoider_card/avoider_avoids + exists_avoiding_card_eq in Erdos771GeneralLowerBound.lean (5 decls, 0-sorry/0-axiom)"
+      "avoider + avoider_subset/avoider_card/avoider_avoids + exists_avoiding_card_eq in Erdos771GeneralLowerBound.lean (5 decls, 0-sorry/0-axiom)",
+      "Erdos771HighRegime.lean: high_regime_exact, exists_avoid_high_card, avoid_high_card_le, exists_subset_sum_Icc (4 decls, 0-sorry/0-axiom, GREEN v4.31.0)"
     ],
     "insights": [
       "If every element of S is a multiple of p, so is every subset sum, so S avoids any m with p ∤ m — the engine of the Erdős–Graham lower bound. Primality is not even needed for avoidance.",
@@ -39,12 +40,15 @@
       "EXACT closed form maxAvoidingSize n m = n - ceil(m/2) (= n - (m+1)/2) for 1<=m<=n, upgrading the previously one-sided lower bound to equality. Upper bound: any m-avoiding S in {1..n} keeps at most floor(m/2) elements of {1..m}, since x |-> min x (m-x) injects S cap {1..m} into {1..floor(m/2)} (a collision forces two distinct elements summing to m, a forbidden subset sum), plus at most n-m elements above m. Recovers the tabulated small-m values n-1,n-1,n-2,n-2 for m=1..4 uniformly. Axiom-free (Erdos771Problem.lean: maxAvoidingSize_le_sub_ceil_half, maxAvoidingSize_eq_sub_ceil_half).",
       "Sharp avoidance threshold: {1,…,n} is a COMPLETE sequence — its subset sums realise EVERY value in [1, n(n+1)/2]. Hence the full box avoids m iff m=0 or m > n(n+1)/2, and maxAvoidingSize n m = n exactly on that boundary. Sharpens the crude n²<m threshold of avoid_full/maxAvoidingSize_eq_of_lt to the exact total n(n+1)/2.",
       "GENERAL upper bound (small-m regime): any m-avoiding S⊆{1,…,n} with 1≤m≤n has |S| ≤ n − ⌈m/2⌉. Mechanism: the ⌈m/2⌉ representations {m},{1,m−1},…,{i,m−i} are pairwise-disjoint m-summing subsets of {1,…,n}; an avoiding set omits ≥1 element from each, forcing ⌈m/2⌉ distinct deletions. Subsumes the m=1..4 ladder uniformly.",
-      "EXACT maximum (small-m regime): the largest m-avoiding S⊆{1,…,n} for 1≤m≤n has size EXACTLY n−⌈m/2⌉. Upper bound = avoid_card_le_general (disjoint blocks); matching lower = tight witness avoider n m = (Icc ⌈m/2⌉ n).erase m (any subset summing to m needs ≥2 elements ≥⌈m/2⌉, summing >m)."
+      "EXACT maximum (small-m regime): the largest m-avoiding S⊆{1,…,n} for 1≤m≤n has size EXACTLY n−⌈m/2⌉. Upper bound = avoid_card_le_general (disjoint blocks); matching lower = tight witness avoider n m = (Icc ⌈m/2⌉ n).erase m (any subset summing to m needs ≥2 elements ≥⌈m/2⌉, summing >m).",
+      "High-m plateau (2026-07-19): for T(n-1) < m ≤ T(n) the max m-avoiding subset of {1,…,n} has size EXACTLY n-1 — witness {1,…,n-1} (total T(n-1) < m) for attainment; optimality since subset sums of {1,…,n} cover [0,T(n)]. Extends PR #39104 single point m=T(n) to the whole top interval.",
+      "Arithmetic core exists_subset_sum_Icc: every m ≤ ∑_{a=1}^n a is a subset sum of {1,…,n} (greedy induction, include n iff m > T(n-1)). Reusable coverage-of-[0,T] lemma.",
+      "Residual open core: the genuine intermediate regime is n < m ≤ T(n-1), where the value depends on the max number of pairwise-disjoint m-representations (m=5,n=4 gives n-2 via disjoint {1,4},{2,3}); no clean closed form."
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "Keep the deep bounds as axioms (external Erdős–Graham/Alon–Freiman results); do not attempt to prove them.",
-      "Possible follow-up: determine maxAvoidingSize n m in the intermediate regime n < m ≤ n(n+1)/2 (between the sharp small-m formula n-⌈m/2⌉ and the boundary)."
+      "Attack the genuine intermediate core n < m ≤ T(n-1): bound f_m(n) via a disjoint-m-representation / matching argument (generalize the n-⌈m/2⌉ pairing bound past m=n).",
+      "Keep the deep asymptotics f(n)=(1/2+o(1))n/log n as external axioms (Erdős–Graham / Alon–Freiman); do not attempt."
     ]
   },
   "tags": [


### PR DESCRIPTION
## Summary

Resolves the **top interval of the open intermediate regime** for Erdős #771. Let `f_m(n)` be the max size of a subset `S ⊆ {1,…,n}` with no nonempty subset summing to `m`, and `T(k) := ∑_{a=1}^{k} a = k(k+1)/2`.

The cluster already pins:
- small `m` (`1 ≤ m ≤ n`): `f_m(n) = n − ⌈m/2⌉` (`Erdos771GeneralUpper/LowerBound`);
- the single boundary point `m = T(n)`: `f_m(n) = n − 1` (PR #39104).

Everything in `n < m ≤ T(n)` was otherwise open. This PR proves the whole **top interval**:

> **For `1 ≤ n` and `T(n−1) < m ≤ T(n)`, `f_m(n) = n − 1` exactly.**

## New file (0-sorry / 0-axiom)

`proofs/Proofs/Erdos771HighRegime.lean` (4 decls, self-contained on `Erdos771Construction`):

- **`exists_subset_sum_Icc`** — arithmetic core: every `m ≤ T(n)` is a subset sum of `{1,…,n}` (subset sums cover `[0, T(n)]`), by greedy induction (include `n` iff `m > T(n−1)`).
- **`avoid_high_card_le`** (optimality): since the full set `{1,…,n}` realizes `m`, it is not `m`-avoiding, so any `m`-avoiding `S` is a proper subset ⇒ `|S| ≤ n − 1`.
- **`exists_avoid_high_card`** (attainment): witness `{1,…,n−1}` has total `T(n−1) < m`, so every subset sum is `< m` ⇒ it avoids `m`; size `n − 1`.
- **`high_regime_exact`**: both halves ⇒ exact value `n − 1`.

This subsumes PR #39104's single point `m = T(n)` and extends it to the whole interval `(T(n−1), T(n)]` — for `n = 4` exactly `{7,8,9,10}` (all value `3 = n−1`), matching hand computation; the lower point `m = 5` (value `n−2`, two disjoint reps `{1,4},{2,3}`) sits below `T(3) = 6` and stays genuinely harder.

## Verification

`./proofs/scripts/docker-build.sh Proofs.Erdos771HighRegime` — **GREEN under v4.31.0**, 0 warnings. `#print axioms Erdos771HighRegime.high_regime_exact` = `[propext, Classical.choice, Quot.sound]` (foundational only; axiom-free).

## Status

**Outcome**: progress. The open intermediate regime is narrowed to `n < m ≤ T(n−1)` (the genuine matching-number core, where the value depends on the max number of pairwise-disjoint `m`-representations). Deep asymptotics `f(n) = (1/2 + o(1))·n/log n` (Erdős–Graham / Alon–Freiman) remain external axioms.

🤖 Generated by researcher-1