### PR TITLE
Enrich chebyshev-bounds-oq-03-oq-02 (ψ−θ = O(√x)): sections 3→5 (96→100)

### DIFF
--- a/src/data/proofs/chebyshev-bounds-oq-03-oq-02/meta.json
+++ b/src/data/proofs/chebyshev-bounds-oq-03-oq-02/meta.json
@@ -97,17 +97,33 @@
   },
   "sections": [
     {
-      "id": "decay-lemmas",
-      "title": "Section I: The log-Eating Decay Bounds",
+      "id": "overview-setup",
+      "title": "Overview, Imports & Setup",
+      "startLine": 1,
+      "endLine": 54,
+      "summary": "Imports (Mathlib's Chebyshev API and rpow asymptotics) and module docstring: the parent chebyshev-bounds-oq-03 proves ψ ∼ θ via Mathlib's |ψ−θ| ≤ 2√x·log x, which carries a spurious log x factor that Mathlib's own comment flags as removable; this file carries out that careful argument to answer the parent's second open question, ψ−θ = O(√x) with no log. Lays out the proof architecture — from ψ−θ = Σ_{n=2}^{K} θ(x^{1/n}), peel the dominant n=2 term and control the n≥3 tail by the decay bound log x ≤ 6·x^{1/6}. Opens the ChebyshevBoundsOQ03OQ02 namespace with Filter / Asymptotics / Finset / Chebyshev / Topology.",
+      "mathContext": "Parent: $|\\psi(x)-\\theta(x)| \\le 2\\sqrt x\\log x$; goal here: $\\psi(x)-\\theta(x)=O(\\sqrt x)$ (no $\\log$)."
+    },
+    {
+      "id": "decay-lemma-log-rpow",
+      "title": "Section I·a: log x ≤ 6·x^{1/6}",
       "startLine": 55,
-      "endLine": 74,
-      "summary": "log_le_six_mul_rpow (log x ≤ 6·x^{1/6}, from Real.log_le_rpow_div at ε = 1/6) and logx_mul_rpow_third_le (log x·x^{1/3} ≤ 6·√x, using x^{1/6}·x^{1/3} = x^{1/2}).",
-      "mathContext": "The single analytic input — the logarithm grows slower than x^{1/6} — repackaged so that the tail's log·x^{1/3} collapses to a bare √x."
+      "endLine": 60,
+      "summary": "log_le_six_mul_rpow: the elementary decay bound log x ≤ 6·x^{1/6} for x > 0, the special case of Real.log_le_rpow_div at exponent ε = 1/6 (log x ≤ x^ε/ε with ε = 1/6). This is the single analytic input of the whole file — the logarithm grows slower than any positive power.",
+      "mathContext": "$\\log x \\le x^{1/6}/(1/6) = 6\\,x^{1/6}$ for $x>0$."
+    },
+    {
+      "id": "decay-lemma-log-eating",
+      "title": "Section I·b: log x · x^{1/3} ≤ 6·√x",
+      "startLine": 61,
+      "endLine": 73,
+      "summary": "logx_mul_rpow_third_le: the log-eating step, log x · x^{1/3} ≤ 6·√x for x > 0. Substitutes the previous bound and collapses the powers via x^{1/6}·x^{1/3} = x^{1/6+1/3} = x^{1/2} = √x (Real.rpow_add, Real.sqrt_eq_rpow). This is what turns the tail's log·x^{1/3} into a bare √x, removing the parent's spurious log factor.",
+      "mathContext": "$\\log x\\cdot x^{1/3} \\le 6\\,x^{1/6}\\cdot x^{1/3} = 6\\,x^{1/2} = 6\\sqrt x$."
     },
     {
       "id": "explicit-bound",
       "title": "Section II: ψ − θ ≤ (log 4 + 12)·√x",
-      "startLine": 76,
+      "startLine": 74,
       "endLine": 145,
       "summary": "psi_sub_theta_le_const_mul_sqrt: from ψ − θ = Σ_{n=2}^{K} θ(x^{1/n}), peel the n = 2 term (θ(√x) ≤ log 4·√x) and bound the n ≥ 3 tail by 12·√x via x^{1/n} ≤ x^{1/3} and the decay lemma.",
       "mathContext": "The explicit-constant O(√x) bound on the prime-power correction, with the log factor removed."


### PR DESCRIPTION
Enrichment pass for `chebyshev-bounds-oq-03-oq-02` (removing the spurious log factor: the prime-power correction is O(√x)).

**Sections 3 → 5, now covering the full file [1,155]:**
- Added an **Overview, Imports & Setup** header section [1,54] covering the previously uncovered imports and docstring (the parent's log-carrying |ψ−θ| ≤ 2√x·log x bound, Mathlib's own note that the log is removable, and the peel-the-n=2-term proof architecture) plus the namespace/open block.
- Split the lumped decay-bounds section [55,74] into **Section I·a: log x ≤ 6·x^{1/6}** [55,60] and **Section I·b: log x · x^{1/3} ≤ 6·√x** [61,73], the two distinct lemmas.

No content deleted; summaries accurate to the Lean source. File 14 KB. Key insights already at 5; axiom integrity unchanged (verified / 0 axioms).