### PR TITLE
Enrich Bell-numbers family: reconcile stale v4.26.0 compiled-against claim to v4.31.0

### DIFF
--- a/src/data/proofs/bell-numbers-oq-01-oq-01/meta.json
+++ b/src/data/proofs/bell-numbers-oq-01-oq-01/meta.json
@@ -169,7 +169,7 @@
     ],
     "axiomCount": 0,
     "lineCount": 157,
-    "assumptions": "0 axioms, 0 sorries, no native_decide. #print axioms reports only [propext, Classical.choice, Quot.sound] for the main results. Compiled against Mathlib v4.26.0. The EGF identity is classical; the contribution is the verified formalization via the ODE characterization, chosen because pinned Mathlib provides PowerSeries.subst but no substitution chain rule to differentiate the closed form exp(eˣ − 1) directly.",
+    "assumptions": "0 axioms, 0 sorries, no native_decide. #print axioms reports only [propext, Classical.choice, Quot.sound] for the main results. Compiled against Mathlib v4.31.0. The EGF identity is classical; the contribution is the verified formalization via the ODE characterization, chosen because pinned Mathlib provides PowerSeries.subst but no substitution chain rule to differentiate the closed form exp(eˣ − 1) directly.",
     "theoremCount": 6,
     "definitionCount": 1,
     "prerequisites": [

--- a/src/data/proofs/bell-numbers-oq-01-oq-02/meta.json
+++ b/src/data/proofs/bell-numbers-oq-01-oq-02/meta.json
@@ -185,7 +185,7 @@
     ],
     "axiomCount": 0,
     "lineCount": 209,
-    "assumptions": "0 axioms, 0 sorries, no native_decide. #print axioms reports only [propext, Classical.choice, Quot.sound] for the main results. Compiled against Mathlib v4.26.0. Dobiński's formula is classical; the contribution is the verified formalization, including the two supporting facts absent from pinned Mathlib (the falling-factorial expansion of powers and the telescoping falling-factorial series).",
+    "assumptions": "0 axioms, 0 sorries, no native_decide. #print axioms reports only [propext, Classical.choice, Quot.sound] for the main results. Compiled against Mathlib v4.31.0. Dobiński's formula is classical; the contribution is the verified formalization, including the two supporting facts absent from pinned Mathlib (the falling-factorial expansion of powers and the telescoping falling-factorial series).",
     "theoremCount": 6,
     "definitionCount": 0,
     "prerequisites": [

--- a/src/data/proofs/bell-numbers-oq-01/meta.json
+++ b/src/data/proofs/bell-numbers-oq-01/meta.json
@@ -180,7 +180,7 @@
     ],
     "axiomCount": 0,
     "lineCount": 120,
-    "assumptions": "0 axioms, 0 sorries, no native_decide. #print axioms reports only [propext, Classical.choice, Quot.sound] for stirlingSecond_horizontal and bell_eq_sum_stirlingSecond. Compiled against Mathlib v4.26.0. The row-sum identity is classical; the horizontal Stirling recurrence used as the bridge is not present in pinned Mathlib and is proved from scratch.",
+    "assumptions": "0 axioms, 0 sorries, no native_decide. #print axioms reports only [propext, Classical.choice, Quot.sound] for stirlingSecond_horizontal and bell_eq_sum_stirlingSecond. Compiled against Mathlib v4.31.0. The row-sum identity is classical; the horizontal Stirling recurrence used as the bridge is not present in pinned Mathlib and is proved from scratch.",
     "theoremCount": 2,
     "definitionCount": 0,
     "prerequisites": [


### PR DESCRIPTION
## Summary

Three sibling entries in the Bell-numbers family carried a stale toolchain claim after the #37508 migration:

- \`bell-numbers-oq-01\`
- \`bell-numbers-oq-01-oq-01\`
- \`bell-numbers-oq-01-oq-02\`

Each has \`meta.mathlib_version: "4.31.0"\` and \`status: "verified"\` (migrated green on main), yet each \`assumptions\` field still stated **"Compiled against Mathlib v4.26.0"** — a stale verification-toolchain claim left by the migration meta-sweep, contradicting the version field.

## Change

Updated the compiled-against version \`v4.26.0\` → \`v4.31.0\` in all three \`assumptions\` fields, matching each entry's \`meta.mathlib_version\`.

- The version-agnostic "pinned Mathlib" gap notes (e.g. "pinned Mathlib provides PowerSeries.subst but no substitution chain rule…") are deliberately **left untouched** — they describe a Mathlib API gap, not a toolchain version, so they remain accurate.
- No axiom/sorry/status changes (all remain 0-axiom, 0-sorry, verified).
- No mathematical content added or removed — correctness reconciliation only.
- JSON validated with \`jq\`; 0 remaining \`v4.26\` mentions in all three metas.