### PR TITLE
Enrich Generalized Continuum Function: fix section line ranges

### DIFF
--- a/src/data/proofs/cantor-diagonalization-oq-01-oq-01-oq-03/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-01-oq-01-oq-03/meta.json
@@ -117,14 +117,21 @@
     },
     {
       "title": "Cantor and König constraints",
+      "startLine": 50,
+      "endLine": 59,
+      "summary": "aleph_lt_contFn (Cantor's ℵ_α < 2^{ℵ_α}, from Cardinal.cantor) and aleph_lt_cof_contFn (König's generalized cf(2^{ℵ_α}) > ℵ_α, one line from lt_cof_power with base 2 > 1 and ℵ₀ ≤ ℵ_α) — the two strict constraints, discharging the parent's stated-only König.",
+      "mathContext": "Cantor: $\\aleph_\\alpha < 2^{\\aleph_\\alpha}$. König: $\\operatorname{cf}(2^{\\aleph_\\alpha}) > \\aleph_\\alpha$."
+    },
+    {
+      "title": "Classical case and no fixed point",
       "startLine": 61,
-      "endLine": 73,
-      "summary": "aleph_lt_contFn (Cantor), aleph_lt_cof_contFn (König, generalized, from lt_cof_power), and the classical aleph0_lt_cof_continuum; plus contFn_ne_aleph (no fixed point).",
-      "mathContext": "Cantor: $\\aleph_\\alpha < 2^{\\aleph_\\alpha}$. König: $\\operatorname{cf}(2^{\\aleph_\\alpha}) > \\aleph_\\alpha$ (so $2^{\\aleph_0} \\ne \\aleph_\\omega$). Together they give $2^{\\aleph_\\alpha} \\ne \\aleph_\\alpha$ (no fixed point)."
+      "endLine": 69,
+      "summary": "aleph0_lt_cof_continuum — the classical instance cf(2^{ℵ₀}) > ℵ₀ (specializing α = 0 and rewriting ℵ_0 = ℵ₀), which forbids 2^{ℵ₀} = ℵ_ω since ℵ_ω has countable cofinality; and contFn_ne_aleph, the corollary of Cantor that the continuum function has no fixed point.",
+      "mathContext": "$\\operatorname{cf}(2^{\\aleph_0}) > \\aleph_0$, so $2^{\\aleph_0} \\ne \\aleph_\\omega$; and $2^{\\aleph_\\alpha} \\ne \\aleph_\\alpha$ (no fixed point)."
     },
     {
       "title": "Packaged admissibility constraints",
-      "startLine": 75,
+      "startLine": 71,
       "endLine": 79,
       "summary": "contFn_constraints: the three Easton constraints (Cantor, König, monotonicity) bundled as the necessary conditions on any consistent continuum pattern.",
       "mathContext": "The conjunction $\\aleph_\\alpha < 2^{\\aleph_\\alpha}$, $\\operatorname{cf}(2^{\\aleph_\\alpha}) > \\aleph_\\alpha$, and $\\alpha\\le\\beta \\Rightarrow 2^{\\aleph_\\alpha}\\le 2^{\\aleph_\\beta}$ — by Easton's theorem, the complete list of ZFC constraints on the continuum function."


### PR DESCRIPTION
## Enrichment pass for `cantor-diagonalization-oq-01-oq-01-oq-03`

**Correctness fix (not accretion).** The "Cantor and König constraints" section declared line range **61–73**, but in the 79-line Lean file:
- `aleph_lt_contFn` (Cantor) is at line **52**
- `aleph_lt_cof_contFn` (König) is at line **58**

So lines **50–60 were uncovered** by any section, and clicking that section navigated to the classical-case/no-fixed-point code instead of Cantor/König.

### Changes
- `Cantor and König constraints` → corrected to **50–59** (the two strict constraints).
- Added **`Classical case and no fixed point` (61–69)** for `aleph0_lt_cof_continuum` and `contFn_ne_aleph`, which were previously lumped into the mislabeled range.
- `Packaged admissibility constraints` → **71–79**.

Sections now partition the whole file accurately: 1–43, 44–49, 50–59, 61–69, 71–79.

### Verification
- JSON validated (`JSON.parse`).
- `pnpm build` gallery-data step processed all 2635 problems including this entry. (Build's final `tsc` step fails with `tsc: command not found` — a pre-existing environment gap, unrelated to this data change.)
- Axiom integrity unchanged: entry remains `verified`/`axiomCount: 0`, consistent with the `import Mathlib` ZFC proof (#print axioms → propext/Classical.choice/Quot.sound only).