### PR TITLE
audit: re-serve erdos-844 (axiomatized) — clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -16826,8 +16826,8 @@
     },
     "erdos-844": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:11:16Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-21T03:07:51Z",
       "result": "clean"
     },
     "erdos-845": {


### PR DESCRIPTION
## Reserve-mode re-audit

Audit queue is drained (4809/4809 audited); reserve-mode re-serve of the oldest uncontested target (`erdos-844`, last audited 2026-05-04).

## Verification

Counts match `meta.json` / `leanFile` exactly against `proofs/Proofs/Erdos844Problem.lean`:
- **2 axioms**: `optimal_set_has_property`, `weisenberg_proof`
- **4 theorems/lemmas**, **9 defs**, **0 sorries**, **0 native_decide**, **0 True stubs**

Prose re-verification (per reserve-mode methodology — verify prose vs actual decls, not just counts):
- All 8 `originalContributions` map to real declarations; `evenSquarefreeNumbers` honestly annotated "cited in prose, not formalized as a theorem."
- Both axioms are **true** statements (even·even ⇒ 4∣ab non-squarefree; non-squarefree factor ⇒ non-squarefree product; `weisenberg_proof` = genuine Weisenberg maximality result) — honest Tier-C axiomatization, not a masked false axiom.
- Status `axiomatized` / badge `axiom` correctly signal the two axioms carry the core result.

Clean. Prior audit fixes #39656/#39808 hold. This PR only bumps the audit-tracker timestamp.

---
Discovered during gallery integrity audit.