### PR TITLE
audit: re-serve erdos-849 (axiomatized) — clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -16863,8 +16863,8 @@
     },
     "erdos-849": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T00:19:51Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-19T20:52:32Z",
       "result": "clean"
     },
     "erdos-85": {


### PR DESCRIPTION
## Gallery Integrity Audit — erdos-849

**Proof**: Erdős Problem #849 — Binomial Coefficient Multiplicities
**Result**: ✅ clean (no integrity issues)

Re-served from the oldest-audit round-robin (last audited 2026-05-04; 3 prior audits). Not covered by any other open PR.

### Verification (meta.json vs `proofs/Proofs/Erdos849Problem.lean`)

| Field | meta | actual |
|-------|------|--------|
| lineCount | 193 | 193 ✓ |
| axiomCount | 3 | 3 ✓ (`two_multiplicity`, `multiplicity_120`, `multiplicity_3003`) |
| sorries | 0 | 0 ✓ |
| theoremCount | 15 | 15 ✓ |
| definitionCount | 4 | 4 ✓ |

- No `True` stubs. `status: axiomatized` / `badge: axiom` correctly reflects the axiomatized Singmaster-style facts.
- 11 `native_decide` uses are confined to concrete binomial-coefficient checks (e.g. `C(10,3)=120`, `C(14,6)=3003`) and are **disclosed** in meta ("Using native_decide to verify …"). No hidden trust shift on the core result.
- `originalContributions` honestly scoped — Singmaster's conjecture is stated as an axiom, examples labeled "Verified examples".

Only the audit tracker timestamp is updated.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)