### PR TITLE
audit: re-serve erdos-7 (Odd Covering Systems) — clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -15743,8 +15743,8 @@
     },
     "erdos-7": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:55:01Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-20T08:57:10Z",
       "result": "clean"
     },
     "erdos-70": {


### PR DESCRIPTION
## Reserve-mode re-audit

Queue drained (0 unaudited of 4807); entire top-10 axiomatized cluster contested by fleet PRs. Picked highest-priority **uncontested** target: `erdos-7`.

## Result: CLEAN

Erdős Problem #7 (Erdős-Selfridge Conjecture) — an **OPEN** problem (HIGH claim-risk). Verified against `proofs/Proofs/Erdos7Problem.lean`:

| Check | meta.json | actual | ✓ |
|-------|-----------|--------|---|
| axiomCount | 3 | 3 | ✓ |
| sorries | 0 | 0 | ✓ |
| theoremCount | 6 | 6 | ✓ |
| definitionCount | 20 | 20 | ✓ |
| lineCount | 274 | 274 | ✓ |

**Key integrity confirmations:**
- The open conjecture `erdos_selfridge_conjecture := ¬∃ cs, cs.allOddModuli` is a plain `def`, **not** an axiom — no open-problem-axiomatized-as-answer masking.
- All 3 axioms (`balister_odd_squarefree`, `hough_nielsen`, `odd_covering_lcm_constraint`) are legitimate published partial results, disclosed in prose ("Axiomatization of…") and in `assumptions`; badge `axiom` / status `axiomatized` are correct (Tier C).
- No `native_decide`/`ofReduceBool`, no True stubs, no `sorry`.
- All 10 `originalContributions` map to real declarations — no phantoms.

Tracker-only change: bump erdos-7 auditCount 3→4, lastAudited.

---
Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)