### PR TITLE
Enrich 20 OQ entries: repair degenerate sections schema (line anchors + hidden text)

### DIFF
--- a/src/data/proofs/angle-trisection-oq-02-oq-02-oq-03/meta.json
+++ b/src/data/proofs/angle-trisection-oq-02-oq-02-oq-03/meta.json
@@ -130,30 +130,40 @@
     {
       "id": "rationals-negation",
       "title": "Part I: Rationals and negation are constructible",
+      "startLine": 1,
+      "endLine": 88,
       "summary": "isConstructibleFromQ_rat: every rational is a constructible real (witnessed by ⊥, degree 1=2⁰). isConstructibleFromQ_zero/one. isConstructibleFromQ_neg: the constructible reals are closed under negation, reusing the same field K (an intermediate field is closed under negation).",
       "mathContext": "$q\\in\\mathbb{Q}$ lies in $\\bot$ with $[\\bot:\\mathbb{Q}]=1=2^0$; closure under negation needs no compositum since $\\alpha\\in K\\Rightarrow-\\alpha\\in K$."
     },
     {
       "id": "complex-constructibility",
       "title": "Part II: Complex constructibility",
+      "startLine": 89,
+      "endLine": 151,
       "summary": "IsConstructibleℂ z := IsConstructibleFromQ z.re ∧ IsConstructibleFromQ z.im. Proves 0, 1, i constructible; the real/imaginary embedding iff; Gaussian rationals; conjugation closure and its iff; closure under multiplication by i (Re(i·z)=−Im z, Im(i·z)=Re z).",
       "mathContext": "The structural backbone of the complex constructibles obtainable purely from real-part/imaginary-part identities plus negation closure — no field-degree arithmetic."
     },
     {
       "id": "analytic-bridge",
       "title": "Part III: The analytic bridge (sin from cos)",
+      "startLine": 152,
+      "endLine": 165,
       "summary": "axiom sin_constructible_of_cos: for n ≥ 3, IsConstructibleFromQ (cos(2π/n)) → IsConstructibleFromQ (sin(2π/n)). The only new assumption, capturing closure of the constructible reals under the non-negative square root sin(2π/n)=√(1−cos²(2π/n)).",
       "mathContext": "For $n\\ge3$, $2\\pi/n\\in(0,\\pi)$ so $\\sin(2\\pi/n)\\ge0$; the constructible reals form a field closed under square roots, which supplies the imaginary coordinate."
     },
     {
       "id": "headline",
       "title": "Part IV: The headline — planar Gauss–Wantzel",
+      "startLine": 166,
+      "endLine": 188,
       "summary": "rootOfUnity_isConstructibleℂ_iff_cos: vertex constructible ↔ cos(2π/n) constructible. ngon_vertex_isConstructibleℂ_iff: vertex constructible ↔ φ(n) a power of two (combining the cos bridge with the parent's gauss_wantzel_theorem).",
       "mathContext": "$\\exp(2\\pi i/n)=\\cos(2\\pi/n)+i\\sin(2\\pi/n)$; constructibility of the complex vertex is equivalent to that of its real coordinate, hence to $\\varphi(n)=2^k$."
     },
     {
       "id": "instances",
       "title": "Parts V–VI: Constructible and non-constructible vertices",
+      "startLine": 189,
+      "endLine": 274,
       "summary": "Constructible: 3-, 4-, 5-, 15-, 17-gon vertices (φ = 2,2,4,8,16). Not constructible: 7- and 9-gon vertices (φ(7)=φ(9)=6, not a power of two). All via kernel decide on the totients.",
       "mathContext": "Worked planar instances derived from the headline equivalence."
     }

--- a/src/data/proofs/bernoulli-inequality-oq002/meta.json
+++ b/src/data/proofs/bernoulli-inequality-oq002/meta.json
@@ -107,27 +107,37 @@
     {
       "id": "trap",
       "title": "The generalized trap",
-      "content": "From |x| ≤ B (which forces 0 ≤ B), the identity |xⁿ| = |x|ⁿ (abs_pow) together with pow_le_pow_left₀ gives |xⁿ| ≤ Bⁿ. Splitting this with abs_le yields the two walls −Bⁿ ≤ xⁿ ≤ Bⁿ: every power of a magnitude-≤ B base lives in the n-dependent band [−Bⁿ, Bⁿ]. This is the verbatim generalization of the parent's band [−1, 1]."
+      "startLine": 1,
+      "endLine": 71,
+      "summary": "From |x| ≤ B (which forces 0 ≤ B), the identity |xⁿ| = |x|ⁿ (abs_pow) together with pow_le_pow_left₀ gives |xⁿ| ≤ Bⁿ (abs_pow_le). Splitting this with abs_le yields the two walls −Bⁿ ≤ xⁿ (neg_pow_le_pow) and xⁿ ≤ Bⁿ (pow_le_pow_band): every power of a magnitude-≤ B base lives in the n-dependent band [−Bⁿ, Bⁿ]. This is the verbatim generalization of the parent's fixed band [−1, 1]."
     },
     {
       "id": "engine",
       "title": "The escape engine",
-      "content": "Two one-step comparisons hold for any B: anything strictly below the lower wall, c < −Bⁿ, is beaten by every power (lt_pow_of_lt_neg_pow: c < xⁿ); anything strictly above the upper wall, Bⁿ < c, beats every power (pow_lt_of_pow_lt: xⁿ < c). These are the building blocks for both sides of the dichotomy."
+      "startLine": 72,
+      "endLine": 83,
+      "summary": "Two one-step comparisons hold for any B: anything strictly below the lower wall, c < −Bⁿ, is beaten by every power (lt_pow_of_lt_neg_pow: c < xⁿ); anything strictly above the upper wall, Bⁿ < c, beats every power (pow_lt_of_pow_lt: xⁿ < c). These are the building blocks for both sides of the dichotomy."
     },
     {
       "id": "shrinking",
       "title": "Shrinking / critical band (0 ≤ B ≤ 1): lines escape",
-      "content": "When B ≤ 1 the wall Bⁿ never exceeds 1 (pow_le_one₀), so the band sits inside [−1, 1] and the parent's argument survives unchanged. A negative-slope line b + n·s eventually drops below −1 ≤ −Bⁿ (threshold N > (b+1)/(−s) from exists_nat_gt), hence below every power (eventually_line_lt_pow_band); the positive-slope mirror is eventually_pow_lt_line_band. The parent (B = 1) is the boundary case."
+      "startLine": 84,
+      "endLine": 127,
+      "summary": "When B ≤ 1 the wall Bⁿ never exceeds 1 (pow_le_one₀, via pow_le_one_of_le_one), so the band sits inside [−1, 1] and the parent's argument survives unchanged. A negative-slope line b + n·s eventually drops below −1 ≤ −Bⁿ (threshold N > (b+1)/(−s) from exists_nat_gt), hence below every power (eventually_line_lt_pow_band); the positive-slope mirror is eventually_pow_lt_line_band. The parent (B = 1) is the boundary case."
     },
     {
       "id": "growing",
       "title": "Growing band (B > 1): the band captures every line",
-      "content": "When B > 1 the walls ±Bⁿ grow exponentially. The quotient (|b| + |s|·n)/Bⁿ → 0 (tendsto_linear_div_pow, built from tendsto_pow_const_div_const_pow_of_one_lt with k = 0, 1), so eventually |b| + |s|·n < Bⁿ (div_lt_one). Bounding the line by its linear envelope (abs_add_le) gives |b + n·s| < Bⁿ, i.e. the line is trapped strictly inside (−Bⁿ, Bⁿ) (eventually_line_mem_band). No line of any slope escapes — the exact opposite of the B ≤ 1 case."
+      "startLine": 128,
+      "endLine": 184,
+      "summary": "When B > 1 the walls ±Bⁿ grow exponentially. The quotient (|b| + |s|·n)/Bⁿ → 0 (tendsto_linear_div_pow, built from tendsto_pow_const_div_const_pow_of_one_lt with k = 0, 1), so eventually |b| + |s|·n < Bⁿ (div_lt_one). Bounding the line by its linear envelope (abs_add_le) gives |b + n·s| < Bⁿ, i.e. the line is trapped strictly inside (−Bⁿ, Bⁿ) (eventually_line_mem_band, unpacked as eventually_neg_pow_lt_line_lt_pow). No line of any slope escapes — the exact opposite of the B ≤ 1 case."
     },
     {
       "id": "dichotomy",
       "title": "The boundary dichotomy",
-      "content": "escape_or_capture packages the contrast for a fixed negative-slope line: if B > 1 the line is eventually captured inside the band, while if B ≤ 1 it eventually escapes below every power. The single comparison B ≷ 1 flips capture into escape, identifying the parent's fixed band B = 1 as the precise critical threshold the parent's open question asked about."
+      "startLine": 185,
+      "endLine": 215,
+      "summary": "escape_or_capture packages the contrast for a fixed negative-slope line: if B > 1 the line is eventually captured inside the band, while if B ≤ 1 it eventually escapes below every power. The single comparison B ≷ 1 flips capture into escape, identifying the parent's fixed band B = 1 as the precise critical threshold the parent's open question asked about. The closing sanity checks exhibit both regimes (line 10 − n escaping the B = 1/2 band; line 5 + 100·n captured inside the B = 2 band)."
     }
   ],
   "overview": {

--- a/src/data/proofs/derangements-oq-03-oq-03-oq-01/meta.json
+++ b/src/data/proofs/derangements-oq-03-oq-03-oq-01/meta.json
@@ -53,16 +53,36 @@
   ],
   "sections": [
     {
-      "title": "Fixed Set as a Group-Action Fixed Set"
+      "id": "fixed-set-as-group-action",
+      "title": "Fixed Set as a Group-Action Fixed Set",
+      "startLine": 1,
+      "endLine": 77,
+      "summary": "Module overview plus the reconciliation of two fixed-set notions. A noncomputable Fintype instance is placed on the orbit quotient of the Sₙ-action (needed to state the Burnside count). `fixedBy_eq_fixedPoints`: Mathlib's group-action fixed set `MulAction.fixedBy (Fin n) σ` equals the dynamical `Function.fixedPoints σ` — both are {x | σ x = x}, the only content being unfolding the `Equiv.Perm` scalar action σ • x = σ x. `ncard_fixedPoints_eq_card_fixedBy`: the parent's `Set.ncard` count used in the trace formula equals the `Fintype.card` of that group-action fixed set consumed by Burnside's lemma.",
+      "mathContext": "$\\mathrm{fixedBy}(\\mathrm{Fin}\\,n)\\,\\sigma=\\mathrm{Fix}(\\sigma)=\\{x\\mid\\sigma x=x\\}$"
     },
     {
-      "title": "Transitivity: a Single Orbit"
+      "id": "transitivity-single-orbit",
+      "title": "Transitivity: a Single Orbit",
+      "startLine": 78,
+      "endLine": 93,
+      "summary": "`card_orbits_eq_one`: for n ≥ 1 (`[NeZero n]`, with `Fin n` nonempty via 0) the natural action of Sₙ = Perm (Fin n) on Fin n is pretransitive, so by `pretransitive_iff_unique_quotient_of_nonempty` the orbit quotient is a singleton and its cardinality is exactly 1 — the symmetric group has a single orbit.",
+      "mathContext": "$\\#\\bigl((\\mathrm{Fin}\\,n)/S_n\\bigr)=1$"
     },
     {
-      "title": "The Burnside Count: Total Fixed Points = n!"
+      "id": "burnside-count",
+      "title": "The Burnside Count: Total Fixed Points = n!",
+      "startLine": 94,
+      "endLine": 107,
+      "summary": "`sum_card_fixedBy`: the Cauchy–Frobenius/Burnside identity `MulAction.sum_card_fixedBy_eq_card_orbits_mul_card_group`, ∑_{σ∈Sₙ} |Fix σ| = (#orbits)·|Sₙ|, specialised to the transitive symmetric-group action. The single orbit and |Sₙ| = n! (via `Fintype.card_perm`, `Fintype.card_fin`) collapse the total to 1·n! = n!.",
+      "mathContext": "$\\sum_{\\sigma\\in S_n}|\\mathrm{Fix}\\,\\sigma|=(\\#\\text{orbits})\\cdot|S_n|=1\\cdot n!=n!$"
     },
     {
-      "title": "Trace Bridge and the Expected Value"
+      "id": "trace-bridge-and-expected-value",
+      "title": "Trace Bridge and the Expected Value",
+      "startLine": 108,
+      "endLine": 157,
+      "summary": "`trace_permMatrix_eq_card_fixedBy` recasts the parent's `Matrix.trace_permutation` so trace (σ.permMatrix ℝ) equals the fixed-point count. `sum_trace_permMatrix`: summing over all σ transports the Burnside total, giving total trace = n!. `expected_trace_eq_one` and `expected_fixed_points_eq_one`: dividing by |Sₙ| = n! (nonzero via `Nat.factorial_ne_zero`) yields the expected trace — equivalently the expected number of fixed points of a uniformly random permutation of Fin n — exactly 1 for every n ≥ 1.",
+      "mathContext": "$\\dfrac{1}{n!}\\sum_{\\sigma\\in S_n}\\mathrm{tr}(\\sigma.\\mathrm{permMatrix}\\,\\mathbb{R})=1$"
     }
   ],
   "references": [

--- a/src/data/proofs/descartes-rule-of-signs-oq-01-oq-04-oq-02/meta.json
+++ b/src/data/proofs/descartes-rule-of-signs-oq-01-oq-04-oq-02/meta.json
@@ -70,21 +70,29 @@
     {
       "id": "module-header",
       "title": "Module: Boundary Exact Count via IVT",
+      "startLine": 1,
+      "endLine": 64,
       "summary": "Module docstring framing the boundary cases of Descartes' Rule, why the parity refinement is unavailable (hard FTA content, only ever assumed in the gallery), and how root existence — not parity — settles signVariations ∈ {0,1}. Notes the ℝ-only scope (X²−2 counterexample over ℚ)."
     },
     {
       "id": "zero-case",
       "title": "Part 1: Zero Sign Variations ⟹ No Positive Roots",
+      "startLine": 65,
+      "endLine": 74,
       "summary": "no_pos_roots_of_signVariations_zero: from Mathlib's Descartes bound, signVariations = 0 forces the positive-root count to 0. No parity, no analysis."
     },
     {
       "id": "ivt-existence",
       "title": "Part 2: Opposite Leading/Trailing Signs Force a Positive Root (IVT)",
+      "startLine": 75,
+      "endLine": 165,
       "summary": "exists_pos_root_of_sign_opposition: the analytic heart. Deflate P = Xᵐ·Q (largest power of X), establish Q.eval 0 = trailingCoeff ≠ 0, Q.leadingCoeff = P.leadingCoeff, and positive degree of Q. Use the ±∞ asymptotics to find a far point carrying the leading sign, then the Intermediate Value Theorem to cross zero in (0, ∞)."
     },
     {
       "id": "boundary-count",
       "title": "Part 3: One Sign Variation ⟹ Exactly One Positive Root",
+      "startLine": 166,
+      "endLine": 192,
       "summary": "exactly_one_pos_root_of_sign_opposition: combine Descartes' upper bound (≤ 1) with the IVT existence (≥ 1) to pin the count at exactly 1, conditional on the combinatorial sign opposition. No parity refinement used."
     }
   ],

--- a/src/data/proofs/descartes-rule-of-signs-oq-01-oq-04-oq-03/meta.json
+++ b/src/data/proofs/descartes-rule-of-signs-oq-01-oq-04-oq-03/meta.json
@@ -78,26 +78,36 @@
     {
       "id": "module-header",
       "title": "Module: Genericity and Map-Invariance",
+      "startLine": 1,
+      "endLine": 59,
       "summary": "Frames the two loose threads of the parent — the ℚ-pinned coefficient field and the merely-rational root bound — and states the hinge result: signVariations is invariant under strictly monotone ring homs."
     },
     {
       "id": "generic-count",
       "title": "Part I: The Computable Count over an Arbitrary Ordered Field",
+      "startLine": 60,
+      "endLine": 94,
       "summary": "signVarList : List F → ℕ for [Field F] [LinearOrder F] [IsStrictOrderedRing F], the rfl bridge signVarList_coeffList, the transported bound posRoots_le_signVarList, and the no-positive-roots certificate — all field-generic."
     },
     {
       "id": "map-invariance",
       "title": "Part II: Invariance under a Strictly Monotone Ring Homomorphism",
+      "startLine": 95,
+      "endLine": 143,
       "summary": "coeffList_map_of_injective (the coefficient list commutes with an injective hom), sign_map_of_strictMono (signs are preserved), and the headline signVariations_map combining them: (P.map φ).signVariations = P.signVariations."
     },
     {
       "id": "rat-real-bridge",
       "title": "Part III: The ℚ → ℝ Bridge — Seeing the Real Roots",
+      "startLine": 144,
+      "endLine": 174,
       "summary": "signVarList_eq_signVariations_ratCast: the computable ℚ count equals the real polynomial's sign-variation count. realRoots_countP_pos_le_signVarList: Descartes' bound for positive REAL roots, computed from rational coefficients."
     },
     {
       "id": "worked-examples",
       "title": "Part IV: Worked Computable Examples",
+      "startLine": 175,
+      "endLine": 202,
       "summary": "The parent's ℚ examples recovered as instances of the now field-generic definition, discharged by kernel decide (no native_decide)."
     }
   ],

--- a/src/data/proofs/descartes-rule-of-signs-oq-01-oq-04/meta.json
+++ b/src/data/proofs/descartes-rule-of-signs-oq-01-oq-04/meta.json
@@ -68,26 +68,36 @@
     {
       "id": "module-header",
       "title": "Module: Constructive Sign-Variation Count",
+      "startLine": 1,
+      "endLine": 53,
       "summary": "Module docstring framing the OQ: Mathlib's signVariations is noncomputable over ℝ/ℚ (coeffList and the real sign map do not reduce). Spells out which half of Descartes' Rule is constructive (the bound) and which is not (the root count, needing Sturm)."
     },
     {
       "id": "computable-count",
       "title": "Part 1: The Computable Core",
+      "startLine": 54,
+      "endLine": 66,
       "summary": "signVarList : List ℚ → ℕ, a decidable mirror of Polynomial.signVariations on an explicit rational coefficient list. Every operation reduces in the kernel, so the function #evals and is provable by decide."
     },
     {
       "id": "bridge-and-bound",
       "title": "Part 2: Correctness Bridge and Transported Bound",
+      "startLine": 67,
+      "endLine": 84,
       "summary": "signVarList_coeffList: signVarList P.coeffList = P.signVariations by rfl, certifying the algorithm. posRoots_le_signVarList: Mathlib's Descartes bound restated with the computable count on the right."
     },
     {
       "id": "decidable-certificate",
       "title": "Part 3: Decidable Certificate of No Positive Roots",
+      "startLine": 85,
+      "endLine": 104,
       "summary": "no_pos_roots_of_signVarList_zero: the decidable test signVarList P.coeffList = 0 soundly proves P has no positive roots. signVarList_pos_of_pos_roots: the contrapositive — a positive root forces a positive variation count."
     },
     {
       "id": "worked-examples",
       "title": "Part 4: Worked Computable Examples",
+      "startLine": 105,
+      "endLine": 134,
       "summary": "Seven explicit coefficient lists discharged by kernel decide: [1,-1,-1,1]→2, [1,3,2]→0 (certificate fires), [1,0,-1]→1, interior zeros never count, fully alternating lists realise the maximum, and the empty/singleton lists give 0."
     }
   ],

--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-03/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-03/meta.json
@@ -42,24 +42,39 @@
   },
   "sections": [
     {
+      "id": "mult-by-unit-permutation-whole-ring",
       "title": "Multiplication by a unit as a permutation of the whole ring",
-      "content": "ringMulPerm a is the permutation x ↦ a·x of all of ℤ/n (not just the units), assembled into a group homomorphism ringMulPermHom : (ℤ/n)ˣ →* Perm (ℤ/n)."
+      "startLine": 1,
+      "endLine": 80,
+      "summary": "ringMulPerm a is the permutation x ↦ a·x of all of ℤ/n (not just the units), with ringMulPerm_one, ringMulPerm_mul and the simp lemma ringMulPerm_apply establishing that it is multiplicative, assembled into the group homomorphism ringMulPermHom : (ℤ/n)ˣ →* Perm (ℤ/n). Acting on the whole ring is essential: |ℤ/n| = n is odd for odd n, whereas |(ℤ/n)ˣ| = φ(n) is even and would trivialise every sign."
     },
     {
+      "id": "zolotarev-sign-character-any-modulus",
       "title": "The Zolotarev sign character for any modulus",
-      "content": "signRingHom = sign ∘ ringMulPermHom : (ℤ/n)ˣ →* ℤˣ, a quadratic character (squares to 1) defined for every positive modulus."
+      "startLine": 81,
+      "endLine": 98,
+      "summary": "signRingHom = sign ∘ ringMulPermHom : (ℤ/n)ˣ →* ℤˣ, the Zolotarev sign character defined for every positive modulus (the parent only had the prime case). signRingHom_sq shows it is a quadratic character (squares to 1) via Int.units_sq."
     },
     {
+      "id": "sign-of-product-permutation",
       "title": "Sign of a product permutation",
-      "content": "sign_prodCongr: sign(σ ×ₚ τ) = sign σ ^ |β| · sign τ ^ |α|, plus units_pow_odd (u^k = u for u ∈ ℤˣ and odd k). General lemmas not in Mathlib."
+      "startLine": 99,
+      "endLine": 127,
+      "summary": "sign_prodCongr: sign(σ ×ₚ τ) = sign σ ^ |β| · sign τ ^ |α|, derived by decomposing σ.prodCongr τ into prodCongrLeft/prodCongrRight of constant families and applying sign_prodCongrLeft / sign_prodCongrRight. Accompanied by units_pow_odd (u^k = u for u ∈ ℤˣ and odd k, since ℤˣ = {±1} has exponent 2). Both are general lemmas not in Mathlib."
     },
     {
+      "id": "crt-decomposition",
       "title": "The CRT decomposition",
-      "content": "sign_ringMulPerm_crt factors the sign through ZMod.chineseRemainder; sign_ringMulPerm_mul_of_odd specializes to odd coprime moduli, where the character is multiplicative — the permutation image of jacobiSym.mul_right."
+      "startLine": 128,
+      "endLine": 178,
+      "summary": "sign_ringMulPerm_crt factors the sign through the Chinese Remainder isomorphism ZMod.chineseRemainder: sign(ringMulPerm a) = sign(ringMulPerm a₁)^n · sign(ringMulPerm a₂)^m, because the CRT iso intertwines multiplication-by-a with the product permutation (sign_eq_sign_of_equiv + sign_prodCongr + ZMod.card). sign_ringMulPerm_mul_of_odd specializes to odd coprime moduli, where the odd exponents collapse via units_pow_odd and the character becomes genuinely multiplicative — the permutation image of jacobiSym.mul_right."
     },
     {
+      "id": "parallel-with-jacobi-symbol",
       "title": "Parallel with the Jacobi symbol",
-      "content": "jacobiSym_mul_right_mirror restates Mathlib's jacobiSym.mul_right (the value-level statement mirrored by the sign decomposition); legendre_eq_jacobi records the prime base case legendreSym.to_jacobiSym."
+      "startLine": 179,
+      "endLine": 261,
+      "summary": "jacobiSym_mul_right_mirror restates Mathlib's jacobiSym.mul_right (the value-level statement mirrored by the sign decomposition); legendre_eq_jacobi records the prime base case legendreSym.to_jacobiSym. The trailing examples confirm signRingHom is a group homomorphism (map_one, map_mul) for composite moduli, and the closing summary block recaps the CRT mechanism and its honest scope (structural decomposition, not yet closing the loop to Jacobi values)."
     }
   ],
   "meta": {

--- a/src/data/proofs/elementary-quadratic-reciprocity-oq004/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq004/meta.json
@@ -44,16 +44,27 @@
   },
   "sections": [
     {
+      "id": "integer-unit-from-coprimality",
       "title": "The integer unit from a coprimality hypothesis",
-      "content": "intCast_isUnit_of_isCoprime: if an integer c is coprime to k, then (c : ℤ/k) is a unit. Bezout's x·c + y·k = 1 reduces mod k (where k = 0) to x·c = 1, exhibiting the inverse. This manufactures the CRT component units at each prime factor."
+      "startLine": 1,
+      "endLine": 82,
+      "summary": "intCast_isUnit_of_isCoprime: if an integer c is coprime to k, then (c : ℤ/k) is a unit. Bezout's x·c + y·k = 1 reduces mod k (where k = 0) to x·c = 1, exhibiting the inverse. This manufactures the CRT component units at each prime factor. The header sets up the goal: the squarefree-odd Frobenius/Jacobi Zolotarev lemma sign(ringMulPerm a on ℤ/n) = J(a | n).",
+      "mathContext": "$\\operatorname{sign}(x \\mapsto a\\cdot x \\text{ on } \\mathbb{Z}/n) = \\left(\\tfrac{a}{n}\\right)$ for $n$ odd squarefree"
     },
     {
+      "id": "main-induction",
       "title": "The main induction",
-      "content": "main: strong induction on n via its smallest prime factor. The n = 1 base uses the subsingleton structure of ℤ/1; the inductive step splits n = p·m coprimely, applies the grandparent's CRT multiplicativity, the parent's prime base case, the inductive hypothesis on the cofactor, and jacobiSym.mul_right to assemble J(a | n)."
+      "startLine": 83,
+      "endLine": 162,
+      "summary": "main: strong induction on n via its smallest prime factor. The n = 1 base uses the subsingleton structure of ℤ/1; the inductive step splits n = p·m coprimely, applies the grandparent's CRT multiplicativity (sign_ringMulPerm_mul_of_odd), the parent's prime base case (sign = legendreSym), the inductive hypothesis on the cofactor m, and jacobiSym.mul_right to assemble J(a | n).",
+      "mathContext": "$\\operatorname{sign}(\\operatorname{ringMulPerm} u) = \\operatorname{sign}(\\operatorname{ringMulPerm} u_1)\\cdot\\operatorname{sign}(\\operatorname{ringMulPerm} u_2) = \\left(\\tfrac{c}{p}\\right)\\left(\\tfrac{c}{m}\\right) = \\left(\\tfrac{c}{pm}\\right)$"
     },
     {
+      "id": "clean-statement",
       "title": "Clean statement",
-      "content": "sign_ringMulPerm_eq_jacobiSym: the result in ordinary binder form — for n odd squarefree, c coprime to n, and the unit u representing c, sign(ringMulPerm u) = J(c | n)."
+      "startLine": 163,
+      "endLine": 211,
+      "summary": "sign_ringMulPerm_eq_jacobiSym: the result in ordinary binder form — for n odd squarefree, c coprime to n, and the unit u representing c, sign(ringMulPerm u) = J(c | n). Followed by the summary docstring recording the honest scope (squarefree odd only; prime-power factors left to a follow-up) and the #check lines."
     }
   ],
   "meta": {

--- a/src/data/proofs/elementary-quadratic-reciprocity-oq005/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq005/meta.json
@@ -43,16 +43,28 @@
   },
   "sections": [
     {
+      "id": "left-regular-representation-generic",
       "title": "The left regular representation of a finite group (generic)",
-      "content": "mulLeftHom : G →* Perm G packages left translation as a monoid hom. mulLeft_no_fixed: translation by a ≠ 1 has no fixed point (mul_right_cancel). mulLeft_generator_isCycle / mulLeft_support_eq_univ: a generator's translation is a single full-support cycle. sign_mulLeft_generator: its sign is -1 when |G| is even. sign_mulLeft_pow: sign of translation is multiplicative under powers. These hold for any finite group and isolate the group-theoretic core."
+      "startLine": 1,
+      "endLine": 124,
+      "summary": "mulLeftHom : G →* Perm G packages left translation as a monoid hom. mulLeft_no_fixed: translation by a ≠ 1 has no fixed point (mul_right_cancel). mulLeft_generator_isCycle / mulLeft_support_eq_univ: a generator's translation is a single full-support cycle. generator_ne_one: a generator of a group with >1 element is nontrivial. sign_mulLeft_generator: its sign is -1 when |G| is even. sign_mulLeft_pow: sign of translation is multiplicative under powers. These hold for any finite group and isolate the group-theoretic core.",
+      "mathContext": "$\\operatorname{sign}(\\operatorname{mulLeft} g) = -1$ for a generator $g$ of an even-order cyclic group"
     },
     {
+      "id": "prime-power-unit-group-even",
       "title": "The prime-power unit group has even order",
-      "content": "card_units_prime_pow_even: |(ℤ/pⁿ)ˣ| = pⁿ⁻¹(p-1) via ZMod.card_units_eq_totient and Nat.totient_prime_pow, which is even because p-1 is even for an odd prime p."
+      "startLine": 125,
+      "endLine": 137,
+      "summary": "card_units_prime_pow_even: |(ℤ/pⁿ)ˣ| = pⁿ⁻¹(p-1) via ZMod.card_units_eq_totient and Nat.totient_prime_pow, which is even because p-1 is even for an odd prime p.",
+      "mathContext": "$|(\\mathbb{Z}/p^n)^\\times| = p^{n-1}(p-1)$ is even for odd prime $p$"
     },
     {
+      "id": "units-level-prime-power-zolotarev",
       "title": "The units-level prime-power Zolotarev lemma",
-      "content": "sign_mulLeft_eq_quadraticChar and sign_mulLeft_eq_legendre: for an odd prime p and n ≥ 1, the sign of left multiplication by u on (ℤ/pⁿ)ˣ equals the quadratic character (resp. Legendre symbol mod p) of the reduction ρ u. Proof: instantiate the generic machinery on the cyclic group (ℤ/pⁿ)ˣ; both sides are -1 at a generator g (single even cycle; ρ g a non-residue), and u = gᵏ makes both (-1)ᵏ."
+      "startLine": 138,
+      "endLine": 202,
+      "summary": "sign_mulLeft_eq_quadraticChar and sign_mulLeft_eq_legendre: for an odd prime p and n ≥ 1, the sign of left multiplication by u on (ℤ/pⁿ)ˣ equals the quadratic character (resp. Legendre symbol mod p) of the reduction ρ u. Proof: instantiate the generic machinery on the cyclic group (ℤ/pⁿ)ˣ (ZMod.isCyclic_units_of_prime_pow); both sides are -1 at a generator g (single even cycle; ρ g a non-residue, ρ surjective), and u = gᵏ makes both (-1)ᵏ.",
+      "mathContext": "$\\operatorname{sign}(x \\mapsto u\\cdot x \\text{ on } (\\mathbb{Z}/p^n)^\\times) = \\left(\\tfrac{\\rho u}{p}\\right)$"
     }
   ],
   "meta": {

--- a/src/data/proofs/elementary-quadratic-reciprocity-oq006/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq006/meta.json
@@ -43,20 +43,36 @@
   },
   "sections": [
     {
+      "id": "p-multiplication-bridge",
       "title": "The p-multiplication bridge on ℤ/pⁿ⁺¹",
-      "content": "mul_p_eq_zero_iff: p·z = 0 in ℤ/pⁿ⁺¹ iff z reduces to 0 in ℤ/pⁿ (both express pⁿ ∣ z.val), via ZMod.natCast_eq_zero_iff and cancelling one factor of p (Nat.mul_dvd_mul_iff_left). mul_p_of_castHom_eq and castHom_eq_of_mul_p_eq promote this to p·u = p·v ⟺ castHom u = castHom v — the single fact behind both the non-unit isomorphism and its intertwining."
+      "startLine": 1,
+      "endLine": 110,
+      "summary": "After the header and the generic bijection unitsEquivIsUnit (Mˣ ≃ {x // IsUnit x}), the bridge lemmas: mul_p_eq_zero_iff: p·z = 0 in ℤ/pⁿ⁺¹ iff z reduces to 0 in ℤ/pⁿ (both express pⁿ ∣ z.val), via ZMod.natCast_eq_zero_iff and cancelling one factor of p (Nat.mul_dvd_mul_iff_left). mul_p_of_castHom_eq and castHom_eq_of_mul_p_eq promote this to p·u = p·v ⟺ castHom u = castHom v — the single fact behind both the non-unit isomorphism and its intertwining.",
+      "mathContext": "$p\\cdot u = p\\cdot v \\iff u \\equiv v \\pmod{p^n}$"
     },
     {
+      "id": "non-unit-block-is-zmod",
       "title": "The non-unit block is ℤ/pⁿ⁻¹",
-      "content": "not_isUnit_mul_p: p·z is never a unit (ZMod.isUnit_iff_coprime). nonUnitsFun / nonUnitsFun_bijective / nonUnitsEquiv: y ↦ p·(lift y) is a bijection ℤ/pⁿ ≃ {non-units of ℤ/pⁿ⁺¹}, injective by the bridge and surjective by counting (pⁿ⁺¹ − φ(pⁿ⁺¹) = pⁿ)."
+      "startLine": 111,
+      "endLine": 170,
+      "summary": "not_isUnit_mul_p: p·z is never a unit (ZMod.isUnit_iff_coprime). nonUnitsFun / nonUnitsFun_bijective / nonUnitsEquiv: y ↦ p·(lift y) is a bijection ℤ/pⁿ ≃ {non-units of ℤ/pⁿ⁺¹}, injective by the bridge and surjective by counting (pⁿ⁺¹ − φ(pⁿ⁺¹) = pⁿ). nonUnitsEquiv_apply_coe records the underlying ring value of the bijection.",
+      "mathContext": "$\\{\\,x \\in \\mathbb{Z}/p^{n+1} : \\neg\\,\\text{IsUnit } x\\,\\} \\simeq \\mathbb{Z}/p^n$"
     },
     {
+      "id": "prime-power-recursion-whole-ring-sign",
       "title": "The prime-power recursion for the whole-ring sign",
-      "content": "sign_ringMulPerm_succ: for a unit a : (ℤ/pⁿ⁺¹)ˣ, sign(ringMulPerm a) = legendreSym p (a mod p) · sign(ringMulPerm ā on ℤ/pⁿ). Proof: sign_subtypeCongr factors the sign over the units / non-units partition; the units block is sign(Equiv.mulLeft a) = legendreSym p (a mod p) (parent lemma, transported via units↔IsUnit-subtype equiv); the non-unit block is sign(ringMulPerm ā) (transported via the μ-bijection, intertwining from the bridge)."
+      "startLine": 171,
+      "endLine": 258,
+      "summary": "sign_ringMulPerm_succ: for a unit a : (ℤ/pⁿ⁺¹)ˣ, sign(ringMulPerm a) = legendreSym p (a mod p) · sign(ringMulPerm ā on ℤ/pⁿ). Proof: sign_subtypeCongr factors the sign over the units / non-units partition; the units block is sign(Equiv.mulLeft a) = legendreSym p (a mod p) (parent lemma, transported via units↔IsUnit-subtype equiv); the non-unit block is sign(ringMulPerm ā) (transported via the μ-bijection, intertwining from the bridge).",
+      "mathContext": "$\\operatorname{sign}(\\operatorname{ringMulPerm} a) = \\left(\\tfrac{a}{p}\\right)\\cdot\\operatorname{sign}(\\operatorname{ringMulPerm} \\bar a)$"
     },
     {
+      "id": "prime-power-zolotarev-frobenius-identity",
       "title": "The prime-power Zolotarev–Frobenius identity",
-      "content": "sign_ringMulPerm_eq_legendre_pow: iterating the recursion, sign(ringMulPerm a on ℤ/pⁿ) = legendreSym p (a mod p)ⁿ. jacobiSym_prime_pow + sign_ringMulPerm_eq_jacobiSym: J(A | pⁿ) = (legendreSym p A)ⁿ (jacobiSym.mul_right), so the sign equals the Jacobi symbol J(a | pⁿ) — closing the prime-power case."
+      "startLine": 259,
+      "endLine": 318,
+      "summary": "sign_ringMulPerm_eq_legendre_pow: iterating the recursion, sign(ringMulPerm a on ℤ/pⁿ) = legendreSym p (a mod p)ⁿ. jacobiSym_prime_pow + sign_ringMulPerm_eq_jacobiSym: J(A | pⁿ) = (legendreSym p A)ⁿ (jacobiSym.mul_right), so the sign equals the Jacobi symbol J(a | pⁿ) — closing the prime-power case.",
+      "mathContext": "$\\operatorname{sign}(\\operatorname{ringMulPerm} a \\text{ on } \\mathbb{Z}/p^n) = \\left(\\tfrac{a}{p}\\right)^n = \\left(\\tfrac{a}{p^n}\\right)$"
     }
   ],
   "meta": {

--- a/src/data/proofs/elementary-quadratic-reciprocity-oq007/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq007/meta.json
@@ -43,20 +43,36 @@
   },
   "sections": [
     {
+      "id": "generic-bridges-units-crt-legendre",
       "title": "Generic bridges: units reduction, CRT components, legendreSym congruence",
-      "content": "coe_unitsMap: (ZMod.unitsMap h u : ℤ/m) = castHom h (u : ℤ/n). chineseRemainder_fst / chineseRemainder_snd: the two projections of ZMod.chineseRemainder are the canonical casts to ℤ/m and ℤ/n — proved by RingHom.ext_zmod (any two ring homs out of ℤ/(m·n) are equal). legendreSym_congr: equal residues mod p give equal Legendre symbols (legendreSym.mod + ZMod.intCast_eq_intCast_iff)."
+      "startLine": 1,
+      "endLine": 102,
+      "summary": "coe_unitsMap: (ZMod.unitsMap h u : ℤ/m) = castHom h (u : ℤ/n). chineseRemainder_fst / chineseRemainder_snd: the two projections of ZMod.chineseRemainder are the canonical casts to ℤ/m and ℤ/n — proved by RingHom.ext_zmod (any two ring homs out of ℤ/(m·n) are equal). legendreSym_congr: equal residues mod p give equal Legendre symbols (legendreSym.mod + ZMod.intCast_eq_intCast_iff).",
+      "mathContext": "$(\\text{chineseRemainder } x)_1 = \\operatorname{castHom} x$;  $A \\equiv B \\pmod p \\Rightarrow \\left(\\tfrac{A}{p}\\right) = \\left(\\tfrac{B}{p}\\right)$"
     },
     {
+      "id": "prime-power-base-representative-free",
       "title": "The prime-power base in representative-free form",
-      "content": "sign_ringMulPerm_eq_jacobiSym_of_cast: for an odd prime p, k ≥ 1, a unit a : (ℤ/pᵏ)ˣ and any integer A ≡ a (mod pᵏ), sign(ringMulPerm a) = J(A | pᵏ). Repackages the parent's sign_ringMulPerm_eq_legendre_pow and jacobiSym_prime_pow, reducing both legendre symbols (of (a mod p).val and of A) to the same residue mod p via legendreSym_congr and one cast of the hypothesis A ≡ a down to ℤ/p."
+      "startLine": 103,
+      "endLine": 131,
+      "summary": "sign_ringMulPerm_eq_jacobiSym_of_cast: for an odd prime p, k ≥ 1, a unit a : (ℤ/pᵏ)ˣ and any integer A ≡ a (mod pᵏ), sign(ringMulPerm a) = J(A | pᵏ). Repackages the parent's sign_ringMulPerm_eq_legendre_pow and jacobiSym_prime_pow, reducing both legendre symbols (of (a mod p).val and of A) to the same residue mod p via legendreSym_congr and one cast of the hypothesis A ≡ a down to ℤ/p.",
+      "mathContext": "$\\operatorname{sign}(\\operatorname{ringMulPerm} a) = \\left(\\tfrac{A}{p^k}\\right)$ for any $A \\equiv a \\pmod{p^k}$"
     },
     {
+      "id": "multiplicative-induction-odd-modulus",
       "title": "Multiplicative induction over the odd modulus",
-      "content": "main_aux: Nat.recOnPosPrimePosCoprime. zero excluded by NeZero; one is ℤ/1 trivial (jacobiSym.one_right); prime_pow derives p ≠ 2 from Odd (pᵏ) and applies the base; coprime n = u·v takes a₁, a₂ = unitsMap a, proves the CRT-component and numerator-cast hypotheses, splits the sign by sign_ringMulPerm_mul_of_odd, applies both inductive hypotheses, and recombines with jacobiSym.mul_right."
+      "startLine": 132,
+      "endLine": 188,
+      "summary": "main_aux: Nat.recOnPosPrimePosCoprime. zero excluded by NeZero; one is ℤ/1 trivial (jacobiSym.one_right); prime_pow derives p ≠ 2 from Odd (pᵏ) and applies the base; coprime n = u·v takes a₁, a₂ = unitsMap a, proves the CRT-component and numerator-cast hypotheses, splits the sign by sign_ringMulPerm_mul_of_odd, applies both inductive hypotheses, and recombines with jacobiSym.mul_right.",
+      "mathContext": "$\\operatorname{sign}(\\operatorname{ringMulPerm} a) = \\operatorname{sign}(\\operatorname{ringMulPerm} a_1)\\cdot\\operatorname{sign}(\\operatorname{ringMulPerm} a_2)$ for $n = uv$"
     },
     {
+      "id": "full-odd-modulus-zolotarev-frobenius",
       "title": "The full odd-modulus Zolotarev–Frobenius identity",
-      "content": "sign_ringMulPerm_eq_jacobiSym_odd: for every odd n > 0, unit a, and representative A ≡ a (mod n), sign(ringMulPerm a) = J(A | n). sign_ringMulPerm_eq_jacobiSym_val: the canonical-representative form J((a).val | n). signRingHom_eq_jacobiSym: through ZolotarevCRT.signRingHom, the Zolotarev sign CHARACTER on (ℤ/n)ˣ IS the Jacobi symbol for odd n."
+      "startLine": 189,
+      "endLine": 216,
+      "summary": "sign_ringMulPerm_eq_jacobiSym_odd: for every odd n > 0, unit a, and representative A ≡ a (mod n), sign(ringMulPerm a) = J(A | n). sign_ringMulPerm_eq_jacobiSym_val: the canonical-representative form J((a).val | n). signRingHom_eq_jacobiSym: through ZolotarevCRT.signRingHom, the Zolotarev sign CHARACTER on (ℤ/n)ˣ IS the Jacobi symbol for odd n.",
+      "mathContext": "$\\operatorname{sign}(x \\mapsto a\\cdot x \\text{ on } \\mathbb{Z}/n) = \\left(\\tfrac{A}{n}\\right)$ for every odd $n$"
     }
   ],
   "meta": {

--- a/src/data/proofs/elementary-quadratic-reciprocity-oq008/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq008/meta.json
@@ -43,20 +43,36 @@
   },
   "sections": [
     {
+      "id": "negation-is-an-involution",
       "title": "Negation is an involution",
-      "content": "ringMulPerm_neg_one_sq: the Zolotarev permutation for a = -1 is multiplication by -1, i.e. negation x ↦ -x, and (ringMulPerm (-1))² = 1 because (-1)·(-1) = 1 in the units (ringMulPerm_mul, neg_one_mul, neg_neg, ringMulPerm_one)."
+      "startLine": 1,
+      "endLine": 63,
+      "summary": "ringMulPerm_neg_one_sq: the Zolotarev permutation for a = -1 is multiplication by -1, i.e. negation x ↦ -x, and (ringMulPerm (-1))² = 1 because (-1)·(-1) = 1 in the units (ringMulPerm_mul, neg_one_mul, neg_neg, ringMulPerm_one). The header frames the goal: the first supplement J(-1 | n) = (-1)^((n-1)/2) read off as the parity of the negation permutation.",
+      "mathContext": "$(\\operatorname{ringMulPerm}(-1))^2 = 1$"
     },
     {
+      "id": "negation-fixes-one-point-odd-n",
       "title": "For odd n, negation fixes exactly one point",
-      "content": "card_fixedPoints_neg_one: via Fintype.card_eq_one_iff, the fixed-point set of negation is {0}. From -x = x one gets 2x = 0 (linear_combination); since n is odd, 2 is coprime to n (Nat.prime_two.coprime_iff_not_dvd + Nat.two_dvd_ne_zero + Nat.odd_iff) hence a unit mod n (ZMod.isUnit_iff_coprime), so x = 0 (IsUnit.mul_right_eq_zero)."
+      "startLine": 64,
+      "endLine": 93,
+      "summary": "card_fixedPoints_neg_one: via Fintype.card_eq_one_iff, the fixed-point set of negation is {0}. From -x = x one gets 2x = 0 (linear_combination); since n is odd, 2 is coprime to n (Nat.prime_two.coprime_iff_not_dvd + Nat.two_dvd_ne_zero + Nat.odd_iff) hence a unit mod n (ZMod.isUnit_iff_coprime), so x = 0 (IsUnit.mul_right_eq_zero).",
+      "mathContext": "$|\\operatorname{Fix}(x \\mapsto -x)| = 1$ for odd $n$"
     },
     {
+      "id": "parity-of-negation-permutation",
       "title": "The parity of the negation permutation",
-      "content": "sign_neg_one: Equiv.Perm.sign_of_pow_two_eq_one applied to the involution gives sign(ringMulPerm (-1)) = (-1)^((|ℤ/n| - |fixedPoints|)/2); substituting ZMod.card n = n and card_fixedPoints_neg_one = 1 yields (-1)^((n-1)/2)."
+      "startLine": 94,
+      "endLine": 111,
+      "summary": "sign_neg_one: Equiv.Perm.sign_of_pow_two_eq_one applied to the involution gives sign(ringMulPerm (-1)) = (-1)^((|ℤ/n| - |fixedPoints|)/2); substituting ZMod.card n = n and card_fixedPoints_neg_one = 1 yields (-1)^((n-1)/2).",
+      "mathContext": "$\\operatorname{sign}(x \\mapsto -x \\text{ on } \\mathbb{Z}/n) = (-1)^{(n-1)/2}$"
     },
     {
+      "id": "first-supplement-and-specializations",
       "title": "The first supplement and its specializations",
-      "content": "jacobiSym_neg_one: J(-1 | n) = (-1)^((n-1)/2) by rewriting through the parent's sign_ringMulPerm_eq_jacobiSym_odd (a = -1, A = -1) and sign_neg_one. jacobiSym_neg_one_eq_chi4: the same value equals χ₄ n (jacobiSym.at_neg_one), recovering ZMod.χ₄_eq_neg_one_pow. legendreSym_neg_one: the Legendre/Euler-criterion case (-1 / p) = (-1)^((p-1)/2) at an odd prime, via jacobiSym.legendreSym.to_jacobiSym and Nat.Prime.odd_of_ne_two."
+      "startLine": 112,
+      "endLine": 153,
+      "summary": "jacobiSym_neg_one: J(-1 | n) = (-1)^((n-1)/2) by rewriting through the parent's sign_ringMulPerm_eq_jacobiSym_odd (a = -1, A = -1) and sign_neg_one. jacobiSym_neg_one_eq_chi4: the same value equals χ₄ n (jacobiSym.at_neg_one), recovering ZMod.χ₄_eq_neg_one_pow. legendreSym_neg_one: the Legendre/Euler-criterion case (-1 / p) = (-1)^((p-1)/2) at an odd prime, via jacobiSym.legendreSym.to_jacobiSym and Nat.Prime.odd_of_ne_two.",
+      "mathContext": "$\\left(\\tfrac{-1}{n}\\right) = (-1)^{(n-1)/2} = \\chi_4(n)$"
     }
   ],
   "meta": {

--- a/src/data/proofs/elementary-quadratic-reciprocity-oq011/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq011/meta.json
@@ -45,20 +45,33 @@
   },
   "sections": [
     {
+      "id": "power-form-combined-supplement",
       "title": "The power form of the combined supplement J(-2 | n)",
-      "content": "jacobiSym_neg_two: J(-2 | n) = (-1)^((n-1)/2 + (n²-1)/8) for odd n. Split -2 = (-1)·2 (jacobiSym.mul_left), rewrite the two factors by the sibling supplements J(-1|n) = (-1)^((n-1)/2) and J(2|n) = (-1)^((n²-1)/8), and fuse the exponents with pow_add. jacobiSym_neg_two_eq: the value form, J(-2|n) = (if n % 8 = 1 ∨ n % 8 = 3 then 1 else -1), read off Mathlib's χ₈' via jacobiSym.at_neg_two and χ₈'_nat_eq_if_mod_eight (the n-even branch discarded by oddness)."
+      "startLine": 1,
+      "endLine": 106,
+      "summary": "jacobiSym_neg_two: J(-2 | n) = (-1)^((n-1)/2 + (n²-1)/8) for odd n. Split -2 = (-1)·2 (jacobiSym.mul_left), rewrite the two factors by the sibling supplements J(-1|n) = (-1)^((n-1)/2) and J(2|n) = (-1)^((n²-1)/8), and fuse the exponents with pow_add. jacobiSym_neg_two_eq: the value form, J(-2|n) = (if n % 8 = 1 ∨ n % 8 = 3 then 1 else -1), read off Mathlib's χ₈' via jacobiSym.at_neg_two and χ₈'_nat_eq_if_mod_eight (the n-even branch discarded by oddness).",
+      "mathContext": "$J(-2 \\mid n) = (-1)^{(n-1)/2 + (n^2-1)/8}$"
     },
     {
+      "id": "closed-form-power-formula-chi8prime",
       "title": "Closed-form power formula for χ₈'",
-      "content": "chi8'_eq_neg_one_pow: χ₈' n = (-1)^((n-1)/2 + (n²-1)/8) for odd n — the -2 analogue of the second supplement's chi8_eq_neg_one_pow, absent from Mathlib (which carries χ₈' only as the mod-8 case split χ₈'_nat_eq_if_mod_eight). Proved by chaining jacobiSym_neg_two_eq and jacobiSym_neg_two. neg_one_pow_neg_two records the dual reading: the fused exponent evaluates to +1 at n ≡ 1,3 (mod 8) and -1 at n ≡ 5,7 (mod 8)."
+      "startLine": 107,
+      "endLine": 126,
+      "summary": "chi8'_eq_neg_one_pow: χ₈' n = (-1)^((n-1)/2 + (n²-1)/8) for odd n — the -2 analogue of the second supplement's chi8_eq_neg_one_pow, absent from Mathlib (which carries χ₈' only as the mod-8 case split χ₈'_nat_eq_if_mod_eight). Proved by chaining jacobiSym_neg_two_eq and jacobiSym_neg_two. neg_one_pow_neg_two records the dual reading: the fused exponent evaluates to +1 at n ≡ 1,3 (mod 8) and -1 at n ≡ 5,7 (mod 8)."
     },
     {
+      "id": "zolotarev-permutation-neg-two",
       "title": "The Zolotarev permutation x ↦ -2·x",
-      "content": "sign_ringMulPerm_neg_two and sign_neg_two: the grandparent's full odd-modulus identity sign_ringMulPerm_eq_jacobiSym_odd (with a unit of residue -2 and integer representative -2) gives sign(x ↦ -2·x on ℤ/n) = J(-2 | n) = (-1)^((n-1)/2 + (n²-1)/8). The canonical hypothesis-free form builds the unit as -(ZMod.unitOfCoprime 2 _), using Nat.Coprime 2 n from oddness and Units.val_neg. This reads the combined supplement off the composition of Zolotarev's negation and doubling permutations."
+      "startLine": 127,
+      "endLine": 155,
+      "summary": "sign_ringMulPerm_neg_two and sign_neg_two: the grandparent's full odd-modulus identity sign_ringMulPerm_eq_jacobiSym_odd (with a unit of residue -2 and integer representative -2) gives sign(x ↦ -2·x on ℤ/n) = J(-2 | n) = (-1)^((n-1)/2 + (n²-1)/8). The canonical hypothesis-free form builds the unit as -(ZMod.unitOfCoprime 2 _), using Nat.Coprime 2 n from oddness and Units.val_neg. This reads the combined supplement off the composition of Zolotarev's negation and doubling permutations."
     },
     {
+      "id": "legendre-special-case-qr-characterization",
       "title": "Legendre special case and the QR characterization",
-      "content": "legendreSym_neg_two: for an odd prime p, (-2 / p) = (-1)^((p-1)/2 + (p²-1)/8), via jacobiSym.legendreSym.to_jacobiSym and Nat.Prime.odd_of_ne_two. legendreSym_neg_two_eq gives the prime mod-8 indicator, and neg_two_qr_iff packages the classical statement: legendreSym p (-2) = 1 ↔ p ≡ 1 or 3 (mod 8) — i.e. -2 is a quadratic residue mod p exactly for those residues."
+      "startLine": 156,
+      "endLine": 201,
+      "summary": "legendreSym_neg_two: for an odd prime p, (-2 / p) = (-1)^((p-1)/2 + (p²-1)/8), via jacobiSym.legendreSym.to_jacobiSym and Nat.Prime.odd_of_ne_two. legendreSym_neg_two_eq gives the prime mod-8 indicator, and neg_two_qr_iff packages the classical statement: legendreSym p (-2) = 1 ↔ p ≡ 1 or 3 (mod 8) — i.e. -2 is a quadratic residue mod p exactly for those residues."
     }
   ],
   "meta": {

--- a/src/data/proofs/erdos-1155-oq-01-oq-06/meta.json
+++ b/src/data/proofs/erdos-1155-oq-01-oq-06/meta.json
@@ -57,52 +57,11 @@
   },
   "sections": [
     {
-      "id": "turan-framework",
-      "title": "The Turán Density Framework",
-      "summary": "Defines the Turán bound turanBound(n) = n²/4 (Mantel's extremal number for triangle-free graphs) and the Turán ratio turanRatio(n) = f(n)/(n²/4). The ratio measures how Turán-like the terminal graph is. Shows turanBound is positive for n ≥ 1 and turanRatio ≤ 1 (from the Mantel bound).",
-      "theorems": [
-        "turanBound_pos",
-        "triangleRemoval_le_turan",
-        "turanRatio_nonneg",
-        "turanRatio_le_one"
-      ]
-    },
-    {
-      "id": "main-structural-result",
-      "title": "Main Result: Terminal Graph Is Not Turán-Like",
-      "summary": "Proves the main structural theorem: for any δ > 0, eventually f(n) ≤ δ·(n²/4), and consequently turanRatio(n) → 0. The proof uses BFL (ε=1/4) to get f(n) ≤ n^{7/4}, then shows n^{7/4} ≤ δ·n²/4 for n ≥ (4/δ)^4, via the estimate n^{1/4} ≥ 4/δ.",
-      "theorems": [
-        "terminal_sub_turan",
-        "turanRatio_tendsto_zero"
-      ],
-      "mathContext": "Key identity: n^{7/4} = n^{1/4} · n^{3/2} and n² = n^{1/4} · n^{7/4} (both via Real.rpow_add). From (4/δ)^4 ≤ n, monotonicity gives n^{1/4} ≥ 4/δ, hence δ·n^{1/4}/4 ≥ 1, so n^{7/4} ≤ (δ·n^{1/4}/4)·n^{7/4} = δ·n²/4."
-    },
-    {
-      "id": "exponent-gap",
-      "title": "Exponent Gap: 3/2 vs 2",
-      "summary": "Formalizes the exponent-level distinction: the terminal graph has exponent 3/2 (BFL) while the Turán maximum has exponent 2 (Mantel). For any α ∈ (3/2, 2), eventually f(n) ≤ n^α. The terminal graph eventually has strictly fewer edges than the Turán bound.",
-      "theorems": [
-        "turan_exponent_gap",
-        "terminal_sub_power",
-        "terminal_not_turan_optimal"
-      ]
-    },
-    {
-      "id": "no-lower-bound",
-      "title": "No Positive Turán Fraction from Below",
-      "summary": "Proves that no constant c > 0 satisfies c·(n²/4) ≤ f(n) eventually. This is the contrapositive of Turán-likeness: the terminal graph cannot be bounded below by any fixed fraction of the Turán density. Equivalently, the turanRatio has no positive lower limit.",
-      "theorems": [
-        "terminal_not_positive_turan_density",
-        "bipartite_cannot_be_turan_dense"
-      ]
-    },
-    {
-      "id": "open-questions",
-      "title": "Open Questions: Bipartiteness and Structure",
-      "summary": "Formally states the bipartiteness question (Is the terminal graph bipartite?) and the Turán ratio monotonicity question. Being bipartite is compatible with the BFL scaling — a sparse bipartite graph can have n^{3/2} edges. The question is whether the random process produces bipartite graphs.",
-      "theorems": [
-        "structural_summary"
-      ]
+      "id": "placeholder-stub",
+      "title": "Placeholder Stub for Terminal Graph Structure",
+      "startLine": 1,
+      "endLine": 10,
+      "summary": "This file is a placeholder stub for Erdős Problem #1155 OQ-01-OQ-06 (terminal graph structure). It contains only a header docstring, an `import Mathlib`, and a comment noting that full formalization is pending (tracked in researcher PR #9455). No definitions, theorems, or lemmas are present yet — the Turán-density framework, structural non-Turán-likeness result, exponent gap, and bipartiteness questions described in the problem remain to be formalized."
     }
   ],
   "overview": {

--- a/src/data/proofs/lucas-theorem-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/lucas-theorem-oq-01-oq-01-oq-01/meta.json
@@ -90,20 +90,32 @@
   },
   "sections": [
     {
+      "id": "gauss-triangular-number",
       "title": "Gauss's Triangular Number (tri_sum)",
-      "text": "The per-digit factor of the block sum is ∑_{r<p}(r+1) = 1+2+⋯+p = p(p+1)/2. To stay clear of natural-number division, the doubled identity tri_two proves 2·∑_{r<p}(r+1) = p(p+1) by induction (peeling the last term with Finset.sum_range_succ and closing with ring), and tri_sum then recovers the divided form by omega."
+      "startLine": 1,
+      "endLine": 61,
+      "summary": "The per-digit factor of the block sum is ∑_{r<p}(r+1) = 1+2+⋯+p = p(p+1)/2. To stay clear of natural-number division, the doubled identity tri_two proves 2·∑_{r<p}(r+1) = p(p+1) by induction (peeling the last term with Finset.sum_range_succ and closing with ring), and tri_sum then recovers the divided form by omega."
     },
     {
+      "id": "euclidean-division-reindexing",
       "title": "Euclidean-Division Reindexing (sum_range_mul_split)",
-      "text": "A range of length p·M splits into M blocks of p: ∑_{n<p·M} f n = ∑_{j<M} ∑_{r<p} f(p·j+r), since every n < p·M is uniquely p·j+r with j < M and r < p. The proof inducts on M, using Finset.sum_range_add to peel off the top block of p rows and Finset.sum_range_succ to match it against the j = M summand. The lemma is stated for an arbitrary f, independent of the binomial content."
+      "startLine": 62,
+      "endLine": 74,
+      "summary": "A range of length p·M splits into M blocks of p: ∑_{n<p·M} f n = ∑_{j<M} ∑_{r<p} f(p·j+r), since every n < p·M is uniquely p·j+r with j < M and r < p. The proof inducts on M, using Finset.sum_range_add to peel off the top block of p rows and Finset.sum_range_succ to match it against the j = M summand. The lemma is stated for an arbitrary f, independent of the binomial content."
     },
     {
+      "id": "row-sum-identity",
       "title": "The Row-Sum Identity (rowSum_eq)",
-      "text": "Define rowSum p m = ∑_{n<pᵐ} fineCount p n. Induct on m. The base case m = 0 is fineCount p 0 = 1. For m+1, write pᵐ⁺¹ = p·pᵐ and apply the block reindexing; the parent recursion fineCount p (p·j+r) = (r+1)·fineCount p j turns the inner sum over r into (∑_{r<p}(r+1))·fineCount p j = (p(p+1)/2)·fineCount p j. Factoring out the constant gives rowSum p (m+1) = (p(p+1)/2)·rowSum p m, and the induction hypothesis closes (p(p+1)/2)·(p(p+1)/2)ᵐ = (p(p+1)/2)ᵐ⁺¹."
+      "startLine": 75,
+      "endLine": 110,
+      "summary": "Define rowSum p m = ∑_{n<pᵐ} fineCount p n. Induct on m. The base case m = 0 is fineCount p 0 = 1. For m+1, write pᵐ⁺¹ = p·pᵐ and apply the block reindexing; the parent recursion fineCount p (p·j+r) = (r+1)·fineCount p j turns the inner sum over r into (∑_{r<p}(r+1))·fineCount p j = (p(p+1)/2)·fineCount p j. Factoring out the constant gives rowSum p (m+1) = (p(p+1)/2)·rowSum p m, and the induction hypothesis closes (p(p+1)/2)·(p(p+1)/2)ᵐ = (p(p+1)/2)ᵐ⁺¹."
     },
     {
+      "id": "sierpinski-count-box-dimension",
       "title": "Sierpiński Count and Box Dimension",
-      "text": "At p = 2 the identity reads ∑_{n<2ᵐ} fineCount 2 n = 3ᵐ — the number of odd entries in the first 2ᵐ rows of Pascal's triangle, the Sierpiński-gasket count of the parent oq-01-oq-02 entry. The growth rate of the block sum, log_p(p(p+1)/2), is the box-counting (fractal) dimension of the limiting mod-p Pascal triangle; for p = 2 it is log₂3 ≈ 1.585, the Sierpiński dimension."
+      "startLine": 111,
+      "endLine": 129,
+      "summary": "At p = 2 the identity reads ∑_{n<2ᵐ} fineCount 2 n = 3ᵐ — the number of odd entries in the first 2ᵐ rows of Pascal's triangle, the Sierpiński-gasket count of the parent oq-01-oq-02 entry. The growth rate of the block sum, log_p(p(p+1)/2), is the box-counting (fractal) dimension of the limiting mod-p Pascal triangle; for p = 2 it is log₂3 ≈ 1.585, the Sierpiński dimension. The sanity checks (rowSum 2 2 = 9, rowSum 2 3 = 27, rowSum 3 1 = 6, rowSum 3 2 = 36) confirm the closed form by kernel decide."
     }
   ],
   "crossReferences": [

--- a/src/data/proofs/lucas-theorem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/lucas-theorem-oq-01-oq-01/meta.json
@@ -94,24 +94,39 @@
   },
   "sections": [
     {
+      "id": "overview-and-definitions",
       "title": "Overview and Definitions",
-      "text": "fineRow p n is the finset of columns k ∈ {0,…,n} with p ∤ C(n,k); fineCount p n is its cardinality — the number of entries in row n not divisible by p. These generalise the parent's oddRow / oddCount (the p = 2 case counting odd entries). The goal is the closed form fineCount p n = ∏ᵢ (nᵢ+1) over the base-p digits of n."
+      "startLine": 1,
+      "endLine": 55,
+      "summary": "fineRow p n is the finset of columns k ∈ {0,…,n} with p ∤ C(n,k); fineCount p n is its cardinality — the number of entries in row n not divisible by p. These generalise the parent's oddRow / oddCount (the p = 2 case counting odd entries). The goal is the closed form fineCount p n = ∏ᵢ (nᵢ+1) over the base-p digits of n."
     },
     {
+      "id": "digit-wise-coprimality",
       "title": "Digit-wise Coprimality (choose_not_dvd_iff)",
-      "text": "For a prime p and a digit value r < p, the small binomial C(r,s) is coprime to p exactly when s ≤ r. If s > r then C(r,s) = 0 and p ∣ 0. If s ≤ r, the factorial identity C(r,s)·s!·(r−s)! = r! together with p ∤ r! (which holds because r < p, via Nat.Prime.dvd_factorial) forces p ∤ C(r,s). This is the survival criterion for a single base-p digit."
+      "startLine": 56,
+      "endLine": 76,
+      "summary": "For a prime p and a digit value r < p, the small binomial C(r,s) is coprime to p exactly when s ≤ r. If s > r then C(r,s) = 0 and p ∣ 0. If s ≤ r, the factorial identity C(r,s)·s!·(r−s)! = r! together with p ∤ r! (which holds because r < p, via Nat.Prime.dvd_factorial) forces p ∤ C(r,s). This is the survival criterion for a single base-p digit."
     },
     {
+      "id": "pointwise-non-divisibility-lucas",
       "title": "Pointwise Non-Divisibility via Lucas (not_dvd_choose_step)",
-      "text": "Writing the row index as p·n+r with last digit r < p, the single base-p step of Lucas' theorem gives C(p·n+r, k) ≡ C(r, k%p)·C(n, k/p) (mod p). Since p is prime it divides the product iff it divides a factor; with C(r, k%p) coprime to p ⟺ k%p ≤ r, this yields p ∤ C(p·n+r, k) ⟺ k%p ≤ r ∧ p ∤ C(n, k/p) — the general-p analogue of the parent's two parity laws."
+      "startLine": 77,
+      "endLine": 98,
+      "summary": "Writing the row index as p·n+r with last digit r < p, the single base-p step of Lucas' theorem gives C(p·n+r, k) ≡ C(r, k%p)·C(n, k/p) (mod p). Since p is prime it divides the product iff it divides a factor; with C(r, k%p) coprime to p ⟺ k%p ≤ r, this yields p ∤ C(p·n+r, k) ⟺ k%p ≤ r ∧ p ∤ C(n, k/p) — the general-p analogue of the parent's two parity laws."
     },
     {
+      "id": "multiplicative-recursion",
       "title": "The Multiplicative Recursion (fineCount_recursion)",
-      "text": "Partition row p·n+r by the last base-p digit s = k%p. The pointwise law identifies the surviving columns with the image of fineRow p n ×ˢ {0,…,r} under the injection (j,s) ↦ p·j+s (injective because s < p pins down s = k%p and j = k/p). Counting the product gives fineCount p (p·n+r) = (r+1)·fineCount p n — the (r+1)-branch generalisation of the parent's even/odd j ↦ 2j, 2j+1 reindexing."
+      "startLine": 99,
+      "endLine": 168,
+      "summary": "Partition row p·n+r by the last base-p digit s = k%p. The pointwise law identifies the surviving columns with the image of fineRow p n ×ˢ {0,…,r} under the injection (j,s) ↦ p·j+s (injective because s < p pins down s = k%p and j = k/p). Counting the product (Finset.card_image_of_injOn, card_product) gives fineCount p (p·n+r) = (r+1)·fineCount p n — the (r+1)-branch generalisation of the parent's even/odd j ↦ 2j, 2j+1 reindexing. The base case fineCount_zero (row 0 has the single surviving entry k = 0) is also established here."
     },
     {
+      "id": "fine-closed-form",
       "title": "Fine's Closed Form (fine_theorem)",
-      "text": "A strong induction on n, peeling the last base-p digit via Nat.digits_def' (digits p n = n%p :: digits p (n/p)) and applying the multiplicative recursion at each step, assembles fineCount p n = ((Nat.digits p n).map (· + 1)).prod = ∏ᵢ (nᵢ+1). Specialising to p = 2 recovers Glaisher's oddCount n = 2^(s₂ n) from the parent entry."
+      "startLine": 169,
+      "endLine": 211,
+      "summary": "A strong induction on n, peeling the last base-p digit via Nat.digits_def' (digits p n = n%p :: digits p (n/p)) and applying the multiplicative recursion at each step, assembles fineCount p n = ((Nat.digits p n).map (· + 1)).prod = ∏ᵢ (nᵢ+1). Specialising to p = 2 recovers Glaisher's oddCount n = 2^(s₂ n) from the parent entry. Closed by sanity checks fineCount 2 5 = 4, fineCount 3 7 = 6, fineCount 3 10 = 4 (kernel decide)."
     }
   ],
   "crossReferences": [

--- a/src/data/proofs/prob-method-expectation-oq-02-oq-01/meta.json
+++ b/src/data/proofs/prob-method-expectation-oq-02-oq-01/meta.json
@@ -74,11 +74,45 @@
     }
   ],
   "sections": [
-    { "title": "Exponent Identity 2·C(k,2) = k(k-1)", "description": "Twice the second binomial coefficient equals the falling factorial k(k-1), proved through descFactorial." },
-    { "title": "Arithmetic Core: Threshold ⟹ Criterion", "description": "n^2 ≤ 2^(k-1) implies 2·C(n,k) < 2^(C(k,2)) via 2·C(n,k) < k!·C(n,k) = n^(k̲) ≤ n^k ≤ 2^(C(k,2)), the last step by squaring the threshold." },
-    { "title": "Closed-Form Ramsey Bound", "description": "Combining the core with the parent's first_moment_ramsey gives R(k,k) > n whenever n ≤ 2^((k-1)/2)." },
-    { "title": "Odd-Diagonal Side Condition", "description": "2j+1 ≤ 2^j for j ≥ 3 (by Nat.le_induction), placing the clique size below the vertex count." },
-    { "title": "Exponential Growth and Concrete Witness", "description": "R(2j+1,2j+1) > 2^j for j ≥ 3, and the instance R(7,7) > 8." }
+    {
+      "id": "exponent-identity",
+      "title": "Exponent Identity 2·C(k,2) = k(k-1)",
+      "startLine": 1,
+      "endLine": 55,
+      "summary": "After the header framing the open question (turn the parent's implication criterion 2·C(n,k) < 2^C(k,2) ⟹ R(k,k) > n into a closed-form growth statement), two_mul_choose_two proves that twice the second binomial coefficient equals the falling factorial k(k-1), via descFactorial (Nat.descFactorial_eq_factorial_mul_choose).",
+      "mathContext": "$2\\binom{k}{2} = k(k-1)$"
+    },
+    {
+      "id": "arithmetic-core",
+      "title": "Arithmetic Core: Threshold ⟹ Criterion",
+      "startLine": 56,
+      "endLine": 97,
+      "summary": "firstMoment_hyp_of_sq: the fraction-free threshold n² ≤ 2^(k-1) (equivalently n ≤ 2^((k-1)/2)) implies the first-moment Ramsey criterion 2·C(n,k) < 2^C(k,2), for k ≥ 3 and k ≤ n. The estimate chain is 2·C(n,k) < k!·C(n,k) = n^(k̲) ≤ n^k ≤ 2^C(k,2), using 2 < k! (for k ≥ 3), C(n,k) ≥ 1, descFactorial = k!·choose, and squaring the threshold with 2·C(k,2) = k(k-1). This is the estimation step the parent entry left open.",
+      "mathContext": "$2\\binom{n}{k} < k!\\binom{n}{k} = n^{\\underline{k}} \\le n^k \\le 2^{\\binom{k}{2}}$"
+    },
+    {
+      "id": "closed-form-ramsey-bound",
+      "title": "Closed-Form Ramsey Bound",
+      "startLine": 98,
+      "endLine": 104,
+      "summary": "ramsey_no_mono_of_sq combines the arithmetic core with the parent's first_moment_ramsey: if k ≥ 3, k ≤ n and n² ≤ 2^(k-1), then K_n has a 2-coloring with no monochromatic K_k, i.e. R(k,k) > n."
+    },
+    {
+      "id": "odd-diagonal-side-condition",
+      "title": "Odd-Diagonal Side Condition",
+      "startLine": 105,
+      "endLine": 116,
+      "summary": "two_mul_add_one_le_pow: for j ≥ 3, 2j+1 ≤ 2^j, keeping the clique size below the vertex count so the closed-form bound applies along the odd diagonal. Proved by Nat.le_induction.",
+      "mathContext": "$2j+1 \\le 2^j \\quad (j \\ge 3)$"
+    },
+    {
+      "id": "exponential-growth-witness",
+      "title": "Exponential Growth and Concrete Witness",
+      "startLine": 117,
+      "endLine": 138,
+      "summary": "ramsey_diagonal_growth: for j ≥ 3, R(2j+1, 2j+1) > 2^j, so writing k = 2j+1 gives R(k,k) > 2^((k-1)/2) = (√2)^(k-1) — the classical Erdős exponential order recovered purely from the first moment method. ramsey_seven_gt_eight gives the concrete instance R(7,7) > 8 (here 8² = 64 = 2⁶ = 2^(7-1), the threshold met with equality).",
+      "mathContext": "$R(2j+1, 2j+1) > 2^j,\\quad R(k,k) > (\\sqrt 2)^{k-1}$"
+    }
   ],
   "crossReferences": [
     {

--- a/src/data/proofs/summation-by-parts-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/summation-by-parts-oq-01-oq-02-oq-01/meta.json
@@ -83,20 +83,34 @@
   },
   "sections": [
     {
+      "id": "second-moment-closed-form",
       "title": "The Second-Moment Closed Form over Any Field",
-      "body": ""
+      "startLine": 1,
+      "endLine": 68,
+      "summary": "Establishes the headline identity `sum_range_sq_geom`: for a field element r ≠ 1, ∑_{k<n} k²·rᵏ = (rⁿ·(n² + (1+2n−2n²)·r + (n−1)²·r²) − r − r²)/(r−1)³. Unlike the sibling entry (real, bare induction), this holds over an arbitrary field K as a purely algebraic fact. Proved by induction on n: Finset.sum_range_succ adds the next term, then push_cast/field_simp/ring close the polynomial identity after clearing (r−1)³.",
+      "mathContext": "$\\sum_{k<n} k^2 r^k = \\dfrac{r^n\\bigl(n^2 + (1+2n-2n^2)r + (n-1)^2 r^2\\bigr) - r - r^2}{(r-1)^3}$"
     },
     {
+      "id": "falling-factorial-companion",
       "title": "The Falling-Factorial Companion ∑ k(k−1)·rᵏ",
-      "body": ""
+      "startLine": 69,
+      "endLine": 86,
+      "summary": "`sum_range_falling_geom` evaluates the second falling-factorial sum ∑_{k<n} k(k−1)·rᵏ = (rⁿ·(n(n−1) + (4n−2n²)·r + (n−1)(n−2)·r²) − 2r²)/(r−1)³, the discrete analogue of the second derivative of the geometric series (limit 2r²/(1−r)³ for |r|<1). Same induction + field_simp + ring method over any field.",
+      "mathContext": "$\\sum_{k<n} k(k-1) r^k = \\dfrac{r^n\\bigl(n(n-1) + (4n-2n^2)r + (n-1)(n-2)r^2\\bigr) - 2r^2}{(r-1)^3}$"
     },
     {
+      "id": "decomposition-k-squared",
       "title": "The Decomposition k² = k(k−1) + k",
-      "body": ""
+      "startLine": 87,
+      "endLine": 98,
+      "summary": "`sum_sq_eq_falling_add_linear` realizes k² = k(k−1) + k as a term-by-term identity of finite sums: the second moment splits as the second falling moment plus the first moment, with no closed forms required. Proved by Finset.sum_add_distrib and ring on the summand."
     },
     {
+      "id": "abel-summation-by-parts",
       "title": "The Abel Summation-by-Parts Derivation",
-      "body": ""
+      "startLine": 99,
+      "endLine": 118,
+      "summary": "`sum_range_sq_geom_eq_byParts` re-derives the second-moment sum through genuine Abel summation via Finset.sum_range_by_parts, taking weight f(k)=k² and geometric sequence g(k)=rᵏ. It exposes that the forward differences f(k+1)−f(k)=2k+1 are linear, so each nested geometric partial sum is weighted by 2i+1 — the discrete signature of differentiating k². The sibling entry never actually used Abel summation despite the family name."
     }
   ],
   "mainTheorems": [


### PR DESCRIPTION
## Enrichment pass — repair degenerate `sections` schema (20 entries)

**Functional defect.** These 20 gallery entries stored `meta.json` `sections` as
objects that (a) lacked numeric `startLine`/`endLine`, and (b) in most cases held
the section's descriptive text under a key the gallery UI never reads
(`content`, `text`, `body`, `description`, or `theorems`) instead of `summary`.

On the proof page this meant:
- **Broken navigation** — `ProofPage.tsx:60,65` scrolls the code viewer to
  `section.startLine`; with no `startLine` this is `NaN` (click does nothing).
- **Invisible text** — the table of contents renders only `section.summary`
  (`TableOfContents.tsx:71`), so body text stored under `content`/`text`/… never
  appeared.

**Fix (per entry).** Convert to the canonical
`{id, title, startLine, endLine, summary [, mathContext]}` schema the UI reads:
move the body text into `summary`, add accurate contiguous line ranges covering
the Lean file `1..EOF` (anchored at banner comments / decl boundaries), preserve
existing titles/order/count. Verified: **only** the `sections` field changed in
each of the 20 files; all ranges are numeric, non-overlapping, start at 1, and
end within ±0 of the Lean file length.

Entries: `elementary-quadratic-reciprocity-oq004/005/006/007/008/011/-oq-01-oq-03`,
`descartes-rule-of-signs-oq-01-oq-04/-oq-02/-oq-03`, `lucas-theorem-oq-01-oq-01/-oq-01`,
`angle-trisection-oq-02-oq-02-oq-03`, `derangements-oq-03-oq-03-oq-01`,
`bernoulli-inequality-oq002`, `summation-by-parts-oq-01-oq-02-oq-01`,
`matrix-posdef-sqrt-oq-01-oq-01-oq-01`, `cantor-diagonalization-oq004`,
`prob-method-expectation-oq-02-oq-01`, `erdos-1155-oq-01-oq-06`.

**Honesty fix.** `erdos-1155-oq-01-oq-06` is a genuine 10-line placeholder stub
(`import Mathlib` + a pending-formalization comment, no defs/theorems). Its old
5 sections described a full Turán-density formalization (`turanBound`,
`terminal_sub_turan`, …) that does not exist in the file — pure fiction. Collapsed
to one honest section covering lines 1–10 stating formalization is pending, and
dropped the stale `theorems` key.

Follows #40064 (which fixed the last 4 bare string-array `sections`); together
these bring all gallery entries onto the structured section schema.
