### PR TITLE
audit: re-serve binomial-theorem-oq-03-oq-02 (verified/mathlib) — clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -3113,9 +3113,9 @@
       "result": "clean"
     },
     "binomial-theorem-oq-03-oq-02": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-04T03:58:18Z",
+      "lastAudited": "2026-07-20T15:07:38Z",
       "result": "clean"
     },
     "binomial-theorem-oq-03-oq-02-oq-03": {


### PR DESCRIPTION
## Gallery Integrity Audit — clean

**Proof**: binomial-theorem-oq-03-oq-02 — "The Classical Limit (1+x/n)^n → exp(x)"
**Result**: clean (no integrity issues)

Reserve-mode re-audit (queue drained; uncontested non-erdos verified/mathlib target).

## Verified

- **Counts match file**: 0 axioms, 0 sorries, 0 True stubs, 0 native_decide; 10 theorems; 215 lines — all agree with meta.json.
- **No phantom declarations**: all 10 `originalContributions` map to real decls in `Proofs/BinomialTheoremOQ03OQ02.lean`.
- **Honest tier**: `badge: mathlib` correctly discloses Mathlib reliance (log derivative, exp continuity). `one_plus_le_exp` is explicitly documented as restated from `Real.add_one_le_exp`.
- **No overclaims**: main theorem `tendsto_one_plus_div_pow_exp` is genuinely derived (six-step log-slope + exp-continuity argument), not a one-line wrapper; summary theorem is a real conjunction, not a vacuous `True` stub. No "first formalization" language.

Only change: bump audit-tracker (`auditCount` 3→4, `result: clean`).

---
Discovered during gallery integrity audit.