### PR TITLE
audit: re-serve erdos-951 (axiomatized/wip) — clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -17631,8 +17631,8 @@
     },
     "erdos-951": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-05-04T03:25:28Z",
+      "auditCount": 5,
+      "lastAudited": "2026-07-19T22:02:19Z",
       "result": "clean"
     },
     "erdos-952": {


### PR DESCRIPTION
## Gallery Integrity Audit — erdos-951 (Beurling Prime Numbers)

Queue is fully drained (0 unaudited of 4807). Re-serving the oldest **uncontested** target (top-10 all held by open fleet PRs).

### Checks (meta.json vs `proofs/Proofs/Erdos951Problem.lean`)

| Check | Claimed | Actual | Verdict |
|-------|---------|--------|---------|
| Sorries | 0 | 0 | ✓ |
| Axioms | 0 | 0 (no `axiom` decls) | ✓ |
| True stubs | — | none | ✓ |
| native_decide | — | none (uses kernel `decide`) | ✓ |
| theoremCount | 18 | 18 | ✓ |
| definitionCount | 10 | 10 | ✓ |

### Narrative integrity
- `badge: wip`, `status: axiomatized`. The main result `erdos951_conjecture` is a `def : Prop` — **explicitly not asserted/axiomatized** (open problem). Honest, no overclaim.
- `BeurlingPrimes` structure fields (`well_separated`, etc.) are hypotheses, not global axioms — instantiated by the **proven** `actualPrimes`, whose `primeSeq_well_separated` is derived from unique factorization (`factorization_prod_at`), not assumed.
- Mathlib dependencies disclosed; `originalContributions` scoped to infrastructure and verified partial results (trivial upper bounds, primes-are-Beurling, powers-of-two counterexample).

**Result: integrity-clean.** No changes to gallery claims; tracker updated only.

---
Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)