### PR TITLE
Fix: eqr-oq-03-oq-02-oq-03 stale lineCount 404→427 + section ranges (#38611)

### DIFF
--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-03-oq-02-oq-03/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-03-oq-02-oq-03/meta.json
@@ -14,7 +14,7 @@
       "jacobiSym"
     ],
     "namespace": "KroneckerSymbol",
-    "lineCount": 404,
+    "lineCount": 427,
     "axiomCount": 1,
     "sorries": 0,
     "definitionCount": 1,
@@ -101,7 +101,7 @@
       "Does the Kronecker QR generalize to the Hilbert symbol over global fields via the product formula? Mathlib formalization of the Hilbert symbol over ℚ would unify all Eisenstein-style supplementary laws.",
       "What is the minimal set of additional axioms — beyond Mathlib's Jacobi QR — sufficient to discharge `kronecker_qr_even_fundamental` constructively?"
     ],
-    "lineCount": 404,
+    "lineCount": 427,
     "theoremCount": 25,
     "definitionCount": 1
   },
@@ -159,14 +159,14 @@
       "id": "numerical-verifications",
       "title": "Part IV — Numerical Verifications",
       "startLine": 322,
-      "endLine": 371,
+      "endLine": 395,
       "summary": "Eleven numerical checks via `native_decide` and direct application of the proved cases: confirmations of (5/3)=(3/5)=-1, (5/7)=(7/5), (5/11)=(11/5), (5/13)=(13/5), (13/17)=(17/13) [all symmetry cases], (3/7)=-(7/3) [sign flip], and the headline `kronecker_neg7_neg3_vals` showing (-7/3)=-1 ≠ 1=(-3/7), which numerically refutes the historically common naïve statement of unconditional equality."
     },
     {
       "id": "summary-theorem",
       "title": "Part V — Complete Summary (kronecker_qr_all_cases)",
-      "startLine": 372,
-      "endLine": 403,
+      "startLine": 396,
+      "endLine": 427,
       "summary": "`kronecker_qr_all_cases` bundles the three QR statements (symmetry for ≡1(4), sign flip for ≡3(4), general fundamental-discriminant law) into a single conjunction. Closing docstring records the Dirichlet-character / Artin-reciprocity interpretation: (D/·)_K is the unique real primitive character of conductor |D|, odd iff D < 0, and quadratic Artin reciprocity asserts χ_D₁(D₂) = χ_D₂(D₁)."
     }
   ],


### PR DESCRIPTION
## Summary

Gallery metadata re-audit for `elementary-quadratic-reciprocity-oq-03-oq-02-oq-03`, flagged by the #38611 statement-repair log (line 10, marked *HIGH-PRIORITY gallery re-audit*).

During the v4.26→v4.31 migration this file was corrected: `kronecker_3_7_vals` had asserted **swapped** Kronecker values that the old `native_decide` certified false, and the both-negative sign-flip theorems (`kronecker_neg7_neg3_vals`, `kronecker_neg7_neg3_sign`) were added to demonstrate the ε sign correction. The source grew **404 → 427 lines**.

The meta's *content* (description, mainTheorems, assumptions, annotations) was already updated to the corrected sign-correction statement, but the structural line fields were left stale.

## Changes (meta.json only)

| Field | Before | After |
|-------|--------|-------|
| `leanFile.lineCount` | 404 | 427 |
| `meta.lineCount` | 404 | 427 |
| section `numerical-verifications` endLine | 371 | 395 |
| section `summary-theorem` startLine / endLine | 372 / 403 | 396 / 427 |

## Evidence

- `wc -l proofs/Proofs/ElementaryQuadraticReciprocityOQ03OQ02OQ03.lean` → **427** (canonical lineCount)
- Part V "Complete Summary" banner begins at L396; `end KroneckerSymbol` at L427.
- Unchanged counts verified against source: `axiomCount` 1 (`kronecker_qr_even_fundamental` L274), `sorries` 0, `theoremCount` 25, `definitionCount` 1 — all already accurate.
- JSON validated with `jq`.

Content and status (`axiomatized`/`axiom` badge) already correct — no change needed there. Inline annotation prose line-number references remain approximate (out of scope; cosmetic).

Part of #38611.