### PR TITLE
Fix: correct stale 'never compiled' caveat on erdos-608 metadata (#39061)

### DIFF
--- a/src/data/proofs/erdos-608/meta.json
+++ b/src/data/proofs/erdos-608/meta.json
@@ -61,7 +61,7 @@
     ],
     "axiomCount": 0,
     "lineCount": 270,
-    "assumptions": "AUDIT (issue #39061): NOT machine-verified. This entry never compiled: a parse error (`unexpected token '('`, ~line 136) together with unproved `omega` goals predate the v4.31 migration (Class B). ORIGINAL METADATA: No axioms. 13 sorry(s) remain in the formalization.",
+    "assumptions": "Compiles on Lean v4.31 (host-verified via `lake env lean`, exit 0) with 13 `sorry` placeholders remaining — status `formalized`/`wip`. No `axiom` declarations. The parse error (`unexpected token '('`, ~line 136) and unproved `omega` goals cited in the earlier #39061 audit note no longer apply on v4.31: the file parses and elaborates cleanly, emitting only the 13 `sorry` warnings plus an `Mathlib.Data.Real.Sqrt` import-deprecation warning. The 13 sorries are the remaining formalization gaps.",
     "theoremCount": 14,
     "definitionCount": 15,
     "additionalFiles": [


### PR DESCRIPTION
## Summary

Audit #39061 recorded a **false** `NOT machine-verified / never compiled` note in `erdos-608` `meta.json` — claiming a parse error (`unexpected token '('`, ~line 136) plus unproved `omega` goals. On v4.31 the file compiles cleanly.

## Evidence

`lake env lean Proofs/Erdos608Problem.lean` (Mathlib-only, cache-restored):

```
EXIT=0
```

Output is only **13 `declaration uses \`sorry\`` warnings** plus one `Mathlib.Data.Real.Sqrt` import-deprecation warning — no parse error, no unsolved-goal errors. The line-136 `unexpected token` and `omega` failures cited by the audit are v4.26-era artifacts that no longer apply.

## Change

Rewrote the `assumptions` field to state the v4.31 reality: compiles with 13 `sorry` placeholders remaining (`formalized`/`wip`), 0 axioms. `status`, `badge`, `sorries: 13`, `axiomCount: 0` were already correct — only the stale prose changed. Single-field metadata edit.

Part of #39061.