### PR TITLE
audit: erdos-875 — drop phantom popcount axiom from conclusion prose

### DIFF
--- a/src/data/proofs/erdos-875/meta.json
+++ b/src/data/proofs/erdos-875/meta.json
@@ -105,7 +105,7 @@
     }
   ],
   "conclusion": {
-    "summary": "The formalization captures Erdős Problem #875 on admissible sequences with three proved results (powers of 2 strictly increasing, growth lower bound a(n) ≥ n+1, partial powers-of-2 admissibility). The gap threshold and ratio-one questions remain open, with the popcount argument for full powers-of-2 admissibility axiomatized.",
+    "summary": "The formalization captures Erdős Problem #875 on admissible sequences with several fully proved results: powers of 2 are strictly increasing (pow2_strictly_increasing) and admissible (powers_of_two_admissible), the latter via the binary-uniqueness lemma pow2_subset_sum_inj — no axiom; the growth lower bound a(n) ≥ n+1 (admissible_growth_lower); the {1,2,4} small example (pow2_small_example, by native_decide); and the trivial finite-#874 bound (finite_version_connection). The gap-threshold and ratio-one questions themselves remain open — they are only stated as predicates (HasPolynomialGaps, HasRatioOne), not resolved.",
     "implications": "Understanding admissible sequences connects to Sidon set theory, the subset sum problem, additive bases, and binary coding theory. The critical exponent c₀ would quantify how efficiently the disjoint sumsets condition constrains growth.",
     "openQuestions": [
       "What is the critical exponent c₀ for polynomial gaps in admissible sequences?",


### PR DESCRIPTION
## Integrity Issue

**Proof**: erdos-875 (Admissible Sequences with Disjoint Sumsets)
**Problem**: `conclusion.summary` describes a popcount axiom that no longer exists and calls a fully-proved theorem "partial" — stale prose contradicting both the section prose and the actual Lean source.

## Evidence

**meta.json `conclusion.summary` claimed**:
> three proved results (... **partial** powers-of-2 admissibility). The gap threshold and ratio-one questions remain open, with the **popcount argument for full powers-of-2 admissibility axiomatized**.

**Lean file (`Proofs/Erdos875Problem.lean`) shows**:
- `powers_of_two_admissible : IsAdmissible (fun n => 2 ^ n)` is proved **in full**, no axiom, via the binary-uniqueness lemma `pow2_subset_sum_inj` (induction on the maximal power).
- 0 `axiom` declarations; the section prose already states the popcount axiom was **"replaced"** and the section is **"Axiom-free."**
- Five theorems are proved, not three: `pow2_strictly_increasing`, `powers_of_two_admissible`, `admissible_growth_lower`, `pow2_small_example`, `finite_version_connection`.

So the conclusion was left stale from a prior axiomatized version, understating the result and internally contradicting the section prose.

## Fix

Rewrote `conclusion.summary` to enumerate the five actually-proved theorems (noting `powers_of_two_admissible` is axiom-free via `pow2_subset_sum_inj`, and `pow2_small_example` uses `native_decide`), and to clarify that the gap-threshold / ratio-one questions remain open — they are only stated as predicates (`HasPolynomialGaps`, `HasRatioOne`), not resolved.

Counts, `status`, `badge`, and the `assumptions` disclosure (which correctly discloses the `native_decide` → `Lean.ofReduceBool` dependency) are left unchanged and accurate.

---
Discovered during gallery integrity audit (reserve-mode prose re-verification).