### PR TITLE
Enrich erdos-266: re-anchor sections & annotations to real declarations

### DIFF
--- a/src/data/proofs/erdos-266/annotations.json
+++ b/src/data/proofs/erdos-266/annotations.json
@@ -27,7 +27,7 @@
     "proofId": "erdos-266",
     "range": {
       "startLine": 21,
-      "endLine": 27
+      "endLine": 25
     },
     "type": "concept",
     "title": "Mathlib Imports",
@@ -49,8 +49,8 @@
     "id": "ann-e266-conjecture",
     "proofId": "erdos-266",
     "range": {
-      "startLine": 31,
-      "endLine": 42
+      "startLine": 29,
+      "endLine": 40
     },
     "type": "definition",
     "title": "Stolarsky's Conjecture",
@@ -72,8 +72,8 @@
     "id": "ann-e266-disproof",
     "proofId": "erdos-266",
     "range": {
-      "startLine": 46,
-      "endLine": 55
+      "startLine": 44,
+      "endLine": 53
     },
     "type": "concept",
     "title": "Kovač-Tao Disproof",
@@ -95,8 +95,8 @@
     "id": "ann-e266-stronger",
     "proofId": "erdos-266",
     "range": {
-      "startLine": 59,
-      "endLine": 72
+      "startLine": 57,
+      "endLine": 70
     },
     "type": "concept",
     "title": "All-Rationals Result",
@@ -118,8 +118,8 @@
     "id": "ann-e266-construction",
     "proofId": "erdos-266",
     "range": {
-      "startLine": 76,
-      "endLine": 84
+      "startLine": 74,
+      "endLine": 82
     },
     "type": "concept",
     "title": "Counterexample Construction",
@@ -141,8 +141,8 @@
     "id": "ann-e266-relation",
     "proofId": "erdos-266",
     "range": {
-      "startLine": 88,
-      "endLine": 98
+      "startLine": 86,
+      "endLine": 96
     },
     "type": "concept",
     "title": "Relation to Problem #264",
@@ -164,8 +164,8 @@
     "id": "ann-e266-harmonic",
     "proofId": "erdos-266",
     "range": {
-      "startLine": 102,
-      "endLine": 104
+      "startLine": 100,
+      "endLine": 111
     },
     "type": "concept",
     "title": "Harmonic Series Diverges",
@@ -187,8 +187,8 @@
     "id": "ann-e266-basel",
     "proofId": "erdos-266",
     "range": {
-      "startLine": 106,
-      "endLine": 108
+      "startLine": 113,
+      "endLine": 120
     },
     "type": "concept",
     "title": "Sum of Reciprocal Squares",
@@ -210,8 +210,8 @@
     "id": "ann-e266-geometric",
     "proofId": "erdos-266",
     "range": {
-      "startLine": 110,
-      "endLine": 112
+      "startLine": 122,
+      "endLine": 127
     },
     "type": "concept",
     "title": "Geometric Series",
@@ -233,8 +233,8 @@
     "id": "ann-e266-shifted-geometric",
     "proofId": "erdos-266",
     "range": {
-      "startLine": 114,
-      "endLine": 116
+      "startLine": 129,
+      "endLine": 138
     },
     "type": "concept",
     "title": "Shifted Geometric Series",

--- a/src/data/proofs/erdos-266/meta.json
+++ b/src/data/proofs/erdos-266/meta.json
@@ -74,42 +74,42 @@
       "id": "imports",
       "title": "Imports and Setup",
       "startLine": 1,
-      "endLine": 28,
+      "endLine": 26,
       "summary": "Module documentation and Mathlib imports for irrationality, summability, and infinite sums."
     },
     {
       "id": "conjecture",
       "title": "Stolarsky's Conjecture",
-      "startLine": 29,
-      "endLine": 43,
+      "startLine": 27,
+      "endLine": 41,
       "summary": "Formal statement of Stolarsky's conjecture: some shift should produce irrationality."
     },
     {
       "id": "main-result",
       "title": "Main Result",
-      "startLine": 44,
-      "endLine": 56,
+      "startLine": 42,
+      "endLine": 54,
       "summary": "Kovač-Tao's disproof: the conjecture is false."
     },
     {
       "id": "stronger",
       "title": "Stronger All-Rationals Result",
-      "startLine": 57,
-      "endLine": 73,
+      "startLine": 55,
+      "endLine": 71,
       "summary": "The stronger result that ALL rational shifts give rational sums."
     },
     {
       "id": "discussion",
       "title": "Discussion and Relations",
-      "startLine": 74,
-      "endLine": 99,
+      "startLine": 72,
+      "endLine": 97,
       "summary": "Understanding the counterexample and connections to Erdős #264."
     },
     {
       "id": "examples",
       "title": "Examples",
-      "startLine": 100,
-      "endLine": 150,
+      "startLine": 98,
+      "endLine": 140,
       "summary": "Standard series examples: harmonic (diverges), Basel (converges), geometric."
     }
   ],


### PR DESCRIPTION
## Summary

Drift-repair pass on `erdos-266` (Stolarsky's shifted-sum conjecture, disproved by Kovač–Tao 2024). The Lean file is 140 lines, but the **Examples** section pointed at `100–150` (overshooting EOF) and the three example annotations had drifted 7–14 lines above their actual theorems.

## What changed (ranges only — no prose edits)

**Sections** aligned to the `## …` banners:
- Imports and Setup → 1–26
- Stolarsky's Conjecture 29–43 → **27–41**
- Main Result 44–56 → **42–54**
- Stronger All-Rationals Result 57–73 → **55–71**
- Discussion and Relations 74–99 → **72–97**
- Examples 100–150 → **98–140**

**Annotations** re-anchored to their docComment..declaration spans — notably `sum_reciprocal_squares_summable` 106→**113–120**, geometric-series `example` 110→**122–127**, shifted-geometric `example` 114→**129–138**.

## Verification

JSON round-trips byte-identically (verified the diff contains only startLine/endLine lines). All ranges within [1, 140], no overshoot. Axiom status unchanged (`axiomatized`, 2 axioms: `stolarsky_conjecture_false`, `kovac_tao_all_rationals`).