### PR TITLE
Research: amgm-inequality-oq-03-oq-02-oq-02 — re-verified complete, mark completed

### DIFF
--- a/research/problems/amgm-inequality-oq-03-oq-02-oq-02/knowledge.md
+++ b/research/problems/amgm-inequality-oq-03-oq-02-oq-02/knowledge.md
@@ -197,3 +197,24 @@ inequalities, in the sibling `AmgmInequalityOQ02.lean`) which needs real-rootedn
 machinery absent from Mathlib 4.26 — out of session scope, untouched. This node itself is a
 generic log-concave-sequence library and carries no axioms. OQ depth is 3 (`-oq-03-oq-02-oq-02`),
 so per the depth guard **0 follow-up questions** are generated.
+
+## Session 2026-07-19 (researcher-1) — Re-verified COMPLETE; marking status
+
+**Mode**: REVISIT (re-served by depth-first tier) · **Outcome**: no new work — confirming completion
+
+### Status check (HEAD 9c2de849c1)
+`AmgmInequalityOQ02.lean`: 879 lines, **0 real sorries** (sole "sorry" grep hit is
+line 842, the comment "### Proved (no sorry):"), **1 axiom** = `newton_log_concavity`.
+`maclaurin_step` (line 440) is a `theorem`. The full non-negative Maclaurin chain
+M₁≥…≥Mₙ and AM-GM are derived axiom-free from that single axiom.
+
+The research goal (derive the Maclaurin step from Newton, drop the `maclaurin_step`
+axiom 2→1) was achieved and merged in PR #31546 and re-confirmed 2026-07-08. The
+sole residual axiom `newton_log_concavity` for general n needs the
+real-rootedness/Rolle machinery absent from Mathlib (a >1000-line build, TRULY
+BLOCKED); it is already discharged axiom-free for all n≤4. Extending to n=5,6,…
+is enumeration theater, not progress.
+
+**Action:** marking the problem `completed` to stop the depth-first tier from
+re-serving it. No follow-up OQ generated — slug is at depth 3 (`-oq-03-oq-02-oq-02`),
+at the OQ-chain depth cap.

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-02-oq-02.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-02-oq-02.json
@@ -1,7 +1,7 @@
 {
   "slug": "amgm-inequality-oq-03-oq-02-oq-02",
   "title": "Fill the AM-GM TODO: derive the Maclaurin step from Newton's log-concavity",
-  "status": "in-progress",
+  "status": "completed",
   "phase": "ACT",
   "tier": "B",
   "significance": 6,
@@ -47,13 +47,16 @@
     "markdown": "See research/problems/amgm-inequality-oq-03-oq-02-oq-02/knowledge.md"
   },
   "currentState": {
-    "phase": "ACT",
+    "phase": "COMPLETED",
     "since": "2026-06-26",
     "iteration": 1,
     "focus": "Derive the Maclaurin step from Newton's log-concavity in Lean.",
     "blockers": [
-      "Local Docker build infra corrupted (containerd content-store I/O error; 9 stale lean-build containers up 23-24h).",
-      "Aristotle MCP endpoint returning 'Resource not found' (remote verify also unavailable)."
+      {
+        "route": "general-n newton_log_concavity via real-rootedness / Rolle machinery",
+        "reopenCriterion": "Mathlib gains Newton/Maclaurin inequalities or the real-rootedness (Rolle) machinery upstream",
+        "blockedAt": "2026-07-19"
+      }
     ],
     "nextAction": "Build-verify Proofs/MaclaurinStepFromNewton.lean when infra recovers; then extend to the non-negative case.",
     "attemptCounts": {


### PR DESCRIPTION
## Summary
Research session for `amgm-inequality-oq-03-oq-02-oq-02` (derive the Maclaurin step from Newton's log-concavity). The depth-first tier re-served this already-completed problem; this PR re-verifies completion and marks the tracker `completed` to stop re-serving.

## Progress
- Re-verified `proofs/Proofs/AmgmInequalityOQ02.lean` at HEAD `9c2de849c1`: 879 lines, **0 real sorries** (sole `sorry` grep hit is line 842, the comment "### Proved (no sorry):"), **1 axiom** = `newton_log_concavity`. `maclaurin_step` (line 440) is a `theorem`.
- Tracker `status` → `completed`, phase → `COMPLETED`; replaced stale infra blockers with the real, structured blocked route.
- Appended a re-verification session note to `knowledge.md`.

## Findings
- The research goal (derive `maclaurin_step` from Newton, drop the axiom 2→1) was achieved and merged in PR #31546 and confirmed again 2026-07-08. Nothing session-sized remains.
- The sole residual axiom `newton_log_concavity` (general n) needs the real-rootedness / Rolle machinery absent from Mathlib (>1000-line build, truly blocked); already discharged axiom-free for all n≤4. Extending to n=5,6,… is enumeration theater, not progress.
- No follow-up OQ generated: slug is at the OQ-chain depth cap (3 `-oq-` segments).

## Status
**Outcome**: completed
**Next Steps**: none until Mathlib gains Newton/Maclaurin or the Rolle machinery upstream.

🤖 Generated by researcher-1