### PR TITLE
Research: erdos-89-wip-01 — first linear upper bound g(n) ≤ n−1 (0-axiom)

### DIFF
--- a/proofs/Proofs/Erdos89WIP01.lean
+++ b/proofs/Proofs/Erdos89WIP01.lean
@@ -56,6 +56,15 @@ first structural theorems.
 9. `minDistinctDistances_zero` / `minDistinctDistances_one` — the remaining low
    values `g(0) = g(1) = 0`, completing the exact table `g(0)=g(1)=0, g(2)=1`.
 
+10. `minDistinctDistances_le_pred` — **the first linear upper bound**
+   `g(n) ≤ n − 1`, via the explicit collinear arithmetic progression
+   `{(0,0), …, (n−1,0)}` (`apPoint`/`apSet`): its distances are exactly the
+   integers `1, …, n − 1`, so there are at most `n − 1` of them
+   (`dist_apPoint`, `apSet_card`, `apSet_distinctDistances_subset`). This
+   improves the worst-case `n.choose 2` ceiling to a linear one. The matching
+   lower bound `Ω(n/√(log n))` (Guth–Katz `Ω(n/log n)`) is genuinely deep and
+   stays an imported result.
+
 ## Summary: 0 sorries, 0 axioms, no `native_decide`. Built over the gallery defs.
 -/
 
@@ -236,5 +245,93 @@ theorem minDistinctDistances_one : minDistinctDistances 1 = 0 := by
       ≤ numDistinctDistances ({0} : Finset (EuclideanSpace ℝ (Fin 2))) :=
         minDistinctDistances_le_of_card_eq hcard
     _ = 0 := numDistinctDistances_eq_zero_of_card_le_one _ (by rw [hcard])
+
+/-! ## A linear upper bound: `g(n) ≤ n − 1`
+
+The prior results bound `g(n)` from above only by the quadratic `n.choose 2`
+(worst case) and pin the exact small values. To obtain a genuine **linear**
+upper bound we exhibit an explicit configuration whose distinct-distance count
+is at most `n − 1`: the collinear arithmetic progression
+`(0,0), (1,0), …, (n−1,0)`. Every distance is an integer in `{1, …, n−1}`, so
+there are at most `n − 1` of them. Together with monotonicity this shows Erdős's
+`g` grows at most linearly — the true growth is `Θ(n/√(log n))`, so `n − 1` is a
+correct (non-sharp) ceiling.
+
+The lower bound `Ω(n/√(log n))` (Guth–Katz's `Ω(n/log n)`) is genuinely deep and
+stays an imported result; this construction supplies the matching-shape upper
+witness on the elementary side. -/
+
+/-- The `i`-th point of the collinear arithmetic progression along the `x`-axis. -/
+noncomputable def apPoint (i : ℕ) : EuclideanSpace ℝ (Fin 2) := !₂[(i : ℝ), 0]
+
+/-- Distance between two progression points is the absolute difference of indices. -/
+theorem dist_apPoint (i j : ℕ) :
+    Erdos89.dist (apPoint i) (apPoint j) = |(i : ℝ) - j| := by
+  unfold Erdos89.dist
+  rw [← dist_eq_norm, apPoint, apPoint, EuclideanSpace.dist_eq, Fin.sum_univ_two]
+  simp only [Matrix.cons_val_zero, Matrix.cons_val_one, Real.dist_eq,
+    sub_self, abs_zero, ne_eq, OfNat.ofNat_ne_zero, not_false_eq_true, zero_pow, add_zero]
+  rw [Real.sqrt_sq_eq_abs, abs_abs]
+
+/-- The progression map is injective (points have distinct `x`-coordinates). -/
+theorem apPoint_injective : Function.Injective apPoint := by
+  intro i j h
+  have hd : |(i : ℝ) - j| = 0 := by
+    rw [← dist_apPoint, h]
+    simp [Erdos89.dist]
+  rw [abs_eq_zero, sub_eq_zero] at hd
+  exact_mod_cast hd
+
+/-- The `n`-point collinear arithmetic progression `{(0,0), …, (n−1,0)}`. -/
+noncomputable def apSet (n : ℕ) : Finset (EuclideanSpace ℝ (Fin 2)) :=
+  (Finset.range n).image apPoint
+
+/-- The progression set has exactly `n` points. -/
+theorem apSet_card (n : ℕ) : (apSet n).card = n := by
+  rw [apSet, Finset.card_image_of_injective _ apPoint_injective, Finset.card_range]
+
+/-- Every distance in the progression is an integer in `{1, …, n−1}`. -/
+theorem apSet_distinctDistances_subset (n : ℕ) :
+    distinctDistances (apSet n)
+      ⊆ (Finset.Icc 1 (n - 1)).image (fun k : ℕ => (k : ℝ)) := by
+  rw [distinctDistances_eq_image]
+  intro d hd
+  rw [Finset.mem_image] at hd
+  obtain ⟨⟨p1, p2⟩, hpq, rfl⟩ := hd
+  rw [Finset.mem_offDiag] at hpq
+  obtain ⟨h1, h2, hne⟩ := hpq
+  rw [apSet, Finset.mem_image] at h1 h2
+  obtain ⟨a, ha, rfl⟩ := h1
+  obtain ⟨b, hb, rfl⟩ := h2
+  rw [Finset.mem_range] at ha hb
+  have hab : a ≠ b := fun h => hne (by rw [h])
+  rw [dist_apPoint]
+  -- The value `|a − b|` equals the natural number `((a : ℤ) − b).natAbs`.
+  have hval : |(a : ℝ) - b| = (((a : ℤ) - b).natAbs : ℝ) := by
+    rw [Nat.cast_natAbs]
+    push_cast; ring
+  rw [hval, Finset.mem_image]
+  refine ⟨((a : ℤ) - b).natAbs, ?_, rfl⟩
+  rw [Finset.mem_Icc]
+  refine ⟨?_, ?_⟩
+  · -- `1 ≤ |a − b|` since `a ≠ b`.
+    omega
+  · -- `|a − b| ≤ n − 1` since `a, b < n`.
+    omega
+
+/-- **Linear upper bound on Erdős's function.** `g(n) ≤ n − 1`: the collinear
+arithmetic progression `{(0,0), …, (n−1,0)}` is an `n`-point set whose `n − 1`
+distinct distances are exactly the integers `1, …, n − 1`. This is the first
+non-quadratic upper bound in the file (improving the worst-case `n.choose 2`),
+and matches the `g(0) = g(1) = 0`, `g(2) = 1` table at the base. -/
+theorem minDistinctDistances_le_pred (n : ℕ) : minDistinctDistances n ≤ n - 1 := by
+  calc minDistinctDistances n
+      ≤ numDistinctDistances (apSet n) :=
+        minDistinctDistances_le_of_card_eq (apSet_card n)
+    _ = (distinctDistances (apSet n)).card := rfl
+    _ ≤ ((Finset.Icc 1 (n - 1)).image (fun k : ℕ => (k : ℝ))).card :=
+        Finset.card_le_card (apSet_distinctDistances_subset n)
+    _ ≤ (Finset.Icc 1 (n - 1)).card := Finset.card_image_le
+    _ = n - 1 := by rw [Nat.card_Icc]; omega
 
 end Erdos89

--- a/research/problems/erdos-89-wip-01/knowledge.md
+++ b/research/problems/erdos-89-wip-01/knowledge.md
@@ -73,3 +73,38 @@ Quot.sound]`. Now 7 theorems, 0 sorry, 0 axiom.
 - Formalize the `√n × √n` grid upper bound feeding `minDistinctDistances_le_*`
   for a concrete `g(n) = O(n)` ceiling.
 - Guth–Katz `Ω(n/log n)` lower bound stays an imported assumption.
+
+## Session (researcher-1, 2026-07-20 #3) — first linear upper bound g(n) ≤ n−1
+
+Added the file's **first non-quadratic upper bound** on Erdős's function:
+`minDistinctDistances_le_pred : minDistinctDistances n ≤ n - 1`. Prior sessions
+bounded `g(n)` above only by the worst-case `n.choose 2` (quadratic); this pins
+the linear ceiling that (together with monotonicity) shows `g` grows at most
+linearly. The truth is `Θ(n/√(log n))`, so `n − 1` is a correct non-sharp ceiling.
+
+Construction (all axiom-free, host-verified `bin/lake env lean` exit 0,
+`#print axioms` = `[propext, Classical.choice, Quot.sound]`):
+- `apPoint i := !₂[(i:ℝ), 0]` — the collinear AP along the x-axis.
+- `dist_apPoint : Erdos89.dist (apPoint i) (apPoint j) = |(i:ℝ) − j|`. Since the
+  gallery `dist` is `‖·−·‖`, rewrite `← dist_eq_norm` to the metric, then
+  `EuclideanSpace.dist_eq` + `Fin.sum_univ_two`; the y-coordinate term vanishes
+  (`sub_self`/`abs_zero`/`zero_pow`), leaving `√(|i−j|²) = |i−j|`
+  (`Real.sqrt_sq_eq_abs`, `abs_abs`).
+- `apPoint_injective` via `dist_apPoint` (distance 0 ⟹ equal indices), so
+  `apSet_card : (apSet n).card = n`.
+- `apSet_distinctDistances_subset` — every distance `|a−b|` (a,b<n, a≠b) equals
+  `((a:ℤ)−b).natAbs ∈ [1, n−1]` (`Nat.cast_natAbs` bridges `|(a:ℝ)−b|` to the nat;
+  bounds by `omega` — omega handles `Int.natAbs`), so the distance set embeds in
+  `(Finset.Icc 1 (n−1)).image (↑·)`, of card `≤ n−1`.
+
+Gotcha: inside `namespace Erdos89`, bare `dist` is `Erdos89.dist` (= ‖·−‖), NOT
+the metric — `EuclideanSpace.dist_eq` needs `_root_.dist`, reached via
+`← dist_eq_norm`. `Nat.cast_natAbs` (NOT `Int.cast_natAbs`, which does not exist)
+is the `(n.natAbs : α) = |↑n|` bridge.
+
+Now 20 theorems, 0 sorry, 0 axiom.
+
+### Next Steps
+- Sharpen toward `Θ(n/√(log n))` via the `√n × √n` grid — DEEP (needs the
+  number-theoretic count of distinct distances in a square integer grid).
+- Guth–Katz `Ω(n/log n)` lower bound stays an imported assumption.

--- a/src/data/research/problems/erdos-89-wip-01.json
+++ b/src/data/research/problems/erdos-89-wip-01.json
@@ -31,7 +31,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Erdos89WIP01.lean — proved g is nondecreasing (minDistinctDistances_mono: g(n)≤g(n+1) by deleting a point from an (n+1)-minimizer) plus subset-monotonicity of the distance set/count (distinctDistances_mono, numDistinctDistances_mono) and the base values g(0)=g(1)=0, completing the exact table g(0)=g(1)=0, g(2)=1. 15 theorems, 0 sorry, 0 axiom; #print axioms = [propext, Classical.choice, Quot.sound]. Guth–Katz lower bound and √n grid upper bound remain open.",
+    "progressSummary": "PROGRESS: g(n) now bracketed on the elementary side — exact small values g(0)=g(1)=0, g(2)=1, monotone, and a new linear upper bound g(n) ≤ n−1 via an explicit collinear AP construction (axiom-free). Only remaining upper-bound gap is the sharp √(log n) improvement (deep).",
     "builtItems": [
       "Erdos89.dist_pos_of_ne in Erdos89WIP01.lean",
       "Erdos89.distinctDistances_eq_image (filter redundant) in Erdos89WIP01.lean",
@@ -44,19 +44,26 @@
       "distinctDistances_mono / numDistinctDistances_mono (subset monotonicity) in Erdos89WIP01.lean (2026-07-20)",
       "exists_card_eq: an n-point set exists for every n (Infinite.exists_subset_card_eq)",
       "minDistinctDistances_mono: Monotone g (g nondecreasing) (2026-07-20)",
-      "minDistinctDistances_zero / _one: g(0)=g(1)=0 (2026-07-20)"
+      "minDistinctDistances_zero / _one: g(0)=g(1)=0 (2026-07-20)",
+      "apPoint/apSet: collinear AP point set in EuclideanSpace ℝ (Fin 2) (Erdos89WIP01.lean)",
+      "dist_apPoint: dist(apPoint i)(apPoint j) = |i−j| via EuclideanSpace.dist_eq + Fin.sum_univ_two + Nat.cast_natAbs (Erdos89WIP01.lean)",
+      "apPoint_injective + apSet_card: |apSet n| = n (Erdos89WIP01.lean)",
+      "apSet_distinctDistances_subset: distances ⊆ image of Icc 1 (n−1) (Erdos89WIP01.lean)",
+      "minDistinctDistances_le_pred: g(n) ≤ n−1, axiom-free (Erdos89WIP01.lean)"
     ],
     "insights": [
       "distinctDistances S filters (·>0) over the off-diagonal image, but every off-diagonal pair (p≠q) already has ‖p−q‖>0, so the filter is redundant: distinctDistances S = S.offDiag.image (dist · ·). This removes the awkward filter for all downstream cardinality reasoning.",
       "Counting envelope: numDistinctDistances S ≤ |S|·(|S|−1) via card_image_le + Finset.offDiag_card; and it vanishes iff too few points (|S|≤1 ⟹ 0, |S|≥2 ⟹ ≥1 via one_lt_card giving a distinct pair).",
       "minDistinctDistances n = sInf over n-point sets is bounded above by any single n-point witness (Nat.sInf_le ⟨S, hcard, rfl⟩) — the membership hook the √n×√n grid upper-bound construction ultimately supplies.",
       "The custom Erdos89.dist (‖p−q‖) is symmetric via norm_sub_rev, so it factors through Sym2; routing S.offDiag.image through Sym2.mk.uncurry and applying Sym2.card_image_offDiag gives the sharp ceiling numDistinctDistances S ≤ S.card.choose 2 (halving |S|·(|S|−1)). Same technique as erdos-98-wip-01.",
-      "The distinct-distances envelope is now an EQUALITY at the base: numDistinctDistances_eq_one_of_card_eq_two shows any 2-point set has exactly 1 distance (sharp ceiling 2.choose 2 = 1 meets the ≥1 floor), and minDistinctDistances_two gives the first exact value of Erdős g(n): g(2) = 1."
+      "The distinct-distances envelope is now an EQUALITY at the base: numDistinctDistances_eq_one_of_card_eq_two shows any 2-point set has exactly 1 distance (sharp ceiling 2.choose 2 = 1 meets the ≥1 floor), and minDistinctDistances_two gives the first exact value of Erdős g(n): g(2) = 1.",
+      "Linear upper bound g(n) ≤ n−1 (minDistinctDistances_le_pred): the collinear arithmetic progression {(0,0),…,(n−1,0)} has distances exactly {1,…,n−1}. First non-quadratic upper bound in the file (prior best was worst-case n.choose 2)."
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "g(3) = 1: exhibit an equilateral triangle (3 points, all pairwise distances equal) so numDistinctDistances = 1, matching the ≥1 floor — needs an explicit 3-point construction in EuclideanSpace ℝ (Fin 2) with card 3 and a single distance value.",
-      "A grid upper bound g(n) ≤ O(n/√(log n)) for the √n×√n grid (the Erdős extremal candidate) — substantial, needs lattice distance-counting."
+      "Sharpen upper bound toward g(n) = Θ(n/√(log n)) via the √n×√n grid (deep: needs number-theoretic count of distinct distances in a square grid).",
+      "Lower bound Ω(n/log n) (Guth–Katz) stays an imported assumption.",
+      "Connect singlePointConjecture (#604) to the global count."
     ],
     "markdown": "# Knowledge Base: erdos-89-wip-01\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },


### PR DESCRIPTION
## Summary
Research session for **erdos-89-wip-01** (Erdős #89, distinct distances). Adds the
file's **first non-quadratic upper bound** on the extremal function
`g(n) = minDistinctDistances n`.

## Progress
`minDistinctDistances_le_pred : minDistinctDistances n ≤ n - 1`, proved via an
explicit collinear arithmetic progression `{(0,0), …, (n−1,0)}`:

- `apPoint i := !₂[(i:ℝ), 0]`, `apSet n := (range n).image apPoint`
- `dist_apPoint`: `dist (apPoint i) (apPoint j) = |i − j|`
  (`EuclideanSpace.dist_eq` + `Fin.sum_univ_two` + `Nat.cast_natAbs`)
- `apPoint_injective`, `apSet_card`: `|apSet n| = n`
- `apSet_distinctDistances_subset`: all distances lie in `{1, …, n−1}`
- `minDistinctDistances_le_pred`: `g(n) ≤ n − 1`

This improves the prior worst-case `n.choose 2` ceiling to a **linear** one, and
is consistent with the exact base table `g(0)=g(1)=0, g(2)=1` already in the file.

## Findings
- Inside `namespace Erdos89`, bare `dist` is the gallery `Erdos89.dist = ‖·−·‖`,
  not the metric — `EuclideanSpace.dist_eq` requires rewriting `← dist_eq_norm`
  first. The `(n.natAbs : α) = |↑n|` bridge is `Nat.cast_natAbs` (not
  `Int.cast_natAbs`, which does not exist). `omega` discharges the `Int.natAbs`
  index bounds.
- The matching lower bound `Ω(n/√(log n))` (Guth–Katz `Ω(n/log n)`) is genuinely
  deep and stays an imported assumption; the sharp `√(log n)` improvement of this
  upper bound (via the `√n × √n` grid) requires the number-theoretic count of
  distinct distances in a square integer grid.

## Verification
Host-verified `bin/lake env lean Proofs/Erdos89WIP01.lean` (exit 0, no warnings);
`#print axioms` on the new theorems = `[propext, Classical.choice, Quot.sound]`
— axiom-free, no `native_decide`, no `sorryAx`. File now 20 theorems, 0 sorry,
0 axiom.

## Status
**Outcome**: progress (upper-bound envelope on Erdős's g(n) extended from
quadratic to linear; parent conjecture #89 remains OPEN)
**Next Steps**: sharpen toward `Θ(n/√(log n))` via the grid (deep); lower bound
stays imported.

🤖 Generated by researcher-1