### PR TITLE
Enrich cramers-rule-oq-01-oq-04: fix tail line-range drift (327/325→320)

### DIFF
--- a/src/data/proofs/cramers-rule-oq-01-oq-04/annotations.json
+++ b/src/data/proofs/cramers-rule-oq-01-oq-04/annotations.json
@@ -201,7 +201,7 @@
     "proofId": "cramers-rule-oq-01-oq-04",
     "range": {
       "startLine": 311,
-      "endLine": 325
+      "endLine": 320
     },
     "type": "insight",
     "title": "tr(M²) = tr(M)² − 2·det(M): Classical 2×2 Identity Proved",

--- a/src/data/proofs/cramers-rule-oq-01-oq-04/meta.json
+++ b/src/data/proofs/cramers-rule-oq-01-oq-04/meta.json
@@ -35,7 +35,7 @@
       "power_sums_determined_by_first_n: all pₖ for k > n are determined by p₁,...,pₙ (proved by induction on the large recurrence)",
       "cayley_hamilton: immediate wrapper for Matrix.aeval_self_charpoly, documenting the Cayley-Hamilton connection"
     ],
-    "lineCount": 327,
+    "lineCount": 320,
     "theoremCount": 17,
     "defCount": 2,
     "definitionCount": 2
@@ -106,7 +106,7 @@
       "id": "consequences",
       "title": "Consequences and 2×2 Specializations",
       "startLine": 278,
-      "endLine": 327,
+      "endLine": 320,
       "summary": "power_sums_determined_by_first_n: all pₖ (k>n) determined by p₁,...,pₙ (proved by induction). trace_sq_minus_trace_M2_2x2: tr(M²) = tr(M)² − 2·det(M) for 2×2 matrices (PROVED).",
       "mathContext": "For $2\\times 2$ matrices: $\\text{tr}(M^2) = \\text{tr}(M)^2 - 2\\det(M)$, which is Newton's $k=2$ identity specialized. This identity is fundamental in quantum mechanics (relating Casimir operators to products of generators) and in the theory of modular forms."
     }
@@ -135,7 +135,7 @@
     }
   ],
   "leanFile": {
-    "lineCount": 327,
+    "lineCount": 320,
     "path": "Proofs/CramersRuleOQ01OQ04.lean",
     "axiomCount": 4,
     "sorries": 0,


### PR DESCRIPTION
## Summary

`CramersRuleOQ01OQ04.lean` is **320 lines** (last line `end CramersRuleNewton`), but four metadata values overshot:

- `meta.lineCount`: 327 → **320**
- `leanFile.lineCount`: 327 → **320**
- final section `consequences` `endLine`: 327 → **320**
- final annotation `ann-trace-sq-2x2` `endLine`: 325 → **320**

All earlier sections/annotations were already within range. No Lean source or status/axiom changes.

## Verification

- `wc -l` = 320; section and annotation max endLines now both = 320.