### PR TITLE
audit: re-serve erdos-826 (axiomatized/wip) — clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -16675,8 +16675,8 @@
     },
     "erdos-826": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:53:23Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-19T22:17:37Z",
       "result": "clean"
     },
     "erdos-827": {


### PR DESCRIPTION
## Re-serve audit — erdos-826

Queue is fully drained (0 unaudited / 4807 total), so this is a reserve-mode
re-audit of the oldest **uncontested** target (top-10 all had open fleet PRs).

**Proof:** erdos-826 — Erdős Problem #826: Divisor Function Growth Along Shifts
**Result:** clean (auditCount 3 → 4)

### Verified against `proofs/Proofs/Erdos826Problem.lean`
| Check | meta.json | Lean file | OK |
|-------|-----------|-----------|----|
| sorries | 0 | 0 | ✅ |
| axiomCount | 0 | 0 axiom decls, no assumption-carrying struct fields | ✅ |
| theoremCount | 6 | 6 | ✅ |
| True stubs | — | none | ✅ |
| native_decide | — | none | ✅ |
| status/badge | axiomatized / wip | open conjecture stated as `def`, not asserted | ✅ |

- Growth bounds (`average_order_tau`, `max_order_tau`) are plain `Prop` defs,
  honestly labeled "stated as a proposition rather than an axiom since it is
  not used in proofs below" — not hidden axioms.
- `erdos_826_main` proves only well-definedness (`rfl`) + implication to #248;
  `prime_satisfies_bound` correctly scoped as a Mathlib-derived fact. No
  overclaim; "OPEN" stated throughout.
- `lineCount` 343 vs actual 349 = stale undercount (harmless).

Discovered during gallery integrity audit.