### PR TITLE
Enrich Inclusion-Exclusion OQ-04-OQ-03: drop stale 'kernel build pending' caveat (inclusion-exclusion-oq-04-oq-03)

### DIFF
--- a/src/data/proofs/inclusion-exclusion-oq-04-oq-03/meta.json
+++ b/src/data/proofs/inclusion-exclusion-oq-04-oq-03/meta.json
@@ -72,7 +72,7 @@
     ],
     "axiomCount": 0,
     "lineCount": 284,
-    "assumptions": "0 axioms, 0 sorries, no native_decide; the file is self-contained (imports only Mathlib.Data.Finset.Powerset and Mathlib.Tactic) and the result holds for an arbitrary finite universe α, finite index type ι, and family A : ι → Finset α. Kernel build pending: the project's Docker build wrapper and the Aristotle service were both unavailable during the authoring session, so the file has not yet been machine-checked in this environment; the deployer's build gate must confirm a clean compile before this entry is treated as fully verified. The proof is a tight structural mirror of the already-verified gallery file InclusionExclusionSieveDerangementsBonferroni (with element x in place of permutation σ).",
+    "assumptions": "0 axioms, 0 sorries, no native_decide; the file is self-contained (imports only Mathlib.Data.Finset.Powerset and Mathlib.Tactic) and the result holds for an arbitrary finite universe α, finite index type ι, and family A : ι → Finset α. Machine-checked under the current toolchain and served on `main` with status verified. The proof is a tight structural mirror of the already-verified gallery file InclusionExclusionSieveDerangementsBonferroni (with element x in place of permutation σ).",
     "mathlib_version": "4.31.0",
     "theoremCount": 13,
     "definitionCount": 5


### PR DESCRIPTION
## Enrichment pass for `inclusion-exclusion-oq-04-oq-03`

**Accuracy correction.** Served on `main` as `status: verified` / `badge: original` (0 axioms / 0 sorries) after the completed v4.31 migration (epic #37508). The `assumptions` field still claimed *'Kernel build pending: … the file has not yet been machine-checked in this environment; the deployer's build gate must confirm a clean compile before this entry is treated as fully verified'* — a transient authoring-session caveat that directly contradicts the verified status.

### Change
- Replace the stale 'kernel build pending / not yet machine-checked' caveat with the accurate current state. The self-containment note (imports only `Mathlib.Data.Finset.Powerset` and `Mathlib.Tactic`; arbitrary finite α, ι) and the structural-mirror provenance (`InclusionExclusionSieveDerangementsBonferroni`) are preserved.

No mathematical content, counts, axiom accounting, or Lean source changed. JSON validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)