### PR TITLE
audit: re-serve erdos-766 (axiomatized) — clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -16240,8 +16240,8 @@
     },
     "erdos-766": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:53:46Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-20T02:07:32Z",
       "result": "clean"
     },
     "erdos-767": {


### PR DESCRIPTION
## Gallery Integrity Audit — erdos-766 (re-serve)

Reserve-mode audit (unaudited queue drained; top targets contested by open fleet PRs). Picked oldest uncontested target: **erdos-766**.

### Verified
- **Counts match** meta.json: 3 axioms, 0 sorries, 2 theorems, 12 defs (lineCount 181 vs actual 184 — harmless stale undercount).
- **No phantom declarations**: all 15 `originalContributions` correspond to real declarations in `Proofs/Erdos766Problem.lean`.
- **Axioms match prose**: the 3 axioms (`dirac_erdos_theorem`, `f_nondecreasing`, `turanDensityExists`) exactly match the `assumptions` field.
- **No overstatement**: `erdos_766_summary` honestly packages the two axioms via direct invocation; `status: axiomatized` / `badge: axiom` correctly reflect a Tier C axiomatized result. Prose consistently states OPEN. No True stubs, no `native_decide`.

### Result
**clean** — tracker updated (auditCount 3→4).

---
Discovered during gallery integrity audit.