### PR TITLE
Research: erdos-89-wip-01 — exact base value + first exact value g(2)=1

### DIFF
--- a/proofs/Proofs/Erdos89WIP01.lean
+++ b/proofs/Proofs/Erdos89WIP01.lean
@@ -131,4 +131,36 @@ theorem minDistinctDistances_le_of_card_eq
     minDistinctDistances n ≤ numDistinctDistances S :=
   Nat.sInf_le ⟨S, hn, rfl⟩
 
+/-- **Exact value at the base.** A two-point set determines *exactly* one distance:
+the sharp ceiling gives `≤ 2.choose 2 = 1` and two points give `≥ 1`.  This pins the
+envelope to an equality at `|S| = 2`, closing the bracket at the base case. -/
+theorem numDistinctDistances_eq_one_of_card_eq_two
+    (S : Finset (EuclideanSpace ℝ (Fin 2))) (hS : S.card = 2) :
+    numDistinctDistances S = 1 := by
+  have hle := numDistinctDistances_le_choose_two S
+  have hge := one_le_numDistinctDistances_of_two_le_card S (by omega)
+  rw [hS, show Nat.choose 2 2 = 1 from rfl] at hle
+  omega
+
+/-- **First exact value of Erdős's function.** `g(2) = 1`: two points always
+determine exactly one distance (`numDistinctDistances_eq_one_of_card_eq_two`), and a
+two-point set exists (the space is nontrivial), so the minimum over two-point sets is
+exactly `1`.  The base case of the extremal function `g(n) = minDistinctDistances n`. -/
+theorem minDistinctDistances_two : minDistinctDistances 2 = 1 := by
+  obtain ⟨q, hq⟩ := exists_ne (0 : EuclideanSpace ℝ (Fin 2))
+  have hcard : ({0, q} : Finset (EuclideanSpace ℝ (Fin 2))).card = 2 :=
+    Finset.card_pair (Ne.symm hq)
+  refine le_antisymm ?_ ?_
+  · calc minDistinctDistances 2 ≤ numDistinctDistances {0, q} :=
+          minDistinctDistances_le_of_card_eq hcard
+      _ = 1 := numDistinctDistances_eq_one_of_card_eq_two _ hcard
+  · have hne : {numDistinctDistances S |
+        (S : Finset (EuclideanSpace ℝ (Fin 2))) (_ : S.card = 2)}.Nonempty :=
+      ⟨1, {0, q}, hcard, numDistinctDistances_eq_one_of_card_eq_two _ hcard⟩
+    obtain ⟨S, hScard, hSeq⟩ := Nat.sInf_mem hne
+    show 1 ≤ minDistinctDistances 2
+    unfold minDistinctDistances
+    rw [← hSeq]
+    exact one_le_numDistinctDistances_of_two_le_card S (by omega)
+
 end Erdos89

--- a/src/data/research/problems/erdos-89-wip-01.json
+++ b/src/data/research/problems/erdos-89-wip-01.json
@@ -20,7 +20,7 @@
   "currentState": {
     "phase": "ACT",
     "since": "2026-07-09T17:33:18-07:00",
-    "iteration": 1,
+    "iteration": 2,
     "focus": "Initial problem understanding. Read problem.md and gather context.",
     "blockers": [],
     "nextAction": "Formalize the √n×√n grid upper bound feeding minDistinctDistances_le_of_card_eq to get a concrete g(n)=O(n) ceiling; connect singlePointConjecture (#604) to the global count. Guth–Katz lower bound stays an imported assumption.",
@@ -31,7 +31,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Erdos89WIP01.lean — added the sharp unordered-pair ceiling numDistinctDistances S ≤ S.card.choose 2 (Sym2 factoring of the symmetric custom distance), completing the counting envelope. 7 theorems, 0 sorry, 0 axiom; #print axioms = [propext, Classical.choice, Quot.sound].",
+    "progressSummary": "PROGRESS: Erdos89WIP01.lean — sharpened the distinct-distances envelope to an EQUALITY at the base: numDistinctDistances_eq_one_of_card_eq_two (2-point sets have exactly 1 distance) and minDistinctDistances_two (g(2)=1, first exact value of Erdős extremal function). 9 theorems, 0 sorry, 0 axiom; #print axioms = [propext, Classical.choice, Quot.sound].",
     "builtItems": [
       "Erdos89.dist_pos_of_ne in Erdos89WIP01.lean",
       "Erdos89.distinctDistances_eq_image (filter redundant) in Erdos89WIP01.lean",
@@ -39,16 +39,21 @@
       "Erdos89.numDistinctDistances_eq_zero_of_card_le_one in Erdos89WIP01.lean",
       "Erdos89.one_le_numDistinctDistances_of_two_le_card in Erdos89WIP01.lean",
       "Erdos89.minDistinctDistances_le_of_card_eq in Erdos89WIP01.lean",
-      "numDistinctDistances_le_choose_two (≤ S.card.choose 2, sharp unordered-pair ceiling) in Erdos89WIP01.lean"
+      "numDistinctDistances_le_choose_two (≤ S.card.choose 2, sharp unordered-pair ceiling) in Erdos89WIP01.lean",
+      "numDistinctDistances_eq_one_of_card_eq_two + minDistinctDistances_two (g(2)=1) in Erdos89WIP01.lean (axiom-free [propext, Classical.choice, Quot.sound]; uses Nat.sInf_mem + exists_ne witness)"
     ],
     "insights": [
       "distinctDistances S filters (·>0) over the off-diagonal image, but every off-diagonal pair (p≠q) already has ‖p−q‖>0, so the filter is redundant: distinctDistances S = S.offDiag.image (dist · ·). This removes the awkward filter for all downstream cardinality reasoning.",
       "Counting envelope: numDistinctDistances S ≤ |S|·(|S|−1) via card_image_le + Finset.offDiag_card; and it vanishes iff too few points (|S|≤1 ⟹ 0, |S|≥2 ⟹ ≥1 via one_lt_card giving a distinct pair).",
       "minDistinctDistances n = sInf over n-point sets is bounded above by any single n-point witness (Nat.sInf_le ⟨S, hcard, rfl⟩) — the membership hook the √n×√n grid upper-bound construction ultimately supplies.",
-      "The custom Erdos89.dist (‖p−q‖) is symmetric via norm_sub_rev, so it factors through Sym2; routing S.offDiag.image through Sym2.mk.uncurry and applying Sym2.card_image_offDiag gives the sharp ceiling numDistinctDistances S ≤ S.card.choose 2 (halving |S|·(|S|−1)). Same technique as erdos-98-wip-01."
+      "The custom Erdos89.dist (‖p−q‖) is symmetric via norm_sub_rev, so it factors through Sym2; routing S.offDiag.image through Sym2.mk.uncurry and applying Sym2.card_image_offDiag gives the sharp ceiling numDistinctDistances S ≤ S.card.choose 2 (halving |S|·(|S|−1)). Same technique as erdos-98-wip-01.",
+      "The distinct-distances envelope is now an EQUALITY at the base: numDistinctDistances_eq_one_of_card_eq_two shows any 2-point set has exactly 1 distance (sharp ceiling 2.choose 2 = 1 meets the ≥1 floor), and minDistinctDistances_two gives the first exact value of Erdős g(n): g(2) = 1."
     ],
     "mathlibGaps": [],
-    "nextSteps": [],
+    "nextSteps": [
+      "g(3) = 1: exhibit an equilateral triangle (3 points, all pairwise distances equal) so numDistinctDistances = 1, matching the ≥1 floor — needs an explicit 3-point construction in EuclideanSpace ℝ (Fin 2) with card 3 and a single distance value.",
+      "A grid upper bound g(n) ≤ O(n/√(log n)) for the √n×√n grid (the Erdős extremal candidate) — substantial, needs lattice distance-counting."
+    ],
     "markdown": "# Knowledge Base: erdos-89-wip-01\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },
   "tags": [


### PR DESCRIPTION
## Summary
Research session for **erdos-89-wip-01** (distinct distances, `g(n) = minDistinctDistances n`). Sharpens the counting envelope at the base from a bound to an **equality**, and computes the first exact value of Erdős's extremal function.

## Progress
Two axiom-free theorems added to `Erdos89WIP01.lean` (7→9 theorems):

- **`numDistinctDistances_eq_one_of_card_eq_two`** — any two-point set determines *exactly* one distance. The sharp ceiling gives `≤ 2.choose 2 = 1` and two points give `≥ 1`, pinning the previously one-sided envelope to an equality at `|S| = 2`.
- **`minDistinctDistances_two`** — `g(2) = 1`, the first exact value of the extremal function. Combines the exact base value (upper bound via a two-point witness, which exists since the space is nontrivial) with `Nat.sInf_mem` for the matching lower bound.

## Findings
- The file already bracketed the count (floor 0, floor ≥1, sharp ceiling `choose 2`, extremal-witness hook); this closes the bracket to an equality at the base and turns the hook into a concrete `g(2)` evaluation.
- `#print axioms` = propext/Classical.choice/Quot.sound on both. Host-verified under Mathlib v4.31, no `native_decide`.

## Files Modified
- `proofs/Proofs/Erdos89WIP01.lean` (7→9 theorems, 0 axioms / 0 sorries)
- `src/data/research/problems/erdos-89-wip-01.json` (insights, builtItems, nextSteps)

## Status
**Outcome**: progress (base-case equality + first exact value g(2)=1; the asymptotic conjecture remains open)
**Next Steps**: `g(3) = 1` via an explicit equilateral triangle; a grid upper bound toward the Erdős extremal candidate.

🤖 Generated by researcher-1