### PR TITLE
audit: erdos-660 — hedge sorry'd Platonic-solid section prose

### DIFF
--- a/src/data/proofs/erdos-660/meta.json
+++ b/src/data/proofs/erdos-660/meta.json
@@ -126,7 +126,7 @@
       "title": "Special Cases and Constructions",
       "startLine": 218,
       "endLine": 253,
-      "summary": "Computes the distinct-distance counts for the Platonic solids: regular tetrahedron (1 distinct distance), cube (3), regular octahedron (2), regular dodecahedron (20 vertices), and regular icosahedron (12 vertices). These small symmetric examples illustrate how high symmetry minimizes the number of distinct distances.",
+      "summary": "States (as sorry'd conjectural theorems) the distinct-distance counts for the Platonic solids: regular tetrahedron (1 distinct distance), cube (3), regular octahedron (2), regular dodecahedron (20 vertices), and regular icosahedron (12 vertices). These small symmetric examples illustrate how high symmetry minimizes the number of distinct distances; the constructions themselves remain sorry.",
       "mathContext": "Regular tetrahedron: 4 vertices, 1 distinct distance. Cube: 8 vertices, 3 distinct distances. Regular octahedron: 6 vertices, 2 distinct distances. High symmetry collapses many pairwise distances to a common value, giving the extremal small cases."
     },
     {


### PR DESCRIPTION
## Integrity Issue

**Proof**: erdos-660 (Distinct Distances in Convex Polyhedra)
**Problem**: The `special-cases` section summary overstated five sorry'd theorems as established computations.

## Evidence

**meta.json claimed**: section summary "**Computes** the distinct-distance counts for the Platonic solids: regular tetrahedron (1 distinct distance), cube (3), regular octahedron (2)..."

**Lean file shows**: all five Platonic theorems are `sorry`:
- `regular_tetrahedron_distances` (line 221) — `sorry`
- `cube_distances` (line 229) — `sorry`
- `regular_octahedron_distances` (line 236) — `sorry`
- `regular_dodecahedron_vertices` (line 243) — `sorry`
- `regular_icosahedron_vertices` (line 249) — `sorry`

Every other section in this wip file correctly hedges sorry'd theorems ("States altman_convex_polygon_distances", "Axiomatizes erdos_660_conjecture", "States linear_lower_bound_conjecture"), and the top-level `assumptions` field already discloses "Platonic-solid constructions remain sorry". Only this section used the assertive verb "Computes".

Counts otherwise verified clean: 9 sorries (meta 9 ✓, one grep hit was a docstring "no `sorry`"), 0 axioms ✓, 0 native_decide ✓, no True stubs, 16 theorems ✓, 10 defs ✓, 265 lines ✓. Convexity predicate is a genuine extreme-points-of-convex-hull definition (non-vacuous).

## Fix

Changed "Computes ..." to "States (as sorry'd conjectural theorems) ..." and appended "the constructions themselves remain sorry."

---
Discovered during gallery integrity audit.