### PR TITLE
Enrich erdos-360 (sum-free partitions): re-anchor drifted sections to full-file coverage

### DIFF
--- a/src/data/proofs/erdos-360/meta.json
+++ b/src/data/proofs/erdos-360/meta.json
@@ -130,26 +130,26 @@
     {
       "id": "small-cases",
       "title": "Small Cases",
-      "summary": "Computing f(2)=1 and f(4)=2 directly (both now machine-verified)",
+      "summary": "The exact small values of f, each proved from first principles via the sInf characterization: f_2 (f(2)=1), f_4 (f(4)=2), f_3 (f(3)=2), f_5 (f(5)=2), and f_6 (f(6)=2). Each proof exhibits an explicit valid partition of the required size and shows no smaller one exists (e.g. for f(5)=2, both {1,4} and {2,3} sum to 5 so a single class fails).",
       "startLine": 135,
-      "endLine": 284,
-      "mathContext": "Verified: f(2)=1 and f(4)=2 proved from first principles via the sInf characterization of f"
+      "endLine": 510,
+      "mathContext": "Verified: f(2)=1, f(3)=f(4)=f(5)=f(6)=2, each machine-checked by producing an explicit minimal valid partition."
     },
     {
       "id": "connections",
-      "title": "Connections to Related Problems",
-      "summary": "Links to sum-free sets, Schur numbers, complete sequences",
-      "startLine": 285,
-      "endLine": 296,
-      "mathContext": "Mathematical content: Links to sum-free sets, Schur numbers, complete sequences"
+      "title": "Connection to Subset Sums and Ramsey Theory",
+      "summary": "Docstring section relating the problem to sum-free sets, Schur numbers, complete sequences, and the subset-sum / additive-combinatorics context that motivates the n^{1/3}·(n/φ(n)) growth rate.",
+      "startLine": 511,
+      "endLine": 521,
+      "mathContext": "Mathematical content: links to sum-free sets, Schur numbers, complete sequences, and subset-sum problems."
     },
     {
       "id": "main-result",
       "title": "Main Result",
-      "summary": "erdos_360_solved theorem showing problem is resolved",
-      "startLine": 297,
-      "endLine": 306,
-      "mathContext": "Verified: erdos_360_solved theorem showing problem is resolved"
+      "summary": "erdos_360_solved: Problem #360 is resolved — ∃ c₁, c₂ > 0 with c₁·n^{1/3}(n/φ(n))/((log n)^{1/3}(log log n)^{2/3}) ≤ f(n) ≤ c₂·(same) for n ≥ 10, discharged by the conlon_fox_pham_2021 axiom.",
+      "startLine": 522,
+      "endLine": 531,
+      "mathContext": "Axiomatized: f(n) ≍ n^{1/3}·(n/φ(n)) / ((log n)^{1/3}·(log log n)^{2/3}), the Conlon–Fox–Pham (2021) determination."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
Enrichment pass for `erdos-360` (Erdős Problem #360).

**Drifted + incomplete section coverage.** Sections stopped at line 306 of a **531-line** file, and three were pointing at the wrong content:

- **Small Cases** (135-284) claimed only f(2)/f(4) but its range ended 226 lines before the actual case theorems `f_3` (279), `f_5` (359), `f_6` (434) — extended to 510 with a corrected summary covering all five small values.
- **Connections** was at 285-296 but the `## Connection to Subset Sums and Ramsey Theory` docstring is actually at **511** — re-anchored to 511-521 and retitled.
- **Main Result** was at 297-306 but `erdos_360_solved` is actually at **522-531** — re-anchored, summary now states the Conlon–Fox–Pham asymptotic f(n) ≍ n^{1/3}(n/φ(n))/((log n)^{1/3}(log log n)^{2/3}).

Now contiguous `1..531` coverage. `status: axiomatized` / `axiomCount: 8` unchanged and consistent (the growth-rate results are the Alon–Erdős/Vu/Conlon–Fox–Pham axioms). No content deleted.