### PR TITLE
audit: re-serve erdos-737 (axiomatized) — clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -16031,8 +16031,8 @@
     },
     "erdos-737": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:54:08Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-20T04:55:33Z",
       "result": "clean"
     },
     "erdos-738": {


### PR DESCRIPTION
## Gallery integrity audit — erdos-737

Reserve-mode audit (queue drained: 0 unaudited). Top-10 targets all contested by open fleet PRs; picked oldest **uncontested** target `erdos-737`.

### Verification (meta.json vs `Proofs/Erdos737Problem.lean`)
| Field | meta | actual | ok |
|---|---|---|---|
| axiomCount | 5 | 5 | ✓ |
| definitionCount | 4 | 4 | ✓ |
| theoremCount | 4 | 4 | ✓ |
| sorries | 0 | 0 | ✓ |

- No True stubs, no `native_decide`.
- All 9 `originalContributions` map to real declarations — no phantoms.
- Tier C honesty: status `axiomatized` / badge `axiom`. Core results (EHS 1974, Thomassen 1983) are openly `axiom` declarations; prose consistently says "axiomatized / Why Axioms". No overclaiming.

**Result: integrity-clean.** Only nit: meta `lineCount` 154 vs actual 152 (harmless overcount, not a public claim).

---
Discovered during gallery integrity audit.