### PR TITLE
audit: erdos-874 — clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -17064,8 +17064,8 @@
     },
     "erdos-874": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T00:18:39Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-20T20:20:44Z",
       "result": "clean"
     },
     "erdos-875": {


### PR DESCRIPTION
## Gallery Integrity Audit — erdos-874

**Result: clean** (no integrity issues)

Erdős Problem #874 (Admissible Sets and Subset Sum Disjointness) is a
transparently **axiomatized** entry and represents itself honestly.

### Verified
- **Status/badge**: `axiomatized` / `axiom` — correct for an entry whose main
  result (`erdos_874`) is literally the axiom `k_limit_is_two`.
- **Counts**: 2 axioms (`deshouillers_freiman_main`, `k_limit_is_two`),
  0 sorries, 4 theorems, 10 defs — all match the source.
- **Compiles**: `lake env lean` succeeds. `#print axioms erdos_874_answer` →
  `[propext, Classical.choice, deshouillers_freiman_main, Quot.sound]` (the one
  disclosed axiom + standard trio); `k_le_self` is fully proven (standard trio
  only).
- **No overclaiming**: `originalContributions` explicitly lists both axioms and
  notes Straus (1966) / ENS (1991) bounds are documented as prose only, not
  axiomatized. No `native_decide`, no True stubs.

### Note (non-blocking)
- `lineCount` = 227 vs ~262 actual — a stale undercount, harmless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)