### PR TITLE
Fix: erdos-1054-oq-01-fnorm stale f(32) value in gallery prose (#38611)

### DIFF
--- a/src/data/proofs/erdos-1054-oq-01-fnorm/annotations.json
+++ b/src/data/proofs/erdos-1054-oq-01-fnorm/annotations.json
@@ -100,8 +100,8 @@
     },
     "type": "concept",
     "title": "Computational Verification of f(n) Values via native_decide",
-    "content": "These theorems use `native_decide` to verify specific values of `computeF`. The pattern reveals interesting behavior: for n = p+1 with p prime, f(n) is typically near p but can be much smaller (e.g., f(12) = 6, not 11, because 12 is the last partial sum of divisors of 6). `f_bounded_50` checks that f(n) ≤ 2n for all representable n ≤ 20. The `native_decide` tactic compiles the decision procedure to native code for fast evaluation of these finitely-checkable propositions.",
-    "mathContext": "f(12) = 6 \\text{ (not 11) because } \\text{partialDivisorSums}(6) = [1,3,6,12] \\text{ and } 12 \\in [1,3,6,12]. \\text{ But } f(32) = 31 = p \\text{ exactly, since div}(31) = \\{1,31\\}.",
+    "content": "These theorems use `native_decide` to verify specific values of `computeF`. The pattern reveals interesting behavior: for n = p+1 with p prime, f(n) is typically near p but can be much smaller (e.g., f(12) = 6, not 11, because 12 is the last partial sum of divisors of 6). `f_bounded_50` checks that f(n) ≤ 2n for all representable n ≤ 20 except n = 19 (which is excluded because f(19) = 42 > 2·19 = 38). The `native_decide` tactic compiles the decision procedure to native code for fast evaluation of these finitely-checkable propositions.",
+    "mathContext": "f(12) = 6 \\text{ (not 11) because } \\text{partialDivisorSums}(6) = [1,3,6,12] \\text{ and } 12 \\in [1,3,6,12]. \\text{ But } f(32) = 21 \\text{ (not 31), since partialDivisorSums}(21) = [1,4,11,32] \\text{ (div}(21) = \\{1,3,7,21\\}, \\ 1{+}3{+}7{+}21 = 32) \\text{ gives the smaller witness } m = 21 < 31.",
     "significance": "supporting",
     "relatedConcepts": [
       "native_decide tactic",

--- a/src/data/proofs/erdos-1054-oq-01-fnorm/meta.json
+++ b/src/data/proofs/erdos-1054-oq-01-fnorm/meta.json
@@ -61,7 +61,7 @@
       "startLine": 116,
       "endLine": 214,
       "summary": "f values for n=3,4,6,8,12,...,32 via native_decide. f_bounded_50: all representable n ≤ 20 have f(n) ≤ 2n. even_representable_small, odd_representable_small. Formal definition of almost_all_little_o encoding the open conjecture.",
-      "mathContext": "$f(3)=2, f(4)=3, f(6)=5, \\ldots, f(32)=31$ verified computationally. Open: $\\forall \\varepsilon > 0$, density of $\\{n : f(n) \\geq \\varepsilon n\\}$ is 0."
+      "mathContext": "$f(3)=2, f(4)=3, f(6)=5, \\ldots, f(32)=21$ verified computationally. Open: $\\forall \\varepsilon > 0$, density of $\\{n : f(n) \\geq \\varepsilon n\\}$ is 0."
     },
     {
       "id": "sigma-infra",


### PR DESCRIPTION
## Problem

The #38611 v4.26→v4.31 statement-repair corrected a false old-toolchain literal in `proofs/Proofs/Erdos1054OQ01.lean`: the old `decide` claimed `computeF 32 100 = 31`, but the true minimal witness is **21** (Lean line 141: `f(32) = 21 ≤ 31 ✓ (better witness exists)`; `f_32_eq : computeF 32 100 = 21`).

The gallery prose for `erdos-1054-oq-01-fnorm` still quoted the **stale** value and an incorrect explanation:
- `meta.json` mathContext: `f(32)=31`
- `annotations.json` mathContext: `f(32) = 31 = p exactly, since div(31) = {1,31}`

This presents a value the Lean source no longer proves (stale-witness integrity class per #38611).

## Fix (metadata only, minimal)

- **meta.json:64** — `f(32)=31` → `f(32)=21`
- **annotations.json** mathContext — replace the `f(32)=31=p` reasoning with the correct minimal witness: `partialDivisorSums(21) = [1,4,11,32]` (div(21)={1,3,7,21}, 1+3+7+21=32), so m=21 < 31.
- **annotations.json** content — `f_bounded_50` excludes n=19, so `all representable n ≤ 20` is corrected to note the exclusion (f(19)=42 > 2·19=38), matching the Lean Finset `{1,3,4,6,7,8,9,10,11,12,13,14,15,16,17,18,20}`.

## Evidence

```
Lean (Erdos1054OQ01.lean:129-141):
  f_16_eq : computeF 16 100 = 12
  f_20_eq : computeF 20 100 = 19
  f_24_eq : computeF 24 100 = 14
  f_30_eq : computeF 30 100 = 29
  f_32_eq : computeF 32 100 = 21   -- gallery said 31
  -- p=31: f(32) = 21 ≤ 31 ✓ (better witness exists)
```

JSON validated. Distinct from PR #39400 (which fixes fnorm meta *counts* only — no line overlap).

Refs #38611