### PR TITLE
Enrich abel-ruffini-galois-extensions-oq-07 (Burnside pᵃqᵇ): re-anchor drifted Part IV/V/VI + cover p²·q² block, fix stale native_decide claim

### DIFF
--- a/src/data/proofs/abel-ruffini-galois-extensions-oq-07/meta.json
+++ b/src/data/proofs/abel-ruffini-galois-extensions-oq-07/meta.json
@@ -252,25 +252,32 @@
       "summary": "`burnside_p_squared_q` and `burnside_p_q_squared`: top-level axiom-free theorems that consolidate the per-case results of Part III.6 into clean statements for the `(a, b) = (2, 1)` and `(a, b) = (1, 2)` shapes, dispatching internally on the `p` vs `q` ordering (and the `|G| = 12` exception) so callers need not case-split."
     },
     {
+      "id": "p-squared-q-squared",
+      "title": "Part III.7 (cont.): |G| = p² · q² shape, (a, b) = (2, 2) (axiom-free, excl. |G| = 36)",
+      "startLine": 1675,
+      "endLine": 1817,
+      "summary": "The `(a, b) = (2, 2)` shape `|G| = p^2 q^2`. `burnside_p_squared_q_squared_p_lt_q` / `_q_lt_p` and the consolidated `burnside_p_squared_q_squared` prove solvability axiom-free by re-using the same Sylow-counting helper `sylow_count_eq_one_of_lt_prime_pow_two` (the constraint $n_q \\mid p^2$, $n_q \\equiv 1 \\pmod q$ is identical to the $|G| = p^2 q$ analysis), forcing a normal Sylow away from the lone exceptional pair $(p, q) = (2, 3)$, i.e. $|G| = 36 = 2^2 \\cdot 3^2$, which is excluded and would need the finer $|G| = 12$-style element-counting. These theorems are proved but not yet wired into the `burnside_pq` dispatch, which still routes $4 \\le a + b$ through the axiom."
+    },
+    {
       "id": "main-theorem",
       "title": "Part IV: Main theorem",
-      "startLine": 1675,
-      "endLine": 1754,
+      "startLine": 1818,
+      "endLine": 1897,
       "summary": "`burnside_pq`: combines the three axiom-free trivial cases with the squarefree-order case (a = b = 1) and the conjectural `burnside_pq_nontrivial` axiom into the unified statement `Nat.card G = p^a · q^b → IsSolvable G`."
     },
     {
       "id": "sanity-checks",
       "title": "Part V: Sanity checks",
-      "startLine": 1755,
-      "endLine": 1828,
-      "summary": "Six `example`s that exercise the axiom-free portions of the file at the boundaries: trivial group ($|G| = 1 = 2^0 \\cdot 3^0$), prime-order group ($|G| = p = p^1 \\cdot 2^0$), pure prime-power group ($|G| = p^a = p^a \\cdot 2^0$) …"
+      "startLine": 1898,
+      "endLine": 1971,
+      "summary": "Six `example`s that exercise the axiom-free portions of the file at the boundaries: trivial group ($|G| = 1 = 2^0 \\cdot 3^0$), prime-order group ($|G| = p = p^1 \\cdot 2^0$), pure prime-power group ($|G| = p^a = p^a \\cdot 2^0$), squarefree $|G| = pq$, the three-prime squarefree $|G| = 30$, the normal-Sylow $|G| = 12$ (realized by $A_4 \\supseteq V_4$), and the Sylow-counting $|G| = 75 = 5^2 \\cdot 3$. All are axiom-free (the lone `native_decide` sits inside a `Squarefree 30` `example`, not a theorem)."
     },
     {
       "id": "sharpness",
       "title": "Part VI: Sharpness witness",
-      "startLine": 1829,
-      "endLine": 1973,
-      "summary": "`alternatingGroupFin5_card`: $|A_5| = 2^2 \\cdot 3 \\cdot 5$ via `Nat.card_eq_fintype_card` + `native_decide`."
+      "startLine": 1972,
+      "endLine": 2115,
+      "summary": "$A_5$ as the canonical sharpness witness. `alternatingGroupFin5_card`: $|A_5| = 2^2 \\cdot 3 \\cdot 5$ via `Nat.card_eq_fintype_card` + kernel `decide` (axiom-free); `alternatingGroupFin5_not_solvable`: $\\neg\\,\\mathrm{IsSolvable}(A_5)$ by reduction to `Equiv.Perm.not_solvable (Fin 5)` through the short exact sequence $A_5 \\to S_5 \\to \\mathbb{Z}/2$; and `burnside_pq_sharp` bundles both, showing Burnside's two-prime bound cannot extend to three distinct primes (and that the `Squarefree` route also fails, since $60 = 2^2 \\cdot 3 \\cdot 5$ is not squarefree). Closes with the file's iteration summary and `#check` roster."
     }
   ],
   "crossReferences": [


### PR DESCRIPTION
Enrichment pass for `abel-ruffini-galois-extensions-oq-07` (Burnside's pᵃqᵇ theorem, Phase-2 axiomatization).

**Section re-anchoring (drift + undercoverage).** The section list had drifted: Parts IV/V/VI were anchored ~140 lines too early (Part IV section said 1675 but the banner is at 1818; Part VI said 1829-1973 but the banner is at 1972). The tail of the file (lines 1974-2115) was entirely uncovered, and a whole axiom-free content block — the consolidated `|G| = p²·q²` theorems (lines 1675-1817) — had no section at all.

Changes to `sections`:
- Added a new section for the `(a,b) = (2,2)` shape (`burnside_p_squared_q_squared*`, lines 1675-1817), noting the `|G| = 36 = 2²·3²` exclusion and that these are proved but not yet wired into the `burnside_pq` dispatch.
- Re-anchored Part IV (Main theorem) → 1818-1897, Part V (Sanity checks) → 1898-1971, Part VI (Sharpness witness) → 1972-2115 to match the true banner positions; sections now cover the file contiguously 1→EOF.

**Fixed a stale/inaccurate claim.** The Part VI summary claimed `alternatingGroupFin5_card` uses `native_decide`; the Lean source actually uses kernel `decide` (axiom-free). The only `native_decide` in the file sits inside a `Squarefree 30` `example` block (benign — not a theorem), which the new Part V summary now notes. No change to `status`/`badge`/`axiomCount` — the file remains correctly `axiom`-badged for its single narrowed `burnside_pq_nontrivial` axiom.

Expanded the Part V and Part VI summaries to enumerate the actual sanity-check examples and the two sharpness-witness theorems (`alternatingGroupFin5_not_solvable` via the `A₅ → S₅ → ℤ/2` sequence, and `burnside_pq_sharp`).

meta.json: 34 KB (under cap). JSON validated; sections verified contiguous 1→2115.
