### PR TITLE
Enrich cauchy-interlacing-theorem-oq-01-oq-02-oq-02-oq-01 (Schur–Horn): cover pointwise-confinement block + 5th key insight (96→100)

### DIFF
--- a/src/data/proofs/catalan-numbers-oq-01-oq-03/meta.json
+++ b/src/data/proofs/catalan-numbers-oq-01-oq-03/meta.json
@@ -65,6 +65,7 @@
       "**Positivity is a genuine gap.** Mathlib records evenness of the large Schröder numbers (Nat.even_largeSchroder) but not positivity; positivity is what licenses cancelling Schröder factors and is the base for every quantitative estimate.",
       "**Two boundary terms already force factor-3 growth.** The convolution sum ∑ i ≤ n+1, L i · L(n+1−i) contains the summands at i = 0 and i = n+1, each equal to L(n+1); together with the leading +L(n+1) in the convolution recurrence this gives L(n+2) ≥ 3·L(n+1) with no analysis of the interior terms.",
       "**The factor 3 is sharp as an integer ratio but loose asymptotically.** The true ratio L(n+1)/L n increases to 3 + 2√2 ≈ 5.83 (the dominant root of x² − 6x + 1, the discriminant of the Schröder generating-function equation); 3 is the best constant available from the two boundary terms alone.",
+      "**The geometric closed form bootstraps from a single step inequality.** The exponential bound 2·3ⁿ ≤ L(n+1) is not proved by re-examining the convolution sum at each n: once the *one* multiplicative step 3·L(n+1) ≤ L(n+2) is in hand, a bare induction compounds it — 2·3^(n+1) = 3·(2·3ⁿ) ≤ 3·L(n+1) ≤ L(n+2) — with the base L 1 = 2 supplying the leading constant. So the four results form a bootstrapping ladder (positivity → boundary convolution bound → one-step growth → geometric closed form), each the hypothesis of the next, and no new combinatorics enters after the step inequality.",
       "**The deeper holonomic recurrence needs generating functions, but is buildable in Mathlib.** The order-two recurrence (n+3)·L(n+2) + n·L n = 3·(2n+3)·L(n+1) follows from the linear ODE x(x²−6x+1) f' = (3x−1) f + (x+1) satisfied by f = ∑ L n xⁿ. Unlike the Catalan first-order recurrence (inherited from central binomials) it has no central-coefficient shortcut, but it is not blocked: the formal-power-series route is fully supported by Mathlib (estimated ~150–250 lines). The GF quadratic X·f² + (x−1)·f + 1 = 0 is a direct mirror of PowerSeries.catalanSeries_sq_mul_X_add_one (Mathlib/RingTheory/PowerSeries/Catalan.lean), and the differentiation/coefficient-extraction step uses PowerSeries.derivative (a Derivation, d⁄dX) together with PowerSeries.coeff_derivative (Mathlib/RingTheory/PowerSeries/Derivative.lean). A concrete five-step lemma plan is recorded in the companion file's docstring; the single remaining sorry awaits automated proof search or a manual session with a working verifier."
     ],
     "prerequisites": [
@@ -76,11 +77,19 @@
   "sections": [
     {
       "id": "header",
-      "title": "Module Header and Setup",
+      "title": "Module Header: the Mathlib gap and results roadmap",
       "startLine": 1,
+      "endLine": 30,
+      "summary": "Imports (Mathlib's Schröder file and Tactic) and the docstring framing: Mathlib defines largeSchroder only via the quadratic convolution recurrence and records only evenness, leaving positivity and the growth rate unrecorded. The '## Main results' roadmap lists the four facts supplied — largeSchroder_pos, two_mul_largeSchroder_le_conv, largeSchroder_ge_three_mul, and the closed exponential bound largeSchroder_ge_two_mul_three_pow.",
+      "mathContext": "$L(n+1) = L(n) + \\sum_{i\\le n} L(i)\\,L(n-i)$; the ratio $L(n+1)/L(n) \\ge 3$ and $\\to 3 + 2\\sqrt2 \\approx 5.83$."
+    },
+    {
+      "id": "deeper-open-question",
+      "title": "The Deeper Open Question (holonomic recurrence)",
+      "startLine": 31,
       "endLine": 49,
-      "summary": "Module docstring describing the Mathlib gap (only the convolution recurrence and evenness are recorded), the four results supplied here, and the deeper holonomic recurrence deferred to the companion file; imports of Mathlib's Schröder file and Tactic.",
-      "mathContext": "$L(n+1) = L(n) + \\sum_{i\\le n} L(i)\\,L(n-i)$; growth ratio $\\to 3 + 2\\sqrt2$."
+      "summary": "The '## The deeper open question' block: the order-two holonomic (P-recursive) recurrence (n+3)·L(n+2) + n·L n = 3·(2n+3)·L(n+1) — the large-Schröder analogue of the Catalan first-order recurrence — is stated but deferred to the companion SchroderLinearRecurrenceAristotle.lean, since its proof needs generating-function machinery (the GF f = ∑ L n xⁿ satisfies x·f² + (x−1)·f + 1 = 0, giving the ODE x(x²−6x+1)·f' = (3x−1)·f + (x+1)). Followed by namespace Nat and open Finset.",
+      "mathContext": "$(n+3)L(n+2) + nL(n) = 3(2n+3)L(n+1)$; GF ODE $x(x^2-6x+1)f' = (3x-1)f + (x+1)$."
     },
     {
       "id": "positivity",

--- a/src/data/proofs/cauchy-group-theorem-oq-01-oq-01-oq-01-oq-01-oq-03-oq-02/meta.json
+++ b/src/data/proofs/cauchy-group-theorem-oq-01-oq-01-oq-01-oq-01-oq-03-oq-02/meta.json
@@ -56,9 +56,17 @@
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Overview: gcd(n,m) recovers the power map",
+      "startLine": 1,
+      "endLine": 58,
+      "summary": "Imports (parent CauchyGroupTheoremOQ01OQ01OQ01OQ01OQ03 and Tactic) and the module docstring. It makes precise the parent's slogan — structurally the n-th power map x ↦ xⁿ on a finite group of order m is the same map as the gcd(n,m)-th power map — in three independent senses (same kernel in any finite group, same image in the cyclic case, uniform fibres/partition in the cyclic case), then records the proof strategy: the kernel via orderOf_dvd_iff_pow_eq_one and o ∣ m → (o ∣ n ↔ o ∣ gcd(n,m)); the image via IsCyclic.card_powMonoidHom_range; the partition via Finset.card_eq_sum_card_image over the parent's count. Namespace and open Finset close the setup.",
+      "mathContext": "Slogan: $x \\mapsto x^n$ equals $x \\mapsto x^{\\gcd(n,m)}$ structurally; $\\#(n\\text{-th powers}) = m/\\gcd(n,m)$."
+    },
+    {
       "id": "kernel-recovery",
       "title": "Same Kernel — the n-torsion is the gcd-torsion",
-      "startLine": 65,
+      "startLine": 59,
       "endLine": 91,
       "summary": "pow_eq_one_iff_pow_gcd: in any finite group, xⁿ = 1 ↔ x^gcd(n, |G|) = 1, via orderOf_dvd_iff_pow_eq_one and the equivalence orderOf x ∣ n ↔ orderOf x ∣ gcd(n, |G|) (using orderOf x ∣ |G|). solutions_pow_one_eq_gcd records the Finset equality of the two torsion solution sets, and ker_pow_eq_ker_pow_gcd lifts the equivalence to an equality of kernel subgroups of the power homomorphisms.",
       "mathContext": "xⁿ = 1 ⟺ x^gcd(n,m) = 1, hence ker(x ↦ xⁿ) = ker(x ↦ x^gcd(n,m)); no commutativity required."
@@ -72,12 +80,20 @@
       "mathContext": "range(x ↦ xⁿ) = range(x ↦ x^gcd(n,m)); both have order m/gcd(n, m)."
     },
     {
-      "id": "fibre-partition",
-      "title": "Uniform Fibres and the Partition Identity",
+      "id": "uniform-fibres",
+      "title": "Uniform Fibre Size",
       "startLine": 121,
+      "endLine": 130,
+      "summary": "card_fiber_pow restates the parent's count: every fibre of x ↦ xⁿ lying over an actual n-th power b has exactly gcd(n, m) elements — the common fibre size that will drive the partition count.",
+      "mathContext": "Each non-empty fibre of $x \\mapsto x^n$ has $\\gcd(n,m)$ elements."
+    },
+    {
+      "id": "partition-count",
+      "title": "The Partition Identity and the Power Count",
+      "startLine": 131,
       "endLine": 164,
-      "summary": "card_fiber_pow restates the parent's count: every fibre of x ↦ xⁿ over an actual n-th power b has exactly gcd(n, m) elements. card_image_pow_mul_gcd counts the group two ways with Finset.card_eq_sum_card_image — each summand collapses to gcd(n, m) — to obtain #(n-th powers)·gcd(n, m) = m. card_image_pow divides by the positive gcd to give #(n-th powers) = m/gcd(n, m): the power map tiles the cyclic group into m/gcd(n,m) fibres of common size gcd(n,m).",
-      "mathContext": "#(n-th powers)·gcd(n, m) = m, so #(n-th powers) = m/gcd(n, m); fibres all have size gcd(n, m)."
+      "summary": "card_image_pow_mul_gcd counts the group two ways with Finset.card_eq_sum_card_image — each summand collapses to the common fibre size gcd(n, m) — to obtain #(n-th powers)·gcd(n, m) = m. card_image_pow then divides by the positive gcd to give #(n-th powers) = m/gcd(n, m): the power map tiles the cyclic group into m/gcd(n,m) fibres of common size gcd(n,m).",
+      "mathContext": "#(n-th powers)·gcd(n, m) = m, so #(n-th powers) = m/gcd(n, m)."
     }
   ],
   "conclusion": {

--- a/src/data/proofs/cauchy-interlacing-theorem-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/cauchy-interlacing-theorem-oq-01-oq-02-oq-01/meta.json
@@ -79,7 +79,8 @@
       "Stating the Ky Fan bounds over an arbitrary index set s : Finset (Fin n) — rather than only over Finset.univ — lets a single pair of theorems subsume both the trace estimate and every top-j partial sum, so the weak-majorization statement is a one-line specialisation with no Fin-interval bookkeeping",
       "The full mathematical weight sits in the parent Poincaré separation theorem; the Ky Fan content is exactly the monotonicity of finite sums, which is honest to record as a Finset.sum_le_sum wrapper rather than dressed up as new spectral theory",
       "Because the eigenvalues are carried as the free functions λ and μ with the index map k ↦ ⟨k+m⟩ / k ↦ ⟨k⟩, the lower bound automatically references the n SMALLEST eigenvalues of T (indices m … n+m-1) and the upper bound the n LARGEST (indices 0 … n-1), making the trace trapping read off directly",
-      "The whole development is operator-theoretic over an arbitrary RCLike field (real or complex), never touching matrices: the compression is characterised purely by the Rayleigh-quotient agreement hypothesis hRayleigh, so the Ky Fan trace and majorization bounds hold for compressions of Hermitian operators on any finite-dimensional inner product space, not just symmetric real matrices"
+      "The whole development is operator-theoretic over an arbitrary RCLike field (real or complex), never touching matrices: the compression is characterised purely by the Rayleigh-quotient agreement hypothesis hRayleigh, so the Ky Fan trace and majorization bounds hold for compressions of Hermitian operators on any finite-dimensional inner product space, not just symmetric real matrices",
+      "The result is WEAK majorization μ ≺_w λ, not full majorization, and the compression's loss of m dimensions is exactly why: because TH lives on a codimension-m subspace, its trace ∑_k μ_k need not equal ∑ λ, so only the top-j partial sums are dominated. This is precisely what makes the trace TRAPPED between the sums of the n smallest and n largest eigenvalues (rather than pinned to one value) — the m discarded eigenvalues can lie anywhere in the spectrum, so the compression trace ranges over that whole band. Full majorization μ ≺ λ would require accounting for the discarded eigenvalue mass, which the one-sided Poincaré sum does not supply"
     ],
     "prerequisites": [
       "The Poincaré separation theorem (cauchy-interlacing-theorem-oq-01-oq-02 / CauchyInterlacingPoincare): termwise interlacing of compression eigenvalues",
@@ -91,10 +92,17 @@
   "sections": [
     {
       "id": "header",
-      "title": "Overview and Compression Setup",
+      "title": "Overview: the three readings of the summed bounds",
       "startLine": 1,
+      "endLine": 41,
+      "summary": "The module docstring frames the Ky Fan package built on the parent Poincaré separation theorem (lam ⟨k+m⟩ ≤ mu k ≤ lam ⟨k⟩), and lays out the three readings of summing those termwise bounds over an index set s ⊆ Fin n: the general monotone-sum bound, the weak-majorization partial sums (s an initial segment), and the trace trapping (s = univ). Emphasises that no new spectral theory is used — the content is monotonicity of finite sums."
+    },
+    {
+      "id": "compression-setup",
+      "title": "Formal Setup: the compression hypotheses",
+      "startLine": 42,
       "endLine": 62,
-      "summary": "The module docstring states the Ky Fan interlacing package built on the parent Poincaré separation theorem: for a symmetric operator T on an (n+m)-dimensional space and its compression TH to an n-dimensional subspace H, the compression eigenvalues μ are trapped between the top and bottom n eigenvalues λ of T. The setup fixes the operators, eigenbases, eigenvalue lists (hlam/hmu antitone), the dimension hypotheses, and the Rayleigh-agreement hypothesis, then `include`s them into every theorem below."
+      "summary": "Opens (InnerProductSpace, BigOperators, CauchyInterlacing.Poincare), namespace CauchyInterlacing.KyFan, and the variable block fixing the abstract compression data over an arbitrary RCLike field 𝕜: the symmetric operator T with orthonormal eigenbasis b and antitone eigenvalues lam, the codimension-m subspace H with Module.finrank = n, its operator TH with eigenbasis bH and antitone eigenvalues mu, and the Rayleigh-quotient agreement hypothesis hRayleigh that characterises TH as the orthogonal compression. An `include` directive threads all hypotheses into every theorem, since they appear only in proof bodies."
     },
     {
       "id": "ky-fan-sum-bounds",

--- a/src/data/proofs/cauchy-interlacing-theorem-oq-01-oq-02-oq-02-oq-01/meta.json
+++ b/src/data/proofs/cauchy-interlacing-theorem-oq-01-oq-02-oq-02-oq-01/meta.json
@@ -107,7 +107,8 @@
       "The Karamata convex-function inequality ∑ φ(dᵢ) ≤ ∑ φ(λⱼ) is the form of majorization that proves itself: it needs only that each dᵢ is a convex combination of the λⱼ, which is exactly Jensen — no sorting, no partial-sum bookkeeping",
       "The change-of-basis squared-modulus matrix D i j = |⟨vⱼ, eᵢ⟩|² is automatically doubly stochastic by Parseval applied in each of the two orthonormal bases — this is the bridge from the spectral theorem to majorization and needs no Birkhoff theorem",
       "diag_decomp re ⟪T(e i), e i⟫ = ∑ⱼ λⱼ |⟨vⱼ, eᵢ⟩|² is the single nontrivial identity; everything downstream is Jensen plus a Fubini-style sum swap collapsed by the column sums",
-      "Phrasing the result for an abstract convex φ on an arbitrary set s containing the spectrum makes the trace equality and the sum-of-squares inequality immediate specializations rather than separate proofs"
+      "Phrasing the result for an abstract convex φ on an arbitrary set s containing the spectrum makes the trace equality and the sum-of-squares inequality immediate specializations rather than separate proofs",
+      "Pointwise confinement is the k=1 extreme of the majorization and needs strictly less than the aggregate results: because diag_decomp writes each diagonal entry as the convex combination ∑ⱼ λⱼ·Dᵢⱼ, a weighted average with weights summing to 1 cannot escape the eigenvalues' hull, so λ_min ≤ dᵢ ≤ λ_max using ONLY the row-stochasticity ∑ⱼ Dᵢⱼ = 1 — the column sums (hence full double-stochasticity) are never invoked. This recovers the classical fact that the diagonal of a Hermitian operator, in any orthonormal basis, sits inside its numerical range [λ_min, λ_max]"
     ],
     "prerequisites": [
       "The finite-dimensional spectral theorem: a symmetric operator has an orthonormal eigenbasis (LinearMap.IsSymmetric.eigenvectorBasis) with real eigenvalues",
@@ -144,6 +145,14 @@
       "startLine": 120,
       "endLine": 178,
       "summary": "schur_majorization_convexOn: for convex φ on s ⊇ spectrum, ConvexOn.map_sum_le applied with weights D i j (nonnegative, summing to 1 by the row sums) and points λ j ∈ s gives φ(d i) ≤ ∑ⱼ D i j • φ(λ j); summing over i, swapping the order (Finset.sum_comm), and collapsing each column with ∑ᵢ D i j = 1 (Finset.sum_smul, one_smul) yields ∑ᵢ φ(d i) ≤ ∑ⱼ φ(λ j). schur_trace_eq specializes to the equality case ∑ d i = ∑ λ j directly from diag_decomp and the column sums (no convexity), and schur_sum_sq_le applies the master theorem with φ = (·)² (Even.convexOn_pow at n=2) to bound ∑ d i² ≤ ∑ λ j²."
+    },
+    {
+      "id": "pointwise-confinement",
+      "title": "Pointwise Confinement (numerical-range bound)",
+      "startLine": 181,
+      "endLine": 250,
+      "summary": "The '## Pointwise confinement' block: the k=1 pointwise shadow of the aggregate majorization — every individual diagonal entry lies in the closed interval spanned by the eigenvalues, λ_{n-1} ≤ re ⟪T(e i), e i⟫ ≤ λ_0. diag_le_of_forall_le / le_diag_of_forall_le are the abstract two-sided bounds (a diagonal entry is the convex combination ∑ⱼ λⱼ·Dᵢⱼ, so it cannot exceed a common bound on the λⱼ), needing only row-stochasticity ∑ⱼ Dᵢⱼ = 1 (not the column sums). diag_le_top / bot_le_diag instantiate M, L at the extreme eigenvalues via eigenvalues_antitone, and diag_mem_Icc bundles them into the numerical-range containment dᵢ ∈ [λ_min, λ_max].",
+      "mathContext": "$\\lambda_{n-1} \\le \\operatorname{re}\\langle T(e_i), e_i\\rangle \\le \\lambda_0$, i.e. $d_i \\in [\\lambda_{\\min}, \\lambda_{\\max}]$ — the $k=1$ extreme of $\\operatorname{diag} T \\prec \\operatorname{spec} T$."
     }
   ],
   "mainTheorems": [


### PR DESCRIPTION
Enrichment pass for `cauchy-interlacing-theorem-oq-01-oq-02-oq-02-oq-01` (Schur–Horn majorization; `SchurHornMajorization.lean`, 250 lines) — quality 96 → 100, pass 0.

## Changes
The `sections` array stopped at line 178, leaving the **entire `## Pointwise confinement` block (lines 181–250, six theorems) uncovered** — a real coverage gap, not a count shortfall.

- **Added a `pointwise-confinement` section** (181–250): the `k=1` pointwise shadow of the aggregate majorization — every diagonal entry lies in `[λ_min, λ_max]` (`diag_le_of_forall_le`, `le_diag_of_forall_le`, `diag_le_top`, `bot_le_diag`, `diag_mem_Icc`).
- **Added a 5th key insight**: pointwise confinement needs strictly less than the aggregate results — only row-stochasticity `∑ⱼ Dᵢⱼ = 1`, never the column sums — recovering the classical numerical-range containment of a Hermitian diagonal.

## Verification
- `meta.json` valid JSON, 24.3 KB (under the 60 KB cap); sections 4→5, keyInsights 4→5.
- New section boundaries (181–250) verified against the source: the `/-! ## Pointwise confinement` heading at line 181 and `end SchurHorn` at line 250; the file is 250 lines (`wc -l`), matching `meta.lineCount`.
- No content deleted; axiom/status unchanged.