### PR TITLE
Enrich Dihedral Index-2 Orbit Folding: link children answering its open questions

### DIFF
--- a/src/data/proofs/burnside-counting-oq-04/meta.json
+++ b/src/data/proofs/burnside-counting-oq-04/meta.json
@@ -128,6 +128,16 @@
   ],
   "crossReferences": [
     {
+      "targetId": "burnside-counting-oq-04-oq-01",
+      "relationship": "extended-by",
+      "description": "Answers this entry's openQuestions[0]: builds a concrete faithful dihedral action ρ : DihedralGroup 4 → Perm (ZMod 4) on the binary colourings and discharges the necklace-count and reflection-total hypotheses of the folding theorem by kernel computation, giving the unconditional |bracelets(4,2)| = 6 without native_decide."
+    },
+    {
+      "targetId": "burnside-counting-oq-04-oq-02",
+      "relationship": "extended-by",
+      "description": "Answers this entry's openQuestions[1]: generalises the concrete construction from D₄ to D_n for every n (reflection form sr i : x ↦ -i-x), specialising the index-2 folding to the general-n dihedral bracelet Burnside identity b(n) = (necklaces(n) + reflection-total(n))/(2n)."
+    },
+    {
       "targetId": "burnside-counting",
       "relationship": "extends",
       "description": "Extends the base cyclic necklace count to the dihedral group by giving the abstract index-2 folding that relates bracelet counts to necklace counts."
@@ -147,8 +157,8 @@
     "summary": "Adding reflections to Burnside necklace counting is captured abstractly by index-2 orbit folding: for any finite G acting on finite X and any subgroup H ≤ G, |X/G|·|G| = |X/H|·|H| + Σ_{g ∉ H} |Fix(g)|. With G = D_n and H = ℤ/nℤ this is the classical bracelets-from-necklaces formula; the file proves it with 0 axioms and no native_decide, adds the |G| = 2|H| doubling form, and verifies the length-4 binary instance (6 bracelets).",
     "implications": "Provides the reusable assembly step that turns per-symmetry fixed-point counts (rotation counts of oq-03, reflection counts of oq-05) into dihedral orbit counts, stated in full generality for any subgroup rather than only the dihedral case.",
     "openQuestions": [
-      "Build a concrete dihedral action on Coloring n k and discharge the necklace and reflection-total hypotheses of binary_four_bracelet_count by kernel computation, yielding an unconditional |bracelets| = 6 (the parent closes the analogous cyclic count only with native_decide).",
-      "Specialise the folding theorem to a fully formalized closed form for the binary bracelet numbers b(n) = (necklaces(n) + reflection-total(n))/(2n) for general n."
+      "Build a concrete dihedral action on Coloring n k and discharge the necklace and reflection-total hypotheses of binary_four_bracelet_count by kernel computation, yielding an unconditional |bracelets| = 6 (the parent closes the analogous cyclic count only with native_decide) — now realized in the gallery by burnside-counting-oq-04-oq-01.",
+      "Specialise the folding theorem to a fully formalized closed form for the binary bracelet numbers b(n) = (necklaces(n) + reflection-total(n))/(2n) for general n — now realized in the gallery by burnside-counting-oq-04-oq-02 (the general-n dihedral construction and its Burnside identity)."
     ]
   },
   "leanFile": {


### PR DESCRIPTION
## Enrichment pass — `burnside-counting-oq-04` (Burnside to the Dihedral Group: Index-2 Orbit Folding)

The entry was already at quality target on prose/annotations/sections. The one genuine gap was **navigational**: both of its child entries link *back* to it, but `oq-04` had **no forward links** to them — even though its two openQuestions are answered verbatim by those children.

### What changed (meta.json only)
- **+2 crossReferences** (`extended-by`) to the children that discharge its open questions:
  - `burnside-counting-oq-04-oq-01` — unconditional `|bracelets(4,2)| = 6` via a concrete faithful D₄ action (no native_decide), answering openQuestions[0].
  - `burnside-counting-oq-04-oq-02` — the general-n dihedral construction and its Burnside identity `b(n) = (necklaces(n) + reflection-total(n))/(2n)`, answering openQuestions[1].
- **openQuestions[0] and [1]** annotated as *now realized in the gallery* by those two children (still accurate as open directions, but no longer implying the gallery lacks them).

### Why this is enrichment, not accretion
Restores missing forward edges in an asymmetric cross-reference graph; no scorer-gaming insight or section-split added. crossReferences 3 → 5 (cap 20). meta.json 13.4 KB → 14.4 KB (cap ~60 KB).

### Verification
JSON parses cleanly. (Sibling PR #39325 applied the same forward-link fix to `oq-03-oq-02-oq-01-oq-02`.)