### PR TITLE
audit: erdos-882 — drop phantom lemma `div_free_implies_distinct` from prose + fix stale lineCount 169→164

### DIFF
--- a/src/data/proofs/erdos-882/meta.json
+++ b/src/data/proofs/erdos-882/meta.json
@@ -55,7 +55,7 @@
       "Connected to Erdős Problem #1 (distinct subset sums)"
     ],
     "axiomCount": 2,
-    "lineCount": 169,
+    "lineCount": 164,
     "assumptions": "2 axioms: upper_bound_refined, lower_bound_max. 0 sorries.",
     "theoremCount": 4,
     "definitionCount": 9
@@ -64,7 +64,7 @@
     "historicalContext": "This problem was posed by Paul Erdős and András Sárközy in the 1990s, combining two classical themes in combinatorial number theory: subset sums and divisibility avoidance. Given $A \\subseteq \\{1,\\ldots,n\\}$, the question asks for the maximum $|A|$ such that the $2^{|A|}-1$ non-empty subset sums form an antichain in the divisibility order $(\\mathbb{N}, \\mid)$.\n\nThe naive greedy algorithm, selecting elements one by one to avoid creating divisibility pairs among sums, achieves only $|A| \\geq (1-o(1))\\log_3 n$. Erdős and Sárközy conjectured that $\\log_2 n$ should be the right order. This was first confirmed by Csaba Sándor using the elegant construction $A = \\{2^i + m \\cdot 2^m : 0 \\leq i < m\\}$, which exploits the binary representation structure to prevent divisibility.\n\nThe definitive result came in the 1999 paper by Erdős, Vsevolod Lev, Gérard Rauzy, Sándor, and Sárközy, who proved that the construction $A = \\{2^{m-1}, 2^{m-1}+1, \\ldots, 2^m - 1\\}$ achieves $|A| > \\log_2 n - 1$ and has all subset sums distinct. This connection to the distinct subset sums problem (Erdős Problem #1) immediately yields the upper bound $|A| \\leq \\log_2 n + \\frac{1}{2}\\log_2(\\log n) + O(1)$, via the Dubroff-Fox-Xu (2021) bound. The Erdős-Moser conjecture, that $|A| \\leq \\log_2 n + O(1)$ for distinct subset sums, would close the remaining gap for Problem #882 as well.",
     "problemStatement": "**Problem**: Find the maximum size of $A \\subseteq \\{1,\\ldots,n\\}$ such that in the set\n$$\\left\\{ \\sum_{a\\in S} a : \\emptyset \\neq S \\subseteq A \\right\\}$$\nno two distinct elements divide each other.\n\n**Answer**: $|A| = (1 + o(1)) \\log_2 n$\n\n**Bounds**:\n- Lower: $|A| > \\log_2 n - 1$ (ELRSS 1999 construction)\n- Upper: $|A| \\leq \\log_2 n + \\frac{1}{2}\\log_2(\\log n) + O(1)$\n- Conjectured: $|A| \\leq \\log_2 n + O(1)$",
     "text": "What is the maximum size of A ⊆ {1,...,n} such that no two distinct non-empty subset sums divide each other? Answer: (1+o(1)) log₂ n.",
-    "proofStrategy": "The formalization builds from first principles: it defines the subset sum operator $\\Sigma(A)$ via `Finset.powerset` and `Finset.image`, and the divisibility-free (antichain) property on $\\Sigma(A)$. Two key constructions are axiomatized — Sándor's $\\{2^i + m \\cdot 2^m\\}$ and the ELRSS interval $[2^{m-1}, 2^m - 1]$ — both achieving $\\sim \\log_2 n$. The upper bound chain is: divisibility-free $\\Rightarrow$ distinct subset sums $\\Rightarrow$ $|A| \\leq \\log_2 n + O(\\log\\log n)$, where the first implication (`div_free_implies_distinct`) is the key bridge to Erdős #1, and the second uses counting arguments (the $2^k - 1$ distinct sums must fit in $[1, \\sigma(A)]$).",
+    "proofStrategy": "The formalization builds from first principles: it defines the subset sum operator $\\Sigma(A)$ via `Finset.powerset` and `Finset.image`, and the divisibility-free (antichain) property on $\\Sigma(A)$. Two key constructions are axiomatized — Sándor's $\\{2^i + m \\cdot 2^m\\}$ and the ELRSS interval $[2^{m-1}, 2^m - 1]$ — both achieving $\\sim \\log_2 n$. The intended upper bound argument is the chain divisibility-free $\\Rightarrow$ distinct subset sums $\\Rightarrow$ $|A| \\leq \\log_2 n + O(\\log\\log n)$, where the first implication is the key bridge to Erdős #1 and the second uses counting arguments (the $2^k - 1$ distinct sums must fit in $[1, \\sigma(A)]$). In the formalization this chain is not proved lemma-by-lemma: the full refined upper bound is captured by the single axiom `upper_bound_refined`, and the only fully proved supporting lemma is `sum_bound` ($\\sigma(A) \\leq |A|\\cdot n$).",
     "keyInsights": [
       "**Divisibility-free implies distinct**: If $\\Sigma(A)$ is an antichain under $\\mid$, then all $2^{|A|}-1$ subset sums must be distinct, since equal sums would trivially divide each other.",
       "**Connection to Erdős #1**: The distinct subset sums problem gives the upper bound $\\log_2 n + \\frac{1}{2}\\log_2 \\log_2 n + O(1)$ via Dubroff-Fox-Xu (2021). Problem #882 inherits this bound through the implication above.",
@@ -171,7 +171,7 @@
       "BigOperators"
     ],
     "namespace": "Erdos882",
-    "lineCount": 169,
+    "lineCount": 164,
     "axiomCount": 2,
     "theoremCount": 4,
     "definitionCount": 9,


### PR DESCRIPTION
## Gallery Integrity Audit — erdos-882 (Subset Sums Without Divisibility)

Re-serve audit (unaudited queue drained; erdos-882 was the oldest top-10 target with no open fleet PR).

### Issue 1: Phantom declaration in `proofStrategy` (MEDIUM)
`proofStrategy` cited a lemma **`div_free_implies_distinct`** as "the key bridge to Erdős #1":

> ...where the first implication (\`div_free_implies_distinct\`) is the key bridge to Erdős #1...

No such declaration exists in `Proofs/Erdos882Problem.lean` (`grep div_free_implies_distinct` → not found). The `DivisibilityFree ⇒ DistinctSubsetSums` implication is **not formalized** — `DistinctSubsetSums` is only a `def` and is never used in any proof. The entire refined upper bound is captured by the single **axiom `upper_bound_refined`**; the only fully proved supporting lemma is `sum_bound`.

**Fix**: reworded to describe the intended mathematical chain without naming a nonexistent lemma, and to state explicitly that the chain is captured by the axiom rather than proved lemma-by-lemma.

### Issue 2: Stale lineCount overcount (LOW)
`meta.lineCount` and `leanFile.lineCount` both said **169**; actual `wc -l` is **164**. Fixed both to 164.

### Verified correct (no change)
- Axioms: **2** (`upper_bound_refined`, `lower_bound_max`) — matches `axiomCount`
- Theorems: **4**, Defs: **9**, Sorries: **0**, no `native_decide`
- status `axiomatized` / badge `axiom` — honest Tier C framing

meta.json-only change; no Lean source touched.

---
Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)