### PR TITLE
Enrich burnside-counting family: complete bidirectional cross-references

### DIFF
--- a/src/data/proofs/burnside-counting-oq-04/meta.json
+++ b/src/data/proofs/burnside-counting-oq-04/meta.json
@@ -151,6 +151,16 @@
       "targetId": "burnside-counting-oq-05",
       "relationship": "related",
       "description": "oq-05 supplies the reflection-fixed counts k^((n+1)/2) for odd cycles and lists 'assemble into a closed dihedral count via Burnside' as an open question; this folding theorem is exactly that assembly mechanism."
+    },
+    {
+      "targetId": "burnside-counting-oq-04-oq-01",
+      "relationship": "related",
+      "description": "Answers this entry's first open question: oq-04-oq-01 realizes the abstract index-2 folding concretely, building a self-contained D₄ action on the 2-colourings of the 4-cycle that recovers |bracelets(4,2)| = 6 without assuming the necklace or reflection totals as hypotheses and without native_decide."
+    },
+    {
+      "targetId": "burnside-counting-oq-04-oq-02",
+      "relationship": "related",
+      "description": "Answers this entry's general-n open question: oq-04-oq-02 promotes the concrete D₄ construction to an explicit faithful representation ρ : DihedralGroup n →* Equiv.Perm (ZMod n) for every n (NeZero n), giving the full D_n dihedral bracelet Burnside identity of which this folding theorem is the abstract skeleton."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Enrichment pass — burnside-counting family (2 entries)

Two verified structural cross-reference completions. Both close genuine
one-directional navigation gaps (the counterpart already links back); neither
adds per-section `mathContext` filler.

### 1. `burnside-counting-oq-03-oq-02-oq-01-oq-02` (quality 96, 0 passes)
Forward link to **burnside-counting-oq-06** (Fermat's little theorem via necklaces),
which imports this file's `card_necklaces_mul_eq_sum_divisors` verbatim and already
links back. The general divisor sum `(#necklaces)·n = Σ_{d∣n} φ(n/d)·k^d`
specializing (n → prime p) to its most famous number-theoretic consequence.
crossRefs 2 → 3.

### 2. `burnside-counting-oq-04` (quality 96, 0 passes)
Forward links to its two direct children, both of which already link back:
- **oq-04-oq-01** — concrete D₄ realization recovering `|bracelets(4,2)| = 6`.
- **oq-04-oq-02** — general-n faithful representation `ρ : DihedralGroup n →* Equiv.Perm (ZMod n)`.
crossRefs 3 → 5.

### Guardrails
- All crossReferences well under the 20-item cap; both meta.json files « 60 KB.
- JSON validated; descriptions grounded in the target entries' own metadata.

Enrichment pass by enricher-1.