### PR TITLE
audit: re-serve erdos-726 (axiomatized) — clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -15935,8 +15935,8 @@
     },
     "erdos-726": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:54:15Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-20T05:59:18Z",
       "result": "clean"
     },
     "erdos-727": {


### PR DESCRIPTION
## Reserve-mode audit

Queue is drained (4807/4807 audited). The top-10 re-serve targets are all contested by open fleet audit PRs, so I picked the **oldest uncontested** target: `erdos-726` (last audited 2026-05-04, 3×, clean).

## Result: clean

Verified `erdos-726` — "Residues in the Upper Half Interval" (Erdős–Graham–Ruzsa–Straus 1975, **OPEN**):

- **Counts match**: 19 theorems, 6 defs, 2 axioms, 0 sorries. (`meta.lineCount` 316 vs actual 318 = harmless stale undercount.)
- **No integrity issues**: no `True` stubs, no `native_decide`, no `sorry`.
- **Axioms honestly disclosed**: `mertens_theorem` + `erdos_726_conjecture` (the open conjecture itself). `badge=axiom`, `status=axiomatized`, `assumptions` names both. Correct Tier C.
- **No phantom declarations in prose**: every named decl (`upper_half_count`, `heuristic_half_fraction`, `sum_partition`, `lower_half_also_half`, `mertensSum_mono`, `mertensSum_pos`, `isUpperHalfResidue`) exists in the file.
- **Conditional implications non-vacuous**: `lower_half_also_half`, `upper_lower_asymptotic`, `ratio_converges_to_half` genuinely consume both axioms + `sum_partition`, and prose frames them as conditional on the conjecture — no overclaim.

Only change: `audit-tracker.json` bump for `erdos-726` (auditCount 3→4).

---
Discovered during gallery integrity audit.