### PR TITLE
audit: re-serve erdos-852 (Maximal Runs of Distinct Prime Gaps) — clean, fix stale lineCount 247→240

### DIFF
--- a/src/data/proofs/erdos-852/meta.json
+++ b/src/data/proofs/erdos-852/meta.json
@@ -21,7 +21,7 @@
     "erdosUrl": "https://erdosproblems.com/852",
     "erdosProblemStatus": "open",
     "axiomCount": 3,
-    "lineCount": 247,
+    "lineCount": 240,
     "assumptions": "3 axioms: brun_sieve_divergence (Brun's sieve result), erdos852_lower_bound (OPEN conjecture), erdos852_upper_bound (OPEN conjecture). The function h(x) = maxDistinctRun and its properties (witness, optimality, bound) are now fully defined and proved.",
     "mathlib_version": "4.31.0",
     "dateUpdated": "2026-03-28",
@@ -106,7 +106,7 @@
       "id": "upper-bound",
       "title": "Upper Bound",
       "startLine": 211,
-      "endLine": 247,
+      "endLine": 240,
       "summary": "PROVES `maxDistinctRun_le_x` ($h(x)\\leq x$, from the definition) and `distinct_run_bounded_by_max_gap` (a distinct run of length $k$ with all gaps $\\leq M$ has $k\\leq M$, by pigeonhole via `Finset.card_image_of_injOn`).",
       "mathContext": "$h(x)\\leq x$; a distinct run with gaps $\\leq M$ has length $\\leq M$ (pigeonhole)."
     }
@@ -137,7 +137,7 @@
       "Real"
     ],
     "namespace": null,
-    "lineCount": 247,
+    "lineCount": 240,
     "axiomCount": 3,
     "theoremCount": 25,
     "definitionCount": 5,


### PR DESCRIPTION
## Reserve-mode re-audit — integrity clean

Queue drained (0 unaudited); top-10 all contested by open fleet PRs. Picked oldest uncontested priority target: **erdos-852**.

### Substantive checks — all pass
- **Counts match**: meta.sorries 0 = file 0; meta.axiomCount 3 = file 3; theoremCount 25 = 25 (incl. private lemmas); definitionCount 5 = 5.
- **No phantom declarations**: every named theorem/def in `proofStrategy`, `sections`, and `conclusion` (nthPrime_*, primeGap_*, isDistinctRun_*, validRunLengths, maxDistinctRun*, erdos852_*, distinct_run_bounded_by_max_gap) exists in `Erdos852Problem.lean`.
- **No True stubs, no native_decide.**
- **Axioms honestly disclosed**: 3 axioms — `brun_sieve_divergence` (Brun's sieve) plus the two OPEN Erdős conjectures `erdos852_lower_bound`/`erdos852_upper_bound`. badge=`axiom`, status=`axiomatized`, erdosStatus=`open`. Open problem is disclosed as axiomatized, not masked.

### Fix
Only nit: stale `lineCount`/section `endLine` overcount **247 → actual 240** (meta.lineCount, leanFile.lineCount, upper-bound section endLine). Not covered by the bulk lineCount sync (#39458).

---
Discovered during gallery integrity audit.