### PR TITLE
Research: roth-theorem-k3-oq-04 — first-moment divisor sum S(N)=φ⋆√ is multiplicative [VERIFIED 0-axiom]

### DIFF
--- a/proofs/Proofs/RothTheoremOQ04Multiplicative.lean
+++ b/proofs/Proofs/RothTheoremOQ04Multiplicative.lean
@@ -1,0 +1,117 @@
+/-
+  Roth Theorem OQ-04 (structural companion): the first-moment divisor sum
+  `S(N) = ∑_{d∣N} φ(N/d)·√d` is a MULTIPLICATIVE arithmetic function.
+
+  `RothTheoremOQ04FirstMoment` evaluates the exact `L¹` first moment of the
+  quadratic Gauss sum at odd `N`:
+
+      `∑_{r} ‖G(r)‖ = √N · ∑_{d∣N} φ(N/d)·√d`   (`sum_norm_sqGaussSum_eq_of_odd`).
+
+  The arithmetic core of that ceiling is the divisor sum
+  `S(N) := ∑_{d∣N} φ(N/d)·√d`.  This file identifies `S` as the **Dirichlet
+  convolution** `φ ⋆ (√·)` of the (multiplicative) Euler totient and the
+  (completely multiplicative) real square root.  Mathlib's
+  `ArithmeticFunction.IsMultiplicative.mul` then gives, for free, that `S` is
+  multiplicative:
+
+      `gcd(m, n) = 1  ⟹  S(m · n) = S(m) · S(n)`   (`isMultiplicative_firstMomentAF`).
+
+  Multiplicativity reduces the first moment at *every* odd `N` to its prime-power
+  values, given in closed form by
+
+  * `firstMomentDivisorSum_prime_pow` — `S(p^k) = ∑_{j≤k} φ(p^{k-j})·p^{j/2}`, and
+  * `firstMomentDivisorSum_prime` — `S(p) = (p-1) + √p`; multiplying by `√p`
+    recovers the prime first moment `p + (p-1)·√p` of
+    `sum_norm_sqGaussSum_eq_of_prime`.
+
+  Because `firstMomentAF N` is, by `firstMomentAF_apply`, *definitionally* the
+  same divisor sum that appears (times `√N`) in `sum_norm_sqGaussSum_eq_of_odd`,
+  this file makes the first moment of the quadratic Gauss sum a `√N`-multiple of
+  a multiplicative arithmetic function whose prime-power values are explicit —
+  a structural characterisation that the earlier ad-hoc evaluations (`N = 9`,
+  the prime case) are now special cases of.
+
+  All results are fully machine-checked: 0 sorries, 0 axioms, no `native_decide`,
+  Mathlib only (no dependency on the heavy `RothTheorem` file).
+-/
+import Mathlib
+
+open Finset ArithmeticFunction
+
+namespace Szemeredi.Roth
+
+/-- The real square root as an arithmetic function `ℕ → ℝ` (with `√0 = 0`). -/
+noncomputable def sqrtAF : ArithmeticFunction ℝ := ⟨fun n => Real.sqrt n, by simp⟩
+
+/-- The Euler totient as a real-valued arithmetic function (`φ 0 = 0`). -/
+noncomputable def totientAF : ArithmeticFunction ℝ := ⟨fun n => (n.totient : ℝ), by simp⟩
+
+/-- The **first-moment divisor sum** `S(N) = ∑_{d∣N} φ(N/d)·√d`, packaged as the
+    Dirichlet convolution `φ ⋆ (√·)`. -/
+noncomputable def firstMomentAF : ArithmeticFunction ℝ := totientAF * sqrtAF
+
+@[simp] theorem sqrtAF_apply (n : ℕ) : sqrtAF n = Real.sqrt n := rfl
+
+@[simp] theorem totientAF_apply (n : ℕ) : totientAF n = (n.totient : ℝ) := rfl
+
+/-- `√·` is multiplicative: `√1 = 1` and `√(m·n) = √m·√n` (in fact completely so). -/
+theorem isMultiplicative_sqrtAF : sqrtAF.IsMultiplicative := by
+  refine ⟨by simp, ?_⟩
+  intro m n _
+  simp only [sqrtAF_apply, Nat.cast_mul]
+  exact Real.sqrt_mul (by positivity) _
+
+/-- The real totient is multiplicative (cast of `Nat.totient_mul`). -/
+theorem isMultiplicative_totientAF : totientAF.IsMultiplicative := by
+  refine ⟨by simp, ?_⟩
+  intro m n hmn
+  simp only [totientAF_apply]
+  rw [Nat.totient_mul hmn, Nat.cast_mul]
+
+/-- **The first-moment divisor sum is multiplicative.**  A Dirichlet convolution
+    of two multiplicative arithmetic functions is multiplicative
+    (`ArithmeticFunction.IsMultiplicative.mul`), so `gcd(m,n)=1 ⟹ S(mn)=S(m)S(n)`. -/
+theorem isMultiplicative_firstMomentAF : firstMomentAF.IsMultiplicative :=
+  isMultiplicative_totientAF.mul isMultiplicative_sqrtAF
+
+/-- **`S(N)` is the first-moment divisor sum.**  Unfolding the Dirichlet
+    convolution and reindexing the antidiagonal by `d ↦ (N/d, d)` gives exactly
+    the sum `∑_{d∣N} φ(N/d)·√d` that appears (times `√N`) in
+    `RothTheoremOQ04FirstMoment.sum_norm_sqGaussSum_eq_of_odd`. -/
+theorem firstMomentAF_apply (N : ℕ) :
+    firstMomentAF N = ∑ d ∈ N.divisors, ((N / d).totient : ℝ) * Real.sqrt d := by
+  rw [firstMomentAF, mul_apply, Nat.sum_divisorsAntidiagonal' (f := fun a b => totientAF a * sqrtAF b)]
+  simp only [totientAF_apply, sqrtAF_apply]
+
+/-- Multiplicative shorthand `S(m·n) = S(m)·S(n)` at coprime arguments. -/
+theorem firstMomentAF_mul_of_coprime {m n : ℕ} (h : m.Coprime n) :
+    firstMomentAF (m * n) = firstMomentAF m * firstMomentAF n :=
+  isMultiplicative_firstMomentAF.map_mul_of_coprime h
+
+/-- **Closed form of `S` at prime powers.**  `S(p^k) = ∑_{j=0}^{k} φ(p^{k-j})·p^{j/2}`.
+    Every divisor of `p^k` is `p^j` with `0 ≤ j ≤ k`, and `p^k / p^j = p^{k-j}`. -/
+theorem firstMomentDivisorSum_prime_pow {p : ℕ} (hp : p.Prime) (k : ℕ) :
+    firstMomentAF (p ^ k)
+      = ∑ j ∈ range (k + 1), ((p ^ (k - j)).totient : ℝ) * Real.sqrt ((p : ℝ) ^ j) := by
+  rw [firstMomentAF_apply, Nat.sum_divisors_prime_pow hp]
+  refine Finset.sum_congr rfl fun j hj => ?_
+  have hjk : j ≤ k := Nat.lt_succ_iff.1 (Finset.mem_range.1 hj)
+  have hdiv : p ^ k / p ^ j = p ^ (k - j) := Nat.pow_div hjk hp.pos
+  rw [hdiv, Nat.cast_pow]
+
+/-- **Closed form of `S` at primes.**  `S(p) = (p-1) + √p`.  Multiplying by `√p`
+    recovers the prime first moment `√p · S(p) = p + (p-1)·√p` of
+    `RothTheoremOQ04FirstMoment.sum_norm_sqGaussSum_eq_of_prime`. -/
+theorem firstMomentDivisorSum_prime {p : ℕ} (hp : p.Prime) :
+    firstMomentAF p = ((p : ℝ) - 1) + Real.sqrt p := by
+  have hk : firstMomentAF (p ^ 1) = _ := firstMomentDivisorSum_prime_pow hp 1
+  rw [pow_one] at hk
+  rw [hk]
+  -- ∑_{j∈{0,1}} φ(p^{1-j})·p^{j/2} = φ(p)·1 + φ(1)·√p = (p-1) + √p
+  rw [Finset.sum_range_succ, Finset.sum_range_one]
+  simp only [Nat.sub_zero, pow_one, Nat.sub_self, pow_zero, Nat.totient_one, Nat.cast_one,
+    Real.sqrt_one, mul_one, Nat.totient_prime hp]
+  rw [Nat.cast_sub hp.one_le, Nat.cast_one]
+  ring
+
+end Szemeredi.Roth

--- a/src/data/research/problems/roth-theorem-k3-oq-04.json
+++ b/src/data/research/problems/roth-theorem-k3-oq-04.json
@@ -11,7 +11,7 @@
   "status": "in-progress",
   "knowledge": {
     "score": 17,
-    "progressSummary": "PROGRESS: exact Lᵖ moment hierarchy machine-checked; sharp single-modulus density |A| ≤ #{n²=0} + N/√minFac(N) at odd N; NEW sqDiffFree_card_le_of_prime specializes it to primes: any square-difference-free A ⊆ ℤ/pℤ (p odd prime) has |A| ≤ 1+√p — a fully machine-checked o(N) Sárközy bound along prime moduli (minFac=p ⟹ √p, and #{n²=0}=1 in a field), with NO bounded-minFac obstruction. Remaining o(N²) for composite N still needs τ(N)=o(√N) (Wigert; Mathlib gap).",
+    "progressSummary": "PROGRESS: NEW structural companion RothTheoremOQ04Multiplicative.lean (0 sorries/0 axioms, Mathlib-only, host-verified) — the first-moment divisor sum S(N)=∑_{d|N}φ(N/d)√d is the Dirichlet convolution φ⋆(√·), hence MULTIPLICATIVE (S(mn)=S(m)S(n) at coprime m,n), with closed forms S(p^k)=∑_{j≤k}φ(p^{k-j})p^{j/2} and S(p)=(p-1)+√p. This makes ∑_r‖G(r)‖=√N·S(N) a √N-multiple of a multiplicative function and pins the first moment ~N^{3/2} at all odd N. Prior: exact Lᵖ moment hierarchy; sharp single-modulus density |A|≤#{n²=0}+N/√minFac(N); Sárközy √p bound at prime moduli. Still-open o(N²) for composite N remains blocked on τ(N)=o(√N) (Wigert; Mathlib gap) and the coset-descent barrier (Part LVII).",
     "insights": [
       "The existing Roth Fourier infrastructure is genuine and 0-axiom: RothTheorem.lean defines fourierCoeff A r = ∑_{x∈A} ψ(r·x) on ZMod N, proves Parseval (∑_r ‖Â(r)‖² = |A|·N), and the key linearization triple_count_fourier: tripleCount(A) + |A| = N⁻¹·∑_r Â(r)²·conj(Â(2r)). The 3-AP count linearizes ONLY because the pattern (x, x+d, x+2d) is a linear form: character orthogonality in x forces the frequency relation and collapses two of the three Fourier factors into Â(r) and Â(2r).",
       "Structural answer to the OQ, part (a) — Sárközy/single square difference IS an accessible extension. For A ⊆ ZMod N the square-difference count SD(A) = ∑_{x,n} 1_A(x)·1_A(x+n²) Fourier-expands (identical orthogonality bookkeeping to triple_count_fourier) to SD(A) = N⁻¹·∑_r |Â(r)|²·G(r), where G(r) = ∑_{n∈ZMod N} ψ(r·n²) is a quadratic GAUSS sum. Principal term r=0: G(0)=N, Â(0)=|A| ⇒ |A|². The new ingredient vs 3-APs is that the non-principal terms are weighted by G(r) (size ≈ √N for r≠0 by classical Gauss-sum bounds) instead of a second coefficient Â(2r). So the LINEAR transform + Weyl/Gauss-sum estimates suffice — this is exactly the circle-method route to Sárközy's theorem.",
@@ -98,7 +98,9 @@
       "Part LVIII: for a square-difference-free A, sqDiffCount A = |A|·κ EXACTLY (κ=#{n:n²=0}), not merely ≤ — every trivial pair (x,n) with n²=0 is counted since x+n²=x∈A, and freeness kills n²≠0; the filtered set is exactly A×ˢ{n:n²=0}.",
       "Part LVIII exact deficit identity: substituting the exact free count into sqDiffCount_fourier_main pins the nonzero-frequency Gauss-weighted Fourier energy EXACTLY: Σ_{r≠0}‖Â(r)‖²·G(r) = N·(|A|·κ−|A|²) = N·|A|·(κ−|A|). The bad mass is not just bounded — it is DETERMINED by |A|. For |A|>κ this is a nonzero multiple of N, an exact lower bound on Gauss-weighted structure the circle method cannot avoid.",
       "Part LVIII is the honest exact form of the density-increment engine: sqDiff_error_le bounds the bad mass from ABOVE (circle method); sqDiffFree_badMass_norm pins it from BELOW at exactly N·|A|·||A|−κ|. The two together force |A|−κ ≤ max_{r≠0}‖G(r)‖, recovering every Parts VI–LII density bound and making explicit that the SDF hypothesis is CONSUMED as this exact energy lower bound.",
-      "The Part-LVIII aggregate deficit ‖Σ_{r≠0}‖Â(r)‖²·G(r)‖=N·|A|·||A|−κ| becomes a POINTWISE large-coefficient statement by a pure N−1-term pigeonhole (norm_sum_le + ‖G‖≤M upper bound vs summing N−1 strict inequalities). This is the honest single-scale density-increment INPUT; it does NOT close o(N) — still blocked by the Part-LVII coset-descent obstruction and the Part-XLVII no-fixed-M barrier."
+      "The Part-LVIII aggregate deficit ‖Σ_{r≠0}‖Â(r)‖²·G(r)‖=N·|A|·||A|−κ| becomes a POINTWISE large-coefficient statement by a pure N−1-term pigeonhole (norm_sum_le + ‖G‖≤M upper bound vs summing N−1 strict inequalities). This is the honest single-scale density-increment INPUT; it does NOT close o(N) — still blocked by the Part-LVII coset-descent obstruction and the Part-XLVII no-fixed-M barrier.",
+      "Part LIX (structural): the first-moment divisor sum S(N)=∑_{d|N}φ(N/d)√d is exactly the Dirichlet convolution φ⋆(√·) of the multiplicative Euler totient and the completely-multiplicative real square root, hence S is a MULTIPLICATIVE arithmetic function (ArithmeticFunction.IsMultiplicative.mul): gcd(m,n)=1 ⟹ S(mn)=S(m)S(n). So ∑_r‖G(r)‖=√N·S(N) is √N times a multiplicative function of N — the ad-hoc N=9 and prime evaluations are now special cases.",
+      "Part LIX closed form: S(p^k)=∑_{j=0}^{k} φ(p^{k-j})·p^{j/2} (firstMomentDivisorSum_prime_pow), and S(p)=(p-1)+√p (firstMomentDivisorSum_prime); ×√p gives p+(p-1)√p, recovering sum_norm_sqGaussSum_eq_of_prime. Multiplicativity reduces the first moment at EVERY odd N to these prime-power values — the leading term is φ(N)~N (from d=1), confirming first moment ~ N^{3/2}, not the trivial N², independent of the still-open τ(N)=o(√N) Wigert gap."
     ],
     "builtItems": [
       "RothTheorem.lean Part VI (researcher-5, 2026-07-05, VERIFIED 0-axiom): sqGaussSum r = ∑_{n∈ZMod N} ψ(r·n²) (quadratic Gauss sum); sqDiffCount A = #{(x,n) : x∈A, x+n²∈A} (square-difference count); sqGaussSum_zero: G(0)=N; sqDiffCount_fourier_complex: SD(A)·N = ∑_r Â(r)·conj(Â(r))·G(r); sqDiffCount_fourier: SD(A) = N⁻¹·∑_r ‖Â(r)‖²·G(r). Proof mirrors triple_count_fourier: expand each term as a triple ψ-sum, bring the r-sum innermost, apply char_orthogonality (∑_r ψ(r·c)=N·[c=0]), collapse the y-sum via y=x+n². #print axioms → [propext, Classical.choice, Quot.sound].",
@@ -251,7 +253,12 @@
       "sqDiffCount_eq_of_free (RothTheorem.lean ~7060): exact sqDiffCount A = |A|·#{n:n²=0} for SDF A [0-axiom]",
       "sqDiffFree_badMass_eq (RothTheorem.lean ~7095): exact complex deficit Σ_{r≠0}‖Â(r)‖²·G(r)=N·(|A|·κ−|A|²) [0-axiom]",
       "sqDiffFree_badMass_norm (RothTheorem.lean ~7130): exact magnitude ‖Σ_{r≠0}‖Â(r)‖²·G(r)‖=N·|A|·||A|−κ| [0-axiom]",
-      "Part LX sqDiffFree_exists_large_fourier_coeff (RothTheorem.lean): L∞ pigeonhole extracts a SINGLE large Fourier coefficient from the Part-LVIII exact deficit — for SDF A with |A|>κ and uniform ‖G(r)‖≤M over r≠0, ∃ r≠0 with N·|A|·(|A|−κ) ≤ (N−1)·M·‖Â(r)‖², i.e. ‖Â(r)‖²≥N·|A|·(|A|−κ)/((N−1)M). With M=√N,|A|=δN gives ‖Â(r)‖≳δN^{3/4}, relative increment ≳N^{−1/4}. VERIFIED 0-axiom"
+      "Part LX sqDiffFree_exists_large_fourier_coeff (RothTheorem.lean): L∞ pigeonhole extracts a SINGLE large Fourier coefficient from the Part-LVIII exact deficit — for SDF A with |A|>κ and uniform ‖G(r)‖≤M over r≠0, ∃ r≠0 with N·|A|·(|A|−κ) ≤ (N−1)·M·‖Â(r)‖², i.e. ‖Â(r)‖²≥N·|A|·(|A|−κ)/((N−1)M). With M=√N,|A|=δN gives ‖Â(r)‖≳δN^{3/4}, relative increment ≳N^{−1/4}. VERIFIED 0-axiom",
+      "firstMomentAF := totientAF * sqrtAF (Dirichlet convolution) in RothTheoremOQ04Multiplicative.lean",
+      "isMultiplicative_firstMomentAF: S is multiplicative, in RothTheoremOQ04Multiplicative.lean",
+      "firstMomentAF_apply: S N = ∑_{d|N} φ(N/d)·√d (bridge to sum_norm_sqGaussSum_eq_of_odd), RothTheoremOQ04Multiplicative.lean",
+      "firstMomentDivisorSum_prime_pow: S(p^k)=∑_{j≤k}φ(p^{k-j})p^{j/2}, RothTheoremOQ04Multiplicative.lean",
+      "firstMomentDivisorSum_prime: S(p)=(p-1)+√p, RothTheoremOQ04Multiplicative.lean"
     ],
     "nextSteps": [
       "DONE (researcher-11): two-torsion DICHOTOMY G(r)∈{0,N} at 2r=0 (sqGaussSum_eq_zero_or_eq_natCast_of_two_mul_eq_zero) — the exact characterization at the frequencies the gcd/kernel-count bounds leave vacuous (‖G(r)‖≤N trivially); rules out all intermediate magnitudes 0<‖G(r)‖<N.",
@@ -320,6 +327,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/RothTheorem.lean"
+    },
+    {
+      "path": "Proofs/RothTheoremOQ04Multiplicative.lean",
+      "filename": "RothTheoremOQ04Multiplicative.lean",
+      "lineCount": 117,
+      "theoremCount": 9,
+      "axiomCount": 0,
+      "defCount": 3,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/RothTheoremOQ04Multiplicative.lean"
     }
   ]
 }


### PR DESCRIPTION
## Summary
Structural companion to `RothTheoremOQ04FirstMoment`. The exact `L¹` first moment of the quadratic Gauss sum at odd `N` is `∑_r ‖G(r)‖ = √N · S(N)` where `S(N) = ∑_{d∣N} φ(N/d)·√d`. This PR proves `S` is a **multiplicative arithmetic function** with explicit prime-power values.

New file `proofs/Proofs/RothTheoremOQ04Multiplicative.lean` (Mathlib-only, host-verified, 0 sorries / 0 axioms; `#print axioms` = `propext, Classical.choice, Quot.sound` only).

## Progress
- `firstMomentAF := totientAF * sqrtAF` — `S` realised as the Dirichlet convolution `φ ⋆ (√·)`.
- `isMultiplicative_firstMomentAF` — `gcd(m,n)=1 ⟹ S(mn)=S(m)S(n)`, via `ArithmeticFunction.IsMultiplicative.mul` (totient multiplicative × `√` completely multiplicative).
- `firstMomentAF_apply` — `S N = ∑_{d∣N} φ(N/d)·√d`, definitionally the divisor sum in `sum_norm_sqGaussSum_eq_of_odd`, so `∑_r ‖G(r)‖ = √N · S(N)` is `√N` times a multiplicative function.
- `firstMomentDivisorSum_prime_pow` — `S(p^k) = ∑_{j≤k} φ(p^{k-j})·p^{j/2}`.
- `firstMomentDivisorSum_prime` — `S(p) = (p-1)+√p`; `×√p` recovers `p+(p-1)√p` (`sum_norm_sqGaussSum_eq_of_prime`).

## Findings
- Multiplicativity reduces the first moment at *every* odd `N` to prime-power values; the ad-hoc `N=9` and prime evaluations are now special cases.
- The leading `d=1` term `φ(N)·√1 ~ N` confirms the first moment `~ N^{3/2}` (not the trivial `N²`), independent of the open Wigert gap.

## Status
**Outcome**: progress (structural result; the target `o(N²)` for composite `N` remains open, blocked on `τ(N)=o(√N)` (Wigert; Mathlib gap) and the Part-LVII coset-descent barrier).
**Next Steps**: an unconditional first-moment/density bound for composite `N` still needs a divisor-growth input not in Mathlib.

🤖 Generated by researcher-1