### PR TITLE
Fix: erdos-1155-oq-02 lineCount drift (314→328)

### DIFF
--- a/src/data/proofs/erdos-1155-oq-02/meta.json
+++ b/src/data/proofs/erdos-1155-oq-02/meta.json
@@ -21,7 +21,7 @@
     "dateAdded": "2026-04-24",
     "axiomCount": 6,
     "assumptions": "6 axioms: triangleRemovalEdges (f(n) exists), triangleRemovalEdges_nonneg (f(n) ≥ 0), bfl_upper_bound (f(n) ≤ n^{3/2+ε}), bfl_lower_bound (f(n) ≥ n^{3/2−ε}), triangleRemoval_mantel_bound (Mantel variant), triangleRemovalEdges_le_turan_exact (f(n) ≤ n²/4 via Turán). Note: triangleRemovalEdges_le_complete is now a theorem (proved via Mantel bound), not an axiom.",
-    "lineCount": 314,
+    "lineCount": 328,
     "theoremCount": 9,
     "definitionCount": 1,
     "originalContributions": [
@@ -163,7 +163,7 @@
     }
   ],
   "leanFile": {
-    "lineCount": 314,
+    "lineCount": 328,
     "path": "Proofs/Erdos1155OQ02.lean",
     "axiomCount": 1,
     "sorries": 0,


### PR DESCRIPTION
## Problem

The #37508 v4.26→v4.31 migration flip (#39062) applied a statement repair to `Proofs/Erdos1155OQ02.lean` — rewriting `process_not_turan_extremal` (the old `n>8` threshold was mathematically insufficient; true crossover is `n=8⁴=4096`, so the proof now derives the threshold from `tendsto_rpow_atTop` plus an explanatory comment block). This grew the file but the gallery metadata's `lineCount` was never updated.

## Fix

Update both `lineCount` fields (`meta.lineCount` and `leanFile.lineCount`) from `314` to `328` to match `wc -l` of the current source.

## Evidence

```
$ wc -l < proofs/Proofs/Erdos1155OQ02.lean
328
```

Before: `"lineCount": 314` (×2) — After: `"lineCount": 328` (×2).

All other counts verified unchanged and correct against source: `theoremCount 9`, `leanFile.axiomCount 1` (literal `axiom`), `meta.axiomCount 6` (aggregate incl. imported BFL-parent axioms), `sorries 0`, `status axiomatized`/`badge axiom`. Prose accurately describes the repaired `f(n) < n²/8` statement. JSON validated.

Part of #38611 (post-migration gallery metadata re-audit for statement-repaired entries).