### PR TITLE
Enrich erdos-635: fix section & annotation line-range overshoot drift

### DIFF
--- a/src/data/proofs/erdos-635/annotations.json
+++ b/src/data/proofs/erdos-635/annotations.json
@@ -26,8 +26,8 @@
     "id": "ann-e635-nondivisible",
     "proofId": "erdos-635",
     "range": {
-      "startLine": 43,
-      "endLine": 49
+      "startLine": 36,
+      "endLine": 42
     },
     "type": "definition",
     "title": "The Non-Divisibility Condition",
@@ -49,8 +49,8 @@
     "id": "ann-e635-admissible",
     "proofId": "erdos-635",
     "range": {
-      "startLine": 51,
-      "endLine": 54
+      "startLine": 44,
+      "endLine": 47
     },
     "type": "definition",
     "title": "Admissible Sets",
@@ -72,8 +72,8 @@
     "id": "ann-e635-extremal",
     "proofId": "erdos-635",
     "range": {
-      "startLine": 62,
-      "endLine": 65
+      "startLine": 55,
+      "endLine": 58
     },
     "type": "definition",
     "title": "The Extremal Function f(N, t)",
@@ -95,8 +95,8 @@
     "id": "ann-e635-oddset",
     "proofId": "erdos-635",
     "range": {
-      "startLine": 74,
-      "endLine": 76
+      "startLine": 67,
+      "endLine": 69
     },
     "type": "definition",
     "title": "The Odd Set Construction",
@@ -118,7 +118,7 @@
     "id": "ann-e635-t1-axioms",
     "proofId": "erdos-635",
     "range": {
-      "startLine": 78,
+      "startLine": 71,
       "endLine": 97
     },
     "type": "concept",
@@ -141,8 +141,8 @@
     "id": "ann-e635-t2-construction",
     "proofId": "erdos-635",
     "range": {
-      "startLine": 106,
-      "endLine": 123
+      "startLine": 202,
+      "endLine": 207
     },
     "type": "concept",
     "title": "The t = 2 Case: Erdős Construction",
@@ -164,8 +164,8 @@
     "id": "ann-e635-conjecture",
     "proofId": "erdos-635",
     "range": {
-      "startLine": 131,
-      "endLine": 147
+      "startLine": 215,
+      "endLine": 231
     },
     "type": "concept",
     "title": "The Main Conjecture (OPEN)",
@@ -187,8 +187,8 @@
     "id": "ann-e635-bounds",
     "proofId": "erdos-635",
     "range": {
-      "startLine": 154,
-      "endLine": 171
+      "startLine": 235,
+      "endLine": 263
     },
     "type": "concept",
     "title": "Known Bounds and Monotonicity",
@@ -210,8 +210,8 @@
     "id": "ann-e635-structural",
     "proofId": "erdos-635",
     "range": {
-      "startLine": 178,
-      "endLine": 187
+      "startLine": 312,
+      "endLine": 333
     },
     "type": "concept",
     "title": "No Far Multiples",
@@ -233,8 +233,8 @@
     "id": "ann-e635-summary",
     "proofId": "erdos-635",
     "range": {
-      "startLine": 191,
-      "endLine": 215
+      "startLine": 337,
+      "endLine": 361
     },
     "type": "concept",
     "title": "Summary and Status",

--- a/src/data/proofs/erdos-635/meta.json
+++ b/src/data/proofs/erdos-635/meta.json
@@ -66,7 +66,7 @@
       "erdos_635_t1_solved theorem: the t = 1 case from axioms (proved)"
     ],
     "axiomCount": 1,
-    "lineCount": 369,
+    "lineCount": 363,
     "assumptions": "1 axiom: erdos_635 (OPEN conjecture). f_t2_lower, erdos_construction_t2 removed (unused). f_t1_density proved.",
     "theoremCount": 15,
     "definitionCount": 5
@@ -93,64 +93,64 @@
     {
       "id": "non-divisibility",
       "title": "Part I: The Non-Divisibility Condition",
-      "startLine": 36,
-      "endLine": 55,
+      "startLine": 29,
+      "endLine": 48,
       "summary": "Defines IsNonDivisible (t-non-divisibility for set pairs) and IsAdmissible (containment in {1,...,N} plus non-divisibility).",
       "mathContext": "Formal definition: Defines IsNonDivisible (t-non-divisibility for set pairs) and IsAdmissible (containment in {1,...,N} plus non-divisibility)."
     },
     {
       "id": "extremal-function",
       "title": "Part II: The Extremal Function",
-      "startLine": 56,
-      "endLine": 66,
+      "startLine": 49,
+      "endLine": 59,
       "summary": "Defines f(N,t) as sSup of achievable cardinalities of t-admissible sets.",
       "mathContext": "Formal definition: Defines f(N,t) as sSup of achievable cardinalities of t-admissible sets."
     },
     {
       "id": "case-t1",
       "title": "Part III: The Case t = 1 — Odd Numbers",
-      "startLine": 67,
-      "endLine": 195,
+      "startLine": 60,
+      "endLine": 201,
       "summary": "Defines oddSet; proves oddSet_admissible, oddSet_card = (N+1)/2, f_t1 optimality.",
       "mathContext": "Proved: oddSet_admissible, oddSet_card = (N+1)/2, f_t1 = (N+1)/2 for N ≥ 1."
     },
     {
       "id": "case-t2",
       "title": "Part IV: The Case t = 2 — Beating the N/2 Barrier",
-      "startLine": 196,
-      "endLine": 202,
+      "startLine": 202,
+      "endLine": 208,
       "summary": "Comment section only — t=2 lower bound construction (f_t2_lower, erdos_construction_t2) removed as unused.",
       "mathContext": "No code in this section; f_t2_lower and erdos_construction_t2 were removed."
     },
     {
       "id": "conjecture",
       "title": "Part V: The Main Conjecture (OPEN)",
-      "startLine": 203,
-      "endLine": 226,
+      "startLine": 209,
+      "endLine": 232,
       "summary": "Defines ErdosConjecture635 with ε-N₀ quantifiers formalizing o_t(1). Axiom erdos_635.",
       "mathContext": "Formal definition: ErdosConjecture635. Axiom: erdos_635 : ErdosConjecture635 (the open conjecture)."
     },
     {
       "id": "bounds",
       "title": "Part VI: Upper and Lower Bounds",
-      "startLine": 227,
-      "endLine": 312,
+      "startLine": 233,
+      "endLine": 306,
       "summary": "Proves: f_upper_trivial (f ≤ N), f_monotone_t, f_lower_half (≥ (N+1)/2), f_t1_density (→ 1/2).",
       "mathContext": "Proved: f_upper_trivial (f $\\leq$ N), f_monotone_t, f_lower_half ($\\geq$ (N+1)/2), f_t1_density ($\\to$ 1/2)."
     },
     {
       "id": "structural",
       "title": "Part VII: Structural Observations",
-      "startLine": 313,
-      "endLine": 340,
+      "startLine": 307,
+      "endLine": 334,
       "summary": "Proves no_far_doubles: admissible sets exclude pairs where the smaller divides the larger at distance ≥ t.",
       "mathContext": "Proved: no_far_doubles (was formerly axiomatized as no_far_multiples)."
     },
     {
       "id": "summary",
       "title": "Part VIII: Summary",
-      "startLine": 341,
-      "endLine": 369,
+      "startLine": 335,
+      "endLine": 363,
       "summary": "erdos_635_t1_solved theorem (from f_t1), erdos_635_status (trivial). Problem OPEN for general t.",
       "mathContext": "Verified: erdos_635_t1_solved theorem (from f_t1), erdos_635_status (trivial). Problem OPEN for general t."
     }
@@ -182,7 +182,7 @@
       "Finset"
     ],
     "namespace": "Erdos635",
-    "lineCount": 369,
+    "lineCount": 363,
     "axiomCount": 1,
     "theoremCount": 15,
     "definitionCount": 5,


### PR DESCRIPTION
Re-anchors `src/data/proofs/erdos-635/` `meta.json` sections and `annotations.json` ranges to the actual Lean source (`proofs/Proofs/Erdos635Problem.lean`), which is **363 lines** (last line = `end Erdos635`). Sections overshot to line 369; annotations were anchored to a stale, shorter layout (max endLine 215) and pointed at the wrong declarations.

## lineCount
- `meta.lineCount`: 369 → **363**
- `leanFile.lineCount`: 369 → **363**

## Sections (re-anchored to actual `## Part` headers, contiguous 29→363, last endLine == EOF)
| id | title | before | after |
|----|-------|--------|-------|
| non-divisibility | Part I | 36–55 | 29–48 |
| extremal-function | Part II | 56–66 | 49–59 |
| case-t1 | Part III | 67–195 | 60–201 |
| case-t2 | Part IV | 196–202 | 202–208 |
| conjecture | Part V | 203–226 | 209–232 |
| bounds | Part VI | 227–312 | 233–306 |
| structural | Part VII | 313–340 | 307–334 |
| summary | Part VIII | 341–369 | 335–363 |

## Annotations (re-anchored to correct declarations; all ranges ≤ 363)
| id | before | after | anchor |
|----|--------|-------|--------|
| ann-e635-header | 1–21 | 1–21 (kept) | header doc block |
| ann-e635-nondivisible | 43–49 | 36–42 | `IsNonDivisible` |
| ann-e635-admissible | 51–54 | 44–47 | `IsAdmissible` |
| ann-e635-extremal | 62–65 | 55–58 | `f` def |
| ann-e635-oddset | 74–76 | 67–69 | `oddSet` def |
| ann-e635-t1-axioms | 78–97 | 71–97 | `oddSet_admissible` |
| ann-e635-t2-construction | 106–123 | 202–207 | Part IV (t=2) |
| ann-e635-conjecture | 131–147 | 215–231 | `ErdosConjecture635` + axiom |
| ann-e635-bounds | 154–171 | 235–263 | Part VI bounds |
| ann-e635-structural | 178–187 | 312–333 | `no_far_doubles` |
| ann-e635-summary | 191–215 | 337–361 | Part VIII summary |

## Axiom cross-check
`grep -cE "^axiom "` = **1** (`axiom erdos_635 : ErdosConjecture635`, the open conjecture). No `native_decide`. Matches `meta.axiomCount: 1`, `status: axiomatized`, `badge: axiom` — no change needed.

## Validation
Contiguity + bounds validated (maxSection=363, maxAnn=361, both ≤ LC=363). `pnpm build` green (bundle budget OK). Only the two erdos-635 JSON files committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)