### PR TITLE
Research: erdos-1039-incomplete-01 — v4.31 integrity GREEN + meta reconciliation

### DIFF
--- a/proofs/Proofs/Erdos1039Problem.lean
+++ b/proofs/Proofs/Erdos1039Problem.lean
@@ -458,7 +458,7 @@ theorem inscribed_ball_subset {S : Set ℂ} {c : ℂ} {r : ℝ}
 theorem inscribed_radius_le {c z0 : ℂ} {r R : ℝ} (hr : 0 < r) (hR : 0 < R)
     (h : ∀ z : ℂ, ‖z - c‖ < r → ‖z - z0‖ < R) : r ≤ R := by
   by_contra hlt
-  push_neg at hlt
+  push Not at hlt
   obtain ⟨u, hu, hcu⟩ : ∃ u : ℂ, ‖u‖ = 1 ∧ (c - z0) = (‖c - z0‖ : ℝ) • u := by
     rcases eq_or_ne (c - z0) 0 with h0 | h0
     · exact ⟨1, norm_one, by rw [h0]; simp⟩
@@ -492,7 +492,7 @@ theorem sublevelSet_subset_ball (hf : 0 < f.degree) :
   simp only [sublevelSet, Set.mem_setOf_eq, UnitDiscPolynomial.eval] at hz
   rw [Metric.mem_ball, dist_zero_right]
   by_contra hcon
-  push_neg at hcon
+  push Not at hcon
   have hfac : ∀ i : Fin f.degree, (1 : ℝ) ≤ ‖z - f.roots i‖ := by
     intro i
     have htri : ‖z‖ ≤ ‖z - f.roots i‖ + ‖f.roots i‖ := by

--- a/research/problems/erdos-1039-incomplete-01/knowledge.md
+++ b/research/problems/erdos-1039-incomplete-01/knowledge.md
@@ -61,3 +61,30 @@ progress (full elaboration clean `[7743/7743]`; olean-write env-blocked → UNVE
 - ★INFRA: builds this session hit stochastic env olean-write crashes (SIGBUS-135 /
   SIGSEGV-139) and, on retry, shared-cache corruption (a Mathlib olean "invalid
   header"). Elaboration completes clean before the crash, so correctness is verifiable.
+
+## Session 2026-07-19 (researcher-1) — v4.31 integrity GREEN + meta reconciliation
+
+**Mode**: REVISIT (triage/maintenance). **Outcome**: integrity — the problem is SOLVED at the
+axiomatized level and stable; no new math (all 4 axioms are deep published results).
+
+### What I did
+- **v4.31 deprecation cleanup**: `Erdos1039Problem.lean` 2× `push_neg` → `push Not` (lines 461,
+  495). Companions (Aristotle / ProblemAristotle / Conformal) had none.
+- **Integrity build**: `docker-build.sh Proofs.Erdos1039Problem` — **GREEN under v4.31.0**
+  (4 axioms / 0 sorries preserved; only pre-existing unused-variable linter warnings).
+- **Gallery meta reconciliation** (`src/data/proofs/erdos-1039/meta.json`): stale counts from
+  file growth — `lineCount` 854→1101, `theoremCount` 24→43 in both `leanFile` and `meta` blocks.
+  `axiomCount` 4 / `definitionCount` 17 / `sorries` 0 were already correct.
+
+### Why no new theorem (assessment stands)
+The 4 remaining axioms — `benchmark_upper` (Erdős–Herzog–Piranian), `pommerenke_lower`
+(Pommerenke 1961), `klr_lower` + `klr_area_bound` (Krishnapur–Lundberg–Ramachandran 2025) —
+are all deep published results; formalizing any means reproducing the source paper. None is
+routine/Mathlib-reachable, so there is no axiom to discharge. The one genuine formalization
+target left (an `Expected[ρ]` functional proved `Θ(1/√n)`) needs a probability model over
+`UnitDiscPolynomial` — a multi-session build, not an incremental step.
+
+### Housekeeping still open (Mechanic scope, not done here)
+`Proofs/Stubs/Erdos1039Problem.lean` still holds the pre-#33815 state (3 sorries, the original
+5 axioms); it is NOT the presented proof (`proofRepoPath` is the main file) and adds no distinct
+assumptions. Deleting it is a Mechanic task (mass-deletion tripwire / out of researcher scope).

--- a/src/data/proofs/erdos-1039/meta.json
+++ b/src/data/proofs/erdos-1039/meta.json
@@ -23,7 +23,7 @@
     "erdosProblemStatus": "open",
     "relatedProblems": [],
     "axiomCount": 4,
-    "lineCount": 854,
+    "lineCount": 1101,
     "assumptions": "4 axioms, all genuine published research results the proof correctly leaves unformalized (not overclaimed): benchmark_upper (Erdos-Herzog-Piranian benchmark rho(z^n-1) <= pi/(2n)), pommerenke_lower (Pommerenke 1961, rho >= 1/(2en^2)), and klr_lower + klr_area_bound (Krishnapur-Lundberg-Ramachandran 2025, rho >> 1/(n*sqrt(log n))). Formalizing any of these would require reproducing the source papers, so they are stated as axioms. The three elementary-geometry lemmas (area_implies_disc_bound, degree_one_optimal, clustered_implies_large_disc) were completed in PR #33815 and the main file Proofs/Erdos1039Problem.lean has 0 sorries (543 lines). UPDATE: the former 5th axiom random_polynomial_expected was DEGENERATE — its intended Expected[rho] middle term was only a comment, so the Lean proposition collapsed to the trivially-true c1/sqrt(n) <= c2/sqrt(n); it has been converted to a proved theorem (witness c1=c2=1), removing a spurious entry from the axiom list (5 -> 4). The real Theta(1/sqrt n) expected-order claim needs an Expected functional and remains unformalized. The deprecated stub Proofs/Stubs/Erdos1039Problem.lean still holds the pre-#33815 state (3 sorries, the original 5 axioms) and is not the presented proof (proofRepoPath is the main file); it adds no distinct assumptions.",
     "mathlib_version": "4.31.0",
     "mathlibDependencies": [
@@ -60,7 +60,7 @@
       "random_polynomial_expected: now a proved theorem (degenerate as stated — c₁/√n ≤ c₂/√n, witness c₁=c₂=1); the genuine Θ(1/√n) expected-order claim needs an Expected functional and is unformalized",
       "sublevelSet_isBounded / rho_le_two / rho_mem_Ioc: assumption-free structural bounds on the geometry. The lemniscate sublevel set {z:|f(z)|<1} is bounded (it lies in B(0,2)), and every inscribed disc is therefore capped, giving the universal ceiling rho(f) ≤ 2 and hence rho(f) ∈ (0,2] for all positive-degree f. This frames the deep lower-bound axioms (Pommerenke, KLR), which sharpen the FLOOR of rho, with a matching elementary cap on its HEIGHT. Axiom-free ([propext, Classical.choice, Quot.sound])."
     ],
-    "theoremCount": 24,
+    "theoremCount": 43,
     "definitionCount": 17,
     "additionalFiles": [
       "Proofs/Erdos1039Aristotle.lean",
@@ -243,9 +243,9 @@
     ],
     "opens": [],
     "namespace": "Erdos1039",
-    "lineCount": 854,
+    "lineCount": 1101,
     "axiomCount": 4,
-    "theoremCount": 24,
+    "theoremCount": 43,
     "definitionCount": 17,
     "path": "Proofs/Erdos1039Problem.lean",
     "sorries": 0,

--- a/src/data/research/problems/erdos-1039-incomplete-01.json
+++ b/src/data/research/problems/erdos-1039-incomplete-01.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "SOLVED (37 decls, 4 deep published axioms, 0 sorry): established the O(2) rotation invariance of ρ — ρ depends only on the rotation orbit of the root configuration (rotate_rho), with negation as a special case.",
+    "progressSummary": "SOLVED/axiomatized (stable). 4 deep published axioms (EHP benchmark_upper, Pommerenke 1961 pommerenke_lower, KLR 2025 klr_lower + klr_area_bound) — reproducing any is paper-scale, not session work. 0 sorries, 43 theorems. This session (researcher-1 2026-07-19): v4.31 integrity build GREEN + 2 push_neg→push Not fixes + reconciled stale gallery meta counts. No new axioms dischargeable (all deep); the one open formalization target (Expected[rho] Theta(1/sqrt n) functional) is a multi-session probability-model build.",
     "builtItems": [
       "Proved area_implies_disc_bound, degree_one_optimal, clustered_implies_large_disc in Proofs/Erdos1039Problem.lean (was 3 sorries, now 0).",
       "Added helpers: inscribed_ball_subset, inscribed_radius_le, sublevelSet_subset_ball, bddAbove_inscribed_radii, sublevelSet_degree_zero.",
@@ -48,7 +48,8 @@
       "STATIC VERIFICATION (researcher-9, 07-02): the hardest proof area_implies_disc_bound's measure-coercion chain (Complex.volume_ball -> ENNReal.toReal_mul/pow/ofReal -> ENNReal.coe_toReal, NNReal.coe_real_pi) mirrors Mathlib's own ConvexBody.lean/Asymptotics.lean idiom EXACTLY. Confirmed against packages/mathlib source: Complex.volume_ball (a r) : volume (ball a r) = .ofReal r ^2 * NNReal.pi (VolumeOfBalls.lean:438); NNReal.pi and NNReal.coe_real_pi both exist.",
       "The multiplicative gap between the KLR lower bound and the EHP-conjectured c/n rate is EXACTLY √log n (conjecturedBound_div_klrBound) and is unbounded — a clean, axiom-free quantification of why KLR does not resolve EHP: it is asymptotically infinitely far (in constants) from the conjecture. √log n → ∞ proved via sqrt→atTop (tendsto_atTop_atTop char, b<=|b|=√(b²)<=√x) composed with tendsto_log_atTop∘tendsto_natCast_atTop_atTop, transported through the exact ratio identity by Tendsto.congr'.",
       "benchmark_family_bracket: 1/(2e·n²) ≤ ρ(zⁿ-1) ≤ π/(2n) — first result pinning the ACTUAL inscribed-disc radius of the extremal family (rootsOfUnity n), by specializing pommerenke_lower to it and pairing with benchmark_upper; multiplicative band width π·e·n",
-      "Rotation invariance (researcher-6): ρ(f) is invariant under rotating all roots by any unimodular u (‖u‖=1), i.e. rho(rotate f u)=rho f. The rigid rotation z↦u·z is an isometry of ℂ carrying the sublevel set {|f|<1} onto u·{|f|<1} and inscribed discs to inscribed discs of equal radius. Hence the Erdős #1039 extremal quantity depends only on the rotation ORBIT of the root configuration — the minimisation carries the full circle-group O(2) symmetry, so one may WLOG fix the argument of a single root. Negation (u=-1) is the special case neg_roots_rho."
+      "Rotation invariance (researcher-6): ρ(f) is invariant under rotating all roots by any unimodular u (‖u‖=1), i.e. rho(rotate f u)=rho f. The rigid rotation z↦u·z is an isometry of ℂ carrying the sublevel set {|f|<1} onto u·{|f|<1} and inscribed discs to inscribed discs of equal radius. Hence the Erdős #1039 extremal quantity depends only on the rotation ORBIT of the root configuration — the minimisation carries the full circle-group O(2) symmetry, so one may WLOG fix the argument of a single root. Negation (u=-1) is the special case neg_roots_rho.",
+      "v4.31 integrity build 2026-07-19 (researcher-1): Erdos1039Problem.lean GREEN under v4.31.0 (docker-build, 4 deep axioms / 0 sorries preserved). Fixed 2 push_neg→push Not (lines 461/495). Reconciled stale gallery meta counts (lineCount 854→1101, theoremCount 24→43; axiomCount 4 / defCount 17 / sorries 0 already correct)."
     ],
     "mathlibGaps": [
       "No ball_subset_ball_iff for open balls (necessary direction); had to prove inscribed_radius_le by hand."
@@ -75,7 +76,7 @@
     "mathlib": []
   },
   "started": "2026-03-30T16:34:54.972Z",
-  "lastUpdate": "2026-07-12",
+  "lastUpdate": "2026-07-19",
   "significance": 6,
   "tractability": 6
 }


### PR DESCRIPTION
## Summary

Maintenance/triage on the max-inscribed-disc-radius ρ problem (Erdős #1039). The problem is **SOLVED at the axiomatized level** and stable; this PR keeps it green under v4.31 and reconciles stale gallery counts.

## Changes

- **v4.31 deprecation cleanup**: 2× `push_neg` → `push Not` in `Erdos1039Problem.lean` (lines 461, 495). Companion files had none.
- **Integrity build GREEN under v4.31.0**: `docker-build.sh Proofs.Erdos1039Problem` (4 axioms / 0 sorries preserved; only pre-existing unused-variable linter warnings).
- **Gallery meta reconciliation** (`src/data/proofs/erdos-1039/meta.json`): stale counts from file growth — `lineCount` 854→1101, `theoremCount` 24→43 in both `leanFile` and `meta` blocks. `axiomCount` 4 / `definitionCount` 17 / `sorries` 0 were already correct.

## Assessment (why no new math)

The 4 remaining axioms are all deep published results — `benchmark_upper` (Erdős–Herzog–Piranian), `pommerenke_lower` (Pommerenke 1961), `klr_lower` + `klr_area_bound` (Krishnapur–Lundberg–Ramachandran 2025). Formalizing any means reproducing the source paper; none is routine/Mathlib-reachable, so there is no axiom to discharge. The one genuine open formalization target (an `Expected[ρ]` functional proved `Θ(1/√n)`) needs a probability model over `UnitDiscPolynomial` — a multi-session build.

**Housekeeping still open (Mechanic scope)**: `Proofs/Stubs/Erdos1039Problem.lean` holds the pre-#33815 state and is not the presented proof; deleting it is a Mechanic task (mass-deletion tripwire).

## Status

**Outcome**: integrity/maintenance. Problem is SOLVED/axiomatized (`status: axiomatized`, 4 deep axioms honestly disclosed). No tractable remaining work.

🤖 Generated by researcher-1