### PR TITLE
Research: erdos-507-wip-01 — heilbronn monotonicity + config existence (5 axiom-free decls)

### DIFF
--- a/proofs/Proofs/Erdos507WIP01.lean
+++ b/proofs/Proofs/Erdos507WIP01.lean
@@ -285,13 +285,13 @@ theorem exists_unitDisk_config (n : ℕ) :
   rcases Nat.eq_zero_or_pos n with hn | hn
   · exact ⟨∅, by simp [hn], isInUnitDisk_empty⟩
   · have hn0 : (n : ℝ) ≠ 0 := Nat.cast_ne_zero.mpr hn.ne'
-    have inj : Function.Injective (fun k : ℕ => (((k : ℝ) / n, (0 : ℝ)) : ℝ × ℝ)) := by
+    have inj : Function.Injective (fun k : ℕ => ((k : ℝ) / n, (0 : ℝ))) := by
       intro a b hab
       simp only [Prod.mk.injEq] at hab
       have h1 := hab.1
       field_simp at h1
       exact_mod_cast h1
-    refine ⟨(Finset.range n).image (fun k => ((k : ℝ) / n, (0 : ℝ))), ?_, ?_⟩
+    refine ⟨(Finset.range n).image (fun k : ℕ => ((k : ℝ) / n, (0 : ℝ))), ?_, ?_⟩
     · rw [Finset.card_image_of_injective _ inj, Finset.card_range]
     · intro p hp
       simp only [Finset.mem_image, Finset.mem_range] at hp
@@ -299,7 +299,8 @@ theorem exists_unitDisk_config (n : ℕ) :
       have hkn : (k : ℝ) / n < 1 := by
         rw [div_lt_one (by exact_mod_cast hn)]
         exact_mod_cast hk
-      have hknneg : 0 ≤ (k : ℝ) / n := by positivity
+      have hknneg : 0 ≤ (k : ℝ) / n :=
+        div_nonneg (Nat.cast_nonneg k) (Nat.cast_nonneg n)
       simp only
       nlinarith [hkn, hknneg]
 
@@ -351,8 +352,9 @@ theorem heilbronn_succ_le (n : ℕ) (hn : 3 ≤ n) :
     rintro α ⟨P, hcard, hdisk, hbound⟩
     have hpos : 0 < P.card := by omega
     obtain ⟨x, hx⟩ := Finset.card_pos.mp hpos
-    refine ⟨P.erase x, ?_, hdisk.subset (Finset.erase_subset x P), ?_⟩
+    refine ⟨P.erase x, ?_, IsInUnitDisk.subset hdisk (Finset.erase_subset x P), ?_⟩
     · rw [Finset.card_erase_of_mem hx, hcard]
+      omega
     · intro p hp q hq r hr hpq hqr hpr
       exact hbound p (Finset.mem_of_mem_erase hp) q (Finset.mem_of_mem_erase hq)
         r (Finset.mem_of_mem_erase hr) hpq hqr hpr

--- a/proofs/Proofs/Erdos507WIP01.lean
+++ b/proofs/Proofs/Erdos507WIP01.lean
@@ -270,4 +270,102 @@ theorem heilbronn_le_three (n : ℕ) (hn : 3 ≤ n) : heilbronn n ≤ 3 := by
     linarith
   · norm_num
 
+/-! ## Existence of unit-disk configurations of every cardinality
+
+For every `n` there is an `n`-point configuration inside the unit disk (place the
+points `(k/n, 0)`, `k = 0, …, n−1`, on a horizontal chord).  This makes the
+defining set of `heilbronn n` nonempty, which is exactly the side condition
+`csSup_le_csSup` needs for the monotonicity result below. -/
+
+/-- **Configurations of every size exist in the unit disk.**  For any `n` there
+is a `Finset` of exactly `n` points, all inside the closed unit disk (the equally
+spaced points `(k/n, 0)` on the horizontal diameter). -/
+theorem exists_unitDisk_config (n : ℕ) :
+    ∃ P : Finset (ℝ × ℝ), P.card = n ∧ IsInUnitDisk P := by
+  rcases Nat.eq_zero_or_pos n with hn | hn
+  · exact ⟨∅, by simp [hn], isInUnitDisk_empty⟩
+  · have hn0 : (n : ℝ) ≠ 0 := Nat.cast_ne_zero.mpr hn.ne'
+    have inj : Function.Injective (fun k : ℕ => (((k : ℝ) / n, (0 : ℝ)) : ℝ × ℝ)) := by
+      intro a b hab
+      simp only [Prod.mk.injEq] at hab
+      have h1 := hab.1
+      field_simp at h1
+      exact_mod_cast h1
+    refine ⟨(Finset.range n).image (fun k => ((k : ℝ) / n, (0 : ℝ))), ?_, ?_⟩
+    · rw [Finset.card_image_of_injective _ inj, Finset.card_range]
+    · intro p hp
+      simp only [Finset.mem_image, Finset.mem_range] at hp
+      obtain ⟨k, hk, rfl⟩ := hp
+      have hkn : (k : ℝ) / n < 1 := by
+        rw [div_lt_one (by exact_mod_cast hn)]
+        exact_mod_cast hk
+      have hknneg : 0 ≤ (k : ℝ) / n := by positivity
+      simp only
+      nlinarith [hkn, hknneg]
+
+/-! ## Monotonicity of `heilbronn`
+
+Adding a point to an admissible configuration can only introduce new triples, so
+it can only *decrease* the minimum triangle area.  Hence `heilbronn` is antitone
+for `n ≥ 3`: every witness configuration for `n + 1` restricts (by deleting one
+point) to a witness for `n` achieving the same bound, so the defining set for
+`n + 1` is contained in that for `n`. -/
+
+/-- The defining set of `heilbronn n` is bounded above by `3` once `n ≥ 3`: any
+admissible bound is `≤` the area of some distinct triple, and every unit-disk
+triangle has area `≤ 3`.  (This is the boundedness half of `heilbronn_le_three`,
+isolated for reuse in the monotonicity proof.) -/
+private theorem heilbronn_defining_bddAbove (n : ℕ) (hn : 3 ≤ n) :
+    BddAbove { α : ℝ | ∃ P : Finset (ℝ × ℝ), P.card = n ∧ IsInUnitDisk P ∧
+      ∀ p ∈ P, ∀ q ∈ P, ∀ r ∈ P, p ≠ q → q ≠ r → p ≠ r →
+        triangleArea p q r ≥ α } := by
+  refine ⟨3, ?_⟩
+  rintro α ⟨P, hcard, hdisk, hbound⟩
+  have hcard3 : 2 < P.card := by omega
+  obtain ⟨p, q, r, hp, hq, hr, hpq, hpr, hqr⟩ := Finset.two_lt_card_iff.mp hcard3
+  have h1 : α ≤ triangleArea p q r := hbound p hp q hq r hr hpq hqr hpr
+  have h2 : triangleArea p q r ≤ 3 := triangleArea_le_three hdisk hp hq hr
+  linarith
+
+/-- **`heilbronn n` is nonnegative for `n ≥ 3`.**  The bound `0` is admissible for
+any configuration (all areas are nonnegative) and an `n`-point unit-disk
+configuration exists, so `0` lies in the defining set of the `sSup`. -/
+theorem heilbronn_nonneg (n : ℕ) (hn : 3 ≤ n) : 0 ≤ heilbronn n := by
+  unfold heilbronn
+  obtain ⟨P, hcard, hdisk⟩ := exists_unitDisk_config n
+  refine le_csSup (heilbronn_defining_bddAbove n hn) ?_
+  exact ⟨P, hcard, hdisk, fun p _ q _ r _ _ _ _ => triangleArea_nonneg p q r⟩
+
+/-- **One-step monotonicity.**  `heilbronn (n + 1) ≤ heilbronn n` for `n ≥ 3`.
+Every witness configuration for `n + 1` restricts, by deleting one point, to an
+`n`-point witness achieving the same lower bound, so the defining set for `n + 1`
+is contained in that for `n`; both `sSup`s are over bounded, nonempty sets. -/
+theorem heilbronn_succ_le (n : ℕ) (hn : 3 ≤ n) :
+    heilbronn (n + 1) ≤ heilbronn n := by
+  unfold heilbronn
+  apply csSup_le_csSup (heilbronn_defining_bddAbove n hn)
+  · -- the defining set for `n + 1` is nonempty: the all-zero bound is admissible
+    obtain ⟨P, hcard, hdisk⟩ := exists_unitDisk_config (n + 1)
+    exact ⟨0, P, hcard, hdisk, fun p _ q _ r _ _ _ _ => triangleArea_nonneg p q r⟩
+  · -- containment: delete one point from an `(n+1)`-witness to get an `n`-witness
+    rintro α ⟨P, hcard, hdisk, hbound⟩
+    have hpos : 0 < P.card := by omega
+    obtain ⟨x, hx⟩ := Finset.card_pos.mp hpos
+    refine ⟨P.erase x, ?_, hdisk.subset (Finset.erase_subset x P), ?_⟩
+    · rw [Finset.card_erase_of_mem hx, hcard]
+    · intro p hp q hq r hr hpq hqr hpr
+      exact hbound p (Finset.mem_of_mem_erase hp) q (Finset.mem_of_mem_erase hq)
+        r (Finset.mem_of_mem_erase hr) hpq hqr hpr
+
+/-- **Monotonicity of `heilbronn`.**  For `3 ≤ m ≤ n`, `heilbronn n ≤ heilbronn m`:
+Heilbronn's function is antitone on `{n ∣ n ≥ 3}`.  (Below `3` the defining `sSup`
+is over an unbounded set and takes the junk value `0`, so monotonicity is stated
+from `3` onward.) -/
+theorem heilbronn_antitone {m n : ℕ} (hm : 3 ≤ m) (hmn : m ≤ n) :
+    heilbronn n ≤ heilbronn m := by
+  induction n, hmn using Nat.le_induction with
+  | base => exact le_rfl
+  | succ k hk ih =>
+    exact le_trans (heilbronn_succ_le k (le_trans hm hk)) ih
+
 end Erdos507WIP01

--- a/research/problems/erdos-507-wip-01/knowledge.md
+++ b/research/problems/erdos-507-wip-01/knowledge.md
@@ -7,6 +7,60 @@ Heilbronn's triangle problem, **OPEN**: the exponent `β` with
 (Komlós–Pintz–Szemerédi, Cohen–Pohoata–Zakharov) are untouched; this file builds
 the elementary geometry of `triangleArea` and `minTriangleArea`/`heilbronn`.
 
+## Session 2026-07-20 (researcher-1) — `heilbronn` monotonicity + config existence
+
+**Mode**: continue a RICH node (18 declarations already on main).
+**Outcome**: progress — 5 new declarations, VERIFIED axiom-free
+(`[propext, Classical.choice, Quot.sound]`, 0 sorry / 0 axiom / no
+native_decide). Host-verified without Docker (parent is Mathlib-only):
+`lake exe cache get`, fresh-built `Erdos507Problem.olean`, `lake env lean` on the
+child, `#print axioms` on all four public results.
+
+### What I added
+- `exists_unitDisk_config (n) : ∃ P, P.card = n ∧ IsInUnitDisk P` — a config of
+  *every* cardinality exists in the disk, via the equally spaced chord points
+  `(k/n, 0)`, `k = 0..n−1` (`(Finset.range n).image`, injective for `n ≥ 1`,
+  membership `(k/n)² ≤ 1` since `0 ≤ k/n < 1`). Makes the `heilbronn` defining
+  set nonempty.
+- `heilbronn_defining_bddAbove (n) (3 ≤ n)` (private) — the `sSup` defining set
+  is bounded above by `3` (the boundedness half of `heilbronn_le_three`, isolated
+  for reuse).
+- `heilbronn_nonneg (n) (3 ≤ n) : 0 ≤ heilbronn n` — `α = 0` is admissible (all
+  areas `≥ 0`) and a config exists, so `0 ∈` the set; `le_csSup`.
+- `heilbronn_succ_le (n) (3 ≤ n) : heilbronn (n+1) ≤ heilbronn n` — every
+  `(n+1)`-witness restricts (delete one point via `Finset.erase`) to an
+  `n`-witness with the same bound, so the `(n+1)`-set `⊆` the `n`-set;
+  `csSup_le_csSup`.
+- `heilbronn_antitone (3 ≤ m ≤ n) : heilbronn n ≤ heilbronn m` — full
+  antitonicity on `{n ≥ 3}` by `Nat.le_induction` on `heilbronn_succ_le`.
+
+### Key findings / reusable Lean recipe
+- **`csSup_le_csSup (BddAbove t) (s.Nonempty) (s ⊆ t) : sSup s ≤ sSup t`** is the
+  right tool for monotone `sSup`s of a *shrinking* defining set. The
+  easy-to-miss side condition is `s.Nonempty` on the **smaller** (here `n+1`)
+  set — supplied by `exists_unitDisk_config` + the always-admissible bound `0`.
+- **The `n ≥ 3` hypothesis is forced by the junk value, not laziness.** For
+  `n < 3` no distinct triple exists, the `∀`-bound condition is vacuous, the
+  defining set is all of `ℝ` (unbounded above) and `heilbronn n` is the
+  `sSup`-junk `0`. Since `heilbronn 3 > 0` (a genuine triangle has positive
+  area) but `heilbronn 2 = 0`, monotonicity is **false** across the `2→3`
+  boundary — state it from `3` onward.
+- **Binder-annotation pitfall.** `fun k => ((k : ℝ)/n, 0)` inside a
+  `Finset.range n` image: the ascription `(k : ℝ)` silently retypes the binder
+  as `ℝ`, so `Finset.range n : Finset ℕ` no longer matches. Annotate the binder
+  `fun k : ℕ => ((k : ℝ)/n, 0)` and cast in the body.
+- **Dot notation fails on a `def`-Prop.** `IsInUnitDisk P` unfolds to
+  `∀ p ∈ P, …` (a Pi type), so `hdisk.subset` resolves to `Function.subset`
+  (nonexistent). Call the namespaced lemma directly: `IsInUnitDisk.subset hdisk …`.
+
+### Next steps
+- Sandwich corollary `0 ≤ heilbronn n ≤ 3` (`heilbronn_nonneg` +
+  `heilbronn_le_three`).
+- Concrete `heilbronn 3` lower witness (largest inscribed equilateral triangle),
+  separating it from the junk `heilbronn 2 = 0`.
+- The deep `α(n)` exponent bounds (KPS lower, CPZ upper) remain open — not
+  session-sized; only `7/6 ≤ β ≤ 2` is known.
+
 ## Session 2026-07-20 (researcher-1) — `minTriangleArea` + `heilbronn` bound
 
 **Mode**: continue a MODERATE node (14 lemmas already on main via #39642).

--- a/src/data/research/problems/erdos-507-wip-01.json
+++ b/src/data/research/problems/erdos-507-wip-01.json
@@ -46,7 +46,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Extended Proofs/Erdos507WIP01.lean (14→18 declarations, 0 sorry / 0 axiom, VERIFIED axiom-free [propext, Classical.choice, Quot.sound], host-verified no-Docker). Added the minTriangleArea layer: bddBelow_range_of_nonneg (private), minTriangleArea_nonneg, minTriangleArea_le (nine-fold nested ciInf descent), and heilbronn_le_three (heilbronn n ≤ 3 for n ≥ 3, so Heilbronn's function is finite). The deep α(n) growth exponent remains open.",
+    "progressSummary": "PROGRESS: Extended Proofs/Erdos507WIP01.lean (18→23 declarations, 0 sorry / 0 axiom, VERIFIED axiom-free [propext, Classical.choice, Quot.sound], host-verified no-Docker). Added the monotonicity layer: exists_unitDisk_config (configs of every cardinality exist in the disk), heilbronn_defining_bddAbove (private), heilbronn_nonneg (0 ≤ heilbronn n), heilbronn_succ_le (one-step antitone via point deletion), and heilbronn_antitone (heilbronn antitone on {n≥3}). The deep α(n) growth exponent (7/6 ≤ β ≤ 2) remains open.",
     "builtItems": [
       "triangleArea_nonneg in Erdos507WIP01.lean",
       "triangleArea_swap_left / triangleArea_swap_right / triangleArea_cyclic (permutation symmetry)",
@@ -59,7 +59,12 @@
       "bddBelow_range_of_nonneg (private): a nonnegative real family is BddBelow",
       "minTriangleArea_nonneg: 0 ≤ minTriangleArea P (empty-index junk value is 0)",
       "minTriangleArea_le: minTriangleArea P ≤ triangleArea p q r for distinct p,q,r ∈ P",
-      "heilbronn_le_three: heilbronn n ≤ 3 for n ≥ 3 (sSup set bounded above)"
+      "heilbronn_le_three: heilbronn n ≤ 3 for n ≥ 3 (sSup set bounded above)",
+      "exists_unitDisk_config in Erdos507WIP01.lean — n-point unit-disk config for every n via chord points (k/n,0), Finset.range image + card_image_of_injective",
+      "heilbronn_defining_bddAbove (private) in Erdos507WIP01.lean — defining sSup-set bounded by 3 for n≥3",
+      "heilbronn_nonneg in Erdos507WIP01.lean — 0 ≤ heilbronn n for n≥3 via le_csSup (α=0 admissible)",
+      "heilbronn_succ_le in Erdos507WIP01.lean — heilbronn (n+1) ≤ heilbronn n for n≥3, delete-a-point (Finset.erase) restriction",
+      "heilbronn_antitone in Erdos507WIP01.lean — full antitonicity on {n≥3} via Nat.le_induction"
     ],
     "insights": [
       "The signed shoelace area p₁(q₂−r₂)+q₁(r₂−p₂)+r₁(p₂−q₂) is alternating: transpositions negate it (area invariant via abs_neg), cyclic rotations fix it — giving full S₃ symmetry after the absolute value.",
@@ -68,15 +73,19 @@
       "Over ℝ the junk value of an empty infimum is 0 (Real.sInf_empty), so minTriangleArea_nonneg and heilbronn_le_three need no nonemptiness hypotheses — use the Real.*-namespaced helpers (Real.iInf_nonneg, Real.le_iInf, Real.sSup_le), not the [Nonempty ι] le_ciInf.",
       "Descend a deeply-nested biInf with ciInf_le_of_le, discharging every BddBelow side goal uniformly by bddBelow_range_of_nonneg + repeat' (apply Real.iInf_nonneg; intro).",
       "A local universe-polymorphic have (∀ {ι : Sort*} …) inside a proof triggers 'AddConstAsyncResult.commitConst: constant has level params [u_1]'; hoist such helpers to top-level (private) theorems.",
-      "heilbronn n ≤ 3 is stated for n ≥ 3: for n < 3 no distinct triple exists, the defining ∀-condition is vacuous, the set is unbounded above, and heilbronn n is the sSup junk value 0 — the bounded-above proof route needs the triple (Finset.two_lt_card_iff)."
+      "heilbronn n ≤ 3 is stated for n ≥ 3: for n < 3 no distinct triple exists, the defining ∀-condition is vacuous, the set is unbounded above, and heilbronn n is the sSup junk value 0 — the bounded-above proof route needs the triple (Finset.two_lt_card_iff).",
+      "heilbronn is antitone on {n ≥ 3}: heilbronn_antitone (3≤m≤n → heilbronn n ≤ heilbronn m). Adding a point can only create new triples, shrinking the min area; the (n+1)-defining sSup-set ⊆ the n-defining set.",
+      "The junk-value boundary at n=2/3 forces the n≥3 hypothesis: for n<3 the triple condition is vacuous so the defining set is all of ℝ (unbounded), giving heilbronn n = sSup-junk 0; monotonicity across the 2→3 boundary is false (heilbronn 3 > 0 = heilbronn 2).",
+      "csSup_le_csSup needs the SMALLER (n+1) set nonempty: supplied via exists_unitDisk_config (n+1) with the admissible bound α=0 (all areas ≥ 0)."
     ],
     "mathlibGaps": [
       "No off-the-shelf lemma reduces the nested membership biInf of minTriangleArea to a single ciInf_le; the junk-value semantics of ⨅ over unsatisfiable membership binders must be handled explicitly (done here via ciInf_le_of_le descent).",
       "No Heilbronn-specific machinery in Mathlib; the α(n) exponent bounds (KPS lower, CPZ upper) are genuine open research, not a tactical search."
     ],
     "nextSteps": [
-      "heilbronn monotonicity: heilbronn (n+1) ≤ heilbronn n by restricting a witness configuration.",
-      "The deep α(n) growth exponent bounds (KPS/CPZ) — not session-sized."
+      "Sandwich corollary: 0 ≤ heilbronn n ≤ 3 for n ≥ 3 (combine heilbronn_nonneg + heilbronn_le_three).",
+      "Explicit lower witness: heilbronn 3 = area of the largest inscribed triangle (equilateral) — a concrete positive value separating heilbronn 3 from the junk heilbronn 2 = 0.",
+      "The deep α(n) growth exponent bounds (KPS lower, CPZ upper) — not session-sized."
     ],
     "markdown": "# Knowledge Base: erdos-507-wip-01\n\n## Session 2026-07-20 (researcher-1) — foundational triangle-area / unit-disk scaffolding\n\n**Mode**: FRESH (EMPTY node). **Outcome**: progress — VERIFIED axiom-free (`[propext, Classical.choice, Quot.sound]`), 0 sorry / 0 axiom. Host-verified (Mathlib-only parent): fresh-built `Erdos507Problem.olean` then `lake env lean` on the child (no Docker).\n\n### What I did\nCreated `proofs/Proofs/Erdos507WIP01.lean` (14 theorems) on the shoelace area `triangleArea p q r = |p₁(q₂−r₂)+q₁(r₂−p₂)+r₁(p₂−q₂)|/2` and the `IsInUnitDisk` predicate:\n- **Nonnegativity**: `triangleArea_nonneg`.\n- **Permutation symmetry**: `triangleArea_swap_left`, `triangleArea_swap_right` (transpositions, via signed-area negation + `abs_neg`), `triangleArea_cyclic` (rotation fixes it).\n- **Degenerate cases**: `triangleArea_self_left / _self_mid / _self_outer` (= 0).\n- **Collinearity**: `triangleArea_eq_zero_iff`.\n- **Explicit value**: `triangleArea_unit` (`(0,0),(1,0),(0,1) ↦ 1/2`).\n- **Unit disk**: `isInUnitDisk_empty`, `IsInUnitDisk.subset`, `unitDisk_abs_fst_le`, `unitDisk_abs_snd_le`, and the uniform bound `triangleArea_le_three`.\n\n### Key findings\n- The signed shoelace form is alternating: transpositions negate, cyclic rotations fix — full `S₃` symmetry after `|·|`.\n- Every unit-disk triangle has area `≤ 3`, so `heilbronn n`'s `sSup` set is bounded above (a step toward finiteness/monotonicity of `heilbronn`).\n\n### Reusable Lean recipe\n- Signed-area alternation: `rw [show <permuted expr> = -(<base expr>) from by ring, abs_neg]`.\n- Coordinate bound from the disk: `nlinarith [sq_nonneg (p.1 - 1), sq_nonneg (p.1 + 1)]` after `have hsq : p.1^2 ≤ 1 := by nlinarith [sq_nonneg p.2]`.\n- Three-term abs bound: `abs_add_le` twice (note `abs_add` was renamed to `abs_add_le` in this pin) + `gcongr`, each summand `≤ 2` via `mul_le_mul` on `|a|·|b−c| ≤ 1·2`.\n- v4.31 renames hit this session: `abs_add → abs_add_le`, `Finset.not_mem_empty → Finset.notMem_empty`.\n\n### Next steps\n- `minTriangleArea P ≤ triangleArea p q r` (nested membership `biInf_le`).\n- `heilbronn n ≤ 3` via `BddAbove` of the defining set.\n\n### Still open (unchanged)\nThe growth exponent of `α(n)` — deep; only `7/6 ≤ β ≤ 2` known (KPS, Cohen–Pohoata–Zakharov).\n"
   },
@@ -100,7 +109,7 @@
     "mathlib": []
   },
   "started": "2026-07-20T12:30:00.000Z",
-  "lastUpdate": "2026-07-20T22:20:00.000Z",
+  "lastUpdate": "2026-07-20",
   "significance": 6,
   "tractability": 5
 }


### PR DESCRIPTION
## Summary
Research session for `erdos-507-wip-01` (Heilbronn's triangle problem — foundations). Extends `proofs/Proofs/Erdos507WIP01.lean` (18 → 23 declarations) with the **monotonicity layer** for Heilbronn's function `heilbronn n`. All new declarations are **0 sorry / 0 axiom**, host-verified without Docker (parent is Mathlib-only).

## Progress — 5 new declarations
- `exists_unitDisk_config (n) : ∃ P, P.card = n ∧ IsInUnitDisk P` — a config of every cardinality exists in the unit disk, via equally spaced chord points `(k/n, 0)`.
- `heilbronn_defining_bddAbove (n) (3 ≤ n)` (private) — the `sSup` defining set is bounded above by `3` (boundedness half of `heilbronn_le_three`, isolated for reuse).
- `heilbronn_nonneg (n) (3 ≤ n) : 0 ≤ heilbronn n` — `α = 0` is admissible and a config exists (`le_csSup`).
- `heilbronn_succ_le (n) (3 ≤ n) : heilbronn (n+1) ≤ heilbronn n` — every `(n+1)`-witness restricts (delete one point via `Finset.erase`) to an `n`-witness with the same bound; `csSup_le_csSup`.
- `heilbronn_antitone (3 ≤ m ≤ n) : heilbronn n ≤ heilbronn m` — full antitonicity on `{n ≥ 3}` by `Nat.le_induction`.

## Findings
- `heilbronn` is **antitone for n ≥ 3**: adding a point can only create new triples, shrinking the minimum triangle area, so the `(n+1)`-defining set is contained in the `n`-defining set.
- The `n ≥ 3` hypothesis is forced by junk-value semantics: for `n < 3` the triple condition is vacuous, the defining set is all of `ℝ` (unbounded), and `heilbronn n` is the `sSup`-junk `0`. Since `heilbronn 3 > 0` but `heilbronn 2 = 0`, monotonicity is genuinely **false** across the `2 → 3` boundary.
- Reusable Lean recipe: `csSup_le_csSup` for a shrinking defining set; the easy-to-miss side condition is `Nonempty` on the *smaller* set (supplied by `exists_unitDisk_config` + admissible bound `0`).

## Verification
```
#print axioms heilbronn_antitone       -- [propext, Classical.choice, Quot.sound]
#print axioms heilbronn_succ_le        -- [propext, Classical.choice, Quot.sound]
#print axioms heilbronn_nonneg         -- [propext, Classical.choice, Quot.sound]
#print axioms exists_unitDisk_config   -- [propext, Classical.choice, Quot.sound]
```
No `sorry`, no custom `axiom`, no `native_decide`/`Lean.ofReduceBool`.

## Status
**Outcome**: progress (foundations). The deep `α(n)` growth exponent (`7/6 ≤ β ≤ 2`) remains OPEN and is not session-sized.
**Next Steps**: sandwich corollary `0 ≤ heilbronn n ≤ 3`; concrete `heilbronn 3` lower witness (inscribed equilateral triangle).

🤖 Generated by researcher-1
