### PR TITLE
Enrich erdos-241 (B₃/Sidon sets): add missing Section VIII (13 axiom-free lemmas) + header, re-anchor sections, fix stale 'Axiomatizes' prose

### DIFF
--- a/src/data/proofs/erdos-241/meta.json
+++ b/src/data/proofs/erdos-241/meta.json
@@ -50,60 +50,76 @@
   },
   "sections": [
     {
+      "id": "header-references",
+      "title": "Header, Status, and References",
+      "startLine": 1,
+      "endLine": 22,
+      "summary": "Module docstring for Erdős #241 (B₃ / Sidon-type sets): the extremal function f(N) = max size of a B₃ subset of {1,…,N}, conjectured f(N) ∼ N^{1/3}. Records the OPEN status ($100 Erdős prize) and the reference block (Bose–Chowla 1962 lower bound, Green 2001 upper bound). Imports Mathlib and opens the namespace.",
+      "mathContext": "Erdős #241: is $f(N)\\sim N^{1/3}$ for $B_3$ sets? OPEN, $100 prize; known $N^{1/3}\\lesssim f(N)\\lesssim (7/2)^{1/3}N^{1/3}$."
+    },
+    {
       "id": "b3-sets",
-      "title": "B₃ Sets",
-      "startLine": 22,
-      "endLine": 40,
+      "title": "Section I: B₃ Sets",
+      "startLine": 23,
+      "endLine": 44,
       "summary": "Defines threeSums (the image of ordered triples under addition) and IsB3 (injectivity of the sum map on ordered triples from A). The definition requires $a_1 + b_1 + c_1 = a_2 + b_2 + c_2$ with ordering constraints to imply equality of triples.",
       "mathContext": "`IsB3 A := ∀ a₁ b₁ c₁ a₂ b₂ c₂ ∈ A, a₁ ≤ b₁ ≤ c₁ → a₂ ≤ b₂ ≤ c₂ → a₁+b₁+c₁ = a₂+b₂+c₂ → (a₁,b₁,c₁) = (a₂,b₂,c₂)`. The ordering constraints $a \\le b \\le c$ reduce from $|A|^3$ to $\\binom{|A|+2}{3}$ comparisons."
     },
     {
       "id": "max-b3-size",
-      "title": "Maximum B₃ Subset Size",
-      "startLine": 41,
-      "endLine": 48,
+      "title": "Section II: Maximum B₃ Subset Size",
+      "startLine": 45,
+      "endLine": 52,
       "summary": "Defines maxB3Size N as the supremum of cardinalities of B₃ subsets of {1,...,N}, using Finset.powerset and filter over the B₃ predicate. This is the extremal function $f(N)$ central to the problem.",
       "mathContext": "$f(N) = \\max\\{|A| : A \\subseteq \\{1, \\ldots, N\\},\\ A \\text{ is } B_3\\}$. Lean: `((Finset.range N).powerset.filter IsB3).sup Finset.card`. The noncomputable tag reflects that the supremum over a finite set is classically defined but not computationally extractable."
     },
     {
       "id": "conjecture",
-      "title": "The Conjecture",
-      "startLine": 49,
-      "endLine": 62,
+      "title": "Section III: The Conjecture",
+      "startLine": 53,
+      "endLine": 66,
       "summary": "States ErdosProblem241: for all $\\varepsilon > 0$, eventually $(1-\\varepsilon)N^{1/3} \\le f(N) \\le (1+\\varepsilon)N^{1/3}$. This $\\varepsilon$-$N_0$ formulation captures $f(N) \\sim N^{1/3}$ precisely.",
       "mathContext": "The conjecture: $\\forall \\varepsilon > 0$, $\\exists N_0$, $\\forall N \\geq N_0$: $(1-\\varepsilon)N^{1/3} \\le f(N) \\le (1+\\varepsilon)N^{1/3}$. Equivalently, $\\lim_{N \\to \\infty} f(N)/N^{1/3} = 1$. The lower bound is known (Bose-Chowla), so the conjecture reduces to proving the upper bound constant is 1."
     },
     {
       "id": "bose-chowla",
-      "title": "The Bose–Chowla Lower Bound",
-      "startLine": 63,
+      "title": "Section IV: The Bose–Chowla Lower Bound",
+      "startLine": 67,
       "endLine": 73,
-      "summary": "Axiomatizes the 1962 lower bound: $f(N) \\ge (1-\\varepsilon)N^{1/3}$ for all $N \\ge N_0(\\varepsilon)$. This is one half of the conjecture and is known to be true via explicit finite field constructions.",
+      "summary": "Documents (not formalized) the 1962 lower bound: $f(N) \\ge (1-\\varepsilon)N^{1/3}$ for all $N \\ge N_0(\\varepsilon)$. This is one half of the conjecture and is known to be true via explicit finite field constructions. Prose only — no declaration; the file contains no axiom for it.",
       "mathContext": "Bose-Chowla (1962): $f(N) \\ge (1-\\varepsilon)N^{1/3}$ for $N \\ge N_0(\\varepsilon)$. Construction: in $\\mathbb{F}_{p^3}$, the set $\\{t + t^3 \\bmod (p^3 - 1) : t \\in \\mathbb{F}_{p^3}^*\\}$ is $B_3$ of size $p \\sim N^{1/3}$."
     },
     {
       "id": "green-bound",
-      "title": "Green's Upper Bound",
+      "title": "Section V: Green's Upper Bound",
       "startLine": 74,
-      "endLine": 84,
-      "summary": "Axiomatizes Green's 2001 result: $f(N) \\le ((7/2)^{1/3}+\\varepsilon)N^{1/3}$ for large $N$. The constant $(7/2)^{1/3} \\approx 1.519$ is the best known and the gap to 1 is the open problem.",
+      "endLine": 80,
+      "summary": "Documents (not formalized) Green's 2001 result: $f(N) \\le ((7/2)^{1/3}+\\varepsilon)N^{1/3}$ for large $N$. The constant $(7/2)^{1/3} \\approx 1.519$ is the best known and the gap to 1 is the open problem. Prose only — no declaration or axiom in the file.",
       "mathContext": "Green (2001): $f(N) \\le ((7/2)^{1/3} + \\varepsilon)N^{1/3}$ for $N \\ge N_0(\\varepsilon)$. The constant $(7/2)^{1/3} \\approx 1.5197$ comes from bounding the additive energy $E_3(A) = |\\{(\\vec{a}, \\vec{b}) \\in A^3 \\times A^3 : \\sum a_i = \\sum b_i\\}|$ via $|A|^3 \\le (7/2)N$."
     },
     {
       "id": "generalized-bh",
-      "title": "Generalized Bₕ Sets",
-      "startLine": 85,
-      "endLine": 118,
+      "title": "Section VI: Generalized Bₕ Sets",
+      "startLine": 81,
+      "endLine": 112,
       "summary": "Defines IsBh for arbitrary $h \\ge 2$ (using subset-sum injectivity), maxBhSize, and the general Bose–Chowla conjecture $f_h(N) \\sim N^{1/h}$. Notes $h=2$ (Sidon sets) is resolved and the lower bound holds for all $h$.",
       "mathContext": "General $B_h$ conjecture: $f_h(N) \\sim N^{1/h}$. IsBh uses subset-sum injectivity: $S_1, S_2 \\subseteq A$, $|S_1| = |S_2| = h$, $\\sum S_1 = \\sum S_2 \\Rightarrow S_1 = S_2$. Bose-Chowla lower bound $f_h(N) \\ge (1+o(1))N^{1/h}$ uses $h$-th power residues in $\\mathbb{F}_{p^h}$. For $h = 2$: Erdős-Turán (1941) proved $f_2(N) \\le N^{1/2} + O(N^{1/4})$."
     },
     {
       "id": "examples",
-      "title": "Known Small B₃ Sets",
-      "startLine": 119,
-      "endLine": 123,
-      "summary": "Axiomatizes that {1,5,14,30} is a B₃ set (note: {1,2,4,8} is NOT B₃ since 1+1+4=2+2+2=6) and states the trivial counting upper bound $k(k+1)(k+2) \\le 18N$ from fitting $\\binom{k+2}{3}$ distinct sums into the interval $[3, 3N]$.",
+      "title": "Section VII: Known Small B₃ Sets",
+      "startLine": 113,
+      "endLine": 125,
+      "summary": "Documents (not formalized) that {1,5,14,30} is a B₃ set (note: {1,2,4,8} is NOT B₃ since 1+1+4=2+2+2=6) and states the trivial counting upper bound $k(k+1)(k+2) \\le 18N$ from fitting $\\binom{k+2}{3}$ distinct sums into the interval $[3, 3N]$. Prose only — no declaration or axiom.",
       "mathContext": "The set $\\{1, 5, 14, 30\\}$ has 20 distinct ordered triple sums. The trivial bound: $\\binom{|A|+2}{3}$ distinct sums must fit in $[3, 3N]$, giving $|A|(|A|+1)(|A|+2) \\le 6 \\cdot 3N = 18N$, so $|A| \\lesssim (18N)^{1/3} \\approx 2.62 N^{1/3}$."
+    },
+    {
+      "id": "foundational-lemmas",
+      "title": "Section VIII: Foundational Lemmas (Axiom-Free)",
+      "startLine": 126,
+      "endLine": 228,
+      "summary": "The machine-checked API (13 lemmas, 0 sorries, 0 axioms — `#print axioms` = propext/Classical.choice/Quot.sound only). For threeSums: mem_threeSums (membership as an ordered triple sum), threeSums_empty, threeSums_mono. For IsB3: isB3_empty, isB3_singleton, IsB3.subset (B₃ is subset-closed). For the extremal function: maxB3Size_le (f(N) ≤ N), maxB3Size_mono, maxB3Size_zero (f(0)=0). Mirrored to the generalized setting: IsBh.subset, isBh_empty (h ≥ 2), maxBhSize_le, maxBhSize_mono. The deep f(N) ∼ N^{1/3} asymptotics stay documented-only (need finite-field / analytic machinery beyond Mathlib).",
+      "mathContext": "Structural API: $x\\in\\mathrm{threeSums}\\,A \\iff \\exists a\\le b\\le c\\in A,\\ a{+}b{+}c=x$; $A\\subseteq B\\Rightarrow$ threeSums/IsB3/IsBh inherit; $f(N)\\le N$, $f$ monotone, $f(0)=0$; same for $f_h$."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Enrichment pass for erdos-241 (B₃ / Sidon-type sets, f(N) ∼ N^{1/3})

**Class:** missing section + tail undercoverage + stale "Axiomatizes" prose.

### Missing section + header recovered
The `sections` list stopped at line 123, leaving the entire `## Section VIII: Foundational Lemmas (axiom-free)` block (lines **126–228**) uncovered — 13 machine-checked lemmas (`mem_threeSums`, `threeSums_mono`, `isB3_singleton`, `IsB3.subset`, `maxB3Size_le/mono/zero`, `IsBh.subset`, `isBh_empty`, `maxBhSize_le/mono`, …). Also added a **Header, Status, and References** section for the module docstring (lines 1–22). Coverage now runs to **228 (full file)**, 9 sections; Sections I–VII re-anchored to their `## Section N` banners.

### Stale-prose fixes (file has 0 axioms — verified `grep '^axiom' = 0`, `#print axioms` clean)
Three section summaries claimed the deep results were "Axiomatizes…", but they are **documentation-only prose** with no declaration and no axiom:
- Section IV (Bose–Chowla lower bound), Section V (Green's upper bound), Section VII (the {1,5,14,30} example / trivial counting bound) → changed "Axiomatizes …" to "Documents (not formalized) …".

No change to `status`/`badge`/`axiomCount` (open problem, `wip`, 0 axioms, 0 sorries). JSON validated.
