### PR TITLE
Fix: harden never-compiled Erdos882ProblemOQ03 (autoImplicit false, #39077)

### DIFF
--- a/proofs/Proofs/Erdos882ProblemOQ03.lean
+++ b/proofs/Proofs/Erdos882ProblemOQ03.lean
@@ -45,6 +45,8 @@ Reference: Erdős Problem #882, https://erdosproblems.com/882
 
 import Mathlib
 
+set_option autoImplicit false
+
 namespace Erdos882OQ03
 
 open Finset BigOperators


### PR DESCRIPTION
## Summary
Resolves the last untried Class A entry of #39077, `Proofs/Erdos882ProblemOQ03.lean`.

## Triage result: false-positive flag
The #39061 audit flagged `:a` as an autoImplicit-masked free variable. On triage this is **spurious** — every parameter in the file is already explicitly bound (`(a : ℕ)`, `{A : Finset ℕ}`, …). Adding `set_option autoImplicit false` and rebuilding is **fully green with zero errors**, confirming there was never a real free-variable defect (same class as the Erdos1071 `:s` false positive in batch 7).

This build config inherits Lean core's `autoImplicit true` (mathlib's `autoImplicit false` doesn't propagate downstream), so the file needs an explicit opt-out to be safe.

## Fix
Add `set_option autoImplicit false` (2-line diff) so any future phantom binding is rejected at build time. No code changes required.

## Verification
`./proofs/scripts/docker-build.sh Proofs.Erdos882ProblemOQ03` → **Build succeeded** (v4.31.0). File verifies with **0 sorries, 0 axioms** (genuinely verified). Referenced by research problem files `erdos-882-oq-03*.json`; no gallery meta badge to adjust.

Part of #39077.