### PR TITLE
Enrich cantor-diagonalization-oq-07: add CH-independence keyInsight

### DIFF
--- a/src/data/proofs/cantor-diagonalization-oq-07/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-07/meta.json
@@ -78,7 +78,8 @@
       "**Stability vs. strict growth.** Diagonalization (oq-06) shows ℝ is strictly larger than ℕ (ℵ₀ < 𝔠); cardinal multiplication shows the continuum is *stable* under products (𝔠 · 𝔠 = 𝔠). Products do not grow an infinite cardinal; power sets do.",
       "**A choice-dependent absorption law.** κ · κ = κ for every infinite κ is equivalent to the axiom of choice (Tarski). Mathlib's `Cardinal.mul_eq_self` supplies it; everything here is a one-line specialization at κ = 𝔠.",
       "**Cardinal equality is a bijection.** `Cardinal.eq` makes #(ℝ × ℝ) = #ℝ literally the statement Nonempty (ℝ × ℝ ≃ ℝ) — Cantor's 1878 'line ≅ plane' bijection, recovered from the cardinal computation.",
-      "**The complex plane is no bigger than the line.** #ℂ = #ℝ falls out immediately, since ℂ ≃ ℝ × ℝ."
+      "**The complex plane is no bigger than the line.** #ℂ = #ℝ falls out immediately, since ℂ ≃ ℝ × ℝ.",
+      "**A ZFC theorem, independent of the Continuum Hypothesis.** Unlike the *value* of 𝔠 (whether 𝔠 = ℵ₁ is undecidable in ZFC — Gödel/Cohen), the *identity* 𝔠 · 𝔠 = 𝔠 is a plain ZFC theorem, needing only ℵ₀ ≤ 𝔠 and the absorption law. It holds no matter how large 𝔠 is or where it sits in the ℵ hierarchy: cardinal arithmetic of the form κ · κ = κ is settled outright, while questions about 𝔠's *position* are CH-sensitive. This entry lives entirely on the decidable side of that line."
     ],
     "prerequisites": [
       "Cardinal arithmetic in Mathlib (Cardinal.mk, ℵ₀, 𝔠, multiplication)",


### PR DESCRIPTION
Enrichment pass for `cantor-diagonalization-oq-07` (#(ℝ × ℝ) = #ℝ).

The entry already met every quality target (5 rich annotations with mathContext/significance/relatedConcepts/prerequisites, accurate section ranges, correct counts, full conclusion). Verified against the Lean source: section line ranges (1-26, 28-33, 35-45, 47-60), theoremCount=5, axiomCount=0/status=verified — **no drift**.

The one genuine conceptual gap: the entry had 4 keyInsights and did not state that 𝔠·𝔠=𝔠 is a plain **ZFC theorem, independent of the Continuum Hypothesis** — a non-obvious distinction between decidable cardinal-arithmetic identities (κ·κ=κ) and CH-sensitive questions about the *position* of 𝔠 in the ℵ hierarchy. Added as a 5th keyInsight (of 12 cap).

meta.json 11.0 → 11.5 KB (well under the 60 KB ceiling). JSON validated.