### PR TITLE
Fix: repair never-compiled Erdos1153Problem (Erdős #1153) for v4.31 — batch of #39077

### DIFF
--- a/proofs/Proofs/Erdos1153Problem.lean
+++ b/proofs/Proofs/Erdos1153Problem.lean
@@ -2,7 +2,7 @@ import Mathlib.Analysis.SpecialFunctions.Log.Basic
 import Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic
 import Mathlib.Tactic
 
-set_option autoImplicit true
+set_option autoImplicit false
 
 /-
 # Erdős Problem #1153 - Lebesgue Constants of Lagrange Interpolation
@@ -94,7 +94,7 @@ theorem lagrangeBasis_self {n : ℕ} (nodes : Fin n → ℝ) (k : Fin n)
   apply Finset.prod_eq_one
   intro i hi
   rw [Finset.mem_erase] at hi
-  have hne : nodes k ≠ nodes i := fun h => hi.1 (hdist h)
+  have hne : nodes k ≠ nodes i := fun h => hi.1 (hdist h.symm)
   exact div_self (sub_ne_zero.mpr hne)
 
 /-
@@ -115,7 +115,8 @@ theorem lebesgueFunction_at_node {n : ℕ} (nodes : Fin n → ℝ)
   unfold lebesgueFunction
   calc ∑ i : Fin n, |lagrangeBasis n nodes i (nodes k)|
       ≥ |lagrangeBasis n nodes k (nodes k)| :=
-        Finset.single_le_sum (fun i _ => abs_nonneg _) (Finset.mem_univ k)
+        Finset.single_le_sum (f := fun i => |lagrangeBasis n nodes i (nodes k)|)
+          (fun i _ => abs_nonneg _) (Finset.mem_univ k)
     _ = |(1 : ℝ)| := by rw [lagrangeBasis_self nodes k hdist]
     _ = 1 := abs_one
 
@@ -129,8 +130,8 @@ theorem lebesgueFunction_at_node_eq {n : ℕ} (nodes : Fin n → ℝ)
       if i = k then 1 else 0 := by
     intro i
     by_cases h : i = k
-    · subst h; rw [lagrangeBasis_self nodes k hdist, abs_one]
-    · rw [lagrangeBasis_other nodes i k (Ne.symm h), abs_zero]
+    · rw [if_pos h, h, lagrangeBasis_self nodes k hdist, abs_one]
+    · rw [if_neg h, lagrangeBasis_other nodes i k (Ne.symm h), abs_zero]
   simp_rw [this]
   simp
 

--- a/src/data/proofs/erdos-1153/meta.json
+++ b/src/data/proofs/erdos-1153/meta.json
@@ -53,8 +53,8 @@
       "erdos_1153_full_interval"
     ],
     "axiomCount": 1,
-    "lineCount": 169,
-    "assumptions": "AUDIT (issue #39061): NOT machine-verified. This entry never validly compiled. Even under Lean v4.26 the proof only 'passed' because the old `autoImplicit true` default silently bound the undefined identifier `k` as a free implicit variable, rendering the stated theorem vacuously general; under v4.31 (autoImplicit off by default) the file fails with `unknownIdentifier 'k'` and typically additional genuine proof errors. The verification claims below are therefore retracted pending a Lean-source repair (Class A). ORIGINAL METADATA: 1 axiom: erdos_1153 (the logarithmic lower bound, proved by Bernstein/Erdős).",
+    "lineCount": 172,
+    "assumptions": "1 axiom: `erdos_1153` — the (2/π)·log n Lebesgue-constant lower bound on arbitrary subintervals, proved classically by Bernstein (1931) and Erdős (1961) but stated here as an axiom rather than reproved. Repaired under #39077 (Class A): the file now compiles green on Lean v4.31 with `autoImplicit false` (0 sorries), confirming no identifier is silently masked and the theorems are not vacuous. Three genuine proof errors — previously hidden by the old `autoImplicit true` default — were fixed: the equality direction in `lagrangeBasis_self`, an unpinned `Finset.single_le_sum` function metavariable in `lebesgueFunction_at_node`, and a `subst` that erased `k` in `lebesgueFunction_at_node_eq`. The machine-checked content (Lagrange Kronecker-delta property lₖ(xⱼ)=δₖⱼ and λ(xₖ)=1 at nodes) is genuine; only the asymptotic lower bound itself is axiomatized.",
     "theoremCount": 6,
     "definitionCount": 4
   },
@@ -136,7 +136,7 @@
       "Finset"
     ],
     "namespace": "Erdos1153",
-    "lineCount": 169,
+    "lineCount": 172,
     "axiomCount": 1,
     "theoremCount": 6,
     "definitionCount": 4,


### PR DESCRIPTION
## Summary

Class A repair for **Erdos1153Problem** (Erdős #1153, Lebesgue constants of Lagrange interpolation), one of the 28 never-compiled entries tracked by #39077.

The file failed on Lean v4.31 with **three genuine proof errors** that the old `set_option autoImplicit true` default had masked (the errors live inside tactic blocks, so v4.31 rejects them even with autoImplicit still on):

| Site | Defect | Fix |
|------|--------|-----|
| `lagrangeBasis_self` (L97) | `hdist h` wrong equality direction (`nodes k = nodes i` vs expected `nodes i = nodes k`) | `hdist h.symm` |
| `lebesgueFunction_at_node` (L118) | `Finset.single_le_sum` function metavariable unpinned under the `≥` calc step | supplied `(f := fun i => …)` |
| `lebesgueFunction_at_node_eq` (L132-133) | `subst h` erased the fixed `k` (→ `unknownIdentifier 'k'`); the `if` was never discharged | rewrote both branches with `if_pos`/`if_neg`, no `subst` |

Also flipped the header `set_option autoImplicit true` → `false` as an anti-masking guard — the file now compiles green with autoImplicit **off**, proving no identifier was silently bound and the theorems are not vacuous.

## Evidence (before → after)

**Before** (`./proofs/scripts/docker-build.sh Proofs.Erdos1153Problem`):
```
error: …:97:55: Application type mismatch … hdist h
error: …:118:8: Type mismatch … single_le_sum …
error: …:132:44: Unknown identifier `k`
error: …:133:4: unsolved goals … ⊢ 0 = if i = k then 1 else 0
error: build failed
```

**After**:
```
✔ [2969/2969] Built Proofs.Erdos1153Problem (1.1s)
Build completed successfully (2969 jobs).
=== Build succeeded ===
```
0 sorries, 1 axiom (`erdos_1153`, the asymptotic (2/π)·log n lower bound stated classically).

## Metadata

`src/data/proofs/erdos-1153/meta.json`: replaced the stale "never compiled / retracted" audit note with an accurate post-repair disclosure; corrected `lineCount` 169 → 172. Status stays `axiomatized`/`badge: axiom` per the Axiom Integrity Policy — the Lagrange Kronecker-delta lemmas (lₖ(xⱼ)=δₖⱼ, λ(xₖ)=1) are machine-checked; only the asymptotic lower bound is axiomatized.

Part of #39077.