### PR TITLE
Research: erdos-54-wip-01 — 5 axiom-free foundational lemmas on Ramsey 2-complete sets

### DIFF
--- a/proofs/Proofs/Erdos54Problem.lean
+++ b/proofs/Proofs/Erdos54Problem.lean
@@ -78,3 +78,42 @@ def ErdosProblem54 : Prop :=
 
 /- Burr–Erdős (1985): There exists a Ramsey 2-complete set with
 `|A ∩ [1,N]| < (2 log₂ N)³`. This was improved by Conlon–Fox–Pham. -/
+
+/- ## Foundational lemmas (axiom-free)
+
+Elementary structural facts developing the def-only stub: membership witnesses
+for the monochromatic subset-sum set (`0` and singletons), and basic bounds and
+monotonicity of the counting function `|A ∩ [1,N]|`. -/
+
+/-- `0` is a monochromatic subset sum of any colour (via the empty subset). -/
+theorem zero_mem_monoSubsetSums (A : Set ℕ) (c : Colouring2 A) (colour : Bool) :
+    0 ∈ monoSubsetSums A c colour :=
+  ⟨∅, by simp, rfl⟩
+
+/-- A single element `n ∈ A` of colour `colour` is itself a monochromatic
+subset sum of that colour. -/
+theorem singleton_mem_monoSubsetSums {A : Set ℕ} {c : Colouring2 A} {colour : Bool}
+    {n : ℕ} (hn : n ∈ A) (hc : c ⟨n, hn⟩ = colour) :
+    n ∈ monoSubsetSums A c colour := by
+  refine ⟨{n}, ?_, by simp⟩
+  intro m hm
+  rw [Finset.mem_singleton] at hm; subst hm
+  exact ⟨hn, hc⟩
+
+/-- The counting function at `0` is `0` (the range `[1,0]` is empty). -/
+theorem countingFn_zero (A : Set ℕ) : countingFn A 0 = 0 := by
+  simp [countingFn]
+
+/-- `|A ∩ [1,N]| ≤ N`. -/
+theorem countingFn_le (A : Set ℕ) (N : ℕ) : countingFn A N ≤ N := by
+  unfold countingFn
+  calc ((Finset.Icc 1 N).filter (· ∈ A)).card
+      ≤ (Finset.Icc 1 N).card := Finset.card_filter_le _ _
+    _ = N := by rw [Nat.card_Icc]; omega
+
+/-- The counting function is monotone in `N`. -/
+theorem countingFn_mono (A : Set ℕ) {N M : ℕ} (h : N ≤ M) :
+    countingFn A N ≤ countingFn A M := by
+  unfold countingFn
+  apply Finset.card_le_card
+  exact Finset.filter_subset_filter _ (Finset.Icc_subset_Icc_right h)

--- a/research/problems/erdos-54-wip-01/knowledge.md
+++ b/research/problems/erdos-54-wip-01/knowledge.md
@@ -19,3 +19,26 @@ Insights accumulated during research on this problem.
 ## Dead Ends
 
 [Approaches known not to work will be documented here]
+
+## Session 2026-07-20 (researcher-1) — Ramsey-2-complete foundations for the def-only stub
+
+**Mode**: FRESH (knowledge score 0). **Outcome**: progress — 5 axiom-free lemmas,
+**host-verified v4.31** (`lake env lean`, exit 0; `#print axioms` spot-check clean).
+
+Erdős Problem 54 (SOLVED, Conlon–Fox–Pham 2021: minimum growth of a Ramsey 2-complete
+set is `Θ((log N)²)`). `Erdos54Problem.lean` held only defs (`Colouring2`,
+`monoSubsetSums`, `IsRamsey2Complete`, `countingFn`, `ErdosProblem54`). Added:
+
+- **zero_mem_monoSubsetSums** — `0` is a monochromatic subset sum of any colour (empty
+  subset, vacuous colour condition).
+- **singleton_mem_monoSubsetSums** — a single `n ∈ A` of colour `colour` is its own
+  monochromatic subset sum.
+- **countingFn_zero** — `countingFn A 0 = 0` (`Icc 1 0` empty).
+- **countingFn_le** — `|A ∩ [1,N]| ≤ N` (`Finset.card_filter_le` + `Nat.card_Icc`).
+- **countingFn_mono** — monotone in `N` (`Finset.filter_subset_filter` +
+  `Finset.Icc_subset_Icc_right`).
+
+### Still open
+The Burr–Erdős lower bound and Conlon–Fox–Pham `(log N)²` upper bound (and hence
+`ErdosProblem54` itself) remain unformalized — this session builds only elementary
+scaffolding around the definitions.

--- a/src/data/proofs/erdos-54/meta.json
+++ b/src/data/proofs/erdos-54/meta.json
@@ -153,9 +153,9 @@
     ],
     "opens": [],
     "namespace": null,
-    "lineCount": 78,
+    "lineCount": 119,
     "axiomCount": 0,
-    "theoremCount": 0,
+    "theoremCount": 5,
     "definitionCount": 5,
     "path": "Proofs/Erdos54Problem.lean",
     "sorries": 0

--- a/src/data/research/problems/erdos-54-wip-01.json
+++ b/src/data/research/problems/erdos-54-wip-01.json
@@ -18,7 +18,7 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "OBSERVE",
+    "phase": "ORIENT",
     "since": "2026-07-09T17:33:19-07:00",
     "iteration": 1,
     "focus": "Initial problem understanding. Read problem.md and gather context.",
@@ -31,9 +31,14 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
+    "progressSummary": "FOUNDATIONS (researcher-1, 2026-07-20): developed the def-only Erdos54Problem.lean stub (Erdos Problem 54, Ramsey 2-complete sets, SOLVED by Conlon-Fox-Pham 2021 at Theta((log N)^2)) with 5 axiom-free lemmas. Membership witnesses for monoSubsetSums (0 via empty subset; a colour-matching singleton is its own monochromatic subset sum) and basic counting-function facts: countingFn_zero, countingFn_le (|A cap [1,N]| <= N via card_filter_le + Nat.card_Icc), countingFn_mono (monotone via Finset.filter_subset_filter + Icc_subset_Icc_right). File 78->119 lines, 0->5 theorems. The Burr-Erdos / Conlon-Fox-Pham (log N)^2 bounds themselves remain unformalized. Host-verified v4.31 lake env lean, exit 0; print axioms clean.",
+    "builtItems": [
+      "zero_mem_monoSubsetSums, singleton_mem_monoSubsetSums (Erdos54Problem.lean)",
+      "countingFn_zero, countingFn_le (<= N via card_filter_le + Nat.card_Icc), countingFn_mono (Icc_subset_Icc_right) (Erdos54Problem.lean)"
+    ],
+    "insights": [
+      "Erdos54Problem.lean stub developed: 5 axiom-free foundational lemmas - monochromatic subset-sum membership witnesses (0 via empty subset, singletons of matching colour) and counting-function bounds (countingFn A N <= N, monotone in N, zero at 0). All axiom-free."
+    ],
     "mathlibGaps": [],
     "nextSteps": [],
     "markdown": "# Knowledge Base: erdos-54-wip-01\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"


### PR DESCRIPTION
## Summary
Research session for **erdos-54-wip-01** (Erdős Problem 54: Ramsey 2-complete sets
— minimum growth rate is `Θ((log N)²)`, solved by Conlon–Fox–Pham 2021). The
parent `Erdos54Problem.lean` was a def-only stub (`Colouring2`, `monoSubsetSums`,
`IsRamsey2Complete`, `countingFn`, `ErdosProblem54`). This develops it with 5
axiom-free lemmas.

## Progress
- **zero_mem_monoSubsetSums** — `0` is a monochromatic subset sum of any colour
  (empty subset, vacuous colour condition).
- **singleton_mem_monoSubsetSums** — a single `n ∈ A` of colour `colour` is its own
  monochromatic subset sum.
- **countingFn_zero** — `countingFn A 0 = 0`.
- **countingFn_le** — `|A ∩ [1,N]| ≤ N` (`Finset.card_filter_le` + `Nat.card_Icc`).
- **countingFn_mono** — monotone in `N` (`Finset.filter_subset_filter` +
  `Finset.Icc_subset_Icc_right`).

Files: `proofs/Proofs/Erdos54Problem.lean` (78→119 lines, 0→5 theorems), gallery
meta + research tracker synced.

## Verification
Host-verified on v4.31 (`lake env lean Proofs/Erdos54Problem.lean`, exit 0, no
errors). `#print axioms` on a spot-check = `[propext, Classical.choice, Quot.sound]`
(one lemma even `[propext, Quot.sound]`) — no `sorry`, no `native_decide`.

## Status
**Outcome**: progress (foundational scaffolding). The Burr–Erdős lower bound and
Conlon–Fox–Pham `(log N)²` upper bound (hence `ErdosProblem54` itself) remain
unformalized.

🤖 Generated by researcher-1