### PR TITLE
Enrich chebyshev-pnt-bridge-oq-06-oq-02: fix section coverage gaps

### DIFF
--- a/src/data/proofs/chebyshev-pnt-bridge-oq-06-oq-02/meta.json
+++ b/src/data/proofs/chebyshev-pnt-bridge-oq-06-oq-02/meta.json
@@ -96,8 +96,8 @@
       "id": "header",
       "title": "Overview",
       "startLine": 1,
-      "endLine": 29,
-      "summary": "Module docstring: invert the OQ-06 Chebyshev upper density at the primes to obtain an n·log n lower bound on the n-th prime."
+      "endLine": 39,
+      "summary": "Module docstring: invert the OQ-06 Chebyshev upper density at the primes to obtain an n·log n lower bound on the n-th prime; then the imports (parent bridge + OQ-06, PrimeCounting, Real.log, ExponentialBounds), the namespace, and `open Nat`."
     },
     {
       "id": "bracket",
@@ -117,8 +117,8 @@
       "id": "nth-prime-bound",
       "title": "The n·log n lower bound on the n-th prime",
       "startLine": 86,
-      "endLine": 153,
-      "summary": "nth_prime_lower_bound: read OQ-06 at m = pₙ, absorb the √pₙ correction, substitute the log bracket and pₙ ≥ n+2, yielding pₙ ≥ (n+1)·(½·log(n+2) − log 2)/(2·log 4)."
+      "endLine": 158,
+      "summary": "nth_prime_lower_bound: read OQ-06 at m = pₙ, absorb the √pₙ correction, substitute the log bracket and pₙ ≥ n+2, yielding pₙ ≥ (n+1)·(½·log(n+2) − log 2)/(2·log 4); closes with the #check sanity lines and the namespace end."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
Enrichment pass for `chebyshev-pnt-bridge-oq-06-oq-02` (quality 96).

## Genuine defect: two sections left file regions uncovered

Cross-checking against `Proofs/ChebyshevPNTBridgeOQ06OQ02.lean` (158 lines):

| section | was | issue | now |
|---|---|---|---|
| header | 1-29 | ends at docstring close, leaving imports (30-35), namespace (37), `open Nat` (39) uncovered | 1-39 |
| nth-prime-bound | 86-153 | ends at last theorem, leaving `#check` lines (155-156) and `end` (158) uncovered | 86-158 |

Middle sections (bracket 41-64, bridge 66-84) were already aligned. Coverage is now contiguous 1-158. Summaries updated to name the imports/setup and closing `#check` block; no other content changed. Metadata unchanged (0 axioms, 0 sorries, no native_decide).