### PR TITLE
audit: re-serve erdos-876 (axiomatized) — clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -17076,8 +17076,8 @@
     },
     "erdos-876": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T00:18:20Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-19T20:18:54Z",
       "result": "clean"
     },
     "erdos-877": {


### PR DESCRIPTION
## Gallery Integrity Audit — erdos-876

Independent re-audit (round-robin re-serve; unaudited queue is drained).

**Verdict: clean.** Verified `src/data/proofs/erdos-876/meta.json` against `proofs/Proofs/Erdos876Problem.lean`:

| Check | Meta | Source | Match |
|-------|------|--------|-------|
| sorries | 2 | 2 (L78, L208) | ✓ |
| axiomCount | 1 | 1 (`graham_result`, L134) | ✓ |
| theoremCount | 3 | 3 | ✓ |
| native_decide | — | none | ✓ |
| True stubs | — | none | ✓ |

- Status `axiomatized` / badge `axiom` (Tier C) correctly signal incompleteness.
- Sorries and the axiom are **fully disclosed** publicly: description says "remains OPEN", `assumptions` = "1 axiom: graham_result. 2 sorries", and `conclusion.summary` names both sorry sites (`erdos_implies_classical`, `powers_of_two_sumfree`).
- No overclaim of completeness.
- `lineCount` meta 257 vs actual 259 — harmless stale undercount.

🤖 Generated with [Claude Code](https://claude.com/claude-code)