### PR TITLE
Research: erdos-510-wip-01 — 16 axiom-free foundational lemmas on Chowla's cosine sum

### DIFF
--- a/proofs/Proofs/Erdos510WIP01.lean
+++ b/proofs/Proofs/Erdos510WIP01.lean
@@ -1,0 +1,146 @@
+/-
+# Erdős Problem #510 (Chowla's Cosine Problem) — Foundational Lemmas
+
+Axiom-free foundational scaffolding for the cosine sum
+
+    cosineSum A θ = ∑_{n ∈ A} cos(n·θ),     minCosineSum A = ⨅_θ cosineSum A θ,
+
+as defined in `Proofs/Erdos510Problem.lean`.
+
+Chowla's cosine problem asks whether there is an absolute constant `c > 0` such
+that every finite `A ⊂ ℕ⁺` of size `N` admits an angle `θ` with
+`cosineSum A θ < −c√N`.  The deep quantitative bounds (Bourgain, Ruzsa, Bedert)
+remain open/hard, but the *elementary structure* of the cosine sum and its
+infimum is fully provable from Mathlib.  This file establishes:
+
+* evaluation lemmas: on the empty set, singletons, `insert`, at `θ = 0` and
+  `θ = π`;
+* the trivial two-sided bound `|cosineSum A θ| ≤ N` (so the sum lives in
+  `[−N, N]`);
+* evenness `cosineSum A (−θ) = cosineSum A θ` and `2π`-periodicity;
+* continuity of `θ ↦ cosineSum A θ`;
+* boundedness-below of the range, hence the basic `minCosineSum` bounds
+  `−N ≤ minCosineSum A ≤ N` and `minCosineSum A ≤ cosineSum A θ`;
+* the exact value `minCosineSum {n} = −1` for `n ≥ 1`.
+
+All results are `0`-axiom / `0`-sorry.  The genuinely open content — the
+`−c√N` lower bound — is untouched (it is the mission, not the scaffolding).
+
+Reference: <https://erdosproblems.com/510>
+-/
+
+import Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic
+import Mathlib.Topology.Algebra.InfiniteSum.Basic
+import Mathlib.Order.ConditionallyCompleteLattice.Indexed
+import Proofs.Erdos510Problem
+
+open Finset Real
+
+namespace Erdos510WIP01
+
+variable (A : Finset ℕ) (θ : ℝ)
+
+/-! ## Evaluation lemmas -/
+
+/-- The cosine sum of the empty set is `0`. -/
+theorem cosineSum_empty : cosineSum ∅ θ = 0 := by
+  simp [cosineSum]
+
+/-- The cosine sum of a singleton is a single cosine. -/
+theorem cosineSum_singleton (n : ℕ) : cosineSum {n} θ = Real.cos (n * θ) := by
+  simp [cosineSum]
+
+/-- Adding a fresh frequency `n ∉ A` adds one cosine term. -/
+theorem cosineSum_insert {n : ℕ} {A : Finset ℕ} (h : n ∉ A) :
+    cosineSum (insert n A) θ = Real.cos (n * θ) + cosineSum A θ := by
+  simp [cosineSum, Finset.sum_insert h]
+
+/-- At `θ = 0` every term is `cos 0 = 1`, so the sum is the cardinality `N`. -/
+theorem cosineSum_zero_angle : cosineSum A 0 = A.card := by
+  simp [cosineSum]
+
+/-- At `θ = π` the sum collapses to an alternating sum `∑ (−1)ⁿ`. -/
+theorem cosineSum_pi : cosineSum A π = ∑ n ∈ A, (-1 : ℝ) ^ n := by
+  simp only [cosineSum]
+  exact Finset.sum_congr rfl (fun n _ => Real.cos_nat_mul_pi n)
+
+/-! ## Symmetry and periodicity -/
+
+/-- The cosine sum is even in the angle: `cosineSum A (−θ) = cosineSum A θ`. -/
+theorem cosineSum_neg : cosineSum A (-θ) = cosineSum A θ := by
+  simp only [cosineSum, mul_neg, Real.cos_neg]
+
+/-- The cosine sum is `2π`-periodic in the angle. -/
+theorem cosineSum_add_two_pi : cosineSum A (θ + 2 * π) = cosineSum A θ := by
+  simp only [cosineSum]
+  refine Finset.sum_congr rfl (fun n _ => ?_)
+  rw [show (n : ℝ) * (θ + 2 * π) = n * θ + n * (2 * π) from by ring,
+    Real.cos_add_nat_mul_two_pi]
+
+/-! ## Trivial two-sided bound -/
+
+/-- Triangle inequality plus `|cos| ≤ 1`: the cosine sum is bounded by `N`. -/
+theorem abs_cosineSum_le_card : |cosineSum A θ| ≤ A.card := by
+  simp only [cosineSum]
+  calc |∑ n ∈ A, Real.cos (n * θ)| ≤ ∑ n ∈ A, |Real.cos (n * θ)| :=
+        Finset.abs_sum_le_sum_abs _ _
+    _ ≤ ∑ _n ∈ A, (1 : ℝ) := Finset.sum_le_sum
+        (fun n _ => abs_le.mpr ⟨Real.neg_one_le_cos _, Real.cos_le_one _⟩)
+    _ = A.card := by simp
+
+/-- Upper bound `cosineSum A θ ≤ N`. -/
+theorem cosineSum_le_card : cosineSum A θ ≤ A.card :=
+  (le_abs_self _).trans (abs_cosineSum_le_card A θ)
+
+/-- Lower bound `−N ≤ cosineSum A θ`. -/
+theorem neg_card_le_cosineSum : -(A.card : ℝ) ≤ cosineSum A θ :=
+  (abs_le.mp (abs_cosineSum_le_card A θ)).1
+
+/-! ## Continuity -/
+
+/-- `θ ↦ cosineSum A θ` is continuous (a finite sum of continuous cosines). -/
+theorem continuous_cosineSum : Continuous (cosineSum A) := by
+  show Continuous (fun θ => ∑ n ∈ A, Real.cos (n * θ))
+  exact continuous_finsetSum _
+    (fun n _ => Real.continuous_cos.comp (continuous_const.mul continuous_id))
+
+/-! ## The infimum `minCosineSum` -/
+
+/-- The range of `cosineSum A` is bounded below (by `−N`). -/
+theorem bddBelow_range_cosineSum : BddBelow (Set.range (cosineSum A)) := by
+  refine ⟨-(A.card : ℝ), ?_⟩
+  rintro x ⟨θ, rfl⟩
+  exact neg_card_le_cosineSum A θ
+
+/-- `minCosineSum A` is a lower bound for every cosine sum value. -/
+theorem minCosineSum_le : minCosineSum A ≤ cosineSum A θ :=
+  ciInf_le (bddBelow_range_cosineSum A) θ
+
+/-- `−N` bounds `minCosineSum A` from below. -/
+theorem neg_card_le_minCosineSum : -(A.card : ℝ) ≤ minCosineSum A :=
+  le_ciInf (fun θ => neg_card_le_cosineSum A θ)
+
+/-- `minCosineSum A ≤ N` (via the value at `θ = 0`). -/
+theorem minCosineSum_le_card : minCosineSum A ≤ A.card :=
+  (minCosineSum_le A 0).trans_eq (cosineSum_zero_angle A)
+
+/-- The minimum cosine sum of the empty set is `0`. -/
+theorem minCosineSum_empty : minCosineSum ∅ = 0 := by
+  have h : cosineSum ∅ = fun _ : ℝ => (0 : ℝ) := funext (fun θ => cosineSum_empty θ)
+  simp only [minCosineSum, h]
+  exact ciInf_const
+
+/-- Exact value for a single positive frequency: `minCosineSum {n} = −1`
+    for `n ≥ 1`.  The bound `−1 ≤ cos` gives `≥ −1`; the angle `θ = π/n`
+    (where `cos(n·θ) = cos π = −1`) gives `≤ −1`. -/
+theorem minCosineSum_singleton {n : ℕ} (hn : 1 ≤ n) : minCosineSum {n} = -1 := by
+  have hn0 : (n : ℝ) ≠ 0 := Nat.cast_ne_zero.mpr (by omega)
+  have hval : cosineSum {n} (π / n) = -1 := by
+    rw [cosineSum_singleton]
+    have hπ : (n : ℝ) * (π / n) = π := by field_simp
+    rw [hπ, Real.cos_pi]
+  apply le_antisymm
+  · exact (minCosineSum_le {n} (π / n)).trans_eq hval
+  · exact le_ciInf (fun θ => by rw [cosineSum_singleton]; exact Real.neg_one_le_cos _)
+
+end Erdos510WIP01

--- a/src/data/research/problems/erdos-510-wip-01.json
+++ b/src/data/research/problems/erdos-510-wip-01.json
@@ -1,0 +1,97 @@
+{
+  "slug": "erdos-510-wip-01",
+  "title": "Complete the Lean Formalization of Erdős Problem #510 (Chowla's Cosine Problem)",
+  "phase": "ORIENT",
+  "status": "active",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "\\exists c > 0,\\ \\forall A \\subset \\mathbb{N}^{+} \\text{ finite of size } N,\\ \\exists \\theta,\\ \\sum_{n \\in A} \\cos(n\\theta) < -c\\sqrt{N}.",
+    "plain": "Chowla's cosine problem asks whether there is an absolute constant c>0 such that every finite set A of positive integers of size N admits an angle θ with ∑_{n∈A} cos(nθ) < −c√N. The example A = B−B for a Sidon set B of size ≈√N shows √N is best possible. Bourgain (1986) gave the first nontrivial bound, improved by Ruzsa (2004) to −exp(O(√log N)); Bedert (2025) and Jin–Milojević–Tomon–Zhang independently obtained polynomial bounds −cN^{1/7}. The gap between N^{1/7} and N^{1/2} remains open. The Lean file Erdos510Problem.lean defines cosineSum and minCosineSum but proves no nontrivial fact; this WIP node formalizes the elementary structural scaffolding.",
+    "whyMatters": [
+      "The cosine problem is a central open question in additive combinatorics (Green's Problem 81), tying difference-set structure to exponential-sum cancellation."
+    ]
+  },
+  "knownResults": {
+    "proven": [
+      "Elementary two-sided bound |cosineSum A θ| ≤ N (this session).",
+      "cosineSum is even, 2π-periodic, continuous; minCosineSum ∈ [−N, N] (this session).",
+      "Exact value minCosineSum {n} = −1 for n ≥ 1 (this session)."
+    ],
+    "open": [
+      "The −c√N lower bound (the conjecture itself) — deep, untouched.",
+      "The gap between the proven N^{1/7} (Bedert 2025) and conjectured N^{1/2}."
+    ],
+    "goal": "Formalize the tractable structural facts about cosineSum / minCosineSum from Mathlib; keep the deep −c√N bound cleanly isolated as the open target."
+  },
+  "currentState": {
+    "phase": "ORIENT",
+    "since": "2026-07-20T12:00:00-07:00",
+    "iteration": 1,
+    "focus": "Axiom-free foundational lemmas on the cosine sum and its infimum.",
+    "blockers": [
+      {
+        "route": "the −c√N lower bound via elementary trigonometric identities",
+        "reopenCriterion": "materially new mechanism required",
+        "blockedAt": "2026-07-20"
+      }
+    ],
+    "nextAction": "Prove that minCosineSum is attained (continuity + 2π-periodicity ⟹ inf over ℝ equals min over [0,2π]); then the average-zero fact ⨍ cosineSum A = 0 for A ⊂ ℕ⁺ giving minCosineSum A ≤ 0.",
+    "attemptCounts": {
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
+    }
+  },
+  "knowledge": {
+    "progressSummary": "PROGRESS: Created Proofs/Erdos510WIP01.lean (16 theorems, 0 sorry / 0 axiom, VERIFIED axiom-free [propext, Classical.choice, Quot.sound]). Established the elementary structure of the Chowla cosine sum: evaluation lemmas (empty/singleton/insert, θ=0 giving N, θ=π giving ∑(−1)ⁿ), evenness and 2π-periodicity, continuity, the trivial two-sided bound |cosineSum A θ| ≤ N, bounded-below range, the basic minCosineSum bounds −N ≤ minCosineSum A ≤ N, and the exact value minCosineSum {n} = −1 for n ≥ 1. The deep −c√N conjecture is untouched (it is the open target).",
+    "builtItems": [
+      "cosineSum_empty / cosineSum_singleton / cosineSum_insert in Erdos510WIP01.lean",
+      "cosineSum_zero_angle (cosineSum A 0 = N), cosineSum_pi (= ∑(−1)ⁿ)",
+      "cosineSum_neg (evenness), cosineSum_add_two_pi (2π-periodicity)",
+      "continuous_cosineSum",
+      "abs_cosineSum_le_card, cosineSum_le_card, neg_card_le_cosineSum",
+      "bddBelow_range_cosineSum, minCosineSum_le, neg_card_le_minCosineSum, minCosineSum_le_card, minCosineSum_empty",
+      "minCosineSum_singleton (= −1 for n ≥ 1)"
+    ],
+    "insights": [
+      "The trivial range of the cosine sum is [−N, N]; the conjectured extremal value −c√N sits strictly inside, so all elementary bounds are far from the truth — the content is entirely in the cancellation.",
+      "minCosineSum {n} = −1 exactly (attained at θ = π/n), showing single-frequency sets are the most negative possible relative to size — the difficulty is genuinely a many-frequency cancellation phenomenon.",
+      "Continuity + 2π-periodicity make minCosineSum an attained minimum, not merely an infimum; formalizing attainment is the natural next structural step.",
+      "The θ=0 value N and θ=π value ∑(−1)ⁿ give cheap explicit witnesses bracketing the infimum."
+    ],
+    "mathlibGaps": [
+      "No direct reduction of an ℝ-infimum of a periodic continuous function to a min over a fundamental period; needs a toIcoMod-style mod-2π reduction to formalize attainment."
+    ],
+    "nextSteps": [
+      "Formalize attainment: ∃ θ, cosineSum A θ = minCosineSum A via continuity on [0,2π] + periodicity.",
+      "For A ⊂ ℕ⁺, prove minCosineSum A ≤ 0 via ∫_0^{2π} cosineSum A = 0 (each ∫cos(nθ)=0 for n≥1).",
+      "Formalize the Sidon-set difference-set example showing √N optimality (harder)."
+    ],
+    "markdown": "# Knowledge Base: erdos-510-wip-01\n\n## Session 2026-07-20 (researcher-1) — foundational cosine-sum scaffolding\n\n**Mode**: FRESH (EMPTY node). **Outcome**: progress — VERIFIED axiom-free (`[propext, Classical.choice, Quot.sound]`), 0 sorry / 0 axiom. Host-verified (Mathlib-only parent): fresh-built `Erdos510Problem.olean` then `lake env lean` on the child (no Docker).\n\n### What I did\nCreated `proofs/Proofs/Erdos510WIP01.lean` (16 theorems) establishing the elementary structure of the Chowla cosine sum `cosineSum A θ = ∑_{n∈A} cos(nθ)` and its infimum `minCosineSum A = ⨅_θ cosineSum A θ`:\n- **Evaluation**: `cosineSum_empty`, `cosineSum_singleton`, `cosineSum_insert`, `cosineSum_zero_angle` (`= N`), `cosineSum_pi` (`= ∑(−1)ⁿ`).\n- **Symmetry / periodicity**: `cosineSum_neg` (even), `cosineSum_add_two_pi` (2π-periodic).\n- **Continuity**: `continuous_cosineSum`.\n- **Two-sided bound**: `abs_cosineSum_le_card` (`|·| ≤ N`), `cosineSum_le_card`, `neg_card_le_cosineSum`.\n- **Infimum**: `bddBelow_range_cosineSum`, `minCosineSum_le`, `neg_card_le_minCosineSum`, `minCosineSum_le_card`, `minCosineSum_empty`, and the exact value `minCosineSum_singleton` (`= −1` for `n ≥ 1`).\n\n### Key findings\n- The cosine sum lives in `[−N, N]`; the conjectured extremum `−c√N` is strictly interior, so every elementary bound is far from the truth — the mathematics is entirely in the cancellation.\n- `minCosineSum {n} = −1` exactly (attained at `θ = π/n`): single-frequency sets are maximally negative per size, so the `−c√N` difficulty is a genuine many-frequency phenomenon.\n\n### Reusable Lean recipe\n- Periodicity per term: `Real.cos_add_nat_mul_two_pi (n*θ) n` after `ring`-rewriting `n·(θ+2π) = n·θ + n·(2π)`.\n- `θ=π` collapse: `Real.cos_nat_mul_pi n : cos(n·π) = (−1)ⁿ`.\n- Infimum bounds in ℝ: `ciInf_le (bddBelow …) θ` and `le_ciInf (fun θ => …)` (index `ℝ` is `Nonempty`); bound the range below by `−N` via `neg_card_le_cosineSum`.\n- `|cos| ≤ 1` without `Analysis.Complex.Trigonometric`: `abs_le.mpr ⟨Real.neg_one_le_cos _, Real.cos_le_one _⟩`.\n- Continuity of a partially-applied `def`: `show Continuous (fun θ => …)` (not `simp only [def]`, which makes no progress under `Continuous`), then `continuous_finsetSum`.\n\n### Next steps\n- Attainment: `∃ θ, cosineSum A θ = minCosineSum A` (continuity on `[0,2π]` + periodicity).\n- `minCosineSum A ≤ 0` for `A ⊂ ℕ⁺` via `∫_0^{2π} cosineSum A = 0`.\n\n### Still open (unchanged)\nThe `−c√N` lower bound (Chowla's conjecture) — deep; Bedert (2025) reached `−cN^{1/7}`, the `N^{1/7}`↔`N^{1/2}` gap is open.\n"
+  },
+  "tags": [
+    "erdos",
+    "harmonic-analysis",
+    "additive-combinatorics",
+    "exponential-sums",
+    "sidon-sets",
+    "trigonometric-polynomials",
+    "open",
+    "wip"
+  ],
+  "relatedProofs": [
+    "erdos-510"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [
+      "https://erdosproblems.com/510"
+    ],
+    "mathlib": []
+  },
+  "started": "2026-07-20T12:00:00.000Z",
+  "lastUpdate": "2026-07-20T12:00:00.000Z",
+  "significance": 6,
+  "tractability": 5
+}


### PR DESCRIPTION
## Summary
Research session on the fresh (EMPTY) WIP node **erdos-510-wip-01** (Erdős #510, Chowla's cosine problem). Adds `proofs/Proofs/Erdos510WIP01.lean` — **16 theorems, 0 sorry / 0 axiom** — establishing the elementary structure of the cosine sum

```
cosineSum A θ = ∑_{n∈A} cos(nθ),    minCosineSum A = ⨅_θ cosineSum A θ
```

as defined in `Erdos510Problem.lean`, which previously proved no nontrivial fact about them.

## What's proved (all axiom-free)
- **Evaluation**: `cosineSum_empty`, `cosineSum_singleton`, `cosineSum_insert`, `cosineSum_zero_angle` (`= N`), `cosineSum_pi` (`= ∑(−1)ⁿ`)
- **Symmetry / periodicity**: `cosineSum_neg` (even in θ), `cosineSum_add_two_pi` (2π-periodic)
- **Continuity**: `continuous_cosineSum`
- **Trivial two-sided bound**: `abs_cosineSum_le_card` (`|cosineSum A θ| ≤ N`), `cosineSum_le_card`, `neg_card_le_cosineSum`
- **Infimum**: `bddBelow_range_cosineSum`, `minCosineSum_le`, `neg_card_le_minCosineSum`, `minCosineSum_le_card`, `minCosineSum_empty`, and the exact value `minCosineSum_singleton` (`= −1` for `n ≥ 1`, attained at `θ = π/n`)

## Why this is honest, non-inflated progress
The cosine sum lives in `[−N, N]`; the conjectured extremal value `−c√N` sits strictly inside, so every bound here is far from the truth — the content is entirely in the cancellation. The deep `−c√N` lower bound (Bourgain 1986 → Ruzsa 2004 → Bedert 2025's `−cN^{1/7}`) is **untouched and cleanly isolated** as the open target. `minCosineSum {n} = −1` shows single-frequency sets are maximally negative per size, i.e. the difficulty is a genuine many-frequency phenomenon.

## Verification
Host-verified (parent is Mathlib-only): fresh-built `Erdos510Problem.olean` via `lake env lean`, then compiled the child — clean, no Docker. `#print axioms` on representative theorems (`minCosineSum_singleton`, `abs_cosineSum_le_card`, `cosineSum_add_two_pi`, `continuous_cosineSum`, `minCosineSum_le`) = `[propext, Classical.choice, Quot.sound]` only.

## Next steps (recorded in tracker)
- Attainment: `∃ θ, cosineSum A θ = minCosineSum A` (continuity on `[0,2π]` + periodicity)
- `minCosineSum A ≤ 0` for `A ⊂ ℕ⁺` via `∫_0^{2π} cosineSum A = 0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)