### PR TITLE
audit: erdos-65 — drop 6 phantom declarations from section prose

### DIFF
--- a/src/data/proofs/erdos-65/meta.json
+++ b/src/data/proofs/erdos-65/meta.json
@@ -88,26 +88,26 @@
     {
       "id": "bipartite-structure",
       "title": "Complete Bipartite Cycle Structure",
-      "summary": "complete_bipartite_cycle_lengths, bipartiteCycleSum, bipartiteCycleSum_eq",
+      "summary": "bipartiteCycleSum definition (reciprocal sum for K_{r,s}); explanatory prose on complete bipartite cycle structure",
       "startLine": 132,
       "endLine": 160,
-      "mathContext": "Mathematical content: complete_bipartite_cycle_lengths, bipartiteCycleSum, bipartiteCycleSum_eq"
+      "mathContext": "Mathematical content: bipartiteCycleSum definition; prose on K_{r,s} cycle structure (no theorems proved here)"
     },
     {
       "id": "lower-bounds",
       "title": "Lower Bounds on Cycle Variety",
-      "summary": "min_degree_implies_short_cycle, high_avg_to_min_degree, Zarankiewicz connection",
+      "summary": "Explanatory prose: Zarankiewicz / Kővári-Sós-Turán connection and remarks on why complete bipartite graphs might minimize the sum (no formal theorems)",
       "startLine": 161,
       "endLine": 202,
-      "mathContext": "Mathematical content: min_degree_implies_short_cycle, high_avg_to_min_degree, Zarankiewicz connection"
+      "mathContext": "Expository comments on the Zarankiewicz connection and the open minimization question; no theorems are proved in this range"
     },
     {
       "id": "special-cases",
       "title": "Special Cases",
-      "summary": "density_one_has_cycle, triangle_free_larger_sum, bipartite parity",
+      "summary": "odd_cycle_positive_contribution (proves 1/k > 0 for an odd cycle length k ≥ 3); prose on density-one cycle existence and bipartite parity",
       "startLine": 203,
       "endLine": 217,
-      "mathContext": "Mathematical content: density_one_has_cycle, triangle_free_larger_sum, bipartite parity"
+      "mathContext": "Mathematical content: odd_cycle_positive_contribution theorem; expository notes on density-one cycles and bipartite parity"
     }
   ],
   "conclusion": {
@@ -163,7 +163,7 @@
       "year": "1984",
       "volume": "44",
       "pages": "283–293",
-      "note": "Proves Σ 1/aᵢ ≥ c·log(e/n) for graphs with e edges; the GKS theorem axiomatized in this formalization."
+      "note": "Proves Σ 1/aᵢ ≥ c·log(e/n) for graphs with e edges; the GKS theorem is referenced as background context in this formalization, not axiomatized or formalized (the file is axiom-free)."
     },
     {
       "authors": [


### PR DESCRIPTION
## Integrity Issue

**Proof**: erdos-65 (Cycle Lengths in Dense Graphs)
**Problem**: Section summaries cite six theorem names that do not exist in `proofs/Proofs/Erdos65Problem.lean`, overstating what is formally proved. Status is `verified`.

## Evidence

The file contains **9 definitions** and exactly **1 theorem** (`odd_cycle_positive_contribution`, proving `1/k > 0` for an odd cycle length `k ≥ 3`). Verified counts: 0 axioms, 0 sorries, 9 defs, 1 theorem, 217 lines — all correct.

But three section summaries invented declaration names (`grep` count = 0 in the file):

- **Complete Bipartite Cycle Structure**: `complete_bipartite_cycle_lengths`, `bipartiteCycleSum_eq` (only the `bipartiteCycleSum` *definition* exists)
- **Lower Bounds on Cycle Variety**: `min_degree_implies_short_cycle`, `high_avg_to_min_degree` (lines 161–202 are pure comments)
- **Special Cases**: `density_one_has_cycle`, `triangle_free_larger_sum` (lines 203–217 are comments + the one real theorem)

The only real theorem was mentioned by no section. A reader would believe the file formally verifies lower bounds and special cases about cycle variety; it does not.

Additionally, the GKS reference note said "the GKS theorem axiomatized in this formalization" — false; the file is axiom-free and `proofStrategy` correctly states GKS is background-only.

## Fix Applied

Rewrote the three section summaries to reflect actual content (one positivity lemma + expository prose) and corrected the GKS reference note. Counts unchanged (already accurate).

---
Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)