### PR TITLE
Research: erdos-370 — prove gpf_mul_le from Mathlib (axiom 2→1)

### DIFF
--- a/proofs/Proofs/Erdos370Problem.lean
+++ b/proofs/Proofs/Erdos370Problem.lean
@@ -96,9 +96,34 @@ theorem gpf_prime_pow (p : ℕ) (hp : p.Prime) (k : ℕ) (hk : k ≥ 1) : gpf (p
   · omega
   · simp [List.getLast?_replicate]
 
-/-- gpf of a product is at most the max of the gpfs. -/
-axiom gpf_mul_le (m n : ℕ) (hm : m > 1) (hn : n > 1) :
-    gpf (m * n) ≤ max (gpf m) (gpf n)
+/-- Any prime `p` dividing `k > 1` is at most `gpf k`.  `gpf k` is the last
+    element of `k.primeFactorsList`, which Mathlib keeps sorted in ascending
+    order, so every member — in particular `p` — is bounded by it. -/
+theorem le_gpf_of_prime_dvd {p k : ℕ} (hk : k > 1) (hp : p.Prime) (hpd : p ∣ k) :
+    p ≤ gpf k := by
+  have hk0 : k ≠ 0 := by omega
+  have hmem : p ∈ k.primeFactorsList :=
+    Nat.mem_primeFactorsList'.mpr ⟨hp, hpd, hk0⟩
+  have hne : k.primeFactorsList ≠ [] := List.ne_nil_of_mem hmem
+  have hrel := ((Nat.primeFactorsList_sorted k).pairwise).rel_getLast hmem
+  have hg : gpf k = k.primeFactorsList.getLast hne := by
+    unfold gpf
+    rw [List.getLast?_eq_getLast_of_ne_nil hne]
+    rfl
+  rw [hg]
+  exact hrel
+
+/-- gpf of a product is at most the max of the gpfs.  The greatest prime factor
+    of `m * n` is a prime dividing `m * n`, hence dividing `m` or `n`, so it is
+    bounded by the corresponding `gpf`.  (Formerly an axiom.) -/
+theorem gpf_mul_le (m n : ℕ) (hm : m > 1) (hn : n > 1) :
+    gpf (m * n) ≤ max (gpf m) (gpf n) := by
+  have hmn : m * n > 1 := by nlinarith
+  have hp : (gpf (m * n)).Prime := gpf_prime_of_gt_one _ hmn
+  have hdvd : gpf (m * n) ∣ m * n := gpf_dvd _ hmn
+  rcases (hp.dvd_mul).mp hdvd with h | h
+  · exact le_trans (le_gpf_of_prime_dvd hm hp h) (le_max_left _ _)
+  · exact le_trans (le_gpf_of_prime_dvd hn hp h) (le_max_right _ _)
 
 /- ## Smooth Numbers -/
 

--- a/src/data/proofs/erdos-370/meta.json
+++ b/src/data/proofs/erdos-370/meta.json
@@ -63,10 +63,10 @@
       "erdos_370_infinitely_many: infinitude statement (sorry'd)",
       "erdos_370: injective-function encoding of infinitude (sorry'd)"
     ],
-    "axiomCount": 2,
+    "axiomCount": 1,
     "lineCount": 284,
-    "assumptions": "2 axioms (gpf_mul_le, dickman_density) and 2 sorries. gpf function and 7 properties now proved from Mathlib.",
-    "theoremCount": 16,
+    "assumptions": "1 axiom (dickman_density — Dickman-de Bruijn smooth-number density, deep analytic result) and 2 sorries (the two main Steinerberger existence theorems). gpf function and 9 properties now proved from Mathlib, including gpf_mul_le (greatest prime factor of a product ≤ max of the factors' gpfs), previously an axiom.",
+    "theoremCount": 18,
     "definitionCount": 7
   },
   "leanFile": {
@@ -93,8 +93,8 @@
       "ValidSteinerbergerM",
       "PomeranceExponent"
     ],
-    "axiomCount": 2,
-    "theoremCount": 16,
+    "axiomCount": 1,
+    "theoremCount": 18,
     "opens": [
       "Nat",
       "Finset",

--- a/src/data/research/problems/erdos-370-incomplete-01.json
+++ b/src/data/research/problems/erdos-370-incomplete-01.json
@@ -29,9 +29,13 @@
     }
   },
   "knowledge": {
-    "progressSummary": "AVAILABLE: parent formalization has 2 open sorry statement(s) to complete.",
-    "builtItems": [],
-    "insights": [],
+    "progressSummary": "AXIOM ELIMINATION (researcher-1, 2026-07-20): converted gpf_mul_le from axiom to theorem in Erdos370Problem.lean, reducing axioms 2→1. Only remaining axiom is dickman_density (deep Dickman-de Bruijn smooth-number density). 2 sorries remain — the two main Steinerberger existence theorems, genuinely hard (naive m=2^k construction fails on Mersenne primes m-1=2^k-1).",
+    "builtItems": [
+      "Proved le_gpf_of_prime_dvd + gpf_mul_le in Erdos370Problem.lean (was axiom); axiom count 2→1, host-verified v4.31.0 EXIT=0"
+    ],
+    "insights": [
+      "gpf_mul_le (greatest prime factor of a product ≤ max of the two gpfs) is provable from Mathlib: gpf(m·n) is a prime dividing m·n, so it divides m or n (Nat.Prime.dvd_mul), and any prime dividing k is ≤ gpf(k) because primeFactorsList is ascending-sorted (primeFactorsList_sorted.pairwise.rel_getLast)."
+    ],
     "mathlibGaps": [],
     "nextSteps": []
   },


### PR DESCRIPTION
## Summary
Axiom-elimination session on **erdos-370** (consecutive √-smooth numbers, Steinerberger). Converts `gpf_mul_le` from an `axiom` to a host-verified `theorem`, reducing `Erdos370Problem.lean`'s axiom count **2 → 1**.

## Progress
- **New lemma `le_gpf_of_prime_dvd`**: any prime `p ∣ k` (with `k > 1`) satisfies `p ≤ gpf k`. Proof: `gpf k` is the `getLast` of `k.primeFactorsList`, which Mathlib keeps ascending-sorted, so every member is bounded by it (`Nat.primeFactorsList_sorted |>.pairwise |>.rel_getLast`).
- **`gpf_mul_le`** (`gpf (m*n) ≤ max (gpf m) (gpf n)`): `gpf (m*n)` is a prime dividing `m*n`, hence dividing `m` or `n` (`Nat.Prime.dvd_mul`), so it is bounded by the corresponding `gpf`. This lemma sits directly on the critical path (the "key insight" line 229).
- Synced gallery meta: `axiomCount 2→1`, `theoremCount 16→18`, `assumptions` note.

## Findings
- The only remaining axiom `dickman_density` is the deep Dickman–de Bruijn smooth-number density result — not routine, left in place.
- The 2 sorries are the two main Steinerberger existence theorems. These are genuinely hard: the naive `m = 2^k` construction fails whenever `m-1 = 2^k-1` is a Mersenne prime (then `gpf(m-1) ≈ m`, not `< √n`). Left untouched.

## Status
**Outcome**: progress (1 axiom eliminated, on critical path)
**Verification**: host-verified on v4.31.0 (`lake env lean`, EXIT=0, no errors; only pre-existing sorry/deprecation warnings)
**Next Steps**: the real Steinerberger argument for the two existence sorries.

🤖 Generated by researcher-1