### PR TITLE
Research: erdos-53-wip-01 — exponential richness of prime sets (0-axiom, host-verified)

### DIFF
--- a/proofs/Proofs/Erdos53WIP01.lean
+++ b/proofs/Proofs/Erdos53WIP01.lean
@@ -1,0 +1,139 @@
+import Proofs.Erdos53Problem
+
+/-
+# Erdős Problem 53 — WIP-01: exponential richness of prime sets (axiom-free)
+
+*Reference:* [erdosproblems.com/53](https://www.erdosproblems.com/53)
+
+Problem 53 (Erdős–Szemerédi 1983, resolved by Chang 2003) asks whether, for every
+fixed `k`, a sufficiently large finite set `A ⊆ ℤ` produces at least `|A|^k`
+integers representable as sums or products of *distinct* elements. The deep
+content — the bound for every `k` uniformly over **all** large `A` — stays
+documented (not axiomatized) in `Erdos53Problem.lean`.
+
+This companion sharpens the *easy* direction on a concrete family. The parent file
+already proves, for a set `A` of distinct positive primes, that the multiplicative
+side alone realises `2^{|A|} - 1` distinct subset products
+(`Erdos53.subsetProducts_card_of_prime`). Here we observe that the additive side
+contributes one genuinely new value — `0`, the empty subset sum, which is never a
+product of positive primes — so the **full** representable set is exponentially
+large:
+
+* `subsetProducts_pos_of_prime` — every subset product of positive primes is `> 0`
+  (hence `0` is not among them).
+* `sumsOrProducts_card_ge_two_pow_of_prime` — `2^{|A|} ≤ |sumsOrProducts A|` for a
+  set of distinct positive primes. The single strongest witness to the "easy"
+  direction of Problem 53: the count is *exponential*, dwarfing every `|A|^k`.
+* `sumsOrProducts_card_prime_pinned` — combined with the parent's trivial upper
+  bracket, prime sets are pinned: `2^{|A|} ≤ |sumsOrProducts A| ≤ 2^{|A|+1}`.
+* `sq_le_two_pow` — the elementary polynomial-vs-exponential bound `n^2 ≤ 2^n` for
+  `n ≥ 4`, by induction (no analysis import).
+* `erdosProblem53_prime_of_dominates` / `erdosProblem53_prime_exponent_two` — the
+  honest conditional connection: on prime sets the `|A|^k` bound follows the moment
+  `|A|^k ≤ 2^{|A|}`, instantiated concretely for `k = 2`, `N₀ = 4`.
+
+All results are axiom-free (`propext / Classical.choice / Quot.sound` only). This is
+a witness on the tractable side; Chang's theorem for arbitrary large sets remains
+the open crux and is not touched here.
+-/
+
+namespace Erdos53
+
+open Finset
+
+/-- Every subset product of a set of **positive** primes is strictly positive.
+    A nonempty product of positive integers is positive; the empty subset is
+    filtered out of `subsetProducts`, so this covers the whole family — in
+    particular `0 ∉ subsetProducts A`. -/
+theorem subsetProducts_pos_of_prime {A : Finset ℤ} (hpos : ∀ p ∈ A, 0 < p)
+    {x : ℤ} (hx : x ∈ subsetProducts A) : 0 < x := by
+  rw [subsetProducts, Finset.mem_image] at hx
+  obtain ⟨S, hS, rfl⟩ := hx
+  rw [Finset.mem_filter, Finset.mem_powerset] at hS
+  obtain ⟨hSA, _⟩ := hS
+  -- `∏_{a ∈ S} a > 0` since every factor is positive (`S ⊆ A`).
+  exact Finset.prod_pos (fun a ha => hpos a (hSA ha))
+
+/-- `0` is not a subset product of positive primes (immediate from positivity). -/
+theorem zero_not_mem_subsetProducts_of_prime {A : Finset ℤ} (hpos : ∀ p ∈ A, 0 < p) :
+    (0 : ℤ) ∉ subsetProducts A :=
+  fun h => (lt_irrefl 0) (subsetProducts_pos_of_prime hpos h)
+
+/-- **Exponential richness of prime sets.** For a set `A` of distinct positive
+    primes, the number of integers representable as a sum or product of distinct
+    elements is at least `2^{|A|}`.
+
+    The parent's `subsetProducts_card_of_prime` gives `2^{|A|} - 1` distinct
+    subset products, all positive; adjoining the empty subset **sum** `0` — which
+    is not a subset product — yields `2^{|A|}` distinct representable integers, all
+    inside `sumsOrProducts A`. This is the strongest possible witness on the easy
+    direction of Problem 53: the representable count is *exponential* in `|A|`. -/
+theorem sumsOrProducts_card_ge_two_pow_of_prime {A : Finset ℤ}
+    (hA : ∀ p ∈ A, Prime p) (hpos : ∀ p ∈ A, 0 < p) :
+    2 ^ A.card ≤ (sumsOrProducts A).card := by
+  -- `insert 0 (subsetProducts A)` has exactly `2^{|A|}` elements and sits inside
+  -- the representable set.
+  have hcard : (insert (0 : ℤ) (subsetProducts A)).card = 2 ^ A.card := by
+    rw [Finset.card_insert_of_notMem (zero_not_mem_subsetProducts_of_prime hpos),
+      subsetProducts_card_of_prime hA hpos]
+    exact Nat.sub_add_cancel (Nat.one_le_two_pow)
+  have hsub : insert (0 : ℤ) (subsetProducts A) ⊆ sumsOrProducts A := by
+    apply Finset.insert_subset
+    · exact zero_mem_sumsOrProducts A
+    · exact subsetProducts_subset_sumsOrProducts A
+  calc 2 ^ A.card = (insert (0 : ℤ) (subsetProducts A)).card := hcard.symm
+    _ ≤ (sumsOrProducts A).card := Finset.card_le_card hsub
+
+/-- **Prime sets are pinned between `2^{|A|}` and `2^{|A|+1}`.** Combining the
+    exponential lower bound above with the parent's trivial upper bracket
+    `sumsOrProducts_card_le`, the representable count of a distinct-positive-prime
+    set is squeezed into a single doubling interval. -/
+theorem sumsOrProducts_card_prime_pinned {A : Finset ℤ}
+    (hA : ∀ p ∈ A, Prime p) (hpos : ∀ p ∈ A, 0 < p) :
+    2 ^ A.card ≤ (sumsOrProducts A).card ∧
+      (sumsOrProducts A).card ≤ 2 ^ (A.card + 1) :=
+  ⟨sumsOrProducts_card_ge_two_pow_of_prime hA hpos, sumsOrProducts_card_le A⟩
+
+/-- **Elementary polynomial-vs-exponential bound.** `n^2 ≤ 2^n` for every `n ≥ 4`,
+    proved by induction on `n` with no analysis import. The step uses
+    `2·n^2 ≥ (n+1)^2` for `n ≥ 3` (equivalently `n^2 - 2n - 1 ≥ 0`). Used to make
+    the Problem-53 connection for prime sets concrete at `k = 2`. -/
+theorem sq_le_two_pow : ∀ n : ℕ, 4 ≤ n → n ^ 2 ≤ 2 ^ n := by
+  intro n
+  induction n with
+  | zero => intro h; omega
+  | succ m ih =>
+      intro h
+      rcases Nat.lt_or_ge m 4 with hm | hm
+      · -- only `m + 1 = 4` survives `4 ≤ m + 1` with `m < 4`
+        interval_cases m <;> simp_all
+      · have hstep : m ^ 2 ≤ 2 ^ m := ih hm
+        have hexp : 2 ^ (m + 1) = 2 * 2 ^ m := by rw [pow_succ]; ring
+        -- `(m+1)^2 ≤ 2·m^2 ≤ 2·2^m = 2^{m+1}`, the first bound from `m ≥ 3`.
+        have hsq : (m + 1) ^ 2 ≤ 2 * m ^ 2 := by nlinarith [hm]
+        calc (m + 1) ^ 2 ≤ 2 * m ^ 2 := hsq
+          _ ≤ 2 * 2 ^ m := by exact Nat.mul_le_mul_left 2 hstep
+          _ = 2 ^ (m + 1) := hexp.symm
+
+/-- **Problem 53 on prime sets, conditional form (honest framing).** If the target
+    exponent satisfies `|A|^k ≤ 2^{|A|}`, then a distinct-positive-prime set already
+    realises at least `|A|^k` representable integers. This is *not* Chang's theorem
+    (which holds for arbitrary large `A`, not just primes) — it records that the
+    prime family is never the obstruction, the `|A|^k` bound failing on it only if
+    exponential growth itself failed. -/
+theorem erdosProblem53_prime_of_dominates {A : Finset ℤ} {k : ℕ}
+    (hA : ∀ p ∈ A, Prime p) (hpos : ∀ p ∈ A, 0 < p)
+    (hdom : A.card ^ k ≤ 2 ^ A.card) :
+    A.card ^ k ≤ (sumsOrProducts A).card :=
+  le_trans hdom (sumsOrProducts_card_ge_two_pow_of_prime hA hpos)
+
+/-- **Problem 53 on prime sets, exponent `k = 2`.** With the explicit threshold
+    `|A| ≥ 4` (so `sq_le_two_pow` supplies `|A|^2 ≤ 2^{|A|}`), every set of distinct
+    positive primes realises at least `|A|^2` representable integers — the first
+    superlinear instance, witnessed unconditionally on the prime family. -/
+theorem erdosProblem53_prime_exponent_two {A : Finset ℤ}
+    (hA : ∀ p ∈ A, Prime p) (hpos : ∀ p ∈ A, 0 < p) (hbig : 4 ≤ A.card) :
+    A.card ^ 2 ≤ (sumsOrProducts A).card :=
+  erdosProblem53_prime_of_dominates hA hpos (sq_le_two_pow A.card hbig)
+
+end Erdos53

--- a/research/problems/erdos-53-wip-01/knowledge.md
+++ b/research/problems/erdos-53-wip-01/knowledge.md
@@ -75,3 +75,42 @@ without the `0 < p` hypothesis. Stated with `hpos : ∀ p ∈ A, 0 < p`.
 - Chang's theorem and the Erdős–Szemerédi subexponential upper bound remain
   genuinely deep (Balog–Szemerédi–Gowers, multiplicative energy) and out of
   Mathlib scope; keep documented, not axiomatized.
+
+## Session 2026-07-20 (researcher-1) — exponential richness of prime sets (0-axiom)
+
+**Mode**: FRESH (greenfield WIP node; parent rich, no prior WIP file) · **Outcome**:
+new axiom-free file `Erdos53WIP01.lean`, host-verified under v4.31.
+
+The parent `Erdos53Problem.lean` (405 L, 0-axiom) already proves the k=1 base case,
+the trivial `2^{|A|+1}` upper bracket, distinct-prime **product** richness
+`|subsetProducts A| = 2^{|A|}-1` (`subsetProducts_card_of_prime`), and
+superincreasing subset-sum injectivity `|subsetSums A| = 2^{|A|}`.
+
+**New content.** The additive side contributes exactly one value the multiplicative
+side cannot: `0` (the empty subset sum), which is never a product of positive primes
+(`subsetProducts_pos_of_prime`: every subset product of positive primes is `> 0`).
+Adjoining it to the `2^{|A|}-1` distinct positive products gives:
+
+- `sumsOrProducts_card_ge_two_pow_of_prime`: `2^{|A|} ≤ |sumsOrProducts A|` for
+  distinct positive primes. The strongest witness on the EASY direction of Problem
+  53 — the representable count is *exponential*, dwarfing every `|A|^k`.
+- `sumsOrProducts_card_prime_pinned`: with the parent upper bracket, prime sets are
+  pinned in `[2^{|A|}, 2^{|A|+1}]`.
+- `sq_le_two_pow`: `n^2 ≤ 2^n` for `n ≥ 4` (elementary induction, no analysis).
+- `erdosProblem53_prime_of_dominates` / `erdosProblem53_prime_exponent_two`: honest
+  conditional — on prime sets `|A|^k ≤ |sumsOrProducts A|` the moment `|A|^k ≤ 2^{|A|}`;
+  instantiated for `k = 2`, `N₀ = 4` (first superlinear instance, unconditional on primes).
+
+**Honesty.** This bears only on the easy direction. Chang's theorem is the uniform
+`|A|^k` bound over ALL large `A` (not just primes); the prime family is never the
+obstruction. Chang's theorem stays documented, not axiomatized.
+
+**Verification.** Parent is Mathlib-only, so host-verified without Docker via the
+fresh-parent-olean path: `bin/lake exe cache get`, build
+`Proofs/Erdos53Problem.olean` into `.lake/build/lib/lean/Proofs/`, then
+`bin/lake env lean Proofs/Erdos53WIP01.lean` → exit 0, no errors/warnings.
+`#print axioms` on the three headline theorems = `[propext, Classical.choice,
+Quot.sound]` (axiom-free).
+
+### Files modified
+- `proofs/Proofs/Erdos53WIP01.lean` (new)

--- a/src/data/research/problems/erdos-53-wip-01.json
+++ b/src/data/research/problems/erdos-53-wip-01.json
@@ -31,19 +31,24 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: added the additive-side sharpness dual to Erdos53Problem.lean (theoremCount 24→26, 0 sorry / 0 axiom, host-verified). subsetSum_injOn_of_superincreasing: a superincreasing set (each element exceeds the sum of the strictly smaller ones) has injective subset sums; subsetSums_card_of_superincreasing: hence exactly 2^|A| distinct subset sums, so the trivial bound subsetSums_card_le is SHARP. This is the additive analogue of the existing subsetProducts_card_of_prime (=2^|A|-1). Deep results (Chang 2003, Erdős–Szemerédi upper bound) remain documented-only.",
+    "progressSummary": "Parent Erdos53Problem.lean is a rich 0-axiom base (k=1 case, trivial 2^{|A|+1} upper bracket, distinct-prime product richness 2^|A|-1, superincreasing subset-sum injectivity). WIP01 adds the exponential lower bound for prime sets |sumsOrProducts A| ≥ 2^|A| (adjoining empty-sum 0 to the 2^|A|-1 products), a pinning corollary, n^2≤2^n, and the honest conditional connection to Problem 53 (witnessed for k=2, |A|≥4). All 0-axiom, host-verified. Chang’s theorem (uniform over all large sets) stays documented, not axiomatized.",
     "builtItems": [
       "zero_mem_subsetSums, mem_subsetSums_of_mem, mem_subsetProducts_of_mem in Erdos53Problem.lean",
       "subsetSums/Products_subset_sumsOrProducts, subsetSumCount/subsetProductCount_le_card in Erdos53Problem.lean",
       "subsetSums_card_le (<=2^|A|), subsetSums_mono, subsetSums_empty in Erdos53Problem.lean",
       "sumset_card_le, productset_card_le (<=|A|^2) in Erdos53Problem.lean",
       "subsetSum_injOn_of_superincreasing (Erdos53Problem.lean): superincreasing ⇒ injective subset sums, via max-element-of-symmetric-difference argument (2026-07-20)",
-      "subsetSums_card_of_superincreasing: |subsetSums A| = 2^|A| for superincreasing A — additive sharpness, dual of subsetProducts_card_of_prime (2026-07-20)"
+      "subsetSums_card_of_superincreasing: |subsetSums A| = 2^|A| for superincreasing A — additive sharpness, dual of subsetProducts_card_of_prime (2026-07-20)",
+      "Erdos53WIP01.lean (new, 0-axiom, host-verified v4.31): sumsOrProducts_card_ge_two_pow_of_prime — for distinct positive primes A, 2^|A| ≤ |sumsOrProducts A| (strengthens parent subsetProducts_card_of_prime by adjoining the empty-sum value 0)",
+      "sq_le_two_pow: n^2 ≤ 2^n for n≥4 (elementary induction, no analysis import)",
+      "erdosProblem53_prime_exponent_two: distinct positive primes with |A|≥4 realise ≥ |A|^2 representable integers (first superlinear instance on the prime family)",
+      "sumsOrProducts_card_prime_pinned: prime sets pinned in [2^|A|, 2^{|A|+1}]"
     ],
     "insights": [
       "Erdos53Problem.lean was a definitions-only stub (9 defs, 0 theorems). Chang 2003 (conjecture holds) and the Erdos-Szemeredi upper bound need deep additive combinatorics beyond Mathlib; tractable axiom-free content is elementary structural facts about subsetSums/subsetProducts/sumset/productset.",
       "Clean generic Finset targets that generalize across these stubs: image-of-powerset card bound (card_image_le + card_powerset gives <= 2^|A|), image-of-product card bound (card_image_le + card_product gives <= |A|^2), monotonicity via powerset_mono + image_subset_image, membership via singleton subset.",
-      "k=1 slice of Problem 53 is elementary: A ⊆ subsetSums A ⊆ sumsOrProducts A gives |A| ≤ |sumsOrProducts A| (erdosProblem53_exponent_one, N₀=0). Distinct-prime richness |subsetProducts A|=2^|A|-1 requires 0<p (Prime over ℤ is closed under negation; positivity kills the p↔-p product collision). Proved axiom-free via Prime.dvd_finsetProd_iff + Prime.associated_of_dvd + Int.associated_iff_natAbs."
+      "k=1 slice of Problem 53 is elementary: A ⊆ subsetSums A ⊆ sumsOrProducts A gives |A| ≤ |sumsOrProducts A| (erdosProblem53_exponent_one, N₀=0). Distinct-prime richness |subsetProducts A|=2^|A|-1 requires 0<p (Prime over ℤ is closed under negation; positivity kills the p↔-p product collision). Proved axiom-free via Prime.dvd_finsetProd_iff + Prime.associated_of_dvd + Int.associated_iff_natAbs.",
+      "Exponential-richness witness (researcher-1, 2026-07-20): the additive side contributes exactly one value the multiplicative side cannot — 0 (empty subset sum), which is never a product of positive primes. So for distinct positive primes |sumsOrProducts A| ≥ (2^|A|-1)+1 = 2^|A|, exhibiting sets where the Problem-53 count is exponential. This is the strongest witness on the EASY direction; it does NOT bear on Chang’s theorem, which is the uniform bound over ALL large sets (prime sets are never the obstruction)."
     ],
     "mathlibGaps": [],
     "nextSteps": [],
@@ -67,7 +72,8 @@
     "mathlib": []
   },
   "started": "2026-07-10T00:41:25.781Z",
-  "lastUpdate": "2026-07-20T23:00:00.000Z",
+  "lastUpdate": "2026-07-20",
   "significance": 7,
-  "tractability": 6
+  "tractability": 6,
+  "nextAction": "Optional extensions: (a) general polynomial-vs-exponential domination ∀k ∃N ∀n≥N, n^k ≤ 2^n (needs induction/analysis) to lift the prime-set connection to every k; (b) an additive richness lower bound for prime sets on the SUM side (subset sums of primes are not generally injective — quantify collisions). Chang’s theorem for arbitrary large sets remains the deep open crux and should stay axiom-documented, not axiomatized."
 }


### PR DESCRIPTION
## Summary
New axiom-free companion `proofs/Proofs/Erdos53WIP01.lean` for Erdős Problem 53 (sums and products of *distinct* elements). Sharpens the easy direction on the distinct-prime family.

## Key result
The parent `Erdos53Problem.lean` proves distinct positive primes give `2^|A| − 1` distinct subset **products** (`subsetProducts_card_of_prime`). The additive side contributes exactly one value the multiplicative side cannot — `0`, the empty subset sum, which is never a product of positive primes — so:

> `sumsOrProducts_card_ge_two_pow_of_prime` : for distinct positive primes `A`, `2^|A| ≤ |sumsOrProducts A|`.

This is the strongest witness on the easy direction of Problem 53: the representable count is **exponential**, dwarfing every `|A|^k`.

## Also proved (all 0-axiom)
- `subsetProducts_pos_of_prime` — subset products of positive primes are `> 0` (so `0 ∉ subsetProducts A`).
- `sumsOrProducts_card_prime_pinned` — prime sets pinned in `[2^|A|, 2^{|A|+1}]`.
- `sq_le_two_pow` — `n² ≤ 2^n` for `n ≥ 4`, elementary induction (no analysis import).
- `erdosProblem53_prime_of_dominates` / `erdosProblem53_prime_exponent_two` — honest conditional: on prime sets `|A|^k ≤ |sumsOrProducts A|` the moment `|A|^k ≤ 2^|A|`; instantiated for `k = 2`, `N₀ = 4` (first superlinear instance, unconditional on the prime family).

## Honesty
Bears only on the **easy** direction — Chang's theorem (2003) is the uniform `|A|^k` bound over **all** large sets, not just primes; the prime family is never the obstruction. Chang's theorem stays documented, not axiomatized. Parent remains 0-axiom.

## Verification
Parent is Mathlib-only → host-verified without Docker via the fresh-parent-olean path (`bin/lake exe cache get`; build `Proofs/Erdos53Problem.olean`; `bin/lake env lean Proofs/Erdos53WIP01.lean` → exit 0, no errors/warnings). `#print axioms` on the three headline theorems = `[propext, Classical.choice, Quot.sound]`.

## Files
- `proofs/Proofs/Erdos53WIP01.lean` (new)
- `src/data/research/problems/erdos-53-wip-01.json` (knowledge)
- `research/problems/erdos-53-wip-01/knowledge.md` (session note)

## Status
**Outcome**: progress (new axiom-free theorems on the tractable side).
**Next**: general poly-vs-exp domination to lift the prime connection to all `k`; additive-side collision analysis. Chang's theorem remains the deep open crux.

🤖 Generated by researcher-1