### PR TITLE
Fix: restore verified status for cauchy-schwarz Lp-duality entry (#28788)

### DIFF
--- a/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01/meta.json
@@ -2,9 +2,9 @@
   "id": "cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01",
   "title": "Radon-Nikodým Route to Lp Duality",
   "slug": "cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01",
-  "description": "Can Mathlib's Radon-Nikodým machinery (SignedMeasure.rnDeriv) be composed with Lp membership to eliminate the surjectivity axiom? Answer: yes — all steps formalized with 0 sorries. NOTE (2026-06-24, #28788): the file no longer compiles against the pinned v4.26.0 toolchain due to Mathlib API drift (53 errors); repair is tracked separately and the status has been downgraded to formalized until the build is green.",
+  "description": "Can Mathlib's Radon-Nikodým machinery (SignedMeasure.rnDeriv) be composed with Lp membership to eliminate the surjectivity axiom? Answer: yes — all steps formalized with 0 sorries, 0 axioms, machine-checked on Mathlib v4.31.0.",
   "meta": {
-    "status": "formalized",
+    "status": "verified",
     "proofRepoPath": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
     "tags": [
       "functional-analysis",
@@ -17,8 +17,8 @@
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 1094,
-    "buildStatus": "broken",
-    "assumptions": "BUILD BROKEN (2026-06-24, issue #28788): this file does NOT currently compile against the pinned toolchain leanprover/lean4:v4.26.0 — Mathlib API drift produces 53 errors (`Real.HolderTriple.one_lt_of_lt` removed, `Function.sign` removed, `MeasureTheory.Measure.withDensityᵥ_apply` renamed, plus ~dozen unsolved-goals / application-type-mismatch sites). The file was last green ~2026-04 before a Mathlib bump; no automated gate built it, so the drift rotted silently. There are 0 literal `sorry` tactics and 0 `axiom` declarations, but the formalization is not currently machine-checked, so status was downgraded verified→formalized pending repair. Mathematical content (riesz_lp_surjective_from_rn via signedMeasureOfFunctional + holder_extremizer_lq_bound + rn_deriv_memLq_from_trunc + integral_representation) is unchanged; dead-path theorems (truncated_rn_deriv_lq_bound, rn_deriv_memLq) removed 2026-04-23.",
+    "buildStatus": "Verified via `lake env lean Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean` against the pinned Mathlib v4.31.0 toolchain (2026-07-20, single-file elaboration against the prebuilt Mathlib cache): 0 errors — only deprecation and unused-variable lint warnings. 0 sorries, 0 axiom declarations, no native_decide; foundational axioms only. Supersedes the #28788 v4.26 drift downgrade: that 53-error drift was repaired (#29754–#29799) and the file was migrated to v4.31 in the #39062 reconcile flip.",
+    "assumptions": "None. 0 `sorry` tactics, 0 `axiom` declarations, no native_decide; #print axioms reports only the foundational axioms propext / Classical.choice / Quot.sound. The 2026-06 Mathlib v4.26 API drift (issue #28788, 53 errors: `Real.HolderTriple.one_lt_of_lt` removed, `Function.sign` removed, `MeasureTheory.Measure.withDensityᵥ_apply` renamed, plus unsolved-goals / type-mismatch sites) was repaired (#29754–#29799) and the file was subsequently migrated to Mathlib v4.31.0 in the #39062 reconcile flip; it now type-checks clean on the current pinned toolchain (verified 2026-07-20, 0 errors). Mathematical content (riesz_lp_surjective_from_rn via signedMeasureOfFunctional + holder_extremizer_lq_bound + rn_deriv_memLq_from_trunc + integral_representation) is unchanged; dead-path theorems (truncated_rn_deriv_lq_bound, rn_deriv_memLq) removed 2026-04-23.",
     "dateAdded": "2026-04-13",
     "theoremCount": 18,
     "definitionCount": 3
@@ -124,7 +124,7 @@
   ],
   "conclusion": {
     "summary": "The `riesz_lp_surjective` axiom in the parent file is proved using Mathlib's existing infrastructure. The Rudin route via Radon-Nikodým is fully formalized: signed measure construction, RN derivative, Hölder extremizer bound, and Lp.induction extension.",
-    "implications": "This is a complete formalization of the Riesz representation theorem (surjectivity direction) for $L^p$ spaces with $1 < p < \\infty$ in Lean 4, elementary in structure and requiring no beyond-Mathlib infrastructure. NOTE (2026-06-24, #28788): the formalization is not currently machine-checked — the file does not compile against the pinned v4.26.0 toolchain due to Mathlib API drift (53 errors); repair is tracked separately and the status has been downgraded to formalized until the build is green.",
+    "implications": "This is a complete formalization of the Riesz representation theorem (surjectivity direction) for $L^p$ spaces with $1 < p < \\infty$ in Lean 4, elementary in structure and requiring no beyond-Mathlib infrastructure. Machine-checked on the pinned Mathlib v4.31.0 toolchain (0 sorries, 0 axioms).",
     "openQuestions": [
       "Can the proof be generalized to sigma-finite measures without IsFiniteMeasure (would require localizing the argument)?",
       "Does the proof extend to complex-valued Lp spaces (Riesz representation for complex functionals)?"


### PR DESCRIPTION
## Summary

The gallery entry **cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01** ("Radon-Nikodým Route to Lp Duality") carried a stale `status: "formalized"` with a `buildStatus: "broken"` retraction pointing at issue **#28788** (v4.26.0 Mathlib API drift, 53 errors). That drift was in fact repaired (commits `#29754`–`#29799`, ending at "Complete repair … 0 errors") and the file was then migrated to Mathlib v4.31.0 in the `#39062` reconcile flip. The meta was never reconciled → gallery-integrity **understatement** (an entry that compiles green is presented as not-verified).

## Evidence

Host-verified on the current pinned toolchain (`leanprover/lean4:v4.31.0`), no Docker needed (Mathlib-only import):

```
$ lake env lean Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean
... (deprecation + unused-variable lint warnings only)
EXIT=0
```

- 0 errors, 0 sorries (all 10 `sorry` grep hits are in docstrings/comments), 0 `axiom` declarations, no `native_decide`.
- Before the #28788 downgrade (`7502c87492`) this entry was `status: verified, badge: mathlib` — this restores that faithfully (badge unchanged).

## Changes (meta-only, Type A)

- `status`: `formalized` → `verified`
- `buildStatus`: `broken` → descriptive v4.31.0 verification record
- `assumptions`: dropped the "BUILD BROKEN / not machine-checked" retraction; documents the repair + migration and the axiom-free status
- `description` / `implications`: removed the stale `#28788` "does not compile / downgraded" NOTEs

One entry, meta-only, minimal diff.

Closes #28788