### PR TITLE
Enrich erdos-16 (2^k+p covering congruences): recover missing 'Assembling the Gears' section + re-anchor drifted sections to EOF

### DIFF
--- a/src/data/proofs/erdos-16/meta.json
+++ b/src/data/proofs/erdos-16/meta.json
@@ -79,111 +79,119 @@
       "id": "erd-s-problem-16-odd-integers-",
       "title": "Erdős Problem #16: Odd Integers Not of the Form 2^k + p",
       "startLine": 1,
-      "endLine": 29,
+      "endLine": 30,
       "summary": "States Erdős Problem #16: is the exceptional set $E = \\{\\text{odd } n : n \\neq 2^k + p\\}$ the union of an arithmetic progression and a density-0 set? Gives historical context from Romanoff (1934) through Chen's disproof (2023).",
       "mathContext": "States Erdős Problem #16: is the exceptional set $E = \\{\\text{odd } n : n \\neq 2^k + p\\}$ the union of an arithmetic progression and a density-0 set?"
     },
     {
       "id": "background",
       "title": "Background",
-      "startLine": 30,
-      "endLine": 44,
+      "startLine": 31,
+      "endLine": 45,
       "summary": "Introduces Romanoff's theorem and the exceptional set. Lists the first exceptional odd integers from OEIS A006285: 1, 127, 149, 251, 331, 337, 373, 509, 599, 701, ...",
       "mathContext": "Documented: Introduces Romanoff's theorem and the exceptional set. Lists the first exceptional odd integers from OEIS A006285: 1, 127, 149, 251, 331, 337, 373, 509, 599, 701, ..."
     },
     {
       "id": "core-definitions",
       "title": "Core Definitions",
-      "startLine": 45,
-      "endLine": 59,
+      "startLine": 46,
+      "endLine": 60,
       "summary": "Defines `IsRomanoff n` ($\\exists k \\geq 1, p$ prime: $n = 2^k + p$), `ExceptionalSet` (odd non-Romanoff integers), and documents (not formalized) the characterization that $n$ is exceptional iff $n - 2^k$ is composite for every valid $k$.",
       "mathContext": "Defines `IsRomanoff n` ($\\exists k \\geq 1, p$ prime: $n = 2^k + p$), `ExceptionalSet` (odd non-Romanoff integers), and documents (not formalized) the characterization that $n$ is exceptional iff $n - 2^k$ is composite for every valid $k$."
     },
     {
       "id": "the-romanoff-theorem",
       "title": "The Romanoff Theorem",
-      "startLine": 60,
-      "endLine": 79,
+      "startLine": 61,
+      "endLine": 80,
       "summary": "Defines asymptotic `density` and `lowerDensity`, then documents (not formalized) Romanoff's theorem: the Romanoff numbers have positive lower density among odd integers. Corollary: the exceptional set has density less than $1/2$.",
       "mathContext": "Defines asymptotic `density` and `lowerDensity`, then documents (not formalized) Romanoff's theorem: the Romanoff numbers have positive lower density among odd integers. Corollary: the exceptional set has density less than $1/2$."
     },
     {
       "id": "erd-s-s-covering-congruence-re",
       "title": "Erdős's Covering Congruence Result (1950)",
-      "startLine": 80,
-      "endLine": 93,
+      "startLine": 81,
+      "endLine": 94,
       "summary": "Defines `IsCoveringSystem` and documents (not formalized) Erdős's 1950 result: using covering congruences with moduli $\\{2, 3, 4, 6, 8, 12, 24\\}$, the exceptional set contains an infinite arithmetic progression.",
       "mathContext": "Formal definition: Defines `IsCoveringSystem` and documents (not formalized) Erdős's 1950 result: using covering congruences with moduli $\\{2, 3, 4, 6, 8, 12, 24\\}$, the exceptional set contains an infinite arithmetic progression."
     },
     {
       "id": "the-conjecture-and-its-disproo",
       "title": "The Conjecture and Its Disproof",
-      "startLine": 94,
-      "endLine": 112,
+      "startLine": 95,
+      "endLine": 113,
       "summary": "Formalizes `ErdosConjecture16`: $E = (\\text{AP}) \\cup (\\text{density-0 set})$. Documents (not formalized) Chen's 2023 disproof (stated as ¬ErdosConjecture16; no such declaration exists in the source) and the consequence that no single AP captures $E$ up to density 0.",
       "mathContext": "Formalizes `ErdosConjecture16`: $E = (\\text{AP}) \\cup (\\text{density-0 set})$. Documents (not formalized) Chen's 2023 disproof (stated as ¬ErdosConjecture16; no such declaration exists in the source) and the consequence that no single AP captures $E$ up to density 0."
     },
     {
       "id": "known-exceptional-numbers",
       "title": "Known Exceptional Numbers",
-      "startLine": 113,
-      "endLine": 121,
+      "startLine": 114,
+      "endLine": 122,
       "summary": "Documents (not formalized) specific exceptional numbers: 127, 149, 251. The source notes in prose (not checked in Lean) that $127 - 2^k$ is composite for $k = 1, \\ldots, 6$ and $2^7 > 127$.",
       "mathContext": "Documents (not formalized) specific exceptional numbers: 127, 149, 251. The source notes in prose (not checked in Lean) that $127 - $2^{k}$$ is composite for $k = 1, \\ldots, 6$ and $$2^{7}$ > 127$."
     },
     {
       "id": "connection-to-covering-congrue",
       "title": "Connection to Covering Congruences",
-      "startLine": 122,
-      "endLine": 132,
+      "startLine": 123,
+      "endLine": 133,
       "summary": "Defines `erdosCovering` with moduli $\\{2,3,4,6,8,12,24\\}$ (period 24) and documents (not formalized) that for exceptional $n$, each $n - 2^k$ is divisible by some prime $p < 100$ from the covering.",
       "mathContext": "Defines `erdosCovering` with moduli $\\{2,3,4,6,8,12,24\\}$ (period 24) and documents (not formalized) that for exceptional $n$, each $n - $2^{k}$$ is divisible by some prime $p < 100$ from the covering."
     },
     {
       "id": "density-bounds",
       "title": "Density Bounds",
-      "startLine": 133,
-      "endLine": 140,
+      "startLine": 134,
+      "endLine": 141,
       "summary": "Documents (not formalized) precise density bounds: $\\underline{d}(E) > 0$ (positive density from the arithmetic progression) and $\\underline{d}(E) < 1/10$ (approximately 9% of all integers, 18% of odd integers).",
       "mathContext": "Documents (not formalized) precise density bounds: $\\underline{d}(E) > 0$ (positive density from the arithmetic progression) and $\\underline{d}(E) < 1/10$ (approximately 9% of all integers, 18% of odd integers)."
     },
     {
       "id": "related-problems",
       "title": "Related Problems",
-      "startLine": 141,
-      "endLine": 163,
+      "startLine": 142,
+      "endLine": 164,
       "summary": "Defines the sibling questions in the 2^k + p family as propositions: Erdos9Question, Erdos10Question, Erdos11Question — the de Polignac / Romanoff neighbourhood of Erdős #16.",
       "mathContext": "The exceptional-set question sits in a family of representation problems $n = 2^k + p$; these `Prop` definitions record the adjacent Erdős problems #9/#10/#11 for cross-reference."
     },
     {
       "id": "why-chen-significant",
       "title": "Why Chen's Result is Significant",
-      "startLine": 164,
-      "endLine": 175,
+      "startLine": 165,
+      "endLine": 176,
       "summary": "Prose: Chen's 2023 disproof shows the exceptional set has rich structure beyond a single arithmetic progression — possibly multiple independent progressions, fractal/quasi-random behaviour, and deep ties to prime distribution.",
       "mathContext": "Motivates the disproof: the exceptional set is not (AP) ∪ (density-0), suggesting genuinely multi-progression / quasi-random structure."
     },
     {
       "id": "foundational-lemmas",
       "title": "Foundational Lemmas (Axiom-Free)",
-      "startLine": 176,
-      "endLine": 367,
+      "startLine": 177,
+      "endLine": 368,
       "summary": "The machine-checked core (0 axioms): mem_exceptionalSet_iff, isRomanoff_four_le, not_isRomanoff_one/three and membership of 1,3 in the exceptional set; Romanoff witnesses isRomanoff_five/seven with five_not_mem_exceptionalSet; density_nonneg / density_le_one; erdosCovering_moduli_pos and erdosCovering_isCoveringSystem (the {2,3,4,6,8,12,24} system genuinely covers ℤ, by decide); the bounded characterisation isRomanoff_iff / isRomanoff_iff_mem_range with the resulting IsRomanoff Decidable instance; and verified exceptionality of the OEIS A006285 terms 127, 149, 251, 331.",
       "mathContext": "Everything here depends only on propext/Classical.choice/Quot.sound. Key device: $\\texttt{isRomanoff\\_iff\\_mem\\_range}$ bounds the witness exponent $k$ to a finite range, making $\\texttt{IsRomanoff}$ decidable and the exceptionality of 127/149/251/331 machine-checkable by `decide`."
     },
     {
       "id": "covering-obstruction",
       "title": "The Covering-Congruence Obstruction Mechanism (Axiom-Free)",
-      "startLine": 368,
-      "endLine": 451,
+      "startLine": 369,
+      "endLine": 452,
       "summary": "The verified gear behind the covering construction: two_pow_mod_three (2^k mod 3 is periodic with period 2), two_pow_modEq_of_dvd (order-periodicity of 2 mod p), the general obstruction covering_prime_not_prime_sub (if p | n − 2^k on a residue class then n − 2^k is composite there), and the concrete gears not_prime_sub_even_mod_three (prime 3, even exponents) and not_prime_sub_mod_seven (prime 7, exponents ≡ 0 mod 3). All axiom-free.",
       "mathContext": "Formalizes how a covering system forces compositeness: fixing a prime $p$ and exponent period $d$, on the residue class where $p \\mid n - 2^k$ the value $n-2^k$ is divisible by $p$ yet exceeds it, so it is not prime — the mechanism producing an AP of exceptional $n$."
     },
     {
+      "id": "assembling-the-gears",
+      "title": "Assembling the Gears: The Full Covering Obstruction (Axiom-Free)",
+      "startLine": 453,
+      "endLine": 555,
+      "summary": "Runs the full covering system of the *exponent*: the six classes k ≡ 0 (2), 0 (3), 1 (4), 3 (8), 7 (12), 23 (24) cover ℤ, each closed by a prime whose order of 2 equals that modulus — 3, 7, 5, 17, 13, 241. The order gears two_pow_two_modEq_three, two_pow_three_modEq_seven, two_pow_four_modEq_five, two_pow_eight_modEq_seventeen, two_pow_twelve_modEq_thirteen, two_pow_twentyfour_modEq_241 (all by decide/norm_num) supply the third table column. The assembled theorem covering_obstruction_not_isRomanoff shows any n meeting the six residues n ≡ 1(3),1(7),2(5),8(17),11(13),121(241) and the size hypothesis (n − 2^k > 241 for all valid k) is not Romanoff, and covering_progression_mem_exceptionalSet packages the odd such n as members of ExceptionalSet — the membership form of Erdős's 1950 theorem that the exceptional set contains a full CRT arithmetic progression mod 3·5·7·13·17·241. All axiom-free.",
+      "mathContext": "Six primes with $\\text{ord}_p(2)=d$ close a covering system of the exponent $k$; by CRT the progression $n \\equiv a \\pmod{3\\cdot5\\cdot7\\cdot13\\cdot17\\cdot241}$ (odd, large) makes every $n-2^k$ composite, so the whole progression lies in $\\text{ExceptionalSet}$ — Erdős (1950), assembled unconditionally modulo one explicit size hypothesis."
+    },
+    {
       "id": "summary",
       "title": "Summary",
-      "startLine": 452,
-      "endLine": 479,
+      "startLine": 556,
+      "endLine": 582,
       "summary": "Closing prose: Problem #16 is SOLVED (disproved by Chen 2023). Recap of Romanoff (1934, positive density are representable), Erdős (1950, exceptional set contains an AP), Chen (2023, not a single AP + noise); the exceptional set has small positive density (~0.09) and complex multi-progression structure. References including OEIS A006285.",
       "mathContext": "Status recap: Erdős #16 disproved; the exceptional set has density $\\approx 0.09$, contains arithmetic progressions via covering congruences, but is not captured by any single progression up to density 0."
     }


### PR DESCRIPTION
## Enrichment pass for erdos-16 (Erdős #16: Odd Integers Not of the Form 2^k + p)

**Class:** missing section + tail-drifted `sections` (all head sections off by +1, `Summary` mis-anchored 100+ lines early).

### Missing section recovered
The entire `## Assembling the gears: the full covering obstruction (axiom-free)` block (lines **453–555**) had **no** entry in `sections`. It contains substantive machine-checked content: the six order-of-2 gear lemmas (`two_pow_two_modEq_three` … `two_pow_twentyfour_modEq_241`), the assembled `covering_obstruction_not_isRomanoff` (any n meeting six covering congruences + a size hypothesis is not Romanoff), and `covering_progression_mem_exceptionalSet` (the CRT progression lies in `ExceptionalSet`) — the membership form of Erdős's 1950 theorem. Added a dedicated section with an accurate summary.

### Re-anchoring
Every head section was off by +1 line relative to its `##` banner (Background 30→31, Core Definitions 45→46, … Foundational Lemmas 176→368). `Summary` was pinned to 452–479 but the `## Summary` banner is at line 556. Re-anchored all 15 sections; coverage now contiguous **1 → 582 (full file)** with no gaps or overlaps.

No status/badge/axiomCount changes (correctly `axiomatized` / `wip`, 0 axioms, 0 sorries). JSON validated; sections verified contiguous to EOF.
