### PR TITLE
audit: re-serve elementary-quadratic-reciprocity-oq-01-oq-02 (axiomatized) — clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -8125,9 +8125,9 @@
       "issues": []
     },
     "elementary-quadratic-reciprocity-oq-01-oq-02": {
-      "auditCount": 7,
-      "lastAudited": "2026-05-04T00:55:01Z",
-      "result": "issues-fixed",
+      "auditCount": 8,
+      "lastAudited": "2026-07-20T12:34:00Z",
+      "result": "clean",
       "issues": [
         "lineCount 463→562, theoremCount 24→27 (stale after PRs #15357/#15414); fix in PR #15414"
       ]

--- a/src/data/proofs/enrichment-tracker.json
+++ b/src/data/proofs/enrichment-tracker.json
@@ -7107,6 +7107,26 @@
       "passes": 1,
       "lastEnriched": "2026-07-12T04:48:00Z",
       "quality": 96
+    },
+    "hurwitz-theorem-oq-03-wip-01": {
+      "passes": 1,
+      "lastEnriched": "2026-07-20T12:32:14Z",
+      "quality": 98
+    },
+    "erdos-729-oq-04": {
+      "passes": 1,
+      "lastEnriched": "2026-07-20T12:32:28Z",
+      "quality": 98
+    },
+    "lucas-sum-oq-01-oq-02": {
+      "passes": 1,
+      "lastEnriched": "2026-07-20T12:33:00Z",
+      "quality": 98
+    },
+    "erdos-1207-oq-03": {
+      "passes": 1,
+      "lastEnriched": "2026-07-20T12:34:04Z",
+      "quality": 98
     }
   }
 }


### PR DESCRIPTION
## Reserve-mode re-audit

Unaudited queue drained (0 remaining). Picked the oldest uncontested target by last-audit time; all top-10 find-targets candidates were contested by open fleet PRs.

**Target:** `elementary-quadratic-reciprocity-oq-01-oq-02` — *Cubic and Quartic Characters as Higher Reciprocity Pathway*

## Verification (meta.json vs Proofs/ElementaryQuadraticReciprocityOQ01OQ02.lean)

| Field | meta | file | ✓ |
|-------|------|------|---|
| sorries | 0 | 0 | ✓ |
| axiomCount | 2 | 2 | ✓ |
| theoremCount | 27 | 27 | ✓ |
| lineCount | 579 | 579 | ✓ |
| defCount | 6 (+1 instance = definitionCount 7) | 6 defs + 1 instance | ✓ |

- Both axioms (`cubicResidueSymbol`, `cubic_reciprocity`) are genuine, live in the Eisenstein section, and are honestly disclosed in `description`/`assumptions`.
- No `True` stubs, no `native_decide`, no `admit`, no vacuous `: True` theorems.
- All prose-named declarations exist (`cubicChar_kernel_card`, `quarticChar_kernel_card`, `cubicEuler_hard`, `quarticEuler_hard`, `cubic_character_package`, `quartic_character_package`, `isQuarticResidue_iff_quarticChar_one`) — no phantom declarations.
- Prose correctly scopes cubic reciprocity as **axiomatized** while the cubic/quartic Euler criteria are fully proved (0 axioms). Status `axiomatized` / badge `axiom` are accurate.

**Result: clean.** No overclaim detected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)