### PR TITLE
Enrich erdos-312: re-anchor +7-drifted section/annotation ranges, fix stale lineCount

### DIFF
--- a/src/data/proofs/erdos-312/annotations.json
+++ b/src/data/proofs/erdos-312/annotations.json
@@ -27,8 +27,8 @@
     "id": "ann-e312-reciprocal-sum",
     "proofId": "erdos-312",
     "range": {
-      "startLine": 37,
-      "endLine": 44
+      "startLine": 30,
+      "endLine": 37
     },
     "type": "definition",
     "title": "Reciprocal Sum Definitions",
@@ -50,8 +50,8 @@
     "id": "ann-e312-subset-algebra",
     "proofId": "erdos-312",
     "range": {
-      "startLine": 46,
-      "endLine": 120
+      "startLine": 39,
+      "endLine": 113
     },
     "type": "insight",
     "title": "Subset Sum Algebra",
@@ -74,8 +74,8 @@
     "id": "ann-e312-exponential-precision",
     "proofId": "erdos-312",
     "range": {
-      "startLine": 124,
-      "endLine": 129
+      "startLine": 117,
+      "endLine": 122
     },
     "type": "definition",
     "title": "Exponential Precision Property",
@@ -97,8 +97,8 @@
     "id": "ann-e312-main-conjecture",
     "proofId": "erdos-312",
     "range": {
-      "startLine": 131,
-      "endLine": 141
+      "startLine": 124,
+      "endLine": 134
     },
     "type": "concept",
     "title": "The Main Conjecture (OPEN)",
@@ -120,8 +120,8 @@
     "id": "ann-e312-polynomial",
     "proofId": "erdos-312",
     "range": {
-      "startLine": 145,
-      "endLine": 160
+      "startLine": 138,
+      "endLine": 153
     },
     "type": "concept",
     "title": "Erdős-Graham Polynomial Bound",
@@ -144,8 +144,8 @@
     "id": "ann-e312-relationship",
     "proofId": "erdos-312",
     "range": {
-      "startLine": 164,
-      "endLine": 223
+      "startLine": 157,
+      "endLine": 216
     },
     "type": "concept",
     "title": "Comparing Exponential and Polynomial Bounds",
@@ -167,8 +167,8 @@
     "id": "ann-e312-exp-gap",
     "proofId": "erdos-312",
     "range": {
-      "startLine": 254,
-      "endLine": 283
+      "startLine": 247,
+      "endLine": 276
     },
     "type": "insight",
     "title": "Exponential Gap: Bounds and Limit",
@@ -191,8 +191,8 @@
     "id": "ann-e312-poly-gap",
     "proofId": "erdos-312",
     "range": {
-      "startLine": 287,
-      "endLine": 325
+      "startLine": 280,
+      "endLine": 318
     },
     "type": "insight",
     "title": "Polynomial Gap Analysis",
@@ -215,8 +215,8 @@
     "id": "ann-e312-taylor",
     "proofId": "erdos-312",
     "range": {
-      "startLine": 329,
-      "endLine": 374
+      "startLine": 322,
+      "endLine": 367
     },
     "type": "insight",
     "title": "Taylor Sandwich for the Exponential Gap",
@@ -239,8 +239,8 @@
     "id": "ann-e312-harmonic",
     "proofId": "erdos-312",
     "range": {
-      "startLine": 378,
-      "endLine": 443
+      "startLine": 371,
+      "endLine": 436
     },
     "type": "definition",
     "title": "Harmonic Numbers",
@@ -263,8 +263,8 @@
     "id": "ann-e312-structural",
     "proofId": "erdos-312",
     "range": {
-      "startLine": 447,
-      "endLine": 502
+      "startLine": 440,
+      "endLine": 495
     },
     "type": "insight",
     "title": "Valid Inputs and Structural Bounds",
@@ -287,8 +287,8 @@
     "id": "ann-e312-greedy",
     "proofId": "erdos-312",
     "range": {
-      "startLine": 511,
-      "endLine": 572
+      "startLine": 504,
+      "endLine": 565
     },
     "type": "concept",
     "title": "Greedy: Maximal Feasible Subsets",
@@ -309,8 +309,8 @@
     "id": "ann-e312-summary",
     "proofId": "erdos-312",
     "range": {
-      "startLine": 576,
-      "endLine": 587
+      "startLine": 569,
+      "endLine": 580
     },
     "type": "concept",
     "title": "Summary: Known Polynomial Bound",
@@ -332,8 +332,8 @@
     "id": "ann-e312-sieve",
     "proofId": "erdos-312",
     "range": {
-      "startLine": 599,
-      "endLine": 716
+      "startLine": 592,
+      "endLine": 709
     },
     "type": "concept",
     "title": "Sieve-and-Greedy Infrastructure",

--- a/src/data/proofs/erdos-312/meta.json
+++ b/src/data/proofs/erdos-312/meta.json
@@ -54,7 +54,7 @@
       "erdos_312_status summary theorem"
     ],
     "axiomCount": 1,
-    "lineCount": 718,
+    "lineCount": 711,
     "assumptions": "1 axiom: erdos_graham_polynomial. See Lean source for the complete statement.",
     "theoremCount": 58,
     "definitionCount": 8
@@ -87,99 +87,99 @@
     {
       "id": "imports-namespace",
       "title": "Imports and Namespace",
-      "startLine": 22,
-      "endLine": 33,
+      "startLine": 21,
+      "endLine": 27,
       "summary": "Imports `Finset`, `Real`, analytic special functions (`ExpDeriv`, `Log.Deriv`), filter/liminf-limsup, and `PSeries`; opens `Finset Real Filter` and enters namespace `Erdos312`."
     },
     {
       "id": "part-i-unit-fractions",
       "title": "Part I: Unit Fraction Sums",
-      "startLine": 35,
-      "endLine": 121,
+      "startLine": 28,
+      "endLine": 114,
       "summary": "Defines `reciprocalSum` ($\\sum_i 1/a(i)$) and `subsetReciprocalSum` ($\\sum_{i\\in S} 1/a(i)$), then proves their basic algebra: non-negativity, $\\text{sum}(S)\\le\\text{total}$, empty/univ/singleton evaluations, monotonicity in $S$, disjoint-union additivity, positivity, and the erase/insert step identities."
     },
     {
       "id": "part-ii-main-conjecture",
       "title": "Part II: The Main Conjecture",
-      "startLine": 122,
-      "endLine": 142,
+      "startLine": 115,
+      "endLine": 135,
       "summary": "Defines `hasExponentialPrecision` (a subset with sum in $(1-e^{-cK}, 1]$) and states `mainConjecture` (OPEN): $\\exists c>0$ such that for all $K>1$, every sufficiently large multiset with reciprocal sum $>K$ has exponential precision. Stated as a `Prop` definition, not a `sorry` theorem."
     },
     {
       "id": "part-iii-polynomial",
       "title": "Part III: Known Result (Polynomial Bound)",
-      "startLine": 143,
-      "endLine": 160,
+      "startLine": 136,
+      "endLine": 154,
       "summary": "Defines `hasPolynomialPrecision` (a subset with sum in $(1-c/K^2, 1]$) and axiomatizes `erdos_graham_polynomial` — the Erdős-Graham theorem that the weaker polynomial bound $c/K^2$ holds. This is the file's sole `axiom`."
     },
     {
       "id": "part-iv-relationship",
       "title": "Part IV: Relationship Between Bounds",
-      "startLine": 162,
-      "endLine": 251,
+      "startLine": 155,
+      "endLine": 244,
       "summary": "Proves the exponential bound is strictly stronger than the polynomial one: `exponential_stronger_than_polynomial` ($e^{-cK} < c'/K^2$ for large $K$, since exponentials dominate polynomials, via `tendsto_pow_mul_exp_neg_atTop_nhds_zero`), `conjecture_implies_known`, the pointwise `exponential_implies_polynomial_pointwise`, and monotonicity in $c$."
     },
     {
       "id": "part-ivb-exp-gap",
       "title": "Part IV.b: Exponential Gap Analysis",
-      "startLine": 252,
-      "endLine": 283,
+      "startLine": 245,
+      "endLine": 277,
       "summary": "Analyzes the gap $1-e^{-cK}$: non-negativity, strictly $<1$ (so the window $(1-e^{-cK},1]$ has positive length), monotonicity in $K$, and the limit `exponential_gap_tends_to_one` ($1-e^{-cK}\\to 1$ as $K\\to\\infty$)."
     },
     {
       "id": "part-ivc-poly-gap",
       "title": "Part IV.c: Polynomial Gap Analysis",
-      "startLine": 285,
-      "endLine": 325,
+      "startLine": 278,
+      "endLine": 319,
       "summary": "Analyzes the gap $c/K^2$: positivity, antitone in $K$ (`polynomial_gap_antitone`), the limit $c/K^2\\to 0$ as $K\\to\\infty$ (`polynomial_gap_tends_to_zero`), and monotonicity of polynomial precision in the constant $c$."
     },
     {
       "id": "part-ivd-taylor",
       "title": "Part IV.d: Taylor Bound Analysis",
-      "startLine": 327,
-      "endLine": 374,
+      "startLine": 320,
+      "endLine": 368,
       "summary": "Establishes Taylor/exponential inequalities: $e^{-x}\\le 1/(1+x)$ for $x\\ge0$, the rational lower bound $1-1/(1+cK)$, the algebraic identity $1-1/(1+t)=t/(1+t)$, and the first-order bound $e^{-x}\\ge 1-x$, combining into the sandwich `exponential_gap_sandwich`: $cK/(1+cK) \\le 1-e^{-cK} \\le cK$."
     },
     {
       "id": "part-v-harmonic",
       "title": "Part V: Harmonic Number Context",
-      "startLine": 376,
-      "endLine": 444,
+      "startLine": 369,
+      "endLine": 437,
       "summary": "Defines `harmonicNumber` $H_n = \\sum_{i<n} 1/(i+1)$ and proves $H_n\\to\\infty$ (`harmonic_unbounded`, via Mathlib's `tendsto_sum_range_one_div_nat_succ_atTop`), monotonicity, $H_0=0$, $H_1=1$, non-negativity, the recurrence $H_{n+1}=H_n+1/(n+1)$, $H_n\\ge 1$ for $n\\ge1$, and that the canonical multiset $\\{1,\\ldots,n\\}$ has reciprocal sum $H_n$."
     },
     {
       "id": "part-vb-valid-inputs",
       "title": "Part V.b: Existence of Valid Inputs",
-      "startLine": 445,
-      "endLine": 456,
+      "startLine": 438,
+      "endLine": 450,
       "summary": "Proves `valid_inputs_exist`: for any $K$ there is a finite multiset of positive integers with reciprocal sum $>K$ (the canonical $\\{1,\\ldots,n\\}$ family), confirming the problem hypotheses are satisfiable."
     },
     {
       "id": "part-vc-structural",
       "title": "Part V.c: Structural Properties",
-      "startLine": 458,
-      "endLine": 502,
+      "startLine": 451,
+      "endLine": 496,
       "summary": "Proves the reciprocal-sum upper bound $\\text{reciprocalSum}\\le n/m$ when all elements $\\ge m$, the trivial feasible subset ($\\emptyset$, sum $\\le1$), and that exponential/polynomial precision yield a nontrivial subset with strictly positive sum $\\le1$."
     },
     {
       "id": "part-vii-maximal-feasible",
       "title": "Part VII: Maximal Feasible Subsets and the Gap Bound",
-      "startLine": 504,
-      "endLine": 572,
+      "startLine": 497,
+      "endLine": 566,
       "summary": "The greedy approach: defines `isFeasible` (sum $\\le1$), proves the empty set is feasible, the full set is infeasible when total $>1$, existence of a maximal feasible subset (`maximal_feasible_exists`, via max-cardinality), the gap bound $\\text{sum}(S)>1-1/a(j)$ for $j\\notin S$, and `subset_near_one`: if all elements $\\ge m$ and total $>1$ then some subset has sum in $(1-1/m, 1]$."
     },
     {
       "id": "part-vi-summary",
       "title": "Part VI: Summary",
-      "startLine": 574,
-      "endLine": 587,
+      "startLine": 567,
+      "endLine": 581,
       "summary": "`erdos_312_status` packages the known result (the polynomial bound exists, via `erdos_graham_polynomial`) while the exponential conjecture remains open."
     },
     {
       "id": "part-viii-sieve-greedy",
       "title": "Part VIII: Restricted Greedy and Sieving Infrastructure",
-      "startLine": 589,
-      "endLine": 717,
+      "startLine": 582,
+      "endLine": 711,
       "summary": "Infrastructure toward proving `erdos_graham_polynomial`: defines `largeElements` (indices with $a(i)\\ge m$), proves its threshold properties, the split `reciprocalSum = largeSum + smallSum`, the restricted maximal-feasible existence and gap bound, `restricted_subset_near_one`, and the core `sieve_and_greedy`: if the large elements have reciprocal sum $>1$, find a subset of them with sum in $(1-1/m, 1]$."
     }
   ],
@@ -210,7 +210,7 @@
       "Filter"
     ],
     "namespace": "Erdos312",
-    "lineCount": 718,
+    "lineCount": 711,
     "axiomCount": 1,
     "theoremCount": 58,
     "definitionCount": 8,


### PR DESCRIPTION
## Summary
The `erdos-312` gallery entry (Erdős #312, subset sums of unit fractions) had a uniform **+7 line-range drift** across all sections and annotations; the final `part-viii` section overshot EOF (endLine **717 > 711**), and `lineCount` read 718 vs the actual 711.

## Changes (line ranges + lineCount only — no content change)
- **All 15 `sections`** re-anchored to the actual `## Part` banners in `proofs/Proofs/Erdos312Problem.lean`; they now tile lines **1–711 contiguously**.
- **All 14 drifted `annotations`** shifted back by 7 — each `startLine` now lands exactly on its target's `/--` docstring (verified construct-by-construct); the header annotation was already correct.
- `meta.lineCount` and `leanFile.lineCount`: **718 → 711** (the same +7 trim that caused the drift).

## Verification
- Both JSON files parse; sections verified contiguous over 1–711; all annotation endLines ≤ 711.
- Cross-checked the Lean source: 1 `axiom` (the Erdős–Graham polynomial-precision assumption), 0 sorries — matching `status: axiomatized`, `axiomCount: 1` (both already accurate, unchanged). No false axiom claims in the annotations.