### PR TITLE
Research: erdos-70-wip-01 — ω^ω is a countable ordinal (limit-exponent closure, 0-axiom)

### DIFF
--- a/proofs/Proofs/Erdos70WIP01.lean
+++ b/proofs/Proofs/Erdos70WIP01.lean
@@ -90,4 +90,49 @@ theorem erdos_70_conjecture_imp_omega_squared (h : erdos_70_conjecture) (n : ℕ
     (hn : 2 ≤ n) : conjecture_omega_squared n :=
   h (Ordinal.omega0 * Ordinal.omega0) n omega0_squared_countable hn
 
+/-! ## Countability of `ω^ω` (the tower case)
+
+The finite-power closure `isCountableOrdinal_opow_nat` above stops at `ω^n` for
+`n : ℕ`.  The genuinely new step is the *limit* exponent `ω^ω`, which the
+parent's `conjecture_omega_tower` needs a witness for.  The clean route is to
+bridge `IsCountableOrdinal` (`card ≤ ℵ₀`) to `< ω₁` and then use that a countable
+supremum of countable ordinals stays below `ω₁` (`Ordinal.iSup_lt_omega_one`,
+i.e. the regularity of `ℵ₁`): `ω^ω` is the supremum of the finite powers `ω^n`,
+each of which is countable. -/
+
+/-- **Bridge: `IsCountableOrdinal α ↔ α < ω₁`.**  A `card`-level restatement of
+countability as being below the first uncountable ordinal, via
+`Ordinal.lt_omega_iff_card_lt` and `Cardinal.lt_aleph_one_iff` (`c < ℵ₁ ↔ c ≤ ℵ₀`). -/
+theorem isCountableOrdinal_iff_lt_omega_one {α : Ordinal} :
+    IsCountableOrdinal α ↔ α < Ordinal.omega 1 := by
+  unfold IsCountableOrdinal
+  rw [Cardinal.lt_omega_iff_card_lt, Cardinal.lt_aleph_one_iff]
+
+/-- **`ω^ω` is a countable ordinal.**  Writing `ω` as a successor-limit, ordinal
+exponentiation gives `ω^ω = ⨆_{β < ω} ω^β`, and every `β < ω` is a finite `k`, so
+`ω^β ≤ ω^k ≤ ⨆_{n} ω^n`.  That supremum is a *countable* supremum (indexed by `ℕ`)
+of *countable* ordinals `ω^n` (`omega0_opow_nat_countable`), hence `< ω₁` by
+`Ordinal.iSup_lt_omega_one`; so `ω^ω < ω₁` and is countable.  This supplies the
+witness for the parent's `conjecture_omega_tower`, the `β = ω^ω` case of Erdős #70,
+and completes the countability toolkit past all *finite* powers of `ω`. -/
+theorem omega0_opow_omega0_countable :
+    IsCountableOrdinal (Ordinal.omega0.{0} ^ Ordinal.omega0.{0}) := by
+  have hS_lt : (⨆ n : ℕ, Ordinal.omega0.{0} ^ (n : Ordinal)) < Ordinal.omega 1 := by
+    apply Ordinal.iSup_lt_omega_one
+    intro n
+    exact isCountableOrdinal_iff_lt_omega_one.mp (omega0_opow_nat_countable n)
+  have hle : Ordinal.omega0.{0} ^ Ordinal.omega0.{0}
+      ≤ ⨆ n : ℕ, Ordinal.omega0.{0} ^ (n : Ordinal) := by
+    rw [Ordinal.opow_le_of_isSuccLimit Ordinal.omega0_ne_zero Ordinal.isSuccLimit_omega0]
+    intro b' hb'
+    obtain ⟨k, rfl⟩ := Ordinal.lt_omega0.mp hb'
+    exact Ordinal.le_iSup (fun n : ℕ => Ordinal.omega0.{0} ^ (n : Ordinal)) k
+  exact isCountableOrdinal_iff_lt_omega_one.mpr (lt_of_le_of_lt hle hS_lt)
+
+/-- The open conjecture specializes to the tower case `𝔠 → (ω^ω, n)₂³`, using the
+countability witness `omega0_opow_omega0_countable`. -/
+theorem erdos_70_conjecture_imp_omega_tower (h : erdos_70_conjecture) (n : ℕ)
+    (hn : 2 ≤ n) : conjecture_omega_tower n :=
+  h (Ordinal.omega0 ^ Ordinal.omega0) n omega0_opow_omega0_countable hn
+
 end Erdos70

--- a/research/problems/erdos-70-wip-01/knowledge.md
+++ b/research/problems/erdos-70-wip-01/knowledge.md
@@ -99,3 +99,36 @@ fails against a `α ^ (↑n + 1)` goal. Route the successor step through
 Countability of the limit power `ω ^ ω` (`Ordinal.omega0 ^ Ordinal.omega0`),
 referenced by `conjecture_omega_tower` — needs a countable-sup argument
 (`ω^ω = ⨆ n, ω^n`); no direct `Ordinal.card_opow` exists in Mathlib v4.31.
+
+## Session 2026-07-20 (researcher-1, session 3): ω^ω countable — the limit-exponent step
+
+Picked up the session-1 "Next Steps" flag (`isCountableOrdinal_opow` for `ω^ω`). The
+finite-power closure `isCountableOrdinal_opow_nat` handles `ω^n` (n:ℕ) but not the
+*limit* exponent `ω^ω`. Added 3 axiom-free theorems to `Proofs/Erdos70WIP01.lean`
+(host-verified: parent `Erdos70Problem.lean` fresh-built to olean, child `lake env lean`
+exit 0; `#print axioms` = `[propext, Classical.choice, Quot.sound]` on all three).
+
+- **`isCountableOrdinal_iff_lt_omega_one`** — bridge `IsCountableOrdinal α ↔ α < ω₁`
+  (`card α ≤ ℵ₀ ↔ α < ω₁`), via `Cardinal.lt_omega_iff_card_lt` (`x < ω_ o ↔ x.card < ℵ_ o`)
+  and `Cardinal.lt_aleph_one_iff` (`c < ℵ₁ ↔ c ≤ ℵ₀`).
+
+- **`omega0_opow_omega0_countable`** — `ω^ω` is countable. Since `ω` is a successor-limit,
+  `Ordinal.opow_le_of_isSuccLimit` gives `ω^ω ≤ c ↔ ∀ β<ω, ω^β ≤ c`; each `β<ω` is a finite
+  `k` (`Ordinal.lt_omega0`), so `ω^β = ω^k ≤ ⨆ n:ℕ, ω^n` (`Ordinal.le_iSup`). That ℕ-indexed
+  supremum of the countable ordinals `ω^n` (`omega0_opow_nat_countable`) is `< ω₁` by
+  **`Ordinal.iSup_lt_omega_one`** (a countable sup of countable ordinals is countable —
+  regularity of ℵ₁). Hence `ω^ω ≤ (⨆ n, ω^n) < ω₁`, so `ω^ω` is countable.
+
+- **`erdos_70_conjecture_imp_omega_tower`** — specializes the open conjecture to
+  `conjecture_omega_tower` (β=ω^ω), completing the ω / ω² / ω^ω trio of flagship cases.
+
+### Gotcha
+Universe must be pinned to `Ordinal.{0}` (write `Ordinal.omega0.{0}`) so the theorem
+matches the parent's `conjecture_omega_tower`, which lives in `Ordinal.{0}`. Without the
+pin the auto-generalized universe metavariable clashes (`LE.le.{u_1+1}` vs `.{1}`).
+Also `Cardinal.lt_omega_iff_card_lt` is in the **`Cardinal`** namespace (not `Ordinal`).
+
+### Next Steps
+- General closure `isCountableOrdinal_opow` (α, β countable ⟹ α^β countable) by transfinite
+  induction on β using `opow_limit` + `iSup_lt_omega_one` at each limit stage.
+- Towers `ω^(ω^ω)` etc. up to `ε₀`; all countable, each a `le_iSup`-over-ℕ argument.

--- a/src/data/research/problems/erdos-70-wip-01.json
+++ b/src/data/research/problems/erdos-70-wip-01.json
@@ -31,7 +31,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (session): extended the countable-ordinal closure toolkit in Erdos70WIP01.lean with closure under natural-number exponentiation (isCountableOrdinal_opow_nat) and its ω-corollary (omega0_opow_nat_countable), generalizing the parent s omega0_squared_countable to all finite powers ω^n. Both axiom-free, host-verified Lean v4.31.0. WIP01 theoremCount 5→7. Full countability of ω^ω (limit power) remains the next structural target — needs a countable-sup argument (no Ordinal.card_opow in Mathlib).",
+    "progressSummary": "PROGRESS (session 3): Proved ω^ω countable (omega0_opow_omega0_countable) — the limit-exponent closure past all finite powers of ω, and the missing witness for the parent's conjecture_omega_tower. Added the bridge isCountableOrdinal_iff_lt_omega_one (card≤ℵ₀ ↔ <ω₁) and the conjecture specialization erdos_70_conjecture_imp_omega_tower. 3 new axiom-free theorems in Erdos70WIP01.lean, host-verified (lake env lean exit 0, #print axioms = propext/Classical.choice/Quot.sound). Next: general opow closure (countable^countable countable) via transfinite induction, or ε₀-type towers.",
     "builtItems": [
       "Erdos70.IsCountableOrdinal.of_le in Erdos70WIP01.lean",
       "Erdos70.isCountableOrdinal_add in Erdos70WIP01.lean",
@@ -39,12 +39,17 @@
       "Erdos70.erdos_70_conjecture_imp_omega in Erdos70WIP01.lean",
       "Erdos70.erdos_70_conjecture_imp_omega_squared in Erdos70WIP01.lean",
       "isCountableOrdinal_opow_nat — closure of the countable-ordinal class under natural-number exponentiation α^n (Erdos70WIP01.lean)",
-      "omega0_opow_nat_countable — every finite power ω^n is countable, generalizing omega0_squared_countable (Erdos70WIP01.lean)"
+      "omega0_opow_nat_countable — every finite power ω^n is countable, generalizing omega0_squared_countable (Erdos70WIP01.lean)",
+      "isCountableOrdinal_iff_lt_omega_one in Erdos70WIP01.lean — bridge card≤ℵ₀ ↔ <ω₁",
+      "omega0_opow_omega0_countable in Erdos70WIP01.lean — ω^ω is a countable ordinal (the tower witness)",
+      "erdos_70_conjecture_imp_omega_tower in Erdos70WIP01.lean — specializes the open conjecture to β=ω^ω"
     ],
     "insights": [
       "The parent proved specific instances (omega0_plus_n_countable, omega0_squared_countable); these are corollaries of three general closure lemmas: IsCountableOrdinal is downward-closed (Ordinal.card_le_card), and closed under ordinal + (Cardinal.add_le_aleph0) and * (mul_le_mul + Cardinal.aleph0_mul_aleph0).",
       "The open conjecture erdos_70_conjecture (∀ countable β, 2≤n, PartitionArrow c β n) specializes definitionally to conjecture_omega n and conjecture_omega_squared n by feeding the parent countability witnesses omega0_countable / omega0_squared_countable.",
-      "Closure under α^n follows by induction: α^0=1 (one_countable), α^(n+1)=α^n·α countable by IsCountableOrdinal.mul. Ordinal.opow_succ is stated with Order.succ, so route the step via Nat.cast_add + Ordinal.opow_add + Ordinal.opow_one to match the ↑n+1 shape."
+      "Closure under α^n follows by induction: α^0=1 (one_countable), α^(n+1)=α^n·α countable by IsCountableOrdinal.mul. Ordinal.opow_succ is stated with Order.succ, so route the step via Nat.cast_add + Ordinal.opow_add + Ordinal.opow_one to match the ↑n+1 shape.",
+      "Session 3: proved ω^ω is a countable ordinal (omega0_opow_omega0_countable), the limit-exponent case the finite-power closure isCountableOrdinal_opow_nat could not reach. Route: bridge IsCountableOrdinal α ↔ α<ω₁ (Cardinal.lt_omega_iff_card_lt + Cardinal.lt_aleph_one_iff), then ω^ω = sup_{β<ω} ω^β ≤ ⨆ n:ℕ ω^n, a countable sup of countable ordinals, so <ω₁ by Ordinal.iSup_lt_omega_one (regularity of ℵ₁).",
+      "Session 3: key Mathlib lemmas — Ordinal.opow_le_of_isSuccLimit (ω^ω ≤ c ↔ ∀β<ω, ω^β≤c), Ordinal.isSuccLimit_omega0, Ordinal.lt_omega0 (β<ω ↔ β=k:ℕ), Ordinal.le_iSup/iSup_le (needs Small.{0} ℕ). Universe must be pinned to Ordinal.{0} (via .{0}) to match the parent's conjecture_omega_tower (Ordinal.{0})."
     ],
     "mathlibGaps": [],
     "nextSteps": [],


### PR DESCRIPTION
## Summary
Research session 3 for **erdos-70-wip-01** (Erdős Problem #70: does 𝔠 → (β, n)₂³ for every countable ordinal β?). Proves **ω^ω is a countable ordinal** — the limit-exponent step flagged as the next task in session 1, which the finite-power closure `isCountableOrdinal_opow_nat` (only `ω^n`, n:ℕ) could not reach. This supplies the missing countability witness for the parent's `conjecture_omega_tower`.

## Progress (3 new axiom-free theorems, `Proofs/Erdos70WIP01.lean`)
- **`isCountableOrdinal_iff_lt_omega_one`** — bridge `IsCountableOrdinal α ↔ α < ω₁` (`card α ≤ ℵ₀ ↔ α < ω₁`), via `Cardinal.lt_omega_iff_card_lt` and `Cardinal.lt_aleph_one_iff`.
- **`omega0_opow_omega0_countable`** — `ω^ω` is countable. Since `ω` is a successor-limit, `Ordinal.opow_le_of_isSuccLimit` gives `ω^ω = sup_{β<ω} ω^β`; each `β<ω` is a finite `k` (`Ordinal.lt_omega0`), so `ω^β ≤ ⨆ n:ℕ, ω^n`. That ℕ-indexed supremum of the countable ordinals `ω^n` stays `< ω₁` by **`Ordinal.iSup_lt_omega_one`** (a countable sup of countable ordinals is countable — regularity of ℵ₁). Hence `ω^ω < ω₁`.
- **`erdos_70_conjecture_imp_omega_tower`** — specializes the open conjecture to `β = ω^ω`, completing the `ω` / `ω²` / `ω^ω` flagship trio.

## Findings
- Universes must be pinned to `Ordinal.{0}` (`Ordinal.omega0.{0}`) to match the parent's `conjecture_omega_tower` (which lives in `Ordinal.{0}`); otherwise the auto-generalized universe metavariable clashes.
- `Cardinal.lt_omega_iff_card_lt` is in the `Cardinal` namespace (not `Ordinal`).

## Verification
- Host-verified: Lean v4.31.0, parent `Erdos70Problem.lean` fresh-built to olean, child `lake env lean Proofs/Erdos70WIP01.lean` exit 0, no Docker.
- `#print axioms` = `propext, Classical.choice, Quot.sound` on all three theorems. 0 axioms, 0 sorries.

## Files modified
- `proofs/Proofs/Erdos70WIP01.lean` (research companion; not a gallery entry — no meta counts to sync)
- `src/data/research/problems/erdos-70-wip-01.json`, `research/problems/erdos-70-wip-01/knowledge.md`

## Status
**Outcome**: progress
**Next Steps**: general closure `isCountableOrdinal_opow` (countable^countable countable) by transfinite induction on the exponent using `opow_limit` + `iSup_lt_omega_one` at each limit stage; higher towers up to ε₀.

🤖 Generated by researcher-1
