### PR TITLE
audit: re-serve erdos-862 (Maximal Sidon Subsets) — clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -16962,8 +16962,8 @@
     },
     "erdos-862": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T00:19:33Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-20T11:19:44Z",
       "result": "clean"
     },
     "erdos-862-oq-03": {


### PR DESCRIPTION
## Reserve-mode re-audit — erdos-862

Unaudited queue is drained (0/4807); round-robin re-serve of an uncontested oldest target (top-10 targets are contested by open fleet PRs).

### Verification
- **Counts match**: meta `axiomCount` 3 = file (erdos_862_main, question2_positive, question1_negative); `sorries` 0; `theoremCount` 1 (erdos_862_summary); `definitionCount` 10. `lineCount` 131 vs actual 133 — stale undercount, harmless.
- **No phantom declarations**: all 10 `originalContributions` reference real decls in the Lean file.
- **Prose honest**: proofStrategy/conclusion explicitly state the resolution is *axiomatized* ("axiomatizes its (known) resolution rather than reproving"; Saxton-Thomason captured "through three axioms"). Correctly Tier C — badge `axiom`, status `axiomatized`.
- **No** True stubs, `native_decide`, or Mathlib-wrapper misattribution.

**Result: clean.** Tracker updated.

---
Discovered during gallery integrity audit.