### PR TITLE
Fix: repair never-compiled Erdos608Problem (Class B) for v4.31 — batch of #39077

### DIFF
--- a/proofs/Proofs/Erdos608Problem.lean
+++ b/proofs/Proofs/Erdos608Problem.lean
@@ -117,23 +117,28 @@ theorem exact_answer :
 def IsOddCycle (G : SimpleGraph V) [DecidableRel G.Adj] (k : ℕ)
     (cycle : Fin (2*k+1) → V) : Prop :=
   (∀ i j, i ≠ j → cycle i ≠ cycle j) ∧
-  (∀ i : Fin (2*k+1), G.Adj (cycle i) (cycle ⟨(i.val + 1) % (2*k+1), by omega⟩))
+  (∀ i : Fin (2*k+1), G.Adj (cycle i) (cycle ⟨(i.val + 1) % (2*k+1), Nat.mod_lt _ (by omega)⟩))
 
 /-- Edges in any C_{2k+1}. -/
 noncomputable def edgesInOddCycle (G : SimpleGraph V) [DecidableRel G.Adj]
     (k : ℕ) : ℕ :=
   (G.edgeFinset.filter (fun e =>
     ∃ cycle : Fin (2*k+1) → V, IsOddCycle G k cycle ∧
-    ∃ i, e = s(cycle i, cycle ⟨(i.val + 1) % (2*k+1), by omega⟩))).card
+    ∃ i, e = s(cycle i, cycle ⟨(i.val + 1) % (2*k+1), Nat.mod_lt _ (by omega)⟩))).card
 
-/-- For k ≥ 3, the bound (2/9)n² IS correct. -/
+/-- For k ≥ 3, the bound (2/9)n² IS correct.
+
+    The informal statement "≥ (2/9)n² − O(1)·n" is encoded here by existentially
+    quantifying a constant `C` (independent of `n` and `G`) governing the lower-order
+    term, i.e. there is a `C` such that for all sufficiently large `n` every dense
+    graph has at least `2/9·n² − C·n` edges in some C_{2k+1}. -/
 theorem odd_cycle_bound_general (k : ℕ) (hk : k ≥ 3) :
-    ∀ᶠ n in Filter.atTop,
+    ∃ C : ℝ, ∀ᶠ n in Filter.atTop,
     ∀ (V : Type) [Fintype V] [DecidableEq V]
       (G : SimpleGraph V) [DecidableRel G.Adj],
     Fintype.card V = n →
     (G.edgeFinset.card : ℝ) > (n : ℝ)^2 / 4 →
-    (edgesInOddCycle G k : ℝ) ≥ 2/9 * (n : ℝ)^2 - O(1) * n := by
+    (edgesInOddCycle G k : ℝ) ≥ 2/9 * (n : ℝ)^2 - C * n := by
   sorry
 
 /- ## Part VII: Triangles -/


### PR DESCRIPTION
## Summary

Class B repair from #39077. \`Proofs/Erdos608Problem.lean\` (Erdős #608, edges in 5-cycles) never compiled — it had a parse error and unproved \`omega\` goals that autoImplicit had masked on the v4.26 baseline. This PR makes the module elaborate green on v4.31 (0 errors; only the pre-existing \`sorry\` warnings remain).

## Defects fixed

1. **Parse error (line 136)** — the theorem \`odd_cycle_bound_general\` stated the bound as `≥ 2/9·n² - O(1) * n`, where `O(1)` is informal big-O notation, not a Lean term (`unexpected token '('`). Re-encoded faithfully by existentially quantifying a constant `C : ℝ` (independent of `n`/`G`) for the lower-order term: `∃ C, ∀ᶠ n ..., ... ≥ 2/9·n² - C·n`. The theorem body remains `sorry`.

2. **Unproved \`omega\` goals (lines 120, 127)** — the \`Fin (2*k+1)\` constructions `⟨(i.val + 1) % (2*k+1), by omega⟩` failed because `omega` treats a **variable** modulus (`2*k+1`) as opaque. Replaced with `Nat.mod_lt _ (by omega)`, which discharges `(i.val+1) % (2*k+1) < 2*k+1` from `0 < 2*k+1`.

## Evidence

Before: `error: unexpected token '('` + `error: omega could not prove the goal` (×2) → `build failed` (exit 1).

After: `./proofs/scripts/docker-build.sh Proofs.Erdos608Problem` →
```
✖→✓ === Build succeeded ===
```
0 errors; 13 `declaration uses sorry` warnings (unchanged; matches `meta.json` `sorries: 13`).

## Metadata

No \`meta.json\` change needed — \`src/data/proofs/erdos-608/meta.json\` was already de-badged by #39067 (no \`verified\`/\`original\` claim; \`sorries: 13\`, \`axiomCount: 0\`, both still accurate). Badge restoration is out of scope: the file still has 13 substantive sorries, so it stays \`formalized\` per the Axiom Integrity Policy.

Part of #39077.