### PR TITLE
audit: erdos-797 — sync stale prose (phantom declarations)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -16456,9 +16456,9 @@
     },
     "erdos-797": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:53:44Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-07-19T23:13:33Z",
+      "result": "issues-fixed"
     },
     "erdos-798": {
       "agentId": "auditor-reaudit-20260708",

--- a/src/data/proofs/erdos-797/meta.json
+++ b/src/data/proofs/erdos-797/meta.json
@@ -52,12 +52,11 @@
       "IsAcyclicColoring combining properness and acyclicity",
       "maxDegree via Finset.sup over vertex degrees",
       "acyclicChromaticNumber via sInf",
-      "f(d) axiomatized with f_realized existence guarantee",
-      "Greedy, Erdős, AMR, and precise lower bound axioms",
-      "asymptotic_theta combining upper and lower into Θ(d^{4/3})",
+      "f(d) axiomatized as the extremal function",
+      "alon_mcdiarmid_reed_upper axiom: AMR O(d^{4/3}) upper bound",
+      "precise_lower_bound axiom: Ω(d^{4/3}/(log d)^{1/3}) lower bound",
       "is_B2_sequence connecting to Sidon sets",
-      "erdos_797_subquadratic: f(d) = o(d²) answering the original question",
-      "erdos_797_summary proved theorem combining AMR upper and precise lower"
+      "erdos_797_summary theorem combining the AMR upper and precise lower bound axioms"
     ],
     "axiomCount": 3,
     "lineCount": 155,
@@ -69,7 +68,7 @@
     "historicalContext": "Erdős asked for estimates of f(d), the maximum acyclic chromatic number over all graphs with maximum degree d. An acyclic coloring is a proper vertex coloring in which no cycle is bichromatic (uses only two colors). A greedy argument gives f(d) ≤ d² + 1, and Erdős asked whether f(d) = o(d²).\n\nErdős himself showed the lower bound f(d) ≥ d^{4/3 - o(1)} using probabilistic constructions related to B₂ sequences (Sidon sets). The problem was resolved by Alon, McDiarmid, and Reed in 1991, who proved the matching upper bound f(d) ≤ O(d^{4/3}) using the Lovász Local Lemma, confirming that f(d) = o(d²) and establishing f(d) = Θ(d^{4/3}).\n\nThe precise asymptotics remain slightly open: the best bounds are c·d^{4/3}/(log d)^{1/3} ≤ f(d) ≤ C·d^{4/3}, leaving a (log d)^{1/3} gap. The connection to B₂ sequences (Sidon sets) is central to the lower bound construction — dense Sidon sets in ℤ_p yield graphs requiring many colors for acyclic coloring.",
     "problemStatement": "Let $f(d)$ be the maximal acyclic chromatic number of any graph with maximum degree $d$. An acyclic coloring is a proper coloring where no cycle uses only two colors.\n\nEstimate $f(d)$. In particular, is it true that $f(d) = o(d^2)$?\n\n**Answer:** YES. $f(d) = \\Theta(d^{4/3})$.\n- Upper: $f(d) \\leq O(d^{4/3})$ [Alon-McDiarmid-Reed 1991]\n- Lower: $f(d) \\geq \\Omega(d^{4/3} / (\\log d)^{1/3})$",
     "text": "Let f(d) be the maximal acyclic chromatic number of any graph with maximum degree d. Estimate f(d). In particular, is f(d) = o(d²)? Resolved: f(d) = Θ(d^{4/3}) by Alon-McDiarmid-Reed (1991).",
-    "proofStrategy": "The formalization defines acyclic coloring via IsProperColoring and HasBichromaticCycle predicates, then axiomatizes f(d) as the extremal function. Four bounds are axiomatized: the greedy upper bound d² + 1, Erdős's lower bound d^{4/3 - ε}, the AMR upper bound O(d^{4/3}), and the precise lower bound Ω(d^{4/3}/(log d)^{1/3}). The subquadratic property f(d) = o(d²) is axiomatized as an explicit ε-δ statement. The summary theorem proves the conjunction of the AMR upper bound and the precise lower bound.",
+    "proofStrategy": "The formalization defines acyclic coloring via IsProperColoring and HasBichromaticCycle predicates, then axiomatizes f(d) as the extremal function. Two bounds are axiomatized: the AMR upper bound O(d^{4/3}) (alon_mcdiarmid_reed_upper) and the precise lower bound Ω(d^{4/3}/(log d)^{1/3}) (precise_lower_bound). The greedy bound d² + 1, Erdős's d^{4/3 - ε} lower bound, the Θ(d^{4/3}) asymptotic, and the subquadratic property f(d) = o(d²) are discussed in comments but not separately declared. The summary theorem (erdos_797_summary) proves the conjunction of the two axiomatized bounds.",
     "keyInsights": [
       "**Greedy Bound:** f(d) ≤ d² + 1 is far from optimal — the true answer is d^{4/3}",
       "**Probabilistic Lower Bound:** Erdős's d^{4/3 - o(1)} lower bound using Sidon sets suggested the true order of magnitude",


### PR DESCRIPTION
## Gallery integrity: erdos-797 originalContributions/proofStrategy overstate present declarations

**Proof**: erdos-797 (Acyclic Chromatic Number)
**Severity**: LOW — narrative only; badge/counts already correct.

### Problem
`meta.json` named several Lean declarations that exist only as **comments** in `Proofs/Erdos797Problem.lean`, not as actual declarations:

- `f_realized` existence guarantee — never declared
- Greedy (`d²+1`) and Erdős (`d^{4/3-ε}`) "bound axioms" — comments only (L86–93)
- `asymptotic_theta` — comment only (L111–113)
- `erdos_797_subquadratic` — comment only (L129–131)
- proofStrategy claimed "**Four** bounds are axiomatized" and that `f(d)=o(d²)` "is axiomatized"

### Evidence (verified against source)
The file actually declares: **3 axioms** (`f`, `alon_mcdiarmid_reed_upper`, `precise_lower_bound`), **1 theorem** (`erdos_797_summary` = conjunction of the two bound axioms), **6 defs**, **0 sorries**.

These match `axiomCount:3`, `theoremCount:1`, `definitionCount:6`, `sorries:0`. Only the `originalContributions` list and `proofStrategy` prose overstated the present declarations.

### Fix
Trimmed `originalContributions` to the declarations that actually exist and corrected `proofStrategy` to say two bounds are axiomatized (the rest discussed in comments). `status:axiomatized` / `badge:axiom` unchanged — those were already honest.

---
Discovered during gallery integrity audit.