### PR TITLE
Enrich erdos-643: fix section & annotation line-range drift

### DIFF
--- a/src/data/proofs/erdos-643/annotations.json
+++ b/src/data/proofs/erdos-643/annotations.json
@@ -26,8 +26,8 @@
     "id": "ann-e643-hypergraph",
     "proofId": "erdos-643",
     "range": {
-      "startLine": 312,
-      "endLine": 320
+      "startLine": 111,
+      "endLine": 120
     },
     "type": "definition",
     "title": "Hypergraph Definitions",
@@ -49,8 +49,8 @@
     "id": "ann-e643-crossed",
     "proofId": "erdos-643",
     "range": {
-      "startLine": 333,
-      "endLine": 342
+      "startLine": 132,
+      "endLine": 142
     },
     "type": "definition",
     "title": "Crossed Pair Configuration",
@@ -72,8 +72,8 @@
     "id": "ann-e643-extremal",
     "proofId": "erdos-643",
     "range": {
-      "startLine": 357,
-      "endLine": 370
+      "startLine": 149,
+      "endLine": 175
     },
     "type": "definition",
     "title": "The Extremal Function",
@@ -95,8 +95,8 @@
     "id": "ann-e643-graph-case",
     "proofId": "erdos-643",
     "range": {
-      "startLine": 409,
-      "endLine": 485
+      "startLine": 184,
+      "endLine": 335
     },
     "type": "concept",
     "title": "Case t = 2: Connection to C₄",
@@ -118,8 +118,8 @@
     "id": "ann-e643-pikhurko",
     "proofId": "erdos-643",
     "range": {
-      "startLine": 822,
-      "endLine": 824
+      "startLine": 625,
+      "endLine": 627
     },
     "type": "concept",
     "title": "Pikhurko-Verstraëte Bound",
@@ -141,8 +141,8 @@
     "id": "ann-e643-bounds",
     "proofId": "erdos-643",
     "range": {
-      "startLine": 1268,
-      "endLine": 1278
+      "startLine": 1068,
+      "endLine": 1082
     },
     "type": "concept",
     "title": "General Bounds",
@@ -164,8 +164,8 @@
     "id": "ann-e643-conjecture",
     "proofId": "erdos-643",
     "range": {
-      "startLine": 1286,
-      "endLine": 1295
+      "startLine": 1084,
+      "endLine": 1100
     },
     "type": "definition",
     "title": "The Main Conjecture",
@@ -187,8 +187,8 @@
     "id": "ann-e643-sunflower",
     "proofId": "erdos-643",
     "range": {
-      "startLine": 1304,
-      "endLine": 1308
+      "startLine": 1103,
+      "endLine": 1116
     },
     "type": "definition",
     "title": "Sunflower Construction",
@@ -210,8 +210,8 @@
     "id": "ann-e643-sunflower-proof",
     "proofId": "erdos-643",
     "range": {
-      "startLine": 1310,
-      "endLine": 1326
+      "startLine": 1118,
+      "endLine": 1135
     },
     "type": "concept",
     "title": "Sunflowers Have No Crossed Pairs",
@@ -233,12 +233,12 @@
     "id": "ann-e643-small",
     "proofId": "erdos-643",
     "range": {
-      "startLine": 1247,
-      "endLine": 1259
+      "startLine": 1050,
+      "endLine": 1064
     },
     "type": "concept",
     "title": "Concrete Lower Bound (t = 3) and Small Cases",
-    "content": "**`f_three_lower_bound`** is the file's strongest fully-proved value-style result: f(n,3) ≥ C(n-1,2) + ⌊(n-1)/3⌋, obtained from the `LowerBoundGraph` (a star through vertex 0 together with a disjoint matching).\n\n**Small cases caveat**: the naive guesses f(4,2)=3 and f(5,2)=5 are *false* — Aristotle negated those statements, and the lower bound already forces f(4,2) ≥ 4 (the true value is 5, since the largest C₄-free graph on 4 vertices has 4 edges). The corresponding `f_four_two`/`f_five_two` blocks survive only as commented-out negations.",
+    "content": "**`f_three_lower_bound`** is the file's strongest fully-proved value-style result: f(n,3) ≥ C(n-1,2) + ⌊(n-1)/3⌋, obtained from the `LowerBoundGraph` (a star through vertex 0 together with a disjoint matching).\n\n**Small cases caveat**: the naive guesses f(4,2)=3 and f(5,2)=5 are *false* — Aristotle negated those statements, and the lower bound already forces f(4,2) ≥ 4 (the true value is 5, since the largest C₄-free graph on 4 vertices has 4 edges). The `f_four_two`/`f_five_two` declarations in the Small Cases section use Harmonic's `negate_state` tactic to formally prove these negations (f(4,2) ≠ 3 and f(5,2) ≠ 5) from `f_lower_bound`.",
     "mathContext": "f(n,3) ≥ C(n-1,2) + ⌊(n-1)/3⌋;  f(4,2) = 5",
     "significance": "supporting",
     "relatedConcepts": [
@@ -256,8 +256,8 @@
     "id": "ann-e643-erdosrado",
     "proofId": "erdos-643",
     "range": {
-      "startLine": 1384,
-      "endLine": 1391
+      "startLine": 1187,
+      "endLine": 1194
     },
     "type": "concept",
     "title": "Erdős-Rado Sunflower Lemma",

--- a/src/data/proofs/erdos-643/meta.json
+++ b/src/data/proofs/erdos-643/meta.json
@@ -49,7 +49,7 @@
       "Statement of Erdős-Rado Sunflower Lemma connection"
     ],
     "axiomCount": 3,
-    "lineCount": 1402,
+    "lineCount": 1206,
     "assumptions": "3 axiom(s) and 1 sorry(s). See the Lean source for details.",
     "theoremCount": 42,
     "definitionCount": 16
@@ -78,99 +78,92 @@
       "id": "problem-statement",
       "title": "Problem Statement & Provenance",
       "startLine": 1,
-      "endLine": 89,
-      "summary": "Aristotle provenance header and the Erdős #643 problem statement with known bounds"
-    },
-    {
-      "id": "tactic-prelude",
-      "title": "Harmonic generalize_proofs Prelude",
-      "startLine": 91,
-      "endLine": 298,
-      "summary": "Injected Mathlib import and Harmonic's modified generalize_proofs tactic (build infrastructure, not part of the mathematics)"
+      "endLine": 104,
+      "summary": "Aristotle provenance header, the Erdős #643 problem statement with known bounds, and the `negate_state` / `generalize_proofs` tactic prelude used by Harmonic's environment"
     },
     {
       "id": "hypergraphs",
       "title": "Hypergraph Definitions",
-      "startLine": 300,
-      "endLine": 320,
+      "startLine": 105,
+      "endLine": 121,
       "summary": "Basic definitions for t-uniform hypergraphs (Hypergraph, IsUniform, edgeCount)"
     },
     {
       "id": "crossed-pair",
       "title": "The Crossed Pair Configuration",
-      "startLine": 322,
-      "endLine": 342,
+      "startLine": 122,
+      "endLine": 143,
       "summary": "Definition of crossed pairs (IsCrossedPair) and when hypergraphs contain them (HasCrossedPair)"
     },
     {
       "id": "extremal-function",
       "title": "The Extremal Function f(n,t)",
-      "startLine": 344,
-      "endLine": 370,
+      "startLine": 144,
+      "endLine": 175,
       "summary": "Definition of f(n,t) via Nat.find as the minimum edge count forcing crossed pairs"
     },
     {
       "id": "graph-case",
       "title": "Case t = 2: Graphs and C₄",
-      "startLine": 372,
-      "endLine": 485,
-      "summary": "Connection to 4-cycles and the Kővári–Sós–Turán bound (common_neighbors_le_one, f_two_upper_bound)"
+      "startLine": 176,
+      "endLine": 335,
+      "summary": "Connection to 4-cycles, the common-neighbour and degree-sum lemmas, and the Kővári–Sós–Turán upper bound (graph_crossed_pair_iff_four_cycle, common_neighbors_le_one, f_two_upper_bound)"
     },
     {
       "id": "t2-bounds",
       "title": "t = 2: Θ(n^{3/2}) Bounds",
-      "startLine": 486,
-      "endLine": 811,
+      "startLine": 336,
+      "endLine": 619,
       "summary": "Affine-plane lower-bound construction, f_two_lower_bound, and the matching asymptotic f_two_asymptotic"
     },
     {
       "id": "pikhurko",
       "title": "t = 3: Pikhurko–Verstraëte Bound",
-      "startLine": 816,
-      "endLine": 824,
-      "summary": "The axiom f(n,3) ≤ (13/9)·C(n,2)"
+      "startLine": 620,
+      "endLine": 634,
+      "summary": "The axiom pikhurko_verstrate_bound: f(n,3) ≤ (13/9)·C(n,2)"
     },
     {
       "id": "t3-lower",
       "title": "t = 3 Lower-Bound Construction",
-      "startLine": 825,
-      "endLine": 1259,
+      "startLine": 635,
+      "endLine": 1065,
       "summary": "Star ∪ Matching (LowerBoundGraph) construction and f_three_lower_bound: f(n,3) ≥ C(n-1,2) + ⌊(n-1)/3⌋"
     },
     {
       "id": "general-bounds",
       "title": "General Bounds",
-      "startLine": 1262,
-      "endLine": 1278,
+      "startLine": 1066,
+      "endLine": 1083,
       "summary": "General lower bound (f_lower_bound, sorry) and upper bound (f_upper_bound, axiom)"
     },
     {
       "id": "conjecture",
       "title": "The Main Conjecture",
-      "startLine": 1280,
-      "endLine": 1295,
+      "startLine": 1084,
+      "endLine": 1100,
       "summary": "Statement of Erdős's asymptotic conjecture (Erdos643Conjecture)"
     },
     {
       "id": "constructions",
       "title": "Sunflower Constructions",
-      "startLine": 1297,
-      "endLine": 1326,
-      "summary": "SunflowerHypergraph and the proof that sunflowers contain no crossed pairs"
+      "startLine": 1101,
+      "endLine": 1135,
+      "summary": "SunflowerHypergraph and the proof that sunflowers contain no crossed pairs (sunflower_no_crossed_pair)"
     },
     {
       "id": "small-cases",
       "title": "Small Cases",
-      "startLine": 1328,
-      "endLine": 1370,
-      "summary": "Commented-out negations of the naive guesses f(4,2)=3 and f(5,2)=5, which the lower bound refutes"
+      "startLine": 1136,
+      "endLine": 1178,
+      "summary": "negate_state proofs that the naive guesses f(4,2)=3 and f(5,2)=5 both fail, since the lower bound forces f(4,2)≥4 and f(5,2)≥6"
     },
     {
       "id": "sunflower-lemma",
       "title": "Erdős–Rado Sunflower Lemma & Context",
-      "startLine": 1372,
-      "endLine": 1401,
-      "summary": "The Erdős–Rado sunflower lemma (axiom) and historical context connecting to Füredi's hypergraph Turán work"
+      "startLine": 1179,
+      "endLine": 1206,
+      "summary": "The Erdős–Rado sunflower lemma (axiom sunflower_lemma) and historical context connecting to Füredi's hypergraph Turán work"
     }
   ],
   "conclusion": {
@@ -237,7 +230,7 @@
       "Classical"
     ],
     "namespace": "Harmonic.GeneralizeProofs",
-    "lineCount": 1402,
+    "lineCount": 1206,
     "axiomCount": 3,
     "theoremCount": 42,
     "definitionCount": 16,


### PR DESCRIPTION
## Enrichment pass for `erdos-643` (Crossed Pairs in Hypergraphs)

Genuine section/annotation line-range drift fix (the at-floor work source: cf. #39486).

### Problem
`Proofs/Erdos643Problem.lean` was shortened by ~196 lines (1402 → 1206 actual) during the v4.31 migration, but `meta.json` sections and `annotations.json` ranges still referenced the old line numbers — **overshooting the end of the file by up to 195 lines**. Sections pointed at nonexistent lines and no longer matched the declarations they described.

### Changes
- **Sections**: realigned all section `startLine`/`endLine` to actual `##`-header and declaration positions (verified against the Lean source). Dropped the stale `tactic-prelude` ("Harmonic generalize_proofs Prelude") section — it claimed a 200-line block at lines 91–298 that does not exist; the tactic code is now just documentation inside the provenance header (folded into section 1's summary).
- **Annotations**: realigned all 12 annotation ranges to their true declaration lines (spot-checked each anchor lands on the described `def`/`theorem`/`axiom`).
- **lineCount**: `1402 → 1206` in both `meta` and `leanFile`.
- Corrected the stale "commented-out negations" note on `f_four_two`/`f_five_two` — these are now real `negate_state` proofs that formally establish f(4,2)≠3 and f(5,2)≠5 from `f_lower_bound`.

### Verification
- `jq` confirms both JSON files are valid.
- `pnpm build` data steps (search-index + enrichment link build, which parse every meta.json) pass; the terminal `tsc` step fails only on a missing `node_modules` binary in this environment (pre-existing, unrelated).
- Axiom integrity unchanged: `axiomCount: 3` (pikhurko_verstrate_bound, f_upper_bound, sunflower_lemma) + 1 sorry, `status: axiomatized` — all still accurate.

No content deleted beyond the one section describing removed code; all summaries preserved.