### PR TITLE
Fix: erdos-876 phantom 'axiomatized' declarations → documented prose (#39223)

### DIFF
--- a/src/data/proofs/erdos-876/annotations.json
+++ b/src/data/proofs/erdos-876/annotations.json
@@ -148,7 +148,7 @@
     },
     "type": "concept",
     "title": "Density Results: Erdős and Łuczak-Schoen",
-    "content": "Three density axioms: (1) `erdos_density_zero` (1962): $|A \\cap [1,N]|/N \\to 0$ for any sum-free $A$. (2) `luczak_schoen_upper` (2000): $|A \\cap [1,N]| \\leq c\\sqrt{N \\log N}$ for an absolute constant $c$. (3) `luczak_schoen_lower` (2000): there exists $B$ sum-free with $|B \\cap [1,N]| \\geq \\sqrt{N}/(\\log N)^{1/2+o(1)}$. Together, these show the counting function is $\\Theta(\\sqrt{N \\log N})$ up to lower-order factors.",
+    "content": "Three density results documented in source comments (prose, not Lean declarations): (1) Erdős (1962): $|A \\cap [1,N]|/N \\to 0$ for any sum-free $A$. (2) Łuczak-Schoen upper bound (2000): $|A \\cap [1,N]| \\leq c\\sqrt{N \\log N}$ for an absolute constant $c$. (3) Łuczak-Schoen lower bound (2000): there exists $B$ sum-free with $|B \\cap [1,N]| \\geq \\sqrt{N}/(\\log N)^{1/2+o(1)}$. Together, these show the counting function is $\\Theta(\\sqrt{N \\log N})$ up to lower-order factors.",
     "mathContext": "**Density zero:** $\\lim_{N \\to \\infty} |A \\cap [1,N]|/N = 0$. **Tight bounds:** $c_1 \\sqrt{N/\\log N} \\leq \\max_A |A \\cap [1,N]| \\leq c_2 \\sqrt{N \\log N}$. The formalization uses `Set.ncard` for the cardinality of possibly infinite intersections and `Real.sqrt`/`Real.log` for the bounds.",
     "significance": "key",
     "relatedConcepts": [
@@ -159,7 +159,7 @@
       "counting function"
     ],
     "prerequisites": [
-      "erdos_density_zero",
+      "sum-free density zero",
       "Set.Icc",
       "asymptotic analysis"
     ]
@@ -173,7 +173,7 @@
     },
     "type": "concept",
     "title": "Deshouillers-Erdős-Melfi Growth Rate",
-    "content": "Axiomatizes the DEM (1999) result: there exists a sum-free set with $n^{3-\\varepsilon} < a_n < n^{3+\\varepsilon}$ for all $\\varepsilon > 0$ and large $n$. The cubic exponent $3$ arises from the counting function: if $|A \\cap [1,N]| \\sim \\sqrt{N}$, then the $n$-th element satisfies $a_n \\sim n^2$. The $\\log N$ correction in Łuczak-Schoen's bound accounts for the extra factor, pushing the exponent from $2$ to $3$. The constant `cubicGrowthExponent := 3` highlights this key parameter.",
+    "content": "Documents (in source comments) the DEM (1999) result: there exists a sum-free set with $n^{3-\\varepsilon} < a_n < n^{3+\\varepsilon}$ for all $\\varepsilon > 0$ and large $n$. The cubic exponent $3$ arises from the counting function: if $|A \\cap [1,N]| \\sim \\sqrt{N}$, then the $n$-th element satisfies $a_n \\sim n^2$. The $\\log N$ correction in Łuczak-Schoen's bound accounts for the extra factor, pushing the exponent from $2$ to $3$. The constant `cubicGrowthExponent := 3` highlights this key parameter.",
     "mathContext": "$a_n = n^{3+o(1)}$: if $|A \\cap [1,N]| \\sim c\\sqrt{N\\log N}$, setting $n = c\\sqrt{N\\log N}$ gives $N \\sim n^2/\\log n$, so $a_n = N \\sim n^2/\\log n$. The extra log factor explains why the growth is closer to cubic than quadratic.",
     "significance": "key",
     "relatedConcepts": [
@@ -196,7 +196,7 @@
     },
     "type": "theorem",
     "title": "Reciprocal Sum Bounds",
-    "content": "Defines `reciprocalSum A = ∑' n, (1/n if n ∈ A and n ≥ 1, else 0)` using Lean's `tsum` for conditionally convergent series. Three axioms: `erdos_reciprocal_bound` ($\\sum 1/a < 100$, Erdős's original), `sullivan_bound` ($\\sum 1/a < 4$, the current best), and `sullivan_conjecture` ($\\exists A$ with $\\sum 1/a > 2$). The gap between 2 and 4 remains unresolved.",
+    "content": "Defines `reciprocalSum A = ∑' n, (1/n if n ∈ A and n ≥ 1, else 0)` using Lean's `tsum` for conditionally convergent series. Three results documented in source comments (prose, not Lean declarations): Erdős's original bound ($\\sum 1/a < 100$), Sullivan's current best ($\\sum 1/a < 4$), and Sullivan's conjecture ($\\exists A$ with $\\sum 1/a > 2$). The gap between 2 and 4 remains unresolved.",
     "mathContext": "$\\text{reciprocalSum}(A) = \\sum_{a \\in A,\\, a \\geq 1} \\frac{1}{a}$. **Erdős:** $< 100$. **Sullivan:** $< 4$. **Conjecture:** $\\sup_A \\text{reciprocalSum}(A) \\approx 2$. The convergence of this series is guaranteed by the density-zero property: $|A \\cap [1,N]| = o(N)$ implies $\\sum_{a \\leq N} 1/a = o(\\log N)$.",
     "significance": "key",
     "relatedConcepts": [


### PR DESCRIPTION
Closes #39223.

## Problem
`erdos-876` (Sum-Free Sets and Gap Growth) presented several results as **formalized/axiomatized declarations** that exist in `proofs/Proofs/Erdos876Problem.lean` only as `/- ... -/` comment blocks (lines 144–192, 199–226). Verified declaration list — the **only** axiom is `graham_result`; there is no `erdos_density_zero`, `luczak_schoen_upper/lower`, `dem_growth`, `erdos_reciprocal_bound`, `sullivan_bound`, or `sullivan_conjecture`.

## Fix (prose only — counts already accurate)
Reworded every phantom "axiom/axiomatizes/declaration" reference to describe **documented (commented) historical context**:

**`src/data/proofs/erdos-876/meta.json`**
- `originalContributions`: dropped the four declaration-style phantom names; kept `reciprocalSum` (a real `def`) and added one "documented in source comments (prose, not declarations)" entry covering the density/DEM/Sullivan results.
- `overview.proofStrategy` steps 4–5: "Axiomatizes …" → "Documents (in source comments) …".
- Section summaries/mathContexts (`density-results`, `growth-rate`, `reciprocal-sum`): "Axiomatizes …" → "Documents (in source comments) …".

**`src/data/proofs/erdos-876/annotations.json`**
- `ann-876-7` ("Three density axioms" + `erdos_density_zero` prerequisite), `ann-876-8` ("Axiomatizes the DEM result"), `ann-876-9` ("Three axioms: erdos_reciprocal_bound, sullivan_bound, sullivan_conjecture") reworded to documented-prose framing.

Left untouched (verified correct): `graham_result` (the real axiom, still described as axiomatized), `reciprocalSum` def, and meta counts `axiomCount: 1` / `sorries: 2` / status `axiomatized`.

## Verification
- `grep` confirms zero remaining phantom declaration names; the only surviving "Axiomatizes" refers to `graham_result`.
- JSON validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)