### PR TITLE
audit: re-serve erdos-818 (axiomatized) — clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -16615,8 +16615,8 @@
     },
     "erdos-818": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:53:24Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-19T22:46:12Z",
       "result": "clean"
     },
     "erdos-819": {


### PR DESCRIPTION
## Gallery integrity audit — erdos-818

**Result: clean** (re-serve; queue drained, reserve mode picked oldest uncontested target)

Product Set Lower Bound for Small Sumsets (Solymosi 2009).

| Check | meta.json | Lean source | Status |
|-------|-----------|-------------|--------|
| Status / badge | axiomatized / axiom | core `solymosi_theorem` is an `axiom` | ✅ correct Tier C |
| Sorries | 1 | 1 real (`proof_outline`); other hits are docstrings | ✅ |
| Axioms | 1 | 1 (`solymosi_theorem`); no assumption-carrying structs | ✅ |
| theoremCount | 8 | 8 | ✅ |
| definitionCount | 7 | 7 | ✅ |
| lineCount | 353 | 353 | ✅ |
| True stubs | — | 0 | ✅ |
| native_decide | — | 0 | ✅ |

`cauchy_schwarz_energy` is honestly credited as Mathlib-backed (`Finset.le_card_mul_mul_mulEnergy`); overview and conclusion explicitly disclose the 1 axiom + 1 remaining sorry. No overclaiming.

---
Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)