### PR TITLE
Research: erdos-1138-oq-03-oq-01 — primes in short intervals from BHP

### DIFF
--- a/proofs/Proofs/Erdos1138OQ03OQ01.lean
+++ b/proofs/Proofs/Erdos1138OQ03OQ01.lean
@@ -725,4 +725,71 @@ theorem maxPrimeGap_unbounded_and_sublinear :
       Tendsto (fun x : ℕ => (maxPrimeGap x : ℝ) / x) atTop (𝓝 0) :=
   ⟨maxPrimeGap_cast_tendsto_atTop, bhp_implies_gap_littleo⟩
 
+-- ============================================================================
+-- Part: Primes in short intervals (localisation consequence of BHP)
+-- ============================================================================
+
+/-- **Primes in short intervals, from Baker–Harman–Pintz.** For every `ε > 0`,
+every sufficiently large `x` contains a prime in the half-open interval
+`(x, (1 + ε)·x]`.
+
+This is a genuinely new *localisation* consequence of BHP-sublinearity, not a
+repackaging of the `maxPrimeGap` asymptotics: those record the *size* of the
+largest gap below `x`, whereas this asserts a prime exists in a *specific short
+window* above `x`. The proof pairs the largest prime `p ≤ x` (`Nat.findGreatest`)
+with the next prime `q` (`Nat.find`); consecutiveness plus Bertrand's postulate
+(`prime_gap_le_prev_prime`) give `q ≤ 2x`, so the gap `q - p` lies in
+`primeGapSet (2x)` and is bounded by `maxPrimeGap (2x)`. BHP-sublinearity applied
+at scale `2x` (the `ε/2` envelope pulled back along `x ↦ 2x`) forces
+`maxPrimeGap (2x) ≤ ε·x` eventually, whence `q - x ≤ q - p ≤ ε·x`, i.e.
+`q ≤ (1 + ε)·x`. Depends only on the parent `baker_harman_pintz` axiom. -/
+theorem bhp_prime_in_short_interval (ε : ℝ) (hε : 0 < ε) :
+    ∀ᶠ x : ℕ in atTop,
+      ∃ q : ℕ, Nat.Prime q ∧ (x : ℝ) < q ∧ (q : ℝ) ≤ (1 + ε) * x := by
+  classical
+  -- `maxPrimeGap` at scale `2x` is eventually `≤ ε·x` (BHP-sublinearity, ε/2 form).
+  have hhalf : (0 : ℝ) < ε / 2 := by positivity
+  have hgap := bhp_gap_eventually_le_eps (ε / 2) hhalf
+  have hmap : Tendsto (fun x : ℕ => 2 * x) atTop atTop :=
+    tendsto_atTop_atTop_of_monotone (fun a b h => by omega) (fun n => ⟨n, by omega⟩)
+  have htwo := hmap.eventually hgap
+  filter_upwards [htwo, eventually_ge_atTop 2] with x hbound hx2
+  -- `p` := largest prime `≤ x`.
+  set p := Nat.findGreatest Nat.Prime x with hp_def
+  have hp_prime : Nat.Prime p := Nat.findGreatest_spec (m := 2) hx2 Nat.prime_two
+  have hp_le : p ≤ x := Nat.findGreatest_le _
+  -- `q` := least prime `> x`.
+  have hqex : ∃ m, x < m ∧ Nat.Prime m := by
+    obtain ⟨r, hr_ge, hr_prime⟩ := Nat.exists_infinite_primes (x + 1)
+    exact ⟨r, by omega, hr_prime⟩
+  set q := Nat.find hqex with hq_def
+  obtain ⟨hxq, hq_prime⟩ := Nat.find_spec hqex
+  have hpq : p < q := by omega
+  -- Consecutiveness: no prime lies strictly between `p` and `q`.
+  have hcons : ∀ r, Nat.Prime r → p < r → q ≤ r := by
+    intro r hr hpr
+    have hxr : x < r := by
+      by_contra hc
+      exact (Nat.findGreatest_is_greatest hpr (not_lt.mp hc)) hr
+    exact Nat.find_le ⟨hxr, hr⟩
+  -- Gap `≤ p` (Bertrand), hence `q ≤ 2x`.
+  have hgap_le : q - p ≤ p := prime_gap_le_prev_prime p q hp_prime hq_prime hpq hcons
+  have hq2x : q ≤ 2 * x := by omega
+  -- The gap lies in `primeGapSet (2x)`, so is `≤ maxPrimeGap (2x)`.
+  have hmem : (q - p) ∈ primeGapSet (2 * x) :=
+    ⟨p, q, hp_prime, hq_prime, hpq, hq2x, hcons, rfl⟩
+  have hle : (q - p) ≤ maxPrimeGap (2 * x) := le_csSup (primeGapSet_bddAbove _) hmem
+  -- Cast to `ℝ` and finish: `q - x ≤ q - p ≤ maxPrimeGap (2x) ≤ ε·x`.
+  refine ⟨q, hq_prime, by exact_mod_cast hxq, ?_⟩
+  have hcastgap : ((q - p : ℕ) : ℝ) = (q : ℝ) - p := by
+    rw [Nat.cast_sub (le_of_lt hpq)]
+  have hle_real : (q : ℝ) - p ≤ (maxPrimeGap (2 * x) : ℝ) := by
+    rw [← hcastgap]; exact_mod_cast hle
+  have hbound' : (maxPrimeGap (2 * x) : ℝ) ≤ ε * x := by
+    have hcast : (ε / 2) * ((2 * x : ℕ) : ℝ) = ε * x := by push_cast; ring
+    rw [hcast] at hbound; exact hbound
+  have hp_le_real : (p : ℝ) ≤ x := by exact_mod_cast hp_le
+  have expand : (1 + ε) * x = x + ε * x := by ring
+  rw [expand]; linarith [hle_real, hbound', hp_le_real]
+
 end Erdos1138OQ03

--- a/research/problems/erdos-1138-oq-03-oq-01/knowledge.md
+++ b/research/problems/erdos-1138-oq-03-oq-01/knowledge.md
@@ -1,5 +1,42 @@
 # Knowledge: erdos-1138-oq-03-oq-01 — BHP ⟹ prime gaps are sublinear
 
+## Session 2026-07-19 (researcher-1): LOCALISATION — primes in short intervals from BHP (VERIFIED)
+
+**Mode**: REVISIT (RICH, saturated for asymptotics). **Outcome**: progress — added the one
+genuinely-new tractable direction repeatedly flagged (researcher-3 2026-07-12) as the only
+non-cosmetic remaining lever.
+
+### What I did
+Added `bhp_prime_in_short_interval` — the **localisation** consequence of BHP-sublinearity,
+which is *not* a repackaging of the `maxPrimeGap` asymptotics (those measure the *size* of the
+largest gap below x; this asserts a prime exists in a *specific short window* above x):
+
+```lean
+theorem bhp_prime_in_short_interval (ε : ℝ) (hε : 0 < ε) :
+    ∀ᶠ x : ℕ in atTop,
+      ∃ q : ℕ, Nat.Prime q ∧ (x : ℝ) < q ∧ (q : ℝ) ≤ (1 + ε) * x
+```
+
+**Construction** (the ~50-line piece researcher-3 deferred, now built): `p := Nat.findGreatest
+Nat.Prime x` (largest prime ≤ x), `q := Nat.find` (least prime > x). Consecutiveness
+`∀ r prime, p<r → q≤r` from `Nat.findGreatest_is_greatest` (r≤x prime > p is impossible) +
+`Nat.find_le`. Bertrand (`prime_gap_le_prev_prime`, already in parent) gives `q-p ≤ p`, so
+`q ≤ 2x`, hence `q-p ∈ primeGapSet (2x)` and `q-p ≤ maxPrimeGap (2x)` (`le_csSup`). Pull the
+`ε/2` envelope `bhp_gap_eventually_le_eps` back along `x ↦ 2x` via `Tendsto.eventually` →
+`maxPrimeGap (2x) ≤ εx` eventually. Then `q-x ≤ q-p ≤ εx` gives `q ≤ (1+ε)x`.
+
+### Verification
+`docker-build.sh Proofs.Erdos1138OQ03OQ01` EXIT 0 (`[8577/8577]`, 3.5s), 0 sorries.
+`#print axioms Erdos1138OQ03.bhp_prime_in_short_interval` = `[propext, baker_harman_pintz,
+Classical.choice, Quot.sound]` — no new axioms, no native_decide, no sorryAx. axiomCount stays 1.
+Also synced the badly-stale gallery meta (`.meta` 16 thm / 418 L, `.leanFile` 29/418) to the
+actual **36 thm / 795 L** at both `.meta.*` and `.leanFile.*`.
+
+### Next steps
+Entry is now saturated for elementary/abstract AND localisation work. The only remaining lever
+is proving/replacing the deep parent `baker_harman_pintz` axiom (analytic NT, out of session
+scope). Recommend marking the entry COMPLETED to stop depth-first re-serving as accretion-bait.
+
 ## Session 2026-07-13 (researcher-2): ORTHOGONAL LOWER BOUND — prime gaps unbounded (axiom-free)
 
 **Mode**: REVISIT (problem marked COMPLETE for sublinearity). **Outcome**: progress (new verified theorems).

--- a/src/data/proofs/erdos-1138-oq-03-oq-01/meta.json
+++ b/src/data/proofs/erdos-1138-oq-03-oq-01/meta.json
@@ -52,9 +52,9 @@
     "dateAdded": "2026-07-05",
     "mathlib_version": "4.31.0",
     "axiomCount": 1,
-    "lineCount": 418,
+    "lineCount": 795,
     "assumptions": "1 axiom, inherited from the parent Erdos1138OQ03: baker_harman_pintz (maxPrimeGap x <= x^0.525 for x >= 25). No axiom is declared in this file (leanFile.axiomCount = 0); the assumption is imported. #print axioms confirms the results depend only on {propext, Classical.choice, Quot.sound, Erdos1138OQ03.baker_harman_pintz}. No sorries, no native_decide.",
-    "theoremCount": 16,
+    "theoremCount": 36,
     "definitionCount": 0
   },
   "overview": {
@@ -143,9 +143,9 @@
       "Topology"
     ],
     "namespace": "Erdos1138OQ03",
-    "lineCount": 418,
+    "lineCount": 795,
     "axiomCount": 0,
-    "theoremCount": 29,
+    "theoremCount": 36,
     "definitionCount": 0,
     "path": "Proofs/Erdos1138OQ03OQ01.lean",
     "sorries": 0

--- a/src/data/research/problems/erdos-1138-oq-03-oq-01.json
+++ b/src/data/research/problems/erdos-1138-oq-03-oq-01.json
@@ -17,12 +17,12 @@
   },
   "currentState": {
     "phase": "PROGRESS",
-    "since": "2026-07-11",
-    "iteration": 2,
-    "focus": "Verified the file builds (built parent Erdos1138OQ03 olean, then OQ01 via lake env lean, EXIT 0). Added normalised-gap decay-rate results gap_div_isBigO_rpow_neg (O(x^(-0.475))) + abstract engine gap_div_isBigO_rpow_sub_one_of_rpow_bound (O(x^(θ-1))); cleaned 2 dead-tactic warnings. 20 theorems, 0 sorry, inherits only the BHP axiom.",
+    "since": "2026-07-19",
+    "iteration": 3,
+    "focus": "Added bhp_prime_in_short_interval (primes in short intervals from BHP). Verified via docker-build (8577 jobs). Synced stale meta 16/418 -> 36/795.",
     "activeApproach": "Real-analysis squeeze: `maxPrimeGap x / x ≤ x^(-0.475) → 0`. Envelope limit from",
     "blockers": [],
-    "nextAction": "Build-capable session: create `proofs/Proofs/Erdos1138OQ03OQ01.lean` (import",
+    "nextAction": "Entry is saturated. Remaining lever is proving/replacing baker_harman_pintz (deep analytic NT, out of scope). Recommend marking completed to stop re-serving.",
     "attemptCounts": {
       "total": 1,
       "currentApproach": 0,
@@ -30,7 +30,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (researcher-2 2026-07-13): added ORTHOGONAL axiom-free ADDITIVE LOWER bound — maxPrimeGap x → ∞ via arbitrarily large prime gaps (composite factorial run), giving maxPrimeGap_unbounded_and_sublinear (grows without bound yet o(x)). Complements the prior upper-bound sublinearity family AND the multiplicative p/q→1 ratio shadow. Divergence theorems verified axiom-free; only the sublinearity half rests on the deep parent axiom baker_harman_pintz.",
+    "progressSummary": "PROGRESS (researcher-1 2026-07-19): added the localisation corollary bhp_prime_in_short_interval — the one genuinely-new tractable direction flagged by researcher-3 (primes in short intervals (x,(1+ε)x]), NOT a maxPrimeGap-asymptotics repackaging. Built the largest-prime/next-prime consecutive pair from findGreatest+Nat.find. Verified (#print axioms = propext/Classical.choice/Quot.sound + baker_harman_pintz). File now 36 thm / 795 L, 0 sorry, axiomCount 1. Entry otherwise saturated for elementary work.",
     "builtItems": [
       "gap_div_le_rpow_neg (Erdos1138OQ03OQ01.lean:37): maxPrimeGap x / x <= x^(-0.475) for x >= 25",
       "bhp_implies_gap_littleo (Erdos1138OQ03OQ01.lean:57): Tendsto (maxPrimeGap x / x) atTop (nhds 0)",
@@ -45,7 +45,8 @@
       "factorial_succ_add_not_prime (Erdos1138OQ03OQ01.lean): (N+1)!+k composite for 2≤k≤N+1 (Nat.dvd_factorial). Axiom-free.",
       "exists_consecutive_prime_gap_ge (Erdos1138OQ03OQ01.lean, VERIFIED axiom-free [propext,choice,Quot.sound]): ∀N ∃ consecutive primes p<q with q-p≥N. p=Nat.findGreatest Prime ((N+1)!+1), q=Nat.find least prime>(N+1)!+1; composite run forces q≥(N+1)!+N+2.",
       "maxPrimeGap_tendsto_atTop / _cast_tendsto_atTop (Erdos1138OQ03OQ01.lean, VERIFIED axiom-free): maxPrimeGap x → ∞ via monotone + unbounded + tendsto_atTop_atTop_of_monotone.",
-      "maxPrimeGap_unbounded_and_sublinear (Erdos1138OQ03OQ01.lean): two-sided (maxPrimeGap x:ℝ)→∞ ∧ maxPrimeGap x/x→0; discloses baker_harman_pintz (sublinearity half only)."
+      "maxPrimeGap_unbounded_and_sublinear (Erdos1138OQ03OQ01.lean): two-sided (maxPrimeGap x:ℝ)→∞ ∧ maxPrimeGap x/x→0; discloses baker_harman_pintz (sublinearity half only).",
+      "bhp_prime_in_short_interval in Erdos1138OQ03OQ01.lean — primes in short intervals from BHP (verified, inherits only baker_harman_pintz)"
     ],
     "insights": [
       "BHP exponent 0.525 < 1: one division by x yields a negative power x^(-0.475) that vanishes at infinity - no finer analysis needed",
@@ -55,7 +56,8 @@
       "Added the explicit decay RATE of the normalised gap (previously only the qualitative Tendsto→0 was recorded): concrete gap_div_isBigO_rpow_neg = O(x^(-0.475)) and abstract gap_div_isBigO_rpow_sub_one_of_rpow_bound = O(x^(θ-1)). Also cleaned two dead `gcongr <;> exact hx` linter warnings. File VERIFIED via lake env lean (built parent olean first), EXIT 0, 0 warnings; 18→20 theorems.",
       "The power structure x^θ is genuinely irrelevant to sublinearity: only f x/x→0 matters. The general envelope engine gap_littleo_of_littleo_envelope subsumes BOTH the x^θ branch (θ<1) AND the parent conditional Cramér (log x)² branch (not a power of x) under one squeeze. gap_littleo_of_rpow_bound is now provably its f x=x^θ instance.",
       "Multiplicative shadow of additive sublinearity: consecutive primes have RATIO→1. Applying the sup-level BHP bound at x=q (pair p<q≤q always qualifies) gives (q−p)/q≤q^(−0.475), so p/q=1−(q−p)/q≥1−q^(−0.475)→1. Reciprocal (q≥25>1 ⟹ q^(−0.475)<1 ⟹ 1−q^(−0.475)>0) gives q/p≤(1−q^(−0.475))⁻¹→1. Orthogonal to the additive o(x) trilogy — this is the multiplicative form p/q→1. ★ℕ-sub cast: Nat.cast_sub (le_of_lt hpq) then sub_div + div_self to get (q−p)/q=1−p/q; reciprocal via one_div_le_one_div_of_le (inv_le_inv_of_le is GONE in current Mathlib); Real.rpow_lt_one_of_one_lt_of_neg for base<1.",
-      "ORTHOGONAL LOWER-BOUND direction (researcher-2, axiom-free): the entire prior file is upper-bound driven (BHP squeeze → maxPrimeGap x/x→0) plus the multiplicative p/q→1 shadow. The complementary ADDITIVE fact is a LOWER bound: consecutive-prime gaps are arbitrarily large (classical composite run (N+1)!+2,…,(N+1)!+(N+1)), so maxPrimeGap x → ∞. Uses only Euclid + Nat.dvd_factorial — NOT baker_harman_pintz. #print axioms = [propext,Classical.choice,Quot.sound]. Combined: maxPrimeGap grows without bound yet sublinearly — full two-sided character."
+      "ORTHOGONAL LOWER-BOUND direction (researcher-2, axiom-free): the entire prior file is upper-bound driven (BHP squeeze → maxPrimeGap x/x→0) plus the multiplicative p/q→1 shadow. The complementary ADDITIVE fact is a LOWER bound: consecutive-prime gaps are arbitrarily large (classical composite run (N+1)!+2,…,(N+1)!+(N+1)), so maxPrimeGap x → ∞. Uses only Euclid + Nat.dvd_factorial — NOT baker_harman_pintz. #print axioms = [propext,Classical.choice,Quot.sound]. Combined: maxPrimeGap grows without bound yet sublinearly — full two-sided character.",
+      "BHP-sublinearity yields a localisation corollary distinct from the maxPrimeGap asymptotics: for every ε>0, eventually every x has a prime in (x,(1+ε)x] (bhp_prime_in_short_interval). Proof pairs largest-prime-≤x (Nat.findGreatest) with next-prime (Nat.find); Bertrand gives q≤2x so gap∈primeGapSet(2x)≤maxPrimeGap(2x), and the ε/2 envelope pulled back along x↦2x forces maxPrimeGap(2x)≤εx."
     ],
     "mathlibGaps": [],
     "nextSteps": [


### PR DESCRIPTION
## Summary
Research session for `erdos-1138-oq-03-oq-01` (BHP ⟹ prime gaps sublinear). The
`maxPrimeGap`-asymptotics family was saturated (35 → 36 theorems across many
re-serves). This session lands the **one genuinely-new tractable direction**
repeatedly flagged (researcher-3, 2026-07-12) and deferred as unbuilt: the
**localisation** consequence of BHP-sublinearity.

## Progress
- New theorem `bhp_prime_in_short_interval`:
  ```lean
  theorem bhp_prime_in_short_interval (ε : ℝ) (hε : 0 < ε) :
      ∀ᶠ x : ℕ in atTop,
        ∃ q : ℕ, Nat.Prime q ∧ (x : ℝ) < q ∧ (q : ℝ) ≤ (1 + ε) * x
  ```
  For every ε>0, eventually every x contains a prime in `(x, (1+ε)x]`. This is
  **not** a repackaging of the existing `maxPrimeGap` asymptotics — those record
  the *size* of the largest gap below x, whereas this asserts a prime exists in a
  *specific short window* above x.
- Built the largest-prime-≤x / next-prime consecutive pair (the ~50-line
  construction researcher-3 scoped but deferred) from `Nat.findGreatest` +
  `Nat.find`; consecutiveness via `Nat.findGreatest_is_greatest` + `Nat.find_le`.
- Synced the badly-stale gallery meta (`.meta` 16 thm/418 L, `.leanFile` 29/418)
  to the actual **36 thm / 795 L**.

## Proof mechanism
`p` = largest prime ≤ x, `q` = next prime. Bertrand (`prime_gap_le_prev_prime`,
already in the parent) gives `q ≤ 2x`, so the gap `q-p ∈ primeGapSet(2x)` and
`q-p ≤ maxPrimeGap(2x)`. The ε/2 sublinearity envelope
(`bhp_gap_eventually_le_eps`) pulled back along `x ↦ 2x` via `Tendsto.eventually`
forces `maxPrimeGap(2x) ≤ εx` eventually, whence `q-x ≤ q-p ≤ εx`, i.e.
`q ≤ (1+ε)x`.

## Verification
- `docker-build.sh Proofs.Erdos1138OQ03OQ01` — EXIT 0 (`[8577/8577]`), 0 sorries.
- `#print axioms Erdos1138OQ03.bhp_prime_in_short_interval` =
  `[propext, baker_harman_pintz, Classical.choice, Quot.sound]` — **no new
  axioms**, no `native_decide`, no `sorryAx`. `axiomCount` stays 1 (inherited BHP).

## Status
**Outcome**: progress (1 substantive new theorem, verified; meta drift repaired)
**Next Steps**: Entry is now saturated for elementary/abstract/localisation work.
The only remaining lever is proving/replacing the deep parent `baker_harman_pintz`
axiom (analytic number theory, out of session scope). Recommend marking the entry
COMPLETED to stop depth-first re-serving as accretion-bait.

🤖 Generated by researcher-1