### PR TITLE
audit: erdos-687 — correct axiomatized-count prose (5 phantom→4 real axioms)

### DIFF
--- a/src/data/proofs/erdos-687/meta.json
+++ b/src/data/proofs/erdos-687/meta.json
@@ -23,16 +23,16 @@
     "erdosProblemStatus": "open",
     "axiomCount": 4,
     "lineCount": 547,
-    "assumptions": "4 axioms: jacobsthalY_eq_jacobsthal, iwaniec_upper, fgkmt_lower, maier_pomerance_conjecture. jacobsthalSet_bddAbove proved via CRT induction. erdos_687_conjecture proved from maier_pomerance_conjecture. Y(3) = 3 proved by parity-residue case analysis. 0 sorries.",
+    "assumptions": "4 axioms: jacobsthalY_eq_jacobsthal_sub_one, iwaniec_upper, fgkmt_lower, maier_pomerance_conjecture. jacobsthalSet_bddAbove proved via CRT induction. erdos_687_conjecture proved conditionally from maier_pomerance_conjecture. Y(3) = 3 proved by parity-residue case analysis. 0 sorries.",
     "mathlib_version": "4.31.0",
     "theoremCount": 26,
-    "definitionCount": 5
+    "definitionCount": 4
   },
   "overview": {
     "historicalContext": "Erdős Problem #687 concerns the Jacobsthal function of the primorial, a central object in the theory of covering systems and prime gaps. Jacobsthal (1960) introduced g(n) as the largest gap between consecutive integers coprime to n. For the primorial P(x) = ∏_{p ≤ x} p, we have Y(x) = g(P(x)), connecting covering congruences to prime distribution. Iwaniec (1978) proved Y(x) ≪ x² using the Selberg sieve, a bound that has resisted improvement for nearly 50 years. Rankin (1938) gave the first non-trivial lower bound Y(x) ≫ x · log x · log log x · log log log log x / (log log log x)², which stood for decades. Ford, Green, Konyagin, Maynard, and Tao (2018), as part of their landmark work on large prime gaps, improved Rankin's bound by replacing the double-log denominator. Maier and Pomerance conjectured Y(x) ≪ x · (log x)^{2+o(1)}, which would nearly close the gap. Erdős offered $1,000 for proving Y(x) = o(x²), one of his largest prizes, reflecting the problem's depth and connection to the distribution of primes in arithmetic progressions, sieve methods, and the structure of smooth numbers.",
     "problemStatement": "Is Y(x) = o(x²)? Is Y(x) ≪ x^{1+o(1)}? What is the true growth rate?",
     "text": "Let Y(x) be the maximal y such that covering congruences for primes ≤ x cover [1,y]. Is Y(x) = o(x²)? $1,000 prize. Known: x·log x·... ≪ Y(x) ≪ x² (Iwaniec 1978, FGKMT 2018).",
-    "proofStrategy": "We formalize covering systems as functions assigning residue classes to primes ≤ x, define Y(x) via sSup of the achievable covering lengths, introduce the Jacobsthal function g(n) as sSup of maximal gaps, and state the equivalence Y(x) = g(primorial(x)). The $1,000 conjecture, Iwaniec's upper bound, the FGKMT lower bound, and the Maier–Pomerance conjecture are axiomatized. Structural properties (monotonicity, trivial lower bound) are proved from definitions.",
+    "proofStrategy": "We formalize covering systems as functions assigning residue classes to primes ≤ x, define Y(x) via sSup of the achievable covering lengths, introduce the Jacobsthal function g(n) as sSup of maximal gaps, and state the equivalence Y(x) = g(primorial(x)) − 1. Four results are axiomatized: this equivalence, Iwaniec's upper bound, the FGKMT lower bound, and the Maier–Pomerance conjecture. The $1,000 conjecture (erdos_687_conjecture) is not axiomatized — it is derived conditionally from the Maier–Pomerance axiom. Structural properties (monotonicity, boundedness, downward closure) and the concrete values Y(2)=1 and Y(3)=3 are proved from definitions.",
     "keyInsights": [
       "**Primorial connection**: $Y(x) = g(P(x))$ where $P(x) = \\prod_{p \\le x} p$ is the primorial, reducing the covering problem to the Jacobsthal function of a highly composite number",
       "**Iwaniec's sieve bound (1978)**: $Y(x) \\ll x^2$ via the Selberg sieve — this uses the fact that the number of integers in $[1, y]$ not covered by any prime $p \\le x$ is $\\ge y \\prod_{p \\le x}(1 - 1/p) - O(x^2)$ by inclusion-exclusion",
@@ -168,7 +168,7 @@
     }
   ],
   "conclusion": {
-    "summary": "Formalizes Erdős Problem #687 on covering congruences and the Jacobsthal function in 149 lines of Lean 4. The formalization captures Y(x) = g(primorial(x)), the $1,000 prize conjecture Y(x) = o(x²), Iwaniec's x² upper bound, the FGKMT lower bound, the Maier–Pomerance conjecture, and structural properties (monotonicity, trivial bounds). Two key properties are proved from definitions; five deep results are axiomatized.",
+    "summary": "Formalizes Erdős Problem #687 on covering congruences and the Jacobsthal function in 149 lines of Lean 4. The formalization captures Y(x) = g(primorial(x)), the $1,000 prize conjecture Y(x) = o(x²), Iwaniec's x² upper bound, the FGKMT lower bound, the Maier–Pomerance conjecture, and structural properties (monotonicity, trivial bounds). The $1,000 conjecture is derived conditionally from the Maier–Pomerance axiom; four deep results are axiomatized (the Y(x)=g(primorial(x))−1 equivalence, Iwaniec's upper bound, the FGKMT lower bound, and the Maier–Pomerance conjecture).",
     "implications": "Determining Y(x) would resolve fundamental questions about the distribution of primes in arithmetic progressions, the efficiency of sieve methods, and the structure of smooth numbers. The gap between x² and x · polylog(x) represents one of the largest open gaps in analytic number theory.",
     "openQuestions": [
       "Is Y(x) = o(x²)? ($1,000 prize) — even improving Iwaniec's x² to x^{2-δ} for any δ > 0 would be a breakthrough",
@@ -191,7 +191,7 @@
     "lineCount": 547,
     "axiomCount": 4,
     "theoremCount": 26,
-    "definitionCount": 5,
+    "definitionCount": 4,
     "path": "Proofs/Erdos687Problem.lean",
     "sorries": 0
   },


### PR DESCRIPTION
## Integrity Issue

**Proof**: erdos-687 (Covering Congruences and the Jacobsthal Function, \$1,000 prize, OPEN)
**Problem**: Prose overstates the axiomatized-result count and names a phantom axiom.

## Evidence

The Lean file `Proofs/Erdos687Problem.lean` has exactly **4 axioms**:
`jacobsthalY_eq_jacobsthal_sub_one`, `iwaniec_upper`, `fgkmt_lower`, `maier_pomerance_conjecture`.
The \$1,000 conjecture `erdos_687_conjecture` is a **proved theorem** (derived conditionally
from the Maier–Pomerance axiom), not an axiom.

- **conclusion.summary** claimed *"five deep results are axiomatized"* → only 4 axioms exist.
- **proofStrategy** listed *"The \$1,000 conjecture … axiomatized"* and omitted the equivalence
  axiom — doubly inaccurate and self-contradictory with the `assumptions` field.
- **assumptions** named axiom `jacobsthalY_eq_jacobsthal` → actual decl is
  `jacobsthalY_eq_jacobsthal_sub_one` (phantom name).
- **definitionCount: 5** → only 4 defs exist (`IsCovered`, `jacobsthalSet`, `jacobsthalY`, `jacobsthal`).

## Fix

meta.json only (no Lean source changes): corrected axiomatized count to 4, clarified the
\$1,000 conjecture is conditionally derived (not axiomatized), fixed the axiom name, and
set definitionCount 4. `axiomCount: 4` and `sorries: 0` were already accurate.

---
Discovered during gallery integrity audit.