### PR TITLE
Enrich erdos-307 (prime reciprocal products): re-anchor 9 tail-drifted sections + fix stale sorry/axiom prose

### DIFF
--- a/src/data/proofs/erdos-307/meta.json
+++ b/src/data/proofs/erdos-307/meta.json
@@ -49,7 +49,7 @@
     ],
     "axiomCount": 0,
     "lineCount": 607,
-    "assumptions": "0 axiom declarations. 2 sorries: prime_sets_disjoint (P∩Q=∅ via p-adic valuation), prime_set_size_lower_bound (|P∪Q|≥60 via Mertens).",
+    "assumptions": "0 axiom declarations. 1 sorry: prime_set_size_lower_bound (|P∪Q|≥60 via Mertens). The disjointness constraint prime_sets_disjoint (P∩Q=∅) is now fully proved via the mod-p₀ valuation argument (prime_not_dvd_primeNumer), leaving prime_set_size_lower_bound as the sole open sorry. Uses one decorative native_decide (search_intractable: 2^60 > 10^18).",
     "theoremCount": 25,
     "definitionCount": 17,
     "additionalFiles": [
@@ -78,111 +78,111 @@
       "id": "header-imports",
       "title": "Header and Imports",
       "startLine": 1,
-      "endLine": 39,
+      "endLine": 40,
       "summary": "Module docstring stating Erdős Problem #307 (prime reciprocal products): do finite prime sets $P,Q$ exist with $(\\sum_{p\\in P}1/p)(\\sum_{q\\in Q}1/q)=1$? Notes the prime version is OPEN, the coprime version SOLVED by Cambie, and the constraints $P\\cap Q=\\emptyset$, $|P\\cup Q|\\geq60$. Attributed to Barbeau (1976). Imports `Nat.Prime.Basic`, `Data.Rat.Basic` ($\\mathbb{Q}$ for exact arithmetic) and `BigOperators`; opens `Finset BigOperators`.",
       "mathContext": "Goal: $(\\sum_{p\\in P}1/p)(\\sum_{q\\in Q}1/q)=1$ over $\\mathbb{Q}$. Prime version OPEN; coprime version SOLVED."
     },
     {
       "id": "problem-statement",
       "title": "Part I: Problem Statement",
-      "startLine": 40,
-      "endLine": 59,
+      "startLine": 41,
+      "endLine": 60,
       "summary": "Defines the core notions: `reciprocalSum S = \\sum_{n\\in S}(n)^{-1} \\in \\mathbb{Q}$, `reciprocalProduct P Q = reciprocalSum P * reciprocalSum Q`, `IsSetOfPrimes` ($\\forall p\\in S,\\text{Nat.Prime}\\,p$), and `IsPairwiseCoprime` (via `Set.Pairwise Nat.Coprime`).",
       "mathContext": "$\\text{reciprocalSum}(S)=\\sum_{n\\in S}1/n$; $\\text{reciprocalProduct}(P,Q)=(\\sum_P 1/p)(\\sum_Q 1/q)$."
     },
     {
       "id": "open-problem",
       "title": "Part II: The Open Problem (Prime Version)",
-      "startLine": 60,
-      "endLine": 73,
+      "startLine": 61,
+      "endLine": 74,
       "summary": "States `ErdosProblem307`: $\\exists P,Q$ sets of primes with reciprocal product $1$. This remains OPEN — no solution found and no impossibility proof known.",
       "mathContext": "$\\exists P,Q\\subseteq\\text{Primes}: (\\sum_P 1/p)(\\sum_Q 1/q)=1$. Status: OPEN."
     },
     {
       "id": "solved-coprime",
       "title": "Part III: The Solved Coprime Version",
-      "startLine": 74,
-      "endLine": 145,
+      "startLine": 75,
+      "endLine": 144,
       "summary": "Defines `ErdosProblem307Coprime` (relaxing 'prime' to pairwise-coprime, cardinality $>1$) and fully verifies Cambie's two examples: $\\{1,5\\},\\{2,3\\}$ giving $(6/5)(5/6)=1$, and $\\{1,41\\},\\{2,3,7\\}$ giving $(42/41)(41/42)=1$. Proves coprimality, the individual reciprocal sums, the products, and `erdos_307_coprime_solved` (the coprime version holds), all via `decide`/`norm_num`.",
       "mathContext": "$(1+1/5)(1/2+1/3)=1$; $(1+1/41)(1/2+1/3+1/7)=1$. Coprime version SOLVED (Cambie)."
     },
     {
       "id": "strengthened-coprime",
       "title": "Part IV: The Strengthened Coprime Version (Open)",
-      "startLine": 146,
-      "endLine": 157,
+      "startLine": 145,
+      "endLine": 156,
       "summary": "Defines `ErdosProblem307CoprimeStrengthened`: the coprime version with the extra requirement $1\\notin P$ and $1\\notin Q$. No examples are known — all of Cambie's solutions rely on the $1+1/n=(n+1)/n$ trick. Remains OPEN.",
       "mathContext": "Coprime version with $1\\notin P\\cup Q$. No known example; OPEN."
     },
     {
       "id": "constraints",
       "title": "Part V: Constraints on Prime Solutions",
-      "startLine": 158,
-      "endLine": 230,
-      "summary": "Constraints any prime solution must satisfy. `prime_sets_disjoint` ($P\\cap Q=\\emptyset$): stated, proof `sorry`. `prime_reciprocal_sum_lower_bound`: FULLY PROVED — for disjoint prime sets with product $1$, $\\sum_{P\\cup Q}1/p\\geq2$, via the AM-GM identity $a+a^{-1}-2=(a-1)^2 a^{-1}\\geq0$. `prime_set_size_lower_bound` ($|P\\cup Q|\\geq60$, since $\\sum_{p\\leq281}1/p\\approx2.009$): stated, proof `sorry`. These two are the file's only sorries.",
-      "mathContext": "$ab=1,a,b>0\\implies a+b\\geq2$ (AM-GM, proved). $P\\cap Q=\\emptyset$ and $|P\\cup Q|\\geq60$ stated as sorry."
+      "startLine": 157,
+      "endLine": 318,
+      "summary": "The file's technical heart, deriving hard constraints on any prime solution. First the integer numerator/denominator of a prime-reciprocal sum are isolated: `primeNumer P = \\sum_{p}\\prod_{q\\neq p}q`, `primeDenom P = \\prod_p p`, with `reciprocalSum_mul_denom` clearing denominators ($(\\sum1/p)\\cdot\\prod p = \\sum_p\\prod_{q\\neq p}q$) and `primeNumer_mul_eq` upgrading $(\\sum1/p)(\\sum1/q)=1$ to the ℕ identity $N_P N_Q = D_P D_Q$. The valuation lemma `prime_not_dvd_primeNumer` (FULLY PROVED, reducing mod $p_0$ in $\\mathbb{Z}/p_0\\mathbb{Z}$: only the $p=p_0$ summand survives and is a nonzero product of units) shows $p_0\\nmid N_P$ for each $p_0\\in P$. From this `prime_sets_disjoint` is now FULLY PROVED (no sorry): $P\\cap Q=\\emptyset$, since $p_0\\in P\\cap Q$ would give $p_0\\nmid N_P N_Q$ yet $p_0\\mid D_P\\mid D_P D_Q = N_P N_Q$. `prime_reciprocal_sum_lower_bound` is PROVED — for disjoint prime sets with product $1$, $\\sum_{P\\cup Q}1/p\\geq2$, via the AM-GM identity $a+a^{-1}-2=(a-1)^2 a^{-1}\\geq0$. Only `prime_set_size_lower_bound` ($|P\\cup Q|\\geq60$, since $\\sum_{p\\leq281}1/p\\approx2.009$) remains a `sorry` — the file's sole sorry.",
+      "mathContext": "$N_P N_Q = D_P D_Q$ in ℕ; $p_0\\nmid N_P$ (valuation $-1$) $\\Rightarrow P\\cap Q=\\emptyset$ (proved). $ab=1,a,b>0\\Rightarrow a+b\\geq2$ (AM-GM, proved). $|P\\cup Q|\\geq60$ still `sorry`."
     },
     {
       "id": "hardness",
       "title": "Part VI: Why the Problem is Hard",
-      "startLine": 231,
-      "endLine": 247,
+      "startLine": 319,
+      "endLine": 335,
       "summary": "Defines `primeReciprocalPartialSum n` ($\\sum$ of $1/p$ over the first primes, via a `Finset.filter` on `minFac`). A docstring note explains the difficulty: $\\sum1/p$ diverges only like $\\log\\log n$ (Mertens), and the product constraint is rigid — given $P$, the required $\\text{reciprocalSum}\\,Q=(\\text{reciprocalSum}\\,P)^{-1}$ must itself decompose into distinct prime reciprocals. No new declarations beyond the definition (no axioms).",
       "mathContext": "$\\sum_{p\\leq n}1/p\\sim\\log\\log n$ (Mertens). Product rigidity makes search hard."
     },
     {
       "id": "egyptian",
       "title": "Part VII: Related Egyptian Fraction Problems",
-      "startLine": 248,
-      "endLine": 263,
+      "startLine": 336,
+      "endLine": 351,
       "summary": "Defines `IsEgyptianOne S` ($\\forall n\\in S, n>0$ and $\\sum_S 1/n=1$) and proves `egyptian_example`: $1=1/2+1/3+1/6$ via `norm_num`. Situates #307 within the Egyptian-fraction / unit-fraction literature.",
       "mathContext": "$1=1/2+1/3+1/6$; Egyptian fraction = distinct unit fractions summing to $1$."
     },
     {
       "id": "computational",
       "title": "Part VIII: Computational Approaches",
-      "startLine": 264,
-      "endLine": 278,
+      "startLine": 352,
+      "endLine": 366,
       "summary": "Defines `searchSpaceSize = 2^{60}$ and proves `partition_count` ($=2^{60}$ by `rfl`) and `search_intractable` ($2^{60}>10^{18}$ via `native_decide`). With $\\geq60$ primes required, exhaustive partition search is infeasible (36+ years at $10^9$ checks/sec).",
       "mathContext": "$2^{60}\\approx1.15\\times10^{18}>10^{18}$ partitions; brute force infeasible."
     },
     {
       "id": "why-one",
       "title": "Part IX: Why Does 1 Appear in Coprime Examples?",
-      "startLine": 279,
-      "endLine": 307,
+      "startLine": 367,
+      "endLine": 397,
       "summary": "Explains why Cambie's solutions include $1$. `one_helps_balance` is FULLY PROVED: if $1\\in P$, $|P|>1$, all elements positive, then $\\text{reciprocalSum}\\,P>1$ (the $1/1=1$ term plus positive remainder, via `Finset.sum_pos`). `pair_with_one` is proved: $\\text{reciprocalSum}\\,\\{1,n\\}=(n+1)/n$ via `field_simp; ring`. The $1+1/n=(n+1)/n$ identity gives a balancing lever.",
       "mathContext": "$1\\in P,|P|>1\\implies\\sum_P 1/p>1$ (proved). $\\sum_{\\{1,n\\}}1/k=(n+1)/n$."
     },
     {
       "id": "alternative",
       "title": "Part X: Alternative Formulations",
-      "startLine": 308,
-      "endLine": 323,
+      "startLine": 398,
+      "endLine": 413,
       "summary": "Defines `MultiplicativeForm P Q`, an algebraic restatement obtained by clearing denominators: the product equals $1$ iff $(\\prod_P p)(\\prod_Q q)$ matches a sum over subsets/complements. A note observes this reformulation does not simplify the search.",
       "mathContext": "$(\\prod P)(\\prod Q)=(\\sum_{S\\subseteq P}\\prod_{P\\setminus S})(\\sum_{T\\subseteq Q}\\prod_{Q\\setminus T})$; equivalent, not easier."
     },
     {
       "id": "partial",
       "title": "Part XI: Partial Results",
-      "startLine": 324,
-      "endLine": 451,
+      "startLine": 414,
+      "endLine": 544,
       "summary": "Non-existence results for small prime sets, all FULLY PROVED. `reciprocal_sum_two_primes_le`: two distinct primes give $\\sum\\leq5/6$. `no_size_two_solution`: no prime solution with $|P|=|Q|=2$, since the product $\\leq(5/6)^2=25/36<1$. `reciprocal_sum_three_primes_le`: three distinct primes give $\\sum\\leq31/30$ (pigeonhole: one $\\geq5$, another $\\geq3$). `no_two_three_solution`: no solution with $|P|=2,|Q|=3$, since the product $\\leq(5/6)(31/30)=31/36<1$.",
       "mathContext": "$|P|=|Q|=2$: product $\\leq(5/6)^2=25/36<1$. $|P|=2,|Q|=3$: $\\leq(5/6)(31/30)=31/36<1$. Both ruled out (proved)."
     },
     {
       "id": "summary-theorem",
       "title": "Part XII: Summary",
-      "startLine": 452,
-      "endLine": 483,
+      "startLine": 545,
+      "endLine": 577,
       "summary": "Proves `erdos_307_summary`, packaging the file's main results: the coprime version is solved (`erdos_307_coprime_solved`) AND every prime solution satisfies $|P\\cup Q|\\geq60$ (`prime_set_size_lower_bound`).",
       "mathContext": "`erdos_307_summary` = (coprime solved) $\\wedge$ ($\\forall$ prime solution, $|P\\cup Q|\\geq60$)."
     },
     {
       "id": "closing-summary",
       "title": "Closing Summary (Post-Namespace)",
-      "startLine": 484,
-      "endLine": 514,
+      "startLine": 578,
+      "endLine": 607,
       "summary": "After `end Erdos307`, a closing docstring recaps the problem status (prime OPEN / coprime SOLVED), what is formalized (definitions, Cambie examples, the $\\geq60$ and disjointness constraints, Egyptian-fraction connection, small-case non-existence), and the key insight that allowing $1$ makes the coprime version tractable while the prime version stays hard.",
       "mathContext": "Recap: prime version OPEN, coprime SOLVED; $1+1/n=(n+1)/n$ is the balancing lever."
     }
@@ -254,7 +254,7 @@
     },
     {
       "citation": "Euler, L. (1737). 'Variae observationes circa series infinitas.' Commentarii academiae scientiarum Petropolitanae 9, 160-188.",
-      "note": "First proof that ∑1/p diverges, axiomatized in the file as prime_reciprocal_divergence"
+      "note": "First proof that ∑1/p diverges — the analytic fact behind the |P ∪ Q| ≥ 60 bound (used informally; the file states that bound as the sole sorry rather than deriving it from a divergence axiom)"
     }
   ],
   "conclusion": {
@@ -262,7 +262,7 @@
     "implications": "The problem connects number theory (primes, Egyptian fractions) with computational complexity (intractable search spaces). The contrast between the solved coprime version and open prime version illustrates how the structure of primes (no 1, slow-growing reciprocal sums) creates fundamental obstacles.",
     "openQuestions": [
       "Does a prime solution exist? The search space (2^60 ≈ 10^18) makes brute force infeasible; new algebraic constraints are needed",
-      "Can the sorry theorems (disjointness via p-adic valuation, AM-GM bound, small case non-existence) be proved in Lean from Mathlib?",
+      "Can the remaining sorry (|P ∪ Q| ≥ 60, via Mertens-type partial-sum estimates) be discharged in Lean? Disjointness (P ∩ Q = ∅ via the mod-p valuation argument), the AM-GM bound, and the small-case non-existence results are now fully proved.",
       "Does a coprime solution with 1 ∉ P ∪ Q exist? This intermediate problem may be more tractable than the prime version",
       "Can the |P ∪ Q| ≥ 60 bound be improved using more refined estimates of partial prime reciprocal sums?",
       "Are there additional Cambie-type examples beyond the (1+1/n)(∑_{p|n+1} 1/p) = 1 family?"


### PR DESCRIPTION
## Enrichment pass for erdos-307 (Erdős #307: Prime Reciprocal Products)

**Class:** tail-drifted `Part` sections (accurate titles, line ranges drifted ~90 lines from Part V onward) + stale integrity prose.

### Section re-anchoring
The `sections` list was drifted: Part V was pinned to lines 158–230 but the actual `## Part V` banner runs 157–318, and every subsequent part was off by ~90 lines, leaving lines 514–607 uncovered. Re-anchored all 14 sections to their actual `/- ## Part … -/` banners; coverage now contiguous **1 → 607 (full file)**.

### Stale-prose / integrity fixes (file has 0 axioms, 1 sorry)
- **Part V summary** rewritten: `prime_sets_disjoint` (P ∩ Q = ∅) is now **fully proved** via the mod-p₀ valuation argument (`prime_not_dvd_primeNumer`, `primeNumer_mul_eq`), not a `sorry` as the old summary claimed. Documented the new `primeNumer`/`primeDenom`/`reciprocalSum_mul_denom` machinery. The sole remaining sorry is `prime_set_size_lower_bound` (|P∪Q| ≥ 60).
- **`assumptions`** corrected from "2 sorries" to "1 sorry"; noted the decorative `native_decide` in `search_intractable`.
- **Euler reference note** fixed: it claimed the file axiomatizes `prime_reciprocal_divergence`, but no such axiom exists (file has 0 axiom declarations).
- **Open question** updated: disjointness / AM-GM / small-case results are proved; only the |P∪Q| ≥ 60 bound remains open.

No status/badge/axiomCount changes (correctly `formalized` / `wip`, 1 sorry). JSON validated; sections verified contiguous to EOF.
