### PR TITLE
audit: re-serve erdos-469 (mathlib, verified) — clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -13887,8 +13887,8 @@
     },
     "erdos-469": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:56:19Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-20T15:21:24Z",
       "result": "clean"
     },
     "erdos-47": {


### PR DESCRIPTION
## Reserve-mode audit

Queue is drained (0 unaudited of 4807). Re-served the oldest uncontested `verified`/`mathlib` target: **erdos-469** (Primitive Pseudoperfect Numbers), last audited 2026-05-04.

## Result: clean

Verified `meta.json` against `proofs/Proofs/Erdos469Problem.lean`:

- **0 sorries, 0 axioms, 0 True stubs**, no `native_decide` (uses plain kernel `decide` for finite witnesses)
- **32 theorems** — matches `theoremCount`
- Open conjecture (Σ 1/n convergence) correctly stated as `def : Prop` (`erdos469_conjecture`, `infinitely_many_primitive`), **not** axiomatized. `assumptions` prose accurate: "The open conjectures … are stated as def : Prop, not asserted as axioms."
- 13 section titles map exactly to the file's `-- ##` headers — no phantom declarations in prose
- Conclusion frames the problem as open; `badge: mathlib` is appropriately humble (elementary lemmas proved independently, Mathlib used for `properDivisors` infrastructure)

No integrity issues. Tracker bumped to auditCount 4.

---
Discovered during gallery integrity audit.