### PR TITLE
Enrich birthday-problem-oq-03-oq-01-oq-01-oq-03: correct stale v4.26.0 caveat

### DIFF
--- a/src/data/proofs/birthday-problem-oq-03-oq-01-oq-01-oq-03/meta.json
+++ b/src/data/proofs/birthday-problem-oq-03-oq-01-oq-01-oq-03/meta.json
@@ -20,7 +20,7 @@
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 119,
-    "assumptions": "None. Fully machine-verified: lake env lean of Proofs/BirthdayProblemOQ03OQ01OQ01OQ03.lean exits 0 against the pinned Mathlib (v4.26.0), and #print axioms reports only the foundational propext / Classical.choice / Quot.sound (no Lean.ofReduceBool, no sorryAx) for birthday_triple_threshold and birthday_triple_threshold_gap. The file imports only Mathlib and is self-contained. Scope note: this proves the threshold to leading order with an explicit additive O(1) bound from the expected-count balance equation; it does not re-derive the balance equation from a probabilistic limit theorem (Poisson approximation), which is the heuristic input.",
+    "assumptions": "None. Fully machine-verified: lake env lean of Proofs/BirthdayProblemOQ03OQ01OQ01OQ03.lean exits 0 against the pinned Mathlib (v4.31.0), and #print axioms reports only the foundational propext / Classical.choice / Quot.sound (no Lean.ofReduceBool, no sorryAx) for birthday_triple_threshold and birthday_triple_threshold_gap. The file imports only Mathlib and is self-contained. Scope note: this proves the threshold to leading order with an explicit additive O(1) bound from the expected-count balance equation; it does not re-derive the balance equation from a probabilistic limit theorem (Poisson approximation), which is the heuristic input.",
     "dateAdded": "2026-06-25",
     "mathlib_version": "4.31.0",
     "mathlibDependencies": [


### PR DESCRIPTION
## Summary

The `assumptions` field claimed the file was "machine-verified … against the pinned Mathlib (v4.26.0)", contradicting `meta.mathlib_version = 4.31.0` (the #37508 toolchain migration flipped the tree to v4.31). Stale pre-migration caveat.

## Verification

Host-verified under the current pinned toolchain (`leanprover/lean4:v4.31.0`, Mathlib v4.31.0):

```
lake env lean Proofs/BirthdayProblemOQ03OQ01OQ01OQ03.lean   # exit 0
'…birthday_triple_threshold' depends on axioms: [propext, Classical.choice, Quot.sound]
'…birthday_triple_threshold_gap' depends on axioms: [propext, Classical.choice, Quot.sound]
```

Only foundational `propext / Classical.choice / Quot.sound` (no `Lean.ofReduceBool`, no `sorryAx`) — `verified` / `axiomCount: 0` are accurate. Only the version string was stale; corrected v4.26.0 → v4.31.0.

## Changes
- `src/data/proofs/birthday-problem-oq-03-oq-01-oq-01-oq-03/meta.json`: `assumptions` v4.26.0 → v4.31.0 (one line)