### PR TITLE
audit: erdos-675 — drop phantom 'stated as separate axioms' prose (only 1 axiom exists)

### DIFF
--- a/src/data/proofs/erdos-675/meta.json
+++ b/src/data/proofs/erdos-675/meta.json
@@ -21,7 +21,7 @@
     "erdosUrl": "https://erdosproblems.com/675",
     "erdosProblemStatus": "open",
     "axiomCount": 1,
-    "lineCount": 134,
+    "lineCount": 135,
     "assumptions": "1 axiom: brun_sieve_translation (Brun's sieve — deep sieve theory). 3 open conjectures converted from axioms to defs. squarefree_translation proved from Brun's sieve via prime-squares B-free set.",
     "mathlib_version": "4.31.0",
     "theoremCount": 4,
@@ -31,7 +31,7 @@
     "historicalContext": "Erdős introduced the translation property in the 1970s as a measure of 'quasi-periodicity' for number-theoretic sets. A set A ⊆ ℕ has this property if every finite initial pattern of A reappears at some translate—weaker than periodicity but capturing a form of self-similarity. The key tool is Brun's sieve (1920), which establishes the property for B-free sets (integers avoiding divisibility by elements of B) when B is pairwise coprime with convergent reciprocal sum. This immediately gives the translation property for squarefree numbers (B = {p² : p prime}, where Σ 1/p² < ∞). Problem 675 asks three deeper questions: (1) Do sums of two squares have the property? This is non-trivial because sums of two squares have density C/√(log x) by the Landau-Ramanujan theorem and are defined by an exponent-parity condition (primes p ≡ 3 mod 4 must divide to even power), not a non-divisibility condition, so Brun's sieve does not directly apply. (2) For balanced partitions P ∪ Q of primes, can P-smooth numbers have the property? This connects to multiplicative number theory and Dickman's function. (3) For squarefree numbers, must the minimal translation t_n grow at least as exp(n^c)? The CRT gives an upper bound t_n ≤ e^{O(n)}, and the question is whether a matching lower bound holds, quantifying the local non-periodicity of the squarefree pattern.",
     "problemStatement": "Three questions: (1) Does the set of sums of two squares have the translation property? (2) For balanced partitions of primes, can integers with prime factors from one part have this property? (3) For squarefree numbers, does the minimal translation t_n grow at least exponentially, i.e., t_n > exp(n^c)?",
     "text": "Does the set of sums of two squares have the translation property? For squarefree numbers, how fast does the minimal translation grow? Brun's sieve establishes the property for squarefree numbers.",
-    "proofStrategy": "The formalization defines HasTranslationProperty as ∀ n, ∃ t ≥ 1, ∀ a ∈ [1,n], (a ∈ A ↔ a+t ∈ A), and minTranslation via Nat.find. Number-theoretic sets (sumOfTwoSquares, squarefreeSet, bFreeSet) are defined as Set ℕ predicates. The sieve conditions (IsPairwiseCoprime, HasSmallReciprocalSum) and the CRT-based result (brun_sieve_translation) are axiomatized. The three parts of Problem 675 are stated as separate axioms. The HasSmallReciprocalSum condition uses a True placeholder for the asymptotic bound, a pragmatic simplification.",
+    "proofStrategy": "The formalization defines HasTranslationProperty as ∀ n, ∃ t ≥ 1, ∀ a ∈ [1,n], (a ∈ A ↔ a+t ∈ A), and minTranslation via sInf. Number-theoretic sets (sumOfTwoSquares, squarefreeSet, bFreeSet) are defined as Set ℕ predicates, and the sieve conditions (IsPairwiseCoprime, HasSmallReciprocalSum) as Prop-valued definitions. Only the CRT-based result (brun_sieve_translation) is axiomatized; the squarefree special case (squarefree_translation) is then proved from it via the prime-squares B-free characterization. The three parts of Problem 675 are stated as unproved `def` Props (open, not axiomatized). The HasSmallReciprocalSum condition uses a True placeholder for the asymptotic bound, a pragmatic simplification.",
     "keyInsights": [
       "**CRT-based translation**: For B-free sets with pairwise coprime B, the Chinese Remainder Theorem constructs translations t_n ≤ lcm(b₁,...,b_k) by choosing k moduli with product > n",
       "**Sums of two squares are not B-free**: The characterization via even exponents of primes p ≡ 3 mod 4 is fundamentally different from non-divisibility, so Brun's sieve approach fails",
@@ -83,8 +83,8 @@
       "title": "Known Results (Brun's Sieve)",
       "startLine": 62,
       "endLine": 74,
-      "summary": "Axiomatizes the CRT-based translation for B-free sets and the squarefree special case.",
-      "mathContext": "Axiomatized: Axiomatizes the CRT-based translation for B-free sets and the squarefree special case."
+      "summary": "Axiomatizes the CRT-based translation for B-free sets (brun_sieve_translation); the squarefree special case is proved from it as a theorem, not axiomatized.",
+      "mathContext": "Axiomatized: the CRT-based translation for B-free sets (brun_sieve_translation). The squarefree special case (squarefree_translation) is a proved theorem, not axiomatized."
     },
     {
       "id": "part1-two-squares",
@@ -131,7 +131,7 @@
     ],
     "opens": [],
     "namespace": null,
-    "lineCount": 134,
+    "lineCount": 135,
     "axiomCount": 1,
     "theoremCount": 4,
     "definitionCount": 13,

--- a/src/data/proofs/erdos-675/meta.json
+++ b/src/data/proofs/erdos-675/meta.json
@@ -59,8 +59,8 @@
       "title": "The Translation Property",
       "startLine": 25,
       "endLine": 37,
-      "summary": "Defines HasTranslationProperty and the minimal translation function via Nat.find.",
-      "mathContext": "Formal definition: Defines HasTranslationProperty and the minimal translation function via Nat.find."
+      "summary": "Defines HasTranslationProperty and the minimal translation function via sInf.",
+      "mathContext": "Formal definition: Defines HasTranslationProperty and the minimal translation function via sInf."
     },
     {
       "id": "number-theoretic-sets",


### PR DESCRIPTION
## Integrity Issue

**Proof**: erdos-675 (Erdős #675 — Translation Property for Number-Theoretic Sets)
**Problem**: `proofStrategy` prose overstates the axiom footprint and misdescribes the file structure.

## Evidence

`proofStrategy` claimed:
- "…and minTranslation via **Nat.find**" — actual definition uses `sInf` (`Proofs/Erdos675Problem.lean:36`).
- "The sieve conditions (IsPairwiseCoprime, HasSmallReciprocalSum) … **are axiomatized**" — both are ordinary `def`s (lines 54, 58), not axioms.
- "The three parts of Problem 675 are **stated as separate axioms**" — the three parts are unproved `def` Props (lines 109, 125, 131), each explicitly annotated "(OPEN — not axiomatized)". This contradicts the file, the `assumptions` field ("3 open conjectures converted from axioms to defs"), and inflates the apparent axiom footprint from 1 → 4.

`known-results` section summary claimed it "Axiomatizes … **and the squarefree special case**" — the squarefree case is the *proved theorem* `squarefree_translation` (line 99), derived from the single axiom, not axiomatized.

**Verified counts (unchanged, all correct):** 1 axiom (`brun_sieve_translation`), 4 theorems, 13 defs, 0 sorries, no `native_decide`. `HasSmallReciprocalSum` uses a `True` placeholder — honestly disclosed in the docstring and retained prose; status `axiomatized`/badge `axiom` (not overclaimed as verified).

## Fix

- Correct `proofStrategy`: `sInf` (not Nat.find); sieve conditions are defs; only `brun_sieve_translation` is axiomatized; squarefree case is proved from it; three parts are unproved `def` Props (open, not axiomatized).
- Correct `known-results` section summary/mathContext: squarefree special case is a proved theorem, not axiomatized.
- `lineCount` 134 → 135 (stale by 1).

---
Discovered during gallery integrity audit (reserve-mode re-serve; queue drained, 0 unaudited).