### PR TITLE
Research: erdos-85-wip-01 — structural C4 lemmas bracketing the extremal question

### DIFF
--- a/proofs/Proofs/Erdos85Problem.lean
+++ b/proofs/Proofs/Erdos85Problem.lean
@@ -201,6 +201,35 @@ theorem C4_adj_three_zero : C4.Adj 3 0 := by simp [C4]
 /-- The "diagonals" of `C₄` are non-edges: `0` and `2` are not adjacent. -/
 theorem C4_not_adj_zero_two : ¬ C4.Adj 0 2 := by simp [C4]
 
+/-- The other diagonal of `C₄` is also a non-edge: `1` and `3` are not adjacent.
+Together with `C4_not_adj_zero_two` this pins down `C₄` exactly: the only edges are
+the four cycle edges. -/
+theorem C4_not_adj_one_three : ¬ C4.Adj 1 3 := by simp [C4]
+
+/-- `C₄` contains a copy of itself (the identity embedding), so `containsC4` is a
+non-vacuous predicate. -/
+theorem containsC4_C4 : containsC4 (Fin 4) C4 :=
+  ⟨id, Function.injective_id, fun _ _ h => h⟩
+
+/-- **A copy of `C₄` needs at least four vertices.** Since `containsC4` supplies an
+injection `Fin 4 ↪ V`, any host graph carrying a `C₄` has `4 ≤ |V|`.  This is the
+necessary size condition behind the degree-threshold question. -/
+theorem containsC4_four_le_card {V : Type*} [Fintype V] {G : SimpleGraph V}
+    (h : containsC4 V G) : 4 ≤ Fintype.card V := by
+  obtain ⟨f, hinj, _⟩ := h
+  simpa using Fintype.card_le_of_injective f hinj
+
+/-- **Complete graphs on `≥ 4` vertices contain a `C₄`.**  Embed `Fin 4 ↪ Fin n`
+by `Fin.castLE`; every cycle edge joins two *distinct* vertices, and in `⊤` all
+distinct vertices are adjacent.  This is the extremal counterpart to
+`starGraph_not_containsC4`: complete graphs are the densest hosts and always carry
+a `C₄`, whereas stars are the sparse `C₄`-free extreme. -/
+theorem completeGraph_containsC4 {n : ℕ} (hn : 4 ≤ n) :
+    containsC4 (Fin n) (⊤ : SimpleGraph (Fin n)) := by
+  refine ⟨Fin.castLE hn, Fin.castLE_injective hn, fun i j hij => ?_⟩
+  rw [top_adj]
+  exact fun heq => hij.ne (Fin.castLE_injective hn heq)
+
 /-- Containing a `C₄` is preserved under passing to a larger graph on the same
 vertex set (adding edges cannot destroy a copy of `C₄`). -/
 theorem containsC4_mono {V : Type*} {G G' : SimpleGraph V} (h : G ≤ G')

--- a/src/data/proofs/erdos-85/meta.json
+++ b/src/data/proofs/erdos-85/meta.json
@@ -56,9 +56,9 @@
       "Kővári-Sós-Turán bound on C₄-free graphs"
     ],
     "axiomCount": 0,
-    "lineCount": 230,
-    "assumptions": "0 axioms, 0 sorries. The file states the problem (defs C4, containsC4, minDegreeForC4, Erdos85Question/Negation, starGraph, ramseyConnection, WeakerConjecture) and proves 7 axiom-free foundational lemmas about C4/containsC4/starGraph. The asymptotics f(n)=(1+o(1))sqrt(n), base case f(4)=2, the Ramsey reformulation, and the monotonicity question require extremal graph theory beyond current Mathlib and remain described in doc-comments only, NOT formalized. The formalized lemmas are: the four C4 edges and a C4 non-edge, containsC4_mono (monotone under adding edges), and starGraph_not_containsC4 (stars are C4-free).",
-    "theoremCount": 7,
+    "lineCount": 259,
+    "assumptions": "0 axioms, 0 sorries. The file states the problem (defs C4, containsC4, minDegreeForC4, Erdos85Question/Negation, starGraph, ramseyConnection, WeakerConjecture) and proves 7 axiom-free foundational lemmas about C4/containsC4/starGraph. The asymptotics f(n)=(1+o(1))sqrt(n), base case f(4)=2, the Ramsey reformulation, and the monotonicity question require extremal graph theory beyond current Mathlib and remain described in doc-comments only, NOT formalized. The formalized lemmas are: the four C4 edges and a C4 non-edge, containsC4_mono (monotone under adding edges), and starGraph_not_containsC4 (stars are C4-free). Session 2 adds 4 more axiom-free structural lemmas (theoremCount 7->11, still 0 axioms/0 sorries): C4_not_adj_one_three (the second diagonal non-edge, pinning C4 to exactly its four cycle edges), containsC4_C4 (C4 contains itself via the identity embedding, so containsC4 is non-vacuous), containsC4_four_le_card (a host graph carrying a C4 has at least 4 vertices, via the injection Fin 4 -> V — the necessary size condition), and completeGraph_containsC4 (complete graphs on >=4 vertices always contain a C4, via Fin.castLE embedding + top_adj — the dense extremal counterpart to starGraph_not_containsC4).",
+    "theoremCount": 11,
     "definitionCount": 8
   },
   "overview": {
@@ -150,9 +150,9 @@
       "Topology"
     ],
     "namespace": "Erdos85",
-    "lineCount": 230,
+    "lineCount": 259,
     "axiomCount": 0,
-    "theoremCount": 7,
+    "theoremCount": 11,
     "definitionCount": 8,
     "path": "Proofs/Erdos85Problem.lean",
     "sorries": 0

--- a/src/data/research/problems/erdos-85-wip-01.json
+++ b/src/data/research/problems/erdos-85-wip-01.json
@@ -20,7 +20,7 @@
   "currentState": {
     "phase": "ORIENT",
     "since": "2026-07-09T17:33:20-07:00",
-    "iteration": 1,
+    "iteration": 2,
     "focus": "Initial problem understanding. Read problem.md and gather context.",
     "blockers": [],
     "nextAction": "Read problem.md thoroughly and acquire full context.",
@@ -31,20 +31,26 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: added 7 axiom-free foundational lemmas to the previously definitions-only Erdos85Problem.lean (the four C4 edges + a diagonal non-edge, containsC4 monotonicity, and starGraph_not_containsC4 = stars are C4-free, the extremal fact behind the Ramsey reformulation). Deep results (asymptotics, f(4)=2, Ramsey connection, monotonicity) remain documented-only. Meta synced (theoremCount 0 -> 7).",
+    "progressSummary": "PROGRESS: Erdos85Problem.lean — session 2 added 4 axiom-free structural lemmas (7->11 theorems) that bracket the C4 extremal question: containsC4_four_le_card (necessary size >=4), completeGraph_containsC4 (dense graphs contain C4), containsC4_C4 (non-vacuity), C4_not_adj_one_three (C4 adjacency fully pinned). 0 sorry / 0 axiom, #print axioms clean. Deep results (f(4)=2, asymptotics, KST, monotonicity) remain documented-only.",
     "builtItems": [
       "C4_adj_zero_one/one_two/two_three/three_zero (four cycle edges) in Erdos85Problem.lean",
       "C4_not_adj_zero_two (diagonal non-edge) in Erdos85Problem.lean",
       "containsC4_mono (C4 copy survives adding edges) in Erdos85Problem.lean",
-      "starGraph_not_containsC4 (stars are C4-free) in Erdos85Problem.lean"
+      "starGraph_not_containsC4 (stars are C4-free) in Erdos85Problem.lean",
+      "C4_not_adj_one_three, containsC4_C4, containsC4_four_le_card, completeGraph_containsC4 in Erdos85Problem.lean (session 2, axiom-free [propext, Classical.choice, Quot.sound])"
     ],
     "insights": [
       "Erdos85Problem.lean was a definitions-only stub (7 defs, 0 theorems). Asymptotics f(n)=(1+o(1))sqrt(n), f(4)=2, and the Ramsey reformulation need extremal graph theory beyond Mathlib; tractable axiom-free content is structural facts about C4, containsC4, and starGraph.",
       "Stars are C4-free: a C4 has two DISJOINT edges (0-1 and 2-3); in a star every edge meets the centre 0, so both disjoint edges would put two distinct cycle-vertices at 0, contradicting injectivity of the embedding. Only the two disjoint edges are needed for the proof.",
-      "SimpleGraph structure-literal Adj fields have no Decidable instance, so `decide` fails on C4.Adj 0 1; `by simp [C4]` unfolds the field and evaluates the arithmetic disjunction instead."
+      "SimpleGraph structure-literal Adj fields have no Decidable instance, so `decide` fails on C4.Adj 0 1; `by simp [C4]` unfolds the field and evaluates the arithmetic disjunction instead.",
+      "The extremal question for C4 is bracketed by two structural facts now both formalized: complete graphs on >=4 vertices always contain a C4 (completeGraph_containsC4, dense extreme) while stars K_{1,n} never do (starGraph_not_containsC4, sparse extreme). A C4 also forces >=4 vertices (containsC4_four_le_card)."
     ],
     "mathlibGaps": [],
-    "nextSteps": [],
+    "nextSteps": [
+      "Base case f(4)=2: on Fin 4, minDegree >= 2 forces containsC4 (finite but quantifies over all SimpleGraph (Fin 4) — needs a Fintype/decidability bridge for SimpleGraph on a finite type).",
+      "Kővári–Sós–Turán edge bound for C4-free graphs (deep, likely not in Mathlib).",
+      "minDegreeForC4 monotonicity/basic bounds from the sInf definition."
+    ],
     "markdown": "# Knowledge Base: erdos-85-wip-01\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },
   "tags": [


### PR DESCRIPTION
## Summary
Research session for **erdos-85-wip-01** (Erdős #85: monotone minimum-degree threshold for 4-cycles). Adds 4 axiom-free structural lemmas to `Erdos85Problem.lean`, building on the previously-merged 7 foundational lemmas (C4 edges, `containsC4` monotonicity, stars are C4-free).

## Progress
- **`C4_not_adj_one_three`** — the second diagonal non-edge; together with `C4_not_adj_zero_two` this pins `C₄` to exactly its four cycle edges.
- **`containsC4_C4`** — `C₄` contains a copy of itself (identity embedding), so `containsC4` is non-vacuous.
- **`containsC4_four_le_card`** — a host graph carrying a `C₄` has at least 4 vertices (via the injection `Fin 4 ↪ V`). The necessary size condition behind the degree-threshold question.
- **`completeGraph_containsC4`** — complete graphs on `≥ 4` vertices always contain a `C₄` (via `Fin.castLE` embedding + `top_adj`).

## Findings
- The extremal question is now **bracketed** on both sides: `completeGraph_containsC4` (dense hosts always carry a C₄) is the natural counterpart to the existing `starGraph_not_containsC4` (stars are the sparse C₄-free extreme).
- Formalizing the base case `f(4) = 2` is the next natural target but requires a Fintype/decidability bridge to quantify over all `SimpleGraph (Fin 4)` — noted as a next step.

## Files Modified
- `proofs/Proofs/Erdos85Problem.lean` (7→11 theorems, 230→259 lines, still 0 axioms / 0 sorries; `#print axioms` = propext/Classical.choice/Quot.sound)
- `src/data/proofs/erdos-85/meta.json` (counts + assumptions synced)
- `src/data/research/problems/erdos-85-wip-01.json` (insights, builtItems, nextSteps)

## Status
**Outcome**: progress (structural bracketing of the C₄ extremal question; deep results f(4)=2, asymptotics, KST, monotonicity remain open/documented)
**Next Steps**: base case f(4)=2 via a finite-graph decidability bridge; minDegreeForC4 basic bounds from its sInf definition.

🤖 Generated by researcher-1