### PR TITLE
Research: erdos-89-wip-01 — sharp n.choose 2 distinct-distance ceiling

### DIFF
--- a/proofs/Proofs/Erdos89WIP01.lean
+++ b/proofs/Proofs/Erdos89WIP01.lean
@@ -29,6 +29,11 @@ first structural theorems.
 3. `numDistinctDistances_le_offDiag` — the trivial ceiling
    `numDistinctDistances S ≤ |S|·(|S|−1)`.
 
+3b. `numDistinctDistances_le_choose_two` — the sharp (unordered-pair) ceiling
+   `numDistinctDistances S ≤ S.card.choose 2`, halving the trivial bound. Proved
+   by factoring the symmetric distance map through `Sym2` and invoking
+   `Sym2.card_image_offDiag`.
+
 4. `numDistinctDistances_eq_zero_of_card_le_one` — the degenerate floor
    (`|S| ≤ 1 ⟹ 0`).
 
@@ -73,6 +78,31 @@ theorem numDistinctDistances_le_offDiag (S : Finset (EuclideanSpace ℝ (Fin 2))
   calc (S.offDiag.image (fun pq => dist pq.1 pq.2)).card
       ≤ S.offDiag.card := card_image_le
     _ = S.card * (S.card - 1) := by rw [Finset.offDiag_card, Nat.mul_sub_one]
+
+/-- **Sharp upper envelope.** Because the distance is symmetric, a distinct
+distance is determined by an *unordered* pair, so the count is at most
+`S.card.choose 2` — the correct ceiling, halving the crude `|S|·(|S|−1)` bound.
+Proved by factoring the symmetric distance map through `Sym2`. -/
+theorem numDistinctDistances_le_choose_two
+    (S : Finset (EuclideanSpace ℝ (Fin 2))) :
+    numDistinctDistances S ≤ S.card.choose 2 := by
+  unfold numDistinctDistances
+  rw [distinctDistances_eq_image]
+  -- The (custom) distance is symmetric, so it factors through `Sym2`.
+  set g : Sym2 (EuclideanSpace ℝ (Fin 2)) → ℝ :=
+    Sym2.lift ⟨fun a b => dist a b, fun a b => by
+      show ‖a - b‖ = ‖b - a‖; exact norm_sub_rev a b⟩ with hg
+  have hfac :
+      (fun pq : EuclideanSpace ℝ (Fin 2) × EuclideanSpace ℝ (Fin 2) => dist pq.1 pq.2)
+        = g ∘ Sym2.mk.uncurry := by
+    funext pq
+    obtain ⟨a, b⟩ := pq
+    simp only [hg, Function.comp_apply, Function.uncurry_apply_pair, Sym2.lift_mk]
+  calc (S.offDiag.image (fun pq => dist pq.1 pq.2)).card
+      = ((S.offDiag.image Sym2.mk.uncurry).image g).card := by
+          rw [hfac, ← Finset.image_image]
+    _ ≤ (S.offDiag.image Sym2.mk.uncurry).card := card_image_le
+    _ = S.card.choose 2 := Sym2.card_image_offDiag S
 
 /-- Fewer than two points determine no distance. -/
 theorem numDistinctDistances_eq_zero_of_card_le_one

--- a/research/problems/erdos-89-wip-01/knowledge.md
+++ b/research/problems/erdos-89-wip-01/knowledge.md
@@ -51,3 +51,25 @@ docker-free), child compiled against it. Exit 0, no warnings.
 - Formalize the `√n × √n` grid upper bound feeding `minDistinctDistances_le_*`,
   giving a concrete `g(n) = O(n)` ceiling.
 - Connect `singlePointConjecture` (Problem #604) to the global count.
+
+## Session (researcher-1, 2026-07-20 #2) — sharp choose-2 ceiling
+
+Added `numDistinctDistances_le_choose_two` — `numDistinctDistances S ≤
+S.card.choose 2`, the sharp unordered-pair ceiling (halves the crude
+`|S|·(|S|−1)` bound from session #1). This was the first listed Next Step.
+
+Key idea (identical to erdos-98-wip-01): the custom `Erdos89.dist p q = ‖p−q‖`
+is symmetric via `norm_sub_rev`, so it factors as `g ∘ Sym2.mk.uncurry` with
+`g = Sym2.lift ⟨fun a b => dist a b, norm_sub_rev⟩`. Then
+`S.offDiag.image (dist ·.1 ·.2) = (S.offDiag.image Sym2.mk.uncurry).image g`
+(`Finset.image_image`), and `Sym2.card_image_offDiag S` counts the off-diagonal
+`Sym2` image as `S.card.choose 2`.
+
+Host-verified `bin/lake env lean Proofs/Erdos89WIP01.lean` exit 0, no warnings;
+`#print axioms numDistinctDistances_le_choose_two` = `[propext, Classical.choice,
+Quot.sound]`. Now 7 theorems, 0 sorry, 0 axiom.
+
+### Next Steps (unchanged)
+- Formalize the `√n × √n` grid upper bound feeding `minDistinctDistances_le_*`
+  for a concrete `g(n) = O(n)` ceiling.
+- Guth–Katz `Ω(n/log n)` lower bound stays an imported assumption.

--- a/src/data/research/problems/erdos-89-wip-01.json
+++ b/src/data/research/problems/erdos-89-wip-01.json
@@ -18,12 +18,12 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "OBSERVE",
+    "phase": "ACT",
     "since": "2026-07-09T17:33:18-07:00",
     "iteration": 1,
     "focus": "Initial problem understanding. Read problem.md and gather context.",
     "blockers": [],
-    "nextAction": "Read problem.md thoroughly and acquire full context.",
+    "nextAction": "Formalize the √n×√n grid upper bound feeding minDistinctDistances_le_of_card_eq to get a concrete g(n)=O(n) ceiling; connect singlePointConjecture (#604) to the global count. Guth–Katz lower bound stays an imported assumption.",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -31,19 +31,21 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Created Erdos89WIP01.lean — first machine-checked theorems for the #89 distinct-distances (Finset) scaffold. Positive-distance structure, redundant-filter characterization, counting envelope 0 ≤ numDistinctDistances ≤ |S|·(|S|−1), and the minDistinctDistances sInf-membership witness fact.",
+    "progressSummary": "PROGRESS: Erdos89WIP01.lean — added the sharp unordered-pair ceiling numDistinctDistances S ≤ S.card.choose 2 (Sym2 factoring of the symmetric custom distance), completing the counting envelope. 7 theorems, 0 sorry, 0 axiom; #print axioms = [propext, Classical.choice, Quot.sound].",
     "builtItems": [
       "Erdos89.dist_pos_of_ne in Erdos89WIP01.lean",
       "Erdos89.distinctDistances_eq_image (filter redundant) in Erdos89WIP01.lean",
       "Erdos89.numDistinctDistances_le_offDiag (≤ |S|·(|S|−1)) in Erdos89WIP01.lean",
       "Erdos89.numDistinctDistances_eq_zero_of_card_le_one in Erdos89WIP01.lean",
       "Erdos89.one_le_numDistinctDistances_of_two_le_card in Erdos89WIP01.lean",
-      "Erdos89.minDistinctDistances_le_of_card_eq in Erdos89WIP01.lean"
+      "Erdos89.minDistinctDistances_le_of_card_eq in Erdos89WIP01.lean",
+      "numDistinctDistances_le_choose_two (≤ S.card.choose 2, sharp unordered-pair ceiling) in Erdos89WIP01.lean"
     ],
     "insights": [
       "distinctDistances S filters (·>0) over the off-diagonal image, but every off-diagonal pair (p≠q) already has ‖p−q‖>0, so the filter is redundant: distinctDistances S = S.offDiag.image (dist · ·). This removes the awkward filter for all downstream cardinality reasoning.",
       "Counting envelope: numDistinctDistances S ≤ |S|·(|S|−1) via card_image_le + Finset.offDiag_card; and it vanishes iff too few points (|S|≤1 ⟹ 0, |S|≥2 ⟹ ≥1 via one_lt_card giving a distinct pair).",
-      "minDistinctDistances n = sInf over n-point sets is bounded above by any single n-point witness (Nat.sInf_le ⟨S, hcard, rfl⟩) — the membership hook the √n×√n grid upper-bound construction ultimately supplies."
+      "minDistinctDistances n = sInf over n-point sets is bounded above by any single n-point witness (Nat.sInf_le ⟨S, hcard, rfl⟩) — the membership hook the √n×√n grid upper-bound construction ultimately supplies.",
+      "The custom Erdos89.dist (‖p−q‖) is symmetric via norm_sub_rev, so it factors through Sym2; routing S.offDiag.image through Sym2.mk.uncurry and applying Sym2.card_image_offDiag gives the sharp ceiling numDistinctDistances S ≤ S.card.choose 2 (halving |S|·(|S|−1)). Same technique as erdos-98-wip-01."
     ],
     "mathlibGaps": [],
     "nextSteps": [],


### PR DESCRIPTION
## Summary
Research session for `erdos-89-wip-01` (Erdős #89 — minimum distinct distances `g(n)` over `n`-point planar sets). Completes the first listed Next Step of the WIP file `Proofs/Erdos89WIP01.lean`: the sharp counting ceiling.

## Progress
- **`numDistinctDistances_le_choose_two`** — `numDistinctDistances S ≤ S.card.choose 2`, the sharp *unordered-pair* ceiling, halving the crude `|S|·(|S|−1)` bound from session #1. The custom distance `Erdos89.dist p q = ‖p−q‖` is symmetric (`norm_sub_rev`), so it factors as `g ∘ Sym2.mk.uncurry` with `g = Sym2.lift ⟨fun a b => dist a b, norm_sub_rev⟩`; then `S.offDiag.image (dist ·.1 ·.2) = (S.offDiag.image Sym2.mk.uncurry).image g` (`Finset.image_image`) and `Sym2.card_image_offDiag S` counts the off-diagonal `Sym2` image as `S.card.choose 2`.

Files modified:
- `proofs/Proofs/Erdos89WIP01.lean` (+~30 lines)
- `src/data/research/problems/erdos-89-wip-01.json`, `research/problems/erdos-89-wip-01/knowledge.md`

(The gallery `erdos-89` meta.json tracks the parent `Erdos89Problem.lean`, which is untouched, so it is left unchanged.)

## Findings
- The correct ceiling of the `g(n)` envelope is the unordered-pair count `S.card.choose 2`; the `Sym2` factoring is the clean route (same technique just applied to the sibling `erdos-98-wip-01`).

## Verification
Host-side `bin/lake env lean Proofs/Erdos89WIP01.lean` → exit 0, no warnings (Mathlib v4.31, docker-free). `#print axioms numDistinctDistances_le_choose_two` = `[propext, Classical.choice, Quot.sound]` — no `sorryAx`, no `native_decide`. **7 theorems, 0 sorry, 0 axiom.**

## Status
**Outcome**: progress (sharpened counting envelope). The Guth–Katz `Ω(n/log n)` lower bound and the conjecture remain out of scope / imported assumptions.
**Next Steps**: formalize the `√n × √n` grid upper bound feeding `minDistinctDistances_le_of_card_eq` for a concrete `g(n) = O(n)` ceiling.

🤖 Generated by researcher-1