### PR TITLE
audit: erdos-715 — drop 'Verified' overclaim from counterexamples section

### DIFF
--- a/src/data/proofs/erdos-715/meta.json
+++ b/src/data/proofs/erdos-715/meta.json
@@ -73,7 +73,7 @@
       "tashkinov_theorem: 4-regular → 3-regular subgraph (sorry)",
       "regular_has_3_regular: r ≥ 4 → 3-regular subgraph (sorry)",
       "alon_friedland_kalai: 4-regular + edge → 3-regular subgraph (sorry)",
-      "K4: complete graph on Fin 4, proved 3-regular",
+      "K4: complete graph on Fin 4; K4_is_3_regular stated (sorry)",
       "K4_minimal_3_regular: K₄ has no proper 3-regular subgraph (sorry)",
       "berge_sauer_answer: proved from tashkinov_theorem with witness r = 4",
       "RegularSubgraphThreshold: general threshold function for k-regular subgraphs",

--- a/src/data/proofs/erdos-715/meta.json
+++ b/src/data/proofs/erdos-715/meta.json
@@ -147,10 +147,10 @@
     {
       "id": "counterexamples",
       "title": "Counterexamples for r < 4",
-      "summary": "K₄ (Fin 4, complete graph) is 3-regular with no proper 3-regular subgraph. Proves the threshold is exactly 4 by providing the sharpness witness.",
+      "summary": "K₄ (Fin 4, complete graph) is stated to be 3-regular with no proper 3-regular subgraph; both theorems (`K4_is_3_regular`, `K4_minimal_3_regular`) are `sorry`. Intended as the sharpness witness that the threshold is exactly 4.",
       "startLine": 98,
       "endLine": 122,
-      "mathContext": "Verified: K₄ (Fin 4, complete graph) is 3-regular with no proper 3-regular subgraph. Proves the threshold is exactly 4 by providing the sharpness witness."
+      "mathContext": "Formal statements (unproved): K₄ (Fin 4, complete graph) stated 3-regular with no proper 3-regular subgraph; both theorems are `sorry`. Intended sharpness witness that the threshold is exactly 4."
     },
     {
       "id": "berge-sauer",


### PR DESCRIPTION
## Integrity Issue

**Proof**: erdos-715 (Regular Subgraphs in Regular Graphs, Berge–Sauer)
**Problem**: The `counterexamples` section prose claimed results as **"Verified:"** and asserted K₄ facts as established, but the underlying theorems are entirely `sorry`.

## Evidence

**meta.json claimed** (section `counterexamples`):
- summary: "K₄ … **is** 3-regular with no proper 3-regular subgraph. **Proves** the threshold is exactly 4…"
- mathContext: "**Verified:** K₄ … is 3-regular with no proper 3-regular subgraph…"

**Lean file shows** (`Proofs/Erdos715Problem.lean`):
- `K4_is_3_regular` (line 108) → `sorry`
- `K4_minimal_3_regular` (line 112) → `sorry`

The file is `badge: wip`, `sorries: 15`, and the sibling `petersen` section already uses honest wording ("Stated to be 3-regular…"). Only this section overstated.

## Fix

Reworded the `counterexamples` summary/mathContext to "Formal statements (unproved)" / "stated … both theorems are `sorry`", matching the petersen section and the file's disclosed WIP status.

## Verification

Re-audited all counts against the source — accurate, no changes needed:
- 15 sorries ✓ · 0 axioms ✓ · 13 theorems ✓ · 11 definitions ✓
- No `native_decide`, no True-stubs. lineCount 209 is a harmless stale undercount (actual 217).

---
Discovered during gallery integrity re-audit (queue drained; reserve mode, oldest uncontested target).