### PR TITLE
audit: erdos-718 — drop phantom axioms/definition from prose (only 2 axioms exist)

### DIFF
--- a/src/data/proofs/erdos-718/meta.json
+++ b/src/data/proofs/erdos-718/meta.json
@@ -49,7 +49,6 @@
       "MaderConjecture definition: the Erdős-Hajnal-Mader conjecture",
       "mader_1967 axiom: exponential bound 2^{r choose 2} suffices",
       "komlos_szemeredi_1996 axiom: quadratic bound Cr²n suffices",
-      "IsKLinked definition: k-linked graphs",
       "erdos_718_solved theorem: main result"
     ],
     "axiomCount": 2,
@@ -62,7 +61,7 @@
     "historicalContext": "**Erdős Problem #718: Subdivisions of Complete Graphs**\n\nThis problem concerns forced substructures in dense graphs, a central theme in extremal graph theory.\n\n**Key History:**\n- Dirac (1960): Proved 2n-2 edges forces a K₄ subdivision; conjectured 3n-5 forces K₅\n- Mader (1967): Proved exponential bound 2^{r choose 2} · n edges suffices for Kᵣ subdivision\n- Erdős, Hajnal, and Mader: Conjectured quadratic bound Cr²n suffices\n- Komlós-Szemerédi (1996): Proved the conjecture\n- Bollobás-Thomason (1996): Independent proof, also characterized highly linked graphs\n\n**Mathematical Setting:**\nA subdivision of a graph H replaces each edge with a path. A subdivision of Kᵣ (the complete graph on r vertices) is called a topological Kᵣ. The question asks: how many edges force a topological Kᵣ?",
     "problemStatement": "**Problem Statement (Solved)**\n\nIs there some constant C > 0 such that any graph on n vertices with ≥ Cr²n edges contains a subdivision of Kᵣ?\n\n**Answer: YES**\n\nProved independently by:\n- Komlós and Szemerédi (1996): \"Topological cliques in graphs II\"\n- Bollobás and Thomason (1996): \"Highly linked graphs\"\n\nThe quadratic bound Cr²n is optimal up to the constant C.",
     "text": "Is there a constant C > 0 such that any graph on n vertices with ≥ Cr²n edges contains a subdivision of Kᵣ? Yes, proved independently by Komlós-Szemerédi and Bollobás-Thomason in 1996.",
-    "proofStrategy": "**Formalization Approach**\n\n1. **Core Definitions:**\n   - IsSubdivisionOfKr: r branch vertices with internally disjoint paths between all pairs\n   - ContainsSubdivisionOfKr: graph contains a Kᵣ subdivision as subgraph\n   - MaderConjecture: ∃ C > 0 such that Cr²n edges forces Kᵣ subdivision\n\n2. **Historical Axioms:**\n   - Dirac 1960: 2n-2 edges → K₄ subdivision\n   - Mader 1967: 2^{r(r-1)/2} · n edges → Kᵣ subdivision (exponential)\n   - Komlós-Szemerédi/Bollobás-Thomason 1996: Cr²n edges → Kᵣ subdivision (quadratic)\n\n3. **Related Results:**\n   - Highly linked graphs: Ckn edges makes a graph k-linked\n   - Minor vs subdivision: subdivision is stronger than minor\n\n4. **Main Theorem:** erdos_718_solved proves MaderConjecture is true",
+    "proofStrategy": "**Formalization Approach**\n\n1. **Core Definitions:**\n   - IsSubdivisionOfKr: r branch vertices with internally disjoint paths between all pairs\n   - ContainsSubdivisionOfKr: graph contains a Kᵣ subdivision as subgraph\n   - MaderConjecture: ∃ C > 0 such that Cr²n edges forces Kᵣ subdivision\n\n2. **Historical Results** (only Mader 1967 and Komlós-Szemerédi 1996 are axiomatized; Dirac 1960 and Bollobás-Thomason are noted in comments only):\n   - Dirac 1960: 2n-2 edges → K₄ subdivision (comment)\n   - Mader 1967: 2^{r(r-1)/2} · n edges → Kᵣ subdivision (exponential; axiom mader_1967)\n   - Komlós-Szemerédi 1996: Cr²n edges → Kᵣ subdivision (quadratic; axiom komlos_szemeredi_1996)\n   - Bollobás-Thomason 1996: independent proof (comment)\n\n3. **Related Results:**\n   - Highly linked graphs: Ckn edges makes a graph k-linked\n   - Minor vs subdivision: subdivision is stronger than minor\n\n4. **Main Theorem:** erdos_718_solved proves MaderConjecture is true",
     "keyInsights": [
       "**Quadratic Growth:** The edge bound Cr²n is quadratic in r, vastly improving the exponential 2^{r choose 2} bound",
       "**Two Independent Proofs:** Both Komlós-Szemerédi and Bollobás-Thomason found proofs in the same year using different methods",
@@ -111,18 +110,18 @@
     {
       "id": "historical-results",
       "title": "Historical Results",
-      "summary": "Axioms for Dirac 1960 and Mader 1967",
+      "summary": "mader_1967 axiom (exponential bound); Dirac 1960 noted in comments only",
       "startLine": 70,
       "endLine": 87,
-      "mathContext": "Axiomatized: Axioms for Dirac 1960 and Mader 1967"
+      "mathContext": "Axiomatized: mader_1967 (exponential bound); Dirac 1960 is comment-only prose"
     },
     {
       "id": "solution-1996",
       "title": "The Solution (1996)",
-      "summary": "Axioms for Komlós-Szemerédi and Bollobás-Thomason proofs",
+      "summary": "komlos_szemeredi_1996 axiom; Bollobás-Thomason noted in comments only",
       "startLine": 88,
       "endLine": 99,
-      "mathContext": "Verified: Axioms for Komlós-Szemerédi and Bollobás-Thomason proofs"
+      "mathContext": "Axiomatized: komlos_szemeredi_1996; Bollobás-Thomason is comment-only prose"
     },
     {
       "id": "specific-bounds",
@@ -135,18 +134,18 @@
     {
       "id": "related-results",
       "title": "Related Results",
-      "summary": "k-linked graphs (axiomatized) and dense graph linkedness",
+      "summary": "k-linked graphs and dense graph linkedness (documented in comments, not formalized)",
       "startLine": 115,
       "endLine": 134,
-      "mathContext": "Axiomatized: k-linked graphs (axiomatized) and dense graph linkedness"
+      "mathContext": "k-linked graphs and dense graph linkedness are comment-only prose, not declarations"
     },
     {
       "id": "minors-subdivisions",
       "title": "Minors vs Subdivisions",
-      "summary": "Axiomatized minor relationship and subdivision-implies-minor",
+      "summary": "Minor relationship and subdivision-implies-minor (documented in comments, not formalized)",
       "startLine": 135,
       "endLine": 148,
-      "mathContext": "Axiomatized: Axiomatized minor relationship and subdivision-implies-minor"
+      "mathContext": "Minor relationship and subdivision-implies-minor are comment-only prose, not declarations"
     },
     {
       "id": "main-results",


### PR DESCRIPTION
## Gallery Integrity Audit — erdos-718

**Result:** counts accurate, prose overstated. Fixed in this PR.

### Verified against `proofs/Proofs/Erdos718Problem.lean`
- axioms: **2** (`mader_1967`, `komlos_szemeredi_1996`) — matches `axiomCount: 2` ✓
- theorems: **4** — matches `theoremCount: 4` ✓
- defs: **5** — matches `definitionCount: 5` ✓
- sorries: **0** ✓ · no True stubs · no `native_decide` ✓

### Phantom prose corrected (declarations that do not exist in the file)
1. `originalContributions` listed **"IsKLinked definition"** — no such declaration; `k-linked` appears only in comment prose (lines 111, 114).
2. Section `historical-results`: "**Axioms** for Dirac 1960 and Mader 1967" — Dirac 1960 is comment-only (line 73); only `mader_1967` is an axiom.
3. Section `solution-1996`: "**Axioms** for Komlós-Szemerédi and Bollobás-Thomason" — Bollobás-Thomason is comment-only (line 90); only `komlos_szemeredi_1996` is an axiom.
4. Section `related-results`: "k-linked graphs (**axiomatized**)" — comment-only (lines 114–116), no declaration.
5. Section `minors-subdivisions`: "**Axiomatized** minor relationship and subdivision-implies-minor" — comment-only (lines 124–126).
6. `proofStrategy` listed Dirac 1960 & Bollobás-Thomason under "Historical Axioms" — reworded to distinguish the 2 real axioms from comment-only history.

No trust-surface change (axiom count was already correct); this is a prose-accuracy fix so the public description matches what the Lean file actually declares.

---
Discovered during gallery integrity re-audit (reserve mode).