### PR TITLE
audit: arithmetic-series-oq004 (Pólya Enumeration) — clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -29906,6 +29906,12 @@
       "lastAudited": "2026-07-21T04:40:56Z",
       "result": "clean",
       "issues": []
+    },
+    "arithmetic-series-oq004": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T04:46:34Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
Gallery integrity audit — **no issues found**.

**Proof**: arithmetic-series-oq004 — *Pólya Enumeration via Cyclic Group Actions* (deep OQ chain under `arithmetic-series`)
**Tier**: C-ish (native_decide-backed concrete values) with a genuinely general core — status `axiomatized` / badge `axiom`.

## Verification
- **Counts match**: theoremCount 30 ✓ (30 theorem/lemma decls incl. private), defCount 5 ✓ (4 `def` + 1 `abbrev`), sorries 0 ✓.
- **axiomCount 1 is conservative disclosure**: no literal `axiom` decls exist (leanFile.axiomCount 0). The `1` accounts for `Lean.ofReduceBool`, introduced by 13 `native_decide` uses — disclosed thoroughly in `assumptions` and the description.
- **No True/vacuous stubs** — every theorem is a genuine claim.
- **General theorem genuinely proved**: `polya_enumeration_theorem_CN` (0 sorries) relies on `BurnsideCountingOQ03.polya_cyclic_fixed_count` and `polya_sum_identity`. Verified the parent file `BurnsideCountingOQ03.lean` is **0 sorries / 0 axioms**, and `polya_cyclic_fixed_count` (lines 184–223) is a real general bijection proof — no native_decide, no sorry. So "General Pólya theorem now fully proved" is accurate.
- The `ZMod n → Fin k` group action is genuinely axiom-free (action law via `sub_sub`), as claimed.

Meta over-discloses rather than over-claims — integrity-clean.

**Nit (parent file, not fixed here)**: `BurnsideCountingOQ03.lean:37` docstring calls `polya_cyclic_fixed_count` "(general, proved for n=4)" — stale wording; the theorem is genuinely general. Harmless.

Persists the clean audit result to the tracker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)