### PR TITLE
audit: re-serve erdos-831 (axiomatized) — clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -16721,8 +16721,8 @@
     },
     "erdos-831": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:53:23Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-19T22:15:14Z",
       "result": "clean"
     },
     "erdos-832": {


### PR DESCRIPTION
## Gallery Integrity Audit — erdos-831

Round-robin re-serve (unaudited queue drained; erdos-881 and all higher-priority targets already contested by open fleet PRs). First uncontested target in priority order.

### Findings
| Check | meta.json | Lean file | Result |
|-------|-----------|-----------|--------|
| sorries | 0 | 0 real occurrences | ✓ |
| axiomCount | 1 | 1 (`erdos_831_growing`) | ✓ |
| True stubs | — | none (`erdos_831_summary`/`erdos_831_open_question` prove real props) | ✓ |
| status/badge | axiomatized/axiom | axiomatized growth claim, problem OPEN | ✓ |
| native_decide | — | none | ✓ |

Description correctly states "This problem remains OPEN." No overclaim.

**Result: integrity-clean.**

---
Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)