### PR TITLE
Research: erdos-510-wip-01 — Chowla cosine-sum minimum is attained (0-axiom)

### DIFF
--- a/proofs/Proofs/Erdos510WIP01.lean
+++ b/proofs/Proofs/Erdos510WIP01.lean
@@ -143,4 +143,29 @@ theorem minCosineSum_singleton {n : ℕ} (hn : 1 ≤ n) : minCosineSum {n} = -1 
   · exact (minCosineSum_le {n} (π / n)).trans_eq hval
   · exact le_ciInf (fun θ => by rw [cosineSum_singleton]; exact Real.neg_one_le_cos _)
 
+/-! ## The infimum is attained -/
+
+/-- **The minimum cosine sum is attained.**  `cosineSum A` is continuous and
+`2π`-periodic, so its infimum over all of `ℝ` equals its minimum over the compact
+interval `[0, 2π]`, and is realised at some concrete angle `θ₀`.  This upgrades
+`minCosineSum` from an `iInf` to an attained minimum — the structural
+prerequisite for locating the extremal angle in the Chowla problem. -/
+theorem exists_eq_minCosineSum (A : Finset ℕ) :
+    ∃ θ₀ : ℝ, cosineSum A θ₀ = minCosineSum A := by
+  have hper : Function.Periodic (cosineSum A) (2 * π) := fun θ => cosineSum_add_two_pi A θ
+  have himg : cosineSum A '' Set.Icc 0 (0 + 2 * π) = Set.range (cosineSum A) :=
+    hper.image_Icc Real.two_pi_pos 0
+  have hne : (Set.Icc (0 : ℝ) (0 + 2 * π)).Nonempty :=
+    ⟨0, Set.left_mem_Icc.mpr (by have := Real.two_pi_pos; linarith)⟩
+  obtain ⟨θ₀, _, hmin⟩ :=
+    isCompact_Icc.exists_isMinOn hne (continuous_cosineSum A).continuousOn
+  refine ⟨θ₀, le_antisymm ?_ (minCosineSum_le A θ₀)⟩
+  -- `cosineSum A θ₀` is a lower bound of the whole range, hence `≤` the infimum
+  refine le_ciInf (fun θ => ?_)
+  have hmem : cosineSum A θ ∈ Set.range (cosineSum A) := ⟨θ, rfl⟩
+  rw [← himg] at hmem
+  obtain ⟨y, hy, hyeq⟩ := hmem
+  rw [← hyeq]
+  exact isMinOn_iff.mp hmin y hy
+
 end Erdos510WIP01

--- a/src/data/research/problems/erdos-510-wip-01.json
+++ b/src/data/research/problems/erdos-510-wip-01.json
@@ -25,7 +25,7 @@
     "goal": "Formalize the tractable structural facts about cosineSum / minCosineSum from Mathlib; keep the deep −c√N bound cleanly isolated as the open target."
   },
   "currentState": {
-    "phase": "ORIENT",
+    "phase": "ACT",
     "since": "2026-07-20T12:00:00-07:00",
     "iteration": 1,
     "focus": "Axiom-free foundational lemmas on the cosine sum and its infimum.",
@@ -36,7 +36,7 @@
         "blockedAt": "2026-07-20"
       }
     ],
-    "nextAction": "Prove that minCosineSum is attained (continuity + 2π-periodicity ⟹ inf over ℝ equals min over [0,2π]); then the average-zero fact ⨍ cosineSum A = 0 for A ⊂ ℕ⁺ giving minCosineSum A ≤ 0.",
+    "nextAction": "The average-zero fact ⨍ cosineSum A = 0 for A ⊂ ℕ⁺ (∫₀^{2π} cos(nθ)dθ = 0) giving minCosineSum A ≤ 0; then work toward the deep −c√N lower bound (the open target).",
     "attemptCounts": {
       "total": 1,
       "currentApproach": 1,
@@ -44,7 +44,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Created Proofs/Erdos510WIP01.lean (16 theorems, 0 sorry / 0 axiom, VERIFIED axiom-free [propext, Classical.choice, Quot.sound]). Established the elementary structure of the Chowla cosine sum: evaluation lemmas (empty/singleton/insert, θ=0 giving N, θ=π giving ∑(−1)ⁿ), evenness and 2π-periodicity, continuity, the trivial two-sided bound |cosineSum A θ| ≤ N, bounded-below range, the basic minCosineSum bounds −N ≤ minCosineSum A ≤ N, and the exact value minCosineSum {n} = −1 for n ≥ 1. The deep −c√N conjecture is untouched (it is the open target).",
+    "progressSummary": "PROGRESS: Erdos510WIP01.lean now proves the Chowla cosine-sum minimum is ATTAINED (exists_eq_minCosineSum: ∃ θ₀, cosineSum A θ₀ = minCosineSum A), upgrading minCosineSum from an iInf to an attained minimum. Via 2π-periodicity (Function.Periodic.image_Icc) the range equals the image of the compact [0,2π], where continuity gives a minimizer (IsCompact.exists_isMinOn). 18 theorems, 0 sorry / 0 axiom, VERIFIED axiom-free [propext, Classical.choice, Quot.sound], host-verified no-Docker. The deep −c√N conjecture remains the open target.",
     "builtItems": [
       "cosineSum_empty / cosineSum_singleton / cosineSum_insert in Erdos510WIP01.lean",
       "cosineSum_zero_angle (cosineSum A 0 = N), cosineSum_pi (= ∑(−1)ⁿ)",
@@ -52,7 +52,8 @@
       "continuous_cosineSum",
       "abs_cosineSum_le_card, cosineSum_le_card, neg_card_le_cosineSum",
       "bddBelow_range_cosineSum, minCosineSum_le, neg_card_le_minCosineSum, minCosineSum_le_card, minCosineSum_empty",
-      "minCosineSum_singleton (= −1 for n ≥ 1)"
+      "minCosineSum_singleton (= −1 for n ≥ 1)",
+      "exists_eq_minCosineSum (Erdos510WIP01.lean): the infimum minCosineSum A is attained at a concrete angle, via periodicity + compactness of [0,2π] (2026-07-20)"
     ],
     "insights": [
       "The trivial range of the cosine sum is [−N, N]; the conjectured extremal value −c√N sits strictly inside, so all elementary bounds are far from the truth — the content is entirely in the cancellation.",
@@ -91,7 +92,7 @@
     "mathlib": []
   },
   "started": "2026-07-20T12:00:00.000Z",
-  "lastUpdate": "2026-07-20T12:00:00.000Z",
+  "lastUpdate": "2026-07-20T23:10:00.000Z",
   "significance": 6,
   "tractability": 5
 }


### PR DESCRIPTION
## Summary

Adds the **attainment** theorem to `proofs/Proofs/Erdos510WIP01.lean` (Erdős #510, Chowla's cosine-sum problem). `minCosineSum A` was defined as `iInf (cosineSum A)` over all of `ℝ`; this proves the infimum is actually a **minimum**, realised at a concrete angle.

## New theorem (0-axiom, host-verified)

- **`exists_eq_minCosineSum`** `: ∃ θ₀, cosineSum A θ₀ = minCosineSum A`. Since `cosineSum A` is continuous (`continuous_cosineSum`) and `2π`-periodic (`cosineSum_add_two_pi`), `Function.Periodic.image_Icc` identifies its range with its image on the compact interval `[0, 2π]`, where `IsCompact.exists_isMinOn` supplies a minimizer; that value is then a lower bound of the whole range (`le_ciInf`), hence equals the infimum.

This upgrades `minCosineSum` from an abstract `iInf` to an attained minimum — the structural prerequisite for locating the extremal angle, which the eventual Chowla `−c√N` lower bound analysis needs.

## Verification

`lake env lean Proofs/Erdos510WIP01.lean` compiles clean (host-verified without Docker; parent `Erdos510Problem` is Mathlib-only, fresh-built olean); 0 sorries; `#print axioms exists_eq_minCosineSum` reports only `[propext, Classical.choice, Quot.sound]`.

## Scope (honesty)

Elementary structural fact. The deep content — the Chowla conjecture that `minCosineSum A ≤ -c√{|A|}` for some absolute `c > 0` — remains **open** and untouched. The natural next step (the average-zero fact `⨍ cosineSum A = 0 ⟹ minCosineSum A ≤ 0`) needs the interval-integral `∫₀^{2π} cos(nθ) dθ = 0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)