### PR TITLE
Enrich combinations-formula-oq-02: re-anchor sections & annotations to real declarations

### DIFF
--- a/src/data/proofs/combinations-formula-oq-02/annotations.json
+++ b/src/data/proofs/combinations-formula-oq-02/annotations.json
@@ -3,8 +3,8 @@
     "id": "ann-catalan-def",
     "proofId": "combinations-formula-oq-02",
     "range": {
-      "startLine": 42,
-      "endLine": 43
+      "startLine": 41,
+      "endLine": 45
     },
     "type": "definition",
     "title": "Catalan Number Definition",
@@ -25,7 +25,7 @@
     "proofId": "combinations-formula-oq-02",
     "range": {
       "startLine": 46,
-      "endLine": 72
+      "endLine": 65
     },
     "type": "concept",
     "title": "Initial Values C_0 through C_5",
@@ -45,8 +45,8 @@
     "id": "ann-absorption-identity",
     "proofId": "combinations-formula-oq-02",
     "range": {
-      "startLine": 80,
-      "endLine": 104
+      "startLine": 70,
+      "endLine": 95
     },
     "type": "concept",
     "title": "Absorption Identity for C(2n,n+1)",
@@ -67,8 +67,8 @@
     "id": "ann-fundamental-identity",
     "proofId": "combinations-formula-oq-02",
     "range": {
-      "startLine": 111,
-      "endLine": 119
+      "startLine": 97,
+      "endLine": 111
     },
     "type": "insight",
     "title": "Fundamental Identity: C_n(n+1) = C(2n,n)",
@@ -88,8 +88,8 @@
     "id": "ann-catalan-pos",
     "proofId": "combinations-formula-oq-02",
     "range": {
-      "startLine": 122,
-      "endLine": 129
+      "startLine": 112,
+      "endLine": 121
     },
     "type": "concept",
     "title": "Catalan Numbers Are Positive",
@@ -108,8 +108,8 @@
     "id": "ann-central-binom-bound",
     "proofId": "combinations-formula-oq-02",
     "range": {
-      "startLine": 154,
-      "endLine": 161
+      "startLine": 141,
+      "endLine": 153
     },
     "type": "insight",
     "title": "Central Binomial Coefficient Upper Bound: 4^n",
@@ -131,8 +131,8 @@
     "id": "ann-central-binom-lower",
     "proofId": "combinations-formula-oq-02",
     "range": {
-      "startLine": 165,
-      "endLine": 194
+      "startLine": 154,
+      "endLine": 189
     },
     "type": "concept",
     "title": "Central Binomial Lower Bound: 2^n",

--- a/src/data/proofs/combinations-formula-oq-02/meta.json
+++ b/src/data/proofs/combinations-formula-oq-02/meta.json
@@ -56,39 +56,39 @@
       "id": "catalan-def",
       "title": "Parts I-II: Catalan Numbers and Fundamental Identity",
       "startLine": 1,
-      "endLine": 115,
+      "endLine": 122,
       "summary": "Definition and initial values C_0 through C_5. Fundamental identity C_n(n+1) = C(2n,n) stated.",
       "mathContext": "$C_n = \\binom{2n}{n} - \\binom{2n}{n+1} = \\frac{1}{n+1}\\binom{2n}{n}$."
     },
     {
       "id": "central-binom",
       "title": "Parts III-IV: Central Binomial Coefficients and Bounds",
-      "startLine": 116,
-      "endLine": 195,
+      "startLine": 123,
+      "endLine": 190,
       "summary": "Central binomial values, 4^n upper bound, and catalan_le_four_pow.",
       "mathContext": "$\\binom{2n}{n} \\leq 4^n$ since $\\binom{2n}{n} \\leq \\sum_k \\binom{2n}{k} = 2^{2n}$."
     },
     {
       "id": "convolution",
       "title": "Part IV: Catalan Number Bounds",
-      "startLine": 196,
-      "endLine": 240,
+      "startLine": 191,
+      "endLine": 231,
       "summary": "Proves catalan_le_four_pow: C_n ≤ 4^n by case analysis for small n and via C_n ≤ C(2n,n) ≤ 4^n for large n. Includes the private lemma centralBinom_succ_eq and the step-lemma catalan_step (C_n ≤ C_{n+1}) used for monotonicity.",
       "mathContext": "$C_n \\leq \\binom{2n}{n} \\leq 4^n$. The first inequality: $C_n = \\binom{2n}{n} - \\binom{2n}{n+1} \\leq \\binom{2n}{n}$. The second: $\\binom{2n}{n} \\leq 4^n$ since the central term of $(1+1)^{2n} = 4^n$ is the largest."
     },
     {
       "id": "monotonicity-tables",
       "title": "Part V: Monotonicity and Tabulated Values",
-      "startLine": 241,
-      "endLine": 280,
+      "startLine": 232,
+      "endLine": 260,
       "summary": "Proves catalan_mono (C_m ≤ C_n for m ≤ n) by induction using catalan_step. Tabulates the first six Catalan numbers (C_0=1,...,C_5=42) and first four central binomial coefficients (C(0,0)=1,...,C(6,3)=20) as a reference table.",
       "mathContext": "$C_n$ is non-decreasing: $C_m \\leq C_n$ for $m \\leq n$. First values: $C_0=1, C_1=1, C_2=2, C_3=5, C_4=14, C_5=42$. Central binomials: $\\binom{0}{0}=1, \\binom{2}{1}=2, \\binom{4}{2}=6, \\binom{6}{3}=20$."
     },
     {
       "id": "convolution-identity",
       "title": "Part VI: The Catalan Convolution Identity",
-      "startLine": 281,
-      "endLine": 312,
+      "startLine": 261,
+      "endLine": 302,
       "summary": "Proves the fundamental Catalan convolution: C_{n+1} = ∑_{k=0}^{n} C_k·C_{n-k}. The proof bridges to Mathlib's _root_.catalan via the characterizing identity C_n*(n+1) = C(2n,n), then applies catalan_succ' from Mathlib. Verifies the identity for C_1=1, C_2=2, C_3=5.",
       "mathContext": "$C_{n+1} = \\sum_{k=0}^n C_k \\cdot C_{n-k}$. Combinatorial meaning: to fully parenthesize $n+2$ factors, choose position $k+1$ for the outermost multiplication, then independently parenthesize left ($C_k$ ways) and right ($C_{n-k}$ ways) factors."
     }


### PR DESCRIPTION
## Summary

Drift-repair pass on `combinations-formula-oq-02` (Catalan numbers & central binomial coefficients, status `verified`). The 302-line Lean file has a clean Part I–VI banner structure, but all 5 sections and all 7 annotations had drifted ~10 lines, and the final section overshot EOF (`281–312 > 302`).

## What changed (ranges only — no prose edits)

**Sections** aligned to the `## Part …` banners:
- Parts I–II 1–115 → **1–122**
- Parts III–IV (Central Binomial) 116–195 → **123–190**
- Part IV (Catalan Bounds) 196–240 → **191–231**
- Part V (Monotonicity & Tables) 241–280 → **232–260**
- Part VI (Convolution Identity) 281–312 → **261–302**

**Annotations** re-anchored to their docComment..declaration spans — e.g. `choose_2n_succ` 80→**70–95**, `catalan_mul_succ` 111→**97–111**, `centralBinom_le_four_pow` 154→**141–153**, `centralBinom_ge_two_pow` 165→**154–189**.

## Verification

Diff contains only startLine/endLine changes (matched original trailing-newline style). All ranges within [1, 302], no overshoot. Status unchanged (`verified`, 0 axioms, 0 sorries).