### PR TITLE
Enrich szemeredi-hypergraph-core-oq-01-incomplete-01: fix tail line-range drift (322→310)

### DIFF
--- a/src/data/proofs/szemeredi-hypergraph-core-oq-01-incomplete-01/meta.json
+++ b/src/data/proofs/szemeredi-hypergraph-core-oq-01-incomplete-01/meta.json
@@ -46,7 +46,7 @@
     ],
     "dateAdded": "2026-04-21",
     "axiomCount": 0,
-    "lineCount": 322,
+    "lineCount": 310,
     "assumptions": "Infrastructure file: 0 sorries, 0 axioms. Provides definitions (SimplicialComplex, completeComplex, topCliques, relativeKDensity, IsGowersRegular, globalDensity) and supporting lemmas. A previously-attempted naive_implies_gowers theorem was removed; the obstruction (sub-complex topCliques are not generally transversals of vertex sub-parts) is documented in-file (Part VII), and three provable surrogates are supplied instead (relativeKDensity_eq_of_topCliques_eq, isGowersRegular_self, isGowersRegular_empty).",
     "mathlib_version": "4.31.0",
     "theoremCount": 14,
@@ -129,7 +129,7 @@
       "title": "Part VII: Documented Obstruction (Naive → Gowers)",
       "summary": "Documents why a direct naive_implies_gowers does not hold: with parts = [univ × k] the transversal set is empty, so the transversal-based hypothesis only bounds density against 0 and cannot control arbitrary sub-complexes. Lists the provable surrogates and the partition-respecting hypothesis that would be needed to bridge weak (transversal) to strong (relative-to-complex) regularity, per Gowers (2007) §4.",
       "startLine": 278,
-      "endLine": 322,
+      "endLine": 310,
       "mathContext": "Documents why a direct naive_implies_gowers does not hold: with parts = [univ × k] the transversal set is empty, so the transversal-based hypothesis only bounds density against 0 and cannot control arbitrary sub-complexes. Lists the provable surrogates and the partition-respecting hypothesis that would be needed to bridge weak (transversal) to strong (relative-to-complex) regularity, per Gowers (2007) §4."
     }
   ],
@@ -186,7 +186,7 @@
       "Classical"
     ],
     "namespace": "Szemeredi.Hypergraph",
-    "lineCount": 322,
+    "lineCount": 310,
     "axiomCount": 0,
     "theoremCount": 14,
     "definitionCount": 7,


### PR DESCRIPTION
## Summary

`SzemerediHypergraphGowers.lean` is **310 lines** (last line: `end Szemeredi.Hypergraph`), but three trailing metadata values read **322** (a 12-line overshoot):

- `meta.lineCount`: 322 → **310**
- `leanFile.lineCount`: 322 → **310**
- final section `obstruction-naive-to-gowers` `endLine`: 322 → **310**

Earlier sections and all annotations (max endLine 244) were already within range. No Lean source or status/axiom/theorem-count changes.

## Verification

- `wc -l` = 310 for the Lean file.
- JSON validated; section max endLine now = 310 ≤ file length.