### PR TITLE
audit: erdos-769 — drop 4 phantom upper-bound axioms, correct axiomatization prose

### DIFF
--- a/src/data/proofs/erdos-769/meta.json
+++ b/src/data/proofs/erdos-769/meta.json
@@ -38,14 +38,13 @@
     ],
     "originalContributions": [
       "CanDecomposeCubeIntoKCubes: decomposability predicate",
-      "cubeDissectionNumber axiom with spec and minimality",
+      "cubeDissectionNumber: opaque axiom declaring the dissection function c(n)",
+      "c_of_2 axiom: c(2) = 6",
       "hadwiger_lower_bound axiom: c(n) ≥ 2^n + 2^{n-1}",
       "hadwiger_explicit theorem: c(n) ≥ 3·2^{n-1} (proved via omega)",
       "connor_marmorino_lower axiom: c(n) ≥ 2^{n+1} - 1 for n ≥ 3",
       "connor_vs_hadwiger theorem: comparison proved via omega",
       "burgess_erdos_upper axiom: c(n) ≪ n^{n+1}",
-      "hudelson_upper_general and hudelson_special axioms",
-      "connor_marmorino_upper_prime and _composite axioms",
       "erdosConjecture and mainQuestion definitions",
       "erdos_769_summary theorem combining key results"
     ],
@@ -59,7 +58,7 @@
     "historicalContext": "The cube dissection problem asks: given an n-dimensional unit cube, what is the minimum number c(n) such that for all k ≥ c(n), the cube can be decomposed into exactly k smaller homothetic (scaled, axis-aligned) cubes? Hadwiger initiated the study of this function, proving the first lower bound c(n) ≥ 2^n + 2^{n-1} = 3·2^{n-1}. The exact value c(2) = 6 is known: a square cannot be split into 2, 3, 4, or 5 squares, but can be split into 6 or more.\n\nBurgess and Erdős (1974) proved the first upper bound c(n) ≪ n^{n+1}, showing the function grows at most super-exponentially. Hudelson (1998) refined this under divisibility conditions, proving c(n) < 6^n when gcd(2^n - 1, 3^n - 1) = 1. The most significant recent advance came from Connor and Marmorino (2018), who improved the lower bound to c(n) ≥ 2^{n+1} - 1 for n ≥ 3 and refined the upper bounds: c(n) ≤ 1.8n^{n+1} when n+1 is prime, and c(n) ≤ e²n^n otherwise.\n\nThe central open question is whether c(n) ≫ n^n. Erdős expressed strong belief that c(n) > n^n when n+1 is prime. The current gap between the exponential lower bound (~2^n) and super-exponential upper bound (~n^n) is enormous, and closing it remains one of the main challenges in combinatorial geometry. Even the exact value c(3) is unknown, though Meier conjectured c(3) = 48.",
     "problemStatement": "**Problem Statement (Open)**\n\nLet $c(n)$ be the minimal integer such that if $k \\geq c(n)$, then the $n$-dimensional unit cube can be decomposed into $k$ homothetic $n$-dimensional cubes.\n\n**Question:** Give good bounds for $c(n)$. In particular, is it true that $c(n) \\gg n^n$?\n\n**Known Bounds:**\n- **Lower:** $c(n) \\geq 2^{n+1} - 1$ for $n \\geq 3$ (Connor-Marmorino 2018)\n- **Upper:** $c(n) \\leq e^2 n^n$ or $c(n) \\leq 1.8 n^{n+1}$ (Connor-Marmorino 2018)\n\n**Status:** OPEN.",
     "text": "Let c(n) be minimal such that for k ≥ c(n), the n-dimensional unit cube can be decomposed into k homothetic cubes. Is c(n) ≫ n^n? OPEN: Lower bound 2^{n+1}-1, upper bound O(n^{n+1}).",
-    "proofStrategy": "The formalization axiomatizes cubeDissectionNumber with two characterizing properties (threshold and minimality), avoiding the sorry-dependent Nat.find approach. The decomposability predicate CanDecomposeCubeIntoKCubes captures the volume constraint. Lower bounds (Hadwiger, Connor-Marmorino) and upper bounds (Burgess-Erdős, Hudelson, Connor-Marmorino) are axiomatized. Two theorems are proved: hadwiger_explicit and connor_vs_hadwiger use omega, and the summary combines the key results.",
+    "proofStrategy": "The formalization declares cubeDissectionNumber as an opaque axiom (the existence proof requires the finite obstruction principle), avoiding a sorry-dependent Nat.find approach. The decomposability predicate CanDecomposeCubeIntoKCubes captures the volume constraint. The value c(2) = 6 and the Hadwiger and Connor-Marmorino lower bounds are axiomatized, together with the single Burgess-Erdős upper bound c(n) ≪ n^{n+1}; the Hudelson and Connor-Marmorino refined upper bounds are discussed in the overview but not formalized. Three theorems are proved: hadwiger_explicit and connor_vs_hadwiger via omega, and erdos_769_summary combines the key results.",
     "keyInsights": [
       "**c(2) = 6:** The 2D case is completely solved — a square cannot be split into 2, 3, 4, or 5 squares",
       "**Exponential Lower Bound:** Connor-Marmorino proved c(n) ≥ 2^{n+1} - 1, exponential in n",
@@ -116,10 +115,10 @@
     {
       "id": "upper-bounds",
       "title": "Upper Bounds",
-      "summary": "Burgess-Erdős, Hudelson, Connor-Marmorino upper bounds",
+      "summary": "Burgess-Erdős upper bound c(n) ≪ n^{n+1} axiomatized (Hudelson and Connor-Marmorino refinements noted in overview only)",
       "startLine": 97,
       "endLine": 116,
-      "mathContext": "Bound: Burgess-Erdős, Hudelson, Connor-Marmorino upper bounds"
+      "mathContext": "Bound: burgess_erdos_upper axiom c(n) ≪ n^{n+1}; Hudelson and Connor-Marmorino refinements are historical context, not formalized"
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Integrity Issue

**Proof**: erdos-769 (Erdős #769: Cube Dissection into Homothetic Cubes)
**Problem**: `originalContributions` and `proofStrategy` claim formalized axioms that do not exist in the Lean source. Counts (`axiomCount: 5`) and the `assumptions` field are accurate — this is a prose overclaim only.

## Evidence

`proofs/Proofs/Erdos769Problem.lean` declares exactly **5 axioms**, **3 theorems**, **3 defs**:

- axioms: `cubeDissectionNumber`, `c_of_2`, `hadwiger_lower_bound`, `connor_marmorino_lower`, `burgess_erdos_upper`
- theorems: `hadwiger_explicit`, `connor_vs_hadwiger`, `erdos_769_summary`
- defs: `CanDecomposeCubeIntoKCubes`, `erdosConjecture`, `mainQuestion`

**meta.json claimed (phantom — 0 hits in the file):**
- `hudelson_upper_general` and `hudelson_special` axioms
- `connor_marmorino_upper_prime` and `_composite` axioms
- `cubeDissectionNumber` "with spec and minimality" / proofStrategy's "two characterizing properties (threshold and minimality)" — the axiom is an opaque `ℕ → ℕ` with no spec

Hudelson's and Connor-Marmorino's refined upper bounds appear only in the historical-context prose; they are not declared as axioms.

## Fix

- Removed the 4 phantom upper-bound axioms from `originalContributions`; added the real `c_of_2` axiom.
- Rewrote `cubeDissectionNumber` contribution as "opaque axiom declaring c(n)".
- Rewrote `proofStrategy` to state only Burgess-Erdős upper bound is axiomatized and that Hudelson/Connor-Marmorino refinements are context only.
- Scoped the Upper Bounds section summary to the one axiomatized bound.

No Lean changes; the formalization was already correct — only the public description was overstated.

---
Discovered during gallery integrity audit (reserve-mode re-verification; queue drained, oldest uncontested target).