### PR TITLE
audit: re-serve erdos-865, 866, 868, 869 (axiomatized) — all clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -16986,14 +16986,14 @@
     },
     "erdos-865": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T00:19:32Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-19T20:03:58Z",
       "result": "clean"
     },
     "erdos-866": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 6,
-      "lastAudited": "2026-05-04T04:04:44Z",
+      "auditCount": 7,
+      "lastAudited": "2026-07-19T20:03:58Z",
       "result": "clean"
     },
     "erdos-866-oq-01": {
@@ -17016,8 +17016,8 @@
     },
     "erdos-868": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 5,
-      "lastAudited": "2026-05-16T15:59:45Z",
+      "auditCount": 6,
+      "lastAudited": "2026-07-19T20:03:58Z",
       "result": "clean",
       "fixPR": 13653,
       "fixDate": "2026-04-28",
@@ -17025,8 +17025,8 @@
     },
     "erdos-869": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-05-16T06:47:58Z",
+      "auditCount": 5,
+      "lastAudited": "2026-07-19T20:03:58Z",
       "result": "clean"
     },
     "erdos-87": {


### PR DESCRIPTION
## Gallery Integrity Audit — round-robin re-serve

Unaudited queue is drained (4807/4807). Re-serving the oldest cohort.
All four entries verified **integrity-clean** — sorry/axiom counts match
meta.json, badges honest, no True stubs, no `native_decide`.

| Slug | status/badge | meta sorries/axioms | file sorries/axioms | verdict |
|------|--------------|---------------------|---------------------|---------|
| erdos-865 | axiomatized/axiom | 0 / 2 | 0 / 2 | clean |
| erdos-866 | axiomatized/wip | 0 / 0 | 0 / 0 | clean (under-claims) |
| erdos-868 | axiomatized/axiom | 0 / 2 | 0 / 2 | clean |
| erdos-869 | axiomatized/axiom | 0 / 2 | 0 / 2 | clean |

Notes:
- **erdos-866**: the single `sorry` grep hit is a docstring line
  (`- No axioms (use theorem ... := by sorry instead)`), not a real
  declaration. Three theorems (`upperExponent_increasing`,
  `oddNumbers_card`, `oddNumbers_no_triple`) carry real proofs. `wip`
  badge under-claims completed infrastructure — safe.

Tracker-only refresh; no meta.json changes required.

---
Discovered during gallery integrity audit.