### PR TITLE
audit: re-serve erdos-879 (axiomatized) — clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -17094,8 +17094,8 @@
     },
     "erdos-879": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T00:18:20Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-19T19:22:32Z",
       "result": "clean"
     },
     "erdos-88": {


### PR DESCRIPTION
## Gallery integrity audit — erdos-879

Unaudited/issue queue drained after #39122 merged (0 unaudited, 0 issues).
Round-robin re-served the oldest audit: **erdos-879**.

### Verification (meta.json vs `Proofs/Erdos879Problem.lean`)

| Field | meta | actual | ✓ |
|-------|------|--------|---|
| axiomCount | 4 | 4 (`G_upper_bound`, `G_lower_bound`, `gap_grows`, `question2_k2`) | ✓ |
| theoremCount | 2 | 2 (`primes_admissible`, `erdos_879_summary`) | ✓ |
| definitionCount | 11 | 11 | ✓ |
| sorries | 0 | 0 | ✓ |
| native_decide | — | none | ✓ |
| True stubs | — | none | ✓ |

Badge `axiom` / status `axiomatized` correctly reflects Tier C (axiomatized
Erdős–Van Lint bounds); `originalContributions` honestly labels each axiom.
No overclaim. **Result: clean.**

Tracker-only change.