### PR TITLE
audit: erdos-791 — drop phantom declarations, correct 'disproof formalized' overstatement

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -16420,9 +16420,9 @@
     },
     "erdos-791": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:53:45Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-07-20T01:16:56Z",
+      "result": "issues-fixed"
     },
     "erdos-792": {
       "agentId": "auditor-cycle-20-batch",

--- a/src/data/proofs/erdos-791/meta.json
+++ b/src/data/proofs/erdos-791/meta.json
@@ -50,16 +50,14 @@
       "isAdditiveBasis predicate: A covers {0,...,n} via sumset",
       "g(n) definition: minimum cardinality of a 2-basis",
       "trivial_basis theorem: {0,...,n} is always a 2-basis",
-      "Rohrbach bounds axioms: 2n ≤ g(n)² ≤ 4n",
-      "Mrose disproof axiom: g(n)² ≤ 3.5n",
-      "Yu lower bound axiom: g(n)² ≥ 2.181n",
-      "Kohonen upper bound axiom: g(n)² ≤ 3.458n",
-      "erdos_791 theorem: main result with bounds",
-      "Small values: g(0)=1, g(1)=2, g(2)=2, g(3)=3"
+      "rohrbach_lower / rohrbach_upper axioms: 2n ≤ g(n)² ≤ 4n (Rohrbach 1937)",
+      "erdos_791 theorem: derives the Rohrbach bounds 2n ≤ g(n)² ≤ 4n from the two axioms",
+      "erdos_791_summary theorem: packages the Rohrbach bounds",
+      "Historical context documented in source comments (not formalized): Mrose g(n)² ≤ 3.5n disproof, Yu 2.181n lower bound, Kohonen 3.458n upper bound, small values g(0..3)"
     ],
     "axiomCount": 2,
-    "lineCount": 205,
-    "assumptions": "2 axioms: rohrbach_lower (2n ≤ g(n)²), rohrbach_upper (g(n)² ≤ 4n). Mrose 1979 disproof of original Rohrbach conjecture formalized. 0 sorries.",
+    "lineCount": 201,
+    "assumptions": "2 axioms: rohrbach_lower (2n ≤ g(n)²), rohrbach_upper (g(n)² ≤ 4n). The erdos_791 theorem formalizes only these Rohrbach bounds; Mrose's disproof of g(n) ~ 2√n and the Yu/Kohonen refinements are described in source comments as historical context but are NOT formalized. 0 sorries.",
     "theoremCount": 3,
     "definitionCount": 3
   },
@@ -67,7 +65,7 @@
     "historicalContext": "**Erdős Problem #791: Finite Additive 2-Bases**\n\nThis problem originates from additive combinatorics and studies the efficiency of representing all integers in {0,...,n} as sums of two elements from a subset.\n\n**Historical Timeline:**\n- **Rohrbach (1937)**: Established the first bounds (2+c)n ≤ g(n)² ≤ 4n, showing g(n) is roughly √(2n) to 2√n.\n- **Erdős Conjecture**: Asked whether g(n) ~ 2√n asymptotically.\n- **Mrose (1979)**: Disproved the conjecture by constructing bases with g(n)² ≤ (7/2)n = 3.5n.\n- **Yu (2015)**: Improved the lower bound to (2.181...+o(1))n.\n- **Kohonen (2017)**: Improved the upper bound to (3.458...+o(1))n.\n\nThe problem connects to sumset theory, a central topic in additive combinatorics with applications to number theory and computer science.",
     "problemStatement": "**Problem Statement (Disproved)**\n\nLet $g(n)$ be the minimal size of a set $A \\subseteq \\{0,\\ldots,n\\}$ such that $\\{0,\\ldots,n\\} \\subseteq A+A$.\n\nEstimate $g(n)$. In particular, is it true that $g(n) \\sim 2n^{1/2}$?\n\n**Answer: NO**\n\nMrose (1979) disproved the conjecture by showing $g(n)^2 \\leq \\frac{7}{2}n$.\n\n**Current Best Bounds:**\n$(2.181\\ldots + o(1))n \\leq g(n)^2 \\leq (3.458\\ldots + o(1))n$\n\nThis means $1.477\\sqrt{n} \\lesssim g(n) \\lesssim 1.860\\sqrt{n}$, far from Erdős's conjectured $2\\sqrt{n}$.",
     "text": "Let g(n) be the minimal size of a set A ⊆ {0,...,n} such that {0,...,n} ⊆ A+A. Is g(n) ~ 2√n? NO - disproved by Mrose (1979).",
-    "proofStrategy": "**Formalization Approach**\n\n1. **Sumset Definition:** Define A+A as the image of A×A under addition.\n\n2. **Additive Basis:** A set A is a 2-basis for {0,...,n} if range(n+1) ⊆ sumset(A).\n\n3. **The Function g(n):** Define as the infimum of cardinalities of all 2-bases.\n\n4. **Bounds:** Axiomatize the key results:\n   - Rohrbach (1937): 2n ≤ g(n)² ≤ 4n\n   - Mrose (1979): g(n)² ≤ 3.5n (disproves g(n) ~ 2√n)\n   - Yu (2015): g(n)² ≥ 2.181n\n   - Kohonen (2017): g(n)² ≤ 3.458n\n\n5. **Main Theorem:** Combine to show the conjecture is false.",
+    "proofStrategy": "**Formalization Approach**\n\n1. **Sumset Definition:** Define A+A as the image of A×A under addition.\n\n2. **Additive Basis:** A set A is a 2-basis for {0,...,n} if range(n+1) ⊆ sumset(A).\n\n3. **The Function g(n):** Define as the infimum of cardinalities of all 2-bases.\n\n4. **Bounds:** Axiomatize the Rohrbach (1937) bounds 2n ≤ g(n)² ≤ 4n as `rohrbach_lower` and `rohrbach_upper`. The later refinements — Mrose (1979) g(n)² ≤ 3.5n, Yu (2015) g(n)² ≥ 2.181n, Kohonen (2017) g(n)² ≤ 3.458n — are recorded in source comments as historical context but are NOT axiomatized or otherwise formalized.\n\n5. **Main Theorem:** `erdos_791` derives the Rohrbach bounds 2n ≤ g(n)² ≤ 4n from the two axioms. This is the formalized content; the actual disproof of g(n) ~ 2√n (which needs Mrose's g(n)² ≤ 3.5n < 4n) is discussed but not derived in Lean.",
     "keyInsights": [
       "**Additive 2-Basis:** A set A such that every k ∈ {0,...,n} can be written as a+b with a,b ∈ A",
       "**Trivial Bound:** The set {0,1,...,n} is always a 2-basis with n+1 elements",
@@ -95,8 +93,8 @@
       "title": "Basic Properties",
       "startLine": 60,
       "endLine": 96,
-      "summary": "basis_contains_zero, trivial_basis, g_le_n_plus_one, g_pos.",
-      "mathContext": "Mathematical content: basis_contains_zero, trivial_basis, g_le_n_plus_one, g_pos."
+      "summary": "trivial_basis theorem ({0,...,n} is always a 2-basis). Zero-membership, g ≤ n+1, and g ≥ 1 are noted in source comments only, not declared.",
+      "mathContext": "Only trivial_basis is a declaration here; basis_contains_zero / g_le_n_plus_one / g_pos are informal comment blocks, not Lean theorems."
     },
     {
       "id": "rohrbach-bounds",
@@ -111,40 +109,40 @@
       "title": "Mrose's Disproof (1979)",
       "startLine": 114,
       "endLine": 132,
-      "summary": "mrose_upper and erdos_conjecture_false axioms.",
-      "mathContext": "Axiomatized: mrose_upper and erdos_conjecture_false axioms."
+      "summary": "Mrose's g(n)² ≤ 3.5n disproof of g(n) ~ 2√n is described in source comments only — NOT axiomatized or formalized (no mrose_upper / erdos_conjecture_false declarations exist).",
+      "mathContext": "Historical context in comments; no Lean declarations. The Mrose bound is not part of the formalized content."
     },
     {
       "id": "modern-bounds",
       "title": "Modern Bounds",
       "startLine": 133,
       "endLine": 148,
-      "summary": "Yu (2015) lower bound and Kohonen (2017) upper bound.",
-      "mathContext": "Bound: Yu (2015) lower bound and Kohonen (2017) upper bound."
+      "summary": "Yu (2015) lower bound and Kohonen (2017) upper bound — recorded in source comments as historical context only, not formalized.",
+      "mathContext": "Comment blocks only; no Lean declarations for the Yu or Kohonen bounds."
     },
     {
       "id": "small-values",
       "title": "Small Values",
       "startLine": 149,
       "endLine": 165,
-      "summary": "g(0)=1, g(1)=2, g(2)=2, g(3)=3 (axiomatized).",
-      "mathContext": "Axiomatized: g(0)=1, g(1)=2, g(2)=2, g(3)=3 (axiomatized)."
+      "summary": "Small values g(0)=1, g(1)=2, g(2)=2, g(3)=3 are stated in a source comment only — NOT axiomatized or proved (no declarations exist).",
+      "mathContext": "Comment block only; no Lean declarations for the small values."
     },
     {
       "id": "structural-properties",
       "title": "Structural Properties",
       "startLine": 166,
       "endLine": 182,
-      "summary": "g_nondecreasing and g_subadditive_approx.",
-      "mathContext": "Mathematical content: g_nondecreasing and g_subadditive_approx."
+      "summary": "Approximate monotonicity and subadditivity of g are sketched in source comments only — no g_nondecreasing / g_subadditive_approx declarations exist.",
+      "mathContext": "Comment blocks only; no Lean declarations."
     },
     {
       "id": "main-results",
       "title": "Main Results",
       "startLine": 183,
       "endLine": 205,
-      "summary": "erdos_791 theorem, erdos_791_answer axiom.",
-      "mathContext": "Verified: erdos_791 theorem, erdos_791_answer axiom."
+      "summary": "erdos_791 and erdos_791_summary theorems, both deriving the Rohrbach bounds 2n ≤ g(n)² ≤ 4n from the two axioms. The negative answer to g(n) ~ 2√n is discussed in a comment but not derived (no erdos_791_answer declaration exists).",
+      "mathContext": "erdos_791 and erdos_791_summary are the only declarations; erdos_791_answer is a comment, not an axiom."
     }
   ],
   "conclusion": {
@@ -171,7 +169,7 @@
       "Nat"
     ],
     "namespace": "Erdos791",
-    "lineCount": 205,
+    "lineCount": 201,
     "axiomCount": 2,
     "theoremCount": 3,
     "definitionCount": 3,


### PR DESCRIPTION
## Gallery Integrity Audit — erdos-791

Reserve-mode audit (queue drained). Verified `meta.json` against `Proofs/Erdos791Problem.lean`.

**Result: ISSUES-FIXED** (MEDIUM severity — phantom declarations + a "formalized" overstatement).

### What was wrong
Counts were accurate (`axiomCount` 2, `theoremCount` 3, `definitionCount` 3), but the prose described ~15 declarations. Most exist only as `/- … -/` comment blocks in the source, **not** as Lean declarations:

| Referenced in meta | Reality in source |
|---|---|
| `basis_contains_zero`, `g_le_n_plus_one`, `g_pos` | comments only — only `trivial_basis` is real |
| `mrose_upper`, `erdos_conjecture_false` axioms | comments only — Mrose disproof not axiomatized |
| Yu (2015) / Kohonen (2017) bound "axioms" | comments only |
| small-value axioms g(0..3) | comment only |
| `g_nondecreasing`, `g_subadditive_approx` | comments only |
| `erdos_791_answer` axiom | comment only |

**Key overstatement:** `assumptions` and `proofStrategy` claimed Mrose's disproof of g(n) ~ 2√n was **"formalized."** It is not. The only two axioms are `rohrbach_lower` / `rohrbach_upper`, and `erdos_791` derives only the Rohrbach bounds 2n ≤ g(n)² ≤ 4n — which are *consistent* with g(n) ~ 2√n (g² ~ 4n), so they do **not** constitute a disproof. Formalizing the disproof would require Mrose's g(n)² ≤ 3.5n < 4n, which is absent.

### Fix
- `originalContributions`: replaced phantom-axiom entries with the real declarations (`sumset`, `isAdditiveBasis`, `g`, `trivial_basis`, `rohrbach_lower/upper`, `erdos_791`, `erdos_791_summary`); moved Mrose/Yu/Kohonen/small-values to a "documented in comments, not formalized" note.
- `assumptions` / `proofStrategy`: scoped the formalized content to the Rohrbach bounds; explicitly marked the disproof as discussed-not-derived.
- Six `sections` summaries/mathContexts corrected to distinguish declarations from comment blocks.
- `lineCount` overcount 205 → 201 (actual).

Status/badge (`axiomatized` / `axiom`) and all counts unchanged — those were already correct.

---
Discovered during gallery integrity audit.