### PR TITLE
Enrich RH prime-gap bound: drop stale build-pending marker (rh-consequences-oq-02)

### DIFF
--- a/src/data/proofs/rh-consequences-oq-02/meta.json
+++ b/src/data/proofs/rh-consequences-oq-02/meta.json
@@ -25,7 +25,6 @@
     "lineCount": 197,
     "theoremCount": 7,
     "definitionCount": 3,
-    "buildStatus": "build-pending",
     "originalContributions": [
       "rh_implies_prime_gap_bound: PROVED (not axiomatized) — the honest elementary reduction from RH short-interval prime existence to the consecutive prime-gap bound p_{n+1} - p_n ≤ C·√p_n·log p_n, via the order-preserving enumeration of primes",
       "PrimeGapBoundRH: precise ∃C>0, ∀n, (p_{n+1}-p_n) ≤ C·√p_n·log p_n formalization of the conditional O(√p_n log p_n) gap bound",


### PR DESCRIPTION
## Enrichment pass for `rh-consequences-oq-02`

**Accuracy correction.** This entry (Cramér's RH ⇒ `p_{n+1} − p_n = O(√p_n·log p_n)`) is served on `main` as `status: axiomatized` / `badge: axiom` (1 axiom for the RH short-interval input, everything downstream machine-checked) following the completed v4.31 toolchain migration (epic #37508). Its meta still carried a bare transient commit-time marker `"buildStatus": "build-pending"` — the build has long since been confirmed (the entry is live on `main`), so the marker is stale and misleading.

### Change
- **Remove the stale `meta.buildStatus: "build-pending"` field.** It was the only 'pending' reference in the file; the `assumptions` field already accurately documents the single axiom and the machine-checked downstream results.

No mathematical content, counts, axiom accounting, or Lean source changed. JSON validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)