### PR TITLE
Enrich bernoulli-inequality-oq-01-oq-02: fix drifted section line ranges

### DIFF
--- a/src/data/proofs/bernoulli-inequality-oq-01-oq-02/meta.json
+++ b/src/data/proofs/bernoulli-inequality-oq-01-oq-02/meta.json
@@ -58,7 +58,7 @@
     "dateAdded": "2026-06-23",
     "axioms": 0,
     "axiomCount": 0,
-    "lineCount": 170,
+    "lineCount": 163,
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries (depends only on propext, Classical.choice, Quot.sound).",
     "mathlib_version": "4.31.0",
     "theoremCount": 6,
@@ -128,15 +128,15 @@
       "id": "choose-and-first-order",
       "title": "Binomial-Coefficient Form and First-Order Corollary",
       "startLine": 136,
-      "endLine": 153,
+      "endLine": 147,
       "summary": "sq_bernoulli_choose restates the bound with the literal C(n,2) = n.choose 2 via Nat.choose_two_right; one_add_mul_eq_pow_iff_ge records the slug's first-order equality case (a = 0 ∨ n ≤ 1 on a ≥ −1) as a corollary of the sibling.",
       "mathContext": "$1 + na + \\binom{n}{2}a^2 \\le (1+a)^n$; first-order equality iff $a = 0 \\vee n \\le 1$."
     },
     {
       "id": "witnesses",
       "title": "Exactness and Sharpness Witnesses",
-      "startLine": 155,
-      "endLine": 170,
+      "startLine": 148,
+      "endLine": 163,
       "summary": "The n = 2 identity (truncation = full expansion), a concrete strict instance (a = 1, n = 4: 11 < 16), and the sharpness witness showing the bound fails for −1 < a < 0 (a = −1/2, n = 3).",
       "mathContext": "Exact at $n=2$; strict at $(a,n)=(1,4)$; fails at $(a,n)=(-1/2,3)$."
     }
@@ -174,7 +174,7 @@
     ],
     "opens": [],
     "namespace": "BernoulliInequalityOQ01OQ02",
-    "lineCount": 170,
+    "lineCount": 163,
     "axiomCount": 0,
     "theoremCount": 6,
     "definitionCount": 0,


### PR DESCRIPTION
## Enrichment pass — section lineRange correctness fix

The two trailing `sections` in `bernoulli-inequality-oq-01-oq-02/meta.json` had drifted off the actual Lean file (`BernoulliInequalityOQ01OQ02.lean`, 163 lines):

- **"Exactness and Sharpness Witnesses"** claimed `startLine 155, endLine 170` — the `endLine` **overran the file** (170 > 163), and the start at 155 missed the first two witness `example`s (lines 150 and 154).
- **"Binomial-Coefficient Form and First-Order Corollary"** ran to `endLine 153`, wrongly swallowing the first witness's docstring/`example`.

### Fix
Corrected both to the true declaration boundaries so the sections tile lines 1–163 with no overrun:
- Binomial/corollary section: `136–147` (`sq_bernoulli_choose` + `one_add_mul_eq_pow_iff_ge`)
- Witnesses section: `148–163` (the three `example` witnesses)

Also corrected stale `lineCount` 170 → 163 in both `meta.lineCount` and `leanFile.lineCount`. `theoremCount: 6` verified correct (examples are not theorems). No prose or `content` was changed — this is a pure correctness fix of the line-range metadata.

🤖 Generated with [Claude Code](https://claude.com/claude-code)