### PR TITLE
Enrich e-transcendental-oq-02: full-file section coverage (10→20) + fix stale lineCount

### DIFF
--- a/src/data/proofs/e-transcendental-oq-02/meta.json
+++ b/src/data/proofs/e-transcendental-oq-02/meta.json
@@ -84,7 +84,7 @@
     ],
     "dateAdded": "2026-05-04",
     "axiomCount": 1,
-    "lineCount": 2160,
+    "lineCount": 2302,
     "assumptions": "1 axiom (the main open conjecture): e_absolutely_normal — e is absolutely normal (open as of 2026). Session 13 discharged the normal_imp_irrational axiom: composing rational_has_missing_ktuple_intCast (the ℤ-valued lift of S12's Layer 4a missing-tuple), rational_match_count_le (the matching-position count is bounded by N₀ via Finset.card_le_card), and tendsto_bounded_count_div_atTop_zero (squeeze: 0 ≤ count_N/N ≤ N₀/N → 0). For rational q, normality forces frequency → b^(-k) > 0, but the bound forces it → 0; tendsto_nhds_unique closes the contradiction. Earlier history: rational-digits-periodic was discharged in Session 11 via the 3-layer recipe (Layer 1 eventually_periodic_iterate S8, Layer 2 ratResidue_eventually_periodic S9, Layer 3 floor_pow_mul_div S10 + nthDigit_succ_via_residue S11), then Session 12 added Layer 4a (Fin b cast bridge) and rational_has_missing_ktuple. 33 public theorems including first 9 decimal digits of e proved from exp_one bounds and now normal_imp_irrational fully axiom-free.",
     "mathlib_version": "4.31.0",
     "definitionCount": 7
@@ -108,7 +108,7 @@
       "Number theory (rational approximation)",
       "Digit expansions and continued fractions"
     ],
-    "lineCount": 2160,
+    "lineCount": 2302,
     "theoremCount": 92
   },
   "sections": [
@@ -116,78 +116,161 @@
       "id": "header",
       "title": "Problem Statement and Context",
       "startLine": 1,
-      "endLine": 55,
+      "endLine": 58,
       "summary": "Overview of normal numbers (Borel 1909), what is known about e's digit distribution, and the open question of e's normality.",
       "mathContext": "**Normal number**: $x$ is normal in base $b$ if for every $k \\geq 1$ and every $s \\in \\{0,\\ldots,b-1\\}^k$: $\\lim_{N \\to \\infty} \\frac{|\\{n < N : (d_n,\\ldots,d_{n+k-1}) = s\\}|}{N} = \\frac{1}{b^k}$. Borel (1909): Lebesgue-a.e. $x$ is absolutely normal."
     },
     {
       "id": "definitions",
-      "title": "Definitions: Normal Numbers",
-      "startLine": 56,
-      "endLine": 77,
+      "title": "Part I — Definitions: Normal Numbers",
+      "startLine": 59,
+      "endLine": 80,
       "summary": "Three definitions: nthDigit (the n-th base-b digit as ⌊bⁿ·x⌋ % b), IsNormalInBase (Tendsto digit frequency condition), IsAbsolutelyNormal (normal in all bases ≥ 2).",
       "mathContext": "`nthDigit b n x = ⌊b^n · x⌋ % b ∈ ℤ`. `IsNormalInBase b x`: for all $k$ and $s : \\text{Fin}\\,k \\to \\text{Fin}\\,b$, frequency of $s$ in base-$b$ expansion tends to $b^{-k}$."
     },
     {
       "id": "known-properties",
-      "title": "Known Properties of e",
-      "startLine": 78,
-      "endLine": 103,
+      "title": "Part II — Known Properties of e",
+      "startLine": 81,
+      "endLine": 106,
       "summary": "e is irrational (from ETranscendental), transcendental (from ETranscendental), lies in (2.718281828, 2.7182818286) from Mathlib bounds, and between 2 and 3.",
       "mathContext": "$e > 2.718281828$ (`exp_one_gt_d9`) and $e < 2.7182818286$ (`exp_one_lt_d9`). These 9-digit Mathlib bounds pin down all 9 decimal digits of e = 2.718281828..."
     },
     {
       "id": "digit-lemmas",
-      "title": "Decimal Digits 1–9 of e",
-      "startLine": 104,
-      "endLine": 200,
+      "title": "Part III — Decimal Digits 1–9 of e",
+      "startLine": 107,
+      "endLine": 203,
       "summary": "Machine-checked proofs that e = 2.718281828...: ⌊10ⁿ·e⌋ computed for n = 1..9, digits 7,1,8,2,8,1,8,2,8 extracted via floor arithmetic. All proved from exp_one_gt_d9 + exp_one_lt_d9 + Int.floor_eq_iff. The 9th digit saturates the Mathlib lower bound 2.718281828.",
       "mathContext": "Pattern: $\\lfloor 10^n \\cdot e \\rfloor$ pinned between $10^n \\cdot 2.718281828$ and $10^n \\cdot 2.7182818286$. For $n=9$: $2718281828 < 10^9 e < 2718281828.6$, so $\\lfloor 10^9 e \\rfloor = 2718281828$ and digit $= 8$."
     },
     {
       "id": "part4-layer1-pigeonhole",
       "title": "Part IV — Layer 1: Orbit Pigeonhole on a Finite Type",
-      "startLine": 201,
-      "endLine": 257,
+      "startLine": 204,
+      "endLine": 259,
       "summary": "Layer 1 of the now machine-checked proof that normality ⇒ irrationality (previously axiomatized, now fully proved). exists_iterate_collision and eventually_periodic_iterate: iterating any function f : α → α on a finite type α from a point eventually cycles, by pigeonhole on the finite orbit.",
       "mathContext": "Pigeonhole foundation: on a finite type α the orbit {x, f x, f² x, …} must repeat, so n ↦ fⁿ x is eventually periodic. This is the combinatorial core behind eventual periodicity of rational base-b digit expansions."
     },
     {
       "id": "part4-layer2-residue",
       "title": "Part IV — Layer 2: Rational Residue Sequence in ZMod q.den",
-      "startLine": 258,
-      "endLine": 324,
+      "startLine": 260,
+      "endLine": 326,
       "summary": "Layer 2: the base-b digit dynamics of a rational q realized as iteration on a finite residue type. ratResidue (private def): the ZMod q.den residue at step n. ratResidue_succ and ratResidue_eq_iterate express it as an iterate of the ×b map; ratResidue_eventually_periodic concludes eventual periodicity via Layer 1's pigeonhole.",
       "mathContext": "For q = p/q.den, the scaled residues live in the finite type ZMod q.den and advance by multiplication by b, so by Layer 1 the residue sequence is eventually periodic — the dynamical reason rational expansions repeat."
     },
     {
       "id": "part4-layer3-floor-bridge",
       "title": "Part IV — Layer 3: Floor/Residue Bridge and Periodicity of Rational Digits",
-      "startLine": 325,
-      "endLine": 483,
+      "startLine": 327,
+      "endLine": 488,
       "summary": "Layer 3 connects the residue dynamics back to actual digits. floor_pow_mul_div, floor_pow_rat_eq_ediv, int_mul_ediv_eq reduce ⌊bⁿ·(p/q)⌋ to integer (Euclidean) division; nthDigit_succ_via_residue and nthDigit_succ_eq_of_emod_eq show the n-th digit is determined by the residue. rational_digits_eventually_periodic (was axiom): a rational's base-b digit sequence is eventually periodic. periodic_has_missing_ktuple: a period-T sequence omits some length-k string once bᵏ > T.",
       "mathContext": "Combining the floor/Euclidean-division identities with Layer 2 yields eventual periodicity (period T ≤ q.den) of rational digit sequences. A T-periodic sequence visits at most T distinct k-tuples, so when bᵏ > T some k-tuple never appears — the seed of the density contradiction."
     },
     {
       "id": "part4-5-layer4a-normal-irrational",
       "title": "Part IV.5 — Layer 4a: Fin b Cast Bridge and the Proof that Normal ⇒ Irrational",
-      "startLine": 484,
-      "endLine": 678,
+      "startLine": 489,
+      "endLine": 728,
       "summary": "Layer 4a and the culminating theorem. nthDigit_nonneg, nthDigit_lt_base, the private def nthDigitFin, and nthDigitFin_intCast / nthDigitFin_eq_iff recast the ℤ-valued nthDigit as a Fin b value. rational_has_missing_ktuple(_intCast): a rational has a length-k string of zero asymptotic density. rational_match_count_le and tendsto_bounded_count_div_atTop_zero show that matching count over N tends to 0. normal_imp_irrational (was axiom): the main theorem — a base-b normal real is irrational.",
       "mathContext": "The contradiction is assembled: if x were rational some k-tuple would have asymptotic density 0, but normality forces every k-tuple to density b⁻ᵏ > 0. Hence normal ⇒ irrational, proved with no axioms (theorem normal_imp_irrational, via tendsto_nhds_unique)."
     },
     {
-      "id": "part5-open-question",
-      "title": "Part V: The Open Question — e is Absolutely Normal (Axiomatized)",
-      "startLine": 679,
-      "endLine": 715,
-      "summary": "The sole axiom and its consequences. axiom e_absolutely_normal: e is absolutely normal (the 2026 open conjecture). e_normal_base_10 and e_normal_binary are immediate consequences; e_normal_implies_uniform_decimal_digits gives each decimal digit 0–9 frequency 1/10 under base-10 normality; e_irrational_necessary_for_normality records that e is irrational (a necessary condition), derived independently from e_irrational.",
-      "mathContext": "Open conjecture (axiomatized): e is normal in every base b ≥ 2; computational evidence over the first 5×10¹³ digits is consistent but no proof exists for any base. Irrationality, a necessary condition, is already proved unconditionally."
+      "id": "part-iv6-nonnormality-criterion",
+      "title": "Part IV.6 — Sharp Boundary: the Non-Normality Criterion",
+      "startLine": 729,
+      "endLine": 820,
+      "summary": "The converse obstruction: an eventually-missing digit-string forbids normality. match_count_le bounds the count of a k-tuple; not_normal_of_eventually_missing_ktuple and not_normal_of_eventually_missing_digit show that if some length-k tuple (or single digit) is eventually absent then x is not normal; normal_imp_irrational_of_criterion re-derives normal ⇒ irrational from this criterion.",
+      "mathContext": "If a base-$b$ string $s$ eventually never occurs, its asymptotic frequency is $0 \\ne b^{-k}$, so $x$ fails normality. This is the sharp boundary of the Part IV argument: normality is exactly the statement that *no* finite string is under- or over-represented."
     },
     {
-      "title": "Part IV.6: Sharp Boundary — the Non-Normality Criterion (missing tuple/digit forbids normality)",
-      "startLine": 729,
-      "endLine": 819
+      "id": "part-iv7-frequency-mismatch",
+      "title": "Part IV.7 — From Absence to Frequency Anomaly",
+      "startLine": 821,
+      "endLine": 946,
+      "summary": "Upgrades 'missing' to 'wrong frequency'. A family of criteria not_normal_of_match_freq_tendsto_ne / _eventually_le / _eventually_ge and their single-digit versions not_normal_of_digit_freq_* rule out normality whenever a tuple's (or digit's) empirical frequency converges to, or is eventually bounded away from, the required b⁻ᵏ.",
+      "mathContext": "Normality demands $\\mathrm{freq}_N(s) \\to b^{-k}$ for every string $s$. Hence any string whose frequency tends to a different limit, or stays eventually $\\le b^{-k} - \\varepsilon$ or $\\ge b^{-k} + \\varepsilon$, witnesses non-normality — a quantitative strengthening of the missing-string criterion."
+    },
+    {
+      "id": "part-iv8-quantitative-disjunctivity",
+      "title": "Part IV.8 — Quantitative Disjunctivity",
+      "startLine": 947,
+      "endLine": 1050,
+      "summary": "From 'infinitely often' to 'positive density'. exists_match_lt_of_count_pos, eventually_match_count_pos_of_normal, and eventually_exists_match_lt_of_normal show a normal number contains every finite string not just infinitely often but with the first occurrence appearing early; match_count_ge_linear_of_normal gives the count of each k-tuple growing linearly (≈ N·b⁻ᵏ).",
+      "mathContext": "For a normal $x$ the match count of any string $s$ satisfies $\\mathrm{count}_N(s) \\ge cN$ eventually — a linear lower bound. This quantitative disjunctivity turns the qualitative 'every string occurs' into an effective occurrence rate."
+    },
+    {
+      "id": "part-iv9-effective-modulus",
+      "title": "Part IV.9 — Effective Normality with an Explicit Modulus",
+      "startLine": 1051,
+      "endLine": 1266,
+      "summary": "An effective refinement. The definition EffectivelyNormalWithModulus packages normality with a convergence modulus; isNormal_of_effectivelyNormal shows it implies normality, and first_occurrence_lt_of_modulus, match_count_ge_linear_of_modulus, exists_match_ge_of_count_gt, next_occurrence_lt_of_modulus give explicit first- and next-occurrence bounds for every string in terms of the modulus.",
+      "mathContext": "An *effective* normal number carries a computable modulus $M(k,\\varepsilon)$ with $|\\mathrm{freq}_N(s) - b^{-k}| < \\varepsilon$ for $N \\ge M$. From it one extracts explicit bounds on where any string $s$ first appears and how often it recurs — the constructive content behind the Part IV.8 density statements."
+    },
+    {
+      "id": "part-iv10-conservation-law",
+      "title": "Part IV.10 — The Conservation Law: Frequencies Form a Probability Distribution",
+      "startLine": 1267,
+      "endLine": 1442,
+      "summary": "The k-tuple frequencies sum to 1. matchFreq defines the empirical frequency of a fixed k-tuple; sum_match_count_eq and sum_matchFreq_eq_one prove the counts (resp. frequencies) over all bᵏ tuples add to N (resp. 1); matchFreq_tendsto_of_others and isNormalInBase_of_all_but_one exploit this conservation law to conclude normality once all-but-one tuple frequencies are pinned.",
+      "mathContext": "At each length $k$ the $b^k$ tuple frequencies partition the window: $\\sum_{s} \\mathrm{count}_N(s) = N$, so $\\sum_s \\mathrm{freq}_N(s) = 1$. Consequently if $b^k - 1$ of the tuples converge to $b^{-k}$, the last one is forced to as well — normality can be checked one tuple short."
+    },
+    {
+      "id": "part-iv11-translation-invariance",
+      "title": "Part IV.11 — Normality is Invariant Under Integer Translation",
+      "startLine": 1443,
+      "endLine": 1585,
+      "summary": "Adding an integer preserves normality. nthDigit_add_int shows the digits of x and x + m agree past the integer part; the helper tendsto_div_of_diff_le_one controls counts differing by ≤ 1, giving isNormalInBase_add_int, its iff form isNormalInBase_add_int_iff, and isAbsolutelyNormal_add_int.",
+      "mathContext": "Since $x$ and $x + m$ (for $m \\in \\mathbb{Z}$) have identical fractional parts, their base-$b$ digit sequences differ only in finitely many positions, so digit frequencies — and hence normality in every base — are unchanged: $x$ normal $\\iff x + m$ normal."
+    },
+    {
+      "id": "part-v-open-question",
+      "title": "Part V — The Open Question: e is Absolutely Normal (Axiomatized)",
+      "startLine": 1586,
+      "endLine": 1619,
+      "summary": "The sole axiom and its consequences. axiom e_absolutely_normal: e is absolutely normal (the open conjecture). e_normal_base_10 and e_normal_binary are immediate consequences; e_normal_implies_uniform_decimal_digits gives each decimal digit 0–9 frequency 1/10 under base-10 normality; e_irrational_necessary_for_normality records that e is irrational (a necessary condition), derived independently.",
+      "mathContext": "Open conjecture (axiomatized): $e$ is normal in every base $b \\ge 2$; computational evidence over trillions of digits is consistent but no proof exists for any base. Irrationality, a necessary condition, is already proved unconditionally (Part IV). This is the file's single `axiom`."
+    },
+    {
+      "id": "part-vi-explicit-nonnormal",
+      "title": "Part VI — Sharpness: an Explicit Irrational Non-Normal Number",
+      "startLine": 1620,
+      "endLine": 1789,
+      "summary": "The converse of normal ⇒ irrational fails, with a verified witness: the Liouville constant ∑ b^{−i!}. exists_factorial_window and liouvilleNumber_floor/liouvilleNumber_digit_le_one analyze its digits; liouvilleNumber_irrational proves it irrational and liouvilleNumber_not_normal (for b ≥ 3) proves it non-normal via a missing digit (2 never occurs). exists_irrational_not_normal and irrational_not_imp_normal package the separation irrationality ⊊ normality.",
+      "mathContext": "The base-$b$ Liouville constant $L_b = \\sum_{i \\ge 0} b^{-i!}$ is irrational but, for $b \\ge 3$, omits the digit $2$ entirely — so it is not normal. Hence irrationality is strictly weaker than normality: $\\text{Irrational} \\not\\Rightarrow \\text{Normal}$, sharpening the Part IV implication."
+    },
+    {
+      "id": "part-vii-base2-digit-structure",
+      "title": "Part VII — Base-2 Digit Structure of the Liouville Constant",
+      "startLine": 1790,
+      "endLine": 1881,
+      "summary": "Sets up the harder base-2 case, where the missing-digit obstruction is unavailable (an irrational binary real omits no digit). liouvilleNumber_window_digit and liouvilleNumber_base_two_one_iff characterize exactly which positions of L₂ carry a 1 — the factorial positions — preparing the frequency argument.",
+      "mathContext": "In base $2$ an irrational number uses both digits infinitely often, so non-normality cannot come from a missing digit. The binary Liouville constant has a $1$ exactly at the factorial positions $i!$; the sparse set $\\{i!\\}$ has density $0$, which drives the frequency-based obstruction of Part VIII."
+    },
+    {
+      "id": "part-viii-base2-sharpness",
+      "title": "Part VIII — Base-2 Sharpness: the Liouville Constant is Not Normal in Base 2",
+      "startLine": 1882,
+      "endLine": 2057,
+      "summary": "The first genuine frequency-criterion application. two_pow_le_factorial_succ and liouvilleNumber_two_one_count_le bound the number of 1-digits; tendsto_natLog_two_div_atTop_zero and liouvilleNumber_two_one_density_zero show the 1-digit density is 0 ≠ 1/2; liouvilleNumber_not_normal_base_two concludes non-normality, and exists_irrational_not_normal_of_two_le gives an irrational non-normal number in every base b ≥ 2.",
+      "mathContext": "The count of $1$s among the first $N$ binary digits of $L_2$ is $O(\\log N / \\log\\log N)$ (only factorial positions), so the digit-$1$ frequency $\\to 0 \\ne \\tfrac12$. By the Part IV.7 frequency criterion $L_2$ is not normal — non-normality without any missing digit, valid for every base $b \\ge 2$."
+    },
+    {
+      "id": "part-ix-base2-block-distribution",
+      "title": "Part IX — Base-2 Block Distribution: the All-Zeros k-Tuple",
+      "startLine": 2058,
+      "endLine": 2258,
+      "summary": "Computes a full length-k block frequency (the over-representation counterpart to Part VIII). nthDigit_two_eq_zero_or_one and liouvilleNumber_two_zeros_bad_count_le bound the positions where an all-zeros block fails; liouvilleNumber_two_all_zeros_density_one shows the all-zeros k-tuple has density 1 ≠ 2^{−k}, and liouvilleNumber_all_zeros_not_normal_base_two re-derives non-normality at the block level.",
+      "mathContext": "Because the $1$s of $L_2$ are so sparse, the all-zeros block $0^k$ occurs with density $1$ for every $k$, versus the required $2^{-k}$. This is the over-representation dual of Part VIII's under-represented single digit, giving a second, block-level proof that $L_2$ is not normal."
+    },
+    {
+      "id": "part-x-absolute-corollaries",
+      "title": "Part X — Consequences of Absolute Normality",
+      "startLine": 2259,
+      "endLine": 2302,
+      "summary": "Absolute-level corollaries. absolutely_normal_imp_irrational and absolutely_normal_imp_disjunctive derive irrationality and disjunctivity (every finite string occurs) from absolute normality; e_disjunctive applies this to e (via the e_absolutely_normal axiom), concluding that e's expansion contains every finite digit-string in every base.",
+      "mathContext": "Absolute normality implies both irrationality and *disjunctivity* (being a normal/rich number: every finite string appears in some, hence infinitely many, positions). Applied to $e$ under the axiom, $e$ is disjunctive in every base $b \\ge 2$."
     }
   ],
   "conclusion": {
@@ -219,7 +302,7 @@
       "Filter"
     ],
     "namespace": "ETranscendentalOQ02",
-    "lineCount": 2160,
+    "lineCount": 2302,
     "axiomCount": 1,
     "theoremCount": 92,
     "definitionCount": 7,


### PR DESCRIPTION
## Enrichment pass for `e-transcendental-oq-02` (Is e a normal number?)

### Problem
`ETranscendentalOQ02.lean` grew to **2302 lines**, but the gallery `sections` covered only lines **1–819** (~35%), stopped with a **broken empty-id section**, and left a **716–728 gap**. Worse, the sections were drifted: the old `Part V — Open Question` was pinned at line 679 while the file's `-- PART V` banner is actually at **1586** — the whole normality-sharpness development (Parts IV.6–IX) had been inserted in between and was invisible in the gallery.

### Changes
- **Section coverage 10 → 20**, re-anchored to the file's authoritative `-- PART` / `Layer` banners for contiguous **1..2302** coverage (verified contiguous, no gaps/overlaps).
- Fixed the drifted early ranges (header/definitions/known-properties/digit-lemmas/Layers 1–4a) and the misplaced Part V.
- Added **11 new sections** with accurate `summary`/`mathContext` keyed to the real declarations:
  - **IV.6** non-normality criterion (`not_normal_of_eventually_missing_ktuple/digit`)
  - **IV.7** frequency-anomaly criteria, **IV.8** quantitative disjunctivity, **IV.9** effective normality with a modulus, **IV.10** the conservation law (`sum_matchFreq_eq_one`), **IV.11** translation invariance
  - **VI** the verified Liouville-constant witness (irrational but not normal, missing digit for b≥3), **VII** its base-2 digit structure, **VIII** base-2 non-normality via the frequency criterion, **IX** the all-zeros block density-1 argument
  - **X** absolute-normality corollaries (`absolutely_normal_imp_irrational/disjunctive`, `e_disjunctive`)
- Fixed stale `lineCount` **2160 → 2302** (all three fields).

### Integrity
- `status: axiomatized` / `badge: axiom` / `axiomCount: 1` unchanged and accurate — the sole `axiom e_absolutely_normal` (the open conjecture) is documented in the Part V section; everything else (including the Liouville witness and normal ⇒ irrational) is machine-checked.
- `meta.json` is 37 KB, under the 60 KB cap.
- JSON validated; contiguity verified programmatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)