### PR TITLE
audit: erdos-883 — drop 5 phantom axioms from section prose (only 2 axioms exist)

### DIFF
--- a/src/data/proofs/erdos-883/meta.json
+++ b/src/data/proofs/erdos-883/meta.json
@@ -91,16 +91,16 @@
       "title": "Part I: The Coprime Graph",
       "startLine": 38,
       "endLine": 64,
-      "summary": "Defines coprimeGraph using SimpleGraph, threshold value floor(n/2) + floor(n/3) - floor(n/6), and threshold_eq_divisible_2_or_3 axiom.",
-      "mathContext": "Formal definition: Defines coprimeGraph using SimpleGraph, threshold value floor(n/2) + floor(n/3) - floor(n/6), and threshold_eq_divisible_2_or_3 axiom."
+      "summary": "Defines coprimeGraph using SimpleGraph and the threshold value floor(n/2) + floor(n/3) - floor(n/6). A prose comment notes (informally, not as an axiom) that this equals the count of integers <= n divisible by 2 or 3 via inclusion-exclusion.",
+      "mathContext": "Formal definition: Defines coprimeGraph using SimpleGraph and the threshold value floor(n/2) + floor(n/3) - floor(n/6). A prose comment notes (informally, not as an axiom) that this equals the count of integers <= n divisible by 2 or 3 via inclusion-exclusion."
     },
     {
       "id": "extremal-example",
       "title": "Part II: The Extremal Example",
       "startLine": 65,
       "endLine": 84,
-      "summary": "Defines extremalSet (multiples of 2 or 3). Axiomatizes extremal_set_triangle_free: no triangles in coprime graph.",
-      "mathContext": "Formal definition: Defines extremalSet (multiples of 2 or 3). Axiomatizes extremal_set_triangle_free: no triangles in coprime graph."
+      "summary": "Defines extremalSet (multiples of 2 or 3) and isCoprimeCycle. The triangle-free property of the extremal set is described only in a prose comment (not axiomatized).",
+      "mathContext": "Formal definition: Defines extremalSet (multiples of 2 or 3) and isCoprimeCycle. The triangle-free property of the extremal set is described only in a prose comment (not axiomatized)."
     },
     {
       "id": "erdos-sarkozy",
@@ -115,8 +115,8 @@
       "title": "Part IV: Question 1 - All Short Odd Cycles",
       "startLine": 100,
       "endLine": 121,
-      "summary": "Defines erdos_883_question_1: does G(A) contain all odd cycles of length at most n/3 + 1? Axiom question_1_open.",
-      "mathContext": "Formal definition: Defines erdos_883_question_1: does G(A) contain all odd cycles of length at most n/3 + 1? Axiom question_1_open."
+      "summary": "Defines erdos_883_question_1: does G(A) contain all odd cycles of length at most n/3 + 1? The openness of this question is noted in a prose comment (no axiom is declared).",
+      "mathContext": "Formal definition: Defines erdos_883_question_1: does G(A) contain all odd cycles of length at most n/3 + 1? The openness of this question is noted in a prose comment (no axiom is declared)."
     },
     {
       "id": "sarkozy-tripartite",
@@ -139,8 +139,8 @@
       "title": "Part VII: Properties of the Coprime Graph",
       "startLine": 195,
       "endLine": 216,
-      "summary": "Placeholder chromatic number axiom, isCoprimeCycle definition, triangles_above_threshold axiom.",
-      "mathContext": "Formal definition: Placeholder chromatic number axiom, isCoprimeCycle definition, triangles_above_threshold axiom."
+      "summary": "Prose comments on the coprime graph's chromatic number and the existence of small odd cycles above the threshold (no axioms declared here), plus the proved theorem threshold_by_inclusion_exclusion (threshold n = n/2 + n/3 - n/6 by rfl).",
+      "mathContext": "Verified: Prose comments on the coprime graph's chromatic number and small odd cycles above the threshold (no axioms declared here), plus the proved theorem threshold_by_inclusion_exclusion (threshold n = n/2 + n/3 - n/6 by rfl)."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Integrity Issue

**Proof**: erdos-883 (Cycles in the Coprime Graph)
**Problem**: Four section summaries in `meta.json` reference axioms that do not exist in `proofs/Proofs/Erdos883Problem.lean`.

## Evidence

The Lean file declares **exactly 2 axioms**: `erdos_sarkozy_odd_cycles` (line 92) and `sarkozy_tripartite` (line 144). `meta.axiomCount` (2), `originalContributions`, and the `overview` prose are all correct.

But the per-section summaries referenced **5 phantom axioms**:
- `coprime-graph`: "threshold_eq_divisible_2_or_3 axiom" → actually an informal comment (lines 56-61)
- `extremal-example`: "Axiomatizes extremal_set_triangle_free" → actually an informal comment (lines 70-76)
- `question-1`: "Axiom question_1_open" → actually an informal comment (lines 115-119)
- `graph-properties`: "Placeholder chromatic number axiom … triangles_above_threshold axiom" → lines 195-216 contain only comments plus the proved theorem `threshold_by_inclusion_exclusion`; `isCoprimeCycle` is not in this range (it's at line 81)

Counts pass; the overstatement was purely in section prose (the reserve-mode prose-vs-declarations failure mode).

## Fix

Rewrote the four section summaries/mathContext to describe the actual comments/defs and the real proved theorem. No Lean or count changes.

---
Discovered during gallery integrity audit (reserve mode; queue drained).