### PR TITLE
Research: erdos-1092-oq-02 — complete the fThreshold regime dichotomy (3 axiom-free lemmas)

### DIFF
--- a/proofs/Proofs/Erdos1092OQ02.lean
+++ b/proofs/Proofs/Erdos1092OQ02.lean
@@ -208,6 +208,32 @@ theorem mem_fThresholdSet_iff {r n : ℕ} (hr : 1 ≤ r) (hn : r + 2 ≤ n) (k :
   · intro hk
     exact fThresholdSet_downClosed hk (fThreshold_mem hr hn)
 
+/-- **The non-degenerate defining set as an interval.** Packaging
+`mem_fThresholdSet_iff` as a `Set` equality: for `1 ≤ r`, `r + 2 ≤ n`, the defining set is
+exactly `Set.Iic (fThreshold r n) = {0, 1, …, fThreshold r n}`. -/
+theorem fThresholdSet_eq_Iic {r n : ℕ} (hr : 1 ≤ r) (hn : r + 2 ≤ n) :
+    fThresholdSet r n = Set.Iic (fThreshold r n) := by
+  ext k
+  rw [Set.mem_Iic]
+  exact mem_fThresholdSet_iff hr hn k
+
+/-- Every graph on at most `r + 1` vertices is `(r+1)`-colorable: colour each vertex with
+its own index (`hasColoring_self`) and embed into `r + 1` colours (`hasColoring_mono`). -/
+theorem hasColoring_of_card_le {r n : ℕ} (hn : n ≤ r + 1) (G : SGraph n) :
+    G.hasColoring (r + 1) :=
+  SGraph.hasColoring_mono G hn (SGraph.hasColoring_self G)
+
+/-- **The degenerate (upper) regime `n ≤ r + 1`.** Every graph on `n ≤ r + 1` vertices is
+already `(r+1)`-colorable, so *every* budget forces the conclusion and the defining set is all
+of `ℕ`: `fThresholdSet r n = Set.univ`. This is the `sSup`-pathology the parent file documents
+in prose — the degenerate counterpart of the non-degenerate interval characterization
+`fThresholdSet_eq_Iic`. (Here `fThreshold r n = sSup Set.univ`, the artifact value.) -/
+theorem fThresholdSet_eq_univ_of_card_le {r n : ℕ} (hn : n ≤ r + 1) :
+    fThresholdSet r n = Set.univ := by
+  rw [Set.eq_univ_iff_forall]
+  intro k G _
+  exact hasColoring_of_card_le hn G
+
 #check @completeGraph_not_hasColoring
 #check @canReduce_removeAll
 #check @fThresholdSet_downClosed
@@ -216,5 +242,8 @@ theorem mem_fThresholdSet_iff {r n : ℕ} (hr : 1 ≤ r) (hn : r + 2 ≤ n) (k :
 #check @fThresholdSet_zero_mem
 #check @fThreshold_mem
 #check @mem_fThresholdSet_iff
+#check @fThresholdSet_eq_Iic
+#check @hasColoring_of_card_le
+#check @fThresholdSet_eq_univ_of_card_le
 
 end Erdos1092OQ02

--- a/research/problems/erdos-1092-oq-02/knowledge.md
+++ b/research/problems/erdos-1092-oq-02/knowledge.md
@@ -108,3 +108,27 @@ self-contained account of `fThreshold`'s well-definedness (nonempty + bounded + 
   "two axioms in the parent" remark — the parent actually has 0 axioms)
 - `src/data/research/problems/erdos-1092-oq-02.json` (builtItems/insights/progressSummary/counts)
 - `research/problems/erdos-1092-oq-02/knowledge.md` (this note)
+
+---
+
+## Session 2026-07-20 (researcher-1): regime dichotomy completed
+
+The previous session (#39466) completed the *non-degenerate* well-definedness story
+(nonempty + bounded + attained + interval `mem_fThresholdSet_iff`). This session
+completes the picture with the **degenerate regime** and a clean Set packaging
+(3 theorems, still 0 axioms; host-verified via parent-olean + `lake env lean`):
+
+- `hasColoring_of_card_le (hn : n ≤ r+1) (G) : G.hasColoring (r+1)` — every graph on
+  `n ≤ r+1` vertices is `(r+1)`-colorable (`hasColoring_self` + `hasColoring_mono`).
+- `fThresholdSet_eq_univ_of_card_le (hn : n ≤ r+1) : fThresholdSet r n = Set.univ` —
+  the degenerate (upper) regime: every budget qualifies, so the defining set is all of ℕ.
+  This *proves* the `sSup`-pathology the parent only documented in prose.
+- `fThresholdSet_eq_Iic (1≤r) (r+2≤n) : fThresholdSet r n = Set.Iic (fThreshold r n)` —
+  packages `mem_fThresholdSet_iff` as a clean `Set` equality.
+
+Regime dichotomy now complete: `fThresholdSet r n` is **either** all of ℕ (`n ≤ r+1`)
+**or** exactly `Set.Iic (fThreshold r n)` (`r+2 ≤ n`).
+
+### Frontier (UNCHANGED)
+Parent open question (Rödl's construction for r ≥ 3) remains research-level and untouched.
+The OQ02 file's own well-definedness account (both regimes) is now complete.

--- a/research/problems/erdos-1092-oq-02/state.md
+++ b/research/problems/erdos-1092-oq-02/state.md
@@ -4,7 +4,7 @@
 **Phase**: OBSERVE
 **Path**: full
 **Since**: 2026-07-04T18:35:43-07:00
-**Iteration**: 1
+**Iteration**: 2
 
 ## Current Focus
 Initial problem understanding. Read problem.md and gather context.

--- a/src/data/research/problems/erdos-1092-oq-02.json
+++ b/src/data/research/problems/erdos-1092-oq-02.json
@@ -19,9 +19,9 @@
     "phase": "ORIENT",
     "since": "2026-07-04T18:35:43-07:00",
     "iteration": 1,
-    "focus": "Initial problem understanding. Read problem.md and gather context.",
+    "focus": "Regime dichotomy completed: fThresholdSet_eq_univ_of_card_le (degenerate n<=r+1 => Set.univ), fThresholdSet_eq_Iic (non-degenerate => Set.Iic), hasColoring_of_card_le. Erdos1092OQ02.lean now well-definedness-complete for both regimes, 0 axioms.",
     "blockers": [],
-    "nextAction": "Read problem.md thoroughly and acquire full context.",
+    "nextAction": "Parent OQ (Rodl construction for r>=3) is research-level, untouched. OQ02 elementary well-definedness account is complete.",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -64,7 +64,7 @@
     "mathlib": []
   },
   "started": "2026-07-05T01:52:27.439Z",
-  "lastUpdate": "2026-07-20T00:00:00.000Z",
+  "lastUpdate": "2026-07-20",
   "leanFiles": [
     {
       "path": "Proofs/Erdos1092OQ02.lean",


### PR DESCRIPTION
## Summary

Completes the `fThreshold` well-definedness story for Erdős #1092 OQ-02. The
merged batch (#39466) settled the *non-degenerate* regime (nonempty + bounded +
attained + interval `mem_fThresholdSet_iff`); this PR adds the **degenerate
regime** and a clean `Set` packaging, giving the full dichotomy. Added to
`proofs/Proofs/Erdos1092OQ02.lean`; the file stays **0 axioms, 0 sorries**.

## New results

- **`hasColoring_of_card_le`** — every graph on `n ≤ r + 1` vertices is
  `(r+1)`-colorable (`hasColoring_self` + `hasColoring_mono`).
- **`fThresholdSet_eq_univ_of_card_le`** — the degenerate (upper) regime: for
  `n ≤ r + 1` every budget forces the conclusion, so `fThresholdSet r n =
  Set.univ`. This **proves** the `sSup`-pathology the parent file only documented
  in prose.
- **`fThresholdSet_eq_Iic`** — packages `mem_fThresholdSet_iff` as the clean `Set`
  equality `fThresholdSet r n = Set.Iic (fThreshold r n)` in the non-degenerate
  regime.

Together: the defining set is **either** all of `ℕ` (`n ≤ r + 1`) **or** exactly
the interval `{0, …, fThreshold r n}` (`r + 2 ≤ n`).

## Verification

Host-verified with `lake env lean` (built the Mathlib-only parent
`Erdos1092Problem` olean first, then the child). Clean compile — 0 errors,
0 sorries (the two remaining `push_neg` warnings are pre-existing batch-1 code on
lines 139/154). `#print axioms` on the new theorems yields only
`[propext, (Classical.choice,) Quot.sound]` — axiom-free.

The parent open question (Rödl's construction for `r ≥ 3`) is genuinely
research-level and untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)