### PR TITLE
Fix: erdos-759 section summaries overstate Prop-defs as proved/axiomatized

### DIFF
--- a/src/data/proofs/erdos-759/meta.json
+++ b/src/data/proofs/erdos-759/meta.json
@@ -101,7 +101,7 @@
     {
       "id": "cochromatic-number",
       "title": "Cochromatic Number",
-      "summary": "Axiomatizes cochromaticNumber G and proves ζ(G) ≤ χ(G): every chromatic coloring is cochromatic since independent sets are cochromatic-valid.",
+      "summary": "Axiomatizes cochromaticNumber G and chromaticNumber G; states ζ(G) ≤ χ(G) as a property definition (cochromatic_le_chromatic_prop, not an axiom, unused in proofs) — every chromatic coloring is cochromatic since independent sets are cochromatic-valid.",
       "startLine": 59,
       "endLine": 94,
       "mathContext": "$\\zeta(G) = \\min\\{k : V(G) = \\bigcup_{i=1}^k S_i, \\text{ each } S_i \\text{ is a clique or independent set}\\}$. Since independent sets are cochromatic-valid, $\\zeta(G) \\leq \\chi(G)$."
@@ -109,7 +109,7 @@
     {
       "id": "surfaces",
       "title": "Surfaces and Genus",
-      "summary": "Defines OrientableSurface structure with genus, sphere (S_0), torus (S_1), isEmbeddableOn, and axiomatizes Euler's formula V - E + F = 2 - 2n.",
+      "summary": "Defines OrientableSurface structure with genus, sphere (S_0), torus (S_1), and isEmbeddableOn (:= True placeholder); states Euler's formula V - E + F = 2 - 2n as a property definition (euler_formula_genus_prop, not an axiom, unused in proofs).",
       "startLine": 95,
       "endLine": 130,
       "mathContext": "The orientable surface $S_n$ is the connected sum of $n$ tori. Euler's formula $V - E + F = 2 - 2n$ for genus $n$ embeddings implies $|E| \\leq 3|V| + 6(n-1)$, bounding graph density."


### PR DESCRIPTION
## Integrity Issue (reserve-mode re-audit)

**Proof**: erdos-759 (Cochromatic Number on Surfaces)
**Problem**: Two section summaries overstate the status of unused `Prop` definitions, breaking the file's own careful convention.

Top-level counts are all correct and reconcile with the source: 6 axioms, 3 theorems, 0 sorries, badge `axiom`, status `axiomatized`. `originalContributions` all map to real declarations. The issue is confined to `sections[]` prose.

## Evidence

1. **`cochromatic-number` section** claimed it *"proves ζ(G) ≤ χ(G)"*. But `cochromatic_le_chromatic_prop` (Erdos759Problem.lean:97) is an **unproven `Prop` def** whose own docstring says *"not used in proofs below"*. No theorem proves it — overclaims proof strength.

2. **`surfaces` section** claimed it *"axiomatizes Euler's formula V − E + F = 2 − 2n"*. But `euler_formula_genus_prop` (Erdos759Problem.lean:129) is a **`def`, not an `axiom`** — `axiomCount: 6` correctly excludes it.

Every other section in this file writes the accurate form *"states X as a property definition (not an axiom, unused in proofs)"* — these two were the outliers.

## Fix

Reworded both summaries to `states … as a property definition (not an axiom, unused in proofs)`, matching the file's convention. No count/status/badge changes.

---
Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)