### PR TITLE
Enrich Lovász Local Lemma entries: cover Part XI threshold-monotonicity tail (364→471)

### DIFF
--- a/src/data/proofs/lovasz-local-lemma/meta.json
+++ b/src/data/proofs/lovasz-local-lemma/meta.json
@@ -135,6 +135,14 @@
       "startLine": 308,
       "endLine": 364,
       "summary": "lllThreshold_eq_product: T(d) = (1/(d+1))·(d/(d+1))^d. threshold_satisfies_lll: prob_i ≤ T(d) → LLL condition holds. symmetric_lll_complete: full symmetric LLL combining condition and positivity."
+    },
+    {
+      "id": "part-xi-threshold-monotonicity",
+      "title": "Part XI: Threshold Monotonicity",
+      "startLine": 365,
+      "endLine": 471,
+      "summary": "lllThreshold_mul_succ (bridge identity (d+1)·T(d) = (d/(d+1))ᵈ, the symmetric avoidance-product form), threshold_mono_key (the private arithmetic kernel (d+1)^{2(d+1)} ≤ dᵈ·(d+2)^{d+2} after cross-multiplication), lllThreshold_succ_le (T(d+1) ≤ T(d): higher-degree dependency graphs get a smaller per-event probability budget, subsuming T(d) ≤ 1/4), and lllThreshold_antitone (the full ≤-chain T(d) ≤ T(c) for 1 ≤ c ≤ d, by induction on the gap).",
+      "mathContext": "$T(d)=\\tfrac{d^d}{(d+1)^{d+1}}$ is antitone: $(d+1)T(d)=(d/(d+1))^d$ and $T(d+1)\\le T(d)$, so $T(d)\\le T(1)=\\tfrac14$."
     }
   ],
   "mainTheorems": [

--- a/src/data/proofs/prob-method-lovasz-local/meta.json
+++ b/src/data/proofs/prob-method-lovasz-local/meta.json
@@ -170,6 +170,14 @@
       "endLine": 364,
       "summary": "Proves `symmetric_lll_complete`: given $\\Pr[A_i] \\leq T(d)$ and dependency degree $\\leq d$, both the general LLL condition and the avoidance positivity hold. Combines `threshold_satisfies_lll` and `symmetric_lll_avoidance`.",
       "mathContext": "The conclusion: $\\Pr[\\cap_i \\bar{A}_i] \\geq \\prod_i (1 - x_i) = (d/(d+1))^n > 0$, so a satisfying assignment exists. This is the complete formal statement of the symmetric Lovász Local Lemma."
+    },
+    {
+      "id": "threshold-monotonicity",
+      "title": "Threshold Monotonicity",
+      "startLine": 365,
+      "endLine": 471,
+      "summary": "The file's PART XI block: lllThreshold_mul_succ (bridge identity (d+1)·T(d) = (d/(d+1))ᵈ, the symmetric avoidance-product form), threshold_mono_key (the private arithmetic kernel (d+1)^{2(d+1)} ≤ dᵈ·(d+2)^{d+2}), lllThreshold_succ_le (T(d+1) ≤ T(d): higher-degree dependency graphs get a smaller per-event probability budget, subsuming T(d) ≤ 1/4), and lllThreshold_antitone (the full ≤-chain T(d) ≤ T(c) for 1 ≤ c ≤ d, by induction on the gap).",
+      "mathContext": "$T(d)=\\tfrac{d^d}{(d+1)^{d+1}}$ is antitone: $(d+1)T(d)=(d/(d+1))^d$ and $T(d+1)\\le T(d)$, so $T(d)\\le T(1)=\\tfrac14$."
     }
   ],
   "crossReferences": [


### PR DESCRIPTION
Enrichment pass — section-coverage tail-append for the two Lovász Local Lemma
gallery entries that share `Proofs/LovaszLocalLemma.lean` (471 lines).

**Problem:** both entries' `sections` stopped at line 364 while the file's final
`PART XI: THRESHOLD MONOTONICITY` block (365–471) had no section.

**Fix:** added one section per entry covering 365–471:
- `lllThreshold_mul_succ` — bridge identity `(d+1)·T(d) = (d/(d+1))ᵈ` (avoidance-product form)
- `threshold_mono_key` — the private arithmetic kernel after cross-multiplication
- `lllThreshold_succ_le` — `T(d+1) ≤ T(d)` (subsumes `T(d) ≤ 1/4`)
- `lllThreshold_antitone` — the full `≤`-chain `T(d) ≤ T(c)` for `1 ≤ c ≤ d`

Entries updated:
- `lovasz-local-lemma` (Part XI: Threshold Monotonicity)
- `prob-method-lovasz-local` (Threshold Monotonicity)

Both now cover the full file. No status/badge/axiom changes; existing content
preserved; well under the ~60 KB cap.
