### PR TITLE
Gallery integrity: erdos-955 section summary claims a non-existent axiom

### DIFF
--- a/src/data/proofs/erdos-955/meta.json
+++ b/src/data/proofs/erdos-955/meta.json
@@ -101,10 +101,10 @@
     {
       "id": "divisor-function",
       "title": "The Sum of Proper Divisors Function",
-      "summary": "Defines $\\sigma(n) = \\sum_{d | n} d$ using Mathlib's `Nat.divisors`, then the aliquot sum $s(n) = \\sigma(n) - n$. An alternative definition `s_alt` sums directly over `Nat.properDivisors`, and an axiom asserts the two definitions agree for $n > 0$.",
+      "summary": "Defines $\\sigma(n) = \\sum_{d | n} d$ using Mathlib's `Nat.divisors`, then the aliquot sum $s(n) = \\sigma(n) - n$. An alternative definition `s_alt` sums directly over `Nat.properDivisors`; the two coincide for $n > 0$, though this equivalence is not separately proved in the file.",
       "startLine": 38,
       "endLine": 58,
-      "mathContext": "Defines $\\sigma(n) = \\sum_{d | n} d$ using Mathlib's `Nat.divisors`, then the aliquot sum $s(n) = \\sigma(n) - n$. An alternative definition `s_alt` sums directly over `Nat.properDivisors`, and an axiom asserts the two definitions agree for $n > 0$."
+      "mathContext": "Defines $\\sigma(n) = \\sum_{d | n} d$ using Mathlib's `Nat.divisors`, then the aliquot sum $s(n) = \\sigma(n) - n$. An alternative definition `s_alt` sums directly over `Nat.properDivisors`; the two coincide for $n > 0$, though this equivalence is not separately proved in the file."
     },
     {
       "id": "perfect-numbers",


### PR DESCRIPTION
## Integrity Issue

**Proof**: erdos-955 (Erdős #955: Sum of Proper Divisors and Density)
**Problem**: The `divisor-function` section summary claims an axiom that does not exist in the Lean file.

## Evidence

**meta.json claims** (`sections[].divisor-function.summary`):
> "An alternative definition `s_alt` sums directly over `Nat.properDivisors`, **and an axiom asserts the two definitions agree for n > 0**."

**Lean file shows** (`Proofs/Erdos955Problem.lean`): only two axioms exist —
`ppt_bound` (line 143) and `erdos_955_summary` (line 171). There is no axiom
relating `s` and `s_alt`; `s_alt` is defined (line 51) and never referenced
again. `axiomCount: 2` is correct.

All other fields verified accurate: axiomCount 2, theoremCount 2 (`sparse_sets_work`, `erdos_955`), definitionCount 14, sorries 0, no native_decide. status `axiomatized` / badge `axiom` appropriate; the `assumptions` field is candid.

## Fix

Corrected the section summary and mathContext to state the two definitions
coincide for n > 0 but that this equivalence is **not separately proved** in the
file, removing the phantom-axiom claim. No count fields change.

Severity: LOW (safe-direction prose — the phantom claim adds a non-existent
assumption rather than overstating proof strength), but it misrepresents Lean
content in public gallery prose.

---
Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)