### PR TITLE
Fix: repair never-compiled Erdos1054OQ02 (Erdős #1054 OQ-02) for v4.31 — #39077

### DIFF
--- a/proofs/Proofs/Erdos1054OQ02.lean
+++ b/proofs/Proofs/Erdos1054OQ02.lean
@@ -80,17 +80,18 @@ theorem divisors_prime_product (q p : ℕ) (hq : q.Prime) (hp : p.Prime)
   · intro ⟨hd, hne⟩
     have hd_pos : d ≥ 1 := by
       by_contra h; push_neg at h
-      interval_cases d; simp [Nat.zero_dvd] at hd; exact hne hd
+      interval_cases d
+      exact absurd (Nat.eq_zero_of_zero_dvd hd) hne
     exact divisor_of_prime_product q p hq hp hlt d hd hd_pos
   · intro h
     have hqpos : q ≥ 1 := hq.pos
     have hppos : p ≥ 1 := hp.pos
-    have hne : q * p ≠ 0 := by omega
-    rcases h with h | h | h | h <;> subst h
-    · exact ⟨one_dvd _, hne⟩
-    · exact ⟨dvd_mul_right q p, hne⟩
-    · exact ⟨dvd_mul_left p q, hne⟩
-    · exact ⟨dvd_refl _, hne⟩
+    have hne : q * p ≠ 0 := Nat.mul_ne_zero (by omega) (by omega)
+    rcases h with h | h | h | h
+    · rw [h]; exact ⟨one_dvd _, hne⟩
+    · rw [h]; exact ⟨dvd_mul_right q p, hne⟩
+    · rw [h]; exact ⟨dvd_mul_left p q, hne⟩
+    · rw [h]; exact ⟨dvd_refl _, hne⟩
 
 /-- The divisor count of q*p for distinct primes is exactly 4. -/
 theorem card_divisors_prime_product (q p : ℕ) (hq : q.Prime) (hp : p.Prime)
@@ -99,8 +100,11 @@ theorem card_divisors_prime_product (q p : ℕ) (hq : q.Prime) (hp : p.Prime)
   rw [divisors_prime_product q p hq hp hlt]
   have hq2 := hq.two_le
   have hp2 := hp.two_le
-  rw [Finset.card_insert_of_notMem (by simp; omega)]
-  rw [Finset.card_insert_of_notMem (by simp; omega)]
+  have hqp4 : 4 ≤ q * p := Nat.mul_le_mul hq2 hp2
+  have hq_qp : q < q * p := by nlinarith [hq.pos, hp.pos, hq2, hp2]
+  have hp_qp : p < q * p := by nlinarith [hq.pos, hp.pos, hq2, hp2]
+  rw [Finset.card_insert_of_notMem (by simp only [mem_insert, mem_singleton]; omega)]
+  rw [Finset.card_insert_of_notMem (by simp only [mem_insert, mem_singleton]; omega)]
   rw [Finset.card_pair (by omega)]
 
 -- ============================================================

--- a/src/data/proofs/erdos-1054-oq-02/meta.json
+++ b/src/data/proofs/erdos-1054-oq-02/meta.json
@@ -18,9 +18,9 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 1,
-    "lineCount": 307,
+    "lineCount": 311,
     "theoremCount": 17,
-    "assumptions": "AUDIT (issue #39061): NOT machine-verified. This entry never validly compiled. Even under Lean v4.26 the proof only 'passed' because the old `autoImplicit true` default silently bound the undefined identifier `q` as a free implicit variable, rendering the stated theorem vacuously general; under v4.31 (autoImplicit off by default) the file fails with `unknownIdentifier 'q'` and typically additional genuine proof errors. The verification claims below are therefore retracted pending a Lean-source repair (Class A). ORIGINAL METADATA: Lean.ofReduceBool. The concrete witness deliverables — goldbach_witness_6..19 and the witnesses_6_to_20 table (advertised as 'concrete witnesses for n ∈ [6,20]') — are discharged by native_decide, which trusts compiler kernel reduction and so depends on the Lean.ofReduceBool axiom (#print axioms lists it). No literal `axiom` declarations exist, so leanFile.axiomCount stays 0; the abstract results (divisor classification, goldbach_implies_representable) are native_decide-free. The conditional Goldbach result itself is proved (modulo Goldbach's conjecture as a hypothesis, not an axiom).",
+    "assumptions": "REPAIRED (issue #39077): the Lean source now compiles cleanly under v4.31 (host-verified via `lake env lean`, EXIT=0, 0 errors, 0 sorries). The #39061 audit had retracted this as a never-compiled Class A entry; the file has no `set_option autoImplicit true` and its `unknownIdentifier 'q'` came from genuine v4.31 proof breakage, now fixed — divisors_prime_product: an over-eager `simp`/`omega`/`subst` chain replaced by `Nat.eq_zero_of_zero_dvd`, `Nat.mul_ne_zero`, and `rw [h]`; card_divisors_prime_product: supplied the `4 ≤ q*p` / `q < q*p` / `p < q*p` bounds omega could not derive. ASSUMPTIONS: the concrete witness deliverables — goldbach_witness_6..19 and the witnesses_6_to_20 table (concrete witnesses for n ∈ [6,20]) — are discharged by native_decide, which trusts compiler kernel reduction and so depends on the Lean.ofReduceBool axiom (#print axioms lists it); hence axiomCount=1 / status=axiomatized / badge=axiom. No literal `axiom` declarations exist, so leanFile.axiomCount stays 0; the abstract results (divisor classification, goldbach_implies_representable) are native_decide-free, and the conditional Goldbach result is proved modulo Goldbach's conjecture as a hypothesis (not an axiom).",
     "mathlibDependencies": [
       {
         "theorem": "Nat.divisors",
@@ -106,7 +106,7 @@
       "Finset"
     ],
     "namespace": "Erdos1054OQ02",
-    "lineCount": 307,
+    "lineCount": 311,
     "axiomCount": 0,
     "theoremCount": 17,
     "definitionCount": 3,


### PR DESCRIPTION
Class A repair from #39077. `Proofs/Erdos1054OQ02.lean` (representability via prime-multiplier families) had genuine v4.31 proof errors — 7 compile errors — now fixed. Host-verified: `lake env lean` → EXIT=0, 0 errors, 0 sorries.

## Root causes & fixes
- **`divisors_prime_product`**
  - `interval_cases d; simp [Nat.zero_dvd] at hd; exact hne hd` — `simp` normalized `q*p = 0` into `q = 0 ∨ p = 0`, so `hne hd` no longer type-checked. Replaced with `exact absurd (Nat.eq_zero_of_zero_dvd hd) hne`.
  - `have hne : q * p ≠ 0 := by omega` — `omega` can't reason about the product. Replaced with `Nat.mul_ne_zero (by omega) (by omega)`.
  - `rcases … <;> subst h` eliminated the theorem parameters `q`/`p` (which then appeared as `unknownIdentifier` in `dvd_mul_right q p` / `dvd_mul_left p q`). Replaced `subst h` with per-case `rw [h]`, keeping `q`/`p` in scope.
- **`card_divisors_prime_product`** — the `by simp; omega` side goals contained `q*p`, which `omega` treats as an opaque atom with no bounds. Supplied `4 ≤ q*p` (`Nat.mul_le_mul`), `q < q*p`, `p < q*p` (`nlinarith`) so `omega` can discharge the `1 ∉ {q,p,q*p}` / `q ∉ {p,q*p}` / `p ≠ q*p` non-membership goals.

## Metadata
`src/data/proofs/erdos-1054-oq-02/meta.json`: replaced the false #39061 "never-compiled" retraction with an accurate repaired-state note; bumped `lineCount` 307→311. **Status stays `axiomatized` / badge `axiom` / `axiomCount: 1`** — the concrete Goldbach witnesses (`goldbach_witness_*`, `witnesses_6_to_20`) are discharged by `native_decide`, which depends on the `Lean.ofReduceBool` axiom per the Axiom Integrity Policy. No literal `axiom` declarations (`leanFile.axiomCount` stays 0).

Part of #39077.