### PR TITLE
Enrich erdos-903: fix section & annotation line-range overshoot drift

### DIFF
--- a/src/data/proofs/erdos-903/annotations.json
+++ b/src/data/proofs/erdos-903/annotations.json
@@ -40,8 +40,8 @@
     "id": "ann-903-blockdesign",
     "proofId": "erdos-903",
     "range": {
-      "startLine": 37,
-      "endLine": 44
+      "startLine": 36,
+      "endLine": 40
     },
     "type": "definition",
     "title": "BlockDesign Structure",
@@ -77,8 +77,8 @@
     "id": "ann-903-numblocks",
     "proofId": "erdos-903",
     "range": {
-      "startLine": 46,
-      "endLine": 47
+      "startLine": 43,
+      "endLine": 44
     },
     "type": "definition",
     "title": "numBlocks",
@@ -99,8 +99,8 @@
     "id": "ann-903-primepower",
     "proofId": "erdos-903",
     "range": {
-      "startLine": 50,
-      "endLine": 51
+      "startLine": 47,
+      "endLine": 48
     },
     "type": "definition",
     "title": "IsPrimePower",
@@ -122,8 +122,8 @@
     "id": "ann-903-projsize",
     "proofId": "erdos-903",
     "range": {
-      "startLine": 54,
-      "endLine": 55
+      "startLine": 51,
+      "endLine": 52
     },
     "type": "definition",
     "title": "IsProjectivePlaneSize",
@@ -144,8 +144,8 @@
     "id": "ann-903-debruijn",
     "proofId": "erdos-903",
     "range": {
-      "startLine": 64,
-      "endLine": 65
+      "startLine": 61,
+      "endLine": 62
     },
     "type": "concept",
     "title": "de Bruijn-Erdős Theorem",
@@ -176,8 +176,8 @@
     "id": "ann-903-minimal",
     "proofId": "erdos-903",
     "range": {
-      "startLine": 68,
-      "endLine": 69
+      "startLine": 65,
+      "endLine": 66
     },
     "type": "definition",
     "title": "IsMinimalDesign",
@@ -198,8 +198,8 @@
     "id": "ann-903-uniform",
     "proofId": "erdos-903",
     "range": {
-      "startLine": 72,
-      "endLine": 73
+      "startLine": 68,
+      "endLine": 68
     },
     "type": "concept",
     "title": "Minimal Design Uniformity",
@@ -220,8 +220,8 @@
     "id": "ann-903-projplane",
     "proofId": "erdos-903",
     "range": {
-      "startLine": 83,
-      "endLine": 90
+      "startLine": 77,
+      "endLine": 84
     },
     "type": "definition",
     "title": "ProjectivePlane Structure",
@@ -258,8 +258,8 @@
     "id": "ann-903-toblockdesign",
     "proofId": "erdos-903",
     "range": {
-      "startLine": 97,
-      "endLine": 98
+      "startLine": 88,
+      "endLine": 89
     },
     "type": "concept",
     "title": "Projective Plane as Block Design",
@@ -287,8 +287,8 @@
     "id": "ann-903-efsw",
     "proofId": "erdos-903",
     "range": {
-      "startLine": 107,
-      "endLine": 109
+      "startLine": 98,
+      "endLine": 100
     },
     "type": "concept",
     "title": "EFSW 1985: The Gap Theorem",
@@ -312,8 +312,8 @@
     "id": "ann-903-strong",
     "proofId": "erdos-903",
     "range": {
-      "startLine": 113,
-      "endLine": 119
+      "startLine": 102,
+      "endLine": 103
     },
     "type": "concept",
     "title": "EFSW Strong Bound",
@@ -334,8 +334,8 @@
     "id": "ann-903-achievable",
     "proofId": "erdos-903",
     "range": {
-      "startLine": 128,
-      "endLine": 129
+      "startLine": 111,
+      "endLine": 112
     },
     "type": "theorem",
     "title": "achievableBlocks",
@@ -356,8 +356,8 @@
     "id": "ann-903-gap",
     "proofId": "erdos-903",
     "range": {
-      "startLine": 136,
-      "endLine": 138
+      "startLine": 116,
+      "endLine": 118
     },
     "type": "concept",
     "title": "The Gap: Forbidden Block Counts",
@@ -388,8 +388,8 @@
     "id": "ann-903-firstabove",
     "proofId": "erdos-903",
     "range": {
-      "startLine": 141,
-      "endLine": 146
+      "startLine": 121,
+      "endLine": 126
     },
     "type": "concept",
     "title": "first_above_n (Proved)",
@@ -410,8 +410,8 @@
     "id": "ann-903-examples",
     "proofId": "erdos-903",
     "range": {
-      "startLine": 152,
-      "endLine": 162
+      "startLine": 132,
+      "endLine": 142
     },
     "type": "concept",
     "title": "Concrete Gap Examples",
@@ -432,8 +432,8 @@
     "id": "ann-903-2design",
     "proofId": "erdos-903",
     "range": {
-      "startLine": 170,
-      "endLine": 171
+      "startLine": 150,
+      "endLine": 151
     },
     "type": "definition",
     "title": "Is2Design",
@@ -461,8 +461,8 @@
     "id": "ann-903-fisher",
     "proofId": "erdos-903",
     "range": {
-      "startLine": 174,
-      "endLine": 176
+      "startLine": 154,
+      "endLine": 156
     },
     "type": "concept",
     "title": "Fisher's Inequality",
@@ -483,8 +483,8 @@
     "id": "ann-903-dbfromfisher",
     "proofId": "erdos-903",
     "range": {
-      "startLine": 179,
-      "endLine": 182
+      "startLine": 159,
+      "endLine": 162
     },
     "type": "concept",
     "title": "de_bruijn_erdos_from_fisher (Proved)",
@@ -505,8 +505,8 @@
     "id": "ann-903-summary",
     "proofId": "erdos-903",
     "range": {
-      "startLine": 201,
-      "endLine": 211
+      "startLine": 181,
+      "endLine": 204
     },
     "type": "concept",
     "title": "erdos_903_summary (Proved)",

--- a/src/data/proofs/erdos-903/meta.json
+++ b/src/data/proofs/erdos-903/meta.json
@@ -55,7 +55,7 @@
       "Noted (in docstring only, not axiomatized) the stronger bound t ≥ n + 1.148p for non-broken-projective-plane designs"
     ],
     "axiomCount": 5,
-    "lineCount": 211,
+    "lineCount": 205,
     "assumptions": "5 axioms: de_bruijn_erdos, projective_plane_design, efsw_1985, gap_theorem, fisher_inequality. 0 sorries.",
     "theoremCount": 3,
     "definitionCount": 8
@@ -83,63 +83,63 @@
       "title": "Basic Definitions",
       "summary": "BlockDesign structure with pair coverage, numBlocks, IsPrimePower, IsProjectivePlaneSize",
       "startLine": 29,
-      "endLine": 56,
+      "endLine": 53,
       "mathContext": "Formal definition: BlockDesign structure with pair coverage, numBlocks, IsPrimePower, IsProjectivePlaneSize"
     },
     {
       "id": "de-bruijn-erdos",
       "title": "The de Bruijn-Erdős Theorem",
       "summary": "de_bruijn_erdos axiom (t ≥ n) and IsMinimalDesign predicate",
-      "startLine": 57,
-      "endLine": 71,
+      "startLine": 54,
+      "endLine": 68,
       "mathContext": "Axiomatized: de_bruijn_erdos (t $\\geq$ n). Defined: IsMinimalDesign."
     },
     {
       "id": "projective-planes",
       "title": "Projective Plane Constructions",
       "summary": "ProjectivePlane structure and projective_plane_design axiom",
-      "startLine": 72,
-      "endLine": 93,
+      "startLine": 69,
+      "endLine": 90,
       "mathContext": "Defined: ProjectivePlane structure. Axiomatized: projective_plane_design (a projective plane gives a block design with t = n)."
     },
     {
       "id": "erdos-sos-theorem",
       "title": "The Erdős-Sós Conjecture (Now Theorem)",
       "summary": "efsw_1985 axiom (gap theorem); 1.148p stronger bound noted in docstring only (not axiomatized)",
-      "startLine": 94,
-      "endLine": 106,
+      "startLine": 91,
+      "endLine": 103,
       "mathContext": "Axiomatized: efsw_1985 (t > n implies t ≥ n + p). The 1.148p stronger bound under non-broken-projective-plane condition appears only in a docstring comment, not as an axiom or theorem."
     },
     {
       "id": "gap-structure",
       "title": "The Gap Structure",
       "summary": "achievableBlocks set, gap_theorem axiom, first_above_n (proved by contradiction)",
-      "startLine": 107,
-      "endLine": 130,
+      "startLine": 104,
+      "endLine": 127,
       "mathContext": "Defined: achievableBlocks. Axiomatized: gap_theorem. Proved: first_above_n (by contradiction from gap_theorem)."
     },
     {
       "id": "examples",
       "title": "Examples",
       "summary": "Concrete gap computations for p = 2, 3, 4, 5 via norm_num",
-      "startLine": 131,
-      "endLine": 146,
+      "startLine": 128,
+      "endLine": 143,
       "mathContext": "Mathematical content: Concrete gap computations for p = 2, 3, 4, 5 via norm_num"
     },
     {
       "id": "2-designs",
       "title": "Connection to Combinatorial Designs",
       "summary": "Is2Design predicate, fisher_inequality axiom, de_bruijn_erdos_from_fisher (proved)",
-      "startLine": 147,
-      "endLine": 165,
+      "startLine": 144,
+      "endLine": 163,
       "mathContext": "Defined: Is2Design. Axiomatized: fisher_inequality. Proved: de_bruijn_erdos_from_fisher (direct application of fisher_inequality)."
     },
     {
       "id": "summary",
       "title": "Summary",
       "summary": "erdos_903_summary (proved): three-part conjunction combining de Bruijn-Erdős, projective plane existence, and EFSW gap theorem",
-      "startLine": 166,
-      "endLine": 211,
+      "startLine": 164,
+      "endLine": 205,
       "mathContext": "Proved: erdos_903_summary, a three-part conjunction combining the de Bruijn-Erdős, projective_plane_design, and efsw_1985 axioms into a single statement."
     }
   ],
@@ -163,7 +163,7 @@
     ],
     "opens": [],
     "namespace": "Erdos903",
-    "lineCount": 211,
+    "lineCount": 205,
     "axiomCount": 5,
     "theoremCount": 3,
     "definitionCount": 8,


### PR DESCRIPTION
Fixes line-range overshoot/drift in the erdos-903 gallery entry. The Lean file `Proofs/Erdos903Problem.lean` is **205** lines (EOF `end Erdos903` at 205), but `meta.json` and every `annotations.json` range were anchored to a stale 211-line layout — the last section overshot EOF (211) and all annotations pointed several lines *below* their intended declarations.

## lineCount
- `meta.lineCount` / `leanFile.lineCount`: 211 → **205** (real `wc -l`)

## Sections (re-anchored to `/- ## Part N` header blocks, contiguous, last == EOF)
| id | before | after |
|----|--------|-------|
| basic-definitions | 29–56 | 29–53 |
| de-bruijn-erdos | 57–71 | 54–68 |
| projective-planes | 72–93 | 69–90 |
| erdos-sos-theorem | 94–106 | 91–103 |
| gap-structure | 107–130 | 104–127 |
| examples | 131–146 | 128–143 |
| 2-designs | 147–165 | 144–163 |
| summary | 166–211 | 164–205 |

## Annotations (re-anchored to actual declaration statements; content preserved)
| id | before | after | target |
|----|--------|-------|--------|
| ann-903-header | 1–22 | 1–22 | header doc |
| ann-903-blockdesign | 37–44 | 36–40 | BlockDesign |
| ann-903-numblocks | 46–47 | 43–44 | numBlocks |
| ann-903-primepower | 50–51 | 47–48 | IsPrimePower |
| ann-903-projsize | 54–55 | 51–52 | IsProjectivePlaneSize |
| ann-903-debruijn | 64–65 | 61–62 | de_bruijn_erdos |
| ann-903-minimal | 68–69 | 65–66 | IsMinimalDesign |
| ann-903-uniform | 72–73 | 68 | uniformity comment |
| ann-903-projplane | 83–90 | 77–84 | ProjectivePlane |
| ann-903-toblockdesign | 97–98 | 88–89 | projective_plane_design |
| ann-903-efsw | 107–109 | 98–100 | efsw_1985 |
| ann-903-strong | 113–119 | 102–103 | strong-bound comment |
| ann-903-achievable | 128–129 | 111–112 | achievableBlocks |
| ann-903-gap | 136–138 | 116–118 | gap_theorem |
| ann-903-firstabove | 141–146 | 121–126 | first_above_n |
| ann-903-examples | 152–162 | 132–142 | p=2..5 examples |
| ann-903-2design | 170–171 | 150–151 | Is2Design |
| ann-903-fisher | 174–176 | 154–156 | fisher_inequality |
| ann-903-dbfromfisher | 179–182 | 159–162 | de_bruijn_erdos_from_fisher |
| ann-903-summary | 201–211 | 181–204 | erdos_903_summary |

## Axiom cross-check
No change. `grep -cE "^axiom " = 5` matches `meta.axiomCount = 5` (de_bruijn_erdos, projective_plane_design, efsw_1985, gap_theorem, fisher_inequality). No `native_decide`. `status: axiomatized` / `badge: axiom` correct.

## Validation
- maxSection 205 ≤ 205, maxAnn 204 ≤ 205, sections contiguous, last endLine == EOF.
- `pnpm build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)