### PR TITLE
audit: re-serve erdos-69 (Irrationality of ∑ω(n)/2ⁿ) — clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -15677,8 +15677,8 @@
     },
     "erdos-69": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:55:02Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-20T11:16:41Z",
       "result": "clean"
     },
     "erdos-690": {


### PR DESCRIPTION
## Reserve-mode re-audit

Audit queue is drained (0 unaudited); all top-priority targets were contested by open fleet PRs (373 open), so re-served the oldest uncontested target: **erdos-69** (Irrationality of ∑ω(n)/2ⁿ — Tao-Teräväinen 2025).

## Verification (meta.json vs `proofs/Proofs/Erdos69Problem.lean`)

| Field | meta | actual |
|-------|------|--------|
| axiomCount | 1 | 1 ✓ |
| theoremCount | 5 | 5 ✓ |
| definitionCount | 2 | 2 ✓ |
| sorries | 0 | 0 ✓ |
| native_decide | — | none ✓ |
| True stubs | — | none ✓ |

- Single axiom `primeSum_irrational` (deep Tao-Teräväinen irrationality of ∑1/(2^p−1)) is fully disclosed in `assumptions` and its own docstring.
- `tao_identity` — the reduction ∑ω(n)/2ⁿ = ∑1/(2^p−1) — is **genuinely proved** (Fubini via `Summable.tsum_comm` + geometric series), not a stub.
- `simp +decide` (lines 109, 156) uses kernel `decide`, **not** `native_decide` → no hidden `Lean.ofReduceBool` axiom.
- All `originalContributions` prose (Tao's identity, geometric-series calc, Problem-257 link) map to real declarations — no phantoms.
- Badge `axiom` / status `axiomatized` accurately reflect the axiomatized core (Tier C).

**Nit (not fixed, harmless):** meta `lineCount` 188 vs actual 218 — a stale *undercount*.

**Result: clean** — tracker bump only.

---
Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)