### PR TITLE
Fix: erdos-201 stale 'anti-monotone in k' prose → monotone (#38611)

### DIFF
--- a/proofs/Proofs/Erdos201Problem.lean
+++ b/proofs/Proofs/Erdos201Problem.lean
@@ -13,7 +13,7 @@ Known: G_k(N) ≤ R_k(N) (trivial), R_k(N) ≪_k G_k(N) (KSS 1975).
 
 Key Results (proved here):
 1. R_k monotone in N (proved structurally)
-2. R_k anti-monotone in k (proved structurally)
+2. R_k monotone in k (proved structurally)
 3. AP containment transfer between k and l when k ≤ l (proved)
 4. gk ≤ rk bound (proved from definitions)
 
@@ -316,7 +316,7 @@ theorem gk_zero (k : ℕ) : gk k 0 = 0 := by
     omega
   · exact Nat.zero_le _
 
-/-- gk_prop is anti-monotone in k: if every N-set has a k-AP-free subset of size m,
+/-- gk_prop is monotone in k: if every N-set has a k-AP-free subset of size m,
     then every N-set has an l-AP-free subset of size m (for l ≥ k). -/
 theorem gk_prop_anti_k {k l N m : ℕ} (hkl : k ≤ l) (hk1 : k ≥ 1)
     (h : gk_prop k N m) : gk_prop l N m := by

--- a/src/data/proofs/erdos-201/annotations.json
+++ b/src/data/proofs/erdos-201/annotations.json
@@ -189,8 +189,8 @@
       "endLine": 149
     },
     "title": "Monotonicity Properties of $R_k$",
-    "content": "$R_k$ is monotone in $N$ ($M \\leq N \\implies R_k(M) \\leq R_k(N)$) and anti-monotone in $k$ ($k \\leq l \\implies R_l(N) \\leq R_k(N)$). Both proved structurally in Lean using subset inclusion and AP transfer.",
-    "mathContext": "rk_mono: $M \\leq N \\implies$ Icc$\\,1\\,M \\subseteq$ Icc$\\,1\\,N$, so every AP-free subset of Icc$\\,1\\,M$ is also a subset of Icc$\\,1\\,N$. rk_anti_k: $k \\leq l \\implies$ every $l$-AP-free set is $k$-AP-free, so $R_l(N) \\leq R_k(N)$.",
+    "content": "$R_k$ is monotone in $N$ ($M \\leq N \\implies R_k(M) \\leq R_k(N)$) and monotone in $k$ ($k \\leq l \\implies R_k(N) \\leq R_l(N)$). Both proved structurally in Lean using subset inclusion and AP transfer.",
+    "mathContext": "rk_mono: $M \\leq N \\implies$ Icc$\\,1\\,M \\subseteq$ Icc$\\,1\\,N$, so every AP-free subset of Icc$\\,1\\,M$ is also a subset of Icc$\\,1\\,N$. rk_anti_k: $k \\leq l \\implies$ every $k$-AP-free set is $l$-AP-free, so $R_k(N) \\leq R_l(N)$.",
     "significance": "key",
     "relatedConcepts": [
       "monotone functions",

--- a/src/data/proofs/erdos-201/meta.json
+++ b/src/data/proofs/erdos-201/meta.json
@@ -35,7 +35,7 @@
       "**Trivial bound with strict gap**: $G_k(N) \\leq R_k(N)$ always, but $G_3(5) = 3 < 4 = R_3(5)$ shows $\\{1, \\ldots, N\\}$ is not the worst case for 3-AP avoidance",
       "**Komlós–Sulyok–Szemerédi (1975)**: $R_k(N) \\leq C(k) \\cdot G_k(N)$, establishing order-of-magnitude equivalence. The conjecture asks whether $C(3) \\to 1$",
       "**Connection to Roth/Szemerédi bounds**: $R_3(N) = o(N)$ (Roth 1953) and recent Kelley–Meka improvements give $R_3(N) \\leq N/\\exp(c(\\log N)^{1/12})$, but these bounds on $R_3$ don't directly determine the ratio $R_3/G_3$",
-      "**Proved monotonicity**: $R_k(N)$ is monotone in $N$ (larger interval has more AP-free subsets) and anti-monotone in $k$ ($l$-AP-free implies $k$-AP-free for $k \\leq l$), both verified in Lean",
+      "**Proved monotonicity**: $R_k(N)$ is monotone in $N$ (larger interval has more AP-free subsets) and monotone in $k$ ($k$-AP-free implies $l$-AP-free for $k \\leq l$), both verified in Lean",
       "**$\\varepsilon$-$N_0$ formalization**: The conjecture uses $\\mathbb{Q}$ for the $(1 + \\varepsilon)$ bound, avoiding real analysis while precisely capturing the asymptotic ratio"
     ],
     "prerequisites": [
@@ -113,8 +113,8 @@
       "title": "Monotonicity Properties (Proved)",
       "startLine": 227,
       "endLine": 252,
-      "summary": "$R_k$ monotone in $N$ and anti-monotone in $k$, both proved structurally using Icc nesting and AP transfer.",
-      "mathContext": "Mathematical content: $R_k$ monotone in $N$ and anti-monotone in $k$, both proved structurally using Icc nesting and AP transfer."
+      "summary": "$R_k$ monotone in $N$ and monotone in $k$, both proved structurally using Icc nesting and AP transfer.",
+      "mathContext": "Mathematical content: $R_k$ monotone in $N$ and monotone in $k$, both proved structurally using Icc nesting and AP transfer."
     },
     {
       "id": "consequences",


### PR DESCRIPTION
## Problem

Issue #38611 (bucket-D binder/direction drift) flags that the v4.26→v4.31 migration repaired `gk_anti_k`/`rk_anti_k`, whose inequality was **backward from inception**. The corrected Lean statement is monotone-*increasing* in $k$:

```
theorem rk_anti_k (k l N : ℕ) (hkl : k ≤ l) (hk1 : k ≥ 1) : rk k N ≤ rk l N
```

i.e. $k \le l \implies R_k(N) \le R_l(N)$ (every $k$-AP-free set is $l$-AP-free via `isAPFree_of_le`). The Lean statements/proofs were fixed during migration, but the gallery prose and two in-file docstrings still described the old, wrong **anti-monotone** direction ($R_l(N) \le R_k(N)$, 'every $l$-AP-free set is $k$-AP-free').

## Fix (prose only — no statements/proofs changed)

- `src/data/proofs/erdos-201/annotations.json` — Monotonicity annotation `content` + `mathContext`
- `src/data/proofs/erdos-201/meta.json` — keyInsight bullet + Monotonicity section `summary`/`mathContext`
- `proofs/Proofs/Erdos201Problem.lean` — header docstring L16 + `gk_prop_anti_k` docstring label (comment-only; theorem names kept per migration log, statements untouched → compilation unaffected)

## Evidence

Before: `anti-monotone in $k$ ($k \le l \implies R_l(N) \le R_k(N)$)`, `every $l$-AP-free set is $k$-AP-free`
After: `monotone in $k$ ($k \le l \implies R_k(N) \le R_l(N)$)`, `every $k$-AP-free set is $l$-AP-free` — matches corrected `rk_anti_k` and existing correct docstrings at L124/L259.

Authoritative source: `research/migration/38611-statement-repairs-v426-to-v431.txt` (Erdos201Problem entry, GALLERY FOLLOW-UP note). JSON validated with `jq empty`.

Part of #38611.