### PR TITLE
Enrich three-place-identity-oq-01: extend truncated Part IV–V section to cover idempotence

### DIFF
--- a/src/data/proofs/three-place-identity-oq-01/meta.json
+++ b/src/data/proofs/three-place-identity-oq-01/meta.json
@@ -78,7 +78,7 @@
       "id": "tpi-oq01-inversion-idem",
       "title": "Parts IV–V: Inversion and Self-Regularization",
       "startLine": 115,
-      "endLine": 164,
+      "endLine": 179,
       "summary": "derivedMem_of_not_foundation: mem x x ⇒ derivedMem mem y x ↔ ¬ mem y x (the round-trip inverts). roundtrip_fails_example: a concrete Unit model with total membership witnesses genuine failure. derivedWFM packages the derived membership as a WellFoundedMembership; derivedMem_idempotent: applying the round-trip twice changes nothing (idempotent regularization), from the parent's roundtrip on derivedWFM.",
       "mathContext": "When Foundation fails the round-trip flips to $\\neg\\,\\mathrm{mem}\\,y\\,x$; since $D(\\mathrm{mem})$ is always well-founded, $D \\circ D = D$ — an idempotent projection onto well-founded membership."
     }


### PR DESCRIPTION
## Enrichment pass — section coverage

`three-place-identity-oq-01/meta.json` had its **"Parts IV–V: Inversion and Self-Regularization"** section ending at line **164**, cutting off `derivedMem_idempotent` (line 165) — the Part V culminating theorem that the section's **own summary already describes** ("applying the round-trip twice changes nothing") — along with the file's final verification `#check` block.

### Fix
Extended `endLine 164 → 179` so the three sections tile lines **52–179**.

No content changed; `lineCount` already correct at 179.

🤖 Generated with [Claude Code](https://claude.com/claude-code)