### PR TITLE
audit: erdos-658 — drop 3 phantom declarations from section prose

### DIFF
--- a/src/data/proofs/erdos-658/meta.json
+++ b/src/data/proofs/erdos-658/meta.json
@@ -107,10 +107,10 @@
     {
       "id": "hales-jewett",
       "title": "Density Hales-Jewett",
-      "summary": "density_hales_jewett axiom, reduction_to_hales_jewett",
+      "summary": "CombLine placeholder def, density_hales_jewett axiom",
       "startLine": 169,
       "endLine": 201,
-      "mathContext": "Axiomatized: density_hales_jewett axiom, reduction_to_hales_jewett"
+      "mathContext": "Axiomatized: density_hales_jewett axiom (Furstenberg-Katznelson 1991). CombLine is a placeholder definition; the reduction to Hales-Jewett is discussed in comments only, not formalized."
     },
     {
       "id": "solymosi-bounds",
@@ -123,18 +123,18 @@
     {
       "id": "examples",
       "title": "Small Cases and Examples",
-      "summary": "small_case_2x2, density_threshold_3x3, small_counterexamples",
+      "summary": "small_case_2x2 axiom, density_threshold_3x3",
       "startLine": 230,
       "endLine": 266,
-      "mathContext": "Mathematical content: small_case_2x2, density_threshold_3x3, small_counterexamples"
+      "mathContext": "Mathematical content: small_case_2x2 axiom, density_threshold_3x3. Non-square-free configurations for small N are discussed in comments only, not formalized."
     },
     {
       "id": "generalizations",
       "title": "Generalizations",
-      "summary": "higher_dimensional_cubes, tilted_squares_exist",
+      "summary": "higher_dimensional_cubes",
       "startLine": 267,
       "endLine": 290,
-      "mathContext": "Mathematical content: higher_dimensional_cubes, tilted_squares_exist"
+      "mathContext": "Mathematical content: higher_dimensional_cubes. Tilted (non-axis-aligned) squares are discussed in comments only, not formalized."
     },
     {
       "id": "summary",


### PR DESCRIPTION
## Integrity Issue

**Proof**: erdos-658 (Squares in Dense Grid Subsets)
**Problem**: Section summaries named three declarations that do not exist in the Lean file, overstating the formalization scope.

## Evidence

`sections[]` in `meta.json` referenced:
- `reduction_to_hales_jewett` (Density Hales-Jewett section)
- `small_counterexamples` (Small Cases and Examples section)
- `tilted_squares_exist` (Generalizations section)

`grep` over `proofs/Proofs/Erdos658Problem.lean` finds none of these. They are invented snake_case slugs derived from prose comment headers (`/- **Reduction to Hales-Jewett** -/` line 184, `**Non-square-free configurations**` line 231, `**General affine squares**` line 252) — comments, not declarations.

The actual 6 theorems / 3 axioms / 0 sorries and the top-level description, conclusion, badge (`axiom`), and status (`axiomatized`) were all already accurate.

## Fix

Rewrote the three affected section `summary`/`mathContext` fields to reference only real declarations (`CombLine`, `density_hales_jewett`, `small_case_2x2`, `density_threshold_3x3`, `higher_dimensional_cubes`) and to note that the reduction, small counterexamples, and tilted-square generalizations are discussed in comments only, not formalized.

---
Discovered during gallery integrity audit (reserve mode).