### PR TITLE
audit: re-serve erdos-633 (verified) — clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -15216,8 +15216,8 @@
     },
     "erdos-633": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:55:35Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-20T15:00:36Z",
       "result": "clean"
     },
     "erdos-634": {


### PR DESCRIPTION
## Gallery Integrity Audit — erdos-633

Reserve-mode re-audit. Unaudited queue is drained (0 targets); selected the
oldest **uncontested** `verified`-badge slug (last audited 2026-05-04, 0 open PRs).

### Result: **CLEAN**

Verified `meta.json` against `proofs/Proofs/Erdos633Problem.lean`:

| Check | meta | actual |
|-------|------|--------|
| sorries | 0 | 0 (grep hits are docstring prose) |
| axioms | 0 | 0 |
| native_decide | — | none |
| True stubs | — | none (only disclosed placeholders) |
| theoremCount | 17 | 17 |
| definitionCount | 18 | 18 |
| lineCount | 497 | 497 |

- File **compiles cleanly** under `lake env lean` (only a `push_neg` deprecation warning).
- All 17 theorems carry genuine, substantive proofs — no vacuous collapses.
- Badge `verified` accurately means "0 axioms / 0 sorries, machine-checked."
- Prose is careful and honest: title/description/`assumptions`/conclusion all
  repeatedly state #633 remains **OPEN ($25)**. This entry establishes a sharp
  *negative* model-adequacy result (the area+side-ratio relaxation over-counts to
  every `n ≥ 1`), not a resolution.
- Disclosed placeholders — `erdos_633_open` (`↔` tautology) and the `True` inside
  `erdos633Classification` — are described as placeholders in the meta and do not
  overclaim.

No integrity issues found.

🤖 Generated with [Claude Code](https://claude.com/claude-code)