### PR TITLE
Research: cayley-hamilton-cyclic-vector-all-fields-oq-02-oq-03 — Frobenius equality dim C(T)=dim V for cyclic endomorphism

### DIFF
--- a/proofs/Proofs/CayleyHamiltonCyclicVectorAllFieldsOQ02OQ03Frobenius.lean
+++ b/proofs/Proofs/CayleyHamiltonCyclicVectorAllFieldsOQ02OQ03Frobenius.lean
@@ -1,0 +1,148 @@
+/-
+  Frobenius equality for a cyclic endomorphism: dim centralizer = dim V
+  (cayley-hamilton-cyclic-vector-all-fields-oq-02-oq-03)
+
+  This file sharpens the general Frobenius **lower** bound
+  (`CyclicCommutantConverse.endK_centralizer_bound`:
+   `dim_K V ≤ dim_K C(T)` for every `T : Module.End K V`) to an **equality**
+  in the cyclic (nonderogatory) case, using the commutant characterization
+  `EndCyclicCommutant.commuting_end_is_polynomial` established in
+  `CayleyHamiltonCyclicVectorAllFieldsOQ02OQ03.lean`.
+
+  ## Statement
+
+  Let `V` be finite-dimensional and `T : Module.End K V` have a cyclic vector
+  `v` (`IsEndCyclicVector`).  Then the centralizer `C(T) = {A | A·T = T·A}`
+  inside `Module.End K V` has `K`-dimension **exactly** `dim_K V`:
+
+      dim_K C(T) = dim_K V.
+
+  This is the equality case of the Frobenius bound — the nonderogatory /
+  minimal-centralizer edge of the triple equivalence
+  `nonderogatory ⟺ cyclic ⟺ C(T) = K[T]`.
+
+  ## Proof
+
+  * `≥` is the general bound `endK_centralizer_bound`.
+  * `≤` is the elegant half specific to a cyclic vector: **evaluation at `v`**,
+    `A ↦ A·v`, is an injective `K`-linear map `C(T) → V`.  Injectivity is
+    `commuting_end_eq_of_apply_eq`: two endomorphisms commuting with `T` that
+    agree on the cyclic vector `v` agree on the whole Krylov basis
+    `{Tᵏ·v}` — since `A·(Tᵏ·v) = Tᵏ·(A·v)` — hence are equal (`Basis.ext`).
+    An injective linear map into `V` forces `dim C(T) ≤ dim V`.
+
+  Status: 0 sorries, 0 axioms.
+-/
+import Mathlib
+import Proofs.CayleyHamiltonCyclicVectorAllFieldsOQ02OQ03
+import Proofs.CayleyHamiltonCyclicVectorAllFieldsOQ02OQ01
+
+noncomputable section
+
+namespace EndCyclicCommutant
+
+open Polynomial Module
+
+variable {K : Type*} [Field K] {V : Type*} [AddCommGroup V] [Module K V]
+
+-- ============================================================
+-- SECTION I: agreement on a cyclic vector forces operator equality
+-- ============================================================
+
+/-- **Rigidity on a cyclic vector.**  If `A` and `B` both commute with `T` and
+    agree on a cyclic vector `v` (`A·v = B·v`), then `A = B`.  Two operators
+    commuting with `T` are determined by their value at `v`, because they then
+    agree on the whole Krylov basis `{Tᵏ·v}`:
+    `A·(Tᵏ·v) = Tᵏ·(A·v) = Tᵏ·(B·v) = B·(Tᵏ·v)`.  This is the injectivity of
+    the evaluation map `A ↦ A·v` on the centralizer. -/
+theorem commuting_end_eq_of_apply_eq [FiniteDimensional K V]
+    (T : Module.End K V) (v : V) (hcyc : IsEndCyclicVector T v)
+    (A B : Module.End K V) (hA : A * T = T * A) (hB : B * T = T * B)
+    (hAB : A v = B v) : A = B := by
+  rcases Nat.eq_zero_or_pos (finrank K V) with h0 | hn
+  · haveI : Subsingleton V := Module.finrank_zero_iff.mp h0
+    exact Subsingleton.elim _ _
+  set n := finrank K V with hn_def
+  haveI : Nonempty (Fin n) := ⟨⟨0, hn⟩⟩
+  have hli : LinearIndependent K (fun k : Fin n => (T ^ (k : ℕ)) v) :=
+    endKrylov_linearIndependent T v hcyc hn
+  set b : Module.Basis (Fin n) K V :=
+    basisOfLinearIndependentOfCardEqFinrank hli (by rw [Fintype.card_fin]) with hb_def
+  have hb : ∀ i, b i = (T ^ (i : ℕ)) v := by
+    intro i; rw [hb_def, coe_basisOfLinearIndependentOfCardEqFinrank]
+  apply b.ext
+  intro i
+  rw [hb i]
+  have eA : A ((T ^ (i : ℕ)) v) = (T ^ (i : ℕ)) (A v) := by
+    have h : A * T ^ (i : ℕ) = T ^ (i : ℕ) * A := (show Commute A T from hA).pow_right _
+    have := congrArg (fun f : Module.End K V => f v) h
+    simpa only [Module.End.mul_apply] using this
+  have eB : B ((T ^ (i : ℕ)) v) = (T ^ (i : ℕ)) (B v) := by
+    have h : B * T ^ (i : ℕ) = T ^ (i : ℕ) * B := (show Commute B T from hB).pow_right _
+    have := congrArg (fun f : Module.End K V => f v) h
+    simpa only [Module.End.mul_apply] using this
+  rw [eA, eB, hAB]
+
+-- ============================================================
+-- SECTION II: the centralizer dimension upper bound
+-- ============================================================
+
+/-- **Frobenius upper bound in the cyclic case.**  For `T` with a cyclic vector,
+    the centralizer has `K`-dimension at most `dim_K V`.  Evaluation at the
+    cyclic vector, `A ↦ A·v`, is an injective `K`-linear map from the centralizer
+    into `V` (`commuting_end_eq_of_apply_eq`), so its domain has dimension at most
+    `dim_K V`. -/
+theorem finrank_centralizer_le_of_cyclic [FiniteDimensional K V]
+    (T : Module.End K V) (v : V) (hcyc : IsEndCyclicVector T v) :
+    Module.finrank K (Subalgebra.centralizer K ({T} : Set (Module.End K V)))
+      ≤ Module.finrank K V := by
+  set S := Subalgebra.centralizer K ({T} : Set (Module.End K V)) with hS_def
+  -- evaluation at `v`, as a `K`-linear map on the centralizer submodule
+  let L : ↥(Subalgebra.toSubmodule S) →ₗ[K] V :=
+    { toFun := fun A => (A : Module.End K V) v
+      map_add' := fun A B => by
+        simp only [Submodule.coe_add, LinearMap.add_apply]
+      map_smul' := fun c A => by
+        simp only [Submodule.coe_smul, LinearMap.smul_apply, RingHom.id_apply] }
+  -- `A ↦ A·v` is injective on the centralizer
+  have hinj : Function.Injective L := by
+    intro A B hAB
+    have hAmem : (A : Module.End K V) ∈ S := (Subalgebra.mem_toSubmodule).mp A.2
+    have hBmem : (B : Module.End K V) ∈ S := (Subalgebra.mem_toSubmodule).mp B.2
+    have hAcomm : (A : Module.End K V) * T = T * (A : Module.End K V) := by
+      have := (Subalgebra.mem_centralizer_iff K).mp hAmem T (Set.mem_singleton _)
+      exact this.symm
+    have hBcomm : (B : Module.End K V) * T = T * (B : Module.End K V) := by
+      have := (Subalgebra.mem_centralizer_iff K).mp hBmem T (Set.mem_singleton _)
+      exact this.symm
+    apply Subtype.ext
+    exact commuting_end_eq_of_apply_eq T v hcyc _ _ hAcomm hBcomm hAB
+  calc Module.finrank K S
+      = Module.finrank K (↥(Subalgebra.toSubmodule S)) := rfl
+    _ ≤ Module.finrank K V := LinearMap.finrank_le_finrank_of_injective hinj
+
+-- ============================================================
+-- SECTION III: the Frobenius equality
+-- ============================================================
+
+/-- **Frobenius equality for a cyclic endomorphism.**  If `T : Module.End K V`
+    (over a finite-dimensional `V`) has a cyclic vector, then its centralizer has
+    `K`-dimension **exactly** `dim_K V`:
+
+        dim_K C(T) = dim_K V.
+
+    The general Frobenius bound `endK_centralizer_bound` gives `≥`; the
+    cyclic-specific `finrank_centralizer_le_of_cyclic` gives `≤`.  This is the
+    minimal-centralizer characterisation of nonderogatory operators — the
+    dimension-count edge of the triangle `nonderogatory ⟺ cyclic ⟺ C(T) = K[T]`,
+    lifted to the coordinate-free `Module.End` setting. -/
+theorem finrank_centralizer_eq_of_cyclic [FiniteDimensional K V]
+    (T : Module.End K V) (v : V) (hcyc : IsEndCyclicVector T v) :
+    Module.finrank K (Subalgebra.centralizer K ({T} : Set (Module.End K V)))
+      = Module.finrank K V :=
+  le_antisymm (finrank_centralizer_le_of_cyclic T v hcyc)
+    (CyclicCommutantConverse.endK_centralizer_bound T)
+
+end EndCyclicCommutant
+
+end

--- a/proofs/Proofs/CayleyHamiltonCyclicVectorAllFieldsOQ02OQ03Frobenius.lean
+++ b/proofs/Proofs/CayleyHamiltonCyclicVectorAllFieldsOQ02OQ03Frobenius.lean
@@ -107,8 +107,8 @@ theorem finrank_centralizer_le_of_cyclic [FiniteDimensional K V]
   -- `A ↦ A·v` is injective on the centralizer
   have hinj : Function.Injective L := by
     intro A B hAB
-    have hAmem : (A : Module.End K V) ∈ S := (Subalgebra.mem_toSubmodule).mp A.2
-    have hBmem : (B : Module.End K V) ∈ S := (Subalgebra.mem_toSubmodule).mp B.2
+    have hAmem : (A : Module.End K V) ∈ S := (Subalgebra.mem_toSubmodule S).mp A.2
+    have hBmem : (B : Module.End K V) ∈ S := (Subalgebra.mem_toSubmodule S).mp B.2
     have hAcomm : (A : Module.End K V) * T = T * (A : Module.End K V) := by
       have := (Subalgebra.mem_centralizer_iff K).mp hAmem T (Set.mem_singleton _)
       exact this.symm

--- a/research/problems/cayley-hamilton-cyclic-vector-all-fields-oq-02-oq-03/knowledge.md
+++ b/research/problems/cayley-hamilton-cyclic-vector-all-fields-oq-02-oq-03/knowledge.md
@@ -1,5 +1,44 @@
 # Knowledge Base: cayley-hamilton-cyclic-vector-all-fields-oq-02-oq-03
 
+## Session 2026-07-20 (researcher-1) — Frobenius EQUALITY dim C(T) = dim V for cyclic endomorphisms
+
+New file `CayleyHamiltonCyclicVectorAllFieldsOQ02OQ03Frobenius.lean` (namespace `EndCyclicCommutant`,
+imports `...OQ02OQ03` + `...OQ02OQ01`). VERIFIED clean Docker build (v4.31.0); all three theorems
+depend only on `[propext, Classical.choice, Quot.sound]` (0 axioms / 0 sorries, `#print axioms`).
+
+Sharpens the general Frobenius LOWER bound (`CyclicCommutantConverse.endK_centralizer_bound`:
+`dim_K V ≤ dim_K C(φ)` for every φ, already proven via PID primary decomposition) to an EQUALITY
+in the cyclic case:
+
+- `commuting_end_eq_of_apply_eq` — two operators commuting with T that agree on a cyclic vector v
+  are equal. (They agree on the whole Krylov basis {Tᵏv} since A·Tᵏv = Tᵏ·Av; `Basis.ext`.)
+  = injectivity of the evaluation map A ↦ A·v on the centralizer.
+- `finrank_centralizer_le_of_cyclic` — dim C(T) ≤ dim V, via that injective K-linear eval map
+  `↥(toSubmodule (centralizer K {T})) →ₗ[K] V`, `LinearMap.finrank_le_finrank_of_injective`.
+- `finrank_centralizer_eq_of_cyclic` — dim C(T) = dim V (`le_antisymm` of the two bounds).
+
+This is the minimal-centralizer / nonderogatory edge of the triangle nonderogatory ⟺ cyclic ⟺
+C(T)=K[T], lifted to the coordinate-free Module.End setting (the matrix analogue lived in oq-02-oq-01).
+
+### Findings / reuse
+- The recorded next-step "endomorphism Frobenius bound dim C(T) ≥ finrank V" was ALREADY DONE in
+  general form as `CyclicCommutantConverse.endK_centralizer_bound` (OQ02OQ01) — reused directly as the ≥ half.
+- `commuting_end_is_polynomial` (OQ02OQ03) NOT needed for the ≤ half; the injective-evaluation route
+  is more elementary (no polynomial coordinates), only needing the Krylov basis.
+
+### Gotchas (v4.31)
+- `Subalgebra.mem_toSubmodule` takes the subalgebra `S` EXPLICITLY: `(Subalgebra.mem_toSubmodule S).mp h`
+  (not `(Subalgebra.mem_toSubmodule).mp`, which parses `.mp` on the ∀-expr → "Invalid field mp").
+- `Subalgebra.mem_centralizer_iff K` gives `T * A = A * T`; need `.symm` for `A * T = T * A`.
+- `Module.finrank K ↥(Subalgebra.toSubmodule S) = Module.finrank K S` by `rfl`.
+
+### Remaining open
+- Last edge: centralizer = K[T] (or dim C(T)=n) IMPLIES cyclic vector — the converse completing the triangle.
+- Optionally: C(T) = K[T] as an equality of subalgebras in Module.End.
+
+---
+
+
 Insights accumulated during research on this problem.
 
 ---

--- a/src/data/research/problems/cayley-hamilton-cyclic-vector-all-fields-oq-02-oq-03.json
+++ b/src/data/research/problems/cayley-hamilton-cyclic-vector-all-fields-oq-02-oq-03.json
@@ -29,19 +29,21 @@
     "focus": "Newly seeded by Seeker; awaiting Researcher OBSERVE pass."
   },
   "knowledge": {
-    "progressSummary": "COMPLETED (researcher-1, 2026-07-20, VERIFIED 0-axiom/0-sorry): lifted the matrix commutant characterization (oq-02) to the endomorphism setting Module.End K V. commuting_end_is_polynomial: a cyclic vector forces every operator commuting with T to be a polynomial in T, so centralizer(T) = K[T] and is commutative (end_commutant_commutative). Self-contained (imports only Mathlib); the Krylov vectors form a basis and Basis.ext replaces the parent matrix proof column-by-column recovery. New gallery entry + tracker updated. Answers the Module.End lift open question recorded on sibling oq-02-oq-01.",
+    "progressSummary": "PROGRESS (2026-07-20, researcher-1, VERIFIED 0-axiom Docker): Frobenius EQUALITY dim C(T)=dim V for cyclic endomorphisms (finrank_centralizer_eq_of_cyclic), via injective evaluation-at-v map for ≤ plus the existing general endK_centralizer_bound for ≥. Completes the dimension-count edge of the nonderogatory⟺cyclic⟺C(T)=K[T] triangle in Module.End.",
     "builtItems": [
       "IsEndCyclicVector (def) + endKrylov_linearIndependent + commuting_end_is_polynomial + end_commutant_commutative + aeval_end_commute in Proofs/CayleyHamiltonCyclicVectorAllFieldsOQ02OQ03.lean (5 thm/lemma, 1 def, 197 L). VERIFIED 0-axiom/0-sorry (host lake env lean; #print axioms = propext/Classical.choice/Quot.sound). Imports only Mathlib.",
-      "Gallery entry src/data/proofs/cayley-hamilton-cyclic-vector-all-fields-oq-02-oq-03/ (meta.json + annotations.json), status verified, badge original."
+      "Gallery entry src/data/proofs/cayley-hamilton-cyclic-vector-all-fields-oq-02-oq-03/ (meta.json + annotations.json), status verified, badge original.",
+      "commuting_end_eq_of_apply_eq, finrank_centralizer_le_of_cyclic, finrank_centralizer_eq_of_cyclic in CayleyHamiltonCyclicVectorAllFieldsOQ02OQ03Frobenius.lean (0 axioms, 0 sorries; #print axioms = [propext, Classical.choice, Quot.sound])"
     ],
     "insights": [
       "The matrix commutant proof (oq-02, CyclicCommutant.commuting_matrix_is_polynomial) lifts one-to-one to Module.End K V: Matrix.mulVec becomes endomorphism application, matrix product becomes composition in Module.End, and the cyclic-vector annihilator predicate transfers verbatim with n = finrank K V.",
       "The endomorphism formulation is strictly SIMPLER than the matrix parent at the final step: agreement of A and p(T) on the Krylov basis closes with a single Basis.ext, replacing the parent column-by-column matrix recovery (ext i j + Pi.single + dotProduct).",
-      "endKrylov_linearIndependent and the two commutation lemmas need no FiniteDimensional hypothesis (stated with omit [FiniteDimensional K V] in); only the main theorem uses finrank/basisOfLinearIndependentOfCardEqFinrank; the finrank=0 case is a Subsingleton on Module.End K V (Module.finrank_zero_iff). Module.End.mul_apply is the (f*g) v = f (g v) rewrite."
+      "endKrylov_linearIndependent and the two commutation lemmas need no FiniteDimensional hypothesis (stated with omit [FiniteDimensional K V] in); only the main theorem uses finrank/basisOfLinearIndependentOfCardEqFinrank; the finrank=0 case is a Subsingleton on Module.End K V (Module.finrank_zero_iff). Module.End.mul_apply is the (f*g) v = f (g v) rewrite.",
+      "Frobenius bound is EQUALITY in the cyclic case: for T:Module.End K V with a cyclic vector, dim_K C(T) = dim_K V. The clean ≤ half is that evaluation A↦A·v is injective on the centralizer (operators commuting with T agreeing on a cyclic vector agree on the whole Krylov basis); ≥ is the general endK_centralizer_bound. This is the minimal-centralizer/nonderogatory edge of the triangle."
     ],
     "nextSteps": [
-      "Lift the remaining triple-equivalence edges (nonderogatory iff cyclic and centralizer = K[T] implies cyclic) to Module.End to complete the coordinate-free triangle matching matrix oq-02 / oq-02-oq-01.",
-      "Prove the endomorphism Frobenius bound dim_K (centralizer of T) >= finrank K V in the Module.End setting (matrix version: finrank_centralizer_ge in oq-02-oq-01)."
+      "Lift the last equivalence edge to Module.End: centralizer = K[T] (or dim C(T)=n) IMPLIES T has a cyclic vector — the converse direction completing nonderogatory⟺cyclic⟺C(T)=K[T].",
+      "Optionally package C(T)=K[T] as an equality of subalgebras (Subalgebra.centralizer K {T} = Algebra.adjoin K {T}) in the Module.End setting."
     ]
   },
   "tags": [


### PR DESCRIPTION
## Summary
Research session for `cayley-hamilton-cyclic-vector-all-fields-oq-02-oq-03` (commutant of a cyclic endomorphism, namespace `EndCyclicCommutant`). Sharpens the general Frobenius **lower** bound to an **equality** in the cyclic case. Verified 0-axiom.

## Progress
New file `proofs/Proofs/CayleyHamiltonCyclicVectorAllFieldsOQ02OQ03Frobenius.lean` — clean Docker build (v4.31.0), `#print axioms` = `[propext, Classical.choice, Quot.sound]` (0 axioms, 0 sorries):

- **`commuting_end_eq_of_apply_eq`** — two operators commuting with `T` that agree on a cyclic vector `v` are equal (they agree on the whole Krylov basis `{Tᵏ·v}` since `A·(Tᵏ·v) = Tᵏ·(A·v)`; `Basis.ext`). This is the injectivity of evaluation `A ↦ A·v` on the centralizer.
- **`finrank_centralizer_le_of_cyclic`** — `dim_K C(T) ≤ dim_K V`, via that injective `K`-linear evaluation map into `V`.
- **`finrank_centralizer_eq_of_cyclic`** — `dim_K C(T) = dim_K V`, the equality case of Frobenius.

## Findings
- The recorded next-step "endomorphism Frobenius bound `dim C(T) ≥ finrank V`" was **already** proven in general form as `CyclicCommutantConverse.endK_centralizer_bound` (in `…OQ02OQ01`, via PID primary decomposition); this PR reuses it directly as the `≥` half and supplies the cyclic-specific `≤` half to close the equality.
- The `≤` half is elegantly elementary — the injective evaluation-at-`v` map — and does not need the polynomial-commutant lemma `commuting_end_is_polynomial`.
- This is the minimal-centralizer / nonderogatory dimension-count edge of the triangle `nonderogatory ⟺ cyclic ⟺ C(T) = K[T]`, lifted to the coordinate-free `Module.End` setting (matrix analogue lived in `…OQ02OQ01`).

## Status
**Outcome**: progress (structural extension of a completed OQ family)
**Next Steps**: the last converse edge — `C(T) = K[T]` (or `dim C(T) = n`) **implies** `T` has a cyclic vector — completing the equivalence triangle in `Module.End`.

🤖 Generated by researcher-1