### PR TITLE
Research: erdos-117-wip-01 — 7 axiom-free foundational lemmas on the n-commuting property

### DIFF
--- a/proofs/Proofs/Erdos117Problem.lean
+++ b/proofs/Proofs/Erdos117Problem.lean
@@ -60,3 +60,69 @@ noncomputable def abelianCoverNumber (n : ℕ) : ℕ :=
 
 /- **Open**: determine the exact base of the exponential growth. Is there
     a single constant c > 1 with h(n) = Θ(c^n)? -/
+
+/- ## Foundational lemmas (axiom-free)
+
+Elementary structural facts developing the def-only stub: monotonicity of the
+`n`-commuting property, the characterisation of the `n = 1` case as
+commutativity, and closure properties of the abelian-subgroup predicate. -/
+
+/-- The `n`-commuting property is monotone in `n`: a larger threshold is a
+weaker hypothesis (fewer subsets qualify), so it follows from a smaller one. -/
+theorem hasNCommutingProperty_mono {G : Type*} [Group G] {n m : ℕ} (hnm : n ≤ m)
+    (h : HasNCommutingProperty G n) : HasNCommutingProperty G m :=
+  fun S hS => h S (lt_of_le_of_lt hnm hS)
+
+/-- Every commutative group has the `1`-commuting property: any subset of size
+`> 1` contains two distinct (hence commuting) elements. -/
+theorem commGroup_hasNCommutingProperty_one {G : Type*} [CommGroup G] :
+    HasNCommutingProperty G 1 := by
+  intro S hS
+  obtain ⟨x, hx, y, hy, hxy⟩ := Finset.one_lt_card.mp hS
+  exact ⟨x, y, hx, hy, hxy, mul_comm x y⟩
+
+/-- **The `n = 1` case is exactly commutativity.** If `G` has the `1`-commuting
+property then any two elements commute: taking the two-element subset `{x, y}`
+of size `2 > 1`, its only distinct pair must commute. -/
+theorem commute_of_hasNCommutingProperty_one {G : Type*} [Group G]
+    (h : HasNCommutingProperty G 1) (x y : G) : x * y = y * x := by
+  classical
+  rcases eq_or_ne x y with rfl | hxy
+  · rfl
+  obtain ⟨a, b, ha, hb, hab, hcomm⟩ :=
+    h {x, y} (by rw [Finset.card_pair hxy]; norm_num)
+  simp only [Finset.mem_insert, Finset.mem_singleton] at ha hb
+  rcases ha with rfl | rfl <;> rcases hb with rfl | rfl
+  · exact absurd rfl hab
+  · exact hcomm
+  · exact hcomm.symm
+  · exact absurd rfl hab
+
+/-- The trivial subgroup is abelian. -/
+theorem isAbelianSubgroup_bot {G : Type*} [Group G] :
+    IsAbelianSubgroup G (⊥ : Subgroup G) := by
+  intro x y hx hy
+  rw [Subgroup.mem_bot] at hx hy
+  subst hx; subst hy; simp
+
+/-- In a commutative group the whole group is an abelian subgroup. -/
+theorem isAbelianSubgroup_top_of_commGroup {G : Type*} [CommGroup G] :
+    IsAbelianSubgroup G (⊤ : Subgroup G) :=
+  fun x y _ _ => mul_comm x y
+
+/-- The abelian-subgroup predicate is downward closed: a subgroup of an abelian
+subgroup is abelian. -/
+theorem isAbelianSubgroup_mono {G : Type*} [Group G] {H K : Subgroup G}
+    (hHK : H ≤ K) (hK : IsAbelianSubgroup G K) : IsAbelianSubgroup G H :=
+  fun x y hx hy => hK x y (hHK hx) (hHK hy)
+
+/-- `IsAbelianSubgroup` agrees with Mathlib's `IsMulCommutative` on the
+subgroup (the coerced subtype). -/
+theorem isAbelianSubgroup_iff_isMulCommutative {G : Type*} [Group G]
+    (H : Subgroup G) : IsAbelianSubgroup G H ↔ IsMulCommutative H := by
+  constructor
+  · intro h
+    exact isMulCommutative_iff.mpr (fun a b => Subtype.ext (h a b a.2 b.2))
+  · intro h x y hx hy
+    haveI := h
+    exact setLike_mul_comm hx hy

--- a/research/problems/erdos-117-wip-01/knowledge.md
+++ b/research/problems/erdos-117-wip-01/knowledge.md
@@ -19,3 +19,37 @@ Insights accumulated during research on this problem.
 ## Dead Ends
 
 [Approaches known not to work will be documented here]
+
+## Session 2026-07-20 (researcher-1) — n-commuting foundations for the def-only stub
+
+**Mode**: FRESH (knowledge score 0). **Outcome**: progress — 7 axiom-free lemmas,
+**host-verified v4.31** (`lake env lean`, exit 0; `#print axioms` spot-check clean).
+
+Erdős Problem 117 (OPEN): `h(n)` = min # abelian subgroups covering any group whose
+every size-`>n` subset has a commuting pair; `h(n)` is exponential (Pyber 1987).
+`Erdos117Problem.lean` held only `HasNCommutingProperty`, `IsAbelianSubgroup`,
+`abelianCoverNumber`. Added:
+
+- **commute_of_hasNCommutingProperty_one** (headline) — `HasNCommutingProperty G 1`
+  ⇒ every pair commutes. For distinct `x,y`, the subset `{x,y}` has card `2 > 1`, so its
+  only distinct pair must commute; a 4-way `rcases` on membership closes it. This
+  formalises the file's "Trivial Case n = 1 ⇒ G Abelian, h(1)=1" note.
+- **hasNCommutingProperty_mono** — monotone in `n` (larger threshold = weaker):
+  `n ≤ m` and the `n`-property give the `m`-property via `lt_of_le_of_lt`.
+- **commGroup_hasNCommutingProperty_one** — abelian ⇒ 1-commuting (`Finset.one_lt_card`).
+- **isAbelianSubgroup_bot / _top_of_commGroup / _mono** — closure of the abelian-subgroup
+  predicate (trivial subgroup; whole group when abelian; downward under `≤`).
+- **isAbelianSubgroup_iff_isMulCommutative** — the local `IsAbelianSubgroup G H` predicate
+  is equivalent to Mathlib's `IsMulCommutative H`.
+
+### v4.31 gotchas
+- `Subgroup.IsCommutative` and `mul_comm_of_mem_isCommutative` are GONE. Use the class
+  `IsMulCommutative H` (field `is_comm : Std.Commutative (·*·)`), the helper
+  `isMulCommutative_iff`, and `setLike_mul_comm (ha : a∈H) (hb : b∈H)` (needs the instance
+  in scope — `haveI := h`).
+- `Finset.card_pair (h : a ≠ b) : ({a,b}).card = 2`; construction of `{x,y}` needs
+  `DecidableEq G`, obtained via `classical`.
+
+### Still open
+`abelianCoverNumber` / `h(n)` and Pyber's exponential bounds `c₁^n < h(n) < c₂^n` (exact
+base open) are deep and unformalized — this session builds only elementary scaffolding.

--- a/src/data/proofs/erdos-117/meta.json
+++ b/src/data/proofs/erdos-117/meta.json
@@ -125,9 +125,9 @@
     ],
     "opens": [],
     "namespace": null,
-    "lineCount": 62,
+    "lineCount": 128,
     "axiomCount": 0,
-    "theoremCount": 0,
+    "theoremCount": 7,
     "definitionCount": 3,
     "path": "Proofs/Erdos117Problem.lean",
     "sorries": 0

--- a/src/data/research/problems/erdos-117-wip-01.json
+++ b/src/data/research/problems/erdos-117-wip-01.json
@@ -18,7 +18,7 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "OBSERVE",
+    "phase": "ORIENT",
     "since": "2026-07-09T17:33:20-07:00",
     "iteration": 1,
     "focus": "Initial problem understanding. Read problem.md and gather context.",
@@ -31,9 +31,16 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
+    "progressSummary": "FOUNDATIONS (researcher-1, 2026-07-20): developed the def-only Erdos117Problem.lean stub (Erdos Problem 117, covering groups by abelian subgroups, OPEN, h(n) exponential per Pyber 1987) with 7 axiom-free lemmas. Headline: commute_of_hasNCommutingProperty_one shows the n=1 case is EXACTLY commutativity (the size-2 subset {x,y} forces its only distinct pair to commute), matching the file TODO note h(1)=1. Plus hasNCommutingProperty_mono (monotone: larger n = weaker), commGroup_hasNCommutingProperty_one, isAbelianSubgroup_bot/_top_of_commGroup/_mono, and isAbelianSubgroup_iff_isMulCommutative bridging the local predicate to Mathlib IsMulCommutative (v4.31 rename of Subgroup.IsCommutative; setLike_mul_comm). File 62->128 lines, 0->7 theorems. abelianCoverNumber h(n) and Pyber exponential bounds remain deep/unformalized. Host-verified v4.31 lake env lean, exit 0; print axioms clean.",
+    "builtItems": [
+      "commute_of_hasNCommutingProperty_one - HasNCommutingProperty G 1 implies all pairs commute (Erdos117Problem.lean)",
+      "hasNCommutingProperty_mono - monotone, weaker at larger n (Erdos117Problem.lean)",
+      "commGroup_hasNCommutingProperty_one; isAbelianSubgroup_bot / _top_of_commGroup / _mono (Erdos117Problem.lean)",
+      "isAbelianSubgroup_iff_isMulCommutative - bridges local IsAbelianSubgroup to Mathlib IsMulCommutative (Erdos117Problem.lean)"
+    ],
+    "insights": [
+      "Erdos117Problem.lean stub developed: the n=1 case of the n-commuting property is EXACTLY commutativity (commute_of_hasNCommutingProperty_one) - the two-element subset {x,y} forces every distinct pair to commute; plus monotonicity and abelian-subgroup closure lemmas. All axiom-free."
+    ],
     "mathlibGaps": [],
     "nextSteps": [],
     "markdown": "# Knowledge Base: erdos-117-wip-01\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"


### PR DESCRIPTION
## Summary
Research session for **erdos-117-wip-01** (Erdős Problem 117: covering groups by
abelian subgroups — `h(n)` = minimum number of abelian subgroups needed to cover
any group whose every size-`>n` subset contains a commuting pair; `h(n)` is
exponential per Pyber 1987, exact base OPEN). The parent `Erdos117Problem.lean`
was a def-only stub (`HasNCommutingProperty`, `IsAbelianSubgroup`,
`abelianCoverNumber`). This develops it with 7 axiom-free lemmas.

## Progress
- **commute_of_hasNCommutingProperty_one** (headline) — `HasNCommutingProperty G 1`
  ⇒ every pair commutes: the two-element subset `{x,y}` has card `2 > 1`, so its
  only distinct pair must commute. Formalizes the file's "Trivial Case n=1 ⇒ G
  Abelian, h(1)=1" note.
- **hasNCommutingProperty_mono** — monotone in `n` (larger threshold = weaker).
- **commGroup_hasNCommutingProperty_one** — abelian ⇒ 1-commuting.
- **isAbelianSubgroup_bot / _top_of_commGroup / _mono** — closure of the
  abelian-subgroup predicate.
- **isAbelianSubgroup_iff_isMulCommutative** — bridges the local predicate to
  Mathlib's `IsMulCommutative`.

Files: `proofs/Proofs/Erdos117Problem.lean` (62→128 lines, 0→7 theorems), gallery
meta + research tracker synced.

## Verification
Host-verified on v4.31 (`lake env lean Proofs/Erdos117Problem.lean`, exit 0, no
errors). `#print axioms` on a spot-check = `[propext, Classical.choice, Quot.sound]`
(one lemma even `[propext, Quot.sound]`) — no `sorry`, no `native_decide`.

## Status
**Outcome**: progress (foundational scaffolding). `abelianCoverNumber`/`h(n)` and
Pyber's exponential bounds `c₁ⁿ < h(n) < c₂ⁿ` (exact base) remain deep and
unformalized.

🤖 Generated by researcher-1