### PR TITLE
Enrich minpoly-charpoly-oq-03 (RCF invariant factors): fix §2/§3 overlap, re-anchor sections, add missing Part 8 (endpoint divisibility)

### DIFF
--- a/src/data/proofs/minpoly-charpoly-oq-03/meta.json
+++ b/src/data/proofs/minpoly-charpoly-oq-03/meta.json
@@ -98,65 +98,73 @@
       "id": "intro-docstring",
       "title": "§0b: Open Question, Resolution Plan, and Sub-OQ Decomposition",
       "startLine": 7,
-      "endLine": 155,
+      "endLine": 167,
       "summary": "Top-level module docstring: states the OQ-03 question, the affirmative resolution via the three-ingredient plan (in-tree companion matrices, Mathlib's structure theorem for finitely generated torsion PID-modules `Module.equiv_directSum_of_isTorsion`, and the cyclic-summand-to-companion-block correspondence), the post-S11-audit Mathlib gap status (exactly one genuine gap: the elementary-divisors→invariant-factors regrouping ~290 LOC), the four-sub-OQ decomposition roadmap (~940 lines), an inventory of what this file contributes, and the References block.",
       "mathContext": "OQ-03: 'Can the rational canonical form (based on minpoly factorization) be formalized in Lean 4?' Resolution: YES; one genuine Mathlib gap (elementary→invariant regrouping), the rest integrative."
     },
     {
       "id": "part-1",
       "title": "§1 (Part 1): InvariantFactorChain — Abstract Data Structure",
-      "startLine": 156,
-      "endLine": 198,
+      "startLine": 168,
+      "endLine": 203,
       "summary": "Namespace/open/variable preamble, then the `InvariantFactorChain F` structure with four fields (factors, monic, posDegree, chain) plus the two derived `noncomputable def`s `prodFactors = factors.prod` (target charpoly) and `lastFactor = getLast?.getD 1` (target minpoly). The divisibility chain p₁ ∣ p₂ ∣ ⋯ ∣ pₖ is captured as a first-class structure field.",
       "mathContext": "$\\mathrm{InvariantFactorChain}\\, F = \\{\\,(p_1,\\dots,p_k): p_i \\in F[X],\\ p_i\\text{ monic},\\ \\deg p_i\\ge 1,\\ p_1\\mid\\cdots\\mid p_k\\,\\}$, with derived $\\prod p_i$ (charpoly) and $p_k$ (minpoly)."
     },
     {
       "id": "part-2",
       "title": "§2 (Part 2): rational_canonical_form_exists (proved)",
-      "startLine": 199,
-      "endLine": 245,
+      "startLine": 204,
+      "endLine": 251,
       "summary": "The main deliverable: Frobenius's RCF existence theorem in its S14-strengthened form — every square matrix `M` over a field admits an `InvariantFactorChain` whose product equals `M.charpoly` AND whose last factor equals `minpoly F M`. Now fully proved (S16): the lone `sorry` is discharged by a one-line bridge to `RationalCanonicalFormExists.rational_canonical_form_exists` (axiom-free, in-tree). The similarity-transform assertion is still omitted, deferred to sub-OQ OQ-03-OQ-04.",
       "mathContext": "**Frobenius RCF (existence, S14 form)**: $\\forall M\\in\\mathrm{Mat}_n(F),\\ \\exists(p_1,\\dots,p_k)$ monic with $\\deg p_i\\ge 1$, $p_1\\mid\\cdots\\mid p_k$, $\\prod_i p_i=\\mathrm{charpoly}(M)$ and $p_k=\\mathrm{minpoly}(M)$."
     },
     {
       "id": "part-3",
       "title": "§3 (Part 3): Unconditional Structural Lemmas",
-      "startLine": 234,
-      "endLine": 276,
+      "startLine": 252,
+      "endLine": 294,
       "summary": "Three matrix-independent facts about the abstract chain data: `prodFactors_empty` (empty chain ⇒ product 1), `prodFactors_monic` (product of monic factors is monic, via the private `list_prod_monic_of_all_monic` induction), and `factor_dvd_prodFactors` (each factor divides the product, instance of `List.dvd_prod`). All sorry-free.",
       "mathContext": "$\\mathrm{prodFactors}(\\emptyset)=1$; $\\prod p_i$ is monic; $p\\in\\text{factors}\\Rightarrow p\\mid\\prod p_i$."
     },
     {
       "id": "part-4",
       "title": "§4 (Part 4): natDegree Helpers — nonzero, degree-sum, degree chain",
-      "startLine": 277,
-      "endLine": 338,
+      "startLine": 295,
+      "endLine": 356,
       "summary": "Three more unconditional helpers (S3 follow-through): `prodFactors_ne_zero` (corollary of monicness), `prodFactors_natDegree` (natDegree of the product = sum of factor natDegrees, via the private `list_prod_natDegree_of_all_monic` induction using `Polynomial.natDegree_mul` on monic factors), and `chain_natDegree_le` (divisibility chain ⇒ natDegree chain, via `Polynomial.natDegree_le_of_dvd`). Sets up the eventual ∑ deg pᵢ = n dimension argument.",
       "mathContext": "$\\prod p_i\\ne 0$; $\\deg(\\prod p_i)=\\sum_i\\deg p_i$; $i\\le j\\Rightarrow\\deg p_i\\le\\deg p_j$."
     },
     {
       "id": "part-5",
       "title": "§5 (Part 5): lastFactor Helpers — membership, monicness, degree maximality",
-      "startLine": 339,
-      "endLine": 419,
+      "startLine": 357,
+      "endLine": 437,
       "summary": "The lastFactor-side structural facts (all conditional on `factors ≠ []`): a robust `length_pos_of_ne_nil` helper, the bridging `lastFactor_eq_getElem_pred` (getLast?.getD 1 = indexed access at length-1), then `lastFactor_mem`, `lastFactor_monic`, and `lastFactor_natDegree_maximal` (every factor's natDegree ≤ lastFactor's — abstract counterpart of 'pₖ = minpoly M has maximal degree').",
       "mathContext": "For nonempty chains: $\\mathrm{lastFactor}\\in\\text{factors}$, is monic, and $\\forall p\\in\\text{factors},\\ \\deg p\\le\\deg(\\mathrm{lastFactor})$."
     },
     {
       "id": "part-6",
       "title": "§6 (Part 6): prodFactors.natDegree ≤ length × lastFactor.natDegree",
-      "startLine": 420,
-      "endLine": 491,
+      "startLine": 438,
+      "endLine": 509,
       "summary": "A coarse upper bound composing §4's degree-sum identity with §5's degree maximality: `prodFactors_natDegree_le_lastFactor_natDegree_mul`, proved via the pure-Nat private helper `nat_list_sum_le_length_mul_of_all_le`. Abstract counterpart of `deg(charpoly M) ≤ k · deg(minpoly M)`.",
       "mathContext": "$\\deg(\\prod p_i)\\le k\\cdot\\deg(\\mathrm{lastFactor})$, the matrix-level $\\deg\\mathrm{charpoly}\\le k\\cdot\\deg\\mathrm{minpoly}$ bound."
     },
     {
       "id": "part-7",
       "title": "§7 (Part 7): firstFactor-side Mirror + Two-Sided Sandwich",
-      "startLine": 492,
-      "endLine": 639,
+      "startLine": 510,
+      "endLine": 657,
       "summary": "The symmetric counterpart to Parts 5–6 (S13): the `firstFactor = head?.getD 1` def, the bridging `firstFactor_eq_getElem_zero` (Plan-B rcases form, API-name independent), then `firstFactor_mem`, `firstFactor_monic`, `firstFactor_natDegree_minimal` (firstFactor's natDegree ≤ every factor's), the pure-Nat `nat_list_sum_ge_length_mul_of_all_ge`, and `prodFactors_natDegree_ge_firstFactor_natDegree_mul`. Together with Part 6 this yields the sandwich k·deg(firstFactor) ≤ deg(prodFactors) ≤ k·deg(lastFactor).",
       "mathContext": "$k\\cdot\\deg(\\mathrm{firstFactor})\\le\\deg(\\prod p_i)\\le k\\cdot\\deg(\\mathrm{lastFactor})$, the abstract two-sided sandwich on $\\deg(\\mathrm{charpoly})$."
+    },
+    {
+      "id": "part-8",
+      "title": "§8 (Part 8): S15 Endpoint Divisibility Helpers",
+      "startLine": 658,
+      "endLine": 739,
+      "summary": "Three short sorry-free divisibility lemmas on the chain endpoints (conditional only on `factors ≠ []`), completing the endpoint characterization: `lastFactor_dvd_prodFactors` (lastFactor ∣ prodFactors, via `factor_dvd_prodFactors` + `lastFactor_mem`) — the abstract counterpart of the parent gallery entry's headline `minpoly M ∣ charpoly M`; `firstFactor_dvd_prodFactors` (symmetric mirror via `firstFactor_mem`); and `firstFactor_dvd_lastFactor` (firstFactor ∣ lastFactor, from the `chain` field at i=0, j=length−1, bridged through `firstFactor_eq_getElem_zero`/`lastFactor_eq_getElem_pred`). Together: firstFactor divides everything in the chain and lastFactor is a multiple of everything.",
+      "mathContext": "For nonempty chains: $\\mathrm{firstFactor}\\mid\\prod p_i$, $\\mathrm{lastFactor}\\mid\\prod p_i$, and $\\mathrm{firstFactor}\\mid\\mathrm{lastFactor}$; the abstract form of $\\mathrm{minpoly}\\,M\\mid\\mathrm{charpoly}\\,M$."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Enrichment pass for minpoly-charpoly-oq-03 (Rational Canonical Form via Minpoly Invariant Factors)

**Class:** section-overlap defect + tail-drifted `§`-sections + one missing section.

### Overlap defect fixed
`§2 (Part 2)` was pinned to lines 199–**245** while `§3 (Part 3)` started at line **234** — an overlapping range (the reader would see two sections claiming lines 234–245). Both are now re-anchored to their true `/-! ## Part N` banners with no overlap.

### Re-anchoring + missing section
Every §-section past the docstring was drifted ~12–18 lines from its banner (Part 1 at 168 not 156, Part 7 at 510 not 492, …). `§7 (Part 7)` ended at 639 but the file runs to 739 — the entire `## Part 8: S15 endpoint divisibility helpers` block (lines **658–739**) had **no** section. That block proves three substantive axiom-free lemmas: `lastFactor_dvd_prodFactors` (the abstract counterpart of the parent entry's headline `minpoly M ∣ charpoly M`), `firstFactor_dvd_prodFactors`, and `firstFactor_dvd_lastFactor`. Added a dedicated §8 section; coverage is now contiguous **1 → 739 (full file)**, 10 sections.

No status/badge/axiomCount changes (correctly `verified`, 0 axioms, 0 sorries). JSON validated; sections verified contiguous with no gaps or overlaps.
