### PR TITLE
audit: erdos-740 — fix 5 phantom declaration names in originalContributions

### DIFF
--- a/src/data/proofs/erdos-740/meta.json
+++ b/src/data/proofs/erdos-740/meta.json
@@ -46,10 +46,10 @@
     "originalContributions": [
       "chromaticNumber: Cardinal-valued chromatic number for infinite graphs (noncomputable via iInf)",
       "isColorable: predicate checking if a graph is k-colorable via a proper coloring function",
-      "hasCycle / hasOddCycle: predicates for the presence of cycles and odd cycles of length ≤ r",
-      "avoidsOddCyclesOf: predicate for a subgraph avoiding all odd cycles of length ≤ r",
-      "erdosHajnal_conjecture: formal statement of the Erdős-Hajnal conjecture for all infinite cardinals",
-      "girth_implies_odd_avoidance: girth > 2r implies avoidance of all odd cycles of length ≤ r"
+      "isOddCycle / containsOddCycleLeq: predicates for a cycle being odd and for the presence of an odd cycle of length ≤ r",
+      "noOddCyclesLeq: predicate for a subgraph avoiding all odd cycles of length ≤ r",
+      "erdosHajnalConjecture: formal statement of the Erdős-Hajnal conjecture for all infinite cardinals",
+      "girth_implies_odd: girth conjecture (avoiding all cycles ≤ r) implies avoidance of all odd cycles of length ≤ r"
     ],
     "theoremCount": 5,
     "definitionCount": 22


### PR DESCRIPTION
## Gallery Integrity Audit

**Proof**: erdos-740 (Erdős Problem #740: Chromatic Number and Odd Cycle Avoidance)

Reserve-mode re-audit (unaudited queue drained). `originalContributions` in `meta.json` named five declarations that do not exist in `proofs/Proofs/Erdos740Problem.lean`.

### Evidence

| Prose (phantom) | Actual declaration |
|---|---|
| `hasCycle` / `hasOddCycle` | `isOddCycle` / `containsOddCycleLeq` |
| `avoidsOddCyclesOf` | `noOddCyclesLeq` |
| `erdosHajnal_conjecture` | `erdosHajnalConjecture` |
| `girth_implies_odd_avoidance` | `girth_implies_odd` |

Confirmed none of the phantom names appear in either `Erdos740Problem.lean` or `Erdos740ProblemProvable.lean`.

### Verified accurate (no change)

- `axiomCount: 2` — `rodl_theorem`, `finite_triangle_free_progress` ✓
- `sorries: 1` — line 305 ✓
- `theoremCount: 5` ✓, status/badge `axiomatized`/`axiom` ✓
- Section summaries already use the real declaration names.

### Fix

Corrected the four affected `originalContributions` entries to the real declaration names. No count or status changes.

---
Discovered during gallery integrity audit.