### PR TITLE
audit: erdos-753 — drop 11 phantom declarations, correct axiomatized prose

### DIFF
--- a/src/data/proofs/erdos-753/meta.json
+++ b/src/data/proofs/erdos-753/meta.json
@@ -52,17 +52,14 @@
       "ListAssignment, IsKListAssignment: list assignment framework with Set.ncard",
       "IsLColoring: proper coloring from vertex-specific lists",
       "IsKChoosable: k-choosability as universal quantification over list assignments",
-      "listChromaticNumber: axiomatized with achieved and minimal properties",
+      "listChromaticNumber: axiomatized as a ℕ-valued function (axiom)",
       "complementGraph: G^c definition with proved symmetry and loopless",
       "complement_complement: PROVED (G^c)^c = G by ext and case analysis",
       "ERTConjecture: formal statement of the Erdős-Rubin-Taylor conjecture",
       "alon_counterexample: Alon's O(sqrt(n log n)) bound (axiom)",
       "conjecture_false: PROVED ERTConjecture is false via asymptotic analysis",
-      "list_chromatic_ge_chromatic, trivial_lower_bound: comparison bounds (axioms)",
-      "nordhaus_gaddum, nordhaus_gaddum_upper: classical bounds for ordinary chi (axioms)",
-      "list_chromatic_differs_from_chromatic: Voigt's example chi_L > chi (axiom)",
-      "bipartite_not_always_two_choosable, complete_graph_list_chromatic: choosability examples",
-      "erdos_753_summary: PROVED conjunction of conjecture_false and alon_counterexample"
+      "erdos_753_summary: PROVED conjunction of conjecture_false and alon_counterexample",
+      "Context results (χ_L ≥ χ, √n lower bound, Δ+1 greedy bound, Nordhaus-Gaddum 2√n / n+1, Voigt's χ_L > χ example, bipartite/complete/Galvin choosability) are discussed in explanatory comments only — not formalized as Lean declarations"
     ],
     "axiomCount": 2,
     "lineCount": 310,
@@ -74,7 +71,7 @@
     "historicalContext": "**The List Chromatic Number and Nordhaus-Gaddum Bounds**\n\nThe list chromatic number χ_L(G) (choosability) was introduced by Erdős, Rubin, and Taylor as a generalization of ordinary graph coloring. While χ(G) asks for the minimum colors from a shared palette, χ_L(G) asks for the minimum k such that any assignment of k-element color lists to vertices admits a proper coloring.\n\n**The Nordhaus-Gaddum Motivation:**\n\nThe classical Nordhaus-Gaddum theorem (1956) gives tight bounds for ordinary chromatic number: 2√n ≤ χ(G) + χ(G^c) ≤ n + 1. This naturally led Erdős, Rubin, and Taylor to ask whether χ_L(G) + χ_L(G^c) also grows polynomially faster than √n — specifically, whether there exists c > 0 with χ_L(G) + χ_L(G^c) > n^{1/2+c}.\n\n**Alon's Disproof (1992):**\n\nNoga Alon resolved the question negatively using the probabilistic method. Random graphs G(n, 1/2) have the property that G and G^c are identically distributed, and both have list chromatic number approximately √(n log n)/2. This gives counterexamples where χ_L(G) + χ_L(G^c) = O(√(n log n)). Since √(n log n) = o(n^{1/2+c}) for any c > 0, the conjecture fails.\n\n**The Logarithmic Gap:**\n\nThe remaining question is whether the log factor is necessary: the best known bounds are √n ≤ χ_L(G) + χ_L(G^c) ≤ O(√(n log n)). Whether the log factor can be removed (i.e., whether √n is the correct order) remains open.\n\n**List vs Ordinary Chromatic Number:**\n\nThe result highlights fundamental differences between χ and χ_L. While χ_L(G) ≥ χ(G) always holds, the inequality can be strict (Voigt's planar example), and complement sum bounds behave very differently.",
     "problemStatement": "The list chromatic number χ_L(G) is defined to be the minimal k such that for any assignment of a list of k colours to each vertex of G (perhaps different lists for different vertices), a colouring of each vertex by a colour on its list can be chosen such that adjacent vertices receive distinct colours. Does there exist some constant c > 0 such that χ_L(G) + χ_L(G^c) > n^{1/2+c} for every graph G on n vertices (where G^c is the complement of G)?",
     "text": "Does there exist some constant c > 0 such that χ_L(G) + χ_L(G^c) > n^{1/2+c} for every graph G on n vertices? Answer: NO (Alon 1992) - counterexamples exist with χ_L(G) + χ_L(G^c) ≤ O((n log n)^{1/2}).",
-    "proofStrategy": "**Formalization Approach**\n\nThe formalization builds the complete list coloring framework:\n\n1. **List Coloring**: ListAssignment, IsKListAssignment (with Set.ncard), IsLColoring (list-restricted proper coloring), IsKChoosable (universal over all list assignments)\n\n2. **List Chromatic Number**: Axiomatized with existence (listChromaticNumber_achieved) and minimality (listChromaticNumber_minimal)\n\n3. **Complement Graph**: complementGraph defined with proved symmetry and loopless; complement_complement PROVED as involution\n\n4. **Conjecture and Disproof**: ERTConjecture formalized precisely; alon_counterexample axiomatized; conjecture_false PROVED via multi-step asymptotic analysis (0 sorries)\n\n5. **Context Results**: Nordhaus-Gaddum bounds, chi_L >= chi, choosability examples (bipartite, complete, Galvin)",
+    "proofStrategy": "**Formalization Approach**\n\nThe formalization builds the complete list coloring framework:\n\n1. **List Coloring**: ListAssignment, IsKListAssignment (with Set.ncard), IsLColoring (list-restricted proper coloring), IsKChoosable (universal over all list assignments)\n\n2. **List Chromatic Number**: listChromaticNumber axiomatized as a ℕ-valued function\n\n3. **Complement Graph**: complementGraph defined with proved symmetry and loopless; complement_complement PROVED as involution\n\n4. **Conjecture and Disproof**: ERTConjecture formalized precisely; alon_counterexample axiomatized; conjecture_false PROVED via multi-step asymptotic analysis (0 sorries)\n\n5. **Context Results**: Nordhaus-Gaddum bounds, chi_L >= chi, and choosability examples (bipartite, complete, Galvin) appear as explanatory comments only — not as formal Lean declarations",
     "keyInsights": [
       "List chromatic number generalizes chromatic number with a universal quantifier over list assignments, making it much harder to analyze but more relevant to constrained coloring problems",
       "The complement graph G^c has edges exactly where G has non-edges; the proved involution (G^c)^c = G ensures the complement operation is well-behaved",
@@ -93,8 +90,8 @@
       "title": "List Coloring Definitions",
       "startLine": 38,
       "endLine": 87,
-      "summary": "ListAssignment (V → Set C), IsKListAssignment (|L(v)| >= k via Set.ncard), IsLColoring (c(v) in L(v) and proper), IsKChoosable (forall k-list, exists L-coloring). listChromaticNumber axiomatized with achieved and minimal properties.",
-      "mathContext": "ListAssignment (V → Set C), IsKListAssignment (|L(v)| >= k via Set.ncard), IsLColoring (c(v) in L(v) and proper), IsKChoosable (forall k-list, exists L-coloring). listChromaticNumber axiomatized with achieved and minimal properties."
+      "summary": "ListAssignment (V → Set C), IsKListAssignment (|L(v)| >= k via Set.ncard), IsLColoring (c(v) in L(v) and proper), IsKChoosable (forall k-list, exists L-coloring). listChromaticNumber axiomatized as a ℕ-valued function.",
+      "mathContext": "ListAssignment (V → Set C), IsKListAssignment (|L(v)| >= k via Set.ncard), IsLColoring (c(v) in L(v) and proper), IsKChoosable (forall k-list, exists L-coloring). listChromaticNumber axiomatized as a ℕ-valued function."
     },
     {
       "id": "complement-graph",
@@ -125,8 +122,8 @@
       "title": "Bounds and Relations",
       "startLine": 163,
       "endLine": 189,
-      "summary": "list_chromatic_ge_chromatic: chi_L >= chi. trivial_lower_bound: sum >= sqrt(n). list_chromatic_le_max_degree_plus_one: chi_L <= Delta+1 (simplified).",
-      "mathContext": "list_chromatic_ge_chromatic: chi_L >= chi. trivial_lower_bound: sum >= $\\sqrt{n}$. list_chromatic_le_max_degree_plus_one: chi_L <= Delta+1 (simplified)."
+      "summary": "Part V explanatory comments only (no formal Lean declarations): chi_L >= chi; sum >= sqrt(n) lower bound; chi_L <= Delta+1 greedy upper bound.",
+      "mathContext": "Part V explanatory comments only (no formal Lean declarations): chi_L >= chi; sum >= $\\sqrt{n}$ lower bound; chi_L <= Delta+1 greedy upper bound."
     },
     {
       "id": "probabilistic",
@@ -141,16 +138,16 @@
       "title": "Related Results",
       "startLine": 209,
       "endLine": 237,
-      "summary": "nordhaus_gaddum: chi(G)+chi(G^c) >= 2*sqrt(n). nordhaus_gaddum_upper: sum <= n+1. list_chromatic_differs_from_chromatic: Voigt's example chi_L > chi.",
-      "mathContext": "nordhaus_gaddum: chi(G)+chi(G^c) >= 2*$\\sqrt{n}$. nordhaus_gaddum_upper: sum <= n+1. list_chromatic_differs_from_chromatic: Voigt's example chi_L > chi."
+      "summary": "Part VII explanatory comments only (no formal Lean declarations): Nordhaus-Gaddum bounds 2*sqrt(n) <= chi(G)+chi(G^c) <= n+1; chi_L differs from chi (Voigt's example).",
+      "mathContext": "Part VII explanatory comments only (no formal Lean declarations): Nordhaus-Gaddum bounds 2*$\\sqrt{n}$ <= chi(G)+chi(G^c) <= n+1; chi_L differs from chi (Voigt's example)."
     },
     {
       "id": "choosability-properties",
       "title": "Choosability Properties",
       "startLine": 238,
       "endLine": 264,
-      "summary": "bipartite_not_always_two_choosable: chi=2 but chi_L>2. complete_graph_list_chromatic: chi_L(K_n)=n. galvin_theorem: chi_L(K_{n,n}) = 1+ceil(log_2(n)).",
-      "mathContext": "Discussed in comments (not formal Lean proofs): bipartite_not_always_two_choosable: chi=2 but chi_L>2. complete_graph_list_chromatic: chi_L(K_n)=n. galvin_theorem: chi_L(K_{n,n}) = 1+ceil(log_2(n))."
+      "summary": "Part VIII explanatory comments only (no formal Lean declarations): bipartite graphs not always 2-choosable (chi=2 but chi_L>2); chi_L(K_n)=n; chi_L(K_{n,n}) = 1+ceil(log_2(n)) (Galvin).",
+      "mathContext": "Part VIII explanatory comments only (not formal Lean proofs): bipartite graphs not always 2-choosable (chi=2 but chi_L>2); chi_L(K_n)=n; chi_L(K_{n,n}) = 1+ceil(log_2(n)) (Galvin)."
     },
     {
       "id": "summary",


### PR DESCRIPTION
## Gallery Integrity Audit

**Proof**: erdos-753 (Erdős Problem #753: List Chromatic Number of Graph and Complement)
**Result**: issues-found → fixed (prose only; badge/status/counts unchanged)

## Problem

`axiomCount` (2), `theoremCount` (3), `definitionCount` (6), and `sorries` (0) all match the Lean source. However the **prose** named **11 declarations that do not exist** in `Proofs/Erdos753Problem.lean` — they appear only as explanatory `/- ... -/` comments (Parts V–VIII):

| Named in meta | Actual state |
|---|---|
| `listChromaticNumber_achieved`, `listChromaticNumber_minimal` | phantom (no such axioms; `listChromaticNumber` is a bare ℕ-valued `axiom`) |
| `list_chromatic_ge_chromatic`, `trivial_lower_bound` | comments only — falsely labeled "(axioms)" |
| `list_chromatic_le_max_degree_plus_one` | comment only |
| `nordhaus_gaddum`, `nordhaus_gaddum_upper` | comments only — falsely labeled "(axioms)" |
| `list_chromatic_differs_from_chromatic` | comment only — falsely labeled "(axiom)" |
| `bipartite_not_always_two_choosable`, `complete_graph_list_chromatic`, `galvin_theorem` | comments only |

The "(axioms)"/"(axiom)" labels overstate the axiomatization: they imply formal axiom declarations for Nordhaus-Gaddum bounds, χ_L ≥ χ, and Voigt's example that the file does not contain.

## Actual declarations (verified)

- **Axioms (2)**: `listChromaticNumber`, `alon_counterexample`
- **Theorems (3)**: `complement_complement`, `conjecture_false`, `erdos_753_summary`
- **Defs (6)**: `ListAssignment`, `IsKListAssignment`, `IsLColoring`, `IsKChoosable`, `complementGraph`, `ERTConjecture`
- 0 sorries, 0 native_decide

## Fix

Corrected `originalContributions`, `proofStrategy`, and the `list-coloring-defs`, `bounds-relations`, `related-results`, and `choosability-properties` section summaries to describe the context results as Part V/VII/VIII explanatory comments only — not formal Lean declarations. Counts, badge (`axiom`), and status (`axiomatized`) are unchanged and correct.

---
Discovered during gallery integrity audit (reserve mode — oldest uncontested target).

🤖 Generated with [Claude Code](https://claude.com/claude-code)