### PR TITLE
Research: erdos-507-wip-01 — minTriangleArea nonneg/lower-bound + heilbronn n ≤ 3 (0-axiom)

### DIFF
--- a/proofs/Proofs/Erdos507WIP01.lean
+++ b/proofs/Proofs/Erdos507WIP01.lean
@@ -176,4 +176,92 @@ theorem triangleArea_le_three {P : Finset (ℝ × ℝ)} (h : IsInUnitDisk P)
       _ ≤ 6 := by linarith [t1, t2, t3]
   linarith [hE]
 
+/-! ## `minTriangleArea`: the nested infimum over triples
+
+`minTriangleArea P` is the infimum of `triangleArea p q r` over all ordered
+triples of *distinct* points `p, q, r ∈ P`, encoded as a nine-fold nested
+`⨅` (three membership binders and three distinctness binders around the value).
+In a conditionally complete lattice such an `⨅` carries junk-value semantics on
+empty index types, but over `ℝ` the junk value of an empty infimum is `0`
+(`Real.sInf_empty`), so the two basic facts below hold unconditionally. -/
+
+/-- A real-valued family that is everywhere nonnegative is bounded below (by
+`0`).  This is the recurring side condition for `ciInf_le` on the nested
+infimum of `minTriangleArea`. -/
+private theorem bddBelow_range_of_nonneg {ι : Sort*} {f : ι → ℝ}
+    (h : ∀ i, 0 ≤ f i) : BddBelow (Set.range f) :=
+  ⟨0, by rintro _ ⟨i, rfl⟩; exact h i⟩
+
+/-- **Nonnegativity of the minimum triangle area.**  Every value in the nested
+infimum is a nonnegative `triangleArea`, and the empty-index junk value is `0`,
+so `minTriangleArea P ≥ 0` for every configuration `P`. -/
+theorem minTriangleArea_nonneg (P : Finset (ℝ × ℝ)) : 0 ≤ minTriangleArea P := by
+  unfold minTriangleArea
+  repeat' first
+    | exact triangleArea_nonneg _ _ _
+    | (apply Real.iInf_nonneg; intro)
+
+/-- **The minimum triangle area is a lower bound.**  For any three *distinct*
+points `p, q, r ∈ P`, the nested infimum defining `minTriangleArea P` is at most
+`triangleArea p q r`.  Proof: descend through the nine `⨅` binders with
+`ciInf_le_of_le`, using nonnegativity to supply the `BddBelow` side conditions. -/
+theorem minTriangleArea_le {P : Finset (ℝ × ℝ)} {p q r : ℝ × ℝ}
+    (hp : p ∈ P) (hq : q ∈ P) (hr : r ∈ P)
+    (hpq : p ≠ q) (hqr : q ≠ r) (hpr : p ≠ r) :
+    minTriangleArea P ≤ triangleArea p q r := by
+  unfold minTriangleArea
+  -- discharge each `∀ i, 0 ≤ f i` side goal produced by `bddBelow_range_of_nonneg`
+  have nn : ∀ {ι : Sort*} {f : ι → ℝ}, (∀ i, 0 ≤ f i) → BddBelow (Set.range f) :=
+    fun h => bddBelow_range_of_nonneg h
+  refine ciInf_le_of_le (nn ?_) p ?_
+  · intro _; repeat' first
+      | exact triangleArea_nonneg _ _ _
+      | (apply Real.iInf_nonneg; intro)
+  refine ciInf_le_of_le (nn ?_) hp ?_
+  · intro _; repeat' first
+      | exact triangleArea_nonneg _ _ _
+      | (apply Real.iInf_nonneg; intro)
+  refine ciInf_le_of_le (nn ?_) q ?_
+  · intro _; repeat' first
+      | exact triangleArea_nonneg _ _ _
+      | (apply Real.iInf_nonneg; intro)
+  refine ciInf_le_of_le (nn ?_) hq ?_
+  · intro _; repeat' first
+      | exact triangleArea_nonneg _ _ _
+      | (apply Real.iInf_nonneg; intro)
+  refine ciInf_le_of_le (nn ?_) r ?_
+  · intro _; repeat' first
+      | exact triangleArea_nonneg _ _ _
+      | (apply Real.iInf_nonneg; intro)
+  refine ciInf_le_of_le (nn ?_) hr ?_
+  · intro _; repeat' first
+      | exact triangleArea_nonneg _ _ _
+      | (apply Real.iInf_nonneg; intro)
+  refine ciInf_le_of_le (nn ?_) hpq ?_
+  · intro _; repeat' first
+      | exact triangleArea_nonneg _ _ _
+      | (apply Real.iInf_nonneg; intro)
+  refine ciInf_le_of_le (nn ?_) hqr ?_
+  · intro _; repeat' first
+      | exact triangleArea_nonneg _ _ _
+      | (apply Real.iInf_nonneg; intro)
+  exact ciInf_le_of_le (nn fun _ => triangleArea_nonneg p q r) hpr le_rfl
+
+/-! ## `heilbronn`: the sSup is bounded for `n ≥ 3` -/
+
+/-- **`heilbronn n ≤ 3` for `n ≥ 3`.**  The defining set of `heilbronn n` is
+bounded above by `3`: any admissible bound `α` is `≤ triangleArea p q r` for some
+distinct triple in the witness configuration (which exists since `card = n ≥ 3`),
+and every unit-disk triangle has area `≤ 3` (`triangleArea_le_three`). -/
+theorem heilbronn_le_three (n : ℕ) (hn : 3 ≤ n) : heilbronn n ≤ 3 := by
+  unfold heilbronn
+  apply Real.sSup_le
+  · rintro α ⟨P, hcard, hdisk, hbound⟩
+    have hcard3 : 2 < P.card := by omega
+    obtain ⟨p, q, r, hp, hq, hr, hpq, hpr, hqr⟩ := Finset.two_lt_card_iff.mp hcard3
+    have h1 : α ≤ triangleArea p q r := hbound p hp q hq r hr hpq hqr hpr
+    have h2 : triangleArea p q r ≤ 3 := triangleArea_le_three hdisk hp hq hr
+    linarith
+  · norm_num
+
 end Erdos507WIP01

--- a/proofs/Proofs/Erdos507WIP01.lean
+++ b/proofs/Proofs/Erdos507WIP01.lean
@@ -26,7 +26,14 @@ of the atomic building block `triangleArea`:
 * an explicit value `triangleArea (0,0) (1,0) (0,1) = 1/2`;
 * unit-disk facts: coordinate bounds `|p₁|, |p₂| ≤ 1`, and the uniform area
   bound `triangleArea p q r ≤ 3` for points in the unit disk (so
-  `heilbronn n` is bounded — its `sSup` is over a bounded set).
+  `heilbronn n` is bounded — its `sSup` is over a bounded set);
+* `minTriangleArea` facts: nonnegativity (`minTriangleArea_nonneg`) and the
+  lower-bound property `minTriangleArea P ≤ triangleArea p q r` for distinct
+  `p, q, r ∈ P` (`minTriangleArea_le`), obtained by descending the nine-fold
+  nested `⨅` with `ciInf_le_of_le` under the junk-value semantics of an empty
+  real infimum;
+* `heilbronn n ≤ 3` for `n ≥ 3` (`heilbronn_le_three`): the defining `sSup` set
+  is bounded above by the uniform area bound, so Heilbronn's function is finite.
 
 All results are `0`-axiom / `0`-sorry.
 
@@ -210,42 +217,41 @@ theorem minTriangleArea_le {P : Finset (ℝ × ℝ)} {p q r : ℝ × ℝ}
     (hpq : p ≠ q) (hqr : q ≠ r) (hpr : p ≠ r) :
     minTriangleArea P ≤ triangleArea p q r := by
   unfold minTriangleArea
-  -- discharge each `∀ i, 0 ≤ f i` side goal produced by `bddBelow_range_of_nonneg`
-  have nn : ∀ {ι : Sort*} {f : ι → ℝ}, (∀ i, 0 ≤ f i) → BddBelow (Set.range f) :=
-    fun h => bddBelow_range_of_nonneg h
-  refine ciInf_le_of_le (nn ?_) p ?_
+  -- Descend through the nine `⨅` binders with `ciInf_le_of_le`; each `BddBelow`
+  -- side goal follows from nonnegativity of the (nested) `triangleArea` values.
+  refine ciInf_le_of_le (bddBelow_range_of_nonneg ?_) p ?_
   · intro _; repeat' first
       | exact triangleArea_nonneg _ _ _
       | (apply Real.iInf_nonneg; intro)
-  refine ciInf_le_of_le (nn ?_) hp ?_
+  refine ciInf_le_of_le (bddBelow_range_of_nonneg ?_) hp ?_
   · intro _; repeat' first
       | exact triangleArea_nonneg _ _ _
       | (apply Real.iInf_nonneg; intro)
-  refine ciInf_le_of_le (nn ?_) q ?_
+  refine ciInf_le_of_le (bddBelow_range_of_nonneg ?_) q ?_
   · intro _; repeat' first
       | exact triangleArea_nonneg _ _ _
       | (apply Real.iInf_nonneg; intro)
-  refine ciInf_le_of_le (nn ?_) hq ?_
+  refine ciInf_le_of_le (bddBelow_range_of_nonneg ?_) hq ?_
   · intro _; repeat' first
       | exact triangleArea_nonneg _ _ _
       | (apply Real.iInf_nonneg; intro)
-  refine ciInf_le_of_le (nn ?_) r ?_
+  refine ciInf_le_of_le (bddBelow_range_of_nonneg ?_) r ?_
   · intro _; repeat' first
       | exact triangleArea_nonneg _ _ _
       | (apply Real.iInf_nonneg; intro)
-  refine ciInf_le_of_le (nn ?_) hr ?_
+  refine ciInf_le_of_le (bddBelow_range_of_nonneg ?_) hr ?_
   · intro _; repeat' first
       | exact triangleArea_nonneg _ _ _
       | (apply Real.iInf_nonneg; intro)
-  refine ciInf_le_of_le (nn ?_) hpq ?_
+  refine ciInf_le_of_le (bddBelow_range_of_nonneg ?_) hpq ?_
   · intro _; repeat' first
       | exact triangleArea_nonneg _ _ _
       | (apply Real.iInf_nonneg; intro)
-  refine ciInf_le_of_le (nn ?_) hqr ?_
+  refine ciInf_le_of_le (bddBelow_range_of_nonneg ?_) hqr ?_
   · intro _; repeat' first
       | exact triangleArea_nonneg _ _ _
       | (apply Real.iInf_nonneg; intro)
-  exact ciInf_le_of_le (nn fun _ => triangleArea_nonneg p q r) hpr le_rfl
+  exact ciInf_le_of_le (bddBelow_range_of_nonneg fun _ => triangleArea_nonneg p q r) hpr le_rfl
 
 /-! ## `heilbronn`: the sSup is bounded for `n ≥ 3` -/
 

--- a/research/problems/erdos-507-wip-01/knowledge.md
+++ b/research/problems/erdos-507-wip-01/knowledge.md
@@ -1,0 +1,66 @@
+# Knowledge Base: erdos-507-wip-01 (Heilbronn's Triangle Problem — foundations)
+
+Target file: `proofs/Proofs/Erdos507WIP01.lean`, foundational scaffolding for the
+objects in `proofs/Proofs/Erdos507Problem.lean` (gallery `erdos-507`,
+Heilbronn's triangle problem, **OPEN**: the exponent `β` with
+`α(n) = n^{−β+o(1)}` satisfies only `7/6 ≤ β ≤ 2`). The deep `α(n)` bounds
+(Komlós–Pintz–Szemerédi, Cohen–Pohoata–Zakharov) are untouched; this file builds
+the elementary geometry of `triangleArea` and `minTriangleArea`/`heilbronn`.
+
+## Session 2026-07-20 (researcher-1) — `minTriangleArea` + `heilbronn` bound
+
+**Mode**: continue a MODERATE node (14 lemmas already on main via #39642).
+**Outcome**: progress — 4 new declarations, VERIFIED axiom-free
+(`[propext, Classical.choice, Quot.sound]`, 0 sorry / 0 axiom / no native_decide).
+Host-verified without Docker (parent is Mathlib-only): `lake exe cache get`, then
+fresh-built `Erdos507Problem.olean` into `.lake/build/lib/lean/Proofs/`, then
+`lake env lean` on the child; `#print axioms` on all three public results.
+
+### What I added
+`minTriangleArea P` is the nine-fold nested `⨅` over distinct triples
+`p, q, r ∈ P` of `triangleArea p q r`. New declarations:
+- `bddBelow_range_of_nonneg` (private) — a nonnegative real family is `BddBelow`
+  (lower bound `0`); the recurring side condition for `ciInf_le`.
+- `minTriangleArea_nonneg (P) : 0 ≤ minTriangleArea P` — every value is a
+  nonnegative `triangleArea` and the empty-index junk value is `0`
+  (`Real.sInf_empty`). Proof: `repeat' (Real.iInf_nonneg ⋯ | triangleArea_nonneg)`.
+- `minTriangleArea_le (hp hq hr hpq hqr hpr) : minTriangleArea P ≤ triangleArea p q r`
+  for distinct `p, q, r ∈ P` — descend the nine `⨅` binders with
+  `ciInf_le_of_le`, discharging each `BddBelow` side goal by nonnegativity.
+- `heilbronn_le_three (n) (hn : 3 ≤ n) : heilbronn n ≤ 3` — the `sSup` defining
+  set is bounded above by `3`: any admissible bound `α` is `≤ triangleArea p q r`
+  for some distinct triple (exists since `card = n ≥ 3`, `Finset.two_lt_card_iff`)
+  and every unit-disk triangle has area `≤ 3` (`triangleArea_le_three`); close
+  with `Real.sSup_le`.
+
+### Key findings / reusable Lean recipe
+- **Junk-value semantics over `ℝ`.** In a conditionally complete lattice an `⨅`
+  over an empty index type is junk, but over `ℝ` it is `0` (`Real.sInf_empty`),
+  so `minTriangleArea P ≥ 0` and `heilbronn n ≤ 3` hold *unconditionally* in the
+  index (no nonemptiness hypothesis needed). The right toolkit is the
+  `Real.*`-namespaced helpers `Real.iInf_nonneg`, `Real.le_iInf`, `Real.sSup_le`
+  (each proved via the empty-set junk value), NOT the `[Nonempty ι]` `le_ciInf`.
+- **Descending a deeply-nested `biInf`.** `ciInf_le_of_le (H : BddBelow (range f))
+  (c) (h : f c ≤ a) : iInf f ≤ a`. Descend one binder at a time; the `BddBelow`
+  side goal at every level is uniformly discharged by
+  `bddBelow_range_of_nonneg` + `repeat' (apply Real.iInf_nonneg; intro)`.
+- **Universe pitfall.** A local `have nn : ∀ {ι : Sort*} …` inside the proof
+  triggers `AddConstAsyncResult.commitConst: constant has level params [u_1]`.
+  Hoist the `BddBelow`-from-nonneg helper to a top-level (private) theorem so it
+  is properly universe-polymorphic.
+- `heilbronn n ≤ 3` needs `n ≥ 3`: for `n < 3` no distinct triple exists, the
+  defining `∀`-condition is vacuous, so the set is all of `ℝ` (unbounded above)
+  and `heilbronn n` is the `sSup`-junk value `0`. The bound `≤ 3` still holds
+  there trivially, but the *proof* route (bounded-above) requires the triple, so
+  the theorem is stated for `n ≥ 3`.
+
+### Next steps (unchanged deep tail)
+- Monotonicity `heilbronn (n+1) ≤ heilbronn n` (restrict a witness config).
+- The deep `α(n)` exponent bounds remain open (KPS lower, CPZ upper) — not
+  session-sized; only `7/6 ≤ β ≤ 2` is known in the literature.
+
+## Prior session 2026-07-20 (#39642) — 14 foundational triangle-area lemmas
+Shoelace `triangleArea` geometry: nonnegativity, full `S₃` permutation symmetry
+(signed-area alternation), the three degenerate cases, collinearity ⟺ zero area,
+explicit value `1/2`, unit-disk coordinate bounds `|p_i| ≤ 1`, and the uniform
+bound `triangleArea ≤ 3`. All 0 sorry / 0 axiom.

--- a/research/problems/erdos-507-wip-01/state.md
+++ b/research/problems/erdos-507-wip-01/state.md
@@ -1,0 +1,36 @@
+# Current State
+
+**Phase**: ACT (foundational scaffolding)
+**Since**: 2026-07-20
+**Iteration**: 2
+
+## Current Focus
+
+Elementary, axiom-free structural facts about `minTriangleArea` and `heilbronn`
+built on the already-verified `triangleArea` geometry. The deep `α(n)` growth
+exponent (`7/6 ≤ β ≤ 2`, KPS lower / CPZ upper bounds) is out of scope — no
+Heilbronn-specific machinery exists in Mathlib and the gap is a genuine open
+research problem.
+
+## Active Approach
+
+Descend the nine-fold nested `⨅` of `minTriangleArea` with `ciInf_le_of_le`,
+discharging every `BddBelow` side condition from nonnegativity of `triangleArea`
+(the empty-index junk value over `ℝ` is `0`, so no nonemptiness hypotheses are
+needed). Bound `heilbronn n` (`n ≥ 3`) via `Real.sSup_le` + `triangleArea_le_three`
++ `Finset.two_lt_card_iff`.
+
+## Blockers
+
+- The `α(n)` growth exponent via elementary planar geometry is deep-blocked
+  (route: elementary planar geometry; reopen: materially new mechanism required).
+  Only the elementary well-definedness/finiteness scaffolding is session-sized.
+
+## Next Action
+
+`heilbronn` monotonicity `heilbronn (n+1) ≤ heilbronn n` by restricting a witness
+configuration; otherwise the deep exponent bounds (not session-sized).
+
+## Attempt Counts
+
+- Total attempts: 2

--- a/src/data/research/problems/erdos-507-wip-01.json
+++ b/src/data/research/problems/erdos-507-wip-01.json
@@ -1,7 +1,7 @@
 {
   "slug": "erdos-507-wip-01",
   "title": "Complete the Lean Formalization of Erdős Problem #507 (Heilbronn's Triangle Problem)",
-  "phase": "ORIENT",
+  "phase": "ACT",
   "status": "active",
   "tier": "B",
   "path": "full",
@@ -14,9 +14,11 @@
   },
   "knownResults": {
     "proven": [
-      "triangleArea nonneg; full permutation symmetry (transpositions negate signed area, cyclic rotations fix it) (this session).",
-      "Degenerate (repeated-vertex) triangles vanish; triangleArea=0 ↔ collinear (this session).",
-      "Unit-disk coordinate bounds |p₁|,|p₂| ≤ 1 and uniform area bound triangleArea ≤ 3 (this session)."
+      "triangleArea nonneg; full permutation symmetry (transpositions negate signed area, cyclic rotations fix it).",
+      "Degenerate (repeated-vertex) triangles vanish; triangleArea=0 ↔ collinear.",
+      "Unit-disk coordinate bounds |p₁|,|p₂| ≤ 1 and uniform area bound triangleArea ≤ 3.",
+      "minTriangleArea_nonneg: 0 ≤ minTriangleArea P; minTriangleArea_le: minTriangleArea P ≤ triangleArea p q r for distinct p,q,r ∈ P (2026-07-20).",
+      "heilbronn_le_three: heilbronn n ≤ 3 for n ≥ 3, so Heilbronn's function is finite (2026-07-20)."
     ],
     "open": [
       "The exponent β of α(n)=n^{-β+o(1)}: only 7/6 ≤ β ≤ 2 known.",
@@ -25,10 +27,10 @@
     "goal": "Formalize the elementary geometry of triangleArea / IsInUnitDisk from Mathlib; keep the deep α(n) bounds cleanly isolated as the open target."
   },
   "currentState": {
-    "phase": "ORIENT",
-    "since": "2026-07-20T12:30:00-07:00",
-    "iteration": 1,
-    "focus": "Axiom-free foundational lemmas on the shoelace triangle area and the unit-disk predicate.",
+    "phase": "ACT",
+    "since": "2026-07-20T15:20:00-07:00",
+    "iteration": 2,
+    "focus": "Axiom-free structural facts on minTriangleArea (the nested triple-infimum) and heilbronn (its sSup), built on the verified triangleArea geometry.",
     "blockers": [
       {
         "route": "the α(n) growth exponent via elementary planar geometry",
@@ -36,15 +38,15 @@
         "blockedAt": "2026-07-20"
       }
     ],
-    "nextAction": "Formalize minTriangleArea/heilbronn structural facts: minTriangleArea P ≤ triangleArea p q r for distinct p,q,r ∈ P (biInf_le over the nested membership binders), minTriangleArea nonneg, and BddAbove of the heilbronn sSup set via triangleArea_le_three.",
+    "nextAction": "heilbronn monotonicity heilbronn (n+1) ≤ heilbronn n via restricting a witness configuration; the deep α(n) exponent bounds (KPS/CPZ) are not session-sized.",
     "attemptCounts": {
-      "total": 1,
+      "total": 2,
       "currentApproach": 1,
       "approachesTried": 1
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Created Proofs/Erdos507WIP01.lean (14 theorems, 0 sorry / 0 axiom, VERIFIED axiom-free [propext, Classical.choice, Quot.sound]). Established the elementary geometry of the shoelace triangleArea and the IsInUnitDisk predicate: nonnegativity, full permutation symmetry (all 6 orderings, via signed-area alternation), the three degenerate cases, collinearity ⟺ zero area, an explicit value 1/2, unit-disk coordinate bounds |p₁|,|p₂| ≤ 1, and the uniform area bound triangleArea ≤ 3 (so heilbronn's sSup is over a bounded set). The deep α(n) bounds are untouched.",
+    "progressSummary": "PROGRESS: Extended Proofs/Erdos507WIP01.lean (14→18 declarations, 0 sorry / 0 axiom, VERIFIED axiom-free [propext, Classical.choice, Quot.sound], host-verified no-Docker). Added the minTriangleArea layer: bddBelow_range_of_nonneg (private), minTriangleArea_nonneg, minTriangleArea_le (nine-fold nested ciInf descent), and heilbronn_le_three (heilbronn n ≤ 3 for n ≥ 3, so Heilbronn's function is finite). The deep α(n) growth exponent remains open.",
     "builtItems": [
       "triangleArea_nonneg in Erdos507WIP01.lean",
       "triangleArea_swap_left / triangleArea_swap_right / triangleArea_cyclic (permutation symmetry)",
@@ -53,20 +55,28 @@
       "triangleArea_unit (= 1/2 explicit)",
       "isInUnitDisk_empty, IsInUnitDisk.subset",
       "unitDisk_abs_fst_le, unitDisk_abs_snd_le (coordinate bounds)",
-      "triangleArea_le_three (uniform area bound in the unit disk)"
+      "triangleArea_le_three (uniform area bound in the unit disk)",
+      "bddBelow_range_of_nonneg (private): a nonnegative real family is BddBelow",
+      "minTriangleArea_nonneg: 0 ≤ minTriangleArea P (empty-index junk value is 0)",
+      "minTriangleArea_le: minTriangleArea P ≤ triangleArea p q r for distinct p,q,r ∈ P",
+      "heilbronn_le_three: heilbronn n ≤ 3 for n ≥ 3 (sSup set bounded above)"
     ],
     "insights": [
       "The signed shoelace area p₁(q₂−r₂)+q₁(r₂−p₂)+r₁(p₂−q₂) is alternating: transpositions negate it (area invariant via abs_neg), cyclic rotations fix it — giving full S₃ symmetry after the absolute value.",
       "triangleArea_le_three bounds the heilbronn sSup set: every triangle in the unit disk has area ≤ 3, so heilbronn n is finite (its defining set is bounded above) — the first step toward showing heilbronn is well-defined and decreasing.",
-      "The coordinate bound |p_i| ≤ 1 falls out of p₁²+p₂² ≤ 1 by nlinarith [sq_nonneg (p_i ± 1)] with the other coordinate's square dropped as nonneg — no sqrt needed."
+      "The coordinate bound |p_i| ≤ 1 falls out of p₁²+p₂² ≤ 1 by nlinarith [sq_nonneg (p_i ± 1)] with the other coordinate's square dropped as nonneg — no sqrt needed.",
+      "Over ℝ the junk value of an empty infimum is 0 (Real.sInf_empty), so minTriangleArea_nonneg and heilbronn_le_three need no nonemptiness hypotheses — use the Real.*-namespaced helpers (Real.iInf_nonneg, Real.le_iInf, Real.sSup_le), not the [Nonempty ι] le_ciInf.",
+      "Descend a deeply-nested biInf with ciInf_le_of_le, discharging every BddBelow side goal uniformly by bddBelow_range_of_nonneg + repeat' (apply Real.iInf_nonneg; intro).",
+      "A local universe-polymorphic have (∀ {ι : Sort*} …) inside a proof triggers 'AddConstAsyncResult.commitConst: constant has level params [u_1]'; hoist such helpers to top-level (private) theorems.",
+      "heilbronn n ≤ 3 is stated for n ≥ 3: for n < 3 no distinct triple exists, the defining ∀-condition is vacuous, the set is unbounded above, and heilbronn n is the sSup junk value 0 — the bounded-above proof route needs the triple (Finset.two_lt_card_iff)."
     ],
     "mathlibGaps": [
-      "No off-the-shelf lemma reduces the nested membership biInf of minTriangleArea to a single ciInf_le; the junk-value semantics of ⨅ over unsatisfiable membership binders must be handled explicitly."
+      "No off-the-shelf lemma reduces the nested membership biInf of minTriangleArea to a single ciInf_le; the junk-value semantics of ⨅ over unsatisfiable membership binders must be handled explicitly (done here via ciInf_le_of_le descent).",
+      "No Heilbronn-specific machinery in Mathlib; the α(n) exponent bounds (KPS lower, CPZ upper) are genuine open research, not a tactical search."
     ],
     "nextSteps": [
-      "minTriangleArea P ≤ triangleArea p q r for distinct p,q,r ∈ P (nested biInf_le).",
-      "BddAbove of the heilbronn defining set via triangleArea_le_three; hence heilbronn n ≤ 3.",
-      "minTriangleArea nonneg (handling the empty-binder junk values)."
+      "heilbronn monotonicity: heilbronn (n+1) ≤ heilbronn n by restricting a witness configuration.",
+      "The deep α(n) growth exponent bounds (KPS/CPZ) — not session-sized."
     ],
     "markdown": "# Knowledge Base: erdos-507-wip-01\n\n## Session 2026-07-20 (researcher-1) — foundational triangle-area / unit-disk scaffolding\n\n**Mode**: FRESH (EMPTY node). **Outcome**: progress — VERIFIED axiom-free (`[propext, Classical.choice, Quot.sound]`), 0 sorry / 0 axiom. Host-verified (Mathlib-only parent): fresh-built `Erdos507Problem.olean` then `lake env lean` on the child (no Docker).\n\n### What I did\nCreated `proofs/Proofs/Erdos507WIP01.lean` (14 theorems) on the shoelace area `triangleArea p q r = |p₁(q₂−r₂)+q₁(r₂−p₂)+r₁(p₂−q₂)|/2` and the `IsInUnitDisk` predicate:\n- **Nonnegativity**: `triangleArea_nonneg`.\n- **Permutation symmetry**: `triangleArea_swap_left`, `triangleArea_swap_right` (transpositions, via signed-area negation + `abs_neg`), `triangleArea_cyclic` (rotation fixes it).\n- **Degenerate cases**: `triangleArea_self_left / _self_mid / _self_outer` (= 0).\n- **Collinearity**: `triangleArea_eq_zero_iff`.\n- **Explicit value**: `triangleArea_unit` (`(0,0),(1,0),(0,1) ↦ 1/2`).\n- **Unit disk**: `isInUnitDisk_empty`, `IsInUnitDisk.subset`, `unitDisk_abs_fst_le`, `unitDisk_abs_snd_le`, and the uniform bound `triangleArea_le_three`.\n\n### Key findings\n- The signed shoelace form is alternating: transpositions negate, cyclic rotations fix — full `S₃` symmetry after `|·|`.\n- Every unit-disk triangle has area `≤ 3`, so `heilbronn n`'s `sSup` set is bounded above (a step toward finiteness/monotonicity of `heilbronn`).\n\n### Reusable Lean recipe\n- Signed-area alternation: `rw [show <permuted expr> = -(<base expr>) from by ring, abs_neg]`.\n- Coordinate bound from the disk: `nlinarith [sq_nonneg (p.1 - 1), sq_nonneg (p.1 + 1)]` after `have hsq : p.1^2 ≤ 1 := by nlinarith [sq_nonneg p.2]`.\n- Three-term abs bound: `abs_add_le` twice (note `abs_add` was renamed to `abs_add_le` in this pin) + `gcongr`, each summand `≤ 2` via `mul_le_mul` on `|a|·|b−c| ≤ 1·2`.\n- v4.31 renames hit this session: `abs_add → abs_add_le`, `Finset.not_mem_empty → Finset.notMem_empty`.\n\n### Next steps\n- `minTriangleArea P ≤ triangleArea p q r` (nested membership `biInf_le`).\n- `heilbronn n ≤ 3` via `BddAbove` of the defining set.\n\n### Still open (unchanged)\nThe growth exponent of `α(n)` — deep; only `7/6 ≤ β ≤ 2` known (KPS, Cohen–Pohoata–Zakharov).\n"
   },
@@ -90,7 +100,7 @@
     "mathlib": []
   },
   "started": "2026-07-20T12:30:00.000Z",
-  "lastUpdate": "2026-07-20T12:30:00.000Z",
+  "lastUpdate": "2026-07-20T22:20:00.000Z",
   "significance": 6,
   "tractability": 5
 }


### PR DESCRIPTION
## Summary

Extends `proofs/Proofs/Erdos507WIP01.lean` (Heilbronn's triangle problem, Erdős #507) from 14 to 18 declarations, adding the `minTriangleArea` / `heilbronn` structural layer on top of the already-verified `triangleArea` geometry (from #39642).

`minTriangleArea P` is the nine-fold nested `⨅` over distinct triples `p, q, r ∈ P` of `triangleArea p q r`; `heilbronn n` is the `sSup` of minimum triangle areas over `n`-point unit-disk configurations. Both were defined in `Erdos507Problem.lean` but had no proved facts.

## New declarations

- **`bddBelow_range_of_nonneg`** (private) — a nonnegative real family is `BddBelow` (lower bound `0`); the recurring `ciInf_le` side condition.
- **`minTriangleArea_nonneg`** `: 0 ≤ minTriangleArea P` — every value is a nonnegative `triangleArea` and the empty-index junk value of a real infimum is `0` (`Real.sInf_empty`), so this holds with **no nonemptiness hypothesis**.
- **`minTriangleArea_le`** `: minTriangleArea P ≤ triangleArea p q r` for distinct `p, q, r ∈ P` — descends the nine `⨅` binders with `ciInf_le_of_le`, discharging each `BddBelow` side goal by nonnegativity.
- **`heilbronn_le_three`** `: heilbronn n ≤ 3` for `n ≥ 3` — the defining `sSup` set is bounded above by `3` (via `triangleArea_le_three` + `Finset.two_lt_card_iff` + `Real.sSup_le`), so Heilbronn's function is finite.

## Verification

All three public results are **VERIFIED axiom-free** — `#print axioms` reports only `[propext, Classical.choice, Quot.sound]`; 0 sorry / 0 axiom / no `native_decide`. Host-verified without Docker (parent `Erdos507Problem` is Mathlib-only): `lake exe cache get`, fresh-built parent olean, then `lake env lean` on the child.

## Scope (honesty)

This is elementary well-definedness/finiteness scaffolding, **not** the Heilbronn bounds. The deep `α(n)` growth exponent (`α(n) = n^{−β+o(1)}` with only `7/6 ≤ β ≤ 2` known — Komlós–Pintz–Szemerédi lower, Cohen–Pohoata–Zakharov upper) remains genuinely **open** and is deep-blocked (no Heilbronn-specific machinery in Mathlib).

🤖 Generated with [Claude Code](https://claude.com/claude-code)