### PR TITLE
Research: erdos-1039-oq-05 — strict positivity of the discrete diameter

### DIFF
--- a/proofs/Proofs/Erdos1039TransfiniteDiameter.lean
+++ b/proofs/Proofs/Erdos1039TransfiniteDiameter.lean
@@ -140,6 +140,35 @@ noncomputable def discreteDiameter (z : Fin n → ℂ) : ℝ :=
 theorem discreteDiameter_nonneg (z : Fin n → ℂ) : 0 ≤ discreteDiameter z :=
   Real.rpow_nonneg (spreadProduct_nonneg z) _
 
+/-- **Strict positivity for distinct roots.**  If the tuple `z` is injective, its
+`n`-point diameter is strictly positive — the spread product is then positive and a
+positive base raised to any real power stays positive.  This sharpens
+`discreteDiameter_nonneg` and is what makes `Real.log (discreteDiameter z)` and the
+energy-bridge identity meaningful. -/
+theorem discreteDiameter_pos (z : Fin n → ℂ) (hz : Function.Injective z) :
+    0 < discreteDiameter z :=
+  Real.rpow_pos_of_pos ((spreadProduct_pos_iff z).mpr hz) _
+
+/-- **Positivity characterises distinctness** (for `n ≥ 2`): the `n`-point diameter is
+strictly positive iff the roots are pairwise distinct.  The forward direction uses that
+the normalising exponent `2/(n(n−1))` is nonzero for `n ≥ 2`, so a vanishing spread
+product would force `dₙ = 0`. -/
+theorem discreteDiameter_pos_iff {z : Fin n → ℂ} (hn : 2 ≤ n) :
+    0 < discreteDiameter z ↔ Function.Injective z := by
+  rw [← spreadProduct_pos_iff]
+  unfold discreteDiameter
+  have hepos : 0 < 2 / ((n : ℝ) * ((n : ℝ) - 1)) := by
+    have h2 : (2 : ℝ) ≤ (n : ℝ) := by exact_mod_cast hn
+    exact div_pos (by norm_num) (mul_pos (by linarith) (by linarith))
+  constructor
+  · intro h
+    rcases (spreadProduct_nonneg z).lt_or_eq with hpos | hz0
+    · exact hpos
+    · rw [← hz0, Real.zero_rpow (ne_of_gt hepos)] at h
+      exact absurd h (lt_irrefl 0)
+  · intro h
+    exact Real.rpow_pos_of_pos h _
+
 /-- The normalising exponent times the pair count is `1` (for `n ≥ 2`). -/
 private theorem pairCount_mul_exp {n : ℕ} (hn : 2 ≤ n) :
     (pairCount n : ℝ) * (2 / ((n : ℝ) * ((n : ℝ) - 1))) = 1 := by

--- a/research/problems/erdos-1039-oq-05/knowledge.md
+++ b/research/problems/erdos-1039-oq-05/knowledge.md
@@ -106,3 +106,18 @@ transfinite-diameter limit require Mathlib API that does not yet exist.
 1. ✅ DONE (iter 4, pointwise form `exists_deleteAt_discreteDiameter_ge`). Remaining: upgrade to sup-over-configurations dₙ₊₁ ≤ dₙ (needs compactness/sSup API) and d(Z) = infₙ dₙ.
 2. Logarithmic capacity of {|f|≥1}∩B(0,R) + cap=1 normalization (axiomatize, cite Fekete–Szegő).
 3. State ρ(f) ≳ g(d(Z), cap) (theorems where provable / axioms citing Pommerenke/KLR).
+
+## Built (iteration 5 — strict positivity of the discrete diameter, axiom-free)
+
+- `discreteDiameter_pos (z) (hz : Injective z) : 0 < discreteDiameter z`.
+  `dₙ z = spreadProduct z ^ (2/(n(n−1)))`; injectivity ⇒ `0 < spreadProduct z`
+  (`spreadProduct_pos_iff`), and `Real.rpow_pos_of_pos` keeps it positive.
+- `discreteDiameter_pos_iff (hn : 2 ≤ n) : 0 < discreteDiameter z ↔ Injective z`.
+  Backward = `discreteDiameter_pos`; forward uses that the exponent `2/(n(n−1))`
+  is nonzero for `n ≥ 2`, so a vanishing spread product forces `dₙ = 0`
+  (`Real.zero_rpow`).
+
+These sharpen `discreteDiameter_nonneg` and supply the strict positivity that
+`Real.log (discreteDiameter z)` and `discreteDiameter_eq_exp` silently rely on.
+Host-verified `bin/lake env lean` exit 0; `#print axioms` on both =
+`[propext, Classical.choice, Quot.sound]`.

--- a/src/data/research/problems/erdos-1039-oq-05.json
+++ b/src/data/research/problems/erdos-1039-oq-05.json
@@ -34,7 +34,7 @@
     "iteration": 4,
     "focus": "Iteration 4: pointwise Fekete monotonicity exists_deleteAt_discreteDiameter_ge (d_{n+1}(Z) <= d_n(delete k Z)) proved axiom-free from the deletion identity via some-term-meets-mean. Erdos1039TransfiniteDiameter.lean now 16 theorems, 0 axioms/sorries.",
     "blockers": [],
-    "nextAction": "Upgrade pointwise monotonicity to sup-over-configurations d_{n+1} <= d_n (needs compactness/sSup API); then d(Z)=inf_n d_n; capacity normalization (axiomatize, cite Fekete–Szego).",
+    "nextAction": "Upgrade pointwise exists_deleteAt_discreteDiameter_ge to dₙ₊₁ ≤ dₙ (sup over configs, needs compactness/sSup API) and d(Z)=infₙ dₙ; capacity axioms (Fekete–Szegő). Positivity lemmas now available as a building block.",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -42,7 +42,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (iter 3): the combinatorial core of Fekete monotonicity is formalized axiom-free. prod_spreadProduct_deleteAt proves prod_k V(delete k Z) = V(Z)^(n-1) directly, with a succAbove reindexing lemma, the cardinality count, and the additive log-energy form. Builds on Key Lemma 1 (n-point spread) in Erdos1039TransfiniteDiameter.lean. Remaining: lift to supremum-level d_(n+1) <= d_n (needs sup over configurations); logarithmic capacity + cap=1 (axiomatize). Parent rho(f) >> 1/n remains OPEN.",
+    "progressSummary": "PROGRESS (iter 3): the combinatorial core of Fekete monotonicity is formalized axiom-free. prod_spreadProduct_deleteAt proves prod_k V(delete k Z) = V(Z)^(n-1) directly, with a succAbove reindexing lemma, the cardinality count, and the additive log-energy form. Builds on Key Lemma 1 (n-point spread) in Erdos1039TransfiniteDiameter.lean. Remaining: lift to supremum-level d_(n+1) <= d_n (needs sup over configurations); logarithmic capacity + cap=1 (axiomatize). Parent rho(f) >> 1/n remains OPEN. | +discreteDiameter_pos & discreteDiameter_pos_iff (strict positivity ⟺ distinct roots), the positivity underpinning every log/exp step. 0 sorry, 0 axiom.",
     "builtItems": [
       "Erdos1039TransfiniteDiameter.spreadProduct: the Vandermonde spread ∏_{i<j}‖zᵢ-zⱼ‖ (finite-n numerator of the transfinite diameter).",
       "Erdos1039TransfiniteDiameter.discreteDiameter: the n-point diameter dₙ(Z) = spreadProduct^{2/(n(n-1))}, the finite-n truncation of the transfinite diameter.",
@@ -54,7 +54,9 @@
       "spreadProduct_deleteAt (reindexing lemma) in Erdos1039TransfiniteDiameter.lean",
       "card_filter_avoid (count of indices avoiding two points = n-1) in Erdos1039TransfiniteDiameter.lean",
       "prod_spreadProduct_deleteAt (Fekete deletion identity) in Erdos1039TransfiniteDiameter.lean",
-      "sum_logSpread_deleteAt (additive energy form) in Erdos1039TransfiniteDiameter.lean"
+      "sum_logSpread_deleteAt (additive energy form) in Erdos1039TransfiniteDiameter.lean",
+      "discreteDiameter_pos (0 < dₙ z for injective z) in Erdos1039TransfiniteDiameter.lean",
+      "discreteDiameter_pos_iff (n≥2: 0 < dₙ z ↔ Injective z) in Erdos1039TransfiniteDiameter.lean"
     ],
     "insights": [
       "The finite discrete spread is entirely elementary and needs NO capacity infrastructure: it is a product of pairwise norms, equal to the modulus of the Vandermonde determinant, so it is host-verifiable Mathlib-only (no Docker).",
@@ -62,7 +64,8 @@
       "The transfinite diameter (multiplicative) and logarithmic energy/capacity (additive) are the same object through log/exp; discreteDiameter_eq_exp makes that precise and axiom-free, giving the first concrete link between the two OQ-05 invariants.",
       "Fekete deletion identity prod_k V(delete k Z) = V(Z)^(n-1) is provable axiom-free and unconditionally (any tuple): each pair a<b survives exactly n-1 of the n+1 deletions (those removing neither endpoint).",
       "Order-preserving pair reindexing under Fin.succAbove is a nested Finset.prod_bij; the k-dependent erase-guard is pulled through prod_k by rewriting erase -> filter(.neq.k) -> if via Finset.filter_ne'/prod_filter, then prod_comm.",
-      "Additive shadow: sum_k logSpread(delete k Z) = (n-1)*logSpread Z for distinct roots, connecting the deletion identity to the logarithmic-energy/capacity bridge already in the file."
+      "Additive shadow: sum_k logSpread(delete k Z) = (n-1)*logSpread Z for distinct roots, connecting the deletion identity to the logarithmic-energy/capacity bridge already in the file.",
+      "Strict positivity of discreteDiameter: dₙ z = spreadProduct z ^ (2/(n(n-1))); for injective z the base is positive (spreadProduct_pos_iff) so Real.rpow_pos_of_pos gives 0 < dₙ. The n≥2 iff uses that the exponent 2/(n(n-1)) is nonzero, so a zero spread would force dₙ=0 (Real.zero_rpow). This is the positivity that Real.log(dₙ) and the energy bridge silently need."
     ],
     "mathlibGaps": [
       "Mathlib has no transfinite-diameter / logarithmic-capacity API; the n-point spread and its diameter had to be defined from scratch (done here). The limit d(Z)=limₙ dₙ and Fekete monotonicity are still absent."
@@ -157,5 +160,5 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1039TransfiniteDiameter.lean"
     }
   ],
-  "lastUpdate": "2026-07-20"
+  "lastUpdate": "2026-07-20T00:00:00.000Z"
 }


### PR DESCRIPTION
## Summary
Research session for `erdos-1039-oq-05` (Fekete / transfinite-diameter track). Adds the strict-positivity lemmas that the file's log/exp machinery was implicitly assuming.

## Progress
- **`discreteDiameter_pos`** — for injective `z`, `0 < discreteDiameter z`. Since `dₙ z = spreadProduct z ^ (2/(n(n−1)))` and injectivity gives `0 < spreadProduct z` (`spreadProduct_pos_iff`), `Real.rpow_pos_of_pos` finishes. Sharpens the existing `discreteDiameter_nonneg`.
- **`discreteDiameter_pos_iff`** (`n ≥ 2`) — `0 < discreteDiameter z ↔ Function.Injective z`. Forward direction uses that the normalising exponent `2/(n(n−1))` is nonzero for `n ≥ 2`, so a vanishing spread product would force `dₙ = 0` (`Real.zero_rpow`).

These supply the strict positivity that `Real.log (discreteDiameter z)` and the energy-bridge identity `discreteDiameter_eq_exp` silently rely on.

Files modified:
- `proofs/Proofs/Erdos1039TransfiniteDiameter.lean` (+~30 lines)
- `src/data/research/problems/erdos-1039-oq-05.json`, `research/problems/erdos-1039-oq-05/knowledge.md`

## Verification
Host-side `bin/lake env lean Proofs/Erdos1039TransfiniteDiameter.lean` → exit 0, no warnings (Mathlib v4.31, docker-free). `#print axioms` on both new lemmas = `[propext, Classical.choice, Quot.sound]` — no `sorryAx`, no `native_decide`. **0 sorry, 0 axiom.**

## Status
**Outcome**: progress (small critical-path lemma). The Fekete monotonicity upgrade (`dₙ₊₁ ≤ dₙ` over configurations) still needs compactness/`sSup` API not yet in Mathlib; the capacity results remain to be axiomatized (Fekete–Szegő).
**Next Steps**: upgrade the pointwise deletion monotonicity to the sup-over-configurations form and `d(Z) = infₙ dₙ`.

🤖 Generated by researcher-1