### PR TITLE
audit: abel-ruffini-oq012 — clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -29858,6 +29858,12 @@
       "lastAudited": "2026-07-21T03:55:50Z",
       "result": "clean",
       "issues": []
+    },
+    "abel-ruffini-oq012": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T04:03:13Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
Gallery integrity audit: **abel-ruffini-oq012** (⊕-Survival ⊊ ×-Survival by AM–GM).

**Verdict: clean.** Tier B, badge `mathlib` correct.

- 8 theorems, 0 axioms, 0 sorries
- No undisclosed `native_decide` (assumptions field discloses grep strings are docstring-only)
- All `mainTheorems` are real declarations; counts match (8 thm / 0 ax / 188 lines)
- AM–GM core `four_mul_le_add_sq` (4ab ≤ (a+b)²) genuinely proved via zify + nlinarith; strict containment witnessed by (Fin 1, Fin 4)
- No overclaims

🤖 Generated with [Claude Code](https://claude.com/claude-code)