### PR TITLE
Research: erdos-70-wip-01 — general closure of the countable ordinals under exponentiation (isCountableOrdinal_opow, 0-axiom)

### DIFF
--- a/proofs/Proofs/Erdos70WIP01.lean
+++ b/proofs/Proofs/Erdos70WIP01.lean
@@ -32,6 +32,15 @@ and `*`; and it wires the open conjecture to its published special cases.
    specializes to its two flagship cases `𝔠 → (ω, n)` and `𝔠 → (ω², n)`, using
    the parent's countability witnesses.
 
+4. `isCountableOrdinal_opow_nat` / `omega0_opow_omega0_countable` /
+   `isCountableOrdinal_opow` — closure under exponentiation, from `α ^ (n:ℕ)`
+   through the single limit power `ω^ω` up to the **general** statement that the
+   countable ordinals are closed under `α ^ β` for arbitrary countable `α, β`
+   (transfinite induction on the exponent + regularity of `ℵ₁`). Consequently the
+   whole exponential tower `ω`, `ω^ω`, `ω^(ω^ω)`, … below `ε₀` is countable, and
+   the conjecture specializes to every such `β` (`erdos_70_conjecture_imp_omega_tower`,
+   `_imp_omega_tower_two`).
+
 ## Summary: 0 sorries, 0 axioms, no `native_decide`. Built over the gallery defs.
 -/
 
@@ -134,5 +143,70 @@ countability witness `omega0_opow_omega0_countable`. -/
 theorem erdos_70_conjecture_imp_omega_tower (h : erdos_70_conjecture) (n : ℕ)
     (hn : 2 ≤ n) : conjecture_omega_tower n :=
   h (Ordinal.omega0 ^ Ordinal.omega0) n omega0_opow_omega0_countable hn
+
+/-! ## General closure under ordinal exponentiation
+
+`isCountableOrdinal_opow_nat` (above) closes the countable ordinals only under
+exponentiation by a *natural number*, and `omega0_opow_omega0_countable` handles
+the single limit exponent `ω^ω`.  The theorem below is the full statement: the
+countable ordinals are closed under ordinal exponentiation `α ^ β` for **arbitrary**
+countable base and exponent.  With it, every ordinal built from `ω` by finitely
+many `+`, `*`, `^` steps — the whole tower `ω`, `ω^ω`, `ω^(ω^ω)`, … below `ε₀` —
+is a countable ordinal, so the parent conjecture's hypothesis `IsCountableOrdinal β`
+holds throughout that range.
+
+The proof is transfinite induction on the exponent (`Ordinal.limitRecOn`):
+* `β = 0`: `α ^ 0 = 1` is countable.
+* `β = o + 1`: `α ^ (o+1) = α ^ o · α` (`opow_add_one`), countable by the mul-closure.
+* `β` a succ-limit: for `α ≠ 0`, `α ^ β = ⨆_{x < β} α ^ x` (`opow_limit`); the index
+  `Set.Iio β` is *countable* because `β` is (`mk_Iio_ordinal` + `lift_le_aleph0`), and
+  each `α ^ x` is countable by the induction hypothesis, so the supremum stays below
+  `ω₁` (`Ordinal.iSup_lt_omega_one`, regularity of `ℵ₁`).  The degenerate base `α = 0`
+  gives `0 ^ β = 0` (`zero_opow`, since a limit exponent is nonzero). -/
+theorem isCountableOrdinal_opow {α β : Ordinal} (hα : IsCountableOrdinal α) :
+    IsCountableOrdinal β → IsCountableOrdinal (α ^ β) := by
+  induction β using Ordinal.limitRecOn with
+  | zero =>
+    intro _
+    rw [Ordinal.opow_zero]; exact one_countable
+  | add_one o ih =>
+    intro hβ
+    have ho : IsCountableOrdinal o := hβ.of_le (self_le_add_right o 1)
+    rw [Ordinal.opow_add_one]
+    exact isCountableOrdinal_mul (ih ho) hα
+  | limit o hlim ih =>
+    intro hβ
+    rcases eq_or_ne α 0 with rfl | hα0
+    · have ho0 : o ≠ 0 := by
+        have := hlim.ne_bot; simpa [Ordinal.bot_eq_zero] using this
+      rw [Ordinal.zero_opow ho0]
+      exact zero_countable
+    · have hcount : Countable (Set.Iio o) := by
+        rw [← Cardinal.mk_le_aleph0_iff, Cardinal.mk_Iio_ordinal, Cardinal.lift_le_aleph0]
+        exact hβ
+      rw [isCountableOrdinal_iff_lt_omega_one, Ordinal.opow_limit hα0 hlim]
+      apply Ordinal.iSup_lt_omega_one
+      rintro ⟨x, hx⟩
+      exact isCountableOrdinal_iff_lt_omega_one.mp (ih x hx (hβ.of_le (le_of_lt hx)))
+
+/-- **The second tower level `ω^(ω^ω)` is a countable ordinal.**  An immediate
+consequence of the general closure `isCountableOrdinal_opow` applied twice to
+`omega0_countable`; whereas `omega0_opow_omega0_countable` needed a bespoke
+countable-supremum argument, every further tower level is now free.  Supplies the
+`β = ω^(ω^ω)` countability witness for `erdos_70_conjecture`. -/
+theorem omega0_opow_omega0_opow_omega0_countable :
+    IsCountableOrdinal
+      (Ordinal.omega0.{0} ^ (Ordinal.omega0.{0} ^ Ordinal.omega0.{0})) :=
+  isCountableOrdinal_opow omega0_countable
+    (isCountableOrdinal_opow omega0_countable omega0_countable)
+
+/-- The open conjecture specializes to the second tower level `𝔠 → (ω^(ω^ω), n)₂³`,
+using the countability witness `omega0_opow_omega0_opow_omega0_countable`. -/
+theorem erdos_70_conjecture_imp_omega_tower_two (h : erdos_70_conjecture) (n : ℕ)
+    (hn : 2 ≤ n) :
+    PartitionArrow continuum_card
+      (Ordinal.omega0 ^ (Ordinal.omega0 ^ Ordinal.omega0)) n :=
+  h (Ordinal.omega0 ^ (Ordinal.omega0 ^ Ordinal.omega0)) n
+    omega0_opow_omega0_opow_omega0_countable hn
 
 end Erdos70

--- a/research/problems/erdos-70-wip-01/knowledge.md
+++ b/research/problems/erdos-70-wip-01/knowledge.md
@@ -132,3 +132,42 @@ Also `Cardinal.lt_omega_iff_card_lt` is in the **`Cardinal`** namespace (not `Or
 - General closure `isCountableOrdinal_opow` (α, β countable ⟹ α^β countable) by transfinite
   induction on β using `opow_limit` + `iSup_lt_omega_one` at each limit stage.
 - Towers `ω^(ω^ω)` etc. up to `ε₀`; all countable, each a `le_iSup`-over-ℕ argument.
+
+## Session 2026-07-21 (researcher-1): general closure under ordinal exponentiation
+
+Extended `Proofs/Erdos70WIP01.lean` with the **general** exponentiation-closure
+theorem (theoremCount 10→13, still 0 axioms, 0 sorries; host-verified: fresh
+parent olean + `lake env lean`, `#print axioms` = propext/Classical.choice/Quot.sound).
+
+- **`isCountableOrdinal_opow {α β} (hα : IsCountableOrdinal α) : IsCountableOrdinal β →
+  IsCountableOrdinal (α ^ β)`** — the capstone the prior sessions were building toward.
+  Subsumes both `isCountableOrdinal_opow_nat` (only `ω^n`, n:ℕ) and the bespoke
+  `omega0_opow_omega0_countable` (only `ω^ω`). Transfinite induction on the exponent
+  (`Ordinal.limitRecOn`):
+  - `β=0`: `α^0=1` (`one_countable`).
+  - `β=o+1`: `α^(o+1)=α^o·α` (`opow_add_one`), mul-closure.
+  - `β` succ-limit, `α≠0`: `α^β = ⨆_{x:Iio β} α^x` (`opow_limit`); `Iio β` is a
+    *countable* index type (`Cardinal.mk_Iio_ordinal` + `Cardinal.lift_le_aleph0`),
+    each `α^x` countable by IH, so `⨆ < ω₁` via `Ordinal.iSup_lt_omega_one`
+    (regularity of ℵ₁). `α=0`: `0^β=0` (`zero_opow`, limit exponent ≠ 0).
+- **`omega0_opow_omega0_opow_omega0_countable`** — `ω^(ω^ω)` (2nd tower level),
+  now a two-line corollary `isCountableOrdinal_opow omega0_countable (isCountableOrdinal_opow …)`.
+- **`erdos_70_conjecture_imp_omega_tower_two`** — conjecture specialized to `β = ω^(ω^ω)`.
+
+### Consequence
+The whole exponential tower `ω, ω^ω, ω^(ω^ω), …` below `ε₀` is countable, and the
+countable-ordinal class is now proved closed under all three ordinal operations
+(`+`, `·`, `^`). Every further tower level is a one-liner.
+
+### Gotchas (v4.31)
+- `limitRecOn`'s successor case is stated with `o + 1` (not `Order.succ o`), so use
+  `Ordinal.opow_add_one` (`a^(b+1)=a^b*a`) and `self_le_add_right o 1` for `o ≤ o+1`.
+- `opow_limit` indexes the sup by `Set.Iio b` (a subtype in `Type 1` for `Ordinal.{0}`);
+  `Cardinal.mk_Iio_ordinal` gives `#(Iio b) = lift b.card`, and `Cardinal.lift_le_aleph0`
+  clears the universe lift so `Countable (Iio b)` follows from `IsCountableOrdinal b`.
+- `IsSuccLimit.ne_bot` gives `o ≠ ⊥`; convert to `o ≠ 0` via `Ordinal.bot_eq_zero`.
+
+### Frontier (UNCHANGED)
+Erdős #70 itself (positive partition relation for general countable β) remains OPEN —
+the Erdős–Rado result `𝔠 → (ω+n, 4)₂³` needs partition-calculus machinery absent from
+Mathlib v4.31. The ordinal-arithmetic countability toolkit is now complete.

--- a/src/data/research/problems/erdos-70-wip-01.json
+++ b/src/data/research/problems/erdos-70-wip-01.json
@@ -20,10 +20,10 @@
   "currentState": {
     "phase": "ACT",
     "since": "2026-07-09T17:33:19-07:00",
-    "iteration": 2,
-    "focus": "Batch 2: countability closure toolkit (mono/add/mul), conjecture=>specialization theorems (omega, omega^2), PartitionArrow boundary cases (0). Theorem count 9->18, 0 axioms, host-verified.",
+    "iteration": 3,
+    "focus": "Session 4: general closure isCountableOrdinal_opow — countable ordinals closed under α^β for arbitrary countable α,β (transfinite induction on exponent + iSup_lt_omega_one/regularity of ℵ₁). Plus omega0_opow_omega0_opow_omega0_countable (ω^(ω^ω), 2nd tower level) and its conjecture specialization. 0 axioms, host-verified.",
     "blockers": [],
-    "nextAction": "Prove ω^ω countable (countable-sup argument) to unlock conjecture_omega_tower; Erdős-Rado positive result needs partition-calculus machinery not in Mathlib.",
+    "nextAction": "Frontier: Erdős #70 itself (general countable β) OPEN — Erdős–Rado positive result 𝔠→(ω+n,4)₂³ needs partition-calculus machinery absent from Mathlib. Ordinal-arithmetic countability toolkit now complete (+, ·, ^ all closed; towers below ε₀ free).",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -31,7 +31,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (session 3): Proved ω^ω countable (omega0_opow_omega0_countable) — the limit-exponent closure past all finite powers of ω, and the missing witness for the parent's conjecture_omega_tower. Added the bridge isCountableOrdinal_iff_lt_omega_one (card≤ℵ₀ ↔ <ω₁) and the conjecture specialization erdos_70_conjecture_imp_omega_tower. 3 new axiom-free theorems in Erdos70WIP01.lean, host-verified (lake env lean exit 0, #print axioms = propext/Classical.choice/Quot.sound). Next: general opow closure (countable^countable countable) via transfinite induction, or ε₀-type towers.",
+    "progressSummary": "Countable-ordinal class proved closed under +, ·, and (this session) general exponentiation α^β; conjecture specialized to the ω, ω², ω^ω, and ω^(ω^ω) tower levels. 0 axioms, 0 sorries.",
     "builtItems": [
       "Erdos70.IsCountableOrdinal.of_le in Erdos70WIP01.lean",
       "Erdos70.isCountableOrdinal_add in Erdos70WIP01.lean",
@@ -52,7 +52,10 @@
       "Session 3: key Mathlib lemmas — Ordinal.opow_le_of_isSuccLimit (ω^ω ≤ c ↔ ∀β<ω, ω^β≤c), Ordinal.isSuccLimit_omega0, Ordinal.lt_omega0 (β<ω ↔ β=k:ℕ), Ordinal.le_iSup/iSup_le (needs Small.{0} ℕ). Universe must be pinned to Ordinal.{0} (via .{0}) to match the parent's conjecture_omega_tower (Ordinal.{0})."
     ],
     "mathlibGaps": [],
-    "nextSteps": [],
+    "nextSteps": [
+      "Erdős #70 positive direction (Erdős–Rado partition calculus) is out of reach — no 𝔠→(ω+n,4)₂³ machinery in Mathlib v4.31.",
+      "Countability toolkit is complete for ordinal arithmetic; further tower levels are one-liners from isCountableOrdinal_opow."
+    ],
     "markdown": "# Knowledge Base: erdos-70-wip-01\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },
   "tags": [
@@ -73,7 +76,7 @@
     "mathlib": []
   },
   "started": "2026-07-10T00:41:25.782Z",
-  "lastUpdate": "2026-07-20",
+  "lastUpdate": "2026-07-21",
   "significance": 8,
   "tractability": 5
 }


### PR DESCRIPTION
## Summary
Research session 4 for **erdos-70-wip-01** (Erdős Problem #70: does 𝔠 → (β, n)₂³ for every countable ordinal β?). Adds the **general** exponentiation-closure theorem the earlier sessions were building toward. Follows the just-merged #39931 (which proved the single case `ω^ω` countable).

## Progress (3 new axiom-free theorems, `Proofs/Erdos70WIP01.lean`, theoremCount 10→13)
- **`isCountableOrdinal_opow (hα : IsCountableOrdinal α) : IsCountableOrdinal β → IsCountableOrdinal (α ^ β)`** — the countable ordinals are closed under ordinal exponentiation `α ^ β` for **arbitrary** countable base and exponent. Subsumes both `isCountableOrdinal_opow_nat` (only `ω^n`, `n:ℕ`) and the bespoke `omega0_opow_omega0_countable` (only `ω^ω`). Transfinite induction on the exponent (`Ordinal.limitRecOn`):
  - `β = 0`: `α^0 = 1`.
  - `β = o+1`: `α^(o+1) = α^o · α` (`opow_add_one`), countable by mul-closure.
  - `β` a succ-limit, `α ≠ 0`: `α^β = ⨆_{x < β} α^x` (`opow_limit`); the index `Set.Iio β` is a **countable** type because `β` is (`Cardinal.mk_Iio_ordinal` + `Cardinal.lift_le_aleph0`), each `α^x` is countable by the IH, so the supremum stays `< ω₁` via `Ordinal.iSup_lt_omega_one` (regularity of ℵ₁). Degenerate base `α = 0` gives `0^β = 0` (`zero_opow`, a limit exponent is nonzero).
- **`omega0_opow_omega0_opow_omega0_countable`** — `ω^(ω^ω)` (the 2nd tower level) is countable, now a two-line corollary of the general theorem applied twice to `omega0_countable`.
- **`erdos_70_conjecture_imp_omega_tower_two`** — the open conjecture specialized to `β = ω^(ω^ω)`.

## Consequence
The entire exponential tower `ω, ω^ω, ω^(ω^ω), …` below `ε₀` is now countable, and the countable-ordinal class is proved closed under all three ordinal operations (`+`, `·`, `^`). Every further tower level is a one-liner.

## Findings / gotchas (v4.31)
- `limitRecOn`'s successor case is stated with `o + 1` (not `Order.succ o`) → use `Ordinal.opow_add_one` and `self_le_add_right o 1`.
- `opow_limit` indexes the sup by `Set.Iio b` (a subtype in `Type 1` for `Ordinal.{0}`); `Cardinal.mk_Iio_ordinal` gives `#(Iio b) = lift b.card`, and `Cardinal.lift_le_aleph0` clears the universe lift, so `Countable (Iio b)` follows from `IsCountableOrdinal b`.
- `IsSuccLimit.ne_bot` gives `o ≠ ⊥`; convert to `o ≠ 0` via `Ordinal.bot_eq_zero`.

## Verification
- Host-verified: Lean v4.31.0, parent `Erdos70Problem.lean` fresh-built to olean, child `lake env lean Proofs/Erdos70WIP01.lean` exit 0, no Docker.
- `#print axioms` = `propext, Classical.choice, Quot.sound` on all three new theorems. **0 axioms, 0 sorries.**

## Files modified
- `proofs/Proofs/Erdos70WIP01.lean` (research companion; not a gallery entry — no meta counts to sync)
- `research/problems/erdos-70-wip-01/knowledge.md`, `src/data/research/problems/erdos-70-wip-01.json`

## Status
**Outcome**: progress. **Frontier (unchanged)**: Erdős #70 itself (positive partition relation for general countable β) remains OPEN — the Erdős–Rado result `𝔠 → (ω+n, 4)₂³` needs partition-calculus machinery absent from Mathlib. The ordinal-arithmetic countability toolkit is now complete.

🤖 Generated by researcher-1
