### PR TITLE
Enrich cayley-hamilton-reduction-oq-01-oq-02: re-anchor drifted ranges, fix stale lineCount + inline refs

### DIFF
--- a/src/data/proofs/cayley-hamilton-reduction-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/cayley-hamilton-reduction-oq-01-oq-02/annotations.json
@@ -4,7 +4,7 @@
     "proofId": "cayley-hamilton-reduction-oq-01-oq-02",
     "range": {
       "startLine": 1,
-      "endLine": 35
+      "endLine": 40
     },
     "type": "concept",
     "title": "Efficient Minimal Polynomial Reduction: The Open Question",
@@ -27,8 +27,8 @@
     "id": "ann-ch-red-oq01-oq02-02-nilpotent-dvd",
     "proofId": "cayley-hamilton-reduction-oq-01-oq-02",
     "range": {
-      "startLine": 46,
-      "endLine": 57
+      "startLine": 45,
+      "endLine": 54
     },
     "type": "insight",
     "title": "Nilpotent Minpoly Divides X^k",
@@ -50,8 +50,8 @@
     "id": "ann-ch-red-oq01-oq02-03-reduction",
     "proofId": "cayley-hamilton-reduction-oq-01-oq-02",
     "range": {
-      "startLine": 74,
-      "endLine": 92
+      "startLine": 72,
+      "endLine": 89
     },
     "type": "insight",
     "title": "Nilpotent Polynomial Reduction (Key Efficiency Theorem)",
@@ -74,7 +74,7 @@
     "id": "ann-ch-red-oq01-oq02-03b-degree-bound",
     "proofId": "cayley-hamilton-reduction-oq-01-oq-02",
     "range": {
-      "startLine": 57,
+      "startLine": 56,
       "endLine": 67
     },
     "type": "insight",
@@ -97,12 +97,12 @@
     "id": "ann-ch-red-oq01-oq02-03c-power-vanish",
     "proofId": "cayley-hamilton-reduction-oq-01-oq-02",
     "range": {
-      "startLine": 93,
-      "endLine": 111
+      "startLine": 91,
+      "endLine": 108
     },
     "type": "insight",
     "title": "Power Vanishing and Reduction Equivalence",
-    "content": "Two supporting results. `nilpotent_power_eq_zero` (lines 96-100): if M^k = 0, then M^j = 0 for all j \u2265 k. This is the Krylov termination certificate: the Krylov sequence {v, Mv, ..., M^{k-1}v} generates the same subspace as {v, Mv, ..., M^{j}v} for all j \u2265 k, since M^k v = 0. The proof uses Nat.exists_eq_add_of_le + pow_add.\n\n`nilpotent_reduction_equiv` (lines 104-111): for nilpotent M, reducing mod X^k gives the same result as reducing mod minpoly K M. This confirms that either modulus can be used equivalently in practice, with X^k being the computationally cheaper choice.",
+    "content": "Two supporting results. `nilpotent_power_eq_zero` (lines 94-98): if M^k = 0, then M^j = 0 for all j \u2265 k. This is the Krylov termination certificate: the Krylov sequence {v, Mv, ..., M^{k-1}v} generates the same subspace as {v, Mv, ..., M^{j}v} for all j \u2265 k, since M^k v = 0. The proof uses Nat.exists_eq_add_of_le + pow_add.\n\n`nilpotent_reduction_equiv` (lines 100-108): for nilpotent M, reducing mod X^k gives the same result as reducing mod minpoly K M. This confirms that either modulus can be used equivalently in practice, with X^k being the computationally cheaper choice.",
     "mathContext": "$M^j = M^{j-k} \\cdot M^k = 0$ for $j \\geq k$. The Krylov sequence $v, Mv, \\ldots, M^{k-1}v$ is a complete basis for the Krylov subspace $\\mathcal{K}_k(M,v) = \\text{span}\\{v, Mv, \\ldots, M^{k-1}v\\}$, since all higher powers vanish. The equivalence $(p \\bmod X^k)(M) = (p \\bmod \\mu_M)(M)$ holds because $\\mu_M \\mid X^k$ implies the two reduction residues agree in evaluation at $M$.",
     "significance": "supporting",
     "relatedConcepts": [
@@ -121,8 +121,8 @@
     "id": "ann-ch-red-oq01-oq02-04-upper-tri",
     "proofId": "cayley-hamilton-reduction-oq-01-oq-02",
     "range": {
-      "startLine": 117,
-      "endLine": 143
+      "startLine": 113,
+      "endLine": 140
     },
     "type": "insight",
     "title": "Upper Triangular Minpoly Divides Diagonal Product",
@@ -146,11 +146,11 @@
     "proofId": "cayley-hamilton-reduction-oq-01-oq-02",
     "range": {
       "startLine": 145,
-      "endLine": 172
+      "endLine": 166
     },
     "type": "insight",
     "title": "General Minimal Polynomial Reduction and Degree Truncation",
-    "content": "`minpoly_poly_reduction` (lines 153-158): the general reduction theorem \u2014 for any matrix M and polynomial p, aeval M p = aeval M (p %\u2098 minpoly K M). This is the same pattern as the nilpotent case but applies universally. The proof is clean: Euclidean division + aeval M (minpoly K M) = 0 (from Mathlib's minpoly.aeval).\n\n`nilpotent_reduction_degree_lt` (lines 163-171): the reduced polynomial p %\u2098 X^k has natDegree < k. This confirms that the nilpotent reduction really does compress the polynomial: any polynomial of degree \u2265 k in a nilpotent matrix reduces to one of degree < k.",
+    "content": "`minpoly_poly_reduction` (lines 145-153): the general reduction theorem \u2014 for any matrix M and polynomial p, aeval M p = aeval M (p %\u2098 minpoly K M). This is the same pattern as the nilpotent case but applies universally. The proof is clean: Euclidean division + aeval M (minpoly K M) = 0 (from Mathlib's minpoly.aeval).\n\n`nilpotent_reduction_degree_lt` (lines 154-166): the reduced polynomial p %\u2098 X^k has natDegree < k. This confirms that the nilpotent reduction really does compress the polynomial: any polynomial of degree \u2265 k in a nilpotent matrix reduces to one of degree < k.",
     "mathContext": "The general reduction: $p(M) = (p \\bmod \\mu_M)(M)$ holds for any $M$ because $p = (p \\bmod \\mu_M) + \\mu_M \\cdot q$ gives $p(M) = (p \\bmod \\mu_M)(M) + \\mu_M(M) \\cdot q(M) = (p \\bmod \\mu_M)(M) + 0$. The degree bound: $\\deg(p \\bmod X^k) < k$ by the division algorithm.",
     "significance": "supporting",
     "relatedConcepts": [
@@ -169,8 +169,8 @@
     "id": "ann-ch-red-oq01-oq02-06-summary",
     "proofId": "cayley-hamilton-reduction-oq-01-oq-02",
     "range": {
-      "startLine": 175,
-      "endLine": 210
+      "startLine": 169,
+      "endLine": 204
     },
     "type": "concept",
     "title": "Summary: Three Efficiency Mechanisms and Algorithmic Impact",

--- a/src/data/proofs/cayley-hamilton-reduction-oq-01-oq-02/meta.json
+++ b/src/data/proofs/cayley-hamilton-reduction-oq-01-oq-02/meta.json
@@ -23,7 +23,7 @@
     "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 210,
+    "lineCount": 204,
     "assumptions": "No axioms, no sorries. All 9 theorems fully proved. Key techniques: modByMonic_add_div for reduction; minpoly.dvd + Polynomial.natDegree_le_of_dvd for divisibility; Matrix.charpoly_of_upperTriangular for the triangular case.",
     "mathlib_version": "4.31.0",
     "theoremCount": 9,
@@ -52,7 +52,7 @@
       "id": "preamble",
       "title": "Header and Imports",
       "startLine": 1,
-      "endLine": 39,
+      "endLine": 40,
       "summary": "Module docstring answers the efficiency question for sparse matrices: yes, with three mechanisms (nilpotent X^k bypass, upper triangular diagonal product, general reduction). Imports Mathlib for charpoly, minpoly, block matrices, polynomial division, and nilpotency. Namespace MinpolyReductionOQ02."
     },
     {
@@ -65,29 +65,29 @@
     {
       "id": "nilpotent-reduction",
       "title": "Part II: Efficient Polynomial Reduction via Nilpotency Index",
-      "startLine": 69,
-      "endLine": 111,
+      "startLine": 68,
+      "endLine": 108,
       "summary": "nilpotent_poly_reduction: aeval M p = aeval M (p %ₘ X^k) — the key efficiency theorem. nilpotent_power_eq_zero: M^j = 0 for all j ≥ k (Krylov termination certificate). nilpotent_reduction_equiv: X^k and minpoly K M are interchangeable reduction moduli. Proves the nilpotent bypass is both correct and complete."
     },
     {
       "id": "upper-triangular",
       "title": "Part III: Upper Triangular Minpoly Bound",
-      "startLine": 113,
-      "endLine": 143,
+      "startLine": 109,
+      "endLine": 140,
       "summary": "upper_tri_minpoly_dvd_prod: minpoly K M | ∏ᵢ(X - M i i) for block-triangular M (using charpoly_of_upperTriangular + minpoly.dvd). upper_tri_minpoly_natDegree_le: degree ≤ n. Reduces minpoly computation to reading the diagonal — O(n) vs O(n³) for general charpoly."
     },
     {
       "id": "general-reduction",
       "title": "Part IV: General Efficient Reduction",
-      "startLine": 145,
-      "endLine": 172,
+      "startLine": 141,
+      "endLine": 168,
       "summary": "minpoly_poly_reduction: the foundational reduction theorem aeval M p = aeval M (p %ₘ minpoly K M), valid for any matrix M. nilpotent_reduction_degree_lt: confirms that p %ₘ X^k has natDegree < k (the reduction genuinely compresses the polynomial). These theorems complete the efficiency framework."
     },
     {
       "id": "summary",
       "title": "Proof Summary and Algorithmic Impact",
-      "startLine": 175,
-      "endLine": 210,
+      "startLine": 169,
+      "endLine": 204,
       "summary": "Documentation block listing all 9 proved theorems under the three mechanisms. Emphasizes the nilpotent case as the most dramatic efficiency gain: polynomial evaluation in nilpotent matrices is pure coefficient truncation — no matrix multiplications for the modulus, O(deg p) total work. For strictly upper triangular n×n matrices, the nilpotency index k = n, recovering the general bound with an explicit formula for the modulus."
     }
   ],
@@ -109,7 +109,7 @@
       "Mathlib.RingTheory.Nilpotent.Basic"
     ],
     "namespace": "MinpolyReductionOQ02",
-    "lineCount": 210,
+    "lineCount": 204,
     "axiomCount": 0,
     "theoremCount": 9,
     "definitionCount": 0,


### PR DESCRIPTION
## Summary
The `cayley-hamilton-reduction-oq-01-oq-02` entry had section/annotation line-range drift (progressive +2..+6) in `proofs/Proofs/CayleyHamiltonReductionOQ01OQ02.lean` (204 lines). The final `summary` section and its annotation overshot EOF (endLine **210 > 204**), and `lineCount` read 210.

## Changes (line ranges + lineCount + inline refs — no substantive content change)
- **All 6 `sections`** re-anchored to the actual `-- PART N` banner comments; they now tile lines **1–204 contiguously**.
- **All 8 `annotations`** re-anchored to their true theorem declarations (e.g. `nilpotent-dvd` 46–57 → 45–54, `upper-tri` 117–143 → 113–140, `summary` 175–210 → 169–204).
- `meta.lineCount` and `leanFile.lineCount`: **210 → 204**.
- Fixed drifted **inline `lines X-Y` references** inside two annotation bodies: `nilpotent_power_eq_zero` 96–100 → 94–98, `nilpotent_reduction_equiv` 104–111 → 100–108, `minpoly_poly_reduction` 153–158 → 145–153, `nilpotent_reduction_degree_lt` 163–171 → 154–166.

## Verification
- Both JSON files parse; sections verified contiguous over 1–204; all annotation endLines ≤ 204.
- Cross-checked the Lean source: 0 axioms, 0 sorries, 9 proved theorems — matching `status: verified`, `axiomCount: 0`, `theoremCount: 9` (all already accurate, unchanged).