### PR TITLE
Enrich: add missing header-section coverage to 4 gallery entries

### DIFF
--- a/src/data/proofs/erdos-1207-oq-03/meta.json
+++ b/src/data/proofs/erdos-1207-oq-03/meta.json
@@ -83,6 +83,14 @@
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Open Question, Module Header & Imports",
+      "startLine": 1,
+      "endLine": 44,
+      "summary": "File docstring stating OQ-03 (combine the parent isosceles↔midpoint-free bridge with quantitative 3-AP-free bounds to pin down P₁(n)) and the classical elementary answer proved here: the base-3 \"digits 0,1 only\" set Sₖ ⊆ [0,3ᵏ) is midpoint-free with |Sₖ| = 2ᵏ, giving the fully explicit machine-checked lower bound P₁(3ᵏ) ≥ 2ᵏ ≈ n^{log₃2}. Imports Mathlib and the parent Proofs.Erdos1207Problem; opens namespace Erdos1207OQ03.",
+      "mathContext": "$S_k=\\{\\sum_{i<k} b_i\\,3^i : b_i\\in\\{0,1\\}\\}\\subseteq\\{0,\\dots,3^k-1\\}$; $|S_k|=2^k=(3^k)^{\\log_3 2}$ with $\\log_3 2\\approx0.6309$. Weaker than Behrend's $n/\\exp(O(\\sqrt{\\log n}))$ but explicit and optimal among restricted-digit constructions."
+    },
+    {
       "id": "encoding",
       "title": "The base-3 digit map",
       "summary": "toNat encodes b : Fin k → Fin 2 as ∑ bᵢ·3ⁱ, with the least-significant-digit recursion toNat_succ.",

--- a/src/data/proofs/erdos-729-oq-04/meta.json
+++ b/src/data/proofs/erdos-729-oq-04/meta.json
@@ -116,6 +116,14 @@
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Open Question, Module Header & Imports",
+      "startLine": 1,
+      "endLine": 60,
+      "summary": "File docstring: the OQ-04 question and a self-contained account of what the file proves (0 axioms / 0 sorries) — a Legendre/Kummer p-adic valuation identity for multinomial coefficients and its no-carry divisibility consequences. Imports Mathlib; opens namespace Erdos729Multinomial with Nat and Finset.",
+      "mathContext": "Legendre: $v_p(n!) = \\sum_{i\\ge1}\\lfloor n/p^i\\rfloor = (n - s_p(n))/(p-1)$. Kummer: $v_p\\binom{n}{k}$ counts base-$p$ carries in $k+(n-k)$; the multinomial form distributes $v_p$ over $\\prod a_j!$."
+    },
+    {
       "id": "prod-and-legendre",
       "title": "Valuation of a Factorial Product and Additive Legendre",
       "startLine": 61,

--- a/src/data/proofs/hurwitz-theorem-oq-03-wip-01/meta.json
+++ b/src/data/proofs/hurwitz-theorem-oq-03-wip-01/meta.json
@@ -77,6 +77,14 @@
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Module Header, Imports & the Obstruction",
+      "startLine": 1,
+      "endLine": 53,
+      "summary": "Imports Mathlib; file docstring describing the anticommuting–determinant obstruction that drives Hurwitz OQ-03, and why it advances the open question. Opens namespace HurwitzOQ03WIP01 with Matrix.",
+      "mathContext": "If $A,B$ anticommute ($AB=-BA$) then $\\det(A)\\det(B)=\\det(AB)=\\det(-BA)=(-1)^n\\det(B)\\det(A)$, forcing $\\det(A)\\det(B)=0$ in odd dimension $n$ — the parity obstruction underlying Hurwitz-type sum-of-squares composition constraints."
+    },
+    {
       "id": "obstruction",
       "title": "The Anticommuting-Determinant Obstruction",
       "summary": "anticommuting_invertible_forces_even: over a field with 2≠0, two anticommuting invertible matrices force Even m",

--- a/src/data/proofs/lucas-sum-oq-01-oq-02/meta.json
+++ b/src/data/proofs/lucas-sum-oq-01-oq-02/meta.json
@@ -24,6 +24,14 @@
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Module Header, Open Question & Imports",
+      "startLine": 1,
+      "endLine": 59,
+      "summary": "Imports Mathlib; file docstring stating OQ-01-OQ-02 (from lucas-sum-oq-01), the Fibonacci comparison/bridge, the telescoped closed-form constants, references, and the axiom/sorry ledger (0 axioms, 0 sorries). Opens namespace LucasSumOQ01OQ02 with Finset.",
+      "mathContext": "Lucas numbers $L_n$: $2,1,3,4,7,11,\\dots$ satisfy the Fibonacci recurrence with $L_0=2,\\,L_1=1$; the file telescopes weighted and squared Lucas partial sums into closed form via the Fibonacci companion identities."
+    },
+    {
       "id": "lucas-def",
       "title": "Section I: The Lucas Numbers and Their Recurrence",
       "startLine": 60,


### PR DESCRIPTION
## Enrichment pass — section coverage gap

Four low-pass gallery entries had their first `sections` entry starting *after* the file docstring, leaving the module header (open-question statement, imports, namespace/open) with **no section coverage** at the top of the file:

| Entry | First section was | Header added |
|-------|------------------|--------------|
| `erdos-1207-oq-03` | L45 | 1–44 |
| `erdos-729-oq-04` | L61 | 1–60 |
| `hurwitz-theorem-oq-03-wip-01` | L54 | 1–53 |
| `lucas-sum-oq-01-oq-02` | L60 | 1–59 |

Each new `header` section summarizes the docstring (OQ statement / 'what this file proves' / references) and the imports, with a LaTeX `mathContext`. Sections now cover the Lean file contiguously from line 1.

- Only `sections` arrays touched — no existing content removed.
- All four `meta.json` remain well under the 60 KB cap (13.9–16.6 KB).
- JSON validated; `pnpm build` gallery-data + search-index steps pass (final `tsc` step fails only on missing node_modules binary, unrelated to this change).
- Axiom/status fields unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)