### PR TITLE
Research: erdos-214-incomplete-01 — v4.31 re-verify clean + close saturated distance-spectrum thread

### DIFF
--- a/research/problems/erdos-214-incomplete-01/state.md
+++ b/research/problems/erdos-214-incomplete-01/state.md
@@ -67,3 +67,25 @@ Mathlib — confirmed again). Added 3 verified axiom-free theorems answering the
 `scaledLattice_infinite`), and `no_maximum_unitDistanceFree_card` (hence no finite
 cap). File 382→414 lines, theoremCount 20→23, 0 sorries, axiomCount unchanged (1).
 docker-build VERIFIED (2364 jobs, exit 0, Lean v4.26.0).
+
+## Session 2026-07-19 (researcher-1) — v4.31 re-verify + thread-close triage
+
+No new theorems (none session-sized remain). Triage + re-verification session:
+
+- **v4.31 re-verify (host, `lake env lean`, EXIT 0, zero deprecations)**: both
+  `Erdos214Incomplete01OQ01.lean` (901 lines, 0 sorries / 0 axioms) and
+  `Erdos214Problem.lean` (1 documented axiom `juhasz_stronger`, 0 sorries) compile
+  clean under `leanprover/lean4:v4.31.0`. Both last touched under v4.26 (#38407),
+  pre-flip #39062 — confirmed no v4.31 repair needed.
+- **Distance-spectrum thread CLOSED (saturated)**: the all-`n` master
+  characterization `scaledLattice_realizes_sqrt_iff` (landed #38407) subsumes every
+  earlier avoidance lemma (√6/√12/√24/√56, mod-4/8/16, odd-prime obstructions) and
+  the √(2p)/√(2pq) realizability results. The "remaining open" notes in the prior
+  tracker (full sum-of-two-squares characterization; √(2pq) products) were written
+  *before* #38407 and are now done. No session-sized frontier remains here.
+- **Core still BLOCKED**: `juhasz_stronger` (Juhász 1979 4-point congruent-copy
+  incidence geometry) is not in Mathlib; `HoldsFor5Points` is the equivalent-strength
+  5-point analog. Registered as a structured `currentState.blockers` entry
+  (reopen bar: materially new mechanism / Mathlib gains the incidence theorem).
+- **Pool status → `blocked`** to stop wasteful depth-first re-serving of a saturated
+  problem.

--- a/src/data/research/problems/erdos-214-incomplete-01.json
+++ b/src/data/research/problems/erdos-214-incomplete-01.json
@@ -24,8 +24,14 @@
     "since": "2026-04-03T08:28:28Z",
     "iteration": 2,
     "focus": "S+1 ACT (researcher-2, 2026-07-11): closed the realizability converse for the prime family √(2p) of the √2·ℤ² distance spectrum. The file's avoidance results were all one-directional; Fermat's two-square theorem (Nat.Prime.sq_add_sq) supplies the missing converse, yielding the sharp iff √(2p) realized ⇔ p≢3 mod4, plus Brahmagupta multiplicative closure of the realizable half-values. Erdos214Incomplete01OQ01.lean 665→757 lines, theoremCount 33→38, still 0 axioms/0 sorries. Core juhasz_stronger still BLOCKED (separate file/axiom).",
-    "blockers": [],
-    "nextAction": "Distance-spectrum thread near-complete: prime family now sharp both directions. Remaining: full sum-of-two-squares characterization of ALL realizable √n (needs Nat.eq_sq_add_sq_iff factorization arithmetic — moderate), or realizability of √(2·p·q) products. Core Juhász theorem still needs juhasz_stronger (not session-sized / not in Mathlib).",
+    "blockers": [
+      {
+        "route": "core Erdős #214 (unit-square-from-unit-distance) and its 5-point analog HoldsFor5Points",
+        "reopenCriterion": "materially new mechanism required — needs Juhász 1979 4-point congruent-copy incidence-geometry theorem (axiom juhasz_stronger); not in Mathlib, confirmed non-session-sized by 3 prior sessions",
+        "blockedAt": "2026-07-19"
+      }
+    ],
+    "nextAction": "No further session-sized work: distance-spectrum characterization is complete and core is deep-blocked on juhasz_stronger. Pool status set to blocked to stop wasteful depth-first re-serving. Reopen only if Mathlib gains the Juhász 4-point incidence theorem or a materially new mechanism for HoldsFor5Points appears.",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -33,7 +39,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: companion OQ01 file COMPLETE — full Fermat characterization of √2·ℤ² realizable distances proved axiom-free; core #214 remains BLOCKED on juhasz_stronger",
+    "progressSummary": "BLOCKED/SATURATED: companion distance-spectrum thread COMPLETE (all-n master characterization scaledLattice_realizes_sqrt_iff, #38407, axiom-free); both files re-verify clean under v4.31. Core #214 BLOCKED on juhasz_stronger (Juhász 1979, not in Mathlib). No session-sized frontier remains.",
     "builtItems": [
       "Erdos214Problem.lean: dist_coords (coordinate distance formula), isUnitSquare_standard (the standard unit square is a unit square), unit_square_from_stronger (sorry eliminated, 0-axiom reduction)",
       "Fixed Mathlib-4.26 build break: UnitDistanceGraph tuple set-builder → setOf on Prod",
@@ -56,7 +62,9 @@
       "The realizable distances of √2·ℤ² are exactly √n with n=2·(sum of two squares) — i.e. dist²=2·(u²+v²). This makes the whole 'distance spectrum' a sum-of-two-squares question. For a PRIME p the family √(2p) is now sharp: realized ⇔ p≢3 mod4 (Fermat). Forward (avoidance) is the u²+v²≢3 mod4 residue obstruction; converse is Fermat's Nat.Prime.sq_add_sq. Note every 2p with p≡3 mod4 is ≡6 mod8, so the avoidance overlaps scaledLattice_dist_ne_sqrt_six_mod_eight — but the realizability converse is genuinely new.",
       "Brahmagupta–Fibonacci identity (a²+b²)(c²+d²)=(ac−bd)²+(ad+bc)² proved by pure `ring` after push_cast — realizes √(2·(a²+b²)(c²+d²)) at latticePoint (ac−bd) (ad+bc). Exhibits the realizable squared-half distances as the multiplicative monoid of Gaussian-integer norms, the structural reason primes ≡3 mod4 govern the avoidance families.",
       "VERIFICATION WORKAROUND for `import Mathlib` files when fleet codegen SIGBUS-135s: `docker run … lake env lean <file>.lean` (plain `lean`, no -o/-c) elaborates + runs `#print axioms` WITHOUT triggering the crashing C-codegen/olean-write phase. A type error would print `error: <file>:<line>` and exit 1 BEFORE any crash; exit 135 = SIGBUS = infra, post-elaboration. Confirms both type-correctness and axiom set.",
-      "CAPSTONE: scaledLattice_realizes_sqrt_two_mul_iff_factorization — √(2m) is a lattice distance IFF every prime r≡3 mod4 divides m to an even power (Nat.eq_sq_add_sq_iff). Complete Fermat characterization of the realizable distance set; subsumes ALL prior avoidance families (mod-4/8/16, r=3, r=7, general r≡3 mod4) and realizability results as special cases."
+      "CAPSTONE: scaledLattice_realizes_sqrt_two_mul_iff_factorization — √(2m) is a lattice distance IFF every prime r≡3 mod4 divides m to an even power (Nat.eq_sq_add_sq_iff). Complete Fermat characterization of the realizable distance set; subsumes ALL prior avoidance families (mod-4/8/16, r=3, r=7, general r≡3 mod4) and realizability results as special cases.",
+      "v4.31 RE-VERIFY (2026-07-19): both Erdos214Incomplete01OQ01.lean (901 lines, 0 sorries/0 axioms) and Erdos214Problem.lean (1 documented axiom juhasz_stronger, 0 sorries) host-verify CLEAN under leanprover/lean4:v4.31.0 (lake env lean, EXIT 0, zero deprecation warnings). Files last touched under v4.26 (#38407) pre-flip #39062; no repair needed.",
+      "THREAD CLOSED: the distance-spectrum sub-problem of #214-incomplete-01 is saturated. The all-n master characterization scaledLattice_realizes_sqrt_iff (√n a √2·ℤ² distance ⇔ n even ∧ n/2 a sum of two squares) landed in #38407 and subsumes every earlier ad-hoc avoidance lemma (√6/√12/√24/√56, mod-4/8/16 and odd-prime obstructions) plus the √(2p)/√(2pq) realizability results. No session-sized open frontier remains on this thread."
     ],
     "mathlibGaps": [],
     "nextSteps": [


### PR DESCRIPTION
## Summary
Triage + toolchain re-verification session for `erdos-214-incomplete-01`. No new
theorems — the developable frontier is exhausted. This PR records the honest state
so the Seeker stops re-serving a saturated problem.

## Progress
- **v4.31 re-verify (host, `lake env lean`, EXIT 0, zero deprecation warnings):**
  - `Erdos214Incomplete01OQ01.lean` — 901 lines, **0 sorries / 0 axioms**
  - `Erdos214Problem.lean` — 1 documented axiom (`juhasz_stronger`), 0 sorries
  - Both last touched under v4.26 (#38407), pre-flip #39062 → **no repair needed**.
- Registered a structured `currentState.blockers` entry for the core.
- Files touched: `src/data/research/problems/erdos-214-incomplete-01.json`,
  `research/problems/erdos-214-incomplete-01/state.md`. **No `.lean` changes.**

## Findings
- The **distance-spectrum thread is saturated.** The all-`n` master characterization
  `scaledLattice_realizes_sqrt_iff` (√n is a √2·ℤ² distance ⇔ n even ∧ n/2 a sum of
  two squares) landed in #38407 and subsumes every earlier ad-hoc avoidance lemma
  (√6/√12/√24/√56, mod-4/8/16, odd-prime obstructions) plus the √(2p)/√(2pq)
  realizability results. The tracker's prior "remaining open" notes (full
  sum-of-two-squares characterization; √(2pq) products) were written *before* #38407
  and are now done.
- The **core Erdős #214 remains blocked** on `juhasz_stronger` (Juhász 1979 4-point
  congruent-copy incidence geometry — not in Mathlib, confirmed non-session-sized by
  3 prior sessions). `HoldsFor5Points` is the equivalent-strength 5-point analog.

## Status
**Outcome**: blocked (core) / saturated (companion thread); pool status set to `blocked`.
**Next Steps**: reopen only if Mathlib gains the Juhász incidence theorem or a
materially new mechanism for `HoldsFor5Points` appears.

🤖 Generated by researcher-1