### PR TITLE
Research: erdos-16-wip-01 — 13 axiom-free foundational lemmas (incl. Erdős covering-system covers ℤ)

### DIFF
--- a/proofs/Proofs/Erdos16Problem.lean
+++ b/proofs/Proofs/Erdos16Problem.lean
@@ -174,6 +174,93 @@ Possible implications:
 -/
 
 /-
+## Foundational lemmas (axiom-free)
+
+The deep results (Romanoff's theorem, Erdős's covering construction, Chen's
+disproof) require analytic number theory beyond current Mathlib and are documented
+in the prose above only.  What *is* fully machine-checkable are the elementary
+structural facts about the definitions in this file: the exponential lower bound
+forcing small odd numbers into the exceptional set, concrete Romanoff witnesses,
+the basic range of the density functional, and the covering property of the
+explicit Erdős covering system.  All lemmas below are axiom-free
+(`propext / Classical.choice / Quot.sound` only). -/
+
+/-- Membership in the exceptional set unfolds to its defining predicate. -/
+theorem mem_exceptionalSet_iff {n : ℕ} :
+    n ∈ ExceptionalSet ↔ Odd n ∧ ¬ IsRomanoff n := Iff.rfl
+
+/-- **Structural lower bound:** every Romanoff number is at least `4`, since
+`2^k ≥ 2` (as `k ≥ 1`) and `p ≥ 2` (as `p` is prime). -/
+theorem isRomanoff_four_le {n : ℕ} (h : IsRomanoff n) : 4 ≤ n := by
+  obtain ⟨k, p, hk, hp, rfl⟩ := h
+  have h2k : 2 ≤ 2 ^ k := by
+    calc (2 : ℕ) = 2 ^ 1 := (pow_one 2).symm
+      _ ≤ 2 ^ k := Nat.pow_le_pow_right (by norm_num) hk
+  have hp2 : 2 ≤ p := hp.two_le
+  omega
+
+/-- `1` is not Romanoff (it is below the Romanoff floor `4`). -/
+theorem not_isRomanoff_one : ¬ IsRomanoff 1 := fun h => by
+  have := isRomanoff_four_le h; omega
+
+/-- `3` is not Romanoff (it is below the Romanoff floor `4`). -/
+theorem not_isRomanoff_three : ¬ IsRomanoff 3 := fun h => by
+  have := isRomanoff_four_le h; omega
+
+/-- `1` is an exceptional odd integer. -/
+theorem one_mem_exceptionalSet : (1 : ℕ) ∈ ExceptionalSet :=
+  ⟨odd_one, not_isRomanoff_one⟩
+
+/-- `3` is an exceptional odd integer. -/
+theorem three_mem_exceptionalSet : (3 : ℕ) ∈ ExceptionalSet :=
+  ⟨by decide, not_isRomanoff_three⟩
+
+/-- Concrete Romanoff witness: `5 = 2^1 + 3`. -/
+theorem isRomanoff_five : IsRomanoff 5 := ⟨1, 3, by norm_num, by norm_num, by norm_num⟩
+
+/-- Concrete Romanoff witness: `7 = 2^2 + 3`. -/
+theorem isRomanoff_seven : IsRomanoff 7 := ⟨2, 3, by norm_num, by norm_num, by norm_num⟩
+
+/-- Since `5` is Romanoff, it is *not* in the exceptional set. -/
+theorem five_not_mem_exceptionalSet : (5 : ℕ) ∉ ExceptionalSet := fun h => h.2 isRomanoff_five
+
+/-- The density functional is nonnegative. -/
+theorem density_nonneg (A : Set ℕ) (N : ℕ) : 0 ≤ density A N := by
+  unfold density; positivity
+
+/-- The density functional never exceeds `1` (the filtered set sits inside
+`range (N+1)`, which has `N+1` elements). -/
+theorem density_le_one (A : Set ℕ) (N : ℕ) : density A N ≤ 1 := by
+  unfold density
+  rw [div_le_one (by positivity)]
+  have hcard : (Finset.filter (fun x => @Decidable.decide (x ∈ A) (Classical.dec _))
+      (Finset.range (N + 1))).card ≤ (Finset.range (N + 1)).card :=
+    Finset.card_filter_le _ _
+  rw [Finset.card_range] at hcard
+  exact_mod_cast hcard
+
+/-- Every modulus in the explicit Erdős covering system is positive. -/
+theorem erdosCovering_moduli_pos : ∀ rm ∈ erdosCovering, 0 < rm.2 := by decide
+
+/-- **The Erdős covering system genuinely covers `ℤ`.** Every integer lies in one
+of the residue classes `{0 mod 2, 0 mod 3, 1 mod 4, 1 mod 6, 3 mod 8, 7 mod 12,
+23 mod 24}`.  This is the covering-congruence engine behind Erdős's 1950 proof
+that the exceptional set contains an infinite arithmetic progression.  Since every
+modulus divides `24`, membership depends only on `n % 24`, giving a finite check. -/
+theorem erdosCovering_isCoveringSystem : IsCoveringSystem erdosCovering := by
+  intro n
+  have hcov : n % 2 = 0 ∨ n % 3 = 0 ∨ n % 4 = 1 ∨ n % 6 = 1 ∨ n % 8 = 3 ∨
+      n % 12 = 7 ∨ n % 24 = 23 := by omega
+  rcases hcov with h | h | h | h | h | h | h
+  · exact ⟨(0, 2), by simp [erdosCovering], by norm_num, by exact_mod_cast h⟩
+  · exact ⟨(0, 3), by simp [erdosCovering], by norm_num, by exact_mod_cast h⟩
+  · exact ⟨(1, 4), by simp [erdosCovering], by norm_num, by exact_mod_cast h⟩
+  · exact ⟨(1, 6), by simp [erdosCovering], by norm_num, by exact_mod_cast h⟩
+  · exact ⟨(3, 8), by simp [erdosCovering], by norm_num, by exact_mod_cast h⟩
+  · exact ⟨(7, 12), by simp [erdosCovering], by norm_num, by exact_mod_cast h⟩
+  · exact ⟨(23, 24), by simp [erdosCovering], by norm_num, by exact_mod_cast h⟩
+
+/-
 ## Summary
 
 **Problem Status: SOLVED (Disproved)**

--- a/research/problems/erdos-16-wip-01/knowledge.md
+++ b/research/problems/erdos-16-wip-01/knowledge.md
@@ -19,3 +19,25 @@ Insights accumulated during research on this problem.
 ## Dead Ends
 
 [Approaches known not to work will be documented here]
+
+---
+
+## Session note (2026-07-20, researcher-1): 13 axiom-free foundational lemmas
+
+`Erdos16Problem.lean` was a definitions-only stub (10 defs, 0 theorems; meta prose
+was already honest about this). Added 13 axiom-free foundational lemmas about its
+own definitions (host-verified, Lean v4.31.0, Mathlib-only, no Docker; `#print axioms`
+= propext/Classical.choice/Quot.sound):
+
+- `isRomanoff_four_le` — Romanoff floor `2^k+p ≥ 4` (k≥1 ⟹ 2^k≥2, p prime ⟹ p≥2).
+- `not_isRomanoff_one/three`, `one/three_mem_exceptionalSet` — small odd numbers are exceptional.
+- `isRomanoff_five` (5=2+3), `isRomanoff_seven` (7=4+3), `five_not_mem_exceptionalSet`.
+- `mem_exceptionalSet_iff`, `density_nonneg`, `density_le_one` (density range 0..1).
+- `erdosCovering_moduli_pos`, **`erdosCovering_isCoveringSystem`** — the explicit Erdős
+  covering `{0 mod 2, 0 mod 3, 1 mod 4, 1 mod 6, 3 mod 8, 7 mod 12, 23 mod 24}` genuinely
+  covers ℤ. Proof: every modulus divides 24, so the covering disjunction is provable
+  directly by `omega`; then the residue-class witness is exhibited per `rcases` branch.
+
+Deep results (Romanoff 1934 positive density, Erdős 1950 covering-progression, Chen 2023
+disproof) remain documented-only — they need analytic number theory absent from Mathlib.
+Meta counts synced (theoremCount 0 → 13, lineCount 203 → 290).

--- a/research/problems/erdos-16-wip-01/state.md
+++ b/research/problems/erdos-16-wip-01/state.md
@@ -1,7 +1,7 @@
 # Research State: erdos-16-wip-01
 
 ## Current State
-**Phase**: OBSERVE
+**Phase**: ORIENT
 **Path**: full
 **Since**: 2026-07-09T17:33:18-07:00
 **Iteration**: 1

--- a/src/data/proofs/erdos-16/meta.json
+++ b/src/data/proofs/erdos-16/meta.json
@@ -45,17 +45,17 @@
         "relationship": "Both are solved Erdős problems in analytic number theory with density/measure-theoretic conclusions"
       }
     ],
-    "lineCount": 203,
-    "assumptions": "This file formalizes definitions only (IsRomanoff, ExceptionalSet, density, lowerDensity, IsCoveringSystem, ErdosConjecture16, erdosCovering, and the related Props Erdos9/10/11Question). It contains 0 axioms, 0 theorems, and 0 sorries. Romanoff's theorem, Erdős's covering result, Chen's 2023 disproof, the specific exceptional numbers, and the density bounds are described in doc-comments only — none is formalized as a theorem or an axiom (there is no `chen_disproof` declaration in the source).",
+    "lineCount": 290,
+    "assumptions": "This file states the problem (definitions IsRomanoff, ExceptionalSet, density, lowerDensity, IsCoveringSystem, ErdosConjecture16, erdosCovering, and the related Props Erdos9/10/11Question) and proves 13 axiom-free foundational lemmas about those definitions. It contains 0 axioms and 0 sorries. The deep results (Romanoff 1934 positive density, Erdos 1950 covering construction, Chen 2023 disproof) require analytic number theory beyond current Mathlib and remain described in doc-comments only, NOT formalized as theorems or axioms. The formalized lemmas are elementary structural facts: the Romanoff floor (2^k+p >= 4), concrete Romanoff witnesses (5=2+3, 7=4+3), membership of 1 and 3 in the exceptional set, the 0<=density<=1 range, and a full machine-checked proof that the explicit Erdos covering system {0 mod 2, 0 mod 3, 1 mod 4, 1 mod 6, 3 mod 8, 7 mod 12, 23 mod 24} genuinely covers the integers.",
     "mathlib_version": "4.31.0",
-    "theoremCount": 0,
+    "theoremCount": 13,
     "definitionCount": 10
   },
   "overview": {
     "historicalContext": "Romanoff (1934) proved that the set $\\{n : n = 2^k + p\\}$ has positive lower density among odd integers, using sieve methods and the prime number theorem to show that the 'expected count' of representations diverges. Erdős (1950) turned to the complementary question: what does the exceptional set $E$ look like? His key tool was covering congruences — systems of residue classes $\\{a_i \\pmod{m_i}\\}$ that tile $\\mathbb{Z}$. By choosing moduli $\\{2, 3, 4, 6, 8, 12, 24\\}$ (whose reciprocals sum to 1), Erdős arranged that for any $n$ in a particular residue class mod $\\text{lcm} = 24$, each $n - 2^k$ is divisible by a small prime. This forced an infinite AP into $E$. Erdős then conjectured — self-deprecatingly calling it 'rather silly' — that $E$ is essentially just this AP plus density-0 noise. After 73 years, Chen (2023) disproved this by showing $E$ contains infinitely many essentially independent APs, each contributing positive density. The exceptional set's structure is far richer than a single covering congruence produces.",
     "problemStatement": "Define the exceptional set E = {odd n : n ≠ 2^k + p for all k ≥ 1 and primes p}. Erdős asked: is E = (arithmetic progression) ∪ (density-0 set)? Chen proved NO: E has more complex structure.",
     "text": "Is the set of odd integers not of the form 2^k + p the union of an arithmetic progression and a density-0 set? DISPROVED by Chen (2023).",
-    "proofStrategy": "The file defines Romanoff numbers (n = 2^k + p), the exceptional set, covering congruence systems, density / lowerDensity, the Prop ErdosConjecture16, and the related Props for Problems #9–#11. Romanoff's theorem, Erdős's covering result, Chen's disproof, and the density bounds appear in documentation only — none is formalized as a theorem or an axiom.",
+    "proofStrategy": "Defines Romanoff numbers (n = 2^k + p, k>=1, p prime), the exceptional set, covering congruence systems, density/lowerDensity, ErdosConjecture16, and the related Props for Problems #9-#11. Adds 13 axiom-free foundational lemmas: isRomanoff_four_le (structural lower bound via 2^k>=2 and p>=2), not_isRomanoff_one/three and one/three_mem_exceptionalSet (small odd numbers are exceptional), isRomanoff_five/seven (concrete witnesses), density_nonneg/density_le_one (range of the density functional), erdosCovering_moduli_pos, and erdosCovering_isCoveringSystem (the explicit covering system covers Z, proved by reducing mod 24 via omega and exhibiting the residue-class witness). Romanoff's theorem, Erdos's covering-progression result, and Chen's disproof appear in documentation only and are not formalized.",
     "keyInsights": [
       "Exceptional set E = {1, 127, 149, 251, 331, ...} (OEIS A006285)",
       "127 is exceptional: 127 - 2^k is composite for all valid k",
@@ -189,9 +189,9 @@
       "BigOperators"
     ],
     "namespace": "Erdos16",
-    "lineCount": 203,
+    "lineCount": 290,
     "axiomCount": 0,
-    "theoremCount": 0,
+    "theoremCount": 13,
     "definitionCount": 10,
     "path": "Proofs/Erdos16Problem.lean",
     "sorries": 0

--- a/src/data/research/problems/erdos-16-wip-01.json
+++ b/src/data/research/problems/erdos-16-wip-01.json
@@ -18,7 +18,7 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "OBSERVE",
+    "phase": "ORIENT",
     "since": "2026-07-09T17:33:18-07:00",
     "iteration": 1,
     "focus": "Initial problem understanding. Read problem.md and gather context.",
@@ -31,9 +31,18 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
+    "progressSummary": "PROGRESS: added 13 axiom-free foundational lemmas to the previously definitions-only Erdos16Problem.lean (Romanoff floor + concrete witnesses, exceptional-set membership of 1/3, density range 0..1, and a machine-checked proof that the explicit Erdos covering system covers Z). Deep results (Romanoff 1934, Erdos 1950, Chen 2023 disproof) remain documented-only, needing Mathlib analytic NT. Meta counts synced (theoremCount 0 -> 13).",
+    "builtItems": [
+      "isRomanoff_four_le, not_isRomanoff_one/three, one/three_mem_exceptionalSet in Erdos16Problem.lean",
+      "isRomanoff_five, isRomanoff_seven, five_not_mem_exceptionalSet in Erdos16Problem.lean",
+      "density_nonneg, density_le_one, mem_exceptionalSet_iff in Erdos16Problem.lean",
+      "erdosCovering_moduli_pos, erdosCovering_isCoveringSystem (covering system covers Z) in Erdos16Problem.lean"
+    ],
+    "insights": [
+      "Erdos16 file was a definitions-only stub (10 defs, 0 theorems). The deep results (Romanoff density, Erdos covering-progression, Chen 2023 disproof) need analytic NT beyond Mathlib; the tractable axiom-free content is elementary structural facts about the file's own defs.",
+      "The explicit Erdos covering system [(0,2),(0,3),(1,4),(1,6),(3,8),(7,12),(23,24)] genuinely covers Z: every modulus divides 24, so the disjunction n%2=0 or n%3=0 or n%4=1 or n%6=1 or n%8=3 or n%12=7 or n%24=23 is provable directly by omega, then the residue-class witness is exhibited per case.",
+      "Romanoff floor: 2^k+p >= 4 for k>=1, p prime, so 1 and 3 are exceptional; 5=2+3 and 7=4+3 are concrete Romanoff (non-exceptional) witnesses."
+    ],
     "mathlibGaps": [],
     "nextSteps": [],
     "markdown": "# Knowledge Base: erdos-16-wip-01\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"


### PR DESCRIPTION
## Summary
`proofs/Proofs/Erdos16Problem.lean` (Erdős #16 — odd integers not of the form 2^k + p) was a **definitions-only stub**: 10 defs, 0 theorems (the meta prose already honestly said so). This PR adds **13 axiom-free foundational lemmas** about the file's own definitions. The parent problem is SOLVED (disproved by Chen 2023); the deep results stay documented-only.

## New theorems (all axiom-free, host-verified under Lean v4.31.0, Mathlib-only)

| Theorem | Statement |
|---|---|
| `isRomanoff_four_le` | Romanoff floor `2^k + p ≥ 4` (`k≥1 ⟹ 2^k≥2`, `p` prime `⟹ p≥2`) |
| `not_isRomanoff_one` / `not_isRomanoff_three` | `1`, `3` are below the floor |
| `one_mem_exceptionalSet` / `three_mem_exceptionalSet` | `1`, `3` are exceptional odd integers |
| `isRomanoff_five` / `isRomanoff_seven` | concrete witnesses `5 = 2¹+3`, `7 = 2²+3` |
| `five_not_mem_exceptionalSet` | `5` is Romanoff ⟹ not exceptional |
| `mem_exceptionalSet_iff` | membership unfolds to `Odd n ∧ ¬IsRomanoff n` |
| `density_nonneg` / `density_le_one` | the density functional lands in `[0,1]` |
| `erdosCovering_moduli_pos` | every modulus of the explicit covering is positive |
| **`erdosCovering_isCoveringSystem`** | the explicit Erdős covering `{0 mod 2, 0 mod 3, 1 mod 4, 1 mod 6, 3 mod 8, 7 mod 12, 23 mod 24}` **genuinely covers ℤ** |

The covering proof is the covering-congruence engine behind Erdős's 1950 result (the exceptional set contains an infinite AP): since every modulus divides 24, the covering disjunction `n%2=0 ∨ n%3=0 ∨ n%4=1 ∨ n%6=1 ∨ n%8=3 ∨ n%12=7 ∨ n%24=23` is discharged directly by `omega`, then the residue-class witness is exhibited per case.

## Verification
- `lake env lean Proofs/Erdos16Problem.lean` — compiles clean (host, v4.31.0).
- `#print axioms` on the new theorems lists only `propext / Classical.choice / Quot.sound` — **axiom-free** (no `sorryAx`, no `Lean.ofReduceBool`).
- Meta synced: `theoremCount` 0 → 13, `lineCount` 203 → 290; `assumptions` / `proofStrategy` updated to describe the new lemmas honestly.

## Status
**Outcome**: progress (definitions-only stub → 13 axiom-free foundational lemmas). Deep results (Romanoff 1934, Erdős 1950, Chen 2023 disproof) remain documented-only, needing analytic number theory beyond current Mathlib. Parent #16 is SOLVED (disproved).

🤖 Generated by researcher-1