### PR TITLE
Research: erdos-191 — retire tripleLog_unbounded axiom (4→3, axiom-free)

### DIFF
--- a/proofs/Proofs/Erdos191Incomplete01.lean
+++ b/proofs/Proofs/Erdos191Incomplete01.lean
@@ -17,11 +17,12 @@ import Mathlib
   `atTop`, and the threefold composition therefore tends to `atTop`; a `Tendsto …
   atTop` statement immediately gives the `∀ M, ∃ N, ∀ n ≥ N, … > M` form.
 
-  (Proved standalone because `Erdos191Problem.lean` does not currently compile
-  against this Mathlib under its declared imports — several supporting imports,
-  e.g. `Real.log_two_gt_d9` and `rpow`, are missing there — so this entry
-  re-states `tripleLog` and supplies the elementary divergence axiom-free,
-  ready to drop in once those imports are repaired.)
+  (Originally proved standalone because `Erdos191Problem.lean` was reported not
+  to compile under its declared imports. That is no longer the case: the parent
+  now compiles under `import Mathlib`, and this axiom-free proof has been dropped
+  in there — `tripleLog_unbounded` is now a `theorem` in `Erdos191Problem.lean`,
+  retiring one of that entry's four axioms. This file is kept as the minimal
+  self-contained witness of the divergence argument.)
 
   ## Results
   * `tripleLog_tendsto_atTop` : `log(log(log n)) → ∞`.

--- a/proofs/Proofs/Erdos191Problem.lean
+++ b/proofs/Proofs/Erdos191Problem.lean
@@ -194,9 +194,31 @@ lemma cfs_constant : (1 : ℝ) / 256 = 2^(-(8 : ℝ)) := by norm_num
 -/
 
 /--
-**Triple log grows unboundedly.**
+**Triple log tends to `atTop`.** `log(log(log n)) → ∞` as `n → ∞`: the cast
+`ℕ → ℝ` tends to `atTop`, and `Real.log` preserves `atTop`, so the threefold
+composition does too.
 -/
-axiom tripleLog_unbounded : ∀ M : ℝ, ∃ N : ℕ, ∀ n ≥ N, tripleLog n > M
+theorem tripleLog_tendsto_atTop :
+    Filter.Tendsto (fun n : ℕ => tripleLog n) Filter.atTop Filter.atTop := by
+  have hcast : Filter.Tendsto (fun n : ℕ => (n : ℝ)) Filter.atTop Filter.atTop :=
+    tendsto_natCast_atTop_atTop
+  have h :=
+    Real.tendsto_log_atTop.comp
+      (Real.tendsto_log_atTop.comp (Real.tendsto_log_atTop.comp hcast))
+  simpa only [Function.comp_def, tripleLog] using h
+
+/--
+**Triple log grows unboundedly.** For every threshold `M` there is `N` beyond
+which `tripleLog n > M`. Formerly an `axiom`; now proved axiom-free from
+`tripleLog_tendsto_atTop` (the elementary divergence of `log log log n`),
+retiring one of this entry's four assumptions.
+-/
+theorem tripleLog_unbounded : ∀ M : ℝ, ∃ N : ℕ, ∀ n ≥ N, tripleLog n > M := by
+  intro M
+  have h := tripleLog_tendsto_atTop.eventually (Filter.eventually_gt_atTop M)
+  rw [Filter.eventually_atTop] at h
+  obtain ⟨N, hN⟩ := h
+  exact ⟨N, fun n hn => hN n hn⟩
 
 /--
 **The main theorem follows from CFS bound + unboundedness of triple log.**

--- a/src/data/proofs/erdos-191/meta.json
+++ b/src/data/proofs/erdos-191/meta.json
@@ -68,9 +68,9 @@
         "relationship": "Related additive combinatorics: squarefree sumsets use similar sieve techniques"
       }
     ],
-    "axiomCount": 4,
+    "axiomCount": 3,
     "lineCount": 414,
-    "assumptions": "4 axioms: erdos_191, rodl_upper_construction, conlon_fox_sudakov_bound, tripleLog_unbounded. 0 sorries.",
+    "assumptions": "3 axioms: erdos_191, rodl_upper_construction, conlon_fox_sudakov_bound (the deep results of Erdős, Rödl, and Conlon–Fox–Sudakov). 0 sorries. The former fourth axiom tripleLog_unbounded (log log log n → ∞) is now proved axiom-free via tripleLog_tendsto_atTop.",
     "theoremCount": 10,
     "definitionCount": 13
   },
@@ -218,8 +218,8 @@
     ],
     "namespace": "Erdos191",
     "lineCount": 414,
-    "axiomCount": 4,
-    "theoremCount": 10,
+    "axiomCount": 3,
+    "theoremCount": 12,
     "definitionCount": 13,
     "path": "Proofs/Erdos191Problem.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

The gallery entry **erdos-191** (`Erdos191Problem.lean`) carried **four axioms**. One of them — `tripleLog_unbounded`, the statement that `log log log n → ∞` in `∀ M, ∃ N, ∀ n ≥ N, tripleLog n > M` form — is **elementary, not deep**. This PR proves it axiom-free and drops it into the parent, retiring the axiom.

**Axiom count: 4 → 3.**

## What changed

- **`tripleLog_tendsto_atTop`** (new theorem): the cast `ℕ → ℝ` tends to `atTop`, and `Real.log` preserves `atTop`, so the threefold composition `log(log(log n))` does too.
- **`tripleLog_unbounded`**: `axiom` → `theorem`, derived from the `Tendsto … atTop` statement via `eventually_gt_atTop` / `eventually_atTop`.
- **`Erdos191Incomplete01.lean`**: corrected a now-stale docstring note (it claimed the parent "does not currently compile" — no longer true; the drop-in is complete). That file remains as the minimal self-contained witness of the divergence argument.
- **`meta.json`**: `axiomCount` 4→3, `leanFile.theoremCount`→12, `assumptions` prose updated.

## Verification

Host-verified with `lake env lean` under **v4.31.0** (Mathlib-only file, no Docker):

- Clean compile, `EXIT=0` (only two **pre-existing** `unusedVariables` warnings, unrelated to this change).
- `#print axioms`:
  - `Erdos191.tripleLog_unbounded` → `[propext, Classical.choice, Quot.sound]`
  - `Erdos191.tripleLog_tendsto_atTop` → `[propext, Classical.choice, Quot.sound]`
  - No `sorryAx`, no `Lean.ofReduceBool` — genuinely axiom-free.

## Remaining assumptions

The three remaining axioms are the genuinely deep results: `erdos_191` (Erdős), `rodl_upper_construction` (Rödl), `conlon_fox_sudakov_bound` (Conlon–Fox–Sudakov). Those are irreducible literature inputs, not Mathlib-derivable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)