### PR TITLE
Fix: erdos-1162 meta — disclose build-blocked compile-infeasible native_decide (#39058)

### DIFF
--- a/src/data/proofs/erdos-1162/meta.json
+++ b/src/data/proofs/erdos-1162/meta.json
@@ -57,7 +57,7 @@
     ],
     "axiomCount": 1,
     "lineCount": 220,
-    "assumptions": "1 axiom: roney_dougal_tracey. 0 sorries.",
+    "assumptions": "1 axiom: roney_dougal_tracey. BUILD-BLOCKED (issue #39058): the file does not currently compile. The small-case theorems f3/f4 (numSubgroups 3 = 6, numSubgroups 4 = 30) are discharged by native_decide computing Nat.card (Subgroup (Equiv.Perm (Fin n))) — a brute-force enumeration of the entire subgroup lattice of S₄ (~2^24 subsets with closure checks per candidate). This is compile-infeasible: two independent verification attempts pegged one core at 100% CPU for 3h41m and >22min with zero progress (not an OOM — pure compute pathology). Consequently these small-case values are NOT machine-checked in the current source, and the entry has not been verified end-to-end. A feasible reproof of the S₄ subgroup count (explicit subgroups + Lagrange, as in SylowTheoremOQ04) is deep formalization work tracked under #39058 / epic #37508.",
     "theoremCount": 9,
     "definitionCount": 5
   },
@@ -71,7 +71,7 @@
       "**Most subgroups are 2-groups**: The overwhelming majority of subgroups of S_n have order a power of 2.",
       "**Wreath product structure**: The key construction is (Z/2Z) ≀ S_{⌊n/4⌋} — wreath products of 2-groups with symmetric groups on a quarter of the points.",
       "**Gaussian binomial coefficients**: The count of subgroups of (Z/2Z)^k involves Gaussian binomials over GF(2), contributing the k²/4 term.",
-      "**Axiom reduction to 1**: The original 6-axiom formalization was reduced to 1 through Lean proofs: f1 via Subsingleton→Unique chain, f2-f4 via native_decide, leaving only the single deep published result (Roney-Dougal-Tracey 2025) as an irreducible assumption."
+      "**Axiom reduction to 1 (build-blocked)**: The formalization was restructured to leave only the single deep published result (Roney-Dougal-Tracey 2025) as an irreducible assumption, with f1 proved via a Subsingleton→Unique chain. The intended discharge of f2-f4 by native_decide does not compile, however: the S₄ subgroup-lattice enumeration is compile-infeasible (see assumptions / issue #39058), so those small cases remain unverified in the current source."
     ],
     "prerequisites": [
       "Symmetric groups $S_n$ and their subgroup structure",


### PR DESCRIPTION
## Problem

The gallery entry `erdos-1162` (`Proofs/Erdos1162Problem.lean`) presented itself as a 0-sorry, single-axiom **axiomatized** result and claimed in its `assumptions`/`keyInsights` that the small cases **f2–f4 were proved via `native_decide`** ("axiom reduction to 1 ... f2-f4 via native_decide").

Per **issue #39058**, those three `native_decide` calls compute `Nat.card (Subgroup (Equiv.Perm (Fin n)))` — a brute-force enumeration of the entire subgroup lattice of S₄ (~2²⁴ subsets, closure-checked). This is **compile-infeasible**: two independent verification attempts pegged a core at 100% CPU for **3h41m** and **>22min** with zero progress (not an OOM — pure compute pathology). The file therefore **does not compile**, so the small-case values are *not* machine-checked and the entry is not verified end-to-end.

## Fix (Fix Type A — metadata honesty only)

Two existing string fields corrected in `src/data/proofs/erdos-1162/meta.json`:

- **`assumptions`** — now discloses the BUILD-BLOCKED status, the S₄ lattice-enumeration root cause, the observed 3h41m/>22min hangs, and that the small cases are not machine-checked. References #39058 / epic #37508.
- **keyInsight "Axiom reduction to 1"** — reworded to "(build-blocked)": f1 is genuinely proved, but the intended `native_decide` discharge of f2–f4 does not compile.

Status stays `axiomatized` / badge `axiom` (already not claiming `verified`). Follows the existing `konigsberg-oq-01-oq-02` "main file does not build" precedent.

## Scope

- Metadata-only; the blocked Lean file is untouched (deep reproof via explicit-subgroup + Lagrange, à la SylowTheoremOQ04, remains tracked under #39058).
- JSON validated well-formed (`python3 -m json.tool`). No structural/schema change — only the content of two existing string values.

## Evidence

Before: `"assumptions": "1 axiom: roney_dougal_tracey. 0 sorries."` and keyInsight asserting "f2-f4 via native_decide" as completed reductions.
After: both fields disclose the compile-infeasibility.

Relates #39058 (does **not** close it — the Lean reproof is still needed).