### PR TITLE
fix(erdos-922): correct sorry count 4→3 to match Lean source

### DIFF
--- a/src/data/proofs/erdos-922/meta.json
+++ b/src/data/proofs/erdos-922/meta.json
@@ -17,13 +17,13 @@
       "folkman"
     ],
     "badge": "axiom",
-    "sorries": 4,
+    "sorries": 3,
     "erdosNumber": 922,
     "erdosUrl": "https://erdosproblems.com/922",
     "erdosProblemStatus": "solved",
     "axiomCount": 2,
     "lineCount": 220,
-    "assumptions": "2 axioms: folkman_theorem, folkman_bound_tight. 4 sorries.",
+    "assumptions": "2 axioms: folkman_theorem, folkman_bound_tight. 3 sorries.",
     "mathlib_version": "4.31.0",
     "theoremCount": 6,
     "definitionCount": 9,
@@ -157,7 +157,7 @@
     "theoremCount": 6,
     "definitionCount": 9,
     "path": "Proofs/Erdos922Problem.lean",
-    "sorries": 4,
+    "sorries": 3,
     "additionalFiles": [
       "Proofs/Erdos922Aristotle.lean"
     ]
@@ -179,5 +179,5 @@
       "description": "Related Erdős problem sharing themes: chromatic-number, graph-theory"
     }
   ],
-  "sorries": 4
+  "sorries": 3
 }


### PR DESCRIPTION
## Gallery Integrity Audit

**Proof**: erdos-922 (Folkman's Chromatic Number Bound)
**Problem**: meta.json overcounts sorries — claims 4, source has 3.

## Evidence

**meta.json claims**: `sorries: 4` (in `meta.sorries`, `assumptions` text, `leanFile.sorries`, and top-level `sorries`)
**Lean file shows**: `proofs/Proofs/Erdos922Problem.lean` has exactly 3 real `sorry` declarations — lines 99, 104, 161. `grep -c sorry` = 3; none are inside docstrings.

## Fix

Set all four `sorries` fields to 3 and update the `assumptions` string. Axiom count (2: `folkman_theorem`, `folkman_bound_tight`) is correct and unchanged; badge `axiom` / status `axiomatized` remain appropriate.

Note: an overcount is conservative (understates completeness) rather than an overclaim, so this is a LOW-severity accuracy correction, not an integrity risk.

---
Discovered during gallery integrity audit.