### PR TITLE
audit: re-serve erdos-857 (axiomatized) — clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -16917,8 +16917,8 @@
     },
     "erdos-857": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T00:19:51Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-19T20:55:20Z",
       "result": "clean"
     },
     "erdos-858": {


### PR DESCRIPTION
## Gallery Integrity Audit — erdos-857

**Proof**: Erdős #857 — The Weak Sunflower Problem
**Result**: ✅ clean (no integrity issues)

Re-served from the oldest-audit round-robin (last audited 2026-05-04). Not covered by any other open PR.

### Verification (meta.json vs `proofs/Proofs/Erdos857Problem.lean`)

| Field | meta | actual |
|-------|------|--------|
| axiomCount | 3 | 3 ✓ (`sunflower_number_exists`, `erdos_ko_rado_sunflower`, `naslund_sawin_bound`) |
| sorries | 0 | 0 ✓ |
| theoremCount | 5 | 5 ✓ |
| definitionCount | 5 | 5 ✓ |
| lineCount | 289 | 287 (negligible 2-line overcount) |

- No `True` stubs, no `native_decide`, no structures (no hidden assumption-carrying fields).
- Core mathematical content (Erdős-Ko-Rado bound, Naslund-Sawin bound) is **axiomatized** and labeled `axiom` in `originalContributions`. Dependent theorems are honestly described — `erdos_857_summary` transparently re-exports the EKR axiom, `bounded_sets_sunflower` is described as a corollary "from EKR".
- `status: axiomatized` / `badge: axiom` correctly reflect the reduction.

Only the audit tracker timestamp is updated.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)