### PR TITLE
audit: erdos-705 — drop phantom Chilakamarri axiom from prose (only 3 axioms exist)

### DIFF
--- a/src/data/proofs/erdos-705/meta.json
+++ b/src/data/proofs/erdos-705/meta.json
@@ -62,7 +62,7 @@
     "historicalContext": "Erdős Problem #705 was posed by Erdős in 1981 (p. 27 of the source). It asks whether forbidding short cycles in unit distance graphs forces the chromatic number down to at most 3. This sits at the intersection of graph theory and combinatorial geometry, closely related to the famous Hadwiger-Nelson problem about the chromatic number of the plane.\n\nThe key constructions are: the Moser spindle (1961, 7 vertices, girth 3, χ = 4), O'Donnell's graph (1994, 56 vertices, girth 4, χ = 4), Chilakamarri's graph (1995, 47 vertices, girth 4, χ = 4), and Wormald's graph (1979, 6448 vertices, girth 5, χ = 4). These show that avoiding short cycles up to length 4 does not force 3-colorability. The frontier is girth 6: no 4-chromatic unit distance graph with girth ≥ 6 is known.\n\nA crucial contrast: for abstract graphs (without geometric constraints), Erdős proved in 1959 that graphs with arbitrarily large girth AND chromatic number exist, using the probabilistic method. But unit distance graphs are constrained by Euclidean geometry. Problem #705 asks whether this geometric constraint eventually forces χ ≤ 3 when short cycles are excluded.",
     "problemStatement": "Let $G$ be a finite unit distance graph in $\\mathbb{R}^2$.\n\nIs there some $k$ such that if $G$ has girth $\\geq k$, then $\\chi(G) \\leq 3$?\n\n**Known:** $k > 5$ if it exists, since Wormald constructed a 4-chromatic unit distance graph with girth 5.\n\n**Status:** OPEN",
     "text": "Is there some k such that every finite unit distance graph in the plane with girth at least k has chromatic number at most 3? Known: 4-chromatic UDGs exist with girth up to 5 (Wormald, 6448 vertices). Open for girth 6+.",
-    "proofStrategy": "The formalization proceeds in ten parts:\n\n1. **Unit distance graphs:** Define adjacency (distance = 1) and the unit distance graph on point sets in ℝ².\n\n2. **Graph parameters:** Axiomatize chromatic number and girth.\n\n3. **Known constructions:** Axiomatize the Moser spindle, O'Donnell, Wormald, and Chilakamarri graphs with their properties.\n\n4. **The conjecture:** Define erdos_705_conjecture and its negation.\n\n5. **Consequences:** Derive girth-specific results from the construction axioms.\n\n6. **Context:** Connect to the Hadwiger-Nelson problem and Erdős's 1959 result on abstract graphs.",
+    "proofStrategy": "The formalization proceeds in ten parts:\n\n1. **Unit distance graphs:** Define adjacency (distance = 1) and the unit distance graph on point sets in ℝ².\n\n2. **Graph parameters:** Axiomatize chromatic number and girth.\n\n3. **Known constructions:** Axiomatize the Moser spindle, O'Donnell, and Wormald graphs with their properties (3 axioms). The Chilakamarri graph is noted in a docstring for context but is not axiomatized.\n\n4. **The conjecture:** Define erdos_705_conjecture and its negation.\n\n5. **Consequences:** Derive girth-specific results from the construction axioms.\n\n6. **Context:** Connect to the Hadwiger-Nelson problem and Erdős's 1959 result on abstract graphs.",
     "keyInsights": [
       "**Geometry vs. Combinatorics:** Abstract graphs have high girth + high χ (Erdős 1959), but unit distance graphs may not — geometry constrains coloring.",
       "**Girth Frontier at 6:** 4-chromatic UDGs exist at girth 3, 4, and 5, but NO girth-6 example is known.",
@@ -95,10 +95,10 @@
     {
       "id": "constructions",
       "title": "Known 4-Chromatic Constructions",
-      "summary": "Moser spindle, O'Donnell, Wormald, Chilakamarri axioms",
+      "summary": "Moser spindle, O'Donnell, Wormald axioms (3 axioms); Chilakamarri noted in prose only",
       "startLine": 109,
       "endLine": 152,
-      "mathContext": "Axiomatized: Moser spindle, O'Donnell, Wormald, Chilakamarri axioms"
+      "mathContext": "Axiomatized: Moser spindle, O'Donnell, Wormald (3 axioms). The Chilakamarri graph is mentioned in a docstring for context but is not axiomatized."
     },
     {
       "id": "conjecture",


### PR DESCRIPTION
## Integrity Issue

**Proof**: erdos-705 (Unit Distance Graphs with Large Girth)
**Problem**: Gallery meta prose claims a **Chilakamarri axiom** that does not exist in the Lean source.

## Evidence

**meta.json claimed** (2 places):
- `sections[constructions].summary` / `.mathContext`: "Axiomatized: Moser spindle, O'Donnell, Wormald, **Chilakamarri axioms**"
- `overview.proofStrategy` part 3: "Axiomatize the Moser spindle, O'Donnell, Wormald, **and Chilakamarri graphs** with their properties."

**Lean file (`Proofs/Erdos705Problem.lean`) shows** exactly 3 axioms:
- `moser_spindle_exists` (line 123)
- `odonnell_graph_exists` (line 133)
- `wormald_graph_exists` (line 144)

The Chilakamarri graph (1995, 47 vertices) appears only inside a `/- ... -/` docstring (lines 149–154) as historical context — it is **not** a declaration. `axiomCount: 3` and `originalContributions` were already correct.

## Fix

Corrected both prose spots to list the 3 real axioms and note that Chilakamarri is prose-only context. No source changes; no count changes.

## Verification (this audit)
- axioms: 3 ✓ (matches `axiomCount`)
- theorems: 10 ✓ / defs: 8 ✓ / sorries: 0 ✓
- native_decide: none ✓
- True stubs: none ✓
- All `originalContributions` declarations exist in source ✓

---
Discovered during gallery integrity audit (reserve-mode re-serve of oldest uncontested target).