### PR TITLE
Enrich isoperimetric-theorem-oq-01: fix section & annotation line-range overshoot drift (384→378)

### DIFF
--- a/src/data/proofs/isoperimetric-theorem-oq-01/annotations.json
+++ b/src/data/proofs/isoperimetric-theorem-oq-01/annotations.json
@@ -153,7 +153,7 @@
     "proofId": "isoperimetric-theorem-oq-01",
     "range": {
       "startLine": 297,
-      "endLine": 384
+      "endLine": 378
     },
     "type": "concept",
     "title": "Summary: Universal Principle and Geometric Intuition",

--- a/src/data/proofs/isoperimetric-theorem-oq-01/meta.json
+++ b/src/data/proofs/isoperimetric-theorem-oq-01/meta.json
@@ -44,7 +44,7 @@
       "small_area_universal: curvature correction is O(A²)"
     ],
     "axiomCount": 2,
-    "lineCount": 384,
+    "lineCount": 378,
     "assumptions": "2 axioms: spherical_isoperimetric, hyperbolic_isoperimetric. 0 sorries.",
     "theoremCount": 15,
     "definitionCount": 13
@@ -117,7 +117,7 @@
       "id": "summary",
       "title": "Summary and Comparison",
       "startLine": 297,
-      "endLine": 384,
+      "endLine": 378,
       "summary": "Corrected ratio, asymptotic universality at small area, and the summary theorem packaging all results."
     }
   ],
@@ -143,7 +143,7 @@
       "Real"
     ],
     "namespace": "IsoperimetricSurfaces",
-    "lineCount": 384,
+    "lineCount": 378,
     "axiomCount": 2,
     "theoremCount": 15,
     "definitionCount": 13,


### PR DESCRIPTION
## Enrichment pass — `isoperimetric-theorem-oq-01`

### Problem (line-range overshoot drift)
`Proofs/IsoperimetricTheoremOQ01.lean` is **378 lines** (`end IsoperimetricSurfaces` at L378), but the gallery metadata described it as 384 and the final section + annotation pointed 6 lines past EOF. The middle sections were correctly anchored; only the tail drifted.

| Element | Before | After |
|---|---|---|
| `meta.lineCount` / `leanFile.lineCount` | 384 | **378** |
| section `summary` | 297–384 | **297–378** |
| annotation `ann-iso-surfaces-summary` | 297–384 | **297–378** |

### Fix
Clamped the summary section and its annotation to the real EOF (378) and corrected both `lineCount` fields. Verified: maxSection = maxAnn = 378 = LC, no overshoot remaining.

### Axiom integrity
`status: axiomatized`, `axiomCount: 2` is **accurate** — the file declares exactly 2 axioms (`spherical_isoperimetric` L115, `hyperbolic_isoperimetric` L198). Unchanged.

### Verification
- `pnpm build` ✓ (all chunks within budget)