### PR TITLE
audit: erdos-708 — disclose native_decide (Lean.ofReduceBool) in example

### DIFF
--- a/src/data/proofs/erdos-708/meta.json
+++ b/src/data/proofs/erdos-708/meta.json
@@ -57,7 +57,7 @@
     ],
     "axiomCount": 5,
     "lineCount": 184,
-    "assumptions": "5 axioms: g_exists, g_two, g_three, erdos_suranyi_lower, c. 0 sorries.",
+    "assumptions": "5 axioms: g_exists, g_two, g_three, erdos_suranyi_lower, c. 0 sorries. One illustrative example (line 141, setProduct {6,10} = 60) uses native_decide, adding a Lean.ofReduceBool trust dependency; no claimed result (erdos_708, erdos_708_summary) depends on it.",
     "theoremCount": 3,
     "definitionCount": 7
   },


### PR DESCRIPTION
## Integrity Audit — erdos-708

**Proof**: erdos-708 (Divisibility of Products by Consecutive Integers)
**Result**: clean on all public claims; one minor trust-disclosure gap fixed.

### Verified against `proofs/Proofs/Erdos708Problem.lean`
- axiomCount **5** ✓ — g_exists, g_two, g_three, erdos_suranyi_lower, c
- theoremCount **3** ✓ — g_three_example, erdos_708, erdos_708_summary
- definitionCount **7** ✓ — setProduct, consecutiveSet, productDivides, validSubset, g, ErdosConjecture, StrongerConjecture
- sorries **0** ✓
- No True stubs; no phantom declarations in prose; honest `axiomatized`/`axiom` framing.

### Gap
Line 141 `example : setProduct ({6, 10} : Finset ℕ) = 60 := by native_decide`
uses `native_decide`, which introduces a `Lean.ofReduceBool` trust dependency
(compiled-code trust, not kernel). It was not disclosed in `assumptions`.

### Fix
Extended the `assumptions` field to note the `native_decide` example and clarify
that no claimed result (`erdos_708`, `erdos_708_summary`) depends on it.

---
Discovered during gallery integrity audit (reserve-mode re-serve, oldest uncontested target).