### PR TITLE
fix(proofs): repair never-compiled Erdos719Problem (#39077)

### DIFF
--- a/proofs/Proofs/Erdos719Problem.lean
+++ b/proofs/Proofs/Erdos719Problem.lean
@@ -492,10 +492,12 @@ theorem turanHypergraph_graph_le (n : ℕ) :
   · -- For each clique-free H, show H.edges.card ≤ n²/4
     rintro m ⟨H, hcf, rfl⟩
     -- Bridge: build a SimpleGraph with the same edge structure
-    let G : SimpleGraph (Fin n) where
-      Adj v w := ({v, w} : Finset (Fin n)) ∈ H.edges
-      symm := fun h => by rwa [Finset.pair_comm]
-      loopless v h := by have := H.uniform _ h; simp at this
+    let G : SimpleGraph (Fin n) := SimpleGraph.mk
+      (fun v w => ({v, w} : Finset (Fin n)) ∈ H.edges)
+      ⟨fun v w (h : ({v, w} : Finset (Fin n)) ∈ H.edges) =>
+        (Finset.pair_comm v w ▸ h : ({w, v} : Finset (Fin n)) ∈ H.edges)⟩
+      ⟨fun v (h : ({v, v} : Finset (Fin n)) ∈ H.edges) => by
+        have := H.uniform _ h; simp at this⟩
     haveI : DecidableRel G.Adj := fun v w => Finset.decidableMem _ _
     -- G is triangle-free (CliqueFree 3)
     have hcf3 : G.CliqueFree 3 := by
@@ -511,9 +513,9 @@ theorem turanHypergraph_graph_le (n : ℕ) :
     have h_sub : H.edges ⊆ G.edgeFinset.image Sym2.toFinset := by
       intro e he
       obtain ⟨v, w, _, rfl⟩ := Finset.card_eq_two.mp (H.uniform e he)
-      exact Finset.mem_image.mpr ⟨s(v, w),
-        SimpleGraph.mem_edgeFinset.mpr (SimpleGraph.mem_edgeSet.mpr he),
-        Sym2.toFinset_mk_eq⟩
+      refine Finset.mem_image.mpr ⟨s(v, w), ?_, Sym2.toFinset_mk_eq⟩
+      rw [SimpleGraph.mem_edgeFinset]
+      exact he
     -- Chain: |H.edges| ≤ |image| ≤ |G.edgeFinset| ≤ n²/4
     calc H.edges.card
         ≤ (G.edgeFinset.image Sym2.toFinset).card := Finset.card_le_card h_sub


### PR DESCRIPTION
Repairs `Proofs/Erdos719Problem.lean` (Erdős–Sauer / graph Turán number), one of the 28 never-compiled entries tracked by #39077. The `:H.edges` autoImplicit marker traced to a broken `SimpleGraph` bridge inside `turanHypergraph_graph_le` that only "type-checked" under the old `autoImplicit true` default.

## Defects fixed (all in `turanHypergraph_graph_le`)
1. **Invalid `let … where` structure syntax** — `let G : SimpleGraph (Fin n) where …` is not valid term syntax; under autoImplicit the trailing fields were swallowed (parse cascade: `internal exception #3`, `unexpected token 'haveI'`). Rebuilt via `SimpleGraph.mk`.
2. **v4.31 field-type drift** — `SimpleGraph.symm`/`loopless` are now `Std.Symm`/`Std.Irrefl` **classes** (not bare `Symmetric`/`Irreflexive` props). Supplied each as a one-field anonymous constructor (`⟨fun a b h => …⟩` for `symm : ∀ a b, r a b → r b a`).
3. **`SimpleGraph.mem_edgeSet.mpr`** failed to resolve; since `mem_edgeSet` is `Iff.rfl` (`s(v,w) ∈ G.edgeSet ≡ G.Adj v w`), replaced with a `mem_edgeFinset` rewrite + `exact he` by defeq.

## Evidence
Host-verified (Mathlib-only imports, no Docker):
```
$ lake env lean Proofs/Erdos719Problem.lean
EXIT=0     # 0 errors
```
Before: 8 errors (`unknownIdentifier H.edges`/`H.uniform`, `internal exception #3`, `unexpected token 'haveI'`, kernel `unknown constant turanHypergraph_graph_le`, …).

0 sorries. Sole `axiom` is the open `erdos_sauer_conjecture` — gallery meta already honestly `axiomatized`/`axiom` with `axiomCount 1`, so no meta change needed.

Part of #39077.