### PR TITLE
Research: erdos-54 — axiom-free foundational lemmas + fix overclaiming meta

### DIFF
--- a/proofs/Proofs/Erdos54Problem.lean
+++ b/proofs/Proofs/Erdos54Problem.lean
@@ -78,3 +78,42 @@ def ErdosProblem54 : Prop :=
 
 /- Burr–Erdős (1985): There exists a Ramsey 2-complete set with
 `|A ∩ [1,N]| < (2 log₂ N)³`. This was improved by Conlon–Fox–Pham. -/
+
+/- ## Foundational lemmas (axiom-free)
+
+The two deep quantitative bounds above (Burr–Erdős lower bound, Conlon–Fox–Pham
+optimal construction) are documented in the header prose only — they are not
+formalised. What follows are the machine-checkable structural facts about the
+definitions, proved with no axioms and no `sorry`. -/
+
+/-- `0` is always a monochromatic subset sum: the empty subset is (vacuously)
+    monochromatic and sums to `0`. -/
+theorem zero_mem_monoSubsetSums (A : Set ℕ) (c : Colouring2 A) (colour : Bool) :
+    0 ∈ monoSubsetSums A c colour :=
+  ⟨∅, by simp, by simp⟩
+
+/-- A single element of `A` carrying the given colour is itself a monochromatic
+    subset sum (via the singleton subset `{n}`). -/
+theorem mem_monoSubsetSums_of_mem (A : Set ℕ) (c : Colouring2 A) (colour : Bool)
+    {n : ℕ} (hn : n ∈ A) (hc : c ⟨n, hn⟩ = colour) :
+    n ∈ monoSubsetSums A c colour := by
+  refine ⟨{n}, ?_, by simp⟩
+  intro m hm
+  rw [Finset.mem_singleton] at hm
+  subst hm
+  exact ⟨hn, hc⟩
+
+/-- The counting function never exceeds the length of the window: at most `N`
+    elements of `A` lie in `{1, …, N}`. -/
+theorem countingFn_le (A : Set ℕ) (N : ℕ) : countingFn A N ≤ N := by
+  unfold countingFn
+  calc ((Finset.Icc 1 N).filter (· ∈ A)).card
+      ≤ (Finset.Icc 1 N).card := Finset.card_filter_le _ _
+    _ = N := by rw [Nat.card_Icc]; omega
+
+/-- The counting function is monotone in the window size. -/
+theorem countingFn_mono (A : Set ℕ) {M N : ℕ} (h : M ≤ N) :
+    countingFn A M ≤ countingFn A N := by
+  unfold countingFn
+  exact Finset.card_le_card
+    (Finset.filter_subset_filter _ (Finset.Icc_subset_Icc_right h))

--- a/research/problems/erdos-54-wip-01/knowledge.md
+++ b/research/problems/erdos-54-wip-01/knowledge.md
@@ -19,3 +19,23 @@ Insights accumulated during research on this problem.
 ## Dead Ends
 
 [Approaches known not to work will be documented here]
+
+---
+
+## Session 2026-07-20 (researcher-1) — bare stub → axiom-free foundational core
+
+**Mode**: FRESH (score 0). **Outcome**: progress (4 theorems, axiom-free), host-verified v4.31.
+
+Same flavor-(b) pathology as erdos-116: `Erdos54Problem.lean` had real definitions + `ErdosProblem54`
+as an unproved `Prop` but **zero theorems**, while meta claimed the bounds "are axiomatised"
+(`axiomCount=0`, none exist) and "All results proved from Lean primitives" (no results).
+
+**Added (all 0-axiom, `#print axioms` = propext[/Classical.choice]/Quot.sound):**
+- `zero_mem_monoSubsetSums` — `0 ∈ monoSubsetSums` via `S=∅` (`⟨∅, by simp, by simp⟩`).
+- `mem_monoSubsetSums_of_mem` — a colour-`colour` element `n∈A` is a subset sum via `{n}`.
+- `countingFn_le` — `|A∩[1,N]| ≤ N` (`Finset.card_filter_le` + `Nat.card_Icc` then `omega` for `N+1-1=N`).
+- `countingFn_mono` — monotone in `N` (`Finset.filter_subset_filter` ∘ `Finset.Icc_subset_Icc_right`).
+
+**Meta synced**: theoremCount 0→4, lineCount→119, `assumptions`/`proofStrategy` rewritten honest.
+**Still open (infra gap)**: Burr–Erdős `c(log N)²` lower bound and Conlon–Fox–Pham `≪(log N)²`
+construction — additive-combinatorics machinery Mathlib lacks.

--- a/src/data/proofs/erdos-54/meta.json
+++ b/src/data/proofs/erdos-54/meta.json
@@ -57,16 +57,16 @@
       "burr_erdos_upper axiom ((2 log₂ N)³ historical bound)"
     ],
     "axiomCount": 0,
-    "lineCount": 78,
-    "assumptions": "0 axioms, 0 sorries. All results proved from Lean primitives.",
-    "theoremCount": 0,
+    "lineCount": 119,
+    "assumptions": "0 axioms, 0 sorries. Four axiom-free foundational lemmas are proved (subset-sum membership basics and counting-function bounds), each depending only on propext/Classical.choice/Quot.sound. The two deep bounds resolving the problem (Burr–Erdős lower bound, Conlon–Fox–Pham construction) are NOT formalized — they are documented only in the header prose. Status \"axiomatized\"/\"wip\" reflects that the headline Θ((log N)²) result is not machine-checked.",
+    "theoremCount": 4,
     "definitionCount": 5
   },
   "overview": {
     "historicalContext": "The concept of **Ramsey 2-complete sequences** was introduced by **Burr and Erdős** (1985), who asked how thin a set $A \\subseteq \\mathbb{N}$ can be while ensuring that every 2-colouring leaves a colour class whose subset sums cover all large integers. They proved a lower bound $c(\\log N)^2$ using digit-extraction colourings and an upper bound $(2\\log_2 N)^3$ via a greedy construction. The gap between quadratic and cubic bounds in $\\log N$ remained open for 36 years. Erdős (1995) specifically asked for improvement. In 2021, **Conlon, Fox, and Pham** resolved the problem completely by constructing a Ramsey 2-complete set with growth $O((\\log N)^2)$ using the **probabilistic method**, matching the lower bound and establishing $\\Theta((\\log N)^2)$ as the exact order of magnitude.",
     "problemStatement": "Improve the bounds on the minimum growth rate of a Ramsey 2-complete set: c(log N)² ≤ |A ∩ [1,N]| ≤ (2 log₂ N)³.",
     "text": "A set A is Ramsey 2-complete if every 2-colouring yields monochromatic sums covering all large integers. Conlon–Fox–Pham (2021) showed the minimum growth rate is Θ((log N)²).",
-    "proofStrategy": "The formalization defines 2-colourings, monochromatic subset sums, and Ramsey 2-completeness. The Burr–Erdős lower bound and the Conlon–Fox–Pham optimal construction are axiomatised.",
+    "proofStrategy": "The formalization defines 2-colourings, monochromatic subset sums (`monoSubsetSums`), Ramsey 2-completeness (`IsRamsey2Complete`), and the counting function `|A ∩ [1,N]|`. `ErdosProblem54` records the target $\\Theta((\\log N)^2)$ as a `Prop`. On top of the definitions it proves four axiom-free foundational lemmas: `zero_mem_monoSubsetSums` (the empty subset gives `0`), `mem_monoSubsetSums_of_mem` (a colour-`colour` element is a monochromatic subset sum via its singleton), `countingFn_le` (`|A ∩ [1,N]| ≤ N`), and `countingFn_mono` (monotonicity in `N`). The two deep bounds — the Burr–Erdős lower bound and the Conlon–Fox–Pham optimal construction — are documented in the header prose but NOT formalized in Lean.",
     "keyInsights": [
       "**Ramsey 2-completeness**: a robustness condition — every 2-colouring of $A$ must leave some colour class whose subset sums cover all large integers",
       "**Lower bound** (Burr–Erdős 1985): $|A \\cap [1,N]| \\ge c(\\log N)^2$ — proved by constructing adversarial digit-extraction colourings",
@@ -153,9 +153,9 @@
     ],
     "opens": [],
     "namespace": null,
-    "lineCount": 78,
+    "lineCount": 119,
     "axiomCount": 0,
-    "theoremCount": 0,
+    "theoremCount": 4,
     "definitionCount": 5,
     "path": "Proofs/Erdos54Problem.lean",
     "sorries": 0

--- a/src/data/research/problems/erdos-54-wip-01.json
+++ b/src/data/research/problems/erdos-54-wip-01.json
@@ -18,7 +18,7 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "OBSERVE",
+    "phase": "ORIENT",
     "since": "2026-07-09T17:33:19-07:00",
     "iteration": 1,
     "focus": "Initial problem understanding. Read problem.md and gather context.",
@@ -31,9 +31,15 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
+    "progressSummary": "PROGRESS: bare stub -> verified axiom-free foundational core (4 theorems); corrected overclaiming meta (theoremCount 0->4, honest assumptions/proofStrategy). Deep bounds remain documented-only.",
+    "builtItems": [
+      "zero_mem_monoSubsetSums / mem_monoSubsetSums_of_mem / countingFn_le / countingFn_mono in proofs/Proofs/Erdos54Problem.lean (4 axiom-free thms; host-verified v4.31)"
+    ],
+    "insights": [
+      "Erdos54Problem.lean was a bare stub: defs (Colouring2, monoSubsetSums, IsRamsey2Complete, countingFn) + ErdosProblem54 as an unproved Prop, ZERO theorems; meta falsely claimed the bounds were axiomatised (axiomCount=0) and All results proved (none existed).",
+      "Axiom-free structural core: 0 is always a monochromatic subset sum (empty subset); a colour-c element is a subset sum via its singleton; countingFn A N <= N and is monotone in N.",
+      "The two deep bounds (Burr-Erdos lower (log N)^2, Conlon-Fox-Pham construction) need additive-combinatorics / density machinery not formalized; left as documented prose."
+    ],
     "mathlibGaps": [],
     "nextSteps": [],
     "markdown": "# Knowledge Base: erdos-54-wip-01\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"


### PR DESCRIPTION
## Summary
Research session for **erdos-54** (Ramsey 2-Complete Sets). `Erdos54Problem.lean` was a bare statement-stub: real definitions and `ErdosProblem54` stated as an unproved `Prop`, but **zero theorems** — while the gallery meta claimed the two bounds "are axiomatised" (`axiomCount=0`, none exist) and "All results proved from Lean primitives" (no results existed). This PR adds a genuine verified core and makes the meta honest.

## Progress
Added **4 axiom-free foundational theorems** to `proofs/Proofs/Erdos54Problem.lean` (host-verified on v4.31; `#print axioms` = `propext/Classical.choice/Quot.sound` only):
- `zero_mem_monoSubsetSums` — `0` is always a monochromatic subset sum (the empty subset)
- `mem_monoSubsetSums_of_mem` — a colour-`colour` element of `A` is a monochromatic subset sum via its singleton
- `countingFn_le` — `|A ∩ [1,N]| ≤ N`
- `countingFn_mono` — the counting function is monotone in `N`

## Findings
- The two deep bounds — Burr–Erdős `c(log N)²` lower bound and the Conlon–Fox–Pham `≪ (log N)²` optimal construction — require additive-combinatorics / density machinery **absent from Mathlib v4.31**; correctly left as documented header prose, not formalized.

## Files modified
- `proofs/Proofs/Erdos54Problem.lean` (+4 theorems, 78→119 lines)
- `src/data/proofs/erdos-54/meta.json` — theoremCount 0→4, lineCount synced; `proofStrategy`/`assumptions` corrected to stop claiming non-existent axioms/results
- `src/data/research/problems/erdos-54-wip-01.json`, `research/problems/erdos-54-wip-01/knowledge.md`

## Status
**Outcome**: progress (4 axiom-free theorems; gallery integrity fix)
**Next Steps**: `¬ IsRamsey2Complete ∅` and measurability/structure lemmas remain reachable; the deep bounds await additive-combinatorics infra.

🤖 Generated by researcher-1