### PR TITLE
audit: erdos-762 — drop 3 phantom declarations from section summaries

### DIFF
--- a/src/data/proofs/erdos-762/meta.json
+++ b/src/data/proofs/erdos-762/meta.json
@@ -99,10 +99,10 @@
     {
       "id": "relationship",
       "title": "Relationship Between χ and ζ",
-      "summary": "proper_implies_cochromatic, chi_ge_zeta",
+      "summary": "proper_implies_cochromatic (χ ≥ ζ noted in prose)",
       "startLine": 101,
       "endLine": 123,
-      "mathContext": "proper_implies_cochromatic, chi_ge_zeta"
+      "mathContext": "proper_implies_cochromatic"
     },
     {
       "id": "conjecture",
@@ -131,10 +131,10 @@
     {
       "id": "bounds",
       "title": "Known Bounds",
-      "summary": "zeta_le_chi, steiner_gap_lower_bound",
+      "summary": "Prose notes on the trivial bound ζ ≤ χ and Steiner's gap lower bound (no declarations)",
       "startLine": 198,
       "endLine": 216,
-      "mathContext": "zeta_le_chi, steiner_gap_lower_bound"
+      "mathContext": "Prose notes only: trivial bound ζ ≤ χ; Steiner's gap ≥ 3 for K₅-free graphs"
     },
     {
       "id": "summary",


### PR DESCRIPTION
## Integrity Issue

**Proof**: erdos-762 (Chromatic vs Cochromatic Number)
**Problem**: Section summaries reference declarations that do not exist in the Lean file.

Counts are all accurate — 5 axioms, 0 sorries, no True stubs, no `native_decide`, badge `axiom`, status `axiomatized`. The `originalContributions` (8 items) all map to real declarations. The defect is phantom declaration names in two section summaries.

## Evidence

Actual declarations in `proofs/Proofs/Erdos762Problem.lean`:
- **defs (4)**: `IsProperColoring`, `IsCochromaticColorClass`, `IsCochromaticColoring`, `egs_conjecture`
- **axioms (5)**: `chromaticNumber`, `cliqueNumber`, `cochromaticNumber`, `steiner_counterexample`, `egs_general_theorem`
- **theorems (4)**: `proper_implies_cochromatic`, `egs_conjecture_false`, `chi_zeta_gap_bounded`, `erdos_762_summary`

Phantom references in `meta.json` `sections`:
- `relationship` → `chi_ge_zeta` — **no such declaration**; χ ≥ ζ appears only as a comment (line 121).
- `bounds` → `zeta_le_chi`, `steiner_gap_lower_bound` — **neither exists**; the section (lines 198–216) contains no declarations, only prose comment blocks.

## Fix

Rewrote both section summaries/`mathContext` to describe the prose accurately without naming nonexistent declarations. `originalContributions` left unchanged (all verified real).

---
Discovered during gallery integrity audit (reserve mode, prose re-verification).

🤖 Generated with [Claude Code](https://claude.com/claude-code)