### PR TITLE
Research: abundant-number-oq-03-oq-03 — fully arithmetic primitivity criterion for m·p

### DIFF
--- a/proofs/Proofs/AbundantNumberOQ03OQ03.lean
+++ b/proofs/Proofs/AbundantNumberOQ03OQ03.lean
@@ -254,4 +254,79 @@ theorem isPrimitiveAbundant_mul_prime' {m p : ℕ} (hp : p.Prime) (hm : 0 < m)
     (fun _ hd => deficient_of_dvd hmdef (mem_divisors.mp hd).1 (pos_of_mem_divisors hd).ne')
     hpdef
 
+-- ============================================================
+-- Fully arithmetic primitivity criterion for `m · p`
+-- ============================================================
+
+/-
+  The criteria above still carry the semantic predicates `Nat.Abundant` and
+  `Nat.Deficient`.  For a *concrete* Route-1 witness search we want the
+  primitivity of `m·p` expressed entirely in terms of divisor sums, so it can be
+  discharged by pure computation (`decide`).  The two lemmas below convert
+  deficiency into a divisor-sum inequality — the deficient dual of
+  `abundant_iff_sum_divisors` / `abundant_mul_prime_iff` — and then package the
+  whole primitivity obligation as three arithmetic inequalities.
+-/
+
+/-- **Deficiency in divisor-sum form.**  For every `n`, `n` is deficient exactly
+when `σ(n) = ∑_{d ∣ n} d` is below `2n`.  The deficient dual of Mathlib's
+`Nat.abundant_iff_sum_divisors`.  (Holds unconditionally: for `n = 0` both sides
+are `0 < 0`, i.e. false.) -/
+theorem deficient_iff_sum_divisors {n : ℕ} :
+    n.Deficient ↔ (∑ d ∈ n.divisors, d) < 2 * n := by
+  rw [Nat.Deficient, sum_divisors_eq_sum_properDivisors_add_self]
+  omega
+
+/-- **Deficiency criterion for `e · p`** (`p` prime, `p ∤ e`): the multiplicative
+dual of `abundant_mul_prime_iff`.  Since `σ(e·p) = σ(e)·(p+1)`, deficiency of
+`e·p` reduces to the single linear-in-`p` inequality `σ(e)·(p+1) < 2·(e·p)`.
+This turns the primitivity side condition "each `p·e` is deficient" into
+arithmetic. -/
+theorem deficient_mul_prime_iff {e p : ℕ} (hp : p.Prime) (hpe : ¬ p ∣ e) :
+    (e * p).Deficient ↔ (∑ d ∈ e.divisors, d) * (p + 1) < 2 * (e * p) := by
+  rw [deficient_iff_sum_divisors, sum_divisors_mul_prime hp hpe]
+
+/-- **Fully arithmetic primitivity criterion for `m · p`** (`p` prime, `0 < m`,
+`p ∤ m`).  Every hypothesis is now a divisor-sum inequality, so a concrete
+Route-1 witness `m·p` can be certified primitive abundant by pure computation:
+
+* `2·m·p < σ(m)·(p+1)`                     — `m·p` is abundant;
+* `σ(m) < 2·m`                             — the base `m` is deficient;
+* `∀ e ∈ m.properDivisors, σ(e)·(p+1) < 2·e·p` — every `p`-multiple of a proper
+  divisor of `m` is deficient.
+
+This is the endpoint of the Route-1 reduction: it eliminates the semantic
+`Abundant`/`Deficient` predicates entirely, leaving only `σ`-arithmetic. -/
+theorem isPrimitiveAbundant_mul_prime_arith {m p : ℕ} (hp : p.Prime) (hm : 0 < m)
+    (hpm : ¬ p ∣ m)
+    (hab : 2 * (m * p) < (∑ d ∈ m.divisors, d) * (p + 1))
+    (hmdef : (∑ d ∈ m.divisors, d) < 2 * m)
+    (hpdef : ∀ e ∈ m.properDivisors,
+      (∑ d ∈ e.divisors, d) * (p + 1) < 2 * (e * p)) :
+    IsPrimitiveAbundant (m * p) := by
+  refine isPrimitiveAbundant_mul_prime' hp hm ((abundant_mul_prime_iff hp hpm).mpr hab)
+    (deficient_iff_sum_divisors.mpr hmdef) (fun e he => ?_)
+  -- `e ∣ m` and `p ∤ m` force `p ∤ e`, so `deficient_mul_prime_iff` applies to `e·p`.
+  have hedvd : e ∣ m := (Nat.mem_properDivisors.mp he).1
+  have hpe : ¬ p ∣ e := fun h => hpm (h.trans hedvd)
+  rw [mul_comm p e]
+  exact (deficient_mul_prime_iff hp hpe).mpr (hpdef e he)
+
+/-- **The base witness `945` recovered through the arithmetic engine.**  Taking
+`m = 189` and the odd prime `p = 5` (so `m·p = 945`), the fully arithmetic
+criterion `isPrimitiveAbundant_mul_prime_arith` certifies `945` primitive
+abundant purely from divisor sums — an end-to-end validation of the Route-1
+machinery against the known least witness.  Here `σ(189) = 320`, so
+`2·945 = 1890 < 1920 = 320·6` (abundant), `320 < 378 = 2·189` (`189` deficient),
+and each proper divisor `e ∣ 189` has `σ(e)·6 < 10·e`. -/
+theorem primitive_945_via_engine : IsPrimitiveAbundant 945 := by
+  have h : IsPrimitiveAbundant (189 * 5) := by
+    refine isPrimitiveAbundant_mul_prime_arith (by norm_num) (by norm_num)
+      (by decide) ?_ ?_ ?_
+    · set_option maxRecDepth 4000 in decide
+    · set_option maxRecDepth 4000 in decide
+    · set_option maxRecDepth 4000 in decide
+  norm_num at h
+  exact h
+
 end AbundantNumberOQ03OQ03

--- a/proofs/Proofs/Erdos510WIP01.lean
+++ b/proofs/Proofs/Erdos510WIP01.lean
@@ -168,4 +168,49 @@ theorem exists_eq_minCosineSum (A : Finset ℕ) :
   rw [← hyeq]
   exact isMinOn_iff.mp hmin y hy
 
+/-! ## The minimum is nonpositive for positive-frequency sets
+
+For a set `A` of *positive* frequencies (`0 ∉ A`), each term `cos(nθ)` integrates to `0`
+over a full period, so `∫₀^{2π} cosineSum A = 0`. Since `minCosineSum A` is a pointwise
+lower bound, integrating the constant gives `2π · minCosineSum A ≤ 0`, whence
+`minCosineSum A ≤ 0`. This is the elementary sign fact behind the Chowla problem: a
+positive-frequency cosine sum must dip to `0` or below somewhere. -/
+
+/-- A single positive-frequency cosine integrates to zero over a full period. -/
+theorem integral_cos_mul_eq_zero {n : ℕ} (hn : 1 ≤ n) :
+    ∫ θ in (0 : ℝ)..(2 * π), Real.cos ((n : ℝ) * θ) = 0 := by
+  have hcn : (n : ℝ) ≠ 0 := Nat.cast_ne_zero.mpr (by omega)
+  rw [intervalIntegral.integral_comp_mul_left (f := fun x => Real.cos x) hcn, integral_cos]
+  have h1 : Real.sin ((n : ℝ) * (2 * π)) = 0 := by
+    rw [show (n : ℝ) * (2 * π) = ((2 * n : ℕ) : ℝ) * π by push_cast; ring]
+    exact Real.sin_nat_mul_pi (2 * n)
+  rw [mul_zero, h1, Real.sin_zero, sub_zero, smul_zero]
+
+/-- `∫₀^{2π} cosineSum A = 0` for a positive-frequency set (`0 ∉ A`). -/
+theorem integral_cosineSum_eq_zero (A : Finset ℕ) (hA : 0 ∉ A) :
+    ∫ θ in (0 : ℝ)..(2 * π), cosineSum A θ = 0 := by
+  simp only [cosineSum]
+  rw [intervalIntegral.integral_finsetSum]
+  · refine Finset.sum_eq_zero (fun n hn => ?_)
+    have hn1 : 1 ≤ n := Nat.one_le_iff_ne_zero.mpr (fun h => hA (h ▸ hn))
+    exact integral_cos_mul_eq_zero hn1
+  · intro n _
+    exact (Real.continuous_cos.comp (continuous_const.mul continuous_id)).intervalIntegrable _ _
+
+/-- **The Chowla cosine sum is nonpositive at its minimum for positive frequencies.**
+If `0 ∉ A` then `minCosineSum A ≤ 0`: since `∫₀^{2π} cosineSum A = 0` and
+`minCosineSum A ≤ cosineSum A θ` pointwise, the constant `minCosineSum A` integrates to
+`2π · minCosineSum A ≤ 0`. -/
+theorem minCosineSum_nonpos (A : Finset ℕ) (hA : 0 ∉ A) : minCosineSum A ≤ 0 := by
+  have hint : ∫ θ in (0 : ℝ)..(2 * π), cosineSum A θ = 0 := integral_cosineSum_eq_zero A hA
+  have hmono := intervalIntegral.integral_mono_on
+    (a := (0 : ℝ)) (b := 2 * π) (μ := MeasureTheory.volume)
+    (f := fun _ => minCosineSum A) (g := cosineSum A)
+    Real.two_pi_pos.le intervalIntegrable_const
+    ((continuous_cosineSum A).intervalIntegrable _ _)
+    (fun θ _ => minCosineSum_le A θ)
+  rw [intervalIntegral.integral_const, hint] at hmono
+  simp only [smul_eq_mul, sub_zero] at hmono
+  nlinarith [Real.two_pi_pos]
+
 end Erdos510WIP01

--- a/proofs/Proofs/Erdos510WIP01.lean
+++ b/proofs/Proofs/Erdos510WIP01.lean
@@ -30,6 +30,8 @@ Reference: <https://erdosproblems.com/510>
 -/
 
 import Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic
+import Mathlib.Analysis.SpecialFunctions.Integrals.Basic
+import Mathlib.MeasureTheory.Integral.IntervalIntegral.Basic
 import Mathlib.Topology.Algebra.InfiniteSum.Basic
 import Mathlib.Order.ConditionallyCompleteLattice.Indexed
 import Proofs.Erdos510Problem

--- a/research/problems/abundant-number-oq-03-oq-03/knowledge.md
+++ b/research/problems/abundant-number-oq-03-oq-03/knowledge.md
@@ -12,6 +12,38 @@ Insights accumulated during research on this problem.
 
 ## Insights
 
+### 2026-07-20 (researcher-1, iteration 4) — fully arithmetic primitivity criterion; 945 recovered through the engine
+
+The Route-1 primitivity obligation now carries **no semantic predicates** — it is three
+divisor-sum inequalities, so a concrete witness `m·p` is certifiable by pure `decide`.
+
+- **`deficient_iff_sum_divisors`** (unconditional): `Deficient n ↔ ∑_{d ∣ n} d < 2n`. The
+  deficient dual of Mathlib's `Nat.abundant_iff_sum_divisors`. Proof: unfold `Nat.Deficient`,
+  `sum_divisors_eq_sum_properDivisors_add_self`, `omega`. Holds even for `n = 0` (both sides
+  `0 < 0`). Mathlib-worthy.
+- **`deficient_mul_prime_iff`** (`p` prime, `p ∤ e`): `(e·p).Deficient ↔ σ(e)·(p+1) < 2ep` —
+  the multiplicative dual of `abundant_mul_prime_iff`, via `sum_divisors_mul_prime`. Turns the
+  "each `p·e` deficient" side condition into a linear-in-`p` inequality.
+- **`isPrimitiveAbundant_mul_prime_arith`** (`p` prime, `0<m`, `p∤m`): `m·p` is primitive
+  abundant from just (a) `2mp < σ(m)(p+1)`, (b) `σ(m) < 2m`, (c) `∀ e ∈ m.properDivisors,
+  σ(e)(p+1) < 2ep`. Endpoint of the Route-1 reduction — eliminates `Abundant`/`Deficient`
+  entirely. The `p∤m` + `e∣m` ⇒ `p∤e` step lets `deficient_mul_prime_iff` fire on each `p·e`.
+- **`primitive_945_via_engine`**: `m=189`, `p=5` (so `m·p=945`) discharges all three conditions
+  by `decide` (`σ(189)=320`: `1890<1920`, `320<378`, and each proper divisor `e∣189` has
+  `σ(e)·6 < 10e`) — an end-to-end validation of the engine against the known least witness.
+
+All 4 axiom-free (`[propext, Classical.choice, Quot.sound]`, no `Lean.ofReduceBool`),
+host-verified `lake env lean` exit 0, `import Mathlib` only.
+
+**Toward infinitude — the reduction is now a clean rational prime window.** Writing
+`I(x) = σ(x)/x` (abundancy index), conditions (a)+(c) say `2p/(p+1)` sits strictly between
+`I*(m) := max_{e ∣ m, e<m} I(e)` and `I(m)`: abundance is `I(m) > 2p/(p+1)` and each `p·e`
+deficient is `I(e) < 2p/(p+1)`. Solving, the prime window is
+`I*(m)/(2−I*(m)) < p < I(m)/(2−I(m))`, `p ∤ m`. So Route-1 infinitude reduces to: an infinite
+family of odd deficient `mₖ` with `I(mₖ)` near 2 (large right endpoint) and a Bertrand-type
+prime in each window. The genuine open crux is unchanged (no such odd family is known), but the
+target is now purely "prime in a rational interval determined by two abundancy indices."
+
 ### 2026-07-20 (researcher-1, iteration 3) — deficiency is divisor-downward-closed; criterion simplified
 
 State.md's "Next Action" (build the coprime proper-divisor decomposition + full primitivity

--- a/research/problems/abundant-number-oq-03-oq-03/state.md
+++ b/research/problems/abundant-number-oq-03-oq-03/state.md
@@ -50,9 +50,24 @@ This iteration simplified the criterion:
 
 All 0-axiom, host-verified (`lake env lean` exit 0, `import Mathlib` only).
 
+## Update (2026-07-20, researcher-1 — iteration 4: fully arithmetic criterion)
+
+The Route-1 primitivity criterion now carries no semantic predicates (`Abundant`/`Deficient`
+eliminated). New axiom-free lemmas (`lake env lean` exit 0):
+- `deficient_iff_sum_divisors` — `Deficient n ↔ σ(n) < 2n` (dual of `abundant_iff_sum_divisors`).
+- `deficient_mul_prime_iff` — `(e·p).Deficient ↔ σ(e)(p+1) < 2ep` (dual of `abundant_mul_prime_iff`).
+- `isPrimitiveAbundant_mul_prime_arith` — `m·p` primitive abundant from three divisor-sum
+  inequalities alone: `2mp<σ(m)(p+1)`, `σ(m)<2m`, `∀ e∈m.properDivisors, σ(e)(p+1)<2ep`.
+- `primitive_945_via_engine` — `189·5 = 945` certified through the arithmetic criterion by
+  `decide`, validating the engine against the known least witness.
+
+**Reduction crystallized:** the prime window is `I*(m)/(2−I*(m)) < p < I(m)/(2−I(m))` where
+`I(x)=σ(x)/x` and `I*(m)=max_{e∣m,e<m} I(e)`. Route-1 infinitude = an infinite odd deficient
+family `mₖ` with `I(mₖ)→2` plus a Bertrand-type prime in each window.
+
 ## Next Action
-Route 1: pick an explicit odd deficient base family `mₖ` (e.g. odd `m` with `σ(m)/m` just below
-2) and a prime window `p` where `mₖ·p` is abundant while every `p·e` (proper divisor `e` of `m`)
-stays deficient — condition (c) is now the last non-trivial obligation. Infinitude remains
-genuinely open (no odd family known to satisfy this for infinitely many members). Route 2
-(primitive-part extraction from `Nat.infinite_odd_abundant`) unchanged.
+Route 1: exhibit an infinite family of odd deficient `mₖ` with `I(mₖ)` approaching 2 from below
+and a controllable `I*(mₖ)`, so the rational prime window `(I*/(2−I*), I(m)/(2−I(m)))` is
+non-empty for infinitely many `k` and contains a prime coprime to `mₖ` (Bertrand-type input).
+Infinitude remains genuinely open (no such odd family is known). Route 2 (primitive-part
+extraction from `Nat.infinite_odd_abundant`) unchanged.

--- a/research/problems/erdos-510-wip-01/knowledge.md
+++ b/research/problems/erdos-510-wip-01/knowledge.md
@@ -1,0 +1,23 @@
+# Knowledge Base: erdos-510-wip-01
+
+## Session 2026-07-20 (researcher-1) — minCosineSum ≤ 0 for positive-frequency sets
+
+**Mode**: build on the attainment result. **Outcome**: progress — 3 axiom-free theorems,
+host-verified v4.31 (`lake env lean` exit 0; `#print axioms` = `[propext, Classical.choice,
+Quot.sound]`; no sorry/native_decide).
+
+`minCosineSum_nonpos : 0 ∉ A → minCosineSum A ≤ 0`. Each positive-frequency term integrates
+to zero over a full period (`integral_cos_mul_eq_zero`: `∫₀^{2π} cos(nθ) = 0` for `n ≥ 1`),
+so `∫₀^{2π} cosineSum A = 0` (`integral_cosineSum_eq_zero`); since `minCosineSum A` is a
+pointwise lower bound, integrating the constant gives `2π·minCosineSum A ≤ 0`.
+
+**Technique**: `intervalIntegral.integral_comp_mul_left` (c≠0) reduces `cos(nθ)` to an
+`n⁻¹`-scaled `integral_cos = sin(n·2π) − sin 0 = 0` (`Real.sin_nat_mul_pi`, `n·2π = (2n)·π`);
+`intervalIntegral.integral_finsetSum` swaps `∑`/`∫`; `intervalIntegral.integral_mono_on`
++ `integral_const` yields the `(2π)·c` bound, closed by `nlinarith [Real.two_pi_pos]`.
+**Import note**: the file did NOT `import Mathlib` fully — needed
+`Analysis.SpecialFunctions.Integrals.Basic` + `MeasureTheory.Integral.IntervalIntegral.Basic`.
+
+### Next
+- Strict `minCosineSum A < 0` for nonempty positive-frequency `A`.
+- Sharp `−c√N` bound (Chowla; Bourgain/Ruzsa/Bedert) stays a deep imported result.

--- a/src/data/research/problems/abundant-number-oq-03-oq-03.json
+++ b/src/data/research/problems/abundant-number-oq-03-oq-03.json
@@ -28,12 +28,12 @@
     "goal": "Formalize {n | Odd n and IsPrimitiveAbundant n}.Infinite in Lean 4 / Mathlib, exhibiting a concrete infinite family of odd primitive abundant witnesses with proofs that each is odd, abundant, and has every proper divisor deficient."
   },
   "currentState": {
-    "phase": "OBSERVE",
-    "since": "2026-07-09T16:43:19-07:00",
-    "iteration": 2,
-    "focus": "Initial problem understanding. Read problem.md and gather context.",
+    "phase": "ACT",
+    "since": "2026-07-20",
+    "iteration": 4,
+    "focus": "Route-1 primitivity reduced to pure divisor-sum arithmetic; infinitude still open",
     "blockers": [],
-    "nextAction": "Read problem.md thoroughly and acquire full context.",
+    "nextAction": "Exhibit an infinite family of odd deficient m_k with abundancy index I(m_k)->2 and controllable I*(m_k), so the rational prime window (I*/(2-I*), I(m)/(2-I(m))) is nonempty and contains a prime coprime to m_k (Bertrand-type input). Infinitude remains genuinely open.",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -41,7 +41,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Simplified the Route-1 primitivity criterion. Proved deficiency is downward-closed under divisibility (deficient_of_dvd, dual of Nat.Abundant.of_dvd) via abundancy-index monotonicity, so isPrimitiveAbundant_mul_prime′ needs only m.Deficient in place of every-divisor-of-m-deficient. Route-1 obligation is now (a) 2mp<σ(m)(p+1), (b) m deficient, (c) p·e deficient for proper divisors e of m. Infinitude still genuinely open (no explicit odd family provably primitive-abundant infinitely often).",
+    "progressSummary": "Base witness 945 verified axiom-free (kernel decide). Route-1 sigma-arithmetic engine complete and now FULLY ARITHMETIC: isPrimitiveAbundant_mul_prime_arith reduces primitivity of m*p to three divisor-sum inequalities (no Abundant/Deficient predicates), validated end-to-end by primitive_945_via_engine (189*5). Prime window crystallized as I*/(2-I*) < p < I(m)/(2-I(m)). Infinitude open (no odd family known).",
     "builtItems": [
       "IsPrimitiveAbundant (A006038 predicate) in proofs/Proofs/AbundantNumberOQ03OQ03.lean",
       "OddPrimitiveAbundant set + mem_oddPrimitiveAbundant_945 (945 is a member) in AbundantNumberOQ03OQ03.lean",
@@ -54,7 +54,11 @@
       "mem_properDivisors_mul_prime + isPrimitiveAbundant_mul_prime in AbundantNumberOQ03OQ03.lean (axiom-free [propext, Classical.choice, Quot.sound]; via Nat.dvd_mul split + p prime)",
       "deficient_iff_abundancyIndex_lt_two (AbundantNumberOQ03OQ03.lean) — Deficient n ↔ abundancyIndex n < 2 (n≠0); deficient counterpart of Nat.abundant_iff_two_lt_abundancyIndex. 0 axiom.",
       "deficient_of_dvd (AbundantNumberOQ03OQ03.lean) — deficiency inherited by divisors. 0 axiom.",
-      "isPrimitiveAbundant_mul_prime′ (AbundantNumberOQ03OQ03.lean) — simplified Route-1 primitivity criterion: needs only m.Deficient (not all-divisors-deficient). 0 axiom."
+      "isPrimitiveAbundant_mul_prime′ (AbundantNumberOQ03OQ03.lean) — simplified Route-1 primitivity criterion: needs only m.Deficient (not all-divisors-deficient). 0 axiom.",
+      "deficient_iff_sum_divisors: Deficient n <-> sigma(n) < 2n (dual of abundant_iff_sum_divisors), axiom-free",
+      "deficient_mul_prime_iff: (e*p).Deficient <-> sigma(e)(p+1) < 2ep for p prime, p not | e",
+      "isPrimitiveAbundant_mul_prime_arith: fully arithmetic primitivity criterion for m*p (three divisor-sum inequalities)",
+      "primitive_945_via_engine: 189*5=945 certified primitive abundant through the arithmetic criterion by decide"
     ],
     "insights": [
       "945 = 3³·5·7 is not just the smallest odd abundant number but is odd PRIMITIVE abundant (OEIS A006038): all 15 proper divisors 1,3,5,7,9,15,21,27,35,45,63,105,135,189,315 are deficient — verified axiom-free.",
@@ -71,9 +75,10 @@
       "No Nat.Coprime.divisors_mul (Finset equality for divisors of a coprime product) in Mathlib v4.31 — only Nat.Coprime.sum_divisors_mul (the sum) and card_divisors_mul (the count). Blocks a clean coprime proper-divisor decomposition."
     ],
     "nextSteps": [
-      "Route 1 (now unblocked on divisor structure): find an explicit odd base m with all divisors deficient (e.g. m a prime power or a deficient squarefree odd number) and a prime window p such that (a) m·p abundant, (b) every p·(proper divisor of m) is deficient — then isPrimitiveAbundant_mul_prime yields an odd primitive abundant m·p. Iterating over an infinite family of such (m,p) would settle infinitude.",
-      "Route 2 (OPEN): control oddness + unboundedness of the primitive divisor extracted from Nat.infinite_odd_abundant.",
-      "Note the strict-vs-weak A006038 definition subtlety recorded earlier."
+      "Find infinite odd deficient family m_k with I(m_k)->2 (abundancy index near 2 from below)",
+      "Bound I*(m_k) so the rational prime window is nonempty for infinitely many k",
+      "Bertrand-type prime existence in the window (I*/(2-I*), I(m)/(2-I(m))), coprime to m_k",
+      "Route 2 alternative: primitive-part extraction from Nat.infinite_odd_abundant"
     ]
   },
   "tags": [
@@ -251,5 +256,6 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AbundantNumberOQ02OQ01Unconditional.lean"
     }
   ],
-  "lastUpdate": "2026-07-20"
+  "lastUpdate": "2026-07-20",
+  "lastUpdated": "2026-07-20"
 }

--- a/src/data/research/problems/erdos-510-wip-01.json
+++ b/src/data/research/problems/erdos-510-wip-01.json
@@ -36,7 +36,7 @@
         "blockedAt": "2026-07-20"
       }
     ],
-    "nextAction": "The average-zero fact ⨍ cosineSum A = 0 for A ⊂ ℕ⁺ (∫₀^{2π} cos(nθ)dθ = 0) giving minCosineSum A ≤ 0; then work toward the deep −c√N lower bound (the open target).",
+    "nextAction": "The deep -c*sqrt(N) lower bound (Chowla conjecture regime) stays imported. Elementary sign/attainment layer now covers: attained minimum, two-sided bounds, minCosineSum{n}=-1, and minCosineSum<=0 (this session).",
     "attemptCounts": {
       "total": 1,
       "currentApproach": 1,
@@ -44,7 +44,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Erdos510WIP01.lean now proves the Chowla cosine-sum minimum is ATTAINED (exists_eq_minCosineSum: ∃ θ₀, cosineSum A θ₀ = minCosineSum A), upgrading minCosineSum from an iInf to an attained minimum. Via 2π-periodicity (Function.Periodic.image_Icc) the range equals the image of the compact [0,2π], where continuity gives a minimizer (IsCompact.exists_isMinOn). 18 theorems, 0 sorry / 0 axiom, VERIFIED axiom-free [propext, Classical.choice, Quot.sound], host-verified no-Docker. The deep −c√N conjecture remains the open target.",
+    "progressSummary": "PROGRESS (2026-07-20, researcher-1, VERIFIED 0-axiom host, print axioms = propext/Classical.choice/Quot.sound): minCosineSum A <= 0 for positive-frequency sets (0 not in A), via integral over full period = 0 (integral_cosineSum_eq_zero) and constant <= pointwise. Prior work: minCosineSum attained (exists_eq_minCosineSum), two-sided bounds, minCosineSum{n}=-1. Remaining: sharp -c*sqrt(N) bound (deep: Bourgain/Ruzsa/Bedert) and the Sidon sqrt(N)-optimality example.",
     "builtItems": [
       "cosineSum_empty / cosineSum_singleton / cosineSum_insert in Erdos510WIP01.lean",
       "cosineSum_zero_angle (cosineSum A 0 = N), cosineSum_pi (= ∑(−1)ⁿ)",
@@ -53,21 +53,26 @@
       "abs_cosineSum_le_card, cosineSum_le_card, neg_card_le_cosineSum",
       "bddBelow_range_cosineSum, minCosineSum_le, neg_card_le_minCosineSum, minCosineSum_le_card, minCosineSum_empty",
       "minCosineSum_singleton (= −1 for n ≥ 1)",
-      "exists_eq_minCosineSum (Erdos510WIP01.lean): the infimum minCosineSum A is attained at a concrete angle, via periodicity + compactness of [0,2π] (2026-07-20)"
+      "exists_eq_minCosineSum (Erdos510WIP01.lean): the infimum minCosineSum A is attained at a concrete angle, via periodicity + compactness of [0,2π] (2026-07-20)",
+      "integral_cos_mul_eq_zero: integral over 0..2pi of cos(n*theta) = 0 for n>=1 (Erdos510WIP01.lean)",
+      "integral_cosineSum_eq_zero: integral over 0..2pi of cosineSum A = 0 when 0 not in A",
+      "minCosineSum_nonpos: minCosineSum A <= 0 for positive-frequency sets (0 not in A)"
     ],
     "insights": [
       "The trivial range of the cosine sum is [−N, N]; the conjectured extremal value −c√N sits strictly inside, so all elementary bounds are far from the truth — the content is entirely in the cancellation.",
       "minCosineSum {n} = −1 exactly (attained at θ = π/n), showing single-frequency sets are the most negative possible relative to size — the difficulty is genuinely a many-frequency cancellation phenomenon.",
       "Continuity + 2π-periodicity make minCosineSum an attained minimum, not merely an infimum; formalizing attainment is the natural next structural step.",
-      "The θ=0 value N and θ=π value ∑(−1)ⁿ give cheap explicit witnesses bracketing the infimum."
+      "The θ=0 value N and θ=π value ∑(−1)ⁿ give cheap explicit witnesses bracketing the infimum.",
+      "minCosineSum A <= 0 for 0 not in A: the average of cosineSum over a full period is 0, and minCosineSum is a pointwise lower bound, so integrating the constant gives 2pi*minCosineSum <= 0. This is the elementary sign fact behind Chowla (a positive-frequency cosine sum must dip to 0 or below).",
+      "Integral technique: intervalIntegral.integral_comp_mul_left (c!=0) reduces cos(n*theta) to n-inverse-scaled integral_cos = sin(n*2pi)-sin 0 = 0 (via Real.sin_nat_mul_pi with n*2pi = (2n)*pi); intervalIntegral.integral_finsetSum swaps finite sum and integral (each term Continuous.intervalIntegrable); intervalIntegral.integral_mono_on hab hf hg h + integral_const gives (2pi)*c bound; nlinarith [Real.two_pi_pos]. NOTE: needs imports Analysis.SpecialFunctions.Integrals.Basic + MeasureTheory.Integral.IntervalIntegral.Basic (the file did NOT import Mathlib fully)."
     ],
     "mathlibGaps": [
       "No direct reduction of an ℝ-infimum of a periodic continuous function to a min over a fundamental period; needs a toIcoMod-style mod-2π reduction to formalize attainment."
     ],
     "nextSteps": [
-      "Formalize attainment: ∃ θ, cosineSum A θ = minCosineSum A via continuity on [0,2π] + periodicity.",
-      "For A ⊂ ℕ⁺, prove minCosineSum A ≤ 0 via ∫_0^{2π} cosineSum A = 0 (each ∫cos(nθ)=0 for n≥1).",
-      "Formalize the Sidon-set difference-set example showing √N optimality (harder)."
+      "minCosineSum A < 0 STRICT for nonempty positive-frequency A (the <=0 result plus ruling out the identically-zero case; needs cosineSum not constant 0, e.g. value N at theta=0).",
+      "The sharp -c*sqrt(N) bound (Chowla) stays a deep imported result (Bourgain/Ruzsa/Bedert).",
+      "Sidon-set difference-set example for sqrt(N) optimality (harder)."
     ],
     "markdown": "# Knowledge Base: erdos-510-wip-01\n\n## Session 2026-07-20 (researcher-1) — foundational cosine-sum scaffolding\n\n**Mode**: FRESH (EMPTY node). **Outcome**: progress — VERIFIED axiom-free (`[propext, Classical.choice, Quot.sound]`), 0 sorry / 0 axiom. Host-verified (Mathlib-only parent): fresh-built `Erdos510Problem.olean` then `lake env lean` on the child (no Docker).\n\n### What I did\nCreated `proofs/Proofs/Erdos510WIP01.lean` (16 theorems) establishing the elementary structure of the Chowla cosine sum `cosineSum A θ = ∑_{n∈A} cos(nθ)` and its infimum `minCosineSum A = ⨅_θ cosineSum A θ`:\n- **Evaluation**: `cosineSum_empty`, `cosineSum_singleton`, `cosineSum_insert`, `cosineSum_zero_angle` (`= N`), `cosineSum_pi` (`= ∑(−1)ⁿ`).\n- **Symmetry / periodicity**: `cosineSum_neg` (even), `cosineSum_add_two_pi` (2π-periodic).\n- **Continuity**: `continuous_cosineSum`.\n- **Two-sided bound**: `abs_cosineSum_le_card` (`|·| ≤ N`), `cosineSum_le_card`, `neg_card_le_cosineSum`.\n- **Infimum**: `bddBelow_range_cosineSum`, `minCosineSum_le`, `neg_card_le_minCosineSum`, `minCosineSum_le_card`, `minCosineSum_empty`, and the exact value `minCosineSum_singleton` (`= −1` for `n ≥ 1`).\n\n### Key findings\n- The cosine sum lives in `[−N, N]`; the conjectured extremum `−c√N` is strictly interior, so every elementary bound is far from the truth — the mathematics is entirely in the cancellation.\n- `minCosineSum {n} = −1` exactly (attained at `θ = π/n`): single-frequency sets are maximally negative per size, so the `−c√N` difficulty is a genuine many-frequency phenomenon.\n\n### Reusable Lean recipe\n- Periodicity per term: `Real.cos_add_nat_mul_two_pi (n*θ) n` after `ring`-rewriting `n·(θ+2π) = n·θ + n·(2π)`.\n- `θ=π` collapse: `Real.cos_nat_mul_pi n : cos(n·π) = (−1)ⁿ`.\n- Infimum bounds in ℝ: `ciInf_le (bddBelow …) θ` and `le_ciInf (fun θ => …)` (index `ℝ` is `Nonempty`); bound the range below by `−N` via `neg_card_le_cosineSum`.\n- `|cos| ≤ 1` without `Analysis.Complex.Trigonometric`: `abs_le.mpr ⟨Real.neg_one_le_cos _, Real.cos_le_one _⟩`.\n- Continuity of a partially-applied `def`: `show Continuous (fun θ => …)` (not `simp only [def]`, which makes no progress under `Continuous`), then `continuous_finsetSum`.\n\n### Next steps\n- Attainment: `∃ θ, cosineSum A θ = minCosineSum A` (continuity on `[0,2π]` + periodicity).\n- `minCosineSum A ≤ 0` for `A ⊂ ℕ⁺` via `∫_0^{2π} cosineSum A = 0`.\n\n### Still open (unchanged)\nThe `−c√N` lower bound (Chowla's conjecture) — deep; Bedert (2025) reached `−cN^{1/7}`, the `N^{1/7}`↔`N^{1/2}` gap is open.\n"
   },


### PR DESCRIPTION
## Summary

Reduces the Route-1 primitivity obligation for **odd primitive abundant numbers** (`abundant-number-oq-03-oq-03`, OEIS A006038) to **pure divisor-sum arithmetic** — the semantic `Nat.Abundant` / `Nat.Deficient` predicates are eliminated, so a concrete witness `m·p` is now certifiable by kernel `decide`. All new theorems are **axiom-free** (`[propext, Classical.choice, Quot.sound]`, no `Lean.ofReduceBool`), host-verified via `lake env lean` (exit 0, `import Mathlib` only).

## New theorems (`proofs/Proofs/AbundantNumberOQ03OQ03.lean`)

- **`deficient_iff_sum_divisors`** — `Deficient n ↔ σ(n) < 2n` (unconditional; the deficient dual of Mathlib's `Nat.abundant_iff_sum_divisors`). Reusable, Mathlib-worthy.
- **`deficient_mul_prime_iff`** — `(e·p).Deficient ↔ σ(e)(p+1) < 2ep` for `p` prime, `p ∤ e`. The multiplicative dual of the existing `abundant_mul_prime_iff`, via `sum_divisors_mul_prime`.
- **`isPrimitiveAbundant_mul_prime_arith`** — `m·p` is primitive abundant from three divisor-sum inequalities alone: `2mp < σ(m)(p+1)`, `σ(m) < 2m`, and `∀ e ∈ m.properDivisors, σ(e)(p+1) < 2ep`. Endpoint of the Route-1 reduction.
- **`primitive_945_via_engine`** — `189·5 = 945` certified primitive abundant through the arithmetic criterion by `decide`, an end-to-end validation of the engine against the known least odd primitive abundant witness.

## Toward infinitude (still open)

Writing `I(x) = σ(x)/x` (abundancy index), conditions collapse to a **rational prime window**: `m·p` is primitive abundant iff `I*(m)/(2−I*(m)) < p < I(m)/(2−I(m))` (with `p ∤ m`), where `I*(m) = max_{e∣m, e<m} I(e)`. Route-1 infinitude thus reduces to an infinite odd deficient family `mₖ` with `I(mₖ) → 2` and a Bertrand-type prime in each window. This remains **genuinely open** — no such odd family is known.

## Verification
- `lake env lean Proofs/AbundantNumberOQ03OQ03.lean` → exit 0, no errors/warnings.
- `#print axioms` on all four new theorems → `[propext, Classical.choice, Quot.sound]` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
