### PR TITLE
Research: erdos-83 — prove Erdős–Ko–Rado bound axiom from Mathlib (axiom 5→4)

### DIFF
--- a/proofs/Proofs/Erdos83Problem.lean
+++ b/proofs/Proofs/Erdos83Problem.lean
@@ -31,6 +31,7 @@ import Mathlib.Data.Finset.Basic
 import Mathlib.Data.Finset.Card
 import Mathlib.Data.Nat.Choose.Basic
 import Mathlib.Combinatorics.SetFamily.Intersecting
+import Mathlib.Combinatorics.SetFamily.KruskalKatona
 import Mathlib.Data.Real.Basic
 import Mathlib.Tactic
 
@@ -76,11 +77,28 @@ def isIntersecting {α : Type*} [DecidableEq α] (F : Finset (Finset α)) : Prop
 /--
 **Maximum Intersecting Family Size:**
 For k-subsets of [n] with n ≥ 2k, the maximum 1-intersecting family has size C(n-1, k-1).
--/
-axiom erdos_ko_rado_bound (n k : ℕ) (hn : n ≥ 2 * k) :
+
+Proved from Mathlib's `Finset.erdos_ko_rado`: the local `isIntersecting`
+(every pair meets in ≥ 1 element) is exactly `Set.Intersecting` (no two members
+are disjoint), `isKUniform F k` is `Set.Sized k`, and `n ≥ 2k` gives `k ≤ n/2`.
+(Formerly an axiom.) -/
+theorem erdos_ko_rado_bound (n k : ℕ) (hn : n ≥ 2 * k) :
   ∀ (F : Finset (Finset (Fin n))),
     isKUniform F k → isIntersecting F →
-    F.card ≤ Nat.choose (n - 1) (k - 1)
+    F.card ≤ Nat.choose (n - 1) (k - 1) := by
+  intro F hUnif hInt
+  have hI : ∀ A ∈ F, ∀ B ∈ F, (A ∩ B).card ≥ 1 := hInt
+  have hInt' : (↑F : Set (Finset (Fin n))).Intersecting := by
+    intro A hA B hB hdisj
+    have hcard := hI A (Finset.mem_coe.mp hA) B (Finset.mem_coe.mp hB)
+    rw [Finset.disjoint_iff_inter_eq_empty] at hdisj
+    rw [hdisj] at hcard
+    simp at hcard
+  have hSized : (↑F : Set (Finset (Fin n))).Sized k := by
+    intro A hA
+    exact hUnif A (Finset.mem_coe.mp hA)
+  have hk : k ≤ n / 2 := by omega
+  exact Finset.erdos_ko_rado hInt' hSized hk
 
 /--
 **EKR Extremal Family:**

--- a/src/data/proofs/erdos-83/meta.json
+++ b/src/data/proofs/erdos-83/meta.json
@@ -71,10 +71,10 @@
       "erdos_83_summary: both directions (bound + tightness)",
       "erdos_83: final theorem statement"
     ],
-    "axiomCount": 5,
+    "axiomCount": 4,
     "lineCount": 404,
-    "assumptions": "5 axioms: erdos_ko_rado_bound, starLikeFamily_achieves, ahlswede_khachatrian_theorem, erdos83_from_ak, erdos83_bound_asymptotic. 2 sorry(s) (both DEFINITION sorries: criticalRatio, akFamily). (starLikeFamily_valid was previously an axiom; it is now a proved theorem — the majority family is 2-intersecting by a pure pigeonhole argument on the 2n-element core, |A∩B| ≥ (n+1)+(n+1)-2n = 2. The starLikeFamily construction sorry is also now completed via a concrete filter over the core erdos83Core, whose cardinality 2n is proved via the Fin (2n) ↪ Fin (4n) embedding. ekr_achieved was likewise previously an axiom, now a proved counting identity.)",
-    "theoremCount": 8,
+    "assumptions": "4 axioms: starLikeFamily_achieves, ahlswede_khachatrian_theorem, erdos83_from_ak, erdos83_bound_asymptotic. 2 sorry(s) (both DEFINITION sorries: criticalRatio, akFamily). The Erdős–Ko–Rado bound (erdos_ko_rado_bound: max 1-intersecting k-uniform family on [n], n≥2k, has ≤ C(n-1,k-1) members) is now proved from Mathlib Finset.erdos_ko_rado (formerly an axiom). starLikeFamily_valid, the starLikeFamily construction, and ekr_achieved were also previously axioms and are now proved.",
+    "theoremCount": 9,
     "definitionCount": 13,
     "additionalFiles": [
       "Proofs/Stubs/Erdos83Aristotle.lean"
@@ -205,8 +205,8 @@
     ],
     "namespace": "Erdos83",
     "lineCount": 404,
-    "axiomCount": 5,
-    "theoremCount": 8,
+    "axiomCount": 4,
+    "theoremCount": 9,
     "definitionCount": 13,
     "path": "Proofs/Erdos83Problem.lean",
     "sorries": 2,

--- a/src/data/research/problems/erdos-83-incomplete-01.json
+++ b/src/data/research/problems/erdos-83-incomplete-01.json
@@ -29,9 +29,13 @@
     }
   },
   "knowledge": {
-    "progressSummary": "AVAILABLE: parent formalization has 2 open sorry statement(s) to complete.",
-    "builtItems": [],
-    "insights": [],
+    "progressSummary": "AXIOM ELIMINATION (researcher-1, 2026-07-20): proved the Erdős–Ko–Rado bound axiom from Mathlib Finset.erdos_ko_rado, axiom count 5→4. Remaining axioms: starLikeFamily_achieves, ahlswede_khachatrian_theorem (deep Ahlswede–Khachatrian), erdos83_from_ak, erdos83_bound_asymptotic. 2 DEFINITION sorries remain (criticalRatio, akFamily).",
+    "builtItems": [
+      "Erdos83Problem.lean: proved erdos_ko_rado_bound from Mathlib Finset.erdos_ko_rado; axiom 5→4. Host-verified v4.31.0 EXIT=0."
+    ],
+    "insights": [
+      "The local erdos_ko_rado_bound axiom is directly provable from Mathlib Finset.erdos_ko_rado: isIntersecting F (every pair meets in ≥1) ↔ Set.Intersecting (no two members Disjoint), isKUniform F k ↔ Set.Sized k, and n≥2k ↔ k≤n/2 (omega). Needs import Mathlib.Combinatorics.SetFamily.KruskalKatona."
+    ],
     "mathlibGaps": [],
     "nextSteps": []
   },


### PR DESCRIPTION
## Summary
Axiom-elimination session on **erdos-83** (Erdős intersecting-family problem). Converts `erdos_ko_rado_bound` — the classical Erdős–Ko–Rado bound (a 1-intersecting `k`-uniform family on `[n]` with `n ≥ 2k` has at most `C(n-1, k-1)` members) — from an `axiom` to a host-verified `theorem`, reducing the file's axiom count **5 → 4**.

## Approach
The bound is exactly Mathlib's `Finset.erdos_ko_rado`; the bridge is definitional:
- local `isIntersecting F` (every pair meets in ≥ 1 element) ⟺ `Set.Intersecting ↑F` (no two members are `Disjoint`),
- local `isKUniform F k` ⟺ `Set.Sized k ↑F`,
- `n ≥ 2k` ⟹ `k ≤ n/2` by `omega`.

Added `import Mathlib.Combinatorics.SetFamily.KruskalKatona`.

## Findings
- Remaining axioms are genuinely deep results: `ahlswede_khachatrian_theorem` (the full Ahlswede–Khachatrian t-intersecting theorem), `starLikeFamily_achieves`, `erdos83_from_ak`, `erdos83_bound_asymptotic`.
- The 2 remaining sorries are definition sorries (`criticalRatio`, `akFamily`).

## Status
**Outcome**: progress (1 axiom eliminated)
**Verification**: host-verified on v4.31.0 (`lake env lean`, EXIT=0, no errors)
**Next Steps**: the Ahlswede–Khachatrian axiom is the deep core; the def sorries need concrete definitions.

🤖 Generated by researcher-1