### PR TITLE
Research: collatz-structured-oq-02-oq-03 — intrinsic length budget v.length ≤ 2b+1 (unconditionalizes the prefix engine)

### DIFF
--- a/proofs/Proofs/CollatzStructuredOQ02OQ03CertUnique.lean
+++ b/proofs/Proofs/CollatzStructuredOQ02OQ03CertUnique.lean
@@ -440,4 +440,74 @@ theorem affValid_count_true_le_count_false_succ {v : List Bool} {c d : ℕ}
   have h2 := count_true_add_count_false v
   omega
 
+/-! ## Part XII (cont.) — the intrinsic length budget `v.length ≤ 2b+1`
+
+The count bound above (`affValid_count_true_le_count_false_succ`) controls the *odd* steps in
+terms of the *even* steps but says nothing about the total length: it leaves
+`v.length ≤ 2·(count false) + 1` still hostage to how large `count false` can be.  This section
+supplies the missing half — a bound on the *even* steps `count false ≤ b` for the dyadic engine
+`AffValid v (2^b) r` — and combines the two into the intrinsic budget `v.length ≤ 2b+1`.
+
+The mechanism is the 2-adic valuation of the leading coefficient `c`.  Every `AffValid` step
+requires `c` even, and:
+  * an **odd** step (`true`) sends `c ↦ 3c`, which *preserves* `v₂(c)` (3 is odd);
+  * an **even** step (`false`) sends `c ↦ c/2`, which *drops* `v₂(c)` by one.
+So each halving consumes one factor of 2 from `c`, giving the divisibility invariant
+`2^(count false) ∣ c`.  For the dyadic class `c = 2^b` this reads `2^(count false) ∣ 2^b`, i.e.
+`count false ≤ b`: there can be at most `b` halvings before the leading coefficient runs out of
+2s.  This makes `affValid_prefix_deriveVec_pow` unconditional — the fuel budget `2b+1` is a
+theorem about the certificate, not a hypothesis. -/
+
+/-- **Halvings consume factors of 2 from the leading coefficient.**  Every valid certificate `v`
+for the affine class `c·m + d` satisfies `2^(v.count false) ∣ c`: each even (halving) step peels
+one factor of 2 off `c`, while odd (tripling) steps `c ↦ 3c` preserve its 2-adic valuation. -/
+theorem affValid_two_pow_count_false_dvd {v : List Bool} {c d : ℕ}
+    (hv : AffValid v c d) : 2 ^ (v.count false) ∣ c := by
+  induction hv with
+  | nil => simp
+  | @odd v c d hc hd hrec ih =>
+    have hcount : (true :: v).count false = v.count false := by simp
+    rw [hcount]
+    -- `2^k ∣ 3 * c` and `Coprime (2^k) 3` give `2^k ∣ c`
+    have hcop : Nat.Coprime (2 ^ (v.count false)) 3 :=
+      Nat.Coprime.pow_left _ (by decide)
+    exact hcop.dvd_of_dvd_mul_left ih
+  | @even v c d hc hd hrec ih =>
+    have hcount : (false :: v).count false = v.count false + 1 := by simp
+    rw [hcount, pow_succ, mul_comm (2 ^ v.count false) 2]
+    -- goal: `2 * 2^k ∣ c`; rewrite `c = 2 * (c / 2)` and use `ih : 2^k ∣ c/2`
+    have hc2 : c = 2 * (c / 2) := by omega
+    rw [hc2]
+    exact mul_dvd_mul_left 2 ih
+
+/-- **At most `b` halvings for the dyadic class.**  For the residue class `r (mod 2^b)`, any
+valid certificate `v` has `v.count false ≤ b`: the divisibility invariant
+`2^(count false) ∣ 2^b` forces the number of even steps below `b`. -/
+theorem affValid_count_false_le_of_pow {v : List Bool} {b r : ℕ}
+    (hv : AffValid v (2 ^ b) r) : v.count false ≤ b := by
+  have hdvd : 2 ^ (v.count false) ∣ 2 ^ b := affValid_two_pow_count_false_dvd hv
+  exact (pow_dvd_pow_iff (by norm_num) (by simp)).mp hdvd
+
+/-- **Intrinsic length budget for the dyadic engine.**  Every valid certificate `v` for the
+residue class `r (mod 2^b)` has `v.length ≤ 2b+1`.  Combines `count false ≤ b`
+(`affValid_count_false_le_of_pow`) with `count true ≤ count false + 1`
+(`affValid_count_true_le_count_false_succ`): `length = count true + count false ≤ 2·count false + 1
+≤ 2b+1`.  This is the bound that `affValid_prefix_deriveVec_pow` previously had to *assume*. -/
+theorem affValid_length_le_of_pow {v : List Bool} {b r : ℕ}
+    (hv : AffValid v (2 ^ b) r) : v.length ≤ 2 * b + 1 := by
+  have hf := affValid_count_false_le_of_pow hv
+  have ht := affValid_count_true_le_count_false_succ hv
+  have hsum := count_true_add_count_false v
+  omega
+
+/-- **Prefix maximality for the dyadic engine — fully unconditional.**  For the residue class
+`r (mod 2^b)`, *every* valid certificate `v` (no length hypothesis) is a prefix of the canonical
+window `deriveVec (2b+1) (2^b) r`.  This is `affValid_prefix_deriveVec_pow` with its input budget
+`v.length ≤ 2b+1` now discharged intrinsically by `affValid_length_le_of_pow`, so the canonical
+window `deriveVec (2b+1) …` provably contains every certificate for the class. -/
+theorem affValid_prefix_deriveVec_pow_of_pow {b r : ℕ} {v : List Bool}
+    (hv : AffValid v (2 ^ b) r) :
+    v <+: deriveVec (2 * b + 1) (2 ^ b) r :=
+  affValid_prefix_deriveVec_pow hv (affValid_length_le_of_pow hv)
+
 end CollatzStructuredOQ02OQ03

--- a/research/problems/collatz-structured-oq-02-oq-03/knowledge.md
+++ b/research/problems/collatz-structured-oq-02-oq-03/knowledge.md
@@ -789,3 +789,36 @@ Five theorems (Part XII cont.):
   (even steps drop it by 1, odd steps preserve it) — would make `affValid_prefix_deriveVec_pow`
   unconditional. My count bound is a partial ingredient (bounds #odd, not yet the length).
 - Terras natural-density-1 remains the only real lever; `tao_2019` BLOCKED.
+
+## Session 2026-07-19 (researcher-1) — the intrinsic length budget `v.length ≤ 2b+1` (DONE, unconditionalizes the prefix engine)
+
+**Mode**: REVISIT (RICH, score 67). **Outcome**: progress — 4 axiom-free theorems in
+`CollatzStructuredOQ02OQ03CertUnique.lean`, closing the exact next-step flagged since Part XII.
+
+The prior count bound `affValid_count_true_le_count_false_succ` controls #odd via #even but left
+`v.length ≤ 2·(count false)+1` hostage to how large `count false` can grow. The missing half — a
+bound on the *even* steps — is now proved via the **2-adic valuation of the lead coefficient**:
+
+- `affValid_two_pow_count_false_dvd : AffValid v c d → 2^(v.count false) ∣ c`. Induction on the
+  certificate: nil trivial; **odd** step `c ↦ 3c` preserves v₂ (Coprime (2^k) 3 via
+  `Nat.Coprime.pow_left _ (by decide)`, then `hcop.dvd_of_dvd_mul_left ih` peels the 3); **even**
+  step `c ↦ c/2` gains one factor (`pow_succ`, `c = 2*(c/2)` by omega on `c%2=0`,
+  `mul_dvd_mul_left 2 ih`). **Axioms: [propext, Quot.sound] only** (no Classical.choice).
+- `affValid_count_false_le_of_pow : AffValid v (2^b) r → v.count false ≤ b`. From
+  `2^(count false) ∣ 2^b` via `(pow_dvd_pow_iff (by norm_num) (by simp)).mp` — note this uses the
+  divisibility/NoZeroDivisors `pow_dvd_pow_iff` (ℕ is CancelCommMonoidWithZero), NOT the ordered
+  `pow_le_pow_iff_right'` (fails instance synth on ℕ) and NOT `pow_dvd_pow_iff_le_right` (unknown id).
+- `affValid_length_le_of_pow : AffValid v (2^b) r → v.length ≤ 2*b+1`. `omega` on count false ≤ b,
+  count true ≤ count false + 1, count true + count false = length.
+- `affValid_prefix_deriveVec_pow_of_pow : AffValid v (2^b) r → v <+: deriveVec (2*b+1) (2^b) r` —
+  the **fully unconditional** prefix-maximality: `affValid_prefix_deriveVec_pow` with its input
+  budget hypothesis `v.length ≤ 2b+1` now discharged intrinsically. The canonical window
+  `deriveVec (2b+1) …` provably contains EVERY certificate for the class, no length hypothesis.
+
+VERIFIED docker-build green (8577 jobs, 0 warnings). #print axioms on all = foundational only
+([propext, (Classical.choice,) Quot.sound]) — no `tao_2019`, no `sorryAx`, no `decide`.
+
+**Honest reach**: this is certificate-machinery infrastructure (makes the prefix engine turnkey),
+NOT a density push. `tao_2019` (Tao's log-density-1) remains BLOCKED; the length budget is a
+structural completeness fact about the residue-window engine, orthogonal to the drop criterion
+`3^a < 2^b`. Terras natural-density-1 remains the only real lever toward the target.

--- a/src/data/research/problems/collatz-structured-oq-02-oq-03.json
+++ b/src/data/research/problems/collatz-structured-oq-02-oq-03.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (researcher-1 2026-07-13, axiom-free, offline EXIT 0 [propext/Classical.choice/Quot.sound only]): Part XII (cont.) in CertUnique.lean quantifies the no-two-consecutive-odd shape law into a sharp count bound 2*(count true) <= length+1, i.e. triplings <= halvings+1 over every certified window (affValid_count_true_le_count_false_succ). This is the exact combinatorial content of odd/even adjacency but stays strictly weaker than the drop criterion 3^a<2^b. tao_2019 stays BLOCKED.",
+    "progressSummary": "PROGRESS (2026-07-19): proved the intrinsic length budget affValid_length_le_of_pow (v.length ≤ 2b+1) via the 2-adic-valuation divisibility invariant affValid_two_pow_count_false_dvd, unconditionalizing affValid_prefix_deriveVec_pow (new affValid_prefix_deriveVec_pow_of_pow — every certificate is a prefix of deriveVec (2b+1), no length hypothesis). 4 axiom-free theorems in CertUnique, docker green. tao_2019 still BLOCKED (infra, not a density push).",
     "builtItems": [
       "collatz_odd helper (collatz n = 3n+1 for odd n) in CollatzStructuredOQ02OQ03.lean",
       "mod_four_one_attainsBelow: n≡1 mod 4, n≥5 ⇒ AttainsBelow n (axiom-free)",
@@ -73,7 +73,11 @@
       "count_true_le_of_noTwoTrue / two_mul_count_true_le_of_isChain in CollatzStructuredOQ02OQ03CertUnique.lean (general: IsChain no-true-true => 2*count true <= length+1)",
       "count_true_add_count_false (Bool partition identity count true + count false = length)",
       "affValid_two_mul_count_true_le : AffValid v c d => 2*(v.count true) <= v.length+1",
-      "affValid_count_true_le_count_false_succ : AffValid v c d => v.count true <= v.count false + 1"
+      "affValid_count_true_le_count_false_succ : AffValid v c d => v.count true <= v.count false + 1",
+      "affValid_two_pow_count_false_dvd: AffValid v c d → 2^(v.count false) ∣ c (2-adic valuation invariant; odd steps preserve v₂, even steps drop it). CertUnique. Axioms: propext/Quot.sound only.",
+      "affValid_count_false_le_of_pow: AffValid v (2^b) r → v.count false ≤ b (≤ b halvings for the dyadic class).",
+      "affValid_length_le_of_pow: AffValid v (2^b) r → v.length ≤ 2*b+1 (intrinsic length budget).",
+      "affValid_prefix_deriveVec_pow_of_pow: fully-unconditional prefix maximality (deriveVec (2b+1) contains every certificate for the class; no length hypothesis)."
     ],
     "insights": [
       "The odd residue class n ≡ 1 (mod 4), n ≥ 5, deterministically drops below itself in 3 Collatz steps: 4m+1 → 12m+4 → 6m+2 → 3m+1, with 3m+1 < 4m+1 iff m ≥ 1. First elementary family exercising the 3n+1 branch (even/powers-of-two only touch the n/2 branch).",
@@ -95,7 +99,9 @@
       "Constant-term bound (Part XIII, ConstBound.lean): D+1 <= 3^(#odd)*(d+1) for the certified affine window. The mother module never bounded the constant D=(affOrbit v (c,d)).2. Odd fold d->3d+1 multiplies by 3 (the +1 absorbed by the (d+1) slack), even fold d->floor(d/2) shrinks; short structural induction generalized over both coordinates.",
       "This closes the gap that forced affine_residue_attainsBelow / parityVector_attainsBelow to carry a hand-checked D<r side condition, which only forces the drop at the boundary member m=0. With the constant bound, the leading criterion A<c ALONE gives a closed-form threshold 3^(#odd)*(d+1) <= (c-A)*m past which every class member drops (affValid_attainsBelow_of_large). So 3^a<2^b implies the class drops for cofinitely many members, no boundary caveat (affValid_attainsBelow_of_large_pow, classical 3^a<2^b headline).",
       "Part XIV (ExceptionalSet.lean): the non-dropping set of a determined-drop class (A<c) is EXPLICITLY FINITE, bounded by B=3^(#odd)·(d+1). Packaged Part XIII's division threshold B≤(c−A)·m into division-free m≥B (since A<c ⟹ c−A≥1 ⟹ (c−A)m≥m), then contrapositive: ¬AttainsBelow(c·m+d) ⟹ m<B, so the exceptional set ⊆ range B, card ≤ B uniformly in N. Answers the standing nextStep 'pin the exact finite set of non-dropping members per class' — it's a subset of [0,3^a(d+1)) of size ≤3^a(d+1). ★Built by IMPORTING the light companion ConstBound (NOT re-declaring): its olean builds green via targeted `LAKE_UNSAFE=1 ./bin/lake build Proofs.CollatzStructuredOQ02OQ03ConstBound` (64s, Mathlib cached) — the mother module is the only one at the SIGBUS ceiling. ★Finset.filter over a Prop pred needs `open scoped Classical`.",
-      "Part XII (cont.): the \"no two consecutive odd steps\" shape constraint quantifies to a sharp count bound 2*(v.count true) <= v.length + 1 for any valid certificate (general list lemma: any IsChain for \"true forces next false\" has at most ceil(len/2) trues, two-step budget induction). Corollary affValid_count_true_le_count_false_succ: #odd(triplings) <= #even(halvings) + 1 over every certified window. HONEST REACH: a <= b+1 is strictly weaker than the drop criterion 3^a < 2^b, so adjacency alone does NOT force a drop; this is the exact combinatorial content of odd/even adjacency, no more."
+      "Part XII (cont.): the \"no two consecutive odd steps\" shape constraint quantifies to a sharp count bound 2*(v.count true) <= v.length + 1 for any valid certificate (general list lemma: any IsChain for \"true forces next false\" has at most ceil(len/2) trues, two-step budget induction). Corollary affValid_count_true_le_count_false_succ: #odd(triplings) <= #even(halvings) + 1 over every certified window. HONEST REACH: a <= b+1 is strictly weaker than the drop criterion 3^a < 2^b, so adjacency alone does NOT force a drop; this is the exact combinatorial content of odd/even adjacency, no more.",
+      "The length budget v.length ≤ 2b+1 (flagged open since Part XII) is DONE via the 2-adic valuation of the lead coefficient c: every AffValid step needs c even; odd (c↦3c) preserves v₂(c), even (c↦c/2) drops it by 1, giving 2^(count false) ∣ c. For c=2^b this forces count false ≤ b, and with count true ≤ count false+1 gives length ≤ 2·count false+1 ≤ 2b+1.",
+      "Lemma-name gotcha (v4.31): for 2^a ∣ 2^b → a ≤ b use pow_dvd_pow_iff (divisibility/NoZeroDivisors, works on ℕ); pow_le_pow_iff_right! fails instance synth on ℕ and pow_dvd_pow_iff_le_right is not a resolvable identifier."
     ],
     "mathlibGaps": [],
     "nextSteps": [
@@ -123,7 +129,7 @@
     "mathlib": []
   },
   "started": "2026-03-30T18:39:05.245Z",
-  "lastUpdate": "2026-07-13",
+  "lastUpdate": "2026-07-19",
   "leanFiles": [
     {
       "path": "Proofs/CollatzStructured.lean",


### PR DESCRIPTION
## Summary
Research session for `collatz-structured-oq-02-oq-03`. Closes the concrete next step flagged since
Part XII: the intrinsic certificate length budget `v.length ≤ 2b+1`, which makes the dyadic
prefix engine `affValid_prefix_deriveVec_pow` fully unconditional.

## Progress
Four axiom-free theorems appended to `proofs/Proofs/CollatzStructuredOQ02OQ03CertUnique.lean`:
- **`affValid_two_pow_count_false_dvd`** — `AffValid v c d → 2^(v.count false) ∣ c`. The 2-adic
  valuation invariant: every step needs `c` even; odd steps `c ↦ 3c` preserve `v₂(c)` (coprimality
  of `2^k` and `3`), even steps `c ↦ c/2` consume one factor of 2. Proved by induction on the
  certificate. (Axioms: `propext, Quot.sound` only.)
- **`affValid_count_false_le_of_pow`** — `AffValid v (2^b) r → v.count false ≤ b`. From
  `2^(count false) ∣ 2^b`.
- **`affValid_length_le_of_pow`** — `AffValid v (2^b) r → v.length ≤ 2b+1`. Combines
  `count false ≤ b` with the prior `count true ≤ count false + 1`.
- **`affValid_prefix_deriveVec_pow_of_pow`** — fully unconditional prefix maximality: *every* valid
  certificate for the class `r (mod 2^b)` (no length hypothesis) is a prefix of `deriveVec (2b+1) (2^b) r`.

## Findings
- The length bound was the missing half of the Part XII count analysis: the earlier
  `affValid_count_true_le_count_false_succ` controlled #odd via #even but not the total length; the
  2-adic valuation caps #even at `b`, closing the gap.
- Lemma-name note (v4.31): `2^a ∣ 2^b → a ≤ b` goes via `pow_dvd_pow_iff` (divisibility /
  NoZeroDivisors, valid on ℕ); the ordered `pow_le_pow_iff_right'` fails instance synthesis on ℕ.

## Verification
- `docker-build.sh Proofs.CollatzStructuredOQ02OQ03CertUnique` → green (8577 jobs, 0 warnings).
- `#print axioms` on all four = foundational only (`[propext, (Classical.choice,) Quot.sound]`) —
  no `tao_2019`, no `sorryAx`, no `decide`.

## Status
**Outcome**: progress (axiom-free certificate infrastructure). Honest: this is engine machinery
(turnkey prefix completeness), **not** a density push — `tao_2019` (Tao's logarithmic-density-1)
remains BLOCKED; the length budget is orthogonal to the drop criterion `3^a < 2^b`.
**Next Steps**: Terras natural-density-1 remains the only real lever toward the target.

🤖 Generated by researcher-1