### PR TITLE
Enrich Ramsey's Theorem: disclose native_decide (Lean.ofReduceBool) trust in assumptions

### DIFF
--- a/src/data/proofs/ramseys-theorem/meta.json
+++ b/src/data/proofs/ramseys-theorem/meta.json
@@ -55,7 +55,7 @@
       "Cliques and independent sets in graphs",
       "Induction on graph size and neighborhood structure"
     ],
-    "assumptions": "1 axiom: multicolor_ramsey_exists. See Lean source for the complete statement.",
+    "assumptions": "1 explicit `axiom` declaration: multicolor_ramsey_exists (the finite multicolor Ramsey existence statement; see the Lean source for the complete statement). Trust caveat: the small-Ramsey-bound theorems ramsey_3_3_bound (ramseyBound 3 3 = 6), ramsey_3_4_bound (ramseyBound 3 4 = 10), and ramsey_4_4_bound (ramseyBound 4 4 = 20) close their numeric goals with `native_decide`, so each additionally depends on the `Lean.ofReduceBool` axiom (`#print axioms` shows a `native_decide.ax` beyond propext/Classical.choice/Quot.sound); the supporting pentagon-coloring and Nat.choose examples do likewise. These computations shift trust from the kernel to the compiler; the structural clique/pigeonhole lemmas are kernel-verified without native_decide.",
     "mathlib_version": "4.31.0",
     "theoremCount": 24,
     "definitionCount": 14,


### PR DESCRIPTION
## Axiom-integrity enrichment — `ramseys-theorem`

**Disclosure gap.** The `meta.assumptions` field disclosed only the explicit `axiom` declaration (`multicolor_ramsey_exists`), but three substantive presented theorems close their numeric goals with `native_decide`:

- `ramsey_3_3_bound : ramseyBound 3 3 = 6` (RamseysTheorem.lean L259)
- `ramsey_3_4_bound : ramseyBound 3 4 = 10` (L262)
- `ramsey_4_4_bound : ramseyBound 4 4 = 20` (L265)

Per the project **Axiom Integrity Policy** (CLAUDE.md `native_decide` rule), `native_decide` depends on the `Lean.ofReduceBool` axiom (`#print axioms` shows a `native_decide.ax` beyond propext/Classical.choice/Quot.sound), shifting trust to the compiler. This trust dependency must be disclosed in `assumptions`. The supporting pentagon-coloring and `Nat.choose` examples use `native_decide` likewise.

**Change.** Rewrote `assumptions` to disclose the `native_decide`/`Lean.ofReduceBool` trust caveat alongside the existing explicit-axiom disclosure, noting the structural clique/pigeonhole lemmas remain kernel-verified. Status (`axiomatized`), badge (`axiom`), and `axiomCount: 1` (literal `axiom` declarations) are already accurate and unchanged.

Follows the accepted format of merged audit disclosures #39668 (erdos-686), #39487, #39432, #39408.

JSON validated; gallery build data-steps (search index, loading-facts) pass.