### PR TITLE
audit: re-serve erdos-728-factorial-divisibility (mathlib, verified) — clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -15953,8 +15953,8 @@
     },
     "erdos-728-factorial-divisibility": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:54:08Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-20T05:09:02Z",
       "result": "clean"
     },
     "erdos-728-factorial-divisibility-oq-04": {


### PR DESCRIPTION
## Gallery Integrity Audit — clean

**Proof**: erdos-728-factorial-divisibility (status `verified`, badge `mathlib`, HIGH claim-risk: famous problem + novel-result framing)

Reserve-mode re-serve (unaudited queue drained; oldest uncontested target). Full re-verify of every technical claim against `Proofs/Erdos728FactorialDivisibility.lean`.

### Counts (meta vs actual — all exact)
| Field | meta | actual |
|---|---|---|
| sorries | 0 | 0 |
| axiomCount | 0 | 0 (only `propext`/`Classical.choice`/`Quot.sound` per `#print axioms`) |
| lineCount | 1416 | 1416 |
| theoremCount | 56 | 56 |
| definitionCount | 29 | 29 |

### Narrative / phantom-declaration checks
- No True stubs, no `native_decide`, no `admit`, no custom `axiom` decls, no assumption-carrying structure fields.
- All 14 named `mainTheorems` exist with matching statements; all prose-referenced lemmas (`lemma_threshold_reduction`, `lemma_markov_exp`, `lemma_mu_lower_bound`, `lemma_small_primes_good`, `lemma_sum_bad_carries_small`, …) exist — **no phantom declarations**.
- `erdos_728` / `erdos_728_fc` genuinely formalize `a! * b! ∣ n! * (a+b-n)!` with the range (`ε·n < a,b`) and logarithmic-gap (`n + C·log n < a+b < n + C'·log n`) constraints — the real theorem, not a proxy bound.
- Badge `mathlib` is appropriately conservative given Kummer reliance (`padicValNat_choose`); "first genuinely novel AI result" language is editorial and attributed (Tao), not a formalization overclaim.

**Result**: integrity-clean. Only change is the audit-tracker bump.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
Discovered during gallery integrity audit.