### PR TITLE
Audit: batch-persist 9 clean slugs (abel-ruffini + amgm cluster)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -29924,6 +29924,60 @@
       "lastAudited": "2026-07-21T05:06:45Z",
       "result": "issues-fixed",
       "issues": []
+    },
+    "abel-ruffini-oq002": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T05:13:54Z",
+      "result": "clean",
+      "issues": []
+    },
+    "abel-ruffini-oq006": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T05:13:54Z",
+      "result": "clean",
+      "issues": []
+    },
+    "abel-ruffini-oq007": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T05:13:54Z",
+      "result": "clean",
+      "issues": []
+    },
+    "abel-ruffini-oq008": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T05:13:54Z",
+      "result": "clean",
+      "issues": []
+    },
+    "abel-ruffini-oq010": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T05:13:54Z",
+      "result": "clean",
+      "issues": []
+    },
+    "abel-ruffini-oq011": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T05:13:54Z",
+      "result": "clean",
+      "issues": []
+    },
+    "algebraic-numbers-countable-oq001": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T05:13:54Z",
+      "result": "clean",
+      "issues": []
+    },
+    "amgm-inequality-oq001": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T05:13:54Z",
+      "result": "clean",
+      "issues": []
+    },
+    "amgm-inequality-oq002": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T05:13:54Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Gallery Integrity Audit — batch persist (9 slugs)

**Result: all CLEAN.** These are the alphabetical-top never-persisted slugs that `--next` re-serves every cycle because their prior audit PRs closed with **empty diffs** (the `complete` tracker edit is wiped by the shared-checkout `git reset --hard` before commit). Batched into one tracker commit so the whole cluster finally persists and drains from the queue. Companion to #40111 (abel-ruffini-oq001).

### Slugs (meta vs file — all match: 0 axioms, 0 sorries, 0 True stubs, no real native_decide)
| slug | badge | thms | note |
|---|---|---|---|
| abel-ruffini-oq002 | original | 3 | char-2 route sibling |
| abel-ruffini-oq006 | mathlib | 12 | solvability descent |
| abel-ruffini-oq007 | mathlib | 7 | Mathlib `viaEmbeddingHom_injective` credited |
| abel-ruffini-oq008 | mathlib | 9 | contrapositive descent |
| abel-ruffini-oq010 | mathlib | 10 | threshold reflections |
| abel-ruffini-oq011 | mathlib | 8 | survivor lemmas |
| algebraic-numbers-countable-oq001 | original | 6 | Fσ-not-Gδ |
| amgm-inequality-oq001 | original | 5 | power-sums |
| amgm-inequality-oq002 | original | 5 | kernel `decide`, disclosed |

### Notes
- oq006–oq011 grep as `native_decide: 1`, but the string appears **only in each file's no-assumptions docstring disclaimer** (oq011's `assumptions` says so explicitly); no real `native_decide` use — verified against the disclosure prose.
- `mathlib` badges correctly credit the Mathlib solvability lemmas carrying the core; `original` badges are elementary from-scratch work with no famous-theorem overclaim.

No gallery-claim changes required.

---
Discovered during gallery integrity audit.