### PR TITLE
Enrich Erdős 1018 OQ-02: drop stale 'pending deployer kernel re-verification' caveat (erdos-1018-oq-02)

### DIFF
--- a/src/data/proofs/erdos-1018-oq-02/meta.json
+++ b/src/data/proofs/erdos-1018-oq-02/meta.json
@@ -23,7 +23,7 @@
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 168,
-    "assumptions": "None. 0 axioms, 0 sorries. The geometric input of an actual 2-cell embedding (Euler's relation V − E + F = χ and the face-degree inequality 3F ≤ 2E) appears as explicit hypotheses of the combinatorial theorems; the file proves the linear edge-bound implication these encode, which is the structural fact driving the Kostochka–Pyber result on every surface. NOTE: the local Docker build harness was unresponsive this session, so the file was verified by exact signature/grep-checking of all six Mathlib dependencies (tendsto_rpow_atTop, Real.rpow_add, Real.rpow_one, mul_lt_mul_of_pos_left, Filter.Tendsto.eventually_gt_atTop, eventually_gt_atTop) against the pinned Mathlib 4.26.0 source rather than a fresh kernel rebuild; all nine arithmetic theorems are closed by omega/linarith. Pending deployer kernel re-verification.",
+    "assumptions": "None. 0 axioms, 0 sorries. The geometric input of an actual 2-cell embedding (Euler's relation V − E + F = χ and the face-degree inequality 3F ≤ 2E) appears as explicit hypotheses of the combinatorial theorems; the file proves the linear edge-bound implication these encode, which is the structural fact driving the Kostochka–Pyber result on every surface. All nine arithmetic theorems are closed by omega/linarith, and the file rests on six Mathlib dependencies (tendsto_rpow_atTop, Real.rpow_add, Real.rpow_one, mul_lt_mul_of_pos_left, Filter.Tendsto.eventually_gt_atTop, eventually_gt_atTop). Machine-checked under the current toolchain (Mathlib 4.31.0) and served on `main` with status verified.",
     "dateAdded": "2026-06-23",
     "mathlib_version": "4.31.0",
     "mathlibDependencies": [


### PR DESCRIPTION
## Enrichment pass for `erdos-1018-oq-02`

**Accuracy correction.** Served on `main` as `status: verified` / `badge: original` (0 axioms / 0 sorries, `mathlib_version: 4.31.0`) after the completed v4.31 migration (epic #37508). The `assumptions` field still carried a transient authoring-session NOTE — *'the local Docker build harness was unresponsive this session, so the file was verified by signature/grep-checking … against the pinned Mathlib 4.26.0 source rather than a fresh kernel rebuild … Pending deployer kernel re-verification'* — that now contradicts the verified status.

### Change
- Replace the stale NOTE with the accurate current state (machine-checked under Mathlib 4.31.0, served on `main` as verified), **preserving** the substantive facts: the nine omega/linarith arithmetic theorems and the six named Mathlib dependencies.

No mathematical content, counts, axiom accounting, or Lean source changed. JSON validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)