### PR TITLE
Enrich ballot-problem-oq-03-oq-02: promote wip→verified (r×r LGV compiles clean on v4.31.0)

### DIFF
--- a/src/data/proofs/ballot-problem-oq-03-oq-02/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-02/meta.json
@@ -2,12 +2,12 @@
   "id": "ballot-problem-oq-03-oq-02",
   "title": "General r×r Lindström-Gessel-Viennot Determinant",
   "slug": "ballot-problem-oq-03-oq-02",
-  "description": "Generalizes the 2×2 LGV lemma to the full r×r case: the number of r-tuples of pairwise non-intersecting lattice paths equals det[e(Aᵢ,Bⱼ)], the determinant of the path count matrix. Formalizes LGVConfig, PathTuple, permutation path tuples, and the Gessel-Viennot sign-reversing involution infrastructure. NOTE: does not currently compile against pinned Mathlib v4.26.0 — a clean single-agent build produces ~20 tactic-drift errors in the canonCrossN_preserved block; downgraded from verified to formalized pending repair.",
+  "description": "Generalizes the 2×2 LGV lemma to the full r×r case: the number of r-tuples of pairwise non-intersecting lattice paths equals det[e(Aᵢ,Bⱼ)], the determinant of the path count matrix. Formalizes LGVConfig, PathTuple, permutation path tuples, and the Gessel-Viennot sign-reversing involution infrastructure. Machine-verified against Mathlib v4.31.0: 0 sorries, 0 axioms; the main theorem lgv_lemma_rxr depends only on the foundational axioms propext/Classical.choice/Quot.sound.",
   "meta": {
     "author": "Lindström (1973), Gessel-Viennot (1985)",
     "sourceUrl": "",
     "date": "1985",
-    "status": "formalized",
+    "status": "verified",
     "proofRepoPath": "Proofs/BallotProblemOQ03OQ02.lean",
     "tags": [
       "combinatorics",
@@ -17,7 +17,7 @@
       "permutations",
       "research"
     ],
-    "badge": "wip",
+    "badge": "verified",
     "sorries": 0,
     "axioms": 0,
     "mathlibDependencies": [
@@ -62,11 +62,11 @@
       "swapTailsAt: tail-swap operation (involution kernel for GV proof)",
       "swapTailsAt length preservation theorems",
       "gessel_viennot_transposition_sign: sign(swap(i,σi)∘σ) = -sign(σ) (proved)",
-      "lgv_lemma_rxr: the main r×r LGV lemma (sorry-free/axiom-free source; does NOT currently compile against pinned Mathlib v4.26.0)",
+      "lgv_lemma_rxr: the main r×r LGV lemma (sorry-free, axiom-free; machine-verified against Mathlib v4.31.0)",
       "firstNonFixed: smallest non-fixed point of non-identity perm (4 lemmas proved)",
       "permPathTuple_card: cardinality factorization for σ-path tuples (proved)",
       "det_pathMatrix_eq_signed_sum: algebraic bridge det = signed perm sum (proved)",
-      "gv_involution_cancellation: GV cancellation (sorry-free source; does NOT currently compile against pinned Mathlib v4.26.0)",
+      "gv_involution_cancellation: GV cancellation (sorry-free; machine-verified against Mathlib v4.31.0)",
       "canonCrossN_preserved: canonical crossing code invariant under GV involution (PROVED)",
       "gvCanon_self_inverse: GV involution is self-inverse via double tail-swap (PROVED)",
       "decoded_y_le: lexicographic y-bound transfer for encoding arithmetic (PROVED)",
@@ -88,14 +88,14 @@
       "Gessel-Viennot involution theory"
     ],
     "assumptions": [
-      "BUILD STATUS (2026-07-04): does not compile against pinned Mathlib v4.26.0. A clean single-agent Docker build fails with ~20 Mathlib tactic-drift errors localized to the canonCrossN_preserved proof (lines ~2109–2338). No sorries or axioms are present in the source; the file is formalized but not currently machine-verified until the tactic errors are repaired."
+      "0 axioms, 0 sorries. VERIFICATION (Mathlib v4.31.0): the ~20 Mathlib tactic-drift errors reported against the old v4.26.0 pin (previously localized to canonCrossN_preserved, lines ~2109–2338) no longer occur — the toolchain migration resolved them. `lake env lean Proofs/BallotProblemOQ03OQ02.lean` compiles cleanly (only benign unused-simp-arg / deprecated-push_neg linter notes), and `#print axioms` on the headline theorems lgv_lemma_rxr, gv_involution_cancellation, det_pathMatrix_eq_signed_sum, and gessel_viennot_transposition_sign reports dependence on only propext, Classical.choice, Quot.sound (no sorryAx, no Lean.ofReduceBool). Status promoted formalized→verified accordingly."
     ],
     "definitionCount": 46
   },
   "overview": {
     "historicalContext": "The Lindström-Gessel-Viennot (LGV) lemma is one of the most versatile tools in enumerative combinatorics. Bernt Lindström proved a general version for vector matroids in 1973, building on ideas from Karlin and McGregor's 1959 work on coincidence probabilities of Markov chains. Ira Gessel and Gérard Viennot independently rediscovered and popularized the result in their influential 1985 paper, providing the elegant sign-reversing involution proof that has become the standard approach. The lemma connects non-intersecting lattice paths to determinants: the number of $r$-tuples of pairwise non-intersecting paths equals $\\det[e(A_i, B_j)]_{i,j}$. This determinantal structure has profound consequences—it underlies the Jacobi-Trudi identity for Schur polynomials, the Cauchy-Binet identity in linear algebra, and the Kasteleyn method for perfect matchings. The GV involution is a paradigmatic example of the 'cancellation via involution' technique that pervades algebraic combinatorics.",
     "problemStatement": "**The r×r LGV Lemma**: Given strictly increasing source points A₁,...,Aᵣ and target points B₁,...,Bᵣ on a lattice grid of width m, the number of r-tuples of pairwise non-intersecting lattice paths (Pᵢ: Aᵢ→Bᵢ) equals\n\n  det[ e(Aᵢ, Bⱼ) ]_{i,j=1}^r\n\nwhere e(A,B) = C(m + (bⱼ - aᵢ), m) is the number of monotone lattice paths from A to B.",
-    "text": "This formalization builds the complete infrastructure for the r×r Lindström-Gessel-Viennot determinant identity in Lean 4. Starting from lattice paths as Boolean lists, it constructs the PathMN type with a Fintype instance, defines the r×r path weight matrix over ℤ, and introduces permutation-indexed path tuples. The proof architecture connects the Leibniz determinant expansion (via Matrix.det_apply) to the combinatorial signed sum over permutation path tuples, then applies the Gessel-Viennot sign-reversing involution to cancel all non-identity contributions. Key proved components include a discrete intermediate value theorem for lattice path crossings, cardinality of PathMN via double induction on Pascal's rule, and the algebraic bridge equating det M with the signed permutation sum. The full canonical GV involution package is now proved — canonCrossN_preserved (canonical crossing invariant under involution), gvCanon_self_inverse (double tail-swap = identity), gvCanon_membership, gvCanon_sign_reversal, and gvCanon_no_fixed. The source contains 0 sorries and 0 axioms, but as of 2026-07-04 it does NOT compile against pinned Mathlib v4.26.0: a clean single-agent build (LEAN_SKIP_CACHE, 30s, no OOM) surfaced ~20 Mathlib-drift errors clustered in the canonical GV involution region (lines ~2109–2338: `simp made no progress`, `omega`/`split_ifs` failures, and type mismatches). Status is therefore `formalized`/`wip` pending repair.",
+    "text": "This formalization builds the complete infrastructure for the r×r Lindström-Gessel-Viennot determinant identity in Lean 4. Starting from lattice paths as Boolean lists, it constructs the PathMN type with a Fintype instance, defines the r×r path weight matrix over ℤ, and introduces permutation-indexed path tuples. The proof architecture connects the Leibniz determinant expansion (via Matrix.det_apply) to the combinatorial signed sum over permutation path tuples, then applies the Gessel-Viennot sign-reversing involution to cancel all non-identity contributions. Key proved components include a discrete intermediate value theorem for lattice path crossings, cardinality of PathMN via double induction on Pascal's rule, and the algebraic bridge equating det M with the signed permutation sum. The full canonical GV involution package is now proved — canonCrossN_preserved (canonical crossing invariant under involution), gvCanon_self_inverse (double tail-swap = identity), gvCanon_membership, gvCanon_sign_reversal, and gvCanon_no_fixed. The source contains 0 sorries and 0 axioms and is machine-verified against Mathlib v4.31.0: the ~20 Mathlib-drift errors that the file previously produced against the old v4.26.0 pin (in the canonical GV involution region, lines ~2109–2338) were resolved by the toolchain migration, and `lake env lean` now compiles the file cleanly.",
     "proofStrategy": "**Gessel-Viennot Involution**:\n1. Expand det M = Σ_σ sign(σ) ∏ᵢ M_{i,σ(i)} where M_{i,j} = e(Aᵢ, Bⱼ)\n2. Each term ∏ M_{i,σ(i)} counts σ-path tuples (Pᵢ: Aᵢ→B_{σ(i)})\n3. For σ ≠ id: find smallest i with σ(i) ≠ i; paths Pᵢ and P_{σ(i)} must cross\n4. Swap tails at first crossing point → maps σ-tuple to (swap(i,σ(i))∘σ)-tuple\n5. sign changes (transposition): terms cancel pairwise\n6. Only σ = id survives; non-NI id-tuples also cancel → niTupleCount = det M",
     "keyInsights": [
       "The sign-reversing involution pairs each σ-tuple with a τ-tuple where τ = swap(i,σ(i))∘σ has opposite sign, causing pairwise cancellation",
@@ -121,7 +121,7 @@
       "startLine": 1,
       "endLine": 76,
       "summary": "Module docstring, imports, and namespace setup for the general r×r Lindström–Gessel–Viennot lemma. These head lines introduce the problem — counting r-tuples of pairwise non-intersecting lattice paths as det[e(Aᵢ,Bⱼ)] with e(A,B)=C(dx+dy,dx) — and the sign-reversing Gessel–Viennot involution strategy that cancels every non-identity permutation, before the LGV namespace opens.",
-      "mathContext": "The LGV lemma (Lindström 1973; Gessel–Viennot 1985) expresses the number of non-intersecting path families as a determinant of single-path counts. Expanding det as an alternating sum over Sᵣ, the identity permutation contributes ∏ e(Aᵢ,Bᵢ) while every other permutation is killed by a sign-reversing involution built from swapping path tails at a forced crossing. Source is written axiom-free and sorry-free, but the file does NOT currently compile against pinned Mathlib v4.26.0 (~20 Mathlib-drift errors in the canonical GV involution region), so it is not machine-checked."
+      "mathContext": "The LGV lemma (Lindström 1973; Gessel–Viennot 1985) expresses the number of non-intersecting path families as a determinant of single-path counts. Expanding det as an alternating sum over Sᵣ, the identity permutation contributes ∏ e(Aᵢ,Bᵢ) while every other permutation is killed by a sign-reversing involution built from swapping path tails at a forced crossing. The file is axiom-free and sorry-free and machine-verified against Mathlib v4.31.0 (the ~20 Mathlib-drift errors it once produced against the old v4.26.0 pin were resolved by the toolchain migration)."
     },
     {
       "id": "lattice-path-foundations",
@@ -261,10 +261,9 @@
     }
   ],
   "conclusion": {
-    "summary": "Formalization of the general r×r LGV lemma in ~2589 lines with 0 axioms and 0 sorries in the source. The main theorem lgv_lemma_rxr states niTupleCount(cfg) = det(pathMatrix(cfg)). The intended proof chain: algebraic bridge (det = signed perm sum) → GV sign-reversing involution (cancellable sum = 0 via Finset.sum_involution with sign_reversal, no_fixed_points, membership, self_inverse) → non-cancellable counting bijection → final theorem. NOTE: as of 2026-07-04 the file does NOT compile against pinned Mathlib v4.26.0 — a clean single-agent build surfaced ~20 Mathlib-drift errors in the canonical GV involution region (lines ~2109–2338), so it is not yet machine-checked (status formalized/wip).",
+    "summary": "Formalization of the general r×r LGV lemma in ~2589 lines with 0 axioms and 0 sorries in the source. The main theorem lgv_lemma_rxr states niTupleCount(cfg) = det(pathMatrix(cfg)). The intended proof chain: algebraic bridge (det = signed perm sum) → GV sign-reversing involution (cancellable sum = 0 via Finset.sum_involution with sign_reversal, no_fixed_points, membership, self_inverse) → non-cancellable counting bijection → final theorem. Machine-verified against Mathlib v4.31.0: `lake env lean` compiles the file cleanly and `#print axioms lgv_lemma_rxr` reports only propext/Classical.choice/Quot.sound — the ~20 Mathlib-drift errors previously seen against the old v4.26.0 pin were resolved by the toolchain migration.",
     "implications": "**Theoretical Significance**: **Applications of the r×r LGV lemma:**\n1. **Schur polynomials**: Via Jacobi-Trudi, s_λ = det[h_{λᵢ-i+j}] counts NI lattice paths (semistandard Young tableaux)\n**2. Plane partitions**: MacMahon's box formula via LGV on 3D lattice\n3. **Aztec diamond**: 2^{n(n+1)/2} tilings via NI path determinant\n4. **Random matrices**: Eigenvalue spacing via NI random walk paths.",
     "openQuestions": [
-      "Repair the ~20 Mathlib-drift errors (lines ~2109–2338) so the file compiles against pinned Mathlib v4.26.0",
       "Connect to Mathlib's Schur polynomial infrastructure for the Jacobi-Trudi identity",
       "Extend to weighted lattice paths (generating function version of LGV)"
     ]


### PR DESCRIPTION
## Enrichment / integrity fix: `ballot-problem-oq-03-oq-02` (General r×r Lindström–Gessel–Viennot Determinant)

This entry (2640-line file, 0 sorries / 0 axioms) was **downgraded `verified`→`formalized`**
by PRs #34884 / #34889 because it failed to compile against the then-pinned
**Mathlib v4.26.0** with ~20 tactic-drift errors in the `canonCrossN_preserved`
region (lines ~2109–2338: `simp made no progress`, `omega`/`split_ifs` failures,
type mismatches). The repo has since migrated to **v4.31.0** (`meta.mathlib_version`
already reflects this), and the migration resolved that drift.

### Verification performed (this session)
File imports only `Mathlib` → host-verifiable without Docker:

```
lake env lean Proofs/BallotProblemOQ03OQ02.lean   # exit 0, 0 errors
```

Compiles cleanly (only benign unused-simp-arg / deprecated-`push_neg` linter notes —
**no errors**). `#print axioms` on the headline theorems `lgv_lemma_rxr`,
`gv_involution_cancellation`, `det_pathMatrix_eq_signed_sum`, and
`gessel_viennot_transposition_sign` reports dependence on **only** `propext`,
`Classical.choice`, `Quot.sound` — no `sorryAx`, no `Lean.ofReduceBool`.

### Axiom integrity
Source has 0 `axiom` declarations, 0 sorries, no `native_decide`, and no
structure-encoded assumptions (the GV involution machinery is proved outright).
So `status: "verified"` / `axiomCount: 0` is accurate.

### Changes (meta.json only)
- `status`: `"formalized"` → `"verified"`; `badge`: `"wip"` → `"verified"`
- removed the stale *"does not compile / downgraded pending repair"* clauses from
  `description`, `assumptions`, `overview.text`, `sections[0].mathContext`,
  `conclusion.summary`, and two `originalContributions` items — reframed as the
  resolved v4.31.0 verification (past-tense references to the old v4.26.0 drift kept
  as history)
- dropped the now-resolved openQuestion *"Repair the ~20 Mathlib-drift errors…"*
  (2 genuinely-open questions remain: Jacobi-Trudi/Schur link, weighted LGV)

No source (.lean) changes; no content deleted beyond the resolved caveat/question.