### PR TITLE
audit: erdos-782 — drop phantom erdos_782_status from section summary

### DIFF
--- a/src/data/proofs/erdos-782/meta.json
+++ b/src/data/proofs/erdos-782/meta.json
@@ -158,10 +158,10 @@
     {
       "id": "status",
       "title": "Problem Status",
-      "summary": "erdos_782_status, erdos_782_question1, erdos_782_question2",
+      "summary": "erdos_782_question1, erdos_782_question2",
       "startLine": 273,
       "endLine": 328,
-      "mathContext": "Mathematical content: erdos_782_status, erdos_782_question1, erdos_782_question2"
+      "mathContext": "Mathematical content: erdos_782_question1, erdos_782_question2"
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Integrity Fix

**Proof**: erdos-782 (Quasi-Progressions and Cubes in the Squares)
**Problem**: The `status` section summary and `mathContext` listed a phantom declaration `erdos_782_status` that does not exist in the Lean source.

## Evidence

- `meta.json` `sections[status].summary`: `"erdos_782_status, erdos_782_question1, erdos_782_question2"`
- `proofs/Proofs/Erdos782Problem.lean` contains only `erdos_782_question1` (L285) and `erdos_782_question2` (L289). `grep erdos_782_status` → not found.

## Fix

Dropped `erdos_782_status` from the section `summary` and `mathContext`.

## Rest of entry verified clean

- **axiomCount 3** matches: `no_4AP_in_squares`, `question1_implies_question2`, `cilleruelo_granville`.
- **sorries 0** matches (no `sorry`, no `native_decide`).
- **theoremCount 10 / definitionCount 17** match actual decls.
- `BombieriLangConjecture` is `opaque ... := True`, correctly excluded from the axiom count and noted in `assumptions`.
- `originalContributions` entries all map to real declarations (no phantoms).
- Badge `axiom` / status `axiomatized` (Tier C) appropriate; title/description do not overstate.

---
Discovered during gallery integrity audit (reserve-mode prose re-verification).