### PR TITLE
Fix: erdos-1097 assumptions asserts false 1.778 > 1.77898 (#38611 re-audit)

### DIFF
--- a/src/data/proofs/erdos-1097/meta.json
+++ b/src/data/proofs/erdos-1097/meta.json
@@ -22,7 +22,7 @@
     "erdosProblemStatus": "open",
     "mathlib_version": "4.31.0",
     "axiomCount": 3,
-    "assumptions": "3 axiom declarations: katz_tao_upper (O(n^{11/6}) upper bound, Katz-Tao 1999), lemm_lower (Ω(n^{1.778}) best known lower bound, Lemm 2015), chan_equivalence (equivalence to Bourgain sums-differences problem, Chan). Three former axioms now proved as theorems from lemm_lower: erdos_spencer_lower (c > 1.778 > 3/2), erdos_ruzsa_explicit (c' = c-1), alphaevolve_improvement (1.778 > 1.77898).",
+    "assumptions": "3 axiom declarations: katz_tao_upper (O(n^{11/6}) upper bound, Katz-Tao 1999), lemm_lower (Ω(n^{1.778}) best known lower bound, Lemm 2015), chan_equivalence (equivalence to Bourgain sums-differences problem, Chan). Three former axioms now proved as theorems from lemm_lower: erdos_spencer_lower (c > 1.778 > 3/2), erdos_ruzsa_explicit (c' = c-1), alphaevolve_improvement (c > 1.77898, implied by lemm_lower).",
     "lineCount": 390,
     "relatedProblems": [
       {


### PR DESCRIPTION
## Problem

Gallery re-audit of a #38611 statement-repaired entry. `Erdos1097Problem.lean`
was corrected during the v4.26→v4.31 migration: the `alphaevolve_improvement`
result had derived `∃ c > 1.77898` from `∃ c > 1.778` via `linarith` — a false
step, since `1.778 < 1.77898` (a decimal-literal artifact the old elaborator
accepted). The fix strengthened `lemm_lower` to `∃ c, c > 1.77898` and now
proves `alphaevolve_improvement` from it.

The gallery `meta.json` `assumptions` field still carried the pre-repair
artifact:

> `alphaevolve_improvement (1.778 > 1.77898)`

which literally states the **false** inequality `1.778 > 1.77898`.

## Fix

Metadata-only. Corrected the parenthetical to match the repaired Lean
statement (`Erdos1097Problem.lean:353-358`, `lemm_lower` at `:318-321`):

```
- alphaevolve_improvement (1.778 > 1.77898).
+ alphaevolve_improvement (c > 1.77898, implied by lemm_lower).
```

The annotations text (`annotations.json:322`, "from `c > 1.778` to
`c > 1.77898`") was already correct and is untouched. Counts unchanged
(`axiomCount=3`, `sorries=0`) — they already match the Lean file.

## Evidence

- Lean: `lemm_lower : ∃ c, c > 1.77898 ∧ …`; `alphaevolve_improvement` proved
  via `obtain ⟨c, hc, h⟩ := lemm_lower; exact ⟨c, by linarith, h⟩`.
- JSON validated with `jq -e .`.

Part of #38611 gallery re-audit.