### PR TITLE
audit: erdos-844 — drop phantom chvatal_intersecting_families declaration + fix lineCount

### DIFF
--- a/src/data/proofs/erdos-844/meta.json
+++ b/src/data/proofs/erdos-844/meta.json
@@ -52,12 +52,12 @@
       "even_product_not_squarefree lemma: 2|a ∧ 2|b ⟹ ¬Squarefree(ab)",
       "nonsquarefree_product lemma: ¬Squarefree(a) ⟹ ¬Squarefree(ab)",
       "IsIntersectingFamily: squarefree subsets where pairs share primes",
-      "chvatal_intersecting_families: maximum is even squarefree",
+      "evenSquarefreeNumbers: the family achieving Chvátal's maximum (cited in prose, not formalized as a theorem)",
       "weisenberg_proof axiom: optimal set achieves maximum",
       "erdos_844_characterization theorem: complete characterization"
     ],
     "axiomCount": 2,
-    "lineCount": 175,
+    "lineCount": 168,
     "assumptions": "2 axioms: optimal_set_has_property (optimal set has non-squarefree products for all N≥1), weisenberg_proof (Weisenberg's bound: optimal set is maximum among sets with non-squarefree products). 0 sorries.",
     "theoremCount": 4,
     "definitionCount": 9
@@ -185,7 +185,7 @@
       "Finset"
     ],
     "namespace": "Erdos844",
-    "lineCount": 175,
+    "lineCount": 168,
     "axiomCount": 2,
     "theoremCount": 4,
     "definitionCount": 9,


### PR DESCRIPTION
## Gallery Integrity Fix

**Proof**: erdos-844 (Maximum Set with Non-Squarefree Products)

### Problem
`originalContributions` claimed a formalized declaration `chvatal_intersecting_families: maximum is even squarefree`. No such theorem/def exists in `Proofs/Erdos844Problem.lean`.

### Evidence
- Declarations in file: 9 defs, 4 theorems/lemmas (`even_product_not_squarefree`, `nonsquarefree_product`, `erdos_844_characterization`, `erdos_844`), 2 axioms (`optimal_set_has_property`, `weisenberg_proof`).
- Only `IsIntersectingFamily`/`evenSquarefreeNumbers` relate to intersecting families — both defs. Chvátal's result appears only in docstring prose (lines 19, 24, 110); the section summary itself states "Chvátal's bound itself is cited in prose, not formalized here." That content is fully absorbed into the `weisenberg_proof` axiom.

### Fix
- Replace the phantom `chvatal_intersecting_families` entry with the real `evenSquarefreeNumbers` def, noting Chvátal's bound is cited in prose, not formalized as a theorem.
- Correct `lineCount` 175 → 168 (actual file length; was an overcount) in both `meta` and `leanFile`.

Counts otherwise accurate: 9 defs, 4 theorems, 2 axioms, 0 sorries. No source `.lean` changes.

---
Discovered during gallery integrity audit (reserve mode).