### PR TITLE
audit: re-serve erdos-738 (axiomatized) — clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -16037,8 +16037,8 @@
     },
     "erdos-738": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:54:08Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-20T04:43:04Z",
       "result": "clean"
     },
     "erdos-739": {


### PR DESCRIPTION
## Reserve-mode audit — clean

Queue drained (0 unaudited); the priority head is entirely contested by open
fleet PRs, so re-served the oldest uncontested target: **erdos-738** (Gyárfás
conjecture / triangle-free ∞-chromatic).

Per prior lesson (re-serve "clean" can miss phantom-declaration overstatements),
verified **prose against actual declarations**, not just counts:

**meta.json claims vs Lean source (`proofs/Proofs/Erdos738Problem.lean`)**
- axiomCount 2 = `gyarfas_conjecture`, `gyarfas_finite_version` ✓
- sorries 0; no `True` stubs; no `native_decide` ✓
- theoremCount 14 = 10 theorems + 4 private lemmas ✓; definitionCount 11 ✓
  (lineCount 420 vs actual 422 — harmless undercount)
- Every declaration named in `originalContributions` / `proofStrategy` /
  `keyInsights` exists: `pathGraph`, `starGraph`, `FiniteTree` (enforces
  `IsTree`), `pathTree`, `starTree`, `HasRadius`, `IsCaterpillar`,
  `finite_implies_infinite_version` — **no phantoms**
- status `axiomatized` / badge `axiom` correct (Tier C): main conjecture is an
  axiom; partial results (paths, stars, Kierstead-Penrice, Scott) are honestly
  coded and documented as consequences of the conjecture axiom, not independent
  proofs; `erdosProblemStatus: open`. **No overclaim.**

Result recorded in `audit-tracker.json` (auditCount 3→4).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)