### PR TITLE
Enrich erdos-1098-oq-01-oq-03 (Neumann's theorem, non-commuting graph): re-anchor drifted+undercovering sections 7→13

### DIFF
--- a/src/data/proofs/erdos-1098-oq-01-oq-03/meta.json
+++ b/src/data/proofs/erdos-1098-oq-01-oq-03/meta.json
@@ -60,57 +60,105 @@
       "id": "sec-overview",
       "title": "Overview: Erdős #1098 — Neumann's theorem ω(Γ(G)) finite ⟺ [G:Z(G)] finite",
       "startLine": 1,
-      "endLine": 74,
-      "summary": "In the non-commuting graph Γ(G) (vertices = group elements, edges = non-commuting pairs) a clique is a set of pairwise non-commuting elements and ω(Γ(G)) is the clique number. Erdős asked whether every group with all such cliques finite must have a centre of finite index; B. H. Neumann (1976) proved yes, and the converse is elementary — Neumann's theorem: ω(Γ(G)) finite ⟺ [G:Z(G)] finite. The file formalizes `BoundedCliques G` and proves: the easy direction FULLY (every clique injects into G⧸Z(G), giving the sharp bound ω ≤ [G:Z(G)]), plus the first two steps of Neumann's hard direction — a single maximal clique's centralizers cover G (`exists_clique_centralizer_cover`), and via Mathlib's coset-covering theorem `CosetCover` some centralizer has finite index (`exists_finiteIndex_centralizer_of_boundedCliques`). The final BFC step (one finite-index centralizer ⇒ finite-index centre) remains the single clearly-labelled axiom `neumann_hard_direction`, unavailable in Mathlib. 0 sorries, 1 axiom; status: honestly axiomatized.",
-      "mathContext": "The bridge between clique number and central index is the quotient G → G⧸Z(G): if a⁻¹b ∈ Z(G) then a and b commute, so non-commuting elements land in distinct central cosets and any clique injects into G⧸Z(G) — instantly giving the sharp bound ω ≤ [G:Z(G)]. Neumann's deep converse uses that a maximal clique's centralizers cover G (a group is never the union of finitely many proper-finite-index subgroups unless one has finite index — B. H. Neumann's coset-covering theorem), reducing to a single finite-index centralizer; the remaining descent to a finite-index centre is the genuine BFC (bounded finite conjugacy) content axiomatized here."
+      "endLine": 100,
+      "summary": "In the non-commuting graph Γ(G) (vertices = group elements, edges = non-commuting pairs) a clique is a set of pairwise non-commuting elements and ω(Γ(G)) is the clique number. Erdős asked whether every group with all such cliques finite must have a centre of finite index; B. H. Neumann (1976) proved yes, and the converse is elementary — Neumann's theorem: ω(Γ(G)) finite ⟺ [G:Z(G)] finite. This header docstring frames the result, the axiomatized status, and the Mathlib imports (Center, Centralizer, Index, Commutator.Finite, Schreier, CosetCover, QuotientGroup) the proof draws on.",
+      "mathContext": "The bridge between clique number and central index is the quotient G → G⧸Z(G): if a⁻¹b ∈ Z(G) then a and b commute, so non-commuting elements land in distinct central cosets and any clique injects into G⧸Z(G) — giving the sharp bound ω ≤ [G:Z(G)]. Neumann's deep converse uses that a maximal clique's centralizers cover G, reducing to a single finite-index centralizer; the remaining descent to a finite-index centre is the genuine BFC (bounded finite conjugacy) content axiomatized here."
     },
     {
       "id": "definitions",
-      "title": "Definitions",
-      "startLine": 75,
-      "endLine": 89,
-      "summary": "nonCommuting, IsClique, and BoundedCliques (ω(Γ(G)) finite as a uniform clique-size bound).",
-      "mathContext": "BoundedCliques G := ∃ B, ∀ S, IsClique S → S.card ≤ B"
+      "title": "Section I — Definitions and graph basics",
+      "startLine": 101,
+      "endLine": 133,
+      "summary": "The core definitions nonCommuting, IsClique, and BoundedCliques (ω(Γ(G)) finite as a uniform clique-size bound), plus the basic graph facts that Γ(G) is undirected (nonCommuting symmetric), loop-free (irreflexive), and its edges are exactly the non-commuting pairs.",
+      "mathContext": "$\\mathrm{BoundedCliques}\\,G := \\exists B,\\ \\forall S,\\ \\mathrm{IsClique}\\,S \\to |S| \\le B$; the edge relation $g*h \\ne h*g$ is symmetric and irreflexive."
     },
     {
       "id": "coset-separation",
-      "title": "Cosets of the centre separate non-commuting elements",
-      "startLine": 90,
-      "endLine": 117,
-      "summary": "commuting_of_invMul_mem_center, nonCommuting_distinct_image, and clique_inj_on_quotient: the quotient map G → G/Z(G) is injective on any clique.",
-      "mathContext": "a⁻¹*b ∈ Z(G) ⟹ a*b = b*a; contrapositive gives distinct images in G/Z(G)"
+      "title": "Section II — Cosets of the centre separate non-commuting elements",
+      "startLine": 134,
+      "endLine": 162,
+      "summary": "commuting_of_invMul_mem_center, the distinct-image lemma, and clique_inj_on_quotient: the quotient map G → G/Z(G) is injective on any clique, the key bridge to the easy direction.",
+      "mathContext": "$a^{-1}b \\in Z(G) \\Rightarrow ab = ba$; contrapositive gives distinct images in $G/Z(G)$, so a clique injects into the quotient."
     },
     {
       "id": "easy-direction",
-      "title": "Easy direction — finite index bounds the clique number",
-      "startLine": 119,
-      "endLine": 150,
-      "summary": "clique_card_le_index (every clique has size ≤ [G:Z(G)], sharp) and bounded_cliques_of_finite_index, both fully proved.",
-      "mathContext": "Inject clique into finite quotient G/Z(G); S.card ≤ Nat.card(G/Z(G)) = (center G).index"
+      "title": "Section III — Easy direction: finite index bounds the clique number",
+      "startLine": 163,
+      "endLine": 205,
+      "summary": "clique_card_le_index (every clique has size ≤ [G:Z(G)], sharp), bounded_cliques_of_finite_index (finite central index ⟹ bounded cliques), and boundedCliques_of_finite (the base case: every finite group has bounded cliques) — all fully proved, axiom-free.",
+      "mathContext": "Inject a clique into the finite quotient $G/Z(G)$: $|S| \\le \\mathrm{Nat.card}(G/Z(G)) = [G:Z(G)]$."
     },
     {
       "id": "centralizer-cover",
-      "title": "First step of the hard direction — the centralizer cover",
-      "startLine": 152,
-      "endLine": 232,
-      "summary": "exists_clique_centralizer_cover (a maximal clique's centralizers cover G) and exists_finiteIndex_centralizer_of_boundedCliques (some centralizer has finite index, via Mathlib's CosetCover) — both fully proved, the first two steps of Neumann's hard direction.",
-      "mathContext": "Pick a max-cardinality clique S (Nat.sSup_mem on the bounded set of clique sizes). If g commuted with no a∈S then insert g S is a larger clique — contradiction; so the C_G(a), a∈S, cover G. As left cosets 1·C_G(a) this is a coset cover, and Subgroup.exists_finiteIndex_of_leftCoset_cover (B. H. Neumann) gives one finite-index centralizer."
+      "title": "Section III.5a — First step of the hard direction: the centralizer cover",
+      "startLine": 206,
+      "endLine": 288,
+      "summary": "exists_clique_centralizer_cover (the centralizers of a maximal clique cover G) and exists_finiteIndex_centralizer_of_boundedCliques (hence some centralizer has finite index, via Mathlib's CosetCover / Neumann's coset-covering theorem) — both fully proved.",
+      "mathContext": "Pick a maximum clique S (Nat.sSup_mem on the bounded set of clique sizes). If g commuted with no a ∈ S then insert g S would be a larger clique — contradiction; so $\\{C_G(a) : a \\in S\\}$ cover G, and Subgroup.exists_finiteIndex_of_leftCoset_cover yields one finite-index centralizer."
+    },
+    {
+      "id": "finite-index-core",
+      "title": "Section III.5b — Refinement to a finite-index core",
+      "startLine": 289,
+      "endLine": 387,
+      "summary": "Strengthens the covering step: exists_finiteIndex_iInf_centralizer_of_boundedCliques (a finite intersection of centralizers, itself finite index), center_le_centralizer_singleton (Z(G) ⊆ C_G(a)), and center_finiteIndex_iff_relIndex_core, which localizes the residual gap to whether Z(G) has finite relative index in a finite-index centralizer core.",
+      "mathContext": "$Z(G) \\le \\bigcap_{a\\in S} C_G(a)$; the residual gap is the finite relative index of the centre inside a finite-index core $\\bigcap_a C_G(a)$."
     },
     {
       "id": "neumann-axiom",
-      "title": "Hard direction — Neumann's theorem (axiom)",
-      "startLine": 234,
-      "endLine": 252,
-      "summary": "neumann_hard_direction: bounded cliques ⟹ finite centre index (Neumann 1976), stated as a cited axiom.",
-      "mathContext": "BoundedCliques G → (Subgroup.center G).index ≠ 0"
+      "title": "Section IV — Hard direction: Neumann's theorem (axiom)",
+      "startLine": 388,
+      "endLine": 406,
+      "summary": "neumann_hard_direction: bounded cliques ⟹ finite centre index (B. H. Neumann 1976), stated as a single clearly-cited axiom — the genuine BFC content unavailable in Mathlib. This is the sole assumption in the file (axiomCount 1, status axiomatized).",
+      "mathContext": "$\\mathrm{BoundedCliques}\\,G \\to (\\mathrm{center}\\,G).\\mathrm{index} \\ne 0$."
     },
     {
       "id": "full-theorem",
-      "title": "Neumann's full theorem",
-      "startLine": 254,
-      "endLine": 279,
-      "summary": "neumann_full_theorem (the equivalence) and abelian_bounded_cliques (sanity check via center_eq_top).",
-      "mathContext": "BoundedCliques G ↔ (Subgroup.center G).index ≠ 0"
+      "title": "Section V — Neumann's full theorem (the equivalence)",
+      "startLine": 407,
+      "endLine": 422,
+      "summary": "neumann_full_theorem: combining the fully-proved easy direction with the axiomatized hard direction gives the equivalence ω(Γ(G)) finite ⟺ [G:Z(G)] finite.",
+      "mathContext": "$\\mathrm{BoundedCliques}\\,G \\leftrightarrow (\\mathrm{center}\\,G).\\mathrm{index} \\ne 0$."
+    },
+    {
+      "id": "abelian-commutativity",
+      "title": "Corollaries — abelian groups and the commutativity characterization",
+      "startLine": 423,
+      "endLine": 461,
+      "summary": "abelian_bounded_cliques (abelian groups have bounded — in fact trivial — cliques, via center_eq_top) and clique_card_le_one_iff_comm (Γ(G) is edgeless, i.e. every clique has size ≤ 1, exactly when G is commutative).",
+      "mathContext": "$G$ abelian $\\Rightarrow Z(G) = G$, index 1; and $\\omega(\\Gamma(G)) \\le 1 \\iff G$ is commutative."
+    },
+    {
+      "id": "heredity",
+      "title": "Heredity — subgroups, quotients, and homomorphisms",
+      "startLine": 462,
+      "endLine": 580,
+      "summary": "Closure properties of BoundedCliques: boundedCliques_of_subgroup (passes to subgroups), boundedCliques_of_surjective and boundedCliques_quotient (passes to surjective images / quotients, ω(Γ(G/N)) ≤ ω(Γ(G))), and boundedCliques_of_injective (pulls back along any injective homomorphism).",
+      "mathContext": "The class of groups with $\\omega(\\Gamma)$ finite is closed under subgroups, quotients, and injective/surjective homomorphic images."
+    },
+    {
+      "id": "axiom-free-special-cases",
+      "title": "Axiom-free hard direction for finite / finite-commutator groups",
+      "startLine": 581,
+      "endLine": 675,
+      "summary": "The hard direction proved unconditionally (axiom-free) in special cases: neumann_hard_direction_of_finite (finite G), neumann_hard_direction_of_finite_commutatorSet (finite commutator set), finite_commutatorSet_iff_finite_commutator (canonical finite-derived-subgroup form), and neumann_hard_direction_of_finite_commutator (finite derived subgroup) — isolating exactly where the Neumann axiom is genuinely needed.",
+      "mathContext": "When $G$ is finite, or its commutator set / derived subgroup $[G,G]$ is finite, bounded cliques force finite central index with no axiom (Schur–BFC machinery available in Mathlib)."
+    },
+    {
+      "id": "iso-products",
+      "title": "Isomorphism invariance and direct products",
+      "startLine": 676,
+      "endLine": 778,
+      "summary": "boundedCliques_congr (BoundedCliques is a group-isomorphism invariant), boundedCliques_prod_of_finiteIndex, boundedCliques_of_prod_left / _right (each factor inherits from a product), and boundedCliques_prod_iff (the class is exactly closed under finite direct products).",
+      "mathContext": "$G \\simeq K \\Rightarrow (\\mathrm{BoundedCliques}\\,G \\leftrightarrow \\mathrm{BoundedCliques}\\,K)$, and $\\mathrm{BoundedCliques}(G \\times K) \\leftrightarrow \\mathrm{BoundedCliques}\\,G \\wedge \\mathrm{BoundedCliques}\\,K$."
+    },
+    {
+      "id": "schur",
+      "title": "Schur's theorem — unconditional easy direction",
+      "startLine": 779,
+      "endLine": 793,
+      "summary": "boundedCliques_of_finite_commutatorSet: Schur's theorem gives, axiom-free, that a finitely generated group with finite derived subgroup has bounded cliques — the easy direction obtained unconditionally in this regime.",
+      "mathContext": "Schur: finite $[G,G]$ (with the group finitely generated) $\\Rightarrow [G:Z(G)]$ finite $\\Rightarrow$ bounded cliques, no axiom."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Enrichment pass for `erdos-1098-oq-01-oq-03`

**Genuine grown-file undercoverage + section drift.** The primary Lean file `Proofs/Erdos1098OQ01OQ03.lean` is 793 lines, but `sections` stopped at line 279 (7 sections) **and** the head sections were drifted:
- the "Neumann axiom" section was anchored at 234–252, but `axiom neumann_hard_direction` is actually at **line 404**;
- the "full theorem" section at 254–279, but `neumann_full_theorem` is at **line 419**;
- "Definitions" claimed 75–89, but the defs are at 105–114 (the header docstring alone runs 1–83).

### What changed
Re-anchored `sections` to contiguous **1..793** coverage (7 → 13), aligned to the file's own `-- SECTION N:` banners and the thematic clusters of the large unbannered tail. Corrected the drifted head boundaries and added coverage for lines 280–793:

| Lines | Section | Content |
|-------|---------|---------|
| 289–387 | Finite-index core refinement | `exists_finiteIndex_iInf_centralizer`, `center_le_centralizer_singleton`, `center_finiteIndex_iff_relIndex_core` |
| 388–406 | Neumann axiom | `axiom neumann_hard_direction` (the sole assumption) |
| 407–422 | Full theorem | `neumann_full_theorem` (the equivalence) |
| 423–461 | Abelian + commutativity | `abelian_bounded_cliques`, `clique_card_le_one_iff_comm` |
| 462–580 | Heredity | subgroups / quotients / injective+surjective homs |
| 581–675 | Axiom-free special cases | finite / finite-commutator-set / finite derived subgroup |
| 676–778 | Iso-invariance & products | `boundedCliques_congr`, `boundedCliques_prod_iff`, projections |
| 779–793 | Schur | `boundedCliques_of_finite_commutatorSet` |

### Verification
- Section boundaries contiguous 1..793, no gaps/overlaps; aligned to `-- SECTION` banners.
- `meta.json` 16.8 KB — well under the 60 KB cap; only the `sections` array changed.
- `pnpm build` passes gallery data generation + search-index checks ("Search index checks passed"; entry re-generated cleanly). The gallery-wide annotation-line warnings are pre-existing across the whole gallery and untouched here.
- **Axiom integrity preserved**: entry remains `status: axiomatized`, `badge: axiom`, `axiomCount: 1` — the single cited `neumann_hard_direction` axiom (line 404) is now explicitly its own section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)