### PR TITLE
audit: erdos-856 — reword 'proved/verified' prose (file does not compile under v4.31)

### DIFF
--- a/src/data/proofs/erdos-856/meta.json
+++ b/src/data/proofs/erdos-856/meta.json
@@ -33,7 +33,7 @@
     "historicalContext": "Erdős posed this problem in 1970 in his paper 'Some extremal problems in combinatorial number theory' dedicated to A. J. Macintyre, asking for the maximum harmonic sum of subsets of $\\{1, \\ldots, N\\}$ that avoid $k$ elements with uniform pairwise LCM. The uniform pairwise LCM condition means every distinct pair $(a, b)$ in the forbidden subset has $\\text{lcm}(a, b) = t$ for the same $t$. Erdős proved $f_k(N) \\ll \\log N / \\log\\log N$ using the observation that for each $t$, the set $\\{a \\in A : \\exists p \\text{ prime},\\, t = ap\\}$ has size $< k$. The problem lay dormant for decades until Tang and Zhang (2025) made significant progress, proving $(\\log N)^{b_k} \\leq f_k(N) \\leq (\\log N)^{c_k}$ for explicit constants $0 < b_k \\leq c_k \\leq 1$, and establishing for $k = 3$ the bounds $(\\log N)^{0.438} \\leq f_3(N) \\leq (\\log N)^{0.889}$. The deep connection to the sunflower conjecture — proved via the Erdős–Ko–Rado theorem and its LCM analogues — shows that $c_k < 1$ if and only if the sunflower conjecture holds for $k$-sunflowers. The sunflower lemma of Erdős and Rado (1960) gives $c_k \\leq 1$, while the conjecture would improve this to $c_k < 1$. Alweiss, Lovett, Wu, and Zhang (2021) made a breakthrough on the sunflower conjecture, which has implications for the upper bound exponents here.",
     "problemStatement": "Let $k \\geq 3$ and $f_k(N)$ be the maximum value of $\\sum_{n \\in A} 1/n$, where $A$ ranges over all subsets of $\\{1, \\ldots, N\\}$ containing no subset of size $k$ with the same pairwise least common multiple. Estimate $f_k(N)$.",
     "text": "Estimate f_k(N), the maximum harmonic sum of subsets of {1,...,N} with no k elements having uniform pairwise LCM. Status: OPEN. Bounds relate to sunflower conjecture.",
-    "proofStrategy": "The formalization defines LCM, uniform pairwise LCM, $k$-LCM-free sets, and the harmonic sum $\\sum 1/n$. The extremal function $f_k(N)$ is defined via `sSup`. Erdős's 1970 upper bound and Tang–Zhang's 2025 improved bounds are axiomatized. The sunflower conjecture connection is formalized as an equivalence: $c_k < 1 \\iff$ sunflower conjecture for $k$. Examples (divisor sets, prime powers) and the natural density variant $g_k(N)$ are also included. Two results are proved in Lean: LCM commutativity and the divisor set LCM property.",
+    "proofStrategy": "The formalization defines LCM, uniform pairwise LCM, $k$-LCM-free sets, and the harmonic sum $\\sum 1/n$. The extremal function $f_k(N)$ is defined via `sSup`. Erdős's 1970 upper bound and Tang–Zhang's 2025 improved bounds are axiomatized. The sunflower conjecture connection is formalized as an equivalence: $c_k < 1 \\iff$ sunflower conjecture for $k$. Examples (divisor sets, prime powers) and the natural density variant $g_k(N)$ are also included. Two supporting lemmas are stated in Lean (LCM commutativity and the divisor set LCM property), but the file does not currently compile under Lean v4.31, so no theorem is machine-verified (see `assumptions`).",
     "keyInsights": [
       "**Harmonic vs. natural density**: The problem measures $f_k(N) = \\max \\sum 1/n$ (logarithmic density) rather than $\\max |A|$ (natural density). This is subtler: for $k \\geq 4$, sets of linear size can avoid the LCM condition, but the harmonic sum is bounded.",
       "**Erdős's prime factorization trick**: For each $t$, the set $\\{a \\in A : \\exists p \\text{ prime},\\, t = ap\\}$ has $< k$ elements (else $k$ elements have $\\text{lcm} = t$). Summing over primes dividing elements of $A$ yields $f_k(N) \\ll \\log N / \\log\\log N$.",
@@ -60,8 +60,8 @@
       "title": "Least Common Multiple",
       "startLine": 47,
       "endLine": 65,
-      "summary": "Defines `myLcm a b = Nat.lcm a b` and proves commutativity $\\text{lcm}(a,b) = \\text{lcm}(b,a)$ and idempotence $\\text{lcm}(a,a) = a$. These are genuine Lean proofs using `Nat.lcm_comm` and `Nat.lcm_self`.",
-      "mathContext": "Defines `myLcm a b = Nat.lcm a b` and proves commutativity $\\text{lcm}(a,b) = \\text{lcm}(b,a)$ and idempotence $\\text{lcm}(a,a) = a$."
+      "summary": "Defines `myLcm a b = Nat.lcm a b` and states commutativity $\\text{lcm}(a,b) = \\text{lcm}(b,a)$ and idempotence $\\text{lcm}(a,a) = a$ via `Nat.lcm_comm` and `Nat.lcm_self`. These are not machine-verified: the file does not currently compile under v4.31 (see `assumptions`).",
+      "mathContext": "Defines `myLcm a b = Nat.lcm a b` and states commutativity $\\text{lcm}(a,b) = \\text{lcm}(b,a)$ and idempotence $\\text{lcm}(a,a) = a$."
     },
     {
       "id": "uniform-lcm",
@@ -116,12 +116,12 @@
       "title": "Examples and Gap Analysis",
       "startLine": 226,
       "endLine": 260,
-      "summary": "Proves divisor sets satisfy $\\text{lcm}(a,b) \\mid n$ (genuine Lean proof). Axiomatizes prime power LCM $\\text{lcm}(p^j, p^k) = p^k$, the open problem formalization, and gap analysis for $k = 3$.",
-      "mathContext": "Verified: Proves divisor sets satisfy $\\text{lcm}(a,b) \\mid n$ (genuine Lean proof). Axiomatizes prime power LCM $\\text{lcm}(p^j, p^k) = p^k$, the open problem formalization, and gap analysis for $k = 3$."
+      "summary": "States that divisor sets satisfy $\\text{lcm}(a,b) \\mid n$ (not machine-verified; the file does not currently compile under v4.31). Axiomatizes prime power LCM $\\text{lcm}(p^j, p^k) = p^k$, the open problem formalization, and gap analysis for $k = 3$.",
+      "mathContext": "States that divisor sets satisfy $\\text{lcm}(a,b) \\mid n$ (not machine-verified; the file does not currently compile). Axiomatizes prime power LCM $\\text{lcm}(p^j, p^k) = p^k$, the open problem formalization, and gap analysis for $k = 3$."
     }
   ],
   "conclusion": {
-    "summary": "Erdős Problem #856 formalizes the maximum harmonic sum of k-LCM-free subsets. The Lean file proves LCM properties and the divisor set lemma, axiomatizes Erdős's 1970 bound, Tang–Zhang's 2025 improvement, and the sunflower equivalence. The formalization covers 10 sections across 307 lines.",
+    "summary": "Erdős Problem #856 formalizes the maximum harmonic sum of k-LCM-free subsets. The Lean file states LCM properties and the divisor set lemma and axiomatizes Erdős's 1970 bound, Tang–Zhang's 2025 improvement, and the sunflower equivalence. It does not currently compile under Lean v4.31, so no result is machine-verified (see `assumptions`). The formalization covers 10 sections across ~260 lines.",
     "implications": "**Theoretical Significance**: Resolution would bridge combinatorial number theory and the sunflower conjecture.\n\nThe equivalence c_k < 1 ⟺ sunflower conjecture shows that progress on either problem implies progress on the other. The Alweiss–Lovett–Wu–Zhang (2021) sunflower breakthrough may lead to improved bounds on f_k(N).",
     "openQuestions": [
       "What is the precise growth exponent $c_k$ for $f_k(N) \\sim (\\log N)^{c_k}$? Is it rational?",


### PR DESCRIPTION
## Integrity Issue

**Proof**: erdos-856 (LCM-Free Sets and Logarithmic Density)
**Problem**: Section summaries, `proofStrategy`, and `conclusion` positively assert theorems are "genuine Lean proofs" / "proved in Lean" / "Verified:", contradicting the top-level `assumptions` retraction — the file does not compile, so nothing is machine-verified.

## Evidence

Actual compile under the repo toolchain (v4.31.0):

```
$ lake env lean Proofs/Erdos856Problem.lean
Erdos856Problem.lean:108: error: And (Finset ℕ) ... expected Prop
Erdos856Problem.lean:108: error: Unknown identifier `A`   (f_k)
Erdos856Problem.lean:153: error: failed to synthesize Inter (Finset α)  (IsSunflower)
Erdos856Problem.lean:182: error: Unknown identifier `A`   (g_k)
Erdos856Problem.lean:227-228: error: failed to synthesize HPow ℝ ℝ  (openProblem_precise_exponent)
```

The `set_option autoImplicit true` added during the v4.31 migration (#39062) did **not** rescue the file. The `assumptions` note (issue #39061) already documents this and retracts verification — but the section/strategy/conclusion prose was never updated to match.

## Fix

- `proofStrategy`: "Two results are proved in Lean" → "Two supporting lemmas are stated in Lean … but the file does not currently compile … so no theorem is machine-verified".
- Section `lcm-basics`: "genuine Lean proofs" → "stated … not machine-verified".
- Section `examples`: "Proves … (genuine Lean proof)" / "Verified:" → "States … (not machine-verified; the file does not currently compile)".
- `conclusion.summary`: "The Lean file proves …" → "states … does not currently compile … no result is machine-verified"; stale "307 lines" → "~260".

`status` (axiomatized) and `badge` (wip) unchanged — already appropriate. The Lean-source repair remains a separate Class A task.

---
Discovered during gallery integrity audit (reserve mode; oldest uncontested target).