### PR TITLE
Research: erdos-89-wip-01 — distinct-distance counting envelope (axiom-free)

### DIFF
--- a/proofs/Proofs/Erdos89WIP01.lean
+++ b/proofs/Proofs/Erdos89WIP01.lean
@@ -1,0 +1,104 @@
+import Mathlib
+import Proofs.Erdos89Problem
+
+/-
+# Erdős #89 — foundational structure for distinct distances (Finset formulation)
+# (erdos-89-wip-01)
+
+## The Problem
+
+**Erdős Problem #89** (OPEN). `g(n) = minDistinctDistances n` is the minimum
+number of distinct pairwise distances over all `n`-point sets in `ℝ²`. Erdős
+conjectured `g(n) ≫ n/√(log n)` (the `√n × √n` grid is the extremal candidate);
+the best proved lower bound is Guth–Katz's `Ω(n/log n)`.
+
+`Erdos89Problem.lean` sets up `dist`, `distinctDistances`, `numDistinctDistances`,
+`minDistinctDistances` and records the conjecture / Guth–Katz consistency, but
+proves nothing about the *counting* objects themselves. This file supplies their
+first structural theorems.
+
+## Results (all in `namespace Erdos89`)
+
+1. `dist_pos_of_ne` — distinct points are a positive distance apart
+   (`0 < ‖p − q‖`), the fact behind every distance count.
+
+2. `distinctDistances_eq_image` — the `filter (· > 0)` in the definition of
+   `distinctDistances` is **redundant**: every off-diagonal pair already has a
+   positive distance, so `distinctDistances S = S.offDiag.image (dist · ·)`.
+
+3. `numDistinctDistances_le_offDiag` — the trivial ceiling
+   `numDistinctDistances S ≤ |S|·(|S|−1)`.
+
+4. `numDistinctDistances_eq_zero_of_card_le_one` — the degenerate floor
+   (`|S| ≤ 1 ⟹ 0`).
+
+5. `one_le_numDistinctDistances_of_two_le_card` — two or more points always
+   determine at least one distance (`2 ≤ |S| ⟹ ≥ 1`).
+
+6. `minDistinctDistances_le_of_card_eq` — every `n`-point set is a witness
+   bounding the extremal `g(n)` from above (`Nat.sInf` membership) — the hook the
+   grid upper-bound construction feeds.
+
+## Summary: 0 sorries, 0 axioms, no `native_decide`. Built over the gallery defs.
+-/
+
+open Finset
+
+namespace Erdos89
+
+/-- Distinct points are a positive distance apart. -/
+theorem dist_pos_of_ne {p q : EuclideanSpace ℝ (Fin 2)} (hpq : p ≠ q) :
+    0 < dist p q := by
+  show (0 : ℝ) < ‖p - q‖
+  rw [norm_pos_iff, sub_ne_zero]
+  exact hpq
+
+/-- The `filter (· > 0)` in `distinctDistances` is redundant: every off-diagonal
+pair already has positive distance. -/
+theorem distinctDistances_eq_image (S : Finset (EuclideanSpace ℝ (Fin 2))) :
+    distinctDistances S = S.offDiag.image (fun pq => dist pq.1 pq.2) := by
+  unfold distinctDistances
+  apply Finset.filter_true_of_mem
+  intro x hx
+  rw [Finset.mem_image] at hx
+  obtain ⟨pq, hpq, rfl⟩ := hx
+  rw [Finset.mem_offDiag] at hpq
+  exact dist_pos_of_ne hpq.2.2
+
+/-- **Upper envelope.** `numDistinctDistances S ≤ |S|·(|S|−1)`. -/
+theorem numDistinctDistances_le_offDiag (S : Finset (EuclideanSpace ℝ (Fin 2))) :
+    numDistinctDistances S ≤ S.card * (S.card - 1) := by
+  unfold numDistinctDistances
+  rw [distinctDistances_eq_image]
+  calc (S.offDiag.image (fun pq => dist pq.1 pq.2)).card
+      ≤ S.offDiag.card := card_image_le
+    _ = S.card * (S.card - 1) := by rw [Finset.offDiag_card, Nat.mul_sub_one]
+
+/-- Fewer than two points determine no distance. -/
+theorem numDistinctDistances_eq_zero_of_card_le_one
+    (S : Finset (EuclideanSpace ℝ (Fin 2))) (hS : S.card ≤ 1) :
+    numDistinctDistances S = 0 := by
+  have hb := numDistinctDistances_le_offDiag S
+  have hz : S.card * (S.card - 1) = 0 :=
+    Nat.mul_eq_zero.mpr (Or.inr (by omega))
+  omega
+
+/-- Two or more points always determine at least one distance. -/
+theorem one_le_numDistinctDistances_of_two_le_card
+    (S : Finset (EuclideanSpace ℝ (Fin 2))) (hS : 2 ≤ S.card) :
+    1 ≤ numDistinctDistances S := by
+  unfold numDistinctDistances
+  apply Finset.card_pos.mpr
+  obtain ⟨a, ha, b, hb, hab⟩ := Finset.one_lt_card.mp (by omega : 1 < S.card)
+  refine ⟨dist a b, ?_⟩
+  rw [distinctDistances_eq_image, Finset.mem_image]
+  exact ⟨(a, b), Finset.mem_offDiag.mpr ⟨ha, hb, hab⟩, rfl⟩
+
+/-- **The extremal witness fact.** Every `n`-point set bounds the minimum
+distinct-distance count `g(n) = minDistinctDistances n` from above. -/
+theorem minDistinctDistances_le_of_card_eq
+    {n : ℕ} {S : Finset (EuclideanSpace ℝ (Fin 2))} (hn : S.card = n) :
+    minDistinctDistances n ≤ numDistinctDistances S :=
+  Nat.sInf_le ⟨S, hn, rfl⟩
+
+end Erdos89

--- a/research/problems/erdos-89-wip-01/knowledge.md
+++ b/research/problems/erdos-89-wip-01/knowledge.md
@@ -19,3 +19,35 @@ Insights accumulated during research on this problem.
 ## Dead Ends
 
 [Approaches known not to work will be documented here]
+
+---
+
+## Session (researcher-1, 2026-07-20) — first machine-checked theorems (axiom-free)
+
+Created `proofs/Proofs/Erdos89WIP01.lean` (6 theorems, 0 sorry, 0 axiom;
+host-verified `bin/lake env lean` exit 0, `#print axioms` = `[propext,
+Classical.choice, Quot.sound]` on all — no `sorryAx`, no `ofReduceBool`). The
+scaffold `Erdos89Problem.lean` proved facts *about the conjecture* (Guth–Katz
+consistency) but nothing about the counting objects; this adds their structure.
+
+- `dist_pos_of_ne` — `p ≠ q ⟹ 0 < ‖p − q‖` (`norm_pos_iff` + `sub_ne_zero`).
+- `distinctDistances_eq_image` — the definitional `filter (· > 0)` is redundant:
+  every off-diagonal pair already has positive distance, so
+  `distinctDistances S = S.offDiag.image (dist · ·)` (`Finset.filter_true_of_mem`).
+- `numDistinctDistances_le_offDiag` — `≤ |S|·(|S|−1)` (`card_image_le`,
+  `Finset.offDiag_card`, `Nat.mul_sub_one`).
+- `numDistinctDistances_eq_zero_of_card_le_one` — degenerate floor.
+- `one_le_numDistinctDistances_of_two_le_card` — `2 ≤ |S| ⟹ ≥ 1`
+  (`Finset.one_lt_card` gives a distinct pair; its distance is a member).
+- `minDistinctDistances_le_of_card_eq` — `g(n) ≤ numDistinctDistances S` for any
+  `n`-point `S` (`Nat.sInf_le`), the grid-upper-bound membership hook.
+
+### Verification
+Parent `Erdos89Problem.lean` fresh-built to olean host-side (Mathlib-only, v4.31,
+docker-free), child compiled against it. Exit 0, no warnings.
+
+### Next Steps
+- Sharpen to `≤ S.card.choose 2` via distance symmetry.
+- Formalize the `√n × √n` grid upper bound feeding `minDistinctDistances_le_*`,
+  giving a concrete `g(n) = O(n)` ceiling.
+- Connect `singlePointConjecture` (Problem #604) to the global count.

--- a/src/data/research/problems/erdos-89-wip-01.json
+++ b/src/data/research/problems/erdos-89-wip-01.json
@@ -1,7 +1,7 @@
 {
   "slug": "erdos-89-wip-01",
   "title": "Complete the Erdős #89 Distinct-Distances Formalization",
-  "phase": "OBSERVE",
+  "phase": "ACT",
   "status": "active",
   "tier": "A",
   "path": "full",
@@ -31,9 +31,20 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
+    "progressSummary": "PROGRESS: Created Erdos89WIP01.lean — first machine-checked theorems for the #89 distinct-distances (Finset) scaffold. Positive-distance structure, redundant-filter characterization, counting envelope 0 ≤ numDistinctDistances ≤ |S|·(|S|−1), and the minDistinctDistances sInf-membership witness fact.",
+    "builtItems": [
+      "Erdos89.dist_pos_of_ne in Erdos89WIP01.lean",
+      "Erdos89.distinctDistances_eq_image (filter redundant) in Erdos89WIP01.lean",
+      "Erdos89.numDistinctDistances_le_offDiag (≤ |S|·(|S|−1)) in Erdos89WIP01.lean",
+      "Erdos89.numDistinctDistances_eq_zero_of_card_le_one in Erdos89WIP01.lean",
+      "Erdos89.one_le_numDistinctDistances_of_two_le_card in Erdos89WIP01.lean",
+      "Erdos89.minDistinctDistances_le_of_card_eq in Erdos89WIP01.lean"
+    ],
+    "insights": [
+      "distinctDistances S filters (·>0) over the off-diagonal image, but every off-diagonal pair (p≠q) already has ‖p−q‖>0, so the filter is redundant: distinctDistances S = S.offDiag.image (dist · ·). This removes the awkward filter for all downstream cardinality reasoning.",
+      "Counting envelope: numDistinctDistances S ≤ |S|·(|S|−1) via card_image_le + Finset.offDiag_card; and it vanishes iff too few points (|S|≤1 ⟹ 0, |S|≥2 ⟹ ≥1 via one_lt_card giving a distinct pair).",
+      "minDistinctDistances n = sInf over n-point sets is bounded above by any single n-point witness (Nat.sInf_le ⟨S, hcard, rfl⟩) — the membership hook the √n×√n grid upper-bound construction ultimately supplies."
+    ],
     "mathlibGaps": [],
     "nextSteps": [],
     "markdown": "# Knowledge Base: erdos-89-wip-01\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"


### PR DESCRIPTION
## Summary

First machine-checked theorems about the *counting objects* of **Erdős Problem
#89** (distinct distances in the plane; OPEN — conjectured `g(n) ≫ n/√(log n)`,
best proved bound Guth–Katz `Ω(n/log n)`). `Erdos89Problem.lean` proved facts
about the conjecture statement (Guth–Katz consistency) but nothing about
`distinctDistances` / `numDistinctDistances` / `minDistinctDistances`. This adds
`proofs/Proofs/Erdos89WIP01.lean` — **6 theorems, 0 sorry, 0 axiom** (namespace
`Erdos89`).

## Results

| Theorem | Statement |
|---|---|
| `dist_pos_of_ne` | `p ≠ q ⟹ 0 < ‖p − q‖` |
| `distinctDistances_eq_image` | the definitional `filter (· > 0)` is redundant — `distinctDistances S = S.offDiag.image (dist · ·)` (every off-diagonal pair already has positive distance) |
| `numDistinctDistances_le_offDiag` | `≤ |S|·(|S|−1)` |
| `numDistinctDistances_eq_zero_of_card_le_one` | `|S| ≤ 1 ⟹ 0` |
| `one_le_numDistinctDistances_of_two_le_card` | `2 ≤ |S| ⟹ ≥ 1` |
| `minDistinctDistances_le_of_card_eq` | `g(n) ≤ numDistinctDistances S` for any `n`-point `S` (`Nat.sInf_le`) — the grid-upper-bound witness hook |

## Verification

Host-verified docker-free (`bin/lake env lean`, Lean v4.31, parent olean
fresh-built): compile **exit 0, no warnings**. `#print axioms` on all six =
`[propext, Classical.choice, Quot.sound]` — no `sorryAx`, no `ofReduceBool`.

## Next steps (logged in knowledge.md)

- Sharpen to `≤ S.card.choose 2` via distance symmetry.
- Formalize the `√n × √n` grid upper bound feeding `minDistinctDistances_le_*`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)