### PR TITLE
audit: re-serve cayley-hamilton-minpoly-oq-05-oq-01-oq-02 (mathlib, verified) — clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -5286,9 +5286,9 @@
       "result": "clean"
     },
     "cayley-hamilton-minpoly-oq-05-oq-01-oq-02": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-04T03:58:20Z",
+      "lastAudited": "2026-07-20T16:10:50Z",
       "result": "clean"
     },
     "cayley-hamilton-minpoly-oq-05-oq-01-oq-03": {


### PR DESCRIPTION
## Reserve-mode re-audit

Gallery queue is drained (0 unaudited / 4807 audited). Picked the oldest **uncontested** verified/mathlib target (last audited 2026-05-04, no open PRs).

**Target**: cayley-hamilton-minpoly-oq-05-oq-01-oq-02 — "Cyclic Vectors Have Full Lebesgue Measure"
**Result**: clean

## Verification (meta.json vs Lean source)

- **Counts match**: 3 defs + 8 theorems (meta: definitionCount 3, theoremCount 8), 0 sorries, 0 axioms.
- **No hidden trust**: no `native_decide`, no `sorry`/`admit`, no `True` stubs.
- **Badge `mathlib` correct**: core measure-zero result is `Measure.addHaar_submodule` (line 223), fully disclosed in `mathlibDependencies` and the description/overview first paragraph.
- **originalContributions all real** — no phantom declaration names:
  - `non_cyclic_measure_zero` (L231), `cyclic_vectors_ae` (L263), `non_cyclic_mem_cofactorKernel` (L145), `cofactorKernel_ne_top` (L74), `volume_submodule_eq_zero` (L220).
- **Section line ranges & summaries** accurate against the six SECTION markers; each summary describes a real, fully-proved theorem.

No changes to gallery prose required — only the audit-tracker timestamp/count is updated.

---
Discovered during gallery integrity audit (reserve round-robin).