### PR TITLE
Enrich carnot-theorem-oq-01-oq-02: correct stale unverified caveat

### DIFF
--- a/src/data/proofs/carnot-theorem-oq-01-oq-02/meta.json
+++ b/src/data/proofs/carnot-theorem-oq-01-oq-02/meta.json
@@ -55,7 +55,7 @@
     "dateAdded": "2026-06-23",
     "axiomCount": 0,
     "lineCount": 163,
-    "assumptions": "0 axioms. 0 sorries. The only hypotheses are the triangle conditions A, B, C > 0 and the angle-sum relation A + B + C = π. Builds on the parent file Proofs/CarnotTheorem.lean (itself axiom-free). Note: local kernel verification was blocked by an unresponsive Docker build host this session; the proof uses only verified Mathlib v4.26.0 lemma signatures (grep-confirmed against the pinned toolchain) and is gated by the deployer build before merge.",
+    "assumptions": "0 axioms. 0 sorries. The only hypotheses are the triangle conditions A, B, C > 0 and the angle-sum relation A + B + C = π. Builds on the parent file Proofs/CarnotTheorem.lean (itself axiom-free). Machine-checked under the pinned Lean/Mathlib toolchain v4.31.0: all six results (cos_pos_of_lt, cos_sq_sum, cos_sq_sum_eq_one_of_right, cos_sq_sum_lt_one_of_acute, cos_sq_sum_gt_one_of_obtuse, cos_sq_sum_lt_one_iff_acute) elaborate with no errors, and #print axioms reports each capstone theorem depends only on the foundational axioms propext, Classical.choice, Quot.sound — no native_decide, no Lean.ofReduceBool, no sorryAx.",
     "mathlib_version": "4.31.0",
     "theoremCount": 7,
     "definitionCount": 0


### PR DESCRIPTION
## Enrichment pass for `carnot-theorem-oq-01-oq-02`

Corrects a stale, migration-era caveat in `meta.meta.assumptions`. The entry is `status: verified`, `axiomCount: 0`, but its assumptions note still claimed:

> local kernel verification was blocked by an unresponsive Docker build host this session; the proof uses only verified Mathlib **v4.26.0** lemma signatures ... and is gated by the deployer build before merge.

### Verification performed
Host-verified under the pinned toolchain **v4.31.0** (no Docker):
1. Built the parent olean fresh: `lake env lean -o .lake/build/lib/lean/Proofs/CarnotTheorem.olean Proofs/CarnotTheorem.lean` → exit 0.
2. Compiled the child `Proofs/CarnotTheoremOQ01OQ02.lean` → exit 0 (only harmless `push_neg` deprecation warnings).
3. `#print axioms` on each capstone theorem:
   - `cos_sq_sum_lt_one_iff_acute`, `cos_sq_sum_eq_one_of_right`, `cos_sq_sum_lt_one_of_acute`, `cos_sq_sum_gt_one_of_obtuse` each depend only on `[propext, Classical.choice, Quot.sound]`.
   - No `native_decide`, no `Lean.ofReduceBool`, no `sorryAx`.

The new text states the actual v4.31.0 verification result. No other fields changed; the entry was already at the gallery quality floor. This is the stale-`assumptions`-caveat work class (cf. #39509, #39507).

🤖 Generated with [Claude Code](https://claude.com/claude-code)