### PR TITLE
Research: erdos-46-wip-01 — unit-fraction splitting identity + lengthening step (5 axiom-free theorems)

### DIFF
--- a/proofs/Proofs/Erdos46Problem.lean
+++ b/proofs/Proofs/Erdos46Problem.lean
@@ -186,3 +186,75 @@ theorem erdosProblem46_of_infinitely_many
   intro r hr c
   obtain ⟨S, hrepr, hmono, _⟩ := h r hr c 0
   exact ⟨S, hrepr, hmono⟩
+
+/-! ## Unit-fraction splitting and a concrete representation
+
+The Fibonacci–Sylvester *splitting identity* `1/n = 1/(n+1) + 1/(n(n+1))` is the
+elementary engine behind unit-fraction constructions: it replaces one reciprocal by
+two strictly larger ones with the same total. Together with a concrete base
+representation it witnesses that `IsUnitFractionRepr` is inhabited. -/
+
+/-- **Telescoping identity.** `1/(n(n+1)) = 1/n - 1/(n+1)` for `n ≥ 1` (as rationals). -/
+theorem inv_mul_succ (n : ℕ) (hn : 1 ≤ n) :
+    (1 : ℚ) / (n * (n + 1)) = 1 / n - 1 / (n + 1) := by
+  have hn0 : (n : ℚ) ≠ 0 := by positivity
+  have hn1 : (n : ℚ) + 1 ≠ 0 := by positivity
+  field_simp
+  ring
+
+/-- **Splitting identity.** `1/n = 1/(n+1) + 1/(n(n+1))` for `n ≥ 1`: a single unit
+fraction splits into two strictly larger ones with the same sum. The Fibonacci–Sylvester
+step used to lengthen unit-fraction representations. -/
+theorem split_unit_fraction (n : ℕ) (hn : 1 ≤ n) :
+    (1 : ℚ) / n = 1 / (n + 1) + 1 / (n * (n + 1)) := by
+  rw [inv_mul_succ n hn]; ring
+
+/-- **A concrete unit-fraction representation of `1`:** `{2, 3, 6}`, since
+`1/2 + 1/3 + 1/6 = 1`. Witnesses that `IsUnitFractionRepr` is inhabited. -/
+theorem isUnitFractionRepr_two_three_six :
+    IsUnitFractionRepr ({2, 3, 6} : Finset ℕ) := by
+  refine ⟨?_, ?_⟩
+  · decide
+  · norm_num [Finset.sum_insert, Finset.mem_insert, Finset.mem_singleton]
+
+/-- Unit-fraction representations of `1` exist. -/
+theorem exists_isUnitFractionRepr : ∃ S : Finset ℕ, IsUnitFractionRepr S :=
+  ⟨{2, 3, 6}, isUnitFractionRepr_two_three_six⟩
+
+/-- **Term-replacement / lengthening step.** Given a unit-fraction representation `S`
+containing `m`, if the two split denominators `m+1` and `m(m+1)` are not already in `S`,
+then replacing `m` by `{m+1, m(m+1)}` (via the splitting identity) yields another
+unit-fraction representation of `1`. This is the elementary induction step behind
+producing arbitrarily long — and, with disjoint choices, infinitely many — monochromatic
+representations. -/
+theorem isUnitFractionRepr_replace
+    {S : Finset ℕ} (hS : IsUnitFractionRepr S) {m : ℕ} (hm : m ∈ S)
+    (h1 : m + 1 ∉ S) (h2 : m * (m + 1) ∉ S) :
+    IsUnitFractionRepr (insert (m + 1) (insert (m * (m + 1)) (S.erase m))) := by
+  obtain ⟨hge, hsum⟩ := hS
+  have hm2 : 2 ≤ m := hge m hm
+  have hm1 : 1 ≤ m := le_trans (by norm_num) hm2
+  have h2erase : m * (m + 1) ∉ S.erase m := fun h => h2 (Finset.mem_of_mem_erase h)
+  have hne : m + 1 ≠ m * (m + 1) := by nlinarith
+  have h1insert : m + 1 ∉ insert (m * (m + 1)) (S.erase m) := by
+    simp only [Finset.mem_insert]
+    push_neg
+    exact ⟨hne, fun h => h1 (Finset.mem_of_mem_erase h)⟩
+  refine ⟨?_, ?_⟩
+  · intro n hn
+    simp only [Finset.mem_insert] at hn
+    rcases hn with rfl | rfl | hn
+    · omega
+    · nlinarith
+    · exact hge n (Finset.mem_of_mem_erase hn)
+  · rw [Finset.sum_insert h1insert, Finset.sum_insert h2erase]
+    have herase : (S.erase m).sum (fun n => (1 : ℚ) / n) = 1 - 1 / m := by
+      have hadd := Finset.add_sum_erase S (fun n => (1 : ℚ) / n) hm
+      rw [hsum] at hadd
+      linarith [hadd]
+    have hcast1 : ((m + 1 : ℕ) : ℚ) = (m : ℚ) + 1 := by push_cast; ring
+    have hcast2 : ((m * (m + 1) : ℕ) : ℚ) = (m : ℚ) * ((m : ℚ) + 1) := by push_cast; ring
+    have hsplit := split_unit_fraction m hm1
+    rw [herase]
+    simp only [hcast1, hcast2]
+    linarith [hsplit]

--- a/research/problems/erdos-46-wip-01/knowledge.md
+++ b/research/problems/erdos-46-wip-01/knowledge.md
@@ -54,3 +54,36 @@ added structural infrastructure:
 Croot's theorem itself (2003, existence of the monochromatic representation) is deep and
 unformalized — needs the density/covering machinery from the paper. This session builds
 only the elementary scaffolding around the statement.
+
+## Session 2026-07-21 (researcher-1) — splitting identity + concrete witness + lengthening step
+
+**Mode**: build on #39650 scaffolding. **Outcome**: progress — 5 axiom-free theorems in
+`Erdos46Problem.lean` (theoremCount 16→21), host-verified v4.31 (`lake env lean`, exit 0,
+`#print axioms` = `[propext, Classical.choice, Quot.sound]` on all 5).
+
+Adds the elementary *construction* machinery the prior session's structural lemmas lacked:
+
+- `inv_mul_succ (n≥1)` — telescoping `1/(n(n+1)) = 1/n − 1/(n+1)` (`field_simp; ring`).
+- `split_unit_fraction (n≥1)` — the **Fibonacci–Sylvester splitting identity**
+  `1/n = 1/(n+1) + 1/(n(n+1))`: one reciprocal splits into two strictly larger ones with
+  equal sum. The engine for lengthening representations.
+- `isUnitFractionRepr_two_three_six` — concrete witness `IsUnitFractionRepr {2,3,6}`
+  (`1/2+1/3+1/6 = 1`; `decide` for the ≥2 side, `norm_num [Finset.sum_insert,…]` for the sum).
+- `exists_isUnitFractionRepr` — the representation set is inhabited.
+- `isUnitFractionRepr_replace` — **the induction step**: from any representation `S ∋ m`,
+  if `m+1, m(m+1) ∉ S`, replacing `m` by `{m+1, m(m+1)}` gives another representation of 1.
+  Proof: `sum_insert` ×2 + `add_sum_erase` (∑ over `S.erase m` = `1 − 1/m`) + the split
+  identity, closed by `linarith`. This is the elementary path toward arbitrarily long /
+  infinitely many disjoint monochromatic representations (`ErdosProblem46_infinitely_many`).
+
+### v4.31 gotchas
+- `split_unit_fraction`'s `1/(n+1)` elaborates in ℚ as `1/((n:ℚ)+1)` (cast-then-add), so
+  after `Finset.sum_insert` the goal's `1/((m+1:ℕ):ℚ)` needs `push_cast` bridges
+  (`((m+1:ℕ):ℚ) = (m:ℚ)+1`) via a `simp only [hcast1,hcast2]` before `linarith [hsplit]`.
+- `Finset.add_sum_erase S f hm : f m + ∑_{S.erase m} f = ∑_S f` — rewrite `hsum` in it, then
+  `linarith` to isolate the erase-sum.
+
+### Still open (UNCHANGED)
+Croot's theorem itself (existence of the monochromatic representation) remains deep and
+unformalized — needs the density/covering machinery from the 2003 paper. This session
+supplies only the elementary splitting/lengthening toolkit around the statement.

--- a/src/data/proofs/erdos-46/meta.json
+++ b/src/data/proofs/erdos-46/meta.json
@@ -57,9 +57,9 @@
       "Verified basic properties (empty, singleton, monotone, cardinality)"
     ],
     "axiomCount": 0,
-    "lineCount": 84,
+    "lineCount": 260,
     "assumptions": "0 axioms, 0 sorries. All results proved from Lean primitives.",
-    "theoremCount": 3,
+    "theoremCount": 21,
     "definitionCount": 7
   },
   "overview": {
@@ -155,9 +155,9 @@
       "Finset"
     ],
     "namespace": null,
-    "lineCount": 188,
+    "lineCount": 260,
     "axiomCount": 0,
-    "theoremCount": 16,
+    "theoremCount": 21,
     "definitionCount": 7,
     "path": "Proofs/Erdos46Problem.lean",
     "sorries": 0

--- a/src/data/research/problems/erdos-46-wip-01.json
+++ b/src/data/research/problems/erdos-46-wip-01.json
@@ -20,10 +20,10 @@
   "currentState": {
     "phase": "ORIENT",
     "since": "2026-07-09T17:33:18-07:00",
-    "iteration": 1,
-    "focus": "Initial problem understanding. Read problem.md and gather context.",
+    "iteration": 2,
+    "focus": "Session 2: splitting identity (Fibonacci–Sylvester 1/n=1/(n+1)+1/(n(n+1))), telescoping form, concrete witness {2,3,6}, existence, and the term-replacement lengthening step (isUnitFractionRepr_replace). 5 axiom-free theorems, theoremCount 16→21, host-verified.",
     "blockers": [],
-    "nextAction": "Read problem.md thoroughly and acquire full context.",
+    "nextAction": "Croot's theorem (existence of monochromatic representation) is deep/unformalized — needs density/covering machinery from the 2003 paper. Elementary splitting/lengthening toolkit now in place; a full lengthening-to-infinity chain would need denominator-freshness bookkeeping.",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -64,7 +64,7 @@
     "mathlib": []
   },
   "started": "2026-07-10T00:41:25.781Z",
-  "lastUpdate": "2026-07-10T00:41:25.928Z",
+  "lastUpdate": "2026-07-21",
   "significance": 6,
   "tractability": 7
 }


### PR DESCRIPTION
## Summary
Session 2 for **erdos-46-wip-01** (Erdős #46 / Croot: every finite colouring of ℕ has a monochromatic `S` with `∑_{n∈S} 1/n = 1`). Adds the elementary **construction** toolkit that the prior session's structural lemmas (#39650) lacked — the splitting identity, a concrete witness, and the term-replacement induction step.

## Progress (5 new axiom-free theorems, `Proofs/Erdos46Problem.lean`, theoremCount 16→21)
- **`split_unit_fraction (n ≥ 1)`** — the Fibonacci–Sylvester **splitting identity** `1/n = 1/(n+1) + 1/(n(n+1))`: one reciprocal splits into two strictly larger ones with equal sum.
- **`inv_mul_succ (n ≥ 1)`** — telescoping form `1/(n(n+1)) = 1/n − 1/(n+1)`.
- **`isUnitFractionRepr_two_three_six`** — concrete witness `IsUnitFractionRepr {2,3,6}` (`1/2+1/3+1/6 = 1`), so the representation set is non-vacuous.
- **`exists_isUnitFractionRepr`** — unit-fraction representations of `1` exist.
- **`isUnitFractionRepr_replace`** — **the induction step**: from any representation `S ∋ m`, if `m+1` and `m(m+1)` are not already in `S`, replacing `m` by `{m+1, m(m+1)}` yields another representation of `1`. Proof: `Finset.sum_insert` ×2 + `Finset.add_sum_erase` (`∑` over `S.erase m` = `1 − 1/m`) + the split identity, closed by `linarith`. This is the elementary path toward arbitrarily long — and, with disjoint choices, infinitely many — monochromatic representations (`ErdosProblem46_infinitely_many`).

## Verification
- Host-verified: Lean v4.31.0, `lake env lean Proofs/Erdos46Problem.lean` exit 0, no Docker.
- `#print axioms` = `propext, Classical.choice, Quot.sound` on all 5 new theorems. **0 axioms, 0 sorries.**

## Status
Gallery entry `erdos-46` stays **`axiomatized` / `wip`** — Croot's theorem itself (existence of the monochromatic representation) remains deep and unformalized (needs the density/covering machinery of the 2003 paper). This PR supplies only the elementary splitting/lengthening toolkit around the statement. Counts synced: `meta`/`leanFile` theoremCount 16→21, lineCount →260.

## Files modified
- `proofs/Proofs/Erdos46Problem.lean`, `src/data/proofs/erdos-46/meta.json`
- `research/problems/erdos-46-wip-01/knowledge.md`, `src/data/research/problems/erdos-46-wip-01.json`

🤖 Generated by researcher-1
