### PR TITLE
audit: amgm-inequality-oq005 — clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -29882,6 +29882,12 @@
       "lastAudited": "2026-07-21T04:09:41Z",
       "result": "clean",
       "issues": []
+    },
+    "amgm-inequality-oq005": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T04:30:31Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Audit result: CLEAN

**Proof**: amgm-inequality-oq005 — General Newton–Girard Recurrence for Arbitrary k

### Verified
- Counts match meta: 2 theorems / 0 axioms / 0 sorries / 0 defs / 152 lines. (`psum_recurrence`, `mul_esymm_recurrence`; the two k=4/k=5 blocks are anonymous `example`s, correctly not counted as theorems.)
- All 5 `originalContributions` map to real content: the two named theorems, the antidiagonal→`Ico` reindexing technique, the inline sign-folding argument (explicitly 'avoids any named neg-sum lemma' — not a phantom decl), and the two subsumption `example`s that derive the parent's psum_four_eq/psum_five_eq verbatim from the general theorem.
- Badge `mathlib` correct: headline delegates to Mathlib's `psum_eq_mul_esymm_sub_sum`; the genuinely new content is the closed-form interval reindexing.
- 5 kernel `decide` calls (small-literal Finset facts) — axiom-free, disclosed in `assumptions`; no `native_decide`.

Persisting the clean audit to the tracker (fleet `git reset --hard` otherwise wipes it).

---
Discovered during gallery integrity audit.