### PR TITLE
Fix: erdos-242 gallery quotes stale wrong Erdős–Straus witnesses (#38611)

### DIFF
--- a/src/data/proofs/erdos-242/annotations.json
+++ b/src/data/proofs/erdos-242/annotations.json
@@ -163,7 +163,7 @@
     },
     "type": "concept",
     "title": "Easy Residue Classes [PROVED]",
-    "content": "Four explicit constructions handle the 'easy' cases:\n\n- **n = 0 mod 4**: 4/(4k) = 1/(2k) + 1/(3k) + 1/(6k)\n- **n = 3 mod 4**: 4/(4k+3) = 1/(k+1) + 1/(2(k+1)) + 1/(2(k+1)(4k+3))\n- **n = 2 mod 3**: 4/(3k+2) = 1/(k+1) + 1/(2(k+1)) + 1/(6(k+1)(3k+2))\n- **p = 5 mod 8**: Uses (p+3)/4 and p(p+3)/8 as denominators\n\nAll four are fully proved with no axiom dependency.",
+    "content": "Four explicit constructions handle the 'easy' cases:\n\n- **n = 0 mod 4**: 4/(4k) = 1/(2k) + 1/(3k) + 1/(6k)\n- **n = 3 mod 4**: 4/(4k+3) = 1/(k+1) + 1/(2(k+1)(4k+3)) + 1/(2(k+1)(4k+3))\n- **n = 2 mod 3**: 4/(3k+2) = 1/(3k+2) + 1/(k+1) + 1/((3k+2)(k+1))\n- **p = 5 mod 8**: Uses (p+3)/4 and p(p+3)/8 as denominators\n\nAll four are fully proved with no axiom dependency.",
     "mathContext": "Each construction is verified by field_simp and ring/ring_nf in the rational number field.",
     "significance": "key",
     "relatedConcepts": [

--- a/src/data/proofs/erdos-242/meta.json
+++ b/src/data/proofs/erdos-242/meta.json
@@ -58,9 +58,9 @@
     ],
     "externalAttribution": "Proof structure adapted from github.com/Suro-One/auro-zera_Erdos-Straus_proof",
     "axiomCount": 1,
-    "lineCount": 590,
+    "lineCount": 677,
     "assumptions": "1 axiom: dyachenko_box (Dyachenko's Theorem 9.21, arXiv:2511.07465) asserting the existence of ED2 lattice box parameters for primes p = 1 mod 4. Used only for 6 hard residue classes mod 840: {1, 121, 169, 289, 361, 529}. All other cases fully proved.",
-    "theoremCount": 50,
+    "theoremCount": 51,
     "definitionCount": 5
   },
   "overview": {
@@ -231,9 +231,9 @@
     ],
     "opens": [],
     "namespace": "Erdos242",
-    "lineCount": 590,
+    "lineCount": 677,
     "axiomCount": 1,
-    "theoremCount": 50,
+    "theoremCount": 51,
     "definitionCount": 5,
     "path": "Proofs/Erdos242Problem.lean",
     "sorries": 0
@@ -358,7 +358,7 @@
       "type": "theorem",
       "statement": "n > 0, n ≡ 3 mod 4 ⟹ ES n",
       "significance": "Handles the residue class n ≡ 3 mod 4 with a uniform explicit construction, one of the elementary families that reduce the conjecture to the genuinely hard primes p ≡ 1 mod 4.",
-      "description": "Writes n = 4k+3 and gives the closed-form solution (k+1, 2(k+1), 2(k+1)(4k+3))."
+      "description": "Writes n = 4k+3 and gives the closed-form solution (k+1, 2(k+1)(4k+3), 2(k+1)(4k+3)), i.e. 4/(4k+3) = 1/(k+1) + 1/(2(k+1)(4k+3)) + 1/(2(k+1)(4k+3))."
     },
     {
       "name": "hard_residues_norm_split",


### PR DESCRIPTION
## Problem

The v4.31 statement-repair pass (#38611) corrected three mathematically-**false** witness tuples in `Erdos242Problem.lean`, but the gallery prose still described the old, wrong constructions — so the gallery presents unit-fraction "solutions" that do not sum to `4/n`.

## Findings (verified against current source)

**ES_for_mod3_mod4** (`n ≡ 3 mod 4`) — quoted in `meta.json` mainTheorems and the annotations "Easy Residue Classes" box:
- Stale: `(k+1, 2(k+1), 2(k+1)(4k+3))` → `1/(k+1) + 1/(2(k+1)) + 1/(2(k+1)(4k+3)) = (6k+5)/((k+1)(4k+3)) ≠ 4/n`
- Source (`Erdos242Problem.lean:421`): `⟨k+1, 2*(k+1)*(4*k+3), 2*(k+1)*(4*k+3)⟩` → `1/(k+1) + 2·1/(2(k+1)(4k+3)) = 4(k+1)/((k+1)(4k+3)) = 4/(4k+3)` ✓

**ES_for_mod2_mod3** (`n ≡ 2 mod 3`) — quoted in the annotations box:
- Stale: `1/(k+1) + 1/(2(k+1)) + 1/(6(k+1)(3k+2))`
- Source (`Erdos242Problem.lean:434`): `⟨3*k+2, k+1, (3*k+2)*(k+1)⟩` → `1/(3k+2) + 1/(k+1) + 1/((3k+2)(k+1)) = 4/(3k+2)` ✓

The source docstring (lines 426–431) itself documents that the old witnesses were "mathematically WRONG ... papered over by a non-closing `ring_nf`."

## Also: count reconciliation after the repair
- `lineCount` 590 → 677 (`wc -l`), both meta.meta and leanFile blocks
- `theoremCount` 50 → 51 (48 theorem + 3 lemma)
- `definitionCount` 5 (4 def + 1 structure) and `axiomCount` 1 unchanged; `status: axiomatized` correct

## Scope
Metadata/annotation only — no Lean source change (source is already correct). Part of #38611 re-audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)