### PR TITLE
Research: combinations-formula-oq-03-oq-04 — general palindrome→unimodal criterion + Sylvester reduction (0-axiom)

### DIFF
--- a/proofs/Proofs/CombinationsFormulaOQ03OQ04.lean
+++ b/proofs/Proofs/CombinationsFormulaOQ03OQ04.lean
@@ -443,38 +443,61 @@ theorem unimodal_of_nonincreasing {f : ℕ → ℤ} (h : ∀ i, f (i + 1) ≤ f 
 theorem unimodal_const (c : ℤ) : Unimodal (fun _ => c) :=
   unimodal_of_nonincreasing (fun _ => le_refl c)
 
+/-- **Palindromic sequences that rise to the midpoint are unimodal (any degree).**
+A nonnegative sequence `f` supported on `[0, d]`, palindromic there (`f j = f (d - j)`
+for `j ≤ d`), and weakly increasing across the first half (`f j ≤ f (j+1)` whenever
+`2j + 2 ≤ d`), is unimodal with peak at `⌊d/2⌋`.  The falling half is recovered from the
+rising half by reflecting each interior descending step through the palindrome symmetry;
+the single central step of an **odd**-degree array (`d = 2i+1`, where the two middle
+coefficients `f i, f (i+1)` are forced equal by palindromy) is discharged directly, and
+nonnegativity closes the boundary step past the support (`f (d+1) = 0 ≤ f d`).  This
+generalises `unimodal_of_even_palindrome_first_half_mono` to **odd** degrees, and is the
+reusable reduction lemma for Sylvester's theorem: for any symmetric coefficient array,
+unimodality follows from weak monotonicity of its first half alone. -/
+theorem unimodal_of_palindrome_first_half_mono {f : ℕ → ℤ} (d : ℕ)
+    (hnonneg : ∀ j, 0 ≤ f j)
+    (hsupp : ∀ j, d < j → f j = 0)
+    (hpal : ∀ j, j ≤ d → f j = f (d - j))
+    (hmono : ∀ j, 2 * j + 2 ≤ d → f j ≤ f (j + 1)) :
+    Unimodal f := by
+  refine ⟨d / 2, fun i hi => hmono i (by omega), ?_⟩
+  intro i hi
+  rcases lt_or_ge i d with hlt | hge
+  · -- `⌊d/2⌋ ≤ i < d`: reflect the descending step into the rising half
+    have h1 : f (i + 1) = f (d - (i + 1)) := hpal (i + 1) (by omega)
+    have h2 : f i = f (d - i) := hpal i (by omega)
+    rw [h1, h2]
+    rcases lt_or_ge d (2 * (d - i - 1) + 2) with hc | hc
+    · -- exact centre of an odd array (`d = 2i+1`): the two middle coeffs are equal
+      have heq : f i = f (i + 1) := by
+        have hp := hpal i (by omega)
+        rwa [show d - i = i + 1 from by omega] at hp
+      rw [show d - (i + 1) = i from by omega, show d - i = i + 1 from by omega]
+      exact le_of_eq heq
+    · -- interior descending step ↦ ascending step `f (d-i-1) ≤ f (d-i)`
+      have hstep := hmono (d - i - 1) (by omega)
+      rw [show d - i - 1 + 1 = d - i from by omega] at hstep
+      rw [show d - (i + 1) = d - i - 1 from by omega]
+      exact hstep
+  · -- `i ≥ d`: past the support, `f (i+1) = 0 ≤ f i`
+    have hs1 : f (i + 1) = 0 := hsupp (i + 1) (by omega)
+    rw [hs1]; exact hnonneg i
+
 /-- **Even-degree palindromic sequences that rise to the midpoint are unimodal.**
 A nonnegative sequence `f` supported on `[0, 2m]`, palindromic there
 (`f j = f (2m - j)`), and weakly increasing on the first half (`f j ≤ f (j+1)` for
-`j < m`), is unimodal with peak at `m`.  The falling half is recovered from the
-rising half through the palindrome symmetry — reflecting an interior descending step
-`f (i+1) ≤ f i` (with `m ≤ i < 2m`) to the ascending step `f (2m-i-1) ≤ f (2m-i)` —
-and nonnegativity discharges the single boundary step `f (2m+1) = 0 ≤ f (2m)`.  This
-is the clean route to unimodality for a symmetric coefficient array whose left half is
-understood: it is used below for `k = 2`, where the degree `2(n-2)` is even and the
-first half is the explicit ramp `⌊j/2⌋+1`. -/
+`j < m`), is unimodal with peak at `m`.  The even-degree specialisation of
+`unimodal_of_palindrome_first_half_mono` (`d = 2m`, where `2j+2 ≤ 2m ⇔ j < m`); it is
+used below for `k = 2`, where the degree `2(n-2)` is even and the first half is the
+explicit ramp `⌊j/2⌋+1`. -/
 theorem unimodal_of_even_palindrome_first_half_mono {f : ℕ → ℤ} (m : ℕ)
     (hnonneg : ∀ j, 0 ≤ f j)
     (hsupp : ∀ j, 2 * m < j → f j = 0)
     (hpal : ∀ j, j ≤ 2 * m → f j = f (2 * m - j))
     (hmono : ∀ j, j < m → f j ≤ f (j + 1)) :
-    Unimodal f := by
-  refine ⟨m, fun i hi => hmono i hi, ?_⟩
-  intro i hi
-  rcases lt_or_ge i (2 * m) with hlt | hge
-  · -- `m ≤ i < 2m`: reflect into the rising half via palindromy
-    have h1 : f (i + 1) = f (2 * m - (i + 1)) := hpal (i + 1) (by omega)
-    have h2 : f i = f (2 * m - i) := hpal i (by omega)
-    have hstep := hmono (2 * m - (i + 1)) (by omega)
-    rw [show 2 * m - (i + 1) + 1 = 2 * m - i from by omega] at hstep
-    rw [h1, h2]; exact hstep
-  · -- `i ≥ 2m`: past (or at) the top of the support
-    have hs1 : f (i + 1) = 0 := hsupp (i + 1) (by omega)
-    rcases eq_or_lt_of_le hge with heq | hgt
-    · -- `i = 2m`: `f (2m+1) = 0 ≤ f (2m)`
-      have := hnonneg i; omega
-    · -- `i > 2m`: both endpoints vanish
-      have hs2 : f i = 0 := hsupp i (by omega); omega
+    Unimodal f :=
+  unimodal_of_palindrome_first_half_mono (2 * m) hnonneg hsupp hpal
+    (fun j hj => hmono j (by omega))
 
 /-- **Direct geometric-sum form of the q-number.**  `[n]_q = ∑_{i<n} qⁱ`.  The parent file
     only provides the `(q-1)`-multiplied identity `qNumber_geometric`; this un-multiplied sum
@@ -627,6 +650,39 @@ theorem qBinomCoeff_unimodal_two (n : ℕ) :
       have hdiv : (j / 2 : ℕ) ≤ (j + 1) / 2 := Nat.div_le_div_right (Nat.le_succ j)
       have : ((j / 2 : ℕ) : ℤ) ≤ (((j + 1) / 2 : ℕ) : ℤ) := by exact_mod_cast hdiv
       linarith
+
+/-! ### The general reduction: unimodality ⇐ first-half monotonicity (all `n, k`)
+
+Sylvester's theorem for a *fixed* `k` now reduces to a single inequality: the coefficient
+array of `[n choose k]_q` is symmetric (`qBinom_X_coeff_symm'`), nonnegative
+(`qBinom_X_coeff_nonneg`), and supported on `[0, k(n-k)]` (`qBinom_X_natDegree`), so its
+unimodality follows from the general palindrome criterion the *moment* one knows the array
+is weakly increasing across its first half.  The lemma below packages the three structural
+facts, leaving future `k`-cases to supply only `coeff j ≤ coeff (j+1)` for `2j+2 ≤ k(n-k)`.
+This is exactly the shape in which `k = 2` (`qBinomCoeff_unimodal_two`) was proved, and the
+`k = 0, 1` cases (non-increasing arrays) are the degenerate instance with an empty first
+half. -/
+
+open Polynomial in
+/-- **Sylvester's theorem reduces to first-half monotonicity.**  For `k ≤ n`, if the
+coefficient sequence of `[n choose k]_q` is weakly increasing across its first half —
+`(qBinom X n k).coeff j ≤ (qBinom X n k).coeff (j+1)` whenever `2j + 2 ≤ k(n-k)` — then the
+whole sequence is unimodal.  The falling half, the central step, and the tail past the
+degree are all supplied by `unimodal_of_palindrome_first_half_mono` from the already-proved
+nonnegativity, degree, and palindromy of the Gaussian polynomial.  This is the reusable
+reduction: any future proof of Sylvester unimodality for a given `k` need only establish the
+first-half inequality. -/
+theorem qBinomCoeff_unimodal_of_first_half_mono {n k : ℕ} (h : k ≤ n)
+    (hmono : ∀ j, 2 * j + 2 ≤ k * (n - k) →
+      (qBinom (X : ℤ[X]) n k).coeff j ≤ (qBinom (X : ℤ[X]) n k).coeff (j + 1)) :
+    Unimodal (fun j => (qBinom (X : ℤ[X]) n k).coeff j) := by
+  apply unimodal_of_palindrome_first_half_mono (k * (n - k))
+  · intro j; exact qBinom_X_coeff_nonneg n k j
+  · intro j hj
+    apply coeff_eq_zero_of_natDegree_lt
+    rw [qBinom_X_natDegree h]; omega
+  · intro j hj; exact qBinom_X_coeff_symm' h hj
+  · exact hmono
 
 end QBinomialCoefficients
 

--- a/research/problems/combinations-formula-oq-03-oq-04/knowledge.md
+++ b/research/problems/combinations-formula-oq-03-oq-04/knowledge.md
@@ -38,6 +38,32 @@ Sylvester unimodality for general k needs sl₂-action / hard Lefschetz (Proctor
 O'Hara's (1990) combinatorial symmetric-chain decomposition — research-grade formalization,
 not yet started.
 
+### 2026-07-20 (researcher-1, S3) — general any-degree criterion + Sylvester reduction lemma
+
+- **Gap in the even-only criterion.** `unimodal_of_even_palindrome_first_half_mono`
+  handled only degree `d = 2m`. `[n,k]_q` has degree `k(n-k)`, which is **odd** whenever
+  `k` and `n-k` are both odd (e.g. `k=3, n-k` odd → `k=3` cases, `k=5`, …). So the k=2
+  route (always even degree `2(n-2)`) hid the need for the odd case.
+- **`unimodal_of_palindrome_first_half_mono d`** (0 ax / 0 sorry): nonneg + support `[0,d]`
+  + palindrome `f j = f(d-j)` + first-half rise (`f j ≤ f(j+1)` while `2j+2 ≤ d`) ⇒ unimodal,
+  peak `⌊d/2⌋`. Falling half by reflecting each descending step to a rising one; the lone
+  odd-centre step (`d=2i+1`, where palindromy forces `f i = f(i+1)`) is discharged by that
+  equality; the tail past `d` by nonnegativity. **The old even lemma is now a one-line
+  corollary** (`d = 2m`, and `2j+2 ≤ 2m ⇔ j < m`) — statement unchanged, so k=2 and the
+  `Unimodal.lean` bridge are untouched.
+- **`qBinomCoeff_unimodal_of_first_half_mono (h : k ≤ n)`** (0 ax / 0 sorry): the packaged
+  reduction. Feeds the file's already-proved nonnegativity (`qBinom_X_coeff_nonneg`),
+  degree (`qBinom_X_natDegree`), and palindromy (`qBinom_X_coeff_symm'`) into the general
+  criterion, leaving a future k-case to supply ONLY `coeff j ≤ coeff (j+1)` for
+  `2j+2 ≤ k(n-k)`. This is the exact shape `qBinomCoeff_unimodal_two` already fits.
+- Host-verified `lake env lean` exit 0 (fresh parent olean at `.lake/build/lib/lean/Proofs/`).
+  `#print axioms` on all three = `[propext, Classical.choice, Quot.sound]`.
+
+**Guidance for next session:** the target is now a *single inequality* per `k`. For `k=3`
+(`[n,3]_q`, partitions in a `3×(n-3)` box) derive the first-half coefficient behaviour and
+feed it to `qBinomCoeff_unimodal_of_first_half_mono`. The k≥3 first-half monotonicity is
+still the genuine open crux (sl₂ / O'Hara).
+
 ---
 
 ## Dead Ends

--- a/research/problems/combinations-formula-oq-03-oq-04/state.md
+++ b/research/problems/combinations-formula-oq-03-oq-04/state.md
@@ -33,12 +33,27 @@ the sequence genuinely rises then falls (e.g. `[6,2]_q = 1,1,2,2,3,2,2,1,1`), ar
 open crux and need the sl₂-action / hard-Lefschetz argument (Proctor 1982) or O'Hara's
 combinatorial decomposition (1990). Not attempted here.
 
-## Next Action (item toward k = 2)
-Derive the explicit coefficient formula for `[n,2]_q` (partitions into ≤ 2 parts each
-≤ n−2; `a_i = ⌊i/2⌋+1` capped and mirrored), then prove `IsCoeffUnimodal (qBinom X n 2)`
-by direct inequality on that formula — the named "tractable first milestone" in
-problem.md. This is the first case where the peak is interior and `_of_antitone` no
-longer applies, so it exercises the rising-then-falling reasoning.
+## Status (S3, researcher-1, 2026-07-20) — general reduction: Sylvester ⇐ first-half monotonicity
+
+k=0,1,2 are already discharged (`qBinomCoeff_unimodal_{zero,one,two}`). This session
+removed the last *structural* obstacle for all remaining k:
+
+- `unimodal_of_palindrome_first_half_mono d` — general any-degree palindrome→unimodal
+  criterion (odd degrees now covered; the previous lemma handled only even `2m`). The even
+  lemma is refactored to a one-line corollary, statement unchanged.
+- `qBinomCoeff_unimodal_of_first_half_mono (h : k ≤ n)` — the packaged reduction: supplies
+  nonnegativity + support + palindromy, so proving Sylvester for a given `k` now needs ONLY
+  the first-half inequality `coeff j ≤ coeff (j+1)` for `2j+2 ≤ k(n-k)`.
+
+Both 0-axiom / 0-sorry, host-verified (`lake env lean` exit 0, axioms
+`[propext, Classical.choice, Quot.sound]`).
+
+## Next Action (item toward k = 3)
+`[n,3]_q` = generating function of partitions in a `3×(n-3)` box. Derive the first-half
+coefficient behaviour (`coeff` weakly increasing up to `⌊3(n-3)/2⌋`) and feed it to
+`qBinomCoeff_unimodal_of_first_half_mono`. The degree `3(n-3)` is odd exactly when `n` is
+even, so this is the first case that genuinely exercises the new odd-degree branch. The
+first-half monotonicity itself remains the open crux (sl₂ / O'Hara).
 
 ## --- S1 template (never filled) below ---
 

--- a/src/data/proofs/combinations-formula-oq-03-oq-04/meta.json
+++ b/src/data/proofs/combinations-formula-oq-03-oq-04/meta.json
@@ -45,8 +45,8 @@
     "namespace": "QBinomialCoefficients",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 632,
-    "theoremCount": 27,
+    "lineCount": 688,
+    "theoremCount": 29,
     "definitionCount": 0
   },
   "overview": {

--- a/src/data/research/problems/combinations-formula-oq-03-oq-04.json
+++ b/src/data/research/problems/combinations-formula-oq-03-oq-04.json
@@ -700,7 +700,9 @@
       "Unimodality API + base cases k<=1 DONE (CombinationsFormulaOQ03OQ04Unimodal.lean): IsCoeffUnimodal predicate fills the Mathlib gap (no Unimodal predicate for integer sequences). isCoeffUnimodal_of_antitone: a non-increasing coeff sequence is unimodal (peak 0). qNumber_X_coeff: coeff array of qNumber X n is [j<n]. qBinom_X_coeff_one: coeffs of [n,1]_q are [j<n]. qBinom_X_unimodal_zero/_one: [n,0]_q and [n,1]_q coeff sequences are unimodal. VERIFIED docker 0-axiom. k>=2 (genuine rise-then-fall, needs sl2/O'Hara) remains the open crux.",
       "FORK DISCOVERED: two parallel unimodality developments on main. CombinationsFormulaOQ03OQ04.lean (PR #39392) uses predicate Unimodal (ℕ→ℤ) and ALREADY proves k=0,1,2 + the palindrome criterion unimodal_of_even_palindrome_first_half_mono. CombinationsFormulaOQ03OQ04Unimodal.lean (PR #39438) uses a different predicate IsCoeffUnimodal and was stuck at k≤1; its stated next-step (re-prove k=2) was duplicative.",
       "Resolved the fork with isCoeffUnimodal_iff_unimodal_coeff: the predicates are provably equivalent (forward = specialise blocks to single steps; backward = telescope adjacent steps into monotone blocks by induction on the gap). Transports k=2 (and any future Unimodal-based result) into IsCoeffUnimodal for free; qBinom_X_unimodal_two now holds without re-proof.",
-      "Going forward, prove new k-cases ONCE against Unimodal (which has the palindrome criterion + coefficient machinery) and transport via the bridge; do not re-develop IsCoeffUnimodal-specific proofs."
+      "Going forward, prove new k-cases ONCE against Unimodal (which has the palindrome criterion + coefficient machinery) and transport via the bridge; do not re-develop IsCoeffUnimodal-specific proofs.",
+      "General palindrome→unimodal criterion (any degree, odd included): unimodal_of_palindrome_first_half_mono in CombinationsFormulaOQ03OQ04.lean. A nonneg sequence supported on [0,d], palindromic (f j = f(d-j)), and weakly rising while 2j+2≤d is unimodal with peak ⌊d/2⌋. The odd-degree central step (d=2i+1, f i = f(i+1) forced equal by palindromy) is the case the prior even-only lemma could not reach.",
+      "The whole Sylvester problem for a fixed k now reduces to ONE inequality: qBinomCoeff_unimodal_of_first_half_mono (k≤n) packages nonnegativity (qBinom_X_coeff_nonneg), degree/support (qBinom_X_natDegree), and palindromy (qBinom_X_coeff_symm) — any future k-case need only supply coeff j ≤ coeff (j+1) for 2j+2 ≤ k(n-k)."
     ],
     "builtItems": [
       "qBinom_reciprocal (CombinationsFormulaOQ03OQ04.lean): [n,k]_q = q^{k(n-k)} times [n,k]_{q inverse} over a field, induction on n using both q-Pascal identities",
@@ -714,7 +716,10 @@
       "qBinom_X_reflect + qBinom_X_coeff_symm/_symm' in CombinationsFormulaOQ03OQ04.lean (researcher-10, 2026-07-12, VERIFIED 0-axiom/0-sorry, propext/Classical/Quot only): COEFFICIENT PALINDROMY over ℤ[X] — reflect (k*(n-k)) (qBinom X n k) = qBinom X n k for k≤n. The integral coefficient-level form of the field identity qBinom_reciprocal, proved directly over ℤ[X] by induction on q-Pascal using Polynomial.reflect: reflecting the FIRST Pascal expansion A+X^{k+1}B (reflect_add + reflect_mul, with reflect(k+1)(X^{k+1})=1 and reflect at degree k*(n-k) fixed by IH+natDegree) yields X^{n-k}A+B = the SECOND Pascal expansion (qBinom_pascal'). Corollaries: qBinom_X_coeff_symm (coeff j = coeff (revAt (k(n-k)) j) via coeff_reflect) and qBinom_X_coeff_symm' (coeff j = coeff (k(n-k)-j) for j≤k(n-k), the a_j=a_{D-j} symmetric array of Sylvester). This is the rigorous SYMMETRIC half of symmetric-unimodal; interior unimodality (Proctor/sl₂) still open.",
       "IsCoeffUnimodal + isCoeffUnimodal_of_antitone + qNumber_X_coeff + qBinom_X_coeff_one + qBinom_X_unimodal_zero/_one in Proofs/CombinationsFormulaOQ03OQ04Unimodal.lean (docker-VERIFIED axiom-free)",
       "isCoeffUnimodal_iff_unimodal_coeff (bridge: IsCoeffUnimodal p ↔ Unimodal p.coeff) in CombinationsFormulaOQ03OQ04Unimodal.lean",
-      "qBinom_X_unimodal_two (k=2 in IsCoeffUnimodal form, transported via bridge) in CombinationsFormulaOQ03OQ04Unimodal.lean"
+      "qBinom_X_unimodal_two (k=2 in IsCoeffUnimodal form, transported via bridge) in CombinationsFormulaOQ03OQ04Unimodal.lean",
+      "unimodal_of_palindrome_first_half_mono (CombinationsFormulaOQ03OQ04.lean) — general any-degree palindrome+first-half-mono ⇒ Unimodal; 0 axiom, 0 sorry.",
+      "unimodal_of_even_palindrome_first_half_mono refactored to a one-line corollary of the general lemma (d=2m).",
+      "qBinomCoeff_unimodal_of_first_half_mono (CombinationsFormulaOQ03OQ04.lean) — Sylvester reduction lemma: first-half monotonicity ⇒ unimodal for all n,k; 0 axiom, 0 sorry."
     ],
     "mathlibGaps": [
       "No direct need: proof uses only parent q-binomial API plus elementary field/power lemmas (mul_inv_cancel_left_zero, inv_pow, pow_ne_zero, pow_add).",
@@ -726,9 +731,9 @@
       "Cross-check: palindromy plus the parent qBinom_symm ([n,k] = [n,n-k]) give the full symmetry group of the coefficient array.",
       "Attempt unimodality proper: sl₂ raising/lowering operator action (Proctor 1982) or an O'Hara-style explicit injection between adjacent coefficient levels."
     ],
-    "progressSummary": "PROGRESS: Unified the two forked unimodality developments. Added isCoeffUnimodal_iff_unimodal_coeff (IsCoeffUnimodal p ↔ Unimodal p.coeff) and transported k=2 (qBinom_X_unimodal_two). 0 sorry, 0 axiom. k≥3 (sl2/O_Hara) remains the open crux."
+    "progressSummary": "PROGRESS: Reduced Sylvester unimodality for every (n,k) to a single first-half-monotonicity inequality. Added a general any-degree palindrome→unimodal criterion (odd degrees now covered, generalising the previous even-only lemma) and the packaged reduction qBinomCoeff_unimodal_of_first_half_mono. Base/small cases k=0,1,2 already discharged upstream. Open crux k≥3: supply the first-half monotone inequality (still needs sl₂/hard-Lefschetz or O Hara)."
   },
   "currentState": "Bridged the two forked unimodality predicates (researcher-1): isCoeffUnimodal_iff_unimodal_coeff proves IsCoeffUnimodal p ↔ Unimodal p.coeff, unifying CombinationsFormulaOQ03OQ04Unimodal.lean (IsCoeffUnimodal, was k≤1) with CombinationsFormulaOQ03OQ04.lean (Unimodal, has k=0,1,2 + palindrome criterion). k=2 transported (qBinom_X_unimodal_two), no re-proof. 0 axioms. k≥3 open.",
-  "lastUpdate": "2026-07-20T00:00:00.000Z",
+  "lastUpdate": "2026-07-20",
   "nextAction": "Prove new k-cases against Unimodal + palindrome criterion and transport via the bridge (do not re-fork IsCoeffUnimodal). k≥3 needs sl2/hard-Lefschetz (Proctor 1982) or O_Hara (1990) — research-grade, not started."
 }


### PR DESCRIPTION
## Summary
Research session on **Unimodality of Gaussian (q-)binomial coefficients** (`combinations-formula-oq-03-oq-04`). Reduces Sylvester's unimodality theorem, for **every** `(n,k)`, to a single first-half-monotonicity inequality, and removes the last *structural* gap (odd degrees) in the existing palindrome machinery.

## Progress
- **`unimodal_of_palindrome_first_half_mono d`** — general **any-degree** criterion: a nonnegative sequence supported on `[0,d]`, palindromic (`f j = f (d-j)`), and weakly increasing while `2j+2 ≤ d`, is unimodal with peak `⌊d/2⌋`. The falling half is reflected from the rising half; the lone odd-degree central step (`d = 2i+1`, where palindromy forces `f i = f (i+1)`) is discharged by that equality; the tail past `d` by nonnegativity. This covers **odd** degrees `k(n-k)` (e.g. every odd `k` with odd `n-k`), which the previous even-only lemma could not reach.
- **`unimodal_of_even_palindrome_first_half_mono`** refactored to a one-line corollary (`d = 2m`); **statement unchanged**, so the `k=2` proof and the `CombinationsFormulaOQ03OQ04Unimodal.lean` bridge are untouched.
- **`qBinomCoeff_unimodal_of_first_half_mono (h : k ≤ n)`** — the packaged reduction: feeds the file's already-proved nonnegativity (`qBinom_X_coeff_nonneg`), degree (`qBinom_X_natDegree`), and palindromy (`qBinom_X_coeff_symm'`) into the general criterion, so any future `k`-case need only supply `coeff j ≤ coeff (j+1)` for `2j+2 ≤ k(n-k)`.

## Files modified
- `proofs/Proofs/CombinationsFormulaOQ03OQ04.lean` (+2 theorems, 1 refactor; 27→29 theorems, 632→688 lines)
- research trackers (`research/problems/.../{knowledge,state}.md`, `src/data/research/problems/....json`)
- `src/data/proofs/.../meta.json` (leanFile counts)

## Findings
- The `k=2` route always had **even** degree `2(n-2)`, which hid the need for an odd-degree criterion; `k=3` (degree `3(n-3)`, odd for even `n`) is the first case that exercises the new branch.
- Sylvester unimodality for a fixed `k` is now a *single inequality*: first-half monotonicity of the coefficient sequence.

## Verification
- Host-verified `lake env lean` (fresh Mathlib-only parent olean), exit 0, 0 sorry.
- `#print axioms` on all three results = `[propext, Classical.choice, Quot.sound]` (axiom-free).

## Status
**Outcome**: progress (0-axiom infrastructure on the critical path)
**Next Steps**: prove the `k=3` first-half monotone inequality and feed it to `qBinomCoeff_unimodal_of_first_half_mono`. The general `k≥3` first-half monotonicity remains the open crux (sl₂ / hard-Lefschetz or O'Hara).

🤖 Generated by researcher-1