### PR TITLE
Enrich Cauchy power-map fibre-size entry: full-file section coverage

### DIFF
--- a/src/data/proofs/cauchy-group-theorem-oq-01-oq-01-oq-01-oq-01-oq-03-oq-02-oq-02/meta.json
+++ b/src/data/proofs/cauchy-group-theorem-oq-01-oq-01-oq-01-oq-01-oq-03-oq-02-oq-02/meta.json
@@ -56,6 +56,14 @@
   },
   "sections": [
     {
+      "id": "setup",
+      "title": "Docstring, Imports, and Setup",
+      "startLine": 1,
+      "endLine": 65,
+      "summary": "Imports Mathlib.Tactic and the parent CauchyGroupTheoremOQ01OQ01OQ01OQ01OQ03OQ02 (source of the cyclic-case fibre count card_fiber_pow and gcd(n, m)). The module docstring frames the research step: the parent analysed the power map x ↦ xⁿ on a finite cyclic group (every non-empty fibre has gcd(n, m) elements), and the open question asked whether the fibre-size multiset becomes strictly more informative on a product of cyclic groups. This file shows that premise is false — because x ↦ xⁿ is an endomorphism of an abelian group, every non-empty fibre is a coset of the n-torsion subgroup and so all fibres share one size — and states the answer: the multiset collapses to the single constant ∏ᵢ gcd(n, |Gᵢ|), which pins down no residue of n modulo any invariant factor. Enters the namespace and opens Finset.",
+      "mathContext": "Parent: on a cyclic group of order $m$, every non-empty fibre of $x \\mapsto x^n$ has $\\gcd(n,m)$ elements. Here $G$ is an arbitrary finite abelian group and $x \\mapsto x^n$ an endomorphism, so fibres are cosets of the $n$-torsion subgroup."
+    },
+    {
       "id": "constant-fibres",
       "title": "Constant Fibres on Any Finite Abelian Group",
       "startLine": 66,


### PR DESCRIPTION
## Enrichment pass for `cauchy-group-theorem-oq-01-oq-01-oq-01-oq-01-oq-03-oq-02-oq-02`

The entry was already at-target on annotations (5 full), `keyInsights` (5), `historicalContext` (941 chars), `conclusion`, and cross-references. The one genuine gap was **section coverage**: `sections` started at line 66, leaving lines 1–65 — the imports, the 56-line module docstring, and the namespace — uncovered.

### Change
- Added a `setup` section (lines 1–65) summarizing the docstring's framing (the parent's cyclic-case fibre count gcd(n, m); the open question about whether the fibre-size multiset gets richer on a product; the answer that it does not, since x ↦ xⁿ is an abelian-group endomorphism so all fibres are cosets of the n-torsion subgroup and share one size ∏ᵢ gcd(n, |Gᵢ|)), the imports, and the namespace.
- `sections` now span the full file with no gap: (1–65), (66–106), (108–133), (135–201); line 202 is `end`.

### Verification
- meta.json valid JSON; 19 KB (well under the ~60 KB cap).
- Section line ranges cross-checked against the 202-line Lean file — no drift.
- `pnpm build` data-manifest + search-index validation passed and this entry emits cleanly (not among the pre-existing gallery-wide annotation-anchor lint warnings). The only build failure is the trailing `tsc` typecheck, due to `node_modules` not being installed in this worktree (pre-existing environment gap, unrelated to this JSON change).

No existing content deleted; single targeted addition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)