### PR TITLE
Research: erdos-98-wip-01 — n=3 general-position existence (explicit triangle)

### DIFF
--- a/proofs/Proofs/Erdos98WIP01.lean
+++ b/proofs/Proofs/Erdos98WIP01.lean
@@ -383,9 +383,7 @@ theorem triangleConfig_injective : Function.Injective triangleConfig := by
     | (exfalso
        have h0 := congrArg (fun p => p 0) hij
        have h1 := congrArg (fun p => p 1) hij
-       simp only [triangleConfig, EuclideanSpace.single_apply, Matrix.cons_val_zero,
-         Matrix.cons_val_one, Matrix.cons_val_two, Matrix.head_cons, Matrix.tail_cons] at h0 h1
-       norm_num at h0 h1)
+       simp [triangleConfig, EuclideanSpace.single_apply] at h0 h1)
 
 /-- **No three of the triangle's vertices are collinear.** The single non-vacuous case:
 a line through all three vertices forces `(a,b,c) = 0`. -/
@@ -396,9 +394,10 @@ theorem noThreeCollinear_triangleConfig : NoThreeCollinear triangleConfig := by
   fin_cases i <;> fin_cases j <;> fin_cases k <;>
     first
     | exact absurd hcard (by decide)
-    | (simp only [triangleConfig, EuclideanSpace.single_apply, Matrix.cons_val_zero,
-         Matrix.cons_val_one, Matrix.cons_val_two, Matrix.head_cons, Matrix.tail_cons,
-         mul_zero, mul_one, add_zero, zero_add] at hi hj hk
+    | (simp only [triangleConfig, Matrix.cons_val_zero, Matrix.cons_val_one,
+         Matrix.cons_val_two, Matrix.head_cons, Matrix.tail_cons,
+         EuclideanSpace.single_apply] at hi hj hk
+       norm_num at hi hj hk
        simp only [Prod.mk.injEq]
        refine ⟨?_, ?_, ?_⟩ <;> linarith)
 

--- a/proofs/Proofs/Erdos98WIP01.lean
+++ b/proofs/Proofs/Erdos98WIP01.lean
@@ -361,4 +361,69 @@ theorem exists_inGeneralPosition_of_le_two (hn : n ≤ 2) :
   · exact noThreeCollinear_of_le_two _ hn
   · exact noFourConcyclic_of_le_three _ (by omega)
 
+/-! ## General-position existence for `n = 3` (the first non-vacuous case)
+
+For `n = 3` the no-four-concyclic condition is still vacuous, but no-three-collinear
+becomes a genuine constraint. An explicit right triangle `(0,0), (1,0), (0,1)` witnesses
+it: any line `a·x + b·y + c = 0` through all three forces `c = 0` (from `(0,0)`), then
+`a = 0` (from `(1,0)`) and `b = 0` (from `(0,1)`), i.e. `(a,b,c) = 0`.  This upgrades the
+attained-minimum guarantee from `n ≤ 2` to `n ≤ 3`. -/
+
+/-- An explicit right triangle `(0,0), (1,0), (0,1)` as a configuration of three points
+in `ℝ²` (each point built with `EuclideanSpace.single` for uniform coordinate access). -/
+noncomputable def triangleConfig : PointConfig 3 :=
+  ![EuclideanSpace.single 0 0, EuclideanSpace.single 0 1, EuclideanSpace.single 1 1]
+
+/-- The three triangle vertices are distinct. -/
+theorem triangleConfig_injective : Function.Injective triangleConfig := by
+  intro i j hij
+  fin_cases i <;> fin_cases j <;>
+    first
+    | rfl
+    | (exfalso
+       have h0 := congrArg (fun p => p 0) hij
+       have h1 := congrArg (fun p => p 1) hij
+       simp only [triangleConfig, EuclideanSpace.single_apply, Matrix.cons_val_zero,
+         Matrix.cons_val_one, Matrix.cons_val_two, Matrix.head_cons, Matrix.tail_cons] at h0 h1
+       norm_num at h0 h1)
+
+/-- **No three of the triangle's vertices are collinear.** The single non-vacuous case:
+a line through all three vertices forces `(a,b,c) = 0`. -/
+theorem noThreeCollinear_triangleConfig : NoThreeCollinear triangleConfig := by
+  intro i j k hcard
+  rintro ⟨a, b, c, hne, hi, hj, hk⟩
+  apply hne
+  fin_cases i <;> fin_cases j <;> fin_cases k <;>
+    first
+    | exact absurd hcard (by decide)
+    | (simp only [triangleConfig, EuclideanSpace.single_apply, Matrix.cons_val_zero,
+         Matrix.cons_val_one, Matrix.cons_val_two, Matrix.head_cons, Matrix.tail_cons,
+         mul_zero, mul_one, add_zero, zero_add] at hi hj hk
+       simp only [Prod.mk.injEq]
+       refine ⟨?_, ?_, ?_⟩ <;> linarith)
+
+/-- No four of the triangle's vertices are concyclic (vacuous: only three points). -/
+theorem noFourConcyclic_triangleConfig : NoFourConcyclic triangleConfig :=
+  noFourConcyclic_of_le_three _ (by norm_num)
+
+/-- **General-position configurations exist for `n = 3`.** The right triangle
+`(0,0), (1,0), (0,1)` is injective, has no three collinear, and (vacuously) no four
+concyclic. Hence the defining set of `h 3` is nonempty and `h 3` is a genuine attained
+minimum. -/
+theorem exists_inGeneralPosition_three :
+    ∃ P : PointConfig 3, InGeneralPosition P :=
+  ⟨triangleConfig, triangleConfig_injective, noThreeCollinear_triangleConfig,
+    noFourConcyclic_triangleConfig⟩
+
+/-- **General-position configurations exist for every `n ≤ 3`.** Combines the vacuous
+small regime (`n ≤ 2`) with the explicit triangle (`n = 3`), so `h n` is an attained
+minimum — not the `sInf ∅` junk value — throughout `n ≤ 3`. -/
+theorem exists_inGeneralPosition_of_le_three (hn : n ≤ 3) :
+    ∃ P : PointConfig n, InGeneralPosition P := by
+  interval_cases n
+  · exact exists_inGeneralPosition_of_le_two (by norm_num)
+  · exact exists_inGeneralPosition_of_le_two (by norm_num)
+  · exact exists_inGeneralPosition_of_le_two (by norm_num)
+  · exact exists_inGeneralPosition_three
+
 end Erdos98WIP01

--- a/research/problems/erdos-98-wip-01/knowledge.md
+++ b/research/problems/erdos-98-wip-01/knowledge.md
@@ -86,3 +86,36 @@ and the genuine next target — it would make `h n` a true minimum over a nonemp
 ### Remaining open (UNCHANGED)
 Existence of general-position configurations for all n (constructive); parent Erdős #98
 (`h(n)/n → ∞`, and even the weak `h(n) ≥ n`) remains OPEN in mathematics.
+
+## Session 2026-07-20 (researcher-1) — n=3 general-position existence (explicit triangle)
+
+**Mode**: build on the n≤2 vacuity result. **Outcome**: progress — 5 axiom-free
+declarations (1 def + 4 theorems), **host-verified v4.31** (`lake env lean` exit 0;
+`#print axioms` = `[propext, Classical.choice, Quot.sound]`; no sorry/native_decide).
+
+Discharged general-position existence for `n = 3` — the first case where no-three-collinear
+is a genuine (non-vacuous) constraint:
+
+- `triangleConfig` — the right triangle `(0,0), (1,0), (0,1)`, each vertex built with
+  `EuclideanSpace.single` for uniform `single_apply` coordinate access.
+- `triangleConfig_injective`, `noThreeCollinear_triangleConfig` (the crux),
+  `noFourConcyclic_triangleConfig` (vacuous via `noFourConcyclic_of_le_three`).
+- `exists_inGeneralPosition_three` and `exists_inGeneralPosition_of_le_three`: GP configs
+  exist for all `n ≤ 3`, so `h n` is a genuine attained minimum (not `sInf ∅`) through `n=3`
+  (previously only `n ≤ 2`).
+
+**Proof technique** (no-3-collinear): a line `a·x+b·y+c=0` through all three vertices
+forces `c=0` (origin), `a=0` ((1,0)), `b=0` ((0,1)). Formalized by `fin_cases` over the 27
+index triples `(i,j,k)`: the degenerate (repeated-index) triples are killed by
+`exact absurd hcard (by decide)` on `card{i,j,k}=3`; the 6 genuine permutations reduce via
+`simp only [Matrix.cons_val_zero/one/two, head_cons, tail_cons, EuclideanSpace.single_apply]`
+then `norm_num` (decides the `ite` conditions + arithmetic), closed by `linarith` on the
+three linear facts. Injectivity: `fin_cases` + full `simp` closes the false coordinate
+equalities.
+
+### Next
+- **n=4** (first non-vacuous no-4-concyclic case): analog of this step for concyclicity —
+  needs the four-points-on-a-circle determinant computation over `EuclideanSpace`.
+- **All n**: failure locus `(3-collinear ∪ 4-concyclic)` is a finite union of proper
+  algebraic subvarieties of `(ℝ²)ⁿ`; complement nonempty by a dimension/genericity argument
+  (the deep constructive piece). Parent Erdős #98 (`h(n)/n → ∞`) remains OPEN.

--- a/src/data/research/problems/erdos-98-wip-01.json
+++ b/src/data/research/problems/erdos-98-wip-01.json
@@ -23,7 +23,7 @@
     "iteration": 2,
     "focus": "Session 4: unconditional upper bound h(n) ≤ n.choose 2 (h_le_choose_two, sidesteps the missing general-position existence witness via the sInf-empty case) + degenerate values h(n)=0 for n≤1. 2 axiom-free theorems, theoremCount 10→12, host-verified.",
     "blockers": [],
-    "nextAction": "Genuine next target: prove general-position configurations exist for all n (Injective ∧ NoThreeCollinear ∧ NoFourConcyclic) — makes h(n) a true minimum over a nonempty set. Parent Erdős #98 (h(n)/n→∞) OPEN.",
+    "nextAction": "Full general-position existence for all n: the failure locus (3-collinear ∪ 4-concyclic) is a finite union of proper algebraic subvarieties of the configuration space (ℝ²)ⁿ, so its complement is nonempty — a dimension/genericity argument, the deep constructive piece. n≤3 now fully covered.",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -31,7 +31,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (2026-07-20, researcher-1, VERIFIED 0-axiom host): general-position existence for n≤2 (exists_inGeneralPosition_of_le_two) via two vacuity lemmas (noThreeCollinear_of_le_two, noFourConcyclic_of_le_three) — so h n is an attained minimum (not sInf∅ junk) in the small regime. Documented the parabola obstruction to full GP existence (4 concyclic when x-coords sum to 0). 18 theorems, 0 axiom.",
+    "progressSummary": "PROGRESS (2026-07-20, researcher-1, VERIFIED 0-axiom host, #print axioms=[propext,Classical.choice,Quot.sound]): n=3 general-position existence discharged via explicit right triangle (first non-vacuous no-3-collinear case) — exists_inGeneralPosition_three + exists_inGeneralPosition_of_le_three, so h n is an attained minimum for all n≤3 (was n≤2). Parent Erdős #98 (h(n)/n→∞) OPEN; full GP existence for all n (parabola fails no-4-concyclic) remains the deep constructive piece.",
     "builtItems": [
       "InGeneralPosition.injective in Erdos98WIP01.lean",
       "numDistinctDistances_le_offDiag (≤ n·(n−1)) in Erdos98WIP01.lean",
@@ -43,7 +43,11 @@
       "strong_imp_weak (h(n)/n→∞ ⟹ h(n)≥n eventually) in Erdos98WIP01.lean",
       "weak_imp_tendsto (weak conj ⟹ h(n)→∞, non-vacuity check) in Erdos98WIP01.lean",
       "tendsto_const_mul_div_log_atTop (c·n/log n → ∞ via Real.isLittleO_log_id_atTop + reciprocal), guthKatz_imp_tendsto (GuthKatzBaseline ⟹ Tendsto h atTop atTop) in Erdos98WIP01.lean (0 axioms, 0 sorries; host-verified v4.31.0 fresh-parent-olean)",
-      "noThreeCollinear_of_le_two, noFourConcyclic_of_le_three, exists_inGeneralPosition_of_le_two in Erdos98WIP01.lean — GP existence for n≤2, 0-axiom host-verified"
+      "noThreeCollinear_of_le_two, noFourConcyclic_of_le_three, exists_inGeneralPosition_of_le_two in Erdos98WIP01.lean — GP existence for n≤2, 0-axiom host-verified",
+      "triangleConfig — explicit right triangle (0,0),(1,0),(0,1) via EuclideanSpace.single (Erdos98WIP01.lean)",
+      "triangleConfig_injective, noThreeCollinear_triangleConfig (first non-vacuous no-3-collinear case), noFourConcyclic_triangleConfig",
+      "exists_inGeneralPosition_three — GP configs exist for n=3",
+      "exists_inGeneralPosition_of_le_three — GP configs exist for all n≤3, so h n is an attained minimum through n=3"
     ],
     "insights": [
       "Every positive pairwise distance comes from an off-diagonal ordered pair (dist>0 ⟹ points distinct ⟹ indices distinct), giving the clean upper bound numDistinctDistances P ≤ n·(n−1) via Finset.offDiag_card — the trivial ceiling of the h(n) envelope.",
@@ -56,12 +60,15 @@
       "The DIVERGENCE h(n)→∞ is unconditionally provable (a theorem), not open: the imported Guth–Katz Ω(n/log n) baseline already forces it, since c·n/log n → ∞. Only the RATE h(n)/n→∞ (strong conjecture) and h(n)≥n (weak) remain open. This sharpens weak_imp_tendsto, which derived the same divergence from the OPEN weak conjecture.",
       "General-position existence is vacuous-then-injective for small n: card{i,j,k}=3 impossible for n≤2 (noThreeCollinear_of_le_two), card{a,b,c,d}=4 impossible for n≤3 (noFourConcyclic_of_le_three); so an injective embedding i↦(i,0) is general-position for n≤2 (exists_inGeneralPosition_of_le_two).",
       "OBSTRUCTION to full GP existence: the natural parabola construction (t,t²) gives no-3-collinear (a line meets a parabola in ≤2 pts) but FAILS no-4-concyclic — a circle meets y=x² in a quartic with zero cubic term, so any 4 parabola points whose x-coordinates SUM TO 0 are concyclic (e.g. x=-3,-1,1,3). Full GP existence needs a genericity/perturbation argument (config space minus finitely many proper algebraic subvarieties), not a single explicit curve.",
-      "EuclideanSpace.single_apply deprecated → PiLp.single_apply (v4.31); coordinate extraction via congrArg (·0) then simpa [PiLp.single_apply]."
+      "EuclideanSpace.single_apply deprecated → PiLp.single_apply (v4.31); coordinate extraction via congrArg (·0) then simpa [PiLp.single_apply].",
+      "n=3 GP existence discharged with the right triangle (0,0),(1,0),(0,1): a line a·x+b·y+c=0 through all three forces c=0 (from origin), a=0 (from (1,0)), b=0 (from (0,1)). Proof by fin_cases over the 27 index triples: degenerate (repeat) triples killed by absurd hcard (by decide) on card{i,j,k}=3; the 6 permutations reduced by simp[cons_val_*, EuclideanSpace.single_apply]+norm_num then linarith.",
+      "Coordinate technique: build points with EuclideanSpace.single for uniform single_apply coordinate access; ![...] index reduction needs Matrix.cons_val_zero/one/two + head_cons/tail_cons; full simp (not simp only) closes false coordinate equalities in injectivity."
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "GP existence for n=3 (first non-vacuous no-3-collinear case): explicit triangle (0,0),(1,0),(0,1); needs the 6-permutation collinearity computation over EuclideanSpace coordinates.",
-      "Full GP existence for all n via genericity: the failure locus (3-collinear ∪ 4-concyclic) is a finite union of proper algebraic subvarieties of the configuration space, so its complement is nonempty (measure-theoretic / dimension argument) — the deep constructive piece."
+      "General-position existence for n=4 (first non-vacuous no-4-concyclic case): needs the four-points-concyclic determinant/circle computation over EuclideanSpace — the analog of the n=3 triangle step for concyclicity.",
+      "Full GP existence for all n via genericity: failure locus is a finite union of proper algebraic subvarieties of (ℝ²)ⁿ, complement nonempty (measure/dimension argument) — deep constructive piece.",
+      "Parent Erdős #98 conjecture h(n)/n→∞ remains OPEN (Erdős could not even prove h(n)≥n)."
     ],
     "markdown": "# Knowledge Base: erdos-98-wip-01\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },


### PR DESCRIPTION
## Summary
Research session on **erdos-98-wip-01** (Erdős #98 — distinct distances in general
position; `h(n)/n → ∞`, OPEN). Discharges general-position existence for `n = 3`, the
first case where **no-three-collinear** is a genuine (non-vacuous) constraint.

## Progress (5 axiom-free declarations, host-verified v4.31)
- `triangleConfig` — the right triangle `(0,0), (1,0), (0,1)` (vertices via
  `EuclideanSpace.single` for uniform coordinate access).
- `triangleConfig_injective`, `noThreeCollinear_triangleConfig` (the crux),
  `noFourConcyclic_triangleConfig` (vacuous, `n = 3 ≤ 3`).
- `exists_inGeneralPosition_three` — GP configs exist for `n = 3`.
- `exists_inGeneralPosition_of_le_three` — GP configs exist for **all** `n ≤ 3`, so `h n`
  is a genuine attained minimum (not the `sInf ∅` junk value) through `n = 3` (previously
  only `n ≤ 2`).

Files: `proofs/Proofs/Erdos98WIP01.lean`,
`src/data/research/problems/erdos-98-wip-01.json`,
`research/problems/erdos-98-wip-01/knowledge.md`.

## Proof technique
A line `a·x+b·y+c=0` through all three vertices forces `c=0` (origin), `a=0` (`(1,0)`),
`b=0` (`(0,1)`). Formalized by `fin_cases` over the 27 index triples: degenerate
(repeated-index) triples are killed by `absurd hcard (by decide)` on `card{i,j,k}=3`; the 6
genuine permutations reduce via `simp only [Matrix.cons_val_*, EuclideanSpace.single_apply]`
+ `norm_num`, closed by `linarith`.

## Verification
`lake env lean Proofs/Erdos98WIP01.lean` exits 0 (against a freshly built parent olean).
`#print axioms` on the four theorems = `[propext, Classical.choice, Quot.sound]`
(no `sorry`, no `native_decide`, no `Lean.ofReduceBool`).

## Status
**Outcome**: progress — attained-minimum guarantee extended from `n ≤ 2` to `n ≤ 3`.
**Next Steps**: `n = 4` (first non-vacuous no-4-concyclic case) and the all-`n` genericity
argument (failure locus is a finite union of proper algebraic subvarieties). Parent Erdős
#98 conjecture remains OPEN.

🤖 Generated by researcher-1
