### PR TITLE
research(registry): durably stop re-serving 3 finished nodes (2 completed, 1 blocked)

### DIFF
--- a/research/registry.json
+++ b/research/registry.json
@@ -5308,7 +5308,7 @@
       "phase": "ACT",
       "path": "full",
       "started": "2026-04-25T12:53:24.052Z",
-      "status": "active",
+      "status": "completed",
       "lastUpdate": "2026-06-30T22:33:51-07:00"
     },
     {

--- a/research/registry.json
+++ b/research/registry.json
@@ -36262,7 +36262,7 @@
       "phase": "ACT",
       "path": "fast",
       "started": "2026-07-08T06:43:02.497Z",
-      "status": "active",
+      "status": "blocked",
       "lastUpdate": "2026-07-08T13:02:28-07:00"
     },
     {
@@ -36739,7 +36739,7 @@
       "phase": "OBSERVE",
       "path": "full",
       "started": "2026-07-10T00:01:19.561Z",
-      "status": "active",
+      "status": "completed",
       "lastUpdate": "2026-07-10T00:01:19.629Z"
     },
     {


### PR DESCRIPTION
## Summary
The candidate pool is regenerated from git-tracked `research/registry.json`; `registry-sync.ts` only appends new nodes (as `active`) and never propagates tracker completion, so ephemeral `claim-problem.sh update` nudges are clobbered on the next sync and finished nodes keep re-serving in the depth-first RICH tier. This flips three such nodes durably (1 line each).

## Changes
- **cantor-diagonalization-oq-06-oq-01 → `completed`.** `CantorDiagonalizationOQ06OQ01.lean` is 615 lines, **0 sorry / 0 axiom**, verified on main (explicit cardinality-free `diagonalReal`). Tracker already `status=completed`.
- **erdos-1093-oq-02 → `blocked`.** Elementary ladder resolves all k≤34; the bounded trust-surface win is landed; remaining native_decide uses are irreducible and the deep frontier needs effective ELS analytic NT absent from Mathlib. Structured blockers in tracker (#39309).
- **cauchy-schwarz-integral-lp-duality-synthesis → `completed`.** Synthesis theorem `riesz_lp_surjective_general` proved (tracker `status=completed`, "Full Lp duality now 0-axiom"); the lone open item (parent gallery axiom) is architecturally blocked — a >1000-line layering refactor belonging to the parent entry, not this node.

## Files Modified
- `research/registry.json` (3 status lines)

## Status
**Outcome**: infra/registry hygiene (durable stop-re-serve)

🤖 Generated by researcher-1