### PR TITLE
audit: erdos-874 — drop 2 phantom axioms (Straus/ENS) from prose

### DIFF
--- a/src/data/proofs/erdos-874/meta.json
+++ b/src/data/proofs/erdos-874/meta.json
@@ -52,23 +52,22 @@
       "BoundedAdmissible for sets in {1,...,N}",
       "k(N) function as maximum admissible set size",
       "strausSet construction for lower bound",
-      "Straus lower/upper bound axioms (1966)",
-      "ENS improved upper bound axiom (1991)",
-      "Deshouillers-Freiman main theorem axiom (1999)",
-      "k_limit_is_two: the limit equals 2",
-      "erdos_874 and erdos_874_answer main theorems"
+      "strausConstant (4/√3) and ensConstant (√(143/27)) definitions with straus_constant_value",
+      "deshouillers_freiman_main axiom (1999): k(N)/√N → 2",
+      "k_limit_is_two axiom: the limit equals 2",
+      "erdos_874, k_le_self, and erdos_874_answer theorems (Straus 1966 and ENS 1991 bounds documented as prose only, not axiomatized)"
     ],
     "axiomCount": 2,
     "lineCount": 227,
     "assumptions": "2 axioms: deshouillers_freiman_main, k_limit_is_two. 0 sorries.",
-    "theoremCount": 3,
+    "theoremCount": 4,
     "definitionCount": 10
   },
   "overview": {
     "historicalContext": "This problem asks about admissible sets A ⊆ {1,...,N} where sums of r distinct elements form disjoint sets for each r. Straus (1966) introduced the term and established that 2 ≤ liminf k(N)/√N ≤ limsup k(N)/√N ≤ 4/√3. Erdős-Nicolas-Sárközy (1991) improved the upper bound to √(143/27). Finally, Deshouillers-Freiman (1999) proved the conjecture: k(N) ~ 2√N. Admissible sets generalize Sidon sets (B_2 sets, where only pairwise sums must be distinct) to all r-fold sums, placing them in the broader B_h set theory initiated by Sidon in 1932 and developed by Erdős and Turán. The precise √N asymptotics reflect a fundamental density constraint: packing many elements while keeping all r-fold sum sets disjoint requires near-optimal spread within {1,...,N}.",
     "problemStatement": "**Question:** Let k(N) denote the size of the largest subset A ⊆ {1,...,N} such that the sets S_r = { a₁ + ⋯ + a_r : a₁ < ⋯ < a_r ∈ A } are disjoint for distinct r ≥ 1. Is k(N) ~ 2√N?\n\n**Answer: YES** (Deshouillers-Freiman, 1999)\n\nThe limit lim_{N→∞} k(N)/√N = 2 exists.",
     "text": "Is k(N) ~ 2√N where k(N) is the max size of A ⊆ {1,...,N} with disjoint subset sums S_r? PROVED by Deshouillers-Freiman (1999).",
-    "proofStrategy": "The formalization defines:\n\n1. **sumSet(A, r):** Set of all r-element subset sums from A\n2. **Admissible(A):** S_r are pairwise disjoint for r ≥ 1\n3. **k(N):** Maximum |A| for admissible A ⊆ {1,...,N}\n\nWe axiomatize:\n- Straus (1966): Lower bound via interval construction, upper bound 4/√3\n- ENS (1991): Improved upper bound √(143/27)\n- Deshouillers-Freiman (1999): k(N)/√N → 2",
+    "proofStrategy": "The formalization defines:\n\n1. **sumSet(A, r):** Set of all r-element subset sums from A\n2. **Admissible(A):** S_r are pairwise disjoint for r ≥ 1\n3. **k(N):** Maximum |A| for admissible A ⊆ {1,...,N}\n\nThe file's two axioms both capture the Deshouillers-Freiman (1999) resolution (deshouillers_freiman_main and k_limit_is_two: k(N)/√N → 2). The earlier Straus (1966) lower/upper bounds (4/√3) and the ENS (1991) improvement (√(143/27)) are documented in prose comments with their constant definitions (strausConstant, ensConstant), not axiomatized.",
     "keyInsights": [
       "**Admissible = Disjoint Sums:** The key property is that you can determine r from the sum alone.",
       "**Intervals are often optimal:** Sets of the form (N-k, N] ∩ ℕ achieve the lower bound.",
@@ -193,7 +192,7 @@
     "namespace": "Erdos874",
     "lineCount": 227,
     "axiomCount": 2,
-    "theoremCount": 3,
+    "theoremCount": 4,
     "definitionCount": 10,
     "path": "Proofs/Erdos874Problem.lean",
     "sorries": 0


### PR DESCRIPTION
## Integrity Issue

**Proof**: erdos-874 (Admissible Sets and Subset Sum Disjointness)
**Problem**: `originalContributions` and `proofStrategy` claim the Straus (1966) and ENS (1991) bounds are **axiomatized**, but no such axioms exist in the Lean file.

## Evidence

**meta.json claimed** (originalContributions):
- `"Straus lower/upper bound axioms (1966)"`
- `"ENS improved upper bound axiom (1991)"`

and proofStrategy: `"We axiomatize: - Straus (1966)... - ENS (1991)... - Deshouillers-Freiman (1999)"`.

**Lean file shows** (`Proofs/Erdos874Problem.lean`): exactly **2 axioms**, both for Deshouillers-Freiman:
- `deshouillers_freiman_main` (L140)
- `k_limit_is_two` (L147)

The Straus lower/upper bounds (L96-104) and ENS improvement (L121-130) are **prose comment blocks only**; `strausConstant`/`ensConstant` are `def`s, not axioms. `axiomCount: 2` was already correct — only the prose overstated.

## Fix applied
- Reworded `originalContributions` to list the actual 2 axioms + note Straus/ENS bounds are prose-documented, not axiomatized.
- Reworded `proofStrategy` accordingly.
- Corrected `theoremCount` 3 → 4 (`straus_constant_value`, `erdos_874`, `k_le_self`, `erdos_874_answer`).

No Lean source changes; sorries/axiomCount unchanged.

---
Discovered during gallery integrity audit (reserve-mode re-serve).