### PR TITLE
audit: erdos-717 — drop phantom declarations from prose (only 4 axioms exist)

### DIFF
--- a/src/data/proofs/erdos-717/meta.json
+++ b/src/data/proofs/erdos-717/meta.json
@@ -57,9 +57,9 @@
       "erdos717Question, erdos717QuestionUniversal definitions",
       "fox_lee_sudakov_theorem axiom: main result",
       "erdos717_answer theorem: YES answer",
-      "hadwiger_conjecture, subdivision_minor_relation, kostochka_thomason axioms",
       "erdos_717_summary theorem: combines all results",
-      "erdos_717 theorem: main result"
+      "erdos_717 theorem: main result",
+      "Documented background (comments only, not formalized): Dirac's theorem, Erdős-Fajtlowicz lower bound, Hadwiger conjecture, Kostochka-Thomason bound, Bollobás-Catlin-Erdős conjecture"
     ],
     "axiomCount": 4,
     "prerequisites": [
@@ -81,7 +81,7 @@
     "historicalContext": "**Erdős Problem #717**\n\nThis problem concerns the relationship between chromatic number and clique subdivisions.\n\n**Key History:**\n- Hajós (1961): Conjectured χ(G) ≤ σ(G)\n- Dirac (1952): Proved Hajós for χ = 4\n- Catlin (1974): Disproved Hajós for χ ≥ 7\n- Erdős-Fajtlowicz (1981): Strong disproof - χ/σ can be Ω(√n/log n)\n- Fox-Lee-Sudakov (2013): Proved χ/σ is O(√n/log n)\n\n**The Setting:**\nσ(G) is the max k such that G contains a subdivision of K_k. The Erdős-Fajtlowicz lower bound was obtained by analysing the random graph G(n, 1/2): with high probability its chromatic number is Θ(n/log n) while its subdivision number is only Θ(√n/log n), giving ratio Θ(√n/log n). The Fox-Lee-Sudakov upper bound matched this extremal case, thereby resolving Erdős's question and showing that random graphs are the extremal examples for the chromatic-to-subdivision ratio.",
     "problemStatement": "**Problem Statement (Solved)**\n\nIs there a constant C such that for all graphs G on n vertices:\nχ(G) ≤ C · (n^{1/2} / log n) · σ(G)?\n\n**Answer: YES**\n\nFox, Lee, and Sudakov (2013) proved this upper bound, matching the Erdős-Fajtlowicz lower bound.\n\n**Key insight:** The ratio χ(G)/σ(G) is Θ(√n/log n) for typical graphs.",
     "text": "Is χ(G) ≤ C · (n^{1/2}/log n) · σ(G) for all n-vertex graphs? YES - Fox, Lee, Sudakov (2013) proved this tight bound matching the Erdős-Fajtlowicz lower bound.",
-    "proofStrategy": "**Formalization Approach**\n\n1. **Chromatic Number:** chromaticNumber G (axiomatized)\n\n2. **Subdivision Number:** σ(G) = max k with K_k subdivision\n\n3. **Key Results:**\n   - dirac_theorem: Hajós holds for χ = 4\n   - catlin_counterexamples: Hajós fails for χ ≥ 7\n   - erdos_fajtlowicz_lower_bound: χ ≥ c · (√n/log n) · σ\n   - fox_lee_sudakov_theorem: χ ≤ C · (√n/log n) · σ\n\n4. **Main Question:** erdos717QuestionUniversal",
+    "proofStrategy": "**Formalization Approach**\n\n1. **Chromatic Number:** chromaticNumber G (axiomatized)\n\n2. **Subdivision Number:** σ(G) = max k with K_k subdivision (axiomatized)\n\n3. **Formalized axioms/theorems:**\n   - catlin_counterexamples (axiom): Hajós fails for χ ≥ 7\n   - fox_lee_sudakov_theorem (axiom): χ ≤ C · (√n/log n) · σ\n   - erdos717_answer (theorem): := fox_lee_sudakov_theorem\n\n   Dirac's theorem (χ = 4 case) and the Erdős-Fajtlowicz lower bound appear as documented background comments only — they are not formalized declarations.\n\n4. **Main Question:** erdos717QuestionUniversal (definition)",
     "keyInsights": [
       "**Hajós Conjecture:** χ ≤ σ is FALSE for k ≥ 7",
       "**Dirac:** Hajós holds for 4-chromatic graphs",
@@ -121,18 +121,18 @@
     {
       "id": "hajos-conjecture",
       "title": "Hajós Conjecture",
-      "summary": "hajosConjecture, dirac_theorem, catlin_counterexamples",
+      "summary": "hajosConjecture (def), catlin_counterexamples (axiom); Dirac's χ=4 case in comments",
       "startLine": 113,
       "endLine": 144,
-      "mathContext": "Verified: hajosConjecture, dirac_theorem, catlin_counterexamples"
+      "mathContext": "hajosConjecture (def), catlin_counterexamples (axiom); Dirac's theorem documented as a comment, not formalized"
     },
     {
       "id": "erdos-fajtlowicz",
       "title": "Erdős-Fajtlowicz Strong Disproof",
-      "summary": "randomGraph, erdos_fajtlowicz_lower_bound",
+      "summary": "Erdős-Fajtlowicz lower bound (documented in comments; no declarations in this section)",
       "startLine": 145,
       "endLine": 173,
-      "mathContext": "Bound: randomGraph, erdos_fajtlowicz_lower_bound"
+      "mathContext": "Narrative only: the random-graph model and Erdős-Fajtlowicz lower bound are documented as comments, not formalized declarations"
     },
     {
       "id": "main-question",
@@ -145,33 +145,33 @@
     {
       "id": "fox-lee-sudakov",
       "title": "Fox-Lee-Sudakov Theorem",
-      "summary": "fox_lee_sudakov_theorem, erdos717_answer",
+      "summary": "fox_lee_sudakov_theorem (axiom), erdos717_answer (theorem)",
       "startLine": 202,
       "endLine": 223,
-      "mathContext": "Verified: fox_lee_sudakov_theorem, erdos717_answer"
+      "mathContext": "fox_lee_sudakov_theorem (axiom); erdos717_answer (theorem) := fox_lee_sudakov_theorem"
     },
     {
       "id": "tight-bound",
       "title": "Tight Bound",
-      "summary": "tight_bound axiom",
+      "summary": "Tight Θ(√n/log n) asymptotic (documented in comments; no declaration in this section)",
       "startLine": 224,
       "endLine": 239
     },
     {
       "id": "related-results",
       "title": "Related Results",
-      "summary": "hadwiger_conjecture, subdivision_minor_relation, kostochka_thomason",
+      "summary": "Hadwiger conjecture, subdivision-vs-minor relation, Kostochka-Thomason bound (documented in comments)",
       "startLine": 240,
       "endLine": 273,
-      "mathContext": "Mathematical content: hadwiger_conjecture, subdivision_minor_relation, kostochka_thomason"
+      "mathContext": "Narrative only: Hadwiger conjecture, subdivision-vs-minor relation, and Kostochka-Thomason bound are documented as comments, not formalized declarations"
     },
     {
       "id": "clique-minor",
       "title": "Clique Minor Conjecture",
-      "summary": "bollobas_catlin_erdos_conjecture, subdivision_from_minor",
+      "summary": "Bollobás-Catlin-Erdős conjecture, minor-implies-subdivision (documented in comments)",
       "startLine": 274,
       "endLine": 289,
-      "mathContext": "Mathematical content: bollobas_catlin_erdos_conjecture, subdivision_from_minor"
+      "mathContext": "Narrative only: the Bollobás-Catlin-Erdős conjecture and minor-implies-subdivision result are documented as comments, not formalized declarations"
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Gallery Integrity Fix

**Proof**: erdos-717 (Chromatic Number and Clique Subdivisions)

**Problem**: Counts are accurate (4 axioms, 6 defs, 3 theorems — all verified against `Erdos717Problem.lean`), but the prose referenced **9 names that exist only as comment blocks**, not as Lean declarations.

## Evidence

`grep -E '^\s*(axiom|def|theorem|lemma)\s+<name>'` finds NONE of these as declarations — they appear only inside `/- ... -/` narrative comments:

`dirac_theorem`, `erdos_fajtlowicz_lower_bound`, `randomGraph`, `tight_bound`, `hadwiger_conjecture`, `subdivision_minor_relation`, `kostochka_thomason`, `bollobas_catlin_erdos_conjecture`, `subdivision_from_minor`

Where they were overstated:
- **originalContributions**: listed `hadwiger_conjecture, subdivision_minor_relation, kostochka_thomason` as **"axioms"** — if real, `axiomCount` would be 7, not 4.
- **proofStrategy**: listed `dirac_theorem` and `erdos_fajtlowicz_lower_bound` under "Key Results".
- **sections**: `hajos-conjecture`/`erdos-fajtlowicz`/`tight-bound`/`related-results`/`clique-minor` summaries+mathContexts named phantom decls, some under "Verified:" labels.

## Fix

Reworded contributions / proofStrategy / section summaries to describe this material as **documented background comments, not formalized declarations**. No count or badge change — the 4 real axioms (`chromaticNumber`, `subdivisionNumber`, `catlin_counterexamples`, `fox_lee_sudakov_theorem`) and 3 theorems are unchanged.

Prior 3 re-serve audits marked this "clean" (counts matched); this pass verifies prose against actual declarations.

---
Discovered during gallery integrity audit (reserve mode; queue drained, uncontested target).