### PR TITLE
audit: erdos-696 — drop phantom h_le_omega theorem + logStar-stub overclaim from prose

### DIFF
--- a/src/data/proofs/erdos-696/meta.json
+++ b/src/data/proofs/erdos-696/meta.json
@@ -44,15 +44,15 @@
       "IsPrimeChain definition: chains p₁ < ... < pₗ with pᵢ₊₁ ≡ 1 (mod pᵢ)",
       "IsDivisorChain definition: same for divisors",
       "h and H definitions as suprema of chain lengths",
-      "logStar definition: iterated logarithm",
-      "ErdosNormalOrderConjecture: h(n) ~ log*(n)",
-      "ErdosRatioConjecture: H(n)/h(n) → ∞",
-      "SophieGermainPrime and Cunningham chain connections",
-      "h_le_omega theorem: trivial upper bound"
+      "logStar: placeholder stub (defined as the constant 0, `fun _ => 0`); the iterated logarithm is described only, not formalized",
+      "ErdosNormalOrderConjecture: Prop stating h(n) ~ log*(n) (relative to the logStar stub; unproved conjecture statement)",
+      "ErdosRatioConjecture: Prop stating H(n)/h(n) → ∞ (unproved conjecture statement)",
+      "SophieGermainPrime and IsCunninghamChain definitions",
+      "prime_chain_is_divisor_chain theorem: every prime chain is a divisor chain"
     ],
     "axiomCount": 2,
-    "lineCount": 310,
-    "assumptions": "2 axioms: h_le_H (h(n) ≤ H(n) for all n), h_tends_to_infinity (h(n) → ∞ almost surely, van Doorn). 0 sorries.",
+    "lineCount": 306,
+    "assumptions": "2 axioms: h_le_H (h(n) ≤ H(n) for all n), h_tends_to_infinity (h(n) → ∞ almost surely, van Doorn). 0 sorries. Note: logStar is a placeholder stub (constant 0), so ErdosNormalOrderConjecture is only a statement relative to that stub, not a formalization of the iterated logarithm. The h(n) ≤ ω(n) upper bound is described in comments only, not formalized as a theorem.",
     "theoremCount": 3,
     "definitionCount": 9
   },


### PR DESCRIPTION
## Gallery Integrity Audit — erdos-696

**Proof**: erdos-696 (Chains of Prime Divisors with Congruence Conditions)
**Status/badge**: axiomatized / axiom (unchanged — honest about scaffold nature)

Prose-vs-code overstatements found in `originalContributions`; the declaration counts themselves were all accurate.

### Findings

1. **Phantom theorem.** `originalContributions` listed `"h_le_omega theorem: trivial upper bound"`, but **no `h_le_omega` theorem exists** in `Proofs/Erdos696Problem.lean`. The h(n) ≤ ω(n) bound appears only as a plain comment (lines 231–234). The file's actual theorems are `prime_chain_is_divisor_chain`, `erdos_696_status`, `erdos_696_summary`.

2. **Stub described as real formalization.** `logStar` is defined as the constant-zero placeholder:
   ```lean
   noncomputable def logStar : ℕ → ℕ := fun _ => 0 -- Axiomatized via properties below
   ```
   (no "properties below" axioms actually exist). But `originalContributions` called it `"logStar definition: iterated logarithm"`, and the counts/prose treated it as a genuine iterated-log formalization. Because `ErdosNormalOrderConjecture` references `logStar`, that Prop is only a statement relative to the stub.

3. **lineCount drift.** meta claimed 310; actual file is 306.

### Verified accurate (no change)
- axiomCount = 2 (`h_le_H`, `h_tends_to_infinity`) ✓
- theoremCount = 3 ✓, definitionCount = 9 ✓, sorries = 0 ✓
- No `native_decide`, no `True` stubs.

### Fix
Reworded the three overstated `originalContributions` bullets to match the source, disclosed the `logStar` stub in `assumptions`, and corrected `lineCount`.

---
Discovered during gallery integrity audit (reserve mode; highest-priority uncontested target).