### PR TITLE
Fix: reconcile erdos-450 annotation with corrected 2≤n hypothesis

### DIFF
--- a/src/data/proofs/erdos-450/annotations.json
+++ b/src/data/proofs/erdos-450/annotations.json
@@ -52,7 +52,7 @@
       "endLine": 109
     },
     "title": "Infrastructure Lemmas",
-    "content": "Seven lemmas are **proved**: (1) `countWithDivisor_le` — count $\\leq y$ (via `card_filter_le`). (2) `countWithDivisor_zero` — empty interval has count $0$. (3,4) `countWithDivisor_n_zero/one` — degenerate $n$ cases. (5) `countWithDivisor_mono_y` — monotonicity in interval length. (6) `hasDivisorIn_of_dvd` — any multiple of $d \\in (n, 2n)$ qualifies. (7) `hasDivisorIn_succ` — $n+1$ has divisor $n+1 \\in (n, 2n)$ for $n \\geq 1$.",
+    "content": "Seven lemmas are **proved**: (1) `countWithDivisor_le` — count $\\leq y$ (via `card_filter_le`). (2) `countWithDivisor_zero` — empty interval has count $0$. (3,4) `countWithDivisor_n_zero/one` — degenerate $n$ cases. (5) `countWithDivisor_mono_y` — monotonicity in interval length. (6) `hasDivisorIn_of_dvd` — any multiple of $d \\in (n, 2n)$ qualifies. (7) `hasDivisorIn_succ` — $n+1$ has divisor $n+1 \\in (n, 2n)$ for $n \\geq 2$.",
     "mathContext": "The monotonicity proof uses `Finset.card_le_card` and `Finset.filter_subset_filter` with `Finset.range_mono`. The bound $N(x, y, n) \\leq y$ follows from $|\\text{filter}(S, P)| \\leq |S|$. The degenerate cases $n = 0$ (interval $(0, 0)$ empty) and $n = 1$ (interval $(1, 2)$ empty) use `omega` to derive contradictions on divisor bounds.",
     "significance": "key",
     "relatedConcepts": [


### PR DESCRIPTION
## Problem

Part of #38611 (Bucket C — verify gallery prose describes the corrected, not original, statement).

`hasDivisorIn_succ` in `proofs/Proofs/Erdos450Problem.lean` was statement-repaired for v4.31 to require `2 ≤ n`:

```lean
/-- n+1 has a divisor in (n, 2n) when n ≥ 2: namely n+1 itself.
    (Statement repair for v4.31: the n = 1 case is degenerate — the witness
    d = n+1 = 2 fails d < 2n = 2, so the hypothesis must be 2 ≤ n.) -/
theorem hasDivisorIn_succ {n : ℕ} (hn : 2 ≤ n) : HasDivisorIn (n + 1) n := ...
```

But the gallery annotation `ann-450-infrastructure` still described the **old, false** `n ≥ 1` hypothesis:

> (7) `hasDivisorIn_succ` — $n+1$ has divisor $n+1 \in (n, 2n)$ for $n \geq 1$.

At $n=1$ the interval $(1,2)$ is empty, so $2 \notin (1,2)$ — the claim is false. The annotation even **contradicted its own mathContext** on the next line, which notes "n = 1 (interval (1, 2) empty)".

## Fix

Minimal one-word prose correction: `n \geq 1` → `n \geq 2` in `ann-450-infrastructure`. No other erdos-450 references were stale (all already say `n \geq 2`).

## Evidence
- Before: `...for $n \geq 1$.` (false at n=1)
- After: `...for $n \geq 2$.` (matches Lean `(hn : 2 ≤ n)`)
- JSON validated with `json.load`.

Part of #38611.