### PR TITLE
audit: re-serve erdos-874 (axiomatized) — clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -17064,8 +17064,8 @@
     },
     "erdos-874": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T00:18:39Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-19T20:27:53Z",
       "result": "clean"
     },
     "erdos-875": {


### PR DESCRIPTION
## Gallery Integrity Audit — erdos-874

Re-audit of **Erdős Problem #874: Admissible Sets and Subset Sum Disjointness** (round-robin re-serve of oldest audits; unaudited queue drained at 4807/4807).

### Verification against `Proofs/Erdos874Problem.lean`

| Check | meta.json | Lean file | ✓ |
|-------|-----------|-----------|---|
| axiomCount | 2 | 2 (`deshouillers_freiman_main`, `k_limit_is_two`) | ✓ |
| sorries | 0 | 0 | ✓ |
| True stubs | — | none | ✓ |
| native_decide | — | none (line 129 hit is docstring prose) | ✓ |
| status / badge | axiomatized / axiom | main results rest on 2 disclosed axioms | ✓ |
| theoremCount | 3 | 4 actual | undercount (safe) |
| lineCount | 227 | 262 actual | undercount (safe) |

### Tier / narrative
- Correctly **Tier C** (axiomatized). `erdos_874` = `k_limit_is_two` (axiom); `erdos_874_answer` is genuinely *derived* from `deshouillers_freiman_main`; `k_le_self` is honestly proved.
- The "SOLVED"/"TRUE" wording lives only in Lean docstrings; the public meta status (`axiomatized`) and badge (`axiom`) disclose the axiom dependency honestly — no overclaim.

### Nit (not blocking)
- `originalContributions` lists "Straus lower/upper bound axioms (1966)" and "ENS improved upper bound axiom (1991)", but these are comment blocks in the file, not axiom declarations — inventory drift in the humble direction, no credibility impact.

**Result: integrity-clean.** Only the audit tracker is updated.

---
Discovered during gallery integrity audit.