### PR TITLE
audit: erdos-663 — fix reversed monotonicity claim + stale 'axiomatized' prose

### DIFF
--- a/src/data/proofs/erdos-663/meta.json
+++ b/src/data/proofs/erdos-663/meta.json
@@ -31,12 +31,12 @@
     "historicalContext": "Erdős posed this problem in connection with his broader program studying prime factors of products of consecutive integers, a theme running through dozens of his papers from the 1930s onward. The function $q(n,k)$, defined as the least prime not dividing $\\prod_{i=1}^{k}(n+i)$, captures the interplay between the prime number theorem and the arithmetic structure of consecutive integers. The weak bound $q(n,k) < (1+o(1))\\,k\\log n$ follows directly from the prime number theorem: among $k$ consecutive integers, every prime $p \\leq k$ must divide at least one term, and primes up to roughly $k\\log n$ are \"used up\" by the product. Erdős conjectured the much stronger bound $q(n,k) < (1+o(1))\\log n$, removing the factor of $k$ entirely. Terence Tao provided heuristic arguments supporting this conjecture based on probabilistic models of prime divisibility. The problem is closely related to Erdős Problem #457 on small prime divisors of consecutive products, and connects to classical work by Sylvester (1892) and Schur on prime factors in consecutive integer ranges, as well as Ingham's results on prime gaps.",
     "problemStatement": "For positive integers $n$ and $k$, define $q(n,k)$ as the least prime not dividing $(n+1)(n+2)\\cdots(n+k)$. Is it true that $q(n,k) < (1 + o(1)) \\log n$ as $n \\to \\infty$ for each fixed $k$?",
     "text": "For positive integers n and k, let q(n,k) be the least prime not dividing (n+1)(n+2)···(n+k). Erdős conjectured q(n,k) < (1+o(1)) log n.",
-    "proofStrategy": "The formalization axiomatizes $q(n,k)$ via three properties: primality, non-divisibility of the consecutive product, and minimality among primes with this property. The main conjecture is stated in $\\varepsilon$-$N$ form: for all $\\varepsilon > 0$ there exists $N_0$ such that $q(n,k) < (1+\\varepsilon)\\log n$ for $n \\geq N_0$. The weak bound is similarly stated with the extra factor of $k$. The formalization proves that the conjecture and weak bound coincide for $k=1$ (by a simple algebraic identity), and that the main conjecture implies the weak bound (since $\\log n \\leq k\\log n$ for $k \\geq 1$). Structural properties of consecutive products — positivity, small prime divisibility, and monotonicity of $q$ in $k$ — are established via a mix of direct proofs and axioms for deeper results.",
+    "proofStrategy": "The formalization defines $q(n,k)$ concretely via `Nat.find` (using the infinitude of primes) and proves its three characterizing properties: primality, non-divisibility of the consecutive product, and minimality among primes with this property. The main conjecture is stated in $\\varepsilon$-$N$ form: for all $\\varepsilon > 0$ there exists $N_0$ such that $q(n,k) < (1+\\varepsilon)\\log n$ for $n \\geq N_0$. The weak bound is similarly stated with the extra factor of $k$. The formalization proves that the conjecture and weak bound coincide for $k=1$ (by a simple algebraic identity), and that the main conjecture implies the weak bound (since $\\log n \\leq k\\log n$ for $k \\geq 1$). Structural properties of consecutive products — positivity, small prime divisibility ($p \\leq k \\Rightarrow p \\mid$ product), the lower bound $q(n,k) > k$, and non-decreasing monotonicity of $q$ in $k$ — are all established by direct proof with 0 axioms and 0 sorries.",
     "keyInsights": [
       "**Pigeonhole for small primes**: Every prime $p \\leq k$ must divide at least one of $k$ consecutive integers, so $q(n,k) > k$ — the \"missing\" prime must be larger than $k$",
       "**PNT gives the weak bound**: The prime number theorem implies there are roughly $k\\log n / \\log(k\\log n)$ primes up to $k\\log n$, and $k$ consecutive integers have enough residue classes to absorb them all, yielding $q(n,k) < (1+o(1))\\,k\\log n$",
       "**Removing the $k$ factor is the crux**: The conjecture asserts that the bound $q(n,k) < (1+o(1))\\log n$ holds uniformly for all fixed $k$, meaning additional consecutive terms contribute enough prime coverage to eliminate the linear dependence on $k$",
-      "**Monotonicity in $k$**: Since $(n+1)\\cdots(n+k+1) = (n+1)\\cdots(n+k) \\cdot (n+k+1)$, enlarging the product can only introduce new prime divisors, so $q(n,k)$ is non-increasing in $k$",
+      "**Monotonicity in $k$**: Since $(n+1)\\cdots(n+k+1) = (n+1)\\cdots(n+k) \\cdot (n+k+1)$, enlarging the product can only introduce new prime divisors, so the smallest *missing* prime $q(n,k)$ is non-decreasing in $k$ (proved as `q_mono_k`)",
       "**Connection to sieve methods**: The problem is intimately related to sieve-theoretic questions about smooth numbers and the distribution of primes in short intervals, bridging analytic and combinatorial number theory"
     ],
     "prerequisites": [
@@ -58,8 +58,8 @@
       "title": "Consecutive Products and Smallest Missing Prime",
       "startLine": 26,
       "endLine": 45,
-      "summary": "Defines $\\mathrm{consecutiveProduct}(n,k) = \\prod_{i=0}^{k-1}(n+i+1)$ as a Finset product, and axiomatizes $q(n,k)$ via three properties: primality, non-divisibility of $(n+1)\\cdots(n+k)$, and minimality among such primes.",
-      "mathContext": "Defines $\\mathrm{consecutiveProduct}(n,k) = \\prod_{i=0}^{k-1}(n+i+1)$ as a Finset product, and axiomatizes $q(n,k)$ via three properties: primality, non-divisibility of $(n+1)\\cdots(n+k)$, and minimality among such primes."
+      "summary": "Defines $\\mathrm{consecutiveProduct}(n,k) = \\prod_{i=0}^{k-1}(n+i+1)$ as a Finset product, defines $q(n,k)$ concretely via `Nat.find`, and proves its three characterizing properties: primality, non-divisibility of $(n+1)\\cdots(n+k)$, and minimality among such primes.",
+      "mathContext": "Defines $\\mathrm{consecutiveProduct}(n,k) = \\prod_{i=0}^{k-1}(n+i+1)$ as a Finset product, defines $q(n,k)$ concretely via `Nat.find`, and proves its three characterizing properties: primality, non-divisibility of $(n+1)\\cdots(n+k)$, and minimality among such primes."
     },
     {
       "id": "conjecture",
@@ -98,16 +98,16 @@
       "title": "Small Prime Divisibility and Lower Bound",
       "startLine": 100,
       "endLine": 111,
-      "summary": "Axiomatizes that every prime $p \\leq k$ divides $(n+1)\\cdots(n+k)$ (pigeonhole on residues), and that $q(n,k) > k$ for $k > 1$ — the smallest missing prime is always larger than the product length.",
-      "mathContext": "Axiomatized: Axiomatizes that every prime $p \\leq k$ divides $(n+1)\\cdots(n+k)$ (pigeonhole on residues), and that $q(n,k) > k$ for $k > 1$ — the smallest missing prime is always larger than the product length."
+      "summary": "Proves that every prime $p \\leq k$ divides $(n+1)\\cdots(n+k)$ (`small_prime_divides_product`, by an explicit residue witness), and that $q(n,k) > k$ for $k > 1$ (`q_gt_k`) — the smallest missing prime is always larger than the product length.",
+      "mathContext": "Proves that every prime $p \\leq k$ divides $(n+1)\\cdots(n+k)$ (`small_prime_divides_product`, by an explicit residue witness), and that $q(n,k) > k$ for $k > 1$ (`q_gt_k`) — the smallest missing prime is always larger than the product length."
     },
     {
       "id": "monotonicity",
       "title": "Monotonicity and Main Implication",
       "startLine": 112,
       "endLine": 127,
-      "summary": "Axiomatizes non-increasing monotonicity $q(n,k_2) \\leq q(n,k_1)$ for $k_1 \\leq k_2$, and proves that the main conjecture implies the weak bound via the inequality $(1+\\varepsilon)\\log n \\leq (1+\\varepsilon)\\,k\\log n$ using `mul_assoc` and `nlinarith`.",
-      "mathContext": "Axiomatizes non-increasing monotonicity $q(n,k_2) \\leq q(n,k_1)$ for $k_1 \\leq k_2$, and proves that the main conjecture implies the weak bound via the inequality $(1+\\varepsilon)\\log n \\leq (1+\\varepsilon)\\,k\\log n$ using `mul_assoc` and `nlinarith`."
+      "summary": "Proves non-decreasing monotonicity $q(n,k_1) \\leq q(n,k_2)$ for $k_1 \\leq k_2$ (`q_mono_k`; a longer product has more prime divisors, so the smallest missing prime can only grow), and proves that the main conjecture implies the weak bound via the inequality $(1+\\varepsilon)\\log n \\leq (1+\\varepsilon)\\,k\\log n$ using `mul_assoc` and `mul_le_mul_of_nonneg_left`.",
+      "mathContext": "Proves non-decreasing monotonicity $q(n,k_1) \\leq q(n,k_2)$ for $k_1 \\leq k_2$ (`q_mono_k`; a longer product has more prime divisors, so the smallest missing prime can only grow), and proves that the main conjecture implies the weak bound via the inequality $(1+\\varepsilon)\\log n \\leq (1+\\varepsilon)\\,k\\log n$ using `mul_assoc` and `mul_le_mul_of_nonneg_left`."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Integrity Issue

**Proof**: erdos-663 (Smallest Prime Not Dividing Consecutive Products)
**Problem**: The Lean file was upgraded to a fully-proved version (0 axioms, 0 sorries), but the gallery prose was left stale — and one claim is mathematically **reversed**.

## Evidence

**Reversed monotonicity (the substantive bug).** The proved theorem is:
```lean
theorem q_mono_k (n k₁ k₂ : ℕ) (hk₁ : 0 < k₁) (hle : k₁ ≤ k₂) :
    smallestMissingPrime n k₁ ≤ smallestMissingPrime n k₂
```
i.e. q is **non-decreasing** in k. The source even comments: *"the original axiom had the wrong direction (≤ instead of ≥)."*

But the meta claimed the opposite:
- keyInsight #4: *"q(n,k) is **non-increasing** in k"*
- monotonicity section: *"Axiomatizes **non-increasing** monotonicity q(n,k₂) ≤ q(n,k₁) for k₁ ≤ k₂"*

**Stale "axiomatized" prose.** `smallestMissingPrime` is defined via `Nat.find` and its properties are proved (`smallestMissingPrime_prime/_not_dvd/_least`, `small_prime_divides_product`, `q_gt_k`, `q_mono_k`) — 0 axioms. Yet `proofStrategy`, the definitions section, the small-primes section, and the monotonicity section all said "axiomatizes"/"Axiomatized". The `assumptions` field already correctly states "All axioms eliminated."

## Fix

- Correct the monotonicity direction in keyInsight #4 and the monotonicity section to **non-decreasing** (`q(n,k₁) ≤ q(n,k₂)`), citing `q_mono_k`.
- Reword "axiomatizes/Axiomatized" → "defines/proves" across `proofStrategy` and the definitions / small-primes / monotonicity sections to match the 0-axiom reality.

No count changes: 11 theorems, 5 defs, 0 axioms, 0 sorries; `ErdosProblem663` remains an unproved def (open conjecture, badge `wip`). All referenced declaration names verified present.

---
Discovered during gallery integrity audit (reserve mode; erdos-663 was the oldest uncontested target).
🤖 Generated with [Claude Code](https://claude.com/claude-code)