### PR TITLE
Complete vdP §6 per-term denominator divisibility for Apéry ζ(3) (Basel OQ-02-OQ-02, Part 15)

### DIFF
--- a/proofs/Proofs/BaselProblemOQ01OQ01OQ02OQ02.lean
+++ b/proofs/Proofs/BaselProblemOQ01OQ01OQ02OQ02.lean
@@ -1093,4 +1093,221 @@ theorem cube_mul_cube_choose_dvd_lcmRange_cube {n m : ℕ} (hm : 0 < m) (hmn : m
 
 end Part14
 
+section Part15
+
+/-! ## Part 15 (Session 25 ACT) — van der Poorten §6 per-term divisibility
+
+This part completes the **per-term denominator analysis** of the
+alternating-bilinear half of the van der Poorten closed form. The
+alternating summand for `1 ≤ m ≤ k ≤ n` carries the denominator
+`2 · m³ · C(n, m) · C(n+m, m)`; the capstone
+`alt_denom_dvd_lcmRange_cube_mul_sq` proves that this denominator
+divides `(lcmRange n)³ · C(n,k)² · C(n+k,k)²` — the exact reduction
+target stated in Part 14's header, *including* the factor 2.
+
+The chain (all pure `Nat`, no casts):
+
+1. `choose_add_mul_choose` — the "upper" subset-of-a-subset identity
+   `C(n+k, k) · C(k, m) = C(n+m, m) · C(n+k, k-m)`, the companion of
+   Mathlib's `Nat.choose_mul` (the "lower" identity
+   `C(n, k) · C(k, m) = C(n, m) · C(n-m, k-m)`).
+
+2. `choose_cross_product_eq` — multiplying the two subset identities:
+   `C(n,m)·C(n+m,m) · (C(n-m,k-m)·C(n+k,k-m)) = C(n,k)·C(n+k,k)·C(k,m)²`.
+   This trades the *denominator* binomials `C(n,m)·C(n+m,m)` for the
+   *inner* binomial `C(k,m)²` (times an integer cofactor).
+
+3. `cube_mul_choose_sq_dvd_lcmRange_cube` —
+   `m³ · C(k,m)² = m · (m·C(k,m))² ∣ (lcmRange n)³`, splitting the cube
+   as `m ∣ lcmRange n` (Part 1) times the square of
+   `m·C(k,m) ∣ lcmRange k ∣ lcmRange n` (Parts 13 + 9).
+
+4. `alt_denom_core_dvd` — combining 2 and 3:
+   `m³ · C(n,m) · C(n+m,m) ∣ (lcmRange n)³ · C(n,k) · C(n+k,k)`.
+
+5. `two_dvd_central_binom` / `two_dvd_choose_mul_choose_add` — the
+   central binomial `C(2m, m) = 2·C(2m-1, m-1)` is even (Pascal +
+   `Nat.choose_symm_half`), hence by the Part 14 reindexing
+   `C(n,k)·C(n+k,k) = C(n+k,2k)·C(2k,k)` the outer pair is even for
+   `k ≥ 1`. This absorbs the `/2` of the alternating term into the
+   *second* copy of the outer square — vdP's observation that the
+   factor 2 "comes for free" from the central binomial.
+
+6. `alt_denom_dvd_lcmRange_cube_mul_sq` (capstone) —
+   `2 · m³ · C(n,m) · C(n+m,m) ∣ (lcmRange n)³ · C(n,k)² · C(n+k,k)²`.
+
+With this, every summand of the alternating-bilinear half clears
+against `(lcmRange n)³` times the outer Apéry square. What remains for
+`denominator_control` is *summation-level assembly only*: cast the
+per-term divisibility to `ℚ` (the `Nat.cast_div` pattern of
+`harmonicCubed_lcm_clear_nat`, Part 4), sum over `1 ≤ m ≤ k`, and
+combine with the already-closed `H_n^{(3)}` half.
+-/
+
+/-- **(Part 15a) Upper subset-of-a-subset identity**:
+    `C(n+k, k) · C(k, m) = C(n+m, m) · C(n+k, k-m)` for `m ≤ k`.
+
+    Companion of Mathlib's `Nat.choose_mul`; obtained from it at
+    `(n+k, n+m, n)` followed by three symmetry flips
+    (`Nat.choose_symm_add` / `Nat.choose_symm_of_eq_add`).
+    Unconditional in `n`. -/
+theorem choose_add_mul_choose {n k m : ℕ} (hmk : m ≤ k) :
+    Nat.choose (n + k) k * Nat.choose k m
+      = Nat.choose (n + m) m * Nat.choose (n + k) (k - m) := by
+  have h := Nat.choose_mul (n := n + k) (k := n + m) (s := n) (Nat.le_add_right n m)
+  have e1 : n + k - n = k := by omega
+  have e2 : n + m - n = m := by omega
+  rw [e1, e2] at h
+  have s1 : Nat.choose (n + k) (n + m) = Nat.choose (n + k) (k - m) :=
+    Nat.choose_symm_of_eq_add (by omega)
+  have s2 : Nat.choose (n + m) n = Nat.choose (n + m) m := Nat.choose_symm_add
+  have s3 : Nat.choose (n + k) n = Nat.choose (n + k) k := Nat.choose_symm_add
+  rw [s1, s2, s3] at h
+  rw [← h]
+  exact Nat.mul_comm _ _
+
+/-- **(Part 15b) Cross-product identity** (van der Poorten §6): for `m ≤ k`,
+    `C(n,m)·C(n+m,m) · (C(n-m,k-m)·C(n+k,k-m)) = C(n,k)·C(n+k,k) · C(k,m)²`.
+
+    Product of the lower (`Nat.choose_mul`) and upper
+    (`choose_add_mul_choose`) subset identities. Trades the
+    alternating-denominator binomials `C(n,m)·C(n+m,m)` for the inner
+    binomial square `C(k,m)²` times an integer cofactor. -/
+theorem choose_cross_product_eq {n k m : ℕ} (hmk : m ≤ k) :
+    Nat.choose n m * Nat.choose (n + m) m
+        * (Nat.choose (n - m) (k - m) * Nat.choose (n + k) (k - m))
+      = Nat.choose n k * Nat.choose (n + k) k * Nat.choose k m ^ 2 := by
+  have h1 := Nat.choose_mul (n := n) (k := k) (s := m) hmk
+  have h2 := choose_add_mul_choose (n := n) hmk
+  calc Nat.choose n m * Nat.choose (n + m) m
+        * (Nat.choose (n - m) (k - m) * Nat.choose (n + k) (k - m))
+      = Nat.choose n m * Nat.choose (n - m) (k - m)
+          * (Nat.choose (n + m) m * Nat.choose (n + k) (k - m)) := by ring
+    _ = Nat.choose n k * Nat.choose k m
+          * (Nat.choose (n + k) k * Nat.choose k m) := by rw [← h1, ← h2]
+    _ = Nat.choose n k * Nat.choose (n + k) k * Nat.choose k m ^ 2 := by ring
+
+/-- **(Part 15c) The `m³·C(k,m)²` block divides `(lcmRange n)³`**:
+    for `0 < m ≤ k ≤ n`,  `m³ · C(k,m)² ∣ (lcmRange n)³`.
+
+    Split as `m · (m·C(k,m))²`: the factor `m` divides `lcmRange n`
+    (Part 1) and `m·C(k,m)` divides `lcmRange k ∣ lcmRange n`
+    (Part 13 + Part 9). -/
+theorem cube_mul_choose_sq_dvd_lcmRange_cube {n k m : ℕ} (hm : 0 < m) (hmk : m ≤ k)
+    (hkn : k ≤ n) :
+    m ^ 3 * Nat.choose k m ^ 2 ∣ (lcmRange n) ^ 3 := by
+  have hmn : m ≤ n := hmk.trans hkn
+  have h1 : m ∣ lcmRange n := dvd_lcmRange hm hmn
+  have h2 : m * Nat.choose k m ∣ lcmRange n :=
+    (mul_choose_dvd_lcmRange hm hmk).trans (lcmRange_dvd_of_le hkn)
+  have h4 : m * (m * Nat.choose k m) ^ 2 ∣ lcmRange n * (lcmRange n) ^ 2 :=
+    mul_dvd_mul h1 (pow_dvd_pow_of_dvd h2 2)
+  have e1 : m * (m * Nat.choose k m) ^ 2 = m ^ 3 * Nat.choose k m ^ 2 := by ring
+  have e2 : lcmRange n * (lcmRange n) ^ 2 = (lcmRange n) ^ 3 := by ring
+  rwa [e1, e2] at h4
+
+/-- **(Part 15d) Alternating-denominator core divisibility**: for
+    `0 < m ≤ k ≤ n`,
+    `m³ · C(n,m) · C(n+m,m) ∣ (lcmRange n)³ · C(n,k) · C(n+k,k)`.
+
+    The cross-product identity (15b) exhibits the left side times the
+    integer cofactor `C(n-m,k-m)·C(n+k,k-m)` as
+    `m³·C(k,m)² · (C(n,k)·C(n+k,k))`, and `m³·C(k,m)²` divides
+    `(lcmRange n)³` by 15c. -/
+theorem alt_denom_core_dvd {n k m : ℕ} (hm : 0 < m) (hmk : m ≤ k) (hkn : k ≤ n) :
+    m ^ 3 * (Nat.choose n m * Nat.choose (n + m) m)
+      ∣ (lcmRange n) ^ 3 * (Nat.choose n k * Nat.choose (n + k) k) := by
+  have hcross := choose_cross_product_eq (n := n) hmk
+  have step1 : m ^ 3 * (Nat.choose n m * Nat.choose (n + m) m)
+      ∣ m ^ 3 * Nat.choose k m ^ 2 * (Nat.choose n k * Nat.choose (n + k) k) :=
+    ⟨Nat.choose (n - m) (k - m) * Nat.choose (n + k) (k - m), by
+      calc m ^ 3 * Nat.choose k m ^ 2 * (Nat.choose n k * Nat.choose (n + k) k)
+          = m ^ 3 * (Nat.choose n k * Nat.choose (n + k) k * Nat.choose k m ^ 2) := by
+            ring
+        _ = m ^ 3 * (Nat.choose n m * Nat.choose (n + m) m
+              * (Nat.choose (n - m) (k - m) * Nat.choose (n + k) (k - m))) := by
+            rw [← hcross]
+        _ = m ^ 3 * (Nat.choose n m * Nat.choose (n + m) m)
+              * (Nat.choose (n - m) (k - m) * Nat.choose (n + k) (k - m)) := by
+            ring⟩
+  exact step1.trans
+    (mul_dvd_mul_right (cube_mul_choose_sq_dvd_lcmRange_cube hm hmk hkn) _)
+
+/-- **(Part 15e) The central binomial is even**: `2 ∣ C(2m, m)` for `0 < m`.
+
+    Pascal splits `C(2m, m) = C(2m-1, m-1) + C(2m-1, m)` and the two
+    halves are equal by `Nat.choose_symm_half`, so
+    `C(2m, m) = 2·C(2m-1, m-1)`. -/
+theorem two_dvd_central_binom {m : ℕ} (hm : 0 < m) :
+    2 ∣ Nat.choose (2 * m) m := by
+  obtain ⟨m', rfl⟩ : ∃ m', m = m' + 1 := ⟨m - 1, by omega⟩
+  have e : 2 * (m' + 1) = 2 * m' + 1 + 1 := by ring
+  rw [e, Nat.choose_succ_succ, Nat.choose_symm_half]
+  omega
+
+/-- **(Part 15f) Evenness of the outer binomial pair**:
+    `2 ∣ C(n,k) · C(n+k,k)` for `0 < k`.
+
+    By the Part 14 reindexing `C(n,k)·C(n+k,k) = C(n+k,2k)·C(2k,k)`
+    and evenness of the central binomial `C(2k,k)` (15e). This is what
+    absorbs the `/2` of the alternating summand. -/
+theorem two_dvd_choose_mul_choose_add {n k : ℕ} (hk : 0 < k) :
+    2 ∣ Nat.choose n k * Nat.choose (n + k) k := by
+  rw [choose_mul_choose_reindex]
+  exact (two_dvd_central_binom hk).mul_left _
+
+/-- **(Part 15g) Per-term denominator divisibility, capstone**: for
+    `0 < m ≤ k ≤ n`,
+    `2 · m³ · C(n,m) · C(n+m,m) ∣ (lcmRange n)³ · C(n,k)² · C(n+k,k)²`.
+
+    This is the full denominator of the van der Poorten §6 alternating
+    summand `(-1)^{m-1} / (2 m³ C(n,m) C(n+m,m))` cleared against
+    `(lcmRange n)³` times the outer Apéry square `C(n,k)² C(n+k,k)²` —
+    the reduction target stated in Part 14, factor 2 included. The
+    factor 2 is absorbed by the *second* copy of the outer pair via
+    15f; the core `m³·C(n,m)·C(n+m,m)` block consumes the first copy
+    and `(lcmRange n)³` via 15d. -/
+theorem alt_denom_dvd_lcmRange_cube_mul_sq {n k m : ℕ} (hm : 0 < m) (hmk : m ≤ k)
+    (hkn : k ≤ n) :
+    2 * m ^ 3 * (Nat.choose n m * Nat.choose (n + m) m)
+      ∣ (lcmRange n) ^ 3 * (Nat.choose n k ^ 2 * Nat.choose (n + k) k ^ 2) := by
+  have hk : 0 < k := hm.trans_le hmk
+  have hmul := mul_dvd_mul (two_dvd_choose_mul_choose_add (n := n) hk)
+    (alt_denom_core_dvd hm hmk hkn)
+  have e1 : 2 * (m ^ 3 * (Nat.choose n m * Nat.choose (n + m) m))
+      = 2 * m ^ 3 * (Nat.choose n m * Nat.choose (n + m) m) := by ring
+  have e2 : Nat.choose n k * Nat.choose (n + k) k
+        * ((lcmRange n) ^ 3 * (Nat.choose n k * Nat.choose (n + k) k))
+      = (lcmRange n) ^ 3 * (Nat.choose n k ^ 2 * Nat.choose (n + k) k ^ 2) := by
+    ring
+  rwa [e1, e2] at hmul
+
+/-- **(Part 15h) ℚ-level per-term clearing**: for `0 < m ≤ k ≤ n`, the
+    alternating summand's denominator divides out exactly over `ℚ`:
+
+    `(lcmRange n)³ · C(n,k)² · C(n+k,k)² / (2 m³ C(n,m) C(n+m,m))`
+    is a natural number.
+
+    This is the `Nat.cast_div` lift of the capstone 15g — the exact
+    shape the summation-level assembly of `denominator_control`
+    consumes (mirroring how `harmonicCubed_lcm_clear_nat` consumed
+    `pow_dvd_lcmRange_pow` in Part 4). -/
+theorem alt_term_lcm_clear {n k m : ℕ} (hm : 0 < m) (hmk : m ≤ k) (hkn : k ≤ n) :
+    ∃ z : ℕ, ((lcmRange n : ℕ) : ℚ) ^ 3
+        * ((Nat.choose n k : ℚ) ^ 2 * (Nat.choose (n + k) k : ℚ) ^ 2)
+        / (2 * (m : ℚ) ^ 3 * ((Nat.choose n m : ℚ) * (Nat.choose (n + m) m : ℚ)))
+      = (z : ℚ) := by
+  have hdvd := alt_denom_dvd_lcmRange_cube_mul_sq hm hmk hkn
+  have hDpos : 0 < 2 * m ^ 3 * (Nat.choose n m * Nat.choose (n + m) m) := by
+    have hA : 0 < Nat.choose n m := Nat.choose_pos (hmk.trans hkn)
+    have hB : 0 < Nat.choose (n + m) m := Nat.choose_pos (Nat.le_add_left m n)
+    positivity
+  refine ⟨(lcmRange n ^ 3 * (Nat.choose n k ^ 2 * Nat.choose (n + k) k ^ 2))
+      / (2 * m ^ 3 * (Nat.choose n m * Nat.choose (n + m) m)), ?_⟩
+  rw [Nat.cast_div hdvd (by exact_mod_cast hDpos.ne')]
+  push_cast
+  ring
+
+end Part15
+
 end BaselProblemOQ01OQ01OQ02OQ02

--- a/research/knowledge/technique-index.json
+++ b/research/knowledge/technique-index.json
@@ -118,6 +118,22 @@
       ],
       "outcome": "success",
       "date": "2026-07-08"
+    },
+    {
+      "name": "Subset-of-a-subset binomial identity pairing (Nat.choose_mul upper/lower)",
+      "used_in_problems": [
+        "basel-problem-oq-01-oq-01-oq-02-oq-02"
+      ],
+      "outcome": "success",
+      "date": "2026-07-20"
+    },
+    {
+      "name": "Central binomial evenness absorbs alternating-sum factor 2",
+      "used_in_problems": [
+        "basel-problem-oq-01-oq-01-oq-02-oq-02"
+      ],
+      "outcome": "success",
+      "date": "2026-07-20"
     }
   ]
 }

--- a/research/problems/basel-problem-oq-01-oq-01-oq-02-oq-02/knowledge.md
+++ b/research/problems/basel-problem-oq-01-oq-01-oq-02-oq-02/knowledge.md
@@ -306,3 +306,65 @@ real error; retried. All three additions use only already-imported
 Mathlib lemmas (`Nat.choose_mul`, `pow_dvd_pow_of_dvd`, `mul_pow`) plus
 `omega`/`ring`; the only new external dependency is `Nat.choose_mul`
 (Mathlib/Data/Nat/Choose/Basic.lean), signature verified against source.
+
+### Session 25 (ACT, 2026-07-20, remote researcher)
+
+**Mode**: REVISIT (depth-first on RICH problem)
+**Outcome**: progress — alternating-half per-term denominator analysis
+COMPLETE (Part 15, +8 theorems, build-verified, foundational axioms only)
+
+#### What I Did
+
+Closed the "pure-binomial cross-factor" gap left by S24, **including the
+factor 2**. Added Part 15 to `BaselProblemOQ01OQ01OQ02OQ02.lean`
+(1097 → 1314 lines, 41 → 49 theorems, 0 sorries, 0 axioms):
+
+1. `choose_add_mul_choose` (:1154) — upper subset-of-a-subset identity
+   `C(n+k,k)·C(k,m) = C(n+m,m)·C(n+k,k-m)`, from `Nat.choose_mul` at
+   `(n+k, n+m, n)` plus three symmetry flips.
+2. `choose_cross_product_eq` (:1176) — product with the lower identity:
+   `C(n,m)C(n+m,m)·(C(n-m,k-m)C(n+k,k-m)) = C(n,k)C(n+k,k)·C(k,m)²`.
+3. `cube_mul_choose_sq_dvd_lcmRange_cube` (:1196) —
+   `m³C(k,m)² = m·(m·C(k,m))² ∣ (lcmRange n)³` (S21 lemma squared,
+   plus `m ∣ lcmRange n`).
+4. `alt_denom_core_dvd` (:1217) —
+   `m³·C(n,m)·C(n+m,m) ∣ (lcmRange n)³·C(n,k)·C(n+k,k)`.
+5. `two_dvd_central_binom` (:1241) — `C(2m,m) = 2·C(2m-1,m-1)` via
+   Pascal + `Nat.choose_symm_half`.
+6. `two_dvd_choose_mul_choose_add` (:1254) — `2 ∣ C(n,k)·C(n+k,k)`
+   via the S24 reindexing; this absorbs the alternating term's `/2`
+   into the *second* copy of the outer square.
+7. `alt_denom_dvd_lcmRange_cube_mul_sq` (:1270) — **capstone**:
+   `2·m³·C(n,m)·C(n+m,m) ∣ (lcmRange n)³·C(n,k)²·C(n+k,k)²`
+   for `1 ≤ m ≤ k ≤ n`.
+8. `alt_term_lcm_clear` (:1295) — ℚ-level cast of the capstone via
+   `Nat.cast_div`: the per-term quotient is a natural number. This is
+   the exact shape the summation assembly consumes.
+
+#### Verification
+
+- `lake build Proofs.BaselProblemOQ01OQ01OQ02OQ02` — clean (2969 jobs;
+  only pre-existing warnings in Parts 4/12/13). Built in a remote
+  isolated container with Lean v4.31.0 + pinned Mathlib cache (Docker
+  wrapper unavailable there; container itself provides the memory
+  isolation the wrapper exists for).
+- `#print axioms` on all 8 new theorems: `[propext, Classical.choice,
+  Quot.sound]` only.
+
+#### Key Findings
+
+- The cross-factor needs **two** subset-of-a-subset identities (lower =
+  Mathlib's `Nat.choose_mul`, upper = its `(n+k, n+m, n)` instance);
+  their product eliminates `C(n,m)C(n+m,m)` in favor of `C(k,m)²`,
+  which the S21 lemma squares away into `(lcmRange n)³`.
+- The `/2` is free: the outer pair `C(n,k)C(n+k,k)` is always even for
+  `k ≥ 1` (S24 reindex + even central binomial) — no 2-adic valuation
+  analysis needed, contrary to what S9's m=3 experience suggested.
+
+#### Next Steps
+
+Summation-level assembly ONLY (see tracker `nextSteps` S26 entry):
+sum `alt_term_lcm_clear` over `m ∈ Icc 1 k` in ℤ (signs), combine with
+`harmonicCubed_lcm_clear`, sum over `k ≤ n` against the vdP closed
+form, then discharge the parent `denominator_control` axiom (needs the
+definitional bridge to the parent file's `aperyA`).

--- a/research/registry.json
+++ b/research/registry.json
@@ -2493,7 +2493,7 @@
       "path": "full",
       "started": "2026-04-26T10:54:44.961Z",
       "status": "active",
-      "lastUpdate": "2026-07-08T15:18:41-07:00"
+      "lastUpdate": "2026-07-20T22:10:00.000Z"
     },
     {
       "slug": "basel-problem-oq-01-oq-01-oq-02-oq-03",

--- a/src/data/research/problems/basel-problem-oq-01-oq-01-oq-02-oq-02.json
+++ b/src/data/research/problems/basel-problem-oq-01-oq-01-oq-02-oq-02.json
@@ -46,7 +46,7 @@
     "lastUpdate": "2026-06-13T15:43:33Z"
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (S24): general mul_choose_dvd_lcmRange (S21) now cubed to clear m³·C(n,m)³ from the alternating denominator; alternating-half integrality reduced to a pure-binomial cross-factor divisibility (no lcm). lcm side of both halves now complete.",
+    "progressSummary": "PROGRESS (S25): per-term denominator divisibility of the vdP alternating half fully closed: 2 m^3 C(n,m) C(n+m,m) | (lcmRange n)^3 C(n,k)^2 C(n+k,k)^2 for 1<=m<=k<=n (Part 15 capstone, machine-verified, 0 sorries / foundational axioms only), plus its Q-level cast alt_term_lcm_clear. Remaining for denominator_control: summation-level assembly only (sum over m, combine with H^(3) half, sum over k against the closed form).",
     "builtItems": [
       "S21 DOCTOR-FIX + BUILD-VERIFY (researcher-1 PR, 2026-06-01, build-verified, 1-token Lean edit): Fixed `Nat.pow_pos hp.pos i` → `Nat.pow_pos hp.pos` at line 959 of `pow_factorization_mul_choose_le` (S20's pasted bearer). Mathlib v4.26.0 has `Nat.pow_pos` with implicit `n`; positional exponent fails type check. Re-build via `./proofs/scripts/docker-build.sh Proofs.BaselProblemOQ01OQ01OQ02OQ02` CLEAN 3058/3058 jobs, exit 0. Bearer now FORMALLY VERIFIED — S22 ACT (`mul_choose_dvd_lcmRange` framework clone) actionable. Adds Mathlib v4.26.0 API-drift cheat-sheet entry: `Nat.pow_pos hp.pos` (NOT `Nat.pow_pos hp.pos n`) — exponent is implicit, inferred from expected return type `0 < (base)^(implicit n)`. 5th-slug confirmation of MEMORY `[Lake self-loop in main repo (G9-inert, 2026-05-31)]` and strong re-confirmation of `[G9 qualifier masks real bugs — ALWAYS Docker-verify]`.",
       "Proofs/BaselProblemOQ01OQ01OQ02OQ02.lean: dvd_lcmRange (k>0, k≤n → k∣lcmRange n) — basic membership divisibility",
@@ -83,7 +83,14 @@
       "mul_choose_dvd_lcmRange (BaselProblemOQ01OQ01OQ02OQ02.lean Part 13): general m·C(n,m) ∣ lcmRange n for 0<m≤n, VERIFIED 0/0. Closes the m≥4 gap via prime-power decomposition (factorization_prod_pow_eq_self + Finset.prod_dvd_of_isRelPrime + Part-12 pow_factorization_mul_choose_le), subsuming Parts 6-11 piecemeal m=1,2,3.",
       "choose_mul_choose_reindex (Part 14, ~line 1075): C(n,m)·C(n+m,m)=C(n+m,2m)·C(2m,m), unconditional, via Nat.choose_mul + omega rewrites + ring",
       "mul_choose_cube_dvd_lcmRange_cube (Part 14): (m·C(n,m))^3 ∣ (lcmRange n)^3 via pow_dvd_pow_of_dvd",
-      "cube_mul_cube_choose_dvd_lcmRange_cube (Part 14): m^3·C(n,m)^3 ∣ (lcmRange n)^3 via mul_pow"
+      "cube_mul_cube_choose_dvd_lcmRange_cube (Part 14): m^3·C(n,m)^3 ∣ (lcmRange n)^3 via mul_pow",
+      "choose_add_mul_choose (upper subset identity) in BaselProblemOQ01OQ01OQ02OQ02.lean:1154",
+      "choose_cross_product_eq (vdP §6 cross-product identity) at :1176",
+      "cube_mul_choose_sq_dvd_lcmRange_cube (m^3 C(k,m)^2 | lcm^3) at :1196",
+      "alt_denom_core_dvd (m^3 C(n,m) C(n+m,m) | lcm^3 C(n,k) C(n+k,k)) at :1217",
+      "two_dvd_central_binom + two_dvd_choose_mul_choose_add at :1241/:1254",
+      "alt_denom_dvd_lcmRange_cube_mul_sq (CAPSTONE: 2 m^3 C(n,m) C(n+m,m) | lcm^3 C(n,k)^2 C(n+k,k)^2, factor 2 included) at :1270",
+      "alt_term_lcm_clear (Q-level per-term clearing, Nat.cast_div lift) at :1295"
     ],
     "insights": [
       "S17 PREP (2026-05-16, researcher-1, doc-only) upgrades the S16 PREP §7 paste-ready S17a skeleton (which had 1 explicit `sorry` on the Kummer carry-count argument) to a **fully-discharged** ~75-LOC paste-ready Lean proof with **0 sorries** by replacing the `multiplicity`/`emultiplicity` bridge approach (S16 §3.3-§3.4 bearers + new `Mathlib.Data.Nat.Multiplicity` import) with a direct **subset-cardinality argument on `Nat.factorization_choose`'s carry formula**. The key insight: `Nat.factorization_choose` at `Mathlib/Data/Nat/Choose/Factorization.lean:131` returns the ℕ-valued carry count `#{i ∈ Ico 1 b | p^i ≤ k%p^i + (n-k)%p^i}` directly — no `emultiplicity → multiplicity → factorization` bridge needed. The carry bound `v_p(C(n,m)) ≤ log p n - v_p(m)` follows from showing the filter set is a subset of `Ico (v_p(m) + 1) (log p n + 1)`: positions `i ≤ v_p(m)` have `p^i ∣ m` (via `Nat.Prime.pow_dvd_iff_le_factorization` at Factorization/Basic.lean:168) ⇒ `m % p^i = 0` ⇒ the condition `p^i ≤ 0 + (n-m)%p^i = (n-m)%p^i < p^i` is impossible. The subset argument was numerically validated at 3 cases including 2 tight cases (n=16/m=8/p=2 and n=8/m=2/p=2 both have filter = Ico exactly).",
@@ -123,7 +130,9 @@
       "S20 ACT: `pow_factorization_mul_choose_le` ships as public `theorem` (not `private`), making it consumable by future S21 ACT and any external proof needing per-prime upper bound for `m * C(n, m)` factorization. This is a Mathlib-quality lemma — the SHARP bound `v_p(m·C(n,m)) ≤ log_p n` is non-trivial (naive sum-of-bounds gives ≤ 2·log_p n) and the proof's 5-stage discharge (Nat.factorization_mul → non-prime/prime split → log reduction → Nat.factorization_choose → subset argument) bypasses the multiplicity/emultiplicity bridges entirely.",
       "General m·C(n,m) ∣ lcmRange n proves cleaner than the m=1,2,3 parity case analysis: decomposing over the ACTUAL prime-support (factorization_prod_pow_eq_self) rather than range(n+1) (prod_pow_factorization_choose) makes every factor base a genuine prime, so primality is immediate from membership — no factorization≠0⇒prime contrapositive needed as in choose_dvd_lcmRange.",
       "S24: alternating-term integrality reduces to m³·C(n,m)·C(n+m,m) ∣ (lcmRange n)³·C(n,k)²·C(n+k,k)²; the m³·C(n,m)³ chunk clears purely from the lcm side (cube of general mul_choose_dvd_lcmRange), separating solved lcm-analysis from remaining pure-binomial telescoping",
-      "S24: C(n,m)·C(n+m,m) = C(n+m,2m)·C(2m,m) UNCONDITIONALLY (subset-of-subset Nat.choose_mul at (n+m,2m,m)); exposes central binomial C(2m,m) for van der Poorten §6 telescoping"
+      "S24: C(n,m)·C(n+m,m) = C(n+m,2m)·C(2m,m) UNCONDITIONALLY (subset-of-subset Nat.choose_mul at (n+m,2m,m)); exposes central binomial C(2m,m) for van der Poorten §6 telescoping",
+      "S25: the vdP §6 cross-factor closes via TWO subset-of-a-subset identities, not one: the lower C(n,k)C(k,m)=C(n,m)C(n-m,k-m) (Mathlib Nat.choose_mul) and an upper companion C(n+k,k)C(k,m)=C(n+m,m)C(n+k,k-m) (Nat.choose_mul at (n+k,n+m,n) + three choose_symm flips). Their product trades the denominator pair C(n,m)C(n+m,m) for C(k,m)^2 times an integer cofactor, and m^3 C(k,m)^2 = m*(m*C(k,m))^2 divides lcm^3 by S21.",
+      "S25: the factor 2 of the alternating denominator is free: C(n,k)C(n+k,k) = C(n+k,2k)C(2k,k) (S24 reindex) and the central binomial C(2k,k)=2C(2k-1,k-1) is even (Pascal + Nat.choose_symm_half), so the SECOND copy of the outer square absorbs the 2. No 2-adic analysis needed."
     ],
     "mathlibGaps": [
       "No Apéry numbers in Mathlib (aperyA, aperyB are gallery-local).",
@@ -147,7 +156,9 @@
       "S15.5 STANDALONE-USE: independent of S16 A.2, A.1 already discharges the `C(n+m, m) ∣ lcmRange (n+m)` divisibility step for vdP §6's alternating-bilinear summand. Combined with the existing `lcmRange_dvd_of_le` (Part 8a, S8 ACT) — which lifts `lcmRange n ∣ lcmRange (n+m)` for any `m ≥ 0` — A.1 alone proves the `C(n+m, m)` denominator absorbs into `lcmRange n` modulo a side gcd-clearing argument. This gives a partial Path (D) result: low-order vdP terms (k ≤ 3) close without waiting for A.2. Audit task for next claim of this slug: re-read vdP §6 to derive the precise hypothesis A.1 covers (likely `n ≥ k` for k ≤ 3, leaving k ≥ 4 to A.2 + Kummer).",
       "Van der Poorten §6 alternating bilinear second summand: Cnk = ∑_{j=1}^k (-1)^{j+1}/(2 j^3 · C(n,j)^2 · C(n+j,j)^2). mul_choose_dvd_lcmRange now supplies m·C(n,m) ∣ lcmRange n; the squared-binomial denominators need j^3·C(n,j)^2·C(n+j,j)^2 ∣ (lcmRange n)^? — assess whether pow of mul_choose_dvd_lcmRange (via pow_dvd_lcmRange_pow analog) or a fresh C(n+j,j) factorization bound is required.",
       "Pure-binomial cross-factor: prove C(n+m,m) ∣ C(n,k)²·C(n+k,k)²/C(n,m)² for 1≤m≤k≤n (the vdP §6 telescoping, no lcm) — this is the remaining gap after S24 separated out the lcm chunk",
-      "Use choose_mul_choose_reindex to route the C(2m,m) central-binomial divisibility (C(2m,m) ∣ lcm(1..2m)) into the cross-factor analysis"
+      "Use choose_mul_choose_reindex to route the C(2m,m) central-binomial divisibility (C(2m,m) ∣ lcm(1..2m)) into the cross-factor analysis",
+      "S25 DONE: per-term denominator analysis of the alternating half is COMPLETE (Part 15, 8 theorems, build-verified under v4.31, foundational axioms only). The S24 cross-factor gap and the /2 are both discharged; alt_term_lcm_clear gives the Q-level per-term shape.",
+      "S26 ACT (summation assembly): define the alternating inner sum altSum n k = sum_{m=1}^{k} (-1)^(m-1)/(2 m^3 C(n,m) C(n+m,m)) and prove exists z : Int, (lcmRange n)^3 * (C(n,k)^2 C(n+k,k)^2) * altSum n k = z by summing alt_term_lcm_clear over m in Finset.Icc 1 k (Int needed for the sign; the m-quotients from alt_term_lcm_clear enter with (-1)^(m-1)). Then combine with harmonicCubed_lcm_clear (Part 4) per k, sum over k in range (n+1) against the vdP closed form of aperyA, and discharge the parent denominator_control axiom. Definitional bridge needed: this file has no aperyA; either import the parent BaselProblemOQ01OQ01OQ02 (heavy analytic deps) or restate the closed form locally and prove equality where the axiom lives."
     ]
   },
   "tags": [
@@ -219,7 +230,7 @@
     ]
   },
   "started": "2026-04-26T08:56:57.649Z",
-  "lastUpdate": "2026-06-14T19:10:00Z",
+  "lastUpdate": "2026-07-20T22:10:00.000Z",
   "significance": 7,
   "tractability": 5,
   "leanFiles": [
@@ -292,8 +303,8 @@
     {
       "path": "Proofs/BaselProblemOQ01OQ01OQ02OQ02.lean",
       "filename": "BaselProblemOQ01OQ01OQ02OQ02.lean",
-      "lineCount": 1097,
-      "theoremCount": 41,
+      "lineCount": 1314,
+      "theoremCount": 49,
       "axiomCount": 0,
       "defCount": 2,
       "sorryCount": 0,


### PR DESCRIPTION
Session 25 (ACT) on basel-problem-oq-01-oq-01-oq-02-oq-02: close the
pure-binomial cross-factor gap left by S24, factor 2 included.

New in Proofs/BaselProblemOQ01OQ01OQ02OQ02.lean (+8 theorems, 0 sorries,
0 axioms, foundational axioms only via #print axioms):

- choose_add_mul_choose: upper subset-of-a-subset identity
  C(n+k,k)·C(k,m) = C(n+m,m)·C(n+k,k-m)
- choose_cross_product_eq: product with Nat.choose_mul trades
  C(n,m)·C(n+m,m) for C(k,m)² times an integer cofactor
- cube_mul_choose_sq_dvd_lcmRange_cube: m³·C(k,m)² ∣ (lcmRange n)³
- alt_denom_core_dvd: m³·C(n,m)·C(n+m,m) ∣ lcm³·C(n,k)·C(n+k,k)
- two_dvd_central_binom / two_dvd_choose_mul_choose_add: the outer
  pair C(n,k)·C(n+k,k) is even, absorbing the alternating term's /2
- alt_denom_dvd_lcmRange_cube_mul_sq (capstone):
  2·m³·C(n,m)·C(n+m,m) ∣ (lcmRange n)³·C(n,k)²·C(n+k,k)²  (1≤m≤k≤n)
- alt_term_lcm_clear: ℚ-level per-term clearing via Nat.cast_div

With this, every summand of the alternating-bilinear half of the van
der Poorten closed form clears against (lcmRange n)³ times the Apéry
outer square. Remaining for the parent denominator_control axiom:
summation-level assembly only (documented in tracker nextSteps).

Build-verified: lake build Proofs.BaselProblemOQ01OQ01OQ02OQ02 clean
under Lean v4.31.0 + pinned Mathlib (remote container; Docker wrapper
unavailable there, container provides the memory isolation).

Trackers updated: knowledge.md S25 note, problem JSON (insights /
builtItems / nextSteps / progressSummary / leanFiles counts), registry
lastUpdate, technique index.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01GbAS86NATxB51LSV5aSBe5