### PR TITLE
Enrich Kronecker symbol multiplicativity (elementary-quadratic-reciprocity-oq-03-oq-02-oq-01): fix section & annotation line-range drift

### DIFF
--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-03-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-03-oq-02-oq-01/annotations.json
@@ -29,11 +29,11 @@
     "proofId": "elementary-quadratic-reciprocity-oq-03-oq-02-oq-01",
     "range": {
       "startLine": 53,
-      "endLine": 88
+      "endLine": 59
     },
     "type": "insight",
     "title": "kronecker0 Multiplicativity: (ab/0) = (a/0)(b/0)",
-    "content": "`kronecker0_mul_of_ne_zero` proves that `kronecker0 (a*b) = kronecker0 a * kronecker0 b` for $ab \\neq 0$. `kronecker0 a` is the unit indicator: 1 if $|a| = 1$ (i.e., $a = \\pm 1$), else 0. Multiplicativity says: $|ab| = 1$ iff $|a| = |b| = 1$ \u2014 exactly when both factors are units. The proof uses `by_cases` on whether $a$ and $b$ are $\\pm 1$, with `simp_all` handling the case arithmetic. The `a \u2260 0` and `b \u2260 0` hypotheses prevent the degenerate case where `kronecker0 0 = 1` would break the product rule.",
+    "content": "`kronecker0_mul_of_ne_zero` proves that `kronecker0 (a*b) = kronecker0 a * kronecker0 b` for $ab \\neq 0$. `kronecker0 a` is the unit indicator: 1 if $|a| = 1$ (i.e., $a = \\pm 1$), else 0. Multiplicativity says: $|ab| = 1$ iff $|a| = |b| = 1$ \u2014 exactly when both factors are units. The proof rewrites `kronecker0` via `\u2190 Int.isUnit_iff` and `IsUnit.mul_iff`, then does `by_cases` on `IsUnit a` and `IsUnit b`, discharging each branch with `simp`. The `a \u2260 0` and `b \u2260 0` hypotheses prevent the degenerate case where `kronecker0 0 = 1` would break the product rule.",
     "mathContext": "`kronecker0` is the Kronecker symbol at modulus 0: $\\left(\\frac{a}{0}\\right) = [|a| = 1]$ (1 if $a$ is a unit in $\\mathbb{Z}$, else 0). The units in $\\mathbb{Z}$ are $\\{\\pm 1\\}$, so `kronecker0 a = 1` iff `a = 1 \u2228 a = -1`. Multiplicativity: $[|ab|=1] = [|a|=1] \\cdot [|b|=1]$ since $|ab|=1 \\iff |a|=1 \\wedge |b|=1$ (product of integers can have absolute value 1 only if both factors have absolute value 1).",
     "significance": "supporting",
     "relatedConcepts": [
@@ -53,12 +53,12 @@
     "id": "kronecker-neg1-mul-theorem",
     "proofId": "elementary-quadratic-reciprocity-oq-03-oq-02-oq-01",
     "range": {
-      "startLine": 89,
-      "endLine": 125
+      "startLine": 60,
+      "endLine": 94
     },
     "type": "insight",
     "title": "Sign Character Multiplicativity: sgn(ab) = sgn(a)\u00b7sgn(b)",
-    "content": "`kroneckerNeg1_mul_of_ne_zero` proves $\\text{sgn}(ab) = \\text{sgn}(a) \\cdot \\text{sgn}(b)$ for $ab \\neq 0$, where `kroneckerNeg1` is the sign character ($-1$ if $a < 0$, $1$ if $a > 0$). The proof uses four cases: (neg \u00d7 neg = pos), (neg \u00d7 pos = neg), (pos \u00d7 neg = neg), (pos \u00d7 pos = pos), with `linarith` and `Int.mul_pos_of_neg_of_neg` handling each. This is the sign homomorphism property of $\\text{sgn}: \\mathbb{Z}^* \\to \\{\\pm 1\\}$.",
+    "content": "`kroneckerNeg1_mul_of_ne_zero` proves $\\text{sgn}(ab) = \\text{sgn}(a) \\cdot \\text{sgn}(b)$ for $ab \\neq 0$, where `kroneckerNeg1` is the sign character ($-1$ if $a < 0$, $1$ if $a \\ge 0$). The proof uses four cases: (neg \u00d7 neg = pos), (neg \u00d7 pos = neg), (pos \u00d7 neg = neg), (pos \u00d7 pos = pos), with `Int.mul_pos_of_neg_of_neg` / `Int.mul_neg_of_neg_of_pos` deciding the sign of the product and `lt_of_le_of_ne` upgrading `\u00ac(\u00b7 < 0)` to strict positivity before each `ring`. This is the sign homomorphism property of $\\text{sgn}: \\mathbb{Z}^* \\to \\{\\pm 1\\}$.",
     "mathContext": "`kroneckerNeg1` corresponds to the Kronecker symbol at modulus $-1$: $\\left(\\frac{a}{-1}\\right) = \\text{sgn}(a)$. For nonzero $a, b$: $\\text{sgn}(ab) = \\text{sgn}(a) \\cdot \\text{sgn}(b)$ since the product of two negatives is positive, one negative and one positive is negative, and two positives is positive. The four-case proof in Lean handles each quadrant: `(ha0 : a < 0)` combined with `(hb0 : b < 0)` gives `Int.mul_pos_of_neg_of_neg ha0 hb0 : 0 < a*b`.",
     "significance": "key",
     "relatedConcepts": [
@@ -78,8 +78,8 @@
     "id": "kronecker-mul-left-proved",
     "proofId": "elementary-quadratic-reciprocity-oq-03-oq-02-oq-01",
     "range": {
-      "startLine": 126,
-      "endLine": 193
+      "startLine": 95,
+      "endLine": 134
     },
     "type": "insight",
     "title": "First-Argument Multiplicativity: (ab/n) = (a/n)(b/n)",
@@ -103,8 +103,8 @@
     "id": "kronecker-mul-right-proved",
     "proofId": "elementary-quadratic-reciprocity-oq-03-oq-02-oq-01",
     "range": {
-      "startLine": 194,
-      "endLine": 267
+      "startLine": 135,
+      "endLine": 258
     },
     "type": "insight",
     "title": "Second-Argument Multiplicativity: (a/mn) = (a/m)(a/n)",

--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-03-oq-02-oq-01/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-03-oq-02-oq-01/meta.json
@@ -12,7 +12,7 @@
       "Nat"
     ],
     "namespace": "KroneckerSymbol",
-    "lineCount": 267,
+    "lineCount": 258,
     "axiomCount": 0,
     "sorries": 0,
     "definitionCount": 0,
@@ -77,45 +77,38 @@
       "kronecker_neg_modulus: negating the modulus introduces/removes the sign character",
       "kroneckerNeg1_sq: the sign character is an involution"
     ],
-    "lineCount": 267,
+    "lineCount": 258,
     "theoremCount": 6,
     "definitionCount": 0
   },
   "sections": [
     {
       "id": "kronecker0-mul",
-      "title": "Multiplicativity of kronecker0",
+      "title": "Part 1: Multiplicativity of kronecker0",
       "startLine": 1,
-      "endLine": 44,
-      "summary": "Imports, module docstring, and theorem kronecker0_mul_of_ne_zero. The unit character at modulus 0: (ab/0) = (a/0)(b/0) for ab ≠ 0. Proved by case analysis: |a| = 1 and |b| = 1 iff |ab| = 1 (since units in ℤ are ±1)."
-    },
-    {
-      "id": "section-45",
-      "title": "Multiplicativity of kronecker0 (continued)",
-      "startLine": 45,
-      "endLine": 88,
-      "summary": "Continuation: remaining proofs and definitions in this section."
+      "endLine": 59,
+      "summary": "Imports, module docstring, and theorem kronecker0_mul_of_ne_zero. The unit character at modulus 0: (ab/0) = (a/0)(b/0) for ab ≠ 0. Proved by rewriting kronecker0 as the unit indicator (← Int.isUnit_iff, IsUnit.mul_iff) and case-splitting on IsUnit a, IsUnit b — |a·b| = 1 iff |a| = |b| = 1 (units in ℤ are ±1)."
     },
     {
       "id": "kronecker-neg1-mul",
-      "title": "Multiplicativity of kroneckerNeg1 (Sign Character)",
-      "startLine": 89,
-      "endLine": 125,
-      "summary": "Theorem kroneckerNeg1_mul_of_ne_zero: sgn(ab) = sgn(a)·sgn(b) for ab ≠ 0. Proved by four cases (pos/neg × pos/neg) using linarith and Int.mul_pos_of_neg_of_neg. This is the sign homomorphism property."
+      "title": "Part 2: Multiplicativity of kroneckerNeg1 (Sign Character)",
+      "startLine": 60,
+      "endLine": 94,
+      "summary": "Theorem kroneckerNeg1_mul_of_ne_zero: sgn(ab) = sgn(a)·sgn(b) for ab ≠ 0. Proved by four cases (pos/neg × pos/neg) using Int.mul_pos_of_neg_of_neg / Int.mul_neg_of_neg_of_pos and lt_of_le_of_ne to pin the strict signs. This is the sign homomorphism property."
     },
     {
       "id": "main-theorem-left",
-      "title": "Multiplicativity in the First Argument",
-      "startLine": 126,
-      "endLine": 193,
-      "summary": "Main theorem kronecker_mul_left_proved: kronecker (a*b) n = kronecker a n * kronecker b n for ab ≠ 0. Case split on n: n=0 uses kronecker0_mul_of_ne_zero, n=-1 uses kroneckerNeg1_mul_of_ne_zero, n=1 is trivial, general n reduces to jacobiSym.mul_left + sign factor."
+      "title": "Part 3: Multiplicativity in the First Argument",
+      "startLine": 95,
+      "endLine": 134,
+      "summary": "Main theorem kronecker_mul_left_proved: kronecker (a*b) n = kronecker a n * kronecker b n for ab ≠ 0. split_ifs unifies the shared moduli conditions across the three kronecker unfoldings into 5 leaf goals: n=0 uses kronecker0_mul_of_ne_zero, n=-1 uses kroneckerNeg1_mul_of_ne_zero, n=1 is trivial, and the general n<0 / n≥0 cases reduce to jacobiSym.mul_left plus the sign factor."
     },
     {
       "id": "main-theorem-right",
-      "title": "Multiplicativity in the Second Argument",
-      "startLine": 194,
-      "endLine": 267,
-      "summary": "Main theorem kronecker_mul_right_proved: kronecker a (m*n) = kronecker a m * kronecker a n for mn ≠ 0. Harder than left multiplicativity: requires handling signs of m and n separately, using kronecker_neg_modulus to introduce sign factors, then jacobiSym.mul_right for the Jacobi part."
+      "title": "Part 4: Multiplicativity in the Second Argument",
+      "startLine": 135,
+      "endLine": 258,
+      "summary": "The private lemmas kroneckerNeg1_sq (the sign character is an involution) and kronecker_neg_modulus (negating the modulus introduces/removes the sign character), then main theorem kronecker_mul_right_proved: kronecker a (m*n) = kronecker a m * kronecker a n for mn ≠ 0. Harder than left multiplicativity: special cases m,n = ±1 are peeled off, then the general case combines jacobiSym.mul_right' with a four-quadrant sign analysis (kroneckerNeg1_sq collapsing the m<0, n<0 branch)."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary

`meta.json` for **elementary-quadratic-reciprocity-oq-03-oq-02-oq-01** was anchored to a 267-line version of `Proofs/ElementaryQuadraticReciprocityOQ03OQ02OQ01.lean`. The file is now **258 lines**, so:

- **Overshoot:** the last section and last annotation both ended at line **267**, 9 lines past the end of the file (`end KroneckerSymbol` is line 258), and both `leanFile.lineCount` and `meta.lineCount` read 267.
- **Interior drift:** the 5 sections and 5 annotations had shifted so their titles/summaries no longer matched their line ranges — e.g. the section titled *"Multiplicativity of kroneckerNeg1"* (89–125) actually spanned the `kronecker_mul_left_proved` proof, and the *"First Argument"* section (126–193) covered the start of the second-argument theorem.

## Changes

Re-anchored everything to the file's own `## Part 1–4` markers (the ground-truth structure):

| # | Section | Was | Now |
|---|---------|-----|-----|
| 1 | Part 1: Multiplicativity of kronecker0 | 1–44 | 1–59 |
| 2 | Part 2: kroneckerNeg1 (sign character) | 89–125 | 60–94 |
| 3 | Part 3: First argument | 126–193 | 95–134 |
| 4 | Part 4: Second argument | 194–267 | 135–258 |

- Dropped the vestigial *"Multiplicativity of kronecker0 (continued)"* filler section (45–88, summary "Continuation: remaining proofs and definitions") — its content is now covered correctly by the re-anchored Part 1/Part 2 sections.
- Annotations re-anchored to contiguous ranges 1–52, 53–59, 60–94, 95–134, 135–258.
- `leanFile.lineCount` and `meta.lineCount` 267 → 258.
- While re-reading the proof, corrected two tactic mis-descriptions: the kronecker0 proof uses `by_cases IsUnit … <;> simp` (not `simp_all`), and the kroneckerNeg1 four-case proof closes with `Int.mul_pos_of_neg_of_neg` / `lt_of_le_of_ne` + `ring` (not `linarith`).

## Verification

- All section/annotation ranges now lie within the 258-line file and cover it contiguously.
- Cross-checked every range against actual declaration positions (`kronecker0_mul_of_ne_zero` @54, `kroneckerNeg1_mul_of_ne_zero` @71, `kronecker_mul_left_proved` @111, `kroneckerNeg1_sq`/`kronecker_neg_modulus` @147/152, `kronecker_mul_right_proved` @180).
- JSON validated; gallery build data/search-index steps pass. No content deleted beyond the empty "continued" filler section. `status`/`axiomCount`/`theoremCount` (verified / 0 / 6) confirmed accurate against the Lean source.