### PR TITLE
Research: erdos-85-wip-01 — improved lower bound f(5) ≥ 3 via the 5-cycle witness

### DIFF
--- a/proofs/Proofs/Erdos510WIP01.lean
+++ b/proofs/Proofs/Erdos510WIP01.lean
@@ -215,4 +215,72 @@ theorem minCosineSum_nonpos (A : Finset ℕ) (hA : 0 ∉ A) : minCosineSum A ≤
   simp only [smul_eq_mul, sub_zero] at hmono
   nlinarith [Real.two_pi_pos]
 
+/-! ## The minimum is *strictly* negative for nonempty positive-frequency sets
+
+The nonpositivity bound above is not tight: for a *nonempty* positive-frequency set the
+minimum is strictly below `0`.  The point is that `cosineSum A` cannot be `≡ 0`: it takes
+the value `N = A.card ≥ 1` at `θ = 0`.  If its minimum were `0` the (continuous, nonnegative)
+integrand would still have integral `0` over a full period, yet it is *strictly* positive on
+a whole subinterval near `0` — forcing the period integral to be positive, a contradiction.
+So the minimum must be `< 0`, i.e. every nonempty positive-frequency cosine sum genuinely
+dips below zero somewhere. -/
+
+/-- **The Chowla cosine sum is strictly negative at its minimum** for a nonempty
+positive-frequency set.  If `0 ∉ A` and `A ≠ ∅` then `minCosineSum A < 0`.  Combined with
+`∫₀^{2π} cosineSum A = 0`: were the minimum `0`, the nonnegative integrand would be strictly
+positive on a subinterval about `θ = 0` (where `cosineSum A 0 = A.card ≥ 1`), making the
+period integral positive — impossible. This strengthens `minCosineSum_nonpos` and is the
+qualitative core of the Chowla problem (the quantitative `−c√N` bound stays deep). -/
+theorem minCosineSum_neg (A : Finset ℕ) (hA : 0 ∉ A) (hne : A.Nonempty) :
+    minCosineSum A < 0 := by
+  rcases (minCosineSum_nonpos A hA).lt_or_eq with h | h
+  · exact h
+  exfalso
+  -- If the minimum is `0`, the sum is pointwise `≥ 0`.
+  have hnn : ∀ θ, 0 ≤ cosineSum A θ := fun θ => h ▸ minCosineSum_le A θ
+  -- The sum is strictly positive at `θ = 0` (value `A.card ≥ 1`).
+  have hc0 : 0 < cosineSum A 0 := by
+    rw [cosineSum_zero_angle]; exact_mod_cast Finset.card_pos.mpr hne
+  -- `{θ | 0 < cosineSum A θ}` is open and contains `0`, so it holds on a ball `(−ε, ε)`.
+  have hopen : IsOpen {θ : ℝ | 0 < cosineSum A θ} :=
+    isOpen_lt continuous_const (continuous_cosineSum A)
+  obtain ⟨ε, hε, hball⟩ := Metric.isOpen_iff.mp hopen 0 hc0
+  -- Work on the interval `[δ/2, δ]` with `δ = min ε π`, safely inside `(0, 2π)`.
+  set δ := min ε π with hδ
+  have hδpos : 0 < δ := lt_min hε Real.pi_pos
+  have hδle : δ ≤ π := min_le_right _ _
+  have hδε : δ ≤ ε := min_le_left _ _
+  have hcd : ∀ x ∈ Set.Ioo (δ / 2) δ, 0 < cosineSum A x := by
+    intro x hx
+    apply hball
+    rw [Real.ball_eq_Ioo]
+    exact ⟨by simp only [zero_sub]; linarith [hx.1], by simpa using lt_of_lt_of_le hx.2 hδε⟩
+  -- Strict positivity of the middle integral, nonnegativity of the two outer ones.
+  have hpos : 0 < ∫ x in (δ / 2)..δ, cosineSum A x :=
+    intervalIntegral.intervalIntegral_pos_of_pos_on
+      ((continuous_cosineSum A).intervalIntegrable _ _) hcd (by linarith)
+  have hn1 : 0 ≤ ∫ x in (0 : ℝ)..(δ / 2), cosineSum A x :=
+    intervalIntegral.integral_nonneg (by linarith) (fun u _ => hnn u)
+  have hn3 : 0 ≤ ∫ x in δ..(2 * π), cosineSum A x :=
+    intervalIntegral.integral_nonneg (by linarith [Real.pi_pos]) (fun u _ => hnn u)
+  -- Split `∫₀^{2π} = ∫₀^{δ/2} + ∫_{δ/2}^{δ} + ∫_δ^{2π}`, which is then `> 0`.
+  have i1 : IntervalIntegrable (cosineSum A) MeasureTheory.volume 0 (δ / 2) :=
+    (continuous_cosineSum A).intervalIntegrable _ _
+  have i2 : IntervalIntegrable (cosineSum A) MeasureTheory.volume (δ / 2) δ :=
+    (continuous_cosineSum A).intervalIntegrable _ _
+  have i3 : IntervalIntegrable (cosineSum A) MeasureTheory.volume δ (2 * π) :=
+    (continuous_cosineSum A).intervalIntegrable _ _
+  have hadd1 := intervalIntegral.integral_add_adjacent_intervals i1 i2
+  have hadd2 := intervalIntegral.integral_add_adjacent_intervals (i1.trans i2) i3
+  have hint : ∫ θ in (0 : ℝ)..(2 * π), cosineSum A θ = 0 := integral_cosineSum_eq_zero A hA
+  linarith [hadd1, hadd2, hpos, hn1, hn3, hint]
+
+/-- **Every nonempty positive-frequency cosine sum dips below zero.**  There is an angle
+`θ` with `cosineSum A θ < 0`.  Immediate from `minCosineSum_neg` and the attainment of the
+minimum (`exists_eq_minCosineSum`): the minimizing angle already realises a negative value. -/
+theorem exists_angle_cosineSum_neg (A : Finset ℕ) (hA : 0 ∉ A) (hne : A.Nonempty) :
+    ∃ θ : ℝ, cosineSum A θ < 0 := by
+  obtain ⟨θ₀, hθ₀⟩ := exists_eq_minCosineSum A
+  exact ⟨θ₀, hθ₀.trans_lt (minCosineSum_neg A hA hne)⟩
+
 end Erdos510WIP01

--- a/proofs/Proofs/Erdos85Problem.lean
+++ b/proofs/Proofs/Erdos85Problem.lean
@@ -345,4 +345,39 @@ theorem two_le_minDegreeForC4 {n : ℕ} (hn : 3 ≤ n) :
   rw [not_le] at hk2
   exact hfree (hk (starGraph n) (le_trans (by omega : k ≤ 1) hstar))
 
+/-- `C₄`'s adjacency `(i+1)%4 = j ∨ (j+1)%4 = i` is a decidable predicate, so `C4`
+has computable degrees and finite membership tests — needed to `decide` whether a
+concrete graph contains a `C₄`. -/
+instance : DecidableRel C4.Adj := fun i j => by unfold C4; infer_instance
+
+/-- **A cycle beats the star: `f(5) ≥ 3`.**  The 5-cycle `C₅` (`SimpleGraph.cycleGraph 5`)
+has *every* degree equal to `2` (`cycleGraph_degree_three_le`) yet contains no `C₄`
+(a `4`-cycle needs four consecutive `±1` steps in `ℤ/5` summing to `0`, forcing two of
+the four vertices to coincide — verified by `decide`).  So no threshold `k ≤ 2` can force
+a `C₄` on `5` vertices, giving `minDegreeForC4 5 ≥ 3`.  This strictly improves the generic
+star bound `f(5) ≥ 2` and confirms `f(5) ≥ 3` (the true asymptotic is `f(n) = (1+o(1))√n`,
+so `f(5)` sits just above `√5 ≈ 2.24`). -/
+theorem three_le_minDegreeForC4_five : 3 ≤ minDegreeForC4 5 := by
+  -- `C₅` is `C₄`-free (concrete `Decidable` instances, no `classical`).
+  have hfree : ¬ containsC4 (Fin 5) (cycleGraph 5) := by
+    unfold containsC4
+    set_option maxRecDepth 100000 in decide
+  -- `C₅` has minimum degree `2` (every vertex has degree `2`).
+  have hdeg : ∀ v : Fin 5, 2 ≤ (cycleGraph 5).degree v := by decide
+  have hmin2 : 2 ≤ (cycleGraph 5).minDegree := by
+    apply le_minDegree_of_forall_le_degree
+    exact hdeg
+  -- The threshold set is nonempty (min-degree `≥ 4` forces `⊤`, hence a `C₄`).
+  have hne : {k : ℕ | ∀ (G : SimpleGraph (Fin 5)) [DecidableRel G.Adj],
+      G.minDegree ≥ k → containsC4 (Fin 5) G}.Nonempty := by
+    refine ⟨4, fun G _ hmin => ?_⟩
+    rw [eq_top_of_minDegree_ge G (by simpa using hmin)]
+    exact completeGraph_containsC4 (by norm_num)
+  unfold minDegreeForC4
+  refine le_csInf hne (fun k hk => ?_)
+  -- Any threshold `k` in the set is `≥ 3`: else `C₅` (min-degree `2 ≥ k`) forces a `C₄`.
+  by_contra hk3
+  rw [not_le] at hk3
+  exact hfree (hk (cycleGraph 5) (le_trans (by omega : k ≤ 2) hmin2))
+
 end Erdos85

--- a/research/problems/erdos-510-wip-01/knowledge.md
+++ b/research/problems/erdos-510-wip-01/knowledge.md
@@ -1,5 +1,35 @@
 # Knowledge Base: erdos-510-wip-01
 
+## Session 2026-07-20 (researcher-1) — strict minCosineSum < 0 for nonempty positive-frequency sets
+
+**Mode**: build on the nonpositivity result. **Outcome**: progress — 2 axiom-free theorems,
+host-verified v4.31 (`lake env lean` exit 0; `#print axioms` = `[propext, Classical.choice,
+Quot.sound]`; no sorry/native_decide).
+
+`minCosineSum_neg : 0 ∉ A → A.Nonempty → minCosineSum A < 0`. Strengthens `minCosineSum_nonpos`.
+Argument (by contradiction on `minCosineSum A = 0`): then `cosineSum A ≥ 0` pointwise, but
+`cosineSum A 0 = A.card ≥ 1 > 0`, so `{θ | 0 < cosineSum A θ}` is open (`isOpen_lt`) and contains
+`0`, hence contains a ball `(−ε, ε)`. On `[δ/2, δ]` (`δ = min ε π ⊂ (0,2π)`) the integrand is
+strictly positive, so `∫_{δ/2}^{δ} cosineSum > 0` (`intervalIntegral.intervalIntegral_pos_of_pos_on`
+— NOTE: lives in `namespace intervalIntegral`, so double-qualified). Splitting
+`∫₀^{2π} = ∫₀^{δ/2} + ∫_{δ/2}^{δ} + ∫_δ^{2π}` via `integral_add_adjacent_intervals`, the outer
+pieces are `≥ 0` (`integral_nonneg`) and the middle `> 0`, so the period integral is `> 0` —
+contradicting `integral_cosineSum_eq_zero = 0`.
+
+`exists_angle_cosineSum_neg : 0 ∉ A → A.Nonempty → ∃ θ, cosineSum A θ < 0`. Immediate from
+`minCosineSum_neg` + `exists_eq_minCosineSum` (minimizing angle realises a negative value).
+
+**Key idiom**: `intervalIntegral_pos_of_pos_on` needs strict positivity on the WHOLE open
+interior, so it can't hit the full period (cosineSum isn't positive everywhere) — instead
+carve a small subinterval where it IS positive (via continuity + `isOpen_lt` ball) and split
+the period integral; outer nonneg + middle strict-pos.
+
+### Next
+- Sharp `−c√N` bound (Chowla; Bourgain/Ruzsa/Bedert) stays a deep imported result — the
+  elementary sign structure (≤0, strict <0, attainment) is now COMPLETE. Remaining elementary
+  targets are thin: perhaps `cosineSum A π = ∑ (−1)^n` sharpness, or lower bounds for specific
+  structured A (e.g. arithmetic progressions). The genuine open mission is quantitative only.
+
 ## Session 2026-07-20 (researcher-1) — minCosineSum ≤ 0 for positive-frequency sets
 
 **Mode**: build on the attainment result. **Outcome**: progress — 3 axiom-free theorems,

--- a/research/problems/erdos-85-wip-01/knowledge.md
+++ b/research/problems/erdos-85-wip-01/knowledge.md
@@ -1,5 +1,38 @@
 # Knowledge Base: erdos-85-wip-01
 
+## Session 2026-07-20 (researcher-1) — improved lower bound f(5) ≥ 3 via the 5-cycle witness
+
+**Mode**: build on the star lower bound. **Outcome**: progress — 1 theorem + 1 instance,
+axiom-free (kernel `decide`, `#print axioms` = `[propext, Classical.choice, Quot.sound]`, no
+`native_decide`/`Lean.ofReduceBool`), host-verified `lake env lean` exit 0.
+
+`three_le_minDegreeForC4_five : 3 ≤ minDegreeForC4 5`. Strictly beats the generic star bound
+`f(5) ≥ 2`. Witness: Mathlib's `SimpleGraph.cycleGraph 5` (the 5-cycle C₅) has every degree
+`= 2` yet is C₄-free, so no threshold `k ≤ 2` forces a C₄ on 5 vertices.
+
+- **C₄-freeness** `¬ containsC4 (Fin 5) (cycleGraph 5)` proved by kernel `decide` — needs
+  `unfold containsC4` first (decide can't see through the `def` to synthesize `Decidable`),
+  plus `set_option maxRecDepth 100000` (the ∃ ranges over `Fin 4 → Fin 5`, 625 functions;
+  ~kernel-heavy but succeeds, NO native_decide). Also needs a **`instance : DecidableRel
+  C4.Adj`** (C4's structure-literal Adj had no registered instance; `fun i j => by unfold C4;
+  infer_instance`). `Function.Injective f` is decidable via `Fintype.decidableInjectiveFintype`.
+- **min degree** via `∀ v : Fin 5, 2 ≤ (cycleGraph 5).degree v := by decide` +
+  `le_minDegree_of_forall_le_degree` (use `apply` form — positional `k` arg mis-elaborates
+  the numeral as `OfNat SimpleGraph`). NOTE: `cycleGraph_degree_three_le` is stated for
+  `cycleGraph (n+3)`; `(cycleGraph 5).degree` does NOT unify `5 =?= ?n+3`, so `decide` the
+  degrees directly instead.
+- Threshold-set nonempty via `eq_top_of_minDegree_ge` (min-degree `≥ 4` ⟹ `⊤` ⟹ C₄);
+  `le_csInf` packages `0,1,2 ∉` the set.
+
+### Next
+- Generalize to `f(n) ≥ 3` for ALL `n ≥ 5` via `cycleGraph n` C₄-free: needs the structural
+  Fin-n argument (four consecutive `±1` steps in ℤ/n summing to 0 ⟹ two vertices coincide),
+  ~80-150 lines, NOT decide-able for general n. The `p=2` (two `+1`, two `−1`) collision is
+  the crux. This is the genuine next lower-bound target.
+- `f(4) = 2` upper half (min-degree ≥ 2 on Fin 4 ⟹ C₄) still needs the enumeration bridge
+  over all `SimpleGraph (Fin 4)` — harder (uniform `DecidableRel` / Fintype of graphs).
+- KST `√n`-scale bound stays deep/imported.
+
 ## Session 2026-07-20 (researcher-1) — lower bound 2 ≤ f(n+1) via the star witness
 
 Added to `Erdos85Problem.lean` (Mathlib-only, host-verified; `#print axioms` =

--- a/src/data/proofs/erdos-85/meta.json
+++ b/src/data/proofs/erdos-85/meta.json
@@ -159,9 +159,9 @@
       "Topology"
     ],
     "namespace": "Erdos85",
-    "lineCount": 300,
+    "lineCount": 383,
     "axiomCount": 0,
-    "theoremCount": 13,
+    "theoremCount": 16,
     "definitionCount": 8,
     "path": "Proofs/Erdos85Problem.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

Improves the min-degree-for-C₄ lower bound (`erdos-85-wip-01`, Erdős #85) from the generic star witness `f(5) ≥ 2` to **`f(5) ≥ 3`**, using Mathlib's 5-cycle. Axiom-free (kernel `decide`, **not** `native_decide`; `#print axioms` = `[propext, Classical.choice, Quot.sound]`), host-verified via `lake env lean` (exit 0).

## New in `proofs/Proofs/Erdos85Problem.lean`

- **`instance : DecidableRel C4.Adj`** — `C4`'s structure-literal `Adj` had no registered `Decidable` instance (`decide` on `C4.Adj 0 1` previously failed); this makes C₄-containment decidable.
- **`three_le_minDegreeForC4_five`** — `3 ≤ minDegreeForC4 5`. The 5-cycle `SimpleGraph.cycleGraph 5` (C₅) has every degree `2` (`le_minDegree_of_forall_le_degree`) yet is **C₄-free**: `¬ containsC4 (Fin 5) (cycleGraph 5)` is proved by **kernel `decide`** over the 625 functions `Fin 4 → Fin 5` (`unfold containsC4`, `maxRecDepth 100000`). So no threshold `k ≤ 2` forces a C₄ on 5 vertices; the threshold set is nonempty via `eq_top_of_minDegree_ge`, and `le_csInf` packages `0,1,2 ∉ set`.

## Context

This strictly improves the prior generic star bound `f(n+1) ≥ 2` and confirms `f(5) ≥ 3`. The true asymptotic is `f(n) = (1+o(1))√n`, so `f(5)` sits just above `√5 ≈ 2.24`. **Next** (documented in knowledge.md): generalize to `f(n) ≥ 3` for all `n ≥ 5` via the structural Fin-`n` cycle argument (four consecutive `±1` steps in `ℤ/n` summing to 0 force two vertices to coincide) — not `decide`-able for general `n`. The Kővári–Sós–Turán `√n`-scale bound and `f(4) = 2` upper half remain deeper targets.

## Verification
- `lake env lean Proofs/Erdos85Problem.lean` → exit 0, no errors/warnings.
- `#print axioms Erdos85.three_le_minDegreeForC4_five` → `[propext, Classical.choice, Quot.sound]` (no `Lean.ofReduceBool`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
