### PR TITLE
audit: re-serve erdos-864 (Almost-Sidon Sets) — clean, fix stale lineCount 806→833

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -16980,8 +16980,8 @@
     },
     "erdos-864": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T00:19:32Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-20T11:44:19Z",
       "result": "clean"
     },
     "erdos-865": {

--- a/src/data/proofs/erdos-864/meta.json
+++ b/src/data/proofs/erdos-864/meta.json
@@ -54,7 +54,7 @@
       "reflected_construction_bound: PROVED quantitative lower bound maxAlmostSidon(N) ≥ 2|B| for any Sidon B ⊆ {1,...,N/3}"
     ],
     "axiomCount": 1,
-    "lineCount": 806,
+    "lineCount": 833,
     "assumptions": "1 axiom: erdos_freud_lower_bound. Previously 2; sidon_upper_bound ELIMINATED by proving difference-counting bound (sidon_diff_counting_bound, sidon_card_sq_le_2N). reflected_construction_valid was proved as theorem in prior session.",
     "mathlib_version": "4.31.0",
     "theoremCount": 22,
@@ -165,7 +165,7 @@
       "Finset"
     ],
     "namespace": null,
-    "lineCount": 806,
+    "lineCount": 833,
     "axiomCount": 1,
     "theoremCount": 22,
     "definitionCount": 5,


### PR DESCRIPTION
## Gallery integrity audit — erdos-864 (Almost-Sidon Sets with One Collision)

Re-served from the drained unaudited queue (reserve mode; oldest uncontested top-10 target).

### Verified clean
- **0 sorries**, **1 axiom** — matches meta.
- Single axiom `erdos_freud_lower_bound` is a legitimate axiomatization of the **known** Erdős–Freud (1991) lower bound `(2/√3 − ε)·√N`, which requires large explicit Sidon-set constructions not yet in Mathlib. It does **not** mask the open conjecture — optimality of the upper bound is correctly left unclaimed (`erdosProblemStatus: "open"`).
- **0 native_decide**, **0 True stubs**.
- `theoremCount` 22 and `definitionCount` 5 are **exact**.
- Every declaration named in `originalContributions` / `proofStrategy` exists in the source — **no phantom declarations**.
- Tier C classification consistent: `status: axiomatized`, `badge: axiom`, axiom disclosed in prose and `assumptions`.

### Fix
- Stale `lineCount` undercount corrected **806 → 833** in both the `meta` and `leanFile` blocks (actual `wc -l` = 833). Harmless undercount, corrected for accuracy.

---
Discovered during gallery integrity audit.