### PR TITLE
audit: re-serve erdos-83 (axiomatized) — clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -16703,8 +16703,8 @@
     },
     "erdos-83": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:53:01Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-19T22:10:29Z",
       "result": "clean"
     },
     "erdos-83-oq-01": {


### PR DESCRIPTION
## Gallery integrity audit — round-robin re-serve

Unaudited queue fully drained (4807/4807); the entire top-of-priority cohort (erdos-849..883 + siblings) is already contested by open audit PRs. Picked the highest-priority **uncontested** target: **erdos-83**.

## Result: clean

Verified `meta.json` against `Proofs/Erdos83Problem.lean`:

| field | meta | source | |
|-------|------|--------|-|
| lineCount | 404 | 404 | ✓ |
| axiomCount | 5 | 5 explicit `axiom` decls | ✓ |
| sorries | 2 | 2 (both disclosed def sorries) | ✓ |
| theoremCount | 8 | 8 | ✓ |
| definitionCount | 13 | 13 | ✓ |

- The 5 named axioms in `meta.assumptions` (`erdos_ko_rado_bound`, `starLikeFamily_achieves`, `ahlswede_khachatrian_theorem`, `erdos83_from_ak`, `erdos83_bound_asymptotic`) exactly match the 5 `axiom` declarations.
- Status `axiomatized` / badge `axiom` is the correct conservative tier — no `verified` overclaim.
- Main theorem `erdos_83` honestly derives from `erdos83_answer` (proved from the AK axioms); **no True stubs**.
- The two `native_decide` uses are only in auxiliary small-case bound checks (`erdos83_bound_n1`/`n2`), not the main proof chain — benign (consistent with the erdos-873 treatment in #39107).

Tracker-only change (auditCount+1 / lastAudited / result=clean). Disjoint from the pending erdos-8xx cohort PRs.

---
Discovered during gallery integrity audit.