### PR TITLE
audit: erdos-774 — drop 3 phantom declaration contributions

### DIFF
--- a/src/data/proofs/erdos-774/meta.json
+++ b/src/data/proofs/erdos-774/meta.json
@@ -47,13 +47,13 @@
       "powersOfTwo, powersOfBase, IsLacunary: examples of dissociated sets",
       "IsProportionatelyDissociated: main definition",
       "dissociated_is_proportionately: basic implication",
-      "IsSidonHarmonic, pisier_theorem: Pisier's characterization",
+      "IsSidonHarmonic: Pisier's harmonic-Sidon characterization",
       "IsSidonAdditive: additive Sidon sets",
       "IsFiniteUnionDissociated: decomposition predicate",
       "ErdosConjecture774: formal statement of the open problem",
       "IsProportionatelySidon, SidonAnalogue: Sidon analogue",
-      "nesetril_rodl_sales_theorem, nrs_construction: 2024 counterexample",
-      "maxDissociatedSize, max_dissociated_log_bound: size bounds"
+      "nesetril_rodl_sales_theorem: 2024 Sidon-analogue counterexample (axiom)",
+      "maxDissociatedSize: maximum dissociated subset size"
     ],
     "axiomCount": 2,
     "lineCount": 215,


### PR DESCRIPTION
## Integrity Issue

**Proof**: erdos-774 (Erdős #774: Dissociated and Proportionately Dissociated Sets)
**Problem**: `originalContributions` names three declarations that do not exist in the Lean source.

## Evidence

Source: `proofs/Proofs/Erdos774Problem.lean` (221 lines).

**meta.json claimed** (originalContributions):
- "IsSidonHarmonic, **pisier_theorem**: Pisier's characterization"
- "nesetril_rodl_sales_theorem, **nrs_construction**: 2024 counterexample"
- "maxDissociatedSize, **max_dissociated_log_bound**: size bounds"

**Lean file shows** — `pisier_theorem`, `nrs_construction`, and `max_dissociated_log_bound` are NOT declared anywhere (`grep -n` returns nothing). Only `IsSidonHarmonic`, the `nesetril_rodl_sales_theorem` axiom, and `maxDissociatedSize` actually exist.

Everything else verified against source and is accurate:
- 2 axioms (`finite_union_is_proportionately`, `nesetril_rodl_sales_theorem`) ✓
- 0 sorries ✓, 3 theorems ✓, no True stubs, no native_decide
- badge `axiom` / status `axiomatized` correct

## Fix Applied

Rewrote the three `originalContributions` entries to cite only declarations that are present. No source changes; prose-only reconciliation.

---
Discovered during gallery integrity audit (reserve-mode re-serve of a 3×-clean target).