### PR TITLE
Research: erdos-326-wip-01 — perfect squares as a concrete order-4 additive basis

### DIFF
--- a/proofs/Proofs/Erdos326WIP01.lean
+++ b/proofs/Proofs/Erdos326WIP01.lean
@@ -19,6 +19,8 @@ ratio and its limit:
 * order monotonicity `IsAddBasisOfOrder A k → k ≤ k' → IsAddBasisOfOrder A k'`
   and set monotonicity under `⊆`, for both `IsAddBasisOfOrder` and `IsAddBasis`;
 * `Set.univ` is an order-1 basis; the empty set and order 0 are never bases;
+* the perfect squares are a concrete additive basis of **order 4** (Lagrange's
+  four-square theorem) — the canonical non-vacuous witness for the predicate;
 * `growthRatio` is nonnegative, `growthRatio b 0 = 0`;
 * the growth limit is unique, and existence of a limit contradicts
   `HasNoGrowthLimit`.
@@ -94,6 +96,27 @@ theorem not_isAddBasisOfOrder_zero (A : Set ℕ) : ¬ IsAddBasisOfOrder A 0 := b
   subst hm0
   simp only [Fin.sum_univ_zero] at hsum
   omega
+
+/-! ## A concrete basis: the perfect squares (Lagrange) -/
+
+/-- The set of perfect squares `{0, 1, 4, 9, …}`. -/
+def Squares : Set ℕ := { n : ℕ | ∃ m : ℕ, n = m ^ 2 }
+
+/-- **The perfect squares form an additive basis of order `4`.**  This is
+Lagrange's four-square theorem (`Nat.sum_four_squares`): *every* natural number
+is a sum of at most four squares.  It is the canonical concrete witness that the
+`IsAddBasisOfOrder` predicate is non-vacuous, and the running example behind
+Erdős #326 (whose growth question concerns order-`2` bases). -/
+theorem isAddBasisOfOrder_squares_four : IsAddBasisOfOrder Squares 4 := by
+  refine ⟨0, fun n _ => ?_⟩
+  obtain ⟨a, b, c, d, habcd⟩ := Nat.sum_four_squares n
+  refine ⟨4, le_refl 4, ![a ^ 2, b ^ 2, c ^ 2, d ^ 2], ?_, ?_⟩
+  · intro i; fin_cases i <;> exact ⟨_, rfl⟩
+  · rw [Fin.sum_univ_four]; simpa using habcd
+
+/-- The perfect squares form an additive basis (of some finite order). -/
+theorem isAddBasis_squares : IsAddBasis Squares :=
+  isAddBasisOfOrder_squares_four.isAddBasis
 
 /-! ## The growth ratio and its limit -/
 

--- a/src/data/research/problems/erdos-326-wip-01.json
+++ b/src/data/research/problems/erdos-326-wip-01.json
@@ -27,7 +27,7 @@
   "currentState": {
     "phase": "ORIENT",
     "since": "2026-07-20T13:00:00-07:00",
-    "iteration": 1,
+    "iteration": 2,
     "focus": "Axiom-free foundational lemmas on IsAddBasis / IsAddBasisOfOrder / growthRatio.",
     "blockers": [
       {
@@ -44,27 +44,29 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Created Proofs/Erdos326WIP01.lean (12 theorems, 0 sorry / 0 axiom, VERIFIED axiom-free [propext, Classical.choice, Quot.sound]). Established the elementary order theory and growth-ratio facts for the additive-basis predicates: order/set monotonicity of IsAddBasisOfOrder and set monotonicity of IsAddBasis, ℕ as an order-1 basis, ∅ and order-0 never bases, growthRatio nonneg / =0 at k=0, growth-limit uniqueness, and the HasNoGrowthLimit unfolding. The deep oscillation content is untouched.",
+    "progressSummary": "PROGRESS: Erdos326WIP01.lean — session 2 added the perfect squares as a concrete additive basis of ORDER 4 (Squares, isAddBasisOfOrder_squares_four via Lagrange Nat.sum_four_squares, isAddBasis_squares). First non-vacuous instance of IsAddBasisOfOrder, complementing the existing monotonicity/extremal-case order theory. 14 theorems + 1 def, 0 sorry / 0 axiom, #print axioms clean [propext, Classical.choice, Quot.sound]. Deep oscillation/growth content (the open order-2 sub-basis question) untouched.",
     "builtItems": [
       "IsAddBasisOfOrder.mono_order / .mono_set in Erdos326WIP01.lean",
       "IsAddBasis.mono",
       "isAddBasisOfOrder_univ_one, isAddBasis_univ",
       "not_isAddBasis_empty, not_isAddBasisOfOrder_zero",
       "growthRatio_nonneg, growthRatio_zero",
-      "HasGrowthLimit.unique, HasGrowthLimit.not_hasNoGrowthLimit, hasNoGrowthLimit_iff"
+      "HasGrowthLimit.unique, HasGrowthLimit.not_hasNoGrowthLimit, hasNoGrowthLimit_iff",
+      "Squares (the set {m^2}), isAddBasisOfOrder_squares_four, isAddBasis_squares in Erdos326WIP01.lean (session 2, axiom-free [propext, Classical.choice, Quot.sound])"
     ],
     "insights": [
       "The basis predicates form a monotone lattice: raising the order or enlarging the set preserves the basis property — the atomic order theory underlying any basis-comparison argument.",
       "Order 0 and the empty set are degenerate non-bases (only 0 is representable), so all substantive work happens at order ≥ 1 with an infinite set.",
-      "growthRatio b 0 = 0 by the ℝ junk convention x/0 = 0 — worth pinning so downstream limit arguments can ignore the k=0 term."
+      "growthRatio b 0 = 0 by the ℝ junk convention x/0 = 0 — worth pinning so downstream limit arguments can ignore the k=0 term.",
+      "The perfect squares are a concrete additive basis of order 4 (Lagrange four-square theorem, Nat.sum_four_squares) — the canonical non-vacuous witness for IsAddBasisOfOrder. Order 4 is the correct order: numbers of the form 4^a(8b+7) (e.g. 7,15,23,28) are never sums of three squares, so squares are not an order-3 basis (that stronger negative needs Legendre three-square, deeper)."
     ],
     "mathlibGaps": [
       "No packaged bₖ = O(k²) bound for order-2 additive bases; would need a density-counting argument (|A ∩ [0,n]| ≥ c√n) not currently in Mathlib."
     ],
     "nextSteps": [
-      "Perfect squares as a concrete order-4 basis via Nat.sum_four_squares (Lagrange).",
-      "The bₖ = O(k²) upper bound for order-2 bases.",
-      "Relate HasGrowthLimit to boundedness of the enumeration."
+      "The b_k = O(k^2) upper bound for order-2 bases (relate the increasing enumeration to a counting/pigeonhole argument).",
+      "Show squares are NOT an order-3 basis via the infinitude of 4^a(8b+7) (needs Legendre three-square theorem — check Mathlib availability).",
+      "Relate HasGrowthLimit to boundedness/monotone behaviour of the enumeration b."
     ],
     "markdown": "# Knowledge Base: erdos-326-wip-01\n\n## Session 2026-07-20 (researcher-1) — foundational additive-basis / growth-ratio scaffolding\n\n**Mode**: FRESH (EMPTY node). **Outcome**: progress — VERIFIED axiom-free (`[propext, Classical.choice, Quot.sound]`), 0 sorry / 0 axiom. Host-verified (Mathlib-only parent): fresh-built `Erdos326Problem.olean` then `lake env lean` on the child (no Docker).\n\n### What I did\nCreated `proofs/Proofs/Erdos326WIP01.lean` (12 theorems) on the additive-basis predicates and the growth ratio:\n- **Monotonicity**: `IsAddBasisOfOrder.mono_order` (raise the order), `IsAddBasisOfOrder.mono_set` and `IsAddBasis.mono` (enlarge the set).\n- **Extremal cases**: `isAddBasisOfOrder_univ_one` / `isAddBasis_univ` (`ℕ` is an order-1 basis); `not_isAddBasis_empty`, `not_isAddBasisOfOrder_zero`.\n- **Growth ratio**: `growthRatio_nonneg`, `growthRatio_zero`, `HasGrowthLimit.unique`, `HasGrowthLimit.not_hasNoGrowthLimit`, `hasNoGrowthLimit_iff`.\n\n### Key findings\n- The basis predicates form a monotone lattice in (order, set) — the atomic order theory for any basis-comparison argument.\n- Order 0 / the empty set are degenerate non-bases; substantive work is at order ≥ 1.\n\n### Reusable Lean recipe\n- Destructure the order predicate: `obtain ⟨N, hN⟩ := h; obtain ⟨m, hm, f, hf, hsum⟩ := hN n hn` (the `(_ : m ≤ k)` binder appears as `hm`).\n- Degenerate non-basis: pick `n = N+1`, split `Nat.eq_zero_or_pos k`; the `k=0` branch closes via `simp only [Fin.sum_univ_zero] at hsum; omega`, the `k>0` branch via `(Set.mem_empty_iff_false _).mp (hf ⟨0, hk⟩)`.\n- `growthRatio b 0 = 0`: `unfold growthRatio; simp` (`x/0 = 0`).\n- Limit uniqueness: `tendsto_nhds_unique` (atTop on ℕ is `NeBot`).\n\n### Next steps\n- Perfect squares as an order-4 basis (`Nat.sum_four_squares`).\n- The `bₖ = O(k²)` bound for order-2 bases.\n\n### Still open (unchanged)\nThe subset-basis oscillation question (Erdős #326) — deep; Cassels (1957) disproved only the `A = B` variant.\n"
   },


### PR DESCRIPTION
## Summary
Research session for **erdos-326-wip-01** (Erdős #326: additive bases and non-convergent subsequences). Adds the first **non-vacuous concrete instance** of the `IsAddBasisOfOrder` predicate to `Erdos326WIP01.lean`, complementing the previously-merged monotonicity/extremal-case order theory (12 lemmas).

## Progress
- **`Squares : Set ℕ`** — the set of perfect squares `{m^2}`.
- **`isAddBasisOfOrder_squares_four : IsAddBasisOfOrder Squares 4`** — the perfect squares are an additive basis of order 4, via Lagrange's four-square theorem (`Nat.sum_four_squares`): every natural number is a sum of at most four squares.
- **`isAddBasis_squares : IsAddBasis Squares`** — corollary.

## Findings
- Order 4 is the *correct* order for the squares: numbers of the form `4^a(8b+7)` (7, 15, 23, 28, …) are never sums of three squares, so the squares are genuinely not an order-3 basis. Formalizing that negative would need Legendre's three-square theorem (deeper — noted as a next step).
- This gives the file a real, classical witness that the basis predicate is inhabited, which the doc-comment referenced (Lagrange) but had not yet formalized.

## Files Modified
- `proofs/Proofs/Erdos326WIP01.lean` (12→14 theorems, +1 def, still 0 axioms / 0 sorries; `#print axioms` = propext/Classical.choice/Quot.sound)
- `src/data/research/problems/erdos-326-wip-01.json` (insights, builtItems, nextSteps)

## Status
**Outcome**: progress (concrete instance on the basis side; deep order-2 sub-basis oscillation question remains open)
**Next Steps**: `b_k = O(k²)` bound for order-2 bases; squares-not-order-3 via Legendre; relate `HasGrowthLimit` to enumeration boundedness.

🤖 Generated by researcher-1