### PR TITLE
audit: erdos-874 — drop 2 phantom axiom claims (Straus/ENS bounds are prose, not axiomatized)

### DIFF
--- a/.claude/commands/repo/followups.md
+++ b/.claude/commands/repo/followups.md
@@ -1,0 +1,180 @@
+---
+name: "followups"
+description: "Capture follow-on work surfaced during this session and file it as issues — routed to this repo or the right upstream tool repo, always confirmed first"
+domain: repo
+type: command
+user-invocable: true
+---
+
+# /repo:followups — File Session Follow-Ups
+
+Mine the current working session for follow-on work that was surfaced but not
+done — bugs found-but-not-fixed, deferred TODOs, documentation gaps, and
+limitations discovered in an upstream tool while using it — then file each as an
+issue in the right repo (this repo, or an upstream tool repo like Loom / Anvil /
+Repo Skills / kicad-tools).
+
+Unlike every other `/repo:*` command, which scans repo / git / filesystem
+state, this one mines the **conversation**: the deferred work and discovered
+bugs that only exist in the session's context. Filing is outward-facing — for
+upstream targets it writes into *other people's* repos — so this command is in
+the same "always confirm first" class as `release`, `remote`, and
+`update-tools`, never the auto-apply behavior of the hygiene commands.
+**Confirmation is the default and only mode; there is no `--ask` flag because
+there is nothing to opt into.**
+
+## Usage
+
+```
+/repo:followups                 # Review this session, propose issues, confirm, then file
+/repo:followups --dry-run       # Propose only — show what would be filed, file nothing
+/repo:followups --repo loom     # Restrict to follow-ups targeting one tool repo
+/repo:followups --here          # Only this repo; skip all upstream tool repos
+```
+
+## Steps
+
+### 1. Mine the session for candidates
+
+Review the working session and collect concrete follow-on work in four
+categories. Only include work that was actually surfaced — do not invent tasks.
+
+- **Bugs found but not fixed** — something broke or misbehaved and was noted
+  but left unaddressed (in this repo's code or in a tool being used).
+- **Deferred TODOs** — "we should do X later", "out of scope for now",
+  intentionally punted work.
+- **Documentation gaps** — missing/stale/wrong docs noticed while working.
+- **Upstream tool limitations** — a bug, missing feature, or rough edge in an
+  installed tool (Loom, Anvil, Repo Skills, kicad-tools) hit while using it.
+
+For each candidate capture: a one-line title, the context / where it came up in
+the session (repro if it's a bug), and suggested acceptance criteria.
+
+### 2. Build the target-routing table
+
+Every candidate has to land in *some* repo. Build the routing table by reusing
+`/repo:update-tools`' discovery — do **not** hardcode a repo list.
+
+- **This repo** (`origin`): follow-ups about the Repo Skills commands
+  themselves, or whatever code/docs live in the current repo.
+
+  ```bash
+  git config --get remote.origin.url    # → derive this repo's owner/repo slug
+  ```
+
+- **Upstream tool repos**: discover installed tools exactly as
+  `/repo:update-tools` step 1 does — find their metadata files, then resolve
+  each tool's local source clone **sidecar-first**, and derive a GitHub slug
+  from that clone's `origin` remote.
+
+  ```bash
+  # a. Find installed-tool metadata (same locations update-tools checks)
+  ls .loom/install-metadata.json .anvil/install-metadata.json 2>/dev/null
+  ls .claude/skills/*/install-metadata.json 2>/dev/null
+  ```
+
+  Resolve each tool's `source` clone path in this order (each step failing is
+  "source unknown", not an error):
+
+  1. **Sidecar first.** For Repo Skills read
+     `.claude/skills/repo/.install-local.json` (generally
+     `.claude/skills/*/.install-local.json`); it holds `source` /
+     `installed_at`. Loom uses the plain-text `.loom/loom-source-path` sidecar
+     for the same purpose. A sidecar is gitignored, so it exists only on the
+     machine that ran the install.
+  2. **Legacy inline fallback.** Pre-split installs still embed `source` /
+     `installed_at` directly in `install-metadata.json` — read from there if no
+     sidecar exists.
+  3. **Unknown → GitHub.** If neither yields a path, the local source clone is
+     simply unknown (normal on a fresh clone elsewhere).
+
+  Then derive the slug from the resolved clone's remote:
+
+  ```bash
+  git -C <source> config --get remote.origin.url   # → owner/repo for gh --repo
+  ```
+
+  `install-metadata.json` (tracked) is JSON, and key names vary by tool
+  (`version` vs `loom_version` / `anvil_version`, etc.) — read whichever variant
+  is present, same as `/repo:update-tools`. Neither the tracked metadata nor the
+  sidecar stores an `owner/repo` slug directly; it is always derived from the
+  source clone's `origin` remote.
+
+- **Unresolvable targets.** If a tool's source clone is unknown (no sidecar, no
+  legacy field) there is no local remote to read — mark that follow-up
+  **UNKNOWN** and surface it for the user to name a slug, per the safety rules.
+  Likewise, if a candidate doesn't clearly belong to any discovered repo,
+  surface it for a target decision rather than dropping it or guessing.
+
+Honor scope flags: `--here` keeps only this-repo targets; `--repo <tool>`
+restricts to a single discovered tool.
+
+### 3. Dedup against existing open issues
+
+Before proposing to file, check each target repo for issues that already cover
+the candidate so nothing is re-filed:
+
+```bash
+gh issue list --repo <slug> --state open --search "<key terms>" \
+  --json number,title,url
+```
+
+Classify each candidate against its target repo's open issues:
+
+- **New** — no match; propose to file.
+- **Near-match** — a similar issue exists; **flag it for the user** with the
+  existing issue's number/URL and let them choose: file anyway, skip, or
+  comment on the existing one. Never silently file over it or silently drop it.
+
+### 4. Report the proposed set and confirm
+
+Present the full proposal and get explicit approval before touching any repo:
+
+```
+FOLLOW-UPS FROM THIS SESSION
+============================
+| # | Target repo        | Title                              | Dedup            |
+|---|--------------------|------------------------------------|------------------|
+| 1 | rjwalters/repo     | orphans check misses nested dirs   | NEW              |
+| 2 | rjwalters/loom     | worktree.sh fails on detached HEAD | near #217 (flag) |
+| 3 | rjwalters/anvil    | (docs gap) …                       | NEW              |
+| 4 | UNKNOWN            | kicad-tools DRC false positive     | ask — no slug    |
+```
+
+For each proposed issue show the target repo, title, a body preview (context /
+repro / suggested acceptance criteria), and dedup status. Then confirm which to
+file. **If `--dry-run` was passed, stop here — file nothing.**
+
+### 5. File the approved issues
+
+For each approved, non-UNKNOWN candidate:
+
+```bash
+gh issue create --repo <slug> \
+  --title "<title>" \
+  --body "$(cat <<'EOF'
+## Context
+<where this came up in the session / repro>
+
+## Suggested acceptance criteria
+- [ ] …
+EOF
+)"
+```
+
+Print the resulting issue URLs. For near-matches the user chose to comment on
+instead of file, use `gh issue comment --repo <slug> <n>`. Leave UNKNOWN /
+skipped candidates unfiled and list them so nothing is silently lost.
+
+Filed issues are triaged like any other afterward — this command does not apply
+`loom:*` or other pipeline labels.
+
+## Safety Rules
+
+1. **Never file without confirmation** — present the full proposed set (target
+   repo, title, body preview, dedup status) and file only what's approved.
+2. **Dedup before filing** — check open issues in each target repo; show
+   near-matches and let the user decide file / skip / comment-on-existing.
+3. **Never guess a target repo** — unresolved or ambiguous targets are reported
+   as UNKNOWN for the user to name, never filed to a guessed slug.
+4. **`--dry-run` files nothing** — pure proposal mode for review.

--- a/.claude/skills/repo/.install-local.json
+++ b/.claude/skills/repo/.install-local.json
@@ -1,0 +1,4 @@
+{
+  "source": "/private/tmp/claude-501/-Users-rwalters-GitHub-lean-genius/ffee83ca-090b-4f60-bd0a-cdf8a9630d9f/scratchpad/repo-clean",
+  "installed_at": "2026-07-18T12:18:19Z"
+}

--- a/.claude/skills/repo/hooks/guard-destructive.sh
+++ b/.claude/skills/repo/hooks/guard-destructive.sh
@@ -1,0 +1,642 @@
+#!/usr/bin/env bash
+# guard-destructive.sh - PreToolUse hook to block destructive agent commands
+#
+# Part of Repo Skills (https://github.com/rjwalters/repo). Generic repository
+# hygiene: this hook is a Claude Code PreToolUse hook that intercepts Bash
+# commands before execution and blocks / asks on catastrophic operations. It is
+# installed by install.sh into .claude/skills/repo/hooks/ and wired into the
+# consumer repo's .claude/settings.json PreToolUse -> Bash matcher.
+#
+# Receives JSON on stdin with tool_input.command and cwd fields.
+#
+# IMPORTANT: This hook only fires when Claude Code is invoked with:
+#   --dangerously-skip-permissions  <- hooks FIRE
+#
+# It does NOT fire with:
+#   --permission-mode bypassPermissions  <- hooks SKIPPED entirely
+#
+# If you have a shell alias like 'alias claude="claude --permission-mode bypassPermissions"',
+# this safety hook will be silently disabled in interactive sessions.
+# Use --dangerously-skip-permissions instead for automation that needs hooks.
+#
+# Decisions:
+#   - Block (deny): Dangerous commands that should never run
+#   - Ask: Commands that need human confirmation
+#   - Allow: Everything else (exit 0, no output)
+#
+# Output format (Claude Code hooks spec):
+#   { "hookSpecificOutput": { "hookEventName": "PreToolUse", "permissionDecision": "deny|ask", "permissionDecisionReason": "..." } }
+#
+# NOTE: The "hookEventName": "PreToolUse" field is REQUIRED by Claude Code's
+# PreToolUse hook schema. Without it, Claude Code silently discards the
+# decision and the guard becomes inert.
+#
+# Toggles (see the SQL / cloud guard sections below):
+#   - SQL DDL/DML guard:  REPO_GUARD_SQL   env, or guards.sqlDdl   config key
+#   - Cloud-CLI guard:    REPO_GUARD_CLOUD env, or guards.cloudCli config key
+#   Config is read from .claude/skills/repo/config.json (Repo Skills' own
+#   location). For back-compat with repos that previously ran Loom's guard, the
+#   legacy LOOM_GUARD_SQL / LOOM_GUARD_CLOUD env vars and .loom/config.json are
+#   accepted as lower-precedence fallbacks.
+#
+# Error handling: This script MUST never exit with a non-zero code or produce
+# invalid output. Any internal error is caught by the trap, logged for
+# diagnostics, and results in an "allow" decision to prevent infinite retry
+# loops in Claude Code.
+
+# Determine log directory relative to this script's location
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd 2>/dev/null || echo ".")"
+HOOK_ERROR_LOG="${SCRIPT_DIR}/../logs/hook-errors.log"
+
+# Log a diagnostic error message (best-effort, never fails the script)
+log_hook_error() {
+    local msg="$1"
+    # Ensure log directory exists
+    mkdir -p "$(dirname "$HOOK_ERROR_LOG")" 2>/dev/null || true
+    echo "[$(date -u '+%Y-%m-%dT%H:%M:%SZ')] [guard-destructive] $msg" >> "$HOOK_ERROR_LOG" 2>/dev/null || true
+}
+
+# Top-level error trap: on ANY unexpected error, output valid JSON "allow"
+# and log the failure for debugging. This prevents Claude Code from showing
+# "PreToolUse:Bash hook error" which causes infinite retry loops.
+trap 'log_hook_error "Unexpected error on line ${LINENO}: ${BASH_COMMAND:-unknown} (exit=$?)"; exit 0' ERR
+
+# Read stdin safely — if cat or jq fails, the ERR trap fires and we allow
+INPUT=$(cat 2>/dev/null) || INPUT=""
+
+# Verify jq is available before attempting to parse
+if ! command -v jq &>/dev/null; then
+    log_hook_error "jq not found in PATH — allowing command (cannot parse input)"
+    exit 0
+fi
+
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null) || COMMAND=""
+CWD=$(echo "$INPUT" | jq -r '.cwd // empty' 2>/dev/null) || CWD=""
+
+# If no command to check, allow
+if [[ -z "$COMMAND" ]]; then
+    exit 0
+fi
+
+# Resolve repo root from cwd (handles worktree paths safely)
+REPO_ROOT=""
+if [[ -n "$CWD" ]] && [[ -d "$CWD" ]]; then
+    REPO_ROOT=$(git -C "$CWD" rev-parse --show-toplevel 2>/dev/null || true)
+elif [[ -n "$CWD" ]]; then
+    # CWD doesn't exist (e.g., deleted worktree) — log but continue without repo root
+    log_hook_error "cwd does not exist: $CWD — skipping repo root resolution"
+fi
+
+# =============================================================================
+# Config toggle resolution helper.
+#
+# read_guard_toggle <config-key> <REPO_env_value> <LOOM_env_value>
+#   Echoes "true" or "false". Resolution order (highest precedence first):
+#     1. REPO_GUARD_* env var  (Repo Skills' own name)
+#     2. LOOM_GUARD_*  env var  (legacy back-compat)
+#     3. .claude/skills/repo/config.json  -> guards.<key>  (Repo Skills' location)
+#     4. .loom/config.json                -> guards.<key>  (legacy back-compat)
+#     5. Default: true (guard on)
+#
+# Env values 0/false/no disable; 1/true/yes force on. Only an explicit `false`
+# in a config file disables (a missing key stays on). Every read is best-effort:
+# any parse failure falls through to guard-ON and never trips the ERR trap.
+# =============================================================================
+read_guard_toggle() {
+    local key="$1" repo_env="$2" loom_env="$3"
+    local enabled=true
+    local cfg
+
+    # Config files (lowest precedence first, so later reads override earlier).
+    for cfg in "$REPO_ROOT/.loom/config.json" "$REPO_ROOT/.claude/skills/repo/config.json"; do
+        if [[ -n "$REPO_ROOT" && -f "$cfg" ]]; then
+            # jq // is alternative-on-null, not default-on-missing, so use
+            # if/then/else to treat only an explicit `false` as disabled (a
+            # missing key stays on). On malformed JSON jq exits non-zero and the
+            # `||` fallback preserves the current value.
+            local val
+            val=$(jq -r --arg k "$key" 'if .guards[$k] == false then "false" elif .guards[$k] == true then "true" else "unset" end' "$cfg" 2>/dev/null) || val="unset"
+            case "$val" in
+                false) enabled=false ;;
+                true)  enabled=true ;;
+            esac
+        fi
+    done
+
+    # Env overrides win over config; REPO name wins over the legacy LOOM name.
+    case "$loom_env" in
+        0|false|no)  enabled=false ;;
+        1|true|yes)  enabled=true ;;
+    esac
+    case "$repo_env" in
+        0|false|no)  enabled=false ;;
+        1|true|yes)  enabled=true ;;
+    esac
+
+    echo "$enabled"
+}
+
+# =============================================================================
+# SQL DDL/DML guard toggle — default ON.
+#
+# The SQL DDL/DML blocks (DROP DATABASE/TABLE/SCHEMA, TRUNCATE TABLE, and
+# DELETE FROM without WHERE) are a category error for repos that are themselves
+# database engines, where those statements are the product's own dev/test
+# vocabulary. Such repos opt out; everyone else keeps the guard on.
+#
+# Resolution runs LAZILY — sql_guard_enabled() is only invoked once a command
+# has already matched a SQL DDL/DML pattern, so the config read never touches
+# the hot path for the ~99% of commands that are not SQL. The result is cached
+# so a command matching multiple SQL patterns pays for at most one read.
+# =============================================================================
+_SQL_GUARD_CACHE=""
+sql_guard_enabled() {
+    if [[ -z "$_SQL_GUARD_CACHE" ]]; then
+        _SQL_GUARD_CACHE=$(read_guard_toggle sqlDdl "${REPO_GUARD_SQL:-}" "${LOOM_GUARD_SQL:-}")
+    fi
+    [[ "$_SQL_GUARD_CACHE" == "true" ]]
+}
+
+# =============================================================================
+# Cloud-CLI guard toggle — default ON. Same mechanism as the SQL guard.
+#
+# Lets a repo whose job IS managing cloud/containers (e.g. a remote-dev
+# command that launches/stops/terminates EC2) opt down the broad aws/docker
+# ASK patterns and the `aws ec2 terminate` deny, which otherwise fire on every
+# read-only describe and make legitimate teardown unrunnable.
+#
+# Lazy + cached, mirroring sql_guard_enabled().
+# =============================================================================
+_CLOUD_GUARD_CACHE=""
+cloud_guard_enabled() {
+    if [[ -z "$_CLOUD_GUARD_CACHE" ]]; then
+        _CLOUD_GUARD_CACHE=$(read_guard_toggle cloudCli "${REPO_GUARD_CLOUD:-}" "${LOOM_GUARD_CLOUD:-}")
+    fi
+    [[ "$_CLOUD_GUARD_CACHE" == "true" ]]
+}
+
+# Helper: output a deny decision and exit
+deny() {
+    local reason="$1"
+    if jq -n --arg reason "$reason" '{
+        hookSpecificOutput: {
+            hookEventName: "PreToolUse",
+            permissionDecision: "deny",
+            permissionDecisionReason: $reason
+        }
+    }' 2>/dev/null; then
+        exit 0
+    fi
+    # jq failed — emit raw JSON as fallback
+    local escaped_reason
+    escaped_reason=$(echo "$reason" | sed 's/\\/\\\\/g; s/"/\\"/g; s/\t/\\t/g; s/\n/\\n/g')
+    echo "{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"permissionDecision\":\"deny\",\"permissionDecisionReason\":\"${escaped_reason}\"}}"
+    exit 0
+}
+
+# Helper: output an ask decision and exit
+ask() {
+    local reason="$1"
+    if jq -n --arg reason "$reason" '{
+        hookSpecificOutput: {
+            hookEventName: "PreToolUse",
+            permissionDecision: "ask",
+            permissionDecisionReason: $reason
+        }
+    }' 2>/dev/null; then
+        exit 0
+    fi
+    # jq failed — emit raw JSON as fallback
+    local escaped_reason
+    escaped_reason=$(echo "$reason" | sed 's/\\/\\\\/g; s/"/\\"/g; s/\t/\\t/g; s/\n/\\n/g')
+    echo "{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"permissionDecision\":\"ask\",\"permissionDecisionReason\":\"${escaped_reason}\"}}"
+    exit 0
+}
+
+# =============================================================================
+# ALWAYS BLOCK - Catastrophic commands that should never execute
+# =============================================================================
+
+ALWAYS_BLOCK_PATTERNS=(
+    # GitHub destructive operations — command-position anchored (start-of-line
+    # or a shell separator must precede the verb) so the phrase inside a flag
+    # value no longer trips. The catastrophic scan still runs over the full raw
+    # command, including quoted/heredoc text, so a `gh repo delete` that a shell
+    # would actually execute (leading, sudo-prefixed, or after a separator)
+    # still denies.
+    '(^|[;&|[:space:]])gh repo delete'
+    '(^|[;&|[:space:]])gh repo archive'
+
+    # Force push to main/master (various flag forms)
+    'git push --force origin main'
+    'git push --force origin master'
+    'git push -f origin main'
+    'git push -f origin master'
+    'git push --force-with-lease origin main'
+    'git push --force-with-lease origin master'
+
+    # Filesystem destruction — anchored to a *real* root/home target so that a
+    # scoped path like `rm -rf /tmp/x` no longer trips the catastrophic rule,
+    # while root / home obliteration still denies. The left side of `rm` is
+    # deliberately NOT anchored, so a quoted payload such as `bash -c 'rm -rf /'`
+    # (root followed by a closing quote) still matches. The trailing class
+    # matches anything that is not a path-continuation character (so `/`, `/ `,
+    # `/*`, `/;`, `/'` all count as "root itself" but `/tmp` does not).
+    'rm[[:space:]]+-[a-zA-Z]*[rf][a-zA-Z]*[[:space:]]+/([^[:alnum:]._~/-]|$)'
+    'rm[[:space:]]+-[a-zA-Z]*[rf][a-zA-Z]*[[:space:]]+~([^[:alnum:]._~/-]|$)'
+    'rm[[:space:]]+-[a-zA-Z]*[rf][a-zA-Z]*[[:space:]]+\$HOME([^[:alnum:]._~/-]|$)'
+
+    # Fork bombs
+    ':\(\)\{ :\|:& \};:'
+
+    # Pipe to shell (supply chain risk)
+    'curl .* \| .*sh'
+    'curl .* \| bash'
+    'wget .* \| .*sh'
+    'wget .* -O- \| sh'
+
+    # Cloud infrastructure destruction. The aws forms below are specific
+    # multi-token phrases, so they stay in this raw substring scan. The az/gcloud
+    # CLIs, by contrast, need command-word anchoring — an unanchored `az.*delete`
+    # matches "h·az·ard … delete" across unrelated prose tokens — so they are
+    # handled by the segment-parsed lifecycle/cloud check further below, NOT here.
+    'aws s3 rm.*--recursive'
+    'aws s3 rb'
+    'aws ec2 terminate'
+    'aws iam delete'
+    'aws cloudformation delete-stack'
+
+    # Docker mass destruction
+    'docker system prune'
+
+    # NOTE: system-lifecycle commands (halt/reboot/poweroff/shutdown/init 0/
+    # init 6) are deliberately NOT in this raw substring scan. Even a
+    # whitespace-inclusive boundary anchor still fired inside ordinary prose
+    # ("...the box will halt", "...after a reboot event"), and a pure regex tweak
+    # can't separate `sudo halt` from `will halt` (both are "<word> halt"). They
+    # are handled by the segment-parsed check below, which denies only when a
+    # segment's *command word* is exactly the lifecycle word.
+)
+
+for pattern in "${ALWAYS_BLOCK_PATTERNS[@]}"; do
+    # EC2 terminate is a first-class teardown verb for cloud-management repos;
+    # let the cloud-CLI toggle downgrade it (deny -> pass to normal flow). The
+    # other catastrophic aws/docker patterns (iam delete, s3 rb, s3 recursive
+    # delete, cloudformation delete-stack, docker system prune) stay always-on.
+    if [[ "$pattern" == 'aws ec2 terminate' ]] && ! cloud_guard_enabled; then
+        continue
+    fi
+    if echo "$COMMAND" | grep -qiE "$pattern"; then
+        deny "BLOCKED: Command matches dangerous pattern: $pattern"
+    fi
+done
+
+# =============================================================================
+# COMMENT-STRIPPED WORKING COPY - used ONLY for the ASK-word and SQL DDL/DML
+# matches below, never for the catastrophic ALWAYS_BLOCK scan.
+#
+# Strips a `#…EOL` shell comment when the `#` is at start-of-line or preceded
+# by whitespace (the common comment shape), so a pattern word that appears only
+# in a trailing comment ("# drop database first", "# git push --force") no
+# longer trips the ASK/DDL gates. This is best-effort: a `#` inside a quoted
+# string that happens to be whitespace-preceded is also stripped, but since the
+# stripped copy is used only for the *narrowing* ASK/DDL matches (never the
+# catastrophic scan) the worst case is a missed ask on quoted data, never a
+# missed catastrophic block. The sed only runs when a `#` is actually present,
+# keeping it off the hot path.
+# =============================================================================
+if [[ "$COMMAND" == *"#"* ]]; then
+    COMMAND_NO_COMMENT=$(printf '%s\n' "$COMMAND" | sed -E 's/(^|[[:space:]])#.*$//')
+else
+    COMMAND_NO_COMMENT="$COMMAND"
+fi
+
+# =============================================================================
+# SYSTEM-LIFECYCLE + CLOUD-CLI DELETE (segment-parsed, command-word anchored)
+#
+# The system-lifecycle commands (halt/reboot/poweroff/shutdown/init 0/init 6)
+# and the az/gcloud cloud-delete CLIs are far too common as ordinary prose,
+# identifiers, and flag names to scan as unanchored substrings — and even a
+# whitespace-inclusive boundary anchor still fired inside comments and commit
+# messages. A pure regex tweak cannot separate `sudo halt` (a real command)
+# from `will halt` (prose) because both are "<word> halt".
+#
+# So we segment-parse instead, mirroring extract_rm_targets(): split the command
+# on ; | & && || and newline, strip a leading sudo/env wrapper from each segment,
+# and deny only when a segment's *command word* (first token) is exactly a
+# lifecycle word — or is `az`/`gcloud` with a `delete` subcommand token. This
+# distinguishes `sudo halt` (command word = halt) from `will halt` (command word
+# = echo/other) and from `--instance-initiated-shutdown-behavior` (not a command
+# word at all). The scan runs against COMMAND_NO_COMMENT so a lifecycle/cloud
+# word sitting in a trailing comment is already gone.
+# =============================================================================
+lifecycle_or_cloud_reason() {
+    # Emit a deny reason (one per line) for every segment whose command word is a
+    # system-lifecycle command or an az/gcloud delete. Portable awk only.
+    printf '%s' "$1" | awk '
+    {
+        gsub(/&&|\|\||[;|&]/, "\n")
+        n = split($0, segs, "\n")
+        for (i = 1; i <= n; i++) {
+            seg = segs[i]
+            sub(/^[ \t]+/, "", seg)
+            sub(/^sudo[ \t]+/, "", seg)
+            # Strip a leading `env` wrapper, then loop-strip the env flags and
+            # NAME=value assignments a shell resolves past before the command
+            # word, so `env FOO=bar halt` resolves to command word `halt` (not
+            # `FOO=bar`) and still denies. `env -i FOO=bar halt` and `env -u
+            # NAME halt` likewise resolve to `halt`. A bare `env halt` (no
+            # assignment) is unaffected — the loop matches nothing and leaves
+            # `halt` as the command word. Portable awk only (no GNU/BSD-specific
+            # escapes), consistent with extract_rm_targets().
+            if (sub(/^env([ \t]+|$)/, "", seg)) {
+                sub(/^[ \t]+/, "", seg)
+                stripped = 1
+                while (stripped) {
+                    stripped = 0
+                    if (sub(/^-u[ \t]+[^ \t]+([ \t]+|$)/, "", seg)) { stripped = 1; continue }
+                    if (sub(/^-i([ \t]+|$)/, "", seg))              { stripped = 1; continue }
+                    if (sub(/^--([ \t]+|$)/, "", seg))              { break }
+                    if (sub(/^[A-Za-z_][A-Za-z0-9_]*=[^ \t]*([ \t]+|$)/, "", seg)) { stripped = 1; continue }
+                }
+            }
+            sub(/^[ \t]+/, "", seg)
+            m = split(seg, toks, /[ \t]+/)
+            if (m == 0) continue
+            cmd = toks[1]
+            if (cmd == "halt" || cmd == "reboot" || cmd == "poweroff" || cmd == "shutdown") {
+                print "system lifecycle command: " cmd
+                continue
+            }
+            if (cmd == "init" && (toks[2] == "0" || toks[2] == "6")) {
+                print "system lifecycle command: init " toks[2]
+                continue
+            }
+            if (cmd == "az" || cmd == "gcloud") {
+                for (j = 2; j <= m; j++) {
+                    if (toks[j] == "delete") {
+                        print "cloud resource deletion: " cmd " delete"
+                        break
+                    }
+                }
+            }
+        }
+    }'
+}
+
+_LIFECYCLE_REASON=$(lifecycle_or_cloud_reason "$COMMAND_NO_COMMENT" | head -1)
+if [[ -n "$_LIFECYCLE_REASON" ]]; then
+    # Gate the cloud-delete portion behind the cloud toggle; lifecycle commands
+    # stay always-on.
+    if [[ "$_LIFECYCLE_REASON" == "cloud resource deletion:"* ]]; then
+        cloud_guard_enabled && deny "BLOCKED: $_LIFECYCLE_REASON"
+    else
+        deny "BLOCKED: $_LIFECYCLE_REASON"
+    fi
+fi
+
+# =============================================================================
+# DATABASE DESTRUCTION - Gated by the SQL DDL/DML guard toggle
+#
+# Kept separate from ALWAYS_BLOCK_PATTERNS so DB-engine repos can opt out
+# (guards.sqlDdl:false / REPO_GUARD_SQL=0). A single alternation grep matches
+# all four DDL statements in one pass (cheaper than a per-pattern loop), and
+# sql_guard_enabled() is consulted only after a match, so the config read stays
+# off the hot path.
+# =============================================================================
+SQL_DDL_PATTERN='DROP DATABASE|DROP TABLE|DROP SCHEMA|TRUNCATE TABLE'
+if echo "$COMMAND_NO_COMMENT" | grep -qiE "$SQL_DDL_PATTERN" && sql_guard_enabled; then
+    matched=$(echo "$COMMAND_NO_COMMENT" | grep -oiE "$SQL_DDL_PATTERN" | head -1)
+    deny "BLOCKED: Command matches dangerous pattern: ${matched:-SQL DDL statement}"
+fi
+
+# =============================================================================
+# rm -rf SCOPE CHECK - Block rm with recursive/force flags on protected paths
+#
+# Only *actual local* `rm` command words are inspected. `extract_rm_targets`
+# splits the command on ; | & && || and, for each simple-command segment whose
+# command word is `rm` (optionally sudo-prefixed) AND which carries a
+# recursive/force flag, emits the non-flag argument tokens. Consequences:
+#   - A token from an earlier command in the same line is never mis-read as an
+#     rm target — only tokens of a real `rm` segment are considered.
+#   - An `rm` inside a remote payload (`ssh host 'rm -rf /home/ubuntu/foo'`) is
+#     NOT treated as a local rm: the wrapper's command word is `ssh`/`scp`, not
+#     `rm`. The ALWAYS_BLOCK catastrophic patterns above still scan the whole
+#     string, so a remote or quoted `rm -rf /` still denies.
+#   - Only root, the user's $HOME, and *top-level* directories (/tmp, /var, /etc,
+#     /usr, /home, /opt, /bin, …) are blocked. A scoped subpath such as
+#     `rm -rf /tmp/whatever` or `rm -rf /var/foo` is allowed — the guard stops
+#     obliteration of a whole system/root directory, not cleanup of a subpath.
+# =============================================================================
+
+extract_rm_targets() {
+    # Emit one rm-target token per line for every local `rm -r/-f` invocation.
+    # Portable awk only (no GNU/BSD-specific escapes); replaces the shell
+    # separators with newlines, then inspects each simple command.
+    printf '%s' "$1" | awk '
+    {
+        gsub(/&&|\|\||[;|&]/, "\n")
+        n = split($0, segs, "\n")
+        for (i = 1; i <= n; i++) {
+            seg = segs[i]
+            sub(/^[ \t]+/, "", seg)
+            sub(/^sudo[ \t]+/, "", seg)
+            sub(/^[ \t]+/, "", seg)
+            if (seg !~ /^rm([ \t]|$)/) continue
+            m = split(seg, toks, /[ \t]+/)
+            has_rf = 0
+            for (j = 2; j <= m; j++)
+                if (toks[j] ~ /^-/ && toks[j] ~ /[rRfF]/) has_rf = 1
+            if (!has_rf) continue
+            for (j = 2; j <= m; j++) {
+                if (toks[j] == "") continue
+                if (toks[j] ~ /^-/) continue
+                print toks[j]
+            }
+        }
+    }'
+}
+
+normalize_abs_path() {
+    # Lexically normalize an ABSOLUTE path without touching the filesystem:
+    #   - collapse duplicate slashes    (//etc        -> /etc)
+    #   - drop "." segments             (/usr/./      -> /usr)
+    #   - resolve ".." segments         (/tmp/..      -> /,   /tmp/../etc -> /etc)
+    #   - ".." at or above root stays at root (/a/../../../etc -> /etc)
+    #   - strip trailing slash except bare root (/tmp/ -> /tmp)
+    # Pure-bash and portable: `realpath -m` is GNU-only and silently no-ops on
+    # macOS, so this MUST NOT rely on it. Without this normalization any
+    # `..`/`//`/`.` traversal (e.g. `rm -rf /tmp/..` -> `/`) would slip past the
+    # protected-path check below and wrongly ALLOW root/system-dir deletion.
+    local path="$1"
+    local seg
+    local -a parts=() out=()
+    local oldIFS="$IFS"
+    IFS='/'
+    read -r -a parts <<< "$path"
+    IFS="$oldIFS"
+    for seg in "${parts[@]}"; do
+        case "$seg" in
+            ''|'.')
+                : ;;                                    # skip empties (// or leading /) and "."
+            '..')
+                if [[ ${#out[@]} -gt 0 ]]; then
+                    out=("${out[@]:0:$(( ${#out[@]} - 1 ))}")   # pop last segment
+                fi
+                ;;                                       # ".." at/above root: stay at root
+            *)
+                out+=("$seg") ;;
+        esac
+    done
+    if [[ ${#out[@]} -eq 0 ]]; then
+        printf '/'
+    else
+        printf '/%s' "${out[@]}"
+    fi
+}
+
+# Cheap pre-check keeps awk off the hot path for the ~99% of commands that have
+# no recursive/force rm at all.
+if echo "$COMMAND" | grep -qE 'rm[[:space:]]+-[a-zA-Z]*[rf]'; then
+    RM_TARGETS=$(extract_rm_targets "$COMMAND" | head -20)
+
+    for target in $RM_TARGETS; do
+        # Skip empty targets
+        [[ -z "$target" ]] && continue
+
+        # Skip known-safe patterns (allowlist)
+        case "$target" in
+            node_modules|./node_modules|*/node_modules)
+                continue ;;
+            target|./target|*/target)
+                continue ;;
+            dist|./dist|*/dist)
+                continue ;;
+            build|./build|*/build)
+                continue ;;
+            .next|./.next|*/.next)
+                continue ;;
+            __pycache__|./__pycache__|*/__pycache__)
+                continue ;;
+            .pytest_cache|./.pytest_cache|*/.pytest_cache)
+                continue ;;
+            *.pyc)
+                continue ;;
+        esac
+
+        # Resolve path to absolute (raw — normalization happens next).
+        ABS_PATH=""
+        if [[ "$target" = /* ]]; then
+            ABS_PATH="$target"
+        elif [[ -n "$CWD" ]]; then
+            ABS_PATH="$CWD/$target"
+        fi
+
+        # Lexically normalize the absolute target BEFORE the protected-path
+        # check. This collapses //, resolves . and .., and strips trailing
+        # slashes, so traversal/normalization tricks cannot smuggle a
+        # root/system-dir deletion past the check below:
+        #   /tmp/..  -> /        //etc     -> /etc
+        #   /usr/./  -> /usr      /a/../../../etc -> /etc
+        # Done in pure shell because `realpath -m` is GNU-only (no-ops on macOS).
+        if [[ "$ABS_PATH" = /* ]]; then
+            ABS_PATH=$(normalize_abs_path "$ABS_PATH")
+        fi
+
+        # Block catastrophic targets only: root, the user's home directory, and
+        # any top-level directory (^/<one-segment>$ — covers /tmp, /home, /usr,
+        # /var, /etc, /opt, /bin, /lib, …). Deeper paths are allowed.
+        if [[ -n "$ABS_PATH" ]]; then
+            if [[ "$ABS_PATH" == "/" ]] || \
+               [[ -n "$HOME" && "$ABS_PATH" == "$HOME" ]] || \
+               [[ "$ABS_PATH" =~ ^/[^/]+$ ]]; then
+                deny "BLOCKED: rm on protected system path: $ABS_PATH"
+            fi
+        fi
+    done
+fi
+
+# =============================================================================
+# DELETE without WHERE - Database safety
+# =============================================================================
+
+# Gated by the SQL DDL/DML guard toggle. DB-engine repos opt out via
+# guards.sqlDdl:false or REPO_GUARD_SQL=0. sql_guard_enabled() is consulted only
+# after the DELETE-FROM-without-WHERE match, keeping the config read off the hot
+# path for non-SQL commands.
+if echo "$COMMAND_NO_COMMENT" | grep -qiE 'DELETE[[:space:]]+FROM[[:space:]]+' && \
+   ! echo "$COMMAND_NO_COMMENT" | grep -qiE 'WHERE[[:space:]]+'; then
+    sql_guard_enabled && deny "BLOCKED: DELETE FROM without WHERE clause"
+fi
+
+# =============================================================================
+# REQUIRE CONFIRMATION - Potentially dangerous but sometimes legitimate
+# =============================================================================
+
+ASK_PATTERNS=(
+    # Git destructive operations (not on main/master - those are blocked above)
+    'git push --force'
+    'git push -f '
+    'git reset --hard'
+    'git clean -fd'
+    'git checkout \.'
+    'git restore \.'
+
+    # GitHub operations that modify shared state
+    'gh pr close'
+    'gh issue close'
+    'gh release delete'
+    'gh label delete'
+
+    # Cloud CLI operations
+    'aws s3'
+    'aws ec2'
+    'aws lambda'
+
+    # Docker operations
+    'docker rm'
+    'docker rmi'
+    'docker stop'
+    'docker kill'
+    'docker restart'
+
+    # Service management
+    'systemctl restart'
+    'systemctl stop'
+    'systemctl disable'
+
+    # Kubernetes operations
+    'kubectl delete'
+    'kubectl rollout restart'
+    'kubectl drain'
+
+    # SkyPilot infrastructure
+    'sky down'
+    'sky stop'
+
+    # Credential exposure
+    'printenv.*SECRET'
+    'printenv.*TOKEN'
+    'printenv.*KEY'
+    'cat.*/\.ssh/'
+    'cat.*/\.aws/credentials'
+)
+
+for pattern in "${ASK_PATTERNS[@]}"; do
+    # When the cloud-CLI guard is toggled off, skip the broad aws/docker
+    # namespace asks (they fire on read-only describe/ls too). The credential-
+    # exposure and non-cloud asks below still apply.
+    case "$pattern" in
+        'aws s3'|'aws ec2'|'aws lambda'|'docker rm'|'docker rmi'|'docker stop'|'docker kill'|'docker restart')
+            cloud_guard_enabled || continue ;;
+    esac
+    if echo "$COMMAND_NO_COMMENT" | grep -qE "$pattern"; then
+        ask "Command requires confirmation: $COMMAND"
+    fi
+done
+
+# =============================================================================
+# ALLOW - Everything else passes through
+# =============================================================================
+
+exit 0

--- a/.loom/hooks/guard-loom-workflow.sh
+++ b/.loom/hooks/guard-loom-workflow.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+# guard-loom-workflow.sh - PreToolUse hook for Loom-workflow-specific Bash guards
+#
+# Claude Code PreToolUse hook that intercepts Bash commands before execution.
+# Receives JSON on stdin with tool_input.command and cwd fields.
+#
+# This hook carries ONLY the two Loom-workflow-specific guards that were
+# extracted from guard-destructive.sh (issue #3604):
+#
+#   1. LOOM: Prefer merge-pr.sh over 'gh pr merge'
+#   2. LOOM: Block 'pip install -e' inside worktrees (issue #2495)
+#
+# The generic repository-hygiene guards (catastrophic denies, SQL/cloud toggles,
+# ASK patterns) live in guard-destructive.sh and are being migrated toward Repo
+# Skills (rjwalters/repo#13). This file stays Loom-owned because both guards are
+# specific to the Loom worktree/merge workflow.
+#
+# IMPORTANT: This hook only fires when Claude Code is invoked with:
+#   --dangerously-skip-permissions  ← hooks FIRE (used by Loom agents)
+#
+# It does NOT fire with:
+#   --permission-mode bypassPermissions  ← hooks SKIPPED entirely
+#
+# Output format (Claude Code hooks spec):
+#   { "hookSpecificOutput": { "hookEventName": "PreToolUse", "permissionDecision": "deny|ask", "permissionDecisionReason": "..." } }
+#
+# NOTE: The "hookEventName": "PreToolUse" field is REQUIRED by Claude Code's
+# PreToolUse hook schema. Without it, Claude Code silently discards the
+# decision and the guard becomes inert (see issue #3550).
+#
+# Error handling: This script MUST never exit with a non-zero code or produce
+# invalid output. Any internal error is caught by the trap, logged for
+# diagnostics, and results in an "allow" decision to prevent infinite retry
+# loops in Claude Code.
+
+# Determine log directory relative to this script's location
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd 2>/dev/null || echo ".")"
+HOOK_ERROR_LOG="${SCRIPT_DIR}/../logs/hook-errors.log"
+
+# Log a diagnostic error message (best-effort, never fails the script)
+log_hook_error() {
+    local msg="$1"
+    # Ensure log directory exists
+    mkdir -p "$(dirname "$HOOK_ERROR_LOG")" 2>/dev/null || true
+    echo "[$(date -u '+%Y-%m-%dT%H:%M:%SZ')] [guard-loom-workflow] $msg" >> "$HOOK_ERROR_LOG" 2>/dev/null || true
+}
+
+# Top-level error trap: on ANY unexpected error, output valid JSON "allow"
+# and log the failure for debugging. This prevents Claude Code from showing
+# "PreToolUse:Bash hook error" which causes infinite retry loops.
+trap 'log_hook_error "Unexpected error on line ${LINENO}: ${BASH_COMMAND:-unknown} (exit=$?)"; exit 0' ERR
+
+# Read stdin safely — if cat or jq fails, the ERR trap fires and we allow
+INPUT=$(cat 2>/dev/null) || INPUT=""
+
+# Verify jq is available before attempting to parse
+if ! command -v jq &>/dev/null; then
+    log_hook_error "jq not found in PATH — allowing command (cannot parse input)"
+    exit 0
+fi
+
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null) || COMMAND=""
+CWD=$(echo "$INPUT" | jq -r '.cwd // empty' 2>/dev/null) || CWD=""
+
+# If no command to check, allow
+if [[ -z "$COMMAND" ]]; then
+    exit 0
+fi
+
+# Resolve repo root from cwd (handles worktree paths safely)
+REPO_ROOT=""
+if [[ -n "$CWD" ]] && [[ -d "$CWD" ]]; then
+    REPO_ROOT=$(git -C "$CWD" rev-parse --show-toplevel 2>/dev/null || true)
+elif [[ -n "$CWD" ]]; then
+    # CWD doesn't exist (e.g., deleted worktree) — log but continue without repo root
+    log_hook_error "cwd does not exist: $CWD — skipping repo root resolution"
+fi
+
+# Helper: output a deny decision and exit
+deny() {
+    local reason="$1"
+    if jq -n --arg reason "$reason" '{
+        hookSpecificOutput: {
+            hookEventName: "PreToolUse",
+            permissionDecision: "deny",
+            permissionDecisionReason: $reason
+        }
+    }' 2>/dev/null; then
+        exit 0
+    fi
+    # jq failed — emit raw JSON as fallback
+    local escaped_reason
+    escaped_reason=$(echo "$reason" | sed 's/\\/\\\\/g; s/"/\\"/g; s/\t/\\t/g; s/\n/\\n/g')
+    echo "{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"permissionDecision\":\"deny\",\"permissionDecisionReason\":\"${escaped_reason}\"}}"
+    exit 0
+}
+
+# Helper: output an ask decision and exit
+ask() {
+    local reason="$1"
+    if jq -n --arg reason "$reason" '{
+        hookSpecificOutput: {
+            hookEventName: "PreToolUse",
+            permissionDecision: "ask",
+            permissionDecisionReason: $reason
+        }
+    }' 2>/dev/null; then
+        exit 0
+    fi
+    # jq failed — emit raw JSON as fallback
+    local escaped_reason
+    escaped_reason=$(echo "$reason" | sed 's/\\/\\\\/g; s/"/\\"/g; s/\t/\\t/g; s/\n/\\n/g')
+    echo "{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"permissionDecision\":\"ask\",\"permissionDecisionReason\":\"${escaped_reason}\"}}"
+    exit 0
+}
+
+# =============================================================================
+# LOOM: Prefer merge-pr.sh over gh pr merge
+# =============================================================================
+
+if echo "$COMMAND" | grep -qE 'gh\s+pr\s+merge'; then
+    # Resolve the merge-pr.sh path for the current repo context. Prefer an
+    # in-repo installed copy (./.loom/scripts/merge-pr.sh); fall back to the
+    # loom-checkout copy under defaults/scripts/ (via $LOOM_HOME) when the repo
+    # runs scripts directly from the checkout rather than an installed copy.
+    MERGE_SCRIPT="./.loom/scripts/merge-pr.sh"
+    if [[ -n "$REPO_ROOT" ]] && [[ ! -x "$REPO_ROOT/.loom/scripts/merge-pr.sh" ]]; then
+        if [[ -n "${LOOM_HOME:-}" ]] && [[ -x "$LOOM_HOME/defaults/scripts/merge-pr.sh" ]]; then
+            MERGE_SCRIPT="$LOOM_HOME/defaults/scripts/merge-pr.sh"
+        elif [[ -x "$REPO_ROOT/defaults/scripts/merge-pr.sh" ]]; then
+            MERGE_SCRIPT="$REPO_ROOT/defaults/scripts/merge-pr.sh"
+        fi
+    fi
+    deny "Use $MERGE_SCRIPT <PR_NUMBER> instead of 'gh pr merge'. The script merges via the GitHub API without local checkout, which avoids worktree errors."
+fi
+
+# =============================================================================
+# LOOM: Block pip install -e inside worktrees (issue #2495)
+#
+# Editable pip installs overwrite a global .pth file in site-packages.
+# When multiple builders run in parallel worktrees, each 'pip install -e .'
+# clobbers the .pth to point at its own worktree, causing all other Python
+# processes to import from the wrong source tree.
+#
+# PYTHONPATH is already set by agent-spawn.sh and _build_worktree_env()
+# so editable installs are unnecessary inside worktrees.
+# =============================================================================
+
+WORKTREE_PATH="${LOOM_WORKTREE_PATH:-}"
+if [[ -n "$WORKTREE_PATH" ]]; then
+    if echo "$COMMAND" | grep -qE '(pip|pip3|uv pip)\s+install\s+.*-e\s' || \
+       echo "$COMMAND" | grep -qE '(pip|pip3|uv pip)\s+install\s+.*--editable\s'; then
+        deny "BLOCKED: 'pip install -e' is not allowed inside worktrees. Editable installs overwrite the global .pth file, breaking parallel builders (see issue #2495). PYTHONPATH is already configured for this worktree — imports resolve correctly without editable installs."
+    fi
+fi
+
+# =============================================================================
+# ALLOW - Everything else passes through
+# =============================================================================
+
+exit 0

--- a/proofs/Proofs/Erdos1026OQ05Mirsky.lean
+++ b/proofs/Proofs/Erdos1026OQ05Mirsky.lean
@@ -1,0 +1,311 @@
+/-
+# erdos-1026-oq-05 (Mirsky companion): the matching UPPER bound on monotonic decompositions
+
+`Erdos1026OQ05.lean` proves the elementary Mirsky/Dilworth **lower** bound
+
+    n ≤ numParts · max (LIS seq) (LDS seq)
+
+and brackets the optimal part count `minMonotonicParts seq ∈ [n / max(LIS,LDS), n]`, leaving the
+matching upper bound open (only the crude `≤ n` from the singleton decomposition was available).
+
+This file supplies the matching **upper** bound — the constructive (Mirsky) half — for sequences
+of *distinct* reals:
+
+    minMonotonicParts seq ≤ LDS seq                (`minMonotonicParts_le_LDS`)
+    minMonotonicParts seq ≤ LIS seq                (`minMonotonicParts_le_LIS`)
+    minMonotonicParts seq ≤ min (LIS seq) (LDS seq) (`minMonotonicParts_le_min`)
+
+so together with the lower bound the optimal part count is now bracketed in
+
+    [ n / max(LIS,LDS) , min(LIS,LDS) ]            (`minMonotonicParts_sharp_bracket`).
+
+For the Erdős–Szekeres extremal sequences (where `LIS ≈ LDS ≈ √n`) this pins
+`minMonotonicParts ≈ √n`, matching the lower bound.
+
+**Construction (Mirsky, avoiding general Dilworth — which Mathlib lacks).**  Colour each index `i`
+by `rank i = ` the length of the longest strictly-*decreasing* subsequence ending at `i`.  Two facts
+drive everything:
+
+* `rank i ∈ [1, LDS seq]` — a decreasing run ending at `i` is a decreasing subsequence.
+* **equal colour ⇒ increasing**: if `seq` is injective, `i < j` and `rank i = rank j`, then
+  `seq i < seq j`.  (If instead `seq j < seq i`, appending `j` to a maximal decreasing run ending at
+  `i` yields a strictly longer one ending at `j`, forcing `rank j > rank i`.)
+
+Hence each colour class is a strictly-increasing subsequence, and there are at most `LDS seq`
+non-empty classes, giving a monotonic decomposition into `≤ LDS` parts.  The `LIS` bound follows by
+negating the sequence (which swaps increasing/decreasing and hence `LIS ↔ LDS`).
+
+No axioms, no sorries.
+-/
+
+import Mathlib
+import Proofs.Erdos1026OQ05
+
+open Finset
+
+namespace Erdos1026OQ05
+
+variable {n : ℕ}
+
+/-! ## The rank colouring: longest strictly-decreasing run ending at `i` -/
+
+/-- The set of achievable lengths of strictly-decreasing runs ending at index `i`: a run is a
+finite set `T` of indices with maximum `i` on which `seq` is strictly antitone (i.e. `seq`
+strictly decreases along increasing indices). -/
+def decRunsEndingAt (seq : RealSeq n) (i : Fin n) : Set ℕ :=
+  {c | ∃ T : Finset (Fin n), c = T.card ∧ i ∈ T ∧ (∀ a ∈ T, a ≤ i) ∧
+        StrictAntiOn seq (T : Set (Fin n))}
+
+/-- The colour of index `i`: the length of the longest strictly-decreasing run ending at `i`. -/
+noncomputable def rank (seq : RealSeq n) (i : Fin n) : ℕ := sSup (decRunsEndingAt seq i)
+
+/-- The singleton run `{i}` shows `decRunsEndingAt` is nonempty (and `rank ≥ 1`). -/
+lemma one_mem_decRunsEndingAt (seq : RealSeq n) (i : Fin n) : 1 ∈ decRunsEndingAt seq i := by
+  refine ⟨{i}, ?_, ?_, ?_, ?_⟩
+  · simp
+  · simp
+  · intro a ha; simp only [Finset.mem_singleton] at ha; exact le_of_eq ha
+  · intro a ha b hb hab
+    simp only [Finset.coe_singleton, Set.mem_singleton_iff] at ha hb
+    exact absurd (ha.trans hb.symm) (ne_of_lt hab)
+
+lemma decRunsEndingAt_nonempty (seq : RealSeq n) (i : Fin n) :
+    (decRunsEndingAt seq i).Nonempty :=
+  ⟨1, one_mem_decRunsEndingAt seq i⟩
+
+/-- Every decreasing run has length at most `n`, so the length set is bounded above. -/
+lemma decRunsEndingAt_bddAbove (seq : RealSeq n) (i : Fin n) :
+    BddAbove (decRunsEndingAt seq i) := by
+  refine ⟨n, ?_⟩
+  rintro c ⟨T, rfl, -, -, -⟩
+  calc T.card ≤ Fintype.card (Fin n) := Finset.card_le_univ T
+    _ = n := Fintype.card_fin n
+
+/-- The maximal decreasing run length is realised by an actual run `T`. -/
+lemma rank_mem (seq : RealSeq n) (i : Fin n) : rank seq i ∈ decRunsEndingAt seq i :=
+  Nat.sSup_mem (decRunsEndingAt_nonempty seq i) (decRunsEndingAt_bddAbove seq i)
+
+/-- `1 ≤ rank i`. -/
+lemma one_le_rank (seq : RealSeq n) (i : Fin n) : 1 ≤ rank seq i :=
+  le_csSup (decRunsEndingAt_bddAbove seq i) (one_mem_decRunsEndingAt seq i)
+
+/-- A strictly-antitone finite index set is (the index range of) a decreasing subsequence, hence
+has length at most `LDS seq`. -/
+lemma card_le_LDS_of_strictAntiOn (seq : RealSeq n) {T : Finset (Fin n)}
+    (hT : StrictAntiOn seq (T : Set (Fin n))) : T.card ≤ LDS seq := by
+  -- Enumerate `T` in increasing index order; the resulting subsequence is decreasing.
+  let idx : Fin T.card → Fin n := T.orderEmbOfFin rfl
+  have hmono : StrictMono idx := (T.orderEmbOfFin rfl).strictMono
+  refine len_le_LDS_of_decreasing (sub := ⟨idx, hmono⟩) ?_
+  intro a b hab
+  have hmemA : idx a ∈ T := T.orderEmbOfFin_mem rfl a
+  have hmemB : idx b ∈ T := T.orderEmbOfFin_mem rfl b
+  exact hT hmemA hmemB (hmono hab)
+
+/-- **Colour bound.** `rank i ≤ LDS seq`. -/
+lemma rank_le_LDS (seq : RealSeq n) (i : Fin n) : rank seq i ≤ LDS seq := by
+  refine csSup_le (decRunsEndingAt_nonempty seq i) ?_
+  rintro c ⟨T, rfl, -, -, hanti⟩
+  exact card_le_LDS_of_strictAntiOn seq hanti
+
+/-! ## Equal colour ⇒ strictly increasing (the heart of the argument) -/
+
+/-- **Key lemma.** For a sequence of distinct reals, two indices with the same colour appear in
+increasing value order: `i < j` and `rank i = rank j` force `seq i < seq j`.
+
+If instead `seq j < seq i`, append `j` to a maximal decreasing run ending at `i`: since every index
+of that run is `≤ i < j` and its values all dominate `seq i > seq j`, the extended set is a longer
+decreasing run ending at `j`, so `rank j ≥ rank i + 1`, contradicting `rank i = rank j`. -/
+theorem seq_lt_of_rank_eq (seq : RealSeq n) (hinj : Function.Injective seq)
+    {i j : Fin n} (hij : i < j) (hrank : rank seq i = rank seq j) : seq i < seq j := by
+  rcases lt_trichotomy (seq i) (seq j) with hlt | heq | hgt
+  · exact hlt
+  · exact absurd (hinj heq) (ne_of_lt hij)
+  · -- The impossible case `seq j < seq i`.
+    exfalso
+    obtain ⟨T, hcard, hiT, hmax, hanti⟩ := rank_mem seq i
+    -- Every value in the run dominates `seq i`.
+    have hdom : ∀ a ∈ T, seq i ≤ seq a := by
+      intro a ha
+      rcases eq_or_lt_of_le (hmax a ha) with h | h
+      · exact le_of_eq (by rw [h])
+      · exact le_of_lt (hanti ha hiT h)
+    -- `j` is above the whole run in index.
+    have hjT : j ∉ T := fun hj => absurd (hmax j hj) (not_le.mpr hij)
+    set T' := insert j T with hT'
+    -- `T'` is a decreasing run ending at `j` of length `rank i + 1`.
+    have hcard' : T'.card = rank seq i + 1 := by
+      rw [hT', Finset.card_insert_of_not_mem hjT, hcard]
+    have hmax' : ∀ a ∈ T', a ≤ j := by
+      intro a ha
+      rcases Finset.mem_insert.mp ha with rfl | ha
+      · exact le_refl a
+      · exact le_of_lt (lt_of_le_of_lt (hmax a ha) hij)
+    have hanti' : StrictAntiOn seq (T' : Set (Fin n)) := by
+      intro a ha b hb hab
+      simp only [hT', Finset.coe_insert, Set.mem_insert_iff] at ha hb
+      rcases hb with rfl | hbT
+      · -- `b = j` is the top; `a < j` forces `a ∈ T`, and every run value dominates `seq i > seq j`.
+        rcases ha with rfl | haT
+        · exact absurd hab (lt_irrefl _)
+        · exact lt_of_lt_of_le hgt (hdom a haT)
+      · rcases ha with rfl | haT
+        · -- `a = j` with `j < b ≤ i < j` is impossible.
+          exact absurd (lt_of_le_of_lt (hmax b hbT) hij) (lt_asymm hab)
+        · exact hanti haT hbT hab
+    have hmemj : rank seq i + 1 ∈ decRunsEndingAt seq j :=
+      ⟨T', hcard'.symm, Finset.mem_insert_self j T, hmax', hanti'⟩
+    have : rank seq i + 1 ≤ rank seq j :=
+      le_csSup (decRunsEndingAt_bddAbove seq j) hmemj
+    omega
+
+/-! ## Assembling the colour classes into a monotonic decomposition -/
+
+section Construction
+
+variable (seq : RealSeq n) (hinj : Function.Injective seq)
+
+/-- Colour class `k`: the indices whose rank is `k + 1`.  Ranks run over `1 … LDS seq`, so classes
+are indexed by `Fin (LDS seq)`. -/
+def colourClass (k : Fin (LDS seq)) : Finset (Fin n) :=
+  Finset.univ.filter (fun i => rank seq i = k.val + 1)
+
+lemma mem_colourClass {k : Fin (LDS seq)} {i : Fin n} :
+    i ∈ colourClass seq k ↔ rank seq i = k.val + 1 := by
+  simp [colourClass]
+
+/-- **The Mirsky decomposition.**  One strictly-increasing part per colour class; there are
+`LDS seq` classes.  Increasing-ness of a class is exactly `seq_lt_of_rank_eq`. -/
+noncomputable def mirskyDecomposition : MonotonicDecomposition n seq where
+  numParts := LDS seq
+  parts := fun k => ⟨(colourClass seq k).card,
+    ⟨(colourClass seq k).orderEmbOfFin rfl, ((colourClass seq k).orderEmbOfFin rfl).strictMono⟩⟩
+  monotonic := by
+    intro k
+    left
+    intro p q hpq
+    have hlt : (colourClass seq k).orderEmbOfFin rfl p < (colourClass seq k).orderEmbOfFin rfl q :=
+      ((colourClass seq k).orderEmbOfFin rfl).strictMono hpq
+    have hmp := (colourClass seq k).orderEmbOfFin_mem rfl p
+    have hmq := (colourClass seq k).orderEmbOfFin_mem rfl q
+    rw [mem_colourClass] at hmp hmq
+    exact seq_lt_of_rank_eq seq hinj hlt (hmp.trans hmq.symm)
+  disjoint := by
+    intro a b p q hab hEq
+    have hm1 := (colourClass seq a).orderEmbOfFin_mem rfl p
+    have hm2 := (colourClass seq b).orderEmbOfFin_mem rfl q
+    rw [mem_colourClass] at hm1 hm2
+    rw [hEq] at hm1
+    rw [hm1] at hm2
+    exact hab (Fin.ext (by omega))
+  covering := by
+    intro i
+    have hge := one_le_rank seq i
+    have hle := rank_le_LDS seq i
+    refine ⟨⟨rank seq i - 1, by omega⟩, ?_⟩
+    have hmem : i ∈ colourClass seq ⟨rank seq i - 1, by omega⟩ := by
+      rw [mem_colourClass]; omega
+    have hi : i ∈ Set.range ⇑((colourClass seq ⟨rank seq i - 1, by omega⟩).orderEmbOfFin rfl) := by
+      rw [Finset.range_orderEmbOfFin]; exact hmem
+    obtain ⟨pos, hpos⟩ := hi
+    exact ⟨pos.val, pos.isLt, by simpa using hpos⟩
+
+/-- **Mirsky upper bound.**  For a sequence of distinct reals, the minimum number of monotone parts
+is at most the longest strictly-decreasing subsequence length. -/
+theorem minMonotonicParts_le_LDS : minMonotonicParts seq ≤ LDS seq := by
+  apply Nat.sInf_le
+  exact ⟨mirskyDecomposition seq hinj, rfl⟩
+
+end Construction
+
+/-! ## The `LIS` bound by negation symmetry, and the sharp bracket -/
+
+/-- The negated sequence, whose increasing/decreasing runs are swapped. -/
+def negSeq (seq : RealSeq n) : RealSeq n := fun i => - seq i
+
+lemma isDecreasing_negSeq (seq : RealSeq n) {m : ℕ} (sub : Subsequence n m) :
+    IsDecreasing (negSeq seq) sub ↔ IsIncreasing seq sub := by
+  constructor
+  · intro h a b hab
+    have := h a b hab
+    simpa [negSeq, neg_lt_neg_iff] using this
+  · intro h a b hab
+    have := h hab
+    simpa [negSeq, neg_lt_neg_iff] using this
+
+lemma isIncreasing_negSeq (seq : RealSeq n) {m : ℕ} (sub : Subsequence n m) :
+    IsIncreasing (negSeq seq) sub ↔ IsDecreasing seq sub := by
+  constructor
+  · intro h a b hab
+    have := h hab
+    simpa [negSeq, neg_lt_neg_iff] using this
+  · intro h a b hab
+    have := h a b hab
+    simpa [negSeq, neg_lt_neg_iff] using this
+
+lemma isMonotonic_negSeq (seq : RealSeq n) {m : ℕ} (sub : Subsequence n m) :
+    IsMonotonic (negSeq seq) sub ↔ IsMonotonic seq sub := by
+  unfold IsMonotonic
+  rw [isIncreasing_negSeq, isDecreasing_negSeq, or_comm]
+
+/-- A monotonic decomposition of `seq` is one of `negSeq seq` (same parts). -/
+def negSeqDecomposition (seq : RealSeq n) (D : MonotonicDecomposition n seq) :
+    MonotonicDecomposition n (negSeq seq) where
+  numParts := D.numParts
+  parts := D.parts
+  monotonic := fun i => (isMonotonic_negSeq seq (D.parts i).2).mpr (D.monotonic i)
+  disjoint := D.disjoint
+  covering := D.covering
+
+/-- …and conversely. -/
+def negSeqDecomposition' (seq : RealSeq n) (D : MonotonicDecomposition n (negSeq seq)) :
+    MonotonicDecomposition n seq where
+  numParts := D.numParts
+  parts := D.parts
+  monotonic := fun i => (isMonotonic_negSeq seq (D.parts i).2).mp (D.monotonic i)
+  disjoint := D.disjoint
+  covering := D.covering
+
+lemma minMonotonicParts_negSeq (seq : RealSeq n) :
+    minMonotonicParts (negSeq seq) = minMonotonicParts seq := by
+  unfold minMonotonicParts
+  congr 1
+  ext p
+  constructor
+  · rintro ⟨D, rfl⟩; exact ⟨negSeqDecomposition' seq D, rfl⟩
+  · rintro ⟨D, rfl⟩; exact ⟨negSeqDecomposition seq D, rfl⟩
+
+lemma LDS_negSeq (seq : RealSeq n) : LDS (negSeq seq) = LIS seq := by
+  unfold LDS LIS
+  congr 1
+  ext m
+  constructor
+  · rintro ⟨sub, h⟩; exact ⟨sub, (isDecreasing_negSeq seq sub).mp h⟩
+  · rintro ⟨sub, h⟩; exact ⟨sub, (isDecreasing_negSeq seq sub).mpr h⟩
+
+/-- **Mirsky upper bound, `LIS` form.**  By negation symmetry, `≤ LIS seq` too. -/
+theorem minMonotonicParts_le_LIS (seq : RealSeq n) (hinj : Function.Injective seq) :
+    minMonotonicParts seq ≤ LIS seq := by
+  have hinj' : Function.Injective (negSeq seq) := fun a b h => hinj (neg_injective h)
+  calc minMonotonicParts seq = minMonotonicParts (negSeq seq) := (minMonotonicParts_negSeq seq).symm
+    _ ≤ LDS (negSeq seq) := minMonotonicParts_le_LDS (negSeq seq) hinj'
+    _ = LIS seq := LDS_negSeq seq
+
+/-- **Matching upper bound.**  `minMonotonicParts seq ≤ min (LIS seq) (LDS seq)`. -/
+theorem minMonotonicParts_le_min (seq : RealSeq n) (hinj : Function.Injective seq) :
+    minMonotonicParts seq ≤ min (LIS seq) (LDS seq) :=
+  le_min (minMonotonicParts_le_LIS seq hinj) (minMonotonicParts_le_LDS seq hinj)
+
+/-- **The sharp bracket.**  Combining the elementary Mirsky/Dilworth lower bound
+(`minMonotonicParts_ge`) with the constructive upper bound proved here, the optimal number of
+monotone parts of a sequence of distinct reals lies in
+
+    [ n / max(LIS, LDS) , min(LIS, LDS) ].
+
+For the Erdős–Szekeres extremal sequences (`LIS ≈ LDS ≈ √n`) both ends are `≈ √n`. -/
+theorem minMonotonicParts_sharp_bracket (seq : RealSeq n) (hinj : Function.Injective seq) :
+    n / max (LIS seq) (LDS seq) ≤ minMonotonicParts seq ∧
+      minMonotonicParts seq ≤ min (LIS seq) (LDS seq) :=
+  ⟨minMonotonicParts_ge seq, minMonotonicParts_le_min seq hinj⟩
+
+end Erdos1026OQ05

--- a/proofs/Proofs/ScratchMRCEq.lean
+++ b/proofs/Proofs/ScratchMRCEq.lean
@@ -1,0 +1,121 @@
+import Mathlib
+
+open Finset
+
+namespace ScratchMRCEq
+
+/-- Lagrange / Binet–Cauchy identity for finite sums of reals. -/
+theorem lagrange_sum_identity {ι : Type*} (s : Finset ι) (f g : ι → ℝ) :
+    ∑ i ∈ s, ∑ j ∈ s, (f i * g j - f j * g i) ^ 2
+      = 2 * ((∑ i ∈ s, f i ^ 2) * (∑ j ∈ s, g j ^ 2) - (∑ i ∈ s, f i * g i) ^ 2) := by
+  have hP1 : ∑ i ∈ s, ∑ j ∈ s, f i ^ 2 * g j ^ 2
+      = (∑ i ∈ s, f i ^ 2) * (∑ j ∈ s, g j ^ 2) := (Finset.sum_mul_sum s s _ _).symm
+  have hP2 : ∑ i ∈ s, ∑ j ∈ s, f j ^ 2 * g i ^ 2
+      = (∑ i ∈ s, f i ^ 2) * (∑ j ∈ s, g j ^ 2) := by
+    rw [Finset.sum_comm, ← Finset.sum_mul_sum]
+  have hP3 : ∑ i ∈ s, ∑ j ∈ s, (f i * g i) * (f j * g j)
+      = (∑ i ∈ s, f i * g i) ^ 2 := by
+    rw [← Finset.sum_mul_sum, ← pow_two]
+  calc ∑ i ∈ s, ∑ j ∈ s, (f i * g j - f j * g i) ^ 2
+      = ∑ i ∈ s, ∑ j ∈ s,
+          (f i ^ 2 * g j ^ 2 + f j ^ 2 * g i ^ 2 - 2 * ((f i * g i) * (f j * g j))) := by
+        refine Finset.sum_congr rfl fun i _ => Finset.sum_congr rfl fun j _ => ?_
+        ring
+    _ = (∑ i ∈ s, ∑ j ∈ s, f i ^ 2 * g j ^ 2)
+          + (∑ i ∈ s, ∑ j ∈ s, f j ^ 2 * g i ^ 2)
+          - 2 * (∑ i ∈ s, ∑ j ∈ s, (f i * g i) * (f j * g j)) := by
+        simp_rw [Finset.sum_sub_distrib, Finset.sum_add_distrib, Finset.mul_sum]
+    _ = 2 * ((∑ i ∈ s, f i ^ 2) * (∑ j ∈ s, g j ^ 2) - (∑ i ∈ s, f i * g i) ^ 2) := by
+        rw [hP1, hP2, hP3]; ring
+
+/-- **Cauchy–Schwarz equality characterization (finite sums).**  For real sequences `f, g`
+on a finite index set, the Cauchy–Schwarz inequality holds with *equality*,
+`(∑ᵢ fᵢgᵢ)² = (∑ᵢ fᵢ²)(∑ⱼ gⱼ²)`, if and only if every 2×2 minor vanishes,
+`fᵢgⱼ = fⱼgᵢ` for all `i, j` — i.e. the vectors `f` and `g` are proportional. -/
+theorem cauchy_schwarz_eq_iff {ι : Type*} (s : Finset ι) (f g : ι → ℝ) :
+    (∑ i ∈ s, f i * g i) ^ 2 = (∑ i ∈ s, f i ^ 2) * (∑ j ∈ s, g j ^ 2) ↔
+      ∀ i ∈ s, ∀ j ∈ s, f i * g j = f j * g i := by
+  have hL := lagrange_sum_identity s f g
+  constructor
+  · intro heq
+    have hzero : ∑ i ∈ s, ∑ j ∈ s, (f i * g j - f j * g i) ^ 2 = 0 := by
+      rw [hL, heq]; ring
+    have hnonneg : ∀ i ∈ s, 0 ≤ ∑ j ∈ s, (f i * g j - f j * g i) ^ 2 :=
+      fun i _ => Finset.sum_nonneg fun j _ => sq_nonneg _
+    have houter := (Finset.sum_eq_zero_iff_of_nonneg hnonneg).mp hzero
+    intro i hi j hj
+    have hinner := (Finset.sum_eq_zero_iff_of_nonneg
+      (fun j _ => sq_nonneg (f i * g j - f j * g i))).mp (houter i hi)
+    have hterm : f i * g j - f j * g i = 0 := sq_eq_zero_iff.mp (hinner j hj)
+    linarith [hterm]
+  · intro h
+    have hzero : ∑ i ∈ s, ∑ j ∈ s, (f i * g j - f j * g i) ^ 2 = 0 := by
+      refine Finset.sum_eq_zero fun i hi => Finset.sum_eq_zero fun j hj => ?_
+      rw [h i hi j hj]; ring
+    rw [hzero] at hL
+    linarith [hL]
+
+/-- **Sharp Cauchy–Schwarz equality case of the MRC signal bound.**  For deterministic gains
+`a`, signal amplitudes `sig`, and strictly positive branch noise variances `v`, the
+maximal-ratio-combining bound `mrc_signal_sq_le` holds with *equality*,
+
+    (∑ᵢ aᵢ·sigᵢ)² = (∑ᵢ aᵢ²·vᵢ) · (∑ᵢ sigᵢ²/vᵢ),
+
+*if and only if* the gain vector is proportional to the matched-filter vector `sigᵢ/vᵢ`,
+expressed cross-multiplied as `aᵢ·vᵢ·sigⱼ = aⱼ·vⱼ·sigᵢ` for all `i, j ∈ s`.  This identifies
+the MRC optimum as exactly the *matched ray* `{a : aᵢ ∝ sigᵢ/vᵢ}`, sharpening `mrc_snr_le`
+(a bare inequality) and generalizing `mrc_snr_matched` (the single point `aᵢ = sigᵢ/vᵢ`).
+The engine is the Lagrange/Binet–Cauchy identity `lagrange_sum_identity` applied to the
+Cauchy–Schwarz split `aᵢsigᵢ = (aᵢ√vᵢ)·(sigᵢ/√vᵢ)`. -/
+theorem mrc_signal_sq_eq_iff {ι : Type*} (s : Finset ι) (a sig v : ι → ℝ)
+    (hv : ∀ i ∈ s, 0 < v i) :
+    (∑ i ∈ s, a i * sig i) ^ 2 = (∑ i ∈ s, a i ^ 2 * v i) * (∑ i ∈ s, sig i ^ 2 / v i) ↔
+      ∀ i ∈ s, ∀ j ∈ s, a i * v i * sig j = a j * v j * sig i := by
+  have e1 : ∀ i ∈ s, (a i * Real.sqrt (v i)) * (sig i / Real.sqrt (v i)) = a i * sig i := by
+    intro i hi
+    have hne : Real.sqrt (v i) ≠ 0 := Real.sqrt_ne_zero'.mpr (hv i hi)
+    field_simp
+  have e2 : ∀ i ∈ s, (a i * Real.sqrt (v i)) ^ 2 = a i ^ 2 * v i := by
+    intro i hi; rw [mul_pow, Real.sq_sqrt (hv i hi).le]
+  have e3 : ∀ i ∈ s, (sig i / Real.sqrt (v i)) ^ 2 = sig i ^ 2 / v i := by
+    intro i hi; rw [div_pow, Real.sq_sqrt (hv i hi).le]
+  rw [show (∑ i ∈ s, a i * sig i)
+        = ∑ i ∈ s, (a i * Real.sqrt (v i)) * (sig i / Real.sqrt (v i))
+        from (Finset.sum_congr rfl e1).symm,
+      show (∑ i ∈ s, a i ^ 2 * v i) = ∑ i ∈ s, (a i * Real.sqrt (v i)) ^ 2
+        from (Finset.sum_congr rfl e2).symm,
+      show (∑ i ∈ s, sig i ^ 2 / v i) = ∑ j ∈ s, (sig j / Real.sqrt (v j)) ^ 2
+        from (Finset.sum_congr rfl e3).symm,
+      cauchy_schwarz_eq_iff s (fun i => a i * Real.sqrt (v i))
+        (fun i => sig i / Real.sqrt (v i))]
+  dsimp only
+  refine forall_congr' fun i => imp_congr_right fun hi => forall_congr' fun j =>
+    imp_congr_right fun hj => ?_
+  have hxx : Real.sqrt (v i) * Real.sqrt (v i) = v i := Real.mul_self_sqrt (hv i hi).le
+  have hyy : Real.sqrt (v j) * Real.sqrt (v j) = v j := Real.mul_self_sqrt (hv j hj).le
+  have hxne : Real.sqrt (v i) ≠ 0 := Real.sqrt_ne_zero'.mpr (hv i hi)
+  have hyne : Real.sqrt (v j) ≠ 0 := Real.sqrt_ne_zero'.mpr (hv j hj)
+  constructor
+  · intro h
+    rw [← mul_div_assoc, ← mul_div_assoc, div_eq_div_iff hyne hxne] at h
+    linear_combination h - (a i * sig j) * hxx + (a j * sig i) * hyy
+  · intro h
+    rw [← mul_div_assoc, ← mul_div_assoc, div_eq_div_iff hyne hxne]
+    linear_combination h + (a i * sig j) * hxx - (a j * sig i) * hyy
+
+/-- **MRC matched-ray achievability.**  Every gain vector on the matched ray, `aᵢ = c·sigᵢ/vᵢ`
+for a scalar `c`, attains the Cauchy–Schwarz equality in the MRC signal bound.  Combined with
+`mrc_signal_sq_eq_iff` this shows the optimum is achieved on the *entire* ray through the
+matched-filter vector, not just at `c = 1` (`mrc_snr_matched`). -/
+theorem mrc_matched_ray_eq {ι : Type*} (s : Finset ι) (c : ℝ) (sig v : ι → ℝ)
+    (hv : ∀ i ∈ s, 0 < v i) :
+    (∑ i ∈ s, (c * (sig i / v i)) * sig i) ^ 2
+      = (∑ i ∈ s, (c * (sig i / v i)) ^ 2 * v i) * (∑ i ∈ s, sig i ^ 2 / v i) := by
+  rw [mrc_signal_sq_eq_iff s (fun i => c * (sig i / v i)) sig v hv]
+  intro i hi j hj
+  have hvi : v i ≠ 0 := (hv i hi).ne'
+  have hvj : v j ≠ 0 := (hv j hj).ne'
+  field_simp
+  ring
+
+end ScratchMRCEq

--- a/proofs/Proofs/WeakGoldbachBounds.lean
+++ b/proofs/Proofs/WeakGoldbachBounds.lean
@@ -1,0 +1,81 @@
+/-
+# Weak Goldbach — sharp minimum bounds and the two-equal (Levy) refinement
+
+Research: weak-goldbach-oq-01
+
+The companion `WeakGoldbach.lean` develops the ternary/binary Goldbach predicates
+(`IsSumOfThreePrimes`, `IsSumOfTwoPrimes`), their decidable search procedures, the additive
+"peel one prime" bridge (`isSumOfThreePrimes_iff_prime_add_sumOfTwoPrimes`), and the
+implication chains `BinaryGoldbach ⟹ WeakGoldbach` and `Levy ⟹ WeakGoldbach`.
+
+This file adds two elementary but previously-missing pieces:
+
+* **Sharp minimum bounds.**  A sum of two primes is `≥ 4` and a sum of three primes is `≥ 6`
+  (each summand is `≥ 2`), and both bounds are attained (`4 = 2+2`, `6 = 2+2+2`).  In
+  particular no `n < 6` is a sum of three primes — the exact lower endpoint of the
+  representable range, pinning down the `n > 5` hypothesis of `WeakGoldbachConjecture`.
+* **The two-equal (Levy) refinement.**  Levy's `n = p + 2q` is a sum of three primes with its
+  last two summands *equal* (`p + q + q`).  So `p + 2q` is always a sum of three primes
+  (`isSumOfThreePrimes_prime_add_two_mul`), and Levy's conjecture yields not merely a ternary
+  representation but one of the special shape `p + q + q`
+  (`levy_isSumOfThreePrimes_two_equal`) — a structural strengthening of
+  `levy_implies_weak_goldbach`.
+
+Everything is `propext`/`Classical.choice`/`Quot.sound`-only (the file's deep
+Helfgott/Chen/circle-method axioms are not invoked).
+-/
+import Mathlib
+import Proofs.WeakGoldbach
+
+namespace WeakGoldbach
+
+/-! ### Sharp minimum bounds -/
+
+/-- **A sum of two primes is at least `4`.**  Both summands are `≥ 2`
+(`Nat.Prime.two_le`), so `n = p + q ≥ 4`.  Sharp: `4 = 2 + 2`. -/
+theorem isSumOfTwoPrimes_four_le {n : ℕ} (h : IsSumOfTwoPrimes n) : 4 ≤ n := by
+  obtain ⟨p, q, hp, hq, heq⟩ := h
+  have := hp.two_le; have := hq.two_le; omega
+
+/-- **A sum of three primes is at least `6`.**  Each of the three summands is `≥ 2`, so
+`n = p + q + r ≥ 6`.  Sharp: `6 = 2 + 2 + 2`.  Hence the `n > 5` hypothesis of the weak
+Goldbach conjecture is exactly the representability threshold. -/
+theorem isSumOfThreePrimes_six_le {n : ℕ} (h : IsSumOfThreePrimes n) : 6 ≤ n := by
+  obtain ⟨p, q, r, hp, hq, hr, heq⟩ := h
+  have := hp.two_le; have := hq.two_le; have := hr.two_le; omega
+
+/-- **Nothing below `6` is a sum of three primes.**  Contrapositive of
+`isSumOfThreePrimes_six_le`; identifies `0,1,2,3,4,5` as the complete list of
+non-representable naturals. -/
+theorem not_isSumOfThreePrimes_of_lt_six {n : ℕ} (h : n < 6) : ¬ IsSumOfThreePrimes n :=
+  fun hs => by have := isSumOfThreePrimes_six_le hs; omega
+
+/-- **`4` is a sum of two primes** (`2 + 2`) — the bound `isSumOfTwoPrimes_four_le` is sharp. -/
+theorem isSumOfTwoPrimes_four : IsSumOfTwoPrimes 4 :=
+  ⟨2, 2, Nat.prime_two, Nat.prime_two, by norm_num⟩
+
+/-- **`6` is a sum of three primes** (`2 + 2 + 2`) — the bound `isSumOfThreePrimes_six_le`
+is sharp. -/
+theorem isSumOfThreePrimes_six : IsSumOfThreePrimes 6 :=
+  ⟨2, 2, 2, Nat.prime_two, Nat.prime_two, Nat.prime_two, by norm_num⟩
+
+/-! ### The two-equal (Levy) refinement -/
+
+/-- **`p + 2q` is a sum of three primes**, for any primes `p, q`: it is `p + q + q`.  The
+elementary witness generator behind `Levy ⟹ WeakGoldbach`, stated for arbitrary primes rather
+than only those arising from a Levy representation. -/
+theorem isSumOfThreePrimes_prime_add_two_mul {p q : ℕ} (hp : Nat.Prime p) (hq : Nat.Prime q) :
+    IsSumOfThreePrimes (p + 2 * q) :=
+  ⟨p, q, q, hp, hq, hq, by ring⟩
+
+/-- **Levy yields a ternary representation with two equal summands.**  Under Levy's conjecture
+every odd `n > 5` is `p + 2q = p + q + q` for primes `p, q` — a sum of three primes whose last
+two summands coincide.  Strengthens `levy_implies_weak_goldbach` (which forgets the equality)
+by retaining the `p + q + q` structure. -/
+theorem levy_isSumOfThreePrimes_two_equal (hLevy : LevyConjecture) :
+    ∀ n : ℕ, n > 5 → Odd n → ∃ p q : ℕ, Nat.Prime p ∧ Nat.Prime q ∧ n = p + q + q := by
+  intro n hn hodd
+  obtain ⟨p, q, hp, hq, heq⟩ := hLevy n hn hodd
+  exact ⟨p, q, hp, hq, by omega⟩
+
+end WeakGoldbach

--- a/research/epic-37508-goal.md
+++ b/research/epic-37508-goal.md
@@ -1,0 +1,293 @@
+# GOAL: Complete Epic #37508 — Lean v4.26.0 → v4.31.0 toolchain + Mathlib migration
+
+**Standing objective** (set by operator 2026-07-13): drive epic #37508 to full completion.
+The lean-genius agent fleet is intentionally OFF while this goal is active; work is driven
+by orchestrator sessions dispatching workers directly.
+
+## Completion criteria (epic closes when all true)
+
+- [ ] #38065 closed — residual failure ledger burned down (safe subset green at v4.31)
+- [ ] #38066 closed — pins flipped on `main` (`lean-toolchain`, `lakefile.toml`, `lake-manifest.json`,
+      `Dockerfile` ×2 lines, `docker-build.sh` IMAGE), volumes refreshed, CI image retagged;
+      0 lingering v4.26.0 refs in build config
+- [ ] #38067 closed — `mathlib_version` swept across ~3,508 `src/data/proofs/*/meta.json` + pnpm build green
+- [ ] #37508 closed — epic dashboard updated, unlocks #37507 (CDC port)
+
+## Operator decisions
+
+- **Aristotle gate (b) of #38066 is RE-SCOPED, not blocking**: do NOT wait for the Aristotle
+  backend to support v4.31. Translate to/from Aristotle's pinned Lean version (currently v4.28)
+  at the submission/integration boundary as needed — they will eventually update. Post-flip,
+  Aristotle outputs get drift-repaired on integration (rename map in
+  `research/toolchain-v4.31-rename-map.md` is the starting point).
+- Disk headroom must be re-verified immediately before the #38066 volume refresh (~10GB cold refill;
+  host has B2/ENOSPC history).
+- **Wrapper volume hazard (found during increment-4 salvage)**: `proofs/scripts/docker-build.sh`
+  hardcodes the shared v4.26 volumes (`lean-mathlib-cache`/`lean-mathlib-packages`). Running it on
+  the v4.31 branch cross-contaminates the fleet-wide v4.26 cache. Migration verification MUST use
+  the containerized recipe in `proofs/batch2/STATUS.md` (dedicated `lean-mathlib-{packages,cache}-v431`
+  volumes, runner4.sh, --memory 11g). The wrapper needs v431-volume awareness as part of the
+  #38066 infra flip.
+
+## State at goal creation (2026-07-13)
+
+- Branch: `feature/issue-37508` (long-lived migration branch; keep rebased/merged vs `main`)
+- Ledger: `proofs/batch2/verify-results.tsv` — 724 GREEN / 1,911 RESIDUAL / 24 PRE-EXISTING
+  after increment 4 (PR #38596, merged 2026-07-13; ledger hygiene + DR14 salvage, +5 GREEN)
+  (of 2,659-fail baseline in `proofs/spike-logs-full/results-full.tsv`)
+- Increments so far: #38384 (+190→484), #38396 (+167→651), #38559 (+68→719), #38596 (+5→724),
+  #38599 inc-5B proof-drift (+81→805), #38600 inc-5A type-mismatch (+189+addl reverify → 1048).
+  #38602 inc-6 instance-synth (+44, cyclotomic root cause = demote DivisionRing.toRatAlgebra),
+  #38601 inc-7 type-mismatch+proof-drift remainder (+122). As of 07-13 ~12:05 PT:
+  **1206 GREEN / 1429 RESIDUAL / 24 PRE-EXISTING** (55% of the 2,635 fixable baseline done).
+  Continued 07-13 PM: #38603 inc-8 unknown-const (+24→1230), #38604 inc-9 rewrite-drift
+  (+34→1264). As of ~13:35 PT: **1264 GREEN / 1371 RESIDUAL** (48% of fixable remaining;
+  unknown-const bucket found to be ~230/323 MIXED rows really belonging to tm/pd passes).
+  NOTE: hitting monthly-spend-limit deaths now (not just session limits) — a /login clears
+  session limits but NOT a monthly spend cap (raise at claude.ai/settings/usage). The
+  14-agent internal fan-out dies on spend-limit; central-fixing fallback is reliable.
+  #38605 inc-10 tm/pd+mixed (+27→1291). As of ~14:10 PT: **1291 GREEN / 1344 RESIDUAL**
+  (49% of fixable remaining). Residual: unknown-const 320 (~mixed), instance-synth 224,
+  type-mismatch 223, proof-drift 222, rewrite-drift 101, parse-error 79, signature-drift 44,
+  elab-drift 44, dot-notation 30, decide-maxrecdepth 13, unclassified 10, noncomputable 9,
+  duplicate-decl 8. Deep-rework tail known: Ballot ncard_biUnion, partenat/ℕ∞, 3 cyclotomic
+  compositum-tower rows.
+- Continued 07-13 PM round 2: #38606 inc-12 parse/sig/elab/dot (+26→1317), #38608 inc-11
+  instance-synth (+46→1363). As of ~15:05 PT: **1363 GREEN / 1272 RESIDUAL** (52% done, 48%
+  of fixable remaining). instance-synth now 178 (deeper cascades). Meta-finding across all
+  increments: a zero-edit re-verify flips ~0 (dep-backfill already ran); every GREEN needs
+  real per-file fixes now. Hook friction fully resolved (#38597/#38598/#38607) — force ops,
+  docker lifecycle, and /Volumes rm all prompt-free on working branches.
+  Parallel pattern works: 2 agents on disjoint failure classes, cpus 0-5 vs 6-11, separate
+  build-cache volumes (lean-mathlib-cache-v431 / -v431-b), shared packages volume (no lock
+  contention). Ledger conflicts on concurrent branches resolve by 3-way row-union keeping both
+  sides' GREEN flips (rows are disjoint → 0 contradictions).
+- Residual class breakdown (07-13 12:05): unknown-const 347 (long tail, mostly singletons),
+  proof-drift 246, instance-synth 224, type-mismatch 223, rewrite-drift 135, parse-error 79,
+  signature-drift 44, elab-drift 44, dot-notation 30, decide-maxrecdepth 13, unclassified 10,
+  noncomputable 9, duplicate-decl 8.
+- **Operator decision (07-13): FIX mathematically false statements when found.** Correct the
+  statement to the intended-true form (add the missing hypothesis / fix the edge case — e.g.
+  exclude n=0, add nontriviality), never weaken to vacuous truth and never `sorry`/axiomatize.
+  Note each statement repair in the commit message and STATUS.md so the gallery meta can be
+  re-checked. Applies to the 4 flagged files: Erdos820Aristotle (`gcd_ge_two_of_ne_one`),
+  Erdos469Problem (`not_pseudoperfect_0`), Erdos1155OQ01 (`f_small_values_bound` conjunct 2),
+  Erdos1156Problem (`isKColorable_zero_iff` mpr) — and any future finds.
+- Doctor increments continue from a fresh `feature/issue-38065` branch reset onto
+  `origin/feature/issue-37508`, family-clusters-first per `proofs/batch2/STATUS.md`.
+
+## MECHANICAL PHASE COMPLETE (2026-07-14 ~17:50 PT)
+
+Base `feature/issue-37508`: **1904 GREEN / 731 RESIDUAL / 24 never-compiled (exempt)**.
+Started 07-13 at 719 GREEN → +1185 over ~2 days across 49 Doctor increments.
+**Both partition seams (A–M, N–Z) DECLARED DRY** by increments 47/48/49: <5–10% of remaining
+residuals are mechanical/catalog-fixable; each further green now requires real proof surgery,
+not a rename. Rename catalog: research/toolchain-v4.31-rename-map.md (~45 families, §7a–§7ae).
+
+Remaining 731 residual composition: deep-rework (#38612: Ballot/condCount, Sylow clusters,
+cyclotomic towers, partenat/ℕ∞, GeneralizeProofs), OOM files (Wolstenholme, TestApi203),
+100+-error rewrites (TriangleAngleSumOQ02, PoincareConjecture, PNPBarriersLegacy),
+dependency-blocked files, and **files whose ORIGINAL statements are unsound** (only compiled by
+luck pre-4.31: Erdos1123/1112/1125/724, TestApi241, BertrandsPostulate exponent ineq) — logged
+to #38611. ~40+ genuine statement repairs made during the burn-down (real math errors the
+stricter toolchain exposed).
+
+**DECISION MADE (operator, 2026-07-14): OPTION (b) — keep grinding the tail.**
+Continue processing the full residual tail to green even though it's slow; do NOT flip the
+#38066 infra pins yet. The loop should NOT keep re-asking the flip question — the decision is
+settled. Deep-rework phase: dispatch Doctor increments at coherent clusters (partenat/ℕ∞,
+GeneralizeProofs, Sylow-API, SchroederBernstein concrete-category) + statement-repair files
+(fix unsound originals to intended-true, log #38611). Infra flip (#38066) remains gated on a
+SEPARATE explicit operator go-ahead, to be raised only once the tail is genuinely exhausted
+(residual ≈ just OOM + never-compiled exempt), not before.
+
+(Superseded option a, for reference: narrow safe-subset excluding #38612, flip #38066 pins on
+main, unblock #38067/#37507 — deferred by operator choice.)
+
+**FRAMING CORRECTION (operator, 2026-07-14):** a file green on the OLD pin means the theorem
+is true and a proof existed — v4.31 changed how the proof is SPELLED, not whether it's
+provable. So "deep-rework"/"stuck" was wrong; the honest word is EXPENSIVE (many surface-drift
+sites per file), not impossible. Every one of the ~700 residual that were green before is
+PORTABLE with enough per-file effort — the tail is finishable, just throughput-bound (slow
+under the ~25-min session throttle). Agents must NOT skip a file as "impossible" just because
+it has 10+ errors — treat it as budget-permitting, keep going. THREE genuine exceptions where
+"we proved it before" does NOT hold: (1) unsound-original files whose old green exploited a bug
+(Erdos1196 Dvd.dvd.symm, Erdos1123 fake trivial, TestApi241 false Sidon) — NOT valid proofs;
+v4.31 correctly rejects them; fix statement+proof to genuinely-true (the #38611 work, mostly
+done). (2) native_decide/noncomputable-SetLike cases (SylowTheoremOQ04) — theorem provable but
+the cheap "compute it" proof is gone; needs a real argument. (3) the 24 never-compiled rows —
+never proven even on v4.26; exempt.
+
+## SESSION HANDOFF (2026-07-14, updated ~21:30 PT) — deep-rework in progress
+
+**State:** base `feature/issue-37508` = **1992 GREEN / 643 RESIDUAL / 24 never-compiled exempt**
+after inc-56 (PR #38659, +30, A), inc-57 (PR #38660, +18, B), inc-58 (PR #38661, +9, A),
+inc-59 (PR #38662, +5, B) all merged. +62 this session. inc-58/59 died on Fable-5 usage
+credits mid-run but push-after-every-file saved all flips (PRs opened early at +3, undercounted;
+merging the branch pulled every pushed commit). Ledger row-unions all auto-merged clean
+(A vs B partitions disjoint — no hand-merge of tsv). Switched to Opus 4.8 to escape the Fable
+credit pool. Statement repairs logged to #38611: Erdos428 (inc-58) added to prior Erdos490Ari/
+Erdos323/Erdos296/Erdos1157(×2)/Erdos623.
+
+**Continued on Opus 4.8:** inc-60 (PR #38664, +4, A) merged → base **1996 GREEN / 639 RESIDUAL**.
+inc-60 KEY FINDING: partition A cheap single-blocker rows are HARVESTED — the `unknown-const:X`
+ledger class is only the FIRST error; every remaining file has 5–33 real errors, ~0 free flips
+left. Deep-rework is now the norm; ~+4/increment is a good rate. New seams: FDeriv-API family
+(`HasFDerivAt.prod`→`.prodMk`, `.comp_hasDerivAt` now 3-arg, `hasFDerivAt_const (v) (pt)`),
+`Set.Finite.of_not_infinite`→`Set.not_infinite`, `gcongr with <name>`.
+
+**07-15 continued (Opus):** inc-61 (PR #38663, +8, B → crossed 2000 GREEN), inc-62 (PR #38665,
++5, A) merged → base **2009 GREEN / 626 RESIDUAL**. inc-61/62 ledger conflicts resolved by
+STATUS.md marker-strip (keep both records) + tsv auto-merge (A/B disjoint). Both partitions
+now confirmed 0 free-flips (deep-rework everywhere). Statement repairs to #38611 now: Erdos428,
+Erdos129(×2), plus candidates Erdos807/823/133 flagged. New seams cataloged §7ah (∀ᶠ binder
+pin, Nat.find atom, abbrev-for-Membership, congrArg(·i) for EuclideanSpace, List.Sorted→Pairwise,
+Classical-instance-for-Nat.find, rpow root delisting, greedy-by, theorem-Prop→def).
+
+**07-15 mid-session tally (Opus, two-lane pipeline steady state):** incs 63 (+6,B), 64 (+6,A),
+65 (+6,B) all merged → base **2027 GREEN / 608 RESIDUAL**. +97 this session (1930→2027, incs
+56–65). Statement repairs to #38611 now 11 total (Erdos428/129×2/823/850/133 + earlier
+490Ari/323/296/1157×2/623/1059); GALLERY FLAG logged to #38611: CevasTheoremOQ01.routhRatio
+denominator is math-wrong (routh_theorem_std genuinely FALSE, dependents only pass at symmetric
+point) — separate follow-up task, NOT a mechanical migration fix, agents told to skip it. More
+seams §7ai (λ reserved keyword; Finset.product↛mem_product simp; decide can't pierce opaque
+Prop-field; open-scoped-Classical shadows computable Decidable; auto-bound vars drop variable
+instance-binders; ℝ≥0∞ scoped notation; inv_ne_zero implication; PiLp._apply for EuclideanSpace).
+~+12/round two-lane; long grind, self-sustaining, push-after-every-file caps death cost at a partial wave.
+
+**CLEAN RESUME POINT (07-15, ~account-throttle wall):** base `feature/issue-37508` =
+**2028 GREEN / 607 RESIDUAL / 24 exempt** (+98 this session over incs 56–66). inc-66 salvaged
+(+1 Erdos598Problem — universe pin + Cardinal.lift; PR #38669 merged). inc-67 died in setup with
+0 pushed (no branch, nothing lost). BOTH worktrees clean, no containers, no in-flight agents.
+BLOCKER: account session limit hit (resets 1:50am PT) — subagents die during setup reads, ~0
+inference headroom. To resume the two-lane grind: `/login` rotates to a fresh account (13
+available) OR wait for the reset, then re-dispatch inc-67 (partition B, .loom/worktrees/issue-38065,
+cpus 0-5) + inc-68 (partition A, /Volumes/Stripe/lean-genius/doctor-b, cpus 6-11), both fresh off
+origin/feature/issue-37508. Deferred warm leads for the next wave: partition B = PartitionTheoremOQ01
+(3000-line, subsetsWithSum dup-decl), Erdos1067/910 (Cardinal toPartENat/continuum), Sylow-API /
+SchroederBernstein / ThreeSubgroupsLemma-lowerCentralSeries / partenat-ℕ∞ clusters; partition A =
+Erdos560/461/153/483, ErdosKoRado-family, Amgm…OQ03, Bezout…Transitive, CantorDiag…Incomplete01.
+Merge protocol: STATUS.md marker-strip (keep both increment records) + tsv row-union auto-merges
+(A/B partitions disjoint). NEVER hand-merge an auto-merged tsv.
+
+**07-15 post-rotation (account /login cleared the wall):** incs 67 (+9,B), 68 (+4,A) merged →
+base **2041 GREEN / 594 RESIDUAL**. +111 this session (1930→2041, incs 56–68). Cleared 3 orphaned
+containers (dr58/dr59 up 10h from the Fable deaths) before relaunch. Statement repairs to #38611
+now 12 (added FeuerbachsTheoremOQ05 sign error N−F=+(R/r)(I−F) not −). Seams through §7aj
+(interval_cases can't bound from x∣N; open-scoped-Classical shadows decide; decide refuses
+have-bound free vars→lift to def; Finset.mul_sum orientation flip; convert-HasDerivAt junk goals;
+dot-notation exact-namespace _root_ fix; lost-import→Function-expected; ring_nf reindexes sums;
+tendsto_arctan→nhdsWithin; λ reserved keyword). In flight: inc-69 (B, cpus 0-5) + inc-70 (A,
+cpus 6-11). NOTE for next wave: BezoutIdentityOQ01OQ02OQ02Transitive may be a never-green (its own
+docstring says never machine-checked) — candidate to reclass RESIDUAL→PRE-EXISTING, not force green.
+
+## 4-LANE SCALE-UP (2026-07-15, operator: "run more agents in parallel")
+
+Scaled the proven two-lane grind to **FOUR parallel Doctor lanes** on the 28-CPU/96GB host.
+Infra: seeded 2 new 21GB cache volumes (`lean-mathlib-cache-v431-c/-d`) from the warm v431 via
+`docker run --rm -v v431:/from -v v431-c:/to alpine cp -a /from/. /to/`; 4 worktrees, disjoint
+CPU sets, shared packages volume. Partition rule (disjoint, sum=RESIDUAL): L1 Erdos<500 (cpus 0-5,
+cache v431, wt .loom/worktrees/issue-38065) · L2 Erdos≥500 (6-11, v431-b, doctor-b) · L3 non-Erdos
+A–K (12-17, v431-c, doctor-c) · L4 non-Erdos L–Z (18-23, v431-d, doctor-d). Merge protocol per wave:
+git auto-merges verify-results.tsv (disjoint rows); STATUS.md conflicts resolve by STRIPPING the 3
+conflict markers (keep both increment records). Merge each PR via
+`~/GitHub/loom/defaults/scripts/merge-pr.sh <PR>` (gh pr merge is hook-blocked; script false-negs
+post-merge verify → confirm with `gh pr view --json state`).
+
+**Wave 1 (incs 73–76, all merged): +13 → base 2075 GREEN / 558 RESIDUAL / 25 PRE-EXISTING.**
+PRs #38677(+4 Erdos367/411/281/471) #38676(+3 Erdos1006/1018Ari/552) #38679(+3 ArithmeticSeries…/
+Hierholzer/FourColorOQ01) #38678(+3 LawsOfLargeNumbersOQ03/+Ari/PartitionThmOQ03). Statement repairs
+to #38611: Erdos552 cycleGraph (missing i≠j, self-loop at n=1), FourColorOQ01 min_counterexample
+(missing minDeg≤avgDeg hyp). Confirmed CevasTheoremOQ01.routhRatio is a real parent-def bug
+(signedArea 1/10 vs routhRatio 25/252 at (1/2,1/3,1/4)) — skip, #38611 follow-up.
+**Wave 2 (incs 77–80) IN FLIGHT.** Big seams found wave 1: PreErgodic/Ergodic field reshape,
+`Nat.factorization_prime`→`Nat.Prime.factorization`, Euler-partition Archive→mainline,
+`PowerSeries.coeff` ring-arg implicit, forward-reference reordering, `open scoped Classical` for
+Finset.filter decidability, root-decl-vs-`_root_` collision→namespace-wrap, minimal-import
+`⌈⌉` lex failure→`import Mathlib.Data.Real.Archimedean`. KEY: many "1-error" rows are
+GREEN-parent-olean-missing cascades — build the parent's olean first to unmask real child drift.
+
+## PAUSE POINT (2026-07-15, operator asked to pause) — superseded by 4-lane scale-up above
+
+**State:** base `feature/issue-37508` = **2063 GREEN / 571 RESIDUAL / 25 PRE-EXISTING (exempt)**.
++133 this session (1930→2063 over incs 56–72, 17 increments). No containers running, BOTH doctor
+worktrees clean (/Volumes/Stripe/lean-genius/doctor-b + .loom/worktrees/issue-38065), no in-flight
+agents, no open increment PRs — everything merged.
+
+**Erdos608Problem reclassified RESIDUAL→PRE-EXISTING** (inc-71): invalid `O(1)` statement syntax +
+`sorry` body, FAIL on v4.26 baseline — never compiled on any toolchain. That's why PRE-EXISTING
+went 24→25. BezoutIdentity…Transitive still pending the same never-green check.
+
+**Statement/reference repairs to #38611 now 13+**: Erdos428/129×2/823/850/133/FeuerbachOQ05 +
+WilsonOQ02ExtOQ02 dangling-ref (miller_prod) + earlier 490Ari/323/296/1157×2/623/1059. Plus the
+CevasTheoremOQ01.routhRatio GALLERY bug (separate #38611 follow-up, agents told to skip).
+
+**To resume the two-lane grind:** re-dispatch inc-73 (partition B = N–Z + Erdos≥600,
+.loom/worktrees/issue-38065, cpus 0-5, cache lean-mathlib-cache-v431) + inc-74 (partition A = A–M +
+Erdos<600, /Volumes/Stripe/lean-genius/doctor-b, cpus 6-11, cache -v431-b), both fresh off
+origin/feature/issue-37508. Deferred warm leads:
+  - Partition B: Erdos1131 (26-err long grind), SylowTheoremOQ04 (native_decide×noncomputable — use
+    upstream-axiom-if-defeq trick like inc-70 Erdos483, else defer), Erdos1067/910 (Cardinal
+    toPartENat/continuum + universe .{0}), PartitionTheoremOQ01 (3000-line subsetsWithSum dup-decl),
+    SchroederBernstein / ThreeSubgroupsLemma-lowerCentralSeries(39) / partenat-ℕ∞ clusters.
+  - Partition A: Erdos367 (14, forward-refs + factorization_prime), Erdos411 (8, forward-refs + 2
+    maxHeartbeats bumps), Erdos358(14)/Erdos201(29), Erdos560/153, ErdosKoRado-family, DeMoivreOQ02OQ02
+    (implicit-R refactor), LagrangeFourSquaresOQ01OQ03 (native_decide catch-22), CantorDiag…Incomplete01
+    (genuine universe-design mismatch), BezoutIdentity…Transitive (never-green check).
+Seam catalog now through §7al. Merge protocol unchanged: STATUS.md marker-strip (keep both records) +
+tsv row-union auto-merges (A/B disjoint); NEVER hand-merge an auto-merged tsv. Partition rule is now Erdos-number-aware
+(Erdos<600 → A, ≥600 → B) since most residuals are Erdos files. Phase: DEEP-REWORK
+(mechanical seam dry). Decision: OPTION (b) grind the tail, NO infra flip, don't re-ask
+(see above + memory epic-37508-tail-decision). Inc-56 logged 3 statement repairs to #38611
+(Erdos490ProblemAristotle missing 0<a₂ hyp; Erdos323 ℚ-rpow respell; Erdos296 witness repair)
+and new seams (forward-reference harvest, Basis→Module.Basis, List.Chain'→IsChain,
+diff→sdiff family, omega structure-field blindness) — details in STATUS.md inc-56 record.
+
+**To resume next session:** re-run the /loop with the deep-rework prompt. Dispatch pattern that
+works: 2 parallel Doctor agents on disjoint partitions (A–M/Erdos<600 on cpus 6-11 via
+/Volumes/Stripe/lean-genius/doctor-b; N–Z/Erdos≥600 on cpus 0-5 via .loom/worktrees/issue-38065),
+UNIQUE branch name per increment (feature/issue-38065-inc<N>), per-file work, PR-early (~+4-8 or
+~20 min — sessions throttle to ~25-30 min), push after every file. Merge via GitHub layer only
+(never git-op a live worktree). Ledger conflicts: scratchpad/merge-ledger.py (skips tsv when
+git auto-merged — do NOT hand-merge an auto-merged tsv, that corrupted it once on 07-13).
+
+**Yielding sub-seams (deep-rework, ~+7-13/increment):** local-`def`-shadows-Mathlib rename;
+Archive→mainline lemma relocation (`condCount`→`uniformOn`, `Theorems100.*`→mainline);
+Type-valued-`theorem`→`def`; `deriving DecidableEq`→`noncomputable instance Classical.decEq`;
+`termination_by`/`Nat.log_lt_self`; missing project-namespace import; free-greens as deps clear;
+partenat/emultiplicity where the PARENT is already green; statement repairs (fix unsound
+originals to intended-true, log #38611). Full rename catalog: research/toolchain-v4.31-rename-map.md
+(§7a–§7af). Per-increment recipes: proofs/batch2/STATUS.md.
+
+**Genuine exceptions (NOT plain renames):** unsound-original files (old green exploited a bug —
+fix statement+proof to genuinely-true); native_decide/noncomputable-SetLike/orderOf (theorem
+provable but the compute-proof is gone, needs a real argument); 24 never-compiled (exempt, never
+proved even on v4.26). Everything else that was green before IS provable/portable, just expensive.
+
+**Account throttle reality:** we exhausted one account's weekly budget in ~1 day of 2-agent
+operation; sessions now throttle to ~25 min. `/login` rotates to a fresh account (13 available).
+Push-after-every-file means a limit-death costs at most a partial wave. On death: salvage the
+branch delta via a follow-up PR (branch is safe on origin because of unique names).
+
+## Follow-on issues (filed 2026-07-13)
+
+- **#38611** — post-migration gallery-metadata re-audit for the ~30 statement-repaired
+  entries (genuine math errors v4.31 caught: wrong arithmetic on display, the Erdos1196
+  `Dvd.dvd.symm` soundness hole, missing-hypothesis/degenerate fixes). NOT covered by
+  #38067 (which is only the `mathlib_version` field). Sequenced after #38065.
+- **#38612** — deep-rework residual clusters deferred by increments (Ballot ncard_biUnion,
+  partenat/ℕ∞, ThreeSubgroupsLemma 39-site lowerCentralSeries, GeneralizeProofs reimpls,
+  3 cyclotomic compositum-tower rows, 24 never-compiled PRE-EXISTING). Long tail of #38065.
+
+## Working loop
+
+1. Salvage/land any in-flight increment (worktree above → PR to `feature/issue-37508`).
+2. Dispatch Doctor increments against the RESIDUAL ledger (family-clusters-first per
+   `proofs/batch2/STATUS.md` routing), verify GREEN claims in Docker
+   (`./proofs/scripts/docker-build.sh`, NEVER bare `lake build`), merge increments.
+3. Repeat until RESIDUAL ≈ 0 (24 PRE-EXISTING never-compiled files are exempt).
+4. Execute #38066 infra flip (disk check first; Aristotle gate re-scoped per above).
+5. Execute #38067 metadata sweep; verify `pnpm build`.
+6. Update + close #37508; note #37507 unblocked.
+
+Progress notes for cross-session continuity go in issue comments on #38065/#37508.

--- a/research/problems/alternating-series-boole-summation-oq-01-oq-02-oq-01/knowledge.md
+++ b/research/problems/alternating-series-boole-summation-oq-01-oq-02-oq-01/knowledge.md
@@ -1,0 +1,46 @@
+# Knowledge Base: alternating-series-boole-summation-oq-01-oq-02-oq-01
+
+## Session 2026-07-12 (researcher-11) — COMPLETED, axiom-free
+
+**Node.** "Sharpen the localization to the strict interior when `a` is strictly
+antitone." The parent (`AlternatingSeriesBooleSummationOQ01OQ02.lean`) proved, for an
+*antitone* null sequence `a` with alternating sum `L` and partial sums
+`Sₘ = altSum a 0 m = ∑_{j<m} (-1)ʲ aⱼ`:
+- `remainder_bound`: `|L − Sₘ| ≤ aₘ`
+- `sum_mem_Icc`: `L ∈ [0, a₀]`
+
+These are attained only at the degenerate eventually-constant boundary (`a ≡ 0` gives
+`L = 0 = a₀`). This session upgraded every inequality to strict under `StrictAnti a`.
+
+### Delivered (new file `Proofs/AlternatingSeriesBooleSummationOQ01OQ02OQ01.lean`, 200 L, 7 thm, 0 sorry, 0 axiom)
+
+- `even_step_lt` / `odd_step_lt` — strict same-parity monotonicity:
+  `S_{2k} < S_{2(k+1)} = S_{2k} + (a_{2k} − a_{2k+1})` and dually
+  `S_{2(k+1)+1} = S_{2k+1} − (a_{2k+1} − a_{2k+2}) < S_{2k+1}`. From `altSum_succ`
+  + strict antitonicity; no convergence needed.
+- `even_partial_lt` / `lt_odd_partial` — strict brackets `S_{2k} < L < S_{2k+1}`,
+  by combining one strict same-parity step with the parent's non-strict
+  `even_partial_le` / `le_odd_partial` (which take `Antitone`, supplied by
+  `StrictAnti.antitone`).
+- `remainder_bound_strict` — `|L − Sₘ| < aₘ`. No null hypothesis on `a`: the two
+  strict brackets already force `aₘ > 0`.
+- `partial_bracket_strict` — `(Sₘ − L)(S_{m+1} − L) < 0`.
+- `sum_mem_Ioo` — `L ∈ (0, a₀)` (the `m = 0` specialization).
+
+### Key insight
+
+Strictness is a *one-extra-step-of-the-same-parity* phenomenon: `S_{2k} < S_{2(k+1)} ≤ L`.
+No new analytic machinery beyond Mathlib's non-strict alternating-series test
+(`Antitone.alternating_series_le_tendsto`, `Antitone.tendsto_le_alternating_series`).
+
+### Verification
+
+`#print axioms` on all 7 theorems → `[propext, Classical.choice, Quot.sound]` only.
+Host `lake build Proofs.AlternatingSeriesBooleSummationOQ01OQ02OQ01` succeeds (Mathlib
+prebuilt). PR #38378.
+
+### Next steps
+
+None strong. The strict/interior regime is fully characterized. A possible (weaker)
+follow-up: quantify the *gap* `aₘ − |L − Sₘ| = ` (next omitted-term tail) explicitly,
+but that is a cosmetic restatement of `even_step_lt`/`odd_step_lt` rather than new theory.

--- a/research/problems/alternating-series-boole-summation-oq-01-oq-02-oq-01/state.md
+++ b/research/problems/alternating-series-boole-summation-oq-01-oq-02-oq-01/state.md
@@ -1,0 +1,26 @@
+# Research State: alternating-series-boole-summation-oq-01-oq-02-oq-01
+
+## Current State
+**Phase**: COMPLETED (axiom-free)
+**Path**: full
+**Since**: 2026-07-12 (researcher-11)
+**Iteration**: 1
+
+## Current Focus
+None. Strict-interior sharpening delivered in
+`Proofs/AlternatingSeriesBooleSummationOQ01OQ02OQ01.lean` (7 thm, 0 sorry, 0 axiom).
+PR #38378.
+
+## Active Approach
+None (solved).
+
+## Attempt Count
+- Total attempts: 1
+- Current approach attempts: 1
+- Approaches tried: 1 (one-extra-same-parity-step strictification of the parent brackets)
+
+## Blockers
+None.
+
+## Next Action
+None. Released as completed.

--- a/src/data/proofs/erdos-874/meta.json
+++ b/src/data/proofs/erdos-874/meta.json
@@ -52,9 +52,9 @@
       "BoundedAdmissible for sets in {1,...,N}",
       "k(N) function as maximum admissible set size",
       "strausSet construction for lower bound",
-      "Straus lower/upper bound axioms (1966)",
-      "ENS improved upper bound axiom (1991)",
-      "Deshouillers-Freiman main theorem axiom (1999)",
+      "strausConstant (4/√3) definition; Straus (1966) bounds documented as prose, not axiomatized",
+      "ensConstant (√(143/27)) definition; ENS (1991) improved bound documented as prose, not axiomatized",
+      "Deshouillers-Freiman main theorem axiom (1999): deshouillers_freiman_main",
       "k_limit_is_two: the limit equals 2",
       "erdos_874 and erdos_874_answer main theorems"
     ],
@@ -68,7 +68,7 @@
     "historicalContext": "This problem asks about admissible sets A ⊆ {1,...,N} where sums of r distinct elements form disjoint sets for each r. Straus (1966) introduced the term and established that 2 ≤ liminf k(N)/√N ≤ limsup k(N)/√N ≤ 4/√3. Erdős-Nicolas-Sárközy (1991) improved the upper bound to √(143/27). Finally, Deshouillers-Freiman (1999) proved the conjecture: k(N) ~ 2√N. Admissible sets generalize Sidon sets (B_2 sets, where only pairwise sums must be distinct) to all r-fold sums, placing them in the broader B_h set theory initiated by Sidon in 1932 and developed by Erdős and Turán. The precise √N asymptotics reflect a fundamental density constraint: packing many elements while keeping all r-fold sum sets disjoint requires near-optimal spread within {1,...,N}.",
     "problemStatement": "**Question:** Let k(N) denote the size of the largest subset A ⊆ {1,...,N} such that the sets S_r = { a₁ + ⋯ + a_r : a₁ < ⋯ < a_r ∈ A } are disjoint for distinct r ≥ 1. Is k(N) ~ 2√N?\n\n**Answer: YES** (Deshouillers-Freiman, 1999)\n\nThe limit lim_{N→∞} k(N)/√N = 2 exists.",
     "text": "Is k(N) ~ 2√N where k(N) is the max size of A ⊆ {1,...,N} with disjoint subset sums S_r? PROVED by Deshouillers-Freiman (1999).",
-    "proofStrategy": "The formalization defines:\n\n1. **sumSet(A, r):** Set of all r-element subset sums from A\n2. **Admissible(A):** S_r are pairwise disjoint for r ≥ 1\n3. **k(N):** Maximum |A| for admissible A ⊆ {1,...,N}\n\nWe axiomatize:\n- Straus (1966): Lower bound via interval construction, upper bound 4/√3\n- ENS (1991): Improved upper bound √(143/27)\n- Deshouillers-Freiman (1999): k(N)/√N → 2",
+    "proofStrategy": "The formalization defines:\n\n1. **sumSet(A, r):** Set of all r-element subset sums from A\n2. **Admissible(A):** S_r are pairwise disjoint for r ≥ 1\n3. **k(N):** Maximum |A| for admissible A ⊆ {1,...,N}\n\nWe axiomatize only the Deshouillers-Freiman (1999) resolution — k(N)/√N → 2 — via the axioms `deshouillers_freiman_main` and `k_limit_is_two`. The earlier Straus (1966) bounds (lower bound via interval construction, upper bound 4/√3) and the ENS (1991) improvement (√(143/27)) are documented as prose commentary with only their constants defined (`strausConstant`, `ensConstant`); they are not axiomatized.",
     "keyInsights": [
       "**Admissible = Disjoint Sums:** The key property is that you can determine r from the sum alone.",
       "**Intervals are often optimal:** Sets of the form (N-k, N] ∩ ℕ achieve the lower bound.",

--- a/src/data/research/problems/pascals-hexagon-oq-03-wip-01.json
+++ b/src/data/research/problems/pascals-hexagon-oq-03-wip-01.json
@@ -1,0 +1,55 @@
+{
+  "slug": "pascals-hexagon-oq-03-wip-01",
+  "title": "Steiner (20) and Kirkman (60) Point Counts for the Hexagrammum Mysticum",
+  "phase": "OBSERVE",
+  "status": "active",
+  "tier": "C",
+  "path": "full",
+  "problemStatement": {
+    "formal": "\\#\\{\\text{Steiner points}\\} = 20, \\qquad \\#\\{\\text{Kirkman points}\\} = 60.",
+    "plain": "Pascal's theorem says the three pairs of opposite sides of a hexagon inscribed",
+    "whyMatters": []
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": ""
+  },
+  "currentState": {
+    "phase": "OBSERVE",
+    "since": "2026-07-09T20:46:01-07:00",
+    "iteration": 1,
+    "focus": "Initial problem understanding. Read problem.md and gather context.",
+    "blockers": [],
+    "nextAction": "Read problem.md thoroughly and acquire full context.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "",
+    "builtItems": [],
+    "insights": [],
+    "mathlibGaps": [],
+    "nextSteps": [],
+    "markdown": "# Knowledge Base: pascals-hexagon-oq-03-wip-01\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
+  },
+  "tags": [
+    "projective-geometry",
+    "combinatorics",
+    "hexagrammum-mysticum"
+  ],
+  "relatedProofs": [
+    "pascals-hexagon",
+    "pascals-hexagon-oq-03"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": []
+  },
+  "started": "2026-07-10T05:15:55.893Z",
+  "lastUpdate": "2026-07-10T05:15:55.929Z"
+}

--- a/src/data/research/problems/roth-theorem-k3-oq-02-wip-01.json
+++ b/src/data/research/problems/roth-theorem-k3-oq-02-wip-01.json
@@ -1,0 +1,56 @@
+{
+  "slug": "roth-theorem-k3-oq-02-wip-01",
+  "title": "Triangle-Count Bounds in the Ruzsa-Szemeredi Graph for Roth via Triangle Removal",
+  "phase": "OBSERVE",
+  "status": "active",
+  "tier": "C",
+  "path": "full",
+  "problemStatement": {
+    "formal": "",
+    "plain": "Roth's theorem states that any subset of the integers with positive density",
+    "whyMatters": []
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": ""
+  },
+  "currentState": {
+    "phase": "OBSERVE",
+    "since": "2026-07-09T20:46:01-07:00",
+    "iteration": 1,
+    "focus": "Initial problem understanding. Read problem.md and gather context.",
+    "blockers": [],
+    "nextAction": "Read problem.md thoroughly and acquire full context.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "",
+    "builtItems": [],
+    "insights": [],
+    "mathlibGaps": [],
+    "nextSteps": [],
+    "markdown": "# Knowledge Base: roth-theorem-k3-oq-02-wip-01\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
+  },
+  "tags": [
+    "additive-combinatorics",
+    "graph-theory",
+    "roth-theorem"
+  ],
+  "relatedProofs": [
+    "roth-theorem",
+    "roth-theorem-k3",
+    "roth-theorem-k3-oq-02"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": []
+  },
+  "started": "2026-07-10T05:15:55.895Z",
+  "lastUpdate": "2026-07-10T05:15:55.930Z"
+}


### PR DESCRIPTION
## Integrity Issue

**Proof**: erdos-874
**Problem**: `originalContributions` and `proofStrategy` overstate the axiomatization by listing Straus and ENS bounds as axioms that do not exist.

## Evidence

**meta.json claimed** (originalContributions):
- "Straus lower/upper bound axioms (1966)"
- "ENS improved upper bound axiom (1991)"

**meta.json claimed** (proofStrategy): *"We axiomatize: Straus (1966)... ENS (1991)... Deshouillers-Freiman (1999)"*

**Lean file (`Proofs/Erdos874Problem.lean`) shows** only 2 axioms:
- `deshouillers_freiman_main` (line 140)
- `k_limit_is_two` (line 147)

The Straus and ENS bounds appear **only as prose comments** (lines 96–104, 121–130); the sections define just the constants `strausConstant` (4/√3) and `ensConstant` (√(143/27)), plus a trivial `straus_constant_value : strausConstant = 4/√3 := rfl`. The `assumptions` field and `axiomCount: 2` already correctly reflect two axioms — the prose was internally inconsistent.

## Fix

- Rewrote the two phantom `originalContributions` entries to credit the actual constant definitions and note the Straus/ENS bounds are prose, not axiomatized.
- Corrected `proofStrategy` to state only the Deshouillers-Freiman resolution is axiomatized.

No count fields changed (axiomCount=2, sorries=0 were already accurate; status `axiomatized` / badge `axiom` unchanged).

---
Discovered during gallery integrity audit (reserve mode; uncontested target).

🤖 Generated with [Claude Code](https://claude.com/claude-code)