### PR TITLE
Research: schroeder-bernstein-oq-03 — prove partialInverse_partrec (close pilot sorry)

### DIFF
--- a/proofs/Proofs/SchroederBernsteinOQ03StatementOnly.lean
+++ b/proofs/Proofs/SchroederBernsteinOQ03StatementOnly.lean
@@ -86,27 +86,23 @@ predicate — a step many tactic searches miss.
 -/
 theorem partialInverse_partrec {g : ℕ → ℕ} (hg : Computable g) :
     Partrec (partialInverse g) := by
-  sorry
+  -- The search predicate `fun (m n : ℕ) => decide (g n = m)` is computable:
+  -- combine `g ∘ snd` and `fst` through Mathlib's `Primrec.eq` (as `Computable₂`).
+  have hpred : Computable (fun x : ℕ × ℕ => decide (g x.2 = x.1)) :=
+    Computable₂.comp Primrec.eq.decide.to_comp (hg.comp Computable.snd) Computable.fst
+  -- `Partrec.rfind` wraps `Nat.rfind` applied to a `Partrec₂` predicate; the
+  -- computable predicate above lifts to `Partrec₂` via `Computable.partrec`.
+  exact Partrec.rfind hpred.partrec
 
--- Proof attempt: a sketched chain of the expected Mathlib glue. Aristotle
--- is free to ignore this; it exists only to seed the MCTS prior (Rivin's
--- pattern from `Polya-Szego`/`StatementOnly_*.lean`).
---
--- The intended structure is:
---   1. Show the search predicate `fun mn : ℕ × ℕ => decide (g mn.2 = mn.1)`
---      is `Computable` by combining `hg` with `Computable.decide` and
---      `Computable.eq` (or the corresponding `Primrec` variants).
---   2. Lift to `Computable₂` so that for each fixed `m`, the family
---      `fun n => decide (g n = m)` is computable uniformly in `m`.
---   3. Apply `Partrec.rfind` (Mathlib's wrapper around `Nat.rfind`):
---        Partrec.rfind : Computable₂ p → Partrec (fun m => Nat.rfind (p m ·))
---      to conclude `Partrec (partialInverse g)`.
---
--- Tactic sketch:
---   refine Partrec.rfind ?_
---   exact (Primrec.eq.comp (hg.comp Computable.snd) Computable.fst).to₂.to_comp.to_decide
---
--- (Names approximated — the real Mathlib API uses
---  `Primrec₂.comp`, `Computable.decide`, and `Partrec.rfind`.)
+-- Proof recap (now discharged directly, no Aristotle round-trip needed):
+--   1. The search predicate `fun x : ℕ × ℕ => decide (g x.2 = x.1)` is
+--      `Computable`: compose Mathlib's `Primrec.eq.decide` (equality test on
+--      `ℕ`, lifted to `Computable₂` via `.to_comp`) with `g ∘ snd` and `fst`
+--      through `Computable₂.comp`.
+--   2. `Computable.partrec` lifts this to the `Partrec₂` predicate that
+--      `Partrec.rfind` consumes, yielding `Partrec (fun m => Nat.rfind …)`,
+--      which is definitionally `partialInverse g`.
+-- Verified axiom-free (`#print axioms` reports only
+-- `propext, Classical.choice, Quot.sound` — no `sorryAx`).
 
 end SchroederBernsteinOQ03Statement

--- a/src/data/research/problems/schroeder-bernstein-oq-03.json
+++ b/src/data/research/problems/schroeder-bernstein-oq-03.json
@@ -99,7 +99,8 @@
       "stageSeq is Classical.choose-noncomputable; closing myhill_isomorphism still needs a genuinely computable stage step (Primrec/Computable scheduler) — the read-off primitives mLookup_computable/fwdOrbit_computable are already in place, the scheduler is not.",
       "split_ifs prunes the outer parity if when the s%2 hypothesis is in context; collapse it with if_pos/if_neg before split_ifs to keep goal count predictable.",
       "The scheduler must carry BOTH balances (Balanced f g L and Balanced g f (L.map swap)); each atomic step must preserve BOTH. The 2x2 preservation matrix is now complete: balanced_cons_domain + balanced_swap_cons_range (domain/range step preserving un-swapped Balanced f g) and balanced_cons_range + balanced_swap_cons_domain (preserving swapped Balanced g f).",
-      "SOLVED (r14 07-03): full theorem VERIFIED 0-axiom. Last mile = replace List.findIdx escape search (no Computable.list_findIdx in Mathlib) with a Nat.rec bounded scan escScan (Computable.nat_rec-friendly). Membership-Bool computable via decide(idxOf<length); PrimrecRel needs .decide.to_comp not .to_comp."
+      "SOLVED (r14 07-03): full theorem VERIFIED 0-axiom. Last mile = replace List.findIdx escape search (no Computable.list_findIdx in Mathlib) with a Nat.rec bounded scan escScan (Computable.nat_rec-friendly). Membership-Bool computable via decide(idxOf<length); PrimrecRel needs .decide.to_comp not .to_comp.",
+      "2026-07-20 (researcher-1): Closed the last open sorry in the Aristotle-pilot SchroederBernsteinOQ03StatementOnly.lean — partialInverse_partrec (Partrec of the Nat.rfind partial inverse of a computable g). Proof is 2 lines of Mathlib glue: Computable₂.comp Primrec.eq.decide.to_comp (hg.comp Computable.snd) Computable.fst, then Partrec.rfind hpred.partrec. Host-verified (lake env lean, v4.31.0), axiom-free (#print axioms = {propext, Classical.choice, Quot.sound})."
     ],
     "mathlibGaps": [
       "Mathlib lacks Myhill isomorphism theorem (OneOneEquiv → computable permutation).",
@@ -236,7 +237,7 @@
       "theoremCount": 1,
       "axiomCount": 0,
       "defCount": 1,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/SchroederBernsteinOQ03StatementOnly.lean"
     },
@@ -286,5 +287,6 @@
     }
   ],
   "lastWorkedBy": "researcher-9",
-  "lastWorkedAt": "2026-07-02"
+  "lastWorkedAt": "2026-07-02",
+  "lastUpdate": "2026-07-20"
 }


### PR DESCRIPTION
## Summary

Closes the single `sorry` in `proofs/Proofs/SchroederBernsteinOQ03StatementOnly.lean`.

**`partialInverse_partrec`**: for a computable `g : ℕ → ℕ`, its `Nat.rfind`-based partial inverse `partialInverse g : ℕ →. ℕ` (the least `n` with `g n = m`) is `Partrec`.

This is the foundational computability lemma underlying the hard direction of **Myhill's Isomorphism Theorem** (the computable refinement of Schroeder–Bernstein). The file was an Aristotle-submission *StatementOnly* pilot; the statement is now discharged directly.

## Proof

Two lines of Mathlib computability glue:

```lean
have hpred : Computable (fun x : ℕ × ℕ => decide (g x.2 = x.1)) :=
  Computable₂.comp Primrec.eq.decide.to_comp (hg.comp Computable.snd) Computable.fst
exact Partrec.rfind hpred.partrec
```

`Primrec.eq.decide` is the decidable equality test on `ℕ` as `Primrec₂`, lifted to `Computable₂` via `.to_comp` and composed with `g ∘ snd` and `fst`; `Computable.partrec` then feeds it to `Partrec.rfind`, whose result is definitionally `partialInverse g`.

## Verification

- Host-verified with `lake env lean` (leanprover/lean4:v4.31.0) — clean elaboration, no errors/warnings.
- Axiom-free: `#print axioms partialInverse_partrec` = `{propext, Classical.choice, Quot.sound}` — no `sorryAx`, no `Lean.ofReduceBool`.

## Tracker

`src/data/research/problems/schroeder-bernstein-oq-03.json`: `SchroederBernsteinOQ03StatementOnly.lean` sorryCount 1 → 0; insight recorded. (Gallery `meta.json` for oq-03 tracks `SchroederBernsteinOQ03.lean` and is unaffected.)

Classified TRIVIAL/HARD per `research/SORRY-CLASSIFICATION.md` — proved directly rather than via an Aristotle round-trip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)