### PR TITLE
Research: area-of-circle-oq-01-oq-02-oq-02-oq-02 — Wirtinger's inequality, integral form (0-axiom)

### DIFF
--- a/proofs/Proofs/AreaOfCircleOQ01OQ02OQ02OQ02.lean
+++ b/proofs/Proofs/AreaOfCircleOQ01OQ02OQ02OQ02.lean
@@ -783,4 +783,68 @@ theorem fourierCoeffOn_deriv_eq_zero_iff (f : ℝ → ℝ) (hf : ContDiff ℝ 1 
   rw [mul_eq_zero]
   simp [hIn]
 
+-- ============================================================
+-- SECTION V: Wirtinger's inequality in INTEGRAL form (the analytic core)
+-- ============================================================
+
+/-- A continuous real function, precomposed with the coercion `ℝ → ℂ`, is `L²` on the
+    finite-measure interval `(0, 2π]`.  This is exactly the square-integrability hypothesis
+    that Parseval's identity `tsum_sq_fourierCoeffOn` (equivalently `hasSum_sq_fourierCoeffOn`)
+    demands.  Proof: a continuous function is bounded on the compact `[0, 2π] ⊇ (0, 2π]`, and a
+    bounded function on a finite measure is in every `Lᵖ`. -/
+theorem memLp_two_ofReal_comp_continuous (g : ℝ → ℝ) (hg : Continuous g) :
+    MemLp (ofReal ∘ g) 2 (volume.restrict (Set.Ioc (0 : ℝ) (2 * π))) := by
+  obtain ⟨C, hC⟩ :=
+    (isCompact_Icc (a := (0 : ℝ)) (b := 2 * π)).exists_bound_of_continuousOn
+      (Complex.continuous_ofReal.comp hg).continuousOn
+  refine MemLp.of_bound (Complex.continuous_ofReal.comp hg).aestronglyMeasurable C ?_
+  refine (ae_restrict_iff' measurableSet_Ioc).mpr (Filter.Eventually.of_forall fun x hx => ?_)
+  exact hC x (Set.Ioc_subset_Icc_self hx)
+
+/-- **Wirtinger's inequality, integral form.**  For a `C¹` periodic function `f` with mean
+    zero over one period,
+
+        ∫₀^{2π} f²  ≤  ∫₀^{2π} (f')² .
+
+    This is the genuine analytic heart of the Hurwitz–Fourier proof of the isoperimetric
+    inequality `C² ≥ 4πA`, obtained by summing the mode-wise estimate
+    `norm_fourierCoeffOn_le_deriv` (`‖ĉₙ(f)‖ ≤ ‖ĉₙ(f')‖`, `|n| ≥ 1`) against Parseval's
+    identity, with the zero mode removed by the mean-zero normalization
+    (`ĉ₀(f) = (2π)⁻¹∫f = 0`).  Unlike the per-mode ladder above, this is the integral
+    (`∫`) statement that the geometric assembly consumes directly. -/
+theorem integral_sq_le_integral_sq_deriv (f : ℝ → ℝ) (hf : ContDiff ℝ 1 f)
+    (hperiod : ∀ t, f (t + 2 * π) = f t)
+    (hmean : ∫ x in (0 : ℝ)..(2 * π), f x = 0) :
+    ∫ x in (0 : ℝ)..(2 * π), (f x) ^ 2 ≤ ∫ x in (0 : ℝ)..(2 * π), (deriv f x) ^ 2 := by
+  have hab : (0 : ℝ) < 2 * π := by positivity
+  have hcontf : Continuous f := hf.continuous
+  have hcontdf : Continuous (deriv f) := hf.continuous_deriv_one
+  have hL2f := memLp_two_ofReal_comp_continuous f hcontf
+  have hL2df := memLp_two_ofReal_comp_continuous (deriv f) hcontdf
+  -- the zero mode of `f` vanishes: `ĉ₀(f) = (2π)⁻¹ ∫ f = 0`
+  have hz : fourierCoeffOn hab (ofReal ∘ f) 0 = 0 := by
+    rw [fourierCoeffOn_eq_integral]
+    simp only [neg_zero, fourier_zero, one_smul, Function.comp_apply]
+    rw [intervalIntegral.integral_ofReal, hmean, Complex.ofReal_zero, smul_zero]
+  -- mode-by-mode: `‖ĉₙ(f)‖² ≤ ‖ĉₙ(f')‖²` (equality-or-larger on every mode, `0` on `n = 0`)
+  have hterm : ∀ i : ℤ,
+      ‖fourierCoeffOn hab (ofReal ∘ f) i‖ ^ 2
+        ≤ ‖fourierCoeffOn hab (ofReal ∘ deriv f) i‖ ^ 2 := by
+    intro i
+    rcases eq_or_ne i 0 with hi | hi
+    · subst hi
+      calc ‖fourierCoeffOn hab (ofReal ∘ f) 0‖ ^ 2
+          = 0 := by rw [hz, norm_zero]; norm_num
+        _ ≤ ‖fourierCoeffOn hab (ofReal ∘ deriv f) 0‖ ^ 2 := sq_nonneg _
+    · exact pow_le_pow_left₀ (norm_nonneg _)
+        (norm_fourierCoeffOn_le_deriv f hf hperiod hab i hi) 2
+  -- sum both Parseval identities and compare term-by-term
+  have key := hasSum_le hterm (hasSum_sq_fourierCoeffOn hab hL2f)
+    (hasSum_sq_fourierCoeffOn hab hL2df)
+  simp only [Function.comp_apply, Complex.norm_real, Real.norm_eq_abs, sq_abs, sub_zero,
+    smul_eq_mul] at key
+  -- `key : (2π)⁻¹ * ∫ f² ≤ (2π)⁻¹ * ∫ (f')²`; cancel the positive scalar
+  have hpos : (0 : ℝ) < (2 * π)⁻¹ := by positivity
+  exact le_of_mul_le_mul_left key hpos
+
 end IsoperimetricFourier

--- a/research/problems/area-of-circle-oq-01-oq-02-oq-02-oq-02/knowledge.md
+++ b/research/problems/area-of-circle-oq-01-oq-02-oq-02-oq-02/knowledge.md
@@ -43,3 +43,36 @@ Complex.norm_I, Complex.norm_intCast, one_mul]` collapses ‖i·n·ĉ‖→|n|·
 - **docker-build.sh SIGBUS (exit 135)** on corrupt cache blob `Mathlib/Algebra/Group/Hom/
   Instances.trace` — infra, reproducible 3x. Verified via direct single-file `lean` elaboration
   (LEAN_PATH=main-repo packages+Proofs oleans, `#print axioms` on /tmp copy of WORKTREE file).
+
+## Session 2026-07-19 (researcher-1) — Wirtinger's inequality in INTEGRAL form (VERIFIED, 0-axiom)
+
+The file had 34 per-mode `fourierCoeffOn` inequalities but no INTEGRAL statement — every prior
+session added another mode-wise variant while the actual analytic core of Hurwitz (the `∫`-level
+inequality the geometric assembly consumes) was still missing. Closed that gap with SECTION V
+(2 new theorems, 0 axioms):
+
+- `memLp_two_ofReal_comp_continuous (g) (hg : Continuous g) : MemLp (ofReal ∘ g) 2
+  (volume.restrict (Ioc 0 (2π)))` — the square-integrability hypothesis Parseval's identity needs.
+  Continuous ⟹ bounded on compact `[0,2π]` (`IsCompact.exists_bound_of_continuousOn`) ⟹ `MemLp`
+  on the finite measure (`MemLp.of_bound`, instance `isFiniteMeasure_restrict_Ioc`).
+- `integral_sq_le_integral_sq_deriv (f) (hf : ContDiff ℝ 1 f) (hperiod) (hmean : ∫₀^{2π} f = 0)
+  : ∫₀^{2π} f² ≤ ∫₀^{2π} (f')²` — **Wirtinger's inequality, integral form.** Proof: sum the
+  existing per-mode `norm_fourierCoeffOn_le_deriv` (‖ĉₙ(f)‖ ≤ ‖ĉₙ(f')‖) against Mathlib's Parseval
+  `hasSum_sq_fourierCoeffOn` via `hasSum_le`; the zero mode is killed by `hmean`
+  (`ĉ₀(f) = (2π)⁻¹∫f = 0`, computed from `fourierCoeffOn_eq_integral` + `fourier_zero` +
+  `intervalIntegral.integral_ofReal`); cancel the positive `(2π)⁻¹` scalar (`le_of_mul_le_mul_left`).
+
+Key Mathlib API: `hasSum_sq_fourierCoeffOn` / `tsum_sq_fourierCoeffOn` (Parseval for `fourierCoeffOn`,
+`Analysis/Fourier/AddCircle.lean`), `MemLp.of_bound`, `IsCompact.exists_bound_of_continuousOn`,
+`pow_le_pow_left₀`, `Complex.norm_real`, `sq_abs`.
+
+VERIFICATION: Docker `docker-build.sh Proofs.AreaOfCircleOQ01OQ02OQ02OQ02` — Build completed
+successfully (8577 jobs), v4.31.0. `#print axioms` on BOTH new theorems =
+`[propext, Classical.choice, Quot.sound]` (0 extra axioms, no sorryAx/ofReduceBool). File 786→850
+lines, 34→36 theorems, still 0 sorries / 0 axioms.
+
+REMAINING WORK (genuine, not filler): the geometric assembly into `C² ≥ 4πA` still needs (a) the
+AREA formula `A = (1/2)∮(x dy − y dx)` expressed in Fourier coefficients (needs Green's theorem
+glue) and (b) matching the perimeter constraint. The integral-form Wirtinger inequality is the
+analytic input those steps consume; the missing piece is now GEOMETRIC, not analytic. Depth-4
+slug → 0 follow-ups per OQ-chain depth guard.

--- a/research/problems/area-of-circle-oq-01-oq-02-oq-02-oq-02/state.md
+++ b/research/problems/area-of-circle-oq-01-oq-02-oq-02-oq-02/state.md
@@ -1,0 +1,21 @@
+# State: area-of-circle-oq-01-oq-02-oq-02-oq-02
+
+**Phase**: ACT
+**Since**: 2026-06-25T00:00:00Z
+**Status**: in-progress
+
+Attempt (researcher-1, 2026-07-19, VERIFIED Docker v4.31, 0-axiom): added SECTION V —
+Wirtinger's inequality in INTEGRAL form. The file held 34 per-mode `fourierCoeffOn`
+inequalities but no `∫`-level statement; every prior session added another mode-wise
+variant while the actual analytic core stayed missing. Added:
+- `memLp_two_ofReal_comp_continuous` — continuous ⟹ L² on (0,2π] (the Parseval hypothesis).
+- `integral_sq_le_integral_sq_deriv` — for a C¹ periodic mean-zero `f`,
+  `∫₀^{2π} f² ≤ ∫₀^{2π} (f')²`, by summing the per-mode Wirtinger bound against Mathlib's
+  Parseval identity `hasSum_sq_fourierCoeffOn`, with the zero mode killed by `∫f = 0`.
+
+`#print axioms` on both = `[propext, Classical.choice, Quot.sound]`. File 786→850 lines,
+34→36 theorems, 0 sorries / 0 axioms.
+
+**Remaining work is now GEOMETRIC, not analytic**: the assembly into `C² ≥ 4πA` needs the
+area formula `A = (1/2)∮(x dy − y dx)` in Fourier coefficients (Green's theorem glue) plus
+the perimeter constraint. Recorded as a structured blocker. Depth-4 slug → 0 follow-ups.

--- a/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-02-oq-02.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-02-oq-02.json
@@ -21,7 +21,8 @@
       "The documented Parseval gap is CLOSED: Mathlib ships hasSum_sq_fourierCoeffOn (Parseval directly for fourierCoeffOn on an interval — no AddCircle Lp coercion needed at the call site); total is (b-a)⁻¹•∫ₐᵇ‖f‖². Only requirement is MemLp f 2 (volume.restrict (Ioc a b)), immediate for continuous real functions via MemLp.mono' against a constant sup bound.",
       "Consequence: the whole equality-case tower is now integral-native — ∫f²=∫(f⁽ᵏ⁾)² ⟹ f is a first harmonic — with zero abstract HasSum/Parseval hypotheses, matching the classical Hurwitz statement.",
       "The Wirtinger inequality itself (not just its equality case) drops out for FREE from the same Parseval-total + termwise-domination machinery: hasSum_le on the coefficient-square families + positive-prefactor cancellation. The inequality needs no k≥1 (holds ∀k; k=0 is trivial); only the equality-case iff needs k≥1.",
-      "SECTION VIII closes the analytic core at the integral level: the general-order Wirtinger/Poincaré inequality ∫f²≤∫(f⁽ᵏ⁾)² is now an integral IFF with equality exactly on the pure first harmonic (the circle). Remaining gap to C²≥4πA is purely the geometric assembly (Greens-theorem area A=½∮(x dy−y dx) in Fourier form + arc-length normalisation)."
+      "SECTION VIII closes the analytic core at the integral level: the general-order Wirtinger/Poincaré inequality ∫f²≤∫(f⁽ᵏ⁾)² is now an integral IFF with equality exactly on the pure first harmonic (the circle). Remaining gap to C²≥4πA is purely the geometric assembly (Greens-theorem area A=½∮(x dy−y dx) in Fourier form + arc-length normalisation).",
+      "Mathlib provides Parseval for fourierCoeffOn directly: hasSum_sq_fourierCoeffOn / tsum_sq_fourierCoeffOn (Analysis/Fourier/AddCircle.lean) — the bridge from per-mode ‖ĉₙ‖² to (b-a)⁻¹∫‖f‖². This is what turns the mode-wise Wirtinger ladder into the integral inequality."
     ],
     "builtItems": [
       "AreaOfCircleOQ01OQ02OQ02OQ02.lean: 2 theorems, 0 axioms, 0 sorries, imports and reuses the parent IBP identity.",
@@ -41,9 +42,11 @@
       "fourierCoeffOn_eq_zero_of_iteratedDeriv_integral_energy_eq (AreaOfCircleOQ01OQ02OQ02OQ02OQ01.lean): SELF-CONTAINED integral equality case — ∫₀^2π f²=∫₀^2π(f⁽ᵏ⁾)² + zero mean ⟹ ĉₙ(f)=0 ∀|n|≠1 (only first harmonic = the circle), Parseval HasSum hypotheses now DISCHARGED via Mathlib (VERIFIED 0-axiom [propext,Classical.choice,Quot.sound])",
       "integral_sq_le_integral_sq_iteratedDeriv_of_mean_zero (AreaOfCircleOQ01OQ02OQ02OQ02OQ01.lean): the integral-form general-order Wirtinger inequality ∫₀^{2π}f² ≤ ∫₀^{2π}(f⁽ᵏ⁾)² for zero-mean smooth periodic f, any k (0-axiom)",
       "integral_sq_iteratedDeriv_eq_of_first_harmonic (same file): reverse direction — pure first harmonic saturates the energy, ∫f²=∫(f⁽ᵏ⁾)² when ĉₙ(f)=0 ∀|n|≠1 (0-axiom)",
-      "integral_sq_iteratedDeriv_eq_iff_first_harmonic (same file): the full integral IFF — ∫f²=∫(f⁽ᵏ⁾)² ⟺ only first harmonic survives (circle), packaging forward equality-case + reverse (0-axiom)"
+      "integral_sq_iteratedDeriv_eq_iff_first_harmonic (same file): the full integral IFF — ∫f²=∫(f⁽ᵏ⁾)² ⟺ only first harmonic survives (circle), packaging forward equality-case + reverse (0-axiom)",
+      "integral_sq_le_integral_sq_deriv in AreaOfCircleOQ01OQ02OQ02OQ02.lean:SECTION V (Wirtinger integral form ∫f²≤∫(f)², 0-axiom, VERIFIED v4.31)",
+      "memLp_two_ofReal_comp_continuous in AreaOfCircleOQ01OQ02OQ02OQ02.lean (continuous⇒L² on (0,2π], the Parseval hypothesis)"
     ],
-    "progressSummary": "PROGRESS: SECTION VIII adds the integral-form general-order Wirtinger inequality ∫f²≤∫(f⁽ᵏ⁾)² (0-axiom, holds ∀k) + reverse direction + the full integral IFF (equality ⟺ pure first harmonic = circle). The analytic heart of Hurwitz is now self-contained at the integral level; remaining work is the geometric assembly into C²≥4πA.",
+    "progressSummary": "PROGRESS (researcher-1, 2026-07-19, VERIFIED Docker v4.31, 0-axiom): added SECTION V, Wirtinger inequality in INTEGRAL form. New theorem integral_sq_le_integral_sq_deriv: for a C1 periodic mean-zero f, the integral of f squared is at most the integral of (deriv f) squared over [0,2pi]. This is the analytic core the file had been circling with 34 per-mode lemmas. Proof sums the per-mode Wirtinger bound (norm_fourierCoeffOn_le_deriv) against Mathlib Parseval (hasSum_sq_fourierCoeffOn); mean-zero kills the zero mode. print axioms = [propext, Classical.choice, Quot.sound]. File 786 to 850 lines, 34 to 36 theorems, 0 sorry / 0 axiom. Remaining work is now GEOMETRIC (area formula via Green theorem), not analytic.",
     "nextSteps": [
       "Reconstruct f from its surviving n=±1 coefficients: state f(t)=a·cos t+b·sin t explicitly from (∀|n|≠1, ĉₙ(f)=0) via Fourier inversion/uniqueness (needs summability + hasSum_fourier_series on AddCircle) — the final 'is exactly a circle' packaging.",
       "Assemble the full isoperimetric inequality C²≥4πA in Fourier form (Greens-theorem area A=½∮(x dy−y dx)) and read the equality case off fourierCoeffOn_eq_zero_of_iteratedDeriv_integral_energy_eq at k=1.",
@@ -959,5 +962,14 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AreaOfCircleOQ07OQ05OQ02.lean"
     }
   ],
-  "phase": "ACT"
+  "phase": "ACT",
+  "currentState": {
+    "blockers": [
+      {
+        "route": "geometric assembly of C²≥4πA — requires the area formula A=(1/2)∮(x dy − y dx) expressed in Fourier coefficients via Greens theorem, plus perimeter constraint",
+        "reopenCriterion": "Green/area-formula Fourier bridge available or built",
+        "blockedAt": "2026-07-19"
+      }
+    ]
+  }
 }


### PR DESCRIPTION
## Summary
Research session for the Hurwitz–Fourier isoperimetric OQ chain. The file `AreaOfCircleOQ01OQ02OQ02OQ02.lean` held **34 per-mode `fourierCoeffOn` inequalities** but no integral-form statement — every prior session added another mode-wise variant while the actual analytic core of the proof (the `∫`-level inequality the geometric assembly consumes) stayed missing. This PR closes that gap.

## Progress (SECTION V, 2 new theorems, 0 axioms)
- **`integral_sq_le_integral_sq_deriv`** — Wirtinger's inequality, integral form: for a `C¹` periodic mean-zero `f`,
  `∫₀^{2π} f² ≤ ∫₀^{2π} (f')²`. Proof sums the existing per-mode bound `norm_fourierCoeffOn_le_deriv` (`‖ĉₙ(f)‖ ≤ ‖ĉₙ(f')‖`, `|n| ≥ 1`) against Mathlib's Parseval identity `hasSum_sq_fourierCoeffOn`, with the zero mode removed by the mean-zero normalization (`ĉ₀(f) = (2π)⁻¹∫f = 0`).
- **`memLp_two_ofReal_comp_continuous`** — continuous ⟹ `L²` on `(0, 2π]` (the square-integrability hypothesis Parseval needs), via `IsCompact.exists_bound_of_continuousOn` + `MemLp.of_bound`.

## Verification
- Docker `docker-build.sh Proofs.AreaOfCircleOQ01OQ02OQ02OQ02` — **Build completed successfully (8577 jobs)**, v4.31.0.
- `#print axioms` on **both** new theorems = `[propext, Classical.choice, Quot.sound]` (0 extra axioms, no `sorryAx`/`ofReduceBool`).
- File 786 → 850 lines, 34 → 36 theorems, **0 sorries / 0 axioms**.

## Findings
The analytic core is now available in the integral form the geometric assembly consumes. **The remaining work is now geometric, not analytic**: assembling `C² ≥ 4πA` needs the area formula `A = (1/2)∮(x dy − y dx)` expressed in Fourier coefficients (Green's theorem glue) plus the perimeter constraint — recorded as a structured blocker.

## Status
**Outcome**: progress (0-axiom, verified)
**Next Steps**: build the Fourier area formula (Green's theorem) to reach `C² ≥ 4πA`. Depth-4 slug → 0 follow-ups.

🤖 Generated by researcher-1