### PR TITLE
Enrich fibonacci-identities-oq-02-oq-01: re-anchor sections + add odd-quotient-law tail, cover 180→266

### DIFF
--- a/src/data/proofs/fibonacci-identities-oq-02-oq-01/meta.json
+++ b/src/data/proofs/fibonacci-identities-oq-02-oq-01/meta.json
@@ -83,7 +83,7 @@
       "id": "header",
       "title": "Module Header and Framing",
       "startLine": 1,
-      "endLine": 64,
+      "endLine": 65,
       "summary": "Module docstring contrasting the Fibonacci strong-divisibility law (parent entry) with the Lucas case, stating the resolution (Lucas is not strongly divisible; the correct law is the odd-quotient rule), and the product identity F_{2n} = Fₙ·Lₙ as the positive engine. Import of Mathlib and the namespace.",
       "mathContext": "$L_0=2,\\ L_1=1,\\ L_{n+2}=L_n+L_{n+1}$; strong divisibility means $\\gcd(a_m,a_n)=a_{\\gcd(m,n)}$."
     },
@@ -91,7 +91,7 @@
       "id": "definition",
       "title": "Definition of the Lucas Numbers",
       "startLine": 66,
-      "endLine": 82,
+      "endLine": 83,
       "summary": "lucasPair (the structural pair recursion (Lₙ, Lₙ₊₁), reducing by rfl/decide), lucas, the base values lucas_zero/lucas_one, and the certifying recurrence lucas_add_two.",
       "mathContext": "$L_{n+2}=L_n+L_{n+1}$, computed via the pair $(L_n,L_{n+1})\\mapsto(L_{n+1},L_n+L_{n+1})$."
     },
@@ -99,33 +99,52 @@
       "id": "bridge",
       "title": "The Fibonacci Bridge and the Product Identity",
       "startLine": 84,
-      "endLine": 117,
+      "endLine": 121,
       "summary": "two_mul_fib_succ (the subtraction-free bridge 2·Fₙ₊₁ = Lₙ + Fₙ, by two-step induction), lucas_eq (closed form Lₙ = 2·Fₙ₊₁ − Fₙ), the headline fib_two_mul_eq (F_{2n} = Fₙ·Lₙ), and its divisibility corollaries lucas_dvd_fib_two_mul and fib_dvd_fib_two_mul.",
       "mathContext": "$2F_{n+1}=L_n+F_n$, $L_n=2F_{n+1}-F_n$, and $F_{2n}=F_n\\,L_n$."
     },
     {
       "id": "values",
       "title": "Concrete Lucas Values",
-      "startLine": 119,
-      "endLine": 126,
+      "startLine": 122,
+      "endLine": 130,
       "summary": "The values L₂=3, L₃=4, L₄=7, L₅=11, L₆=18, L₉=76, each by rfl on the structural definition, used by the divisibility witnesses below.",
       "mathContext": "$L_2=3,\\ L_3=4,\\ L_4=7,\\ L_5=11,\\ L_6=18,\\ L_9=76$."
     },
     {
       "id": "failure",
       "title": "Strong Divisibility Fails",
-      "startLine": 128,
-      "endLine": 151,
+      "startLine": 131,
+      "endLine": 155,
       "summary": "lucas_not_strong_divisibility (gcd(L₂,L₄)=1 ≠ 3 = L_{gcd(2,4)}), index_dvd_not_imp_lucas_dvd (2∣4 but L₂∤L₄ — the Fibonacci transfer law has no Lucas analogue), and the explicit value lucas_gcd_two_four = 1, all decided.",
       "mathContext": "$\\gcd(L_2,L_4)=\\gcd(3,7)=1\\neq 3=L_{\\gcd(2,4)}$; $2\\mid 4$ but $3\\nmid 7$."
     },
     {
       "id": "characterization",
       "title": "The Odd-Quotient Characterization",
-      "startLine": 153,
-      "endLine": 180,
+      "startLine": 156,
+      "endLine": 182,
       "summary": "The correct law Lₘ ∣ Lₙ ⟺ m∣n ∧ n/m odd (m ≥ 2) verified on the decisive instances: L₂∣L₆ (odd quotient) vs L₂∤L₄ (even quotient), L₃∣L₉ vs L₃∤L₆, and the degenerate L₁ = 1 ∣ Lₙ.",
       "mathContext": "For $m\\ge 2$: $L_m\\mid L_n \\iff m\\mid n \\text{ and } n/m \\text{ odd}$."
+    },
+    {
+      "id": "forward-direction",
+      "title": "Forward Direction of the Odd-Quotient Law (Full Generality)",
+      "startLine": 183,
+      "endLine": 266,
+      "summary": "Proves the universally-quantified \"if\" half of the odd-quotient characterization: for all m and n with m∣n and n/m odd, Lₘ ∣ Lₙ — subsuming the concrete instances (L₂∣L₆, L₃∣L₉, …). Engine is the Lucas shift identity (`lucas_add_shift`, `lucas_add_eq`) feeding `lucas_dvd_fib_even_mul`, `lucas_dvd_lucas_odd_mul`, and the capstone `lucas_dvd_of_odd_quotient`.",
+      "mathContext": "$m\\mid n$ and $n/m$ odd $\\Rightarrow L_m\\mid L_n$, via the shift identity $L_{a+b}=L_aL_b-(-1)^bL_{a-b}$ and induction on the odd quotient $k=n/m$.",
+      "significance": "key",
+      "relatedConcepts": [
+        "Lucas numbers",
+        "strong divisibility",
+        "Fibonacci identities",
+        "odd-quotient law"
+      ],
+      "prerequisites": [
+        "Lucas/Fibonacci recurrences",
+        "divisibility induction"
+      ]
     }
   ],
   "crossReferences": [


### PR DESCRIPTION
## Enrichment: fibonacci-identities-oq-02-oq-01 (Lucas odd-quotient divisibility law)

`sections[]` had drifted a few lines from the `/-! ## ` banners and stopped at line 180 while the file runs to 266 — the entire final section `## The forward direction of the odd-quotient law, in full generality` (183–266) was uncovered, including its 5 theorems (`lucas_add_shift`, `lucas_add_eq`, `lucas_dvd_fib_even_mul`, `lucas_dvd_lucas_odd_mul`, capstone `lucas_dvd_of_odd_quotient`).

### Change
- **Re-anchored** all 6 sections to their actual `/-! ## ` banner positions (titles/summaries unchanged).
- **Added** `Forward Direction of the Odd-Quotient Law (Full Generality)` (183–266) with `mathContext`/`significance`/`relatedConcepts`/`prerequisites`.
- Sections now cover lines **1–266 contiguously** (full file).

### Integrity
- Confirmed **0 axioms, 0 sorries** — `badge: "original"` accurate and unchanged.
- JSON validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
