### PR TITLE
Enrich hilbert-20-oq-01-oq-03: add head+PART8 sections, re-anchor 6 drifted PARTs (cover 1-363)

### DIFF
--- a/src/data/proofs/hilbert-20-oq-01-oq-03/meta.json
+++ b/src/data/proofs/hilbert-20-oq-01-oq-03/meta.json
@@ -70,46 +70,60 @@
   },
   "sections": [
     {
+      "id": "imports-overview",
+      "title": "Imports, Overview, and Setup",
+      "startLine": 1,
+      "endLine": 50,
+      "summary": "Mathlib imports (inner-product spaces, normed fields, Fréchet derivatives, complex numbers) and the module docstring framing OQ-01/OQ-03 of Hilbert's 20th problem: local solvability of linear PDOs. Opens `Classical`, `Finset`, `Complex` and the `Hilbert20OQ01OQ03` namespace extending the parent framework."
+    },
+    {
       "id": "pdo-framework",
       "title": "PDO Structure and Principal Symbol",
-      "startLine": 52,
-      "endLine": 65,
+      "startLine": 51,
+      "endLine": 73,
       "summary": "Defines multi-indices, linear PDOs of order m, and the principal symbol extraction."
     },
     {
       "id": "monomial-conjugation",
       "title": "Monomial Reality and Conjugation",
-      "startLine": 71,
-      "endLine": 94,
+      "startLine": 74,
+      "endLine": 98,
       "summary": "Proves monomials with real arguments are real and fixed by conjugation — the algebraic linchpin for the adjoint symbol theorem."
     },
     {
       "id": "adjoint-theory",
       "title": "Formal Adjoint and Symbol Relation",
-      "startLine": 100,
-      "endLine": 139,
+      "startLine": 99,
+      "endLine": 145,
       "summary": "Defines the formal adjoint by conjugating coefficients, proves p*(x,ξ) = conj(p(x,ξ)), adjoint involutivity, and self-adjointness for real coefficients."
     },
     {
       "id": "hormander-duality",
       "title": "Hörmander Duality Framework",
-      "startLine": 141,
-      "endLine": 162,
+      "startLine": 146,
+      "endLine": 168,
       "summary": "Axiomatizes a priori estimates, local solvability, and Hörmander's duality theorem connecting solvability to adjoint estimates."
     },
     {
       "id": "dencker-weight",
       "title": "Dencker Weight and Condition (Ψ)",
-      "startLine": 168,
-      "endLine": 225,
+      "startLine": 169,
+      "endLine": 244,
       "summary": "Defines Dencker weight structure, condition (Ψ) via bicharacteristic sign control, and axiomatizes weight existence and estimate derivation."
     },
     {
       "id": "sufficiency-theorem",
       "title": "Dencker's Sufficiency Theorem and Corollaries",
-      "startLine": 227,
-      "endLine": 284,
+      "startLine": 245,
+      "endLine": 319,
       "summary": "Proves the main theorem: condition (Ψ) → solvability via the three-step chain. Derives corollaries for real-symbol and self-adjoint operators."
+    },
+    {
+      "id": "summary",
+      "title": "PART 8: Summary of Results",
+      "startLine": 320,
+      "endLine": 363,
+      "summary": "Closing summary docstring cataloguing the 10 axiom-free proved results (from `monomial_real` through `self_adjoint_solvable` and the now-`rfl` `imSymbolAlongCurve_spec`), the structures/defs concretized out of axiom status (`BicharacteristicCurve`, `imSymbolAlongCurve`), and the 5 genuinely-deep remaining axioms (`HasAPrioriEstimate`, `IsLocallySolvable`, `hormander_duality`, `dencker_weight_exists`, `weight_implies_estimate`), each requiring Sobolev-space / distribution machinery not yet in scope. Ends with `#check`s of the key proved theorems. 0 sorries."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
Object-section drift + coverage-gap repair for **hilbert-20-oq-01-oq-03** (Hilbert's 20th, local solvability of linear PDOs; Dencker's condition (Ψ)).

**Problem:** `Proofs/Hilbert20OQ01OQ03.lean` is 363 lines but `meta.json` covered only `52 → 284`:
- **Head gap:** lines 1–51 (imports + module docstring + namespace) had no section.
- **Drift:** the 6 existing sections were anchored a few lines short of their `PART N` banners.
- **Tail gap:** PART 7's local-solvability corollaries (`real_symbol_solvable`, `self_adjoint_solvable`) and the entire PART 8 summary (285–363) were uncovered — even though the `sufficiency-theorem` summary already advertised "corollaries for real-symbol and self-adjoint operators."

**Fix (sections only — no status/badge/axiomCount change):**
- Added `imports-overview` (1–50) and `summary` (PART 8, 320–363) sections.
- Re-anchored the 6 existing sections to their real `PART 1–6` + PART 7 ranges (`sufficiency-theorem` extended 245→319 to include the PART 7 corollaries it already describes). Existing summaries preserved.

Coverage now contiguous `1 → 363` (validated: no gaps/overlaps). `axiomCount: 5`, `status: axiomatized`, `badge: axiom` unchanged — verified against the file's own PART 8 axiom roll-call (the 5 axioms `HasAPrioriEstimate`, `IsLocallySolvable`, `hormander_duality`, `dencker_weight_exists`, `weight_implies_estimate`).
