### PR TITLE
Enrich Totient Necklace Congruence: add sibling link to the Möbius companion

### DIFF
--- a/src/data/proofs/burnside-counting-oq-06-oq-01/meta.json
+++ b/src/data/proofs/burnside-counting-oq-06-oq-01/meta.json
@@ -189,6 +189,12 @@
       "targetId": "burnside-counting",
       "relationship": "extends",
       "description": "Delivers the number-theoretic payoff of the root Burnside/necklace framework at general modulus: the totient (Gauss-type) congruence n ∣ ∑_{d∣n} φ(n/d) k^d generalizing the prime-length Fermat case."
+    },
+    {
+      "id": "xref-burnside-oq0602-mobius-sibling",
+      "targetId": "burnside-counting-oq-06-oq-02",
+      "relationship": "sibling",
+      "description": "The Möbius companion under the same parent (oq-06): this entry generalizes Fermat via the φ-weighted total count ∑_{d∣n} φ(n/d)·k^d (all necklaces), while the sibling handles the μ-weighted aperiodic (Lyndon-word) count (1/n)·∑_{d∣n} μ(d)·k^{n/d}. Both closed forms collapse at a prime to the same Fermat congruence k^p ≡ k (mod p) — the φ-form and μ-form being the two classical divisor-sum expressions the Burnside necklace count admits."
     }
   ]
 }


### PR DESCRIPTION
## Enrichment pass — `burnside-counting-oq-06-oq-01` (Totient Necklace Congruence at Arbitrary Modulus)

Upstream cross-references were already complete (parent `oq-06`, the divisor-form `oq-03-oq-02-oq-01-oq-02` it generalizes, and the base entry). The one genuine missing edge: **no sibling link to `oq-06-oq-02`**, the Möbius/Lyndon companion under the same parent — neither child linked to the other.

### What changed (meta.json only)
- **+1 crossReference** (`sibling`) to `burnside-counting-oq-06-oq-02`: this entry generalizes Fermat via the φ-weighted **total** necklace count `∑_{d∣n} φ(n/d)·k^d`, while the sibling handles the μ-weighted **aperiodic** (Lyndon-word) count `(1/n)·∑_{d∣n} μ(d)·k^{n/d}`; both collapse at a prime to the same Fermat congruence. These are the two classical divisor-sum expressions the Burnside necklace count admits.

### Why this is enrichment, not accretion
A single but structurally real edge: the φ-form/μ-form companion pair was disconnected in the cross-reference graph. Description carries genuine mathematical content (the two closed forms and their common prime specialization), not a filler field. crossReferences 3 → 4 (cap 20). meta.json 18.7 KB → 19.3 KB.

### Verification
JSON parses cleanly. Part of a burnside-family forward/lateral-linking sweep (siblings #39325, #39326, #39327).