### PR TITLE
audit: re-serve erdos-807 (axiomatized/wip) — clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -16536,8 +16536,8 @@
     },
     "erdos-807": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:53:44Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-19T22:58:21Z",
       "result": "clean"
     },
     "erdos-808": {


### PR DESCRIPTION
## Gallery Integrity Audit — erdos-807

**Result: CLEAN** (reserve-mode re-serve; queue drained, oldest uncontested target)

Erdős #807 (Bipartite Decomposition of Random Graphs — disproved by Alon 2015).

### Verification
| Check | meta.json | Lean source | Verdict |
|-------|-----------|-------------|---------|
| status | `axiomatized` | True-stub scaffold | ✓ |
| badge | `wip` | scaffold only | ✓ |
| sorries | 0 | 0 | ✓ |
| axiomCount | 0 | 0 | ✓ |
| theoremCount | 4 | 4 | ✓ |
| definitionCount | 6 | 6 | ✓ |
| native_decide | — | none | ✓ |
| lineCount | 236 | 237 | stale undercount by 1 (harmless) |

### Notes
Main results (`alon_bohman_huang_2017`, `erdos_807`) are `∃ c, c > 0 ∧ True` True-stubs and `erw_conjecture_false` proves a vacuous encoding — but this is **honestly disclosed**: status=`axiomatized`, badge=`wip`, and the `assumptions` field explicitly states the main theorems are True-stub scaffolds. No overclaiming. Public claims match kernel reality.

---
Discovered during gallery integrity audit.