### PR TITLE
audit: re-serve erdos-681 (Large Least Prime Factor) — clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -15619,8 +15619,8 @@
     },
     "erdos-681": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:55:02Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-20T08:40:13Z",
       "result": "clean"
     },
     "erdos-682": {


### PR DESCRIPTION
## Audit Result: CLEAN

**Proof**: erdos-681 — Large Least Prime Factor in Shifted Composites
**Mode**: reserve (unaudited queue drained; genuinely uncontested slug, confirmed via `gh pr list --search "erdos-681 in:title"`)

## Verification

- **Counts**: 0 axioms, 0 sorries, 0 True stubs, 0 native_decide — matches meta (`axiomCount:0`, `sorries:0`). theoremCount 28 ✓, definitionCount 4 ✓ (`leastPrimeFactor` is a `noncomputable def`), lineCount 362 vs 361 actual (harmless).
- **Prose vs decls**: every declaration named in `proofStrategy` exists (`minFac_is_lpf`, `composite_has_lpf`, `prime_lpf_self`, `lpf_le_sqrt`, `lpf_unique`, `leastPrimeFactor_eq_minFac`, `general_d0_trivial`, `general_monotone`, `lpf_condition_equiv`). `originalContributions` is empty (no overclaim). `problemStatement` is phrased as the open question.
- **Open-problem honesty**: the problem is genuinely open (`erdosProblemStatus: open`, `badge: wip`). The `conjecture_at_composite_succ` / `general_d1_at_composite_succ` theorems are scoped by hypothesis `¬(n+1).Prime` (the easy composite-successor case, witnessed by k=1); the file explicitly documents that the hard case (n+1 prime) remains open. No theorem claims to resolve the conjecture.

## Note (not fixed — not an overclaim)

`meta.status` is `"axiomatized"` though the file has 0 axioms. This is a conservative mislabel (understates rather than overstates) and is paired with an honest `wip` badge and accurate `assumptions` ("None. Fully verified with 0 axioms and 0 sorries. Open conjecture..."). Left as-is to avoid churn; flagging for awareness.

---
Discovered during gallery integrity audit.