### PR TITLE
Research: erdos-818 — axiom-free product-set lower bound |A| ≤ |A·A| (completes Part II)

### DIFF
--- a/proofs/Proofs/Erdos818Problem.lean
+++ b/proofs/Proofs/Erdos818Problem.lean
@@ -123,6 +123,36 @@ theorem sumset_lower_bound (A : Finset ℤ) (hne : A.Nonempty) :
   rw [sumset_eq_add, two_mul]
   exact cauchy_davenport_add_of_linearOrder_isCancelAdd hne hne
 
+/--
+**Product set lower bound (proved):** `|A| ≤ |A · A|` for any `A ⊆ ℤ` containing a
+nonzero element.
+
+This is the multiplicative analogue of `sumset_lower_bound`, completing the
+comment-only "Lower bound on product set" of Part II. Fix a nonzero `a₀ ∈ A`;
+since `ℤ` is an integral domain, `a ↦ a₀ · a` is injective (`mul_left_cancel₀`),
+and it maps `A` into the product set `A · A` (each `a₀ · a` is the product of two
+elements of `A`). Hence `|A| = |a₀ · A| ≤ |A · A|`. Axiom-free.
+
+The nonzero hypothesis is necessary: for `A = {0}`, `A · A = {0}`, so `|A| = 1`
+holds, but for e.g. `A = {0}` the injection argument needs the nonzero pivot; a
+set can fail to have a nonzero element only when `A ⊆ {0}`, where the bound is
+still trivially true but not via this cancellation route.
+-/
+theorem productSet_lower_bound (A : Finset ℤ) {a₀ : ℤ} (ha₀ : a₀ ∈ A)
+    (hne : a₀ ≠ 0) :
+    A.card ≤ (productSet A).card := by
+  have hinj : Set.InjOn (fun a => a₀ * a) A :=
+    fun x _ y _ h => mul_left_cancel₀ hne h
+  calc A.card
+      = (A.image (fun a => a₀ * a)).card := (Finset.card_image_of_injOn hinj).symm
+    _ ≤ (productSet A).card := by
+        apply Finset.card_le_card
+        intro x hx
+        simp only [Finset.mem_image] at hx
+        obtain ⟨a, ha, rfl⟩ := hx
+        rw [productSet, Finset.mem_image]
+        exact ⟨(a₀, a), Finset.mem_product.mpr ⟨ha₀, ha⟩, rfl⟩
+
 /-
 ## Part III: The Original Conjecture
 -/

--- a/research/problems/erdos-818-incomplete-01/knowledge.md
+++ b/research/problems/erdos-818-incomplete-01/knowledge.md
@@ -69,3 +69,27 @@ Cleaned `proofs/Proofs/Erdos818Aristotle.lean` (imports Mathlib only):
 The main file (`Erdos818Problem.lean`) is untouched: its `solymosi_theorem`
 axiom and `proof_outline` sorry are both genuine deep external inputs (Solymosi
 2009), not session-eliminable.
+
+## Session 2026-07-20 (researcher-1) — product-set lower bound
+
+**Mode**: continue. **Outcome**: progress — host-verified, axiom-free, no Docker.
+
+Added `productSet_lower_bound` to `Erdos818Problem.lean` (Part II): for `A ⊆ ℤ`
+with a nonzero element `a₀ ∈ A`, `|A| ≤ |A · A|`. This is the multiplicative
+analogue of the already-proved `sumset_lower_bound` and fills the previously
+comment-only "Lower bound on product set" of Part II. Proof: `a ↦ a₀ · a` is
+injective on ℤ (domain, `mul_left_cancel₀`), and maps `A` into `A · A`, so
+`|A| = |a₀·A| ≤ |A·A|`. `#print axioms` = `[propext, Classical.choice, Quot.sound]`
+(axiom-free by project convention). File still compiles with only the
+pre-existing `proof_outline` sorry warning.
+
+**Saturation note.** With both Part II trivial bounds now proved, the file's
+elementary content is exhausted. The two remaining items are research-depth and
+unchanged:
+- axiom `solymosi_theorem` — Solymosi's multiplicative-energy upper bound
+  `E×(A) ≤ C·|A+A|²·log|A|`, not in Mathlib (dyadic pigeonhole on multiplicative
+  fibers; BUILD/BLOCKED tier).
+- sorry `proof_outline` — the sharp `1/(K·log|A|)` product-set bound, a
+  registered blocked route (`currentState.blockers`) requiring a materially new
+  mechanism (the standard energy argument yields only `1/(C·K²·log|A|)`, proved
+  axiom-free modulo the energy hypothesis as `product_lower_of_mult_energy`).

--- a/src/data/research/problems/erdos-818-incomplete-01.json
+++ b/src/data/research/problems/erdos-818-incomplete-01.json
@@ -35,17 +35,19 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Main file unchanged (1 deep axiom solymosi_theorem + 1 deep proof_outline sorry, both genuine external inputs not in Mathlib). This session cleaned the Erdos818Aristotle.lean companion: 3 sorries → 0, all axiom-free, host-verified. Notably mul_div_ge_div was FALSE as stated (fails for x<0) and now carries the required 0≤x hypothesis. multEnergy_ge_sq and the companion cauchy_schwarz_energy are now proved. The Solymosi energy inequality E×(A)≤C·|A+A|²·log|A| remains the single deep open external input.",
+    "progressSummary": "PROGRESS: Added productSet_lower_bound (|A|≤|A·A|, axiom-free) completing Part II's trivial-bounds section symmetrically with sumset_lower_bound. Elementary content of the file is now saturated. The two remaining deep items are unchanged and genuinely research-depth: the solymosi_theorem axiom (Solymosi's multiplicative-energy upper bound E×(A) ≤ C·|A+A|²·log|A|, not in Mathlib) and the proof_outline sorry (sharp K-linear product-set bound, a registered blocked route requiring a materially new mechanism).",
     "builtItems": [
       "sumset_eq_add (Erdos818Problem.lean): sumset A = A + A (pointwise), axiom-free.",
       "sumset_lower_bound (Erdos818Problem.lean): 2|A|-1 ≤ |A+A| for nonempty A⊆ℤ, via Mathlib cauchy_davenport_add_of_linearOrder_isCancelAdd; fills the previously comment-only Part II. Axiom-free.",
       "product_lower_of_mult_energy (Erdos818Problem.lean): from cauchy_schwarz_energy + hypothesis E×(A) ≤ C·|A+A|²·log|A|, proves |A·A| ≥ |A|²/(C·K²·log|A|) for |A+A| ≤ K·|A|. Axiom-free (propext/Choice/Quot only).",
-      "Erdos818Aristotle.lean companion: eliminated all 3 sorries (now 0). Fixed mul_div_ge_div (was FALSE without 0≤x); proved multEnergy_ge_sq (E×(A)≥|A|² via diagonal injection) and cauchy_schwarz_energy (E×(A)·|A·A|≥|A|⁴ via Finset.le_card_mul_mul_mulEnergy) + multEnergy_eq_mulEnergy. Host-verified, axiom-free (2026-07-20)."
+      "Erdos818Aristotle.lean companion: eliminated all 3 sorries (now 0). Fixed mul_div_ge_div (was FALSE without 0≤x); proved multEnergy_ge_sq (E×(A)≥|A|² via diagonal injection) and cauchy_schwarz_energy (E×(A)·|A·A|≥|A|⁴ via Finset.le_card_mul_mul_mulEnergy) + multEnergy_eq_mulEnergy. Host-verified, axiom-free (2026-07-20).",
+      "productSet_lower_bound (Erdos818Problem.lean): |A| ≤ |A·A| for A⊆ℤ containing a nonzero element — the multiplicative analogue of sumset_lower_bound, completing the comment-only product-set lower bound of Part II. Injection a↦a₀·a (mul_left_cancel₀, ℤ a domain) into A*A. Axiom-free (propext/Choice/Quot), host-verified under Mathlib v4.31 (2026-07-20)."
     ],
     "insights": [
       "The lone remaining sorry (proof_outline in Erdos818Problem.lean) is genuinely OPEN: its bound |A·A| ≥ |A|²/(K·log|A|) requires Solymosi's multiplicative-energy upper bound E×(A) ≤ C·|A+A|²·log|A|, which is not in Mathlib. It is NOT derivable from the file's solymosi_theorem axiom (absolute-constant form c·|A|²/log|A|), which would need c·K ≥ 1.",
       "Honest constant mismatch: substituting |A+A| ≤ K·|A| into Solymosi's energy bound E×(A) ≤ C·|A+A|²·log|A| yields |A·A| ≥ |A|²/(C·K²·log|A|) — a K² dependence — NOT the sharper K in proof_outline's stated 1/(K·log|A|). So proof_outline as stated is strictly stronger than the standard argument delivers and remains open.",
-      "The full Solymosi reduction (energy upper bound + Cauchy–Schwarz ⇒ product-set lower bound) is now machine-checked axiom-free, with the energy inequality passed as an explicit hypothesis rather than a new axiom — isolating the single genuine external input."
+      "The full Solymosi reduction (energy upper bound + Cauchy–Schwarz ⇒ product-set lower bound) is now machine-checked axiom-free, with the energy inequality passed as an explicit hypothesis rather than a new axiom — isolating the single genuine external input.",
+      "Part II now has both trivial bounds proved axiom-free: 2|A|-1 ≤ |A+A| (sumset_lower_bound, Cauchy–Davenport) and |A| ≤ |A·A| (productSet_lower_bound, domain injection). The deep content remains isolated: 1 axiom (solymosi_theorem energy inequality) + 1 open sorry (proof_outline sharp 1/(K·log|A|) form)."
     ],
     "mathlibGaps": [
       "Companion cauchy_schwarz_energy reuses Finset.le_card_mul_mul_mulEnergy (Mathlib) — the elementary CS energy bound IS in Mathlib; only Solymosi's energy UPPER bound is the missing deep input."


### PR DESCRIPTION
## Summary
Research session for `erdos-818-incomplete-01` (Erdős #818, product set lower bound for small sumsets).

## Progress
- **`productSet_lower_bound`** (new, `Erdos818Problem.lean`, Part II): for `A ⊆ ℤ` with a nonzero element `a₀ ∈ A`, `|A| ≤ |A·A|`. This is the multiplicative analogue of the already-proved `sumset_lower_bound` (`2|A|−1 ≤ |A+A|`) and fills the previously **comment-only** "Lower bound on product set" of Part II.
- Proof: `a ↦ a₀·a` is injective on `ℤ` (integral domain, `mul_left_cancel₀`) and maps `A` into the product set `A·A`, so `|A| = |a₀·A| ≤ |A·A|`.
- `#print axioms` = `[propext, Classical.choice, Quot.sound]` — **axiom-free** by project convention.
- Host-verified under Mathlib v4.31 (`lake env lean`, no Docker); file compiles with only the pre-existing `proof_outline` sorry warning.

## Findings
- With both Part II trivial bounds now proved, the file's **elementary content is saturated**. The two remaining items are research-depth and unchanged:
  - axiom `solymosi_theorem` — Solymosi's multiplicative-energy upper bound `E×(A) ≤ C·|A+A|²·log|A|`, not in Mathlib (dyadic pigeonhole on multiplicative fibers; BUILD/BLOCKED tier).
  - sorry `proof_outline` — the sharp `1/(K·log|A|)` product-set bound, a **registered blocked route** (`currentState.blockers`); the standard energy argument yields only `1/(C·K²·log|A|)`, already proved axiom-free modulo the energy hypothesis as `product_lower_of_mult_energy`.

## Status
**Outcome**: progress (1 axiom-free lemma; deep content unchanged/documented-open)
**Next Steps**: formalize Solymosi's energy inequality (only tractable path to eliminate the axiom / discharge the sorry) — substantial, not a single session.

🤖 Generated by researcher-1