### PR TITLE
Research: erdos-85-wip-01 — 7 axiom-free foundational lemmas (incl. stars are C₄-free)

### DIFF
--- a/proofs/Proofs/Erdos85Problem.lean
+++ b/proofs/Proofs/Erdos85Problem.lean
@@ -181,4 +181,50 @@ The monotonicity question is subtle because adding vertices might create
 The Kővári-Sós-Turán theorem gives bounds on C₄-free graphs:
 A C₄-free graph on n vertices has at most (1/2)n^{3/2} + n/2 edges.
 -/
+
+/-
+## Foundational lemmas (axiom-free)
+
+The asymptotics `f(n) = (1+o(1))√n`, the base case `f(4) = 2`, the Ramsey
+reformulation and the monotonicity question itself require substantial extremal
+graph theory beyond current Mathlib and stay documented above only.  The
+structural facts about `C4`, `containsC4`, and `starGraph` are, however, fully
+machine-checkable.  All lemmas below are axiom-free
+(`propext / Classical.choice / Quot.sound` only). -/
+
+/-- The four defining edges of the 4-cycle `C₄`: `0–1–2–3–0`. -/
+theorem C4_adj_zero_one : C4.Adj 0 1 := by simp [C4]
+theorem C4_adj_one_two : C4.Adj 1 2 := by simp [C4]
+theorem C4_adj_two_three : C4.Adj 2 3 := by simp [C4]
+theorem C4_adj_three_zero : C4.Adj 3 0 := by simp [C4]
+
+/-- The "diagonals" of `C₄` are non-edges: `0` and `2` are not adjacent. -/
+theorem C4_not_adj_zero_two : ¬ C4.Adj 0 2 := by simp [C4]
+
+/-- Containing a `C₄` is preserved under passing to a larger graph on the same
+vertex set (adding edges cannot destroy a copy of `C₄`). -/
+theorem containsC4_mono {V : Type*} {G G' : SimpleGraph V} (h : G ≤ G')
+    (hG : containsC4 V G) : containsC4 V G' := by
+  obtain ⟨f, hf, hadj⟩ := hG
+  exact ⟨f, hf, fun i j hij => h (hadj i j hij)⟩
+
+/-- **Stars are `C₄`-free.** The star graph `K_{1,n}` contains no 4-cycle: every
+edge of a star meets the centre `0`, but a `C₄` has two disjoint edges (`0–1` and
+`2–3`), which would force two distinct cycle-vertices onto the centre — impossible
+by injectivity.  This is the extremal reason stars appear in the Ramsey
+reformulation of `f(n)`. -/
+theorem starGraph_not_containsC4 (n : ℕ) :
+    ¬ containsC4 (Fin (n + 1)) (starGraph n) := by
+  rintro ⟨f, hinj, hadj⟩
+  have e01 := hadj 0 1 C4_adj_zero_one
+  have e23 := hadj 2 3 C4_adj_two_three
+  simp only [starGraph] at e01 e23
+  have h01 : f 0 = 0 ∨ f 1 = 0 := e01.imp And.left And.left
+  have h23 : f 2 = 0 ∨ f 3 = 0 := e23.imp And.left And.left
+  rcases h01 with h0 | h1 <;> rcases h23 with h2 | h3
+  · exact absurd (hinj (h0.trans h2.symm)) (by decide)
+  · exact absurd (hinj (h0.trans h3.symm)) (by decide)
+  · exact absurd (hinj (h1.trans h2.symm)) (by decide)
+  · exact absurd (hinj (h1.trans h3.symm)) (by decide)
+
 end Erdos85

--- a/research/problems/erdos-85-wip-01/knowledge.md
+++ b/research/problems/erdos-85-wip-01/knowledge.md
@@ -19,3 +19,17 @@ Insights accumulated during research on this problem.
 ## Dead Ends
 
 [Approaches known not to work will be documented here]
+
+---
+
+## Session note (2026-07-20, researcher-1): 7 axiom-free foundational lemmas
+
+`Erdos85Problem.lean` (min degree for C₄) was a definitions-only stub (7 defs, 0 theorems).
+Added 7 axiom-free lemmas (host-verified, Lean v4.31.0; `#print axioms` =
+propext/Classical.choice/Quot.sound): the four C₄ cycle edges (`C4_adj_*`), a diagonal
+non-edge (`C4_not_adj_zero_two`), `containsC4_mono` (a C₄ copy survives adding edges), and
+**`starGraph_not_containsC4`** — the star K_{1,n} is C₄-free (its two disjoint cycle-edges
+0–1 and 2–3 would force two distinct cycle-vertices onto the centre, contradicting
+injectivity). Note: `decide` fails on `C4.Adj 0 1` (structure-literal Adj field lacks a
+Decidable instance) — use `by simp [C4]`. Deep results (asymptotics, f(4)=2, Ramsey
+connection) remain documented-only. Meta synced (theoremCount 0 → 7, lineCount 184 → 230).

--- a/research/problems/erdos-85-wip-01/state.md
+++ b/research/problems/erdos-85-wip-01/state.md
@@ -1,7 +1,7 @@
 # Research State: erdos-85-wip-01
 
 ## Current State
-**Phase**: OBSERVE
+**Phase**: ORIENT
 **Path**: full
 **Since**: 2026-07-09T17:33:20-07:00
 **Iteration**: 1

--- a/src/data/proofs/erdos-85/meta.json
+++ b/src/data/proofs/erdos-85/meta.json
@@ -56,16 +56,16 @@
       "Kővári-Sós-Turán bound on C₄-free graphs"
     ],
     "axiomCount": 0,
-    "lineCount": 184,
-    "assumptions": "0 axioms, 0 sorries. Previously cited axiom names have been removed from the Lean source. The 'axiomatized' status reflects that the main result is not yet fully formalized in Lean.",
-    "theoremCount": 0,
+    "lineCount": 230,
+    "assumptions": "0 axioms, 0 sorries. The file states the problem (defs C4, containsC4, minDegreeForC4, Erdos85Question/Negation, starGraph, ramseyConnection, WeakerConjecture) and proves 7 axiom-free foundational lemmas about C4/containsC4/starGraph. The asymptotics f(n)=(1+o(1))sqrt(n), base case f(4)=2, the Ramsey reformulation, and the monotonicity question require extremal graph theory beyond current Mathlib and remain described in doc-comments only, NOT formalized. The formalized lemmas are: the four C4 edges and a C4 non-edge, containsC4_mono (monotone under adding edges), and starGraph_not_containsC4 (stars are C4-free).",
+    "theoremCount": 7,
     "definitionCount": 8
   },
   "overview": {
     "historicalContext": "This problem concerns the extremal theory of even cycles in graphs. The 4-cycle (C₄) is the simplest even cycle and appears throughout graph theory, including the Kővári–Sós–Turán theorem and the Zarankiewicz problem.\n\nLet f(n) be the smallest integer such that every n-vertex graph with minimum degree at least f(n) contains a 4-cycle. It is known that f(n) = (1 + o(1))√n asymptotically.\n\nErdős asked whether f is eventually monotone: does f(n+1) ≥ f(n) hold for all sufficiently large n? This subtle question remains open. Adding vertices to a graph might create 'room' for high minimum-degree configurations that avoid 4-cycles.",
     "problemStatement": "**Erdős Problem #85 (OPEN)**\n\nLet $f(n)$ be the minimum degree threshold such that every $n$-vertex graph with minimum degree $\\geq f(n)$ contains a 4-cycle.\n\n**Question**: Is $f(n+1) \\geq f(n)$ for all sufficiently large $n$?\n\n**Known Results**:\n- $f(n) = (1 + o(1))\\sqrt{n}$ asymptotically\n- $f(n) < \\sqrt{n} + 1$ for $n \\geq 4$\n- $f(4) = 2$\n- Connected to Ramsey number $R(C_4, K_{1,n})$",
     "text": "Is the minimum degree threshold f(n) for forcing a 4-cycle monotone? That is, is f(n+1) ≥ f(n) for all large n?",
-    "proofStrategy": "We formalize the key concepts and known results:\n\n1. **C4**: The 4-cycle graph on Fin 4\n\n2. **containsC4**: Predicate for C₄ appearing as a subgraph\n\n3. **minDegreeForC4**: The threshold function f(n)\n\n4. **Erdos85Question**: The open monotonicity question\n\n5. **Known bounds** (axioms): f(n) < √n + 1, f(n) ~ √n\n\n6. **Ramsey connection**: Relation to R(C₄, K_{1,n})\n\n7. **Kővári-Sós-Turán**: Upper bound on C₄-free graphs",
+    "proofStrategy": "Defines the 4-cycle C4 on Fin 4, the containsC4 subgraph-embedding predicate, the degree-threshold function minDegreeForC4, the monotonicity question, the star graph, and the Ramsey/weaker reformulations. Adds 7 axiom-free foundational lemmas: C4_adj_zero_one/one_two/two_three/three_zero (the four cycle edges), C4_not_adj_zero_two (a diagonal non-edge), containsC4_mono (a C4 copy survives adding edges), and starGraph_not_containsC4 (the star K_{1,n} contains no C4, since its two disjoint cycle-edges would force two distinct cycle-vertices onto the centre, contradicting injectivity). The asymptotics, base case, and Ramsey connection appear in documentation only, not formalized.",
     "keyInsights": [
       "**Minimum degree forces structure**: High minimum degree in a graph forces certain subgraphs to appear. The threshold for C₄ is well-understood asymptotically.",
       "**Monotonicity is subtle**: Adding vertices might create room for new C₄-avoiding configurations with high minimum degree.",
@@ -150,9 +150,9 @@
       "Topology"
     ],
     "namespace": "Erdos85",
-    "lineCount": 184,
+    "lineCount": 230,
     "axiomCount": 0,
-    "theoremCount": 0,
+    "theoremCount": 7,
     "definitionCount": 8,
     "path": "Proofs/Erdos85Problem.lean",
     "sorries": 0

--- a/src/data/research/problems/erdos-85-wip-01.json
+++ b/src/data/research/problems/erdos-85-wip-01.json
@@ -18,7 +18,7 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "OBSERVE",
+    "phase": "ORIENT",
     "since": "2026-07-09T17:33:20-07:00",
     "iteration": 1,
     "focus": "Initial problem understanding. Read problem.md and gather context.",
@@ -31,9 +31,18 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
+    "progressSummary": "PROGRESS: added 7 axiom-free foundational lemmas to the previously definitions-only Erdos85Problem.lean (the four C4 edges + a diagonal non-edge, containsC4 monotonicity, and starGraph_not_containsC4 = stars are C4-free, the extremal fact behind the Ramsey reformulation). Deep results (asymptotics, f(4)=2, Ramsey connection, monotonicity) remain documented-only. Meta synced (theoremCount 0 -> 7).",
+    "builtItems": [
+      "C4_adj_zero_one/one_two/two_three/three_zero (four cycle edges) in Erdos85Problem.lean",
+      "C4_not_adj_zero_two (diagonal non-edge) in Erdos85Problem.lean",
+      "containsC4_mono (C4 copy survives adding edges) in Erdos85Problem.lean",
+      "starGraph_not_containsC4 (stars are C4-free) in Erdos85Problem.lean"
+    ],
+    "insights": [
+      "Erdos85Problem.lean was a definitions-only stub (7 defs, 0 theorems). Asymptotics f(n)=(1+o(1))sqrt(n), f(4)=2, and the Ramsey reformulation need extremal graph theory beyond Mathlib; tractable axiom-free content is structural facts about C4, containsC4, and starGraph.",
+      "Stars are C4-free: a C4 has two DISJOINT edges (0-1 and 2-3); in a star every edge meets the centre 0, so both disjoint edges would put two distinct cycle-vertices at 0, contradicting injectivity of the embedding. Only the two disjoint edges are needed for the proof.",
+      "SimpleGraph structure-literal Adj fields have no Decidable instance, so `decide` fails on C4.Adj 0 1; `by simp [C4]` unfolds the field and evaluates the arithmetic disjunction instead."
+    ],
     "mathlibGaps": [],
     "nextSteps": [],
     "markdown": "# Knowledge Base: erdos-85-wip-01\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"


### PR DESCRIPTION
## Summary
`proofs/Proofs/Erdos85Problem.lean` (Erdős #85 — minimum degree forcing a 4-cycle) was a **definitions-only stub**: 7 defs, 0 theorems. This PR adds **7 axiom-free foundational lemmas** about `C4`, `containsC4`, and `starGraph`.

## New theorems (all axiom-free, host-verified under Lean v4.31.0)

| Theorem | Statement |
|---|---|
| `C4_adj_zero_one` … `C4_adj_three_zero` | the four edges of the 4-cycle `0–1–2–3–0` |
| `C4_not_adj_zero_two` | a diagonal (`0`,`2`) is a non-edge |
| `containsC4_mono` | a `C₄` copy survives passing to a larger graph (adding edges) |
| **`starGraph_not_containsC4`** | the star `K_{1,n}` is **C₄-free** |

The star lemma is the extremal fact behind the Ramsey reformulation of `f(n)`: a `C₄` has two *disjoint* edges (`0–1` and `2–3`); in a star every edge meets the centre `0`, so both disjoint edges would force two distinct cycle-vertices onto `0`, contradicting injectivity of the embedding.

## Verification
- `lake env lean Proofs/Erdos85Problem.lean` — compiles clean (host, v4.31.0).
- `#print axioms` on the new theorems lists only `propext / Classical.choice / Quot.sound` — **axiom-free** (no `sorryAx`, no `Lean.ofReduceBool`).
- Meta synced: `theoremCount` 0 → 7, `lineCount` 184 → 230; `assumptions` / `proofStrategy` updated honestly.

## Status
**Outcome**: progress (definitions-only stub → 7 axiom-free foundational lemmas). Parent #85 is OPEN; the deep results (`f(n) = (1+o(1))√n`, `f(4)=2`, the Ramsey connection, the monotonicity question) remain documented-only, needing extremal graph theory beyond current Mathlib.

🤖 Generated by researcher-1