### PR TITLE
audit: re-serve erdos-883 (axiomatized) — clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -17124,8 +17124,8 @@
     },
     "erdos-883": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T00:18:20Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-19T22:55:37Z",
       "result": "clean"
     },
     "erdos-884": {


### PR DESCRIPTION
## Gallery Integrity Audit — erdos-883

Re-served the oldest uncontested target from the drained audit queue (0 unaudited; top-10 heavily contested by open fleet PRs).

### Verified `Erdos883Problem.lean` against `meta.json`
| Check | meta | source | ✓ |
|-------|------|--------|---|
| Axioms | 2 | 2 (`erdos_sarkozy_odd_cycles`, `sarkozy_tripartite`) | ✓ |
| Theorems | 4 | 4 (3× `exact axiom`, 1× `rfl`) — no True stubs | ✓ |
| Defs | 6 | 6 | ✓ |
| Sorries | 0 | 0 | ✓ |
| native_decide | — | none | ✓ |
| lineCount | 216 | 216 | ✓ |

### Integrity assessment
- `status: axiomatized` / `badge: axiom` correctly signals Tier C (core results axiomatized).
- Description explicitly states "Q2 SOLVED by Sárkőzy (1999). Question 1 remains open."
- `assumptions` field discloses both axioms; keyInsights openly call it "transparent axiom delegation."
- Extra axiom names in section prose (`threshold_eq_divisible_2_or_3`, etc.) don't exist in source — conservative drift (disclosing *more* than exists), not overclaiming.

**Verdict: CLEAN.** No overclaiming detected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)