### PR TITLE
Enrich hilbert-15: re-anchor all sections & annotations to real declarations

### DIFF
--- a/src/data/proofs/hilbert-15/annotations.json
+++ b/src/data/proofs/hilbert-15/annotations.json
@@ -3,8 +3,8 @@
     "id": "ann-intro",
     "proofId": "hilbert-15",
     "range": {
-      "startLine": 9,
-      "endLine": 62
+      "startLine": 3,
+      "endLine": 58
     },
     "type": "concept",
     "title": "Hilbert's 15th Problem — Historical Introduction",
@@ -27,8 +27,8 @@
     "id": "ann-grassmannian",
     "proofId": "hilbert-15",
     "range": {
-      "startLine": 73,
-      "endLine": 105
+      "startLine": 87,
+      "endLine": 99
     },
     "type": "definition",
     "title": "The Grassmannian Gr(k,n)",
@@ -51,8 +51,8 @@
     "id": "ann-lines",
     "proofId": "hilbert-15",
     "range": {
-      "startLine": 106,
-      "endLine": 142
+      "startLine": 118,
+      "endLine": 154
     },
     "type": "theorem",
     "title": "Lines in Projective 3-Space",
@@ -75,8 +75,8 @@
     "id": "ann-four-lines",
     "proofId": "hilbert-15",
     "range": {
-      "startLine": 143,
-      "endLine": 218
+      "startLine": 184,
+      "endLine": 230
     },
     "type": "concept",
     "title": "The Four Lines Theorem",
@@ -99,8 +99,8 @@
     "id": "ann-numbers",
     "proofId": "hilbert-15",
     "range": {
-      "startLine": 219,
-      "endLine": 250
+      "startLine": 252,
+      "endLine": 262
     },
     "type": "concept",
     "title": "Famous Schubert Numbers",
@@ -122,8 +122,8 @@
     "id": "ann-schubert-classes",
     "proofId": "hilbert-15",
     "range": {
-      "startLine": 251,
-      "endLine": 302
+      "startLine": 285,
+      "endLine": 314
     },
     "type": "definition",
     "title": "Schubert Varieties and Classes",
@@ -146,8 +146,8 @@
     "id": "ann-lr-rule",
     "proofId": "hilbert-15",
     "range": {
-      "startLine": 303,
-      "endLine": 356
+      "startLine": 337,
+      "endLine": 368
     },
     "type": "concept",
     "title": "Littlewood-Richardson Rule",
@@ -170,8 +170,8 @@
     "id": "ann-computation",
     "proofId": "hilbert-15",
     "range": {
-      "startLine": 357,
-      "endLine": 398
+      "startLine": 391,
+      "endLine": 410
     },
     "type": "concept",
     "title": "Four Lines via Schubert Calculus Computation",
@@ -192,8 +192,8 @@
     "id": "ann-status",
     "proofId": "hilbert-15",
     "range": {
-      "startLine": 399,
-      "endLine": 453
+      "startLine": 412,
+      "endLine": 447
     },
     "type": "concept",
     "title": "Problem Status and Summary",

--- a/src/data/proofs/hilbert-15/meta.json
+++ b/src/data/proofs/hilbert-15/meta.json
@@ -74,74 +74,74 @@
     {
       "id": "docstring",
       "title": "Module Docstring",
-      "startLine": 9,
-      "endLine": 74,
+      "startLine": 1,
+      "endLine": 67,
       "summary": "Historical exposition of Schubert's enumerative calculus (1879), Hilbert's request for rigor (1900), and the 20th-century resolution via intersection theory, Schubert classes, and Littlewood-Richardson coefficients."
     },
     {
       "id": "grassmannian",
       "title": "Part I: The Grassmannian",
-      "startLine": 75,
-      "endLine": 107,
+      "startLine": 68,
+      "endLine": 100,
       "summary": "Defines Grassmannian k n K as the subtype {V : Submodule K (Fin n → K) // finrank K V = k}, with CoeSort instance and grassmannian_rank theorem.",
       "mathContext": "$\\text{Gr}(k, n) = \\{V \\leq K^n : \\dim V = k\\}$. Dimension: $\\dim \\text{Gr}(k,n) = k(n-k)$."
     },
     {
       "id": "lines-in-p3",
       "title": "Part II: Lines in P³",
-      "startLine": 108,
-      "endLine": 162,
+      "startLine": 101,
+      "endLine": 155,
       "summary": "Defines LineInP3 as Gr(2,4), SubspacesMeet (V ⊓ W ≠ ⊥), LinesMeet, LinesMeet' (finrank of span < 4), and proves their equivalence via the Grassmann dimension formula."
     },
     {
       "id": "four-lines",
       "title": "Part III: The Four Lines Theorem",
-      "startLine": 163,
-      "endLine": 238,
+      "startLine": 156,
+      "endLine": 231,
       "summary": "Defines FourLinesGeneralPosition (no two meet), IsTransversal (meets all four), Transversals (the set), and axiomatizes exactly 2 transversals via both existential and ncard formulations.",
       "mathContext": "Four lines in general position in $\\mathbb{P}^3$: exactly 2 lines meet all four. Schubert computation: $\\sigma_1^4 = 2\\sigma_{22}$ in $H^*(\\text{Gr}(2,4))$."
     },
     {
       "id": "schubert-numbers",
       "title": "Part IV: Classical Schubert Numbers",
-      "startLine": 239,
-      "endLine": 270,
+      "startLine": 232,
+      "endLine": 263,
       "summary": "Records schubertNumber_FourLines = 2, schubertNumber_CubicSurface = 27, schubertNumber_FiveConics = 3264, schubertNumber_FivePoints = 1 as ℕ constants.",
       "mathContext": "Classical enumerative results: 2 lines meet 4 general lines, 27 lines on a cubic surface, 3264 conics tangent to 5 conics (Steiner's corrected count)."
     },
     {
       "id": "schubert-varieties",
       "title": "Part V: Schubert Varieties and Classes",
-      "startLine": 271,
-      "endLine": 322,
+      "startLine": 264,
+      "endLine": 315,
       "summary": "Defines Partition (weakly decreasing list), fitsIn (k × (n-k) box), SchubertClass, and axiomatizes the Schubert basis theorem (bijection with fitting partitions, distinctness)."
     },
     {
       "id": "lr-rule",
       "title": "Part VI: Littlewood-Richardson Rule",
-      "startLine": 323,
-      "endLine": 376,
+      "startLine": 316,
+      "endLine": 369,
       "summary": "Axiomatizes littlewoodRichardsonCoeff, littlewood_richardson_rule (expansion exists with correct partition sizes), and pieris_rule (special case for single-row partitions)."
     },
     {
       "id": "four-lines-schubert",
       "title": "Part VII: Four Lines via Schubert Calculus",
-      "startLine": 377,
-      "endLine": 418,
+      "startLine": 370,
+      "endLine": 411,
       "summary": "Defines partition_1 and partition_22, axiomatizes sigma1_fourth_power (LR coefficient = 2), and proves four_lines_via_schubert by rfl."
     },
     {
       "id": "status",
       "title": "Part VIII: Problem Status",
-      "startLine": 419,
-      "endLine": 456,
+      "startLine": 412,
+      "endLine": 449,
       "summary": "Documents the resolution timeline (1930s-1984) and summarizes the answer with hilbert_15_statement."
     },
     {
       "id": "exports",
       "title": "Exports",
-      "startLine": 457,
-      "endLine": 470,
+      "startLine": 450,
+      "endLine": 463,
       "summary": "#check verifies all major exports: Grassmannian, LineInP3, LinesMeet, four_lines_theorem, transversal_count, schubertNumber_FourLines, SchubertClass, schubert_basis_theorem, littlewood_richardson_rule, four_lines_via_schubert."
     }
   ],


### PR DESCRIPTION
## Summary

Drift-repair pass on `hilbert-15` (Schubert enumerative calculus). The 463-line Lean file has 10 decorated `/-! ═══ … ═══ -/` Part banners, but all 10 sections and all 9 annotations had drifted ~7 lines uniformly, with the Exports section overshooting EOF (`457–470 > 463`).

## What changed (ranges only — no prose edits)

**Sections** aligned to the banner boundaries: Module Docstring **1–67**, Part I **68–100**, Part II **101–155**, Part III **156–231**, Part IV **232–263**, Part V **264–315**, Part VI **316–369**, Part VII **370–411**, Part VIII **412–449**, Exports **450–463**.

**Annotations** re-anchored to each Part's declaration cluster — e.g. Grassmannian **87–99**, Four Lines Theorem axioms **184–230**, Schubert numbers **252–262**, LR rule **337–368**, four-lines-via-Schubert **391–410**.

## Verification

Diff contains only startLine/endLine changes (trailing-newline styles preserved per file). All ranges within [1, 463], no overshoot. Axiom status unchanged (`axiomatized`, 7 axioms).