### PR TITLE
Research: erdos-46 — discharge singleton-exclusion + |S|≥2 structural lemmas

### DIFF
--- a/proofs/Proofs/Erdos46Problem.lean
+++ b/proofs/Proofs/Erdos46Problem.lean
@@ -69,7 +69,16 @@ theorem not_unitFractionRepr_empty : ¬IsUnitFractionRepr ∅ := by
   intro ⟨_, hsum⟩
   simp at hsum
 
-/-  A singleton {n} is a unit fraction representation iff n = 1, which contradicts n ≥ 2. -/
+/-- A singleton `{n}` is never a unit fraction representation of `1`: the
+constraint `n ≥ 2` forces `1/n ≤ 1/2 < 1`, so its sum cannot equal `1`. -/
+theorem not_unitFractionRepr_singleton (n : ℕ) : ¬IsUnitFractionRepr {n} := by
+  rintro ⟨hge, hsum⟩
+  have hn : 2 ≤ n := hge n (mem_singleton_self n)
+  have hn0 : (n : ℚ) ≠ 0 := by exact_mod_cast (show n ≠ 0 by omega)
+  rw [Finset.sum_singleton, div_eq_one_iff_eq hn0] at hsum
+  have : n = 1 := by exact_mod_cast hsum.symm
+  omega
+
 /-- Any monochromatic set under a 1-colouring is trivially monochromatic. -/
 theorem mono_one_colour (c : FiniteColouring 1) (S : Finset ℕ) :
     IsMonochromatic c S := by
@@ -81,4 +90,17 @@ theorem mono_subset {r : ℕ} {c : FiniteColouring r} {S T : Finset ℕ}
   obtain ⟨col, hcol⟩ := hS
   exact ⟨col, fun n hn => hcol n (hTS hn)⟩
 
-/- A unit fraction representation has at least two elements. -/
+/-- A unit fraction representation of `1` has at least two elements: it is
+neither empty (sum `0 ≠ 1`) nor a singleton (`not_unitFractionRepr_singleton`). -/
+theorem two_le_card_unitFractionRepr {S : Finset ℕ} (h : IsUnitFractionRepr S) :
+    2 ≤ S.card := by
+  rcases Nat.lt_or_ge S.card 2 with hlt | hge
+  · exfalso
+    have : S.card = 0 ∨ S.card = 1 := by omega
+    rcases this with h0 | h1
+    · rw [Finset.card_eq_zero] at h0
+      subst h0
+      exact not_unitFractionRepr_empty h
+    · obtain ⟨a, rfl⟩ := Finset.card_eq_one.mp h1
+      exact not_unitFractionRepr_singleton a h
+  · exact hge

--- a/src/data/proofs/erdos-46/meta.json
+++ b/src/data/proofs/erdos-46/meta.json
@@ -155,9 +155,9 @@
       "Finset"
     ],
     "namespace": null,
-    "lineCount": 84,
+    "lineCount": 106,
     "axiomCount": 0,
-    "theoremCount": 3,
+    "theoremCount": 5,
     "definitionCount": 7,
     "path": "Proofs/Erdos46Problem.lean",
     "sorries": 0

--- a/src/data/research/problems/erdos-46-wip-01.json
+++ b/src/data/research/problems/erdos-46-wip-01.json
@@ -1,7 +1,7 @@
 {
   "slug": "erdos-46-wip-01",
   "title": "Complete the Erdős #46 Monochromatic Unit-Fraction Formalization",
-  "phase": "OBSERVE",
+  "phase": "ACT",
   "status": "active",
   "tier": "B",
   "path": "full",
@@ -18,12 +18,18 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "OBSERVE",
+    "phase": "ACT",
     "since": "2026-07-09T17:33:18-07:00",
-    "iteration": 1,
-    "focus": "Initial problem understanding. Read problem.md and gather context.",
-    "blockers": [],
-    "nextAction": "Read problem.md thoroughly and acquire full context.",
+    "iteration": 2,
+    "focus": "Discharge provable structural lemmas; isolate Croot's theorem as the single external input.",
+    "blockers": [
+      {
+        "route": "Croot's theorem (monochromatic unit-fraction representation of 1)",
+        "reopenCriterion": "density Hales–Jewett / Croot's analytic input formalized in Mathlib",
+        "blockedAt": "2026-07-20"
+      }
+    ],
+    "nextAction": "Prove ErdosGraham_rational follows from ErdosProblem46_infinitely_many (elementary reduction); keep Croot's theorem isolated as the density-Hales–Jewett external input.",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -31,9 +37,15 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
+    "progressSummary": "PROGRESS: discharged the two structural lemmas the completion task flagged as 'asserted rather than proved' — singleton exclusion (not_unitFractionRepr_singleton) and the ≥2-elements bound (two_le_card_unitFractionRepr), both axiom-free, host-verified v4.31. Erdos46Problem.lean theoremCount 3→5, lineCount 84→106. Remaining open: Croot's theorem (needs density Hales–Jewett, absent from Mathlib) as the single genuine external input; the Erdős–Graham rational generalization should reduce to the infinitely-many version elementarily (next provable target).",
+    "builtItems": [
+      "not_unitFractionRepr_singleton (Erdos46Problem.lean): ¬IsUnitFractionRepr {n}, axiom-free (via div_eq_one_iff_eq + n≥2).",
+      "two_le_card_unitFractionRepr (Erdos46Problem.lean): 2 ≤ S.card for any IsUnitFractionRepr S, axiom-free (empty/singleton exclusion)."
+    ],
+    "insights": [
+      "The two structural facts previously stated only as comments in Erdos46Problem.lean (singleton exclusion and |S|≥2) are elementary and axiom-free: a singleton {n} fails because n≥2 ⟹ 1/n<1, and any unit-fraction representation of 1 is neither ∅ (sum 0) nor a singleton, so has ≥2 elements.",
+      "Remaining genuine external inputs toward `verified`: Croot's theorem (ErdosProblem46 / _infinitely_many) rests on the density Hales–Jewett input, not in Mathlib; ErdosGraham_rational should follow from the infinitely-many version by an elementary reduction (candidate next provable lemma)."
+    ],
     "mathlibGaps": [],
     "nextSteps": [],
     "markdown": "# Knowledge Base: erdos-46-wip-01\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
@@ -56,7 +68,7 @@
     "mathlib": []
   },
   "started": "2026-07-10T00:41:25.781Z",
-  "lastUpdate": "2026-07-10T00:41:25.928Z",
+  "lastUpdate": "2026-07-20",
   "significance": 6,
   "tractability": 7
 }


### PR DESCRIPTION
## Summary

Advances the `erdos-46-wip-01` completion task on `proofs/Proofs/Erdos46Problem.lean`
(gallery entry `erdos-46`, monochromatic unit-fraction representations).
Host-verified under Mathlib v4.31; **axiom-free** (new theorems depend only on
`propext`/`Classical.choice`/`Quot.sound`).

## What changed

Two structural facts that the completion task explicitly flags as *"asserted
rather than proved"* were present only as comments. They are now proved theorems:

- **`not_unitFractionRepr_singleton`** — a singleton `{n}` is never a
  unit-fraction representation of `1` (the constraint `n ≥ 2` forces `1/n < 1`).
- **`two_le_card_unitFractionRepr`** — any unit-fraction representation of `1`
  has `≥ 2` elements (neither empty, sum `0`, nor a singleton).

## Remaining open input

Croot's theorem (`ErdosProblem46` / `_infinitely_many`) rests on the density
Hales–Jewett input, which is not in Mathlib — recorded as a structured blocker.
The Erdős–Graham rational generalization should follow from the
infinitely-many version by an elementary reduction (flagged as the next
provable target).

## Housekeeping

- `leanFile` counts updated: `theoremCount` 3→5, `lineCount` 84→106
  (`axiomCount` 0, `sorries` 0 — unchanged).
- Updated research knowledge tracker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)