### PR TITLE
Fix: erdos-731 remove vacuous True-stub lower_bound_most_n (#39344)

### DIFF
--- a/proofs/Proofs/Erdos731Problem.lean
+++ b/proofs/Proofs/Erdos731Problem.lean
@@ -127,12 +127,6 @@ theorem least_nondiv_counterexample : ¬Nat.Prime 4 ∧ centralBinom 2 = 6 := by
 
 /- ## Bounds -/
 
-/-- Lower bound: for any P, there exists a density threshold.
-    Placeholder: the actual density claim requires measure theory. -/
-theorem lower_bound_most_n :
-    ∀ (P : ℕ), ∃ (D : ℕ), D > 0 ∧ True :=
-  fun _ => ⟨1, by omega, trivial⟩
-
 /-- C(N, k) divides lcm(1, ..., N) for k ≤ N.
     Proof: For each prime p, v_p(C(N,k)) ≤ log_p(N) = v_p(lcm(1,...,N)).
     The key steps are:

--- a/src/data/proofs/erdos-731/annotations.json
+++ b/src/data/proofs/erdos-731/annotations.json
@@ -272,28 +272,6 @@
     ]
   },
   {
-    "id": "erdos-731-lower-most",
-    "proofId": "erdos-731",
-    "type": "concept",
-    "range": {
-      "startLine": 94,
-      "endLine": 101
-    },
-    "title": "Lower Bound for Most n",
-    "content": "Axiomatizes `lower_bound_most_n`: for any threshold $P$, there is a positive density $D$ such that for at least a $(1 - 1/D)$ fraction of $n \\leq N$, the least non-divisor exceeds $P$. This captures the fact that small primes almost always divide $\\binom{2n}{n}$: for fixed $p$, the set of $n$ with $p \\nmid \\binom{2n}{n}$ has density $(\\lceil p/2 \\rceil / p)^{1/(\\log p)} \\to 0$, so by union bound, the least non-divisor exceeds any fixed $P$ for almost all $n$. Uses placeholder `True`.",
-    "mathContext": "$\\forall P,\\; \\exists D > 0: \\#\\{n \\leq N : \\text{leastNonDivCentral}(n) > P\\} \\geq (1 - 1/D) \\cdot N$",
-    "significance": "supporting",
-    "relatedConcepts": [
-      "natural density",
-      "union bound",
-      "digit independence"
-    ],
-    "prerequisites": [
-      "small_primes_divide",
-      "natural density"
-    ]
-  },
-  {
     "id": "erdos-731-upper",
     "proofId": "erdos-731",
     "type": "concept",

--- a/src/data/proofs/erdos-731/meta.json
+++ b/src/data/proofs/erdos-731/meta.json
@@ -21,7 +21,7 @@
     "erdosUrl": "https://erdosproblems.com/731",
     "erdosProblemStatus": "open",
     "axiomCount": 1,
-    "lineCount": 439,
+    "lineCount": 425,
     "mathlibDependencies": [
       {
         "theorem": "Nat.choose",
@@ -41,7 +41,7 @@
     ],
     "assumptions": "1 axiom declaration: prime_divides_central_iff (Kummer's carry characterization: p | C(2n,n) iff some base-p digit of n is ≥ ⌈p/2⌉). Proved: choose_dvd_lcm (C(N,k) divides lcm(1,...,N+1), via Nat.factorization_choose_le_log), upper_bound_trivial (least non-divisor ≤ 2n+1, by contradiction using choose_dvd_lcm), two_divides_central (Pascal+symmetry), bertrand_central (Bertrand+dvd_choose_add), central_binom_lower (binomial sum+max term). Note: choose_dvd_lcm and upper_bound_trivial are NOT axioms — both are fully proved theorems in the file.",
     "mathlib_version": "4.31.0",
-    "theoremCount": 33,
+    "theoremCount": 32,
     "definitionCount": 3
   },
   "overview": {
@@ -161,9 +161,9 @@
     ],
     "opens": [],
     "namespace": null,
-    "lineCount": 439,
+    "lineCount": 425,
     "axiomCount": 1,
-    "theoremCount": 33,
+    "theoremCount": 32,
     "definitionCount": 3,
     "path": "Proofs/Erdos731Problem.lean",
     "sorries": 0


### PR DESCRIPTION
Closes #39344.

## Problem
`erdos-731` (Least Non-Divisor of Central Binomial Coefficients) counted a vacuous placeholder among its 33 public theorems:

```lean
theorem lower_bound_most_n :
    ∀ (P : ℕ), ∃ (D : ℕ), D > 0 ∧ True :=
  fun _ => ⟨1, by omega, trivial⟩
```

The payload is `True` — it establishes no lower bound, yet the name reads as the EGRS "lower bound for most n" result (keyInsights[3]).

## Fix (removal, per issue's preferred option)
- **Lean**: removed the `lower_bound_most_n` stub from `proofs/Proofs/Erdos731Problem.lean`.
- **meta.json**: `theoremCount` 33 → 32 (both `meta` and `leanFile` blocks); refreshed stale `lineCount` 439 → 425.
- **annotations.json**: dropped the `erdos-731-lower-most` annotation, which described the stub as *"Axiomatizes `lower_bound_most_n` … Uses placeholder `True`"* — the only reference to the removed decl.

The now-removed decl also resolves the issue's secondary note that the `asymptotics` prose disclosed a nonexistent commented decl while omitting this real-but-vacuous one.

## Verification
- Host-compiled the Lean file (Mathlib-only import): no errors (only pre-existing deprecation/linter warnings).
- `grep` confirmed no remaining references to `lower_bound_most_n`.
- JSON validated.

Untouched (verified accurate per issue): `axiomCount: 1` (`prime_divides_central_iff`), `sorries: 0`, status `axiomatized`/badge `axiom`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)