### PR TITLE
audit: erdos-747 — drop 6 phantom declarations from section summaries, fix axiom/def labels

### DIFF
--- a/src/data/proofs/erdos-747/meta.json
+++ b/src/data/proofs/erdos-747/meta.json
@@ -64,7 +64,7 @@
       "shamirThreshold definition: ℓ(n) = n log n",
       "johansson_kahn_vu axiom: threshold ≍ n log n",
       "kahn_precise_threshold axiom: threshold ~ n log n",
-      "erdos_747 theorem: main result"
+      "erdos_747 axiom: main result (axiomatized)"
     ],
     "axiomCount": 5,
     "lineCount": 313,
@@ -128,18 +128,18 @@
     {
       "id": "answer",
       "title": "The Answer",
-      "summary": "shamirThreshold, johansson_kahn_vu, kahn_precise_threshold axioms",
+      "summary": "shamirThreshold def; johansson_kahn_vu, kahn_precise_threshold axioms",
       "startLine": 145,
       "endLine": 186,
-      "mathContext": "Axiomatized: shamirThreshold, johansson_kahn_vu, kahn_precise_threshold axioms"
+      "mathContext": "shamirThreshold def; axiomatized: johansson_kahn_vu, kahn_precise_threshold"
     },
     {
       "id": "below-threshold",
       "title": "Below the Threshold",
-      "summary": "below_threshold_fails, isolated_vertices_obstruction axioms",
+      "summary": "below_threshold_fails axiom (isolated-vertex obstruction noted in prose)",
       "startLine": 187,
       "endLine": 207,
-      "mathContext": "Axiomatized: below_threshold_fails, isolated_vertices_obstruction axioms"
+      "mathContext": "Axiomatized: below_threshold_fails axiom"
     },
     {
       "id": "above-threshold",
@@ -152,18 +152,18 @@
     {
       "id": "comparison",
       "title": "Comparison with Graphs",
-      "summary": "graph_matching_threshold, uniformity_independence",
+      "summary": "Prose notes: graph case (r=2) threshold and uniformity independence (no declarations)",
       "startLine": 229,
       "endLine": 250,
-      "mathContext": "Mathematical content: graph_matching_threshold, uniformity_independence"
+      "mathContext": "Expository prose: comparison with the r=2 graph case and uniformity independence"
     },
     {
       "id": "history",
       "title": "Historical Notes",
-      "summary": "erdos_comment, shamir_1979, factor_problems",
+      "summary": "Prose notes: Erdős's comment, Shamir's 1979 question, factor problems (no declarations)",
       "startLine": 251,
       "endLine": 275,
-      "mathContext": "Mathematical content: erdos_comment, shamir_1979, factor_problems"
+      "mathContext": "Expository prose: historical notes (Erdős's comment, Shamir 1979, factor problems)"
     },
     {
       "id": "summary",


### PR DESCRIPTION
## Integrity Issue

**Proof**: erdos-747 (Erdős #747, Shamir's Problem)
**Problem**: Section summaries name snake_case identifiers that are **not declarations** — they are prose comment blocks — plus two axiom/def mislabels.

## Evidence

Verified against `Proofs/Erdos747Problem.lean`. Actual declarations: 5 axioms (`johansson_kahn_vu`, `kahn_precise_threshold`, `below_threshold_fails`, `above_threshold_succeeds`, `erdos_747`), 2 theorems (`erdos_747_answer`, `erdos_747_summary`), 13 defs. These match `axiomCount`/`theoremCount`/`definitionCount`/`sorries`. ✅

Phantom identifiers in section summaries (absent from the file — only `/- ... -/` prose):

- **below-threshold**: claimed `isolated_vertices_obstruction axioms` → phantom; the section has exactly one axiom (`below_threshold_fails`). The obstruction is a prose note (lines 200-203).
- **comparison**: `graph_matching_threshold, uniformity_independence` → phantom; section is expository prose (lines 224-237), no declarations.
- **history**: `erdos_comment, shamir_1979, factor_problems` → phantom; prose only (lines 243-259).

Mislabels:
- **answer** section listed the `shamirThreshold` *def* among "axioms".
- `originalContributions` called `erdos_747` a "theorem"; it is an `axiom` (line 268).

## Fix

meta.json prose only — scope section summaries to real declarations, mark expository sections as prose, correct the def/axiom labels. No Lean source changes; all public counts already accurate.

---
Discovered during gallery integrity audit (reserve mode, prose-vs-declaration re-verification).