### PR TITLE
audit: re-serve erdos-731 (axiomatized) — clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -15989,8 +15989,8 @@
     },
     "erdos-731": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:54:08Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-20T13:57:44Z",
       "result": "clean"
     },
     "erdos-732": {


### PR DESCRIPTION
## Reserve-mode audit — erdos-731

Queue drained (0 unaudited); re-serving the oldest uncontested target.

**Result: CLEAN.** All meta counts match the Lean source (`Proofs/Erdos731Problem.lean`):

| field | meta | source |
|-------|------|--------|
| sorries | 0 | 0 |
| axiomCount | 1 | 1 (`prime_divides_central_iff`) |
| theoremCount | 33 | 33 |
| definitionCount | 3 | 3 |
| lineCount | 439 | 439 |

- `status: axiomatized` / `badge: axiom` (Tier C) is appropriate — the core Kummer divisibility criterion is axiomatized.
- `native_decide` (9 uses) is disclosed in the Core Definitions section prose.
- Phantom source-comment names (`erdos_731_conjecture`, `egrs_typical_behavior`) are explicitly flagged "no Lean declaration exists" in the sections — no overclaim.
- `lower_bound_most_n` is a vacuous `True` stub but is not referenced/claimed as a real lower bound in any prose; the "lower bounds" claim is backed by real floor lemmas (`_ge_two`, `_ge_three`, `central_binom_lower`).

No integrity issues; only the audit-tracker timestamp/count is bumped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)