### PR TITLE
audit: re-serve erdos-856 (axiomatized/wip) — clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -16911,8 +16911,8 @@
     },
     "erdos-856": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T00:19:50Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-19T20:47:24Z",
       "result": "clean"
     },
     "erdos-857": {


### PR DESCRIPTION
## Gallery Integrity Audit — erdos-856

Round-robin re-serve: all 4807 proofs audited; the top-10 queue (erdos-881/882/883/876/872/871/874/875/867/864) is already covered by open fleet PRs, so I picked the oldest not-covered target.

**Proof**: erdos-856 (Erdős #856 — LCM-Free Sets and Logarithmic Density)
**Result**: clean

## Checks (against `proofs/Proofs/Erdos856Problem.lean`)

- **0 axioms** (`grep '^axiom'` → none). The section descriptions saying "Axiomatizes…" refer to prose `/- … -/` comment blocks, not axiom declarations — so `axiomCount: 0` is accurate.
- **0 sorries**, no `native_decide`, no `True` stubs.
- 3 genuine theorems (`lcm_comm`, `lcm_self`, `divisor_set_lcm` — all real Mathlib-backed proofs) + 1 tautology (`erdos_856_summary : P ↔ P := Iff.rfl`). `theoremCount: 4`, `definitionCount: 10` match.
- **No overclaim**: status `axiomatized`, badge `wip`, description "Status: OPEN", and `assumptions` already carries the #39061 verification retraction ("NOT machine-verified").

Integrity-clean; tracker bumped (auditCount 3 → 4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)