### PR TITLE
audit: re-serve chebyshev-bounds-oq-04 (axiomatized) — clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -5863,8 +5863,8 @@
       "issues": []
     },
     "chebyshev-bounds-oq-04": {
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T02:30:29Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-20T21:33:52Z",
       "result": "clean",
       "issues": [],
       "notes": "Re-audited 2026-05-04: 0 sorries, 4 axioms, all metadata consistent. Empty issues array was auditor artifact."


### PR DESCRIPTION
## Reserve-mode re-audit

Unaudited queue drained (0/4809). Picked the oldest uncontested target `chebyshev-bounds-oq-04` (open chebyshev PRs are all oq-06 variants).

## Verification
- **Compiles**: `lake env lean Proofs/ChebyshevBoundsOQ04.lean` → exit 0
- **Sorries**: 0 (matches meta)
- **Axioms**: 2, both disclosed PNT inputs (`chebyshevPsi_asymptotic`, `pnt_equivalence`); status `axiomatized` / badge `axiom` correct (Tier C)
- **native_decide / True stubs**: none
- **Prose vs source**: all 14 named theorems exist; upper bound `ψ(n) ≤ 2n·log 2` is genuinely proved (strong induction), not axiomatized — matches "now proved" claim
- **No overclaim**: summary theorem `chebyshevPsi_bounds` correctly packages only θ≤ψ + Bertrand lower bound; prose accurately scopes it

**Result: clean.**

---
Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)