### PR TITLE
audit: cayley-hamilton-cyclic-vector-all-fields-oq-02-oq-03 — clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -29840,6 +29840,12 @@
       "lastAudited": "2026-07-19T18:57:17Z",
       "result": "clean",
       "issues": []
+    },
+    "cayley-hamilton-cyclic-vector-all-fields-oq-02-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-20T20:10:15Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Gallery integrity audit — clean

**Proof**: cayley-hamilton-cyclic-vector-all-fields-oq-02-oq-03
**Result**: clean (no integrity issues)

### Verified
- **Compiles**: `lake env lean` exit 0, no `sorry` warnings → sorries = 0 ✓
- **Axioms**: `#print axioms` on `commuting_end_is_polynomial` and `end_commutant_commutative` report only `propext, Classical.choice, Quot.sound` → axiomCount = 0 ✓
- **Counts**: theoremCount = 5, definitionCount = 1, lineCount = 197 all match source ✓
- **No** True stubs, `native_decide`, or hidden Mathlib wrapper of the core result
- All 5 `originalContributions` name real declarations in the file
- Badge `original` defensible: genuine coordinate-free construction on Mathlib primitives (Basis.ext, aeval, basisOfLinearIndependentOfCardEqFinrank); prose properly credits Mathlib API

Tracker updated to record the completed audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)