### PR TITLE
Enrich cauchy-schwarz-integral σ-finite Lp Riesz (incomplete-01): split into 5 sections (94→100)

### DIFF
--- a/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01-incomplete-01/meta.json
+++ b/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01-incomplete-01/meta.json
@@ -60,20 +60,44 @@
   },
   "sections": [
     {
-      "id": "overview",
-      "title": "Overview, Split Rationale, and Imports",
+      "id": "docstring-split-rationale",
+      "title": "Module Docstring and S20 Split Rationale",
       "startLine": 1,
-      "endLine": 22,
-      "summary": "Module header, imports, and setup for the assembling file. Documents the S20 split (#35122): the 1012-line monolith was divided into this 47-line main file plus the Loc/Norm/Infra companions (all namespace RieszSigmaFiniteComplete, same public names), because the combined graph elaborated past the 32GB/40min Docker envelope so its error summary never flushed. This file imports the Loc companion (Step A) and states the assembled theorem; Steps A/B/C themselves live in the companion files listed in additionalFiles.",
-      "mathContext": "Riesz $L^p$ representation for $\\sigma$-finite $\\mu$: every continuous functional on $L^p$ is $\\varphi(f) = \\int f g$ for some $g \\in L^q$, $1/p + 1/q = 1$. Established here for any SigmaFinite measure — IsFiniteMeasure is not required."
+      "endLine": 11,
+      "summary": "Module `/- -/` header documenting the S20 split (#35122, researcher-15): the 1012-line monolith was divided into this ~47-line assembling file plus the Loc/Norm/Infra companions (all namespace RieszSigmaFiniteComplete, same public names). Rationale: with the S18 drift fixes applied, the combined ~1020-line graph elaborated past the 32GB/40min Docker build envelope, so its error summary never flushed. Splitting each ≥300-line theorem into its own file makes each piece elaborate independently and within budget, and makes any residual Mathlib-drift errors measurable per file. Because the namespace and public names are preserved, downstream imports are unaffected.",
+      "mathContext": "Riesz $L^p$ representation for $\\sigma$-finite $\\mu$: every continuous functional on $L^p$ is $\\varphi(f) = \\int f\\,g$ for some $g \\in L^q$, $1/p + 1/q = 1$. Established here for any SigmaFinite measure — IsFiniteMeasure is not required. The split is purely an elaboration-budget device; the mathematical content is unchanged."
     },
     {
-      "id": "main-theorem",
-      "title": "§6. Main Theorem (Assembled)",
+      "id": "imports-setup",
+      "title": "Imports, Namespace, and Variable Setup",
+      "startLine": 12,
+      "endLine": 21,
+      "summary": "`import Mathlib` plus the single project import `Proofs.…Incomplete01Loc` (Step A, localization_existence). Opens `noncomputable section` and the namespaces `MeasureTheory ENNReal NNReal Set Filter`, fixes the abstract measure space `{α : Type*} [MeasurableSpace α] {μ : Measure α}`, and enters `namespace RieszSigmaFiniteComplete`. Importing only the Loc companion (rather than Infra/Norm directly) is deliberate: Loc transitively re-exports the Infra lemmas the assembly needs, keeping this file's import surface minimal.",
+      "mathContext": "The ambient setting is a completely abstract measurable space $(\\alpha, \\mathcal{M})$ with a measure $\\mu$ — no topology, no $\\sigma$-finiteness, and no finiteness is imposed at the file level; those hypotheses are introduced per-theorem as typeclass instances (`[SigmaFinite μ]`, `[Fact (1 ≤ p)]`)."
+    },
+    {
+      "id": "theorem-statement",
+      "title": "§6. Statement of riesz_lp_surjective_sigma_finite",
       "startLine": 23,
+      "endLine": 34,
+      "summary": "The `§ 6. Main theorem` banner and the full statement of riesz_lp_surjective_sigma_finite. For Hölder-conjugate exponents `p.toReal.HolderConjugate q.toReal` with `1 < p`, `p ≠ ⊤`, `[SigmaFinite μ]` and `[Fact (1 ≤ p)]`, every `φ : Lp ℝ p μ →L[ℝ] ℝ` admits a representer `g` with `MemLp g q μ`, the norm bound `eLpNorm g q μ ≤ ENNReal.ofReal ‖φ‖`, and the integral identity `φ f = ∫ a, f a * g a ∂μ` for all `f`. Note the hypotheses: `SigmaFinite μ` replaces the classical `IsFiniteMeasure μ`, which is the headline generalization of this entry.",
+      "mathContext": "$\\varphi(f) = \\int f\\,g\\,d\\mu$ for all $f \\in L^p$, with $g \\in L^q$ and $\\lVert g\\rVert_q \\le \\lVert\\varphi\\rVert$. The surjectivity of $g \\mapsto (f \\mapsto \\int fg)$ onto $(L^p)^*$ is exactly the statement $(L^p)^* \\cong L^q$ for $1/p + 1/q = 1$, $1 < p < \\infty$, now for arbitrary $\\sigma$-finite $\\mu$."
+    },
+    {
+      "id": "proof-assembly",
+      "title": "Proof: Assembling Steps A, B, C",
+      "startLine": 35,
+      "endLine": 43,
+      "summary": "The tactic proof glues the three companion steps. It introduces `φ`, obtains `⟨g, hg_lq, hg_norm, hagree⟩` from localization_existence (Step A, Loc companion — this delivers `g`, its `L^q`-membership, the norm bound, and indicator agreement on μ-finite sets), then `refine`s the goal down to the integral identity. It applies integral_representation_sf (Step C density extension via Lp.induction, Infra) to promote indicator agreement to all `f`; the remaining obligation is discharged per μ-finite `E` by first reconciling the two `Lp` encodings of the finite-measure indicator `1_E` — indicator_memLp_sf vs memLp_indicator_const — via the definitional bridge `heq : … = … := rfl`, then `exact hagree E hE hfin`. Step B (lp_truncation_tendsto_zero, Infra) is used inside Step A to extend indicator agreement from E ⊆ Sₙ to arbitrary finite-measure E.",
+      "mathContext": "The assembly composes Step A (localization_existence, Loc), Step B (lp_truncation_tendsto_zero, Infra) and Step C (integral_representation_sf, Infra). The local `heq : rfl` identifies the two $L^p$ representatives of the finite-measure indicator $\\mathbf{1}_E$, so that Step C's density conclusion applies to Step A's indicator-agreement hypothesis without a coercion mismatch."
+    },
+    {
+      "id": "namespace-close",
+      "title": "Namespace and Section Close",
+      "startLine": 44,
       "endLine": 47,
-      "summary": "riesz_lp_surjective_sigma_finite: the full sigma-finite Riesz Lp representation, assembled from the three steps proved in the companion files. It draws g and its indicator agreement from localization_existence (Step A, in the Loc companion), applies integral_representation_sf (Step C density extension via Lp.induction, in Infra) to promote indicator agreement to all f, and reconciles the two indicator encodings (indicator_memLp_sf vs memLp_indicator_const) by an rfl bridge (heq) before discharging via the Step A agreement. Step B (lp_truncation_tendsto_zero, Infra) supplies the truncation convergence that Step A uses to extend indicator agreement from E ⊆ Sₙ to arbitrary finite-measure E. All four files are 0-sorry / 0-axiom; the per-step mathematics is detailed in overview.keyInsights and the conclusion.",
-      "mathContext": "$\\varphi(f) = \\int f\\,g\\,d\\mu$ with $g \\in L^q$ and $\\lVert g\\rVert_q \\le \\lVert\\varphi\\rVert$. The assembly composes Step A (localization_existence, Loc), Step B (lp_truncation_tendsto_zero, Infra) and Step C (integral_representation_sf, Infra); the local `heq : rfl` identifies the two $L^p$ representatives of the finite-measure indicator $\\mathbf{1}_E$."
+      "summary": "`end RieszSigmaFiniteComplete` closes the namespace and `end` closes the `noncomputable section` opened at line 15. All four files (this assembler plus Infra/Norm/Loc) live in the same RieszSigmaFiniteComplete namespace and are 0-sorry / 0-axiom; the per-step mathematics is detailed in overview.keyInsights and the conclusion.",
+      "mathContext": "Structural close only. The complete result — $(L^p)^* \\cong L^q$ for any $\\sigma$-finite $\\mu$, $1 < p < \\infty$ — is now machine-checked across the four-file build graph without `IsFiniteMeasure` and without any `axiom` or `sorry`."
     }
   ],
   "openQuestions": [


### PR DESCRIPTION
Enrichment pass for `cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01-incomplete-01`.

**Gap:** entry scored 94 — all annotation buckets (9 annotations, all with mathContext/significance/relatedConcepts), historicalContext, keyInsights (9), and conclusion (summary+implications+openQuestions) were already maxed. The only sub-maxed bucket was `sections` (2 sections = 4/10).

**Change:** split the two lumped sections into 5 that track the file's natural boundaries, full coverage of the 47-line assembler:
- `docstring-split-rationale` (1–11) — S20 split rationale
- `imports-setup` (12–21) — imports, namespace, variable setup
- `theorem-statement` (23–34) — §6 statement of `riesz_lp_surjective_sigma_finite`
- `proof-assembly` (35–43) — gluing Steps A/B/C + the `heq : rfl` indicator bridge
- `namespace-close` (44–47) — structural close

Each section carries a substantive `summary` and LaTeX `mathContext`; existing content was preserved and redistributed, none deleted. sections 2→5 → +6 → **100**.

No change to status/badge/axiomCount (remains verified / original / 0, matching the 0-sorry/0-axiom four-file build graph).