### PR TITLE
Enrich partition-theorem-oq-02: correct stale v4.26.0 verification caveat

### DIFF
--- a/src/data/proofs/partition-theorem-oq-02/meta.json
+++ b/src/data/proofs/partition-theorem-oq-02/meta.json
@@ -20,7 +20,7 @@
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 152,
-    "assumptions": "None. Fully machine-verified: `lake env lean` builds Proofs/PartitionTheoremOQ02.lean to exit 0 against the pinned Mathlib (v4.26.0), and #print axioms reports only the foundational propext / Classical.choice / Quot.sound (no Lean.ofReduceBool, no sorryAx) for card_restricted_not_dvd_mono and card_distincts_le_card_not_dvd_three. The file imports only Mathlib and is self-contained, building directly on Mathlib's Nat.Partition.card_restricted_eq_card_countRestricted (Glaisher's theorem) and Nat.Partition.card_odds_eq_card_distincts (Euler's theorem).",
+    "assumptions": "None. Fully machine-verified: `lake env lean` builds Proofs/PartitionTheoremOQ02.lean to exit 0 against the pinned Mathlib (v4.31.0), and #print axioms reports only the foundational propext / Classical.choice / Quot.sound (no Lean.ofReduceBool, no sorryAx) for card_restricted_not_dvd_mono and card_distincts_le_card_not_dvd_three. The file imports only Mathlib and is self-contained, building directly on Mathlib's Nat.Partition.card_restricted_eq_card_countRestricted (Glaisher's theorem) and Nat.Partition.card_odds_eq_card_distincts (Euler's theorem).",
     "dateAdded": "2026-06-25",
     "mathlib_version": "4.31.0",
     "mathlibDependencies": [


### PR DESCRIPTION
## Summary

The `assumptions` field for `partition-theorem-oq-02` stated the file was "Fully machine-verified … against the pinned Mathlib (v4.26.0)", contradicting `meta.mathlib_version = 4.31.0` (the #37508 toolchain migration flipped the whole tree to v4.31). Stale pre-migration caveat.

## Verification

Host-verified under the current pinned toolchain (`leanprover/lean4:v4.31.0`, Mathlib v4.31.0):

```
lake env lean Proofs/PartitionTheoremOQ02.lean   # exit 0
'PartitionTheoremOQ02.card_restricted_not_dvd_mono' depends on axioms: [propext, Classical.choice, Quot.sound]
'PartitionTheoremOQ02.card_distincts_le_card_not_dvd_three' depends on axioms: [propext, Classical.choice, Quot.sound]
```

Only the foundational `propext / Classical.choice / Quot.sound` (no `Lean.ofReduceBool`, no `sorryAx`) — the `verified` / `axiomCount: 0` claims are accurate. Only the version string was stale; corrected v4.26.0 → v4.31.0.

## Changes
- `src/data/proofs/partition-theorem-oq-02/meta.json`: `assumptions` v4.26.0 → v4.31.0 (one line)