### PR TITLE
Enrich hurwitz-theorem-oq-03-wip-01: cover the Product Engine section

### DIFF
--- a/src/data/proofs/hurwitz-theorem-oq-03-wip-01/meta.json
+++ b/src/data/proofs/hurwitz-theorem-oq-03-wip-01/meta.json
@@ -99,6 +99,14 @@
       "startLine": 123,
       "endLine": 138,
       "mathContext": "The engine is exercised over ℝ (driving the parent's odd case) and over ℂ (the field of the n≡2 mod 4 reduction, where the effective complex dimension n/2 is odd)."
+    },
+    {
+      "id": "product-engine",
+      "title": "The Product Engine: Moving an Anticommuting Element Through a Product",
+      "startLine": 139,
+      "endLine": 203,
+      "summary": "The reusable ring-level engine behind the n ≡ 2 (mod 4) reduction. mul_prod_anticomm: an element a that anticommutes with every factor of a list t picks up the sign (−1)^t.length when moved across the whole product — a * t.prod = (−1)^t.length * (t.prod * a). Its parity corollaries commute_prod_of_anticomm_of_even (even length ⇒ a commutes with the product) and anticommute_prod_of_anticomm_of_odd (odd length ⇒ a anticommutes) are the algebraic core controlling how a fresh structure moves through P = M₁⋯M_{n−1}. Stated over an arbitrary ring, so they apply verbatim to the real crossMat family and its complexification.",
+      "mathContext": "$a\\,\\prod t = (-1)^{|t|}\\,(\\prod t)\\,a$ when $a$ anticommutes with each factor; parity of $|t|$ decides commute vs. anticommute."
     }
   ],
   "references": [


### PR DESCRIPTION
## Enrichment pass — section coverage

`hurwitz-theorem-oq-03-wip-01/meta.json` had **3 sections stopping at line 138** of a **203-line** file, leaving the entire `section ProductEngine` (lines 139–203) — the three ring-level lemmas `mul_prod_anticomm`, `commute_prod_of_anticomm_of_even`, `anticommute_prod_of_anticomm_of_odd` that are the algebraic core of the *n ≡ 2 (mod 4)* Hurwitz reduction — with no section coverage, despite the file's own banner comment delimiting it.

### Fix
Added one section `139–203` ("The Product Engine: Moving an Anticommuting Element Through a Product") so the four sections now tile lines **54–203**.

No existing content removed; `lineCount` already correct at 203.

🤖 Generated with [Claude Code](https://claude.com/claude-code)