### PR TITLE
Fix: harden Erdos1100 pair with autoImplicit false (false-positive #39061)

### DIFF
--- a/proofs/Proofs/Erdos1100Problem.lean
+++ b/proofs/Proofs/Erdos1100Problem.lean
@@ -34,6 +34,8 @@ import Mathlib.Analysis.SpecialFunctions.Pow.Real
 
 open Real Nat Finset
 
+set_option autoImplicit false
+
 namespace Erdos1100
 
 /-

--- a/proofs/Proofs/Erdos1100ProblemProvable.lean
+++ b/proofs/Proofs/Erdos1100ProblemProvable.lean
@@ -34,6 +34,8 @@ import Mathlib.Analysis.SpecialFunctions.Pow.Real
 
 open Real Nat Finset
 
+set_option autoImplicit false
+
 namespace Erdos1100
 
 /-


### PR DESCRIPTION
## Summary

`Proofs/Erdos1100Problem.lean` and its **byte-identical** sibling `Proofs/Erdos1100ProblemProvable.lean` (the gallery `erdos-1100` leanFile) were listed in #39061 as *never compiled even on v4.26 (autoImplicit-masked, `:p`)*.

## Evidence

- **Baseline Docker build (unmodified, v4.31.0):** `Build completed successfully (1992 jobs)` — both files compile clean **as-is**. The #39061 flag is a **false positive**, matching the Erdos770 (#39704) / erdos-608 (#39705) pattern already established in this batch.
- **After adding `set_option autoImplicit false` to both files:** re-built each via `./proofs/scripts/docker-build.sh` → both `Build completed successfully (1992 jobs)`. Green with the option in place confirms no autoImplicit-injected variable was being relied upon.

## Change

Minimal: one line (`set_option autoImplicit false`) added after `open Real Nat Finset` in each file. No proof/logic changes. The `Erdos1100ProblemAristotle` wrapper cascades green off the (unchanged-content) Provable file.

Class A hardening item for #39061. Does not close the umbrella issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)