### PR TITLE
Research: erdos-326-wip-01 — bounded-order additive bases are infinite (0-axiom)

### DIFF
--- a/proofs/Proofs/Erdos326WIP01.lean
+++ b/proofs/Proofs/Erdos326WIP01.lean
@@ -144,4 +144,28 @@ theorem hasNoGrowthLimit_iff (b : ℕ → ℕ) :
   unfold HasNoGrowthLimit
   rw [not_exists]
 
+/-! ## Bounded-order bases are infinite -/
+
+/-- **A basis of bounded order is infinite.**  Unlike `IsAddBasis` (which allows
+arbitrarily many summands — so e.g. the singleton `{1}` qualifies, representing
+`n` as `1 + ⋯ + 1`), a basis of a *fixed* order `k` must be infinite: a finite
+set `A` is bounded by some `M`, so every sum of at most `k` of its elements is
+`≤ k · M`, and finitely many such values cannot cover all sufficiently large `n`. -/
+theorem IsAddBasisOfOrder.infinite {A : Set ℕ} {k : ℕ}
+    (h : IsAddBasisOfOrder A k) : A.Infinite := by
+  by_contra hfin
+  rw [Set.not_infinite] at hfin
+  obtain ⟨N, hN⟩ := h
+  obtain ⟨M, hM⟩ := hfin.bddAbove
+  -- the target `n` is chosen `≥ N` and strictly above the reachable ceiling `k · M`
+  obtain ⟨m, hmk, f, hf, hsum⟩ := hN (max N (k * M + 1)) (le_max_left _ _)
+  have hbound : ∑ i, f i ≤ k * M :=
+    calc ∑ i, f i ≤ ∑ _i : Fin m, M := Finset.sum_le_sum (fun i _ => hM (hf i))
+      _ = m * M := by
+          rw [Finset.sum_const, Finset.card_univ, Fintype.card_fin, smul_eq_mul]
+      _ ≤ k * M := by gcongr
+  rw [hsum] at hbound
+  have hge : k * M + 1 ≤ max N (k * M + 1) := le_max_right _ _
+  omega
+
 end Erdos326

--- a/src/data/research/problems/erdos-326-wip-01.json
+++ b/src/data/research/problems/erdos-326-wip-01.json
@@ -25,7 +25,7 @@
     "goal": "Formalize the elementary order theory of the basis predicates and the basic growth-ratio/limit facts from Mathlib; keep the deep oscillation content cleanly isolated as the open target."
   },
   "currentState": {
-    "phase": "ORIENT",
+    "phase": "ACT",
     "since": "2026-07-20T13:00:00-07:00",
     "iteration": 2,
     "focus": "Axiom-free foundational lemmas on IsAddBasis / IsAddBasisOfOrder / growthRatio.",
@@ -36,7 +36,7 @@
         "blockedAt": "2026-07-20"
       }
     ],
-    "nextAction": "Formalize the standard bₖ = O(k²) upper bound for order-2 bases (density ≥ c√n ⟹ k-th element ≤ Ck²); and the perfect squares as a concrete order-4 basis via Lagrange four-square (Mathlib: Nat.sum_four_squares).",
+    "nextAction": "Formalize the standard bₖ = O(k²) upper bound for order-2 bases (density ≥ c√n ⟹ k-th element ≤ Ck²); triangular numbers as an order-3 basis if Gauss Eureka is in Mathlib. Deep oscillation content stays open.",
     "attemptCounts": {
       "total": 1,
       "currentApproach": 1,
@@ -44,7 +44,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Erdos326WIP01.lean — session 2 added the perfect squares as a concrete additive basis of ORDER 4 (Squares, isAddBasisOfOrder_squares_four via Lagrange Nat.sum_four_squares, isAddBasis_squares). First non-vacuous instance of IsAddBasisOfOrder, complementing the existing monotonicity/extremal-case order theory. 14 theorems + 1 def, 0 sorry / 0 axiom, #print axioms clean [propext, Classical.choice, Quot.sound]. Deep oscillation/growth content (the open order-2 sub-basis question) untouched.",
+    "progressSummary": "PROGRESS: Erdos326WIP01.lean — proved IsAddBasisOfOrder.infinite: a basis of FIXED order k must be infinite (a finite set is bounded by M, so sums of ≤ k elements are ≤ k·M and cannot cover all large n). This distinguishes bounded-order bases from IsAddBasis, which permits arbitrarily many summands so e.g. {1} qualifies. 15 theorems + 1 def, 0 sorry / 0 axiom, VERIFIED axiom-free [propext, Classical.choice, Quot.sound], host-verified no-Docker. Deep growth content (bₖ=O(k²) upper bound, order-2 sub-basis question) untouched.",
     "builtItems": [
       "IsAddBasisOfOrder.mono_order / .mono_set in Erdos326WIP01.lean",
       "IsAddBasis.mono",
@@ -52,7 +52,8 @@
       "not_isAddBasis_empty, not_isAddBasisOfOrder_zero",
       "growthRatio_nonneg, growthRatio_zero",
       "HasGrowthLimit.unique, HasGrowthLimit.not_hasNoGrowthLimit, hasNoGrowthLimit_iff",
-      "Squares (the set {m^2}), isAddBasisOfOrder_squares_four, isAddBasis_squares in Erdos326WIP01.lean (session 2, axiom-free [propext, Classical.choice, Quot.sound])"
+      "Squares (the set {m^2}), isAddBasisOfOrder_squares_four, isAddBasis_squares in Erdos326WIP01.lean (session 2, axiom-free [propext, Classical.choice, Quot.sound])",
+      "IsAddBasisOfOrder.infinite (Erdos326WIP01.lean): a bounded-order additive basis is infinite, via Set.Finite.bddAbove + sum ≤ k·M ceiling (2026-07-20)"
     ],
     "insights": [
       "The basis predicates form a monotone lattice: raising the order or enlarging the set preserves the basis property — the atomic order theory underlying any basis-comparison argument.",
@@ -90,7 +91,7 @@
     "mathlib": []
   },
   "started": "2026-07-20T13:00:00.000Z",
-  "lastUpdate": "2026-07-20T13:00:00.000Z",
+  "lastUpdate": "2026-07-20T23:20:00.000Z",
   "significance": 6,
   "tractability": 5
 }


### PR DESCRIPTION
## Summary

Adds a structural theorem to `proofs/Proofs/Erdos326WIP01.lean` (Erdős #326, additive bases / minimal-growth question): a basis of a **fixed order `k`** must be infinite.

## New theorem (0-axiom, host-verified)

- **`IsAddBasisOfOrder.infinite`** `: IsAddBasisOfOrder A k → A.Infinite`. Unlike `IsAddBasis` (which allows arbitrarily many summands — so the singleton `{1}` qualifies, writing `n = 1 + ⋯ + 1`), a fixed-order-`k` basis cannot be finite: a finite `A` is bounded above by some `M` (`Set.Finite.bddAbove`), so every sum of at most `k` of its elements is `≤ k · M`, and these finitely many values cannot cover all sufficiently large `n`. Proof takes the target `n := max N (k·M + 1)`, which is `≥ N` (so representable) yet `> k·M` (so unrepresentable) — contradiction.

This sharpens the file's order theory (which had `not_isAddBasisOfOrder_zero`, the order-monotonicity lemmas, and the perfect-squares order-4 instance) by pinning the qualitative gap between bounded-order and unbounded-order bases.

## Verification

`lake env lean Proofs/Erdos326WIP01.lean` compiles clean (host-verified without Docker; parent `Erdos326Problem` fresh-built olean); 0 sorries; `#print axioms IsAddBasisOfOrder.infinite` reports only `[propext, Classical.choice, Quot.sound]`.

## Scope (honesty)

Elementary structural fact. The deep content — the `bₖ = O(k²)` growth bound for order-2 bases and the open minimal-growth / oscillation questions of Erdős #326 — remains untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)