### PR TITLE
audit: erdos-716 — drop 'Verified:' overclaim from 2 comment-only section labels

### DIFF
--- a/src/data/proofs/erdos-716/meta.json
+++ b/src/data/proofs/erdos-716/meta.json
@@ -93,7 +93,7 @@
       "summary": "Triangle removal lemma and its derivation of the RS theorem",
       "startLine": 144,
       "endLine": 162,
-      "mathContext": "Verified: Triangle removal lemma and its derivation of the RS theorem"
+      "mathContext": "Expository comments (no formal declarations): the triangle removal lemma and how the RS theorem is deduced from it"
     },
     {
       "id": "arithmetic-progressions",
@@ -101,7 +101,7 @@
       "summary": "3-AP-free sets, Roth's theorem, Behrend construction, RS implies Roth",
       "startLine": 163,
       "endLine": 197,
-      "mathContext": "Verified: 3-AP-free sets, Roth's theorem, Behrend construction, RS implies Roth"
+      "mathContext": "3-AP-free sets (def) and Roth's r₃(n) (axiom); Roth's theorem, the Behrend construction, and RS ⇒ Roth are expository comments"
     },
     {
       "id": "bes-conjecture",


### PR DESCRIPTION
## Integrity Issue

**Proof**: erdos-716 (Ruzsa-Szemerédi (6,3) Problem)
**Problem**: Two section `mathContext` labels claim `"Verified:"` but contain no verified theorems.

## Evidence

Counts are correct and honest: badge `axiom`, status `axiomatized`, 5 axioms / 0 sorries / 3 theorems — all match the Lean file. The main result `ruzsa_szemeredi_theorem` is genuinely an axiom.

However the section metadata overstates:

- **Part V (triangle-removal, lines 139–149)** — labeled `"Verified: Triangle removal lemma and its derivation of the RS theorem"`, but the section is **entirely block comments** (`/- … -/`). Zero declarations exist there.
- **Part VI (arithmetic-progressions, lines 151–174)** — labeled `"Verified: 3-AP-free sets, Roth's theorem, Behrend construction, RS implies Roth"`, but only `is3APFree` (def) and `roth_r3` (axiom) exist; Roth's theorem, Behrend, and RS⇒Roth are expository comments, not formalized.

In an axiomatized file where the main theorem is itself an axiom, stamping a section "Verified" is doubly misleading.

## Fix

Replaced the two `"Verified:"` prefixes with accurate descriptions noting the content is expository / axiom+def, not verified. No count changes.

---
Discovered during gallery integrity audit (reserve mode — oldest uncontested target).

🤖 Generated with [Claude Code](https://claude.com/claude-code)