### PR TITLE
feat(research): cap OQ-recursion depth & stop re-serving saturated chains

### DIFF
--- a/.lean/config/oq-policy.json
+++ b/.lean/config/oq-policy.json
@@ -1,0 +1,8 @@
+{
+  "maxOqDepth": 3,
+  "description": "Open-question (OQ) recursion policy for the researcher/seeker pipeline. `maxOqDepth` is the maximum number of `-oq-NN` segments allowed in a research problem slug/chain. A parent whose slug already has this many `-oq-` segments does NOT spawn further OQ children (depth-first descent stops), and runtime selection deprioritizes at-cap chains in favor of unexplored problems while excluding over-cap chains entirely. Override at runtime with the MAX_OQ_DEPTH environment variable (env var > this file > built-in default of 3). See issue #39827 / #39821.",
+  "policyDocs": [
+    ".lean/roles/seeker.md (OQ-Chain Guardrails)",
+    ".lean/roles/researcher.md (OQ-chain depth guard)"
+  ]
+}

--- a/.lean/roles/researcher.md
+++ b/.lean/roles/researcher.md
@@ -273,13 +273,18 @@ entries via the Seeker (`<parent>-oq-NN`), which can recurse without bound. Befo
 proposing any follow-up:
 
 ```bash
-# Count -oq- segments already in the current problem's slug.
+# Count -oq- segments already in the current problem's slug, and read the cap
+# (env override > .lean/config/oq-policy.json > default 3). Mirrors
+# scripts/lib/oq-policy.sh (source it to reuse oq_depth/oq_max_depth).
 OQ_DEPTH=$(echo "$SLUG" | grep -o -- '-oq-[0-9]*' | wc -l | tr -d ' ')
+OQ_CAP="${MAX_OQ_DEPTH:-$(jq -r '.maxOqDepth // 3' .lean/config/oq-policy.json 2>/dev/null || echo 3)}"
 ```
 
-- **If the current problem is already at depth ≥ 3** (its slug already contains 3 or
-  more `-oq-` segments), generate **0** follow-up questions. A depth-4 child would
-  exceed the cap and the Seeker will refuse to spawn it anyway.
+- **If the current problem is already at depth ≥ the cap** (`maxOqDepth`, default
+  3), generate **0** follow-up questions. This is now enforced in code: the
+  extractor drops the OQ children of at/over-cap proofs and the selector never
+  re-serves over-cap chains (issue #39827), so a deeper child is neither created
+  nor served — don't rely on the guard alone.
 - **Never** propose a follow-up that merely re-asks the same question the current
   problem answers (this is what produces degenerate `-oq-01-oq-01-oq-01…` loops).
   A follow-up must open a genuinely new direction, not recurse on the same index.

--- a/.lean/roles/seeker.md
+++ b/.lean/roles/seeker.md
@@ -72,16 +72,27 @@ entry's open question; the child exposes its own open questions, recursively.
 Unbounded, this produces degenerate chains like
 `abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01-oq-01-oq-01-oq-01-oq-01-oq-01-oq-01`.
 
+The depth cap is now **enforced in code** (issue #39827): the extractor
+(`.lean/scripts/extract-problems.ts`) drops open-question children of any proof
+already at/over the cap, and the selector (`scripts/research/claim-problem.sh
+claim-random`) never re-serves over-cap chains and deprioritizes at-cap ones in
+favor of breadth. The cap lives in `.lean/config/oq-policy.json` (`maxOqDepth`,
+default 3) and is overridable with the `MAX_OQ_DEPTH` env var. Keep applying the
+guards below as a second line of defense when you hand-pick or hand-initialize a
+problem.
+
 **Before selecting or initializing ANY problem whose slug contains `-oq-`, apply
 all three guards. REJECT the candidate if it fails any of them.**
 
 ```bash
 SLUG="$PROBLEM_ID"
 
-# Guard 1 — Recursion-depth cap: at most 3 -oq- segments in a chain.
+# Guard 1 — Recursion-depth cap: at most maxOqDepth (default 3) -oq- segments.
+# Mirrors scripts/lib/oq-policy.sh (source it to reuse oq_depth/oq_max_depth).
+CAP="${MAX_OQ_DEPTH:-$(jq -r '.maxOqDepth // 3' .lean/config/oq-policy.json 2>/dev/null || echo 3)}"
 DEPTH=$(echo "$SLUG" | grep -o -- '-oq-[0-9]*' | wc -l | tr -d ' ')
-if [ "$DEPTH" -gt 3 ]; then
-  echo "REJECT $SLUG: OQ chain depth $DEPTH exceeds cap of 3"
+if [ "$DEPTH" -gt "$CAP" ]; then
+  echo "REJECT $SLUG: OQ chain depth $DEPTH exceeds cap of $CAP"
 fi
 
 # Guard 2 — Same-index repetition: refuse a slug whose tail repeats one OQ index
@@ -99,8 +110,9 @@ ls -d src/data/proofs/"$PARENT"-oq-* 2>/dev/null   # inspect existing siblings
 ```
 
 **Rules:**
-- **Depth cap**: never spawn a child at depth > 3. Past depth 3 the marginal
-  mathematical value is essentially zero and the page tree becomes unreadable.
+- **Depth cap**: never spawn a child past the cap (`maxOqDepth`, default 3).
+  Past the cap the marginal mathematical value is essentially zero and the page
+  tree becomes unreadable.
 - **No same-index loops**: a genuinely new question gets a new index; a repeated
   index signals the loop is re-asking the same question.
 - **Dedupe siblings**: never spawn a child whose mathematical content duplicates
@@ -157,7 +169,8 @@ hand the problem to a Researcher.
 
 REJECT a candidate if any of:
 
-- OQ chain depth > 3, same-index loop, or sibling duplicate (guards above)
+- OQ chain depth over the cap (`maxOqDepth`, default 3), same-index loop, or
+  sibling duplicate (guards above)
 - Near-duplicate of a problem completed in the last 30 days
   (check `research/problems/*/knowledge.md`)
 - Shallow specialization or notation variant of an existing gallery proof

--- a/.lean/scripts/extract-problems.ts
+++ b/.lean/scripts/extract-problems.ts
@@ -17,6 +17,46 @@
 import { readFileSync, writeFileSync, readdirSync, existsSync } from 'fs';
 import { join } from 'path';
 
+// ---------------------------------------------------------------------------
+// OQ-recursion-depth policy (issue #39827 / #39821)
+//
+// Open-question children are named `<parent>-oq-NN`. The depth-first tier
+// recurses into a result's open questions indefinitely, producing degenerate
+// chains up to 11 levels deep. Cap it AT THE SOURCE: a proof whose id already
+// has `maxOqDepth` `-oq-` segments does not contribute further OQ children, so
+// no problem beyond the cap is ever extracted into the pool.
+//
+// Configuration precedence: MAX_OQ_DEPTH env var > .lean/config/oq-policy.json
+// > built-in default (3).
+// ---------------------------------------------------------------------------
+const OQ_POLICY_DEFAULT_DEPTH = 3;
+
+function resolveMaxOqDepth(): number {
+  const fromEnv = process.env.MAX_OQ_DEPTH;
+  if (fromEnv !== undefined && /^\d+$/.test(fromEnv.trim())) {
+    return parseInt(fromEnv.trim(), 10);
+  }
+  try {
+    const configPath = join(process.cwd(), '.lean/config/oq-policy.json');
+    if (existsSync(configPath)) {
+      const cfg = JSON.parse(readFileSync(configPath, 'utf-8'));
+      if (typeof cfg.maxOqDepth === 'number' && Number.isFinite(cfg.maxOqDepth)) {
+        return cfg.maxOqDepth;
+      }
+    }
+  } catch {
+    // Fall through to default on any parse/read error.
+  }
+  return OQ_POLICY_DEFAULT_DEPTH;
+}
+
+// Number of `-oq-NN` segments in a slug/id (its OQ-recursion depth).
+function oqDepth(id: string): number {
+  return (id.match(/-oq-\d+/g) || []).length;
+}
+
+const MAX_OQ_DEPTH = resolveMaxOqDepth();
+
 // Types
 interface ProofMeta {
   id: string;
@@ -124,6 +164,7 @@ function extractTitle(question: string): string {
 // Main extraction function
 function extractProblems(proofsDir: string): ExtractedProblem[] {
   const problems: ExtractedProblem[] = [];
+  let cappedChains = 0; // proofs whose OQ children were suppressed by the cap
 
   // Get all proof directories
   const proofDirs = readdirSync(proofsDir, { withFileTypes: true })
@@ -138,8 +179,14 @@ function extractProblems(proofsDir: string): ExtractedProblem[] {
     try {
       const meta: ProofMeta = JSON.parse(readFileSync(metaPath, 'utf-8'));
 
-      // 1. Extract from openQuestions
-      if (meta.conclusion?.openQuestions) {
+      // OQ depth cap (issue #39827): a proof already at/over the cap must not
+      // spawn a deeper `-oq-` child. Its own open questions are dropped so the
+      // chain stops descending; the parent entry itself is untouched.
+      const parentDepth = oqDepth(meta.id);
+      const oqChildrenAllowed = parentDepth < MAX_OQ_DEPTH;
+
+      // 1. Extract from openQuestions (only when below the depth cap)
+      if (oqChildrenAllowed && meta.conclusion?.openQuestions) {
         meta.conclusion.openQuestions.forEach((rawQuestion, index) => {
           // openQuestions entries may be plain strings (legacy) or
           // {id, question, significance} objects (enriched). Normalize to a string.
@@ -162,6 +209,14 @@ function extractProblems(proofsDir: string): ExtractedProblem[] {
             relatedProofs: [meta.id]
           });
         });
+      } else if (!oqChildrenAllowed && (meta.conclusion?.openQuestions?.length ?? 0) > 0) {
+        // Chain has reached the depth cap: suppress its OQ children so it stops
+        // descending, and record it for the summary telemetry line below.
+        cappedChains += 1;
+        console.error(
+          `OQ-cap: suppressing ${meta.conclusion!.openQuestions!.length} open-question child(ren) of ${meta.id} ` +
+          `(depth ${parentDepth} >= cap ${MAX_OQ_DEPTH})`
+        );
       }
 
       // 2. Incomplete proofs (sorries > 0, but not fallacy/pedagogical)
@@ -243,6 +298,13 @@ function extractProblems(proofsDir: string): ExtractedProblem[] {
     }
   }
 
+  if (cappedChains > 0) {
+    console.error(
+      `OQ-cap: capped OQ recursion for ${cappedChains} chain(s) at depth >= ${MAX_OQ_DEPTH} ` +
+      `(set MAX_OQ_DEPTH or .lean/config/oq-policy.json to adjust)`
+    );
+  }
+
   return problems;
 }
 
@@ -307,7 +369,8 @@ const tractabilityFilter = args.find(a => a.startsWith('--tractability='))?.spli
 const proofsDir = join(process.cwd(), 'src/data/proofs');
 const outputPath = join(process.cwd(), '.lean/research/problems.json');
 
-console.log('Extracting problems from proof gallery...\n');
+console.log('Extracting problems from proof gallery...');
+console.log(`OQ-recursion cap: maxOqDepth=${MAX_OQ_DEPTH} (override with MAX_OQ_DEPTH env)\n`);
 
 let problems = extractProblems(proofsDir);
 

--- a/scripts/lib/oq-policy.sh
+++ b/scripts/lib/oq-policy.sh
@@ -1,0 +1,103 @@
+#!/bin/bash
+#
+# oq-policy.sh - Shared open-question (OQ) recursion policy for research agents.
+#
+# Sourced by the researcher/seeker problem-selection scripts to keep the
+# OQ-recursion-depth cap in ONE place (issue #39827 / #39821). Without a cap the
+# depth-first tier recurses into a result's open questions indefinitely,
+# producing degenerate chains like
+#   abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01-oq-01-oq-01-oq-01-oq-01-oq-01-oq-01
+# and single problems with 15+ descendants (erdos-396).
+#
+# A gallery entry's "OQ depth" is the number of `-oq-NN` segments in its slug/id.
+#
+# Configuration precedence (highest first):
+#   1. MAX_OQ_DEPTH environment variable
+#   2. maxOqDepth in .lean/config/oq-policy.json
+#   3. built-in default (OQ_POLICY_DEFAULT_DEPTH below)
+#
+# Functions:
+#   oq_depth <slug>       Echo the number of -oq- segments in <slug>.
+#   oq_max_depth          Echo the configured max OQ depth.
+#   oq_over_cap <slug>    Return 0 (true) if <slug> is strictly deeper than the
+#                         cap (an entry that should never have been spawned).
+#   oq_at_or_over_cap <slug>
+#                         Return 0 (true) if <slug> is at OR beyond the cap
+#                         (a leaf that must not spawn further children).
+
+# Built-in default cap. Matches the prose guards in the seeker/researcher roles
+# (at most 3 -oq- segments in a chain).
+OQ_POLICY_DEFAULT_DEPTH=3
+
+# Resolve the repo root so we can find the config file regardless of the caller's
+# cwd (agents run from linked worktrees). Falls back to the default when git or
+# the config file is unavailable.
+_oq_policy_repo_root() {
+    local common_dir
+    if common_dir="$(git rev-parse --git-common-dir 2>/dev/null)" \
+        && common_dir="$(cd "$common_dir" 2>/dev/null && pwd)"; then
+        dirname "$common_dir"
+        return 0
+    fi
+    local dir="$PWD"
+    while [[ "$dir" != "/" ]]; do
+        if [[ -e "$dir/.git" ]]; then
+            echo "$dir"
+            return 0
+        fi
+        dir="$(dirname "$dir")"
+    done
+    echo "$PWD"
+}
+
+# oq_depth <slug> — count of -oq- segments (0 for a root entry).
+oq_depth() {
+    local slug="$1"
+    [[ -z "$slug" ]] && { echo 0; return; }
+    # Count occurrences of "-oq-" followed by digits. grep -o prints one match
+    # per line; wc -l counts them. `|| true` keeps set -e callers happy on 0.
+    local n
+    n=$(printf '%s\n' "$slug" | grep -o -- '-oq-[0-9]*' | wc -l | tr -d ' ')
+    echo "${n:-0}"
+}
+
+# oq_max_depth — resolve the configured cap (env > config file > default).
+oq_max_depth() {
+    if [[ -n "${MAX_OQ_DEPTH:-}" ]]; then
+        # Validate: must be a non-negative integer, else fall through.
+        if [[ "$MAX_OQ_DEPTH" =~ ^[0-9]+$ ]]; then
+            echo "$MAX_OQ_DEPTH"
+            return
+        fi
+    fi
+
+    local root config depth
+    root="$(_oq_policy_repo_root)"
+    config="$root/.lean/config/oq-policy.json"
+    if [[ -f "$config" ]] && command -v jq >/dev/null 2>&1; then
+        depth=$(jq -r '.maxOqDepth // empty' "$config" 2>/dev/null || true)
+        if [[ "$depth" =~ ^[0-9]+$ ]]; then
+            echo "$depth"
+            return
+        fi
+    fi
+
+    echo "$OQ_POLICY_DEFAULT_DEPTH"
+}
+
+# oq_over_cap <slug> — true (0) if slug is strictly deeper than the cap.
+oq_over_cap() {
+    local depth cap
+    depth="$(oq_depth "$1")"
+    cap="$(oq_max_depth)"
+    [[ "$depth" -gt "$cap" ]]
+}
+
+# oq_at_or_over_cap <slug> — true (0) if slug is at or beyond the cap; such an
+# entry must not spawn further OQ children.
+oq_at_or_over_cap() {
+    local depth cap
+    depth="$(oq_depth "$1")"
+    cap="$(oq_max_depth)"
+    [[ "$depth" -ge "$cap" ]]
+}

--- a/scripts/research/claim-problem.sh
+++ b/scripts/research/claim-problem.sh
@@ -53,6 +53,22 @@ PROBLEMS_DIR="$REPO_ROOT/src/data/research/problems"
 LOCKS_DIR="$REPO_ROOT/.loom/locks"
 POOL_LOCK_FILE="$LOCKS_DIR/candidate-pool.lock"
 
+# Shared OQ-recursion-depth policy (issue #39827): provides oq_depth,
+# oq_max_depth, oq_over_cap, oq_at_or_over_cap. Sourcing is best-effort so this
+# script still runs if the lib is missing on an older checkout.
+# shellcheck source=../lib/oq-policy.sh
+if [[ -f "$REPO_ROOT/scripts/lib/oq-policy.sh" ]]; then
+    source "$REPO_ROOT/scripts/lib/oq-policy.sh"
+fi
+# Fallbacks so an older checkout without the lib still selects problems (it just
+# won't apply the depth cap).
+if ! declare -f oq_depth >/dev/null 2>&1; then
+    oq_depth() { echo 0; }
+    oq_max_depth() { echo "${MAX_OQ_DEPTH:-3}"; }
+    oq_over_cap() { return 1; }
+    oq_at_or_over_cap() { return 1; }
+fi
+
 # Defaults
 # TTL raised 90 -> 180 (fix C): research sessions with Docker builds + Mathlib-drift
 # repair routinely exceed 90 min. When a claim expired mid-session, the Seeker
@@ -358,6 +374,14 @@ claim_random_problem() {
     local available=()
     local scores=()
 
+    # OQ-recursion-depth policy (issue #39827): never re-serve chains that are
+    # already deeper than the cap (they should never have been spawned), and
+    # deprioritize chains that have reached the cap in favor of breadth.
+    local oq_cap
+    oq_cap="$(oq_max_depth)"
+    local over_cap_skipped=0
+    local at_cap_deferred=()  # candidate ids at exactly the cap (deprioritized)
+
     while IFS= read -r problem_id; do
         [[ -z "$problem_id" ]] && continue
 
@@ -368,11 +392,42 @@ claim_random_problem() {
             continue
         fi
 
+        # Never re-serve a saturated (over-cap) chain.
+        if oq_over_cap "$problem_id"; then
+            over_cap_skipped=$((over_cap_skipped + 1))
+            continue
+        fi
+
+        # Defer at-cap chains: they are eligible only if nothing shallower is
+        # available, so selection favors breadth (issue #39827).
+        if oq_at_or_over_cap "$problem_id"; then
+            at_cap_deferred+=("$problem_id")
+            continue
+        fi
+
         local score
         score=$(get_knowledge_score "$problem_id")
         available+=("$problem_id")
         scores+=("$score")
     done < <(jq -r '.candidates[] | select(.status != "completed" and .status != "blocked" and .status != "graduated" and .status != "skipped") | .id' "$POOL_FILE" 2>/dev/null)
+
+    if [[ $over_cap_skipped -gt 0 ]]; then
+        echo "OQ-cap: excluded $over_cap_skipped saturated chain(s) deeper than cap=$oq_cap (not re-served)" >&2
+    fi
+
+    # Breadth preference: fall back to at-cap chains only when no shallower
+    # problem is available.
+    if [[ ${#available[@]} -eq 0 && ${#at_cap_deferred[@]} -gt 0 ]]; then
+        echo "OQ-cap: no problems below depth cap=$oq_cap; falling back to ${#at_cap_deferred[@]} at-cap chain(s)" >&2
+        for problem_id in "${at_cap_deferred[@]}"; do
+            local score
+            score=$(get_knowledge_score "$problem_id")
+            available+=("$problem_id")
+            scores+=("$score")
+        done
+    elif [[ ${#at_cap_deferred[@]} -gt 0 ]]; then
+        echo "OQ-cap: deprioritized ${#at_cap_deferred[@]} at-cap chain(s) (depth=$oq_cap) in favor of breadth" >&2
+    fi
 
     if [[ ${#available[@]} -eq 0 ]]; then
         echo "No available problems to claim" >&2
@@ -659,6 +714,9 @@ Environment Variables:
   RESEARCHER_ID    Agent identifier (default: researcher-PID)
   CLAIM_TTL        Claim time-to-live in minutes (default: 180)
   FORCE_COMPLETE   Set to 1 to bypass graduation quality gate
+  MAX_OQ_DEPTH     Max -oq- segments in a servable chain (default: 3, or
+                   .lean/config/oq-policy.json). Chains deeper than the cap are
+                   never re-served; at-cap chains are deprioritized (breadth).
 
 Knowledge Tiers (DEPTH OVER BREADTH - higher = higher priority):
   MODERATE (6-15) - Highest priority: advance toward proof

--- a/scripts/tests/claim-problem-oq-cap.test.sh
+++ b/scripts/tests/claim-problem-oq-cap.test.sh
@@ -1,0 +1,106 @@
+#!/bin/bash
+# Integration tests for the OQ-recursion-depth cap in
+# scripts/research/claim-problem.sh:claim_random_problem() (issue #39827).
+#
+# Drives the REAL shipped CLI (`claim-random`) inside throwaway git sandboxes so
+# find_repo_root resolves entirely into mktemp dirs and no shared coordination
+# state is touched. Asserts the three policy behaviors:
+#
+#   1. Over-cap exclusion: chains deeper than the cap are never selected and are
+#      reported as excluded/saturated.
+#   2. Breadth preference: when a shallow problem and an at-cap chain are both
+#      available, the shallow one is selected and the at-cap one is deprioritized.
+#   3. Fallback: when ONLY at-cap chains are available, one is still selected
+#      (with a "falling back" notice) rather than starving the pipeline.
+#
+# Run: bash scripts/tests/claim-problem-oq-cap.test.sh
+# Exits non-zero if any assertion fails.
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CLAIM_SCRIPT="$SCRIPT_DIR/../research/claim-problem.sh"
+
+PASS=0; FAIL=0
+assert_eq() { # <desc> <expected> <actual>
+    if [[ "$3" == "$2" ]]; then echo "  ok: $1 -> $3"; ((PASS++)); else echo "  FAIL: $1 expected '$2' got '$3'"; ((FAIL++)); fi
+}
+assert_contains() { # <desc> <needle> <haystack>
+    if [[ "$3" == *"$2"* ]]; then echo "  ok: $1"; ((PASS++)); else echo "  FAIL: $1 (missing '$2')"; ((FAIL++)); fi
+}
+assert_not_contains() { # <desc> <needle> <haystack>
+    if [[ "$3" != *"$2"* ]]; then echo "  ok: $1"; ((PASS++)); else echo "  FAIL: $1 (should not contain '$2')"; ((FAIL++)); fi
+}
+
+if [[ ! -f "$CLAIM_SCRIPT" ]]; then
+    echo "FAIL: claim-problem.sh not found at $CLAIM_SCRIPT" >&2
+    exit 1
+fi
+
+# new_sandbox <pool-json> -> echoes sandbox path
+new_sandbox() {
+    local pool="$1" sb
+    sb="$(mktemp -d)"
+    mkdir -p "$sb/research/claims" "$sb/.lean/state" \
+             "$sb/.lean/config" "$sb/src/data/research/problems" "$sb/.loom/locks"
+    # Ship the same policy config the repo tracks so the cap resolves to 3.
+    printf '{"maxOqDepth": 3}\n' > "$sb/.lean/config/oq-policy.json"
+    # Make the shared lib importable at $sb/scripts/lib/oq-policy.sh.
+    mkdir -p "$sb/scripts/lib"
+    cp "$SCRIPT_DIR/../lib/oq-policy.sh" "$sb/scripts/lib/oq-policy.sh"
+    printf '%s\n' "$pool" > "$sb/.lean/state/candidate-pool.json"
+    git -C "$sb" init -q
+    echo "$sb"
+}
+
+# run_claim_random <sandbox> -> populates OUT (stdout) and ERR (stderr), RC
+run_claim_random() {
+    local sb="$1"
+    OUT="$( cd "$sb" && MAX_OQ_DEPTH=3 RESEARCHER_ID=test-agent bash "$CLAIM_SCRIPT" claim-random 2>/tmp/oq_err_$$ )"
+    RC=$?
+    ERR="$(cat /tmp/oq_err_$$ 2>/dev/null)"
+    rm -f /tmp/oq_err_$$
+}
+
+echo "--- Case 1: over-cap chain is excluded, never re-served ---"
+POOL='{"candidates":[{"id":"foo-oq-01-oq-02-oq-03-oq-04","status":"available"}]}'
+SB="$(new_sandbox "$POOL")"
+run_claim_random "$SB"
+assert_eq "no claimable problem (only over-cap present)" "1" "$RC"
+assert_contains "excluded saturated chain logged" "excluded 1 saturated chain" "$ERR"
+assert_not_contains "over-cap id never selected" "Selected foo-oq-01-oq-02-oq-03-oq-04" "$OUT"
+rm -rf "$SB"
+
+echo "--- Case 2: breadth preference (shallow beats at-cap) ---"
+POOL='{"candidates":[
+  {"id":"shallow-problem","status":"available"},
+  {"id":"deep-oq-01-oq-02-oq-03","status":"available"}
+]}'
+SB="$(new_sandbox "$POOL")"
+run_claim_random "$SB"
+assert_eq "a problem was claimed" "0" "$RC"
+assert_contains "shallow problem selected" "Selected shallow-problem" "$OUT"
+assert_contains "at-cap chain deprioritized" "deprioritized 1 at-cap chain" "$ERR"
+rm -rf "$SB"
+
+echo "--- Case 3: fallback to at-cap when nothing shallower exists ---"
+POOL='{"candidates":[{"id":"only-oq-01-oq-02-oq-03","status":"available"}]}'
+SB="$(new_sandbox "$POOL")"
+run_claim_random "$SB"
+assert_eq "at-cap chain claimed as fallback" "0" "$RC"
+assert_contains "at-cap chain selected" "Selected only-oq-01-oq-02-oq-03" "$OUT"
+assert_contains "fallback logged" "falling back to 1 at-cap chain" "$ERR"
+rm -rf "$SB"
+
+echo "--- Case 4: raising the cap admits a deeper chain ---"
+# Same pool as Case 1 but MAX_OQ_DEPTH=4 -> depth-4 chain is now at-cap (servable).
+POOL='{"candidates":[{"id":"foo-oq-01-oq-02-oq-03-oq-04","status":"available"}]}'
+SB="$(new_sandbox "$POOL")"
+OUT="$( cd "$SB" && MAX_OQ_DEPTH=4 RESEARCHER_ID=test-agent bash "$CLAIM_SCRIPT" claim-random 2>/tmp/oq_err_$$ )"
+RC=$?; ERR="$(cat /tmp/oq_err_$$ 2>/dev/null)"; rm -f /tmp/oq_err_$$
+assert_eq "depth-4 chain claimable at cap=4" "0" "$RC"
+assert_contains "depth-4 chain selected at cap=4" "Selected foo-oq-01-oq-02-oq-03-oq-04" "$OUT"
+rm -rf "$SB"
+
+echo ""
+echo "Passed: $PASS  Failed: $FAIL"
+[[ $FAIL -eq 0 ]]

--- a/scripts/tests/extract-problems-oq-cap.test.sh
+++ b/scripts/tests/extract-problems-oq-cap.test.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+# Integration test for the OQ-recursion-depth cap in
+# .lean/scripts/extract-problems.ts (issue #39827).
+#
+# Runs the REAL extractor against a synthetic src/data/proofs tree in a temp
+# cwd and asserts that a proof whose id is already at/over the cap does NOT
+# spawn `-oq-` children, while shallower proofs still do. Also verifies the
+# MAX_OQ_DEPTH env override and the telemetry line on stderr.
+#
+# Requires `tsx` on PATH (the extractor imports only Node builtins, so no
+# node_modules install is needed).
+#
+# Run: bash scripts/tests/extract-problems-oq-cap.test.sh
+# Exits non-zero if any assertion fails.
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+EXTRACTOR="$SCRIPT_DIR/../../.lean/scripts/extract-problems.ts"
+
+if ! command -v tsx >/dev/null 2>&1 && ! command -v npx >/dev/null 2>&1; then
+    echo "SKIP: neither tsx nor npx on PATH" >&2
+    exit 0
+fi
+TSX_CMD=(tsx)
+command -v tsx >/dev/null 2>&1 || TSX_CMD=(npx tsx)
+
+PASS=0; FAIL=0
+assert_eq() { if [[ "$3" == "$2" ]]; then echo "  ok: $1 -> $3"; ((PASS++)); else echo "  FAIL: $1 expected '$2' got '$3'"; ((FAIL++)); fi; }
+assert_contains() { if [[ "$3" == *"$2"* ]]; then echo "  ok: $1"; ((PASS++)); else echo "  FAIL: $1 (missing '$2')"; ((FAIL++)); fi; }
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+# make_proof <id>  -- writes a verified proof meta.json with one open question.
+make_proof() {
+    local id="$1"
+    mkdir -p "$WORK/src/data/proofs/$id"
+    cat > "$WORK/src/data/proofs/$id/meta.json" <<EOF
+{
+  "id": "$id",
+  "title": "Proof $id",
+  "slug": "$id",
+  "description": "test",
+  "meta": { "status": "verified", "badge": "original", "tags": ["t"], "sorries": 0 },
+  "conclusion": { "openQuestions": [ { "id": "q1", "question": "Can we generalize $id?" } ] }
+}
+EOF
+}
+
+mkdir -p "$WORK/.lean/config" "$WORK/.lean/research"
+printf '{"maxOqDepth": 3}\n' > "$WORK/.lean/config/oq-policy.json"
+
+# Depths: root(0), 2, 3(at cap), 4(over cap).
+make_proof "alpha"
+make_proof "beta-oq-01-oq-02"
+make_proof "gamma-oq-01-oq-02-oq-03"
+make_proof "delta-oq-01-oq-02-oq-03-oq-04"
+
+echo "--- Run 1: default cap (config=3) ---"
+ERRFILE="$WORK/err1.txt"
+( cd "$WORK" && "${TSX_CMD[@]}" "$EXTRACTOR" --json ) >/dev/null 2>"$ERRFILE"
+IDS="$(python3 -c "import json;print('\n'.join(p['id'] for p in json.load(open('$WORK/.lean/research/problems.json'))))")"
+
+assert_contains "root proof spawns oq child" "alpha-oq-01" "$IDS"
+assert_contains "depth-2 proof spawns oq child" "beta-oq-01-oq-02-oq-01" "$IDS"
+# gamma is AT the cap (depth 3): must NOT spawn a depth-4 child.
+if [[ "$IDS" == *"gamma-oq-01-oq-02-oq-03-oq-01"* ]]; then
+    echo "  FAIL: at-cap proof spawned a child"; ((FAIL++))
+else
+    echo "  ok: at-cap proof (depth 3) spawned no child"; ((PASS++))
+fi
+# delta is OVER the cap (depth 4): must NOT spawn a child either.
+if [[ "$IDS" == *"delta-oq-01-oq-02-oq-03-oq-04-oq-01"* ]]; then
+    echo "  FAIL: over-cap proof spawned a child"; ((FAIL++))
+else
+    echo "  ok: over-cap proof (depth 4) spawned no child"; ((PASS++))
+fi
+assert_contains "telemetry line emitted" "OQ-cap: capped OQ recursion" "$(cat "$ERRFILE")"
+
+echo "--- Run 2: MAX_OQ_DEPTH=4 admits gamma's child ---"
+( cd "$WORK" && MAX_OQ_DEPTH=4 "${TSX_CMD[@]}" "$EXTRACTOR" --json ) >/dev/null 2>/dev/null
+IDS2="$(python3 -c "import json;print('\n'.join(p['id'] for p in json.load(open('$WORK/.lean/research/problems.json'))))")"
+assert_contains "gamma spawns child when cap raised to 4" "gamma-oq-01-oq-02-oq-03-oq-01" "$IDS2"
+# delta (depth 4) is now AT cap 4 -> still no child.
+if [[ "$IDS2" == *"delta-oq-01-oq-02-oq-03-oq-04-oq-01"* ]]; then
+    echo "  FAIL: depth-4 proof spawned child at cap=4"; ((FAIL++))
+else
+    echo "  ok: depth-4 proof still capped at cap=4"; ((PASS++))
+fi
+
+echo ""
+echo "Passed: $PASS  Failed: $FAIL"
+[[ $FAIL -eq 0 ]]

--- a/scripts/tests/oq-policy.test.sh
+++ b/scripts/tests/oq-policy.test.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+# Unit tests for scripts/lib/oq-policy.sh (issue #39827).
+#
+# Covers:
+#   - oq_depth: counts -oq- segments in a slug (0 for roots, N for chains)
+#   - oq_max_depth: env var > .lean/config/oq-policy.json > built-in default
+#   - oq_over_cap / oq_at_or_over_cap: cap comparisons
+#
+# tmpdir-based; no network, no writes outside mktemp dirs.
+# Run: bash scripts/tests/oq-policy.test.sh
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib/oq-policy.sh
+source "$SCRIPT_DIR/../lib/oq-policy.sh"
+
+PASS=0; FAIL=0
+assert_eq() { # <desc> <expected> <actual>
+    if [[ "$3" == "$2" ]]; then echo "  ok: $1 -> $3"; ((PASS++)); else echo "  FAIL: $1 expected '$2' got '$3'"; ((FAIL++)); fi
+}
+assert_true() { # <desc> ; runs "$@" from index 2
+    local desc="$1"; shift
+    if "$@"; then echo "  ok: $desc"; ((PASS++)); else echo "  FAIL: $desc (expected success)"; ((FAIL++)); fi
+}
+assert_false() { # <desc> ; runs "$@" from index 2
+    local desc="$1"; shift
+    if "$@"; then echo "  FAIL: $desc (expected failure)"; ((FAIL++)); else echo "  ok: $desc"; ((PASS++)); fi
+}
+
+echo "--- Section 1: oq_depth ---"
+assert_eq "root entry has depth 0" "0" "$(oq_depth 'abel-ruffini')"
+assert_eq "single oq segment" "1" "$(oq_depth 'abel-ruffini-oq-04')"
+assert_eq "two oq segments" "2" "$(oq_depth 'dirichlets-theorem-oq-02-oq-01')"
+assert_eq "deep chain" "11" "$(oq_depth 'abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01-oq-01-oq-01-oq-01-oq-01-oq-01-oq-01')"
+assert_eq "empty slug" "0" "$(oq_depth '')"
+# A literal "oq" in the base name (no -NN) must not be miscounted.
+assert_eq "non-oq token not counted" "0" "$(oq_depth 'oqbert-theorem')"
+assert_eq "incomplete suffix not counted as oq" "2" "$(oq_depth 'angle-trisection-oq-02-oq-01-incomplete-01')"
+
+echo "--- Section 2: oq_max_depth resolution ---"
+# Isolate from any ambient env / repo config: point the resolver at a temp repo.
+ROOT=$(mktemp -d)
+trap 'rm -rf "$ROOT"' EXIT
+mkdir -p "$ROOT/.git" "$ROOT/.lean/config"
+# Make the resolver treat $ROOT as the repo root: run from inside it and neutralize git.
+_run_in_repo() { ( cd "$ROOT" && env -u MAX_OQ_DEPTH PATH="$PATH" bash -c "
+    source '$SCRIPT_DIR/../lib/oq-policy.sh'
+    $1
+" ); }
+
+# No env, no config -> built-in default (3).
+rm -f "$ROOT/.lean/config/oq-policy.json"
+assert_eq "default when unconfigured" "3" "$(_run_in_repo 'oq_max_depth')"
+
+# Config file value is honored.
+printf '{"maxOqDepth": 5}\n' > "$ROOT/.lean/config/oq-policy.json"
+assert_eq "config file honored" "5" "$(_run_in_repo 'oq_max_depth')"
+
+# Env var beats config file.
+assert_eq "env beats config" "2" "$( ( cd "$ROOT" && MAX_OQ_DEPTH=2 bash -c "source '$SCRIPT_DIR/../lib/oq-policy.sh'; oq_max_depth" ) )"
+
+# Non-numeric env var is ignored -> falls back to config (5).
+assert_eq "non-numeric env ignored" "5" "$( ( cd "$ROOT" && MAX_OQ_DEPTH=abc bash -c "source '$SCRIPT_DIR/../lib/oq-policy.sh'; oq_max_depth" ) )"
+
+# Malformed config -> built-in default.
+printf 'not json\n' > "$ROOT/.lean/config/oq-policy.json"
+assert_eq "malformed config falls back to default" "3" "$(_run_in_repo 'oq_max_depth')"
+
+echo "--- Section 3: cap comparisons (cap=3 via env) ---"
+export MAX_OQ_DEPTH=3
+assert_false "depth 0 not over cap" oq_over_cap 'root-problem'
+assert_false "depth 3 not over cap (at cap)" oq_over_cap 'a-oq-01-oq-02-oq-03'
+assert_true  "depth 4 over cap" oq_over_cap 'a-oq-01-oq-02-oq-03-oq-04'
+assert_false "depth 2 not at-or-over cap" oq_at_or_over_cap 'a-oq-01-oq-02'
+assert_true  "depth 3 at-or-over cap" oq_at_or_over_cap 'a-oq-01-oq-02-oq-03'
+assert_true  "depth 4 at-or-over cap" oq_at_or_over_cap 'a-oq-01-oq-02-oq-03-oq-04'
+unset MAX_OQ_DEPTH
+
+echo ""
+echo "Passed: $PASS  Failed: $FAIL"
+[[ $FAIL -eq 0 ]]


### PR DESCRIPTION
Closes #39827 (part of #39821).

## Problem
The depth-first researcher/seeker tier recursed into a result's open questions (OQ) without bound, spawning child gallery entries `<parent>-oq-NN`. This produced degenerate chains up to 11 levels deep (e.g. `abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01-oq-01-oq-01-oq-01-oq-01-oq-01-oq-01`) and single problems with 15 descendants (erdos-396). Existing depth guards lived only in the role-doc prose (unreliable agent instructions), so nothing enforced them.

## What this does
A gallery entry's **OQ depth** = number of `-oq-NN` segments in its slug. This PR adds a **configurable max OQ-recursion depth** (default 3) and enforces it in code at both the spawn source and the selection point.

- **`.lean/config/oq-policy.json`** (new, tracked) — single source of truth for the cap (`maxOqDepth`, default 3). Overridable at runtime via the **`MAX_OQ_DEPTH`** env var. Precedence: env var > config file > built-in default.
- **`scripts/lib/oq-policy.sh`** (new) — shared shell helpers: `oq_depth`, `oq_max_depth`, `oq_over_cap`, `oq_at_or_over_cap`.
- **`.lean/scripts/extract-problems.ts`** — a proof already at/over the cap no longer contributes OQ children, so **no over-cap problem is ever extracted into the pool** (stops descent at the source). Emits a telemetry line per capped chain.
- **`scripts/research/claim-problem.sh` (`claim-random`)** — at selection time:
  - **never re-serves** over-cap chains (saturated → excluded),
  - **defers at-cap chains** so a shallower/unexplored problem is preferred (**breadth over depth**), falling back to at-cap chains only when nothing shallower is available,
  - logs each cap / defer / fallback decision to stderr (visible in researcher/seeker logs).
- **Role docs** (`seeker.md`, `researcher.md`) updated to reference the now-enforced, configurable cap (guards kept as a second line of defense).

The cap lives in tracked files only; `research/db/` (knowledge.db, sync_pool.py) is gitignored, so the DB-side pool is covered instead by the selection-time filter, which is the actual consumer path.

## Acceptance criteria
- [x] No new entries created beyond the configured depth cap (extractor drops at/over-cap OQ children).
- [x] Selection favors breadth once a chain reaches the cap (at-cap chains deferred).
- [x] Saturated (over-cap) chains are not re-served (excluded from selection).
- [x] Cap is configurable, not hardcoded (`MAX_OQ_DEPTH` env / `.lean/config/oq-policy.json`).
- [x] Log line emitted when a chain is capped.

## Tests
Three new suites, 36 assertions, all green; no network, tmpdir-sandboxed:
- `scripts/tests/oq-policy.test.sh` (18) — depth counting, cap resolution precedence (env > config > default), malformed/non-numeric handling, cap comparisons.
- `scripts/tests/claim-problem-oq-cap.test.sh` (11) — drives the real `claim-random` CLI: over-cap exclusion, breadth preference, at-cap fallback, raising the cap.
- `scripts/tests/extract-problems-oq-cap.test.sh` (7) — runs the real extractor: at/over-cap proofs spawn no children, shallower ones still do, `MAX_OQ_DEPTH` override.

Existing regression `scripts/tests/claim-problem-reclaim-race.test.sh` still passes (20/20). `shellcheck -x` clean (info-level only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)