### PR TITLE
Fix: reconcile erdos-437 annotations with source (remove 3 phantom axioms)

### DIFF
--- a/src/data/proofs/erdos-437/annotations.json
+++ b/src/data/proofs/erdos-437/annotations.json
@@ -166,7 +166,7 @@
     },
     "type": "concept",
     "title": "Trivial Upper Bound",
-    "content": "**L_le_x:**\n\nL(x) ≤ x:\n```lean\naxiom L_le_x : ∀ x : ℕ, x ≥ 2 → L x ≤ x\n```\n\n**Reason:** A sequence has at most x elements (since each aᵢ ≤ x and they're distinct), so at most x partial products exist.",
+    "content": "**Trivial Upper Bound:**\n\nFor x ≥ 2, L(x) ≤ x. This bound is noted informally in the source (Part V, \"Trivial Bounds\") as motivating context; it is not a formal axiom of the file.\n\n**Reason:** A sequence has at most x elements (since each aᵢ ≤ x and they're distinct), so at most x partial products exist.",
     "significance": "supporting",
     "mathContext": "$L(x) \\leq x$ since a sequence in $\\{1, \\ldots, x\\}$ has at most $x$ distinct elements, hence at most $x$ partial products. This is the trivial bound; the interesting question is how close to $x$ the count $L(x)$ can get.",
     "relatedConcepts": [
@@ -303,7 +303,7 @@
     },
     "type": "concept",
     "title": "Siegel's Theorem Consequence",
-    "content": "**siegel_theorem_consequence:**\n\nFrom Siegel's theorem, L(x) < x for all x:\n```lean\naxiom siegel_theorem_consequence :\n  ∀ x : ℕ, x ≥ 2 → ∃ C : ℝ, C < x ∧ (L x : ℝ) ≤ C\n```\n\n**Siegel's Theorem (1929):** An elliptic curve E/ℚ has only finitely many integral points. This constrains how partial products can simultaneously be squares.",
+    "content": "**Siegel's Theorem Consequence:**\n\nFrom Siegel's theorem, for x ≥ 2 there is a bound C < x with L(x) ≤ C, so L(x) < x. This consequence is discussed informally in the source (Part V); it is not a formal axiom of the file — the formalized statement is the o(x) bound `L_little_o_x`.\n\n**Siegel's Theorem (1929):** An elliptic curve E/ℚ has only finitely many integral points. This constrains how partial products can simultaneously be squares.",
     "mathContext": "A fundamental theorem in Diophantine geometry.",
     "significance": "key",
     "relatedConcepts": [
@@ -326,7 +326,7 @@
     },
     "type": "concept",
     "title": "Hyperelliptic Curves Connection",
-    "content": "**hyperelliptic_connection:**\n\nThe problem reduces to counting integral points on hyperelliptic curves:\n```lean\naxiom hyperelliptic_connection :\n  ∀ a, IsStrictlyIncreasing a →\n  ∃ curve_degree ≥ 3, squareCount a ≤ a.length\n```\n\n**Key insight:** If a₁·a₂·...·aⱼ = y² and a₁·...·aₖ = z² (j < k), then we get a relation on a hyperelliptic curve y² = f(x). Bui-Pratt-Zaharescu analyze these systematically.",
+    "content": "**Hyperelliptic Curves Connection:**\n\nThe problem reduces to counting integral points on hyperelliptic curves. This connection is described informally in the source (Part V); it is not a formal axiom of the file.\n\n**Key insight:** If a₁·a₂·...·aⱼ = y² and a₁·...·aₖ = z² (j < k), then we get a relation on a hyperelliptic curve y² = f(x). Bui-Pratt-Zaharescu analyze these systematically.",
     "significance": "key",
     "relatedConcepts": [
       "Algebraic curves",


### PR DESCRIPTION
## Problem (part of #38611 Bucket D — annotation reconciliation)

The gallery annotations for **erdos-437** presented three `axiom` declarations in ```lean code blocks that **do not exist** in the verified source `proofs/Proofs/Erdos437Problem.lean`:

- `axiom L_le_x` (card `ann-e437-trivial-bound`)
- `axiom siegel_theorem_consequence` (card `ann-e437-siegel-consequence`)
- `axiom hyperelliptic_connection` (card `ann-e437-hyperelliptic`)

The source file has **exactly 4 axioms** — `L_little_o_x`, `erdos_437`, `L_lower_bound`, `L_upper_bound` — and keeps these three facts as **informal prose comment blocks** (Part V, "Trivial Bounds"). At some point the axioms were downgraded to comments and `meta.json` was updated accordingly (`axiomCount: 4`, assumptions list the 4 real axioms), but `annotations.json` was left stale, over-representing the assumption set as 7 axioms on the proof page.

## Fix

Reworded the three annotation cards to drop the false `axiom ...` code blocks and note that each fact is an informal remark in the source (not a formal axiom), preserving the pedagogical `mathContext`. No change to the verified axiom set; `meta.json` was already correct.

## Evidence

- **Before:** annotations render 6 `axiom` cards; `grep 'axiom '` in the annotation contents lists L_le_x / siegel_theorem_consequence / hyperelliptic_connection.
- **After:** `python3 -c 'json.load(...)'` valid; 19 annotations intact; zero `axiom`-block references to non-existent declarations; the 4 real axioms remain individually annotated.
- Source has exactly 4 `^axiom` declarations (decommented count); `meta.axiomCount = 4` unchanged.

Scope: annotations-only, single file, 3 content strings. Aligns gallery display with the corrected v4.31 source per #38611 acceptance criteria ("verify the gallery prose/annotations describe the corrected statement").

Part of #38611.

🤖 Generated with [Claude Code](https://claude.com/claude-code)