### PR TITLE
audit: re-serve erdos-8 (axiomatized) — clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -16476,8 +16476,8 @@
     },
     "erdos-8": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:53:44Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-19T23:17:33Z",
       "result": "clean"
     },
     "erdos-8-oq-02": {


### PR DESCRIPTION
## Gallery Integrity Audit — erdos-8

**Result: CLEAN.** Re-served the oldest uncontested target (queue fully drained; last audited 2026-05-04, 3×).

**Proof**: Erdős Problem #8 — Monochromatic Covering Systems (Tier C, axiomatized)

### Verified
- `meta.axiomCount = 2` matches source: `hough_minimum_modulus` (Hough 2015 bound), `density_conjecture_false` — both real `axiom` decls, honestly labeled.
- `sorries = 0`, 0 True stubs, 0 `native_decide` — all match `Proofs/Erdos8Problem.lean`.
- `badge: axiom` / `status: axiomatized` correctly disclose reliance on axiomatized deep results; `author: Hough (2015)`.
- `bottleneck_counterexample` is a fully-proved reduction (explicit coloring into `Fin 616001`); `erdos_8_resolution` / `erdos_8_false` genuinely derive `¬erdos_graham_conjecture` from the axiomatized bound — not a True-stub.
- `originalContributions` scoped to what is independently formalized (structures, predicates, statement, derivation).
- Description "DISPROVED by Hough (2015)" attributes correctly — no delegation opacity, no axiom masking.

### Minor (harmless, no fix needed)
- `meta.lineCount = 351` vs actual 356 — stale undercount (safe per audit gotchas).

---
Discovered during gallery integrity audit (reserve/re-serve mode).