### PR TITLE
Enrich erdos-890: re-anchor all sections & annotations to real declarations

### DIFF
--- a/src/data/proofs/erdos-890/annotations.json
+++ b/src/data/proofs/erdos-890/annotations.json
@@ -4,7 +4,7 @@
     "proofId": "erdos-890",
     "range": {
       "startLine": 30,
-      "endLine": 41
+      "endLine": 36
     },
     "type": "concept",
     "title": "Imports and Namespace Setup",
@@ -26,8 +26,8 @@
     "id": "ann-890-cumulative-omega",
     "proofId": "erdos-890",
     "range": {
-      "startLine": 49,
-      "endLine": 50
+      "startLine": 40,
+      "endLine": 45
     },
     "type": "definition",
     "title": "Cumulative Omega S_k(n)",
@@ -50,8 +50,8 @@
     "id": "ann-890-pi",
     "proofId": "erdos-890",
     "range": {
-      "startLine": 56,
-      "endLine": 56
+      "startLine": 47,
+      "endLine": 51
     },
     "type": "definition",
     "title": "Prime Counting Function pi(k)",
@@ -71,8 +71,8 @@
     "id": "ann-890-liminf-atmost",
     "proofId": "erdos-890",
     "range": {
-      "startLine": 64,
-      "endLine": 65
+      "startLine": 55,
+      "endLine": 60
     },
     "type": "definition",
     "title": "Liminf At Most Predicate",
@@ -93,8 +93,8 @@
     "id": "ann-890-liminf-atleast",
     "proofId": "erdos-890",
     "range": {
-      "startLine": 71,
-      "endLine": 72
+      "startLine": 62,
+      "endLine": 67
     },
     "type": "definition",
     "title": "Liminf At Least Predicate",
@@ -115,8 +115,8 @@
     "id": "ann-890-limsup-ratio",
     "proofId": "erdos-890",
     "range": {
-      "startLine": 80,
-      "endLine": 85
+      "startLine": 69,
+      "endLine": 80
     },
     "type": "definition",
     "title": "Limsup Ratio Is One Predicate",
@@ -138,8 +138,8 @@
     "id": "ann-890-conjecture-liminf",
     "proofId": "erdos-890",
     "range": {
-      "startLine": 96,
-      "endLine": 98
+      "startLine": 84,
+      "endLine": 93
     },
     "type": "definition",
     "title": "Conjecture 1: Liminf Upper Bound (OPEN)",
@@ -162,8 +162,8 @@
     "id": "ann-890-conjecture-limsup",
     "proofId": "erdos-890",
     "range": {
-      "startLine": 108,
-      "endLine": 109
+      "startLine": 97,
+      "endLine": 104
     },
     "type": "definition",
     "title": "Conjecture 2: Limsup Ratio (OPEN)",
@@ -185,8 +185,8 @@
     "id": "ann-890-erdos-selfridge",
     "proofId": "erdos-890",
     "range": {
-      "startLine": 122,
-      "endLine": 124
+      "startLine": 108,
+      "endLine": 119
     },
     "type": "concept",
     "title": "Erdős-Selfridge Lower Bound",
@@ -210,8 +210,8 @@
     "id": "ann-890-classical-omega",
     "proofId": "erdos-890",
     "range": {
-      "startLine": 130,
-      "endLine": 130
+      "startLine": 121,
+      "endLine": 125
     },
     "type": "concept",
     "title": "Classical Omega Limsup (Hardy-Ramanujan)",
@@ -233,8 +233,8 @@
     "id": "ann-890-mono",
     "proofId": "erdos-890",
     "range": {
-      "startLine": 137,
-      "endLine": 143
+      "startLine": 129,
+      "endLine": 138
     },
     "type": "concept",
     "title": "Monotonicity of S_k (PROVED)",
@@ -256,8 +256,8 @@
     "id": "ann-890-k1",
     "proofId": "erdos-890",
     "range": {
-      "startLine": 148,
-      "endLine": 150
+      "startLine": 140,
+      "endLine": 145
     },
     "type": "concept",
     "title": "Lower Bound at k = 1 (PROVED)",
@@ -277,8 +277,8 @@
     "id": "ann-890-sandwich",
     "proofId": "erdos-890",
     "range": {
-      "startLine": 156,
-      "endLine": 162
+      "startLine": 147,
+      "endLine": 157
     },
     "type": "concept",
     "title": "Liminf Sandwich (PROVED, conditional)",
@@ -299,8 +299,8 @@
     "id": "ann-890-restated",
     "proofId": "erdos-890",
     "range": {
-      "startLine": 167,
-      "endLine": 170
+      "startLine": 159,
+      "endLine": 165
     },
     "type": "concept",
     "title": "Known Lower Bound (PROVED)",

--- a/src/data/proofs/erdos-890/meta.json
+++ b/src/data/proofs/erdos-890/meta.json
@@ -51,63 +51,63 @@
       "id": "header",
       "title": "Problem Statement and Imports",
       "startLine": 1,
-      "endLine": 42,
+      "endLine": 37,
       "summary": "Header documenting Erdős Problem #890 with references to Erdős-Selfridge [ErSe67] and Pólya's theorem. Imports `ArithmeticFunction.Defs` (for $\\omega$), `PrimeCounting` (for $\\pi$), `Finset.Basic`, `Filter.Basic`, `SpecialFunctions.Log.Basic` (for $\\log$), and `Tactic`. Opens `Nat`, `Finset`, `Filter`, and `ArithmeticFunction.omega` namespaces."
     },
     {
       "id": "primitives",
       "title": "Core Definitions",
-      "startLine": 43,
-      "endLine": 57,
+      "startLine": 38,
+      "endLine": 52,
       "summary": "Defines `cumulativeOmega k n = (Finset.range k).sum (\\lambda i \\Rightarrow \\omega(n+i))` for $S_k(n) = \\sum_{i=0}^{k-1} \\omega(n+i)$. Defines `pi k = Nat.primeCounting k` as a convenience alias for $\\pi(k)$. Both are marked `noncomputable`."
     },
     {
       "id": "asymptotics",
       "title": "Liminf and Limsup Predicates",
-      "startLine": 58,
-      "endLine": 86,
+      "startLine": 53,
+      "endLine": 81,
       "summary": "Defines `LiminfAtMost f L`: $\\forall N_0,\\, \\exists n \\geq N_0,\\, f(n) \\leq L$ (liminf $\\leq L$). Defines `LiminfAtLeast f L`: $\\exists N_0,\\, \\forall n \\geq N_0,\\, f(n) \\geq L$ (liminf $\\geq L$). Defines `LimsupRatioIsOne f`: for all $\\varepsilon > 0$, eventually $f(n) \\cdot \\log\\log n \\leq (1+\\varepsilon) \\log n$ and infinitely often $f(n) \\cdot \\log\\log n \\geq (1-\\varepsilon) \\log n$."
     },
     {
       "id": "conjecture-liminf",
       "title": "Conjecture 1: Liminf Upper Bound",
-      "startLine": 87,
-      "endLine": 99,
+      "startLine": 82,
+      "endLine": 94,
       "summary": "Defines `ErdosConjecture890_liminf : Prop` as $\\forall k \\geq 1,\\, \\text{LiminfAtMost}\\,(S_k)\\,(k + \\pi(k))$. This would show $\\liminf S_k(n) \\leq k + \\pi(k)$, complementing the Erdős-Selfridge lower bound."
     },
     {
       "id": "conjecture-limsup",
       "title": "Conjecture 2: Limsup Ratio",
-      "startLine": 100,
-      "endLine": 110,
+      "startLine": 95,
+      "endLine": 105,
       "summary": "Defines `ErdosConjecture890_limsup k : Prop` as `LimsupRatioIsOne (cumulativeOmega k)`. This states $\\limsup S_k(n) \\cdot \\log\\log n / \\log n = 1$, generalizing the Hardy-Ramanujan result from $k = 1$ to arbitrary $k$."
     },
     {
       "id": "known-results",
       "title": "Known Results (Axioms)",
-      "startLine": 111,
-      "endLine": 131,
+      "startLine": 106,
+      "endLine": 126,
       "summary": "Axiomatizes `erdos_selfridge_lower_bound`: $\\forall k \\geq 1,\\, \\text{LiminfAtLeast}\\,(S_k)\\,(k + \\pi(k) - 1)$. Axiomatizes `classical_omega_limsup`: $\\text{LimsupRatioIsOne}\\,(\\omega)$. Both are deep number-theoretic results."
     },
     {
       "id": "structural",
       "title": "Structural Theorems",
-      "startLine": 132,
-      "endLine": 172,
+      "startLine": 127,
+      "endLine": 166,
       "summary": "Proves `cumulativeOmega_mono`: $S_k(n) \\leq S_{k+1}(n)$ via `Finset.sum_le_sum_of_subset`. Proves `erdos_890_lower_bound_k1`: the Erdős-Selfridge bound at $k=1$. Proves `erdos_890_liminf_sandwich`: conditional on Conjecture 1, $k + \\pi(k) - 1 \\leq \\liminf S_k(n) \\leq k + \\pi(k)$. Proves `erdos_890_known_lower_bound`: restates the Erdős-Selfridge axiom."
     },
     {
       "id": "additional-lemmas",
       "title": "Additional Structural Lemmas",
-      "startLine": 172,
-      "endLine": 187,
+      "startLine": 167,
+      "endLine": 182,
       "summary": "Proves `cumulativeOmega_zero`: $S_0(n) = 0$ (empty sum). Proves `cumulativeOmega_one`: $S_1(n) = \\omega(n)$ via `Finset.sum_range_one`. Proves `cumulativeOmega_add`: additivity $S_{k+j}(n) = S_k(n) + S_j(n+k)$ via `Finset.sum_range_add`."
     },
     {
       "id": "conjecture1-k1",
       "title": "Conjecture 1 Verified for k = 1",
-      "startLine": 188,
-      "endLine": 210,
+      "startLine": 183,
+      "endLine": 199,
       "summary": "Proves `omega_prime`: $\\omega(p) = 1$ for any prime $p$. Proves `conjecture1_k1`: an unconditional verification of Conjecture 1 at $k = 1$ ($\\text{LiminfAtMost}\\,(S_1)\\,(1 + \\pi(1))$), using Euclid's infinitude of primes (`Nat.exists_infinite_primes`) since $S_1(p) = \\omega(p) = 1 \\leq 1 + \\pi(1)$ for infinitely many primes $p$."
     }
   ],


### PR DESCRIPTION
## Summary

Drift-repair pass on `erdos-890` (Sum of ω over consecutive integers). The 199-line Lean file has a clean Part I–VIII banner structure, but **every** section and annotation range had drifted ~5 lines below its actual declaration, and the tail section overshot EOF (`188–210 > 199`).

## What changed (ranges only — no prose edits)

**Sections** re-aligned to the Part banners:
- Core Definitions 43–57 → **38–52**
- Liminf/Limsup Predicates 58–86 → **53–81**
- Conjecture 1 87–99 → **82–94**
- Conjecture 2 100–110 → **95–105**
- Known Results (Axioms) 111–131 → **106–126**
- Structural Theorems 132–172 → **127–166**
- Additional Structural Lemmas 172–187 → **167–182**
- Conjecture 1 Verified for k=1 188–210 → **183–199**

**Annotations** re-anchored to their `/-- … -/` docComment..declaration spans, e.g. `cumulativeOmega` 40–45, `pi` 47–51, the two axioms 108–119 / 121–125, and the structural theorems 129–165.

## Verification

JSON round-trips byte-identically (only startLine/endLine values changed — verified the diff contains no non-range lines). All ranges lie within [1, 199], no overshoot. Axiom status unchanged (`axiomatized`, 2 axioms: `erdos_selfridge_lower_bound`, `classical_omega_limsup`).