### PR TITLE
Enrich Burnside index-2 orbit folding: correct leanFile.imports

### DIFF
--- a/src/data/proofs/burnside-counting-oq-04/meta.json
+++ b/src/data/proofs/burnside-counting-oq-04/meta.json
@@ -153,7 +153,10 @@
   },
   "leanFile": {
     "imports": [
-      "Mathlib"
+      "Mathlib.GroupTheory.GroupAction.Quotient",
+      "Mathlib.GroupTheory.SpecificGroups.Dihedral",
+      "Mathlib.Data.Fintype.Card",
+      "Mathlib.Tactic"
     ],
     "opens": [
       "Finset",


### PR DESCRIPTION
Enrichment pass for `burnside-counting-oq-04` (quality 96, passes 0 — first pass).

## Change
Corrected `leanFile.imports` from the umbrella `["Mathlib"]` to the four specific modules the Lean source actually imports:
- `Mathlib.GroupTheory.GroupAction.Quotient`
- `Mathlib.GroupTheory.SpecificGroups.Dihedral`
- `Mathlib.Data.Fintype.Card`
- `Mathlib.Tactic`

This is a correctness fix (the field was factually wrong), not accretion.

## Assessment
The entry already meets every enrichment quality target — verified accurate against the Lean source:
- 8 annotations, each with `mathContext`, `significance`, `relatedConcepts`, `prerequisites`
- rich `historicalContext`, 4 `keyInsights` with genuine depth
- `conclusion` with summary, implications, and 2 `openQuestions`
- `sections` covering the full 157-line file with accurate line ranges
- `status: verified`, `axiomCount: 0` — confirmed accurate (no structure-encoded assumptions, no native_decide)

No accretion added; per size guardrails the entry is otherwise done.