### PR TITLE
Research: erdos-744-incomplete-01 — flag placeholder f_k(n) stub (axiom is tautological) + v4.31 clean re-verify

### DIFF
--- a/proofs/Proofs/Erdos744Problem.lean
+++ b/proofs/Proofs/Erdos744Problem.lean
@@ -199,7 +199,7 @@ theorem bipartitionNumber_pos_iff {V : Type*} [Fintype V] [LinearOrder V]
   constructor
   · intro h c
     have hc := h c
-    push_neg at hc
+    push Not at hc
     exact hc
   · intro h c hc
     obtain ⟨u, v, hadj, huv⟩ := h c
@@ -292,7 +292,7 @@ theorem monochromaticEdges_add_bichromaticEdges {V : Type*} [Fintype V] [LinearO
           (fun p => ¬ c p.1 = c p.2)).card := by
     rw [bichromaticEdges, Finset.filter_filter]
     congr 1; ext p; simp only [Finset.mem_filter, ne_eq]; tauto
-  rw [hmono, hbi, Finset.filter_card_add_filter_neg_card_eq_card]
+  rw [hmono, hbi, Finset.card_filter_add_card_filter_not]
   rfl
 
 /-- **Max-cut of `G`.** The maximum number of edges separated by a 2-coloring,
@@ -503,7 +503,7 @@ theorem card_colorings_cut {V : Type*} [Fintype V] [LinearOrder V] (u v : V)
   have hpart : (Finset.univ.filter (fun c : V → Bool => c u ≠ c v)).card
       + (Finset.univ.filter (fun c : V → Bool => ¬ c u ≠ c v)).card
       = Fintype.card (V → Bool) := by
-    rw [Finset.filter_card_add_filter_neg_card_eq_card]; rfl
+    rw [Finset.card_filter_add_card_filter_not]; rfl
   have hcard : (Finset.univ.filter (fun c : V → Bool => c u ≠ c v)).card
       = (Finset.univ.filter (fun c : V → Bool => ¬ c u ≠ c v)).card := by
     apply Finset.card_bij'
@@ -834,7 +834,7 @@ theorem monochromaticEdges_add_complement {V : Type*} [Fintype V] [LinearOrder V
     simp only [Finset.mem_filter, Finset.mem_univ, true_and, complement]
     exact ⟨fun ⟨h1, ⟨_, h3⟩, h4⟩ => ⟨⟨h1, h4⟩, h3⟩,
       fun ⟨⟨h1, h4⟩, h3⟩ => ⟨h1, ⟨ne_of_lt h1, h3⟩, h4⟩⟩
-  rw [hbase, hG, hGc, Finset.filter_card_add_filter_neg_card_eq_card]
+  rw [hbase, hG, hGc, Finset.card_filter_add_card_filter_not]
 
 /-- `edgeCount` is the monochromatic count of the constant `true` coloring: every
 edge is monochromatic when all endpoints share a color. -/
@@ -882,9 +882,30 @@ theorem bipartitionNumber_add_bipartitionNumber_complement_le {V : Type*} [Finty
 f_k(n) = min { bipartitionNumber(G) : G is k-critical on n vertices }
 
 This is the central function studied in Erdős Problem #744.
+
+⚠️ **INTEGRITY WARNING — this `f` is a PLACEHOLDER, not a faithful model of f_k(n).**
+The intended `f_k(n)` is a genuine minimisation over all k-critical graphs on `n`
+vertices, and the whole content of #744 is whether that quantity grows with `n`.
+The definition below instead **hardcodes the Rödl–Tuza answer** `(k-1)(k-2)/2`,
+making `f` a constant in `n`. Consequences:
+
+* `rodl_tuza_theorem` (below) is **tautological** under this definition — it is
+  provable by `unfold f` (take `N₀ = 0`), so it carries no real mathematical
+  content. **Do NOT convert it to a `theorem` to claim the file is "verified"** —
+  that would launder a stub into a false 0-axiom claim. The axiom is kept
+  deliberately to flag that the deep Rödl–Tuza result is *assumed*, not formalised.
+* `erdos_conjecture_false` / `erdos_744_statement` are therefore **vacuous** with
+  respect to the real `f_k(n)`: they say nothing about the genuine minimisation.
+
+A faithful formalisation would define `f k n` as
+`sInf { bipartitionNumber G | G : SimpleGraph (Fin n), IsKCritical k G }` (a finite
+min, hence definable) and would then require the actual Rödl–Tuza bound — a deep
+1985 combinatorics result absent from Mathlib — to prove any of the statements
+below. See the problem tracker's `currentState.blockers` for the reopen criterion.
 -/
-noncomputable def f (k n : ℕ) : ℕ :=
-  -- We axiomatize the known values from Rödl-Tuza
+noncomputable def f (k _n : ℕ) : ℕ :=
+  -- PLACEHOLDER: hardcodes the Rödl–Tuza answer (see integrity warning above);
+  -- this is NOT the real min over k-critical graphs. `_n` is intentionally unused.
   if k < 3 then 0
   else if k = 3 then 1  -- Odd cycles: remove 1 edge
   else (k - 1) * (k - 2) / 2  -- Rödl-Tuza result for large n
@@ -902,7 +923,7 @@ For 3-chromatic critical graphs (odd cycles), removing any single edge
 makes the graph bipartite (gives a path). This is because the only
 3-critical graphs are odd cycles.
 -/
-theorem f_3_equals_1 (n : ℕ) (hn : n ≥ 3 ∧ n % 2 = 1) : f 3 n = 1 := by
+theorem f_3_equals_1 (n : ℕ) (_hn : n ≥ 3 ∧ n % 2 = 1) : f 3 n = 1 := by
   unfold f
   simp
 
@@ -961,6 +982,14 @@ tend to infinity — it stabilizes at a binomial coefficient.
 
 The key insight: in large k-critical graphs, the non-bipartiteness
 is concentrated in a small substructure of bounded size.
+
+⚠️ **TAUTOLOGICAL under the current placeholder `f`** (see the integrity warning
+on `def f`): because `f` is hardcoded to `(k-1)(k-2)/2`, this statement is provable
+by `unfold f` with `N₀ = 0` and encodes none of the real Rödl–Tuza content. It is
+kept as an `axiom` — rather than being discharged — precisely to signal that the
+deep 1985 result is *assumed*. Discharging it would falsely present a stubbed
+formalisation as verified. A genuine proof requires the faithful minimisation
+definition of `f` plus the actual Rödl–Tuza theorem.
 -/
 axiom rodl_tuza_theorem (k : ℕ) (hk : k ≥ 3) :
     ∃ N₀ : ℕ, ∀ n ≥ N₀, f k n = (k - 1) * (k - 2) / 2
@@ -1022,7 +1051,7 @@ shows f_k(n) never exceeds this bound.
 -/
 theorem erdos_conjecture_false : ¬erdosOriginalConjecture := by
   unfold erdosOriginalConjecture
-  push_neg
+  push Not
   use 4
   constructor
   · norm_num

--- a/research/problems/erdos-744-incomplete-01/state.md
+++ b/research/problems/erdos-744-incomplete-01/state.md
@@ -31,3 +31,32 @@ action tractable without k-critical-graph infrastructure.
 - Total attempts: 2
 - Current approach attempts: 1
 - Approaches tried: 1
+
+## Session 2026-07-19 (researcher-1) — integrity finding + v4.31 clean re-verify
+
+**Integrity finding (the important part).** The central function `f k n` in
+`Erdos744Problem.lean` is a **placeholder**: it hardcodes the Rödl–Tuza value
+`(k-1)(k-2)/2` and is *constant in `n`*, rather than the intended
+`min { bipartitionNumber G : G k-critical on n vertices }`. Because of this:
+
+- `axiom rodl_tuza_theorem` is **tautological** — provable by `unfold f` with
+  `N₀ = 0`. It carries none of the real 1985 combinatorics content.
+- `erdos_conjecture_false` and `erdos_744_statement` are **vacuous** with respect
+  to the genuine `f_k(n)`.
+
+The file is definitional theater, not a genuine formalization of #744. (The gallery
+`meta.json` already, correctly, labels it `axiomatized` / `badge: axiom`.)
+
+**Action taken (anti-laundering).** Added prominent in-file INTEGRITY WARNINGs on
+`def f` and `axiom rodl_tuza_theorem` explicitly forbidding a future agent from
+discharging the axiom via `unfold f` to claim "0-axiom verified" — that would
+launder a stub into a false verification. Registered the genuine gap as a
+structured `currentState.blockers` entry and corrected the tracker's prior
+"COMPLETE" overclaim.
+
+**v4.31 re-verify + clean** (host, `lake env lean`, EXIT 0, now zero warnings):
+cleared 5 deprecations (2× `push_neg`→`push Not`; 3× `Finset.filter_card_add_filter_neg_card_eq_card`→`Finset.card_filter_add_card_filter_not`) and 2 unused-variable
+lints. File previously built only under v4.26. Axiom/sorry counts unchanged (1 / 0).
+
+**Pool status → `blocked`** (genuine formalization is deep-blocked on the real
+Rödl–Tuza bound, absent from Mathlib).

--- a/src/data/research/problems/erdos-744-incomplete-01.json
+++ b/src/data/research/problems/erdos-744-incomplete-01.json
@@ -1,8 +1,8 @@
 {
   "slug": "erdos-744-incomplete-01",
   "title": "Erdős #744: Critical Graphs — Complete `bipartitionNumber` definition",
-  "phase": "OBSERVE",
-  "status": "completed",
+  "phase": "BLOCKED",
+  "status": "blocked",
   "tier": "C",
   "path": "full",
   "problemStatement": {
@@ -20,8 +20,14 @@
     "since": "2026-04-03T08:17:23-07:00",
     "iteration": 1,
     "focus": "Initial problem understanding. Read problem.md and gather context.",
-    "blockers": [],
-    "nextAction": "Read problem.md thoroughly and acquire full context.",
+    "blockers": [
+      {
+        "route": "genuine formalization of Erdős #744 (faithful f_k(n) + real Rödl–Tuza bound)",
+        "reopenCriterion": "materially new mechanism required — needs (a) redefining f k n = sInf over k-critical graphs on Fin n of bipartitionNumber (definable, ~session-sized) AND (b) the deep Rödl–Tuza 1985 bound, which is not in Mathlib. Only attempt (a)+(b) together; adding (a) alone would turn every downstream theorem into a sorry and regress the file.",
+        "blockedAt": "2026-07-19"
+      }
+    ],
+    "nextAction": "Do NOT discharge rodl_tuza_theorem to claim verification (would launder the stub). Genuine progress requires a faithful minimisation definition of f_k(n) plus the deep Rödl–Tuza bound (not in Mathlib) — see currentState.blockers. Pool set to blocked.",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -29,7 +35,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETE + extended (Part 3e added): complement Gc and complete graph Kn introduced (both absent before); per-coloring partition monochromaticEdges G + Gc = Kn, its edgeCount specialization edgeCount G + Gc = Kn, and both cut-invariant sums bounded by edgeCount Kn. All 0-axiom (tautological Rodl-Tuza axiom untouched). File: 0 sorries, 1 axiom, 47 theorems, 1114 lines.",
+    "progressSummary": "AXIOMATIZED / DEFINITIONAL-THEATER (corrected from prior COMPLETE overclaim): the file compiles 0-sorry with 1 axiom, but `f` is a placeholder that hardcodes the Rödl–Tuza answer, so the axiom is tautological and the disproof vacuous w.r.t. the real f_k(n). Added in-file integrity warnings against laundering. v4.31 re-verified clean (deprecations cleared). Genuine formalization is deep-blocked on the real Rödl–Tuza bound.",
     "builtItems": [
       "monochromaticEdges G c : ℕ — count of same-colored adjacent pairs u<v (Erdos744Problem.lean:99)",
       "bipartitionNumber G := inf over c:V→Bool of monochromaticEdges G c — total, sorry-free, no chromaticNumber axiom (Erdos744Problem.lean:115)",
@@ -53,7 +59,10 @@
       "Both extremal invariants grow with the graph: bipartitionNumber_mono (min-uncut side) and maxCut_mono (max-cut side) are duals, each reducing to per-colouring monotonicity of monochromatic/bichromatic edge counts. This is the formal content of Erdős's original growth intuition for f_k, cleanly separated from the (false) asymptotic-divergence claim.",
       "Single-edge Lipschitz continuity: adding one edge {a,b} raises both bipartitionNumber and maxCut by AT MOST 1 (they land in {v(G), v(G)+1}). This sharpens the earlier monotonicity (which only gave ≥) with a matching +1 upper bound — the exact modulus of continuity for the edge-edit metric. Proof: for a fixed coloring the monochromatic/bichromatic edge set of H is contained in that of G together with the single added ordered pair (a,b), so its card rises by ≤1 (Finset.card_insert_le); transfer through the optimal coloring.",
       "Complement/complete-graph give a genuinely new direction orthogonal to the saturated single-graph max-cut/min-uncut square: G join Gc = Kn at the coloring level partitions monochromatic counts.",
-      "ne_of_lt discharges the p.1 != p.2 conjunct of complement/completeGraph adjacency; tauto cannot derive != from <, so filter-equality steps need explicit iff witnesses."
+      "ne_of_lt discharges the p.1 != p.2 conjunct of complement/completeGraph adjacency; tauto cannot derive != from <, so filter-equality steps need explicit iff witnesses.",
+      "INTEGRITY FINDING (2026-07-19, researcher-1): the central function `f k n` is a PLACEHOLDER — it hardcodes the Rödl–Tuza answer (k-1)(k-2)/2 and is CONSTANT in n, not the intended min over k-critical graphs on n vertices. Consequence: the sole axiom `rodl_tuza_theorem` is TAUTOLOGICAL (provable by `unfold f`, N₀=0), and `erdos_conjecture_false`/`erdos_744_statement` are VACUOUS w.r.t. the real f_k(n). The file is definitional theater, not a genuine formalization of #744. Gallery meta correctly labels it axiomatized/badge:axiom.",
+      "Added prominent in-file INTEGRITY WARNINGs on `def f` and `axiom rodl_tuza_theorem` explicitly forbidding laundering: do NOT discharge the axiom via `unfold f` to claim 0-axiom verification — that would present a stub as verified.",
+      "v4.31 re-verify + clean (host, lake env lean, EXIT 0, now zero warnings): cleared 5 deprecations (2× push_neg→push Not, 3× Finset.filter_card_add_filter_neg_card_eq_card→Finset.card_filter_add_card_filter_not) and 2 unused-variable lints. File last built under v4.26."
     ],
     "mathlibGaps": [],
     "nextSteps": [


### PR DESCRIPTION
## Summary
Integrity + toolchain re-verification session for `erdos-744-incomplete-01`
(`Erdos744Problem.lean`). The headline is an **honesty correction**, not new theorems.

## Integrity finding
The central function `f k n` is a **placeholder**: it hardcodes the Rödl–Tuza answer
`(k-1)(k-2)/2` and is **constant in `n`**, rather than the intended
`min { bipartitionNumber G : G is k-critical on n vertices }`. Consequences:

- `axiom rodl_tuza_theorem` is **tautological** — provable by `unfold f` with `N₀ = 0`;
  it encodes none of the real 1985 combinatorics content.
- `erdos_conjecture_false` / `erdos_744_statement` are **vacuous** with respect to the
  genuine `f_k(n)`.

So the file is definitional theater, not a genuine formalization of #744. The gallery
`meta.json` already (correctly) labels it `axiomatized` / `badge: axiom`, so this PR
does not change the gallery status — it prevents a *future* overclaim.

## Anti-laundering action
Added prominent in-file **INTEGRITY WARNINGs** on `def f` and `axiom rodl_tuza_theorem`
explicitly forbidding a future agent from discharging the axiom via `unfold f` to claim
"0-axiom verified" — that would launder a stub into a false verification. Corrected the
tracker's prior "COMPLETE" overclaim and registered the real gap as a structured
`currentState.blockers` entry.

## v4.31 re-verify + clean
Host-verified (`lake env lean`, EXIT 0, **now zero warnings**). Cleared 5 deprecations
(2× `push_neg`→`push Not`; 3× `Finset.filter_card_add_filter_neg_card_eq_card`
→`Finset.card_filter_add_card_filter_not`) and 2 unused-variable lints. File previously
built only under v4.26. **Axiom/sorry counts unchanged (1 / 0)** — comment/docstring +
deprecation edits only.

## Status
**Outcome**: blocked (genuine formalization needs a faithful `f_k(n)` minimisation
definition + the deep Rödl–Tuza bound, not in Mathlib). Pool status set to `blocked`.

🤖 Generated by researcher-1