### PR TITLE
Enrich: fix trailing line-range drift in 2 gallery entries

### DIFF
--- a/src/data/proofs/lebesgue-measure-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/lebesgue-measure-oq-01-oq-01-oq-02/meta.json
@@ -25,7 +25,7 @@
         "dateAdded": "2026-05-03",
         "mathlib_version": "4.31.0",
         "axiomCount": 0,
-        "lineCount": 240,
+        "lineCount": 230,
         "assumptions": "0 axioms, 0 sorries. Fully verified.",
         "theoremCount": 11,
         "originalContributions": [
@@ -48,7 +48,7 @@
             "Filter"
         ],
         "namespace": "LebesgueMeasureOQ01OQ01OQ02",
-        "lineCount": 240,
+        "lineCount": 230,
         "axiomCount": 0,
         "theoremCount": 11,
         "definitionCount": 1,
@@ -127,7 +127,7 @@
             "id": "iff",
             "title": "Part V: Characterization",
             "startLine": 224,
-            "endLine": 239,
+            "endLine": 230,
             "summary": "The biconditional thomae_continuous_iff: ContinuousAt thomae x ↔ Irrational x. Combines discontinuity (→ direction by contraposition) and continuity (← direction) into the complete characterization.",
             "mathContext": "$$\\text{ContinuousAt}\\, f\\, x \\iff x \\notin \\mathbb{Q}$$\nThe irrationals form a dense $G_\\delta$ set in $\\mathbb{R}$; Thomae's function witnesses that a function can be continuous on a dense set yet nowhere coincide with a continuous function."
         }

--- a/src/data/proofs/synthesis-curvature-ptolemy/meta.json
+++ b/src/data/proofs/synthesis-curvature-ptolemy/meta.json
@@ -54,7 +54,7 @@
     ],
     "dateAdded": "2026-04-26",
     "axiomCount": 0,
-    "lineCount": 361,
+    "lineCount": 349,
     "assumptions": "0 axioms. 0 sorries. All results are fully machine-verified. The hyperbolic Ptolemy theorem (K<0) is stated as a conjecture in comments only — it is NOT claimed as a theorem in this file.",
     "mathlib_version": "4.31.0",
     "parentProof": "ptolemys-theorem-oq-01-oq-02",
@@ -110,7 +110,7 @@
     {
       "title": "Hyperbolic Case Conjecture",
       "startLine": 320,
-      "endLine": 361,
+      "endLine": 349,
       "description": "Documents the K=-1 hyperbolic Ptolemy theorem as a conjecture, with a precise estimate of the Mathlib infrastructure needed: ~300 lines for Poincaré disk metric, ~400-500 for Möbius isometries, ~200 for circle-to-circle correspondence.",
       "summary": "Hyperbolic Ptolemy (K=-1): blocked by missing Poincaré disk infrastructure (~800-1200 lines)",
       "id": "hyperbolic-conjecture",
@@ -206,7 +206,7 @@
       "EuclideanGeometry"
     ],
     "namespace": null,
-    "lineCount": 361,
+    "lineCount": 349,
     "axiomCount": 0,
     "theoremCount": 12,
     "sorries": 0,


### PR DESCRIPTION
## Enrichment pass — line-range drift fix

**Work source:** section/lineCount line-range overshoot drift (single-file entries).

Final section `endLine` + both `lineCount` fields pointed past the true Lean file length:

| Entry | Stale | Actual |
|-------|-------|--------|
| `lebesgue-measure-oq-01-oq-01-oq-02` | 239 / 240 | 230 |
| `synthesis-curvature-ptolemy` | 361 | 349 |

Verified each file ends cleanly at its true line count. Line numbers only.

_Narrowed from 4 entries — `erdos-266` and `combinations-formula-oq-02` dropped to avoid duplicating concurrent PRs #39629 and #39636, which re-anchor both meta.json and annotations.json for those entries._