### PR TITLE
Research: erdos-53-wip-01 — k=1 base case + distinct-prime richness (batch 2, 12 axiom-free lemmas)

### DIFF
--- a/proofs/Proofs/Erdos53Problem.lean
+++ b/proofs/Proofs/Erdos53Problem.lean
@@ -194,4 +194,130 @@ theorem productset_card_le (A : Finset ℤ) : (productset A).card ≤ A.card ^ 2
 theorem subsetSums_empty : subsetSums (∅ : Finset ℤ) = {0} := by
   rw [subsetSums, Finset.powerset_empty, Finset.image_singleton, Finset.sum_empty]
 
+/-
+## Section 8: The `k = 1` base case, the trivial upper bracket, and
+distinct-prime richness (all axiom-free)
+
+Section 7 recorded structural facts about `subsetSums`.  Here we (i) prove the
+`k = 1` slice of the Erdős–Szemerédi lower bound — the one instance of Problem 53
+that is elementary — (ii) supply the matching trivial *upper* bracket
+`|sumsOrProducts A| ≤ 2^{|A|+1}`, (iii) fill in the missing `subsetProducts`
+analogues of the Section-7 `subsetSums` lemmas, and (iv) prove the distinct-prime
+richness fact `|subsetProducts A| = 2^{|A|} - 1` (Chang's problem.md "Key lemma 2"),
+which shows the trivial upper bound is *attained* for sets of distinct primes.  All
+lemmas remain axiom-free (`propext / Classical.choice / Quot.sound` only). -/
+
+/-- Every element of `A` is a subset sum, so `A ⊆ subsetSums A`. -/
+theorem subset_subsetSums (A : Finset ℤ) : A ⊆ subsetSums A :=
+  fun _ ha => mem_subsetSums_of_mem ha
+
+/-- The representable count is at least `|A|`: the ground set embeds into the
+    subset sums, which in turn sit inside `sumsOrProducts A`. -/
+theorem card_le_sumsOrProducts (A : Finset ℤ) : A.card ≤ (sumsOrProducts A).card :=
+  Finset.card_le_card ((subset_subsetSums A).trans (subsetSums_subset_sumsOrProducts A))
+
+/-- **Erdős Problem 53 holds for the exponent `k = 1`.** Taking `N₀ = 0`, every
+    finite `A` already satisfies `|sumsOrProducts A| ≥ |A|^1`.  This is the
+    elementary base case of the Erdős–Szemerédi lower bound; the deep content of
+    Chang's theorem is the growth to `|A|^k` for every `k`, which stays
+    documented (not axiomatized) above. -/
+theorem erdosProblem53_exponent_one :
+    ∃ N₀ : ℕ, ∀ A : Finset ℤ, A.card ≥ N₀ → (sumsOrProducts A).card ≥ A.card ^ 1 := by
+  refine ⟨0, fun A _ => ?_⟩
+  simpa using card_le_sumsOrProducts A
+
+/-- `subsetProducts` of the empty set is empty: there are no nonempty subsets. -/
+theorem subsetProducts_empty : subsetProducts (∅ : Finset ℤ) = ∅ := by
+  rw [subsetProducts, Finset.powerset_empty]
+  simp
+
+/-- There are at most `2^{|A|}` subset products (image of a subfamily of the
+    powerset). -/
+theorem subsetProducts_card_le (A : Finset ℤ) : (subsetProducts A).card ≤ 2 ^ A.card := by
+  rw [subsetProducts]
+  calc ((A.powerset.filter (fun S => S.Nonempty)).image (fun S => S.prod id)).card
+      ≤ (A.powerset.filter (fun S => S.Nonempty)).card := Finset.card_image_le
+    _ ≤ A.powerset.card := Finset.card_filter_le _ _
+    _ = 2 ^ A.card := Finset.card_powerset A
+
+/-- Subset products are monotone in the ground set. -/
+theorem subsetProducts_mono {A B : Finset ℤ} (h : A ⊆ B) :
+    subsetProducts A ⊆ subsetProducts B := by
+  rw [subsetProducts, subsetProducts]
+  exact Finset.image_subset_image (Finset.filter_subset_filter _ (Finset.powerset_mono.mpr h))
+
+/-- The sum-or-product representable set is monotone in the ground set. -/
+theorem sumsOrProducts_mono {A B : Finset ℤ} (h : A ⊆ B) :
+    sumsOrProducts A ⊆ sumsOrProducts B := by
+  rw [sumsOrProducts, sumsOrProducts]
+  exact Finset.union_subset_union (subsetSums_mono h) (subsetProducts_mono h)
+
+/-- `0` is always representable (as the empty subset sum). -/
+theorem zero_mem_sumsOrProducts (A : Finset ℤ) : (0 : ℤ) ∈ sumsOrProducts A :=
+  subsetSums_subset_sumsOrProducts A (zero_mem_subsetSums A)
+
+/-- The representable set is always nonempty. -/
+theorem sumsOrProducts_nonempty (A : Finset ℤ) : (sumsOrProducts A).Nonempty :=
+  ⟨0, zero_mem_sumsOrProducts A⟩
+
+/-- Trivial upper bracket: the representable count is at most `2^{|A|+1}`.
+    Together with `card_le_sumsOrProducts` this pins `|sumsOrProducts A|` between
+    `|A|` and `2^{|A|+1}`; Chang's theorem sharpens the *lower* end to `|A|^k`. -/
+theorem sumsOrProducts_card_le (A : Finset ℤ) :
+    (sumsOrProducts A).card ≤ 2 ^ (A.card + 1) := by
+  rw [sumsOrProducts]
+  calc (subsetSums A ∪ subsetProducts A).card
+      ≤ (subsetSums A).card + (subsetProducts A).card := Finset.card_union_le _ _
+    _ ≤ 2 ^ A.card + 2 ^ A.card :=
+        Nat.add_le_add (subsetSums_card_le A) (subsetProducts_card_le A)
+    _ = 2 ^ (A.card + 1) := by rw [pow_succ]; ring
+
+/-- For a set `A` of **distinct positive primes**, subset products are pairwise
+    distinct: a positive prime `p ∈ A` divides `∏ S` iff `p ∈ S`, so the subset
+    is recovered from its product.  (Positivity rules out the `p ↔ -p` collision
+    that `Prime` alone permits over `ℤ`.) -/
+theorem subsetProd_injOn_of_prime {A : Finset ℤ}
+    (hA : ∀ p ∈ A, Prime p) (hpos : ∀ p ∈ A, 0 < p) :
+    Set.InjOn (fun S => S.prod id) (A.powerset : Set (Finset ℤ)) := by
+  have key : ∀ U : Finset ℤ, U ⊆ A → ∀ p, p ∈ A → (p ∈ U ↔ p ∣ U.prod id) := by
+    intro U hU p hp
+    refine ⟨fun hpU => Finset.dvd_prod_of_mem id hpU, fun hdvd => ?_⟩
+    rcases (Prime.dvd_finsetProd_iff (hA p hp) id).mp hdvd with ⟨x, hxU, hpx⟩
+    have hxA : x ∈ A := hU hxU
+    have hnat : p.natAbs = x.natAbs :=
+      Int.associated_iff_natAbs.mp ((hA p hp).associated_of_dvd (hA x hxA) hpx)
+    have hp' : (p.natAbs : ℤ) = p := Int.natAbs_of_nonneg (le_of_lt (hpos p hp))
+    have hx' : (x.natAbs : ℤ) = x := Int.natAbs_of_nonneg (le_of_lt (hpos x hxA))
+    have hpx' : p = x := by rw [← hp', ← hx', hnat]
+    rw [hpx']; exact hxU
+  intro S hS T hT hST
+  rw [Finset.mem_coe, Finset.mem_powerset] at hS hT
+  have hST : S.prod id = T.prod id := hST
+  apply Finset.ext
+  intro p
+  by_cases hp : p ∈ A
+  · rw [key S hS p hp, key T hT p hp, hST]
+  · exact ⟨fun h => absurd (hS h) hp, fun h => absurd (hT h) hp⟩
+
+/-- **Distinct-prime richness (problem.md "Key lemma 2").** For a set `A` of
+    distinct positive primes, the number of distinct nonempty subset products is
+    exactly `2^{|A|} - 1` — unique factorization makes every nonempty subset
+    yield a different product.  This exhibits sets attaining the trivial upper
+    bound `sumsOrProducts_card_le` on the multiplicative side. -/
+theorem subsetProducts_card_of_prime {A : Finset ℤ}
+    (hA : ∀ p ∈ A, Prime p) (hpos : ∀ p ∈ A, 0 < p) :
+    (subsetProducts A).card = 2 ^ A.card - 1 := by
+  have hsub : (↑(A.powerset.filter (fun S => S.Nonempty)) : Set (Finset ℤ)) ⊆ ↑A.powerset :=
+    Finset.coe_subset.mpr (Finset.filter_subset _ _)
+  have hinj : Set.InjOn (fun S => S.prod id)
+      (↑(A.powerset.filter (fun S => S.Nonempty)) : Set (Finset ℤ)) :=
+    Set.InjOn.mono hsub (subsetProd_injOn_of_prime hA hpos)
+  rw [subsetProducts, Finset.card_image_of_injOn hinj]
+  have hfe : A.powerset.filter (fun S => S.Nonempty) = A.powerset.erase ∅ := by
+    ext S
+    simp only [Finset.mem_filter, Finset.mem_erase, Finset.mem_powerset,
+      Finset.nonempty_iff_ne_empty]
+    tauto
+  rw [hfe, Finset.card_erase_of_mem (Finset.empty_mem_powerset A), Finset.card_powerset]
+
 end Erdos53

--- a/research/problems/erdos-53-wip-01/knowledge.md
+++ b/research/problems/erdos-53-wip-01/knowledge.md
@@ -32,3 +32,46 @@ membership (`0` and each element), inclusions into `sumsOrProducts`, `subsetSums
 (≤ |A|²), and `subsetSums_empty` ({0}). Chang 2003 (conjecture holds) and the Erdős–Szemerédi
 upper bound remain documented-only — they need additive combinatorics beyond Mathlib.
 Meta synced (theoremCount 0 → 12, lineCount 116 → 197).
+
+---
+
+## Session 2026-07-20 (researcher-1): k=1 base case + distinct-prime richness
+
+Batch 2 of axiom-free lemmas added to `Proofs/Erdos53Problem.lean` (Section 8),
+raising the theorem count 12 → 24, still 0 axioms. Host-verified with
+`lake env lean` (Mathlib-only imports); `#print axioms` on every new headline
+theorem yields only `[propext, Classical.choice, Quot.sound]`.
+
+Key results (mechanism, not wording):
+
+- **k=1 base case (`erdosProblem53_exponent_one`)**: `A ⊆ subsetSums A ⊆
+  sumsOrProducts A` gives `|A| ≤ |sumsOrProducts A|`, i.e. the `k=1` slice of the
+  Erdős–Szemerédi lower bound holds with `N₀ = 0`. This is the *only* elementary
+  instance of Problem 53; growth to `|A|^k` for `k ≥ 2` is Chang's deep theorem.
+- **Distinct-prime richness (`subsetProducts_card_of_prime`)**: for a `Finset ℤ`
+  of distinct **positive** primes, `|subsetProducts A| = 2^{|A|} - 1`. Proof =
+  subset-product injectivity (`subsetProd_injOn_of_prime`): for a positive prime
+  `p ∈ A`, `p ∈ S ↔ p ∣ ∏ S` (via `Prime.dvd_finsetProd_iff` +
+  `Prime.associated_of_dvd` + `Int.associated_iff_natAbs`, with positivity
+  killing the `p ↔ -p` collision that `Prime` alone allows over `ℤ`), so a
+  nonempty subset is recovered from its product. Number of nonempty subsets =
+  `2^{|A|} - 1` via `powerset.erase ∅`.
+- **Trivial upper bracket (`sumsOrProducts_card_le`)**: `|sumsOrProducts A| ≤
+  2^{|A|+1}`. Combined with the base case this pins the count in `[|A|,
+  2^{|A|+1}]`; distinct-prime richness shows the multiplicative side of the upper
+  bound is essentially attained.
+- Missing `subsetProducts` analogues filled: `subsetProducts_empty`,
+  `subsetProducts_card_le`, `subsetProducts_mono`; plus `sumsOrProducts_mono`,
+  `zero_mem_sumsOrProducts`, `sumsOrProducts_nonempty`, `subset_subsetSums`.
+
+### Insight
+Positivity (not just `Prime`) is required for the ℤ richness lemma: `Prime`
+over `ℤ` is closed under negation, so `{2, -2}` would collide on products
+without the `0 < p` hypothesis. Stated with `hpos : ∀ p ∈ A, 0 < p`.
+
+### Next targets
+- Small concrete `decide` computations of `|sumsOrProducts A|` for explicit tiny
+  `A` (problem.md item iii) — bounded by `2^{|A|}` powerset enumeration.
+- Chang's theorem and the Erdős–Szemerédi subexponential upper bound remain
+  genuinely deep (Balog–Szemerédi–Gowers, multiplicative energy) and out of
+  Mathlib scope; keep documented, not axiomatized.

--- a/research/problems/erdos-53-wip-01/state.md
+++ b/research/problems/erdos-53-wip-01/state.md
@@ -4,13 +4,13 @@
 **Phase**: ORIENT
 **Path**: full
 **Since**: 2026-07-09T17:33:19-07:00
-**Iteration**: 1
+**Iteration**: 2
 
 ## Current Focus
-Initial problem understanding. Read problem.md and gather context.
+Batch 2 of axiom-free lemmas landed (Section 8): k=1 base case, distinct-prime richness 2^|A|-1, trivial upper bracket. Theorem count 12 -> 24, still 0 axioms.
 
 ## Active Approach
-None yet.
+Elementary structural formalization of subset-sum/product sets; Chang deep theorem stays documented.
 
 ## Attempt Count
 - Total attempts: 0
@@ -21,5 +21,4 @@ None yet.
 None.
 
 ## Next Action
-Read problem.md thoroughly and acquire full context.
-Then move to ORIENT phase to explore literature and related proofs.
+Optional: small decide computations of |sumsOrProducts A| for tiny explicit A (problem.md item iii). Chang/Erdős–Szemerédi upper bound out of Mathlib scope.

--- a/src/data/proofs/erdos-53/meta.json
+++ b/src/data/proofs/erdos-53/meta.json
@@ -20,7 +20,7 @@
     "erdosUrl": "https://erdosproblems.com/53",
     "erdosProblemStatus": "proved",
     "axiomCount": 0,
-    "lineCount": 197,
+    "lineCount": 323,
     "prerequisites": [
       "Sumsets and product sets",
       "Additive vs multiplicative structure",
@@ -29,7 +29,7 @@
     ],
     "assumptions": "0 axioms, 0 sorries. The file states the problem (defs subsetSums, subsetProducts, sumsOrProducts, ErdosProblem53, sumset, productset, SumProductConjecture, subsetSumCount, subsetProductCount) and proves 12 axiom-free foundational lemmas about those definitions. The Erdos-Szemeredi conjecture (Chang 2003) and the exp((log|A|)^2 loglog|A|) upper bound require deep additive combinatorics beyond current Mathlib and remain described in doc-comments only, NOT formalized. The formalized lemmas are elementary: subset-sum/product membership (0 and each element), inclusion of subset sums/products into sumsOrProducts, the 2^|A| bound on subset sums, monotonicity, the |A|^2 bounds on the sumset/product set, and subsetSums(emptyset)={0}.",
     "mathlib_version": "4.31.0",
-    "theoremCount": 12,
+    "theoremCount": 24,
     "definitionCount": 9
   },
   "overview": {
@@ -124,9 +124,9 @@
       "Finset"
     ],
     "namespace": "Erdos53",
-    "lineCount": 197,
+    "lineCount": 323,
     "axiomCount": 0,
-    "theoremCount": 12,
+    "theoremCount": 24,
     "definitionCount": 9,
     "path": "Proofs/Erdos53Problem.lean",
     "sorries": 0

--- a/src/data/research/problems/erdos-53-wip-01.json
+++ b/src/data/research/problems/erdos-53-wip-01.json
@@ -18,12 +18,12 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "ORIENT",
+    "phase": "ACT",
     "since": "2026-07-09T17:33:19-07:00",
-    "iteration": 1,
-    "focus": "Initial problem understanding. Read problem.md and gather context.",
+    "iteration": 2,
+    "focus": "Batch 2 axiom-free lemmas landed (Section 8): k=1 base case (erdosProblem53_exponent_one), distinct-prime richness |subsetProducts A|=2^|A|-1, trivial upper bracket 2^(|A|+1). Theorem count 12->24, 0 axioms, host-verified.",
     "blockers": [],
-    "nextAction": "Read problem.md thoroughly and acquire full context.",
+    "nextAction": "Optional: small decide computations of |sumsOrProducts A| for tiny explicit A (problem.md item iii). Chang theorem + Erdős–Szemerédi upper bound stay documented (out of Mathlib scope).",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -40,7 +40,8 @@
     ],
     "insights": [
       "Erdos53Problem.lean was a definitions-only stub (9 defs, 0 theorems). Chang 2003 (conjecture holds) and the Erdos-Szemeredi upper bound need deep additive combinatorics beyond Mathlib; tractable axiom-free content is elementary structural facts about subsetSums/subsetProducts/sumset/productset.",
-      "Clean generic Finset targets that generalize across these stubs: image-of-powerset card bound (card_image_le + card_powerset gives <= 2^|A|), image-of-product card bound (card_image_le + card_product gives <= |A|^2), monotonicity via powerset_mono + image_subset_image, membership via singleton subset."
+      "Clean generic Finset targets that generalize across these stubs: image-of-powerset card bound (card_image_le + card_powerset gives <= 2^|A|), image-of-product card bound (card_image_le + card_product gives <= |A|^2), monotonicity via powerset_mono + image_subset_image, membership via singleton subset.",
+      "k=1 slice of Problem 53 is elementary: A ⊆ subsetSums A ⊆ sumsOrProducts A gives |A| ≤ |sumsOrProducts A| (erdosProblem53_exponent_one, N₀=0). Distinct-prime richness |subsetProducts A|=2^|A|-1 requires 0<p (Prime over ℤ is closed under negation; positivity kills the p↔-p product collision). Proved axiom-free via Prime.dvd_finsetProd_iff + Prime.associated_of_dvd + Int.associated_iff_natAbs."
     ],
     "mathlibGaps": [],
     "nextSteps": [],
@@ -64,7 +65,7 @@
     "mathlib": []
   },
   "started": "2026-07-10T00:41:25.781Z",
-  "lastUpdate": "2026-07-10T00:41:25.928Z",
+  "lastUpdate": "2026-07-20",
   "significance": 7,
   "tractability": 6
 }


### PR DESCRIPTION
## Summary

Second batch of **axiom-free** foundational lemmas for Erdős Problem #53 (sums
and products of distinct elements), added as Section 8 of
`proofs/Proofs/Erdos53Problem.lean`. Builds on the merged batch 1 (#39534). The
theorem count rises 12 → 24; the file still has **0 axiom declarations, 0
sorries**. Chang's deep 2003 theorem and the Erdős–Szemerédi subexponential
upper bound remain documented in prose (not axiomatized).

## Headline results

- **`erdosProblem53_exponent_one`** — the **k = 1 slice** of the
  Erdős–Szemerédi lower bound: since `A ⊆ subsetSums A ⊆ sumsOrProducts A`, every
  finite `A` satisfies `|sumsOrProducts A| ≥ |A|^1` (with `N₀ = 0`). This is the
  one elementary instance of Problem 53; growth to `|A|^k` for `k ≥ 2` is Chang's
  deep content.
- **`subsetProducts_card_of_prime`** — distinct-prime richness (problem.md "Key
  lemma 2"): for a `Finset ℤ` of distinct **positive** primes,
  `|subsetProducts A| = 2^{|A|} − 1`. Proved via subset-product injectivity
  (`subsetProd_injOn_of_prime`): for a positive prime `p ∈ A`, `p ∈ S ↔ p ∣ ∏ S`,
  so each nonempty subset is recovered from its product. Positivity is required —
  `Prime` over `ℤ` is closed under negation, so `{2, −2}` would collide without
  `0 < p`.
- **`sumsOrProducts_card_le`** — trivial upper bracket `|sumsOrProducts A| ≤
  2^{|A|+1}`. With the base case this pins the count in `[|A|, 2^{|A|+1}]`;
  distinct-prime richness shows the multiplicative side of the bound is
  essentially attained.

Plus the missing `subsetProducts` analogues of the batch-1 `subsetSums` lemmas
(`subsetProducts_empty`, `subsetProducts_card_le`, `subsetProducts_mono`) and
`sumsOrProducts_mono`, `zero_mem_sumsOrProducts`, `sumsOrProducts_nonempty`,
`subset_subsetSums`.

## Verification

Host-verified with `lake env lean` (file imports only `Mathlib.*`). Clean
compile — 0 errors, 0 warnings, 0 sorries. `#print axioms` on every new headline
theorem yields only `[propext, Classical.choice, Quot.sound]` — genuinely
axiom-free (no `Lean.ofReduceBool`, no `sorryAx`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)