### PR TITLE
Enrich erdos-732: fix section & annotation line-range overshoot drift

### DIFF
--- a/src/data/proofs/erdos-732/annotations.json
+++ b/src/data/proofs/erdos-732/annotations.json
@@ -27,8 +27,8 @@
     "id": "ann-732-block",
     "proofId": "erdos-732",
     "range": {
-      "startLine": 43,
-      "endLine": 64
+      "startLine": 45,
+      "endLine": 62
     },
     "type": "definition",
     "title": "Blocks, Pairs, and Coverage",
@@ -51,8 +51,8 @@
     "id": "ann-732-pbd",
     "proofId": "erdos-732",
     "range": {
-      "startLine": 66,
-      "endLine": 74
+      "startLine": 64,
+      "endLine": 71
     },
     "type": "definition",
     "title": "Pairwise Balanced Block Design (PBD)",
@@ -75,8 +75,8 @@
     "id": "ann-732-compatible",
     "proofId": "erdos-732",
     "range": {
-      "startLine": 75,
-      "endLine": 97
+      "startLine": 77,
+      "endLine": 94
     },
     "type": "definition",
     "title": "Block-Compatible Sequences",
@@ -98,8 +98,8 @@
     "id": "ann-732-paircount",
     "proofId": "erdos-732",
     "range": {
-      "startLine": 98,
-      "endLine": 126
+      "startLine": 100,
+      "endLine": 123
     },
     "type": "concept",
     "title": "Pair-Counting Necessary Condition",
@@ -122,8 +122,8 @@
     "id": "ann-732-hard",
     "proofId": "erdos-732",
     "range": {
-      "startLine": 127,
-      "endLine": 153
+      "startLine": 129,
+      "endLine": 148
     },
     "type": "concept",
     "title": "Question 1: Characterization (OPEN)",
@@ -146,8 +146,8 @@
     "id": "ann-732-counting",
     "proofId": "erdos-732",
     "range": {
-      "startLine": 155,
-      "endLine": 194
+      "startLine": 153,
+      "endLine": 182
     },
     "type": "definition",
     "title": "Counting Function and Q2 Resolution",
@@ -170,8 +170,8 @@
     "id": "ann-732-asymptotic",
     "proofId": "erdos-732",
     "range": {
-      "startLine": 196,
-      "endLine": 227
+      "startLine": 188,
+      "endLine": 214
     },
     "type": "concept",
     "title": "Asymptotic Constant",
@@ -193,8 +193,8 @@
     "id": "ann-732-examples",
     "proofId": "erdos-732",
     "range": {
-      "startLine": 228,
-      "endLine": 269
+      "startLine": 220,
+      "endLine": 251
     },
     "type": "concept",
     "title": "Concrete Examples",
@@ -217,8 +217,8 @@
     "id": "ann-732-steiner",
     "proofId": "erdos-732",
     "range": {
-      "startLine": 270,
-      "endLine": 284
+      "startLine": 253,
+      "endLine": 266
     },
     "type": "concept",
     "title": "Related Problems and Steiner Systems",
@@ -241,8 +241,8 @@
     "id": "ann-732-summary",
     "proofId": "erdos-732",
     "range": {
-      "startLine": 285,
-      "endLine": 316
+      "startLine": 272,
+      "endLine": 310
     },
     "type": "concept",
     "title": "Summary Theorems",

--- a/src/data/proofs/erdos-732/meta.json
+++ b/src/data/proofs/erdos-732/meta.json
@@ -62,7 +62,7 @@
       "Concrete examples for n=3,4,6"
     ],
     "axiomCount": 3,
-    "lineCount": 316,
+    "lineCount": 310,
     "assumptions": "3 axioms: pair_count_necessary, alon_lower_bound, question_2_solved. 0 sorries.",
     "theoremCount": 4,
     "definitionCount": 10
@@ -98,79 +98,79 @@
       "title": "Imports and Setup",
       "summary": "Mathlib imports for Finset, SimpleGraph, and Real, plus the Erdos732 namespace.",
       "startLine": 35,
-      "endLine": 42,
+      "endLine": 40,
       "mathContext": "Mathematical content: Mathlib imports for Finset, SimpleGraph, and Real, plus the Erdos732 namespace."
     },
     {
       "id": "definitions",
       "title": "Basic Definitions",
       "summary": "Defines Block (Finset of Fin n), Pair (2-element subset), pairsCoveredBy (pairs within a block), and IsPBD (every pair in exactly one block).",
-      "startLine": 43,
-      "endLine": 74,
+      "startLine": 41,
+      "endLine": 72,
       "mathContext": "Formal definition: Defines Block (Finset of Fin n), Pair (2-element subset), pairsCoveredBy (pairs within a block), and IsPBD (every pair in exactly one block)."
     },
     {
       "id": "block-compatible",
       "title": "Block-Compatible Sequences",
       "summary": "Defines IsBlockCompatible (exists a PBD with matching block sizes) and IsWellFormed (2 ≤ Xᵢ ≤ n, sorted, non-empty).",
-      "startLine": 75,
-      "endLine": 97,
+      "startLine": 73,
+      "endLine": 95,
       "mathContext": "Defines IsBlockCompatible (exists a PBD with matching block sizes) and IsWellFormed (2 $\\leq$ Xᵢ $\\leq$ n, sorted, non-empty)."
     },
     {
       "id": "necessary",
       "title": "Necessary Conditions",
       "summary": "Defines PairCountCondition (Σ C(Xᵢ,2) = C(n,2)) and axiomatizes pair_count_necessary. Includes the trivial pair_count_explanation theorem.",
-      "startLine": 98,
-      "endLine": 125,
+      "startLine": 96,
+      "endLine": 124,
       "mathContext": "Defines PairCountCondition ($\\sum$ C(Xᵢ,2) = C(n,2)) and axiomatizes pair_count_necessary. Includes the trivial pair_count_explanation theorem."
     },
     {
       "id": "characterization",
       "title": "Question 1 - Characterization (OPEN)",
       "summary": "Formalizes CharacterizationQuestion as the existence of a decidable necessary-and-sufficient predicate. Documents in a docstring that pair-counting is not sufficient (Q1 remains open; no characterization_hard axiom is declared).",
-      "startLine": 126,
-      "endLine": 153,
-      "mathContext": "Formal definition: Formalizes CharacterizationQuestion as the existence of a decidable necessary-and-sufficient predicate. Notes in docstring (lines 146-150) that pair-counting is not sufficient; no separate characterization_hard axiom is declared."
+      "startLine": 125,
+      "endLine": 148,
+      "mathContext": "Formal definition: Formalizes CharacterizationQuestion as the existence of a decidable necessary-and-sufficient predicate. Notes in docstring (lines 144-148) that pair-counting is not sufficient; no separate characterization_hard axiom is declared."
     },
     {
       "id": "counting",
       "title": "Question 2 - Counting (SOLVED)",
-      "summary": "Defines B(n), axiomatizes Alon's lower bound (alon_lower_bound) and question_2_solved. Erdős's upper bound is documented in a docstring (lines 163-166) but not declared as an axiom.",
-      "startLine": 154,
-      "endLine": 186,
-      "mathContext": "Formal definition: Defines B(n) as the count of block-compatible sequences. Axioms declared: alon_lower_bound (line 171) and question_2_solved (line 182). Erdős's upper bound appears only in a docstring (lines 163-166) and is not axiomatized."
+      "summary": "Defines B(n), axiomatizes Alon's lower bound (alon_lower_bound) and question_2_solved. Erdős's upper bound is documented in a docstring (lines 160-163) but not declared as an axiom.",
+      "startLine": 149,
+      "endLine": 183,
+      "mathContext": "Formal definition: Defines B(n) as the count of block-compatible sequences. Axioms declared: alon_lower_bound (line 168) and question_2_solved (line 179). Erdős's upper bound appears only in a docstring (lines 160-163) and is not axiomatized."
     },
     {
       "id": "asymptotic",
       "title": "The Asymptotic Constant",
       "summary": "Defines AsymptoticConstant (B(n) = 2^{(c+o(1))√n log n}) and proves constant_at_least_half (c ≥ 1/2) from alon_lower_bound using norm_num.",
-      "startLine": 187,
-      "endLine": 217,
+      "startLine": 184,
+      "endLine": 215,
       "mathContext": "Defines AsymptoticConstant (B(n) = $$2^{{(c+o(1))√n $\\log n$}$}$) and proves constant_at_least_half (c $\\geq$ 1/2) from alon_lower_bound using norm_num."
     },
     {
       "id": "examples",
       "title": "Concrete Examples",
       "summary": "Verifies PairCountCondition for n=4 ([4] and [2,2,2,2,2,2]) and n=6 ([3,3,3,3,3]) via anonymous `example` blocks using simp/norm_num. Docstrings describe the n=3 case. No named declaration — `example_n3` does not exist as a theorem or axiom.",
-      "startLine": 219,
-      "endLine": 257,
+      "startLine": 216,
+      "endLine": 252,
       "mathContext": "Mathematical content: anonymous example blocks verifying PairCountCondition for specific sequences; n=3 case is docstring only."
     },
     {
       "id": "related",
       "title": "Related Problems",
       "summary": "Notes connections to Problem #733 (line-compatible sequences) and Steiner systems S(2,k,n).",
-      "startLine": 259,
-      "endLine": 272,
+      "startLine": 253,
+      "endLine": 267,
       "mathContext": "Mathematical content: Notes connections to Problem #733 (line-compatible sequences) and Steiner systems S(2,k,n)."
     },
     {
       "id": "summary",
       "title": "Summary Theorems",
       "summary": "erdos_732_summary packages Q2-solved + pair-counting necessity as a conjunction. erdos_732 is an alias.",
-      "startLine": 274,
-      "endLine": 316,
+      "startLine": 268,
+      "endLine": 310,
       "mathContext": "Mathematical content: erdos_732_summary packages Q2-solved + pair-counting necessity as a conjunction. erdos_732 is an alias."
     }
   ],
@@ -207,7 +207,7 @@
     ],
     "opens": [],
     "namespace": "Erdos732",
-    "lineCount": 316,
+    "lineCount": 310,
     "axiomCount": 3,
     "theoremCount": 4,
     "definitionCount": 10,


### PR DESCRIPTION
## Summary

`src/data/proofs/erdos-732/meta.json` and `annotations.json` line ranges overshot the actual Lean file (`Proofs/Erdos732Problem.lean`, true `wc -l` = **310**, real EOF `end Erdos732` at line 310). Re-anchored all `sections[]` and annotation `range`s to real declaration / `/- ## Part N -/` header positions. Not a uniform shift — top sections were only 2 off, tail sections ~6 off.

## lineCount

| field | before | after |
|---|---|---|
| `meta.lineCount` | 316 | 310 |
| `leanFile.lineCount` | 316 | 310 |

## sections (meta.json)

| id | before | after |
|---|---|---|
| header-docs | 1–34 | 1–34 |
| imports-setup | 35–42 | 35–40 |
| definitions | 43–74 | 41–72 |
| block-compatible | 75–97 | 73–95 |
| necessary | 98–125 | 96–124 |
| characterization | 126–153 | 125–148 |
| counting | 154–186 | 149–183 |
| asymptotic | 187–217 | 184–215 |
| examples | 219–257 | 216–252 |
| related | 259–272 | 253–267 |
| summary | 274–316 | 268–310 |

Sections now contiguous with last `endLine` == 310 == EOF (previously had gaps at 218/258/273 and overshot to 316). Embedded line references in `characterization`/`counting` mathContext also re-anchored (docstring/axiom line numbers).

## annotations (annotations.json)

| id | before | after |
|---|---|---|
| ann-732-overview | 1–33 | 1–33 |
| ann-732-block | 43–64 | 45–62 |
| ann-732-pbd | 66–74 | 64–71 |
| ann-732-compatible | 75–97 | 77–94 |
| ann-732-paircount | 98–126 | 100–123 |
| ann-732-hard | 127–153 | 129–148 |
| ann-732-counting | 155–194 | 153–182 |
| ann-732-asymptotic | 196–227 | 188–214 |
| ann-732-examples | 228–269 | 220–251 |
| ann-732-steiner | 270–284 | 253–266 |
| ann-732-summary | 285–316 | 272–310 |

All annotation ranges now ≤ EOF (max 310).

## Axiom cross-check

No change. `grep -cE "^axiom " = 3` (`pair_count_necessary` L113, `alon_lower_bound` L168, `question_2_solved` L179) matches `axiomCount: 3`, `status: "axiomatized"`, `badge: "axiom"`. No `native_decide`. Correct as-is.

## Build

`pnpm install --frozen-lockfile` + `pnpm build` green; bundle budget check passed.