### PR TITLE
audit: re-serve erdos-955 (aliquot-sum density) — clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -17655,9 +17655,9 @@
     },
     "erdos-955": {
       "agentId": "mechanic-tracker-sync",
-      "auditCount": 4,
-      "lastAudited": "2026-05-04T01:00:00Z",
-      "result": "issues-fixed",
+      "auditCount": 5,
+      "lastAudited": "2026-07-20T21:22:55Z",
+      "result": "clean",
       "issues": [
         "IsUntouchable def had empty body (parse error); stale Axiomatizes narratives in 4 sections — fixed via PR #15406"
       ]


### PR DESCRIPTION
## Gallery integrity audit — erdos-955

Re-serve (round-robin; unaudited queue drained). **Result: clean.**

### Verified against \`proofs/Proofs/Erdos955Problem.lean\`
| meta.json | actual | ok |
|-----------|--------|----|
| axiomCount 2 | \`ppt_bound\`, \`erdos_955_summary\` | ✓ |
| sorries 0 | 0 (4 "True" hits are docstring prose) | ✓ |
| theoremCount 2 | \`sparse_sets_work\`, \`erdos_955\` | ✓ |
| definitionCount 14 | 14 | ✓ |
| native_decide | none | ✓ |

- Status \`axiomatized\` / badge \`axiom\` are correct: \`erdos_955 := erdos_955_summary\` (an axiom), and \`sparse_sets_work\` is a one-line corollary of \`ppt_bound\`.
- \`assumptions\` field honestly discloses that the primes (Pollack) and sums-of-two-squares (Troupe) cases are *asserted within* the axiom, not independently proved.
- Every \`originalContributions\` name maps to a real declaration — no phantom decls.
- Minor: lineCount 192 vs actual 190 (trivial drift, not an overclaim).

No overclaiming detected.

---
Discovered during gallery integrity audit.