### PR TITLE
Research: abundant-number-oq-03-oq-03 — 945 odd-primitive-abundant witness + Route-1 σ-arithmetic engine (axiom-free)

### DIFF
--- a/proofs/Proofs/AbundantNumberOQ03OQ03.lean
+++ b/proofs/Proofs/AbundantNumberOQ03OQ03.lean
@@ -34,6 +34,18 @@
                                        abundant proper divisor destroys primitivity
                                        (abundance and deficiency are exclusive).
 
+  Toward the (open) infinitude, this file also builds the **σ-arithmetic engine**
+  for the Route-1 family `m·p`:
+
+  * `sum_divisors_prime`             — `σ(p) = p + 1` for prime `p`.
+  * `sum_divisors_mul_prime`         — `σ(m·p) = σ(m)·(p+1)` when `p` is prime and
+                                       `p ∤ m` (multiplicativity of `σ` on coprime
+                                       factors).
+  * `abundant_mul_prime_iff`         — reduces abundance of `m·p` to the single
+                                       linear-in-`p` inequality `2mp < σ(m)(p+1)`.
+  * `deficient_left_of_primitive_mul_prime` — any Route-1 base `m` must itself be
+                                       deficient (it is a proper divisor of `m·p`).
+
   ## Verification status: verified (axiom-free)
 
   Unlike the sibling `abundant-number-oq-02` entry, which discharges the 945-range
@@ -108,5 +120,56 @@ theorem primitive_945 : IsPrimitiveAbundant 945 := by
 (OEIS A006038), and the base witness that any infinitude construction must extend. -/
 theorem mem_oddPrimitiveAbundant_945 : 945 ∈ OddPrimitiveAbundant :=
   ⟨odd_945, primitive_945⟩
+
+-- ============================================================
+-- Toward infinitude: the σ-arithmetic engine for `m · p`
+-- ============================================================
+
+/-
+  Route 1 (odd `m · p` with `p` an odd prime outside a Bertrand-type window)
+  needs the sum-of-divisors of `m · p` in closed form.  Since `p ∤ m` makes
+  `m` and `p` coprime and `σ` (the sum-of-divisors) is multiplicative, we get
+  the workhorse identity `σ(m·p) = σ(m)·(p+1)`, which turns the abundance test
+  `2·(m·p) < σ(m·p)` into a *linear-in-`p`* inequality `2mp < σ(m)(p+1)`.  That
+  is the lever any explicit odd-family construction pulls: fix `m`, then choose
+  `p` in the range that keeps `m·p` abundant.
+
+  These lemmas are stated for the raw Mathlib sum `∑ d ∈ n.divisors, d`
+  (`= Nat.ArithmeticFunction.σ 1 n`) so they compose with
+  `Nat.abundant_iff_sum_divisors`.
+-/
+
+/-- The sum of the divisors of a prime `p` is `p + 1` (its only divisors are
+`1` and `p`).  The base case of the σ-arithmetic engine. -/
+theorem sum_divisors_prime {p : ℕ} (hp : p.Prime) :
+    ∑ d ∈ p.divisors, d = p + 1 := by
+  rw [hp.divisors, Finset.sum_pair hp.one_lt.ne]
+  omega
+
+/-- **σ closed form for `m · p`** (`p` prime, `p ∤ m`): the sum of divisors is
+multiplicative on the coprime factors `m` and `p`, so
+`σ(m·p) = σ(m) · (p + 1)`.  The reusable lever for Route-1 witness search. -/
+theorem sum_divisors_mul_prime {m p : ℕ} (hp : p.Prime) (hpm : ¬ p ∣ m) :
+    ∑ d ∈ (m * p).divisors, d = (∑ d ∈ m.divisors, d) * (p + 1) := by
+  have hcop : m.Coprime p := (hp.coprime_iff_not_dvd.mpr hpm).symm
+  rw [hcop.sum_divisors_mul, sum_divisors_prime hp]
+
+/-- **Abundance criterion for `m · p`** (`p` prime, `p ∤ m`): reduces the
+abundance of `m·p` to the single linear-in-`p` inequality
+`2·(m·p) < σ(m)·(p+1)`.  Directly usable to search for a prime `p` making a
+fixed odd base `m` abundant at `m·p`. -/
+theorem abundant_mul_prime_iff {m p : ℕ} (hp : p.Prime) (hpm : ¬ p ∣ m) :
+    (m * p).Abundant ↔ 2 * (m * p) < (∑ d ∈ m.divisors, d) * (p + 1) := by
+  rw [Nat.abundant_iff_sum_divisors, sum_divisors_mul_prime hp hpm]
+
+/-- **Necessary condition for primitivity of `m · p`**: if `m · p` is primitive
+abundant with `p` prime and `0 < m`, then the cofactor `m` is deficient — `m`
+is a proper divisor of `m·p` (as `p ≥ 2`), so primitivity forces it deficient.
+Every Route-1 base `m` must therefore itself be deficient. -/
+theorem deficient_left_of_primitive_mul_prime {m p : ℕ} (hp : p.Prime)
+    (hm : 0 < m) (hprim : IsPrimitiveAbundant (m * p)) : m.Deficient := by
+  refine hprim.2 m (Nat.mem_properDivisors.mpr ⟨dvd_mul_right m p, ?_⟩)
+  have hle : m * 2 ≤ m * p := by gcongr; exact hp.two_le
+  omega
 
 end AbundantNumberOQ03OQ03

--- a/proofs/Proofs/AbundantNumberOQ03OQ03.lean
+++ b/proofs/Proofs/AbundantNumberOQ03OQ03.lean
@@ -1,0 +1,112 @@
+/-
+  # Odd primitive abundant numbers — the base witness 945
+
+  *Open question* (`abundant-number-oq-03-oq-03`): are there infinitely many
+  **odd primitive abundant** numbers?  A positive integer `n` is *abundant* when
+  `n < σ'(n) := ∑_{d ∣ n, d < n} d`, and *deficient* when `σ'(n) < n`
+  (`Nat.Abundant` / `Nat.Deficient` in `Mathlib.NumberTheory.FactorisationProperties`).
+  Following OEIS A006038, `n` is **primitive abundant** here when it is abundant
+  yet *every* proper divisor is deficient — abundance appears for the first time,
+  under divisibility, exactly at `n`.  The target set is
+
+  `OddPrimitiveAbundant = { n | Odd n ∧ IsPrimitiveAbundant n }`   (A006038),
+
+  and the open question asks whether it is infinite.
+
+  ## What this file settles
+
+  The infinitude is genuinely open (no explicit odd family is known that is
+  provably primitive abundant for infinitely many members).  What *can* be pinned
+  down, axiom-free, is the **base of the problem**: the smallest odd abundant
+  number, `945 = 3³·5·7`, is in fact odd primitive abundant, so the target set is
+  nonempty with an explicit least element.  This anchors any future infinitude
+  construction (each new witness must, like 945, be abundant with all 15 proper
+  divisors deficient).
+
+  * `IsPrimitiveAbundant`            — the A006038 predicate (abundant, all proper
+                                       divisors deficient).
+  * `abundant_945`, `odd_945`        — `σ'(945) = 975 > 945`, and `945` is odd.
+  * `primitive_945`                  — all 15 proper divisors of `945`
+                                       (`1,3,5,7,9,15,21,27,35,45,63,105,135,189,315`)
+                                       are deficient, so `945` is primitive abundant.
+  * `mem_oddPrimitiveAbundant_945`   — `945 ∈ OddPrimitiveAbundant`.
+  * `not_primitive_of_abundant_properDivisor` — the structural obstruction: any
+                                       abundant proper divisor destroys primitivity
+                                       (abundance and deficiency are exclusive).
+
+  ## Verification status: verified (axiom-free)
+
+  Unlike the sibling `abundant-number-oq-02` entry, which discharges the 945-range
+  computations with `native_decide` (`Lean.ofReduceBool`, axiomatized), the finite
+  checks here are small enough — a single number `945` and its 15 divisors, each
+  `≤ 315` — to run in the Lean **kernel** via `decide` with a raised
+  `maxRecDepth`.  `#print axioms` for every theorem below lists only
+  `propext, Classical.choice, Quot.sound`.
+
+  ## Toward infinitude (recorded, not proved)
+
+  Two routes, both open:
+  1. *Odd analogue of the even `2^k·p` construction* — an odd base `m` with
+     `σ(m)/m` just below 2 times an odd prime `p` in a controlled (Bertrand-type)
+     window, so `m·p` is abundant for the first time at itself.  The obstruction:
+     odd `m` approach the abundance boundary slowly, and proper-divisor deficiency
+     is a real case analysis, not the clean "powers of two are deficient" fact.
+  2. *Primitive-part extraction* — every abundant `n` has a primitive abundant
+     divisor; show the primitive parts of an infinite odd abundant family
+     (`Nat.infinite_odd_abundant`) are odd and unbounded.  The obstruction:
+     controlling oddness and unboundedness of the primitive part needs a
+     pigeonhole that a single bounded part could defeat.
+
+  Reference: OEIS A006038 (odd primitive abundant numbers); A091191 (primitive
+  abundant numbers).  Sibling gallery entries: `abundant-number-oq-02` (945 is the
+  smallest odd abundant number), `abundant-number-oq-01` (12 is the smallest
+  abundant number).
+-/
+import Mathlib
+
+namespace AbundantNumberOQ03OQ03
+
+open Nat
+
+/-- **Primitive abundant** (OEIS A006038 sense): `n` is abundant, but every proper
+divisor of `n` is deficient. Abundance appears for the first time, under
+divisibility, exactly at `n`. -/
+def IsPrimitiveAbundant (n : ℕ) : Prop :=
+  n.Abundant ∧ ∀ d ∈ n.properDivisors, d.Deficient
+
+/-- The set of **odd primitive abundant** numbers, OEIS A006038. Whether this set
+is infinite is the open problem `abundant-number-oq-03-oq-03`. -/
+def OddPrimitiveAbundant : Set ℕ := {n | Odd n ∧ IsPrimitiveAbundant n}
+
+/-- Abundance and deficiency are mutually exclusive: no number is both. -/
+theorem not_deficient_of_abundant {n : ℕ} (h : n.Abundant) : ¬ n.Deficient := by
+  -- `Abundant n : n < σ'(n)`, `Deficient n : σ'(n) < n`
+  exact fun hd => absurd h (Nat.not_lt.mpr (le_of_lt hd))
+
+/-- The structural obstruction to primitivity: if any proper divisor of `n` is
+itself abundant, then `n` is *not* primitive abundant (the divisor cannot be
+deficient). This is the divisibility-minimality content of the definition. -/
+theorem not_primitive_of_abundant_properDivisor {n d : ℕ}
+    (hd : d ∈ n.properDivisors) (hab : d.Abundant) : ¬ IsPrimitiveAbundant n := by
+  rintro ⟨-, hdef⟩
+  exact not_deficient_of_abundant hab (hdef d hd)
+
+/-- `945` is odd. -/
+theorem odd_945 : Odd (945 : ℕ) := by decide
+
+/-- **`945` is abundant.** Its proper divisors sum to `975 > 945`. -/
+theorem abundant_945 : Nat.Abundant 945 := by
+  set_option maxRecDepth 4000 in decide
+
+/-- **`945` is primitive abundant.** Every one of its 15 proper divisors
+`1,3,5,7,9,15,21,27,35,45,63,105,135,189,315` is deficient. -/
+theorem primitive_945 : IsPrimitiveAbundant 945 := by
+  refine ⟨abundant_945, ?_⟩
+  set_option maxRecDepth 4000 in decide
+
+/-- **`945` is odd primitive abundant** — the least element of `OddPrimitiveAbundant`
+(OEIS A006038), and the base witness that any infinitude construction must extend. -/
+theorem mem_oddPrimitiveAbundant_945 : 945 ∈ OddPrimitiveAbundant :=
+  ⟨odd_945, primitive_945⟩
+
+end AbundantNumberOQ03OQ03

--- a/research/problems/abundant-number-oq-03-oq-03/knowledge.md
+++ b/research/problems/abundant-number-oq-03-oq-03/knowledge.md
@@ -57,3 +57,26 @@ Created `proofs/Proofs/AbundantNumberOQ03OQ03.lean` (self-contained, imports onl
   unbounded (pigeonhole).
 - Intermediate lemma: `σ(m·p) = σ(m)(p+1)` for odd prime `p ∤ m`, and a reusable
   proper-divisor-deficiency criterion for `m·p`.
+
+## Iteration 2 (2026-07-20) — Route-1 σ-arithmetic engine (axiom-free)
+
+Built the reusable σ-engine for the `m·p` family, all host-verified via
+`lake env lean` (`propext/Classical.choice/Quot.sound` only, no `native_decide`):
+
+- `sum_divisors_prime`: `σ(p) = p+1` (prime `p`; divisors `{1,p}`).
+- `sum_divisors_mul_prime`: `σ(m·p) = σ(m)·(p+1)` for `p` prime, `p ∤ m` — via
+  Mathlib `Nat.Coprime.sum_divisors_mul` (multiplicativity of `σ` on coprimes,
+  `isMultiplicative_sigma`) + `Nat.Prime.coprime_iff_not_dvd`.
+- `abundant_mul_prime_iff`: `(m·p).Abundant ↔ 2mp < σ(m)(p+1)` — via
+  `Nat.abundant_iff_sum_divisors`. Abundance of the Route-1 family is now a
+  single **linear-in-`p`** inequality.
+- `deficient_left_of_primitive_mul_prime`: any Route-1 base `m` (with `0<m`) is
+  deficient, since `m` is a proper divisor of `m·p`.
+
+### Remaining Route-1 gap (primitivity, not abundance)
+Full primitivity of `m·p` requires every proper divisor
+`{d, p·d : d ∣ m}` deficient. Mathlib v4.31 has `Nat.Coprime.sum_divisors_mul`
+and `card_divisors_mul` but **no** `Nat.Coprime.divisors_mul` Finset equality, so
+the decomposition `(m·p).properDivisors = m.divisors ∪ (p·) '' m.properDivisors`
+must be built from `filter_dvd_eq_divisors` before `abundant_mul_prime_iff`
+upgrades to a full `IsPrimitiveAbundant (m·p)` criterion.

--- a/research/problems/abundant-number-oq-03-oq-03/knowledge.md
+++ b/research/problems/abundant-number-oq-03-oq-03/knowledge.md
@@ -19,3 +19,41 @@ Insights accumulated during research on this problem.
 ## Dead Ends
 
 [Approaches known not to work will be documented here]
+
+## Session 2026-07-20 (researcher-1) — base witness: 945 is odd primitive abundant [VERIFIED, axiom-free]
+
+**Mode**: FRESH (score 0) · **Outcome**: progress (base witness pinned; infinitude still OPEN)
+
+### What I did
+Created `proofs/Proofs/AbundantNumberOQ03OQ03.lean` (self-contained, imports only
+`Mathlib`; host-verified via `lake env lean`, EXIT 0). All theorems axiom-free —
+`#print axioms` = `[propext, Classical.choice, Quot.sound]` (no `Lean.ofReduceBool`).
+
+- `IsPrimitiveAbundant n := n.Abundant ∧ ∀ d ∈ n.properDivisors, d.Deficient` — the
+  OEIS A006038 predicate (abundant, *every* proper divisor deficient).
+- `OddPrimitiveAbundant := {n | Odd n ∧ IsPrimitiveAbundant n}` — the target set.
+- `abundant_945`, `odd_945`, `primitive_945`, `mem_oddPrimitiveAbundant_945` — the
+  smallest odd abundant number 945 = 3³·5·7 is in fact odd primitive abundant; all
+  15 proper divisors (1,3,5,7,9,15,21,27,35,45,63,105,135,189,315) are deficient.
+- `not_deficient_of_abundant`, `not_primitive_of_abundant_properDivisor` — the
+  divisibility-minimality obstruction (an abundant proper divisor kills primitivity).
+
+### Key findings
+- **Verified, not axiomatized.** The finite checks (one number 945 + its 15
+  divisors, all ≤ 315) are small enough for the Lean *kernel* via `decide` with
+  `set_option maxRecDepth 4000` — no `native_decide`. This is strictly stronger
+  than the sibling `abundant-number-oq-02` (945-range minimality) which needs
+  `native_decide`/`pdSum` because it evaluates the whole `∀ n<945` window.
+- Mathlib already has the *parent* `Nat.infinite_odd_abundant`
+  (`NumberTheory.FactorisationProperties`), plus `Prime.deficient` /
+  `IsPrimePow.deficient` — so among the proper divisors of 945 only the composite
+  ones (15,21,35,45,63,105,135,189,315) carry non-trivial deficiency content.
+
+### Next steps (infinitude OPEN)
+- Route 1: odd analogue of the even `2^k·p` primitive construction — odd base `m`
+  with `σ(m)/m` just below 2, times an odd prime `p` in a Bertrand-type window.
+- Route 2: primitive-part extraction from `Nat.infinite_odd_abundant` — show the
+  primitive abundant divisors of an infinite odd abundant family are odd and
+  unbounded (pigeonhole).
+- Intermediate lemma: `σ(m·p) = σ(m)(p+1)` for odd prime `p ∤ m`, and a reusable
+  proper-divisor-deficiency criterion for `m·p`.

--- a/research/problems/abundant-number-oq-03-oq-03/state.md
+++ b/research/problems/abundant-number-oq-03-oq-03/state.md
@@ -1,25 +1,26 @@
 # Research State: abundant-number-oq-03-oq-03
 
 ## Current State
-**Phase**: OBSERVE
+**Phase**: ACT (base witness done; infinitude open)
 **Path**: full
-**Since**: 2026-07-09T16:43:19-07:00
+**Since**: 2026-07-20
 **Iteration**: 1
 
 ## Current Focus
-Initial problem understanding. Read problem.md and gather context.
+Infinitude of odd primitive abundant numbers (OEIS A006038).
 
-## Active Approach
-None yet.
-
-## Attempt Count
-- Total attempts: 0
-- Current approach attempts: 0
-- Approaches tried: 0
+## Progress
+Base witness VERIFIED axiom-free: `AbundantNumberOQ03OQ03.lean` establishes the
+`IsPrimitiveAbundant` predicate, the `OddPrimitiveAbundant` target set, and that
+945 = 3³·5·7 (the smallest odd abundant number) is odd primitive abundant — all 15
+proper divisors deficient, kernel `decide` (maxRecDepth 4000), no native_decide.
+Plus the obstruction lemma `not_primitive_of_abundant_properDivisor`.
 
 ## Blockers
-None.
+None yet — infinitude is genuinely open (no explicit odd family known to be
+provably primitive abundant infinitely often).
 
 ## Next Action
-Read problem.md thoroughly and acquire full context.
-Then move to ORIENT phase to explore literature and related proofs.
+Attack infinitude via Route 1 (odd `m·p`, Bertrand window) or Route 2 (primitive-
+part extraction from `Nat.infinite_odd_abundant`). First build the reusable
+`σ(m·p)=σ(m)(p+1)` closed form and a proper-divisor-deficiency criterion.

--- a/research/problems/abundant-number-oq-03-oq-03/state.md
+++ b/research/problems/abundant-number-oq-03-oq-03/state.md
@@ -4,7 +4,7 @@
 **Phase**: ACT (base witness done; infinitude open)
 **Path**: full
 **Since**: 2026-07-20
-**Iteration**: 1
+**Iteration**: 2
 
 ## Current Focus
 Infinitude of odd primitive abundant numbers (OEIS A006038).
@@ -16,11 +16,28 @@ Base witness VERIFIED axiom-free: `AbundantNumberOQ03OQ03.lean` establishes the
 proper divisors deficient, kernel `decide` (maxRecDepth 4000), no native_decide.
 Plus the obstruction lemma `not_primitive_of_abundant_properDivisor`.
 
+**Iteration 2 (2026-07-20):** built the Route-1 **σ-arithmetic engine**, all
+axiom-free (`propext/Classical.choice/Quot.sound` only, host-verified via
+`lake env lean`):
+- `sum_divisors_prime`: `σ(p) = p+1` for prime `p`.
+- `sum_divisors_mul_prime`: `σ(m·p) = σ(m)·(p+1)` for `p` prime, `p ∤ m` (via
+  Mathlib `Nat.Coprime.sum_divisors_mul` + `isMultiplicative_sigma`).
+- `abundant_mul_prime_iff`: `(m·p).Abundant ↔ 2mp < σ(m)(p+1)` — abundance of the
+  Route-1 family is now a single linear-in-`p` test (via
+  `Nat.abundant_iff_sum_divisors`).
+- `deficient_left_of_primitive_mul_prime`: any Route-1 base `m` is deficient.
+
 ## Blockers
-None yet — infinitude is genuinely open (no explicit odd family known to be
-provably primitive abundant infinitely often).
+Infinitude is genuinely open (no explicit odd family known to be provably
+primitive abundant infinitely often). The engine reduces *abundance* of `m·p`
+to a linear inequality, but the *primitivity* half — deficiency of ALL proper
+divisors `{d, p·d : d ∣ m}` — still needs the coprime-product proper-divisor
+decomposition (no clean `Nat.Coprime.divisors_mul` Finset equality in Mathlib
+v4.31; would have to be built from `filter_dvd_eq_divisors`).
 
 ## Next Action
-Attack infinitude via Route 1 (odd `m·p`, Bertrand window) or Route 2 (primitive-
-part extraction from `Nat.infinite_odd_abundant`). First build the reusable
-`σ(m·p)=σ(m)(p+1)` closed form and a proper-divisor-deficiency criterion.
+Route 1: build the coprime proper-divisor decomposition
+`(m·p).properDivisors = m.divisors ∪ (p · ·) '' (m.properDivisors)` so
+`abundant_mul_prime_iff` upgrades to a full `IsPrimitiveAbundant (m·p)` iff, then
+search for an explicit odd base `m` + prime window. Route 2 remains open on
+controlling oddness/unboundedness of primitive parts of `Nat.infinite_odd_abundant`.

--- a/src/data/research/problems/abundant-number-oq-03-oq-03.json
+++ b/src/data/research/problems/abundant-number-oq-03-oq-03.json
@@ -41,11 +41,24 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
+    "progressSummary": "PROGRESS (base witness, infinitude still OPEN): verified axiom-free that 945 is odd PRIMITIVE abundant (least element of OEIS A006038), plus the IsPrimitiveAbundant predicate, the OddPrimitiveAbundant target set, and the abundant-proper-divisor obstruction lemma. New file AbundantNumberOQ03OQ03.lean (kernel decide, maxRecDepth 4000, no native_decide). The infinitude of odd primitive abundant numbers remains open; two candidate routes recorded.",
+    "builtItems": [
+      "IsPrimitiveAbundant (A006038 predicate) in proofs/Proofs/AbundantNumberOQ03OQ03.lean",
+      "OddPrimitiveAbundant set + mem_oddPrimitiveAbundant_945 (945 is a member) in AbundantNumberOQ03OQ03.lean",
+      "abundant_945 / odd_945 / primitive_945 (axiom-free base witness) in AbundantNumberOQ03OQ03.lean",
+      "not_primitive_of_abundant_properDivisor + not_deficient_of_abundant (structural obstruction) in AbundantNumberOQ03OQ03.lean"
+    ],
+    "insights": [
+      "945 = 3³·5·7 is not just the smallest odd abundant number but is odd PRIMITIVE abundant (OEIS A006038): all 15 proper divisors 1,3,5,7,9,15,21,27,35,45,63,105,135,189,315 are deficient — verified axiom-free.",
+      "The base-witness finite checks (single n=945 + 15 divisors, each ≤315) fit in the Lean KERNEL via decide with set_option maxRecDepth 4000 — no native_decide needed, so this entry is verified (propext/Classical.choice/Quot.sound only), unlike sibling abundant-number-oq-02 which uses native_decide (Lean.ofReduceBool).",
+      "Structural obstruction lemma not_primitive_of_abundant_properDivisor: any abundant proper divisor destroys primitivity (abundance and deficiency are mutually exclusive via not_deficient_of_abundant). This is the divisibility-minimality content of the A006038 predicate.",
+      "Mathlib already contains the PARENT result Nat.infinite_odd_abundant (infinitely many odd abundant) in NumberTheory.FactorisationProperties, plus Prime.deficient / IsPrimePow.deficient (explaining why only the composite proper divisors 15,21,...,315 need a genuine check)."
+    ],
     "mathlibGaps": [],
-    "nextSteps": []
+    "nextSteps": [
+      "Infinitude (OPEN): exhibit an infinite odd family provably primitive abundant. Route 1 = odd analogue of even 2^k·p (odd base m with σ(m)/m just below 2, times Bertrand-window odd prime p). Route 2 = primitive-part extraction from Nat.infinite_odd_abundant (control oddness+unboundedness of the primitive divisor).",
+      "Intermediate: prove σ-multiplicativity closed form σ(m·p)=σ(m)(p+1) for odd prime p coprime to odd base m, and a reusable proper-divisor-deficiency criterion for m·p."
+    ]
   },
   "tags": [
     "number-theory",

--- a/src/data/research/problems/abundant-number-oq-03-oq-03.json
+++ b/src/data/research/problems/abundant-number-oq-03-oq-03.json
@@ -41,23 +41,32 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (base witness, infinitude still OPEN): verified axiom-free that 945 is odd PRIMITIVE abundant (least element of OEIS A006038), plus the IsPrimitiveAbundant predicate, the OddPrimitiveAbundant target set, and the abundant-proper-divisor obstruction lemma. New file AbundantNumberOQ03OQ03.lean (kernel decide, maxRecDepth 4000, no native_decide). The infinitude of odd primitive abundant numbers remains open; two candidate routes recorded.",
+    "progressSummary": "PROGRESS (base witness + Route-1 σ-engine; infinitude still OPEN): axiom-free that 945 is odd PRIMITIVE abundant (least of A006038), plus the σ-arithmetic engine σ(p)=p+1, σ(m·p)=σ(m)(p+1), the linear abundance test (m·p).Abundant ↔ 2mp<σ(m)(p+1), and deficiency of any Route-1 base. All in AbundantNumberOQ03OQ03.lean, host-verified, no native_decide. Remaining Route-1 gap is primitivity (proper-divisor decomposition of a coprime product), a documented Mathlib v4.31 gap. Infinitude open.",
     "builtItems": [
       "IsPrimitiveAbundant (A006038 predicate) in proofs/Proofs/AbundantNumberOQ03OQ03.lean",
       "OddPrimitiveAbundant set + mem_oddPrimitiveAbundant_945 (945 is a member) in AbundantNumberOQ03OQ03.lean",
       "abundant_945 / odd_945 / primitive_945 (axiom-free base witness) in AbundantNumberOQ03OQ03.lean",
-      "not_primitive_of_abundant_properDivisor + not_deficient_of_abundant (structural obstruction) in AbundantNumberOQ03OQ03.lean"
+      "not_primitive_of_abundant_properDivisor + not_deficient_of_abundant (structural obstruction) in AbundantNumberOQ03OQ03.lean",
+      "sum_divisors_prime: σ(p)=p+1 for prime p (axiom-free) in AbundantNumberOQ03OQ03.lean",
+      "sum_divisors_mul_prime: σ(m·p)=σ(m)(p+1) for p prime, p∤m via Nat.Coprime.sum_divisors_mul (axiom-free) in AbundantNumberOQ03OQ03.lean",
+      "abundant_mul_prime_iff: (m·p).Abundant ↔ 2mp < σ(m)(p+1) via Nat.abundant_iff_sum_divisors (axiom-free) in AbundantNumberOQ03OQ03.lean",
+      "deficient_left_of_primitive_mul_prime: Route-1 base m must be deficient (axiom-free) in AbundantNumberOQ03OQ03.lean"
     ],
     "insights": [
       "945 = 3³·5·7 is not just the smallest odd abundant number but is odd PRIMITIVE abundant (OEIS A006038): all 15 proper divisors 1,3,5,7,9,15,21,27,35,45,63,105,135,189,315 are deficient — verified axiom-free.",
       "The base-witness finite checks (single n=945 + 15 divisors, each ≤315) fit in the Lean KERNEL via decide with set_option maxRecDepth 4000 — no native_decide needed, so this entry is verified (propext/Classical.choice/Quot.sound only), unlike sibling abundant-number-oq-02 which uses native_decide (Lean.ofReduceBool).",
       "Structural obstruction lemma not_primitive_of_abundant_properDivisor: any abundant proper divisor destroys primitivity (abundance and deficiency are mutually exclusive via not_deficient_of_abundant). This is the divisibility-minimality content of the A006038 predicate.",
-      "Mathlib already contains the PARENT result Nat.infinite_odd_abundant (infinitely many odd abundant) in NumberTheory.FactorisationProperties, plus Prime.deficient / IsPrimePow.deficient (explaining why only the composite proper divisors 15,21,...,315 need a genuine check)."
+      "Mathlib already contains the PARENT result Nat.infinite_odd_abundant (infinitely many odd abundant) in NumberTheory.FactorisationProperties, plus Prime.deficient / IsPrimePow.deficient (explaining why only the composite proper divisors 15,21,...,315 need a genuine check).",
+      "Route-1 σ-arithmetic engine complete: σ is multiplicative on coprime factors (Mathlib isMultiplicative_sigma / Nat.Coprime.sum_divisors_mul), so σ(m·p)=σ(m)(p+1) and abundance of m·p becomes the LINEAR-in-p test 2mp < σ(m)(p+1). This is the exact lever an odd-family construction pulls: fix odd deficient base m, then pick prime p in the window keeping m·p abundant.",
+      "The remaining Route-1 obstruction is PRIMITIVITY not abundance: need every proper divisor of m·p (the set {d, p·d : d ∣ m}) deficient. Mathlib v4.31 lacks a clean Nat.Coprime.divisors_mul Finset equality, so the coprime proper-divisor decomposition (m·p).properDivisors = m.divisors ∪ (p·)  m.properDivisors must be built from filter_dvd_eq_divisors before abundant_mul_prime_iff upgrades to a full IsPrimitiveAbundant iff."
     ],
-    "mathlibGaps": [],
+    "mathlibGaps": [
+      "No Nat.Coprime.divisors_mul (Finset equality for divisors of a coprime product) in Mathlib v4.31 — only Nat.Coprime.sum_divisors_mul (the sum) and card_divisors_mul (the count). Blocks a clean coprime proper-divisor decomposition."
+    ],
     "nextSteps": [
-      "Infinitude (OPEN): exhibit an infinite odd family provably primitive abundant. Route 1 = odd analogue of even 2^k·p (odd base m with σ(m)/m just below 2, times Bertrand-window odd prime p). Route 2 = primitive-part extraction from Nat.infinite_odd_abundant (control oddness+unboundedness of the primitive divisor).",
-      "Intermediate: prove σ-multiplicativity closed form σ(m·p)=σ(m)(p+1) for odd prime p coprime to odd base m, and a reusable proper-divisor-deficiency criterion for m·p."
+      "Route 1: build (m·p).properDivisors = m.divisors ∪ (p·) \"\" m.properDivisors (p prime, p∤m) from filter_dvd_eq_divisors, then upgrade abundant_mul_prime_iff to a full IsPrimitiveAbundant (m·p) criterion; then search an explicit odd base m + prime window.",
+      "Route 2 (OPEN): control oddness + unboundedness of the primitive divisor extracted from Nat.infinite_odd_abundant.",
+      "Note the strict-vs-weak A006038 definition subtlety: this file requires ALL proper divisors DEFICIENT (excludes perfect), stricter than the no-abundant-proper-divisor convention; harmless for odd n unless odd perfect numbers exist (open)."
     ]
   },
   "tags": [


### PR DESCRIPTION
## Summary

Establishes the **base witness** of the open problem `abundant-number-oq-03-oq-03` (*are there infinitely many odd primitive abundant numbers?*, OEIS A006038): the smallest odd abundant number **945 = 3³·5·7** is in fact odd *primitive* abundant — abundant, with **all 15 proper divisors deficient**.

New self-contained file `proofs/Proofs/AbundantNumberOQ03OQ03.lean` (imports only `Mathlib`):

- `IsPrimitiveAbundant n := n.Abundant ∧ ∀ d ∈ n.properDivisors, d.Deficient` — the OEIS A006038 predicate.
- `OddPrimitiveAbundant := {n | Odd n ∧ IsPrimitiveAbundant n}` — the target set.
- `abundant_945`, `odd_945`, `primitive_945`, `mem_oddPrimitiveAbundant_945` — 945 is the least element.
- `not_deficient_of_abundant`, `not_primitive_of_abundant_properDivisor` — the divisibility-minimality obstruction (an abundant proper divisor destroys primitivity).

## Verification

**Verified, axiom-free.** `#print axioms` for every theorem = `[propext, Classical.choice, Quot.sound]` — **no `Lean.ofReduceBool`**. The finite checks (one number + 15 divisors, each ≤ 315) run in the Lean *kernel* via `decide` with `set_option maxRecDepth 4000`; no `native_decide` (strictly stronger than the sibling `abundant-number-oq-02`, which axiomatizes its 945-range minimality check). Host-verified via `lake env lean`, EXIT 0.

## Scope / honesty

Research-only file, **no gallery entry**: the headline **infinitude remains OPEN**. This PR pins the base witness and the predicate that any future construction must extend. Two candidate routes (odd `m·p` Bertrand-window; primitive-part extraction from Mathlib's `Nat.infinite_odd_abundant`) are recorded in `knowledge.md`/`state.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)