### PR TITLE
research(registry): durably stop re-serving erdos-490 (completed) + erdos-1064-oq-03 (blocked)

### DIFF
--- a/research/registry.json
+++ b/research/registry.json
@@ -14454,7 +14454,7 @@
       "phase": "OBSERVE",
       "path": "full",
       "started": "2026-04-05T12:58:50.773Z",
-      "status": "active",
+      "status": "completed",
       "lastUpdate": "2026-06-28T12:29:05.798Z"
     },
     {
@@ -36229,7 +36229,7 @@
       "phase": "OBSERVE",
       "path": "full",
       "started": "2026-07-08T06:43:02.484Z",
-      "status": "active",
+      "status": "blocked",
       "lastUpdate": "2026-07-08T06:43:02.571Z"
     },
     {


### PR DESCRIPTION
## Summary
Two finished research nodes were still marked `active` in `research/registry.json`, so the depth-first RICH claim tier kept re-serving them (pool `update` is ephemeral — the Seeker regenerates pool status from the git-tracked registry, so the registry flip is the only durable stop-re-serve). This session claimed both, verified they are terminal, and flips their registry status.

## Changes (2 status lines)
- **erdos-490-incomplete-01 → `completed`**: `Erdos490Problem.lean` is 0-sorry; the lone remaining assumption is the deep Szemerédi (1976) `N²/log N` distinct-products upper bound — correctly axiomatized, out of scope. The completion task (build repair + sorry elimination 6→0) is done.
- **erdos-1064-oq-03 → `blocked`**: the formalizable OQ-03 content is COMPLETE and machine-checked — `oq03_both_directions_infinite` / `oq03_three_way_infinite` prove the forward (odd primes), reverse (`21·2^(k+1)`, `ReversalSet.Infinite`) and equality (`15·2^(k+1)`) regimes each occur infinitely often (0 sorry / 0 axiom, host-verified `[propext, Classical.choice, Quot.sound]`). The only open direction — density-1 forward `φ(n)>φ(D(n))` for almost all `n` (Luca–Pomerance) — needs `ψ(x,y)` smooth-number analytic density input absent from Mathlib. Reopen: materially new mechanism required.

## Non-duplication
Verified against open PRs: cube-root / cauchy-interlacing (already in #39131/#39214) and elementary-QR-wip (already in #39166) were **dropped** to avoid same-line conflicts. #39158 populates the erdos-1064 tracker `currentState.blockers` but leaves its tracker status `in-progress`, so the registry flip here is the actual durable fix; #39322 is the systemic reconcile (scripts only, no registry edits). No open PR flips these 2 registry entries.

## Status
**Outcome**: durable stop-re-serve (registry status reconcile). No Lean changes.

🤖 Generated by researcher-1