### PR TITLE
Research: schroeder-bernstein-oq-03-incomplete-01 — COMPLETE (correct stale sorry docstrings)

### DIFF
--- a/proofs/Proofs/SchroederBernsteinOQ03.lean
+++ b/proofs/Proofs/SchroederBernsteinOQ03.lean
@@ -65,9 +65,11 @@ computable via Partrec.rfind. The orbit type is determined by bounded search.
   partial-bijection layer and the two atomic, correspondence-preserving back-and-forth
   extension steps (domain step through f, range step through g). matching_functional /
   matching_cofunctional: the matching is a partial bijection (both coordinates determine
-  the partner). These are the pieces the stage scheduler assembles; only the scheduler
-  (collision-chasing via the alternating f/g chain) remains open.
-- myhill_isomorphism: hard direction has sorry (open: stage-wise back-and-forth construction)
+  the partner). These are the pieces the stage scheduler assembles.
+- myhill_isomorphism: COMPLETE (0-sorry / 0-axiom). Both directions proved; the hard direction
+  uses the computable extension-only scheduler `sigmaC` (Section 5·C), whose read-off is
+  `Computable` (`sigmaC_computable`), so the resulting permutation is a genuine computable
+  bijection. `#print axioms` → `[propext, Classical.choice, Quot.sound]` only.
 
 ## References
 - Myhill, J. (1955). "Creative sets." Z. Math. Logik Grundlag. Math. 1, 97–108.
@@ -3454,14 +3456,13 @@ theorem sigmaC_computable {f g : ℕ → ℕ} (hfc : Computable f) (hgc : Comput
     (c) Membership condition p n ↔ q (σ n) preserved by the back-and-forth
     (d) Computability: σ(n) is determined by the finite stage at which n enters dom
 
-    **Status (Path B assembled).** The bijection and its correspondence are now VERIFIED: Section
-    5·B builds the extension-only cons scheduler `stageSeqB` and reads off
-    `sigmaEquivB : ℕ ≃ ℕ` with `∀ n, p n ↔ q (sigmaEquivB n)` (`sigmaEquivB_corr`), all 0-axiom.
-    The **sole** remaining gap is *computability* of that bijection: `stageSeqB` is
-    `noncomputable` (uses `Classical.choose` on the escape existentials), so `sigmaEquivB` is not
-    yet a `Computable` permutation. Discharging `e.Computable` requires a computable parallel
-    `stageSeqB` (bounded `Nat.rfind` escape search, licensed by `escape_exists'`'s
-    `N ≤ (mRan L).length` bound) — the residual `sorry` below. -/
+    **Status (Path C assembled — COMPLETE, 0-sorry / 0-axiom).** The computability gap that Path B
+    left open is now closed: Section 5·C replaces the `noncomputable` `stageSeqB` with the
+    computable extension-only scheduler behind `sigmaC f g`, whose read-off `sigmaC_computable`
+    (`mLookup_computable ∘ stageListC_computable` at the fixed computable index `2n+1`) makes the
+    permutation `Equiv.ofBijective (sigmaC f g)` a genuine `Computable` permutation. The hard
+    direction below therefore discharges `e.Computable` directly — there is no remaining `sorry`.
+    `#print axioms myhill_isomorphism` → `[propext, Classical.choice, Quot.sound]` only. -/
 theorem myhill_isomorphism (p q : ℕ → Prop) :
     OneOneEquiv p q ↔
     ∃ e : ℕ ≃ ℕ, e.Computable ∧ ∀ n, p n ↔ q (e n) := by

--- a/research/problems/schroeder-bernstein-oq-03-incomplete-01/knowledge.md
+++ b/research/problems/schroeder-bernstein-oq-03-incomplete-01/knowledge.md
@@ -1,0 +1,30 @@
+# Knowledge Base: schroeder-bernstein-oq-03-incomplete-01
+
+Completion task: close the residual `sorry` in `SchroederBernsteinOQ03.lean`
+(Myhill's Isomorphism Theorem, 1955 — the computable Schröder–Bernstein).
+
+## Session 2026-07-19 (researcher-1) — problem COMPLETE (stale docstrings corrected)
+
+**Mode:** FRESH · **Outcome:** completed (no code `sorry` remains; corrected misleading docstrings)
+
+### Finding
+The residual `sorry` this completion task targets **no longer exists**. The file's hard
+direction was closed via **Path C** — the computable extension-only scheduler `sigmaC f g`,
+whose read-off `sigmaC_computable` (= `mLookup_computable ∘ stageListC_computable` at the fixed
+computable index `2n+1`) makes `Equiv.ofBijective (sigmaC f g)` a genuine `Computable`
+permutation. `myhill_isomorphism` proves both directions with **no `sorry`**. Two docstrings
+were stale, still describing Path B's open computability gap ("the residual `sorry` below",
+"hard direction has sorry"); these are now corrected to reflect the completed Path C.
+
+### Verification (v4.31, host `lake exe cache get` + `lake env lean`)
+- `proofs/Proofs/SchroederBernsteinOQ03.lean` (3556 lines, Mathlib.Computability imports)
+  elaborates **exit 0, no `sorry`, no errors** (only benign unused-variable/section-var linter
+  warnings).
+- `#print axioms MyhillIsomorphism.myhill_isomorphism` and `...sigmaC_computable` →
+  `[propext, Classical.choice, Quot.sound]` only. No `sorryAx`, no custom axioms.
+- Gallery meta `src/data/proofs/schroeder-bernstein-oq-03/meta.json` already correctly reads
+  `status: verified, sorries: 0, axiomCount: 0` — no gallery change needed.
+
+### Next steps
+- None. Pool status set to `completed`. Myhill's theorem (computable bijection from computable
+  injections) is fully machine-checked.


### PR DESCRIPTION
## Summary
Completion task `schroeder-bernstein-oq-03-incomplete-01` targets the residual `sorry` in
`SchroederBernsteinOQ03.lean` (Myhill's Isomorphism Theorem, 1955 — the computable
Schröder–Bernstein). That `sorry` **no longer exists**: the hard direction was closed via
**Path C**, the computable extension-only scheduler `sigmaC f g`. This session verifies the
completed state under v4.31 and corrects two docstrings that still described Path B's open
computability gap.

## Details
- `myhill_isomorphism` proves both directions with no `sorry`. The hard direction builds the
  computable permutation `Equiv.ofBijective (sigmaC f g)`; its read-off `sigmaC_computable`
  (= `mLookup_computable ∘ stageListC_computable` at the fixed computable index `2n+1`)
  discharges the `Computable` obligation directly.
- Two stale docstrings claimed a residual `sorry` ("**Status (Path B assembled)** … the residual
  `sorry` below", and the file-header summary "hard direction has sorry"). Both corrected to
  reflect the completed Path C. **No proof logic changed.**

## Verification (v4.31, host `lake exe cache get` + `lake env lean`)
- `proofs/Proofs/SchroederBernsteinOQ03.lean` (3556 lines) elaborates **exit 0, no `sorry`,
  no errors** (only benign unused-variable/section-var linter warnings).
- `#print axioms MyhillIsomorphism.myhill_isomorphism` and `...sigmaC_computable` →
  **`[propext, Classical.choice, Quot.sound]` only**. No `sorryAx`, no custom axioms.
- Gallery meta `src/data/proofs/schroeder-bernstein-oq-03/meta.json` already reads
  `status: verified, sorries: 0, axiomCount: 0` — no gallery change needed.

## Status
**Outcome**: completed — Myhill's theorem is fully machine-checked; the completion task's
target sorry was already closed and the file's docstrings now say so.
**Next Steps**: none; pool status set to `completed`.

🤖 Generated by researcher-1