### PR TITLE
Enrich chebyshev-pnt-bridge-oq-03: fix overlapping section ranges

### DIFF
--- a/src/data/proofs/chebyshev-pnt-bridge-oq-03/meta.json
+++ b/src/data/proofs/chebyshev-pnt-bridge-oq-03/meta.json
@@ -125,14 +125,14 @@
       "id": "pi-doubling",
       "title": "π Grows Across Each Doubling",
       "startLine": 42,
-      "endLine": 79,
+      "endLine": 74,
       "summary": "Main consequences: π(2n) ≥ π(n) + 1 (the Bertrand prime is new), π(2^k) ≥ k by induction, and a prime in (2^k, 2^(k+1)].",
       "mathContext": "π'(n+1) ≤ π'(p) < π'(p+1) ≤ π'(2n+1) via monotonicity and the count_succ jump at the prime p."
     },
     {
       "id": "examples",
       "title": "Strictness and Explicit Cases",
-      "startLine": 76,
+      "startLine": 75,
       "endLine": 89,
       "summary": "π(n) < π(2n) strictly, and explicit primes in (1,2] and (5,10].",
       "mathContext": "Bertrand at n = 1 gives 2; at n = 5 gives 7."


### PR DESCRIPTION
Enrichment pass for `chebyshev-pnt-bridge-oq-03` (quality 96).

## Genuine defect: two sections overlapped (double-covered lines 76–79)

In `meta.json`, `pi-doubling` (42–79) and `examples` (76–89) overlapped. The double-covered span 76–79 is the strictness theorem `primeCounting_lt_two_mul` (docstring 75, body 76–79 in `Proofs/ChebyshevPNTBridgeOQ03.lean`). By title and summary that theorem belongs to **"Strictness and Explicit Cases"** (`examples`: *"π(n) < π(2n) strictly, and explicit primes..."*), not to `pi-doubling` (whose summary lists only the three growth theorems π(2n)≥π(n)+1, π(2^k)≥k, and a prime in (2^k, 2^{k+1}]).

Fix:
- `pi-doubling` 42–79 → 42–74 (ends after `exists_prime_between_consecutive_powers`)
- `examples` 76–89 → 75–89 (starts at the strictness theorem's docstring)

Coverage is now contiguous and non-overlapping (1–35, 37–40, 42–74, 75–89), and the strictness theorem's docstring (line 75), previously uncovered, is now included. Meta-only; no content deleted, metadata unchanged (0 axioms, 0 sorries).