### PR TITLE
Fix: retract false 'IsPrimePow 1' claim in erdos-723 metadata

### DIFF
--- a/src/data/proofs/erdos-723/annotations.json
+++ b/src/data/proofs/erdos-723/annotations.json
@@ -128,7 +128,7 @@
     },
     "type": "concept",
     "title": "Verified for n ≤ 11",
-    "content": "**axiom verified_up_to_11**:\nFor all projective planes with order ≤ 11, the order is a prime power.\n\n**Breakdown**:\n- n = 1,2,3,4,5,7,8,9,11: prime powers, planes exist via PG(2,q)\n- n = 6: ruled out by Bruck-Ryser (verified in this file)\n- n = 10: ruled out by Lam's computer search (1989)\n\nThe conjecture holds through order 11.",
+    "content": "**axiom verified_up_to_11**:\nFor all projective planes with order ≤ 11, the order is a prime power.\n\n**Breakdown**:\n- n = 2,3,4,5,7,8,9,11: prime powers, planes exist via PG(2,q)\n- n = 6: ruled out by Bruck-Ryser (verified in this file)\n- n = 10: ruled out by Lam's computer search (1989)\n\nThe conjecture holds through order 11.",
     "mathContext": "Each case beyond prime powers required different techniques. Orders 6, 14, 21, 22 fall to Bruck-Ryser's algebraic obstruction. Order 10 required exhaustive computation because $10 = 1^2 + 3^2$ passes the Bruck-Ryser test. The progression from theoretical to computational methods reflects a general pattern in combinatorics.",
     "significance": "key",
     "relatedConcepts": [
@@ -273,7 +273,7 @@
     },
     "type": "concept",
     "title": "Small Orders (Verified)",
-    "content": "**Verified by `decide`**:\n- `order_1_is_prime_power` ✓ (trivial plane: 3 points)\n- `order_2_is_prime_power` ✓ (Fano plane: 7 points)\n- `order_3_is_prime_power` ✓ (PG(2,3): 13 points)\n- `order_4_is_prime_power` ✓ ($2^2 = 4$: 21 points)\n- `order_5_is_prime_power` ✓ (PG(2,5): 31 points)\n\n**Non-prime-powers (verified)**:\n- `order_6_not_prime_power` ✓\n- `order_10_not_prime_power` ✓\n- `order_12_not_prime_power` ✓\n\nOrder 4 requires special handling: `decide` alone times out, so the proof rewrites $4 = 2^2$ and applies `IsPrimePow.pow`.",
+    "content": "**Verified by `decide`**:\n- `order_2_is_prime_power` ✓ (Fano plane: 7 points)\n- `order_3_is_prime_power` ✓ (PG(2,3): 13 points)\n- `order_4_is_prime_power` ✓ ($2^2 = 4$: 21 points)\n- `order_5_is_prime_power` ✓ (PG(2,5): 31 points)\n\n**Non-prime-powers (verified)**:\n- `order_1_not_prime_power` ✓ (order 1 is the degenerate case, not a prime power)\n- `order_6_not_prime_power` ✓\n- `order_10_not_prime_power` ✓\n- `order_12_not_prime_power` ✓\n\nOrder 4 requires special handling: `decide` alone times out, so the proof rewrites $4 = 2^2$ and applies `IsPrimePow.pow`.",
     "mathContext": "The `decide` tactic reduces `IsPrimePow n` to a finite computation. For $n = 4 = 2^2$, the composite prime power case requires explicitly exhibiting the factorization, since `decide` on `IsPrimePow 4` involves checking divisibility patterns that exceed the default timeout. This illustrates a general pattern: composite prime powers are harder for automated methods than primes.",
     "significance": "key",
     "relatedConcepts": [

--- a/src/data/proofs/erdos-723/meta.json
+++ b/src/data/proofs/erdos-723/meta.json
@@ -132,8 +132,8 @@
       "title": "Examples of Small Orders",
       "startLine": 128,
       "endLine": 155,
-      "summary": "Verified computations: IsPrimePow for orders 1-5 via decide (with order 4 needing explicit 4=2² rewrite), and ¬IsPrimePow for 6, 10, 12 confirming these are not prime powers.",
-      "mathContext": "Mathematical content: Verified computations: IsPrimePow for orders 1-5 via decide (with order 4 needing explicit 4=2² rewrite), and ¬IsPrimePow for 6, 10, 12 confirming these are not prime powers."
+      "summary": "Verified computations: IsPrimePow for orders 2-5 via decide (with order 4 needing explicit 4=2² rewrite), and ¬IsPrimePow for 1, 6, 10, 12 confirming these are not prime powers.",
+      "mathContext": "Mathematical content: Verified computations: IsPrimePow for orders 2-5 via decide (with order 4 needing explicit 4=2² rewrite), and ¬IsPrimePow for 1, 6, 10, 12 confirming these are not prime powers."
     },
     {
       "id": "bruck-ryser-applications",
@@ -145,7 +145,7 @@
     }
   ],
   "conclusion": {
-    "summary": "Erdős Problem #723 (Prime Power Conjecture) is OPEN in general. The formalization includes verified proofs that orders 1-5 are prime powers, a complete Bruck-Ryser application ruling out order 6, and records Lam's computational result for order 10. Order 12 remains the smallest unknown case.",
+    "summary": "Erdős Problem #723 (Prime Power Conjecture) is OPEN in general. The formalization includes verified proofs that orders 2-5 are prime powers (and that order 1 is not a prime power), a complete Bruck-Ryser application ruling out order 6, and records Lam's computational result for order 10. Order 12 remains the smallest unknown case.",
     "implications": "**Theoretical Significance**: The conjecture sits at the intersection of finite geometry, algebraic number theory, and combinatorial design theory.\n\nThe Bruck-Ryser necessary condition links plane existence to quadratic form theory, while the equivalence between projective planes and complete sets of MOLS connects to Latin square combinatorics. If a non-prime-power projective plane were found, it would require construction methods fundamentally different from finite field algebra—potentially revolutionizing our understanding of combinatorial designs.",
     "openQuestions": [
       "Does a projective plane of order 12 exist? This is the smallest open case and would require an order-of-magnitude leap in computational methods beyond Lam's work on order 10.",


### PR DESCRIPTION
## Problem

Bucket-A credibility fix under #38611 (gallery metadata reconciliation vs v4.31-corrected Lean).

The `erdos-723` gallery data displayed a **mathematically false, nonexistent theorem**: `order_1_is_prime_power ✓ (trivial plane: 3 points)` under a green **"Verified by `decide`"** heading, and listed `n = 1` among the prime powers. `IsPrimePow 1` is **false**.

The Lean source proves the opposite:

```
proofs/Proofs/Erdos723Problem.lean:132
theorem order_1_not_prime_power : ¬IsPrimePow 1 := by decide
```

There is no `order_1_is_prime_power` in the file (orders 2,3,4,5 are the verified prime powers; 1,6,10,12 are the verified non-prime-powers).

## Fix (metadata only — 2 files, 5 lines)

- `annotations.json` "Small Orders (Verified)": removed the false `order_1_is_prime_power` line; added `order_1_not_prime_power ✓` under the non-prime-powers list.
- `annotations.json` "Verified for n ≤ 11" breakdown: prime-power enumeration `1,2,3,4,5,...` → `2,3,4,5,...`.
- `meta.json` (section summary/mathContext + conclusion summary): "IsPrimePow for orders 1-5 … ¬IsPrimePow for 6,10,12" → "orders 2-5 … ¬IsPrimePow for 1,6,10,12"; "orders 1-5 are prime powers" → "orders 2-5 are prime powers (and order 1 is not a prime power)".

`status`/`badge`/`axiomCount` unchanged — the entry is correctly `axiomatized`/`axiom` (carries `axiom bruck_ryser`); this was wrong prose under a verified heading, not a status overclaim.

## Evidence

- **Before:** `order_1_is_prime_power ✓` (asserts `IsPrimePow 1`, false) shown as decide-verified.
- **After:** matches Lean `order_1_not_prime_power : ¬IsPrimePow 1`.
- Both JSON files re-validate (`json.load`); no residual `order_1_is_prime_power` / `orders 1-5` strings remain in the entry.

Part of #38611.