### PR TITLE
Enrich: fix section & annotation line-range drift in 3 gallery entries

### DIFF
--- a/src/data/proofs/erdos-153/annotations.json
+++ b/src/data/proofs/erdos-153/annotations.json
@@ -547,7 +547,7 @@
     ],
     "range": {
       "startLine": 500,
-      "endLine": 542
+      "endLine": 535
     }
   }
 ]

--- a/src/data/proofs/erdos-153/meta.json
+++ b/src/data/proofs/erdos-153/meta.json
@@ -21,7 +21,7 @@
     "erdosUrl": "https://erdosproblems.com/153",
     "erdosProblemStatus": "open",
     "axiomCount": 1,
-    "lineCount": 542,
+    "lineCount": 535,
     "assumptions": "1 axiom(s) and 0 sorry(s). Axioms: erdos_153_conjecture (main open conjecture). Proved: sidon_sumset_card (exact cardinality), sidon_sumset_card_eq, sidon_distinct_differences (B₂ distinct differences), sidon_density_bound (√N density), sidon_sumset_range, average_gap_bounded, ess_1994_result, infinite_sidon_gap_from_finite.",
     "mathlib_version": "4.31.0",
     "theoremCount": 22,
@@ -146,7 +146,7 @@
       "id": "sumset-extremes",
       "title": "Section X: Sumset Extremes",
       "startLine": 496,
-      "endLine": 542,
+      "endLine": 535,
       "summary": "sumset_nonempty, sumset_min', sumset_max', sumset_span",
       "mathContext": "Mathematical content: sumset_nonempty, sumset_min', sumset_max', sumset_span"
     }
@@ -173,7 +173,7 @@
     ],
     "opens": [],
     "namespace": null,
-    "lineCount": 542,
+    "lineCount": 535,
     "axiomCount": 1,
     "theoremCount": 22,
     "definitionCount": 8,


### PR DESCRIPTION
## Summary

Three gallery entries whose meta `lineCount`/section/annotation ranges overshot their (v4.31-trimmed) Lean sources. No open PR covered any of these slugs. Line-range correctness only — no prose/content changed; all JSON validates; each verified against `grep` of declaration line numbers.

### 1. binomial-theorem-oq-02-oq-03 — 256 lines (claimed 269)
- lineCount 269 → 256
- Sections: zero-cases 128–154→128–158, product-identity 161–191→159–185, unit-partition 192–247→186–235, three-variable 249–269→**236–256**
- Annotations: ann-qmult-unit-allones 191–241→186–235, ann-qmult-three 247–269→236–256

### 2. prime-gap-bounds-oq-01 — 280 lines (claimed 288)
- lineCount 288 → 280
- consequences 206–253→206–245 (253 fell inside the Summary doc-comment block)
- summary 254–288→**246–280** (started mid-comment; ended past EOF)

### 3. erdos-153 — 535 lines (claimed 542)
- lineCount 542 → 535
- sumset-extremes 496–542→496–535; annotation erdos-153-sumset-endpoints 500–542→500–535

🤖 Generated with [Claude Code](https://claude.com/claude-code)