### PR TITLE
Research: erdos-531-incomplete-01 — k=2 subset-sum machinery toward F(2)=8 (axiom-free)

### DIFF
--- a/proofs/Proofs/Erdos531Incomplete01.lean
+++ b/proofs/Proofs/Erdos531Incomplete01.lean
@@ -1,0 +1,76 @@
+import Mathlib
+import Proofs.Erdos531Problem
+
+/-
+# Erdős #531 — subset-sum machinery for two-element Folkman sets
+# (erdos-531-incomplete-01)
+
+## The Problem
+
+**Erdős Problem #531** (OPEN growth rate). `F(k)` is the least `N` such that every
+2-colouring of `{1,…,N}` admits a `k`-element set whose non-empty subset sums are
+monochromatic. `Erdos531Problem.lean` proves `F 1 = 1` but leaves `F 2 = 8` as a
+`sorry`, noting it needs the reduction of the infinite colouring quantifier
+`∀ c : ℕ → Bool` to a finite search — deferred there as out of scope.
+
+This companion supplies the reusable **`k = 2` subset-sum machinery** that
+reduction rests on: for a genuine two-element set `{a, b}` (`a ≠ b`) the
+non-empty subset sums are exactly `a`, `b`, `a + b`.
+
+## Results (namespace `Erdos531`)
+
+1. `mem_subsetSums_pair_left` / `_right` / `_add` — `a`, `b`, `a + b` are subset
+   sums of `{a, b}` (witnessed by `{a}`, `{b}`, `{a, b}`; the last needs `a ≠ b`
+   so the pair has two elements).
+
+2. `monochromaticSubsetSums_pair_forward` — if `{a, b}`'s subset sums are
+   monochromatic then `c a = c b` and `c b = c (a + b)`. This is precisely the
+   necessary condition a colouring must satisfy for a distinct pair to be
+   Folkman-monochromatic — the fact the `F 2 ≥ 8` counterexample direction checks
+   pair-by-pair against the witness colouring `1,2,4 ↦ B`, `3,5,6,7 ↦ R`.
+
+## Summary: 0 sorries, 0 axioms, no `native_decide`. Built over the gallery defs.
+-/
+
+open Finset
+
+namespace Erdos531
+
+/-- `a` is a subset sum of `{a, b}` (witness `{a}`). -/
+theorem mem_subsetSums_pair_left (a b : ℕ) : a ∈ SubsetSums {a, b} := by
+  rw [SubsetSums, Finset.mem_image]
+  refine ⟨{a}, ?_, by simp⟩
+  rw [Finset.mem_filter, Finset.mem_powerset]
+  exact ⟨Finset.singleton_subset_iff.mpr (Finset.mem_insert_self a {b}),
+    Finset.singleton_ne_empty a⟩
+
+/-- `b` is a subset sum of `{a, b}` (witness `{b}`). -/
+theorem mem_subsetSums_pair_right (a b : ℕ) : b ∈ SubsetSums {a, b} := by
+  rw [SubsetSums, Finset.mem_image]
+  refine ⟨{b}, ?_, by simp⟩
+  rw [Finset.mem_filter, Finset.mem_powerset]
+  exact ⟨Finset.singleton_subset_iff.mpr
+      (Finset.mem_insert_of_mem (Finset.mem_singleton_self b)),
+    Finset.singleton_ne_empty b⟩
+
+/-- `a + b` is a subset sum of `{a, b}` when `a ≠ b` (witness the whole pair). -/
+theorem mem_subsetSums_pair_add {a b : ℕ} (hab : a ≠ b) :
+    a + b ∈ SubsetSums {a, b} := by
+  rw [SubsetSums, Finset.mem_image]
+  refine ⟨{a, b}, ?_, ?_⟩
+  · rw [Finset.mem_filter, Finset.mem_powerset]
+    exact ⟨Finset.Subset.refl _, Finset.insert_ne_empty a {b}⟩
+  · simp [Finset.sum_pair hab]
+
+/-- **Necessary condition.** If the subset sums of a distinct pair `{a, b}` are
+monochromatic under `c`, then `c a = c b` and `c b = c (a + b)`. -/
+theorem monochromaticSubsetSums_pair_forward {c : Coloring} {a b : ℕ}
+    (hab : a ≠ b) (h : MonochromaticSubsetSums c {a, b}) :
+    c a = c b ∧ c b = c (a + b) := by
+  obtain ⟨col, hcol⟩ := h
+  have ha := hcol a (mem_subsetSums_pair_left a b)
+  have hb := hcol b (mem_subsetSums_pair_right a b)
+  have hab' := hcol (a + b) (mem_subsetSums_pair_add hab)
+  exact ⟨ha.trans hb.symm, hb.trans hab'.symm⟩
+
+end Erdos531

--- a/research/problems/erdos-531-incomplete-01/knowledge.md
+++ b/research/problems/erdos-531-incomplete-01/knowledge.md
@@ -1,0 +1,24 @@
+
+---
+
+## Session (researcher-1, 2026-07-20) — k=2 subset-sum machinery (axiom-free)
+
+Created `proofs/Proofs/Erdos531Incomplete01.lean` (4 theorems, 0 sorry, 0 axiom;
+host-verified, `#print axioms` = `[propext, Classical.choice, Quot.sound]` on all
+— importantly no `sorryAx` leaked from the parent's `F_2` sorry). Supplies the
+`k = 2` machinery the deferred `F 2 = 8` reduction needs.
+
+- `mem_subsetSums_pair_left/_right/_add` — `a`, `b`, `a+b ∈ SubsetSums {a,b}`
+  (witnesses `{a}`, `{b}`, `{a,b}`; the last via `Finset.sum_pair (hab : a ≠ b)`).
+- `monochromaticSubsetSums_pair_forward` — mono ⟹ `c a = c b ∧ c b = c (a+b)`,
+  the necessary condition for the `F 2 ≥ 8` counterexample direction.
+
+### The remaining F_2 = 8 reduction (scoped by the parent as follow-up)
+1. Reduce `∀ c : ℕ → Bool` to `c|[1,15]` (subset sums of pairs in `[1,8]` reach ≤ 15).
+2. `8 ∈ ValidN 2` — needs the *backward* char (also `SubsetSums {a,b} ⊆ {a,b,a+b}`).
+3. `∀ m < 8, m ∉ ValidN 2` — witness colouring `1,2,4↦B`, `3,5,6,7↦R`; forward char
+   defeats each of the ≤ 21 distinct pairs in `[1,7]`.
+
+### Next Steps
+- Prove `subsetSums_pair_subset : SubsetSums {a,b} ⊆ {a,b,a+b}` (subset enumeration
+  of `{a,b}`), upgrading forward to the full iff and enabling step 2.

--- a/src/data/research/problems/erdos-531-incomplete-01.json
+++ b/src/data/research/problems/erdos-531-incomplete-01.json
@@ -1,7 +1,7 @@
 {
   "slug": "erdos-531-incomplete-01",
   "title": "Complete proof of Erdős Problem #531: Folkman's Theorem - Monochromatic Subset Sums (2 sorries)",
-  "phase": "NEW",
+  "phase": "ACT",
   "status": "available",
   "tier": "B",
   "path": "full",
@@ -29,9 +29,16 @@
     }
   },
   "knowledge": {
-    "progressSummary": "AVAILABLE: parent formalization has 2 open sorry statement(s) to complete.",
-    "builtItems": [],
-    "insights": [],
+    "progressSummary": "PROGRESS: Created Erdos531Incomplete01.lean — axiom-free k=2 subset-sum machinery toward the deferred F 2 = 8 finite-coloring reduction. Establishes SubsetSums {a,b} membership of a,b,a+b and the forward monochromatic characterization (c a = c b = c(a+b)).",
+    "builtItems": [
+      "Erdos531.mem_subsetSums_pair_left / _right / _add in Erdos531Incomplete01.lean",
+      "Erdos531.monochromaticSubsetSums_pair_forward in Erdos531Incomplete01.lean"
+    ],
+    "insights": [
+      "For a distinct pair {a,b} the non-empty subset sums are exactly a, b, a+b (witnessed by {a},{b},{a,b}; the a+b witness needs a≠b via Finset.sum_pair). This is the concrete SubsetSums the abstract F_2 reduction must range over.",
+      "monochromaticSubsetSums_pair_forward gives the necessary condition c a = c b = c(a+b): the forward direction the F 2 ≥ 8 counterexample checks pair-by-pair against the witness colouring 1,2,4↦B / 3,5,6,7↦R. The backward direction (constructing a mono set) additionally needs SubsetSums {a,b} ⊆ {a,b,a+b}, left for follow-up.",
+      "The F 2 = 8 sorry in the parent needs (a) reduce ∀ c:ℕ→Bool to c|[1,15] finite search, (b) 8∈ValidN 2 via backward char, (c) ∀ m<8, m∉ValidN 2 via the explicit witness colouring + forward char. This session supplies the pair machinery for steps (b)/(c)."
+    ],
     "mathlibGaps": [],
     "nextSteps": []
   },


### PR DESCRIPTION
## Summary

**Erdős Problem #531** (Folkman numbers). `Erdos531Problem.lean` proves `F 1 = 1`
but leaves `F 2 = 8` as a `sorry`, noting it needs the infinite→finite colouring
reduction (explicitly deferred there as out of scope). This adds
`proofs/Proofs/Erdos531Incomplete01.lean` — **4 theorems, 0 sorry, 0 axiom**
(namespace `Erdos531`) — the `k = 2` subset-sum machinery that reduction rests on.

## Results

| Theorem | Statement |
|---|---|
| `mem_subsetSums_pair_left` / `_right` | `a`, `b ∈ SubsetSums {a, b}` |
| `mem_subsetSums_pair_add` | `a ≠ b ⟹ a + b ∈ SubsetSums {a, b}` (`Finset.sum_pair`) |
| `monochromaticSubsetSums_pair_forward` | mono subset sums ⟹ `c a = c b ∧ c b = c (a + b)` |

The forward characterization is exactly the necessary condition the `F 2 ≥ 8`
counterexample direction checks pair-by-pair against the witness colouring
`1,2,4 ↦ B`, `3,5,6,7 ↦ R`. The remaining reduction (finite search + backward
`SubsetSums {a,b} ⊆ {a,b,a+b}`) is scoped in `knowledge.md` as follow-up.

## Verification

Does **not** touch the parent's `F_2` sorry. `#print axioms` confirms no `sorryAx`
leaks — all four = `[propext, Classical.choice, Quot.sound]`. Host-verified
docker-free (`bin/lake env lean`, Lean v4.31), compile exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)