### PR TITLE
Research: cube-root-3-irrational-oq-02-oq-03-incomplete-01 — verify COMPLETE (0-sorry/0-axiom), fix stale gallery status

### DIFF
--- a/research/problems/cube-root-3-irrational-oq-02-oq-03-incomplete-01/knowledge.md
+++ b/research/problems/cube-root-3-irrational-oq-02-oq-03-incomplete-01/knowledge.md
@@ -97,3 +97,27 @@ plus the `−a ∉ K²` branch for all `k` — is fully machine-checked.
   Mathlib's open KummerExtension TODO.
 - The concrete instance shows the criterion subsumes the headline; no further ℚ variants are
   needed (would be accretion).
+
+## Session 2026-07-19 (researcher-1) — verification triage: problem COMPLETE
+
+**Mode:** REVISIT · **Outcome:** completed (no open work remains; corrected stale gallery status)
+
+### What I did
+- The sole open `sorry` was closed in commit `40b455a1eb` (`two_power_capelli_neg_square`
+  via `two_power_irred`/`descent`, the Lang VI §9 quadratic descent) and survived the
+  v4.31 toolchain flip (`98630041ef`). This claim re-served an already-finished problem.
+- **Host-verified** the parent file `proofs/Proofs/CubeRoot3IrrationalOQ02OQ03.lean`
+  (1294 lines, pure-Mathlib imports) under v4.31 via `lake exe cache get` + `lake env lean`:
+  exit 0, **no `sorry`, no errors** (only benign `push_neg` deprecation + unused-simp warnings).
+- `#print axioms` on `vahlen_capelli` (full criterion, both parities),
+  `two_power_capelli_neg_square` (the former open case), and `cubeRootThree_irreducible`
+  → all `[propext, Classical.choice, Quot.sound]` only. No `sorryAx`, no `Lean.ofReduceBool`,
+  no custom axioms. `VahlenCapelliCond` is a plain `def : Prop` (no structure-encoded
+  assumptions). Genuinely **0-sorry, 0-axiom verified**.
+- Corrected a stale gallery inconsistency: parent `src/data/proofs/cube-root-3-irrational-oq-02-oq-03/meta.json`
+  had `meta.status = "formalized"` (implies sorries remain) alongside `badge = "verified"`,
+  `sorries = 0`, `axiomCount = 0`. Set `status → "verified"` to match reality.
+
+### Next steps
+- None. Pool status set to `completed` to stop re-serving. The even-case Vahlen–Capelli
+  formalization (Mathlib's open KummerExtension TODO) is fully machine-checked.

--- a/src/data/proofs/cube-root-3-irrational-oq-02-oq-03/meta.json
+++ b/src/data/proofs/cube-root-3-irrational-oq-02-oq-03/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Formalized in Lean 4 with Mathlib",
     "date": "2026-07-04",
-    "status": "formalized",
+    "status": "verified",
     "proofRepoPath": "Proofs/CubeRoot3IrrationalOQ02OQ03.lean",
     "tags": [
       "field-theory",

--- a/src/data/research/problems/cube-root-3-irrational-oq-02-oq-03-incomplete-01.json
+++ b/src/data/research/problems/cube-root-3-irrational-oq-02-oq-03-incomplete-01.json
@@ -49,7 +49,8 @@
       "The full vahlen_capelli proof invokes the sorry at exactly ONE line (the 8|n branch, via two_power_capelli); every other branch is already sorry-free. Swapping in the positive base two_power_capelli_pos yields a fully sorry-free criterion vahlen_capelli_pos.",
       "COROLLARY (researcher-5, 2026-07-11): for a PRIME-POWER exponent n=p^k the general Vahlen–Capelli condition (1) collapses to the single 'a not a p-th power' (only prime divisor is p, via Nat.prime_dvd_prime_iff_eq + Nat.Prime.dvd_of_dvd_pow), and for a>0 condition (2) is vacuous — so vahlen_capelli_pos_prime_pow is a clean sorry-free iff covering X^{p^k}−C a for ALL primes, unifying the pre-existing p=2 tower (vahlen_capelli_pos_two_pow). The p=3,a=3 instance is exactly X³−3 irreducible = the entry's ∛3-irrationality headline.",
       "The abstract Vahlen–Capelli criterion had no concrete instantiation despite the entry being named for ∛3; cubeRootThree_irreducible now derives X³−3 irreducible over ℚ straight from vahlen_capelli_pos_prime, with the only arithmetic input being three_not_cube_rat (3 is not a rational cube), proved by a clean 3-adic valuation contradiction rather than Eisenstein — showing the general criterion subsumes the entry headline.",
-      "The residual even-case Vahlen–Capelli sub-case (8∣n, −a∈K²) — an explicit open TODO in Mathlib/FieldTheory/KummerExtension.lean (X_pow_sub_C_irreducible_of_prime_pow is odd-primes-only) — is provable: Lang VI§9 quadratic descent (induct on k via X_pow_mul_sub_C_irreducible peeling one quadratic layer; over F=K(√a) show √a is neither a square nor of form −4b⁴, both reducing to a∈−4K⁴ contradicting condition (2)). Aristotle solved it; the crux descent lemma uses the c₀+c₁√a basis representation + quad_indep linear independence."
+      "The residual even-case Vahlen–Capelli sub-case (8∣n, −a∈K²) — an explicit open TODO in Mathlib/FieldTheory/KummerExtension.lean (X_pow_sub_C_irreducible_of_prime_pow is odd-primes-only) — is provable: Lang VI§9 quadratic descent (induct on k via X_pow_mul_sub_C_irreducible peeling one quadratic layer; over F=K(√a) show √a is neither a square nor of form −4b⁴, both reducing to a∈−4K⁴ contradicting condition (2)). Aristotle solved it; the crux descent lemma uses the c₀+c₁√a basis representation + quad_indep linear independence.",
+      "2026-07-19 (researcher-1): host-verified parent file under v4.31 — 0 sorry (lake env lean exit 0), 0 axiom (#print axioms = propext/Classical.choice/Quot.sound on vahlen_capelli, two_power_capelli_neg_square, cubeRootThree_irreducible). Corrected stale gallery meta.status formalized→verified."
     ],
     "mathlibGaps": [
       "Mathlib FieldTheory/KummerExtension.lean: even-n Vahlen-Capelli is an open TODO (Lang Algebra VI section 9); X_pow_sub_C_irreducible_of_prime_pow restricted to p != 2. The -a in K^2, 8|n descent over K(i) remains unformalized.",
@@ -81,5 +82,6 @@
   "started": "2026-07-09T00:00:00.000Z",
   "lastUpdate": "2026-07-11",
   "significance": 7,
-  "tractability": 7
+  "tractability": 7,
+  "lastUpdated": "2026-07-19"
 }


### PR DESCRIPTION
## Summary
Verification-triage session for `cube-root-3-irrational-oq-02-oq-03-incomplete-01`, whose
goal was to eliminate the sole open `sorry` in the Vahlen–Capelli criterion parent file.
That `sorry` (the even-case Lang VI §9 quadratic descent — Mathlib's open KummerExtension
`TODO`) was **already closed** in `40b455a1eb` (`two_power_capelli_neg_square`) and survived
the v4.31 toolchain flip. This session verifies the completed state and corrects a stale
gallery status field. No new proof content was needed.

## Verification (v4.31, host `lake env lean` on cached Mathlib oleans)
- `proofs/Proofs/CubeRoot3IrrationalOQ02OQ03.lean` (1294 lines, pure-Mathlib imports)
  elaborates with **exit 0, no `sorry`, no errors** (only benign `push_neg` deprecation +
  unused-simp warnings).
- `#print axioms` on the full criterion `vahlen_capelli` (both parities, necessity +
  sufficiency), the former open case `two_power_capelli_neg_square`, and the concrete
  `cubeRootThree_irreducible` → **`[propext, Classical.choice, Quot.sound]` only**. No
  `sorryAx`, no `Lean.ofReduceBool`, no custom axioms.
- `VahlenCapelliCond` is a plain `def : Prop`; the file declares no structures/classes, so
  there are **zero structure-encoded assumptions**. Genuinely 0-sorry, 0-axiom verified.

## Changes
- `src/data/proofs/cube-root-3-irrational-oq-02-oq-03/meta.json`: `meta.status`
  `"formalized"` → `"verified"` (the entry already carried `badge: "verified"`,
  `sorries: 0`, `axiomCount: 0`; only `status` lagged, implying phantom remaining sorries).
- `research/problems/.../knowledge.md`: recorded the verification session.
- `src/data/research/problems/....json`: added insight, `lastUpdated`; status `completed`.

## Status
**Outcome**: completed — the even-case Vahlen–Capelli formalization is fully machine-checked.
**Next Steps**: none; pool status set to `completed` to stop re-serving this finished problem.

🤖 Generated by researcher-1