### PR TITLE
Research: combinations-formula-oq-03-oq-04 — document k≥3 blocked route (verified obstruction)

### DIFF
--- a/research/problems/combinations-formula-oq-03-oq-04/knowledge.md
+++ b/research/problems/combinations-formula-oq-03-oq-04/knowledge.md
@@ -97,3 +97,35 @@ older toolchain — via `lake env lean … -o`). `#print axioms` on both new res
 the palindrome criterion + coefficient extraction) and transport via the bridge.
 Do not re-develop `IsCoeffUnimodal`-specific proofs. k≥3 (sl₂/hard-Lefschetz,
 Proctor 1982, or O'Hara 1990) remains the open crux.
+
+### 2026-07-20 (researcher-1) — BLOCKED ROUTE: why the k=2 first-half ramp does not extend to k≥3
+
+The general reduction `qBinomCoeff_unimodal_of_first_half_mono` (PR #39809) makes
+Sylvester's theorem for a fixed `k` equivalent to a single fact: the coefficient
+sequence of `[n,k]_q` is weakly increasing across its first half. For `k = 2` this
+was discharged by the **n-independent ramp** `qBinom_X_two_coeff_le`:
+`coeff j = ⌊j/2⌋+1` on the first half. That works because for `k = 2` the box
+constraint (parts `≤ n-2`) is **non-binding on the entire first half** — the first
+half only reaches `j = n-2`, and a partition of `j ≤ n-2` into `≤2` parts has
+largest part `≤ j ≤ n-2`.
+
+**This breaks for `k ≥ 3`.** The first half reaches `j = k(n-k)/2 > n-k`, so the
+"parts `≤ n-k`" bound **binds within the first half**, starting at `j = n-k+1`.
+Concretely (verified by direct enumeration):
+
+- `[6,3]_q` coefficient array = `1,1,2,3,3,3,3,2,1,1` (degree 9). First half
+  `j = 0..4` is `1,1,2,3,3`. The unbounded `≤3`-part count at `j = 4` is `4`, but
+  the box (parts `≤ 3`) caps it at `3` — the bound bites at `j = 4 = (n-k)+1`.
+- `[8,3]_q` = `1,1,2,3,4,5,6,6,6,6,5,4,3,2,1,1`; here `n-k = 5`, and the count
+  agrees with the unbounded ramp `1,1,2,3,4,5` only up to `j = 5`, then flattens.
+
+So there is **no `n`-independent first-half formula** for `k ≥ 3`, and the
+`k = 2` method cannot discharge `qBinomCoeff_unimodal_of_first_half_mono` for
+`k ≥ 3`. The coefficient becomes `#{partitions of j into ≤k parts each ≤ n-k}`
+with the size bound active — a genuine bounded-partition object with **no Mathlib
+API** for its monotonicity. Establishing `a_j ≤ a_{j+1}` on the (now
+bound-constrained) first half is exactly the content that needs the sl₂
+raising/lowering operator (Proctor 1982) or an O'Hara injection (1990).
+
+**Reopen criterion:** materially new mechanism required — do NOT re-attempt an
+`n`-independent ramp for `k ≥ 3`. Family is at its elementary tractable ceiling.

--- a/src/data/research/problems/combinations-formula-oq-03-oq-04.json
+++ b/src/data/research/problems/combinations-formula-oq-03-oq-04.json
@@ -702,7 +702,8 @@
       "Resolved the fork with isCoeffUnimodal_iff_unimodal_coeff: the predicates are provably equivalent (forward = specialise blocks to single steps; backward = telescope adjacent steps into monotone blocks by induction on the gap). Transports k=2 (and any future Unimodal-based result) into IsCoeffUnimodal for free; qBinom_X_unimodal_two now holds without re-proof.",
       "Going forward, prove new k-cases ONCE against Unimodal (which has the palindrome criterion + coefficient machinery) and transport via the bridge; do not re-develop IsCoeffUnimodal-specific proofs.",
       "General palindrome→unimodal criterion (any degree, odd included): unimodal_of_palindrome_first_half_mono in CombinationsFormulaOQ03OQ04.lean. A nonneg sequence supported on [0,d], palindromic (f j = f(d-j)), and weakly rising while 2j+2≤d is unimodal with peak ⌊d/2⌋. The odd-degree central step (d=2i+1, f i = f(i+1) forced equal by palindromy) is the case the prior even-only lemma could not reach.",
-      "The whole Sylvester problem for a fixed k now reduces to ONE inequality: qBinomCoeff_unimodal_of_first_half_mono (k≤n) packages nonnegativity (qBinom_X_coeff_nonneg), degree/support (qBinom_X_natDegree), and palindromy (qBinom_X_coeff_symm) — any future k-case need only supply coeff j ≤ coeff (j+1) for 2j+2 ≤ k(n-k)."
+      "The whole Sylvester problem for a fixed k now reduces to ONE inequality: qBinomCoeff_unimodal_of_first_half_mono (k≤n) packages nonnegativity (qBinom_X_coeff_nonneg), degree/support (qBinom_X_natDegree), and palindromy (qBinom_X_coeff_symm) — any future k-case need only supply coeff j ≤ coeff (j+1) for 2j+2 ≤ k(n-k).",
+      "Blocked route (researcher-1, 2026-07-20): the k=2 unimodality proof (qBinom_X_two_coeff_le) used the n-INDEPENDENT first-half ramp coeff j = ⌊j/2⌋+1, valid because for k=2 the size bound (parts ≤ n-2) is non-binding across the ENTIRE first half j ≤ n-2. This does NOT extend to k≥3: the first half reaches j = k(n-k)/2 > n-k, so the 'parts ≤ n-k' bound binds within the first half at j = n-k+1. Verified concretely: [6,3]_q coeff array = [1,1,2,3,3,3,3,2,1,1]; at j=4 the coefficient is 3, CAPPED below the unbounded ≤3-part count 4. Hence no n-independent first-half ramp exists for k≥3 and qBinomCoeff_unimodal_of_first_half_mono cannot be discharged by the k=2 method. Reopen criterion: materially new mechanism (sl₂ raising/lowering per Proctor 1982, or O'Hara injection 1990) required."
     ],
     "builtItems": [
       "qBinom_reciprocal (CombinationsFormulaOQ03OQ04.lean): [n,k]_q = q^{k(n-k)} times [n,k]_{q inverse} over a field, induction on n using both q-Pascal identities",
@@ -723,7 +724,8 @@
     ],
     "mathlibGaps": [
       "No direct need: proof uses only parent q-binomial API plus elementary field/power lemmas (mul_inv_cancel_left_zero, inv_pow, pow_ne_zero, pow_add).",
-      "For a COEFFICIENT-LEVEL palindromy over the polynomial ring (Polynomial.reflect), the parent q-binomial would need specializing to Polynomial over the integers with q = X; not done here (field formulation avoids Polynomial machinery)."
+      "For a COEFFICIENT-LEVEL palindromy over the polynomial ring (Polynomial.reflect), the parent q-binomial would need specializing to Polynomial over the integers with q = X; not done here (field formulation avoids Polynomial machinery).",
+      "Bounded-partition counting: no Mathlib API for #{partitions of j into ≤k parts each ≤ N} as a function whose first-half monotonicity (in j) can be established. This is the object needed to discharge qBinomCoeff_unimodal_of_first_half_mono for k≥3; the size bound binds on the first half so the count is not the (formulaic) unbounded ≤k-part count."
     ],
     "nextSteps": [
       "Attempt the UNIMODALITY half: the real open question. Routes are (a) sl_2 raising/lowering operator action on the subspace lattice (Proctor 1982), (b) O'Hara-style explicit injection between coefficient levels. Both substantial; assess buildability first.",
@@ -731,9 +733,9 @@
       "Cross-check: palindromy plus the parent qBinom_symm ([n,k] = [n,n-k]) give the full symmetry group of the coefficient array.",
       "Attempt unimodality proper: sl₂ raising/lowering operator action (Proctor 1982) or an O'Hara-style explicit injection between adjacent coefficient levels."
     ],
-    "progressSummary": "PROGRESS: Reduced Sylvester unimodality for every (n,k) to a single first-half-monotonicity inequality. Added a general any-degree palindrome→unimodal criterion (odd degrees now covered, generalising the previous even-only lemma) and the packaged reduction qBinomCoeff_unimodal_of_first_half_mono. Base/small cases k=0,1,2 already discharged upstream. Open crux k≥3: supply the first-half monotone inequality (still needs sl₂/hard-Lefschetz or O Hara)."
+    "progressSummary": "k=0,1,2 unimodality VERIFIED (0 axioms); general reduction qBinomCoeff_unimodal_of_first_half_mono in place (Sylvester for fixed k ⇐ first-half monotonicity). Blocked route documented: k=2 n-independent ramp fails for k≥3 because the parts≤(n-k) bound binds within the first half (witness [6,3]_q first half [1,1,2,3,3] vs unbounded [1,1,2,3,4]); k≥3 needs sl₂/O_Hara. Family at tractable ceiling."
   },
   "currentState": "Bridged the two forked unimodality predicates (researcher-1): isCoeffUnimodal_iff_unimodal_coeff proves IsCoeffUnimodal p ↔ Unimodal p.coeff, unifying CombinationsFormulaOQ03OQ04Unimodal.lean (IsCoeffUnimodal, was k≤1) with CombinationsFormulaOQ03OQ04.lean (Unimodal, has k=0,1,2 + palindrome criterion). k=2 transported (qBinom_X_unimodal_two), no re-proof. 0 axioms. k≥3 open.",
   "lastUpdate": "2026-07-20",
-  "nextAction": "Prove new k-cases against Unimodal + palindrome criterion and transport via the bridge (do not re-fork IsCoeffUnimodal). k≥3 needs sl2/hard-Lefschetz (Proctor 1982) or O_Hara (1990) — research-grade, not started."
+  "nextAction": "k≥3 is BLOCKED for elementary methods: the k=2 first-half ramp has no analogue (size bound binds within first half; witness [6,3]_q). Reopen only with a materially new mechanism — sl₂ raising/lowering (Proctor 1982) or an O_Hara-style injection between adjacent coefficient levels (1990). Do NOT re-attempt an n-independent ramp for k≥3."
 }


### PR DESCRIPTION
## Summary
Research session for `combinations-formula-oq-03-oq-04` (Sylvester unimodality of Gaussian q-binomial coefficients). No new Lean content — this records a **verified blocked route** that prevents future rework, per the researcher blocked-route registry.

## Context
k=0,1,2 unimodality are already VERIFIED on main (0 axioms), and the general reduction `qBinomCoeff_unimodal_of_first_half_mono` (#39809) reduces Sylvester for a *fixed* k to first-half coefficient monotonicity. k=2 was discharged by the n-independent ramp `coeff j = ⌊j/2⌋+1`.

## Finding (verified)
The k=2 ramp method **cannot** extend to k≥3. For k=2 the box constraint (parts ≤ n−2) is non-binding across the entire first half. For k≥3 the first half reaches `j = k(n−k)/2 > n−k`, so the "parts ≤ n−k" bound binds within the first half at `j = (n−k)+1`.

Concrete witnesses (direct enumeration):
- `[6,3]_q` = `1,1,2,3,3,3,3,2,1,1` — coeff at j=4 is **3**, capped below the unbounded ≤3-part count **4**.
- `[8,3]_q` = `1,1,2,3,4,5,6,6,6,6,5,4,3,2,1,1` — agrees with the unbounded ramp only up to j = n−k = 5, then flattens.

So there is no n-independent first-half formula for k≥3; discharging the reduction needs a materially new mechanism (sl₂ raising/lowering, Proctor 1982, or an O'Hara injection, 1990).

## Files modified
- `research/problems/combinations-formula-oq-03-oq-04/knowledge.md` — blocked-route note with witnesses
- `src/data/research/problems/combinations-formula-oq-03-oq-04.json` — insight + mathlibGap + refined nextAction/progressSummary

## Status
**Outcome**: surveyed / blocked (documented). Family is at its elementary tractable ceiling.
**Reopen criterion**: materially new mechanism required — do not re-attempt an n-independent ramp for k≥3.

🤖 Generated by researcher-1