### PR TITLE
Research: erdos-507-wip-01 — concrete positive lower bound heilbronn 3 ≥ 1/2 (2 axiom-free theorems)

### DIFF
--- a/proofs/Proofs/Erdos507WIP01.lean
+++ b/proofs/Proofs/Erdos507WIP01.lean
@@ -33,7 +33,10 @@ of the atomic building block `triangleArea`:
   nested `⨅` with `ciInf_le_of_le` under the junk-value semantics of an empty
   real infimum;
 * `heilbronn n ≤ 3` for `n ≥ 3` (`heilbronn_le_three`): the defining `sSup` set
-  is bounded above by the uniform area bound, so Heilbronn's function is finite.
+  is bounded above by the uniform area bound, so Heilbronn's function is finite;
+* a concrete positive lower bound `heilbronn 3 ≥ 1/2` (`heilbronn_three_ge_half`)
+  from the unit right triangle, hence `heilbronn 3 > 0` (`heilbronn_three_pos`) —
+  separating `heilbronn 3` from the junk value `heilbronn 2 = 0`.
 
 All results are `0`-axiom / `0`-sorry.
 
@@ -377,5 +380,51 @@ area envelope `0 ≤ heilbronn n ≤ 3`.  (The true order of magnitude is
 this records the elementary two-sided bound the foundational lemmas already give.) -/
 theorem heilbronn_mem_Icc (n : ℕ) (hn : 3 ≤ n) : heilbronn n ∈ Set.Icc (0 : ℝ) 3 :=
   ⟨heilbronn_nonneg n hn, heilbronn_le_three n hn⟩
+
+/-! ## A concrete positive lower bound at `n = 3`
+
+The `heilbronn_nonneg` bound above (`0 ≤ heilbronn n`) does not separate the
+`n ≥ 3` regime from the junk value `heilbronn 2 = 0`; a genuine *positive*
+witness is needed.  The unit right triangle `(0,0), (1,0), (0,1)` is a
+three-point unit-disk configuration all of whose orderings have `triangleArea`
+equal to `1/2` (`triangleArea_unit` together with the permutation lemmas), so
+`1/2` is admissible for `heilbronn 3`.  This gives `heilbronn 3 ≥ 1/2 > 0`,
+confirming that `heilbronn 3 > heilbronn 2 = 0` and hence that the `n ≥ 3`
+hypothesis on the monotonicity lemmas is forced rather than cosmetic. -/
+
+/-- **`heilbronn 3 ≥ 1/2`.**  The right triangle `(0,0), (1,0), (0,1)` lies in the
+unit disk and every ordering of its three distinct vertices has `triangleArea`
+exactly `1/2`, so `1/2` lies in the defining `sSup` set of `heilbronn 3`
+(`le_csSup`, using `heilbronn_defining_bddAbove` for boundedness). -/
+theorem heilbronn_three_ge_half : (1 : ℝ) / 2 ≤ heilbronn 3 := by
+  unfold heilbronn
+  refine le_csSup (heilbronn_defining_bddAbove 3 (by norm_num)) ?_
+  refine ⟨{((0 : ℝ), (0 : ℝ)), (1, 0), (0, 1)}, ?_, ?_, ?_⟩
+  · -- the three vertices are distinct, so the configuration has cardinality `3`
+    rw [Finset.card_eq_three]
+    exact ⟨(0, 0), (1, 0), (0, 1),
+      by simp [Prod.ext_iff], by simp [Prod.ext_iff], by simp [Prod.ext_iff], rfl⟩
+  · -- each vertex lies in the closed unit disk
+    intro p hp
+    simp only [Finset.mem_insert, Finset.mem_singleton] at hp
+    rcases hp with rfl | rfl | rfl <;> norm_num
+  · -- every ordered distinct triple has area `1/2 ≥ 1/2`
+    intro p hp q hq r hr hpq hqr hpr
+    simp only [Finset.mem_insert, Finset.mem_singleton] at hp hq hr
+    rcases hp with rfl | rfl | rfl <;> rcases hq with rfl | rfl | rfl <;>
+        rcases hr with rfl | rfl | rfl <;>
+      first
+        | exact absurd rfl hpq
+        | exact absurd rfl hqr
+        | exact absurd rfl hpr
+        | (show (1 : ℝ) / 2 ≤ triangleArea _ _ _; unfold triangleArea; norm_num)
+
+/-- **`heilbronn 3` is strictly positive.**  Immediate from
+`heilbronn_three_ge_half`.  Since `heilbronn 2 = 0` (no distinct triple exists
+below `n = 3`, so the defining `sSup` collapses to its junk value `0`), this
+shows Heilbronn's function is *not* monotone across the `2 → 3` boundary — the
+reason the monotonicity lemmas are stated only from `n = 3` onward. -/
+theorem heilbronn_three_pos : 0 < heilbronn 3 :=
+  lt_of_lt_of_le (by norm_num) heilbronn_three_ge_half
 
 end Erdos507WIP01

--- a/research/problems/erdos-507-wip-01/knowledge.md
+++ b/research/problems/erdos-507-wip-01/knowledge.md
@@ -7,6 +7,45 @@ Heilbronn's triangle problem, **OPEN**: the exponent `β` with
 (Komlós–Pintz–Szemerédi, Cohen–Pohoata–Zakharov) are untouched; this file builds
 the elementary geometry of `triangleArea` and `minTriangleArea`/`heilbronn`.
 
+## Session 2026-07-20 (researcher-1, iter 3) — concrete positive lower bound `heilbronn 3 ≥ 1/2`
+
+**Mode**: continue a RICH node (24 declarations already on main).
+**Outcome**: progress — 2 new public declarations, VERIFIED axiom-free
+(`[propext, Classical.choice, Quot.sound]`, 0 sorry / 0 axiom / no
+native_decide). Host-verified without Docker (parent is Mathlib-only):
+`lake env lean` fresh-built `Erdos507Problem.olean`, compiled the child clean
+(exit 0), `#print axioms` on both new results.
+
+### What I added
+- `heilbronn_three_ge_half : (1:ℝ)/2 ≤ heilbronn 3` — the unit right triangle
+  `(0,0),(1,0),(0,1)` is a 3-point unit-disk config whose every ordering of its
+  distinct vertices has `triangleArea = 1/2` (`triangleArea_unit` + the
+  permutation lemmas), so `1/2` lies in the defining `sSup` set;
+  `le_csSup (heilbronn_defining_bddAbove 3 _)`.
+- `heilbronn_three_pos : 0 < heilbronn 3` — immediate from the above. Since
+  `heilbronn 2 = 0` (no distinct triple below `n=3`, junk `sSup`), this shows
+  Heilbronn is **not** monotone across the `2→3` boundary — the reason the
+  monotonicity lemmas start at `n=3`.
+
+### Key findings / reusable Lean recipe
+- **`Finset.card_eq_three`** certifies a 3-point *real* config has card 3 without
+  `decide` (`DecidableEq ℝ` is not computable): supply the three points + the
+  three pairwise `≠` via `by simp [Prod.ext_iff]`, and `rfl` for the set equality.
+- **Distinct-triple `∀`-bound over a 3-element `Finset`.** After
+  `simp only [Finset.mem_insert, Finset.mem_singleton] at hp hq hr`,
+  `rcases … <;> rcases … <;> rcases …` (27 cases) then
+  `first | exact absurd rfl h<pair> | (unfold triangleArea; norm_num)`: the 21
+  repeated-vertex cases die on the distinctness hyps, the 6 genuine permutations
+  each compute to `1/2` — no need to invoke the permutation lemmas explicitly,
+  `norm_num` evaluates each concrete `|·|/2`.
+- The lower bound `1/2` is **not tight** (`heilbronn 3 = 3√3/4 ≈ 1.299` via the
+  largest inscribed triangle); the tight value needs a max-inscribed-triangle
+  upper bound, likely not session-sized.
+
+### Next steps
+- Tight `heilbronn 3 = 3√3/4` needs the max-inscribed-triangle bound (open here).
+- Deep `α(n)` exponent bounds (KPS lower, CPZ upper) remain open, `7/6 ≤ β ≤ 2`.
+
 ## Session 2026-07-20 (researcher-1) — `heilbronn` monotonicity + config existence
 
 **Mode**: continue a RICH node (18 declarations already on main).

--- a/research/problems/erdos-507-wip-01/state.md
+++ b/research/problems/erdos-507-wip-01/state.md
@@ -2,7 +2,7 @@
 
 **Phase**: ACT (foundational scaffolding)
 **Since**: 2026-07-20
-**Iteration**: 2
+**Iteration**: 3
 
 ## Current Focus
 
@@ -28,9 +28,11 @@ needed). Bound `heilbronn n` (`n ≥ 3`) via `Real.sSup_le` + `triangleArea_le_t
 
 ## Next Action
 
-`heilbronn` monotonicity `heilbronn (n+1) ≤ heilbronn n` by restricting a witness
-configuration; otherwise the deep exponent bounds (not session-sized).
+Sharpen the `n=3` lower bound toward the exact `heilbronn 3 = 3√3/4` (largest
+inscribed triangle); the upper half needs a max-inscribed-triangle bound, likely
+not session-sized. Otherwise the deep `α(n)` exponent bounds (KPS/CPZ) remain
+out of scope.
 
 ## Attempt Counts
 
-- Total attempts: 2
+- Total attempts: 3

--- a/src/data/research/problems/erdos-507-wip-01.json
+++ b/src/data/research/problems/erdos-507-wip-01.json
@@ -29,7 +29,7 @@
   "currentState": {
     "phase": "ACT",
     "since": "2026-07-20T15:20:00-07:00",
-    "iteration": 2,
+    "iteration": 3,
     "focus": "Axiom-free structural facts on minTriangleArea (the nested triple-infimum) and heilbronn (its sSup), built on the verified triangleArea geometry.",
     "blockers": [
       {
@@ -38,15 +38,15 @@
         "blockedAt": "2026-07-20"
       }
     ],
-    "nextAction": "heilbronn monotonicity heilbronn (n+1) ≤ heilbronn n via restricting a witness configuration; the deep α(n) exponent bounds (KPS/CPZ) are not session-sized.",
+    "nextAction": "Sharpen the n=3 lower bound toward the exact heilbronn 3 = 3√3/4 (largest inscribed triangle) — upper half needs a max-inscribed-triangle bound, likely not session-sized. Otherwise the deep α(n) exponent bounds (KPS/CPZ) remain out of scope.",
     "attemptCounts": {
-      "total": 2,
+      "total": 3,
       "currentApproach": 1,
       "approachesTried": 1
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Extended Proofs/Erdos507WIP01.lean (18→23 declarations, 0 sorry / 0 axiom, VERIFIED axiom-free [propext, Classical.choice, Quot.sound], host-verified no-Docker). Added the monotonicity layer: exists_unitDisk_config (configs of every cardinality exist in the disk), heilbronn_defining_bddAbove (private), heilbronn_nonneg (0 ≤ heilbronn n), heilbronn_succ_le (one-step antitone via point deletion), and heilbronn_antitone (heilbronn antitone on {n≥3}). The deep α(n) growth exponent (7/6 ≤ β ≤ 2) remains open.",
+    "progressSummary": "PROGRESS: Extended Proofs/Erdos507WIP01.lean (24→26 declarations, 0 sorry / 0 axiom, VERIFIED axiom-free [propext, Classical.choice, Quot.sound], host-verified no-Docker). Added a concrete positive lower bound at n=3: heilbronn_three_ge_half (heilbronn 3 ≥ 1/2, from the unit right triangle whose every ordering has area 1/2) and heilbronn_three_pos (0 < heilbronn 3). This separates heilbronn 3 from the junk value heilbronn 2 = 0, showing the n ≥ 3 hypothesis on the monotonicity lemmas is forced. The deep α(n) growth exponent (7/6 ≤ β ≤ 2) remains open.",
     "builtItems": [
       "triangleArea_nonneg in Erdos507WIP01.lean",
       "triangleArea_swap_left / triangleArea_swap_right / triangleArea_cyclic (permutation symmetry)",
@@ -65,7 +65,9 @@
       "heilbronn_nonneg in Erdos507WIP01.lean — 0 ≤ heilbronn n for n≥3 via le_csSup (α=0 admissible)",
       "heilbronn_succ_le in Erdos507WIP01.lean — heilbronn (n+1) ≤ heilbronn n for n≥3, delete-a-point (Finset.erase) restriction",
       "heilbronn_antitone in Erdos507WIP01.lean — full antitonicity on {n≥3} via Nat.le_induction",
-      "heilbronn_mem_Icc in Erdos507WIP01.lean — sandwich 0 ≤ heilbronn n ≤ 3 for n≥3 (PR #39991), 0-axiom"
+      "heilbronn_mem_Icc in Erdos507WIP01.lean — sandwich 0 ≤ heilbronn n ≤ 3 for n≥3 (PR #39991), 0-axiom",
+      "heilbronn_three_ge_half (1/2 ≤ heilbronn 3) in Proofs/Erdos507WIP01.lean",
+      "heilbronn_three_pos (0 < heilbronn 3) in Proofs/Erdos507WIP01.lean"
     ],
     "insights": [
       "The signed shoelace area p₁(q₂−r₂)+q₁(r₂−p₂)+r₁(p₂−q₂) is alternating: transpositions negate it (area invariant via abs_neg), cyclic rotations fix it — giving full S₃ symmetry after the absolute value.",
@@ -77,7 +79,11 @@
       "heilbronn n ≤ 3 is stated for n ≥ 3: for n < 3 no distinct triple exists, the defining ∀-condition is vacuous, the set is unbounded above, and heilbronn n is the sSup junk value 0 — the bounded-above proof route needs the triple (Finset.two_lt_card_iff).",
       "heilbronn is antitone on {n ≥ 3}: heilbronn_antitone (3≤m≤n → heilbronn n ≤ heilbronn m). Adding a point can only create new triples, shrinking the min area; the (n+1)-defining sSup-set ⊆ the n-defining set.",
       "The junk-value boundary at n=2/3 forces the n≥3 hypothesis: for n<3 the triple condition is vacuous so the defining set is all of ℝ (unbounded), giving heilbronn n = sSup-junk 0; monotonicity across the 2→3 boundary is false (heilbronn 3 > 0 = heilbronn 2).",
-      "csSup_le_csSup needs the SMALLER (n+1) set nonempty: supplied via exists_unitDisk_config (n+1) with the admissible bound α=0 (all areas ≥ 0)."
+      "csSup_le_csSup needs the SMALLER (n+1) set nonempty: supplied via exists_unitDisk_config (n+1) with the admissible bound α=0 (all areas ≥ 0).",
+      "heilbronn 3 ≥ 1/2 via the explicit unit right triangle (0,0),(1,0),(0,1): all six orderings of its distinct vertices have triangleArea = 1/2 (triangleArea_unit + permutation lemmas), so 1/2 lies in the defining sSup set; le_csSup with heilbronn_defining_bddAbove gives the bound.",
+      "Finset.card_eq_three is the clean way to certify a 3-point real config has cardinality 3 (avoids decide, which fails on DecidableEq ℝ): provide the three points plus pairwise inequalities via simp [Prod.ext_iff].",
+      "For an ∀-over-a-3-element-Finset distinct-triple bound, rcases each membership (Finset.mem_insert/mem_singleton) three-ways (27 cases) and discharge with first | exact absurd rfl h<pair> | (unfold triangleArea; norm_num) — the 21 repeated-vertex cases die on the distinctness hyps, the 6 genuine permutations compute to 1/2.",
+      "heilbronn 3 > 0 = heilbronn 2 confirms Heilbronn is NOT monotone across the 2→3 boundary, so the n ≥ 3 hypothesis on the monotonicity lemmas is forced, not cosmetic."
     ],
     "mathlibGaps": [
       "No off-the-shelf lemma reduces the nested membership biInf of minTriangleArea to a single ciInf_le; the junk-value semantics of ⨅ over unsatisfiable membership binders must be handled explicitly (done here via ciInf_le_of_le descent).",


### PR DESCRIPTION
## Summary

Continues the axiom-free foundational scaffolding for **Erdős #507** (Heilbronn's triangle problem) in `proofs/Proofs/Erdos507WIP01.lean`. Adds a **concrete positive lower bound at `n = 3`**, the first *positive* witness for Heilbronn's function (previous work established only `0 ≤ heilbronn n`).

## New theorems (both axiom-free)

- **`heilbronn_three_ge_half : (1:ℝ)/2 ≤ heilbronn 3`** — the unit right triangle `(0,0), (1,0), (0,1)` is a 3-point unit-disk configuration whose every ordering of its distinct vertices has `triangleArea = 1/2` (`triangleArea_unit` together with the permutation lemmas), so `1/2` lies in the defining `sSup` set. Proof: `le_csSup (heilbronn_defining_bddAbove 3 _)`, with cardinality via `Finset.card_eq_three` and the distinct-triple bound by a 27-way `rcases` over the 3-element `Finset`.
- **`heilbronn_three_pos : 0 < heilbronn 3`** — immediate corollary.

## Why it matters

Since `heilbronn 2 = 0` (no distinct triple exists below `n = 3`, so the defining `sSup` collapses to its junk value), `heilbronn 3 > 0 = heilbronn 2` shows Heilbronn's function is **not** monotone across the `2 → 3` boundary — confirming the `n ≥ 3` hypothesis on the existing monotonicity lemmas (`heilbronn_succ_le`, `heilbronn_antitone`) is forced, not cosmetic.

The bound `1/2` is deliberately not tight (`heilbronn 3 = 3√3/4 ≈ 1.299` via the largest inscribed triangle); the exact value would need a max-inscribed-triangle upper bound, and the deep `α(n)` growth exponent (`7/6 ≤ β ≤ 2`, KPS/CPZ) remains the open research core.

## Verification

Host-verified without Docker (parent `Erdos507Problem` is Mathlib-only): fresh-built `Erdos507Problem.olean` via `lake env lean`, compiled the child clean (exit 0), `#print axioms` on both new results:

```
'heilbronn_three_ge_half' depends on axioms: [propext, Classical.choice, Quot.sound]
'heilbronn_three_pos' depends on axioms: [propext, Classical.choice, Quot.sound]
```

0 sorry / 0 axiom / no `native_decide`. File: 24 → 26 declarations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
