### PR TITLE
Research: erdos-53-wip-01 — 12 axiom-free foundational lemmas (sum-product / subset sums)

### DIFF
--- a/proofs/Proofs/Erdos53Problem.lean
+++ b/proofs/Proofs/Erdos53Problem.lean
@@ -111,6 +111,87 @@ def subsetSumCount (A : Finset ℤ) : ℕ := (subsetSums A).card
 /-- Count of integers representable as subset products. -/
 def subsetProductCount (A : Finset ℤ) : ℕ := (subsetProducts A).card
 
-/-  The union count is at least the subset sum count. -/
-/- The union count is at least the subset product count. -/
+/-
+## Section 7: Foundational lemmas (axiom-free)
+
+The Erdős–Szemerédi conjecture (Chang's theorem) and the upper bound require deep
+additive combinatorics beyond current Mathlib and stay documented above only.  The
+elementary structural facts about the set-valued definitions in this file are,
+however, fully machine-checkable.  All lemmas below are axiom-free
+(`propext / Classical.choice / Quot.sound` only). -/
+
+/-- The empty sum (empty subset) shows `0` is always a subset sum. -/
+theorem zero_mem_subsetSums (A : Finset ℤ) : (0 : ℤ) ∈ subsetSums A := by
+  rw [subsetSums, Finset.mem_image]
+  exact ⟨∅, Finset.empty_mem_powerset A, by simp⟩
+
+/-- Every element of `A` is itself a subset sum (via the singleton subset). -/
+theorem mem_subsetSums_of_mem {A : Finset ℤ} {a : ℤ} (ha : a ∈ A) :
+    a ∈ subsetSums A := by
+  rw [subsetSums, Finset.mem_image]
+  exact ⟨{a}, Finset.mem_powerset.mpr (Finset.singleton_subset_iff.mpr ha), by simp⟩
+
+/-- Every element of `A` is itself a subset product (via the singleton subset). -/
+theorem mem_subsetProducts_of_mem {A : Finset ℤ} {a : ℤ} (ha : a ∈ A) :
+    a ∈ subsetProducts A := by
+  rw [subsetProducts, Finset.mem_image]
+  refine ⟨{a}, ?_, by simp⟩
+  rw [Finset.mem_filter]
+  exact ⟨Finset.mem_powerset.mpr (Finset.singleton_subset_iff.mpr ha),
+    Finset.singleton_nonempty a⟩
+
+/-- Subset sums are among the sum-or-product representable integers. -/
+theorem subsetSums_subset_sumsOrProducts (A : Finset ℤ) :
+    subsetSums A ⊆ sumsOrProducts A := by
+  rw [sumsOrProducts]; exact Finset.subset_union_left
+
+/-- Subset products are among the sum-or-product representable integers. -/
+theorem subsetProducts_subset_sumsOrProducts (A : Finset ℤ) :
+    subsetProducts A ⊆ sumsOrProducts A := by
+  rw [sumsOrProducts]; exact Finset.subset_union_right
+
+/-- There are at most `2^{|A|}` subset sums (image of the powerset). -/
+theorem subsetSums_card_le (A : Finset ℤ) : (subsetSums A).card ≤ 2 ^ A.card := by
+  rw [subsetSums]
+  calc (A.powerset.image (fun S => S.sum id)).card
+      ≤ A.powerset.card := Finset.card_image_le
+    _ = 2 ^ A.card := Finset.card_powerset A
+
+/-- Subset sums are monotone in the ground set. -/
+theorem subsetSums_mono {A B : Finset ℤ} (h : A ⊆ B) : subsetSums A ⊆ subsetSums B := by
+  rw [subsetSums, subsetSums]
+  exact Finset.image_subset_image (Finset.powerset_mono.mpr h)
+
+/-- The union count dominates the subset-sum count. -/
+theorem subsetSumCount_le_card (A : Finset ℤ) :
+    subsetSumCount A ≤ (sumsOrProducts A).card := by
+  rw [subsetSumCount]
+  exact Finset.card_le_card (subsetSums_subset_sumsOrProducts A)
+
+/-- The union count dominates the subset-product count. -/
+theorem subsetProductCount_le_card (A : Finset ℤ) :
+    subsetProductCount A ≤ (sumsOrProducts A).card := by
+  rw [subsetProductCount]
+  exact Finset.card_le_card (subsetProducts_subset_sumsOrProducts A)
+
+/-- The sumset `A + A` has at most `|A|²` elements. -/
+theorem sumset_card_le (A : Finset ℤ) : (sumset A).card ≤ A.card ^ 2 := by
+  rw [sumset]
+  calc ((A ×ˢ A).image (fun p => p.1 + p.2)).card
+      ≤ (A ×ˢ A).card := Finset.card_image_le
+    _ = A.card * A.card := Finset.card_product A A
+    _ = A.card ^ 2 := (sq _).symm
+
+/-- The product set `A · A` has at most `|A|²` elements. -/
+theorem productset_card_le (A : Finset ℤ) : (productset A).card ≤ A.card ^ 2 := by
+  rw [productset]
+  calc ((A ×ˢ A).image (fun p => p.1 * p.2)).card
+      ≤ (A ×ˢ A).card := Finset.card_image_le
+    _ = A.card * A.card := Finset.card_product A A
+    _ = A.card ^ 2 := (sq _).symm
+
+/-- The empty set has exactly one subset sum, namely `0`. -/
+theorem subsetSums_empty : subsetSums (∅ : Finset ℤ) = {0} := by
+  rw [subsetSums, Finset.powerset_empty, Finset.image_singleton, Finset.sum_empty]
+
 end Erdos53

--- a/research/problems/erdos-53-wip-01/knowledge.md
+++ b/research/problems/erdos-53-wip-01/knowledge.md
@@ -19,3 +19,16 @@ Insights accumulated during research on this problem.
 ## Dead Ends
 
 [Approaches known not to work will be documented here]
+
+---
+
+## Session note (2026-07-20, researcher-1): 12 axiom-free foundational lemmas
+
+`Erdos53Problem.lean` (sum-product / Erdős–Szemerédi Problem 53) was a definitions-only
+stub (9 defs, 0 theorems). Added 12 axiom-free foundational lemmas (host-verified, Lean
+v4.31.0; `#print axioms` = propext/Classical.choice/Quot.sound): subset-sum/product
+membership (`0` and each element), inclusions into `sumsOrProducts`, `subsetSums_card_le`
+(≤ 2^|A|), `subsetSums_mono`, the count-domination lemmas, `sumset_card_le`/`productset_card_le`
+(≤ |A|²), and `subsetSums_empty` ({0}). Chang 2003 (conjecture holds) and the Erdős–Szemerédi
+upper bound remain documented-only — they need additive combinatorics beyond Mathlib.
+Meta synced (theoremCount 0 → 12, lineCount 116 → 197).

--- a/research/problems/erdos-53-wip-01/state.md
+++ b/research/problems/erdos-53-wip-01/state.md
@@ -1,7 +1,7 @@
 # Research State: erdos-53-wip-01
 
 ## Current State
-**Phase**: OBSERVE
+**Phase**: ORIENT
 **Path**: full
 **Since**: 2026-07-09T17:33:19-07:00
 **Iteration**: 1

--- a/src/data/proofs/erdos-53/meta.json
+++ b/src/data/proofs/erdos-53/meta.json
@@ -20,23 +20,23 @@
     "erdosUrl": "https://erdosproblems.com/53",
     "erdosProblemStatus": "proved",
     "axiomCount": 0,
-    "lineCount": 116,
+    "lineCount": 197,
     "prerequisites": [
       "Sumsets and product sets",
       "Additive vs multiplicative structure",
       "Combinatorial number theory",
       "Arithmetic combinatorics"
     ],
-    "assumptions": "0 axioms, 0 sorries. Previously cited axiom names have been removed from the Lean source. The 'axiomatized' status reflects that the main result is not yet fully formalized in Lean.",
+    "assumptions": "0 axioms, 0 sorries. The file states the problem (defs subsetSums, subsetProducts, sumsOrProducts, ErdosProblem53, sumset, productset, SumProductConjecture, subsetSumCount, subsetProductCount) and proves 12 axiom-free foundational lemmas about those definitions. The Erdos-Szemeredi conjecture (Chang 2003) and the exp((log|A|)^2 loglog|A|) upper bound require deep additive combinatorics beyond current Mathlib and remain described in doc-comments only, NOT formalized. The formalized lemmas are elementary: subset-sum/product membership (0 and each element), inclusion of subset sums/products into sumsOrProducts, the 2^|A| bound on subset sums, monotonicity, the |A|^2 bounds on the sumset/product set, and subsetSums(emptyset)={0}.",
     "mathlib_version": "4.31.0",
-    "theoremCount": 0,
+    "theoremCount": 12,
     "definitionCount": 9
   },
   "overview": {
     "historicalContext": "Erdős and Szemerédi posed this problem in 1983, asking whether sums and products of distinct elements from a finite integer set must be super-polynomially abundant. The question captures a deep principle in additive combinatorics: that additive and multiplicative structure in a set are fundamentally incompatible, so at least one of sums or products must be very rich. The problem is closely related to their more famous sum-product conjecture (Problem 52), which concerns pairwise operations $|A+A| + |A \\cdot A|$ rather than subset operations. Erdős and Szemerédi also established an upper bound, showing that arbitrarily large sets exist where the representable count is at most $\\exp(c(\\log|A|)^2 \\log\\log|A|)$, so the growth is subexponential. In 2003, Mei-Chu Chang resolved the problem affirmatively, proving that for every $k$, sufficiently large sets have at least $|A|^k$ representable integers. Chang's proof combined the Balog-Szemerédi-Gowers theorem with multiplicative energy estimates, building on the growing toolkit of additive combinatorics developed by Gowers, Bourgain, and others. The result confirmed that finite integer sets are inherently arithmetically rich when measured by subset operations.",
     "problemStatement": "Let $A$ be a finite set of integers. For every $k \\geq 1$, if $|A|$ is sufficiently large (depending on $k$), are there at least $|A|^k$ integers representable as sums or products of distinct elements of $A$?",
     "text": "For every k, if |A| is sufficiently large, are there at least |A|^k integers representable as sums or products of distinct elements of A? PROVED by Chang (2003). Erdős–Szemerédi upper bound: exp(c(log|A|)² log log|A|).",
-    "proofStrategy": "The formalization defines subset sums and products via $\\text{Finset.powerset}$ and $\\text{Finset.image}$, states the conjecture as a Lean Prop requiring polynomial growth of the representable count, axiomatizes Chang's affirmative resolution and the Erdős-Szemerédi upper bound, and connects to the pairwise sum-product conjecture (Problem 52) by defining sumsets and product sets separately.",
+    "proofStrategy": "Defines subset sums/products of distinct elements, their union, the Erdos-Szemeredi Problem 53 statement, the related sumset/productset and Problem 52 conjecture, and the two count functionals. Adds 12 axiom-free foundational lemmas: zero_mem_subsetSums, mem_subsetSums_of_mem, mem_subsetProducts_of_mem, subsetSums/Products_subset_sumsOrProducts, subsetSums_card_le (<= 2^|A| via card_image_le + card_powerset), subsetSums_mono, subsetSumCount/subsetProductCount_le_card, sumset_card_le and productset_card_le (<= |A|^2 via card_image_le + card_product), and subsetSums_empty ({0}). Chang's theorem and the Erdos-Szemeredi upper bound appear in documentation only, not formalized.",
     "keyInsights": [
       "The problem counts integers representable as $\\sum_{a \\in S} a$ or $\\prod_{a \\in S} a$ for subsets $S \\subseteq A$ — not pairwise sums/products as in Problem 52",
       "Chang's 2003 proof uses the Balog-Szemerédi-Gowers theorem to convert approximate additive structure into exact structure, then applies multiplicative energy estimates",
@@ -124,9 +124,9 @@
       "Finset"
     ],
     "namespace": "Erdos53",
-    "lineCount": 116,
+    "lineCount": 197,
     "axiomCount": 0,
-    "theoremCount": 0,
+    "theoremCount": 12,
     "definitionCount": 9,
     "path": "Proofs/Erdos53Problem.lean",
     "sorries": 0

--- a/src/data/research/problems/erdos-53-wip-01.json
+++ b/src/data/research/problems/erdos-53-wip-01.json
@@ -18,7 +18,7 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "OBSERVE",
+    "phase": "ORIENT",
     "since": "2026-07-09T17:33:19-07:00",
     "iteration": 1,
     "focus": "Initial problem understanding. Read problem.md and gather context.",
@@ -31,9 +31,17 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
+    "progressSummary": "PROGRESS: added 12 axiom-free foundational lemmas to the previously definitions-only Erdos53Problem.lean (subset-sum/product membership + inclusions, 2^|A| bound on subset sums, monotonicity, |A|^2 bounds on sumset/productset, subsetSums(empty)={0}). Deep results (Chang 2003, Erdos-Szemeredi upper bound) remain documented-only, needing additive combinatorics beyond Mathlib. Meta synced (theoremCount 0 -> 12).",
+    "builtItems": [
+      "zero_mem_subsetSums, mem_subsetSums_of_mem, mem_subsetProducts_of_mem in Erdos53Problem.lean",
+      "subsetSums/Products_subset_sumsOrProducts, subsetSumCount/subsetProductCount_le_card in Erdos53Problem.lean",
+      "subsetSums_card_le (<=2^|A|), subsetSums_mono, subsetSums_empty in Erdos53Problem.lean",
+      "sumset_card_le, productset_card_le (<=|A|^2) in Erdos53Problem.lean"
+    ],
+    "insights": [
+      "Erdos53Problem.lean was a definitions-only stub (9 defs, 0 theorems). Chang 2003 (conjecture holds) and the Erdos-Szemeredi upper bound need deep additive combinatorics beyond Mathlib; tractable axiom-free content is elementary structural facts about subsetSums/subsetProducts/sumset/productset.",
+      "Clean generic Finset targets that generalize across these stubs: image-of-powerset card bound (card_image_le + card_powerset gives <= 2^|A|), image-of-product card bound (card_image_le + card_product gives <= |A|^2), monotonicity via powerset_mono + image_subset_image, membership via singleton subset."
+    ],
     "mathlibGaps": [],
     "nextSteps": [],
     "markdown": "# Knowledge Base: erdos-53-wip-01\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"


### PR DESCRIPTION
## Summary
`proofs/Proofs/Erdos53Problem.lean` (Erdős #53 — sums & products of distinct elements, Erdős–Szemerédi 1983 / Chang 2003) was a **definitions-only stub**: 9 defs, 0 theorems. This PR adds **12 axiom-free foundational lemmas** about the file's own definitions.

## New theorems (all axiom-free, host-verified under Lean v4.31.0)

| Theorem | Statement |
|---|---|
| `zero_mem_subsetSums` | `0` is always a subset sum (empty subset) |
| `mem_subsetSums_of_mem` | each `a ∈ A` is a subset sum (singleton) |
| `mem_subsetProducts_of_mem` | each `a ∈ A` is a subset product |
| `subsetSums_subset_sumsOrProducts` / `subsetProducts_subset_sumsOrProducts` | both feed into `sumsOrProducts` |
| `subsetSums_card_le` | `\|subsetSums A\| ≤ 2^{\|A\|}` (image of the powerset) |
| `subsetSums_mono` | subset sums monotone in the ground set |
| `subsetSumCount_le_card` / `subsetProductCount_le_card` | union count dominates each count |
| `sumset_card_le` / `productset_card_le` | `\|A+A\|, \|A·A\| ≤ \|A\|²` |
| `subsetSums_empty` | `subsetSums ∅ = {0}` |

## Verification
- `lake env lean Proofs/Erdos53Problem.lean` — compiles clean (host, v4.31.0).
- `#print axioms` on the new theorems lists only `propext / Classical.choice / Quot.sound` — **axiom-free** (no `sorryAx`, no `Lean.ofReduceBool`).
- Meta synced: `theoremCount` 0 → 12, `lineCount` 116 → 197; `assumptions` / `proofStrategy` updated honestly.

## Status
**Outcome**: progress (definitions-only stub → 12 axiom-free foundational lemmas). The deep results (Chang 2003 affirmative resolution, Erdős–Szemerédi `exp(c·(log|A|)²·loglog|A|)` upper bound) remain documented-only, needing additive combinatorics beyond current Mathlib.

🤖 Generated by researcher-1