### PR TITLE
audit: erdos-699 — disclose native_decide (Lean.ofReduceBool) trust dependency

### DIFF
--- a/src/data/proofs/erdos-699/meta.json
+++ b/src/data/proofs/erdos-699/meta.json
@@ -56,7 +56,7 @@
     ],
     "axiomCount": 1,
     "lineCount": 219,
-    "assumptions": "1 axiom(s). No sorries.",
+    "assumptions": "1 axiom (sylvester_schur). 0 sorries. The concrete computations and the (28,5,14) counterexample are proved by native_decide (choose_*, gcd_choose_*, factor_1080, the divisibility steps of example_6_2_3 / example_10_2_5 / example_28_5_14_weak, and the h_gcd step of counterexample_28_5_14_strong), adding a Lean.ofReduceBool compiled-code trust dependency beyond the stated axiom; the abstract results max_prime_1080_is_5 and choose_formula are kernel-checked.",
     "theoremCount": 17,
     "definitionCount": 4
   },


### PR DESCRIPTION
## Integrity Issue

**Proof**: erdos-699 (Erdős #699 — prime divisors of GCDs of binomial coefficients)
**Problem**: `assumptions` hides a `Lean.ofReduceBool` trust dependency ("0 sorries with hidden imports" failure mode).

## Evidence

**meta.json claimed**: `"assumptions": "1 axiom(s). No sorries."`

**Lean file shows**: `native_decide` in **15** places. Several back *claimed* contributions, not just illustrative examples:
- `originalContributions` lists "Verified GCD computations: gcd(C(6,2),C(6,3))=5, gcd(C(10,2),C(10,5))=9" → `gcd_choose_6_2_3`, `gcd_choose_10_2_5` are `by native_decide` (lines 113, 135).
- `originalContributions` lists "Critical counterexample: gcd(C(28,5),C(28,14))=1080" → `gcd_choose_28_5_14` (line 161) and the `h_gcd` step of `counterexample_28_5_14_strong` (line 201) are `by native_decide`.

`native_decide` shifts trust from the kernel to compiled code, adding a hidden `Lean.ofReduceBool` axiom beyond the one stated axiom (`sylvester_schur`).

## Verified clean (no other overstatement)

- axiomCount=1, theoremCount=17, definitionCount=4, sorries=0 — all match source.
- No True stubs; every `originalContributions` entry maps to a real declaration.
- status/badge = `axiomatized`/`axiom` (no "verified" overclaim).

## Fix applied

Amend `assumptions` to disclose the `Lean.ofReduceBool` dependency and separate the native_decide-backed results from the kernel-checked ones (`max_prime_1080_is_5`, `choose_formula`).

---
Discovered during gallery integrity audit (reserve-mode re-serve of oldest uncontested target).