### PR TITLE
Research: erdos-1039-oq-05 — pin the first exact transfinite-diameter term d₂ = 2 (4 axiom-free theorems)

### DIFF
--- a/proofs/Proofs/Erdos1039TransfiniteDiameter.lean
+++ b/proofs/Proofs/Erdos1039TransfiniteDiameter.lean
@@ -561,4 +561,52 @@ theorem transfiniteDiameter_le (n : ℕ) :
     transfiniteDiameter ≤ transfiniteDiameterN (n + 2) :=
   ciInf_le transfiniteDiameterN_shift_bddBelow n
 
+/-! ### The first term is exact: `d₂ = 2`
+
+The `2`-point diameter reduces to the single gap `d₂(z) = ‖z₀ - z₁‖`, whose
+supremum over the closed unit disc is `2`, attained by the antipodal pair
+`{1, -1}`.  This is the only stage of the sequence whose value is elementary
+(the sharp `d = 1` for the disc is the deep Fekete–Szegő content); it pins the
+top of the monotone sequence exactly and shows the uniform bound
+`dₙ ≤ 2` is attained at `n = 2`. -/
+
+/-- The spread product of a `2`-point configuration is the single gap
+`‖z₀ - z₁‖` (the only pair `i < j` in `Fin 2`). -/
+theorem spreadProduct_two (z : Fin 2 → ℂ) : spreadProduct z = ‖z 0 - z 1‖ := by
+  unfold spreadProduct
+  rw [Fin.prod_univ_two]
+  have h0 : Finset.Ioi (0 : Fin 2) = {1} := by decide
+  have h1 : Finset.Ioi (1 : Fin 2) = (∅ : Finset (Fin 2)) := by decide
+  rw [h0, h1, Finset.prod_singleton, Finset.prod_empty, mul_one]
+
+/-- The `2`-point diameter is exactly the gap `‖z₀ - z₁‖`: the normalising
+exponent `2/(n(n-1))` equals `1` at `n = 2`. -/
+theorem discreteDiameter_two (z : Fin 2 → ℂ) :
+    discreteDiameter z = ‖z 0 - z 1‖ := by
+  rw [discreteDiameter, spreadProduct_two]
+  norm_num
+
+/-- **`d₂ = 2`.**  The `2`-point transfinite diameter of the closed unit disc is
+exactly `2`, attained by the antipodal configuration `{1, -1}`: the upper bound
+`d₂ ≤ 2` (from `discreteDiameter_le_two`) is achieved, since
+`d₂({1,-1}) = ‖1 - (-1)‖ = 2`. -/
+theorem transfiniteDiameterN_two : transfiniteDiameterN 2 = 2 := by
+  refine le_antisymm (transfiniteDiameterN_mem_Icc (le_refl 2)).2 ?_
+  have hwit : discreteDiameter (![(1 : ℂ), -1]) = 2 := by
+    rw [discreteDiameter_two]
+    norm_num
+  refine le_csSup (unitDiscDiameters_bddAbove (le_refl 2))
+    ⟨![(1 : ℂ), -1], ?_, hwit⟩
+  intro i
+  fin_cases i <;> norm_num
+
+/-- **The transfinite diameter of the disc is at most `2`, sharply.**  Since
+`d = ⨅ₙ d_{n+2}` and the first term `d₂ = 2` (`transfiniteDiameterN_two`), the
+bound `d ≤ 2` from `transfiniteDiameter_mem_Icc` is exactly the `n = 0` term of
+the defining infimum. -/
+theorem transfiniteDiameter_le_two_via_d2 :
+    transfiniteDiameter ≤ 2 := by
+  have := transfiniteDiameter_le 0
+  rwa [transfiniteDiameterN_two] at this
+
 end Erdos1039TransfiniteDiameter

--- a/research/problems/erdos-1039-oq-05/knowledge.md
+++ b/research/problems/erdos-1039-oq-05/knowledge.md
@@ -1,5 +1,44 @@
 # Knowledge Base: erdos-1039-oq-05
 
+## Session 2026-07-20 (researcher-1, iter 5) — first exact term `d₂ = 2`
+
+**Mode**: continue a RICH node; the elementary transfinite-diameter scaffolding
+(spread product, Fekete monotonicity `transfiniteDiameterN_succ_le`, the limit
+`transfiniteDiameter = ⨅ₙ d_{n+2}` with antitone/bddBelow/tendsto/`∈[0,2]`) was
+already complete on main. **Outcome**: progress — 4 new axiom-free theorems in
+`Proofs/Erdos1039TransfiniteDiameter.lean` (`[propext, Classical.choice, Quot.sound]`,
+0 sorry / 0 axiom), host-verified directly (`import Mathlib` only, `lake env lean`
+exit 0, `#print axioms` on all four).
+
+### What I added
+- `spreadProduct_two (z : Fin 2 → ℂ) : spreadProduct z = ‖z 0 - z 1‖` — the double
+  product `∏ᵢ ∏_{j>i}` collapses to the single pair `(0,1)` in `Fin 2`.
+- `discreteDiameter_two : discreteDiameter z = ‖z 0 - z 1‖` — the normalising
+  exponent `2/(n(n-1))` is `1` at `n = 2`, so `dₙ = spreadProduct^1 = ‖z₀-z₁‖`.
+- `transfiniteDiameterN_two : transfiniteDiameterN 2 = 2` — the upper bound `d₂ ≤ 2`
+  (`discreteDiameter_le_two`) is **attained** by the antipodal pair `![1,-1]`
+  (`d₂ = ‖1-(-1)‖ = 2`), via `le_csSup`. The only exactly-computed stage of the
+  sequence.
+- `transfiniteDiameter_le_two_via_d2 : transfiniteDiameter ≤ 2` — the `d ≤ 2` bound
+  is exactly the `n=0` term of the defining `⨅`, now that `d₂ = 2`.
+
+### Key findings / reusable Lean recipe
+- **Collapsing `∏ i : Fin 2, ∏ j ∈ Finset.Ioi i, f i j`**: `Fin.prod_univ_two`, then
+  `Finset.Ioi (0:Fin 2) = {1}` and `Finset.Ioi (1:Fin 2) = ∅` both close by
+  `decide` (Fin is a decidable `LocallyFiniteOrder`); finish with
+  `Finset.prod_singleton`, `Finset.prod_empty`, `mul_one`.
+- **`![1,-1] : Fin 2 → ℂ` membership/value goals** discharge by `norm_num`
+  (evaluates `Matrix.cons_val`, `‖(2:ℂ)‖ = 2`, `‖±1‖ = 1`); the disc-membership
+  `∀ i, ‖z i‖ ≤ 1` by `fin_cases i <;> norm_num`.
+- **State.md was STALE**: it claimed Fekete monotonicity `dₙ₊₁ ≤ dₙ` was still "next",
+  but `transfiniteDiameterN_succ_le` (sup level) + the full limit were already on
+  main. Verify the actual .lean before trusting the tracker's "Next Action".
+
+### Next steps (all fiddly, not clearly session-sized)
+- Exact `d₃` via 3 cube-roots-of-unity on the boundary (spread `3√3`, `d₃ = 3^{1/2}`).
+- Strict `d₃ < d₂ = 2` (Fekete monotonicity strict at the top).
+- Sharp limit `d = 1` (= log-capacity of disc) stays deep-blocked (Fekete–Szegő).
+
 ## Session 2026-07-20 (researcher-1) — Fekete monotonicity at the SUPREMUM level
 
 Added the sup-over-configurations capstone to `Erdos1039TransfiniteDiameter.lean` (host-verified

--- a/research/problems/erdos-1039-oq-05/state.md
+++ b/research/problems/erdos-1039-oq-05/state.md
@@ -4,30 +4,37 @@
 **Phase**: ACT
 **Path**: full
 **Since**: 2026-07-09T15:40:19-07:00
-**Iteration**: 4
+**Iteration**: 5
 
 ## Current Focus
-Finite discrete transfinite diameter (n-point spread) and the **combinatorial core
-of Fekete monotonicity** are now formalized axiom-free in
-`Proofs/Erdos1039TransfiniteDiameter.lean`. The deletion identity
-`∏ₖ V(delete k Z) = V(Z)^{n-1}` is proved directly. Next: turn it into the
-supremum-level monotonicity dₙ₊₁ ≤ dₙ (needs sup over configurations) and the
-logarithmic-capacity side.
+`Proofs/Erdos1039TransfiniteDiameter.lean` now carries the FULL elementary
+transfinite-diameter scaffolding, all axiom-free: the discrete spread product,
+Fekete monotonicity at the **supremum level** (`transfiniteDiameterN_succ_le`,
+`dₙ₊₁ ≤ dₙ`), and the transfinite diameter as a genuine limit
+(`transfiniteDiameter = ⨅ₙ d_{n+2}`, antitone + bddBelow + `tendsto`, `∈ [0,2]`).
+S5 pinned the **first exact term `d₂ = 2`** (only elementary stage; sharp `d=1`
+needs Fekete–Szegő).
 
 ## Active Approach
-Approach B (Fekete points / transfinite diameter of the root set), building the
-finite discrete spread first and advancing toward the limiting diameter.
+Approach B (Fekete points / transfinite diameter of the root set). The finite
+discrete spread and the monotone-limit structure are complete; remaining exact
+values (dₙ for n ≥ 3) and the logarithmic-capacity identity `cap = 1` are deep.
 
 ## Attempt Count
-- Total attempts: 2
-- Current approach attempts: 2
+- Total attempts: 3
+- Current approach attempts: 3
 - Approaches tried: 1
 
 ## Blockers
-None (parent conjecture ρ(f) ≫ 1/n remains OPEN, but out of scope for this OQ).
+- Sharp value `d = 1` (= logarithmic capacity of the unit disc) needs the
+  Fekete–Szegő theorem and extremal root-of-unity configurations, absent from
+  Mathlib (route: Fekete–Szegő / potential theory; reopen: materially new Mathlib
+  potential-theory API). The parent conjecture ρ(f) ≫ 1/n remains OPEN, out of
+  scope for this OQ.
 
 ## Next Action
-Deletion identity `∏ₖ V(delete k Z) = V(Z)^{n-1}` is DONE (axiom-free). Remaining:
-lift it to the supremum-level Fekete monotonicity dₙ₊₁ ≤ dₙ (pigeonhole giving one
-deletion with V(delete k) ≥ V^{(n-1)/(n+1)}, then sup over configurations in K),
-then define logarithmic capacity of the lemniscate complement and axiomatize cap=1.
+The elementary layer is saturated. Candidate next increments (all fiddly, not
+clearly session-sized): (a) exact `d₃` via the equilateral-triangle
+configuration (3 cube-roots-of-unity scaled to the boundary, spread `3√3`);
+(b) the strict inequality `d₃ < d₂ = 2` witnessing that Fekete monotonicity is
+strict at the top. The sharp limit `d = 1` stays deep-blocked.

--- a/src/data/research/problems/erdos-1039-oq-05.json
+++ b/src/data/research/problems/erdos-1039-oq-05.json
@@ -33,8 +33,14 @@
     "since": "2026-07-09T00:00:00Z",
     "iteration": 4,
     "focus": "Iteration 4: pointwise Fekete monotonicity exists_deleteAt_discreteDiameter_ge (d_{n+1}(Z) <= d_n(delete k Z)) proved axiom-free from the deletion identity via some-term-meets-mean. Erdos1039TransfiniteDiameter.lean now 16 theorems, 0 axioms/sorries.",
-    "blockers": [],
-    "nextAction": "Upgrade pointwise exists_deleteAt_discreteDiameter_ge to dₙ₊₁ ≤ dₙ (sup over configs, needs compactness/sSup API) and d(Z)=infₙ dₙ; capacity axioms (Fekete–Szegő). Positivity lemmas now available as a building block.",
+    "blockers": [
+      {
+        "route": "sharp value d = 1 (log-capacity of unit disc) via Fekete–Szegő / potential theory",
+        "reopenCriterion": "materially new Mathlib potential-theory API required",
+        "blockedAt": "2026-07-20"
+      }
+    ],
+    "nextAction": "Exact d₃ via cube-roots-of-unity on the boundary, or strict d₃ < d₂ = 2 (Fekete strict at top); both fiddly. Sharp limit d=1 deep-blocked (Fekete–Szegő, not in Mathlib).",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -42,7 +48,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "Discrete/transfinite diameter API is 0-axiom and now closes the limit: dₙ non-increasing (Fekete, transfiniteDiameterN_succ_le) and bounded in [0,2], so d = ⨅ₙ dₙ = limₙ dₙ is a well-defined real in [0,2] (transfiniteDiameter, tendsto_transfiniteDiameterN, transfiniteDiameter_mem_Icc). Remaining: sharp value d=1 (Fekete–Szegő + roots-of-unity extremal configs); connection to ρ(f) via capacity.",
+    "progressSummary": "PROGRESS: Pinned the first exact term of the transfinite-diameter sequence, transfiniteDiameterN 2 = 2 (attained by antipodal ![1,-1]), plus spreadProduct_two/discreteDiameter_two helpers and transfiniteDiameter_le_two_via_d2 — all 0-axiom/0-sorry, host-verified [propext, Classical.choice, Quot.sound]. The elementary transfinite-diameter layer (spread, Fekete monotonicity dₙ₊₁≤dₙ at sup level, the ⨅ₙ limit ∈[0,2]) is now complete; sharp d=1 (log-capacity) stays deep-blocked (Fekete–Szegő).",
     "builtItems": [
       "Erdos1039TransfiniteDiameter.spreadProduct: the Vandermonde spread ∏_{i<j}‖zᵢ-zⱼ‖ (finite-n numerator of the transfinite diameter).",
       "Erdos1039TransfiniteDiameter.discreteDiameter: the n-point diameter dₙ(Z) = spreadProduct^{2/(n(n-1))}, the finite-n truncation of the transfinite diameter.",
@@ -60,7 +66,8 @@
       "unitDiscDiameters, transfiniteDiameterN, zero_mem_unitDiscDiameters, unitDiscDiameters_nonempty/bddAbove, transfiniteDiameterN_succ_le, transfiniteDiameterN_mem_Icc in Erdos1039TransfiniteDiameter.lean (0 axioms, 0 sorries; host-verified v4.31.0)",
       "transfiniteDiameter (def) + tendsto_transfiniteDiameterN: the n-point diameters d_{n+2} converge to d = ⨅ₙ d_{n+2} (antitone + bounded-below ⟹ tendsto_atTop_ciInf). Makes the transfinite diameter of the unit disc a genuine LIMIT, not just an infimum.",
       "transfiniteDiameter_mem_Icc: d ∈ [0,2]; transfiniteDiameter_le: d ≤ d_{n+2} for all n. All 0-axiom, host-verified v4.31.",
-      "Fekete monotonicity (sup form) transfiniteDiameterN_succ_le was ALREADY DONE in-tree (knowledge Next#1 was stale)."
+      "Fekete monotonicity (sup form) transfiniteDiameterN_succ_le was ALREADY DONE in-tree (knowledge Next#1 was stale).",
+      "spreadProduct_two, discreteDiameter_two, transfiniteDiameterN_two (=2), transfiniteDiameter_le_two_via_d2 in Erdos1039TransfiniteDiameter.lean (4 axiom-free)"
     ],
     "insights": [
       "The finite discrete spread is entirely elementary and needs NO capacity infrastructure: it is a product of pairwise norms, equal to the modulus of the Vandermonde determinant, so it is host-verifiable Mathlib-only (no Docker).",
@@ -71,7 +78,9 @@
       "Additive shadow: sum_k logSpread(delete k Z) = (n-1)*logSpread Z for distinct roots, connecting the deletion identity to the logarithmic-energy/capacity bridge already in the file.",
       "Strict positivity of discreteDiameter: dₙ z = spreadProduct z ^ (2/(n(n-1))); for injective z the base is positive (spreadProduct_pos_iff) so Real.rpow_pos_of_pos gives 0 < dₙ. The n≥2 iff uses that the exponent 2/(n(n-1)) is nonzero, so a zero spread would force dₙ=0 (Real.zero_rpow). This is the positivity that Real.log(dₙ) and the energy bridge silently need.",
       "Fekete monotonicity LIFTS to the supremum level: defining dₙ = sup over n-point configs in the closed unit disc of discreteDiameter, the pointwise exists_deleteAt_discreteDiameter_ge gives transfiniteDiameterN_succ_le (d_{n+1} ≤ dₙ, n≥2) directly via csSup_le + le_csSup — no compactness API needed, only that the config values stay in the disc under deletion and that dₙ(Z)≤2 bounds the sup. The disc is the natural compact set (parent lemniscate roots lie in it).",
-      "Limit existence (researcher-1, 2026-07-20): the transfinite diameter of the closed unit disc is now a well-defined real number d = limₙ dₙ = ⨅ₙ dₙ ∈ [0,2], via Mathlib tendsto_atTop_ciInf on the antitone (Fekete) bounded-below sequence. The SHARP value d = 1 (= logarithmic capacity of the disc) remains open: it needs the Fekete–Szegő theorem plus extremal root-of-unity configurations (spreadProduct of nth roots of unity → the discriminant), not yet formalized. The current upper bound is the coarse dₙ ≤ 2."
+      "Limit existence (researcher-1, 2026-07-20): the transfinite diameter of the closed unit disc is now a well-defined real number d = limₙ dₙ = ⨅ₙ dₙ ∈ [0,2], via Mathlib tendsto_atTop_ciInf on the antitone (Fekete) bounded-below sequence. The SHARP value d = 1 (= logarithmic capacity of the disc) remains open: it needs the Fekete–Szegő theorem plus extremal root-of-unity configurations (spreadProduct of nth roots of unity → the discriminant), not yet formalized. The current upper bound is the coarse dₙ ≤ 2.",
+      "d₂ = transfiniteDiameterN 2 = 2 EXACTLY: the 2-point diameter reduces to the single gap ‖z₀-z₁‖ (exponent 2/(n(n-1))=1 at n=2), max over the closed disc is 2, attained by antipodal ![1,-1]. Only elementary exact stage; sharp d=1 needs Fekete–Szegő.",
+      "Lean: collapse ∏ i:Fin 2, ∏ j∈Ioi i via Fin.prod_univ_two + (Finset.Ioi (0:Fin 2)={1}, Ioi (1:Fin 2)=∅) by decide; ![1,-1] value/membership goals by norm_num / fin_cases."
     ],
     "mathlibGaps": [
       "Mathlib has no transfinite-diameter / logarithmic-capacity API; the n-point spread and its diameter had to be defined from scratch (done here). The limit d(Z)=limₙ dₙ and Fekete monotonicity are still absent."


### PR DESCRIPTION
## Summary

Continues the axiom-free transfinite-diameter formalization for **Erdős #1039 (OQ-05)** in `proofs/Proofs/Erdos1039TransfiniteDiameter.lean`. The file already carries the full elementary scaffolding — the discrete Vandermonde spread product, Fekete monotonicity `dₙ₊₁ ≤ dₙ` at the supremum level (`transfiniteDiameterN_succ_le`), and the transfinite diameter as a genuine limit `d = ⨅ₙ d_{n+2} ∈ [0,2]`. This PR pins the **only exactly-computable stage of the sequence, `d₂ = 2`**.

## New theorems (all axiom-free)

- **`spreadProduct_two`** — for `z : Fin 2 → ℂ`, the double product `∏ᵢ ∏_{j>i} ‖zᵢ - zⱼ‖` collapses to the single pair `(0,1)`: `spreadProduct z = ‖z₀ - z₁‖`.
- **`discreteDiameter_two`** — the normalising exponent `2/(n(n-1))` is `1` at `n = 2`, so `d₂(z) = spreadProduct(z)^1 = ‖z₀ - z₁‖`.
- **`transfiniteDiameterN_two`** — `d₂ = 2` exactly. The upper bound `d₂ ≤ 2` (`discreteDiameter_le_two`) is **attained** by the antipodal configuration `![1, -1]`, since `d₂({1,-1}) = ‖1 - (-1)‖ = 2`.
- **`transfiniteDiameter_le_two_via_d2`** — `d ≤ 2` is exactly the `n = 0` term of the defining infimum, now that `d₂ = 2`.

This is the first stage of the monotone sequence whose value is elementary and shows the uniform bound `dₙ ≤ 2` is sharp at `n = 2`.

## Scope / honesty

The sharp limit `d = 1` (the logarithmic capacity of the unit disc) requires the Fekete–Szegő theorem and extremal root-of-unity configurations, absent from Mathlib — it remains deep-blocked and out of scope. The parent conjecture `ρ(f) ≫ 1/n` is likewise open.

This PR also **corrects a stale `state.md`** that listed the (already-completed on `main`) supremum-level Fekete monotonicity as the pending "Next Action".

## Verification

Host-verified without Docker (`import Mathlib` only): `lake env lean` compiled the whole file clean (exit 0), `#print axioms` on all four new results returns `[propext, Classical.choice, Quot.sound]`. 0 sorry / 0 axiom / no `native_decide`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
