### PR TITLE
audit: erdos-795 — correct Sidon section summary (removed/false theorem)

### DIFF
--- a/src/data/proofs/erdos-795/meta.json
+++ b/src/data/proofs/erdos-795/meta.json
@@ -131,8 +131,8 @@
       "title": "Connection to Multiplicative Sidon Sets",
       "startLine": 360,
       "endLine": 415,
-      "summary": "Defines multiplicative Sidon sets (no non-trivial product relations ab = cd), proves Sidon implies distinct products, and shows the converse fails. Links to the broader theory of B_h sequences.",
-      "mathContext": "Formal definition: Defines multiplicative Sidon sets (no non-trivial product relations ab = cd), proves Sidon implies distinct products, and shows the converse fails. Links to the broader theory of B_h sequences."
+      "summary": "Defines multiplicative Sidon sets (no non-trivial product relations ab = cd). Documents that Sidon does NOT imply distinct subset products — that false direction (counterexample {2,3,6}) was removed — and states the correct fact distinct_products_not_sidon: distinct subset products do not imply Sidon (witness {2,6,18}). This theorem is sorry'd. Links to the broader theory of B_h sequences.",
+      "mathContext": "Formal definition: Defines multiplicative Sidon sets (no non-trivial product relations ab = cd). Documents that Sidon does NOT imply distinct subset products — that false direction (counterexample {2,3,6}) was removed — and states the correct fact distinct_products_not_sidon: distinct subset products do not imply Sidon (witness {2,6,18}). This theorem is sorry'd. Links to the broader theory of B_h sequences."
     },
     {
       "id": "sec-795-related",


### PR DESCRIPTION
## Integrity Issue

**Proof**: erdos-795 (Distinct Subset Products)
**Problem**: Section `sec-795-sidon` summary claims a proof of a theorem that was removed from the source because it is mathematically false.

## Evidence

**meta.json claimed** (sec-795-sidon summary/mathContext):
> Defines multiplicative Sidon sets ..., **proves Sidon implies distinct products**, and shows the converse fails.

**Lean file shows** (`proofs/Proofs/Erdos795Problem.lean:372-382`):
> NOTE: The theorem `sidon_implies_distinct_products` (Sidon → DSP) was **REMOVED because it is MATHEMATICALLY FALSE**. Counterexample: A = {2, 3, 6} ...

The only Sidon-related theorem actually present is `distinct_products_not_sidon` (line 389, **sorry'd**), which shows distinct subset products do **not** imply Sidon (witness {2,6,18}).

## Fix

Rewrote the `summary` and `mathContext` for `sec-795-sidon` to:
- Note that Sidon → DSP is false (removed, counterexample {2,3,6})
- State the correct present fact `distinct_products_not_sidon` (DSP does not imply Sidon, witness {2,6,18})
- Disclose that this theorem is sorry'd

## Audit notes (otherwise clean)

Counts all verified accurate: 14 sorries (main file), 0 axioms, 0 true stubs, 13 theorems, 7 definitions. Only `raghavan_error_is_smaller` is non-sorry (correctly disclosed in sec-795-error). Badge `wip` + `assumptions: "14 sorry(s)"` correctly disclose scaffold status. No native_decide.

---
Discovered during gallery integrity audit (reserve-mode re-serve of erdos-795).