### PR TITLE
Research: erdos-98-wip-01 — general-position existence for n≤2 + vacuity lemmas (0-axiom)

### DIFF
--- a/proofs/Proofs/Erdos98WIP01.lean
+++ b/proofs/Proofs/Erdos98WIP01.lean
@@ -356,7 +356,7 @@ theorem exists_inGeneralPosition_of_le_two (hn : n ≤ 2) :
     intro i j hij
     have h0 : (i : ℝ) = (j : ℝ) := by
       have := congrArg (fun f : EuclideanSpace ℝ (Fin 2) => f 0) hij
-      simpa [EuclideanSpace.single_apply] using this
+      simpa [PiLp.single_apply] using this
     exact Fin.ext (by exact_mod_cast h0)
   · exact noThreeCollinear_of_le_two _ hn
   · exact noFourConcyclic_of_le_three _ (by omega)

--- a/proofs/Proofs/Erdos98WIP01.lean
+++ b/proofs/Proofs/Erdos98WIP01.lean
@@ -311,5 +311,54 @@ theorem h_eq_zero_of_le_one (hn : n ≤ 1) : h n = 0 := by
   have hc : n.choose 2 = 0 := Nat.choose_eq_zero_of_lt (by omega)
   omega
 
+/-! ## General-position existence in the small-cardinality regime
+
+The interesting content of `h_le_choose_two` lives in the branch where a
+general-position configuration exists (otherwise `h n = sInf ∅ = 0` vacuously).
+Existence of general-position sets for **all** `n` is the deep constructive piece
+(the natural parabola construction `(t, t²)` already fails *no four concyclic* —
+any four parabola points whose `x`-coordinates sum to `0` are concyclic). But for
+small `n` the two nondegeneracy conditions become **vacuous** — `card {i,j,k} = 3`
+is impossible when `n ≤ 2`, and `card {a,b,c,d} = 4` is impossible when `n ≤ 3` —
+so an injective configuration already lies in general position. -/
+
+/-- **Vacuity of no-three-collinear for `n ≤ 2`.** Three *distinct* indices cannot
+exist among `n ≤ 2` points, so the condition holds for every configuration. -/
+theorem noThreeCollinear_of_le_two (P : PointConfig n) (hn : n ≤ 2) :
+    NoThreeCollinear P := by
+  intro i j k hcard
+  exfalso
+  have hle : ({i, j, k} : Finset (Fin n)).card ≤ n := by
+    have := Finset.card_le_card (Finset.subset_univ ({i, j, k} : Finset (Fin n)))
+    simpa [Finset.card_univ, Fintype.card_fin] using this
+  omega
+
+/-- **Vacuity of no-four-concyclic for `n ≤ 3`.** Four *distinct* indices cannot
+exist among `n ≤ 3` points, so the condition holds for every configuration. -/
+theorem noFourConcyclic_of_le_three (P : PointConfig n) (hn : n ≤ 3) :
+    NoFourConcyclic P := by
+  intro a b c d hcard
+  exfalso
+  have hle : ({a, b, c, d} : Finset (Fin n)).card ≤ n := by
+    have := Finset.card_le_card (Finset.subset_univ ({a, b, c, d} : Finset (Fin n)))
+    simpa [Finset.card_univ, Fintype.card_fin] using this
+  omega
+
+/-- **General-position configurations exist for `n ≤ 2`.** Both nondegeneracy
+conditions are vacuous there, so the injective embedding `i ↦ (i, 0)` (distinct
+first coordinates) is in general position. Consequently the defining set of `h n`
+is nonempty and `h n` is a genuine attained minimum (not the `sInf ∅` junk value)
+in this regime. -/
+theorem exists_inGeneralPosition_of_le_two (hn : n ≤ 2) :
+    ∃ P : PointConfig n, InGeneralPosition P := by
+  refine ⟨fun i => EuclideanSpace.single (0 : Fin 2) (i : ℝ), ?_, ?_, ?_⟩
+  · -- injective: distinct indices give distinct first coordinates
+    intro i j hij
+    have h0 : (i : ℝ) = (j : ℝ) := by
+      have := congrArg (fun f : EuclideanSpace ℝ (Fin 2) => f 0) hij
+      simpa [EuclideanSpace.single_apply] using this
+    exact Fin.ext (by exact_mod_cast h0)
+  · exact noThreeCollinear_of_le_two _ hn
+  · exact noFourConcyclic_of_le_three _ (by omega)
 
 end Erdos98WIP01

--- a/research/problems/erdos-98-wip-01/knowledge.md
+++ b/research/problems/erdos-98-wip-01/knowledge.md
@@ -1,5 +1,43 @@
 # Knowledge Base: erdos-98-wip-01
 
+## Session 2026-07-20 (researcher-1) — general-position existence for n ≤ 2 + vacuity lemmas
+
+Added to `Erdos98WIP01.lean` (host-verified, parent `Erdos98Problem` is
+Mathlib-only; all three depend only on `[propext, Classical.choice, Quot.sound]`,
+0 sorry / 0 axiom):
+
+- `noThreeCollinear_of_le_two (P) (n ≤ 2) : NoThreeCollinear P` — vacuous:
+  `card {i,j,k} = 3` is impossible among `n ≤ 2` points
+  (`Finset.card_le_card (subset_univ ..)` + `card_univ`/`Fintype.card_fin`, `omega`).
+- `noFourConcyclic_of_le_three (P) (n ≤ 3) : NoFourConcyclic P` — vacuous:
+  `card {a,b,c,d} = 4` impossible among `n ≤ 3` points.
+- `exists_inGeneralPosition_of_le_two (n ≤ 2) : ∃ P, InGeneralPosition P` — the
+  injective embedding `i ↦ EuclideanSpace.single 0 (i:ℝ)` (distinct first
+  coordinates) is general-position since both nondegeneracy conditions are
+  vacuous. **Consequence:** the defining set of `h n` is nonempty for `n ≤ 2`, so
+  `h n` is an *attained* minimum there, not the `sInf ∅ = 0` junk value that the
+  empty branch of `h_le_choose_two` falls back to.
+
+### Key obstruction (negative knowledge)
+The natural **parabola** construction `(t, t²)` does NOT give general position:
+- No 3 collinear ✓ (a line meets `y = x²` in ≤ 2 points).
+- No 4 concyclic ✗ — a circle meets `y = x²` in the quartic
+  `x⁴ + (1−2q)x² − 2px + (p²+q²−r²) = 0`, whose **cubic coefficient is 0**, so the
+  4 roots sum to `0`. Hence any 4 parabola points with `x`-coordinates summing to
+  `0` (e.g. `x = −3,−1,1,3`) ARE concyclic. Full GP existence needs a
+  genericity/perturbation argument (config space minus finitely many proper
+  algebraic subvarieties), not a single explicit algebraic curve.
+
+### v4.31 gotcha
+`EuclideanSpace.single_apply` is deprecated → use `PiLp.single_apply`. Extract a
+coordinate from an equality of `EuclideanSpace` points via
+`congrArg (fun f => f 0) hij` then `simpa [PiLp.single_apply]`.
+
+### Next
+- `n = 3` (first non-vacuous no-3-collinear case): explicit triangle
+  `(0,0),(1,0),(0,1)`, needing the 6-permutation collinearity computation.
+- Full GP existence for all `n` via genericity (deep constructive piece).
+
 ## Session 2026-07-20 (researcher-1) — h(n)→∞ is UNCONDITIONAL (Guth–Katz baseline)
 
 Added 2 axiom-free theorems to `Erdos98WIP01.lean` (host-verified v4.31.0 via fresh-parent-olean;

--- a/src/data/research/problems/erdos-98-wip-01.json
+++ b/src/data/research/problems/erdos-98-wip-01.json
@@ -31,7 +31,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (2026-07-20, researcher-1, VERIFIED 0-axiom host): proved h(n)→∞ is UNCONDITIONAL (guthKatz_imp_tendsto): the imported Ω(n/log n) Guth–Katz baseline already forces divergence via c·n/log n→∞ (tendsto_const_mul_div_log_atTop). Sharpens weak_imp_tendsto (which assumed the open weak conjecture). Only the rate h(n)/n→∞ and h(n)≥n stay open. 15 theorems, 0 axiom.",
+    "progressSummary": "PROGRESS (2026-07-20, researcher-1, VERIFIED 0-axiom host): general-position existence for n≤2 (exists_inGeneralPosition_of_le_two) via two vacuity lemmas (noThreeCollinear_of_le_two, noFourConcyclic_of_le_three) — so h n is an attained minimum (not sInf∅ junk) in the small regime. Documented the parabola obstruction to full GP existence (4 concyclic when x-coords sum to 0). 18 theorems, 0 axiom.",
     "builtItems": [
       "InGeneralPosition.injective in Erdos98WIP01.lean",
       "numDistinctDistances_le_offDiag (≤ n·(n−1)) in Erdos98WIP01.lean",
@@ -42,7 +42,8 @@
       "PachUpperBound / EFPUpperBound / GuthKatzBaseline / Erdos98WeakConjecture / Erdos98StrongConjecture as typed Props in Erdos98WIP01.lean",
       "strong_imp_weak (h(n)/n→∞ ⟹ h(n)≥n eventually) in Erdos98WIP01.lean",
       "weak_imp_tendsto (weak conj ⟹ h(n)→∞, non-vacuity check) in Erdos98WIP01.lean",
-      "tendsto_const_mul_div_log_atTop (c·n/log n → ∞ via Real.isLittleO_log_id_atTop + reciprocal), guthKatz_imp_tendsto (GuthKatzBaseline ⟹ Tendsto h atTop atTop) in Erdos98WIP01.lean (0 axioms, 0 sorries; host-verified v4.31.0 fresh-parent-olean)"
+      "tendsto_const_mul_div_log_atTop (c·n/log n → ∞ via Real.isLittleO_log_id_atTop + reciprocal), guthKatz_imp_tendsto (GuthKatzBaseline ⟹ Tendsto h atTop atTop) in Erdos98WIP01.lean (0 axioms, 0 sorries; host-verified v4.31.0 fresh-parent-olean)",
+      "noThreeCollinear_of_le_two, noFourConcyclic_of_le_three, exists_inGeneralPosition_of_le_two in Erdos98WIP01.lean — GP existence for n≤2, 0-axiom host-verified"
     ],
     "insights": [
       "Every positive pairwise distance comes from an off-diagonal ordered pair (dist>0 ⟹ points distinct ⟹ indices distinct), giving the clean upper bound numDistinctDistances P ≤ n·(n−1) via Finset.offDiag_card — the trivial ceiling of the h(n) envelope.",
@@ -52,12 +53,15 @@
       "The strong conjecture h(n)/n→∞ is stated as Filter.Tendsto (fun n => (h n:ℝ)/n) atTop atTop; the weak conjecture as ∀ᶠ n, n ≤ h n. strong_imp_weak proves the former entails the latter (one_le_div + eventually_ge_atTop 1), so the two typed statements are correctly related, not independent guesses.",
       "weak_imp_tendsto shows the weak statement already forces h(n)→∞ (tendsto_atTop_mono with id), confirming the Prop is non-vacuous.",
       "Pach n^{log₂3}, Erdős–Füredi–Pach n·exp(c√log n), and Guth–Katz Ω(n/log n) are now typed Props (PachUpperBound/EFPUpperBound/GuthKatzBaseline) flagged as imported assumptions — the comment-only bounds of the scaffold are now checkable Lean statements.",
-      "The DIVERGENCE h(n)→∞ is unconditionally provable (a theorem), not open: the imported Guth–Katz Ω(n/log n) baseline already forces it, since c·n/log n → ∞. Only the RATE h(n)/n→∞ (strong conjecture) and h(n)≥n (weak) remain open. This sharpens weak_imp_tendsto, which derived the same divergence from the OPEN weak conjecture."
+      "The DIVERGENCE h(n)→∞ is unconditionally provable (a theorem), not open: the imported Guth–Katz Ω(n/log n) baseline already forces it, since c·n/log n → ∞. Only the RATE h(n)/n→∞ (strong conjecture) and h(n)≥n (weak) remain open. This sharpens weak_imp_tendsto, which derived the same divergence from the OPEN weak conjecture.",
+      "General-position existence is vacuous-then-injective for small n: card{i,j,k}=3 impossible for n≤2 (noThreeCollinear_of_le_two), card{a,b,c,d}=4 impossible for n≤3 (noFourConcyclic_of_le_three); so an injective embedding i↦(i,0) is general-position for n≤2 (exists_inGeneralPosition_of_le_two).",
+      "OBSTRUCTION to full GP existence: the natural parabola construction (t,t²) gives no-3-collinear (a line meets a parabola in ≤2 pts) but FAILS no-4-concyclic — a circle meets y=x² in a quartic with zero cubic term, so any 4 parabola points whose x-coordinates SUM TO 0 are concyclic (e.g. x=-3,-1,1,3). Full GP existence needs a genericity/perturbation argument (config space minus finitely many proper algebraic subvarieties), not a single explicit curve.",
+      "EuclideanSpace.single_apply deprecated → PiLp.single_apply (v4.31); coordinate extraction via congrArg (·0) then simpa [PiLp.single_apply]."
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "Combine the envelope into h n ≤ n.choose 2 given a general-position witness (existence of GP configs for all n is the missing constructive piece).",
-      "State the compatibility of PachUpperBound with the weak conjecture (n ≤ h < n^{log₂3}) as a consistency lemma."
+      "GP existence for n=3 (first non-vacuous no-3-collinear case): explicit triangle (0,0),(1,0),(0,1); needs the 6-permutation collinearity computation over EuclideanSpace coordinates.",
+      "Full GP existence for all n via genericity: the failure locus (3-collinear ∪ 4-concyclic) is a finite union of proper algebraic subvarieties of the configuration space, so its complement is nonempty (measure-theoretic / dimension argument) — the deep constructive piece."
     ],
     "markdown": "# Knowledge Base: erdos-98-wip-01\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },
@@ -79,7 +83,7 @@
     "mathlib": []
   },
   "started": "2026-07-10T00:41:25.785Z",
-  "lastUpdate": "2026-07-21",
+  "lastUpdate": "2026-07-20",
   "significance": 7,
   "tractability": 6
 }


### PR DESCRIPTION
## Summary
Research session for `erdos-98-wip-01` (Erdős #98, distinct distances in general position). Adds the small-cardinality **general-position existence** layer to `proofs/Proofs/Erdos98WIP01.lean`. **0 sorry / 0 axiom**, host-verified (parent `Erdos98Problem` is Mathlib-only).

## Progress — 3 new theorems
- `noThreeCollinear_of_le_two (P) (n ≤ 2) : NoThreeCollinear P` — the no-3-collinear condition is **vacuous** for `n ≤ 2` (`card {i,j,k} = 3` is impossible).
- `noFourConcyclic_of_le_three (P) (n ≤ 3) : NoFourConcyclic P` — the no-4-concyclic condition is **vacuous** for `n ≤ 3` (`card {a,b,c,d} = 4` is impossible).
- `exists_inGeneralPosition_of_le_two (n ≤ 2) : ∃ P, InGeneralPosition P` — the injective embedding `i ↦ (i, 0)` is in general position. **Consequence:** the defining set of `h n` is nonempty for `n ≤ 2`, so `h n` is a genuine *attained* minimum there (not the `sInf ∅ = 0` junk value the empty branch of `h_le_choose_two` falls back to).

## Findings
- **Obstruction to full GP existence (negative knowledge):** the natural parabola construction `(t, t²)` gives no-3-collinear but *fails* no-4-concyclic — a circle meets `y = x²` in a quartic with **zero cubic coefficient**, so any 4 parabola points whose `x`-coordinates sum to `0` (e.g. `x = −3,−1,1,3`) are concyclic. Full GP existence for all `n` requires a genericity/perturbation argument (configuration space minus finitely many proper algebraic subvarieties), not a single explicit curve.
- v4.31 gotcha: `EuclideanSpace.single_apply` deprecated → `PiLp.single_apply`.

## Verification
```
#print axioms exists_inGeneralPosition_of_le_two   -- [propext, Classical.choice, Quot.sound]
#print axioms noThreeCollinear_of_le_two           -- [propext, Classical.choice, Quot.sound]
#print axioms noFourConcyclic_of_le_three          -- [propext, Classical.choice, Quot.sound]
```

## Status
**Outcome**: progress (foundations toward the constructive GP-existence piece). The Erdős #98 conjecture (`h(n)/n → ∞`) and even `h(n) ≥ n` remain OPEN.
**Next steps**: `n = 3` (first non-vacuous no-3-collinear case) via an explicit triangle; full GP existence via genericity.

🤖 Generated by researcher-1
