### PR TITLE
Enrich erdos-552: re-anchor sections & annotations to real declarations

### DIFF
--- a/src/data/proofs/erdos-552/annotations.json
+++ b/src/data/proofs/erdos-552/annotations.json
@@ -3,8 +3,8 @@
     "id": "ann-552-graphs",
     "proofId": "erdos-552",
     "range": {
-      "startLine": 38,
-      "endLine": 57
+      "startLine": 40,
+      "endLine": 63
     },
     "type": "definition",
     "title": "Graph Definitions: C_4 and Star Graph S_n",
@@ -27,8 +27,8 @@
     "id": "ann-552-ramsey",
     "proofId": "erdos-552",
     "range": {
-      "startLine": 59,
-      "endLine": 81
+      "startLine": 64,
+      "endLine": 76
     },
     "type": "definition",
     "title": "Ramsey Number R(C_4, S_n) Definition",
@@ -51,8 +51,8 @@
     "id": "ann-552-bounds",
     "proofId": "erdos-552",
     "range": {
-      "startLine": 83,
-      "endLine": 101
+      "startLine": 77,
+      "endLine": 96
     },
     "type": "concept",
     "title": "Known Bounds: Parsons Upper and BEFRS Lower",
@@ -75,8 +75,8 @@
     "id": "ann-552-exact",
     "proofId": "erdos-552",
     "range": {
-      "startLine": 103,
-      "endLine": 119
+      "startLine": 97,
+      "endLine": 114
     },
     "type": "concept",
     "title": "Exact Values for Prime Power Parameters",
@@ -99,8 +99,8 @@
     "id": "ann-552-question",
     "proofId": "erdos-552",
     "range": {
-      "startLine": 121,
-      "endLine": 134
+      "startLine": 115,
+      "endLine": 129
     },
     "type": "concept",
     "title": "The Erdős Question ($100 Prize)",
@@ -123,8 +123,8 @@
     "id": "ann-552-primes",
     "proofId": "erdos-552",
     "range": {
-      "startLine": 136,
-      "endLine": 153
+      "startLine": 130,
+      "endLine": 148
     },
     "type": "concept",
     "title": "Prime Gap Connection and Cramér's Conjecture",
@@ -147,8 +147,8 @@
     "id": "ann-552-f-function",
     "proofId": "erdos-552",
     "range": {
-      "startLine": 155,
-      "endLine": 171
+      "startLine": 149,
+      "endLine": 166
     },
     "type": "concept",
     "title": "The Function f(n) = R(C_4, S_n) and Its Properties",
@@ -169,8 +169,8 @@
     "id": "ann-552-constructions",
     "proofId": "erdos-552",
     "range": {
-      "startLine": 173,
-      "endLine": 197
+      "startLine": 167,
+      "endLine": 189
     },
     "type": "concept",
     "title": "Parsons Construction and Extremal Results",

--- a/src/data/proofs/erdos-552/meta.json
+++ b/src/data/proofs/erdos-552/meta.json
@@ -59,79 +59,79 @@
       "title": "Problem Statement, Known Bounds, and Imports",
       "summary": "Documentation header with problem statement, $100 prize, BEFRS/Parsons bounds, exact values for prime powers, Cramér connection, and Mathlib imports for SimpleGraph and real analysis",
       "startLine": 1,
-      "endLine": 37,
+      "endLine": 39,
       "mathContext": "Bound: Documentation header with problem statement, $100 prize, BEFRS/Parsons bounds, exact values for prime powers, Cramér connection, and Mathlib imports for SimpleGraph and real analysis"
     },
     {
       "id": "graphs",
       "title": "Graph Definitions: C_4 and Star Graph S_n",
       "summary": "cycleGraph C_n via modular adjacency with symmetry/loopless proofs, C4 as cycleGraph 4, starGraph S_n = K_{1,n} with center vertex 0 adjacent to all leaves",
-      "startLine": 38,
-      "endLine": 58,
+      "startLine": 40,
+      "endLine": 63,
       "mathContext": "Verified: cycleGraph C_n via modular adjacency with symmetry/loopless proofs, C4 as cycleGraph 4, starGraph S_n = K_{1,n} with center vertex 0 adjacent to all leaves"
     },
     {
       "id": "ramsey",
       "title": "Ramsey Number R(C_4, S_n)",
       "summary": "ContainsSubgraph via injective adjacency-preserving maps, complement graph definition, ramseyNumber via sInf, R_C4_Sn specializing to the cycle-star pair",
-      "startLine": 59,
-      "endLine": 82,
+      "startLine": 64,
+      "endLine": 76,
       "mathContext": "Formal definition: ContainsSubgraph via injective adjacency-preserving maps, complement graph definition, ramseyNumber via sInf, R_C4_Sn specializing to the cycle-star pair"
     },
     {
       "id": "bounds",
       "title": "Known Bounds: Parsons Upper and BEFRS Lower",
       "summary": "parsons_upper_bound (1975): R ≤ n + ⌈√n⌉ + 1. befrs_lower_bound (1989): R ≥ n + √n - 6n^{11/40} via Filter.atTop. asymptotic_bounds combining both into R = n + √n + O(n^{11/40})",
-      "startLine": 83,
-      "endLine": 102,
+      "startLine": 77,
+      "endLine": 96,
       "mathContext": "parsons_upper_bound (1975): R $\\leq$ n + ⌈√n⌉ + 1. befrs_lower_bound (1989): R $\\geq$ n + √n - 6n^{11/40} via Filter.atTop. asymptotic_bounds combining both into R = n + √n + $O(n^{11/40})$"
     },
     {
       "id": "exact",
       "title": "Exact Values for Prime Power Parameters",
       "summary": "exact_value_q2_plus_1: R = n + q for n = q²+1. exact_value_q2: R = n + q + 1 for n = q². exact_value_q2_minus_t: R = q²-t+q+1 for 0 ≤ t ≤ q. All via projective plane constructions",
-      "startLine": 103,
-      "endLine": 120,
+      "startLine": 97,
+      "endLine": 114,
       "mathContext": "exact_value_q2_plus_1: R = n + q for n = q²+1. exact_value_q2: R = n + q + 1 for n = q². exact_value_q2_minus_t: R = q²-t+q+1 for 0 $\\leq$ t $\\leq$ q. All via projective plane constructions"
     },
     {
       "id": "main-question",
       "title": "The Erdős Question ($100 Prize)",
       "summary": "ErdosQuestion: infinitely many n with R ≤ n + √n - c. ErdosConjecture: holds for ALL c > 0. ErdosConjectureNegation: eventual lower bound n + √n - c₀",
-      "startLine": 121,
-      "endLine": 135,
+      "startLine": 115,
+      "endLine": 129,
       "mathContext": "ErdosQuestion: infinitely many n with R $\\leq$ n + √n - c. ErdosConjecture: holds for ALL c > 0. ErdosConjectureNegation: eventual lower bound n + √n - c₀"
     },
     {
       "id": "prime-gaps",
       "title": "Prime Gap Connection and Cramér's Conjecture",
       "summary": "primeGap function via sInf of primes exceeding p, CramerConjecture as O((log p)²), cramer_implies_better_bound: conditionally R ≥ n + √n - n^ε for any ε > 0",
-      "startLine": 136,
-      "endLine": 154,
+      "startLine": 130,
+      "endLine": 148,
       "mathContext": "primeGap function via sInf of primes exceeding p, CramerConjecture as $O((log p)$²), cramer_implies_better_bound: conditionally R $\\geq$ n + √n - n^ε for any ε > 0"
     },
     {
       "id": "f-function",
       "title": "The Function f(n) = R(C_4, S_n)",
       "summary": "f = R_C4_Sn convenience wrapper, ConsecutiveEqualQuestion (f(n+1) = f(n) infinitely often?), BoundedIncreaseQuestion (f(n+1) ≤ f(n) + 2?), f_eventually_increasing",
-      "startLine": 155,
-      "endLine": 172,
+      "startLine": 149,
+      "endLine": 166,
       "mathContext": "f = R_C4_Sn convenience wrapper, ConsecutiveEqualQuestion (f(n+1) = f(n) infinitely often?), BoundedIncreaseQuestion (f(n+1) $\\leq$ f(n) + 2?), f_eventually_increasing"
     },
     {
       "id": "constructions",
       "title": "Parsons Construction and Extremal Results",
       "summary": "parsons_construction via PG(2,q) for prime q, polarityGraph definition (sorry), c4_minimum_degree Dirac-type condition, c4_star_extremal weaker bound R ≤ n + 2√n + 3",
-      "startLine": 173,
-      "endLine": 198,
+      "startLine": 167,
+      "endLine": 189,
       "mathContext": "parsons_construction via PG(2,q) for prime q, polarityGraph definition (sorry), c4_minimum_degree Dirac-type condition, c4_star_extremal weaker bound R $\\leq$ n + 2$\\sqrt{n}$ + 3"
     },
     {
       "id": "summary",
       "title": "Summary and Open Questions",
       "summary": "Overview of formalized results: OPEN status, $100 prize, known bounds, exact values, prime gap connection, key sorries, open dependence on prime gaps",
-      "startLine": 199,
-      "endLine": 238,
+      "startLine": 190,
+      "endLine": 231,
       "mathContext": "Bound: Overview of formalized results: OPEN status, $100 prize, known bounds, exact values, prime gap connection, key sorries, open dependence on prime gaps"
     }
   ],


### PR DESCRIPTION
## Summary

Drift-repair pass on `erdos-552` (Ramsey number R(C₄, Sₙ), status `formalized`, 12 sorries). The 231-line Lean file's 10 sections and 8 annotations had drifted ~5–6 lines, with the Summary section overshooting EOF (`199–238 > 231`).

## What changed (ranges only — no prose edits)

**Sections** aligned to declaration clusters: Problem Statement 1–39, Graph Definitions 40–63, Ramsey Number 64–76, Known Bounds 77–96, Exact Values 97–114, Erdős Question 115–129, Prime Gap 130–148, Function f 149–166, Parsons Construction 167–189, Summary (trailing comment block) 190–231.

**Annotations** re-anchored 1:1 to their matching sections.

## Verification

Diff contains only startLine/endLine changes. All ranges within [1, 231], no overshoot. Status unchanged (`formalized`, 12 sorries, 0 axioms).