### PR TITLE
Enrich erdos-1018-oq-04-incomplete-01 (K₄ planar / non-embeddability): re-anchor Parts II–VIII drift (up to 279 lines), cover tail 738→1017

### DIFF
--- a/src/data/proofs/erdos-1018-oq-04-incomplete-01/meta.json
+++ b/src/data/proofs/erdos-1018-oq-04-incomplete-01/meta.json
@@ -62,55 +62,55 @@
       "id": "concrete-def",
       "title": "Part I — Concrete isEmbeddable Definition",
       "startLine": 43,
-      "endLine": 59,
+      "endLine": 61,
       "summary": "Defines isEmbeddableConc via vertex maps φ : V → Fin d → ℝ with convex hull separation.",
       "mathContext": "H embeddable in ℝ^d iff ∃ injective φ : V → ℝ^d, ∀ e₁ ≠ e₂ ∈ H.edges: ConvHull(φ(e₁)) ∩ ConvHull(φ(e₂)) ⊆ ConvHull(φ(e₁ ∩ e₂))."
     },
     {
       "id": "properties-k3",
       "title": "Part II — Properties of the Concrete Definition (incl. K₃)",
-      "startLine": 60,
-      "endLine": 233,
+      "startLine": 62,
+      "endLine": 302,
       "summary": "Proves `embeddable_injective`, `embeddable_mono` (higher dimensions only help), and `K3_planar` via the explicit coordinate embedding (0,0),(1,0),(0,1) with linear-functional convex-hull arguments.",
       "mathContext": "K₃ at {(0,0),(1,0),(0,1)}: non-degenerate triangle, embeddable in ℝ²."
     },
     {
       "id": "k4-planar",
       "title": "Part IV — K₄ is Planar",
-      "startLine": 234,
-      "endLine": 614,
+      "startLine": 303,
+      "endLine": 888,
       "summary": "`K4_planar`: a fully-proved planar embedding of K₄ at (0,0),(3,0),(1,2),(2,2), establishing the non-crossing condition for all edge pairs via explicit linear functionals on convex hulls (a long, detailed proof).",
       "mathContext": "K₄ at {(0,0),(3,0),(1,2),(2,2)}: valid planar configuration, embeddable in ℝ²."
     },
     {
       "id": "graph-recovery",
       "title": "Part V — Graph Case Recovery",
-      "startLine": 615,
-      "endLine": 635,
+      "startLine": 889,
+      "endLine": 909,
       "summary": "Edge counts for complete graphs: `Kn_edges` (|E(K_n)| = C(n,2)), and the concrete `K5_edges`, `K3_edges`, `K4_edges`.",
       "mathContext": "|E(K_n)| = \\binom{n}{2}; K5 has 10 edges, K3 has 3, K4 has 6."
     },
     {
       "id": "density",
       "title": "Part VI — Density and Non-Embeddability",
-      "startLine": 636,
-      "endLine": 672,
+      "startLine": 910,
+      "endLine": 946,
       "summary": "`planar_graphs_edge_bound` (|E| ≤ 3|V| − 6, the file's sole sorry — Euler's formula, not yet in Mathlib) and `dense_graph_not_planar` (graphs with n^{1+ε} edges eventually exceed the planar bound).",
       "mathContext": "Planar: |E| ≤ 3n − 6. For ε > 0, n^{1+ε} = n·n^ε eventually exceeds 3n − 6, so such graphs are non-planar."
     },
     {
       "id": "kostochka-pyber",
       "title": "Part VII — Connection to Main Conjecture",
-      "startLine": 673,
-      "endLine": 709,
+      "startLine": 947,
+      "endLine": 988,
       "summary": "The file's sole axiom `kostochka_pyber_r2` (the r=2 graph case, Kostochka–Pyber 1988) and `r2_implies_main_r2` deriving the r=2 case of the main conjecture from it.",
       "mathContext": "∀ε>0, ∃C,N: graphs on n≥N vertices with n^{1+ε} edges contain a non-planar subgraph on ≤C vertices."
     },
     {
       "id": "summary",
       "title": "Part VIII — Summary",
-      "startLine": 710,
-      "endLine": 738,
+      "startLine": 989,
+      "endLine": 1017,
       "summary": "Closing docstring: the parent's isEmbeddable sorry is resolved (→ isEmbeddableConc); turanNumber and the planar edge bound remain as the remaining gaps."
     }
   ],


### PR DESCRIPTION
Enrichment pass for `erdos-1018-oq-04-incomplete-01` (concrete isEmbeddable / K₄ planarity toward the r=2 non-embeddability case).

**Section drift fixed** (meta.json only, no Lean changes).

Every section from Part II onward was drifted against the actual `/-! ## Part … -/` banners in `Proofs/Erdos1018OQ04Incomplete01.lean`: the K₄-planarity proof (Part IV) had grown substantially, so Part II under-covered and Parts V–VIII were off by ~275 lines. Sections stopped at line 738 while the file runs to 1017.

Re-anchored to the real banners:
- Part II 60–233 → **62–302**
- Part IV (K₄ is Planar) 234–614 → **303–888**
- Part V 615–635 → **889–909**
- Part VI 636–672 → **910–946**
- Part VII 673–709 → **947–988**
- Part VIII 710–738 → **989–1017**

Sections now cover the full file (1–1017) contiguously; titles and content-summaries were already accurate (Part-based) and are unchanged. Axiom integrity unchanged and accurate: `badge: axiom`, `axiomCount: 1` (`kostochka_pyber_r2`, Part VII), `sorries: 1` (Euler's-formula bound in `planar_graphs_edge_bound`, Part VI) — both remain correctly disclosed.
