### PR TITLE
Research: erdos-751 — replace 3 definition-axioms with Mathlib defs (axiom 5→2)

### DIFF
--- a/proofs/Proofs/Erdos751Problem.lean
+++ b/proofs/Proofs/Erdos751Problem.lean
@@ -26,6 +26,8 @@ References:
 
 import Mathlib.Combinatorics.SimpleGraph.Basic
 import Mathlib.Combinatorics.SimpleGraph.Connectivity.WalkCounting
+import Mathlib.Combinatorics.SimpleGraph.Coloring.Vertex
+import Mathlib.Combinatorics.SimpleGraph.Girth
 import Mathlib.Data.Finset.Basic
 import Mathlib.Data.Nat.Basic
 
@@ -59,23 +61,29 @@ noncomputable def maxDegree (G : SimpleGraph V) [DecidableRel G.Adj] : ℕ :=
 **Chromatic Number:**
 The chromatic number χ(G) is the minimum number of colors needed to properly
 color the vertices of G (no two adjacent vertices have the same color).
--/
-axiom chromaticNumber (G : SimpleGraph V) [DecidableRel G.Adj] : ℕ
+
+Defined from Mathlib's `SimpleGraph.chromaticNumber : ℕ∞` via `.toNat`.
+(Formerly an axiom.) -/
+noncomputable def chromaticNumber (G : SimpleGraph V) [DecidableRel G.Adj] : ℕ :=
+  (SimpleGraph.chromaticNumber G).toNat
 
 /--
 **Girth:**
 The girth of G is the length of the shortest cycle in G.
-If G is acyclic (a forest), the girth is defined as ∞ (we use 0).
-Axiomatized since cycle enumeration infrastructure is required.
--/
-axiom girth (G : SimpleGraph V) [DecidableRel G.Adj] : ℕ
+If G is acyclic (a forest), the girth is 0 (Mathlib's `girth = egirth.toNat`,
+and `egirth` of an acyclic graph is `⊤`, whose `toNat` is `0`).
+
+Defined from Mathlib's `SimpleGraph.girth`. (Formerly an axiom.) -/
+noncomputable def girth (G : SimpleGraph V) [DecidableRel G.Adj] : ℕ :=
+  SimpleGraph.girth G
 
 /--
 **Cycle Lengths:**
-The set of all cycle lengths present in G.
-Axiomatized since walk/cycle infrastructure is required.
--/
-axiom cycleLengths (G : SimpleGraph V) [DecidableRel G.Adj] : Set ℕ
+The set of all cycle lengths present in G: lengths of closed cycle walks.
+
+Defined directly from Mathlib's `Walk`/`IsCycle`. (Formerly an axiom.) -/
+def cycleLengths (G : SimpleGraph V) [DecidableRel G.Adj] : Set ℕ :=
+  {n | ∃ (v : V) (c : G.Walk v v), c.IsCycle ∧ c.length = n}
 
 /--
 **Cycle Length Gap:**

--- a/src/data/proofs/erdos-751/meta.json
+++ b/src/data/proofs/erdos-751/meta.json
@@ -51,9 +51,9 @@
       "erdos_751_with_girth: girth doesn't help",
       "erdos_751_summary: combined results"
     ],
-    "axiomCount": 5,
+    "axiomCount": 2,
     "lineCount": 235,
-    "assumptions": "5 axioms: chromaticNumber, girth, cycleLengths, four_chromatic_minDeg, bondy_vince_theorem. 2 sorries.",
+    "assumptions": "2 axioms: four_chromatic_minDeg (χ(G)=4 ⟹ minDegree ≥ 3) and bondy_vince_theorem (Bondy–Vince 1998: minDegree ≥ 3 ⟹ two cycle lengths differ by ≤ 2) — both deep graph-theory results. 2 sorries (minCycleLengthGap definition and its ≤2 bound). The chromaticNumber, girth, and cycleLengths definitions were previously axiomatized; they are now defined from Mathlib (SimpleGraph.chromaticNumber.toNat, SimpleGraph.girth, and the set of cycle-walk lengths respectively).",
     "theoremCount": 6,
     "definitionCount": 3
   },
@@ -142,7 +142,7 @@
     ],
     "namespace": "Erdos751",
     "lineCount": 235,
-    "axiomCount": 5,
+    "axiomCount": 2,
     "theoremCount": 6,
     "definitionCount": 3,
     "path": "Proofs/Erdos751Problem.lean",

--- a/src/data/research/problems/erdos-751-incomplete-01.json
+++ b/src/data/research/problems/erdos-751-incomplete-01.json
@@ -29,9 +29,13 @@
     }
   },
   "knowledge": {
-    "progressSummary": "AVAILABLE: parent formalization has 2 open sorry statement(s) to complete.",
-    "builtItems": [],
-    "insights": [],
+    "progressSummary": "AXIOM ELIMINATION (researcher-1, 2026-07-20): replaced 3 definition-axioms (chromaticNumber, girth, cycleLengths) with real Mathlib-backed definitions, axiom count 5→2. Remaining 2 axioms are deep: four_chromatic_minDeg and bondy_vince_theorem (Bondy–Vince 1998). 2 sorries remain (minCycleLengthGap def + its bound).",
+    "builtItems": [
+      "Erdos751Problem.lean: replaced 3 def-axioms (chromaticNumber, girth, cycleLengths) with Mathlib-backed real definitions; axiom 5→2. Host-verified v4.31.0 EXIT=0."
+    ],
+    "insights": [
+      "The chromaticNumber/girth/cycleLengths in Erdos751Problem.lean were DEFINITION axioms (opaque functions) that Mathlib actually provides: SimpleGraph.chromaticNumber (ℕ∞, use .toNat), SimpleGraph.girth (ℕ, via egirth.toNat), and cycleLengths as {n | ∃ v (c:G.Walk v v), c.IsCycle ∧ c.length=n}. All downstream usage is abstract (passed to the remaining axioms), so replacing the axioms with real defs compiles cleanly."
+    ],
     "mathlibGaps": [],
     "nextSteps": []
   },


### PR DESCRIPTION
## Summary
Axiom-elimination session on **erdos-751** (cycle-length gaps in 4-chromatic graphs). The `chromaticNumber`, `girth`, and `cycleLengths` "definitions" were axiomatized as opaque functions even though Mathlib provides all three. Replacing each `axiom` with a real definition drops the file's axiom count **5 → 2**.

## Change
- `chromaticNumber G := (SimpleGraph.chromaticNumber G).toNat`  (`ℕ∞ → ℕ`)
- `girth G := SimpleGraph.girth G`  (already `ℕ`, `= egirth.toNat`; acyclic ⇒ `⊤.toNat = 0`, matching the file's stated convention)
- `cycleLengths G := {n | ∃ v (c : G.Walk v v), c.IsCycle ∧ c.length = n}`

Added imports `SimpleGraph.Coloring.Vertex` and `SimpleGraph.Girth`. Every downstream use of these three is abstract (they feed the remaining axioms/theorems by value only), so the whole file recompiles with no other change.

## Findings
- The remaining 2 axioms are genuinely deep graph theory: `four_chromatic_minDeg` (χ(G)=4 ⟹ minDegree ≥ 3) and `bondy_vince_theorem` (Bondy–Vince 1998: minDegree ≥ 3 ⟹ two cycle lengths differ by ≤ 2).
- The 2 sorries are definition-level (`minCycleLengthGap` and its ≤ 2 bound).

## Status
**Outcome**: progress (3 axioms eliminated — opaque def-axioms replaced by real Mathlib-backed definitions)
**Verification**: host-verified on v4.31.0 (`lake env lean`, EXIT=0, no errors)
**Next Steps**: `minCycleLengthGap` needs a concrete definition; the two theorem-axioms are literature results.

🤖 Generated by researcher-1