### PR TITLE
Fix: verify never-compiled BezoutIdentityOQ01OQ02OQ02Transitive (Class C, #39077)

### DIFF
--- a/proofs/Proofs/BezoutIdentityOQ01OQ02OQ02Transitive.lean
+++ b/proofs/Proofs/BezoutIdentityOQ01OQ02OQ02Transitive.lean
@@ -40,15 +40,14 @@
   - Grandparent `BezoutIdentityOQ01OQ02` (`bezoutMatrix`, `bezoutMatrix_mulVec`).
   - Companion `BezoutIdentityOQ01OQ02OQ02Descent` (`embedOneSL`, `headBlockNSL`).
 
-  BUILD STATUS (2026-07-09): **UNVERIFIED — not yet machine-checked.**  The Docker build
-  infrastructure was down this session (containerd content-store blob I/O error, operator-level)
-  and the Aristotle service was unreachable, so this file could not be elaborated even once.  The
-  proof strategy was validated by hand and every Mathlib API call was cross-checked against the
-  pinned Mathlib source (`Fin.append`/`cons` lemmas, `Matrix.mulVec_mulVec`,
-  `SpecialLinearGroup.coe_mul`, `Int.gcd_dvd_left/right`, `Int.eq_one_of_dvd_one`), but the two
-  pure-`Fin` bridge lemmas below (`gcdForm_two`, `cons_gcdForm`) are finicky index-arithmetic
-  tactic proofs and are the most likely to need adjustment on first build.  Do NOT report this entry
-  as `verified` until a clean build confirms it.
+  BUILD STATUS (2026-07-19): **VERIFIED — machine-checked on Lean 4.31 / Mathlib.**  Builds green
+  via `./proofs/scripts/docker-build.sh Proofs.BezoutIdentityOQ01OQ02OQ02Transitive` with 0 sorries
+  and 0 `axiom` declarations; `#print axioms sln_acts_transitive` reports only the standard
+  foundational trio `[propext, Classical.choice, Quot.sound]` (no `sorryAx`, no `Lean.ofReduceBool`).
+  The two pure-`Fin` bridge lemmas flagged at authoring time (`gcdForm_two`, `cons_gcdForm`) did
+  require repair: the `2 + (m + 1)` grouping forced `Fin.addCases` (`m := 2`) and `headBlockNSL`
+  (`m := m + 1`) to be pinned explicitly, and `cons_gcdForm` was re-proved coordinatewise with
+  auxiliary `hzero`/`gcdZero`/`key` helpers.
 -/
 
 import Mathlib

--- a/proofs/Proofs/BezoutIdentityOQ01OQ02OQ02Transitive.lean
+++ b/proofs/Proofs/BezoutIdentityOQ01OQ02OQ02Transitive.lean
@@ -86,29 +86,55 @@ def gcdForm (m : ℕ) (g : ℤ) : Fin (2 + m) → ℤ :=
 
 theorem gcdForm_two (g : ℤ) : gcdForm 0 g = ![g, 0] := by
   funext i
-  fin_cases i <;> simp [gcdForm, Fin.append_left]
+  fin_cases i <;> rfl
 
 /-- **Content bridge.**  Prepending `a` to the gcd-normal form `(b, 0, …, 0) ∈ ℤ^{2+m}` gives the
 vector `(a, b, 0, …, 0) ∈ ℤ^{2+(m+1)}`, repackaged in `Fin.append` shape so the head block acts. -/
 theorem cons_gcdForm (m : ℕ) (a b : ℤ) :
     Fin.cons a (gcdForm m b) = Fin.append (![a, b] : Fin 2 → ℤ) (0 : Fin (m + 1) → ℤ) := by
+  -- `gcdForm m b` vanishes at every coordinate `≥ 1` (only coordinate 0 carries `b`)
+  have hzero : ∀ k : Fin (2 + m), 1 ≤ (k : ℕ) →
+      Fin.append (![b, 0] : Fin 2 → ℤ) (0 : Fin m → ℤ) k = 0 := by
+    refine Fin.addCases (m := 2) (n := m) (fun k hk => ?_) (fun k _ => ?_)
+    · rw [Fin.append_left]
+      fin_cases k <;> simp_all [Fin.val_castAdd]
+    · rw [Fin.append_right]; rfl
+  -- coordinate 0 of the gcd-normal form is `b`
+  have gcdZero : gcdForm m b (0 : Fin (2 + m)) = b := by
+    simp only [gcdForm]
+    have h0 : (0 : Fin (2 + m)) = Fin.castAdd m (0 : Fin 2) := by apply Fin.ext; simp
+    rw [h0, Fin.append_left]
+  -- the composite `Fin.cons a (gcdForm m b)` vanishes at every coordinate `≥ 2`
+  have key : ∀ i : Fin (2 + (m + 1)), 2 ≤ (i : ℕ) →
+      (Fin.cons a (gcdForm m b) : Fin (2 + (m + 1)) → ℤ) i = 0 := by
+    intro i
+    induction i using Fin.cases with
+    | zero => intro hi; simp at hi
+    | succ i' =>
+      intro hi
+      rw [Fin.cons_succ]
+      simp only [gcdForm]
+      exact hzero i' (by simp only [Fin.val_succ] at hi; omega)
   funext i
-  -- split the ambient `Fin (2 + (m + 1))` into the first two coordinates and the tail
-  refine Fin.addCases (fun j => ?_) (fun j => ?_) i
-  · -- left block: the two leading coordinates, `j : Fin 2`
+  -- force the `2 + (m + 1)` grouping (default reduction peels the last coordinate instead)
+  refine Fin.addCases (m := 2) (n := m + 1) (fun j => ?_) (fun j => ?_) i
+  · -- left block `j : Fin 2`: `Fin.append_left` evaluates the RHS to `![a, b] j`
     rw [Fin.append_left]
-    fin_cases j
-    · -- coordinate 0 → `a` (head of the `Fin.cons`)
-      simp [gcdForm]
-    · -- coordinate 1 → `b` (head of the inner `Fin.append` inside `gcdForm`)
-      simp [gcdForm, Fin.append_left]
-  · -- right block: the remaining coordinates, `j : Fin (m + 1)`; every entry is `0`
-    rw [Fin.append_right]
-    -- `Fin.natAdd 2 j = (Fin.natAdd 1 j).succ`, so the `Fin.cons` peels to the tail append
-    have hj : (Fin.natAdd 2 j : Fin (2 + (m + 1))) = (Fin.natAdd 1 j).succ := by
-      apply Fin.ext; simp [Fin.natAdd, Fin.succ, Nat.add_comm, Nat.add_assoc, Nat.add_left_comm]
-    rw [hj, Fin.cons_succ]
-    simp [gcdForm, Fin.append_right]
+    refine Fin.cases ?_ (fun j' => ?_) j
+    · -- coordinate 0 → `a`
+      have hc : (Fin.castAdd (m + 1) (0 : Fin 2) : Fin (2 + (m + 1))) = 0 := by
+        apply Fin.ext; simp
+      rw [hc, Fin.cons_zero]; simp
+    · -- coordinate 1 → `b`
+      have hj' : j' = 0 := Subsingleton.elim _ _
+      subst hj'
+      have hc : (Fin.castAdd (m + 1) (Fin.succ 0 : Fin 2) : Fin (2 + (m + 1)))
+          = Fin.succ (0 : Fin (2 + m)) := by
+        apply Fin.ext; simp only [Fin.val_castAdd, Fin.val_succ, Fin.val_zero]; omega
+      rw [hc, Fin.cons_succ, gcdZero]; simp
+  · -- right block `j : Fin (m+1)`: coordinate `Fin.natAdd 2 j` has value `≥ 2`
+    rw [Fin.append_right, Pi.zero_apply]
+    exact key _ (by simp only [Fin.val_natAdd]; omega)
 
 /-! ### The general reduction to gcd-normal form -/
 
@@ -150,14 +176,14 @@ theorem reduce_to_gcd (m : ℕ) :
       rw [Fin.cons_self_tail] at h1
       rw [h1, hT]
     -- Step 2: the head block clears coordinate `1` against coordinate `0`.
-    have hHd : (headBlockNSL N : Matrix (Fin (2 + (m + 1))) (Fin (2 + (m + 1))) ℤ)
+    have hHd : (headBlockNSL (m := m + 1) N : Matrix (Fin (2 + (m + 1))) (Fin (2 + (m + 1))) ℤ)
         *ᵥ Fin.cons (v 0) (gcdForm m gw) = gcdForm (m + 1) g := by
       rw [cons_gcdForm]
       show headBlockN (N : Matrix (Fin 2) (Fin 2) ℤ) *ᵥ Fin.append ![v 0, gw] (0 : Fin (m + 1) → ℤ)
           = gcdForm (m + 1) g
       rw [headBlockN_mulVec, hN]
       rfl
-    refine ⟨headBlockNSL N * embedOneSL T, g, ?_, Int.natCast_nonneg _, ?_⟩
+    refine ⟨headBlockNSL (m := m + 1) N * embedOneSL T, g, ?_, Int.natCast_nonneg _, ?_⟩
     · rw [Matrix.SpecialLinearGroup.coe_mul, ← Matrix.mulVec_mulVec, hE, hHd]
     · intro i
       refine Fin.cases ?_ (fun j => ?_) i

--- a/proofs/Proofs/BezoutIdentityOQ01OQ02OQ02Transitive.lean
+++ b/proofs/Proofs/BezoutIdentityOQ01OQ02OQ02Transitive.lean
@@ -103,7 +103,7 @@ theorem cons_gcdForm (m : ℕ) (a b : ℤ) :
   have gcdZero : gcdForm m b (0 : Fin (2 + m)) = b := by
     simp only [gcdForm]
     have h0 : (0 : Fin (2 + m)) = Fin.castAdd m (0 : Fin 2) := by apply Fin.ext; simp
-    rw [h0, Fin.append_left]
+    rw [h0, Fin.append_left]; rfl
   -- the composite `Fin.cons a (gcdForm m b)` vanishes at every coordinate `≥ 2`
   have key : ∀ i : Fin (2 + (m + 1)), 2 ≤ (i : ℕ) →
       (Fin.cons a (gcdForm m b) : Fin (2 + (m + 1)) → ℤ) i = 0 := by
@@ -130,7 +130,7 @@ theorem cons_gcdForm (m : ℕ) (a b : ℤ) :
       subst hj'
       have hc : (Fin.castAdd (m + 1) (Fin.succ 0 : Fin 2) : Fin (2 + (m + 1)))
           = Fin.succ (0 : Fin (2 + m)) := by
-        apply Fin.ext; simp only [Fin.val_castAdd, Fin.val_succ, Fin.val_zero]; omega
+        apply Fin.ext; simp only [Fin.val_castAdd, Fin.val_succ, Fin.val_zero]
       rw [hc, Fin.cons_succ, gcdZero]; simp
   · -- right block `j : Fin (m+1)`: coordinate `Fin.natAdd 2 j` has value `≥ 2`
     rw [Fin.append_right, Pi.zero_apply]


### PR DESCRIPTION
## Summary

Repairs the last **Class C** entry of #39077 (28 never-compiled Lean entries). `proofs/Proofs/BezoutIdentityOQ01OQ02OQ02Transitive.lean` self-reported `BUILD STATUS … UNVERIFIED — not yet machine-checked` (Docker/Aristotle were down when it was authored). It now **builds green on Lean 4.31 / Mathlib** with 0 sorries and 0 axioms.

## What was broken

The file never elaborated. `docker-build.sh` surfaced real defects in the two `Fin`-index bridge lemmas the author flagged as untested, all rooted in `2 + (m + 1)` reducing definitionally to `(2 + m) + 1`:

- `gcdForm_two` — `simp` left `Fin.append` residuals; closed by `rfl` per coordinate.
- `cons_gcdForm` — `Fin.addCases` split the ambient `Fin (2+(m+1))` the wrong way (peeling the *last* coordinate). Re-proved coordinatewise with an explicit `(m := 2) (n := m+1)` split plus auxiliary helpers `hzero` (gcd-form vanishes at coords ≥1), `gcdZero` (coord 0 = b), `key` (composite vanishes at coords ≥2).
- Two `headBlockNSL` applications needed `(m := m + 1)` pinned so the `2+(m+1)` index inferred correctly.

## Evidence

**Before:** `error: … unsolved goals / rewrite failed / Type mismatch` (5 error sites).
**After:**
```
Build completed successfully (8579 jobs).
```
`#print axioms sln_acts_transitive` → `[propext, Classical.choice, Quot.sound]` only (no `sorryAx`, no `Lean.ofReduceBool`). Per the Axiom Integrity Policy this is genuinely `verified`. Docstring BUILD STATUS updated accordingly.

No gallery `meta.json` references this module, so there is no badge/metadata to restore.

## Notes

- Only the three flagged lemmas + two type ascriptions changed; the mathematical content is untouched.
- A stale empty worktree branch `research/bezout-oq010202-verify-transitive` (researcher-1, 0 commits, no PR) targets the same file — flagging in case of overlap; this PR supersedes it with a verified build.

Closes #39077's Class C item (BezoutIdentityOQ01OQ02OQ02Transitive). Part of #39077.