### PR TITLE
Enrich chebyshev-pnt-bridge-oq-04: fix section coverage gaps

### DIFF
--- a/src/data/proofs/chebyshev-pnt-bridge-oq-04/meta.json
+++ b/src/data/proofs/chebyshev-pnt-bridge-oq-04/meta.json
@@ -89,8 +89,8 @@
       "id": "header",
       "title": "Overview",
       "startLine": 1,
-      "endLine": 61,
-      "summary": "Module docstring framing OQ#4: Mertens' first theorem via the von Mangoldt floor identity, listing the three verified steps, the two analytic inputs, and the prime-power strip to the honest prime sum."
+      "endLine": 67,
+      "summary": "Module docstring framing OQ#4: Mertens' first theorem via the von Mangoldt floor identity, listing the three verified steps, the two analytic inputs, and the prime-power strip to the honest prime sum; then the import, the `open Finset` / `open scoped BigOperators ArithmeticFunction` setup, and the namespace."
     },
     {
       "id": "floor-identity",
@@ -128,7 +128,7 @@
       "id": "prime-power-strip",
       "title": "Prime-Power Strip — Upper Bound for the Honest Prime Sum",
       "startLine": 261,
-      "endLine": 322,
+      "endLine": 323,
       "summary": "primeLogRecip (Σ_{p≤N} (log p)/p) and primePowerTail (R(N) = Σ_{d≤N, ¬prime} Λ(d)/d) are defined; lambdaRecip_prime_split proves the exact decomposition Σ Λ(d)/d = Σ_{p≤N}(log p)/p + R(N) via Finset.sum_filter_add_sum_filter_not and vonMangoldt_apply_prime; primePowerTail_nonneg gives R(N) ≥ 0; primeLogRecip_le transfers the upper half Σ_{p≤N}(log p)/p ≤ log N + (1+c_S+c_ψ) with no new assumptions.",
       "mathContext": "Σ_{p≤N} (log p)/p ≤ log N + (1 + c_S + c_ψ) for N ≥ 2 — the upper half of Mertens' first theorem for the genuine prime sum."
     }


### PR DESCRIPTION
Enrichment pass for `chebyshev-pnt-bridge-oq-04` (quality 96).

## Genuine defect: two `sections` left file regions uncovered

Cross-checking against `Proofs/ChebyshevPNTBridgeOQ04.lean` (323 lines):

| section | was | issue | now |
|---|---|---|---|
| header | 1–61 | ends at docstring close, leaving `import Mathlib` (62), the `open Finset` / `open scoped BigOperators ArithmeticFunction` setup (64–65), and the namespace (67) uncovered | 1–67 |
| prime-power-strip | 261–322 | ends one line short, leaving the namespace close `end` (323) uncovered | 261–323 |

Coverage now runs contiguously to EOF (323). The five middle/body sections were already aligned. Summaries preserved (header summary widened to name the import/opens/namespace setup). Meta-only; no content deleted, metadata unchanged (0 axioms).
