### PR TITLE
fix(erdos-712): remove false 'no rational value' axiom masking openness (#39421)

### DIFF
--- a/proofs/Proofs/Erdos712Problem.lean
+++ b/proofs/Proofs/Erdos712Problem.lean
@@ -138,31 +138,31 @@ axiom kruskal_katona_upper (r k : ℕ) (hr : r ≥ 2) (hk : k > r) :
 def erdos_712_problem (r k : ℕ) (hr : r > 2) (hk : k > r) : Prop :=
   ∃ explicit : ℚ, turanDensity r k = explicit
 
-/-- The problem is unsolved for all k > r > 2 -/
-axiom erdos_712_open (r k : ℕ) (hr : r > 2) (hk : k > r) :
-  ¬∃ explicit : ℚ, turanDensity r k = explicit
+/-- Erdős Problem #712: The main *proved* statement.
 
-/-- Erdős Problem #712: The main statement -/
+    For every `k > r > 2` the Turán density exists and is bounded strictly
+    between 0 and 1 (positivity + the Kruskal–Katona upper bound). The exact
+    value is undetermined — this is the open problem. We deliberately do NOT
+    encode "openness" as a theorem: asserting `¬∃ explicit : ℚ, …` would claim
+    the density is irrational, an unproven proposition that also contradicts
+    the conjectured rational values (5/9 for K_4^3, 3/4 for K_5^3). The open
+    status is documented in prose only. -/
 theorem erdos_712 (r k : ℕ) (hr : r > 2) (hk : k > r) :
     -- The Turán density exists and has nice bounds
-    (∃ π : ℝ, turanDensity r k = π ∧ 0 < π ∧ π < 1) ∧
-    -- But the exact value is unknown
-    (¬∃ explicit : ℚ, turanDensity r k = explicit) := by
+    ∃ π : ℝ, turanDensity r k = π ∧ 0 < π ∧ π < 1 := by
+  use turanDensity r k
   constructor
-  · use turanDensity r k
-    constructor
-    · rfl
-    constructor
-    · exact turan_density_positive r k (by omega) hk
-    · -- Use Kruskal-Katona bound: π ≤ 1 - 1/k < 1 for k > 1
-      have hkk := kruskal_katona_upper r k (by omega) hk
-      have hk_pos : (0 : ℝ) < k := by
-        have : 0 < k := by omega
-        exact_mod_cast this
-      have h_one_div_k_pos : (0 : ℝ) < 1 / k := by positivity
-      calc turanDensity r k ≤ 1 - 1 / k := hkk
-        _ < 1 := by linarith
-  · exact erdos_712_open r k hr hk
+  · rfl
+  constructor
+  · exact turan_density_positive r k (by omega) hk
+  · -- Use Kruskal-Katona bound: π ≤ 1 - 1/k < 1 for k > 1
+    have hkk := kruskal_katona_upper r k (by omega) hk
+    have hk_pos : (0 : ℝ) < k := by
+      have : 0 < k := by omega
+      exact_mod_cast this
+    have h_one_div_k_pos : (0 : ℝ) < 1 / k := by positivity
+    calc turanDensity r k ≤ 1 - 1 / k := hkk
+      _ < 1 := by linarith
 
 /-
 ## Part VIII: Related Conjectures
@@ -208,10 +208,8 @@ Prize: $500 for any case, $1000 for full solution -/
 theorem erdos_712_summary :
     -- Turán solved the graph case (r = 2)
     (∀ k ≥ 2, turanDensity 2 k = turanGraphDensity k) ∧
-    -- Hypergraph case (r > 2) is open for all k > r
-    (∀ r k, r > 2 → k > r → ¬∃ explicit : ℚ, turanDensity r k = explicit) ∧
     -- Turán's K_4^3 conjecture: lower bound 5/9
     (turanDensity 3 4 ≥ 5 / 9) := by
-  exact ⟨fun k hk => turan_theorem k hk, erdos_712_open, K43_lower_bound⟩
+  exact ⟨fun k hk => turan_theorem k hk, K43_lower_bound⟩
 
 end Erdos712

--- a/src/data/proofs/erdos-712/meta.json
+++ b/src/data/proofs/erdos-712/meta.json
@@ -54,12 +54,12 @@
       "turanDensity: asymptotic density π_r(K_k^r)",
       "turan_theorem axiom: graph case solved",
       "K43_lower_bound axiom: 5/9 lower bound",
-      "erdos_712 theorem: density exists with 0 < π < 1 but value unknown",
-      "erdos_712_summary theorem: combining all results"
+      "erdos_712 theorem: proves the Turán density exists in (0,1) via positivity + the Kruskal-Katona upper bound; the exact value is left open (documented in prose, not asserted as a theorem)",
+      "erdos_712_summary theorem: combines the graph-case value and the 5/9 lower bound"
     ],
-    "axiomCount": 5,
-    "lineCount": 218,
-    "assumptions": "5 axioms: turan_theorem, K43_lower_bound, turan_density_positive, kruskal_katona_upper, erdos_712_open. See Lean source for complete statements.",
+    "axiomCount": 4,
+    "lineCount": 215,
+    "assumptions": "4 axioms: turan_theorem (graph case r=2, Turán 1941), K43_lower_bound (turanDensity 3 4 >= 5/9), turan_density_positive (density > 0), kruskal_katona_upper (density <= 1 - 1/k). The former axiom erdos_712_open was REMOVED: it asserted '¬∃ rational value', i.e. the density is irrational — an unproven claim contradicting the conjectured rational values (5/9, 3/4). The open status of the problem is now documented in prose only, not encoded as a theorem/axiom. See Lean source for complete statements.",
     "theoremCount": 2,
     "definitionCount": 11
   },
@@ -132,10 +132,10 @@
     {
       "id": "general-problem",
       "title": "The General Problem Statement",
-      "summary": "erdos_712_problem, erdos_712_open, erdos_712 theorem with full proof",
+      "summary": "erdos_712_problem definition, erdos_712 theorem with full proof",
       "startLine": 167,
       "endLine": 202,
-      "mathContext": "Erdős Problem #712: determine $\\pi_r(K_k^r)$ as an explicit (preferably rational) value for all $k > r > 2$. The `erdos_712` theorem proves the density exists in $(0, 1)$ using positivity and Kruskal-Katona, but axiomatizes that no rational value is known. Prize: \\$500 for any single case, \\$1000 for the general solution."
+      "mathContext": "Erdős Problem #712: determine $\\pi_r(K_k^r)$ as an explicit (preferably rational) value for all $k > r > 2$. The `erdos_712` theorem proves the density exists in $(0, 1)$ using positivity and Kruskal-Katona; the exact value is left undetermined and the open status is described in prose only (it is NOT encoded as a `¬∃ rational` axiom, which would falsely assert irrationality). Prize: \\$500 for any single case, \\$1000 for the general solution."
     },
     {
       "id": "conjectures",
@@ -169,8 +169,8 @@
       "Finset"
     ],
     "namespace": "Erdos712",
-    "lineCount": 218,
-    "axiomCount": 5,
+    "lineCount": 215,
+    "axiomCount": 4,
     "theoremCount": 2,
     "definitionCount": 11,
     "path": "Proofs/Erdos712Problem.lean",


### PR DESCRIPTION
Fixes #39421.

## Problem
The axiom `erdos_712_open` asserted `¬∃ explicit : ℚ, turanDensity r k = explicit` — that the Turán density is **irrational** — and was used to discharge the second conjunct of the headline `erdos_712` theorem (and a conjunct of `erdos_712_summary`). This mis-formalizes "the problem is open/unknown" as a strictly stronger, unproven, almost-certainly-**false** proposition that contradicts the file's own conjectured **rational** values (5/9 for K_4^3, 3/4 for K_5^3). Had `turanDensity 3 4 = 5/9` ever been added as an axiom, the axiom set would be inconsistent.

## Fix (Lean source — `Erdos712Problem.lean`)
- Remove the `erdos_712_open` axiom.
- `erdos_712` now proves only the genuinely-true, bounded-density result `∃ π, turanDensity r k = π ∧ 0 < π ∧ π < 1` (via `turan_density_positive` + `kruskal_katona_upper`).
- Drop the matching openness conjunct from `erdos_712_summary`.
- The open status of the problem is documented in prose/docstring, **not** encoded as a theorem/axiom.

## Meta (`src/data/proofs/erdos-712/meta.json`)
- `axiomCount` 5 → 4; remove `erdos_712_open` from `assumptions` (remaining: `turan_theorem`, `K43_lower_bound`, `turan_density_positive`, `kruskal_katona_upper`).
- Reword `originalContributions` and section prose so no field claims the Lean file proves the value is unknown / irrational.
- `lineCount` 218 → 215.

## Verification
Host-verified with `lake env lean` (toolchain v4.31.0): compiles clean, `EXIT=0`. Remaining warnings are pre-existing unused-variable lints on unchanged declarations.

Status remains `axiomatized` (4 stated assumptions) — accurate.