### PR TITLE
audit: erdos-745 — drop 7 phantom declarations, correct axiomatized prose

### DIFF
--- a/src/data/proofs/erdos-745/meta.json
+++ b/src/data/proofs/erdos-745/meta.json
@@ -40,7 +40,6 @@
       "criticalProbability definition: p = 1/n",
       "criticalRandomGraph definition: G(n, 1/n)",
       "ComponentSizes, largestComponentSize, secondLargestComponentSize",
-      "subcritical_components, supercritical_giant axioms",
       "critical_giant_size axiom: giant is Θ(n^{2/3})",
       "komlos_sulyok_szemeredi axiom: second largest is O(log n)",
       "second_largest_lower_bound axiom: second largest is Ω(log n)",
@@ -90,10 +89,10 @@
     {
       "id": "phase-transition",
       "title": "Phase Transition",
-      "summary": "subcritical_components, supercritical_giant, critical_regime axioms",
+      "summary": "Subcritical, supercritical, and critical regimes described in prose (no formal declarations)",
       "startLine": 107,
       "endLine": 135,
-      "mathContext": "Axiomatized: subcritical_components, supercritical_giant, critical_regime axioms"
+      "mathContext": "Prose only: subcritical, supercritical, and critical regimes are described in comments; no declarations in this section"
     },
     {
       "id": "giant-component",
@@ -114,18 +113,18 @@
     {
       "id": "component-structure",
       "title": "The Component Structure",
-      "summary": "component_distribution, component_count, componentExponent",
+      "summary": "componentExponent definition (component size distribution and counts described in prose only)",
       "startLine": 208,
       "endLine": 237,
-      "mathContext": "Mathematical content: component_distribution, component_count, componentExponent"
+      "mathContext": "Formal definition: componentExponent; component size distribution and counts are described in comments only"
     },
     {
       "id": "percolation",
       "title": "Connection to Percolation",
-      "summary": "percolation_connection, critical_window axioms",
+      "summary": "Percolation analogy and critical window described in prose (no formal declarations)",
       "startLine": 238,
       "endLine": 267,
-      "mathContext": "Axiomatized: percolation_connection, critical_window axioms"
+      "mathContext": "Prose only: percolation analogy and critical window are described in comments; no declarations in this section"
     },
     {
       "id": "summary",


### PR DESCRIPTION
## Integrity Issue

**Proof**: erdos-745 (Erdős #745 — Second Largest Component of Random Graphs)
**Problem**: `meta.json` names 7 declarations that do not exist in the Lean source — they are prose comment blocks only, presented as "axioms"/formalized content.

## Evidence

**meta.json claims** (originalContributions + section summaries): `subcritical_components`, `supercritical_giant`, `critical_regime`, `component_distribution`, `component_count`, `percolation_connection`, `critical_window`.

**Lean file shows** (`proofs/Proofs/Erdos745Problem.lean`): all 7 are `/- ... -/` comment blocks; `grep` declaration count = 0 for each. Actual decls: 7 theorems + 8 defs/structure (matches theoremCount/definitionCount).

Core status fields are accurate and were left unchanged: `status=axiomatized`, `badge=wip`, `axiomCount=0`, `sorries=0` (the 7 theorems are True-stubs `∃ c, c > 0 ∧ True`, disclosed in `assumptions`).

## Fix

- Removed phantom `originalContributions` entry `"subcritical_components, supercritical_giant axioms"`.
- Rewrote the Phase Transition, Component Structure, and Percolation section summaries/mathContext to reflect prose-only content and the one real declaration (`componentExponent`).

---
Discovered during gallery integrity audit (reserve mode — unaudited queue drained; oldest uncontested target).

🤖 Generated with [Claude Code](https://claude.com/claude-code)