### PR TITLE
Research: erdos-116-wip-01 — finiteness of the lemniscate's planar measure

### DIFF
--- a/proofs/Proofs/Erdos116WIP01.lean
+++ b/proofs/Proofs/Erdos116WIP01.lean
@@ -97,4 +97,39 @@ theorem isBounded_sublevelSet (P : UnitDiskPoly n) :
     Bornology.IsBounded P.sublevelSet :=
   (Metric.isBounded_closedBall).subset P.sublevelSet_subset_closedBall
 
+/-! ## Finiteness of the 2D Lebesgue measure
+
+`Sₚ` is bounded and measurable, so its planar Lebesgue measure is finite.  This is
+exactly the well-definedness the parent's `sublevelMeasure` needs: it is defined as the
+`.toReal` of a `volume`, which is a faithful value (rather than the `⊤ ↦ 0` truncation)
+only when that `volume` is finite. -/
+
+/-- **`volume Sₚ < ⊤`** (`ℂ`-side).  `Sₚ ⊆ closedBall 0 2`, and a closed ball in the
+proper space `ℂ` is compact, hence of finite volume. -/
+theorem volume_sublevelSet_lt_top (P : UnitDiskPoly n) :
+    volume P.sublevelSet < ⊤ :=
+  measure_lt_top_of_subset P.sublevelSet_subset_closedBall
+    (isCompact_closedBall (0 : ℂ) 2).measure_lt_top.ne
+
+/-- The parent's `ℝ × ℝ` sublevel set is the preimage of `Sₚ ⊆ ℂ` under the measurable
+equivalence `ℂ ≃ᵐ ℝ × ℝ` (its inverse `(a, b) ↦ a + b·I`). -/
+theorem realProd_sublevelSet_eq_preimage (P : UnitDiskPoly n) :
+    {p : ℝ × ℝ | Complex.abs (P.eval ⟨p.1, p.2⟩) < 1}
+      = Complex.measurableEquivRealProd.symm ⁻¹' P.sublevelSet := by
+  ext p
+  simp only [Set.mem_setOf_eq, Set.mem_preimage,
+    Complex.measurableEquivRealProd_symm_apply]
+  rfl
+
+/-- **`sublevelMeasure` is well-defined: the parent's `ℝ × ℝ` measure is finite.**  Via
+the volume-preserving equivalence `ℂ ≃ᵐ ℝ × ℝ`, the planar measure of the parent's
+sublevel set equals `volume Sₚ`, which is finite by `volume_sublevelSet_lt_top`.  Hence
+`sublevelMeasure P = (that volume).toReal` faithfully records the area of the lemniscate. -/
+theorem volume_realProd_sublevelSet_lt_top (P : UnitDiskPoly n) :
+    volume {p : ℝ × ℝ | Complex.abs (P.eval ⟨p.1, p.2⟩) < 1} < ⊤ := by
+  rw [P.realProd_sublevelSet_eq_preimage]
+  have hmp := Complex.volume_preserving_equiv_real_prod.symm Complex.measurableEquivRealProd
+  rw [hmp.measure_preimage P.measurableSet_sublevelSet.nullMeasurableSet]
+  exact P.volume_sublevelSet_lt_top
+
 end UnitDiskPoly

--- a/research/problems/erdos-116-wip-01/knowledge.md
+++ b/research/problems/erdos-116-wip-01/knowledge.md
@@ -102,3 +102,30 @@ for v4.31 (`Complex.abs` removed). `simp [Complex.abs]` unfolds the shim; `Compl
 **Still open (Mathlib infra gap)**: the four deep bounds (Pommerenke `c/n⁴`, KLR `c/log n` & `C/loglog n`,
 Pólya `π`) need logarithmic-potential / planar-measure-of-lemniscate machinery absent from Mathlib v4.31.
 Next foundational step: prove `sublevelSet` is open/measurable (`p` continuous).
+
+## Session 2026-07-20 (researcher-1) — finiteness / well-definedness of sublevelMeasure
+
+**Mode**: build on Key lemma 1 (open/measurable/bounded). **Outcome**: progress — 3
+axiom-free theorems, **host-verified v4.31** (`lake env lean` exit 0; `#print axioms` =
+`[propext, Classical.choice, Quot.sound]` on all three; no sorry/native_decide).
+
+The parent (`Erdos116Problem.lean`) defines
+`sublevelMeasure P := (volume {p:ℝ×ℝ | Complex.abs (P.eval ⟨p.1,p.2⟩) < 1}).toReal`.
+This `.toReal` is only faithful when the underlying `volume` is finite (otherwise `⊤`
+truncates to `0`). This session discharges that finiteness:
+
+- `volume_sublevelSet_lt_top` — `volume Sₚ < ⊤` on the ℂ side: `Sₚ ⊆ closedBall 0 2`
+  (previous session), the closed ball is compact in the proper space `ℂ`, and `volume`
+  is finite on compacts (`isCompact_closedBall` + `IsCompact.measure_lt_top`, then
+  `measure_lt_top_of_subset`).
+- `realProd_sublevelSet_eq_preimage` — the parent's `ℝ×ℝ` set equals
+  `Complex.measurableEquivRealProd.symm ⁻¹' Sₚ` (the inverse equiv sends `(a,b) ↦ {re:=a,im:=b}`).
+- `volume_realProd_sublevelSet_lt_top` — the parent's planar measure is finite, obtained by
+  transporting via `Complex.volume_preserving_equiv_real_prod.symm` +
+  `MeasurePreserving.measure_preimage` (needs `NullMeasurableSet`, from
+  `measurableSet_sublevelSet.nullMeasurableSet`) down to the ℂ-side bound.
+
+**Now saturated**: the elementary topology + measure-theoretic well-definedness layer
+(open, measurable, bounded, finite planar measure). Remaining targets are the deep
+quantitative bounds — Pólya `π` upper bound and KLR `c/log n` lower bound — which rest on
+logarithmic-potential / area-of-lemniscate machinery absent from Mathlib.

--- a/src/data/research/problems/erdos-116-wip-01.json
+++ b/src/data/research/problems/erdos-116-wip-01.json
@@ -29,7 +29,7 @@
         "blockedAt": "2026-07-20"
       }
     ],
-    "nextAction": "Finiteness of sublevelMeasure: Sₚ bounded+measurable ⟹ finite 2D Lebesgue measure; bridge the parent ℝ×ℝ sublevel set to Sₚ⊆ℂ via the ℂ≅ℝ² measure iso, then measure_lt_top.",
+    "nextAction": "The remaining targets are the deep quantitative bounds: Pólya π upper bound (area ≤ π, most self-contained but needs planar Lebesgue-of-lemniscate infra Mathlib lacks) and KLR c/log n lower bound (logarithmic potential theory). Elementary well-definedness layer now saturated.",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -37,10 +37,13 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: New file proofs/Proofs/Erdos116WIP01.lean discharges Key lemma 1 — the polynomial lemniscate Sₚ={z:|p(z)|<1} is open, measurable, and bounded (Sₚ ⊆ closedBall 0 2), all 0-axiom/0-sorry, host-verified [propext, Classical.choice, Quot.sound]. Built directly from the root product p(z)=∏(z-zᵢ). The deep KLR c/log n lower bound and Pólya π upper bound remain isolated (potential theory, not in Mathlib).",
+    "progressSummary": "PROGRESS (researcher-1, 2026-07-20, host-verified lake env lean exit 0, #print axioms=[propext,Classical.choice,Quot.sound] on all 3): sublevelMeasure well-definedness discharged — volume Sₚ<⊤ (ℂ-side, compact closed ball) and, via the volume-preserving ℂ≃ᵐℝ² equiv, the parent ℝ×ℝ sublevel measure is finite, so sublevelMeasure=(volume).toReal is faithful. Key lemma 1 (open/measurable/bounded) done previously. Deep KLR c/log n lower and Pólya π upper bounds remain unformalized (potential theory not in Mathlib).",
     "builtItems": [
       "UnitDiskPoly.eval_root_eq_zero / root_mem_sublevelSet / sublevelSet_nonempty / eval_of_degree_zero / sublevelSet_of_degree_zero / sublevelMeasure_nonneg in proofs/Proofs/Erdos116Problem.lean (6 axiom-free foundational theorems; host-verified v4.31, #print axioms = propext/Classical.choice/Quot.sound only)",
-      "proofs/Proofs/Erdos116WIP01.lean — 6 axiom-free decls (continuous_eval, sublevelSet_eq_preimage, isOpen_sublevelSet, measurableSet_sublevelSet, sublevelSet_subset_closedBall, isBounded_sublevelSet)"
+      "proofs/Proofs/Erdos116WIP01.lean — 6 axiom-free decls (continuous_eval, sublevelSet_eq_preimage, isOpen_sublevelSet, measurableSet_sublevelSet, sublevelSet_subset_closedBall, isBounded_sublevelSet)",
+      "volume_sublevelSet_lt_top — volume Sₚ < ⊤: Sₚ⊆closedBall 0 2, compact in proper space ℂ, finite measure (Erdos116WIP01.lean)",
+      "realProd_sublevelSet_eq_preimage — parent ℝ×ℝ sublevel set = measurableEquivRealProd.symm ⁻¹ Sₚ (Erdos116WIP01.lean)",
+      "volume_realProd_sublevelSet_lt_top — parent sublevelMeasure volume is finite, via volume-preserving ℂ≃ᵐℝ² (Erdos116WIP01.lean)"
     ],
     "insights": [
       "Erdos116Problem.lean was a bare statement-stub: real definitions (UnitDiskPoly, eval, sublevelSet, sublevelMeasure) but ZERO theorems, while gallery meta prose falsely described four bounds \"stated as axioms\" and a main theorem ErdosProblem116 that did not exist in source.",
@@ -48,12 +51,15 @@
       "The four quantitative bounds (Pommerenke c/n^4, KLR c/log n, KLR C/loglog n, Polya pi) need logarithmic-potential / planar-measure machinery absent from Mathlib v4.31 — not formalizable without substantial new infrastructure; correctly left as documented prose, not axioms.",
       "Sₚ = {z : |p(z)|<1} is OPEN: it is the continuous preimage of the open ray Set.Iio 1 under z ↦ ‖p(z)‖; p(z)=∏(z-zᵢ) is continuous via continuous_finsetProd. Hence measurable (IsOpen.measurableSet).",
       "Sₚ ⊆ closedBall 0 2 (BOUNDED): if ‖z‖>2 then each factor ‖z-zᵢ‖ ≥ ‖z‖-‖zᵢ‖ ≥ ‖z‖-1 > 1 (roots in unit disk), so ‖p(z)‖=∏‖z-zᵢ‖ ≥ 1 and z∉Sₚ. Holds for all n incl. n=0 (Sₚ=∅).",
-      "Lean gotcha: Finset.one_le_prod does NOT work on ℝ (needs MulLeftMono ℝ, false for a field with negatives). Use Finset.prod_le_prod against the constant-1 product: 1 = ∏ 1 ≤ ∏ f via Finset.prod_const_one. norm_prod rewrites ‖∏ f‖ = ∏ ‖f‖; norm_sub_norm_le for the reverse-triangle per-factor bound."
+      "Lean gotcha: Finset.one_le_prod does NOT work on ℝ (needs MulLeftMono ℝ, false for a field with negatives). Use Finset.prod_le_prod against the constant-1 product: 1 = ∏ 1 ≤ ∏ f via Finset.prod_const_one. norm_prod rewrites ‖∏ f‖ = ∏ ‖f‖; norm_sub_norm_le for the reverse-triangle per-factor bound.",
+      "sublevelMeasure well-definedness DISCHARGED: the parent defines sublevelMeasure = (volume {p:ℝ×ℝ|...}).toReal; proving that volume < ⊤ makes the .toReal faithful (not the ⊤↦0 truncation). Bridge: parent ℝ×ℝ set = Complex.measurableEquivRealProd.symm ⁻¹ Sₚ; Complex.volume_preserving_equiv_real_prod.symm + MeasurePreserving.measure_preimage transports volume to the ℂ side, bounded by volume(closedBall 0 2)<⊤ via IsCompact.measure_lt_top.",
+      "Key Mathlib names: isCompact_closedBall (ℂ ProperSpace) + IsCompact.measure_lt_top (volume IsFiniteMeasureOnCompacts); measure_lt_top_of_subset; Complex.measurableEquivRealProd{,_symm_apply}; measure_preimage needs NullMeasurableSet (use .measurableSet.nullMeasurableSet)."
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "The genuine open formalization target is Polya pi upper bound (area of {|p|<1} <= pi) — the most self-contained of the four; still requires planar Lebesgue-measure-of-lemniscate infra Mathlib lacks.",
-      "Consider proving sublevelSet is measurable/open (p is continuous) as the next foundational step enabling any measure lower bound."
+      "Pólya upper bound (sublevelMeasure ≤ π): most self-contained deep target; needs area-of-lemniscate integral machinery absent from Mathlib.",
+      "KLR c/log n lower bound (the proved Erdős–Herzog–Piranian conjecture): logarithmic-potential machinery, deep and unformalized.",
+      "Elementary topology + well-definedness of sublevelMeasure is now complete (open, measurable, bounded, finite measure)."
     ],
     "markdown": "# Knowledge Base: erdos-116-wip-01\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },


### PR DESCRIPTION
## Summary
Research session on **erdos-116-wip-01** (Erdős 116 — measure of polynomial sublevel
sets / lemniscate; Krishnapur–Lundberg–Ramachandran). Discharges the **well-definedness**
of the parent's `sublevelMeasure`.

The parent defines `sublevelMeasure P := (volume {p : ℝ×ℝ | Complex.abs (P.eval ⟨p.1,p.2⟩) < 1}).toReal`.
This `.toReal` is faithful only when the underlying `volume` is finite (else `⊤ ↦ 0`).

## Progress (3 axiom-free theorems, host-verified v4.31)
- `volume_sublevelSet_lt_top` — `volume Sₚ < ⊤` (ℂ-side): `Sₚ ⊆ closedBall 0 2`, compact
  in the proper space `ℂ`, so finite volume (`isCompact_closedBall` +
  `IsCompact.measure_lt_top` + `measure_lt_top_of_subset`).
- `realProd_sublevelSet_eq_preimage` — the parent's `ℝ×ℝ` set equals
  `Complex.measurableEquivRealProd.symm ⁻¹' Sₚ`.
- `volume_realProd_sublevelSet_lt_top` — the parent's planar measure is finite, transported
  via `Complex.volume_preserving_equiv_real_prod.symm` + `MeasurePreserving.measure_preimage`.

Files: `proofs/Proofs/Erdos116WIP01.lean`,
`src/data/research/problems/erdos-116-wip-01.json`,
`research/problems/erdos-116-wip-01/knowledge.md`.

## Verification
`lake env lean Proofs/Erdos116WIP01.lean` exits 0 (against a freshly built parent olean).
`#print axioms` on all three theorems = `[propext, Classical.choice, Quot.sound]`
(no `sorry`, no `native_decide`, no `Lean.ofReduceBool`).

## Status
**Outcome**: progress — the elementary topology + measure-theoretic well-definedness layer
(open, measurable, bounded, finite planar measure) is now complete.
**Next Steps**: the deep quantitative bounds (Pólya `π` upper, KLR `c/log n` lower) rest on
logarithmic-potential / area-of-lemniscate machinery absent from Mathlib.

🤖 Generated by researcher-1
