### PR TITLE
audit: erdos-622 — drop phantom axioms bound_tight/half_half from section prose

### DIFF
--- a/src/data/proofs/erdos-622/meta.json
+++ b/src/data/proofs/erdos-622/meta.json
@@ -49,15 +49,13 @@
       "SpannedByCycle definition",
       "cycleSpannedCount noncomputable function",
       "MainTheorem asymptotic formulation",
-      "DKM 2025 theorem axiomatization",
-      "Tightness bound theorem",
-      "Erdős observation about non-cycle sets",
-      "Half-half symmetry theorem",
+      "dkm_2025 axiomatization (the DKM 2025 main result)",
+      "erdos_observation axiomatization (non-cycle sets)",
+      "knn_few_cycles axiomatization (regularity-is-essential counterexample bound)",
       "completeBipartite K_{n,n} definition",
       "knn_with_stars counterexample construction",
       "IsPaleyGraph definition",
-      "IsHamiltonianCycle definition",
-      "erdos_faudree_edge_count density theorem"
+      "IsHamiltonianCycle definition"
     ],
     "axiomCount": 3,
     "lineCount": 171,
@@ -102,7 +100,7 @@
     "historicalContext": "Erdős and Faudree posed Problem #622 in the 1990s (referenced in [Er99]), asking whether dense regular graphs must contain many cycle-spanning subsets. The conjecture emerges from the intersection of Hamiltonian graph theory and subset enumeration. Dirac's theorem (1952) guarantees that graphs with minimum degree ≥ n/2 on n vertices are Hamiltonian, so Erdős-Faudree graphs (degree n+1 on 2n vertices) certainly contain Hamiltonian cycles. The deeper question is whether the cycle-spanning phenomenon extends to exponentially many subsets. Erdős himself observed (claiming it was 'easy to see') that at least (1/2 + o(1))2^{2n} subsets are NOT spanned by cycles, establishing an upper bound on the cycle-spanned fraction. In 2025, Nemanja Draganić, Peter Keevash, and Alp Müyesser resolved the conjecture, proving that at least (1/2 + o(1))2^{2n} subsets ARE cycle-spanned. Their proof uses the absorbing method (introduced by Rödl, Ruciński, and Szemerédi for Hamiltonicity problems) combined with refined counting techniques. The matching upper and lower bounds reveal a remarkable half-half symmetry: cycle-spanned and non-cycle-spanned subsets each comprise approximately half the powerset.",
     "problemStatement": "**Problem Statement (SOLVED)**\n\nLet G be a regular graph with 2n vertices and degree n+1. Must G have ≫ 2^{2n} subsets that are spanned by a cycle?\n\n**Solution (Draganić-Keevash-Müyesser 2025):**\nYES! At least (1/2 + o(1))2^{2n} subsets are spanned by cycles. Combined with Erdős's observation that (1/2 + o(1))2^{2n} sets are NOT on cycles, this shows a remarkable half-half symmetry.\n\n**Key Condition:** Regularity is essential. Minimum degree n+1 alone is insufficient (K_{n,n} with stars is a counterexample).",
     "text": "Let G be a regular graph with 2n vertices and degree n+1. Must G have ≫ 2^{2n} subsets spanned by a cycle? SOLVED by Draganić-Keevash-Müyesser (2025): YES, at least (1/2 + o(1))2^{2n} subsets, asymptotically tight.",
-    "proofStrategy": "The formalization axiomatizes the Draganić-Keevash-Müyesser theorem and builds comprehensive infrastructure. Graph setup: IsRegular and IsErdosFaudreeGraph predicates on SimpleGraph V. Cycle infrastructure: IsCycle as closed vertex-disjoint walks, SpannedByCycle for exact vertex set matching, cycleSpannedCount via powerset filtering. The main theorem uses Filter.atTop for ε-δ asymptotics. Tightness uses Filter.Frequently for infinitely many witnesses. Counterexamples: completeBipartite K_{n,n} (n-regular, O(n!²) cycle sets) and knn_with_stars (minimum degree n+1 but non-regular, o(2^{2n}) cycle sets). Examples: IsPaleyGraph for explicit dense regular graphs. Hamiltonian connection: IsHamiltonianCycle and Dirac's theorem application.",
+    "proofStrategy": "The formalization axiomatizes the Draganić-Keevash-Müyesser theorem and builds comprehensive infrastructure. Graph setup: IsRegular and IsErdosFaudreeGraph predicates on SimpleGraph V. Cycle infrastructure: IsCycle as closed vertex-disjoint walks, SpannedByCycle for exact vertex set matching, cycleSpannedCount via powerset filtering. The main theorem (MainTheorem, axiomatized as dkm_2025) uses Filter.atTop for ε-δ asymptotics. Counterexamples: completeBipartite K_{n,n} (n-regular, O(n!²) cycle sets) and knn_with_stars (minimum degree n+1 but non-regular, o(2^{2n}) cycle sets). Examples: IsPaleyGraph for explicit dense regular graphs. Hamiltonian connection: IsHamiltonianCycle and Dirac's theorem application.",
     "keyInsights": [
       "**Half-half symmetry**: Both cycle-spanned and non-cycle-spanned subsets comprise $(1/2 + o(1)) \\cdot 2^{2n}$ elements of the powerset, pinning the fraction at exactly $1/2$ — a rare instance of a natural combinatorial quantity converging to a simple constant",
       "**Regularity is essential**: The complete bipartite graph $K_{n,n}$ with added stars has minimum degree $n+1$ but only $o(2^{2n})$ cycle-spanned subsets, showing regularity (not just minimum degree) is the correct structural hypothesis",

--- a/src/data/proofs/erdos-622/meta.json
+++ b/src/data/proofs/erdos-622/meta.json
@@ -151,15 +151,15 @@
     {
       "id": "main-theorem",
       "title": "Main Result: DKM 2025",
-      "summary": "States `MainTheorem`: $\\forall \\varepsilon > 0,\\; \\forall^\\infty n,\\; \\text{cycleSpannedCount}(G) \\geq (1/2 - \\varepsilon) \\cdot 2^{2n}$. Axiomatizes `dkm_2025` and `bound_tight` (tightness via `Filter.Frequently`).",
+      "summary": "States `MainTheorem`: $\\forall \\varepsilon > 0,\\; \\forall^\\infty n,\\; \\text{cycleSpannedCount}(G) \\geq (1/2 - \\varepsilon) \\cdot 2^{2n}$. Axiomatizes `dkm_2025` (the DKM 2025 result).",
       "startLine": 60,
       "endLine": 80,
-      "mathContext": "States `MainTheorem`: $\\forall \\varepsilon > 0,\\; \\forall^\\infty n,\\; \\text{cycleSpannedCount}(G) \\geq (1/2 - \\varepsilon) \\cdot 2^{2n}$. Axiomatizes `dkm_2025` and `bound_tight` (tightness via `Filter.Frequently`)."
+      "mathContext": "States `MainTheorem`: $\\forall \\varepsilon > 0,\\; \\forall^\\infty n,\\; \\text{cycleSpannedCount}(G) \\geq (1/2 - \\varepsilon) \\cdot 2^{2n}$. Axiomatizes `dkm_2025` (the DKM 2025 result)."
     },
     {
       "id": "erdos-observation",
       "title": "Erdős's Observation and Half-Half Symmetry",
-      "summary": "Defines `nonCycleCount = 2^{|V|} - \\text{cycleSpannedCount}$. Axiomatizes Erdős's observation ($\\text{nonCycleCount} \\geq (1/2 - \\varepsilon) \\cdot 2^{2n}$) and `half_half` (both bounds combined).",
+      "summary": "Defines `nonCycleCount = 2^{|V|} - \\text{cycleSpannedCount}$. Axiomatizes `erdos_observation` ($\\text{nonCycleCount} \\geq (1/2 - \\varepsilon) \\cdot 2^{2n}$); the half-half symmetry is documented in prose, not a separate declaration.",
       "startLine": 81,
       "endLine": 103,
       "mathContext": "$\\text{nonCycleCount}(G) = 2^{2n} - \\text{cycleSpannedCount}(G)$. Erdős's observation: $\\text{nonCycleCount}(G) \\geq (1/2 - \\varepsilon) \\cdot 2^{2n}$. Combined: $(1/2-\\varepsilon) \\cdot 2^{2n} \\leq \\text{cycleSpannedCount}(G) \\leq (1/2+\\varepsilon) \\cdot 2^{2n}$."
@@ -167,10 +167,10 @@
     {
       "id": "regularity",
       "title": "Regularity is Essential: Counterexamples",
-      "summary": "Defines `completeBipartite` $K_{n,n}$ on `Fin n ⊕ Fin n`. Proves $K_{n,n}$ has $2n$ vertices, degree $n$, and $O((n!)^2)$ cycle-spanned sets. Defines `knn_with_stars` ($\\delta = n+1$ but non-regular) with $o(2^n)$ cycle sets.",
+      "summary": "Defines `completeBipartite` $K_{n,n}$ on `Fin n ⊕ Fin n` and axiomatizes `knn_few_cycles`: $K_{n,n}$ has $O((n!)^2)$ cycle-spanned sets (the regularity-is-essential counterexample). Defines `knn_with_stars` ($\\delta = n+1$ but non-regular). No theorems are proved in this file; the counterexample bound is an axiom.",
       "startLine": 104,
       "endLine": 147,
-      "mathContext": "Defines `completeBipartite` $K_{n,n}$ on `Fin n ⊕ Fin n`. Proves $K_{n,n}$ has $2n$ vertices, degree $n$, and $O((n!)^2)$ cycle-spanned sets. Defines `knn_with_stars` ($\\delta = n+1$ but non-regular) with $o(2^n)$ cycle sets."
+      "mathContext": "Defines `completeBipartite` $K_{n,n}$ on `Fin n ⊕ Fin n` and axiomatizes `knn_few_cycles`: $K_{n,n}$ has $O((n!)^2)$ cycle-spanned sets (the regularity-is-essential counterexample). Defines `knn_with_stars` ($\\delta = n+1$ but non-regular). No theorems are proved in this file; the counterexample bound is an axiom."
     },
     {
       "id": "examples",


### PR DESCRIPTION
## Integrity Issue

**Proof**: erdos-622 (Cycle-Spanning Subsets in Regular Graphs)
**Problem**: Section prose claims two axioms that do not exist in the Lean source, and describes an axiomatized bound as "Proved".

## Evidence

`Proofs/Erdos622Problem.lean` axiomatizes **exactly 3** declarations and proves **0** theorems:
- `dkm_2025` (line 75)
- `erdos_observation` (line 84)
- `knn_few_cycles` (line 103)

Section summaries claimed:
- **main-theorem**: "Axiomatizes `dkm_2025` and `bound_tight`" — no `bound_tight` declaration exists.
- **erdos-observation**: "Axiomatizes Erdős's observation … and `half_half`" — no `half_half` declaration exists.
- **regularity**: "Proves $K_{n,n}$ has … $O((n!)^2)$ cycle-spanned sets" — this bound is the axiom `knn_few_cycles`, not a proved theorem (the file has 0 theorems).

`meta.axiomCount` (3), `sorries` (0), and the conclusion ("0 proved theorems, 3 axioms") were already correct — only the section prose had drifted.

## Fix

- main-theorem section: drop phantom `bound_tight`.
- erdos-observation section: drop phantom `half_half`; note half-half symmetry is prose, not a declaration.
- regularity section: "Proves … " → "axiomatizes `knn_few_cycles`"; state no theorems are proved.

---
Discovered during gallery integrity audit (reserve-mode re-serve; no prior open PR on erdos-622).

🤖 Generated with [Claude Code](https://claude.com/claude-code)