### PR TITLE
Fix: basel-problem-oq-04-oq-03 stale coprime-pair counts (13,21→11,19)

### DIFF
--- a/src/data/proofs/basel-problem-oq-04-oq-03/annotations.json
+++ b/src/data/proofs/basel-problem-oq-04-oq-03/annotations.json
@@ -289,7 +289,7 @@
     "type": "concept",
     "title": "Computational Verification for Small N",
     "content": "Six theorems verify countCoprimePairs at N=1,2,3,4,5,10 using `native_decide`, which compiles the decision procedure to native code for efficient evaluation. The densities start at 1.0 (N=1), dip to ~0.63 at N=10, and converge toward 6/π² ≈ 0.608. These verified values serve as a sanity check and illustrate the slow monotone convergence of the density. Notice the density at N=2 is 3/4=0.75 (pairs (1,1),(1,2),(2,1)) — the non-coprime pair (2,2) with gcd=2 is the only exclusion.",
-    "mathContext": "Densities: $N=1: 1.0$, $N=2: 0.75$, $N=3: 7/9\\approx0.778$, $N=4: 13/16=0.813$, $N=5: 21/25=0.84$, $N=10: 0.63$. All exceed $6/\\pi^2\\approx0.608$ (density approaches from above).",
+    "mathContext": "Densities: $N=1: 1.0$, $N=2: 0.75$, $N=3: 7/9\\approx0.778$, $N=4: 11/16\\approx0.688$, $N=5: 19/25=0.76$, $N=10: 0.63$. All exceed $6/\\pi^2\\approx0.608$ (density approaches from above).",
     "significance": "supporting",
     "relatedConcepts": [
       "native_decide",

--- a/src/data/proofs/basel-problem-oq-04-oq-03/meta.json
+++ b/src/data/proofs/basel-problem-oq-04-oq-03/meta.json
@@ -145,7 +145,7 @@
       "title": "Small Case Verification",
       "startLine": 466,
       "endLine": 497,
-      "summary": "Native_decide verification for N=1,2,3,4,5,10 confirming countCoprimePairs gives 1,3,7,13,21,63. Densities converge toward 6/π² ≈ 0.608 from above.",
+      "summary": "Native_decide verification for N=1,2,3,4,5,10 confirming countCoprimePairs gives 1,3,7,11,19,63. Densities converge toward 6/π² ≈ 0.608 from above.",
       "mathContext": "Empirical: $N=1: 1/1=1.0$, $N=10: 63/100=0.63$. The density converges to $6/\\pi^2\\approx 0.608$ from above."
     },
     {


### PR DESCRIPTION
## Problem

The #38611 statement-repair log records that `BaselProblemOQ04OQ03.lean` had **two wrong small-case numeric literals** corrected under the v4.26→v4.31 migration: the coprime-pair counts for N=4 (13→11) and N=5 (21→19), the true values via $2\cdot\sum_{k\le N}\varphi(k)-1$.

The corrected Lean source now proves:
- `countCoprimePairs_four : countCoprimePairs 4 = 11` (density 11/16 ≈ 0.688)
- `countCoprimePairs_five : countCoprimePairs 5 = 19` (density 19/25 = 0.76)

But the gallery metadata still quoted the **old, false** values (13, 21), a stale-falsehood surviving the repair.

## Fix (metadata only, minimal)

- `meta.json`: section summary `1,3,7,13,21,63` → `1,3,7,11,19,63`
- `annotations.json`: densities `N=4: 13/16=0.813, N=5: 21/25=0.84` → `N=4: 11/16≈0.688, N=5: 19/25=0.76`

## Evidence

Lean source (post-repair, this checkout):
```
theorem countCoprimePairs_four : countCoprimePairs 4 = 11 := by unfold countCoprimePairs; native_decide
theorem countCoprimePairs_five : countCoprimePairs 5 = 19 := by unfold countCoprimePairs; native_decide
```
Cross-check: $2(\varphi(1)+\cdots+\varphi(4))-1 = 2\cdot6-1 = 11$; $2\cdot10-1 = 19$.

Both edited files validate as JSON (`jq empty`).

Part of #38611 gallery re-audit.