### PR TITLE
Fix: lift stale #39061 audit retraction from 3 repaired-Lean metas

### DIFF
--- a/src/data/proofs/erdos-701/meta.json
+++ b/src/data/proofs/erdos-701/meta.json
@@ -28,8 +28,8 @@
       "Hereditary families (downsets / independence systems)",
       "Extremal set theory fundamentals"
     ],
-    "lineCount": 284,
-    "assumptions": "AUDIT (issue #39061): NOT machine-verified. This entry never validly compiled. Even under Lean v4.26 the proof only 'passed' because the old `autoImplicit true` default silently bound the undefined identifier `A` as a free implicit variable, rendering the stated theorem vacuously general; under v4.31 (autoImplicit off by default) the file fails with `unknownIdentifier 'A'` and typically additional genuine proof errors. The verification claims below are therefore retracted pending a Lean-source repair (Class A). ORIGINAL METADATA: 0 axioms. All constructs are definitions and theorems; no axiom declarations or structure-encoded assumptions. Open conjecture; supporting lemmas fully verified.",
+    "lineCount": 285,
+    "assumptions": "REPAIR (issue #39077, follow-on to #39061): the Lean source was repaired for Lean v4.31 and compiles green — the #39061 audit flagged a masked free identifier `A`, which was fixed by binding it explicitly. No axiom declarations and no structure-encoded assumptions (axiomCount 0); 0 sorries. Chvátal's conjecture itself is OPEN and is only stated (as the Prop `ChvatalConjecture`), not asserted; the supporting lemmas on hereditary/intersecting families, stars, and covering number are fully verified. Status stays axiomatized/wip to signal the conjecture is unresolved.",
     "mathlib_version": "4.31.0",
     "theoremCount": 7,
     "definitionCount": 8
@@ -140,7 +140,7 @@
       "Set"
     ],
     "namespace": "Erdos701",
-    "lineCount": 284,
+    "lineCount": 285,
     "axiomCount": 0,
     "sorries": 0,
     "definitionCount": 8,

--- a/src/data/proofs/erdos-719/meta.json
+++ b/src/data/proofs/erdos-719/meta.json
@@ -77,8 +77,8 @@
       }
     ],
     "axiomCount": 1,
-    "lineCount": 546,
-    "assumptions": "AUDIT (issue #39061): NOT machine-verified. This entry never validly compiled. Even under Lean v4.26 the proof only 'passed' because the old `autoImplicit true` default silently bound the undefined identifier `H.edges` as a free implicit variable, rendering the stated theorem vacuously general; under v4.31 (autoImplicit off by default) the file fails with `unknownIdentifier 'H.edges'` and typically additional genuine proof errors. The verification claims below are therefore retracted pending a Lean-source repair (Class A). ORIGINAL METADATA: 1 axiom: erdos_sauer_conjecture (OPEN problem). Turán's theorem for graphs fully proved via Mathlib bridge.",
+    "lineCount": 548,
+    "assumptions": "Formalized with one stated assumption: the axiom erdos_sauer_conjecture (the OPEN Erdős–Sauer problem). REPAIR (issue #39077, follow-on to #39061): the Lean source was repaired for Lean v4.31 and compiles green — the earlier autoImplicit-masked free identifier `H.edges` was fixed by binding the offending variables explicitly. Turán's theorem for graphs is fully proved via the Mathlib bridge; 0 sorries. The single axiom is a deliberate, disclosed mathematical assumption — the open conjecture is not reproved here.",
     "theoremCount": 20,
     "definitionCount": 10
   },
@@ -211,7 +211,7 @@
     ],
     "opens": [],
     "namespace": null,
-    "lineCount": 546,
+    "lineCount": 548,
     "axiomCount": 1,
     "theoremCount": 20,
     "definitionCount": 10,

--- a/src/data/proofs/ramseys-theorem-oq-04/meta.json
+++ b/src/data/proofs/ramseys-theorem-oq-04/meta.json
@@ -32,7 +32,7 @@
       "pigeonhole_ramsey: k=1 proved via Finset.exists_lt_card_fiber_of_nsmul_lt_card"
     ],
     "axiomCount": 1,
-    "assumptions": "AUDIT (issue #39061): NOT machine-verified. This entry never validly compiled. Even under Lean v4.26 the proof only 'passed' because the old `autoImplicit true` default silently bound the undefined identifier `n` as a free implicit variable, rendering the stated theorem vacuously general; under v4.31 (autoImplicit off by default) the file fails with `unknownIdentifier 'n'` and typically additional genuine proof errors. The verification claims below are therefore retracted pending a Lean-source repair (Class A). ORIGINAL METADATA: 1 axiom: hypergraph_ramsey_k2 (k ≥ 2 existence requiring the stepping-up lemma). All infrastructure, special cases, both base cases (n ≤ k and k=1 pigeonhole), and monotonicity are fully proved. The axiom isolates exactly the inductive step of the k-uniform stepping-up argument.",
+    "assumptions": "Formalized with one stated assumption: the axiom hypergraph_ramsey_k2 (the k ≥ 2 hypergraph Ramsey existence bound requiring the k-uniform stepping-up lemma). REPAIR (issue #39077, follow-on to #39061): the Lean source was repaired for Lean v4.31 and compiles green — the earlier autoImplicit-masked free identifier `n` was fixed by binding the offending variables explicitly, so the stated theorem is no longer vacuously general. All infrastructure, special cases, both base cases (n ≤ k and k = 1 pigeonhole), and monotonicity are fully proved; 0 sorries. The single axiom isolates exactly the inductive step of the k-uniform stepping-up argument — a deliberate, disclosed mathematical assumption, not reproved here.",
     "lineCount": 260,
     "mathlibDependencies": [
       {


### PR DESCRIPTION
## Problem

Three gallery entries had their Lean source repaired for Lean v4.31 by **already-merged** #39077 PRs, but their `meta.json` still carries the stale `#39061` audit retraction ("NOT machine-verified … verification claims retracted pending a Lean-source repair"). The metadata now understates entries that compile green — a gallery-integrity mismatch.

| Entry | Lean repaired by | Lean on main | meta was |
|---|---|---|---|
| `ramseys-theorem-oq-04` | #39267 | 1 axiom, 0 sorry, compiles | retracted ✗ |
| `erdos-701` | #39628 | 0 axiom, 0 sorry, conjecture stated as `def` | retracted ✗ |
| `erdos-719` | #39640 | 1 axiom, 0 sorry, compiles | retracted ✗ |

## Fix (metadata only)

- Replace each `assumptions` field: drop the false "NOT machine-verified / retracted" prefix; restore honest post-repair description (repaired for v4.31, offending autoImplicit-masked identifier bound explicitly, current axiom/sorry status).
- Fix minor `lineCount` drift: erdos-701 284→285, erdos-719 546→548 (match `wc -l`).
- `status` / `badge` / `axiomCount` were **already correct** and are unchanged:
  - ramseys-theorem-oq-04 — axiomatized/axiom, axiomCount 1 (`hypergraph_ramsey_k2`)
  - erdos-701 — axiomatized/wip, axiomCount 0 (Chvátal's conjecture is OPEN, stated only)
  - erdos-719 — axiomatized/axiom, axiomCount 1 (`erdos_sauer_conjecture`)

## Evidence

`git log origin/main -- proofs/Proofs/<file>.lean` shows each file's #39077 repair merged; `grep '^axiom'` / `grep sorry` on main confirm the axiom/sorry counts above. JSON validated with `JSON.parse`.

Supersedes the now-conflicting bundled repair PRs #39095/#39096/#39106 (their Lean portions already merged separately). Part of #39061.