### PR TITLE
Audit abel-ruffini-oq013 (Toward Burnside pᵃqᵇ: verified reduction): clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -29864,6 +29864,12 @@
       "lastAudited": "2026-07-21T04:03:13Z",
       "result": "clean",
       "issues": []
+    },
+    "abel-ruffini-oq013": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T04:14:10Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Gallery Integrity Audit — CLEAN (famous-theorem, HIGH-risk title, verified honest)

**Proof**: abel-ruffini-oq013 — "Toward Burnside's pᵃqᵇ theorem: verified reduction to non-simplicity"
**Result**: clean (never-audited, uncontested)

## Verification

| Check | meta.json | Lean file | ✓ |
|-------|-----------|-----------|---|
| lineCount | 166 | 166 | ✓ |
| theoremCount | 4 | 4 | ✓ |
| definitionCount | 1 | 1 (`OrderTwoPrimes`) | ✓ |
| sorries | 0 | 0 | ✓ |
| axiomCount | 0 | 0 | ✓ |
| native_decide | none | none | ✓ |

## Why it passes despite a Millennium-adjacent famous title

- The title carries the qualifier **"Toward"** / **"reduction to non-simplicity"**; the description states plainly the theorem is **"not yet in Mathlib"** and that this entry **"isolates the one missing ingredient"**, framing the centerpiece as an explicit **IF…THEN**.
- `burnside_reduces_to_nonsimplicity` is a genuine, fully-proved strong induction on `|G|` that takes non-simplicity as an **explicit hypothesis** (`not_simple`), *not* an axiom — so 0 axioms is real, and Burnside is provably **not** claimed as proved.
- Base case (`isSolvable_of_isPGroup`) and extension engine (`solvable_of_normal_extension`) correctly credit Mathlib's p-group nilpotency and `solvable_of_ker_le_range`.
- All 4 theorems + 1 def match; `originalContributions` have no phantoms; no overclaim anywhere.

Badge `original` is defensible: the verified reduction infrastructure is genuine original fully-machine-checked work, not a wrapper of a nonexistent-in-Mathlib Burnside proof.

Only updates `audit-tracker.json`.

---
Discovered during gallery integrity audit.