### PR TITLE
Research: erdos-870-incomplete-01 — parent sorries assert false (representationCount degenerate, axiom-free)

### DIFF
--- a/proofs/Proofs/Erdos870Incomplete01.lean
+++ b/proofs/Proofs/Erdos870Incomplete01.lean
@@ -1,0 +1,103 @@
+import Mathlib
+import Proofs.Erdos870Problem
+
+/-
+# Erdős #870 — the representation count is degenerate as defined
+# (erdos-870-incomplete-01)
+
+## Finding
+
+`Erdos870Problem.lean` leaves two `sorry`s — `naturals_basis`
+(`IsAdditiveBasis NaturalNumbers 1`) and the `basis_subset_reps` inheritance
+step — both of which reduce to proving `representationCount A k n ≥ 1`.
+
+**These sorries cannot be discharged honestly: they assert a false statement.**
+The culprit is the definition
+
+```
+structure KRepresentation (A) (k n) where
+  terms : Finset ℕ
+  count : ℕ → ℕ           -- unconstrained off `terms`
+  sum_eq : terms.sum count = n
+  ...
+noncomputable def representationCount A k n := Nat.card {rep : KRepresentation A k n // True}
+```
+
+The field `count : ℕ → ℕ` is a *total* function whose values **off** `terms` are
+unconstrained (`sum_eq` only pins `∑_{terms} count`). So whenever a single
+representation exists, perturbing `count` at any point outside `terms` yields
+infinitely many distinct representations — the representation type is infinite,
+hence `Nat.card = 0`. And if none exists the type is empty, again `Nat.card = 0`.
+Either way `representationCount A k n = 0`, so `IsAdditiveBasis A k`
+(`∃ n₀, ∀ n ≥ n₀, representationCount ≥ 1`) is **unsatisfiable for every `A`, `k`**.
+
+## Results (namespace `Erdos870`)
+
+1. `representationCount_eq_zero` — `representationCount A k n = 0` unconditionally.
+
+2. `not_isAdditiveBasis` — consequently `¬ IsAdditiveBasis A k` for every `A`, `k`.
+
+The fix (out of scope here, a definition change to the parent) is to make `count`
+finitely supported — e.g. `count : ℕ →₀ ℕ` with `count.support ⊆ terms`, or drop
+`count` and sum a multiset. Until then the file's basis theory is vacuous and the
+two sorries should not be "closed". This is the honest resolution of the node.
+
+## Summary: 0 sorries, 0 axioms, no `native_decide`. Built over the gallery defs.
+-/
+
+open Finset
+
+namespace Erdos870
+
+/-- **The representation count is identically zero as defined.** The unconstrained
+total field `count : ℕ → ℕ` makes the representation type infinite whenever it is
+nonempty (perturb `count` off `terms`), and `Nat.card` of an infinite type is `0`. -/
+theorem representationCount_eq_zero (A : AdditiveSet) (k n : ℕ) :
+    representationCount A k n = 0 := by
+  rw [representationCount]
+  rcases isEmpty_or_nonempty (KRepresentation A k n) with he | hne
+  · -- No representation: the subtype is empty.
+    rw [Nat.card_eq_zero]
+    exact Or.inl ⟨fun x => he.false x.1⟩
+  · -- A representation exists ⟹ infinitely many ⟹ Nat.card = 0.
+    obtain ⟨r⟩ := hne
+    -- Pick a point `w ∉ r.terms` and perturb `r.count` there.
+    obtain ⟨w, hw⟩ : ∃ w, w ∉ r.terms :=
+      ⟨r.terms.sup id + 1, by
+        intro hmem
+        have hle := Finset.le_sup (f := id) hmem
+        simp only [id_eq] at hle
+        omega⟩
+    have hsum : ∀ m : ℕ, (r.terms.sum (Function.update r.count w m)) = n := by
+      intro m
+      have hcongr : r.terms.sum (Function.update r.count w m) = r.terms.sum r.count := by
+        apply Finset.sum_congr rfl
+        intro x hx
+        have hxw : x ≠ w := by rintro rfl; exact hw hx
+        rw [Function.update_apply, if_neg hxw]
+      rw [hcongr]; exact r.sum_eq
+    -- The map `m ↦ (perturbed rep)` injects `ℕ` into the subtype.
+    let g : ℕ → { rep : KRepresentation A k n // True } := fun m =>
+      ⟨{ terms := r.terms, count := Function.update r.count w m,
+         sum_eq := hsum m, bound := r.bound, subset := r.subset }, trivial⟩
+    have hg : Function.Injective g := by
+      intro m m' hmm'
+      -- Equal subtype values ⟹ equal `count` fields ⟹ equal at `w` ⟹ `m = m'`.
+      have h2 : (g m).val = (g m').val := Subtype.ext_iff.mp hmm'
+      have hcount : Function.update r.count w m = Function.update r.count w m' :=
+        congrArg KRepresentation.count h2
+      have hval := congrFun hcount w
+      simpa using hval
+    haveI : Infinite { rep : KRepresentation A k n // True } :=
+      Infinite.of_injective g hg
+    exact Nat.card_eq_zero_of_infinite
+
+/-- Consequently the basis predicate is unsatisfiable: no set is an additive basis
+of any order under the current (degenerate) `representationCount`. -/
+theorem not_isAdditiveBasis (A : AdditiveSet) (k : ℕ) : ¬ IsAdditiveBasis A k := by
+  rintro ⟨n₀, h⟩
+  have h1 := h n₀ (le_refl n₀)
+  rw [representationCount_eq_zero] at h1
+  exact absurd h1 (by norm_num)
+
+end Erdos870

--- a/research/problems/erdos-870-incomplete-01/knowledge.md
+++ b/research/problems/erdos-870-incomplete-01/knowledge.md
@@ -1,0 +1,27 @@
+
+---
+
+## Session (researcher-1, 2026-07-20) — the two sorries assert FALSE statements (axiom-free finding)
+
+Created `proofs/Proofs/Erdos870Incomplete01.lean` (2 theorems, 0 sorry, 0 axiom;
+host-verified, `#print axioms` = `[propext, Classical.choice, Quot.sound]`, no
+dependence on the parent's axioms or `F_2`-style sorries).
+
+**Finding.** The parent's `representationCount A k n = Nat.card {rep :
+KRepresentation A k n // True}` is **identically 0**. `KRepresentation.count :
+ℕ → ℕ` is a total function pinned by `sum_eq` only on `terms`; perturbing it off
+`terms` produces infinitely many distinct representations, so the type is
+infinite and `Nat.card = 0` (and empty if no rep exists — still 0). Hence:
+
+- `representationCount_eq_zero` — `representationCount A k n = 0` unconditionally.
+- `not_isAdditiveBasis` — `¬ IsAdditiveBasis A k` for every `A`, `k`.
+
+Therefore both parent sorries — `naturals_basis` (line 199) and
+`basis_subset_reps` (line 221), each reducing to `representationCount ≥ 1` —
+**cannot be honestly closed; they assert false statements.** This is the honest
+resolution of the incomplete-01 node: the sorries are not "hard", they are
+unprovable as stated.
+
+### Required fix (parent definition change — out of companion scope)
+Make `count` finitely supported: `count : ℕ →₀ ℕ` with `support ⊆ terms`, or
+drop `count` in favour of a multiset of `terms`. Recorded as a structured blocker.

--- a/src/data/research/problems/erdos-870-incomplete-01.json
+++ b/src/data/research/problems/erdos-870-incomplete-01.json
@@ -1,7 +1,7 @@
 {
   "slug": "erdos-870-incomplete-01",
   "title": "Complete proof of Erdős Problem #870: Minimal Additive Bases (2 sorries)",
-  "phase": "NEW",
+  "phase": "ACT",
   "status": "available",
   "tier": "B",
   "path": "full",
@@ -20,7 +20,13 @@
     "since": "2026-07-09T00:00:00.000Z",
     "iteration": 0,
     "focus": "Initial exploration of the problem.",
-    "blockers": [],
+    "blockers": [
+      {
+        "route": "close naturals_basis / basis_subset_reps sorries as stated",
+        "reopenCriterion": "parent representationCount redefined with finitely-supported count (currently degenerate ≡0, sorries assert false)",
+        "blockedAt": "2026-07-20"
+      }
+    ],
     "nextAction": "Begin problem exploration.",
     "attemptCounts": {
       "total": 0,
@@ -29,9 +35,16 @@
     }
   },
   "knowledge": {
-    "progressSummary": "AVAILABLE: parent formalization has 2 open sorry statement(s) to complete.",
-    "builtItems": [],
-    "insights": [],
+    "progressSummary": "FINDING: the two parent sorries (naturals_basis, basis_subset_reps) assert FALSE statements — representationCount is degenerate (≡0). Proved representationCount_eq_zero and not_isAdditiveBasis (axiom-free). The def KRepresentation.count : ℕ→ℕ is unconstrained off terms, making the rep type infinite ⟹ Nat.card=0 ⟹ IsAdditiveBasis unsatisfiable. Needs a parent def fix (finitely-supported count).",
+    "builtItems": [
+      "Erdos870.representationCount_eq_zero in Erdos870Incomplete01.lean",
+      "Erdos870.not_isAdditiveBasis in Erdos870Incomplete01.lean"
+    ],
+    "insights": [
+      "representationCount A k n = Nat.card {rep : KRepresentation A k n // True} is IDENTICALLY 0: KRepresentation.count : ℕ→ℕ is a total function only pinned on terms by sum_eq, so any existing rep spawns infinitely many by perturbing count off terms (Nat.card of infinite = 0); if none exists the type is empty (also 0).",
+      "Consequently IsAdditiveBasis A k (∃n₀,∀n≥n₀, representationCount≥1) is unsatisfiable for every A,k — proved not_isAdditiveBasis. So the parent sorries naturals_basis (line 199) and basis_subset_reps (line 221), both reducing to representationCount≥1, CANNOT be honestly closed; they assert false statements.",
+      "Fix (parent def change, out of scope for a companion): make count finitely supported — count : ℕ →₀ ℕ with support ⊆ terms, or replace count by a multiset of terms. Then representationCount becomes a genuine finite count."
+    ],
     "mathlibGaps": [],
     "nextSteps": []
   },


### PR DESCRIPTION
## Summary

The `erdos-870-incomplete-01` node exposes two `sorry`s in `Erdos870Problem.lean`
(`naturals_basis`, `basis_subset_reps`), both reducing to
`representationCount A k n ≥ 1`. **These sorries cannot be honestly closed — they
assert a false statement.** `proofs/Proofs/Erdos870Incomplete01.lean` proves why,
axiom-free (2 theorems, 0 sorry, 0 axiom, namespace `Erdos870`).

## The defect

```
structure KRepresentation (A) (k n) where
  terms : Finset ℕ
  count : ℕ → ℕ            -- total, unconstrained OFF `terms`
  sum_eq : terms.sum count = n
  ...
def representationCount A k n := Nat.card {rep : KRepresentation A k n // True}
```

`count` is pinned by `sum_eq` only on `terms`. So one representation begets
infinitely many (perturb `count` at any point outside `terms`) — the type is
infinite, `Nat.card = 0`. If none exists, the type is empty — again `0`.

## Results

| Theorem | Statement |
|---|---|
| `representationCount_eq_zero` | `representationCount A k n = 0` (unconditional) |
| `not_isAdditiveBasis` | `¬ IsAdditiveBasis A k` for every `A`, `k` |

So `naturals_basis` and `basis_subset_reps` are **unprovable as stated**, not
merely hard.

## Required fix (parent definition change — out of this companion's scope)

Make `count` finitely supported: `count : ℕ →₀ ℕ` with `support ⊆ terms`, or drop
`count` for a multiset of `terms`. Recorded as a structured blocker on the node.

## Verification

Host-verified docker-free (`bin/lake env lean`, v4.31): compile exit 0. `#print
axioms` on both = `[propext, Classical.choice, Quot.sound]` — no `sorryAx`, no
dependence on the parent's `axiom`s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)