### PR TITLE
Enrich minpoly-charpoly-oq-01-oq-01: correct stale v4.26.0 caveat

### DIFF
--- a/src/data/proofs/minpoly-charpoly-oq-01-oq-01/meta.json
+++ b/src/data/proofs/minpoly-charpoly-oq-01-oq-01/meta.json
@@ -24,7 +24,7 @@
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 197,
-    "assumptions": "0 axioms, 0 sorries. Build-verified via `lake env lean Proofs/MinpolyCharpolyOQ01OQ01.lean` against Mathlib pin v4.26.0; `#print axioms` on `minpoly_jordanBlock`, `shift_pow_apply`, `shift_pow_dim_eq_zero`, and `shift_pow_pred_ne_zero` reports only `[propext, Classical.choice, Quot.sound]` (the standard foundational axioms — no `sorryAx`, no `Lean.ofReduceBool`/native_decide, no added `axiom`). The file is deliberately self-contained: it restates the `jordanBlock` definition from the parent `Proofs.MinpolyCharpolyOQ01` rather than importing it, so it verifies independently of the parent file's build state and imports only `Mathlib`.",
+    "assumptions": "0 axioms, 0 sorries. Build-verified via `lake env lean Proofs/MinpolyCharpolyOQ01OQ01.lean` against Mathlib pin v4.31.0; `#print axioms` on `minpoly_jordanBlock`, `shift_pow_apply`, `shift_pow_dim_eq_zero`, and `shift_pow_pred_ne_zero` reports only `[propext, Classical.choice, Quot.sound]` (the standard foundational axioms — no `sorryAx`, no `Lean.ofReduceBool`/native_decide, no added `axiom`). The file is deliberately self-contained: it restates the `jordanBlock` definition from the parent `Proofs.MinpolyCharpolyOQ01` rather than importing it, so it verifies independently of the parent file's build state and imports only `Mathlib`.",
     "mathlib_version": "4.31.0",
     "dateAdded": "2026-07-02",
     "theoremCount": 8,


### PR DESCRIPTION
## Summary

The `assumptions` field cited verification against "Mathlib pin v4.26.0", contradicting `meta.mathlib_version = 4.31.0` (#37508 toolchain migration). Stale pre-migration caveat.

## Verification

Host-verified under the current pinned toolchain (`leanprover/lean4:v4.31.0`):

```
lake env lean Proofs/MinpolyCharpolyOQ01OQ01.lean   # exit 0
```

File has no `native_decide`/`sorry`/`axiom`, so the foundational-axioms claim holds. Only the version string was stale; corrected v4.26.0 → v4.31.0.

## Changes
- `src/data/proofs/minpoly-charpoly-oq-01-oq-01/meta.json`: `assumptions` v4.26.0 → v4.31.0 (one line)