### PR TITLE
audit: re-serve erdos-727 (axiomatized) — clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -15941,8 +15941,8 @@
     },
     "erdos-727": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:54:15Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-20T06:05:40Z",
       "result": "clean"
     },
     "erdos-728": {


### PR DESCRIPTION
## Gallery integrity re-audit — erdos-727

Reserve-mode re-serve (unaudited queue drained). Verified all `meta.json`
claims against `proofs/Proofs/Erdos727Problem.lean`.

| Check | meta | file | ✓ |
|---|---|---|---|
| axiomCount | 3 | 3 (`balakran_theorem`, `egrs_theorem`, `erdos_factorial_bound`) | ✓ |
| theoremCount | 7 | 7 | ✓ |
| definitionCount | 9 | 9 | ✓ |
| sorries | 0 | 0 | ✓ |
| status/badge | axiomatized / axiom | matches | ✓ |

- Main conjecture (`erdos_727_conjecture`) is a `def` (Prop), not a proven theorem — correctly not claimed as solved.
- Description honestly states the problem is OPEN for k≥2; Balakran (k=1) and EGRS variant are axiomatized.
- No True stubs, no `native_decide` (only kernel `decide` in one example).
- All 7 `originalContributions` map to real declarations; `proofStrategy`/`assumptions` accurate.
- Nit only: `lineCount` 296 vs actual 293 (immaterial overcount, not a public claim).

No integrity issues. Marked clean.

---
Discovered during gallery integrity audit.