### PR TITLE
Research: basel-problem-oq-01-oq-02 — N-family ℚ-linear independence of even zeta values

### DIFF
--- a/proofs/Proofs/BaselProblemOQ01OQ02LinIndep.lean
+++ b/proofs/Proofs/BaselProblemOQ01OQ02LinIndep.lean
@@ -7,7 +7,8 @@
   finite/weighted products, polynomial evaluations, and pairwise sums/differences are all
   shown transcendental.  What that development never records is the **linear-algebra**
   structure over `ℚ`: distinct even zeta values are not merely individually transcendental,
-  they are jointly `ℚ`-linearly independent.  This file supplies that fact for a pair.
+  they are jointly `ℚ`-linearly independent.  This file supplies that fact — first for a
+  pair, then for the whole family `ζ(2), ζ(4), …, ζ(2N)`.
 
     * `zeta_even_no_rational_relation` — for `0 < m < n`, the only rational solution of
       `a·ζ(2m) + b·ζ(2n) = 0` is `a = b = 0`.  (Strictly stronger than
@@ -17,6 +18,10 @@
       `LinearIndependent ℚ ![ζ(2m), ζ(2n)]`.
     * `zeta_two_zeta_four_linearIndependent` — the concrete Basel instance
       `LinearIndependent ℚ ![ζ(2), ζ(4)]`.
+    * `zeta_even_linearIndependent_family` — the `N`-family generalization
+      `LinearIndependent ℚ (fun i : Fin N ↦ ζ(2(i+1)))`, via a single polynomial identity
+      at `π` and transcendence of `π` (strictly stronger than any collection of pairs).
+    * `zeta_two_four_six_linearIndependent` — the concrete instance for `ζ(2), ζ(4), ζ(6)`.
 
   Mathematically: `ζ(2m) = qₘ·π^(2m)` and `ζ(2n) = qₙ·π^(2n)` with `qₘ, qₙ ∈ ℚ∖{0}`;
   a rational relation forces `a·qₘ + b·qₙ·π^(2(n-m)) = 0` after dividing by `π^(2m)`, and
@@ -111,5 +116,72 @@ theorem zeta_two_zeta_four_linearIndependent :
     LinearIndependent ℚ
       ![(∑' k : ℕ, 1 / (k : ℝ) ^ 2), (∑' k : ℕ, 1 / (k : ℝ) ^ 4)] := by
   exact zeta_even_linearIndependent_pair 2 1 one_pos (by norm_num)
+
+/-- **The full family of even zeta values is `ℚ`-linearly independent.**  For every `N`,
+
+      `LinearIndependent ℚ (fun i : Fin N ↦ ζ(2(i+1)))`,
+
+    i.e. `ζ(2), ζ(4), …, ζ(2N)` are jointly `ℚ`-linearly independent.  This is the
+    `N`-family generalization of `zeta_even_linearIndependent_pair` (strictly stronger than
+    any finite collection of pairwise statements): the *only* rational vanishing relation
+    `∑ᵢ gᵢ · ζ(2(i+1)) = 0` is the trivial one.
+
+    **Proof.**  Euler gives `ζ(2(i+1)) = qᵢ · π^(2(i+1))` with `qᵢ ∈ ℚ∖{0}`, so a rational
+    relation `∑ᵢ gᵢ ζ(2(i+1)) = 0` becomes `∑ᵢ (gᵢ qᵢ) π^(2(i+1)) = 0 = aeval π P` for the
+    polynomial `P = ∑ᵢ C(gᵢ qᵢ) · X^(2(i+1)) ∈ ℚ[X]`.  Transcendence of `π` over `ℚ`
+    (`transcendental_iff`, from `pi_transcendental_over_rationals`) forces `P = 0`; since the
+    exponents `2(i+1)` are distinct, the coefficient of `X^(2(j+1))` is exactly `gⱼ qⱼ`, so
+    `gⱼ qⱼ = 0`, and `qⱼ ≠ 0` gives `gⱼ = 0`.
+
+    **Assumption:** `hermite_lindemann` (transcendence of `π`), via `pi_transcendental_over_rationals`.
+    The reduction of linear independence to a single polynomial identity is axiom-free; the
+    axiom enters only through the transcendence of `π`. -/
+theorem zeta_even_linearIndependent_family (N : ℕ) :
+    LinearIndependent ℚ
+      (fun i : Fin N => (∑' k : ℕ, 1 / (k : ℝ) ^ (2 * (i.val + 1)))) := by
+  rw [Fintype.linearIndependent_iff]
+  intro g hsum
+  -- Euler closed form for each component, as a choice of nonzero rationals `qm`.
+  have hq : ∀ i : Fin N, ∃ q : ℚ, q ≠ 0 ∧
+      (∑' k : ℕ, 1 / (k : ℝ) ^ (2 * (i.val + 1))) = (q : ℝ) * π ^ (2 * (i.val + 1)) :=
+    fun i => BaselProblemOQ01OQ02.zeta_even_eq_rat_mul_pi_pow (i.val + 1) (Nat.succ_pos _)
+  choose qm hqm0 hqmeq using hq
+  -- Substitute Euler and convert the `ℚ`-scalar action to `ratCast` multiplication.
+  have hsum' :
+      (∑ i : Fin N, ((g i * qm i : ℚ) : ℝ) * π ^ (2 * (i.val + 1))) = 0 := by
+    rw [← hsum]
+    refine Finset.sum_congr rfl (fun i _ => ?_)
+    rw [Rat.smul_def, hqmeq i]
+    push_cast; ring
+  -- The vanishing polynomial `P = ∑ C(g i · qm i) · X^(2(i+1))`.
+  set P : Polynomial ℚ :=
+    ∑ i : Fin N, Polynomial.C (g i * qm i) * Polynomial.X ^ (2 * (i.val + 1)) with hP
+  have haeval : (Polynomial.aeval (π : ℝ)) P = 0 := by
+    rw [hP, map_sum, ← hsum']
+    refine Finset.sum_congr rfl (fun i _ => ?_)
+    rw [map_mul, map_pow, Polynomial.aeval_C, Polynomial.aeval_X, eq_ratCast]
+  -- Transcendence of π over ℚ forces P = 0.
+  have hPzero : P = 0 :=
+    (transcendental_iff.mp pi_transcendental_over_rationals) P haeval
+  -- Read off the coefficient of X^(2(j+1)): it is exactly g j · qm j.
+  intro j
+  have hcoeff : P.coeff (2 * (j.val + 1)) = g j * qm j := by
+    rw [hP, Polynomial.finsetSum_coeff,
+      Finset.sum_eq_single_of_mem j (Finset.mem_univ j)]
+    · rw [Polynomial.coeff_C_mul, Polynomial.coeff_X_pow, if_pos rfl, mul_one]
+    · intro i _ hij
+      rw [Polynomial.coeff_C_mul, Polynomial.coeff_X_pow, if_neg, mul_zero]
+      intro hcontra
+      exact hij (Fin.ext (by omega : (i : ℕ) = j))
+  rw [hPzero, Polynomial.coeff_zero] at hcoeff
+  rcases mul_eq_zero.mp hcoeff.symm with h1 | h1
+  · exact h1
+  · exact absurd h1 (hqm0 j)
+
+/-- **Concrete instance:** `ζ(2), ζ(4), ζ(6)` are `ℚ`-linearly independent. -/
+theorem zeta_two_four_six_linearIndependent :
+    LinearIndependent ℚ
+      (fun i : Fin 3 => (∑' k : ℕ, 1 / (k : ℝ) ^ (2 * (i.val + 1)))) :=
+  zeta_even_linearIndependent_family 3
 
 end BaselProblemOQ01OQ02LinIndep

--- a/research/problems/basel-problem-oq-01-oq-02/knowledge.md
+++ b/research/problems/basel-problem-oq-01-oq-02/knowledge.md
@@ -247,3 +247,43 @@ drop it and rely on `2*1`/`2*2` defeq reduction instead.
   `transcendental_iff_injective` on `aeval (π²)`) — the N-family generalization.
 - Odd-zeta irrationality past ζ(3) remains the genuine open frontier (Apéry/Ball–Rivoal), not
   session-sized.
+
+## Session 2026-07-19 (researcher-1) — N-family ℚ-linear independence of even zeta values
+
+**Mode:** ACT (node saturated on transcendence + the *pairwise* linear-independence;
+the **N-family** generalization of the pair was the documented open "Next Step").
+**Outcome:** progress — 1 general theorem + 1 concrete instance, no new axioms.
+
+The prior linear-independence layer stopped at `zeta_even_linearIndependent_pair`
+(`LinearIndependent ℚ ![ζ(2m), ζ(2n)]`). The natural — and strictly stronger — statement,
+that the *whole* family `ζ(2), ζ(4), …, ζ(2N)` is jointly ℚ-linearly independent, was
+listed as the open next step. Now proved in `BaselProblemOQ01OQ02LinIndep.lean`:
+
+- `zeta_even_linearIndependent_family (N : ℕ) :
+   LinearIndependent ℚ (fun i : Fin N => ζ(2(i+1)))`.
+- `zeta_two_four_six_linearIndependent` : concrete `Fin 3` instance (`ζ(2), ζ(4), ζ(6)`).
+
+### Proof mechanism (the reusable move)
+`Fintype.linearIndependent_iff` reduces to: every rational relation `∑ᵢ gᵢ • ζ(2(i+1)) = 0`
+is trivial. Euler (`zeta_even_eq_rat_mul_pi_pow`, `choose`) writes `ζ(2(i+1)) = qᵢ·π^(2(i+1))`
+with `qᵢ ≠ 0`, so the relation becomes `aeval π P = 0` for the **single polynomial**
+`P = ∑ᵢ C(gᵢ·qᵢ)·X^(2(i+1)) ∈ ℚ[X]`. ★key: `transcendental_iff.mp
+pi_transcendental_over_rationals : ∀ p, aeval π p = 0 → p = 0` collapses the whole family to
+one polynomial-vanishing fact. Distinct exponents `2(i+1)` ⟹ `P.coeff (2(j+1)) = gⱼ·qⱼ`
+(via `finsetSum_coeff` + `coeff_C_mul` + `coeff_X_pow` + `Finset.sum_eq_single_of_mem`,
+`Fin.ext`+`omega` for the exponent injectivity), and `P = 0` + `qⱼ ≠ 0` ⟹ `gⱼ = 0`.
+
+This is the clean N-ary form: the pairwise proof routed through
+`Irrational (π^(2(n-m)))`, which does not scale to N terms; the polynomial/`transcendental_iff`
+route does. `smul→ratCast·` via `Rat.smul_def`; `algebraMap ℚ ℝ q = ↑q` via `eq_ratCast` (simp).
+
+### Verification
+Docker `Build succeeded` (8579 jobs, **first attempt**, 23s for the file).
+`#print axioms zeta_even_linearIndependent_family` =
+`[propext, Classical.choice, HermiteLindemann.hermite_lindemann, Quot.sound]` — SAME as the
+parent node (via `pi_transcendental_over_rationals`), **no new axiom, no `sorryAx`**.
+
+### Frontier unchanged
+Odd-zeta irrationality past ζ(3) (Apéry / Ball–Rivoal) remains the genuine open frontier and
+is not session-sized. **No new OQ** generated: slug is at OQ depth 2 but the provable ℚ·π^(even)
+side (now including full N-family independence) is saturated; a follow-up would be accretion.

--- a/src/data/research/problems/basel-problem-oq-01-oq-02.json
+++ b/src/data/research/problems/basel-problem-oq-01-oq-02.json
@@ -44,7 +44,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: added the cross-power algebraic-DEPENDENCE layer to BaselProblemOQ01OQ02.lean — ζ(2n)^m/ζ(2m)^n ∈ ℚ (zeta_even_cross_pow_ratio_rational) and its proportionality form (zeta_even_cross_pow_proportional). Both axiom-free (NO hermite_lindemann; π cancels exactly), complementing the existing π-power-incommensurability of plain ratios and showing all even zeta values lie in the transcendence-degree-1 field ℚ(π).",
+    "progressSummary": "PROGRESS: proved the N-family ℚ-linear independence LinearIndependent ℚ (fun i:Fin N => ζ(2(i+1))) (zeta_even_linearIndependent_family) — the strictly-stronger generalization of the pairwise result, via a single polynomial identity at π and transcendental_iff. Verified, axioms identical to parent (hermite_lindemann only, no new axiom, no sorry). Node saturated on the provable ℚ·π^(even) side; open frontier remains odd-zeta irrationality (Apéry/Ball–Rivoal), not session-sized.",
     "builtItems": [
       "basel_hasSum : HasSum (fun n => 1/n^2) (pi^2/6) — Euler's Basel identity via Mathlib hasSum_zeta_two (Wiedijk #14).",
       "basel_tsum : tsum form of the Basel identity.",
@@ -57,7 +57,9 @@
       "BaselProblemOQ01OQ02.lean (researcher-6, 2026-07-11): subtraction family completing the ± frontier — zeta_even_sub_transcendental (ζ(2n)−ζ(2m), m<n; polynomial C qn·X^2n + C(−qm)·X^2m, natDegree 2n≠0 via natDegree_add_eq_left_of_natDegree_lt, aeval via map_neg+eq_ratCast+ring), zeta_four_sub_zeta_two_transcendental, transcendental_sub_ratCast (axiom-free, via transcendental_add_ratCast(−q)), zeta_even_sub_ratCast_transcendental. 3 carry only hermite_lindemann, engine is 0-axiom; VERIFIED green lake env lean v4.26.0.",
       "BaselProblemOQ01OQ02.lean: zeta_even_cross_pow_ratio_rational — ζ(2n)^m/ζ(2m)^n ∈ ℚ (π cancels exactly), axiom-free.",
       "BaselProblemOQ01OQ02.lean: zeta_even_cross_pow_proportional — ∃ q≠0, ζ(2n)^m = q·ζ(2m)^n (proportionality form), axiom-free.",
-      "Proofs/BaselProblemOQ01OQ02Graded.lean — graded multiplicativity ζ(2n)ζ(2m)=q·ζ(2(n+m)) + ratio form; researcher-5, axiom-free"
+      "Proofs/BaselProblemOQ01OQ02Graded.lean — graded multiplicativity ζ(2n)ζ(2m)=q·ζ(2(n+m)) + ratio form; researcher-5, axiom-free",
+      "zeta_even_linearIndependent_family (N:ℕ): LinearIndependent ℚ (fun i:Fin N => ζ(2(i+1))) in BaselProblemOQ01OQ02LinIndep.lean — verified, no new axiom",
+      "zeta_two_four_six_linearIndependent: concrete Fin 3 instance ζ(2),ζ(4),ζ(6) in BaselProblemOQ01OQ02LinIndep.lean"
     ],
     "insights": [
       "The odd-zeta question asked by this slug is OPEN; it cannot be closed, only framed/contrasted with the even case.",
@@ -69,7 +71,8 @@
       "The n=0 term is 0 by the 1/0=0 convention, so the natural-number-indexed sum agrees with the classical n>=1 sum.",
       "Classical clean extensions are saturated in siblings: pi^2/8 (odd), pi^2/12 (alternating), zeta(6); a new brick here would be pure accretion.",
       "Transcendence over ℚ is preserved when scaling a transcendental by a nonzero rational: q·x algebraic ⟹ x = q⁻¹·(q·x) algebraic. This upgrades ζ(2n) from irrational to transcendental with no extra axiom, since π^(2n) is already transcendental (pi_transcendental_over_rationals.pow).",
-      "Even zeta values are algebraically DEPENDENT (commensurable after crossing exponents): ζ(2n)^m/ζ(2m)^n ∈ ℚ, since both equal (rational)·π^(2nm) with the identical π-power. This is axiom-free (no hermite_lindemann — π cancels), complementing the incommensurability of plain ratios, and shows all even zetas lie in ℚ(π)."
+      "Even zeta values are algebraically DEPENDENT (commensurable after crossing exponents): ζ(2n)^m/ζ(2m)^n ∈ ℚ, since both equal (rational)·π^(2nm) with the identical π-power. This is axiom-free (no hermite_lindemann — π cancels), complementing the incommensurability of plain ratios, and shows all even zetas lie in ℚ(π).",
+      "N-family ℚ-linear independence of even zeta values ζ(2),…,ζ(2N) collapses to a SINGLE polynomial-vanishing fact via transcendental_iff.mp on π: a relation ∑ gᵢ ζ(2(i+1))=0 becomes aeval π P=0 for P=∑ C(gᵢqᵢ)X^(2(i+1)), forcing P=0 and (distinct exponents) gⱼqⱼ=0. This scales where the pairwise Irrational(π^(2(n-m))) route does not."
     ],
     "mathlibGaps": [
       "No 0-axiom route to Irrational(π^n) for n≥2: Mathlib has irrational_pi (does NOT lift to powers) but no Irrational(π^2)/Irrational(π^n) lemma.",


### PR DESCRIPTION
## Summary
Research session for `basel-problem-oq-01-oq-02`. The node was saturated on transcendence of individual even zeta values and on the **pairwise** ℚ-linear-independence (`zeta_even_linearIndependent_pair`). This PR proves the documented open next step: the **N-family** generalization.

## Progress
- **`zeta_even_linearIndependent_family (N : ℕ) : LinearIndependent ℚ (fun i : Fin N => ζ(2(i+1)))`** — the full family `ζ(2), ζ(4), …, ζ(2N)` is jointly ℚ-linearly independent. Strictly stronger than any collection of pairwise statements.
- **`zeta_two_four_six_linearIndependent`** — concrete `Fin 3` instance for `ζ(2), ζ(4), ζ(6)`.
- File: `proofs/Proofs/BaselProblemOQ01OQ02LinIndep.lean` (header docstring + knowledge/tracker updated).

## Findings
- **Mechanism:** `Fintype.linearIndependent_iff` + Euler's closed form (`zeta_even_eq_rat_mul_pi_pow`, `choose`) collapse a rational relation `∑ᵢ gᵢ·ζ(2(i+1)) = 0` to `aeval π P = 0` for the **single** polynomial `P = ∑ᵢ C(gᵢ·qᵢ)·X^(2(i+1)) ∈ ℚ[X]`. Transcendence of π (`transcendental_iff.mp pi_transcendental_over_rationals`) forces `P = 0`; distinct exponents `2(i+1)` give `P.coeff (2(j+1)) = gⱼ·qⱼ`, and `qⱼ ≠ 0 ⟹ gⱼ = 0`. This scales to N terms where the pairwise `Irrational(π^(2(n-m)))` route does not.
- Open frontier unchanged: odd-zeta irrationality past ζ(3) (Apéry / Ball–Rivoal), not session-sized. No new OQ (provable ℚ·π^(even) side saturated; a follow-up would be accretion).

## Verification
- Docker `Build succeeded` (8579 jobs, **first attempt**, 23s for the file).
- `#print axioms zeta_even_linearIndependent_family` = `[propext, Classical.choice, HermiteLindemann.hermite_lindemann, Quot.sound]` — **identical to the parent node**, no new axiom, no `sorryAx`.

## Status
**Outcome**: progress
**Next Steps**: none session-sized on the provable side; the odd-zeta frontier requires Apéry/Ball–Rivoal machinery.

🤖 Generated by researcher-1