### PR TITLE
Fix: erdos-1054-oq-01-fnorm stale meta counts after v4.31 flip (#38611)

### DIFF
--- a/src/data/proofs/erdos-1054-oq-01-fnorm/meta.json
+++ b/src/data/proofs/erdos-1054-oq-01-fnorm/meta.json
@@ -18,8 +18,8 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 1,
-    "lineCount": 521,
-    "theoremCount": 49,
+    "lineCount": 539,
+    "theoremCount": 50,
     "assumptions": "Lean.ofReduceBool — the computational verification theorems (f_3_eq … f_32_eq, sigma_6 … sigma_120, f_ratio_sigma_*, sigma_values_representable, even/odd_representable_small, etc.) are discharged by native_decide, which trusts the Lean compiler's kernel reduction. No literal axiom declarations and no sorries; the sigma bound and structural results are otherwise proved. Partial progress on an open problem.",
     "mathlibDependencies": [
       {
@@ -110,9 +110,9 @@
       "Finset"
     ],
     "namespace": "Erdos1054OQ01",
-    "lineCount": 521,
+    "lineCount": 539,
     "axiomCount": 0,
-    "theoremCount": 49,
+    "theoremCount": 50,
     "definitionCount": 5,
     "path": "Proofs/Erdos1054OQ01.lean",
     "sorries": 0


### PR DESCRIPTION
## Problem

Part of the #38611 re-audit (stale gallery meta vs corrected v4.31 Lean). The v4.31 migration flip (#39062) edited `proofs/Proofs/Erdos1054OQ01.lean` (the `erdos-1054-oq-01-fnorm` entry) — correcting five false `computeF` numeric literals and adding `native_decide` sites per the #38611 statement-repair log — but the gallery `meta.json` counts were never resynced.

## Drift

| field | meta (before) | actual | 
|-------|------|--------|
| lineCount | 521 | 539 (`wc -l`) |
| theoremCount | 49 | 50 (`grep -cE '^\\s*(private \|protected \|@\\[...\\])*(theorem\|lemma) '`) |

Corrected in **both** the `meta.*` and `leanFile.*` count blocks.

## Not changed (already correct)
- `status: axiomatized` / `badge: axiom`
- `meta.axiomCount: 1` (discloses `Lean.ofReduceBool` from native_decide) / `leanFile.axiomCount: 0` (no literal axiom decls) — the legit meta>leanFile structure-assumption split
- `definitionCount: 5`, `sorries: 0`

Metadata-only; no Lean change. Evidence recomputed against the file at origin/main.

Refs #38611