### PR TITLE
Research: erdos-1039-oq-05 — transfinite diameter of the unit disc as a limit (0-axiom)

### DIFF
--- a/proofs/Proofs/Erdos1039TransfiniteDiameter.lean
+++ b/proofs/Proofs/Erdos1039TransfiniteDiameter.lean
@@ -507,4 +507,58 @@ theorem transfiniteDiameterN_mem_Icc (hn : 2 ≤ n) :
   · exact csSup_le (unitDiscDiameters_nonempty hn)
       (by rintro d ⟨z, hz, rfl⟩; exact discreteDiameter_le_two hn hz)
 
+/-! ### The transfinite diameter of the closed unit disc as a limit
+
+The sequence `dₙ = transfiniteDiameterN n` is non-increasing for `n ≥ 2`
+(`transfiniteDiameterN_succ_le`) and bounded in `[0,2]`
+(`transfiniteDiameterN_mem_Icc`). A bounded, monotone-decreasing real sequence
+converges to its infimum, so the **transfinite diameter of the disc**
+`d = infₙ dₙ = limₙ dₙ` is a well-defined real number in `[0,2]`. Its exact value
+(`= 1`, the logarithmic capacity of the unit disc) requires the Fekete–Szegő
+theorem and extremal root-of-unity configurations, and is not established here. -/
+
+open Filter Topology
+
+/-- The **transfinite diameter of the closed unit disc**, `d = ⨅ₙ dₙ`. Indexed as
+`n ↦ d_{n+2}` so the entire sequence lies in the `n ≥ 2` monotone regime where
+`transfiniteDiameterN_succ_le` applies. -/
+noncomputable def transfiniteDiameter : ℝ := ⨅ n : ℕ, transfiniteDiameterN (n + 2)
+
+/-- The shifted sequence `n ↦ d_{n+2}` is antitone — this is Fekete monotonicity
+(`transfiniteDiameterN_succ_le`) packaged over the shifted index. -/
+theorem transfiniteDiameterN_shift_antitone :
+    Antitone (fun n : ℕ => transfiniteDiameterN (n + 2)) :=
+  antitone_nat_of_succ_le (fun n => transfiniteDiameterN_succ_le (by omega))
+
+/-- The shifted sequence `n ↦ d_{n+2}` is bounded below by `0`
+(`transfiniteDiameterN_mem_Icc`), so its infimum exists. -/
+theorem transfiniteDiameterN_shift_bddBelow :
+    BddBelow (Set.range (fun n : ℕ => transfiniteDiameterN (n + 2))) := by
+  refine ⟨0, ?_⟩
+  rintro x ⟨n, rfl⟩
+  exact (transfiniteDiameterN_mem_Icc (by omega)).1
+
+/-- **The `n`-point diameters converge to the transfinite diameter.** Being an
+antitone sequence bounded below, `d_{n+2} → ⨅ₙ d_{n+2} = d` as `n → ∞`. This makes
+`transfiniteDiameter` a genuine limit, not merely an infimum. -/
+theorem tendsto_transfiniteDiameterN :
+    Tendsto (fun n : ℕ => transfiniteDiameterN (n + 2)) atTop
+      (nhds transfiniteDiameter) :=
+  tendsto_atTop_ciInf transfiniteDiameterN_shift_antitone transfiniteDiameterN_shift_bddBelow
+
+/-- **The transfinite diameter of the disc lies in `[0,2]`.** As the infimum of the
+`[0,2]`-valued sequence `dₙ`, it inherits both bounds. (The sharp value `d = 1` is
+the deep Fekete–Szegő content, not established here.) -/
+theorem transfiniteDiameter_mem_Icc : transfiniteDiameter ∈ Set.Icc (0 : ℝ) 2 := by
+  constructor
+  · exact le_ciInf (fun n => (transfiniteDiameterN_mem_Icc (by omega)).1)
+  · exact ciInf_le_of_le transfiniteDiameterN_shift_bddBelow 0
+      (transfiniteDiameterN_mem_Icc (by omega)).2
+
+/-- Every finite-stage diameter dominates the transfinite diameter: `d ≤ d_{n+2}`
+for all `n`.  The limit sits below the whole monotone sequence. -/
+theorem transfiniteDiameter_le (n : ℕ) :
+    transfiniteDiameter ≤ transfiniteDiameterN (n + 2) :=
+  ciInf_le transfiniteDiameterN_shift_bddBelow n
+
 end Erdos1039TransfiniteDiameter

--- a/research/problems/erdos-1039-oq-05/knowledge.md
+++ b/research/problems/erdos-1039-oq-05/knowledge.md
@@ -150,3 +150,33 @@ These sharpen `discreteDiameter_nonneg` and supply the strict positivity that
 `Real.log (discreteDiameter z)` and `discreteDiameter_eq_exp` silently rely on.
 Host-verified `bin/lake env lean` exit 0; `#print axioms` on both =
 `[propext, Classical.choice, Quot.sound]`.
+
+## Session 2026-07-20 (researcher-1) — transfinite diameter as a limit (0-axiom)
+
+**Mode**: REVISIT (RICH, live vein) · **Outcome**: closed the limit existence in
+`Erdos1039TransfiniteDiameter.lean`, host-verified v4.31.
+
+The knowledge "Next #1" (upgrade the pointwise deletion to the sup-over-configurations
+`d_{n+1} ≤ dₙ`) was already DONE in-tree as `transfiniteDiameterN_succ_le` (Fekete
+monotonicity, supremum form), with `transfiniteDiameterN_mem_Icc` giving `dₙ ∈ [0,2]`.
+So the natural next milestone was assembling the **limit**.
+
+**New content** (all `#print axioms` = `[propext, Classical.choice, Quot.sound]`):
+- `transfiniteDiameter := ⨅ n, transfiniteDiameterN (n+2)` — indexed over the `n ≥ 2`
+  monotone regime.
+- `transfiniteDiameterN_shift_antitone` / `_shift_bddBelow` — the shifted sequence is
+  antitone (Fekete) and bounded below by `0`.
+- `tendsto_transfiniteDiameterN` — `d_{n+2} → transfiniteDiameter` via Mathlib
+  `tendsto_atTop_ciInf` (antitone + bddBelow ⟹ converges to the infimum). The
+  transfinite diameter is now a genuine **limit**, not merely an infimum.
+- `transfiniteDiameter_mem_Icc` (`d ∈ [0,2]`) and `transfiniteDiameter_le`
+  (`d ≤ d_{n+2}` for all `n`).
+
+**Open crux (unchanged).** The sharp value `d = 1` (= logarithmic capacity of the unit
+disc) needs the Fekete–Szegő theorem plus extremal root-of-unity configurations: the
+`spreadProduct` of the `n`-th roots of unity is the Vandermonde discriminant, giving the
+matching lower bound `dₙ ≥ n^{1/(n-1)} → 1`. The current upper bound is the coarse
+`dₙ ≤ 2`. Not formalized here.
+
+### Files modified
+- `proofs/Proofs/Erdos1039TransfiniteDiameter.lean` (+~55 lines, limit section)

--- a/src/data/research/problems/erdos-1039-oq-05.json
+++ b/src/data/research/problems/erdos-1039-oq-05.json
@@ -42,7 +42,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (2026-07-20, researcher-1, VERIFIED 0-axiom host): lifted Fekete monotonicity to the SUPREMUM level. New defs unitDiscDiameters/transfiniteDiameterN (sup of dₙ(Z) over configs in the closed unit disc) + transfiniteDiameterN_succ_le (d_{n+1} ≤ dₙ, n≥2) and transfiniteDiameterN_mem_Icc (0 ≤ dₙ ≤ 2). The transfinite diameter d = infₙ dₙ is now a well-defined monotone bounded limit. Parent ρ(f) ≫ 1/n remains OPEN.",
+    "progressSummary": "Discrete/transfinite diameter API is 0-axiom and now closes the limit: dₙ non-increasing (Fekete, transfiniteDiameterN_succ_le) and bounded in [0,2], so d = ⨅ₙ dₙ = limₙ dₙ is a well-defined real in [0,2] (transfiniteDiameter, tendsto_transfiniteDiameterN, transfiniteDiameter_mem_Icc). Remaining: sharp value d=1 (Fekete–Szegő + roots-of-unity extremal configs); connection to ρ(f) via capacity.",
     "builtItems": [
       "Erdos1039TransfiniteDiameter.spreadProduct: the Vandermonde spread ∏_{i<j}‖zᵢ-zⱼ‖ (finite-n numerator of the transfinite diameter).",
       "Erdos1039TransfiniteDiameter.discreteDiameter: the n-point diameter dₙ(Z) = spreadProduct^{2/(n(n-1))}, the finite-n truncation of the transfinite diameter.",
@@ -57,7 +57,10 @@
       "sum_logSpread_deleteAt (additive energy form) in Erdos1039TransfiniteDiameter.lean",
       "discreteDiameter_pos (0 < dₙ z for injective z) in Erdos1039TransfiniteDiameter.lean",
       "discreteDiameter_pos_iff (n≥2: 0 < dₙ z ↔ Injective z) in Erdos1039TransfiniteDiameter.lean",
-      "unitDiscDiameters, transfiniteDiameterN, zero_mem_unitDiscDiameters, unitDiscDiameters_nonempty/bddAbove, transfiniteDiameterN_succ_le, transfiniteDiameterN_mem_Icc in Erdos1039TransfiniteDiameter.lean (0 axioms, 0 sorries; host-verified v4.31.0)"
+      "unitDiscDiameters, transfiniteDiameterN, zero_mem_unitDiscDiameters, unitDiscDiameters_nonempty/bddAbove, transfiniteDiameterN_succ_le, transfiniteDiameterN_mem_Icc in Erdos1039TransfiniteDiameter.lean (0 axioms, 0 sorries; host-verified v4.31.0)",
+      "transfiniteDiameter (def) + tendsto_transfiniteDiameterN: the n-point diameters d_{n+2} converge to d = ⨅ₙ d_{n+2} (antitone + bounded-below ⟹ tendsto_atTop_ciInf). Makes the transfinite diameter of the unit disc a genuine LIMIT, not just an infimum.",
+      "transfiniteDiameter_mem_Icc: d ∈ [0,2]; transfiniteDiameter_le: d ≤ d_{n+2} for all n. All 0-axiom, host-verified v4.31.",
+      "Fekete monotonicity (sup form) transfiniteDiameterN_succ_le was ALREADY DONE in-tree (knowledge Next#1 was stale)."
     ],
     "insights": [
       "The finite discrete spread is entirely elementary and needs NO capacity infrastructure: it is a product of pairwise norms, equal to the modulus of the Vandermonde determinant, so it is host-verifiable Mathlib-only (no Docker).",
@@ -67,7 +70,8 @@
       "Order-preserving pair reindexing under Fin.succAbove is a nested Finset.prod_bij; the k-dependent erase-guard is pulled through prod_k by rewriting erase -> filter(.neq.k) -> if via Finset.filter_ne'/prod_filter, then prod_comm.",
       "Additive shadow: sum_k logSpread(delete k Z) = (n-1)*logSpread Z for distinct roots, connecting the deletion identity to the logarithmic-energy/capacity bridge already in the file.",
       "Strict positivity of discreteDiameter: dₙ z = spreadProduct z ^ (2/(n(n-1))); for injective z the base is positive (spreadProduct_pos_iff) so Real.rpow_pos_of_pos gives 0 < dₙ. The n≥2 iff uses that the exponent 2/(n(n-1)) is nonzero, so a zero spread would force dₙ=0 (Real.zero_rpow). This is the positivity that Real.log(dₙ) and the energy bridge silently need.",
-      "Fekete monotonicity LIFTS to the supremum level: defining dₙ = sup over n-point configs in the closed unit disc of discreteDiameter, the pointwise exists_deleteAt_discreteDiameter_ge gives transfiniteDiameterN_succ_le (d_{n+1} ≤ dₙ, n≥2) directly via csSup_le + le_csSup — no compactness API needed, only that the config values stay in the disc under deletion and that dₙ(Z)≤2 bounds the sup. The disc is the natural compact set (parent lemniscate roots lie in it)."
+      "Fekete monotonicity LIFTS to the supremum level: defining dₙ = sup over n-point configs in the closed unit disc of discreteDiameter, the pointwise exists_deleteAt_discreteDiameter_ge gives transfiniteDiameterN_succ_le (d_{n+1} ≤ dₙ, n≥2) directly via csSup_le + le_csSup — no compactness API needed, only that the config values stay in the disc under deletion and that dₙ(Z)≤2 bounds the sup. The disc is the natural compact set (parent lemniscate roots lie in it).",
+      "Limit existence (researcher-1, 2026-07-20): the transfinite diameter of the closed unit disc is now a well-defined real number d = limₙ dₙ = ⨅ₙ dₙ ∈ [0,2], via Mathlib tendsto_atTop_ciInf on the antitone (Fekete) bounded-below sequence. The SHARP value d = 1 (= logarithmic capacity of the disc) remains open: it needs the Fekete–Szegő theorem plus extremal root-of-unity configurations (spreadProduct of nth roots of unity → the discriminant), not yet formalized. The current upper bound is the coarse dₙ ≤ 2."
     ],
     "mathlibGaps": [
       "Mathlib has no transfinite-diameter / logarithmic-capacity API; the n-point spread and its diameter had to be defined from scratch (done here). The limit d(Z)=limₙ dₙ and Fekete monotonicity are still absent."
@@ -162,5 +166,6 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1039TransfiniteDiameter.lean"
     }
   ],
-  "lastUpdate": "2026-07-20T00:00:00.000Z"
+  "lastUpdate": "2026-07-20",
+  "nextAction": "Sharpen the transfinite diameter to its true value d = 1: (a) compute discreteDiameter of the n-th roots of unity via the Vandermonde/discriminant product (spreadProduct of roots of unity), giving a lower bound dₙ ≥ n^{1/(n-1)} → 1; (b) matching upper bound d ≤ 1 (needs a capacity/potential argument, likely axiomatize citing Fekete–Szegő). Then connect d(disc)=cap=1 to the Erdős-1039 radius bound ρ(f)."
 }


### PR DESCRIPTION
## Summary
Extends `proofs/Proofs/Erdos1039TransfiniteDiameter.lean` to close the **limit existence** for the transfinite diameter of the closed unit disc. All axiom-free, host-verified under v4.31.

## Context
The file already proved Fekete monotonicity in supremum form (`transfiniteDiameterN_succ_le`: `d_{n+1} ≤ dₙ`) and `dₙ ∈ [0,2]` (`transfiniteDiameterN_mem_Icc`). An antitone real sequence bounded below converges to its infimum — this session assembles that limit.

## New content (all 0-axiom)
- `transfiniteDiameter := ⨅ n, transfiniteDiameterN (n+2)` — indexed over the `n ≥ 2` monotone regime.
- `transfiniteDiameterN_shift_antitone` / `_shift_bddBelow` — antitone (Fekete) + bounded below by 0.
- `tendsto_transfiniteDiameterN` — `d_{n+2} → transfiniteDiameter` via Mathlib `tendsto_atTop_ciInf`. **The transfinite diameter is now a genuine limit, not merely an infimum.**
- `transfiniteDiameter_mem_Icc` (`d ∈ [0,2]`) and `transfiniteDiameter_le` (`d ≤ d_{n+2}`).

## Honesty
The **sharp value `d = 1`** (= logarithmic capacity of the disc) is the deep Fekete–Szegő content and is **not** established: it needs the extremal root-of-unity configurations (the `spreadProduct` of the `n`-th roots of unity is the Vandermonde discriminant, giving `dₙ ≥ n^{1/(n-1)} → 1`). The upper bound here is the coarse `dₙ ≤ 2`.

## Verification
`bin/lake env lean Proofs/Erdos1039TransfiniteDiameter.lean` → exit 0, no errors/warnings. `#print axioms` on `tendsto_transfiniteDiameterN`, `transfiniteDiameter_mem_Icc`, `transfiniteDiameter_le` = `[propext, Classical.choice, Quot.sound]`.

## Files
- `proofs/Proofs/Erdos1039TransfiniteDiameter.lean` (+~55 lines)
- `src/data/research/problems/erdos-1039-oq-05.json`, `research/problems/erdos-1039-oq-05/knowledge.md`

## Status
**Outcome**: progress (limit existence closed, 0-axiom).
**Next**: sharpen to `d = 1` via root-of-unity extremal configs + capacity upper bound; connect to the Erdős-1039 radius bound ρ(f).

🤖 Generated by researcher-1