### PR TITLE
Enrich cayley-hamilton-minpoly-oq-05-oq-01-oq-04-wip-01: fix annotation range drift (290→279)

### DIFF
--- a/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-01-oq-04-wip-01/annotations.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-01-oq-04-wip-01/annotations.json
@@ -179,8 +179,8 @@
     "id": "ann-axiom-main",
     "proofId": "cayley-hamilton-minpoly-oq-05-oq-01-oq-04-wip-01",
     "range": {
-      "startLine": 235,
-      "endLine": 290
+      "startLine": 230,
+      "endLine": 279
     },
     "type": "insight",
     "title": "The Axiom and Final Assembly: Nonderogatory ⟹ Cyclic Vector",


### PR DESCRIPTION
## Summary

The final annotation `ann-axiom-main` had range **235–290** in a **279-line** file. Retargeted to **230–279** so it accurately covers the axiom `nonderogatory_similar_to_companion` (line 230) through the file end (line 279) — matching its "The Axiom and Final Assembly" content.

## Notes

- All other annotations and sections were already within range.
- Axiom accounting is already honest: `status: axiomatized`, `badge: axiom`, `axiomCount: 1`, matching the single `axiom` declaration in the file. No status changes.

## Verification

- `wc -l` = 279; annotation max endLine now = 279.
- JSON validated.