### PR TITLE
audit: re-serve erdos-833 (axiomatized) — clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -16733,8 +16733,8 @@
     },
     "erdos-833": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:15:34Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-20T21:20:32Z",
       "result": "clean"
     },
     "erdos-834": {


### PR DESCRIPTION
## Gallery integrity audit — erdos-833

Reserve-mode re-audit (unaudited queue drained, 0 remaining). Re-served the oldest uncontested axiomatized target.

**Result: clean.** Verified `proofs/Proofs/Erdos833Problem.lean` against `src/data/proofs/erdos-833/meta.json`:

- **axiomCount 3** ✓ — `hypergraph_trivially_colorable`, `erdos_lovasz_bound`, `erdos_833_solution` (all real `axiom` decls, disclosed in originalContributions/assumptions)
- **theoremCount 2** ✓ (`exists_high_degree_vertex`, `erdos_833`), **definitionCount 11** ✓, **sorries 0** ✓, **lineCount 213** ✓
- No `native_decide`, no True stubs, no undisclosed Mathlib wrapper
- Section summaries correctly flag phantom decls (`edge_lower_bound`, `contrapositive_form`, `f_2_achieved`, `fano_plane_example`) as **comment-only, no Lean declaration**
- Tier C prose is honest: badge `axiom`, status `axiomatized`, conclusion explicitly states the Erdős–Lovász resolution is stated as axioms — no independent-proof overclaim

Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)