### PR TITLE
Research: erdos-16-wip-01 — formalize covering-congruence obstruction mechanism

### DIFF
--- a/proofs/Proofs/Erdos16Problem.lean
+++ b/proofs/Proofs/Erdos16Problem.lean
@@ -366,6 +366,90 @@ theorem threeHundredThirtyOne_mem_exceptionalSet : (331 : ℕ) ∈ ExceptionalSe
   ⟨⟨165, by norm_num⟩, not_isRomanoff_331⟩
 
 /-
+## The covering-congruence obstruction mechanism (axiom-free)
+
+The A006285 refutations above check each exponent `k` individually.  Erdős's 1950
+argument is structural: it groups the exponents into finitely many residue classes
+(a covering system of `ℤ`, e.g. `erdosCovering`), and to each class `k ≡ r (mod d)`
+attaches a *fixed prime* `p` with `2^d ≡ 1 (mod p)`.  Then `2^k ≡ 2^r (mod p)` for
+every `k` in that class, so choosing `n ≡ 2^r (mod p)` forces `p ∣ n - 2^k`, making
+`n - 2^k` composite whenever it exceeds `p`.  Running this over a covering system
+kills *all* exponents simultaneously, placing an entire arithmetic progression of
+`n` into the exceptional set.  The lemmas below formalize this mechanism (one prime
+= one "gear"); assembling all gears into a single progression via CRT is the
+remaining deep step (Romanoff/Erdős-grade, documented above only). -/
+
+/-- The residue of `2^k` modulo `3` is periodic with period `2`: it is `1` for even
+`k` and `2` for odd `k` (the order of `2` mod `3` is `2`).  This is the smallest
+"gear" of the covering machine. -/
+theorem two_pow_mod_three (k : ℕ) : (2 : ℕ) ^ k % 3 = if k % 2 = 0 then 1 else 2 := by
+  induction k with
+  | zero => rfl
+  | succ n ih =>
+    rw [pow_succ, Nat.mul_mod, ih]
+    rcases (by omega : n % 2 = 0 ∨ n % 2 = 1) with h | h
+    · rw [if_pos h, if_neg (by omega : ¬ (n + 1) % 2 = 0)]
+    · rw [if_neg (by omega : ¬ n % 2 = 0), if_pos (by omega : (n + 1) % 2 = 0)]
+
+/-- **Exponent periodicity of `2` modulo `p`.**  If `2^d ≡ 1 (mod p)` (i.e. the
+multiplicative order of `2` mod `p` divides `d`), then `2^k ≡ 2^r (mod p)` whenever
+`k ≡ r (mod d)` with `r ≤ k`.  This is the core algebraic fact that lets a single
+prime cover a whole residue class of exponents. -/
+theorem two_pow_modEq_of_dvd {p d k r : ℕ} (hd : (2 : ℕ) ^ d ≡ 1 [MOD p])
+    (hle : r ≤ k) (hdvd : d ∣ (k - r)) : (2 : ℕ) ^ k ≡ 2 ^ r [MOD p] := by
+  obtain ⟨t, ht⟩ := hdvd
+  have hk : k = r + d * t := by omega
+  subst hk
+  calc (2 : ℕ) ^ (r + d * t)
+      = 2 ^ r * (2 ^ d) ^ t := by rw [pow_add, pow_mul]
+    _ ≡ 2 ^ r * 1 ^ t [MOD p] := (Nat.ModEq.refl _).mul (hd.pow t)
+    _ = 2 ^ r := by rw [one_pow, mul_one]
+
+/-- **The covering obstruction (general gear).**  Fix a prime `p` and an exponent
+period `d` with `2^d ≡ 1 (mod p)`.  For any exponent `k ≡ r (mod d)` and any `n`
+with `n ≡ 2^r (mod p)`, the prime `p` divides `n - 2^k`; hence if additionally
+`p < n - 2^k` (so the quotient is `> 1`), the complement `n - 2^k` is **composite**.
+This is exactly the step by which one residue class of exponents is eliminated in
+Erdős's construction. -/
+theorem covering_prime_not_prime_sub {p d k r n : ℕ}
+    (hp : Nat.Prime p) (hd : (2 : ℕ) ^ d ≡ 1 [MOD p])
+    (hle : r ≤ k) (hdvd : d ∣ (k - r)) (hn : n ≡ 2 ^ r [MOD p])
+    (hlt : 2 ^ k < n) (hbig : p < n - 2 ^ k) : ¬ Nat.Prime (n - 2 ^ k) := by
+  have hper : (2 : ℕ) ^ k ≡ 2 ^ r [MOD p] := two_pow_modEq_of_dvd hd hle hdvd
+  have hnk : (2 : ℕ) ^ k ≡ n [MOD p] := hper.trans hn.symm
+  have hdvd2 : p ∣ n - 2 ^ k := (Nat.modEq_iff_dvd' hlt.le).mp hnk
+  intro hprime
+  rcases hprime.eq_one_or_self_of_dvd p hdvd2 with h | h
+  · have := hp.two_le; omega
+  · omega
+
+/-- **Concrete gear (prime `3`, even exponents).**  If `n ≡ 1 (mod 3)` then for
+every *even* exponent `k` with `2^k < n` and `n - 2^k > 3`, the complement `n - 2^k`
+is composite (since `2^k ≡ 1 (mod 3)` for even `k`, so `3 ∣ n - 2^k`).  Thus in the
+progression `n ≡ 1 (mod 3)` no even exponent can witness a Romanoff representation. -/
+theorem not_prime_sub_even_mod_three {n k : ℕ}
+    (hn : n % 3 = 1) (hk : Even k) (hlt : 2 ^ k < n) (hbig : 3 < n - 2 ^ k) :
+    ¬ Nat.Prime (n - 2 ^ k) := by
+  obtain ⟨m, hm⟩ := hk
+  refine covering_prime_not_prime_sub (p := 3) (d := 2) (r := 0)
+    (by norm_num) (by decide) (Nat.zero_le k) ⟨m, by omega⟩ ?_ hlt hbig
+  show n % 3 = 2 ^ 0 % 3
+  norm_num [hn]
+
+/-- **Concrete gear (prime `7`, exponents `≡ 0 mod 3`).**  If `n ≡ 1 (mod 7)` then
+for every exponent `k` divisible by `3` with `2^k < n` and `n - 2^k > 7`, the
+complement `n - 2^k` is composite (the order of `2` mod `7` is `3`, so `2^k ≡ 1
+(mod 7)`, giving `7 ∣ n - 2^k`).  A second prime covering a *different* class of
+exponents, demonstrating the mechanism is not special to `p = 3`. -/
+theorem not_prime_sub_mod_seven {n k : ℕ}
+    (hn : n % 7 = 1) (hk : k % 3 = 0) (hlt : 2 ^ k < n) (hbig : 7 < n - 2 ^ k) :
+    ¬ Nat.Prime (n - 2 ^ k) := by
+  refine covering_prime_not_prime_sub (p := 7) (d := 3) (r := 0)
+    (by norm_num) (by decide) (Nat.zero_le k) ⟨k / 3, by omega⟩ ?_ hlt hbig
+  show n % 7 = 2 ^ 0 % 7
+  norm_num [hn]
+
+/-
 ## Summary
 
 **Problem Status: SOLVED (Disproved)**

--- a/research/problems/erdos-16-wip-01/knowledge.md
+++ b/research/problems/erdos-16-wip-01/knowledge.md
@@ -85,3 +85,36 @@ Built on the 18 merged theorems. Added 5 axiom-free theorems + 1 instance
 
 Meta synced: theoremCount 18→23, definitionCount 10→11, lineCount 337→395. Deep
 results (Romanoff 1934, Erdős 1950 covering, Chen 2023) remain documented-only.
+
+## Session note (2026-07-20, researcher-1, session 4): covering-congruence obstruction mechanism
+
+Instead of adding more A006285 terms (enumeration theater — the per-`k` refutation
+technique was already at 4 terms), this session formalized the **structural mechanism**
+behind Erdős's 1950 covering-congruence argument. 5 new axiom-free theorems
+(host-verified, Lean v4.31.0, `#print axioms` = propext/Classical.choice/Quot.sound):
+
+- **`two_pow_mod_three`** — `2^k % 3 = if k % 2 = 0 then 1 else 2` (order of 2 mod 3
+  is 2). The smallest gear; proved by induction with an omega-driven parity split.
+- **`two_pow_modEq_of_dvd`** — the algebraic core: `2^d ≡ 1 [MOD p]` ∧ `d ∣ (k−r)`
+  (with `r ≤ k`) ⟹ `2^k ≡ 2^r [MOD p]`. Proof writes `k = r + d·t` and uses
+  `(2^d)^t ≡ 1^t`. This is exponent-periodicity of 2 mod p — the fact that lets one
+  prime cover an entire residue class of exponents.
+- **`covering_prime_not_prime_sub`** — the general obstruction gear: given a prime
+  `p` with `2^d ≡ 1 [MOD p]`, an exponent `k ≡ r (mod d)`, and `n ≡ 2^r (mod p)`,
+  then `p ∣ n − 2^k`; hence `n − 2^k` is **composite** whenever `p < n − 2^k`.
+  This is exactly the step that eliminates one whole residue class of exponents in
+  Erdős's construction (vs. the earlier one-`k`-at-a-time A006285 checks).
+- **`not_prime_sub_even_mod_three`** — concrete gear (prime 3, order 2): for
+  `n ≡ 1 (mod 3)`, every even exponent `k` with `n − 2^k > 3` gives a composite
+  complement. So no even exponent witnesses a Romanoff representation of such `n`.
+- **`not_prime_sub_mod_seven`** — concrete gear (prime 7, order 3): for
+  `n ≡ 1 (mod 7)`, every exponent `k ≡ 0 (mod 3)` with `n − 2^k > 7` gives a
+  composite complement. A second, different prime — the mechanism is general.
+
+Meta synced: theoremCount 23→28, lineCount 395→479. **Remaining deep step** (still
+documented-only): CRT-assemble the individual gears over a full covering system of
+the exponent (moduli 2,3,4,6,8,12,24 with primes whose order of 2 matches) to force
+an infinite arithmetic progression of `n` into the exceptional set — this would
+formalize Erdős 1950 itself. It needs the order-of-2 facts for primes 5,13,17,241
+plus a CRT packaging, but **no analytic number theory** — a tractable (if sizable)
+future BUILD. Romanoff 1934 density and Chen 2023 disproof remain analytic/deep.

--- a/src/data/proofs/erdos-16/meta.json
+++ b/src/data/proofs/erdos-16/meta.json
@@ -45,10 +45,10 @@
         "relationship": "Both are solved Erdős problems in analytic number theory with density/measure-theoretic conclusions"
       }
     ],
-    "lineCount": 395,
-    "assumptions": "This file states the problem (definitions IsRomanoff, ExceptionalSet, density, lowerDensity, IsCoveringSystem, ErdosConjecture16, erdosCovering, and the related Props Erdos9/10/11Question) and proves 13 axiom-free foundational lemmas about those definitions. It contains 0 axioms and 0 sorries. The deep results (Romanoff 1934 positive density, Erdos 1950 covering construction, Chen 2023 disproof) require analytic number theory beyond current Mathlib and remain described in doc-comments only, NOT formalized as theorems or axioms. The formalized lemmas are elementary structural facts: the Romanoff floor (2^k+p >= 4), concrete Romanoff witnesses (5=2+3, 7=4+3), membership of 1 and 3 in the exceptional set, the 0<=density<=1 range, and a full machine-checked proof that the explicit Erdos covering system {0 mod 2, 0 mod 3, 1 mod 4, 1 mod 6, 3 mod 8, 7 mod 12, 23 mod 24} genuinely covers the integers. Session 3 adds a finite-range refinement isRomanoff_iff_mem_range (the witness exponent lies in Finset.range n since 2^k<n forces k<2^k<n), a Decidable (IsRomanoff n) instance derived from it (kernel reduction only, no native_decide), and two further A006285 terms proved exceptional: 251 (249=3·83, 247=13·19, 243=3^5, 235=5·47, 219=3·73, 187=11·17, 123=3·41 all composite) and 331 (329=7·47, 327=3·109, 323=17·19, 315=5·63, 299=13·23, 267=3·89, 203=7·29, 75=3·25 all composite). Still 0 axioms, 0 sorries.",
+    "lineCount": 479,
+    "assumptions": "This file states the problem (definitions IsRomanoff, ExceptionalSet, density, lowerDensity, IsCoveringSystem, ErdosConjecture16, erdosCovering, and the related Props Erdos9/10/11Question) and proves 13 axiom-free foundational lemmas about those definitions. It contains 0 axioms and 0 sorries. The deep results (Romanoff 1934 positive density, Erdos 1950 covering construction, Chen 2023 disproof) require analytic number theory beyond current Mathlib and remain described in doc-comments only, NOT formalized as theorems or axioms. The formalized lemmas are elementary structural facts: the Romanoff floor (2^k+p >= 4), concrete Romanoff witnesses (5=2+3, 7=4+3), membership of 1 and 3 in the exceptional set, the 0<=density<=1 range, and a full machine-checked proof that the explicit Erdos covering system {0 mod 2, 0 mod 3, 1 mod 4, 1 mod 6, 3 mod 8, 7 mod 12, 23 mod 24} genuinely covers the integers. Session 3 adds a finite-range refinement isRomanoff_iff_mem_range (the witness exponent lies in Finset.range n since 2^k<n forces k<2^k<n), a Decidable (IsRomanoff n) instance derived from it (kernel reduction only, no native_decide), and two further A006285 terms proved exceptional: 251 (249=3·83, 247=13·19, 243=3^5, 235=5·47, 219=3·73, 187=11·17, 123=3·41 all composite) and 331 (329=7·47, 327=3·109, 323=17·19, 315=5·63, 299=13·23, 267=3·89, 203=7·29, 75=3·25 all composite). Still 0 axioms, 0 sorries. Session 4 formalizes the covering-congruence OBSTRUCTION mechanism behind Erdos's 1950 argument (5 new axiom-free theorems, still 0 axioms/0 sorries): two_pow_mod_three (order of 2 mod 3 is 2: 2^k%3 = 1 if k even else 2), two_pow_modEq_of_dvd (the core algebraic gear: if 2^d = 1 mod p and k = r mod d then 2^k = 2^r mod p), covering_prime_not_prime_sub (the general obstruction: given a prime p with 2^d = 1 mod p, an exponent k = r mod d, and n = 2^r mod p, then p divides n-2^k, so n-2^k is composite whenever it exceeds p — this is exactly how one residue class of exponents is eliminated), and two concrete gears not_prime_sub_even_mod_three (prime 3 kills even exponents for n = 1 mod 3) and not_prime_sub_mod_seven (prime 7 kills exponents divisible by 3 for n = 1 mod 7). Assembling all gears over a full covering system into a single arithmetic progression via CRT remains the deep step (documented only).",
     "mathlib_version": "4.31.0",
-    "theoremCount": 23,
+    "theoremCount": 28,
     "definitionCount": 11
   },
   "overview": {
@@ -189,10 +189,10 @@
       "BigOperators"
     ],
     "namespace": "Erdos16",
-    "lineCount": 337,
+    "lineCount": 479,
     "axiomCount": 0,
-    "theoremCount": 18,
-    "definitionCount": 10,
+    "theoremCount": 28,
+    "definitionCount": 11,
     "path": "Proofs/Erdos16Problem.lean",
     "sorries": 0
   },

--- a/src/data/research/problems/erdos-16-wip-01.json
+++ b/src/data/research/problems/erdos-16-wip-01.json
@@ -20,10 +20,10 @@
   "currentState": {
     "phase": "ACT",
     "since": "2026-07-09T17:33:18-07:00",
-    "iteration": 1,
-    "focus": "Initial problem understanding. Read problem.md and gather context.",
+    "iteration": 4,
+    "focus": "Session 4: formalized the covering-congruence obstruction mechanism (Erdős 1950 gear + 2 concrete instances).",
     "blockers": [],
-    "nextAction": "Deep results (Romanoff 1934 density, Erdős 1950 covering-progression, Chen 2023 disproof) need analytic number theory absent from Mathlib; remaining tractable work is further A006285 verification (via decide for small n or interval_cases) and possibly a lowerDensity monotonicity/containment lemma.",
+    "nextAction": "CRT-assemble the individual covering gears over a full covering system of the exponent to force an infinite arithmetic progression into the exceptional set (formalizing Erdős 1950). Needs order-of-2 facts for primes 5,13,17,241 and CRT packaging — substantial but analytic-free.",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -31,7 +31,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Erdos16Problem.lean — added finite-range characterization isRomanoff_iff_mem_range + Decidable (IsRomanoff n) instance (kernel-only, axiom-clean infrastructure), and proved A006285 terms 251 and 331 exceptional. 23 theorems + 11 defs/instances, 0 sorry, 0 axiom; #print axioms clean on all new results.",
+    "progressSummary": "PROGRESS: Erdos16Problem.lean — session 4 formalized the Erdős 1950 covering-congruence OBSTRUCTION mechanism (the actual math, not more A006285 enumeration): general gear covering_prime_not_prime_sub (prime p with 2^d≡1 mod p kills exponent class k≡r mod d for n≡2^r mod p, since p∣n−2^k), its algebraic core two_pow_modEq_of_dvd, two_pow_mod_three, and two concrete gears (primes 3 and 7). 28 theorems + 11 defs/instances, 0 sorry, 0 axiom; #print axioms clean on all new results. Remaining deep step: CRT-assemble gears over a full covering system to get the infinite AP (needs orders of 2 mod 5,13,17,241 + CRT, no analytic input).",
     "builtItems": [
       "isRomanoff_four_le, not_isRomanoff_one/three, one/three_mem_exceptionalSet in Erdos16Problem.lean",
       "isRomanoff_five, isRomanoff_seven, five_not_mem_exceptionalSet in Erdos16Problem.lean",
@@ -43,7 +43,8 @@
       "isRomanoff_iff_mem_range (bounded existential over Finset.range n) in Erdos16Problem.lean",
       "decidableIsRomanoff : Decidable (IsRomanoff n) instance in Erdos16Problem.lean",
       "not_isRomanoff_251 / twoHundredFiftyOne_mem_exceptionalSet in Erdos16Problem.lean",
-      "not_isRomanoff_331 / threeHundredThirtyOne_mem_exceptionalSet in Erdos16Problem.lean"
+      "not_isRomanoff_331 / threeHundredThirtyOne_mem_exceptionalSet in Erdos16Problem.lean",
+      "two_pow_mod_three, two_pow_modEq_of_dvd, covering_prime_not_prime_sub, not_prime_sub_even_mod_three, not_prime_sub_mod_seven in Proofs/Erdos16Problem.lean (session 4, axiom-free)"
     ],
     "insights": [
       "Erdos16 file was a definitions-only stub (10 defs, 0 theorems). The deep results (Romanoff density, Erdos covering-progression, Chen 2023 disproof) need analytic NT beyond Mathlib; the tractable axiom-free content is elementary structural facts about the file's own defs.",
@@ -53,10 +54,16 @@
       "Concrete exceptional numbers (127, 149) are host-verifiable axiom-free: bound k via 2^(K+1)>n (by_contra + Nat.pow_le_pow_right), then interval_cases k and norm_num refutes Prime(n−2^k) for each residue.",
       "isRomanoff_iff can be refined to a bounded search: 2^k<n forces k<2^k<n, so the witness exponent lies in Finset.range n. This makes IsRomanoff decidable (decidableIsRomanoff instance) by kernel reduction only — no native_decide, axioms stay [propext, Classical.choice, Quot.sound].",
       "decide over Finset.range n is impractical for the A006285 exceptional terms (>250) because the kernel would evaluate 2^{n-1} and hit the exponentiation threshold / recursion depth; the explicit interval_cases refutations (bounding k≤log2 n) keep 2^k small and are the robust route for specific numbers.",
-      "251 and 331 are the 3rd and 4th nontrivial A006285 terms; both proved exceptional by the isRomanoff_iff + interval_cases pattern (all complements n−2^k composite)."
+      "251 and 331 are the 3rd and 4th nontrivial A006285 terms; both proved exceptional by the isRomanoff_iff + interval_cases pattern (all complements n−2^k composite).",
+      "Erdős 1950 covering mechanism formalized as a reusable gear (covering_prime_not_prime_sub): for a prime p with 2^d ≡ 1 (mod p), any exponent k ≡ r (mod d) and any n ≡ 2^r (mod p) satisfy p ∣ n − 2^k, so n − 2^k is composite once it exceeds p. This eliminates a whole residue class of exponents at once — the structural upgrade over per-k A006285 checks.",
+      "Core algebraic lemma two_pow_modEq_of_dvd: 2^d ≡ 1 (mod p) ∧ k ≡ r (mod d) ⟹ 2^k ≡ 2^r (mod p), proved by writing k = r + d·t and using (2^d)^t ≡ 1. This is exponent-periodicity of 2 modulo p — the fact that makes one prime cover an arithmetic progression of exponents.",
+      "Two concrete covering gears verified: prime 3 (order 2) kills even exponents for n ≡ 1 (mod 3); prime 7 (order 3) kills exponents ≡ 0 (mod 3) for n ≡ 1 (mod 7). Demonstrates the general lemma is not specialized to a single prime."
     ],
     "mathlibGaps": [],
-    "nextSteps": [],
+    "nextSteps": [
+      "Assemble the individual covering gears over a full covering system of the exponent (moduli 2,3,4,6,8,12,24 → primes with matching orders of 2) and use CRT to produce a single arithmetic progression of n all of whose exponents are covered — this would formalize Erdős 1950 (exceptional set contains an infinite AP). Blocker: needs the order-of-2 facts for primes 5,13,17,241 and a CRT packaging; substantial but no analytic input required.",
+      "Prove lowerDensity monotonicity/containment lemmas (density A ≤ density B when A ⊆ B) as further axiom-free density infrastructure."
+    ],
     "markdown": "# Knowledge Base: erdos-16-wip-01\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },
   "tags": [


### PR DESCRIPTION
## Summary
Research session 4 for **erdos-16-wip-01** (Erdős Problem #16: odd integers not of the form 2^k + p). Rather than adding more OEIS A006285 terms (per-`k` enumeration, already at 4 terms and flagged as theater), this session formalizes the **structural mechanism** behind Erdős's 1950 covering-congruence argument.

## Progress
5 new axiom-free theorems in `proofs/Proofs/Erdos16Problem.lean` (Lean v4.31.0, `#print axioms` = propext/Classical.choice/Quot.sound on all):

- **`two_pow_mod_three`** — order of 2 mod 3 is 2 (`2^k % 3 = 1` if `k` even else `2`).
- **`two_pow_modEq_of_dvd`** — exponent-periodicity core: `2^d ≡ 1 (mod p)` ∧ `k ≡ r (mod d)` ⟹ `2^k ≡ 2^r (mod p)`. This is the fact that lets one prime cover an entire residue class of exponents.
- **`covering_prime_not_prime_sub`** — the general obstruction gear: a prime `p` with `2^d ≡ 1 (mod p)` eliminates the exponent class `k ≡ r (mod d)` for any `n ≡ 2^r (mod p)`, since `p ∣ n − 2^k`, so `n − 2^k` is composite once it exceeds `p`.
- **`not_prime_sub_even_mod_three`** / **`not_prime_sub_mod_seven`** — two concrete gears (primes 3 and 7) instantiating the general lemma, demonstrating it is not special to a single prime.

## Findings
- The covering-congruence engine reduces to elementary modular arithmetic — no analytic number theory. The obstruction gear turns "n − 2^k is composite" for a whole residue class of exponents into a two-line divisibility argument.
- **Remaining deep step** (documented only): CRT-assemble the individual gears over a full covering system of the exponent (moduli 2,3,4,6,8,12,24 with primes whose order of 2 matches) to force an infinite arithmetic progression into the exceptional set — this would formalize Erdős 1950 itself. Needs the order-of-2 facts for primes 5,13,17,241 plus CRT packaging; sizable but analytic-free.
- Romanoff 1934 (positive density) and Chen 2023 (disproof) remain genuinely analytic/deep and stay documented-only.

## Files Modified
- `proofs/Proofs/Erdos16Problem.lean` (23→28 theorems, 395→479 lines, still 0 axioms / 0 sorries)
- `src/data/proofs/erdos-16/meta.json` (counts + assumptions synced)
- `src/data/research/problems/erdos-16-wip-01.json` (insights, builtItems, nextSteps)
- `research/problems/erdos-16-wip-01/knowledge.md` (session 4 note)

## Status
**Outcome**: progress (structural — covering mechanism formalized on the critical path toward Erdős 1950)
**Next Steps**: CRT-assemble the gears over a full covering system to formalize the infinite-AP result; add lowerDensity monotonicity lemmas.

🤖 Generated by researcher-1