### PR TITLE
Research: erdos-16-wip-01 — isRomanoff_iff + 127/149 proved exceptional

### DIFF
--- a/proofs/Proofs/Erdos16Problem.lean
+++ b/proofs/Proofs/Erdos16Problem.lean
@@ -260,6 +260,53 @@ theorem erdosCovering_isCoveringSystem : IsCoveringSystem erdosCovering := by
   · exact ⟨(7, 12), by simp [erdosCovering], by norm_num, by exact_mod_cast h⟩
   · exact ⟨(23, 24), by simp [erdosCovering], by norm_num, by exact_mod_cast h⟩
 
+/-- **Bounded characterisation of the Romanoff property.**  The unbounded
+existential `∃ k p, k ≥ 1 ∧ Prime p ∧ n = 2^k + p` is equivalent to the
+*decidable-flavoured* statement that some exponent `k ≥ 1` with `2^k < n` makes
+the complementary residue `n - 2^k` prime.  This eliminates the prime variable
+`p` entirely (it is forced to be `n - 2^k`) and bounds the search: since `2^k < n`
+forces `k ≤ log₂ n`, membership reduces to checking finitely many exponents. -/
+theorem isRomanoff_iff {n : ℕ} :
+    IsRomanoff n ↔ ∃ k, 1 ≤ k ∧ 2 ^ k < n ∧ Nat.Prime (n - 2 ^ k) := by
+  constructor
+  · rintro ⟨k, p, hk, hp, rfl⟩
+    exact ⟨k, hk, by have := hp.two_le; omega, by simpa using hp⟩
+  · rintro ⟨k, hk, hlt, hp⟩
+    exact ⟨k, n - 2 ^ k, hk, hp, by omega⟩
+
+/-- **`127` is exceptional.**  It is the first nontrivial odd integer of OEIS
+A006285: for every `k` with `1 ≤ k` and `2^k < 127`, the complement `127 - 2^k`
+is composite (`125 = 5³`, `123 = 3·41`, `119 = 7·17`, `111 = 3·37`, `95 = 5·19`,
+`63 = 7·9`), so `127` is not of the form `2^k + p`. -/
+theorem not_isRomanoff_127 : ¬ IsRomanoff 127 := by
+  rw [isRomanoff_iff]
+  rintro ⟨k, hk, hlt, hp⟩
+  have hk6 : k ≤ 6 := by
+    by_contra h
+    have h7 : (2 : ℕ) ^ 7 ≤ 2 ^ k := Nat.pow_le_pow_right (by norm_num) (by omega)
+    norm_num at h7; omega
+  interval_cases k <;> norm_num at hp
+
+/-- `127` is an exceptional odd integer (`127 ∈ ExceptionalSet`). -/
+theorem oneHundredTwentySeven_mem_exceptionalSet : (127 : ℕ) ∈ ExceptionalSet :=
+  ⟨⟨63, by norm_num⟩, not_isRomanoff_127⟩
+
+/-- **`149` is exceptional** (the second nontrivial term of A006285).  For every
+`k` with `2^k < 149` the complement is composite (`147 = 3·49`, `145 = 5·29`,
+`141 = 3·47`, `133 = 7·19`, `117 = 9·13`, `85 = 5·17`, `21 = 3·7`). -/
+theorem not_isRomanoff_149 : ¬ IsRomanoff 149 := by
+  rw [isRomanoff_iff]
+  rintro ⟨k, hk, hlt, hp⟩
+  have hk7 : k ≤ 7 := by
+    by_contra h
+    have h8 : (2 : ℕ) ^ 8 ≤ 2 ^ k := Nat.pow_le_pow_right (by norm_num) (by omega)
+    norm_num at h8; omega
+  interval_cases k <;> norm_num at hp
+
+/-- `149` is an exceptional odd integer (`149 ∈ ExceptionalSet`). -/
+theorem oneHundredFortyNine_mem_exceptionalSet : (149 : ℕ) ∈ ExceptionalSet :=
+  ⟨⟨74, by norm_num⟩, not_isRomanoff_149⟩
+
 /-
 ## Summary
 

--- a/research/problems/erdos-16-wip-01/knowledge.md
+++ b/research/problems/erdos-16-wip-01/knowledge.md
@@ -41,3 +41,22 @@ own definitions (host-verified, Lean v4.31.0, Mathlib-only, no Docker; `#print a
 Deep results (Romanoff 1934 positive density, Erdős 1950 covering-progression, Chen 2023
 disproof) remain documented-only — they need analytic number theory absent from Mathlib.
 Meta counts synced (theoremCount 0 → 13, lineCount 203 → 290).
+
+## Session note (2026-07-20, researcher-1, session 2): isRomanoff_iff + 127/149 exceptional
+
+Built on the 13 foundational lemmas already merged. Added 5 axiom-free theorems
+(host-verified, Lean v4.31.0, `#print axioms` = propext/Classical.choice/Quot.sound):
+
+- **`isRomanoff_iff`** — `IsRomanoff n ↔ ∃ k, 1 ≤ k ∧ 2^k < n ∧ Nat.Prime (n − 2^k)`.
+  Eliminates the prime variable `p` (forced to `n − 2^k`) and bounds the search
+  (`2^k < n ⟹ k ≤ log₂ n`), turning membership into a finite per-exponent check.
+- **`not_isRomanoff_127` / `oneHundredTwentySeven_mem_exceptionalSet`** — the first
+  nontrivial OEIS A006285 term (the file previously only *asserted* "127 is in the
+  exceptional set" in a comment). Proof: bound `k ≤ 6` via `by_contra` +
+  `Nat.pow_le_pow_right`, then `interval_cases k <;> norm_num at hp` refutes
+  `Prime (127 − 2^k)` for each `k` (125,123,119,111,95,63 all composite).
+- **`not_isRomanoff_149` / `oneHundredFortyNine_mem_exceptionalSet`** — same technique,
+  `k ≤ 7` (147,145,141,133,117,85,21 all composite).
+
+Meta synced: theoremCount 13→18, lineCount 290→337. Deep results (Romanoff 1934
+density, Erdős 1950 covering-progression, Chen 2023 disproof) remain documented-only.

--- a/src/data/proofs/erdos-16/meta.json
+++ b/src/data/proofs/erdos-16/meta.json
@@ -45,10 +45,10 @@
         "relationship": "Both are solved Erdős problems in analytic number theory with density/measure-theoretic conclusions"
       }
     ],
-    "lineCount": 290,
+    "lineCount": 337,
     "assumptions": "This file states the problem (definitions IsRomanoff, ExceptionalSet, density, lowerDensity, IsCoveringSystem, ErdosConjecture16, erdosCovering, and the related Props Erdos9/10/11Question) and proves 13 axiom-free foundational lemmas about those definitions. It contains 0 axioms and 0 sorries. The deep results (Romanoff 1934 positive density, Erdos 1950 covering construction, Chen 2023 disproof) require analytic number theory beyond current Mathlib and remain described in doc-comments only, NOT formalized as theorems or axioms. The formalized lemmas are elementary structural facts: the Romanoff floor (2^k+p >= 4), concrete Romanoff witnesses (5=2+3, 7=4+3), membership of 1 and 3 in the exceptional set, the 0<=density<=1 range, and a full machine-checked proof that the explicit Erdos covering system {0 mod 2, 0 mod 3, 1 mod 4, 1 mod 6, 3 mod 8, 7 mod 12, 23 mod 24} genuinely covers the integers.",
     "mathlib_version": "4.31.0",
-    "theoremCount": 13,
+    "theoremCount": 18,
     "definitionCount": 10
   },
   "overview": {
@@ -189,9 +189,9 @@
       "BigOperators"
     ],
     "namespace": "Erdos16",
-    "lineCount": 290,
+    "lineCount": 337,
     "axiomCount": 0,
-    "theoremCount": 13,
+    "theoremCount": 18,
     "definitionCount": 10,
     "path": "Proofs/Erdos16Problem.lean",
     "sorries": 0

--- a/src/data/research/problems/erdos-16-wip-01.json
+++ b/src/data/research/problems/erdos-16-wip-01.json
@@ -31,17 +31,22 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: added 13 axiom-free foundational lemmas to the previously definitions-only Erdos16Problem.lean (Romanoff floor + concrete witnesses, exceptional-set membership of 1/3, density range 0..1, and a machine-checked proof that the explicit Erdos covering system covers Z). Deep results (Romanoff 1934, Erdos 1950, Chen 2023 disproof) remain documented-only, needing Mathlib analytic NT. Meta counts synced (theoremCount 0 -> 13).",
+    "progressSummary": "PROGRESS (session 2): added isRomanoff_iff (bounded characterisation eliminating the prime variable) and machine-checked proofs that 127 and 149 — the first two nontrivial OEIS A006285 exceptional numbers cited in the file prose — are genuinely exceptional (previously only claimed in a comment). All 5 new lemmas axiom-free (propext/Classical.choice/Quot.sound), host-verified Lean v4.31.0. theoremCount 13→18, lineCount 290→337. Deep results (Romanoff 1934, Erdos 1950, Chen 2023) still documented-only.",
     "builtItems": [
       "isRomanoff_four_le, not_isRomanoff_one/three, one/three_mem_exceptionalSet in Erdos16Problem.lean",
       "isRomanoff_five, isRomanoff_seven, five_not_mem_exceptionalSet in Erdos16Problem.lean",
       "density_nonneg, density_le_one, mem_exceptionalSet_iff in Erdos16Problem.lean",
-      "erdosCovering_moduli_pos, erdosCovering_isCoveringSystem (covering system covers Z) in Erdos16Problem.lean"
+      "erdosCovering_moduli_pos, erdosCovering_isCoveringSystem (covering system covers Z) in Erdos16Problem.lean",
+      "isRomanoff_iff — bounded characterisation: IsRomanoff n ↔ ∃ k≥1, 2^k<n ∧ Prime(n−2^k), eliminating the prime variable p (Erdos16Problem.lean)",
+      "not_isRomanoff_127 + oneHundredTwentySeven_mem_exceptionalSet — first nontrivial A006285 term proved exceptional (Erdos16Problem.lean)",
+      "not_isRomanoff_149 + oneHundredFortyNine_mem_exceptionalSet — second nontrivial A006285 term proved exceptional (Erdos16Problem.lean)"
     ],
     "insights": [
       "Erdos16 file was a definitions-only stub (10 defs, 0 theorems). The deep results (Romanoff density, Erdos covering-progression, Chen 2023 disproof) need analytic NT beyond Mathlib; the tractable axiom-free content is elementary structural facts about the file's own defs.",
       "The explicit Erdos covering system [(0,2),(0,3),(1,4),(1,6),(3,8),(7,12),(23,24)] genuinely covers Z: every modulus divides 24, so the disjunction n%2=0 or n%3=0 or n%4=1 or n%6=1 or n%8=3 or n%12=7 or n%24=23 is provable directly by omega, then the residue-class witness is exhibited per case.",
-      "Romanoff floor: 2^k+p >= 4 for k>=1, p prime, so 1 and 3 are exceptional; 5=2+3 and 7=4+3 are concrete Romanoff (non-exceptional) witnesses."
+      "Romanoff floor: 2^k+p >= 4 for k>=1, p prime, so 1 and 3 are exceptional; 5=2+3 and 7=4+3 are concrete Romanoff (non-exceptional) witnesses.",
+      "The unbounded ∃ k p in IsRomanoff collapses to a finite search: p is forced to be n−2^k, and 2^k<n bounds k≤log2 n. isRomanoff_iff makes non-membership a per-exponent compositeness check dischargeable by interval_cases + norm_num prime extension.",
+      "Concrete exceptional numbers (127, 149) are host-verifiable axiom-free: bound k via 2^(K+1)>n (by_contra + Nat.pow_le_pow_right), then interval_cases k and norm_num refutes Prime(n−2^k) for each residue."
     ],
     "mathlibGaps": [],
     "nextSteps": [],


### PR DESCRIPTION
## Summary
Second research session on **erdos-16-wip-01** (Erdős #16: odd integers not of the form 2ᵏ + p). Builds on the 13 axiom-free foundational lemmas already merged.

## Progress
Added 5 new **axiom-free** theorems to `proofs/Proofs/Erdos16Problem.lean` (host-verified, Lean v4.31.0, `#print axioms` = `propext / Classical.choice / Quot.sound` only):

- **`isRomanoff_iff`** — `IsRomanoff n ↔ ∃ k, 1 ≤ k ∧ 2^k < n ∧ Nat.Prime (n − 2^k)`. Eliminates the prime variable `p` (forced to `n − 2^k`) and bounds the search (`2^k < n ⟹ k ≤ log₂ n`), turning membership into a finite per-exponent compositeness check.
- **`not_isRomanoff_127`** + **`oneHundredTwentySeven_mem_exceptionalSet`** — the first nontrivial OEIS A006285 exceptional number. The file previously only *asserted* "127 is in the exceptional set" in a comment; this proves it. (125, 123, 119, 111, 95, 63 all composite.)
- **`not_isRomanoff_149`** + **`oneHundredFortyNine_mem_exceptionalSet`** — the second A006285 term (147, 145, 141, 133, 117, 85, 21 all composite).

## Findings
- The unbounded existential in `IsRomanoff` collapses to a finite search via `isRomanoff_iff`; non-membership is then dischargeable by `interval_cases k <;> norm_num at hp` (norm_num's prime extension).
- Deep results (Romanoff 1934 positive density, Erdős 1950 covering-progression, Chen 2023 disproof) remain documented-only — they need analytic number theory beyond current Mathlib.

## Files modified
- `proofs/Proofs/Erdos16Problem.lean` (+5 theorems)
- `src/data/proofs/erdos-16/meta.json` (theoremCount 13→18, lineCount 290→337)
- `src/data/research/problems/erdos-16-wip-01.json`, `research/problems/erdos-16-wip-01/knowledge.md`

## Status
**Outcome**: progress (axiom-free structural + concrete-witness lemmas)
**Next Steps**: further A006285 witnesses; the covering-congruence → infinite-AP construction is the natural next structural target once the CRT machinery is assembled.

🤖 Generated by researcher-1