### PR TITLE
Research: erdos-89-wip-01 — exact value g(3)=1 (equilateral triangle)

### DIFF
--- a/proofs/Proofs/Erdos89WIP01.lean
+++ b/proofs/Proofs/Erdos89WIP01.lean
@@ -403,7 +403,7 @@ theorem eqp1_ne_eqp2 : eqp1 ≠ eqp2 := by
 
 /-- The equilateral triangle has exactly three (distinct) vertices. -/
 theorem eqTri_card : eqTri.card = 3 := by
-  rw [eqTri, Finset.card_insert_of_not_mem, Finset.card_insert_of_not_mem,
+  rw [eqTri, Finset.card_insert_of_notMem, Finset.card_insert_of_notMem,
     Finset.card_singleton]
   · simp only [Finset.mem_singleton]; exact eqp1_ne_eqp2
   · simp only [Finset.mem_insert, Finset.mem_singleton, not_or]

--- a/proofs/Proofs/Erdos89WIP01.lean
+++ b/proofs/Proofs/Erdos89WIP01.lean
@@ -334,4 +334,125 @@ theorem minDistinctDistances_le_pred (n : ℕ) : minDistinctDistances n ≤ n - 
     _ ≤ (Finset.Icc 1 (n - 1)).card := Finset.card_image_le
     _ = n - 1 := by rw [Nat.card_Icc]; omega
 
+/-! ## The exact value `g(3) = 1`
+
+The linear bound gives only `g(3) ≤ 2`; the sharp ceiling gives `g(3) ≤ 3.choose 2 = 3`.
+But three points can determine a *single* distance — an **equilateral triangle** — so in
+fact `g(3) = 1`. This is the first exact value beyond the trivial/base table
+`g(0)=g(1)=0, g(2)=1`, and it is *strictly below* the collinear-AP upper bound, showing the
+AP is not extremal at `n = 3`. -/
+
+/-- Symmetry of the (custom) distance: `dist a b = dist b a`. -/
+theorem dist_comm' (a b : EuclideanSpace ℝ (Fin 2)) :
+    Erdos89.dist a b = Erdos89.dist b a := by
+  unfold Erdos89.dist; exact norm_sub_rev a b
+
+/-- Closed form for the distance between two explicit planar points. -/
+theorem dist_eqPts (a b c d : ℝ) :
+    Erdos89.dist !₂[a, b] !₂[c, d] = Real.sqrt ((a - c) ^ 2 + (b - d) ^ 2) := by
+  unfold Erdos89.dist
+  rw [← dist_eq_norm, EuclideanSpace.dist_eq, Fin.sum_univ_two]
+  simp only [Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.head_cons, Real.dist_eq,
+    sq_abs]
+
+/-- Vertex `(0,0)` of the equilateral triangle. -/
+noncomputable def eqp0 : EuclideanSpace ℝ (Fin 2) := !₂[0, 0]
+/-- Vertex `(1,0)` of the equilateral triangle. -/
+noncomputable def eqp1 : EuclideanSpace ℝ (Fin 2) := !₂[1, 0]
+/-- Vertex `(1/2, √3/2)` of the equilateral triangle. -/
+noncomputable def eqp2 : EuclideanSpace ℝ (Fin 2) := !₂[1 / 2, Real.sqrt 3 / 2]
+
+/-- The three equilateral-triangle vertices, as a `Finset`. -/
+noncomputable def eqTri : Finset (EuclideanSpace ℝ (Fin 2)) := {eqp0, eqp1, eqp2}
+
+theorem dist_eqp01 : Erdos89.dist eqp0 eqp1 = 1 := by
+  rw [eqp0, eqp1, dist_eqPts,
+    show ((0 : ℝ) - 1) ^ 2 + ((0 : ℝ) - 0) ^ 2 = 1 by ring, Real.sqrt_one]
+
+theorem dist_eqp02 : Erdos89.dist eqp0 eqp2 = 1 := by
+  have harg : ((0 : ℝ) - 1 / 2) ^ 2 + ((0 : ℝ) - Real.sqrt 3 / 2) ^ 2 = 1 := by
+    have h3 : Real.sqrt 3 ^ 2 = 3 := Real.sq_sqrt (by norm_num)
+    have hrw : ((0 : ℝ) - Real.sqrt 3 / 2) ^ 2 = Real.sqrt 3 ^ 2 / 4 := by ring
+    rw [hrw, h3]; norm_num
+  rw [eqp0, eqp2, dist_eqPts, harg, Real.sqrt_one]
+
+theorem dist_eqp12 : Erdos89.dist eqp1 eqp2 = 1 := by
+  have harg : ((1 : ℝ) - 1 / 2) ^ 2 + ((0 : ℝ) - Real.sqrt 3 / 2) ^ 2 = 1 := by
+    have h3 : Real.sqrt 3 ^ 2 = 3 := Real.sq_sqrt (by norm_num)
+    have hrw : ((0 : ℝ) - Real.sqrt 3 / 2) ^ 2 = Real.sqrt 3 ^ 2 / 4 := by ring
+    rw [hrw, h3]; norm_num
+  rw [eqp1, eqp2, dist_eqPts, harg, Real.sqrt_one]
+
+theorem eqp0_ne_eqp1 : eqp0 ≠ eqp1 := by
+  intro h
+  have h0 := congrArg (fun p => p 0) h
+  simp only [eqp0, eqp1, Matrix.cons_val_zero] at h0
+  norm_num at h0
+
+theorem eqp0_ne_eqp2 : eqp0 ≠ eqp2 := by
+  intro h
+  have h0 := congrArg (fun p => p 0) h
+  simp only [eqp0, eqp2, Matrix.cons_val_zero] at h0
+  norm_num at h0
+
+theorem eqp1_ne_eqp2 : eqp1 ≠ eqp2 := by
+  intro h
+  have h0 := congrArg (fun p => p 0) h
+  simp only [eqp1, eqp2, Matrix.cons_val_zero] at h0
+  norm_num at h0
+
+/-- The equilateral triangle has exactly three (distinct) vertices. -/
+theorem eqTri_card : eqTri.card = 3 := by
+  rw [eqTri, Finset.card_insert_of_not_mem, Finset.card_insert_of_not_mem,
+    Finset.card_singleton]
+  · simp only [Finset.mem_singleton]; exact eqp1_ne_eqp2
+  · simp only [Finset.mem_insert, Finset.mem_singleton, not_or]
+    exact ⟨eqp0_ne_eqp1, eqp0_ne_eqp2⟩
+
+/-- **The equilateral triangle determines exactly one distance.** All three pairwise
+distances equal `1`, so `numDistinctDistances = 1`. -/
+theorem numDistinctDistances_eqTri : numDistinctDistances eqTri = 1 := by
+  have hsub : distinctDistances eqTri ⊆ {(1 : ℝ)} := by
+    rw [distinctDistances_eq_image]
+    intro d hd
+    rw [Finset.mem_image] at hd
+    obtain ⟨⟨p, q⟩, hpq, rfl⟩ := hd
+    rw [Finset.mem_offDiag] at hpq
+    obtain ⟨hp, hq, hne⟩ := hpq
+    simp only [eqTri, Finset.mem_insert, Finset.mem_singleton] at hp hq
+    rw [Finset.mem_singleton]
+    rcases hp with rfl | rfl | rfl <;> rcases hq with rfl | rfl | rfl <;>
+      first
+        | exact absurd rfl hne
+        | exact dist_eqp01
+        | exact dist_eqp02
+        | exact dist_eqp12
+        | (rw [dist_comm']; exact dist_eqp01)
+        | (rw [dist_comm']; exact dist_eqp02)
+        | (rw [dist_comm']; exact dist_eqp12)
+  refine le_antisymm ?_
+    (one_le_numDistinctDistances_of_two_le_card _ (by have := eqTri_card; omega))
+  show (distinctDistances eqTri).card ≤ 1
+  calc (distinctDistances eqTri).card
+      ≤ ({(1 : ℝ)} : Finset ℝ).card := Finset.card_le_card hsub
+    _ = 1 := Finset.card_singleton _
+
+/-- **Exact value `g(3) = 1`.** The equilateral triangle realizes a single distance
+(`numDistinctDistances_eqTri`), giving `g(3) ≤ 1`; and any three points determine at least
+one distance, giving `g(3) ≥ 1`. This is *strictly below* the collinear-AP bound
+`g(3) ≤ 2`, so the arithmetic progression is not extremal at `n = 3`. -/
+theorem minDistinctDistances_three : minDistinctDistances 3 = 1 := by
+  refine le_antisymm ?_ ?_
+  · calc minDistinctDistances 3
+        ≤ numDistinctDistances eqTri := minDistinctDistances_le_of_card_eq eqTri_card
+      _ = 1 := numDistinctDistances_eqTri
+  · have hne : {numDistinctDistances S |
+        (S : Finset (EuclideanSpace ℝ (Fin 2))) (_ : S.card = 3)}.Nonempty :=
+      ⟨numDistinctDistances eqTri, eqTri, eqTri_card, rfl⟩
+    obtain ⟨S, hScard, hSeq⟩ := Nat.sInf_mem hne
+    show 1 ≤ minDistinctDistances 3
+    unfold minDistinctDistances
+    rw [← hSeq]
+    exact one_le_numDistinctDistances_of_two_le_card S (by omega)
+
 end Erdos89

--- a/research/problems/erdos-89-wip-01/knowledge.md
+++ b/research/problems/erdos-89-wip-01/knowledge.md
@@ -108,3 +108,31 @@ Now 20 theorems, 0 sorry, 0 axiom.
 - Sharpen toward `Θ(n/√(log n))` via the `√n × √n` grid — DEEP (needs the
   number-theoretic count of distinct distances in a square integer grid).
 - Guth–Katz `Ω(n/log n)` lower bound stays an imported assumption.
+
+## Session 2026-07-20 (researcher-1) — exact value g(3) = 1 (equilateral triangle)
+
+**Mode**: build on the linear upper bound g(n) ≤ n−1. **Outcome**: progress — the first
+exact value beyond the trivial table, host-verified v4.31 (`lake env lean` exit 0;
+`#print axioms` = `[propext, Classical.choice, Quot.sound]`; no sorry/native_decide).
+
+`minDistinctDistances_three : minDistinctDistances 3 = 1`. The equilateral triangle
+`(0,0), (1,0), (1/2, √3/2)` has all three pairwise distances equal to `1`, so it determines
+a single distance; and any three points determine at least one. This value is **strictly
+below** the collinear-AP upper bound `g(3) ≤ 2`, so the arithmetic progression (the file's
+`apSet` construction) is *not* extremal at `n = 3`.
+
+**Technique**:
+- `dist_eqPts a b c d : dist !₂[a,b] !₂[c,d] = √((a-c)²+(b-d)²)` — closed form via
+  `← dist_eq_norm`, `EuclideanSpace.dist_eq`, `Fin.sum_univ_two`, `sq_abs`.
+- The equilateral coordinate `√3/2` handled by `Real.sq_sqrt : (√3)² = 3` (arg `≥ 0`).
+- `numDistinctDistances_eqTri = 1`: show `distinctDistances eqTri ⊆ {1}` by `rcases` over
+  the 3×3 vertex pairs — diagonal killed by `absurd rfl hne`, the 6 off-diagonal by
+  `dist_eqp01/02/12` (with `dist_comm'` for the reversed orders).
+- `card_insert_of_not_mem` → `card_insert_of_notMem` (v4.31 rename).
+
+### Next
+- **g(4) = 2**: the unit square `(0,0),(1,0),(0,1),(1,1)` realizes distances `{1, √2}` → 2
+  distinct; `g(4) ≥ 2` needs ruling out a 4-point 1-distance set (a regular simplex,
+  impossible in ℝ²).
+- `√n × √n` grid upper bound toward `g(n) = Θ(n/√(log n))` (deep, number-theoretic). Guth–Katz
+  `Ω(n/log n)` lower bound stays imported.

--- a/src/data/research/problems/erdos-89-wip-01.json
+++ b/src/data/research/problems/erdos-89-wip-01.json
@@ -23,7 +23,7 @@
     "iteration": 2,
     "focus": "Initial problem understanding. Read problem.md and gather context.",
     "blockers": [],
-    "nextAction": "Formalize the √n×√n grid upper bound feeding minDistinctDistances_le_of_card_eq for a concrete O(n) ceiling on g(n); or an exact g(3). Guth–Katz lower bound stays an imported assumption.",
+    "nextAction": "Exact g(4): the unit square gives 2 distinct distances (side + diagonal). Determine and prove g(4)=2. Or the sqrt(n)-grid upper bound (deep, number-theoretic).",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -31,7 +31,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: g(n) now bracketed on the elementary side — exact small values g(0)=g(1)=0, g(2)=1, monotone, and a new linear upper bound g(n) ≤ n−1 via an explicit collinear AP construction (axiom-free). Only remaining upper-bound gap is the sharp √(log n) improvement (deep).",
+    "progressSummary": "PROGRESS (2026-07-20, researcher-1, VERIFIED 0-axiom host, print axioms = propext/Classical.choice/Quot.sound): exact value g(3)=minDistinctDistances 3 = 1 via an explicit equilateral triangle (all three pairwise distances = 1). First exact value beyond the trivial table g(0)=g(1)=0, g(2)=1, and strictly below the linear AP bound g(3)<=2 - the collinear AP is not extremal at n=3. Prior work: g(n)<=n-1 (collinear AP), monotonicity, sharp n.choose 2 ceiling. Guth-Katz Omega(n/log n) lower bound stays imported.",
     "builtItems": [
       "Erdos89.dist_pos_of_ne in Erdos89WIP01.lean",
       "Erdos89.distinctDistances_eq_image (filter redundant) in Erdos89WIP01.lean",
@@ -49,7 +49,11 @@
       "dist_apPoint: dist(apPoint i)(apPoint j) = |i−j| via EuclideanSpace.dist_eq + Fin.sum_univ_two + Nat.cast_natAbs (Erdos89WIP01.lean)",
       "apPoint_injective + apSet_card: |apSet n| = n (Erdos89WIP01.lean)",
       "apSet_distinctDistances_subset: distances ⊆ image of Icc 1 (n−1) (Erdos89WIP01.lean)",
-      "minDistinctDistances_le_pred: g(n) ≤ n−1, axiom-free (Erdos89WIP01.lean)"
+      "minDistinctDistances_le_pred: g(n) ≤ n−1, axiom-free (Erdos89WIP01.lean)",
+      "eqTri equilateral triangle (0,0),(1,0),(1/2, sqrt3/2) as a Finset (Erdos89WIP01.lean)",
+      "dist_eqPts closed form dist(!2[a,b],!2[c,d]) = sqrt((a-c)^2+(b-d)^2); dist_comm symmetry",
+      "dist_eqp01/02/12 all three pairwise distances = 1 (via Real.sq_sqrt for sqrt(3)^2=3)",
+      "numDistinctDistances_eqTri = 1; minDistinctDistances_three: exact g(3)=1"
     ],
     "insights": [
       "distinctDistances S filters (·>0) over the off-diagonal image, but every off-diagonal pair (p≠q) already has ‖p−q‖>0, so the filter is redundant: distinctDistances S = S.offDiag.image (dist · ·). This removes the awkward filter for all downstream cardinality reasoning.",
@@ -57,13 +61,15 @@
       "minDistinctDistances n = sInf over n-point sets is bounded above by any single n-point witness (Nat.sInf_le ⟨S, hcard, rfl⟩) — the membership hook the √n×√n grid upper-bound construction ultimately supplies.",
       "The custom Erdos89.dist (‖p−q‖) is symmetric via norm_sub_rev, so it factors through Sym2; routing S.offDiag.image through Sym2.mk.uncurry and applying Sym2.card_image_offDiag gives the sharp ceiling numDistinctDistances S ≤ S.card.choose 2 (halving |S|·(|S|−1)). Same technique as erdos-98-wip-01.",
       "The distinct-distances envelope is now an EQUALITY at the base: numDistinctDistances_eq_one_of_card_eq_two shows any 2-point set has exactly 1 distance (sharp ceiling 2.choose 2 = 1 meets the ≥1 floor), and minDistinctDistances_two gives the first exact value of Erdős g(n): g(2) = 1.",
-      "Linear upper bound g(n) ≤ n−1 (minDistinctDistances_le_pred): the collinear arithmetic progression {(0,0),…,(n−1,0)} has distances exactly {1,…,n−1}. First non-quadratic upper bound in the file (prior best was worst-case n.choose 2)."
+      "Linear upper bound g(n) ≤ n−1 (minDistinctDistances_le_pred): the collinear arithmetic progression {(0,0),…,(n−1,0)} has distances exactly {1,…,n−1}. First non-quadratic upper bound in the file (prior best was worst-case n.choose 2).",
+      "g(3)=1 EXACT via equilateral triangle, strictly below the collinear-AP upper bound g(3)<=2, so the arithmetic progression is NOT extremal at n=3. Lower bound g(3)>=1 from one_le_numDistinctDistances_of_two_le_card + Nat.sInf_mem (nonempty witness eqTri).",
+      "Distance-computation technique: dist_eqPts closed form via dist_eq_norm + EuclideanSpace.dist_eq + Fin.sum_univ_two + sq_abs; equilateral coords sqrt(3)^2=3 via Real.sq_sqrt; distinctDistances subset {1} by rcases over the 3x3 vertex pairs (diagonal killed by absurd rfl hne, off-diagonal by dist_eqpXX + dist_comm for reversed order)."
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "Sharpen upper bound toward g(n) = Θ(n/√(log n)) via the √n×√n grid (deep: needs number-theoretic count of distinct distances in a square grid).",
-      "Lower bound Ω(n/log n) (Guth–Katz) stays an imported assumption.",
-      "Connect singlePointConjecture (#604) to the global count."
+      "Exact g(4): the unit square (0,0),(1,0),(0,1),(1,1) has distances {1, sqrt2} -> 2 distinct; g(4)>=2 needs ruling out a 4-point set with 1 distance (a regular simplex, impossible in R^2). Prove g(4)=2.",
+      "sqrt(n) x sqrt(n) grid upper bound toward g(n)=Theta(n/sqrt(log n)) - deep, needs the number-theoretic count of distinct distances in a square grid.",
+      "Guth-Katz Omega(n/log n) lower bound stays an imported assumption."
     ],
     "markdown": "# Knowledge Base: erdos-89-wip-01\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },


### PR DESCRIPTION
## Summary
Research session on **erdos-89-wip-01** (Erdős #89 — distinct distances; `g(n)/√(log n)`,
OPEN). Establishes the exact value **`g(3) = 1`** — the first exact value beyond the
trivial/base table `g(0)=g(1)=0, g(2)=1`.

## Progress (host-verified v4.31, 0 axioms)
- `eqTri` — the equilateral triangle `(0,0), (1,0), (1/2, √3/2)`.
- `dist_eqPts`, `dist_comm'`, `dist_eqp01/02/12` — all three pairwise distances equal `1`.
- `numDistinctDistances_eqTri = 1`.
- `minDistinctDistances_three : minDistinctDistances 3 = 1`.

The value is **strictly below** the file's collinear-AP upper bound `g(3) ≤ 2`, so the
arithmetic progression is *not* extremal at `n = 3`.

Files: `proofs/Proofs/Erdos89WIP01.lean`,
`src/data/research/problems/erdos-89-wip-01.json`,
`research/problems/erdos-89-wip-01/knowledge.md`.

## Verification
`lake env lean Proofs/Erdos89WIP01.lean` exits 0 (against a freshly built parent olean).
`#print axioms` on `minDistinctDistances_three`, `numDistinctDistances_eqTri`, `dist_eqp02`
= `[propext, Classical.choice, Quot.sound]` (no `sorry`, `native_decide`, or `Lean.ofReduceBool`).

## Proof technique
Closed-form distance `dist !₂[a,b] !₂[c,d] = √((a-c)²+(b-d)²)` (`← dist_eq_norm`,
`EuclideanSpace.dist_eq`, `Fin.sum_univ_two`, `sq_abs`); the `√3/2` coordinate handled by
`Real.sq_sqrt`; `distinctDistances eqTri ⊆ {1}` by `rcases` over the 3×3 vertex pairs.

## Status
**Outcome**: progress — first exact value beyond the base table; AP shown non-extremal at n=3.
**Next Steps**: exact `g(4) = 2` (unit square realizes `{1, √2}`); `√n × √n` grid upper bound
toward `g(n) = Θ(n/√(log n))` (deep). Guth–Katz `Ω(n/log n)` lower bound stays imported.

🤖 Generated by researcher-1
