### PR TITLE
audit: erdos-686 — fix stale 'axiomatized' prose (0 axioms; conjecture is a def, follow-up proved)

### DIFF
--- a/src/data/proofs/erdos-686/meta.json
+++ b/src/data/proofs/erdos-686/meta.json
@@ -43,7 +43,7 @@
     "historicalContext": "Erdős Problem #686 appears in [Er79d] and was further discussed in the influential monograph 'Old and New Problems and Results in Combinatorial Number Theory' by Erdős and Graham (1980). The question explores the surprising representational power of products of consecutive integers — structures intimately connected to factorials, binomial coefficients, and the Gamma function. Products of $k$ consecutive integers satisfy $\\prod_{i=1}^k (n+i) = (n+k)!/n! = k! \\binom{n+k}{k}$, linking this problem to deep divisibility theory of binomial coefficients. The related Problem #677 asks the simpler question of which integers are products of consecutive integers (no ratio). Bertrand's postulate (Chebyshev, 1850) guarantees a prime in $(n, 2n)$, which constrains which integers can appear as such products. The ratio formulation in #686 is strictly more general, as demonstrated by the `product_implies_ratio` reduction in the formalization.",
     "problemStatement": "Can every integer N ≥ 2 be written as ∏_{i=1}^k (m+i) / ∏_{i=1}^k (n+i) for some k ≥ 2 and m ≥ n + k? The constraints ensure non-trivial non-overlapping ranges with ratio > 1. OPEN.",
     "text": "Can every integer N ≥ 2 be written as ∏(m+i) / ∏(n+i) for some k ≥ 2 and m ≥ n + k? OPEN.",
-    "proofStrategy": "The formalization has four layers:\n\n1. **Foundation**: `consecutiveProduct(n,k)` via `Finset.prod`, with proved identities linking to factorials (`consecutiveProduct_eq_factorial`, by induction on $k$) and binomial coefficients (`product_binomial_relation`, using `Nat.choose_mul_factorial_mul_factorial`)\n\n2. **Ratio machinery**: `ratioExpression` over $\\mathbb{Q}$ for exact division, `ratio_as_binomials` proving it equals $\\binom{m+k}{k}/\\binom{n+k}{k}$ via `field_simp`\n\n3. **Structural properties**: `numerator_gt_denominator` (proved via `Finset.prod_lt_prod_of_nonempty`), `consecutiveProduct_pos`, `consecutiveProduct_mono`\n\n4. **Conjecture**: `erdos_686_conjecture` axiomatized; `representable_set_infinite` axiomatized; verified examples for $N = 2$ and $N = 6$",
+    "proofStrategy": "The formalization has four layers:\n\n1. **Foundation**: `consecutiveProduct(n,k)` via `Finset.prod`, with proved identities linking to factorials (`consecutiveProduct_eq_factorial`, by induction on $k$) and binomial coefficients (`product_binomial_relation`, using `Nat.choose_mul_factorial_mul_factorial`)\n\n2. **Ratio machinery**: `ratioExpression` over $\\mathbb{Q}$ for exact division, `ratio_as_binomials` proving it equals $\\binom{m+k}{k}/\\binom{n+k}{k}$ via `field_simp`\n\n3. **Structural properties**: `numerator_gt_denominator` (proved via `Finset.prod_lt_prod_of_nonempty`), `consecutiveProduct_pos`, `consecutiveProduct_mono`\n\n4. **Conjecture**: `Erdos686Conjecture` stated as a `Prop` definition (the open problem itself — not axiomatized); `representable_set_infinite` fully proved via the shifted-multiple injection $t \\mapsto P(n+(t+1)P(n,k),k)/P(n,k)$; verified examples for $N = 2$ and $N = 6$",
     "keyInsights": [
       "P(n,k) = (n+k)!/n! = k! * C(n+k, k)",
       "m ≥ n + k ensures non-overlapping ranges and ratio > 1",
@@ -82,7 +82,7 @@
       "title": "Part III: The Representation Property",
       "startLine": 92,
       "endLine": 106,
-      "summary": "Defines IsRepresentable (k ≥ 2, m ≥ n+k, ratio = N), Representable (existential), and axiomatizes ErdosConjecture686: ∀ N ≥ 2, Representable N.",
+      "summary": "Defines IsRepresentable (k ≥ 2, m ≥ n+k, ratio = N), Representable (existential), and Erdos686Conjecture: ∀ N ≥ 2, Representable N — stated as a Prop definition (the open conjecture is not axiomatized).",
       "mathContext": "The constraints $k \\geq 2$ (excludes trivial single-factor ratios) and $m \\geq n + k$ (non-overlapping consecutive ranges) ensure meaningful representations with ratio $\\geq 2$."
     },
     {
@@ -106,7 +106,7 @@
       "title": "Part VI: Follow-Up Question",
       "startLine": 147,
       "endLine": 157,
-      "summary": "Defines RepresentableSet(n,k) — the set of integers representable with fixed initial parameters. Axiomatizes representable_set_infinite: this set is infinite for k ≥ 2.",
+      "summary": "Defines RepresentableSet(n,k) — the set of integers representable with fixed initial parameters. Proves representable_set_infinite: this set is infinite for k ≥ 2 (formerly axiomatized, now discharged — see Part VI in the source).",
       "mathContext": "For fixed $n, k$, the set $\\{N : \\exists m \\geq n+k, P(m,k)/P(n,k) = N\\}$ is infinite because the ratio $P(m,k)/P(n,k) \\to \\infty$ as $m \\to \\infty$."
     },
     {


### PR DESCRIPTION
## Integrity Issue

**Proof**: erdos-686 (Ratios of Products of Consecutive Integers — OPEN)
**Problem**: Meta prose describes declarations as *axiomatized* that carry no axiom. The file has **0 axioms / 0 sorries**.

## Evidence

Header docstring (`proofs/Proofs/Erdos686Problem.lean:19`):
> Axiom elimination (researcher-3): representable_set_infinite was axiomatized. Now proved via...

Actual source:
- `Erdos686Conjecture : Prop := ∀ N ≥ 2, Representable N` — a **def**, the open problem stated (not axiomatized). (line 109)
- `representable_set_infinite` — a **proved theorem** via the shifted-multiple injection. (line 280)
- `grep '^axiom'` → none; `meta.axiomCount = 0`; `assumptions` already says "0 axioms, 0 sorries".

Stale prose that contradicted this (now fixed):
1. `proofStrategy` layer 4 — "`erdos_686_conjecture` axiomatized; `representable_set_infinite` axiomatized"
2. section **representability** — "axiomatizes ErdosConjecture686" (also a wrong name)
3. section **followup** — "Axiomatizes representable_set_infinite"

## Fix

Reworded all three to match the source: conjecture is a `Prop` definition; `representable_set_infinite` is proved. No status/badge change (badge `wip` remains accurate — the main conjecture is stated, not proved).

## Verified accurate (no change)

- theoremCount 23, definitionCount 9, lineCount 293 — all match the file exactly
- sorries 0, axiomCount 0 — match
- native_decide disclosed in prerequisites / examples

---
Discovered during gallery integrity audit (reserve mode; oldest uncontested target).
🤖 Generated with [Claude Code](https://claude.com/claude-code)