### PR TITLE
Research: erdos-46-wip-01 — infinitely many unit-fraction representations of 1 (0-axiom)

### DIFF
--- a/proofs/Proofs/Erdos46Problem.lean
+++ b/proofs/Proofs/Erdos46Problem.lean
@@ -258,3 +258,53 @@ theorem isUnitFractionRepr_replace
     rw [herase]
     simp only [hcast1, hcast2]
     linarith [hsplit]
+
+/-- **Arbitrarily long unit-fraction representations of `1`.** For every `k` there
+is a representation `S` with `k ≤ |S|`.  Induction on `k`: start from `{2, 3, 6}`
+and, at each step, split the *largest* denominator `m` of the current
+representation via `isUnitFractionRepr_replace` — both split denominators `m+1` and
+`m(m+1)` exceed `m` (hence lie outside `S`), so the replacement is legal and
+strictly increases the cardinality by one. -/
+theorem exists_isUnitFractionRepr_card_ge (k : ℕ) :
+    ∃ S : Finset ℕ, IsUnitFractionRepr S ∧ k ≤ S.card := by
+  induction k with
+  | zero => exact ⟨{2, 3, 6}, isUnitFractionRepr_two_three_six, Nat.zero_le _⟩
+  | succ k ih =>
+    obtain ⟨S, hS, hcard⟩ := ih
+    have hc2 : 2 ≤ S.card := two_le_card_of_isUnitFractionRepr hS
+    have hne : S.Nonempty := by rw [← Finset.card_pos]; omega
+    -- split the largest denominator `m`
+    set m := S.max' hne with hm_def
+    have hmS : m ∈ S := S.max'_mem hne
+    have hmax : ∀ a ∈ S, a ≤ m := fun a ha => S.le_max' a ha
+    have hm2 : 2 ≤ m := (hS.1) m hmS
+    -- `m+1` and `m(m+1)` both exceed `m`, so neither is already in `S`
+    have h1 : m + 1 ∉ S := fun h => by have := hmax _ h; omega
+    have h2 : m * (m + 1) ∉ S := fun h => by
+      have := hmax _ h; nlinarith
+    have hrepl := isUnitFractionRepr_replace hS hmS h1 h2
+    refine ⟨insert (m + 1) (insert (m * (m + 1)) (S.erase m)), hrepl, ?_⟩
+    -- the replacement raises the cardinality by exactly one
+    have hne' : m + 1 ≠ m * (m + 1) := by nlinarith
+    have h2erase : m * (m + 1) ∉ S.erase m := fun h => h2 (Finset.mem_of_mem_erase h)
+    have h1insert : m + 1 ∉ insert (m * (m + 1)) (S.erase m) := by
+      simp only [Finset.mem_insert]
+      push_neg
+      exact ⟨hne', fun h => h1 (Finset.mem_of_mem_erase h)⟩
+    rw [Finset.card_insert_of_not_mem h1insert, Finset.card_insert_of_not_mem h2erase,
+      Finset.card_erase_of_mem hmS]
+    omega
+
+/-- **There are infinitely many distinct unit-fraction representations of `1`.**
+Consequence of `exists_isUnitFractionRepr_card_ge`: the representations have
+unbounded cardinality, so the set of them cannot be finite (a finite family of
+`Finset`s would have bounded cardinality). This is the elementary,
+colouring-free lower bound behind Erdős Problem 46 — the deep monochromatic
+statement (Croot 2003) remains unformalized. -/
+theorem infinite_isUnitFractionRepr :
+    {S : Finset ℕ | IsUnitFractionRepr S}.Infinite := by
+  intro hfin
+  obtain ⟨M, hM⟩ := (hfin.image Finset.card).bddAbove
+  obtain ⟨S, hS, hcard⟩ := exists_isUnitFractionRepr_card_ge (M + 1)
+  have hle : S.card ≤ M := hM ⟨S, hS, rfl⟩
+  omega

--- a/proofs/Proofs/Erdos46Problem.lean
+++ b/proofs/Proofs/Erdos46Problem.lean
@@ -288,10 +288,9 @@ theorem exists_isUnitFractionRepr_card_ge (k : ℕ) :
     have hne' : m + 1 ≠ m * (m + 1) := by nlinarith
     have h2erase : m * (m + 1) ∉ S.erase m := fun h => h2 (Finset.mem_of_mem_erase h)
     have h1insert : m + 1 ∉ insert (m * (m + 1)) (S.erase m) := by
-      simp only [Finset.mem_insert]
-      push_neg
+      simp only [Finset.mem_insert, not_or]
       exact ⟨hne', fun h => h1 (Finset.mem_of_mem_erase h)⟩
-    rw [Finset.card_insert_of_not_mem h1insert, Finset.card_insert_of_not_mem h2erase,
+    rw [Finset.card_insert_of_notMem h1insert, Finset.card_insert_of_notMem h2erase,
       Finset.card_erase_of_mem hmS]
     omega
 

--- a/src/data/research/problems/erdos-46-wip-01.json
+++ b/src/data/research/problems/erdos-46-wip-01.json
@@ -31,19 +31,25 @@
     }
   },
   "knowledge": {
-    "progressSummary": "FOUNDATIONS (researcher-1, 2026-07-20): developed the def-only Erdos46Problem.lean stub (Erdos Problem 46, monochromatic unit-fraction representations, Croot) with 13 axiom-free elementary lemmas: singleton/empty exclusions, the two-element lower bound (card>=2), term bound 1/n<=1/2, reciprocal-sum nonnegativity/positivity, uniqueness of the represented rational, additivity over disjoint unions (isRatFractionRepr_union — the arithmetic backbone for assembling disjoint monochromatic solutions), and the structural reduction erdosProblem46_of_infinitely_many (base Croot statement follows from the infinitely-many-disjoint-solutions version at N=0). File 84->188 lines, 3->16 theorems. Deep result (Croot 2003) itself unformalized. Host-verified v4.31 lake env lean, exit 0.",
+    "progressSummary": "PROGRESS (researcher-1, 2026-07-20, VERIFIED 0/0 host): realized the chain-to-∞ direction — exists_isUnitFractionRepr_card_ge (unit-fraction reprs of 1 with arbitrarily large cardinality, by splitting the largest denominator via isUnitFractionRepr_replace) and infinite_isUnitFractionRepr (the set of such reprs is Set.Infinite). The colouring-free lower bound behind Erdős 46; the deep monochromatic Croot 2003 result stays unformalized. 28 axiom-free theorems.",
     "builtItems": [
       "not_isUnitFractionRepr_singleton — no singleton represents 1 (Erdos46Problem.lean)",
       "two_le_card_of_isUnitFractionRepr — a UFR of 1 has >= 2 elements (Erdos46Problem.lean)",
       "isRatFractionRepr_union — reciprocal-sum representations add over disjoint unions (Erdos46Problem.lean)",
       "erdosProblem46_of_infinitely_many — base Croot statement reduces to the infinitely-many version (Erdos46Problem.lean)",
-      "term_le_half / sum_inv_nonneg / isRatFractionRepr_pos / isRatFractionRepr_unique / pos_of_mem / forall_two_le_of_subset / isMonochromatic_empty / isMonochromatic_singleton / isRatFractionRepr_one_iff"
+      "term_le_half / sum_inv_nonneg / isRatFractionRepr_pos / isRatFractionRepr_unique / pos_of_mem / forall_two_le_of_subset / isMonochromatic_empty / isMonochromatic_singleton / isRatFractionRepr_one_iff",
+      "exists_isUnitFractionRepr_card_ge, infinite_isUnitFractionRepr in Erdos46Problem.lean — arbitrarily-long + infinitely-many unit-fraction reprs of 1, 0-axiom host-verified"
     ],
     "insights": [
-      "Erdos46Problem.lean stub developed: 13 axiom-free foundational lemmas on unit-fraction / rational representations and monochromatic sets (all [propext,Classical.choice,Quot.sound], no sorry/native_decide)."
+      "Erdos46Problem.lean stub developed: 13 axiom-free foundational lemmas on unit-fraction / rational representations and monochromatic sets (all [propext,Classical.choice,Quot.sound], no sorry/native_decide).",
+      "Infinitely many distinct unit-fraction representations of 1 exist (infinite_isUnitFractionRepr): via reprs of arbitrarily large cardinality (exists_isUnitFractionRepr_card_ge), obtained by iterating isUnitFractionRepr_replace on the LARGEST denominator m — both split denominators m+1, m(m+1) exceed m so ∉S, legal replacement raising |S| by exactly one.",
+      "Set.Infinite from unbounded card: by_contra, (hfin.image Finset.card).bddAbove gives M, then exists_...card_ge (M+1) overflows it. Finset.card_insert_of_not_mem renamed → card_insert_of_notMem in v4.31."
     ],
     "mathlibGaps": [],
-    "nextSteps": [],
+    "nextSteps": [
+      "Disjoint-support chaining: produce infinitely many PAIRWISE-DISJOINT unit-fraction reprs (needed for the monochromatic pigeonhole toward ErdosProblem46_infinitely_many) — splitting the largest denom keeps introducing fresh large denominators, so consecutive reprs can be made disjoint on their tails.",
+      "The deep monochromatic statement (Croot 2003) itself remains unformalized."
+    ],
     "markdown": "# Knowledge Base: erdos-46-wip-01\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },
   "tags": [
@@ -64,7 +70,7 @@
     "mathlib": []
   },
   "started": "2026-07-10T00:41:25.781Z",
-  "lastUpdate": "2026-07-21",
+  "lastUpdate": "2026-07-20",
   "significance": 6,
   "tractability": 7
 }


### PR DESCRIPTION
## Summary
Research session for `erdos-46-wip-01` (Erdős #46, monochromatic unit-fraction representations, Croot 2003). Realizes the **"chain to ∞"** direction in `proofs/Proofs/Erdos46Problem.lean`. **0 sorry / 0 axiom**, host-verified (Mathlib-only file).

## Progress — 2 new theorems
- `exists_isUnitFractionRepr_card_ge (k) : ∃ S, IsUnitFractionRepr S ∧ k ≤ S.card` — unit-fraction representations of `1` with **arbitrarily large cardinality**. Induction on `k`: start from `{2,3,6}` and split the *largest* denominator `m` via the existing `isUnitFractionRepr_replace`; both split denominators `m+1` and `m(m+1)` exceed `m`, hence lie outside `S`, so the replacement is legal and raises `|S|` by exactly one.
- `infinite_isUnitFractionRepr : {S | IsUnitFractionRepr S}.Infinite` — consequently the set of representations is **infinite** (unbounded cardinality cannot fit in a finite family).

This is the colouring-free lower bound behind Erdős 46; the deep monochromatic statement (Croot 2003) remains unformalized.

## Findings
- `Set.Infinite` from unbounded card: `by_contra`, `(hfin.image Finset.card).bddAbove` gives a ceiling `M`, then `exists_isUnitFractionRepr_card_ge (M+1)` overflows it.
- v4.31 rename: `Finset.card_insert_of_not_mem` → `Finset.card_insert_of_notMem`.

## Verification
```
#print axioms infinite_isUnitFractionRepr          -- [propext, Classical.choice, Quot.sound]
#print axioms exists_isUnitFractionRepr_card_ge    -- [propext, Classical.choice, Quot.sound]
```

## Status
**Outcome**: progress. Erdős #46 (monochromatic version) remains OPEN.
**Next steps**: disjoint-support chaining (pairwise-disjoint reprs) toward `ErdosProblem46_infinitely_many`.

🤖 Generated by researcher-1
