### PR TITLE
Research: erdos-1038-wip-01 — v4.31 re-verify clean + clear 6 warnings

### DIFF
--- a/proofs/Proofs/Erdos1038WIP01.lean
+++ b/proofs/Proofs/Erdos1038WIP01.lean
@@ -119,13 +119,13 @@ theorem sublevelSet_quadratic :
   have hs : (Real.sqrt 2) ^ 2 = 2 := Real.sq_sqrt (by norm_num)
   have hspos : 0 < Real.sqrt 2 := Real.sqrt_pos.mpr (by norm_num)
   ext x
-  rw [mem_sublevelSet_quadratic, Set.mem_diff, Set.mem_Ioo, Set.mem_singleton_iff]
+  rw [mem_sublevelSet_quadratic, Set.mem_sdiff, Set.mem_Ioo, Set.mem_singleton_iff]
   constructor
   · rintro ⟨h0, h2⟩
     refine ⟨⟨?_, ?_⟩, ?_⟩
     · nlinarith [hs, hspos, sq_nonneg (x + Real.sqrt 2)]
     · nlinarith [hs, hspos, sq_nonneg (x - Real.sqrt 2)]
-    · intro hx; rw [hx] at h0; simpa using h0
+    · intro hx; rw [hx] at h0; simp at h0
   · rintro ⟨⟨h1, h2⟩, h3⟩
     refine ⟨?_, ?_⟩
     · have : x ≠ 0 := h3
@@ -138,7 +138,7 @@ theorem sublevelSet_quadratic :
 theorem sublevelMeasure_quadratic :
     sublevelMeasure q = ENNReal.ofReal (2 * Real.sqrt 2) := by
   unfold sublevelMeasure
-  rw [sublevelSet_quadratic, measure_diff_null (by simp), Real.volume_Ioo]
+  rw [sublevelSet_quadratic, measure_sdiff_null (by simp), Real.volume_Ioo]
   congr 1
   ring
 
@@ -738,7 +738,7 @@ theorem sublevelMeasure_le_four {f : Polynomial ℝ} (hf : MonicRealRootedIn01' 
     Together they confine `sublevelSup' ∈ [2√2, 4]` with no potential theory; Tao's sharp
     `= 2√2` sits inside this interval and remains beyond Mathlib. -/
 theorem sublevelSup'_le_four : sublevelSup' ≤ ENNReal.ofReal 4 :=
-  iSup_le fun f => iSup_le fun hf => sublevelMeasure_le_four hf
+  iSup_le fun _f => iSup_le fun hf => sublevelMeasure_le_four hf
 
 /-- **The faithful supremum is sandwiched: `2√2 ≤ sublevelSup' ≤ 4`.**  A fully elementary,
     axiom-free localisation of the open Erdős #1038 extremal constant to a concrete finite
@@ -971,7 +971,7 @@ theorem sublevelMeasure_quadraticGen_ge_two {a b : ℝ} (ha : a ∈ Set.Icc (-1 
         (by linarith [hxIoo.1] : (0:ℝ) < 2 + (2 * x - a - b)), sq_nonneg (a - b)]
   have hvol : volume (Set.Ioo ((a + b) / 2 - 1) ((a + b) / 2 + 1) \ {(a + b) / 2})
       = ENNReal.ofReal 2 := by
-    rw [measure_diff_null (measure_singleton _), Real.volume_Ioo]
+    rw [measure_sdiff_null (measure_singleton _), Real.volume_Ioo]
     congr 1; ring
   calc ENNReal.ofReal 2
       = volume (Set.Ioo ((a + b) / 2 - 1) ((a + b) / 2 + 1) \ {(a + b) / 2}) := hvol.symm
@@ -1033,7 +1033,7 @@ theorem sublevelMeasure_quadraticGen {a b : ℝ} (ha : a ∈ Set.Icc (-1 : ℝ) 
     unfold sublevelMeasure
     calc ENNReal.ofReal s
         = volume (Set.Ioo ((a + b - s) / 2) ((a + b + s) / 2) \ {(a + b) / 2}) := by
-            rw [measure_diff_null (measure_singleton _), hvolIoo]
+            rw [measure_sdiff_null (measure_singleton _), hvolIoo]
       _ ≤ volume (sublevelSet (quadraticGen a b)) := measure_mono hlo
   exact le_antisymm hupM hloM
 

--- a/research/problems/erdos-1038-wip-01/knowledge.md
+++ b/research/problems/erdos-1038-wip-01/knowledge.md
@@ -269,3 +269,19 @@ the literal is `insert a {b}`, must prepend `Multiset.insert_eq_cons`. (2) `0 < 
 
 **Files Modified:** proofs/Proofs/Erdos1038WIP01.lean (+12 decls; 888→1094 lines). Gallery
 meta untouched (still tracks the stub `Erdos1038Problem.lean`, not this WIP file).
+
+## Session 2026-07-19 (researcher-1) — v4.31 re-verify clean + cleared 6 warnings
+
+Confirmed `Erdos1038WIP01.lean` (1192L, Mathlib-only) compiles clean under v4.31 (host
+`lake env lean`, exit 0), 0 sorries / 0 axioms, headline `sublevelInfDeg2_lt_sublevelSupDeg2`
+`#print axioms` = `[propext, Classical.choice, Quot.sound]`. Cleared 6 v4.31 warnings for a
+clean re-verify:
+- `Set.mem_diff` → `Set.mem_sdiff` (×1) and `measure_diff_null` → `measure_sdiff_null` (×3) —
+  Mathlib v4.31 diff→sdiff renames.
+- `simpa using h0` → `simp at h0` (proof-by-contradiction: h0 simplifies to False, closing the goal).
+- unused binder `fun f =>` → `fun _f =>` in the sup bound (f used only implicitly via hf's type).
+
+No math added — the degree-2 slice is COMPLETE and the genuine open items (faithful sup upper
+bound 2√2, exact infimum 2^(4/3)−1) need logarithmic potential theory beyond Mathlib (Tao 2025),
+not session-sized. Tracker blocker documentation is handled by sibling PRs #39144/#39249 (this
+PR touches ONLY the Lean file + knowledge.md to avoid a tracker-JSON conflict).


### PR DESCRIPTION
## Summary
Clean re-verify of `Erdos1038WIP01.lean` (Erdős #1014… actually #1038 sublevel-set measure
theory) under v4.31, clearing 6 warnings. **Lean-file-only** — deliberately does not touch the
tracker JSON to avoid a conflict with the sibling blocker-doc PRs #39144/#39249 (which touch only
`src/data/research/problems/erdos-1038-wip-01.json`).

## Progress
- **Verified under v4.31** (host `lake env lean`, exit 0): 1192L, Mathlib-only, **0 sorries / 0
  axioms**; headline `sublevelInfDeg2_lt_sublevelSupDeg2` `#print axioms` =
  `[propext, Classical.choice, Quot.sound]`.
- **Cleared 6 warnings**:
  - `Set.mem_diff` → `Set.mem_sdiff` (×1); `measure_diff_null` → `measure_sdiff_null` (×3) —
    Mathlib v4.31 `diff`→`sdiff` renames.
  - `simpa using h0` → `simp at h0` (proof by contradiction; `h0` simplifies to `False`).
  - unused binder `fun f =>` → `fun _f =>` (f used only implicitly via `hf`'s type).

## Status
**Outcome**: progress (clean v4.31 re-verify + warning cleanup; no math added)
**Next Steps**: the degree-2 slice is complete; the open items (faithful sup upper bound 2√2, exact
infimum 2^(4/3)−1) need logarithmic potential theory beyond Mathlib — deep, not session-sized.

🤖 Generated by researcher-1