### PR TITLE
Research: erdos-85-wip-01 — upper bound f(n) ≤ n-1 + full-degree⟹complete graph

### DIFF
--- a/proofs/Proofs/Erdos85Problem.lean
+++ b/proofs/Proofs/Erdos85Problem.lean
@@ -256,4 +256,45 @@ theorem starGraph_not_containsC4 (n : ℕ) :
   · exact absurd (hinj (h1.trans h2.symm)) (by decide)
   · exact absurd (hinj (h1.trans h3.symm)) (by decide)
 
+/-- **Full minimum degree forces the complete graph.**  On `Fin n`, a simple graph
+whose minimum degree is at least `n - 1` must be the complete graph `⊤`: every
+vertex `i` has `deg i ≤ n - 1` (its neighbours avoid `i`), so `deg i ≥ n - 1`
+forces its neighbourhood to be *all* other vertices, i.e. `i` is adjacent to every
+`j ≠ i`. -/
+theorem eq_top_of_minDegree_ge {n : ℕ} (G : SimpleGraph (Fin n)) [DecidableRel G.Adj]
+    (hmin : n - 1 ≤ G.minDegree) : G = ⊤ := by
+  ext i j
+  rw [top_adj]
+  refine ⟨fun h => h.ne, fun hij => ?_⟩
+  -- `deg i ≥ n - 1`, and the neighbourhood of `i` sits inside the `n - 1` other vertices
+  have hdeg : n - 1 ≤ (G.neighborFinset i).card := by
+    rw [G.card_neighborFinset_eq_degree]
+    exact le_trans hmin (G.minDegree_le_degree i)
+  have hsub : G.neighborFinset i ⊆ Finset.univ.erase i := by
+    intro x hx
+    refine Finset.mem_erase.mpr ⟨?_, Finset.mem_univ x⟩
+    exact (G.ne_of_adj ((G.mem_neighborFinset i x).mp hx)).symm
+  have hcard : (Finset.univ.erase i).card ≤ (G.neighborFinset i).card := by
+    rw [Finset.card_erase_of_mem (Finset.mem_univ i), Finset.card_univ, Fintype.card_fin]
+    exact hdeg
+  have heq : G.neighborFinset i = Finset.univ.erase i :=
+    Finset.eq_of_subset_of_card_le hsub hcard
+  have hjmem : j ∈ G.neighborFinset i := by
+    rw [heq]; exact Finset.mem_erase.mpr ⟨(Ne.symm hij), Finset.mem_univ j⟩
+  exact (G.mem_neighborFinset i j).mp hjmem
+
+/-- **A crude but honest upper bound on `f(n)`.**  For `n ≥ 4`,
+`minDegreeForC4 n ≤ n - 1`: minimum degree `n - 1` on `Fin n` forces the complete
+graph (`eq_top_of_minDegree_ge`), which contains a `C₄` (`completeGraph_containsC4`).
+In particular the threshold set defining `minDegreeForC4` is non-empty, so the
+`sInf` is a genuine minimum rather than the junk value `sInf ∅ = 0` — some finite
+minimum degree really does force a 4-cycle.  (The true value is `f(n) = (1+o(1))√n`,
+far below this bound, but that requires Kővári–Sós–Turán, beyond current Mathlib.) -/
+theorem minDegreeForC4_le_sub_one {n : ℕ} (hn : 4 ≤ n) :
+    minDegreeForC4 n ≤ n - 1 := by
+  apply Nat.sInf_le
+  intro G _ hmin
+  rw [eq_top_of_minDegree_ge G hmin]
+  exact completeGraph_containsC4 hn
+
 end Erdos85

--- a/research/problems/erdos-85-wip-01/knowledge.md
+++ b/research/problems/erdos-85-wip-01/knowledge.md
@@ -1,5 +1,27 @@
 # Knowledge Base: erdos-85-wip-01
 
+## Session 2026-07-20 (researcher-1) — upper bound f(n) ≤ n-1 + full-degree ⟹ complete
+
+Added 2 axiom-free lemmas to `Erdos85Problem.lean` (host-verified v4.31.0, `#print axioms` =
+propext/Classical.choice/Quot.sound; theoremCount 11→13, lineCount 259→300):
+
+- `eq_top_of_minDegree_ge` — on `Fin n`, `minDegree ≥ n-1` forces `G = ⊤`. Proof: `deg i =
+  card (neighborFinset i)`, and `neighborFinset i ⊆ univ.erase i` (card `n-1`); `deg i ≥ n-1`
+  + `Finset.eq_of_subset_of_card_le` ⟹ `neighborFinset i = univ.erase i`, so `i` is adjacent
+  to every `j ≠ i`.
+- `minDegreeForC4_le_sub_one` — `f(n) ≤ n-1` for `n≥4` via `Nat.sInf_le`: `minDegree ≥ n-1`
+  ⟹ `G = ⊤` ⟹ `containsC4` (`completeGraph_containsC4`). Bonus: the threshold set is
+  non-empty, so `f(n)` is a genuine minimum (not the junk `sInf ∅ = 0`).
+
+Crude vs the true `f(n)=(1+o(1))√n` (needs Kővári–Sós–Turán, beyond Mathlib) but the first
+honest bound tying the `sInf` definition to the structural `completeGraph_containsC4`.
+
+### API used
+`SimpleGraph.card_neighborFinset_eq_degree`, `minDegree_le_degree`, `mem_neighborFinset`,
+`ne_of_adj`, `top_adj`, `Finset.card_erase_of_mem`, `Finset.eq_of_subset_of_card_le`,
+`Nat.sInf_le`. The set membership binder `∀ G [DecidableRel G.Adj], …` is entered by `intro G _`.
+
+
 Insights accumulated during research on this problem.
 
 ---

--- a/src/data/proofs/erdos-85/meta.json
+++ b/src/data/proofs/erdos-85/meta.json
@@ -150,9 +150,9 @@
       "Topology"
     ],
     "namespace": "Erdos85",
-    "lineCount": 259,
+    "lineCount": 300,
     "axiomCount": 0,
-    "theoremCount": 11,
+    "theoremCount": 13,
     "definitionCount": 8,
     "path": "Proofs/Erdos85Problem.lean",
     "sorries": 0

--- a/src/data/research/problems/erdos-85-wip-01.json
+++ b/src/data/research/problems/erdos-85-wip-01.json
@@ -31,25 +31,27 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Erdos85Problem.lean — session 2 added 4 axiom-free structural lemmas (7->11 theorems) that bracket the C4 extremal question: containsC4_four_le_card (necessary size >=4), completeGraph_containsC4 (dense graphs contain C4), containsC4_C4 (non-vacuity), C4_not_adj_one_three (C4 adjacency fully pinned). 0 sorry / 0 axiom, #print axioms clean. Deep results (f(4)=2, asymptotics, KST, monotonicity) remain documented-only.",
+    "progressSummary": "PROGRESS (2026-07-20, researcher-1, VERIFIED 0-axiom host): added f(n) ≤ n-1 upper bound (minDegreeForC4_le_sub_one) + eq_top_of_minDegree_ge (full min-degree ⟹ complete graph). Ties the sInf definition to completeGraph_containsC4 and shows the threshold set is non-empty (f(n) a genuine minimum). 13 axiom-free theorems total; deep results (f(4)=2, KST, asymptotics, monotonicity) remain documented-only.",
     "builtItems": [
       "C4_adj_zero_one/one_two/two_three/three_zero (four cycle edges) in Erdos85Problem.lean",
       "C4_not_adj_zero_two (diagonal non-edge) in Erdos85Problem.lean",
       "containsC4_mono (C4 copy survives adding edges) in Erdos85Problem.lean",
       "starGraph_not_containsC4 (stars are C4-free) in Erdos85Problem.lean",
-      "C4_not_adj_one_three, containsC4_C4, containsC4_four_le_card, completeGraph_containsC4 in Erdos85Problem.lean (session 2, axiom-free [propext, Classical.choice, Quot.sound])"
+      "C4_not_adj_one_three, containsC4_C4, containsC4_four_le_card, completeGraph_containsC4 in Erdos85Problem.lean (session 2, axiom-free [propext, Classical.choice, Quot.sound])",
+      "eq_top_of_minDegree_ge, minDegreeForC4_le_sub_one in Erdos85Problem.lean (0 axioms, 0 sorries; host-verified v4.31.0, #print axioms = [propext, Classical.choice, Quot.sound]). theoremCount 11→13."
     ],
     "insights": [
       "Erdos85Problem.lean was a definitions-only stub (7 defs, 0 theorems). Asymptotics f(n)=(1+o(1))sqrt(n), f(4)=2, and the Ramsey reformulation need extremal graph theory beyond Mathlib; tractable axiom-free content is structural facts about C4, containsC4, and starGraph.",
       "Stars are C4-free: a C4 has two DISJOINT edges (0-1 and 2-3); in a star every edge meets the centre 0, so both disjoint edges would put two distinct cycle-vertices at 0, contradicting injectivity of the embedding. Only the two disjoint edges are needed for the proof.",
       "SimpleGraph structure-literal Adj fields have no Decidable instance, so `decide` fails on C4.Adj 0 1; `by simp [C4]` unfolds the field and evaluates the arithmetic disjunction instead.",
-      "The extremal question for C4 is bracketed by two structural facts now both formalized: complete graphs on >=4 vertices always contain a C4 (completeGraph_containsC4, dense extreme) while stars K_{1,n} never do (starGraph_not_containsC4, sparse extreme). A C4 also forces >=4 vertices (containsC4_four_le_card)."
+      "The extremal question for C4 is bracketed by two structural facts now both formalized: complete graphs on >=4 vertices always contain a C4 (completeGraph_containsC4, dense extreme) while stars K_{1,n} never do (starGraph_not_containsC4, sparse extreme). A C4 also forces >=4 vertices (containsC4_four_le_card).",
+      "First honest UPPER bound on f(n) from the sInf definition: minDegreeForC4 n ≤ n-1 for n≥4. On Fin n, minDegree ≥ n-1 forces the complete graph (eq_top_of_minDegree_ge: neighborFinset i ⊆ univ.erase i, card n-1, so equality ⟹ i adjacent to all j≠i), which contains C4. Also proves the threshold set is non-empty, so f(n) is a genuine minimum not sInf ∅ = 0."
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "Base case f(4)=2: on Fin 4, minDegree >= 2 forces containsC4 (finite but quantifies over all SimpleGraph (Fin 4) — needs a Fintype/decidability bridge for SimpleGraph on a finite type).",
-      "Kővári–Sós–Turán edge bound for C4-free graphs (deep, likely not in Mathlib).",
-      "minDegreeForC4 monotonicity/basic bounds from the sInf definition."
+      "Base case f(4)=2: minDegree ≥ 2 on Fin 4 forces containsC4 (finite but quantifies over all SimpleGraph (Fin 4) — needs a decidability/enumeration bridge), plus f(4) > 1 via a minDegree-1 C4-free witness (e.g. a perfect matching on Fin 4).",
+      "Kővári–Sós–Turán edge bound for C4-free graphs (deep, likely not in Mathlib) — would give the true √n-scale bound.",
+      "minDegreeForC4 monotonicity/sInf basic bounds."
     ],
     "markdown": "# Knowledge Base: erdos-85-wip-01\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },


### PR DESCRIPTION
## Summary
Research session for `erdos-85-wip-01` (Erdős #85, minimum degree forcing a 4-cycle). Adds the first honest **upper bound** on the threshold `f(n) = minDegreeForC4 n` from its `sInf` definition. Verified 0-axiom.

## Progress
Two new axiom-free lemmas in `proofs/Proofs/Erdos85Problem.lean` (host-verified, Lean v4.31.0; `#print axioms` = `[propext, Classical.choice, Quot.sound]`; `leanFile.theoremCount` 11→13):

- **`eq_top_of_minDegree_ge`** — on `Fin n`, `G.minDegree ≥ n-1` forces `G = ⊤` (the complete graph). Each vertex's neighbourhood sits inside the `n-1` other vertices (`neighborFinset i ⊆ univ.erase i`), so `deg i ≥ n-1` + `Finset.eq_of_subset_of_card_le` makes it *all* of them.
- **`minDegreeForC4_le_sub_one`** — `minDegreeForC4 n ≤ n-1` for `n ≥ 4`, via `Nat.sInf_le`: minimum degree `n-1` ⟹ `G = ⊤` ⟹ contains `C₄` (`completeGraph_containsC4`).

## Findings
- Beyond the bound itself, `minDegreeForC4_le_sub_one` shows the threshold set `{k | ∀ G, minDeg ≥ k → C₄ ⊆ G}` is **non-empty**, so `minDegreeForC4 n` is a genuine minimum rather than the junk value `sInf ∅ = 0` — some finite minimum degree really does force a 4-cycle.
- This is the first result connecting the `sInf` definition to the file's structural lemmas (`completeGraph_containsC4`). The true value `f(n) = (1+o(1))√n` is far smaller but requires the Kővári–Sós–Turán theorem, which is beyond current Mathlib.

## Status
**Outcome**: progress (extends a WIP node from 11 to 13 axiom-free theorems)
**Next Steps**: base case `f(4)=2` (needs a decidability/enumeration bridge over `SimpleGraph (Fin 4)` plus a min-degree-1 C₄-free witness); the KST √n-scale bound.

🤖 Generated by researcher-1