### PR TITLE
Enrich erdos-1167: fix Section 4/5 & consequences-annotation drift

### DIFF
--- a/src/data/proofs/erdos-1167/annotations.json
+++ b/src/data/proofs/erdos-1167/annotations.json
@@ -93,7 +93,7 @@
     "proofId": "erdos-1167",
     "range": {
       "startLine": 210,
-      "endLine": 233
+      "endLine": 231
     },
     "type": "concept",
     "title": "The Open Conjecture and Known Results",
@@ -115,8 +115,8 @@
     "id": "ann-e1167-consequences",
     "proofId": "erdos-1167",
     "range": {
-      "startLine": 246,
-      "endLine": 264
+      "startLine": 546,
+      "endLine": 562
     },
     "type": "concept",
     "title": "Consequences of the Conjecture",
@@ -136,8 +136,8 @@
     "id": "ann-e1167-consistency",
     "proofId": "erdos-1167",
     "range": {
-      "startLine": 266,
-      "endLine": 291
+      "startLine": 563,
+      "endLine": 586
     },
     "type": "concept",
     "title": "Consistency Checks and Classical Ramsey Results",

--- a/src/data/proofs/erdos-1167/meta.json
+++ b/src/data/proofs/erdos-1167/meta.json
@@ -138,15 +138,15 @@
       "id": "infinite-ramsey",
       "title": "Section 4 — The Infinite Ramsey Theorem (Proved)",
       "startLine": 232,
-      "endLine": 549,
+      "endLine": 541,
       "summary": "Fully proves (0 sorries) the infinite Ramsey theorem ℵ₀ → (ℵ₀)^r_k for all finite r, k, eliminating the former axiom. Base cases: infinite_ramsey_zero (r=0, unique empty subset) and infinite_ramsey_one (r=1, infinite pigeonhole via Finite.exists_infinite_fiber). The private lemma ramsey_step performs one diagonal extraction: fix a vertex v of the infinite set, build the reduced r-coloring g(T)=f({v}∪T) on a subtype of S∖{v}, apply the IH, and transfer the monochromatic subset back to the ambient type (the delicate subtype-lifting argument). The main theorem infinite_ramsey then iterates ramsey_step via Nat.rec to build a sequence of (vertex, color) pairs, proves the vertex map injective, applies pigeonhole on the finitely many colors to get an infinite fiber, and assembles the monochromatic set H = vertex '' {n | color n = c*}.",
       "mathContext": "$\\aleph_0 \\to (\\aleph_0)^r_k$ by induction on $r$: the diagonal argument reduces an $(r{+}1)$-coloring on an infinite set to an $r$-coloring on a subtype, iterating to a vertex/color sequence, then pigeonholes the colors into an infinite monochromatic subsequence."
     },
     {
       "id": "consequences",
       "title": "Section 5 — Consequences and Consistency Checks",
-      "startLine": 550,
-      "endLine": 594,
+      "startLine": 542,
+      "endLine": 586,
       "summary": "Derives corollaries of the conjecture and Ramsey theorem: erdos_1167_r2_case (the r=2 instantiation), erdos_1167_general_case (any r≥2), conjecture_consistent_aleph0 and ramsey_pairs/ramsey_triples_two_colors (consistency: ℵ₀ → (ℵ₀)²_k and ℵ₀ → (ℵ₀)³_2 hold by the proved infinite Ramsey theorem), and erdos_rado_weakened (weakening the Erdős-Rado target via partition_monotone_target). Closes the namespace.",
       "mathContext": "Concrete instances: $\\aleph_0 \\to (\\aleph_0)^2_k$ and $\\aleph_0 \\to (\\aleph_0)^3_2$ from infinite Ramsey; $(2^\\kappa)^+ \\to (\\kappa)^2_\\kappa$ by target monotonicity from Erdős–Rado."
     }


### PR DESCRIPTION
## Summary

Drift-repair pass on `erdos-1167` (stepping-down for partition relations). The 586-line Lean file's tail sections and two annotations had drifted after the ~300-line `infinite_ramsey` proof (Section 4) was inserted.

## What changed (ranges only — no prose edits)

**Sections:**
- Section 4 (Infinite Ramsey Theorem) 232–549 → **232–541** (was overshooting past the Section 5 banner at line 543)
- Section 5 (Consequences and Consistency Checks) 550–594 → **542–586** (started 7 lines late, overshot EOF by 8)

**Annotations** — two annotations describing Section-5 theorems (`erdos_1167_r2_case`, `erdos_1167_general_case`, `conjecture_consistent_aleph0`, `ramsey_pairs`, `erdos_rado_weakened`) still pointed at lines 246–291, stale from before the Ramsey proof was added:
- "The Open Conjecture and Known Results" 210–233 → **210–231**
- "Consequences of the Conjecture" 246–264 → **546–562**
- "Consistency Checks and Classical Ramsey Results" 266–291 → **563–586**

## Verification

JSON round-trips byte-identically (diff contains only startLine/endLine lines). All ranges within [1, 586], no overshoot, sections contiguous. Axiom status unchanged (`axiomatized`, 2 axioms). Note: the large Section 4 proof remains without a dedicated annotation — a coverage opportunity, not addressed here to keep this a clean range-repair.