### PR TITLE
Fix: harden Erdos770Problem with autoImplicit false (Class A, #39061)

### DIFF
--- a/proofs/Proofs/Erdos770Problem.lean
+++ b/proofs/Proofs/Erdos770Problem.lean
@@ -34,7 +34,7 @@ import Mathlib.RingTheory.Polynomial.Basic
 import Mathlib.Topology.Algebra.Order.LiminfLimsup
 import Mathlib.Tactic
 
-set_option autoImplicit true
+set_option autoImplicit false
 
 open Finset
 open scoped Polynomial


### PR DESCRIPTION
## Summary

Audit #39061 flagged `Erdos770Problem` (Erdős #770) as *never-compiled / autoImplicit-masked (`:X`)*. This is a **false positive**: the file compiles cleanly on v4.31.

## Evidence

Host-verified with `lake env lean Proofs/Erdos770Problem.lean` (Mathlib-only imports, cache-restored) **after** flipping to `set_option autoImplicit false`:

```
EXIT=0
--- error lines ---
(no errors)
```

Only output is a `push_neg` deprecation warning. No variable was ever silently autoImplicit-bound (the `X` the audit saw is `Polynomial.X` / the `R[X]` polynomial notation, not an auto-bound type). The `autoImplicit true → false` flip hardens the file to match the rest of the #39061 Class A batch and removes the masking risk.

## Metadata

Gallery `meta.json` for `erdos-770` is already accurate — `status: axiomatized`, `badge: axiom`, `axiomCount: 3` (two `axiom` declarations for the open sub-questions + `Lean.ofReduceBool` from `native_decide`), "Machine-verified on Lean v4.31". No meta change needed.

## Scope

Single-line change: `set_option autoImplicit true` → `false`.

Part of #39061.