### PR TITLE
Research: shannon-channel-coding-awgn-oq-03-oq-01 — capacity concave in total power budget

### DIFF
--- a/proofs/Proofs/ShannonChannelCodingAWGNOQ03OQ01CapacityBudgetConcave.lean
+++ b/proofs/Proofs/ShannonChannelCodingAWGNOQ03OQ01CapacityBudgetConcave.lean
@@ -123,7 +123,8 @@ theorem capacity_midpoint_concave_budget (N : ι → ℝ) (hN : ∀ i, 0 < N i)
     (h3 : waterBudget N μ₃ = (waterBudget N μ₁ + waterBudget N μ₂) / 2) :
     (parallelRate N (waterAlloc μ₁ N) + parallelRate N (waterAlloc μ₂ N)) / 2
       ≤ parallelRate N (waterAlloc μ₃ N) := by
-  have hmain := capacity_concave_budget N hN hμ₃ (a := 1 / 2) (b := 1 / 2)
+  have hmain := capacity_concave_budget N hN hμ₃ (μ₁ := μ₁) (μ₂ := μ₂)
+    (a := 1 / 2) (b := 1 / 2)
     (by norm_num) (by norm_num) (by norm_num) (by rw [h3]; ring)
   linarith [hmain]
 

--- a/proofs/Proofs/ShannonChannelCodingAWGNOQ03OQ01CapacityBudgetConcave.lean
+++ b/proofs/Proofs/ShannonChannelCodingAWGNOQ03OQ01CapacityBudgetConcave.lean
@@ -1,0 +1,130 @@
+/-
+# Shannon AWGN water-filling, oq-03-oq-01 — capacity is CONCAVE in the total power budget
+
+Source: parallel-Gaussian-channel water-filling (see
+`ShannonChannelCodingAWGNOQ03OQ01.lean`, namespace `ShannonWaterFilling`).
+
+The value function of the water-filling convex program,
+
+    C(P) = max { R(x) : xᵢ ≥ 0, ∑ᵢ xᵢ ≤ P },   R(x) = ∑ᵢ ½ log(1 + xᵢ/Nᵢ),
+
+is the parallel-Gaussian channel capacity as a function of the *total* power
+budget `P`.  The companion `…EqualNoise.lean` proves scalar-power concavity only
+in the degenerate **equal-noise** case `C(P) = (n/2)·log(1 + P/(nc))`; the
+`…Concave.lean` / `…StrictConcave.lean` files prove concavity in the power
+**vector** and `…WidebandConcave.lean` proves it in the **bandwidth/channel
+count**.  What no existing file supplies is the classical macroscopic law for a
+*general* noise profile: the optimal capacity `C(P)` is a **concave** function of
+the scalar total power `P` — spending more total power yields *diminishing
+marginal capacity*.  This file fills that gap, all axiom-free / sorry-free.
+
+The proof is the standard "value function of a concave program over a
+budget-scaled convex feasible set is concave" argument, with no envelope theorem
+needed.  Given optimal allocations at water levels `μ₁, μ₂` realising budgets
+`P₁ = g(μ₁)`, `P₂ = g(μ₂)`, the convex combination
+`x = a·waterAlloc μ₁ N + b·waterAlloc μ₂ N` is a feasible allocation for the
+budget `a·P₁ + b·P₂`:
+
+* it is non-negative (`waterAlloc_nonneg`, `mul_nonneg`, `add_nonneg`), and
+* its total power is exactly `a·P₁ + b·P₂ = g(μ₃)`, the budget realised by the
+  combined water level `μ₃`.
+
+Hence by optimality of water-filling at level `μ₃` (`waterfilling_optimal`),
+`R(x) ≤ R(waterAlloc μ₃ N) = C(a·P₁ + b·P₂)`, while joint concavity of `R` in the
+power vector (`parallelRate_concaveOn_power`) gives
+`a·C(P₁) + b·C(P₂) = a·R(waterAlloc μ₁ N) + b·R(waterAlloc μ₂ N) ≤ R(x)`.
+Chaining the two inequalities is the concavity of `C`.
+
+* `capacity_concave_budget` — the general midpoint/convex-combination form:
+  `a·C(P₁) + b·C(P₂) ≤ C(a·P₁ + b·P₂)` (concavity of the value function).
+* `capacity_midpoint_concave_budget` — the `a = b = ½` specialisation making the
+  "diminishing returns in total power" reading explicit.
+
+Tags: information-theory, shannon, awgn, water-filling, capacity, concavity, value-function, convex-program
+-/
+
+import Mathlib
+import Proofs.ShannonChannelCodingAWGNOQ03OQ01Concave
+
+set_option linter.unusedSectionVars false
+
+namespace ShannonWaterFilling
+
+open scoped BigOperators
+
+variable {ι : Type*} [Fintype ι]
+
+/-- **The water-filling capacity is concave in the total power budget.**
+Let `μ₁, μ₂` be water levels realising budgets `P₁ = g(μ₁)`, `P₂ = g(μ₂)`, and let
+`μ₃` (with `μ₃ > 0`) realise the convexly-combined budget
+`g(μ₃) = a·P₁ + b·P₂` for weights `a, b ≥ 0`, `a + b = 1`.  Then the optimal
+capacities satisfy
+
+    a · C(P₁) + b · C(P₂) ≤ C(a·P₁ + b·P₂),
+
+where `C(g(μ)) = parallelRate N (waterAlloc μ N)` is the water-filling rate.  This
+is the concavity of the capacity–power value function for a *general* noise
+profile `N` — the macroscopic "capacity is a concave function of total power",
+i.e. diminishing marginal returns as the total power budget grows.
+
+Proof: the convex combination `x = a·waterAlloc μ₁ N + b·waterAlloc μ₂ N` is a
+feasible allocation for the budget `g(μ₃)` (non-negative, total power `a·P₁+b·P₂`).
+Optimality of water-filling at level `μ₃` (`waterfilling_optimal`) bounds
+`R(x) ≤ R(waterAlloc μ₃ N)`, and joint concavity of `R` in the power vector
+(`parallelRate_concaveOn_power`) bounds `a·R(waterAlloc μ₁ N)+b·R(waterAlloc μ₂ N)
+≤ R(x)`; chaining gives the claim. -/
+theorem capacity_concave_budget (N : ι → ℝ) (hN : ∀ i, 0 < N i)
+    {μ₁ μ₂ μ₃ : ℝ} (hμ₃ : 0 < μ₃) {a b : ℝ}
+    (ha : 0 ≤ a) (hb : 0 ≤ b) (hab : a + b = 1)
+    (h3 : waterBudget N μ₃ = a * waterBudget N μ₁ + b * waterBudget N μ₂) :
+    a * parallelRate N (waterAlloc μ₁ N) + b * parallelRate N (waterAlloc μ₂ N)
+      ≤ parallelRate N (waterAlloc μ₃ N) := by
+  -- the convex-combination allocation
+  set x : ι → ℝ := a • waterAlloc μ₁ N + b • waterAlloc μ₂ N with hx_def
+  -- `x` is a non-negative allocation
+  have hxnonneg : ∀ i, 0 ≤ x i := by
+    intro i
+    have h := add_nonneg (mul_nonneg ha (waterAlloc_nonneg μ₁ N i))
+      (mul_nonneg hb (waterAlloc_nonneg μ₂ N i))
+    simpa [hx_def, Pi.add_apply, Pi.smul_apply, smul_eq_mul] using h
+  -- its total power equals the combined budget `g(μ₃)`
+  have hxsum : ∑ i, x i ≤ waterBudget N μ₃ := by
+    have hsumeq : ∑ i, x i = a * waterBudget N μ₁ + b * waterBudget N μ₂ := by
+      simp only [hx_def, waterBudget, Pi.add_apply, Pi.smul_apply, smul_eq_mul,
+        Finset.sum_add_distrib, Finset.mul_sum]
+    rw [hsumeq, ← h3]
+  -- membership of the two optimal allocations in the non-negative orthant
+  have hmem : ∀ μ : ℝ,
+      waterAlloc μ N ∈ Set.univ.pi fun _ : ι => Set.Ici (0 : ℝ) := by
+    intro μ
+    rw [Set.mem_univ_pi]
+    intro i
+    exact Set.mem_Ici.mpr (waterAlloc_nonneg μ N i)
+  -- concavity of `R` in the power vector applied to the two optima
+  have hconc := (parallelRate_concaveOn_power N hN).2 (hmem μ₁) (hmem μ₂) ha hb hab
+  simp only [smul_eq_mul] at hconc
+  rw [← hx_def] at hconc
+  -- optimality of water-filling at level `μ₃`
+  have hopt := waterfilling_optimal N hN hμ₃ (rfl : waterBudget N μ₃ = waterBudget N μ₃)
+    x hxnonneg hxsum
+  linarith [hconc, hopt]
+
+/-- **Diminishing returns in total power (midpoint form).**  The `a = b = ½`
+specialisation of `capacity_concave_budget`: if `μ₃` (with `μ₃ > 0`) realises the
+average budget `g(μ₃) = (g(μ₁) + g(μ₂))/2`, then
+
+    (C(P₁) + C(P₂)) / 2 ≤ C((P₁ + P₂)/2).
+
+The average of the capacities at two budgets never exceeds the capacity at their
+average budget — the concave "diminishing marginal capacity" law for a general
+noise profile. -/
+theorem capacity_midpoint_concave_budget (N : ι → ℝ) (hN : ∀ i, 0 < N i)
+    {μ₁ μ₂ μ₃ : ℝ} (hμ₃ : 0 < μ₃)
+    (h3 : waterBudget N μ₃ = (waterBudget N μ₁ + waterBudget N μ₂) / 2) :
+    (parallelRate N (waterAlloc μ₁ N) + parallelRate N (waterAlloc μ₂ N)) / 2
+      ≤ parallelRate N (waterAlloc μ₃ N) := by
+  have hmain := capacity_concave_budget N hN hμ₃ (a := 1 / 2) (b := 1 / 2)
+    (by norm_num) (by norm_num) (by norm_num) (by rw [h3]; ring)
+  linarith [hmain]
+
+end ShannonWaterFilling

--- a/research/problems/shannon-channel-coding-awgn-oq-03-oq-01/knowledge.md
+++ b/research/problems/shannon-channel-coding-awgn-oq-03-oq-01/knowledge.md
@@ -1,3 +1,39 @@
+## Session 2026-07-20 (researcher-1) — capacity CONCAVE in the scalar total power budget
+
+New file `ShannonChannelCodingAWGNOQ03OQ01CapacityBudgetConcave.lean` (namespace
+`ShannonWaterFilling`, imports `...Concave`). VERIFIED clean Docker build (v4.31.0);
+both theorems depend only on `[propext, Classical.choice, Quot.sound]` (0 axioms / 0 sorries,
+confirmed by `#print axioms`).
+
+Fills the last easy gap in the concavity story. Prior files gave concavity in the power
+VECTOR (`parallelRate_concaveOn_power`, `parallelRate_strictConcaveOn_power`), in the
+BANDWIDTH/channel-count (`wideRate_strictConcaveOn`), and scalar-power concavity ONLY in the
+degenerate equal-noise case (`EqualNoise.lean`). Missing was the general-profile macroscopic
+law: the water-filling value function `C(P) = max{R(x) : x≥0, ∑xᵢ≤P}` is CONCAVE in the
+scalar total power `P` — diminishing marginal capacity as the budget grows.
+
+- `capacity_concave_budget` — `a·C(P₁) + b·C(P₂) ≤ C(a·P₁+b·P₂)`, parametrised by three water
+  levels μ₁,μ₂,μ₃ with `g(μ₃)=a·g(μ₁)+b·g(μ₂)` (matches the file's existing water-level
+  parametrisation convention, e.g. `capacity_mono_budget`). Proof: the convex combination
+  `x = a•waterAlloc μ₁ N + b•waterAlloc μ₂ N` is feasible for budget `g(μ₃)` (nonneg;
+  ∑x = a·g(μ₁)+b·g(μ₂) via `Finset.sum_add_distrib`+`Finset.mul_sum`), so `waterfilling_optimal`
+  gives `R(x) ≤ R(waterAlloc μ₃ N)`; `parallelRate_concaveOn_power .2` gives
+  `a·C(P₁)+b·C(P₂) ≤ R(x)`; `linarith` chains. NO envelope theorem needed.
+- `capacity_midpoint_concave_budget` — `a=b=½` corollary: `(C(P₁)+C(P₂))/2 ≤ C((P₁+P₂)/2)`.
+
+### Gotchas
+- Corollary call `capacity_concave_budget N hN hμ₃ (a:=1/2)(b:=1/2) …` left the implicit
+  `{μ₁ μ₂}` unpinned → Lean unified BOTH to μ₃ (hmain collapsed to `½C(μ₃)+½C(μ₃)≤C(μ₃)`),
+  `linarith` failed. Fix: pass `(μ₁ := μ₁) (μ₂ := μ₂)` explicitly.
+- `waterfilling_optimal` needs `0 < μ₃`; taken as an explicit hypothesis (auto-holds whenever
+  the combined budget is positive, via `waterLevel_pos`).
+
+INFRA NOTE: worktree `/Volumes/Stripe/lean-genius/researcher-1` was janitor-reaped mid first
+Docker build (disk 10% — the fresh-no-commit-worktree reap, not disk-full). Recreated via
+`git worktree add <path> <branch>` and committed the .lean file BEFORE rebuilding.
+
+---
+
 ## Session 2026-07-20 (researcher-1) — wideband rate STRICT CONCAVITY in bandwidth (diminishing returns)
 
 New file `ShannonChannelCodingAWGNOQ03OQ01WidebandConcave.lean` (namespace `ShannonWaterFilling`,

--- a/src/data/research/problems/shannon-channel-coding-awgn-oq-03-oq-01.json
+++ b/src/data/research/problems/shannon-channel-coding-awgn-oq-03-oq-01.json
@@ -71,7 +71,8 @@
       "Wideband rate g(t)=(t/2)log(1+a/t) is STRICTLY CONCAVE in the bandwidth/channel-count variable t>0: second derivative g''(t) = -a^2/(2 t (t+a)^2) < 0. Complements the existing strict-monotonicity (rate_equalNoise_count_strictMonoOn); together they pin the wideband capacity curve as strictly increasing + strictly concave + asymptotic to P/(2c) from below. Distinct from the power-concavity in Concave.lean (parallelRate_concaveOn_power).",
       "Lean gotcha: HasDerivAt.div/HasDerivAt.sub emit Pi.div/Pi.sub function forms ((fun _=>a)/(fun s=>s+a)); 'convert ... using 1' then spawns a spurious AddCommGroup instance-equality goal. Fix: annotate intermediate HasDerivAt with the pointwise lambda type (forces defeq) and close by rewriting the target derivative value then 'exact hhalf' instead of convert.",
       "Lean gotcha: field_simp makes NO progress when a denominator is a bare SUM like (1 + a/t) (cannot prove a sum != 0 structurally). Rewrite 1 + a/t = (t+a)/t (add_div + div_self) first so only atomic denominators t, t+a remain.",
-      "parallelRate is jointly STRICTLY concave in the power vector on the nonnegative orthant, not merely weakly concave: distinct allocations differ in some coordinate whose per-channel term is strictly concave, the rest weakly concave, so Finset.sum_lt_sum gives a strict sum inequality. This upgrades water-filling from a global optimum to THE unique global optimum."
+      "parallelRate is jointly STRICTLY concave in the power vector on the nonnegative orthant, not merely weakly concave: distinct allocations differ in some coordinate whose per-channel term is strictly concave, the rest weakly concave, so Finset.sum_lt_sum gives a strict sum inequality. This upgrades water-filling from a global optimum to THE unique global optimum.",
+      "The water-filling capacity value function C(P) is CONCAVE in the scalar total power budget for a general (non-equal) noise profile — proved via feasibility of the convex-combination allocation (waterfilling_optimal) + joint vector concavity (parallelRate_concaveOn_power), no envelope theorem. Previously only the equal-noise special case and vector/bandwidth concavity existed."
     ],
     "builtItems": [
       "waterfilling_optimal (KKT optimality of P_i*=(mu-N_i)_+) in ShannonChannelCodingAWGNOQ03OQ01.lean",
@@ -89,7 +90,8 @@
       "parallelRate_concaveOn_power (…Concave.lean): HEADLINE — total parallel rate ∑ᵢ½log(1+Pᵢ/Nᵢ) JOINTLY concave in the power vector on {P|∀i,0≤Pᵢ}, via ConcaveOn.comp_linearMap (LinearMap.proj i) + ConcaveOn.subset onto the orthant + concaveOn_finset_sum; 0 axioms. The concavity making water-filling a convex program",
       "ShannonChannelCodingAWGNOQ03OQ01Supremum.lean (NEW): rate_equalNoise_seq_le_wideband (sequence-form ceiling (n/2)·log(1+P/(nc))≤P/(2c) for ALL n:ℕ incl n=0) + rate_equalNoise_iSup_eq_wideband (HEADLINE: ⨆ n:ℕ, (n/2)·log(1+P/(nc)) = P/(2c) — the wideband ceiling is the exact LUB of the equal-noise rates, upgrading the tendsto+ceiling pair to an explicit supremum via ciSup_le + le_of_tendsto/le_ciSup). VERIFIED 0-axiom [propext,Classical.choice,Quot.sound], builds green via lake env lean against Mathlib v4.26 oleans.",
       "hasDerivAt_wideRate_deriv, wideRate_strictConcaveOn, rate_equalNoise_count_diminishing in ShannonChannelCodingAWGNOQ03OQ01WidebandConcave.lean (VERIFIED docker, axioms [propext,Classical.choice,Quot.sound])",
-      "parallelRate_strictConcaveOn_power + parallelRate_unique_maximizer in new file ShannonChannelCodingAWGNOQ03OQ01StrictConcave.lean (axiom-free [propext, Classical.choice, Quot.sound]; uses perUseCapacity_strictConcaveOn/concaveOn + Finset.sum_lt_sum + StrictConcaveOn.eq_of_isMaxOn)"
+      "parallelRate_strictConcaveOn_power + parallelRate_unique_maximizer in new file ShannonChannelCodingAWGNOQ03OQ01StrictConcave.lean (axiom-free [propext, Classical.choice, Quot.sound]; uses perUseCapacity_strictConcaveOn/concaveOn + Finset.sum_lt_sum + StrictConcaveOn.eq_of_isMaxOn)",
+      "capacity_concave_budget + capacity_midpoint_concave_budget in ShannonChannelCodingAWGNOQ03OQ01CapacityBudgetConcave.lean (0 axioms, 0 sorries; #print axioms = [propext, Classical.choice, Quot.sound])"
     ],
     "mathlibGaps": [],
     "nextSteps": [
@@ -98,7 +100,7 @@
       "Extend the finite water-filling optimum to a genuine continuous infinite-band (integral over frequency) capacity, beyond the equal-noise wideband scalar limit.",
       "Optional: joint STRICT concavity of parallelRate in the power vector (distinct vectors differ in some coordinate i₀ whose term is strictly concave, others weakly ⇒ strict overall via Finset.sum_lt_sum). Would pin the water-filling optimum as the UNIQUE global maximizer."
     ],
-    "progressSummary": "PROGRESS (2026-07-20, researcher-1, VERIFIED 0-axiom): proved the water-filling optimum is UNIQUE. New file ShannonChannelCodingAWGNOQ03OQ01StrictConcave.lean: parallelRate_strictConcaveOn_power (strict joint concavity of the total rate in the power vector, sharpening the existing weak parallelRate_concaveOn_power via one-strict-rest-weak Finset.sum_lt_sum) and parallelRate_unique_maximizer (StrictConcaveOn.eq_of_isMaxOn ⟹ at most one maximizer over the convex orthant). Pins the KKT/water-filling allocation as THE global optimum. All [propext,Classical.choice,Quot.sound]."
+    "progressSummary": "PROGRESS (2026-07-20, researcher-1, VERIFIED 0-axiom Docker): general-noise scalar capacity-power concavity C(P) via value-function argument (capacity_concave_budget), the classical diminishing-returns-in-total-power law absent from the equal-noise/vector/bandwidth concavity files."
   },
   "currentState": {
     "iteration": 2


### PR DESCRIPTION
## Summary
Research session for `shannon-channel-coding-awgn-oq-03-oq-01` (parallel-Gaussian water-filling, namespace `ShannonWaterFilling`). Adds the general-noise **capacity–power concavity** law, verified 0-axiom.

## Progress
New file `proofs/Proofs/ShannonChannelCodingAWGNOQ03OQ01CapacityBudgetConcave.lean` — clean Docker build (v4.31.0), `#print axioms` = `[propext, Classical.choice, Quot.sound]` (0 axioms, 0 sorries):

- **`capacity_concave_budget`** — `a·C(P₁) + b·C(P₂) ≤ C(a·P₁ + b·P₂)`. The water-filling value function `C(P) = max{R(x) : xᵢ ≥ 0, ∑ᵢ xᵢ ≤ P}` is concave in the **scalar total power budget** for a **general** noise profile.
- **`capacity_midpoint_concave_budget`** — the `a = b = ½` diminishing-returns specialisation, `(C(P₁)+C(P₂))/2 ≤ C((P₁+P₂)/2)`.

## Findings
- This is the classical macroscopic "capacity is a concave function of total power" law. The existing family only had scalar-power concavity in the **equal-noise** special case (`…EqualNoise.lean`), plus concavity in the power **vector** (`…Concave`/`…StrictConcave`) and the **bandwidth/channel-count** (`…WidebandConcave`) — none in the general-profile scalar budget.
- Proof is the value-function argument (no envelope theorem): the convex-combination allocation `a•waterAlloc μ₁ N + b•waterAlloc μ₂ N` is feasible for the combined budget, so `waterfilling_optimal` bounds its rate above by `C(a·P₁+b·P₂)`, while joint vector concavity (`parallelRate_concaveOn_power`) bounds it below by `a·C(P₁)+b·C(P₂)`; `linarith` chains.
- Parametrised by three water levels (`g(μ₃) = a·g(μ₁)+b·g(μ₂)`), matching the file's existing convention (`capacity_mono_budget`, `capacity_strictMono_budget`).

## Status
**Outcome**: progress (structural extension of a verified, completed OQ family)
**Next Steps**: remaining open items are the two deep ones — an operational coding theorem (random Gaussian codebooks, parent oq-04) and a genuine continuous infinite-band integral capacity.

🤖 Generated by researcher-1