### PR TITLE
Enrich elementary-quadratic-reciprocity-oq-02-oq-01: fix line-range drift

### DIFF
--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-02-oq-01/annotations.json
@@ -66,7 +66,7 @@
   {
     "id": "quadratic-and-nontrivial",
     "proofId": "elementary-quadratic-reciprocity-oq-02-oq-01",
-    "range": { "startLine": 80, "endLine": 116 },
+    "range": { "startLine": 84, "endLine": 100 },
     "type": "insight",
     "title": "Key Properties: Quadratic and Nontrivial",
     "content": "Two properties are needed to apply gaussSum_sq: (1) quadCharC_isQuadratic shows the character is quadratic (IsQuadratic: χ(a)² = 1 for units) by lifting quadraticChar_isQuadratic through Int.cast via MulChar.IsQuadratic.comp. (2) quadCharC_ne_one shows the character is nontrivial for odd prime p, proven by contradiction: if quadCharC = 1, then Int.cast injectivity forces quadraticChar = 1, contradicting quadraticChar_ne_one (which requires ringChar ≠ 2).",
@@ -88,7 +88,7 @@
   {
     "id": "gauss-sum-sq-main",
     "proofId": "elementary-quadratic-reciprocity-oq-02-oq-01",
-    "range": { "startLine": 118, "endLine": 176 },
+    "range": { "startLine": 105, "endLine": 159 },
     "type": "insight",
     "title": "Main Theorem: Gauss Sum Squared Formula in ℂ",
     "content": "The central result: (gaussSum χ ψ)² = (-1)^(p/2)·p in ℂ. The proof has three main steps: (1) apply gaussSum_sq to get χ(-1)·|ZMod p|; (2) simplify |ZMod p| = p via ZMod.card; (3) compute χ(-1) = (-1)^(p/2) via the chain quadCharC → Int.cast(quadraticChar) → legendreSym p (-1) → χ₄(p) → (-1)^(p/2). The first supplementary law of quadratic reciprocity (legendreSym.at_neg_one) and χ₄_eq_neg_one_pow are the key evaluation lemmas.",
@@ -111,7 +111,7 @@
   {
     "id": "existential-and-verifications",
     "proofId": "elementary-quadratic-reciprocity-oq-02-oq-01",
-    "range": { "startLine": 178, "endLine": 199 },
+    "range": { "startLine": 161, "endLine": 187 },
     "type": "insight",
     "title": "Existential Form and Concrete Verifications",
     "content": "gauss_sum_sq_exists packages the main theorem in existential form ∃ τ : ℂ, τ² = (-1)^(p/2)·p, with the explicit witness τ = gaussSum(quadCharC p, stdAddChar). Three examples verify the formula for small primes: p=3 gives τ² = -3 (since (-1)^1·3 = -3); p=5 gives τ² = 5 (since (-1)^2·5 = 5); p=7 gives τ² = -7 (since (-1)^3·7 = -7). These examples are proved by norm_num from the general theorem, illustrating the alternating sign pattern controlled by (-1)^(p/2).",

--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-02-oq-01/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-02-oq-01/meta.json
@@ -21,7 +21,7 @@
     "dateAdded": "2026-05-05",
     "axiomCount": 0,
     "assumptions": "None. This proof uses only Mathlib theorems: gaussSum_sq, quadraticChar_isQuadratic, quadraticChar_ne_one, ZMod.isPrimitive_stdAddChar, legendreSym.at_neg_one, χ₄_eq_neg_one_pow.",
-    "lineCount": 199,
+    "lineCount": 187,
     "theoremCount": 5,
     "definitionCount": 1,
     "originalContributions": [
@@ -35,7 +35,7 @@
   "leanFile": {
     "namespace": "GaussSumQRCyclotomic",
     "path": "Proofs/ElementaryQuadraticReciprocityOQ02OQ01.lean",
-    "lineCount": 199,
+    "lineCount": 187,
     "axiomCount": 0,
     "theoremCount": 5,
     "definitionCount": 1,
@@ -64,36 +64,36 @@
     {
       "id": "imports-and-namespace",
       "title": "Imports, Opens, and Variable Declaration",
-      "startLine": 51,
-      "endLine": 63,
+      "startLine": 50,
+      "endLine": 64,
       "summary": "Imports GaussSum, QuadraticChar, LegendreSymbol, and CircleAddChar from Mathlib. Declares variable p : ℕ [Fact p.Prime] for use throughout the noncomputable namespace GaussSumQRCyclotomic."
     },
     {
       "id": "quad-char-c",
       "title": "Setup: The Quadratic Character in ℂ",
       "startLine": 65,
-      "endLine": 78,
+      "endLine": 79,
       "summary": "Defines quadCharC : MulChar (ZMod p) ℂ as quadraticChar (ZMod p) composed with Int.castRingHom ℂ. Private lemma char_ZMod_ne_two shows ringChar (ZMod p) = p ≠ 2 for odd prime p."
     },
     {
       "id": "char-properties",
       "title": "Properties: Quadratic and Nontrivial",
       "startLine": 80,
-      "endLine": 116,
+      "endLine": 100,
       "summary": "quadCharC_isQuadratic: character is quadratic (IsQuadratic) by lifting via Int.cast. quadCharC_ne_one: nontrivial for odd prime p, proved by contradiction using Int.cast injectivity to transfer from the ℤ-valued quadraticChar_ne_one."
     },
     {
       "id": "main-theorem",
       "title": "Main Theorem: Gauss Sum Squared Formula",
-      "startLine": 118,
-      "endLine": 176,
+      "startLine": 101,
+      "endLine": 160,
       "summary": "gauss_sum_sq_in_complex: applies gaussSum_sq, simplifies cardinality |ZMod p| = p, and evaluates χ(-1) = (-1)^(p/2) via legendreSym.at_neg_one and χ₄_eq_neg_one_pow."
     },
     {
       "id": "existential-and-examples",
       "title": "Existential Form and Concrete Verifications",
-      "startLine": 178,
-      "endLine": 199,
+      "startLine": 161,
+      "endLine": 187,
       "summary": "gauss_sum_sq_exists wraps the main theorem as ∃ τ:ℂ, τ²=(-1)^(p/2)·p. Three norm_num examples verify the formula for p=3 (τ²=-3), p=5 (τ²=5), and p=7 (τ²=-7)."
     }
   ],


### PR DESCRIPTION
## Enrichment pass — `elementary-quadratic-reciprocity-oq-02-oq-01` (Gauss sum squared in ℂ)

**Defect: line-range + line-count drift.** `ElementaryQuadraticReciprocityOQ02OQ01.lean` is **187 lines**, but the metadata carried an old **199**-line snapshot:
- Both `lineCount` fields (`meta` and `leanFile`) read **199**.
- The `existential-and-examples` section and its annotation ran to line **199 (12 past EOF)**.
- `char-properties` (80–**116**) overran into the main theorem, and `main-theorem` started at 118 instead of its banner at 101.

### Fix
- Realigned all six `sections` to the file's actual `-- ===` banners, contiguous and accurate: header 1–49, imports 50–64, quad-char-c 65–79, char-properties 80–100, main-theorem 101–160, existential-and-examples 161–187. Max `endLine` now exactly 187.
- Re-anchored three annotations onto their real declarations: `quadratic-and-nontrivial` 80–116 → **84–100**, `gauss-sum-sq-main` 118–176 → **105–159**, `existential-and-verifications` 178–199 → **161–187**.
- Corrected both `lineCount` fields **199 → 187**.

### Verification
- `meta.json` / `annotations.json` valid JSON; ranges checked against actual declaration/banner positions.
- `theoremCount` (5) confirmed accurate; no changes to axiom/sorry/status claims (0 axioms, 0 sorries, verified).