### PR TITLE
Enrich dirichlets-theorem-oq-02-oq-03: realign & extend section coverage (4→13 sections)

### DIFF
--- a/src/data/proofs/dirichlets-theorem-oq-02-oq-03/annotations.json
+++ b/src/data/proofs/dirichlets-theorem-oq-02-oq-03/annotations.json
@@ -2,73 +2,132 @@
   {
     "id": "ann-header-context",
     "proofId": "dirichlets-theorem-oq-02-oq-03",
-    "range": { "startLine": 1, "endLine": 35 },
+    "range": {
+      "startLine": 1,
+      "endLine": 35
+    },
     "type": "concept",
     "title": "Certified Growth vs. True Asymptotics",
     "content": "The parent entry proves *infinitely many* primes $\\equiv 3 \\pmod 4$ via Euclid's argument. This file asks a quantitative follow-up: a constructive existence proof that produces the next prime as a factor of $N = 4\\cdot(n+1)! - 1$ automatically certifies a *growth rate*. Writing $p_0 < p_1 < \\dots$ for the increasing enumeration of primes $\\equiv 3 \\pmod 4$, the construction yields the explicit iterated-factorial tower $B_0 = 3$, $B_{k+1} = 4\\cdot(B_k+1)! - 1$ as an upper bound on $p_k$. The genuine asymptotic $p_k \\sim 2k\\ln k$ (PNT for arithmetic progressions) is incomparably smaller — the whole point of the file is to make that gap precise and honest.",
     "mathContext": "$q = 4$, $a = 3$: the elementary case of Dirichlet's theorem, where units mod 4 form $\\{1, 3\\}$",
     "significance": "central",
-    "relatedConcepts": ["Euclid's argument", "prime number theorem for APs", "explicit bounds", "iterated factorial"],
-    "prerequisites": ["modular arithmetic", "infinitude of primes"]
+    "relatedConcepts": [
+      "Euclid's argument",
+      "prime number theorem for APs",
+      "explicit bounds",
+      "iterated factorial"
+    ],
+    "prerequisites": [
+      "modular arithmetic",
+      "infinitude of primes"
+    ]
   },
   {
     "id": "ann-interval-bound",
     "proofId": "dirichlets-theorem-oq-02-oq-03",
-    "range": { "startLine": 78, "endLine": 100 },
+    "range": {
+      "startLine": 78,
+      "endLine": 100
+    },
     "type": "theorem",
     "title": "The Euclid Interval Bound",
     "content": "`exists_prime_three_mod_four_in_interval` is the certified content of Euclid's construction in interval form: for every $n$ there is a prime $p \\equiv 3 \\pmod 4$ with $n < p \\le 4\\cdot(n+1)! - 1$. The upper bound is immediate — $p$ divides $N = 4\\cdot(n+1)! - 1$, so $p \\le N$. The lower bound $p > n$ is the Euclid twist: if $p \\le n+1$ then $p \\mid (n+1)! \\mid N+1$, while $p \\mid N$, forcing $p \\mid (N+1) - N = 1$, impossible for a prime. The existence of a factor $\\equiv 3 \\pmod 4$ uses that $N \\equiv 3 \\pmod 4$ cannot be a product of primes all $\\equiv 1 \\pmod 4$.",
     "mathContext": "A prime $\\equiv 3 \\pmod 4$ always occupies the window $(n,\\, 4(n+1)! - 1]$",
     "significance": "central",
-    "relatedConcepts": ["Euclid's argument", "factorial", "coprimality of consecutive integers"],
-    "prerequisites": ["divisibility", "gcd(N, N+1) = 1"]
+    "relatedConcepts": [
+      "Euclid's argument",
+      "factorial",
+      "coprimality of consecutive integers"
+    ],
+    "prerequisites": [
+      "divisibility",
+      "gcd(N, N+1) = 1"
+    ]
   },
   {
     "id": "ann-next-prime",
     "proofId": "dirichlets-theorem-oq-02-oq-03",
-    "range": { "startLine": 111, "endLine": 134 },
+    "range": {
+      "startLine": 111,
+      "endLine": 134
+    },
     "type": "definition",
     "title": "nextP3: the Immediate Next Prime ≡ 3 (mod 4)",
     "content": "`nextP3 n` is defined as `Nat.find` of the predicate 'prime $\\equiv 3 \\pmod 4$ and $> n$', well defined because such primes exist above every $n$ (the interval bound). `Nat.find` returns the *least* witness, so `nextP3_le_of` shows any prime $q \\equiv 3 \\pmod 4$ with $q > n$ satisfies $\\text{nextP3}\\,n \\le q$ — i.e. no such prime is skipped. Combined with the interval bound, `nextP3_le_factorial` gives the one-step estimate $\\text{nextP3}\\,n \\le 4\\cdot(n+1)! - 1$, the engine of the tower.",
     "mathContext": "The successor function on primes $\\equiv 3 \\pmod 4$, packaged without Mathlib's `Nat.nth`",
     "significance": "supporting",
-    "relatedConcepts": ["Nat.find", "least witness", "well-founded search"],
-    "prerequisites": ["decidability of primality", "Nat.find_spec / Nat.find_min'"]
+    "relatedConcepts": [
+      "Nat.find",
+      "least witness",
+      "well-founded search"
+    ],
+    "prerequisites": [
+      "decidability of primality",
+      "Nat.find_spec / Nat.find_min'"
+    ]
   },
   {
     "id": "ann-enumeration",
     "proofId": "dirichlets-theorem-oq-02-oq-03",
-    "range": { "startLine": 136, "endLine": 168 },
+    "range": {
+      "startLine": 136,
+      "endLine": 168
+    },
     "type": "definition",
     "title": "p3: the Increasing Enumeration",
     "content": "`p3` iterates `nextP3` from the least prime $\\equiv 3 \\pmod 4$: `p3 0 = 3`, `p3 (k+1) = nextP3 (p3 k)`. Because it starts at the smallest such prime and each step takes the immediate next (minimality of `nextP3`), `p3` enumerates *all* primes $\\equiv 3 \\pmod 4$ in increasing order with none skipped — so `p3 k` is exactly the $k$-th such prime. `p3_prime`, `p3_mod`, and `p3_strictMono` certify these properties directly, avoiding any appeal to `Nat.nth`.",
     "mathContext": "$p_0 = 3 < p_1 = 7 < p_2 = 11 < \\dots$",
     "significance": "central",
-    "relatedConcepts": ["enumeration", "strict monotonicity", "structural recursion"],
-    "prerequisites": ["strictMono_nat_of_lt_succ"]
+    "relatedConcepts": [
+      "enumeration",
+      "strict monotonicity",
+      "structural recursion"
+    ],
+    "prerequisites": [
+      "strictMono_nat_of_lt_succ"
+    ]
   },
   {
     "id": "ann-tower-bound",
     "proofId": "dirichlets-theorem-oq-02-oq-03",
-    "range": { "startLine": 194, "endLine": 201 },
+    "range": {
+      "startLine": 212,
+      "endLine": 264
+    },
     "type": "theorem",
     "title": "The Certified Tower Bound p3 k ≤ B k",
     "content": "`p3_le_tower` is the main result: the $k$-th prime $\\equiv 3 \\pmod 4$ is at most $B(k)$, where $B(0)=3$ and $B(k+1)=4\\cdot(B(k)+1)!-1$. The induction is a three-line `calc`: $p_3(k+1) = \\text{nextP3}(p_3 k) \\le 4\\cdot(p_3 k + 1)! - 1 \\le 4\\cdot(B_k+1)! - 1 = B(k+1)$, using the one-step factorial bound and monotonicity of $x \\mapsto 4\\cdot(x+1)!-1$ (`step_mono`) with the inductive hypothesis $p_3 k \\le B_k$.",
     "mathContext": "$B_0 = 3,\\ B_1 = 95,\\ B_2 = 4\\cdot 96! - 1,\\ \\dots$ — an iterated-factorial tower",
     "significance": "central",
-    "relatedConcepts": ["induction", "iterated factorial", "monotonicity"],
-    "prerequisites": ["Nat.factorial_le", "Nat subtraction monotonicity"]
+    "relatedConcepts": [
+      "induction",
+      "iterated factorial",
+      "monotonicity"
+    ],
+    "prerequisites": [
+      "Nat.factorial_le",
+      "Nat subtraction monotonicity"
+    ]
   },
   {
     "id": "ann-honest-contrast",
     "proofId": "dirichlets-theorem-oq-02-oq-03",
-    "range": { "startLine": 203, "endLine": 229 },
+    "range": {
+      "startLine": 265,
+      "endLine": 291
+    },
     "type": "insight",
     "title": "How Loose Is the Certified Bound?",
     "content": "`p3_one` computes $p_3(1) = 7$ (proved by ruling out 4, 5, 6 via the minimality of `nextP3`), and `B_one` gives $B_1 = 95$ by kernel `decide` (keeping the file `ofReduceBool`-free). So already at $k = 1$ the certified bound overshoots the truth by more than $13\\times$, and the gap explodes: $B_2 = 4\\cdot 96! - 1$ dwarfs $p_3(2) = 11$. This is the honest headline — Euclid's argument certifies existence with an iterated-factorial rate, whereas the real growth $p_k \\sim 2k\\ln k$ is essentially linear. Closing the gap provably requires analytic (PNT-level) input the elementary construction cannot supply.",
     "mathContext": "Certified $p_k \\le$ tower of factorials vs. true $p_k \\sim 2k\\ln k$",
     "significance": "central",
-    "relatedConcepts": ["prime number theorem for APs", "effective vs. ineffective bounds", "kernel decide"],
-    "prerequisites": ["asymptotic density of primes in APs"]
+    "relatedConcepts": [
+      "prime number theorem for APs",
+      "effective vs. ineffective bounds",
+      "kernel decide"
+    ],
+    "prerequisites": [
+      "asymptotic density of primes in APs"
+    ]
   }
 ]

--- a/src/data/proofs/dirichlets-theorem-oq-02-oq-03/meta.json
+++ b/src/data/proofs/dirichlets-theorem-oq-02-oq-03/meta.json
@@ -87,39 +87,108 @@
   },
   "sections": [
     {
-      "id": "header",
+      "id": "overview",
       "title": "File Overview",
+      "summary": "Motivating contrast between an elementary *certified* growth bound for the primes ≡ 3 (mod 4) and their true asymptotic density (Dirichlet). Sets up the certified factorial/primorial towers B and C and the honest gap between the provable lower bound and the truth.",
       "startLine": 1,
-      "endLine": 35,
-      "summary": "Frames the certified-bound question: the Euclid tower B(k) as an upper bound on the k-th prime ≡ 3 (mod 4), versus the true p_k ∼ 2k·ln k; imports and namespace."
+      "endLine": 36,
+      "mathContext": "Header docstring and imports framing OQ-02-OQ-03: proving explicit, kernel-checkable lower bounds on the k-th prime ≡ 3 (mod 4) and its counting function π(x; 4, 3), and quantifying how far these certified towers sit below the real n·log-scale growth."
     },
     {
-      "id": "interval-bound",
+      "id": "step-1",
       "title": "Step 1: The Euclid Interval Bound",
+      "summary": "Euclid-style existence: every n has a prime factor ≡ 3 (mod 4) exceeding a given bound, giving a prime ≡ 3 (mod 4) in a controlled interval and one larger than any N.",
       "startLine": 37,
-      "endLine": 105,
-      "summary": "Re-proves the factor lemma and packages the construction as exists_prime_three_mod_four_in_interval: a prime ≡ 3 (mod 4) always lies in (n, 4·(n+1)! − 1]."
+      "endLine": 106,
+      "mathContext": "exists_prime_factor_three_mod_four, exists_prime_three_mod_four_in_interval and exists_prime_three_mod_four_gt: the classical Euclidean argument (a product +2 style witness) forces a new prime ≡ 3 (mod 4), bounding where the next one must appear."
     },
     {
-      "id": "next-prime-enumeration",
-      "title": "Step 2: The Next Prime and the Increasing Enumeration",
+      "id": "step-2",
+      "title": "Step 2: The Next Prime and the Increasing Enumeration p3",
+      "summary": "Defines nextP3 (the immediate next prime ≡ 3 (mod 4) above n) and the strictly increasing enumeration p3 of all primes ≡ 3 (mod 4), proving it is prime-valued, ≡ 3 (mod 4), strictly monotone, and surjective onto that set.",
       "startLine": 107,
-      "endLine": 168,
-      "summary": "Defines nextP3 (least prime ≡ 3 mod 4 above n) with its spec and minimality, the one-step factorial bound nextP3_le_factorial, and the enumeration p3 with p3_prime/p3_mod/p3_strictMono."
+      "endLine": 211,
+      "mathContext": "nextP3 with nextP3_gt/_prime/_mod/_le_factorial; p3 with p3_prime, p3_mod, p3_strictMono, p3_le_self, p3_surjective and mem_range_p3_iff establishing that p3 enumerates exactly the primes ≡ 3 (mod 4)."
     },
     {
-      "id": "tower-bound",
-      "title": "Step 3: The Certified Iterated-Factorial Tower",
-      "startLine": 170,
-      "endLine": 201,
-      "summary": "Defines B(0)=3, B(k+1)=4·(B(k)+1)!−1, proves monotonicity of the one-step map, and the main bound p3_le_tower: p3 k ≤ B k."
+      "id": "step-3",
+      "title": "Step 3: The Certified Iterated-Factorial Tower Bound",
+      "summary": "Defines the factorial tower B and proves the certified upper bound p3 k ≤ B k, together with the linear lower bound and the two-sided bracket for p3.",
+      "startLine": 212,
+      "endLine": 264,
+      "mathContext": "def B (iterated-factorial tower), step_mono, p3_le_tower (p3 k ≤ B k), p3_ge_linear and p3_bracketed give an explicit, kernel-certified two-sided envelope for the k-th prime ≡ 3 (mod 4)."
     },
     {
-      "id": "sanity-contrast",
+      "id": "step-4",
       "title": "Step 4: Worked Values and the Honest Contrast",
-      "startLine": 203,
-      "endLine": 229,
-      "summary": "p3 1 = 7 and B 1 = 95 (via kernel decide), with tower_loose_at_one quantifying the looseness against the true 2k·ln k asymptotic."
+      "summary": "Sanity checks at small k (p3_one, B_one) and tower_loose_at_one, quantifying how loose the certified factorial-tower bound is against the true value.",
+      "startLine": 265,
+      "endLine": 291,
+      "mathContext": "p3_one, B_one, tower_loose_at_one: worked base cases demonstrating the (large) gap between the certified bound B and the actual primes, motivating the tighter primorial tower next."
+    },
+    {
+      "id": "step-5",
+      "title": "Step 5: The Tighter Primorial Bound",
+      "summary": "Introduces the primorial tower C (via towerProd) and proves the sharper certified bound p3 k ≤ C k, with worked values and the fact that the primorial tower is tighter than the factorial tower.",
+      "startLine": 292,
+      "endLine": 409,
+      "mathContext": "p3_le_primorial; def towerProd, def C, C_eq, towerProd_eq_prod, p3_le_primorialTower; C_zero_eq/C_one_eq/C_two_eq; primorial_tighter_than_factorial and p3_bracketed_primorial sharpen Step 3's envelope using primorials instead of factorials."
+    },
+    {
+      "id": "step-6",
+      "title": "Step 6: The Primorial Tower Never Exceeds the Factorial Tower (C k ≤ B k)",
+      "summary": "Proves the (weak) domination C k ≤ B k of the primorial tower by the factorial tower, via the per-step factorial bound.",
+      "startLine": 410,
+      "endLine": 462,
+      "mathContext": "factorial_ge_mul_pred, towerProd_succ_le_factorial and C_le_B: each primorial step is dominated by the corresponding factorial step, so C k ≤ B k for all k."
+    },
+    {
+      "id": "step-7",
+      "title": "Steps 7–8: Strict Domination and the Closed-form Doubly-exponential Bound",
+      "summary": "Upgrades to strict domination C k < B k for k ≥ 1 (with the equality case), and derives an explicit non-recursive closed-form doubly-exponential bracket for the primorial tower C — showing the doubly-exponential growth is intrinsic.",
+      "startLine": 463,
+      "endLine": 629,
+      "mathContext": "factorial_gt_mul_pred, towerProd_succ_lt_factorial, C_lt_B, C_eq_B_iff (strict domination); four_mul_towerProd_le, C_le_doubly_exp, p3_le_doubly_exp, towerProd_ge, C_ge_doubly_exp and C_doubly_exp_bracket give a matching two-sided doubly-exponential closed form for C."
+    },
+    {
+      "id": "step-9",
+      "title": "Step 9: The Factorial Tower B Is Tower-exponential",
+      "summary": "Shows B grows tower-exponentially: 2^(...) lower bounds on successive B values, and 2^k · C k ≤ B (k+1), widening the gap between B and C.",
+      "startLine": 630,
+      "endLine": 684,
+      "mathContext": "two_pow_le_succ_factorial, B_succ_ge_two_pow and two_pow_C_le_B_succ establish exponential blow-up of B relative to C at each step."
+    },
+    {
+      "id": "step-10",
+      "title": "Step 10: The Ratio B / C Diverges",
+      "summary": "Proves B k ≥ (C k)² and m · C k ≤ B k for every m, so the ratio B/C diverges — the factorial tower outpaces the primorial tower without bound.",
+      "startLine": 685,
+      "endLine": 796,
+      "mathContext": "C_succ_add_one, C_succ_le_sq, C_mono, C_ge_add, quartic_le_two_pow, C_sq_le_B ((C k)² ≤ B k) and B_div_C_diverges: the certified factorial tower dominates every constant multiple of the primorial tower."
+    },
+    {
+      "id": "step-11",
+      "title": "Step 11: The Factorial Tower B Is Tetrational (2 ↑↑ k ≤ B k)",
+      "summary": "Introduces the tetration tower tower2 (2 ↑↑ k) and sandwiches it strictly between the doubly-exponential and factorial growth, giving a growth-class separation.",
+      "startLine": 797,
+      "endLine": 902,
+      "mathContext": "def tower2 (2 ↑↑ k), tower2_le_B (2 ↑↑ k ≤ B k), two_pow_le_tower2, doubly_exp_le_tower2, tower2_lt_doubly_exp_at_four and growth_class_separation separate tetrational B from the doubly-exponential C."
+    },
+    {
+      "id": "step-12",
+      "title": "Step 12: A Certified Lower Bound on the Counting Function π(x; 4, 3)",
+      "summary": "Defines the counting function primesCount3 for primes ≡ 3 (mod 4) up to x, and proves an unbounded certified lower bound driven by the doubly-exponential tower.",
+      "startLine": 903,
+      "endLine": 976,
+      "mathContext": "def primesCount3, card_le_primesCount3, primesCount3_mono, primesCount3_ge_of_doubly_exp, primesCount3_ge and primesCount3_unbounded: transfer the tower bounds to a certified, unbounded lower bound on π(x; 4, 3)."
+    },
+    {
+      "id": "step-13",
+      "title": "Step 13: B Dominates Every Fixed Power of C",
+      "summary": "Strengthens Step 10: for every fixed exponent p, (C k)^p ≤ B k eventually, so B/(C^p) diverges and B/C → ∞ — the factorial tower beats every fixed polynomial power of the primorial tower.",
+      "startLine": 977,
+      "endLine": 1095,
+      "mathContext": "two_pow_two_mul_le_tower2, C_pow_le_B_eventually ((C k)^p ≤ B k eventually), B_div_C_pow_diverges, tendsto_B_div_C_pow_atTop and tendsto_B_div_C_atTop: the domination of B over C holds against every fixed power, an atTop-divergence of the ratio."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary

Section-drift / navigation-accuracy fix for the `dirichlets-theorem-oq-02-oq-03` gallery entry (certified growth bounds for primes ≡ 3 (mod 4) and π(x; 4, 3)).

`meta.json` had only **4 sections covering lines 1–229**, but `DirichletsTheoremOQ02OQ03.lean` is **1095 lines**:

- **Steps 5–13 had no section coverage at all** — the tighter primorial bound, weak/strict domination `C k ≤/< B k`, the closed-form doubly-exponential bracket, `B` being tower-exponential and tetrational (`2 ↑↑ k ≤ B k`), the certified counting-function lower bound on `π(x; 4, 3)`, and `B` dominating every fixed power of `C`.
- The existing "Step 3" (170–201) and "Step 4" (203–229) sections were **mislabeled** relative to the file's own `/-! ## Step N` banners (real Step 3 @212, Step 4 @265).
- Two `annotations.json` ranges ("The Certified Tower Bound `p3 k ≤ B k`" and "How Loose Is the Certified Bound?") were drifted off their targets.

## Changes

- **Rebuilt a contiguous 13-section partition (lines 1–1095)** aligned to the file's `## Step 1 … ## Step 13` banners (Steps 7–8 folded into one section, matching the file, which has no separate Step 8 banner). Summaries name the actual theorems in each range.
- **Realigned the 2 drifted annotation ranges** to their true Step 3/4 locations (verified they now land on `p3_le_tower` and `tower_loose_at_one`). The 4 head annotations sit in the unmoved region and are unchanged.
- `lineCount` was already correct (1095); status/badge/axiomCount untouched.

Contiguous partition verified (no gaps/overlaps, covers 1–1095); both JSON files validate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)