### PR TITLE
audit: re-serve erdos-850 (axiomatized) — clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -16875,8 +16875,8 @@
     },
     "erdos-850": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T00:19:51Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-19T20:54:20Z",
       "result": "clean"
     },
     "erdos-851": {


### PR DESCRIPTION
## Gallery Integrity Audit — erdos-850

**Proof**: Erdős #850 — Same Prime Factors for Three Consecutive Shifts (Erdős-Woods)
**Result**: ✅ clean (no integrity issues)

Re-served from the oldest-audit round-robin (last audited 2026-05-04). Not covered by any other open PR.

### Verification (meta.json vs `proofs/Proofs/Erdos850Problem.lean`)

| Field | meta | actual |
|-------|------|--------|
| axiomCount | 1 | 1 ✓ (`shorey_tijdeman`) |
| sorries | 0 | 0 ✓ |
| theoremCount | 11 | 11 ✓ |
| definitionCount | 8 | 8 ✓ |
| lineCount | 158 | 164 (harmless stale undercount) |

- No `True` stubs. `status: axiomatized` / `badge: axiom` correct.
- Sole axiom `shorey_tijdeman : StrongABCConjecture → ErdosProblem850` is a disclosed conditional result — the core claim rests on it, and it is labeled "(axiom)" in `originalContributions`.
- No hidden assumption-carrying structure fields — all 8 definitions are plain `def`/`abbrev`.
- `native_decide`/`decide` are confined to concrete example checks (Makowski `(75,1215)`, small parametric cases), not the core result. Meta makes no contradicting "machine-verified"/kernel claim ("kernel" in the text = *squarefree kernel*).

Minor observation (not blocking): unlike erdos-849, this entry does not mention its `native_decide` use in `assumptions`; disclosing it in a future enrichment pass would improve consistency.

Only the audit tracker timestamp is updated.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)