### PR TITLE
audit: erdos-833 — drop phantom axioms/declarations from prose

### DIFF
--- a/src/data/proofs/erdos-833/meta.json
+++ b/src/data/proofs/erdos-833/meta.json
@@ -51,21 +51,20 @@
     ],
     "originalContributions": [
       "UniformHypergraph structure: r-uniform hypergraph definition",
-      "vertexDegree definition: edges containing a vertex",
-      "IsProperColoring, IsKColorable: hypergraph coloring",
+      "vertexDegree, maxDegree, minMaxDegree definitions: edges containing a vertex and degree extrema",
+      "IsProperColoring, IsKColorable, chromaticNumber: hypergraph coloring",
       "HasChromaticNumber3: exactly 3-chromatic",
       "hypergraph_trivially_colorable axiom: every H is |V|-colorable",
-      "f(r) definition: minimum max degree over 3-chromatic r-uniform hypergraphs",
-      "ExponentialGrowthConjecture: the main question",
-      "erdos_lovasz_bound axiom: 2^{r-1}/(4r) bound",
-      "f_lower_bound: f(r) ≥ 2^{r-1}/(4r)",
-      "bound_is_exponential: bound grows like (√2)^r",
+      "f(r) definition: minimum max degree over 3-chromatic r-uniform hypergraphs (via sInf)",
+      "ExponentialGrowthConjecture definition: the main question",
+      "erdos_lovasz_bound axiom: pointwise 2^{r-1}/(4r) degree bound",
       "erdos_833_solution axiom: exponential growth holds",
-      "f_2_achieved: triangle achieves f(2)=2",
-      "contrapositive_form: low degree implies 2-colorable"
+      "exists_high_degree_vertex theorem: derives the high-degree vertex from erdos_lovasz_bound",
+      "erdos_833 theorem: packages ExponentialGrowthConjecture together with the pointwise bound",
+      "erdos_833_status definition: solved-status string"
     ],
     "axiomCount": 3,
-    "lineCount": 215,
+    "lineCount": 213,
     "assumptions": "3 axioms: hypergraph_trivially_colorable, erdos_lovasz_bound, erdos_833_solution. Structure fields are object definitions, not assumptions.",
     "theoremCount": 2,
     "definitionCount": 11
@@ -74,7 +73,7 @@
     "historicalContext": "**Erdős Problem #833: Vertex Degrees in 3-Chromatic Hypergraphs**\n\nThis problem lies at the intersection of hypergraph coloring theory and the probabilistic method, and its resolution introduced one of the most important tools in combinatorics.\n\n**Property B and Hypergraph Coloring:** A hypergraph $H = (V, E)$ has **Property B** (named after Felix Bernstein, who studied the concept in 1908) if its vertices can be 2-colored so that no edge is monochromatic. For $r$-uniform hypergraphs (every edge has exactly $r$ vertices), Erdős (1963) showed that any $r$-uniform hypergraph with fewer than $2^{r-1}$ edges has Property B — this is the simplest application of the probabilistic method to hypergraph coloring. A hypergraph with chromatic number $\\chi(H) = 3$ is one that fails Property B but can be properly 3-colored.\n\n**The Function $f(r)$:** Erdős defined $f(r)$ as the minimum, over all $r$-uniform 3-chromatic hypergraphs $H$, of the maximum vertex degree $\\Delta(H)$. The question is: how large must the busiest vertex be in any 3-chromatic $r$-uniform hypergraph? Known values are $f(2) = 2$ (the triangle $K_3$ is the unique minimal 3-chromatic graph, with every vertex in exactly 2 edges) and $f(3) = 3$ (the **Fano plane** $\\mathrm{PG}(2,2)$, the smallest finite projective plane, with 7 vertices, 7 triples, every vertex in exactly 3 triples, and $\\chi = 3$). Erdős noted that $f(4)$ was unknown.\n\n**The 1975 Paper and the Birth of the LLL:** The question was resolved in the landmark 1975 paper *Problems and results on 3-chromatic hypergraphs and some related questions* by Erdős and Lovász, presented at the Keszthely conference. This same paper introduced the **Lovász Local Lemma** (LLL), one of the most powerful and widely-used tools in probabilistic combinatorics. The LLL provides conditions under which a random experiment avoids all 'bad events' simultaneously, even when the events are not independent.\n\n**The Proof:** Erdős and Lovász proved that every $r$-uniform 3-chromatic hypergraph has a vertex in at least $2^{r-1}/(4r)$ edges. The argument is by contrapositive: assume all vertices have degree $< 2^{r-1}/(4r)$. Color each vertex randomly with one of 2 colors. For each edge $e$, the bad event $A_e$ (edge is monochromatic) has probability $2 \\cdot 2^{-r} = 2^{1-r}$. Each bad event depends on at most $r \\cdot \\Delta$ others (edges sharing a vertex with $e$). The symmetric LLL guarantees all bad events are simultaneously avoided when $e \\cdot p \\cdot d \\leq 1$, yielding $\\Delta < 2^{r-1}/(er)$. The published bound $2^{r-1}/(4r)$ uses a slightly sharper analysis.\n\n**Exponential Growth:** Since $2^{r-1}/(4r) \\sim (\\sqrt{2})^r / (4r)$ and $(\\sqrt{2})^r$ dominates $4r$, we get $f(r) \\geq (1+c)^r$ for $c \\approx 0.414$ (taking $1+c = \\sqrt{2}$). This confirms that vertex degrees in 3-chromatic hypergraphs grow exponentially with the uniformity $r$.\n\n**Legacy:** The Erdős–Lovász paper became one of the most influential in combinatorics. The LLL has since found applications in graph coloring, satisfiability (Moser–Tardos constructive version, 2010), coding theory, and computational complexity. Problem #833 exemplifies how a specific extremal question can catalyze the development of a major mathematical tool.",
     "problemStatement": "**Problem Statement (SOLVED)**\n\nLet $f(r)$ be the largest integer such that every $r$-uniform hypergraph with $\\chi(H) = 3$ has a vertex in at least $f(r)$ edges.\n\n**Question:** Does there exist $c > 0$ such that $f(r) \\geq (1+c)^r$ for all $r \\geq 2$?\n\n**Answer (Erdős–Lovász 1975): YES!**\n\nEvery $r$-uniform 3-chromatic hypergraph has a vertex in at least $\\frac{2^{r-1}}{4r}$ edges.\n\nSince $\\frac{2^{r-1}}{4r} \\sim \\frac{(\\sqrt{2})^r}{4r}$, this grows exponentially with base $\\sqrt{2} \\approx 1.414$, confirming the conjecture with $c = \\sqrt{2} - 1 \\approx 0.414$.",
     "text": "Does there exist c > 0 such that every r-uniform 3-chromatic hypergraph has a vertex in at least (1+c)^r edges? SOLVED by Erdős-Lovász (1975): YES, with bound 2^{r-1}/(4r).",
-    "proofStrategy": "**Formalization Approach**\n\n1. **Hypergraph Structure:** Defines `UniformHypergraph V` as a Lean 4 structure with uniformity parameter $r$, edge set `Finset (Finset V)`, uniformity constraint, and $r \\geq 2$.\n\n2. **Vertex Degree:** Defines $\\deg_H(v) = |\\{e \\in E : v \\in e\\}|$ via `Finset.filter`, plus `maxDegree` and `minMaxDegree` via `Finset.univ.sup`.\n\n3. **Colorings:** Defines `IsProperColoring` (no monochromatic edge), `IsKColorable`, `chromaticNumber` via `Nat.find`, and `HasChromaticNumber3`.\n\n4. **f(r) Function:** Defines $f(r)$ as `sInf` over the set of achievable degree bounds.\n\n5. **Main Theorem:** Axiomatizes the Erdős–Lovász bound $2^{r-1}/(4r)$ in pointwise, function, and asymptotic forms.\n\n6. **Exponential Growth:** Derives `ExponentialGrowthConjecture` from the bound.\n\n7. **Proof Technique:** Axiomatizes the LLL contrapositive: low degree $\\implies$ 2-colorable.\n\n8. **Why Axioms:** The Lovász Local Lemma requires probability spaces and dependency graphs beyond current Mathlib capabilities.",
+    "proofStrategy": "**Formalization Approach**\n\n1. **Hypergraph Structure:** Defines `UniformHypergraph V` as a Lean 4 structure with uniformity parameter $r$, edge set `Finset (Finset V)`, uniformity constraint, and $r \\geq 2$.\n\n2. **Vertex Degree:** Defines $\\deg_H(v) = |\\{e \\in E : v \\in e\\}|$ via `Finset.filter`, plus `maxDegree` and `minMaxDegree` via `Finset.univ.sup`.\n\n3. **Colorings:** Defines `IsProperColoring` (no monochromatic edge), `IsKColorable`, `chromaticNumber` via `Nat.find`, and `HasChromaticNumber3`.\n\n4. **f(r) Function:** Defines $f(r)$ as `sInf` over the set of achievable degree bounds.\n\n5. **Main Theorem:** Axiomatizes the Erdős–Lovász bound $2^{r-1}/(4r)$ in a single pointwise form (`erdos_lovasz_bound`: some vertex has degree $\\geq 2^{r-1}/(4r)$).\n\n6. **Exponential Growth:** Axiomatizes `ExponentialGrowthConjecture` directly (`erdos_833_solution`); `erdos_833` and `exists_high_degree_vertex` package the two axioms into named theorems.\n\n7. **Proof Technique:** The LLL contrapositive (low degree $\\implies$ 2-colorable) is described in source comments only — it is not a Lean declaration.\n\n8. **Why Axioms:** The Lovász Local Lemma requires probability spaces and dependency graphs beyond current Mathlib capabilities.",
     "keyInsights": [
       "**Birth of the Lovász Local Lemma:** This problem's resolution in the 1975 Erdős–Lovász paper introduced the LLL, now one of the most important tools in probabilistic combinatorics. The LLL states: if bad events each have probability $\\leq p$ and each depends on at most $d$ others, with $ep(d+1) \\leq 1$, then all bad events can be simultaneously avoided.",
       "**Contrapositive Structure:** The proof is beautifully indirect. Rather than directly constructing a high-degree vertex, it assumes all degrees are small, applies the LLL to show a random 2-coloring works, contradicting $\\chi(H) = 3$. This 'if structure is simple, then coloring is easy' paradigm pervades modern combinatorics.",
@@ -116,10 +115,10 @@
     {
       "id": "f-function",
       "title": "The Function $f(r)$ and Known Values",
-      "summary": "Defines $f(r) = \\inf\\{d : \\forall H \\in \\mathcal{H}_{r,3},\\; \\Delta(H) \\geq d\\}$ via `sInf`; axiomatizes $f(2) = 2$ (triangle) and $f(3) = 3$ (Fano plane $\\mathrm{PG}(2,2)$)",
+      "summary": "Defines $f(r) = \\inf\\{d : \\forall H \\in \\mathcal{H}_{r,3},\\; \\Delta(H) \\geq d\\}$ via `sInf`. The known values $f(2) = 2$ (triangle) and $f(3) = 3$ (Fano plane $\\mathrm{PG}(2,2)$) appear only in source comments — they are not axiomatized",
       "startLine": 105,
       "endLine": 126,
-      "mathContext": "Formal definition: Defines $f(r) = \\inf\\{d : \\forall H \\in \\mathcal{H}_{r,3},\\; \\Delta(H) \\geq d\\}$ via `sInf`; axiomatizes $f(2) = 2$ (triangle) and $f(3) = 3$ (Fano plane $\\mathrm{PG}(2,2)$)"
+      "mathContext": "Formal definition: Defines $f(r) = \\inf\\{d : \\forall H \\in \\mathcal{H}_{r,3},\\; \\Delta(H) \\geq d\\}$ via `sInf`. The known values $f(2) = 2$ (triangle) and $f(3) = 3$ (Fano plane $\\mathrm{PG}(2,2)$) appear only in source comments — they are not axiomatized"
     },
     {
       "id": "exponential-question",
@@ -132,10 +131,10 @@
     {
       "id": "erdos-lovasz",
       "title": "Erdős–Lovász Theorem (1975)",
-      "summary": "Axiomatizes the bound in three forms: pointwise ($\\exists v,\\; \\deg(v) \\geq 2^{r-1}/(4r)$), function ($f(r) \\geq \\lfloor 2^{r-1}/(4r) \\rfloor$), and asymptotic ($\\geq (\\sqrt{2} - \\varepsilon)^r$ for large $r$). Derives `erdos_833_solution` confirming exponential growth",
+      "summary": "Axiomatizes the bound in a single pointwise form, `erdos_lovasz_bound` ($\\exists v,\\; \\deg(v) \\geq 2^{r-1}/(4r)$), and separately axiomatizes `erdos_833_solution : ExponentialGrowthConjecture`. (No function-form or asymptotic-form bound is declared.)",
       "startLine": 137,
       "endLine": 170,
-      "mathContext": "Axiomatizes the bound in three forms: pointwise ($\\exists v,\\; \\deg(v) \\geq 2^{r-1}/(4r)$), function ($f(r) \\geq \\lfloor 2^{r-1}/(4r) \\rfloor$), and asymptotic ($\\geq (\\sqrt{2} - \\varepsilon)^r$ for large $r$)."
+      "mathContext": "Axiomatizes the bound in a single pointwise form, `erdos_lovasz_bound` ($\\exists v,\\; \\deg(v) \\geq 2^{r-1}/(4r)$), and separately axiomatizes `erdos_833_solution : ExponentialGrowthConjecture`. (No function-form or asymptotic-form bound is declared.)"
     },
     {
       "id": "related-results",
@@ -148,10 +147,10 @@
     {
       "id": "specific-values",
       "title": "Specific Values: Triangle and Fano Plane",
-      "summary": "Axiomatizes tight examples: `f_2_achieved` (triangle $K_3$ with $\\Delta = 2$, $\\chi = 3$) and `fano_plane_example` (Fano plane $\\mathrm{PG}(2,2)$: 7 vertices, 7 triples, $\\Delta = 3$, $\\chi = 3$)",
+      "summary": "Source-comment placeholder (Part VII) describing the tight examples — triangle $K_3$ ($\\Delta = 2$, $\\chi = 3$) and Fano plane $\\mathrm{PG}(2,2)$ (7 vertices, 7 triples, $\\Delta = 3$, $\\chi = 3$). No Lean declarations (`f_2_achieved`, `fano_plane_example`) are defined here",
       "startLine": 192,
       "endLine": 207,
-      "mathContext": "Axiomatized: Axiomatizes tight examples: `f_2_achieved` (triangle $K_3$ with $\\Delta = 2$, $\\chi = 3$) and `fano_plane_example` (Fano plane $\\mathrm{PG}(2,2)$: 7 vertices, 7 triples, $\\Delta = 3$, $\\chi = 3$)"
+      "mathContext": "Source-comment placeholder (Part VII) describing the tight examples — triangle $K_3$ ($\\Delta = 2$, $\\chi = 3$) and Fano plane $\\mathrm{PG}(2,2)$ (7 vertices, 7 triples, $\\Delta = 3$, $\\chi = 3$). No Lean declarations (`f_2_achieved`, `fano_plane_example`) are defined here"
     },
     {
       "id": "proof-technique",
@@ -163,7 +162,7 @@
     }
   ],
   "conclusion": {
-    "summary": "Erdős Problem #833 asked whether vertex degrees in 3-chromatic $r$-uniform hypergraphs must grow exponentially with $r$. Erdős and Lovász (1975) proved YES: every such hypergraph has a vertex in at least $2^{r-1}/(4r)$ edges, which grows like $(\\sqrt{2})^r$. The proof — using the Lovász Local Lemma in its inaugural appearance — shows that low maximum degree implies 2-colorability via random coloring, contradicting $\\chi(H) = 3$. The formalization captures the full structure: hypergraph definitions, the extremal function $f(r)$, known values $f(2) = 2$ (triangle) and $f(3) = 3$ (Fano plane), the exponential growth conjecture, and the Erdős–Lovász resolution.",
+    "summary": "Erdős Problem #833 asked whether vertex degrees in 3-chromatic $r$-uniform hypergraphs must grow exponentially with $r$. Erdős and Lovász (1975) proved YES: every such hypergraph has a vertex in at least $2^{r-1}/(4r)$ edges, which grows like $(\\sqrt{2})^r$. The proof — using the Lovász Local Lemma in its inaugural appearance — shows that low maximum degree implies 2-colorability via random coloring, contradicting $\\chi(H) = 3$. The formalization captures the structural scaffold: hypergraph definitions, the extremal function $f(r)$, the exponential growth conjecture, and the Erdős–Lovász resolution stated as axioms (`erdos_lovasz_bound`, `erdos_833_solution`). The known values $f(2) = 2$ (triangle) and $f(3) = 3$ (Fano plane) are documented in source comments only, not formalized.",
     "implications": "**Theoretical Significance**: **Mathematical Significance**\n\n1. **Birth of the Lovász Local Lemma:** The 1975 Erdős–Lovász paper introducing this result also introduced the LLL, now one of the most widely-used tools in combinatorics, theoretical computer science, and probability theory.\n\n2. **Structural Consequences of Chromaticity:** The result establishes a fundamental principle: high chromatic number forces structural complexity (high-degree vertices). This paradigm extends far beyond hypergraphs.\n\n**3. Property B Refinement:** Strengthens Erdős's 1963 result ($|E| < 2^{r-1} \\implies$ Property B) from an edge-count condition to a maximum-degree condition, which is strictly more powerful.\n\n4. **Extremal Combinatorics:** The function $f(r)$ captures the precise tradeoff between uniformity and vertex degree under chromatic constraints, a central theme in extremal hypergraph theory.\n\n5. **Constructive Developments:** The Moser–Tardos algorithm (2010) made the LLL constructive, enabling efficient 2-coloring of low-degree hypergraphs. This algorithmic advance has implications for constraint satisfaction and coding theory.",
     "openQuestions": [
       "What are exact values of $f(r)$ for $r \\geq 4$? The Erdős–Lovász bound gives $f(4) \\geq \\lfloor 2^3/16 \\rfloor = 0$, which is trivial — can explicit 4-uniform 3-chromatic hypergraphs with small max degree be constructed?",
@@ -186,7 +185,7 @@
       "Finset"
     ],
     "namespace": "Erdos833",
-    "lineCount": 215,
+    "lineCount": 213,
     "axiomCount": 3,
     "theoremCount": 2,
     "definitionCount": 11,


### PR DESCRIPTION
## Integrity Issue

**Proof**: erdos-833 (Vertex Degrees in 3-Chromatic Hypergraphs)
**Problem**: meta prose names Lean declarations and axiomatized results that do not exist in `Proofs/Erdos833Problem.lean`. Declaration counts (3 axioms / 2 theorems / 11 defs / 0 sorries) are correct; only the narrative overstates scope.

## Evidence

**Actual file declarations**:
- axioms (3): `hypergraph_trivially_colorable`, `erdos_lovasz_bound`, `erdos_833_solution`
- theorems (2): `exists_high_degree_vertex`, `erdos_833`
- 11 defs/structure; 0 sorries; 0 native_decide

**Phantom names in meta (0 grep hits in the file)**:
- `originalContributions`: `f_lower_bound`, `bound_is_exponential`, `f_2_achieved`, `contrapositive_form`
- section `specific-values`: `f_2_achieved`, `fano_plane_example`

**Phantom axiomatization claims**:
- section `f-function`: "axiomatizes f(2)=2 (triangle) and f(3)=3 (Fano plane)" — these appear in source comments only.
- section `erdos-lovasz` + `proofStrategy` step 5: "axiomatizes the bound in three forms (pointwise, function, asymptotic)" — only the single pointwise `erdos_lovasz_bound` exists (plus `erdos_833_solution`).
- section `specific-values`: Part VII is a comment placeholder — no declarations.

## Fix

- Rewrote `originalContributions` to list only real declarations (added the two real theorems + `erdos_833_status`).
- Corrected the three section summaries, `proofStrategy` steps 5–7, and the conclusion to state that the known values / extra bound forms are documented in comments, not formalized.
- Stale `lineCount` 215 → 213 (both meta blocks).

Counts unchanged. Prose now matches the file exactly.

---
Discovered during gallery integrity audit. Companion to the open re-serve PR #39177 (which marked erdos-833 "clean" from a counts-only check).