### PR TITLE
audit: re-serve erdos-690 (axiomatized) — clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -15683,8 +15683,8 @@
     },
     "erdos-690": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:55:02Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-20T12:52:28Z",
       "result": "clean"
     },
     "erdos-691": {


### PR DESCRIPTION
## Gallery Integrity Audit — erdos-690

**Proof**: erdos-690 — *Unimodality of k-th Prime Factor Density*
**Result**: clean (reserve-mode re-audit; queue drained, 0 unaudited)

### Verification

| Check | meta.json | Lean file | OK |
|-------|-----------|-----------|----|
| sorries | 0 | 0 | ✓ |
| axiomCount | 8 | 8 | ✓ |
| theoremCount | 11 | 11 | ✓ |
| definitionCount | 3 | 3 | ✓ |
| True stubs | — | 0 | ✓ |
| native_decide | — | 0 | ✓ |

- lineCount 171 vs actual 173 — harmless undercount, no change.

### Prose vs. reality (Tier C — honest)

- status `axiomatized` / badge `axiom` throughout; `assumptions` lists all 8 axioms accurately.
- Axioms encode Cambie's **published** results (arXiv:2501.10333), disclosed as axiomatized — not the still-open k>20 case. erdosProblemStatus `open` is conservatively correct.
- Axiom set is consistent: `d1_at_2 = 1/2 > d1_at_3 = 1/6` agrees with `d1_strictly_decreasing`; no False/inconsistent axiom masking.
- `d1_unimodal` genuinely **proved** from `d1_strictly_decreasing`; `erdos_690_answer_no` derived from the disclosed `cambie_not_unimodal` axiom.
- No phantom declaration names in section summaries / keyInsights / proofStrategy.

No overclaim detected. Tracker updated (auditCount 3 → 4).

---
Discovered during gallery integrity audit.