### PR TITLE
Fix: repair never-compiled Erdos832Problem (Erdős #832) for v4.31 — batch of #39077

### DIFF
--- a/proofs/Proofs/Erdos832Problem.lean
+++ b/proofs/Proofs/Erdos832Problem.lean
@@ -25,12 +25,13 @@ References:
 - https://erdosproblems.com/832
 -/
 
-import Mathlib.Combinatorics.SimpleGraph.Coloring
+import Mathlib.Combinatorics.SimpleGraph.Coloring.Vertex
 import Mathlib.Data.Nat.Choose.Basic
 import Mathlib.Data.Finset.Basic
 import Mathlib.Data.Real.Basic
+import Mathlib.Topology.Instances.Real.Lemmas
 
-set_option autoImplicit true
+set_option autoImplicit false
 
 namespace Erdos832
 
@@ -42,16 +43,16 @@ structure Hypergraph (V : Type*) where
   edges : Set (Finset V)
 
 /-- **r-Uniformity:** All edges have exactly r vertices. -/
-def IsUniform (H : Hypergraph V) (r : ℕ) : Prop :=
+def IsUniform {V : Type*} (H : Hypergraph V) (r : ℕ) : Prop :=
   ∀ e ∈ H.edges, e.card = r
 
 /-- **Proper k-colouring of a hypergraph:**
 An assignment of colours to vertices such that no edge is monochromatic. -/
-def IsProperColouring {V : Type*} (H : Hypergraph V) (c : V → Fin k) : Prop :=
+def IsProperColouring {V : Type*} {k : ℕ} (H : Hypergraph V) (c : V → Fin k) : Prop :=
   ∀ e ∈ H.edges, ∃ u v, u ∈ e ∧ v ∈ e ∧ c u ≠ c v
 
 /-- **Chromatic number at least k:** No proper (k-1)-colouring exists. -/
-def hasChromaticNumberAtLeast (H : Hypergraph V) (k : ℕ) : Prop :=
+def hasChromaticNumberAtLeast {V : Type*} (H : Hypergraph V) (k : ℕ) : Prop :=
   ¬∃ c : V → Fin (k - 1), IsProperColouring H c
 
 /- ## Part II: The Classical Graph Case (r = 2) -/
@@ -66,7 +67,7 @@ For r ≥ 3 and k sufficiently large, every r-uniform hypergraph with
 chromatic number k has at least C((r-1)(k-1)+1, r) edges. -/
 def erdosConjecture (r k : ℕ) : Prop :=
   r ≥ 3 →
-    ∀ H : Hypergraph V, IsUniform H r → hasChromaticNumberAtLeast H k →
+    ∀ (V : Type) (H : Hypergraph V), IsUniform H r → hasChromaticNumberAtLeast H k →
       ∃ n : ℕ, n ≥ Nat.choose ((r - 1) * (k - 1) + 1) r
 
 /- ## Part IV: Counterexamples -/
@@ -82,7 +83,7 @@ axiom alon_disproof :
     ∃ C : ℕ, C > 0 ∧
       ∀ r : ℕ, r ≥ C →
         ∀ k : ℕ, k ≥ C * r →
-          ∃ H : Hypergraph V,
+          ∃ (V : Type) (H : Hypergraph V),
             IsUniform H r ∧
             hasChromaticNumberAtLeast H k
 
@@ -111,10 +112,10 @@ def r3_open_question : Prop :=
 /- ## Part VII: Concrete Examples -/
 
 /-- The Fano plane bound: C(5,3) = 10, so 7 edges < 10. -/
-example : 7 < Nat.choose 5 3 := by norm_num
+example : 7 < Nat.choose 5 3 := by decide
 
-/-- Alon's factor for r = 4: (7/8)^4 ≈ 0.586. -/
-example : (7/8 : ℝ)^4 < 0.6 := by norm_num
+/-- Alon's factor for r = 4: (7/8)^4 ≈ 0.586 < 3/5. -/
+example : (7 / 8 : ℝ) ^ 4 < 3 / 5 := by norm_num
 
 /- ## Part VIII: Summary -/
 
@@ -132,7 +133,7 @@ theorem erdos_832 :
     (∃ C : ℕ, C > 0 ∧
       ∀ r : ℕ, r ≥ C →
         ∀ k : ℕ, k ≥ C * r →
-          ∃ H : Hypergraph V,
+          ∃ (V : Type) (H : Hypergraph V),
             IsUniform H r ∧ hasChromaticNumberAtLeast H k) ∧
     (∀ r : ℕ, r ≥ 3 →
       ∃ c_r : ℝ, c_r > 0 ∧

--- a/src/data/proofs/erdos-832/meta.json
+++ b/src/data/proofs/erdos-832/meta.json
@@ -26,7 +26,7 @@
       {
         "theorem": "SimpleGraph.chromaticNumber",
         "description": "Chromatic number for graphs",
-        "module": "Mathlib.Combinatorics.SimpleGraph.Coloring"
+        "module": "Mathlib.Combinatorics.SimpleGraph.Coloring.Vertex"
       },
       {
         "theorem": "Nat.choose",
@@ -46,8 +46,8 @@
     ],
     "dateAdded": "2026-01-18",
     "axiomCount": 3,
-    "lineCount": 140,
-    "assumptions": "AUDIT (issue #39061): NOT machine-verified. This entry never validly compiled. Even under Lean v4.26 the proof only 'passed' because the old `autoImplicit true` default silently bound the undefined identifier `V` as a free implicit variable, rendering the stated theorem vacuously general; under v4.31 (autoImplicit off by default) the file fails with `unknownIdentifier 'V'` and typically additional genuine proof errors. The verification claims below are therefore retracted pending a Lean-source repair (Class A). ORIGINAL METADATA: 3 axioms: alon_disproof, m, cherkashin_petrov_limit. 0 sorries.",
+    "lineCount": 143,
+    "assumptions": "REPAIRED (issue #39077, Class A): the file now compiles green on Lean v4.31 with `set_option autoImplicit false`. The vertex type `V` (previously an autoImplicit-masked free variable) is now explicitly bound: `{V : Type*}` in the definitions and predicates, and existentially quantified `∃ (V : Type) (H : Hypergraph V)` in `alon_disproof` and the `erdos_832` summary theorem — so the statements are no longer vacuously general. The two concrete `example`s were repaired (`decide` for the `Nat.choose` bound; a rational bound `< 3/5` for `(7/8)^4`), and `Mathlib.Topology.Instances.Real.Lemmas` was added for `Filter.Tendsto`/`nhds`. Status remains axiomatized: the result rests on 3 axioms — alon_disproof (Alon's 1985 disproof for r ≥ 4), m (minimum-edges function), cherkashin_petrov_limit (2020 asymptotic). 0 sorries.",
     "theoremCount": 1,
     "definitionCount": 6
   },
@@ -132,14 +132,15 @@
   },
   "leanFile": {
     "imports": [
-      "Mathlib.Combinatorics.SimpleGraph.Coloring",
+      "Mathlib.Combinatorics.SimpleGraph.Coloring.Vertex",
       "Mathlib.Data.Nat.Choose.Basic",
       "Mathlib.Data.Finset.Basic",
-      "Mathlib.Data.Real.Basic"
+      "Mathlib.Data.Real.Basic",
+      "Mathlib.Topology.Instances.Real.Lemmas"
     ],
     "opens": [],
     "namespace": "Erdos832",
-    "lineCount": 140,
+    "lineCount": 143,
     "axiomCount": 3,
     "theoremCount": 1,
     "definitionCount": 6,


### PR DESCRIPTION
## Summary

Class A repair from the #39077 tracking issue (28 never-compiled entries). Fixes `Erdos832Problem` (flagged identifier `:V`) so it compiles green on Lean v4.31.

**Root cause.** Under the old `autoImplicit true` default, the vertex type `V` was silently bound as a free implicit variable across the definitions/predicates (`IsUniform`, `IsProperColouring`, `hasChromaticNumberAtLeast`, `erdosConjecture`) and in the `alon_disproof` axiom + `erdos_832` theorem. This rendered the existence statements vacuously general (`∀ {V}, ∃ H : Hypergraph V`). v4.31 (autoImplicit off) correctly rejects the undefined `V`.

## Fix

- `set_option autoImplicit false`; explicitly bind `{V : Type*}` (and `{k : ℕ}` in `IsProperColouring`) in every definition and predicate.
- Existentially quantify `∃ (V : Type) (H : Hypergraph V)` in `alon_disproof` and the `erdos_832` summary theorem — so "there exists a hypergraph" is the faithful reading, not "for every vertex type there is one."
- Repair the two concrete `example`s: `by decide` for `7 < Nat.choose 5 3`; rational bound `(7/8 : ℝ)^4 < 3/5` for Alon's factor.
- Add `Mathlib.Topology.Instances.Real.Lemmas` for `Filter.Tendsto`/`nhds` (module was missing); update deprecated `SimpleGraph.Coloring` import to `Coloring.Vertex`.

## Evidence

**Before:** `unknownIdentifier 'V'` (multiple sites), `Unknown identifier Filter.Tendsto` (×2), 2 unsolved `norm_num` goals.

**After:**
```
✔ [1573/1573] Built Proofs.Erdos832Problem (659ms)
Build completed successfully (1573 jobs).
=== Build succeeded ===
```
Verified via `./proofs/scripts/docker-build.sh Proofs.Erdos832Problem` (0 warnings).

## Metadata

Status **remains `axiomatized`/`axiom`** — the result still rests on 3 axioms (`alon_disproof`, `m`, `cherkashin_petrov_limit`), 0 sorries. No badge upgrade. `meta.json`: `lineCount` 140→143, imports synced, and the `assumptions` field rewritten from the audit retraction to a repair note per the Axiom Integrity Policy.

Part of #39077.