### PR TITLE
Research: erdos-1038-wip-01 — record potential-theory blockers (elementary side saturated)

### DIFF
--- a/src/data/research/problems/erdos-1038-wip-01.json
+++ b/src/data/research/problems/erdos-1038-wip-01.json
@@ -28,7 +28,18 @@
     "since": "2026-06-22T00:00:00-07:00",
     "iteration": 1,
     "focus": "Added the faithful predicate MonicRealRootedIn01' (complete real splitting f.roots.card=f.natDegree) + sublevelSup'; transferred the 2√2 sup lower bound (le_sublevelSup') to the faithful object and proved X²+1 is excluded (sq_add_one_not_admissible'), so the literal-predicate sublevelInf_eq_zero degeneracy does not affect the faithful infimum.",
-    "blockers": [],
+    "blockers": [
+      {
+        "route": "sharp faithful supremum sublevelSup' = 2√2 (currently only the elementary sandwich 2√2 ≤ sublevelSup' ≤ 4 is machine-checked)",
+        "reopenCriterion": "materially new mechanism required — logarithmic potential theory (Tao 2025) enters Mathlib; the elementary |x−r| ≥ |x|−1 argument caps at the non-tight ≤ 4",
+        "blockedAt": "2026-07-19"
+      },
+      {
+        "route": "exact faithful infimum sublevelInf = 2^(4/3) − 1 (currently only sublevelInf ≤ 2 via linear X; the degree-2 slice infimum is exactly 2, separated from the true degree→∞ infimum)",
+        "reopenCriterion": "materially new mechanism required — potential theory + the (x+1)(x−1)^m extremal family; needs degree→∞ analysis beyond Mathlib",
+        "blockedAt": "2026-07-19"
+      }
+    ],
     "nextAction": "The faithful sup lower bound 2√2 ≤ sublevelSup' is done. Remaining OPEN/blocked: the faithful infimum exact value 2^(4/3)−1 (needs logarithmic potential theory beyond Mathlib) and both matching upper bounds. A cheap next win: the linear witness X also gives sublevelInf' ≤ 2 under the faithful predicate (define sublevelInf', mirror linear_admissible').",
     "attemptCounts": {
       "total": 2,


### PR DESCRIPTION
## Summary
Triage of `erdos-1038-wip-01` (Erdős #1038, faithful-polynomial sublevel-set measure extremes). **No Lean changes.** Records the deep blockers so the depth-first Seeker stops re-serving a problem whose elementary side is complete.

## Findings
`Proofs/Erdos1038WIP01.lean` (1094 lines, 0 axioms, 0 sorries, Mathlib-only) has all elementary/measure-theoretic bounds machine-checked:
- Supremum sandwich `2√2 ≤ sublevelSup' ≤ 4` (`sublevelSup'_mem_Icc`), via `|x − r| ≥ |x| − 1 ≥ 1` for `|x| ≥ 2` ⟹ `sublevelSet ⊆ (−2,2)`.
- Infimum `sublevelInf ≤ 2` (linear `X`), and the exact degree-2 slice infimum `= 2`.

The two **sharp** results are not session-sized:
- `sublevelSup' = 2√2` — needs logarithmic potential theory (Tao 2025), absent from Mathlib; the elementary argument caps at the non-tight `≤ 4`.
- `sublevelInf = 2^(4/3) − 1` — needs the `(x+1)(x−1)^m` extremal family + degree→∞ potential theory.

## Changes
- `src/data/research/problems/erdos-1038-wip-01.json`: two structured `currentState.blockers` entries (reopen bar: potential theory enters Mathlib / materially new mechanism).

## Status
**Outcome**: blocked (documented) — elementary side saturated, sharp constants need potential theory.

🤖 Generated by researcher-1