### PR TITLE
audit: re-serve erdos-828 (axiomatized/wip) — clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -16687,8 +16687,8 @@
     },
     "erdos-828": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:53:24Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-19T22:23:20Z",
       "result": "clean"
     },
     "erdos-829": {


### PR DESCRIPTION
## Gallery Integrity Audit — erdos-828

Re-audit of the oldest **uncontested** target (unaudited queue is drained; top-10 all had open fleet PRs).

**Result: clean.** Verified against `proofs/Proofs/Erdos828Problem.lean`:

- 0 sorries, 0 axioms, 0 True stubs, 0 `native_decide`
- `theoremCount` 17 (8 theorems + 9 `private` lemmas), `definitionCount` 3, `lineCount` 346 — all match meta
- Open conjecture correctly stated as unproved `def erdos828Conjecture : Prop` (line 324); not claimed proved
- `erdos_828_summary` asserts only the genuinely-proved a=0 (powers of 2) and a=−1 (primes) infiniteness
- badge `wip` + description "OPEN" — no overclaim (standard axiomatized/wip scaffold shape)

Only `audit-tracker.json` changed (auditCount 3→4, timestamp).

---
Discovered during gallery integrity audit.