### PR TITLE
Enrich erdos-653 (Distinct Distance Counts): re-anchor 5 drifted tail sections to grown file (253→335)

### DIFF
--- a/src/data/proofs/erdos-653/meta.json
+++ b/src/data/proofs/erdos-653/meta.json
@@ -135,48 +135,48 @@
       "title": "Basic Properties",
       "summary": "g_le_n theorem (g(n) ≤ n, discharged from axiom); g_le_n_sub_one theorem (g(n) ≤ n-1, n ≥ 2); g_pos and g_mono discussed only in docstrings",
       "startLine": 138,
-      "endLine": 210,
-      "mathContext": "discharged g_le_n theorem (g(n) ≤ n) plus the proved sharp bound g_le_n_sub_one (g(n) ≤ n-1 for n ≥ 2); g_pos and g_mono appear only in docstrings"
+      "endLine": 231,
+      "mathContext": "discharged g_le_n theorem (g(n) ≤ n) plus the proved sharp bound g_le_n_sub_one (g(n) ≤ n-1 for n ≥ 2), whose card_erase / Finset.Icc counting argument runs to line 231; g_pos and g_mono appear only in docstrings"
     },
     {
       "id": "special-configs",
       "title": "Special Configurations",
-      "summary": "IsCollinear, IsRegularPolygon, regular_polygon_r_value",
-      "startLine": 154,
-      "endLine": 178,
-      "mathContext": "Mathematical content: IsCollinear, IsRegularPolygon, regular_polygon_r_value"
+      "summary": "IsCollinear, IsRegularPolygon (regular_polygon_r_value is a documentary note, not formalized)",
+      "startLine": 232,
+      "endLine": 257,
+      "mathContext": "Mathematical content: IsCollinear (points on a common line via affine parametrization) and IsRegularPolygon (common circumradius); the regular-polygon R-value claim is a documentary note only"
     },
     {
       "id": "extremal-configs",
       "title": "Extremal Configurations",
-      "summary": "IsOptimalConfig, optimal_exists",
-      "startLine": 179,
-      "endLine": 193,
-      "mathContext": "Mathematical content: IsOptimalConfig, optimal_exists"
+      "summary": "IsOptimalConfig (existence of optimal configs is a documentary note)",
+      "startLine": 258,
+      "endLine": 273,
+      "mathContext": "Formal definition: IsOptimalConfig (numDistinctRValues S = g S.card); the existence of optimal configurations for each n is a documentary note, not formalized"
     },
     {
       "id": "asymptotic",
       "title": "Asymptotic Analysis",
       "summary": "Asymptotic gap commentary in docstrings (no axioms in this section)",
-      "startLine": 194,
-      "endLine": 203,
-      "mathContext": "Mathematical content: asymptotic gap commentary (gap_lower_bound and gap_bounds in docstrings only)"
+      "startLine": 274,
+      "endLine": 285,
+      "mathContext": "Mathematical content: asymptotic gap commentary — the Ω(n^{2/3}) lower gap and the combined cn^{2/3} ≤ n - g(n) ≤ (3/10)n bound appear in docstrings only"
     },
     {
       "id": "connections",
       "title": "Connection to Unit Distance Problem",
       "summary": "unitDistPairs, totalDistinctDistances",
-      "startLine": 204,
-      "endLine": 223,
-      "mathContext": "Mathematical content: unitDistPairs, totalDistinctDistances"
+      "startLine": 286,
+      "endLine": 305,
+      "mathContext": "Mathematical content: unitDistPairs (points at unit distance from some other point) and totalDistinctDistances (biUnion of per-point distance sets), tying the R-value diversity to the unit-distance and distinct-distances problems"
     },
     {
       "id": "summary",
       "title": "Summary",
       "summary": "erdos_653_summary theorem, erdos_653 theorem",
-      "startLine": 224,
-      "endLine": 253,
-      "mathContext": "Verified: erdos_653_summary theorem, erdos_653 theorem"
+      "startLine": 306,
+      "endLine": 335,
+      "mathContext": "Verified: erdos_653_summary and erdos_653 bundle the three formalized facts — Csizmadia's g(n) > 7n/10 (axiom), the trivial g(n) ≤ n, and the nontrivial n - cn^{2/3} upper gap (axiom)"
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Enrichment: erdos-653 (Distinct Distance Counts in the Plane)

**Vein:** grown-file section drift. `Erdos653Problem.lean` grew from ~253 to 335 lines; the front 6 sections (Parts I–VI) stayed correctly anchored, but the back 5 (Parts VII–XI) were still pinned to stale line ranges 80+ lines short of their real positions, leaving the entire Part VII–XI tail (Special/Extremal Configurations, Asymptotic Analysis, Connections, and the capstone `erdos_653_summary`/`erdos_653` theorems) effectively uncovered.

### Changes (meta.json only)
- Re-anchored the 5 drifted tail sections to their true banners:
  - `special-configs` 154–178 → **232–257**
  - `extremal-configs` 179–193 → **258–273**
  - `asymptotic` 194–203 → **274–285**
  - `connections` 204–223 → **286–305**
  - `summary` 224–253 → **306–335** (EOF)
- Extended `basic-properties` endLine 210 → **231** (the `g_le_n_sub_one` `card_erase`/`Finset.Icc` counting argument runs to line 231, before Part VII).
- Deepened tail `mathContext` and corrected two stale summaries: `regular_polygon_r_value` and `optimal_exists` are documentary docstring notes, **not** formalized declarations.

Sections now tile the file 39–335 with no gaps or overlaps. No Lean source, status, badge, or `axiomCount` changes (remains `axiomatized`, 2 axioms: `csizmadia_bound`, `upper_bound`).
