### PR TITLE
audit: erdos-799 — correct prose overstating axiomatized/formal scaffold

### DIFF
--- a/src/data/proofs/erdos-799/meta.json
+++ b/src/data/proofs/erdos-799/meta.json
@@ -56,7 +56,7 @@
       "erdos_799 theorem: the main solved result"
     ],
     "axiomCount": 2,
-    "lineCount": 178,
+    "lineCount": 174,
     "assumptions": "2 axioms: listChromaticRandom, alon_krivelevich_sudakov_1999. 0 sorries.",
     "theoremCount": 1,
     "definitionCount": 4
@@ -65,7 +65,7 @@
     "historicalContext": "**Erdős Problem #799: List Chromatic Number of Random Graphs**\n\nList coloring was introduced independently by Vizing (1976) and Erdős, Rubin, and Taylor (1979). In ordinary graph coloring, all vertices share a common palette of colors; in list coloring, each vertex $v$ receives its own list $L(v)$ of available colors, and the coloring must use a color from the vertex's own list. The *list chromatic number* (or *choice number*) $\\chi_L(G) = \\text{ch}(G)$ is the minimum $k$ such that $G$ is $k$-choosable — meaning a proper coloring exists no matter what $k$-element lists are assigned.\n\nErdős, Rubin, and Taylor observed early that $\\chi_L(G) \\geq \\chi(G)$ always, but the gap can be arbitrarily large: the complete bipartite graph $K_{n,n}$ has $\\chi = 2$ yet $\\chi_L \\geq \\lfloor\\log_2 n\\rfloor + 1$. This raised the natural question of how $\\chi_L$ behaves for *typical* (random) graphs. Problem #799 asks: is $\\chi_L(G) = o(n)$ for almost all graphs on $n$ vertices?\n\n**Resolution Timeline:**\n- **1976**: Vizing introduces list coloring.\n- **1979**: Erdős, Rubin, Taylor formalize the concept and raise foundational questions about choosability, including the list coloring conjecture ($\\chi_L = \\chi'$ for line graphs).\n- **1988**: Bollobás determines $\\chi(G(n,1/2)) \\sim n/(2\\log_2 n)$, establishing the baseline for comparison.\n- **1992**: Alon proves $\\chi_L(G(n,1/2)) \\leq C \\cdot \\frac{\\log\\log n}{\\log n} \\cdot n$ a.s., answering Problem #799 affirmatively. The proof uses the Lovász Local Lemma applied to random list colorings.\n- **1999**: Alon, Krivelevich, and Sudakov determine the precise order: $\\chi_L(G(n,1/2)) \\asymp n/\\log n$ a.s. The upper bound uses the semi-random method (Rödl nibble), while the lower bound constructs adversarial lists.",
     "problemStatement": "**Problem Statement (Solved)**\n\nThe list chromatic number $\\chi_L(G)$ is the minimal $k$ such that for any assignment of a list of $k$ colours to each vertex, a proper coloring exists where each vertex uses a color from its list.\n\n**Question:** Is $\\chi_L(G) = o(n)$ for almost all graphs on $n$ vertices?\n\n**Answer: YES**\n\nAlon (1992) proved: $\\chi_L(G) \\ll \\frac{\\log\\log n}{\\log n} \\cdot n$ almost surely.\n\nAlon-Krivelevich-Sudakov (1999) proved: $\\chi_L(G) \\asymp \\frac{n}{\\log n}$ almost surely.\n\nThis gives the precise order of magnitude for random graphs.",
     "text": "Is the list chromatic number χ_L(G) = o(n) for almost all graphs on n vertices? YES, proved by Alon (1992) and refined by Alon-Krivelevich-Sudakov (1999).",
-    "proofStrategy": "**Formalization Approach**\n\n1. **List Coloring Framework:** The formalization builds list coloring from scratch: `ColorListAssignment` (vertex-specific palettes), `IsValidListColoring` (properness + list compliance), `IsListColorable` (adversarial guarantee), and `listChromaticNumber` (minimum choosability).\n\n2. **Structural Results:** Two key structural facts are axiomatized — that $\\chi_L(G) \\geq \\chi(G)$ always, and that the gap can be arbitrarily large for bipartite graphs.\n\n3. **Random Graph Model:** Rather than formalizing the full Erdős-Rényi probability space (which requires measure theory beyond Mathlib's scope), `listChromaticRandom n` is axiomatized as a function capturing the almost-sure behavior of $\\chi_L(G(n,1/2))$.\n\n4. **Two-Stage Resolution:** Alon's 1992 bound (answering Problem #799) and the 1999 AKS tight bound are both axiomatized. The main theorem `erdos_799` follows directly from the AKS result.\n\n5. **Why Axioms:** The proofs require the Lovász Local Lemma, concentration inequalities, the semi-random method (Rödl nibble), and adversarial list constructions — all beyond current Mathlib capabilities.",
+    "proofStrategy": "**Formalization Approach**\n\n1. **List Coloring Framework:** The formalization builds list coloring from scratch: `ColorListAssignment` (vertex-specific palettes), `IsValidListColoring` (properness + list compliance), `IsListColorable` (adversarial guarantee), and `listChromaticNumber` (minimum choosability).\n\n2. **Structural Results:** Two key structural facts are documented as informal remarks (not formalized) — that $\\chi_L(G) \\geq \\chi(G)$ always, and that the gap can be arbitrarily large for bipartite graphs.\n\n3. **Random Graph Model:** Rather than formalizing the full Erdős-Rényi probability space (which requires measure theory beyond Mathlib's scope), `listChromaticRandom n` is axiomatized as a function capturing the almost-sure behavior of $\\chi_L(G(n,1/2))$.\n\n4. **Two-Stage Resolution:** Alon's 1992 bound (answering Problem #799) and the 1999 AKS tight bound are both axiomatized. The main theorem `erdos_799` follows directly from the AKS result.\n\n5. **Why Axioms:** The proofs require the Lovász Local Lemma, concentration inequalities, the semi-random method (Rödl nibble), and adversarial list constructions — all beyond current Mathlib capabilities.",
     "keyInsights": [
       "**List vs Ordinary Coloring:** List coloring is fundamentally harder because an adversary chooses the color lists. With uniform lists ($L(v) = \\{1,\\ldots,k\\}$ for all $v$), list coloring reduces to ordinary coloring, so $\\chi_L \\geq \\chi$. But the adversary can exploit graph structure to force more colors.",
       "**The $K_{n,n}$ Example:** For complete bipartite graphs, $\\chi = 2$ but $\\chi_L \\geq \\lfloor\\log_2 n\\rfloor + 1$. The adversarial strategy assigns lists so that the two sides of the bipartition always have conflicting available colors. This shows the gap $\\chi_L - \\chi$ can be arbitrarily large.",
@@ -115,10 +115,10 @@
     {
       "id": "alon-1992",
       "title": "Alon's 1992 Result",
-      "summary": "First proof that χ_L(G) = o(n): the bound χ_L ≤ C · (log log n / log n) · n via the Lovász Local Lemma, plus the formal o(n) corollary answering Problem #799",
+      "summary": "First proof that χ_L(G) = o(n): the bound χ_L ≤ C · (log log n / log n) · n via the Lovász Local Lemma, plus the o(n) corollary (documented as a remark, not formalized) answering Problem #799",
       "startLine": 119,
       "endLine": 142,
-      "mathContext": "First proof that χ_L(G) = o(n): the bound χ_L $\\leq$ C · (log $\\log n$ / $\\log n$) · n via the Lovász Local Lemma, plus the formal o(n) corollary answering Problem #799"
+      "mathContext": "First proof that χ_L(G) = o(n): the bound χ_L $\\leq$ C · (log $\\log n$ / $\\log n$) · n via the Lovász Local Lemma, plus the o(n) corollary (documented as a remark, not formalized) answering Problem #799"
     },
     {
       "id": "aks-1999",
@@ -169,7 +169,7 @@
       "Finset"
     ],
     "namespace": "Erdos799",
-    "lineCount": 178,
+    "lineCount": 174,
     "axiomCount": 2,
     "theoremCount": 1,
     "definitionCount": 4,


### PR DESCRIPTION
## Gallery Integrity Audit (reserve mode)

**Proof**: erdos-799 (List Chromatic Number of Random Graphs)

Counts are all accurate — 2 axioms, 1 theorem, 4 definitions, 0 sorries, badge `axiom`, status `axiomatized` (Tier C). No count/badge/status issues. Two **narrative overstatements** in prose overstate the formal footprint:

### Evidence

**1. `proofStrategy` step 2** claimed:
> "Two key structural facts are axiomatized — that χ_L(G) ≥ χ(G) always, and that the gap can be arbitrarily large for bipartite graphs."

The Lean source contains these only as informal `/- ... -/` comment blocks (Part II) — **not** axioms. The file has exactly two axioms: `listChromaticRandom` and `alon_krivelevich_sudakov_1999`. Fixed to "documented as informal remarks (not formalized)".

**2. Section `alon-1992` summary** claimed:
> "...plus the formal o(n) corollary answering Problem #799"

No formal corollary declaration exists — the o(n) corollary is a comment block (Part IV), not a `theorem`/`lemma`. Fixed to "the o(n) corollary (documented as a remark, not formalized)".

**3.** Corrected stale `lineCount` overcount (178 → actual 174) in both `meta` and `leanFile` blocks.

### Verification
```
$ grep -nE '^\s*(axiom|def|noncomputable def|theorem|lemma)\b' proofs/Proofs/Erdos799Problem.lean
48:def ColorListAssignment ...
55:def IsValidListColoring ...
64:def IsListColorable ...
73:noncomputable def listChromaticNumber ...
98:axiom listChromaticRandom ...
133:axiom alon_krivelevich_sudakov_1999 ...
168:theorem erdos_799 ...
```
2 axioms, 1 theorem, 4 defs, 0 sorries — matches corrected meta.

---
Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)