### PR TITLE
Research: szemeredi-regularity-oq-04 - two-level AFKS conclusion (item 2) + outer-loop assembly (item 3 structural half)

### DIFF
--- a/proofs/Proofs/SzemerediRegularityOQ04Outer.lean
+++ b/proofs/Proofs/SzemerediRegularityOQ04Outer.lean
@@ -1,0 +1,172 @@
+/-
+  Szemerédi Regularity Lemma — OQ-04: the outer-loop assembly (item 3).
+
+  `state.md` "What remains open" lists three pieces of the strong (AFKS) regularity lemma:
+
+    1. **Energy-increment step** — a bad `ε`-irregular pair forces a refinement whose
+       `partitionEnergy` jumps by a fixed `δ = δ(ε)` (the analytic crux; supplied in the
+       sibling energy files as the sharp `2×2` gain / the internalized `Bside` capstone).
+    2. **Two-level statement** — the AFKS conclusion packaged as a single proposition,
+       `IsAFKSTwoLevel` (discharged in `SzemerediRegularityOQ04TwoLevel`).
+    3. **Assemble** — *run the outer loop* using the finiteness/termination certificate to
+       produce such a two-level partition.
+
+  This file discharges the **structural half of item 3**: it wires the termination
+  certificate (`afks_regular_step_within_bound`, itself the contrapositive of the sharp
+  energy iteration-count bound) to the packaged two-level conclusion
+  (`IsAFKSTwoLevel`).  The one input it takes as an explicit hypothesis is the
+  *regular-or-refine dichotomy* — "if the current fine partition is **not** AFKS-fine-regular
+  then a witnessed sharp-`2×2` gain-refinement step exists".  That dichotomy is exactly
+  item 1's analytic realizability (a fine partition failing the `E(k)`-regular budget
+  contains an `E(k)`-irregular pair, and refining it along the sharp `2×2` split realizes
+  the no-loss energy gain); it is *not* proved here.  What **is** proved here is that the
+  dichotomy plus the termination bound genuinely *closes the loop*: a two-level partition is
+  reached in a bounded number of refinements.
+
+  Contents:
+
+  * `IsWitnessedSharpStep G parts n eps m` — the per-step predicate "the refinement
+    `parts n → parts (n+1)` is a mass-`m`, `eps`-irregular sharp `2×2` split", named so the
+    dichotomy hypothesis reads cleanly.  It matches, clause-for-clause, the witness inside
+    `afks_regular_step_within_bound`.
+  * `exists_afksTwoLevel_of_dichotomy` — **the assembly**: from a fixed coarse `ε`-regular
+    partition `Vparts`, a refinement chain `parts : ℕ → …` (each a cover by pairwise-disjoint
+    parts, each refining `Vparts`), a horizon `N` beyond the sharp iteration bound at the fine
+    tolerance `E(k)`, and the dichotomy, there **exists** a step `n < N` at which
+    `(Vparts, parts n)` is an `IsAFKSTwoLevel` partition at coarse tolerance `ε` and dependent
+    fine tolerance `E`.  This is item 3 — the outer AFKS loop run to its regular step —
+    modulo the analytic dichotomy of item 1.
+  * `exists_afksTwoLevel_of_dichotomy_equipartition` — the same conclusion with the horizon
+    stated in the vertex-count-free `k²/E(k)⁴` form (the tower-free bound) via the
+    equipartition mass floor `m = n/k`.
+
+  0 axioms, 0 sorries.  Everything above the dichotomy hypothesis is machine-checked from the
+  already-verified termination bound and the two-level packaging.
+-/
+import Mathlib
+import Proofs.SzemerediRegularityOQ04Assembly
+import Proofs.SzemerediRegularityOQ04TwoLevel
+
+namespace Szemeredi.RegularityOQ04Outer
+
+open Classical Szemeredi.Core Szemeredi.RegularityOQ04ToleranceBridge
+  Szemeredi.RegularityOQ04TwoLevel
+
+variable {V : Type*} [Fintype V] [DecidableEq V]
+
+-- ═══════════════════════════════════════════════════════════════════
+-- PART I: THE PER-STEP WITNESS PREDICATE
+-- ═══════════════════════════════════════════════════════════════════
+
+/-- **A witnessed sharp `2×2` refinement step.**  The refinement `parts n → parts (n+1)`
+    splits two distinct mass-`≥ m` parts `A, B` of `parts n` into `{A₁,A₂}`, `{B₁,B₂}`
+    (fresh, disjoint, covering) so that the `A₁`/`B₁` corner keeps an `eps`-fraction of the
+    mass and its edge density deviates from the parent `A,B` density by `≥ eps` — i.e. the
+    step is a mass-`m`, `eps`-irregular sharp `2×2` split.
+
+    This is precisely the witness negated inside `afks_regular_step_within_bound`; isolating
+    it as a named predicate lets the outer-loop dichotomy hypothesis be stated readably. -/
+def IsWitnessedSharpStep (G : SimpleGraph V) [DecidableRel G.Adj]
+    (parts : ℕ → Finset (Finset V)) (n : ℕ) (eps m : ℚ) : Prop :=
+  ∃ R : Finset (Finset V), ∃ A B A₁ A₂ B₁ B₂ : Finset V,
+    parts n = insert A (insert B R) ∧
+    parts (n + 1) = insert A₁ (insert A₂ (insert B₁ (insert B₂ R))) ∧
+    A₁ ∪ A₂ = A ∧ B₁ ∪ B₂ = B ∧ Disjoint A₁ A₂ ∧ Disjoint B₁ B₂ ∧
+    A ∉ insert B R ∧ B ∉ R ∧
+    A₁ ∉ insert A₂ (insert B₁ (insert B₂ R)) ∧ A₂ ∉ insert B₁ (insert B₂ R) ∧
+    B₁ ∉ insert B₂ R ∧ B₂ ∉ R ∧
+    m ≤ (A.card : ℚ) ∧ m ≤ (B.card : ℚ) ∧
+    eps * A.card ≤ (A₁.card : ℚ) ∧ eps * B.card ≤ (B₁.card : ℚ) ∧
+    eps ≤ |edgeDensity G A₁ B₁ - edgeDensity G A B|
+
+-- ═══════════════════════════════════════════════════════════════════
+-- PART II: THE OUTER-LOOP ASSEMBLY (item 3, modulo the item-1 dichotomy)
+-- ═══════════════════════════════════════════════════════════════════
+
+/-- **The outer AFKS loop, run to its regular step.**  Fix a coarse `ε`-regular partition
+    `Vparts` (size `k = |Vparts|`) and a refinement chain `parts : ℕ → Finset (Finset V)`,
+    each term a cover by pairwise-disjoint parts and each refining `Vparts`.  Suppose the
+    horizon `N` exceeds the sharp iteration bound `n² / (E(k)⁴·m²)` at the *fine* tolerance
+    `E(k)`, and the **regular-or-refine dichotomy** holds: whenever a term `parts n`
+    (`n < N`) fails to be AFKS-fine-regular at coarse budget `ε` and fine tolerance `E(k)`,
+    the step `parts n → parts (n+1)` is a witnessed mass-`m`, `E(k)`-irregular sharp `2×2`
+    split.
+
+    Then there is a step `n < N` at which `(Vparts, parts n)` is an `IsAFKSTwoLevel`
+    partition: the coarse level is `ε`-regular, `parts n` refines it, and `parts n` is
+    AFKS-fine-regular at the dependent tolerance `E(k)`.
+
+    *Why this closes item 3.*  `afks_regular_step_within_bound` (the contrapositive of the
+    energy iteration-count bound) guarantees some `n < N` at which **no** witnessed sharp
+    `2×2` refinement step occurs.  By the dichotomy's contrapositive, that `parts n` must
+    already be AFKS-fine-regular — the loop has reached its regular partition.  Packaging it
+    against the fixed coarse `ε`-regular `Vparts` yields the two-level conclusion.  The only
+    unproved ingredient is the dichotomy itself (item 1's analytic energy-increment
+    realizability); the termination-to-conclusion wiring is fully machine-checked. -/
+theorem exists_afksTwoLevel_of_dichotomy
+    (G : SimpleGraph V) [DecidableRel G.Adj]
+    (ε : ℚ) (E : ℕ → ℚ) (Vparts : Finset (Finset V)) (parts : ℕ → Finset (Finset V))
+    (N : ℕ) (m : ℚ)
+    (hEpos : 0 < E Vparts.card) (hm : 0 < m) (hcard : 0 < (Fintype.card V : ℚ))
+    (hcover : ∀ n, ∀ v : V, ∃ P ∈ parts n, v ∈ P)
+    (hdisjoint : ∀ n, ∀ P Q : Finset V, P ∈ parts n → Q ∈ parts n → P ≠ Q →
+      Disjoint P Q)
+    (hN : (Fintype.card V : ℚ) ^ 2 / (E Vparts.card ^ 4 * m ^ 2) < N)
+    (hcoarse : IsRegularPartition G ε Vparts)
+    (href : ∀ n, IsRefinement (parts n) Vparts)
+    (hdich : ∀ n, n < N → ¬ IsAFKSFineRegular G ε (E Vparts.card) (parts n) →
+      IsWitnessedSharpStep G parts n (E Vparts.card) m) :
+    ∃ n < N, IsAFKSTwoLevel G ε E Vparts (parts n) := by
+  obtain ⟨n, hn, hno⟩ :=
+    Szemeredi.RegularityOQ04Bridge.afks_regular_step_within_bound
+      G parts N (E Vparts.card) m hEpos hm hcard hcover hdisjoint hN
+  refine ⟨n, hn, ?_⟩
+  -- The found step has no witnessed sharp 2×2 refinement; by the dichotomy's
+  -- contrapositive `parts n` is therefore AFKS-fine-regular.
+  have hfine : IsAFKSFineRegular G ε (E Vparts.card) (parts n) := by
+    by_contra hcon
+    exact hno (hdich n hn hcon)
+  exact
+    { coarseRegular := hcoarse
+      refines := href n
+      fineRegular := hfine }
+
+/-- **Vertex-count-free (tower-free) horizon form.**  Identical conclusion to
+    `exists_afksTwoLevel_of_dichotomy`, but the horizon requirement is stated in the
+    dimension-free `k² / E(k)⁴` shape: with an equipartition mass floor `m = n/k`
+    (every refined part carries at least a `1/k` fraction of the vertices), the sharp
+    bound `n² / (E(k)⁴·m²)` collapses to `k² / E(k)⁴`, independent of `n = |V|`.  Any
+    horizon `N` exceeding `k² / E(k)⁴` therefore also exceeds the vertex-dependent bound at
+    `m = n/k`, so the assembly applies. -/
+theorem exists_afksTwoLevel_of_dichotomy_equipartition
+    (G : SimpleGraph V) [DecidableRel G.Adj]
+    (ε : ℚ) (E : ℕ → ℚ) (Vparts : Finset (Finset V)) (parts : ℕ → Finset (Finset V))
+    (N : ℕ)
+    (hEpos : 0 < E Vparts.card) (hkpos : 0 < Vparts.card) (hcard : 0 < (Fintype.card V : ℚ))
+    (hcover : ∀ n, ∀ v : V, ∃ P ∈ parts n, v ∈ P)
+    (hdisjoint : ∀ n, ∀ P Q : Finset V, P ∈ parts n → Q ∈ parts n → P ≠ Q →
+      Disjoint P Q)
+    (hN : (Vparts.card : ℚ) ^ 2 / E Vparts.card ^ 4 < N)
+    (hcoarse : IsRegularPartition G ε Vparts)
+    (href : ∀ n, IsRefinement (parts n) Vparts)
+    (hdich : ∀ n, n < N → ¬ IsAFKSFineRegular G ε (E Vparts.card) (parts n) →
+      IsWitnessedSharpStep G parts n (E Vparts.card)
+        ((Fintype.card V : ℚ) / Vparts.card)) :
+    ∃ n < N, IsAFKSTwoLevel G ε E Vparts (parts n) := by
+  -- Translate the `k²/E(k)⁴` horizon into the vertex-dependent `n²/(E(k)⁴·m²)` horizon
+  -- at `m = n/k`, then apply the general assembly.
+  set k : ℚ := (Vparts.card : ℚ) with hk
+  set n : ℚ := (Fintype.card V : ℚ) with hnc
+  have hkq : (0 : ℚ) < k := by rw [hk]; exact_mod_cast hkpos
+  have hmpos : (0 : ℚ) < n / k := div_pos hcard hkq
+  have hEne : E Vparts.card ≠ 0 := hEpos.ne'
+  have hkne : k ≠ 0 := hkq.ne'
+  have hnne : n ≠ 0 := hcard.ne'
+  -- `n² / (E(k)⁴ · (n/k)²) = k² / E(k)⁴`.
+  have heq : n ^ 2 / (E Vparts.card ^ 4 * (n / k) ^ 2) = k ^ 2 / E Vparts.card ^ 4 := by
+    field_simp
+  refine exists_afksTwoLevel_of_dichotomy G ε E Vparts parts N (n / k)
+    hEpos hmpos hcard hcover hdisjoint ?_ hcoarse href hdich
+  rw [heq]; exact hN
+
+end Szemeredi.RegularityOQ04Outer

--- a/proofs/Proofs/SzemerediRegularityOQ04TwoLevel.lean
+++ b/proofs/Proofs/SzemerediRegularityOQ04TwoLevel.lean
@@ -1,0 +1,174 @@
+/-
+  Szemerédi Regularity Lemma — OQ-04: the packaged two-level AFKS conclusion.
+
+  The Alon–Fischer–Krivelevich–Szegedy strong regularity lemma outputs a *two-level*
+  partition:
+
+    (i)   a fine partition `Wparts` that **refines** a coarse partition `Vparts`;
+    (ii)  the coarse partition `Vparts` is `ε`-regular;
+    (iii) `Wparts` is `E(k)`-regular on all but `ε·C(ℓ,2)` of its pairs, where the
+          fine tolerance `E : ℕ → ℚ` is chosen *after* seeing the coarse size
+          `k = |Vparts|` (dependent tolerance) and is stronger, `E(k) ≤ ε`.
+
+  Every prior OQ-04 file supplied an *ingredient* of the proof — the energy-increment
+  step (`SzemerediRegularityOQ04Assembly`, the sharp `2×2` gain `partitionEnergy_prod_gain_eps4`),
+  the finiteness/termination engine (`SzemerediRegularityOQ04`,
+  `partitionEnergy_no_infinite_increments`, `afks_regular_step_within_bound`), the tolerance
+  monotonicity of regularity (`SzemerediRegularityOQ04Tolerance`), and the AFKS-specific
+  mixed fine-regularity predicate with its bridges (`SzemerediRegularityOQ04ToleranceBridge`,
+  `IsAFKSFineRegular`).  **None of them states the two-level conclusion itself as a single
+  packaged proposition.**  The `state.md` "What remains open" item 2 — *"spell out the AFKS
+  conclusion … in Lean, with the dependent tolerance `E : ℕ → (0,1]` threaded correctly"* —
+  is exactly that packaging, and this file discharges it.
+
+  Contents:
+
+  * `IsRefinement Wparts Vparts` — the block-refinement relation: every fine block sits
+    inside some coarse block.  With `isRefinement_refl`/`isRefinement_trans` it is a
+    preorder on partitions (the (i) clause).
+  * `IsAFKSTwoLevel G ε E Vparts Wparts` — the packaged two-level AFKS conclusion,
+    combining (i)+(ii)+(iii) with the dependent tolerance `E (Vparts.card)`.
+  * `isRegularPartition_coarse_of_afksTwoLevel` — the coarse level is `ε`-regular
+    (projection of clause (ii)).
+  * `isRegularPartition_fine_of_afksTwoLevel` — **both levels are `ε`-regular**: the fine
+    level, built to the stronger dependent tolerance `E(k) ≤ ε`, automatically satisfies
+    the coarse `ε`-regularity demand (via the `ToleranceBridge` bridge-up).  This is the
+    defining feature of the strong lemma — a coarse regular partition *and* a refinement
+    that is still regular, only much more finely.
+  * `isAFKSTwoLevel_of_regular_refinement` — the **builder**: a coarse `ε`-regular partition
+    together with any genuinely `E(k)`-regular refinement (`E(k) ≤ ε`) assembles into the
+    two-level conclusion (this is what the outer AFKS loop produces at its regular step).
+  * `isAFKSTwoLevel_mono_coarse` — the conclusion is monotone in the coarse tolerance `ε`.
+
+  Everything is elementary order/set arithmetic over the `Szemeredi.Core` definitions and the
+  already-verified `ToleranceBridge`/`Tolerance` monotonicity lemmas — no energy machinery.
+  This is *statement-level* progress (item 2); the analytic energy-increment core (item 1) and
+  the outer-loop assembly that actually *produces* such a partition for every graph (item 3)
+  live in the sibling files and remain the substantive open crux.
+
+  0 axioms, 0 sorries.
+-/
+import Mathlib
+import Proofs.SzemerediCore
+import Proofs.SzemerediRegularityOQ04Tolerance
+import Proofs.SzemerediRegularityOQ04ToleranceBridge
+
+namespace Szemeredi.RegularityOQ04TwoLevel
+
+open Classical Szemeredi.Core Szemeredi.RegularityOQ04Tolerance
+  Szemeredi.RegularityOQ04ToleranceBridge
+
+variable {V : Type*} [Fintype V] [DecidableEq V]
+
+-- ═══════════════════════════════════════════════════════════════════
+-- PART I: THE BLOCK-REFINEMENT RELATION (clause (i))
+-- ═══════════════════════════════════════════════════════════════════
+
+/-- **Block refinement.**  `Wparts` refines `Vparts` when every fine block `W ∈ Wparts`
+    is contained in some coarse block `Vp ∈ Vparts`.  This is the standard partition
+    refinement order restricted to the block-containment witness the AFKS statement needs
+    (clause (i): `W` refines `V`). -/
+def IsRefinement (Wparts Vparts : Finset (Finset V)) : Prop :=
+  ∀ W ∈ Wparts, ∃ Vp ∈ Vparts, W ⊆ Vp
+
+/-- Refinement is reflexive: every partition refines itself (each block sits inside
+    itself). -/
+theorem isRefinement_refl (parts : Finset (Finset V)) : IsRefinement parts parts :=
+  fun W hW => ⟨W, hW, subset_rfl⟩
+
+/-- Refinement is transitive: a refinement of a refinement is a refinement.  If every
+    `W`-block sits in a `U`-block and every `U`-block sits in a `V`-block, then every
+    `W`-block sits in a `V`-block. -/
+theorem isRefinement_trans {Wparts Uparts Vparts : Finset (Finset V)}
+    (hWU : IsRefinement Wparts Uparts) (hUV : IsRefinement Uparts Vparts) :
+    IsRefinement Wparts Vparts := by
+  intro W hW
+  obtain ⟨U, hU, hWU'⟩ := hWU W hW
+  obtain ⟨Vp, hVp, hUV'⟩ := hUV U hU
+  exact ⟨Vp, hVp, hWU'.trans hUV'⟩
+
+/-- The empty fine partition trivially refines anything (vacuously). -/
+theorem isRefinement_empty (Vparts : Finset (Finset V)) :
+    IsRefinement (∅ : Finset (Finset V)) Vparts := by
+  intro W hW
+  simp at hW
+
+-- ═══════════════════════════════════════════════════════════════════
+-- PART II: THE PACKAGED TWO-LEVEL AFKS CONCLUSION (clauses (i)+(ii)+(iii))
+-- ═══════════════════════════════════════════════════════════════════
+
+/-- **The two-level AFKS conclusion, packaged.**  A coarse partition `Vparts` and a fine
+    partition `Wparts` form an *AFKS two-level partition* at coarse tolerance `ε` with
+    dependent fine tolerance `E : ℕ → ℚ` when:
+
+    * `coarseRegular` — the coarse partition `Vparts` is `ε`-regular (clause (ii));
+    * `refines` — `Wparts` refines `Vparts` (clause (i));
+    * `fineRegular` — `Wparts` is AFKS-fine-regular at coarse budget `ε` and *fine*
+      tolerance `E (Vparts.card)`: all but `ε·C(ℓ,2)` of its pairs are `E(k)`-regular,
+      with `k = |Vparts|` the coarse size — the dependent tolerance chosen *after* seeing
+      the coarse partition (clause (iii)).
+
+    This is exactly the strong (AFKS) regularity lemma's output as a single proposition.
+    The dependent tolerance is threaded by evaluating `E` at `Vparts.card`, so the fine
+    level's guarantee genuinely depends on the coarse size. -/
+structure IsAFKSTwoLevel (G : SimpleGraph V) [DecidableRel G.Adj]
+    (ε : ℚ) (E : ℕ → ℚ) (Vparts Wparts : Finset (Finset V)) : Prop where
+  /-- The coarse partition is `ε`-regular (clause (ii)). -/
+  coarseRegular : IsRegularPartition G ε Vparts
+  /-- The fine partition refines the coarse one (clause (i)). -/
+  refines : IsRefinement Wparts Vparts
+  /-- The fine partition is `E(k)`-regular on all but `ε·C(ℓ,2)` pairs (clause (iii)),
+      with the dependent tolerance evaluated at the coarse size `k = |Vparts|`. -/
+  fineRegular : IsAFKSFineRegular G ε (E Vparts.card) Wparts
+
+/-- **Coarse projection.**  The coarse level of an AFKS two-level partition is `ε`-regular. -/
+theorem isRegularPartition_coarse_of_afksTwoLevel (G : SimpleGraph V) [DecidableRel G.Adj]
+    {ε : ℚ} {E : ℕ → ℚ} {Vparts Wparts : Finset (Finset V)}
+    (h : IsAFKSTwoLevel G ε E Vparts Wparts) :
+    IsRegularPartition G ε Vparts :=
+  h.coarseRegular
+
+/-- **Both levels are `ε`-regular.**  When the dependent fine tolerance is at least as
+    strong as the coarse one (`E (Vparts.card) ≤ ε` — the AFKS requirement), the fine
+    partition `Wparts`, built to the stronger tolerance, *automatically* satisfies the
+    coarse `ε`-regularity demand.  Thus an AFKS two-level partition delivers a coarse
+    `ε`-regular partition **and** an `ε`-regular refinement of it — the defining strength
+    of the strong lemma over the classical one.  Proof: the fine clause (iii) is
+    `IsAFKSFineRegular` at fine tolerance `E(k)`; bridge up (`ToleranceBridge`) turns that
+    into `IsRegularPartition G ε Wparts` under `E(k) ≤ ε`. -/
+theorem isRegularPartition_fine_of_afksTwoLevel (G : SimpleGraph V) [DecidableRel G.Adj]
+    {ε : ℚ} {E : ℕ → ℚ} {Vparts Wparts : Finset (Finset V)}
+    (h : IsAFKSTwoLevel G ε E Vparts Wparts)
+    (hEε : E (Vparts.card) ≤ ε) :
+    IsRegularPartition G ε Wparts :=
+  isRegularPartition_of_afksFineRegular G h.fineRegular hEε
+
+/-- **Builder.**  Assemble the two-level conclusion from its pieces: a coarse `ε`-regular
+    partition `Vparts`, a refinement `Wparts` of it, and a genuine `E(k)`-regularity of
+    `Wparts` at the stronger tolerance `E(k) ≤ ε`.  The `E(k)`-regular refinement is
+    upgraded to the AFKS mixed predicate by bridge-down (`afksFineRegular_of_isRegularPartition`).
+    This is the shape the outer AFKS loop produces at the regular step it terminates in. -/
+theorem isAFKSTwoLevel_of_regular_refinement (G : SimpleGraph V) [DecidableRel G.Adj]
+    {ε : ℚ} {E : ℕ → ℚ} {Vparts Wparts : Finset (Finset V)}
+    (hcoarse : IsRegularPartition G ε Vparts)
+    (href : IsRefinement Wparts Vparts)
+    (hfine : IsRegularPartition G (E (Vparts.card)) Wparts)
+    (hEε : E (Vparts.card) ≤ ε) :
+    IsAFKSTwoLevel G ε E Vparts Wparts where
+  coarseRegular := hcoarse
+  refines := href
+  fineRegular := afksFineRegular_of_isRegularPartition G hfine hEε
+
+/-- **Monotone in the coarse tolerance.**  Enlarging the coarse tolerance `ε ≤ ε'`
+    preserves the two-level conclusion (same partitions, same dependent tolerance `E`):
+    the coarse regularity relaxes (`isRegularPartition_mono`), the refinement is unchanged,
+    and the fine mixed predicate relaxes its budget (`afksFineRegular_mono_coarse`). -/
+theorem isAFKSTwoLevel_mono_coarse (G : SimpleGraph V) [DecidableRel G.Adj]
+    {ε ε' : ℚ} {E : ℕ → ℚ} {Vparts Wparts : Finset (Finset V)}
+    (h : IsAFKSTwoLevel G ε E Vparts Wparts) (hεε' : ε ≤ ε') :
+    IsAFKSTwoLevel G ε' E Vparts Wparts where
+  coarseRegular := isRegularPartition_mono G h.coarseRegular hεε'
+  refines := h.refines
+  fineRegular := afksFineRegular_mono_coarse G h.fineRegular hεε'
+
+end Szemeredi.RegularityOQ04TwoLevel

--- a/research/problems/szemeredi-regularity-oq-04/state.md
+++ b/research/problems/szemeredi-regularity-oq-04/state.md
@@ -6,6 +6,38 @@
 **Since**: 2026-07-08T19:18:01-07:00
 **Iteration**: 3
 
+## Status (S10, researcher-1, 2026-07-19) — OUTER-LOOP ASSEMBLY wired (item 3 STRUCTURAL half DONE)
+
+New file `SzemerediRegularityOQ04Outer.lean` (2 thm, 1 def, 0 ax, 0 sorry, docker-VERIFIED,
+8586 jobs; `#print axioms = [propext, Classical.choice, Quot.sound]` on both theorems).
+Discharges the **structural half of "What remains open" item 3** — *run the outer loop using
+the termination certificate to produce a two-level partition* — by wiring the already-verified
+termination bound `afks_regular_step_within_bound` (the contrapositive of the sharp energy
+iteration-count) to the packaged conclusion `IsAFKSTwoLevel` (item 2).
+
+- `IsWitnessedSharpStep G parts n eps m` — names the per-step witness negated inside
+  `afks_regular_step_within_bound` (mass-`m`, `eps`-irregular sharp `2×2` split) so the
+  dichotomy hypothesis reads cleanly; it matches that witness clause-for-clause.
+- `exists_afksTwoLevel_of_dichotomy` — **the assembly**: from a fixed coarse `ε`-regular
+  `Vparts`, a refinement chain `parts : ℕ → …` (covers, pairwise-disjoint, each refining
+  `Vparts`), a horizon `N` beyond `n²/(E(k)⁴·m²)`, and the **regular-or-refine dichotomy**
+  (`¬IsAFKSFineRegular (parts n) ⟹ IsWitnessedSharpStep … n`), ∃ `n < N` with
+  `IsAFKSTwoLevel G ε E Vparts (parts n)`. Proof: `afks_regular_step_within_bound` yields a
+  step with no witnessed refinement; the dichotomy's contrapositive makes that `parts n`
+  AFKS-fine-regular; package against the coarse level.
+- `exists_afksTwoLevel_of_dichotomy_equipartition` — same conclusion, horizon in the
+  vertex-count-free tower-free form `k²/E(k)⁴` (equipartition mass floor `m = n/k`).
+
+**What is NOT yet done (the remaining crux):** the dichotomy is taken as an *explicit
+hypothesis*, not proved. That hypothesis IS item 1's analytic realizability — a fine
+partition failing the `E(k)`-regular budget contains an `E(k)`-irregular pair whose sharp
+`2×2` refinement realizes the no-loss energy gain. The sibling energy files (Bside capstone
+`exists_refinement_energy_gain_of_irregular` at the `ε²/(8n²)` floor; the sharp-2×2
+`partitionEnergy_prod_gain_eps4*`) supply the per-pair gain; assembling them into the exact
+`IsWitnessedSharpStep`-shaped, whole-partition dichotomy (freshness + equipartition split
+realizability `|A₁| ≥ ε|A|`) is the substantive open piece. Item 3 is therefore
+**structurally closed, analytically open**.
+
 ## Status (S9, researcher-1, 2026-07-19) — TWO-LEVEL AFKS CONCLUSION packaged (item 2 DONE)
 
 New file `SzemerediRegularityOQ04TwoLevel.lean` (5 thm, 1 def, 1 structure, 0 ax, 0 sorry,

--- a/research/problems/szemeredi-regularity-oq-04/state.md
+++ b/research/problems/szemeredi-regularity-oq-04/state.md
@@ -6,6 +6,33 @@
 **Since**: 2026-07-08T19:18:01-07:00
 **Iteration**: 3
 
+## Status (S9, researcher-1, 2026-07-19) — TWO-LEVEL AFKS CONCLUSION packaged (item 2 DONE)
+
+New file `SzemerediRegularityOQ04TwoLevel.lean` (5 thm, 1 def, 1 structure, 0 ax, 0 sorry,
+docker-VERIFIED, 8579 jobs). Discharges "What remains open" **item 2** — the two-level AFKS
+conclusion (clauses i–iii) as a single packaged proposition, threading the dependent tolerance
+`E : ℕ → ℚ` correctly:
+
+- `IsRefinement Wparts Vparts` — block refinement (every fine block ⊆ some coarse block), with
+  `isRefinement_refl` / `isRefinement_trans` / `isRefinement_empty` (a preorder — clause (i)).
+- `structure IsAFKSTwoLevel G ε E Vparts Wparts` — fields `coarseRegular` (`IsRegularPartition G ε
+  Vparts`, clause ii), `refines` (clause i), `fineRegular` (`IsAFKSFineRegular G ε (E Vparts.card)
+  Wparts`, clause iii). The dependent tolerance is threaded by evaluating `E` at the coarse size
+  `k = |Vparts|` — the "chosen after seeing k" dependency the statement demands.
+- `isRegularPartition_coarse_of_afksTwoLevel` — coarse level is ε-regular (projection).
+- `isRegularPartition_fine_of_afksTwoLevel` — **BOTH levels ε-regular**: the fine partition, built
+  to the stronger `E(k) ≤ ε`, satisfies the coarse ε-demand for free (ToleranceBridge bridge-up).
+  This is the strong lemma's signature strength over the classical single-ε lemma.
+- `isAFKSTwoLevel_of_regular_refinement` — **builder**: coarse ε-regular partition + `E(k)`-regular
+  refinement (`E(k) ≤ ε`) ⟹ the two-level conclusion (bridge-down). The shape the outer loop yields.
+- `isAFKSTwoLevel_mono_coarse` — monotone in the coarse tolerance ε.
+
+Elementary order/set arithmetic over `Szemeredi.Core` + the verified ToleranceBridge/Tolerance
+lemmas; no energy machinery. **Now open**: item 3 only — the outer-loop *assembly* that actually
+produces an `IsAFKSTwoLevel` witness for every graph, wiring the Mathlib classical regularity lemma
+(black box) into `afks_regular_step_within_bound` (the termination engine, already verified). Item 1
+(sharp 2×2 energy increment + termination) is DONE in Assembly/base files.
+
 ## Status (S8, researcher-8, 2026-07-12) — TOLERANCE monotonicity (item-2 dimension opened)
 
 New file `SzemerediRegularityOQ04Tolerance.lean` (7 thm, 0 ax, 0 sorry, docker-VERIFIED


### PR DESCRIPTION
## Summary
Two research sessions on the strong (AFKS) Szemerédi regularity lemma (OQ-04), advancing `state.md` "What remains open" items **2** and the **structural half of 3**. Both new files are docker-VERIFIED, 0 axiom / 0 sorry, `#print axioms = [propext, Classical.choice, Quot.sound]`.

## Progress
- **Item 2 — `SzemerediRegularityOQ04TwoLevel.lean`** (S9): packages the two-level AFKS conclusion (clauses i–iii) as a single proposition `IsAFKSTwoLevel G ε E Vparts Wparts`, threading the dependent tolerance `E : ℕ → ℚ` evaluated at the coarse size `k = |Vparts|`. Includes the block-refinement preorder `IsRefinement`, coarse/fine projections (both levels ε-regular via the tolerance bridge), the builder, and coarse-tolerance monotonicity.
- **Item 3 structural — `SzemerediRegularityOQ04Outer.lean`** (S10): `exists_afksTwoLevel_of_dichotomy` wires the already-verified termination bound `afks_regular_step_within_bound` (contrapositive of the sharp energy iteration-count) to `IsAFKSTwoLevel`. Given a coarse ε-regular `Vparts`, a refinement chain, a horizon beyond `n²/(E(k)⁴·m²)`, and the **regular-or-refine dichotomy**, there is a step at which `(Vparts, parts n)` is a two-level partition. Plus the vertex-count-free `k²/E(k)⁴` horizon variant `_equipartition`.

## Findings
- Item 3 splits cleanly into a **structural** half (termination-certificate → two-level conclusion — now done) and an **analytic** half (the dichotomy `¬fine-regular ⟹ witnessed sharp-2×2 gain step` = item-1 realizability). The structural wiring needs no new mathematics beyond the termination bound + the item-2 packaging.
- `IsWitnessedSharpStep` names the per-step witness negated inside `afks_regular_step_within_bound`, matched clause-for-clause.

## Status
**Outcome**: progress (items 2 + 3-structural verified; the analytic dichotomy of item 1 remains the open crux)
**Next Steps**: assemble the sibling energy-gain lemmas (`exists_refinement_energy_gain_of_irregular`, `partitionEnergy_prod_gain_eps4*`) into the exact `IsWitnessedSharpStep`-shaped whole-partition dichotomy (freshness done; equipartition split-realizability `|A₁| ≥ ε|A|` open).

🤖 Generated by researcher-1