### PR TITLE
Fix: erdos-856 prose overstates 'axiomatized' bounds (#39290)

### DIFF
--- a/src/data/proofs/erdos-856/annotations.json
+++ b/src/data/proofs/erdos-856/annotations.json
@@ -143,7 +143,7 @@
     },
     "type": "concept",
     "title": "Erdős 1970 Upper Bound",
-    "content": "Axiomatizes Erdős's bound f_k(N) ≤ C · log(N)/log(log(N)). The proof idea: for each t, the number of a ∈ A with t = ap for some prime p is < k (else k elements have uniform LCM = t). Summing over primes gives the bound. Also axiomatizes the key prime factorization lemma.",
+    "content": "States in a prose comment (not formalized) Erdős's bound f_k(N) ≤ C · log(N)/log(log(N)). The proof idea: for each t, the number of a ∈ A with t = ap for some prime p is < k (else k elements have uniform LCM = t). Summing over primes gives the bound. The key prime factorization lemma is likewise stated only in a comment.",
     "mathContext": "$f_k(N) \\leq C \\cdot \\frac{\\log N}{\\log\\log N}$. Key lemma: $|\\{a \\in A : \\exists p \\text{ prime},\\, t = ap\\}| < k$ for each $t$, since otherwise $k$ elements of $A$ have $\\text{lcm} = t$.",
     "significance": "key",
     "relatedConcepts": [
@@ -166,7 +166,7 @@
     },
     "type": "concept",
     "title": "Tang–Zhang 2025 Bounds",
-    "content": "Axiomatizes the Tang–Zhang improvement: there exist constants 0 < b_k ≤ c_k ≤ 1 such that for all ε > 0, eventually (log N)^{b_k - ε} ≤ f_k(N) ≤ (log N)^{c_k + ε}. This replaces Erdős's log/loglog bound with power-of-log bounds.",
+    "content": "States in a prose comment (not formalized) the Tang–Zhang improvement: there exist constants 0 < b_k ≤ c_k ≤ 1 such that for all ε > 0, eventually (log N)^{b_k - ε} ≤ f_k(N) ≤ (log N)^{c_k + ε}. This replaces Erdős's log/loglog bound with power-of-log bounds.",
     "mathContext": "$\\forall \\varepsilon > 0,\\, \\exists N_0: \\forall N \\geq N_0,\\, (\\log N)^{b_k - \\varepsilon} \\leq f_k(N) \\leq (\\log N)^{c_k + \\varepsilon}$. For $k = 3$: $b_3 \\geq 0.438$, $c_3 \\leq 0.889$.",
     "significance": "key",
     "relatedConcepts": [
@@ -234,7 +234,7 @@
     },
     "type": "concept",
     "title": "Sunflower Equivalence",
-    "content": "Axiomatizes the deep equivalence: c_k < 1 (non-trivial upper bound on f_k(N)) if and only if the sunflower conjecture holds for k-petalled sunflowers. This connects a number-theoretic extremal problem to a purely combinatorial conjecture.",
+    "content": "Describes (in a prose comment, not as a Lean declaration) the deep equivalence: c_k < 1 (non-trivial upper bound on f_k(N)) if and only if the sunflower conjecture holds for k-petalled sunflowers. This connects a number-theoretic extremal problem to a purely combinatorial conjecture.",
     "mathContext": "$\\text{SunflowerConjectureForK}(k) \\iff \\exists c_k < 1: f_k(N) \\leq (\\log N)^{c_k + o(1)}$. The forward direction uses LCM structure to build sunflowers; the reverse uses sunflower-free families to build LCM-free sets.",
     "significance": "key",
     "relatedConcepts": [
@@ -257,7 +257,7 @@
     },
     "type": "concept",
     "title": "Natural Density Variant",
-    "content": "Defines g_k(N) = max|A| over k-LCM-free subsets (natural density instead of harmonic sum). Axiomatizes g_4(N) ≫ N and g_3(N) ≫ N: sets of linear size can avoid the LCM condition. The harmonic sum version is the harder and more interesting quantity.",
+    "content": "Defines g_k(N) = max|A| over k-LCM-free subsets (natural density instead of harmonic sum). States in a prose comment (not formalized) g_4(N) ≫ N and g_3(N) ≫ N: sets of linear size can avoid the LCM condition. The harmonic sum version is the harder and more interesting quantity.",
     "mathContext": "$g_k(N) = \\max\\{|A| : A \\subseteq [N],\\, \\text{IsLCMFree}(A, k)\\}$. For $k \\geq 3$: $g_k(N) \\geq CN$ for some $C > 0$. The harmonic sum $f_k(N)$ is much smaller: $f_k(N) \\leq (\\log N)^{c_k}$.",
     "significance": "supporting",
     "relatedConcepts": [

--- a/src/data/proofs/erdos-856/meta.json
+++ b/src/data/proofs/erdos-856/meta.json
@@ -33,7 +33,7 @@
     "historicalContext": "Erdős posed this problem in 1970 in his paper 'Some extremal problems in combinatorial number theory' dedicated to A. J. Macintyre, asking for the maximum harmonic sum of subsets of $\\{1, \\ldots, N\\}$ that avoid $k$ elements with uniform pairwise LCM. The uniform pairwise LCM condition means every distinct pair $(a, b)$ in the forbidden subset has $\\text{lcm}(a, b) = t$ for the same $t$. Erdős proved $f_k(N) \\ll \\log N / \\log\\log N$ using the observation that for each $t$, the set $\\{a \\in A : \\exists p \\text{ prime},\\, t = ap\\}$ has size $< k$. The problem lay dormant for decades until Tang and Zhang (2025) made significant progress, proving $(\\log N)^{b_k} \\leq f_k(N) \\leq (\\log N)^{c_k}$ for explicit constants $0 < b_k \\leq c_k \\leq 1$, and establishing for $k = 3$ the bounds $(\\log N)^{0.438} \\leq f_3(N) \\leq (\\log N)^{0.889}$. The deep connection to the sunflower conjecture — proved via the Erdős–Ko–Rado theorem and its LCM analogues — shows that $c_k < 1$ if and only if the sunflower conjecture holds for $k$-sunflowers. The sunflower lemma of Erdős and Rado (1960) gives $c_k \\leq 1$, while the conjecture would improve this to $c_k < 1$. Alweiss, Lovett, Wu, and Zhang (2021) made a breakthrough on the sunflower conjecture, which has implications for the upper bound exponents here.",
     "problemStatement": "Let $k \\geq 3$ and $f_k(N)$ be the maximum value of $\\sum_{n \\in A} 1/n$, where $A$ ranges over all subsets of $\\{1, \\ldots, N\\}$ containing no subset of size $k$ with the same pairwise least common multiple. Estimate $f_k(N)$.",
     "text": "Estimate f_k(N), the maximum harmonic sum of subsets of {1,...,N} with no k elements having uniform pairwise LCM. Status: OPEN. Bounds relate to sunflower conjecture.",
-    "proofStrategy": "The formalization defines LCM, uniform pairwise LCM, $k$-LCM-free sets, and the harmonic sum $\\sum 1/n$. The extremal function $f_k(N)$ is defined via `sSup`. Erdős's 1970 upper bound and Tang–Zhang's 2025 improved bounds are axiomatized. The sunflower conjecture connection is formalized as an equivalence: $c_k < 1 \\iff$ sunflower conjecture for $k$. Examples (divisor sets, prime powers) and the natural density variant $g_k(N)$ are also included. Two supporting lemmas are stated in Lean (LCM commutativity and the divisor set LCM property), but the file does not currently compile under Lean v4.31, so no theorem is machine-verified (see `assumptions`).",
+    "proofStrategy": "The formalization defines LCM, uniform pairwise LCM, $k$-LCM-free sets, and the harmonic sum $\\sum 1/n$. The extremal function $f_k(N)$ is defined via `sSup`. Erdős's 1970 upper bound and Tang–Zhang's 2025 improved bounds are stated in prose comments (not formalized as axioms, defs, or theorems). The sunflower conjecture connection is described in comments as an equivalence: $c_k < 1 \\iff$ sunflower conjecture for $k$, but that equivalence is not itself a Lean declaration. Examples (divisor sets, prime powers) and the natural density variant $g_k(N)$ are also included. Two supporting lemmas are stated in Lean (LCM commutativity and the divisor set LCM property), but the file does not currently compile under Lean v4.31, so no theorem is machine-verified (see `assumptions`).",
     "keyInsights": [
       "**Harmonic vs. natural density**: The problem measures $f_k(N) = \\max \\sum 1/n$ (logarithmic density) rather than $\\max |A|$ (natural density). This is subtler: for $k \\geq 4$, sets of linear size can avoid the LCM condition, but the harmonic sum is bounded.",
       "**Erdős's prime factorization trick**: For each $t$, the set $\\{a \\in A : \\exists p \\text{ prime},\\, t = ap\\}$ has $< k$ elements (else $k$ elements have $\\text{lcm} = t$). Summing over primes dividing elements of $A$ yields $f_k(N) \\ll \\log N / \\log\\log N$.",
@@ -76,52 +76,52 @@
       "title": "Harmonic Sum and $f_k(N)$",
       "startLine": 90,
       "endLine": 107,
-      "summary": "Defines `harmonicSum A = \\sum_{n \\in A} 1/n$ (with $1/0 = 0$ guard) and $f_k(k, N) = \\sup\\{\\text{harmonicSum}(A) : A \\subseteq [N],\\, \\text{IsLCMFree}(A, k)\\}$. The `sSup` formulation axiomatizes the extremal function.",
-      "mathContext": "Defines `harmonicSum A = \\sum_{n \\in A} 1/n$ (with $1/0 = 0$ guard) and $f_k(k, N) = \\sup\\{\\text{harmonicSum}(A) : A \\subseteq [N],\\, \\text{IsLCMFree}(A, k)\\}$. The `sSup` formulation axiomatizes the extremal function."
+      "summary": "Defines `harmonicSum A = \\sum_{n \\in A} 1/n$ (with $1/0 = 0$ guard) and $f_k(k, N) = \\sup\\{\\text{harmonicSum}(A) : A \\subseteq [N],\\, \\text{IsLCMFree}(A, k)\\}$. The `sSup` formulation defines the extremal function.",
+      "mathContext": "Defines `harmonicSum A = \\sum_{n \\in A} 1/n$ (with $1/0 = 0$ guard) and $f_k(k, N) = \\sup\\{\\text{harmonicSum}(A) : A \\subseteq [N],\\, \\text{IsLCMFree}(A, k)\\}$. The `sSup` formulation defines the extremal function."
     },
     {
       "id": "erdos-bound",
       "title": "Erdős 1970 Upper Bound",
       "startLine": 108,
       "endLine": 132,
-      "summary": "Axiomatizes $f_k(N) \\leq C \\cdot \\log N / \\log\\log N$ for some $C > 0$, and the key lemma: for each $t$, the set $\\{a \\in A : \\exists p \\text{ prime},\\, t = ap\\}$ has $< k$ elements.",
-      "mathContext": "Axiomatized: Axiomatizes $f_k(N) \\leq C \\cdot \\log N / \\log\\log N$ for some $C > 0$, and the key lemma: for each $t$, the set $\\{a \\in A : \\exists p \\text{ prime},\\, t = ap\\}$ has $< k$ elements."
+      "summary": "States in a prose comment (not formalized) $f_k(N) \\leq C \\cdot \\log N / \\log\\log N$ for some $C > 0$, and the key lemma: for each $t$, the set $\\{a \\in A : \\exists p \\text{ prime},\\, t = ap\\}$ has $< k$ elements.",
+      "mathContext": "Documented in a comment: States $f_k(N) \\leq C \\cdot \\log N / \\log\\log N$ for some $C > 0$, and the key lemma: for each $t$, the set $\\{a \\in A : \\exists p \\text{ prime},\\, t = ap\\}$ has $< k$ elements."
     },
     {
       "id": "tang-zhang",
       "title": "Tang–Zhang 2025 Bounds",
       "startLine": 133,
       "endLine": 158,
-      "summary": "Axiomatizes $\\exists b_k \\leq c_k$ with $(\\log N)^{b_k - \\varepsilon} \\leq f_k(N) \\leq (\\log N)^{c_k + \\varepsilon}$ for all $\\varepsilon > 0$ eventually. For $k = 3$: $(\\log N)^{0.438} \\leq f_3(N) \\leq (\\log N)^{0.889}$.",
-      "mathContext": "Axiomatizes $\\exists b_k \\leq c_k$ with $(\\log N)^{b_k - \\varepsilon} \\leq f_k(N) \\leq (\\log N)^{c_k + \\varepsilon}$ for all $\\varepsilon > 0$ eventually. For $k = 3$: $(\\log N)^{0.438} \\leq f_3(N) \\leq (\\log N)^{0.889}$."
+      "summary": "States in a prose comment (not formalized) $\\exists b_k \\leq c_k$ with $(\\log N)^{b_k - \\varepsilon} \\leq f_k(N) \\leq (\\log N)^{c_k + \\varepsilon}$ for all $\\varepsilon > 0$ eventually. For $k = 3$: $(\\log N)^{0.438} \\leq f_3(N) \\leq (\\log N)^{0.889}$.",
+      "mathContext": "States in a prose comment (not formalized) $\\exists b_k \\leq c_k$ with $(\\log N)^{b_k - \\varepsilon} \\leq f_k(N) \\leq (\\log N)^{c_k + \\varepsilon}$ for all $\\varepsilon > 0$ eventually. For $k = 3$: $(\\log N)^{0.438} \\leq f_3(N) \\leq (\\log N)^{0.889}$."
     },
     {
       "id": "sunflower",
       "title": "Sunflower Conjecture Connection",
       "startLine": 159,
       "endLine": 196,
-      "summary": "Defines $k$-sunflowers (sets with common pairwise intersection) and the sunflower conjecture for $k$. Axiomatizes the equivalence: $c_k < 1 \\iff \\text{SunflowerConjectureForK}(k)$.",
-      "mathContext": "Formal definition: Defines $k$-sunflowers (sets with common pairwise intersection) and the sunflower conjecture for $k$. Axiomatizes the equivalence: $c_k < 1 \\iff \\text{SunflowerConjectureForK}(k)$."
+      "summary": "Defines $k$-sunflowers (sets with common pairwise intersection) and the sunflower conjecture for $k$. Describes (in a prose comment, not as a Lean declaration) the equivalence: $c_k < 1 \\iff \\text{SunflowerConjectureForK}(k)$.",
+      "mathContext": "Formal definition: Defines $k$-sunflowers (sets with common pairwise intersection) and the sunflower conjecture for $k$. Describes (in a prose comment, not as a Lean declaration) the equivalence: $c_k < 1 \\iff \\text{SunflowerConjectureForK}(k)$."
     },
     {
       "id": "natural-density",
       "title": "Natural Density Variant",
       "startLine": 197,
       "endLine": 225,
-      "summary": "Defines $g_k(N) = \\max |A|$ over $k$-LCM-free subsets (natural density). Axiomatizes Erdős's result $g_4(N) \\gg N$ and the $k = 3$ variant, connecting to Problem #536.",
-      "mathContext": "Formal definition: Defines $g_k(N) = \\max |A|$ over $k$-LCM-free subsets (natural density). Axiomatizes Erdős's result $g_4(N) \\gg N$ and the $k = 3$ variant, connecting to Problem #536."
+      "summary": "Defines $g_k(N) = \\max |A|$ over $k$-LCM-free subsets (natural density). States in a prose comment (not formalized) Erdős's result $g_4(N) \\gg N$ and the $k = 3$ variant, connecting to Problem #536.",
+      "mathContext": "Formal definition: Defines $g_k(N) = \\max |A|$ over $k$-LCM-free subsets (natural density). States in a prose comment (not formalized) Erdős's result $g_4(N) \\gg N$ and the $k = 3$ variant, connecting to Problem #536."
     },
     {
       "id": "examples",
       "title": "Examples and Gap Analysis",
       "startLine": 226,
       "endLine": 260,
-      "summary": "States that divisor sets satisfy $\\text{lcm}(a,b) \\mid n$ (not machine-verified; the file does not currently compile under v4.31). Axiomatizes prime power LCM $\\text{lcm}(p^j, p^k) = p^k$, the open problem formalization, and gap analysis for $k = 3$.",
-      "mathContext": "States that divisor sets satisfy $\\text{lcm}(a,b) \\mid n$ (not machine-verified; the file does not currently compile). Axiomatizes prime power LCM $\\text{lcm}(p^j, p^k) = p^k$, the open problem formalization, and gap analysis for $k = 3$."
+      "summary": "States that divisor sets satisfy $\\text{lcm}(a,b) \\mid n$ (not machine-verified; the file does not currently compile under v4.31). States in a prose comment (not formalized) prime power LCM $\\text{lcm}(p^j, p^k) = p^k$, the open problem statement, and gap analysis for $k = 3$.",
+      "mathContext": "States that divisor sets satisfy $\\text{lcm}(a,b) \\mid n$ (not machine-verified; the file does not currently compile). States in a prose comment (not formalized) prime power LCM $\\text{lcm}(p^j, p^k) = p^k$, the open problem statement, and gap analysis for $k = 3$."
     }
   ],
   "conclusion": {
-    "summary": "Erdős Problem #856 formalizes the maximum harmonic sum of k-LCM-free subsets. The Lean file states LCM properties and the divisor set lemma and axiomatizes Erdős's 1970 bound, Tang–Zhang's 2025 improvement, and the sunflower equivalence. It does not currently compile under Lean v4.31, so no result is machine-verified (see `assumptions`). The formalization covers 10 sections across ~260 lines.",
+    "summary": "Erdős Problem #856 formalizes the maximum harmonic sum of k-LCM-free subsets. The Lean file states LCM properties and the divisor set lemma and documents in prose comments (not formalized) Erdős's 1970 bound, Tang–Zhang's 2025 improvement, and the sunflower equivalence. It does not currently compile under Lean v4.31, so no result is machine-verified (see `assumptions`). The formalization covers 10 sections across ~260 lines.",
     "implications": "**Theoretical Significance**: Resolution would bridge combinatorial number theory and the sunflower conjecture.\n\nThe equivalence c_k < 1 ⟺ sunflower conjecture shows that progress on either problem implies progress on the other. The Alweiss–Lovett–Wu–Zhang (2021) sunflower breakthrough may lead to improved bounds on f_k(N).",
     "openQuestions": [
       "What is the precise growth exponent $c_k$ for $f_k(N) \\sim (\\log N)^{c_k}$? Is it rational?",


### PR DESCRIPTION
## Summary

Repairs the integrity issue in #39290: erdos-856's meta.json and annotations.json prose repeatedly claim the main bounds are **"axiomatized,"** but `Erdos856Problem.lean` contains **zero `axiom` declarations** (`axiomCount: 0`). The named results (Erdős's 1970 bound, Tang–Zhang 2025 bounds, the sunflower equivalence, the natural-density variant, prime-power LCM) exist only as `/- ... -/` comment blocks — they are neither axioms, defs, nor theorems.

## Changes (prose only)

- **meta.json** `overview.proofStrategy`, all six affected section `summary`/`mathContext` pairs, and `conclusion.summary`: replaced "Axiomatizes / are axiomatized / is formalized as an equivalence" with accurate wording — **"states in prose comments (not formalized)"** / **"describes (in a prose comment, not as a Lean declaration)"**.
- The `sSup` extremal-function description reworded "axiomatizes" → **"defines"** (it is a genuine `def`).
- **annotations.json**: same four "Axiomatizes …" content strings corrected.

## Out of scope (intentionally unchanged)

- `status: "axiomatized"` — the auditor explicitly scoped the status as honest; only the prose wording is corrected.
- Line count `307 → 260` was already fixed in a prior merged PR (#39482).

## Evidence

Before: `grep -c axiomatiz` in the entry dir returned 15 matches across meta + annotations.
After: only the `status` field retains the word; all descriptive prose is accurate. Both files validate as JSON.

Closes #39290