### PR TITLE
Research: erdos-142-wip-01 — 13 axiom-free foundational lemmas on the r_k(N) def-only stub

### DIFF
--- a/proofs/Proofs/Erdos142Problem.lean
+++ b/proofs/Proofs/Erdos142Problem.lean
@@ -41,6 +41,109 @@ noncomputable def rk (k N : ℕ) : ℕ :=
     ((Finset.powerset (Finset.range N)).filter (fun S => IsAPFree S k))
     Finset.card
 
+/- ## Foundational Lemmas (axiom-free)
+
+These lemmas develop the basic API of `arithProg`, `IsAPFree`, and `rk`.  They are
+all fully machine-checked with no `sorry` and no `axiom` (host-verified on Lean
+v4.31.0).  The deep content of Erdős #142 — the asymptotic formula for `r_k(N)`,
+Szemerédi's theorem, Roth/Kelley–Meka and Behrend's bounds — remains
+documented-only below; it needs additive-combinatorial machinery beyond Mathlib. -/
+
+/-- The empty progression: a length-`0` arithmetic progression is empty. -/
+theorem arithProg_zero (a d : ℕ) : arithProg a d 0 = ∅ := by
+  simp [arithProg]
+
+/-- Membership in an arithmetic progression: `x` is one of the `k` terms
+`a, a+d, …, a+(k-1)d`. -/
+theorem mem_arithProg {a d k x : ℕ} :
+    x ∈ arithProg a d k ↔ ∃ i < k, a + i * d = x := by
+  simp only [arithProg, Finset.mem_image, Finset.mem_range]
+
+/-- An arithmetic progression of length `k` has at most `k` elements (the map
+`i ↦ a + i·d` need not be injective when `d = 0`). -/
+theorem arithProg_card_le (a d k : ℕ) : (arithProg a d k).card ≤ k := by
+  rw [arithProg]
+  exact Finset.card_image_le.trans_eq (Finset.card_range k)
+
+/-- The base point `a` lies in every nonempty progression (it is the term `i = 0`). -/
+theorem self_mem_arithProg {a d k : ℕ} (hk : 0 < k) : a ∈ arithProg a d k := by
+  rw [mem_arithProg]
+  exact ⟨0, hk, by simp⟩
+
+/-- A length-`1` progression is the singleton `{a}`. -/
+theorem arithProg_one (a d : ℕ) : arithProg a d 1 = {a} := by
+  ext x
+  rw [mem_arithProg, Finset.mem_singleton]
+  constructor
+  · rintro ⟨i, hi, rfl⟩
+    have : i = 0 := by omega
+    subst this; simp
+  · rintro rfl
+    exact ⟨0, one_pos, by simp⟩
+
+/-- With a genuine common difference `d > 0` the map `i ↦ a + i·d` is injective, so
+a length-`k` progression has exactly `k` elements. -/
+theorem arithProg_card {a d : ℕ} (hd : 0 < d) (k : ℕ) :
+    (arithProg a d k).card = k := by
+  have hinj : Function.Injective (fun i => a + i * d) := by
+    intro i j h
+    simp only [add_right_inj] at h
+    exact Nat.eq_of_mul_eq_mul_right hd h
+  rw [arithProg, Finset.card_image_of_injective _ hinj, Finset.card_range]
+
+/-- Any set is trivially AP-`k`-free once `k ≤ 1`: there is no nontrivial
+progression to avoid. -/
+theorem IsAPFree_of_k_le_one {S : Finset ℕ} {k : ℕ} (h : k ≤ 1) : IsAPFree S k := by
+  intro a d _ _; exact h
+
+/-- The empty set is AP-`k`-free for every `k` (it contains no progression of any
+positive length, and length `0`/`1` are trivially allowed). -/
+theorem IsAPFree_empty (k : ℕ) : IsAPFree (∅ : Finset ℕ) k := by
+  intro a d _ hsub
+  rcases Nat.lt_or_ge k 1 with hk | hk
+  · omega
+  · exact absurd (hsub (self_mem_arithProg hk)) (by simp)
+
+/-- AP-freeness is inherited by subsets: a subset of an AP-`k`-free set is
+AP-`k`-free. -/
+theorem IsAPFree.subset {S T : Finset ℕ} {k : ℕ} (hST : S ⊆ T)
+    (hT : IsAPFree T k) : IsAPFree S k := by
+  intro a d hd hsub
+  exact hT a d hd (hsub.trans hST)
+
+/-- `r_k(N)` never exceeds `N`, the size of the ambient window `{0, …, N-1}`. -/
+theorem rk_le (k N : ℕ) : rk k N ≤ N := by
+  unfold rk
+  apply Finset.sup_le
+  intro S hS
+  rw [Finset.mem_filter, Finset.mem_powerset] at hS
+  exact (Finset.card_le_card hS.1).trans_eq (Finset.card_range N)
+
+/-- `r_k(N)` is monotone in the window size `N`. -/
+theorem rk_mono_N {k N M : ℕ} (h : N ≤ M) : rk k N ≤ rk k M := by
+  unfold rk
+  apply Finset.sup_mono
+  intro S hS
+  rw [Finset.mem_filter, Finset.mem_powerset] at hS ⊢
+  have hr : Finset.range N ⊆ Finset.range M := fun x hx =>
+    Finset.mem_range.mpr (lt_of_lt_of_le (Finset.mem_range.mp hx) h)
+  exact ⟨hS.1.trans hr, hS.2⟩
+
+/-- The empty window forces `r_k(0) = 0`. -/
+theorem rk_zero (k : ℕ) : rk k 0 = 0 :=
+  Nat.le_zero.mp (rk_le k 0)
+
+/-- For `k ≤ 1` there is no progression to forbid, so the whole window is
+AP-`k`-free and `r_k(N) = N`. -/
+theorem rk_eq_of_k_le_one {k : ℕ} (h : k ≤ 1) (N : ℕ) : rk k N = N := by
+  apply le_antisymm (rk_le k N)
+  have hmem : Finset.range N ∈
+      (Finset.powerset (Finset.range N)).filter (fun S => IsAPFree S k) := by
+    rw [Finset.mem_filter, Finset.mem_powerset]
+    exact ⟨subset_rfl, IsAPFree_of_k_le_one h⟩
+  calc N = (Finset.range N).card := (Finset.card_range N).symm
+    _ ≤ _ := Finset.le_sup hmem
+
 /- ## Szemerédi's Theorem (qualitative) -/
 
 /- ## Roth's Theorem (k = 3) -/

--- a/research/problems/erdos-142-wip-01/knowledge.md
+++ b/research/problems/erdos-142-wip-01/knowledge.md
@@ -1,0 +1,25 @@
+# erdos-142-wip-01 — Asymptotic formula for r_k(N)
+
+## State
+Parent `Erdos142Problem.lean` was a definitions-only stub (arithProg, IsAPFree, rk;
+0 theorems). The problem itself (asymptotic formula for r_k(N)) is OPEN and worth
+$10,000; even k=3 (Roth / Kelley–Meka) is far from an asymptotic formula.
+
+## Session 2026-07-20 (researcher-1)
+Route: **foundational API on the def-only stub** (no attempt at the deep asymptotics —
+that needs additive-combinatorial machinery well beyond Mathlib).
+
+Added 13 axiom-free, sorry-free lemmas (host-verified Lean v4.31.0,
+`#print axioms` = propext/Classical.choice/Quot.sound only):
+
+- arithProg: `arithProg_zero`, `mem_arithProg`, `arithProg_card_le` (≤ k),
+  `self_mem_arithProg`, `arithProg_one` (= {a}), `arithProg_card` (= k when d>0, via injectivity).
+- IsAPFree: `IsAPFree_of_k_le_one`, `IsAPFree_empty`, `IsAPFree.subset` (downward closed).
+- rk: `rk_le` (≤ N), `rk_mono_N` (monotone in N), `rk_zero` (rk k 0 = 0),
+  `rk_eq_of_k_le_one` (rk k N = N for k ≤ 1).
+
+## Blocked / not attempted
+- Szemerédi (r_k(N) = o(N)), Roth/Kelley–Meka upper bounds, Behrend lower bound,
+  Green–Tao k=4: all require machinery not in Mathlib. Route "prove asymptotics
+  directly" is BLOCKED (reopen bar: materially new Mathlib additive-combinatorics
+  infrastructure).

--- a/src/data/proofs/erdos-142/meta.json
+++ b/src/data/proofs/erdos-142/meta.json
@@ -28,9 +28,9 @@
       "erdos-289"
     ],
     "axiomCount": 0,
-    "lineCount": 54,
-    "theoremCount": 0,
-    "assumptions": "Definitional scaffold only. The Lean file provides the definitions `arithProg`, `IsAPFree`, and `rk` (0 axioms, 0 theorems, 0 sorries); the theorems for Szemerédi/Roth/Behrend/Kelley–Meka and the main open question are not yet stated.",
+    "lineCount": 159,
+    "theoremCount": 13,
+    "assumptions": "Definitional scaffold plus foundational API. The Lean file provides the definitions arithProg, IsAPFree, and rk together with 13 axiom-free, sorry-free foundational lemmas about them (host-verified on Lean v4.31.0: membership/cardinality of arithProg, monotonicity and small-k evaluation of IsAPFree and rk). The deep results for Szemeredi/Roth/Behrend/Kelley-Meka and the main open asymptotic question are documented but not yet stated.",
     "mathlib_version": "4.31.0",
     "definitionCount": 3
   },
@@ -113,11 +113,11 @@
     ],
     "opens": [],
     "namespace": null,
-    "lineCount": 54,
+    "lineCount": 159,
     "axiomCount": 0,
     "sorries": 0,
     "definitionCount": 3,
-    "theoremCount": 0
+    "theoremCount": 13
   },
   "references": [
     "Szemerédi (1975): On sets of integers containing no k elements in arithmetic progression",
@@ -147,5 +147,7 @@
       "description": "Related Erdős problem sharing themes: additive-combinatorics, arithmetic-progressions, open"
     }
   ],
-  "sorries": 0
+  "sorries": 0,
+  "lineCount": 159,
+  "theoremCount": 13
 }


### PR DESCRIPTION
## Summary

Erdős Problem #142 (asymptotic formula for `r_k(N)`, the largest AP-`k`-free subset of `{1,…,N}` — **open**, $10,000 reward) had a **definitions-only** Lean stub: `arithProg`, `IsAPFree`, `rk` with **0 theorems** and empty section headers.

This PR develops the basic axiom-free API of those three definitions — the greenfield "foundational lemmas on a def-only stub" pattern (cf. erdos-53/85/89). It does **not** attempt the deep asymptotics, which need additive-combinatorial machinery well beyond Mathlib.

## Added (13 theorems, all axiom-free, sorry-free)

**`arithProg`:** `arithProg_zero`, `mem_arithProg`, `arithProg_card_le` (`≤ k`), `self_mem_arithProg`, `arithProg_one` (`= {a}`), `arithProg_card` (`= k` when `d > 0`, via injectivity of `i ↦ a + i·d`).

**`IsAPFree`:** `IsAPFree_of_k_le_one`, `IsAPFree_empty`, `IsAPFree.subset` (downward closed under `⊆`).

**`rk`:** `rk_le` (`≤ N`), `rk_mono_N` (monotone in `N`), `rk_zero` (`rk k 0 = 0`), `rk_eq_of_k_le_one` (`rk k N = N` for `k ≤ 1`).

## Verification

- Host-verified on Lean **v4.31.0** (`lake env lean`, Mathlib-only file, no Docker).
- `#print axioms` on representatives (`arithProg_card`, `rk_eq_of_k_le_one`, `IsAPFree_empty`, `rk_le`) = `[propext, Classical.choice, Quot.sound]` only — **axiom-free**.
- Gallery meta synced: `theoremCount` 0 → 13, `lineCount` 54 → 159, `assumptions` text updated.

## Not attempted (documented-only)

Szemerédi (`r_k(N) = o(N)`), Roth/Kelley–Meka upper bounds, Behrend lower bound, Green–Tao `k=4` — all require infrastructure not in Mathlib. Recorded as a blocked route in the knowledge tracker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)