### PR TITLE
Fix: erdos-610 lineCount drift 222→234 (#38611 re-audit)

### DIFF
--- a/src/data/proofs/erdos-610/meta.json
+++ b/src/data/proofs/erdos-610/meta.json
@@ -88,7 +88,7 @@
       }
     ],
     "axiomCount": 2,
-    "lineCount": 222,
+    "lineCount": 234,
     "assumptions": "2 axiom(s) and 17 sorries. See the Lean source for details.",
     "theoremCount": 13,
     "definitionCount": 16,
@@ -211,7 +211,7 @@
       "SimpleGraph"
     ],
     "namespace": null,
-    "lineCount": 222,
+    "lineCount": 234,
     "axiomCount": 1,
     "theoremCount": 13,
     "definitionCount": 16,


### PR DESCRIPTION
## Problem

Part of the #38611 post-migration re-audit. The v4.31 statement repair for `Erdos610Problem` (added `[Nonempty V]` to the variable line + 6 statements — see `research/migration/38611-statement-repairs-v426-to-v431.txt` line 48) grew the single Lean source file, leaving the gallery `lineCount` stale.

## Evidence

- `wc -l proofs/Proofs/Erdos610Problem.lean` → **234**
- `meta.lineCount` and `leanFile.lineCount` recorded **222**
- No `additionalFiles`, so `lineCount` should equal the single file's line count exactly.

Other counts verified unchanged and correct: `sorries` 17=17, `leanFile.axiomCount` 1=1 axiom decl, `theoremCount` 13=13 theorem/lemma keywords. The strengthening added only hypotheses, no new declarations.

## Fix

Update both duplicated `lineCount` fields 222 → 234. Metadata-only, minimal diff (2 lines).

Re #38611 (one entry re-audited; tracking issue stays open).

🤖 Generated with [Claude Code](https://claude.com/claude-code)