### PR TITLE
Gallery integrity: erdos-757 section summary claims phantom 'bounded above' property

### DIFF
--- a/src/data/proofs/erdos-757/meta.json
+++ b/src/data/proofs/erdos-757/meta.json
@@ -134,8 +134,8 @@
       "title": "Admissible Constants",
       "startLine": 171,
       "endLine": 207,
-      "summary": "Properties of the set of admissible constants: bounded above, nonempty.",
-      "mathContext": "Bound: Properties of the set of admissible constants: bounded above, nonempty."
+      "summary": "The set of admissible constants is nonempty: zero_admissible and neg_admissible prove every c ≤ 0 is admissible (take S = ∅), and admissible_nonempty packages this. The nontrivial upper bound (c < 3/5, Gyárfás-Lehel) is discussed in comments only, not formalized.",
+      "mathContext": "Nonempty: {c | IsAdmissible c} contains 0 and all negatives (proved). Upper boundedness (c < 3/5) is comment-only, not a formalized theorem."
     },
     {
       "id": "extremal",


### PR DESCRIPTION
## Integrity Issue

**Proof**: erdos-757 (List Chromatic → *Sidon Sets in Almost-Sidon Families*)
**Problem**: The `Admissible Constants` section summary overstates formalization scope.

## Evidence

**meta.json claimed** (sections[id=admissible]):
> "Properties of the set of admissible constants: **bounded above**, nonempty."

**Lean file shows** (`proofs/Proofs/Erdos753Problem.lean` lines 199-228 — the admissible section) only three theorems:
- `zero_admissible : IsAdmissible 0` — trivial (`S = ∅`)
- `neg_admissible (c) (hc : c < 0) : IsAdmissible c` — trivial (`S = ∅`)
- `admissible_nonempty : {c | IsAdmissible c}.Nonempty` — from `zero_admissible`

There is **no boundedness theorem**. The nontrivial upper bound `c < 3/5` (Gyárfás-Lehel 1995) appears in **comments only** (lines ~86-90), never formalized. So "bounded above" describes a property the kernel does not guarantee.

## Fix applied in this PR

Reword the section `summary`/`mathContext` to state only what is proved (nonempty via c ≤ 0), and explicitly note the upper bound is comment-only, not formalized.

## Notes

Entry is otherwise **clean**: 0 axioms, 0 sorries, `wip`/open, badge `wip`. All 8 theorems are real and non-vacuous (base Sidon facts, difference-set structure, `almostSidon_of_sidon`, `|B−B|≥11` bound). The c ≤ 0 admissibility theorems are legitimately trivial and honestly documented as such — the only overclaim was the section-summary word "bounded above".

---
Discovered during gallery integrity audit.