### PR TITLE
Fix: repair never-compiled Erdos451Problem (Erdős #451) for v4.31 — batch of #39077

### DIFF
--- a/proofs/Proofs/Erdos451Problem.lean
+++ b/proofs/Proofs/Erdos451Problem.lean
@@ -20,7 +20,7 @@ Reference: https://erdosproblems.com/451
 
 import Mathlib
 
-set_option autoImplicit true
+set_option autoImplicit false
 
 open Finset Real
 
@@ -65,7 +65,7 @@ axiom nk_minimal (k : ℕ) (hk : 1 ≤ k) (n : ℕ) (hn : 2 * k < n)
 
 /-- For prime p > k, at most one of n-1, ..., n-k is divisible by p.
     If p | (n-i) and p | (n-j) then p | (i-j), but |i-j| < k < p. -/
-theorem at_most_one_div (n k p : ℕ) (hp : Nat.Prime p) (hpk : k < p)
+theorem at_most_one_div (n k p : ℕ) (_hp : Nat.Prime p) (hpk : k < p)
     (i j : ℕ) (hi : i ∈ Finset.Icc 1 k) (hj : j ∈ Finset.Icc 1 k)
     (hdi : p ∣ (n - i)) (hdj : p ∣ (n - j)) (hn : k < n) :
     i = j := by
@@ -132,7 +132,7 @@ theorem avoids_when_divisible_by_all (n k : ℕ) (hn : 2 * k < n)
     (hdiv : ∀ p : ℕ, IsInBertrandRange p k → p ∣ n) :
     AvoidsBertrandPrimes n k := by
   intro p hp hprod
-  obtain ⟨hpk, _, hprime⟩ := hp
+  obtain ⟨hpk, _, hprime⟩ := id hp
   rw [prime_dvd_descendingProduct n k p hprime (by omega)] at hprod
   obtain ⟨i, hi, hdi⟩ := hprod
   rw [Finset.mem_Icc] at hi

--- a/src/data/proofs/erdos-451/meta.json
+++ b/src/data/proofs/erdos-451/meta.json
@@ -23,8 +23,8 @@
     "dateAdded": "2025-01-01",
     "mathlib_version": "4.31.0",
     "axiomCount": 3,
-    "lineCount": 185,
-    "assumptions": "AUDIT (issue #39061): NOT machine-verified. This entry never validly compiled. Even under Lean v4.26 the proof only 'passed' because the old `autoImplicit true` default silently bound the undefined identifier `hp` as a free implicit variable, rendering the stated theorem vacuously general; under v4.31 (autoImplicit off by default) the file fails with `unknownIdentifier 'hp'` and typically additional genuine proof errors. The verification claims below are therefore retracted pending a Lean-source repair (Class A). ORIGINAL METADATA: 3 axioms: nk, nk_gt_2k, nk_minimal. 0 sorries.",
+    "lineCount": 187,
+    "assumptions": "REPAIRED (issue #39077, Class A): the file now compiles green on Lean v4.31 with `set_option autoImplicit false`. The genuine defect was in `avoids_when_divisible_by_all`: `obtain ⟨hpk, _, hprime⟩ := hp` destructured and cleared the hypothesis `hp`, which was still needed later as `hdiv p hp` — under v4.31 this surfaced as `unknownIdentifier 'hp'`. Fixed by destructuring a copy (`:= id hp`) so `hp` remains in scope; the unused primality binder in `at_most_one_div` was renamed `_hp` to silence the linter. The supporting CRT lemmas (at_most_one_div, prime_dvd_descendingProduct, card_safeResidues, avoids_when_divisible_by_all, avoidsBertrand_iff_finset, …) are fully proved. Status remains axiomatized: the n_k function and its defining bounds rest on 3 axioms (nk, nk_gt_2k, nk_minimal), and the two main statements ErdosProblem451_superpolynomial / _subexponential are stated as open-conjecture `Prop` definitions, not proved. 0 sorries.",
     "theoremCount": 8,
     "definitionCount": 8
   },
@@ -124,7 +124,7 @@
       "Real"
     ],
     "namespace": null,
-    "lineCount": 185,
+    "lineCount": 187,
     "axiomCount": 3,
     "theoremCount": 8,
     "definitionCount": 8,


### PR DESCRIPTION
## Summary

Class A repair from the #39077 tracking issue. Fixes `Erdos451Problem` (flagged identifier `:hp`) so it compiles green on Lean v4.31.

**Root cause.** In `avoids_when_divisible_by_all`, the line
```lean
obtain ⟨hpk, _, hprime⟩ := hp
```
destructured **and cleared** the hypothesis `hp : IsInBertrandRange p k`. But `hp` is still needed two lines later as `(hdiv p hp)`. Under v4.31 this surfaced as `error: unknownIdentifier 'hp'`. (Under the old `autoImplicit true` default the file never validly compiled either.)

## Fix

- Destructure a **copy** so the original stays in scope:
  ```lean
  obtain ⟨hpk, _, hprime⟩ := id hp
  ```
- Rename the unused primality binder in `at_most_one_div` from `hp` to `_hp` (silences the unused-variable linter; matches the file's existing `_`-prefix convention).
- `set_option autoImplicit false` to close the #39077 root cause.

## Evidence

**Before:** `error: Proofs/Erdos451Problem.lean:140:12: Unknown identifier 'hp'` (+ unused-var warning at line 68).

**After:**
```
✔ [8576/8576] Built Proofs.Erdos451Problem (2.4s)
Build completed successfully (8576 jobs).
=== Build succeeded ===
```
Verified via `./proofs/scripts/docker-build.sh Proofs.Erdos451Problem` (0 warnings).

## Metadata

Status **remains `axiomatized`/`axiom`**. The CRT support lemmas (`at_most_one_div`, `prime_dvd_descendingProduct`, `card_safeResidues`, `avoids_when_divisible_by_all`, `avoidsBertrand_iff_finset`, …) are fully proved, but the result rests on 3 axioms (`nk`, `nk_gt_2k`, `nk_minimal`) and the two headline statements (`ErdosProblem451_superpolynomial` / `_subexponential`) are stated as open-conjecture `Prop` definitions, not proved. 0 sorries. No badge upgrade. `meta.json`: `lineCount` 185→187, `assumptions` rewritten from the audit retraction to an accurate repair note per the Axiom Integrity Policy.

Part of #39077.