### PR TITLE
audit: erdos-683 — drop 8 phantom axiomatized declarations from prose

### DIFF
--- a/src/data/proofs/erdos-683/meta.json
+++ b/src/data/proofs/erdos-683/meta.json
@@ -47,16 +47,16 @@
       }
     ],
     "originalContributions": [
-      "largestPrimeDivisor with P_is_prime, P_divides, P_largest axioms",
-      "P(C(n,k)) applied to binomial coefficients",
-      "sylvester_schur axiom: P(C(n,k)) > k",
+      "largestPrimeDivisor definition (via Nat.find), with P_is_prime and P_divides theorems proved from Nat.find_spec",
+      "P(n,k) := largestPrimeDivisor(C(n,k)) definition",
+      "sylvester_schur axiom: P(C(n,k)) > k for k ≤ n/2",
       "erdos_1955_bound axiom: P(C(n,k)) ≥ c·k·log k",
-      "erdosConjecture683: the main open conjecture formalized",
-      "erdos_1979_belief: k^{1+c} with finite exceptions",
-      "prime_gap_heuristic and heuristic_stronger_than_conjecture",
-      "consecutiveProduct, bertrand_for_central, consecutive_has_large_prime",
-      "central_binom_bound and small_k_case_2",
-      "erdos_683_summary combining proven bounds"
+      "choose_gt_one and binom_has_large_prime theorems derived from the axioms",
+      "erdos_1955_asymptotic theorem: instantiation of the 1955 bound",
+      "erdosConjecture683 definition: the main open conjecture stated as a Prop",
+      "consecutiveProduct definition: ∏_{i<k}(m+i)",
+      "erdos_683_summary theorem combining the two axiomatized bounds",
+      "Prose comments (documentation only, no Lean declarations) discussing the 1979 belief, the Cramér heuristic e^{c√k}, the trivial upper bound P≤n, Bertrand/central-binomial, and small-k cases"
     ],
     "relatedProblems": [
       {
@@ -100,7 +100,7 @@
     "historicalContext": "**Origins: Sylvester and Schur (1892–1929)**\n\nJ.J. Sylvester (1892) proved that among any $k$ consecutive integers greater than $k$, at least one has a prime factor exceeding $k$. Issai Schur (1929) refined this to show that the binomial coefficient $\\binom{n}{k}$ itself has a prime divisor $> k$ when $k \\le n/2$. The key insight is that $\\binom{n}{k} = \\frac{(n-k+1) \\cdots n}{k!}$, and primes $> k$ in the numerator survive division by $k!$.\n\n**Erdős's Contributions (1934–1979)**\n\nErdős gave a new proof of the Sylvester-Schur theorem in 1934, using elementary methods. In 1955, he achieved a breakthrough by proving $P(\\binom{n}{k}) \\ge c \\cdot k \\log k$ using the prime number theorem and a counting argument on prime factors in consecutive products. By 1979, in 'Some unconventional problems in number theory,' Erdős conjectured the far stronger bound $P(\\binom{n}{k}) \\ge \\min(n-k+1, k^{1+c})$ and wrote that it 'seems certain' that $P > k^{1+c}$ for ANY $c > 0$ with only finitely many exceptions.\n\n**Current Status and Heuristics**\n\nThe problem remains open after 45+ years. The gap from $k \\log k$ (Erdős 1955) to $k^{1+c}$ (the conjecture) is enormous. Cramér-type probabilistic heuristics based on the random model of primes suggest the even stronger stretched exponential bound $P > e^{c\\sqrt{k}}$, which dwarfs any polynomial. The problem is essentially equivalent to Erdős Problem #961 on smooth numbers in consecutive intervals.",
     "problemStatement": "**Problem Statement (OPEN)**\n\nFor every $1 \\le k \\le n$, does there exist a constant $c > 0$ such that:\n$$P(\\binom{n}{k}) \\ge \\min(n - k + 1,\\, k^{1+c})$$\nwhere $P(m)$ denotes the largest prime divisor of $m$?\n\n**Known:**\n- $P(\\binom{n}{k}) > k$ for $k \\le n/2$ (Sylvester 1892, Schur 1929)\n- $P(\\binom{n}{k}) \\ge c \\cdot k \\log k$ for $k \\le n/2$ (Erdős 1955)\n\n**Believed:**\n- For any $c > 0$, $P(\\binom{n}{k}) > k^{1+c}$ with only finitely many exceptions (Erdős 1979)",
     "text": "For 1 ≤ k ≤ n, is P(C(n,k)) ≥ min(n-k+1, k^{1+c}) for some c > 0? Sylvester-Schur (1892/1929) proved P(C(n,k)) > k. Erdős (1955) improved this to P(C(n,k)) ≫ k log k. The full conjecture remains OPEN.",
-    "proofStrategy": "**Formalization Strategy**\n\n1. **Axiomatic approach to $P(n)$**: Defines `largestPrimeDivisor` via `Nat.find`, then axiomatizes the three key properties (primality, divisibility, maximality) to avoid dependence on Mathlib's factorization internals\n2. **Hierarchy of bounds**: Formalizes the chain $k < k \\log k < k^{1+c} < e^{c\\sqrt{k}}$ with each result building on the previous\n3. **Two-regime structure**: The $\\min(n-k+1, k^{1+c})$ captures the transition at $k \\approx n^{1/(1+c)}$\n4. **Consecutive product connection**: Defines `consecutiveProduct` and links it to $\\binom{n}{k}$ via the numerator identity\n5. **Special cases**: Verifies the central binomial ($k = n/2$) and small $k$ cases as consistency checks\n6. **Summary theorem**: Combines the two proven bounds (Sylvester-Schur and Erdős 1955) into a single conjunction via term-mode proof",
+    "proofStrategy": "**Formalization Strategy**\n\n1. **Axiomatic approach to $P(n)$**: Defines `largestPrimeDivisor` via `Nat.find`, then axiomatizes the three key properties (primality, divisibility, maximality) to avoid dependence on Mathlib's factorization internals\n2. **Hierarchy of bounds**: Formalizes the chain $k < k \\log k < k^{1+c} < e^{c\\sqrt{k}}$ with each result building on the previous\n3. **Two-regime structure**: The $\\min(n-k+1, k^{1+c})$ captures the transition at $k \\approx n^{1/(1+c)}$\n4. **Consecutive product connection**: Defines `consecutiveProduct` and links it to $\\binom{n}{k}$ via the numerator identity\n5. **Special cases**: Discusses the central binomial ($k = n/2$) and small $k$ cases in prose comments as consistency checks (not formalized)\n6. **Summary theorem**: `erdos_683_summary` combines the two axiomatized bounds (Sylvester-Schur and Erdős 1955) into a single conjunction via term-mode proof",
     "keyInsights": [
       "**Sylvester-Schur foundation**: $P(\\binom{n}{k}) > k$ because primes $> k$ in the numerator $(n-k+1) \\cdots n$ survive division by $k!$, which contains only primes $\\le k$",
       "**Erdős's logarithmic leap**: The improvement from $k$ to $c \\cdot k \\log k$ uses the prime number theorem — among $k$ consecutive integers, $\\sim k/\\log k$ are prime, providing a logarithmic factor",
@@ -144,40 +144,40 @@
       "title": "The Main Conjecture: $P \\ge \\min(n-k+1, k^{1+c})$",
       "startLine": 139,
       "endLine": 162,
-      "summary": "Formalizes `erdosConjecture683` as a `Prop` and axiomatizes Erdős's 1979 belief that $P > k^{1+c}$ for all $c > 0$ with finite exceptions.",
-      "mathContext": "Axiomatized: Formalizes `erdosConjecture683` as a `Prop` and axiomatizes Erdős's 1979 belief that $P > k^{1+c}$ for all $c > 0$ with finite exceptions."
+      "summary": "Formalizes `erdosConjecture683` as a `Prop`. Erdős's 1979 belief ($P > k^{1+c}$ for all $c > 0$ with finite exceptions) is documented in a prose comment, not formalized.",
+      "mathContext": "Formal definition: Formalizes `erdosConjecture683` as a `Prop`. Erdős's 1979 belief ($P > k^{1+c}$ for all $c > 0$ with finite exceptions) is documented in a prose comment, not formalized."
     },
     {
       "id": "heuristics",
       "title": "Heuristic Bounds: $P > e^{c\\sqrt{k}}$",
       "startLine": 163,
       "endLine": 189,
-      "summary": "Axiomatizes the Cramér-type heuristic $P(\\binom{n}{k}) > e^{c\\sqrt{k}}$ and the comparison $e^{c\\sqrt{k}} > k^{1+c}$ (stretched exponential vs polynomial).",
-      "mathContext": "Axiomatized: Axiomatizes the Cramér-type heuristic $P(\\binom{n}{k}) > e^{c\\sqrt{k}}$ and the comparison $e^{c\\sqrt{k}} > k^{1+c}$ (stretched exponential vs polynomial)."
+      "summary": "Prose only: documents (in comments, no Lean declarations) the Cramér-type heuristic $P(\\binom{n}{k}) > e^{c\\sqrt{k}}$ and the comparison $e^{c\\sqrt{k}} > k^{1+c}$ (stretched exponential vs polynomial).",
+      "mathContext": "Prose only: documents (in comments, no Lean declarations) the Cramér-type heuristic $P(\\binom{n}{k}) > e^{c\\sqrt{k}}$ and the comparison $e^{c\\sqrt{k}} > k^{1+c}$ (stretched exponential vs polynomial)."
     },
     {
       "id": "min-bound",
       "title": "Trivial Upper Bound: $P(\\binom{n}{k}) \\le n$",
       "startLine": 190,
       "endLine": 200,
-      "summary": "Axiomatizes $P(\\binom{n}{k}) \\le n$, the trivial upper bound since $\\binom{n}{k}$ divides products of terms $\\le n$.",
-      "mathContext": "Axiomatized: Axiomatizes $P(\\binom{n}{k}) \\le n$, the trivial upper bound since $\\binom{n}{k}$ divides products of terms $\\le n$."
+      "summary": "Prose only: documents the trivial upper bound $P(\\binom{n}{k}) \\le n$ in a comment (since $\\binom{n}{k}$ divides products of terms $\\le n$); not formalized.",
+      "mathContext": "Prose only: documents the trivial upper bound $P(\\binom{n}{k}) \\le n$ in a comment (since $\\binom{n}{k}$ divides products of terms $\\le n$); not formalized."
     },
     {
       "id": "consecutive",
       "title": "Consecutive Products and Bertrand's Postulate",
       "startLine": 201,
       "endLine": 228,
-      "summary": "Defines `consecutiveProduct m k = \\prod_{i=0}^{k-1}(m+i)` and axiomatizes Bertrand-type results: $P(\\binom{2n}{n}) > n$ and Sylvester's theorem for consecutive products.",
-      "mathContext": "Formal definition: Defines `consecutiveProduct m k = \\prod_{i=0}^{k-1}(m+i)` and axiomatizes Bertrand-type results: $P(\\binom{2n}{n}) > n$ and Sylvester's theorem for consecutive products."
+      "summary": "Defines `consecutiveProduct m k = \\prod_{i=0}^{k-1}(m+i)`. Bertrand-type results ($P(\\binom{2n}{n}) > n$, Sylvester's theorem for consecutive products) are documented in prose comments, not axiomatized.",
+      "mathContext": "Formal definition: Defines `consecutiveProduct m k = \\prod_{i=0}^{k-1}(m+i)`. Bertrand-type results ($P(\\binom{2n}{n}) > n$, Sylvester's theorem for consecutive products) are documented in prose comments, not axiomatized."
     },
     {
       "id": "specific-cases",
       "title": "Central Binomial and Small $k$ Cases",
       "startLine": 229,
       "endLine": 250,
-      "summary": "Axiomatizes $P(\\binom{2k}{k}) > \\frac{4}{3}k$ for large $k$ and $P(\\binom{n}{2}) \\ge (n-1)/2$ for $n \\ge 4$ as consistency checks.",
-      "mathContext": "Axiomatized: Axiomatizes $P(\\binom{2k}{k}) > \\frac{4}{3}k$ for large $k$ and $P(\\binom{n}{2}) \\ge (n-1)/2$ for $n \\ge 4$ as consistency checks."
+      "summary": "Prose only: documents the central binomial case $P(\\binom{2k}{k}) > \\frac{4}{3}k$ for large $k$ and the small-$k$ case $P(\\binom{n}{2}) \\ge (n-1)/2$ for $n \\ge 4$ in comments; neither is formalized.",
+      "mathContext": "Prose only: documents the central binomial case $P(\\binom{2k}{k}) > \\frac{4}{3}k$ for large $k$ and the small-$k$ case $P(\\binom{n}{2}) \\ge (n-1)/2$ for $n \\ge 4$ in comments; neither is formalized."
     },
     {
       "id": "summary",


### PR DESCRIPTION
## Integrity Issue

**Proof**: erdos-683 (Largest Prime Divisor of Binomial Coefficients)
**Problem**: meta.json prose overstates the formalization — it names 8 declarations that do not exist and describes prose comment blocks as "Axiomatizes …".

## Evidence

Complete declaration inventory of `proofs/Proofs/Erdos683Problem.lean` (12 decls):
- **defs (4)**: `largestPrimeDivisor`, `P`, `erdosConjecture683`, `consecutiveProduct`
- **theorems (6)**: `P_is_prime`, `P_divides`, `choose_gt_one`, `binom_has_large_prime`, `erdos_1955_asymptotic`, `erdos_683_summary`
- **axioms (2)**: `sylvester_schur`, `erdos_1955_bound`

**Phantom names in `originalContributions`** (0 occurrences in source): `P_largest`, `erdos_1979_belief`, `prime_gap_heuristic`, `heuristic_stronger_than_conjecture`, `bertrand_for_central`, `consecutive_has_large_prime`, `central_binom_bound`, `small_k_case_2`.

**Sections falsely claiming "Axiomatizes"** — Parts V–VIII (`heuristics`, `min-bound`, part of `consecutive`, `specific-cases`, and the 1979 belief in `main-conjecture`) are entirely prose comments with no Lean declarations, yet were described as axiomatized results (Cramér heuristic $e^{c\sqrt{k}}$, upper bound $P\le n$, Bertrand $P(\binom{2n}{n})>n$, central binomial $\tfrac43 k$, small-$k$ cases).

## Fix

- Rewrote `originalContributions` to list only the 12 real declarations, with a final bullet noting the Part V–VIII items are prose documentation only.
- Corrected the 5 section summaries/`mathContext` to say "Prose only / documented in comments, not formalized" instead of "Axiomatizes".
- Softened `proofStrategy` item 5 ("Verifies" → "Discusses in prose comments").

Counts (`axiomCount: 2`, `theoremCount: 6`, `sorries: 0`) were already correct and are unchanged; `status: axiomatized` / `badge: axiom` remain appropriate (Tier C). Only the narrative is corrected.

---
Discovered during gallery integrity audit.