### PR TITLE
Fix: erdos-413 gallery prose stale barrier_gap_two bound ω(n)≤1 → ω(n)≤2

### DIFF
--- a/src/data/proofs/erdos-413/annotations.json
+++ b/src/data/proofs/erdos-413/annotations.json
@@ -216,7 +216,7 @@
     },
     "type": "concept",
     "title": "Barrier Spacing and Gap Theorems",
-    "content": "Several theorems constrain how barriers can be spaced:\n\n- **barrier_gap_two**: If $n \\geq 2$, $n$ and $n+2$ are both barriers, then $\\omega(n) \\leq 1$ and $\\omega(n+1) \\leq 1$\n- **barrier_succ_iff**: $n+1$ is a barrier iff $\\omega(n) \\leq 1$ (given $n$ is a barrier)\n- **consecutive_barriers_prime_power**: Consecutive barriers at $n, n+1$ force $\\omega(n) \\leq 1$\n- **non_prime_power_barrier_gap**: If $\\omega(n) \\geq 2$ at a barrier $n$, the next barrier is $\\geq n+2$\n\nThese show that consecutive barriers require intervening prime powers.",
+    "content": "Several theorems constrain how barriers can be spaced:\n\n- **barrier_gap_two**: If $n \\geq 2$, $n$ and $n+2$ are both barriers, then $\\omega(n) \\leq 2$ and $\\omega(n+1) \\leq 1$ (e.g. $n = 6$ shows the $\\omega(n) \\leq 2$ bound is sharp: $\\omega(6) = 2$ and both $6$ and $8$ are barriers)\n- **barrier_succ_iff**: $n+1$ is a barrier iff $\\omega(n) \\leq 1$ (given $n$ is a barrier)\n- **consecutive_barriers_prime_power**: Consecutive barriers at $n, n+1$ force $\\omega(n) \\leq 1$\n- **non_prime_power_barrier_gap**: If $\\omega(n) \\geq 2$ at a barrier $n$, the next barrier is $\\geq n+2$\n\nThese show that consecutive barriers require intervening prime powers.",
     "mathContext": "If $n$ and $n+1$ are both $\\omega$-barriers, then $\\omega(n) \\leq 1$, i.e., $n$ is a prime power (or 0 or 1). If $n$ has $\\geq 2$ distinct prime factors, the next barrier must skip at least one integer.",
     "significance": "key",
     "relatedConcepts": [

--- a/src/data/proofs/erdos-413/meta.json
+++ b/src/data/proofs/erdos-413/meta.json
@@ -164,7 +164,7 @@
       "title": "Barrier Structural and Spacing Theorems",
       "startLine": 356,
       "endLine": 433,
-      "summary": "Not-barrier witness extraction (∃ m<n, m+f(m)>n), barrier predecessors are prime powers, downward closure (barrier for constant 0), and spacing: gap-two barriers force ω(n),ω(n+1) ≤ 1, and barrier-to-successor conditions.",
+      "summary": "Not-barrier witness extraction (∃ m<n, m+f(m)>n), barrier predecessors are prime powers, downward closure (barrier for constant 0), and spacing: gap-two barriers force ω(n) ≤ 2 and ω(n+1) ≤ 1, and barrier-to-successor conditions.",
       "mathContext": "Every barrier $n\\geq 2$ for ω has $n-1\\in\\{1\\}\\cup\\{p^k\\}$. If $n$ and $n+2$ are both barriers then $\\omega(n),\\omega(n+1)\\leq 1$ — barriers cannot cluster around composite-rich predecessors."
     },
     {
@@ -340,8 +340,8 @@
     {
       "name": "barrier_gap_two",
       "type": "theorem",
-      "statement": "If n ≥ 2 and both n and n+2 are ω-barriers, then ω(n) ≤ 1 and ω(n+1) ≤ 1",
-      "significance": "A spacing law: two barriers only two apart force the intervening values to have at most one prime factor. This limits how densely ω-barriers can cluster.",
+      "statement": "If n ≥ 2 and both n and n+2 are ω-barriers, then ω(n) ≤ 2 and ω(n+1) ≤ 1",
+      "significance": "A spacing law: two barriers only two apart bound ω(n) ≤ 2 (sharp at n = 6) and force ω(n+1) ≤ 1. This limits how densely ω-barriers can cluster.",
       "description": "Applies the n+2 barrier hypothesis at m = n and m = n+1 and simplifies with omega."
     },
     {


### PR DESCRIPTION
## Problem

Flagged in the #38611 re-audit log (`research/migration/38611-statement-repairs-v426-to-v431.txt`):

> Erdos413Problem: barrier_gap_two claimed ω(n)≤1 (FALSE at n=6, ω(6)=2, both 6&8 barriers); tightened to ω(n)≤2.

The Lean theorem `barrier_gap_two` now concludes `ω(n) ≤ 2 ∧ ω(n+1) ≤ 1` (from the `n+2` barrier applied at `m=n`, one gets `n + ω(n) ≤ n+2`, i.e. `ω(n) ≤ 2`; `n=6` is a counterexample to the old `≤ 1` claim). The Lean statement + docstring were corrected but 3 gallery-metadata sites still stated the old false `ω(n) ≤ 1` bound.

## Fix (metadata only)

| Site | Before | After |
|------|--------|-------|
| `annotations.json:219` | "then $\omega(n) \leq 1$ and $\omega(n+1) \leq 1$" | "then $\omega(n) \leq 2$ and $\omega(n+1) \leq 1$" (+ n=6 sharpness note) |
| `meta.json:167` | "gap-two barriers force ω(n),ω(n+1) ≤ 1" | "gap-two barriers force ω(n) ≤ 2 and ω(n+1) ≤ 1" |
| `meta.json:343` (originalContributions statement) | "then ω(n) ≤ 1 and ω(n+1) ≤ 1" | "then ω(n) ≤ 2 and ω(n+1) ≤ 1" |
| `meta.json:344` (significance) | "force the intervening values to have at most one prime factor" | "bound ω(n) ≤ 2 (sharp at n = 6) and force ω(n+1) ≤ 1" |

`barrier_no_three_consecutive` (three consecutive barriers `n, n+1, n+2`) genuinely gives `ω(n) ≤ 1` via the `n+1` barrier, so its metadata (`meta.json:350`) is left unchanged.

## Validation

- Both JSON files parse (`json.load` OK).
- Lean source unchanged; corrected statement at `proofs/Proofs/Erdos413Problem.lean:411-418`.

Part of #38611.