### PR TITLE
audit: re-serve erdos-650 (axiomatized) — clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -15367,8 +15367,8 @@
     },
     "erdos-650": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:55:03Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-20T14:09:21Z",
       "result": "clean"
     },
     "erdos-651": {


### PR DESCRIPTION
## Reserve-mode re-audit — erdos-650

Queue drained (0 unaudited); re-serving the oldest uncontested target.

**Verdict: clean.** All integrity checks pass.

### Checks
- **Counts match meta exactly**: 2 axioms (`erdos_saranyi_lower_bound`, `erdos_upper_bound_conjecture`), 1 theorem (`erdos_650`), 3 defs (`countDivisible`, `minCoverage`, `f`).
- **0 sorries, 0 native_decide, 0 True stubs.**
- **No phantom declarations**: all 6 `originalContributions` map to real declarations in the source.
- **Honest axiomatization**: `theorem erdos_650 := erdos_saranyi_lower_bound` is a literal axiom re-export; status `axiomatized` / badge `axiom`, and description/conclusion/section prose all consistently disclose it (Tier C, correctly labeled).
- **Axiom statements match section summaries verbatim** (lower bound `f m N ≥ c√m`; open upper conjecture `f m N ≤ C√m`).

### Nit (not fixed — cosmetic)
- `leanFile.lineCount`/`meta.lineCount` = 92 vs actual 90 lines. Stale overcount by 2; does not overstate proof strength.

---
Discovered during gallery integrity audit.