### PR TITLE
Enrich property-b-first-moment-oq-03: fix section gap/overlap + add sharpness & Erdős-bound sections, cover 401→498

### DIFF
--- a/src/data/proofs/property-b-first-moment-oq-03/meta.json
+++ b/src/data/proofs/property-b-first-moment-oq-03/meta.json
@@ -87,7 +87,7 @@
       "id": "criterion",
       "title": "The Non-Uniform First-Moment Criterion",
       "startLine": 1,
-      "endLine": 71,
+      "endLine": 72,
       "mathContext": "$2\\cdot\\sum_{e\\in E} 2^{\\,n-|e|} < 2^{n} \\;\\Rightarrow\\; \\exists c,\\ \\forall e\\in E,\\ \\neg\\,\\mathrm{Mono}(e,c)$",
       "summary": "Module docstring scoping the result against the Radhakrishnan–Srinivasan target. property_b_of_weighted_first_moment: the incidence total ∑_c #(mono edges) = ∑_e 2·2^(n-|e|) via card_filter + sum_comm + the parent's card_mono per edge; the threshold is the hypothesis after mul_sum; exists_zero_of_sum_lt_card yields a coloring with empty monochromatic-edge filter."
     },
@@ -95,7 +95,7 @@
       "id": "uniform-corollary",
       "title": "Recovering Erdős' Uniform Bound as a Special Case",
       "startLine": 73,
-      "endLine": 108,
+      "endLine": 109,
       "mathContext": "$|e| = k,\\ |E| < 2^{k-1} \\;\\Rightarrow\\; 2|E|\\,2^{\\,n-k} < 2^{n}$",
       "summary": "property_b_two_colorable_of_uniform: with every |e| = k the weighted sum collapses to |E|·2^(n-k) (sum_const), and |E| < 2^(k-1) gives 2·|E| < 2^k, hence 2·|E|·2^(n-k) < 2^k·2^(n-k) = 2^n. This re-derives the parent theorem from the non-uniform criterion, confirming the refinement is faithful."
     },
@@ -103,7 +103,7 @@
       "id": "mixed-example",
       "title": "A Mixed-Size Family the Uniform Theorem Misses",
       "startLine": 110,
-      "endLine": 122,
+      "endLine": 121,
       "mathContext": "$E = \\{\\{0,1\\},\\{0,1,2\\}\\}\\subseteq 2^{\\mathrm{Fin}\\,3},\\quad 2(2^{1}+2^{0}) = 6 < 8 = 2^{3}$",
       "summary": "mixed_example_two_colorable: a size-2 and a size-3 edge over Fin 3; weighted sum 2 + 1 = 3, and 2·3 = 6 < 8, so the criterion certifies a proper 2-coloring. The hypotheses (edges nonempty, threshold) are dispatched by decide."
     },
@@ -111,7 +111,7 @@
       "id": "quantitative-first-moment",
       "title": "Quantitative First Moment: a Coloring with Few Monochromatic Edges",
       "startLine": 122,
-      "endLine": 227,
+      "endLine": 228,
       "mathContext": "$\\sum_{e} 2\\cdot 2^{\\,n-|e|} \\le 2^{n} t \\;\\Rightarrow\\; \\exists c,\\ \\#\\{e : \\mathrm{Mono}(e,c)\\} \\le t$",
       "summary": "exists_le_of_sum_le_card_mul (nonstrict min ≤ mean over ℕ, the averaging cousin of exists_zero_of_sum_lt_card) feeds the same card_mono incidence count to give exists_coloring_few_mono: some coloring leaves ≤ t monochromatic edges. exists_coloring_few_mono_uniform specializes to k-uniform (|E| ≤ 2^(k-1)·t ⟹ ≤ t defects); triangle_few_mono shows K₃ over Fin 3 (incidence 12 ≤ 16 = 2³·2) admits a coloring with ≤ 2 monochromatic edges where the strict criterion is silent."
     },
@@ -119,16 +119,54 @@
       "id": "deletion-method",
       "title": "Deletion (Alteration) Method: a 2-Colorable Subfamily After Removing Few Edges",
       "startLine": 229,
-      "endLine": 311,
+      "endLine": 310,
       "mathContext": "$\\sum_{e} 2\\cdot 2^{\\,n-|e|} \\le 2^{n} t \\;\\Rightarrow\\; \\exists D\\subseteq E,\\ |D|\\le t,\\ E\\setminus D \\text{ is 2-colorable}$",
       "summary": "subfamily_of_few_mono turns the few-mono coloring into a 2-colorable subfamily by deleting exactly its monochromatic edges D = {e : Mono e c}; the same c properly 2-colors E \\ D. exists_two_colorable_subfamily (general) and exists_two_colorable_subfamily_uniform (k-uniform: retain ≥ |E| − ⌈|E|/2^(k-1)⌉ edges) formalize the standard deletion method, the elementary integer sibling of RS recoloring. k4_bipartite_subfamily is a finite Max-Cut-flavored instance: K₄ over Fin 4 (incidence 48 = 2⁴·3) yields a bipartite subgraph after deleting ≤ 3 of 6 edges."
+    },
+    {
+      "id": "sharpness-criterion",
+      "title": "Sharpness of the Strict First-Moment Criterion",
+      "startLine": 311,
+      "endLine": 369,
+      "summary": "Shows the strict threshold ∑2^(1-|e|)<1 cannot be relaxed to ≤: a single singleton edge {v} is monochromatic under every coloring (`mono_singleton`), so the family is not 2-colorable yet sits exactly at incidence 2^n (`weighted_criterion_sharp`), with `boundary_singleton_fin1` a concrete Fin 1 boundary witness.",
+      "mathContext": "The bound $2\\sum 2^{n-|e|}<2^n$ (i.e. $\\sum 2^{1-|e|}<1$) is sharp: at equality a singleton edge defeats Property B, so the inequality cannot be weakened.",
+      "significance": "supporting",
+      "relatedConcepts": [
+        "Property B",
+        "first moment method",
+        "sharp thresholds",
+        "monochromatic sets"
+      ],
+      "prerequisites": [
+        "probabilistic method",
+        "2-colorings"
+      ]
     },
     {
       "id": "fano-plane-upper-witness",
       "title": "Extremal Upper Side: the Fano Plane is Not 2-Colorable",
       "startLine": 370,
-      "endLine": 401,
+      "endLine": 400,
       "summary": "The first-moment criterion is a lower-bound engine (few edges ⟹ 2-colorable); the extremal question m(3) asks the fewest edges of a non-2-colorable 3-uniform hypergraph. fanoPlane is the Fano plane PG(2,2), the unique Steiner triple system S(2,3,7) on Fin 7. fano_three_uniform and fano_card_eq_seven (both by decide) record that it is 3-uniform with 7 edges; fano_not_two_colorable (by kernel decide over all 2^7 colorings) shows no 2-coloring avoids a monochromatic line, so m(3) ≤ 7. With the count lower bound m(3) ≥ 2^(3-1) = 4 (property_b_two_colorable_of_uniform) this brackets 4 ≤ m(3) ≤ 7. Axiom-free: kernel decide, no native_decide."
+    },
+    {
+      "id": "converse-lower-bound",
+      "title": "Converse: Weighted Lower Bound and Erdős m(k) ≥ 2^(k-1)",
+      "startLine": 401,
+      "endLine": 498,
+      "summary": "The necessary direction: the exact first moment `total_mono_incidence_eq`, the weighted lower bound `weighted_lower_bound_of_not_property_b` for families lacking Property B, and Erdős's uniform lower bound `uniform_lower_bound_of_not_property_b` giving m(k) ≥ 2^(k-1) for k-uniform families.",
+      "mathContext": "For a non-2-colorable $k$-uniform family $E$, summing monochromatic incidences forces $|E|\\ge 2^{k-1}$, i.e. Erdős's classical bound $m(k)\\ge 2^{k-1}$.",
+      "significance": "key",
+      "relatedConcepts": [
+        "Erdős m(k) bound",
+        "Property B",
+        "first moment method",
+        "hypergraph 2-coloring"
+      ],
+      "prerequisites": [
+        "probabilistic method",
+        "uniform hypergraphs"
+      ]
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Enrichment: property-b-first-moment-oq-03 (Erdős Property B, first-moment method)

`sections[]` had a coverage gap (311–369 uncovered) and stopped at line 401, leaving lines 401–498 uncovered — two substantive blocks were undocumented, plus a 1-line overlap between `mixed-example` and `quantitative-first-moment` at line 122.

### Change
- **Fixed** the `mixed-example`/`quantitative-first-moment` overlap and closed the small head gaps.
- **Added** `Sharpness of the Strict First-Moment Criterion` (311–369): `mono_singleton`, `weighted_criterion_sharp`, `boundary_singleton_fin1` — the threshold ∑2^(1-|e|)<1 is sharp.
- **Added** `Converse: Weighted Lower Bound and Erdős m(k) ≥ 2^(k-1)` (401–498): `total_mono_incidence_eq`, `weighted_lower_bound_of_not_property_b`, `uniform_lower_bound_of_not_property_b`.
- Sections now cover lines **1–498 contiguously** (full file).

### Integrity
- Confirmed **0 axioms, 0 sorries** (the two `axiom` grep hits at lines 379/495 are the docstring phrases "axiom-free" / "Axiom audit: foundational axioms only"). `badge: "original"` accurate and unchanged.
- JSON validated; new sections carry `significance`/`relatedConcepts`/`prerequisites`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
