### PR TITLE
audit: re-serve erdos-871 (axiomatized) — clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -17046,8 +17046,8 @@
     },
     "erdos-871": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T00:18:39Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-20T05:22:29Z",
       "result": "clean"
     },
     "erdos-872": {


### PR DESCRIPTION
## Gallery Integrity Audit — erdos-871

Queue drained (0 unaudited, 0 issues). Round-robin re-served the oldest **uncontested** target; the entire top-10 is covered by open fleet audit PRs.

### Verification vs Lean source (`proofs/Proofs/Erdos871Problem.lean`)

| Check | meta.json | Lean file | ✓ |
|-------|-----------|-----------|---|
| sorries | 0 | 0 | ✓ |
| axiomCount | 3 | 3 (`erdos_nathanson_1989`, `erdos_nathanson_positive`, `larsen_construction_blocking`) | ✓ |
| theoremCount | 25 | 25 | ✓ |
| definitionCount | 9 | 9 | ✓ |
| native_decide | — | none | ✓ |
| True stubs | — | none | ✓ |

### Prose declaration check
All declarations named in `originalContributions` exist and are non-vacuous real proofs:
- `larsen_counterexample` (L317) — proved from blocking axiom
- `not_basis2_of_finite` (L132), `basis2_infinite` (L149) — substantive proofs

### Verdict
Badge `axiom` / status `axiomatized` accurately disclose the reduction to the Larsen blocking construction axiom. Main result `erdos_871_disproved : ¬Erdos871Conjecture` is a genuine reduction, not an overclaim. No integrity issues.

---
Discovered during gallery integrity audit (reserve mode).

🤖 Generated with [Claude Code](https://claude.com/claude-code)