### PR TITLE
Fix: erdos-469 meta reflects nonempty-subset pseudoperfect predicate

### DIFF
--- a/src/data/proofs/erdos-469/meta.json
+++ b/src/data/proofs/erdos-469/meta.json
@@ -40,8 +40,8 @@
       "title": "Definitions",
       "startLine": 22,
       "endLine": 38,
-      "summary": "Defines `IsPseudoperfect` (a subset of proper divisors sums to $n$), `IsPrimitivePseudoperfect` (pseudoperfect with no pseudoperfect proper divisor), and the set `primitivePseudoperfectSet`.",
-      "mathContext": "$\\text{IsPseudoperfect}(n):\\exists S\\subseteq\\text{properDivisors}(n),\\ \\sum S=n$; primitive if no proper divisor is pseudoperfect."
+      "summary": "Defines `IsPseudoperfect` (a nonempty subset of proper divisors sums to $n$), `IsPrimitivePseudoperfect` (pseudoperfect with no pseudoperfect proper divisor), and the set `primitivePseudoperfectSet`.",
+      "mathContext": "$\\text{IsPseudoperfect}(n):\\exists S\\neq\\emptyset,\\ S\\subseteq\\text{properDivisors}(n),\\ \\sum S=n$ (nonemptiness excludes the degenerate empty-sum representation of $0$); primitive if no proper divisor is pseudoperfect."
     },
     {
       "id": "perfect-pseudoperfect",


### PR DESCRIPTION
## Problem (part of #38611, bucket C)

The v4.31 statement repair added `S.Nonempty` to `IsPseudoperfect` in `proofs/Proofs/Erdos469Problem.lean:32-33` (excluding the degenerate empty-sum representation of $0$, which would otherwise make `IsPseudoperfect 0` hold and falsify `not_pseudoperfect_0` / `pseudoperfect_ge_six`). The gallery `meta.json` still displayed the OLD, broader formal predicate.

## Fix (metadata only)

`src/data/proofs/erdos-469/meta.json`, `definitions` section:

- **Before:** `IsPseudoperfect(n): ∃S⊆properDivisors(n), ∑S=n`
- **After:** `IsPseudoperfect(n): ∃S≠∅, S⊆properDivisors(n), ∑S=n` (with a note that nonemptiness excludes the empty-sum representation of 0)
- Summary prose updated: "a nonempty subset of proper divisors sums to $n$".

`status`/`badge`/`axiomCount` were already correct and are unchanged. JSON validated.

Part of #38611.