### PR TITLE
Research: erdos-116 — axiom-free foundational lemmas + fix overclaiming meta

### DIFF
--- a/proofs/Proofs/Erdos116Problem.lean
+++ b/proofs/Proofs/Erdos116Problem.lean
@@ -63,6 +63,56 @@ noncomputable def sublevelMeasure (P : UnitDiskPoly n) : ℝ :=
 /-  Pólya's bound: the sublevel measure is at most π, and equality holds
     only when all roots coincide (p(z) = (z - z₀)ⁿ for some |z₀| ≤ 1) -/
 
+/- ## Foundational Structure Lemmas (axiom-free)
+
+The deep quantitative bounds above (Pommerenke `c/n⁴`, KLR `c/log n`,
+KLR `C/log log n`, Pólya `π`) rest on logarithmic-potential and measure
+machinery not presently available in Mathlib, so they are stated only in
+the header prose. What *is* machine-checkable here is the basic geometry of
+the lemniscate `{|p(z)| < 1}` directly from the root factorization. These
+lemmas are proved with no axioms and no `sorry`. -/
+
+/-- Evaluating `p` at one of its own roots gives `0`: the factor `(zᵢ - zᵢ)`
+    vanishes, so the whole product does. -/
+@[simp] theorem UnitDiskPoly.eval_root_eq_zero (P : UnitDiskPoly n) (i : Fin n) :
+    P.eval (P.roots i) = 0 := by
+  refine Finset.prod_eq_zero (Finset.mem_univ i) ?_
+  simp
+
+/-- Every root lies in the sublevel set: `|p(zᵢ)| = 0 < 1`. -/
+theorem UnitDiskPoly.root_mem_sublevelSet (P : UnitDiskPoly n) (i : Fin n) :
+    P.roots i ∈ P.sublevelSet := by
+  show Complex.abs (P.eval (P.roots i)) < 1
+  rw [P.eval_root_eq_zero i]
+  simp [Complex.abs]
+
+/-- For a positive-degree polynomial the sublevel set is nonempty — it contains
+    every root. -/
+theorem UnitDiskPoly.sublevelSet_nonempty (P : UnitDiskPoly n) (hn : 0 < n) :
+    P.sublevelSet.Nonempty :=
+  ⟨P.roots ⟨0, hn⟩, P.root_mem_sublevelSet ⟨0, hn⟩⟩
+
+/-- The degenerate degree-`0` polynomial is the empty product `p ≡ 1`. -/
+@[simp] theorem UnitDiskPoly.eval_of_degree_zero (P : UnitDiskPoly 0) (z : ℂ) :
+    P.eval z = 1 := by
+  simp [UnitDiskPoly.eval]
+
+/-- In degree `0`, `p ≡ 1`, so `{|p(z)| < 1}` is empty: the boundary case that
+    makes the positive-degree hypothesis in `sublevelSet_nonempty` essential. -/
+theorem UnitDiskPoly.sublevelSet_of_degree_zero (P : UnitDiskPoly 0) :
+    P.sublevelSet = (∅ : Set ℂ) := by
+  ext z
+  simp only [Set.mem_empty_iff_false, iff_false]
+  show ¬ Complex.abs (P.eval z) < 1
+  rw [P.eval_of_degree_zero z]
+  simp [Complex.abs]
+
+/-- The sublevel measure is always nonnegative (it is the real part of an
+    `ℝ≥0∞`-valued measure). -/
+theorem UnitDiskPoly.sublevelMeasure_nonneg (P : UnitDiskPoly n) :
+    0 ≤ sublevelMeasure P :=
+  ENNReal.toReal_nonneg
+
 /- ## The Erdős–Herzog–Piranian Conjecture (PROVED) -/
 
 /-  Erdős Problem 116 (Erdős–Herzog–Piranian, PROVED):

--- a/research/problems/erdos-116-wip-01/knowledge.md
+++ b/research/problems/erdos-116-wip-01/knowledge.md
@@ -19,3 +19,33 @@ Insights accumulated during research on this problem.
 ## Dead Ends
 
 [Approaches known not to work will be documented here]
+
+---
+
+## Session 2026-07-20 (researcher-1) — bare stub → axiom-free foundational core
+
+**Mode**: FRESH (knowledge score 0). **Outcome**: progress (6 theorems, axiom-free), host-verified v4.31.
+
+**Finding**: `Erdos116Problem.lean` had real definitions but **zero theorems**, yet the gallery
+meta (`proofStrategy`, `conclusion`) described "four bounds stated as axioms" and a main theorem
+`ErdosProblem116` — none of which existed in the source (an overclaim). Fixed both the Lean file and
+the prose.
+
+**Added (proofs/Proofs/Erdos116Problem.lean, all 0-axiom, `#print axioms` = propext/Classical.choice/Quot.sound):**
+- `UnitDiskPoly.eval_root_eq_zero` — `p(zᵢ)=0` (a factor vanishes); proof `Finset.prod_eq_zero (mem_univ i) (by simp)`.
+- `UnitDiskPoly.root_mem_sublevelSet` — every root ∈ `{|p|<1}` (|0|=0<1).
+- `UnitDiskPoly.sublevelSet_nonempty` (n>0) — witness `roots ⟨0,hn⟩`.
+- `UnitDiskPoly.eval_of_degree_zero` — `n=0 ⟹ p ≡ 1` (empty product).
+- `UnitDiskPoly.sublevelSet_of_degree_zero` — `n=0 ⟹ {|p|<1} = ∅` (|1|=1 ≮ 1). The boundary case
+  making the `n>0` hypothesis essential.
+- `UnitDiskPoly.sublevelMeasure_nonneg` — `0 ≤ μ` (`ENNReal.toReal_nonneg`).
+
+**Gotcha**: file has no namespace (`namespace: null`); shim `noncomputable def Complex.abs (z) := ‖z‖`
+for v4.31 (`Complex.abs` removed). `simp [Complex.abs]` unfolds the shim; `Complex.abs 0` → `‖0‖` → `0`.
+
+**Meta synced**: theoremCount 0→6 (both `.meta` and `.leanFile`), lineCount 74→124, imports→`["Mathlib"]`,
+`assumptions`/`proofStrategy`/`conclusion` rewritten to stop referencing non-existent axioms/`ErdosProblem116`.
+
+**Still open (Mathlib infra gap)**: the four deep bounds (Pommerenke `c/n⁴`, KLR `c/log n` & `C/loglog n`,
+Pólya `π`) need logarithmic-potential / planar-measure-of-lemniscate machinery absent from Mathlib v4.31.
+Next foundational step: prove `sublevelSet` is open/measurable (`p` continuous).

--- a/src/data/proofs/erdos-116/meta.json
+++ b/src/data/proofs/erdos-116/meta.json
@@ -20,17 +20,17 @@
     "erdosUrl": "https://erdosproblems.com/116",
     "erdosProblemStatus": "solved",
     "axiomCount": 0,
-    "lineCount": 74,
-    "assumptions": "0 axioms, 0 sorries. Previously cited axiom names have been removed from the Lean source. The 'axiomatized' status reflects that the main result is not yet fully formalized in Lean.",
+    "lineCount": 124,
+    "assumptions": "0 axioms, 0 sorries. The file proves six axiom-free foundational lemmas about the sublevel set (each root lies in it, degree-0 emptiness vs positive-degree nonemptiness, measure nonnegativity), each depending only on propext/Classical.choice/Quot.sound. The deep quantitative bounds (Pommerenke, KLR, Pólya) that resolve the conjecture are NOT formalized in Lean — they are documented only in the header prose. Status \"axiomatized\" reflects that the headline result is not machine-checked.",
     "mathlib_version": "4.31.0",
-    "theoremCount": 0,
+    "theoremCount": 6,
     "definitionCount": 4
   },
   "overview": {
     "historicalContext": "This conjecture was posed by Paul Erdős, Fritz Herzog, and George Piranian in their 1958 paper on metric properties of polynomials. They asked: for a monic polynomial $p(z) = \\prod(z - z_i)$ of degree $n$ with all roots in the closed unit disk $\\overline{\\mathbb{D}}$, how small can the 2D Lebesgue measure of the sublevel set $\\{z \\in \\mathbb{C} : |p(z)| < 1\\}$ be? They conjectured the measure is at least $n^{-O(1)}$, or even $(\\log n)^{-O(1)}$.\n\nThe sublevel set $\\{|p(z)| < 1\\}$ is a polynomial lemniscate — the region where the polynomial is small. Its geometry depends intricately on the root configuration: when roots cluster, the lemniscate concentrates into a single blob of area $\\pi$; when roots spread across the disk, it fragments into many small components whose total area shrinks.\n\nThe first major progress came from Pommerenke, who proved the measure is at least $c/n^4$ using logarithmic potential theory and transfinite diameter estimates. This established the polynomial decay rate but left a large gap.\n\nThe problem was fully resolved by Manjunath Krishnapur, Erik Lundberg, and Koushik Ramachandran, who proved the optimal lower bound $c/\\log n$. Their proof combined probabilistic methods with careful estimates on the polynomial's value distribution. They also showed this is nearly tight by constructing polynomials achieving measure at most $C/\\log\\log n$, leaving only a small gap between $1/\\log n$ and $1/\\log\\log n$.",
     "problemStatement": "Is the 2D Lebesgue measure of $\\{z \\in \\mathbb{C} : |p(z)| < 1\\}$ at least $(\\log n)^{-O(1)}$ for every monic degree-$n$ polynomial with roots in the unit disk?",
     "text": "For a monic polynomial p with all roots in the unit disk, is |{|p(z)|<1}| ≥ n^{-O(1)}? PROVED: Krishnapur-Lundberg-Ramachandran showed |{|p(z)|<1}| ≥ c/log n, and this is tight up to log log factors.",
-    "proofStrategy": "The formalization defines the key objects in 74 lines of Lean 4: the `UnitDiskPoly` structure (monic polynomials with roots in $\\overline{\\mathbb{D}}$), the sublevel set $\\{|p(z)| < 1\\}$, and the sublevel measure $\\mu(S_p)$ as 2D Lebesgue measure. Four main bounds are stated as axioms: Pommerenke's $c/n^4$, KLR's lower bound $c/\\log n$ (which proves the conjecture), KLR's upper bound $C/\\log\\log n$ (near-tightness), and Pólya's absolute upper bound $\\pi$. The main result `ErdosProblem116` records the resolution. A final axiom states the existence of minimizers via compactness.",
+    "proofStrategy": "The Lean file (124 lines) defines the core objects: the `UnitDiskPoly` structure (monic degree-$n$ polynomials given by roots in the closed unit disk), polynomial evaluation via the root product $p(z) = \\prod(z - z_i)$, the sublevel set $\\{|p(z)| < 1\\}$, and the sublevel measure as 2D Lebesgue measure. On top of these it proves six axiom-free foundational lemmas about the lemniscate geometry: `eval_root_eq_zero` ($p$ vanishes at each root), `root_mem_sublevelSet` (every root lies in the sublevel set), `sublevelSet_nonempty` (nonempty in positive degree), `eval_of_degree_zero` / `sublevelSet_of_degree_zero` (the degenerate degree-0 case $p \\equiv 1$ gives an empty sublevel set), and `sublevelMeasure_nonneg`. The four deep quantitative bounds — Pommerenke $c/n^4$, KLR $c/\\log n$ (which resolves the conjecture) and $C/\\log\\log n$, and Pólya $\\pi$ — require logarithmic-potential and measure machinery not yet in Mathlib and are documented in the header prose rather than formalized.",
     "keyInsights": [
       "The sublevel set $\\{|p(z)| < 1\\}$ is a polynomial lemniscate whose geometry encodes the root distribution: clustered roots give large area (up to $\\pi$), while spread-out roots fragment the set and shrink its measure to $\\Theta(1/\\log n)$.",
       "The resolution proceeded through a dramatic improvement: from Pommerenke's $c/n^4$ (polynomial decay) to KLR's $c/\\log n$ (logarithmic decay), an exponential improvement in the dependence on degree $n$.",
@@ -102,7 +102,7 @@
     }
   ],
   "conclusion": {
-    "summary": "This formalization captures the complete landscape of Erdős Problem #116 in 74 lines of Lean 4: from the `UnitDiskPoly` definition through four major bounds (Pommerenke $c/n^4$, KLR $c/\\log n$, KLR $C/\\log\\log n$, Pólya $\\pi$) to the formal resolution. The problem is PROVED with the optimal $c/\\log n$ lower bound.",
+    "summary": "This entry formalizes the definitional framework of Erdős Problem #116 (the `UnitDiskPoly` structure, the sublevel set, and its 2D Lebesgue measure) together with six axiom-free foundational lemmas on the lemniscate $\\{|p(z)| < 1\\}$, including the degree-0 emptiness / positive-degree nonemptiness dichotomy. The four deep bounds that resolve the problem (Pommerenke $c/n^4$, KLR $c/\\log n$ and $C/\\log\\log n$, Pólya $\\pi$) are stated in the header prose but not yet formalized in Lean; the mathematical resolution is due to Krishnapur–Lundberg–Ramachandran with the optimal $c/\\log n$ lower bound.",
     "implications": "**Theoretical Significance**: The resolution connects polynomial geometry to measure theory through the study of lemniscates.\n\nThe techniques of Krishnapur, Lundberg, and Ramachandran combine probabilistic methods with potential-theoretic estimates, suggesting new approaches to related extremal problems about polynomial level sets. The result also has implications for numerical analysis, where sublevel set sizes affect condition number estimates.",
     "openQuestions": [
       "What is the exact asymptotic minimum of $\\mu(S_P)$ over degree-$n$ unit disk polynomials? The gap between $c/\\log n$ and $C/\\log\\log n$ is open.",
@@ -113,17 +113,13 @@
   },
   "leanFile": {
     "imports": [
-      "Mathlib.Analysis.SpecialFunctions.Complex.Circle",
-      "Mathlib.MeasureTheory.Measure.Lebesgue.Basic",
-      "Mathlib.Analysis.SpecialFunctions.Log.Basic",
-      "Mathlib.Data.Complex.Basic",
-      "Mathlib.Tactic"
+      "Mathlib"
     ],
     "opens": [],
     "namespace": null,
-    "lineCount": 74,
+    "lineCount": 124,
     "axiomCount": 0,
-    "theoremCount": 0,
+    "theoremCount": 6,
     "definitionCount": 4,
     "path": "Proofs/Erdos116Problem.lean",
     "sorries": 0

--- a/src/data/research/problems/erdos-116-wip-01.json
+++ b/src/data/research/problems/erdos-116-wip-01.json
@@ -18,7 +18,7 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "OBSERVE",
+    "phase": "ORIENT",
     "since": "2026-07-09T17:33:18-07:00",
     "iteration": 1,
     "focus": "Initial problem understanding. Read problem.md and gather context.",
@@ -31,11 +31,20 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
+    "progressSummary": "PROGRESS: converted bare stub into a formalization with a verified axiom-free foundational core (6 theorems: root membership, degree-0 emptiness vs positive-degree nonemptiness, measure nonnegativity). Corrected gallery meta which falsely described non-existent axioms/ErdosProblem116; theoremCount 0->6, imports/lineCount synced, assumptions text made honest. Deep bounds remain documented-only (Mathlib infra gap).",
+    "builtItems": [
+      "UnitDiskPoly.eval_root_eq_zero / root_mem_sublevelSet / sublevelSet_nonempty / eval_of_degree_zero / sublevelSet_of_degree_zero / sublevelMeasure_nonneg in proofs/Proofs/Erdos116Problem.lean (6 axiom-free foundational theorems; host-verified v4.31, #print axioms = propext/Classical.choice/Quot.sound only)"
+    ],
+    "insights": [
+      "Erdos116Problem.lean was a bare statement-stub: real definitions (UnitDiskPoly, eval, sublevelSet, sublevelMeasure) but ZERO theorems, while gallery meta prose falsely described four bounds \"stated as axioms\" and a main theorem ErdosProblem116 that did not exist in source.",
+      "The lemniscate {|p(z)|<1} has a clean degree dichotomy: for n=0 the empty product gives p≡1 so the set is EMPTY; for n>0 every root zi satisfies p(zi)=0<1 so each root lies in the set (nonempty). This is the axiom-free core the deep measure bounds build on.",
+      "The four quantitative bounds (Pommerenke c/n^4, KLR c/log n, KLR C/loglog n, Polya pi) need logarithmic-potential / planar-measure machinery absent from Mathlib v4.31 — not formalizable without substantial new infrastructure; correctly left as documented prose, not axioms."
+    ],
     "mathlibGaps": [],
-    "nextSteps": [],
+    "nextSteps": [
+      "The genuine open formalization target is Polya pi upper bound (area of {|p|<1} <= pi) — the most self-contained of the four; still requires planar Lebesgue-measure-of-lemniscate infra Mathlib lacks.",
+      "Consider proving sublevelSet is measurable/open (p is continuous) as the next foundational step enabling any measure lower bound."
+    ],
     "markdown": "# Knowledge Base: erdos-116-wip-01\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },
   "tags": [


### PR DESCRIPTION
## Summary
Research session for **erdos-116** (Measure of Polynomial Sublevel Sets). `Erdos116Problem.lean` was a bare statement-stub — real definitions but **zero theorems** — while the gallery meta prose described "four bounds stated as axioms" and a main theorem `ErdosProblem116` that **did not exist** in the Lean source (an overclaim). This PR gives the entry a genuine verified core and makes the prose honest.

## Progress
Added **6 axiom-free foundational theorems** to `proofs/Proofs/Erdos116Problem.lean` (host-verified on v4.31; `#print axioms` = `propext/Classical.choice/Quot.sound` only):
- `UnitDiskPoly.eval_root_eq_zero` — `p` vanishes at each of its roots
- `UnitDiskPoly.root_mem_sublevelSet` — every root lies in `{|p(z)| < 1}`
- `UnitDiskPoly.sublevelSet_nonempty` — nonempty in positive degree
- `UnitDiskPoly.eval_of_degree_zero` / `sublevelSet_of_degree_zero` — the degree-0 case `p ≡ 1` gives an **empty** sublevel set (the boundary case making the `n>0` hypothesis essential)
- `UnitDiskPoly.sublevelMeasure_nonneg`

## Findings
- The lemniscate `{|p(z)|<1}` has a clean degree dichotomy (empty at `n=0`, contains all roots at `n>0`) — the axiom-free core the deep measure bounds build on.
- The four deep quantitative bounds (Pommerenke `c/n⁴`, KLR `c/log n` & `C/log log n`, Pólya `π`) need logarithmic-potential / planar-measure-of-lemniscate machinery **absent from Mathlib v4.31**; correctly left as documented header prose, not formalized.

## Files modified
- `proofs/Proofs/Erdos116Problem.lean` (+6 theorems, 74→124 lines)
- `src/data/proofs/erdos-116/meta.json` — theoremCount 0→6, lineCount 74→124, imports→`["Mathlib"]`; `proofStrategy`/`conclusion`/`assumptions` corrected to stop referencing the non-existent axioms/`ErdosProblem116`
- `src/data/research/problems/erdos-116-wip-01.json`, `research/problems/erdos-116-wip-01/knowledge.md` — knowledge

## Status
**Outcome**: progress (6 axiom-free theorems; gallery integrity fix)
**Next Steps**: prove `sublevelSet` open/measurable (`p` continuous); the self-contained Pólya `π` upper bound remains the most reachable of the four deep bounds once planar-measure infra exists.

🤖 Generated by researcher-1