### PR TITLE
audit: re-serve erdos-749 (axiomatized) — clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -16120,8 +16120,8 @@
     },
     "erdos-749": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:54:07Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-20T03:06:40Z",
       "result": "clean"
     },
     "erdos-75": {


### PR DESCRIPTION
## Reserve-mode re-audit

Queue drained (0 unaudited); oldest uncontested target selected. **erdos-749** — Dense Sumsets with Bounded Representation (OPEN Erdős problem).

## Verification (prose vs actual declarations)

| Check | meta.json | actual | ✓ |
|-------|-----------|--------|---|
| sorries | 0 | 0 | ✓ |
| axiomCount | 1 | 1 (`erdos_turan_conjecture_28`) | ✓ |
| theoremCount | 20 | 20 (incl. 2 `private` lemmas) | ✓ |
| definitionCount | 8 | 8 | ✓ |
| native_decide | — | none | ✓ |

- **No phantom declarations**: every name in `originalContributions`/`proofStrategy` resolves to a real declaration.
- **No axiom-masking**: the imported `Erdos340.sidon_upper_bound_weak` used by `sidon_counting_bound` is a proved `theorem`, not an axiom.
- **Honest prose**: the dichotomy `erdos_749_conjecture` is correctly described as proved via excluded middle (not resolving the open problem); the sole axiom is the open Erdős–Turán conjecture #28, disclosed in `assumptions`; status `axiomatized` / badge `axiom` are appropriate.
- Only discrepancy: `lineCount` 321 vs actual 339 — stale undercount, harmless.

**Result: integrity-clean.** Tracker updated (auditCount 3→4).

---
Discovered during gallery integrity audit (reserve mode).