### PR TITLE
Research: erdos-98-wip-01 — sharp n.choose 2 ceiling + comment→typed statements

### DIFF
--- a/proofs/Proofs/Erdos98WIP01.lean
+++ b/proofs/Proofs/Erdos98WIP01.lean
@@ -39,6 +39,30 @@ concrete configuration and the extremal quantity `h`.
    `Nat.sInf`-membership fact that any upper-bound construction (Pach's
    `n^{log₂ 3}`, Erdős–Füredi–Pach's `n·exp(c√log n)`) ultimately feeds.
 
+6. `numDistinctDistances_le_choose_two` — the sharp (unordered-pair) ceiling of
+   the envelope: distances are symmetric, so the count is at most `n.choose 2`,
+   not merely `n·(n−1)`. Proved by factoring the symmetric distance function
+   through `Sym2 (Fin n)` and invoking `Sym2.card_image_offDiag`.
+
+## From source comments to typed statements
+
+The scaffold left Pach's bound, the Erdős–Füredi–Pach bound, the Guth–Katz
+baseline, and both forms of the conjecture as *prose comments only*. This file
+turns each into an explicit Lean `Prop` over the gallery definitions
+(`PachUpperBound`, `EFPUpperBound`, `GuthKatzBaseline`, `Erdos98WeakConjecture`,
+`Erdos98StrongConjecture`), and proves the two relations that hold unconditionally
+between them:
+
+7. `strong_imp_weak` — `h(n)/n → ∞` implies `h(n) ≥ n` eventually (the strong
+   conjecture entails the weak one). Machine-checked.
+
+8. `weak_imp_tendsto` — even the weak conjecture already forces `h(n) → ∞`
+   (a non-vacuity sanity check on the statements). Machine-checked.
+
+The `Prop` definitions are faithful transcriptions only — Pach/EFP/Guth–Katz are
+imported as *assumptions* (deep results, not reproved here) and the two
+conjectures are *open* in mathematics; nothing below claims to resolve them.
+
 ## Summary: 0 sorries, 0 axioms, no `native_decide`. Built over the gallery defs.
 -/
 
@@ -120,5 +144,102 @@ minimum distinct-distance count `h n` from above. -/
 theorem h_le_of_inGeneralPosition {P : PointConfig n}
     (hgp : InGeneralPosition P) : h n ≤ numDistinctDistances P :=
   Nat.sInf_le ⟨P, hgp, rfl⟩
+
+/-- **Sharp upper envelope.** Because `dist` is symmetric, a distinct distance is
+determined by an *unordered* pair, so the count is at most `n.choose 2` — the
+correct ceiling, halving the crude `n·(n−1)` bound. Proved by factoring the
+symmetric distance map through `Sym2 (Fin n)`. -/
+theorem numDistinctDistances_le_choose_two (P : PointConfig n) :
+    numDistinctDistances P ≤ n.choose 2 := by
+  unfold numDistinctDistances
+  set f : Fin n × Fin n → ℝ := fun p => dist (P p.1) (P p.2) with hf
+  -- The symmetric distance function factors through `Sym2 (Fin n)`.
+  set g : Sym2 (Fin n) → ℝ :=
+    Sym2.lift ⟨fun a b => dist (P a) (P b), fun a b => dist_comm _ _⟩ with hg
+  have hfac : f = g ∘ Sym2.mk.uncurry := by
+    funext p
+    obtain ⟨a, b⟩ := p
+    simp only [hf, hg, Function.comp_apply, Function.uncurry_apply_pair, Sym2.lift_mk]
+  -- A positive distance still comes from an off-diagonal pair.
+  have hsub :
+      ((univ.product univ).image f).filter (· > 0) ⊆ (univ.offDiag).image f := by
+    intro d hd
+    rw [mem_filter, mem_image] at hd
+    obtain ⟨⟨p, _, hpd⟩, hpos⟩ := hd
+    rw [mem_image]
+    refine ⟨p, ?_, hpd⟩
+    rw [mem_offDiag]
+    have hposp : (0 : ℝ) < f p := by rw [hpd]; exact hpos
+    have hne : P p.1 ≠ P p.2 := by
+      have := dist_pos.mp hposp; simpa [hf] using this
+    exact ⟨mem_univ _, mem_univ _, fun hpp => hne (by rw [hpp])⟩
+  -- Reroute the off-diagonal image through `Sym2` and count unordered pairs.
+  calc (((univ.product univ).image f).filter (· > 0)).card
+      ≤ ((univ.offDiag).image f).card := card_le_card hsub
+    _ = (((univ.offDiag).image Sym2.mk.uncurry).image g).card := by
+          rw [hfac, ← Finset.image_image]
+    _ ≤ ((univ.offDiag).image Sym2.mk.uncurry).card := card_image_le
+    _ = n.choose 2 := by
+          rw [Sym2.card_image_offDiag]; simp
+
+/-! ## The bounds and conjectures as typed Lean propositions
+
+Everything below converts the source comments of `Erdos98Problem.lean` into
+explicit `Prop`s over the gallery definitions. Each is annotated as an imported
+assumption (a documented deep result we do not reprove) or as open. -/
+
+open scoped Filter Topology in
+/-- **Pach's upper bound** (documented result — imported as an assumption).
+General-position sets exist with fewer than `n^{log₂ 3} ≈ n^{1.585}` distinct
+distances, so for large `n`, `h(n) < n^{log₂ 3}`. -/
+def PachUpperBound : Prop :=
+  ∀ᶠ n : ℕ in Filter.atTop, (h n : ℝ) < (n : ℝ) ^ Real.logb 2 3
+
+open scoped Filter Topology in
+/-- **Erdős–Füredi–Pach upper bound** (documented result — imported as an
+assumption). `h(n) < n · exp(c·√(log n))` for some `c > 0`, near-linear since the
+exponential factor is `n^{o(1)}`. -/
+def EFPUpperBound : Prop :=
+  ∃ c : ℝ, 0 < c ∧
+    ∀ᶠ n : ℕ in Filter.atTop, (h n : ℝ) < n * Real.exp (c * Real.sqrt (Real.log n))
+
+open scoped Filter Topology in
+/-- **Guth–Katz baseline** (documented result — imported as an assumption). Any
+`n` planar points (in particular any general-position configuration) determine
+`Ω(n / log n)` distinct distances, giving the unconditional lower bound
+`c·n/log n ≤ h(n)` for some `c > 0`. -/
+def GuthKatzBaseline : Prop :=
+  ∃ c : ℝ, 0 < c ∧
+    ∀ᶠ n : ℕ in Filter.atTop, c * n / Real.log n ≤ (h n : ℝ)
+
+open scoped Filter Topology in
+/-- **Weak Erdős conjecture** (OPEN). Even `h(n) ≥ n` for all large `n` is
+unknown; Erdős could not prove it. -/
+def Erdos98WeakConjecture : Prop :=
+  ∀ᶠ n : ℕ in Filter.atTop, n ≤ h n
+
+open scoped Filter Topology in
+/-- **Strong Erdős conjecture** (OPEN). `h(n)/n → ∞`: general position forces
+superlinearly many distinct distances. This is Erdős Problem #98 itself. -/
+def Erdos98StrongConjecture : Prop :=
+  Filter.Tendsto (fun n : ℕ => (h n : ℝ) / (n : ℝ)) Filter.atTop Filter.atTop
+
+/-! ## Provable relations among the typed statements -/
+
+/-- The strong conjecture entails the weak one: if `h(n)/n → ∞` then eventually
+`h(n)/n ≥ 1`, i.e. `h(n) ≥ n`. -/
+theorem strong_imp_weak (H : Erdos98StrongConjecture) : Erdos98WeakConjecture := by
+  have h1 : ∀ᶠ n : ℕ in Filter.atTop, (1 : ℝ) ≤ (h n : ℝ) / (n : ℝ) :=
+    H.eventually_ge_atTop 1
+  filter_upwards [h1, Filter.eventually_ge_atTop 1] with n hn1 hn2
+  have hnp : 0 < n := hn2
+  have hnpos : (0 : ℝ) < (n : ℝ) := by exact_mod_cast hnp
+  rw [one_le_div hnpos] at hn1
+  exact_mod_cast hn1
+
+/-- Non-vacuity check: the weak conjecture already forces `h(n) → ∞`. -/
+theorem weak_imp_tendsto (H : Erdos98WeakConjecture) :
+    Filter.Tendsto h Filter.atTop Filter.atTop :=
+  Filter.tendsto_atTop_mono' Filter.atTop H Filter.tendsto_id
 
 end Erdos98WIP01

--- a/research/problems/erdos-98-wip-01/knowledge.md
+++ b/research/problems/erdos-98-wip-01/knowledge.md
@@ -50,8 +50,53 @@ Parent `Erdos98Problem.lean` fresh-built to olean host-side (Mathlib-only, v4.31
 docker-free), then child compiled against it. Exit 0, no warnings.
 
 ### Next Steps
-- Sharpen the upper envelope to `numDistinctDistances P ≤ n.choose 2` using the
-  symmetry `dist (P i) (P j) = dist (P j) (P i)` (image over `{i < j}` pairs).
+- ~~Sharpen the upper envelope to `numDistinctDistances P ≤ n.choose 2`~~ — DONE
+  this session (see below).
 - A lower bound beyond `1`: the elementary Erdős pigeonhole `≥ √(n − 3/4) − 1/2`
   distinct distances (needs the max-degree-of-a-distance argument) would be the
   first genuinely superconstant floor.
+
+---
+
+## Session (researcher-1, 2026-07-20 #2) — sharp ceiling + comment→statement conversion
+
+Extended `Erdos98WIP01.lean` (now 13 theorems/defs, 0 sorry, 0 axiom;
+`#print axioms` = `[propext, Classical.choice, Quot.sound]` on the new results —
+no `sorryAx`, no `native_decide`). Two kinds of progress:
+
+**1. Sharp unordered-pair ceiling.**
+`numDistinctDistances_le_choose_two` — `numDistinctDistances P ≤ n.choose 2`,
+halving the crude `n·(n−1)` bound from session #1. Key idea: `dist` is symmetric,
+so the distance map `f (i,j) = dist (P i) (P j)` factors as `g ∘ Sym2.mk.uncurry`
+with `g = Sym2.lift ⟨fun a b => dist (P a) (P b), dist_comm⟩`. Then
+`(univ.offDiag).image f = ((univ.offDiag).image Sym2.mk.uncurry).image g`
+(`Finset.image_image`), and `Sym2.card_image_offDiag` counts the off-diagonal
+`Sym2` image as `(#univ).choose 2 = n.choose 2`. This is the correct
+(unordered-pair) ceiling of the `h(n)` envelope.
+
+**2. Comment-only bounds → typed Lean `Prop`s** (the stated mission of this
+problem: "from comments to checkable statements"). Added, over the gallery `h`:
+- `PachUpperBound` — `∀ᶠ n, (h n:ℝ) < n ^ logb 2 3` (imported assumption).
+- `EFPUpperBound` — `∃ c>0, ∀ᶠ n, (h n:ℝ) < n·exp(c·√(log n))` (assumption).
+- `GuthKatzBaseline` — `∃ c>0, ∀ᶠ n, c·n/log n ≤ h n` (assumption; Ω(n/log n)).
+- `Erdos98WeakConjecture` — `∀ᶠ n, n ≤ h n` (OPEN).
+- `Erdos98StrongConjecture` — `Tendsto (fun n => (h n:ℝ)/n) atTop atTop` (OPEN).
+
+And two **machine-checked** relations proving the typed statements are correctly
+wired (not independent guesses):
+- `strong_imp_weak` — strong ⟹ weak (`one_le_div` + `eventually_ge_atTop 1`).
+- `weak_imp_tendsto` — weak already forces `h(n)→∞` (`tendsto_atTop_mono'`),
+  a non-vacuity sanity check.
+
+### Verification
+Host-side `bin/lake env lean Proofs/Erdos98WIP01.lean`, exit 0, no warnings
+(Mathlib v4.31, docker-free). Axioms confirmed via `#print axioms`. Isolated
+worktree (`researcher-1-erdos98`) because the shared main worktree's concurrent
+Aristotle-integration automation was sweeping in-flight edits into its commits.
+
+### Next Steps (unchanged core gap)
+- The elementary Erdős pigeonhole lower bound `≥ √(n − 3/4) − 1/2` remains the
+  first genuinely superconstant floor and the natural next proved theorem; it
+  needs the max-multiplicity-of-a-single-distance counting argument.
+- Everything deeper (Pach construction, EFP, Guth–Katz, either conjecture) stays
+  an imported assumption / open — out of scope for host formalization.

--- a/src/data/research/problems/erdos-98-wip-01.json
+++ b/src/data/research/problems/erdos-98-wip-01.json
@@ -18,12 +18,12 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "OBSERVE",
+    "phase": "ACT",
     "since": "2026-07-09T17:33:19-07:00",
     "iteration": 1,
     "focus": "Initial problem understanding. Read problem.md and gather context.",
     "blockers": [],
-    "nextAction": "Read problem.md thoroughly and acquire full context.",
+    "nextAction": "Elementary superconstant lower bound (Erdős pigeonhole ≥ √(n−3/4)−1/2 via max multiplicity of a single distance) would be the first genuinely nontrivial floor; needs the max-degree-of-a-distance counting argument.",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -31,18 +31,26 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Created Erdos98WIP01.lean — first machine-checked theorems for the #98 general-position distinct-distances scaffold. Axiom-free counting envelope (0 ≤ numDistinctDistances ≤ n·(n−1)) plus the h(n) sInf-membership upper-bound fact.",
+    "progressSummary": "PROGRESS: Erdos98WIP01.lean extended — sharp n.choose 2 ceiling (Sym2 factoring) plus all four comment-only bounds/conjectures converted to typed Lean Props (Pach/EFP/Guth-Katz assumptions + weak/strong conjectures), with two machine-checked relations strong_imp_weak and weak_imp_tendsto. 13 theorems/defs, 0 sorry, 0 axiom; #print axioms = [propext, Classical.choice, Quot.sound].",
     "builtItems": [
       "InGeneralPosition.injective in Erdos98WIP01.lean",
       "numDistinctDistances_le_offDiag (≤ n·(n−1)) in Erdos98WIP01.lean",
       "numDistinctDistances_eq_zero_of_le_one in Erdos98WIP01.lean",
       "one_le_numDistinctDistances_of_injective (n≥2 ⟹ ≥1) in Erdos98WIP01.lean",
-      "h_le_of_inGeneralPosition (h n ≤ numDistinctDistances P) in Erdos98WIP01.lean"
+      "h_le_of_inGeneralPosition (h n ≤ numDistinctDistances P) in Erdos98WIP01.lean",
+      "numDistinctDistances_le_choose_two (≤ n.choose 2, sharp unordered-pair ceiling) in Erdos98WIP01.lean",
+      "PachUpperBound / EFPUpperBound / GuthKatzBaseline / Erdos98WeakConjecture / Erdos98StrongConjecture as typed Props in Erdos98WIP01.lean",
+      "strong_imp_weak (h(n)/n→∞ ⟹ h(n)≥n eventually) in Erdos98WIP01.lean",
+      "weak_imp_tendsto (weak conj ⟹ h(n)→∞, non-vacuity check) in Erdos98WIP01.lean"
     ],
     "insights": [
       "Every positive pairwise distance comes from an off-diagonal ordered pair (dist>0 ⟹ points distinct ⟹ indices distinct), giving the clean upper bound numDistinctDistances P ≤ n·(n−1) via Finset.offDiag_card — the trivial ceiling of the h(n) envelope.",
       "The degenerate floor: n ≤ 1 forces numDistinctDistances = 0 (no off-diagonal pair); and any injective config with n ≥ 2 realizes at least one positive distance, so 1 ≤ numDistinctDistances there.",
-      "h(n) = sInf over general-position configs is bounded above by any single witness config (Nat.sInf_le with ⟨P, hgp, rfl⟩) — the membership fact that every known upper-bound construction (Pach n^{log₂3}, Erdős–Füredi–Pach n·exp(c√log n)) feeds into."
+      "h(n) = sInf over general-position configs is bounded above by any single witness config (Nat.sInf_le with ⟨P, hgp, rfl⟩) — the membership fact that every known upper-bound construction (Pach n^{log₂3}, Erdős–Füredi–Pach n·exp(c√log n)) feeds into.",
+      "The distance map is symmetric, so it factors through Sym2 (Fin n); routing the off-diagonal image through Sym2.mk.uncurry and applying Sym2.card_image_offDiag gives the sharp ceiling numDistinctDistances P ≤ n.choose 2 (halving the crude n·(n−1)).",
+      "The strong conjecture h(n)/n→∞ is stated as Filter.Tendsto (fun n => (h n:ℝ)/n) atTop atTop; the weak conjecture as ∀ᶠ n, n ≤ h n. strong_imp_weak proves the former entails the latter (one_le_div + eventually_ge_atTop 1), so the two typed statements are correctly related, not independent guesses.",
+      "weak_imp_tendsto shows the weak statement already forces h(n)→∞ (tendsto_atTop_mono with id), confirming the Prop is non-vacuous.",
+      "Pach n^{log₂3}, Erdős–Füredi–Pach n·exp(c√log n), and Guth–Katz Ω(n/log n) are now typed Props (PachUpperBound/EFPUpperBound/GuthKatzBaseline) flagged as imported assumptions — the comment-only bounds of the scaffold are now checkable Lean statements."
     ],
     "mathlibGaps": [],
     "nextSteps": [],
@@ -66,7 +74,7 @@
     "mathlib": []
   },
   "started": "2026-07-10T00:41:25.785Z",
-  "lastUpdate": "2026-07-10T00:41:25.930Z",
+  "lastUpdate": "2026-07-20T00:00:00.000Z",
   "significance": 7,
   "tractability": 6
 }


### PR DESCRIPTION
## Summary
Research session for `erdos-98-wip-01` (Erdős #98, distinct distances in general position). Extends the already-merged `Erdos98WIP01.lean` (PR #39575) with (a) the sharp counting ceiling and (b) the conversion of the scaffold's comment-only bounds/conjectures into typed Lean `Prop`s — the stated mission of this problem ("from comments to checkable statements").

## Progress
- **`numDistinctDistances_le_choose_two`** — sharp unordered-pair ceiling `numDistinctDistances P ≤ n.choose 2`, halving the crude `n·(n−1)` bound from session #1. Proof factors the symmetric distance map `f (i,j) = dist (P i) (P j)` through `Sym2 (Fin n)` (`Sym2.lift ⟨·, dist_comm⟩`), rewrites the off-diagonal image via `Finset.image_image`, and counts with `Sym2.card_image_offDiag`.
- **Typed statements** for the previously comment-only results, over the gallery `h`:
  - `PachUpperBound` — `∀ᶠ n, (h n:ℝ) < n ^ logb 2 3` (imported assumption)
  - `EFPUpperBound` — `∃ c>0, ∀ᶠ n, (h n:ℝ) < n·exp(c·√(log n))` (imported assumption)
  - `GuthKatzBaseline` — `∃ c>0, ∀ᶠ n, c·n/log n ≤ h n` (imported assumption, Ω(n/log n))
  - `Erdos98WeakConjecture` — `∀ᶠ n, n ≤ h n` (OPEN)
  - `Erdos98StrongConjecture` — `Tendsto (fun n => (h n:ℝ)/n) atTop atTop` (OPEN)
- **`strong_imp_weak`** — the strong conjecture entails the weak one (machine-checked).
- **`weak_imp_tendsto`** — even the weak conjecture forces `h(n)→∞`, a non-vacuity check (machine-checked).

Files modified:
- `proofs/Proofs/Erdos98WIP01.lean` (+121 lines)
- `src/data/research/problems/erdos-98-wip-01.json`
- `research/problems/erdos-98-wip-01/knowledge.md`

## Findings
- The correct ceiling of the `h(n)` envelope is the unordered-pair count `n.choose 2`; the `Sym2` factoring is the clean route (avoids a bespoke upper-triangle cardinality lemma).
- The two conjecture `Prop`s are correctly related (strong ⟹ weak) and non-vacuous (weak ⟹ unbounded) — verifying the transcription is faithful, not just type-correct.

## Verification
Host-side `bin/lake env lean Proofs/Erdos98WIP01.lean` → exit 0, no warnings (Mathlib v4.31, docker-free). `#print axioms` on all three new theorems = `[propext, Classical.choice, Quot.sound]` — no `sorryAx`, no `native_decide`. **13 theorems/defs, 0 sorry, 0 axiom.**

The `Prop` definitions are faithful transcriptions only; Pach/EFP/Guth–Katz are imported as assumptions and both conjectures remain open in mathematics — nothing here claims to resolve them.

## Status
**Outcome**: progress (surveyed + proved) — the honest deliverable of this WIP problem (typed statements + definitional/counting lemmas), not a resolution.
**Next Steps**: The elementary Erdős pigeonhole lower bound `≥ √(n − 3/4) − 1/2` (via max multiplicity of a single distance) would be the first genuinely superconstant floor and is the natural next proved theorem.

🤖 Generated by researcher-1