### PR TITLE
Enrich amgm-inequality: re-anchor drifted section & annotation line ranges

### DIFF
--- a/src/data/proofs/amgm-inequality/annotations.json
+++ b/src/data/proofs/amgm-inequality/annotations.json
@@ -4,7 +4,7 @@
     "proofId": "amgm-inequality",
     "range": {
       "startLine": 1,
-      "endLine": 4
+      "endLine": 1
     },
     "type": "concept",
     "title": "Mathlib Imports for Mean Inequalities",
@@ -26,8 +26,8 @@
     "id": "ann-intro",
     "proofId": "amgm-inequality",
     "range": {
-      "startLine": 6,
-      "endLine": 52
+      "startLine": 3,
+      "endLine": 48
     },
     "type": "concept",
     "title": "AM-GM Inequality: Wiedijk #38",
@@ -53,8 +53,8 @@
     "id": "ann-elementary-proof",
     "proofId": "amgm-inequality",
     "range": {
-      "startLine": 53,
-      "endLine": 79
+      "startLine": 50,
+      "endLine": 76
     },
     "type": "insight",
     "title": "Elementary Two-Variable Proof via Square Non-negativity",
@@ -78,8 +78,8 @@
     "id": "ann-alt-form",
     "proofId": "amgm-inequality",
     "range": {
-      "startLine": 81,
-      "endLine": 87
+      "startLine": 78,
+      "endLine": 85
     },
     "type": "insight",
     "title": "Alternative Formulation: a + b \u2265 2\u221a(ab)",
@@ -102,8 +102,8 @@
     "id": "ann-equality",
     "proofId": "amgm-inequality",
     "range": {
-      "startLine": 89,
-      "endLine": 132
+      "startLine": 86,
+      "endLine": 130
     },
     "type": "insight",
     "title": "Equality Characterization: AM = GM iff a = b",
@@ -127,8 +127,8 @@
     "id": "ann-weighted-general",
     "proofId": "amgm-inequality",
     "range": {
-      "startLine": 134,
-      "endLine": 147
+      "startLine": 131,
+      "endLine": 145
     },
     "type": "concept",
     "title": "General Weighted AM-GM via Mathlib",
@@ -156,8 +156,8 @@
     "id": "ann-weighted-two-var",
     "proofId": "amgm-inequality",
     "range": {
-      "startLine": 149,
-      "endLine": 160
+      "startLine": 146,
+      "endLine": 158
     },
     "type": "insight",
     "title": "Two-Variable AM-GM via Weighted Means and convert",
@@ -181,8 +181,8 @@
     "id": "ann-examples",
     "proofId": "amgm-inequality",
     "range": {
-      "startLine": 162,
-      "endLine": 181
+      "startLine": 159,
+      "endLine": 177
     },
     "type": "concept",
     "title": "Concrete Verification Examples",
@@ -205,8 +205,8 @@
     "id": "ann-product-sum",
     "proofId": "amgm-inequality",
     "range": {
-      "startLine": 182,
-      "endLine": 194
+      "startLine": 178,
+      "endLine": 190
     },
     "type": "insight",
     "title": "Product-Sum Corollary: ab \u2264 ((a+b)/2)\u00b2",
@@ -232,8 +232,8 @@
     "id": "ann-mean-chain",
     "proofId": "amgm-inequality",
     "range": {
-      "startLine": 196,
-      "endLine": 203
+      "startLine": 191,
+      "endLine": 199
     },
     "type": "concept",
     "title": "The Mean Inequality Chain: QM \u2265 AM \u2265 GM",
@@ -257,8 +257,8 @@
     "id": "ann-three-variable",
     "proofId": "amgm-inequality",
     "range": {
-      "startLine": 205,
-      "endLine": 218
+      "startLine": 200,
+      "endLine": 214
     },
     "type": "insight",
     "title": "Three-Variable AM-GM via Mathlib",
@@ -282,8 +282,8 @@
     "id": "ann-check-epilogue",
     "proofId": "amgm-inequality",
     "range": {
-      "startLine": 220,
-      "endLine": 225
+      "startLine": 216,
+      "endLine": 221
     },
     "type": "concept",
     "title": "Type-Check Verification and Namespace Close",

--- a/src/data/proofs/amgm-inequality/meta.json
+++ b/src/data/proofs/amgm-inequality/meta.json
@@ -74,7 +74,7 @@
     "wiedijkNumber": 38,
     "axiomCount": 5,
     "assumptions": "5 axiom(s), all in the AMGMOperatorMeans.lean chain companion (operator/Loewner-order AM-GM, a separate matrix-AM-GM formalization): matGeomMean, matGeomMean_self (matrix geometric mean), operator_am_gm (the operator AM-GM inequality, Ando 1979 / Kubo-Ando 1980), matHarmonicMean, harmonic_le_geometric. The main scalar AMGMInequality.lean (Wiedijk #38) is itself axiom-free: the elementary two-variable proof (`am_gm_two`) and equality characterization (`am_gm_two_eq_iff`) are original constructions using `sq_nonneg`, `Real.sq_sqrt`, and `linarith`; the general weighted form (`am_gm_weighted`) and three-variable case (`am_gm_three`) are pedagogical wrappers around Mathlib's `Real.geom_mean_le_arith_mean_weighted` and `Real.geom_mean_le_arith_mean3_weighted`. No sorries.",
-    "lineCount": 225,
+    "lineCount": 221,
     "mathlib_version": "4.31.0",
     "relatedProblems": [
       {
@@ -175,63 +175,63 @@
       "id": "imports-and-docstring",
       "title": "Imports, Module Docstring, and Setup",
       "startLine": 1,
-      "endLine": 52,
+      "endLine": 49,
       "summary": "Four Mathlib imports (`MeanInequalities`, `Pow.Real`, `Field.Basic`, `Tactic`), module docstring describing the AM-GM inequality for two and n variables, the elementary proof strategy, Mathlib dependencies, historical notes (Euclid, Cauchy), and Wiedijk #38 status. Namespace `AMGMInequality` opens at line 51.",
       "mathContext": "The module docstring gives the two-variable form $(a+b)/2 \\geq \\sqrt{ab}$ and the general $n$-variable form $(a_1 + \\cdots + a_n)/n \\geq \\sqrt[n]{a_1 \\cdots a_n}$. The proof strategy reduces to $(\\sqrt{a} - \\sqrt{b})^2 \\geq 0$ for the elementary case, and delegates to `Real.geom_mean_le_arith_mean_weighted` (via Jensen's inequality) for the general case."
     },
     {
       "id": "two-variable",
       "title": "Two-Variable Elementary Proof",
-      "startLine": 53,
-      "endLine": 88,
+      "startLine": 50,
+      "endLine": 85,
       "summary": "The classical proof using $(\\sqrt{a} - \\sqrt{b})^2 \\geq 0$, plus the equivalent form $a + b \\geq 2\\sqrt{ab}$.",
       "mathContext": "$(\\sqrt{a} - \\sqrt{b})^2 \\geq 0 \\implies a + b \\geq 2\\sqrt{ab} \\implies (a+b)/2 \\geq \\sqrt{ab}$"
     },
     {
       "id": "equality",
       "title": "Equality Characterization",
-      "startLine": 89,
-      "endLine": 133,
+      "startLine": 86,
+      "endLine": 130,
       "summary": "Proof that equality $(a+b)/2 = \\sqrt{ab}$ holds if and only if $a = b$, using a calc chain to show the square difference vanishes.",
       "mathContext": "$(a+b)/2 = \\sqrt{ab} \\iff (\\sqrt{a} - \\sqrt{b})^2 = 0 \\iff a = b$"
     },
     {
       "id": "weighted",
       "title": "General Weighted AM-GM",
-      "startLine": 134,
-      "endLine": 161,
+      "startLine": 131,
+      "endLine": 158,
       "summary": "The weighted form $\\prod z_i^{w_i} \\leq \\sum w_i z_i$ via Mathlib's `Real.geom_mean_le_arith_mean_weighted`, and its two-variable specialization.",
       "mathContext": "$\\prod_i z_i^{w_i} \\leq \\sum_i w_i z_i$ for $w_i \\geq 0$, $\\sum w_i = 1$, $z_i \\geq 0$"
     },
     {
       "id": "examples",
       "title": "Concrete Verification Examples",
-      "startLine": 162,
-      "endLine": 181,
+      "startLine": 159,
+      "endLine": 177,
       "summary": "Three concrete examples: AM = GM for equal inputs, a strict inequality for $a=1, b=4$, and delegation to the main theorem for $a=2, b=8$.",
       "mathContext": "$(1+4)/2 = 5/2 > \\sqrt{4} = 2$; $(2+8)/2 = 5 \\geq \\sqrt{16} = 4$"
     },
     {
       "id": "product-sum-corollary",
       "title": "Product-Sum Inequality",
-      "startLine": 182,
-      "endLine": 195,
+      "startLine": 178,
+      "endLine": 190,
       "summary": "Derives $ab \\leq ((a+b)/2)^2$ by squaring both sides of AM-GM, using `sq_le_sq'` and `Real.sq_sqrt`. This corollary is the key step in proving that the square maximizes area among rectangles with fixed perimeter.",
       "mathContext": "$ab = (\\sqrt{ab})^2 \\leq ((a+b)/2)^2$, obtained by squaring $(a+b)/2 \\geq \\sqrt{ab}$"
     },
     {
       "id": "mean-chain-and-three-var",
       "title": "Mean Chain Alias and Three-Variable AM-GM",
-      "startLine": 196,
-      "endLine": 219,
+      "startLine": 191,
+      "endLine": 215,
       "summary": "The `am_ge_gm` alias places AM-GM in the QM $\\geq$ AM $\\geq$ GM $\\geq$ HM chain. Then `am_gm_three` proves the three-variable case $a^{1/3}b^{1/3}c^{1/3} \\leq (a+b+c)/3$ via Mathlib's `Real.geom_mean_le_arith_mean3_weighted` with equal weights $1/3$.",
       "mathContext": "$M_{-1} \\leq M_0 \\leq M_1 \\leq M_2$; three-variable: $\\sqrt[3]{abc} \\leq (a+b+c)/3$"
     },
     {
       "id": "check-epilogue",
       "title": "Type-Check Verification",
-      "startLine": 220,
-      "endLine": 225,
+      "startLine": 216,
+      "endLine": 221,
       "summary": "Four `#check` commands verifying the signatures of `am_gm_two`, `am_gm_two_eq_iff`, `am_gm_weighted`, and `am_gm_three`. Namespace `AMGMInequality` closes.",
       "mathContext": "The four verified theorems span the hierarchy: elementary two-variable, equality characterization, general weighted (Finset-based), and three-variable specialization."
     }
@@ -306,7 +306,7 @@
     ],
     "opens": [],
     "namespace": "AMGMInequality",
-    "lineCount": 225,
+    "lineCount": 221,
     "axiomCount": 0,
     "theoremCount": 8,
     "substantiveTheoremCount": 3,


### PR DESCRIPTION
## Summary

The AM-GM inequality gallery entry (`amgm-inequality`) had all its section and annotation line ranges anchored to a **pre-v4.31, 225-line** version of `AMGMInequality.lean`. The current file is **221 lines**, so every range was shifted ~4 lines past its true anchor — the last section pointed to lines **220-225, four lines past EOF**.

This is the section/annotation re-anchoring explicitly **deferred to the enricher** by the lineCount bulk-sync tool (`scripts/sync-linecounts.py` header note, #39452/#39458), which only corrects the scalar `lineCount` fields.

## Changes (line numbers only — no prose altered)
- Re-anchored all **8 sections** to the actual `/-! ## ` headers; they are now contiguous and cover exactly lines **1-221**.
- Re-anchored all **12 annotations** to their true theorem/example boundaries.
- Synced `leanFile.lineCount` and `meta.lineCount` from 225 → 221 (self-consistency; overlaps the bulk #39458 sync harmlessly).

Verified: sections partition 1..221 with no gaps/overlaps, no range exceeds EOF, all annotation ranges in-bounds. Diff touches only `startLine`/`endLine`/`lineCount` integers.