### PR TITLE
audit: re-serve erdos-874 (axiomatized) — clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -17064,8 +17064,8 @@
     },
     "erdos-874": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T00:18:39Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-19T22:30:36Z",
       "result": "clean"
     },
     "erdos-875": {


### PR DESCRIPTION
## Gallery Integrity Audit — erdos-874

Reserve-mode re-serve (unaudited queue drained; picked oldest uncontested target).

**Result: CLEAN** — no integrity issues.

### Verification
| Check | meta.json | Lean file | Status |
|-------|-----------|-----------|--------|
| axiomCount | 2 | 2 (`deshouillers_freiman_main`, `k_limit_is_two`) | ✓ |
| sorries | 0 | 0 | ✓ |
| True stubs | — | none | ✓ |
| native_decide | — | none (docstring mention only) | ✓ |
| badge / status | axiom / axiomatized | main theorem `erdos_874` := `k_limit_is_two` (Tier C) | ✓ |
| assumptions field | "2 axioms … 0 sorries" | matches exactly | ✓ |

Title/description honestly attribute the result to Deshouillers-Freiman (1999) and the formalization axiomatizes it — no overclaim. `theoremCount` (3 vs 4) and `lineCount` (227 vs 262) are harmless undercounts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)