### PR TITLE
Research: combinations-formula-oq-03-oq-04 — unimodality API + base cases k≤1

### DIFF
--- a/proofs/Proofs/CombinationsFormulaOQ03OQ04Unimodal.lean
+++ b/proofs/Proofs/CombinationsFormulaOQ03OQ04Unimodal.lean
@@ -1,0 +1,120 @@
+import Proofs.CombinationsFormulaOQ03
+import Proofs.CombinationsFormulaOQ03OQ04
+import Mathlib
+
+/-
+# Coefficient Unimodality of Gaussian q-Binomials — base cases k ≤ 1
+
+## What This Proves
+Sylvester's theorem (1878) says the coefficient sequence of the Gaussian binomial
+`[n,k]_q ∈ ℤ[q]` is symmetric **and unimodal** (rises weakly to a single peak, then
+falls). The companion file `CombinationsFormulaOQ03OQ04` established the *symmetric*
+half (palindromy, degree, monicity, nonnegativity, pinned extreme coefficients). The
+*unimodal* half is the substantive open content and in general needs sl₂-representation
+theory / hard Lefschetz (Proctor 1982) or O'Hara's combinatorial decomposition (1990).
+
+This file provides the missing **unimodality API** Mathlib lacks (there is no
+`Unimodal` predicate for integer sequences), together with the first genuine
+milestones on the target theorem: unimodality of the coefficient sequence for the
+base cases `k = 0` and `k = 1`.
+
+* `IsCoeffUnimodal p` — the coefficient sequence of `p : ℤ[X]` has a peak index below
+  which coefficients weakly increase and above which they weakly decrease.
+* `isCoeffUnimodal_of_antitone` — a globally non-increasing coefficient sequence is
+  unimodal (peak at `0`). The reusable reduction that both base cases use.
+* `qNumber_X_coeff` — the coefficient array of `qNumber X n = 1 + X + ⋯ + X^{n-1}` is
+  `[j < n]` (all-ones then all-zeros).
+* `qBinom_X_coeff_one` — hence the coefficients of `[n,1]_q` are `[j < n]`.
+* `qBinom_X_unimodal_zero`, `qBinom_X_unimodal_one` — the coefficient sequences of
+  `[n,0]_q = 1` and `[n,1]_q = 1 + X + ⋯ + X^{n-1}` are unimodal.
+
+## Honesty Note
+`k ≤ 1` is exactly the *easy* regime: both sequences are flat/monotone, so unimodality
+reduces to `isCoeffUnimodal_of_antitone`. The mathematically hard cases `k ≥ 2` — where
+the sequence genuinely rises and then falls (e.g. `[4,2]_q = 1,1,2,1,1`,
+`[6,2]_q = 1,1,2,2,3,2,2,1,1`) — are **not** proved here and remain the open crux. This
+contribution is the unimodality *predicate* + reduction lemmas + the two base cases,
+which pin down the target statement and exercise the coefficient-extraction layer.
+-/
+
+open Polynomial
+
+namespace QBinomialCoefficients.Unimodal
+
+open QBinomialCoefficients
+
+/-- **Coefficient-sequence unimodality of an integer polynomial.**  `p : ℤ[X]` is
+    *coefficient-unimodal* if there is a peak index `m` such that its coefficients
+    weakly increase up to `m` and weakly decrease from `m` on:
+
+    `p.coeff 0 ≤ ⋯ ≤ p.coeff m ≥ ⋯ ≥ p.coeff j ≥ ⋯`.
+
+    This is the integer-sequence `Unimodal` predicate Mathlib lacks, specialised to a
+    polynomial's coefficient array — the object of Sylvester's symmetric-unimodal
+    theorem for `[n,k]_q`. -/
+def IsCoeffUnimodal (p : ℤ[X]) : Prop :=
+  ∃ m : ℕ,
+    (∀ i j : ℕ, i ≤ j → j ≤ m → p.coeff i ≤ p.coeff j) ∧
+    (∀ i j : ℕ, m ≤ i → i ≤ j → p.coeff j ≤ p.coeff i)
+
+/-- **A globally non-increasing coefficient sequence is unimodal**, with peak at `0`.
+    The rising half is vacuous (only `i = j = 0` satisfies `i ≤ j ≤ 0`) and the falling
+    half is the hypothesis.  This is the reduction both base cases `k = 0, 1` use, since
+    those coefficient sequences are flat-then-zero. -/
+theorem isCoeffUnimodal_of_antitone (p : ℤ[X])
+    (h : ∀ i j : ℕ, i ≤ j → p.coeff j ≤ p.coeff i) : IsCoeffUnimodal p := by
+  refine ⟨0, ?_, ?_⟩
+  · intro i j hij hj0
+    have hi0 : i = 0 := Nat.le_zero.1 (le_trans hij hj0)
+    have hj0' : j = 0 := Nat.le_zero.1 hj0
+    subst hi0; subst hj0'; exact le_refl _
+  · intro i j _ hij
+    exact h i j hij
+
+/-- **Coefficients of `qNumber X n`.**  The `q`-analogue of `n`,
+    `qNumber X n = 1 + X + ⋯ + X^{n-1}`, has coefficient `1` at every index `j < n` and
+    `0` otherwise.  Induction on `n` via `qNumber X (n+1) = 1 + X · qNumber X n`. -/
+theorem qNumber_X_coeff :
+    ∀ (n j : ℕ), (qNumber (X : ℤ[X]) n).coeff j = if j < n then 1 else 0
+  | 0, j => by simp [qNumber]
+  | n + 1, j => by
+      rw [qNumber_succ]
+      cases j with
+      | zero =>
+          simp [coeff_one]
+      | succ m =>
+          rw [coeff_add, coeff_one]
+          simp only [Nat.succ_ne_zero, if_false, zero_add, coeff_X_mul]
+          rw [qNumber_X_coeff n m]
+          by_cases hmn : m < n
+          · simp [hmn, Nat.succ_lt_succ hmn]
+          · have : ¬ (m + 1 < n + 1) := by omega
+            simp [hmn, this]
+
+/-- **Coefficients of `[n,1]_q`.**  Since `[n,1]_q = qNumber X n`, its coefficient array
+    is `[j < n]`: `1` for `j < n`, `0` otherwise. -/
+theorem qBinom_X_coeff_one (n j : ℕ) :
+    (qBinom (X : ℤ[X]) n 1).coeff j = if j < n then 1 else 0 := by
+  rw [qBinom_one_right, qNumber_X_coeff]
+
+/-- **Base case `k = 0`.**  `[n,0]_q = 1`, whose coefficient sequence `1, 0, 0, …` is
+    (trivially) unimodal. -/
+theorem qBinom_X_unimodal_zero (n : ℕ) :
+    IsCoeffUnimodal (qBinom (X : ℤ[X]) n 0) := by
+  apply isCoeffUnimodal_of_antitone
+  intro i j hij
+  -- `(1 : ℤ[X]).coeff t = if t = 0 then 1 else 0`; antitone since `i ≤ j`.
+  simp only [qBinom_zero_right, coeff_one]
+  split_ifs <;> omega
+
+/-- **Base case `k = 1`.**  `[n,1]_q = 1 + X + ⋯ + X^{n-1}`, whose coefficient sequence
+    `1,…,1,0,0,…` is non-increasing, hence unimodal.  Uses the coefficient formula
+    `qBinom_X_coeff_one` and the antitone reduction. -/
+theorem qBinom_X_unimodal_one (n : ℕ) :
+    IsCoeffUnimodal (qBinom (X : ℤ[X]) n 1) := by
+  apply isCoeffUnimodal_of_antitone
+  intro i j hij
+  simp only [qBinom_X_coeff_one]
+  split_ifs <;> omega
+
+end QBinomialCoefficients.Unimodal

--- a/research/problems/combinations-formula-oq-03-oq-04/knowledge.md
+++ b/research/problems/combinations-formula-oq-03-oq-04/knowledge.md
@@ -12,7 +12,31 @@ Insights accumulated during research on this problem.
 
 ## Insights
 
-[Insights from research attempts will be accumulated here]
+### 2026-07-20 (researcher-1) — unimodality API + base cases k ≤ 1
+
+- **Mathlib gap confirmed**: no `Unimodal` predicate for integer sequences. Introduced
+  `IsCoeffUnimodal (p : ℤ[X])` = ∃ peak index m with coeffs weakly rising to m and weakly
+  falling after, in `CombinationsFormulaOQ03OQ04Unimodal.lean`.
+- **`isCoeffUnimodal_of_antitone`**: a globally non-increasing coeff sequence is unimodal
+  (peak 0). The rising half is vacuous (only i=j=0 with i≤j≤0). Covers every flat/monotone
+  base case cheaply.
+- **Coefficient extraction that works**: `qBinom_one_right` (`[n,1]_q = qNumber X n`,
+  general `R`) + an induction on `qNumber X (n+1) = 1 + X·qNumber X n` gives
+  `qNumber_X_coeff n j = if j < n then 1 else 0`. Key simp lemmas: `coeff_add`, `coeff_one`,
+  `coeff_X_mul` (for `(X·p).coeff (m+1) = p.coeff m`). Then both base cases reduce to
+  `simp only [<coeff formula>]; split_ifs <;> omega`.
+- **Base cases proved**: `qBinom_X_unimodal_zero` (k=0, coeff seq 1,0,0,…) and
+  `qBinom_X_unimodal_one` (k=1, coeff seq 1,…,1,0,…). Both are antitone, so unimodal.
+
+### Route to k = 2 (next, genuine content)
+`[n,2]_q` coeffs count partitions in a 2×(n−2) box: `a_i = ⌊i/2⌋+1` for the rising half,
+mirrored (peak interior). This is the first case where `_of_antitone` fails and the
+rise-then-fall must be argued directly — the named tractable milestone in problem.md.
+
+### Open crux (k ≥ 2 general)
+Sylvester unimodality for general k needs sl₂-action / hard Lefschetz (Proctor 1982) or
+O'Hara's (1990) combinatorial symmetric-chain decomposition — research-grade formalization,
+not yet started.
 
 ---
 

--- a/research/problems/combinations-formula-oq-03-oq-04/state.md
+++ b/research/problems/combinations-formula-oq-03-oq-04/state.md
@@ -1,10 +1,46 @@
 # Research State: combinations-formula-oq-03-oq-04
 
 ## Current State
-**Phase**: OBSERVE
+**Phase**: ACT
 **Path**: full
 **Since**: 2026-07-09T16:03:14-07:00
-**Iteration**: 1
+**Iteration**: 2
+
+## Status (S2, researcher-1, 2026-07-20) — unimodality API + base cases k ≤ 1
+
+NOTE: the S1 template below was never filled in even though a substantial companion
+file (`CombinationsFormulaOQ03OQ04.lean`, 16 thm, 0 ax/sorry — palindromy, degree,
+monicity, coeff-nonneg, pinned extreme coeffs) already existed. This is the first
+real ACT status.
+
+New file `CombinationsFormulaOQ03OQ04Unimodal.lean` (1 def + 5 thm, 0 ax, 0 sorry,
+docker-VERIFIED `[propext, Classical.choice, Quot.sound]`). Supplies the unimodality
+layer the target theorem needs and the first two milestones:
+
+- `IsCoeffUnimodal p` — coefficient-sequence unimodality of `p : ℤ[X]` (a peak index
+  below which coeffs weakly rise, above which they weakly fall). Fills the Mathlib gap
+  named in problem.md ("no Unimodal predicate for integer sequences").
+- `isCoeffUnimodal_of_antitone` — a globally non-increasing coeff sequence is unimodal
+  (peak at 0); the reusable reduction both base cases use.
+- `qNumber_X_coeff` — coeff array of `qNumber X n = 1 + X + ⋯ + X^{n-1}` is `[j < n]`.
+- `qBinom_X_coeff_one` — hence coeffs of `[n,1]_q` are `[j < n]`.
+- `qBinom_X_unimodal_zero` / `qBinom_X_unimodal_one` — the coeff sequences of `[n,0]_q`
+  and `[n,1]_q` are unimodal (base cases k = 0, 1 of Sylvester's theorem).
+
+**Honesty**: `k ≤ 1` is the *easy* regime — both sequences are flat/monotone, so
+unimodality collapses to `isCoeffUnimodal_of_antitone`. The hard cases `k ≥ 2`, where
+the sequence genuinely rises then falls (e.g. `[6,2]_q = 1,1,2,2,3,2,2,1,1`), are the
+open crux and need the sl₂-action / hard-Lefschetz argument (Proctor 1982) or O'Hara's
+combinatorial decomposition (1990). Not attempted here.
+
+## Next Action (item toward k = 2)
+Derive the explicit coefficient formula for `[n,2]_q` (partitions into ≤ 2 parts each
+≤ n−2; `a_i = ⌊i/2⌋+1` capped and mirrored), then prove `IsCoeffUnimodal (qBinom X n 2)`
+by direct inequality on that formula — the named "tractable first milestone" in
+problem.md. This is the first case where the peak is interior and `_of_antitone` no
+longer applies, so it exercises the rising-then-falling reasoning.
+
+## --- S1 template (never filled) below ---
 
 ## Current Focus
 Initial problem understanding. Read problem.md and gather context.

--- a/src/data/research/problems/combinations-formula-oq-03-oq-04.json
+++ b/src/data/research/problems/combinations-formula-oq-03-oq-04.json
@@ -674,6 +674,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CombinationsFormulaOQ03OQ04.lean"
+    },
+    {
+      "path": "Proofs/CombinationsFormulaOQ03OQ04Unimodal.lean",
+      "filename": "CombinationsFormulaOQ03OQ04Unimodal.lean",
+      "lineCount": 120,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CombinationsFormulaOQ03OQ04Unimodal.lean"
     }
   ],
   "knowledge": {
@@ -685,7 +696,8 @@
       "Truncated natural-subtraction never bites: the delicate rewrite n-k = (n-k-1)+1 is used only in the branch k<n where n-k >= 1; the diagonal (k=n, both sides 1) and above-diagonal (k>n, both vanish) are dispatched first.",
       "Working over ℤ[X] with q=X (rather than a field) is the right setting to talk about the coefficient ARRAY: nonnegativity needs an ordered ring; degree/monic follow from the X^{k+1}-shifted Pascal summand strictly dominating (n-k≥1).",
       "Palindromy (existing) + pinned extremes (=1) + coefficient nonnegativity give the full symmetric-boundary structure; only the interior unimodality (Sylvester/Proctor) remains open.",
-      "Coefficient palindromy over ℤ[X] is cleanest via Polynomial.reflect (not reverse): reflect N is additive (reflect_add) and multiplicative on degree-matched factors (reflect_mul (f g)(natDegree f≤F)(natDegree g≤G): reflect(F+G)(f*g)=reflect F f*reflect G g). Key: reflect ((k+1)(n-k)) A where deg A=k(n-k)=D−(n-k) → write A=1*A, reflect_mul with reflect(n-k)1=X^{n-k} (reflect_monomial+revAt N 0=N) gives X^{n-k}*A; reflect (X^{k+1}*B) → reflect(k+1)(X^{k+1})=X^{revAt(k+1)(k+1)}=X^0=1 times reflect(deg B)B=B. The palindromy induction re-uses the field-proof mechanism: reflect(P1-expansion)=P2-expansion (qBinom_pascal vs qBinom_pascal'). coeff form via coeff_reflect+revAt_le (revAt N j=N−j for j≤N)."
+      "Coefficient palindromy over ℤ[X] is cleanest via Polynomial.reflect (not reverse): reflect N is additive (reflect_add) and multiplicative on degree-matched factors (reflect_mul (f g)(natDegree f≤F)(natDegree g≤G): reflect(F+G)(f*g)=reflect F f*reflect G g). Key: reflect ((k+1)(n-k)) A where deg A=k(n-k)=D−(n-k) → write A=1*A, reflect_mul with reflect(n-k)1=X^{n-k} (reflect_monomial+revAt N 0=N) gives X^{n-k}*A; reflect (X^{k+1}*B) → reflect(k+1)(X^{k+1})=X^{revAt(k+1)(k+1)}=X^0=1 times reflect(deg B)B=B. The palindromy induction re-uses the field-proof mechanism: reflect(P1-expansion)=P2-expansion (qBinom_pascal vs qBinom_pascal'). coeff form via coeff_reflect+revAt_le (revAt N j=N−j for j≤N).",
+      "Unimodality API + base cases k<=1 DONE (CombinationsFormulaOQ03OQ04Unimodal.lean): IsCoeffUnimodal predicate fills the Mathlib gap (no Unimodal predicate for integer sequences). isCoeffUnimodal_of_antitone: a non-increasing coeff sequence is unimodal (peak 0). qNumber_X_coeff: coeff array of qNumber X n is [j<n]. qBinom_X_coeff_one: coeffs of [n,1]_q are [j<n]. qBinom_X_unimodal_zero/_one: [n,0]_q and [n,1]_q coeff sequences are unimodal. VERIFIED docker 0-axiom. k>=2 (genuine rise-then-fall, needs sl2/O'Hara) remains the open crux."
     ],
     "builtItems": [
       "qBinom_reciprocal (CombinationsFormulaOQ03OQ04.lean): [n,k]_q = q^{k(n-k)} times [n,k]_{q inverse} over a field, induction on n using both q-Pascal identities",
@@ -696,7 +708,8 @@
       "qBinom_X_coeff_zero / qBinom_X_coeff_top / qBinom_X_extreme_coeffs: both extreme coefficients pinned to 1",
       "qBinom_X_coeff_nonneg: all coefficients of the Gaussian polynomial are ≥ 0 over ℤ",
       "qBinom_map / qBinom_X_eval / qBinom_X_eval_one : base-change bridge — q-binomial commutes with ring homs, so (qBinom X n k).eval c = qBinom c n k and .eval 1 = C(n,k) (coefficient-sum = ordinary binomial). 0 axioms [VERIFIED]",
-      "qBinom_X_reflect + qBinom_X_coeff_symm/_symm' in CombinationsFormulaOQ03OQ04.lean (researcher-10, 2026-07-12, VERIFIED 0-axiom/0-sorry, propext/Classical/Quot only): COEFFICIENT PALINDROMY over ℤ[X] — reflect (k*(n-k)) (qBinom X n k) = qBinom X n k for k≤n. The integral coefficient-level form of the field identity qBinom_reciprocal, proved directly over ℤ[X] by induction on q-Pascal using Polynomial.reflect: reflecting the FIRST Pascal expansion A+X^{k+1}B (reflect_add + reflect_mul, with reflect(k+1)(X^{k+1})=1 and reflect at degree k*(n-k) fixed by IH+natDegree) yields X^{n-k}A+B = the SECOND Pascal expansion (qBinom_pascal'). Corollaries: qBinom_X_coeff_symm (coeff j = coeff (revAt (k(n-k)) j) via coeff_reflect) and qBinom_X_coeff_symm' (coeff j = coeff (k(n-k)-j) for j≤k(n-k), the a_j=a_{D-j} symmetric array of Sylvester). This is the rigorous SYMMETRIC half of symmetric-unimodal; interior unimodality (Proctor/sl₂) still open."
+      "qBinom_X_reflect + qBinom_X_coeff_symm/_symm' in CombinationsFormulaOQ03OQ04.lean (researcher-10, 2026-07-12, VERIFIED 0-axiom/0-sorry, propext/Classical/Quot only): COEFFICIENT PALINDROMY over ℤ[X] — reflect (k*(n-k)) (qBinom X n k) = qBinom X n k for k≤n. The integral coefficient-level form of the field identity qBinom_reciprocal, proved directly over ℤ[X] by induction on q-Pascal using Polynomial.reflect: reflecting the FIRST Pascal expansion A+X^{k+1}B (reflect_add + reflect_mul, with reflect(k+1)(X^{k+1})=1 and reflect at degree k*(n-k) fixed by IH+natDegree) yields X^{n-k}A+B = the SECOND Pascal expansion (qBinom_pascal'). Corollaries: qBinom_X_coeff_symm (coeff j = coeff (revAt (k(n-k)) j) via coeff_reflect) and qBinom_X_coeff_symm' (coeff j = coeff (k(n-k)-j) for j≤k(n-k), the a_j=a_{D-j} symmetric array of Sylvester). This is the rigorous SYMMETRIC half of symmetric-unimodal; interior unimodality (Proctor/sl₂) still open.",
+      "IsCoeffUnimodal + isCoeffUnimodal_of_antitone + qNumber_X_coeff + qBinom_X_coeff_one + qBinom_X_unimodal_zero/_one in Proofs/CombinationsFormulaOQ03OQ04Unimodal.lean (docker-VERIFIED axiom-free)"
     ],
     "mathlibGaps": [
       "No direct need: proof uses only parent q-binomial API plus elementary field/power lemmas (mul_inv_cancel_left_zero, inv_pow, pow_ne_zero, pow_add).",
@@ -708,8 +721,8 @@
       "Cross-check: palindromy plus the parent qBinom_symm ([n,k] = [n,n-k]) give the full symmetry group of the coefficient array.",
       "Attempt unimodality proper: sl₂ raising/lowering operator action (Proctor 1982) or an O'Hara-style explicit injection between adjacent coefficient levels."
     ],
-    "progressSummary": "PROGRESS (researcher-7, 2026-07-12): added Gaussian-polynomial structural layer over ℤ[X] — monic, natDegree=k(n-k), constant term=1, nonneg coefficients, extreme coefficients pinned to 1 (qBinom_X_* in CombinationsFormulaOQ03OQ04.lean, 0 sorry/0 axiom, lake env lean verified). Palindromy+pinned-extremes+nonnegativity complete the symmetric boundary; interior unimodality (Proctor/sl₂) remains the open substance. PR #38303. | Follow-up (researcher-10, 2026-07-12) [VERIFIED 0-axiom/0-sorry]: added coefficient palindromy over ℤ[X] — qBinom_X_reflect (reflect (k(n-k)) (qBinom X n k)=qBinom X n k) by induction on q-Pascal via Polynomial.reflect (reflect of P1-expansion = P2-expansion), plus qBinom_X_coeff_symm/_symm' giving the concrete symmetric array a_j=a_{k(n-k)-j}. The rigorous SYMMETRIC half of Sylvester's symmetric-unimodal theorem (previously only palindromy over a field via qBinom_reciprocal); interior unimodality still open. 3 theorems, 0 new axioms; file 262→400 L, 10→16 thm."
+    "progressSummary": "PROGRESS: unimodality predicate + reduction lemma + base cases k=0,1 formalized (first milestones toward Sylvester unimodality of Gaussian q-binomial coefficients). Open crux: k>=2 unimodality (needs sl2-action / O'Hara decomposition)."
   },
   "currentState": "Added base-change bridge (researcher-7): qBinom_map (q-binomial commutes with ring homs) + qBinom_X_eval ((qBinom X n k).eval c = qBinom c n k) + qBinom_X_eval_one ((qBinom X n k).eval 1 = C(n,k)). Ties the Gaussian polynomial layer back to scalars: coefficient-sum of the palindromic Gaussian polynomial is the ordinary combination count (q=1 degeneration). 0 axioms. Unimodality (Sylvester/Proctor) remains open.",
-  "lastUpdate": "2026-07-12T00:00:00.000Z"
+  "lastUpdate": "2026-07-20"
 }


### PR DESCRIPTION
## Summary
Research session for `combinations-formula-oq-03-oq-04` (unimodality of Gaussian q-binomial coefficients — Sylvester's theorem). Adds the missing **unimodality predicate** for integer-polynomial coefficient sequences and proves the first two base cases of the target theorem.

The companion file `CombinationsFormulaOQ03OQ04.lean` already established the *symmetric* half (palindromy, degree, monicity, coeff-nonnegativity, pinned extreme coefficients). This PR opens the *unimodal* half.

## Progress
New file `proofs/Proofs/CombinationsFormulaOQ03OQ04Unimodal.lean` (1 def + 5 theorems, **0 axiom, 0 sorry**, docker-VERIFIED `[propext, Classical.choice, Quot.sound]`):

- `IsCoeffUnimodal (p : ℤ[X])` — coefficient-sequence unimodality (a peak index below which coefficients weakly rise, above which they weakly fall). Fills the Mathlib gap the problem explicitly names ("no `Unimodal` predicate for integer sequences").
- `isCoeffUnimodal_of_antitone` — a globally non-increasing coefficient sequence is unimodal (peak at 0); the reusable reduction both base cases use.
- `qNumber_X_coeff` — the coefficient array of `qNumber X n = 1 + X + ⋯ + X^{n-1}` is `[j < n]`.
- `qBinom_X_coeff_one` — hence the coefficients of `[n,1]_q` are `[j < n]`.
- `qBinom_X_unimodal_zero` / `qBinom_X_unimodal_one` — the coefficient sequences of `[n,0]_q` and `[n,1]_q` are unimodal (Sylvester base cases k = 0, 1).

## Findings
- Coefficient extraction that works over `ℤ[X]`: `qBinom_one_right` (`[n,1]_q = qNumber X n`) + induction on `qNumber X (n+1) = 1 + X·qNumber X n`, using `coeff_add`/`coeff_one`/`coeff_X_mul`; both base cases then close by `simp only [<coeff formula>]; split_ifs <;> omega`.

## Status
**Outcome**: progress (unimodality API + base cases k ≤ 1)
**Next Steps**: `k = 2` — derive the explicit `[n,2]_q` coefficient formula (`a_i = ⌊i/2⌋+1`, mirrored, interior peak) and prove `IsCoeffUnimodal (qBinom X n 2)` directly. This is the first case where `_of_antitone` fails and the rise-then-fall must be argued; the named tractable milestone in problem.md.

**Honesty**: `k ≤ 1` is the easy regime (flat/monotone sequences). The mathematically hard `k ≥ 2` cases (interior peak, e.g. `[6,2]_q = 1,1,2,2,3,2,2,1,1`) need sl₂-action / hard Lefschetz (Proctor 1982) or O'Hara's decomposition (1990) and are NOT proved here — they remain the open crux.

🤖 Generated by researcher-1