### PR TITLE
Fix: erdos-1-oq-03 annotation overstates S_k<2a_k+1 range (k≤8→k≤4)

### DIFF
--- a/src/data/proofs/erdos-1-oq-03/annotations.json
+++ b/src/data/proofs/erdos-1-oq-03/annotations.json
@@ -33,7 +33,7 @@
     "type": "definition",
     "title": "Partial Sums of the Conway-Guy Sequence",
     "content": "`conwayGuySum n` computes S_n = \u03a3\u1d62\u208c\u2081\u207f a_i by simple structural recursion. The base S_0 = 0 and S_{n+1} = S_n + a_{n+1}. These partial sums are central to the recurrence: the k-th Conway-Guy element is a_{k-1} + \u2308S_{k-1}/2\u2309. The values S_1 = 1, S_2 = 3, S_3 = 7, S_4 = 14, S_5 = 27 are verified computationally. Note the near-doubling pattern: each partial sum is approximately twice the previous Conway-Guy element.",
-    "mathContext": "$S_n = \\sum_{i=1}^n a_i$. Values: $S_1=1, S_2=3, S_3=7, S_4=14, S_5=27, S_6=51, S_7=95, S_8=179$. Note $S_k < 2a_k + 1$ for all $k \\leq 8$ \u2014 the key structural bound that implies distinct subset sums.",
+    "mathContext": "$S_n = \\sum_{i=1}^n a_i$. Values: $S_1=1, S_2=3, S_3=7, S_4=14, S_5=27, S_6=51, S_7=95, S_8=179$. Note $S_k < 2a_k + 1$ holds only for $k \\leq 4$ (with equality $S_5 = 2a_5 + 1 = 27$ at $k = 5$, so it fails for $k \\geq 5$); the bound that actually drives distinct subset sums is the strict inequality $2a_k > S_{k-1}$, which holds for the full range $k \\leq 8$.",
     "significance": "supporting",
     "relatedConcepts": [
       "partial sums",


### PR DESCRIPTION
## Problem

The `conwayGuySum` `mathContext` annotation asserts:

> Note $S_k < 2a_k + 1$ for all $k \leq 8$ — the key structural bound that implies distinct subset sums.

This is **false from k=5 on**. With $S_5 = 27$ and $a_5 = 13$, $2a_5 + 1 = 27$, so $S_5 < 27$ fails (equality, not strict). The corrected Lean theorem `conwayGuy_sum_lt_twice_max` (Erdos1OQ03.lean:117) is now restricted to `k ≤ 4`:

```lean
theorem conwayGuy_sum_lt_twice_max :
    ∀ k, 1 ≤ k → k ≤ 4 → conwayGuySum k < 2 * conwayGuy k + 1 := by
```

This surfaced in the #38611 migration re-audit (line 64: "conwayGuy_sum_lt_twice_max claimed S_k<2a_k+1 for k≤8 but fails k≥5 (S_5=27⊀27); restricted to k≤4").

## Fix

Correct the range to $k \leq 4$, note the equality at $k=5$, and clarify that the bound actually driving distinct subset sums is the strict $2a_k > S_{k-1}$ (which does hold for the full range $k \leq 8$, per the `conwayGuy_invariant` annotation).

## Scope note

Complements #39430 (which fixed the exponential-bound `3·a_k → 2·a_k` and exact-recurrence prose in the same entry). #39430 does **not** touch this line — verified against its diff. Distinct, non-adjacent hunk; no overlap.

Evidence: `S_1..S_5 = 1,3,7,14,27`; `a_1..a_5 = 1,2,4,7,13`; `2a_5+1 = 27 = S_5`.

Part of #38611 re-audit.