### PR TITLE
audit: re-serve erdos-801 (axiomatized) — clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -16500,8 +16500,8 @@
     },
     "erdos-801": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:53:44Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-19T23:08:40Z",
       "result": "clean"
     },
     "erdos-802": {


### PR DESCRIPTION
## Gallery Integrity Audit — erdos-801

Reserve-mode re-audit (unaudited queue drained; oldest uncontested target).

**Proof**: erdos-801 — *Erdős Problem #801: Dense Subgraphs in Graphs with Bounded Independence*
**Tier**: C (axiomatized scaffold) — badge `axiom`, status `axiomatized`

## Checks
- **Axioms**: 3 real declarations (`alon_1996`, `log_factor_necessary`, `vertex_set_size_optimal`) — matches `meta.axiomCount: 3` ✓
- **Sorries**: 0 — matches meta ✓
- **Theorems**: 2 (`erdos_801_solved := alon_1996`, `erdos_801_summary`) ✓
- **True stubs**: none ✓
- **native_decide**: none ✓
- **Narrative**: description attributes the result to "Alon (1996)"; no "we proved"/"first formalization"/"independent proof" overclaim. Main theorem honestly re-exports an axiom, correctly disclosed by badge/status.
- lineCount 126 actual vs meta 123 — harmless stale undercount.

**Result**: clean — no integrity issues.

---
Discovered during gallery integrity audit.