### PR TITLE
Enrich Lp Riesz (σ-finite, split): realign sections to the 47-line assembling file

### DIFF
--- a/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01-incomplete-01/meta.json
+++ b/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01-incomplete-01/meta.json
@@ -61,75 +61,19 @@
   "sections": [
     {
       "id": "overview",
-      "title": "Overview and Statement",
+      "title": "Overview, Split Rationale, and Imports",
       "startLine": 1,
-      "endLine": 42,
-      "summary": "Module header for the sigma-finite Riesz Lp representation theorem: states what is proved (Steps A localization, B Lp truncation convergence, C density extension), the dependency on σ-finiteness rather than finiteness of the measure, and references.",
-      "mathContext": "Riesz Lp representation for $\\sigma$-finite $\\mu$: every continuous functional on $L^p$ is $\\varphi(f) = \\int f g$ for some $g \\in L^q$, $1/p + 1/q = 1$."
-    },
-    {
-      "id": "helper-lemmas",
-      "title": "§0. Helper Lemmas",
-      "startLine": 43,
-      "endLine": 78,
-      "summary": "indicator_memLp_sf, lintegral_mul_le_sf (Hölder), integrable_mul_sf — all proved without IsFiniteMeasure.",
-      "mathContext": "Hölder's inequality for $L^p \\times L^q \\to L^1$ integrability holds for any measure. These lemmas isolate the minimal measure-theoretic content needed."
-    },
-    {
-      "id": "integration-clm",
-      "title": "§1. Integration CLM for Sigma-Finite Measures",
-      "startLine": 79,
-      "endLine": 119,
-      "summary": "integrationCLM_sf and integrationCLM_sf_apply: define and evaluate the integration functional Λ(f) = ∫ fg for SigmaFinite μ.",
-      "mathContext": "LinearMap.mkContinuous with Hölder bound. The IsFiniteMeasure hypothesis in the parent's integrationCLM was superfluous."
-    },
-    {
-      "id": "density-extension",
-      "title": "§2. Density Extension (Step C, Proved)",
-      "startLine": 120,
-      "endLine": 168,
-      "summary": "integral_representation_sf: if φ agrees with ∫ fg on indicators, then φ = ∫ fg everywhere. Uses Lp.induction (valid for SigmaFinite).",
-      "mathContext": "The proof is essentially the parent's integral_representation with IsFiniteMeasure dropped. Three cases: indicators, additivity, closedness. All work for sigma-finite."
-    },
-    {
-      "id": "spanning-set-lemmas",
-      "title": "§3. Spanning-Set Approximation Lemmas",
-      "startLine": 169,
-      "endLine": 189,
-      "summary": "mem_spanningSets_eventually and pointwise_mul_indicator_tendsto — proved, identical to parent entry.",
-      "mathContext": "Basic set-theoretic consequences of the sigma-finite exhaustion. Used in the proof of lp_truncation_tendsto_zero (Step B)."
-    },
-    {
-      "id": "lp-truncation",
-      "title": "§4. Lp Truncation Convergence (Step B, Proved)",
-      "startLine": 190,
-      "endLine": 238,
-      "summary": "lp_truncation_tendsto_zero: eLpNorm(f - f·1_{Sₙ}) → 0 via Vitali's convergence theorem.",
-      "mathContext": "unifIntegrable_const + unifTight_const + tendsto_Lp_of_tendsto_ae. Domination $|f - f\\cdot 1_{S_n}| \\le |f|$ propagates UI/UT from the constant-f sequence."
-    },
-    {
-      "id": "ext-by-zero-infra",
-      "title": "§4.5. Extension-by-Zero Infrastructure",
-      "startLine": 239,
-      "endLine": 317,
-      "summary": "Extension-by-zero machinery used by Step A: eLpNorm_indicator_eq_restrict_loc (eLpNorm of an indicator under μ equals eLpNorm under μ.restrict S), memLp_indicator_of_restrict_loc, and the continuous linear map extByZeroCLM : Lp(μ.restrict S) →L[ℝ] Lp(μ).",
-      "mathContext": "Extension-by-zero $L^p(\\mu\\!\\restriction\\! S) \\to L^p(\\mu)$ is an isometry: $\\lVert S.\\mathrm{indicator}\\,f\\rVert_{L^p(\\mu)} = \\lVert f\\rVert_{L^p(\\mu\\restriction S)}$. Bypasses the standard Lp.restrict_comap path."
-    },
-    {
-      "id": "localization",
-      "title": "§5. Localization (Step A, Proved)",
-      "startLine": 318,
-      "endLine": 928,
-      "summary": "localization_existence: constructs g ∈ Lq(μ) with indicator agreement on every finite-measure set. ~600 lines, fully proved without an Lp restriction map.",
-      "mathContext": "Classical Folland §6.2 proof, but the standard Lp.restrict_comap path was bypassed: extByZeroCLM (Lp(μ.restrict Sₙ) →L[ℝ] Lp(μ)) plus the Hölder-extremizer norm bound (truncation + lintegral_iSup MCT) plus ae_eq_of_forall_setIntegral_eq_of_sigmaFinite for cross-level consistency suffice. Global g built via Nat.find on the spanning-set cover; MemLp g via lintegral_iSup over Sₙ ↑ univ; indicator agreement extended from E ⊆ Sₙ to general E via Step B truncation + CLM continuity."
+      "endLine": 22,
+      "summary": "Module header, imports, and setup for the assembling file. Documents the S20 split (#35122): the 1012-line monolith was divided into this 47-line main file plus the Loc/Norm/Infra companions (all namespace RieszSigmaFiniteComplete, same public names), because the combined graph elaborated past the 32GB/40min Docker envelope so its error summary never flushed. This file imports the Loc companion (Step A) and states the assembled theorem; Steps A/B/C themselves live in the companion files listed in additionalFiles.",
+      "mathContext": "Riesz $L^p$ representation for $\\sigma$-finite $\\mu$: every continuous functional on $L^p$ is $\\varphi(f) = \\int f g$ for some $g \\in L^q$, $1/p + 1/q = 1$. Established here for any SigmaFinite measure — IsFiniteMeasure is not required."
     },
     {
       "id": "main-theorem",
       "title": "§6. Main Theorem (Assembled)",
-      "startLine": 929,
-      "endLine": 952,
-      "summary": "riesz_lp_surjective_sigma_finite: full Riesz Lp for sigma-finite, assembled from Steps A, B, and C — all three proved in this file.",
-      "mathContext": "Steps A (localization_existence), B (lp_truncation_tendsto_zero / pointwise_mul_indicator_tendsto), and C (integral_representation_sf) compose directly."
+      "startLine": 23,
+      "endLine": 47,
+      "summary": "riesz_lp_surjective_sigma_finite: the full sigma-finite Riesz Lp representation, assembled from the three steps proved in the companion files. It draws g and its indicator agreement from localization_existence (Step A, in the Loc companion), applies integral_representation_sf (Step C density extension via Lp.induction, in Infra) to promote indicator agreement to all f, and reconciles the two indicator encodings (indicator_memLp_sf vs memLp_indicator_const) by an rfl bridge (heq) before discharging via the Step A agreement. Step B (lp_truncation_tendsto_zero, Infra) supplies the truncation convergence that Step A uses to extend indicator agreement from E ⊆ Sₙ to arbitrary finite-measure E. All four files are 0-sorry / 0-axiom; the per-step mathematics is detailed in overview.keyInsights and the conclusion.",
+      "mathContext": "$\\varphi(f) = \\int f\\,g\\,d\\mu$ with $g \\in L^q$ and $\\lVert g\\rVert_q \\le \\lVert\\varphi\\rVert$. The assembly composes Step A (localization_existence, Loc), Step B (lp_truncation_tendsto_zero, Infra) and Step C (integral_representation_sf, Infra); the local `heq : rfl` identifies the two $L^p$ representatives of the finite-measure indicator $\\mathbf{1}_E$."
     }
   ],
   "openQuestions": [


### PR DESCRIPTION
## Enrichment pass — `cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01-incomplete-01`

**Defect:** stale `sections` after the S20 file split.

This entry's primary Lean file (`CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01.lean`) was split in #35122: the 1012-line monolith became a **47-line assembling file** that only states the main theorem, with Steps A/B/C moved into the `Loc`/`Norm`/`Infra` companions (already listed in `leanFile.additionalFiles`). The `sections` array was never updated — §0–§5 pointed to lines **43–928 that do not exist** in the 47-line file (`leanFile.lineCount: 47`).

**Fix:** realign `sections` to the actual file:
- `Overview, Split Rationale, and Imports` — lines 1–22 (header, split rationale, imports/setup)
- `§6. Main Theorem (Assembled)` — lines 23–47 (`riesz_lp_surjective_sigma_finite`)

No substantive content lost: the per-step (A localization / B truncation / C density-extension) detail the stale sections carried is preserved in `overview.keyInsights` and `conclusion` (untouched), and the companion files where that code now lives are in `additionalFiles`. The §6 summary now names which companion proves each step.

Verified: JSON parses, `max(endLine) == 47 == lineCount`, `pnpm build` regenerates the gallery data + search index cleanly. Only the target `meta.json` is staged (build re-serialization noise excluded).