### PR TITLE
Fix erdos-658: remove false/inconsistent axiom small_case_2x2

### DIFF
--- a/proofs/Proofs/Erdos658Problem.lean
+++ b/proofs/Proofs/Erdos658Problem.lean
@@ -209,17 +209,6 @@ Concrete examples for small grids.
 -/
 
 /--
-**Example: 2×2 grid**
-Any 3 points in the 2×2 grid contain a square vertex set.
-(In fact, any 3 points of a 2×2 grid contain 3 corners of a square.)
--/
-/- small_case_2x2: Any 3 points in a 2×2 grid contain a square
-   (3 corners suffice by pigeonhole on the 2 rows). Proof requires case analysis. -/
-axiom small_case_2x2 :
-    ∀ A : Finset (ℕ × ℕ), A ⊆ grid 2 → A.card ≥ 3 →
-      containsAxisAlignedSquare A
-
-/--
 **Density threshold for 3×3:**
 In a 3×3 grid, having at least 5 points guarantees a square.
 -/

--- a/src/data/proofs/erdos-658/meta.json
+++ b/src/data/proofs/erdos-658/meta.json
@@ -51,13 +51,12 @@
       "GrahamConjectureAxisAligned: formal statement of the conjecture",
       "graham_axis_aligned_true axiom: the main result",
       "density_hales_jewett axiom: the underlying deep theorem (Furstenberg-Katznelson 1991)",
-      "small_case_2x2 axiom: 2×2 base case (any 3 points in 2×2 grid contain a square)",
       "erdos_658 theorem: main result",
       "erdos_658_answer theorem: final answer"
     ],
-    "axiomCount": 3,
-    "lineCount": 295,
-    "assumptions": "3 axioms: graham_axis_aligned_true (main result), density_hales_jewett (Furstenberg-Katznelson 1991), small_case_2x2 (2×2 base case). 0 sorries.",
+    "axiomCount": 2,
+    "lineCount": 285,
+    "assumptions": "2 axioms: graham_axis_aligned_true (main result), density_hales_jewett (Furstenberg-Katznelson 1991). 0 sorries.",
     "theoremCount": 6,
     "definitionCount": 8
   },
@@ -65,7 +64,7 @@
     "historicalContext": "**Erdős Problem #658: Squares in Dense Grid Subsets**\n\nThis problem, attributed to Graham, asks a natural geometric question: if you have enough points in an N×N grid, must some four of them form the vertices of a square?\n\n**Key History:**\n- Graham: Posed the problem for axis-aligned squares\n- Erdős [Er97e]: Included in his list of favorite unsolved problems (ambiguous about axis-alignment)\n- Furstenberg-Katznelson (1991): Proved qualitatively via the density Hales-Jewett theorem\n- Solymosi (2004): Gave the first quantitative proof with explicit bounds\n\n**Mathematical Setting:**\nThe problem connects discrete geometry with additive combinatorics. The proof uses the density Hales-Jewett theorem, one of the deepest results in the field, showing that dense sets in high-dimensional spaces must contain combinatorial structures.",
     "problemStatement": "**Problem Statement (Proved)**\n\nLet $\\delta > 0$ and $N$ be sufficiently large depending on $\\delta$. Is it true that if $A \\subseteq \\{1,\\ldots,N\\}^2$ has $|A| \\geq \\delta N^2$ then $A$ must contain the vertices of a square?\n\n**Answer: YES**\n\nFurstenberg and Katznelson (1991) proved this follows from the density Hales-Jewett theorem. Solymosi (2004) gave explicit (but very large, tower-type) bounds on N₀(δ).",
     "text": "Do dense subsets of the N×N grid contain squares? YES, proved via density Hales-Jewett (Furstenberg-Katznelson 1991), with quantitative bounds by Solymosi (2004).",
-    "proofStrategy": "**Formalization Approach**\n\n1. **Grid and Squares:** Define the N×N grid and what it means for four points to form a square\n\n2. **Density:** Define δ-dense subsets where |A| ≥ δN²\n\n3. **Main Conjecture:** State GrahamConjectureAxisAligned formally\n\n4. **Key Axioms:**\n   - graham_axis_aligned_true: The main theorem\n   - density_hales_jewett: The underlying deep result (Furstenberg-Katznelson 1991)\n   - small_case_2x2: 2×2 base case axiom\n\n5. **Connections:** Link to Hales-Jewett and higher-dimensional generalizations",
+    "proofStrategy": "**Formalization Approach**\n\n1. **Grid and Squares:** Define the N×N grid and what it means for four points to form a square\n\n2. **Density:** Define δ-dense subsets where |A| ≥ δN²\n\n3. **Main Conjecture:** State GrahamConjectureAxisAligned formally\n\n4. **Key Axioms:**\n   - graham_axis_aligned_true: The main theorem\n   - density_hales_jewett: The underlying deep result (Furstenberg-Katznelson 1991)\n\n5. **Connections:** Link to Hales-Jewett and higher-dimensional generalizations",
     "keyInsights": [
       "**Density Forces Structure:** Sufficiently dense sets in grids must contain geometric patterns like squares",
       "**Hales-Jewett Connection:** The proof reduces to the density Hales-Jewett theorem, a cornerstone of additive combinatorics",
@@ -115,18 +114,18 @@
     {
       "id": "solymosi-bounds",
       "title": "Bounds and Small Cases",
-      "summary": "small_case_2x2 axiom (2×2 base case); Solymosi quantitative bounds discussed in comments only",
+      "summary": "Solymosi quantitative bounds discussed in comments only",
       "startLine": 202,
       "endLine": 229,
-      "mathContext": "Axiomatized: small_case_2x2 (any 3 points in a 2×2 grid contain a square). Solymosi (2004) tower-type bounds on N₀(δ) are described in section comments but not formalized as axioms in this file."
+      "mathContext": "Solymosi (2004) tower-type bounds on N₀(δ) are described in section comments but not formalized as axioms in this file."
     },
     {
       "id": "examples",
       "title": "Small Cases and Examples",
-      "summary": "small_case_2x2 axiom, density_threshold_3x3",
+      "summary": "density_threshold_3x3",
       "startLine": 230,
       "endLine": 266,
-      "mathContext": "Mathematical content: small_case_2x2 axiom, density_threshold_3x3. Non-square-free configurations for small N are discussed in comments only, not formalized."
+      "mathContext": "Mathematical content: density_threshold_3x3. Non-square-free configurations for small N are discussed in comments only, not formalized."
     },
     {
       "id": "generalizations",
@@ -168,8 +167,8 @@
       "Finset"
     ],
     "namespace": "Erdos658",
-    "lineCount": 295,
-    "axiomCount": 3,
+    "lineCount": 285,
+    "axiomCount": 2,
     "theoremCount": 6,
     "definitionCount": 8,
     "path": "Proofs/Erdos658Problem.lean",


### PR DESCRIPTION
## Summary

Removes the false, unused axiom `small_case_2x2` from `Erdos658Problem.lean`, which made the file's axiom environment inconsistent (the Lean kernel could derive `False`).

## The problem (auditor issue #40025)

`small_case_2x2` asserted:

    ∀ A : Finset (ℕ × ℕ), A ⊆ grid 2 → A.card ≥ 3 → containsAxisAlignedSquare A

But `containsAxisAlignedSquare` requires **all four** square corners. In `grid 2` (4 points), the only square needs all 4. A 3-point subset such as `{(0,0),(1,0),(0,1)}` (missing `(1,1)`) satisfies the hypotheses yet contains no square — so the axiom is false, and any theorem in the file is vacuously derivable.

## Fix

Per the auditor's primary recommendation (the axiom is decorative and **unused** by `erdos_658 := graham_axis_aligned_true`): remove it.

- **Lean**: deleted the `axiom small_case_2x2` declaration and its doc/comment block. Verified no remaining references (`grep small_case` → none). The main axiom `graham_axis_aligned_true` and `density_hales_jewett` are untouched.
- **meta.json**: `axiomCount` 3 → 2 (both `leanFile` blocks); `lineCount` 295 → 285; rewrote `assumptions` to list the 2 remaining axioms; removed `small_case_2x2` from `originalContributions` and `proofStrategy`; updated the two `sections` entries whose summary/mathContext named the removed axiom.

## Verification

Removing an unused `axiom` declaration cannot break compilation (it is referenced nowhere, and the following declaration keeps its own docstring). JSON validated with `python3 -m json.tool`.

Closes #40025
