### PR TITLE
Enrich Necklace Burnside Sum in Divisor Form: fix header section coverage

### DIFF
--- a/src/data/proofs/burnside-counting-oq-03-oq-02-oq-01-oq-02/meta.json
+++ b/src/data/proofs/burnside-counting-oq-03-oq-02-oq-01-oq-02/meta.json
@@ -89,8 +89,8 @@
       "id": "header",
       "title": "Problem Statement and Results",
       "startLine": 1,
-      "endLine": 36,
-      "summary": "Module docstring: the parent's request to push the integer-form Burnside total to divisor form, and the three results — (D) the range-form identity Σ_{r<n} k^{gcd(n,r)} = Σ_{d∣n} φ(n/d) k^d, (E) its ZMod n version, and (F) the necklace count (#necklaces)·n = Σ_{d∣n} φ(n/d) k^d.",
+      "endLine": 45,
+      "summary": "Module docstring stating the parent's request to push the integer-form Burnside total to divisor form and the three results — (D) the range-form identity Σ_{r<n} k^{gcd(n,r)} = Σ_{d∣n} φ(n/d) k^d, (E) its ZMod n version, and (F) the necklace count (#necklaces)·n = Σ_{d∣n} φ(n/d) k^d — followed by the setup: import Mathlib and the parent file Proofs.BurnsideCountingOQ03OQ02OQ01, the Finset/BigOperators/MulAction opens, the namespace, and the open pulling in the parent's Rot, rotation, and sum_pow_gcd_eq_card_necklaces_mul.",
       "mathContext": "$\\sum_{r} k^{\\gcd(n,r)} = \\sum_{d\\mid n} \\varphi(n/d)\\,k^d$"
     },
     {


### PR DESCRIPTION
## Enrichment pass for `burnside-counting-oq-03-oq-02-oq-01-oq-02`

The entry is already rich and accurate (quality 96), so this is a targeted **section-coverage correctness fix** — the sanctioned at-floor work source, not accretion.

### Gap
The `header` section declared `endLine: 36`, but in the Lean file the module docstring closes at line 37 and the setup runs through line 45:
- `import Mathlib` + `import Proofs.BurnsideCountingOQ03OQ02OQ01` (38-39)
- `open Finset BigOperators MulAction` (41)
- `namespace BurnsideCountingOQ03OQ02OQ01OQ02` (43)
- `open BurnsideCountingOQ03OQ02OQ01 (...)` (45)

Section I begins at line 47. So **lines 37-46 were covered by no section.**

### Fix
- Extend `header` to `endLine: 45`, giving full section coverage of the 105-line file (header 1-45, Section I 47-65, Section II 67-86, Section III 88-105; single blank lines between).
- Expand the header `summary` to describe the import/open/namespace setup it now covers.

No math content changed; `status`/`badge`/`axiomCount` verified consistent with the Lean file (verified, original, 0 axioms).

### Validation
`pnpm build` gallery-data validators (`check-search-index`, `build-loading-facts`) pass on all entries; JSON validated with `jq`.