### PR TITLE
audit: re-serve erdos-875 (axiomatized/wip) — clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -17070,8 +17070,8 @@
     },
     "erdos-875": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T00:18:39Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-19T22:43:24Z",
       "result": "clean"
     },
     "erdos-876": {


### PR DESCRIPTION
## Gallery Integrity Audit — erdos-875

Re-served from the oldest uncontested cohort (unaudited queue drained; top-10 contested by fleet PRs). **Result: clean — no overclaims.**

### Checks
- **0 axiom declarations, 0 sorries, 0 True stubs** ✓
- `native_decide` (line 195, `pow2_small_example`) — **properly disclosed** in `assumptions` and the "Small Examples" section summary (`Lean.ofReduceBool`) ✓
- theoremCount 7 / definitionCount 7 — both match the source ✓
- Public status `axiomatized` / badge `wip` — conservative and honest for an OPEN Erdős problem; no theorem-level overclaim in title/description/keyInsights ✓

### Non-issues (safe direction, not flagged)
- `meta.axiomCount:1` vs `leanFile.axiomCount:0` drift: the `1` is the **conservative** direction, accounting for the `ofReduceBool` compiler axiom from `native_decide`. Overcounting axioms understates completeness — not an overclaim.
- lineCount 212 vs actual 213: stale undercount, harmless.
- Conclusion prose calls powers-of-2 admissibility "partial/axiomatized" though it's now fully proved via `pow2_subset_sum_inj` — an underclaim, safe.

Tracker updated to record the clean re-audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)