### PR TITLE
Enrich de-moivre-oq-02-oq-02-oq-01: promote pending→verified (Chebyshev U·U, host-checked v4.31.0)

### DIFF
--- a/src/data/proofs/de-moivre-oq-02-oq-02-oq-01/meta.json
+++ b/src/data/proofs/de-moivre-oq-02-oq-02-oq-01/meta.json
@@ -7,7 +7,7 @@
     "author": "Formalized in Lean 4 (Mathlib)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Chebyshev_polynomials#Products_of_Chebyshev_polynomials",
     "date": "2026",
-    "status": "pending",
+    "status": "verified",
     "proofRepoPath": "Proofs/DeMoivreOQ02OQ02OQ01.lean",
     "tags": [
       "chebyshev-polynomials",
@@ -20,13 +20,13 @@
       "finset-sum",
       "research"
     ],
-    "badge": "wip",
+    "badge": "verified",
     "sorries": 0,
     "dateAdded": "2026-06-15",
     "mathlib_version": "4.31.0",
     "axiomCount": 0,
     "lineCount": 146,
-    "assumptions": "0 axioms, 0 sorries, but BUILD-PENDING — not yet machine-checked. The proof is fully written, but the flip-to-verified build (#24866) was terminated during the Mathlib cache download before this file was ever elaborated, so no successful compilation exists. Needs `docker-build.sh Proofs.DeMoivreOQ02OQ02OQ01` to confirm before any verified claim. Polynomial identity over any commutative ring R, for m : ℤ and n : ℕ.",
+    "assumptions": "0 axioms, 0 sorries. Machine-verified against Mathlib v4.31.0: `lake env lean Proofs/DeMoivreOQ02OQ02OQ01.lean` compiles cleanly, and `#print axioms U_mul_U` / `Ssum_rec` report dependence on only propext, Classical.choice, Quot.sound (no sorryAx, no Lean.ofReduceBool). The earlier flip-to-verified build (#24866) had been aborted during the Mathlib cache download before the file was ever elaborated; that infrastructure gap is now resolved. Polynomial identity over any commutative ring R, for m : ℤ and n : ℕ.",
     "theoremCount": 6,
     "definitionCount": 1,
     "originalContributions": [
@@ -94,7 +94,7 @@
       "title": "Open Question, Answer, and Strategy",
       "startLine": 1,
       "endLine": 52,
-      "summary": "Imports, module docstring, and setup. States the open question left by the parent T·U entry — can U_m·U_n be written purely as second-kind polynomials, with no T and no (1−x²) factor? — and answers YES with the linearization U_m·U_n = ∑_{k=0}^{n} U_{m+n−2k}. Records the proof plan (sum recurrence + two-step induction), the build-pending status, and fixes the ambient commutative ring R.",
+      "summary": "Imports, module docstring, and setup. States the open question left by the parent T·U entry — can U_m·U_n be written purely as second-kind polynomials, with no T and no (1−x²) factor? — and answers YES with the linearization U_m·U_n = ∑_{k=0}^{n} U_{m+n−2k}. Records the proof plan (sum recurrence + two-step induction) and fixes the ambient commutative ring R.",
       "mathContext": "$U_m \\cdot U_n = \\sum_{k=0}^{n} U_{m+n-2k} = U_{m+n} + U_{m+n-2} + \\cdots + U_{m-n}$ in $R[X]$."
     },
     {


### PR DESCRIPTION
## Enrichment / integrity fix: `de-moivre-oq-02-oq-02-oq-01` (Chebyshev U·U Linearization)

146-line file, imports only `Mathlib`, 0 sorries / 0 axioms. It was `status: "pending"` /
`badge: "wip"` because the flip-to-verified build (#24866) was **aborted during the
Mathlib cache download before the file was ever elaborated** — an infrastructure gap,
not a compile failure.

### Verification performed
```
lake env lean Proofs/DeMoivreOQ02OQ02OQ01.lean   # exit 0, 0 errors
```
Compiles cleanly. `#print axioms U_mul_U` and `Ssum_rec` report dependence on only
`propext, Classical.choice, Quot.sound` — no `sorryAx`, no `Lean.ofReduceBool`.

### Changes (meta.json only)
- `status`: `"pending"` → `"verified"`; `badge`: `"wip"` → `"verified"`
- `assumptions`: BUILD-PENDING note → the v4.31.0 machine-check + `#print axioms` result
- `sections[0].summary`: dropped the "build-pending status" clause

No source changes; no content deleted.