### PR TITLE
audit: erdos-667 — drop undisclosed native_decide axiom from p=3 theorems

### DIFF
--- a/proofs/Proofs/Erdos667Problem.lean
+++ b/proofs/Proofs/Erdos667Problem.lean
@@ -381,7 +381,7 @@ theorem p3_max : cpq 3 (Nat.choose 2 2 + 1) = 1 := cpq_at_max 3 (by omega)
 /-- For p = 3: the conjecture reduces to c(3,1) < c(3,2) = 1. -/
 theorem p3_strict : cpq 3 1 < cpq 3 2 := by
   have h2 : cpq 3 2 = 1 := by
-    have : Nat.choose 2 2 + 1 = 2 := by native_decide
+    have : Nat.choose 2 2 + 1 = 2 := by decide
     rw [← this]; exact cpq_at_max 3 (by omega)
   rw [h2]
   have := cpq_upper_ramsey 3 (by omega)
@@ -439,7 +439,7 @@ theorem erdos667_holds_for_p3 :
     ∀ q, 1 ≤ q → q < Nat.choose 2 2 + 1 → cpq 3 q < cpq 3 (q + 1) := by
   intro q hq1 hq_lt
   have hq_eq : q = 1 := by
-    have : Nat.choose 2 2 + 1 = 2 := by native_decide
+    have : Nat.choose 2 2 + 1 = 2 := by decide
     omega
   subst hq_eq
   exact p3_strict


### PR DESCRIPTION
## Integrity fix

**Proof**: erdos-667 (Clique Density Exponent c(p,q))

### Problem

`Proofs/Erdos667Problem.lean` proved the trivial fact `Nat.choose 2 2 + 1 = 2`
with `by native_decide` in two places (lines 384, 442). `native_decide` shifts
trust from the kernel to compiled code and injects a `Lean.ofReduceBool`-family
axiom. `#print axioms` confirmed this leaked into the p=3 results:

```
'Erdos667.p3_strict' depends on axioms: [propext, Classical.choice,
  cpq_at_max, cpq_upper_ramsey, Quot.sound, p3_strict._native.native_decide.ax_1_1]
'Erdos667.erdos667_holds_for_p3' depends on axioms: [..., erdos667_holds_for_p3._native.native_decide.ax_1_1, p3_strict._native.native_decide.ax_1_1]
```

These are exactly the theorems meta.json advertises as the **fully resolved p=3
case** (`p3_strict: complete resolution of the p=3 case`,
`erdos667_holds_for_p3`, "p=3 is FULLY resolved"). The compiler-trust axiom is
**not disclosed**: meta claims `axiomCount: 4` and "4 axiom declarations (deep
math results only) and 0 sorries".

### Fix

Replace `native_decide` with `decide` for `Nat.choose 2 2 + 1 = 2` (a trivially
decidable arithmetic identity). No `native_decide` remains in the file. After
the fix:

```
'Erdos667.p3_strict' depends on axioms: [propext, Classical.choice, cpq_at_max, cpq_upper_ramsey, Quot.sound]
'Erdos667.erdos667_holds_for_p3' depends on axioms: [propext, Classical.choice, cpq_at_max, cpq_upper_ramsey, Quot.sound]
```

The p=3 theorems now depend only on the standard axioms plus the 4 declared file
axioms — matching the public claim exactly. File compiles clean (`lake env lean`,
warnings only).

---
Discovered during gallery integrity audit.