### PR TITLE
Research: erdos-1064-oq-03 — close elementary prime obstruction (seedE p ≥ 2 ⟹ strict .gt)

### DIFF
--- a/proofs/Proofs/EulerTotientOQ04OQ03.lean
+++ b/proofs/Proofs/EulerTotientOQ04OQ03.lean
@@ -2185,6 +2185,126 @@ theorem prime_three_mod_four_family_not_reversal
   exact classifySeed_prime_three_mod_four_ne_lt hp hp3
 
 -- ---------------------------------------------------------------------------
+-- CLOSING THE PRIME OBSTRUCTION:  seedE p ≥ 2  ⟹  classifySeed p = .gt
+-- ---------------------------------------------------------------------------
+-- `classifySeed_prime_three_mod_four_gt_of_seedE` reduced the excluded-prime
+-- forward regime to the single arithmetic fact `2 ≤ seedE p` (the odd part of
+-- the second landing constant `C = seedC p`).  We now prove that fact outright
+-- for every prime `p ≡ 3 (mod 4)`, `p ≥ 7`, discharging the obstruction the
+-- engine's docstring flagged as the last open elementary step.
+--
+-- Arithmetic.  Write `p + 1 = w·2^S` (`w` odd, `S = v₂(p+1) ≥ 2`).  Then
+-- `seedS p = S`, `seedB p = w`, and with `d = 2^{S−2}`, `A = w·d`, `B = φ(w)·d`,
+--   `p + 1 = 4A`,   `seedC p = 2p − 2B = 2·(4A − B − 1)`.
+-- The bracket `e = 4A − B − 1` is ODD — it is `even − 1`, because `2 ∣ B`:
+--   `S ≥ 3`  gives `2 ∣ 2^{S−2} = d ∣ B`;  `S = 2` forces `w ≥ 3` (else
+--   `p + 1 = 4`, i.e. `p = 3 < 7`), so `2 ∣ φ(w) = B`.  And `e ≥ 3A − 1 ≥ 2`.
+-- Hence `seedC p = e·2^1` with `e` odd, so `seedT p = 1` and `seedE p = e ≥ 2`.
+-- ---------------------------------------------------------------------------
+
+/-- **The odd part of the second landing constant is nontrivial for `p ≥ 7`.**
+    For a prime `p ≡ 3 (mod 4)` with `p ≥ 7`, `2 ≤ seedE p`.  Writing
+    `p + 1 = w·2^S` (`w` odd, `S = v₂(p+1) ≥ 2`) and `d = 2^{S−2}`, the landing
+    constant factors as `seedC p = 2·((4w − φ(w))·d − 1)` whose bracket is odd
+    (an `even − 1`, using `2 ∣ φ(w)` when `w ≥ 3` and `2 ∣ 2^{S−2}` when
+    `S ≥ 3`) and `≥ 2`; hence `seedT p = 1` and `seedE p = (4w − φ(w))·d − 1`.
+    The single degenerate exclusion `S = 2 ∧ w = 1` is exactly `p = 3`, ruled
+    out by `p ≥ 7`.  This discharges the sole arithmetic obstruction isolated by
+    `classifySeed_prime_three_mod_four_gt_of_seedE`. -/
+theorem seedE_prime_three_mod_four_ge_two
+    {p : ℕ} (hp : p.Prime) (hp3 : p % 4 = 3) (hp7 : 7 ≤ p) :
+    2 ≤ seedE p := by
+  have hp3' : 3 ≤ p := by omega
+  have hφp : Nat.totient p = p - 1 := Nat.totient_prime hp
+  -- 2-adic decomposition of `p + 1`:  `p + 1 = w·2^S`, `w` odd, `S ≥ 2`
+  obtain ⟨S, w, hwodd, hS2, hpw⟩ :
+      ∃ S w, Odd w ∧ 2 ≤ S ∧ p + 1 = w * 2 ^ S := by
+    have hp1ne : p + 1 ≠ 0 := by omega
+    refine ⟨(p + 1).factorization 2, (p + 1) / 2 ^ ((p + 1).factorization 2), ?_, ?_, ?_⟩
+    · have hnd : ¬ (2 : ℕ) ∣ (p + 1) / 2 ^ ((p + 1).factorization 2) :=
+        Nat.not_dvd_ordCompl Nat.prime_two hp1ne
+      exact Nat.odd_iff.mpr (by omega)
+    · have h4 : (2 : ℕ) ^ 2 ∣ p + 1 := by
+        rw [show (2 : ℕ) ^ 2 = 4 from by norm_num]; omega
+      exact (Nat.Prime.pow_dvd_iff_le_factorization Nat.prime_two hp1ne).mp h4
+    · rw [mul_comm]; exact (Nat.ordProj_mul_ordCompl_eq_self (p + 1) 2).symm
+  -- `seedS p = S`, `seedB p = w`
+  have hEq : 2 * p - Nat.totient p = w * 2 ^ S := by rw [hφp]; omega
+  have hSval : seedS p = S := by unfold seedS; exact (factor_two_split hwodd hEq).1
+  have hBval : seedB p = w := by unfold seedB seedS; exact (factor_two_split hwodd hEq).2
+  -- power identities in terms of `d = 2^(S-2)`
+  have h2S : (2 : ℕ) ^ S = 4 * 2 ^ (S - 2) := by
+    conv_lhs => rw [show S = (S - 2) + 2 from by omega, pow_add]
+    ring
+  have h2S1 : (2 : ℕ) ^ (S - 1) = 2 * 2 ^ (S - 2) := by
+    conv_lhs => rw [show S - 1 = (S - 2) + 1 from by omega, pow_succ]
+    ring
+  set d := (2 : ℕ) ^ (S - 2) with hd
+  have hdpos : 0 < d := by rw [hd]; exact pow_pos (by norm_num) _
+  have hwpos : 0 < w := by rcases hwodd with ⟨i, hi⟩; omega
+  set A := w * d with hAdef
+  set B := Nat.totient w * d with hBdef
+  have hA1 : 1 ≤ A := by
+    rw [hAdef]; exact Nat.one_le_iff_ne_zero.mpr (Nat.mul_ne_zero hwpos.ne' hdpos.ne')
+  have hBle : B ≤ A := by
+    rw [hBdef, hAdef]; exact Nat.mul_le_mul (Nat.totient_le w) (le_refl d)
+  -- `p + 1 = 4A`  and  `seedC p = 2p − 2B`
+  have hA : p + 1 = 4 * A := by rw [hAdef, hpw, h2S]; ring
+  have hφB : Nat.totient w * 2 ^ (S - 1) = 2 * B := by rw [hBdef, h2S1]; ring
+  have hCdef2 : seedC p = 2 * p - 2 * B := by unfold seedC; rw [hBval, hSval, hφB]
+  -- factorisation `seedC p = e · 2^1` with odd part `e = 4A − B − 1`
+  have hSC : seedC p = (4 * A - B - 1) * 2 ^ 1 := by rw [hCdef2, pow_one]; omega
+  -- `2 ∣ B` in both regimes (`S = 2` forces `w ≥ 3 ⇒ 2∣φ(w)`; `S ≥ 3 ⇒ 2∣2^{S-2}`)
+  have hBeven : 2 ∣ B := by
+    rcases Nat.lt_or_ge S 3 with hS3 | hS3
+    · have hSeq : S = 2 := by omega
+      have hw3 : 3 ≤ w := by
+        have h4w : p + 1 = w * 4 := by rw [hpw, hSeq]; norm_num
+        rcases hwodd with ⟨i, hi⟩; omega
+      have hev : Even (Nat.totient w) := Nat.totient_even (by omega)
+      have hBeq : B = Nat.totient w := by rw [hBdef, hd, hSeq]; norm_num
+      rw [hBeq]; exact hev.two_dvd
+    · have hdd : (2 : ℕ) ∣ d := by rw [hd]; exact dvd_pow_self 2 (by omega)
+      rw [hBdef]; exact hdd.mul_left _
+  have hodd_e : Odd (4 * A - B - 1) := by rw [Nat.odd_iff]; omega
+  have hEval : seedE p = 4 * A - B - 1 := by
+    unfold seedE seedT; exact (factor_two_split hodd_e hSC).2
+  rw [hEval]; omega
+
+/-- **Every prime `p ≡ 3 (mod 4)` with `p ≥ 7` is strictly forward.**  Combining
+    the reduction `classifySeed_prime_three_mod_four_gt_of_seedE` (which needs
+    only `2 ≤ seedE p`) with the arithmetic core
+    `seedE_prime_three_mod_four_ge_two`, the classifier is exactly `.gt`: the
+    whole family `p·2^{k+1}` lies in the forward regime `φ(n) > φ(D(n))`. -/
+theorem classifySeed_prime_three_mod_four_gt
+    {p : ℕ} (hp : p.Prime) (hp3 : p % 4 = 3) (hp7 : 7 ≤ p) :
+    classifySeed p = Ordering.gt :=
+  classifySeed_prime_three_mod_four_gt_of_seedE hp hp3
+    (seedE_prime_three_mod_four_ge_two hp hp3 hp7)
+
+/-- **Exact prime-seed trichotomy in the excluded regime.**  For every prime
+    `p ≡ 3 (mod 4)` the family `p·2^{k+1}` is `.eq` exactly when `p = 3` (there
+    `seedE 3 = 1`, cf. `classifySeed_3`) and `.gt` for every `p ≥ 7` (there
+    `seedE p ≥ 2`); it is never `.lt`.  This sharpens the non-reversal statement
+    `classifySeed_prime_three_mod_four_ne_lt` (which only excluded `.lt`) to the
+    precise regime of each excluded prime, closing the elementary obstruction
+    that theorem's docstring isolated. -/
+theorem classifySeed_prime_three_mod_four_eq_or_gt
+    {p : ℕ} (hp : p.Prime) (hp3 : p % 4 = 3) :
+    (p = 3 ∧ classifySeed p = Ordering.eq) ∨
+    (7 ≤ p ∧ classifySeed p = Ordering.gt) := by
+  by_cases h3 : p = 3
+  · exact Or.inl ⟨h3, by subst h3; exact classifySeed_3⟩
+  · have hp7 : 7 ≤ p := by
+      have h2 := hp.two_le
+      by_contra h7
+      push_neg at h7
+      interval_cases p <;> first
+        | exact absurd hp (by decide)
+        | omega
+    exact Or.inr ⟨hp7, classifySeed_prime_three_mod_four_gt hp hp3 hp7⟩
+
+-- ---------------------------------------------------------------------------
 -- THE FULL EXCLUDED PRIME-POWER FAMILY:  a = p^k,  p ≡ 3 (mod 4)
 -- ---------------------------------------------------------------------------
 -- The engine `classifySeed_ne_lt_of_excess_bound` reduced non-reversal of an

--- a/research/problems/erdos-1064-oq-03/knowledge.md
+++ b/research/problems/erdos-1064-oq-03/knowledge.md
@@ -672,3 +672,45 @@ from any worktree w/ prebuilt mathlib oleans, exit 0. External worktree /Users/r
 
 REMAINING (unchanged): elementary/structural side COMPLETE. Sole open direction = analytic
 density-1 forward ψ(x,y) smooth-number statement (genuine Mathlib gap, not session-sized).
+
+## Session 2026-07-20 (researcher-1) — CLOSED the elementary prime obstruction (seedE p ≥ 2)
+
+**Mode**: REVISIT (RICH tier) | **Outcome**: progress (VERIFIED 0 sorry / 0 axiom,
+host-lean v4.31.0 `[propext, Classical.choice, Quot.sound]`, no native_decide).
+
+### What I did
+The engine `classifySeed_prime_three_mod_four_gt_of_seedE` (added 2026-07-12) had
+reduced "every excluded prime `p ≡ 3 mod4`, `p ≥ 7` is strictly forward (`.gt`)"
+to the SINGLE arithmetic fact `2 ≤ seedE p`, flagged in that theorem's docstring
+as the exact remaining elementary obstruction. **Proved it outright**, so the
+prime-seed forward regime is now fully closed and sharp.
+
+### Mechanism (elementary — no analytic input)
+Write `p + 1 = w·2^S` (`w` odd, `S = v₂(p+1) ≥ 2`). Then `seedS p = S`,
+`seedB p = w`, and with `d = 2^{S−2}`, `A = w·d`, `B = φ(w)·d`:
+- `p + 1 = 4A`, so `seedC p = 2p − φ(w)·2^{S−1} = 2p − 2B = 2·(4A − B − 1)`.
+- The bracket `e = 4A − B − 1` is **odd** (an `even − 1`): `2 ∣ B` because
+  `S ≥ 3 ⇒ 2 ∣ 2^{S−2} = d ∣ B`, and `S = 2 ⇒ w ≥ 3` (else `p+1 = 4`, i.e.
+  `p = 3 < 7`) so `2 ∣ φ(w) = B`. And `e ≥ 3A − 1 ≥ 2`.
+- Hence `seedC p = e·2^1` with `e` odd ⟹ `seedT p = 1`, `seedE p = e ≥ 2`.
+The single degenerate exclusion `S = 2 ∧ w = 1` is exactly `p = 3` (`seedE 3 = 1`,
+the `.eq` case).
+
+### New declarations (all VERIFIED 0/0)
+- `seedE_prime_three_mod_four_ge_two` — `2 ≤ seedE p` for prime `p≡3 mod4`, `p≥7`.
+- `classifySeed_prime_three_mod_four_gt` — such `p` is strictly `.gt`.
+- `classifySeed_prime_three_mod_four_eq_or_gt` — exact prime trichotomy:
+  `p = 3 ⟹ .eq`, `p ≥ 7 ⟹ .gt` (never `.lt`).
+
+### Files Modified
+- `proofs/Proofs/EulerTotientOQ04OQ03.lean` (+3 theorems, ~95 lines, after
+  `prime_three_mod_four_family_not_reversal`)
+- `research/problems/erdos-1064-oq-03/knowledge.md`, tracker json
+
+### Honesty / remaining
+Genuine sharpening of the structural side: upgrades `_ne_lt` (rules out `.lt`) to
+the exact regime for every excluded prime. Does NOT touch the sole open terminus
+— the analytic density-1 forward `ψ(x,y)` smooth-number statement (Luca–Pomerance;
+genuine Mathlib gap, not session-sized). Optional elementary follow-up: extend
+`seedE ≥ 2` from prime seeds `p` to prime powers `p^k` (would strengthen
+`classifySeed_prime_pow_three_mod_four_ne_lt` to strict `.gt`).

--- a/src/data/research/problems/erdos-1064-oq-03.json
+++ b/src/data/research/problems/erdos-1064-oq-03.json
@@ -4,7 +4,7 @@
   "phase": "ACT",
   "status": "in-progress",
   "started": "2026-07-08T00:00:00.000Z",
-  "lastUpdate": "2026-07-11",
+  "lastUpdate": "2026-07-20",
   "path": "full",
   "parentId": "erdos-1064",
   "tier": "B",
@@ -35,7 +35,7 @@
     }
   ],
   "knowledge": {
-    "progressSummary": "PROGRESS: Structural side COMPLETE/VERIFIED (0/0). §7 added the symbolic-landing MASTER form of the prime-triple reversal family (previously only the forward family had one), yielding the sharp reversal criterion 12m<φ(14m+3) and a concrete non-reversing prime-triple-shape witness (seed 57). Only remaining open direction: density-1 forward statement (Luca–Pomerance), not session-sized.",
+    "progressSummary": "PROGRESS: Closed the elementary prime obstruction. Every prime p≡3 mod4, p≥7 now proven strictly forward (classifySeed=.gt), not just ≠.lt — exact prime trichotomy p=3→.eq / p≥7→.gt. Structural side (excluded regime) fully closed AND now sharp on primes. Sole remaining terminus = analytic density-1 forward ψ(x,y) smooth-number statement (genuine Mathlib gap, not session-sized).",
     "builtItems": [
       "dblIter (EulerTotientOQ04OQ03.lean) — the double cototient iterate D(n) = n − φ(n − φ(n)), the object of OQ-03.",
       "dblIter_prime — collapse lemma: for EVERY prime p, D(p) = p − 1 exactly (φ(p)=p−1 ⟹ p−φ(p)=1 ⟹ φ(1)=1 ⟹ D(p)=p−1).",
@@ -119,7 +119,8 @@
       "classifySeed_eq_compare_of_seedS_one_seedE_primePow in EulerTotientOQ04OQ03.lean (prime-power-landing trichotomy criterion)",
       "classifySeed_{lt,eq,gt}_iff_of_seedS_one_seedE_primePow + primePow_landing_family_reversal",
       "Witnesses: totient_401/361/561, classifySeed_561, seedE_561 (=19²), seedE_561_not_prime, mem_ReversalSet_561, reversal_seed_primePow_landing",
-      "primeTriple_totient_values / reversal_gap_primeTriple_eq_totient / reversal_gap_primeTriple_pow_dvd / reversal_primeTriple_iff_totient_landing / reversal_gap_primeTriple_of_prime_landing / primeTriple_shape_not_reversal_57 (EulerTotientOQ04OQ03.lean, after reversal_gap_primeTriple_ge ~L3326): symbolic-landing master form of the prime-triple reversal family (reversal mirror of forward_gap_fiveTimes_eq_totient), giving the exact reversal criterion 12m<φ(14m+3) and a concrete non-reversing prime-triple-shape witness (seed 57). All 6 theorems 0-axiom/0-sorry, host-lean v4.26.0 verified (docker still SIGBUS-135)."
+      "primeTriple_totient_values / reversal_gap_primeTriple_eq_totient / reversal_gap_primeTriple_pow_dvd / reversal_primeTriple_iff_totient_landing / reversal_gap_primeTriple_of_prime_landing / primeTriple_shape_not_reversal_57 (EulerTotientOQ04OQ03.lean, after reversal_gap_primeTriple_ge ~L3326): symbolic-landing master form of the prime-triple reversal family (reversal mirror of forward_gap_fiveTimes_eq_totient), giving the exact reversal criterion 12m<φ(14m+3) and a concrete non-reversing prime-triple-shape witness (seed 57). All 6 theorems 0-axiom/0-sorry, host-lean v4.26.0 verified (docker still SIGBUS-135).",
+      "seedE_prime_three_mod_four_ge_two / classifySeed_prime_three_mod_four_gt / classifySeed_prime_three_mod_four_eq_or_gt (EulerTotientOQ04OQ03.lean, after prime_three_mod_four_family_not_reversal ~L2187): CLOSES the elementary prime obstruction. Proves 2 ≤ seedE p for every prime p≡3 mod4, p≥7 (odd part of landing constant C = 2·((4w−φ(w))·2^{S−2}−1) is odd via 2∣φ(w) [w≥3] or 2∣2^{S−2} [S≥3], and ≥2), upgrading classifySeed_prime_three_mod_four_ne_lt to the exact regime: p=3⟹.eq, p≥7⟹.gt. All 3 theorems VERIFIED 0-axiom/0-sorry (propext/Classical.choice/Quot.sound), host-lean v4.31.0."
     ],
     "insights": [
       "On primes the higher iterate is trivial: D(p) = p − 1 for all primes p, because the first cototient step p − φ(p) = 1 and φ(1) = 1. So φ(D(p)) = φ(p−1), and φ(p−1) < p−1 = φ(p) for every p ≥ 3 (with equality only at p = 2). This gives the forward direction on an infinite explicit family with a one-line reduction to Nat.totient_lt — no density machinery needed.",
@@ -163,7 +164,8 @@
       "Reversal seeds with PROPER prime-power landings exist and were uncovered by prior engines: a=561 (landing 19²=361), a=1225 (31²), a=1595 (11³). Enumeration a<4000: 154 reversal seeds = 72 prime / 79 general-composite / 3 proper-prime-power landings.",
       "a=561 (smallest Carmichael number) reverses its whole family 561·2^(k+1): b=401 prime, landing e=361=19²; certified by prime-power engine via φ(401)+19·2=438 < 482=2·(561-320).",
       "Lean/omega gotcha: keep the totient identity LINEAR as φ(e)=e-p^(m-1) (not p^(m-1)·(p-1)); clear the nonlinear seedE a=p^(m-1)·p / =p^m facts before the classifier trichotomy so omega keeps seedE a·2^{…} as opaque atoms.",
-      "§7 (researcher-7, 2026-07-12): the prime-triple REVERSAL family 18m+3 = 3·(6m+1) now has the symbolic-landing MASTER form that the forward family already had (forward_gap_fiveTimes_eq_totient). primeTriple_totient_values proves φ(n)=12m·2^k and φ(D(n))=φ(14m+3)·2^k needing only 4m+1,6m+1 prime — NOT the landing 14m+3. Consequences: reversal_gap_primeTriple_eq_totient (signed gap (φ(14m+3)−12m)·2^k via Nat.sub_mul, sign-free), reversal_gap_primeTriple_pow_dvd (2^k | gap unconditionally on landing), and the sharp criterion reversal_primeTriple_iff_totient_landing: the WHOLE family reverses ⟺ 12m<φ(14m+3), k-freely. Landing primality (φ=14m+2>12m) forces reversal (recovers reversal_gap_primeTriple); a composite landing with φ(14m+3)≤12m does NOT reverse — concretely primeTriple_shape_not_reversal_57 (m=3, seed 57, landing 45=3²·5, φ(45)=24<36) shows the identical seed SHAPE that reverses at m=1 (a=21) fails at m=3."
+      "§7 (researcher-7, 2026-07-12): the prime-triple REVERSAL family 18m+3 = 3·(6m+1) now has the symbolic-landing MASTER form that the forward family already had (forward_gap_fiveTimes_eq_totient). primeTriple_totient_values proves φ(n)=12m·2^k and φ(D(n))=φ(14m+3)·2^k needing only 4m+1,6m+1 prime — NOT the landing 14m+3. Consequences: reversal_gap_primeTriple_eq_totient (signed gap (φ(14m+3)−12m)·2^k via Nat.sub_mul, sign-free), reversal_gap_primeTriple_pow_dvd (2^k | gap unconditionally on landing), and the sharp criterion reversal_primeTriple_iff_totient_landing: the WHOLE family reverses ⟺ 12m<φ(14m+3), k-freely. Landing primality (φ=14m+2>12m) forces reversal (recovers reversal_gap_primeTriple); a composite landing with φ(14m+3)≤12m does NOT reverse — concretely primeTriple_shape_not_reversal_57 (m=3, seed 57, landing 45=3²·5, φ(45)=24<36) shows the identical seed SHAPE that reverses at m=1 (a=21) fails at m=3.",
+      "The obstruction seedE p ≥ 2 (isolated 2026-07-12) is TRUE and elementary: writing p+1=w·2^S, seedC p = 2·Q with Q=(4w−φ(w))·2^{S−2}−1 forced ODD, so seedT p=1 and seedE p=Q≥3. Degenerate S=2∧w=1 is exactly p=3 (seedE=1). No analytic input needed — the prime-seed forward regime is now fully elementary."
     ],
     "mathlibGaps": [
       "Kernel `decide` on Nat.totient of a seed (e.g. totient 21) blows the stack → SIGBUS (Lean exit 135, line-less); must prove totient values by factorisation (Nat.totient_mul + Nat.totient_prime). Reconfirms the file's existing note."
@@ -176,7 +178,9 @@
       "Elementary follow-up: is the reversal gap the LARGEST among transport-admissible (seedS=1) reversal seeds at fixed a-size, or can a 5q/other-shape seed reverse by a wider margin? Compare (2m+2)*2^k against the general classifier margin phi(seedE a)*2^(seedT a-1) - phi(a).",
       "Do OTHER shared landings occur? Characterise all seed pairs (a1,a2) with 2a1-φ(b1)=2a2-φ(b2) so D(a1·2^(k+1))=D(a2·2^(k+1)); the 3q/5q pair 18m+3,20m+5 is one infinite family. A shared landing whose two seeds hit the reversal and EQUALITY regimes (or all three) would be the sharpest landing-independence statement.",
       "Is the three-way shared landing infinite / does a PARAMETRIC family of triples exist (like 18m+3,20m+5 for the two-way)? Equality seed on the landing L needs φ(seed)=φ(L) with matching transport — a hard Diophantine constraint (e.g. landing 14m+3 forces 7(7m+1)(m−1) a perfect square), so no obvious infinite family; L=917 found only by search.",
-      "ENV: docker-build broken (code 135 SIGBUS on pristine file AND minimal Mathlib import) — verify new work via host elan lean v4.26.0 + project Mathlib LEAN_PATH on a self-contained copy until docker recovers."
+      "ENV: docker-build broken (code 135 SIGBUS on pristine file AND minimal Mathlib import) — verify new work via host elan lean v4.26.0 + project Mathlib LEAN_PATH on a self-contained copy until docker recovers.",
+      "Analytic density-1 forward direction (ψ(x,y) smooth-number density / Luca–Pomerance) — hard analytic terminus, genuine Mathlib gap, NOT session-sized. Do not reclaim for elementary work.",
+      "OPTIONAL: extend seedE≥2 from prime seeds p to full prime powers p^k (would upgrade classifySeed_prime_pow_three_mod_four_ne_lt to strict .gt, mirroring this session for primes)."
     ]
   },
   "relatedProofs": [


### PR DESCRIPTION
## Summary

Closes the **exact elementary obstruction** that `classifySeed_prime_three_mod_four_gt_of_seedE` isolated (2026-07-12): proving `2 ≤ seedE p` for every prime `p ≡ 3 (mod 4)` with `p ≥ 7`. This upgrades the non-reversal result `classifySeed_prime_three_mod_four_ne_lt` (only ruled out `.lt`) to the **exact regime** of each excluded prime:

| seed | classifier |
|------|-----------|
| `p = 3` | `.eq`  (`seedE 3 = 1`) |
| `p ≥ 7`, `p ≡ 3 mod 4` | `.gt`  (`seedE p ≥ 2`) |

The family `p·2^{k+1}` is therefore strictly forward (`φ(n) > φ(D(n))`) for every such `p ≥ 7`.

## Mechanism (elementary — no analytic input)

Write `p + 1 = w·2^S` (`w` odd, `S = v₂(p+1) ≥ 2`). With `d = 2^{S−2}`, `A = w·d`, `B = φ(w)·d`:
- `p + 1 = 4A`, so `seedC p = 2p − φ(w)·2^{S−1} = 2p − 2B = 2·(4A − B − 1)`.
- The bracket `e = 4A − B − 1` is **odd** (an `even − 1`): `2 ∣ B` because `S ≥ 3 ⇒ 2 ∣ 2^{S−2}`, and `S = 2 ⇒ w ≥ 3` (else `p+1 = 4`, i.e. `p = 3 < 7`) so `2 ∣ φ(w)`. And `e ≥ 3A − 1 ≥ 2`.
- Hence `seedC p = e·2^1` with `e` odd ⟹ `seedT p = 1`, `seedE p = e ≥ 2`.

The single degenerate exclusion `S = 2 ∧ w = 1` is exactly `p = 3`.

## New theorems (all VERIFIED 0-axiom / 0-sorry)

- `seedE_prime_three_mod_four_ge_two`
- `classifySeed_prime_three_mod_four_gt`
- `classifySeed_prime_three_mod_four_eq_or_gt`

## Verification

`./bin/lake env lean Proofs/EulerTotientOQ04OQ03.lean` (host, toolchain v4.31.0) — **exit 0**, no errors, only pre-existing deprecation warnings. `#print axioms` for all three new theorems = `[propext, Classical.choice, Quot.sound]` (no `sorryAx`, no `native_decide`/`ofReduceBool`).

## Scope

Sharpens the **structural** side only. The sole remaining open terminus is unchanged: the analytic density-1 forward `ψ(x,y)` smooth-number statement (Luca–Pomerance; genuine Mathlib gap, not session-sized). Optional elementary follow-up noted in the tracker: extend `seedE ≥ 2` from prime seeds `p` to prime powers `p^k`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)