### PR TITLE
Enrich lebesgue-measure-oq-01-oq-01-oq-02: fix trailing annotation range drift

### DIFF
--- a/src/data/proofs/lebesgue-measure-oq-01-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/lebesgue-measure-oq-01-oq-01-oq-02/annotations.json
@@ -181,7 +181,7 @@
     "proofId": "lebesgue-measure-oq-01-oq-01-oq-02",
     "range": {
       "startLine": 165,
-      "endLine": 222
+      "endLine": 213
     },
     "type": "insight",
     "title": "Continuity at Every Irrational: Epsilon-Delta via Finite Denominator Control",
@@ -208,8 +208,8 @@
     "id": "ann-iff",
     "proofId": "lebesgue-measure-oq-01-oq-01-oq-02",
     "range": {
-      "startLine": 229,
-      "endLine": 239
+      "startLine": 218,
+      "endLine": 230
     },
     "type": "insight",
     "title": "Complete Characterization: Continuous Exactly at Irrationals",


### PR DESCRIPTION
## Summary

`LebesgueMeasureOQ01OQ01OQ02.lean` (Thomae's function) is **230 lines**, but the last annotation `ann-iff` ran to **229–239** — starting at the `end` line and overshooting past the file.

- `ann-iff`: 229–239 → **218–230** (covers `thomae_continuous_iff`: docstring 218, theorem 219–228, `end` 230).
- `ann-continuity`: 165–222 → **165–213** (its theorem `thomae_continuous_at_irrational` ends at 213), removing the resulting overlap with the iff theorem.

Sections and `lineCount` were already correct (230). No Lean source or status changes.

## Verification

- `wc -l` = 230; annotation ranges now all ≤ 230, non-overlapping, ordered.