### PR TITLE
Research: lagrange-theorem-oq-01 — triage: corpus saturated, 4 Hall axioms irreducible on v4.31

### DIFF
--- a/research/problems/lagrange-theorem-oq-01/knowledge.md
+++ b/research/problems/lagrange-theorem-oq-01/knowledge.md
@@ -1,0 +1,39 @@
+# Knowledge Base: lagrange-theorem-oq-01
+
+**Problem**: Can the Sylow theorems / partial converse of Lagrange be formalized? (finite-group
+order-classification programme built on Lagrange's theorem)
+
+## Current state (triage 2026-07-19, researcher-1)
+
+The `LagrangeTheorem*` corpus is large (32 files) and mature. A corpus-wide scan found:
+
+- **0 real sorries** anywhere (`grep` hits are all docstring prose like "0-sorry / 0-axiom").
+- **4 `axiom` declarations, all Hall's theorem for solvable groups** — genuinely irreducible
+  against Mathlib v4.31:
+  - `LagrangeTheoremOQ01OQ03.lean`: `hall_solvable`, `hall_characterizes_solvability`
+  - `LagrangeTheoremOQ03.lean`: `hall_existence`, `hall_conjugacy`
+  - **Why irreducible:** Mathlib has only the *combinatorial* Hall marriage theorem
+    (`Mathlib/Combinatorics/Hall`) and `SchurZassenhaus` (the coprime-normal special case). There
+    is **no** general Hall π-subgroup existence/conjugacy theorem for finite solvable groups in
+    Mathlib. So these 4 axioms cannot currently be discharged. (Reopen criterion: Mathlib upstreams
+    a general solvable-group Hall theorem.)
+
+## Extensions (from the tracker's currentState) — status
+
+- **(b) order-p² groups are abelian, cyclic vs (ℤ/p)² fork — DONE.** `LagrangeTheoremOQ01PSquare.lean`
+  (0 sorry / 0 axiom): `card_prime_sq_commutative`, `commGroupOfCardPrimeSq`, the dichotomy
+  `card_prime_sq_cyclic_or_pow_p_eq_one`, plus concrete orders 4/9/25/49. Wraps Mathlib
+  `IsPGroup.isMulCommutative_of_card_eq_prime_sq`.
+- **(a) nonabelian order-pq witness (ℤ/q⋊ℤ/p when q≡1 mod p)** — the corpus already carries
+  dihedral / semidirect / metacyclic content (`LagrangeTheoremOQ01OQ01*`, `OQ09`); the pq
+  cyclic-vs-metacyclic dichotomy is recorded as CLOSED in the tracker. Any remaining witness-
+  construction refinement would be a `SemidirectProduct` build — genuinely finicky, verify against
+  existing files before starting to avoid duplication.
+- **(c) order p²q / p³ classification** — hard, multi-session; not attempted.
+
+## Assessment
+
+No session-sized formalization gap: the tractable order-classification extensions (p², pq) are
+complete, the deep Hall axioms are blocked on missing Mathlib infrastructure, and there are no
+sorries to eliminate. Deeper classifications (p²q, p³) are multi-session. Recorded for the next
+researcher so the Mathlib-Hall check and the corpus sorry/axiom scan need not be repeated.

--- a/src/data/research/problems/lagrange-theorem-oq-01.json
+++ b/src/data/research/problems/lagrange-theorem-oq-01.json
@@ -20,7 +20,13 @@
     "since": "2026-03-28T20:57:10.258Z",
     "iteration": 1,
     "focus": "Initial exploration of the problem.",
-    "blockers": [],
+    "blockers": [
+      {
+        "route": "eliminate the 4 Hall-subgroup axioms (hall_existence/conjugacy/solvable/characterizes_solvability)",
+        "reopenCriterion": "Mathlib upstreams a general Hall π-subgroup existence+conjugacy theorem for finite solvable groups (currently only Combinatorics/Hall marriage + SchurZassenhaus exist)",
+        "blockedAt": "2026-07-19"
+      }
+    ],
     "nextAction": "Begin problem exploration.",
     "attemptCounts": {
       "total": 0,
@@ -29,7 +35,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "Order-pq classification CLOSED (prior). This session: REPAIRED Mathlib-drift build breakage in the Hall-subgroup companion LagrangeTheoremOQ01OQ03.lean (was silently failing against pinned mathlib 2df2f01 — CI cache masked it) AND added the p-group branch of the converse of Lagrange. Drift fixes: hall_trivial_bot via Subgroup.card_bot; exists_prime_orderOf_dvd_card now [Fact p.Prime]-instance form; orderOf_pow_div_of_dvd needs [Finite G] + Nat.div_div_self's m≠0 arg; hall_solvability_necessary reproved (alternatingGroup.center_eq_bot + IsSimpleGroup.comm_iff_isSolvable, A₅ nonabelian via trivial centre); imports → `import Mathlib`. New theory: converse_lagrange_pgroup (finite p-group has a subgroup of EVERY divisor order — full converse of Lagrange, 2nd class after cyclic) + isHallDivisor_prime_pow (Hall divisors of pⁿ are only 1 and pⁿ) + hall_pgroup_hall_divisor + not_isHallDivisor_two_eight. Host-verified EXIT 0, axioms=[propext,Classical.choice,Quot.sound] for all new/repaired thms; file still 0-sorry, 2 pre-existing deep axioms (hall_solvable, hall_characterizes_solvability) untouched.",
+    "progressSummary": "SATURATED on the tractable side (triage 2026-07-19): corpus (32 files) has 0 real sorries; the 4 remaining axioms are all Hall-theorem-for-solvable-groups, irreducible against Mathlib v4.31 (only combinatorial Hall + SchurZassenhaus exist, no general solvable Hall existence/conjugacy). Extensions p² (PSquare file) and pq (dichotomy CLOSED) done; p²q/p³ multi-session. Populated the empty knowledge.md with this assessment.",
     "builtItems": [
       "LagrangeTheoremOQ01.lean: ~140 lines, 11 theorems, 0 sorries, 0 axioms",
       "Parts I-V: Lagrange, Sylow existence, conjugacy, counting, partial converse + Cauchy",
@@ -106,7 +112,7 @@
     "mathlib": []
   },
   "started": "2026-03-28T20:57:10.258Z",
-  "lastUpdate": "2026-03-28T20:57:10.258Z",
+  "lastUpdate": "2026-07-19",
   "significance": 6,
   "tractability": 5,
   "leanFiles": [


### PR DESCRIPTION
## Summary
Re-claim triage of `lagrange-theorem-oq-01` (RICH). Doc-only: no session-sized formalization gap
in the 32-file `LagrangeTheorem*` order-classification corpus.

## Finding
Corpus-wide scan:
- **0 real sorries** anywhere (all `grep` hits are docstring prose).
- **4 `axiom`s, all Hall's theorem for solvable groups** — `hall_existence`, `hall_conjugacy`
  (`LagrangeTheoremOQ03`), `hall_solvable`, `hall_characterizes_solvability`
  (`LagrangeTheoremOQ01OQ03`). **Irreducible against Mathlib v4.31**: Mathlib has only the
  *combinatorial* Hall marriage theorem (`Mathlib/Combinatorics/Hall`) and `SchurZassenhaus` (the
  coprime-normal special case), not a general Hall π-subgroup existence/conjugacy theorem for
  finite solvable groups. Recorded as a structured blocker with reopen criterion.
- Tractable extensions **done**: order-p² abelian + cyclic-vs-`(ℤ/p)²` fork
  (`LagrangeTheoremOQ01PSquare.lean`, 0 sorry/0 axiom); order-pq cyclic-vs-metacyclic dichotomy
  CLOSED. Order p²q / p³ classifications are multi-session.

## Changes
- Created the previously-empty `knowledge.md` with the current-state assessment.
- Tracker: structured Hall-axiom blocker + progressSummary.

## Status
**Outcome**: surveyed / saturated on the tractable side (no new Lean). Recorded so future sessions
skip the Mathlib-Hall check and the corpus sorry/axiom re-scan.

🤖 Generated by researcher-1