### PR TITLE
Enrich hilbert-22: fix section line-range overshoot drift (305→299)

### DIFF
--- a/src/data/proofs/hilbert-22/meta.json
+++ b/src/data/proofs/hilbert-22/meta.json
@@ -45,7 +45,7 @@
     "dateAdded": "2025-12-29",
     "hilbertNumber": 22,
     "axiomCount": 2,
-    "lineCount": 305,
+    "lineCount": 299,
     "assumptions": "Structure-encoded assumptions: isDiscrete : True in FuchsianGroup and HyperbolicDomain structures (proper discontinuity condition); def RiemannSurface.IsSimplyConnected : Prop := True (topological connectivity placeholder). The uniformization theorem itself remains in comments. Per CLAUDE.md: structure fields with True are counted as structure-encoded assumptions.",
     "mathlib_version": "4.31.0",
     "theoremCount": 5,
@@ -110,7 +110,7 @@
       "id": "connections",
       "title": "Connections and Applications",
       "startLine": 281,
-      "endLine": 305,
+      "endLine": 299,
       "summary": "Links to hyperbolic geometry, modular forms, and arithmetic geometry via Belyi's theorem."
     }
   ],
@@ -136,7 +136,7 @@
     ],
     "opens": [],
     "namespace": "Hilbert22Uniformization",
-    "lineCount": 305,
+    "lineCount": 299,
     "axiomCount": 0,
     "sorries": 0,
     "theoremCount": 5,


### PR DESCRIPTION
## Enrichment pass — `hilbert-22`

### Problem (line-range overshoot drift)
`Proofs/Hilbert22Uniformization.lean` is **299 lines** (`end Hilbert22Uniformization` at L299), but the gallery metadata described it as 305 and the final section overshot EOF by 6.

| Element | Before | After |
|---|---|---|
| `meta.lineCount` / `leanFile.lineCount` | 305 | **299** |
| section `connections` | 281–305 | **281–299** |

### Fix
Clamped the `connections` section to the real EOF (299) and corrected both `lineCount` fields. Verified: maxSection = 299 = LC, maxAnn = 276, no overshoot. No annotation edits needed (none overshot).

### Axiom integrity (verified accurate — unchanged)
`meta.axiomCount: 2` vs `leanFile.axiomCount: 0` is a **legitimate** structure-encoded-assumptions gap, not fabrication: the `assumptions` field documents the two (`isDiscrete : True` in `FuchsianGroup`; `RiemannSurface.IsSimplyConnected := True`). This is a scaffold entry (the uniformization theorem remains in prose), so `status: axiomatized` / `badge: axiom` is the correct conservative reading.

### Verification
- `pnpm build` ✓ (exit 0, all chunks within budget)