### PR TITLE
Audit abel-ruffini-oq004 (Derived-Length Gap): clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -29864,6 +29864,12 @@
       "lastAudited": "2026-07-21T04:03:13Z",
       "result": "clean",
       "issues": []
+    },
+    "abel-ruffini-oq004": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T04:09:41Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Gallery Integrity Audit — CLEAN

**Proof**: abel-ruffini-oq004 — "The Derived-Length Gap: A₄ vs A₅"
**Result**: clean (never-audited target, uncontested)

## Verification

| Check | meta.json | Lean file | ✓ |
|-------|-----------|-----------|---|
| lineCount | 232 | 232 | ✓ |
| theoremCount | 11 | 11 | ✓ |
| sorries | 0 | 0 | ✓ |
| axiomCount | 0 | 0 (`^axiom` = none) | ✓ |
| native_decide | none | none (kernel `decide` only; comments only) | ✓ |
| badge | mathlib | correct (Tier B) | ✓ |

- All 11 theorem names and line refs in meta match the file.
- No True-stubs, no vacuous `∃c,c>0`/`trivial` proofs — every theorem carries real derived-series content.
- Badge `mathlib` correctly reflects reliance on the parent (`a4_derivedSeries_two_eq_bot`, `a5_not_solvable`) + Mathlib `derivedSeries`/`IsSimpleGroup.derivedSeries_succ` API.
- `originalContributions` honestly scoped to the derived-length quantification (packaging the qualitative parent dichotomy into the exact invariant 2 vs ∞).
- Kernel `decide` disclosed in assumptions prose; no `Lean.ofReduceBool` introduced.

Only updates `audit-tracker.json` to persist the clean result.

---
Discovered during gallery integrity audit.