### PR TITLE
Research: erdos-1003-wip-01 — 16 axiom-free foundational lemmas + de-native_decide (φ(n)=φ(n+1))

### DIFF
--- a/proofs/Proofs/Erdos1003Problem.lean
+++ b/proofs/Proofs/Erdos1003Problem.lean
@@ -83,33 +83,21 @@ The OEIS sequence A001274 gives the first values where φ(n) = φ(n+1):
 Let's verify some small cases.
 -/
 
-/--
-φ(1) = φ(2) = 1.
--/
-example : 1 ∈ ConsecutiveEqualTotients := by
-  simp only [ConsecutiveEqualTotients, mem_setOf_eq]
-  native_decide
+/-- φ(1) = φ(2) = 1, so `1 ∈ ConsecutiveEqualTotients` (kernel-checked, axiom-free). -/
+theorem one_mem_consecutiveEqualTotients : 1 ∈ ConsecutiveEqualTotients := by
+  simp only [ConsecutiveEqualTotients, mem_setOf_eq]; decide
 
-/--
-φ(3) = φ(4) = 2.
--/
-example : 3 ∈ ConsecutiveEqualTotients := by
-  simp only [ConsecutiveEqualTotients, mem_setOf_eq]
-  native_decide
+/-- φ(3) = φ(4) = 2, so `3 ∈ ConsecutiveEqualTotients` (kernel-checked, axiom-free). -/
+theorem three_mem_consecutiveEqualTotients : 3 ∈ ConsecutiveEqualTotients := by
+  simp only [ConsecutiveEqualTotients, mem_setOf_eq]; decide
 
-/--
-φ(15) = φ(16) = 8.
--/
-example : 15 ∈ ConsecutiveEqualTotients := by
-  simp only [ConsecutiveEqualTotients, mem_setOf_eq]
-  native_decide
+/-- φ(15) = φ(16) = 8, so `15 ∈ ConsecutiveEqualTotients` (kernel-checked, axiom-free). -/
+theorem fifteen_mem_consecutiveEqualTotients : 15 ∈ ConsecutiveEqualTotients := by
+  simp only [ConsecutiveEqualTotients, mem_setOf_eq]; decide
 
-/--
-φ(104) = φ(105) = 48.
--/
-example : 104 ∈ ConsecutiveEqualTotients := by
-  simp only [ConsecutiveEqualTotients, mem_setOf_eq]
-  native_decide
+/-- φ(104) = φ(105) = 48, so `104 ∈ ConsecutiveEqualTotients` (kernel-checked, axiom-free). -/
+theorem oneOhFour_mem_consecutiveEqualTotients : 104 ∈ ConsecutiveEqualTotients := by
+  simp only [ConsecutiveEqualTotients, mem_setOf_eq]; decide
 
 /-
 ## Consecutive k Equal Values
@@ -205,25 +193,17 @@ Why does φ(104) = φ(105) = 48?
 The pattern often involves a power of 2 matching a product of small primes.
 -/
 
-/--
-φ(15) = 8 because 15 = 3 × 5.
--/
-example : φ 15 = 8 := by native_decide
+/-- φ(15) = 8 because 15 = 3 × 5 (kernel-checked, axiom-free). -/
+theorem totient_fifteen : φ 15 = 8 := by decide
 
-/--
-φ(16) = 8 because 16 = 2⁴.
--/
-example : φ 16 = 8 := by native_decide
+/-- φ(16) = 8 because 16 = 2⁴ (kernel-checked, axiom-free). -/
+theorem totient_sixteen : φ 16 = 8 := by decide
 
-/--
-φ(104) = 48 because 104 = 2³ × 13.
--/
-example : φ 104 = 48 := by native_decide
+/-- φ(104) = 48 because 104 = 2³ × 13 (kernel-checked, axiom-free). -/
+theorem totient_oneOhFour : φ 104 = 48 := by decide
 
-/--
-φ(105) = 48 because 105 = 3 × 5 × 7.
--/
-example : φ 105 = 48 := by native_decide
+/-- φ(105) = 48 because 105 = 3 × 5 × 7 (kernel-checked, axiom-free). -/
+theorem totient_oneOhFive : φ 105 = 48 := by decide
 
 /-
 ## The Consecutive Triple: 5186, 5187, 5188
@@ -258,4 +238,77 @@ formally open.
 Ford-Luca-Pomerance result: there are many solutions.
 For any ε > 0, eventually the count exceeds x^(1-ε).
 -/
+
+/-
+## Foundational Lemmas (axiom-free)
+
+Basic API for `ConsecutiveEqualTotients`, `ConsecutiveKEqualTotients`, and
+`countConsecutiveEqual`.  All lemmas below are fully machine-checked with no
+`sorry`, no `axiom`, and no `native_decide` (host-verified on Lean v4.31.0;
+`#print axioms` = propext/Classical.choice/Quot.sound only).  The main
+conjectures (`erdos_1003_conjecture`, `erdos_1003_strong_conjecture`) remain
+open. -/
+
+/-- Membership characterisation for the base problem. -/
+theorem mem_consecutiveEqualTotients {n : ℕ} :
+    n ∈ ConsecutiveEqualTotients ↔ φ n = φ (n + 1) := Iff.rfl
+
+/-- With `k = 0` the constraint is vacuous (only `φ n = φ n`), so every `n`
+qualifies. -/
+theorem consecutiveKEqualTotients_zero : ConsecutiveKEqualTotients 0 = Set.univ := by
+  ext n
+  simp only [ConsecutiveKEqualTotients, mem_setOf_eq, mem_univ, iff_true]
+  intro i hi
+  obtain rfl : i = 0 := Nat.le_zero.mp hi
+  simp
+
+/-- The `k = 1` layer is exactly the base set `φ n = φ (n+1)`. -/
+theorem consecutiveKEqualTotients_one :
+    ConsecutiveKEqualTotients 1 = ConsecutiveEqualTotients := by
+  ext n
+  simp only [ConsecutiveKEqualTotients, ConsecutiveEqualTotients, mem_setOf_eq]
+  constructor
+  · intro h; exact h 1 (le_refl 1)
+  · intro h i hi
+    rcases i with _ | _ | i
+    · simp
+    · exact h
+    · omega
+
+/-- The `k`-layers are nested: a longer equal-totient run implies every shorter
+run, so `ConsecutiveKEqualTotients` is antitone in `k`. -/
+theorem consecutiveKEqualTotients_antitone {k l : ℕ} (h : k ≤ l) :
+    ConsecutiveKEqualTotients l ⊆ ConsecutiveKEqualTotients k := by
+  intro n hn i hi
+  exact hn i (hi.trans h)
+
+/-- Every `k ≥ 1` layer sits inside the base set `φ n = φ (n+1)`. -/
+theorem consecutiveKEqualTotients_subset_base {k : ℕ} (hk : 1 ≤ k) :
+    ConsecutiveKEqualTotients k ⊆ ConsecutiveEqualTotients := by
+  rw [← consecutiveKEqualTotients_one]
+  exact consecutiveKEqualTotients_antitone hk
+
+/-- The counting function is monotone in the cutoff `N`. -/
+theorem countConsecutiveEqual_mono {N M : ℕ} (h : N ≤ M) :
+    countConsecutiveEqual N ≤ countConsecutiveEqual M := by
+  unfold countConsecutiveEqual
+  apply Finset.card_le_card
+  apply Finset.filter_subset_filter
+  intro x hx
+  exact Finset.mem_range.mpr (lt_of_lt_of_le (Finset.mem_range.mp hx) (by omega))
+
+/-- There are at most `N + 1` solutions below `N` (the whole window `{0,…,N}`). -/
+theorem countConsecutiveEqual_le (N : ℕ) : countConsecutiveEqual N ≤ N + 1 := by
+  unfold countConsecutiveEqual
+  exact (Finset.card_filter_le _ _).trans_eq (Finset.card_range (N + 1))
+
+/-- The strong conjecture (infinitely many `k+1`-term runs for every `k ≥ 1`)
+implies the base conjecture (infinitely many `φ n = φ (n+1)`). -/
+theorem strong_conjecture_imp_conjecture :
+    erdos_1003_strong_conjecture → erdos_1003_conjecture := by
+  intro h
+  have h1 := h 1 (le_refl 1)
+  rw [consecutiveKEqualTotients_one] at h1
+  exact h1
+
 end Erdos1003

--- a/research/problems/erdos-1003-wip-01/knowledge.md
+++ b/research/problems/erdos-1003-wip-01/knowledge.md
@@ -1,0 +1,28 @@
+# erdos-1003-wip-01 — Consecutive equal totients φ(n)=φ(n+1)
+
+## State
+OPEN. Erdős asks whether {n : φ(n)=φ(n+1)} is infinite (and the stronger
+∀k≥1, {n : φ(n)=…=φ(n+k)} infinite). Parent Erdos1003Problem.lean was a
+def-only stub: ConsecutiveEqualTotients, erdos_1003_conjecture,
+ConsecutiveKEqualTotients, erdos_1003_strong_conjecture, countConsecutiveEqual,
+carmichael_totient_conjecture — 0 theorems (small cases only as native_decide examples).
+
+## Session 2026-07-20 (researcher-1)
+Route: **foundational API + de-native_decide** on the def-only stub.
+
+Added 16 axiom-free, kernel-checked theorems (host-verified Lean v4.31.0,
+`#print axioms` = propext/Classical.choice/Quot.sound only — NO Lean.ofReduceBool):
+
+- Converted 8 native_decide examples (memberships 1/3/15/104; totients 15/16/104/105)
+  to kernel-`decide` theorems → file no longer depends on Lean.ofReduceBool.
+- mem_consecutiveEqualTotients (membership characterisation).
+- consecutiveKEqualTotients_zero (= univ), _one (= base set),
+  _antitone (nested in k), _subset_base (k≥1 ⊆ base).
+- countConsecutiveEqual_mono (monotone in N), _le (≤ N+1).
+- strong_conjecture_imp_conjecture.
+
+## Blocked / not attempted
+- Infinitude (erdos_1003_conjecture) and the strong conjecture: OPEN, no known
+  unconditional Lean-formalizable proof. Route "prove infinitude directly" BLOCKED
+  (reopen bar: materially new mechanism / Mathlib infrastructure).
+- EPS sparsity upper bound and FLP lower bound: analytic number theory beyond Mathlib.

--- a/src/data/proofs/erdos-1003/meta.json
+++ b/src/data/proofs/erdos-1003/meta.json
@@ -49,9 +49,9 @@
       "Ford-Luca-Pomerance lower bound (implying infinitude, documented in source comments)"
     ],
     "axiomCount": 0,
-    "lineCount": 261,
-    "assumptions": "0 axioms, 0 sorries. Open problem formalized as Lean Prop definitions. Conjecture stated as def (not axiom). Specific small cases verified via native_decide. Prior axioms removed in refactor; badge updated from 'axiom' to 'wip'.",
-    "theoremCount": 0,
+    "lineCount": 314,
+    "assumptions": "0 axioms, 0 sorries, 0 native_decide. Open problem formalized as Lean Prop definitions (conjecture stated as def, not axiom). Adds 16 axiom-free, kernel-checked foundational lemmas (host-verified Lean v4.31.0): small-case memberships and totient values via kernel decide (replacing the former native_decide examples, so the file no longer depends on Lean.ofReduceBool), the k-layer API (ConsecutiveKEqualTotients nested/antitone, k=0 univ, k=1 = base set), counting-function monotonicity and the N+1 upper bound, and strong-conjecture => base-conjecture. The main conjectures remain open.",
+    "theoremCount": 16,
     "definitionCount": 6
   },
   "overview": {
@@ -266,9 +266,9 @@
       "Real"
     ],
     "namespace": "Erdos1003",
-    "lineCount": 261,
+    "lineCount": 314,
     "axiomCount": 0,
-    "theoremCount": 0,
+    "theoremCount": 16,
     "definitionCount": 6,
     "path": "Proofs/Erdos1003Problem.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

Erdős Problem #1003 (are there infinitely many `n` with `φ(n) = φ(n+1)`? — **open**) had a **definitions-only** Lean stub: `ConsecutiveEqualTotients`, `ConsecutiveKEqualTotients`, `countConsecutiveEqual`, the conjectures, and Carmichael — with **0 theorems** and small cases proved only via `native_decide` (so the file depended on `Lean.ofReduceBool`).

This PR develops the axiom-free API of those definitions and **removes the `ofReduceBool` dependency**, following the greenfield "foundational lemmas on a def-only stub" pattern. It does not attempt the open infinitude question.

## Added (16 theorems, all axiom-free & kernel-checked)

- **De-`native_decide`:** converted the 8 example small cases (memberships `1,3,15,104`; totients `φ15,φ16,φ104,φ105`) into named theorems proved by **kernel `decide`** — the file no longer depends on `Lean.ofReduceBool`.
- **Structure:** `mem_consecutiveEqualTotients`; `consecutiveKEqualTotients_zero` (`= univ`), `_one` (`= ConsecutiveEqualTotients`), `_antitone` (nested in `k`), `_subset_base` (`k ≥ 1 ⊆` base).
- **Counting:** `countConsecutiveEqual_mono` (monotone in `N`), `_le` (`≤ N+1`).
- **Reduction:** `strong_conjecture_imp_conjecture`.

## Verification

- Host-verified on Lean **v4.31.0** (`lake env lean`, Mathlib-only file, no Docker).
- `#print axioms` on representatives (`oneOhFour_mem_consecutiveEqualTotients`, `totient_oneOhFive`, `consecutiveKEqualTotients_one`, `strong_conjecture_imp_conjecture`, `countConsecutiveEqual_le`) = `[propext, Classical.choice, Quot.sound]` only — **axiom-free, no `Lean.ofReduceBool`**.
- Gallery meta synced: `theoremCount` 0 → 16, `lineCount` 261 → 314, `assumptions` updated.

## Not attempted (open / documented-only)

Infinitude (`erdos_1003_conjecture`), the strong conjecture, the EPS sparsity upper bound, and the Ford–Luca–Pomerance lower bound — all beyond current Mathlib. Recorded as blocked routes in the knowledge tracker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)