### PR TITLE
Enrich central-limit-theorem-oq-02 (martingale/mixing CLT): re-anchor drifted sections, fix false sorry claim, cover Parts X–XI (7→12, coverage 727→935)

### DIFF
--- a/src/data/proofs/central-limit-theorem-oq-02/meta.json
+++ b/src/data/proofs/central-limit-theorem-oq-02/meta.json
@@ -117,60 +117,100 @@
   ],
   "sections": [
     {
+      "id": "sec-clt02-preamble",
+      "title": "Problem Statement & Imports",
+      "startLine": 1,
+      "endLine": 52,
+      "summary": "Module docstring framing OQ02: the classical CLT is a corollary of two strictly more general theorems — the martingale-difference-array CLT (McLeish 1974) and the α-mixing CLT (Ibragimov 1962). Imports Mathlib's probability, martingale, conditional-expectation, and Bochner-integral machinery; opens the CentralLimitTheoremOQ02 namespace.",
+      "mathContext": "Goal: recover $(X_1+\\cdots+X_n)/\\sqrt{n}\\xrightarrow{d}N(0,\\sigma^2)$ as a special case of dependence-robust CLTs (martingale-difference / α-mixing)."
+    },
+    {
       "id": "sec-clt02-mda",
-      "title": "Part I: Martingale Difference Array Structure",
-      "startLine": 44,
-      "endLine": 99,
-      "summary": "MartingaleDiffArray structure (rowSize, X, filtration ℱ, mda_property). rowSum definition. rowSum_mean_zero: E[S_n] = 0 via integral_finset_sum + mda_property.",
-      "mathContext": "$\\{X_{n,k}\\}$ MDA: $\\mathbb{E}[X_{n,k} \\mid \\mathcal{F}_{n,k-1}] = 0$; $S_n = \\sum_{k=0}^{\\text{rowSize}(n)-1} X_{n,k}$; $\\mathbb{E}[S_n] = 0$"
+      "title": "Part I — Martingale Difference Arrays",
+      "startLine": 53,
+      "endLine": 108,
+      "summary": "The `MartingaleDiffArray` structure (rowSize, X, filtration ℱ, filtration_mono, adapted, integrable, sq_integrable, mda_property E[X_{n,k}]=0), the `rowSum` definition S_n = ∑_{k<rowSize n} X_{n,k}, and `rowSum_mean_zero` proving E[S_n]=0 via `integral_finset_sum` + the MDA property. This abstract setting needs neither independence nor identical distribution.",
+      "mathContext": "$\\{X_{n,k}\\}$ MDA: $\\mathbb{E}[X_{n,k}\\mid\\mathcal{F}_{n,k-1}]=0$; $S_n=\\sum_{k<\\text{rowSize}(n)}X_{n,k}$; $\\mathbb{E}[S_n]=0$."
     },
     {
       "id": "sec-clt02-conditions",
-      "title": "Parts II–III: Variance, Lindeberg, and Lyapunov Conditions",
-      "startLine": 100,
-      "endLine": 177,
-      "summary": "varianceSum, lindebergSum (indicator 1{|X|>ε}), lindebergCondition (L_n(ε)→0), varianceConverges (V_n→σ²). lyapunovSum (∑E[|X|^{2+δ}]), lyapunovCondition. lindeberg_sum_nonneg via Finset.sum_nonneg.",
-      "mathContext": "$L_n(\\varepsilon) = \\sum_k \\mathbb{E}[X_{n,k}^2 \\cdot \\mathbf{1}_{|X_{n,k}|>\\varepsilon}] \\to 0$; $V_n = \\sum_k \\mathbb{E}[X_{n,k}^2] \\to \\sigma^2$; $\\Lambda_n(\\delta) = \\sum_k \\mathbb{E}[|X_{n,k}|^{2+\\delta}] \\to 0$"
+      "title": "Part II — Conditional Variance and Lindeberg Condition",
+      "startLine": 109,
+      "endLine": 150,
+      "summary": "The two hypotheses of the martingale CLT as Lean definitions: `varianceSum` V_n = ∑_k E[X²_{n,k}], `lindebergSum` L_n(ε) = ∑_k E[X²_{n,k}·1{|X_{n,k}|>ε}], `lindebergCondition` (∀ε>0, L_n(ε)→0), and `varianceConverges` (V_n→σ²). Lindeberg encodes asymptotic negligibility — no summand dominates.",
+      "mathContext": "$L_n(\\varepsilon)=\\sum_k\\mathbb{E}[X_{n,k}^2\\mathbf{1}_{|X_{n,k}|>\\varepsilon}]\\to0$; $V_n=\\sum_k\\mathbb{E}[X_{n,k}^2]\\to\\sigma^2$."
     },
     {
       "id": "sec-clt02-lyapunov-lindeberg",
-      "title": "Part III: Lyapunov Implies Lindeberg (Fully Proved)",
-      "startLine": 181,
-      "endLine": 270,
-      "summary": "rpow_indicator_bound private lemma: x²·ε^δ ≤ |x|^{2+δ} on {|x|>ε} via Real.rpow_add + mul_le_mul. lyapunov_implies_lindeberg: L_n(ε) ≤ Λ_n(δ)/ε^δ → 0 via integral_mono_of_nonneg + squeeze theorem. variance_sum_nonneg.",
-      "mathContext": "$|x| > \\varepsilon, \\delta > 0 \\Rightarrow x^2 \\cdot \\varepsilon^\\delta \\leq |x|^{2+\\delta}$; $L_n(\\varepsilon) \\leq \\Lambda_n(\\delta)/\\varepsilon^\\delta \\to 0$ (squeeze: $0 \\leq L_n \\leq \\Lambda_n/\\varepsilon^\\delta \\to 0$)"
+      "title": "Part III — Lyapunov Condition Implies Lindeberg (Fully Proved)",
+      "startLine": 151,
+      "endLine": 280,
+      "summary": "Defines `lyapunovCondition` (Λ_n(δ)=∑_k E[|X_{n,k}|^{2+δ}]→0), then the private `rpow_indicator_bound` (x²·ε^δ ≤ |x|^{2+δ} on {|x|>ε} via Real.rpow_add) feeding `lyapunov_implies_lindeberg`: L_n(ε) ≤ Λ_n(δ)/ε^δ → 0 by a squeeze. `lindeberg_sum_nonneg` and `variance_sum_nonneg` close the section — all axiom-free.",
+      "mathContext": "$|x|>\\varepsilon,\\delta>0\\Rightarrow x^2\\varepsilon^\\delta\\le|x|^{2+\\delta}$; hence $0\\le L_n(\\varepsilon)\\le\\Lambda_n(\\delta)/\\varepsilon^\\delta\\to0$."
     },
     {
       "id": "sec-clt02-martingale-clt",
-      "title": "Part IV: Martingale CLT (McLeish 1974) — Axiomatized",
-      "startLine": 272,
-      "endLine": 318,
-      "summary": "rowSumCharFun definition (E[exp(itS_n)]). martingale_clt axiom: MDA + Lindeberg + V_n→σ² ⟹ char fn converges to Gaussian exp(-σ²t²/2). Proof sketch via char fn Taylor expansion and conditional expectation.",
-      "mathContext": "$\\text{MDA} + \\text{Lindeberg} + V_n \\to \\sigma^2 \\Rightarrow \\forall t: \\mathbb{E}[e^{itS_n}] \\to e^{-\\sigma^2 t^2/2}$ (McLeish 1974, Brown 1971)"
+      "title": "Part IV — Martingale CLT (McLeish 1974), Axiomatized",
+      "startLine": 281,
+      "endLine": 328,
+      "summary": "The `rowSumCharFun` definition E[exp(itS_n)] and the sole assumption of the file, the axiom `martingale_clt`: an MDA satisfying the Lindeberg condition and V_n→σ² has row-sum characteristic function converging to the Gaussian exp(−σ²t²/2). This is the one deep external input (McLeish 1974) the whole development is reduced to.",
+      "mathContext": "Axiom: MDA + Lindeberg + $V_n\\to\\sigma^2\\Rightarrow\\forall t:\\ \\mathbb{E}[e^{itS_n}]\\to e^{-\\sigma^2t^2/2}$."
     },
     {
       "id": "sec-clt02-iid-case",
-      "title": "Part V: i.i.d. Case — Classical CLT as Corollary",
-      "startLine": 320,
-      "endLine": 401,
-      "summary": "IIDSequence structure (mean zero, common variance σ²). IIDSequence.toMDA: X_{n,k} = X_k/√n with trivial filtration. iid_mda_variance_converges: V_n = σ² exactly for n ≥ 1 (proved via integral_mul_const + Real.sq_sqrt + field_simp).",
-      "mathContext": "$X_{n,k} = X_k/\\sqrt{n}$; $V_n = \\sum_{k<n} \\sigma^2/n = \\sigma^2$ (exact for $n \\geq 1$); row sum $S_n = (\\sum_{k<n} X_k)/\\sqrt{n}$"
+      "title": "Part V — i.i.d. Case Recovers Classical CLT",
+      "startLine": 329,
+      "endLine": 418,
+      "summary": "The `IIDSequence` structure (independence + common mean-zero variance σ²) and its embedding `toMDA` sending X_{n,k}=X_k/√n with the trivial filtration. `iid_mda_variance_converges` proves V_n = σ² exactly for n≥1 (via integral_mul_const + Real.sq_sqrt + field_simp), verifying the variance hypothesis of the martingale CLT for the classical setting.",
+      "mathContext": "$X_{n,k}=X_k/\\sqrt{n}$; $V_n=\\sum_{k<n}\\sigma^2/n=\\sigma^2$ exactly for $n\\ge1$; $S_n=(\\sum_{k<n}X_k)/\\sqrt{n}$."
     },
     {
       "id": "sec-clt02-mixing",
-      "title": "Parts VI–VIII: α-Mixing, Long-Run Variance, Independence",
-      "startLine": 403,
-      "endLine": 499,
-      "summary": "alphaMixingCoeff (nested iSup over measurable sets). AlphaMixingSequence (mixing_bound, mixing_decay α(n)→0). longRunVariance = Var(X₁) + 2∑Cov. independent_implies_zero_mixing (sorry: nested ciSup = 0 in ℝ).",
-      "mathContext": "$\\alpha(\\mathcal{F}_1,\\mathcal{F}_2) = \\sup_{A,B} |P(A\\cap B) - P(A)P(B)|$; $\\sigma^2_\\infty = \\mathrm{Var}(X_1) + 2\\sum_{k\\geq 1}\\mathrm{Cov}(X_1,X_{k+1})$; $\\alpha(n) \\to 0$ (Rosenblatt 1956)"
+      "title": "Part VI — α-Mixing (Strong Mixing) Condition",
+      "startLine": 419,
+      "endLine": 462,
+      "summary": "Defines the `alphaMixingCoeff` α(ℱ₁,ℱ₂)=sup_{A,B}|μ(A∩B)−μ(A)μ(B)| as a nested iSup over measurable sets, and the `AlphaMixingSequence` structure (integrable, past/future σ-algebras, mixing_bound, and mixing_decay α(n)→0). This is Rosenblatt's (1956) framework for weakly-dependent stationary sequences.",
+      "mathContext": "$\\alpha(\\mathcal{F}_1,\\mathcal{F}_2)=\\sup_{A,B}|\\mu(A\\cap B)-\\mu(A)\\mu(B)|$; α-mixing: $\\alpha(n)\\to0$."
+    },
+    {
+      "id": "sec-clt02-mixing-clt",
+      "title": "Part VII — CLT for Mixing Sequences",
+      "startLine": 463,
+      "endLine": 486,
+      "summary": "Prose statement of Ibragimov's (1962) α-mixing CLT and the `longRunVariance` definition σ²_∞ = Var(X₁) + 2∑_{k≥1}Cov(X₁,X_{k+1}), the variance of partial sums accounting for temporal correlations. (The mixing CLT itself is discussed, not axiomatized — the file's only axiom is the martingale CLT.)",
+      "mathContext": "$\\sigma^2_\\infty=\\mathrm{Var}(X_1)+2\\sum_{k\\ge1}\\mathrm{Cov}(X_1,X_{k+1})$; mixing CLT needs $\\sum_n\\alpha(n)^{\\delta/(2+\\delta)}<\\infty$."
+    },
+    {
+      "id": "sec-clt02-independence",
+      "title": "Part VIII — Independent Variables are Trivially Mixing",
+      "startLine": 487,
+      "endLine": 539,
+      "summary": "`independent_implies_zero_mixing`, fully proved (no sorry): for an independent sequence the α-mixing coefficient is 0 at every lag n≥1. The proof shows every term of the defining supremum vanishes via independence, then collapses the nested Prop-indexed iSup of the constant 0 using a by_cases on the guarding Prop — sidestepping ℝ's lack of a CompleteLattice instance. This exhibits the classical CLT as a special case of the mixing CLT.",
+      "mathContext": "Independent $\\Rightarrow \\alpha(n)=0$ for all $n\\ge1$: each $|\\mu(A\\cap B)-\\mu(A)\\mu(B)|=0$, so the whole nested $\\sup$ collapses to $0$."
+    },
+    {
+      "id": "sec-clt02-hierarchy",
+      "title": "Part IX — Relationship Between Generalizations",
+      "startLine": 540,
+      "endLine": 757,
+      "summary": "The inclusion hierarchy i.i.d. ⊂ Lindeberg–Feller ⊂ MDA ⊂ α-mixing, then the substantive corollaries: `iid_satisfies_lindeberg` (Lindeberg holds for i.i.d./√n, proved via dominated convergence on truncated moments using measurable_truncSq and iid_trunc_swap), `classical_clt_from_martingale` (classical CLT deduced from martingale_clt + the two i.i.d. hypotheses), and `iid_satisfies_lyapunov` (closed form Λ_n(δ)=C/n^{δ/2}→0 for finite (2+δ)-moment).",
+      "mathContext": "$\\mathbb{E}[X_0^2\\mathbf{1}_{|X_0|>\\varepsilon\\sqrt{n}}]\\xrightarrow{\\text{DCT}}0$; $\\Lambda_n(\\delta)=\\mathbb{E}[|X_0|^{2+\\delta}]/n^{\\delta/2}\\to0$."
     },
     {
       "id": "sec-clt02-additional",
-      "title": "Parts IX–XI: Classical CLT Recovery and Additional Results",
-      "startLine": 501,
-      "endLine": 727,
-      "summary": "classical_clt_from_martingale (derives classical CLT from the now-proved iid_satisfies_lindeberg + martingale_clt). iid_satisfies_lindeberg (proved via DCT on truncated moments). iid_satisfies_lyapunov (proved via rpow moment decay). lyapunov_sum_at_zero (δ=0 = varianceSum via sq_abs). rowSumCharFun_zero. Zero-variable lemmas. variance_sum_bounded_of_converges (eventual bound + Finset.sup').",
-      "mathContext": "$(X_1+\\cdots+X_n)/\\sqrt{n} \\xrightarrow{d} N(0,\\sigma^2)$; proved: $\\mathbb{E}[X^2 \\cdot \\mathbf{1}_{|X|>\\varepsilon\\sqrt{n}}] \\xrightarrow{\\text{DCT}} 0$; $\\Lambda_n(\\delta) = \\mathbb{E}[|X|^{2+\\delta}]/n^{\\delta/2} \\to 0$"
+      "title": "Part X — Additional Proved Results",
+      "startLine": 758,
+      "endLine": 902,
+      "summary": "Eleven clean axiom-free lemmas rounding out the formalization: lyapunov_sum_at_zero (Λ_n(0)=V_n via sq_abs), iid_mda_rowSum_eq, iid_toMDA_rowSize, variance_sum_iid_eq (V_n=σ² for n≥1), rowSumCharFun_zero and gaussian_charfun_zero (both CLT sides equal 1 at t=0), the three zero-variable lemmas (lindeberg/variance/lyapunov sums vanish when X≡0 a.e.), variance_sum_bounded_of_converges (a convergent variance sum is globally bounded via eventual bound + Finset.sup' over the finite prefix), and integral_sq_nonneg.",
+      "mathContext": "$\\Lambda_n(0)=V_n$; $\\hat S_n(0)=1$; convergent $V_n\\Rightarrow\\exists C,\\ V_n\\le C$ (eventual ball + finite-prefix max)."
+    },
+    {
+      "id": "sec-clt02-summary",
+      "title": "Part XI — Summary and Key Results",
+      "startLine": 903,
+      "endLine": 935,
+      "summary": "A ledger docstring cataloguing what is fully proved (MDA structure, mean-zero row sums, i.i.d. variance convergence, Lyapunov⇒Lindeberg, independence⇒zero mixing, the Part X lemmas), what is proved conditionally on the axiom (classical CLT from the martingale CLT), and the single axiomatized input (McLeish's martingale CLT). NOTE: the embedded 'remaining sorries' tally in this docstring is stale — the actual file has 0 sorries and exactly 1 axiom (see meta.axiomCount).",
+      "mathContext": "Bottom line: classical CLT holds modulo one axiom (martingale CLT); everything else — Lyapunov⇒Lindeberg, i.i.d. reductions, independence⇒mixing — is machine-checked."
     }
   ],
   "sorries": 0,


### PR DESCRIPTION
## Enrichment pass — central-limit-theorem-oq-02 (Martingale / α-mixing generalizations of the CLT)

**Section re-anchoring + tail coverage + integrity fix.** The `sections` list had drifted and, critically, stopped at line **727** while `Proofs/CentralLimitTheoremOQ02.lean` runs to line **935** — the entire **Part X (11 proved axiom-free lemmas)** and **Part XI (results ledger)** were uncovered. Several existing sections also merged multiple `## Part` banners under drifted line ranges (e.g. "Parts VI–VIII [403–499]" cut off mid-Part-VIII; "Parts IX–XI [501–727]" never reached Parts X or XI).

### What changed
- Re-anchored all sections to the actual `## Part N:` banners, now **contiguous line 1 → 935 (EOF)**.
- Section count **7 → 12**: split the merged multi-Part sections, added a head "Problem Statement & Imports" section, and added dedicated sections for **Part X** (`lyapunov_sum_at_zero`, `variance_sum_iid_eq`, `rowSumCharFun_zero`, the three zero-variable lemmas, `variance_sum_bounded_of_converges`, `integral_sq_nonneg`, …) and **Part XI**.
- **Integrity fix:** the old Part VI–VIII summary claimed `independent_implies_zero_mixing` still had a `sorry` ("nested ciSup = 0 in ℝ"). It is in fact **fully proved** (lines 495–537, via a by_cases Prop-indexed iSup collapse). Corrected the summary and gave it its own Part VIII section.
- Added a note on the new Part XI section that the Lean file's embedded "remaining sorries (3)" ledger line is itself **stale** — the file genuinely has **0 sorries and 1 axiom** (verified by grep; matches `meta.axiomCount: 1`, `sorries: 0`).

### Integrity
- No status/badge/axiomCount change: remains `axiomatized`, `badge: "axiom"`, `axiomCount: 1` (the single `axiom martingale_clt`, McLeish 1974). Verified 1 axiom / 0 sorries in the primary Lean file.
- Contiguity 1..935 and JSON round-trip checked locally.
