### PR TITLE
Enrich amgm-inequality-oq-02-oq-03: drop stale UNVERIFIED/v4.26 caveat

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-02-oq-03/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-02-oq-03/meta.json
@@ -28,7 +28,7 @@
     "dateAdded": "2026-03-30",
     "axiomCount": 0,
     "lineCount": 242,
-    "assumptions": "0 axioms, 0 sorries. newton_lc now delegates to NewtonLogConcavity.newton_log_concavity_proved (proved from first principles in AmgmInequalityOQ02OQ02.lean via NewtonInductiveStep.lean — both axiom-free, 0-sorry, no native_decide), so the entire Maclaurin chain in this file is axiom-free and no longer inherits the newton_log_concavity axiom from AmgmInequalityOQ02.lean. The maclaurin_step axiom was already eliminated here (maclaurin_step_proved). NOTE: UNVERIFIED this session — build host unavailable (disk ~97% full, zombie containers); the one-line axiom→theorem delegation is a defeq-identical drop-in checked by inspection against the pinned Mathlib 4.26.0 source, pending rebuild confirmation.",
+    "assumptions": "0 axioms, 0 sorries. newton_lc now delegates to NewtonLogConcavity.newton_log_concavity_proved (proved from first principles in AmgmInequalityOQ02OQ02.lean via NewtonInductiveStep.lean — both axiom-free, 0-sorry, no native_decide), so the entire Maclaurin chain in this file is axiom-free and no longer inherits the newton_log_concavity axiom from AmgmInequalityOQ02.lean. The maclaurin_step axiom was already eliminated here (maclaurin_step_proved). Verified against Mathlib 4.31.0 (the axiom→theorem delegation landed in #35127 and the entry compiles green in the tree-wide 4.31.0 reconcile).",
     "mathlib_version": "4.31.0",
     "theoremCount": 7,
     "definitionCount": 1


### PR DESCRIPTION
## Enrichment pass — stale-caveat correction

**Target:** `amgm-inequality-oq-02-oq-03` (AM–GM / Maclaurin chain)

### Defect
The `meta.assumptions` field ended with a stale caveat:

> NOTE: UNVERIFIED this session — build host unavailable (disk ~97% full, zombie containers); the one-line axiom→theorem delegation is a defeq-identical drop-in checked by inspection against the pinned **Mathlib 4.26.0** source, pending rebuild confirmation.

This directly contradicts the entry's current metadata: `status: verified`, `badge: verified`, `mathlib_version: 4.31.0`, `axiomCount: 0`, `sorries: 0`.

### Evidence it is stale
- The caveat originated in #30743 ("UNVERIFIED — build host down").
- #35127 subsequently repaired and **landed** the axiom→theorem delegation, building it on v4.26.
- The tree-wide 4.31.0 reconcile flip (#39062) is green on `main`; #39063 swept this entry's `mathlib_version` to 4.31.0.
- `AmgmInequalityOQ02OQ03.lean` has **0** real `axiom`/`sorry`/`native_decide` declarations (only mentions in comments); `newton_lc` delegates to the axiom-free `NewtonLogConcavity.newton_log_concavity_proved`.

### Change
Replaced the stale "pending rebuild / 4.26.0" sentence with an accurate note ("Verified against Mathlib 4.31.0 …"), preserving the substantive axiom-elimination description. Single-field, single-file edit; JSON validated; gallery build data checks pass.