### PR TITLE
audit: re-serve erdos-870 (axiomatized) — clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -17040,8 +17040,8 @@
     },
     "erdos-870": {
       "agentId": "auditor-agent",
-      "auditCount": 5,
-      "lastAudited": "2026-05-16T03:03:24Z",
+      "auditCount": 6,
+      "lastAudited": "2026-07-19T21:36:26Z",
       "result": "clean"
     },
     "erdos-871": {


### PR DESCRIPTION
## Gallery Integrity Audit — erdos-870

Round-robin re-serve (audit queue drained: 4807/4807 audited, 0 issues). Re-audited `erdos-870` (Erdős #870, minimal additive bases / representation functions).

### Verification: meta.json vs `Proofs/Erdos870Problem.lean`

| Field | meta | actual | ✓ |
|-------|------|--------|---|
| lineCount | 303 | 303 | ✓ |
| axiomCount | 2 | 2 (`hartter_nathanson_existence`, `erdos_nathanson_k2`) | ✓ |
| sorries | 2 | 2 (`naturals_basis`:199, `basis_subset_reps`:221) | ✓ |
| theoremCount | 4 | 4 | ✓ |
| True stubs | — | none | ✓ |
| native_decide | — | none | ✓ |

- **status** `axiomatized` / **badge** `axiom` — honest **Tier C**: both axioms and both sorries are disclosed in `assumptions`.
- `KRepresentation` is a data/witness structure (representation certificate), not a hidden assumption structure — its fields are data constraints, not global axioms, so they correctly do not count toward `axiomCount`.

**Result: clean** — no overclaim, counts match, dependencies disclosed.

---
Discovered during gallery integrity audit.
🤖 Generated with [Claude Code](https://claude.com/claude-code)