### PR TITLE
Enrich erdos-226: fix line-range drift + remove 3 non-existent axioms

### DIFF
--- a/src/data/proofs/erdos-226/annotations.json
+++ b/src/data/proofs/erdos-226/annotations.json
@@ -5,7 +5,7 @@
     "type": "concept",
     "range": {
       "startLine": 1,
-      "endLine": 43
+      "endLine": 40
     },
     "title": "Problem Overview and History",
     "content": "**Erdős Problem #226**: Is there an entire non-linear $f$ with $x \\in \\mathbb{Q} \\Leftrightarrow f(x) \\in \\mathbb{Q}$?\n\n**Status**: SOLVED (YES) by Barth-Schneider (1970)\n\nThe question goes beyond Stäckel's 1895 result that a transcendental entire function can map $\\mathbb{Q}$ into $\\mathbb{Q}$: Erdős required the biconditional. Barth and Schneider proved the much stronger result that for ANY countable dense $A, B \\subset \\mathbb{R}$, a transcendental entire $f$ with $f(A) = B$ exists. Their 1971 follow-up extended this to $\\mathbb{C}$.",
@@ -27,8 +27,8 @@
     "proofId": "erdos-226",
     "type": "definition",
     "range": {
-      "startLine": 45,
-      "endLine": 68
+      "startLine": 43,
+      "endLine": 64
     },
     "title": "Entire Function Definitions",
     "content": "Three key definitions:\n\n- `IsEntire(f)` := `Differentiable ℂ f` — holomorphic on all of $\\mathbb{C}$\n- `IsTranscendental(f)` := `IsEntire f ∧ ¬∃ (n : ℕ) (p : Polynomial ℂ), ∀ z, f z = p.eval z` — entire but not polynomial\n- `IsNonLinear(f)` := `¬∃ (a b : ℂ), ∀ z, f z = a * z + b` — not affine\n\nThe transcendence condition is strictly stronger than non-linearity: every transcendental function is non-linear, but not conversely ($z^2$ is non-linear but polynomial).",
@@ -49,8 +49,8 @@
     "proofId": "erdos-226",
     "type": "insight",
     "range": {
-      "startLine": 69,
-      "endLine": 86
+      "startLine": 67,
+      "endLine": 82
     },
     "title": "ℚ is Countable Dense (Proved)",
     "content": "`IsCountableDense(S)` := `S.Countable ∧ Dense S`.\n\n`rationals_countable_dense` (**proved**): $\\mathbb{Q}$ is countable and dense in $\\mathbb{R}$. The proof is a direct two-line application of `Set.countable_range` and `Rat.denseRange_ratCast` — two fundamental Mathlib facts.\n\nThis is the only non-trivial verified theorem in the formalization (everything else is either a definition or derived from axioms).",
@@ -72,8 +72,8 @@
     "proofId": "erdos-226",
     "type": "definition",
     "range": {
-      "startLine": 87,
-      "endLine": 129
+      "startLine": 85,
+      "endLine": 125
     },
     "title": "The Erdős and General Questions",
     "content": "Four definitions formalizing the problem:\n\n- `PreservesRationality(f)`: $\\forall x \\in \\mathbb{R}, (\\exists q \\in \\mathbb{Q}, q = x) \\Leftrightarrow (\\exists q \\in \\mathbb{Q}, q = f(x))$\n- `MapsSetToSet(f, A, B)`: $\\forall x, x \\in A \\Leftrightarrow f(x) \\in B$\n- `ErdosQuestion`: $\\exists$ entire non-linear $f$ preserving rationality\n- `GeneralQuestion`: $\\forall$ countable dense $A, B$, $\\exists$ entire $f$ with $f(A) = B$\n\nThe `GeneralQuestion` strictly implies `ErdosQuestion` (take $A = B = \\mathbb{Q}$).",
@@ -94,11 +94,11 @@
     "proofId": "erdos-226",
     "type": "concept",
     "range": {
-      "startLine": 130,
-      "endLine": 161
+      "startLine": 128,
+      "endLine": 148
     },
     "title": "Barth-Schneider Theorem (1970) — Axiomatized",
-    "content": "Two axioms encoding the Barth-Schneider theorem:\n\n1. `barth_schneider_1970` (axiom): For all countable dense $A, B \\subset \\mathbb{R}$, $\\exists$ transcendental entire $f$ with $z \\in A \\Leftrightarrow f(z) \\in B$ on the reals.\n\n2. `barth_schneider_monotone` (axiom): Same, but additionally $f|_{\\mathbb{R}}$ is strictly monotone.\n\nThe original construction uses Weierstrass products: enumerate $A = \\{a_n\\}$, $B = \\{b_n\\}$, and build $f$ as an infinite product forcing $f(a_n) = b_n$ while maintaining entireness. The monotonicity requires more care in ordering the interpolation points.",
+    "content": "The single axiom `barth_schneider_1970`: for all countable dense $A, B \\subset \\mathbb{R}$, $\\exists$ transcendental entire $f$ with $z \\in A \\Leftrightarrow f(z) \\in B$ on the reals.\n\nA following docstring (lines 144–148) records that the Barth-Schneider construction can additionally be made strictly monotone on $\\mathbb{R}$ — but this strengthening is stated only as commentary, not declared as a separate axiom.\n\nThe original construction uses Weierstrass products: enumerate $A = \\{a_n\\}$, $B = \\{b_n\\}$, and build $f$ as an infinite product forcing $f(a_n) = b_n$ while maintaining entireness. The monotonicity refinement requires more care in ordering the interpolation points.",
     "mathContext": "The construction produces $f(z) = \\lim_{n \\to \\infty} P_n(z)$ where each $P_n$ is a polynomial interpolating the first $n$ pairs $(a_i, b_i)$, with corrections via Weierstrass factors $E_p(z/z_n)$ to ensure convergence on $\\mathbb{C}$.",
     "significance": "key",
     "relatedConcepts": [
@@ -117,17 +117,17 @@
     "proofId": "erdos-226",
     "type": "insight",
     "range": {
-      "startLine": 162,
-      "endLine": 207
+      "startLine": 151,
+      "endLine": 188
     },
     "title": "The Answer: YES (Proved from Axioms)",
     "content": "`erdos_question_affirmative` (**proved**): The answer is YES.\n\nThe proof instantiates `barth_schneider_1970` with $A = B = \\text{Set.range}(\\uparrow \\cdot : \\mathbb{Q} \\to \\mathbb{R})$, applying `rationals_countable_dense`. It then shows transcendental $\\Rightarrow$ non-linear by contradiction: if $f(z) = az + b$, encode this as the polynomial $C(b) + C(a) \\cdot X$, contradicting transcendence.\n\n`general_question_affirmative` (**proved**): Follows immediately by unwrapping `barth_schneider_1970` and extracting the `IsEntire` component from `IsTranscendental`.",
-    "mathContext": "The transcendental $\\Rightarrow$ non-linear step: any affine function $az + b$ equals $\\text{eval}_z(b + aX)$, a degree-1 polynomial. So $f$ would satisfy $\\exists n, p, \\forall z, f(z) = p.\\text{eval}(z)$, contradicting `IsTranscendental`. Uses `ring_nf` to simplify $a \\cdot z + b = (b + a \\cdot X).\\text{eval}(z)$.",
+    "mathContext": "The transcendental $\\Rightarrow$ non-linear step: any affine function $az + b$ equals $\\text{eval}_z(b + aX)$, a degree-1 polynomial. So $f$ would satisfy $\\exists n, p, \\forall z, f(z) = p.\\text{eval}(z)$, contradicting `IsTranscendental`. After `simp only` unfolds the polynomial evaluation, `ring` closes $a \\cdot z + b = (b + a \\cdot X).\\text{eval}(z)$.",
     "significance": "key",
     "relatedConcepts": [
       "Polynomial.C",
       "Polynomial.X",
-      "ring_nf"
+      "ring"
     ],
     "prerequisites": [
       "barth_schneider_1970",
@@ -140,11 +140,11 @@
     "proofId": "erdos-226",
     "type": "concept",
     "range": {
-      "startLine": 208,
-      "endLine": 222
+      "startLine": 189,
+      "endLine": 196
     },
     "title": "Complex Extension (1971)",
-    "content": "`barth_schneider_complex` (axiom): For countable dense $A, B \\subseteq \\mathbb{C}$, $\\exists$ transcendental entire $f$ with $z \\in A \\Leftrightarrow f(z) \\in B$.\n\nThis is a substantial generalization: $\\mathbb{C}$ has richer topology than $\\mathbb{R}$ (simply connected, algebraically closed), so the interpolation argument requires different techniques to handle the two-dimensional dense set.",
+    "content": "A docstring records the 1971 complex extension: for countable dense $A, B \\subseteq \\mathbb{C}$, $\\exists$ transcendental entire $f$ with $z \\in A \\Leftrightarrow f(z) \\in B$. This is discussed as historical context only — it is **not** declared as an axiom in the file (the file's sole axiom is `barth_schneider_1970` over $\\mathbb{R}$).\n\nThe complex case is a substantial generalization: $\\mathbb{C}$ has richer topology than $\\mathbb{R}$ (simply connected, algebraically closed), so the interpolation argument requires different techniques to handle the two-dimensional dense set.",
     "mathContext": "Countable dense subsets of $\\mathbb{C}$ include $\\mathbb{Q}[i] = \\{a + bi : a, b \\in \\mathbb{Q}\\}$ and $\\overline{\\mathbb{Q}} \\cap \\mathbb{C}$ (algebraic numbers). The axiom states the result for arbitrary such sets.",
     "significance": "supporting",
     "relatedConcepts": [
@@ -162,11 +162,11 @@
     "proofId": "erdos-226",
     "type": "insight",
     "range": {
-      "startLine": 224,
-      "endLine": 240
+      "startLine": 197,
+      "endLine": 210
     },
     "title": "Why Polynomials Fail",
-    "content": "`no_polynomial_works` (axiom): No polynomial of degree $> 1$ preserves rationality bidirectionally.\n\nThe argument: if $p \\in \\mathbb{R}[x]$ with $\\deg p > 1$ and $p(\\mathbb{Q}) \\subseteq \\mathbb{Q}$, then $p$ must have rational coefficients (by evaluating at $0, 1, 2, \\ldots$). But a degree-$d$ rational polynomial $p(x) - r = 0$ has at most $d$ roots, so most irrational preimages of rationals exist: $\\exists x \\notin \\mathbb{Q}$ with $p(x) \\in \\mathbb{Q}$, breaking the biconditional.",
+    "content": "A docstring argues (informally, **not** as an axiom or theorem) that no polynomial of degree $> 1$ preserves rationality bidirectionally.\n\nThe argument: if $p \\in \\mathbb{R}[x]$ with $\\deg p > 1$ and $p(\\mathbb{Q}) \\subseteq \\mathbb{Q}$, then $p$ must have rational coefficients (by evaluating at $0, 1, 2, \\ldots$). But a degree-$d$ rational polynomial $p(x) - r = 0$ has at most $d$ roots, so irrational preimages of rationals exist: $\\exists x \\notin \\mathbb{Q}$ with $p(x) \\in \\mathbb{Q}$, breaking the biconditional. This explains why the witnessing function must be transcendental; the file leaves the claim as prose rather than formalizing it.",
     "mathContext": "For $p(x) = x^2$: $p(\\sqrt{2}) = 2 \\in \\mathbb{Q}$ but $\\sqrt{2} \\notin \\mathbb{Q}$. This is the simplest counterexample. More generally, $p^{-1}(\\mathbb{Q})$ is dense but strictly larger than $\\mathbb{Q}$ for any $\\deg p > 1$.",
     "significance": "supporting",
     "relatedConcepts": [
@@ -184,11 +184,11 @@
     "proofId": "erdos-226",
     "type": "concept",
     "range": {
-      "startLine": 242,
-      "endLine": 268
+      "startLine": 213,
+      "endLine": 258
     },
     "title": "Summary: Problem SOLVED",
-    "content": "Three theorems wrap up the formalization:\n\n- `erdos_226_summary` (**proved**): `ErdosQuestion ∧ GeneralQuestion`\n- `erdos_226` := `erdos_question_affirmative` (alias)\n- `erdos_226_answer` (**proved**): $\\exists$ entire transcendental $f$ preserving rationality — the most explicit statement\n\n**Score**: 4 axioms (Barth-Schneider real/complex, monotone version, no-polynomial), 1 verified theorem (`rationals_countable_dense`), 3 derived theorems, 0 sorries.",
+    "content": "Three theorems wrap up the formalization:\n\n- `erdos_226_summary` (**proved**): `ErdosQuestion ∧ GeneralQuestion`\n- `erdos_226` := `erdos_question_affirmative` (alias)\n- `erdos_226_answer` (**proved**): $\\exists$ entire transcendental $f$ preserving rationality — the most explicit statement\n\n**Score**: 1 axiom (`barth_schneider_1970`), 1 directly verified theorem (`rationals_countable_dense`), and the derived theorems above, with 0 sorries. The complex-extension, monotonicity, and no-polynomial claims appear as commentary only, not as additional axioms.",
     "mathContext": "The `erdos_226_answer` theorem provides the strongest formulation: $\\exists f : \\mathbb{C} \\to \\mathbb{C}$, `IsEntire f` $\\wedge$ `IsTranscendental f` $\\wedge$ $\\forall x \\in \\mathbb{R}, x \\in \\mathbb{Q} \\Leftrightarrow f(x) \\in \\mathbb{Q}$.",
     "significance": "key",
     "relatedConcepts": [

--- a/src/data/proofs/erdos-226/meta.json
+++ b/src/data/proofs/erdos-226/meta.json
@@ -53,7 +53,7 @@
       "Weierstrass product theorem and interpolation",
       "Algebraic number theory (rationality of polynomial values)"
     ],
-    "lineCount": 268,
+    "lineCount": 258,
     "assumptions": "1 axiom: barth_schneider_1970. 0 sorries.",
     "mathlib_version": "4.31.0",
     "theoremCount": 6,
@@ -82,80 +82,80 @@
     {
       "id": "entire-functions",
       "title": "Part 1: Entire Functions",
-      "startLine": 45,
-      "endLine": 68,
+      "startLine": 41,
+      "endLine": 64,
       "summary": "IsEntire (Differentiable ℂ f), IsTranscendental (entire and not polynomial), IsNonLinear (not affine) definitions.",
       "mathContext": "Formal definition: IsEntire (Differentiable ℂ f), IsTranscendental (entire and not polynomial), IsNonLinear (not affine) definitions."
     },
     {
       "id": "countable-dense",
       "title": "Part 2: Countable Dense Sets",
-      "startLine": 69,
-      "endLine": 86,
+      "startLine": 65,
+      "endLine": 82,
       "summary": "IsCountableDense definition. rationals_countable_dense: proved ℚ is countable dense in ℝ using Set.countable_range and Rat.denseRange_ratCast.",
       "mathContext": "IsCountableDense definition. rationals_countable_dense: proved $\\mathbb{Q}$ is countable dense in $\\mathbb{R}$ using Set.countable_range and Rat.denseRange_ratCast."
     },
     {
       "id": "rationality-preservation",
       "title": "Part 3: Rationality Preservation",
-      "startLine": 87,
-      "endLine": 102,
+      "startLine": 83,
+      "endLine": 98,
       "summary": "PreservesRationality (f(x) ∈ ℚ ↔ x ∈ ℚ) and MapsSetToSet (x ∈ A ↔ f(x) ∈ B) definitions.",
       "mathContext": "PreservesRationality (f(x) ∈ $\\mathbb{Q}$ ↔ x ∈ $\\mathbb{Q}$) and MapsSetToSet (x ∈ A ↔ f(x) ∈ B) definitions."
     },
     {
       "id": "original-question",
       "title": "Part 4: The Original Question",
-      "startLine": 103,
-      "endLine": 115,
+      "startLine": 99,
+      "endLine": 111,
       "summary": "ErdosQuestion: ∃ entire non-linear f with x ∈ ℚ ↔ f(x) ∈ ℚ.",
       "mathContext": "ErdosQuestion: ∃ entire non-linear f with x ∈ $\\mathbb{Q}$ ↔ f(x) ∈ $\\mathbb{Q}$."
     },
     {
       "id": "general-question",
       "title": "Part 5: The General Question",
-      "startLine": 116,
-      "endLine": 129,
+      "startLine": 112,
+      "endLine": 125,
       "summary": "GeneralQuestion: for all countable dense A, B, ∃ entire f mapping A to B.",
       "mathContext": "Mathematical content: GeneralQuestion: for all countable dense A, B, ∃ entire f mapping A to B."
     },
     {
       "id": "barth-schneider",
       "title": "Part 6: Barth-Schneider Theorem",
-      "startLine": 130,
-      "endLine": 152,
+      "startLine": 126,
+      "endLine": 148,
       "summary": "barth_schneider_1970 axiom (transcendental entire f with f(A) = B). The monotonicity result is described in a docstring but not declared as an axiom.",
-      "mathContext": "Axiomatized: barth_schneider_1970 axiom (transcendental entire f with f(A) = B). The monotonicity commentary at lines 153-155 is a docstring only; no barth_schneider_monotone axiom is declared."
+      "mathContext": "Axiomatized: barth_schneider_1970 axiom (transcendental entire f with f(A) = B). The monotonicity commentary at lines 144-148 is a docstring only; no barth_schneider_monotone axiom is declared."
     },
     {
       "id": "main-answer",
       "title": "Part 7: The Answer",
-      "startLine": 153,
-      "endLine": 198,
+      "startLine": 149,
+      "endLine": 188,
       "summary": "erdos_question_affirmative (proved from barth_schneider_1970 with A=B=ℚ) and general_question_affirmative (proved directly).",
       "mathContext": "erdos_question_affirmative (proved from barth_schneider_1970 with A=B=$\\mathbb{Q}$) and general_question_affirmative (proved directly)."
     },
     {
       "id": "extensions",
       "title": "Part 8: Extensions",
-      "startLine": 199,
-      "endLine": 206,
+      "startLine": 189,
+      "endLine": 196,
       "summary": "Docstring discussion of the 1971 ℂ extension (Barth-Schneider 1971); no axiom is declared.",
-      "mathContext": "Commentary on the 1971 extension to countable dense subsets of ℂ. No barth_schneider_complex axiom is declared; lines 199-206 are a docstring only."
+      "mathContext": "Commentary on the 1971 extension to countable dense subsets of ℂ. No barth_schneider_complex axiom is declared; lines 191-196 are a docstring only."
     },
     {
       "id": "insights",
       "title": "Part 9: Why This Works",
-      "startLine": 207,
-      "endLine": 220,
+      "startLine": 197,
+      "endLine": 210,
       "summary": "Docstring discussion of why transcendence is necessary: no polynomial of degree > 1 can preserve rationality. Not axiomatized.",
-      "mathContext": "Commentary on the transcendence argument. Lines 207-220 are a docstring discussing why no polynomial works; no no_polynomial_works axiom is declared."
+      "mathContext": "Commentary on the transcendence argument. Lines 199-209 are a docstring discussing why no polynomial works; no no_polynomial_works axiom is declared."
     },
     {
       "id": "summary",
       "title": "Part 10: Summary",
-      "startLine": 221,
-      "endLine": 268,
+      "startLine": 211,
+      "endLine": 258,
       "summary": "erdos_226_summary (proved), erdos_226, erdos_226_answer theorems. Problem SOLVED.",
       "mathContext": "Verified: erdos_226_summary (proved), erdos_226, erdos_226_answer theorems. Problem SOLVED."
     }
@@ -195,7 +195,7 @@
       "Set"
     ],
     "namespace": "Erdos226",
-    "lineCount": 268,
+    "lineCount": 258,
     "axiomCount": 1,
     "theoremCount": 6,
     "definitionCount": 8,


### PR DESCRIPTION
Enrichment pass for **erdos-226** (Entire Functions Preserving Rationality). A correctness fix: gallery metadata had drifted against `Erdos226Problem.lean` (258 lines, not the 268 recorded), and the annotations overstated the axiom count.

## Line-range drift
- Realigned all 10 `sections` and 9 annotation ranges to the actual `## Part I–X` boundaries. Every range had drifted ~4 lines and the last ones spilled past EOF (max endLine 268 vs a 258-line file). Section + annotation coverage now tiles 1–258 exactly.
- Fixed `lineCount` 268 → 258 (`meta` + `leanFile`), and updated stale line-number references embedded in section `mathContext` fields.

## Non-existent axioms removed
The annotations described **four** axioms; the file has exactly **one** (`axiomCount: 1` was already correct):
- `barth_schneider_monotone` — the strict-monotone strengthening is a docstring (lines 144–148), not an axiom.
- `barth_schneider_complex` — the 1971 ℂ extension is historical commentary (lines 191–196), not an axiom.
- `no_polynomial_works` — the "why polynomials fail" argument is an informal docstring (lines 199–209), not an axiom or theorem.

The "Summary" annotation's `**Score**: 4 axioms` line (which directly contradicted `axiomCount: 1`) is corrected to "1 axiom (`barth_schneider_1970`)". Also fixed the `erdos_question_affirmative` tactic note (`ring`, not `ring_nf`).

The file's sole axiom `barth_schneider_1970` and the proved `rationals_countable_dense` / derived theorems are described accurately; no accurate context was removed.

JSON validated; gallery-build schema is identical to the erdos-471 sibling PR that passed full `pnpm build`. The `tsc`/`tsx` steps require node_modules, absent in this fresh worktree (known gap).