### PR TITLE
Fix: erdos-752 annotation shows disproven ≥ c·k^s bound → floor form ⌊c·k^s⌋₊

### DIFF
--- a/src/data/proofs/erdos-752/annotations.json
+++ b/src/data/proofs/erdos-752/annotations.json
@@ -80,8 +80,8 @@
       "endLine": 70
     },
     "title": "The Erdős-Faudree-Schelp Conjecture",
-    "content": "**ErdosFaudreeSchelpConjecture:**\n\nThere exists c > 0 such that for all graphs G with minimum degree ≥ k and girth > 2s:\n\n|{cycle lengths in G}| ≥ c · k^s\n\nThis quantifies how many distinct cycle lengths are forced by the degree and girth conditions.",
-    "mathContext": "The ≫ notation in the original statement means 'grows at least as fast as' up to constants. The formal statement makes the constant c explicit.",
+    "content": "**ErdosFaudreeSchelpConjecture:**\n\nThere exists c > 0 such that for all graphs G with minimum degree ≥ k and girth > 2s:\n\n|{cycle lengths in G}| ≥ ⌊c · k^s⌋₊\n\nThis quantifies how many distinct cycle lengths are forced by the degree and girth conditions. The bound is stated in floor form (the discrete reading of \"≫ k^s\"): when c · k^s < 1 the bound is trivially 0, the correct degenerate behavior (e.g. a perfect matching has min degree 1 and arbitrarily high girth but no cycles at all).",
+    "mathContext": "The ≫ notation in the original statement means 'grows at least as fast as' up to constants. The formal statement makes the constant c explicit and uses the natural-number floor ⌊·⌋₊ so the count is a genuine cardinality; the bare real bound ≥ c · k^s is false at small k·s where c · k^s ∈ (0,1) yet no cycle length is forced.",
     "significance": "key",
     "relatedConcepts": [
       "Extremal bounds",


### PR DESCRIPTION
## Problem

The `ErdosFaudreeSchelpConjecture` annotation for **erdos-752** displayed the bare real bound:

```
|{cycle lengths in G}| ≥ c · k^s
```

The v4.26→v4.31 migration audit (#38611) found this statement **mathematically false** at small `k·s`: when `c·k^s ∈ (0,1)`, no cycle length is forced (e.g. a perfect matching has min degree 1 and arbitrarily high girth but *no cycles at all*). The Lean statement was accordingly corrected to the **floor form**:

```lean
numCycleLengths G ≥ ⌊c * (k : ℝ) ^ s⌋₊
```

The gallery annotation was never updated, so the gallery displayed a disproven statement.

## Fix

Update `src/data/proofs/erdos-752/annotations.json` (the `ErdosFaudreeSchelpConjecture` annotation only) to show the floor form and explain the degenerate-zero behavior, matching the corrected Lean docstring. No Lean/count changes — meta axioms/status already correct.

## Evidence
- Before: `|{cycle lengths in G}| ≥ c · k^s`
- After: `|{cycle lengths in G}| ≥ ⌊c · k^s⌋₊` (+ note on degenerate 0 case)
- Repair log: `research/migration/38611-statement-repairs-v426-to-v431.txt` (Erdos752Problem entry, flagged "gallery meta erdos-752 RE-AUDIT")
- Lean source `proofs/Proofs/Erdos752Problem.lean:63-70` uses `⌊c·k^s⌋₊`.

Auditor re-serve PR #39304 verified counts/axioms and marked erdos-752 clean but did **not** compare the annotation statement text against the corrected Lean.

Part of #38611.