### PR TITLE
Research: erdos-1039-oq-05 — pointwise Fekete monotonicity from the deletion identity (axiom-free)

### DIFF
--- a/proofs/Proofs/Erdos1039TransfiniteDiameter.lean
+++ b/proofs/Proofs/Erdos1039TransfiniteDiameter.lean
@@ -390,7 +390,7 @@ theorem exists_deleteAt_discreteDiameter_ge (hn : 2 ≤ n)
   calc 2 / (((n : ℝ) + 1) * (n : ℝ)) * logSpread z
       = 2 / ((n : ℝ) * ((n : ℝ) - 1))
           * (((n : ℝ) - 1) * logSpread z / ((n : ℝ) + 1)) := by
-        field_simp; ring
+        field_simp
     _ ≤ 2 / ((n : ℝ) * ((n : ℝ) - 1)) * logSpread (deleteAt z k) := hstep
 
 end Erdos1039TransfiniteDiameter

--- a/proofs/Proofs/Erdos1039TransfiniteDiameter.lean
+++ b/proofs/Proofs/Erdos1039TransfiniteDiameter.lean
@@ -340,4 +340,57 @@ theorem sum_logSpread_deleteAt (z : Fin (n + 1) → ℂ) (hz : Function.Injectiv
   refine Finset.sum_congr rfl (fun k _ => ?_)
   rw [log_spreadProduct _ (deleteAt_injective hz k)]
 
+/- ## Fekete monotonicity: the pointwise inequality
+
+The deletion identity, in its additive form `sum_logSpread_deleteAt`, says the
+`n+1` deletion energies average to `(n-1)/(n+1)` of the full energy.  Since some
+term of a finite sum always meets the mean, at least one deletion has energy
+`≥ (n-1)/(n+1) · logSpread z`, and the exponent bookkeeping
+`2/(n(n-1)) · (n-1)/(n+1) = 2/((n+1)n)` turns that into the diameter comparison
+`d_{n+1}(Z) ≤ dₙ(delete k Z)`.  This is the finite heart of Fekete's monotonicity
+theorem `d_{n+1} ≤ dₙ`; the classical statement follows by taking suprema over
+configurations in a compact set (which needs compactness API beyond this file). -/
+
+/-- **Fekete monotonicity (pointwise form).** For every injective `(n+1)`-tuple of
+roots with `n ≥ 2`, at least one `n`-point deletion has `n`-point diameter no
+smaller than the `(n+1)`-point diameter of the whole tuple:
+`∃ k, d_{n+1}(Z) ≤ dₙ(delete k Z)`.  Axiom-free consequence of the deletion
+identity via "some term of a sum meets the mean". -/
+theorem exists_deleteAt_discreteDiameter_ge (hn : 2 ≤ n)
+    (z : Fin (n + 1) → ℂ) (hz : Function.Injective z) :
+    ∃ k : Fin (n + 1), discreteDiameter z ≤ discreteDiameter (deleteAt z k) := by
+  have hr2 : (2 : ℝ) ≤ (n : ℝ) := by exact_mod_cast hn
+  have hr0 : (0 : ℝ) < (n : ℝ) := by linarith
+  have hrm1 : (0 : ℝ) < (n : ℝ) - 1 := by linarith
+  have hrp1 : (0 : ℝ) < (n : ℝ) + 1 := by linarith
+  -- additive deletion identity, cast cleaned up
+  have hcast : ((n - 1 : ℕ) : ℝ) = (n : ℝ) - 1 := by
+    rw [Nat.cast_sub (by omega : 1 ≤ n), Nat.cast_one]
+  have hsum : ∑ k, logSpread (deleteAt z k) = ((n : ℝ) - 1) * logSpread z := by
+    rw [sum_logSpread_deleteAt z hz, hcast]
+  -- the constant "mean" term sums to the same total
+  have hconst : (∑ _k : Fin (n + 1), ((n : ℝ) - 1) * logSpread z / ((n : ℝ) + 1))
+      = ((n : ℝ) - 1) * logSpread z := by
+    rw [Finset.sum_const, Finset.card_univ, Fintype.card_fin, nsmul_eq_mul]
+    have hcp : ((n + 1 : ℕ) : ℝ) = (n : ℝ) + 1 := by push_cast; ring
+    rw [hcp]
+    field_simp
+  -- some deletion beats the mean
+  have hle : (∑ _k : Fin (n + 1), ((n : ℝ) - 1) * logSpread z / ((n : ℝ) + 1))
+      ≤ ∑ k, logSpread (deleteAt z k) := by rw [hconst, hsum]
+  obtain ⟨k, -, hk⟩ := Finset.exists_le_of_sum_le Finset.univ_nonempty hle
+  refine ⟨k, ?_⟩
+  have hzk : Function.Injective (deleteAt z k) := deleteAt_injective hz k
+  rw [discreteDiameter_eq_exp z hz, discreteDiameter_eq_exp (deleteAt z k) hzk,
+    Real.exp_le_exp]
+  have hcp : ((n + 1 : ℕ) : ℝ) = (n : ℝ) + 1 := by push_cast; ring
+  rw [hcp, add_sub_cancel_right]
+  have hc : (0 : ℝ) < 2 / ((n : ℝ) * ((n : ℝ) - 1)) := div_pos (by norm_num) (mul_pos hr0 hrm1)
+  have hstep := mul_le_mul_of_nonneg_left hk (le_of_lt hc)
+  calc 2 / (((n : ℝ) + 1) * (n : ℝ)) * logSpread z
+      = 2 / ((n : ℝ) * ((n : ℝ) - 1))
+          * (((n : ℝ) - 1) * logSpread z / ((n : ℝ) + 1)) := by
+        field_simp; ring
+    _ ≤ 2 / ((n : ℝ) * ((n : ℝ) - 1)) * logSpread (deleteAt z k) := hstep
+
 end Erdos1039TransfiniteDiameter

--- a/research/problems/erdos-1039-oq-05/knowledge.md
+++ b/research/problems/erdos-1039-oq-05/knowledge.md
@@ -71,6 +71,29 @@ All iteration-3 theorems: axioms `[propext, Classical.choice, Quot.sound]` (veri
 
 ---
 
+## Built (iteration 4 — pointwise Fekete monotonicity, axiom-free)
+
+- `exists_deleteAt_discreteDiameter_ge (hn : 2 ≤ n) (z : Fin (n+1) → ℂ)
+  (hz : Injective z) : ∃ k, discreteDiameter z ≤ discreteDiameter (deleteAt z k)`.
+  For every injective (n+1)-tuple of roots (n ≥ 2), some n-point deletion has
+  n-point diameter ≥ the (n+1)-point diameter of the whole tuple — i.e.
+  d_{n+1}(Z) ≤ dₙ(delete k Z), the **finite heart of Fekete monotonicity**.
+  Proof: additive deletion identity `sum_logSpread_deleteAt`
+  (∑ₖ logSpread(delete k Z) = (n−1)·logSpread Z over n+1 terms) ⇒ some term meets
+  the mean (`Finset.exists_le_of_sum_le` against the constant (n−1)E/(n+1)) ⇒
+  exponent bookkeeping 2/(n(n−1)) · (n−1)/(n+1) = 2/((n+1)n) ⇒ compare via
+  `discreteDiameter_eq_exp` + `Real.exp_le_exp`. Axiom-free
+  (`#print axioms` = [propext, Classical.choice, Quot.sound]).
+
+★RECIPE: "some sample beats the mean" over a Finset — build the constant function
+`fun _ => (∑ f)/card`, show its sum equals ∑ f (`Finset.sum_const` +
+`card_univ`/`Fintype.card_fin` + `nsmul_eq_mul` + `field_simp`), then
+`Finset.exists_le_of_sum_le univ_nonempty (le_of_eq ...)`. Cast bridge for the
+(n+1)-point exponent: `((n+1:ℕ):ℝ) = (n:ℝ)+1` by `push_cast; ring`, then
+`add_sub_cancel_right` clears the `((n:ℝ)+1)-1`.
+
+---
+
 ## Dead Ends
 
 None recorded yet. The capacity/Green's-function route (Approach A) and the
@@ -80,6 +103,6 @@ transfinite-diameter limit require Mathlib API that does not yet exist.
 
 ## Next
 
-1. Fekete monotonicity dₙ₊₁(Z) ≤ dₙ(Z) → transfinite diameter d(Z) = infₙ dₙ.
+1. ✅ DONE (iter 4, pointwise form `exists_deleteAt_discreteDiameter_ge`). Remaining: upgrade to sup-over-configurations dₙ₊₁ ≤ dₙ (needs compactness/sSup API) and d(Z) = infₙ dₙ.
 2. Logarithmic capacity of {|f|≥1}∩B(0,R) + cap=1 normalization (axiomatize, cite Fekete–Szegő).
 3. State ρ(f) ≳ g(d(Z), cap) (theorems where provable / axioms citing Pommerenke/KLR).

--- a/research/problems/erdos-1039-oq-05/state.md
+++ b/research/problems/erdos-1039-oq-05/state.md
@@ -4,7 +4,7 @@
 **Phase**: ACT
 **Path**: full
 **Since**: 2026-07-09T15:40:19-07:00
-**Iteration**: 3
+**Iteration**: 4
 
 ## Current Focus
 Finite discrete transfinite diameter (n-point spread) and the **combinatorial core

--- a/src/data/research/problems/erdos-1039-oq-05.json
+++ b/src/data/research/problems/erdos-1039-oq-05.json
@@ -31,10 +31,10 @@
   "currentState": {
     "phase": "ACT",
     "since": "2026-07-09T00:00:00Z",
-    "iteration": 3,
-    "focus": "Finite discrete transfinite diameter (n-point spread) now formalized axiom-free in Erdos1039TransfiniteDiameter.lean. Next: the limit d(Z) = limₙ dₙ and the logarithmic-capacity side (cap of {|f|≥1}), plus the ρ(f) ≳ g(d,cap) links.",
+    "iteration": 4,
+    "focus": "Iteration 4: pointwise Fekete monotonicity exists_deleteAt_discreteDiameter_ge (d_{n+1}(Z) <= d_n(delete k Z)) proved axiom-free from the deletion identity via some-term-meets-mean. Erdos1039TransfiniteDiameter.lean now 16 theorems, 0 axioms/sorries.",
     "blockers": [],
-    "nextAction": "Formalize the transfinite diameter as the limit/inf of the n-point diameters dₙ(Z) (Fekete monotonicity dₙ₊₁ ≤ dₙ is the key missing lemma), then define logarithmic capacity of the lemniscate complement and axiomatize the cap=1 normalization (mirroring pommerenke_lower/klr_area_bound).",
+    "nextAction": "Upgrade pointwise monotonicity to sup-over-configurations d_{n+1} <= d_n (needs compactness/sSup API); then d(Z)=inf_n d_n; capacity normalization (axiomatize, cite Fekete–Szego).",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -156,5 +156,6 @@
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1039TransfiniteDiameter.lean"
     }
-  ]
+  ],
+  "lastUpdate": "2026-07-20"
 }


### PR DESCRIPTION
## Summary

Iteration 4 on the discrete transfinite diameter for Erdős #1039 OQ-05. Adds one
theorem to `proofs/Proofs/Erdos1039TransfiniteDiameter.lean`, delivering the
**finite heart of Fekete's monotonicity theorem** — the "Next" target flagged by
the merged deletion-identity work (#39506). The file stays **0 axioms, 0 sorries**.

## New result

**`exists_deleteAt_discreteDiameter_ge`** — for every injective `(n+1)`-tuple of
roots with `n ≥ 2`, at least one `n`-point deletion has `n`-point diameter no
smaller than the `(n+1)`-point diameter of the whole tuple:

```
∃ k, discreteDiameter z ≤ discreteDiameter (deleteAt z k)      -- d_{n+1}(Z) ≤ dₙ(delete k Z)
```

This is the finite/pointwise form of Fekete monotonicity `d_{n+1} ≤ dₙ`; the
classical statement follows by taking suprema over configurations in a compact
set (which needs compactness/`sSup` API beyond this file).

### Proof

Purely from the already-merged **additive deletion identity**
`sum_logSpread_deleteAt` (`∑ₖ logSpread(delete k Z) = (n−1)·logSpread Z`, a sum of
`n+1` terms):

1. Some term of a finite sum meets its mean, so some deletion has energy
   `≥ (n−1)/(n+1) · logSpread Z` (`Finset.exists_le_of_sum_le` against the
   constant `(n−1)E/(n+1)`).
2. Exponent bookkeeping `2/(n(n−1)) · (n−1)/(n+1) = 2/((n+1)n)` matches the
   `(n+1)`-point normalisation, and `discreteDiameter_eq_exp` + `Real.exp_le_exp`
   convert the energy inequality to the diameter inequality.

## Verification

Host-verified with `lake env lean` (file imports `Mathlib`). Clean compile —
0 errors, 0 warnings, 0 sorries. `#print axioms exists_deleteAt_discreteDiameter_ge`
= `[propext, Classical.choice, Quot.sound]` — axiom-free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)