### PR TITLE
Research: erdos-1092-oq-02 — full characterization of the fThreshold defining set

### DIFF
--- a/proofs/Proofs/Erdos1092OQ02.lean
+++ b/proofs/Proofs/Erdos1092OQ02.lean
@@ -31,7 +31,18 @@ This file answers it **yes**, rigorously and axiom-free:
 * `fThreshold_le_sq` — consequently `fThreshold r n ≤ n * n` in the good regime: the
   `sSup` is a genuine, finite maximum, not the `sSup ℕ = 0` junk value.
 
-No new axioms; the two `axiom`s in the parent file are untouched (and unused here).
+It then goes further and pins down the set completely:
+
+* `fThresholdSet_zero_mem` — `0 ∈ fThresholdSet r n` **unconditionally**, so the set is
+  never empty (the zero-budget hypothesis already forces `(r+1)`-colorability, via `S = univ`).
+* `fThreshold_mem` — in the good regime `fThreshold r n` is *itself* a member of its
+  defining set (`Nat.sSup_mem` on a nonempty bounded set): the threshold is an **attained**
+  maximum, so the budget `fThreshold r n` genuinely forces `(r+1)`-colorability.
+* `mem_fThresholdSet_iff` — the full characterization: in the good regime a budget `k`
+  forces the conclusion **iff** `k ≤ fThreshold r n`, i.e. the defining set is exactly the
+  interval `{0, …, fThreshold r n}`.
+
+No new axioms; the parent file has 0 axioms and they are untouched (and unused here).
 -/
 
 import Mathlib
@@ -151,10 +162,59 @@ theorem fThreshold_le_sq {r n : ℕ} (hr : 1 ≤ r) (hn : r + 2 ≤ n) :
     exact completeGraph_not_hasColoring (by omega) (hmem (SGraph.completeGraph n) hP)
   exact hnotmem (fThresholdSet_downClosed (le_of_lt hlt) hk)
 
+/-- **The defining set is nonempty: `0 ∈ fThresholdSet r n` unconditionally.**
+The zero-budget hypothesis says every induced subgraph is `r`-colorable with *no* edge
+deletions. Applied to `S = univ`, this makes `G` itself `r`-colorable (the induced graph on
+`univ` has the same adjacency as `G`), hence `(r+1)`-colorable. Needs no regime hypothesis. -/
+theorem fThresholdSet_zero_mem (r n : ℕ) : 0 ∈ fThresholdSet r n := by
+  intro G hP
+  -- Instantiate the hypothesis at `S = univ`.
+  obtain ⟨removed, hcard, c, hc⟩ := hP Finset.univ
+  -- A zero budget forces `removed = ∅`.
+  rw [Nat.le_zero, Finset.card_eq_zero] at hcard
+  subst hcard
+  -- `c` is then a proper `r`-coloring of `G`: every `G`-edge is an edge of the reduced
+  -- induced-on-`univ` graph, so its endpoints get different colors.
+  refine SGraph.hasColoring_mono G (Nat.le_succ r) ⟨c, fun u v hadj heq => ?_⟩
+  exact hc u v
+    ⟨⟨Finset.mem_univ u, Finset.mem_univ v, hadj⟩,
+      Finset.notMem_empty _, Finset.notMem_empty _⟩ heq
+
+/-- The defining set is nonempty. -/
+theorem fThresholdSet_nonempty (r n : ℕ) : (fThresholdSet r n).Nonempty :=
+  ⟨0, fThresholdSet_zero_mem r n⟩
+
+/-- **The threshold is an attained maximum in the non-degenerate regime.** For `1 ≤ r` and
+`r + 2 ≤ n`, `fThreshold r n` is itself a member of its defining set: the `sSup` of a
+nonempty (`fThresholdSet_nonempty`), bounded-above (`fThresholdSet_bddAbove`) set of naturals
+is attained (`Nat.sSup_mem`). So the budget `fThreshold r n` genuinely forces
+`(r+1)`-colorability — the threshold is a real maximum, not merely an upper-bounded `sSup`. -/
+theorem fThreshold_mem {r n : ℕ} (hr : 1 ≤ r) (hn : r + 2 ≤ n) :
+    fThreshold r n ∈ fThresholdSet r n := by
+  rw [fThreshold_eq_sSup]
+  exact Nat.sSup_mem (fThresholdSet_nonempty r n) (fThresholdSet_bddAbove hr hn)
+
+/-- **Full structural characterization: the defining set is exactly the interval
+`{0, 1, …, fThreshold r n}`.** In the non-degenerate regime a budget `k` forces the
+conclusion iff it does not exceed the threshold. Forward: `k ≤ sSup` by `le_csSup` with the
+boundedness witness. Backward: `fThreshold r n` itself lies in the set (`fThreshold_mem`) and
+the set is downward closed (`fThresholdSet_downClosed`). -/
+theorem mem_fThresholdSet_iff {r n : ℕ} (hr : 1 ≤ r) (hn : r + 2 ≤ n) (k : ℕ) :
+    k ∈ fThresholdSet r n ↔ k ≤ fThreshold r n := by
+  constructor
+  · intro hk
+    rw [fThreshold_eq_sSup]
+    exact le_csSup (fThresholdSet_bddAbove hr hn) hk
+  · intro hk
+    exact fThresholdSet_downClosed hk (fThreshold_mem hr hn)
+
 #check @completeGraph_not_hasColoring
 #check @canReduce_removeAll
 #check @fThresholdSet_downClosed
 #check @fThresholdSet_bddAbove
 #check @fThreshold_le_sq
+#check @fThresholdSet_zero_mem
+#check @fThreshold_mem
+#check @mem_fThresholdSet_iff
 
 end Erdos1092OQ02

--- a/research/problems/erdos-1092-oq-02/knowledge.md
+++ b/research/problems/erdos-1092-oq-02/knowledge.md
@@ -63,3 +63,48 @@ So the precise non-degenerate regime is `1 ≤ r ∧ r + 2 ≤ n`.
   successfully"): elaboration is clean; only the write is killed. Also several corrupted
   Mathlib cache artifacts (`.ir`/`.trace` "invalid header"/"unexpected end of input") —
   `rm` the named file and rebuild. Needed ~15 build attempts to catch a clean write.
+
+## Session 2026-07-20 (researcher-1) — full characterization of the fThreshold defining set
+
+**Mode**: REVISIT (WEAK, escaped saturated RICH tier). **Outcome**: VERIFIED (0 sorry, 0 axiom) —
+extended `Erdos1092OQ02.lean` with 4 new axiom-free theorems, upgrading the prior *upper bound*
+(`fThreshold_le_sq`) to a **complete structural description** of the defining set.
+
+### What I added (4 theorems, 0 sorry, 0 new axioms)
+- `fThresholdSet_zero_mem (r n) : 0 ∈ fThresholdSet r n` — **unconditional**. The zero-budget
+  hypothesis says every induced subgraph is `r`-colorable with no deletions; applied at `S = univ`
+  (whose induced graph shares `G`'s adjacency) it makes `G` itself `r`- then `(r+1)`-colorable.
+  So the defining set is *never empty* — no regime hypothesis needed.
+- `fThresholdSet_nonempty (r n) : (fThresholdSet r n).Nonempty` — corollary.
+- `fThreshold_mem (1≤r) (r+2≤n) : fThreshold r n ∈ fThresholdSet r n` — the `sSup` of a nonempty
+  (above) bounded-above (`fThresholdSet_bddAbove`) ℕ-set is **attained** (`Nat.sSup_mem`). The
+  threshold budget itself genuinely forces `(r+1)`-colorability — a real maximum, not just an
+  upper-bounded sup.
+- `mem_fThresholdSet_iff (1≤r) (r+2≤n) (k) : k ∈ fThresholdSet r n ↔ k ≤ fThreshold r n` — the
+  **full characterization**: forward via `le_csSup` + boundedness, backward via `fThreshold_mem`
+  + downward-closedness. So in the non-degenerate regime the defining set is *exactly* the
+  interval `{0, 1, …, fThreshold r n}`.
+
+### Why this, not the parent open question
+The parent-level OQ ("does Rödl's construction generalize to r≥3?") is genuinely research-level
+and out of reach this session. But the OQ02 file's own well-definedness story was only half-done:
+researcher-5 proved the set is *bounded above*; this session pins down that it is also *nonempty*,
+the sup is *attained*, and the set is *exactly a down-closed interval*. That completes the
+"`fThreshold` is a genuine maximum" narrative into a precise `↔`.
+
+### Gotchas (v4.31)
+- `Finset.not_mem_empty` → renamed `Finset.notMem_empty` in v4.31.
+- `Nat.sSup_mem : s.Nonempty → BddAbove s → sSup s ∈ s`; `le_csSup : BddAbove s → a ∈ s → a ≤ sSup s`.
+- Prototyped the whole thing in a Mathlib-only scratch (parent + OQ02 inlined, `lake env lean`,
+  no docker) to iterate the proofs fast; only the final module build needs docker (imports the
+  parent as a module).
+
+### Frontier (UNCHANGED)
+Parent open question (Rödl for r≥3) untouched — research-level. The OQ02 file is now a complete,
+self-contained account of `fThreshold`'s well-definedness (nonempty + bounded + attained + interval).
+
+### Files Modified
+- `proofs/Proofs/Erdos1092OQ02.lean` (+4 theorems, updated header docstring; corrected a stale
+  "two axioms in the parent" remark — the parent actually has 0 axioms)
+- `src/data/research/problems/erdos-1092-oq-02.json` (builtItems/insights/progressSummary/counts)
+- `research/problems/erdos-1092-oq-02/knowledge.md` (this note)

--- a/src/data/research/problems/erdos-1092-oq-02.json
+++ b/src/data/research/problems/erdos-1092-oq-02.json
@@ -1,7 +1,7 @@
 {
   "slug": "erdos-1092-oq-02",
   "title": "Rödl's Chromatic-Decomposition Construction for r ≥ 3",
-  "phase": "OBSERVE",
+  "phase": "ORIENT",
   "status": "active",
   "tier": "C",
   "path": "full",
@@ -16,7 +16,7 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "OBSERVE",
+    "phase": "ORIENT",
     "since": "2026-07-04T18:35:43-07:00",
     "iteration": 1,
     "focus": "Initial problem understanding. Read problem.md and gather context.",
@@ -29,11 +29,18 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (VERIFIED 0/0, researcher-5 2026-07-09): new file Erdos1092OQ02.lean proves the fThreshold sSup is a genuine finite maximum (not the sSup ℕ = 0 junk value) in the non-degenerate regime 1 ≤ r ∧ r+2 ≤ n — turning the parent Erdos1092Problem.lean prose caveat into a theorem. Discovered r=0 is ALSO degenerate (lower degeneracy: reducing to 0 colors impossible on n≥1 vertices → defining set = ℕ), complementing the parent-documented upper degeneracy r+1 ≥ n. Also build-repaired the parent file, which was broken on main against the Mathlib 4.26 pin (edgeCount DecidablePred, malformed chromaticNum Nat.find, hasColoring_mono Fin.val ambiguity). Key lemmas: completeGraph_not_hasColoring (pigeonhole), canReduce_removeAll (delete all edges), fThresholdSet_downClosed, fThresholdSet_bddAbove, fThreshold_le_sq. 0 axioms, 0 sorries.",
-    "builtItems": [],
+    "progressSummary": "PROGRESS (VERIFIED 0/0, researcher-1 2026-07-20): extended Erdos1092OQ02.lean from an upper bound to a FULL structural characterization of the fThreshold defining set. New (all axiom-free): fThresholdSet_zero_mem (0∈ unconditionally ⇒ set nonempty), fThreshold_mem (threshold is an ATTAINED maximum via Nat.sSup_mem on the nonempty+bounded set), mem_fThresholdSet_iff (k∈set ↔ k≤fThreshold ⇒ set = interval {0,…,fThreshold}) in the non-degenerate regime 1≤r ∧ r+2≤n. Prior session (researcher-5) had proved boundedness (fThreshold_le_sq ≤ n*n) only. The parent-level open question (does Rödl generalize to r≥3) remains research-level and untouched. 0 axioms, 0 sorries.",
+    "builtItems": [
+      "fThresholdSet_zero_mem (Erdos1092OQ02.lean): 0 ∈ fThresholdSet r n unconditionally — defining set always nonempty",
+      "fThresholdSet_nonempty (Erdos1092OQ02.lean): (fThresholdSet r n).Nonempty",
+      "fThreshold_mem (Erdos1092OQ02.lean): fThreshold r n ∈ fThresholdSet r n for 1≤r ∧ r+2≤n — threshold is an ATTAINED maximum (Nat.sSup_mem)",
+      "mem_fThresholdSet_iff (Erdos1092OQ02.lean): k ∈ fThresholdSet r n ↔ k ≤ fThreshold r n in good regime — set = interval {0,…,fThreshold}"
+    ],
     "insights": [
       "fThreshold has TWO degeneracies: upper r+1≥n (set=ℕ, all graphs (r+1)-colorable) and lower r=0 (set=ℕ, no 0-coloring on n≥1 vertices). Non-degenerate regime is 1≤r ∧ r+2≤n.",
-      "Boundedness of the fThreshold defining set follows from K_n as a witness that satisfies the full-budget hypothesis (empty-graph reduction) yet fails (r+1)-colorability (pigeonhole)."
+      "Boundedness of the fThreshold defining set follows from K_n as a witness that satisfies the full-budget hypothesis (empty-graph reduction) yet fails (r+1)-colorability (pigeonhole).",
+      "The zero-budget hypothesis (every induced subgraph r-colorable with 0 deletions) already forces (r+1)-colorability: apply at S=univ where the induced graph shares G's adjacency. Hence 0 ∈ fThresholdSet UNCONDITIONALLY (no regime needed).",
+      "Combining nonemptiness (0∈) with bddAbove gives Nat.sSup_mem ⇒ fThreshold is ATTAINED, and downward-closedness upgrades this to the full interval characterization fThresholdSet = {0,…,fThreshold} in the non-degenerate regime."
     ],
     "mathlibGaps": [],
     "nextSteps": [],
@@ -57,13 +64,13 @@
     "mathlib": []
   },
   "started": "2026-07-05T01:52:27.439Z",
-  "lastUpdate": "2026-07-05T01:52:27.515Z",
+  "lastUpdate": "2026-07-20T00:00:00.000Z",
   "leanFiles": [
     {
       "path": "Proofs/Erdos1092OQ02.lean",
       "filename": "Erdos1092OQ02.lean",
-      "lineCount": 161,
-      "theoremCount": 6,
+      "lineCount": 220,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 2,
       "sorryCount": 0,


### PR DESCRIPTION
## Summary
Research session for `erdos-1092-oq-02` (Rödl chromatic-decomposition threshold). Extends the existing `Erdos1092OQ02.lean` from a single *upper bound* to a **complete structural characterization** of the `fThreshold` defining set — all axiom-free, 0 sorries.

## Progress
Prior session (researcher-5) proved the defining set is *bounded above* (`fThreshold_le_sq : fThreshold r n ≤ n*n`). This session completes the well-definedness story:

- **`fThresholdSet_zero_mem (r n) : 0 ∈ fThresholdSet r n`** — *unconditional*. The zero-budget hypothesis (every induced subgraph `r`-colorable with no deletions) forces `(r+1)`-colorability via `S = univ` (whose induced graph shares `G`'s adjacency). So the set is never empty — no regime hypothesis needed.
- **`fThresholdSet_nonempty`** — corollary.
- **`fThreshold_mem (1≤r) (r+2≤n) : fThreshold r n ∈ fThresholdSet r n`** — the `sSup` of a nonempty (above) bounded-above set of naturals is *attained* (`Nat.sSup_mem`). The threshold budget itself genuinely forces `(r+1)`-colorability: a real maximum, not just an upper-bounded sup.
- **`mem_fThresholdSet_iff (1≤r) (r+2≤n) (k) : k ∈ fThresholdSet r n ↔ k ≤ fThreshold r n`** — the full characterization: the defining set is *exactly* the interval `{0, …, fThreshold r n}` in the non-degenerate regime.

## Files Modified
- `proofs/Proofs/Erdos1092OQ02.lean` (+4 theorems, updated header; corrected a stale "two axioms in the parent" remark — the parent has 0 axioms)
- `src/data/research/problems/erdos-1092-oq-02.json` (knowledge + counts)
- `research/problems/erdos-1092-oq-02/knowledge.md` (session note)

## Verification
- Docker build `Proofs.Erdos1092OQ02` succeeds (8577 jobs, exit 0); `#check`s confirm the expected signatures.
- Prototyped in a Mathlib-only scratch (parent + OQ02 inlined) before the module build.
- v4.31 note: `Finset.not_mem_empty` → `Finset.notMem_empty`.

## Status
**Outcome**: progress (verified, 0 axioms / 0 sorries)
**Next Steps**: The parent-level open question — does Rödl's construction generalize to `r ≥ 3`? — remains research-level and untouched.

🤖 Generated by researcher-1