### PR TITLE
Enrich erdos-1204 (admissible sequences A(k)): re-anchor drifted sections + full-file coverage 10→12

### DIFF
--- a/src/data/proofs/erdos-1204/meta.json
+++ b/src/data/proofs/erdos-1204/meta.json
@@ -119,7 +119,7 @@
       "id": "header",
       "title": "Overview: Admissible Sequences and Problem #1204",
       "startLine": 1,
-      "endLine": 28,
+      "endLine": 35,
       "mathContext": "Admissible $\\iff$ for every prime $p$ some class mod $p$ is missed; $A(k) = \\min a_k$, conjecturally $A(k)\\sim k\\log k$.",
       "summary": "Module docstring framing Erdős #1204. Defines admissibility as the local (mod-p) obstruction central to the Hardy–Littlewood prime k-tuples conjecture and bounded-gaps work (Zhang, Maynard, Tao), states the two OPEN asymptotic questions — A(k) ∼ k log k? and the order of B(k)? — and lists what is formalized: the definition, the small-prime reduction, worked examples, and the extremal quantity A(k) with its first exact values."
     },
@@ -127,7 +127,7 @@
       "id": "definition",
       "title": "Definition: Admissible",
       "startLine": 36,
-      "endLine": 42,
+      "endLine": 43,
       "mathContext": "$\\mathrm{Admissible}(a) := \\forall p\\ \\text{prime},\\ \\exists r \\in \\mathbb{Z}/p\\mathbb{Z},\\ \\forall x \\in a,\\ (x \\bmod p) \\ne r$.",
       "summary": "The central definition: a Finset ℕ is admissible if for every prime p there is a residue class r : ZMod p avoided by all of its elements — equivalently, the image of a in ZMod p is never all of ZMod p."
     },
@@ -135,7 +135,7 @@
       "id": "reduction",
       "title": "The Reduction to Small Primes",
       "startLine": 44,
-      "endLine": 78,
+      "endLine": 79,
       "mathContext": "$|a| < p \\Rightarrow a$ misses a class mod $p$; hence admissibility only constrains primes $p \\le |a|$.",
       "summary": "missing_class_of_card_lt: a set of fewer than p elements cannot surject onto the p classes of ZMod p, so it always misses one (a pigeonhole/counting argument via card_image_le and ZMod.card). admissible_iff_card packages this into the key reduction — admissibility is equivalent to missing a class modulo every prime p ≤ |a|, making it a finite check."
     },
@@ -143,7 +143,7 @@
       "id": "examples",
       "title": "Worked Examples",
       "startLine": 80,
-      "endLine": 121,
+      "endLine": 122,
       "mathContext": "$\\emptyset, \\{0\\}, \\{0,2\\}$ admissible; $\\{0,1\\}$ not — it covers both classes mod $2$.",
       "summary": "Concrete computations: ∅, every singleton, and {0,2} are admissible, while {0,1} is not because it occupies both residue classes mod 2. The {0,2} vs {0,1} contrast shows why admissible patterns must dodge a small prime's classes — the local condition that twin-prime-like constellations satisfy."
     },
@@ -151,49 +151,57 @@
       "id": "structural",
       "title": "Structural Properties and Existence of A(k)",
       "startLine": 123,
-      "endLine": 185,
+      "endLine": 207,
       "mathContext": "Closed under subsets and translation; an admissible $k$-set exists for every $k$ (multiples of the primorial $\\prod_{p\\le k}p$).",
       "summary": "Admissibility is downward closed (Admissible.subset) and translation invariant (admissible_image_add, card_image_add) — it depends only on the pattern, not the position. exists_admissible_card constructs an admissible k-set for every k from the multiples 0, N, …, (k−1)N of the primorial N = ∏_{p≤k} p (each element ≡ 0 mod each small prime, so class 1 is missed), guaranteeing A(k) is well-defined and giving the weak upper bound A(k) ≤ (k−1)·primorial."
     },
     {
       "id": "parity-diameter",
       "title": "The Parity Constraint and a Sharper Diameter Bound",
-      "startLine": 187,
-      "endLine": 240,
+      "startLine": 208,
+      "endLine": 262,
       "mathContext": "All elements share parity, so $\\max - \\min \\ge 2(|a|-1)$ — double the trivial packing span $|a|-1$.",
       "summary": "Because ZMod 2 has only two classes and an admissible set misses one, every element shares a single parity (admissible_same_parity). admissible_diam_ge then injects a via x ↦ (x−min)/2 into {0,…,(max−min)/2}, forcing diameter ≥ 2(card−1) — exactly double the trivial packing bound, the leading prime-2 term of the k log k heuristic."
     },
     {
       "id": "extremal-A",
       "title": "The Extremal Quantity A(k) and Its Bounds",
-      "startLine": 242,
-      "endLine": 349,
-      "mathContext": "$A(k) = \\inf\\{\\,a.\\sup\\ \\mathrm{id} : |a|=k,\\ \\mathrm{Admissible}(a)\\}$, with $2(k-1) \\le A(k)$ and $A(0)=A(1)=0$, $A(2)=2$.",
-      "summary": "A(k) is defined as the infimum of the largest element a.sup id over admissible k-sets; nonempty by exists_admissible_card so the infimum is attained (A_mem, A_le). Two lower bounds: the trivial sub_one_le_A (A(k) ≥ k−1) and the parity-sharpened two_mul_sub_one_le_A (A(k) ≥ 2(k−1)). Exact small values A(0)=A(1)=0 and A(2)=2 — the latter is where admissibility first bites, since the densest 2-set {0,1} is inadmissible and pushes the minimum above the packing value 1."
+      "startLine": 263,
+      "endLine": 534,
+      "mathContext": "$A(k) = \\inf\\{\\,a.\\sup\\ \\mathrm{id} : |a|=k,\\ \\mathrm{Admissible}(a)\\}$; monotone and strictly increasing, $A(k)$ even, with $2(k-1) \\le A(k)$ and $A(0)=A(1)=0$, $A(2)=2$.",
+      "summary": "A(k) is defined as the infimum of the largest element a.sup id over admissible k-sets; nonempty by exists_admissible_card so the infimum is attained (A_mem, A_le). Order structure: A is monotone (A_le_A_succ, A_monotone) and, for k ≥ 1, strictly increasing (A_lt_A_succ, A_succ_strictMono). Two lower bounds: the trivial sub_one_le_A (A(k) ≥ k−1) and the parity-sharpened two_mul_sub_one_le_A (A(k) ≥ 2(k−1)), the latter via admissible_two_mul_card_sub_one_le_sup. A_even shows A(k) is even for every k — the prime 2 pins the parity of the optimum, not just its packing bound — which upgrades the strict step to A_succ_ge_add_two (A(k)+2 ≤ A(k+1)). Exact small values A(0)=A(1)=0, A(2)=2 (A_zero, A_one, A_two, A_eq_zero_iff, two_le_A_iff, A_pos) — A(2)=2 is where admissibility first bites, since the densest 2-set {0,1} is inadmissible and pushes the minimum above the packing value 1."
     },
     {
       "id": "a-three",
       "title": "The Exact Value A(3) = 6",
-      "startLine": 351,
-      "endLine": 486,
+      "startLine": 535,
+      "endLine": 649,
       "mathContext": "$A(3)=6 = H(3)$, the Hardy–Littlewood minimal diameter; witness $\\{0,2,6\\}$, with $\\{0,2,4\\},\\{1,3,5\\}$ ruled out mod $3$.",
       "summary": "A(3)=6 matches the Hardy–Littlewood minimal diameter H(3). Upper bound: {0,2,6} is admissible (all even mod 2, residues {0,2,0} mod 3 miss class 1). Lower bound (admissible_three_sup_ge): any admissible 3-set with max ≤ 5 must be single-parity, pinning it to {0,2,4} or {1,3,5} — both of which cover every class mod 3 and so fail admissibility, so no admissible 3-set fits below 6."
     },
     {
       "id": "open-problems",
       "title": "Open Problems",
-      "startLine": 488,
-      "endLine": 500,
+      "startLine": 650,
+      "endLine": 663,
       "mathContext": "Open: $A(k)\\sim k\\log k$? and the order of $B(k)=\\min(a_1+\\cdots+a_k)/k$.",
       "summary": "The asymptotic questions of #1204 remain open and are documented but not asserted: whether A(k) ∼ k log k and the correct order of the minimal average B(k). Both need sieve-theoretic analytic number theory beyond the elementary framework formalized here."
     },
     {
       "id": "upper-bound",
       "title": "An Explicit Upper Bound A(k) ≤ (k−1)·∏_{p ≤ k} p",
-      "startLine": 502,
-      "endLine": 561,
+      "startLine": 664,
+      "endLine": 722,
       "mathContext": "$2(k-1) \\le A(k) \\le (k-1)\\cdot\\!\\!\\prod_{p \\le k}\\! p$; the primorial spacing $N=\\prod_{p\\le k}p$ gives the admissible set $\\{0,N,\\dots,(k-1)N\\}$.",
       "summary": "primorialUpTo k = ∏_{p ≤ k} p (product of primes ≤ k) and A_le_primorial: A(k) ≤ (k−1)·primorialUpTo k. The arithmetic progression {0, N, …, (k−1)N} with N = primorialUpTo k is admissible (every element ≡ 0 mod each prime p ≤ k, so class 1 is missed), has k elements, and largest element (k−1)N; feeding it to A_le gives the bound. Together with two_mul_sub_one_le_A this sandwiches A(k) between 2(k−1) and (k−1)·∏_{p≤k}p — an elementary two-sided companion far from the conjectured A(k) ∼ k log k, since N grows like e^{(1+o(1))k}."
+    },
+    {
+      "id": "sandwich-divergence",
+      "title": "The Two-Sided Sandwich and the Divergence of A(k)",
+      "startLine": 723,
+      "endLine": 751,
+      "mathContext": "$2(k-1) \\le A(k) \\le (k-1)\\cdot\\!\\!\\prod_{p \\le k}\\! p$, hence $A(k) \\to \\infty$ as $k \\to \\infty$.",
+      "summary": "Packages the parity lower bound two_mul_sub_one_le_A and the primorial upper bound A_le_primorial into a single two-sided statement A_sandwich: 2(k−1) ≤ A(k) ≤ (k−1)·primorialUpTo k. Because the lower bound 2(k−1) already tends to infinity, A_tendsto_atTop concludes that A(k) → ∞ (Filter.Tendsto A atTop atTop) via a squeeze off the linear lower bound — a first qualitative confirmation of the conjectured unbounded growth A(k) ∼ k log k, established without any of the deep sieve theory the sharp asymptotic would require."
     },
     {
       "id": "joint-2-3-lower-bound",


### PR DESCRIPTION
## Enrichment pass: erdos-1204 (Admissible Sequences, A(k))

**Class: CLEAN re-anchor + tail-append** (grown-file section drift).

The `Erdos1204Problem.lean` file grew to 751 lines but `meta.json` sections were
anchored to stale line numbers drifted 50–180 lines behind the file, and the
final section (the two-sided sandwich + divergence of A(k)) was entirely
uncovered.

### Changes
- **Re-anchored all 10 primary sections** to their actual banner positions
  (e.g. "The Exact Value A(3)=6" 351–486 → 535–649; "Extremal Quantity A(k)"
  242–349 → 263–534).
- **Added 1 new section** `sandwich-divergence` (723–751) documenting
  `A_sandwich` (2(k−1) ≤ A(k) ≤ (k−1)·primorial) and `A_tendsto_atTop`
  (A(k) → ∞), which were previously outside all section ranges.
- **Enriched the extremal-A summary** to reflect the monotonicity/strict-mono
  (`A_monotone`, `A_lt_A_succ`), parity (`A_even`, `A_succ_ge_add_two`), and
  exact small-value lemmas that section now spans.
- Sections now cover lines **1..751 contiguously** (10 → 12 sections, incl.
  the companion Erdos1204C.lean section).

No content deleted; no status/badge/axiomCount change (remains
`axiomatized`/`wip`, 0 axioms, 0 sorries — accurate). Validated via JSON
round-trip.
