### PR TITLE
Fix: repair never-compiled Erdos1119Problem (Erdős #1119) for v4.31 — batch of #39077

### DIFF
--- a/proofs/Proofs/Erdos1119Problem.lean
+++ b/proofs/Proofs/Erdos1119Problem.lean
@@ -29,11 +29,17 @@ import Mathlib.SetTheory.Cardinal.Continuum
 import Mathlib.Topology.Basic
 import Mathlib.Analysis.Complex.Basic
 
-set_option autoImplicit true
+set_option autoImplicit false
 
 namespace Erdos1119
 
 open Cardinal Set
+
+-- Index type for a family of entire functions {f_α : α ∈ ι}.
+-- Declared explicitly (previously bound silently via `autoImplicit`).
+-- Fixed at universe 0 so that `#ι` lives in `Cardinal.{0}`, matching
+-- `continuum`, `ℵ₀`, and the parameter `m : Cardinal`.
+variable {ι : Type}
 
 /- ## Part I: Basic Definitions -/
 

--- a/src/data/proofs/erdos-1119/meta.json
+++ b/src/data/proofs/erdos-1119/meta.json
@@ -57,8 +57,8 @@
       "erdos_1119_summary theorem"
     ],
     "axiomCount": 3,
-    "lineCount": 133,
-    "assumptions": "AUDIT (issue #39061): NOT machine-verified. This entry never validly compiled. Even under Lean v4.26 the proof only 'passed' because the old `autoImplicit true` default silently bound the undefined identifier `ι` as a free implicit variable, rendering the stated theorem vacuously general; under v4.31 (autoImplicit off by default) the file fails with `unknownIdentifier 'ι'` and typically additional genuine proof errors. The verification claims below are therefore retracted pending a Lean-source repair (Class A). ORIGINAL METADATA: 3 axioms: IsEntire (entire function predicate — axiomatized), erdos_1964_wetzel (Erdős 1964 — if ¬CH then Wetzel families of entire functions are countable), easy_case (intermediate cardinality case ℵ₁ < m < 𝔠 via diagonalization). 0 sorries.",
+    "lineCount": 141,
+    "assumptions": "Machine-checked under Lean v4.31.0 with `set_option autoImplicit false`: 0 sorries, builds clean (verified during #39077 repair). REPAIR (Class A, issue #39061/#39077): the file previously relied on the old `autoImplicit true` default to silently bind the index type `ι` as a free implicit; under v4.31 (autoImplicit off) this fails with `unknownIdentifier 'ι'`. Repaired by declaring `variable {ι : Type}` explicitly (fixed at universe 0 so `#ι` lives in `Cardinal.{0}`, matching `continuum`/`ℵ₀`/`m`) and setting `set_option autoImplicit false` as a guard. The entry remains legitimately `axiomatized`: 3 axioms encode the mathematical content — IsEntire (entire-function predicate, axiomatized since full complex-analysis formalization is extensive), erdos_1964_wetzel (Erdős 1964: if ¬CH then Wetzel families of entire functions are countable), and easy_case (Hayman 1974: 𝔪⁺ < 𝔠 implies the family has size ≤ 𝔪 via diagonalization over value sets). The Kumar-Shelah (2017) and Schilhan-Weinert (2024) independence results are documented in source comments only, not as Lean axioms. `erdos_1119_summary` combines erdos_1964_wetzel and easy_case by `exact ⟨...⟩`.",
     "theoremCount": 2,
     "definitionCount": 6
   },
@@ -258,7 +258,7 @@
       "Set"
     ],
     "namespace": "Erdos1119",
-    "lineCount": 133,
+    "lineCount": 141,
     "axiomCount": 3,
     "theoremCount": 2,
     "definitionCount": 6,


### PR DESCRIPTION
## What

Repairs `proofs/Proofs/Erdos1119Problem.lean`, one of the 28 never-compiled entries tracked by #39077 (Class A — undefined-identifier / autoImplicit-masked). Genuine defect, not a false positive.

## Root cause

The index type `ι` (used in `family : ι → (ℂ → ℂ)` and cardinality bounds `#ι ≤ …` throughout) was never declared. Under the old `autoImplicit true` default it was silently bound as a free implicit; under v4.31 (autoImplicit off) the file fails with `unknownIdentifier 'ι'`.

## Fix

- Declare `variable {ι : Type}` explicitly, **fixed at universe 0** so `#ι` lives in `Cardinal.{0}`, matching `continuum`, `ℵ₀`, and the parameter `m : Cardinal` (using `Type*` instead produced universe-mismatch errors on `m` — autoImplicit had originally unified `ι` at universe 0).
- Add `set_option autoImplicit false` as a regression guard.
- meta.json: retire the #39061 audit retraction in `assumptions`, note the repair; bump `lineCount` 133 → 141.

## Evidence

Before: `unexpected token` / `unknownIdentifier 'ι'` under v4.31.
After (`./proofs/scripts/docker-build.sh Proofs.Erdos1119Problem`, Lean v4.31.0):

```
✔ [1851/1851] Built Proofs.Erdos1119Problem (752ms)
Build completed successfully (1851 jobs).
=== Build succeeded ===
```

## Status unchanged

Remains `axiomatized` / badge `axiom` — 3 axioms (IsEntire, erdos_1964_wetzel, easy_case) encode genuine mathematical assumptions per the Axiom Integrity Policy. 0 sorries. No badge upgrade claimed.

Part of #39077.