### PR TITLE
Enrich Non-Euclidean Pappus–Brianchon hexagon algebra: full-file section coverage

### DIFF
--- a/src/data/proofs/cevas-theorem-non-euclidean-oq-03/meta.json
+++ b/src/data/proofs/cevas-theorem-non-euclidean-oq-03/meta.json
@@ -58,6 +58,14 @@
   },
   "sections": [
     {
+      "id": "setup",
+      "title": "Docstring, imports, and the GeneralizedCevianConfig framework",
+      "startLine": 1,
+      "endLine": 60,
+      "summary": "The module docstring frames the research goal (approach non-Euclidean Pappus–Brianchon via the parent's abstract configuration) and states the honest scope: this file formalizes the geometry-independent hexagon ratio invariant, not the full projective incidence theorem. It recalls the parent CevasTheoremNonEuclidean, whose GeneralizedCevianConfig packages six positive 'measures' bd,dc,ce,ea,af,fb with the geometry-independent Ceva product P(cfg) = (bd/dc)(ce/ea)(af/fb), and observes that those six measures are exactly the six sides of the Pappus hexagon (vertices alternating on two geodesics — a degenerate conic). Imports the parent (source of GeneralizedCevianConfig, generalizedCevaProduct, and the spherical/hyperbolic measure builders) and Mathlib.Tactic (field_simp, positivity, ring), then opens the CevaNonEuclideanOQ03 namespace.",
+      "mathContext": "Parent: $P(\\mathrm{cfg}) = \\frac{bd}{dc}\\cdot\\frac{ce}{ea}\\cdot\\frac{af}{fb}$ over six positive measures; $P = 1$ is the geometry-independent concurrence condition, the measures being the six sides of the Pappus hexagon."
+    },
+    {
       "id": "dual-product",
       "title": "The dual product and the hexagon closure relation",
       "startLine": 61,


### PR DESCRIPTION
## Enrichment pass for `cevas-theorem-non-euclidean-oq-03`

The entry was already at-target on annotations (5 full), `keyInsights` (5), `historicalContext`, `conclusion`, and cross-references. The one genuine gap was **section coverage**: the `sections` array started at line 61, leaving lines 1–60 — the substantive 54-line module docstring plus imports and namespace — uncovered.

### Change
- Added a `setup` section (lines 1–60) summarizing the docstring's framing (the parent's `GeneralizedCevianConfig`, the six positive measures as the six sides of the Pappus hexagon, and the honest scope note that this formalizes the geometry-independent ratio invariant rather than the full projective incidence theorem), the imports, and the namespace.
- `sections` now span the full 174-line Lean file with no gap: (1–60), (61–98), (100–152), (154–174).

### Verification
- meta.json valid JSON; 16.7 KB (well under the ~60 KB cap).
- Section line ranges and `theoremCount: 3→8`/`lineCount: 174` cross-checked against the Lean file — no drift.
- `axiomCount: 0`/`status: verified` confirmed consistent with the source (`#print axioms` note is honest: only propext/Classical.choice/Quot.sound; positivity fields are ordinary hypotheses, not encoded axioms).
- `pnpm build` data-manifest + search-index validation passed; only the trailing `tsc` typecheck fails, due to `node_modules` not being installed in this worktree (pre-existing environment gap, unrelated to this JSON change).

No existing content deleted; single targeted addition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)