### PR TITLE
Fix: repair never-compiled Erdos856Problem (Erdős #856) for v4.31 — #39077

### DIFF
--- a/proofs/Proofs/Erdos856Problem.lean
+++ b/proofs/Proofs/Erdos856Problem.lean
@@ -38,6 +38,7 @@ import Mathlib.Data.Nat.GCD.Basic
 import Mathlib.Data.Finset.Basic
 import Mathlib.Data.Real.Basic
 import Mathlib.Analysis.SpecialFunctions.Log.Basic
+import Mathlib.Analysis.SpecialFunctions.Pow.Real
 import Mathlib.Algebra.Order.BigOperators.Group.Finset
 
 set_option autoImplicit true
@@ -105,7 +106,7 @@ noncomputable def harmonicSum (A : Finset ℕ) : ℝ :=
 The maximum harmonic sum over all k-LCM-free subsets of {1,...,N}.
 -/
 noncomputable def f_k (k N : ℕ) : ℝ :=
-  sSup { harmonicSum A | A : Finset ℕ ∧ (∀ a ∈ A, 1 ≤ a ∧ a ≤ N) ∧ IsLCMFree A k }
+  sSup { x : ℝ | ∃ A : Finset ℕ, (∀ a ∈ A, 1 ≤ a ∧ a ≤ N) ∧ IsLCMFree A k ∧ harmonicSum A = x }
 
 /-
 ## Part IV: Erdős's Upper Bound
@@ -148,7 +149,7 @@ There exist constants 0 < b_k ≤ c_k ≤ 1 such that
 A k-sunflower is a collection of k sets where any two have the same
 intersection (the "core").
 -/
-def IsSunflower {α : Type*} (sets : Finset (Finset α)) (k : ℕ) : Prop :=
+def IsSunflower {α : Type*} [DecidableEq α] (sets : Finset (Finset α)) (k : ℕ) : Prop :=
   sets.card = k ∧
   ∃ core : Finset α, ∀ S ∈ sets, ∀ T ∈ sets, S ≠ T → S ∩ T = core
 
@@ -179,7 +180,7 @@ c_k < 1 (non-trivial upper bound) iff sunflower conjecture holds for k.
 Instead of maximizing Σ 1/n, we maximize |A|.
 -/
 noncomputable def g_k (k N : ℕ) : ℕ :=
-  sSup { A.card | A : Finset ℕ ∧ (∀ a ∈ A, 1 ≤ a ∧ a ≤ N) ∧ IsLCMFree A k }
+  sSup { x : ℕ | ∃ A : Finset ℕ, (∀ a ∈ A, 1 ≤ a ∧ a ≤ N) ∧ IsLCMFree A k ∧ A.card = x }
 
 /- 
 **Erdős's Construction (1970):**

--- a/src/data/proofs/erdos-856/meta.json
+++ b/src/data/proofs/erdos-856/meta.json
@@ -23,8 +23,8 @@
     "erdosUrl": "https://erdosproblems.com/856",
     "erdosProblemStatus": "open",
     "axiomCount": 0,
-    "lineCount": 260,
-    "assumptions": "AUDIT (issue #39061): NOT machine-verified. This entry never validly compiled. Even under Lean v4.26 the proof only 'passed' because the old `autoImplicit true` default silently bound the undefined identifier `A` as a free implicit variable, rendering the stated theorem vacuously general; under v4.31 (autoImplicit off by default) the file fails with `unknownIdentifier 'A'` and typically additional genuine proof errors. The verification claims below are therefore retracted pending a Lean-source repair (Class A). ORIGINAL METADATA: None. Fully verified with 0 axioms and 0 sorries. Open conjecture; supporting lemmas fully verified.",
+    "lineCount": 263,
+    "assumptions": "REPAIRED (issue #39077): the Lean source now compiles cleanly under v4.31 with 0 sorries and 0 axioms (host-verified via `lake env lean`). The earlier autoImplicit-masked defects have been fixed: the malformed set-builder binders in f_k/g_k were rewritten as explicit `{ x | ∃ A : Finset ℕ, ... }` comprehensions, IsSunflower gained the required `[DecidableEq α]`, and the real-exponent rpow import was added. This entry is a statement-only formalization of an OPEN problem: the definitions and elementary supporting lemmas (lcm_comm, lcm_self, divisor_set_lcm) are fully machine-checked, but the open question (the growth rate of f_k(N)) is not resolved. Badge remains wip / status axiomatized accordingly — no verified/original claim.",
     "mathlib_version": "4.31.0",
     "theoremCount": 4,
     "definitionCount": 10
@@ -138,13 +138,14 @@
       "Mathlib.Data.Finset.Basic",
       "Mathlib.Data.Real.Basic",
       "Mathlib.Analysis.SpecialFunctions.Log.Basic",
+      "Mathlib.Analysis.SpecialFunctions.Pow.Real",
       "Mathlib.Algebra.Order.BigOperators.Group.Finset"
     ],
     "opens": [
       "Nat"
     ],
     "namespace": "Erdos856",
-    "lineCount": 260,
+    "lineCount": 263,
     "axiomCount": 0,
     "sorries": 0,
     "definitionCount": 10,


### PR DESCRIPTION
Class A repair from #39077 (never-compiled Lean entries). `Proofs/Erdos856Problem.lean` (Erdős #856, LCM-free sets) never validly compiled — its errors were masked by \`autoImplicit true\`. Fixed the genuine defects so it compiles green under v4.31.

## Root cause & fixes
- **`f_k` / `g_k` (lines 108, 182)** — malformed set-builder binder `{ harmonicSum A | A : Finset ℕ ∧ ... }` parsed `A :` as a type ascription onto `Finset ℕ ∧ (Prop)` (ill-typed `And (Finset ℕ) ...`), leaving `A` unbound (`unknownIdentifier 'A'`). Rewrote as explicit comprehensions `{ x | ∃ A : Finset ℕ, ... ∧ ... = x }`.
- **`IsSunflower` (line 153)** — `S ∩ T` on `Finset α` needs `[DecidableEq α]`; added the instance argument.
- **`openProblem_precise_exponent` (lines 227–228)** — real-exponent `(Real.log N)^(c_k - ε)` needs `Real.rpow`; added `import Mathlib.Analysis.SpecialFunctions.Pow.Real`.

## Verification
Host-verified (Mathlib-only file, no Docker needed):
\`\`\`
$ lake env lean Proofs/Erdos856Problem.lean   # EXIT=0, 0 errors, 0 sorries, 0 axioms
\`\`\`
(only a pre-existing benign unused-variable warning on `hn` remains.)

## Metadata
`src/data/proofs/erdos-856/meta.json`: replaced the retracted #39061 audit note with an accurate repaired-state description, bumped `lineCount` 260→263, added the new import. **Badge stays `wip` / status `axiomatized`** — #856 is an OPEN problem and this is a statement-only formalization (definitions + elementary supporting lemmas verified; the open growth-rate question is not resolved). No verified/original claim.

Part of #39077.