### PR TITLE
Enrich erdos-1201: fix section & annotation line-range drift

### DIFF
--- a/src/data/proofs/erdos-1201/annotations.json
+++ b/src/data/proofs/erdos-1201/annotations.json
@@ -263,7 +263,7 @@
     "proofId": "erdos-1201",
     "range": {
       "startLine": 407,
-      "endLine": 483
+      "endLine": 485
     },
     "type": "concept",
     "title": "Good-Set Monotonicity in k and the Density Machinery",
@@ -286,8 +286,8 @@
     "id": "ann-eps-monotone-partial",
     "proofId": "erdos-1201",
     "range": {
-      "startLine": 489,
-      "endLine": 544
+      "startLine": 491,
+      "endLine": 546
     },
     "type": "concept",
     "title": "ε-Monotonicity and the Partial Conjecture (Proved for ε ≥ 1/2)",
@@ -310,8 +310,8 @@
     "id": "ann-upper-lower-bounds",
     "proofId": "erdos-1201",
     "range": {
-      "startLine": 551,
-      "endLine": 667
+      "startLine": 553,
+      "endLine": 669
     },
     "type": "concept",
     "title": "Two-Sided Bounds and Tight Bertrand Estimates",
@@ -334,8 +334,8 @@
     "id": "ann-max-formula-smooth",
     "proofId": "erdos-1201",
     "range": {
-      "startLine": 673,
-      "endLine": 710
+      "startLine": 675,
+      "endLine": 712
     },
     "type": "concept",
     "title": "Max Formula and Smooth-Window Reformulation",
@@ -358,8 +358,8 @@
     "id": "ann-primes-short-windows",
     "proofId": "erdos-1201",
     "range": {
-      "startLine": 716,
-      "endLine": 792
+      "startLine": 718,
+      "endLine": 794
     },
     "type": "concept",
     "title": "GPF for Primes, Short Windows, and Products",
@@ -381,8 +381,8 @@
     "id": "ann-recursive-concat",
     "proofId": "erdos-1201",
     "range": {
-      "startLine": 798,
-      "endLine": 969
+      "startLine": 800,
+      "endLine": 971
     },
     "type": "concept",
     "title": "Recursive Formulas, Window Concatenation, and Localization",
@@ -405,8 +405,8 @@
     "id": "ann-factorial-lower-bound",
     "proofId": "erdos-1201",
     "range": {
-      "startLine": 975,
-      "endLine": 1108
+      "startLine": 977,
+      "endLine": 1110
     },
     "type": "concept",
     "title": "Factorial Divisibility and the Universal Lower Bound",
@@ -429,8 +429,8 @@
     "id": "ann-smooth-characterization",
     "proofId": "erdos-1201",
     "range": {
-      "startLine": 1114,
-      "endLine": 1167
+      "startLine": 1116,
+      "endLine": 1169
     },
     "type": "concept",
     "title": "Smooth-Window Characterization and Conditional Reduction",
@@ -452,8 +452,8 @@
     "id": "ann-density-complement",
     "proofId": "erdos-1201",
     "range": {
-      "startLine": 1173,
-      "endLine": 1285
+      "startLine": 1175,
+      "endLine": 1287
     },
     "type": "insight",
     "title": "Density Complement and the Smooth-Density Conditional",
@@ -476,8 +476,8 @@
     "id": "ann-upper-density-asymptotics",
     "proofId": "erdos-1201",
     "range": {
-      "startLine": 1291,
-      "endLine": 1398
+      "startLine": 1293,
+      "endLine": 1394
     },
     "type": "concept",
     "title": "Upper-Density Basic Facts and Asymptotic Growth",
@@ -500,8 +500,8 @@
     "id": "ann-lower-density-strong",
     "proofId": "erdos-1201",
     "range": {
-      "startLine": 1404,
-      "endLine": 1613
+      "startLine": 1400,
+      "endLine": 1599
     },
     "type": "concept",
     "title": "Lower Density and the Strong Conjecture",
@@ -524,8 +524,8 @@
     "id": "ann-prime-window-goodness",
     "proofId": "erdos-1201",
     "range": {
-      "startLine": 1619,
-      "endLine": 1649
+      "startLine": 1605,
+      "endLine": 1635
     },
     "type": "concept",
     "title": "Prime-Window Automatic Goodness",

--- a/src/data/proofs/erdos-1201/meta.json
+++ b/src/data/proofs/erdos-1201/meta.json
@@ -23,7 +23,7 @@
     "erdosProblemStatus": "open",
     "axiomCount": 1,
     "assumptions": "1 axiom: erdos_1201_half_case (the ε=1/2 partial result, proved by Erdős). The main conjecture ErdosProblem1201 is open. Includes: Bertrand window bounds, Sylvester-Schur (prime window sizes and special cases), factorial divisibility, ε/k-monotonicity, individual threshold, density-monotonicity, smooth-window duality, rough-term characterization, conditional reduction to prime gaps, formal reduction ErdosProblem1201 ← smooth-decay conjecture, lowerDensity with exact complement duality, full equivalence ErdosProblem1201Strong ↔ smooth-decay, prime-window automatic goodness (session 18, 0 sorries).",
-    "lineCount": 1651,
+    "lineCount": 1637,
     "mathlib_version": "4.31.0",
     "theoremCount": 116,
     "definitionCount": 8
@@ -276,119 +276,119 @@
       "id": "monotonicity-window",
       "title": "Monotonicity in Window Width",
       "startLine": 403,
-      "endLine": 484,
+      "endLine": 486,
       "summary": "Good-set monotonicity in $k$: pointwise (`erdos_1201_good_implies_good_succ`) and as set containment (`erdos_1201_good_set_mono_k`). Builds the `densityFun` machinery (nonneg, $\\le1$, monotone, bounded/cobounded, complement-sum) and proves `upperDensity_mono` and `erdos_1201_density_mono_k` (good-set density is non-decreasing in $k$)."
     },
     {
       "id": "epsilon-monotonicity",
       "title": "Epsilon-Monotonicity and Partial Conjecture Proof",
-      "startLine": 485,
-      "endLine": 546,
+      "startLine": 487,
+      "endLine": 548,
       "summary": "Monotonicity in $\\varepsilon$ and the first conditional result. Shows $n^{1-\\varepsilon} \\le \\sqrt n$ for $\\varepsilon\\ge1/2$, the good set grows with $\\varepsilon$ (pointwise/containment/density), and proves `erdos_1201_partial_conjecture`: **ErdosProblem1201 holds for all $\\varepsilon\\ge1/2$**, deduced from the half-case axiom via $\\varepsilon$-monotonicity."
     },
     {
       "id": "upper-bounds-tight",
       "title": "Upper Bounds and Tight Estimates",
-      "startLine": 547,
-      "endLine": 624,
+      "startLine": 549,
+      "endLine": 626,
       "summary": "Upper and tight bounds: $P(n,0) = \\mathrm{gpf}(n)$, $P(n,k) \\le n+k$ (`gpfConsecutive_upper_bound`), prime-window-size Sylvester–Schur ($k+1$ prime $\\Rightarrow P(n,k) \\ge k+1$ via a complete residue system), and the Bertrand sandwich $n < P(n,n) \\le 2n$ (`gpfConsecutive_between`)."
     },
     {
       "id": "upper-bounds-bertrand",
       "title": "Upper Bounds and Bertrand Structure",
-      "startLine": 625,
-      "endLine": 668,
+      "startLine": 627,
+      "endLine": 670,
       "summary": "Refines the upper bound `gpfConsecutive_le_right` ($P(n,k)\\le n+k$), the exact value when the right endpoint is prime (`gpfConsecutive_eq_of_prime_right`: $P(n,k)=n+k$), and `gpfConsecutive_bertrand`: every $n$ has a window $k\\le n$ with $n+k$ prime achieving $P(n,k)=n+k$."
     },
     {
       "id": "max-formula",
       "title": "Max Formula and Smooth-Number Reformulation",
-      "startLine": 669,
-      "endLine": 711,
+      "startLine": 671,
+      "endLine": 713,
       "summary": "Key reformulation `gpfConsecutive_eq_sup_range`: $P(n,k)$ equals the max of the individual term GPFs $\\mathrm{gpf}(n+i)$. Yields the smooth-window duality `gpfConsecutive_le_iff`: $P(n,k)\\le t \\iff$ every term $n+i$ is $t$-smooth — connecting the conjecture to smooth-number density."
     },
     {
       "id": "gpf-primes-short",
       "title": "Greatest Prime Factor for Primes and Short Windows",
-      "startLine": 712,
-      "endLine": 772,
+      "startLine": 714,
+      "endLine": 774,
       "summary": "GPF for primes and small windows: $\\mathrm{gpf}(p)=p$, $P(p,0)=p$, $P(n,1)=\\max(\\mathrm{gpf}(n),\\mathrm{gpf}(n+1))$ with the two GPFs coprime and distinct (consecutive integers coprime), and the endpoint bounds $\\mathrm{gpf}(n), \\mathrm{gpf}(n+k) \\le P(n,k)$."
     },
     {
       "id": "gpf-of-products",
       "title": "GPF of Products",
-      "startLine": 773,
-      "endLine": 793,
+      "startLine": 775,
+      "endLine": 795,
       "summary": "`greatestPrimeFactor_mul`: $\\mathrm{gpf}(ab) = \\max(\\mathrm{gpf}(a),\\mathrm{gpf}(b))$ for $a,b\\ge2$, the multiplicative backbone of the max formula."
     },
     {
       "id": "general-monotonicity-recursive",
       "title": "General Monotonicity and Recursive Formula",
-      "startLine": 794,
-      "endLine": 819,
+      "startLine": 796,
+      "endLine": 821,
       "summary": "General $k$-monotonicity `gpfConsecutive_le_of_le_k` ($k_1\\le k_2 \\Rightarrow P(n,k_1)\\le P(n,k_2)$) and the recursion `gpfConsecutive_succ_right`: $P(n,k+1) = \\max(P(n,k), \\mathrm{gpf}(n+k+1))$."
     },
     {
       "id": "right-endpoint-biconditional",
       "title": "Right-Endpoint Biconditional and Infinite Sets",
-      "startLine": 820,
-      "endLine": 862,
+      "startLine": 822,
+      "endLine": 864,
       "summary": "`gpfConsecutive_eq_right_iff`: $P(n,k)=n+k \\iff (n+k)$ prime — the upper bound is hit exactly at prime right endpoints. Plus infinitude: $\\{n \\mid n+k \\text{ prime}\\}$ and $\\{n \\mid P(n,k)=n+k\\}$ are both infinite."
     },
     {
       "id": "window-extension",
       "title": "Window Extension and Concatenation Formulas",
-      "startLine": 863,
-      "endLine": 970,
+      "startLine": 865,
+      "endLine": 972,
       "summary": "Left-endpoint extension `gpfConsecutive_succ_left` and window concatenation `gpfConsecutive_window_concat` ($P(n,j+k+1) = \\max(P(n,j), P(n+j+1,k))$). Prime-term lower bound, the sufficient goodness condition `erdos_1201_good_of_prime_in_window`, and GPF localization `gpfConsecutive_eq_term_gpf` (when $P(n,k)>k$ the GPF comes from a single term)."
     },
     {
       "id": "factorial-divisibility",
       "title": "Factorial Divisibility and Universal Lower Bound",
-      "startLine": 971,
-      "endLine": 1109,
+      "startLine": 973,
+      "endLine": 1111,
       "summary": "Factorial structure: the product equals a descending factorial, so $(k+1)! \\mid$ product (`factorial_dvd_consecutiveProduct`). Gives the **universal** lower bounds $\\mathrm{gpf}((k+1)!) \\le P(n,k)$ and $k < 2 P(n,k)$ for ALL $n\\ge1$ (via Bertrand, no $n>k$ needed), the threshold bound, trivial goodness for large $\\varepsilon$, the reduction `erdos_1201_conjecture_large_eps` to $\\varepsilon=1/2$, individual thresholds, and the equivalence `erdos_1201_equiv_small_eps` (the conjecture reduces to $\\varepsilon<1/2$)."
     },
     {
       "id": "smooth-window-characterization",
       "title": "Smooth-Window Characterization and Conditional Reduction",
-      "startLine": 1110,
-      "endLine": 1168,
+      "startLine": 1112,
+      "endLine": 1170,
       "summary": "Smooth-window duality: $n$ is bad $\\iff$ the window $[n,n+k]$ is $n^{1-\\varepsilon}$-smooth (`erdos_1201_not_good_smooth_window`), equivalently good $\\iff$ some term is rough (`erdos_1201_good_iff_rough_term`). Proves the prime-gap conditional `erdos_1201_conditional_proof`: a Cramér-type density hypothesis on primes in short windows implies ErdosProblem1201."
     },
     {
       "id": "density-complement",
       "title": "Density Complement and Smooth-Density Conditional",
-      "startLine": 1169,
-      "endLine": 1286,
+      "startLine": 1171,
+      "endLine": 1288,
       "summary": "Density complement machinery: primes are good at $k=0$, `upperDensity_compl_ge` ($1 - d(S) \\le d(S^c)$), monotonicity up to a finite set, and `erdos_1201_from_bad_density_bound`. Culminates in `erdos_1201_smooth_decay_implies_conjecture`: ErdosProblem1201 follows if the smooth-window (bad-set) density decays to 0 as $k\\to\\infty$ — the Dickman-function form of Erdős's heuristic."
     },
     {
       "id": "upper-density-basic",
       "title": "Upper Density Basic Facts",
-      "startLine": 1287,
-      "endLine": 1332,
+      "startLine": 1289,
+      "endLine": 1326,
       "summary": "Basic density facts: $|[1,N]| = N$, `upperDensity_empty` $=0$, `upperDensity_le_one`, `upperDensity_ge_zero`, and `upperDensity_univ` $=1$."
     },
     {
       "id": "asymptotic-window",
       "title": "Asymptotic Behavior as Window Grows",
-      "startLine": 1333,
-      "endLine": 1399,
+      "startLine": 1327,
+      "endLine": 1395,
       "summary": "For fixed $n\\ge2$, $P(n,k) \\to \\infty$ as $k\\to\\infty$ (`gpfConsecutive_atTop`, via infinitude of primes). Each $n$ is eventually good (`erdos_1201_eventually_good`), and assuming the conjecture the good density stays $\\ge 1-\\eta$ for all large $k$ (`erdos_1201_density_eventually_large`)."
     },
     {
       "id": "lower-density",
       "title": "Lower Density",
-      "startLine": 1400,
-      "endLine": 1614,
+      "startLine": 1396,
+      "endLine": 1600,
       "summary": "Defines `lowerDensity` (liminf), proves nonnegativity, $\\mathrm{lower} \\le \\mathrm{upper}$, and the complement dualities $d_*(S^c) = 1 - d^*(S)$ and $d^*(S^c) = 1 - d_*(S)$. States the **strong conjecture** `ErdosProblem1201Strong` (lower density form), shows strong $\\Rightarrow$ weak, and proves `erdos_1201_strong_iff_smooth_decay`: the strong conjecture is exactly equivalent to the smooth-window density decaying to 0."
     },
     {
       "id": "prime-window-automatic",
       "title": "Prime-Window Automatic Goodness",
-      "startLine": 1615,
-      "endLine": 1651,
+      "startLine": 1601,
+      "endLine": 1637,
       "summary": "Automatic goodness: any prime in the window makes $n$ good with no size condition (`erdos_1201_good_of_any_prime_in_window`), specializing to prime start (`erdos_1201_good_prime_any_k`) and prime right endpoint (`erdos_1201_good_prime_endpoint`)."
     }
   ],
@@ -407,7 +407,7 @@
     ],
     "opens": [],
     "namespace": "Erdos1201",
-    "lineCount": 1651,
+    "lineCount": 1637,
     "axiomCount": 1,
     "theoremCount": 116,
     "definitionCount": 8,


### PR DESCRIPTION
## Enrichment pass for erdos-1201

**Work source:** section/annotation line-range drift (genuine at-floor correctness fix, not accretion).

The v4.31 toolchain flip (#39062) reshaped `Erdos1201Problem.lean` from **1651 → 1637** lines (early insertions, net deletions later), leaving the gallery metadata stale:

- `meta.lineCount` / `leanFile.lineCount` still read 1651
- The final section (`prime-window-automatic`) `endLine` overshot EOF by 14
- Interior section/annotation ranges drifted non-monotonically (+2 early → −14 late)

### Fix
- Re-anchored all 31 section boundaries + 22 annotation ranges via a content-based difflib old→new map against the pre-flip blob (`515ea3d34c`)
- `lineCount` 1651 → 1637

### Verification
- Both JSON files well-formed
- Sections remain contiguous with full EOF coverage
- All ranges within 1..1637; no inversions, no EOF overshoot

No prose/content changed — pure line-anchor correctness pass.