### PR TITLE
Fix: erdos-184 stale lineCount 242→253 + section ranges (#38611)

### DIFF
--- a/src/data/proofs/erdos-184/meta.json
+++ b/src/data/proofs/erdos-184/meta.json
@@ -56,7 +56,7 @@
       "Lower bound from bipartite graph K_{3,n-3}"
     ],
     "axiomCount": 5,
-    "lineCount": 242,
+    "lineCount": 253,
     "assumptions": "5 axioms: decompNumber, lower_bound_from_bipartite, bucic_montgomery_bound, conlon_fox_sudakov, coverNumber. 0 sorries.",
     "theoremCount": 2,
     "definitionCount": 10
@@ -74,63 +74,63 @@
       "id": "imports",
       "title": "Imports and Setup",
       "startLine": 33,
-      "endLine": 42,
+      "endLine": 44,
       "summary": "Imports Mathlib's `SimpleGraph`, `Subgraph`, `Finset`, and `Real.log` modules. Opens `Finset` namespace.",
       "mathContext": "Mathematical content: Imports Mathlib's `SimpleGraph`, `Subgraph`, `Finset`, and `Real.log` modules. Opens `Finset` namespace."
     },
     {
       "id": "basic-definitions",
       "title": "Basic Definitions",
-      "startLine": 43,
-      "endLine": 81,
+      "startLine": 45,
+      "endLine": 83,
       "summary": "Defines `Graph V` (alias for `SimpleGraph V`), `numVertices`, `Cycle G` (structure with $\\geq 3$ distinct adjacent vertices in cyclic order), and `SingleEdge G` (pair with adjacency proof).",
       "mathContext": "Formal definition: Defines `Graph V` (alias for `SimpleGraph V`), `numVertices`, `Cycle G` (structure with $\\geq 3$ distinct adjacent vertices in cyclic order), and `SingleEdge G` (pair with adjacency proof)."
     },
     {
       "id": "decomposition",
       "title": "Decomposition Framework",
-      "startLine": 82,
-      "endLine": 120,
+      "startLine": 84,
+      "endLine": 122,
       "summary": "Defines `DecompPiece G` (sum type: cycle or edge), `edgesOfPiece` (extracts edge set via `Sym2 V`), `IsValidDecomposition` (edge coverage + disjointness), and `decompNumber G` (axiomatized minimum piece count).",
       "mathContext": "Defines `DecompPiece G` (sum type: cycle or edge), `edgesOfPiece` (extracts edge set via `Sym2 V`), `IsValidDecomposition` (edge coverage + disjointness), and `decompNumber G` (axiomatized minimum piece count)."
     },
     {
       "id": "conjecture",
       "title": "The Erdős–Gallai Conjecture",
-      "startLine": 121,
-      "endLine": 132,
+      "startLine": 123,
+      "endLine": 134,
       "summary": "States the conjecture as a `Prop`: $\\exists C > 0$ such that $\\text{dec}(G) \\leq C \\cdot n$ for all $G$ on $n$ vertices.",
       "mathContext": "Mathematical content: States the conjecture as a `Prop`: $\\exists C > 0$ such that $\\text{dec}(G) \\leq C \\cdot n$ for all $G$ on $n$ vertices."
     },
     {
       "id": "known-bounds",
       "title": "Known Upper and Lower Bounds",
-      "startLine": 133,
-      "endLine": 173,
+      "startLine": 135,
+      "endLine": 182,
       "summary": "Axiomatizes two bounds: the $(1+c)n$ lower bound from $K_{3,n-3}$ and Bucić–Montgomery's $O(n \\log^* n)$. The original Erdős–Gallai $O(n \\log n)$ bound is mentioned in a docstring but not formally axiomatized. Defines the iterated logarithm `logStar`.",
       "mathContext": "Axiomatizes two bounds: the $(1+c)n$ lower bound from $K_{3,n-3}$ and Bucić–Montgomery's $$O(n \\log^* n)$$. The original Erdős–Gallai $$O(n \\log n)$$ bound is mentioned in a docstring but not formally axiomatized. Defines the iterated logarithm `logStar`."
     },
     {
       "id": "dense-graphs",
       "title": "Dense Graph Result",
-      "startLine": 174,
-      "endLine": 193,
+      "startLine": 183,
+      "endLine": 204,
       "summary": "Defines `minDegree G` and axiomatizes Conlon–Fox–Sudakov (2014): when $\\delta(G) \\geq \\varepsilon n$, $O(n)$ pieces suffice. The dense case is **fully resolved**.",
       "mathContext": "Defines `minDegree G` and axiomatizes Conlon–Fox–Sudakov (2014): when $\\$\\delta$(G) \\geq \\varepsilon n$, $$O(n)$$ pieces suffice. The dense case is **fully resolved**."
     },
     {
       "id": "non-disjoint",
       "title": "Non-Disjoint Covering",
-      "startLine": 194,
-      "endLine": 217,
+      "startLine": 205,
+      "endLine": 228,
       "summary": "Defines `IsValidCovering` (drops disjointness) and axiomatizes the `coverNumber` function symbol. Erdős's bound $\\text{cov}(G) \\leq n - 1$ is mentioned in a docstring but not formally axiomatized.",
       "mathContext": "Formal definition: Defines `IsValidCovering` (drops disjointness) and axiomatizes the `coverNumber` function symbol. Erdős's bound $$\\text{cov}(G) \\leq n - 1$$ is mentioned in a docstring but not formally axiomatized."
     },
     {
       "id": "summary",
       "title": "Summary and Verification",
-      "startLine": 218,
-      "endLine": 242,
+      "startLine": 229,
+      "endLine": 253,
       "summary": "Combines all three bounds into `erdos_184_summary`. Computationally verifies $\\log^*(65536) = 4$ and $\\log^*(4) = 2$ via `native_decide`.",
       "mathContext": "Bound: Combines all three bounds into `erdos_184_summary`. Computationally verifies $\\log^*(65536) = 4$ and $\\log^*(4) = 2$ via `native_decide`."
     }
@@ -174,7 +174,7 @@
       "Finset"
     ],
     "namespace": "Erdos184",
-    "lineCount": 242,
+    "lineCount": 253,
     "axiomCount": 5,
     "theoremCount": 2,
     "definitionCount": 10,


### PR DESCRIPTION
## Problem

The v4.31 toolchain flip (#39062) edited `proofs/Proofs/Erdos184Problem.lean`, growing it from **242 → 253 lines** (16 insertions, 5 deletions across 4 hunks). The post-flip meta sweep (#39063) updated `mathlib_version` but never corrected the gallery `lineCount` or the section line ranges, leaving `src/data/proofs/erdos-184/meta.json` stale.

## Evidence

```
$ git show 98630041ef^:proofs/Proofs/Erdos184Problem.lean | wc -l   # 242 (pre-flip)
$ wc -l proofs/Proofs/Erdos184Problem.lean                          # 253 (current)
```

Section boundary anchors were re-located in the current source (content-matched, not arithmetic) and remapped:

| Section | before | after |
|---|---|---|
| Problem Statement | 1–32 | 1–32 |
| Imports and Setup | 33–42 | 33–44 |
| Basic Definitions | 43–81 | 45–83 |
| Decomposition Framework | 82–120 | 84–122 |
| Erdős–Gallai Conjecture | 121–132 | 123–134 |
| Known Upper and Lower Bounds | 133–173 | 135–182 |
| Dense Graph Result | 174–193 | 183–204 |
| Non-Disjoint Covering | 194–217 | 205–228 |
| Summary and Verification | 218–242 | 229–253 |

Cumulative shifts (+2, +2, +2, +2, +9, +11, +11, +11) match the four flip hunks (+2 imports, +7 logStar, +2 bucic bound).

## What is NOT changed

`axiomCount` (5), `theoremCount` (2), `definitionCount` (10), `sorries` (0) all remain accurate — the flip changed no declarations (18 decl lines before and after). Status/badge (`axiomatized`/`axiom`) untouched.

## Separate observation (out of scope, for auditor)

`key_insight_log_star` (line 251) is proved with `native_decide`, which pulls in `Lean.ofReduceBool`. The `assumptions` field discloses the 5 named axioms but not `ofReduceBool`. That is a distinct integrity question and is intentionally left for the auditor rather than bundled here.

Closes the erdos-184 entry of the #38611 gallery re-audit.