### PR TITLE
Research: erdos-818 — eliminate 3 Aristotle companion sorries + fix a false lemma (0-axiom)

### DIFF
--- a/proofs/Proofs/Erdos818Aristotle.lean
+++ b/proofs/Proofs/Erdos818Aristotle.lean
@@ -100,14 +100,14 @@ lemma multEnergy_ge_sq (A : Finset ℤ) : multEnergy A ≥ A.card ^ 2 := by
   rw [hcard]
   refine Finset.card_le_card_of_injOn (fun p => (p, p)) ?_ ?_
   · intro p hp
-    simp only [Finset.mem_filter, Finset.mem_product] at hp ⊢
-    exact ⟨⟨hp, hp⟩, rfl⟩
+    obtain ⟨a, b⟩ := p
+    exact Finset.mem_filter.mpr ⟨Finset.mem_product.mpr ⟨hp, hp⟩, rfl⟩
   · intro a _ b _ hab
     exact (Prod.ext_iff.mp hab).1
 
 /-- Cauchy–Schwarz: `E×(A) · |A·A| ≥ |A|⁴`, from Mathlib's
     `Finset.le_card_mul_mul_mulEnergy`. -/
-lemma cauchy_schwarz_energy (A : Finset ℤ) (hA : A.card ≥ 2) :
+lemma cauchy_schwarz_energy (A : Finset ℤ) (_hA : A.card ≥ 2) :
     (multEnergy A : ℝ) * (A * A : Finset ℤ).card ≥ (A.card : ℝ) ^ 4 := by
   have hnat : A.card ^ 4 ≤ multEnergy A * (A * A : Finset ℤ).card := by
     rw [multEnergy_eq_mulEnergy]

--- a/proofs/Proofs/Erdos818Aristotle.lean
+++ b/proofs/Proofs/Erdos818Aristotle.lean
@@ -38,10 +38,14 @@ lemma log_pos_of_ge_two (n : ℕ) (hn : n ≥ 2) : Real.log n > 0 :=
 lemma rpow_one_eq (x : ℝ) : x ^ (1 : ℝ) = x :=
   Real.rpow_one x
 
-/-- c * x / y ≥ x / y when c ≥ 1 and y > 0 -/
-lemma mul_div_ge_div (c x y : ℝ) (hc : c ≥ 1) (hy : y > 0) :
-    c * x / y ≥ x / y := by
-  sorry
+/-- `c * x / y ≥ x / y` when `c ≥ 1`, `x ≥ 0` and `y > 0`.
+
+The `x ≥ 0` hypothesis is essential: without it the statement is false (e.g.
+`c = 2, x = -1, y = 1` gives `-2 ≥ -1`), since scaling a *negative* numerator by
+`c ≥ 1` makes it more negative. -/
+lemma mul_div_ge_div (c x y : ℝ) (hc : c ≥ 1) (hx : 0 ≤ x) (hy : y > 0) :
+    c * x / y ≥ x / y :=
+  (div_le_div_iff_of_pos_right hy).mpr (by nlinarith [mul_nonneg (by linarith : (0:ℝ) ≤ c - 1) hx])
 
 /-- c * x^2 / log n ≥ x^2 / log n when c ≥ 1 -/
 lemma const_sq_div_log_ge (c x : ℝ) (n : ℕ) (hc : c ≥ 1) (hlog : Real.log n > 0) :
@@ -82,14 +86,37 @@ lemma productSet_card_ge (A : Finset ℤ) (hA : A.Nonempty) :
 noncomputable def multEnergy (A : Finset ℤ) : ℕ :=
   ((A ×ˢ A) ×ˢ (A ×ˢ A)).filter (fun ((a, b), (c, d)) => a * b = c * d) |>.card
 
-/-- E×(A) ≥ |A|^2 (at least the diagonal pairs (a,a), (a,a)) -/
-lemma multEnergy_ge_sq (A : Finset ℤ) : multEnergy A ≥ A.card ^ 2 := by
-  sorry
+/-- `multEnergy A` is Mathlib's `Finset.mulEnergy A A`. -/
+lemma multEnergy_eq_mulEnergy (A : Finset ℤ) :
+    multEnergy A = Finset.mulEnergy A A := by
+  unfold multEnergy
+  exact (Finset.mulEnergy_eq_card_filter A A).symm
 
-/-- Cauchy-Schwarz: E×(A) * |A*A| ≥ |A|^4 -/
+/-- E×(A) ≥ |A|² (embed the diagonal `(a,b) ↦ ((a,b),(a,b))`, which always
+    satisfies `a·b = a·b`, so the `|A|²` pairs inject into the energy set). -/
+lemma multEnergy_ge_sq (A : Finset ℤ) : multEnergy A ≥ A.card ^ 2 := by
+  unfold multEnergy
+  have hcard : A.card ^ 2 = (A ×ˢ A).card := by rw [Finset.card_product]; ring
+  rw [hcard]
+  refine Finset.card_le_card_of_injOn (fun p => (p, p)) ?_ ?_
+  · intro p hp
+    simp only [Finset.mem_filter, Finset.mem_product] at hp ⊢
+    exact ⟨⟨hp, hp⟩, rfl⟩
+  · intro a _ b _ hab
+    exact (Prod.ext_iff.mp hab).1
+
+/-- Cauchy–Schwarz: `E×(A) · |A·A| ≥ |A|⁴`, from Mathlib's
+    `Finset.le_card_mul_mul_mulEnergy`. -/
 lemma cauchy_schwarz_energy (A : Finset ℤ) (hA : A.card ≥ 2) :
     (multEnergy A : ℝ) * (A * A : Finset ℤ).card ≥ (A.card : ℝ) ^ 4 := by
-  sorry
+  have hnat : A.card ^ 4 ≤ multEnergy A * (A * A : Finset ℤ).card := by
+    rw [multEnergy_eq_mulEnergy]
+    calc A.card ^ 4 = A.card ^ 2 * A.card ^ 2 := by ring
+      _ ≤ (A * A).card * Finset.mulEnergy A A := Finset.le_card_mul_mul_mulEnergy A A
+      _ = Finset.mulEnergy A A * (A * A).card := by ring
+  calc (A.card : ℝ) ^ 4 = ((A.card ^ 4 : ℕ) : ℝ) := by push_cast; ring
+    _ ≤ ((multEnergy A * (A * A : Finset ℤ).card : ℕ) : ℝ) := by exact_mod_cast hnat
+    _ = (multEnergy A : ℝ) * (A * A : Finset ℤ).card := by push_cast; ring
 
 /-
   ## Section 4: Bound Arithmetic

--- a/research/problems/erdos-818-incomplete-01/knowledge.md
+++ b/research/problems/erdos-818-incomplete-01/knowledge.md
@@ -47,3 +47,25 @@ Solymosi's multiplicative-energy inequality `E×(A) ≤ C·|A+A|²·log|A|` (dya
 pigeonhole on the multiplicative fibers `{(a,b) : ab = m}`) — not currently in
 Mathlib. Formalizing it would discharge `product_lower_of_mult_energy`'s
 hypothesis and give the `K²` product-set bound unconditionally.
+
+## Session 2026-07-20 (researcher-1) — Aristotle companion cleanup (3 sorries → 0)
+
+**Mode**: continue. **Outcome**: progress — host-verified, axiom-free, no Docker.
+Cleaned `proofs/Proofs/Erdos818Aristotle.lean` (imports Mathlib only):
+
+- **`mul_div_ge_div` was FALSE as stated** — `c*x/y ≥ x/y` fails for `x < 0`
+  (`c=2, x=-1, y=1 ⟹ -2 ≥ -1`). Added the required `0 ≤ x` hypothesis; proof
+  `(div_le_div_iff_of_pos_right hy).mpr (by nlinarith [mul_nonneg …])`.
+- **`multEnergy_ge_sq`** `E×(A) ≥ |A|²`: inject the diagonal `(a,b) ↦ ((a,b),(a,b))`
+  (always satisfies `ab = ab`) via `Finset.card_le_card_of_injOn`;
+  `A.card² = (A ×ˢ A).card` by `Finset.card_product`. Destructure `p` to `(a,b)`
+  first so the filter's pattern-match predicate reduces to `rfl`.
+- **`cauchy_schwarz_energy`** (companion) `E×(A)·|A·A| ≥ |A|⁴`: connect the local
+  `multEnergy` to `Finset.mulEnergy A A` (`multEnergy_eq_mulEnergy`, via
+  `Finset.mulEnergy_eq_card_filter`), then `Finset.le_card_mul_mul_mulEnergy` + a
+  ℕ→ℝ cast. The elementary CS energy bound **is** in Mathlib; only Solymosi's
+  energy *upper* bound is the missing deep input.
+
+The main file (`Erdos818Problem.lean`) is untouched: its `solymosi_theorem`
+axiom and `proof_outline` sorry are both genuine deep external inputs (Solymosi
+2009), not session-eliminable.

--- a/src/data/research/problems/erdos-818-incomplete-01.json
+++ b/src/data/research/problems/erdos-818-incomplete-01.json
@@ -35,18 +35,21 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (still 1 open sorry): Added the axiom-free sumset lower bound 2|A|-1 ≤ |A+A| (Mathlib Cauchy–Davenport) and the axiom-free Solymosi reduction product_lower_of_mult_energy, which machine-checks energy-upper-bound + Cauchy–Schwarz ⇒ |A·A| ≥ |A|²/(C·K²·log|A|), isolating Solymosi's multiplicative-energy inequality E×(A) ≤ C·|A+A|²·log|A| as the single genuine external input (not in Mathlib). Documented that the file's remaining proof_outline sorry, with denominator K·log|A| (vs K²·log|A|), is a strictly stronger still-open target. Host-verified under Mathlib v4.31, 0 new axioms. leanFile theoremCount 8→11, lineCount 353→437.",
+    "progressSummary": "PROGRESS: Main file unchanged (1 deep axiom solymosi_theorem + 1 deep proof_outline sorry, both genuine external inputs not in Mathlib). This session cleaned the Erdos818Aristotle.lean companion: 3 sorries → 0, all axiom-free, host-verified. Notably mul_div_ge_div was FALSE as stated (fails for x<0) and now carries the required 0≤x hypothesis. multEnergy_ge_sq and the companion cauchy_schwarz_energy are now proved. The Solymosi energy inequality E×(A)≤C·|A+A|²·log|A| remains the single deep open external input.",
     "builtItems": [
       "sumset_eq_add (Erdos818Problem.lean): sumset A = A + A (pointwise), axiom-free.",
       "sumset_lower_bound (Erdos818Problem.lean): 2|A|-1 ≤ |A+A| for nonempty A⊆ℤ, via Mathlib cauchy_davenport_add_of_linearOrder_isCancelAdd; fills the previously comment-only Part II. Axiom-free.",
-      "product_lower_of_mult_energy (Erdos818Problem.lean): from cauchy_schwarz_energy + hypothesis E×(A) ≤ C·|A+A|²·log|A|, proves |A·A| ≥ |A|²/(C·K²·log|A|) for |A+A| ≤ K·|A|. Axiom-free (propext/Choice/Quot only)."
+      "product_lower_of_mult_energy (Erdos818Problem.lean): from cauchy_schwarz_energy + hypothesis E×(A) ≤ C·|A+A|²·log|A|, proves |A·A| ≥ |A|²/(C·K²·log|A|) for |A+A| ≤ K·|A|. Axiom-free (propext/Choice/Quot only).",
+      "Erdos818Aristotle.lean companion: eliminated all 3 sorries (now 0). Fixed mul_div_ge_div (was FALSE without 0≤x); proved multEnergy_ge_sq (E×(A)≥|A|² via diagonal injection) and cauchy_schwarz_energy (E×(A)·|A·A|≥|A|⁴ via Finset.le_card_mul_mul_mulEnergy) + multEnergy_eq_mulEnergy. Host-verified, axiom-free (2026-07-20)."
     ],
     "insights": [
       "The lone remaining sorry (proof_outline in Erdos818Problem.lean) is genuinely OPEN: its bound |A·A| ≥ |A|²/(K·log|A|) requires Solymosi's multiplicative-energy upper bound E×(A) ≤ C·|A+A|²·log|A|, which is not in Mathlib. It is NOT derivable from the file's solymosi_theorem axiom (absolute-constant form c·|A|²/log|A|), which would need c·K ≥ 1.",
       "Honest constant mismatch: substituting |A+A| ≤ K·|A| into Solymosi's energy bound E×(A) ≤ C·|A+A|²·log|A| yields |A·A| ≥ |A|²/(C·K²·log|A|) — a K² dependence — NOT the sharper K in proof_outline's stated 1/(K·log|A|). So proof_outline as stated is strictly stronger than the standard argument delivers and remains open.",
       "The full Solymosi reduction (energy upper bound + Cauchy–Schwarz ⇒ product-set lower bound) is now machine-checked axiom-free, with the energy inequality passed as an explicit hypothesis rather than a new axiom — isolating the single genuine external input."
     ],
-    "mathlibGaps": [],
+    "mathlibGaps": [
+      "Companion cauchy_schwarz_energy reuses Finset.le_card_mul_mul_mulEnergy (Mathlib) — the elementary CS energy bound IS in Mathlib; only Solymosi's energy UPPER bound is the missing deep input."
+    ],
     "nextSteps": []
   },
   "tags": [
@@ -68,7 +71,7 @@
     "mathlib": []
   },
   "started": "2026-07-09T00:00:00.000Z",
-  "lastUpdate": "2026-07-20",
+  "lastUpdate": "2026-07-20T22:35:00.000Z",
   "significance": 6,
   "tractability": 7
 }


### PR DESCRIPTION
## Summary

Cleans up `proofs/Proofs/Erdos818Aristotle.lean` (the Aristotle supporting-lemma companion for Erdős #818, sum-product for small sumsets): **3 sorries → 0**, all host-verified and axiom-free. The main formalization `Erdos818Problem.lean` is untouched — its `solymosi_theorem` axiom and `proof_outline` sorry are genuine deep external inputs (Solymosi 2009), not session-eliminable.

## Changes

- **`mul_div_ge_div` was FALSE as stated.** `c * x / y ≥ x / y` with only `c ≥ 1, y > 0` fails for negative `x` (e.g. `c = 2, x = -1, y = 1` gives `-2 ≥ -1`). Added the required `0 ≤ x` hypothesis and proved it. This corrects a latent unprovable stub.
- **`multEnergy_ge_sq`** (`E×(A) ≥ |A|²`): proved by injecting the diagonal `(a,b) ↦ ((a,b),(a,b))` into the energy set via `Finset.card_le_card_of_injOn`.
- **`cauchy_schwarz_energy`** (companion, `E×(A) · |A·A| ≥ |A|⁴`): proved by connecting the local `multEnergy` to Mathlib's `Finset.mulEnergy` (new helper `multEnergy_eq_mulEnergy`) and applying `Finset.le_card_mul_mul_mulEnergy`.

## Verification

`lake env lean Proofs/Erdos818Aristotle.lean` compiles clean (Mathlib-only import, host-verified without Docker); 0 remaining sorries; `#print axioms` on all three lemmas reports only `[propext, Classical.choice, Quot.sound]`.

## Scope (honesty)

This is companion-lemma cleanup, not progress on the conjecture itself. The elementary Cauchy–Schwarz energy bound is already in Mathlib; the genuine open input remains **Solymosi's multiplicative-energy upper bound** `E×(A) ≤ C·|A+A|²·log|A|`, which is not in Mathlib and gates the main file's `proof_outline` sorry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)