### PR TITLE
Enrich descartes-rule-of-signs-oq-01-oq-02: fix section & annotation line-range drift

### DIFF
--- a/src/data/proofs/descartes-rule-of-signs-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/descartes-rule-of-signs-oq-01-oq-02/annotations.json
@@ -3,8 +3,8 @@
     "id": "ann-dr-oq01-oq02-header",
     "proofId": "descartes-rule-of-signs-oq-01-oq-02",
     "range": {
-      "startLine": 1,
-      "endLine": 57
+      "startLine": 2,
+      "endLine": 53
     },
     "type": "insight",
     "title": "Header: Minimal Infrastructure for Descartes Parity — Both Ingredients Needed",
@@ -28,8 +28,8 @@
     "id": "ann-parity-arithmetic",
     "proofId": "descartes-rule-of-signs-oq-01-oq-02",
     "range": {
-      "startLine": 61,
-      "endLine": 86
+      "startLine": 57,
+      "endLine": 73
     },
     "type": "concept",
     "title": "Parity Arithmetic Scaffolding",
@@ -52,8 +52,8 @@
     "id": "ann-root-decomposition",
     "proofId": "descartes-rule-of-signs-oq-01-oq-02",
     "range": {
-      "startLine": 100,
-      "endLine": 113
+      "startLine": 88,
+      "endLine": 97
     },
     "type": "insight",
     "title": "Root Count Decomposition with Conjugate Pair Parity",
@@ -76,8 +76,8 @@
     "id": "ann-gap-analysis",
     "proofId": "descartes-rule-of-signs-oq-01-oq-02",
     "range": {
-      "startLine": 119,
-      "endLine": 148
+      "startLine": 104,
+      "endLine": 133
     },
     "type": "insight",
     "title": "The Gap: Why Conjugate Pairing Alone Is Insufficient",
@@ -100,8 +100,8 @@
     "id": "ann-parity-chain",
     "proofId": "descartes-rule-of-signs-oq-01-oq-02",
     "range": {
-      "startLine": 150,
-      "endLine": 163
+      "startLine": 135,
+      "endLine": 140
     },
     "type": "insight",
     "title": "Parity Chain Theorem: Assembling All Four Ingredients",
@@ -123,8 +123,8 @@
     "id": "ann-hard-axiom",
     "proofId": "descartes-rule-of-signs-oq-01-oq-02",
     "range": {
-      "startLine": 169,
-      "endLine": 186
+      "startLine": 147,
+      "endLine": 164
     },
     "type": "insight",
     "title": "Sign Variation Parity Under Positive Root (Axiomatized)",
@@ -147,8 +147,8 @@
     "id": "ann-linear-parity",
     "proofId": "descartes-rule-of-signs-oq-01-oq-02",
     "range": {
-      "startLine": 192,
-      "endLine": 205
+      "startLine": 170,
+      "endLine": 183
     },
     "type": "concept",
     "title": "Linear Parity: Base Case with pos ≤ sv ≤ 1",
@@ -171,8 +171,8 @@
     "id": "ann-quadratic-parity",
     "proofId": "descartes-rule-of-signs-oq-01-oq-02",
     "range": {
-      "startLine": 211,
-      "endLine": 223
+      "startLine": 189,
+      "endLine": 200
     },
     "type": "concept",
     "title": "Quadratic Parity: interval_cases Decides All 9 Combinations",
@@ -197,8 +197,8 @@
     "id": "ann-summary-assessment",
     "proofId": "descartes-rule-of-signs-oq-01-oq-02",
     "range": {
-      "startLine": 228,
-      "endLine": 270
+      "startLine": 207,
+      "endLine": 249
     },
     "type": "insight",
     "title": "Summary: Both Ingredients Required, Neither Alone Sufficient",

--- a/src/data/proofs/descartes-rule-of-signs-oq-01-oq-02/meta.json
+++ b/src/data/proofs/descartes-rule-of-signs-oq-01-oq-02/meta.json
@@ -47,7 +47,7 @@
     ],
     "dateAdded": "2026-03-30",
     "axiomCount": 1,
-    "lineCount": 317,
+    "lineCount": 296,
     "prerequisites": [
       "Descartes' Rule of Signs (upper bound from Mathlib)",
       "Complex conjugate root theorem",
@@ -81,56 +81,56 @@
     {
       "id": "parity-arithmetic",
       "title": "Parity Arithmetic Framework",
-      "startLine": 50,
-      "endLine": 80,
+      "startLine": 46,
+      "endLine": 68,
       "summary": "Lemmas about even/odd arithmetic: even + even, parity additivity, same parity from even difference.",
       "mathContext": "$(a + b) \\text{ even} \\iff a,b \\text{ same parity}$"
     },
     {
       "id": "root-decomposition",
       "title": "Root Count Decomposition",
-      "startLine": 82,
-      "endLine": 104,
+      "startLine": 70,
+      "endLine": 90,
       "summary": "Decomposes total root count into positive + negative + non-real, proving parity preservation from conjugate pairing.",
       "mathContext": "$\\deg p = |\\text{pos}| + |\\text{neg}| + |\\text{nonreal}|$, $|\\text{nonreal}|$ even"
     },
     {
       "id": "gap-analysis",
       "title": "Why Conjugate Pairing is Insufficient",
-      "startLine": 106,
-      "endLine": 148,
+      "startLine": 92,
+      "endLine": 133,
       "summary": "Identifies the gap: conjugate pairing gives degree ≡ real_roots (mod 2), but parity needs signVariations ≡ positive_roots (mod 2). The parity_chain theorem shows what additional ingredients close the gap.",
       "mathContext": "Need: $\\text{sv}(p) \\equiv |\\text{pos roots}| \\pmod{2}$"
     },
     {
       "id": "key-axiom",
       "title": "Sign Variation Under Root Extraction",
-      "startLine": 150,
-      "endLine": 175,
+      "startLine": 135,
+      "endLine": 153,
       "summary": "The axiomatized hard lemma: when p = (x-r)q with r > 0, sign variations of p and q have different parity. This is the irreducible difficulty.",
       "mathContext": "$p = (x-r)q,\\, r > 0 \\Rightarrow \\text{sv}(p) + \\text{sv}(q) \\text{ odd}$"
     },
     {
       "id": "small-cases",
       "title": "Linear and Quadratic Cases",
-      "startLine": 177,
-      "endLine": 223,
+      "startLine": 155,
+      "endLine": 200,
       "summary": "Complete parity proofs for degree 1 and 2 polynomials by case analysis.",
       "mathContext": "Parity holds trivially for $\\deg \\le 2$"
     },
     {
       "id": "parity-bookkeeping",
       "title": "General Parity Bookkeeping",
-      "startLine": 225,
-      "endLine": 269,
+      "startLine": 204,
+      "endLine": 248,
       "summary": "Degree-uniform arithmetic core: parity_witness (pos ≤ sv ∧ Even(sv+pos) ⇒ ∃ k, pos+2k=sv) plus the cubic/quartic corollaries and the composite descartes_parity_witness that bundles parity_chain with parity_witness.",
       "mathContext": "$\\text{pos} \\le \\text{sv} \\land 2 \\mid (\\text{sv}+\\text{pos}) \\;\\Rightarrow\\; \\exists k,\\ \\text{pos} + 2k = \\text{sv}$"
     },
     {
       "id": "assessment",
       "title": "Summary Assessment",
-      "startLine": 271,
-      "endLine": 317,
+      "startLine": 250,
+      "endLine": 296,
       "summary": "Final assessment: minimal infrastructure = conjugate pairing + sign variation parity under root extraction. Neither alone suffices.",
       "mathContext": "Minimal: conjugate pairs + sv parity under root factoring"
     }
@@ -170,7 +170,7 @@
     ],
     "opens": [],
     "namespace": "DescartesRuleOfSignsOQ01OQ02",
-    "lineCount": 317,
+    "lineCount": 296,
     "axiomCount": 1,
     "theoremCount": 13,
     "definitionCount": 0,


### PR DESCRIPTION
## Enrichment pass for descartes-rule-of-signs-oq-01-oq-02

**Work source:** section/annotation line-range drift (genuine at-floor correctness fix, not accretion).

The v4.31 toolchain flip (#39062) trimmed `DescartesRuleOfSignsOQ01OQ02.lean` from **317 → 296** lines. Stale gallery metadata:
- `meta.lineCount` / `leanFile.lineCount` still read 317
- The final section (`assessment`) `endLine` overshot EOF by 21
- Interior section/annotation ranges drifted (up to −23)

### Fix
- Re-anchored all 7 section boundaries + 10 annotation ranges via a content-based difflib old→new map against the pre-flip blob (`515ea3d34c`)
- `lineCount` 317 → 296
- Preserved the entry's existing sparse section layout (pre-existing header gaps)

### Verification
- Both JSON files well-formed; all ranges within 1..296, no inversions, no EOF overshoot
- Axiom cross-check: the single real axiom `sign_variation_parity_under_positive_root` matches `meta.axiomCount = 1` (status `axiomatized`); the annotation's "1 axiom" note is consistent

No prose/content changed — pure line-anchor correctness pass.