### PR TITLE
audit: re-serve erdos-804 (axiomatized) — clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -16518,8 +16518,8 @@
     },
     "erdos-804": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:53:44Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-19T23:03:03Z",
       "result": "clean"
     },
     "erdos-805": {


### PR DESCRIPTION
## Gallery Integrity Audit — erdos-804

Re-served from the drained unaudited queue (reserve mode); target was uncontested by open PRs.

**Result: CLEAN** — no integrity issues.

### Verification (meta.json vs Proofs/Erdos804Problem.lean)

| Field | meta.json | Lean source | OK |
|-------|-----------|-------------|-----|
| axiomCount | 5 | 5 `axiom` decls | ✓ |
| sorries | 0 | none | ✓ |
| theoremCount | 3 | 3 | ✓ |
| definitionCount | 3 | 3 | ✓ |
| lineCount | 244 | 246 (stale undercount, harmless) | ✓ |
| status/badge | axiomatized / axiom | disproof genuinely axiomatized | ✓ |

- No `True` stubs, no `native_decide`.
- `erdos_804` and `erdos_804_resolution` honestly combine the 5 axioms; `originalContributions` lists each axiom explicitly. Description states the result was DISPROVED by Alon-Sudakov and formalized via axiomatization — no overclaim.

Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)