### PR TITLE
Research: erdos-507-wip-01 — sandwich corollary heilbronn ∈ [0,3] (0-axiom)

### DIFF
--- a/proofs/Proofs/Erdos507WIP01.lean
+++ b/proofs/Proofs/Erdos507WIP01.lean
@@ -370,4 +370,12 @@ theorem heilbronn_antitone {m n : ℕ} (hm : 3 ≤ m) (hmn : m ≤ n) :
   | succ k hk ih =>
     exact le_trans (heilbronn_succ_le k (le_trans hm hk)) ih
 
+/-- **Heilbronn's function is bounded into `[0, 3]`.**  Combining `heilbronn_nonneg`
+and `heilbronn_le_three`, for `n ≥ 3` the value `heilbronn n` lies in the unit-disk
+area envelope `0 ≤ heilbronn n ≤ 3`.  (The true order of magnitude is
+`n^{−β+o(1)}` with `7/6 ≤ β ≤ 2`, far below `3`, but that is the open deep content;
+this records the elementary two-sided bound the foundational lemmas already give.) -/
+theorem heilbronn_mem_Icc (n : ℕ) (hn : 3 ≤ n) : heilbronn n ∈ Set.Icc (0 : ℝ) 3 :=
+  ⟨heilbronn_nonneg n hn, heilbronn_le_three n hn⟩
+
 end Erdos507WIP01

--- a/src/data/research/problems/erdos-507-wip-01.json
+++ b/src/data/research/problems/erdos-507-wip-01.json
@@ -64,7 +64,8 @@
       "heilbronn_defining_bddAbove (private) in Erdos507WIP01.lean — defining sSup-set bounded by 3 for n≥3",
       "heilbronn_nonneg in Erdos507WIP01.lean — 0 ≤ heilbronn n for n≥3 via le_csSup (α=0 admissible)",
       "heilbronn_succ_le in Erdos507WIP01.lean — heilbronn (n+1) ≤ heilbronn n for n≥3, delete-a-point (Finset.erase) restriction",
-      "heilbronn_antitone in Erdos507WIP01.lean — full antitonicity on {n≥3} via Nat.le_induction"
+      "heilbronn_antitone in Erdos507WIP01.lean — full antitonicity on {n≥3} via Nat.le_induction",
+      "heilbronn_mem_Icc in Erdos507WIP01.lean — sandwich 0 ≤ heilbronn n ≤ 3 for n≥3 (PR #39991), 0-axiom"
     ],
     "insights": [
       "The signed shoelace area p₁(q₂−r₂)+q₁(r₂−p₂)+r₁(p₂−q₂) is alternating: transpositions negate it (area invariant via abs_neg), cyclic rotations fix it — giving full S₃ symmetry after the absolute value.",


### PR DESCRIPTION
## Summary
Follow-up to the merged monotonicity work (#39965) on `erdos-507-wip-01` (Heilbronn's triangle problem — foundations). Adds one corollary to `proofs/Proofs/Erdos507WIP01.lean`. **0 sorry / 0 axiom**, host-verified.

## Progress — 1 new theorem
```lean
theorem heilbronn_mem_Icc (n : ℕ) (hn : 3 ≤ n) : heilbronn n ∈ Set.Icc (0 : ℝ) 3
```
Combines the existing `heilbronn_nonneg` and `heilbronn_le_three` into the two-sided envelope `0 ≤ heilbronn n ≤ 3` for `n ≥ 3` — the elementary bracket the foundational lemmas already give. (The true order of magnitude is `n^{−β+o(1)}` with `7/6 ≤ β ≤ 2`, the open deep content.)

## Verification
```
#print axioms heilbronn_mem_Icc   -- [propext, Classical.choice, Quot.sound]
```

## Status
**Outcome**: progress (foundations). Heilbronn's exponent `β` remains OPEN.

🤖 Generated by researcher-1
