### PR TITLE
Research: erdos-89-wip-01 — g(n) monotone + base values g(0)=g(1)=0 (0-axiom)

### DIFF
--- a/proofs/Proofs/Erdos89WIP01.lean
+++ b/proofs/Proofs/Erdos89WIP01.lean
@@ -163,4 +163,66 @@ theorem minDistinctDistances_two : minDistinctDistances 2 = 1 := by
     rw [← hSeq]
     exact one_le_numDistinctDistances_of_two_le_card S (by omega)
 
+/-! ## Subset monotonicity and monotonicity of `g`
+
+Adding points to a configuration can only add distances, and every `n`-point
+configuration restricts to an `(n+1)`-point one by deleting a point.  Together
+these give that Erdős's extremal function `g(n) = minDistinctDistances n` is
+nondecreasing, and pin the remaining low values `g(0) = g(1) = 0`. -/
+
+/-- Distinct-distance sets are monotone under inclusion. -/
+theorem distinctDistances_mono {S T : Finset (EuclideanSpace ℝ (Fin 2))}
+    (h : S ⊆ T) : distinctDistances S ⊆ distinctDistances T := by
+  rw [distinctDistances_eq_image, distinctDistances_eq_image]
+  exact Finset.image_subset_image (Finset.offDiag_mono h)
+
+/-- The distinct-distance count is monotone under inclusion. -/
+theorem numDistinctDistances_mono {S T : Finset (EuclideanSpace ℝ (Fin 2))}
+    (h : S ⊆ T) : numDistinctDistances S ≤ numDistinctDistances T :=
+  Finset.card_le_card (distinctDistances_mono h)
+
+/-- For every `n` there is an `n`-point configuration (the plane is infinite),
+so the defining set of `minDistinctDistances n` is always nonempty. -/
+theorem exists_card_eq (n : ℕ) :
+    ∃ S : Finset (EuclideanSpace ℝ (Fin 2)), S.card = n :=
+  Infinite.exists_subset_card_eq _ n
+
+/-- **Erdős's function is nondecreasing.**  `g(n) ≤ g(n+1)`: take an
+`(n+1)`-point set `U` attaining `g(n+1)` (the minimum is achieved since such sets
+exist), delete a point to get an `n`-point subset `S ⊆ U`; then
+`g(n) ≤ numDistinctDistances S ≤ numDistinctDistances U = g(n+1)`. -/
+theorem minDistinctDistances_mono : Monotone minDistinctDistances := by
+  apply monotone_nat_of_le_succ
+  intro n
+  obtain ⟨T, hTcard⟩ := exists_card_eq (n + 1)
+  have hne : {numDistinctDistances S |
+      (S : Finset (EuclideanSpace ℝ (Fin 2))) (_ : S.card = n + 1)}.Nonempty :=
+    ⟨numDistinctDistances T, T, hTcard, rfl⟩
+  obtain ⟨U, hUcard, hUeq⟩ := Nat.sInf_mem hne
+  have hUpos : U.Nonempty := by rw [← Finset.card_pos, hUcard]; omega
+  obtain ⟨a, ha⟩ := hUpos
+  have hScard : (U.erase a).card = n := by
+    rw [Finset.card_erase_of_mem ha, hUcard]
+  calc minDistinctDistances n
+      ≤ numDistinctDistances (U.erase a) := minDistinctDistances_le_of_card_eq hScard
+    _ ≤ numDistinctDistances U := numDistinctDistances_mono (Finset.erase_subset a U)
+    _ = minDistinctDistances (n + 1) := hUeq
+
+/-- **`g(0) = 0`.** The only `0`-point set is empty and determines no distance. -/
+theorem minDistinctDistances_zero : minDistinctDistances 0 = 0 := by
+  refine Nat.le_zero.mp ?_
+  calc minDistinctDistances 0
+      ≤ numDistinctDistances (∅ : Finset (EuclideanSpace ℝ (Fin 2))) :=
+        minDistinctDistances_le_of_card_eq Finset.card_empty
+    _ = 0 := numDistinctDistances_eq_zero_of_card_le_one _ (by simp)
+
+/-- **`g(1) = 0`.** A single point determines no distance. -/
+theorem minDistinctDistances_one : minDistinctDistances 1 = 0 := by
+  refine Nat.le_zero.mp ?_
+  have hcard : ({0} : Finset (EuclideanSpace ℝ (Fin 2))).card = 1 := Finset.card_singleton _
+  calc minDistinctDistances 1
+      ≤ numDistinctDistances ({0} : Finset (EuclideanSpace ℝ (Fin 2))) :=
+        minDistinctDistances_le_of_card_eq hcard
+    _ = 0 := numDistinctDistances_eq_zero_of_card_le_one _ (by rw [hcard])
+
 end Erdos89

--- a/proofs/Proofs/Erdos89WIP01.lean
+++ b/proofs/Proofs/Erdos89WIP01.lean
@@ -44,6 +44,18 @@ first structural theorems.
    bounding the extremal `g(n)` from above (`Nat.sInf` membership) — the hook the
    grid upper-bound construction feeds.
 
+7. `distinctDistances_mono` / `numDistinctDistances_mono` — the distance set and
+   its count are monotone under inclusion (`S ⊆ T`), the structural input behind
+   monotonicity of `g`.
+
+8. `minDistinctDistances_mono` — **Erdős's function `g` is nondecreasing**:
+   `g(n) ≤ g(n+1)` by deleting a point from an `(n+1)`-point minimizer.
+   `exists_card_eq` records that an `n`-point configuration exists for every `n`
+   (so the defining `sInf` is attained).
+
+9. `minDistinctDistances_zero` / `minDistinctDistances_one` — the remaining low
+   values `g(0) = g(1) = 0`, completing the exact table `g(0)=g(1)=0, g(2)=1`.
+
 ## Summary: 0 sorries, 0 axioms, no `native_decide`. Built over the gallery defs.
 -/
 
@@ -202,7 +214,7 @@ theorem minDistinctDistances_mono : Monotone minDistinctDistances := by
   have hUpos : U.Nonempty := by rw [← Finset.card_pos, hUcard]; omega
   obtain ⟨a, ha⟩ := hUpos
   have hScard : (U.erase a).card = n := by
-    rw [Finset.card_erase_of_mem ha, hUcard]
+    rw [Finset.card_erase_of_mem ha, hUcard]; omega
   calc minDistinctDistances n
       ≤ numDistinctDistances (U.erase a) := minDistinctDistances_le_of_card_eq hScard
     _ ≤ numDistinctDistances U := numDistinctDistances_mono (Finset.erase_subset a U)

--- a/src/data/research/problems/erdos-89-wip-01.json
+++ b/src/data/research/problems/erdos-89-wip-01.json
@@ -23,7 +23,7 @@
     "iteration": 2,
     "focus": "Initial problem understanding. Read problem.md and gather context.",
     "blockers": [],
-    "nextAction": "Formalize the √n×√n grid upper bound feeding minDistinctDistances_le_of_card_eq to get a concrete g(n)=O(n) ceiling; connect singlePointConjecture (#604) to the global count. Guth–Katz lower bound stays an imported assumption.",
+    "nextAction": "Formalize the √n×√n grid upper bound feeding minDistinctDistances_le_of_card_eq for a concrete O(n) ceiling on g(n); or an exact g(3). Guth–Katz lower bound stays an imported assumption.",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -31,7 +31,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Erdos89WIP01.lean — sharpened the distinct-distances envelope to an EQUALITY at the base: numDistinctDistances_eq_one_of_card_eq_two (2-point sets have exactly 1 distance) and minDistinctDistances_two (g(2)=1, first exact value of Erdős extremal function). 9 theorems, 0 sorry, 0 axiom; #print axioms = [propext, Classical.choice, Quot.sound].",
+    "progressSummary": "PROGRESS: Erdos89WIP01.lean — proved g is nondecreasing (minDistinctDistances_mono: g(n)≤g(n+1) by deleting a point from an (n+1)-minimizer) plus subset-monotonicity of the distance set/count (distinctDistances_mono, numDistinctDistances_mono) and the base values g(0)=g(1)=0, completing the exact table g(0)=g(1)=0, g(2)=1. 15 theorems, 0 sorry, 0 axiom; #print axioms = [propext, Classical.choice, Quot.sound]. Guth–Katz lower bound and √n grid upper bound remain open.",
     "builtItems": [
       "Erdos89.dist_pos_of_ne in Erdos89WIP01.lean",
       "Erdos89.distinctDistances_eq_image (filter redundant) in Erdos89WIP01.lean",
@@ -40,7 +40,11 @@
       "Erdos89.one_le_numDistinctDistances_of_two_le_card in Erdos89WIP01.lean",
       "Erdos89.minDistinctDistances_le_of_card_eq in Erdos89WIP01.lean",
       "numDistinctDistances_le_choose_two (≤ S.card.choose 2, sharp unordered-pair ceiling) in Erdos89WIP01.lean",
-      "numDistinctDistances_eq_one_of_card_eq_two + minDistinctDistances_two (g(2)=1) in Erdos89WIP01.lean (axiom-free [propext, Classical.choice, Quot.sound]; uses Nat.sInf_mem + exists_ne witness)"
+      "numDistinctDistances_eq_one_of_card_eq_two + minDistinctDistances_two (g(2)=1) in Erdos89WIP01.lean (axiom-free [propext, Classical.choice, Quot.sound]; uses Nat.sInf_mem + exists_ne witness)",
+      "distinctDistances_mono / numDistinctDistances_mono (subset monotonicity) in Erdos89WIP01.lean (2026-07-20)",
+      "exists_card_eq: an n-point set exists for every n (Infinite.exists_subset_card_eq)",
+      "minDistinctDistances_mono: Monotone g (g nondecreasing) (2026-07-20)",
+      "minDistinctDistances_zero / _one: g(0)=g(1)=0 (2026-07-20)"
     ],
     "insights": [
       "distinctDistances S filters (·>0) over the off-diagonal image, but every off-diagonal pair (p≠q) already has ‖p−q‖>0, so the filter is redundant: distinctDistances S = S.offDiag.image (dist · ·). This removes the awkward filter for all downstream cardinality reasoning.",
@@ -74,7 +78,7 @@
     "mathlib": []
   },
   "started": "2026-07-10T00:41:25.783Z",
-  "lastUpdate": "2026-07-10T00:41:25.930Z",
+  "lastUpdate": "2026-07-20T22:45:00.000Z",
   "significance": 7,
   "tractability": 6
 }


### PR DESCRIPTION
## Summary

Extends `proofs/Proofs/Erdos89WIP01.lean` (Erdős #89, distinct distances) with the monotonicity structure of the extremal function `g(n) = minDistinctDistances n` — the minimum number of distinct pairwise distances over `n`-point sets in `ℝ²`. The file previously pinned `g(2) = 1`; this adds that `g` is nondecreasing and fills the base table.

## New theorems (all 0-axiom, host-verified)

- **`distinctDistances_mono` / `numDistinctDistances_mono`** — the distance set and its count are monotone under set inclusion `S ⊆ T` (via `Finset.offDiag_mono` + image monotonicity).
- **`exists_card_eq`** — an `n`-point configuration exists for every `n` (the plane is infinite, `Infinite.exists_subset_card_eq`), so the `sInf` defining `g(n)` is attained.
- **`minDistinctDistances_mono`** — **`g` is nondecreasing** (`Monotone minDistinctDistances`): take an `(n+1)`-point minimizer `U`, delete a point to get `S ⊆ U` with `|S| = n`, then `g(n) ≤ numDistinctDistances S ≤ numDistinctDistances U = g(n+1)`.
- **`minDistinctDistances_zero` / `minDistinctDistances_one`** — `g(0) = g(1) = 0`, completing the exact low-end table `g(0) = g(1) = 0, g(2) = 1`.

## Verification

`lake env lean Proofs/Erdos89WIP01.lean` compiles clean (host-verified without Docker: parent `Erdos89Problem` is Mathlib-only, fresh-built olean); 0 sorries; `#print axioms` on the new results reports only `[propext, Classical.choice, Quot.sound]`.

## Scope (honesty)

Elementary structural facts about the extremal function. The problem is **OPEN**: the Guth–Katz lower bound `Ω(n/log n)`, Erdős's conjectured `n/√(log n)`, and the `√n × √n` grid upper bound are untouched (the grid construction feeding `minDistinctDistances_le_of_card_eq` remains the natural next step).

🤖 Generated with [Claude Code](https://claude.com/claude-code)