### PR TITLE
Enrich sylow-theorem-oq-04 (Simplicity of A₅ via Sylow): re-anchor 7 drifted sections to rewritten file (276→498), fix stale unused-lemma prose

### DIFF
--- a/src/data/proofs/sylow-theorem-oq-04/meta.json
+++ b/src/data/proofs/sylow-theorem-oq-04/meta.json
@@ -33,13 +33,13 @@
   "overview": {
     "historicalContext": "The simplicity of A₅ was first perceived by Évariste Galois (1811–1832), who recognized it as the fundamental obstruction to solving the general degree-5 polynomial by radicals. Galois' 1832 memoir (published posthumously in 1846) showed that the Galois group of a general quintic contains A₅ as a composition factor, and the non-abelian simplicity of A₅ makes it non-solvable. Niels Henrik Abel (1802–1829) and Paolo Ruffini (1765–1822) had earlier proved the impossibility of solving the quintic (Abel 1824, Ruffini 1799) by algebraic means, but Galois' theory provided the definitive structural explanation. Camille Jordan (1838–1922) systematized these ideas in his landmark 'Traité des substitutions et des équations algébriques' (1870), proving the Jordan-Hölder theorem and placing simplicity of alternating groups in a broader context. Ludwig Sylow's 1872 theorems provided the counting tools that make simplicity proofs tractable: by constraining n_p ≡ 1 (mod p) and n_p | m, one can determine the exact Sylow numbers and rule out normal subgroups. William Burnside (1852–1927) applied these methods extensively in his 1897 'Theory of Groups of Finite Order'. Today, A₅ ≅ PSL(2,5) ≅ I (icosahedral symmetry group) occupies a unique place at the base of the Classification of Finite Simple Groups: it is the smallest non-abelian simple group.",
     "problemStatement": "**Theorem**: The alternating group A₅ on 5 elements (order 60 = 2²·3·5) is simple: it has no proper nontrivial normal subgroups.\n\nAs a corollary: A₅ is not solvable, which implies the general quintic polynomial cannot be solved by radicals.\n\nThe proof uses two complementary approaches:\n1. **Sylow counting**: n₂ = 5, n₃ = 10, n₅ = 6 (all > 1), so no Sylow subgroup is normal.\n2. **Conjugacy classes**: A₅ has conjugacy class sizes {1, 12, 12, 15, 20}; no proper nontrivial union including the identity sums to a divisor of 60.",
-    "proofStrategy": "**Parts I–II**: Establish |A₅| = 60 and its prime factorization 2²·3·5 using `native_decide`.\n\n**Part III**: Apply Sylow III (from the parent SylowTheorem entry) to get divisibility and congruence constraints on each n_p.\n\n**Part IV**: Compute exact Sylow numbers by exhaustive enumeration over the 60-element group using `native_decide`: n₂ = 5, n₃ = 10, n₅ = 6.\n\n**Part V**: Since each n_p > 1, a uniqueness argument (via `Sylow.unique_of_normal`) shows no Sylow subgroup can be normal: if a Sylow p-subgroup P were normal, then `Sylow.unique_of_normal` gives `Subsingleton (Sylow p G)`, contradicting n_p > 1.\n\n**Part VI**: A `decide` computation over Boolean flags rules out all intermediate conjugacy class sums, confirming no proper divisor of 60 between 1 and 60 can be a union of conjugacy class sizes.\n\n**Parts VII–VIII**: Conclude A₅ is simple via Mathlib's `alternatingGroup.isSimpleGroup_five`, then derive non-solvability from simplicity using the A₅ → S₅ → ℤ/2 exact sequence and `Equiv.Perm.not_solvable`.",
+    "proofStrategy": "**Parts I–II**: Establish |A₅| = 60 and its prime factorization 2²·3·5 using `native_decide`.\n\n**Part III**: Apply Sylow III (from the parent SylowTheorem entry) to get divisibility and congruence constraints on each n_p.\n\n**Part IV**: Compute the exact Sylow numbers n₂ = 5, n₃ = 10, n₅ = 6. Because `Fintype.card (Sylow p A5)` is not directly enumerable (its `Fintype` instance is noncomputable), each n_p is obtained by building an *explicit* Sylow p-subgroup from concrete permutations, computing its normalizer as a literal `Finset` by `native_decide`, and applying `Sylow.card_eq_index_normalizer` with Lagrange (`Subgroup.card_mul_index`) to get n_p = [A₅ : N_{A₅}(Sₚ)]. Simplicity (`A5_isSimple`, delegated to Mathlib) is also proved here, since Part V consumes it.\n\n**Part V**: No Sylow p-subgroup is normal. A Sylow p-subgroup P has order p^(v_p 60) ∈ {4,3,5} by `Sylow.card_eq_multiplicity`, which is neither 1 nor 60; but simplicity forces a normal subgroup to be ⊥ or ⊤ (`A5_isSimple.eq_bot_or_eq_top_of_normal`), a contradiction closed by `omega`. This route is independent of the exact counts of Part IV.\n\n**Part VI**: A `decide` computation over Boolean flags rules out all intermediate conjugacy class sums, confirming no proper divisor of 60 between 1 and 60 can be a union of conjugacy class sizes.\n\n**Parts VII–VIII**: A₅ is simple via Mathlib's `alternatingGroup.isSimpleGroup (by simp)`; non-solvability then follows using the A₅ → S₅ → ℤ/2 exact sequence (`solvable_of_ker_le_range`) and `Equiv.Perm.not_solvable`.",
     "keyInsights": [
-      "The exact Sylow numbers n₂ = 5, n₃ = 10, n₅ = 6 can be computed by exhaustive enumeration over the 60-element group — a striking use of `native_decide` for group theory.",
+      "The exact Sylow numbers n₂ = 5, n₃ = 10, n₅ = 6 are recovered by building an explicit Sylow p-subgroup, brute-forcing its normalizer as a `Finset` with `native_decide`, and applying n_p = [G : N_G(Sₚ)] — a workaround for the fact that `Fintype (Sylow p A5)` is noncomputable, so `Fintype.card (Sylow p A5)` cannot itself be evaluated by `native_decide`.",
       "The conjugacy class approach gives a cleaner conceptual proof: a normal subgroup is a union of conjugacy classes, and a simple divisibility check (implemented as a Boolean decision procedure via `decide`) rules out all possibilities.",
       "Non-solvability of A₅ follows formally from simplicity via the short exact sequence A₅ → S₅ → ℤ/2: solvability is closed under extensions, so if A₅ were solvable, S₅ would be solvable, contradicting `Equiv.Perm.not_solvable`.",
       "Mathlib already contains `alternatingGroup.isSimpleGroup_five`, illustrating that proof by delegation to a library is valid when the wrapper adds significant pedagogical or computational content (the Sylow analysis and conjugacy class computation).",
-      "The pattern `Sylow.unique_of_normal P hPN` → `Fintype.card_unique` → contradiction with `n_p_eq` is reusable: it converts 'P is a normal Sylow p-subgroup' into 'n_p = 1', contradicting any known exact count n_p > 1."
+      "The non-normality argument is reusable and does not even need the exact Sylow counts: a Sylow p-subgroup has order p^(v_p |G|) by `Sylow.card_eq_multiplicity`, which for A₅ is 4, 3, or 5 — neither 1 (= |⊥|) nor 60 (= |⊤|). Since simplicity forces any normal subgroup to be ⊥ or ⊤ (`A5_isSimple.eq_bot_or_eq_top_of_normal`), a normal Sylow subgroup is impossible; `omega` closes the card contradiction."
     ],
     "prerequisites": [
       "Sylow's theorems (see sylow-theorem entry)",
@@ -54,50 +54,71 @@
       "id": "sec-sylow-oq04-header",
       "title": "Header, Imports, and Problem Setup",
       "startLine": 1,
-      "endLine": 31,
-      "description": "Module docstring stating the Sylow counting constraints for A₅ (n₂ ∈ {1,3,5,15}, n₃ ∈ {1,4,10}, n₅ ∈ {1,6}), the exact values (n₂=5, n₃=10, n₅=6), and the conjugacy class sizes {1,12,12,15,20}. References Sylow 1872, Rotman 1995, Dummit & Foote 2004. Opens namespace SylowA5 with the `alternatingGroup (Fin 5)` abbreviation."
+      "endLine": 33,
+      "description": "Module docstring stating the Sylow counting constraints for A₅ (n₂ ∈ {1,3,5,15}, n₃ ∈ {1,4,10}, n₅ ∈ {1,6}), the exact values (n₂=5, n₃=10, n₅=6), and the conjugacy class sizes {1,12,12,15,20}. References Sylow 1872, Rotman 1995, Dummit & Foote 2004. Imports `Mathlib` and `Mathlib.GroupTheory.SpecificGroups.Alternating.Simple`, then opens namespace `SylowA5`."
     },
     {
       "id": "sec-sylow-oq04-order",
-      "title": "Parts I–II: Order and Prime Factorization of |A₅| = 60",
-      "startLine": 33,
-      "endLine": 59,
-      "description": "Establishes |A₅| = 60 via `native_decide`, then computes the three p-adic valuations: v₂(60) = 2, v₃(60) = 1, v₅(60) = 1. These valuations determine the orders of Sylow subgroups (4, 3, 5 respectively) and their indices (15, 20, 12). All four theorems are proved by `native_decide`."
+      "title": "Part I: Order of A₅ = 60",
+      "startLine": 34,
+      "endLine": 49,
+      "description": "Defines `A5 := alternatingGroup (Fin 5)`, registers `Fact (Nat.Prime 5)` (needed for `Sylow 5 A5` statements), and proves `card_A5 : Fintype.card A5 = 60` by `native_decide`. The order 60 = 5!/2 is the arithmetic foundation for all subsequent Sylow analysis."
+    },
+    {
+      "id": "sec-sylow-oq04-factorization",
+      "title": "Part II: Prime Factorization 60 = 2²·3·5",
+      "startLine": 50,
+      "endLine": 64,
+      "description": "Computes the three p-adic valuations via `native_decide`: `val_60_at_2 : v₂(60) = 2`, `val_60_at_3 : v₃(60) = 1`, `val_60_at_5 : v₅(60) = 1`. These valuations determine the orders of the Sylow subgroups (2² = 4, 3, 5 respectively) and their indices in A₅ (15, 20, 12)."
     },
     {
       "id": "sec-sylow-oq04-constraints",
       "title": "Part III: Sylow Counting Constraints",
-      "startLine": 60,
-      "endLine": 97,
+      "startLine": 65,
+      "endLine": 103,
       "description": "Six theorems applying Sylow III to A₅. Three congruence constraints (n₂ ≡ 1 mod 2, n₃ ≡ 1 mod 3, n₅ ≡ 1 mod 5) via `card_sylow_modEq_one`. Three divisibility constraints (n₂ | [A₅:P₂]=15, n₃ | [A₅:P₃]=20, n₅ | [A₅:P₅]=12) via `card_sylow_dvd_index`. Together these constrain: n₂ ∈ {1,3,5,15}, n₃ ∈ {1,4,10}, n₅ ∈ {1,6}."
     },
     {
-      "id": "sec-sylow-oq04-exact",
-      "title": "Part IV: Exact Sylow Numbers by Exhaustive Enumeration",
-      "startLine": 99,
-      "endLine": 124,
-      "description": "Computes the exact Sylow numbers via `native_decide` over the 60-element group: n₂=5 (the five Klein 4-subgroups of A₅), n₃=10 (the ten cyclic subgroups ⟨(ijk)⟩ of order 3), n₅=6 (the six cyclic subgroups ⟨(ijklm)⟩ of order 5). The theorem `all_sylow_numbers_gt_one` packages these into a conjunction showing every n_p > 1 by omega after substituting the exact values."
+      "id": "sec-sylow-oq04-exact-n5",
+      "title": "Part IV: Explicit Sylow 5-Subgroup and n₅ = 6",
+      "startLine": 104,
+      "endLine": 190,
+      "description": "Establishes the exact-Sylow-number method: rather than evaluating `Fintype.card (Sylow p A5)` directly (impossible, since the `Fintype (Sylow p A5)` instance factors through the noncomputable `SetLike.instFintype`), the proof builds an *explicit* Sylow p-subgroup from concrete permutations, computes its normalizer as a literal `Finset` by `native_decide`, and recovers `n_p = [A₅ : N_{A₅}(Sₚ)]` via `Sylow.card_eq_index_normalizer` and Lagrange (`Subgroup.card_mul_index`). Carries this out for p = 5: the 5-cycle `c5`, its `Fin5` power set, the Sylow subgroup `S5`, its order-10 normalizer `NF5`, and finally `n5_eq : Fintype.card (Sylow 5 A5) = 6`."
+    },
+    {
+      "id": "sec-sylow-oq04-exact-n2",
+      "title": "Part IV (cont.): Explicit Sylow 2-Subgroup (Klein-four) and n₂ = 5",
+      "startLine": 191,
+      "endLine": 260,
+      "description": "Applies the same explicit-construction method to p = 2. Two commuting double-transpositions `ca2`, `cb2` generate a Klein-four subgroup with element set `Fin4 = {1, ca2, cb2, ca2·cb2}`; `H2` is the explicit Sylow 2-subgroup, its normalizer `NF2` (order 12, ≅ A₄) computed by `native_decide`, yielding `n2_eq : Fintype.card (Sylow 2 A5) = 5`."
+    },
+    {
+      "id": "sec-sylow-oq04-exact-n3",
+      "title": "Part IV (cont.): Explicit Sylow 3-Subgroup, n₃ = 10, and Simplicity",
+      "startLine": 261,
+      "endLine": 337,
+      "description": "Completes p = 3: the 3-cycle `c3`, its `Fin3` power set, Sylow subgroup `S3`, order-6 normalizer `NF3` (≅ S₃), and `n3_eq : Fintype.card (Sylow 3 A5) = 10`. Then `all_sylow_numbers_gt_one` packages n₂,n₃,n₅ > 1 by `omega`. Finally `A5_isSimple` is proved by delegation to `alternatingGroup.isSimpleGroup (by simp)` (Mathlib's simplicity for A_n, n ≥ 5) — placed here, ahead of the Part V banner, because the non-normality arguments below consume it."
     },
     {
       "id": "sec-sylow-oq04-nonnormal",
       "title": "Part V: Non-Normality of Sylow Subgroups",
-      "startLine": 126,
-      "endLine": 153,
-      "description": "Three theorems showing no Sylow p-subgroup of A₅ is normal, using the pattern: assume P is normal → `Sylow.unique_of_normal P hPN` gives `Subsingleton (Sylow p A5)` → `Fintype.card_unique` gives card = 1 → contradiction with n_p_eq (which gives 5, 10, or 6). The key lemma `Sylow.unique_of_normal` encapsulates: normality of a Sylow subgroup implies it is the unique conjugate, hence the only Sylow subgroup."
+      "startLine": 338,
+      "endLine": 378,
+      "description": "Three theorems (`sylow2_not_normal`, `sylow3_not_normal`, `sylow5_not_normal`) showing no Sylow p-subgroup of A₅ is normal. The argument is independent of the exact counts above: a Sylow p-subgroup P has `Nat.card P = p^(v_p 60)` via `Sylow.card_eq_multiplicity` (4, 3, 5 respectively, computed by `native_decide`), which is neither 1 = `Nat.card ⊥` nor 60 = `Nat.card ⊤`; but simplicity forces any normal subgroup to be ⊥ or ⊤ (`A5_isSimple.eq_bot_or_eq_top_of_normal`), so P is not normal — closed by `omega` on the card contradiction."
     },
     {
       "id": "sec-sylow-oq04-conjugacy",
       "title": "Part VI: Conjugacy Class Analysis via Boolean Decision",
-      "startLine": 154,
-      "endLine": 191,
-      "description": "The conjugacy class comment enumerates all 16 subsets of {12,12,15,20} (two distinct 12-element conjugacy classes treated as independent Boolean flags), showing no sum 1+… (between 1 and 59) divides 60. The theorem `no_intermediate_conjugacy_sum` encodes this as a universal statement over 4 Boolean flags, proved by `decide`. This provides an independent proof that A₅ has no proper nontrivial normal subgroup via the class equation."
+      "startLine": 379,
+      "endLine": 416,
+      "description": "The conjugacy class comment enumerates all subsets of {12,12,15,20} (the two distinct 12-element classes treated as independent Boolean flags), showing no sum 1+… strictly between 1 and 60 divides 60. The theorem `no_intermediate_conjugacy_sum` encodes this as a universal statement over 4 Boolean flags `∀ a b c d, s ∣ 60 → s = 1 ∨ s = 60`, proved by `decide`. This gives an independent proof (via the class equation) that A₅ has no proper nontrivial normal subgroup."
     },
     {
       "id": "sec-sylow-oq04-simplicity-corollaries",
       "title": "Parts VII–VIII: Simplicity, Non-Solvability, and Summary",
-      "startLine": 192,
-      "endLine": 276,
-      "description": "Part VII proves `A5_isSimple` by delegation to `alternatingGroup.isSimpleGroup_five` (Mathlib's verified proof for all n ≥ 5). Part VIII derives three corollaries: `A5_not_solvable` uses the short exact sequence A₅ → S₅ → ℤ/2 and `solvable_of_ker_le_range` to show S₅ solvable would follow, contradicting `Equiv.Perm.not_solvable`; `A5_normal_subgroups` shows the only normal subgroups are ⊥ and ⊤. The summary table catalogs all 18 results with their proof methods."
+      "startLine": 417,
+      "endLine": 498,
+      "description": "Part VII summarizes the simplicity argument (A5_isSimple was established in Part IV, ahead of its use). Part VIII derives two corollaries: `A5_not_solvable` shows that S₅ solvable would follow from A₅ solvable via `solvable_of_ker_le_range` on the sign homomorphism A₅ → S₅ → ℤ/2, contradicting `Equiv.Perm.not_solvable`; `A5_normal_subgroups` shows the only normal subgroups are ⊥ and ⊤ via `A5_isSimple.eq_bot_or_eq_top_of_normal`. Closes with a summary table cataloging all results with their methods and a `#check` block."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Enrichment pass: sylow-theorem-oq-04 (Simplicity of A₅ via Sylow's Theorems)

**Grown-file section drift.** The Lean file `Proofs/SylowTheoremOQ04.lean` was rewritten to build *explicit* Sylow p-subgroups (concrete permutations, literal-`Finset` normalizers, index-via-Lagrange), expanding it to 498 lines. The `meta.json` sections still described the old outline and stopped at line 276 (`maxSectionEnd = 276 « wc-l = 498`), leaving the entire back half of the file (Parts V–VIII, ~220 lines) unanchored.

### Changes (meta.json only)
- **Re-anchored all sections to the real `## Part` banners**, now covering lines **1–498 contiguously** (7 sections → 10). Split the 233-line Part IV computational core by prime (n₅ / n₂ / n₃ + simplicity) for navigability.
- **Fixed stale prose that contradicted the current Lean source:**
  - `proofStrategy` Part V and keyInsight #5 cited a `Sylow.unique_of_normal → Fintype.card_unique` pattern that **is not in the file**. The actual non-normality proof uses `Sylow.card_eq_multiplicity` + `A5_isSimple.eq_bot_or_eq_top_of_normal` (independent of the exact counts). Rewritten to match.
  - `proofStrategy` Part VII cited `alternatingGroup.isSimpleGroup_five`; the file uses `alternatingGroup.isSimpleGroup (by simp)`. Corrected.
  - keyInsight #1 / Part IV description refined to reflect the explicit-construction + normalizer-index method (needed because `Fintype (Sylow p A5)` is noncomputable), rather than a direct `native_decide` on the Sylow count.

### Integrity
`status: axiomatized`, `axiomCount: 1`, `Lean.ofReduceBool` disclosed — unchanged and consistent with the substantive `native_decide` calls (`card_A5`, normalizer `Finset`s, `card_eq_multiplicity` reductions). No status/badge changes. Existing overview, historicalContext, conclusion, and crossReferences preserved. File 17.5 KB, well under the 60 KB cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
