### PR TITLE
Enrich: fix trailing line-range drift in 4 more gallery entries

### DIFF
--- a/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-01-oq-04-wip-01/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-01-oq-04-wip-01/meta.json
@@ -20,7 +20,7 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 1,
-    "lineCount": 306,
+    "lineCount": 279,
     "assumptions": "1 axiom: nonderogatory_similar_to_companion (nonderogatory matrix is similar to its companion matrix). NOTE (audit 2026-04-27): the PID structure theorem IS in Mathlib (Module.equiv_directSum_of_isTorsion, Module.equiv_free_prod_directSum at Mathlib.Algebra.Module.PID), and Module.exists_ker_toSpanSingleton_eq_annihilator combined with Module.AEval' (Mathlib.Algebra.Polynomial.Module.AEval) directly gives a cyclic vector for nonderogatory matrices without needing similarity to a companion matrix at all. The remaining work is bridging code, not a missing structure theorem.",
     "mathlib_version": "4.31.0",
     "mathlibDependencies": [
@@ -120,7 +120,7 @@
       "id": "main-theorem",
       "title": "VI. Main Theorem and Corollary",
       "startLine": 248,
-      "endLine": 290,
+      "endLine": 279,
       "summary": "Proves nonderogatory_has_cyclic_vector_any_field (over any field) and the corollary for finite fields by combining: companion cyclic vector (proved), similarity (axiom), and transfer (proved).",
       "mathContext": "For n > 0: companionMat(charpoly M) has e0 as a cyclic vector (Section IV); M is similar to it (axiom); similarity transfers cyclic vectors (Section V). Therefore M has a cyclic vector. The finite-field corollary removes the [Infinite K] hypothesis from the parent file's approach."
     }
@@ -164,7 +164,7 @@
       "BigOperators"
     ],
     "namespace": "CompanionCyclicVector",
-    "lineCount": 306,
+    "lineCount": 279,
     "axiomCount": 1,
     "theoremCount": 11,
     "definitionCount": 3,

--- a/src/data/proofs/navier-stokes-existence/meta.json
+++ b/src/data/proofs/navier-stokes-existence/meta.json
@@ -63,7 +63,7 @@
     ],
     "dateAdded": "2026-03-14",
     "relatedProblems": [],
-    "lineCount": 21110,
+    "lineCount": 21090,
     "mathlib_version": "4.31.0",
     "theoremCount": 845,
     "definitionCount": 366
@@ -215,7 +215,7 @@
       "title": "Helicity, Pressure, Liouville Theorems",
       "summary": "Parts XXXVIII-XL: Helicity conservation and Beltrami flows, pressure estimates via Calderon-Zygmund, KNSS Liouville theorem, Seregin zero theorem, Landau solution, millennium connection.",
       "startLine": 6663,
-      "endLine": 21110,
+      "endLine": 21090,
       "mathContext": "Helicity: $H(t) = \\int u \\cdot \\omega\\,dx$ conserved for inviscid flow. Beltrami: $\\omega = \\lambda u$ (eigenvectors of curl). Pressure: $-\\Delta p = \\partial_i \\partial_j (u_i u_j)$, with $\\|p\\|_{L^{3/2}} \\leq C\\|u\\|_{L^3}^2$ via Calderon-Zygmund. KNSS Liouville: bounded ancient solutions in $L^{9/2}$ are zero."
     }
   ],
@@ -266,7 +266,7 @@
       "TwoDimensionalGlobal"
     ],
     "namespace": "NavierStokesRegularity",
-    "lineCount": 21110,
+    "lineCount": 21090,
     "axiomCount": 0,
     "theoremCount": 845,
     "definitionCount": 366,

--- a/src/data/proofs/navier-stokes-oq-01/meta.json
+++ b/src/data/proofs/navier-stokes-oq-01/meta.json
@@ -60,7 +60,7 @@
       "Theorem total_dissipation_bound: ∫₀ᵀ 2νP(t) dt ≤ E(0), total dissipation bounded by initial enstrophy"
     ],
     "dateAdded": "2026-02-26",
-    "lineCount": 21110,
+    "lineCount": 21090,
     "assumptions": "Relies on `Lean.ofReduceBool`. The analytic core — the quantitative enstrophy decay bound E(t) ≤ E(s)·exp(-2νμ₁(t-s)) and the integrated energy identity (FTC applied to the enstrophy ODE) — is kernel-checked and axiom-free. However, the Sobolev/Lions-threshold classification theorems `lions_3d`, `lions_2d`, `critical_at_lions_is_zero`, `standard_ns_gap`, and `standard_2d_gap` are discharged by `native_decide`, which trusts the Lean compiler's kernel reduction and so depends on the `Lean.ofReduceBool` axiom (it appears under `#print axioms` for those theorems; these are rational-arithmetic facts that could alternatively be closed by kernel `decide`/`norm_num`). `leanFile.axiomCount` remains 0 because there are no literal `axiom` declarations.",
     "relatedProblems": [
       {
@@ -132,7 +132,7 @@
       "id": "dissipation-formula",
       "title": "Enstrophy Dissipation Formula and Total Bound",
       "startLine": 2639,
-      "endLine": 21110,
+      "endLine": 21090,
       "summary": "enstrophy_dissipation_formula: E(0) - E(T) = ∫₀ᵀ 2νP dt (enstrophy decrease = integrated dissipation). total_dissipation_bound: ∫₀ᵀ 2νP ≤ E(0) (cumulative dissipation bounded by initial enstrophy)."
     }
   ],
@@ -183,7 +183,7 @@
       "TwoDimensionalGlobal"
     ],
     "namespace": "NavierStokesRegularity",
-    "lineCount": 21110,
+    "lineCount": 21090,
     "axiomCount": 0,
     "theoremCount": 845,
     "definitionCount": 366,

--- a/src/data/proofs/partition-theorem-oq-01/meta.json
+++ b/src/data/proofs/partition-theorem-oq-01/meta.json
@@ -56,7 +56,7 @@
     "mathlib_version": "4.31.0",
     "axioms": 4,
     "axiomCount": 4,
-    "lineCount": 3552,
+    "lineCount": 3541,
     "assumptions": "4 assumptions. (1) Three axiom declarations — rogers_ramanujan_first, rogers_ramanujan_second, schur_partition_identity_corrected — the deep Rogers-Ramanujan and Schur cardinality identities, which require q-series (Jacobi triple product) or bijective machinery not yet in Mathlib. (2) Lean.ofReduceBool: the computational-verification contributions (24 native_decide examples for n=0..7, 60+ for n=0..12) and 16 named concrete count/strict-subset theorems (rr1_count_*, schur_count_*, *_strict_subset_*_n, schurGapFull_ne_schurGap_9) are discharged via native_decide, which trusts the Lean compiler's kernel reduction and so adds the Lean.ofReduceBool axiom (#print axioms lists it). The ~140 structural containment/monotonicity theorems are native_decide-free (omega/Pairwise reasoning). leanFile.axiomCount remains 3 (literal axiom declarations only). See Lean source for complete statements.",
     "theoremCount": 143,
     "definitionCount": 40
@@ -164,7 +164,7 @@
       "title": "Containment Hierarchy and Euler Connection",
       "summary": "Proves the containment hierarchy for partition counts: $|\\text{Schur gap}| \\leq |\\text{RR1 gap}| \\leq |\\text{distinct}|$ and $|\\text{RR2 gap}| \\leq |\\text{RR1 gap}|$. Connects to Euler's partition theorem (distinct $=$ odd) to place RR1 gap partitions in context. Verifies concrete counts: for $n=5$, RR1 gap has 2 partitions while distinct has 3.",
       "startLine": 402,
-      "endLine": 3552,
+      "endLine": 3541,
       "mathContext": "Proves the containment hierarchy for partition counts: $|\\text{Schur gap}| \\leq |\\text{RR1 gap}| \\leq |\\text{distinct}|$ and $|\\text{RR2 gap}| \\leq |\\text{RR1 gap}|$. Connects to Euler's partition theorem (distinct $=$ odd) to place RR1 gap partitions in context. Verifies concrete counts: for $n=5$, RR1 gap has 2 partitions while distinct has 3."
     }
   ],
@@ -249,7 +249,7 @@
       "PowerSeries"
     ],
     "namespace": "RogersRamanujan",
-    "lineCount": 3552,
+    "lineCount": 3541,
     "axiomCount": 3,
     "theoremCount": 143,
     "definitionCount": 40,


### PR DESCRIPTION
## Enrichment pass — batch line-range drift fix (round 2)

**Work source:** section/lineCount line-range overshoot drift (single-file entries).

Each entry's **final section `endLine`** and both **`lineCount`** fields pointed past the true Lean file length (files trimmed, metadata not updated):

| Entry | Stale | Actual |
|-------|-------|--------|
| `partition-theorem-oq-01` | 3552 | 3541 |
| `cayley-hamilton-minpoly-oq-05-oq-01-oq-04-wip-01` | 306 / 290 | 279 |
| `navier-stokes-oq-01` | 21110 | 21090 |
| `navier-stokes-existence` | 21110 | 21090 |

`navier-stokes-oq-01` and `navier-stokes-existence` both index `Proofs/NavierStokes.lean` (21090 lines). Verified each file ends cleanly at its true line count (`end <Namespace>`). All other sections already within bounds — line numbers only.