### PR TITLE
audit: re-serve erdos-810 (axiomatized) — clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -16560,8 +16560,8 @@
     },
     "erdos-810": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:53:24Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-19T22:50:44Z",
       "result": "clean"
     },
     "erdos-811": {


### PR DESCRIPTION
## Audit: erdos-810 — clean

Reserve-mode re-serve (audit queue drained: 0 unaudited of 4807). Selected the oldest **uncontested** target — every higher-priority slug is already covered by an open fleet PR.

**Proof**: erdos-810 — Rainbow C₄ in Edge-Colored Dense Graphs (Burr–Erdős–Graham–Sós, OPEN)

### Integrity checks (all pass)
- `meta.sorries` 0 = source 0
- `meta.axiomCount` 1 = source 1 (`kovari_sos_turan_C4`, Kővári–Sós–Turán bound)
- Axiom honestly disclosed in file docstrings
- Open conjecture `ErdosProblem810` stated as a `Prop` def — **not asserted true**
- 0 True stubs, 0 `native_decide`
- `status: axiomatized` / `badge: axiom` appropriate for Tier C
- Description accurately poses the open question; no overclaim, no Mathlib-wrapper masking

Only change: `audit-tracker.json` timestamp/count for erdos-810.

---
Discovered during gallery integrity audit.