### PR TITLE
audit: erdos-561 — drop phantom axiom size_vs_classical from section prose

### DIFF
--- a/src/data/proofs/erdos-561/meta.json
+++ b/src/data/proofs/erdos-561/meta.json
@@ -146,7 +146,7 @@
       "startLine": 196,
       "endLine": 211,
       "summary": "Relates size Ramsey numbers to classical Ramsey numbers, noting that stars are particularly efficient.",
-      "mathContext": "Axiomatized `classicalRamseyNumber` and `size_vs_classical`: $\\hat{R}(F_1, F_2) \\leq R(F_1,F_2) \\cdot (R(F_1,F_2) - 1)/2$. Beck's theorem shows this bound is far from tight for bounded-degree graphs."
+      "mathContext": "Axiomatizes `classicalRamseyNumber`. The relationship $\\hat{R}(F_1, F_2) \\leq R(F_1,F_2) \\cdot (R(F_1,F_2) - 1)/2$ is noted only in a source comment (no declaration). Beck's theorem shows this bound is far from tight for bounded-degree graphs."
     },
     {
       "id": "summary-main",


### PR DESCRIPTION
## Integrity Issue

**Proof**: erdos-561 (Size Ramsey Numbers for Unions of Stars)
**Problem**: A section `mathContext` claims an axiom that does not exist.

## Evidence

`Proofs/Erdos561Problem.lean` has exactly 5 axioms: `hasMonochromaticCopy`, `sizeRamseyNumber`, `befrs78_theorem`, `sizeRamsey_lower_bound`, `classicalRamseyNumber`.

The **classical-connection** section claimed:
> "Axiomatized `classicalRamseyNumber` and `size_vs_classical`: $\hat{R}(F_1,F_2) \leq R(R-1)/2$"

`size_vs_classical` is **not a declaration**. The bound appears only as a source comment (lines 199–201: "R̂(F₁,F₂) ≤ (R(F₁,F₂) choose 2)"). `meta.axiomCount` (5) and the top-level assumptions list are correct — only this section's prose drifted.

## Fix

Reword the section to axiomatize `classicalRamseyNumber` only and note the relationship bound is a comment, not a declaration.

---
Discovered during gallery integrity audit (reserve-mode re-serve; no prior open PR on erdos-561).

🤖 Generated with [Claude Code](https://claude.com/claude-code)