### PR TITLE
Enrich: fix trailing line-range drift in 3 more gallery entries

### DIFF
--- a/src/data/proofs/basel-problem-oq-01-oq-01-oq-02-oq-03/meta.json
+++ b/src/data/proofs/basel-problem-oq-01-oq-01-oq-02-oq-03/meta.json
@@ -19,7 +19,7 @@
       "Nat"
     ],
     "namespace": "BaselProblemOQ01OQ01OQ02OQ03",
-    "lineCount": 1802,
+    "lineCount": 1794,
     "axiomCount": 1,
     "theoremCount": 77,
     "definitionCount": 1,
@@ -42,7 +42,7 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 1,
-    "lineCount": 1802,
+    "lineCount": 1794,
     "theoremCount": 77,
     "definitionCount": 1,
     "assumptions": "Axiomatized: hanson_bound — for all n, lcm(1,...,n) ≤ 3^n. Numerically verified for n ∈ {1..10, 12, 15, 20} via decide/native_decide. Hanson's original 1972 proof uses Beta-integral identities and Chebyshev-style prime-power bounds; neither is in Mathlib. Provable easier bounds (lcm | n!, lcm ≤ n!, lcm ≤ n^n) are included with no axioms.",
@@ -195,7 +195,7 @@
       "id": "hanson-axiom",
       "title": "Part 5: Hanson's Bound (Axiom + Sharpness Check)",
       "startLine": 1772,
-      "endLine": 1802,
+      "endLine": 1794,
       "summary": "`axiom hanson_bound : ∀ n, lcmRange n ≤ 3^n` is the precise open Lean target — Hanson's classical 1972 theorem. The docstring documents the two known strategies: Hanson's original integral identity (Beta integrals + Chebyshev-style prime-power bounds) and Erdős's / Nair's combinatorial identities. `hanson_strictly_stronger_than_factorial` (3^n < n^n for n ≥ 4) is the sharpness check: the axiomatized constant 3 is genuinely tighter than the trivial Part 3 bound n^n, justifying why the axiom is non-redundant.",
       "mathContext": "Hanson 1972: $\\operatorname{lcm}(1, \\ldots, n) \\le 3^n$. Original proof (Hanson, *Canad. Math. Bull.* 15) uses the integer-valued integral identity $\\operatorname{lcm}(1, \\ldots, n) \\cdot \\int_0^1 x^k (1-x)^{n-k}\\,\\mathrm{d}x = \\frac{\\operatorname{lcm}(1, \\ldots, n)}{(n+1)\\binom{n}{k}} \\in \\mathbb{Z}$ combined with Chebyshev-style upper bounds on prime-power contributions. The constant $3$ sits between the asymptotic $e \\approx 2.718$ (PNT-implied) and Apéry's irrationality threshold $\\approx 3.245$ — hence 'smallest constant with an elementary proof'."
     }

--- a/src/data/proofs/prime-gap-bounds-oq-01/meta.json
+++ b/src/data/proofs/prime-gap-bounds-oq-01/meta.json
@@ -57,7 +57,7 @@
     ],
     "dateAdded": "2026-04-12",
     "axiomCount": 3,
-    "lineCount": 288,
+    "lineCount": 280,
     "prerequisites": [
       "Prime Number Theorem (axiomatized)",
       "Properties of the natural logarithm",
@@ -141,7 +141,7 @@
       "id": "summary",
       "title": "Summary",
       "startLine": 254,
-      "endLine": 288,
+      "endLine": 280,
       "summary": "Documentation footer (## Summary): lists the 3 axioms (nth_prime_asymptotic, dusart_upper_bound, dusart_lower_bound), the 7 proved theorems, the improvement chain Bertrand -> PNT -> Dusart, and confirms the axiom count of 3.",
       "mathContext": "No new declarations; a prose recap of the axiom/theorem inventory and the bound-improvement chain $p_n \\le 2^{n+1}$ (Bertrand) $\\to p_n \\sim n\\ln n$ (PNT) $\\to$ explicit Dusart sandwich."
     }
@@ -194,7 +194,7 @@
       "Nat"
     ],
     "namespace": "DusartBounds",
-    "lineCount": 288,
+    "lineCount": 280,
     "axiomCount": 3,
     "theoremCount": 9,
     "definitionCount": 0,


### PR DESCRIPTION
## Enrichment pass — batch line-range drift fix (round 3)

**Work source:** section/lineCount line-range overshoot drift (single-file entries).

Final section `endLine` + both `lineCount` fields pointed past the true Lean file length:

| Entry | Stale | Actual |
|-------|-------|--------|
| `prime-gap-bounds-oq-01` | 288 | 280 |
| `erdos-199` | 174 | 166 |
| `basel-problem-oq-01-oq-01-oq-02-oq-03` | 1802 | 1794 |

Verified each file ends cleanly at its true line count (`end <Namespace>`). All other sections within bounds — line numbers only.