### PR TITLE
Research: erdos-70-wip-01 — countable-ordinal closure + conjecture specializations (axiom-free)

### DIFF
--- a/proofs/Proofs/Erdos70WIP01.lean
+++ b/proofs/Proofs/Erdos70WIP01.lean
@@ -1,0 +1,73 @@
+import Mathlib
+import Proofs.Erdos70Problem
+
+/-
+# Erdős #70 — closure of the countable-ordinal class and conjecture specializations
+# (erdos-70-wip-01)
+
+## The Problem
+
+**Erdős Problem #70** (OPEN). Does the continuum satisfy the partition relation
+`𝔠 → (β, n)₂³` for *every* countable ordinal `β` and every `2 ≤ n < ω`?
+`Erdos70Problem.lean` sets up `PartitionArrow`, `IsCountableOrdinal`, the
+conjecture `erdos_70_conjecture` and the special cases `conjecture_omega` /
+`conjecture_omega_squared`, and proves a handful of specific countability facts
+(`omega0_countable`, `omega0_plus_n_countable`, `omega0_squared_countable`) plus
+the two monotonicity directions of the arrow.
+
+This file supplies the **general structural lemmas** those specific facts are
+instances of: the countable ordinals are downward-closed and closed under `+`
+and `*`; and it wires the open conjecture to its published special cases.
+
+## Results (all in `namespace Erdos70`)
+
+1. `IsCountableOrdinal.of_le` — countability is *downward closed*: `α ≤ β` and
+   `β` countable ⟹ `α` countable. (`omega0_plus_n_countable` etc. become
+   corollaries of this + closure below.)
+
+2. `isCountableOrdinal_add` / `isCountableOrdinal_mul` — the countable ordinals
+   are closed under ordinal addition and multiplication.
+
+3. `erdos_70_conjecture_imp_omega` / `_imp_omega_squared` — the open conjecture
+   specializes to its two flagship cases `𝔠 → (ω, n)` and `𝔠 → (ω², n)`, using
+   the parent's countability witnesses.
+
+## Summary: 0 sorries, 0 axioms, no `native_decide`. Built over the gallery defs.
+-/
+
+namespace Erdos70
+
+/-- **Downward closure.** A sub-ordinal of a countable ordinal is countable. -/
+theorem IsCountableOrdinal.of_le {α β : Ordinal} (hαβ : α ≤ β)
+    (h : IsCountableOrdinal β) : IsCountableOrdinal α :=
+  (Ordinal.card_le_card hαβ).trans h
+
+/-- The countable ordinals are closed under ordinal addition. -/
+theorem isCountableOrdinal_add {α β : Ordinal}
+    (hα : IsCountableOrdinal α) (hβ : IsCountableOrdinal β) :
+    IsCountableOrdinal (α + β) := by
+  unfold IsCountableOrdinal at *
+  rw [Ordinal.card_add]
+  exact Cardinal.add_le_aleph0.mpr ⟨hα, hβ⟩
+
+/-- The countable ordinals are closed under ordinal multiplication. -/
+theorem isCountableOrdinal_mul {α β : Ordinal}
+    (hα : IsCountableOrdinal α) (hβ : IsCountableOrdinal β) :
+    IsCountableOrdinal (α * β) := by
+  unfold IsCountableOrdinal at *
+  rw [Ordinal.card_mul]
+  calc α.card * β.card ≤ Cardinal.aleph0 * Cardinal.aleph0 :=
+        mul_le_mul' hα hβ
+    _ = Cardinal.aleph0 := Cardinal.aleph0_mul_aleph0
+
+/-- The open conjecture specializes to the flagship case `𝔠 → (ω, n)₂³`. -/
+theorem erdos_70_conjecture_imp_omega (h : erdos_70_conjecture) (n : ℕ)
+    (hn : 2 ≤ n) : conjecture_omega n :=
+  h Ordinal.omega0 n omega0_countable hn
+
+/-- The open conjecture specializes to `𝔠 → (ω², n)₂³`. -/
+theorem erdos_70_conjecture_imp_omega_squared (h : erdos_70_conjecture) (n : ℕ)
+    (hn : 2 ≤ n) : conjecture_omega_squared n :=
+  h (Ordinal.omega0 * Ordinal.omega0) n omega0_squared_countable hn
+
+end Erdos70

--- a/research/problems/erdos-70-wip-01/knowledge.md
+++ b/research/problems/erdos-70-wip-01/knowledge.md
@@ -19,3 +19,31 @@ Insights accumulated during research on this problem.
 ## Dead Ends
 
 [Approaches known not to work will be documented here]
+
+---
+
+## Session (researcher-1, 2026-07-20) — countable-ordinal closure + conjecture specializations (axiom-free)
+
+Created `proofs/Proofs/Erdos70WIP01.lean` (5 theorems, 0 sorry, 0 axiom;
+host-verified `bin/lake env lean` exit 0, `#print axioms` = `[propext,
+Classical.choice, Quot.sound]` on all). Generalizes the parent's specific
+countability facts and connects the open conjecture to its special cases.
+
+- `IsCountableOrdinal.of_le` — downward closure (`Ordinal.card_le_card`).
+- `isCountableOrdinal_add` — closed under `+` (`Ordinal.card_add`,
+  `Cardinal.add_le_aleph0`).
+- `isCountableOrdinal_mul` — closed under `*` (`Ordinal.card_mul`, `mul_le_mul'`,
+  `Cardinal.aleph0_mul_aleph0`).
+- `erdos_70_conjecture_imp_omega` / `_imp_omega_squared` — specialize the open
+  conjecture to `conjecture_omega` / `conjecture_omega_squared` via the parent
+  witnesses `omega0_countable` / `omega0_squared_countable`.
+
+### Verification
+Parent `Erdos70Problem.lean` fresh-built to olean host-side (Mathlib-only, v4.31,
+docker-free), child compiled against it. Exit 0.
+
+### Next Steps
+- `isCountableOrdinal_opow` for `ω^ω` (`conjecture_omega_tower` witness) — needs
+  the `Ordinal.card` behaviour of `opow`, less directly available in Mathlib.
+- Derive `omega0_plus_n_countable` / `omega0_squared_countable` as one-line
+  corollaries of the new closure lemmas (dedup the parent).

--- a/src/data/research/problems/erdos-70-wip-01.json
+++ b/src/data/research/problems/erdos-70-wip-01.json
@@ -1,7 +1,7 @@
 {
   "slug": "erdos-70-wip-01",
   "title": "Complete the Erdős #70 Partition-Calculus Formalization",
-  "phase": "OBSERVE",
+  "phase": "ACT",
   "status": "active",
   "tier": "A",
   "path": "full",
@@ -31,9 +31,18 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
+    "progressSummary": "PROGRESS: Created Erdos70WIP01.lean — general countable-ordinal closure lemmas (downward-closed, closed under + and *) generalizing the parent scaffold s specific countability facts, plus wiring the open conjecture to its flagship special cases 𝔠→(ω,n) and 𝔠→(ω²,n).",
+    "builtItems": [
+      "Erdos70.IsCountableOrdinal.of_le in Erdos70WIP01.lean",
+      "Erdos70.isCountableOrdinal_add in Erdos70WIP01.lean",
+      "Erdos70.isCountableOrdinal_mul in Erdos70WIP01.lean",
+      "Erdos70.erdos_70_conjecture_imp_omega in Erdos70WIP01.lean",
+      "Erdos70.erdos_70_conjecture_imp_omega_squared in Erdos70WIP01.lean"
+    ],
+    "insights": [
+      "The parent proved specific instances (omega0_plus_n_countable, omega0_squared_countable); these are corollaries of three general closure lemmas: IsCountableOrdinal is downward-closed (Ordinal.card_le_card), and closed under ordinal + (Cardinal.add_le_aleph0) and * (mul_le_mul + Cardinal.aleph0_mul_aleph0).",
+      "The open conjecture erdos_70_conjecture (∀ countable β, 2≤n, PartitionArrow c β n) specializes definitionally to conjecture_omega n and conjecture_omega_squared n by feeding the parent countability witnesses omega0_countable / omega0_squared_countable."
+    ],
     "mathlibGaps": [],
     "nextSteps": [],
     "markdown": "# Knowledge Base: erdos-70-wip-01\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"


### PR DESCRIPTION
## Summary

Structural lemmas for **Erdős Problem #70** (does `𝔠 → (β, n)₂³` hold for every
countable ordinal `β`? OPEN). `Erdos70Problem.lean` proved specific countability
facts (`omega0_countable`, `omega0_plus_n_countable`, `omega0_squared_countable`)
and the arrow's two monotonicity directions. This adds
`proofs/Proofs/Erdos70WIP01.lean` — **5 theorems, 0 sorry, 0 axiom** (namespace
`Erdos70`) — the *general* facts those instances specialize.

## Results

| Theorem | Statement |
|---|---|
| `IsCountableOrdinal.of_le` | `α ≤ β`, `β` countable ⟹ `α` countable (downward closure) |
| `isCountableOrdinal_add` | countable ordinals closed under `+` |
| `isCountableOrdinal_mul` | countable ordinals closed under `*` |
| `erdos_70_conjecture_imp_omega` | conjecture ⟹ `conjecture_omega n` (`2 ≤ n`) |
| `erdos_70_conjecture_imp_omega_squared` | conjecture ⟹ `conjecture_omega_squared n` |

The closure lemmas subsume the parent's `omega0_plus_n_countable` /
`omega0_squared_countable` as one-line corollaries; the specialization lemmas
wire the open conjecture to its two flagship published cases.

## Verification

Host-verified docker-free (`bin/lake env lean`, Lean v4.31, parent olean
fresh-built): compile **exit 0**. `#print axioms` on all five = `[propext,
Classical.choice, Quot.sound]` — no `sorryAx`, no `ofReduceBool`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)