### PR TITLE
audit: erdos-757 — drop phantom Gyárfás-Lehel axiomatization claim

### DIFF
--- a/src/data/proofs/erdos-757/meta.json
+++ b/src/data/proofs/erdos-757/meta.json
@@ -44,7 +44,7 @@
       "Formal definition of Sidon sets via sum characterization",
       "Definition of the almost-Sidon property (|B - B| ≥ 11 for 4-element subsets)",
       "Definition of admissible constants",
-      "Axiomatization of Gyárfás-Lehel bounds (1/2 < c < 3/5)",
+      "Gyárfás-Lehel bounds (1/2 < c < 3/5) documented as prose commentary, not axiomatized (the file contains no axioms)",
       "Properties of Sidon sets and difference sets",
       "Connection to B₂ sequences and extremal combinatorics"
     ],
@@ -58,7 +58,7 @@
     "historicalContext": "A **Sidon set** (or B₂ sequence) is a set where all pairwise sums are distinct. Equivalently, all non-zero differences are distinct. For a 4-element Sidon set, the difference set B - B has exactly 13 elements (including 0).\n\nErdős asked: if every 4-element subset of A has 'almost' this property (|B - B| ≥ 11, missing at most one pair of differences), must A contain a large Sidon subset?\n\nErdős and Sós first proved c ≥ 1/2. Gyárfás and Lehel (1995) improved this to strict bounds:\n- **Lower bound**: c > 1/2 (greedy construction)\n- **Upper bound**: c < 3/5 (Fibonacci numbers as counterexample)\n\nThe exact value of c remains OPEN.",
     "problemStatement": "Let $A \\subset \\mathbb{R}$ be a set of size $n$ such that every subset $B \\subseteq A$ with $|B| = 4$ has $|B - B| \\geq 11$.\n\n**Question**: What is the best constant $c > 0$ such that $A$ must always contain a Sidon set of size $\\geq cn$?\n\n**Known bounds** (Gyárfás-Lehel 1995):\n$$\\frac{1}{2} < c < \\frac{3}{5}$$\n\n**Interpretation**: For any 4 elements in $A$, at most one difference 'collides' with another. The question asks how large a 'fully Sidon' subset can be guaranteed.",
     "text": "Let A ⊂ ℝ be a set of size n such that every 4-element subset B has |B - B| ≥ 11. Find the best constant c > 0 such that A must contain a Sidon set of size ≥ cn. Known: 1/2 < c < 3/5.",
-    "proofStrategy": "We formalize this problem by:\n\n1. **Sidon sets**: A set where a + b = c + d implies {a,b} = {c,d}\n\n2. **Almost-Sidon property**: Every 4-element subset has |B - B| ≥ 11\n\n3. **Admissible constants**: Values c such that almost-Sidon sets contain Sidon subsets of size ≥ cn\n\n4. **Main conjecture**: Find sSup{c : IsAdmissible c}\n\n5. **Known bounds**: Axiomatize Gyárfás-Lehel results\n\n6. **Properties**: Sidon subsets, difference set structure, connection to extremal problems",
+    "proofStrategy": "We formalize this problem by:\n\n1. **Sidon sets**: A set where a + b = c + d implies {a,b} = {c,d}\n\n2. **Almost-Sidon property**: Every 4-element subset has |B - B| ≥ 11\n\n3. **Admissible constants**: Values c such that almost-Sidon sets contain Sidon subsets of size ≥ cn\n\n4. **Main conjecture**: Find sSup{c : IsAdmissible c}\n\n5. **Known bounds**: Gyárfás-Lehel results (1/2 < c < 3/5) recorded as prose commentary — not axiomatized; the file contains no axioms\n\n6. **Properties**: Sidon subsets, difference set structure, connection to extremal problems",
     "keyInsights": [
       "**Why |B - B| = 13 for Sidon 4-sets**: A 4-element set has 6 pairs, giving 12 non-zero differences (±), plus 0.",
       "**Why 11 is special**: Requiring |B - B| ≥ 11 means at most one collision among 4 elements—a minimal relaxation of Sidon.",


### PR DESCRIPTION
## Integrity Issue

**Proof**: erdos-757 (Sidon Sets in Almost-Sidon Families)
**Problem**: meta.json claims the Gyárfás-Lehel bounds are *axiomatized*, but the Lean file contains **zero axioms**.

## Evidence

**meta.json claimed**:
- `originalContributions`: "Axiomatization of Gyárfás-Lehel bounds (1/2 < c < 3/5)"
- `proofStrategy` step 5: "Known bounds: Axiomatize Gyárfás-Lehel results"

**Lean file (`Proofs/Erdos757Problem.lean`) shows**:
- `axiomCount: 0` — grep for `axiom` returns nothing; no `sorry`, no `native_decide`.
- The bounds (1/2 < c < 3/5) appear **only as `/- ... -/` comment prose** (lines 74, 81–90). They are neither axioms nor theorems.
- What is actually formalized: 5 definitions (`IsSidon`, `differenceSet`, `AlmostSidon`, `IsAdmissible`, `IsB2Sequence`) and 8 proved supporting lemmas (e.g. `almostSidon_of_sidon`, difference-set properties, `zero_admissible`). All counts match meta (8 theorems / 5 defs / 0 sorries).

## Fix Applied

Corrected the two prose spots to state the Gyárfás-Lehel bounds are documented commentary, **not axiomatized**. Matches the precedent for erdos-874 (#39293), which relabeled prose bounds as "documented as prose, not axiomatized." `status`/`badge` left unchanged (`axiomatized`/`wip`) — appropriate for an open conjecture with 0 axioms and 0 sorries.

---
Discovered during gallery integrity audit (reserve-mode re-serve).