### PR TITLE
Research: erdos-818 — axiom-free sumset lower bound + Solymosi energy reduction

### DIFF
--- a/proofs/Proofs/Erdos818Problem.lean
+++ b/proofs/Proofs/Erdos818Problem.lean
@@ -40,6 +40,7 @@ import Mathlib.Data.Real.Basic
 import Mathlib.Analysis.SpecialFunctions.Log.Basic
 import Mathlib.Analysis.SpecialFunctions.Pow.Real
 import Mathlib.Combinatorics.Additive.Energy
+import Mathlib.Combinatorics.Additive.CauchyDavenport
 
 open Finset Real
 open scoped Pointwise
@@ -104,6 +105,23 @@ theorem productSet_upper_bound (A : Finset ℤ) :
       ≤ (A ×ˢ A).card := Finset.card_image_le
     _ = A.card * A.card := Finset.card_product A A
     _ = A.card ^ 2 := by ring
+
+/-- `sumset A` is the pointwise sum `A + A`. -/
+theorem sumset_eq_add (A : Finset ℤ) : sumset A = A + A := by
+  rw [sumset, Finset.add_def]
+
+/--
+**Sumset lower bound (proved):** `2|A| - 1 ≤ |A + A|` for nonempty `A ⊆ ℤ`.
+
+This is the elementary lower bound quoted in Part II. It is the additive
+Cauchy–Davenport bound for linearly ordered cancellative additive monoids
+(`|A + B| ≥ |A| + |B| - 1`), specialized to `B = A` on `ℤ`, via Mathlib's
+`cauchy_davenport_add_of_linearOrder_isCancelAdd`. Axiom-free.
+-/
+theorem sumset_lower_bound (A : Finset ℤ) (hne : A.Nonempty) :
+    2 * A.card - 1 ≤ (sumset A).card := by
+  rw [sumset_eq_add, two_mul]
+  exact cauchy_davenport_add_of_linearOrder_isCancelAdd hne hne
 
 /-
 ## Part III: The Original Conjecture
@@ -221,6 +239,66 @@ theorem cauchy_schwarz_energy (A : Finset ℤ) :
   calc A.card ^ 4 = A.card ^ 2 * A.card ^ 2 := by ring
     _ ≤ (A * A).card * Finset.mulEnergy A A := Finset.le_card_mul_mul_mulEnergy A A
 
+/--
+**Solymosi reduction (proved, axiom-free modulo the stated energy hypothesis).**
+
+Solymosi's strategy combines two ingredients:
+* the Cauchy–Schwarz lower bound `|A|⁴ ≤ |A·A| · E×(A)` (proved above as
+  `cauchy_schwarz_energy`, axiom-free), and
+* the multiplicative-energy *upper* bound `E×(A) ≤ C · |A + A|² · log|A|`
+  (Solymosi's core inequality, not yet in Mathlib).
+
+Taking the second as an explicit hypothesis `hEnergy`, this lemma machine-checks
+the full reduction to the product-set bound
+`|A·A| ≥ |A|² / (C · K² · log|A|)` for any set with `|A + A| ≤ K·|A|`. It thereby
+isolates the genuine external input (`hEnergy`) *without* introducing a new
+axiom.
+
+**Honest constant note.** The standard argument delivers the denominator
+`C · K² · log|A|`, i.e. a `K²` dependence, not the `K` recorded in
+`proof_outline` below (see that theorem's docstring): substituting the sumset
+bound `|A + A| ≤ K·|A|` into `E×(A) ≤ C·|A+A|²·log|A|` costs the square. So this
+lemma is the faithful consequence of the energy inequality; `proof_outline`'s
+sharper `1/(K·log|A|)` form is a strictly stronger, still-open target. -/
+theorem product_lower_of_mult_energy
+    (A : Finset ℤ) (hA : A.card ≥ 2)
+    (K : ℝ) (hK : K > 0) (hsmall : hasSmallSumset A K)
+    (C : ℝ) (hC : C > 0)
+    (hEnergy : (multiplicativeEnergy A : ℝ)
+        ≤ C * ((sumset A).card : ℝ) ^ 2 * log A.card) :
+    ((productSet A).card : ℝ)
+        ≥ (A.card : ℝ) ^ 2 / (C * K ^ 2 * log A.card) := by
+  -- Positivity facts.
+  have hn2 : (2 : ℝ) ≤ (A.card : ℝ) := by exact_mod_cast hA
+  have hnpos : (0 : ℝ) < (A.card : ℝ) := by linarith
+  have hn2pos : (0 : ℝ) < (A.card : ℝ) ^ 2 := by positivity
+  have hLpos : (0 : ℝ) < log (A.card : ℝ) := Real.log_pos (by linarith)
+  have hSnn : (0 : ℝ) ≤ ((sumset A).card : ℝ) := by positivity
+  have hPnn : (0 : ℝ) ≤ ((productSet A).card : ℝ) := by positivity
+  have hM : (0 : ℝ) < C * K ^ 2 * log (A.card : ℝ) :=
+    mul_pos (mul_pos hC (by positivity)) hLpos
+  -- Square the small-sumset hypothesis: |A+A|² ≤ K²·|A|².
+  have hS2 : ((sumset A).card : ℝ) ^ 2 ≤ K ^ 2 * (A.card : ℝ) ^ 2 := by
+    nlinarith [mul_le_mul hsmall hsmall hSnn (mul_nonneg hK.le hnpos.le)]
+  -- Energy is controlled by K²·|A|²·log|A|.
+  have hE2 : (multiplicativeEnergy A : ℝ)
+      ≤ C * (K ^ 2 * (A.card : ℝ) ^ 2) * log (A.card : ℝ) := by
+    refine hEnergy.trans ?_
+    apply mul_le_mul_of_nonneg_right _ hLpos.le
+    exact mul_le_mul_of_nonneg_left hS2 hC.le
+  -- Cauchy–Schwarz lower bound, transported to ℝ.
+  have hcs : (A.card : ℝ) ^ 4
+      ≤ ((productSet A).card : ℝ) * (multiplicativeEnergy A : ℝ) := by
+    exact_mod_cast cauchy_schwarz_energy A
+  -- Combine: |A|⁴ ≤ |A·A| · C·K²·|A|²·log|A|.
+  have hchain : (A.card : ℝ) ^ 4
+      ≤ ((productSet A).card : ℝ)
+          * (C * (K ^ 2 * (A.card : ℝ) ^ 2) * log (A.card : ℝ)) :=
+    hcs.trans (mul_le_mul_of_nonneg_left hE2 hPnn)
+  -- Clear the denominator and cancel |A|².
+  rw [ge_iff_le, div_le_iff₀ hM]
+  nlinarith [hchain, hn2pos]
+
 /-
 **Solymosi's key lemma:**
 Bounds multiplicative energy in terms of sumset size.
@@ -252,7 +330,13 @@ Bounds multiplicative energy in terms of sumset size.
     `|A|⁴ ≤ |A·A|·E×(A)` — is now PROVED (`cauchy_schwarz_energy`, axiom-free,
     via Mathlib's `Finset.le_card_mul_mul_mulEnergy`). The remaining gap is
     therefore *exactly* Solymosi's multiplicative-energy upper bound
-    `E×(A) ≤ C·|A|²·|A+A|·log|A|`, which is not yet formalized in Mathlib. -/
+    `E×(A) ≤ C·|A+A|²·log|A|`, which is not yet formalized in Mathlib.
+
+    The reduction from that energy inequality to a product-set bound is now
+    machine-checked, axiom-free, as `product_lower_of_mult_energy` — but it
+    delivers the `1/(C·K²·log|A|)` form, since substituting `|A+A| ≤ K·|A|`
+    into the energy bound costs a factor of `K`. This theorem's sharper
+    `1/(K·log|A|)` denominator is a strictly stronger, still-open target. -/
 theorem proof_outline (A : Finset ℤ) (hA : A.card ≥ 2) (hne : A.Nonempty)
     (K : ℝ) (hK : K > 0) (hsmall : hasSmallSumset A K) :
     ((productSet A).card : ℝ) ≥

--- a/research/problems/erdos-818-incomplete-01/knowledge.md
+++ b/research/problems/erdos-818-incomplete-01/knowledge.md
@@ -1,0 +1,49 @@
+# Knowledge: Erdős 818 — Product Set Lower Bound for Small Sumsets (completion)
+
+## Session 2026-07-20 (researcher-1)
+
+Target file: `proofs/Proofs/Erdos818Problem.lean` (gallery entry `erdos-818`).
+Started at 1 axiom (`solymosi_theorem`) + 1 sorry (`proof_outline`).
+
+### What was added (axiom-free, host-verified under Mathlib v4.31)
+
+- **`sumset_eq_add`** — `sumset A = A + A` (pointwise), the additive analogue of
+  the file's `productSet_eq_mul`.
+- **`sumset_lower_bound`** — `2|A| - 1 ≤ |A + A|` for nonempty `A ⊆ ℤ`, via
+  Mathlib's `cauchy_davenport_add_of_linearOrder_isCancelAdd`. Fills the
+  previously comment-only Part II.
+- **`product_lower_of_mult_energy`** — the faithful Solymosi reduction. From
+  `cauchy_schwarz_energy` (already proved) plus the multiplicative-energy upper
+  bound `E×(A) ≤ C·|A+A|²·log|A|` supplied as an **explicit hypothesis**, it
+  proves `|A·A| ≥ |A|² / (C·K²·log|A|)` when `|A+A| ≤ K·|A|`. This machine-checks
+  the whole reduction and isolates the single genuine external input WITHOUT
+  adding a new axiom.
+
+Required adding `import Mathlib.Combinatorics.Additive.CauchyDavenport` (the
+Cauchy–Davenport lemma is not transitively imported by `...Additive.Energy`).
+
+### The remaining open sorry (`proof_outline`)
+
+`proof_outline` claims the sharper `|A·A| ≥ |A|² / (K·log|A|)` (denominator
+`K`, not `K²`). Two honest facts:
+
+1. It is **not** derivable from the `solymosi_theorem` axiom (absolute constant
+   `c·|A|²/log|A|`): that would require `c·K ≥ 1`, which the existential `c` does
+   not provide.
+2. It is **stronger** than the standard energy argument yields. Substituting
+   `|A+A| ≤ K·|A|` into `E×(A) ≤ C·|A+A|²·log|A|` costs a square, giving only
+   `1/(C·K²·log|A|)` (exactly `product_lower_of_mult_energy`). The `K`-linear
+   form needs a materially different argument, or Solymosi's energy inequality
+   formalized in Mathlib.
+
+### Blocker (structured, in tracker `currentState.blockers`)
+
+- route: proof_outline sharp `1/(K·log|A|)` product-set bound via multiplicative
+  energy — reopen only with a materially new mechanism.
+
+### Next external input to formalize
+
+Solymosi's multiplicative-energy inequality `E×(A) ≤ C·|A+A|²·log|A|` (dyadic
+pigeonhole on the multiplicative fibers `{(a,b) : ab = m}`) — not currently in
+Mathlib. Formalizing it would discharge `product_lower_of_mult_energy`'s
+hypothesis and give the `K²` product-set bound unconditionally.

--- a/src/data/proofs/erdos-818/meta.json
+++ b/src/data/proofs/erdos-818/meta.json
@@ -274,9 +274,9 @@
       "Real"
     ],
     "namespace": "Erdos818",
-    "lineCount": 353,
+    "lineCount": 437,
     "axiomCount": 1,
-    "theoremCount": 8,
+    "theoremCount": 11,
     "definitionCount": 7,
     "path": "Proofs/Erdos818Problem.lean",
     "sorries": 1,

--- a/src/data/research/problems/erdos-818-incomplete-01.json
+++ b/src/data/research/problems/erdos-818-incomplete-01.json
@@ -1,7 +1,7 @@
 {
   "slug": "erdos-818-incomplete-01",
   "title": "Complete proof of Product Set Lower Bound for Small Sumsets (1 sorries)",
-  "phase": "NEW",
+  "phase": "ACT",
   "status": "available",
   "tier": "B",
   "path": "full",
@@ -16,12 +16,18 @@
     "goal": "Eliminate the 1 remaining sorry statement(s) in the parent formalization."
   },
   "currentState": {
-    "phase": "NEW",
+    "phase": "ACT",
     "since": "2026-07-09T00:00:00.000Z",
-    "iteration": 0,
-    "focus": "Initial exploration of the problem.",
-    "blockers": [],
-    "nextAction": "Begin problem exploration.",
+    "iteration": 1,
+    "focus": "Reduce the open product-set bound to a single named, non-Mathlib energy inequality.",
+    "blockers": [
+      {
+        "route": "proof_outline sharp 1/(K·log|A|) product-set bound via multiplicative energy",
+        "reopenCriterion": "materially new mechanism required (Solymosi's energy inequality gives only 1/(C·K²·log|A|); the sharper K-linear form needs a different argument or the energy inequality formalized in Mathlib)",
+        "blockedAt": "2026-07-20"
+      }
+    ],
+    "nextAction": "Formalize Solymosi's energy inequality E×(A) ≤ C·|A+A|²·log|A| (dyadic pigeonhole on multiplicative fibers) — the remaining external input — or prove the sharper 1/(K·log|A|) form if a distinct argument exists.",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -29,9 +35,17 @@
     }
   },
   "knowledge": {
-    "progressSummary": "AVAILABLE: parent formalization has 1 open sorry statement(s) to complete.",
-    "builtItems": [],
-    "insights": [],
+    "progressSummary": "PROGRESS (still 1 open sorry): Added the axiom-free sumset lower bound 2|A|-1 ≤ |A+A| (Mathlib Cauchy–Davenport) and the axiom-free Solymosi reduction product_lower_of_mult_energy, which machine-checks energy-upper-bound + Cauchy–Schwarz ⇒ |A·A| ≥ |A|²/(C·K²·log|A|), isolating Solymosi's multiplicative-energy inequality E×(A) ≤ C·|A+A|²·log|A| as the single genuine external input (not in Mathlib). Documented that the file's remaining proof_outline sorry, with denominator K·log|A| (vs K²·log|A|), is a strictly stronger still-open target. Host-verified under Mathlib v4.31, 0 new axioms. leanFile theoremCount 8→11, lineCount 353→437.",
+    "builtItems": [
+      "sumset_eq_add (Erdos818Problem.lean): sumset A = A + A (pointwise), axiom-free.",
+      "sumset_lower_bound (Erdos818Problem.lean): 2|A|-1 ≤ |A+A| for nonempty A⊆ℤ, via Mathlib cauchy_davenport_add_of_linearOrder_isCancelAdd; fills the previously comment-only Part II. Axiom-free.",
+      "product_lower_of_mult_energy (Erdos818Problem.lean): from cauchy_schwarz_energy + hypothesis E×(A) ≤ C·|A+A|²·log|A|, proves |A·A| ≥ |A|²/(C·K²·log|A|) for |A+A| ≤ K·|A|. Axiom-free (propext/Choice/Quot only)."
+    ],
+    "insights": [
+      "The lone remaining sorry (proof_outline in Erdos818Problem.lean) is genuinely OPEN: its bound |A·A| ≥ |A|²/(K·log|A|) requires Solymosi's multiplicative-energy upper bound E×(A) ≤ C·|A+A|²·log|A|, which is not in Mathlib. It is NOT derivable from the file's solymosi_theorem axiom (absolute-constant form c·|A|²/log|A|), which would need c·K ≥ 1.",
+      "Honest constant mismatch: substituting |A+A| ≤ K·|A| into Solymosi's energy bound E×(A) ≤ C·|A+A|²·log|A| yields |A·A| ≥ |A|²/(C·K²·log|A|) — a K² dependence — NOT the sharper K in proof_outline's stated 1/(K·log|A|). So proof_outline as stated is strictly stronger than the standard argument delivers and remains open.",
+      "The full Solymosi reduction (energy upper bound + Cauchy–Schwarz ⇒ product-set lower bound) is now machine-checked axiom-free, with the energy inequality passed as an explicit hypothesis rather than a new axiom — isolating the single genuine external input."
+    ],
     "mathlibGaps": [],
     "nextSteps": []
   },
@@ -54,7 +68,7 @@
     "mathlib": []
   },
   "started": "2026-07-09T00:00:00.000Z",
-  "lastUpdate": "2026-07-09T00:00:00.000Z",
+  "lastUpdate": "2026-07-20",
   "significance": 6,
   "tractability": 7
 }


### PR DESCRIPTION
## Summary

Advances the `erdos-818-incomplete-01` completion task on
`proofs/Proofs/Erdos818Problem.lean` (gallery entry `erdos-818`).
Host-verified under Mathlib v4.31; **0 new axioms** (new theorems depend only on
`propext`/`Classical.choice`/`Quot.sound`).

## New theorems (all axiom-free)

- **`sumset_eq_add`** — `sumset A = A + A` (pointwise), additive analogue of the
  file's `productSet_eq_mul`.
- **`sumset_lower_bound`** — `2|A| - 1 ≤ |A + A|` for nonempty `A ⊆ ℤ`, via
  Mathlib's `cauchy_davenport_add_of_linearOrder_isCancelAdd`. Fills the
  previously comment-only Part II.
- **`product_lower_of_mult_energy`** — the faithful Solymosi reduction. From
  `cauchy_schwarz_energy` plus the multiplicative-energy upper bound
  `E×(A) ≤ C·|A+A|²·log|A|` supplied as an **explicit hypothesis**, proves
  `|A·A| ≥ |A|² / (C·K²·log|A|)` when `|A+A| ≤ K·|A|`. This machine-checks the
  entire reduction and isolates the single genuine external input **without
  introducing a new axiom**.

## Honesty note on the remaining sorry

The file's lone remaining sorry (`proof_outline`) claims the sharper
`|A·A| ≥ |A|² / (K·log|A|)` (denominator `K`, not `K²`). This is documented as
genuinely open:

1. Not derivable from the `solymosi_theorem` axiom (absolute-constant form) —
   would require `c·K ≥ 1`.
2. Strictly stronger than the standard energy argument delivers: substituting
   `|A+A| ≤ K·|A|` into `E×(A) ≤ C·|A+A|²·log|A|` costs a square, giving only
   `1/(C·K²·log|A|)` (exactly `product_lower_of_mult_energy`).

Recorded as a structured blocker in the tracker; the sorry count is unchanged.

## Housekeeping

- Added `import Mathlib.Combinatorics.Additive.CauchyDavenport`.
- `leanFile` counts updated: `theoremCount` 8→11, `lineCount` 353→437,
  `axiomCount` unchanged (1), `sorries` unchanged (1).
- Updated research knowledge tracker + `knowledge.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)