### PR TITLE
Enrich erdos-471: fix line-range drift + remove 4 non-existent axioms

### DIFF
--- a/src/data/proofs/erdos-471/annotations.json
+++ b/src/data/proofs/erdos-471/annotations.json
@@ -73,11 +73,11 @@
     "proofId": "erdos-471",
     "range": {
       "startLine": 89,
-      "endLine": 121
+      "endLine": 111
     },
     "type": "concept",
-    "title": "Vinogradov's Theorem (Three Forms)",
-    "content": "**Three axiomatized forms of Vinogradov's theorem, each strengthening the last:**\n\n1. **vinogradov_three_primes:** Every large odd n = p + q + r for primes p, q, r. This is the classical 1937 result.\n\n2. **vinogradov_distinct:** The primes can be chosen pairwise distinct (p ≠ q ≠ r ≠ p). This follows from the basic version by a counting argument.\n\n3. **vinogradov_smaller_primes:** For large primes p, the summands q₁, q₂, q₃ can all be chosen strictly less than p. This is the crucial form — it means large primes *decompose* into smaller ones.\n\nAll three are axiomatized because Vinogradov's theorem requires deep analytic number theory (exponential sums, circle method) far beyond current Mathlib.",
+    "title": "Vinogradov's Theorem (Key Form)",
+    "content": "**One axiom captures the ingredient the argument actually needs, preceded by commentary on Vinogradov's theorem in increasing strength:**\n\n1. **Basic three-primes form** (stated as commentary): every large odd n = p + q + r for primes p, q, r — the classical 1937 result.\n\n2. **Distinct-primes form** (stated as commentary): the three primes can be chosen pairwise distinct, which follows from the basic version by a counting argument.\n\n3. **vinogradov_smaller_primes** (the sole axiom here): for large primes p, the summands q₁, q₂, q₃ can all be chosen strictly *less* than p and pairwise distinct. This is the crucial form — it means large primes decompose into smaller ones, which is exactly what drives the inductive generation of the Q-sequence.\n\nOnly the third form is axiomatized (the first two are informal motivation), because Vinogradov's theorem requires deep analytic number theory (exponential sums, circle method) far beyond current Mathlib.",
     "mathContext": "Vinogradov's theorem is one of the landmark results of 20th-century number theory. The proof uses the Hardy-Littlewood circle method with exponential sum estimates. Helfgott (2013) proved the theorem for all odd n > 5, removing the 'sufficiently large' qualifier.",
     "significance": "key",
     "relatedConcepts": [
@@ -96,12 +96,12 @@
     "id": "ann-e471-solution",
     "proofId": "erdos-471",
     "range": {
-      "startLine": 123,
-      "endLine": 173
+      "startLine": 112,
+      "endLine": 158
     },
     "type": "concept",
     "title": "The Solution: vinogradovQ₀ Construction",
-    "content": "**The elegant solution constructs Q₀ from Vinogradov's constant:**\n\n**vinogradovQ₀** = {p prime : p ≤ N} where N = Classical.choose vinogradov_smaller_primes.\n\n**vinogradovQ₀_finite** (proved): This set is finite — there are only finitely many primes ≤ N.\n\n**all_primes_in_QLim** (axiom): Every prime appears in Q∞. The argument: by strong induction, any prime p > N decomposes as p = q₁ + q₂ + q₃ with smaller primes, which are in some Qᵢ, so p ∈ Q_{i+1}.\n\n**ulams_question_positive** (axiom): YES, there exists Q₀ making |Qᵢ| → ∞.\n\n**stronger_question_positive** (proved): Q∞ contains ALL primes. This follows directly from vinogradovQ₀_finite and all_primes_in_QLim.",
+    "content": "**The elegant solution constructs Q₀ from Vinogradov's constant:**\n\n**vinogradovQ₀** = {p prime : p ≤ N} where N = Classical.choose vinogradov_smaller_primes.\n\n**vinogradovQ₀_finite** (proved): This set is finite — there are only finitely many primes ≤ N.\n\n**all_primes_in_QLim** (axiom): Every prime appears in Q∞. The argument: by strong induction, any prime p > N decomposes as p = q₁ + q₂ + q₃ with smaller primes, which are in some Qᵢ, so p ∈ Q_{i+1}.\n\n**stronger_question_positive** (proved): Q∞ contains ALL primes. This follows directly from vinogradovQ₀_finite and all_primes_in_QLim.\n\nThe affirmative answer to Ulam's original question (|Qᵢ| → ∞) is discussed in the surrounding commentary but is subsumed by this stronger, formally-proved statement rather than stated as a separate declaration.",
     "mathContext": "The use of Classical.choose extracts the Vinogradov constant N from the existential. The finiteness proof uses Finset.filter on Finset.range to construct a witnessing finite set. The stronger theorem is proved constructively from the axiom.",
     "significance": "key",
     "relatedConcepts": [
@@ -119,13 +119,13 @@
     "id": "ann-e471-examples",
     "proofId": "erdos-471",
     "range": {
-      "startLine": 175,
-      "endLine": 221
+      "startLine": 159,
+      "endLine": 188
     },
     "type": "concept",
     "title": "Concrete Examples: Q₁ from {3, 5, 7, 11}",
-    "content": "**Ulam's original test case Q₀ = {3, 5, 7, 11} is explored concretely:**\n\n**Q1_contains_19** (fully proved): 3 + 5 + 11 = 19 is prime, so 19 ∈ Q₁. The proof uses Nat.prime_def_lt'' with norm_num and interval_cases to verify primality.\n\n**Q1_contains_23** (fully proved): 5 + 7 + 11 = 23 is prime, so 23 ∈ Q₁.\n\n**ulam_example_contains_all_primes** (axiom): Conjectured that Q∞ from {3, 5, 7, 11} contains all primes ≥ 3. This is a computational question — the sequence grows quickly enough that it likely captures everything.\n\nNote that 2 can never appear (it's even, and sums of three odd primes are always odd), which is why the axiom requires p ≥ 3.",
-    "mathContext": "The proofs demonstrate Lean 4 tactics for computational primality: norm_num for arithmetic, interval_cases for exhaustive case analysis on small ranges, and simp for set membership in finite sets like {3, 5, 7, 11}.",
+    "content": "**Ulam's original test case ulamQ₀ = {3, 5, 7, 11} is explored concretely:**\n\n**Q1_contains_19** (fully proved): 3 + 5 + 11 = 19 is prime, so 19 ∈ Q₁. The membership is witnessed by taking the `right` branch of nextQ and discharging primality and the set-membership side conditions with norm_num and simp.\n\n**Q1_contains_23** (fully proved): 5 + 7 + 11 = 23 is prime, so 23 ∈ Q₁, by the same pattern.\n\nWhether Q∞ starting from {3, 5, 7, 11} contains *all* primes ≥ 3 is left as commentary — it is a computational conjecture, not a formalized declaration in this file.\n\nNote that 2 can never appear (it is even, and a sum of three odd primes is always odd), so any such statement is necessarily about primes ≥ 3.",
+    "mathContext": "The proofs demonstrate Lean 4 tactics for computational primality: norm_num for the arithmetic and primality checks, and simp for set membership in finite sets like {3, 5, 7, 11}.",
     "significance": "key",
     "relatedConcepts": [
       "computational verification",
@@ -142,8 +142,8 @@
     "id": "ann-e471-properties",
     "proofId": "erdos-471",
     "range": {
-      "startLine": 223,
-      "endLine": 249
+      "startLine": 189,
+      "endLine": 216
     },
     "type": "concept",
     "title": "Structural Properties (Fully Proved)",
@@ -165,8 +165,8 @@
     "id": "ann-e471-summary",
     "proofId": "erdos-471",
     "range": {
-      "startLine": 272,
-      "endLine": 274
+      "startLine": 228,
+      "endLine": 256
     },
     "type": "concept",
     "title": "Summary Theorem",

--- a/src/data/proofs/erdos-471/annotations.json
+++ b/src/data/proofs/erdos-471/annotations.json
@@ -26,7 +26,7 @@
     "id": "ann-e471-defs",
     "proofId": "erdos-471",
     "range": {
-      "startLine": 36,
+      "startLine": 38,
       "endLine": 69
     },
     "type": "definition",
@@ -49,7 +49,7 @@
     "id": "ann-e471-questions",
     "proofId": "erdos-471",
     "range": {
-      "startLine": 71,
+      "startLine": 73,
       "endLine": 87
     },
     "type": "concept",
@@ -72,7 +72,7 @@
     "id": "ann-e471-vinogradov",
     "proofId": "erdos-471",
     "range": {
-      "startLine": 89,
+      "startLine": 99,
       "endLine": 111
     },
     "type": "concept",
@@ -96,7 +96,7 @@
     "id": "ann-e471-solution",
     "proofId": "erdos-471",
     "range": {
-      "startLine": 112,
+      "startLine": 114,
       "endLine": 158
     },
     "type": "concept",
@@ -119,7 +119,7 @@
     "id": "ann-e471-examples",
     "proofId": "erdos-471",
     "range": {
-      "startLine": 159,
+      "startLine": 161,
       "endLine": 188
     },
     "type": "concept",
@@ -142,7 +142,7 @@
     "id": "ann-e471-properties",
     "proofId": "erdos-471",
     "range": {
-      "startLine": 189,
+      "startLine": 191,
       "endLine": 216
     },
     "type": "concept",
@@ -165,7 +165,7 @@
     "id": "ann-e471-summary",
     "proofId": "erdos-471",
     "range": {
-      "startLine": 228,
+      "startLine": 230,
       "endLine": 256
     },
     "type": "concept",

--- a/src/data/proofs/erdos-471/meta.json
+++ b/src/data/proofs/erdos-471/meta.json
@@ -44,7 +44,8 @@
       "nextQ closure operation: Q ∪ {primes that are three-element sums from Q}",
       "QSeq iterative sequence and QLim limit definitions",
       "UlamsQuestion and StrongerQuestion formal problem statements",
-      "vinogradov_three_primes, vinogradov_distinct, vinogradov_smaller_primes axioms",
+      "vinogradov_smaller_primes axiom: every large prime is a sum of three distinct strictly smaller primes (Vinogradov's basic and distinct-prime forms appear only as commentary, not as separate axioms)",
+      "all_primes_in_QLim axiom: every prime lies in Q∞ for the Vinogradov seed vinogradovQ₀",
       "vinogradovQ₀ construction: {primes ≤ N} for Vinogradov's constant",
       "vinogradovQ₀_finite theorem: Q₀ is finite (proved)",
       "stronger_question_positive theorem: Q∞ contains all primes (proved from axioms)",
@@ -53,7 +54,7 @@
       "erdos_471_summary: combines StrongerQuestion, monotonicity, and primality preservation"
     ],
     "axiomCount": 2,
-    "lineCount": 274,
+    "lineCount": 256,
     "assumptions": "2 axioms: vinogradov_smaller_primes (Vinogradov — three primes theorem with smaller primes bound), all_primes_in_QLim (all primes are in Q_lim). 0 sorries.",
     "theoremCount": 7,
     "definitionCount": 8
@@ -96,49 +97,49 @@
       "id": "vinogradov",
       "title": "Vinogradov's Theorem",
       "startLine": 89,
-      "endLine": 122,
-      "summary": "Three axiomatized forms: basic, distinct primes, and smaller primes.",
-      "mathContext": "Axiomatized: Three axiomatized forms: basic, distinct primes, and smaller primes."
+      "endLine": 111,
+      "summary": "The single axiom vinogradov_smaller_primes: every prime > N is a sum of three distinct strictly smaller primes. The basic and distinct-prime forms of Vinogradov's theorem are stated as commentary only.",
+      "mathContext": "Axiomatized: vinogradov_smaller_primes — the key ingredient that lets large primes decompose into smaller ones, enabling the inductive generation argument."
     },
     {
       "id": "solution",
       "title": "The Solution",
-      "startLine": 123,
-      "endLine": 174,
-      "summary": "vinogradovQ₀ construction, finiteness proof, main theorems.",
-      "mathContext": "Verified: vinogradovQ₀ construction, finiteness proof, main theorems."
+      "startLine": 112,
+      "endLine": 158,
+      "summary": "vinogradovQ₀ = {primes ≤ N} construction, the proved vinogradovQ₀_finite, the all_primes_in_QLim axiom, and the proved stronger_question_positive.",
+      "mathContext": "Verified: vinogradovQ₀ construction and finiteness proof; stronger_question_positive derived from the all_primes_in_QLim axiom."
     },
     {
       "id": "special-case",
       "title": "Special Case Q = {3, 5, 7, 11}",
-      "startLine": 175,
-      "endLine": 222,
-      "summary": "Ulam's original example with concrete proofs for Q₁ ∋ 19, 23.",
-      "mathContext": "Verified: Ulam's original example with concrete proofs for Q₁ ∋ 19, 23."
+      "startLine": 159,
+      "endLine": 188,
+      "summary": "Ulam's original example ulamQ₀ with concrete fully-proved membership theorems Q1_contains_19 and Q1_contains_23.",
+      "mathContext": "Verified: Ulam's original example with concrete proofs for Q₁ ∋ 19 (=3+5+11) and 23 (=5+7+11)."
     },
     {
       "id": "properties",
       "title": "Properties of the Sequence",
-      "startLine": 223,
-      "endLine": 250,
+      "startLine": 189,
+      "endLine": 216,
       "summary": "QSeq_monotone and QSeq_primes structural properties (fully proved).",
       "mathContext": "Mathematical content: QSeq_monotone and QSeq_primes structural properties (fully proved)."
     },
     {
       "id": "vinogradov-proof",
       "title": "Why Vinogradov Works",
-      "startLine": 251,
-      "endLine": 271,
-      "summary": "Inductive argument: vinogradov_induction and eventually_all_primes axioms.",
-      "mathContext": "Axiomatized: Inductive argument: vinogradov_induction and eventually_all_primes axioms."
+      "startLine": 217,
+      "endLine": 227,
+      "summary": "Prose exposition of the strong-induction step underlying all_primes_in_QLim — no new declarations, only commentary explaining why iterating from a large enough seed captures every prime.",
+      "mathContext": "Exposition: informal justification of the inductive argument behind the all_primes_in_QLim axiom."
     },
     {
       "id": "summary",
       "title": "Summary",
-      "startLine": 272,
-      "endLine": 274,
-      "summary": "erdos_471_summary combining StrongerQuestion, monotonicity, and primality.",
-      "mathContext": "Mathematical content: erdos_471_summary combining StrongerQuestion, monotonicity, and primality."
+      "startLine": 228,
+      "endLine": 256,
+      "summary": "erdos_471_summary combining StrongerQuestion, monotonicity, and primality preservation.",
+      "mathContext": "Mathematical content: erdos_471_summary combining StrongerQuestion, monotonicity, and primality preservation."
     }
   ],
   "conclusion": {
@@ -163,7 +164,7 @@
       "Set"
     ],
     "namespace": "Erdos471",
-    "lineCount": 274,
+    "lineCount": 256,
     "axiomCount": 2,
     "theoremCount": 7,
     "definitionCount": 8,


### PR DESCRIPTION
Enrichment pass for **erdos-471** (Ulam's Prime Sequence Problem). This is a correctness fix: the gallery metadata had drifted against the v4.31-trimmed `Erdos471Problem.lean` (256 lines, not the 274 recorded).

## Line-range drift
- Realigned all 8 `sections` and 5 annotation ranges to the actual `## Part I–VIII` boundaries in the Lean file. Ranges previously ran past EOF (max endLine 274 vs a 256-line file).
- Fixed `lineCount` 274 → 256 in both `meta` and `leanFile`.

## Non-existent axioms removed
The annotations and two section summaries named **axioms that do not exist** in the file:
- `vinogradov_three_primes`, `vinogradov_distinct` — the basic and distinct-prime forms of Vinogradov's theorem appear only as `/- -/` commentary, not as axioms.
- `ulams_question_positive` — the affirmative answer to Ulam's original question is discussed in commentary but is subsumed by the proved `stronger_question_positive`.
- `ulam_example_contains_all_primes` — the {3,5,7,11} conjecture is commentary, not a declaration.
- `vinogradov_induction`, `eventually_all_primes` — named in the "Why Vinogradov Works" section summary; that Part is pure prose.

The file has **exactly 2 axioms**: `vinogradov_smaller_primes` and `all_primes_in_QLim` (`axiomCount: 2` was already correct). Updated `originalContributions` and the `Q1_contains_19/23` proof-tactic description to match the real proof (norm_num + simp, not `Nat.prime_def_lt''`/`interval_cases`).

No content was deleted beyond factual corrections; all accurate context preserved.

Gallery data validation (`pnpm build` enrichment summary + search-index checks) passes; the `tsc` step fails only on the known missing-node_modules worktree gap.