### PR TITLE
audit: re-serve erdos-671 (axiomatized) — clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -15549,9 +15549,9 @@
     },
     "erdos-671": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 6,
+      "auditCount": 7,
       "issues": [],
-      "lastAudited": "2026-05-04T03:22:29Z",
+      "lastAudited": "2026-07-19T21:59:30Z",
       "result": "clean"
     },
     "erdos-672": {


### PR DESCRIPTION
## Gallery Integrity Re-Audit

Round-robin re-serve of the oldest **uncontested** audited entry. The unaudited queue is drained (0/4807) and the entire top-10 priority cohort (erdos-881/882/883/876/872/871/874/875/867/864) is already covered by open fleet PRs — independently spot-checked erdos-882 against PR #39165 (accurate) before moving to an uncontested target.

### erdos-671 — Lagrange Interpolation Convergence — **integrity-clean**

| Field | meta.json | Lean file | Match |
|-------|-----------|-----------|-------|
| status | axiomatized | — | ✓ |
| badge | axiom | — | ✓ |
| erdosStatus | open | — | ✓ |
| sorries | 7 | 7 | ✓ |
| axiomCount | 3 | 3 | ✓ |

**Axioms (all disclosed in `assumptions`):** `question1_open`, `question2_open`, `main_conjecture_open`.

**Checks:** No True stubs, no `native_decide`. Prose honestly frames both questions as **open** ($250 prize); Bernstein (1931) and Erdős–Vértesi (1980) negative results correctly attributed — no overclaiming. Companion files (`Erdos671Aristotle.lean`, `Erdos671ProblemAristotle.lean`) are not the claimed `leanFile` and make no additional public claim.

Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)