### PR TITLE
audit: re-serve dirichlets-theorem-oq-01-oq-01 (axiomatized) — clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -7620,9 +7620,9 @@
       "result": "issues-fixed"
     },
     "dirichlets-theorem-oq-01-oq-01": {
-      "auditCount": 1,
-      "lastAudited": "2026-05-04T10:06:24Z",
-      "result": "issues-fixed",
+      "auditCount": 2,
+      "lastAudited": "2026-07-20T06:57:29Z",
+      "result": "clean",
       "issues": []
     },
     "dirichlets-theorem-oq-01-oq-01-oq-04": {


### PR DESCRIPTION
## Reserve-mode re-audit — clean

Queue drained (0 unaudited); re-served the oldest uncontested target. Previous result was `issues-fixed` (single audit); this re-verifies the fix stuck and the prose matches source.

## Verification

- **Sorries**: 0 ✓ (matches meta)
- **Axioms**: `meta.axiomCount=7` = 2 local (`linnik_bound`, `effective_linnik_no_siegel`) + 5 inherited from parent `DirichletsTheoremOQ01` (`siegel_theorem`, `grh_implies_no_siegel_zeros`, `landau_page_theorem`, `deuring_heilbronn_repulsion`, `tatuzawa_theorem` — all confirmed present). `leanFile.axiomCount=2` correctly reflects local-only.
- **Counts**: 20 theorems ✓, 1 def ✓
- **No** True-stubs, `native_decide`, or `decide`
- **No phantom declarations**: every `originalContributions` name exists in source
- **Prose honesty**: "20 theorems are consequences, not new mathematics"; `SiegelZeroExistenceQuestion := SZC ∨ ¬SZC` proved via `Classical.em`, correctly framed as a classical tautology (not overclaimed). Badge `axiom` / status `axiomatized` correct (Tier C).

Only change: `audit-tracker.json` entry bumped to `auditCount:2`, `result:clean`.

---
Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)