### PR TITLE
Fix: erdos-ko-rado stale hm_bound_n7_k3 value (14→13) in gallery meta

### DIFF
--- a/src/data/proofs/erdos-ko-rado/meta.json
+++ b/src/data/proofs/erdos-ko-rado/meta.json
@@ -135,7 +135,7 @@
       "title": "Part III: Hilton-Milner Theorem (1967)",
       "startLine": 507,
       "endLine": 549,
-      "summary": "IsStar A k: ∃ x, A = Star x k. hiltonMilnerBound n k := C(n-1,k-1) - C(n-k-1,k-1) + 1. hilton_milner axiom: if A is intersecting, not a star, and n≥2k, then |A| ≤ hiltonMilnerBound. hm_bound_n7_k3: hiltonMilnerBound 7 3 = 14 (verified by native_decide). hm_gap_positive: hiltonMilnerBound n k < C(n-1,k-1) when n>2k and k≥2 (since C(n-k-1,k-1) ≥ k ≥ 2 > 1).",
+      "summary": "IsStar A k: ∃ x, A = Star x k. hiltonMilnerBound n k := C(n-1,k-1) - C(n-k-1,k-1) + 1. hilton_milner axiom: if A is intersecting, not a star, and n≥2k, then |A| ≤ hiltonMilnerBound. hm_bound_n7_k3: hiltonMilnerBound 7 3 = 13 (= 15 - 3 + 1, verified by native_decide). hm_gap_positive: hiltonMilnerBound n k < C(n-1,k-1) when n>2k and k≥2 (since C(n-k-1,k-1) ≥ k ≥ 2 > 1).",
       "mathContext": "Hilton-Milner (1967) characterizes the 'second-largest' intersecting family: it consists of one set B plus all k-sets that meet B and contain a fixed core element not in B. The HM bound = C(n-1,k-1) - C(n-k-1,k-1) + 1 is strictly less than the EKR bound C(n-1,k-1) for n>2k, showing stars are significantly larger than non-star intersecting families."
     },
     {


### PR DESCRIPTION
## Summary

The #38611 v4.31 statement repair corrected `hm_bound_n7_k3` in `proofs/Proofs/ErdosKoRado.lean` to its true value:

```lean
/-- For n=7, k=3: HM bound = C(6,2) - C(3,2) + 1 = 15 - 3 + 1 = 13.
    (The original statement here had an arithmetic typo (16-3+1=14 ≠ 13) ...) -/
theorem hm_bound_n7_k3 : hiltonMilnerBound 7 3 = 15 - 3 + 1 := by ...
```

The gallery `annotations.json` was already updated to `13`, but the section summary in `meta.json` still described the old, incorrect value `= 14`.

## Change

Single-line metadata fix in `src/data/proofs/erdos-ko-rado/meta.json`:

- **Before:** `hm_bound_n7_k3: hiltonMilnerBound 7 3 = 14 (verified by native_decide).`
- **After:** `hm_bound_n7_k3: hiltonMilnerBound 7 3 = 13 (= 15 - 3 + 1, verified by native_decide).`

## Evidence

- Lean source (`ErdosKoRado.lean:526-529`): true value is `13`; docstring explicitly flags old `14` as an arithmetic typo.
- `annotations.json:189-190`: already state `15-3+1=13`.
- JSON validated with `jq`; minimal one-line diff.

Metadata-only fix, no Lean change. Part of #38611 gallery re-audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)