### PR TITLE
Enrich euler-polyhedral-formula-oq-02-oq-02: full-file section coverage (9→21)

### DIFF
--- a/src/data/proofs/euler-polyhedral-formula-oq-02-oq-02/meta.json
+++ b/src/data/proofs/euler-polyhedral-formula-oq-02-oq-02/meta.json
@@ -44,7 +44,7 @@
     ],
     "historicalContext": "Gauss (1827) and Bonnet (1848) related Gaussian curvature to topology for surfaces: ∫K dA = 2πχ. Allendoerfer-Weil (1943) and then Chern (1944-45) generalized this to all closed oriented even-dimensional Riemannian manifolds, expressing the Euler characteristic as the integral of the Pfaffian of the curvature form: ∫_M Pf(Ω/2π) = χ(M). Chern's intrinsic proof, via the transgression of the Euler form, became a cornerstone of characteristic-class theory. For 2-manifolds (n=1) the Pfaffian of the 2×2 curvature is the Gaussian curvature times the area form, recovering classical Gauss-Bonnet; for polyhedral surfaces the curvature concentrates at vertices as angular deficiency, recovering the discrete theorem Σδ(v)=2πχ.",
     "axiomCount": 2,
-    "lineCount": 1302,
+    "lineCount": 1340,
     "assumptions": "0 sorries; 0 axiom declarations; 2 structure-encoded assumptions. (1) CGBManifold.chern_gauss_bonnet encodes the Chern-Gauss-Bonnet identity ∫_M Pf(Ω) = (2π)^n·χ(M); Mathlib v4.26.0 has no Pfaffian of a curvature form, no integration of characteristic forms over manifolds, and no manifold Euler characteristic, so the identity is taken as a field rather than derived. (2) ClosedOddManifold.chi_zero encodes the Poincaré-duality fact that closed odd-dimensional manifolds have χ=0. All 129 theorems are then derived; the sphere Euler characteristics, normalization-constant lemmas, the 2×2 Pfaffian identity, the genus-g Betti numbers, and the Poincaré-polynomial layer (Part XX) and the product-monoid/Künneth layers (Parts XVII–XVIII) are independently verified (depend only on propext/Classical.choice/Quot.sound). #print axioms confirms no sorryAx and no Lean.ofReduceBool.",
     "mathlib_version": "4.31.0",
     "theoremCount": 131,
@@ -77,76 +77,172 @@
   },
   "sections": [
     {
+      "id": "module-header",
+      "title": "Module Header: Chern–Gauss–Bonnet and Euler Characteristics",
+      "startLine": 1,
+      "endLine": 53,
+      "summary": "Module docstring and setup (imports Mathlib, opens Real, namespace ChernGaussBonnet). Frames OQ-02-OQ-02: extend the classical 2-dimensional Gauss–Bonnet theorem to the higher-dimensional Chern–Gauss–Bonnet identity ∫_M Pf(Ω) = (2π)ⁿ·χ(M), the sole geometric input structure-encoded as an assumption because Mathlib lacks the differential geometry to derive it.",
+      "mathContext": "The generalized Gauss–Bonnet–Chern theorem: for a closed oriented Riemannian 2n-manifold, $\\int_M \\mathrm{Pf}(\\Omega) = (2\\pi)^n\\,\\chi(M)$."
+    },
+    {
       "id": "part-i-sphere-euler",
       "title": "Part I: Euler Characteristics of Spheres",
-      "startLine": 53,
-      "endLine": 92,
+      "startLine": 54,
+      "endLine": 94,
       "summary": "sphereEulerChar m = 1 + (-1)^m, with the even/odd dichotomy (2 in even dimension, 0 in odd) proved several ways: closed cases S^0,…,S^4, the general sphereEulerChar_even/odd, and the unified sphereEulerChar_eq_ite. Verified, 0-axiom.",
       "mathContext": "$\\chi(S^m) = 1 + (-1)^m$ — equal to $2$ for even $m$, $0$ for odd $m$."
     },
     {
       "id": "part-ii-normalization",
       "title": "Part II: The Chern Normalization Constant (2π)ⁿ",
-      "startLine": 94,
-      "endLine": 118,
+      "startLine": 95,
+      "endLine": 120,
       "summary": "cgbConst n = (2π)^n, with positivity (cgbConst_pos), nonvanishing, the base values cgbConst 0 = 1 and cgbConst 1 = 2π, and multiplicativity cgbConst(m+n) = cgbConst m · cgbConst n. Verified, 0-axiom.",
       "mathContext": "$(2\\pi)^n$ converts the unnormalized Pfaffian integral $\\int_M \\mathrm{Pf}(\\Omega)$ into $\\chi(M)$; it is positive and multiplicative."
     },
     {
       "id": "part-iii-pfaffian",
       "title": "Part III: The 2×2 Pfaffian and Pf² = det",
-      "startLine": 120,
-      "endLine": 144,
+      "startLine": 121,
+      "endLine": 146,
       "summary": "pf2 and det2 for the antisymmetric matrix [[0,a],[-a,0]], with the identity pf2_sq_eq_det2 (Pf² = det), det2_eq (= a²), and pf2_eq. The algebraic core of the n = 1 reduction. Verified, 0-axiom.",
       "mathContext": "For $\\begin{psmallmatrix}0&a\\\\-a&0\\end{psmallmatrix}$: $\\mathrm{Pf} = a$, $\\det = a^2$, so $\\mathrm{Pf}^2 = \\det$."
     },
     {
       "id": "part-iv-cgbmanifold",
       "title": "Part IV: The Chern-Gauss-Bonnet Manifold (Structure-Encoded)",
-      "startLine": 146,
-      "endLine": 210,
+      "startLine": 147,
+      "endLine": 212,
       "summary": "CGBManifold bundles halfDim, χ, total Pfaffian, and the chern_gauss_bonnet identity as a field — the structure-encoded assumption that makes this entry 'axiomatized'. Downstream: dim_even, normalized (∫Pf/(2π)ⁿ = χ), totalPfaffian_eq, the χ=0 ⇔ ∫Pf=0 equivalences, and the sign correspondence totalPfaffian_pos_iff.",
       "mathContext": "$\\int_M \\mathrm{Pf}(\\Omega) = (2\\pi)^n\\,\\chi(M)$, encoded as a structure field (Mathlib lacks the geometry to derive it)."
     },
     {
       "id": "part-v-two-dim",
       "title": "Part V: Recovery of 2-Dimensional Gauss-Bonnet (n = 1)",
-      "startLine": 212,
-      "endLine": 229,
+      "startLine": 213,
+      "endLine": 231,
       "summary": "two_dim_gauss_bonnet: at halfDim = 1 the identity becomes ∫_M Pf(Ω) = 2π·χ(M) — exactly the classical Gauss-Bonnet of the parent entries. zero_dim_counts_points: at halfDim = 0, ∫Pf = χ (counting measure).",
       "mathContext": "$n = 1 \\Rightarrow \\int_M \\mathrm{Pf}(\\Omega) = 2\\pi\\,\\chi(M)$, the classical Gauss-Bonnet."
     },
     {
       "id": "part-vi-spheres",
       "title": "Part VI: Sphere Manifolds S^{2n}",
-      "startLine": 231,
-      "endLine": 259,
+      "startLine": 232,
+      "endLine": 261,
       "summary": "sphereCGB n realizes S^{2n} with χ = 2 and ∫Pf = 2·(2π)ⁿ. Lemmas confirm its dimension (2n), agreement of its χ field with the Part I combinatorial value (sphereCGB_chi_eq), its total Pfaffian, and the concrete ∫_{S²}Pf = 4π.",
       "mathContext": "$S^{2n}$: $\\chi = 2$, $\\int \\mathrm{Pf}(\\Omega) = 2(2\\pi)^n$; for $n=1$, $\\int_{S^2} K\\,dA = 4\\pi$."
     },
     {
       "id": "part-vii-products",
       "title": "Part VII: Products of Manifolds (χ Multiplicative)",
-      "startLine": 261,
-      "endLine": 292,
+      "startLine": 262,
+      "endLine": 294,
       "summary": "prodCGB M N: dimension adds, χ multiplies (χ(M×N) = χ(M)·χ(N)), and the total Pfaffian multiplies — consistent with Chern-Gauss-Bonnet because (2π)^{m+n} factors (cgbConst_add). Worked example S²×S²: χ = 4.",
       "mathContext": "$\\chi(M\\times N) = \\chi(M)\\,\\chi(N)$; total Pfaffian multiplies via $(2\\pi)^{m+n} = (2\\pi)^m(2\\pi)^n$."
     },
     {
       "id": "part-viii-vanishing",
       "title": "Part VIII: Vanishing Euler Characteristic — Tori and Odd Dimensions",
-      "startLine": 294,
-      "endLine": 332,
+      "startLine": 295,
+      "endLine": 345,
       "summary": "torusCGB n: the flat torus T^{2n} with χ = 0 and ∫Pf = 0. ClosedOddManifold structure-encodes Poincaré duality (χ = 0 in odd dimension); oddSphere_chi_zero confirms S^{2k+1} realizes it, matching Part I.",
       "mathContext": "Flat tori and closed odd-dimensional manifolds have $\\chi = 0$, hence $\\int \\mathrm{Pf}(\\Omega) = 0$."
     },
     {
       "id": "part-ix-euler-number",
       "title": "Part IX: The Euler Number Is an Integer",
-      "startLine": 334,
-      "endLine": 353,
+      "startLine": 346,
+      "endLine": 366,
       "summary": "euler_number_integral: the curvature integral ∫_M Pf(Ω/2π) is always an integer (it equals χ ∈ ℤ) — the deep content of Chern-Gauss-Bonnet. chi_determined: same dimension and total Pfaffian ⇒ same χ, so the integral determines the Euler characteristic.",
       "mathContext": "$\\int_M \\mathrm{Pf}(\\Omega/2\\pi) = \\chi(M) \\in \\mathbb{Z}$: a transcendental integral lands on a topological integer."
+    },
+    {
+      "id": "part-x-connected-sums",
+      "title": "Part X: Connected Sums (χ Additive up to the Sphere Correction)",
+      "startLine": 367,
+      "endLine": 477,
+      "summary": "connectedSumCGB M N (same dimension) realizes M # N with χ(M # N) = χ(M) + χ(N) − χ(S^{2n}) and the correspondingly corrected total Pfaffian. The sphere S^{2n} is the connected-sum identity (χ and ∫Pf neutral), making (2n-manifolds, #) a monoid with χ − 2 the induced additive homomorphism to (ℤ, +); worked genus-2 witness T² # T² with χ = −2, ∫Pf = −4π.",
+      "mathContext": "Removing an open 2n-disk from each summand and gluing along boundary spheres gives $\\chi(M \\mathbin{\\#} N) = \\chi(M) + \\chi(N) - \\chi(S^{2n})$; in dimension 2 the correction is $-2$."
+    },
+    {
+      "id": "part-xi-genus-surface",
+      "title": "Part XI: The Closed Orientable Surface of Genus g",
+      "startLine": 478,
+      "endLine": 534,
+      "summary": "genusSurfaceCGB g realizes Σ_g, the g-fold connected sum of tori (a sphere with g handles), as a Chern-Gauss-Bonnet manifold with χ(Σ_g) = 2 − 2g and ∫Pf = 4π(1 − g). Each handle drops the Euler characteristic by 2, giving the full classification of closed orientable surfaces by genus.",
+      "mathContext": "$\\chi(\\Sigma_g) = 2 - 2g$: sphere ($g=0$, $\\chi=2$), torus ($g=1$, $\\chi=0$), and every added handle lowers $\\chi$ by $2$."
+    },
+    {
+      "id": "part-xii-genus-additivity",
+      "title": "Part XII: Genus is Additive under Connected Sum — (surfaces, #) ≅ (ℕ, +)",
+      "startLine": 535,
+      "endLine": 563,
+      "summary": "connectedSum_genusSurface_chi: Σ_g # Σ_h = Σ_{g+h} on both invariants, since (2 − 2g) + (2 − 2h) − 2 = 2 − 2(g+h). Genus is thus the monoid isomorphism (closed orientable surfaces, #) ≅ (ℕ, +) — the additivity behind the single-handle recursion χ(Σ_{g+1}) = χ(Σ_g) − 2.",
+      "mathContext": "Connected sum adds genus: $\\Sigma_g \\mathbin{\\#} \\Sigma_h = \\Sigma_{g+h}$, so genus is an isomorphism onto $(\\mathbb{N}, +)$."
+    },
+    {
+      "id": "part-xiii-complete-invariant",
+      "title": "Part XIII: χ is a Complete Invariant of Σ_g (Faithfulness)",
+      "startLine": 564,
+      "endLine": 657,
+      "summary": "χ(Σ_g) = χ(Σ_h) ↔ g = h: the Euler characteristic is a complete invariant of the genus surfaces, with genusSurfaceCGB_chi_strictAnti recording strict antitonicity of g ↦ 2 − 2g. Combined with the additivity of Part XII this exhibits (surfaces, #) ↪ (ℕ, +) as a faithful monoid embedding.",
+      "mathContext": "Since $g \\mapsto 2 - 2g$ is strictly decreasing, $\\chi(\\Sigma_g) = \\chi(\\Sigma_h) \\iff g = h$: $\\chi$ separates all genus surfaces."
+    },
+    {
+      "id": "part-xiv-sign-trichotomy",
+      "title": "Part XIV: The Gauss-Bonnet Sign Trichotomy",
+      "startLine": 658,
+      "endLine": 713,
+      "summary": "The sign of the total curvature ∫Pf(Σ_g) = 4π(1 − g) detects the uniformization regime from the genus: positive ⇔ g = 0 (spherical), zero ⇔ g = 1 (flat torus), negative ⇔ g ≥ 2 (hyperbolic). The χ > 0 / = 0 / < 0 trichotomy read off the genus.",
+      "mathContext": "$\\int \\mathrm{Pf}(\\Sigma_g) = 4\\pi(1-g)$ is positive/zero/negative for $g = 0$ / $g = 1$ / $g \\ge 2$ — sphere / torus / higher-genus."
+    },
+    {
+      "id": "part-xv-antitonicity-products",
+      "title": "Part XV: Weak Antitonicity and Product Surfaces Σ_g × Σ_h",
+      "startLine": 714,
+      "endLine": 744,
+      "summary": "The ≤-form of the strict antitonicity of Part XIII: every added handle can only lower χ(Σ_g) = 2 − 2g (weak monotone decrease). Also computes the Euler characteristic and total curvature of the Cartesian product surfaces Σ_g × Σ_h via the multiplicativity of χ.",
+      "mathContext": "$g \\mapsto \\chi(\\Sigma_g)$ is (weakly) antitone; $\\chi(\\Sigma_g \\times \\Sigma_h) = (2-2g)(2-2h)$ by multiplicativity."
+    },
+    {
+      "id": "part-xvi-homology-betti",
+      "title": "Part XVI: The Homological Origin of χ(Σ_g) = 2 − 2g",
+      "startLine": 745,
+      "endLine": 847,
+      "summary": "A second, purely topological route to χ(Σ_g) = 2 − 2g through the singular homology of the surface: Betti numbers (b₀, b₁, b₂) = (1, 2g, 1), Poincaré duality, and the Euler–Poincaré formula χ = Σ(−1)ⁱbᵢ = 1 − 2g + 1 = 2 − 2g. Complements the geometric handle-recursion derivation of Parts XI–XV.",
+      "mathContext": "Euler–Poincaré: $\\chi(\\Sigma_g) = b_0 - b_1 + b_2 = 1 - 2g + 1 = 2 - 2g$, with $(b_0, b_1, b_2) = (1, 2g, 1)$."
+    },
+    {
+      "id": "part-xvii-product-monoid",
+      "title": "Part XVII: The Cartesian-Product Monoid (CGBManifolds, ×)",
+      "startLine": 848,
+      "endLine": 933,
+      "summary": "The Cartesian product prodCGB is commutative and associative on χ with the single point pointCGB (χ = 1) as two-sided identity, so (CGBManifolds, ×) is a commutative monoid with χ a homomorphism to (ℤ, ·). The multiplicative parallel to the connected-sum monoid of Part X (where χ − 2 maps to (ℤ, +)).",
+      "mathContext": "$(\\mathrm{CGBManifolds}, \\times)$ with the point as unit; $\\chi$ is a monoid homomorphism to $(\\mathbb{Z}, \\cdot)$, complementary to $\\chi - 2 : (\\cdot, \\#) \\to (\\mathbb{Z}, +)$."
+    },
+    {
+      "id": "part-xviii-kunneth-betti",
+      "title": "Part XVIII: The Künneth Formula for Betti Numbers",
+      "startLine": 934,
+      "endLine": 1113,
+      "summary": "A homological re-derivation of the multiplicativity of χ for Σ_g × Σ_h via the Künneth theorem: for spaces with free integral homology the homology of a product is the graded tensor product, so the Betti numbers convolve (kunnethBetti). Reconciles the structure-field prodCGB_chi (Part VII) with the Betti table (Part XVI).",
+      "mathContext": "Künneth: $b_k(M \\times N) = \\sum_{i+j=k} b_i(M)\\,b_j(N)$; summing $(-1)^k$ recovers $\\chi(M\\times N) = \\chi(M)\\,\\chi(N)$."
+    },
+    {
+      "id": "part-xix-kunneth-convolution",
+      "title": "Part XIX: The Künneth Convolution — Commutativity and the Point as Unit",
+      "startLine": 1114,
+      "endLine": 1235,
+      "summary": "The Betti-sequence convolution kunnethBetti is studied as a binary operation in its own right: it is commutative with the point's Betti sequence as unit, carrying the algebraic structure behind the symmetric-monoidal product of spaces and yielding a monoid homomorphism from the Part XVII product monoid.",
+      "mathContext": "$\\mathrm{kunnethBetti}$ is a commutative convolution with the point's sequence $(1)$ as identity — the Betti-level shadow of the symmetric-monoidal Cartesian product."
+    },
+    {
+      "id": "part-xx-poincare-polynomial",
+      "title": "Part XX: The Poincaré Polynomial of Σ_g",
+      "startLine": 1236,
+      "endLine": 1340,
+      "summary": "The Betti numbers (1, 2g, 1) are packaged as the Poincaré polynomial P_{Σ_g}(t) = 1 + 2g·t + t², whose functional equation (palindromic symmetry from Poincaré duality) and connected-sum law (with the sphere correction) are recorded, and whose evaluation at t = −1 recovers χ(Σ_g) = 2 − 2g.",
+      "mathContext": "$P_{\\Sigma_g}(t) = 1 + 2g\\,t + t^2$; Poincaré duality makes it palindromic, and $P_{\\Sigma_g}(-1) = 2 - 2g = \\chi(\\Sigma_g)$."
     }
   ],
   "leanFile": {


### PR DESCRIPTION
## Enrichment pass for `euler-polyhedral-formula-oq-02-oq-02` (Chern–Gauss–Bonnet)

**Genuine section drift.** The Lean file `Proofs/EulerPolyhedralOQ02OQ02.lean` grew to **Part XX / 1340 lines**, but the gallery `sections` still only covered **Parts I–IX (lines 53-353)** — leaving ~970 lines (Parts X–XX: connected sums, genus surfaces, the Gauss–Bonnet sign trichotomy, Betti/homology, the product monoid, and the Künneth / Poincaré-polynomial layers) entirely uncovered. Even the Part I–IX boundaries had drifted off the actual `-- Part N:` comment markers.

### Changes
- Added a `module-header` section (1-53), re-anchored Parts I–IX to their real comment lines, and appended **Parts X–XX** — now **21 contiguous sections covering lines 1..1340**, each with an accurate `summary` and `mathContext` naming the real constructions (`connectedSumCGB`, `genusSurfaceCGB`, the χ(Σ_g)=2−2g classification, `kunnethBetti`, the Poincaré polynomial P_{Σ_g}(t)=1+2g·t+t²).
- Fixed stale `meta.lineCount`: **1302 → 1340** (`leanFile.lineCount` was already 1340).

Axiom integrity verified: the entry's `axiomatized` status and `axiomCount: 2` correctly reflect the 2 structure-encoded assumptions (`CGBManifold.chern_gauss_bonnet`, `ClosedOddManifold.chi_zero`); no `axiom` declarations in the file. Left untouched. Section array validated contiguous (1..1340, no gaps); `pnpm build` search-index checks pass.