### PR TITLE
audit: erdos-838 — drop 5 phantom declaration contributions

### DIFF
--- a/src/data/proofs/erdos-838/meta.json
+++ b/src/data/proofs/erdos-838/meta.json
@@ -46,17 +46,12 @@
       "isConvexSubset axiom: convex polygon with empty interior (axiomatized)",
       "numConvexSubsets definition: count of convex subsets in a point set",
       "f axiom: minimum convex subsets over all n-point configurations",
-      "f_lower_bound: f(n) is a lower bound for any n-point set",
-      "f_achieved: f(n) is tight for some configuration",
       "erdos_lower_bound axiom: f(n) > n^{c₁ log n}",
       "erdos_upper_bound axiom: f(n) < n^{c₂ log n}",
       "erdos_bounds theorem: combines lower and upper bounds (proved)",
       "normalizedLogF definition: (log f(n))/(log n)²",
       "limitExists definition: formal statement of limit existence",
-      "erdos_szekeres_convex_subset: convex subset from Erdős-Szekeres",
-      "triangles_are_convex: 3-element subsets are convex",
       "f_superpolynomial axiom: f grows faster than any polynomial",
-      "f_subexponential: f grows slower than any exponential",
       "erdos_838_summary theorem: combines bounds with superpolynomial growth (proved)"
     ],
     "axiomCount": 5,
@@ -106,8 +101,8 @@
       "title": "The Function f(n)",
       "startLine": 73,
       "endLine": 92,
-      "summary": "Axiomatizes f(n) with lower bound and tightness properties.",
-      "mathContext": "Axiomatized: Axiomatizes f(n) with lower bound and tightness properties."
+      "summary": "Axiomatizes f(n) as the minimum convex-subset count over n-point configurations.",
+      "mathContext": "Axiomatized: Axiomatizes f(n) as the minimum convex-subset count over n-point configurations."
     },
     {
       "id": "erdos-bounds",
@@ -130,8 +125,8 @@
       "title": "Erdős-Szekeres Connection",
       "startLine": 135,
       "endLine": 142,
-      "summary": "Erdős-Szekeres theorem, triangles are convex, triangle count bound.",
-      "mathContext": "Verified: Erdős-Szekeres theorem, triangles are convex, triangle count bound."
+      "summary": "Placeholder section noting the connection to Erdős-Szekeres; no declarations are formalized here.",
+      "mathContext": "Placeholder: the connection to the Erdős-Szekeres theorem is noted in comments but not formalized."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Integrity Issue

**Proof**: erdos-838 (Erdős Problem #838: Convex Subsets of Point Sets)
**Problem**: `originalContributions` overstates the formalization by listing 5 declarations that do not exist in the Lean source. The declaration counts (5 axioms, 2 theorems, 0 sorries) are all correct, so a counts-only re-serve would mark this clean — the overstatement is entirely in the prose.

## Evidence

**meta.json claimed** (as `originalContributions`), none of which appear in `proofs/Proofs/Erdos838Problem.lean`:
- `f_lower_bound: f(n) is a lower bound for any n-point set`
- `f_achieved: f(n) is tight for some configuration`
- `erdos_szekeres_convex_subset: convex subset from Erdős-Szekeres`
- `triangles_are_convex: 3-element subsets are convex`
- `f_subexponential: f grows slower than any exponential`

`grep` for each of these names returns 0 matches. The file's actual top-level declarations are 5 axioms (`isConvexSubset`, `f`, `erdos_lower_bound`, `erdos_upper_bound`, `f_superpolynomial`), 2 theorems (`erdos_bounds`, `erdos_838_summary`), and the defs `collinear`, `inGeneralPosition`, `numConvexSubsets`, `normalizedLogF`, `limitExists` (+ `Point2D`). Part 6 ("Erdős-Szekeres Connection") and Part 7 are empty section headers with no declarations.

## Fix applied

- Removed the 5 phantom entries from `originalContributions` (18 → 13, all remaining map to real declarations).
- Corrected the `erdos-szekeres` section, which claimed `mathContext: "Verified: Erdős-Szekeres theorem, triangles are convex, triangle count bound."` — nothing is verified there; relabeled as a placeholder.
- Dropped the phantom "tightness properties" (`f_achieved`) from the `function-f` section summary.

No count fields changed — they were already accurate.

---
Discovered during gallery integrity audit (reserve mode: prose re-verification of a previously-clean entry).