### PR TITLE
audit: erdos-851 — drop phantom axiom claims (Romanoff/conjecture not formalized)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -16881,9 +16881,9 @@
     },
     "erdos-851": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:10:12Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-07-19T23:33:48Z",
+      "result": "issues-fixed"
     },
     "erdos-852": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Gallery integrity audit — erdos-851

**Result:** issues-fixed (prose overstatement; numeric counts already correct)

### What the Lean file actually contains
`Proofs/Erdos851Problem.lean` (163 lines):
- **1 axiom**: `lowerDensity (S : Set ℕ) : ℝ` — an uninterpreted density functional
- **1 def**: `TwoPowAddSet`
- **7 theorems**: `twoPow_add_one_mem`, `twoPowAddSet_mono`, `twoPowAddSet_union_covers`, `three_mem`, `five_mem`, `nine_mem`, `seventeen_mem`

`axiomCount: 1`, `theoremCount: 7`, `definitionCount: 1`, `sorries: 0` were all accurate, and `assumptions` honestly said "1 axiom: lowerDensity."

### The overstatement (phantom declarations)
`originalContributions` and `proofStrategy` claimed:
- "Romanoff's Theorem (1934) **as axiom**" — no such axiom; prose comment only
- "Erdős's density conjecture (OPEN) **as axiom**" — no such axiom; prose comment only
- proofStrategy: "Axiomatize `0 < lowerDensity(TwoPowAddSet 1)`", "Axiomatize `∀ε…`", "Axiomatize the ~0.0868 Erdős–Odlyzko bound" — none formalized
- `density-properties` section implied formalized density monotonicity/upper-bound theorems — only set-level `twoPowAddSet_mono` exists

Lines 64–130 of the source are pure `/- ... -/` documentation blocks for these results.

### Fix
Reworded `originalContributions`, `proofStrategy`, and the `romanoff` / `density-properties` section summaries so the gallery accurately states that only `lowerDensity` is axiomatized and that Romanoff's theorem, the conjecture, and the density bounds are prose documentation, not Lean declarations. No source or numeric-count changes.

---
Discovered during gallery integrity audit (reserve-mode re-serve).

🤖 Generated with [Claude Code](https://claude.com/claude-code)