### PR TITLE
Enrich Pythagorean Theorem (Non-Euclidean): fix trailing line-range drift

### DIFF
--- a/src/data/proofs/pythagorean-theorem-oq-03/meta.json
+++ b/src/data/proofs/pythagorean-theorem-oq-03/meta.json
@@ -63,7 +63,7 @@
       }
     ],
     "axiomCount": 0,
-    "lineCount": 1431,
+    "lineCount": 1421,
     "assumptions": "0 axioms. Structure fields (HyperbolicRightTriangle.law, SphericalRightTriangle.law, SphericalRightTriangleR.law) define the mathematical objects — users must provide proof to construct instances. All 50+ consequence theorems are fully proved.",
     "mathlib_version": "4.31.0",
     "theoremCount": 105,
@@ -295,7 +295,7 @@
       "id": "four-geometries",
       "title": "The Four Pythagorean-Type Relations",
       "startLine": 1368,
-      "endLine": 1431,
+      "endLine": 1421,
       "mathContext": "Euclidean $c^2=a^2+b^2$, spherical $\\cos c=\\cos a\\cos b$, hyperbolic $\\cosh c=\\cosh a\\cosh b$, Minkowski $\\tau^2=t^2-x^2$.",
       "summary": "PART XXV. The capstone comparison of the four metric forms: `euclideanForm = x²+y²` versus `minkowskiForm = t²−x²`, with `euclideanForm_nonneg`, `minkowski_form_indefinite`, `euclidean_ge_minkowski`, and the difference identity, contrasting definite (curved/flat) against indefinite (Lorentzian) signatures."
     }
@@ -460,7 +460,7 @@
       "Real"
     ],
     "namespace": "PythagoreanNonEuclidean",
-    "lineCount": 1431,
+    "lineCount": 1421,
     "axiomCount": 0,
     "sorries": 0,
     "definitionCount": 21,


### PR DESCRIPTION
## Enrichment pass for `pythagorean-theorem-oq-03`

**Work source:** section/lineCount line-range overshoot drift.

`Proofs/PythagoreanTheoremOQ03.lean` is **1421 lines** (ends at `end PythagoreanNonEuclidean`), but the final section *The Four Pythagorean-Type Relations* had `endLine: 1431` — 10 lines past EOF — and both `leanFile.lineCount` and `meta.lineCount` still read the stale **1431**.

### Changes
- Section `four-geometries` `endLine` 1431 → 1421.
- `leanFile.lineCount` 1431 → 1421.
- `meta.lineCount` 1431 → 1421.

All other 25 sections were already within bounds (drift was a consistent 10-line tail trim). Annotations do not overshoot (max 1023). No content changed beyond line numbers.