### PR TITLE
Enrich erdos-340-greedy-sidon (greedy Mian-Chowla Sidon library): re-anchor 2 axiom-era section summaries + cover tail 505→648, fix stale '21 axioms' claim on axiom-free file

### DIFF
--- a/src/data/proofs/erdos-340-greedy-sidon/meta.json
+++ b/src/data/proofs/erdos-340-greedy-sidon/meta.json
@@ -73,14 +73,14 @@
   },
   "overview": {
     "historicalContext": "Simon Sidon posed the problem of constructing dense sets of integers with all pairwise sums distinct to Paul Erdos in the 1930s. The question immediately attracted attention: how large can a Sidon subset of {1,...,N} be? Erdos and Turan (1941) proved the fundamental upper bound: at most sqrt(N) + O(N^{1/4}) elements, a result that remains essentially optimal 80+ years later. For the lower bound, Singer (1938) used perfect difference sets from finite projective planes to construct Sidon sets achieving (1-o(1))sqrt(N) elements, showing the Erdos-Turan bound is tight up to lower order terms.\n\nThe greedy (Mian-Chowla) construction, introduced independently by Mian and Chowla (1944), takes a different approach: start with 1, then repeatedly add the smallest positive integer that preserves the Sidon property. This produces the remarkable sequence 1, 2, 4, 8, 13, 21, 31, 45, 66, 81, 97, ... (OEIS A005282). Despite its elegant simplicity, analyzing the greedy sequence has proved extraordinarily difficult. The best proven lower bound on its counting function is the 'trivial' N^(1/3), unchanged since the 1940s, while Erdos conjectured (Problem #340) that the true growth is N^(1/2-epsilon) for all epsilon > 0 — nearly as dense as the theoretical maximum.\n\nThe gap between the N^(1/3) bound and the conjectured N^(1/2-epsilon) is one of the most persistent open problems in additive combinatorics. Ruzsa (1998) showed that non-greedy algebraic constructions can achieve N^(sqrt(2)-1) ~ N^0.414 elements, far exceeding N^(1/3), but the greedy algorithm's deterministic nature makes it resistant to the probabilistic and algebraic techniques that succeed for other constructions. The problem sits at the intersection of number theory, combinatorics, and algorithm analysis.",
-    "problemStatement": "Provide a comprehensive library of Sidon set theory:\n\n1. **Definition**: IsSidon(A) iff all pairwise sums a+b (a <= b) are distinct\n2. **Closure properties**: Empty, singleton, pair are Sidon; subsets of Sidon sets are Sidon\n3. **Difference injectivity**: In a Sidon set, all pairwise differences are distinct\n4. **Counting**: The difference set has exactly n(n-1)/2 elements\n5. **Lower bound**: max(A) >= n(n-1)/2 (pigeonhole on differences)\n6. **Upper bound**: |A| <= sqrt(2N) + 1 for A in [1,N] (proved)\n7. **Greedy sequence**: Axiomatize the Mian-Chowla sequence and its properties\n8. **Main conjecture**: Formal statement of Erdos #340",
+    "problemStatement": "Provide a comprehensive library of Sidon set theory:\n\n1. **Definition**: IsSidon(A) iff all pairwise sums a+b (a <= b) are distinct\n2. **Closure properties**: Empty, singleton, pair are Sidon; subsets of Sidon sets are Sidon\n3. **Difference injectivity**: In a Sidon set, all pairwise differences are distinct\n4. **Counting**: The difference set has exactly n(n-1)/2 elements\n5. **Lower bound**: max(A) >= n(n-1)/2 (pigeonhole on differences)\n6. **Upper bound**: |A| <= sqrt(2N) + 1 for A in [1,N] (proved)\n7. **Greedy sequence**: Construct the Mian-Chowla sequence explicitly (axiom-free) and prove its basic properties\n8. **Main conjecture**: Record the open growth statement of Erdos #340 as commentary",
     "text": "Comprehensive Sidon set library for Erdos Problem #340: defines Sidon sets, proves closure under subsets, difference injectivity, counting arguments (|diffSet| = n(n-1)/2), the pigeonhole upper bound max(A) >= n(n-1)/2, and the weak upper bound |A| <= sqrt(2N) + 1. Constructs the greedy Sidon sequence explicitly (no axioms) and records Erdos's open conjecture that its growth is N^(1/2-epsilon) as commentary. Fully axiom-free. Imported by Erdos44Problem and Erdos44SidonLowerBound.",
     "proofStrategy": "The proved results use three main techniques:\n\n1. **Difference counting** (sidon_lower_bound): A Sidon set with n elements has n(n-1)/2 distinct positive differences, all in [1, max(A)]. By pigeonhole, max(A) >= n(n-1)/2.\n\n2. **Upper bound** (sidon_upper_bound_weak): If n(n-1)/2 <= N and n >= sqrt(2N) + 2, then (n-1)^2 > 2N, so n(n-1) = (n-1)^2 + (n-1) > 2N + 1, giving n(n-1)/2 > N, contradiction.\n\n3. **Bijection argument** (orderedPairsLt_card_via_choose): The number of ordered pairs with a < b equals C(n,2) = n(n-1)/2, established via an explicit bijection with 2-element subsets (powersetCard 2 A).\n\nThe file is now fully axiom-free: the tight Erdos-Turan upper bound, formerly the file's only axiom, is discharged downstream by the verified Erdos340.sidon_card_le_sqrt; the greedy sequence is a genuine Nat.find recursion; and the main conjecture appears only as commentary, never as an assumption.",
     "keyInsights": [
       "The difference-set approach gives sidon_lower_bound elegantly: n(n-1)/2 distinct positive differences must fit in [1, max(A)], giving max(A) >= n(n-1)/2",
       "The bijection between orderedPairsLt and powersetCard 2 uses Finset.card_bij with explicit forward map, injectivity, and surjectivity proofs",
       "The weak upper bound sqrt(2N) + 1 is proved from differences alone; the tight Erdos-Turan bound sqrt(N) + O(N^{1/4}) requires counting sums instead",
-      "21 axioms: 1 tight upper bound (known result), 5 greedy sequence properties, 11 specific values, 2 growth bounds, 2 difference set memberships. The high axiom count reflects the difficulty of constructive Sidon sequence theory",
+      "The greedy sequence is a genuine axiom-free construction, not a list of postulates: instDecidableIsSidon makes IsSidon decidable (its four quantifiers are effectively bounded), so nextSidon can pick each term by Nat.find, and sidon_exists_extension (explicit witness 2*sup(A)+1) guarantees the recursion never stalls — hence strict monotonicity (greedySidonSeq_strictMono) and the Sidon property of every initial segment (greedySidonSeq_isSidon) are theorems, formerly axioms",
       "Erdos #340 is OPEN: the gap between the N^(1/3) lower bound and conjectured N^(1/2-epsilon) has persisted for 80+ years"
     ],
     "prerequisites": [
@@ -117,19 +117,43 @@
     },
     {
       "id": "greedy-sequence",
-      "title": "Greedy Sidon Sequence Axiomatization",
+      "title": "Decidability and the Sidon Extension Lemma",
       "startLine": 374,
       "endLine": 443,
-      "summary": "Axiomatizes greedySidonSeq with properties: starts at 1, strictly monotone, first n+1 terms always Sidon, each term is the smallest preserving Sidon. Gives first 11 values as axioms (OEIS A005282). Defines greedySidonSet and greedySidonCount.",
-      "mathContext": "The greedy Sidon sequence: $a_0 = 1$, $a_{n+1} = \\min\\{m > a_n : \\{a_0, \\ldots, a_n, m\\}$ is Sidon$\\}$. First terms: 1, 2, 4, 8, 13, 21, 31, 45, 66, 81, 97."
+      "summary": "Part 3 opens by building the machinery for an explicit, axiom-free greedy construction. CanAddProp and the instDecidableIsSidon instance make IsSidon decidable (the four defining quantifiers are effectively bounded by the finite set), which is what lets the greedy rule be a genuine Nat.find recursion rather than an axiom. sidon_insert_of_large then shows that inserting an m strictly above every element of a Sidon set A preserves the Sidon property unless m completes a triple collision m = a + c - d with a, c, d in A.",
+      "mathContext": "Decidability: $\\mathrm{IsSidon}(A)$ has four quantifiers over the finite set $A$, so it is a $\\mathtt{Decidable}$ proposition. Insertion: for $m > \\max A$, $A \\cup \\{m\\}$ is Sidon iff $m \\neq a + c - d$ for all $a,c,d \\in A$."
     },
     {
       "id": "growth-conjecture",
-      "title": "Growth Rate and Main Conjecture",
+      "title": "Explicit Greedy (Mian-Chowla) Construction",
       "startLine": 444,
       "endLine": 505,
-      "summary": "Axiomatizes greedySidon_growth_third (greedy grows >= N^{1/3}) and erdos_340 (the OPEN conjecture that growth is >= N^{1/2-epsilon}). Defines the difference set of the greedy sequence with two membership axioms.",
-      "mathContext": "Known: $|A \\cap [1,N]| \\geq \\Omega(N^{1/3})$ (trivial bound). **Conjecture (Erdos #340)**: $\\forall \\varepsilon > 0$, $|A \\cap [1,N]| \\geq \\Omega(N^{1/2 - \\varepsilon})$. **STATUS: OPEN.**"
+      "summary": "Builds the greedy sequence as a genuine definition rather than a postulate. sidon_exists_extension (explicit witness 2*sup(A)+1) proves the greedy rule never gets stuck; nextSidon picks the least valid next term via Nat.find; greedyPair recurses from a_0 = 1 to define greedySidonSeq (the values, OEIS A005282) and greedySeqSet (the initial segments). greedySeqSet_isSidon and greedySidonSeq_lt_succ confirm every initial segment is Sidon and the sequence is strictly increasing step-by-step -- both formerly stated as axioms, now theorems.",
+      "mathContext": "$a_0 = 1$, $a_{n+1} = \\mathrm{nextSidon}(\\{a_0,\\ldots,a_n\\}, a_n) = \\min\\{m > a_n : \\{a_0,\\ldots,a_n,m\\}\\text{ is Sidon}\\}$. First terms: 1, 2, 4, 8, 13, 21, 31, 45, 66, 81, 97 (Mian-Chowla, OEIS A005282). Extension witness $2\\sup(A)+1$ makes the min well-defined."
+    },
+    {
+      "id": "computational-verification",
+      "title": "Discharging the Former Sequence Axioms",
+      "startLine": 506,
+      "endLine": 547,
+      "summary": "Derives, purely from the explicit construction, the global properties that earlier versions had assumed: greedySidonSeq_strictMono (StrictMono, via strictMono_nat_of_lt_succ applied to the step lemma), greedySeqSet_eq_image (the greedy set equals the image of the first n+1 sequence terms, by induction), and greedySidonSeq_isSidon. Part 4 adds the greedySidon / greedySidonSet aliases and re-states their strict-monotonicity and Sidon corollaries. Each 'Was axiom ... now a theorem' comment marks one discharged assumption.",
+      "mathContext": "$\\{a_0,\\ldots,a_n\\} = \\mathrm{greedySidonSeq}(\\mathrm{range}(n+1))$ and $\\mathrm{StrictMono}(a_\\bullet)$ follow from $a_n < a_{n+1}$ by $\\mathtt{strictMono\\_nat\\_of\\_lt\\_succ}$; hence every $\\{a_0,\\ldots,a_n\\}$ is Sidon as a theorem."
+    },
+    {
+      "id": "growth-rate-bounds",
+      "title": "Growth Rate Bounds and the Open Conjecture",
+      "startLine": 548,
+      "endLine": 620,
+      "summary": "Defines greedySidonCount N = |range(greedySidon) intersect [1,N]| and records, strictly as commentary (no axioms), the analysis of the growth rate: the known N^(1/3) lower bound via a forbidden-set covering argument (a_n <= (n+1) + (n+1)^3 = O(n^3), inverting to Omega(N^(1/3))), why the exponent is cubic rather than quadratic, Erdos's open N^(1/2-epsilon) conjecture (Problem #340), potential research approaches, and intermediate formalization targets. The 1/3-vs-1/2 exponent gap is exactly what #340 asks about.",
+      "mathContext": "Covering bound: every integer in $[1, a_n]$ is either in $A_n$ or a forbidden value $a_i + a_j - a_l$, so $a_n \\leq (n+1) + (n+1)^3 = O(n^3)$, giving $|A \\cap [1,N]| \\geq \\Omega(N^{1/3})$. **Conjecture (Erdos #340, OPEN)**: $\\forall \\varepsilon>0,\\ |A \\cap [1,N]| \\geq \\Omega(N^{1/2-\\varepsilon})$."
+    },
+    {
+      "id": "difference-set",
+      "title": "The Difference Set of the Greedy Sequence",
+      "startLine": 621,
+      "endLine": 648,
+      "summary": "Part 6 defines greedySidonDiffSet = {d in ZZ : d = a - b, a, b in range(greedySidon)}, the difference set of the greedy sequence over the integers. Because the sequence is Sidon, every nonzero difference is realized at most once, so a set of n elements has exactly n^2 - n + 1 distinct differences (including 0). Concrete membership facts are noted from the Mian-Chowla values, e.g. 204 - 182 = 22 is in A - A (greedySidon 14 - greedySidon 13).",
+      "mathContext": "For a Sidon set $A$ with $|A| = n$: $|A - A| = n^2 - n + 1$ (each ordered pair $a \\neq b$ gives a distinct nonzero difference, plus $0$). Example: $22 = 204 - 182 \\in A - A$."
     }
   ],
   "crossReferences": [
@@ -190,10 +214,10 @@
     }
   ],
   "conclusion": {
-    "summary": "This module provides a comprehensive Sidon set library (648 lines, 24 theorems/lemmas, 14 definitions, 0 axioms, 0 sorries) for Erdos Problem #340 and related problems. The fully proved results include Sidon closure, difference injectivity, counting arguments, the pigeonhole lower bound, and the weak upper bound. The axiomatized content includes the greedy sequence, its known N^(1/3) growth bound, and the open N^(1/2-epsilon) conjecture.",
+    "summary": "This module provides a comprehensive Sidon set library (648 lines, 24 theorems/lemmas, 14 definitions, 0 axioms, 0 sorries) for Erdos Problem #340 and related problems. The fully proved results include Sidon closure, difference injectivity, counting arguments, the pigeonhole lower bound, and the weak upper bound. The greedy (Mian-Chowla) sequence is built explicitly as a Nat.find recursion -- strict monotonicity and the Sidon property of every initial segment are theorems, not axioms -- while the known N^(1/3) growth bound and the open N^(1/2-epsilon) conjecture appear only as commentary.",
     "implications": "**Theoretical Significance**: The Sidon set infrastructure is a foundation for additive combinatorics in Lean.\n\nThe counting technique (bijection with powersetCard 2, then pigeonhole) is a pattern that extends to B_h sequences (sets where all h-fold sums are distinct). The 80-year gap between the N^(1/3) lower bound and the N^(1/2-epsilon) conjecture for the greedy sequence remains one of the most tantalizing open problems in combinatorial number theory.",
     "openQuestions": [
-      "Prove the N^(1/3) greedy growth bound rigorously (currently axiomatized)",
+      "Prove the N^(1/3) greedy growth bound rigorously (currently recorded only as a commented forbidden-set covering sketch)",
       "Formalize the Erdos-Turan tight upper bound sqrt(N) + O(N^{1/4}) using sum-counting",
       "Any improvement beyond N^(1/3) for the greedy sequence would be publishable",
       "Analyze the difference set density of the greedy sequence",


### PR DESCRIPTION
## Enrichment pass: erdos-340-greedy-sidon

The Lean file `Proofs/Erdos340GreedySidon.lean` (648 lines, **0 axioms**, 0 sorries) was de-axiomatized in an earlier rewrite — the greedy (Mian–Chowla) sequence is now an explicit `Nat.find` recursion — but several `meta.json` fields still carried axiom-era claims, and the section list covered only lines 1–505 of 648.

### Stale axiom-era claims fixed (file is now axiom-free)
- **keyInsight** "21 axioms: 1 tight upper bound, 5 greedy sequence properties, 11 specific values, 2 growth bounds, 2 difference set memberships" → replaced with an accurate insight explaining the axiom-free construction (`instDecidableIsSidon` → `nextSidon` via `Nat.find`; `sidon_exists_extension` guarantees the recursion never stalls).
- **problemStatement** item 7 "Axiomatize the Mian-Chowla sequence" → "Construct … explicitly (axiom-free)".
- **conclusion.summary** "The axiomatized content includes the greedy sequence …" → now states it is built explicitly with strict monotonicity / Sidon-ness as theorems.
- **conclusion.openQuestions[0]** "(currently axiomatized)" → "(currently recorded only as a commented forbidden-set covering sketch)".

### Two drifted section summaries re-anchored to true content
- `greedy-sequence` (374–443): was "Greedy Sidon Sequence Axiomatization / gives 11 values as axioms" → **"Decidability and the Sidon Extension Lemma"** (`CanAddProp`, `instDecidableIsSidon`, `sidon_insert_of_large`).
- `growth-conjecture` (444–505): was "Axiomatizes greedySidon_growth_third / two membership axioms" → **"Explicit Greedy (Mian-Chowla) Construction"** (`sidon_exists_extension`, `nextSidon`, `greedyPair`, `greedySidonSeq`, `greedySeqSet_isSidon`, `greedySidonSeq_lt_succ`).

### Tail coverage added (505 → 648), 3 new sections
- `computational-verification` (506–547): "Discharging the Former Sequence Axioms" — `greedySidonSeq_strictMono`, `greedySeqSet_eq_image`, `greedySidonSeq_isSidon`, the `greedySidon`/`greedySidonSet` aliases (Part 4).
- `growth-rate-bounds` (548–620): "Growth Rate Bounds and the Open Conjecture" — `greedySidonCount`, the N^(1/3) forbidden-set covering argument, Erdős's open N^(1/2−ε) conjecture, research approaches.
- `difference-set` (621–648): "The Difference Set of the Greedy Sequence" — `greedySidonDiffSet`, |A−A| = n²−n+1, Mian–Chowla example 204−182=22.

Coverage now 1–648 (contiguous, no gaps), 5→8 sections. meta.json 19.5 KB → 23.6 KB (well under caps). JSON validated by round-trip; no Lean source changed.
