### PR TITLE
Enrich chebyshev-pnt-bridge-oq-03-oq-01: add missing section for 6th theorem

### DIFF
--- a/src/data/proofs/chebyshev-pnt-bridge-oq-03-oq-01/meta.json
+++ b/src/data/proofs/chebyshev-pnt-bridge-oq-03-oq-01/meta.json
@@ -83,8 +83,8 @@
       "id": "header",
       "title": "Overview",
       "startLine": 1,
-      "endLine": 50,
-      "summary": "Module docstring: isolate the elementary half of the θ ↔ π equivalence — the two-sided sandwich transferring the asymptotic between θ and π·log — while the deep PNT limit stays blocked."
+      "endLine": 53,
+      "summary": "Module docstring: isolate the elementary half of the θ ↔ π equivalence — the two-sided sandwich transferring the asymptotic between θ and π·log — while the deep PNT limit stays blocked; then the imports (Primorial, PrimeCounting, Real.log, the θ-bound and sibling bridge files) and the `open Finset` / `open ChebyshevThetaBound` setup."
     },
     {
       "id": "card",
@@ -118,8 +118,16 @@
       "id": "sandwich",
       "title": "The packaged sandwich",
       "startLine": 148,
-      "endLine": 155,
+      "endLine": 153,
       "summary": "chebyshev_theta_primeCounting_sandwich: the two halves conjoined — the analysis-free reduction underlying θ(x) ~ x ⟺ π(x) ~ x/log x."
+    },
+    {
+      "id": "ratio-form",
+      "title": "Limit-ready ratio form",
+      "startLine": 155,
+      "endLine": 189,
+      "summary": "primeCounting_mul_log_div_sandwich: dividing both halves of the sandwich by n puts the normalized count π(n)·log n / n between θ(n)/n and θ(n)/n·(log n/log y) + y·log n/n — exactly the shape the PNT limit consumes, so that choosing y ≈ n/(log n)² (with y/n → 0, log n/log y → 1) forces π(n)·log n / n → 1 ⟺ θ(n)/n → 1, leaving only elementary o(1) bookkeeping (the deep θ(n)/n → 1 being Wiener–Ikehara-level, blocked in the pinned Mathlib). Closes the namespace.",
+      "mathContext": "$\\frac{\\theta(n)}{n} \\le \\frac{\\pi(n)\\log n}{n} \\le \\frac{\\theta(n)}{n}\\cdot\\frac{\\log n}{\\log y} + \\frac{y\\log n}{n}$."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
Enrichment pass for `chebyshev-pnt-bridge-oq-03-oq-01` (quality 96).

## Genuine defect: a whole theorem had no section; 34 lines uncovered

The `sections` array covered only the first 5 of the file's 6 theorems and stopped at line 155, leaving lines 156–189 of `Proofs/ChebyshevPNTBridgeOQ03OQ01.lean` (189 lines) unhighlighted:

- **Missing section.** The entire 6th theorem `primeCounting_mul_log_div_sandwich` (docstring 155–162, body 163–187) and the namespace close (189) had no section at all. Added a new **`ratio-form`** section (155–189) describing the limit-ready ratio form of the θ ↔ π sandwich.
- **`sandwich`** ended at 155, spilling into the next theorem's docstring; its content (`chebyshev_theta_primeCounting_sandwich`) ends at 153 → **148–153**.
- **`header`** ended at 50 (last import), leaving `open Finset` and `open ChebyshevThetaBound` (52–53) uncovered → **1–53**.

Coverage now runs contiguously to EOF (189). Meta-only; no content deleted, counts unchanged (`theoremCount` 6 already correct), 0 axioms, 0 sorries, no native_decide.
