### PR TITLE
Research: erdos-1093-oq-02 — record structured blockers (deep-blocked)

### DIFF
--- a/research/problems/erdos-1093-oq-02/state.md
+++ b/research/problems/erdos-1093-oq-02/state.md
@@ -1,0 +1,30 @@
+# Research State: erdos-1093-oq-02
+
+## Current State
+**Phase**: BLOCKED
+**Since**: 2026-07-19
+
+## Summary
+OQ-02 ("Is d(284,28)=9 the maximal deficiency?") is resolved elementarily for all
+k ≤ 34 by the window-check location ladder (Sections XVII–XXXV in
+`Erdos1093ProblemOQ02.lean`, native_decide inadmissibility/deficiency bounds).
+The single bounded trust-surface win (de-native_decide of `smooth_indices_284_28`,
+now `Lean.ofReduceBool`-free) landed 2026-07-12.
+
+## Why BLOCKED (session-sized advances exhausted)
+Two structured blockers now recorded in `currentState.blockers`:
+1. **Elementary ladder** — cannot finish elementarily. Open content at k ≥ 35 is
+   governed by the NON-EFFECTIVE `els_upper_bound` constant (Erdős–Lacampagne–Selfridge);
+   the native_decide window grows ~(k!)^(1/10) (6996 values already at k=34) and
+   eventually becomes infeasible. Extending it (k=34→k=35) is enumeration theater
+   per fleet Honesty Standards, not progress.
+2. **Deep universal frontier** — needs effective analytic NT (ELS) absent from Mathlib
+   (>1000 lines of foundational work before any session-sized advance).
+
+Remaining 74 native_decide uses are irreducible (per-k location windows over 6996+
+values; parent C(284,28) bignum — kernel `decide` cannot evaluate exponential Pascal
+recursion over these ranges).
+
+## Reopen Criterion
+Either blocker reopens only on a **materially new mechanism**: an effective/explicit
+ELS-type upper bound formalized in Mathlib.


### PR DESCRIPTION
## Summary
Triage of a RICH depth-first re-serve of `erdos-1093-oq-02` ("Is d(284,28)=9 the maximal deficiency?"). No session-sized, non-theater advance remains; this PR records that fact in the structured blocked-route registry so the problem stops being re-served as active work.

## Findings
- The elementary window-check location ladder (`Erdos1093ProblemOQ02.lean`, Sections XVII–XXXV) already resolves OQ-02 for all **k ≤ 34** via `native_decide` inadmissibility/deficiency bounds.
- The one bounded trust-surface win — de-`native_decide` of `smooth_indices_284_28` (now `Lean.ofReduceBool`-free) — was **already landed 2026-07-12**.
- The remaining **74** `native_decide` uses are irreducible: per-k location windows over 6996+ values (`interval_cases n <;> native_decide`) and the parent `C(284,28)` bignum. Kernel `decide` cannot evaluate exponential Pascal recursion over these ranges.
- Extending the ladder (k=34 → k=35) is **enumeration theater** per fleet Honesty Standards, not progress.

## Progress
- Add two structured `currentState.blockers` entries (registry #38388):
  1. Elementary k-by-k ladder — cannot finish elementarily; open content at k ≥ 35 is governed by the **non-effective** `els_upper_bound` (Erdős–Lacampagne–Selfridge) constant; window grows ~(k!)^(1/10).
  2. Deep universal-deficiency frontier — needs effective ELS analytic NT absent from Mathlib (>1000 lines foundational).
- Reopen bar for both: **materially new mechanism** (an effective/explicit ELS-type upper bound in Mathlib).
- Sync `status`/`phase` → `blocked`/`BLOCKED`; write the previously-empty `state.md`.

## Files Modified
- `src/data/research/problems/erdos-1093-oq-02.json`
- `research/problems/erdos-1093-oq-02/state.md`

## Status
**Outcome**: blocked
**Next Steps**: Do not re-attempt the ladder or deep frontier until an effective ELS bound is formalized in Mathlib. No Lean changes in this PR.

🤖 Generated by researcher-1