### PR TITLE
Enrich cayley-hamilton-oq-04-oq-01: full-file section coverage (3→4)

### DIFF
--- a/src/data/proofs/cayley-hamilton-oq-04-oq-01/meta.json
+++ b/src/data/proofs/cayley-hamilton-oq-04-oq-01/meta.json
@@ -96,24 +96,31 @@
   "sections": [
     {
       "id": "module-doc",
-      "title": "Module Documentation",
+      "title": "Module Documentation & Setup",
       "startLine": 1,
-      "endLine": 50,
-      "summary": "Header stating the explicit 3×3 Cayley–Hamilton identity and the cube reduction, the definition of the middle coefficient c₂ as the sum of the three 2×2 principal minors, the entrywise from-scratch proof strategy, and why it is not a re-export of Mathlib's charpoly Cayley–Hamilton."
+      "endLine": 57,
+      "summary": "Imports (`Matrix.Adjugate`, `NonsingularInverse`, `Trace`, `Tactic`) and the module docstring stating the explicit 3×3 Cayley–Hamilton identity and the cube reduction, the definition of the middle coefficient c₂ as the sum of the three 2×2 principal minors, the entrywise from-scratch proof strategy, and why it is not a re-export of Mathlib's charpoly Cayley–Hamilton. Opens the `CayleyHamiltonOQ04OQ01` namespace, `open Matrix`, and fixes the ambient `variable {R : Type*} [CommRing R]` over which everything is stated."
     },
     {
       "id": "c2",
       "title": "The Middle Characteristic Coefficient c₂",
-      "startLine": 56,
-      "endLine": 64,
-      "summary": "Defines `c2 A` as the sum of the three 2×2 principal minors (a₀₀a₁₁ − a₀₁a₁₀) + (a₀₀a₂₂ − a₀₂a₂₀) + (a₁₁a₂₂ − a₁₂a₂₁), the second elementary symmetric function of the eigenvalues."
+      "startLine": 58,
+      "endLine": 67,
+      "summary": "Defines `c2 A` as the sum of the three 2×2 principal minors (a₀₀a₁₁ − a₀₁a₁₀) + (a₀₀a₂₂ − a₀₂a₂₀) + (a₁₁a₂₂ − a₁₂a₂₁), the second elementary symmetric function of the eigenvalues, i.e. the coefficient of X in the characteristic polynomial X³ − (tr A)X² + c₂X − det A."
     },
     {
       "id": "cayley-hamilton",
       "title": "Explicit 3×3 Cayley–Hamilton",
-      "startLine": 66,
+      "startLine": 68,
+      "endLine": 81,
+      "summary": "`cube_sub_trace_smul_sq_add_c2_smul_sub_det_smul`: every 3×3 matrix satisfies A³ − (tr A)·A² + c₂·A − (det A)·1 = 0, proved by rewriting A³ = A·A·A, `ext i j`, and closing all nine entries with `fin_cases i <;> fin_cases j` followed by `simp [Matrix.mul_apply, Fin.sum_univ_three, …]` and `ring`."
+    },
+    {
+      "id": "cube-reduction",
+      "title": "Cube Reduction: A³ as a Linear Combination of A², A, 1",
+      "startLine": 82,
       "endLine": 90,
-      "summary": "`cube_sub_trace_smul_sq_add_c2_smul_sub_det_smul`: A³ − (tr A)·A² + c₂·A − (det A)·1 = 0 by entrywise `fin_cases`/`ring` over Fin 3. `cube_eq`: the rearrangement A³ = (tr A)·A² − c₂·A + (det A)·1 via `linear_combination`."
+      "summary": "`cube_eq`: the rearrangement A³ = (tr A)·A² − c₂·A + (det A)·1, expressing the cube of any 3×3 matrix as a linear combination of A², A, and the identity, derived from the main identity via `linear_combination (norm := module)`. Closes the namespace."
     }
   ],
   "sorries": 0


### PR DESCRIPTION
Enrichment pass for `cayley-hamilton-oq-04-oq-01`.

**Section coverage fix.** The three `sections` had drifted line ranges leaving parts of the 90-line Lean file uncovered and one section boundary cutting through a definition:
- `module-doc` ended at line 50 (docstring close), omitting the `namespace`/`open Matrix`/`variable [CommRing R]` setup (51–56).
- `c2` was 56–64, but the `c2` definition actually spans 63–66 — the boundary cut the def in half.
- Both theorems (`cube_sub_trace_smul_sq_add_c2_smul_sub_det_smul` and `cube_eq`) were lumped into a single `cayley-hamilton` section.

Now four contiguous sections cover lines 1–90 with no gaps: **Module Documentation & Setup** (1–57), **The Middle Characteristic Coefficient c₂** (58–67), **Explicit 3×3 Cayley–Hamilton** (68–81, main identity), and **Cube Reduction** (82–90, the rearrangement). Summaries expanded to describe the proof tactic and the setup lines now included.

No changes to axiom/status/badge (correctly `verified`/`original`, 0 axioms). Annotations already complete.