### PR TITLE
Research: erdos-18-wip-01 — decidability + 13 axiom-free foundational lemmas on practical numbers

### DIFF
--- a/proofs/Proofs/Erdos18Problem.lean
+++ b/proofs/Proofs/Erdos18Problem.lean
@@ -151,6 +151,80 @@ def knownPracticalNumbers : List ℕ :=
 
 /- ## Why This Problem is Hard -/
 
+/- ## Foundational lemmas (axiom-free)
+
+Elementary structural facts developing the def-only stub: basic representability
+witnesses and bounds, decidability of representability and practicality (a single
+finite powerset search subsuming all future example checks), and small
+worked (non-)examples discharged by that decision procedure. -/
+
+/-- `0` is representable by the empty subset of divisors. -/
+theorem zero_isRepresentable (m : ℕ) : IsRepresentable 0 m :=
+  ⟨∅, Finset.empty_subset _, rfl⟩
+
+/-- Any representable value is at most the sum of all divisors of `m`. -/
+theorem isRepresentable_le_sigma {k m : ℕ} (h : IsRepresentable k m) :
+    k ≤ (divisors m).sum id := by
+  obtain ⟨S, hS, rfl⟩ := h
+  exact Finset.sum_le_sum_of_subset hS
+
+/-- Every divisor of `m` is at most `m`. -/
+theorem mem_divisors_le {m d : ℕ} (h : d ∈ divisors m) : d ≤ m :=
+  Nat.divisor_le h
+
+/-- For `m ≥ 1`, the value `1` is representable (via the divisor `1`). -/
+theorem one_isRepresentable {m : ℕ} (hm : 1 ≤ m) : IsRepresentable 1 m := by
+  refine ⟨{1}, ?_, by simp⟩
+  simp only [divisors, Finset.singleton_subset_iff]
+  exact Nat.one_mem_divisors.mpr (by omega)
+
+/-- For `m ≥ 1`, `m` itself is representable (via the divisor `m`). -/
+theorem isRepresentable_self {m : ℕ} (hm : 1 ≤ m) : IsRepresentable m m := by
+  refine ⟨{m}, ?_, by simp⟩
+  simp only [divisors, Finset.singleton_subset_iff, Nat.mem_divisors]
+  exact ⟨dvd_refl m, by omega⟩
+
+/-- A practical number is positive. -/
+theorem isPractical_pos {m : ℕ} (h : IsPractical m) : 1 ≤ m := h.1
+
+/-- `0` is not practical. -/
+theorem not_isPractical_zero : ¬IsPractical 0 := fun h => by have := h.1; omega
+
+/-- Membership in `PracticalNumbers` unfolds to `IsPractical`. -/
+theorem mem_practicalNumbers_iff {m : ℕ} : m ∈ PracticalNumbers ↔ IsPractical m :=
+  Iff.rfl
+
+/-- Representability is decidable: search the powerset of the divisor set. -/
+instance decidableIsRepresentable (k m : ℕ) : Decidable (IsRepresentable k m) :=
+  decidable_of_iff (∃ S ∈ (divisors m).powerset, S.sum id = k)
+    (by simp only [Finset.mem_powerset, IsRepresentable])
+
+/-- Practicality is decidable (bounded search over `k < m`, each a finite
+powerset search). This subsumes all future example verification. -/
+instance decidableIsPractical (m : ℕ) : Decidable (IsPractical m) :=
+  decidable_of_iff (1 ≤ m ∧ ∀ k, k < m → 1 ≤ k → IsRepresentable k m)
+    (by
+      unfold IsPractical
+      refine and_congr_right (fun _ => ?_)
+      exact ⟨fun h k hk1 hkm => h k hkm hk1, fun h k hkm hk1 => h k hk1 hkm⟩)
+
+/- ## Small worked examples (via the decision procedure) -/
+
+/-- `4` is practical: divisors `{1,2,4}` represent `1,2,3`. -/
+theorem four_practical : IsPractical 4 := by decide
+
+/-- `6` is practical: divisors `{1,2,3,6}` represent `1,…,5`. -/
+theorem six_practical : IsPractical 6 := by decide
+
+/-- `8` is practical. -/
+theorem eight_practical : IsPractical 8 := by decide
+
+/-- `3` is **not** practical: `2` is not a sum of distinct divisors of `3`. -/
+theorem not_practical_three : ¬IsPractical 3 := by decide
+
+/-- `5` is **not** practical: `2` is not a sum of distinct divisors of `5`. -/
+theorem not_practical_five : ¬IsPractical 5 := by decide
+
 end Erdos18
 
 /-

--- a/research/problems/erdos-18-wip-01/knowledge.md
+++ b/research/problems/erdos-18-wip-01/knowledge.md
@@ -19,3 +19,37 @@ Insights accumulated during research on this problem.
 ## Dead Ends
 
 [Approaches known not to work will be documented here]
+
+## Session 2026-07-20 (researcher-1) — decidability + foundations for the def-only stub
+
+**Mode**: FRESH (knowledge score 0). **Outcome**: progress — 13 axiom-free lemmas + 2
+Decidable instances, **host-verified v4.31** (`lake env lean`, exit 0; `#print axioms`
+spot-check = `[propext, Classical.choice, Quot.sound]`, no `native_decide`).
+
+Erdős Problem 18 (practical numbers, $250): `m` is practical if every `1 ≤ k < m` is a
+sum of distinct divisors of `m`; the open questions concern the growth of `h(m)`.
+`Erdos18Problem.lean` held only defs + `one_practical`/`two_practical`. Added:
+
+- **decidableIsRepresentable** — `IsRepresentable k m` (`∃ S ⊆ divisors m, S.sum id = k`)
+  is decidable by searching `(divisors m).powerset` (`decidable_of_iff`, the iff is
+  `Finset.mem_powerset`).
+- **decidableIsPractical** — reorders the two implications of the bounded `∀ k` so
+  `Nat.decidableBallLT` fires, giving a full decision procedure.
+- Worked examples by plain kernel `decide`: `four_practical`, `six_practical`,
+  `eight_practical`, `not_practical_three`, `not_practical_five` — **axiom-free**
+  (no `Lean.ofReduceBool`; confirmed via `#print axioms`).
+- Witnesses/bounds: `zero_isRepresentable` (∅), `one_isRepresentable`,
+  `isRepresentable_self`, `isRepresentable_le_sigma` (`k ≤ Σ divisors` via
+  `Finset.sum_le_sum_of_subset`), `mem_divisors_le` (`Nat.divisor_le`),
+  `isPractical_pos`, `not_isPractical_zero`, `mem_practicalNumbers_iff`.
+
+### Notes / gotchas
+- The bounded quantifier in `IsPractical` is `∀ k, 1 ≤ k → k < m → …`; `Nat.decidableBallLT`
+  needs the `k < m` bound outermost, so the decidability iff swaps the two hypotheses.
+- Plain `decide` (kernel) keeps the examples axiom-free; `native_decide` would pull in
+  `Lean.ofReduceBool` and must be avoided for a clean status.
+
+### Still open
+`h(m)` and its growth (`conjecture_part1`, `conjecture_part2_weak/strong`, the $250
+`h(n!) < n^{o(1)}` question) are deep and unformalized — this session builds only the
+elementary decidable scaffolding around the definitions.

--- a/src/data/proofs/erdos-18/meta.json
+++ b/src/data/proofs/erdos-18/meta.json
@@ -239,9 +239,9 @@
       "Nat"
     ],
     "namespace": "Erdos18",
-    "lineCount": 187,
+    "lineCount": 261,
     "axiomCount": 0,
-    "theoremCount": 2,
+    "theoremCount": 15,
     "definitionCount": 11,
     "path": "Proofs/Erdos18Problem.lean",
     "sorries": 0

--- a/src/data/research/problems/erdos-18-wip-01.json
+++ b/src/data/research/problems/erdos-18-wip-01.json
@@ -18,7 +18,7 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "OBSERVE",
+    "phase": "ORIENT",
     "since": "2026-07-09T17:33:19-07:00",
     "iteration": 1,
     "focus": "Initial problem understanding. Read problem.md and gather context.",
@@ -31,9 +31,16 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
+    "progressSummary": "FOUNDATIONS (researcher-1, 2026-07-20): developed the def-only Erdos18Problem.lean stub (Erdos Problem 18, practical numbers, $250 open) with 13 axiom-free lemmas + 2 Decidable instances. Key deliverable: IsRepresentable and IsPractical are DECIDABLE (search the powerset of Nat.divisors) — a reusable decision procedure that discharges example checks by plain kernel `decide` (four/six/eight_practical, not_practical_three/five), staying axiom-free (no native_decide). Plus basic witnesses/bounds: zero/one/self representable, representable <= sigma(m), divisors <= m, isPractical_pos, not_isPractical_zero. File 187->261 lines, 2->15 theorems. The h(m) growth conjectures (Parts 1-2) remain open/unformalized. Host-verified v4.31 lake env lean, exit 0; #print axioms = [propext,Classical.choice,Quot.sound].",
+    "builtItems": [
+      "decidableIsRepresentable / decidableIsPractical instances (Erdos18Problem.lean)",
+      "zero_isRepresentable, one_isRepresentable, isRepresentable_self, isRepresentable_le_sigma, mem_divisors_le (Erdos18Problem.lean)",
+      "four/six/eight_practical + not_practical_three/five via decide (Erdos18Problem.lean)",
+      "isPractical_pos, not_isPractical_zero, mem_practicalNumbers_iff (Erdos18Problem.lean)"
+    ],
+    "insights": [
+      "Erdos18Problem.lean stub developed: representability (IsRepresentable) and practicality (IsPractical) are DECIDABLE via a finite powerset search over the divisor set — a single decision procedure subsuming all future example checks; all lemmas axiom-free (plain kernel decide, no native_decide/Lean.ofReduceBool)."
+    ],
     "mathlibGaps": [],
     "nextSteps": [],
     "markdown": "# Knowledge Base: erdos-18-wip-01\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"


### PR DESCRIPTION
## Summary
Research session for **erdos-18-wip-01** (Erdős Problem 18, practical numbers, $250
open). A positive integer `m` is *practical* if every `1 ≤ k < m` is a sum of
distinct divisors of `m`; the open questions concern the growth of `h(m)`. The
parent file `Erdos18Problem.lean` was a def-only stub (11 defs, only
`one_practical`/`two_practical` proved). This develops it with 13 axiom-free
lemmas and 2 `Decidable` instances.

## Progress
- **decidableIsRepresentable** — `IsRepresentable k m` is decidable by searching
  `(divisors m).powerset` (`decidable_of_iff`, iff via `Finset.mem_powerset`).
- **decidableIsPractical** — a full decision procedure (reorders the bounded `∀ k`
  hypotheses so `Nat.decidableBallLT` fires). This subsumes all future example checks.
- Worked (non-)examples by **plain kernel `decide`**: `four_practical`,
  `six_practical`, `eight_practical`, `not_practical_three`, `not_practical_five`.
- Witnesses/bounds: `zero_isRepresentable`, `one_isRepresentable`,
  `isRepresentable_self`, `isRepresentable_le_sigma` (`k ≤ Σ divisors m`),
  `mem_divisors_le`, `isPractical_pos`, `not_isPractical_zero`,
  `mem_practicalNumbers_iff`.

Files: `proofs/Proofs/Erdos18Problem.lean` (187→261 lines, 2→15 theorems), gallery
meta + research tracker synced.

## Verification
Host-verified on v4.31 (`lake env lean Proofs/Erdos18Problem.lean`, exit 0, no
errors). `#print axioms` on a spot-check (including the `decide`-backed examples) =
`[propext, Classical.choice, Quot.sound]` — **no `sorry`, no `native_decide`**
(plain kernel `decide`, so no `Lean.ofReduceBool`; the entry stays axiom-free).

## Status
**Outcome**: progress (decidable scaffolding + foundations). The `h(m)` growth
conjectures — including the $250 `h(n!) < n^{o(1)}` question — remain deep and
unformalized.

🤖 Generated by researcher-1