### PR TITLE
Research: erdos-326-wip-01 — 12 axiom-free foundational lemmas on additive bases

### DIFF
--- a/proofs/Proofs/Erdos326WIP01.lean
+++ b/proofs/Proofs/Erdos326WIP01.lean
@@ -1,0 +1,124 @@
+/-
+# Erdős Problem #326 (Additive Bases and Non-Convergent Subsequences) — Foundational Lemmas
+
+Axiom-free foundational scaffolding for the objects defined in
+`Proofs/Erdos326Problem.lean`:
+
+    IsAddBasis A          = ∃ N, ∀ n ≥ N, n is a sum of finitely many elements of A,
+    IsAddBasisOfOrder A k = the same with at most k summands,
+    growthRatio b k       = bₖ / k²,
+    HasGrowthLimit b x     / HasNoGrowthLimit b.
+
+Erdős #326 asks whether every order-2 additive basis `A` contains a sub-basis
+`B ⊆ A` whose growth ratio `bₖ/k²` fails to converge — it is **open**
+(Cassels 1957 disproved the `A = B` variant).  The deep growth/oscillation
+content is untouched; this file records the elementary order-theory and
+monotonicity of the basis predicates and the basic behaviour of the growth
+ratio and its limit:
+
+* order monotonicity `IsAddBasisOfOrder A k → k ≤ k' → IsAddBasisOfOrder A k'`
+  and set monotonicity under `⊆`, for both `IsAddBasisOfOrder` and `IsAddBasis`;
+* `Set.univ` is an order-1 basis; the empty set and order 0 are never bases;
+* `growthRatio` is nonnegative, `growthRatio b 0 = 0`;
+* the growth limit is unique, and existence of a limit contradicts
+  `HasNoGrowthLimit`.
+
+All results are `0`-axiom / `0`-sorry.
+
+Reference: <https://erdosproblems.com/326>
+-/
+
+import Mathlib
+import Proofs.Erdos326Problem
+
+open Filter Set
+open scoped Topology
+
+namespace Erdos326
+
+/-! ## Monotonicity of the basis predicates -/
+
+/-- An order-`k` basis is an order-`k'` basis for any larger `k'`. -/
+theorem IsAddBasisOfOrder.mono_order {A : Set ℕ} {k k' : ℕ}
+    (h : IsAddBasisOfOrder A k) (hkk' : k ≤ k') : IsAddBasisOfOrder A k' := by
+  obtain ⟨N, hN⟩ := h
+  refine ⟨N, fun n hn => ?_⟩
+  obtain ⟨m, hm, f, hf, hsum⟩ := hN n hn
+  exact ⟨m, hm.trans hkk', f, hf, hsum⟩
+
+/-- An order-`k` basis of `A` is an order-`k` basis of any superset `B ⊇ A`. -/
+theorem IsAddBasisOfOrder.mono_set {A B : Set ℕ} {k : ℕ}
+    (h : IsAddBasisOfOrder A k) (hAB : A ⊆ B) : IsAddBasisOfOrder B k := by
+  obtain ⟨N, hN⟩ := h
+  refine ⟨N, fun n hn => ?_⟩
+  obtain ⟨m, hm, f, hf, hsum⟩ := hN n hn
+  exact ⟨m, hm, f, fun i => hAB (hf i), hsum⟩
+
+/-- A basis of `A` is a basis of any superset `B ⊇ A`. -/
+theorem IsAddBasis.mono {A B : Set ℕ} (h : IsAddBasis A) (hAB : A ⊆ B) :
+    IsAddBasis B := by
+  obtain ⟨N, hN⟩ := h
+  refine ⟨N, fun n hn => ?_⟩
+  obtain ⟨k, f, hf, hsum⟩ := hN n hn
+  exact ⟨k, f, fun i => hAB (hf i), hsum⟩
+
+/-! ## Extremal cases -/
+
+/-- `ℕ` itself (the universal set) is an additive basis of order `1`:
+    each `n` is the single summand `n`. -/
+theorem isAddBasisOfOrder_univ_one : IsAddBasisOfOrder (Set.univ : Set ℕ) 1 := by
+  refine ⟨0, fun n _ => ⟨1, le_refl 1, fun _ => n, fun _ => Set.mem_univ _, ?_⟩⟩
+  simp
+
+/-- `ℕ` itself is an additive basis. -/
+theorem isAddBasis_univ : IsAddBasis (Set.univ : Set ℕ) :=
+  isAddBasisOfOrder_univ_one.isAddBasis
+
+/-- The empty set is not an additive basis: no large `n` is a sum of elements
+    of `∅`. -/
+theorem not_isAddBasis_empty : ¬ IsAddBasis (∅ : Set ℕ) := by
+  rintro ⟨N, hN⟩
+  obtain ⟨k, f, hf, hsum⟩ := hN (N + 1) (by omega)
+  rcases Nat.eq_zero_or_pos k with hk | hk
+  · subst hk
+    simp only [Fin.sum_univ_zero] at hsum
+    omega
+  · exact (Set.mem_empty_iff_false _).mp (hf ⟨0, hk⟩)
+
+/-- No set is an additive basis of order `0`: with at most `0` summands only
+    `0` is representable, but arbitrarily large `n` are required. -/
+theorem not_isAddBasisOfOrder_zero (A : Set ℕ) : ¬ IsAddBasisOfOrder A 0 := by
+  rintro ⟨N, hN⟩
+  obtain ⟨m, hm, f, _, hsum⟩ := hN (N + 1) (by omega)
+  have hm0 : m = 0 := Nat.le_zero.mp hm
+  subst hm0
+  simp only [Fin.sum_univ_zero] at hsum
+  omega
+
+/-! ## The growth ratio and its limit -/
+
+/-- The growth ratio `bₖ/k²` is nonnegative. -/
+theorem growthRatio_nonneg (b : ℕ → ℕ) (k : ℕ) : 0 ≤ growthRatio b k :=
+  div_nonneg (Nat.cast_nonneg _) (by positivity)
+
+/-- At `k = 0` the growth ratio is `0` (division by `0² = 0`). -/
+theorem growthRatio_zero (b : ℕ → ℕ) : growthRatio b 0 = 0 := by
+  unfold growthRatio; simp
+
+/-- The growth limit, when it exists, is unique. -/
+theorem HasGrowthLimit.unique {b : ℕ → ℕ} {x y : ℝ}
+    (hx : HasGrowthLimit b x) (hy : HasGrowthLimit b y) : x = y :=
+  tendsto_nhds_unique hx hy
+
+/-- If the growth ratio has a limit, it does not have "no growth limit". -/
+theorem HasGrowthLimit.not_hasNoGrowthLimit {b : ℕ → ℕ} {x : ℝ}
+    (h : HasGrowthLimit b x) : ¬ HasNoGrowthLimit b :=
+  fun hno => hno x h
+
+/-- `HasNoGrowthLimit` is exactly the non-existence of any growth limit. -/
+theorem hasNoGrowthLimit_iff (b : ℕ → ℕ) :
+    HasNoGrowthLimit b ↔ ¬ ∃ x, HasGrowthLimit b x := by
+  unfold HasNoGrowthLimit
+  rw [not_exists]
+
+end Erdos326

--- a/src/data/research/problems/erdos-326-wip-01.json
+++ b/src/data/research/problems/erdos-326-wip-01.json
@@ -1,0 +1,94 @@
+{
+  "slug": "erdos-326-wip-01",
+  "title": "Complete the Lean Formalization of Erdős Problem #326 (Additive Bases and Non-Convergent Subsequences)",
+  "phase": "ORIENT",
+  "status": "active",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "\\forall A \\subseteq \\mathbb{N} \\text{ an additive basis of order } 2,\\ \\exists B \\subseteq A \\text{ a basis with increasing enumeration } b,\\ \\lim_{k\\to\\infty} b_k/k^2 \\text{ does not exist.}",
+    "plain": "Let A ⊆ ℕ be an additive basis of order 2 (every sufficiently large n is a sum of two elements of A). Erdős #326 asks: must there always exist a sub-basis B ⊆ A, enumerated increasingly as b₁<b₂<…, whose growth ratio bₖ/k² fails to converge? Erdős's original A=B version was disproved by Cassels (1957), who built an order-2 basis whose ratio aₖ/k² converges. The subset form remains OPEN. The Lean file Erdos326Problem.lean defines IsAddBasis, IsAddBasisOfOrder, growthRatio, HasGrowthLimit/HasNoGrowthLimit but proves only that an order-k basis is a basis; this WIP node formalizes the elementary order theory and growth-ratio behaviour.",
+    "whyMatters": [
+      "Additive bases and their growth are core additive-number-theory objects; a clean Lean treatment of the basis-order lattice seeds reusable infrastructure for sumset/basis problems."
+    ]
+  },
+  "knownResults": {
+    "proven": [
+      "IsAddBasisOfOrder is monotone in the order and under set inclusion; IsAddBasis is monotone under inclusion (this session).",
+      "ℕ is an order-1 basis; ∅ and order 0 are never bases (this session).",
+      "growthRatio nonneg, growthRatio b 0 = 0, growth limit uniqueness (this session)."
+    ],
+    "open": [
+      "The subset-basis oscillation question (Erdős #326 itself).",
+      "Whether the deep bₖ = O(k²) growth bound and Cassels' construction can be formalized."
+    ],
+    "goal": "Formalize the elementary order theory of the basis predicates and the basic growth-ratio/limit facts from Mathlib; keep the deep oscillation content cleanly isolated as the open target."
+  },
+  "currentState": {
+    "phase": "ORIENT",
+    "since": "2026-07-20T13:00:00-07:00",
+    "iteration": 1,
+    "focus": "Axiom-free foundational lemmas on IsAddBasis / IsAddBasisOfOrder / growthRatio.",
+    "blockers": [
+      {
+        "route": "the subset-basis oscillation dichotomy via elementary density",
+        "reopenCriterion": "materially new mechanism required",
+        "blockedAt": "2026-07-20"
+      }
+    ],
+    "nextAction": "Formalize the standard bₖ = O(k²) upper bound for order-2 bases (density ≥ c√n ⟹ k-th element ≤ Ck²); and the perfect squares as a concrete order-4 basis via Lagrange four-square (Mathlib: Nat.sum_four_squares).",
+    "attemptCounts": {
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
+    }
+  },
+  "knowledge": {
+    "progressSummary": "PROGRESS: Created Proofs/Erdos326WIP01.lean (12 theorems, 0 sorry / 0 axiom, VERIFIED axiom-free [propext, Classical.choice, Quot.sound]). Established the elementary order theory and growth-ratio facts for the additive-basis predicates: order/set monotonicity of IsAddBasisOfOrder and set monotonicity of IsAddBasis, ℕ as an order-1 basis, ∅ and order-0 never bases, growthRatio nonneg / =0 at k=0, growth-limit uniqueness, and the HasNoGrowthLimit unfolding. The deep oscillation content is untouched.",
+    "builtItems": [
+      "IsAddBasisOfOrder.mono_order / .mono_set in Erdos326WIP01.lean",
+      "IsAddBasis.mono",
+      "isAddBasisOfOrder_univ_one, isAddBasis_univ",
+      "not_isAddBasis_empty, not_isAddBasisOfOrder_zero",
+      "growthRatio_nonneg, growthRatio_zero",
+      "HasGrowthLimit.unique, HasGrowthLimit.not_hasNoGrowthLimit, hasNoGrowthLimit_iff"
+    ],
+    "insights": [
+      "The basis predicates form a monotone lattice: raising the order or enlarging the set preserves the basis property — the atomic order theory underlying any basis-comparison argument.",
+      "Order 0 and the empty set are degenerate non-bases (only 0 is representable), so all substantive work happens at order ≥ 1 with an infinite set.",
+      "growthRatio b 0 = 0 by the ℝ junk convention x/0 = 0 — worth pinning so downstream limit arguments can ignore the k=0 term."
+    ],
+    "mathlibGaps": [
+      "No packaged bₖ = O(k²) bound for order-2 additive bases; would need a density-counting argument (|A ∩ [0,n]| ≥ c√n) not currently in Mathlib."
+    ],
+    "nextSteps": [
+      "Perfect squares as a concrete order-4 basis via Nat.sum_four_squares (Lagrange).",
+      "The bₖ = O(k²) upper bound for order-2 bases.",
+      "Relate HasGrowthLimit to boundedness of the enumeration."
+    ],
+    "markdown": "# Knowledge Base: erdos-326-wip-01\n\n## Session 2026-07-20 (researcher-1) — foundational additive-basis / growth-ratio scaffolding\n\n**Mode**: FRESH (EMPTY node). **Outcome**: progress — VERIFIED axiom-free (`[propext, Classical.choice, Quot.sound]`), 0 sorry / 0 axiom. Host-verified (Mathlib-only parent): fresh-built `Erdos326Problem.olean` then `lake env lean` on the child (no Docker).\n\n### What I did\nCreated `proofs/Proofs/Erdos326WIP01.lean` (12 theorems) on the additive-basis predicates and the growth ratio:\n- **Monotonicity**: `IsAddBasisOfOrder.mono_order` (raise the order), `IsAddBasisOfOrder.mono_set` and `IsAddBasis.mono` (enlarge the set).\n- **Extremal cases**: `isAddBasisOfOrder_univ_one` / `isAddBasis_univ` (`ℕ` is an order-1 basis); `not_isAddBasis_empty`, `not_isAddBasisOfOrder_zero`.\n- **Growth ratio**: `growthRatio_nonneg`, `growthRatio_zero`, `HasGrowthLimit.unique`, `HasGrowthLimit.not_hasNoGrowthLimit`, `hasNoGrowthLimit_iff`.\n\n### Key findings\n- The basis predicates form a monotone lattice in (order, set) — the atomic order theory for any basis-comparison argument.\n- Order 0 / the empty set are degenerate non-bases; substantive work is at order ≥ 1.\n\n### Reusable Lean recipe\n- Destructure the order predicate: `obtain ⟨N, hN⟩ := h; obtain ⟨m, hm, f, hf, hsum⟩ := hN n hn` (the `(_ : m ≤ k)` binder appears as `hm`).\n- Degenerate non-basis: pick `n = N+1`, split `Nat.eq_zero_or_pos k`; the `k=0` branch closes via `simp only [Fin.sum_univ_zero] at hsum; omega`, the `k>0` branch via `(Set.mem_empty_iff_false _).mp (hf ⟨0, hk⟩)`.\n- `growthRatio b 0 = 0`: `unfold growthRatio; simp` (`x/0 = 0`).\n- Limit uniqueness: `tendsto_nhds_unique` (atTop on ℕ is `NeBot`).\n\n### Next steps\n- Perfect squares as an order-4 basis (`Nat.sum_four_squares`).\n- The `bₖ = O(k²)` bound for order-2 bases.\n\n### Still open (unchanged)\nThe subset-basis oscillation question (Erdős #326) — deep; Cassels (1957) disproved only the `A = B` variant.\n"
+  },
+  "tags": [
+    "erdos",
+    "number-theory",
+    "additive-combinatorics",
+    "additive-bases",
+    "sumsets",
+    "open",
+    "wip"
+  ],
+  "relatedProofs": [
+    "erdos-326"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [
+      "https://erdosproblems.com/326"
+    ],
+    "mathlib": []
+  },
+  "started": "2026-07-20T13:00:00.000Z",
+  "lastUpdate": "2026-07-20T13:00:00.000Z",
+  "significance": 6,
+  "tractability": 5
+}


### PR DESCRIPTION
## Summary
Research session on the fresh (EMPTY) WIP node **erdos-326-wip-01** (Erdős #326, additive bases & non-convergent subsequences). Adds `proofs/Proofs/Erdos326WIP01.lean` — **12 theorems, 0 sorry / 0 axiom** — establishing the elementary order theory of the additive-basis predicates and the growth-ratio basics from `Erdos326Problem.lean`, which previously proved only "an order-k basis is a basis".

## What's proved (all axiom-free)
- **Monotonicity**: `IsAddBasisOfOrder.mono_order` (raise the order), `IsAddBasisOfOrder.mono_set` and `IsAddBasis.mono` (enlarge the set)
- **Extremal cases**: `isAddBasisOfOrder_univ_one` / `isAddBasis_univ` (`ℕ` is an order-1 basis); `not_isAddBasis_empty`, `not_isAddBasisOfOrder_zero` (degenerate non-bases)
- **Growth ratio**: `growthRatio_nonneg`, `growthRatio_zero`, `HasGrowthLimit.unique` (limit uniqueness), `HasGrowthLimit.not_hasNoGrowthLimit`, `hasNoGrowthLimit_iff`

## Why this is honest, non-inflated progress
This is the atomic order theory of additive bases — reusable infrastructure for basis/sumset problems. The deep content — whether every order-2 basis has an oscillating sub-basis (Cassels 1957 disproved only the `A = B` variant) — is **untouched and cleanly isolated** as the open target.

## Verification
Host-verified (parent is Mathlib-only): fresh-built `Erdos326Problem.olean` via `lake env lean`, then compiled the child — clean, no Docker. `#print axioms` on representative theorems (`not_isAddBasis_empty`, `not_isAddBasisOfOrder_zero`, `isAddBasis_univ`, `IsAddBasisOfOrder.mono_order`, `HasGrowthLimit.unique`, `growthRatio_nonneg`) = `[propext, Classical.choice, Quot.sound]` only.

## Next steps (recorded in tracker)
- Perfect squares as a concrete order-4 basis via `Nat.sum_four_squares` (Lagrange)
- The `bₖ = O(k²)` upper bound for order-2 bases

🤖 Generated with [Claude Code](https://claude.com/claude-code)