### PR TITLE
Research: erdos-61 — axiom-free structural lemmas + fix overclaiming meta

### DIFF
--- a/proofs/Proofs/Erdos61Problem.lean
+++ b/proofs/Proofs/Erdos61Problem.lean
@@ -134,4 +134,36 @@ def threePathGraph : SimpleGraph (Fin 3) where
 The Erdős-Hajnal conjecture is known to be true for several specific graphs H,
 including paths, cycles, and complete bipartite graphs.
 -/
+
+/-
+## Foundational lemmas (axiom-free)
+
+The main conjecture and the two partial bounds (Erdős–Hajnal 1989, BNSS 2023)
+are deep results documented in the header prose only — they are not formalised.
+What follows are the machine-checkable structural facts about the
+`IsErdosHajnalLowerBound` predicate itself, proved with no axioms and no `sorry`.
+Together they isolate *why* the conjecture is nontrivial: a lower bound of size
+`0` always exists, so the entire content of the conjecture is the *growth rate*
+(the polynomial exponent `c > 0`), not mere existence.
+-/
+
+/-- The constant bound `0` is always an Erdős–Hajnal lower bound: the independence
+    number is a nonnegative integer, so the left disjunct holds for every graph.
+    Hence the conjecture is entirely about the *rate* `n^c`, not existence. -/
+theorem isErdosHajnalLowerBound_zero {α : Type*} [Fintype α] [DecidableEq α]
+    (H : SimpleGraph α) : IsErdosHajnalLowerBound H (fun _ => 0) :=
+  Filter.Eventually.of_forall fun _ _ _ => Or.inl (by simp only [ge_iff_le]; positivity)
+
+/-- Erdős–Hajnal lower bounds are downward closed: weakening the target function
+    pointwise preserves the property. So the difficulty is monotone in the demanded
+    rate — establishing a *larger* bound is what is hard. -/
+theorem IsErdosHajnalLowerBound.mono {α : Type*} [Fintype α] [DecidableEq α]
+    {H : SimpleGraph α} {f g : ℕ → ℝ} (hg : IsErdosHajnalLowerBound H g)
+    (hfg : ∀ n, f n ≤ g n) : IsErdosHajnalLowerBound H f := by
+  filter_upwards [hg] with n hn
+  intro G hG
+  rcases hn G hG with hi | hc
+  · exact Or.inl (le_trans (hfg n) hi)
+  · exact Or.inr (le_trans (hfg n) hc)
+
 end Erdos61

--- a/research/problems/erdos-61-wip-01/knowledge.md
+++ b/research/problems/erdos-61-wip-01/knowledge.md
@@ -19,3 +19,25 @@ Insights accumulated during research on this problem.
 ## Dead Ends
 
 [Approaches known not to work will be documented here]
+
+---
+
+## Session 2026-07-20 (researcher-1) — bare stub → axiom-free structural lemmas
+
+**Mode**: FRESH (score 0). **Outcome**: progress (2 theorems, axiom-free), host-verified v4.31.
+**Problem is OPEN** (Erdős–Hajnal polynomial bound) — no attempt to prove the conjecture.
+
+Same flavor-(b) pathology: `Erdos61Problem.lean` had defs + `ErdosHajnalConjecture` Prop but **zero
+theorems**, while meta claimed the bounds were "stated as axioms" (`axiomCount=0`) and "All results
+proved from Lean primitives".
+
+**Added (0-axiom, `#print axioms` = propext/Classical.choice/Quot.sound):**
+- `isErdosHajnalLowerBound_zero` — the constant `0` is always an EH lower bound (`indepNum ≥ 0`);
+  `Filter.Eventually.of_forall … Or.inl (by simp only [ge_iff_le]; positivity)`.
+- `IsErdosHajnalLowerBound.mono` — downward closed: `f ≤ g` pointwise + `H`-bound-`g` ⟹ `H`-bound-`f`
+  (`filter_upwards [hg]` then `le_trans (hfg n)` into each disjunct).
+
+Conceptual point isolated: the conjecture is entirely about the growth *rate* (exponent `c>0`), not
+existence of a bound. **Meta synced**: theoremCount 0→2, lineCount→169, honest assumptions/proofStrategy.
+**Still open**: the conjecture itself + partial bounds (1989 exp(c√log n), BNSS 2023) — probabilistic
+combinatorics well beyond Mathlib v4.31.

--- a/src/data/proofs/erdos-61/meta.json
+++ b/src/data/proofs/erdos-61/meta.json
@@ -52,22 +52,22 @@
       "Concrete example graphs (triangle, 3-path)"
     ],
     "axiomCount": 0,
-    "lineCount": 137,
+    "lineCount": 169,
     "prerequisites": [
       "Ramsey theory and Ramsey numbers",
       "Hereditary graph properties",
       "Regularity method and blow-up lemma",
       "Probabilistic combinatorics"
     ],
-    "assumptions": "0 axioms, 0 sorries. All results proved from Lean primitives.",
-    "theoremCount": 0,
+    "assumptions": "0 axioms, 0 sorries. Two axiom-free structural lemmas about the IsErdosHajnalLowerBound predicate are proved (the zero bound always holds; lower bounds are downward closed), each depending only on propext/Classical.choice/Quot.sound. The main Erdős–Hajnal conjecture is OPEN, and the two partial bounds (1989, BNSS 2023) are NOT formalized — they are documented only in the header prose. Status \"axiomatized\"/\"wip\" reflects an open problem with no machine-checked bound.",
+    "theoremCount": 2,
     "definitionCount": 4
   },
   "overview": {
     "historicalContext": "The Erdős–Hajnal conjecture, proposed in 1989, is one of the most important open problems in graph theory. It connects two fundamental concepts: induced subgraphs and Ramsey-type bounds.\n\nClassical Ramsey theory tells us that every graph on n vertices contains either a clique or independent set of size at least c·log(n). This logarithmic bound is tight for general graphs. However, Erdős and Hajnal conjectured that FORBIDDING a specific induced subgraph H should dramatically improve this bound to a polynomial n^c.\n\nDespite intensive study for over 35 years, the conjecture remains open. The best known general bound, due to Bucić, Nguyen, Scott, and Seymour (2023), is exp(c√(log n · log log n))—still far from the conjectured polynomial.",
     "problemStatement": "**The Erdős–Hajnal Conjecture (OPEN)**\n\nFor any graph $H$, there exists a constant $c = c(H) > 0$ such that every graph $G$ on $n$ vertices that does NOT contain $H$ as an induced subgraph has either:\n- A clique of size $\\geq n^c$, OR\n- An independent set of size $\\geq n^c$\n\n**Status**: OPEN\n\n**Best known bounds**:\n- Erdős-Hajnal (1989): $\\exp(c_H \\sqrt{\\log n})$\n- BNSS (2023): $\\exp(c_H \\sqrt{\\log n \\cdot \\log\\log n})$",
     "text": "For any graph H, does there exist c > 0 such that every H-free graph on n vertices has a clique or independent set of size at least n^c?",
-    "proofStrategy": "We formalize the conjecture and its partial results:\n\n1. **IsErdosHajnalLowerBound**: A predicate capturing when function f is a valid lower bound for graph H\n\n2. **ErdosHajnalConjecture**: The statement that polynomial bounds always exist\n\n3. **Axioms for partial results**: We state the 1989 and 2023 bounds as axioms, since their proofs require probabilistic combinatorics beyond current Mathlib\n\n4. **Example graphs**: We define concrete small graphs (triangle, 3-path) to make the definitions testable",
+    "proofStrategy": "We formalize the Erdős–Hajnal conjecture and record the state of the art. The Lean file defines `IsErdosHajnalLowerBound H f` (eventually, every H-free graph on n vertices has an independent set or clique of size ≥ f(n)) and `ErdosHajnalConjecture` (a polynomial bound n^c exists for every H), plus concrete example graphs. On top of the definitions it proves two axiom-free structural lemmas: `isErdosHajnalLowerBound_zero` (the constant bound 0 is always a lower bound, since the independence number is nonnegative) and `IsErdosHajnalLowerBound.mono` (lower bounds are downward closed). Together they isolate that the conjecture is entirely about the growth rate (the exponent c>0), not existence. The main conjecture is OPEN; the two partial bounds (Erdős–Hajnal 1989 exp(c√log n), BNSS 2023 exp(c√(log n·log log n))) are documented in the header prose but NOT formalized.",
     "keyInsights": [
       "**Induced subgraph**: H is induced in G if we find H by selecting vertices and keeping EXACTLY their edges—no extra edges, no missing edges. This is stronger than just being a subgraph.",
       "**Why Ramsey bounds are weak**: Random graphs show that log(n) is the best general bound. The conjecture says structure (forbidding H) should help.",
@@ -146,9 +146,9 @@
       "Real"
     ],
     "namespace": "Erdos61",
-    "lineCount": 137,
+    "lineCount": 169,
     "axiomCount": 0,
-    "theoremCount": 0,
+    "theoremCount": 2,
     "definitionCount": 4,
     "path": "Proofs/Erdos61Problem.lean",
     "sorries": 0

--- a/src/data/research/problems/erdos-61-wip-01.json
+++ b/src/data/research/problems/erdos-61-wip-01.json
@@ -18,7 +18,7 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "OBSERVE",
+    "phase": "ORIENT",
     "since": "2026-07-09T17:33:20-07:00",
     "iteration": 1,
     "focus": "Initial problem understanding. Read problem.md and gather context.",
@@ -31,9 +31,14 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
+    "progressSummary": "PROGRESS: bare stub -> 2 axiom-free structural lemmas clarifying the conjecture is about growth rate not existence; fixed overclaiming meta (theoremCount 0->2). Main conjecture OPEN; partial bounds documented-only.",
+    "builtItems": [
+      "isErdosHajnalLowerBound_zero / IsErdosHajnalLowerBound.mono in proofs/Proofs/Erdos61Problem.lean (2 axiom-free thms; host-verified v4.31)"
+    ],
+    "insights": [
+      "Erdos61Problem.lean (Erdős–Hajnal, OPEN) was a bare stub: defs + ErdosHajnalConjecture Prop, ZERO theorems; meta falsely said the bounds were stated as axioms (axiomCount=0) and All results proved.",
+      "Structural core: the 0 bound is always an EH lower bound (indepNum≥0), and EH lower bounds are downward closed — so the conjecture is about the exponent c>0, not existence."
+    ],
     "mathlibGaps": [],
     "nextSteps": [],
     "markdown": "# Knowledge Base: erdos-61-wip-01\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"


### PR DESCRIPTION
## Summary
Research session for **erdos-61** (Erdős–Hajnal conjecture, **OPEN**). `Erdos61Problem.lean` was a bare statement-stub: real definitions and `ErdosHajnalConjecture` as a `Prop`, but **zero theorems** — while the gallery meta claimed the partial bounds were "stated as axioms" (`axiomCount=0`, none exist) and "All results proved from Lean primitives" (no results existed). This PR adds a genuine verified core and makes the meta honest.

## Progress
Added **2 axiom-free structural lemmas** to `proofs/Proofs/Erdos61Problem.lean` (host-verified on v4.31; `#print axioms` = `propext/Classical.choice/Quot.sound` only):
- `isErdosHajnalLowerBound_zero` — the constant bound `0` is always an Erdős–Hajnal lower bound (the independence number is nonnegative). This isolates that the conjecture's content is the *growth rate* (exponent `c > 0`), not existence.
- `IsErdosHajnalLowerBound.mono` — EH lower bounds are downward closed (weakening the target pointwise preserves the property).

## Findings
- The main conjecture is genuinely OPEN; the two partial bounds (Erdős–Hajnal 1989 `exp(c√log n)`, BNSS 2023 `exp(c√(log n·log log n))`) require probabilistic combinatorics **beyond Mathlib v4.31** and remain documented header prose.

## Files modified
- `proofs/Proofs/Erdos61Problem.lean` (+2 theorems, 137→169 lines)
- `src/data/proofs/erdos-61/meta.json` — theoremCount 0→2, lineCount synced; `proofStrategy`/`assumptions` corrected
- `src/data/research/problems/erdos-61-wip-01.json`, `research/problems/erdos-61-wip-01/knowledge.md`

## Status
**Outcome**: progress (2 axiom-free theorems; gallery integrity fix). Main conjecture remains OPEN.

🤖 Generated by researcher-1