### PR TITLE
Research: erdos-116-wip-01 — polynomial lemniscate is open, measurable, bounded (5 axiom-free theorems)

### DIFF
--- a/proofs/Proofs/Erdos116WIP01.lean
+++ b/proofs/Proofs/Erdos116WIP01.lean
@@ -1,0 +1,100 @@
+/-
+# Erdős Problem #116 (Measure of Polynomial Sublevel Sets) — Topology of the lemniscate
+
+Axiom-free foundational scaffolding for the objects defined in
+`Proofs/Erdos116Problem.lean` (gallery `erdos-116`, the Erdős–Herzog–Piranian
+conjecture, PROVED by Krishnapur–Lundberg–Ramachandran: for a monic degree-`n`
+polynomial `p(z) = ∏(z - zᵢ)` with all roots in the closed unit disk, the
+sublevel set `Sₚ = {z : |p(z)| < 1}` has area `≥ c/log n`).
+
+The deep quantitative bounds (Pommerenke `c/n⁴`, KLR `c/log n`, KLR `C/log log n`,
+Pólya `π`) rest on logarithmic-potential machinery not in Mathlib and stay in the
+parent's header prose.  This file discharges **Key lemma 1** of the research task
+— that the lemniscate `Sₚ` is *open* (hence measurable) and *bounded* — directly
+from the root factorization, with no axioms and no `sorry`:
+
+* `continuous_eval` — `z ↦ p(z) = ∏(z - zᵢ)` is continuous (a finite product of
+  continuous factors);
+* `isOpen_sublevelSet` — `Sₚ` is the preimage of the open ray `[0,1)` under the
+  continuous map `z ↦ ‖p(z)‖`, hence open;
+* `measurableSet_sublevelSet` — an open set is measurable;
+* `sublevelSet_subset_closedBall` — `Sₚ ⊆ closedBall 0 2`: if `‖z‖ > 2` then each
+  factor `‖z - zᵢ‖ ≥ ‖z‖ - 1 > 1`, so `‖p(z)‖ = ∏‖z - zᵢ‖ ≥ 1` and `z ∉ Sₚ`;
+* `isBounded_sublevelSet` — hence `Sₚ` is bounded (`Bornology.IsBounded`).
+
+These give exactly the well-definedness the parent's `sublevelMeasure` needs: `Sₚ`
+is a bounded measurable set, so its 2D Lebesgue measure is finite.  The remaining
+open content — the `c/log n` lower bound and the `1/log n` vs `1/log log n` gap —
+is the genuinely deep KLR input, cleanly isolated.
+
+All results are `0`-axiom / `0`-sorry.
+
+Reference: <https://erdosproblems.com/116>
+-/
+
+import Proofs.Erdos116Problem
+
+open MeasureTheory Metric
+
+namespace UnitDiskPoly
+
+variable {n : ℕ}
+
+/-! ## Continuity of the polynomial map -/
+
+/-- The evaluation map `z ↦ p(z) = ∏(z - zᵢ)` is continuous: it is a finite
+product of the continuous factors `z ↦ z - zᵢ`. -/
+theorem continuous_eval (P : UnitDiskPoly n) : Continuous P.eval := by
+  unfold UnitDiskPoly.eval
+  exact continuous_finsetProd _ (fun i _ => continuous_id.sub continuous_const)
+
+/-! ## Openness and measurability of the sublevel set -/
+
+/-- The sublevel set `Sₚ = {z : |p(z)| < 1}` is the preimage of the open ray
+`Set.Iio 1` under the continuous map `z ↦ ‖p(z)‖`. -/
+theorem sublevelSet_eq_preimage (P : UnitDiskPoly n) :
+    P.sublevelSet = (fun z => ‖P.eval z‖) ⁻¹' Set.Iio 1 := by
+  ext z
+  simp only [UnitDiskPoly.sublevelSet, Set.mem_setOf_eq, Set.mem_preimage, Set.mem_Iio]
+  rfl
+
+/-- **`Sₚ` is open.**  It is the continuous preimage of the open set `[0, 1)`. -/
+theorem isOpen_sublevelSet (P : UnitDiskPoly n) : IsOpen P.sublevelSet := by
+  rw [P.sublevelSet_eq_preimage]
+  exact isOpen_Iio.preimage (continuous_norm.comp P.continuous_eval)
+
+/-- **`Sₚ` is measurable.**  An open set is measurable. -/
+theorem measurableSet_sublevelSet (P : UnitDiskPoly n) :
+    MeasurableSet P.sublevelSet :=
+  P.isOpen_sublevelSet.measurableSet
+
+/-! ## Boundedness of the sublevel set -/
+
+/-- **`Sₚ ⊆ closedBall 0 2`.**  If `‖z‖ > 2` then, since every root has
+`‖zᵢ‖ ≤ 1`, each factor satisfies `‖z - zᵢ‖ ≥ ‖z‖ - ‖zᵢ‖ ≥ ‖z‖ - 1 > 1`, so
+`‖p(z)‖ = ∏ᵢ ‖z - zᵢ‖ ≥ 1` (product of factors each `≥ 1`) and `z ∉ Sₚ`.
+The bound holds for every degree, including `n = 0` where `Sₚ = ∅`. -/
+theorem sublevelSet_subset_closedBall (P : UnitDiskPoly n) :
+    P.sublevelSet ⊆ Metric.closedBall (0 : ℂ) 2 := by
+  intro z hz
+  by_contra hout
+  rw [Metric.mem_closedBall, dist_zero_right, not_le] at hout
+  -- `hout : 2 < ‖z‖`; `hz : ‖p(z)‖ < 1`
+  have hz' : ‖P.eval z‖ < 1 := hz
+  have hge : (1 : ℝ) ≤ ‖P.eval z‖ := by
+    rw [UnitDiskPoly.eval, norm_prod]
+    calc (1 : ℝ) = ∏ _i : Fin n, (1 : ℝ) := by rw [Finset.prod_const_one]
+      _ ≤ ∏ i : Fin n, ‖z - P.roots i‖ := by
+          refine Finset.prod_le_prod (fun i _ => by norm_num) (fun i _ => ?_)
+          have hri : ‖P.roots i‖ ≤ 1 := P.roots_in_disk i
+          have hlow : ‖z‖ - ‖P.roots i‖ ≤ ‖z - P.roots i‖ :=
+            norm_sub_norm_le z (P.roots i)
+          linarith
+  linarith
+
+/-- **`Sₚ` is bounded** (`Bornology.IsBounded`): it sits inside `closedBall 0 2`. -/
+theorem isBounded_sublevelSet (P : UnitDiskPoly n) :
+    Bornology.IsBounded P.sublevelSet :=
+  (Metric.isBounded_closedBall).subset P.sublevelSet_subset_closedBall
+
+end UnitDiskPoly

--- a/research/problems/erdos-116-wip-01/knowledge.md
+++ b/research/problems/erdos-116-wip-01/knowledge.md
@@ -4,6 +4,59 @@ Insights accumulated during research on this problem.
 
 ---
 
+## Session 2026-07-20 (researcher-1, iter 1 ACT) — sublevel set open / measurable / bounded
+
+**Mode**: first real ACT on a fresh wip-01 node (parent `Erdos116Problem.lean`
+had 5 axiom-free structural lemmas; no `Erdos116WIP01.lean` existed).
+**Outcome**: progress — new file `proofs/Proofs/Erdos116WIP01.lean` with 6
+declarations (5 public results + `sublevelSet_eq_preimage`), 0 sorry / 0 axiom /
+no native_decide, VERIFIED axiom-free (`[propext, Classical.choice, Quot.sound]`).
+Host-verified without Docker (parent imports `Mathlib` only): fresh-built
+`Erdos116Problem.olean` via `lake env lean`, compiled the child clean (exit 0, no
+warnings), `#print axioms` on all five public results.
+
+This discharges **Key lemma 1** of `problem.md`: the lemniscate
+`Sₚ = {z : |p(z)| < 1}` is open (hence measurable) and bounded.
+
+### What I added (namespace `UnitDiskPoly`)
+- `continuous_eval : Continuous P.eval` — `z ↦ ∏ᵢ (z - zᵢ)` is a finite product of
+  continuous factors (`continuous_finsetProd`, each factor `continuous_id.sub
+  continuous_const`).
+- `sublevelSet_eq_preimage` — `Sₚ = (fun z => ‖p(z)‖) ⁻¹' Set.Iio 1` (`rfl` after
+  unfolding, since `Complex.abs = ‖·‖`).
+- `isOpen_sublevelSet` — continuous preimage of the open ray `[0,1)`
+  (`isOpen_Iio.preimage (continuous_norm.comp continuous_eval)`).
+- `measurableSet_sublevelSet` — `IsOpen.measurableSet`.
+- `sublevelSet_subset_closedBall : Sₚ ⊆ closedBall 0 2` — if `‖z‖ > 2` then each
+  factor `‖z - zᵢ‖ ≥ ‖z‖ - ‖zᵢ‖ ≥ ‖z‖ - 1 > 1`, so `‖p(z)‖ = ∏‖z-zᵢ‖ ≥ 1`.
+- `isBounded_sublevelSet` — `Bornology.IsBounded` via subset of `closedBall`.
+
+### Key findings / reusable Lean recipe
+- **`Finset.one_le_prod'` does NOT apply to ℝ** — it needs `MulLeftMono ℝ`, which
+  fails because ℝ's multiplication is not `≤`-monotone (negatives flip it). For
+  "product of nonneg reals each `≥ 1` is `≥ 1`", use `Finset.prod_le_prod`
+  against the constant-`1` product: `(1 : ℝ) = ∏ _i, 1 ≤ ∏ i, f i` via
+  `Finset.prod_const_one` + `Finset.prod_le_prod (0 ≤ 1) (1 ≤ f i)`.
+- **`norm_prod`** rewrites `‖∏ i, f i‖ = ∏ i, ‖f i‖` for ℂ (normed field).
+- **`norm_sub_norm_le z w : ‖z‖ - ‖w‖ ≤ ‖z - w‖`** is the reverse-triangle form
+  needed for the per-factor lower bound.
+- `Complex.abs` here is the parent's local compat def `= ‖·‖`, so
+  `P.roots_in_disk i : Complex.abs (roots i) ≤ 1` is defeq to `‖roots i‖ ≤ 1` and
+  `hz : z ∈ sublevelSet` is defeq to `‖p(z)‖ < 1` (no rewrite needed).
+
+### Next steps
+- **Finiteness of `sublevelMeasure`**: `Sₚ` is a bounded measurable set, so its 2D
+  Lebesgue measure is finite. The parent's `sublevelMeasure` is defined on the
+  `ℝ×ℝ` copy `{p | Complex.abs (P.eval ⟨p.1,p.2⟩) < 1}`; connect it to `Sₚ ⊆ ℂ`
+  via the `Complex.equivRealProdCLM`/`measurableEquivRealProd` measure iso, then
+  `measure_lt_top` from boundedness. (Session-sized but fiddly — the ℂ≅ℝ² measure
+  bridge is the main friction.)
+- **Pólya's `π` upper bound** and the deep KLR `c/log n` lower bound remain out of
+  scope (potential theory, not in Mathlib) — isolate KLR as a single named
+  assumption when the gallery entry is upgraded.
+
+---
+
 ## Problem Understanding
 
 [Initial observations about the problem will be recorded here]

--- a/research/problems/erdos-116-wip-01/state.md
+++ b/research/problems/erdos-116-wip-01/state.md
@@ -1,25 +1,38 @@
 # Research State: erdos-116-wip-01
 
 ## Current State
-**Phase**: OBSERVE
+**Phase**: ACT
 **Path**: full
-**Since**: 2026-07-09T17:33:18-07:00
-**Iteration**: 1
+**Since**: 2026-07-20
+**Iteration**: 2
 
 ## Current Focus
-Initial problem understanding. Read problem.md and gather context.
+Axiom-free topology of the polynomial lemniscate `Sₚ = {z : |p(z)| < 1}` for
+`p ∈ UnitDiskPoly n`, built on the parent's root-factorization definitions.
+
+## Status (S1, researcher-1, 2026-07-20) — Sₚ open / measurable / bounded
+New file `proofs/Proofs/Erdos116WIP01.lean` (6 decls, 0 ax / 0 sorry,
+host-verified `[propext, Classical.choice, Quot.sound]`). Discharges **Key lemma 1**
+of problem.md: `continuous_eval`, `isOpen_sublevelSet`, `measurableSet_sublevelSet`,
+`sublevelSet_subset_closedBall` (`Sₚ ⊆ closedBall 0 2`), `isBounded_sublevelSet`.
 
 ## Active Approach
-None yet.
+Elementary complex-analysis / measure-theory scaffolding from the root product
+`p(z) = ∏(z - zᵢ)`. The deep KLR `c/log n` lower bound and Pólya's `π` upper bound
+rest on logarithmic potential theory absent from Mathlib and stay isolated.
 
 ## Attempt Count
-- Total attempts: 0
-- Current approach attempts: 0
-- Approaches tried: 0
+- Total attempts: 1
+- Current approach attempts: 1
+- Approaches tried: 1
 
 ## Blockers
-None.
+- The KLR `c/log n` lower bound (and the `1/log n` vs `1/log log n` gap) is
+  deep-blocked (route: logarithmic potential theory / value-distribution; reopen:
+  materially new Mathlib potential-theory API required). Only the
+  well-definedness/topology scaffolding is session-sized.
 
 ## Next Action
-Read problem.md thoroughly and acquire full context.
-Then move to ORIENT phase to explore literature and related proofs.
+Finiteness of `sublevelMeasure`: `Sₚ` is bounded + measurable ⟹ finite 2D
+Lebesgue measure; bridge the parent's `ℝ×ℝ` sublevel set to `Sₚ ⊆ ℂ` via the
+`ℂ ≅ ℝ²` measure isomorphism, then `measure_lt_top`.

--- a/src/data/research/problems/erdos-116-wip-01.json
+++ b/src/data/research/problems/erdos-116-wip-01.json
@@ -18,12 +18,18 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "ORIENT",
+    "phase": "ACT",
     "since": "2026-07-09T17:33:18-07:00",
     "iteration": 1,
     "focus": "Initial problem understanding. Read problem.md and gather context.",
-    "blockers": [],
-    "nextAction": "Read problem.md thoroughly and acquire full context.",
+    "blockers": [
+      {
+        "route": "KLR c/log n lower bound via logarithmic potential theory / value-distribution",
+        "reopenCriterion": "materially new Mathlib potential-theory API required",
+        "blockedAt": "2026-07-20"
+      }
+    ],
+    "nextAction": "Finiteness of sublevelMeasure: Sₚ bounded+measurable ⟹ finite 2D Lebesgue measure; bridge the parent ℝ×ℝ sublevel set to Sₚ⊆ℂ via the ℂ≅ℝ² measure iso, then measure_lt_top.",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -31,14 +37,18 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: converted bare stub into a formalization with a verified axiom-free foundational core (6 theorems: root membership, degree-0 emptiness vs positive-degree nonemptiness, measure nonnegativity). Corrected gallery meta which falsely described non-existent axioms/ErdosProblem116; theoremCount 0->6, imports/lineCount synced, assumptions text made honest. Deep bounds remain documented-only (Mathlib infra gap).",
+    "progressSummary": "PROGRESS: New file proofs/Proofs/Erdos116WIP01.lean discharges Key lemma 1 — the polynomial lemniscate Sₚ={z:|p(z)|<1} is open, measurable, and bounded (Sₚ ⊆ closedBall 0 2), all 0-axiom/0-sorry, host-verified [propext, Classical.choice, Quot.sound]. Built directly from the root product p(z)=∏(z-zᵢ). The deep KLR c/log n lower bound and Pólya π upper bound remain isolated (potential theory, not in Mathlib).",
     "builtItems": [
-      "UnitDiskPoly.eval_root_eq_zero / root_mem_sublevelSet / sublevelSet_nonempty / eval_of_degree_zero / sublevelSet_of_degree_zero / sublevelMeasure_nonneg in proofs/Proofs/Erdos116Problem.lean (6 axiom-free foundational theorems; host-verified v4.31, #print axioms = propext/Classical.choice/Quot.sound only)"
+      "UnitDiskPoly.eval_root_eq_zero / root_mem_sublevelSet / sublevelSet_nonempty / eval_of_degree_zero / sublevelSet_of_degree_zero / sublevelMeasure_nonneg in proofs/Proofs/Erdos116Problem.lean (6 axiom-free foundational theorems; host-verified v4.31, #print axioms = propext/Classical.choice/Quot.sound only)",
+      "proofs/Proofs/Erdos116WIP01.lean — 6 axiom-free decls (continuous_eval, sublevelSet_eq_preimage, isOpen_sublevelSet, measurableSet_sublevelSet, sublevelSet_subset_closedBall, isBounded_sublevelSet)"
     ],
     "insights": [
       "Erdos116Problem.lean was a bare statement-stub: real definitions (UnitDiskPoly, eval, sublevelSet, sublevelMeasure) but ZERO theorems, while gallery meta prose falsely described four bounds \"stated as axioms\" and a main theorem ErdosProblem116 that did not exist in source.",
       "The lemniscate {|p(z)|<1} has a clean degree dichotomy: for n=0 the empty product gives p≡1 so the set is EMPTY; for n>0 every root zi satisfies p(zi)=0<1 so each root lies in the set (nonempty). This is the axiom-free core the deep measure bounds build on.",
-      "The four quantitative bounds (Pommerenke c/n^4, KLR c/log n, KLR C/loglog n, Polya pi) need logarithmic-potential / planar-measure machinery absent from Mathlib v4.31 — not formalizable without substantial new infrastructure; correctly left as documented prose, not axioms."
+      "The four quantitative bounds (Pommerenke c/n^4, KLR c/log n, KLR C/loglog n, Polya pi) need logarithmic-potential / planar-measure machinery absent from Mathlib v4.31 — not formalizable without substantial new infrastructure; correctly left as documented prose, not axioms.",
+      "Sₚ = {z : |p(z)|<1} is OPEN: it is the continuous preimage of the open ray Set.Iio 1 under z ↦ ‖p(z)‖; p(z)=∏(z-zᵢ) is continuous via continuous_finsetProd. Hence measurable (IsOpen.measurableSet).",
+      "Sₚ ⊆ closedBall 0 2 (BOUNDED): if ‖z‖>2 then each factor ‖z-zᵢ‖ ≥ ‖z‖-‖zᵢ‖ ≥ ‖z‖-1 > 1 (roots in unit disk), so ‖p(z)‖=∏‖z-zᵢ‖ ≥ 1 and z∉Sₚ. Holds for all n incl. n=0 (Sₚ=∅).",
+      "Lean gotcha: Finset.one_le_prod does NOT work on ℝ (needs MulLeftMono ℝ, false for a field with negatives). Use Finset.prod_le_prod against the constant-1 product: 1 = ∏ 1 ≤ ∏ f via Finset.prod_const_one. norm_prod rewrites ‖∏ f‖ = ∏ ‖f‖; norm_sub_norm_le for the reverse-triangle per-factor bound."
     ],
     "mathlibGaps": [],
     "nextSteps": [


### PR DESCRIPTION
## Summary

First real formalization progress on **Erdős #116** (measure of polynomial sublevel sets — the Erdős–Herzog–Piranian conjecture, proved by Krishnapur–Lundberg–Ramachandran). New file `proofs/Proofs/Erdos116WIP01.lean` discharges **Key lemma 1** of the research task: for a monic degree-`n` polynomial `p(z) = ∏(z - zᵢ)` with all roots in the closed unit disk, the lemniscate `Sₚ = {z : |p(z)| < 1}` is **open (hence measurable) and bounded**.

Previously the parent `Erdos116Problem.lean` had only 5 elementary structural lemmas (root membership, degree-0 emptiness, measure nonnegativity); the topology of `Sₚ` — exactly what makes the parent's `sublevelMeasure` well-defined — was untouched.

## New theorems (all axiom-free, namespace `UnitDiskPoly`)

- **`continuous_eval`** — `z ↦ p(z) = ∏ᵢ (z - zᵢ)` is continuous (a finite product of continuous factors).
- **`sublevelSet_eq_preimage`** — `Sₚ = (fun z => ‖p(z)‖) ⁻¹' Set.Iio 1`.
- **`isOpen_sublevelSet`** — `Sₚ` is the continuous preimage of the open ray `[0, 1)`.
- **`measurableSet_sublevelSet`** — open ⟹ measurable.
- **`sublevelSet_subset_closedBall`** — `Sₚ ⊆ closedBall 0 2`: if `‖z‖ > 2` then each factor `‖z - zᵢ‖ ≥ ‖z‖ - ‖zᵢ‖ ≥ ‖z‖ - 1 > 1`, so `‖p(z)‖ = ∏‖z - zᵢ‖ ≥ 1` and `z ∉ Sₚ` (holds for all degrees, including `n = 0` where `Sₚ = ∅`).
- **`isBounded_sublevelSet`** — hence `Sₚ` is `Bornology.IsBounded`.

Together: `Sₚ` is a bounded measurable set, the well-definedness needed for its 2D Lebesgue measure to be finite.

## Scope / honesty

The deep quantitative bounds — KLR `c/log n` lower bound, Pólya `π` upper bound, and the open `1/log n` vs `1/log log n` gap — rest on logarithmic potential theory absent from Mathlib and are **not** attempted here; they remain cleanly isolated for a future named assumption. This PR is the axiom-free topological scaffolding only.

## Verification

Host-verified without Docker (parent imports `Mathlib` only): fresh-built `Erdos116Problem.olean` via `lake env lean`, compiled the child clean (exit 0, no warnings), `#print axioms` on all five public results:

```
'continuous_eval' / 'isOpen_sublevelSet' / 'measurableSet_sublevelSet' /
'sublevelSet_subset_closedBall' / 'isBounded_sublevelSet'
  depends on axioms: [propext, Classical.choice, Quot.sound]
```

0 sorry / 0 axiom / no `native_decide`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
