### PR TITLE
audit: re-serve erdos-860 (Prime Covering Intervals) — clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -16950,8 +16950,8 @@
     },
     "erdos-860": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T00:19:32Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-20T11:08:55Z",
       "result": "clean"
     },
     "erdos-861": {


### PR DESCRIPTION
## Gallery integrity audit — erdos-860

**Result: clean.** Re-serve from drained queue (reserve mode); erdos-860 was the highest-priority uncontested target.

### Verified against `proofs/Proofs/Erdos860Problem.lean`
| Field | meta.json | source | ok |
|-------|-----------|--------|----|
| axiomCount | 5 | 5 `axiom` decls | ✓ |
| sorries | 3 | 3 real code sorries | ✓ |
| theoremCount | 3 | 3 | ✓ |
| definitionCount | 7 | 7 | ✓ |
| lineCount | 205 | 207 | harmless stale undercount |

- All 10 `originalContributions` map to real declarations — **no phantom declarations**.
- No `native_decide` / `Lean.ofReduceBool`; no `True` stubs.
- `status: axiomatized` + badge `axiom` correct for this OPEN problem (Tier C).
- Prose honestly discloses that `erdos_860` is proved *from axioms* (`ruzsa_growth`, `erdos_pomerance_upper_bound`); no axiom masking.

Only change: `audit-tracker.json` bump.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)