### PR TITLE
Enrich beta-central-binomial-asymptotic: cover tail 148-233 (Stirling central binomial + Catalan asymptotics)

### DIFF
--- a/src/data/proofs/beta-central-binomial-asymptotic/meta.json
+++ b/src/data/proofs/beta-central-binomial-asymptotic/meta.json
@@ -82,6 +82,27 @@
       "startLine": 138,
       "endLine": 147,
       "summary": "betaIntegral_diag_eq proves Complex.betaIntegral (n+1) (n+1) = (betaDiag n : ℂ) via the parent's betaIntegral_diag_centralBinom, so the real sequence analysed here is literally the value of the Euler Beta integral on the diagonal — the asymptotic therefore describes Complex.betaIntegral itself."
+    },
+    {
+      "id": "diagonal-beta-vanishes",
+      "title": "Vanishing of the Diagonal Beta Value",
+      "startLine": 148,
+      "endLine": 174,
+      "summary": "betaDiag_tendsto_zero shows the diagonal Euler Beta value B(n+1,n+1) = betaDiag n tends to 0 as n → ∞. The proof factors betaDiag n through (2n+1)·C(2n,n), whose reciprocal-type growth 4^n/√(πn) is dominated by the 4^{-n}-type normalization, so the product tends to 0 — the qualitative complement to the sharp asymptotic established just below."
+    },
+    {
+      "id": "central-binomial-stirling",
+      "title": "Sharp Stirling Form of the Central Binomial",
+      "startLine": 175,
+      "endLine": 187,
+      "summary": "centralBinom_div_stirling_tendsto_one packages the central binomial asymptotic in its cleanest ratio form: C(2n,n) / (4^n / √(πn)) → 1, i.e. C(2n,n) ~ 4^n/√(πn). This is the Stirling-normalized statement that downstream Catalan and Beta-value asymptotics all reduce to."
+    },
+    {
+      "id": "catalan-asymptotics",
+      "title": "Catalan Number Asymptotics",
+      "startLine": 188,
+      "endLine": 233,
+      "summary": "catalan_cast rewrites catalan n = C(2n,n)/(n+1); catalan_isEquivalent and catalan_div_stirling_tendsto_one then transport the central-binomial Stirling form through this identity to give catalan n ~ 4^n/((n+1)√(πn)) — equivalently catalan n ~ 4^n/(√π · n^{3/2}) — the classical growth rate of the Catalan numbers, obtained here as a direct corollary of the diagonal Beta asymptotic."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Enrichment: beta-central-binomial-asymptotic

Section coverage stopped at line 147 while the Lean file runs to 233. The uncovered tail (148-233) is a coherent, axiom-free asymptotics block that was invisible to the gallery.

### Added 3 sections covering 148-233
- **Vanishing of the Diagonal Beta Value** (148-174): `betaDiag_tendsto_zero` — B(n+1,n+1) → 0.
- **Sharp Stirling Form of the Central Binomial** (175-187): `centralBinom_div_stirling_tendsto_one` — C(2n,n) ~ 4^n/√(πn).
- **Catalan Number Asymptotics** (188-233): `catalan_cast`, `catalan_isEquivalent`, `catalan_div_stirling_tendsto_one` — catalan n ~ 4^n/((n+1)√(πn)).

Sections are contiguous and now cover the full file (50-233). No status/badge/axiom changes (file is 0-axiom, 0-sorry; `verified` retained). meta.json 12.3 KB → 13.9 KB, well under the 60 KB cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
