### PR TITLE
audit: erdos-872 — drop 5 phantom declarations, correct 'axiomatized bounds' prose

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -17052,9 +17052,9 @@
     },
     "erdos-872": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T00:18:38Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-07-20T01:46:53Z",
+      "result": "issues-fixed"
     },
     "erdos-873": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Integrity Issue

**Proof**: erdos-872 (Antichain Saturation Game)
**Problem**: meta.json prose overstated contributions — 5 phantom declarations + false "axiomatized bounds" claim. All numeric counts and the badge/status were already correct.

## Evidence

Actual declarations in `proofs/Proofs/Erdos872Problem.lean` (verified by grep):
- **8 defs**: IsDivisibilityAntichain, IsPrimitiveSet, gameBoard, IsLegalMove, IsMaximalAntichain, gameLastsLinear, gameLastsNearOptimal, firstPlayerAdvantage
- **5 theorems**: antichain_iff_primitive, legal_move_iff, primes_antichain, upper_half_antichain, erdos_872_summary
- **2 axioms**: gameValue, gameValue_upper
- 0 sorries, no native_decide, 301 lines

**Phantom `originalContributions` (do not exist — prose comments only):**
`gameBoard_card`, `game_terminates`, `maximal_antichain_upper_bound`, `prime_antichain_bound`, `erdos_872_conjecture`.

**Prose overstatements:**
- `proofStrategy`/`conclusion`: "bounds are axiomatized" — the antichain size bounds (n/2 upper, prime lower) are only in comments; the only axioms are gameValue/gameValue_upper.
- `proofStrategy`: cited a nonexistent "positivity" axiom on gameValue.
- Section summaries (game-board, game-state, game-theory) named three phantom decls.

## Fix

- Removed 5 phantom entries from `originalContributions`.
- Corrected `proofStrategy` and `conclusion.summary` to state bounds/termination are documented informally in comments, and that the two real axioms are gameValue and gameValue_upper.
- Cleaned the three section summaries/mathContexts.
- Counts (axiomCount=2, theoremCount=5, definitionCount=8, sorries=0, lineCount=301) and badge/status (axiom/axiomatized) unchanged — they were accurate.

---
Discovered during gallery integrity audit (reserve-mode re-serve of erdos-872).