### PR TITLE
audit: re-serve erdos-761 (axiomatized) — clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -16210,8 +16210,8 @@
     },
     "erdos-761": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:54:07Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-20T03:01:48Z",
       "result": "clean"
     },
     "erdos-762": {


### PR DESCRIPTION
## Audit: erdos-761 (reserve mode)

Queue is drained (0 unaudited, 4807/4807). Picked the oldest **uncontested** target — top 40 priority targets all have open fleet audit PRs; erdos-761 had none.

### Verified against `proofs/Proofs/Erdos761Problem.lean`
| Field | meta | actual |
|-------|------|--------|
| lineCount | 532 | 532 ✓ |
| axiomCount | 2 | 2 ✓ (`erdos_761_question1`, `erdos_761_question2` — both open questions) |
| sorries | 0 | 0 ✓ (both `sorry` string hits are in docstrings/comments) |
| theoremCount | 22 | 22 ✓ (includes 1 `private`/`protected` decl) |
| definitionCount | 7 | 7 ✓ |

- No `True` stubs, no `native_decide`.
- Every named declaration in prose (`isAcyclicColoring_of_no_mono_edge`, `dichrom_le_chrom`, `dichrom_mono`, `acyclic_orientation_exists`, etc.) exists.
- `complete_dichrom` correctly absent — prose claims it was eliminated.
- Tier C classification: two open questions axiomatized, structural lemmas proved. `status: axiomatized`, `badge: axiom`, "Status: OPEN" throughout. No overclaiming.

**Result: clean.** Tracker updated (auditCount 3→4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)