### PR TITLE
Fix: retract stale "never compiled" claim on 4 #39078-repaired entries

### DIFF
--- a/src/data/proofs/erdos-1015/meta.json
+++ b/src/data/proofs/erdos-1015/meta.json
@@ -23,7 +23,7 @@
     "erdosProblemStatus": "solved",
     "axiomCount": 2,
     "lineCount": 149,
-    "assumptions": "AUDIT (issue #39061): NOT machine-verified. This entry never validly compiled. Even under Lean v4.26 the proof only 'passed' because the old `autoImplicit true` default silently bound the undefined identifier `n` as a free implicit variable, rendering the stated theorem vacuously general; under v4.31 (autoImplicit off by default) the file fails with `unknownIdentifier 'n'` and typically additional genuine proof errors. The verification claims below are therefore retracted pending a Lean-source repair (Class A). ORIGINAL METADATA: 2 axioms: ramseyNumber (Ramsey number function — axiomatized, requires finite combinatorics), burr_erdos_spencer (Burr-Erdős-Spencer — f(t) = R(t,t-1) + x for 0 ≤ x < t). 0 sorries.",
+    "assumptions": "Compiles green on Lean v4.31 (autoImplicit off, verified via docker-build.sh) with 0 sorries following the Class A Lean-source repair in PR #39078 (the earlier #39061 audit finding is resolved). Stated assumptions: 2 axioms: ramseyNumber (Ramsey number function — axiomatized, requires finite combinatorics), burr_erdos_spencer (Burr-Erdős-Spencer — f(t) = R(t,t-1) + x for 0 ≤ x < t).",
     "mathlib_version": "4.31.0",
     "theoremCount": 2,
     "definitionCount": 10

--- a/src/data/proofs/erdos-1066/meta.json
+++ b/src/data/proofs/erdos-1066/meta.json
@@ -55,7 +55,7 @@
     ],
     "axiomCount": 2,
     "lineCount": 118,
-    "assumptions": "AUDIT (issue #39061): NOT machine-verified. This entry never validly compiled. Even under Lean v4.26 the proof only 'passed' because the old `autoImplicit true` default silently bound the undefined identifier `n` as a free implicit variable, rendering the stated theorem vacuously general; under v4.31 (autoImplicit off by default) the file fails with `unknownIdentifier 'n'` and typically additional genuine proof errors. The verification claims below are therefore retracted pending a Lean-source repair (Class A). ORIGINAL METADATA: 2 axioms: g, g_d. Structure fields are object definitions, not assumptions.",
+    "assumptions": "Compiles green on Lean v4.31 (autoImplicit off, verified via docker-build.sh) with 0 sorries following the Class A Lean-source repair in PR #39078 (the earlier #39061 audit finding is resolved). Stated assumptions: 2 axioms: g, g_d. Structure fields are object definitions, not assumptions.",
     "theoremCount": 5,
     "definitionCount": 6
   },

--- a/src/data/proofs/erdos-423/meta.json
+++ b/src/data/proofs/erdos-423/meta.json
@@ -29,7 +29,7 @@
       "Set.Infinite and natural density concepts"
     ],
     "lineCount": 409,
-    "assumptions": "AUDIT (issue #39061): NOT machine-verified. This entry never validly compiled. Even under Lean v4.26 the proof only 'passed' because the old `autoImplicit true` default silently bound the undefined identifier `n` as a free implicit variable, rendering the stated theorem vacuously general; under v4.31 (autoImplicit off by default) the file fails with `unknownIdentifier 'n'` and typically additional genuine proof errors. The verification claims below are therefore retracted pending a Lean-source repair (Class A). ORIGINAL METADATA: 3 axioms: excess_nondecreasing, excess_unbounded, infinitely_many_missing. 0 sorries.",
+    "assumptions": "Compiles green on Lean v4.31 (autoImplicit off, verified via docker-build.sh) with 0 sorries following the Class A Lean-source repair in PR #39078 (the earlier #39061 audit finding is resolved). Stated assumptions: 3 axioms: excess_nondecreasing, excess_unbounded, infinitely_many_missing.",
     "mathlib_version": "4.31.0",
     "theoremCount": 42,
     "definitionCount": 9

--- a/src/data/proofs/erdos-713/meta.json
+++ b/src/data/proofs/erdos-713/meta.json
@@ -56,7 +56,7 @@
     ],
     "axiomCount": 2,
     "lineCount": 195,
-    "assumptions": "AUDIT (issue #39061): NOT machine-verified. This entry never validly compiled. Even under Lean v4.26 the proof only 'passed' because the old `autoImplicit true` default silently bound the undefined identifier `n` as a free implicit variable, rendering the stated theorem vacuously general; under v4.31 (autoImplicit off by default) the file fails with `unknownIdentifier 'n'` and typically additional genuine proof errors. The verification claims below are therefore retracted pending a Lean-source repair (Class A). ORIGINAL METADATA: 2 axioms: extremalNumber, erdos_simonovits_counterexample. 0 sorries.",
+    "assumptions": "Compiles green on Lean v4.31 (autoImplicit off, verified via docker-build.sh) with 0 sorries following the Class A Lean-source repair in PR #39078 (the earlier #39061 audit finding is resolved). Stated assumptions: 2 axioms: extremalNumber, erdos_simonovits_counterexample.",
     "theoremCount": 2,
     "definitionCount": 8
   },


### PR DESCRIPTION
## Summary

Metadata follow-up to **PR #39078** (batch 1 of #39077). #39078 repaired the Lean sources for **erdos-1015, erdos-1066, erdos-713, erdos-423** (Class A) — all four now compile green on v4.31 with 0 sorries and their stated axioms. It correctly updated the badges (already `axiomatized`/`axiom` from #39067) but left each entry's `assumptions` field carrying the now-**false** #39061 retraction:

> "AUDIT (issue #39061): NOT machine-verified. This entry never validly compiled. … The verification claims below are therefore retracted pending a Lean-source repair (Class A)."

That repair has landed, so the text is stale and misrepresents the gallery. This PR replaces it with an accurate statement (file compiles green on v4.31; lists the genuine stated axioms). `status`/`badge` are unchanged.

## Evidence

- **Before:** all 4 `assumptions` fields claimed "NOT machine-verified … never validly compiled."
- **After:** `"Compiles green on Lean v4.31 (autoImplicit off, verified via docker-build.sh) with 0 sorries following the Class A Lean-source repair in PR #39078 … Stated assumptions: N axioms: …"`
- Rebuilt `Erdos1066Problem.lean` green via `./proofs/scripts/docker-build.sh Proofs.Erdos1066Problem` (`✔ Built Proofs.Erdos1066Problem`, 0 sorries, 2 axioms).
- Other three verified green in #39078 (merged, `f066fbc254`); all four source files confirmed 0 sorries with binder repairs present.
- All 4 `meta.json` re-validated as parseable JSON.

Metadata-only; no Lean or schema changes. Partial progress on #39077 (metadata half for batch 1).