### PR TITLE
audit: erdos-694 — drop phantom Erdős-conditional axiomatization from prose

### DIFF
--- a/src/data/proofs/erdos-694/meta.json
+++ b/src/data/proofs/erdos-694/meta.json
@@ -37,9 +37,9 @@
     ],
     "originalContributions": [
       "Clean Lean 4 formalization of totient preimages",
-      "Definitions of f_max and f_min functions",
+      "Axiomatized f_max and f_min extremal preimage functions",
       "Formalization of Carmichael's Totient Conjecture",
-      "Axiomatization of Erdős's conditional infinitude result",
+      "Prose documentation of Erdős's conditional infinitude result (not formalized)",
       "Proved theorems: one_not_carmichael, two_not_carmichael",
       "Concrete examples of totient computations"
     ],


### PR DESCRIPTION
## Integrity Issue

**Proof**: erdos-694 (Preimages of Euler's Totient Function)
**Problem**: `originalContributions` claims a formalization that does not exist in the Lean source.

## Evidence

**meta.json claimed**:
- "Axiomatization of Erdős's conditional infinitude result"
- "Definitions of f_max and f_min functions"

**Lean file (`Proofs/Erdos694Problem.lean`) shows**:
- Only **2 axioms exist**: `f_max` (line 49) and `f_min` (line 52) — consistent with the `assumptions` field ("2 axioms: f_max, f_min").
- Erdős's conditional infinitude result appears **only as a prose comment** (lines 87–101), never as an `axiom`/`theorem` declaration.
- `f_max`/`f_min` are `axiom` declarations, not `def`s.

## Fix

- "Axiomatization of Erdős's conditional infinitude result" → "Prose documentation of Erdős's conditional infinitude result (not formalized)"
- "Definitions of f_max and f_min functions" → "Axiomatized f_max and f_min extremal preimage functions"

## Verified accurate (no change)

2 axioms, 5 theorems, 7 defs, 0 sorries, 171 lines. No True stubs, no `native_decide`. Badge `axiom` / status `axiomatized` correct.

---
Discovered during gallery integrity audit (reserve mode, oldest uncontested target).