### PR TITLE
audit: re-serve erdos-81 (axiomatized) — clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -16554,8 +16554,8 @@
     },
     "erdos-81": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:53:24Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-19T22:48:24Z",
       "result": "clean"
     },
     "erdos-810": {


### PR DESCRIPTION
## Gallery Integrity Audit — erdos-81

Re-served oldest uncontested target (queue drained; reserve mode).

**Result: clean** — all counts verify against `proofs/Proofs/Erdos81Problem.lean`.

| Field | meta.json | Actual | OK |
|-------|-----------|--------|-----|
| axiomCount | 4 | 4 (`split_is_chordal`, `extremal_construction_exists`, `erdos_ordman_zalcstein`, `peo_gives_clique_partition`) | ✅ |
| sorries | 0 | 0 | ✅ |
| theoremCount | 4 | 4 | ✅ |
| definitionCount | 10 | 10 | ✅ |
| status / badge | axiomatized / axiom | core results axiomatized | ✅ |
| native_decide / True stubs | — | none | ✅ |

lineCount 290 vs actual 293 = stale undercount (harmless). Description correctly states the problem "remains open"; no overclaim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)