### PR TITLE
Enrich dini-theorem-oq-01-oq-02: correct stale v4.26.0 caveat

### DIFF
--- a/src/data/proofs/dini-theorem-oq-01-oq-02/meta.json
+++ b/src/data/proofs/dini-theorem-oq-01-oq-02/meta.json
@@ -20,7 +20,7 @@
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 172,
-    "assumptions": "None. Fully machine-verified: lake env lean of Proofs/DiniTheoremOQ01OQ02.lean exits 0 against the pinned Mathlib (v4.26.0), and #print axioms reports only the foundational propext / Classical.choice / Quot.sound (no Lean.ofReduceBool, no sorryAx) for pow_uniform_error_Ico and pow_not_tendstoUniformlyOn_Ico_sharp. The file imports only Mathlib and is self-contained.",
+    "assumptions": "None. Fully machine-verified: lake env lean of Proofs/DiniTheoremOQ01OQ02.lean exits 0 against the pinned Mathlib (v4.31.0), and #print axioms reports only the foundational propext / Classical.choice / Quot.sound (no Lean.ofReduceBool, no sorryAx) for pow_uniform_error_Ico and pow_not_tendstoUniformlyOn_Ico_sharp. The file imports only Mathlib and is self-contained.",
     "dateAdded": "2026-06-25",
     "mathlib_version": "4.31.0",
     "mathlibDependencies": [


### PR DESCRIPTION
## Summary

The `assumptions` field claimed "lake env lean … exits 0 against the pinned Mathlib (v4.26.0)", contradicting `meta.mathlib_version = 4.31.0` (#37508 toolchain migration). Stale pre-migration caveat.

## Verification

Host-verified under the current pinned toolchain (`leanprover/lean4:v4.31.0`):

```
lake env lean Proofs/DiniTheoremOQ01OQ02.lean   # exit 0
```

File has no `native_decide`/`sorry`/`axiom`. Only the version string was stale; corrected v4.26.0 → v4.31.0.

## Changes
- `src/data/proofs/dini-theorem-oq-01-oq-02/meta.json`: `assumptions` v4.26.0 → v4.31.0 (one line)