### PR TITLE
Research: erdos-70-wip-01 — closure under finite ordinal exponentiation

### DIFF
--- a/proofs/Proofs/Erdos70WIP01.lean
+++ b/proofs/Proofs/Erdos70WIP01.lean
@@ -60,6 +60,26 @@ theorem isCountableOrdinal_mul {α β : Ordinal}
         mul_le_mul' hα hβ
     _ = Cardinal.aleph0 := Cardinal.aleph0_mul_aleph0
 
+/-- **Closure under natural-number exponentiation.**  If `α` is a countable
+ordinal then so is `α ^ n` for every `n : ℕ`.  Proof by induction on `n`:
+`α ^ 0 = 1` is countable, and `α ^ (n+1) = α ^ n * α` is countable by
+`IsCountableOrdinal.mul`.  This generalises the parent's `omega0_squared_countable`
+(`ω * ω = ω ^ 2`) to all finite powers. -/
+theorem isCountableOrdinal_opow_nat {α : Ordinal} (hα : IsCountableOrdinal α) :
+    ∀ n : ℕ, IsCountableOrdinal (α ^ (n : Ordinal))
+  | 0 => by simpa using one_countable
+  | (n + 1) => by
+      have hstep : α ^ ((n + 1 : ℕ) : Ordinal) = α ^ (n : Ordinal) * α := by
+        rw [Nat.cast_add, Nat.cast_one, Ordinal.opow_add, Ordinal.opow_one]
+      rw [hstep]
+      exact (isCountableOrdinal_opow_nat hα n).mul hα
+
+/-- Every finite power of `ω` is a countable ordinal: `ω ^ n` is countable for all
+`n : ℕ`.  (`ω ^ 2 = ω · ω` recovers the parent's `omega0_squared_countable`.) -/
+theorem omega0_opow_nat_countable (n : ℕ) :
+    IsCountableOrdinal (Ordinal.omega0 ^ (n : Ordinal)) :=
+  isCountableOrdinal_opow_nat omega0_countable n
+
 /-- The open conjecture specializes to the flagship case `𝔠 → (ω, n)₂³`. -/
 theorem erdos_70_conjecture_imp_omega (h : erdos_70_conjecture) (n : ℕ)
     (hn : 2 ≤ n) : conjecture_omega n :=

--- a/research/problems/erdos-70-wip-01/knowledge.md
+++ b/research/problems/erdos-70-wip-01/knowledge.md
@@ -76,3 +76,26 @@ Batch 2 of axiom-free lemmas in `Proofs/Erdos70Problem.lean` (theorem count
   argument (no direct `Ordinal.card_opow` in Mathlib), left as follow-up.
 - Erdős Problem 70 itself (general countable β) is OPEN; the Erdős–Rado positive
   result 𝔠 → (ω+n, 4)₂³ needs partition-calculus machinery absent from Mathlib.
+
+## Session 2026-07-20 (researcher-1): closure under finite exponentiation
+
+Added 2 axiom-free theorems to `Proofs/Erdos70WIP01.lean` (theoremCount 5→7,
+0 axioms, 0 sorries; `#print axioms` = propext/Classical.choice/Quot.sound only,
+host-verified via parent-olean + `lake env lean`):
+
+- **`isCountableOrdinal_opow_nat`** — the countable ordinals are closed under
+  exponentiation by a natural number: `IsCountableOrdinal α → IsCountableOrdinal (α ^ (n:ℕ))`.
+  Induction on `n`: base `α^0 = 1` (`one_countable`); step `α^(n+1) = α^n · α`
+  via `Ordinal.opow_add`/`opow_one`, countable by `IsCountableOrdinal.mul`.
+- **`omega0_opow_nat_countable`** — every finite power `ω^n` is countable,
+  generalizing the parent's `omega0_squared_countable` (`ω·ω = ω^2`).
+
+### Gotcha
+`Ordinal.opow_succ` is stated as `a ^ Order.succ b`, so `rw [Ordinal.opow_succ]`
+fails against a `α ^ (↑n + 1)` goal. Route the successor step through
+`Nat.cast_add, Nat.cast_one, Ordinal.opow_add, Ordinal.opow_one` instead.
+
+### Next target
+Countability of the limit power `ω ^ ω` (`Ordinal.omega0 ^ Ordinal.omega0`),
+referenced by `conjecture_omega_tower` — needs a countable-sup argument
+(`ω^ω = ⨆ n, ω^n`); no direct `Ordinal.card_opow` exists in Mathlib v4.31.

--- a/src/data/research/problems/erdos-70-wip-01.json
+++ b/src/data/research/problems/erdos-70-wip-01.json
@@ -31,17 +31,20 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Created Erdos70WIP01.lean — general countable-ordinal closure lemmas (downward-closed, closed under + and *) generalizing the parent scaffold s specific countability facts, plus wiring the open conjecture to its flagship special cases 𝔠→(ω,n) and 𝔠→(ω²,n).",
+    "progressSummary": "PROGRESS (session): extended the countable-ordinal closure toolkit in Erdos70WIP01.lean with closure under natural-number exponentiation (isCountableOrdinal_opow_nat) and its ω-corollary (omega0_opow_nat_countable), generalizing the parent s omega0_squared_countable to all finite powers ω^n. Both axiom-free, host-verified Lean v4.31.0. WIP01 theoremCount 5→7. Full countability of ω^ω (limit power) remains the next structural target — needs a countable-sup argument (no Ordinal.card_opow in Mathlib).",
     "builtItems": [
       "Erdos70.IsCountableOrdinal.of_le in Erdos70WIP01.lean",
       "Erdos70.isCountableOrdinal_add in Erdos70WIP01.lean",
       "Erdos70.isCountableOrdinal_mul in Erdos70WIP01.lean",
       "Erdos70.erdos_70_conjecture_imp_omega in Erdos70WIP01.lean",
-      "Erdos70.erdos_70_conjecture_imp_omega_squared in Erdos70WIP01.lean"
+      "Erdos70.erdos_70_conjecture_imp_omega_squared in Erdos70WIP01.lean",
+      "isCountableOrdinal_opow_nat — closure of the countable-ordinal class under natural-number exponentiation α^n (Erdos70WIP01.lean)",
+      "omega0_opow_nat_countable — every finite power ω^n is countable, generalizing omega0_squared_countable (Erdos70WIP01.lean)"
     ],
     "insights": [
       "The parent proved specific instances (omega0_plus_n_countable, omega0_squared_countable); these are corollaries of three general closure lemmas: IsCountableOrdinal is downward-closed (Ordinal.card_le_card), and closed under ordinal + (Cardinal.add_le_aleph0) and * (mul_le_mul + Cardinal.aleph0_mul_aleph0).",
-      "The open conjecture erdos_70_conjecture (∀ countable β, 2≤n, PartitionArrow c β n) specializes definitionally to conjecture_omega n and conjecture_omega_squared n by feeding the parent countability witnesses omega0_countable / omega0_squared_countable."
+      "The open conjecture erdos_70_conjecture (∀ countable β, 2≤n, PartitionArrow c β n) specializes definitionally to conjecture_omega n and conjecture_omega_squared n by feeding the parent countability witnesses omega0_countable / omega0_squared_countable.",
+      "Closure under α^n follows by induction: α^0=1 (one_countable), α^(n+1)=α^n·α countable by IsCountableOrdinal.mul. Ordinal.opow_succ is stated with Order.succ, so route the step via Nat.cast_add + Ordinal.opow_add + Ordinal.opow_one to match the ↑n+1 shape."
     ],
     "mathlibGaps": [],
     "nextSteps": [],


### PR DESCRIPTION
## Summary
Research session on **erdos-70-wip-01** (Erdős #70: does `𝔠 → (β, n)₂³` hold for every countable ordinal β?). Extends the countable-ordinal *closure toolkit* in `proofs/Proofs/Erdos70WIP01.lean`.

## Progress
Added 2 **axiom-free** theorems (host-verified, Lean v4.31.0, `#print axioms` = `propext / Classical.choice / Quot.sound` only):

- **`isCountableOrdinal_opow_nat`** — the countable ordinals are closed under exponentiation by a natural number: `IsCountableOrdinal α → IsCountableOrdinal (α ^ (n : ℕ))`. Induction on `n`: base `α^0 = 1` (`one_countable`); step `α^(n+1) = α^n · α` countable by `IsCountableOrdinal.mul`.
- **`omega0_opow_nat_countable`** — every finite power `ω^n` is countable, generalizing the parent's `omega0_squared_countable` (`ω·ω = ω^2`) to all finite exponents.

This completes the "closed under +, ·, and finite powers" picture the file was building (it already had downward-closure, `+`, and `·`).

## Findings
- **Gotcha**: `Ordinal.opow_succ` is stated with `Order.succ`, so it won't rewrite a `α ^ (↑n + 1)` goal directly — route the successor step through `Nat.cast_add, Nat.cast_one, Ordinal.opow_add, Ordinal.opow_one`.
- Full countability of the *limit* power `ω^ω` remains open here: it needs a countable-sup argument (`ω^ω = ⨆ n, ω^n`); there is no direct `Ordinal.card_opow` in Mathlib v4.31.

## Files modified
- `proofs/Proofs/Erdos70WIP01.lean` (+2 theorems, 5→7)
- `src/data/research/problems/erdos-70-wip-01.json`, `research/problems/erdos-70-wip-01/knowledge.md`

## Status
**Outcome**: progress (axiom-free structural closure lemma)
**Next Steps**: countability of `ω^ω` via countable sup of `ω^n`; then the tower cases of the conjecture.

🤖 Generated by researcher-1