### PR TITLE
Enrich erdos-1007-oq-05: fix section/annotation drift + correct proof-tactic prose

### DIFF
--- a/src/data/proofs/erdos-1007-oq-05/annotations.json
+++ b/src/data/proofs/erdos-1007-oq-05/annotations.json
@@ -27,19 +27,19 @@
     "id": "ann-oq05-02",
     "proofId": "erdos-1007-oq-05",
     "range": {
-      "startLine": 52,
-      "endLine": 93
+      "startLine": 54,
+      "endLine": 78
     },
     "type": "concept",
     "title": "Key Calculation: Scaled Basis Vectors Have Unit Pairwise Distance",
-    "content": "The private lemma scaled_basis_sq_dist is the heart of the construction. Given two distinct indices i ≠ j in Fin n, the sum Σ_k ((δ_{ik}/√2) − (δ_{jk}/√2))² = 1. The proof proceeds in three steps: (1) all terms except k=i and k=j are zero; (2) the terms at k=i and k=j each contribute (1/√2)² = 1/2; (3) the total is 1/2 + 1/2 = 1. The proof uses Finset.add_sum_erase to extract the two non-zero terms, then simplification with simp and linarith for the arithmetic. The positivity of √2 is established via Real.sqrt_pos_of_pos.",
+    "content": "The private lemma scaled_basis_sq_dist is the heart of the construction. Given two distinct indices i ≠ j in Fin n, the sum Σ_k ((δ_{ik}/√2) − (δ_{jk}/√2))² = 1. The proof proceeds in three steps: (1) a pointwise rewrite (by_cases on whether k = i and k = j) turns each squared difference into the indicator sum (if i=k then 1/2) + (if j=k then 1/2), using (1/√2)² = 1/2; (2) Finset.sum_add_distrib splits the sum and two Finset.sum_ite_eq rewrites collapse each indicator sum to its single 1/2 term; (3) norm_num finishes 1/2 + 1/2 = 1. The positivity of √2 (used for the squaring step) is established via Real.sqrt_pos_of_pos.",
     "mathContext": "$\\sum_{k=0}^{n-1} \\left(\\frac{\\delta_{ik}}{\\sqrt{2}} - \\frac{\\delta_{jk}}{\\sqrt{2}}\\right)^2 = \\frac{1}{2} + \\frac{1}{2} = 1 \\text{ for } i \\neq j$",
     "significance": "key",
     "relatedConcepts": [
       "Euclidean distance",
       "standard basis vectors",
-      "Finset.add_sum_erase",
-      "linarith tactic"
+      "Finset.sum_ite_eq",
+      "norm_num tactic"
     ],
     "prerequisites": [
       "Finset.sum",
@@ -53,8 +53,8 @@
     "id": "ann-oq05-03",
     "proofId": "erdos-1007-oq-05",
     "range": {
-      "startLine": 94,
-      "endLine": 110
+      "startLine": 80,
+      "endLine": 96
     },
     "type": "insight",
     "title": "Main Theorem: Scaled Basis Construction Proves Unit Embedding Existence",
@@ -78,8 +78,8 @@
     "id": "ann-oq05-04",
     "proofId": "erdos-1007-oq-05",
     "range": {
-      "startLine": 112,
-      "endLine": 120
+      "startLine": 98,
+      "endLine": 106
     },
     "type": "concept",
     "title": "Corollary: Complete Bipartite Graphs Always Embed as Unit Distances",
@@ -103,8 +103,8 @@
     "id": "ann-oq05-05",
     "proofId": "erdos-1007-oq-05",
     "range": {
-      "startLine": 122,
-      "endLine": 141
+      "startLine": 108,
+      "endLine": 125
     },
     "type": "concept",
     "title": "Deep Remaining Axioms: Literature Classification",

--- a/src/data/proofs/erdos-1007-oq-05/meta.json
+++ b/src/data/proofs/erdos-1007-oq-05/meta.json
@@ -67,38 +67,38 @@
       "id": "header-imports",
       "title": "Module Header and Imports",
       "startLine": 1,
-      "endLine": 51,
-      "summary": "Module header with imports, docstring, and namespace setup."
+      "endLine": 53,
+      "summary": "Module header with imports, the axiom-audit docstring, namespace setup, and the section banner for proving hasUnitEmbedding_exists."
     },
     {
       "id": "helper-lemma",
       "title": "Helper Lemma: Squared Distance Calculation",
-      "startLine": 52,
-      "endLine": 93,
-      "summary": "Private lemma scaled_basis_sq_dist proves that scaled standard basis vectors at distinct indices i ≠ j in Fin n are at squared Euclidean distance exactly 1. Uses Finset.add_sum_erase to extract the two non-zero summands.",
+      "startLine": 54,
+      "endLine": 78,
+      "summary": "Private lemma scaled_basis_sq_dist proves that scaled standard basis vectors at distinct indices i ≠ j in Fin n are at squared Euclidean distance exactly 1. Rewrites each summand pointwise (by_cases on the two Kronecker deltas) into 1/2 indicators, then collapses the sum via Finset.sum_add_distrib and Finset.sum_ite_eq, closing with norm_num.",
       "mathContext": "$\\sum_{k} \\left(\\frac{\\delta_{ik}}{\\sqrt{2}} - \\frac{\\delta_{jk}}{\\sqrt{2}}\\right)^2 = \\frac{1}{2} + \\frac{1}{2} = 1$ for $i \\neq j$"
     },
     {
       "id": "main-theorem",
       "title": "Main Theorem: Unit Embedding via Scaled Basis Vectors",
-      "startLine": 94,
-      "endLine": 110,
+      "startLine": 80,
+      "endLine": 96,
       "summary": "Theorem hasUnitEmbedding_exists_irr: every finite graph with irreflexive adjacency admits a unit distance embedding in ℝ^|V|. Constructs the embedding using Fintype.equivFin and the scaled basis, applying the helper lemma and Real.sqrt_one.",
       "mathContext": "$f(v)_k = \\delta_{\\varphi(v),k} / \\sqrt{2}$; irreflexivity ensures $u \\neq v$, so $\\varphi(u) \\neq \\varphi(v)$ and the helper applies"
     },
     {
       "id": "bipartite-corollary",
       "title": "Corollary: Complete Bipartite Graphs Have Unit Embeddings",
-      "startLine": 112,
-      "endLine": 120,
+      "startLine": 98,
+      "endLine": 106,
       "summary": "Proves completeBipartiteAdj is irreflexive (by cases on Fin m ⊕ Fin n), then applies the main theorem to conclude K_{m,n} always has a unit distance embedding of some dimension.",
       "mathContext": "$\\neg\\,\\text{completeBipartiteAdj}\\, v\\, v$ for all $v \\in \\text{Fin}\\, m \\oplus \\text{Fin}\\, n \\Rightarrow \\exists d,\\; \\text{hasUnitEmbedding}(K_{m,n}, d)$"
     },
     {
       "id": "axiom-summary",
       "title": "Remaining Deep Axioms: Literature Classification",
-      "startLine": 122,
-      "endLine": 141,
+      "startLine": 108,
+      "endLine": 127,
       "summary": "Documents the three remaining axioms: min_edges_dimension_4 (House 2013: dim-4 graphs need ≥9 edges), k33_unique_minimum (K_{3,3} is the unique minimizer), and min_edges_dimension_5 (Chaffee-Noble 2016: dim-5 graphs need ≥15 edges). Each requires geometric rigidity analysis beyond current Lean formalization infrastructure.",
       "mathContext": "$\\min\\{|E(G)| : \\dim(G) = 4\\} = 9$, uniquely $K_{3,3}$; $\\min\\{|E(G)| : \\dim(G) = 5\\} = 15$"
     }


### PR DESCRIPTION
## Summary

Drift-repair/enrichment pass on `erdos-1007-oq-05` (Axiom Elimination for Graph Dimension). The Lean file is 127 lines, but the gallery sections and annotations pointed at ranges extending to line 141 — drifted ~14 lines and overshooting EOF.

## What changed

**Section & annotation re-anchoring** — realigned all 5 sections and all 4 sub-header annotations to their real declarations:
- Module Header: 1–51 → **1–53**
- Helper Lemma `scaled_basis_sq_dist`: 52–93 → **54–78**
- Main Theorem `hasUnitEmbedding_exists_irr`: 94–110 → **80–96**
- Bipartite Corollary: 112–120 → **98–106**
- Remaining Deep Axioms summary: 122–141 → **108–127**

**Corrected proof-tactic prose** — the description of `scaled_basis_sq_dist` claimed it "uses `Finset.add_sum_erase` … `simp` and `linarith`." The actual proof does a pointwise `by_cases` rewrite into 1/2 indicators, then `Finset.sum_add_distrib` + two `Finset.sum_ite_eq` rewrites, closing with `norm_num`. Fixed in both the section summary and the annotation content, and swapped the stale `Finset.add_sum_erase`/`linarith` entries in `relatedConcepts` for `Finset.sum_ite_eq`/`norm_num`.

## Verification

JSON validated; all section/annotation ranges now lie within [1, 127] with no overshoot. Axiom status unchanged (`axiomatized`, badge `axiom`, 4 axioms: 1 proved here + 3 deep literature results), which the header docstring and prose accurately reflect.