### PR TITLE
Research: cayley-hamilton-cyclic-vector-all-fields-oq-02-oq-03 — Module.End lift of the commutant characterization

### DIFF
--- a/proofs/Proofs/CayleyHamiltonCyclicVectorAllFieldsOQ02OQ03.lean
+++ b/proofs/Proofs/CayleyHamiltonCyclicVectorAllFieldsOQ02OQ03.lean
@@ -1,0 +1,197 @@
+/-
+  Commutant of a Cyclic Endomorphism is K[T]  (Module.End lift)
+  (cayley-hamilton-cyclic-vector-all-fields-oq-02-oq-03)
+
+  This file lifts the matrix commutant characterization
+  (`CayleyHamiltonCyclicVectorAllFieldsOQ02.lean`,
+   `CyclicCommutant.commuting_matrix_is_polynomial`) from concrete matrices
+  `Matrix (Fin n) (Fin n) K` to the coordinate-free endomorphism setting
+  `Module.End K V` over a finite-dimensional vector space `V`.
+
+  ## Statement
+
+  Let `V` be a finite-dimensional `K`-vector space and `T : Module.End K V`.
+  A vector `v` is a **cyclic vector** for `T` if no nonzero polynomial of
+  degree `< finrank K V` annihilates `v` (`IsEndCyclicVector`, the direct
+  analogue of the matrix `GeneralCyclicVector.IsCyclicVector`).
+
+    **If `T` has a cyclic vector then every endomorphism commuting with `T`
+    is a polynomial in `T`.**
+
+  Equivalently, the commutant (centralizer) of `T` inside `Module.End K V`
+  coincides with the subalgebra `K[T]` and is therefore commutative.
+
+  ## Proof
+
+  The argument mirrors the parent matrix proof, replacing `Matrix.mulVec`
+  by endomorphism application:
+
+  1. The Krylov vectors `{Tᵏ·v}_{k<n}` (`n = finrank K V`) are linearly
+     independent — a nontrivial linear relation would furnish a nonzero
+     annihilating polynomial of degree `< n` (`endKrylov_linearIndependent`).
+     They therefore form a basis `b` of `V`.
+  2. Write `A·v` in the Krylov basis: `A·v = ∑_{k<n} cₖ (Tᵏ·v)`, with
+     `cₖ = b.repr (A·v) k`; set `p = ∑ cₖ Xᵏ`. Then `p(T)·v = A·v`.
+  3. `A` and `p(T)` agree on every basis vector `Tⁱ·v`:
+       `A·(Tⁱ·v) = Tⁱ·(A·v) = Tⁱ·(p(T)·v) = p(T)·(Tⁱ·v)`,
+     using that `A` and `p(T)` each commute with `Tⁱ`. Two linear maps that
+     agree on a basis are equal (`Basis.ext`), so `A = p(T)`. This is where
+     the endomorphism formulation is cleaner than the matrix parent: no
+     column-by-column matrix recovery is needed.
+
+  Status: 0 sorries, 0 axioms.
+-/
+import Mathlib
+
+noncomputable section
+
+namespace EndCyclicCommutant
+
+open Polynomial Module
+
+variable {K : Type*} [Field K] {V : Type*} [AddCommGroup V] [Module K V]
+
+-- ============================================================
+-- SECTION I: Cyclic vectors for an endomorphism
+-- ============================================================
+
+/-- A vector `v` is **cyclic** for the endomorphism `T` if no nonzero
+    polynomial of degree `< finrank K V` annihilates `v`. This is the direct
+    analogue, in the endomorphism setting, of the matrix definition
+    `GeneralCyclicVector.IsCyclicVector`. -/
+def IsEndCyclicVector (T : Module.End K V) (v : V) : Prop :=
+  ∀ p : K[X], p.natDegree < finrank K V → (aeval T p) v = 0 → p = 0
+
+variable [FiniteDimensional K V]
+
+omit [FiniteDimensional K V] in
+/-- If `v` is a cyclic vector for `T`, the Krylov vectors `{Tᵏ·v}_{k<n}`
+    (`n = finrank K V`) are linearly independent. Endomorphism analogue of
+    `CyclicCommutant.krylov_linearIndependent`. -/
+theorem endKrylov_linearIndependent
+    (T : Module.End K V) (v : V) (hv : IsEndCyclicVector T v)
+    (hn : 0 < finrank K V) :
+    LinearIndependent K (fun k : Fin (finrank K V) => (T ^ (k : ℕ)) v) := by
+  rw [Fintype.linearIndependent_iff]
+  intro c hc i
+  set p := ∑ k : Fin (finrank K V), C (c k) * X ^ (k : ℕ) with hp_def
+  have hp_aeval : aeval T p = ∑ k : Fin (finrank K V), c k • T ^ (k : ℕ) := by
+    simp only [p, map_sum, map_mul, map_pow, aeval_C, aeval_X,
+               Algebra.algebraMap_eq_smul_one, smul_mul_assoc, one_mul]
+  have hp_ann : (aeval T p) v = 0 := by
+    rw [hp_aeval]
+    simpa only [LinearMap.sum_apply, LinearMap.smul_apply] using hc
+  have hp_deg : p.natDegree < finrank K V := by
+    apply lt_of_le_of_lt (natDegree_sum_le _ _)
+    apply (Finset.sup_lt_iff hn).mpr
+    intro k _; exact lt_of_le_of_lt (natDegree_C_mul_X_pow_le (c k) ↑k) k.isLt
+  have hp_zero : p = 0 := hv p hp_deg hp_ann
+  have h_coeff := congr_arg (Polynomial.coeff · ↑i) hp_zero
+  simp only [Polynomial.coeff_zero, p, C_mul_X_pow_eq_monomial,
+             finsetSum_coeff, coeff_monomial] at h_coeff
+  simpa [Fin.val_injective.eq_iff] using h_coeff
+
+-- ============================================================
+-- SECTION II: Polynomials in T commute with powers of T
+-- ============================================================
+
+omit [FiniteDimensional K V] in
+/-- `p(T)` commutes with `Tʲ` (polynomials in `T` commute with powers of `T`).
+    Endomorphism analogue of `CyclicCommutant.aeval_commute_pow`. -/
+private lemma aeval_end_commute_pow (p : K[X]) (T : Module.End K V) (j : ℕ) :
+    aeval T p * T ^ j = T ^ j * aeval T p := by
+  have hcomm : Commute (aeval T p) T := by
+    show aeval T p * T = T * aeval T p
+    have h : aeval T p * aeval T (X : K[X]) = aeval T (X : K[X]) * aeval T p := by
+      rw [← map_mul, ← map_mul, mul_comm p X]
+    simpa [aeval_X] using h
+  exact hcomm.pow_right j
+
+-- ============================================================
+-- SECTION III: Main theorem — commuting endomorphisms are polynomials in T
+-- ============================================================
+
+/-- **Commutant characterization (endomorphism form).** If `T : Module.End K V`
+    has a cyclic vector `v` and `A` commutes with `T`, then `A` is a polynomial
+    in `T`: there is `p` with `A = aeval T p`.
+
+    Coordinate-free lift of `CyclicCommutant.commuting_matrix_is_polynomial`:
+    a cyclic vector forces the centralizer of `T` inside `Module.End K V` to be
+    exactly the subalgebra `K[T]`. -/
+theorem commuting_end_is_polynomial
+    (T : Module.End K V) (v : V) (hcyc : IsEndCyclicVector T v)
+    (A : Module.End K V) (hA : A * T = T * A) :
+    ∃ p : K[X], A = aeval T p := by
+  -- Degenerate case `finrank = 0`: `V` is trivial, so `Module.End K V` is
+  -- a subsingleton and every endomorphism equals `aeval T 0`.
+  rcases Nat.eq_zero_or_pos (finrank K V) with h0 | hn
+  · haveI : Subsingleton V := Module.finrank_zero_iff.mp h0
+    exact ⟨0, Subsingleton.elim _ _⟩
+  set n := finrank K V with hn_def
+  haveI : Nonempty (Fin n) := ⟨⟨0, hn⟩⟩
+  have hli : LinearIndependent K (fun k : Fin n => (T ^ (k : ℕ)) v) :=
+    endKrylov_linearIndependent T v hcyc hn
+  -- Krylov vectors form a basis of `V`.
+  set b : Module.Basis (Fin n) K V :=
+    basisOfLinearIndependentOfCardEqFinrank hli (by rw [Fintype.card_fin]) with hb_def
+  have hb : ∀ i, b i = (T ^ (i : ℕ)) v := by
+    intro i; rw [hb_def, coe_basisOfLinearIndependentOfCardEqFinrank]
+  -- The polynomial whose coordinates are those of `A·v` in the Krylov basis.
+  refine ⟨∑ k : Fin n, C (b.repr (A v) k) * X ^ (k : ℕ), ?_⟩
+  set p : K[X] := ∑ k : Fin n, C (b.repr (A v) k) * X ^ (k : ℕ) with hp_def
+  have hp_aeval : aeval T p = ∑ k : Fin n, b.repr (A v) k • T ^ (k : ℕ) := by
+    simp only [p, map_sum, map_mul, map_pow, aeval_C, aeval_X,
+               Algebra.algebraMap_eq_smul_one, smul_mul_assoc, one_mul]
+  -- `p(T)·v = A·v` (`Basis.sum_repr`).
+  have hAv : (aeval T p) v = A v := by
+    rw [hp_aeval]
+    simp only [LinearMap.sum_apply, LinearMap.smul_apply]
+    rw [show (∑ k : Fin n, b.repr (A v) k • (T ^ (k : ℕ)) v) =
+             ∑ k : Fin n, b.repr (A v) k • b k from
+          Finset.sum_congr rfl (fun k _ => by rw [hb k])]
+    exact b.sum_repr (A v)
+  -- `A` and `p(T)` agree on every basis vector.
+  have key : ∀ i : Fin n, A (b i) = (aeval T p) (b i) := by
+    intro i
+    have e1 : A ((T ^ (i : ℕ)) v) = (T ^ (i : ℕ)) (A v) := by
+      have h : A * T ^ (i : ℕ) = T ^ (i : ℕ) * A :=
+        (show Commute A T from hA).pow_right (i : ℕ)
+      have := congrArg (fun f : Module.End K V => f v) h
+      simpa only [Module.End.mul_apply] using this
+    have e2 : (aeval T p) ((T ^ (i : ℕ)) v) = (T ^ (i : ℕ)) ((aeval T p) v) := by
+      have h : aeval T p * T ^ (i : ℕ) = T ^ (i : ℕ) * aeval T p :=
+        aeval_end_commute_pow p T i
+      have := congrArg (fun f : Module.End K V => f v) h
+      simpa only [Module.End.mul_apply] using this
+    rw [hb i, e1, e2, hAv]
+  -- Two linear maps agreeing on a basis are equal.
+  exact b.ext key
+
+-- ============================================================
+-- SECTION IV: Consequences
+-- ============================================================
+
+/-- The centralizer of an endomorphism with a cyclic vector is **commutative**:
+    any two endomorphisms commuting with `T` commute with each other, since
+    both are polynomials in `T`. Endomorphism analogue of
+    `CyclicCommutant.commutant_commutative`. -/
+theorem end_commutant_commutative
+    (T : Module.End K V) (v : V) (hcyc : IsEndCyclicVector T v)
+    (A B : Module.End K V)
+    (hA : A * T = T * A) (hB : B * T = T * B) :
+    A * B = B * A := by
+  obtain ⟨p, rfl⟩ := commuting_end_is_polynomial T v hcyc A hA
+  obtain ⟨q, rfl⟩ := commuting_end_is_polynomial T v hcyc B hB
+  rw [← map_mul, ← map_mul, mul_comm]
+
+omit [FiniteDimensional K V] in
+/-- Every polynomial in `T` commutes with `T` — the trivial inclusion
+    `K[T] ⊆ centralizer(T)`. Together with `commuting_end_is_polynomial` this
+    gives the full equality of the centralizer with `K[T]`. -/
+theorem aeval_end_commute (T : Module.End K V) (p : K[X]) :
+    aeval T p * T = T * aeval T p := by
+  simpa using aeval_end_commute_pow p T 1
+
+end EndCyclicCommutant
+
+end

--- a/src/data/proofs/cayley-hamilton-cyclic-vector-all-fields-oq-02-oq-03/annotations.json
+++ b/src/data/proofs/cayley-hamilton-cyclic-vector-all-fields-oq-02-oq-03/annotations.json
@@ -1,0 +1,119 @@
+[
+  {
+    "id": "chcv-oq02oq03-ann-overview",
+    "proofId": "cayley-hamilton-cyclic-vector-all-fields-oq-02-oq-03",
+    "range": {
+      "startLine": 1,
+      "endLine": 63
+    },
+    "type": "concept",
+    "title": "Lifting the Commutant Edge to Module.End",
+    "content": "The header states the coordinate-free lift of the matrix entry oq-02: for a finite-dimensional K-vector space V and an endomorphism T : Module.End K V with a cyclic vector, every endomorphism commuting with T is a polynomial in T, so the centralizer equals the subalgebra K[T]. The predicate IsEndCyclicVector T v — no nonzero polynomial of degree < finrank K V annihilates v — is the direct analogue of the matrix GeneralCyclicVector.IsCyclicVector, and it is the only cyclicity input the proof uses. Unlike the sibling matrix entries, the file imports only Mathlib and carries no matrix scaffolding.",
+    "mathContext": "$v$ cyclic for $T \\iff \\{T^k v\\}_{k<n}$ is a basis of $V$, where $n = \\dim_K V$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "module endomorphism",
+      "cyclic vector",
+      "centralizer / commutant",
+      "Krylov subspace",
+      "polynomial algebra K[T]"
+    ],
+    "prerequisites": [
+      "linear algebra over a field",
+      "finite-dimensional vector spaces and finrank",
+      "polynomials evaluated at an operator (Polynomial.aeval)"
+    ]
+  },
+  {
+    "id": "chcv-oq02oq03-ann-krylov",
+    "proofId": "cayley-hamilton-cyclic-vector-all-fields-oq-02-oq-03",
+    "range": {
+      "startLine": 66,
+      "endLine": 91
+    },
+    "type": "technique",
+    "title": "Krylov Independence = Cyclicity",
+    "content": "endKrylov_linearIndependent proves that the Krylov vectors {Tᵏ·v}_{k<finrank K V} are linearly independent. Via Fintype.linearIndependent_iff, a dependence ∑ cₖ (Tᵏ·v) = 0 is turned into the polynomial p = ∑ cₖ Xᵏ of degree < finrank with (aeval T p)·v = 0; cyclicity forces p = 0, and reading off coefficients of the monomial sum gives every cₖ = 0. The apply-a-sum-of-operators step uses LinearMap.sum_apply and LinearMap.smul_apply to turn (∑ cₖ Tᵏ)·v into ∑ cₖ (Tᵏ·v). No FiniteDimensional hypothesis is needed for this lemma, so it is stated with omit.",
+    "mathContext": "$\\sum_k c_k T^k v = 0 \\Rightarrow p(T)v = 0,\\ \\deg p < n \\Rightarrow p = 0 \\Rightarrow \\forall k,\\ c_k = 0$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Krylov subspace",
+      "linear independence",
+      "annihilating polynomial",
+      "coefficient extraction"
+    ],
+    "prerequisites": [
+      "Fintype.linearIndependent_iff",
+      "Polynomial.natDegree bounds",
+      "Polynomial.coeff of a monomial"
+    ]
+  },
+  {
+    "id": "chcv-oq02oq03-ann-commute",
+    "proofId": "cayley-hamilton-cyclic-vector-all-fields-oq-02-oq-03",
+    "range": {
+      "startLine": 93,
+      "endLine": 106
+    },
+    "type": "technique",
+    "title": "Polynomials in T Commute with Powers of T",
+    "content": "aeval_end_commute_pow shows p(T)·Tʲ = Tʲ·p(T). Because aeval T is a K-algebra homomorphism, p(T)·T = T·p(T) follows from mul_comm p X (using aeval_X : aeval T X = T); Commute.pow_right then upgrades commutation with T to commutation with every power Tʲ. This is the endomorphism analogue of the parent's aeval_commute_pow and supplies one of the two commutations used to compare A and p(T) on basis vectors.",
+    "mathContext": "$p(T)\\,T = T\\,p(T)$ since $\\mathrm{aeval}\\,T$ is an algebra hom, hence $p(T)\\,T^j = T^j\\,p(T)$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "algebra homomorphism",
+      "Commute.pow_right",
+      "commuting operators"
+    ],
+    "prerequisites": [
+      "Polynomial.aeval as a ring homomorphism",
+      "Commute and Commute.pow_right"
+    ]
+  },
+  {
+    "id": "chcv-oq02oq03-ann-main",
+    "proofId": "cayley-hamilton-cyclic-vector-all-fields-oq-02-oq-03",
+    "range": {
+      "startLine": 108,
+      "endLine": 176
+    },
+    "type": "key-step",
+    "title": "Commuting Endomorphisms are Polynomials in T",
+    "content": "commuting_end_is_polynomial builds a basis b from the Krylov vectors (basisOfLinearIndependentOfCardEqFinrank), reads the coordinates of A·v to form p = ∑ (b.repr (A·v) k) Xᵏ, and proves p(T)·v = A·v via Basis.sum_repr. Then A and p(T) agree on every basis vector Tⁱ·v: A·(Tⁱ·v) = Tⁱ·(A·v) [A commutes with Tⁱ] = Tⁱ·(p(T)·v) = p(T)·(Tⁱ·v) [p(T) commutes with Tⁱ]. Because two linear maps agreeing on a basis are equal (Basis.ext), A = p(T). This is precisely where the endomorphism formulation beats the matrix parent — the parent recovers the matrix equality column-by-column (ext i j with Pi.single), whereas Basis.ext closes it in one step. The finrank = 0 case is a Subsingleton on Module.End K V.",
+    "mathContext": "$A(T^i v) = T^i (A v) = T^i (p(T) v) = p(T)(T^i v)$ for all $i$, so $A = p(T)$ by $\\textsf{Basis.ext}$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "centralizer = K[T]",
+      "basis of a Krylov subspace",
+      "Basis.ext",
+      "coordinate representation"
+    ],
+    "prerequisites": [
+      "basisOfLinearIndependentOfCardEqFinrank",
+      "Basis.sum_repr and Basis.ext",
+      "Commute.pow_right"
+    ]
+  },
+  {
+    "id": "chcv-oq02oq03-ann-consequences",
+    "proofId": "cayley-hamilton-cyclic-vector-all-fields-oq-02-oq-03",
+    "range": {
+      "startLine": 177,
+      "endLine": 197
+    },
+    "type": "concept",
+    "title": "Commutative Centralizer and the K[T] Equality",
+    "content": "end_commutant_commutative deduces that the centralizer of a cyclic endomorphism is commutative: any A, B commuting with T are both polynomials in T (main theorem), and polynomials in T commute, so A·B = B·A. aeval_end_commute records the trivial inclusion K[T] ⊆ centralizer(T); together with commuting_end_is_polynomial (the reverse inclusion) this pins the centralizer of a cyclic endomorphism to exactly K[T].",
+    "mathContext": "$\\mathrm{centralizer}(T) = K[T]$, a commutative subalgebra of $\\mathrm{End}_K V$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "commutative centralizer",
+      "polynomial algebra K[T]",
+      "subalgebra equality"
+    ],
+    "prerequisites": [
+      "commuting_end_is_polynomial",
+      "polynomials in one operator commute"
+    ]
+  }
+]

--- a/src/data/proofs/cayley-hamilton-cyclic-vector-all-fields-oq-02-oq-03/meta.json
+++ b/src/data/proofs/cayley-hamilton-cyclic-vector-all-fields-oq-02-oq-03/meta.json
@@ -1,0 +1,134 @@
+{
+  "id": "cayley-hamilton-cyclic-vector-all-fields-oq-02-oq-03",
+  "title": "Commutant of a Cyclic Endomorphism is K[T] (Module.End lift)",
+  "slug": "cayley-hamilton-cyclic-vector-all-fields-oq-02-oq-03",
+  "description": "Lifts the matrix commutant characterization of the sibling entry oq-02 (a cyclic vector forces the centralizer of M to equal K[M]) from concrete matrices Matrix (Fin n) (Fin n) K to the coordinate-free endomorphism setting Module.End K V over a finite-dimensional vector space. If an endomorphism T has a cyclic vector then every endomorphism commuting with T is a polynomial in T, so the centralizer of T inside End K V equals the subalgebra K[T] and is commutative. Fully machine-checked, 0 axioms, 0 sorries; the file imports only Mathlib and needs no matrix scaffolding. Working with linear maps replaces the parent's column-by-column matrix recovery with a single Basis.ext. Status: verified (axiomCount = 0).",
+  "meta": {
+    "author": "Lean Genius Research",
+    "date": "2026-07-20",
+    "status": "verified",
+    "proofRepoPath": "Proofs/CayleyHamiltonCyclicVectorAllFieldsOQ02OQ03.lean",
+    "parentProofId": "cayley-hamilton-cyclic-vector-all-fields-oq-02",
+    "additionalFiles": [],
+    "tags": [
+      "linear-algebra",
+      "module-endomorphism",
+      "cyclic-vector",
+      "cayley-hamilton",
+      "minimal-polynomial",
+      "nonderogatory",
+      "commutant",
+      "centralizer",
+      "krylov-subspace",
+      "research",
+      "open-question"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 197,
+    "theoremCount": 5,
+    "definitionCount": 1,
+    "assumptions": "None. Fully machine-checked, 0 axioms, 0 sorries. #print axioms commuting_end_is_polynomial and #print axioms end_commutant_commutative report only propext, Classical.choice, Quot.sound (the standard foundational trio, which do not count as assumptions). The file imports only Mathlib.",
+    "dateAdded": "2026-07-20",
+    "mathlib_version": "4.31.0",
+    "originalContributions": [
+      "IsEndCyclicVector T v: a cyclic-vector predicate for an endomorphism T : Module.End K V — no nonzero polynomial of degree < finrank K V annihilates v — the coordinate-free analogue of the matrix predicate GeneralCyclicVector.IsCyclicVector.",
+      "endKrylov_linearIndependent: the Krylov vectors {Tᵏ·v}_{k<finrank K V} of a cyclic vector are linearly independent, hence a basis; the endomorphism analogue of CyclicCommutant.krylov_linearIndependent, proved directly over Module.End K V with no FiniteDimensional hypothesis on the statement itself.",
+      "commuting_end_is_polynomial: the main lift — if T has a cyclic vector and A commutes with T (A * T = T * A in Module.End K V) then A = aeval T p for some p : K[X]. Coordinate-free version of CyclicCommutant.commuting_matrix_is_polynomial; agreement of A and p(T) on the Krylov basis is closed by Basis.ext rather than the parent's per-column matrix recovery.",
+      "end_commutant_commutative: the centralizer of a cyclic endomorphism is commutative — any two endomorphisms commuting with T commute with each other, since both are polynomials in T.",
+      "aeval_end_commute: the trivial inclusion K[T] ⊆ centralizer(T); together with commuting_end_is_polynomial it gives the exact equality centralizer(T) = K[T]."
+    ],
+    "historicalContext": "An endomorphism T of a finite-dimensional K-vector space V is nonderogatory when its minimal and characteristic polynomials coincide, equivalently when it admits a cyclic vector v (one for which v, Tv, …, T^{n-1}v span V). A third classical characterization (Hoffman & Kunze §7.5, Roman §10.4) describes the centralizer: for a nonderogatory operator, every operator commuting with T is a polynomial in T, so the centralizer equals K[T]. The parent gallery entry oq-02 proves this forward commutant edge for concrete matrices Matrix (Fin n) (Fin n) K. This entry answers the open question recorded by the sibling oq-02-oq-01 ('recast the triple equivalence for Module.End over a finite-dimensional vector space') for the commutant edge, restating and reproving the result basis-free in Module.End K V.",
+    "proofStrategy": "Let n = finrank K V and let v be a cyclic vector for T. (1) The Krylov vectors {Tᵏ·v}_{k<n} are linearly independent: a nontrivial relation ∑ cₖ Tᵏ·v = 0 packages into a nonzero polynomial p = ∑ cₖ Xᵏ of degree < n with (p(T))·v = 0, contradicting cyclicity (endKrylov_linearIndependent). Being n independent vectors they form a basis b via basisOfLinearIndependentOfCardEqFinrank. (2) Expand A·v in this basis, A·v = ∑ (b.repr (A·v) k) · (Tᵏ·v), and set p = ∑ (b.repr (A·v) k) Xᵏ; then p(T)·v = A·v by Basis.sum_repr. (3) A and p(T) agree on each basis vector Tⁱ·v: A·(Tⁱ·v) = Tⁱ·(A·v) = Tⁱ·(p(T)·v) = p(T)·(Tⁱ·v), using that A commutes with Tⁱ (Commute.pow_right) and that p(T) commutes with Tⁱ (aeval is an algebra hom). Two linear maps agreeing on a basis are equal (Basis.ext), so A = p(T). The degenerate finrank = 0 case is dispatched by Subsingleton on Module.End K V (Module.finrank_zero_iff)."
+  },
+  "overview": {
+    "problemStatement": "**Open question from cayley-hamilton-cyclic-vector-all-fields-oq-02 (recorded on oq-02-oq-01)**: The matrix entry oq-02 shows a cyclic vector forces the centralizer of $M \\in K^{n\\times n}$ to equal $K[M]$. Lift this to the coordinate-free endomorphism setting.\n\nFormally: for a finite-dimensional $K$-vector space $V$ and $T : \\mathrm{End}_K V$ with a cyclic vector $v$, show that any $A$ commuting with $T$ satisfies $A = p(T)$ for some $p \\in K[X]$; hence the centralizer of $T$ inside $\\mathrm{End}_K V$ equals $K[T]$ and is commutative.",
+    "historicalContext": "For a nonderogatory operator on a finite-dimensional space the centralizer is exactly the algebra $K[T]$ of polynomials in $T$ (Hoffman–Kunze §7.5). The matrix form of this commutant edge is settled by the parent gallery entry; the endomorphism form is the reusable, basis-free statement the gallery's linear-algebra entries can build on, and was flagged as an explicit open direction by the sibling converse entry.",
+    "keyInsights": [
+      "The cyclic-vector predicate transfers verbatim to endomorphisms: v is cyclic for T iff no nonzero polynomial of degree < finrank K V annihilates v. This is all that is needed to make the Krylov vectors a basis.",
+      "Linear independence of the Krylov vectors {Tᵏ·v} is exactly cyclicity: a dependence ∑ cₖ Tᵏ·v = 0 is a nonzero low-degree annihilating polynomial, so cyclicity forbids it.",
+      "Every step of the matrix proof has a one-to-one endomorphism translation: Matrix.mulVec becomes endomorphism application, matrix multiplication becomes composition in Module.End, and Commute.pow_right / aeval being an algebra hom supply the commutations.",
+      "The endomorphism formulation is genuinely simpler than the matrix parent: two operators that agree on the Krylov basis are equal by Basis.ext — no column-by-column matrix recovery (the parent's ext i j / Pi.single argument) is required.",
+      "The result needs no external file: it depends only on Mathlib's basis, finrank, and Polynomial.aeval API, so it is a self-contained, reusable centralizer lemma for Module.End."
+    ],
+    "prerequisites": [
+      "Polynomial.aeval and that aeval T : K[X] → Module.End K V is a K-algebra homomorphism (map_sum, map_mul, aeval_X)",
+      "basisOfLinearIndependentOfCardEqFinrank: n linearly independent vectors in an n-dimensional space form a basis",
+      "Basis.repr / Basis.sum_repr and Basis.ext (a linear map is determined by its values on a basis)",
+      "Commute.pow_right: if A commutes with T then A commutes with every power Tⁱ",
+      "Fintype.linearIndependent_iff and Polynomial.natDegree bounds for coefficient extraction",
+      "Module.finrank_zero_iff for the degenerate trivial-space case"
+    ],
+    "openQuestions": [
+      "Lift the remaining edges of the triple equivalence (nonderogatory ⟺ cyclic and centralizer = K[T] ⟹ cyclic) to Module.End, completing the coordinate-free triangle to match the matrix entries oq-02-oq-01 / oq-02.",
+      "Prove the endomorphism Frobenius bound dim_K (centralizer of T) ≥ finrank K V directly in the Module.End setting (the matrix version is finrank_centralizer_ge in oq-02-oq-01)."
+    ]
+  },
+  "sections": [
+    {
+      "id": "chcv-oq02oq03-sec-cyclic",
+      "title": "Cyclic vectors for an endomorphism and Krylov independence",
+      "startLine": 54,
+      "endLine": 91,
+      "summary": "Defines IsEndCyclicVector T v (no nonzero polynomial of degree < finrank K V annihilates v) and proves endKrylov_linearIndependent: the Krylov vectors {Tᵏ·v}_{k<finrank K V} of a cyclic vector are linearly independent. A dependence is repackaged as a nonzero annihilating polynomial of degree < finrank, contradicting cyclicity; coefficient extraction uses Fintype.linearIndependent_iff and Polynomial.coeff of a monomial sum."
+    },
+    {
+      "id": "chcv-oq02oq03-sec-commute",
+      "title": "Polynomials in T commute with powers of T",
+      "startLine": 93,
+      "endLine": 106,
+      "summary": "aeval_end_commute_pow: p(T) commutes with Tʲ, because aeval T is a K-algebra homomorphism (p(T)·T = T·p(T) from mul_comm p X and aeval_X), then Commute.pow_right. The endomorphism analogue of the parent's aeval_commute_pow."
+    },
+    {
+      "id": "chcv-oq02oq03-sec-main",
+      "title": "Main theorem: commuting endomorphisms are polynomials in T",
+      "startLine": 108,
+      "endLine": 176,
+      "summary": "commuting_end_is_polynomial: with a cyclic vector, the Krylov vectors form a basis b; the polynomial p reading off the coordinates of A·v satisfies p(T)·v = A·v (Basis.sum_repr); A and p(T) then agree on every basis vector Tⁱ·v via the two commutation lemmas, so A = p(T) by Basis.ext. The trivial finrank = 0 case is closed by Subsingleton on Module.End K V."
+    },
+    {
+      "id": "chcv-oq02oq03-sec-consequences",
+      "title": "Consequences: commutative centralizer and the K[T] inclusion",
+      "startLine": 177,
+      "endLine": 197,
+      "summary": "end_commutant_commutative: two endomorphisms commuting with a cyclic T commute with each other (both are polynomials in T, which commute). aeval_end_commute: the trivial inclusion K[T] ⊆ centralizer(T); together with the main theorem this gives the exact equality centralizer(T) = K[T]."
+    }
+  ],
+  "conclusion": {
+    "summary": "For a finite-dimensional K-vector space V and T : Module.End K V with a cyclic vector, every endomorphism commuting with T is a polynomial in T, so the centralizer of T equals K[T] and is commutative. The coordinate-free lift of the matrix entry oq-02 is fully machine-checked with 0 axioms and imports only Mathlib.",
+    "implications": "This supplies the reusable, basis-free form of the commutant edge that the gallery's linear-algebra entries can apply without choosing coordinates. It answers the Module.End lift open question posed on the sibling oq-02-oq-01, and its Basis.ext-based agreement argument is a template for other 'operators determined on a Krylov basis' results.",
+    "openQuestions": [
+      "Complete the coordinate-free triple equivalence by lifting nonderogatory ⟺ cyclic and centralizer = K[T] ⟹ cyclic to Module.End.",
+      "Prove the endomorphism Frobenius dimension bound dim_K (centralizer of T) ≥ finrank K V in the Module.End setting."
+    ]
+  },
+  "crossReferences": [
+    {
+      "proofId": "cayley-hamilton-cyclic-vector-all-fields-oq-02",
+      "relationship": "parent — proves the matrix commutant edge (a cyclic vector forces the centralizer of M to equal K[M]); this entry restates and reproves it coordinate-free over Module.End K V"
+    },
+    {
+      "proofId": "cayley-hamilton-cyclic-vector-all-fields-oq-02-oq-01",
+      "relationship": "sibling — its recorded open questions explicitly ask to recast the triple equivalence for Module.End; this entry answers that for the commutant edge"
+    },
+    {
+      "proofId": "cayley-hamilton-cyclic-vector-all-fields",
+      "relationship": "ancestor — the biconditional nonderogatory ⟺ cyclic vector over arbitrary fields that anchors the cyclic-vector theory"
+    }
+  ],
+  "sorries": 0,
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "namespace": "EndCyclicCommutant",
+    "lineCount": 197,
+    "axiomCount": 0,
+    "theoremCount": 5,
+    "definitionCount": 1,
+    "path": "Proofs/CayleyHamiltonCyclicVectorAllFieldsOQ02OQ03.lean",
+    "sorries": 0,
+    "additionalFiles": []
+  }
+}

--- a/src/data/research/problems/cayley-hamilton-cyclic-vector-all-fields-oq-02-oq-03.json
+++ b/src/data/research/problems/cayley-hamilton-cyclic-vector-all-fields-oq-02-oq-03.json
@@ -2,7 +2,7 @@
   "slug": "cayley-hamilton-cyclic-vector-all-fields-oq-02-oq-03",
   "title": "Lift the result to the endomorphism setting (Module.End) rather than concrete matrices, for reuse across the gallery's linear-algebra…",
   "phase": "OBSERVE",
-  "status": "available",
+  "status": "completed",
   "tier": "B",
   "path": "full",
   "problemStatement": {
@@ -29,13 +29,19 @@
     "focus": "Newly seeded by Seeker; awaiting Researcher OBSERVE pass."
   },
   "knowledge": {
-    "progressSummary": "Seeded stub. No research performed yet.",
-    "builtItems": [],
-    "insights": [],
+    "progressSummary": "COMPLETED (researcher-1, 2026-07-20, VERIFIED 0-axiom/0-sorry): lifted the matrix commutant characterization (oq-02) to the endomorphism setting Module.End K V. commuting_end_is_polynomial: a cyclic vector forces every operator commuting with T to be a polynomial in T, so centralizer(T) = K[T] and is commutative (end_commutant_commutative). Self-contained (imports only Mathlib); the Krylov vectors form a basis and Basis.ext replaces the parent matrix proof column-by-column recovery. New gallery entry + tracker updated. Answers the Module.End lift open question recorded on sibling oq-02-oq-01.",
+    "builtItems": [
+      "IsEndCyclicVector (def) + endKrylov_linearIndependent + commuting_end_is_polynomial + end_commutant_commutative + aeval_end_commute in Proofs/CayleyHamiltonCyclicVectorAllFieldsOQ02OQ03.lean (5 thm/lemma, 1 def, 197 L). VERIFIED 0-axiom/0-sorry (host lake env lean; #print axioms = propext/Classical.choice/Quot.sound). Imports only Mathlib.",
+      "Gallery entry src/data/proofs/cayley-hamilton-cyclic-vector-all-fields-oq-02-oq-03/ (meta.json + annotations.json), status verified, badge original."
+    ],
+    "insights": [
+      "The matrix commutant proof (oq-02, CyclicCommutant.commuting_matrix_is_polynomial) lifts one-to-one to Module.End K V: Matrix.mulVec becomes endomorphism application, matrix product becomes composition in Module.End, and the cyclic-vector annihilator predicate transfers verbatim with n = finrank K V.",
+      "The endomorphism formulation is strictly SIMPLER than the matrix parent at the final step: agreement of A and p(T) on the Krylov basis closes with a single Basis.ext, replacing the parent column-by-column matrix recovery (ext i j + Pi.single + dotProduct).",
+      "endKrylov_linearIndependent and the two commutation lemmas need no FiniteDimensional hypothesis (stated with omit [FiniteDimensional K V] in); only the main theorem uses finrank/basisOfLinearIndependentOfCardEqFinrank; the finrank=0 case is a Subsingleton on Module.End K V (Module.finrank_zero_iff). Module.End.mul_apply is the (f*g) v = f (g v) rewrite."
+    ],
     "nextSteps": [
-      "Survey the parent gallery entry and its Lean source.",
-      "State the question precisely in Lean 4.",
-      "Identify supporting Mathlib theory."
+      "Lift the remaining triple-equivalence edges (nonderogatory iff cyclic and centralizer = K[T] implies cyclic) to Module.End to complete the coordinate-free triangle matching matrix oq-02 / oq-02-oq-01.",
+      "Prove the endomorphism Frobenius bound dim_K (centralizer of T) >= finrank K V in the Module.End setting (matrix version: finrank_centralizer_ge in oq-02-oq-01)."
     ]
   },
   "tags": [


### PR DESCRIPTION
## Summary
Research session for **cayley-hamilton-cyclic-vector-all-fields-oq-02-oq-03** ("Lift the result to the endomorphism setting `Module.End` rather than concrete matrices").

Lifts the matrix commutant characterization of the sibling entry `oq-02` (`CyclicCommutant.commuting_matrix_is_polynomial`: a cyclic vector forces the centralizer of `M` to equal `K[M]`) from concrete matrices `Matrix (Fin n) (Fin n) K` to the coordinate-free endomorphism setting `Module.End K V` over a finite-dimensional vector space.

## Progress
New self-contained file `proofs/Proofs/CayleyHamiltonCyclicVectorAllFieldsOQ02OQ03.lean` (imports only Mathlib, 197 L, 5 thm/lemma + 1 def):

- `IsEndCyclicVector T v` — cyclic-vector predicate for `T : Module.End K V` (no nonzero polynomial of degree `< finrank K V` annihilates `v`).
- `endKrylov_linearIndependent` — the Krylov vectors `{Tᵏ·v}` of a cyclic vector are linearly independent, hence a basis.
- `commuting_end_is_polynomial` — **main lift**: `A * T = T * A ⟹ ∃ p, A = aeval T p`.
- `end_commutant_commutative` — the centralizer of a cyclic `T` is commutative.
- `aeval_end_commute` — `K[T] ⊆ centralizer(T)`; with the main theorem this pins `centralizer(T) = K[T]`.

Also adds the gallery entry `src/data/proofs/cayley-hamilton-cyclic-vector-all-fields-oq-02-oq-03/` (meta.json + annotations.json) and marks the research problem `completed`.

## Findings
- The matrix proof lifts one-to-one: `Matrix.mulVec` → endomorphism application, matrix product → composition in `Module.End`, cyclic-vector predicate transfers verbatim with `n = finrank K V`.
- The endomorphism formulation is **strictly simpler** at the final step: agreement of `A` and `p(T)` on the Krylov basis closes with a single `Basis.ext`, replacing the parent's column-by-column matrix recovery (`ext i j` + `Pi.single` + `dotProduct`).
- `endKrylov_linearIndependent` and the commutation lemmas need no `FiniteDimensional` hypothesis (`omit`); only the main theorem uses `finrank` / `basisOfLinearIndependentOfCardEqFinrank`. The `finrank = 0` case is a `Subsingleton` on `Module.End K V`.
- This directly answers the open question recorded on sibling **oq-02-oq-01** ("recast the triple equivalence for `Module.End`") for the commutant edge.

## Verification
`#print axioms commuting_end_is_polynomial` and `end_commutant_commutative` report only `propext, Classical.choice, Quot.sound`. **0 axioms, 0 sorries** (host-verified with `lake env lean`).

## Status
**Outcome**: completed
**Next Steps**: lift the remaining triple-equivalence edges (`nonderogatory ⟺ cyclic`, `centralizer = K[T] ⟹ cyclic`) and the Frobenius bound `dim_K centralizer(T) ≥ finrank K V` to `Module.End`.

🤖 Generated by researcher-1