### PR TITLE
audit: erdos-876 — drop phantom axiomatized declarations from prose

### DIFF
--- a/src/data/proofs/erdos-876/meta.json
+++ b/src/data/proofs/erdos-876/meta.json
@@ -40,12 +40,10 @@
       "IsSumFreeClassical definition: classical x + y ≠ z",
       "IsIncreasingEnumeration, gap, HasGapBound, HasLinearGapBound",
       "ErdosQuestion876: the main open question",
-      "graham_result axiom: gaps < n^{1+ε} achievable",
-      "erdos_density_zero: sum-free sets have density zero",
-      "luczak_schoen_upper/lower: density bounds",
-      "dem_growth: aₙ ~ n^{3+o(1)} achievable",
-      "reciprocalSum definition and sullivan_bound",
-      "powers_of_two_sumfree theorem sketch"
+      "graham_result axiom: gaps < n^{1+ε} achievable (the only axiom)",
+      "cubicGrowthExponent := 3 and reciprocalSum definition (via tsum)",
+      "powers_of_two_sumfree theorem sketch (sorry)",
+      "Density-zero, Łuczak-Schoen, DEM, and Sullivan results appear only as prose comments — they are NOT formalized as axioms or theorems"
     ],
     "axiomCount": 1,
     "lineCount": 257,
@@ -60,7 +58,7 @@
     "historicalContext": "**Erdős Problem #876: Sum-Free Sets and Gap Growth**\n\nA **sum-free set** in Erdős's sense is an infinite set $A = \\{a_1 < a_2 < \\cdots\\} \\subset \\mathbb{N}$ where no element equals a sum of distinct smaller elements from $A$. This is strictly stronger than the classical sum-free condition (no $a + b = c$), as it forbids all subset sums, not just pairs.\n\nPaul Erdős proved in 1962 that such sets must have asymptotic density zero, establishing a fundamental sparsity constraint. The natural follow-up question — how sparse must they be? — was pursued through several key developments:\n\n- **Erdős (1962):** Proved density zero and the crude reciprocal sum bound $\\sum_{a \\in A} 1/a < 100$.\n- **Ronald Graham (c. 1998):** Showed that for any $\\varepsilon > 0$, there exists a sum-free set with gaps $a_{n+1} - a_n < n^{1+\\varepsilon}$ for large $n$. This is the best positive result toward the linear gap question.\n- **Jean-Marc Deshouillers, Erdős, and Giuseppe Melfi (1999):** Constructed a sum-free set with $a_n \\sim n^{3+o(1)}$, establishing the cubic growth rate as achievable.\n- **Tomasz Łuczak and Tomasz Schoen (2000):** Proved tight bounds on the counting function: $|A \\cap [1,N]| = O(\\sqrt{N \\log N})$ for any sum-free $A$, and there exists $B$ with $|B \\cap [1,N]| \\gg \\sqrt{N/(\\log N)^{1/2+o(1)}}$.\n- **Steven Sullivan:** Improved Erdős's reciprocal sum bound to $\\sum 1/a < 4$ and conjectured the supremum is slightly above 2.\n\nThe central open question remains: **can the gaps be made linear**, i.e., is $a_{n+1} - a_n < n$ achievable? Graham's result shows we can get arbitrarily close to linear ($n^{1+\\varepsilon}$), suggesting the answer might be yes, but the problem has resisted resolution for over two decades.",
     "problemStatement": "**Problem Statement (Partially Solved)**\n\nLet $A = \\{a_1 < a_2 < \\cdots\\} \\subset \\mathbb{N}$ be an infinite sum-free set, meaning no $a \\in A$ equals $b_1 + b_2 + \\cdots + b_r$ for distinct $b_i \\in A$ with $b_i < a$.\n\n**Questions:**\n1. How small can the gaps $a_{n+1} - a_n$ be?\n2. Is it possible that $a_{n+1} - a_n < n$?\n\n**Known:**\n- Graham: Gaps can be $< n^{1+o(1)}$\n- Main question (linear gaps) is OPEN\n\n**Additional Question:**\nWhat is $\\max \\sum_{a \\in A} 1/a$? Sullivan shows $< 4$, conjectures $\\approx 2$.",
     "text": "For an infinite sum-free set A = {a₁ < a₂ < ⋯}, how small can gaps aₙ₊₁ - aₙ be? Graham showed n^{1+o(1)} is achievable; whether gaps < n is possible remains OPEN.",
-    "proofStrategy": "**Formalization Approach**\n\nThe formalization distinguishes two sum-free notions and builds toward the open question:\n\n1. **Two Definitions (Lines 49–76):** `IsSumFreeErdos` forbids any subset sum of distinct predecessors equaling an element; `IsSumFreeClassical` only forbids $a + b = c$. The implication `erdos_implies_classical` has a sorry.\n\n2. **Gap Machinery (Lines 84–109):** Defines `gap a n = a(n+1) - a(n)`, `HasGapBound`, and the critical `HasLinearGapBound` condition $a_{n+1} - a_n < n$.\n\n3. **The Open Question (Lines 117–136):** `ErdosQuestion876` existentially asserts a sum-free set with linear gaps. Graham's axiom shows near-linear ($n^{1+\\varepsilon}$) gaps are achievable.\n\n4. **Density and Growth (Lines 142–194):** Axiomatizes Erdős's density-zero result, Łuczak-Schoen's tight counting bounds $\\Theta(\\sqrt{N \\log N})$, and DEM's cubic growth construction.\n\n5. **Reciprocal Sums (Lines 199–226):** Defines `reciprocalSum` via `tsum` and axiomatizes Erdős's bound, Sullivan's improvement, and Sullivan's conjecture.\n\n6. **Examples and Summary (Lines 230–298):** Powers of 2 as a basic sum-free set (sorry in proof), connections to Sidon sets, and the summary theorem.",
+    "proofStrategy": "**Formalization Approach**\n\nThe formalization distinguishes two sum-free notions and builds toward the open question:\n\n1. **Two Definitions (Lines 49–76):** `IsSumFreeErdos` forbids any subset sum of distinct predecessors equaling an element; `IsSumFreeClassical` only forbids $a + b = c$. The implication `erdos_implies_classical` has a sorry.\n\n2. **Gap Machinery (Lines 84–109):** Defines `gap a n = a(n+1) - a(n)`, `HasGapBound`, and the critical `HasLinearGapBound` condition $a_{n+1} - a_n < n$.\n\n3. **The Open Question (Lines 117–136):** `ErdosQuestion876` existentially asserts a sum-free set with linear gaps. Graham's axiom shows near-linear ($n^{1+\\varepsilon}$) gaps are achievable.\n\n4. **Density and Growth (Lines 140–169):** Erdős's density-zero result, Łuczak-Schoen's counting bounds $\\Theta(\\sqrt{N \\log N})$, and DEM's cubic growth construction are recorded in prose comments only — none are formalized as axioms or theorems. The only declaration is `def cubicGrowthExponent := 3`.\n\n5. **Reciprocal Sums (Lines 175–193):** Defines `reciprocalSum` via `tsum`; Erdős's bound, Sullivan's improvement, and Sullivan's conjecture are described in comments, not axiomatized.\n\n6. **Examples and Summary (Lines 198–257):** Powers of 2 as a basic sum-free set (sorry in proof), connections to Sidon sets, and the summary theorem.",
     "keyInsights": [
       "**Erdős vs Classical Sum-Free:** The Erdős condition ($\\nexists$ subset sum of predecessors $= a$) is strictly stronger than classical ($a + b \\neq c$). The set $\\{1, 5, 6\\}$ is classically sum-free ($1+5=6$ violates classical!) but illustrates the distinction — Erdős sum-free sets avoid ALL subset sums, making them much sparser.",
       "**Density-Growth Duality:** The Łuczak-Schoen counting bound $|A \\cap [1,N]| = O(\\sqrt{N \\log N})$ and the DEM growth rate $a_n \\sim n^{3+o(1)}$ are dual perspectives: if $|A \\cap [1,N]| \\sim \\sqrt{N}$, inverting gives $a_n \\sim n^2$. The $\\log N$ correction explains the cubic (rather than quadratic) growth.",
@@ -109,26 +107,26 @@
     {
       "id": "density-results",
       "title": "Density Results",
-      "summary": "Axiomatizes Erdős's density-zero theorem ($|A \\cap [1,N]|/N \\to 0$), Łuczak-Schoen upper bound $|A \\cap [1,N]| \\leq c\\sqrt{N \\log N}$, and lower bound $|B \\cap [1,N]| \\geq \\sqrt{N}/(\\log N)^{1/2+o(1)}$ for an explicit construction $B$.",
+      "summary": "Documents in prose comments (NOT formalized) Erdős's density-zero theorem ($|A \\cap [1,N]|/N \\to 0$), the Łuczak-Schoen upper bound $|A \\cap [1,N]| \\leq c\\sqrt{N \\log N}$, and the lower bound $|B \\cap [1,N]| \\geq \\sqrt{N}/(\\log N)^{1/2+o(1)}$. No axioms or theorems are declared for these; the section is comment blocks only.",
       "startLine": 138,
       "endLine": 172,
-      "mathContext": "Axiomatizes Erdős's density-zero theorem ($|A \\cap [1,N]|/N \\to 0$), Łuczak-Schoen upper bound $|A \\cap [1,N]| \\leq c\\sqrt{N \\log N}$, and lower bound $|B \\cap [1,N]| \\geq \\sqrt{N}/(\\log N)^{1/2+o(1)}$ for an explicit construction $B$."
+      "mathContext": "Documents in prose comments (NOT formalized) Erdős's density-zero theorem ($|A \\cap [1,N]|/N \\to 0$), the Łuczak-Schoen upper bound $|A \\cap [1,N]| \\leq c\\sqrt{N \\log N}$, and the lower bound $|B \\cap [1,N]| \\geq \\sqrt{N}/(\\log N)^{1/2+o(1)}$. No axioms or theorems are declared for these; the section is comment blocks only."
     },
     {
       "id": "growth-rate",
       "title": "Growth Rate: DEM Construction",
-      "summary": "Axiomatizes the Deshouillers-Erdős-Melfi result: $\\exists a$ sum-free with $n^{3-\\varepsilon} < a_n < n^{3+\\varepsilon}$ for large $n$. The cubic exponent relates to the counting function via $a_n \\sim n^3 \\iff |A \\cap [1,N]| \\sim N^{1/3}$.",
+      "summary": "Documents the Deshouillers-Erdős-Melfi result ($\\exists a$ sum-free with $n^{3-\\varepsilon} < a_n < n^{3+\\varepsilon}$) in prose comments only; the sole declaration here is `def cubicGrowthExponent : ℕ := 3`. The cubic exponent relates to the counting function via $a_n \\sim n^3 \\iff |A \\cap [1,N]| \\sim N^{1/3}$.",
       "startLine": 173,
       "endLine": 194,
-      "mathContext": "Axiomatizes the Deshouillers-Erdős-Melfi result: $\\exists a$ sum-free with $n^{3-\\varepsilon} < a_n < n^{3+\\varepsilon}$ for large $n$. The cubic exponent relates to the counting function via $a_n \\sim n^3 \\iff |A \\cap [1,N]| \\sim N^{1/3}$."
+      "mathContext": "Documents the Deshouillers-Erdős-Melfi result ($\\exists a$ sum-free with $n^{3-\\varepsilon} < a_n < n^{3+\\varepsilon}$) in prose comments only; the sole declaration here is `def cubicGrowthExponent : ℕ := 3`. The cubic exponent relates to the counting function via $a_n \\sim n^3 \\iff |A \\cap [1,N]| \\sim N^{1/3}$."
     },
     {
       "id": "reciprocal-sum",
       "title": "Reciprocal Sum Bounds",
-      "summary": "Defines `reciprocalSum A = \\sum_{a \\in A,\\, a \\geq 1} 1/a$ via `tsum`. Axiomatizes Erdős's crude bound ($< 100$), Sullivan's improvement ($< 4$), and Sullivan's conjecture ($\\exists A$ with $\\sum 1/a > 2$).",
+      "summary": "Defines `reciprocalSum A = \\sum_{a \\in A,\\, a \\geq 1} 1/a$ via `tsum`. Erdős's crude bound ($< 100$), Sullivan's improvement ($< 4$), and Sullivan's conjecture ($\\exists A$ with $\\sum 1/a > 2$) are described in prose comments only — not formalized as axioms.",
       "startLine": 195,
       "endLine": 226,
-      "mathContext": "Defines `reciprocalSum A = \\sum_{a \\in A,\\, a \\geq 1} 1/a$ via `tsum`. Axiomatizes Erdős's crude bound ($< 100$), Sullivan's improvement ($< 4$), and Sullivan's conjecture ($\\exists A$ with $\\sum 1/a > 2$)."
+      "mathContext": "Defines `reciprocalSum A = \\sum_{a \\in A,\\, a \\geq 1} 1/a$ via `tsum`. Erdős's crude bound ($< 100$), Sullivan's improvement ($< 4$), and Sullivan's conjecture ($\\exists A$ with $\\sum 1/a > 2$) are described in prose comments only — not formalized as axioms."
     },
     {
       "id": "examples",


### PR DESCRIPTION
## Gallery Integrity Audit (reserve mode)

**Proof**: erdos-876 (Sum-Free Sets and Gap Growth)
**Severity**: MEDIUM — phantom-declaration overstatement in prose; counts are honest.

### Finding
The declaration counts all match reality: **1 axiom** (`graham_result`), **3 theorems** (`erdos_implies_classical`, `powers_of_two_sumfree`, `erdos_876_summary`), **9 defs**, **2 sorries**. A count-based check passes cleanly.

But the prose overstates the formalization scope:

- `originalContributions` listed **5 phantom declarations** that do not exist in `Proofs/Erdos876Problem.lean`:
  `erdos_density_zero`, `luczak_schoen_upper`, `luczak_schoen_lower`, `dem_growth`, `sullivan_bound`
  (grep confirms 0 occurrences each). These appear only as `/- ... -/` comment blocks — never formalized.
- The **density-results**, **growth-rate**, and **reciprocal-sum** sections claimed to "**Axiomatize**" these results. The file's *only* axiom is `graham_result`.
- `proofStrategy` items 4–5 repeated the same false "axiomatizes" wording and cited line numbers (e.g. 298) past the 257-line file.

### Fix
- Dropped the 5 phantom entries from `originalContributions`; replaced with the real decls (`cubicGrowthExponent := 3`, `reciprocalSum`, `powers_of_two_sumfree` sketch) plus an explicit note that density-zero / Łuczak-Schoen / DEM / Sullivan are documented in comments only.
- Reworded the three section descriptions and `proofStrategy` items 4–5 from "Axiomatizes X" to "documented in prose comments (not formalized)".
- No Lean source changes; no count changes (status `axiomatized` / badge `axiom` remain correct).

---
Discovered during gallery integrity audit.