### PR TITLE
fix(research): durably stop re-serving finished problems (DB status reconcile + pool sync)

### DIFF
--- a/scripts/research/launch-seeker.sh
+++ b/scripts/research/launch-seeker.sh
@@ -182,6 +182,13 @@ You are the **seeker** agent. Your mission is to keep the research pipeline fed 
    # script writes, interleaving stdout progress lines into the JSON and
    # corrupting the reservoir. (Caused 100+ no-op replenish cycles.)
    npx tsx .lean/scripts/extract-problems.ts --json 2>/dev/null
+   # Reconcile finished problems INTO the DB before regenerating the pool.
+   # sync_pool.py treats knowledge.db as the source of truth, but nothing else
+   # propagates completion back into it, so problems marked graduated/blocked in
+   # the git-tracked registry keep their servable DB status and get re-served
+   # forever (140 such rows on 2026-07-19). This one-way reconcile only moves a
+   # servable row to a terminal status; it never resurrects a finished problem.
+   python3 scripts/research/sync-db-status-from-registry.py 2>/dev/null
    # sync_pool.py writes directly to the consumed pool at
    # .lean/state/candidate-pool.json (see #26802). No copy step is needed.
    python3 research/db/sync_pool.py 2>/dev/null

--- a/scripts/research/sync-data.ts
+++ b/scripts/research/sync-data.ts
@@ -397,6 +397,16 @@ function sync(): void {
           poolEntry.status = 'completed'
           updatedInPool++
           console.log(`   🔄 ${DRY_RUN ? 'Would update' : 'Updated'} pool status: ${entry.slug} → completed`)
+        } else if ((entry.status === 'blocked' || entry.status === 'abandoned') && poolEntry.status !== 'skipped') {
+          // Mirror the completed/graduated branch: a registry entry that is
+          // blocked or abandoned must stop being served from the pool.
+          // registryToPoolStatus() already maps these to 'skipped'; without this
+          // branch the pool entry keeps its servable status forever and the
+          // depth-first claimer re-serves finished/blocked problems (see the
+          // 140-entry drift observed 2026-07-19).
+          poolEntry.status = 'skipped'
+          updatedInPool++
+          console.log(`   🔄 ${DRY_RUN ? 'Would update' : 'Updated'} pool status: ${entry.slug} → skipped`)
         }
       }
     }

--- a/scripts/research/sync-db-status-from-registry.py
+++ b/scripts/research/sync-db-status-from-registry.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""
+Reconcile problem status in knowledge.db from the git-tracked registry.
+
+`sync_pool.py` regenerates the consumed candidate pool
+(`.lean/state/candidate-pool.json`) directly from `knowledge.db`, treating the
+DB as the single source of truth. But nothing propagates *completion* back INTO
+the DB: `claim-problem.sh update` writes only the pool, and the Seeker's
+`sync_pool.py` overwrites the pool from the (stale) DB every cycle. So a problem
+that is genuinely finished — marked `graduated`/`blocked` in the git-tracked
+`research/registry.json` (which build.ts derives from each problem's `meta.json`,
+the status source of truth) — keeps its servable `in-progress`/`available`
+status in the DB and is re-served to Researchers forever.
+
+Observed 2026-07-19: 140 DB problems were servable while terminal in the
+registry (131 graduated, 9 blocked); a Researcher hit 3 already-finished
+problems in 3 consecutive RICH-tier claims.
+
+This script closes the loop: it copies terminal registry statuses INTO the DB
+so the next `sync_pool.py` run stops serving them. It only ever moves a problem
+FROM a servable status TO a terminal one — it never resurrects a finished
+problem, so it is safe to run repeatedly and safe to wire into the Seeker cycle
+before `sync_pool.py`.
+
+Mapping (registry status -> DB status):
+    graduated            -> graduated
+    blocked | abandoned  -> blocked
+
+Only DB rows currently in a *servable* status (available / in-progress /
+surveyed) are touched; rows already terminal (completed / graduated / blocked /
+skipped) are left as-is.
+
+Usage:
+    python scripts/research/sync-db-status-from-registry.py            # apply
+    python scripts/research/sync-db-status-from-registry.py --dry-run  # report only
+"""
+
+import json
+import sqlite3
+import sys
+from pathlib import Path
+
+# This script lives in scripts/research/; the DB scripts and data live under
+# research/db/ (gitignored — see #38387), so resolve both from the repo root.
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+DB_PATH = REPO_ROOT / "research" / "db" / "knowledge.db"
+REGISTRY_PATH = REPO_ROOT / "research" / "registry.json"
+
+# DB statuses from which a problem is still handed out to Researchers.
+SERVABLE = {"available", "in-progress", "surveyed"}
+
+# registry status -> desired terminal DB status
+REGISTRY_TO_DB = {
+    "graduated": "graduated",
+    "blocked": "blocked",
+    "abandoned": "blocked",
+}
+
+
+def load_registry_terminal() -> dict:
+    """Return {slug: db_status} for registry entries in a terminal status."""
+    with open(REGISTRY_PATH) as f:
+        registry = json.load(f)
+    result = {}
+    for p in registry.get("problems", []):
+        slug = p.get("slug")
+        target = REGISTRY_TO_DB.get(p.get("status"))
+        if slug and target:
+            result[slug] = target
+    return result
+
+
+def main() -> None:
+    dry_run = "--dry-run" in sys.argv or "-n" in sys.argv
+
+    if not DB_PATH.exists():
+        print(f"Error: Database not found at {DB_PATH}")
+        sys.exit(1)
+
+    terminal = load_registry_terminal()
+
+    conn = sqlite3.connect(DB_PATH)
+    conn.row_factory = sqlite3.Row
+    cur = conn.cursor()
+
+    cur.execute("SELECT slug, status FROM problems")
+    db_status = {row["slug"]: row["status"] for row in cur.fetchall()}
+
+    updates = []  # (slug, old, new)
+    for slug, new_status in terminal.items():
+        old = db_status.get(slug)
+        if old is None:
+            continue  # in registry but not in DB — nothing to reconcile
+        if old in SERVABLE and old != new_status:
+            updates.append((slug, old, new_status))
+
+    graduated = sum(1 for _, _, n in updates if n == "graduated")
+    blocked = sum(1 for _, _, n in updates if n == "blocked")
+
+    print(f"Registry terminal entries: {len(terminal)}")
+    print(f"Servable DB rows to reconcile: {len(updates)} "
+          f"({graduated} -> graduated, {blocked} -> blocked)")
+
+    if dry_run:
+        for slug, old, new in updates[:50]:
+            print(f"  [dry-run] {slug}: {old} -> {new}")
+        if len(updates) > 50:
+            print(f"  ... and {len(updates) - 50} more")
+        print("\n[DRY RUN] no rows written")
+        conn.close()
+        return
+
+    for slug, _old, new in updates:
+        cur.execute(
+            "UPDATE problems SET status = ?, "
+            "last_updated = CURRENT_TIMESTAMP WHERE slug = ?",
+            (new, slug),
+        )
+    conn.commit()
+    conn.close()
+
+    print(f"✓ Reconciled {len(updates)} DB rows from registry terminal statuses")
+    print("  Run `python research/db/sync_pool.py` to regenerate the pool.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Problem
The Researcher RICH depth-first tier keeps re-serving already-finished problems.
On 2026-07-19 a Researcher hit **3 finished problems in 3 consecutive claims**
(erdos-1039-incomplete-01, euler-polyhedral-formula-oq-02-oq-02,
brouwer-fixed-point-oq-02-oq-02-oq-01 — all `graduated` in the registry, 0 sorry).

## Root cause
`research/db/knowledge.db` is the declared single source of truth: the Seeker
runs `research/db/sync_pool.py` every cycle to regenerate the consumed pool
(`.lean/state/candidate-pool.json`) directly from the DB. **But nothing
propagates completion back INTO the DB.** `claim-problem.sh update` writes only
the pool, so the Seeker's next `sync_pool.py` overwrites it from the stale DB. A
problem marked `graduated`/`blocked` in the git-tracked `registry.json` (which
`build.ts` derives from each `meta.json`, the status source of truth) keeps its
servable `in-progress`/`available` DB status and is handed out forever.

Measured drift: **140 DB rows servable while terminal in the registry** (131
graduated, 9 blocked).

## Fix
1. **`scripts/research/sync-db-status-from-registry.py`** (new) — one-way
   reconcile that copies terminal registry statuses INTO the DB
   (`graduated → graduated`, `blocked`/`abandoned → blocked`), but only for rows
   currently in a servable status. It never resurrects a finished problem, so it
   is safe to run every cycle and idempotent. Lives under `scripts/research/`
   because `research/db/` is gitignored (the untracked-DB-scripts gap, #38387).
2. **`launch-seeker.sh`** — runs the reconcile immediately before `sync_pool.py`
   in the reservoir-replenish step, so the DB is corrected before the pool is
   regenerated.
3. **`sync-data.ts`** — complementary correctness fix on the registry→pool path:
   section 2 only mirrored `graduated → completed` and dropped
   `blocked`/`abandoned → skipped`. (Latent on its own — `sync-data.ts` is not in
   the Seeker cycle and `sync_pool.py` clobbers its pool edits — but correct.)

## Verification (against the live DB)
- `sync-db-status-from-registry.py --dry-run`: reported 140 rows (131 graduated,
  9 blocked). After apply + `sync_pool.py`: pool↔registry divergence **140 → 0**,
  DB `in-progress` **237 → 103**. Re-run dry-run: **0 rows** (idempotent).
- `sync-data.ts --dry-run`: now emits `→ skipped` for blocked/abandoned; pool
  updates 141 → 192; registry/meta updates unchanged at 0.
- The live DB and pool were reconciled out-of-band as part of this session, so
  the fleet stops re-serving these 140 immediately; this PR makes it durable.

## Status
**Outcome**: research-pipeline infra fix (durably stops re-serving finished problems)

🤖 Generated by researcher-1