### PR TITLE
Enrich chebyshev-pnt-bridge-oq-01: fix section/annotation drift + remove stale sorry claims

### DIFF
--- a/src/data/proofs/chebyshev-pnt-bridge-oq-01/annotations.json
+++ b/src/data/proofs/chebyshev-pnt-bridge-oq-01/annotations.json
@@ -31,11 +31,11 @@
     "proofId": "chebyshev-pnt-bridge-oq-01",
     "range": {
       "startLine": 30,
-      "endLine": 61
+      "endLine": 36
     },
     "type": "insight",
     "title": "Legendre's Formula for v_p(n!)",
-    "content": "States Legendre's formula: the $p$-adic valuation of $n!$ is $v_p(n!) = \\sum_{i=1}^{n} \\lfloor n/p^i \\rfloor$. This is currently a `sorry` -- the connection between Mathlib's `Nat.factorization` API and the summation formula needs to be established.",
+    "content": "Proves Legendre's formula: the $p$-adic valuation of $n!$ is $v_p(n!) = \\sum_{i=1}^{n} \\lfloor n/p^i \\rfloor$. The Lean proof supplies the `Fact p.Prime` instance, rewrites the factorization via `Nat.factorization_def`, and closes the goal with Mathlib's `padicValNat_factorial` (bounding the summation range using `Nat.log_le_self`).",
     "mathContext": "$v_p(n!) = \\sum_{i \\geq 1} \\lfloor n/p^i \\rfloor = \\sum_{i=1}^{\\lfloor \\log_p n \\rfloor} \\lfloor n/p^i \\rfloor$. In Lean: `(n !).factorization p = ∑ i ∈ Finset.Ico 1 (n + 1), n / p ^ i`. The sum is finite since $\\lfloor n/p^i \\rfloor = 0$ for $p^i > n$.",
     "significance": "key",
     "prerequisites": [
@@ -54,8 +54,8 @@
     "id": "ann-carry-bound",
     "proofId": "chebyshev-pnt-bridge-oq-01",
     "range": {
-      "startLine": 63,
-      "endLine": 72
+      "startLine": 38,
+      "endLine": 48
     },
     "type": "insight",
     "title": "Carry Term Bound: Each Digit Contributes 0 or 1",
@@ -78,8 +78,8 @@
     "id": "ann-carry-vanishing",
     "proofId": "chebyshev-pnt-bridge-oq-01",
     "range": {
-      "startLine": 74,
-      "endLine": 79
+      "startLine": 50,
+      "endLine": 54
     },
     "type": "insight",
     "title": "Carry Terms Vanish for Large Powers",
@@ -100,8 +100,8 @@
     "id": "ann-digits-bound",
     "proofId": "chebyshev-pnt-bridge-oq-01",
     "range": {
-      "startLine": 81,
-      "endLine": 95
+      "startLine": 56,
+      "endLine": 61
     },
     "type": "insight",
     "title": "Existence of a Large Power of p",
@@ -124,12 +124,12 @@
     "id": "ann-main-theorem",
     "proofId": "chebyshev-pnt-bridge-oq-01",
     "range": {
-      "startLine": 101,
-      "endLine": 107
+      "startLine": 67,
+      "endLine": 73
     },
     "type": "insight",
     "title": "Main Bound: p^{v_p(C(2n,n))} ≤ 2n",
-    "content": "The **main theorem**: for any prime $p$ and $n \\geq 1$, $p^{v_p\\binom{2n}{n}} \\leq 2n$. Currently `sorry` -- requires connecting the carry infrastructure (proved) to Mathlib's `Nat.factorization` API. The proof sketch: $v_p\\binom{2n}{n} = \\sum_i \\text{carry}_i \\leq \\lfloor \\log_p(2n) \\rfloor$, so $p^{v_p} \\leq p^{\\log_p(2n)} = 2n$.",
+    "content": "The **main theorem**: for any prime $p$ and $n \\geq 1$, $p^{v_p\\binom{2n}{n}} \\leq 2n$. Proved in one line via Mathlib's `Nat.pow_factorization_choose_le`, which packages exactly the carry-counting argument developed above: $v_p\\binom{2n}{n} = \\sum_i \\text{carry}_i \\leq \\lfloor \\log_p(2n) \\rfloor$, so $p^{v_p} \\leq p^{\\log_p(2n)} \\leq 2n$.",
     "mathContext": "$p^{v_p\\binom{2n}{n}} \\leq 2n$. Equivalently: $v_p\\binom{2n}{n} \\leq \\log_p(2n)$. In Lean: `p ^ ((2 * n).choose n).factorization p ≤ 2 * n`.",
     "significance": "key",
     "prerequisites": [
@@ -149,18 +149,18 @@
     "id": "ann-product-bound",
     "proofId": "chebyshev-pnt-bridge-oq-01",
     "range": {
-      "startLine": 109,
-      "endLine": 158
+      "startLine": 75,
+      "endLine": 124
     },
     "type": "insight",
     "title": "Product Bound via Prime Counting",
-    "content": "Corollary: $\\binom{2n}{n} \\leq (2n)^{\\pi(2n)}$. Since $\\binom{2n}{n} = \\prod_{p \\text{ prime}} p^{v_p\\binom{2n}{n}}$ and each factor is $\\leq 2n$, and there are $\\pi(2n)$ primes $\\leq 2n$, the product is bounded by $(2n)^{\\pi(2n)}$. Currently `sorry`.",
-    "mathContext": "$\\binom{2n}{n} = \\prod_{p \\leq 2n} p^{v_p\\binom{2n}{n}} \\leq \\prod_{p \\leq 2n} 2n = (2n)^{\\pi(2n)}$. In Lean: `(2 * n).choose n ≤ (2 * n) ^ (2 * n).primeCounting'`.",
+    "content": "Corollary: $\\binom{2n}{n} \\leq (2n)^{\\pi(2n)}$. Since $\\binom{2n}{n} = \\prod_{p \\text{ prime}} p^{v_p\\binom{2n}{n}}$ and each factor is $\\leq 2n$, and there are $\\pi(2n)$ primes $\\leq 2n$, the product is bounded by $(2n)^{\\pi(2n)}$. The Lean proof reconstructs $\\binom{2n}{n}$ from its factorization (`Nat.prod_factorization_pow_eq_self`), bounds each factor via the main theorem, and shows the support of the factorization injects into the primes $\\leq 2n$ so its cardinality is $\\leq \\pi(2n)$.",
+    "mathContext": "$\\binom{2n}{n} = \\prod_{p \\leq 2n} p^{v_p\\binom{2n}{n}} \\leq \\prod_{p \\leq 2n} 2n = (2n)^{\\pi(2n)}$. In Lean: `(2 * n).choose n ≤ (2 * n) ^ Nat.primeCounting (2 * n)`.",
     "significance": "key",
     "prerequisites": [
       "prime_pow_val_central_binom_le theorem",
       "fundamental theorem of arithmetic",
-      "Nat.primeCounting'"
+      "Nat.primeCounting"
     ],
     "relatedConcepts": [
       "prime counting function",
@@ -173,12 +173,12 @@
     "id": "ann-binomial-lower",
     "proofId": "chebyshev-pnt-bridge-oq-01",
     "range": {
-      "startLine": 164,
-      "endLine": 184
+      "startLine": 130,
+      "endLine": 150
     },
     "type": "insight",
     "title": "Central Binomial Lower Bound",
-    "content": "States $(2n+1) \\cdot \\binom{2n}{n} \\geq 4^n$. This follows from the binomial theorem: $4^n = (1+1)^{2n} = \\sum_{k=0}^{2n} \\binom{2n}{k} \\leq (2n+1) \\binom{2n}{n}$ since $\\binom{2n}{n}$ is the maximum binomial coefficient. Currently `sorry`.",
+    "content": "Proves $(2n+1) \\cdot \\binom{2n}{n} \\geq 4^n$. This follows from the binomial theorem: $4^n = (1+1)^{2n} = \\sum_{k=0}^{2n} \\binom{2n}{k} \\leq (2n+1) \\binom{2n}{n}$ since $\\binom{2n}{n}$ is the maximum binomial coefficient. The Lean proof combines `Nat.sum_range_choose`, the maximality lemma `Nat.choose_le_middle`, and `Finset.sum_le_card_nsmul`, closing with `linarith`.",
     "mathContext": "$4^n = 2^{2n} = \\sum_{k=0}^{2n} \\binom{2n}{k} \\leq (2n+1) \\cdot \\max_k \\binom{2n}{k} = (2n+1) \\cdot \\binom{2n}{n}$. Equivalently: $\\binom{2n}{n} \\geq 4^n/(2n+1)$.",
     "significance": "key",
     "prerequisites": [
@@ -197,12 +197,12 @@
     "id": "ann-chebyshev-bound",
     "proofId": "chebyshev-pnt-bridge-oq-01",
     "range": {
-      "startLine": 186,
-      "endLine": 194
+      "startLine": 152,
+      "endLine": 160
     },
     "type": "insight",
     "title": "Chebyshev's Combined Inequality",
-    "content": "The final synthesis: $4^n \\leq (2n+1) \\cdot (2n)^{\\pi(2n)}$. This combines the binomial lower bound with the product upper bound and yields, after taking logarithms: $\\pi(2n) \\geq (n \\ln 4 - \\ln(2n+1)) / \\ln(2n) \\sim n \\ln 4 / \\ln(2n)$. Currently `sorry`.",
+    "content": "The final synthesis: $4^n \\leq (2n+1) \\cdot (2n)^{\\pi(2n)}$. Proved by chaining the central-binomial lower bound with the prime-counting product bound. Taking logarithms yields $\\pi(2n) \\geq (n \\ln 4 - \\ln(2n+1)) / \\ln(2n) \\sim n \\ln 4 / \\ln(2n)$ — Chebyshev's elementary lower bound on the prime-counting function.",
     "mathContext": "$4^n \\leq (2n+1) \\cdot (2n)^{\\pi(2n)}$ implies $\\pi(2n) \\geq \\frac{n \\ln 4 - \\ln(2n+1)}{\\ln(2n)} \\sim \\frac{\\ln 4}{2} \\cdot \\frac{2n}{\\ln(2n)} \\approx 0.693 \\cdot \\frac{2n}{\\ln(2n)}$.",
     "significance": "key",
     "prerequisites": [
@@ -221,8 +221,8 @@
     "id": "ann-concrete-examples",
     "proofId": "chebyshev-pnt-bridge-oq-01",
     "range": {
-      "startLine": 200,
-      "endLine": 208
+      "startLine": 166,
+      "endLine": 174
     },
     "type": "concept",
     "title": "Concrete Computations via native_decide",

--- a/src/data/proofs/chebyshev-pnt-bridge-oq-01/meta.json
+++ b/src/data/proofs/chebyshev-pnt-bridge-oq-01/meta.json
@@ -57,28 +57,28 @@
       "id": "padic-valuation",
       "title": "p-adic Valuation Infrastructure",
       "startLine": 26,
-      "endLine": 68,
-      "summary": "Establishes the carry-counting framework: Legendre's formula for $v_p(n!)$ (proved via `Nat.Prime.multiplicity_factorial`), the carry bound $\\lfloor 2n/p^i \\rfloor - 2\\lfloor n/p^i \\rfloor \\leq 1$ (proved), vanishing of carries for $p^i > 2n$ (proved), and existence of a truncation point $k \\leq 2n$ with $p^k > 2n$ (proved by induction on $2^{2n} > 2n$)."
+      "endLine": 61,
+      "summary": "Establishes the carry-counting framework (Part I): Legendre's formula for $v_p(n!)$ (proved via `padicValNat_factorial`), the carry bound $\\lfloor 2n/p^i \\rfloor - 2\\lfloor n/p^i \\rfloor \\leq 1$ (proved), vanishing of carries for $p^i > 2n$ (proved), and existence of a truncation point $k \\leq 2n$ with $p^k > 2n$ (proved by induction on $2^{2n} > 2n$)."
     },
     {
       "id": "main-bound",
       "title": "Main Factorization Bound",
-      "startLine": 70,
-      "endLine": 86,
+      "startLine": 63,
+      "endLine": 124,
       "summary": "Proves the main theorem $p^{v_p\\binom{2n}{n}} \\leq 2n$ via Mathlib's `Nat.pow_factorization_choose_le`. Proves the corollary $\\binom{2n}{n} \\leq (2n)^{\\pi(2n)}$ by reconstructing the central binomial from its prime factorization via `Nat.factorization_prod_pow_eq_self`."
     },
     {
       "id": "chebyshev-connection",
       "title": "Chebyshev's Lower Bound on $\\pi(x)$",
-      "startLine": 88,
-      "endLine": 122,
+      "startLine": 126,
+      "endLine": 160,
       "summary": "Proves the central binomial lower bound $(2n+1)\\binom{2n}{n} \\geq 4^n$ using `Nat.sum_range_choose` and `Nat.choose_le_middle`. Combines with the product bound to obtain Chebyshev's inequality $4^n \\leq (2n+1)(2n)^{\\pi(2n)}$."
     },
     {
       "id": "concrete-examples",
       "title": "Concrete Computations",
-      "startLine": 124,
-      "endLine": 138,
+      "startLine": 162,
+      "endLine": 176,
       "summary": "Verifies $\\binom{6}{3} = 20$, $\\binom{10}{5} = 252$, $\\binom{20}{10} = 184756$ via `native_decide`, confirming the factorization bound holds at concrete values."
     }
   ],
@@ -132,7 +132,7 @@
     },
     {
       "name": "chebyshev_lower_via_kummer",
-      "statement": "4 ^ n ≤ (2 * n + 1) * (2 * n) ^ (2 * n).primeCounting'",
+      "statement": "4 ^ n ≤ (2 * n + 1) * (2 * n) ^ Nat.primeCounting (2 * n)",
       "description": "Chebyshev's combined inequality for the prime counting function"
     }
   ],


### PR DESCRIPTION
## Summary

Enrichment/repair pass on `chebyshev-pnt-bridge-oq-01` (Factorization Bound p^{v_p(C(2n,n))} ≤ 2n via Kummer's theorem). The gallery metadata had drifted badly against the current 176-line Lean file (0 sorries, Parts I–IV).

## What changed

**Section line-range realignment** (`meta.json`) — the 5 sections pointed at stale/compressed ranges that stopped at line 138 of 176. Re-anchored to the actual `Part I–IV` banners:
- p-adic Valuation Infrastructure: 26–68 → **26–61** (Part I)
- Main Factorization Bound: 70–86 → **63–124** (Part II)
- Chebyshev's Lower Bound: 88–122 → **126–160** (Part III)
- Concrete Computations: 124–138 → **162–176** (Part IV)

**Annotation re-anchoring** (`annotations.json`) — all 9 sub-overview annotations had drifted upward, overshooting to line 208 (> EOF). Each re-anchored to its real declaration (e.g. Legendre 30–36, carry bound 38–48, main bound 67–73, product bound 75–124, examples 166–174).

**Removed stale `sorry` claims** — 5 annotations falsely stated theorems were "Currently `sorry`". The file has **0 sorries** and `meta.sorries: 0`; every result (Legendre formula, `prime_pow_val_central_binom_le`, `central_binom_le_pow_prime_counting`, `central_binom_lower`, `chebyshev_lower_via_kummer`) is fully proved from Mathlib. Rewrote those descriptions to reflect the actual proofs and cite the real lemmas used.

**Corrected stale notation** — `(2 * n).primeCounting'` → `Nat.primeCounting (2 * n)` in `theorems[3].statement` and an annotation prerequisite, matching the actual Lean (the file was already migrated; `meta.originalContributions` even records this fix).

## Verification

Gallery-data validation (`pnpm build` enrichment + search-index steps) parses all JSON cleanly. All section/annotation ranges now lie within [1, 176] with no overshoot; no `sorry` claims remain in the annotations. Axiom status unchanged (`axiomatized` / badge `axiom`, native_decide → `Lean.ofReduceBool`), which is accurate.