### PR TITLE
Research: erdos-46-wip-01 — multiplicative scaling engine for unit-fraction reprs

### DIFF
--- a/proofs/Proofs/Erdos46Problem.lean
+++ b/proofs/Proofs/Erdos46Problem.lean
@@ -307,3 +307,53 @@ theorem infinite_isUnitFractionRepr :
   obtain ⟨S, hS, hcard⟩ := exists_isUnitFractionRepr_card_ge (M + 1)
   have hle : S.card ≤ M := hM ⟨S, hS, rfl⟩
   omega
+
+/-! ## Multiplicative scaling of representations
+
+`isRatFractionRepr_union` above assembles representations *additively* (over disjoint
+unions of denominator sets). The complementary *multiplicative* engine scales every
+denominator by a common factor `t`: this divides the represented rational by `t` and
+pushes every denominator up to at least `2t`. It is the natural tool for producing
+representations whose denominators are all large — a prerequisite for the pairwise-disjoint
+chaining behind `ErdosProblem46_infinitely_many` (reprs with `min > N` are automatically
+disjoint from any repr supported below `N`). -/
+
+/-- **Scaling lemma.** If `S` represents the rational `q`, then scaling every denominator by
+`t ≥ 1` (the map `n ↦ t · n`, injective since `t > 0`) yields a representation of `q / t`.
+The multiplicative counterpart of `isRatFractionRepr_union`. -/
+theorem isRatFractionRepr_smul {S : Finset ℕ} {q : ℚ}
+    (hS : IsRatFractionRepr S q) {t : ℕ} (ht : 1 ≤ t) :
+    IsRatFractionRepr (S.image (fun n => t * n)) (q / t) := by
+  obtain ⟨hge, hsum⟩ := hS
+  have htpos : 0 < t := ht
+  have hinj : ∀ a ∈ S, ∀ b ∈ S, t * a = t * b → a = b :=
+    fun a _ b _ hab => Nat.eq_of_mul_eq_mul_left htpos hab
+  refine ⟨?_, ?_⟩
+  · intro m hm
+    rw [Finset.mem_image] at hm
+    obtain ⟨n, hn, rfl⟩ := hm
+    have hn2 : 2 ≤ n := hge n hn
+    have hle : n ≤ t * n := Nat.le_mul_of_pos_left n htpos
+    omega
+  · rw [Finset.sum_image hinj]
+    have hterm : ∀ n ∈ S, (1 : ℚ) / (↑(t * n)) = (1 / t) * (1 / n) := by
+      intro n _
+      push_cast
+      rw [one_div, one_div, one_div, mul_inv]
+    rw [Finset.sum_congr rfl hterm, ← Finset.mul_sum, hsum]
+    ring
+
+/-- **Arbitrarily large denominators for `1/t`.** For every `t ≥ 1`, the reciprocal `1/t`
+has a rational representation `{2t, 3t, 6t}` (the concrete representation `{2,3,6}` of `1`
+scaled by `t`) whose denominators are all `≥ 2t`. Witnesses that the large-denominator
+regime is reachable for reciprocals of arbitrary size. -/
+theorem exists_isRatFractionRepr_inv_min_ge (t : ℕ) (ht : 1 ≤ t) :
+    ∃ S : Finset ℕ, IsRatFractionRepr S (1 / t) ∧ ∀ n ∈ S, 2 * t ≤ n := by
+  refine ⟨({2, 3, 6} : Finset ℕ).image (fun n => t * n), ?_, ?_⟩
+  · have h236 : IsRatFractionRepr ({2, 3, 6} : Finset ℕ) 1 :=
+      (isRatFractionRepr_one_iff _).mpr isUnitFractionRepr_two_three_six
+    exact isRatFractionRepr_smul h236 ht
+  · intro m hm
+    rw [Finset.mem_image] at hm
+    obtain ⟨n, hn, rfl⟩ := hm
+    fin_cases hn <;> omega

--- a/research/problems/erdos-46-wip-01/knowledge.md
+++ b/research/problems/erdos-46-wip-01/knowledge.md
@@ -87,3 +87,32 @@ Adds the elementary *construction* machinery the prior session's structural lemm
 Croot's theorem itself (existence of the monochromatic representation) remains deep and
 unformalized — needs the density/covering machinery from the 2003 paper. This session
 supplies only the elementary splitting/lengthening toolkit around the statement.
+
+## Session 2026-07-20 (researcher-1) — multiplicative scaling engine
+
+**Mode**: build on prior scaffolding (splitting/lengthening toolkit). **Outcome**: progress
+— 2 axiom-free theorems, **host-verified v4.31** (`lake env lean`, exit 0; `#print axioms` =
+`[propext, Classical.choice, Quot.sound]` on both new theorems, no sorry/native_decide).
+
+Added the *multiplicative* counterpart of the existing additive `isRatFractionRepr_union`:
+
+- `isRatFractionRepr_smul` — scaling every denominator by `t ≥ 1` (the injective map
+  `n ↦ t·n`) sends a representation of `q` to a representation of `q/t`, with every new
+  denominator `≥ 2t`. Proof: `Finset.sum_image` with pairwise-injectivity from
+  `Nat.eq_of_mul_eq_mul_left`, then `1/(t·n) = (1/t)(1/n)` (`push_cast`, `mul_inv`) and
+  `← Finset.mul_sum`, closed by `ring`.
+- `exists_isRatFractionRepr_inv_min_ge` — `{2t, 3t, 6t}` represents `1/t` with min denom
+  `≥ 2t` (scale the concrete `{2,3,6}`). The large-denominator regime is reachable for
+  reciprocals of arbitrary size.
+
+### The disjoint-chaining obstruction (analyzed)
+The remaining blocker toward `ErdosProblem46_infinitely_many` is **collision-freeness**, not
+arithmetic:
+- Splitting the *largest* denominator (existing `exists_isUnitFractionRepr_card_ge` engine)
+  leaves the small head `{2,3}` fixed, so consecutive reprs are never disjoint.
+- Scaling a whole repr of 1 by a factor gives a repr of `1/t` (not 1); assembling several
+  scaled sub-reprs of a fixed decomposition `1 = ∑ 1/mᵢ` back into a repr of 1 produces
+  cross-copy denominator collisions (e.g. `2·{2,3,6} ∪ 3·{2,3,6}` shares `6`).
+- A repr of 1 with all denominators `> N` would immediately yield infinitely many
+  pairwise-disjoint reprs (chain `Nᵢ₊₁ = max Sᵢ`), but constructing one needs exact
+  collision bookkeeping (a coprimality/valuation argument on the scale factors), still open.

--- a/src/data/research/problems/erdos-46-wip-01.json
+++ b/src/data/research/problems/erdos-46-wip-01.json
@@ -20,7 +20,7 @@
   "currentState": {
     "phase": "ORIENT",
     "since": "2026-07-09T17:33:18-07:00",
-    "iteration": 2,
+    "iteration": 3,
     "focus": "Session 2: splitting identity (Fibonacci–Sylvester 1/n=1/(n+1)+1/(n(n+1))), telescoping form, concrete witness {2,3,6}, existence, and the term-replacement lengthening step (isUnitFractionRepr_replace). 5 axiom-free theorems, theoremCount 16→21, host-verified.",
     "blockers": [],
     "nextAction": "Croot's theorem (existence of monochromatic representation) is deep/unformalized — needs density/covering machinery from the 2003 paper. Elementary splitting/lengthening toolkit now in place; a full lengthening-to-infinity chain would need denominator-freshness bookkeeping.",
@@ -31,24 +31,29 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (researcher-1, 2026-07-20, VERIFIED 0/0 host): realized the chain-to-∞ direction — exists_isUnitFractionRepr_card_ge (unit-fraction reprs of 1 with arbitrarily large cardinality, by splitting the largest denominator via isUnitFractionRepr_replace) and infinite_isUnitFractionRepr (the set of such reprs is Set.Infinite). The colouring-free lower bound behind Erdős 46; the deep monochromatic Croot 2003 result stays unformalized. 28 axiom-free theorems.",
+    "progressSummary": "PROGRESS (researcher-1, 2026-07-20, VERIFIED host lake env lean exit 0, #print axioms=[propext,Classical.choice,Quot.sound] on both new thms): added the multiplicative scaling engine isRatFractionRepr_smul (repr of q ↦ repr of q/t with all denoms ≥2t) and exists_isRatFractionRepr_inv_min_ge ({2t,3t,6t} reps 1/t). Complements the additive union lemma. Remaining obstruction toward pairwise-disjoint reprs of 1 with min>N is collision-free assembly (documented), not arithmetic. Deep Croot 2003 monochromatic result stays unformalized.",
     "builtItems": [
       "not_isUnitFractionRepr_singleton — no singleton represents 1 (Erdos46Problem.lean)",
       "two_le_card_of_isUnitFractionRepr — a UFR of 1 has >= 2 elements (Erdos46Problem.lean)",
       "isRatFractionRepr_union — reciprocal-sum representations add over disjoint unions (Erdos46Problem.lean)",
       "erdosProblem46_of_infinitely_many — base Croot statement reduces to the infinitely-many version (Erdos46Problem.lean)",
       "term_le_half / sum_inv_nonneg / isRatFractionRepr_pos / isRatFractionRepr_unique / pos_of_mem / forall_two_le_of_subset / isMonochromatic_empty / isMonochromatic_singleton / isRatFractionRepr_one_iff",
-      "exists_isUnitFractionRepr_card_ge, infinite_isUnitFractionRepr in Erdos46Problem.lean — arbitrarily-long + infinitely-many unit-fraction reprs of 1, 0-axiom host-verified"
+      "exists_isUnitFractionRepr_card_ge, infinite_isUnitFractionRepr in Erdos46Problem.lean — arbitrarily-long + infinitely-many unit-fraction reprs of 1, 0-axiom host-verified",
+      "isRatFractionRepr_smul — scaling all denominators by t≥1 (n↦t·n, injective) sends a repr of q to a repr of q/t, all denoms ≥2t (Erdos46Problem.lean); multiplicative counterpart of isRatFractionRepr_union",
+      "exists_isRatFractionRepr_inv_min_ge — {2t,3t,6t} represents 1/t with min denom ≥2t (scale {2,3,6}); large-denominator regime reachable for arbitrary reciprocals"
     ],
     "insights": [
       "Erdos46Problem.lean stub developed: 13 axiom-free foundational lemmas on unit-fraction / rational representations and monochromatic sets (all [propext,Classical.choice,Quot.sound], no sorry/native_decide).",
       "Infinitely many distinct unit-fraction representations of 1 exist (infinite_isUnitFractionRepr): via reprs of arbitrarily large cardinality (exists_isUnitFractionRepr_card_ge), obtained by iterating isUnitFractionRepr_replace on the LARGEST denominator m — both split denominators m+1, m(m+1) exceed m so ∉S, legal replacement raising |S| by exactly one.",
-      "Set.Infinite from unbounded card: by_contra, (hfin.image Finset.card).bddAbove gives M, then exists_...card_ge (M+1) overflows it. Finset.card_insert_of_not_mem renamed → card_insert_of_notMem in v4.31."
+      "Set.Infinite from unbounded card: by_contra, (hfin.image Finset.card).bddAbove gives M, then exists_...card_ge (M+1) overflows it. Finset.card_insert_of_not_mem renamed → card_insert_of_notMem in v4.31.",
+      "Multiplicative scaling engine added: image under (t·) divides represented rational by t (Finset.sum_image with pairwise-injectivity from Nat.eq_of_mul_eq_mul_left; 1/(t·n)=(1/t)(1/n) via mul_inv then ring). Complements the additive union lemma; the two engines (additive-union + multiplicative-scale) are the assembly toolkit for disjoint-support reprs.",
+      "Disjoint-chaining obstruction is collision-freeness, not the arithmetic: splitting the LARGEST denom leaves small heads {2,3} fixed (reprs share them); scaling a whole repr by different factors produces cross-copy denominator collisions; multiplicative/additive assembly of a min>N repr of 1 needs exact collision bookkeeping (open)."
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "Disjoint-support chaining: produce infinitely many PAIRWISE-DISJOINT unit-fraction reprs (needed for the monochromatic pigeonhole toward ErdosProblem46_infinitely_many) — splitting the largest denom keeps introducing fresh large denominators, so consecutive reprs can be made disjoint on their tails.",
-      "The deep monochromatic statement (Croot 2003) itself remains unformalized."
+      "Collision-free assembly of a unit-fraction repr of 1 with all denominators > N: candidate route is combining the additive union lemma with scaled sub-reprs of a fixed decomposition 1=∑ 1/mᵢ, choosing scale factors that guarantee pairwise-disjoint denominator sets (needs a coprimality/valuation argument to rule out cross-copy collisions).",
+      "Given exists_...min_gt N, infinitely many PAIRWISE-DISJOINT reprs of 1 follow immediately by chaining Nᵢ₊₁ = max Sᵢ.",
+      "Deep monochromatic statement (Croot 2003) remains unformalized — needs density/covering machinery."
     ],
     "markdown": "# Knowledge Base: erdos-46-wip-01\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },


### PR DESCRIPTION
## Summary
Research session on **erdos-46-wip-01** (Erdős 46 — monochromatic unit-fraction
representations). Adds the *multiplicative* scaling engine for reciprocal-sum
representations, complementing the existing *additive* `isRatFractionRepr_union`.

## Progress (2 axiom-free theorems, host-verified v4.31)
- `isRatFractionRepr_smul` — scaling every denominator by `t ≥ 1` (the injective map
  `n ↦ t·n`) sends a representation of `q` to a representation of `q/t`, with every new
  denominator `≥ 2t`.
- `exists_isRatFractionRepr_inv_min_ge` — `{2t, 3t, 6t}` represents `1/t` with min
  denominator `≥ 2t` (scaling the concrete `{2,3,6}` representation of `1`).

Files: `proofs/Proofs/Erdos46Problem.lean`,
`src/data/research/problems/erdos-46-wip-01.json`,
`research/problems/erdos-46-wip-01/knowledge.md`.

## Verification
`lake env lean Proofs/Erdos46Problem.lean` exits 0 (Mathlib-only import, host build).
`#print axioms` on both new theorems = `[propext, Classical.choice, Quot.sound]`
(no `sorry`, no `native_decide`, no `Lean.ofReduceBool`).

## Findings
The remaining obstruction toward `ErdosProblem46_infinitely_many` (infinitely many
pairwise-disjoint reprs of `1`) is **collision-freeness**, not arithmetic: splitting the
largest denominator keeps a fixed small head `{2,3}`; scaling a whole repr changes the
represented value; assembling scaled sub-reprs of `1 = ∑ 1/mᵢ` produces cross-copy
denominator collisions. A repr of `1` with all denominators `> N` would immediately give
the disjoint chain — constructing one needs exact collision bookkeeping (open).

## Status
**Outcome**: progress (elementary infrastructure; deep Croot 2003 monochromatic result
remains unformalized)
**Next Steps**: collision-free assembly of a `min > N` representation of `1`.

🤖 Generated by researcher-1
