### PR TITLE
audit: erdos-701 — drop phantom 'axiomatized' prose (0 axioms exist)

### DIFF
--- a/src/data/proofs/erdos-701/meta.json
+++ b/src/data/proofs/erdos-701/meta.json
@@ -38,7 +38,7 @@
     "historicalContext": "Chvátal's conjecture (1974) generalizes the Erdős-Ko-Rado theorem to hereditary families. The conjecture asserts that the maximum intersecting subfamily is always a 'star' - all sets containing a fixed element. Despite nearly 50 years of research, the general case remains open. Partial results exist for injection-based orderings (Chvátal 1974), Sterboul conditions (1974), covering number 2 (Frankl-Kupavskii 2023), and weighted versions (Borg 2011). The Erdős-Ko-Rado theorem itself (1961) established that for uniform k-element families on an n-element set with n ≥ 2k, the maximum intersecting family has size C(n-1, k-1) and is achieved by a star; Chvátal's conjecture aims to extend this star-maximality to the much broader setting of hereditary families, where sets of varying sizes are allowed. The conjecture has been verified for several structured classes including families with covering number at most 2 and families arising from matroids.",
     "problemStatement": "Let F be a family of sets closed under taking subsets (hereditary). There exists an element x such that for any intersecting subfamily F' ⊆ F: |F'| ≤ |{A ∈ F : x ∈ A}|.",
     "text": "Let F be a hereditary family. There exists x such that every intersecting subfamily F' has |F'| ≤ |{A ∈ F : x ∈ A}|. Status: OPEN with partial results.",
-    "proofStrategy": "The formalization defines hereditary families, intersecting families, and stars. The main conjecture is axiomatized as open. Partial results (Sterboul conditions, covering number 2) are stated as separate axioms. The connection to Erdős-Ko-Rado is explored, showing how uniform families are NOT hereditary (explaining why EKR is not a direct special case).",
+    "proofStrategy": "The formalization defines hereditary families, intersecting families, and stars. The main conjecture is stated as a definition (ChvatalConjecture : Prop) recording its logical form; it is neither proved nor axiomatized — the file contains 0 axioms. Partial results are represented as predicate definitions only: Sterboul's conditions (SterboulConditions) and Borg's weighted version (WeightedChvatalConjecture) are stated as Props, while Chvátal's 1974 ordering result and Frankl-Kupavskii's covering-number-2 result appear only as prose comments, not as formal statements. The connection to Erdős-Ko-Rado is explored via the proved theorem uniform_not_hereditary, showing how uniform families are NOT hereditary (explaining why EKR is not a direct special case).",
     "keyInsights": [
       "Hereditary = closed under subsets (also called downsets or ideals)",
       "Stars (sets containing x) are always intersecting subfamilies",
@@ -80,8 +80,8 @@
       "id": "conjecture",
       "startLine": 130,
       "endLine": 151,
-      "summary": "Statement of Chvátal's conjecture as a definition and axiom recording its open status.",
-      "title": "Statement of Chvátal's conjecture as a definition and axiom recording its open status."
+      "summary": "Statement of Chvátal's conjecture as a definition (Prop); its open status is noted in a comment. No axiom is declared.",
+      "title": "Statement of Chvátal's conjecture as a definition (Prop); its open status is noted in a comment. No axiom is declared."
     },
     {
       "id": "partial",


### PR DESCRIPTION
## Integrity Issue

**Proof**: erdos-701 (Chvátal's Conjecture on Intersecting Families)
**Problem**: Phantom-axiom overstatement — prose claims axioms that do not exist.

## Evidence

`proofs/Proofs/Erdos701Problem.lean` contains **0 axioms** (verified: no `axiom` declarations; `meta.axiomCount:0` and `leanFile.axiomCount:0` are already correct). Declarations are 8 `def`s + 7 `theorem`s (matches `theoremCount:7`, `definitionCount:8`), 0 sorries.

**meta.json claimed** (`overview.proofStrategy`):
> "The main conjecture is axiomatized as open. Partial results (Sterboul conditions, covering number 2) are stated as separate axioms."

**Lean file shows**:
- `ChvatalConjecture` is a `def : Prop` (line 139) — stated, not axiomatized.
- `SterboulConditions` (174) and `WeightedChvatalConjecture` (196) are predicate `def`s (Props), not axioms or proved theorems.
- Chvátal-1974 and Frankl-Kupavskii (covering number 2) appear **only as prose comments** (lines 160-165, 187-190), not as any formal statement.
- Line 143-146 is a comment ("This axiom records that Chvátal's conjecture is unresolved") but **no axiom is declared** there.

The `conjecture` section summary/title likewise claimed "a definition **and axiom** recording its open status."

## Fix

Corrected `overview.proofStrategy` and the `conjecture` section summary/title to describe the actual declarations (definitions/predicates; 0 axioms). Counts unchanged. `badge:wip` / `status:axiomatized` and the existing #39061 non-verification retraction in `assumptions` are left intact.

---
Discovered during gallery integrity re-audit (reserve mode: queue drained, re-serving oldest uncontested targets).