### PR TITLE
Research: basel-problem-oq-01-oq-02 — N-family ℚ-linear independence of even zeta values

### DIFF
--- a/proofs/Proofs/BaselProblemOQ01OQ02LinIndep.lean
+++ b/proofs/Proofs/BaselProblemOQ01OQ02LinIndep.lean
@@ -17,6 +17,13 @@
       `LinearIndependent ℚ ![ζ(2m), ζ(2n)]`.
     * `zeta_two_zeta_four_linearIndependent` — the concrete Basel instance
       `LinearIndependent ℚ ![ζ(2), ζ(4)]`.
+    * `pi_sq_pow_linearIndependent` — the powers `{(π²)ⁱ}ᵢ` are `ℚ`-linearly independent
+      (transcendence of `π²` ⟹ `aeval (π²)` injective ⟹ the monomial basis maps to an
+      independent family).
+    * `zeta_even_family_linearIndependent` — the `N`-family generalization
+      `LinearIndependent ℚ (fun k : Fin N => ζ(2(k+1)))`: *all* the even zeta values
+      `ζ(2), ζ(4), …, ζ(2N)` are jointly `ℚ`-linearly independent, not merely pairwise.
+    * `zeta_two_four_six_linearIndependent` — the concrete triple `ζ(2), ζ(4), ζ(6)`.
 
   Mathematically: `ζ(2m) = qₘ·π^(2m)` and `ζ(2n) = qₙ·π^(2n)` with `qₘ, qₙ ∈ ℚ∖{0}`;
   a rational relation forces `a·qₘ + b·qₙ·π^(2(n-m)) = 0` after dividing by `π^(2m)`, and
@@ -30,7 +37,7 @@
 import Mathlib
 import Proofs.BaselProblemOQ01OQ02
 
-open Real
+open Real Polynomial
 
 namespace BaselProblemOQ01OQ02LinIndep
 
@@ -111,5 +118,87 @@ theorem zeta_two_zeta_four_linearIndependent :
     LinearIndependent ℚ
       ![(∑' k : ℕ, 1 / (k : ℝ) ^ 2), (∑' k : ℕ, 1 / (k : ℝ) ^ 4)] := by
   exact zeta_even_linearIndependent_pair 2 1 one_pos (by norm_num)
+
+/-! ### The `N`-family generalization
+
+    The pair result above shows any two distinct even zeta values are `ℚ`-independent.  The
+    real structural statement is that *all* of them are jointly independent: `{ζ(2k)}_{k≥1}`
+    is a `ℚ`-linearly independent family.  The mechanism is the transcendence of `π²`.  Since
+    `ζ(2(k+1)) = q_{k+1} · (π²)^(k+1)` with `q_{k+1} ∈ ℚ∖{0}` (Euler), the family is a nonzero
+    rational rescaling of the powers `{(π²)^(k+1)}`, and powers of a transcendental element are
+    linearly independent (the polynomial-evaluation map `ℚ[X] → ℝ` at `π²` is injective, so it
+    carries the monomial basis to an independent family).  -/
+
+/-- **Powers of `π²` are `ℚ`-linearly independent.**  `π²` is transcendental over `ℚ` (from
+    transcendence of `π`), so `aeval (π²) : ℚ[X] → ℝ` is injective; it sends the monomial basis
+    `{Xⁱ}` of `ℚ[X]` to the family `{(π²)ⁱ}`, which is therefore `ℚ`-linearly independent. -/
+theorem pi_sq_pow_linearIndependent :
+    LinearIndependent ℚ (fun i : ℕ => ((π : ℝ) ^ 2) ^ i) := by
+  have htr : Transcendental ℚ ((π : ℝ) ^ 2) :=
+    pi_transcendental_over_rationals.pow (by norm_num)
+  have hinj : Function.Injective (Polynomial.aeval ((π : ℝ) ^ 2) : ℚ[X] →ₐ[ℚ] ℝ) :=
+    transcendental_iff_injective.1 htr
+  have hker :
+      LinearMap.ker (Polynomial.aeval ((π : ℝ) ^ 2) : ℚ[X] →ₐ[ℚ] ℝ).toLinearMap = ⊥ :=
+    LinearMap.ker_eq_bot.2 hinj
+  have hb := (Polynomial.basisMonomials ℚ).linearIndependent.map'
+      (Polynomial.aeval ((π : ℝ) ^ 2) : ℚ[X] →ₐ[ℚ] ℝ).toLinearMap hker
+  have hfun :
+      (Polynomial.aeval ((π : ℝ) ^ 2) : ℚ[X] →ₐ[ℚ] ℝ).toLinearMap ∘ ⇑(Polynomial.basisMonomials ℚ)
+        = fun i : ℕ => ((π : ℝ) ^ 2) ^ i := by
+    funext i
+    simp [Polynomial.coe_basisMonomials, Polynomial.aeval_monomial]
+  rwa [hfun] at hb
+
+/-- **The `N`-family `ζ(2), ζ(4), …, ζ(2N)` is `ℚ`-linearly independent.**  For every `N`,
+
+      `LinearIndependent ℚ (fun k : Fin N => ζ(2(k+1)))`.
+
+    Strictly generalizes `zeta_even_linearIndependent_pair` (the `N = 2` slice with a
+    reindexing).  Each `ζ(2(k+1)) = q_{k+1}·(π²)^(k+1)` with `q_{k+1} ∈ ℚ∖{0}` (Euler,
+    `zeta_even_eq_rat_mul_pi_pow`), so the family is a nonzero-rational (unit) rescaling of the
+    linearly independent powers `{(π²)^(k+1)}` (`pi_sq_pow_linearIndependent`, restricted to the
+    shifted index `k ↦ k+1`, then `LinearIndependent.units_smul`).
+
+    Uses `hermite_lindemann` only through the transcendence of `π` — no new assumption beyond the
+    parent node. -/
+theorem zeta_even_family_linearIndependent (N : ℕ) :
+    LinearIndependent ℚ
+      (fun k : Fin N => (∑' j : ℕ, 1 / (j : ℝ) ^ (2 * (k.val + 1)))) := by
+  -- Shifted powers of π² are linearly independent (restrict the full ℕ-indexed family).
+  have hshift : Function.Injective (fun k : Fin N => k.val + 1) :=
+    Nat.succ_injective.comp Fin.val_injective
+  have hbase : LinearIndependent ℚ (fun k : Fin N => ((π : ℝ) ^ 2) ^ (k.val + 1)) :=
+    pi_sq_pow_linearIndependent.comp _ hshift
+  -- Euler's closed form supplies, for each k, a nonzero rational qₖ with ζ(2(k+1)) = qₖ·π^(2(k+1)).
+  choose q hqne hqeq using fun k : Fin N =>
+    BaselProblemOQ01OQ02.zeta_even_eq_rat_mul_pi_pow (k.val + 1) (Nat.succ_pos _)
+  -- Rescale the base family by the units qₖ; linear independence is preserved.
+  have hscaled := hbase.units_smul (fun k : Fin N => Units.mk0 (q k) (hqne k))
+  -- Identify the rescaled family with the zeta family.
+  have hfun :
+      (fun k : Fin N => (∑' j : ℕ, 1 / (j : ℝ) ^ (2 * (k.val + 1))))
+        = (fun k : Fin N => Units.mk0 (q k) (hqne k))
+            • (fun k : Fin N => ((π : ℝ) ^ 2) ^ (k.val + 1)) := by
+    funext k
+    simp only [Pi.smul_apply', Units.smul_def, Units.val_mk0, Rat.smul_def]
+    rw [hqeq k, pow_mul]
+  rw [hfun]
+  exact hscaled
+
+/-- **The concrete Basel triple `ζ(2), ζ(4), ζ(6)` is `ℚ`-linearly independent.**  The `N = 3`
+    instance of `zeta_even_family_linearIndependent`. -/
+theorem zeta_two_four_six_linearIndependent :
+    LinearIndependent ℚ
+      ![(∑' k : ℕ, 1 / (k : ℝ) ^ 2), (∑' k : ℕ, 1 / (k : ℝ) ^ 4),
+        (∑' k : ℕ, 1 / (k : ℝ) ^ 6)] := by
+  have h := zeta_even_family_linearIndependent 3
+  have heq :
+      (fun k : Fin 3 => (∑' j : ℕ, 1 / (j : ℝ) ^ (2 * (k.val + 1))))
+        = ![(∑' k : ℕ, 1 / (k : ℝ) ^ 2), (∑' k : ℕ, 1 / (k : ℝ) ^ 4),
+            (∑' k : ℕ, 1 / (k : ℝ) ^ 6)] := by
+    funext k
+    fin_cases k <;> rfl
+  rwa [heq] at h
 
 end BaselProblemOQ01OQ02LinIndep

--- a/research/problems/basel-problem-oq-01-oq-02/knowledge.md
+++ b/research/problems/basel-problem-oq-01-oq-02/knowledge.md
@@ -247,3 +247,39 @@ drop it and rely on `2*1`/`2*2` defeq reduction instead.
   `transcendental_iff_injective` on `aeval (π²)`) — the N-family generalization.
 - Odd-zeta irrationality past ζ(3) remains the genuine open frontier (Apéry/Ball–Rivoal), not
   session-sized.
+
+## Session 2026-07-19 (researcher-1) — N-family ℚ-linear independence (the generalization from Next Steps)
+
+**Mode**: ACT (executed the "Next Steps" item logged 2026-07-12: general
+`LinearIndependent ℚ (fun k : Fin N => ζ(2(k+1)))`). **Outcome**: progress, no new axioms.
+
+The pair result (`zeta_even_linearIndependent_pair`) only gives *pairwise* independence. The
+structural statement is that the whole family is jointly independent. Added to
+`BaselProblemOQ01OQ02LinIndep.lean`:
+
+- `pi_sq_pow_linearIndependent` : `LinearIndependent ℚ (fun i : ℕ => (π²)^i)`. ★key move:
+  `π²` transcendental over ℚ ⟹ `transcendental_iff_injective.1` gives `aeval (π²)` injective
+  ⟹ `(Polynomial.basisMonomials ℚ).linearIndependent.map' _ (LinearMap.ker_eq_bot.2 hinj)`
+  carries the monomial basis `{Xⁱ}` to `{(π²)ⁱ}`; the composed family simplifies via
+  `[Polynomial.coe_basisMonomials, Polynomial.aeval_monomial]`. (Needs `open Polynomial` for the
+  `ℚ[X]` and `X` notation — omitting it gives "Unknown identifier `X`".)
+- `zeta_even_family_linearIndependent (N)` : `LinearIndependent ℚ (fun k : Fin N => ζ(2(k+1)))`.
+  Restrict `pi_sq_pow_linearIndependent` along the injective shift `k ↦ k+1`
+  (`.comp _ (Nat.succ_injective.comp Fin.val_injective)`), then rescale by the nonzero rationals
+  `qₖ` from Euler's `zeta_even_eq_rat_mul_pi_pow` using `LinearIndependent.units_smul` with
+  `Units.mk0 (q k) (hqne k)`. Identify the rescaled family with the zeta family via
+  `simp only [Pi.smul_apply', Units.smul_def, Units.val_mk0, Rat.smul_def]` + `rw [hqeq k, pow_mul]`
+  (`pow_mul π 2 (k+1) : π^(2*(k+1)) = (π²)^(k+1)`). `choose q hqne hqeq using …` builds the
+  scalar family over `Fin N`.
+- `zeta_two_four_six_linearIndependent` : concrete `![ζ(2),ζ(4),ζ(6)]` (N=3 via `fin_cases k <;> rfl`).
+
+Axioms on all three: `[propext, Classical.choice, HermiteLindemann.hermite_lindemann, Quot.sound]`
+— SAME as parent (via `pi_transcendental_over_rationals`), NO new assumption; `Classical.choice`
+is from `choose`, harmless. VERIFIED via Docker build + `#print axioms` EXIT 0.
+
+### Next Steps
+- The even-zeta closure algebra now has: individual transcendence, products/powers/ratios,
+  cross-power dependence, pairwise AND N-family ℚ-linear independence. This side is saturated.
+- The genuine open frontier remains odd-zeta irrationality (ζ(5), ζ(7), ζ(2n+1)) —
+  Apéry/Ball–Rivoal, not in Mathlib, not session-sized. **0 follow-ups** (depth-2 OQ; the
+  provable ℚ(π)-structure is exhausted).

--- a/src/data/research/problems/basel-problem-oq-01-oq-02.json
+++ b/src/data/research/problems/basel-problem-oq-01-oq-02.json
@@ -44,7 +44,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: added the cross-power algebraic-DEPENDENCE layer to BaselProblemOQ01OQ02.lean — ζ(2n)^m/ζ(2m)^n ∈ ℚ (zeta_even_cross_pow_ratio_rational) and its proportionality form (zeta_even_cross_pow_proportional). Both axiom-free (NO hermite_lindemann; π cancels exactly), complementing the existing π-power-incommensurability of plain ratios and showing all even zeta values lie in the transcendence-degree-1 field ℚ(π).",
+    "progressSummary": "PROGRESS: generalized the pairwise ℚ-linear independence of even zeta values to the full N-family — zeta_even_family_linearIndependent : LinearIndependent ℚ (fun k:Fin N => ζ(2(k+1))) for every N, plus the underlying pi_sq_pow_linearIndependent (powers of π² independent) and the concrete ζ(2),ζ(4),ζ(6) triple. Same axiom footprint as parent (hermite_lindemann via π-transcendence, NO new assumption). Builds clean; #print axioms = [propext, Classical.choice, HermiteLindemann.hermite_lindemann, Quot.sound].",
     "builtItems": [
       "basel_hasSum : HasSum (fun n => 1/n^2) (pi^2/6) — Euler's Basel identity via Mathlib hasSum_zeta_two (Wiedijk #14).",
       "basel_tsum : tsum form of the Basel identity.",
@@ -57,7 +57,10 @@
       "BaselProblemOQ01OQ02.lean (researcher-6, 2026-07-11): subtraction family completing the ± frontier — zeta_even_sub_transcendental (ζ(2n)−ζ(2m), m<n; polynomial C qn·X^2n + C(−qm)·X^2m, natDegree 2n≠0 via natDegree_add_eq_left_of_natDegree_lt, aeval via map_neg+eq_ratCast+ring), zeta_four_sub_zeta_two_transcendental, transcendental_sub_ratCast (axiom-free, via transcendental_add_ratCast(−q)), zeta_even_sub_ratCast_transcendental. 3 carry only hermite_lindemann, engine is 0-axiom; VERIFIED green lake env lean v4.26.0.",
       "BaselProblemOQ01OQ02.lean: zeta_even_cross_pow_ratio_rational — ζ(2n)^m/ζ(2m)^n ∈ ℚ (π cancels exactly), axiom-free.",
       "BaselProblemOQ01OQ02.lean: zeta_even_cross_pow_proportional — ∃ q≠0, ζ(2n)^m = q·ζ(2m)^n (proportionality form), axiom-free.",
-      "Proofs/BaselProblemOQ01OQ02Graded.lean — graded multiplicativity ζ(2n)ζ(2m)=q·ζ(2(n+m)) + ratio form; researcher-5, axiom-free"
+      "Proofs/BaselProblemOQ01OQ02Graded.lean — graded multiplicativity ζ(2n)ζ(2m)=q·ζ(2(n+m)) + ratio form; researcher-5, axiom-free",
+      "pi_sq_pow_linearIndependent (LinearIndependent ℚ (fun i:ℕ => (π²)^i)) in BaselProblemOQ01OQ02LinIndep.lean via transcendental_iff_injective + Polynomial.basisMonomials.linearIndependent.map'",
+      "zeta_even_family_linearIndependent (LinearIndependent ℚ (fun k:Fin N => ζ(2(k+1)))) — N-family generalization via LinearIndependent.comp (shift k to k+1) + LinearIndependent.units_smul (rescale by units q_k)",
+      "zeta_two_four_six_linearIndependent — concrete ζ(2),ζ(4),ζ(6) triple (N=3 instance)"
     ],
     "insights": [
       "The odd-zeta question asked by this slug is OPEN; it cannot be closed, only framed/contrasted with the even case.",
@@ -69,7 +72,8 @@
       "The n=0 term is 0 by the 1/0=0 convention, so the natural-number-indexed sum agrees with the classical n>=1 sum.",
       "Classical clean extensions are saturated in siblings: pi^2/8 (odd), pi^2/12 (alternating), zeta(6); a new brick here would be pure accretion.",
       "Transcendence over ℚ is preserved when scaling a transcendental by a nonzero rational: q·x algebraic ⟹ x = q⁻¹·(q·x) algebraic. This upgrades ζ(2n) from irrational to transcendental with no extra axiom, since π^(2n) is already transcendental (pi_transcendental_over_rationals.pow).",
-      "Even zeta values are algebraically DEPENDENT (commensurable after crossing exponents): ζ(2n)^m/ζ(2m)^n ∈ ℚ, since both equal (rational)·π^(2nm) with the identical π-power. This is axiom-free (no hermite_lindemann — π cancels), complementing the incommensurability of plain ratios, and shows all even zetas lie in ℚ(π)."
+      "Even zeta values are algebraically DEPENDENT (commensurable after crossing exponents): ζ(2n)^m/ζ(2m)^n ∈ ℚ, since both equal (rational)·π^(2nm) with the identical π-power. This is axiom-free (no hermite_lindemann — π cancels), complementing the incommensurability of plain ratios, and shows all even zetas lie in ℚ(π).",
+      "ℚ-linear independence of even zeta values is not merely pairwise but holds for the whole family: {ζ(2),ζ(4),…,ζ(2N)} is jointly ℚ-linearly independent for every N. Mechanism: ζ(2(k+1))=q_{k+1}·(π²)^(k+1) rescales the linearly-independent powers {(π²)^i}, which are independent because π² is transcendental over ℚ (aeval(π²):ℚ[X]→ℝ injective, so the monomial basis maps to an independent family)."
     ],
     "mathlibGaps": [
       "No 0-axiom route to Irrational(π^n) for n≥2: Mathlib has irrational_pi (does NOT lift to powers) but no Irrational(π^2)/Irrational(π^n) lemma.",


### PR DESCRIPTION
## Summary
Research session for `basel-problem-oq-01-oq-02` (Is ζ(2n+1) irrational?). The odd case is genuinely open and out of reach; this session executes the concrete "Next Steps" item logged on 2026-07-12: generalize the *pairwise* ℚ-linear independence of even zeta values to the whole **N-family**.

## Progress
Added to `proofs/Proofs/BaselProblemOQ01OQ02LinIndep.lean`:
- **`zeta_even_family_linearIndependent (N)`** : `LinearIndependent ℚ (fun k : Fin N => ζ(2(k+1)))` — for every `N`, the values `ζ(2), ζ(4), …, ζ(2N)` are *jointly* ℚ-linearly independent, not merely pairwise. Strictly generalizes `zeta_even_linearIndependent_pair`.
- **`pi_sq_pow_linearIndependent`** : `LinearIndependent ℚ (fun i : ℕ => (π²)ⁱ)` — powers of `π²` are independent, since `π²` is transcendental over ℚ so `aeval (π²) : ℚ[X] → ℝ` is injective and carries the monomial basis to an independent family.
- **`zeta_two_four_six_linearIndependent`** : the concrete Basel triple `![ζ(2), ζ(4), ζ(6)]` (N = 3 instance).

## Mechanism
`ζ(2(k+1)) = q_{k+1}·(π²)^(k+1)` with `q_{k+1} ∈ ℚ∖{0}` (Euler, `zeta_even_eq_rat_mul_pi_pow`). So the family is a nonzero-rational (unit) rescaling of the linearly independent powers `{(π²)^(k+1)}`: `pi_sq_pow_linearIndependent` restricted along the injective shift `k ↦ k+1` (`LinearIndependent.comp`), then `LinearIndependent.units_smul`.

## Findings / Honesty
- **No new axioms.** `#print axioms` on all three theorems = `[propext, Classical.choice, HermiteLindemann.hermite_lindemann, Quot.sound]` — identical to the parent node (`hermite_lindemann` enters only through transcendence of π; `Classical.choice` is from `choose`). No `sorryAx`, no `ofReduceBool`.
- Verified via Docker build (`docker-build.sh Proofs.BaselProblemOQ01OQ02LinIndep`, EXIT 0) and a `#print axioms` pass.
- The even-zeta ℚ(π)-closure algebra is now saturated (transcendence, products/powers/ratios, cross-power dependence, pairwise + N-family independence). The remaining open frontier is odd-zeta irrationality (Apéry/Ball–Rivoal), which is not session-sized.

## Status
**Outcome**: progress (structural theorem; axiomatized on `hermite_lindemann`, no new assumption)
**Next Steps**: none session-sized — odd-zeta irrationality remains open.

🤖 Generated by researcher-1