### PR TITLE
Research: erdos-46-wip-01 — 13 axiom-free foundational lemmas on unit-fraction representations

### DIFF
--- a/proofs/Proofs/Erdos46Problem.lean
+++ b/proofs/Proofs/Erdos46Problem.lean
@@ -81,4 +81,108 @@ theorem mono_subset {r : ℕ} {c : FiniteColouring r} {S T : Finset ℕ}
   obtain ⟨col, hcol⟩ := hS
   exact ⟨col, fun n hn => hcol n (hTS hn)⟩
 
-/- A unit fraction representation has at least two elements. -/
+/- ## Foundational lemmas
+
+The following develop the def-only stub above into a body of axiom-free
+elementary facts about unit-fraction / rational representations and
+monochromatic sets: singleton/empty exclusions, the two-element lower bound,
+term and positivity bounds, additivity over disjoint unions, and the reduction
+of the base Croot statement to the infinitely-many version. -/
+
+/-- No singleton `{n}` is a unit-fraction representation of `1`: the sum is
+`1/n`, and for `n ≥ 2` we have `1/n < 1`. -/
+theorem not_isUnitFractionRepr_singleton (n : ℕ) : ¬IsUnitFractionRepr {n} := by
+  rintro ⟨hge, hsum⟩
+  have hn : 2 ≤ n := hge n (mem_singleton_self n)
+  rw [Finset.sum_singleton] at hsum
+  have hnpos : (0 : ℚ) < n := by exact_mod_cast (by omega : 0 < n)
+  have hlt : (1 : ℚ) / n < 1 := by
+    rw [div_lt_one hnpos]; exact_mod_cast (by omega : 1 < n)
+  rw [hsum] at hlt
+  exact lt_irrefl 1 hlt
+
+/-- Membership in a set all of whose elements are `≥ 2` is subset-closed. -/
+theorem forall_two_le_of_subset {S T : Finset ℕ} (hTS : T ⊆ S)
+    (hS : ∀ n ∈ S, 2 ≤ n) : ∀ n ∈ T, 2 ≤ n :=
+  fun n hn => hS n (hTS hn)
+
+/-- Every element of a unit-fraction representation is positive. -/
+theorem pos_of_mem_isUnitFractionRepr {S : Finset ℕ} (hS : IsUnitFractionRepr S)
+    {n : ℕ} (hn : n ∈ S) : 0 < n := by
+  have := hS.1 n hn; omega
+
+/-- A unit-fraction representation of `1` has at least two elements: the empty
+set sums to `0` and a singleton sums to `< 1`, so neither reaches `1`. -/
+theorem two_le_card_of_isUnitFractionRepr {S : Finset ℕ}
+    (hS : IsUnitFractionRepr S) : 2 ≤ S.card := by
+  rcases eq_or_ne S.card 0 with h0 | h0
+  · rw [Finset.card_eq_zero] at h0; subst h0
+    exact absurd hS not_unitFractionRepr_empty
+  rcases eq_or_ne S.card 1 with h1 | h1
+  · rw [Finset.card_eq_one] at h1
+    obtain ⟨a, rfl⟩ := h1
+    exact absurd hS (not_isUnitFractionRepr_singleton a)
+  omega
+
+/-- Each term `1/n` with `n ≥ 2` is at most `1/2`. -/
+theorem term_le_half {n : ℕ} (hn : 2 ≤ n) : (1 : ℚ) / n ≤ 1 / 2 := by
+  have h2 : (2 : ℚ) ≤ n := by exact_mod_cast hn
+  exact one_div_le_one_div_of_le (by norm_num) h2
+
+/-- The reciprocal sum over any set of naturals is nonnegative. -/
+theorem sum_inv_nonneg (S : Finset ℕ) : 0 ≤ S.sum (fun n => (1 : ℚ) / n) := by
+  apply Finset.sum_nonneg
+  intro n _; positivity
+
+/-- At `q = 1`, a rational representation is exactly a unit-fraction
+representation. -/
+theorem isRatFractionRepr_one_iff (S : Finset ℕ) :
+    IsRatFractionRepr S 1 ↔ IsUnitFractionRepr S := Iff.rfl
+
+/-- The rational a set represents is unique (it is the reciprocal sum). -/
+theorem isRatFractionRepr_unique {S : Finset ℕ} {q p : ℚ}
+    (hq : IsRatFractionRepr S q) (hp : IsRatFractionRepr S p) : q = p := by
+  rw [← hq.2, ← hp.2]
+
+/-- A rational representation by a nonempty set represents a positive rational. -/
+theorem isRatFractionRepr_pos {S : Finset ℕ} {q : ℚ}
+    (hS : IsRatFractionRepr S q) (hne : S.Nonempty) : 0 < q := by
+  rw [← hS.2]
+  apply Finset.sum_pos _ hne
+  intro n hn
+  have hnpos : (0 : ℚ) < n := by
+    have := hS.1 n hn; exact_mod_cast (by omega : 0 < n)
+  positivity
+
+/-- Rational representations add over disjoint unions: representing `q` on `S`
+and `p` on a disjoint `T` gives a representation of `q + p` on `S ∪ T`. This is
+the arithmetic backbone of assembling disjoint monochromatic solutions. -/
+theorem isRatFractionRepr_union {S T : Finset ℕ} {q p : ℚ}
+    (hdisj : Disjoint S T) (hS : IsRatFractionRepr S q)
+    (hT : IsRatFractionRepr T p) : IsRatFractionRepr (S ∪ T) (q + p) := by
+  obtain ⟨hS2, hSsum⟩ := hS
+  obtain ⟨hT2, hTsum⟩ := hT
+  refine ⟨fun n hn => ?_, ?_⟩
+  · rcases Finset.mem_union.mp hn with h | h
+    · exact hS2 n h
+    · exact hT2 n h
+  · rw [Finset.sum_union hdisj, hSsum, hTsum]
+
+/-- The empty set is monochromatic under any colouring with at least one
+colour (vacuously, using colour `0`). -/
+theorem isMonochromatic_empty {r : ℕ} (hr : 0 < r) (c : FiniteColouring r) :
+    IsMonochromatic c (∅ : Finset ℕ) :=
+  ⟨⟨0, hr⟩, fun n hn => by simp at hn⟩
+
+/-- Every singleton is monochromatic under any colouring. -/
+theorem isMonochromatic_singleton {r : ℕ} (c : FiniteColouring r) (n : ℕ) :
+    IsMonochromatic c ({n} : Finset ℕ) :=
+  ⟨c n, fun m hm => by rw [Finset.mem_singleton.mp hm]⟩
+
+/-- The base Croot statement (Erdős Problem 46) follows from the stronger
+infinitely-many-disjoint-solutions version by taking the threshold `N = 0`. -/
+theorem erdosProblem46_of_infinitely_many
+    (h : ErdosProblem46_infinitely_many) : ErdosProblem46 := by
+  intro r hr c
+  obtain ⟨S, hrepr, hmono, _⟩ := h r hr c 0
+  exact ⟨S, hrepr, hmono⟩

--- a/research/problems/erdos-46-wip-01/knowledge.md
+++ b/research/problems/erdos-46-wip-01/knowledge.md
@@ -19,3 +19,38 @@ Insights accumulated during research on this problem.
 ## Dead Ends
 
 [Approaches known not to work will be documented here]
+
+## Session 2026-07-20 (researcher-1) — develop the def-only stub (13 axiom-free lemmas)
+
+**Mode**: FRESH (knowledge score 0). **Outcome**: progress — 13 axiom-free foundational
+lemmas, **host-verified v4.31** (`lake env lean`, exit 0, `#print axioms` =
+`[propext, Classical.choice, Quot.sound]` on a spot-check of 4).
+
+Erdős Problem 46 (Croot): every finite colouring of ℕ has a monochromatic `S` with
+`∑_{n∈S} 1/n = 1`. `Erdos46Problem.lean` held only defs (`IsUnitFractionRepr`,
+`IsRatFractionRepr`, `FiniteColouring`, `IsMonochromatic`, the three headline Props) plus
+3 trivial lemmas. Filled the two `TODO` comments (singleton exclusion, ≥2 elements) and
+added structural infrastructure:
+
+- `not_isUnitFractionRepr_singleton` — `1/n = 1` fails for `n ≥ 2` (`div_lt_one`).
+- `two_le_card_of_isUnitFractionRepr` — card ≠ 0 (empty sums 0) and ≠ 1 (singleton < 1),
+  so `2 ≤ card` (via `card_eq_zero` / `card_eq_one` + `omega`).
+- `term_le_half`, `sum_inv_nonneg`, `pos_of_mem_isUnitFractionRepr`,
+  `isRatFractionRepr_pos`, `isRatFractionRepr_unique`, `isRatFractionRepr_one_iff`,
+  `forall_two_le_of_subset`.
+- `isRatFractionRepr_union` — reciprocal-sum representations add over **disjoint** unions
+  (`Finset.sum_union`); the arithmetic backbone for assembling disjoint monochromatic
+  solutions (the "infinitely many disjoint" strengthening).
+- `isMonochromatic_empty` (needs `0 < r`), `isMonochromatic_singleton`.
+- `erdosProblem46_of_infinitely_many` — the base statement reduces to the
+  infinitely-many-disjoint version by instantiating the threshold `N = 0`.
+
+### v4.31 gotchas
+- `div_le_div_iff` unknown → use `one_div_le_one_div_of_le (0<a) (a≤b) : 1/b ≤ 1/a`.
+- `Finset.not_mem_empty` unknown as a term here → discharge empty membership with
+  `by simp at hn`.
+
+### Still open
+Croot's theorem itself (2003, existence of the monochromatic representation) is deep and
+unformalized — needs the density/covering machinery from the paper. This session builds
+only the elementary scaffolding around the statement.

--- a/src/data/proofs/erdos-46/meta.json
+++ b/src/data/proofs/erdos-46/meta.json
@@ -155,9 +155,9 @@
       "Finset"
     ],
     "namespace": null,
-    "lineCount": 84,
+    "lineCount": 188,
     "axiomCount": 0,
-    "theoremCount": 3,
+    "theoremCount": 16,
     "definitionCount": 7,
     "path": "Proofs/Erdos46Problem.lean",
     "sorries": 0

--- a/src/data/research/problems/erdos-46-wip-01.json
+++ b/src/data/research/problems/erdos-46-wip-01.json
@@ -18,7 +18,7 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "OBSERVE",
+    "phase": "ORIENT",
     "since": "2026-07-09T17:33:18-07:00",
     "iteration": 1,
     "focus": "Initial problem understanding. Read problem.md and gather context.",
@@ -31,9 +31,17 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
+    "progressSummary": "FOUNDATIONS (researcher-1, 2026-07-20): developed the def-only Erdos46Problem.lean stub (Erdos Problem 46, monochromatic unit-fraction representations, Croot) with 13 axiom-free elementary lemmas: singleton/empty exclusions, the two-element lower bound (card>=2), term bound 1/n<=1/2, reciprocal-sum nonnegativity/positivity, uniqueness of the represented rational, additivity over disjoint unions (isRatFractionRepr_union — the arithmetic backbone for assembling disjoint monochromatic solutions), and the structural reduction erdosProblem46_of_infinitely_many (base Croot statement follows from the infinitely-many-disjoint-solutions version at N=0). File 84->188 lines, 3->16 theorems. Deep result (Croot 2003) itself unformalized. Host-verified v4.31 lake env lean, exit 0.",
+    "builtItems": [
+      "not_isUnitFractionRepr_singleton — no singleton represents 1 (Erdos46Problem.lean)",
+      "two_le_card_of_isUnitFractionRepr — a UFR of 1 has >= 2 elements (Erdos46Problem.lean)",
+      "isRatFractionRepr_union — reciprocal-sum representations add over disjoint unions (Erdos46Problem.lean)",
+      "erdosProblem46_of_infinitely_many — base Croot statement reduces to the infinitely-many version (Erdos46Problem.lean)",
+      "term_le_half / sum_inv_nonneg / isRatFractionRepr_pos / isRatFractionRepr_unique / pos_of_mem / forall_two_le_of_subset / isMonochromatic_empty / isMonochromatic_singleton / isRatFractionRepr_one_iff"
+    ],
+    "insights": [
+      "Erdos46Problem.lean stub developed: 13 axiom-free foundational lemmas on unit-fraction / rational representations and monochromatic sets (all [propext,Classical.choice,Quot.sound], no sorry/native_decide)."
+    ],
     "mathlibGaps": [],
     "nextSteps": [],
     "markdown": "# Knowledge Base: erdos-46-wip-01\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"


### PR DESCRIPTION
## Summary
Research session for **erdos-46-wip-01** (Erdős Problem 46, Croot: every finite
colouring of ℕ has a monochromatic solution to `1 = ∑ 1/nᵢ`). The parent file
`Erdos46Problem.lean` was a def-only stub (4 definitions, 3 headline Props, 3
trivial lemmas). This develops it with 13 axiom-free elementary lemmas, filling
the two in-file `TODO` comments and adding structural infrastructure.

## Progress
- **not_isUnitFractionRepr_singleton** — no singleton represents 1 (`1/n < 1` for `n ≥ 2`).
- **two_le_card_of_isUnitFractionRepr** — a representation of 1 has `≥ 2` elements
  (empty sums 0; singleton `< 1`).
- **term_le_half**, **sum_inv_nonneg**, **pos_of_mem_isUnitFractionRepr**,
  **isRatFractionRepr_pos**, **isRatFractionRepr_unique**, **isRatFractionRepr_one_iff**,
  **forall_two_le_of_subset** — term/positivity bounds and basic characterizations.
- **isRatFractionRepr_union** — reciprocal-sum representations add over **disjoint**
  unions; the arithmetic backbone for assembling disjoint monochromatic solutions.
- **isMonochromatic_empty** (needs `0 < r`), **isMonochromatic_singleton**.
- **erdosProblem46_of_infinitely_many** — the base Croot statement reduces to the
  stronger infinitely-many-disjoint-solutions version by taking threshold `N = 0`.

Files: `proofs/Proofs/Erdos46Problem.lean` (84→188 lines, 3→16 theorems),
gallery meta + research tracker synced.

## Verification
Host-verified on v4.31 (`lake env lean Proofs/Erdos46Problem.lean`, exit 0, no
errors). `#print axioms` on a spot-check (card bound, disjoint-union additivity,
the reduction, term bound) = `[propext, Classical.choice, Quot.sound]` — no
`sorry`, no `native_decide`. The 4 remaining linter warnings are pre-existing in
the original `def` statements (unused binder names), untouched here.

## Status
**Outcome**: progress (foundational infrastructure). Croot's theorem itself (2003)
remains deep and unformalized — this session builds only the elementary scaffolding
around the statement.

🤖 Generated by researcher-1