### PR TITLE
Fix: platonic-solids-oq-02 annotation quotes stale Euler field form (#38611)

### DIFF
--- a/src/data/proofs/platonic-solids-oq-02/annotations.json
+++ b/src/data/proofs/platonic-solids-oq-02/annotations.json
@@ -83,7 +83,7 @@
     },
     "type": "concept",
     "title": "ArchimedeanData: V, E, F Counts with Euler Formula Verification",
-    "content": "`ArchimedeanData` stores the name, vertex type, and (V, E, F) with a field `euler : vertices - edges + faces = 2` proved by `omega`. The 13 specific instances range from the truncated tetrahedron (12V, 18E, 8F) to the truncated icosidodecahedron (120V, 180E, 62F). Notable: the snub cube (24V, 60E, 38F) and snub dodecahedron (60V, 150E, 92F) have many more edges than faces \u2014 due to the four-triangle vertex type requiring many adjacencies. The `omega` tactic trivially verifies V-E+F=2 from the numerics.",
+    "content": "`ArchimedeanData` stores the name, vertex type, and (V, E, F) with a field `euler : vertices + faces = edges + 2` proved by `omega` — the subtraction-free form of Euler's formula V−E+F=2 (stated this way because E>V for every Archimedean solid, so a naive `vertices - edges + faces = 2` would silently truncate in ℕ and become false). The 13 specific instances range from the truncated tetrahedron (12V, 18E, 8F) to the truncated icosidodecahedron (120V, 180E, 62F). Notable: the snub cube (24V, 60E, 38F) and snub dodecahedron (60V, 150E, 92F) have many more edges than faces \u2014 due to the four-triangle vertex type requiring many adjacencies. The `omega` tactic trivially verifies V-E+F=2 from the numerics.",
     "significance": "supporting",
     "relatedConcepts": [
       "ArchimedeanData structure",


### PR DESCRIPTION
## Problem

Part of the #38611 post-migration gallery re-audit. The `ann-archimedes-euler` annotation for **platonic-solids-oq-02** describes the `ArchimedeanData` structure's Euler field with the literal Lean form:

> a field `euler : vertices - edges + faces = 2` proved by `omega`

That form is **stale and unsound**. The v4.31 statement repair (per `research/migration/38611-statement-repairs-v426-to-v431.txt`) restated the field subtraction-free:

```lean
-- V - E + F = 2, stated as `V + F = E + 2` to avoid ℕ truncated subtraction
-- (E > V for every Archimedean solid, so `vertices - edges` would silently
-- truncate to 0 and make the naive `vertices - edges + faces = 2` false)
euler : vertices + faces = edges + 2
```

The old quoted form (`vertices - edges + faces = 2`) reduces to a **false** statement in ℕ for every one of the 13 solids (all have E > V — the annotation even cites the snub cube 24V/60E), so the annotation misrepresents the actual verified code.

## Fix

Minimal, single-line change: corrected the literal field quote to the actual `euler : vertices + faces = edges + 2` and noted why it is stated subtraction-free. The mathematically-correct `V−E+F=2` descriptions elsewhere in the entry are left untouched (they are standard, true math).

## Evidence

**Before:** `a field `euler : vertices - edges + faces = 2` proved by `omega``
**After:** `a field `euler : vertices + faces = edges + 2` proved by `omega` — the subtraction-free form of Euler's formula V−E+F=2 ...`

- `python3 -m json.tool` on the annotation file: JSON OK
- Matches `proofs/Proofs/PlatonicSolidsOQ02.lean:132`

Re-audit follow-on to #38611.