### PR TITLE
Fix: erdos-549 gallery quotes stale false Burr-Erdős value (2|T|-1 → |T|)

### DIFF
--- a/src/data/proofs/erdos-549/annotations.json
+++ b/src/data/proofs/erdos-549/annotations.json
@@ -305,8 +305,8 @@
     },
     "type": "concept",
     "title": "Related Classical Results",
-    "content": "**chvatal_harary** (sorry): $R(T) \\leq 2n - 2$ for any tree on $n$ vertices — the universal upper bound. **star_ramsey** (sorry): $R(S_n) = 2n - 1$. **path_ramsey** (sorry): $R(P_n) = n$ for $n \\geq 2$. **tree_burr_erdos** (proved): The Burr-Erdős formula $(\\chi - 1)(|H| - 1) + 1$ specialized to trees ($\\chi = 2$) gives $2|T| - 1$. These classical results contextualize problem #549: Erdős sought a refinement of these bounds for the specific $(k, 2k)$ bipartition class.",
-    "mathContext": "chvatal_harary : RamseyNumber T ≤ 2 * |V| - 2\nstar_ramsey : RamseyNumber (starGraph n) = 2*n - 1\npath_ramsey : RamseyNumber (pathGraph n) = n\ntree_burr_erdos : burrErdosFormula T 2 = 2*|V| - 1 (proved)",
+    "content": "**chvatal_harary** (sorry): $R(T) \\leq 2n - 2$ for any tree on $n$ vertices — the universal upper bound. **star_ramsey** (sorry): $R(S_n) = 2n - 1$. **path_ramsey** (sorry): $R(P_n) = n$ for $n \\geq 2$. **tree_burr_erdos** (proved): The Burr-Erdős formula $(\\chi - 1)(|H| - 1) + 1$ specialized to trees ($\\chi = 2$) gives $|T|$. These classical results contextualize problem #549: Erdős sought a refinement of these bounds for the specific $(k, 2k)$ bipartition class.",
+    "mathContext": "chvatal_harary : RamseyNumber T ≤ 2 * |V| - 2\nstar_ramsey : RamseyNumber (starGraph n) = 2*n - 1\npath_ramsey : RamseyNumber (pathGraph n) = n\ntree_burr_erdos : burrErdosFormula T 2 = |V| (proved)",
     "significance": "key",
     "prerequisites": [
       "RamseyNumber",

--- a/src/data/proofs/erdos-549/meta.json
+++ b/src/data/proofs/erdos-549/meta.json
@@ -169,7 +169,7 @@
       "summary": "States chvatal_harary (R(T) <= 2n-2), star_ramsey (R(S_n) = 2n-1), path_ramsey (R(P_n) = n). Defines burrErdosFormula and proves tree_burr_erdos.",
       "startLine": 197,
       "endLine": 248,
-      "mathContext": "Chvátal-Harary: $R(T) \\leq 2n - 2$. $R(S_n) = 2n - 1$. $R(P_n) = n$. Burr-Erdős: $R(T) = (\\chi(T) - 1)(|T| - 1) + 1 = 2|T| - 1$ for trees (proved)."
+      "mathContext": "Chvátal-Harary: $R(T) \\leq 2n - 2$. $R(S_n) = 2n - 1$. $R(P_n) = n$. Burr-Erdős: $R(T) = (\\chi(T) - 1)(|T| - 1) + 1 = |T|$ for trees (proved)."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Problem (#38611 re-audit)

The v4.31 statement repair (`research/migration/38611-statement-repairs-v426-to-v431.txt`) corrected `tree_burr_erdos` in `Erdos549Problem.lean`. The Burr-Erdős formula `burrErdosFormula H χ = (χ-1)(|V|-1)+1` specialized to trees (χ=2) evaluates to **|T| = Fintype.card V**, not `2|T|-1`. The Lean docstring (lines 232-233) now explicitly states the old `2|T|-1` claim is *false* for `card V ≥ 2` (e.g. 3-vertex tree gives 3, not 5), and the proved theorem is:

```lean
theorem tree_burr_erdos ... : burrErdosFormula T 2 = Fintype.card V
```

But the gallery still quoted the disproven `2|T|-1` in three places.

## Fix (metadata only)

| Location | Before | After |
|---|---|---|
| `annotations.json` content | "...gives $2|T| - 1$" | "...gives $|T|$" |
| `annotations.json` mathContext | `burrErdosFormula T 2 = 2*|V| - 1` | `burrErdosFormula T 2 = |V|` |
| `meta.json` section mathContext | `...+ 1 = 2|T| - 1$ for trees` | `...+ 1 = |T|$ for trees` |

Now consistent with the proved Lean statement. `(χ-1)(|T|-1)+1` at χ=2 = |T| arithmetically. JSON validated.

Closes #38611 partial (erdos-549 entry only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)