### PR TITLE
audit: erdos-799 — correct 2 section summaries overstating comment-only ranges as formalized

### DIFF
--- a/src/data/proofs/erdos-799/meta.json
+++ b/src/data/proofs/erdos-799/meta.json
@@ -99,10 +99,10 @@
     {
       "id": "comparison-chromatic",
       "title": "Comparison with Ordinary Chromatic Number",
-      "summary": "Two structural results: χ_L(G) ≥ χ(G) always holds, and the gap can be arbitrarily large (K_{n,n} example with χ = 2, χ_L ≥ log₂ n + 1)",
+      "summary": "Documentation only (comment blocks, not formalized): two structural facts — χ_L(G) ≥ χ(G) always holds, and the gap can be arbitrarily large (K_{n,n} example with χ = 2, χ_L ≥ log₂ n + 1). Note the ordinary chromatic number χ(G) is not defined in this file",
       "startLine": 80,
       "endLine": 100,
-      "mathContext": "Two structural results: χ_L(G) $\\geq$ χ(G) always holds, and the gap can be arbitrarily large (K_{n,n} example with χ = 2, χ_L $\\geq$ log₂ n + 1)"
+      "mathContext": "Documentation only (comment blocks, not formalized): two structural facts — χ_L(G) $\\geq$ χ(G) always holds, and the gap can be arbitrarily large (K_{n,n} example with χ = 2, χ_L $\\geq$ log₂ n + 1)"
     },
     {
       "id": "random-graph-model",
@@ -131,10 +131,10 @@
     {
       "id": "chromatic-comparison",
       "title": "Asymptotic Ratio χ_L/χ",
-      "summary": "The ratio χ_L(G)/χ(G) → 2/ln(2) ≈ 2.885 for random graphs, formalized as χ_L(G) ~ n/log n",
+      "summary": "Documentation only (comment block, not formalized): the ratio χ_L(G)/χ(G) → 2/ln(2) ≈ 2.885 for random graphs",
       "startLine": 161,
       "endLine": 177,
-      "mathContext": "The ratio χ_L(G)/χ(G) $\\to$ 2/ln(2) ≈ 2.885 for random graphs, formalized as χ_L(G) ~ n/$\\log n$"
+      "mathContext": "Documentation only (comment block, not formalized): the ratio χ_L(G)/χ(G) $\\to$ 2/ln(2) ≈ 2.885 for random graphs"
     },
     {
       "id": "main-results",


### PR DESCRIPTION
## Integrity Issue

**Proof**: erdos-799 (List Chromatic Number of Random Graphs)
**Problem**: Two `sections[]` summaries describe comment-only ranges of `Erdos799Problem.lean` as if they were formalized results.

## Evidence

`proofs/Proofs/Erdos799Problem.lean` contains exactly 4 defs, 2 axioms (`listChromaticRandom`, `alon_krivelevich_sudakov_1999`), and 1 theorem (`erdos_799`, which is definitionally the AKS axiom). Parts II, IV, and VI are pure `/- … -/` comment blocks with no declarations.

- **Section "Comparison with Ordinary Chromatic Number"** (lines 80–100, comment-only) said: *"Two structural results: χ_L(G) ≥ χ(G) always holds, and the gap can be arbitrarily large…"*. Nothing is declared there, and the ordinary chromatic number `χ(G)` is never even defined in the file.
- **Section "Asymptotic Ratio χ_L/χ"** (lines 161–177, comment-only) said the ratio is *"formalized as χ_L(G) ~ n/log n"* — no formalization exists in that range.

## Fix

Reworded both summaries (and their `mathContext`) to "Documentation only (comment block, not formalized): …". No count changes (0 sorries, 2 axioms, 1 theorem); prose-accuracy only. Complements #39259, which corrected the top-level axiomatized-scaffold prose but left these two section summaries.

---
Discovered during gallery integrity audit (reserve-mode re-verification).