### PR TITLE
Enrich bernoulli-inequality-oq-01-oq-02: fix trailing annotation range drift (170→163)

### DIFF
--- a/src/data/proofs/bernoulli-inequality-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/bernoulli-inequality-oq-01-oq-02/annotations.json
@@ -74,7 +74,7 @@
   {
     "id": "witnesses",
     "proofId": "bernoulli-inequality-oq-01-oq-02",
-    "range": { "startLine": 155, "endLine": 170 },
+    "range": { "startLine": 155, "endLine": 163 },
     "type": "concept",
     "title": "Exactness and Sharpness Witnesses",
     "content": "Three witnesses anchor the classification. The n = 2 identity holds for every a — the quadratic truncation is the complete expansion (1+a)² = 1 + 2a + a². A concrete strict instance at a = 1, n = 4 gives 1 + 4 + 6 = 11 < 16 = 2⁴. The sharpness witness shows the hypothesis a ≥ 0 is necessary: at a = −1/2, n = 3 the truncation 1 − 3/2 + 3/8 = 1/4 EXCEEDS (1/2)³ = 1/8, so the second-order inequality fails on −1 < a < 0 — unlike the first-order inequality, which holds down to a = −2.",


### PR DESCRIPTION
## Summary

`BernoulliInequalityOQ01OQ02.lean` is **163 lines**, but the final annotation `witnesses` ran to endLine **170**. Retargeted to **155–163** (the sharpness-witness `example` block ends at `end BernoulliInequalityOQ01OQ02` on line 163).

`lineCount` (×2) and all sections were already correct at 163. No Lean source or status changes.

## Verification

- `wc -l` = 163; annotation max endLine now = 163.