### PR TITLE
audit: re-serve erdos-867 (axiomatized) — clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -17010,8 +17010,8 @@
     },
     "erdos-867": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T00:19:32Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-19T22:07:24Z",
       "result": "clean"
     },
     "erdos-868": {


### PR DESCRIPTION
## Audit: erdos-867 (Consecutive Sum-Free Sets)

Re-served from the drained unaudited queue (reserve mode). **Result: clean.**

Verified against `proofs/Proofs/Erdos867Problem.lean`:

| Field | meta.json | actual |
|-------|-----------|--------|
| axiomCount | 1 | 1 (`coppersmith_phillips_lower`) ✓ |
| sorries | 0 | 0 ✓ |
| theoremCount | 5 | 5 ✓ |
| definitionCount | 5 | 5 ✓ |

- Badge `axiom` / status `axiomatized` honestly reflect the single load-bearing axiom; `assumptions` discloses it accurately.
- `erdos_867_answer` (the disproof) genuinely depends on the axiom — no masking.
- `native_decide` appears only in a throwaway illustrative `example` (`{3,4,5}.card = 3`), not in any load-bearing theorem.
- No True stubs, no hidden structure-field axioms.
- Minor/harmless: `lineCount` 288 vs actual 287; section prose says "axiomatizes" for upperHalf/Adenwalla/Freud which are actually proved/documentation-only (understates work — integrity-safe).

No overclaims found.

🤖 Generated with [Claude Code](https://claude.com/claude-code)