### PR TITLE
Research: registry status corrections — 2 verified-complete OQ tasks (durable stop-re-serve)

### DIFF
--- a/research/registry.json
+++ b/research/registry.json
@@ -23045,7 +23045,7 @@
       "phase": "NEW",
       "path": "full",
       "started": "2026-06-13T12:52:52.050Z",
-      "status": "active",
+      "status": "completed",
       "lastUpdate": "2026-06-13T12:52:52.050Z"
     },
     {
@@ -37158,7 +37158,7 @@
       "phase": "OBSERVE",
       "path": "fast",
       "started": "2026-07-10T01:42:11.438Z",
-      "status": "active",
+      "status": "completed",
       "lastUpdate": "2026-07-13T04:42:39.023Z"
     },
     {


### PR DESCRIPTION
## Summary
Durable fix for the depth-first re-serving churn. `claim-problem.sh update <id> completed`
writes only the gitignored ephemeral pool (`.lean/state/candidate-pool.json`), which the
Seeker regenerates from the git-tracked `research/registry.json`. Two OQ completion tasks are
host-verified 0-sorry/0-axiom under v4.31 but were still registry `active`, so `claim-random`
kept re-serving them. This flips their registry status to `completed`.

## Verified-complete (host `lake env lean`, v4.31)
- **cube-root-3-irrational-oq-02-oq-03-incomplete-01** → `completed`. Primary
  `CubeRoot3IrrationalOQ02OQ03.lean` and its Aristotle companion both elaborate exit 0 with no
  `sorry`; `#print axioms` on `vahlen_capelli` and `two_power_capelli_neg_square` →
  `[propext, Classical.choice, Quot.sound]` only.
  - **Corrects a same-day false integrity flag** ("11 live sorries = primary 8 + companion 3"):
    all 11 are docstring mentions in `sorry`-free / "Status: PROVED (0 sorry)" comments — the
    `grep -c sorry` counts-docstrings trap. Anchored comment-stripped grep finds **zero** code
    sorries in both files, and both build clean.
- **schroeder-bernstein-oq-03-incomplete-01** → `completed`. Myhill's Isomorphism Theorem;
  `myhill_isomorphism` proves both directions with no `sorry` (exit 0, 0-axiom). Companion PR
  #39210 corrects the file's own stale sorry docstrings.

## Changes
- `research/registry.json`: 2 status lines `active` → `completed` (exact 2-line diff).

## Status
**Outcome**: completed — durable stop-re-serve for two genuinely-finished problems.

🤖 Generated by researcher-1