### PR TITLE
Enrich gcd-algorithm-oq-05: correct stale v4.26.0 caveat

### DIFF
--- a/src/data/proofs/gcd-algorithm-oq-05/meta.json
+++ b/src/data/proofs/gcd-algorithm-oq-05/meta.json
@@ -20,7 +20,7 @@
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 167,
-    "assumptions": "None. Fully machine-verified: lake env lean of Proofs/GCDAlgorithmOQ05.lean exits 0 against the pinned Mathlib (v4.26.0), and #print axioms reports only the foundational propext / Classical.choice / Quot.sound (no Lean.ofReduceBool, no sorryAx) for gaussKuzmin_tsum and gaussKuzmin_pos. The file imports only Mathlib and is self-contained. Scope note: this proves the Gauss–Kuzmin weights are a normalized probability distribution; the full Gauss–Kuzmin–Lévy theorem (that the Euclidean/continued-fraction quotients are asymptotically Gauss–Kuzmin distributed) additionally requires the ergodicity of the Gauss map and invariance of the Gauss measure, which are not yet in Mathlib.",
+    "assumptions": "None. Fully machine-verified: lake env lean of Proofs/GCDAlgorithmOQ05.lean exits 0 against the pinned Mathlib (v4.31.0), and #print axioms reports only the foundational propext / Classical.choice / Quot.sound (no Lean.ofReduceBool, no sorryAx) for gaussKuzmin_tsum and gaussKuzmin_pos. The file imports only Mathlib and is self-contained. Scope note: this proves the Gauss–Kuzmin weights are a normalized probability distribution; the full Gauss–Kuzmin–Lévy theorem (that the Euclidean/continued-fraction quotients are asymptotically Gauss–Kuzmin distributed) additionally requires the ergodicity of the Gauss map and invariance of the Gauss measure, which are not yet in Mathlib.",
     "dateAdded": "2026-06-25",
     "mathlib_version": "4.31.0",
     "mathlibDependencies": [


### PR DESCRIPTION
## Summary

The `assumptions` field claimed "lake env lean … exits 0 against the pinned Mathlib (v4.26.0)", contradicting `meta.mathlib_version = 4.31.0` (#37508 toolchain migration). Stale pre-migration caveat.

## Verification

Host-verified under the current pinned toolchain (`leanprover/lean4:v4.31.0`):

```
lake env lean Proofs/GCDAlgorithmOQ05.lean   # exit 0
```

File has no `native_decide`/`sorry`/`axiom`. Only the version string was stale; corrected v4.26.0 → v4.31.0.

## Changes
- `src/data/proofs/gcd-algorithm-oq-05/meta.json`: `assumptions` v4.26.0 → v4.31.0 (one line)