### PR TITLE
Fix: erdos-712 drop false 'no rational value' axiom masking openness

### DIFF
--- a/proofs/Proofs/Erdos712Problem.lean
+++ b/proofs/Proofs/Erdos712Problem.lean
@@ -134,35 +134,35 @@ axiom kruskal_katona_upper (r k : ℕ) (hr : r ≥ 2) (hk : k > r) :
 -/
 
 /-- **Erdős Problem #712:** Determine the Turán density π_r(K_k^r)
-    for all k > r > 2 as an explicit (preferably rational) value. -/
+    for all k > r > 2 as an explicit (preferably rational) value. This is
+    the *goal* of the problem, stated as a proposition; it is neither
+    asserted nor refuted here. -/
 def erdos_712_problem (r k : ℕ) (hr : r > 2) (hk : k > r) : Prop :=
   ∃ explicit : ℚ, turanDensity r k = explicit
 
-/-- The problem is unsolved for all k > r > 2 -/
-axiom erdos_712_open (r k : ℕ) (hr : r > 2) (hk : k > r) :
-  ¬∃ explicit : ℚ, turanDensity r k = explicit
+/-- Erdős Problem #712: The main statement.
 
-/-- Erdős Problem #712: The main statement -/
+    The Turán density exists and is bounded strictly inside `(0, 1)` (via
+    positivity and the Kruskal-Katona upper bound). The *exact* value is
+    unknown for every `k > r > 2` — but that openness is **epistemic** and is
+    deliberately NOT encoded as a theorem. Encoding it as `¬∃ q : ℚ,
+    turanDensity r k = q` would assert the strictly stronger, unproven, and
+    almost-certainly-false claim that the density is irrational, contradicting
+    the file's own conjectures `turanDensity 3 4 = 5/9` and `π_3(K_5^3) = 3/4`
+    (both rational). We therefore prove only what is genuinely true. -/
 theorem erdos_712 (r k : ℕ) (hr : r > 2) (hk : k > r) :
-    -- The Turán density exists and has nice bounds
-    (∃ π : ℝ, turanDensity r k = π ∧ 0 < π ∧ π < 1) ∧
-    -- But the exact value is unknown
-    (¬∃ explicit : ℚ, turanDensity r k = explicit) := by
-  constructor
-  · use turanDensity r k
-    constructor
-    · rfl
-    constructor
-    · exact turan_density_positive r k (by omega) hk
-    · -- Use Kruskal-Katona bound: π ≤ 1 - 1/k < 1 for k > 1
-      have hkk := kruskal_katona_upper r k (by omega) hk
-      have hk_pos : (0 : ℝ) < k := by
-        have : 0 < k := by omega
-        exact_mod_cast this
-      have h_one_div_k_pos : (0 : ℝ) < 1 / k := by positivity
-      calc turanDensity r k ≤ 1 - 1 / k := hkk
-        _ < 1 := by linarith
-  · exact erdos_712_open r k hr hk
+    ∃ π : ℝ, turanDensity r k = π ∧ 0 < π ∧ π < 1 := by
+  use turanDensity r k
+  refine ⟨rfl, ?_, ?_⟩
+  · exact turan_density_positive r k (by omega) hk
+  · -- Use Kruskal-Katona bound: π ≤ 1 - 1/k < 1 for k > 1
+    have hkk := kruskal_katona_upper r k (by omega) hk
+    have hk_pos : (0 : ℝ) < k := by
+      have : 0 < k := by omega
+      exact_mod_cast this
+    have h_one_div_k_pos : (0 : ℝ) < 1 / k := by positivity
+    calc turanDensity r k ≤ 1 - 1 / k := hkk
+      _ < 1 := by linarith
 
 /-
 ## Part VIII: Related Conjectures
@@ -208,10 +208,8 @@ Prize: $500 for any case, $1000 for full solution -/
 theorem erdos_712_summary :
     -- Turán solved the graph case (r = 2)
     (∀ k ≥ 2, turanDensity 2 k = turanGraphDensity k) ∧
-    -- Hypergraph case (r > 2) is open for all k > r
-    (∀ r k, r > 2 → k > r → ¬∃ explicit : ℚ, turanDensity r k = explicit) ∧
     -- Turán's K_4^3 conjecture: lower bound 5/9
     (turanDensity 3 4 ≥ 5 / 9) := by
-  exact ⟨fun k hk => turan_theorem k hk, erdos_712_open, K43_lower_bound⟩
+  exact ⟨fun k hk => turan_theorem k hk, K43_lower_bound⟩
 
 end Erdos712

--- a/src/data/proofs/erdos-712/meta.json
+++ b/src/data/proofs/erdos-712/meta.json
@@ -54,12 +54,12 @@
       "turanDensity: asymptotic density π_r(K_k^r)",
       "turan_theorem axiom: graph case solved",
       "K43_lower_bound axiom: 5/9 lower bound",
-      "erdos_712 theorem: density exists with 0 < π < 1 but value unknown",
+      "erdos_712 theorem: Turán density exists and is bounded in (0, 1) via positivity + Kruskal-Katona; the exact value stays open as prose, not encoded as a theorem",
       "erdos_712_summary theorem: combining all results"
     ],
-    "axiomCount": 5,
-    "lineCount": 218,
-    "assumptions": "5 axioms: turan_theorem, K43_lower_bound, turan_density_positive, kruskal_katona_upper, erdos_712_open. See Lean source for complete statements.",
+    "axiomCount": 4,
+    "lineCount": 215,
+    "assumptions": "4 axioms: turan_theorem, K43_lower_bound, turan_density_positive, kruskal_katona_upper. See Lean source for complete statements.",
     "theoremCount": 2,
     "definitionCount": 11
   },
@@ -132,10 +132,10 @@
     {
       "id": "general-problem",
       "title": "The General Problem Statement",
-      "summary": "erdos_712_problem, erdos_712_open, erdos_712 theorem with full proof",
+      "summary": "erdos_712_problem, erdos_712 theorem with full proof",
       "startLine": 167,
-      "endLine": 202,
-      "mathContext": "Erdős Problem #712: determine $\\pi_r(K_k^r)$ as an explicit (preferably rational) value for all $k > r > 2$. The `erdos_712` theorem proves the density exists in $(0, 1)$ using positivity and Kruskal-Katona, but axiomatizes that no rational value is known. Prize: \\$500 for any single case, \\$1000 for the general solution."
+      "endLine": 199,
+      "mathContext": "Erdős Problem #712: determine $\\pi_r(K_k^r)$ as an explicit (preferably rational) value for all $k > r > 2$, captured by the proposition `erdos_712_problem`. The `erdos_712` theorem proves the density exists in $(0, 1)$ using positivity and Kruskal-Katona. The exact value being unknown is epistemic and is stated only as prose — it is deliberately NOT encoded as a theorem, since `¬∃ q : ℚ, turanDensity r k = q` would assert the stronger, unproven, and likely-false irrationality claim, contradicting the conjectures $\\pi_3(K_4^3) = 5/9$ and $\\pi_3(K_5^3) = 3/4$. Prize: \\$500 for any single case, \\$1000 for the general solution."
     },
     {
       "id": "conjectures",
@@ -169,8 +169,8 @@
       "Finset"
     ],
     "namespace": "Erdos712",
-    "lineCount": 218,
-    "axiomCount": 5,
+    "lineCount": 215,
+    "axiomCount": 4,
     "theoremCount": 2,
     "definitionCount": 11,
     "path": "Proofs/Erdos712Problem.lean",


### PR DESCRIPTION
## Summary

Closes #39421.

The axiom `erdos_712_open` mis-formalized Erdős #712's *open status* as the strictly stronger, unproven, and almost-certainly-**false** proposition that the Turán density equals **no** rational number (`¬∃ q : ℚ, turanDensity r k = q` — i.e. the density is irrational). This directly contradicts the file's own conjectures:
- `turanConjectureK43 = 5/9` with `K43_lower_bound : turanDensity 3 4 ≥ 5/9` (rational)
- Mubayi's `π_3(K_5^3) = 3/4` (rational)

If the conjectured value were ever added as an axiom, the axiom set would be **inconsistent** with `erdos_712_open`. "Unknown" (epistemic) ≠ "provably has no rational value" (a false mathematical claim).

## Fix (minimal, per issue's preferred Lean-source remedy)

- **Remove** the `erdos_712_open` axiom and the `¬∃ rational` conjunct from `erdos_712` and from `erdos_712_summary`.
- `erdos_712` now proves only the genuinely-true, bounded result: `∃ π : ℝ, turanDensity r k = π ∧ 0 < π ∧ π < 1` (via `turan_density_positive` + `kruskal_katona_upper`).
- The problem's openness is documented as **prose/docstring**, not as a theorem/axiom.

## Meta updates
- `axiomCount` 5 → 4 (both `meta` and `leanFile`); dropped `erdos_712_open` from `assumptions`.
- `lineCount` 218 → 215.
- Reworded the `originalContributions` entry and the `general-problem` section `mathContext` (no longer claims 'axiomatizes that no rational value is known').

## Verification
- Host-verified: `lake env lean Erdos712Problem.lean` → **EXIT=0** (only pre-existing unused-variable warnings on the untouched `erdos_712_problem` def).
- Remaining 4 axioms: `turan_theorem`, `K43_lower_bound`, `turan_density_positive`, `kruskal_katona_upper` — all legitimate stated assumptions.
- gallery data steps (search index, enrichment) pass `pnpm build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)