### PR TITLE
Research: erdos-1039-oq-05 — Fekete monotonicity at the supremum level (d_{n+1} ≤ dₙ)

### DIFF
--- a/proofs/Proofs/Erdos1039TransfiniteDiameter.lean
+++ b/proofs/Proofs/Erdos1039TransfiniteDiameter.lean
@@ -422,4 +422,89 @@ theorem exists_deleteAt_discreteDiameter_ge (hn : 2 ≤ n)
         field_simp
     _ ≤ 2 / ((n : ℝ) * ((n : ℝ) - 1)) * logSpread (deleteAt z k) := hstep
 
+/- ## Fekete monotonicity: the supremum-level statement
+
+The pointwise inequality `exists_deleteAt_discreteDiameter_ge` lifts to the
+classical **supremum** form once we take suprema over all configurations inside a
+compact set.  We do this for the closed unit disc `{|z| ≤ 1}` — the setting of the
+parent lemniscate problem, whose roots lie in the unit disc.  Define
+
+    dₙ := sup { dₙ(Z) : Z an n-point configuration in the closed unit disc }.
+
+Every `dₙ(Z) ≤ 2` (`discreteDiameter_le_two`), so the supremum exists, and the
+pointwise deletion inequality forces `d_{n+1} ≤ dₙ`.  Hence `n ↦ dₙ` is
+non-increasing (for `n ≥ 2`) and, being bounded below by `0`, converges — this is
+the sense in which the transfinite diameter `d = infₙ dₙ` is a well-defined limit. -/
+
+/-- The set of `n`-point discrete diameters `dₙ(Z)` achievable by configurations
+`Z` in the **closed unit disc** `{|z| ≤ 1}`. -/
+def unitDiscDiameters (n : ℕ) : Set ℝ :=
+  { d | ∃ z : Fin n → ℂ, (∀ i, ‖z i‖ ≤ 1) ∧ discreteDiameter z = d }
+
+/-- The **`n`-point transfinite diameter of the closed unit disc**,
+`dₙ = sup_Z dₙ(Z)` over configurations `Z` in `{|z| ≤ 1}`. -/
+noncomputable def transfiniteDiameterN (n : ℕ) : ℝ := sSup (unitDiscDiameters n)
+
+/-- The all-zero configuration realises the diameter `0`, so `0 ∈ unitDiscDiameters n`
+(for `n ≥ 2`, where a repeated point makes the configuration non-injective and hence
+`dₙ = 0`).  In particular the set is non-empty. -/
+theorem zero_mem_unitDiscDiameters (hn : 2 ≤ n) : (0 : ℝ) ∈ unitDiscDiameters n := by
+  refine ⟨fun _ => 0, fun _ => by simp, ?_⟩
+  have hni : ¬ Function.Injective (fun _ : Fin n => (0 : ℂ)) := by
+    intro h
+    have h01 : (⟨0, by omega⟩ : Fin n) = ⟨1, by omega⟩ := h rfl
+    simp [Fin.ext_iff] at h01
+  have hnpos : ¬ 0 < discreteDiameter (fun _ : Fin n => (0 : ℂ)) := fun h =>
+    hni ((discreteDiameter_pos_iff hn).mp h)
+  exact le_antisymm (not_lt.mp hnpos) (discreteDiameter_nonneg _)
+
+/-- `unitDiscDiameters n` is non-empty (contains `0`) for `n ≥ 2`. -/
+theorem unitDiscDiameters_nonempty (hn : 2 ≤ n) : (unitDiscDiameters n).Nonempty :=
+  ⟨0, zero_mem_unitDiscDiameters hn⟩
+
+/-- `unitDiscDiameters n` is bounded above by `2` (`discreteDiameter_le_two`), so its
+supremum `transfiniteDiameterN n` exists. -/
+theorem unitDiscDiameters_bddAbove (hn : 2 ≤ n) : BddAbove (unitDiscDiameters n) := by
+  refine ⟨2, ?_⟩
+  rintro d ⟨z, hz, rfl⟩
+  exact discreteDiameter_le_two hn hz
+
+/-- **Fekete monotonicity (supremum form).**  The `n`-point transfinite diameter of
+the closed unit disc is non-increasing in `n`:  `d_{n+1} ≤ dₙ` for `n ≥ 2`.
+
+For each `(n+1)`-configuration `Z` in the disc: if `Z` has distinct points, the
+pointwise deletion inequality (`exists_deleteAt_discreteDiameter_ge`) supplies an
+`n`-point sub-configuration — still inside the disc — of diameter `≥ d_{n+1}(Z)`,
+which is bounded above by `dₙ`; if `Z` has a repeated point then `d_{n+1}(Z) = 0 ≤ dₙ`.
+Taking the supremum over `Z` gives `d_{n+1} ≤ dₙ`.  Combined with `0 ≤ dₙ ≤ 2` this
+makes the transfinite diameter `d = infₙ dₙ` a well-defined (monotone, bounded) limit. -/
+theorem transfiniteDiameterN_succ_le (hn : 2 ≤ n) :
+    transfiniteDiameterN (n + 1) ≤ transfiniteDiameterN n := by
+  have hbddn : BddAbove (unitDiscDiameters n) := unitDiscDiameters_bddAbove hn
+  refine csSup_le (unitDiscDiameters_nonempty (by omega)) ?_
+  rintro d ⟨z, hzdisc, rfl⟩
+  by_cases hz : Function.Injective z
+  · -- distinct points: some deletion has diameter ≥ d_{n+1}(z), and lies in the disc
+    obtain ⟨k, hk⟩ := exists_deleteAt_discreteDiameter_ge hn z hz
+    have hmem : discreteDiameter (deleteAt z k) ∈ unitDiscDiameters n :=
+      ⟨deleteAt z k, fun i => hzdisc _, rfl⟩
+    exact le_trans hk (le_csSup hbddn hmem)
+  · -- repeated point: d_{n+1}(z) = 0 ≤ dₙ
+    have hnpos : ¬ 0 < discreteDiameter z := fun h =>
+      hz ((discreteDiameter_pos_iff (by omega : 2 ≤ n + 1)).mp h)
+    have hzero : discreteDiameter z = 0 :=
+      le_antisymm (not_lt.mp hnpos) (discreteDiameter_nonneg _)
+    rw [hzero]
+    exact le_csSup hbddn (zero_mem_unitDiscDiameters hn)
+
+/-- `0 ≤ dₙ ≤ 2` for the `n`-point transfinite diameter of the closed unit disc
+(`n ≥ 2`): the monotone sequence of `transfiniteDiameterN_succ_le` is bounded, so its
+infimum — the transfinite diameter of the disc — is well-defined. -/
+theorem transfiniteDiameterN_mem_Icc (hn : 2 ≤ n) :
+    transfiniteDiameterN n ∈ Set.Icc (0 : ℝ) 2 := by
+  constructor
+  · exact le_csSup (unitDiscDiameters_bddAbove hn) (zero_mem_unitDiscDiameters hn)
+  · exact csSup_le (unitDiscDiameters_nonempty hn)
+      (by rintro d ⟨z, hz, rfl⟩; exact discreteDiameter_le_two hn hz)
+
 end Erdos1039TransfiniteDiameter

--- a/research/problems/erdos-1039-oq-05/knowledge.md
+++ b/research/problems/erdos-1039-oq-05/knowledge.md
@@ -1,5 +1,34 @@
 # Knowledge Base: erdos-1039-oq-05
 
+## Session 2026-07-20 (researcher-1) — Fekete monotonicity at the SUPREMUM level
+
+Added the sup-over-configurations capstone to `Erdos1039TransfiniteDiameter.lean` (host-verified
+v4.31.0; `#print axioms` = propext/Classical.choice/Quot.sound, 0 sorry/0 axiom):
+
+- `unitDiscDiameters n` — the set { dₙ(Z) : Z an n-point config in the closed unit disc }.
+- `transfiniteDiameterN n = sSup (unitDiscDiameters n)` — the n-point transfinite diameter of the disc.
+- `zero_mem_unitDiscDiameters` / `unitDiscDiameters_nonempty` / `unitDiscDiameters_bddAbove` (≤ 2).
+- `transfiniteDiameterN_succ_le` — **d_{n+1} ≤ dₙ for n ≥ 2**. Lifts the pointwise
+  `exists_deleteAt_discreteDiameter_ge` over the config sup: `csSup_le` + per-config bound
+  (injective ⟹ some deletion in the disc has larger diameter ⟹ `le_csSup`; non-injective ⟹
+  diameter 0 ≤ dₙ). NO compactness API needed — only that deletion keeps values in the disc.
+- `transfiniteDiameterN_mem_Icc` — `0 ≤ dₙ ≤ 2`, so `d = infₙ dₙ` is a well-defined monotone
+  bounded limit.
+
+This resolves the "needs sup over configurations" caveat on next-step #1 (the pointwise heart
+was already done as `exists_deleteAt_discreteDiameter_ge`). The compactness worry was unfounded:
+the closed unit disc bound `dₙ(Z) ≤ 2` alone makes the sup exist and the monotonicity go through.
+
+### API used
+`csSup_le`, `le_csSup`, `BddAbove`, `Set.Nonempty`, `discreteDiameter_le_two`,
+`discreteDiameter_pos_iff` (non-injective ⟹ diameter 0), `deleteAt` norm-preservation.
+
+### Remaining open
+- Package `d(disc) = ⨅ₙ transfiniteDiameterN n` + `Tendsto` (Antitone+BddBelow).
+- Logarithmic capacity + cap=1 (axiomatize, Fekete–Szegő); ρ(f) ≳ g(d,cap) (Pommerenke/KLR axioms).
+- Parent ρ(f) ≫ 1/n remains OPEN.
+
+
 Insights accumulated during research on this problem.
 
 ---

--- a/src/data/research/problems/erdos-1039-oq-05.json
+++ b/src/data/research/problems/erdos-1039-oq-05.json
@@ -42,7 +42,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (iter 3): the combinatorial core of Fekete monotonicity is formalized axiom-free. prod_spreadProduct_deleteAt proves prod_k V(delete k Z) = V(Z)^(n-1) directly, with a succAbove reindexing lemma, the cardinality count, and the additive log-energy form. Builds on Key Lemma 1 (n-point spread) in Erdos1039TransfiniteDiameter.lean. Remaining: lift to supremum-level d_(n+1) <= d_n (needs sup over configurations); logarithmic capacity + cap=1 (axiomatize). Parent rho(f) >> 1/n remains OPEN. | +discreteDiameter_pos & discreteDiameter_pos_iff (strict positivity ⟺ distinct roots), the positivity underpinning every log/exp step. 0 sorry, 0 axiom.",
+    "progressSummary": "PROGRESS (2026-07-20, researcher-1, VERIFIED 0-axiom host): lifted Fekete monotonicity to the SUPREMUM level. New defs unitDiscDiameters/transfiniteDiameterN (sup of dₙ(Z) over configs in the closed unit disc) + transfiniteDiameterN_succ_le (d_{n+1} ≤ dₙ, n≥2) and transfiniteDiameterN_mem_Icc (0 ≤ dₙ ≤ 2). The transfinite diameter d = infₙ dₙ is now a well-defined monotone bounded limit. Parent ρ(f) ≫ 1/n remains OPEN.",
     "builtItems": [
       "Erdos1039TransfiniteDiameter.spreadProduct: the Vandermonde spread ∏_{i<j}‖zᵢ-zⱼ‖ (finite-n numerator of the transfinite diameter).",
       "Erdos1039TransfiniteDiameter.discreteDiameter: the n-point diameter dₙ(Z) = spreadProduct^{2/(n(n-1))}, the finite-n truncation of the transfinite diameter.",
@@ -56,7 +56,8 @@
       "prod_spreadProduct_deleteAt (Fekete deletion identity) in Erdos1039TransfiniteDiameter.lean",
       "sum_logSpread_deleteAt (additive energy form) in Erdos1039TransfiniteDiameter.lean",
       "discreteDiameter_pos (0 < dₙ z for injective z) in Erdos1039TransfiniteDiameter.lean",
-      "discreteDiameter_pos_iff (n≥2: 0 < dₙ z ↔ Injective z) in Erdos1039TransfiniteDiameter.lean"
+      "discreteDiameter_pos_iff (n≥2: 0 < dₙ z ↔ Injective z) in Erdos1039TransfiniteDiameter.lean",
+      "unitDiscDiameters, transfiniteDiameterN, zero_mem_unitDiscDiameters, unitDiscDiameters_nonempty/bddAbove, transfiniteDiameterN_succ_le, transfiniteDiameterN_mem_Icc in Erdos1039TransfiniteDiameter.lean (0 axioms, 0 sorries; host-verified v4.31.0)"
     ],
     "insights": [
       "The finite discrete spread is entirely elementary and needs NO capacity infrastructure: it is a product of pairwise norms, equal to the modulus of the Vandermonde determinant, so it is host-verifiable Mathlib-only (no Docker).",
@@ -65,16 +66,17 @@
       "Fekete deletion identity prod_k V(delete k Z) = V(Z)^(n-1) is provable axiom-free and unconditionally (any tuple): each pair a<b survives exactly n-1 of the n+1 deletions (those removing neither endpoint).",
       "Order-preserving pair reindexing under Fin.succAbove is a nested Finset.prod_bij; the k-dependent erase-guard is pulled through prod_k by rewriting erase -> filter(.neq.k) -> if via Finset.filter_ne'/prod_filter, then prod_comm.",
       "Additive shadow: sum_k logSpread(delete k Z) = (n-1)*logSpread Z for distinct roots, connecting the deletion identity to the logarithmic-energy/capacity bridge already in the file.",
-      "Strict positivity of discreteDiameter: dₙ z = spreadProduct z ^ (2/(n(n-1))); for injective z the base is positive (spreadProduct_pos_iff) so Real.rpow_pos_of_pos gives 0 < dₙ. The n≥2 iff uses that the exponent 2/(n(n-1)) is nonzero, so a zero spread would force dₙ=0 (Real.zero_rpow). This is the positivity that Real.log(dₙ) and the energy bridge silently need."
+      "Strict positivity of discreteDiameter: dₙ z = spreadProduct z ^ (2/(n(n-1))); for injective z the base is positive (spreadProduct_pos_iff) so Real.rpow_pos_of_pos gives 0 < dₙ. The n≥2 iff uses that the exponent 2/(n(n-1)) is nonzero, so a zero spread would force dₙ=0 (Real.zero_rpow). This is the positivity that Real.log(dₙ) and the energy bridge silently need.",
+      "Fekete monotonicity LIFTS to the supremum level: defining dₙ = sup over n-point configs in the closed unit disc of discreteDiameter, the pointwise exists_deleteAt_discreteDiameter_ge gives transfiniteDiameterN_succ_le (d_{n+1} ≤ dₙ, n≥2) directly via csSup_le + le_csSup — no compactness API needed, only that the config values stay in the disc under deletion and that dₙ(Z)≤2 bounds the sup. The disc is the natural compact set (parent lemniscate roots lie in it)."
     ],
     "mathlibGaps": [
       "Mathlib has no transfinite-diameter / logarithmic-capacity API; the n-point spread and its diameter had to be defined from scratch (done here). The limit d(Z)=limₙ dₙ and Fekete monotonicity are still absent."
     ],
     "nextSteps": [
-      "Prove Fekete monotonicity dₙ₊₁(Z) ≤ dₙ(Z) so the transfinite diameter d(Z)=infₙ dₙ is well-defined (needs the (n+1)-choose-n sub-configuration product argument).",
-      "Define logarithmic capacity of the compact complement {|f|≥1}∩B(0,R) and axiomatize the cap=1 normalization for monic f (literature: Fekete–Szegő).",
-      "State ρ(f) ≳ g(d(Z), cap) as theorems where provable / axioms where they cite Pommerenke/KLR, extending the Erdos1039Problem axiom pattern.",
-      "Bridge spreadProduct to Erdos1039Problem.UnitDiscPolynomial.roots (this requires importing Proofs.Erdos1039Problem → Docker verification)."
+      "Package d(disc) = ⨅ₙ transfiniteDiameterN n and show the sequence converges to it (Antitone + BddBelow ⟹ Tendsto to iInf).",
+      "Define logarithmic capacity of the lemniscate complement and axiomatize cap=1 normalization for monic f (Fekete–Szegő).",
+      "State ρ(f) ≳ g(d(Z),cap) as theorems/axioms citing Pommerenke/KLR.",
+      "Bridge spreadProduct to Erdos1039Problem.UnitDiscPolynomial.roots (needs Docker)."
     ],
     "markdown": "# Knowledge Base: erdos-1039-oq-05\n\nInsights accumulated during research on relating ρ(f) to transfinite diameter and logarithmic capacity.\n\n---\n\n## Problem Understanding\n\nρ(f) is the inscribed-disc radius of the lemniscate interior {|f|<1}. The lemniscate {|f|=1} is the level-1 curve of the Green's function of the complement, so ρ(f) is potential-theoretic. Two capacity-type invariants attach to f: the transfinite diameter d of the root multiset, and the logarithmic capacity of {|f|≥1}.\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },


### PR DESCRIPTION
## Summary
Research session for `erdos-1039-oq-05` (transfinite diameter / logarithmic capacity for Erdős #1039). Lifts the pointwise Fekete deletion inequality to the classical **supremum-over-configurations** form, making the transfinite diameter of the unit disc a well-defined monotone limit. Verified 0-axiom.

## Progress
New content in `proofs/Proofs/Erdos1039TransfiniteDiameter.lean` (Mathlib-only; host-verified, Lean v4.31.0; `#print axioms` = `[propext, Classical.choice, Quot.sound]`):

- **`unitDiscDiameters n`** / **`transfiniteDiameterN n = sSup (unitDiscDiameters n)`** — the `n`-point transfinite diameter of the closed unit disc, `dₙ = sup_Z dₙ(Z)` over configurations `Z` in `{|z| ≤ 1}`.
- **`zero_mem_unitDiscDiameters` / `unitDiscDiameters_nonempty` / `unitDiscDiameters_bddAbove`** — the set is non-empty and bounded above by `2` (`discreteDiameter_le_two`), so the `sSup` exists.
- **`transfiniteDiameterN_succ_le`** — `d_{n+1} ≤ dₙ` for `n ≥ 2`. Lifts the existing pointwise `exists_deleteAt_discreteDiameter_ge` over the config supremum via `csSup_le` + `le_csSup` (injective configs: a deletion stays in the disc with larger diameter; repeated-point configs: diameter `0`).
- **`transfiniteDiameterN_mem_Icc`** — `0 ≤ dₙ ≤ 2`, so `d = infₙ dₙ` is a well-defined monotone bounded limit.

## Findings
- The prior next-step flagged the sup-level lift as needing "compactness API beyond this file." That worry was unfounded: the closed-unit-disc bound `dₙ(Z) ≤ 2` alone makes the supremum exist and the monotonicity go through — no compactness machinery required, only that `deleteAt` keeps configuration values in the disc.
- The pointwise heart (`exists_deleteAt_discreteDiameter_ge`) was already proven in a prior session; this PR completes the classical statement `d_{n+1} ≤ dₙ`.

## Status
**Outcome**: progress (completes Fekete monotonicity at the supremum level for the unit disc)
**Next Steps**: package `d = ⨅ₙ dₙ` with a `Tendsto` convergence statement (Antitone + BddBelow); logarithmic-capacity side (axiomatized, Fekete–Szegő). Parent `ρ(f) ≫ 1/n` remains OPEN.

🤖 Generated by researcher-1