### PR TITLE
Enrich borsuk-ulam-oq-02: fix section & annotation line-range drift

### DIFF
--- a/src/data/proofs/borsuk-ulam-oq-02/annotations.json
+++ b/src/data/proofs/borsuk-ulam-oq-02/annotations.json
@@ -4,7 +4,7 @@
     "proofId": "borsuk-ulam-oq-02",
     "range": {
       "startLine": 1,
-      "endLine": 53
+      "endLine": 47
     },
     "type": "concept",
     "title": "Equivariant Borsuk-Ulam: From Antipodal Pairs to Group Actions",
@@ -31,8 +31,8 @@
     "id": "ann-borsuk-ulam-oq02-02-framework",
     "proofId": "borsuk-ulam-oq-02",
     "range": {
-      "startLine": 55,
-      "endLine": 92
+      "startLine": 49,
+      "endLine": 86
     },
     "type": "definition",
     "title": "IsEquivariant: Abstract G-Equivariance via SMul Typeclass",
@@ -59,8 +59,8 @@
     "id": "ann-borsuk-ulam-oq02-03-z2-case",
     "proofId": "borsuk-ulam-oq-02",
     "range": {
-      "startLine": 93,
-      "endLine": 149
+      "startLine": 87,
+      "endLine": 145
     },
     "type": "concept",
     "title": "Odd Functions = ℤ/2-Equivariant Maps: Deriving Classical Borsuk-Ulam",
@@ -87,8 +87,8 @@
     "id": "ann-borsuk-ulam-oq02-04-zp-rotation",
     "proofId": "borsuk-ulam-oq-02",
     "range": {
-      "startLine": 164,
-      "endLine": 215
+      "startLine": 160,
+      "endLine": 210
     },
     "type": "concept",
     "title": "ℤ/p Rotation: Isometry via Pythagorean Identity and Yang-Borsuk Axiom",
@@ -115,8 +115,8 @@
     "id": "ann-borsuk-ulam-oq02-05-freeness",
     "proofId": "borsuk-ulam-oq-02",
     "range": {
-      "startLine": 218,
-      "endLine": 289
+      "startLine": 220,
+      "endLine": 270
     },
     "type": "concept",
     "title": "Freeness Proof: cos(2π/p) ≠ 1 Implies No Fixed Points on S¹",
@@ -142,8 +142,8 @@
     "id": "ann-borsuk-ulam-oq02-06-dold-open",
     "proofId": "borsuk-ulam-oq-02",
     "range": {
-      "startLine": 290,
-      "endLine": 355
+      "startLine": 271,
+      "endLine": 336
     },
     "type": "insight",
     "title": "Dold's Theorem, Open Cases, and the Trivial Dimension Upper Bound",
@@ -170,8 +170,8 @@
     "id": "ann-borsuk-ulam-oq02-07-extras",
     "proofId": "borsuk-ulam-oq-02",
     "range": {
-      "startLine": 371,
-      "endLine": 389
+      "startLine": 349,
+      "endLine": 376
     },
     "type": "concept",
     "title": "Part 7: Antipodal Involution, Fixed-Point Freeness, and Z/2 Action Completeness",

--- a/src/data/proofs/borsuk-ulam-oq-02/meta.json
+++ b/src/data/proofs/borsuk-ulam-oq-02/meta.json
@@ -85,7 +85,7 @@
     ],
     "dateAdded": "2026-02-24",
     "axiomCount": 1,
-    "lineCount": 389,
+    "lineCount": 376,
     "assumptions": "1 axiom encoding the core ℤ/2 equivariant Borsuk-Ulam vanishing result (z2_equivariant_borsuk_ulam). No structure-encoded assumptions.",
     "mathlib_version": "4.31.0",
     "theoremCount": 18,
@@ -115,63 +115,63 @@
       "id": "header",
       "title": "Problem Statement and Historical Context",
       "startLine": 1,
-      "endLine": 54,
+      "endLine": 48,
       "summary": "Overview of equivariant Borsuk-Ulam theory: ℤ/2 (classical), Yang-Borsuk (prime groups), Dold's theorem, and open problems for general Lie groups. Key references: Borsuk 1933, Yang 1954, Dold 1983.",
       "mathContext": "The equivariant reformulation: $f(-x) = -f(x)$ is $\\mathbb{Z}/2$-equivariance. Yang-Borsuk: $\\mathbb{Z}/p$ equivariant $f: S^{2n-1} \\to \\mathbb{R}^{2n}$ must vanish. Dold: cohomological index obstruction for free $G$-space maps."
     },
     {
       "id": "general-framework",
       "title": "Part 1: G-Equivariant Maps — General Framework",
-      "startLine": 55,
-      "endLine": 92,
+      "startLine": 49,
+      "endLine": 86,
       "summary": "Abstract definition of G-equivariant maps via SMul G X. Proved: equivariant_comp (composition), equivariant_id (identity), equivariant_const (constant at fixed point), equivariant_maps_orbits (maps orbits to orbits).",
       "mathContext": "$f: X \\to Y$ is $G$-equivariant iff $\\forall g \\in G, x \\in X: f(g \\cdot x) = g \\cdot f(x)$. Composition preserves equivariance: $(h \\circ f)(g \\cdot x) = g \\cdot (h \\circ f)(x)$. Orbits map to orbits: $f(G \\cdot x) \\subseteq G \\cdot f(x)$."
     },
     {
       "id": "z2-case",
       "title": "Part 2: ℤ/2 Equivariance = Odd Functions (Classical Case)",
-      "startLine": 93,
-      "endLine": 149,
+      "startLine": 87,
+      "endLine": 145,
       "summary": "Explicit ℤ/2 SMul instance on Euclidean space. Theorem odd_iff_z2_equivariant: f(-x)=-f(x) iff ℤ/2-equivariant. Theorem antipode_on_sphere. Axiom z2_equivariant_borsuk_ulam (core vanishing result). Theorem classical_borsuk_ulam_from_equivariant: derives ∃x: f(x)=f(-x).",
       "mathContext": "$\\mathbb{Z}/2$ acts on $\\mathbb{R}^n$ by negation: $1 \\cdot x = -x$. $f(-x) = -f(x)$ $\\iff$ $f$ is $\\mathbb{Z}/2$-equivariant. Classical BU: $\\forall f: S^n \\to \\mathbb{R}^n$ continuous, $\\exists x: f(x) = f(-x)$ follows by setting $g(x) = f(x) - f(-x)$ (odd, hence equivariant, hence vanishes)."
     },
     {
       "id": "zp-case",
       "title": "Part 3: ℤ/p Equivariant Case (Yang-Borsuk Theorem)",
-      "startLine": 150,
-      "endLine": 289,
+      "startLine": 146,
+      "endLine": 270,
       "summary": "zp_rotation: explicit Z/p rotation on ℝ² by 2π/p. PROVED zp_rotation_isometry (isometry via cos²+sin²=1) and zp_rotation_free_statement (no fixed points for prime p, using cos(2π/p)≠1). AXIOM yang_borsuk_theorem: equivariant maps on S^(2n-1) must vanish.",
       "mathContext": "$\\mathbb{Z}/p$ acts on $\\mathbb{R}^2$ by rotation $R_{2\\pi/p} = \\begin{pmatrix} \\cos(2\\pi/p) & -\\sin(2\\pi/p) \\\\ \\sin(2\\pi/p) & \\cos(2\\pi/p) \\end{pmatrix}$. Isometry: $\\cos^2(2\\pi/p) + \\sin^2(2\\pi/p) = 1$. Free on $S^1$: $\\cos(2\\pi k/p) = 1 \\Rightarrow k \\equiv 0 \\pmod{p}$ for prime $p$."
     },
     {
       "id": "dold-theorem",
       "title": "Part 4: Dold's Theorem (Cohomological Index Obstruction)",
-      "startLine": 290,
-      "endLine": 323,
+      "startLine": 271,
+      "endLine": 304,
       "summary": "Definition IsFreeAction: free group action (no fixed points). AXIOM dold_theorem: general cohomological obstruction for free G-space maps — no equivariant map from highly connected free G-space to low-dimensional G-space.",
       "mathContext": "Dold's theorem (1983): if $G$ acts freely on an $(n-1)$-connected space $X$ and $\\dim Y < n$, then no $G$-equivariant continuous map $X \\to Y$ exists. The cohomological index $\\text{ind}_G(X)$ controls the minimal target dimension."
     },
     {
       "id": "open-cases",
       "title": "Part 5: What Remains Open",
-      "startLine": 324,
-      "endLine": 355,
+      "startLine": 305,
+      "endLine": 336,
       "summary": "AXIOM equivariant_borsuk_ulam_free_G: general finite free G-action case. PROVED equivariant_dimension_bound_trivial: trivial upper bound via identity. Documents three open problems: non-free actions, optimal bounds, compact Lie groups.",
       "mathContext": "Open: for non-free $G$-actions, the equivariant BU dimension depends on the fixed-point set structure. For $\\mathbb{Z}/4$ on $S^2$ (non-free), Smith theory bounds apply. For compact Lie groups, representation-theoretic obstructions replace cohomological ones."
     },
     {
       "id": "summary",
       "title": "Part 6: Summary of Known Equivariant Borsuk-Ulam Results",
-      "startLine": 356,
-      "endLine": 370,
+      "startLine": 337,
+      "endLine": 348,
       "summary": "equivariant_bu_landscape: unified theorem combining ℤ/2 Borsuk-Ulam (every f: Sⁿ → ℝⁿ has antipodal pair) with equivariance infrastructure (identity is always equivariant).",
       "mathContext": "Combined result: $\\forall f: S^n \\to \\mathbb{R}^n$ continuous, $\\exists x: f(x) = f(-x)$ (classical BU from equivariant form) $\\wedge$ identity is always $G$-equivariant (trivial upper bound on equivariant dimension)."
     },
     {
       "id": "part7-extras",
       "title": "Part 7: Additional Equivariance Properties",
-      "startLine": 371,
-      "endLine": 389,
+      "startLine": 349,
+      "endLine": 376,
       "summary": "Seven structural lemmas: antipode_involutive (double negation), antipode_fixed_point_free (no fixed points on sphere via 2‖x‖=0 contradiction), zp_rotation_maps_sphere (isometries preserve S¹), z2_smul_zero/one (explicit Z/2 action values), z2_action_involutive (k•(k•x)=x), equivariant_add_z2 (sum of Z/2-equivariant maps is equivariant).",
       "mathContext": "Structural properties: antipode is involutive ($(-1)^2 = 1$ in $\\mathbb{Z}/2$), fixed-point-free on $S^n$ (since $x = -x \\Rightarrow 2\\|x\\| = 0$ contradicts $\\|x\\| = 1$), and $\\mathbb{Z}/p$ rotation preserves $S^1$. Sum of $\\mathbb{Z}/2$-equivariant maps is equivariant."
     }
@@ -231,7 +231,7 @@
       "Metric"
     ],
     "namespace": "BorsukUlamOQ02",
-    "lineCount": 389,
+    "lineCount": 376,
     "axiomCount": 1,
     "theoremCount": 18,
     "definitionCount": 5,


### PR DESCRIPTION
## Enrichment pass for borsuk-ulam-oq-02

**Work source:** section/annotation line-range drift (genuine at-floor correctness fix, not accretion).

The v4.31 toolchain flip (#39062) trimmed `BorsukUlamOQ02.lean` from **389 → 376** lines. Stale gallery metadata:
- `meta.lineCount` / `leanFile.lineCount` still read 389
- The final section (`part7-extras`) `endLine` overshot EOF by 13
- Interior ranges drifted (up to −19 near EOF)

### Fix
- Re-anchored all 8 section boundaries + 7 annotation ranges via a content-based difflib old→new map against the pre-flip blob (`515ea3d34c`)
- `lineCount` 389 → 376

### Verification
- Both JSON files well-formed; sections contiguous with full EOF coverage; all ranges within 1..376, no inversions
- Axiom cross-check: annotations name no axioms; the single real axiom `z2_equivariant_borsuk_ulam` matches `meta.axiomCount = 1`

No prose/content changed — pure line-anchor correctness pass.