### PR TITLE
audit: erdos-875 — drop phantom 'popcount axiomatized' from conclusion prose

### DIFF
--- a/src/data/proofs/erdos-875/meta.json
+++ b/src/data/proofs/erdos-875/meta.json
@@ -105,7 +105,7 @@
     }
   ],
   "conclusion": {
-    "summary": "The formalization captures Erdős Problem #875 on admissible sequences with three proved results (powers of 2 strictly increasing, growth lower bound a(n) ≥ n+1, partial powers-of-2 admissibility). The gap threshold and ratio-one questions remain open, with the popcount argument for full powers-of-2 admissibility axiomatized.",
+    "summary": "The formalization captures Erdős Problem #875 on admissible sequences with three fully proved supporting results (powers of 2 strictly increasing, growth lower bound a(n) ≥ n+1, and full powers-of-2 admissibility via the binary-uniqueness lemma pow2_subset_sum_inj — no popcount axiom). The gap threshold and ratio-one questions remain open and are defined only as predicates (HasPolynomialGaps, HasRatioOne). The sole remaining trust dependency is Lean.ofReduceBool, from the native_decide-discharged pow2_small_example.",
     "implications": "Understanding admissible sequences connects to Sidon set theory, the subset sum problem, additive bases, and binary coding theory. The critical exponent c₀ would quantify how efficiently the disjoint sumsets condition constrains growth.",
     "openQuestions": [
       "What is the critical exponent c₀ for polynomial gaps in admissible sequences?",


### PR DESCRIPTION
## Integrity Issue

**Proof**: erdos-875 (Admissible Sequences with Disjoint Sumsets)
**Problem**: `conclusion.summary` described powers-of-2 admissibility as *partial* and claimed "the popcount argument for full powers-of-2 admissibility [is] axiomatized" — a phantom axiom that does not exist in the Lean file.

## Evidence

**meta.json conclusion claimed**: "three proved results (... partial powers-of-2 admissibility). ... with the popcount argument for full powers-of-2 admissibility axiomatized."

**Lean file shows** (`Proofs/Erdos875Problem.lean`):
- `powers_of_two_admissible : IsAdmissible (fun n => 2 ^ n)` is **fully proved**, no sorry, no axiom.
- Its proof uses the fully-proved private lemma `pow2_subset_sum_inj` (binary uniqueness by induction) — the former popcount axiom was **replaced** by this proof.
- `grep '^axiom'` → 0 axiom declarations. `sorries: 0`.
- Every other meta field already agrees: `proofStrategy` ("It fully proves powers-of-2 admissibility via binary uniqueness"), the `powers-of-two` section ("Axiom-free", "replacing a former popcount axiom").

Only the conclusion was stale, and it was internally contradictory with the rest of the entry.

## Fix

Rewrote `conclusion.summary` to state the three supporting results are fully proved (incl. full powers-of-2 admissibility via `pow2_subset_sum_inj`, no popcount axiom), note the open gap/ratio questions are defined only as predicates, and name the sole remaining trust dependency: `Lean.ofReduceBool` from the `native_decide`-discharged `pow2_small_example` (consistent with `meta.axiomCount: 1` / `assumptions`).

No Lean or count changes; prose-only alignment. Understatement fixed — the file proves more than the conclusion admitted.

---
Discovered during gallery integrity audit (reserve-mode re-serve, prose-vs-declarations).