### PR TITLE
audit: erdos-955 — drop phantom pollack_primes/troupe_two_squares from prose

### DIFF
--- a/src/data/proofs/erdos-955/meta.json
+++ b/src/data/proofs/erdos-955/meta.json
@@ -58,14 +58,14 @@
       "preimage_s: Definition of s⁻¹(A)",
       "EGPSConjecture: Main conjecture statement",
       "IsUntouchable: Numbers not in range of s",
-      "pollack_primes: Result for prime set",
-      "troupe_two_squares: Result for sums of squares",
-      "ppt_bound: Threshold x^{1/2+o(1)}",
-      "sparse_sets_work: Corollary of PPT"
+      "IsSumOfTwoSquares: Sum-of-two-squares predicate",
+      "ppt_bound: Axiomatized PPT threshold x^{1/2+o(1)}",
+      "sparse_sets_work: Corollary of the ppt_bound axiom",
+      "erdos_955_summary / erdos_955: Axiomatized combination of the primes (Pollack), sums-of-two-squares (Troupe), and sparse-set (PPT) partial results"
     ],
     "dateAdded": "2026-01-19",
     "axiomCount": 2,
-    "assumptions": "2 axiom declarations: ppt_bound (Pollack-Pomerance-Thompson 2018: if |A cap [1,x]| <= x^{1/2+o(1)} then s^{-1}(A) has density 0), erdos_955_summary (combined partial results: primes, sums of two squares, sparse sets). Former axioms s_eq_s_alt, six_perfect, twentyeight_perfect, forward_fails, erdos_1973_empty_preimage, two_untouchable, five_untouchable, pollack_primes, troupe_many_factors, troupe_two_squares, s_bound now proved as theorems or definitions.",
+    "assumptions": "2 axiom declarations: ppt_bound (Pollack-Pomerance-Thompson 2018: if |A cap [1,x]| <= x^{1/2+o(1)} then s^{-1}(A) has density 0), erdos_955_summary (asserts the combined partial results: primes, sums of two squares, sparse sets). NOTE: the primes case (Pollack) and sums-of-two-squares case (Troupe) are ASSERTED within the erdos_955_summary axiom, not independently proved. The only proved theorem is sparse_sets_work (a one-line corollary of the ppt_bound axiom). The remaining partial results and contrasts (perfect-number examples, forward-direction failure, untouchable numbers, Troupe many-factors, growth bound) appear only as docstring/comment prose, not as Lean declarations.",
     "lineCount": 192,
     "theoremCount": 2,
     "definitionCount": 14


### PR DESCRIPTION
## Integrity Issue

**Proof**: erdos-955 (Sum of Proper Divisors and Density)
**Problem**: Prose references declarations that do not exist in the Lean file (phantom declarations), and mislabels axiomatized results as "proved".

## Evidence

Actual declarations in `Proofs/Erdos955Problem.lean`: 14 defs, 2 axioms (`ppt_bound`, `erdos_955_summary`), 2 theorems (`sparse_sets_work`, `erdos_955`).

**meta.json claimed** (`originalContributions`):
- `pollack_primes: Result for prime set` — **no such declaration**
- `troupe_two_squares: Result for sums of squares` — **no such declaration**

**meta.json claimed** (`assumptions`): former axioms `pollack_primes`, `troupe_two_squares`, `s_eq_s_alt`, `six_perfect`, `forward_fails`, … are "now proved as theorems or definitions".

**Lean file shows**: those names do not appear at all. The primes (Pollack) and sums-of-two-squares (Troupe) cases are merely **asserted inside the `erdos_955_summary` axiom**, not proved. The only proved theorem is `sparse_sets_work`, a one-line corollary of the `ppt_bound` axiom. The remaining "partial results/contrasts" survive only as docstring/comment prose.

## Fix Applied

- Replaced the two phantom `originalContributions` entries with accurate ones (`IsSumOfTwoSquares`, the two axioms, `sparse_sets_work`, and an entry making clear `erdos_955_summary`/`erdos_955` are an axiomatized combination).
- Rewrote `assumptions` to state that the primes/two-squares cases are asserted within the axiom (not proved) and the rest are prose-only.

status/badge/sorries/axiomCount were already correct — this is prose-only.

---
Discovered during gallery integrity audit (reserve mode).