### PR TITLE
Audit abel-ruffini-oq005 (Aα↔Sα Solvability Bridge): clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -29864,6 +29864,12 @@
       "lastAudited": "2026-07-21T04:03:13Z",
       "result": "clean",
       "issues": []
+    },
+    "abel-ruffini-oq005": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T04:11:13Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Gallery Integrity Audit — CLEAN

**Proof**: abel-ruffini-oq005 — "The Aα ↔ Sα Solvability Bridge"
**Result**: clean (never-audited target, uncontested)

## Verification

| Check | meta.json | Lean file | ✓ |
|-------|-----------|-----------|---|
| lineCount | 167 | 167 | ✓ |
| theoremCount | 12 | 12 | ✓ |
| sorries | 0 | 0 | ✓ |
| axiomCount | 0 | 0 | ✓ |
| native_decide | none | none | ✓ |
| badge | mathlib | correct (Tier B bridge) | ✓ |

- All 12 declared theorems are genuine and substantive — no True-stubs, no vacuous proofs.
- All 5 `leanFile.mainTheorems` exist with correct line refs; no phantom `originalContributions`.
- Badge `mathlib` correctly reflects reliance on Mathlib (`solvable_of_ker_le_range`, `subgroup_solvable_of_solvable`) + parent classification (`alternating_solvable_iff`, `an_not_solvable_of_ge_five`, `a4_solvable`, `a5_not_solvable`).
- The `Aα ↔ Sα` bridge and its `Fin n` specialisation are honest: `sym_solvable_iff n : IsSolvable (Perm (Fin n)) ↔ n ≤ 4` is *derived* from the parent, not re-proved, and the prose says so.

Only updates `audit-tracker.json` to persist the clean result.

---
Discovered during gallery integrity audit.