### PR TITLE
audit: erdos-80 — reword 4 phantom decl-style annotation headers

### DIFF
--- a/src/data/proofs/erdos-80/annotations.json
+++ b/src/data/proofs/erdos-80/annotations.json
@@ -123,7 +123,7 @@
     },
     "type": "concept",
     "title": "Alon-Trotter Upper Bound",
-    "content": "**alon_trotter_bound:** For c < 1/4: f_c(n) ≪ n^{1/2}\n\nAlon and Trotter constructed triangle-saturated graphs with cn² edges where the maximum book size is only O(√n).",
+    "content": "**Alon–Trotter upper bound (external result):** For c < 1/4: f_c(n) ≪ n^{1/2}\n\nAlon and Trotter constructed triangle-saturated graphs with cn² edges where the maximum book size is only O(√n).\n\n(Stated in a source comment for context — not formalized as a declaration in this file.)",
     "significance": "key",
     "mathContext": "See annotation content for formal details of alon-trotter upper bound",
     "relatedConcepts": [
@@ -145,7 +145,7 @@
     },
     "type": "concept",
     "title": "Fox-Loh Upper Bound (2012)",
-    "content": "**fox_loh_bound:** For c < 1/4: f_c(n) ≤ n^{O(1/log log n)}\n\nThis is essentially n^{o(1)}, meaning NO polynomial lower bound exists! This disproved Erdős's conjecture that f_c(n) > n^ε for some ε > 0.\n\nUsed sophisticated probabilistic construction.",
+    "content": "**Fox–Loh upper bound, 2012 (external result):** For c < 1/4: f_c(n) ≤ n^{O(1/log log n)}\n\nThis is essentially n^{o(1)}, meaning NO polynomial lower bound exists! This disproved Erdős's conjecture that f_c(n) > n^ε for some ε > 0.\n\nUsed sophisticated probabilistic construction.\n\n(Stated in a source comment for context — not formalized as a declaration in this file.)",
     "mathContext": "The key breakthrough that resolved one of Erdős's questions negatively.",
     "significance": "key",
     "relatedConcepts": [
@@ -167,7 +167,7 @@
     },
     "type": "concept",
     "title": "Polynomial Conjecture: DISPROVED",
-    "content": "**erdos_polynomial_conjecture_false:** Erdős asked: Is f_c(n) > n^ε for some ε > 0?\n\n**Answer: NO** (for c < 1/4). Fox-Loh's n^{O(1/log log n)} bound eventually falls below any n^ε.",
+    "content": "**Erdős's polynomial-growth conjecture — disproved (external result):** Erdős asked: Is f_c(n) > n^ε for some ε > 0?\n\n**Answer: NO** (for c < 1/4). Fox-Loh's n^{O(1/log log n)} bound eventually falls below any n^ε.\n\n(Stated in a source comment for context — not formalized as a declaration in this file.)",
     "significance": "key",
     "mathContext": "See annotation content for formal details of polynomial conjecture: disproved",
     "relatedConcepts": [
@@ -189,7 +189,7 @@
     },
     "type": "concept",
     "title": "Linear Bound Above Threshold",
-    "content": "**linear_bound_above_threshold:** For c > 1/4: f_c(n) ≥ n/6\n\nAbove the threshold 1/4, books of LINEAR size are guaranteed! Proved independently by Edwards and by Khadziivanov-Nikiforov (1979).",
+    "content": "**Edwards / Khadziivanov–Nikiforov linear bound, 1979 (external result):** For c > 1/4: f_c(n) ≥ n/6\n\nAbove the threshold 1/4, books of LINEAR size are guaranteed! Proved independently by Edwards and by Khadziivanov-Nikiforov (1979).\n\n(External result — stated in a source comment; the file's related statement is the `above_threshold_linear` axiom, not an independent proof.)",
     "mathContext": "This shows the phase transition at c = 1/4 is sharp.",
     "significance": "key",
     "relatedConcepts": [


### PR DESCRIPTION
## Gallery Integrity Audit — erdos-80

**Proof**: erdos-80 (Erdős Problem #80: Book Size in Triangle-Saturated Graphs)
**Result**: issues-fixed (annotations prose)

## Problem

`annotations.json` labeled four comment-only ranges with Lean-identifier-style
`**snake_case:**` headers that imply formalized declarations. None of these
names exist in `proofs/Proofs/Erdos80Problem.lean`:

| Header | Range | Reality |
|--------|-------|---------|
| `alon_trotter_bound` | 133-141 | comment block only |
| `fox_loh_bound` | 143-151 | comment block only |
| `erdos_polynomial_conjecture_false` | 153-159 | comment block only |
| `linear_bound_above_threshold` | 165-172 | no such decl; range covers the `regularity_lower_bound` axiom |

The file's actual formal content is 3 axioms (`regularity_lower_bound`,
`above_threshold_linear`, `below_threshold_subpolynomial`), the supporting
definitions, and one summary theorem `erdos_80_summary` that bundles the axioms.
The known-results bounds above are only stated in source comments.

This is the same phantom-declaration-header defect already corrected in this
proof's section summaries (#39262) and in the annotations of erdos-838 (#39812)
and erdos-844 (#39808).

## Fix

Reword the four headers to plain descriptive text marked "(external result)"
with an explicit note that they are not formalized as declarations in this file.
The c>1/4 linear-bound note points at the actual `above_threshold_linear` axiom
(which axiomatizes rather than proves the statement).

## Verification

- `axiomCount`, `sorries`, `status`, `badge` unchanged and accurate:
  3 axioms, 0 sorries, `axiomatized` / `axiom`.
- No True stubs, no `native_decide`.
- JSON validated.

---
Discovered during gallery integrity audit (reserve mode, re-serve of erdos-80).