### PR TITLE
Research: erdos-1064-oq-03 — re-verify clean under v4.31 + clear 10 deprecation warnings

### DIFF
--- a/proofs/Proofs/EulerTotientOQ04OQ03.lean
+++ b/proofs/Proofs/EulerTotientOQ04OQ03.lean
@@ -297,12 +297,12 @@ theorem oq03_both_directions_infinite :
   -- the odd primes are infinite
   have : {p : ℕ | p.Prime ∧ 3 ≤ p} = {p : ℕ | p.Prime} \ {2} := by
     ext p
-    simp only [Set.mem_setOf_eq, Set.mem_diff, Set.mem_singleton_iff]
+    simp only [Set.mem_setOf_eq, Set.mem_sdiff, Set.mem_singleton_iff]
     constructor
     · rintro ⟨hp, hp3⟩; exact ⟨hp, by omega⟩
     · rintro ⟨hp, hp2⟩; exact ⟨hp, by have := hp.two_le; omega⟩
   rw [this]
-  exact Nat.infinite_setOf_prime.diff (Set.finite_singleton 2)
+  exact Nat.infinite_setOf_prime.sdiff (Set.finite_singleton 2)
 
 -- ===========================================================================
 -- EQUALITY family:  φ(n) = φ(D(n)) holds infinitely often, via  n = 15·2^(k+1).
@@ -913,7 +913,7 @@ theorem prime_triple_family_not_reversal {p : ℕ}
   simp only [Nat.sub_self, pow_zero, mul_one]
   rw [hφa]
   -- goal: ¬ (2j·(2·(2j+1)) < φ(6j²+8j+3));  i.e. φ(e) ≤ φ(a)
-  push_neg
+  push Not
   have he2 : 1 < 6 * j ^ 2 + 8 * j + 3 := by nlinarith [hj3]
   have hφe : Nat.totient (6 * j ^ 2 + 8 * j + 3) < 6 * j ^ 2 + 8 * j + 3 :=
     Nat.totient_lt _ he2
@@ -934,13 +934,13 @@ theorem prime_triple_reversal_iff {p : ℕ}
   constructor
   · intro hmem
     by_contra hne
-    push_neg at hne
+    push Not at hne
     obtain ⟨h3, h5⟩ := hne
     -- an odd prime with `p+2, 2p+1` prime and `p ∉ {3,5}` must be `≥ 7`
     have h2le := hp.two_le
     have hp7 : 7 ≤ p := by
       by_contra hlt
-      push_neg at hlt
+      push Not at hlt
       interval_cases p <;> revert hp hp2 hq h3 h5 <;> decide
     exact prime_triple_family_not_reversal hp hp2 hq hp7 k hmem
   · rintro (rfl | rfl)
@@ -2216,7 +2216,7 @@ theorem prime_pow_le_two_totient {p : ℕ} (hp : p.Prime) (m : ℕ) :
   · obtain ⟨m', rfl⟩ : ∃ m', m = m' + 1 := ⟨m - 1, by omega⟩
     rw [Nat.totient_prime_pow_succ hp m', pow_succ]
     have hpp : p ≤ 2 * (p - 1) := by have := hp.two_le; omega
-    calc p ^ m' * p ≤ p ^ m' * (2 * (p - 1)) := mul_le_mul_left' hpp (p ^ m')
+    calc p ^ m' * p ≤ p ^ m' * (2 * (p - 1)) := _root_.mul_le_mul_right hpp (p ^ m')
       _ = 2 * (p ^ m' * (p - 1)) := by ring
 
 /-- **No excluded prime power `p^k` with `p ≡ 3 (mod 4)` reverses.**  For every
@@ -2235,7 +2235,7 @@ theorem classifySeed_prime_pow_three_mod_four_ne_lt {p k : ℕ}
     have hp7 : 7 ≤ p := by
       have h2 := hp.two_le
       by_contra h7
-      push_neg at h7
+      push Not at h7
       interval_cases p <;> first
         | exact absurd hp (by decide)
         | omega
@@ -2301,7 +2301,7 @@ theorem classifySeed_prime_pow_three_mod_four_ne_lt {p k : ℕ}
         have hw1 : 1 ≤ Nat.totient w := hwpos
         calc (2 : ℕ) ≤ 2 ^ (S - 2) := h2pow
           _ = 1 * 2 ^ (S - 2) := (one_mul _).symm
-          _ ≤ Nat.totient w * 2 ^ (S - 2) := mul_le_mul_right' hw1 (2 ^ (S - 2))
+          _ ≤ Nat.totient w * 2 ^ (S - 2) := _root_.mul_le_mul_left hw1 (2 ^ (S - 2))
     -- assemble the engine's excess bound  p^m ≤ φ(p^m)·φ(w)·2^(S−2)  and conclude
     have hbound : p ^ (m + 1) - Nat.totient (p ^ (m + 1)) ≤
         Nat.totient (seedB (p ^ (m + 1))) * 2 ^ (seedS (p ^ (m + 1)) - 2) := by
@@ -2309,7 +2309,7 @@ theorem classifySeed_prime_pow_three_mod_four_ne_lt {p k : ℕ}
       calc p ^ m ≤ 2 * Nat.totient (p ^ m) := prime_pow_le_two_totient hp m
         _ = Nat.totient (p ^ m) * 2 := by ring
         _ ≤ Nat.totient (p ^ m) * (Nat.totient w * 2 ^ (S - 2)) :=
-              mul_le_mul_left' hQ2 (Nat.totient (p ^ m))
+              _root_.mul_le_mul_right hQ2 (Nat.totient (p ^ m))
         _ = Nat.totient (p ^ m) * Nat.totient w * 2 ^ (S - 2) := by ring
     have hpge : p ≤ p ^ (m + 1) := by
       calc p = p ^ 1 := (pow_one p).symm
@@ -3519,7 +3519,7 @@ theorem forward_gap_fiveTimes_ge {m : ℕ} (hm : 3 ≤ m)
   have hple : Nat.totient (14 * m + 3) ≤ 14 * m + 2 := by
     have := Nat.totient_lt (14 * m + 3) (by omega); omega
   rw [hφn, hφD, ← Nat.sub_mul]
-  exact mul_le_mul_right' (by omega) (2 ^ k)
+  exact _root_.mul_le_mul_left (by omega) (2 ^ k)
 
 /-- **The forward margin is unbounded below by `2^(k+2)`.**  A direct corollary of
     `forward_gap_fiveTimes_ge`: since `2m−2 ≥ 4` for `m ≥ 3`, the forward margin

--- a/research/problems/erdos-1064-oq-03/sessions/2026-07-19-r1-v431-reverify-depwarn.md
+++ b/research/problems/erdos-1064-oq-03/sessions/2026-07-19-r1-v431-reverify-depwarn.md
@@ -1,0 +1,60 @@
+# Session 2026-07-19 (researcher-1) — v4.31 re-verify + deprecation cleanup
+
+**Mode**: REVISIT (RICH tier; structural side already COMPLETE/VERIFIED) |
+**Outcome**: maintenance — re-confirmed VERIFIED 0/0 under the new toolchain and
+made the file warning-clean. No new mathematics (the problem is saturated on its
+tractable side; see below).
+
+## Context
+
+`EulerTotientOQ04OQ03.lean` (3746L, 236 KB) resolves the entire tractable content
+of Erdős 1064 OQ-03: all three φ-iterate regimes occur infinitely often, the
+classifier `classifySeed` decides every family `n = a·2^(k+1)`, the excluded
+`seedS ≥ 2` regime is fully closed (no excluded seed reverses), and prime /
+prime-power / composite landing engines certify concrete reversal witnesses
+(21, 57, 165, 561, …). The last real research was §7 (#38564, symbolic-landing
+master form of the prime-triple family). The file was subsequently touched only
+by the mechanical v4.31 migration flip (#39062).
+
+## What I did
+
+1. **Re-verified under v4.31.0** — the file imports only Mathlib
+   (`Data.Nat.Totient`, `Data.Nat.Prime.Basic`, `Tactic`), no `Proofs.*` deps, so
+   it host-verifies via `bin/lake env lean` without Docker. `exit 0` in ~20 s.
+   Confirms the migration flip #39062 did **not** break the verified structural
+   result. 0 sorry / 0 axiom / 0 native_decide (the 3 `native_decide` grep hits
+   are comments explicitly noting none is used).
+
+2. **Cleared all 10 residual v4.31 deprecation warnings** — file is now
+   warning-clean. Re-verified after edits: `exit 0`, zero diagnostics.
+   - `Set.mem_diff` → `Set.mem_sdiff` (L300)
+   - `Set.Infinite.diff` → `Set.Infinite.sdiff` (L305)
+   - `mul_le_mul_left' h c`  → `_root_.mul_le_mul_right h c`  (L2219, L2312) —
+     both give `c*a ≤ c*b` (verified against Mathlib
+     `Order/Monoid/Unbundled/Basic.lean`)
+   - `mul_le_mul_right' h c` → `_root_.mul_le_mul_left h c`   (L2304, L3522) —
+     both give `a*c ≤ b*c`
+   - `push_neg` → `push Not` (4 sites: L916, L937, L943, L2238)
+
+3. **Corrected stale ENV note** in the tracker: the prior "docker-build broken
+   (SIGBUS 135) — verify via host elan v4.26.0" note is obsolete; v4.31 host-verify
+   is clean.
+
+## Frontier (unchanged, honest)
+
+The only genuinely-open direction remains the **density-1 forward statement**
+`φ(n) > φ(D(n))` for almost all `n`, requiring ψ(x,y) smooth-number density /
+Luca–Pomerance analytic input — a real Mathlib gap, not session-sized, not
+Aristotle-suitable. Recorded as a blocked OPEN direction in `knowledge.mathlibGaps`
+(reopen bar: materially new analytic mechanism in Mathlib). Every elementary tier
+(prime / prime-power / composite landings, the excluded regime) is already engined.
+
+## Files modified
+
+- `proofs/Proofs/EulerTotientOQ04OQ03.lean` (10 deprecation-only edits; math unchanged)
+- this session note
+
+Tracker metadata (`src/data/research/problems/erdos-1064-oq-03.json`
+`currentState.blockers`, stale-ENV correction) is handled by the sibling triage
+PR #39158 from an earlier researcher-1 session the same day; this PR stays scoped
+to the Lean file to remain conflict-free with it.


### PR DESCRIPTION
## Summary
Maintenance session on `erdos-1064-oq-03` (Erdős 1064 OQ-03, double totient iterate). The structural side has been COMPLETE/VERIFIED (0 sorry / 0 axiom) for several sessions; the file was subsequently touched only by the mechanical v4.31 migration flip (#39062). This PR re-confirms it under the new toolchain and clears the residual deprecation warnings.

**Scope:** Lean file + session note only. Tracker metadata (`currentState.blockers`, stale-ENV correction) is handled by the sibling triage PR #39158 from an earlier researcher-1 session the same day; this PR is intentionally kept conflict-free with it (disjoint files).

## Progress
- **Re-verified `EulerTotientOQ04OQ03.lean` under v4.31.0** — host `bin/lake env lean`, exit 0, zero diagnostics. Mathlib-only imports (no `Proofs.*`), so it host-verifies without Docker. The migration flip #39062 did **not** break the verified result. Still **0 sorry / 0 axiom / 0 native_decide** (the 3 `native_decide` grep hits are comments explicitly noting none is used).
- **Cleared all 10 residual v4.31 deprecation warnings** — file is now warning-clean; re-verified clean after edits:
  - `Set.mem_diff` → `Set.mem_sdiff`, `Set.Infinite.diff` → `.sdiff`
  - `mul_le_mul_left' h c` → `_root_.mul_le_mul_right h c` (both `c*a ≤ c*b`)
  - `mul_le_mul_right' h c` → `_root_.mul_le_mul_left h c` (both `a*c ≤ b*c`)
  - `push_neg` → `push Not` (4 sites)

## Findings
- No new mathematics: the tractable side of OQ-03 is saturated (all three φ-iterate regimes shown infinitely often; excluded regime fully closed; prime / prime-power / composite landing engines with witnesses 21, 57, 165, 561).
- The only genuinely-open direction remains the **density-1 forward statement** `φ(n) > φ(D(n))` for almost all `n`, requiring ψ(x,y) smooth-number density / Luca–Pomerance analytic machinery — a real Mathlib gap, not session-sized, not Aristotle-suitable.

## Status
**Outcome**: maintenance (re-verified + warning-clean; math unchanged)
**Next Steps**: none session-sized — remaining direction is analytically blocked (Luca–Pomerance).

🤖 Generated by researcher-1