### PR TITLE
Research: puiseux-theorem-wip-01 — re-verify clean under v4.31 + clear 4 warnings

### DIFF
--- a/proofs/Proofs/PuiseuxTheorem.lean
+++ b/proofs/Proofs/PuiseuxTheorem.lean
@@ -351,7 +351,7 @@ section NewtonPuiseux
 
 /-- The Newton polygon slope determines leading exponents for roots.
     For an edge of slope -p/q, roots have leading exponent p/q. -/
-def leadingExponentFromSlope (p q : ℕ) (hq : 0 < q) : ℚ := p / q
+def leadingExponentFromSlope (p q : ℕ) (_hq : 0 < q) : ℚ := p / q
 
 /-- **Ramification: every monomial `x` has fractional roots as a Puiseux series.**
 
@@ -378,7 +378,7 @@ theorem puiseux_nth_root_of_monomial {K : Type*} [Field K] (n : ℕ+) :
   · rw [HahnSeries.single_pow]
     have hn : (n : ℚ) ≠ 0 := by exact_mod_cast n.ne_zero
     congr 1
-    · rw [nsmul_eq_mul]; push_cast; field_simp
+    · rw [nsmul_eq_mul]; field_simp
     · rw [one_pow]
 
 /- The Newton-Puiseux algorithm terminates and produces valid roots.
@@ -703,7 +703,7 @@ theorem isPuiseux_mul {K : Type*} [NonUnitalNonAssocSemiring K] {f g : HahnSerie
   have hn0 : ((n : ℕ) : ℚ) ≠ 0 := by exact_mod_cast n.pos.ne'
   have hm0 : ((m : ℕ) : ℚ) ≠ 0 := by exact_mod_cast m.pos.ne'
   refine ⟨n * m, fun q hq => ?_⟩
-  obtain ⟨a, ha, b, hb, hab⟩ := Set.mem_add.mp (HahnSeries.support_mul_subset_add_support hq)
+  obtain ⟨a, ha, b, hb, hab⟩ := Set.mem_add.mp (HahnSeries.support_mul_subset hq)
   obtain ⟨k, hk⟩ := hn a ha
   obtain ⟨l, hl⟩ := hm b hb
   refine ⟨k * (m : ℤ) + l * (n : ℤ), ?_⟩
@@ -1032,7 +1032,7 @@ theorem isPuiseuxOfRamification_mul {K : Type*} [NonUnitalNonAssocSemiring K] {n
     {f g : HahnSeries ℚ K} (hf : IsPuiseuxOfRamification n f)
     (hg : IsPuiseuxOfRamification n g) : IsPuiseuxOfRamification n (f * g) := by
   intro q hq
-  obtain ⟨a, ha, b, hb, hab⟩ := Set.mem_add.mp (HahnSeries.support_mul_subset_add_support hq)
+  obtain ⟨a, ha, b, hb, hab⟩ := Set.mem_add.mp (HahnSeries.support_mul_subset hq)
   obtain ⟨k, hk⟩ := hf a ha
   obtain ⟨l, hl⟩ := hg b hb
   refine ⟨k + l, ?_⟩

--- a/research/problems/puiseux-theorem-wip-01/sessions/2026-07-19-r1-v431-reverify-depwarn.md
+++ b/research/problems/puiseux-theorem-wip-01/sessions/2026-07-19-r1-v431-reverify-depwarn.md
@@ -1,0 +1,53 @@
+# Session 2026-07-19 (researcher-1) — v4.31 re-verify + warning cleanup
+
+**Mode**: REVISIT (RICH tier; elementary side already COMPLETE) |
+**Outcome**: maintenance — re-confirmed the verified fragment under the new
+toolchain and made `PuiseuxTheorem.lean` warning-clean. No new mathematics
+(the problem is a saturated terminus; see Frontier).
+
+## Context
+
+`PuiseuxTheorem.lean` (1648L, 99 KB) is 0 sorry / 0 axiom. Across Parts I–XVI it
+establishes: the verified Puiseux fragment, the binomial ramification
+biconditional (`Yⁿ − xᵐ` unramified ⟺ `n ∣ m`), the subring/subalgebra/subfield
+edifice (proper — Part XV), the value-group lattice tower (inf↦gcd via
+`ramificationValueSubgroup_gcd_bezout`, sup↦lcm via `ramificationValueSubgroup_sup`,
+`directed_*`, `iSup_*`), and `orderTop` as a Mathlib `AddValuation` (Part XVI).
+Companion OQ files: OQ01/OQ02 are 0/0; OQ03 has 1 sorry (a **separate** problem,
+`puiseux-theorem-oq-03`, not touched here). The main file was last modified only
+by the mechanical v4.31 migration flip (#39062).
+
+## What I did
+
+1. **Re-verified under v4.31.0** — Mathlib-only imports (HahnSeries, PowerSeries,
+   IsAlgClosed, Tactic), no `Proofs.*` deps, so it host-verifies via
+   `bin/lake env lean`. `exit 0`. The migration flip #39062 did **not** break the
+   verified result. Still 0 sorry / 0 axiom.
+
+2. **Cleared all 4 residual v4.31 warnings** — file now warning-clean; re-verified
+   after edits (`exit 0`, zero diagnostics):
+   - `HahnSeries.support_mul_subset_add_support` → `HahnSeries.support_mul_subset`
+     (L706, L1035) — exact Mathlib alias (`alias … := support_mul_subset`).
+   - removed no-op `push_cast` (L381; linter: "tactic does nothing").
+   - unused def binder `hq` → `_hq` (L354, `leadingExponentFromSlope`, which has
+     no callers).
+
+3. **Corrected stale nextStep**: the "possible next increment — value-group
+   directedness lattice statement" is already DONE (`ramificationValueSubgroup_sup`,
+   `_gcd_bezout`, `directed_ramificationValueSubgroup`, all verified). Reset the
+   tracker `nextSteps` to the single real blocked direction.
+
+## Frontier (unchanged, honest)
+
+The only genuinely-open direction is **full Newton–Puiseux for arbitrary
+polynomials** (Newton polygon + char-0 convergence ⇒ `IsAlgClosed (PuiseuxField K)`)
+— >1000L of machinery absent from Mathlib; not session-sized, not Aristotle-suitable.
+Every elementary/structural layer is complete and verified. Marked the problem a
+saturated terminus (`completed`) with the blocked direction recorded (reopen bar:
+Mathlib gains Newton-polygon / Puiseux-convergence infrastructure).
+
+## Files modified
+
+- `proofs/Proofs/PuiseuxTheorem.lean` (4 warning-only edits; math unchanged)
+- `src/data/research/problems/puiseux-theorem-wip-01.json`
+- this session note

--- a/src/data/research/problems/puiseux-theorem-wip-01.json
+++ b/src/data/research/problems/puiseux-theorem-wip-01.json
@@ -44,7 +44,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETE (verified fragment) + ramification criterion (researcher-5 2026-07-12): sharpened the binomial ramification result to a biconditional — root x^{m/n} of Yⁿ−xᵐ is unramified (in Laurent base K⸨x⸩) ⟺ n∣m, plus the ℚ-arithmetic core ynMinusXm_exponent_isInt_iff and the first in-range (unramified) worked example Y²−x⁴. 3 new theorems, 0 domain axioms. Full Newton–Puiseux (arbitrary polynomials + char-0 convergence) remains the genuine open remainder (>1000L).",
+    "progressSummary": "SATURATED TERMINUS (elementary/structural side COMPLETE): PuiseuxTheorem.lean = 1648L, 0 sorry / 0 axiom, RE-VERIFIED clean under v4.31.0 (host, exit 0) and warning-clean (2026-07-19). Verified fragment + ramification biconditional + subring/subalgebra/subfield edifice (proper, Part XV) + value-group lattice tower (inf to gcd / sup to lcm, directed, iSup) + orderTop AddValuation (Part XVI). Sole remaining open direction: full Newton–Puiseux for arbitrary polynomials (Newton polygon + char-0 convergence, >1000L, machinery absent from Mathlib) — not session-sized.",
     "builtItems": [
       "puiseux_binomial_isRoot in proofs/Proofs/PuiseuxTheorem.lean (binomial Puiseux root as Polynomial.IsRoot of Xⁿ-C(single m c); verified, 0 substantive axioms)",
       "puiseuxSubalgebra (K:CommRing): the Puiseux series form a K-subalgebra of HahnSeries Q K, upgrading the Subring; algebraMap_mem via isPuiseux_algebraMap (algebraMap = C = single 0) [VERIFIED]",
@@ -68,12 +68,13 @@
       "STRUCTURE (researcher-5, 2026-07-11): the level-n value group, previously only a raw Set (WithTop ℚ) of attained orderTop values, is literally the cyclic AddSubgroup.zmultiples ((n:ℚ)⁻¹) of ℚ. mem via AddSubgroup.mem_zmultiples_iff + zsmul_eq_mul (k • n⁻¹ = k/n); mono reuses the k/n=(k·d)/n' cast juggling (push_cast + div_eq_div_iff) from IsPuiseuxOfRamification.mono; iSup=⊤ realizes each q at level q.den via Rat.num_div_den. Gives the AddSubgroup-tower analogue of the subring tower iSup_puiseuxRamificationSubring.",
       "Session 2026-07-12 (researcher-8): the value-subgroup side had mono/directed/iSup but only a ONE-DIRECTIONAL inclusion. Added the order-embedding characterization ramificationValueSubgroup_le_iff ((1/n)ℤ ≤ (1/n′)ℤ ↔ n∣n′, converse of mono) + ramificationValueSubgroup_injective (distinct levels ⟹ distinct subgroups). So n↦(1/n)ℤ is an order embedding of (ℕ⁺,∣) into AddSubgroup ℚ and the iSup=⊤ filtration is faithful. 0-axiom, docker-verified [3070]. Forward proof: generator 1/n∈level n′ ⟹ 1/n=k/n′ ⟹ n′=k·n ⟹ n∣n′ (div_eq_div_iff + linear_combination + PNat.dvd_iff).",
       "The binomial root x^{m/n} of Yⁿ−xᵐ is unramified (integer valuation, lies in K⸨x⸩) exactly when n∣m, i.e. reduced ramification index n/gcd(n,m)=1. Prior file had only the one-directional not-isInt⟹ramified; the biconditional pins the exact ramification criterion.",
-      "OQ-01 (Artin–Schreier obstruction, gallery entry puiseux-theorem-oq-01): the obstruction is now NON-VACUOUS. artinSchreierExp_range_isPWO proves the exponent set {−1/p^{k+1}} is IsPWO (strictly monotone image of ℕ via Set.isPWO_of_wellQuasiOrderedLE + image_of_monotone), so artinSchreierSeries builds an explicit HahnSeries over any field with that support, and exists_hahnSeries_not_puiseux realises the obstruction by a genuine Hahn-field element."
+      "OQ-01 (Artin–Schreier obstruction, gallery entry puiseux-theorem-oq-01): the obstruction is now NON-VACUOUS. artinSchreierExp_range_isPWO proves the exponent set {−1/p^{k+1}} is IsPWO (strictly monotone image of ℕ via Set.isPWO_of_wellQuasiOrderedLE + image_of_monotone), so artinSchreierSeries builds an explicit HahnSeries over any field with that support, and exists_hahnSeries_not_puiseux realises the obstruction by a genuine Hahn-field element.",
+      "Session 2026-07-19 (researcher-1): PuiseuxTheorem.lean re-verifies clean under v4.31.0 (host bin/lake env lean, exit 0) — migration flip #39062 did NOT break it. Still 0 sorry / 0 axiom. Cleared all 4 residual warnings (HahnSeries.support_mul_subset_add_support to support_mul_subset x2, no-op push_cast removed, unused binder hq to _hq); file now warning-clean. Confirmed the prior nextStep 'directedness lattice increment P n ⊔ P m ⊆ P of n·m' is STALE — already done: ramificationValueSubgroup_sup (sup to lcm), _gcd_bezout (inf to gcd), directed_ramificationValueSubgroup, directed_puiseuxRamificationSubfield etc. all present and verified."
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "Value-group side of the colimit is now COMPLETE (mono + union, Part XIV). Remaining genuine open: full Newton–Puiseux for arbitrary polynomials (Newton polygon + char-0 convergence, >1000L, not in Mathlib) — the documented open remainder.",
-      "Possible next increment: directedness of the value-group tower as an explicit lattice/order statement (P n ⊔ P m ⊆ P (n*m)), mirroring exists_common_ramification at the valuation level."
+      "BLOCKED (sole open direction): full Newton–Puiseux for arbitrary polynomials — Newton polygon + char-0 convergence giving IsAlgClosed (PuiseuxField K). >1000L of machinery absent from Mathlib; not session-sized, not Aristotle-suitable. Reopen bar: Mathlib gains Newton-polygon / Puiseux-convergence infrastructure.",
+      "NOTE: the earlier nextStep suggesting the value-group lattice directedness increment is STALE — that work is DONE (ramificationValueSubgroup_sup / _gcd_bezout / directed_ramificationValueSubgroup, verified)."
     ],
     "markdown": "# Knowledge Base: puiseux-theorem-wip-01\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },
@@ -95,7 +96,7 @@
     "mathlib": []
   },
   "started": "2026-04-21T16:44:08+02:00",
-  "lastUpdate": "2026-07-12",
+  "lastUpdate": "2026-07-19",
   "leanFiles": [
     {
       "path": "Proofs/PuiseuxTheorem.lean",


### PR DESCRIPTION
## Summary
Maintenance session on `puiseux-theorem-wip-01`. The elementary/structural side of the Puiseux formalization has been COMPLETE/VERIFIED (0 sorry / 0 axiom) across Parts I–XVI; the main file was subsequently touched only by the mechanical v4.31 migration flip (#39062). This PR re-confirms it under the new toolchain and clears the residual warnings.

## Progress
- **Re-verified `PuiseuxTheorem.lean` under v4.31.0** — host `bin/lake env lean`, exit 0. Mathlib-only imports (no `Proofs.*`), so no Docker needed. The migration flip #39062 did **not** break the verified result. Still **0 sorry / 0 axiom**.
- **Cleared all 4 residual v4.31 warnings** (file now warning-clean; re-verified clean after edits):
  - `HahnSeries.support_mul_subset_add_support` → `HahnSeries.support_mul_subset` (×2; exact Mathlib alias)
  - removed no-op `push_cast` (linter: "tactic does nothing")
  - unused def binder `hq` → `_hq` (`leadingExponentFromSlope`, no callers)
- **Tracker**: recorded the re-verification and reset a stale `nextStep` — the "value-group lattice directedness increment" it suggested is already DONE (`ramificationValueSubgroup_sup` = sup↦lcm, `_gcd_bezout` = inf↦gcd, `directed_ramificationValueSubgroup`, all verified).

## Findings
- No new mathematics: the elementary/structural side is a saturated terminus (verified fragment, ramification biconditional, proper subfield edifice, value-group lattice tower, `orderTop` AddValuation).
- The only genuinely-open direction is **full Newton–Puiseux for arbitrary polynomials** (Newton polygon + char-0 convergence ⇒ `IsAlgClosed (PuiseuxField K)`) — >1000L of machinery absent from Mathlib; not session-sized, not Aristotle-suitable.

## Status
**Outcome**: maintenance (re-verified + warning-clean; math unchanged); problem marked a saturated terminus (`completed`) with the blocked direction recorded.
**Next Steps**: none session-sized.

🤖 Generated by researcher-1