### PR TITLE
audit: erdos-80 — drop 5 phantom declaration names from section summaries

### DIFF
--- a/src/data/proofs/erdos-80/meta.json
+++ b/src/data/proofs/erdos-80/meta.json
@@ -106,14 +106,14 @@
     {
       "id": "upper-bounds",
       "title": "Known Upper Bounds",
-      "summary": "alon_trotter_bound, fox_loh_bound, erdos_polynomial_conjecture_false",
+      "summary": "Alon-Trotter (n^{1/2}) and Fox-Loh (n^{O(1/log log n)}) upper bounds and the disproof of Erdős's polynomial conjecture — expository comments, not formal declarations",
       "startLine": 127,
       "endLine": 160
     },
     {
       "id": "lower-bounds",
       "title": "Known Lower Bounds",
-      "summary": "linear_bound_above_threshold, regularity_lower_bound, f_tends_to_infinity",
+      "summary": "regularity_lower_bound axiom (f_c(n) → ∞); Edwards-Khadziivanov-Nikiforov linear bound (c > 1/4) as an expository comment",
       "startLine": 161,
       "endLine": 189
     },


### PR DESCRIPTION
## Integrity Issue

**Proof**: erdos-80 (Book Size in Triangle-Saturated Graphs)
**Problem**: Two section summaries name Lean declarations that do not exist — they are only `/- -/` expository comment blocks.

## Evidence

`Erdos80Problem.lean` has exactly 3 axioms, 1 theorem, 10 defs, 0 sorries (all counts in meta match).

**upper-bounds summary claimed**: `alon_trotter_bound, fox_loh_bound, erdos_polynomial_conjecture_false` → **0 real declarations** (comments at lines 132–149).

**lower-bounds summary claimed**: `linear_bound_above_threshold, regularity_lower_bound, f_tends_to_infinity` → only `regularity_lower_bound` (line 165) is a real axiom; the other two are comment-only.

## Fix

Rewrote both section summaries to describe the actual content (real axiom + expository comments) instead of naming phantom declarations. No count/badge/status change — those were already honest (`badge=axiom`, `status=axiomatized`).

---
Discovered during gallery integrity audit (reserve mode, prose-vs-declaration re-verification).

🤖 Generated with [Claude Code](https://claude.com/claude-code)