### PR TITLE
Fix: erdos-814 axiomCount 3→2 (drop phantom sauermann_constant)

### DIFF
--- a/src/data/proofs/erdos-814/meta.json
+++ b/src/data/proofs/erdos-814/meta.json
@@ -49,8 +49,7 @@
     "originalContributions": [
       "edgeThreshold definition: the critical edge count (k-1)(n-k+2) + C(k-2,2) + 1",
       "minDegree definition: minimum degree over all vertices",
-      "sauermann_constant axiom: existence of cₖ ≫ 1/k³",
-      "sauermann_theorem axiom: full 2019 resolution",
+      "sauermann_theorem axiom: full 2019 resolution (existence of the single constant cₖ ≫ 1/k³ is embedded in this axiom)",
       "erdos_814 theorem: main result restated",
       "edgeThreshold_three theorem: k=3 threshold computation",
       "edgeThreshold_two theorem: k=2 threshold computation",
@@ -60,9 +59,9 @@
       "erdos_814_summary theorem: comprehensive summary",
       "Historical bounds (EFRS 1990 √n savings, MNS 2017 n/log n savings) discussed in doc comments; not formalized as separate declarations."
     ],
-    "axiomCount": 3,
+    "axiomCount": 2,
     "lineCount": 292,
-    "assumptions": "3 axioms: sauermann_constant, sauermann_theorem, handshaking. 0 sorries.",
+    "assumptions": "2 axioms: sauermann_theorem, handshaking. 0 sorries.",
     "theoremCount": 7,
     "definitionCount": 3
   },
@@ -70,7 +69,7 @@
     "historicalContext": "**Erdős Problem #814: Minimum Degree Subgraphs**\n\nThis problem concerns a fundamental question in extremal graph theory: given a dense graph, can we always find a small induced subgraph with high minimum degree?\n\n**Key History:**\n- Erdős and Hajnal [Er91]: Studied the case k=3 as a standalone problem\n- Erdős, Faudree, Rousseau, Schelp (1990): Formulated the general conjecture and proved the first quantitative bound of n - cₖ√n vertices\n- Mousset, Noever, Skorić (2017): Improved to n - cₖ·n/log(n) vertices\n- Sauermann (2019): Fully resolved the conjecture with cₖ ≫ 1/k³\n\n**Mathematical Setting:**\nThe edge threshold (k-1)(n-k+2) + C(k-2,2) + 1 is precisely chosen. Graphs with fewer edges can be constructed to avoid the desired subgraph, showing the bound is tight. The conjecture asks whether exceeding this threshold by even one edge forces a small minimum-degree-k subgraph.",
     "problemStatement": "**Problem Statement (Proved)**\n\nLet $k \\geq 2$ and $G$ be a graph with $n \\geq k-1$ vertices and\n$$(k-1)(n-k+2) + \\binom{k-2}{2} + 1$$\nedges. Does there exist some $c_k > 0$ such that $G$ must contain an induced subgraph on at most $(1-c_k)n$ vertices with minimum degree at least $k$?\n\n**Answer: YES**\n\nSauermann (2019) proved the conjecture with $c_k \\gg 1/k^3$. This means for any $k$, there exists a constant $c_k$ of order at least $1/k^3$ such that every sufficiently dense graph contains a proper induced subgraph with minimum degree $k$.",
     "text": "For k ≥ 2, does every dense graph contain a small induced subgraph with minimum degree k? YES, proved by Sauermann (2019).",
-    "proofStrategy": "**Formalization Approach**\n\n1. **Edge Threshold:** Define the critical edge count using binomial coefficients from Mathlib\n\n2. **Key Axioms:**\n   - sauermann_constant: Existence of cₖ with the right asymptotic behavior\n   - sauermann_theorem: The main result about induced subgraphs\n   - handshaking: edge–degree counting identity used by the averaging argument\n\n3. **Main Theorem:** erdos_814 states that for every k ≥ 2, the desired constant exists\n\n4. **Special Cases:** Explicit analysis of k=2 and k=3 cases\n\n5. **Auxiliary Results:** Handshaking lemma and degree averaging arguments\n\n6. **Historical Context (doc comments):** The 1990 EFRS √n savings and the 2017 MNS n/log n savings are described in the file's doc comments to motivate the threshold; they are not declared as separate axioms or theorems.",
+    "proofStrategy": "**Formalization Approach**\n\n1. **Edge Threshold:** Define the critical edge count using binomial coefficients from Mathlib\n\n2. **Key Axioms:**\n   - sauermann_theorem: The main result about induced subgraphs, with the single constant cₖ ≫ 1/k³ existence embedded\n   - handshaking: edge–degree counting identity used by the averaging argument\n\n3. **Main Theorem:** erdos_814 states that for every k ≥ 2, the desired constant exists\n\n4. **Special Cases:** Explicit analysis of k=2 and k=3 cases\n\n5. **Auxiliary Results:** Handshaking lemma and degree averaging arguments\n\n6. **Historical Context (doc comments):** The 1990 EFRS √n savings and the 2017 MNS n/log n savings are described in the file's doc comments to motivate the threshold; they are not declared as separate axioms or theorems.",
     "keyInsights": [
       "**Edge Threshold Significance:** The formula (k-1)(n-k+2) + C(k-2,2) + 1 is tight - graphs with one fewer edge can avoid the conclusion",
       "**Progressive Improvement:** The savings went from √n (1990) to n/log(n) (2017) to cn (2019)",
@@ -87,7 +86,7 @@
     {
       "id": "definitions",
       "title": "Basic Definitions",
-      "summary": "edgeThreshold, minDegree, subgraphFraction, sauermann_constant",
+      "summary": "edgeThreshold, minDegree, subgraphFraction",
       "startLine": 47,
       "endLine": 81
     },
@@ -161,7 +160,7 @@
     ],
     "namespace": "Erdos814",
     "lineCount": 292,
-    "axiomCount": 3,
+    "axiomCount": 2,
     "theoremCount": 7,
     "definitionCount": 3,
     "path": "Proofs/Erdos814Problem.lean",


### PR DESCRIPTION
## Summary
Re-audit of erdos-814 gallery metadata against the v4.31-corrected Lean source (#38611 follow-up).

During the v4.26→v4.31 migration, `Erdos814Problem.lean` was restructured: the separate `sauermann_constant` axiom was **removed** and its content (existence of the single constant cₖ ≫ 1/k³) was folded into `sauermann_theorem` (see `∃ c, c > 0 ∧ c·k³ ≥ 1 ∧ …` at Erdos814Problem.lean:114). The gallery meta still claimed 3 axioms.

## Evidence
Actual axioms in `proofs/Proofs/Erdos814Problem.lean`:
```
114: axiom sauermann_theorem
238: axiom handshaking
```
→ 2 axioms, 0 sorries, 0 structure-encoded assumptions.

## Changes (metadata only)
- `meta.axiomCount`: 3 → 2
- `leanFile.axiomCount`: 3 → 2
- `assumptions`: "3 axioms: sauermann_constant, sauermann_theorem, handshaking" → "2 axioms: sauermann_theorem, handshaking"
- `originalContributions`: dropped phantom `sauermann_constant axiom` bullet; noted the constant is embedded in `sauermann_theorem`
- `proofStrategy` Key Axioms list + `definitions` section summary: dropped `sauermann_constant`

Status remains `axiomatized` / badge `axiom` (correct — 2 axioms present).

Part of #38611.