### PR TITLE
audit: abel-ruffini-oq014 — clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -29864,6 +29864,12 @@
       "lastAudited": "2026-07-21T04:03:13Z",
       "result": "clean",
       "issues": []
+    },
+    "abel-ruffini-oq014": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T04:21:10Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Audit result: CLEAN

**Proof**: abel-ruffini-oq014 — Metabelian/Metacyclic Groups Are Solvable of Derived Length ≤ 2

### Verified
- **Counts match meta**: 5 theorems / 0 axioms / 0 sorries / 0 defs / 129 lines — all exact.
- **No True stubs, no vacuous statements**: every theorem has real content; conditional theorems take the abelian conditions (`hN`, `hQ` / `IsCyclic` instances) as explicit hypotheses — **no false axioms**.
- **Not a Mathlib wrapper**: `derivedSeries_two_eq_bot_of_metabelian` is a genuine two-step derived-series descent, not a single Mathlib call. Badge `verified/verified` is appropriate.
- **No `native_decide` / `decide`** — `Lean.ofReduceBool` not introduced; disclosure in `assumptions` is accurate.
- **Honest prose**: description explicitly credits Mathlib's derived-series API and correctly notes how the class-2 bound sharpens `solvable_of_ker_le_range`.

Persisting the clean audit to the tracker (fleet `git reset --hard` otherwise wipes it).

---
Discovered during gallery integrity audit.