### PR TITLE
audit: erdos-851 — drop phantom axiomatized Romanoff/conjecture/density claims from prose

### DIFF
--- a/src/data/proofs/erdos-851/meta.json
+++ b/src/data/proofs/erdos-851/meta.json
@@ -42,11 +42,9 @@
     ],
     "originalContributions": [
       "Definition of TwoPowAddSet: integers 2^k + n with ω(n) ≤ r",
-      "Axiomatization of lower density for natural number sets",
-      "Romanoff's Theorem (1934) as axiom",
-      "Erdős's density conjecture (OPEN) as axiom",
-      "Monotonicity of TwoPowAddSet in r",
-      "Covering property: union covers all m ≥ 2",
+      "Axiomatization of lower density as an opaque real-valued functional lowerDensity : Set ℕ → ℝ (declared with no constraining axioms)",
+      "Monotonicity of TwoPowAddSet in r (set inclusion)",
+      "Covering property: for every m ≥ 2 some TwoPowAddSet r contains m",
       "Verified examples: 3, 5, 9, 17 in TwoPowAddSet 0"
     ],
     "axiomCount": 1,
@@ -59,7 +57,7 @@
     "historicalContext": "**Romanoff's Theorem (1934)** initiated the study of integers representable as 2^k + p where p is prime. Romanoff proved this set has positive lower density (approximately 0.0868).\n\n**Erdős's Question** generalizes this: if we allow n to have more prime factors (not just 1), can we cover almost all integers?\n\n**Timeline**:\n- 1934: Romanoff proves positive density for 2^k + p\n- 1979: Erdős-Odlyzko improve density bounds to ~0.0868\n- Present: The general conjecture remains **OPEN**\n\nThe problem connects to:\n- Additive number theory\n- Sieve methods\n- Covering congruences",
     "problemStatement": "For integer $n \\geq 1$, define the set\n$$\\text{TwoPowAddSet}(r) = \\{2^k + n : k \\geq 0, \\omega(n) \\leq r\\}$$\nwhere $\\omega(n)$ counts distinct prime factors.\n\n**Romanoff's Theorem (1934)**: The set of integers $2^k + p$ (p prime or 1) has positive lower density:\n$$\\liminf_{N \\to \\infty} \\frac{|\\text{TwoPowAddSet}(1) \\cap [1,N]|}{N} > 0$$\n\n**Erdős Problem #851 (OPEN)**: For every $\\varepsilon > 0$, is there some $r$ such that\n$$\\liminf_{N \\to \\infty} \\frac{|\\text{TwoPowAddSet}(r) \\cap [1,N]|}{N} \\geq 1 - \\varepsilon?$$\n\nIn other words, can we cover almost all integers by allowing n to have a bounded number of prime factors?",
     "text": "Romanoff (1934) proved that integers of the form 2^k + p (p prime) have positive lower density. Erdős asked: for any ε > 0, is there r such that integers of form 2^k + n (n has ≤ r prime factors) have density ≥ 1 - ε? OPEN.",
-    "proofStrategy": "We formalize this problem by:\n\n1. **TwoPowAddSet definition**: {m | ∃ k n, m = 2^k + n ∧ n.primeFactors.card ≤ r}\n\n2. **Lower density axiom**: Axiomatize lowerDensity(S) as liminf of counting measure\n\n3. **Romanoff's Theorem**: Axiomatize 0 < lowerDensity(TwoPowAddSet 1)\n\n4. **Main conjecture**: Axiomatize ∀ ε > 0, ∃ r, 1 - ε ≤ lowerDensity(TwoPowAddSet r)\n\n5. **Properties**: Prove monotonicity, covering, and verify specific examples\n\n6. **Density bounds**: Axiomatize the ~0.0868 lower bound from Erdős-Odlyzko",
+    "proofStrategy": "We set up scaffolding for this problem by:\n\n1. **TwoPowAddSet definition**: {m | ∃ k n, m = 2^k + n ∧ n.primeFactors.card ≤ r}\n\n2. **Lower density axiom**: Axiomatize lowerDensity(S) : ℝ as an opaque real-valued functional (intended as the liminf of the counting measure), declared with no further constraining axioms\n\n3. **Set-level lemmas**: Prove that 2^k + 1 ∈ TwoPowAddSet 0, monotonicity of TwoPowAddSet in r, and that the union over r covers all m ≥ 2\n\n4. **Examples**: Verify 3, 5, 9, 17 ∈ TwoPowAddSet 0\n\nRomanoff's theorem (0 < lowerDensity(TwoPowAddSet 1)), Erdős's main OPEN conjecture, and the ~0.0868 Erdős–Odlyzko bound are recorded only as documentation comments in the source; they are **not** stated or axiomatized in Lean, and lowerDensity carries no axioms relating it to these claims.",
     "keyInsights": [
       "**Why r = 1 isn't enough**: Romanoff's density ~0.0868 leaves most integers uncovered. Many integers cannot be written as 2^k + p for any prime p.",
       "**Monotonicity**: TwoPowAddSet(r) ⊆ TwoPowAddSet(s) for r ≤ s, so density is non-decreasing in r.",
@@ -96,7 +94,7 @@
       "title": "Romanoff's Theorem (1934)",
       "startLine": 64,
       "endLine": 77,
-      "summary": "The foundational result: 2^k + p has positive lower density, approximately 0.0868.",
+      "summary": "Documentation of Romanoff's 1934 result (positive lower density ≈ 0.0868 for 2^k + p); recorded as a source comment, not stated or axiomatized in Lean.",
       "mathContext": "$\\liminf_{N \\to \\infty} \\frac{|\\mathrm{TwoPowAddSet}(1) \\cap [1,N]|}{N} \\approx 0.0868 > 0$"
     },
     {
@@ -104,7 +102,7 @@
       "title": "Main Conjecture (OPEN)",
       "startLine": 78,
       "endLine": 92,
-      "summary": "Erdős's question about achieving density arbitrarily close to 1.",
+      "summary": "Documentation of Erdős's OPEN question (density → 1 as r grows); recorded as a source comment, not stated or axiomatized in Lean.",
       "mathContext": "$\\forall \\varepsilon > 0,\\; \\exists r \\in \\mathbb{N},\\; \\liminf_{N \\to \\infty} \\frac{|\\mathrm{TwoPowAddSet}(r) \\cap [1,N]|}{N} \\geq 1 - \\varepsilon$"
     },
     {
@@ -112,7 +110,7 @@
       "title": "Density Properties",
       "startLine": 93,
       "endLine": 117,
-      "summary": "Monotonicity of density in r, upper bound of 1, and equivalence to limit being 1.",
+      "summary": "Prose discussion of the key open question (whether the limiting density equals 1); these density properties are comments only — no monotonicity, upper-bound, or equivalence theorems are formalized here.",
       "mathContext": "$r \\leq s \\Rightarrow d^-(\\mathrm{TwoPowAddSet}(r)) \\leq d^-(\\mathrm{TwoPowAddSet}(s)) \\leq 1$; conjecture $\\Leftrightarrow \\lim_{r \\to \\infty} d^-(\\mathrm{TwoPowAddSet}(r)) = 1$"
     },
     {
@@ -120,7 +118,7 @@
       "title": "Related Results",
       "startLine": 118,
       "endLine": 130,
-      "summary": "Uncovered integers, Erdős-Odlyzko bounds, and covering problem status.",
+      "summary": "Documentation of related results (uncovered integers, Erdős–Odlyzko 1979 bounds, covering-problem status); recorded as source comments, not formalized in Lean.",
       "mathContext": "$d^-(\\mathrm{TwoPowAddSet}(1)^c) > 0$; Erdős–Odlyzko (1979): $d^-(\\mathrm{TwoPowAddSet}(1)) > 0.0868$"
     },
     {


### PR DESCRIPTION
## Gallery Integrity Audit — erdos-851

**Proof**: erdos-851 (Density of Integers 2^k + n)
**Result**: prose overstates formalized content (counts are all correct)

## What the Lean file actually contains

`proofs/Proofs/Erdos851Problem.lean` (163 lines) declares only:
- `def TwoPowAddSet` (1 definition)
- `axiom lowerDensity (S : Set ℕ) : ℝ` — an **opaque, unconstrained** functional; used nowhere, with no axioms relating it to any density fact
- 7 trivial theorems: `twoPow_add_one_mem`, `twoPowAddSet_mono`, `twoPowAddSet_union_covers`, and `three/five/nine/seventeen_mem`

Counts in meta (axiomCount=1, theoremCount=7, definitionCount=1, sorries=0, lineCount=163) are **accurate**.

## The overstatement

- **originalContributions** listed `"Romanoff's Theorem (1934) as axiom"` and `"Erdős's density conjecture (OPEN) as axiom"`. Neither is stated or axiomatized in Lean — they exist only as English comment blocks (lines 70-71, 80-84).
- **proofStrategy** steps 3/4/6 claimed axiomatizations of `0 < lowerDensity(TwoPowAddSet 1)`, the main conjecture, and the ~0.0868 Erdős–Odlyzko bound. **None exist** in the source.
- **sections**: `density-properties` (lines 93-117) summarized "Monotonicity of density in r, upper bound of 1, and equivalence to limit being 1" — those lines are pure comments; **no such theorems exist**. `romanoff`, `main-conjecture`, and `related-results` similarly summarized formalized results over comment-only ranges.

## Fix

meta.json prose only — no Lean changes. Removed the two phantom "as axiom" contributions, reframed the proofStrategy to reflect that only `lowerDensity` is axiomatized (unconstrained) and the rest is documentation, and rewrote the four section summaries to mark them as documentation over comment ranges.

---
Discovered during gallery integrity audit (reserve mode, oldest uncontested target).