### PR TITLE
audit: re-serve erdos-805 (axiomatized) — clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -16524,8 +16524,8 @@
     },
     "erdos-805": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:53:24Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-19T22:35:20Z",
       "result": "clean"
     },
     "erdos-806": {


### PR DESCRIPTION
## Gallery Integrity Audit — erdos-805

Oldest uncontested re-serve target (last audited 2026-05-04; entire top-10 of the queue is contested by open fleet PRs).

**Result: clean.** Meta claims match the Lean source exactly.

| Check | meta.json | Erdos805Problem.lean |
|-------|-----------|----------------------|
| status | axiomatized | — |
| badge | axiom | — |
| sorries | 0 | 0 |
| axiomCount | 2 | 2 (`alon_sudakov_2007`, `alon_bucic_sudakov_2021`) |
| True stubs | — | 0 |
| native_decide | — | 0 |

- Tier C scaffold: `theorem erdos_805` is a plain conjunction of the two named axioms, each corresponding to a real published result (Alon–Sudakov 2007 negative bound; Alon–Bucić–Sudakov 2021 positive bound).
- `assumptions` field discloses both axioms by name.
- Description honestly labels the problem "PARTIALLY SOLVED: Bounds by Alon-Sudakov (2007) and Alon-Bucić-Sudakov (2021)" — no overclaim of a full resolution.

No integrity issues found.

🤖 Generated with [Claude Code](https://claude.com/claude-code)