### PR TITLE
Enrich erdos-199: re-anchor sections & annotations to real declarations

### DIFF
--- a/src/data/proofs/erdos-199/annotations.json
+++ b/src/data/proofs/erdos-199/annotations.json
@@ -28,7 +28,7 @@
     "proofId": "erdos-199",
     "range": {
       "startLine": 42,
-      "endLine": 44
+      "endLine": 45
     },
     "type": "definition",
     "title": "3-Term Arithmetic Progression",
@@ -95,7 +95,7 @@
     "proofId": "erdos-199",
     "range": {
       "startLine": 52,
-      "endLine": 54
+      "endLine": 55
     },
     "type": "definition",
     "title": "Contains Infinite AP",
@@ -117,7 +117,7 @@
     "proofId": "erdos-199",
     "range": {
       "startLine": 62,
-      "endLine": 64
+      "endLine": 65
     },
     "type": "definition",
     "title": "Erdős's Conjecture",
@@ -138,8 +138,8 @@
     "id": "ann-199-baumgartner",
     "proofId": "erdos-199",
     "range": {
-      "startLine": 73,
-      "endLine": 83
+      "startLine": 74,
+      "endLine": 77
     },
     "type": "concept",
     "title": "Baumgartner's Partition (1975)",
@@ -161,8 +161,8 @@
     "id": "ann-199-disproved",
     "proofId": "erdos-199",
     "range": {
-      "startLine": 91,
-      "endLine": 99
+      "startLine": 84,
+      "endLine": 93
     },
     "type": "concept",
     "title": "Conjecture Disproved",
@@ -183,8 +183,8 @@
     "id": "ann-199-main",
     "proofId": "erdos-199",
     "range": {
-      "startLine": 101,
-      "endLine": 103
+      "startLine": 94,
+      "endLine": 97
     },
     "type": "concept",
     "title": "Main Result",
@@ -205,8 +205,8 @@
     "id": "ann-199-vdw",
     "proofId": "erdos-199",
     "range": {
-      "startLine": 114,
-      "endLine": 118
+      "startLine": 107,
+      "endLine": 108
     },
     "type": "concept",
     "title": "Van der Waerden's Theorem",
@@ -228,8 +228,8 @@
     "id": "ann-199-example-nat",
     "proofId": "erdos-199",
     "range": {
-      "startLine": 127,
-      "endLine": 138
+      "startLine": 116,
+      "endLine": 119
     },
     "type": "concept",
     "title": "Example: ℕ Has 3-APs",
@@ -250,8 +250,8 @@
     "id": "ann-199-example-rat",
     "proofId": "erdos-199",
     "range": {
-      "startLine": 140,
-      "endLine": 150
+      "startLine": 121,
+      "endLine": 131
     },
     "type": "concept",
     "title": "Example: ℚ Contains Infinite APs",

--- a/src/data/proofs/erdos-199/meta.json
+++ b/src/data/proofs/erdos-199/meta.json
@@ -92,35 +92,35 @@
       "id": "baumgartner",
       "title": "Baumgartner's Counterexample",
       "startLine": 66,
-      "endLine": 84,
+      "endLine": 77,
       "summary": "The partition axiom and counterexample existence"
     },
     {
       "id": "main-result",
       "title": "Main Result",
-      "startLine": 85,
-      "endLine": 104,
+      "startLine": 78,
+      "endLine": 97,
       "summary": "Proof that Erdős's conjecture is false"
     },
     {
       "id": "related-results",
       "title": "Related Results",
-      "startLine": 105,
-      "endLine": 119,
+      "startLine": 98,
+      "endLine": 108,
       "summary": "Van der Waerden's theorem and connections to Ramsey theory"
     },
     {
       "id": "examples",
       "title": "Examples",
-      "startLine": 116,
-      "endLine": 140,
+      "startLine": 109,
+      "endLine": 132,
       "summary": "Concrete examples with naturals and rationals"
     },
     {
       "id": "summary",
       "title": "Summary",
-      "startLine": 142,
-      "endLine": 174,
+      "startLine": 133,
+      "endLine": 166,
       "summary": "Complete statement of the disproved result"
     }
   ],


### PR DESCRIPTION
## Summary

Drift-repair pass on `erdos-199` (Baumgartner's disproof of Erdős's 3-AP-complement conjecture). The 166-line Lean file has clean Part I–VII banners, but all 7 sections and most annotations had drifted, with the Summary section overshooting EOF (`142–174 > 166`).

## What changed (ranges only — no prose edits)

**Sections** aligned to the `## Part …` banners:
- Basic Definitions 36–55, Erdős's Conjecture 56–65, Baumgartner 66–84→**66–77**, Main Result 85–104→**78–97**, Related Results 105–119→**98–108**, Examples 116–140→**109–132**, Summary 142–174→**133–166**.

**Annotations** re-anchored to their declarations — e.g. `erdos_199_disproved` 91→**84–93**, `erdos_199` 101→**94–97**, "Van der Waerden's Theorem" 114→**107–108** (the actual VdW prose), example blocks 127→**116–119** and 140→**121–131**.

## Verification

Diff contains only startLine/endLine changes. All ranges within [1, 166], no overshoot. Axiom status unchanged (`axiomatized`, 1 axiom `baumgartner_3AP_free`).