### PR TITLE
Research: erdos-748-incomplete-01 — document deep-axiom blockers (saturated)

### DIFF
--- a/research/problems/erdos-748-incomplete-01/state.md
+++ b/research/problems/erdos-748-incomplete-01/state.md
@@ -27,3 +27,18 @@ Typechecks clean (`lake env lean`, exit 0; Docker down).
 Attempt 1: added `f_monotone` + `sumFreeSubsets_subset_succ` (0 axioms). File now
 0 sorries, 2 deep axioms (Green 2004, Sapozhenko 2003 — BLOCKED, >1000 lines each).
 Follow-up "max sum-free size = ⌈n/2⌉" owned by open PR #30202.
+
+## Attempt 4 (researcher-1, 2026-07-19) — SATURATED / BLOCKED (no session-sized work)
+
+Triage only, no Lean changes. `Erdos748Problem.lean` is axiom-complete: 1089 lines, 41
+theorems, **0 sorries**, and every elementary/structural layer that can be built without the
+deep counting theorem is already present (sharp lower bound `2^⌈n/2⌉`, unconditional lower
+half of the log-asymptotic, two-family domination strict + non-strict, non-uniqueness of the
+maximum sum-free sets, sum-free closure properties). The two remaining axioms —
+`green_upper_bound` (Green 2004, `f(n) ≪ 2^{n/2}`) and `precise_asymptotic` (Sapozhenko 2003,
+parity constants `c_even, c_odd`) — are each >1000-line results absent from Mathlib and NOT
+session-provable. Recorded both as structured `currentState.blockers` entries (reopen bar:
+the counting theorem enters Mathlib / materially new mechanism). Adding further Parts on top
+of these axioms would be scaffolding, not formalization (see role "What does NOT count").
+**No PR with new theorems; released.** Follow-up "max sum-free subset = ⌈n/2⌉" remains owned
+by PR #30202 (do not duplicate).

--- a/src/data/research/problems/erdos-748-incomplete-01.json
+++ b/src/data/research/problems/erdos-748-incomplete-01.json
@@ -20,7 +20,18 @@
     "since": "2026-04-03T08:27:10.084Z",
     "iteration": 2,
     "focus": "",
-    "blockers": [],
+    "blockers": [
+      {
+        "route": "eliminate green_upper_bound axiom (Green 2004: f(n) ≪ 2^{n/2})",
+        "reopenCriterion": "Green's / Sapozhenko's O(2^{n/2}) upper-bound counting theorem enters Mathlib, or a materially new elementary upper-bound mechanism is found",
+        "blockedAt": "2026-07-19"
+      },
+      {
+        "route": "eliminate precise_asymptotic axiom (parity-dependent constants c_even, c_odd)",
+        "reopenCriterion": "Cameron–Erdős precise asymptotic (Green/Sapozhenko constants) enters Mathlib; materially new mechanism required",
+        "blockedAt": "2026-07-19"
+      }
+    ],
     "nextAction": "",
     "attemptCounts": {
       "total": 0,
@@ -29,7 +40,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (researcher-2, 2026-07-12): added Part XV (non-uniqueness of maximum sum-free sets — ≥2 extremal sets of size ⌈n/2⌉, 5 thms 0 new axioms) AND repaired a pre-existing build breakage (kernel-decide SIGBUS on f_0..f_6 removed). File now compiles clean (VERIFIED, 0 sorries, still 2 deep Green/Sapozhenko axioms).",
+    "progressSummary": "SATURATED / BLOCKED (researcher-1, 2026-07-19): file is axiom-complete — 1089 lines, 41 theorems, 0 sorries, and every session-sized elementary layer is already present (sharp lower bound 2^⌈n/2⌉, unconditional lower half of the log-asymptotic, two-family domination strict+non-strict, non-uniqueness of maximum sum-free sets, structural closure properties). The remaining substantive content is the two DEEP axioms green_upper_bound (Green 2004) and precise_asymptotic (Sapozhenko 2003), each a >1000-line result absent from Mathlib and NOT session-provable. No further session-sized work; adding more Parts on top of these axioms would be scaffolding, not formalization.",
     "builtItems": [
       "Proved trivial_lower_bound in Erdos748Problem.lean: U.powerset ⊆ sumFreeSubsets n ⇒ f n ≥ 2^|U| ≥ 2^{⌊n/2⌋}",
       "Added decidableIsSumFree instance (sum-free predicate is decidable via bounded ∀∈A form)",


### PR DESCRIPTION
## Summary
Triage of `erdos-748-incomplete-01` (Cameron–Erdős: number of sum-free subsets of {1,…,n}). **No Lean changes** — the formalization is axiom-complete and there is no session-sized advance left. This PR records that state so the depth-first Seeker stops re-serving it as if work remained.

## Findings
`proofs/Proofs/Erdos748Problem.lean` is 1089 lines, 41 theorems, **0 sorries**. Every elementary/structural layer buildable without the deep counting theorem is already present (sharp lower bound `2^⌈n/2⌉`, unconditional lower half of the log-asymptotic, two-family domination strict + non-strict, non-uniqueness of maximum sum-free sets, sum-free closure properties, accreted over Parts VI/XIV/XV by prior sessions).

The two remaining axioms are the entire substantive content and are **not session-provable**:
- `green_upper_bound` — Green 2004, `f(n) ≪ 2^{n/2}`
- `precise_asymptotic` — Sapozhenko 2003, parity-dependent constants `c_even, c_odd`

Each is a >1000-line result absent from Mathlib. Adding further Parts on top of them would be scaffolding, not formalization (role "What does NOT count").

## Changes
- `src/data/research/problems/erdos-748-incomplete-01.json`: two structured `currentState.blockers` entries (reopen bar: the counting theorem enters Mathlib / materially new mechanism); honest SATURATED/BLOCKED `progressSummary`.
- `research/problems/erdos-748-incomplete-01/state.md`: Attempt 4 note.

## Status
**Outcome**: blocked (documented) — 2 deep literature axioms, no session-sized work.
**Next Steps**: reopen only if Green/Sapozhenko counting bounds land in Mathlib. Follow-up "max sum-free subset = ⌈n/2⌉" remains owned by PR #30202.

🤖 Generated by researcher-1