### PR TITLE
Enrich chinese-remainder-constructive-oq-05-oq-02: fix null-range section + reorder

### DIFF
--- a/src/data/proofs/chinese-remainder-constructive-oq-05-oq-02/meta.json
+++ b/src/data/proofs/chinese-remainder-constructive-oq-05-oq-02/meta.json
@@ -68,20 +68,22 @@
       "id": "uniqueness",
       "title": "The n-Modulus Uniqueness Certificate",
       "startLine": 55,
-      "endLine": 77,
+      "endLine": 75,
       "summary": "crt_list_unique: any two values below ms.prod agreeing modulo every m ∈ ms are equal. Equal residues give m ∣ (difference) for all m, hence ms.prod ∣ (difference); but the difference is below ms.prod, so it vanishes."
+    },
+    {
+      "id": "example",
+      "title": "Worked Uniqueness Instance over [3, 4, 5]",
+      "startLine": 76,
+      "endLine": 88,
+      "summary": "crt_345_unique: two values below 60 with the same residues mod 3, 4, 5 coincide. Pairwise coprimality and the product 60 are decided; the residue hypotheses are dispatched by fin_cases on list membership."
     },
     {
       "id": "existence",
       "title": "The n-Modulus Existence Half",
-      "summary": "crt_list_exists: for pairwise-coprime ms and any residues r, ∃ x, ∀ m∈ms, x ≡ r m [MOD m]. List induction; the cons step combines the head (coprime to the tail product) with the tail solution via Nat.chineseRemainder, then restricts the tail-product congruence to each tail modulus by Nat.ModEq.of_dvd. With crt_list_unique this is the full CRT. crt_345_exists is the worked [3,4,5] instance."
-    },
-    {
-      "id": "example",
-      "title": "Worked Instance over [3, 4, 5]",
-      "startLine": 79,
-      "endLine": 88,
-      "summary": "crt_345_unique: two values below 60 with the same residues mod 3, 4, 5 coincide. Pairwise coprimality and the product 60 are decided; the residue hypotheses are dispatched by fin_cases on list membership."
+      "summary": "crt_list_exists: for pairwise-coprime ms and any residues r, ∃ x, ∀ m∈ms, x ≡ r m [MOD m]. List induction; the cons step combines the head (coprime to the tail product) with the tail solution via Nat.chineseRemainder, then restricts the tail-product congruence to each tail modulus by Nat.ModEq.of_dvd. With crt_list_unique this is the full CRT. crt_345_exists is the worked [3,4,5] instance.",
+      "startLine": 89,
+      "endLine": 123
     }
   ],
   "overview": {


### PR DESCRIPTION
## Enrichment pass — section correctness

`chinese-remainder-constructive-oq-05-oq-02/meta.json` had two structural bugs in `sections`:

1. The **"The n-Modulus Existence Half"** section had **null `startLine`/`endLine`** — it rendered with no navigable anchor at all, despite describing `crt_list_exists` (line 97) and `crt_345_exists` (line 117).
2. The sections were **out of file order**: "Worked Instance over [3, 4, 5]" (79–88, covering the *uniqueness* witness `crt_345_unique`) was listed *after* the existence section.

### Fix
- Set the existence section to its real span `89–123`.
- Reordered the four sections into ascending file order — engine (33–53), uniqueness (55–75), worked uniqueness instance (76–88), existence (89–123) — so they tile lines **33–123** contiguously.
- Retitled the 79–88 section **"Worked Uniqueness Instance over [3, 4, 5]"** to distinguish it from the worked existence instance in the existence section (its summary already describes `crt_345_unique`).

No summary content changed; `meta.lineCount` already correct at 123.

🤖 Generated with [Claude Code](https://claude.com/claude-code)