### PR TITLE
Enrich wilsons-theorem-oq-02-ext: fix section & annotation line-range drift

### DIFF
--- a/src/data/proofs/wilsons-theorem-oq-02-ext/annotations.json
+++ b/src/data/proofs/wilsons-theorem-oq-02-ext/annotations.json
@@ -26,7 +26,7 @@
   {
     "id": "ann-card-s-ge3",
     "proofId": "wilsons-theorem-oq-02-ext",
-    "range": { "startLine": 278, "endLine": 301 },
+    "range": { "startLine": 214, "endLine": 250 },
     "type": "theorem",
     "title": "card_sq_eq_one_ge_three_of_not_cyclic_zmod: 2-Torsion ≥ 3",
     "content": "For n ≥ 3 with (ZMod n)× non-cyclic: |{x : (ZMod n)× | x²=1}| ≥ 3. This imports the result from GaussWilsonNonCyclic: there exists a third square root of unity x ≠ ±1, giving the three distinct elements {1, -1, x} in the 2-torsion. The bound |S| ≥ 3 is needed for the two-involution trick to pick distinct c, d ∈ S\\{1}.",
@@ -38,7 +38,7 @@
   {
     "id": "ann-prod-eq-prod-sq",
     "proofId": "wilsons-theorem-oq-02-ext",
-    "range": { "startLine": 310, "endLine": 331 },
+    "range": { "startLine": 251, "endLine": 274 },
     "type": "theorem",
     "title": "prod_eq_prod_sq_eq_one: Reduction to 2-Torsion Product",
     "content": "In any finite commutative group G: ∏G = ∏{x : x²=1}. Proved by showing that units x with x² ≠ 1 pair with x⁻¹ ≠ x, each pair contributing x·x⁻¹ = 1 to the product. In Lean: use Finset.prod_pairing on the non-square-root units with σ(x) = x⁻¹ (which is FPF with pair product 1). The 2-torsion S = {x : x²=1} consists precisely of self-inverse elements, so they don't pair away — their product remains.",
@@ -50,7 +50,7 @@
   {
     "id": "ann-prod-non-cyclic",
     "proofId": "wilsons-theorem-oq-02-ext",
-    "range": { "startLine": 362, "endLine": 436 },
+    "range": { "startLine": 302, "endLine": 375 },
     "type": "theorem",
     "title": "prod_units_one_of_not_cyclic_ext: Two-Involution Trick",
     "content": "For n ≥ 3 with (ZMod n)× non-cyclic: ∏(ZMod n)× = 1. Proof: (1) Reduce to ∏S via prod_eq_prod_sq_eq_one. (2) From |S| ≥ 3, pick distinct c, d ∈ S\\{1}. (3) Involution x↦cx on S: x·cx = c^2 = 1 — wait, the pair product is x·(cx) = cx² = c·1 = c. So ∏S = c^(|S|/2) by prod_involution_const. (4) Involution x↦cdx on S: x·(cdx) = cdx² = cd. So ∏S = (cd)^(|S|/2) = c^(|S|/2)·d^(|S|/2). Equating (3) and (4): c^(|S|/2) = c^(|S|/2)·d^(|S|/2), so d^(|S|/2) = 1. By symmetry c^(|S|/2) = 1. Hence ∏S = c^(|S|/2) = 1.",
@@ -62,7 +62,7 @@
   {
     "id": "ann-gauss-wilson-abstract",
     "proofId": "wilsons-theorem-oq-02-ext",
-    "range": { "startLine": 490, "endLine": 538 },
+    "range": { "startLine": 410, "endLine": 421 },
     "type": "theorem",
     "title": "gaussWilson_abstract_ext: Complete Gauss-Wilson Characterization",
     "content": "For n ≥ 3: ∏(ZMod n)× = -1 ↔ IsCyclic (ZMod n)×. The two directions: (←) if (ZMod n)× is cyclic, prod_units_neg_one_of_cyclic' (Mathlib's Wilson infrastructure) gives ∏ = -1; (→) if non-cyclic, prod_units_one_of_not_cyclic_ext gives ∏ = 1 ≠ -1 (since n ≥ 3 implies -1 ≠ 1 in ZMod n). This is the full Gauss-Wilson theorem: the product characterizes cyclicity.",

--- a/src/data/proofs/wilsons-theorem-oq-02-ext/meta.json
+++ b/src/data/proofs/wilsons-theorem-oq-02-ext/meta.json
@@ -10,7 +10,7 @@
     "axiomCount": 0,
     "theoremCount": 22,
     "definitionCount": 1,
-    "lineCount": 539,
+    "lineCount": 461,
     "imports": [
       "Mathlib.NumberTheory.Wilson",
       "Mathlib.Data.Nat.Factorial.Basic",
@@ -40,35 +40,35 @@
       "id": "module-setup",
       "title": "Module Header and Imports",
       "startLine": 1,
-      "endLine": 57,
+      "endLine": 58,
       "summary": "Imports Mathlib's Wilson theorem infrastructure and the GaussWilsonNonCyclic module. Opens WilsonsTheoremOQ02Ext namespace. Module documentation explains the Gauss-Wilson theorem and the two-involution strategy."
     },
     {
       "id": "group-lemmas",
       "title": "Group-Theoretic Foundation: FPF Involutions and Products",
       "startLine": 59,
-      "endLine": 150,
+      "endLine": 213,
       "summary": "Two public theorems. even_card_of_fpf_involution: a fixed-point-free involution on a finite set forces even cardinality (proved by explicit pairing). prod_involution_const: in a finite commutative group with FPF involution σ satisfying x·σ(x) = c for all x, the product ∏G = c^(|G|/2). These are the abstract engines: each FPF involution gives a way to compute a product by pairing."
     },
     {
       "id": "non-cyclic-structure",
       "title": "Non-Cyclic Structure Lemmas (Third Square Roots)",
-      "startLine": 151,
-      "endLine": 301,
+      "startLine": 214,
+      "endLine": 250,
       "summary": "Private lemmas proving the 2-torsion lower bound for non-cyclic ZMod. Includes third square root constructions (CRT and power-of-2 cases, same as GaussWilsonNonCyclic), and the public card_sq_eq_one_ge_three_of_not_cyclic_zmod which extracts the bound from the import. These provide the ≥ 3 cardinality needed to pick distinct c, d in the two-involution trick."
     },
     {
       "id": "product-reduction",
       "title": "Product Reduction and Non-Cyclic Product Theorem",
-      "startLine": 303,
-      "endLine": 437,
+      "startLine": 251,
+      "endLine": 376,
       "summary": "prod_eq_prod_sq_eq_one: reduces ∏(ZMod n)× to ∏S (the 2-torsion) via pairing non-square-root units with their inverses. prod_units_one_of_not_cyclic_ext: the two-involution trick — pick distinct c, d ∈ S\\{1}; involution x↦cx gives ∏S = c^(|S|/2); involution x↦cdx gives (cd)^(|S|/2); combining forces d^(|S|/2) = 1, then c^(|S|/2) = 1, so ∏S = 1. Hence ∏(ZMod n)× = 1."
     },
     {
       "id": "main-theorem",
       "title": "Gauss-Wilson Complete Characterization",
-      "startLine": 438,
-      "endLine": 539,
+      "startLine": 377,
+      "endLine": 461,
       "summary": "gaussWilson_abstract_ext: for n ≥ 3, ∏(ZMod n)× = -1 ↔ IsCyclic (ZMod n)×. The two directions: (←) cyclic case uses Mathlib's Wilson theorem infrastructure (prod_units_neg_one_of_cyclic'); (→) non-cyclic case uses prod_units_one_of_not_cyclic_ext and the fact that 1 ≠ -1 for n ≥ 3. This gives the complete group-theoretic characterization of the Gauss-Wilson product."
     }
   ],
@@ -107,7 +107,7 @@
   ],
   "leanFile": {
     "path": "Proofs/WilsonsTheoremOQ02Ext.lean",
-    "lineCount": 539,
+    "lineCount": 461,
     "axiomCount": 0,
     "sorries": 0,
     "theoremCount": 22,


### PR DESCRIPTION
## Enrichment pass for `wilsons-theorem-oq-02-ext` (Gauss-Wilson Theorem)

Section/annotation line-range drift fix (the at-floor genuine work source; cf. #39486, #39535).

### Problem
`Proofs/WilsonsTheoremOQ02Ext.lean` was shortened from **539 → 461 lines**, but `meta.json` sections and `annotations.json` ranges still referenced the old numbers — **overshooting the end of the file by up to 78 lines**. Most conspicuously, the `gaussWilson_abstract_ext` annotation pointed at lines **490–538** (past EOF) while the theorem actually lives at line **412**.

### Changes
- **Sections** (5): realigned every `startLine`/`endLine` to actual `##`-header / declaration positions:
  - Module Header 1–58, Group-Theoretic Foundation 59–213, Non-Cyclic Structure Lemmas 214–250, Product Reduction 251–376, Gauss-Wilson Characterization 377–461.
- **Annotations** (4 of 6 drifted): `card_sq…` 278→214, `prod_eq_prod_sq…` 310→251, `prod_units_one…` 362→302, `gaussWilson…` 490→410. Each anchor verified to land on its described `theorem`.
- **lineCount**: `539 → 461` in both `meta` and `leanFile`.

Summaries and all content preserved; only line numbers changed.

### Verification
- `jq` confirms both JSON files valid.
- Every new anchor spot-checked against the Lean source (e.g. L214 = `card_sq_eq_one_ge_three_of_not_cyclic_zmod`, L412 = `gaussWilson_abstract_ext`).
- Axiom integrity unchanged: `status: verified`, `axiomCount: 0`, `sorries: 0` — all still accurate (this is a fully sorry-free file).