### PR TITLE
Fix: correct maxUnionFreeSize domain formula in erdos-447 annotation (#38611)

### DIFF
--- a/src/data/proofs/erdos-447/annotations.json
+++ b/src/data/proofs/erdos-447/annotations.json
@@ -151,7 +151,7 @@
     },
     "title": "Asymptotic Notation and maxUnionFreeSize",
     "content": "**IsLittleO f g** captures $f(n) = o(g(n))$: for every $\\varepsilon > 0$, eventually $f(n) \\leq \\varepsilon \\cdot g(n)$. **AsymptoticUpperBound f g** captures $f(n) \\leq (1+o(1)) \\cdot g(n)$: for every $\\varepsilon > 0$, eventually $f(n) \\leq (1+\\varepsilon) \\cdot g(n)$.\n\n**maxUnionFreeSize n** is the maximum $|\\mathcal{F}|$ over all union-free $\\mathcal{F} \\subseteq 2^{[n]}$, defined as the supremum of cardinalities over the filtered power set.",
-    "mathContext": "`IsLittleO` uses $\\varepsilon$-$N$ definitions with $\\mathbb{R}$-valued bounds. `maxUnionFreeSize` uses `Finset.sup Finset.card` over `(powerSet n).filter IsUnionFree`, which is well-defined since `Finset` operations are decidable. `AsymptoticUpperBound` is equivalent to $\\limsup f(n)/g(n) \\leq 1$.",
+    "mathContext": "`IsLittleO` uses $\\varepsilon$-$N$ definitions with $\\mathbb{R}$-valued bounds. `maxUnionFreeSize` uses `Finset.sup Finset.card` over `(powerSet n).powerset.filter IsUnionFree` — the filter ranges over *families* of subsets (elements of $2^{2^{[n]}}$), since `IsUnionFree` is a predicate on families, not on individual subsets. This is well-defined since `Finset` operations are decidable. `AsymptoticUpperBound` is equivalent to $\\limsup f(n)/g(n) \\leq 1$.",
     "significance": "key",
     "relatedConcepts": [
       "little-o notation",


### PR DESCRIPTION
## Problem

Part of the #38611 v4.31 statement-repair re-audit. During the migration, `maxUnionFreeSize` in `Erdos447Problem.lean` was repaired: the old ill-typed definition filtered `powerSet n` (individual subsets) with `IsUnionFree`, but `IsUnionFree` is a predicate on **families** of subsets. The corrected, compiling definition is:

```lean
noncomputable def maxUnionFreeSize (n : ℕ) : ℕ :=
  ((powerSet n).powerset.filter IsUnionFree).sup Finset.card
```

The gallery annotation (`erdos-447/annotations.json`, insight 'Asymptotic Notation and maxUnionFreeSize') still showed the OLD ill-typed formula:

> `maxUnionFreeSize` uses `Finset.sup Finset.card` over `(powerSet n).filter IsUnionFree`

## Fix

Updated the formula to `(powerSet n).powerset.filter IsUnionFree` and clarified that the filter ranges over *families* of subsets (elements of $2^{2^{[n]}}$), matching the corrected Lean. The conceptual prose elsewhere ('sup over union-free families', both here and in `meta.json`) was already correct — only this explicit formula was stale.

Metadata-only change; JSON validated.

Part of #38611.