### PR TITLE
audit: re-serve erdos-881 (axiomatized) — clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -17112,8 +17112,8 @@
     },
     "erdos-881": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T00:18:20Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-20T14:11:54Z",
       "result": "clean"
     },
     "erdos-882": {


### PR DESCRIPTION
## Audit: erdos-881 (re-serve, reserve mode)

Queue drained (0 unaudited / 4807 total); re-served highest-priority uncontested target.

**Verified against `proofs/Proofs/Erdos881Problem.lean`:**
- 0 sorries, 1 axiom (`erdos_881` = the open conjecture) — matches `axiomCount: 1`, `sorries: 0`
- 8 theorems, 6 defs, lineCount 243 — all match meta
- Badge `axiom`, status `axiomatized`, `erdosProblemStatus: open` — honest disclosure
- `squares_basis_order_4` genuinely proved via Mathlib `Nat.sum_four_squares`; no `native_decide` / True stubs / `admit`
- `originalContributions` all map to real declarations

**Nits (understate our work → safe direction, not filed):**
1. `proofStrategy` prose says key theorems "use `sorry`" — reality is 1 named axiom + rest proved.
2. "Minimal Bases" section summary says "infinite axiom" / mathContext "Axiomatized" — but that section holds proved theorems (`finite_not_basis`, `minimal_basis_infinite`); the only axiom is `erdos_881` elsewhere.

Top-level integrity claims all accurate. Result: **clean**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)