### PR TITLE
Research: erdos-326-wip-01 — order-2 bases are quadratically dense (Key Observation 1, 0-axiom)

### DIFF
--- a/proofs/Proofs/Erdos326WIP01.lean
+++ b/proofs/Proofs/Erdos326WIP01.lean
@@ -220,4 +220,120 @@ theorem not_isAddBasisOfOrder_squares_of_le_three {k : ℕ} (hk : k ≤ 3) :
     ¬ IsAddBasisOfOrder Squares k :=
   fun h => not_isAddBasisOfOrder_squares_three (h.mono_order hk)
 
+/-! ## Order-2 bases are quadratically dense (Key Observation 1)
+
+The parent file records as *Key Observation 1* that any order-`2` additive basis
+must have density at least `√n` — there are `≥ c√n` elements up to `n`, hence the
+`k`-th element is `≤ Ck²`.  This is the elementary counting fact underlying the
+whole growth question of Erdős #326.  We formalize it here.
+
+The mechanism: every `m ∈ [N, n]` is a sum of at most two elements of `A`, each
+`≤ m ≤ n`.  Pad each representation to an ordered pair `(aₘ, bₘ)` with
+`aₘ + bₘ = m` and `aₘ, bₘ ∈ A ∪ {0}`.  Because the sum recovers `m`, the map
+`m ↦ (aₘ, bₘ)` is injective on `[N,n]`, so `[N,n]` injects into `(S ∪ {0})²`
+where `S ⊆ A ∩ [0,n]` collects the nonzero coordinates.  Hence
+`|[N,n]| ≤ (|S| + 1)²`, i.e. `|S| ≥ √(n+1−N) − 1`.  Axiom-free.  The deep
+oscillation dichotomy (the open part of #326) is untouched. -/
+
+/-- **An order-2 additive basis is quadratically dense.**  If `A` is an additive
+basis of order `2`, there is a threshold `N` such that for every `n ≥ N` some
+finite `S ⊆ A` of elements `≤ n` satisfies `|Icc N n| ≤ (|S| + 1)²`.  This is the
+counting bound behind the standard `bₖ = O(k²)` growth estimate (Key Observation
+1 of `Erdos326Problem`). -/
+theorem IsAddBasisOfOrder.two_quadratic_density {A : Set ℕ}
+    (h : IsAddBasisOfOrder A 2) :
+    ∃ N : ℕ, ∀ n : ℕ, N ≤ n →
+      ∃ S : Finset ℕ, ↑S ⊆ A ∧ (∀ s ∈ S, s ≤ n) ∧
+        (Finset.Icc N n).card ≤ (S.card + 1) ^ 2 := by
+  classical
+  obtain ⟨N, hN⟩ := h
+  -- For each `m ≥ N`, choose an ordered `0`-padded summand pair from `A ∪ {0}`.
+  have hpair : ∀ m : ℕ, N ≤ m → ∃ a b : ℕ,
+      a + b = m ∧ (a ∈ A ∨ a = 0) ∧ (b ∈ A ∨ b = 0) ∧ a ≤ m ∧ b ≤ m := by
+    intro m hm
+    obtain ⟨k, hk, f, hf, hsum⟩ := hN m hm
+    interval_cases k
+    · simp only [Fin.sum_univ_zero] at hsum
+      exact ⟨0, 0, by omega, Or.inr rfl, Or.inr rfl, by omega, by omega⟩
+    · simp only [Fin.sum_univ_one] at hsum
+      exact ⟨f 0, 0, by omega, Or.inl (hf 0), Or.inr rfl, by omega, by omega⟩
+    · rw [Fin.sum_univ_two] at hsum
+      exact ⟨f 0, f 1, hsum, Or.inl (hf 0), Or.inl (hf 1), by omega, by omega⟩
+  choose! a b hsum hmemA hmemB hlea hleb using hpair
+  refine ⟨N, fun n hn => ?_⟩
+  set imgs : Finset ℕ :=
+    (Finset.Icc N n).image a ∪ (Finset.Icc N n).image b with himgs
+  set T : Finset ℕ := insert 0 imgs with hTdef
+  have h0T : (0 : ℕ) ∈ T := Finset.mem_insert_self 0 imgs
+  refine ⟨T.erase 0, ?_, ?_, ?_⟩
+  · -- `S ⊆ A`
+    intro s hs
+    rw [Finset.mem_coe, Finset.mem_erase, hTdef, Finset.mem_insert, himgs,
+      Finset.mem_union] at hs
+    obtain ⟨hs0, hmem⟩ := hs
+    rcases hmem with h0 | hmem
+    · exact absurd h0 hs0
+    rcases hmem with hima | himb
+    · obtain ⟨m, hmIcc, rfl⟩ := Finset.mem_image.mp hima
+      rw [Finset.mem_Icc] at hmIcc
+      rcases hmemA m hmIcc.1 with h | h
+      · exact h
+      · exact absurd h hs0
+    · obtain ⟨m, hmIcc, rfl⟩ := Finset.mem_image.mp himb
+      rw [Finset.mem_Icc] at hmIcc
+      rcases hmemB m hmIcc.1 with h | h
+      · exact h
+      · exact absurd h hs0
+  · -- every element of `S` is `≤ n`
+    intro s hs
+    rw [Finset.mem_erase, hTdef, Finset.mem_insert, himgs, Finset.mem_union] at hs
+    obtain ⟨_, hmem⟩ := hs
+    rcases hmem with h0 | hmem
+    · omega
+    rcases hmem with hima | himb
+    · obtain ⟨m, hmIcc, rfl⟩ := Finset.mem_image.mp hima
+      rw [Finset.mem_Icc] at hmIcc
+      exact (hlea m hmIcc.1).trans hmIcc.2
+    · obtain ⟨m, hmIcc, rfl⟩ := Finset.mem_image.mp himb
+      rw [Finset.mem_Icc] at hmIcc
+      exact (hleb m hmIcc.1).trans hmIcc.2
+  · -- the cardinality bound
+    have hTcard : (T.erase 0).card + 1 = T.card := Finset.card_erase_add_one h0T
+    have hle : (Finset.Icc N n).card ≤ (T ×ˢ T).card := by
+      apply Finset.card_le_card_of_injOn (fun m => (a m, b m))
+      · intro m hm
+        rw [Finset.mem_coe, Finset.mem_Icc] at hm
+        rw [Finset.mem_coe, Finset.mem_product]
+        refine ⟨Finset.mem_insert_of_mem ?_, Finset.mem_insert_of_mem ?_⟩
+        · exact Finset.mem_union_left _
+            (Finset.mem_image.mpr ⟨m, Finset.mem_Icc.mpr hm, rfl⟩)
+        · exact Finset.mem_union_right _
+            (Finset.mem_image.mpr ⟨m, Finset.mem_Icc.mpr hm, rfl⟩)
+      · intro m1 hm1 m2 hm2 hEq
+        rw [Finset.mem_coe, Finset.mem_Icc] at hm1 hm2
+        simp only [Prod.mk.injEq] at hEq
+        have e1 := hsum m1 hm1.1
+        have e2 := hsum m2 hm2.1
+        omega
+    calc (Finset.Icc N n).card
+        ≤ (T ×ˢ T).card := hle
+      _ = T.card * T.card := Finset.card_product T T
+      _ = ((T.erase 0).card + 1) * ((T.erase 0).card + 1) := by rw [hTcard]
+      _ = ((T.erase 0).card + 1) ^ 2 := by ring
+
+/-- Counting-function form: for an order-2 basis there is a threshold `N` such
+that for every `n ≥ N` the witnessing finite subset `S ⊆ A` of elements `≤ n`
+satisfies `n + 1 − N ≤ (|S| + 1)²`.  Equivalently the number of basis elements
+used up to `n` is `≥ √(n+1−N) − 1`, the `√n` density behind `bₖ = O(k²)`. -/
+theorem IsAddBasisOfOrder.two_quadratic_density' {A : Set ℕ}
+    (h : IsAddBasisOfOrder A 2) :
+    ∃ N : ℕ, ∀ n : ℕ, N ≤ n →
+      ∃ S : Finset ℕ, ↑S ⊆ A ∧ (∀ s ∈ S, s ≤ n) ∧
+        n + 1 - N ≤ (S.card + 1) ^ 2 := by
+  obtain ⟨N, hN⟩ := h.two_quadratic_density
+  refine ⟨N, fun n hn => ?_⟩
+  obtain ⟨S, hS, hSn, hcard⟩ := hN n hn
+  rw [Nat.card_Icc] at hcard
+  exact ⟨S, hS, hSn, hcard⟩
+
 end Erdos326

--- a/research/problems/erdos-326-wip-01/knowledge.md
+++ b/research/problems/erdos-326-wip-01/knowledge.md
@@ -24,3 +24,41 @@ the full theorem (`n ≠ 4^a(8b+7) ⟺ sum of 3 squares`) is not needed and is d
 ### Remaining open
 - `b_k = O(k^2)` upper bound for order-2 bases; `HasGrowthLimit` ↔ enumeration boundedness.
 - Full Legendre three-square (converse) — deep, check Mathlib.
+
+## Session 2026-07-20 (researcher-1) — order-2 bases are quadratically dense (Key Observation 1)
+
+**Mode**: continue. **Outcome**: progress — host-verified, axiom-free, no Docker.
+
+Formalized the parent's *Key Observation 1* (`Erdos326Problem`: "any order-2 basis
+must have density ≥ O(√n) ⟹ bₖ = O(k²)"), previously prose-only. Added to
+`Erdos326WIP01.lean` (theoremCount 18→20):
+
+- `IsAddBasisOfOrder.two_quadratic_density` — for an order-2 basis `A`, `∃ N`,
+  `∀ n ≥ N`, `∃` finite `S ⊆ A` of elements `≤ n` with
+  `|Finset.Icc N n| ≤ (|S| + 1)²`.
+- `IsAddBasisOfOrder.two_quadratic_density'` — the counting-function form
+  `n + 1 − N ≤ (|S| + 1)²` (i.e. `|S| ≥ √(n+1−N) − 1`).
+
+Both `#print axioms` = `[propext, Classical.choice, Quot.sound]` (axiom-free).
+
+**Proof idea.** Every `m ∈ [N,n]` is a sum of `≤ 2` elements of `A`, each `≤ m ≤ n`.
+Pad to an ordered pair `(aₘ, bₘ)` with `aₘ + bₘ = m`, `aₘ, bₘ ∈ A ∪ {0}` (via
+`choose!` on a per-`m` existence lemma; `interval_cases k` on the `≤ 2` summand
+count). Since the sum recovers `m`, `m ↦ (aₘ, bₘ)` is injective on `[N,n]`
+(`Finset.card_le_card_of_injOn`, `omega`), so `[N,n]` injects into `(S ∪ {0})²`
+where `S = T.erase 0` collects the nonzero coordinates. Hence
+`|Icc N n| ≤ T.card² = (|S|+1)²` (`Finset.card_erase_add_one`, `Finset.card_product`).
+
+### Gotchas
+- `Finset.card_le_card_of_injOn`'s `hf`/`InjOn` goals use **Set-coe** membership
+  (`m ∈ ↑s`), so `rw [Finset.mem_coe, Finset.mem_Icc]` / `[Finset.mem_coe,
+  Finset.mem_product]` — a bare `Finset.mem_Icc` rewrite fails.
+- Host-verify: parent `Erdos326Problem.lean` is Mathlib-only → build its olean
+  fresh (`lake env lean -o .lake/build/lib/lean/Proofs/Erdos326Problem.olean`)
+  before compiling the child; the shipped pre-v4.31 olean is header-incompatible.
+
+### Remaining open (unchanged)
+- The oscillation dichotomy — must every order-2 basis contain a sub-basis with
+  `bₖ/k²` non-convergent — the OPEN part of #326 (structured blocker). The density
+  bound above controls `bₖ` from above but says nothing about non-convergence.
+- `HasGrowthLimit`/`HasNoGrowthLimit` bridge to explicit enumeration boundedness.

--- a/src/data/research/problems/erdos-326-wip-01.json
+++ b/src/data/research/problems/erdos-326-wip-01.json
@@ -44,7 +44,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (2026-07-20, researcher-1, VERIFIED 0-axiom host): pinned the additive-basis order of the squares to EXACTLY 4. not_isAddBasisOfOrder_squares_three (8N+7 obstruction, mod-8 decide) + not_isAddBasisOfOrder_squares_of_le_three + mem_squares_mod_eight. Sharpens isAddBasisOfOrder_squares_four (order 4 is tight, not just an upper bound). 18 axiom-free theorems. Deep growth content (b_k=O(k^2), oscillation) untouched.",
+    "progressSummary": "PROGRESS (2026-07-20, researcher-1, VERIFIED 0-axiom host): formalized Key Observation 1 of the parent — an order-2 additive basis is quadratically dense (IsAddBasisOfOrder.two_quadratic_density / '). For every n≥N there is a finite S⊆A of elements ≤n with |Icc N n| ≤ (|S|+1)², i.e. the counting function up to n is ≥√(n+1-N)-1 (the √n density behind b_k=O(k²)), via an injection of [N,n] into padded summand pairs. 20 axiom-free theorems. The deep oscillation dichotomy (the open part of #326) is untouched and remains a structured blocker.",
     "builtItems": [
       "IsAddBasisOfOrder.mono_order / .mono_set in Erdos326WIP01.lean",
       "IsAddBasis.mono",
@@ -54,14 +54,16 @@
       "HasGrowthLimit.unique, HasGrowthLimit.not_hasNoGrowthLimit, hasNoGrowthLimit_iff",
       "Squares (the set {m^2}), isAddBasisOfOrder_squares_four, isAddBasis_squares in Erdos326WIP01.lean (session 2, axiom-free [propext, Classical.choice, Quot.sound])",
       "IsAddBasisOfOrder.infinite (Erdos326WIP01.lean): a bounded-order additive basis is infinite, via Set.Finite.bddAbove + sum ≤ k·M ceiling (2026-07-20)",
-      "mem_squares_mod_eight, not_isAddBasisOfOrder_squares_three, not_isAddBasisOfOrder_squares_of_le_three in Erdos326WIP01.lean (0 axioms, 0 sorries; host-verified v4.31.0 via fresh-parent-olean; #print axioms clean)"
+      "mem_squares_mod_eight, not_isAddBasisOfOrder_squares_three, not_isAddBasisOfOrder_squares_of_le_three in Erdos326WIP01.lean (0 axioms, 0 sorries; host-verified v4.31.0 via fresh-parent-olean; #print axioms clean)",
+      "IsAddBasisOfOrder.two_quadratic_density + .two_quadratic_density' (Erdos326WIP01.lean): an order-2 additive basis is quadratically dense — ∃N, ∀n≥N ∃ finite S⊆A with elements ≤n and |Icc N n| ≤ (|S|+1)² (equivalently n+1-N ≤ (|S|+1)², so the counting function up to n is ≥√(n+1-N)-1). Formalizes the parent's stated Key Observation 1 behind b_k=O(k²). Proof: pad each m∈[N,n] to an ordered summand pair (a_m,b_m)∈(A∪{0})²; m↦(a_m,b_m) is injective (sum recovers m), so [N,n] injects into (S∪{0})². Axiom-free (propext/Choice/Quot), host-verified v4.31 via fresh-parent-olean (2026-07-20)."
     ],
     "insights": [
       "The basis predicates form a monotone lattice: raising the order or enlarging the set preserves the basis property — the atomic order theory underlying any basis-comparison argument.",
       "Order 0 and the empty set are degenerate non-bases (only 0 is representable), so all substantive work happens at order ≥ 1 with an infinite set.",
       "growthRatio b 0 = 0 by the ℝ junk convention x/0 = 0 — worth pinning so downstream limit arguments can ignore the k=0 term.",
       "The perfect squares are a concrete additive basis of order 4 (Lagrange four-square theorem, Nat.sum_four_squares) — the canonical non-vacuous witness for IsAddBasisOfOrder. Order 4 is the correct order: numbers of the form 4^a(8b+7) (e.g. 7,15,23,28) are never sums of three squares, so squares are not an order-3 basis (that stronger negative needs Legendre three-square, deeper).",
-      "The additive-basis order of the perfect squares is EXACTLY 4: Lagrange gives order 4, and order 3 fails because 8N+7 ≡ 7 mod 8 is never a sum of ≤3 squares. This is the EASY (necessary) direction of Legendre three-square — no full Legendre needed, just squares ≡ 0/1/4 mod 8 and no three summing to 7 mod 8, a decide over ZMod 8."
+      "The additive-basis order of the perfect squares is EXACTLY 4: Lagrange gives order 4, and order 3 fails because 8N+7 ≡ 7 mod 8 is never a sum of ≤3 squares. This is the EASY (necessary) direction of Legendre three-square — no full Legendre needed, just squares ≡ 0/1/4 mod 8 and no three summing to 7 mod 8, a decide over ZMod 8.",
+      "The √n density lower bound for order-2 bases (Key Observation 1) is now machine-checked axiom-free — the elementary counting core behind b_k=O(k²). The remaining open content is the growth/oscillation dichotomy (Erdős #326 proper), which this bound does not touch: it bounds b_k above but says nothing about the non-convergence of b_k/k² for a sub-basis."
     ],
     "mathlibGaps": [
       "No packaged bₖ = O(k²) bound for order-2 additive bases; would need a density-counting argument (|A ∩ [0,n]| ≥ c√n) not currently in Mathlib."


### PR DESCRIPTION
## Summary
Research session for `erdos-326-wip-01` (Erdős #326, additive bases and non-convergent subsequences).

Formalizes the parent file's **Key Observation 1** — stated there only in prose: *"Any order-2 basis must have density at least O(√n) — there must be at least C√n elements up to n, which means the k-th element is at most O(k²)."*

## Progress (`Erdos326WIP01.lean`, theoremCount 18→20, axiom-free)
- **`IsAddBasisOfOrder.two_quadratic_density`** — for an order-2 additive basis `A`, `∃ N`, `∀ n ≥ N`, there is a finite `S ⊆ A` of elements `≤ n` with `|Finset.Icc N n| ≤ (|S| + 1)²`.
- **`IsAddBasisOfOrder.two_quadratic_density'`** — counting-function form `n + 1 − N ≤ (|S| + 1)²`, i.e. the number of basis elements up to `n` is `≥ √(n+1−N) − 1` (the √n density behind `bₖ = O(k²)`).

**Proof.** Every `m ∈ [N,n]` is a sum of `≤ 2` elements of `A`, each `≤ m ≤ n`. Pad to an ordered pair `(aₘ, bₘ)` with `aₘ + bₘ = m`, `aₘ, bₘ ∈ A ∪ {0}`. Since the sum recovers `m`, `m ↦ (aₘ, bₘ)` is injective on `[N,n]`, so `[N,n]` injects into `(S ∪ {0})²` where `S` collects the nonzero coordinates. Hence `|Icc N n| ≤ (|S|+1)²`.

## Verification
- Host-verified under Mathlib v4.31 (`lake env lean` via fresh-parent-olean; parent is Mathlib-only). No Docker.
- `#print axioms` on both = `[propext, Classical.choice, Quot.sound]` — axiom-free by project convention. 0 sorries.

## Status
**Outcome**: progress (2 axiom-free lemmas formalizing a previously prose-only observation)
**Next Steps**: the OPEN part of #326 — the oscillation dichotomy (must every order-2 basis contain a sub-basis with `bₖ/k²` non-convergent) — remains a structured blocker; this density bound controls `bₖ` from above but does not touch non-convergence.

🤖 Generated by researcher-1