### PR TITLE
Research: shannon-channel-coding-awgn-oq-03-oq-01 — re-verify clean under v4.31 + clear 3 deprecations

### DIFF
--- a/proofs/Proofs/ShannonChannelCodingAWGNOQ03OQ01.lean
+++ b/proofs/Proofs/ShannonChannelCodingAWGNOQ03OQ01.lean
@@ -308,7 +308,7 @@ theorem waterAlloc_rate_closedForm
 theorem continuous_waterBudget (N : ι → ℝ) :
     Continuous (waterBudget N) := by
   unfold waterBudget waterAlloc
-  exact continuous_finset_sum _ fun i _ =>
+  exact continuous_finsetSum _ fun i _ =>
     (continuous_id.sub continuous_const).max continuous_const
 
 /-- The budget function is monotone in the water level. -/
@@ -365,7 +365,7 @@ theorem waterBudget_strictMono_of_pos (N : ι → ℝ) {a b : ℝ}
   -- some channel is active at level a
   have hact : ∃ i, 0 < waterAlloc a N i := by
     by_contra hcon
-    push_neg at hcon
+    push Not at hcon
     have hle : waterBudget N a ≤ 0 := by
       unfold waterBudget
       exact Finset.sum_nonpos fun i _ => hcon i
@@ -411,7 +411,7 @@ theorem waterLevel_unique (N : ι → ℝ) {P : ℝ} (hP : 0 < P)
 theorem waterLevel_pos (N : ι → ℝ) (hN : ∀ i, 0 < N i) {P : ℝ} (hP : 0 < P)
     {μ : ℝ} (hμ : waterBudget N μ = P) : 0 < μ := by
   by_contra hcon
-  push_neg at hcon
+  push Not at hcon
   have hmono := monotone_waterBudget N hcon
   rw [waterBudget_zero N hN, hμ] at hmono
   linarith

--- a/research/problems/shannon-channel-coding-awgn-oq-03-oq-01/sessions/2026-07-19-r1-v431-reverify-depwarn.md
+++ b/research/problems/shannon-channel-coding-awgn-oq-03-oq-01/sessions/2026-07-19-r1-v431-reverify-depwarn.md
@@ -1,0 +1,40 @@
+# Session 2026-07-19 (researcher-1) — v4.31 re-verify + deprecation cleanup
+
+**Mode**: REVISIT (RICH tier; equal-noise wideband limit already COMPLETE) |
+**Outcome**: maintenance — re-confirmed the verified result under v4.31 and
+cleared the residual deprecation warnings. No new mathematics (saturated terminus).
+
+## Context
+
+`ShannonChannelCodingAWGNOQ03OQ01.lean` (454L, Mathlib-only imports) plus its
+sub-files (Concave / EqualNoise / Monotone / MonotoneCount / Supremum / Greatest)
+are all 0 sorry / 0 axiom. The main least-upper-bound result
+`rate_equalNoise_iSup_eq_wideband` proves the infinite-bandwidth AWGN capacity
+`P/(2c)` is the exact `iSup` of the finite equal-noise rates. The main file was
+last touched only by the mechanical v4.31 migration flip (#39062).
+
+## What I did
+
+1. **Re-verified under v4.31.0** — host `bin/lake env lean`, exit 0. The migration
+   flip #39062 did **not** break it. Still 0 sorry / 0 axiom (every `sorry` grep hit
+   is a "sorry-free" docstring).
+2. **Cleared 3 v4.31 deprecations** (re-verified clean after edits):
+   - `continuous_finset_sum` → `continuous_finsetSum` (L311; exact Mathlib alias)
+   - `push_neg at hcon` → `push Not at hcon` (L368, L414)
+   - Left 4 benign "automatically included section variable unused" linter warnings
+     (not deprecations; fixing them would require `omit`/scoping edits that risk the
+     proofs — not worth it for style noise).
+
+## Frontier (unchanged, honest)
+
+The tractable equal-noise wideband **scalar** limit is a saturated terminus. The
+remaining open directions are NOT session-sized:
+- connect to an operational coding theorem (random Gaussian codebooks; parent `oq-04`);
+- a genuine continuous infinite-band (integral-over-frequency) capacity beyond the
+  equal-noise scalar limit.
+
+## Files modified
+
+- `proofs/Proofs/ShannonChannelCodingAWGNOQ03OQ01.lean` (3 deprecation-only edits; math unchanged)
+- `src/data/research/problems/shannon-channel-coding-awgn-oq-03-oq-01.json`
+- this session note


### PR DESCRIPTION
## Summary
Maintenance session on `shannon-channel-coding-awgn-oq-03-oq-01`. The equal-noise wideband scalar limit has been COMPLETE/VERIFIED (0 sorry / 0 axiom); the main file was subsequently touched only by the mechanical v4.31 migration flip (#39062). This PR re-confirms it under the new toolchain and clears residual deprecations.

## Progress
- **Re-verified `ShannonChannelCodingAWGNOQ03OQ01.lean` under v4.31.0** — host `bin/lake env lean`, exit 0. Mathlib-only imports (no `Proofs.*`). The migration flip #39062 did **not** break it. Still **0 sorry / 0 axiom** (every `sorry` grep hit is a "sorry-free" docstring).
- **Cleared 3 v4.31 deprecations** (re-verified clean after edits):
  - `continuous_finset_sum` → `continuous_finsetSum` (exact Mathlib alias)
  - `push_neg at hcon` → `push Not at hcon` (×2)
  - Left 4 benign "unused section variable" linter warnings (not deprecations; fixing them would risk restructuring the proofs).

## Findings
- No new mathematics: the tractable equal-noise wideband scalar limit is a saturated terminus. `rate_equalNoise_iSup_eq_wideband` proves the infinite-bandwidth AWGN capacity `P/(2c)` is the exact `iSup` of finite equal-noise rates; the Monotone/Concave/EqualNoise/Supremum sub-files are all present and verified.
- Remaining open directions (NOT session-sized): connect to an operational coding theorem (random Gaussian codebooks, parent `oq-04`); a genuine continuous infinite-band integral-over-frequency capacity.

## Status
**Outcome**: maintenance (re-verified + deprecations cleared; math unchanged); saturated terminus.
**Next Steps**: none session-sized.

🤖 Generated by researcher-1