### PR TITLE
audit: erdos-686 — disclose native_decide (Lean.ofReduceBool) trust dependency

### DIFF
--- a/src/data/proofs/erdos-686/meta.json
+++ b/src/data/proofs/erdos-686/meta.json
@@ -34,7 +34,7 @@
       "native_decide"
     ],
     "lineCount": 293,
-    "assumptions": "None. Fully verified: 0 axioms, 0 sorries. The open conjecture (Erdos686Conjecture) is stated as a Prop definition, not axiomatized. All supporting infrastructure is proved. Open conjecture; supporting lemmas fully verified.",
+    "assumptions": "0 explicit `axiom` declarations, 0 sorries. The open conjecture (Erdos686Conjecture) is stated as a Prop definition, not axiomatized, and all supporting infrastructure is proved. Trust caveat: the three verified examples `example_N6`, `example_N3`, and `example_N10` close numeric goals with `native_decide`, so each depends on the `Lean.ofReduceBool` axiom (`#print axioms` shows a `native_decide.ax` beyond propext/Classical.choice/Quot.sound). These results shift trust from the kernel to the compiler for those computations; the structural lemmas are kernel-verified without native_decide.",
     "mathlib_version": "4.31.0",
     "theoremCount": 23,
     "definitionCount": 9


### PR DESCRIPTION
## Integrity Issue

**Proof**: erdos-686 (Erdős Problem #686: Ratios of Products of Consecutive Integers)
**Problem**: `meta.assumptions` overstated the trust base — it claimed "None. Fully verified: 0 axioms, 0 sorries" while three theorems rely on `native_decide`, which shifts trust to compiled code via the `Lean.ofReduceBool` axiom.

## Evidence

**meta.assumptions claimed**: `"None. Fully verified: 0 axioms, 0 sorries. ... supporting lemmas fully verified."`

**Lean file shows**: `example_N6`, `example_N3`, `example_N10` (Proofs/Erdos686Problem.lean:230, 238, 244) close their numeric goals with `native_decide`.

**Kernel confirmation** (`#print axioms`, built via docker-build.sh):
```
'Erdos686.example_N6'  depends on axioms: [propext, Classical.choice, Quot.sound, example_N6._native.native_decide.ax_1_1]
'Erdos686.example_N3'  depends on axioms: [propext, Classical.choice, Quot.sound, example_N3._native.native_decide.ax_1_1]
'Erdos686.example_N10' depends on axioms: [propext, Classical.choice, Quot.sound, example_N10._native.native_decide.ax_1_1]
```
The `native_decide.ax` entries are the `Lean.ofReduceBool` trust axiom — the kernel does not verify these computations.

## Fix

Rewrote `meta.assumptions` to disclose the `native_decide` / `Lean.ofReduceBool` compiled-code trust dependency for the three verified examples, while noting the structural lemmas remain kernel-verified without native_decide. No count fields changed (0 explicit `axiom` declarations, 0 sorries remain accurate).

---
Discovered during gallery integrity audit (reserve mode, re-serve of erdos-686).