### PR TITLE
Enrich erdos-1-oq-02-oq-01 (distinct-subset-sums counting bound): cover Section 5 superincreasing-sets tail (209→346)

### DIFF
--- a/src/data/proofs/erdos-1-oq-02-oq-01/meta.json
+++ b/src/data/proofs/erdos-1-oq-02-oq-01/meta.json
@@ -132,9 +132,17 @@
       "id": "extremal",
       "title": "The Powers-of-Two Extremal Set",
       "startLine": 118,
-      "endLine": 209,
+      "endLine": 217,
       "summary": "The matching construction: geomSet n = {2^0,…,2^{n-1}} is a genuine distinct-subset-sums set (geomSet_hasDistinctSubsetSums, via Mathlib Finset.geomSum_injective + subset_image_iff), has card n, attains equality ΣA = 2^n − 1 (sum_geomSet), and has max element 2^{n-1} (max'_geomSet). exists_extremal_geomSet packages these into a two-sided wall (2^n−1)/n ≤ M(n) ≤ 2^{n-1} on the Erdős extremal maximum, so the conjectural constant c ≤ 1/2.",
       "mathContext": "Extremal max $M(n)$ obeys $(2^n-1)/n \\le M(n) \\le 2^{n-1}$; the constant $c$ in $\\max A \\ge c\\cdot 2^{|A|}$ satisfies $c \\le 1/2$."
+    },
+    {
+      "id": "superincreasing",
+      "title": "Superincreasing Sets — the Structural Principle",
+      "startLine": 219,
+      "endLine": 346,
+      "summary": "Section 5 abstracts the powers-of-two distinctness into the single structural principle behind it. Superincreasing A := every element exceeds the sum of all strictly smaller elements of A (∀ a ∈ A, Σ{x ∈ A : x < a} < a) — the mechanism underlying knapsack / Merkle–Hellman constructions. Three lemmas: Superincreasing.erase (the property is hereditary), Superincreasing.zero_not_mem (a superincreasing set omits 0, the structural analogue of the distinct-subset-sums zero_not_mem), and the key Superincreasing.hasDistinctSubsetSums — every superincreasing set has distinct subset sums, proved self-contained by strong induction peeling the largest element m (both/neither contain m ⇒ recurse on A∖{m}; exactly one contains m ⇒ Σ(without m) < m ≤ Σ(with m), contradiction). geomSet_superincreasing shows the powers of two are superincreasing (2ⁱ > 2⁰+⋯+2^{i-1} = 2ⁱ−1, the least possible slack, which is why they minimise the maximum and sit on the upper wall M(n) ≤ 2^{n-1}), and a closing example re-derives geomSet distinctness from the general principle with no appeal to geomSum_injective. Closes namespace Erdos1OQ02OQ01.",
+      "mathContext": "$A$ superincreasing $\\iff \\forall a\\in A,\\ \\sum\\{x\\in A: x<a\\} < a$; then any two subsets with equal sum are equal, so superincreasing $\\Rightarrow$ distinct subset sums. Powers of two are the slowest-growing superincreasing set ($2^i = (2^0+\\cdots+2^{i-1})+1$)."
     }
   ],
   "mainTheorems": [


### PR DESCRIPTION
## Enrichment pass — erdos-1-oq-02-oq-01 (Elementary Counting Lower Bound for Distinct Subset Sums)

Genuine grown-file section undercoverage: `meta.json` sections stopped at line 209, but `Proofs/Erdos1OQ02OQ01.lean` runs to 346 with a whole `## Section 5: superincreasing sets` block (a `def` + four theorems + a closing `example`) uncovered.

### Changes
- **Section coverage 5→6, now covers lines 1..346** (was 1..209):
  - Extended "The Powers-of-Two Extremal Set" endLine 209→217 to include `exists_extremal_geomSet` (the two-sided-wall capstone its own summary already describes).
  - New "Superincreasing Sets — the Structural Principle" (219–346): `Superincreasing` def, `Superincreasing.erase` (hereditary), `Superincreasing.zero_not_mem`, `Superincreasing.hasDistinctSubsetSums` (superincreasing ⇒ distinct subset sums, by strong induction peeling the max), `geomSet_superincreasing`, and the closing `example` re-deriving geomSet distinctness from the general principle.

No axiom/status/count changes (verified, 0 axioms, 0 sorries; theoremCount 20 / definitionCount 3 already accurate). File 20 KB, well under caps. Section line ranges verified against the Lean source.
