### PR TITLE
fix(proofs): repair never-compiled Erdos701Problem (#39077)

### DIFF
--- a/proofs/Proofs/Erdos701Problem.lean
+++ b/proofs/Proofs/Erdos701Problem.lean
@@ -94,8 +94,8 @@ theorem singleton_intersecting {α : Type*} (A : Set α) (hA : A.Nonempty) :
     IsIntersecting ({A} : Set (Set α)) := by
   intro B hB C hC
   simp only [Set.mem_singleton_iff] at hB hC
-  subst hB hC
-  exact ⟨A, Set.inter_self A ▸ hA⟩
+  rw [hB, hC, Set.inter_self]
+  exact hA
 
 /-
 ## Part III: Stars
@@ -226,18 +226,19 @@ theorem uniform_not_hereditary {α : Type*} [Fintype α] [DecidableEq α]
     ¬IsHereditary (UniformFamily (α := α) k) := by
   intro hhered
   -- Take any proper non-empty subset of X
-  obtain ⟨x, hx⟩ := Set.ncard_pos.mp (by omega : X.ncard > 0)
+  obtain ⟨x, hx⟩ := Set.nonempty_of_ncard_ne_zero (s := X) (by omega)
   let B := X \ {x}
   have hBX : B ⊂ X := by
     constructor
-    · exact Set.diff_subset
+    · exact Set.sdiff_subset
     · intro heq
-      simp [B] at heq
-      exact heq hx
+      have hxB : x ∈ B := heq hx
+      simp [B] at hxB
   have hBcard : B.ncard = k - 1 := by
-    rw [Set.ncard_diff_singleton_of_mem hx hXfin, hX]
-  have hBF : B ∈ UniformFamily k := hhered X ⟨hXfin, hX⟩ B (Set.diff_subset)
-  simp [UniformFamily] at hBF
+    show (X \ {x}).ncard = k - 1
+    rw [Set.ncard_sdiff_singleton_of_mem hx, hX]
+  have hBF : B ∈ UniformFamily k := hhered X ⟨hXfin, hX⟩ B Set.sdiff_subset
+  simp only [UniformFamily, Set.mem_setOf_eq] at hBF
   omega
 
 /-


### PR DESCRIPTION
Repairs `Proofs/Erdos701Problem.lean` (Chvátal's Conjecture scaffold), one of the 28 never-compiled entries tracked by #39077. Under the old `autoImplicit true` default the undefined identifier `A` was silently bound as an opaque implicit; v4.31 (autoImplicit off) correctly rejects it, exposing genuine defects.

## Defects fixed
1. **`singleton_intersecting`** — `subst hB hC` eliminated the theorem parameter `A`, so the closing `exact ⟨A, …⟩` referenced an unknown identifier. Rewrote via `rw [hB, hC, Set.inter_self]` then `exact hA`.
2. **`uniform_not_hereditary`** — cascade of Mathlib API drift + a real logic gap once `A` no longer masked it:
   - `Set.ncard_pos.mp (…)` → `Set.nonempty_of_ncard_ne_zero (s := X) (by omega)` (`Set.ncard_pos` now takes a finiteness autoparam and isn't an iff constant).
   - `¬ X ⊆ B` branch: derive the contradiction from `x ∈ X \ {x}` explicitly (`have hxB := heq hx; simp [B] at hxB`).
   - `Set.ncard_diff_singleton_of_mem hx hXfin` → `Set.ncard_sdiff_singleton_of_mem hx` (renamed; finiteness arg dropped), via `show (X \ {x}).ncard = …`.
   - deprecated `Set.diff_subset` → `Set.sdiff_subset`.

## Evidence
Host-verified (Mathlib-only imports, no Docker needed):
```
$ lake env lean Proofs/Erdos701Problem.lean
EXIT=0     # clean — 0 errors, 0 warnings
```
Before: 4 errors (`unknownIdentifier A` ×2, `Unknown constant Set.ncard_pos.mp`, rcases failure).

File remains 0 sorries / 0 `axiom` declarations. Chvátal's conjecture stays stated (as `def ChvatalConjecture : Prop`), not asserted — this is an open problem, so gallery meta is intentionally left at `axiomatized`/`wip` (no overclaim to `verified`).

Part of #39077.