### PR TITLE
Research: erdos-326-wip-01 — squares are not an order-3 additive basis (basis order = exactly 4)

### DIFF
--- a/proofs/Proofs/Erdos326WIP01.lean
+++ b/proofs/Proofs/Erdos326WIP01.lean
@@ -168,4 +168,56 @@ theorem IsAddBasisOfOrder.infinite {A : Set ℕ} {k : ℕ}
   have hge : k * M + 1 ≤ max N (k * M + 1) := le_max_right _ _
   omega
 
+/-! ## The squares are a basis of order 4 but NOT of order 3 (mod-8 obstruction)
+
+Lagrange's four-square theorem makes the squares an order-`4` basis
+(`isAddBasisOfOrder_squares_four`).  Order `3` does **not** suffice: infinitely
+many integers — those `≡ 7 (mod 8)` — are not sums of three squares.  This is the
+*easy* (necessary) direction of Legendre's three-square theorem, needing only the
+finite fact that squares are `0, 1, 4 (mod 8)` and no three of those sum to `7`
+modulo `8` (a `decide` over `ZMod 8`); the full Legendre theorem is not required.
+Consequently the four-square order is sharp. -/
+
+/-- Every perfect square is `0`, `1`, or `4` modulo `8`. -/
+theorem mem_squares_mod_eight {s : ℕ} (hs : s ∈ Squares) :
+    (s : ZMod 8) = 0 ∨ (s : ZMod 8) = 1 ∨ (s : ZMod 8) = 4 := by
+  obtain ⟨r, rfl⟩ := hs
+  have hx : ∀ x : ZMod 8, x ^ 2 = 0 ∨ x ^ 2 = 1 ∨ x ^ 2 = 4 := by decide
+  have hcast : ((r ^ 2 : ℕ) : ZMod 8) = (r : ZMod 8) ^ 2 := by push_cast; ring
+  rw [hcast]; exact hx _
+
+/-- **The perfect squares are not an additive basis of order `3`.**  If they were,
+every sufficiently large `n` — in particular `n = 8N + 7` — would be a sum of at
+most three squares.  But modulo `8` each square is `0, 1` or `4`, and no sum of at
+most three of these equals `7 (mod 8)`, while `8N + 7 ≡ 7 (mod 8)`.  Contradiction.
+Together with `isAddBasisOfOrder_squares_four` this shows the order of the squares
+as an additive basis is exactly `4`. -/
+theorem not_isAddBasisOfOrder_squares_three : ¬ IsAddBasisOfOrder Squares 3 := by
+  rintro ⟨N, hN⟩
+  obtain ⟨m, hm, f, hf, hsum⟩ := hN (8 * N + 7) (by omega)
+  -- reduce the representation modulo 8
+  have hcast : (∑ i, (f i : ZMod 8)) = 7 := by
+    have h : ((∑ i, f i : ℕ) : ZMod 8) = 7 := by
+      rw [hsum]; push_cast; rw [show (8 : ZMod 8) = 0 from by decide]; ring
+    rwa [Nat.cast_sum] at h
+  have hmod : ∀ i, (f i : ZMod 8) = 0 ∨ (f i : ZMod 8) = 1 ∨ (f i : ZMod 8) = 4 :=
+    fun i => mem_squares_mod_eight (hf i)
+  interval_cases m
+  · rw [Fin.sum_univ_zero] at hcast; exact absurd hcast (by decide)
+  · rw [Fin.sum_univ_one] at hcast
+    rcases hmod 0 with h | h | h <;> rw [h] at hcast <;> revert hcast <;> decide
+  · rw [Fin.sum_univ_two] at hcast
+    rcases hmod 0 with h0 | h0 | h0 <;> rcases hmod 1 with h1 | h1 | h1 <;>
+      rw [h0, h1] at hcast <;> revert hcast <;> decide
+  · rw [Fin.sum_univ_three] at hcast
+    rcases hmod 0 with h0 | h0 | h0 <;> rcases hmod 1 with h1 | h1 | h1 <;>
+      rcases hmod 2 with h2 | h2 | h2 <;> rw [h0, h1, h2] at hcast <;> revert hcast <;> decide
+
+/-- **The additive-basis order of the perfect squares is exactly `4`:** they form a
+basis of order `4` (Lagrange) but of no smaller order (the `≡ 7 (mod 8)` obstruction
+rules out order `3`, and `mono_order` propagates non-representability downward). -/
+theorem not_isAddBasisOfOrder_squares_of_le_three {k : ℕ} (hk : k ≤ 3) :
+    ¬ IsAddBasisOfOrder Squares k :=
+  fun h => not_isAddBasisOfOrder_squares_three (h.mono_order hk)
+
 end Erdos326

--- a/research/problems/erdos-326-wip-01/knowledge.md
+++ b/research/problems/erdos-326-wip-01/knowledge.md
@@ -1,0 +1,26 @@
+# Knowledge Base: erdos-326-wip-01
+
+## Session 2026-07-20 (researcher-1) — squares are NOT an order-3 basis (order = exactly 4)
+
+Added 3 axiom-free lemmas to `Erdos326WIP01.lean` (host-verified v4.31.0 via fresh-parent-olean;
+`#print axioms` = propext/Classical.choice/Quot.sound; theoremCount 15→18):
+
+- `mem_squares_mod_eight` — every square is `0/1/4 (mod 8)` (`∀ x:ZMod 8, x^2 ∈ {0,1,4}` by `decide`).
+- `not_isAddBasisOfOrder_squares_three` — the squares are NOT an order-3 additive basis. Pick
+  `n = 8N+7 ≥ N`; it must be a sum of `≤3` squares, but mod 8 each square is `0/1/4` and no `≤3`
+  of those sum to `7`. `interval_cases m` (m∈{0,1,2,3}) + `Fin.sum_univ_*` + `rcases`×3 + `decide`.
+- `not_isAddBasisOfOrder_squares_of_le_three` — via `mono_order`, no order `≤3`; combined with
+  `isAddBasisOfOrder_squares_four` the basis order of the squares is EXACTLY 4 (sharp).
+
+Only the EASY direction of Legendre's three-square theorem is used (necessary condition mod 8);
+the full theorem (`n ≠ 4^a(8b+7) ⟺ sum of 3 squares`) is not needed and is deep.
+
+### Gotchas
+- `((8*N+7:ℕ):ZMod 8) = 7`: `push_cast` then `rw [show (8:ZMod 8)=0 from by decide]; ring`.
+- Cast the sum with `Nat.cast_sum`; work with `(f i : ZMod 8)` throughout.
+- Host-verify: parent `Erdos326Problem.lean` is Mathlib-only → `mkdir -p .lake/build/lib/lean/Proofs`
+  then `lake env lean -o .../Proofs/Erdos326Problem.olean` before compiling the child (no Docker).
+
+### Remaining open
+- `b_k = O(k^2)` upper bound for order-2 bases; `HasGrowthLimit` ↔ enumeration boundedness.
+- Full Legendre three-square (converse) — deep, check Mathlib.

--- a/src/data/research/problems/erdos-326-wip-01.json
+++ b/src/data/research/problems/erdos-326-wip-01.json
@@ -44,7 +44,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Erdos326WIP01.lean — proved IsAddBasisOfOrder.infinite: a basis of FIXED order k must be infinite (a finite set is bounded by M, so sums of ≤ k elements are ≤ k·M and cannot cover all large n). This distinguishes bounded-order bases from IsAddBasis, which permits arbitrarily many summands so e.g. {1} qualifies. 15 theorems + 1 def, 0 sorry / 0 axiom, VERIFIED axiom-free [propext, Classical.choice, Quot.sound], host-verified no-Docker. Deep growth content (bₖ=O(k²) upper bound, order-2 sub-basis question) untouched.",
+    "progressSummary": "PROGRESS (2026-07-20, researcher-1, VERIFIED 0-axiom host): pinned the additive-basis order of the squares to EXACTLY 4. not_isAddBasisOfOrder_squares_three (8N+7 obstruction, mod-8 decide) + not_isAddBasisOfOrder_squares_of_le_three + mem_squares_mod_eight. Sharpens isAddBasisOfOrder_squares_four (order 4 is tight, not just an upper bound). 18 axiom-free theorems. Deep growth content (b_k=O(k^2), oscillation) untouched.",
     "builtItems": [
       "IsAddBasisOfOrder.mono_order / .mono_set in Erdos326WIP01.lean",
       "IsAddBasis.mono",
@@ -53,21 +53,23 @@
       "growthRatio_nonneg, growthRatio_zero",
       "HasGrowthLimit.unique, HasGrowthLimit.not_hasNoGrowthLimit, hasNoGrowthLimit_iff",
       "Squares (the set {m^2}), isAddBasisOfOrder_squares_four, isAddBasis_squares in Erdos326WIP01.lean (session 2, axiom-free [propext, Classical.choice, Quot.sound])",
-      "IsAddBasisOfOrder.infinite (Erdos326WIP01.lean): a bounded-order additive basis is infinite, via Set.Finite.bddAbove + sum ≤ k·M ceiling (2026-07-20)"
+      "IsAddBasisOfOrder.infinite (Erdos326WIP01.lean): a bounded-order additive basis is infinite, via Set.Finite.bddAbove + sum ≤ k·M ceiling (2026-07-20)",
+      "mem_squares_mod_eight, not_isAddBasisOfOrder_squares_three, not_isAddBasisOfOrder_squares_of_le_three in Erdos326WIP01.lean (0 axioms, 0 sorries; host-verified v4.31.0 via fresh-parent-olean; #print axioms clean)"
     ],
     "insights": [
       "The basis predicates form a monotone lattice: raising the order or enlarging the set preserves the basis property — the atomic order theory underlying any basis-comparison argument.",
       "Order 0 and the empty set are degenerate non-bases (only 0 is representable), so all substantive work happens at order ≥ 1 with an infinite set.",
       "growthRatio b 0 = 0 by the ℝ junk convention x/0 = 0 — worth pinning so downstream limit arguments can ignore the k=0 term.",
-      "The perfect squares are a concrete additive basis of order 4 (Lagrange four-square theorem, Nat.sum_four_squares) — the canonical non-vacuous witness for IsAddBasisOfOrder. Order 4 is the correct order: numbers of the form 4^a(8b+7) (e.g. 7,15,23,28) are never sums of three squares, so squares are not an order-3 basis (that stronger negative needs Legendre three-square, deeper)."
+      "The perfect squares are a concrete additive basis of order 4 (Lagrange four-square theorem, Nat.sum_four_squares) — the canonical non-vacuous witness for IsAddBasisOfOrder. Order 4 is the correct order: numbers of the form 4^a(8b+7) (e.g. 7,15,23,28) are never sums of three squares, so squares are not an order-3 basis (that stronger negative needs Legendre three-square, deeper).",
+      "The additive-basis order of the perfect squares is EXACTLY 4: Lagrange gives order 4, and order 3 fails because 8N+7 ≡ 7 mod 8 is never a sum of ≤3 squares. This is the EASY (necessary) direction of Legendre three-square — no full Legendre needed, just squares ≡ 0/1/4 mod 8 and no three summing to 7 mod 8, a decide over ZMod 8."
     ],
     "mathlibGaps": [
       "No packaged bₖ = O(k²) bound for order-2 additive bases; would need a density-counting argument (|A ∩ [0,n]| ≥ c√n) not currently in Mathlib."
     ],
     "nextSteps": [
-      "The b_k = O(k^2) upper bound for order-2 bases (relate the increasing enumeration to a counting/pigeonhole argument).",
-      "Show squares are NOT an order-3 basis via the infinitude of 4^a(8b+7) (needs Legendre three-square theorem — check Mathlib availability).",
-      "Relate HasGrowthLimit to boundedness/monotone behaviour of the enumeration b."
+      "The b_k = O(k^2) upper bound for order-2 bases (increasing enumeration ↔ counting/pigeonhole).",
+      "Relate HasGrowthLimit to boundedness/monotone behaviour of the enumeration b.",
+      "Full Legendre three-square (n is sum of 3 squares iff n ≠ 4^a(8b+7)) — the converse direction, deep; check Mathlib."
     ],
     "markdown": "# Knowledge Base: erdos-326-wip-01\n\n## Session 2026-07-20 (researcher-1) — foundational additive-basis / growth-ratio scaffolding\n\n**Mode**: FRESH (EMPTY node). **Outcome**: progress — VERIFIED axiom-free (`[propext, Classical.choice, Quot.sound]`), 0 sorry / 0 axiom. Host-verified (Mathlib-only parent): fresh-built `Erdos326Problem.olean` then `lake env lean` on the child (no Docker).\n\n### What I did\nCreated `proofs/Proofs/Erdos326WIP01.lean` (12 theorems) on the additive-basis predicates and the growth ratio:\n- **Monotonicity**: `IsAddBasisOfOrder.mono_order` (raise the order), `IsAddBasisOfOrder.mono_set` and `IsAddBasis.mono` (enlarge the set).\n- **Extremal cases**: `isAddBasisOfOrder_univ_one` / `isAddBasis_univ` (`ℕ` is an order-1 basis); `not_isAddBasis_empty`, `not_isAddBasisOfOrder_zero`.\n- **Growth ratio**: `growthRatio_nonneg`, `growthRatio_zero`, `HasGrowthLimit.unique`, `HasGrowthLimit.not_hasNoGrowthLimit`, `hasNoGrowthLimit_iff`.\n\n### Key findings\n- The basis predicates form a monotone lattice in (order, set) — the atomic order theory for any basis-comparison argument.\n- Order 0 / the empty set are degenerate non-bases; substantive work is at order ≥ 1.\n\n### Reusable Lean recipe\n- Destructure the order predicate: `obtain ⟨N, hN⟩ := h; obtain ⟨m, hm, f, hf, hsum⟩ := hN n hn` (the `(_ : m ≤ k)` binder appears as `hm`).\n- Degenerate non-basis: pick `n = N+1`, split `Nat.eq_zero_or_pos k`; the `k=0` branch closes via `simp only [Fin.sum_univ_zero] at hsum; omega`, the `k>0` branch via `(Set.mem_empty_iff_false _).mp (hf ⟨0, hk⟩)`.\n- `growthRatio b 0 = 0`: `unfold growthRatio; simp` (`x/0 = 0`).\n- Limit uniqueness: `tendsto_nhds_unique` (atTop on ℕ is `NeBot`).\n\n### Next steps\n- Perfect squares as an order-4 basis (`Nat.sum_four_squares`).\n- The `bₖ = O(k²)` bound for order-2 bases.\n\n### Still open (unchanged)\nThe subset-basis oscillation question (Erdős #326) — deep; Cassels (1957) disproved only the `A = B` variant.\n"
   },


### PR DESCRIPTION
## Summary
Research session for `erdos-326-wip-01` (Erdős #326, additive bases). Pins the additive-basis order of the perfect squares to **exactly 4** by ruling out order 3 with the elementary mod-8 obstruction. Verified 0-axiom.

## Progress
Three new axiom-free lemmas in `proofs/Proofs/Erdos326WIP01.lean` (host-verified, Lean v4.31.0 via fresh-parent-olean; `#print axioms` = `[propext, Classical.choice, Quot.sound]`; theoremCount 15→18):

- **`mem_squares_mod_eight`** — every perfect square is `0`, `1`, or `4` modulo `8` (`∀ x : ZMod 8, x² ∈ {0,1,4}` by `decide`).
- **`not_isAddBasisOfOrder_squares_three`** — the squares are **not** an order-3 additive basis. If they were, `n = 8N+7 ≥ N` would be a sum of at most three squares; but mod 8 no sum of `≤3` elements of `{0,1,4}` equals `7`, while `8N+7 ≡ 7 (mod 8)`.
- **`not_isAddBasisOfOrder_squares_of_le_three`** — via `mono_order`, no order `≤ 3`; with `isAddBasisOfOrder_squares_four` (Lagrange) this makes the basis order exactly `4`.

## Findings
- Only the **easy (necessary) direction** of Legendre's three-square theorem is used — the finite mod-8 fact — so no deep number theory is required. The full Legendre theorem (`n` is a sum of three squares iff `n ≠ 4ᵃ(8b+7)`) is not needed here.
- This sharpens the existing `isAddBasisOfOrder_squares_four` from "order ≤ 4" to "order = 4".

## Status
**Outcome**: progress (extends the WIP node from 15 to 18 axiom-free theorems; pins a sharp value)
**Next Steps**: the `bₖ = O(k²)` growth bound for order-2 bases; relating `HasGrowthLimit` to boundedness of the enumeration. The parent oscillation question remains OPEN.

🤖 Generated by researcher-1