### PR TITLE
Enrich binomial-theorem-oq-02-oq-03: fix section/annotation line-range drift

### DIFF
--- a/src/data/proofs/binomial-theorem-oq-02-oq-03/annotations.json
+++ b/src/data/proofs/binomial-theorem-oq-02-oq-03/annotations.json
@@ -75,8 +75,8 @@
     "id": "ann-qmult-product-identity",
     "proofId": "binomial-theorem-oq-02-oq-03",
     "range": {
-      "startLine": 161,
-      "endLine": 185
+      "startLine": 159,
+      "endLine": 181
     },
     "type": "concept",
     "title": "Product Identity: The q-Analog of multinomial × ∏kᵢ! = n!",
@@ -99,8 +99,8 @@
     "id": "ann-qmult-unit-allones",
     "proofId": "binomial-theorem-oq-02-oq-03",
     "range": {
-      "startLine": 191,
-      "endLine": 241
+      "startLine": 186,
+      "endLine": 231
     },
     "type": "concept",
     "title": "Unit Partitions and All-Ones: Special Cases",
@@ -122,8 +122,8 @@
     "id": "ann-qmult-three",
     "proofId": "binomial-theorem-oq-02-oq-03",
     "range": {
-      "startLine": 247,
-      "endLine": 269
+      "startLine": 236,
+      "endLine": 256
     },
     "type": "concept",
     "title": "Three-Variable Formula and Row Sum Identity",

--- a/src/data/proofs/binomial-theorem-oq-02-oq-03/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-02-oq-03/meta.json
@@ -85,40 +85,40 @@
   "sections": [
     {
       "id": "imports",
-      "title": "Imports",
+      "title": "Imports and Module Overview",
       "startLine": 1,
-      "endLine": 5,
-      "summary": "Imports Mathlib and Proofs.CombinationsFormulaOQ03 (q-binomial coefficients, q-factorials, and their key identities including qBinom_at_one and qBinom_product).",
-      "mathContext": "Depends on CombinationsFormulaOQ03's qBinom, qFactorial, and associated lemmas."
+      "endLine": 42,
+      "summary": "Imports Mathlib and Proofs.CombinationsFormulaOQ03 (q-binomial coefficients, q-factorials, and their key identities including qBinom_at_one and qBinom_product), plus the module docstring stating the OQ-02-OQ-03 goal (formalize the q-multinomial theorem), the recursive definition of qMultinom, the key results, and the finite-field/quantum-group context. Opens QBinomialCoefficients/Finset/BigOperators and works over a variable CommRing R.",
+      "mathContext": "Depends on CombinationsFormulaOQ03's qBinom, qFactorial, and associated lemmas; qMultinom q k = ∏ᵢ qBinom q (∑_{j≥i} kⱼ) (kᵢ)."
     },
     {
       "id": "definition",
       "title": "Definition of q-Multinomial Coefficient",
-      "startLine": 55,
-      "endLine": 64,
+      "startLine": 43,
+      "endLine": 58,
       "summary": "qMultinom q k defined recursively: base case (m=0) is 1; recursive case is qBinom q (∑kᵢ) (k 0) * qMultinom q (k∘Fin.succ). Works over arbitrary CommRing R.",
       "mathContext": "qMultinom q k = ∏ᵢ qBinom q (∑_{j≥i} kⱼ) (kᵢ)"
     },
     {
       "id": "basic-properties",
       "title": "Basic Properties",
-      "startLine": 65,
-      "endLine": 88,
+      "startLine": 59,
+      "endLine": 82,
       "summary": "Four boundary cases: nil (returns 1), single variable (returns 1), cons recursion, and two-variable formula qMultinom q k = qBinom q (k₀+k₁) k₀.",
       "mathContext": "These mirror classical multinomial boundary cases."
     },
     {
       "id": "reduction-at-one",
       "title": "Reduction at q=1",
-      "startLine": 89,
-      "endLine": 127,
+      "startLine": 83,
+      "endLine": 123,
       "summary": "qMultinom_at_one: at q=1, the q-multinomial equals Nat.multinomial. Proved by induction using qBinom_at_one and Nat.multinomial_insert. Key: Finset.univ (Fin (m+1)) = insert 0 (image Fin.succ univ).",
       "mathContext": "qMultinom (1:R) k = (Nat.multinomial Finset.univ k : R)"
     },
     {
       "id": "zero-cases",
       "title": "Zero Cases",
-      "startLine": 128,
+      "startLine": 124,
       "endLine": 154,
       "summary": "qMultinom_eq_zero_of_lt: zero when any kᵢ exceeds the total sum. qMultinom_eq_zero_when_head_exceeds_sum: special case when k₀ > ∑kᵢ.",
       "mathContext": "Mirrors the fact C(n,k) = 0 when k > n."
@@ -126,30 +126,30 @@
     {
       "id": "product-identity",
       "title": "Product Identity with q-Factorials",
-      "startLine": 161,
-      "endLine": 191,
+      "startLine": 155,
+      "endLine": 181,
       "summary": "qMultinom_product_qFactorial: qMultinom q k * ∏ qFactorial q (kᵢ) = qFactorial q (∑kᵢ). The q-analog of multinomial(k) * ∏kᵢ! = n!. Proved by induction using qBinom_product.",
       "mathContext": "This is the fundamental identity characterizing q-multinomials."
     },
     {
       "id": "unit-partition",
       "title": "Unit and All-Ones Partitions",
-      "startLine": 192,
-      "endLine": 247,
+      "startLine": 182,
+      "endLine": 231,
       "summary": "qMultinom_unit_partition: for k = eⱼ (unit vector), result is 1. qMultinom_all_ones: k = (1,1,...,1) gives qFactorial q m.",
       "mathContext": "Unit partitions correspond to C(1,1)=1; all-ones to m!_q = [m]_q!."
     },
     {
       "id": "three-variable",
       "title": "Three-Variable Formula",
-      "startLine": 249,
-      "endLine": 269,
+      "startLine": 232,
+      "endLine": 256,
       "summary": "qMultinom_three: qMultinom q k = qBinom q (k₀+k₁+k₂) k₀ * qBinom q (k₁+k₂) k₁. qMultinom_two_row_sum: row sum identity over j ∈ range(n+1).",
       "mathContext": "Three-variable formula via two successive q-binomial choices."
     }
   ],
   "conclusion": {
-    "summary": "This 269-line formalization confirms: YES, the q-multinomial theorem can be formalized in Lean 4. The q-multinomial coefficient is defined over arbitrary CommRings, reduces to the classical multinomial at q=1, satisfies the fundamental product identity with q-factorials, and admits explicit formulas for 2- and 3-variable cases. The proof achieves 0 sorries and 0 axioms.",
+    "summary": "This 256-line formalization confirms: YES, the q-multinomial theorem can be formalized in Lean 4. The q-multinomial coefficient is defined over arbitrary CommRings, reduces to the classical multinomial at q=1, satisfies the fundamental product identity with q-factorials, and admits explicit formulas for 2- and 3-variable cases. The proof achieves 0 sorries and 0 axioms.",
     "implications": "The q-multinomial coefficient formalization provides the foundation for:\n1. **q-Multinomial theorem in quantum groups**: In algebras where yx = qxy, the expansion of (x₁+···+xₘ)^n uses exactly these q-multinomial coefficients.\n2. **Counting subspace flags in finite geometry**: qMultinom q (k₁,...,kₘ) counts the number of chains of subspaces V₁ ⊂ V₂ ⊂ ··· in F_q^n with consecutive dimensions k₁, k₂, ...\n3. **q-Analog identity chains**: Combined with q-Pascal's rule and q-binomial theorem, these form a complete q-analog toolkit for formal combinatorics.",
     "openQuestions": [
       "Can the full q-multinomial theorem (expansion of (x₁+···+xₘ)^n in a q-commutative algebra) be formalized? This requires setting up q-commutative algebras as a typeclass.",

--- a/src/data/proofs/binomial-theorem-oq-02-oq-03/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-02-oq-03/meta.json
@@ -21,7 +21,7 @@
     "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 269,
+    "lineCount": 256,
     "theoremCount": 12,
     "assumptions": "None. All results proved from Mathlib's q-binomial (Gaussian binomial) infrastructure in CombinationsFormulaOQ03.",
     "mathlib_version": "4.31.0",
@@ -228,7 +228,7 @@
       "BigOperators"
     ],
     "namespace": "QMultinomialCoefficients",
-    "lineCount": 269,
+    "lineCount": 256,
     "axiomCount": 0,
     "sorries": 0,
     "theoremCount": 12,


### PR DESCRIPTION
## Enrichment pass — `binomial-theorem-oq-02-oq-03` (q-multinomial coefficients)

**Defect: section & annotation line-range drift.** `BinomialTheoremOQ02OQ03.lean` is **256 lines**, but the `sections` and `annotations` ranges had drifted forward — the last section (`three-variable`) and last annotation (`ann-qmult-three`) both ended at line **269 (13 past EOF)**, so the gallery source highlighter mis-anchored the tail declarations.

### Fix
- **Sections** realigned to the file's own `SECTION I–VII` banners, contiguous and accurate: header 1–42, definition 43–58, basic-properties 59–82, reduction-at-one 83–123, zero-cases 124–154, product-identity 155–181, unit-partition 182–231, three-variable 232–256. Max `endLine` now exactly 256.
- Expanded the header section (was 1–5) to **1–42**, covering the previously-uncovered module docstring (lines 6–54: the OQ statement, recursive definition, key results, finite-field/quantum-group context).
- **Annotations** pulled back onto their real declarations: product-identity 161–185 → **159–181**, unit-allones 191–241 → **186–231**, three 247–269 → **236–256**.
- Corrected `conclusion.summary` "This **269-line** formalization" → "**256-line**" (stale pre-trim line count).

### Verification
- `meta.json` and `annotations.json` valid JSON; ranges verified against the actual declaration/banner positions.
- No changes to axiom/sorry/status claims (still 0 axioms, 0 sorries, verified).