### PR TITLE
Research: erdos-241-wip-01 — 13 axiom-free foundational lemmas on the B₃-sets stub

### DIFF
--- a/proofs/Proofs/Erdos241Problem.lean
+++ b/proofs/Proofs/Erdos241Problem.lean
@@ -121,3 +121,108 @@ Note: The previously claimed {1,2,4,8} is NOT B₃ since 1+1+4 = 2+2+2 = 6. -/
 
 /- The trivial upper bound: a B₃ set in {1,...,N} has at most
 O(N^{1/3}) elements since distinct sums lie in {3,...,3N}. -/
+
+/-
+## Section VIII: Foundational Lemmas (axiom-free)
+
+Basic API for `threeSums`, `IsB3`, `maxB3Size`, `IsBh`, and `maxBhSize`.  All
+lemmas below are fully machine-checked with no `sorry` and no `axiom`
+(host-verified on Lean v4.31.0; `#print axioms` = propext/Classical.choice/Quot.sound
+only — `Classical.choice` enters only through the `DecidablePred` instances above).
+The deep content of Erdős #241 (the `f(N) ~ N^{1/3}` asymptotics of Bose–Chowla
+and Green) remains documented-only; it needs finite-field / analytic machinery
+beyond Mathlib. -/
+
+/-- Membership characterisation of `threeSums`: `x` is an ordered triple sum. -/
+theorem mem_threeSums {A : Finset ℕ} {x : ℕ} :
+    x ∈ threeSums A ↔ ∃ a ∈ A, ∃ b ∈ A, ∃ c ∈ A, a ≤ b ∧ b ≤ c ∧ a + b + c = x := by
+  simp only [threeSums, Finset.mem_image, Finset.mem_filter, Finset.mem_product]
+  constructor
+  · rintro ⟨⟨a, b, c⟩, ⟨⟨ha, hb, hc⟩, hab, hbc⟩, rfl⟩
+    exact ⟨a, ha, b, hb, c, hc, hab, hbc, rfl⟩
+  · rintro ⟨a, ha, b, hb, c, hc, hab, hbc, rfl⟩
+    exact ⟨⟨a, b, c⟩, ⟨⟨ha, hb, hc⟩, hab, hbc⟩, rfl⟩
+
+/-- The empty set has no three-element sums. -/
+theorem threeSums_empty : threeSums (∅ : Finset ℕ) = ∅ := by
+  simp [threeSums]
+
+/-- `threeSums` is monotone: enlarging `A` can only add sums. -/
+theorem threeSums_mono {A B : Finset ℕ} (hAB : A ⊆ B) :
+    threeSums A ⊆ threeSums B := by
+  intro x hx
+  rw [mem_threeSums] at hx ⊢
+  obtain ⟨a, ha, b, hb, c, hc, hab, hbc, hsum⟩ := hx
+  exact ⟨a, hAB ha, b, hAB hb, c, hAB hc, hab, hbc, hsum⟩
+
+/-- The empty set is (vacuously) a B₃ set. -/
+theorem isB3_empty : IsB3 (∅ : Finset ℕ) := by
+  intro a₁ ha₁
+  exact absurd ha₁ (by simp)
+
+/-- Every singleton is a B₃ set (its only ordered triple is `(a,a,a)`). -/
+theorem isB3_singleton (a : ℕ) : IsB3 ({a} : Finset ℕ) := by
+  intro a₁ ha₁ b₁ hb₁ c₁ hc₁ a₂ ha₂ b₂ hb₂ c₂ hc₂ _ _ _ _ _
+  rw [Finset.mem_singleton] at ha₁ hb₁ hc₁ ha₂ hb₂ hc₂
+  subst ha₁ hb₁ hc₁ ha₂ hb₂ hc₂
+  exact ⟨rfl, rfl, rfl⟩
+
+/-- The B₃ property is inherited by subsets. -/
+theorem IsB3.subset {A B : Finset ℕ} (hAB : A ⊆ B) (hB : IsB3 B) : IsB3 A := by
+  intro a₁ ha₁ b₁ hb₁ c₁ hc₁ a₂ ha₂ b₂ hb₂ c₂ hc₂ h1 h2 h3 h4 hsum
+  exact hB a₁ (hAB ha₁) b₁ (hAB hb₁) c₁ (hAB hc₁)
+    a₂ (hAB ha₂) b₂ (hAB hb₂) c₂ (hAB hc₂) h1 h2 h3 h4 hsum
+
+/-- `f(N) = maxB3Size N` never exceeds the window size `N`. -/
+theorem maxB3Size_le (N : ℕ) : maxB3Size N ≤ N := by
+  unfold maxB3Size
+  apply Finset.sup_le
+  intro S hS
+  rw [Finset.mem_filter, Finset.mem_powerset] at hS
+  exact (Finset.card_le_card hS.1).trans_eq (Finset.card_range N)
+
+/-- `maxB3Size` is monotone in the window size. -/
+theorem maxB3Size_mono {N M : ℕ} (h : N ≤ M) : maxB3Size N ≤ maxB3Size M := by
+  unfold maxB3Size
+  apply Finset.sup_mono
+  intro S hS
+  rw [Finset.mem_filter, Finset.mem_powerset] at hS ⊢
+  refine ⟨hS.1.trans ?_, hS.2⟩
+  intro x hx
+  exact Finset.mem_range.mpr (lt_of_lt_of_le (Finset.mem_range.mp hx) h)
+
+/-- `f(0) = 0`. -/
+theorem maxB3Size_zero : maxB3Size 0 = 0 := Nat.le_zero.mp (maxB3Size_le 0)
+
+/-- The Bₕ property is inherited by subsets. -/
+theorem IsBh.subset {h : ℕ} {A B : Finset ℕ} (hAB : A ⊆ B) (hB : IsBh h B) :
+    IsBh h A := by
+  obtain ⟨hh, hdist⟩ := hB
+  refine ⟨hh, fun S₁ S₂ h1 h2 c1 c2 hsum => ?_⟩
+  exact hdist S₁ S₂ (h1.trans hAB) (h2.trans hAB) c1 c2 hsum
+
+/-- The empty set is a Bₕ set for every `h ≥ 2` (no `h`-subset exists to clash). -/
+theorem isBh_empty {h : ℕ} (hh : 2 ≤ h) : IsBh h (∅ : Finset ℕ) := by
+  refine ⟨hh, fun S₁ S₂ h1 _ c1 _ _ => ?_⟩
+  rw [Finset.subset_empty] at h1
+  subst h1
+  rw [Finset.card_empty] at c1
+  omega
+
+/-- The maximum Bₕ subset size never exceeds the window size `N`. -/
+theorem maxBhSize_le (h N : ℕ) : maxBhSize h N ≤ N := by
+  unfold maxBhSize
+  apply Finset.sup_le
+  intro S hS
+  rw [Finset.mem_filter, Finset.mem_powerset] at hS
+  exact (Finset.card_le_card hS.1).trans_eq (Finset.card_range N)
+
+/-- `maxBhSize` is monotone in the window size. -/
+theorem maxBhSize_mono {h N M : ℕ} (hNM : N ≤ M) : maxBhSize h N ≤ maxBhSize h M := by
+  unfold maxBhSize
+  apply Finset.sup_mono
+  intro S hS
+  rw [Finset.mem_filter, Finset.mem_powerset] at hS ⊢
+  refine ⟨hS.1.trans ?_, hS.2⟩
+  intro x hx
+  exact Finset.mem_range.mpr (lt_of_lt_of_le (Finset.mem_range.mp hx) hNM)

--- a/research/problems/erdos-241-wip-01/knowledge.md
+++ b/research/problems/erdos-241-wip-01/knowledge.md
@@ -1,21 +1,23 @@
-# Knowledge Base: erdos-241-wip-01
+# erdos-241-wip-01 — Maximum size of B₃ sets, f(N) ~ N^(1/3)?
 
-Insights accumulated during research on this problem.
+## State
+OPEN ($100 prize). f(N) = max |A ⊆ {1..N}| with all a+b+c (a≤b≤c) distinct.
+Parent Erdos241Problem.lean was a def-only stub: threeSums, IsB3, maxB3Size,
+ErdosProblem241, IsBh, maxBhSize, BoseChowlaConjecture — 0 theorems.
 
----
+## Session 2026-07-20 (researcher-1)
+Route: **foundational API on the def-only stub**.
 
-## Problem Understanding
+Added 13 axiom-free lemmas (host-verified Lean v4.31.0; #print axioms =
+propext/Classical.choice/Quot.sound — Classical.choice only via the file's
+DecidablePred instances):
 
-[Initial observations about the problem will be recorded here]
+- threeSums: mem_threeSums (characterisation), threeSums_empty, threeSums_mono.
+- IsB3: isB3_empty, isB3_singleton, IsB3.subset (downward closed).
+- maxB3Size: maxB3Size_le (<= N), maxB3Size_mono (in N), maxB3Size_zero.
+- Bh generalization: IsBh.subset, isBh_empty (h>=2), maxBhSize_le, maxBhSize_mono.
 
----
-
-## Insights
-
-[Insights from research attempts will be accumulated here]
-
----
-
-## Dead Ends
-
-[Approaches known not to work will be documented here]
+## Blocked / not attempted
+- f(N) ~ N^(1/3) asymptotics: Bose-Chowla lower bound (finite-field construction)
+  and Green's upper bound (analytic) both beyond Mathlib. Route "prove asymptotics
+  directly" BLOCKED (reopen bar: materially new Mathlib infrastructure).

--- a/src/data/proofs/erdos-241/meta.json
+++ b/src/data/proofs/erdos-241/meta.json
@@ -20,15 +20,15 @@
     "erdosUrl": "https://erdosproblems.com/241",
     "erdosProblemStatus": "open",
     "axiomCount": 0,
-    "lineCount": 123,
+    "lineCount": 228,
     "originalContributions": [
       "Formal statement of Erdős Problem 241 as an ε-N₀ asymptotic equivalence",
       "Generalization to Bₕ sets for arbitrary h ≥ 2 with the Bose-Chowla conjecture",
       "Separation of lower bound (Bose-Chowla, known) from upper bound (Green, best known) as distinct axioms"
     ],
-    "assumptions": "0 axioms, 0 sorries. Previously cited axiom names have been removed from the Lean source. The 'axiomatized' status reflects that the main result is not yet fully formalized in Lean.",
+    "assumptions": "0 axioms, 0 sorries. Adds 13 axiom-free foundational lemmas on the B3/Bh definitions (host-verified Lean v4.31.0; #print axioms = propext/Classical.choice/Quot.sound, Classical.choice entering only via the file's DecidablePred instances): mem_threeSums characterisation, threeSums empty/monotone, IsB3 empty/singleton/subset-closed, maxB3Size le-N/monotone/zero, and the Bh analogues IsBh.subset, isBh_empty, maxBhSize le-N/monotone. The f(N) ~ N^(1/3) asymptotics (Bose-Chowla, Green) remain documented-only, needing finite-field/analytic machinery beyond Mathlib.",
     "mathlib_version": "4.31.0",
-    "theoremCount": 0,
+    "theoremCount": 13,
     "definitionCount": 7
   },
   "overview": {
@@ -144,9 +144,9 @@
     ],
     "opens": [],
     "namespace": null,
-    "lineCount": 123,
+    "lineCount": 228,
     "axiomCount": 0,
-    "theoremCount": 0,
+    "theoremCount": 13,
     "definitionCount": 7,
     "path": "Proofs/Erdos241Problem.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

Erdős Problem #241 (maximum size `f(N)` of a B₃ set in `{1,…,N}`; is `f(N) ~ N^{1/3}`? — **open**, $100 prize) had a **definitions-only** Lean stub: `threeSums`, `IsB3`, `maxB3Size`, `IsBh`, `maxBhSize`, and the conjectures — with **0 theorems**.

This PR develops the axiom-free API of those definitions (greenfield "foundational lemmas on a def-only stub" pattern). It does not attempt the open asymptotics.

## Added (13 theorems, all axiom-free)

- **`threeSums`:** `mem_threeSums` (ordered-triple-sum characterisation), `threeSums_empty`, `threeSums_mono`.
- **`IsB3`:** `isB3_empty`, `isB3_singleton`, `IsB3.subset` (downward closed).
- **`maxB3Size`:** `maxB3Size_le` (`≤ N`), `maxB3Size_mono` (in `N`), `maxB3Size_zero`.
- **Bₕ generalization:** `IsBh.subset`, `isBh_empty` (`h ≥ 2`), `maxBhSize_le`, `maxBhSize_mono`.

## Verification

- Host-verified on Lean **v4.31.0** (`lake env lean`, Mathlib-only file, no Docker).
- `#print axioms` on representatives = `[propext, Classical.choice, Quot.sound]` only (`Classical.choice` enters solely through the file's pre-existing `DecidablePred` instances) — **axiom-free**.
- Gallery meta synced: `theoremCount` 0 → 13, `lineCount` 123 → 228, `assumptions` updated.

## Not attempted (open / documented-only)

The `f(N) ~ N^{1/3}` asymptotics — Bose–Chowla lower bound (finite-field construction) and Green's upper bound (analytic) — are beyond current Mathlib. Recorded as a blocked route in the knowledge tracker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)