### PR TITLE
Research: erdos-506-wip-01 — 9 axiom-free lemmas + flag degenerate minCircles def

### DIFF
--- a/proofs/Proofs/Erdos506Problem.lean
+++ b/proofs/Proofs/Erdos506Problem.lean
@@ -95,3 +95,58 @@ noncomputable def minCircles (n : ℕ) : ℕ :=
     for lines: n non-collinear points determine at least n lines.
     The circle analogue asks for the minimum number of circles from
     non-concyclic points. -/
+
+/- ## Foundational Lemmas (axiom-free)
+
+Basic API for `AreCollinear`, `AllCollinear`, `AllConcyclic`, `numCircles`, and
+`minCircles`.  All lemmas are machine-checked, no `sorry`, no `axiom`
+(host-verified on Lean v4.31.0).
+
+**Degeneracy note.** `minCircles` as currently defined does not depend on its
+argument `n` at all — it is `Finset.inf'` of the constant image `{0}`, hence
+identically `0` (`minCircles_eq_zero` below).  It is therefore a *placeholder*
+that does not yet model "the minimum number of circles over non-degenerate
+`n`-point configurations"; a faithful definition would range over actual
+`PointConfig n` values excluding the concyclic/collinear cases.  We record the
+degeneracy as an explicit theorem so the gallery cannot silently present it as
+the intended quantity. -/
+
+/-- Degenerate triple with the first two points equal is collinear. -/
+theorem areCollinear_left_eq (p r : Point2) : AreCollinear p p r := by
+  unfold AreCollinear; ring
+
+/-- Degenerate triple with the last two points equal is collinear. -/
+theorem areCollinear_right_eq (p q : Point2) : AreCollinear p q q := by
+  unfold AreCollinear; ring
+
+/-- Degenerate triple with the outer two points equal is collinear. -/
+theorem areCollinear_outer_eq (p q : Point2) : AreCollinear p q p := by
+  unfold AreCollinear; ring
+
+/-- Collinearity is symmetric in the last two points. -/
+theorem areCollinear_swap {p q r : Point2} :
+    AreCollinear p q r ↔ AreCollinear p r q := by
+  unfold AreCollinear; exact eq_comm
+
+/-- Any `0`-point configuration is (vacuously) all-collinear. -/
+theorem allCollinear_fin_zero (config : PointConfig 0) : AllCollinear config := by
+  intro i; exact Fin.elim0 i
+
+/-- Any `1`-point configuration is all-collinear. -/
+theorem allCollinear_fin_one (config : PointConfig 1) : AllCollinear config := by
+  intro i j k
+  fin_cases i; fin_cases j; fin_cases k
+  unfold AreCollinear; ring
+
+/-- Any `0`-point configuration is (vacuously) all-concyclic. -/
+theorem allConcyclic_fin_zero (config : PointConfig 0) : AllConcyclic config :=
+  ⟨![0, 0], 0, fun i => Fin.elim0 i⟩
+
+/-- A `0`-point configuration determines no circles. -/
+theorem numCircles_fin_zero (config : PointConfig 0) : numCircles config = 0 := by
+  simp [numCircles]
+
+/-- **Degeneracy of `minCircles`.** The current definition ignores `n` and equals
+`0` for every `n`; it is a placeholder, not the intended minimum. -/
+theorem minCircles_eq_zero (n : ℕ) : minCircles n = 0 := by
+  simp [minCircles]

--- a/research/problems/erdos-506-wip-01/knowledge.md
+++ b/research/problems/erdos-506-wip-01/knowledge.md
@@ -1,0 +1,27 @@
+# erdos-506-wip-01 — Minimum number of circles from n points
+
+## State
+OPEN. Min number of distinct circles determined by n points in ℝ² (not all
+concyclic/collinear). Elliott (1967): ≥ C(n-1,2) for n>393; Segre: n=8 counterexample.
+Parent Erdos506Problem.lean was a def-only stub: AreCollinear, circumcircle,
+SameCircle, PointConfig, AllConcyclic, AllCollinear, numCircles, minCircles — 0 theorems.
+
+## Session 2026-07-20 (researcher-1)
+Route: **foundational API + degeneracy flag** on the def-only stub.
+
+Added 9 axiom-free lemmas (host-verified Lean v4.31.0):
+- AreCollinear: areCollinear_left_eq/right_eq/outer_eq (degenerate triples),
+  areCollinear_swap (symmetric in last two points).
+- Small-n: allCollinear_fin_zero/fin_one, allConcyclic_fin_zero, numCircles_fin_zero.
+- **minCircles_eq_zero**: the current `minCircles` def is `Finset.inf'` of the
+  constant image {0} — it ignores its argument n and is identically 0. It is a
+  PLACEHOLDER, not the intended quantity.
+
+## Blockers (structured)
+- route: "prove Elliott/Segre bounds against current minCircles"
+  reopenCriterion: "minCircles redefined to range over non-degenerate PointConfig n"
+  blockedAt: 2026-07-20
+  (The headline object minCircles is degenerate — see minCircles_eq_zero. Any
+  bound theorem stated against it is vacuous until the def is repaired.)
+- Elliott (1967) C(n-1,2) lower bound and Segre's cube-projection counterexample:
+  incidence geometry beyond current Mathlib.

--- a/src/data/proofs/erdos-506/meta.json
+++ b/src/data/proofs/erdos-506/meta.json
@@ -21,10 +21,10 @@
     "erdosUrl": "https://erdosproblems.com/506",
     "erdosProblemStatus": "partially solved",
     "axiomCount": 0,
-    "lineCount": 97,
-    "assumptions": "0 axioms, 0 sorries. Previously cited axiom names have been removed from the Lean source. The 'axiomatized' status reflects that the main result is not yet fully formalized in Lean.",
+    "lineCount": 152,
+    "assumptions": "0 axioms, 0 sorries. Adds 9 axiom-free foundational lemmas (host-verified Lean v4.31.0; #print axioms = propext/Classical.choice/Quot.sound): AreCollinear degenerate/symmetry facts, small-n triviality of AllCollinear/AllConcyclic/numCircles, and a DEGENERACY THEOREM minCircles_eq_zero — the current minCircles definition ignores n and is identically 0, so it is a placeholder, not the intended minimum-number-of-circles quantity. The Elliott/Segre results and the true minimum for small n remain documented-only and require a faithful minCircles definition ranging over non-degenerate point configurations.",
     "mathlib_version": "4.31.0",
-    "theoremCount": 0,
+    "theoremCount": 9,
     "definitionCount": 9
   },
   "overview": {
@@ -122,9 +122,9 @@
     ],
     "opens": [],
     "namespace": null,
-    "lineCount": 97,
+    "lineCount": 152,
     "axiomCount": 0,
-    "theoremCount": 0,
+    "theoremCount": 9,
     "definitionCount": 9,
     "path": "Proofs/Erdos506Problem.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

Erdős Problem #506 (minimum number of distinct circles determined by `n` points in ℝ², not all concyclic/collinear — **open**) had a **definitions-only** Lean stub with **0 theorems**.

This PR develops the axiom-free API of those definitions **and flags a degeneracy** in the headline object `minCircles`.

## Added (9 theorems, all axiom-free)

- **`AreCollinear`:** `areCollinear_left_eq`, `areCollinear_right_eq`, `areCollinear_outer_eq` (degenerate triples are collinear), `areCollinear_swap` (symmetric in the last two points).
- **Small-`n`:** `allCollinear_fin_zero`, `allCollinear_fin_one`, `allConcyclic_fin_zero`, `numCircles_fin_zero`.
- **⚠️ `minCircles_eq_zero` (degeneracy flag):** the current `minCircles` definition is `Finset.inf'` of the *constant* image `{0}` — it **ignores its argument `n`** and is identically `0`. It is a **placeholder**, not the intended "minimum number of circles over non-degenerate `n`-point configurations"; any bound stated against it would be vacuous. Recorded as a structured blocker (reopen criterion: `minCircles` redefined to range over real `PointConfig n` values).

## Verification

- Host-verified on Lean **v4.31.0** (`lake env lean`, Mathlib-only file, no Docker).
- `#print axioms` on representatives = `[propext, Classical.choice, Quot.sound]` only — **axiom-free**.
- Gallery meta synced: `theoremCount` 0 → 9, `lineCount` 97 → 152, `assumptions` updated to disclose the degeneracy.

## Not attempted (open / documented-only)

Elliott's `C(n-1,2)` lower bound and Segre's cube-projection counterexample — incidence geometry beyond current Mathlib, and blocked until `minCircles` is given a faithful definition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)