### PR TITLE
audit: erdos-871 fix stale lineCount 425→420 (overcount)

### DIFF
--- a/src/data/proofs/erdos-871/meta.json
+++ b/src/data/proofs/erdos-871/meta.json
@@ -56,7 +56,7 @@
       "Proved bases must be infinite (not_basis2_of_finite, basis2_infinite)"
     ],
     "axiomCount": 3,
-    "lineCount": 425,
+    "lineCount": 420,
     "assumptions": "3 axiom(s): erdos_nathanson_1989, erdos_nathanson_positive, larsen_construction_blocking. See Lean source for complete statements.",
     "theoremCount": 25,
     "definitionCount": 9
@@ -139,7 +139,7 @@
     {
       "title": "Summary",
       "startLine": 227,
-      "endLine": 425,
+      "endLine": 420,
       "summary": "Overview of results and references",
       "mathContext": "Mathematical content: Overview of results and references",
       "id": "summary"
@@ -167,7 +167,7 @@
       "Nat"
     ],
     "namespace": "Erdos871",
-    "lineCount": 425,
+    "lineCount": 420,
     "axiomCount": 3,
     "theoremCount": 25,
     "definitionCount": 9,


### PR DESCRIPTION
## Integrity Audit — erdos-871 (Partitioning Additive Bases of Order 2)

Re-served under reserve-mode round-robin (unaudited queue drained). Substantive integrity is **clean**; one stale overcount corrected.

### What was verified (all accurate)
- **Counts match source** `Proofs/Erdos871Problem.lean`: 3 axioms (`erdos_nathanson_1989`, `erdos_nathanson_positive`, `larsen_construction_blocking`), 25 theorems, 9 defs, 0 sorries, 0 `native_decide`, 0 `True` stubs.
- **Tier C honest**: status `axiomatized` / badge `axiom`. The core disproof rests on the `larsen_construction_blocking` axiom (that Larsen's construction has the blocking property with r_A(n)→∞); `larsen_counterexample` and `erdos_871_disproved` are genuinely derived from it via the proved `blocking_prevents_partition`.
- **No phantom declarations**: all 7 `originalContributions` map to real decls (`repFunc`, `IsAdditiveBasis2`, `CanPartitionIntoBases`, `HasBlockingProperty`/`blocking_prevents_partition`, `larsen_counterexample`, `not_basis2_of_finite`, `basis2_infinite`).
- `assumptions` prose lists exactly the 3 real axioms.

### Fix
- `meta.lineCount` and `leanFile.lineCount`: 425 → 420 (file ends at line 420, `end Erdos871`).
- Summary section `endLine`: 425 → 420.

Only stale overcounts were corrected; no prose or claim changes needed.

---
Discovered during gallery integrity audit.