### PR TITLE
Fix erdos-683: repair inconsistent axiom scaffold (largest prime divisor mis-defined)

### DIFF
--- a/proofs/Proofs/Erdos683Problem.lean
+++ b/proofs/Proofs/Erdos683Problem.lean
@@ -31,6 +31,7 @@ Tags: number-theory, primes, binomial-coefficients, prime-divisors
 import Mathlib.Data.Nat.Basic
 import Mathlib.Data.Nat.Choose.Basic
 import Mathlib.Data.Nat.Prime.Basic
+import Mathlib.Data.Nat.PrimeFin
 import Mathlib.Analysis.SpecialFunctions.Log.Basic
 import Mathlib.Analysis.SpecialFunctions.Pow.Real
 
@@ -46,8 +47,8 @@ P(n) is the largest prime dividing n, or 1 if n ≤ 1.
 -/
 noncomputable def largestPrimeDivisor (n : ℕ) : ℕ :=
   if h : n > 1 then
-    Nat.find (Nat.exists_prime_and_dvd (by omega : n ≠ 1))
-    -- In reality this is sup of prime divisors; we axiomatize the key properties
+    -- The genuine largest prime divisor: the maximum of the prime-factors finset.
+    n.primeFactors.max' (Nat.nonempty_primeFactors.mpr h)
   else 1
 
 /--
@@ -62,7 +63,7 @@ P(n) is prime when n > 1. Proved from Nat.find_spec.
 -/
 theorem P_is_prime {n : ℕ} (hn : n > 1) : (largestPrimeDivisor n).Prime := by
   unfold largestPrimeDivisor; rw [dif_pos hn]
-  exact (Nat.find_spec (Nat.exists_prime_and_dvd ((by omega : n ≠ 1)))).1
+  exact Nat.prime_of_mem_primeFactors (Finset.max'_mem _ _)
 
 /--
 **Divisibility Property:**
@@ -70,12 +71,17 @@ P(n) divides n when n > 1. Proved from Nat.find_spec.
 -/
 theorem P_divides {n : ℕ} (hn : n > 1) : largestPrimeDivisor n ∣ n := by
   unfold largestPrimeDivisor; rw [dif_pos hn]
-  exact (Nat.find_spec (Nat.exists_prime_and_dvd ((by omega : n ≠ 1)))).2
+  exact Nat.dvd_of_mem_primeFactors (Finset.max'_mem _ _)
 
-/- 
+/--
 **Maximality Property:**
-P(n) is the largest prime divisor.
+`largestPrimeDivisor n` is genuinely the largest prime divisor: every prime
+dividing `n` is `≤ largestPrimeDivisor n`. Proved from `Finset.le_max'`.
 -/
+theorem P_maximal {n p : ℕ} (hn : n > 1) (hp : p.Prime) (hdvd : p ∣ n) :
+    p ≤ largestPrimeDivisor n := by
+  unfold largestPrimeDivisor; rw [dif_pos hn]
+  exact Finset.le_max' _ p (Nat.mem_primeFactors.mpr ⟨hp, hdvd, by omega⟩)
 
 /- ## Part II: Sylvester-Schur Theorem -/
 

--- a/src/data/proofs/erdos-683/meta.json
+++ b/src/data/proofs/erdos-683/meta.json
@@ -47,7 +47,7 @@
       }
     ],
     "originalContributions": [
-      "largestPrimeDivisor definition (via Nat.find), with P_is_prime and P_divides theorems proved from Nat.find_spec",
+      "largestPrimeDivisor definition (via n.primeFactors.max', the genuine largest prime divisor), with P_is_prime, P_divides, and P_maximal theorems proved from primeFactors membership",
       "P(n,k) := largestPrimeDivisor(C(n,k)) definition",
       "sylvester_schur axiom: P(C(n,k)) > k for k ≤ n/2",
       "erdos_1955_bound axiom: P(C(n,k)) ≥ c·k·log k",
@@ -91,16 +91,16 @@
       }
     ],
     "axiomCount": 2,
-    "lineCount": 253,
+    "lineCount": 259,
     "assumptions": "2 axioms: sylvester_schur (Sylvester-Schur — largest prime factor P(n,k) > k for 1≤k, 2k≤n), erdos_1955_bound (Erdős 1955 — P(C(n,k)) ≥ c·k·log k). 0 sorries.",
-    "theoremCount": 6,
+    "theoremCount": 7,
     "definitionCount": 4
   },
   "overview": {
     "historicalContext": "**Origins: Sylvester and Schur (1892–1929)**\n\nJ.J. Sylvester (1892) proved that among any $k$ consecutive integers greater than $k$, at least one has a prime factor exceeding $k$. Issai Schur (1929) refined this to show that the binomial coefficient $\\binom{n}{k}$ itself has a prime divisor $> k$ when $k \\le n/2$. The key insight is that $\\binom{n}{k} = \\frac{(n-k+1) \\cdots n}{k!}$, and primes $> k$ in the numerator survive division by $k!$.\n\n**Erdős's Contributions (1934–1979)**\n\nErdős gave a new proof of the Sylvester-Schur theorem in 1934, using elementary methods. In 1955, he achieved a breakthrough by proving $P(\\binom{n}{k}) \\ge c \\cdot k \\log k$ using the prime number theorem and a counting argument on prime factors in consecutive products. By 1979, in 'Some unconventional problems in number theory,' Erdős conjectured the far stronger bound $P(\\binom{n}{k}) \\ge \\min(n-k+1, k^{1+c})$ and wrote that it 'seems certain' that $P > k^{1+c}$ for ANY $c > 0$ with only finitely many exceptions.\n\n**Current Status and Heuristics**\n\nThe problem remains open after 45+ years. The gap from $k \\log k$ (Erdős 1955) to $k^{1+c}$ (the conjecture) is enormous. Cramér-type probabilistic heuristics based on the random model of primes suggest the even stronger stretched exponential bound $P > e^{c\\sqrt{k}}$, which dwarfs any polynomial. The problem is essentially equivalent to Erdős Problem #961 on smooth numbers in consecutive intervals.",
     "problemStatement": "**Problem Statement (OPEN)**\n\nFor every $1 \\le k \\le n$, does there exist a constant $c > 0$ such that:\n$$P(\\binom{n}{k}) \\ge \\min(n - k + 1,\\, k^{1+c})$$\nwhere $P(m)$ denotes the largest prime divisor of $m$?\n\n**Known:**\n- $P(\\binom{n}{k}) > k$ for $k \\le n/2$ (Sylvester 1892, Schur 1929)\n- $P(\\binom{n}{k}) \\ge c \\cdot k \\log k$ for $k \\le n/2$ (Erdős 1955)\n\n**Believed:**\n- For any $c > 0$, $P(\\binom{n}{k}) > k^{1+c}$ with only finitely many exceptions (Erdős 1979)",
     "text": "For 1 ≤ k ≤ n, is P(C(n,k)) ≥ min(n-k+1, k^{1+c}) for some c > 0? Sylvester-Schur (1892/1929) proved P(C(n,k)) > k. Erdős (1955) improved this to P(C(n,k)) ≫ k log k. The full conjecture remains OPEN.",
-    "proofStrategy": "**Formalization Strategy**\n\n1. **Axiomatic approach to $P(n)$**: Defines `largestPrimeDivisor` via `Nat.find`, then axiomatizes the three key properties (primality, divisibility, maximality) to avoid dependence on Mathlib's factorization internals\n2. **Hierarchy of bounds**: Formalizes the chain $k < k \\log k < k^{1+c} < e^{c\\sqrt{k}}$ with each result building on the previous\n3. **Two-regime structure**: The $\\min(n-k+1, k^{1+c})$ captures the transition at $k \\approx n^{1/(1+c)}$\n4. **Consecutive product connection**: Defines `consecutiveProduct` and links it to $\\binom{n}{k}$ via the numerator identity\n5. **Special cases**: Discusses the central binomial ($k = n/2$) and small $k$ cases in prose comments as consistency checks (not formalized)\n6. **Summary theorem**: `erdos_683_summary` combines the two axiomatized bounds (Sylvester-Schur and Erdős 1955) into a single conjunction via term-mode proof",
+    "proofStrategy": "**Formalization Strategy**\n\n1. **Concrete definition of $P(n)$**: Defines `largestPrimeDivisor` as the genuine largest prime divisor via `n.primeFactors.max'` (the maximum of the prime-factors finset), then *proves* the three key properties as theorems — primality (`P_is_prime`), divisibility (`P_divides`), and maximality (`P_maximal`). Only the two deep number-theoretic bounds (Sylvester-Schur, Erdős 1955) remain as axioms\n2. **Hierarchy of bounds**: Formalizes the chain $k < k \\log k < k^{1+c} < e^{c\\sqrt{k}}$ with each result building on the previous\n3. **Two-regime structure**: The $\\min(n-k+1, k^{1+c})$ captures the transition at $k \\approx n^{1/(1+c)}$\n4. **Consecutive product connection**: Defines `consecutiveProduct` and links it to $\\binom{n}{k}$ via the numerator identity\n5. **Special cases**: Discusses the central binomial ($k = n/2$) and small $k$ cases in prose comments as consistency checks (not formalized)\n6. **Summary theorem**: `erdos_683_summary` combines the two axiomatized bounds (Sylvester-Schur and Erdős 1955) into a single conjunction via term-mode proof",
     "keyInsights": [
       "**Sylvester-Schur foundation**: $P(\\binom{n}{k}) > k$ because primes $> k$ in the numerator $(n-k+1) \\cdots n$ survive division by $k!$, which contains only primes $\\le k$",
       "**Erdős's logarithmic leap**: The improvement from $k$ to $c \\cdot k \\log k$ uses the prime number theorem — among $k$ consecutive integers, $\\sim k/\\log k$ are prime, providing a logarithmic factor",
@@ -118,72 +118,72 @@
     {
       "id": "definitions",
       "title": "Basic Definitions: $P(n)$ and $P(\\binom{n}{k})$",
-      "startLine": 41,
-      "endLine": 79,
-      "summary": "Defines `largestPrimeDivisor` via `Nat.find` and `P n k = P(\\binom{n}{k})`. Axiomatizes $P(n)$ as prime, dividing $n$, and maximal among prime divisors.",
-      "mathContext": "Formal definition: Defines `largestPrimeDivisor` via `Nat.find` and `P n k = P(\\binom{n}{k})`. Axiomatizes $P(n)$ as prime, dividing $n$, and maximal among prime divisors."
+      "startLine": 42,
+      "endLine": 85,
+      "summary": "Defines `largestPrimeDivisor` as the genuine largest prime divisor via `n.primeFactors.max'`, and `P n k = P(\\binom{n}{k})`. Proves $P(n)$ is prime (`P_is_prime`), divides $n$ (`P_divides`), and is maximal among prime divisors (`P_maximal`).",
+      "mathContext": "Formal definition: Defines `largestPrimeDivisor` as the genuine largest prime divisor via `n.primeFactors.max'`, and `P n k = P(\\binom{n}{k})`. Proves $P(n)$ is prime (`P_is_prime`), divides $n$ (`P_divides`), and is maximal among prime divisors (`P_maximal`)."
     },
     {
       "id": "sylvester-schur",
       "title": "Sylvester-Schur Theorem: $P(\\binom{n}{k}) > k$",
-      "startLine": 80,
-      "endLine": 114,
+      "startLine": 86,
+      "endLine": 120,
       "summary": "Axiomatizes $P(\\binom{n}{k}) > k$ for $k \\le n/2$ and derives the existential form $\\exists p$ prime with $p \\mid \\binom{n}{k}$ and $p > k$ (proved from axioms).",
       "mathContext": "Axiomatized: Axiomatizes $P(\\binom{n}{k}) > k$ for $k \\le n/2$ and derives the existential form $\\exists p$ prime with $p \\mid \\binom{n}{k}$ and $p > k$ (proved from axioms)."
     },
     {
       "id": "erdos-1955",
       "title": "Erdős 1955: $P(\\binom{n}{k}) \\ge c \\cdot k \\log k$",
-      "startLine": 115,
-      "endLine": 138,
+      "startLine": 121,
+      "endLine": 144,
       "summary": "Axiomatizes the quantitative improvement $P(\\binom{n}{k}) \\ge c \\cdot k \\log k$ and instantiates it for specific $n, k$ via `obtain`.",
       "mathContext": "Axiomatized: Axiomatizes the quantitative improvement $P(\\binom{n}{k}) \\ge c \\cdot k \\log k$ and instantiates it for specific $n, k$ via `obtain`."
     },
     {
       "id": "main-conjecture",
       "title": "The Main Conjecture: $P \\ge \\min(n-k+1, k^{1+c})$",
-      "startLine": 139,
-      "endLine": 162,
+      "startLine": 145,
+      "endLine": 168,
       "summary": "Formalizes `erdosConjecture683` as a `Prop`. Erdős's 1979 belief ($P > k^{1+c}$ for all $c > 0$ with finite exceptions) is documented in a prose comment, not formalized.",
       "mathContext": "Formal definition: Formalizes `erdosConjecture683` as a `Prop`. Erdős's 1979 belief ($P > k^{1+c}$ for all $c > 0$ with finite exceptions) is documented in a prose comment, not formalized."
     },
     {
       "id": "heuristics",
       "title": "Heuristic Bounds: $P > e^{c\\sqrt{k}}$",
-      "startLine": 163,
-      "endLine": 189,
+      "startLine": 169,
+      "endLine": 195,
       "summary": "Prose only: documents (in comments, no Lean declarations) the Cramér-type heuristic $P(\\binom{n}{k}) > e^{c\\sqrt{k}}$ and the comparison $e^{c\\sqrt{k}} > k^{1+c}$ (stretched exponential vs polynomial).",
       "mathContext": "Prose only: documents (in comments, no Lean declarations) the Cramér-type heuristic $P(\\binom{n}{k}) > e^{c\\sqrt{k}}$ and the comparison $e^{c\\sqrt{k}} > k^{1+c}$ (stretched exponential vs polynomial)."
     },
     {
       "id": "min-bound",
       "title": "Trivial Upper Bound: $P(\\binom{n}{k}) \\le n$",
-      "startLine": 190,
-      "endLine": 200,
+      "startLine": 196,
+      "endLine": 206,
       "summary": "Prose only: documents the trivial upper bound $P(\\binom{n}{k}) \\le n$ in a comment (since $\\binom{n}{k}$ divides products of terms $\\le n$); not formalized.",
       "mathContext": "Prose only: documents the trivial upper bound $P(\\binom{n}{k}) \\le n$ in a comment (since $\\binom{n}{k}$ divides products of terms $\\le n$); not formalized."
     },
     {
       "id": "consecutive",
       "title": "Consecutive Products and Bertrand's Postulate",
-      "startLine": 201,
-      "endLine": 228,
+      "startLine": 207,
+      "endLine": 234,
       "summary": "Defines `consecutiveProduct m k = \\prod_{i=0}^{k-1}(m+i)`. Bertrand-type results ($P(\\binom{2n}{n}) > n$, Sylvester's theorem for consecutive products) are documented in prose comments, not axiomatized.",
       "mathContext": "Formal definition: Defines `consecutiveProduct m k = \\prod_{i=0}^{k-1}(m+i)`. Bertrand-type results ($P(\\binom{2n}{n}) > n$, Sylvester's theorem for consecutive products) are documented in prose comments, not axiomatized."
     },
     {
       "id": "specific-cases",
       "title": "Central Binomial and Small $k$ Cases",
-      "startLine": 229,
-      "endLine": 250,
+      "startLine": 235,
+      "endLine": 256,
       "summary": "Prose only: documents the central binomial case $P(\\binom{2k}{k}) > \\frac{4}{3}k$ for large $k$ and the small-$k$ case $P(\\binom{n}{2}) \\ge (n-1)/2$ for $n \\ge 4$ in comments; neither is formalized.",
       "mathContext": "Prose only: documents the central binomial case $P(\\binom{2k}{k}) > \\frac{4}{3}k$ for large $k$ and the small-$k$ case $P(\\binom{n}{2}) \\ge (n-1)/2$ for $n \\ge 4$ in comments; neither is formalized."
     },
     {
       "id": "summary",
       "title": "Summary Theorem",
-      "startLine": 251,
-      "endLine": 253,
+      "startLine": 257,
+      "endLine": 259,
       "summary": "Combines Sylvester-Schur ($P > k$) and Erdős 1955 ($P \\ge c \\cdot k \\log k$) into a single conjunction, proved in term mode.",
       "mathContext": "Mathematical content: Combines Sylvester-Schur ($P > k$) and Erdős 1955 ($P \\ge c \\cdot k \\log k$) into a single conjunction, proved in term mode."
     }
@@ -211,9 +211,9 @@
       "Real"
     ],
     "namespace": "Erdos683",
-    "lineCount": 253,
+    "lineCount": 259,
     "axiomCount": 2,
-    "theoremCount": 6,
+    "theoremCount": 7,
     "definitionCount": 4,
     "path": "Proofs/Erdos683Problem.lean",
     "sorries": 0


### PR DESCRIPTION
## Problem

`erdos-683` presented an "axiomatized, 0 sorries" reduction of open problem #683, but the axiom base was **logically inconsistent** — `False` was provable.

Root cause: `largestPrimeDivisor` was defined via `Nat.find (Nat.exists_prime_and_dvd …)`, which returns the **least** prime divisor, not the largest. So the axiom `sylvester_schur : P n k > k` was refutable within its own hypotheses (n=4, k=2: C(4,2)=6, least prime divisor 2, so `P 4 2 = 2`, contradicting `P 4 2 > 2`).

## Fix (auditor's Option 1 — the honest formalization)

- **Redefine** `largestPrimeDivisor n` as the genuine largest prime divisor via `n.primeFactors.max'` (max of the prime-factors finset), guarded by `Nat.nonempty_primeFactors` for `n > 1`.
- `P_is_prime` / `P_divides` now proved from `Finset.max'_mem` + `Nat.prime_of_mem_primeFactors` / `Nat.dvd_of_mem_primeFactors` (previously `Nat.find_spec`).
- Add `P_maximal` theorem establishing maximality (was prose-only — the auditor noted maximality was "never declared"). Every prime dividing `n` is `≤ largestPrimeDivisor n`, via `Finset.le_max'`.
- With `P` now genuinely the largest prime divisor, `sylvester_schur` and `erdos_1955_bound` are **true** (consistent) statements of the named theorems. `False` is no longer derivable.
- Added import `Mathlib.Data.Nat.PrimeFin`.

## Metadata

Synced meta.json prose/counts with the repaired source: dropped stale "via `Nat.find`" / "axiomatizes maximality" claims, bumped `theoremCount` 6→7, `lineCount` 253→259, re-anchored section line numbers. `axiomCount` remains 2, `sorries` 0, `status` axiomatized.

## Verification

`./proofs/scripts/docker-build.sh Proofs.Erdos683Problem` → **Build succeeded** (Lean v4.31.0 / Mathlib 4.31.0). Only pre-existing unused-variable linter warnings in `erdos_683_summary`.

Closes #39980
