### PR TITLE
audit: re-serve erdos-662 (axiomatized) — clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -15476,8 +15476,8 @@
     },
     "erdos-662": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:55:03Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-20T15:54:12Z",
       "result": "clean"
     },
     "erdos-663": {


### PR DESCRIPTION
## Reserve-mode audit — erdos-662

Unaudited queue is drained (0 remaining); round-robin re-serve of the oldest **uncontested** target. Verified per-slug that no open PR already touches erdos-662.

**Result: integrity-clean.** Verification against `proofs/Proofs/Erdos662Problem.lean`:

- **axiomCount 2** = explicit `axiom erdos_662_lattice_optimal` (the open ELV conjecture, t>1) + `Lean.ofReduceBool` from `native_decide` on `triLatticeCountInt_one`/`triLatticeCountInt_three`. Both fully disclosed in `assumptions`.
- **`kissing_number_2d`** genuinely proved via angular-sector pigeonhole (Complex.arg) — no sorry, no axiom. Matches the "Fully proved / no axioms" section claim.
- **`erdos_662_unit_case`** derives the t=1 bound from `contact_number_3n → ordered_unit_pairs_bound → unit_neighbor_bound → kissing_number_2d`, provably **not** depending on the conjecture axiom; `assumptions` documents the exact axiom set.
- **Counts match**: 23 theorems+lemmas, 12 defs, 0 sorries, ~409 lines.
- **Badge `axiom` / status `axiomatized`** are honest; the t=1 case is correctly scoped as a proved theorem, the general conjecture as open.

Minor non-reportable nit (not fixed here): the `assumptions` prose glosses `triLatticeCountInt_three` as "f(3)=12" where it means f(√3)=12; harmless labeling slip in the disclosure text, does not overstate proof strength.

---
Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)