### PR TITLE
Enrich erdos-367: re-anchor drifted ranges, fix stale lineCount, correct false axiom labels

### DIFF
--- a/src/data/proofs/erdos-367/annotations.json
+++ b/src/data/proofs/erdos-367/annotations.json
@@ -27,8 +27,8 @@
     "proofId": "erdos-367",
     "type": "definition",
     "range": {
-      "startLine": 39,
-      "endLine": 72
+      "startLine": 40,
+      "endLine": 78
     },
     "title": "The 2-Full Part B₂(n)",
     "content": "**Two equivalent definitions:**\n\n1. **twoFullPart(n)** = $n / \\text{squarefreePart}(n)$ as integer division.\n2. **twoFullPartAlt(n)** = $\\prod_{v_p(n) \\geq 2} p^{v_p(n)}$ via prime factorization.\n\nThe **squarefreePart(n)** = $\\prod_{v_p(n) = 1} p$ extracts primes appearing exactly once.",
@@ -51,8 +51,8 @@
     "proofId": "erdos-367",
     "type": "definition",
     "range": {
-      "startLine": 74,
-      "endLine": 87
+      "startLine": 86,
+      "endLine": 93
     },
     "title": "Product over Consecutive Integers",
     "content": "**productTwoFullParts(n, k)** = $\\prod_{m \\in [n, n+k)} B_2(m)$. This is the central quantity whose growth rate the problem asks about.\n\nUsing `Finset.Ico n (n+k)` for the half-open interval $[n, n+k)$.",
@@ -74,8 +74,8 @@
     "proofId": "erdos-367",
     "type": "definition",
     "range": {
-      "startLine": 89,
-      "endLine": 127
+      "startLine": 100,
+      "endLine": 133
     },
     "title": "Weak and Strong Bounds, Conjecture",
     "content": "**weakBound(k):** $\\forall \\varepsilon > 0, \\exists C > 0 : \\text{product} \\leq C \\cdot n^{2+\\varepsilon}$ for all $n \\geq 1$. This is the $n^{2+o(1)}$ bound.\n\n**strongBound(k):** $\\exists C > 0 : \\text{product} \\leq C \\cdot n^2$ for all $n \\geq 1$. The pure $n^2$ bound.\n\n**erdos_367_conjecture:** weakBound holds for all $k \\geq 1$. The main open question.",
@@ -96,11 +96,11 @@
     "proofId": "erdos-367",
     "type": "concept",
     "range": {
-      "startLine": 129,
-      "endLine": 147
+      "startLine": 140,
+      "endLine": 175
     },
     "title": "Trivial Cases (k ≤ 2)",
-    "content": "**strong_bound_k1 (axiom):** strongBound 1 holds. Since $B_2(n) \\leq n \\leq n^2$.\n\n**strong_bound_k2 (axiom):** strongBound 2 holds. Since $B_2(n) \\cdot B_2(n+1) \\leq n(n+1) < 2n^2$.\n\nThese are 'trivial' because $B_2(m) \\leq m$ for any $m$.",
+    "content": "**strong_bound_k1 (proved theorem):** strongBound 1 holds, since $B_2(n) \\leq n \\leq n^2$.\n\n**strong_bound_k2 (proved theorem):** strongBound 2 holds, since $B_2(n) \\cdot B_2(n+1) \\leq n(n+1) < 2n^2$.\n\nBoth are fully proved (not axiomatized) — they are 'trivial' because $B_2(m) \\leq m$ for any $m$ (`twoFullPart_le`).",
     "mathContext": "$k = 1$: $B_2(n) \\leq n \\leq n^2$ with $C = 1$. $k = 2$: $B_2(n) \\cdot B_2(n+1) \\leq n(n+1) < 2n^2$ with $C = 2$. The product of at most 2 terms bounded by $n$ can't exceed $n^2$.",
     "significance": "supporting",
     "relatedConcepts": [
@@ -117,11 +117,11 @@
     "proofId": "erdos-367",
     "type": "concept",
     "range": {
-      "startLine": 149,
-      "endLine": 171
+      "startLine": 206,
+      "endLine": 260
     },
     "title": "van Doorn: Strong Bound Fails for k ≥ 3",
-    "content": "**strong_bound_fails_k3 (axiom):** $\\neg$ strongBound 3.\n\n**van_doorn_lower_bound (axiom):** $\\exists c > 0 : \\forall N, \\exists n \\geq N$ with $\\prod B_2(m) \\geq c \\cdot n^2 \\cdot \\log n$.\n\nThe logarithmic factor prevents any constant bound $C \\cdot n^2$. This shows the transition happens between $k = 2$ and $k = 3$.",
+    "content": "**strong_bound_fails_k3 (proved theorem):** $\\neg$ strongBound 3 — proved as a consequence of the axiom below, not itself axiomatized.\n\n**van_doorn_lower_bound (axiom, the file's sole assumption):** $\\exists c > 0 : \\forall N, \\exists n \\geq N$ with $\\prod B_2(m) \\geq c \\cdot n^2 \\cdot \\log n$.\n\nThe logarithmic factor prevents any constant bound $C \\cdot n^2$. This shows the transition happens between $k = 2$ and $k = 3$.",
     "mathContext": "van Doorn's construction exploits $n$ near multiples of large prime squares: if $p^2 \\mid n$ and $q^2 \\mid n+1$ for large primes $p, q$, then $B_2(n) \\cdot B_2(n+1) \\cdot B_2(n+2)$ can be large. Such $n$ exist by the Chinese Remainder Theorem and are dense enough to give a logarithmic lower bound.",
     "significance": "key",
     "relatedConcepts": [
@@ -140,11 +140,11 @@
     "proofId": "erdos-367",
     "type": "concept",
     "range": {
-      "startLine": 173,
-      "endLine": 221
+      "startLine": 318,
+      "endLine": 360
     },
     "title": "Properties of B₂",
-    "content": "**Six axiomatized properties:**\n\n- $B_2(n) = 1 \\iff n$ is squarefree\n- $B_2(p) = 1$ for primes $p$\n- $B_2(p^2) = p^2$ for primes $p$\n- $B_2(mn) = B_2(m) \\cdot B_2(n)$ when $\\gcd(m,n) = 1$ (multiplicativity)\n- $B_2(n) \\leq n$ always\n- $B_2(n) \\mid n$ always",
+    "content": "**Proved properties of $B_2$ (no axioms in this part):**\n\n- $B_2(p) = 1$ for primes $p$ (`twoFullPart_prime`)\n- $B_2(p^2) = p^2$ for primes $p$ (`twoFullPart_prime_sq`)\n- $B_2(n) \\mid n$ always (`twoFullPart_dvd`)\n- $B_2(n) \\leq n$ always (`twoFullPart_le`, established in Part 1)\n\nEarlier drafts also stated $B_2(n) = 1 \\iff n$ squarefree and multiplicativity $B_2(mn) = B_2(m)B_2(n)$ for coprime $m,n$; those were **removed** rather than axiomatized (see the note at the top of Part 7 in the source).",
     "mathContext": "These properties characterize $B_2$ as a multiplicative arithmetic function. The density of squarefree numbers is $6/\\pi^2 \\approx 0.608$, so $B_2(n) = 1$ about 60% of the time. When $B_2(n) > 1$, it captures the 'powerful' part of $n$'s factorization.",
     "significance": "supporting",
     "relatedConcepts": [
@@ -164,8 +164,8 @@
     "proofId": "erdos-367",
     "type": "concept",
     "range": {
-      "startLine": 223,
-      "endLine": 254
+      "startLine": 367,
+      "endLine": 393
     },
     "title": "r-Full Parts Generalization",
     "content": "**rFullPart(r, n)** = $\\prod_{v_p(n) \\geq r} p^{v_p(n)}$ generalizes to arbitrary $r$.\n\n**twoFullPart_eq_rFullPart (proved by rfl):** `twoFullPartAlt n = rFullPart 2 n`.\n\n**generalizedConjecture(r, k):** $\\prod B_r(m) \\ll n^{r+o(1)}$? Extends the problem to higher-full parts.",
@@ -187,11 +187,11 @@
     "proofId": "erdos-367",
     "type": "concept",
     "range": {
-      "startLine": 256,
-      "endLine": 271
+      "startLine": 394,
+      "endLine": 403
     },
     "title": "Heuristic Analysis",
-    "content": "**average_twoFullPart_bounded (axiom):** The average of $B_2(n)$ over $[1, N]$ is $O(1)$.\n\nOn average, $B_2(n)$ is bounded because most numbers are nearly squarefree. But consecutive integers can share high prime powers (e.g., $n = p^2$ and $n+1 = q^2$), creating large products over short intervals. This tension between average and worst-case behavior is why the problem is subtle.",
+    "content": "Part 9 records the heuristic that the average of $B_2(n)$ over $[1, N]$ is $O(1)$. An earlier `average_twoFullPart_bounded` axiom asserting this was **removed** (see the note in the source); it is discussed here only informally, not as a formal assumption of the file.\n\nOn average, $B_2(n)$ is bounded because most numbers are nearly squarefree. But consecutive integers can share high prime powers (e.g., $n = p^2$ and $n+1 = q^2$), creating large products over short intervals. This tension between average and worst-case behavior is why the problem is subtle.",
     "mathContext": "$\\frac{1}{N} \\sum_{n=1}^{N} B_2(n) \\leq C$ for some constant $C$. This is because $B_2(n) = 1$ with density $6/\\pi^2$ and the contribution from non-squarefree numbers is controlled. But $\\max_n \\prod_{m=n}^{n+k-1} B_2(m)$ can be much larger than the average predicts.",
     "significance": "supporting",
     "relatedConcepts": [
@@ -210,8 +210,8 @@
     "proofId": "erdos-367",
     "type": "concept",
     "range": {
-      "startLine": 273,
-      "endLine": 295
+      "startLine": 408,
+      "endLine": 426
     },
     "title": "Summary and Known Results",
     "content": "**erdos_367_summary (proved):** Conjunction of three facts:\n1. strongBound(1) $\\wedge$ strongBound(2) — $k \\leq 2$ works\n2. $\\neg$ strongBound(3) — $k \\geq 3$ fails\n3. True — conjecture stated\n\nThe proof is $\\langle\\langle$strong_bound_k1, strong_bound_k2$\\rangle$, strong_bound_fails_k3, trivial$\\rangle$.",
@@ -233,8 +233,8 @@
     "proofId": "erdos-367",
     "type": "concept",
     "range": {
-      "startLine": 239,
-      "endLine": 244
+      "startLine": 377,
+      "endLine": 382
     },
     "title": "Consistency Theorem (PROVED)",
     "content": "**twoFullPart_eq_rFullPart (proved by rfl):** The alternative 2-full definition equals `rFullPart 2`, confirming the generalization is consistent with the original definition.\n\nThis is a definitional equality — both reduce to the same `Finset.prod` expression.",

--- a/src/data/proofs/erdos-367/meta.json
+++ b/src/data/proofs/erdos-367/meta.json
@@ -66,7 +66,7 @@
       "weak_bound_k2: Erdős conjecture confirmed for k=2 via strongBound_implies_weakBound"
     ],
     "axiomCount": 1,
-    "lineCount": 436,
+    "lineCount": 430,
     "theoremCount": 16,
     "prerequisites": [
       "Prime factorization and p-adic valuations",
@@ -104,95 +104,95 @@
       "id": "header",
       "title": "Header: Statement and References",
       "startLine": 1,
-      "endLine": 38,
+      "endLine": 32,
       "summary": "States Erdős Problem #367 (products of 2-full parts). For $n$, the 2-full part $B_2(n)=n/n'$ (where $n'$ is the squarefree part) $=\\prod_{p^2\\mid n}p^{v_p(n)}$. Question: for each fixed $k\\geq1$, is $\\prod_{n\\leq m<n+k}B_2(m)\\ll n^{2+o(1)}$ (or even $\\ll_k n^2$)? Known: trivial for $k\\leq2$; strong bound fails for $k\\geq3$ (van Doorn). Status OPEN. Imports factorization/squarefree and analysis.",
       "mathContext": "$B_2(n)=\\prod_{p^2\\mid n}p^{v_p(n)}$; study $\\prod_{n\\leq m<n+k}B_2(m)$ vs $n^{2+o(1)}$."
     },
     {
       "id": "part1",
       "title": "Part 1: The 2-Full Part",
-      "startLine": 39,
-      "endLine": 73,
+      "startLine": 33,
+      "endLine": 78,
       "summary": "Defines `squarefreePart n` ($\\prod$ of primes with exponent exactly $1$), `twoFullPart n` ($B_2(n)=n/\\text{squarefreePart}$ when it divides), and `twoFullPartAlt n` ($\\prod_{v_p\\geq2}p^{v_p}$ via a factorization filter).",
       "mathContext": "$B_2(n)=n/n'$ where $n'=\\prod_{v_p(n)=1}p$; equivalently $\\prod_{v_p(n)\\geq2}p^{v_p(n)}$."
     },
     {
       "id": "part2",
       "title": "Part 2: Product over Consecutive Integers",
-      "startLine": 74,
-      "endLine": 88,
+      "startLine": 79,
+      "endLine": 93,
       "summary": "Defines `productTwoFullParts n k` $=\\prod_{m\\in[n,n+k)}B_2(m)$, the main object of study.",
       "mathContext": "$\\prod_{n\\leq m<n+k}B_2(m)$."
     },
     {
       "id": "part3",
       "title": "Part 3: The Bounds",
-      "startLine": 89,
-      "endLine": 112,
+      "startLine": 94,
+      "endLine": 117,
       "summary": "Defines `weakBound k` ($\\forall\\varepsilon>0,\\ \\text{product}\\leq C\\,n^{2+\\varepsilon}$) and `strongBound k` ($\\text{product}\\leq C\\,n^2$) — the two asymptotic regimes.",
       "mathContext": "weak: $\\leq C\\,n^{2+\\varepsilon}$; strong: $\\leq C\\,n^2$."
     },
     {
       "id": "part4",
       "title": "Part 4: The Erdős Conjecture",
-      "startLine": 113,
-      "endLine": 128,
+      "startLine": 118,
+      "endLine": 133,
       "summary": "Defines `erdos_367_conjecture`: `weakBound k` holds for all $k\\geq1$ — the main open question.",
       "mathContext": "Conjecture: $\\forall k\\geq1,\\ \\prod_{n\\leq m<n+k}B_2(m)\\ll n^{2+o(1)}$."
     },
     {
       "id": "part5",
       "title": "Part 5: Known Results — Trivial Cases",
-      "startLine": 129,
-      "endLine": 169,
+      "startLine": 134,
+      "endLine": 175,
       "summary": "PROVES the strong bound for the trivial cases: `strong_bound_k1` ($B_2(n)\\leq n\\leq n^2$) and `strong_bound_k2` ($B_2(n)B_2(n+1)\\leq n(n+1)<2n^2$), both from `twoFullPart_le`.",
       "mathContext": "strongBound(1), strongBound(2) hold (since $B_2(n)\\leq n$)."
     },
     {
       "id": "part5b",
       "title": "Part 5b: Weak Bound for k ≤ 2",
-      "startLine": 170,
-      "endLine": 193,
+      "startLine": 176,
+      "endLine": 199,
       "summary": "PROVES `strongBound_implies_weakBound` ($C\\,n^2\\leq C\\,n^{2+\\varepsilon}$ for $n\\geq1$) and applies it to get `weak_bound_k1` and `weak_bound_k2`, so the Erdős conjecture holds for $k=1,2$.",
       "mathContext": "strongBound $\\Rightarrow$ weakBound; hence conjecture holds for $k=1,2$."
     },
     {
       "id": "part6",
       "title": "Part 6: Known Results — Failure of Strong Bound",
-      "startLine": 194,
-      "endLine": 254,
+      "startLine": 200,
+      "endLine": 260,
       "summary": "PROVES `strong_bound_fails_k3` ($\\neg\\text{strongBound}(3)$): from van Doorn's lower bound, $c\\,n^2\\log n\\leq\\text{product}\\leq C\\,n^2$ forces $C\\geq c\\log n$ for arbitrarily large $n$, a contradiction. The single AXIOM `van_doorn_lower_bound` supplies $\\prod_{n\\leq m<n+3}B_2(m)\\geq c\\,n^2\\log n$ infinitely often.",
       "mathContext": "$\\neg$strongBound(3): $\\prod_{n\\leq m<n+3}B_2(m)\\geq c\\,n^2\\log n$ i.o. (van Doorn, axiom)."
     },
     {
       "id": "part7",
       "title": "Part 7: Properties of the 2-Full Part",
-      "startLine": 255,
-      "endLine": 366,
+      "startLine": 261,
+      "endLine": 360,
       "summary": "Properties of $B_2$, all PROVED (no axioms here). Private helpers `primeFactors_prime_eq`, `primeFactors_prime_sq_eq`, `squarefreePart_prime_eq`, `squarefreePart_prime_sq_eq` feed the theorems `twoFullPart_prime` ($B_2(p)=1$), `twoFullPart_prime_sq` ($B_2(p^2)=p^2$), `twoFullPart_le` ($B_2(n)\\leq n$), and `twoFullPart_dvd` ($B_2(n)\\mid n$). (Notes record that the formerly-stated $B_2=1\\Leftrightarrow$ squarefree and multiplicativity lemmas were removed as unused — they are not axioms.)",
       "mathContext": "$B_2(p)=1$, $B_2(p^2)=p^2$, $B_2(n)\\leq n$, $B_2(n)\\mid n$ (all proved)."
     },
     {
       "id": "part8",
       "title": "Part 8: Generalization to r-Full Parts",
-      "startLine": 367,
-      "endLine": 399,
+      "startLine": 361,
+      "endLine": 393,
       "summary": "Defines `rFullPart r n` ($\\prod_{v_p\\geq r}p^{v_p}$), PROVES `twoFullPart_eq_rFullPart` ($\\text{twoFullPartAlt}=\\text{rFullPart }2$ by `rfl`), and defines `generalizedConjecture r k` ($\\prod_{[n,n+k)}B_r\\ll n^{r+o(1)}$).",
       "mathContext": "$B_r(n)=\\prod_{v_p(n)\\geq r}p^{v_p(n)}$; generalized conjecture $\\prod B_r\\ll n^{r+o(1)}$."
     },
     {
       "id": "part9",
       "title": "Part 9: Heuristic Analysis",
-      "startLine": 400,
-      "endLine": 409,
+      "startLine": 394,
+      "endLine": 403,
       "summary": "A docstring discussing the average behaviour of $B_2(n)$ and why worst-case products exceed the average prediction. No declarations (a note records that the former average-boundedness axiom was removed as unused).",
       "mathContext": "Average $B_2(n)=O(1)$ heuristically, but worst-case products are larger (no formal decl)."
     },
     {
       "id": "part10",
       "title": "Part 10: Summary",
-      "startLine": 410,
-      "endLine": 436,
+      "startLine": 404,
+      "endLine": 430,
       "summary": "PROVES `erdos_367_summary`: strongBound holds for $k=1,2$, the weak bound holds for $k=1,2$, strongBound fails for $k=3$, and the $k\\geq3$ weak-bound conjecture remains open (`True`). Defines `erdos_367_status = \"OPEN\"`.",
       "mathContext": "Summary: strongBound$(1,2)$ $\\wedge$ weakBound$(1,2)$ $\\wedge\\ \\neg$strongBound$(3)$; $k\\geq3$ open."
     }
@@ -255,7 +255,7 @@
       "Finset"
     ],
     "namespace": "Erdos367",
-    "lineCount": 436,
+    "lineCount": 430,
     "axiomCount": 1,
     "theoremCount": 16,
     "definitionCount": 10,


### PR DESCRIPTION
## Summary
The `erdos-367` gallery entry had the +6 line-range drift plus several **false axiom claims** in its annotations. Fixed all three.

## Line ranges (drift)
- **All 12 `sections`** re-anchored to the actual `# Part N` banners in `proofs/Proofs/Erdos367Problem.lean` (430 lines); the final `part10` section overshot EOF (endLine **436 > 430**). They now tile lines **1–430 contiguously**.
- **All 10 drifted `annotations`** re-anchored to their true declarations (e.g. `productTwoFullParts` 74–87 → 86–93, `van_doorn`/`strong_bound_fails_k3` 149–171 → 206–260, Part-7 properties 173–221 → 318–360).

## Stale count
- `meta.lineCount` and `leanFile.lineCount` read **436**; the file is **430** lines. Corrected both (the same 6-line trim that caused the drift).

## Axiom-integrity corrections
The file's **only** axiom is `van_doorn_lower_bound` (`meta.axiomCount: 1` is correct), but four annotations overclaimed axioms:
- `strong_bound_k1` / `strong_bound_k2`: "(axiom)" → **proved theorems**.
- `strong_bound_fails_k3`: "(axiom)" → **proved theorem** (derived from the van Doorn axiom).
- Part-7 "**Six axiomatized properties**" → the properties actually **proved** (`twoFullPart_prime`, `_prime_sq`, `_dvd`, `_le`); noted that the `=1 iff squarefree` and multiplicativity claims were *removed*, not axiomatized (per the source note).
- Part-9 `average_twoFullPart_bounded` described as an axiom, but it was **removed** — now flagged as an informal heuristic.

## Verification
- Both JSON files parse; sections verified contiguous over 1–430; all annotation endLines ≤ 430.
- Cross-checked against the Lean source: 1 `axiom` (van_doorn_lower_bound), 0 sorries — matching `status: axiomatized`, `axiomCount: 1`.