### PR TITLE
Fix: Erdos485OQ01 — set autoImplicit false (Class A hardening, #39077)

### DIFF
--- a/proofs/Proofs/Erdos485OQ01.lean
+++ b/proofs/Proofs/Erdos485OQ01.lean
@@ -4,7 +4,7 @@ import Mathlib.Data.Real.Basic
 import Mathlib.Order.Filter.Basic
 import Mathlib.Tactic
 
-set_option autoImplicit true
+set_option autoImplicit false
 
 set_option maxHeartbeats 800000
 


### PR DESCRIPTION
## Problem

`Erdos485OQ01` (Erdős #485 OQ-01) is the last remaining **Class A** entry from the integrity audit #39061 ("28 entries never compiled") still declaring `set_option autoImplicit true`. Its gallery meta already states *"the earlier `autoImplicit true` masking was eliminated by fixing the real underlying errors"* — but line 7 still enabled `autoImplicit`, contradicting that claim.

## Fix

Flip line 7 to `set_option autoImplicit false` (minimal, one-line).

## Evidence

Host-verified with `lake env lean Proofs/Erdos485OQ01.lean` on v4.31 (Mathlib-only imports):

```
EXIT=0   (warnings only: unused simp args, deprecated push_neg, unused var names)
```

Compiling clean under `autoImplicit false` proves **no undefined identifiers were being masked** — the stated theorems (`growth_at_least_log`, `growth_at_most_sublinear`, structural lemmas) are genuinely non-vacuous. This makes the meta's own claim literally true.

## Scope

- No proof or axiom changes: 3 axioms (`schinzel_zannier_lower`, `erdos_upper`, `f_diverges`), 0 sorries.
- Status/badge unchanged (`axiomatized`/`axiom`) — already honest, no meta edit needed.

Refs #39077, #39061.

🤖 Generated with [Claude Code](https://claude.com/claude-code)