### PR TITLE
Enrich cayley-hamilton-cyclic-vector-all-fields-oq-02-oq-03: fix section & annotation line-range drift

### DIFF
--- a/src/data/proofs/cayley-hamilton-cyclic-vector-all-fields-oq-02-oq-03/annotations.json
+++ b/src/data/proofs/cayley-hamilton-cyclic-vector-all-fields-oq-02-oq-03/annotations.json
@@ -28,8 +28,8 @@
     "id": "chcv-oq02oq03-ann-krylov",
     "proofId": "cayley-hamilton-cyclic-vector-all-fields-oq-02-oq-03",
     "range": {
-      "startLine": 66,
-      "endLine": 91
+      "startLine": 67,
+      "endLine": 92
     },
     "type": "technique",
     "title": "Krylov Independence = Cyclicity",
@@ -52,8 +52,8 @@
     "id": "chcv-oq02oq03-ann-commute",
     "proofId": "cayley-hamilton-cyclic-vector-all-fields-oq-02-oq-03",
     "range": {
-      "startLine": 93,
-      "endLine": 106
+      "startLine": 98,
+      "endLine": 108
     },
     "type": "technique",
     "title": "Polynomials in T Commute with Powers of T",
@@ -74,8 +74,8 @@
     "id": "chcv-oq02oq03-ann-main",
     "proofId": "cayley-hamilton-cyclic-vector-all-fields-oq-02-oq-03",
     "range": {
-      "startLine": 108,
-      "endLine": 176
+      "startLine": 114,
+      "endLine": 168
     },
     "type": "key-step",
     "title": "Commuting Endomorphisms are Polynomials in T",
@@ -98,7 +98,7 @@
     "id": "chcv-oq02oq03-ann-consequences",
     "proofId": "cayley-hamilton-cyclic-vector-all-fields-oq-02-oq-03",
     "range": {
-      "startLine": 177,
+      "startLine": 174,
       "endLine": 197
     },
     "type": "concept",

--- a/src/data/proofs/cayley-hamilton-cyclic-vector-all-fields-oq-02-oq-03/meta.json
+++ b/src/data/proofs/cayley-hamilton-cyclic-vector-all-fields-oq-02-oq-03/meta.json
@@ -70,27 +70,27 @@
       "id": "chcv-oq02oq03-sec-cyclic",
       "title": "Cyclic vectors for an endomorphism and Krylov independence",
       "startLine": 54,
-      "endLine": 91,
+      "endLine": 92,
       "summary": "Defines IsEndCyclicVector T v (no nonzero polynomial of degree < finrank K V annihilates v) and proves endKrylov_linearIndependent: the Krylov vectors {Tᵏ·v}_{k<finrank K V} of a cyclic vector are linearly independent. A dependence is repackaged as a nonzero annihilating polynomial of degree < finrank, contradicting cyclicity; coefficient extraction uses Fintype.linearIndependent_iff and Polynomial.coeff of a monomial sum."
     },
     {
       "id": "chcv-oq02oq03-sec-commute",
       "title": "Polynomials in T commute with powers of T",
-      "startLine": 93,
-      "endLine": 106,
+      "startLine": 94,
+      "endLine": 108,
       "summary": "aeval_end_commute_pow: p(T) commutes with Tʲ, because aeval T is a K-algebra homomorphism (p(T)·T = T·p(T) from mul_comm p X and aeval_X), then Commute.pow_right. The endomorphism analogue of the parent's aeval_commute_pow."
     },
     {
       "id": "chcv-oq02oq03-sec-main",
       "title": "Main theorem: commuting endomorphisms are polynomials in T",
-      "startLine": 108,
-      "endLine": 176,
+      "startLine": 110,
+      "endLine": 168,
       "summary": "commuting_end_is_polynomial: with a cyclic vector, the Krylov vectors form a basis b; the polynomial p reading off the coordinates of A·v satisfies p(T)·v = A·v (Basis.sum_repr); A and p(T) then agree on every basis vector Tⁱ·v via the two commutation lemmas, so A = p(T) by Basis.ext. The trivial finrank = 0 case is closed by Subsingleton on Module.End K V."
     },
     {
       "id": "chcv-oq02oq03-sec-consequences",
       "title": "Consequences: commutative centralizer and the K[T] inclusion",
-      "startLine": 177,
+      "startLine": 170,
       "endLine": 197,
       "summary": "end_commutant_commutative: two endomorphisms commuting with a cyclic T commute with each other (both are polynomials in T, which commute). aeval_end_commute: the trivial inclusion K[T] ⊆ centralizer(T); together with the main theorem this gives the exact equality centralizer(T) = K[T]."
     }


### PR DESCRIPTION
Enrichment pass for `cayley-hamilton-cyclic-vector-all-fields-oq-02-oq-03`.

The four `sections` and five annotation ranges had drifted from the actual declaration boundaries in the 197-line Lean file (`CayleyHamiltonCyclicVectorAllFieldsOQ02OQ03.lean`) — several undershot the true end of a theorem, and the main-theorem section/annotation overshot into the Consequences block.

**Sections realigned to the SECTION banners and true declaration ends:**
- Cyclic vectors + Krylov independence: 54–91 → **54–92**
- Polynomials commute with powers: 93–106 → **94–108**
- Main theorem: 108–176 → **110–168**
- Consequences: 177–197 → **170–197**

**Annotations anchored to their docstrings/declarations:**
- krylov: 66–91 → **67–92**
- commute: 93–106 → **98–108**
- main: 108–176 → **114–168**
- consequences: 177–197 → **174–197**

No prose changed; content is otherwise untouched. Verified against the Lean source; `status: verified / axiomCount: 0` accurately reflects the 0-sorry, 0-axiom file. Gallery data validation (enrichment + search-index build steps) passes.