### PR TITLE
Research: erdos-771 — intermediate-regime upper bound f_m(n) ≤ ⌊m/2⌋ (n < m ≤ 2n)

### DIFF
--- a/proofs/Proofs/Erdos771IntermediateUpper.lean
+++ b/proofs/Proofs/Erdos771IntermediateUpper.lean
@@ -1,0 +1,141 @@
+/-
+# Erdős Problem #771 — an intermediate-regime upper bound `f_m(n) ≤ ⌊m/2⌋`
+
+Let `f_m(n)` be the largest size of an `m`-avoiding subset of `{1,…,n}` (a subset none of whose
+nonempty subsets sums to `m`).  The cluster already pins the exact value at both ends of the range
+of `m`:
+
+* **small `m`** (`1 ≤ m ≤ n`):        `f_m(n) = n − ⌈m/2⌉`   (`Erdos771GeneralUpper/LowerBound`);
+* **high `m`** (`T(n−1) < m ≤ T(n)`, `T(k) = k(k+1)/2`): `f_m(n) = n − 1`  (`Erdos771HighRegime`).
+
+Everything in the **intermediate regime** `n < m ≤ T(n−1)` is otherwise open — this is the genuine
+"matching-number" core, where the value is governed by the maximum number of pairwise-disjoint
+representations of `m` inside `{1,…,n}` (pairs, triples, …).
+
+This file proves the **pair-only upper bound for the bottom slice** `n < m ≤ 2n` of that regime.
+The mechanism is the same disjoint family of representations used in the small-`m` proof, but with
+the singleton block `{m}` (no longer a subset of `{1,…,n}` once `m > n`) dropped and the pair index
+restricted so that both endpoints stay in range:
+
+    {i, m−i}   for   m − n ≤ i < ⌈m/2⌉.
+
+These `⌈m/2⌉ − (m − n)` pairs are pairwise disjoint subsets of `{1,…,n}`, each summing to `m`, so an
+`m`-avoiding set omits at least one element from each:
+
+    f_m(n) ≤ n − (⌈m/2⌉ − (m − n)) = ⌊m/2⌋      (for `n < m ≤ 2n`).
+
+Combined with the always-valid `f_m(n) ≤ n − 1` from the high regime (every `m ≤ T(n)` is a subset
+sum of `{1,…,n}`), this gives `f_m(n) ≤ min(n − 1, ⌊m/2⌋)`, a strict improvement over `n − 1` for
+`m ≤ 2n − 3`.
+
+**Tightness.**  The bound is *exact* at the bottom of the regime (machine-checked ground truth:
+`f_5(4) = 2 = ⌊5/2⌋`, `f_6(5) = 3 = ⌊6/2⌋`, `f_7(6) = 3`, `f_8(6) = 4`, …), but becomes loose as `m`
+approaches `2n`, because triples then contribute additional disjoint representations that the
+pair-only family misses (e.g. `f_9(5) = 3 < 4 = ⌊9/2⌋`).  Pinning the exact value throughout
+`n < m ≤ T(n−1)` remains the open matching-number problem.
+
+All results are `0`-sorry / `0`-axiom on top of Mathlib, `Erdos771Construction`, and
+`Erdos771GeneralUpperBound` (whose `blk` family, `blk_sum`, `blk_disjoint`, and `sum_mem_subsetSums`
+are reused verbatim).
+-/
+import Mathlib
+import Proofs.Erdos771Construction
+import Proofs.Erdos771GeneralUpperBound
+
+open Finset
+
+namespace Erdos771IntermediateUpper
+
+open Erdos771Construction
+open Erdos771GeneralUpperBound
+
+/-! ## The pair blocks stay inside `{1,…,n}` in the intermediate regime -/
+
+/-- For `n < m ≤ 2n` and `m − n ≤ i < ⌈m/2⌉`, the block `blk m i = {i, m − i}` is a subset of
+    `{1,…,n}`.  The lower index bound `m − n ≤ i` forces `m − i ≤ n`; the upper bound `i < ⌈m/2⌉`
+    together with `m ≤ 2n` forces `i ≤ n`; and `m > n` forces `i ≥ 1`, so the block is the genuine
+    two-element pair rather than the singleton `{m}`. -/
+theorem blk_subset_high {m i n : ℕ} (hnm : n < m) (hm2n : m ≤ 2 * n)
+    (hi1 : m - n ≤ i) (hi2 : i < (m + 1) / 2) : blk m i ⊆ Icc_n n := by
+  intro x hx
+  rw [mem_blk] at hx
+  rw [Icc_n, Finset.mem_Icc]
+  rcases hx with ⟨h0, rfl⟩ | ⟨_, rfl | rfl⟩ <;> omega
+
+/-! ## The intermediate-regime upper bound -/
+
+/-- **Intermediate-regime optimality bound for Erdős #771.**  For `1 ≤ n` and `n < m ≤ 2n`, every
+    `m`-avoiding subset `S ⊆ {1,…,n}` has
+
+        |S| ≤ n − (⌈m/2⌉ − (m − n)).
+
+    Proof: the `⌈m/2⌉ − (m − n)` pairs `blk m i = {i, m − i}` for `m − n ≤ i < ⌈m/2⌉` are pairwise
+    disjoint subsets of `{1,…,n}`, each summing to `m`.  Since `S` avoids `m`, no pair is contained
+    in `S`, so each contributes at least one element of the deleted set `D = {1,…,n} ∖ S`.
+    Disjointness makes these deletions distinct, so `|D| ≥ ⌈m/2⌉ − (m − n)`. -/
+theorem avoid_card_le_intermediate (n m : ℕ) (hn : 1 ≤ n) (hnm : n < m) (hm2n : m ≤ 2 * n)
+    (S : Finset ℕ) (hS : S ⊆ Icc_n n) (hav : AvoidSum S m) :
+    S.card ≤ n - ((m + 1) / 2 - (m - n)) := by
+  set I := Finset.Ico (m - n) ((m + 1) / 2) with hI
+  set K := (m + 1) / 2 - (m - n) with hKdef
+  have hIcard : I.card = K := by rw [hI, Nat.card_Ico]
+  set D : Finset ℕ := (Icc_n n) \ S with hD
+  set F : ℕ → Finset ℕ := fun i => blk m i ∩ D with hF
+  -- Each pair meets `D` in at least one element.
+  have hFpos : ∀ i ∈ I, 1 ≤ (F i).card := by
+    intro i hi
+    rw [hI, Finset.mem_Ico] at hi
+    obtain ⟨hi1, hi2⟩ := hi
+    have hnsub : ¬ blk m i ⊆ S := by
+      intro hsub
+      apply hav
+      have := sum_mem_subsetSums S (blk m i) hsub (by rw [blk_sum (by omega) hi2]; omega)
+      rwa [blk_sum (by omega) hi2] at this
+    rw [Finset.not_subset] at hnsub
+    obtain ⟨x, hxblk, hxS⟩ := hnsub
+    have hsub : blk m i ⊆ Icc_n n := blk_subset_high hnm hm2n hi1 hi2
+    have hxD : x ∈ F i := by
+      rw [hF, Finset.mem_inter, hD, Finset.mem_sdiff]
+      exact ⟨hxblk, hsub hxblk, hxS⟩
+    exact Finset.card_pos.mpr ⟨x, hxD⟩
+  -- The `F i` are pairwise disjoint (subsets of disjoint blocks).
+  have hFdisj : (↑I : Set ℕ).PairwiseDisjoint F := by
+    intro i hi j hj hij
+    rw [Finset.mem_coe, hI, Finset.mem_Ico] at hi hj
+    exact (blk_disjoint hi.2 hj.2 hij).mono Finset.inter_subset_left Finset.inter_subset_left
+  have hbUsub : I.biUnion F ⊆ D := by
+    intro x hx
+    rw [Finset.mem_biUnion] at hx
+    obtain ⟨i, _, hxi⟩ := hx
+    exact (Finset.inter_subset_right : F i ⊆ D) hxi
+  have hcardD : K ≤ D.card := by
+    calc K = ∑ _i ∈ I, 1 := by rw [Finset.sum_const, hIcard]; ring
+      _ ≤ ∑ i ∈ I, (F i).card := Finset.sum_le_sum hFpos
+      _ = (I.biUnion F).card := (Finset.card_biUnion hFdisj).symm
+      _ ≤ D.card := Finset.card_le_card hbUsub
+  have hcardIcc : (Icc_n n).card = n := by rw [Icc_n, Nat.card_Icc]; omega
+  have hcardS_le : S.card ≤ n := hcardIcc ▸ Finset.card_le_card hS
+  have hDcard : D.card = n - S.card := by
+    rw [hD, Finset.card_sdiff_of_subset hS, hcardIcc]
+  omega
+
+/-- **Closed form.**  In the intermediate regime the pair-only bound is exactly `⌊m/2⌋`:
+    `n − (⌈m/2⌉ − (m − n)) = ⌊m/2⌋` whenever `n < m ≤ 2n`. -/
+theorem avoid_card_le_intermediate_closed (n m : ℕ) (hn : 1 ≤ n) (hnm : n < m) (hm2n : m ≤ 2 * n)
+    (S : Finset ℕ) (hS : S ⊆ Icc_n n) (hav : AvoidSum S m) :
+    S.card ≤ m / 2 := by
+  have h := avoid_card_le_intermediate n m hn hnm hm2n S hS hav
+  have hcf : n - ((m + 1) / 2 - (m - n)) = m / 2 := by omega
+  omega
+
+/-- **Consistency with the high regime.**  At the very top of the pair-only range, `m = 2n − 1`,
+    the bound `⌊m/2⌋` equals `n − 1`, matching `Erdos771HighRegime`; the pair-only family stops
+    improving on `n − 1` precisely there (and above). -/
+theorem intermediate_top_matches_high (n : ℕ) (hn : 2 ≤ n) (S : Finset ℕ)
+    (hS : S ⊆ Icc_n n) (hav : AvoidSum S (2 * n - 1)) :
+    S.card ≤ n - 1 := by
+  have h := avoid_card_le_intermediate_closed n (2 * n - 1) (by omega) (by omega) (by omega) S hS hav
+  have : (2 * n - 1) / 2 = n - 1 := by omega
+  omega
+
+end Erdos771IntermediateUpper

--- a/research/problems/erdos-771/knowledge.md
+++ b/research/problems/erdos-771/knowledge.md
@@ -257,3 +257,47 @@ upper bound (#38524). Together they pin the EXACT maximum `f_m(n) = n − ⌈m/2
 ### Status
 Small-m regime (1≤m≤n) now EXACTLY resolved: max avoiding-set size = n − ⌈m/2⌉ (upper #38524 +
 this lower). Deep asymptotics f(n)=(1/2+o(1))·n/log n (Erdős–Graham/Alon–Freiman) remain BLOCKED.
+
+## Session 2026-07-19 (researcher-1) — INTERMEDIATE-regime upper bound f_m(n) ≤ ⌊m/2⌋ (n < m ≤ 2n)
+
+**Mode**: extend the disjoint-family upper-bound mechanism into the OPEN intermediate regime.
+**Outcome**: progress (0-sorry/0-axiom, Docker-GREEN under v4.31.0, foundational axioms only —
+no native_decide). New file `proofs/Proofs/Erdos771IntermediateUpper.lean` (3 thms + 1 helper).
+
+### Frontier before this session
+The cluster pins the exact value at BOTH ends of the range of m:
+- small m (1 ≤ m ≤ n): f_m(n) = n − ⌈m/2⌉ (`Erdos771GeneralUpper/LowerBound`);
+- high m (T(n−1) < m ≤ T(n), T(k)=k(k+1)/2): f_m(n) = n − 1 (`Erdos771HighRegime`, #39123).
+Open: the **intermediate regime n < m ≤ T(n−1)** — the genuine matching-number core, where the
+value is governed by the max number of pairwise-disjoint representations of m in {1,…,n}.
+
+### What I did — pair-only bound for the bottom slice n < m ≤ 2n
+Reused the `blk`/`blk_sum`/`blk_disjoint`/`sum_mem_subsetSums` machinery from
+`Erdos771GeneralUpperBound` verbatim; only the singleton block `{m}` (no longer ⊆ {1,…,n} once
+m > n) is dropped and the pair index restricted so both endpoints stay in range:
+`{i, m−i}` for `m−n ≤ i < ⌈m/2⌉`. These `⌈m/2⌉−(m−n)` pairs are pairwise-disjoint m-reps ⊆ {1,…,n}.
+- `blk_subset_high`: pairs stay in {1,…,n} (lower index bound m−n≤i ⟹ m−i≤n; i<⌈m/2⌉ ∧ m≤2n ⟹ i≤n).
+- `avoid_card_le_intermediate`: f_m(n) ≤ n − (⌈m/2⌉ − (m−n)) for 1≤n, n<m≤2n.
+- `avoid_card_le_intermediate_closed`: the RHS is exactly `⌊m/2⌋` (pure omega, ℕ-division).
+- `intermediate_top_matches_high`: at m=2n−1 the bound is n−1, matching the high regime — the
+  pair-only family stops improving on n−1 there and above.
+
+Combined with the always-valid f_m(n) ≤ n−1 (every m ≤ T(n) is a subset sum of {1,…,n}), this is
+`f_m(n) ≤ min(n−1, ⌊m/2⌋)` — a STRICT improvement over n−1 for m ≤ 2n−3. For n ≥ 5 the whole slice
+n<m≤2n−1 sits strictly below T(n−1)=n(n−1)/2, so this genuinely advances the open regime.
+
+### Tightness (machine-checked ground truth via brute force, NOT claimed as a theorem)
+EXACT at the bottom: f_5(4)=2=⌊5/2⌋, f_6(5)=3, f_7(6)=3, f_8(6)=4, f_7(8)=4, f_9(7)=4.
+LOOSE near m=2n (triples add disjoint reps the pair-family misses): f_9(5)=3 < 4=⌊9/2⌋,
+f_10(6)=4 < 5, f_14(7)=4 < 7. Pinning the exact value throughout n<m≤T(n−1) remains open.
+
+### Gotchas
+- Index over `Finset.Ico (m−n) ((m+1)/2)`; card via `Nat.card_Ico` = `(m+1)/2 − (m−n)`.
+- omega natively reasons about both `(m+1)/2` and `m/2` (ℕ division by literal 2) — the closed-form
+  `n − ((m+1)/2 − (m−n)) = m/2` under n<m≤2n is a single omega.
+- `blk_subset_high` case-splits `mem_blk`; the i=0 (singleton) branch is vacuous under m−n≤i (omega).
+
+### Still open (unchanged)
+- Exact value in the UPPER intermediate regime 2n < m ≤ T(n−1) and the loose sub-part of n<m≤2n
+  (needs the triple/general-matching count, not just pairs).
+- Deep asymptotics f(n)=(1/2+o(1))·n/log n (Erdős–Graham/Alon–Freiman) remain external.

--- a/src/data/research/problems/erdos-771.json
+++ b/src/data/research/problems/erdos-771.json
@@ -7,7 +7,7 @@
   "path": "full",
   "problemStatement": "f(n) = max k such that for every m ≥ 1 there is S ⊆ {1,…,n}, |S| = k, with no nonempty subset summing to m. Is f(n) = (1/2 + o(1))·n/log n?",
   "knownResults": "SOLVED: f(n) = (1/2 + o(1))·n/log n (Erdős–Graham lower bound via prime multiples; Alon–Freiman upper bound via LCM).",
-  "currentState": "Verified the elementary Erdős–Graham construction in a new self-contained file; the deep asymptotics remain axiomatized in the companion file.",
+  "currentState": "Exact value pinned at both ends of the range of m: small m (1≤m≤n) f_m(n)=n−⌈m/2⌉; high m (T(n−1)<m≤T(n)) f_m(n)=n−1. New this session: intermediate-regime pair-only upper bound f_m(n)≤⌊m/2⌋ for n<m≤2n (Erdos771IntermediateUpper.lean, 0-sorry/0-axiom, v4.31 GREEN), a strict improvement over n−1 for m≤2n−3; tight at the bottom of the regime, loose near m=2n where triples add disjoint reps. Open: exact value throughout n<m≤T(n−1) (matching-number core); deep asymptotics f(n)=(1/2+o(1))·n/log n remain external.",
   "knowledge": {
     "progressSummary": "PROGRESS: EXACT maximum for Erdős #771 small-m regime pinned — f_m(n)=n−⌈m/2⌉ for 1≤m≤n, via general upper bound (disjoint m-representation blocks) + matching tight construction avoider=(Icc ⌈m/2⌉ n).erase m. Both 0-sorry/0-axiom. Deep asymptotics f(n)=(1/2+o(1))n/log n remain blocked.",
     "builtItems": [
@@ -65,7 +65,7 @@
     "Alon–Freiman (1988)"
   ],
   "started": "2026-06-25T00:00:00.000Z",
-  "lastUpdate": "2026-07-11",
+  "lastUpdate": "2026-07-19",
   "significance": "Verifies the combinatorial core of the Erdős–Graham lower bound for f(n).",
   "tractability": "verified-construction-open-asymptotics",
   "leanFiles": [
@@ -112,6 +112,17 @@
       "sorryCount": 0,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos771ProblemAristotle.lean"
+    },
+    {
+      "path": "Proofs/Erdos771IntermediateUpper.lean",
+      "filename": "Erdos771IntermediateUpper.lean",
+      "lineCount": 141,
+      "theoremCount": 4,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos771IntermediateUpper.lean"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Advances the **open intermediate regime** of Erdős #771. Let `f_m(n)` be the largest size of an `m`-avoiding subset of `{1,…,n}` (no nonempty subset sums to `m`), and `T(k) := k(k+1)/2`.

The cluster already pins the exact value at **both ends** of the range of `m`:
- small `m` (`1 ≤ m ≤ n`): `f_m(n) = n − ⌈m/2⌉` (`Erdos771GeneralUpper/LowerBound`);
- high `m` (`T(n−1) < m ≤ T(n)`): `f_m(n) = n − 1` (`Erdos771HighRegime`, #39123).

The whole **intermediate regime `n < m ≤ T(n−1)`** — the genuine matching-number core — was otherwise open. This PR proves the pair-only upper bound for its **bottom slice `n < m ≤ 2n`**.

## New file (0-sorry / 0-axiom)

`proofs/Proofs/Erdos771IntermediateUpper.lean` (4 decls, self-contained on `Erdos771Construction` + `Erdos771GeneralUpperBound`, whose `blk`/`blk_sum`/`blk_disjoint`/`sum_mem_subsetSums` are reused verbatim):

- **`blk_subset_high`** — the pairs `{i, m−i}` for `m−n ≤ i < ⌈m/2⌉` stay inside `{1,…,n}` (the lower index bound forces `m−i ≤ n`; `i < ⌈m/2⌉` with `m ≤ 2n` forces `i ≤ n`). The singleton block `{m}` is dropped since `m > n`.
- **`avoid_card_le_intermediate`** — these `⌈m/2⌉ − (m−n)` pairwise-disjoint `m`-representations force that many deletions, so `f_m(n) ≤ n − (⌈m/2⌉ − (m−n))` for `1 ≤ n`, `n < m ≤ 2n`.
- **`avoid_card_le_intermediate_closed`** — the RHS is exactly `⌊m/2⌋`.
- **`intermediate_top_matches_high`** — at `m = 2n−1` the bound equals `n−1`, matching the high regime (where the pair-only family stops improving).

Combined with the always-valid `f_m(n) ≤ n−1` (every `m ≤ T(n)` is a subset sum of `{1,…,n}`), this gives `f_m(n) ≤ min(n−1, ⌊m/2⌋)` — a **strict improvement over `n−1` for `m ≤ 2n−3`**. For `n ≥ 5` the whole slice `n < m ≤ 2n−1` sits strictly below `T(n−1)`, so this genuinely advances the open regime.

## Tightness (honest framing)

The bound is **exact at the bottom** of the regime (brute-force ground truth: `f_5(4)=2`, `f_6(5)=3`, `f_7(6)=3`, `f_8(6)=4`, …) but becomes **loose near `m = 2n`**, where triples contribute additional disjoint representations the pair family misses (e.g. `f_9(5)=3 < 4 = ⌊9/2⌋`). This is stated in the file/knowledge notes as a machine-checked observation, **not** proved as a theorem. Pinning the exact value throughout `n < m ≤ T(n−1)` remains the open matching-number problem.

## Verification

`./proofs/scripts/docker-build.sh Proofs.Erdos771IntermediateUpper` — **GREEN under v4.31.0**, 0 warnings on the new file. No `native_decide`/`sorry`/`axiom`; the 0-axiom dependency chain gives foundational axioms only (`propext`, `Classical.choice`, `Quot.sound`).

## Status

**Outcome**: progress. The open intermediate regime is narrowed — its bottom slice `n < m ≤ 2n−3` now has a strict-improvement upper bound. The upper part (`2n < m ≤ T(n−1)`, and the loose sub-part near `m=2n`) needs the general triple/matching count. Deep asymptotics `f(n) = (1/2 + o(1))·n/log n` remain external axioms.

🤖 Generated by researcher-1