### PR TITLE
Research: erdos-53-wip-01 — superincreasing sets have 2^|A| distinct subset sums (0-axiom)

### DIFF
--- a/proofs/Proofs/Erdos53Problem.lean
+++ b/proofs/Proofs/Erdos53Problem.lean
@@ -343,10 +343,10 @@ theorem subsetSum_injOn_of_superincreasing {A : Finset ℤ}
     have hmA : m ∈ A := hS (Finset.mem_sdiff.mp hm).1
     -- the two half-differences have equal sum
     have hu1 : (S ∪ T).sum id = S.sum id + (T \ S).sum id := by
-      rw [← Finset.union_sdiff_self_eq_union, Finset.sum_union Finset.disjoint_sdiff_self_right]
+      rw [← Finset.union_sdiff_self_eq_union, Finset.sum_union disjoint_sdiff_self_right]
     have hu2 : (S ∪ T).sum id = T.sum id + (S \ T).sum id := by
       rw [Finset.union_comm, ← Finset.union_sdiff_self_eq_union,
-        Finset.sum_union Finset.disjoint_sdiff_self_right]
+        Finset.sum_union disjoint_sdiff_self_right]
     have hsplit : (S \ T).sum id = (T \ S).sum id := by
       have : S.sum id + (T \ S).sum id = T.sum id + (S \ T).sum id := by rw [← hu1, hu2]
       linarith

--- a/proofs/Proofs/Erdos53Problem.lean
+++ b/proofs/Proofs/Erdos53Problem.lean
@@ -320,4 +320,86 @@ theorem subsetProducts_card_of_prime {A : Finset ℤ}
     tauto
   rw [hfe, Finset.card_erase_of_mem (Finset.empty_mem_powerset A), Finset.card_powerset]
 
+/-- **Superincreasing ⇒ injective subset sums.** If every element of `A` is
+positive and strictly exceeds the sum of the strictly smaller elements of `A`
+(the *superincreasing* condition, e.g. `{1, 2, 4, …, 2^{k−1}}`), then distinct
+subsets have distinct sums.  This is the additive analogue of
+`subsetProd_injOn_of_prime`.
+
+Proof: if `S ≠ T` had equal sums, let `m` be the largest element in their
+symmetric difference, say `m ∈ S \ T`.  Cancelling the common part gives
+`(S\T).sum = (T\S).sum`; but `m ≤ (S\T).sum` while every element of `T\S` is
+`< m`, so `(T\S).sum ≤ (Σ elements < m) < m` by superincreasingness — a
+contradiction. -/
+theorem subsetSum_injOn_of_superincreasing {A : Finset ℤ}
+    (hpos : ∀ a ∈ A, 0 < a)
+    (hsi : ∀ a ∈ A, (A.filter (· < a)).sum id < a) :
+    Set.InjOn (fun S => S.sum id) (A.powerset : Set (Finset ℤ)) := by
+  -- one-sided contradiction, applied with the two subsets in the order that puts
+  -- the max element of the symmetric difference on the left
+  have key : ∀ S T : Finset ℤ, S ⊆ A → T ⊆ A → S.sum id = T.sum id →
+      ∀ m, m ∈ S \ T → (∀ x ∈ T \ S, x < m) → False := by
+    intro S T hS hT hsum m hm hmax
+    have hmA : m ∈ A := hS (Finset.mem_sdiff.mp hm).1
+    -- the two half-differences have equal sum
+    have hu1 : (S ∪ T).sum id = S.sum id + (T \ S).sum id := by
+      rw [← Finset.union_sdiff_self_eq_union, Finset.sum_union Finset.disjoint_sdiff_self_right]
+    have hu2 : (S ∪ T).sum id = T.sum id + (S \ T).sum id := by
+      rw [Finset.union_comm, ← Finset.union_sdiff_self_eq_union,
+        Finset.sum_union Finset.disjoint_sdiff_self_right]
+    have hsplit : (S \ T).sum id = (T \ S).sum id := by
+      have : S.sum id + (T \ S).sum id = T.sum id + (S \ T).sum id := by rw [← hu1, hu2]
+      linarith
+    -- m ≤ (S \ T).sum, since m ∈ S \ T and all elements are positive
+    have hge : m ≤ (S \ T).sum id :=
+      Finset.single_le_sum
+        (fun x hx => le_of_lt (hpos x (hS (Finset.mem_sdiff.mp hx).1))) hm
+    -- (T \ S).sum < m, since T \ S ⊆ {elements of A below m}
+    have hTsub : T \ S ⊆ A.filter (· < m) := fun x hx =>
+      Finset.mem_filter.mpr ⟨hT (Finset.mem_sdiff.mp hx).1, hmax x hx⟩
+    have hle : (T \ S).sum id ≤ (A.filter (· < m)).sum id :=
+      Finset.sum_le_sum_of_subset_of_nonneg hTsub
+        (fun x hx _ => le_of_lt (hpos x (Finset.mem_filter.mp hx).1))
+    have hfilt : (A.filter (· < m)).sum id < m := hsi m hmA
+    linarith
+  intro S hS T hT hST
+  rw [Finset.mem_coe, Finset.mem_powerset] at hS hT
+  by_contra hne
+  -- the symmetric difference is nonempty
+  have hD : (S \ T ∪ T \ S).Nonempty := by
+    by_contra h
+    rw [Finset.not_nonempty_iff_eq_empty] at h
+    apply hne
+    have h1 : S \ T = ∅ := Finset.subset_empty.mp (h ▸ Finset.subset_union_left)
+    have h2 : T \ S = ∅ := Finset.subset_empty.mp (h ▸ Finset.subset_union_right)
+    exact Finset.Subset.antisymm (Finset.sdiff_eq_empty_iff_subset.mp h1)
+      (Finset.sdiff_eq_empty_iff_subset.mp h2)
+  -- its maximum lies in one side; the other side is strictly below it
+  set m := (S \ T ∪ T \ S).max' hD with hm_def
+  have hm_mem : m ∈ S \ T ∪ T \ S := Finset.max'_mem _ hD
+  have hmax : ∀ x ∈ S \ T ∪ T \ S, x ≤ m := fun x hx => Finset.le_max' _ x hx
+  rcases Finset.mem_union.mp hm_mem with hmL | hmR
+  · refine key S T hS hT hST m hmL (fun x hx => ?_)
+    rcases lt_or_eq_of_le (hmax x (Finset.mem_union.mpr (Or.inr hx))) with h | h
+    · exact h
+    · exact absurd ((h ▸ hx : m ∈ T \ S)) (fun hmTS =>
+        (Finset.mem_sdiff.mp hmL).2 (Finset.mem_sdiff.mp hmTS).1)
+  · refine key T S hT hS hST.symm m hmR (fun x hx => ?_)
+    rcases lt_or_eq_of_le (hmax x (Finset.mem_union.mpr (Or.inl hx))) with h | h
+    · exact h
+    · exact absurd ((h ▸ hx : m ∈ S \ T)) (fun hmST =>
+        (Finset.mem_sdiff.mp hmR).2 (Finset.mem_sdiff.mp hmST).1)
+
+/-- **Additive richness (dual of `subsetProducts_card_of_prime`).** For a
+superincreasing set `A`, the number of distinct subset sums is exactly `2^{|A|}`
+— every subset gives a different sum.  This exhibits sets attaining the trivial
+upper bound `subsetSums_card_le` on the additive side, so that bound is sharp. -/
+theorem subsetSums_card_of_superincreasing {A : Finset ℤ}
+    (hpos : ∀ a ∈ A, 0 < a)
+    (hsi : ∀ a ∈ A, (A.filter (· < a)).sum id < a) :
+    (subsetSums A).card = 2 ^ A.card := by
+  rw [subsetSums,
+    Finset.card_image_of_injOn (subsetSum_injOn_of_superincreasing hpos hsi),
+    Finset.card_powerset]
+
 end Erdos53

--- a/src/data/proofs/erdos-53/meta.json
+++ b/src/data/proofs/erdos-53/meta.json
@@ -124,9 +124,9 @@
       "Finset"
     ],
     "namespace": "Erdos53",
-    "lineCount": 323,
+    "lineCount": 405,
     "axiomCount": 0,
-    "theoremCount": 24,
+    "theoremCount": 26,
     "definitionCount": 9,
     "path": "Proofs/Erdos53Problem.lean",
     "sorries": 0

--- a/src/data/research/problems/erdos-53-wip-01.json
+++ b/src/data/research/problems/erdos-53-wip-01.json
@@ -23,7 +23,7 @@
     "iteration": 2,
     "focus": "Batch 2 axiom-free lemmas landed (Section 8): k=1 base case (erdosProblem53_exponent_one), distinct-prime richness |subsetProducts A|=2^|A|-1, trivial upper bracket 2^(|A|+1). Theorem count 12->24, 0 axioms, host-verified.",
     "blockers": [],
-    "nextAction": "Optional: small decide computations of |sumsOrProducts A| for tiny explicit A (problem.md item iii). Chang theorem + Erdős–Szemerédi upper bound stay documented (out of Mathlib scope).",
+    "nextAction": "Additive/multiplicative sides now both shown sharp. Optional: an explicit superincreasing witness (e.g. {1,2,4,…}) instantiating subsetSums_card_of_superincreasing; small decide computations of |sumsOrProducts A|. Chang theorem + Erdős–Szemerédi upper bound stay documented (out of Mathlib scope).",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -31,12 +31,14 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: added 12 axiom-free foundational lemmas to the previously definitions-only Erdos53Problem.lean (subset-sum/product membership + inclusions, 2^|A| bound on subset sums, monotonicity, |A|^2 bounds on sumset/productset, subsetSums(empty)={0}). Deep results (Chang 2003, Erdos-Szemeredi upper bound) remain documented-only, needing additive combinatorics beyond Mathlib. Meta synced (theoremCount 0 -> 12).",
+    "progressSummary": "PROGRESS: added the additive-side sharpness dual to Erdos53Problem.lean (theoremCount 24→26, 0 sorry / 0 axiom, host-verified). subsetSum_injOn_of_superincreasing: a superincreasing set (each element exceeds the sum of the strictly smaller ones) has injective subset sums; subsetSums_card_of_superincreasing: hence exactly 2^|A| distinct subset sums, so the trivial bound subsetSums_card_le is SHARP. This is the additive analogue of the existing subsetProducts_card_of_prime (=2^|A|-1). Deep results (Chang 2003, Erdős–Szemerédi upper bound) remain documented-only.",
     "builtItems": [
       "zero_mem_subsetSums, mem_subsetSums_of_mem, mem_subsetProducts_of_mem in Erdos53Problem.lean",
       "subsetSums/Products_subset_sumsOrProducts, subsetSumCount/subsetProductCount_le_card in Erdos53Problem.lean",
       "subsetSums_card_le (<=2^|A|), subsetSums_mono, subsetSums_empty in Erdos53Problem.lean",
-      "sumset_card_le, productset_card_le (<=|A|^2) in Erdos53Problem.lean"
+      "sumset_card_le, productset_card_le (<=|A|^2) in Erdos53Problem.lean",
+      "subsetSum_injOn_of_superincreasing (Erdos53Problem.lean): superincreasing ⇒ injective subset sums, via max-element-of-symmetric-difference argument (2026-07-20)",
+      "subsetSums_card_of_superincreasing: |subsetSums A| = 2^|A| for superincreasing A — additive sharpness, dual of subsetProducts_card_of_prime (2026-07-20)"
     ],
     "insights": [
       "Erdos53Problem.lean was a definitions-only stub (9 defs, 0 theorems). Chang 2003 (conjecture holds) and the Erdos-Szemeredi upper bound need deep additive combinatorics beyond Mathlib; tractable axiom-free content is elementary structural facts about subsetSums/subsetProducts/sumset/productset.",
@@ -65,7 +67,7 @@
     "mathlib": []
   },
   "started": "2026-07-10T00:41:25.781Z",
-  "lastUpdate": "2026-07-20",
+  "lastUpdate": "2026-07-20T23:00:00.000Z",
   "significance": 7,
   "tractability": 6
 }


### PR DESCRIPTION
## Summary

Adds the **additive-side sharpness** result to `proofs/Proofs/Erdos53Problem.lean` (Erdős #53, sums-or-products of subsets). The file already had multiplicative-side sharpness (`subsetProducts_card_of_prime`: a set of distinct primes has exactly `2^{|A|}−1` distinct subset products). This supplies the missing additive dual.

## New theorems (0-axiom, host-verified)

- **`subsetSum_injOn_of_superincreasing`** — if every element of `A` is positive and strictly exceeds the sum of the strictly smaller elements of `A` (the *superincreasing* condition, e.g. `{1,2,4,…,2^{k−1}}`), then distinct subsets have distinct sums (`Set.InjOn` of the subset-sum map on `A.powerset`). Proof: if two subsets had equal sums, take the largest element `m` of their symmetric difference; cancelling the common part gives `(S\T).sum = (T\S).sum`, but `m ≤ (S\T).sum` while every element of the other side is `< m`, so its sum is `≤ (Σ elements < m) < m` by superincreasingness — contradiction.
- **`subsetSums_card_of_superincreasing`** — hence `|subsetSums A| = 2^{|A|}`, exhibiting sets that attain the trivial upper bound `subsetSums_card_le`, so that bound is **sharp** on the additive side.

This mirrors `subsetProd_injOn_of_prime` / `subsetProducts_card_of_prime` exactly, completing the sharpness picture for both operations.

## Verification

`lake env lean Proofs/Erdos53Problem.lean` compiles clean (Mathlib-only imports, host-verified without Docker); 0 sorries; `#print axioms` on both new theorems reports only `[propext, Classical.choice, Quot.sound]`. Gallery meta synced (`leanFile.theoremCount` 24→26, `lineCount` 323→405).

## Scope (honesty)

Elementary sharpness of the trivial bounds. The problem was **resolved by Chang (2003)**; the deep results (Chang's theorem, the Erdős–Szemerédi upper bound) require additive-combinatorics machinery beyond Mathlib and remain documented-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)