### PR TITLE
audit: erdos-849 — disclose native_decide (ofReduceBool) trust dependency

### DIFF
--- a/src/data/proofs/erdos-849/meta.json
+++ b/src/data/proofs/erdos-849/meta.json
@@ -57,7 +57,7 @@
     ],
     "axiomCount": 3,
     "lineCount": 193,
-    "assumptions": "3 axioms: two_multiplicity, multiplicity_120, multiplicity_3003. 0 sorries.",
+    "assumptions": "3 literal axioms: two_multiplicity, multiplicity_120, multiplicity_3003 (the known multiplicity values of 2, 120, 3003). 0 sorries. The headline case theorems t_equals_1/3/4 depend only on these 3 axioms plus the standard propext/Classical.choice/Quot.sound. Additionally, the 11 binomial-coefficient verification lemmas (choose_10_3, choose_16_2, choose_120_1, choose_14_6, choose_15_5, choose_78_2, choose_3003_1, choose_5_2, choose_10_1, choose_15_7, choose_6435_1) are discharged by `native_decide`, which trusts the Lean compiler's kernel reduction and so introduces a `native_decide`-generated (`Lean.ofReduceBool`-family) axiom under `#print axioms` (not among the 3 literal axioms).",
     "theoremCount": 15,
     "definitionCount": 4
   },


### PR DESCRIPTION
## Integrity Issue

**Proof**: erdos-849 (Binomial Coefficient Multiplicities)
**Problem**: The `assumptions` field discloses only the 3 literal axioms and "0 sorries", omitting the compiler-trust (`Lean.ofReduceBool`-family) axiom introduced by 11 `native_decide` uses.

## Evidence

**meta.json claimed**: `"3 axioms: two_multiplicity, multiplicity_120, multiplicity_3003. 0 sorries."`

**Lean file shows**: 11 verification lemmas (`choose_10_3`, `choose_16_2`, `choose_120_1`, `choose_14_6`, `choose_15_5`, `choose_78_2`, `choose_3003_1`, `choose_5_2`, `choose_10_1`, `choose_15_7`, `choose_6435_1`) are proved `by native_decide`.

Verified with `lake env lean` (file compiles cleanly under Mathlib 4.31):
- `#print axioms Erdos849.t_equals_3` → `[propext, Classical.choice, Erdos849.multiplicity_120, Quot.sound]` (headline cases are clean, rest only on disclosed axioms ✓)
- `#print axioms Erdos849.choose_3003_1` → `[Erdos849.choose_3003_1._native.native_decide.ax_1_1]` (undisclosed native_decide axiom)

## Fix

Reworded `assumptions` to disclose the `native_decide`/`ofReduceBool` dependency, following the established convention (cf. `abel-ruffini-galois-extensions`). Counts unchanged: 3 literal axioms, 0 sorries remain accurate; `proofStrategy` already mentioned native_decide narratively.

---
Discovered during gallery integrity audit (reserve mode; erdos-849 was the oldest uncontested target).

🤖 Generated with [Claude Code](https://claude.com/claude-code)