### PR TITLE
audit: re-serve erdos-800 (axiomatized) — clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -16494,8 +16494,8 @@
     },
     "erdos-800": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:53:45Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-19T23:47:22Z",
       "result": "clean"
     },
     "erdos-801": {


### PR DESCRIPTION
## Reserve-mode re-audit

Queue drained (0 unaudited / 4807). Picked oldest **uncontested** target after cross-referencing the top targets against open fleet PRs; erdos-800 had no in-flight PR.

**Proof**: erdos-800 — *Linear Ramsey Numbers for Graphs Without Adjacent High-Degree Vertices* (Alon 1994, R(G) ≤ 12n)

## Verification vs `proofs/Proofs/Erdos800Problem.lean`

- **5 axioms** — `ramseyNumber`, `ramseyNumber_spec`, `alon_theorem`, `no_adjacent_high_degree_is_2_degenerate`, `burr_erdos_theorem` — matches `axiomCount: 5`
- **0 sorries**, no `True` stubs, no `native_decide`
- **status** `axiomatized` / **badge** `axiom` (Tier C) — the core result `alon_theorem` is honestly axiomatized and disclosed; title/description carry no overclaim (description attributes the result to Alon, not to this formalization)
- All `originalContributions` map to real declarations — **no phantom declarations** (verified each named def/axiom/theorem exists)
- `lineCount` meta 267 vs actual 269 — stale undercount, harmless

**Result: clean** — no integrity issues.

---
Discovered during gallery integrity audit (reserve mode).