### PR TITLE
Enrich erdos-936: fix section & annotation line-range overshoot drift

### DIFF
--- a/src/data/proofs/erdos-936/annotations.json
+++ b/src/data/proofs/erdos-936/annotations.json
@@ -25,8 +25,8 @@
     "id": "ann-e936-powerful-def",
     "proofId": "erdos-936",
     "range": {
-      "startLine": 51,
-      "endLine": 65
+      "startLine": 47,
+      "endLine": 61
     },
     "type": "definition",
     "title": "Powerful Number Definition",
@@ -47,8 +47,8 @@
     "id": "ann-e936-one-powerful",
     "proofId": "erdos-936",
     "range": {
-      "startLine": 67,
-      "endLine": 71
+      "startLine": 63,
+      "endLine": 66
     },
     "type": "concept",
     "title": "1 is Powerful",
@@ -68,8 +68,8 @@
     "id": "ann-e936-sq-powerful",
     "proofId": "erdos-936",
     "range": {
-      "startLine": 73,
-      "endLine": 78
+      "startLine": 68,
+      "endLine": 73
     },
     "type": "concept",
     "title": "Perfect Squares are Powerful",
@@ -89,8 +89,8 @@
     "id": "ann-e936-prime-not-powerful",
     "proofId": "erdos-936",
     "range": {
-      "startLine": 92,
-      "endLine": 100
+      "startLine": 87,
+      "endLine": 94
     },
     "type": "concept",
     "title": "Primes are NOT Powerful",
@@ -110,8 +110,8 @@
     "id": "ann-e936-eventually-not-powerful",
     "proofId": "erdos-936",
     "range": {
-      "startLine": 118,
-      "endLine": 129
+      "startLine": 112,
+      "endLine": 123
     },
     "type": "definition",
     "title": "Eventually Not Powerful",
@@ -131,8 +131,8 @@
     "id": "ann-e936-concrete-examples",
     "proofId": "erdos-936",
     "range": {
-      "startLine": 131,
-      "endLine": 190
+      "startLine": 129,
+      "endLine": 184
     },
     "type": "concept",
     "title": "Verified Small Cases",
@@ -152,8 +152,8 @@
     "id": "ann-e936-abc-conjecture",
     "proofId": "erdos-936",
     "range": {
-      "startLine": 199,
-      "endLine": 207
+      "startLine": 193,
+      "endLine": 201
     },
     "type": "concept",
     "title": "ABC Conjecture",
@@ -174,8 +174,8 @@
     "id": "ann-e936-cushing-pascoe",
     "proofId": "erdos-936",
     "range": {
-      "startLine": 209,
-      "endLine": 219
+      "startLine": 203,
+      "endLine": 213
     },
     "type": "concept",
     "title": "Cushing-Pascoe Theorem (2016)",
@@ -195,8 +195,8 @@
     "id": "ann-e936-crowdmath",
     "proofId": "erdos-936",
     "range": {
-      "startLine": 221,
-      "endLine": 228
+      "startLine": 215,
+      "endLine": 222
     },
     "type": "concept",
     "title": "CrowdMath Theorem (2020)",
@@ -216,8 +216,8 @@
     "id": "ann-e936-four-variants",
     "proofId": "erdos-936",
     "range": {
-      "startLine": 230,
-      "endLine": 284
+      "startLine": 228,
+      "endLine": 262
     },
     "type": "concept",
     "title": "The Four Variants",
@@ -237,8 +237,8 @@
     "id": "ann-e936-squarefree",
     "proofId": "erdos-936",
     "range": {
-      "startLine": 294,
-      "endLine": 307
+      "startLine": 272,
+      "endLine": 285
     },
     "type": "definition",
     "title": "Squarefree Numbers",
@@ -259,8 +259,8 @@
     "id": "ann-e936-summary",
     "proofId": "erdos-936",
     "range": {
-      "startLine": 313,
-      "endLine": 327
+      "startLine": 291,
+      "endLine": 319
     },
     "type": "concept",
     "title": "Problem Summary",

--- a/src/data/proofs/erdos-936/meta.json
+++ b/src/data/proofs/erdos-936/meta.json
@@ -62,7 +62,7 @@
       "erdos_936_summary: complete status of the problem"
     ],
     "axiomCount": 3,
-    "lineCount": 327,
+    "lineCount": 321,
     "assumptions": "3 axioms: abc_conjecture_holds (the unproven ABC conjecture as a Prop), cushing_pascoe_theorem (2016: ABC → n!±1 eventually not powerful), crowdmath_theorem (2020: ABC → 2^n±1 eventually not powerful). The four variant axioms have been PROVED from these two conditional theorems.",
     "theoremCount": 27,
     "definitionCount": 3
@@ -90,50 +90,50 @@
       "id": "powerful-numbers",
       "title": "Powerful Numbers",
       "summary": "Definition of powerful numbers and basic examples",
-      "startLine": 45,
-      "endLine": 107
+      "startLine": 41,
+      "endLine": 101
     },
     {
       "id": "sequences",
       "title": "The Sequences in Question",
       "summary": "Definition of EventuallyNotPowerful and the four target sequences",
-      "startLine": 108,
-      "endLine": 130
+      "startLine": 102,
+      "endLine": 124
     },
     {
       "id": "concrete-examples",
       "title": "Concrete Examples",
       "summary": "Verified computations for small values of n",
-      "startLine": 131,
-      "endLine": 191
+      "startLine": 125,
+      "endLine": 185
     },
     {
       "id": "abc-connection",
       "title": "ABC Conjecture Connection",
       "summary": "The Cushing-Pascoe and CrowdMath theorems",
-      "startLine": 192,
-      "endLine": 229
+      "startLine": 186,
+      "endLine": 223
     },
     {
       "id": "four-variants",
       "title": "The Four Variants",
       "summary": "Four variant theorems proved from the two conditional axioms: 2^n±1 and n!±1 eventually not powerful, each conditional on abc_conjecture_holds.",
-      "startLine": 230,
-      "endLine": 285
+      "startLine": 224,
+      "endLine": 263
     },
     {
       "id": "squarefree",
       "title": "Squarefree Observations",
       "summary": "Relationship between squarefree and powerful numbers",
-      "startLine": 286,
-      "endLine": 308
+      "startLine": 264,
+      "endLine": 286
     },
     {
       "id": "summary",
       "title": "Summary and Status",
       "summary": "Complete formalization status and main results",
-      "startLine": 309,
-      "endLine": 327
+      "startLine": 287,
+      "endLine": 321
     }
   ],
   "conclusion": {
@@ -162,7 +162,7 @@
       "Finset"
     ],
     "namespace": "Erdos936",
-    "lineCount": 327,
+    "lineCount": 321,
     "axiomCount": 3,
     "theoremCount": 27,
     "definitionCount": 3,


### PR DESCRIPTION
Fixes line-range overshoot drift in the `erdos-936` gallery entry. Metadata was anchored to an older/longer Lean file (327 lines) but the actual `proofs/Proofs/Erdos936Problem.lean` is **321 lines**. Re-anchored every section and annotation to the real declaration positions (not a blind constant subtraction).

## lineCount
| field | before | after |
|---|---|---|
| `meta.lineCount` | 327 | 321 |
| `leanFile.lineCount` | 327 | 321 |

## sections[] (re-anchored to `## Part` comment blocks; now contiguous, last endLine == real EOF 321)
| section | before | after |
|---|---|---|
| powerful-numbers | 45–107 | 41–101 |
| sequences | 108–130 | 102–124 |
| concrete-examples | 131–191 | 125–185 |
| abc-connection | 192–229 | 186–223 |
| four-variants | 230–285 | 224–263 |
| squarefree | 286–308 | 264–286 |
| summary | 309–327 | 287–321 |

## annotations.json (re-anchored to the declaration each describes)
| annotation | before | after |
|---|---|---|
| ann-e936-header | 1–33 | 1–33 (unchanged) |
| ann-e936-powerful-def | 51–65 | 47–61 |
| ann-e936-one-powerful | 67–71 | 63–66 |
| ann-e936-sq-powerful | 73–78 | 68–73 |
| ann-e936-prime-not-powerful | 92–100 | 87–94 |
| ann-e936-eventually-not-powerful | 118–129 | 112–123 |
| ann-e936-concrete-examples | 131–190 | 129–184 |
| ann-e936-abc-conjecture | 199–207 | 193–201 |
| ann-e936-cushing-pascoe | 209–219 | 203–213 |
| ann-e936-crowdmath | 221–228 | 215–222 |
| ann-e936-four-variants | 230–284 | 228–262 |
| ann-e936-squarefree | 294–307 | 272–285 |
| ann-e936-summary | 313–327 (over-EOF) | 291–319 |

Validation: sections contiguous with last endLine == 321; max section endLine (321) and max annotation endLine (319) both ≤ real LC 321.

## Axiom cross-check (no change needed)
- `grep -cE "^axiom " ` = **3** (`abc_conjecture_holds`, `cushing_pascoe_theorem`, `crowdmath_theorem`) — matches `meta.axiomCount: 3`.
- No `native_decide`, no `sorry`.
- `status: "axiomatized"`, `badge: "axiom"` — correct and unchanged.

`pnpm build` green (bundle budget check passed). Only `meta.json` and `annotations.json` committed.