### PR TITLE
Enrich cauchy-interlacing-theorem-oq-03-oq-02 (dual Weyl inequality): split proof into two phases + 5th key insight (96→100)

### DIFF
--- a/src/data/proofs/catalan-numbers-oq-01-oq-03/meta.json
+++ b/src/data/proofs/catalan-numbers-oq-01-oq-03/meta.json
@@ -65,6 +65,7 @@
       "**Positivity is a genuine gap.** Mathlib records evenness of the large Schröder numbers (Nat.even_largeSchroder) but not positivity; positivity is what licenses cancelling Schröder factors and is the base for every quantitative estimate.",
       "**Two boundary terms already force factor-3 growth.** The convolution sum ∑ i ≤ n+1, L i · L(n+1−i) contains the summands at i = 0 and i = n+1, each equal to L(n+1); together with the leading +L(n+1) in the convolution recurrence this gives L(n+2) ≥ 3·L(n+1) with no analysis of the interior terms.",
       "**The factor 3 is sharp as an integer ratio but loose asymptotically.** The true ratio L(n+1)/L n increases to 3 + 2√2 ≈ 5.83 (the dominant root of x² − 6x + 1, the discriminant of the Schröder generating-function equation); 3 is the best constant available from the two boundary terms alone.",
+      "**The geometric closed form bootstraps from a single step inequality.** The exponential bound 2·3ⁿ ≤ L(n+1) is not proved by re-examining the convolution sum at each n: once the *one* multiplicative step 3·L(n+1) ≤ L(n+2) is in hand, a bare induction compounds it — 2·3^(n+1) = 3·(2·3ⁿ) ≤ 3·L(n+1) ≤ L(n+2) — with the base L 1 = 2 supplying the leading constant. So the four results form a bootstrapping ladder (positivity → boundary convolution bound → one-step growth → geometric closed form), each the hypothesis of the next, and no new combinatorics enters after the step inequality.",
       "**The deeper holonomic recurrence needs generating functions, but is buildable in Mathlib.** The order-two recurrence (n+3)·L(n+2) + n·L n = 3·(2n+3)·L(n+1) follows from the linear ODE x(x²−6x+1) f' = (3x−1) f + (x+1) satisfied by f = ∑ L n xⁿ. Unlike the Catalan first-order recurrence (inherited from central binomials) it has no central-coefficient shortcut, but it is not blocked: the formal-power-series route is fully supported by Mathlib (estimated ~150–250 lines). The GF quadratic X·f² + (x−1)·f + 1 = 0 is a direct mirror of PowerSeries.catalanSeries_sq_mul_X_add_one (Mathlib/RingTheory/PowerSeries/Catalan.lean), and the differentiation/coefficient-extraction step uses PowerSeries.derivative (a Derivation, d⁄dX) together with PowerSeries.coeff_derivative (Mathlib/RingTheory/PowerSeries/Derivative.lean). A concrete five-step lemma plan is recorded in the companion file's docstring; the single remaining sorry awaits automated proof search or a manual session with a working verifier."
     ],
     "prerequisites": [
@@ -76,11 +77,19 @@
   "sections": [
     {
       "id": "header",
-      "title": "Module Header and Setup",
+      "title": "Module Header: the Mathlib gap and results roadmap",
       "startLine": 1,
+      "endLine": 30,
+      "summary": "Imports (Mathlib's Schröder file and Tactic) and the docstring framing: Mathlib defines largeSchroder only via the quadratic convolution recurrence and records only evenness, leaving positivity and the growth rate unrecorded. The '## Main results' roadmap lists the four facts supplied — largeSchroder_pos, two_mul_largeSchroder_le_conv, largeSchroder_ge_three_mul, and the closed exponential bound largeSchroder_ge_two_mul_three_pow.",
+      "mathContext": "$L(n+1) = L(n) + \\sum_{i\\le n} L(i)\\,L(n-i)$; the ratio $L(n+1)/L(n) \\ge 3$ and $\\to 3 + 2\\sqrt2 \\approx 5.83$."
+    },
+    {
+      "id": "deeper-open-question",
+      "title": "The Deeper Open Question (holonomic recurrence)",
+      "startLine": 31,
       "endLine": 49,
-      "summary": "Module docstring describing the Mathlib gap (only the convolution recurrence and evenness are recorded), the four results supplied here, and the deeper holonomic recurrence deferred to the companion file; imports of Mathlib's Schröder file and Tactic.",
-      "mathContext": "$L(n+1) = L(n) + \\sum_{i\\le n} L(i)\\,L(n-i)$; growth ratio $\\to 3 + 2\\sqrt2$."
+      "summary": "The '## The deeper open question' block: the order-two holonomic (P-recursive) recurrence (n+3)·L(n+2) + n·L n = 3·(2n+3)·L(n+1) — the large-Schröder analogue of the Catalan first-order recurrence — is stated but deferred to the companion SchroderLinearRecurrenceAristotle.lean, since its proof needs generating-function machinery (the GF f = ∑ L n xⁿ satisfies x·f² + (x−1)·f + 1 = 0, giving the ODE x(x²−6x+1)·f' = (3x−1)·f + (x+1)). Followed by namespace Nat and open Finset.",
+      "mathContext": "$(n+3)L(n+2) + nL(n) = 3(2n+3)L(n+1)$; GF ODE $x(x^2-6x+1)f' = (3x-1)f + (x+1)$."
     },
     {
       "id": "positivity",

--- a/src/data/proofs/cauchy-group-theorem-oq-01-oq-01-oq-01-oq-01-oq-03-oq-02/meta.json
+++ b/src/data/proofs/cauchy-group-theorem-oq-01-oq-01-oq-01-oq-01-oq-03-oq-02/meta.json
@@ -56,9 +56,17 @@
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Overview: gcd(n,m) recovers the power map",
+      "startLine": 1,
+      "endLine": 58,
+      "summary": "Imports (parent CauchyGroupTheoremOQ01OQ01OQ01OQ01OQ03 and Tactic) and the module docstring. It makes precise the parent's slogan — structurally the n-th power map x ↦ xⁿ on a finite group of order m is the same map as the gcd(n,m)-th power map — in three independent senses (same kernel in any finite group, same image in the cyclic case, uniform fibres/partition in the cyclic case), then records the proof strategy: the kernel via orderOf_dvd_iff_pow_eq_one and o ∣ m → (o ∣ n ↔ o ∣ gcd(n,m)); the image via IsCyclic.card_powMonoidHom_range; the partition via Finset.card_eq_sum_card_image over the parent's count. Namespace and open Finset close the setup.",
+      "mathContext": "Slogan: $x \\mapsto x^n$ equals $x \\mapsto x^{\\gcd(n,m)}$ structurally; $\\#(n\\text{-th powers}) = m/\\gcd(n,m)$."
+    },
+    {
       "id": "kernel-recovery",
       "title": "Same Kernel — the n-torsion is the gcd-torsion",
-      "startLine": 65,
+      "startLine": 59,
       "endLine": 91,
       "summary": "pow_eq_one_iff_pow_gcd: in any finite group, xⁿ = 1 ↔ x^gcd(n, |G|) = 1, via orderOf_dvd_iff_pow_eq_one and the equivalence orderOf x ∣ n ↔ orderOf x ∣ gcd(n, |G|) (using orderOf x ∣ |G|). solutions_pow_one_eq_gcd records the Finset equality of the two torsion solution sets, and ker_pow_eq_ker_pow_gcd lifts the equivalence to an equality of kernel subgroups of the power homomorphisms.",
       "mathContext": "xⁿ = 1 ⟺ x^gcd(n,m) = 1, hence ker(x ↦ xⁿ) = ker(x ↦ x^gcd(n,m)); no commutativity required."
@@ -72,12 +80,20 @@
       "mathContext": "range(x ↦ xⁿ) = range(x ↦ x^gcd(n,m)); both have order m/gcd(n, m)."
     },
     {
-      "id": "fibre-partition",
-      "title": "Uniform Fibres and the Partition Identity",
+      "id": "uniform-fibres",
+      "title": "Uniform Fibre Size",
       "startLine": 121,
+      "endLine": 130,
+      "summary": "card_fiber_pow restates the parent's count: every fibre of x ↦ xⁿ lying over an actual n-th power b has exactly gcd(n, m) elements — the common fibre size that will drive the partition count.",
+      "mathContext": "Each non-empty fibre of $x \\mapsto x^n$ has $\\gcd(n,m)$ elements."
+    },
+    {
+      "id": "partition-count",
+      "title": "The Partition Identity and the Power Count",
+      "startLine": 131,
       "endLine": 164,
-      "summary": "card_fiber_pow restates the parent's count: every fibre of x ↦ xⁿ over an actual n-th power b has exactly gcd(n, m) elements. card_image_pow_mul_gcd counts the group two ways with Finset.card_eq_sum_card_image — each summand collapses to gcd(n, m) — to obtain #(n-th powers)·gcd(n, m) = m. card_image_pow divides by the positive gcd to give #(n-th powers) = m/gcd(n, m): the power map tiles the cyclic group into m/gcd(n,m) fibres of common size gcd(n,m).",
-      "mathContext": "#(n-th powers)·gcd(n, m) = m, so #(n-th powers) = m/gcd(n, m); fibres all have size gcd(n, m)."
+      "summary": "card_image_pow_mul_gcd counts the group two ways with Finset.card_eq_sum_card_image — each summand collapses to the common fibre size gcd(n, m) — to obtain #(n-th powers)·gcd(n, m) = m. card_image_pow then divides by the positive gcd to give #(n-th powers) = m/gcd(n, m): the power map tiles the cyclic group into m/gcd(n,m) fibres of common size gcd(n,m).",
+      "mathContext": "#(n-th powers)·gcd(n, m) = m, so #(n-th powers) = m/gcd(n, m)."
     }
   ],
   "conclusion": {

--- a/src/data/proofs/cauchy-interlacing-theorem-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/cauchy-interlacing-theorem-oq-01-oq-02-oq-01/meta.json
@@ -79,7 +79,8 @@
       "Stating the Ky Fan bounds over an arbitrary index set s : Finset (Fin n) — rather than only over Finset.univ — lets a single pair of theorems subsume both the trace estimate and every top-j partial sum, so the weak-majorization statement is a one-line specialisation with no Fin-interval bookkeeping",
       "The full mathematical weight sits in the parent Poincaré separation theorem; the Ky Fan content is exactly the monotonicity of finite sums, which is honest to record as a Finset.sum_le_sum wrapper rather than dressed up as new spectral theory",
       "Because the eigenvalues are carried as the free functions λ and μ with the index map k ↦ ⟨k+m⟩ / k ↦ ⟨k⟩, the lower bound automatically references the n SMALLEST eigenvalues of T (indices m … n+m-1) and the upper bound the n LARGEST (indices 0 … n-1), making the trace trapping read off directly",
-      "The whole development is operator-theoretic over an arbitrary RCLike field (real or complex), never touching matrices: the compression is characterised purely by the Rayleigh-quotient agreement hypothesis hRayleigh, so the Ky Fan trace and majorization bounds hold for compressions of Hermitian operators on any finite-dimensional inner product space, not just symmetric real matrices"
+      "The whole development is operator-theoretic over an arbitrary RCLike field (real or complex), never touching matrices: the compression is characterised purely by the Rayleigh-quotient agreement hypothesis hRayleigh, so the Ky Fan trace and majorization bounds hold for compressions of Hermitian operators on any finite-dimensional inner product space, not just symmetric real matrices",
+      "The result is WEAK majorization μ ≺_w λ, not full majorization, and the compression's loss of m dimensions is exactly why: because TH lives on a codimension-m subspace, its trace ∑_k μ_k need not equal ∑ λ, so only the top-j partial sums are dominated. This is precisely what makes the trace TRAPPED between the sums of the n smallest and n largest eigenvalues (rather than pinned to one value) — the m discarded eigenvalues can lie anywhere in the spectrum, so the compression trace ranges over that whole band. Full majorization μ ≺ λ would require accounting for the discarded eigenvalue mass, which the one-sided Poincaré sum does not supply"
     ],
     "prerequisites": [
       "The Poincaré separation theorem (cauchy-interlacing-theorem-oq-01-oq-02 / CauchyInterlacingPoincare): termwise interlacing of compression eigenvalues",
@@ -91,10 +92,17 @@
   "sections": [
     {
       "id": "header",
-      "title": "Overview and Compression Setup",
+      "title": "Overview: the three readings of the summed bounds",
       "startLine": 1,
+      "endLine": 41,
+      "summary": "The module docstring frames the Ky Fan package built on the parent Poincaré separation theorem (lam ⟨k+m⟩ ≤ mu k ≤ lam ⟨k⟩), and lays out the three readings of summing those termwise bounds over an index set s ⊆ Fin n: the general monotone-sum bound, the weak-majorization partial sums (s an initial segment), and the trace trapping (s = univ). Emphasises that no new spectral theory is used — the content is monotonicity of finite sums."
+    },
+    {
+      "id": "compression-setup",
+      "title": "Formal Setup: the compression hypotheses",
+      "startLine": 42,
       "endLine": 62,
-      "summary": "The module docstring states the Ky Fan interlacing package built on the parent Poincaré separation theorem: for a symmetric operator T on an (n+m)-dimensional space and its compression TH to an n-dimensional subspace H, the compression eigenvalues μ are trapped between the top and bottom n eigenvalues λ of T. The setup fixes the operators, eigenbases, eigenvalue lists (hlam/hmu antitone), the dimension hypotheses, and the Rayleigh-agreement hypothesis, then `include`s them into every theorem below."
+      "summary": "Opens (InnerProductSpace, BigOperators, CauchyInterlacing.Poincare), namespace CauchyInterlacing.KyFan, and the variable block fixing the abstract compression data over an arbitrary RCLike field 𝕜: the symmetric operator T with orthonormal eigenbasis b and antitone eigenvalues lam, the codimension-m subspace H with Module.finrank = n, its operator TH with eigenbasis bH and antitone eigenvalues mu, and the Rayleigh-quotient agreement hypothesis hRayleigh that characterises TH as the orthogonal compression. An `include` directive threads all hypotheses into every theorem, since they appear only in proof bodies."
     },
     {
       "id": "ky-fan-sum-bounds",

--- a/src/data/proofs/cauchy-interlacing-theorem-oq-01-oq-02-oq-02-oq-01/meta.json
+++ b/src/data/proofs/cauchy-interlacing-theorem-oq-01-oq-02-oq-02-oq-01/meta.json
@@ -107,7 +107,8 @@
       "The Karamata convex-function inequality ∑ φ(dᵢ) ≤ ∑ φ(λⱼ) is the form of majorization that proves itself: it needs only that each dᵢ is a convex combination of the λⱼ, which is exactly Jensen — no sorting, no partial-sum bookkeeping",
       "The change-of-basis squared-modulus matrix D i j = |⟨vⱼ, eᵢ⟩|² is automatically doubly stochastic by Parseval applied in each of the two orthonormal bases — this is the bridge from the spectral theorem to majorization and needs no Birkhoff theorem",
       "diag_decomp re ⟪T(e i), e i⟫ = ∑ⱼ λⱼ |⟨vⱼ, eᵢ⟩|² is the single nontrivial identity; everything downstream is Jensen plus a Fubini-style sum swap collapsed by the column sums",
-      "Phrasing the result for an abstract convex φ on an arbitrary set s containing the spectrum makes the trace equality and the sum-of-squares inequality immediate specializations rather than separate proofs"
+      "Phrasing the result for an abstract convex φ on an arbitrary set s containing the spectrum makes the trace equality and the sum-of-squares inequality immediate specializations rather than separate proofs",
+      "Pointwise confinement is the k=1 extreme of the majorization and needs strictly less than the aggregate results: because diag_decomp writes each diagonal entry as the convex combination ∑ⱼ λⱼ·Dᵢⱼ, a weighted average with weights summing to 1 cannot escape the eigenvalues' hull, so λ_min ≤ dᵢ ≤ λ_max using ONLY the row-stochasticity ∑ⱼ Dᵢⱼ = 1 — the column sums (hence full double-stochasticity) are never invoked. This recovers the classical fact that the diagonal of a Hermitian operator, in any orthonormal basis, sits inside its numerical range [λ_min, λ_max]"
     ],
     "prerequisites": [
       "The finite-dimensional spectral theorem: a symmetric operator has an orthonormal eigenbasis (LinearMap.IsSymmetric.eigenvectorBasis) with real eigenvalues",
@@ -144,6 +145,14 @@
       "startLine": 120,
       "endLine": 178,
       "summary": "schur_majorization_convexOn: for convex φ on s ⊇ spectrum, ConvexOn.map_sum_le applied with weights D i j (nonnegative, summing to 1 by the row sums) and points λ j ∈ s gives φ(d i) ≤ ∑ⱼ D i j • φ(λ j); summing over i, swapping the order (Finset.sum_comm), and collapsing each column with ∑ᵢ D i j = 1 (Finset.sum_smul, one_smul) yields ∑ᵢ φ(d i) ≤ ∑ⱼ φ(λ j). schur_trace_eq specializes to the equality case ∑ d i = ∑ λ j directly from diag_decomp and the column sums (no convexity), and schur_sum_sq_le applies the master theorem with φ = (·)² (Even.convexOn_pow at n=2) to bound ∑ d i² ≤ ∑ λ j²."
+    },
+    {
+      "id": "pointwise-confinement",
+      "title": "Pointwise Confinement (numerical-range bound)",
+      "startLine": 181,
+      "endLine": 250,
+      "summary": "The '## Pointwise confinement' block: the k=1 pointwise shadow of the aggregate majorization — every individual diagonal entry lies in the closed interval spanned by the eigenvalues, λ_{n-1} ≤ re ⟪T(e i), e i⟫ ≤ λ_0. diag_le_of_forall_le / le_diag_of_forall_le are the abstract two-sided bounds (a diagonal entry is the convex combination ∑ⱼ λⱼ·Dᵢⱼ, so it cannot exceed a common bound on the λⱼ), needing only row-stochasticity ∑ⱼ Dᵢⱼ = 1 (not the column sums). diag_le_top / bot_le_diag instantiate M, L at the extreme eigenvalues via eigenvalues_antitone, and diag_mem_Icc bundles them into the numerical-range containment dᵢ ∈ [λ_min, λ_max].",
+      "mathContext": "$\\lambda_{n-1} \\le \\operatorname{re}\\langle T(e_i), e_i\\rangle \\le \\lambda_0$, i.e. $d_i \\in [\\lambda_{\\min}, \\lambda_{\\max}]$ — the $k=1$ extreme of $\\operatorname{diag} T \\prec \\operatorname{spec} T$."
     }
   ],
   "mainTheorems": [

--- a/src/data/proofs/cauchy-interlacing-theorem-oq-03-oq-02/meta.json
+++ b/src/data/proofs/cauchy-interlacing-theorem-oq-03-oq-02/meta.json
@@ -71,7 +71,8 @@
       "**Superadditivity is subadditivity in a mirror.** The lower Weyl bracket needs no fresh variational argument: the reflection T ↦ −T sends the descending eigenvalue list μ to −μ read backwards, so the parent's single subadditive inequality already contains its own dual. Both halves of the two-sided Weyl bound rest on one Grassmann count.",
       "**Negation reverses the eigenvalue order, hence reindex by Fin.rev.** −T has eigenvalues −μ, but to keep them DESCENDING they must be read in reverse: the k-th largest eigenvalue of −T is minus the k-th smallest of T, i.e. −μ(n−1−k). Formalising this is exactly reindexing the eigenbasis by the order-reversing involution Fin.revPerm and negating; the antitone hypothesis survives because two order reversals compose to a monotone one, then negation flips once more.",
       "**The index arithmetic is the whole content of the dual bound.** Under index reversal the clean hypothesis i + j ≤ k of weyl_add_le becomes k + (n−1) ≤ i + j — the characteristic 'n−1 defect' of the lower Weyl inequality appears precisely because reversing three indices in [0, n) injects three copies of (n−1) that omega rearranges into a single one. No spectral input is touched.",
-      "**A negated sum stays a sum of negations.** (−T) + (−U) = −(T + U) lets the negated presentation of the sum operator be obtained from that of T + U directly, so the same neg_reindex_eigen lemma serves all three operators and the call to weyl_add_le sees genuinely the sum of the two negated operators it is fed."
+      "**A negated sum stays a sum of negations.** (−T) + (−U) = −(T + U) lets the negated presentation of the sum operator be obtained from that of T + U directly, so the same neg_reindex_eigen lemma serves all three operators and the call to weyl_add_le sees genuinely the sum of the two negated operators it is fed.",
+    "**The reflection is a duality on the whole keystone, not a trick for this one bound.** T ↦ −T with basis reindexing by Fin.rev acts only on the order/linear structure — reverse the enumeration, negate the eigenvalues — and never touches the variational content (Grassmann counts, Rayleigh quotients). So the same substitution dualizes ANY one-sided bound in the keystone family (interlacing's λ_{k+m} ≤ μ_k, Weyl monotonicity, the additive bound) into its mirror lower companion; weyl_add_ge is merely the first instance applied, and the two-sided Weyl bracket therefore costs exactly one genuine variational proof."
     ],
     "prerequisites": [
       "The parent entry's subadditive Weyl inequality (cauchy-interlacing-theorem-oq-03, weyl_add_le): for i + j ≤ k, ρ(k) ≤ μ(i) + ν(j)",
@@ -106,12 +107,20 @@
       "mathContext": "The descending order of −T's eigenvalues: −μ(Fin.rev ·) is antitone because Fin.rev reverses order once and negation reverses it again."
     },
     {
-      "id": "dual-weyl",
-      "title": "The Dual Weyl Inequality",
+      "id": "dual-weyl-setup",
+      "title": "The Dual Weyl Inequality — building the reflected data",
       "startLine": 75,
+      "endLine": 116,
+      "summary": "weyl_add_ge (statement + first phase): μ(i) + ν(j) ≤ ρ(k) for k + (n−1) ≤ i + j. Assembles the reflected presentations the primal inequality will consume — the three negated/reversed eigen-presentations via neg_reindex_eigen (the sum handled through (−T)+(−U) = −(T+U)), the three antitone facts via antitone_neg_rev, and the reversed-index hypothesis Fin.rev i + Fin.rev j ≤ Fin.rev k (Fin.val_rev + omega, where the n−1 defect is absorbed).",
+      "mathContext": "Reflect the data: eigenvalues μ ↦ −μ∘Fin.rev, indices i ↦ Fin.rev i; the hypothesis k + (n−1) ≤ i + j becomes the primal's Fin.rev i + Fin.rev j ≤ Fin.rev k."
+    },
+    {
+      "id": "dual-weyl-reduction",
+      "title": "The Dual Weyl Inequality — reduction to the primal bound",
+      "startLine": 117,
       "endLine": 126,
-      "summary": "weyl_add_ge: μ(i) + ν(j) ≤ ρ(k) for k + (n−1) ≤ i + j. Builds the three negated/reversed presentations (the sum via (−T)+(−U) = −(T+U)), the three antitone facts, and the reversed-index hypothesis (Fin.val_rev + omega), then applies the parent's weyl_add_le to −T, −U at indices Fin.rev i, Fin.rev j, Fin.rev k; Fin.rev_rev and linarith finish.",
-      "mathContext": "The superadditive lower bracket of the two-sided Weyl bound, λ_i(A) + λ_j(B) ≤ λ_{i+j−n}(A+B), obtained purely by reflection from the subadditive upper bound."
+      "summary": "weyl_add_ge (second phase): apply the parent's weyl_add_le to −T, −U, −(T+U) in the reversed eigenbases at indices Fin.rev i, Fin.rev j, Fin.rev k, obtaining −ρ(k) ≤ −μ(i) − ν(j); Fin.rev_rev collapses the double reversal and linarith rearranges to μ(i) + ν(j) ≤ ρ(k). No variational machinery is re-entered.",
+      "mathContext": "The superadditive lower bracket λ_i(A) + λ_j(B) ≤ λ_{i+j−n}(A+B), obtained purely by reflection from the subadditive upper bound."
     }
   ],
   "mainTheorems": [

--- a/src/data/proofs/cauchy-interlacing-theorem-oq-03/meta.json
+++ b/src/data/proofs/cauchy-interlacing-theorem-oq-03/meta.json
@@ -72,7 +72,8 @@
       "**Monotonicity is the lower-into-upper pairing.** The keystone's two halves are not only the ingredients of interlacing; pairing the lower half of T with the upper half of U on the *same* optimal subspace immediately yields eigenvalue monotonicity — the cleanest possible consequence of Courant–Fischer.",
       "**The additive inequality is a double Grassmann count.** Weyl's λ_{i+j+1}(A+B) ≤ λ_{i+1}(A) + λ_{j+1}(B) needs exactly one new ingredient over interlacing — Rayleigh additivity R_{T+U} = R_T + R_U — plus intersecting the optimal subspace with two eigenspans instead of one. finrank_inf_lb applied twice supplies the (k+1) − i − j ≥ 1 count.",
       "**No new spectral theory.** Every eigenvalue fact used is the keystone's; no eigenvalue is re-derived, no new variational principle is proved. This realises the structural prediction of oq-02 that the keystone already subsumes Weyl-type perturbation bounds, with only the dimension bookkeeping changing.",
-      "**Monotonicity is not a special case of the additive form here.** Because the three operators carry independent eigenbases, weyl_monotone is proved directly (a single pairing) rather than by specialising weyl_add_le; the two theorems share the keystone but not the proof."
+      "**Monotonicity is not a special case of the additive form here.** Because the three operators carry independent eigenbases, weyl_monotone is proved directly (a single pairing) rather than by specialising weyl_add_le; the two theorems share the keystone but not the proof.",
+    "**Non-commutativity is sidestepped by pointwise Rayleigh additivity.** T, U, and T+U carry three independent eigenbases b, c, d and are generally NOT simultaneously diagonalizable (T and U need not commute), so no shared eigenvector argument is available. The proof never needs one: it produces a single common vector x by dimension counting, and the only additive fact used is that the Rayleigh quotient is additive at that one point, R_{T+U}(x) = R_T(x) + R_U(x) — an identity of inner products (inner_add_left), not of spectra. The whole force of Weyl's inequality is thus the linearity of ⟪T·,·⟫ in T evaluated on one cleverly chosen vector."
     ],
     "prerequisites": [
       "The parent entry's Courant–Fischer max–min keystone (CauchyInterlacingKeystone): eigenvalue_maxmin_lower / eigenvalue_maxmin_upper and the eigenspan Rayleigh bound rayleigh_bounds_on_eigenspan",
@@ -107,12 +108,20 @@
       "mathContext": "Eigenvalues are monotone in the Loewner order — the simplest Courant–Fischer corollary."
     },
     {
-      "id": "additive",
-      "title": "Weyl's Additive Inequality",
+      "id": "additive-dimension",
+      "title": "Weyl's Additive Inequality — the dimension count",
       "startLine": 114,
+      "endLine": 166,
+      "summary": "weyl_add_le (statement + first proof phase): for i + j ≤ k, ρ(k) ≤ μ(i) + ν(j). Take the optimal (k+1)-dimensional subspace S for T+U (lower keystone half eigenvalue_maxmin_lower) and the upper-tail eigenspans A = span{b i,…} (dim n−i) and B = span{c j,…} (dim n−j). Two Grassmann counts (finrank_inf_lb applied to S⊓A then (S⊓A)⊓B, with hEdim = n) give finrank((S⊓A)⊓B) ≥ (k+1) − i − j ≥ 1, so the triple intersection is nonzero and yields a common vector x ≠ 0 lying in S, A, and B.",
+      "mathContext": "$\\dim(S \\cap A \\cap B) \\ge (k+1) - i - j \\ge 1$: the optimal subspace and the two eigenspans must meet in a nonzero vector."
+    },
+    {
+      "id": "additive-rayleigh",
+      "title": "Weyl's Additive Inequality — the Rayleigh estimate",
+      "startLine": 167,
       "endLine": 187,
-      "summary": "weyl_add_le: for i + j ≤ k, ρ(k) ≤ μ(i) + ν(j). The optimal (k+1)-dim subspace for T+U meets the upper-tail eigenspans of T and U; two Grassmann counts leave a common nonzero vector, on which Rayleigh additivity gives ρ(k) ≤ R_T(x) + R_U(x) ≤ μ(i) + ν(j).",
-      "mathContext": "The classical λ_{i+j+1}(A+B) ≤ λ_{i+1}(A) + λ_{j+1}(B) in 0-based descending form — the foundational eigenvalue perturbation bound."
+      "summary": "weyl_add_le (second proof phase): on the common vector x, the upper-eigenspan bound gives R_T(x) ≤ μ(i) and R_U(x) ≤ ν(j) (rayleigh_le_on_upper_eigenspan), while membership in S gives the lower bound ρ(k) ≤ R_{T+U}(x) (hSlb). Rayleigh additivity R_{T+U}(x) = R_T(x) + R_U(x) (from inner_add_left / map_add, then add_div) closes the calc: ρ(k) ≤ R_{T+U}(x) = R_T(x) + R_U(x) ≤ μ(i) + ν(j). This is the classical λ_{i+j+1}(A+B) ≤ λ_{i+1}(A) + λ_{j+1}(B) in 0-based descending form.",
+      "mathContext": "$\\rho(k) \\le R_{T+U}(x) = R_T(x) + R_U(x) \\le \\mu(i) + \\nu(j)$ — the foundational eigenvalue perturbation bound."
     }
   ],
   "mainTheorems": [


### PR DESCRIPTION
Enrichment pass for `cauchy-interlacing-theorem-oq-03-oq-02` (dual/superadditive Weyl inequality; `CauchyInterlacingWeylDual.lean`) — quality 96 → 100, pass 0.

## Changes
- **Split the 52-line `dual-weyl` section** (75–126) at the proof's phase boundary (line 117) into:
  - `dual-weyl-setup` (75–116): statement plus building the reflected data — the three negated/reversed eigen-presentations (`neg_reindex_eigen`, the sum via `(−T)+(−U) = −(T+U)`), the antitone facts (`antitone_neg_rev`), and the reversed-index hypothesis.
  - `dual-weyl-reduction` (117–126): apply the primal `weyl_add_le` to the negated data and flip via `Fin.rev_rev` + `linarith`.
- **Added a 5th key insight**: the reflection `T ↦ −T` (with `Fin.rev` reindexing) is a duality on the *whole* keystone family — it acts only on the order/linear structure and never re-enters the variational machinery, so it dualizes any one-sided keystone bound (interlacing, monotonicity, additive); `weyl_add_ge` is just the first instance.

## Verification
- `meta.json` valid JSON, 23.3 KB (under 60 KB cap); sections 4→5, keyInsights 4→5.
- Split boundary (117) verified against the source; contiguous coverage of the theorem body preserved (`end` at 127).
- No content deleted; axiom/status unchanged.