### PR TITLE
Research: abundant-number-oq-03-oq-03 — deficiency is divisor-downward-closed; Route-1 criterion simplified (0-axiom)

### DIFF
--- a/proofs/Proofs/AbundantNumberOQ03OQ03.lean
+++ b/proofs/Proofs/AbundantNumberOQ03OQ03.lean
@@ -210,4 +210,48 @@ theorem isPrimitiveAbundant_mul_prime {m p : ℕ} (hp : p.Prime) (hm : 0 < m)
   · exact hmdef d h
   · exact hpdef e he
 
+-- ============================================================
+-- Deficiency is inherited by divisors — simplifying the criterion
+-- ============================================================
+
+/-- **Deficiency via the abundancy index.**  For `n ≠ 0`, `n` is deficient exactly when its
+abundancy index `σ(n)/n` is below `2`.  The deficient counterpart of Mathlib's
+`Nat.abundant_iff_two_lt_abundancyIndex`. -/
+theorem deficient_iff_abundancyIndex_lt_two {n : ℕ} (hn : n ≠ 0) :
+    n.Deficient ↔ n.abundancyIndex < 2 := by
+  have hpos : (0 : ℚ) < (n : ℚ) := by exact_mod_cast Nat.pos_of_ne_zero hn
+  rw [abundancyIndex, div_lt_iff₀ hpos]
+  have hcast : ((∑ i ∈ n.divisors, i : ℕ) : ℚ) < 2 * (n : ℚ)
+      ↔ (∑ i ∈ n.divisors, i) < 2 * n := by
+    rw [show (2 : ℚ) * (n : ℚ) = ((2 * n : ℕ) : ℚ) by push_cast; ring]
+    exact Nat.cast_lt
+  rw [hcast, sum_divisors_eq_sum_properDivisors_add_self]
+  unfold Nat.Deficient
+  omega
+
+/-- **Deficiency is inherited by divisors.**  If `n` is deficient and `m ∣ n` (`m ≠ 0`), then
+`m` is deficient.  The abundancy index is monotone under divisibility
+(`Nat.abundancyIndex_le_of_dvd`), so `m`'s index is at most `n`'s, which is `< 2`.  This is the
+divisibility-downward dual of `Nat.Abundant.of_dvd`: every divisor of a deficient number is
+itself deficient. -/
+theorem deficient_of_dvd {m n : ℕ} (hn : n.Deficient) (hd : m ∣ n) (hm : m ≠ 0) :
+    m.Deficient := by
+  have hn0 : n ≠ 0 := by rintro rfl; exact absurd hn (by decide)
+  rw [deficient_iff_abundancyIndex_lt_two hm]
+  exact lt_of_le_of_lt (abundancyIndex_le_of_dvd hn0 hd)
+    ((deficient_iff_abundancyIndex_lt_two hn0).mp hn)
+
+/-- **Simplified primitivity criterion for `m · p`.**  Since deficiency is inherited by divisors
+(`deficient_of_dvd`), the "every divisor of `m` is deficient" hypothesis of
+`isPrimitiveAbundant_mul_prime` collapses to `m` itself being deficient.  So `m·p` is primitive
+abundant as soon as it is abundant, `m` is deficient, and every `p`-multiple of a proper divisor
+of `m` is deficient — one fewer obligation for a Route-1 witness search. -/
+theorem isPrimitiveAbundant_mul_prime' {m p : ℕ} (hp : p.Prime) (hm : 0 < m)
+    (hab : (m * p).Abundant) (hmdef : m.Deficient)
+    (hpdef : ∀ e ∈ m.properDivisors, (p * e).Deficient) :
+    IsPrimitiveAbundant (m * p) :=
+  isPrimitiveAbundant_mul_prime hp hm hab
+    (fun _ hd => deficient_of_dvd hmdef (mem_divisors.mp hd).1 (pos_of_mem_divisors hd).ne')
+    hpdef
+
 end AbundantNumberOQ03OQ03

--- a/research/problems/abundant-number-oq-03-oq-03/knowledge.md
+++ b/research/problems/abundant-number-oq-03-oq-03/knowledge.md
@@ -12,7 +12,33 @@ Insights accumulated during research on this problem.
 
 ## Insights
 
-[Insights from research attempts will be accumulated here]
+### 2026-07-20 (researcher-1, iteration 3) — deficiency is divisor-downward-closed; criterion simplified
+
+State.md's "Next Action" (build the coprime proper-divisor decomposition + full primitivity
+criterion) was already **done and merged** by #39789 (`mem_properDivisors_mul_prime`,
+`isPrimitiveAbundant_mul_prime`). This session simplified the criterion further.
+
+- **`deficient_iff_abundancyIndex_lt_two`** (`n ≠ 0`): `Deficient n ↔ abundancyIndex n < 2`.
+  The deficient counterpart of Mathlib's `Nat.abundant_iff_two_lt_abundancyIndex`. Proof:
+  `abundancyIndex n = σ(n)/n`, clear the `/n` (n>0), rewrite `σ(n) = σ'(n) + n`
+  (`sum_divisors_eq_sum_properDivisors_add_self`), and `Deficient n` unfolds to `σ'(n) < n`;
+  `omega` on the two nat forms.
+- **`deficient_of_dvd`** (`n.Deficient`, `m ∣ n`, `m ≠ 0` ⇒ `m.Deficient`): the
+  divisibility-**downward** dual of Mathlib's `Nat.Abundant.of_dvd`. Immediate from
+  abundancy-index monotonicity `Nat.abundancyIndex_le_of_dvd` (m's index ≤ n's index < 2).
+  Reusable, Mathlib-worthy.
+- **`isPrimitiveAbundant_mul_prime′`**: since every divisor of a deficient number is deficient,
+  the `∀ d ∈ m.divisors, d.Deficient` hypothesis of `isPrimitiveAbundant_mul_prime` collapses to
+  just `m.Deficient`. Route-1 witness search now needs only: (a) `2mp < σ(m)(p+1)`, (b) `m`
+  deficient, (c) each `p·e` deficient for proper divisors `e` of `m`.
+
+All three 0-axiom (`[propext, Classical.choice, Quot.sound]`), host-verified (`lake env lean`
+exit 0; `import Mathlib` only, no `Proofs.*` dependency).
+
+**Next**: the primitivity obligation is down to condition (c) plus abundance and a single
+deficiency of `m`. To reach infinitude, need an explicit odd deficient base family `mₖ` and a
+prime window `p` making `mₖ·p` abundant while all `p·e` stay deficient — still the genuine open
+crux (no such odd family is known to work infinitely often).
 
 ---
 

--- a/research/problems/abundant-number-oq-03-oq-03/state.md
+++ b/research/problems/abundant-number-oq-03-oq-03/state.md
@@ -35,9 +35,24 @@ divisors `{d, p·d : d ∣ m}` — still needs the coprime-product proper-diviso
 decomposition (no clean `Nat.Coprime.divisors_mul` Finset equality in Mathlib
 v4.31; would have to be built from `filter_dvd_eq_divisors`).
 
+## Update (2026-07-20, researcher-1 — iteration 3: criterion simplified)
+
+The prior "Next Action" (coprime proper-divisor decomposition + full primitivity iff) was
+already merged by #39789 (`mem_properDivisors_mul_prime`, `isPrimitiveAbundant_mul_prime`).
+This iteration simplified the criterion:
+
+- `deficient_iff_abundancyIndex_lt_two` — `Deficient n ↔ abundancyIndex n < 2` (n≠0).
+- `deficient_of_dvd` — deficiency is inherited by divisors (dual of `Nat.Abundant.of_dvd`),
+  via `Nat.abundancyIndex_le_of_dvd`.
+- `isPrimitiveAbundant_mul_prime′` — the all-divisors-of-`m`-deficient hypothesis collapses to
+  just `m.Deficient`. Route-1 obligation is now (a) `2mp < σ(m)(p+1)`, (b) `m` deficient,
+  (c) each `p·e` deficient for proper divisors `e` of `m`.
+
+All 0-axiom, host-verified (`lake env lean` exit 0, `import Mathlib` only).
+
 ## Next Action
-Route 1: build the coprime proper-divisor decomposition
-`(m·p).properDivisors = m.divisors ∪ (p · ·) '' (m.properDivisors)` so
-`abundant_mul_prime_iff` upgrades to a full `IsPrimitiveAbundant (m·p)` iff, then
-search for an explicit odd base `m` + prime window. Route 2 remains open on
-controlling oddness/unboundedness of primitive parts of `Nat.infinite_odd_abundant`.
+Route 1: pick an explicit odd deficient base family `mₖ` (e.g. odd `m` with `σ(m)/m` just below
+2) and a prime window `p` where `mₖ·p` is abundant while every `p·e` (proper divisor `e` of `m`)
+stays deficient — condition (c) is now the last non-trivial obligation. Infinitude remains
+genuinely open (no odd family known to satisfy this for infinitely many members). Route 2
+(primitive-part extraction from `Nat.infinite_odd_abundant`) unchanged.

--- a/src/data/research/problems/abundant-number-oq-03-oq-03.json
+++ b/src/data/research/problems/abundant-number-oq-03-oq-03.json
@@ -41,7 +41,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (base witness 945 + Route-1 σ-engine + Route-1 DIVISOR STRUCTURE; infinitude OPEN): added mem_properDivisors_mul_prime (proper divisors of m·p = divisors of m ⊔ p·(proper divisors of m), p prime) and isPrimitiveAbundant_mul_prime (full A006038 criterion reducing primitivity of m·p to deficiency conditions on m and its p-multiples). Closes the divisor-decomposition gap from the previous session. All axiom-free [propext,Classical.choice,Quot.sound], host-verified v4.31, no native_decide. Infinitude still open (needs an explicit infinite (m,p) family).",
+    "progressSummary": "PROGRESS: Simplified the Route-1 primitivity criterion. Proved deficiency is downward-closed under divisibility (deficient_of_dvd, dual of Nat.Abundant.of_dvd) via abundancy-index monotonicity, so isPrimitiveAbundant_mul_prime′ needs only m.Deficient in place of every-divisor-of-m-deficient. Route-1 obligation is now (a) 2mp<σ(m)(p+1), (b) m deficient, (c) p·e deficient for proper divisors e of m. Infinitude still genuinely open (no explicit odd family provably primitive-abundant infinitely often).",
     "builtItems": [
       "IsPrimitiveAbundant (A006038 predicate) in proofs/Proofs/AbundantNumberOQ03OQ03.lean",
       "OddPrimitiveAbundant set + mem_oddPrimitiveAbundant_945 (945 is a member) in AbundantNumberOQ03OQ03.lean",
@@ -51,7 +51,10 @@
       "sum_divisors_mul_prime: σ(m·p)=σ(m)(p+1) for p prime, p∤m via Nat.Coprime.sum_divisors_mul (axiom-free) in AbundantNumberOQ03OQ03.lean",
       "abundant_mul_prime_iff: (m·p).Abundant ↔ 2mp < σ(m)(p+1) via Nat.abundant_iff_sum_divisors (axiom-free) in AbundantNumberOQ03OQ03.lean",
       "deficient_left_of_primitive_mul_prime: Route-1 base m must be deficient (axiom-free) in AbundantNumberOQ03OQ03.lean",
-      "mem_properDivisors_mul_prime + isPrimitiveAbundant_mul_prime in AbundantNumberOQ03OQ03.lean (axiom-free [propext, Classical.choice, Quot.sound]; via Nat.dvd_mul split + p prime)"
+      "mem_properDivisors_mul_prime + isPrimitiveAbundant_mul_prime in AbundantNumberOQ03OQ03.lean (axiom-free [propext, Classical.choice, Quot.sound]; via Nat.dvd_mul split + p prime)",
+      "deficient_iff_abundancyIndex_lt_two (AbundantNumberOQ03OQ03.lean) — Deficient n ↔ abundancyIndex n < 2 (n≠0); deficient counterpart of Nat.abundant_iff_two_lt_abundancyIndex. 0 axiom.",
+      "deficient_of_dvd (AbundantNumberOQ03OQ03.lean) — deficiency inherited by divisors. 0 axiom.",
+      "isPrimitiveAbundant_mul_prime′ (AbundantNumberOQ03OQ03.lean) — simplified Route-1 primitivity criterion: needs only m.Deficient (not all-divisors-deficient). 0 axiom."
     ],
     "insights": [
       "945 = 3³·5·7 is not just the smallest odd abundant number but is odd PRIMITIVE abundant (OEIS A006038): all 15 proper divisors 1,3,5,7,9,15,21,27,35,45,63,105,135,189,315 are deficient — verified axiom-free.",
@@ -60,7 +63,9 @@
       "Mathlib already contains the PARENT result Nat.infinite_odd_abundant (infinitely many odd abundant) in NumberTheory.FactorisationProperties, plus Prime.deficient / IsPrimePow.deficient (explaining why only the composite proper divisors 15,21,...,315 need a genuine check).",
       "Route-1 σ-arithmetic engine complete: σ is multiplicative on coprime factors (Mathlib isMultiplicative_sigma / Nat.Coprime.sum_divisors_mul), so σ(m·p)=σ(m)(p+1) and abundance of m·p becomes the LINEAR-in-p test 2mp < σ(m)(p+1). This is the exact lever an odd-family construction pulls: fix odd deficient base m, then pick prime p in the window keeping m·p abundant.",
       "The remaining Route-1 obstruction is PRIMITIVITY not abundance: need every proper divisor of m·p (the set {d, p·d : d ∣ m}) deficient. Mathlib v4.31 lacks a clean Nat.Coprime.divisors_mul Finset equality, so the coprime proper-divisor decomposition (m·p).properDivisors = m.divisors ∪ (p·)  m.properDivisors must be built from filter_dvd_eq_divisors before abundant_mul_prime_iff upgrades to a full IsPrimitiveAbundant iff.",
-      "Route-1 primitivity is now reducible to conditions purely on m and its p-multiples: mem_properDivisors_mul_prime shows every proper divisor of m·p (p prime, 0<m) is either a divisor of m or p·(a proper divisor of m), and isPrimitiveAbundant_mul_prime turns primitivity of m·p into (m·p abundant) ∧ (all divisors of m deficient) ∧ (all p·(proper divisors of m) deficient). The divisor-structure gap flagged in the prior next step is closed."
+      "Route-1 primitivity is now reducible to conditions purely on m and its p-multiples: mem_properDivisors_mul_prime shows every proper divisor of m·p (p prime, 0<m) is either a divisor of m or p·(a proper divisor of m), and isPrimitiveAbundant_mul_prime turns primitivity of m·p into (m·p abundant) ∧ (all divisors of m deficient) ∧ (all p·(proper divisors of m) deficient). The divisor-structure gap flagged in the prior next step is closed.",
+      "Deficiency is downward-closed under divisibility: deficient_of_dvd (m ∣ n, n deficient, m≠0 ⇒ m deficient), the dual of Mathlib Nat.Abundant.of_dvd, via monotonicity of the abundancy index (abundancyIndex_le_of_dvd) and the helper deficient_iff_abundancyIndex_lt_two (n≠0 ⇒ (Deficient n ↔ abundancyIndex n < 2)).",
+      "Consequence: the isPrimitiveAbundant_mul_prime obligation ∀ d ∈ m.divisors, d.Deficient is EQUIVALENT to just m.Deficient. Route-1 witness search therefore only needs (i) m·p abundant, (ii) m deficient, (iii) every p·e (e proper divisor of m) deficient."
     ],
     "mathlibGaps": [
       "No Nat.Coprime.divisors_mul (Finset equality for divisors of a coprime product) in Mathlib v4.31 — only Nat.Coprime.sum_divisors_mul (the sum) and card_divisors_mul (the count). Blocks a clean coprime proper-divisor decomposition."
@@ -245,5 +250,6 @@
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AbundantNumberOQ02OQ01Unconditional.lean"
     }
-  ]
+  ],
+  "lastUpdate": "2026-07-20"
 }


### PR DESCRIPTION
## Summary
Research session on **infinitude of odd primitive abundant numbers** (`abundant-number-oq-03-oq-03`, OEIS A006038). Proves that deficiency is inherited by divisors — the divisibility-downward dual of Mathlib's `Nat.Abundant.of_dvd` — and uses it to simplify the Route-1 primitivity criterion.

## Progress
- **`deficient_iff_abundancyIndex_lt_two`** (`n ≠ 0`): `Deficient n ↔ abundancyIndex n < 2`, the deficient counterpart of Mathlib's `Nat.abundant_iff_two_lt_abundancyIndex`.
- **`deficient_of_dvd`**: `n.Deficient → m ∣ n → m ≠ 0 → m.Deficient`, via abundancy-index monotonicity `Nat.abundancyIndex_le_of_dvd`. Reusable, Mathlib-worthy — every divisor of a deficient number is deficient.
- **`isPrimitiveAbundant_mul_prime′`**: the `∀ d ∈ m.divisors, d.Deficient` hypothesis of the existing `isPrimitiveAbundant_mul_prime` collapses to just `m.Deficient`. The Route-1 witness obligation is now: (a) `2mp < σ(m)(p+1)`, (b) `m` deficient, (c) each `p·e` deficient for proper divisors `e` of `m`.

## Findings
- `state.md`'s prior "Next Action" (coprime proper-divisor decomposition + full primitivity iff) was **already merged** by #39789 (`mem_properDivisors_mul_prime`, `isPrimitiveAbundant_mul_prime`); this session builds on top and trims the remaining criterion.
- The last non-trivial primitivity obligation is condition (c). Infinitude itself remains **genuinely open** (no odd deficient base family + prime window is known to satisfy (a)–(c) for infinitely many members).

## Verification
- Host-verified `lake env lean` (file imports only `Mathlib`), exit 0, 0 sorry.
- `#print axioms` on all three results = `[propext, Classical.choice, Quot.sound]` (axiom-free).
- Research-only file (`AbundantNumberOQ03OQ03.lean`), no gallery meta.

## Status
**Outcome**: progress (0-axiom infrastructure simplifying the primitivity criterion)
**Next Steps**: search for an explicit odd deficient base family + prime window satisfying (c); or Route 2 (primitive-part extraction from `Nat.infinite_odd_abundant`).

🤖 Generated by researcher-1