### PR TITLE
Fix: erdos-731 — remove vacuous True-stub lower_bound_most_n, correct theoremCount 33→32

### DIFF
--- a/proofs/Proofs/Erdos731Problem.lean
+++ b/proofs/Proofs/Erdos731Problem.lean
@@ -127,12 +127,6 @@ theorem least_nondiv_counterexample : ¬Nat.Prime 4 ∧ centralBinom 2 = 6 := by
 
 /- ## Bounds -/
 
-/-- Lower bound: for any P, there exists a density threshold.
-    Placeholder: the actual density claim requires measure theory. -/
-theorem lower_bound_most_n :
-    ∀ (P : ℕ), ∃ (D : ℕ), D > 0 ∧ True :=
-  fun _ => ⟨1, by omega, trivial⟩
-
 /-- C(N, k) divides lcm(1, ..., N) for k ≤ N.
     Proof: For each prime p, v_p(C(N,k)) ≤ log_p(N) = v_p(lcm(1,...,N)).
     The key steps are:

--- a/src/data/proofs/erdos-731/meta.json
+++ b/src/data/proofs/erdos-731/meta.json
@@ -21,7 +21,7 @@
     "erdosUrl": "https://erdosproblems.com/731",
     "erdosProblemStatus": "open",
     "axiomCount": 1,
-    "lineCount": 439,
+    "lineCount": 425,
     "mathlibDependencies": [
       {
         "theorem": "Nat.choose",
@@ -41,7 +41,7 @@
     ],
     "assumptions": "1 axiom declaration: prime_divides_central_iff (Kummer's carry characterization: p | C(2n,n) iff some base-p digit of n is ≥ ⌈p/2⌉). Proved: choose_dvd_lcm (C(N,k) divides lcm(1,...,N+1), via Nat.factorization_choose_le_log), upper_bound_trivial (least non-divisor ≤ 2n+1, by contradiction using choose_dvd_lcm), two_divides_central (Pascal+symmetry), bertrand_central (Bertrand+dvd_choose_add), central_binom_lower (binomial sum+max term). Note: choose_dvd_lcm and upper_bound_trivial are NOT axioms — both are fully proved theorems in the file.",
     "mathlib_version": "4.31.0",
-    "theoremCount": 33,
+    "theoremCount": 32,
     "definitionCount": 3
   },
   "overview": {
@@ -161,9 +161,9 @@
     ],
     "opens": [],
     "namespace": null,
-    "lineCount": 439,
+    "lineCount": 425,
     "axiomCount": 1,
-    "theoremCount": 33,
+    "theoremCount": 32,
     "definitionCount": 3,
     "path": "Proofs/Erdos731Problem.lean",
     "sorries": 0


### PR DESCRIPTION
## Problem (#39344)

`erdos-731` counted a **vacuous True-stub** among its public `theoremCount: 33`:

```lean
theorem lower_bound_most_n :
    ∀ (P : ℕ), ∃ (D : ℕ), D > 0 ∧ True :=
  fun _ => ⟨1, by omega, trivial⟩
```

For any `P`, pick `D = 1`; the payload is `True`. It carries **no lower-bound content**, yet its name reads as the EGRS "lower bound for most n" result (keyInsights[3]), and it was undisclosed in any meta prose.

## Fix

Chose **removal** (option 1 in the issue — cleanest for credibility):

- **Lean**: deleted `theorem lower_bound_most_n` (+ its docstring) from `proofs/Proofs/Erdos731Problem.lean`.
- **meta.json**: `theoremCount` 33 → 32 in both the `meta` and `leanFile` blocks.
- **meta.json**: `lineCount` 439 → 425 (issue noted 439 was already a stale overcount; now accurate: `wc -l` = 425).

## Evidence

- Grep confirms no remaining references to `lower_bound_most_n` anywhere in `proofs/` or `src/data/proofs/erdos-731/` — the stub was self-contained, so removal cannot break compilation of any downstream declaration.
- Post-edit theorem/lemma count via grep = 32, matching the new `theoremCount`.
- meta.json validates as JSON.
- Unrelated fields verified accurate by the auditor and left untouched: `axiomCount: 1`, `sorries: 0`, `status: axiomatized`/`badge: axiom`.

Closes #39344