### PR TITLE
audit: erdos-874 — drop 2 phantom axiom contributions

### DIFF
--- a/src/data/proofs/erdos-874/meta.json
+++ b/src/data/proofs/erdos-874/meta.json
@@ -52,8 +52,7 @@
       "BoundedAdmissible for sets in {1,...,N}",
       "k(N) function as maximum admissible set size",
       "strausSet construction for lower bound",
-      "Straus lower/upper bound axioms (1966)",
-      "ENS improved upper bound axiom (1991)",
+      "strausConstant and ensConstant definitions with straus_constant_value (historical Straus/ENS bounds documented in prose, not axiomatized)",
       "Deshouillers-Freiman main theorem axiom (1999)",
       "k_limit_is_two: the limit equals 2",
       "erdos_874 and erdos_874_answer main theorems"


### PR DESCRIPTION
## Integrity Issue

**Proof**: erdos-874 (Erdős Problem #874: k(N) ~ 2√N, Deshouillers-Freiman)
**Problem**: `originalContributions` overstates by listing two axioms that do not exist in the Lean source.

## Evidence

**meta.json claimed** (originalContributions):
- "Straus lower/upper bound axioms (1966)"
- "ENS improved upper bound axiom (1991)"

**Lean file shows** (`Proofs/Erdos874Problem.lean`): only **2 axioms** exist —
`deshouillers_freiman_main` (L140) and `k_limit_is_two` (L147), matching `axiomCount: 2`.
There are **no** Straus or ENS axioms. Those bounds appear only in docstrings (L81–128).
The file does define `strausConstant`/`ensConstant` and proves `straus_constant_value` (rfl).

Note: the `native_decide` string at L129 is inside a docstring ("beyond native_decide"), not a real use — no kernel-trust concern.

## Fix

Replace the two phantom axiom items with one accurate def-level contribution noting the
Straus/ENS constants are defined but the bounds are documented in prose, not axiomatized.
`axiomCount`, `sorries`, `status`, and `badge` are all already correct; only prose changed.

## Note for the fleet

Two prior re-serve PRs (#39151, #39194) marked erdos-874 "clean" but audited counts only, missing this prose-level overstatement.

---
Discovered during gallery integrity audit (reserve mode: re-verify prose vs. actual declarations).