### PR TITLE
Research: cauchy-schwarz-integral-oq-04 — Maccone-Pati saturation characterization [VERIFIED 0-axiom]

### DIFF
--- a/proofs/Proofs/CauchySchwarzIntegralOQ04.lean
+++ b/proofs/Proofs/CauchySchwarzIntegralOQ04.lean
@@ -1259,6 +1259,65 @@ theorem maccone_pati_stronger_than_robertson_sum {A B : E →ₗ[𝕜] E} (hA : 
   · rw [habs]; linarith [hpos, hmin_pos]
   · rw [habs]; linarith [hneg, hmin_neg]
 
+/-- **Maccone–Pati saturation — the perpendicular vector `Γ` collinear with `ψ⊥`.**
+Over a field with a genuine imaginary unit (`RCLike.I ≠ 0`, i.e. `ℂ`), the stronger
+Maccone–Pati bound `maccone_pati_uncertainty` (the `+i` orientation) holds with
+**equality**
+
+    `2·Im⟪(A−a)ψ,(B−b)ψ⟫ + ‖⟪w, Aψ + i·Bψ⟫‖² = ‖(A−a)ψ‖² + ‖(B−b)ψ‖²`
+
+**iff** the combined vector `Γ = (A−a)ψ + i·(B−b)ψ` (assumed nonzero) is parallel to
+the unit `ψ⊥` witness `w`, i.e. `Γ = r • w` for some `r ≠ 0`.
+
+This is the equality companion of `maccone_pati_uncertainty`, completing its saturation
+story exactly as `gram_eq_iff_parallel` / `im_inner_sq_eq_iff_robertson_saturated`
+complete Cauchy–Schwarz and Robertson, and `schrodinger_saturated_iff` completes
+Schrödinger.  The MP bound's *only* inequality step is Cauchy–Schwarz against the unit
+vector `w` (`‖⟪w,Γ⟫‖² ≤ ‖w‖²·‖Γ‖² = ‖Γ‖²`); the shift-collapse `⟪w,Γ⟫ = ⟪w,(A+iB)ψ⟫`
+and the polarization `‖Γ‖² = ‖u‖²+‖v‖²−2·Im⟪u,v⟫` are both equalities.  So the bound is
+saturated **exactly** when Cauchy–Schwarz is — when the perpendicular projection onto
+`w` captures *all* of `Γ`, i.e. `Γ ∈ span{w}`.  Physically: the Maccone–Pati projection
+term reaches its maximal value `‖Γ‖²` precisely when the "amplitude" vector
+`(A+iB−⟨A+iB⟩)ψ` points entirely along the chosen orthogonal direction `ψ⊥`.
+
+Proof: substitute `⟪w,(A+iB)ψ⟫ = ⟪w,Γ⟫` (shift terms vanish by `⟪w,ψ⟫ = 0`) and the
+polarization identity `normSq_add_I_smul`, reducing the equality to
+`‖⟪w,Γ⟫‖² = ‖w‖²·‖Γ‖²` (using `‖w‖ = 1`), then close by the Cauchy–Schwarz equality
+case `gram_eq_iff_parallel` applied to the pair `(w, Γ)`. -/
+theorem maccone_pati_saturated_iff {A B : E →ₗ[𝕜] E} (hA : A.IsSymmetric)
+    (hB : B.IsSymmetric) (ψ : E) (a b : ℝ) (hI : (RCLike.I : 𝕜) ≠ 0)
+    {w : E} (hw : inner 𝕜 w ψ = 0) (hwn : ‖w‖ = 1)
+    (hΓ0 : A ψ - (a : 𝕜) • ψ + (RCLike.I : 𝕜) • (B ψ - (b : 𝕜) • ψ) ≠ 0) :
+    2 * RCLike.im (inner 𝕜 (A ψ - (a : 𝕜) • ψ) (B ψ - (b : 𝕜) • ψ))
+        + ‖inner 𝕜 w (A ψ + (RCLike.I : 𝕜) • B ψ)‖ ^ 2
+      = ‖A ψ - (a : 𝕜) • ψ‖ ^ 2 + ‖B ψ - (b : 𝕜) • ψ‖ ^ 2
+    ↔ ∃ r : 𝕜, r ≠ 0 ∧
+        A ψ - (a : 𝕜) • ψ + (RCLike.I : 𝕜) • (B ψ - (b : 𝕜) • ψ) = r • w := by
+  set u := A ψ - (a : 𝕜) • ψ with hu
+  set v := B ψ - (b : 𝕜) • ψ with hv
+  have hw0 : w ≠ 0 := by
+    intro h; rw [h, norm_zero] at hwn; exact one_ne_zero hwn.symm
+  -- The projection onto `w` sees only the uncentred part, since `w ⊥ ψ`.
+  have hΓeq : inner 𝕜 w (u + (RCLike.I : 𝕜) • v)
+      = inner 𝕜 w (A ψ + (RCLike.I : 𝕜) • B ψ) := by
+    simp only [hu, hv, inner_add_right, inner_sub_right, inner_smul_right, hw,
+      mul_zero, sub_zero]
+  have hid := normSq_add_I_smul (𝕜 := 𝕜) hI u v
+  have hnormsq : (RCLike.re (inner 𝕜 w (u + (RCLike.I : 𝕜) • v))) ^ 2
+        + (RCLike.im (inner 𝕜 w (u + (RCLike.I : 𝕜) • v))) ^ 2
+      = ‖inner 𝕜 w (u + (RCLike.I : 𝕜) • v)‖ ^ 2 := by
+    rw [RCLike.norm_sq_eq_def]; ring
+  rw [← hΓeq]
+  rw [show (2 * RCLike.im (inner 𝕜 u v)
+          + ‖inner 𝕜 w (u + (RCLike.I : 𝕜) • v)‖ ^ 2
+          = ‖u‖ ^ 2 + ‖v‖ ^ 2)
+        ↔ ((RCLike.re (inner 𝕜 w (u + (RCLike.I : 𝕜) • v))) ^ 2
+            + (RCLike.im (inner 𝕜 w (u + (RCLike.I : 𝕜) • v))) ^ 2
+            = ‖w‖ ^ 2 * ‖u + (RCLike.I : 𝕜) • v‖ ^ 2) from by
+      rw [hnormsq, hwn, one_pow, one_mul, hid]
+      constructor <;> intro h <;> linarith]
+  exact gram_eq_iff_parallel (𝕜 := 𝕜) hw0 hΓ0
+
 /-- **Schrödinger saturation — the full minimum-uncertainty family.**  Over a field with
 a genuine imaginary unit (`RCLike.I ≠ 0`, i.e. `ℂ`), for symmetric `A, B`, a state `ψ`
 and real shifts `a, b` with both centred vectors `u = (A−a)ψ`, `v = (B−b)ψ` nonzero, the

--- a/research/problems/cauchy-schwarz-integral-oq-04/knowledge.md
+++ b/research/problems/cauchy-schwarz-integral-oq-04/knowledge.md
@@ -237,3 +237,33 @@ no build/verify possible), so even a marginal addition could not be verified. Pe
 standards, made NO change and released the claim rather than churn a complete file. Next
 claimant: this is a terminus — skip unless a genuinely new direction (e.g. mixed-state /
 density-operator uncertainty, or a tightness/attainability existence result) is proposed.
+
+## Session 2026-07-19 (researcher-1) — Maccone–Pati saturation/equality characterization (VERIFIED axiom-free)
+
+Prior sessions completed the MP *inequalities* (`maccone_pati_uncertainty` ±i,
+variance form, stronger-than-Robertson) but never characterized their **equality case**.
+The tracker `nextAction` explicitly flagged this as open direction (b). MP was the only
+bound family in the file lacking a saturation `iff` — Gram (`gram_eq_iff_parallel`),
+Robertson (`im_inner_sq_eq_iff_robertson_saturated`) and Schrödinger
+(`schrodinger_saturated_iff`) all had one. Added `maccone_pati_saturated_iff` (1 theorem,
+1441→~1508 lines, still 0 axioms / 0 sorries):
+
+- `maccone_pati_saturated_iff`: for symmetric A,B, state ψ, shifts a,b, unit `w ⊥ ψ`,
+  and nonzero amplitude vector `Γ = u + i·v` (u=(A−a)ψ, v=(B−b)ψ), the MP (+i) bound
+  `2·Im⟪u,v⟫ + ‖⟪w,(A+iB)ψ⟫‖² = ‖u‖²+‖v‖²` holds **iff** `∃ r≠0, Γ = r•w` (Γ ∥ ψ⊥).
+  KEY OBSERVATION: `maccone_pati_uncertainty`'s proof has exactly ONE inequality step —
+  Cauchy–Schwarz `‖⟪w,Γ⟫‖² ≤ ‖w‖²‖Γ‖²` against the unit w. The shift-collapse
+  `⟪w,Γ⟫=⟪w,(A+iB)ψ⟫` (from `⟪w,ψ⟫=0`) and the polarization `‖Γ‖²=‖u‖²+‖v‖²−2Im⟪u,v⟫`
+  (`normSq_add_I_smul`) are both EQUALITIES. So the MP bound saturates ⟺ Cauchy–Schwarz
+  saturates ⟺ (by `gram_eq_iff_parallel` on the pair (w,Γ), both nonzero) Γ ∥ w.
+  Proof mechanics: `rw [← hΓeq]`, then an inline `show … ↔ …` rewrite folding the
+  polarization + ‖w‖=1 to turn the goal into the raw Gram equality `(Re)²+(Im)²=‖w‖²‖Γ‖²`,
+  closed by `gram_eq_iff_parallel hw0 hΓ0`. Physically: the MP projection term reaches its
+  max ‖Γ‖² precisely when the amplitude vector (A+iB−⟨·⟩)ψ points entirely along ψ⊥.
+
+BUILD: **VERIFIED axiom-free** via host path (main v4.31 Mathlib oleans, Docker-free):
+`cd /Users/rwalters/GitHub/lean-genius/proofs && LAKE_UNSAFE=1 ./bin/lake env lean <worktree-abs-file>`,
+exit 0, no errors/sorries. `#print axioms maccone_pati_saturated_iff` = `[propext,
+Classical.choice, Quot.sound]` (no sorryAx, no ofReduceBool). ★Toolchain note: the file is
+now v4.31 (epic #37508 migration landed) — prior sessions' "v4.26 oleans" note is stale;
+host-verify still works because the file is `import Mathlib`-only (no `import Proofs.*`).

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-04.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-04.json
@@ -24,7 +24,7 @@
     "iteration": 2,
     "focus": "Formalized the full Robertson uncertainty relation robertson_uncertainty AND its variance-form heisenberg_variance_form, THEN (researcher-1) strengthened Robertson to the SCHRÖDINGER relation schrodinger_uncertainty keeping the covariance term, with inner_normSq_le (full Gram split) and robertson_of_schrodinger. All verified, 0 axioms/sorries, 8 theorems.",
     "blockers": [],
-    "nextAction": "Maccone-Pati sum relation now formalized (researcher-8). Remaining optional directions: (a) the SECOND Maccone-Pati relation (amplitude/perpendicular form with |⟨ψ⊥|(A+B)|ψ⟩|² over an orthonormal completion); (b) saturation/equality characterization of the MP bound (attained iff Γ=u±i·v is parallel to ψ⊥, i.e. the projection captures all of Γ). Core operator content is complete.",
+    "nextAction": "Saturation stories now complete for Gram/Robertson/Schrödinger/Maccone-Pati. Remaining optional: (a) the SECOND Maccone-Pati relation (amplitude form over an orthonormal completion, |⟨ψ⊥ᵢ|(A+B)|ψ⟩|² summed); (b) -i orientation saturation companion (mirror of the +i just added). Core operator content is complete; file is at TERMINUS.",
     "attemptCounts": {
       "total": 1,
       "currentApproach": 1,
@@ -32,7 +32,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (researcher-8, 2026-07-12, VERIFIED axiom-free): added the Maccone-Pati STRONGER sum uncertainty relation (5 theorems), the direction flagged by nextAction. Unlike the pre-existing AM-GM sum forms (robertson/heisenberg_sum_form) whose lower bound vanishes when ⟪ψ,[A,B]ψ⟫=0, the MP relation adds a nonneg state-dependent projection term ‖⟪ψ⊥,(A±iB)ψ⟫‖² (ψ⊥⊥ψ) that stays informative for incompatible observables in commutator-null states. Host-lean verified [propext,Classical.choice,Quot.sound] only, 0 sorries. File 1134→~1230 lines, still 0 axioms.",
+    "progressSummary": "PROGRESS (researcher-1, 2026-07-19, VERIFIED axiom-free): added maccone_pati_saturated_iff — the equality/saturation characterization of the Maccone-Pati (+i) stronger uncertainty bound, the one direction (b) flagged in prior nextAction. MP bound saturates iff amplitude vector Γ=u+i•v ∥ ψ⊥ witness w. Completes saturation story (Robertson/Schrödinger/Gram already had iff-characterizations; MP did not). File 1441→~1508 lines, 26 theorems, still 0 axioms / 0 sorries. Host-lean v4.31 verified foundational-axioms-only.",
     "builtItems": [
       "CauchySchwarzIntegralOQ04.lean: 5 theorems over a general RCLike inner product space, 0 axioms (propext/Classical.choice/Quot.sound), 0 sorries.",
       "abs_im_inner_le_norm_mul_norm: |RCLike.im (inner 𝕜 u v)| ≤ ‖u‖·‖v‖ (RCLike.abs_im_le_norm |im z| ≤ ‖z‖, then norm_inner_le_norm).",
@@ -56,7 +56,8 @@
       "maccone_pati_variance_form: MP bound at expectation values (Var(A)+Var(B) form)",
       "maccone_pati_stronger_than_robertson_sum: ‖⟪ψ,[A,B]ψ⟫‖ + min(both projection terms) ≤ Var sum — makes the strengthening over robertson_sum_form explicit",
       "schrodinger_saturated_iff (CauchySchwarzIntegralOQ04.lean, researcher-7, PR #38152): operator-level Schrödinger saturation over ℂ (RCLike.I≠0) — ¼‖⟪ψ,[A,B]ψ⟫‖²+(Re⟪u,v⟫)²=‖u‖²‖v‖² ↔ ∃r≠0, v=r•u, the FULL minimum-uncertainty family (coherent+squeezed), not just the Robertson subclass (Re r=0 slice). Proof: ‖comm‖=2|Im⟪u,v⟫| exactly (‖I‖=1) → ¼‖comm‖²=(Im)² → Gram equality → gram_eq_iff_parallel. 0 axioms.",
-      "schrodinger_variance_saturated_iff (CauchySchwarzIntegralOQ04.lean, researcher-7, PR #38152): variance-form capstone at a=⟨A⟩, b=⟨B⟩ under hcomm: ⟪ψ,[A,B]ψ⟫≠0 — the nonzero commutator discharges the nonvanishing-fluctuation hypotheses via centred_ne_zero_of_commutator_ne_zero. Var(A)·Var(B)=¼‖comm‖²+Cov² ↔ (B−⟨B⟩)ψ=r(A−⟨A⟩)ψ. 0 axioms."
+      "schrodinger_variance_saturated_iff (CauchySchwarzIntegralOQ04.lean, researcher-7, PR #38152): variance-form capstone at a=⟨A⟩, b=⟨B⟩ under hcomm: ⟪ψ,[A,B]ψ⟫≠0 — the nonzero commutator discharges the nonvanishing-fluctuation hypotheses via centred_ne_zero_of_commutator_ne_zero. Var(A)·Var(B)=¼‖comm‖²+Cov² ↔ (B−⟨B⟩)ψ=r(A−⟨A⟩)ψ. 0 axioms.",
+      "maccone_pati_saturated_iff in CauchySchwarzIntegralOQ04.lean (~line 1262): 2·Im⟪u,v⟫+‖⟪w,(A+iB)ψ⟫‖²=‖u‖²+‖v‖² ↔ ∃r≠0, u+i•v=r•w. Proof: shift-collapse ⟪w,Γ⟫=⟪w,(A+iB)ψ⟫ (w⊥ψ) + normSq_add_I_smul polarization reduce to ‖⟪w,Γ⟫‖²=‖w‖²‖Γ‖², close by gram_eq_iff_parallel. Host-verified axiom-free [propext,Classical.choice,Quot.sound]."
     ],
     "insights": [
       "The Heisenberg/Robertson uncertainty inequality's analytic core is Cauchy-Schwarz on the imaginary part: |Im⟪u,v⟫| ≤ |⟪u,v⟫| ≤ ‖u‖‖v‖. For real fields Im = 0 (trivial); the content is the ℂ case.",
@@ -70,7 +71,8 @@
       "The abstract inner-product-space uncertainty core specializes to the literal integral Cauchy–Schwarz with NO extra work: MeasureTheory.L2.inner_def makes ⟪f,g⟫ on α→₂[μ]ℂ DEFINITIONALLY ∫ a, ⟪f a, g a⟫ ∂μ, and RCLike.inner_apply' rewrites the pointwise inner to conj(f a)·g a, so a single rw [← L2_inner_eq_integral] transports every abstract bound (abs_im/im_sq/abs_re/re_sq/gram/norm) onto ∫ conj(f)·g. The operator-level Robertson/Schrödinger statements do NOT specialize cleanly — position/momentum are unbounded operators on L², needing domains — so the tractable L² payload is exactly the Cauchy–Schwarz CORE, which is what OQ-04 literally asks for.",
       "Maccone-Pati (PRL 113 260401, 2014) STRONGER sum uncertainty relation: Var(A)+Var(B) ≥ 2·Im⟪(A−a)ψ,(B−b)ψ⟫ + ‖⟪ψ⊥,(A±iB)ψ⟫‖² for any unit ψ⊥⊥ψ. The extra projection term ‖⟪ψ⊥,(A±iB)ψ⟫‖² is nonneg and can be POSITIVE even when the commutator expectation ⟪ψ,[A,B]ψ⟫=0 — removing the defect of all AM-GM sum forms (robertson_sum_form etc.) whose bound vanishes there. Genuinely stronger than robertson_sum_form.",
       "Mechanism is one line of Hilbert-space geometry: for Γ=u±i·v the polarization identity ‖u±i·v‖²=‖u‖²+‖v‖²∓2·Im⟪u,v⟫ (normSq_add_I_smul via Mathlib norm_add_sq + RCLike.I_mul_re), and Cauchy-Schwarz ‖⟪w,Γ⟫‖²≤‖w‖²‖Γ‖²=‖Γ‖² for unit w; shifts a,b drop from the projection because ⟪w,ψ⟫=0. Im⟪u,v⟫ is shift-independent.",
-      "Over ℂ the commutator norm is EXACT: ‖⟪ψ,[A,B]ψ⟫‖=2|Im⟪u,v⟫| (the Robertson estimate is tight because ‖RCLike.I‖=1), so ¼‖comm‖²=(Im⟪u,v⟫)² and the Schrödinger inequality collapses to the Gram equality — this bridges the physical (commutator-expectation) statement to the inner-product gram_eq_iff_parallel."
+      "Over ℂ the commutator norm is EXACT: ‖⟪ψ,[A,B]ψ⟫‖=2|Im⟪u,v⟫| (the Robertson estimate is tight because ‖RCLike.I‖=1), so ¼‖comm‖²=(Im⟪u,v⟫)² and the Schrödinger inequality collapses to the Gram equality — this bridges the physical (commutator-expectation) statement to the inner-product gram_eq_iff_parallel.",
+      "Maccone-Pati (+i) bound saturates EXACTLY when the amplitude vector Γ=(A−a)ψ+i(B−b)ψ is parallel to the ψ⊥ witness w (Γ=r•w, r≠0): the MP bound has only ONE inequality step (Cauchy-Schwarz vs unit w), so its equality case is precisely the CS equality case gram_eq_iff_parallel(w,Γ). Completes the file saturation story — MP was the only bound family without an iff characterization (Robertson, Schrödinger, and raw Gram all had one)."
     ],
     "mathlibGaps": [
       "The full operator-theoretic uncertainty principle (self-adjoint operators, variance of an observable in a state, the commutator [A,B]) is not packaged in Mathlib; only the underlying Cauchy-Schwarz inequality is in reach here."


### PR DESCRIPTION
## Summary
Research session on `cauchy-schwarz-integral-oq-04` (a RICH, near-TERMINUS quantum
uncertainty-relations file). Added the **equality/saturation characterization of the
Maccone–Pati stronger uncertainty bound** — the one theory-level direction the tracker's
`nextAction` still flagged as open (direction b).

## Progress
- **`maccone_pati_saturated_iff`** (new): for symmetric `A,B`, state `ψ`, real shifts
  `a,b`, and a unit witness `w ⊥ ψ`, with nonzero amplitude vector
  `Γ = (A−a)ψ + i·(B−b)ψ`, the Maccone–Pati (`+i`) bound holds with **equality**

  `2·Im⟪(A−a)ψ,(B−b)ψ⟫ + ‖⟪w,(A+iB)ψ⟫‖² = ‖(A−a)ψ‖² + ‖(B−b)ψ‖²`

  **iff** `∃ r ≠ 0, Γ = r • w` — i.e. `Γ` is parallel to `ψ⊥`, the perpendicular
  projection captures all of `Γ`.
- Files: `proofs/Proofs/CauchySchwarzIntegralOQ04.lean` (1441→~1508 lines, 26 theorems),
  tracker JSON, `knowledge.md`.

## Findings
- The Maccone–Pati proof (`maccone_pati_uncertainty`) has **exactly one** inequality
  step: Cauchy–Schwarz `‖⟪w,Γ⟫‖² ≤ ‖w‖²‖Γ‖²` against the unit `w`. The shift-collapse
  `⟪w,Γ⟫ = ⟪w,(A+iB)ψ⟫` (from `⟪w,ψ⟫=0`) and the polarization identity
  `‖Γ‖² = ‖u‖²+‖v‖²−2·Im⟪u,v⟫` (`normSq_add_I_smul`) are both equalities. Hence the MP
  bound saturates **exactly** when Cauchy–Schwarz does, characterized by the file's
  existing `gram_eq_iff_parallel` applied to the pair `(w, Γ)`.
- This completes the file's saturation story: raw Gram (`gram_eq_iff_parallel`),
  Robertson (`im_inner_sq_eq_iff_robertson_saturated`), and Schrödinger
  (`schrodinger_saturated_iff`) each already had an `iff`; Maccone–Pati was the one gap.

## Verification
Host-verified Docker-free against main's v4.31 Mathlib oleans
(`LAKE_UNSAFE=1 ./bin/lake env lean <file>`), exit 0, no errors/sorries.
`#print axioms maccone_pati_saturated_iff` = `[propext, Classical.choice, Quot.sound]`
(no `sorryAx`, no `Lean.ofReduceBool`). File remains **0 axioms / 0 sorries**.

## Status
**Outcome**: progress (completed problem — genuine saturation-completion theorem, not filler)
**Next Steps**: optional `−i`-orientation saturation companion; the second Maccone–Pati
(amplitude-completion) relation. Core operator content is at TERMINUS.

🤖 Generated by researcher-1