### PR TITLE
Fix: erdos-682 gallery prose stale 'm≥1' → 'm>1' for one_rough_all

### DIFF
--- a/src/data/proofs/erdos-682/annotations.json
+++ b/src/data/proofs/erdos-682/annotations.json
@@ -115,7 +115,7 @@
     },
     "type": "concept",
     "title": "one_rough_all",
-    "content": "**one_rough_all**: Every $m \\geq 1$ is 1-rough. **Lean proof**: the smallest prime is 2 $\\geq$ 1.",
+    "content": "**one_rough_all**: Every integer $m > 1$ is 1-rough. **Lean proof**: the smallest prime is 2 $\\geq$ 1. ($m = 1$ is excluded: `leastPrimeFactor 1 = 0` is the sentinel for $p(1) = \\infty$.)",
     "mathContext": "This base case confirms the definition is sensible. As $k$ increases, the set of $k$-rough numbers thins out: the density of $k$-rough numbers in $[1,N]$ is $\\sim e^{-\\gamma}/\\log k$.",
     "significance": "supporting",
     "relatedConcepts": [

--- a/src/data/proofs/erdos-682/meta.json
+++ b/src/data/proofs/erdos-682/meta.json
@@ -63,7 +63,7 @@
       "gafni_tao_main_theorem axiom: almost all n satisfy property",
       "erdos682_answer theorem: YES answer",
       "leastPrimeFactor_prime, leastPrimeFactor_dvd: proved theorems",
-      "one_rough_all: every positive integer is 1-rough",
+      "one_rough_all: every integer m > 1 is 1-rough",
       "exceptional_density_zero, most_gaps_have_rough: density results",
       "erdos_682_summary, erdos_682: main results"
     ],
@@ -123,8 +123,8 @@
       "title": "$k$-Rough Numbers",
       "startLine": 83,
       "endLine": 112,
-      "summary": "`isKRough m k` ($p(m) \\geq k$), `one_rough_all` (every positive integer is 1-rough), example: 7 is 7-rough",
-      "mathContext": "An integer $m \\geq 1$ is $k$-rough if $p(m) \\geq k$, i.e., no prime $< k$ divides $m$. Dually, $m$ is $k$-smooth if all prime factors are $\\leq k$. The theorem `one_rough_all` ($\\forall m \\geq 1$, $m$ is 1-rough) is trivial; the example $7$ is 7-rough since $p(7) = 7$."
+      "summary": "`isKRough m k` ($p(m) \\geq k$), `one_rough_all` (every integer $m > 1$ is 1-rough), example: 7 is 7-rough",
+      "mathContext": "An integer $m \\geq 1$ is $k$-rough if $p(m) \\geq k$, i.e., no prime $< k$ divides $m$. Dually, $m$ is $k$-smooth if all prime factors are $\\leq k$. The theorem `one_rough_all` ($\\forall m > 1$, $m$ is 1-rough) is trivial ($m = 1$ is excluded, since $p(1)$ is the $\\infty$ sentinel $0$); the example $7$ is 7-rough since $p(7) = 7$."
     },
     {
       "id": "prime-gaps",


### PR DESCRIPTION
## Problem

Flagged in the #38611 re-audit log (`research/migration/38611-statement-repairs-v426-to-v431.txt`):

> Erdos682Problem: one_rough_all claimed 'every m≥1 is 1-rough' FALSE at m=1 (leastPrimeFactor 1=0 sentinel for p(1)=∞ breaks ≥; old simp closed vacuously). Narrowed to m>1. gallery src/data/proofs/erdos-682/annotations.json+meta.json still describe old false m≥1 claim → UPDATE

The Lean theorem was corrected to `one_rough_all (m : ℕ) (hm : m > 1)` and its docstring updated, but the gallery metadata still described the old, false `m ≥ 1` claim in 4 places.

## Fix (metadata only)

| Site | Before | After |
|------|--------|-------|
| `annotations.json:118` | "Every $m \geq 1$ is 1-rough" | "Every integer $m > 1$ is 1-rough" (+ m=1 exclusion note) |
| `meta.json:66` | "every positive integer is 1-rough" | "every integer m > 1 is 1-rough" |
| `meta.json:126` | "every positive integer is 1-rough" | "every integer $m > 1$ is 1-rough" |
| `meta.json:127` | "$\forall m \geq 1$, $m$ is 1-rough" | "$\forall m > 1$, $m$ is 1-rough" (+ sentinel note) |

The definitional "An integer $m \geq 1$ is $k$-rough if $p(m) \geq k$" wording is left unchanged — it correctly reflects `def isKRough (m k : ℕ) := m ≥ 1 ∧ leastPrimeFactor m ≥ k`.

## Validation

- Both JSON files parse (`json.load` OK).
- No remaining stale `m ≥ 1` claims about `one_rough_all`.
- Lean source unchanged (docstring already correct at `proofs/Proofs/Erdos682Problem.lean:100-108`).

Part of #38611.