### PR TITLE
audit: re-serve erdos-827 (axiomatized) — clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -16681,8 +16681,8 @@
     },
     "erdos-827": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:53:23Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-19T22:19:54Z",
       "result": "clean"
     },
     "erdos-828": {


### PR DESCRIPTION
## Gallery Integrity Re-serve (reserve mode)

Queue drained (0 unaudited); oldest uncontested target selected after filtering the fleet's open-PR titles (incl. comma-list titles).

**erdos-827 — Distinct Circumradii in General Position**

| Check | meta | file | ok |
|---|---|---|---|
| status/badge | axiomatized / axiom | Tier C axiomatized | ✓ |
| sorries | 0 | 0 | ✓ |
| axiomCount | 2 | 2 (`nk_exists_witness`, `martinez_roldan_pensado`) | ✓ |
| True stubs | — | 0 | ✓ |
| native_decide | — | 0 | ✓ |

Title/description honestly credit the external Martinez-Roldán-Pensado bound (n_k ≪ k⁹) as axiomatized. No overclaim.

**Result: clean.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)