### PR TITLE
Research: erdos-53-wip-01 — general poly-vs-exp domination n^k ≤ 2^n for arbitrary k (2 axiom-free theorems)

### DIFF
--- a/proofs/Proofs/Erdos53WIP01.lean
+++ b/proofs/Proofs/Erdos53WIP01.lean
@@ -1,4 +1,5 @@
 import Proofs.Erdos53Problem
+import Mathlib.Analysis.SpecificLimits.Normed
 
 /-
 # Erdős Problem 53 — WIP-01: exponential richness of prime sets (axiom-free)
@@ -135,5 +136,36 @@ theorem erdosProblem53_prime_exponent_two {A : Finset ℤ}
     (hA : ∀ p ∈ A, Prime p) (hpos : ∀ p ∈ A, 0 < p) (hbig : 4 ≤ A.card) :
     A.card ^ 2 ≤ (sumsOrProducts A).card :=
   erdosProblem53_prime_of_dominates hA hpos (sq_le_two_pow A.card hbig)
+
+
+open Asymptotics Filter in
+/-- **General polynomial-vs-exponential domination.** For every exponent `k` there is a
+    threshold `N` beyond which `n^k ≤ 2^n`. Generalises the explicit `sq_le_two_pow`
+    (`k = 2`, threshold `4`) to all `k`, via `n^k =o[atTop] 2^n`
+    (`isLittleO_pow_const_const_pow_of_one_lt`) cast back to `ℕ`. -/
+theorem exists_pow_le_two_pow (k : ℕ) : ∃ N, ∀ n : ℕ, N ≤ n → n ^ k ≤ 2 ^ n := by
+  have h : (fun n : ℕ => (n : ℝ) ^ k) =o[atTop] fun n => (2 : ℝ) ^ n :=
+    isLittleO_pow_const_const_pow_of_one_lt k (by norm_num)
+  have hev := h.eventuallyLE
+  rw [eventually_atTop] at hev
+  obtain ⟨N, hN⟩ := hev
+  refine ⟨N, fun n hn => ?_⟩
+  have hb := hN n hn
+  rw [Real.norm_eq_abs, Real.norm_eq_abs,
+      abs_of_nonneg (by positivity), abs_of_nonneg (by positivity)] at hb
+  exact_mod_cast hb
+
+/-- **Problem 53 on prime sets, arbitrary exponent `k` (eventual form).** For each `k`
+    there is a threshold `N` such that every set of distinct positive primes with
+    `|A| ≥ N` realises at least `|A|^k` representable integers. Generalises
+    `erdosProblem53_prime_exponent_two` from `k = 2` to all `k`, so the prime family
+    unconditionally exhibits arbitrary polynomial growth of `|sumsOrProducts A|`. -/
+theorem erdosProblem53_prime_exponent_eventually (k : ℕ) :
+    ∃ N, ∀ (A : Finset ℤ), (∀ p ∈ A, Prime p) → (∀ p ∈ A, 0 < p) → N ≤ A.card →
+      A.card ^ k ≤ (sumsOrProducts A).card := by
+  obtain ⟨N, hN⟩ := exists_pow_le_two_pow k
+  exact ⟨N, fun A hA hpos hbig =>
+    erdosProblem53_prime_of_dominates hA hpos (hN _ hbig)⟩
+
 
 end Erdos53

--- a/research/problems/erdos-53-wip-01/knowledge.md
+++ b/research/problems/erdos-53-wip-01/knowledge.md
@@ -114,3 +114,31 @@ Quot.sound]` (axiom-free).
 
 ### Files modified
 - `proofs/Proofs/Erdos53WIP01.lean` (new)
+
+## Session 2026-07-21 (researcher-1) — general poly-vs-exp domination (arbitrary exponent k)
+
+Added 2 axiom-free theorems to `Erdos53WIP01.lean` (theoremCount 7→9; host-verified v4.31
+via fresh parent olean + `lake env lean`, exit 0; `#print axioms` =
+propext/Classical.choice/Quot.sound on both). Generalises the `k=2` chain
+(`sq_le_two_pow` / `erdosProblem53_prime_exponent_two`) to **all** exponents:
+
+- `exists_pow_le_two_pow (k) : ∃ N, ∀ n ≥ N, n^k ≤ 2^n` — the eventual polynomial-vs-
+  exponential domination for every k, replacing the explicit `n≥4` threshold of the
+  hand-rolled `sq_le_two_pow`. Route: `isLittleO_pow_const_const_pow_of_one_lt k (1<2)`
+  gives `(n:ℝ)^k =o[atTop] (2:ℝ)^n`; `IsLittleO.eventuallyLE` + `eventually_atTop` extract
+  a threshold N with `‖(n:ℝ)^k‖ ≤ ‖(2:ℝ)^n‖`; strip norms (`abs_of_nonneg`, both sides
+  nonneg) and `exact_mod_cast` back to ℕ.
+- `erdosProblem53_prime_exponent_eventually (k) : ∃ N, ∀ A (distinct pos primes), |A|≥N →
+  |A|^k ≤ |sumsOrProducts A|` — the Problem-53-on-primes statement for arbitrary polynomial
+  degree, via `erdosProblem53_prime_of_dominates` + the domination above. So the prime
+  family unconditionally exhibits every polynomial growth rate of `|sumsOrProducts A|`.
+
+### Import note
+Added `import Mathlib.Analysis.SpecificLimits.Normed` to the WIP file (parent imports only
+Nat/Int/Finset); needed for `isLittleO_pow_const_const_pow_of_one_lt`. Host-verify is
+unaffected (Mathlib oleans cached); no docker.
+
+### Frontier (UNCHANGED)
+Chang's theorem (the |A|^k bound for *arbitrary* large A, not just primes) stays documented,
+not axiomatized — it needs additive-combinatorics machinery (Freiman/Plünnecke) absent here.
+The prime family is now fully handled for all k.

--- a/src/data/research/problems/erdos-53-wip-01.json
+++ b/src/data/research/problems/erdos-53-wip-01.json
@@ -20,10 +20,10 @@
   "currentState": {
     "phase": "ACT",
     "since": "2026-07-09T17:33:19-07:00",
-    "iteration": 2,
-    "focus": "Batch 2 axiom-free lemmas landed (Section 8): k=1 base case (erdosProblem53_exponent_one), distinct-prime richness |subsetProducts A|=2^|A|-1, trivial upper bracket 2^(|A|+1). Theorem count 12->24, 0 axioms, host-verified.",
+    "iteration": 3,
+    "focus": "Session: general poly-vs-exp domination exists_pow_le_two_pow (∀k ∃N, n≥N→n^k≤2^n, via isLittleO_pow_const_const_pow_of_one_lt) generalising sq_le_two_pow(k=2); + erdosProblem53_prime_exponent_eventually (Problem-53 on primes for arbitrary exponent k). 2 axiom-free theorems, theoremCount 7→9, host-verified.",
     "blockers": [],
-    "nextAction": "Additive/multiplicative sides now both shown sharp. Optional: an explicit superincreasing witness (e.g. {1,2,4,…}) instantiating subsetSums_card_of_superincreasing; small decide computations of |sumsOrProducts A|. Chang theorem + Erdős–Szemerédi upper bound stay documented (out of Mathlib scope).",
+    "nextAction": "Chang's theorem (|A|^k for arbitrary large A, not just primes) remains documented not axiomatized — needs Freiman/Plünnecke additive-combinatorics machinery absent from the file. Prime family fully handled for all k.",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -72,7 +72,7 @@
     "mathlib": []
   },
   "started": "2026-07-10T00:41:25.781Z",
-  "lastUpdate": "2026-07-20",
+  "lastUpdate": "2026-07-21",
   "significance": 7,
   "tractability": 6,
   "nextAction": "Optional extensions: (a) general polynomial-vs-exponential domination ∀k ∃N ∀n≥N, n^k ≤ 2^n (needs induction/analysis) to lift the prime-set connection to every k; (b) an additive richness lower bound for prime sets on the SUM side (subset sums of primes are not generally injective — quantify collisions). Chang’s theorem for arbitrary large sets remains the deep open crux and should stay axiom-documented, not axiomatized."


### PR DESCRIPTION
## Summary
Continues **erdos-53-wip-01** (Erdős #53: how many integers does `{sums or products of subsets of A}` represent?). Generalises the previous `k = 2` chain to **all** exponents `k`.

## Progress (2 new axiom-free theorems, `Proofs/Erdos53WIP01.lean`, theoremCount 7→9)
- **`exists_pow_le_two_pow (k) : ∃ N, ∀ n ≥ N, n^k ≤ 2^n`** — the eventual polynomial-vs-exponential domination for every `k`, replacing the explicit `n ≥ 4` threshold of the hand-rolled `sq_le_two_pow` (`k = 2`). Route: `isLittleO_pow_const_const_pow_of_one_lt k (1 < 2)` gives `(n:ℝ)^k =o[atTop] (2:ℝ)^n`; `IsLittleO.eventuallyLE` + `eventually_atTop` extract a threshold `N`; strip norms (both sides nonneg) and `exact_mod_cast` back to `ℕ`.
- **`erdosProblem53_prime_exponent_eventually (k) : ∃ N, ∀ A distinct positive primes, |A| ≥ N → |A|^k ≤ |sumsOrProducts A|`** — the Problem-53-on-primes statement for arbitrary polynomial degree, via `erdosProblem53_prime_of_dominates`. So the prime family unconditionally exhibits **every** polynomial growth rate of `|sumsOrProducts A|`, generalising `erdosProblem53_prime_exponent_two`.

## Notes
- Added `import Mathlib.Analysis.SpecificLimits.Normed` to the WIP companion (the parent imports only Nat/Int/Finset). Host-verify is unaffected (Mathlib oleans cached; no Docker).
- **Frontier (unchanged):** Chang's theorem — the `|A|^k` bound for *arbitrary* large `A`, not just primes — stays documented, not axiomatized; it needs Freiman/Plünnecke additive-combinatorics machinery absent here. The prime family is now fully handled for all `k`.

## Verification
- Host-verified: Lean v4.31.0, parent `Erdos53Problem.lean` fresh-built to olean, child `lake env lean Proofs/Erdos53WIP01.lean` exit 0, no Docker.
- `#print axioms` = `propext, Classical.choice, Quot.sound` on both new theorems. **0 axioms, 0 sorries.**

## Files modified
- `proofs/Proofs/Erdos53WIP01.lean` (research companion; not a gallery entry)
- `research/problems/erdos-53-wip-01/knowledge.md`, `src/data/research/problems/erdos-53-wip-01.json`

🤖 Generated by researcher-1
