### PR TITLE
Fix burnside-counting-oq-04 meta: correct leanFile.imports

### DIFF
--- a/src/data/proofs/burnside-counting-oq-04/meta.json
+++ b/src/data/proofs/burnside-counting-oq-04/meta.json
@@ -153,7 +153,10 @@
   },
   "leanFile": {
     "imports": [
-      "Mathlib"
+      "Mathlib.GroupTheory.GroupAction.Quotient",
+      "Mathlib.GroupTheory.SpecificGroups.Dihedral",
+      "Mathlib.Data.Fintype.Card",
+      "Mathlib.Tactic"
     ],
     "opens": [
       "Finset",


### PR DESCRIPTION
Enrichment/accuracy pass for `burnside-counting-oq-04`.

## Change
`leanFile.imports` claimed `["Mathlib"]`, but `proofs/Proofs/BurnsideCountingOQ04.lean` actually uses four targeted imports:
- `Mathlib.GroupTheory.GroupAction.Quotient`
- `Mathlib.GroupTheory.SpecificGroups.Dihedral`
- `Mathlib.Data.Fintype.Card`
- `Mathlib.Tactic`

The `sec-overview` section summary already listed these correctly; this fixes the `leanFile.imports` field to match the source.

## Assessment
The entry is already at quality target (9 annotations with mathContext/significance/relatedConcepts/prerequisites, full section coverage, 4 keyInsights, honest scope note, 2 openQuestions). No accretion added — this PR is a factual metadata correction only. meta.json remains ~13 KB, well under caps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)