### PR TITLE
Enrich chebyshev-pnt-bridge-oq-06-oq-01: fix section coverage gaps

### DIFF
--- a/src/data/proofs/chebyshev-pnt-bridge-oq-06-oq-01/meta.json
+++ b/src/data/proofs/chebyshev-pnt-bridge-oq-06-oq-01/meta.json
@@ -81,8 +81,8 @@
       "id": "header",
       "title": "Overview",
       "startLine": 1,
-      "endLine": 39,
-      "summary": "Module docstring framing OQ-06·OQ-01: pin the integer-square-root logarithm bracket and use it to consolidate the two Chebyshev halves onto a common scale."
+      "endLine": 50,
+      "summary": "Module docstring framing OQ-06·OQ-01: pin the integer-square-root logarithm bracket and use it to consolidate the two Chebyshev halves onto a common scale; then the imports (parent bridge plus siblings OQ-05 and OQ-06, PrimeCounting, Real.log), the namespace, and `open Nat`."
     },
     {
       "id": "bracket",
@@ -102,8 +102,8 @@
       "id": "common-scale",
       "title": "Upper bound on the common π(m)·log m scale",
       "startLine": 124,
-      "endLine": 156,
-      "summary": "primeCounting_mul_log_upper: substituting the bracket lower bound for log(√m) renormalises the OQ-06 upper bound onto the π(m)·log m scale of OQ-05, with only a lower-order 2 log 2·π(m) residual."
+      "endLine": 162,
+      "summary": "primeCounting_mul_log_upper: substituting the bracket lower bound for log(√m) renormalises the OQ-06 upper bound onto the π(m)·log m scale of OQ-05, with only a lower-order 2 log 2·π(m) residual; closes with the #check sanity lines and the namespace end."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
Enrichment pass for `chebyshev-pnt-bridge-oq-06-oq-01` (quality 96).

## Genuine defect: two sections left file regions uncovered

Cross-checking against `Proofs/ChebyshevPNTBridgeOQ06OQ01.lean` (162 lines):

| section | was | issue | now |
|---|---|---|---|
| header | 1-39 | ends at docstring close, leaving imports (41-46), namespace (48), `open Nat` (50) uncovered | 1-50 |
| common-scale | 124-156 | ends at last theorem, leaving `#check` lines (157-160) and `end` (162) uncovered | 124-162 |

Middle sections (bracket 52-101, sandwich 102-123) were already aligned. Coverage is now contiguous 1-162. Summaries updated to name the imports/setup and closing `#check` block; no other content changed. Metadata unchanged (0 axioms, 0 sorries, no native_decide).