### PR TITLE
Research: erdos-117-oq-01-incomplete-01 — re-verified COMPLETE (v4.31), mark completed

### DIFF
--- a/research/problems/erdos-117-oq-01-incomplete-01/knowledge.md
+++ b/research/problems/erdos-117-oq-01-incomplete-01/knowledge.md
@@ -174,3 +174,23 @@ body, then `linarith [hlog_super m n]`. (2) After `rintro x ⟨n, rfl⟩` the ra
 **Verification.** Docker build `Proofs.Erdos117OQ01Incomplete01` — `✔ Built (3.6s)`. No `sorry`/`axiom`
 in the file; inherits only the parent's 3 structural axioms (h/h_pos/pyber_bounds). 8→13 theorems,
 138→260 lines. Open convergence question itself unchanged (it IS #117-OQ-01).
+
+## Session 2026-07-19 (researcher-1) — re-verified COMPLETE on v4.31, mark completed
+
+Depth-first re-serve of an already-COMPLETED entry. No new theorems — the file family is
+saturated; the underlying convergence question for Erdős #117 is genuinely open and out of
+scope for this formalization.
+
+Re-verification (Docker `docker-build.sh Proofs.Erdos117OQ01Incomplete01`, v4.31.0):
+**Build completed successfully (8577 jobs)**. The claimed file
+`proofs/Proofs/Erdos117OQ01Incomplete01.lean` is 287 lines, 14 theorems, **0 sorries,
+0 local axioms** (inherits the 3 structural axioms `h`, `h_pos`, `pyber_bounds` from the
+parent `Proofs.Erdos117OQ01` — genuine domain assumptions, not scaffolding to prove away).
+The family compiles clean on v4.31 despite being authored for v4.26.
+
+Observation for a future mechanic/migration pass (NOT fixed here to keep this scoped to the
+claimed slug): `Proofs/Erdos117OQ01.lean:415` uses the now-deprecated `push_neg`
+(v4.31 prefers `push Not`) — a non-fatal deprecation warning on the sibling gallery entry
+`erdos-117-oq-01`, not this incomplete-01 file.
+
+Recommend the Seeker **stop re-serving** this slug — no routine work remains.

--- a/research/problems/erdos-117-oq-01-incomplete-01/state.md
+++ b/research/problems/erdos-117-oq-01-incomplete-01/state.md
@@ -22,8 +22,9 @@ None.
 
 ## Next Action
 
-None — entry verified (0 sorries, 3 structural axioms). The underlying
-convergence question for #117 remains open and is out of scope here.
+None — re-verified COMPLETE on v4.31 (Docker build succeeded, 2026-07-19,
+researcher-1). 0 sorries, 0 local axioms (3 structural axioms inherited from parent).
+Underlying #117 convergence question remains open and out of scope. Recommend stop re-serving.
 
 ## Attempt Counts
 

--- a/src/data/research/problems/erdos-117-oq-01-incomplete-01.json
+++ b/src/data/research/problems/erdos-117-oq-01-incomplete-01.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (researcher-10, 2026-07-12): added the DUAL sufficient condition to the oscillation companion. Supermultiplicativity h(m)·h(n)≤h(m+n) ⟹ convergence / oscillation=0 / exponential base exists — derived by applying Mathlib Subadditive.tendsto_lim to −log(h n) (bounded below via the Pyber UPPER bound), the mirror of the parent submultiplicative (subadditive) Fekete result. Capstone not_exponentialBaseExists_implies_not_multiplicative: any counterexample must violate BOTH one-sided multiplicative laws. 5 new theorems, 0 new axioms (inherits only h/h_pos/pyber_bounds). The convergence question itself remains open (#117-OQ-01).",
+    "progressSummary": "COMPLETE + RE-VERIFIED (researcher-1, 2026-07-19): Docker build of Proofs.Erdos117OQ01Incomplete01 succeeded on v4.31.0 (8577 jobs). Claimed file 287 lines, 14 thm, 0 sorries, 0 local axioms (inherits 3 structural axioms h/h_pos/pyber_bounds from parent, genuine assumptions). Saturated; underlying #117 convergence question is open and out of scope. Recommend stop re-serving.",
     "builtItems": [
       "Erdos117OQ01.base_implies_behavior — proved (was sorry): convergence to log c ⇒ ExponentialBehavior c for ε ∈ (0,c)",
       "Erdos117OQ01.ExponentialBehavior — corrected statement to ε ∈ (0,c) (unrestricted ∀ε>0 form is false)",
@@ -52,7 +52,8 @@
       "GOTCHA le_of_tendsto vs ge_of_tendsto: ge_of_tendsto (Tendsto f→a) (∀ᶠ b≤f) : b≤a (b≤limit); le_of_tendsto (Tendsto f→a) (∀ᶠ f≤b) : a≤b (limit≤b). For lower bound log c₁≤log c use ge_of_tendsto with hev_l:log c₁≤growthRate.",
       "First SUFFICIENT condition in the companion: the parent Fekete result submultiplicative_implies_convergence, lifted into the oscillation/base language, resolves Erdos #117 OQ-01 positively whenever h is submultiplicative. Contrapositive: a genuinely oscillating (no-base) h must be super-multiplicative at some (m,n) — a necessary condition on any counterexample. No new axioms (inherits only the 3 Pyber axioms).",
       "supermultiplicative_implies_convergence (researcher-10): the DUAL Fekete sufficient condition. Mathlib has no Superadditive API, so h(m)·h(n)≤h(m+n) ⟹ convergence is obtained by applying Subadditive.tendsto_lim to g n = −log(h n) (subadditive iff log h superadditive), with g n/n = −growthRate n bounded below by −log c₂ from the Pyber UPPER bound. Mirror of the parent submultiplicative proof which used the lower bound.",
-      "not_exponentialBaseExists_implies_not_multiplicative (researcher-10): sharpened counterexample constraint — since EITHER sub- OR super-multiplicativity alone forces convergence, any genuine counterexample to #117-OQ-01 (oscillating growth rate) must violate BOTH one-sided multiplicative laws simultaneously."
+      "not_exponentialBaseExists_implies_not_multiplicative (researcher-10): sharpened counterexample constraint — since EITHER sub- OR super-multiplicativity alone forces convergence, any genuine counterexample to #117-OQ-01 (oscillating growth rate) must violate BOTH one-sided multiplicative laws simultaneously.",
+      "Re-verified COMPLETE on v4.31.0 (2026-07-19, researcher-1): family builds clean despite v4.26 authorship. Note push_neg deprecation at Erdos117OQ01.lean:415 for a future migration pass (sibling entry, not this file)."
     ],
     "mathlibGaps": [],
     "nextSteps": [


### PR DESCRIPTION
## Summary
Depth-first re-serve of an already-COMPLETED entry. No new theorems — the family is saturated and the underlying Erdős #117 convergence question is genuinely open / out of scope. This PR records the v4.31 re-verification and marks the problem completed to stop the re-serve churn.

## Progress
- **Docker build** `docker-build.sh Proofs.Erdos117OQ01Incomplete01` — **Build completed successfully (8577 jobs)**, v4.31.0 (family authored for v4.26, still compiles clean).
- Claimed file `Erdos117OQ01Incomplete01.lean`: 287 lines, 14 theorems, **0 sorries, 0 local axioms** (inherits the 3 structural axioms `h` / `h_pos` / `pyber_bounds` from the parent `Proofs.Erdos117OQ01` — genuine domain assumptions).

## Findings
Noted for a future migration pass (not fixed here, to keep this scoped to the claimed slug): `Proofs/Erdos117OQ01.lean:415` uses the deprecated `push_neg` (v4.31 prefers `push Not`) — a non-fatal deprecation warning on the sibling gallery entry `erdos-117-oq-01`.

## Status
**Outcome**: completed (verified — saturated)
**Next Steps**: Seeker should stop re-serving this slug.

🤖 Generated by researcher-1