### PR TITLE
Research: erdos-98-wip-01 — distinct-distance counting envelope (axiom-free)

### DIFF
--- a/proofs/Proofs/Erdos98WIP01.lean
+++ b/proofs/Proofs/Erdos98WIP01.lean
@@ -1,0 +1,124 @@
+import Mathlib
+import Proofs.Erdos98Problem
+
+/-
+# Erdős #98 — foundational counting bounds for distinct distances in general position
+# (erdos-98-wip-01)
+
+## The Problem
+
+**Erdős Problem #98** (OPEN). Let `h(n)` be the minimum number of distinct
+distances determined by `n` points in `ℝ²` in *general position* — no three
+collinear and no four concyclic. Erdős asked whether `h(n)/n → ∞`; he could not
+even prove `h(n) ≥ n`.
+
+The scaffold `Erdos98Problem.lean` sets up the objects — `PointConfig`,
+`NoThreeCollinear`, `NoFourConcyclic`, `InGeneralPosition`,
+`numDistinctDistances`, and `h` — but proves **no theorems**. This file supplies
+the first structural theorems: the elementary counting envelope that pins the
+distinct-distance count between the trivial bounds, and the link between a
+concrete configuration and the extremal quantity `h`.
+
+## Results
+
+1. `InGeneralPosition.injective` — a general-position configuration is injective
+   (the first conjunct), so its `n` points are genuinely distinct.
+
+2. `numDistinctDistances_le_offDiag` — the count of distinct (positive) distances
+   is at most `n·(n−1)`: every positive distance is realized by an *off-diagonal*
+   pair `(i, j)` with `i ≠ j`, and there are `n·(n−1)` such ordered pairs.
+
+3. `numDistinctDistances_eq_zero_of_le_one` — fewer than two points determine no
+   positive distance (`n ≤ 1 ⟹ 0`), the degenerate floor of the envelope.
+
+4. `one_le_numDistinctDistances_of_injective` — conversely, two or more *distinct*
+   points always determine at least one positive distance (`2 ≤ n ⟹ ≥ 1`).
+
+5. `h_le_of_inGeneralPosition` — every general-position configuration is a witness
+   bounding the minimum from above: `h n ≤ numDistinctDistances P`. This is the
+   `Nat.sInf`-membership fact that any upper-bound construction (Pach's
+   `n^{log₂ 3}`, Erdős–Füredi–Pach's `n·exp(c√log n)`) ultimately feeds.
+
+## Summary: 0 sorries, 0 axioms, no `native_decide`. Built over the gallery defs.
+-/
+
+open Finset
+
+namespace Erdos98WIP01
+
+variable {n : ℕ}
+
+/-- A general-position configuration is injective (its `n` points are distinct). -/
+theorem InGeneralPosition.injective {P : PointConfig n}
+    (h : InGeneralPosition P) : Function.Injective P :=
+  h.1
+
+/-- **Upper envelope.** The number of distinct positive distances is at most
+`n·(n−1)`: a positive distance can only come from an off-diagonal pair. -/
+theorem numDistinctDistances_le_offDiag (P : PointConfig n) :
+    numDistinctDistances P ≤ n * (n - 1) := by
+  -- Unfold the definition to a filtered image over all ordered pairs.
+  unfold numDistinctDistances
+  set f : Fin n × Fin n → ℝ := fun p => dist (P p.1) (P p.2) with hf
+  -- The filtered image is contained in the image of the off-diagonal.
+  have hsub :
+      ((univ.product univ).image f).filter (· > 0) ⊆
+        (univ.offDiag).image f := by
+    intro d hd
+    rw [mem_filter, mem_image] at hd
+    obtain ⟨⟨p, _, hpd⟩, hpos⟩ := hd
+    -- `d > 0` forces `f p > 0`, hence the two points differ, hence `p.1 ≠ p.2`.
+    rw [mem_image]
+    refine ⟨p, ?_, hpd⟩
+    rw [mem_offDiag]
+    have hposp : (0 : ℝ) < f p := by rw [hpd]; exact hpos
+    have hne : P p.1 ≠ P p.2 := by
+      have := dist_pos.mp hposp
+      simpa [hf] using this
+    refine ⟨mem_univ _, mem_univ _, ?_⟩
+    intro hpp
+    exact hne (by rw [hpp])
+  -- Card monotonicity through the subset and the image, then count the off-diagonal.
+  calc (((univ.product univ).image f).filter (· > 0)).card
+      ≤ ((univ.offDiag).image f).card := card_le_card hsub
+    _ ≤ (univ.offDiag).card := card_image_le
+    _ = n * (n - 1) := by
+        rw [Finset.offDiag_card, card_univ, Fintype.card_fin, Nat.mul_sub_one]
+
+/-- Fewer than two points determine no positive distance. -/
+theorem numDistinctDistances_eq_zero_of_le_one (P : PointConfig n) (hn : n ≤ 1) :
+    numDistinctDistances P = 0 := by
+  have hb := numDistinctDistances_le_offDiag P
+  have hz : n * (n - 1) = 0 := by interval_cases n <;> rfl
+  omega
+
+/-- Two or more distinct points determine at least one positive distance. -/
+theorem one_le_numDistinctDistances_of_injective (P : PointConfig n)
+    (hinj : Function.Injective P) (hn : 2 ≤ n) :
+    1 ≤ numDistinctDistances P := by
+  unfold numDistinctDistances
+  set f : Fin n × Fin n → ℝ := fun p => dist (P p.1) (P p.2) with hf
+  -- Two distinct indices `i ≠ j` exist since `2 ≤ n`.
+  have hi : (0 : ℕ) < n := by omega
+  have hj : (1 : ℕ) < n := by omega
+  let i : Fin n := ⟨0, hi⟩
+  let j : Fin n := ⟨1, hj⟩
+  have hij : i ≠ j := by simp [i, j, Fin.ext_iff]
+  -- Their distance is positive (points distinct because `P` is injective).
+  have hpts : P i ≠ P j := fun h => hij (hinj h)
+  have hpos : (0 : ℝ) < f (i, j) := by
+    have := dist_pos.mpr hpts
+    simpa [hf] using this
+  -- Hence the filtered image is nonempty.
+  have hmem : f (i, j) ∈ ((univ.product univ).image f).filter (· > 0) := by
+    rw [mem_filter, mem_image]
+    exact ⟨⟨(i, j), by simp, rfl⟩, hpos⟩
+  exact card_pos.mpr ⟨_, hmem⟩
+
+/-- **The extremal witness fact.** Every general-position configuration bounds the
+minimum distinct-distance count `h n` from above. -/
+theorem h_le_of_inGeneralPosition {P : PointConfig n}
+    (hgp : InGeneralPosition P) : h n ≤ numDistinctDistances P :=
+  Nat.sInf_le ⟨P, hgp, rfl⟩
+
+end Erdos98WIP01

--- a/research/problems/erdos-98-wip-01/knowledge.md
+++ b/research/problems/erdos-98-wip-01/knowledge.md
@@ -19,3 +19,39 @@ Insights accumulated during research on this problem.
 ## Dead Ends
 
 [Approaches known not to work will be documented here]
+
+---
+
+## Session (researcher-1, 2026-07-20) — first machine-checked theorems (axiom-free)
+
+Created `proofs/Proofs/Erdos98WIP01.lean` (5 theorems, 0 sorry, 0 axiom;
+host-verified `bin/lake env lean` exit 0, `#print axioms` = `[propext,
+Classical.choice, Quot.sound]` on all — no `sorryAx`, no `ofReduceBool`). The
+scaffold `Erdos98Problem.lean` had only definitions; this file proves the first
+structural facts about `numDistinctDistances` and `h`.
+
+The **counting envelope** that any analysis of `h(n)` sits inside:
+
+- `numDistinctDistances_le_offDiag` — `numDistinctDistances P ≤ n·(n−1)`. A
+  positive distance forces `P i ≠ P j` (`dist_pos`), hence `i ≠ j`, so the
+  distinct positive distances embed into `Finset.image f univ.offDiag`; count via
+  `Finset.offDiag_card` and `Nat.mul_sub_one`.
+- `numDistinctDistances_eq_zero_of_le_one` — degenerate floor `n ≤ 1 ⟹ 0`.
+- `one_le_numDistinctDistances_of_injective` — for injective `P`, `2 ≤ n ⟹ ≥ 1`
+  (exhibit indices `0 ≠ 1`, distinct images, positive distance).
+- `InGeneralPosition.injective` — general position ⟹ injective (first conjunct).
+- `h_le_of_inGeneralPosition` — `h n ≤ numDistinctDistances P` via `Nat.sInf_le
+  ⟨P, hgp, rfl⟩`: every general-position configuration is an upper-bound witness
+  for the minimum. This is the membership hook every known upper-bound
+  construction (Pach `n^{log₂3}`, Erdős–Füredi–Pach `n·exp(c√log n)`) supplies.
+
+### Verification
+Parent `Erdos98Problem.lean` fresh-built to olean host-side (Mathlib-only, v4.31,
+docker-free), then child compiled against it. Exit 0, no warnings.
+
+### Next Steps
+- Sharpen the upper envelope to `numDistinctDistances P ≤ n.choose 2` using the
+  symmetry `dist (P i) (P j) = dist (P j) (P i)` (image over `{i < j}` pairs).
+- A lower bound beyond `1`: the elementary Erdős pigeonhole `≥ √(n − 3/4) − 1/2`
+  distinct distances (needs the max-degree-of-a-distance argument) would be the
+  first genuinely superconstant floor.

--- a/src/data/research/problems/erdos-98-wip-01.json
+++ b/src/data/research/problems/erdos-98-wip-01.json
@@ -1,7 +1,7 @@
 {
   "slug": "erdos-98-wip-01",
   "title": "Complete the Erdős #98 General-Position Distances Formalization",
-  "phase": "OBSERVE",
+  "phase": "ACT",
   "status": "active",
   "tier": "A",
   "path": "full",
@@ -31,9 +31,19 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
+    "progressSummary": "PROGRESS: Created Erdos98WIP01.lean — first machine-checked theorems for the #98 general-position distinct-distances scaffold. Axiom-free counting envelope (0 ≤ numDistinctDistances ≤ n·(n−1)) plus the h(n) sInf-membership upper-bound fact.",
+    "builtItems": [
+      "InGeneralPosition.injective in Erdos98WIP01.lean",
+      "numDistinctDistances_le_offDiag (≤ n·(n−1)) in Erdos98WIP01.lean",
+      "numDistinctDistances_eq_zero_of_le_one in Erdos98WIP01.lean",
+      "one_le_numDistinctDistances_of_injective (n≥2 ⟹ ≥1) in Erdos98WIP01.lean",
+      "h_le_of_inGeneralPosition (h n ≤ numDistinctDistances P) in Erdos98WIP01.lean"
+    ],
+    "insights": [
+      "Every positive pairwise distance comes from an off-diagonal ordered pair (dist>0 ⟹ points distinct ⟹ indices distinct), giving the clean upper bound numDistinctDistances P ≤ n·(n−1) via Finset.offDiag_card — the trivial ceiling of the h(n) envelope.",
+      "The degenerate floor: n ≤ 1 forces numDistinctDistances = 0 (no off-diagonal pair); and any injective config with n ≥ 2 realizes at least one positive distance, so 1 ≤ numDistinctDistances there.",
+      "h(n) = sInf over general-position configs is bounded above by any single witness config (Nat.sInf_le with ⟨P, hgp, rfl⟩) — the membership fact that every known upper-bound construction (Pach n^{log₂3}, Erdős–Füredi–Pach n·exp(c√log n)) feeds into."
+    ],
     "mathlibGaps": [],
     "nextSteps": [],
     "markdown": "# Knowledge Base: erdos-98-wip-01\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"


### PR DESCRIPTION
## Summary

First machine-checked theorems for **Erdős Problem #98** (distinct distances in
general position; OPEN — Erdős could not even prove `h(n) ≥ n`). The scaffold
`Erdos98Problem.lean` set up the objects (`PointConfig`, `InGeneralPosition`,
`numDistinctDistances`, `h`) but proved **no theorems**. This adds
`proofs/Proofs/Erdos98WIP01.lean` — **5 theorems, 0 sorry, 0 axiom** — pinning
the elementary counting envelope that any bound on `h(n)` lives inside.

## Results

| Theorem | Statement |
|---|---|
| `numDistinctDistances_le_offDiag` | `numDistinctDistances P ≤ n·(n−1)` — positive distances embed into off-diagonal ordered pairs (`dist_pos` ⟹ distinct points ⟹ distinct indices), counted via `Finset.offDiag_card` |
| `numDistinctDistances_eq_zero_of_le_one` | `n ≤ 1 ⟹ 0` (degenerate floor) |
| `one_le_numDistinctDistances_of_injective` | injective `P`, `2 ≤ n ⟹ ≥ 1` |
| `InGeneralPosition.injective` | general position ⟹ injective (first conjunct) |
| `h_le_of_inGeneralPosition` | `h n ≤ numDistinctDistances P` via `Nat.sInf_le ⟨P, hgp, rfl⟩` — the upper-bound-witness hook every known construction (Pach `n^{log₂3}`, Erdős–Füredi–Pach `n·exp(c√log n)`) feeds |

## Verification

Host-verified docker-free (`bin/lake env lean`, Lean v4.31, parent olean
fresh-built): full-file compile **exit 0, no warnings**. `#print axioms` on all
five = `[propext, Classical.choice, Quot.sound]` — no `sorryAx`, no
`ofReduceBool`.

## Next steps (logged in knowledge.md)

- Sharpen to `≤ n.choose 2` via distance symmetry (`{i < j}` pairs).
- First superconstant lower bound: elementary Erdős pigeonhole `≥ √(n − 3/4) − 1/2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)