### PR TITLE
audit: erdos-872 — drop 5 phantom declarations from prose + fix false 'bounds axiomatized' claim

### DIFF
--- a/src/data/proofs/erdos-872/meta.json
+++ b/src/data/proofs/erdos-872/meta.json
@@ -57,13 +57,9 @@
       "IsPrimitiveSet definition: equivalent negative formulation",
       "antichain_iff_primitive theorem: constructive equivalence proof",
       "gameBoard definition: the set {2,...,n}",
-      "gameBoard_card: game board size",
       "IsLegalMove definition: valid game moves",
       "legal_move_iff theorem: characterizes valid game moves",
       "IsMaximalAntichain definition: terminal game states",
-      "game_terminates: game terminates in finite moves",
-      "maximal_antichain_upper_bound: antichain size bounded by n/2",
-      "prime_antichain_bound: prime set gives lower bound",
       "gameLastsLinear: first Erdős question formalized with typed game length",
       "gameLastsNearOptimal: second Erdős question formalized",
       "primes_antichain theorem: constructive proof using Nat.Prime.eq_one_or_self_of_dvd",
@@ -71,7 +67,6 @@
       "firstPlayerAdvantage definition: existential statement that different game plays yield different terminal antichain sizes",
       "gameValue axiom: minimax game length function (axiomatized, exponential to compute)",
       "gameValue_upper axiom: gameValue(n) ≤ (n+1)/2 upper bound",
-      "erdos_872_conjecture: linear vs sublinear dichotomy",
       "erdos_872_summary: combines primes_antichain and gameValue_upper"
     ],
     "axiomCount": 2,
@@ -84,7 +79,7 @@
     "historicalContext": "**The Antichain Saturation Game**\n\nErdős posed this problem in his 1992 survey paper [Er92c, p.47] \"Some of my favourite problems in various branches of combinatorics,\" published in Le Matematiche. The problem combines two rich mathematical traditions: the study of primitive sets (antichains under divisibility) and combinatorial game theory.\n\n**The Game and Its Rules**\n\nTwo players alternately choose integers from {2, 3, ..., n} to build a set A where no element divides another. The game ends when A becomes a maximal antichain — no further element can be added without creating a divisibility pair. One player (the Maximizer) wants the game to last as long as possible, while the other (the Minimizer) wants it to end quickly. Erdős asks: how many moves can the Maximizer guarantee?\n\n**Related Saturation Games**\n\nThis is a number-theoretic variant of Hajnal's triangle-free game, where players alternately add edges to a complete graph while keeping it triangle-free. For the graph version, Füredi and Seress (1991) proved the game lasts at least Omega(n log n) moves, while Biró, Horn, and Wildstrom (2016) showed the upper bound (26/121 + o(1))n². The divisibility antichain game remains much less understood — both of Erdős's specific questions are open.",
     "problemStatement": "**Problem Statement (Open)**\n\nConsider the two-player game on $\\{2, 3, \\ldots, n\\}$:\n- Players alternately choose integers for set $A$\n- Constraint: no $a \\mid b$ for distinct $a, b \\in A$ (antichain under divisibility)\n- Game ends when $A$ is maximal\n- One player maximizes, one minimizes duration\n\n**Questions:**\n1. Can the game last at least $\\varepsilon n$ moves for some $\\varepsilon > 0$?\n2. Can the game last at least $(1-\\varepsilon)\\frac{n}{2}$ moves?\n\n**Bounds:**\n- Upper: Any antichain in $\\{2,\\ldots,n\\}$ has size at most $\\lfloor n/2 \\rfloor$\n- Lower: Primes give antichains of size $\\sim n/(2 \\ln n)$",
     "text": "How long can a two-player game on divisibility antichains in {2,...,n} be guaranteed to last when one player maximizes and one minimizes game length?",
-    "proofStrategy": "We formalize the complete game structure: IsDivisibilityAntichain and IsPrimitiveSet with a constructive equivalence proof, gameBoard, IsLegalMove, IsMaximalAntichain, and game termination. Bounds are axiomatized: the upper bound n/2 from the chain decomposition argument, and the prime antichain lower bound from the prime number theorem. Erdős's two open questions are formalized as gameLastsLinear and gameLastsNearOptimal with proper typed game-length functions (replacing True placeholders). The game-theoretic formulation introduces gameValue with positivity and upper bound axioms. The key proved result is primes_antichain, using Mathlib's Nat.Prime.eq_one_or_self_of_dvd.",
+    "proofStrategy": "We formalize the game structure with definitions IsDivisibilityAntichain and IsPrimitiveSet (plus a constructive equivalence proof antichain_iff_primitive), gameBoard, IsLegalMove (with the characterization theorem legal_move_iff), and IsMaximalAntichain. Termination and the size bounds (upper bound n/2, prime antichain lower bound) are discussed in prose comments only, not as declarations. Erdős's two open questions are formalized as gameLastsLinear and gameLastsNearOptimal with typed game-length functions. The game-theoretic formulation introduces two axioms: gameValue (the minimax game length function) and gameValue_upper (its (n+1)/2 upper bound). The key proved results are primes_antichain (using Mathlib's Nat.Prime.eq_one_or_self_of_dvd) and upper_half_antichain.",
     "keyInsights": [
       "**Primitive sets are antichains**: A divisibility antichain (no a | b for distinct elements) is equivalent to a primitive set — fundamental objects in multiplicative number theory",
       "**Upper bound n/2**: The set {n/2+1, ..., n} shows the maximum antichain has floor(n/2) elements, since if a | b with both > n/2, then b >= 2a > n",
@@ -110,18 +105,18 @@
     {
       "id": "game-board",
       "title": "The Game Board",
-      "summary": "gameBoard, gameBoard_card, IsLegalMove, legal_move_iff",
+      "summary": "gameBoard, IsLegalMove, legal_move_iff",
       "startLine": 79,
       "endLine": 110,
-      "mathContext": "Mathematical content: gameBoard, gameBoard_card, IsLegalMove, legal_move_iff"
+      "mathContext": "Mathematical content: gameBoard, IsLegalMove, legal_move_iff"
     },
     {
       "id": "game-state",
       "title": "Game State and Termination",
-      "summary": "IsMaximalAntichain, game_terminates",
+      "summary": "IsMaximalAntichain (termination discussed in prose)",
       "startLine": 111,
       "endLine": 131,
-      "mathContext": "Mathematical content: IsMaximalAntichain, game_terminates"
+      "mathContext": "Mathematical content: IsMaximalAntichain (termination discussed in prose)"
     },
     {
       "id": "bounds",
@@ -158,10 +153,10 @@
     {
       "id": "game-theory",
       "title": "Game-Theoretic Formulation",
-      "summary": "gameValue axiom with properties, erdos_872_conjecture",
+      "summary": "gameValue and gameValue_upper axioms",
       "startLine": 255,
       "endLine": 277,
-      "mathContext": "Axiomatized: gameValue axiom with properties, erdos_872_conjecture"
+      "mathContext": "Axiomatized: gameValue and gameValue_upper axioms"
     },
     {
       "id": "summary",
@@ -173,7 +168,7 @@
     }
   ],
   "conclusion": {
-    "summary": "Erdős Problem #872 asks about the guaranteed length of a two-player saturation game on divisibility antichains in {2,...,n}. The formalization defines the complete game structure, proves primes form antichains (the key constructive result), axiomatizes bounds (max antichain size n/2, prime lower bound), and formalizes both of Erdős's open questions with properly typed game-length functions. All True := trivial placeholders and sorry proofs have been replaced with meaningful axioms.",
+    "summary": "Erdős Problem #872 asks about the guaranteed length of a two-player saturation game on divisibility antichains in {2,...,n}. The formalization defines the complete game structure, proves primes form antichains (the key constructive result) and that {n/2+1,...,n} is an antichain, axiomatizes the minimax game value via gameValue and its (n+1)/2 upper bound gameValue_upper, and formalizes both of Erdős's open questions with properly typed game-length functions. The size bounds (max antichain n/2, prime lower bound) are described in prose comments rather than as declarations.",
     "implications": "**Theoretical Significance**: Understanding the game value would connect primitive set theory with combinatorial game theory.\n\nThe problem sits at the intersection of number theory (divisibility structure), extremal combinatorics (maximal antichains), and game theory (minimax analysis). Resolution would likely require new techniques beyond those used for the triangle-free graph game.",
     "openQuestions": [
       "Does the game last Theta(n) moves under optimal play?",


### PR DESCRIPTION
## Integrity Issue

**Proof**: erdos-872 (Antichain Saturation Game)
**Problem**: meta prose overstates the formalization — names 5 declarations that exist only as comment blocks, and claims the size bounds are axiomatized when they are prose only.

## Evidence

Lean file counts are all correct: 5 theorems, 8 defs, 2 axioms, 0 sorries, 0 True stubs, 0 native_decide.

`originalContributions` listed these phantom declarations (grep confirms 0 declarations each in `Proofs/Erdos872Problem.lean`):
- `gameBoard_card` (only a comment at lines 88–92)
- `game_terminates` (only a comment at lines 139–142)
- `maximal_antichain_upper_bound` (only a comment at lines 147–156)
- `prime_antichain_bound` (only a comment at lines 158–161)
- `erdos_872_conjecture` (only a comment at lines 273–277)

`proofStrategy` claimed "Bounds are axiomatized" and "gameValue with positivity … axioms" — no bound axioms and no positivity axiom exist (only `gameValue` and `gameValue_upper`).

`conclusion.summary` claimed "axiomatizes bounds (max antichain size n/2, prime lower bound)".

## Fix

- Dropped the 5 phantom entries from `originalContributions` (20 → 15 real declarations).
- Reworded `proofStrategy` and `conclusion.summary`: bounds are prose comments, only the game value is axiomatized; removed phantom "positivity" axiom.
- Cleaned phantom names from the game-board / game-state / game-theory section summaries + mathContext.

Counts, status (`axiomatized`/`axiom`), and the 2-axiom disclosure are unchanged.

---
Discovered during gallery integrity audit (reserve-mode re-serve).

🤖 Generated with [Claude Code](https://claude.com/claude-code)