### PR TITLE
Research: erdos-11-wip-01-oq-01 — representable set is infinite (axiom-free)

### DIFF
--- a/proofs/Proofs/Erdos11WIP01OQ01.lean
+++ b/proofs/Proofs/Erdos11WIP01OQ01.lean
@@ -20,6 +20,10 @@
     `n > 1` in the conjecture is genuinely needed at the boundary: the only
     candidate `2^0 = 1` would force the squarefree summand to be `0`, which is
     not squarefree.
+  * `infinite_setOf_isSquarefreePlusPow2` — the set `{n | IsSquarefreePlusPow2 n}`
+    is infinite.  Unconditional (independent of the open conjecture): every `p + 1`
+    with `p` prime is representable via the `k = 0` family, since `p` is squarefree,
+    and `p ↦ p + 1` is injective on the infinite set of primes.
 
   All results are fully machine-checked (0 axioms, 0 sorries).
 
@@ -61,8 +65,31 @@ theorem one_not_works : ¬ IsSquarefreePlusPow2 1 := by
     exact not_squarefree_zero hsf
   · exact absurd hle (by norm_num)
 
+/-- **The representable set is infinite.**  Beyond the specific values checked in the parent and
+the `k = 0` sufficient family above, the set of naturals that are squarefree + a power of two is
+genuinely infinite.  Witness: for every prime `p`, the successor `p + 1` is representable, because
+`(p + 1) − 2 ^ 0 = p` is squarefree (primes are squarefree).  The map `p ↦ p + 1` is injective on
+the infinite set of primes, so its image — a subset of the representable set — is infinite.
+This is an unconditional lower bound on the size of `{n | IsSquarefreePlusPow2 n}` that needs no
+appeal to the open conjecture (which would say the complement, among odd `n > 1`, is *empty*). -/
+theorem infinite_setOf_isSquarefreePlusPow2 :
+    {n | IsSquarefreePlusPow2 n}.Infinite := by
+  refine Set.infinite_of_injective_forall_mem
+    (f := fun p : Nat.Primes => (p : ℕ) + 1) ?_ ?_
+  · -- `p ↦ p + 1` is injective (successor of the injective coercion `Nat.Primes ↪ ℕ`)
+    intro a b h
+    exact Nat.Primes.coe_nat_injective (by simpa using h)
+  · -- every `p + 1` lies in the representable set, via the `k = 0` family with witness `p`
+    intro p
+    show IsSquarefreePlusPow2 ((p : ℕ) + 1)
+    refine works_of_pred_squarefree (by omega) ?_
+    have : (p : ℕ) + 1 - 1 = (p : ℕ) := by omega
+    rw [this]
+    exact p.2.prime.squarefree
+
 end Erdos11WIP01
 
 #print axioms Erdos11WIP01.decidableIsSquarefreePlusPow2
 #print axioms Erdos11WIP01.works_of_pred_squarefree
 #print axioms Erdos11WIP01.one_not_works
+#print axioms Erdos11WIP01.infinite_setOf_isSquarefreePlusPow2

--- a/src/data/proofs/erdos-11-wip-01-oq-01/meta.json
+++ b/src/data/proofs/erdos-11-wip-01-oq-01/meta.json
@@ -14,8 +14,8 @@
     ],
     "axiomCount": 0,
     "sorries": 0,
-    "lineCount": 68,
-    "theoremCount": 2,
+    "lineCount": 95,
+    "theoremCount": 3,
     "definitionCount": 0
   },
   "openQuestion": {
@@ -66,33 +66,41 @@
       "id": "header",
       "title": "Module Docstring and Import",
       "startLine": 1,
-      "endLine": 34,
+      "endLine": 37,
       "summary": "Docstring framing Erdős #11 (OPEN: is every odd n > 1 a squarefree number plus a power of two?) and this file's three contributions — the DecidablePred instance the parent only promised, the k = 0 sufficient family, and the n = 1 boundary. Imports the parent Erdos11WIP01 (which supplies isSquarefreePlusPow2_iff and squarefreePlusPow2_of_witness); namespace Erdos11WIP01, open Finset.",
       "mathContext": "IsSquarefreePlusPow2 n ⟺ ∃ k ∈ range (n+1), 2^k ≤ n ∧ Squarefree (n − 2^k); the parent's bounded characterization this file builds on."
     },
     {
       "id": "decidable",
       "title": "The Decidability Instance",
-      "startLine": 35,
-      "endLine": 41,
+      "startLine": 39,
+      "endLine": 45,
       "summary": "decidableIsSquarefreePlusPow2: the DecidablePred instance via decidable_of_iff and the parent's bounded characterization.",
       "mathContext": "IsSquarefreePlusPow2 n ↔ a finite search; the search is decidable, so the predicate is."
     },
     {
       "id": "family",
       "title": "Sufficient Family (k = 0)",
-      "startLine": 43,
-      "endLine": 51,
+      "startLine": 47,
+      "endLine": 54,
       "summary": "works_of_pred_squarefree: if n ≥ 1 and n − 1 is squarefree then n = (n−1) + 2^0 is representable.",
       "mathContext": "Squarefree (n−1) ⟹ IsSquarefreePlusPow2 n via the power of two 2^0 = 1."
     },
     {
       "id": "boundary",
       "title": "The n = 1 Boundary Fails",
-      "startLine": 53,
-      "endLine": 62,
+      "startLine": 56,
+      "endLine": 66,
       "summary": "one_not_works: 1 is not squarefree + a power of two; only 2^0 = 1 fits, forcing the squarefree summand to be 0 (not squarefree).",
       "mathContext": "No k ∈ {0,1} works: k=0 ⟹ Squarefree 0 (false); k=1 ⟹ 2 ≤ 1 (false)."
+    },
+    {
+      "id": "infinitude",
+      "title": "The Representable Set Is Infinite",
+      "startLine": 68,
+      "endLine": 89,
+      "summary": "infinite_setOf_isSquarefreePlusPow2: {n | IsSquarefreePlusPow2 n} is infinite, via the image of the primes under p ↦ p + 1.",
+      "mathContext": "Every prime p gives a representable p + 1 (p squarefree = (p+1) − 2⁰); injectivity of p ↦ p+1 on the infinite prime set forces an infinite representable set. Unconditional — does not use the open conjecture."
     }
   ],
   "mainTheorems": [
@@ -101,24 +109,32 @@
       "type": "core",
       "description": "**The DecidablePred instance the parent only named.** decidable_of_iff transports decidability across the parent's bounded equivalence isSquarefreePlusPow2_iff, which rewrites IsSquarefreePlusPow2 n to a finite search ∃ k ∈ range (n+1), 2^k ≤ n ∧ Squarefree (n − 2^k) whose body is decidable (Squarefree on ℕ). No new computation — decidability is pure transport.",
       "leanType": "DecidablePred IsSquarefreePlusPow2",
-      "startLine": 40,
-      "endLine": 41
+      "startLine": 44,
+      "endLine": 45
     },
     {
       "name": "works_of_pred_squarefree",
       "type": "key",
       "description": "**Sufficient family (k = 0).** If n ≥ 1 and n − 1 is squarefree then n = (n−1) + 2⁰ is representable — an infinite family of representable numbers requiring no search. Instantiates the parent's squarefreePlusPow2_of_witness at the power of two 2⁰ = 1.",
       "leanType": "{n : ℕ} → 1 ≤ n → Squarefree (n - 1) → IsSquarefreePlusPow2 n",
-      "startLine": 46,
-      "endLine": 50
+      "startLine": 50,
+      "endLine": 54
     },
     {
       "name": "one_not_works",
       "type": "key",
       "description": "**The n = 1 boundary fails.** 1 is not squarefree + a power of two: interval_cases leaves only k ∈ {0,1}; k = 0 forces the squarefree summand to be 1 − 1 = 0 (excluded by not_squarefree_zero) and k = 1 needs 2 ≤ 1 (false). Confirms the conjecture's n > 1 hypothesis is necessary.",
       "leanType": "¬ IsSquarefreePlusPow2 1",
-      "startLine": 55,
-      "endLine": 62
+      "startLine": 59,
+      "endLine": 66
+    },
+    {
+      "name": "infinite_setOf_isSquarefreePlusPow2",
+      "type": "key",
+      "description": "**The representable set is infinite.** Unconditional lower bound on {n | IsSquarefreePlusPow2 n}, independent of the open conjecture: every p + 1 with p prime is representable via the k = 0 family (p = (p+1) − 2⁰ is squarefree, as primes are squarefree), and p ↦ p + 1 is injective on the infinite set of primes (Nat.Primes), so the image is an infinite subset. Uses infinite_of_injective_forall_mem with Nat.Primes.coe_nat_injective and Prime.squarefree.",
+      "leanType": "{n | IsSquarefreePlusPow2 n}.Infinite",
+      "startLine": 75,
+      "endLine": 89
     }
   ],
   "conclusion": {
@@ -193,12 +209,13 @@
     "originalContributions": [
       "decidableIsSquarefreePlusPow2: the DecidablePred IsSquarefreePlusPow2 instance, via the parent's bounded characterization",
       "works_of_pred_squarefree: n − 1 squarefree ⟹ n representable (the 2^0 sufficient family)",
-      "one_not_works: 1 is not squarefree + a power of two (the n = 1 boundary case fails)"
+      "one_not_works: 1 is not squarefree + a power of two (the n = 1 boundary case fails)",
+      "infinite_setOf_isSquarefreePlusPow2: {n | IsSquarefreePlusPow2 n} is infinite — every p + 1 (p prime) is representable, unconditionally (independent of the open conjecture)"
     ],
     "axiomCount": 0,
-    "lineCount": 68,
+    "lineCount": 95,
     "assumptions": "0 axioms. Imports the verified parent erdos-11-wip-01 and standard Mathlib decidability/squarefree lemmas.",
-    "theoremCount": 2,
+    "theoremCount": 3,
     "definitionCount": 0
   },
   "sorries": 0


### PR DESCRIPTION
## Summary
Adds one axiom-free theorem to the Erdős #11 WIP-01/OQ-01 file: the set of
naturals that are a squarefree number plus a power of two is **infinite**.

## Progress
- `infinite_setOf_isSquarefreePlusPow2 : {n | IsSquarefreePlusPow2 n}.Infinite`.
  Witness: every `p + 1` with `p` prime is representable via the existing `k = 0`
  sufficient family (`p = (p+1) − 2⁰` is squarefree since primes are squarefree),
  and `p ↦ p + 1` is injective on the infinite prime set `Nat.Primes`, so the
  image is an infinite subset of the representable set.
- Files: `proofs/Proofs/Erdos11WIP01OQ01.lean` (+1 theorem), gallery meta
  (`theoremCount` 2→3, `lineCount` 68→95, new mainTheorem/section/contribution).

## Findings
- The bound is **unconditional** — it does not assume the open Erdős #11
  conjecture (which would say the *complement*, among odd `n > 1`, is empty).
  The file previously had only finite/pointwise sufficient conditions; this is
  the first infinitude statement.
- Mathlib API used: `Set.infinite_of_injective_forall_mem`,
  `Nat.Primes.coe_nat_injective`, `Prime.squarefree`.

## Verification
Host-verified (`lake env lean`, toolchain v4.31.0, Mathlib-only, no Docker):
0 sorries; `#print axioms` on the new theorem →
`[propext, Classical.choice, Quot.sound]` — axiom-free.

## Status
**Outcome**: progress (1 new axiom-free structural theorem)
**Next Steps**: a density/quantitative lower bound (count of representable
`n ≤ N`) via squarefree density, or a disjunctive small-witness sufficient family.

🤖 Generated by researcher-1