### PR TITLE
Research: erdos-98-wip-01 — general-position existence for ALL n (parabola construction)

### DIFF
--- a/proofs/Proofs/Erdos98WIP01.lean
+++ b/proofs/Proofs/Erdos98WIP01.lean
@@ -63,6 +63,14 @@ The `Prop` definitions are faithful transcriptions only — Pach/EFP/Guth–Katz
 imported as *assumptions* (deep results, not reproved here) and the two
 conjectures are *open* in mathematics; nothing below claims to resolve them.
 
+9. `exists_inGeneralPosition` — **general-position configurations exist for *every* `n`**,
+   via the uniform parabola witness `i ↦ (i+1, (i+1)²)` (strictly positive, distinct
+   abscissae). This settles the constructive existence question the `n = 4` section flagged
+   as "the deep constructive piece": four parabola points are concyclic iff their abscissae
+   sum to `0`, so positivity of the abscissae rules concyclicity out, and strict convexity
+   rules out collinearity. Consequently `h_attained` upgrades the attained-minimum guarantee
+   from `n ≤ 4` to all `n` — `h n` is never the `sInf ∅` junk value.
+
 ## Summary: 0 sorries, 0 axioms, no `native_decide`. Built over the gallery defs.
 -/
 
@@ -510,5 +518,233 @@ theorem exists_inGeneralPosition_of_le_four (hn : n ≤ 4) :
   · have : n = 4 := by omega
     subst this
     exact exists_inGeneralPosition_four
+
+/-! ## General-position existence for **every** `n` — the parabola with positive abscissae
+
+The concrete `n ≤ 4` witnesses above are subsumed by a single uniform construction that
+settles general-position existence for **all** `n`, the "deep constructive piece" the
+`n = 4` header flagged as open.  The obstruction it named — "the natural parabola
+construction `(t, t²)` already fails *no four concyclic*: any four parabola points whose
+`x`-coordinates sum to `0` are concyclic" — is real but avoidable: four points
+`(xₐ, xₐ²), …, (x_d, x_d²)` on `y = x²` are concyclic **iff** `xₐ + x_b + x_c + x_d = 0`
+(the four abscissae are the roots of the monic quartic `x⁴ + (1-2c₁)x² - 2c₀x + s` cut out by
+a circle `(x-c₀)² + (y-c₁)² = r²`, whose `x³`-coefficient vanishes).  Choosing the abscissae
+**strictly positive** — here `xᵢ = i + 1 ∈ {1, …, n}` — makes every 4-subset sum `≥ 4 > 0`, so
+no four are concyclic.  And on a parabola no three points are *ever* collinear: three points
+`(xᵢ, xᵢ²)` collinear forces `a + b(xᵢ+xⱼ) = 0` for each pair, hence `b = 0` then `a = 0` then
+`c = 0`.  Both nondegeneracy conditions thus hold for `parabolaConfig n`, giving
+`exists_inGeneralPosition n` for all `n` and, via `Nat.sInf_mem`, that `h n` is a genuinely
+attained minimum for every `n` (never the `sInf ∅` junk value). -/
+
+/-- Distinct indices have distinct abscissae `(·) + 1` (the cast `Fin n ↪ ℕ ↪ ℝ` is injective). -/
+private theorem parabola_x_ne {p q : Fin n} (hpq : p ≠ q) :
+    ((p : ℕ) : ℝ) + 1 ≠ ((q : ℕ) : ℝ) + 1 := by
+  intro h
+  apply hpq
+  have : ((p : ℕ) : ℝ) = ((q : ℕ) : ℝ) := by linarith
+  exact Fin.ext (by exact_mod_cast this)
+
+/-- A three-element `{i, j, k}` has pairwise-distinct entries. -/
+private theorem card_triple_pairwise_ne {α : Type*} [DecidableEq α] {i j k : α}
+    (h : ({i, j, k} : Finset α).card = 3) : i ≠ j ∧ i ≠ k ∧ j ≠ k := by
+  have card_le2 : ∀ p q : α, ({p, q} : Finset α).card ≤ 2 :=
+    fun p q => (Finset.card_insert_le _ _).trans (by simp)
+  have hine : i ∉ ({j, k} : Finset α) := by
+    intro hmem
+    rw [Finset.insert_eq_self.mpr hmem] at h
+    have := card_le2 j k; omega
+  have hjk2 : ({j, k} : Finset α).card = 2 := by
+    have := Finset.card_insert_of_notMem hine; omega
+  have hjne : j ≠ k := by
+    intro hjk'; rw [hjk'] at hjk2; simp at hjk2
+  simp only [Finset.mem_insert, Finset.mem_singleton, not_or] at hine
+  exact ⟨hine.1, hine.2, hjne⟩
+
+/-- A four-element `{a, b, c, d}` has pairwise-distinct entries. -/
+private theorem card_quad_pairwise_ne {α : Type*} [DecidableEq α] {a b c d : α}
+    (h : ({a, b, c, d} : Finset α).card = 4) :
+    a ≠ b ∧ a ≠ c ∧ a ≠ d ∧ b ≠ c ∧ b ≠ d ∧ c ≠ d := by
+  have card_le3 : ∀ p q r : α, ({p, q, r} : Finset α).card ≤ 3 := by
+    intro p q r
+    calc ({p, q, r} : Finset α).card
+        ≤ ({q, r} : Finset α).card + 1 := Finset.card_insert_le _ _
+      _ ≤ (({r} : Finset α).card + 1) + 1 := by
+            have := Finset.card_insert_le q ({r} : Finset α); omega
+      _ = 3 := by simp
+  have hane : a ∉ ({b, c, d} : Finset α) := by
+    intro hmem
+    rw [Finset.insert_eq_self.mpr hmem] at h
+    have := card_le3 b c d; omega
+  have hbcd : ({b, c, d} : Finset α).card = 3 := by
+    have := Finset.card_insert_of_notMem hane; omega
+  have hbne : b ∉ ({c, d} : Finset α) := by
+    intro hmem
+    rw [Finset.insert_eq_self.mpr hmem] at hbcd
+    have : ({c, d} : Finset α).card ≤ 2 := (Finset.card_insert_le _ _).trans (by simp)
+    omega
+  have hcd2 : ({c, d} : Finset α).card = 2 := by
+    have := Finset.card_insert_of_notMem hbne; omega
+  have hcne : c ≠ d := by
+    intro hcd'; rw [hcd'] at hcd2; simp at hcd2
+  simp only [Finset.mem_insert, Finset.mem_singleton, not_or] at hane hbne
+  exact ⟨hane.1, hane.2.1, hane.2.2, hbne.1, hbne.2, hcne⟩
+
+/-- **Parabola no-three-collinear, abstractly.** If a line `a·x + b·y + c = 0` passes through
+three distinct-abscissa parabola points `(xₜ, xₜ²)`, then `(a, b, c) = 0`. Cancelling the
+distinct differences turns the three incidences into `a + b(xᵢ+xⱼ) = 0`, forcing `b = 0`,
+then `a = 0`, then `c = 0`. -/
+private theorem parabola_collinear_trivial (xi xj xk a b c : ℝ)
+    (hxij : xi ≠ xj) (hxik : xi ≠ xk) (hxjk : xj ≠ xk)
+    (hi : a * xi + b * xi ^ 2 + c = 0)
+    (hj : a * xj + b * xj ^ 2 + c = 0)
+    (hk : a * xk + b * xk ^ 2 + c = 0) :
+    a = 0 ∧ b = 0 ∧ c = 0 := by
+  have P1 : a + b * (xi + xj) = 0 := by
+    have hp : (xi - xj) * (a + b * (xi + xj)) = 0 := by linear_combination hi - hj
+    rcases mul_eq_zero.mp hp with hz | hz
+    · exact absurd (sub_eq_zero.mp hz) hxij
+    · exact hz
+  have P2 : a + b * (xi + xk) = 0 := by
+    have hp : (xi - xk) * (a + b * (xi + xk)) = 0 := by linear_combination hi - hk
+    rcases mul_eq_zero.mp hp with hz | hz
+    · exact absurd (sub_eq_zero.mp hz) hxik
+    · exact hz
+  have hb : b = 0 := by
+    have hp : (xj - xk) * b = 0 := by linear_combination P1 - P2
+    rcases mul_eq_zero.mp hp with hz | hz
+    · exact absurd (sub_eq_zero.mp hz) hxjk
+    · exact hz
+  have ha : a = 0 := by linear_combination P1 - (xi + xj) * hb
+  have hc : c = 0 := by linear_combination hi - xi * ha - xi ^ 2 * hb
+  exact ⟨ha, hb, hc⟩
+
+/-- **Parabola concyclicity forces zero abscissa-sum.** Four distinct-abscissa parabola points
+equidistant (squared) from a common centre `(c₀, c₁)` satisfy `w + x + y + z = 0`. This is the
+`x³`-coefficient-`0` Vieta relation, obtained here by three rounds of difference-and-cancel:
+`(c₀-t)²+(c₁-t²)²` equal across pairs ⟹ a linear-in-centre relation `M(t,u)=0` ⟹ a
+quadratic-symmetric relation `N(·,·)=0` ⟹ the abscissa sum. -/
+private theorem parabola_concyclic_sum_zero (w x y z c0 c1 R : ℝ)
+    (hwx : w ≠ x) (hxy : x ≠ y) (hyz : y ≠ z)
+    (hwy : w ≠ y) (hwz : w ≠ z) (hxz : x ≠ z)
+    (Hw : (c0 - w) ^ 2 + (c1 - w ^ 2) ^ 2 = R)
+    (Hx : (c0 - x) ^ 2 + (c1 - x ^ 2) ^ 2 = R)
+    (Hy : (c0 - y) ^ 2 + (c1 - y ^ 2) ^ 2 = R)
+    (Hz : (c0 - z) ^ 2 + (c1 - z ^ 2) ^ 2 = R) :
+    w + x + y + z = 0 := by
+  -- `M(t,u) := -2c₀ + (t+u)(1 - 2c₁ + t² + u²)`: from equal squared distances, `M = 0`.
+  have Mwx : -2 * c0 + (w + x) * (1 - 2 * c1 + w ^ 2 + x ^ 2) = 0 := by
+    have hp : (w - x) * (-2 * c0 + (w + x) * (1 - 2 * c1 + w ^ 2 + x ^ 2)) = 0 := by
+      linear_combination Hw - Hx
+    rcases mul_eq_zero.mp hp with hz | hz
+    · exact absurd (sub_eq_zero.mp hz) hwx
+    · exact hz
+  have Mwy : -2 * c0 + (w + y) * (1 - 2 * c1 + w ^ 2 + y ^ 2) = 0 := by
+    have hp : (w - y) * (-2 * c0 + (w + y) * (1 - 2 * c1 + w ^ 2 + y ^ 2)) = 0 := by
+      linear_combination Hw - Hy
+    rcases mul_eq_zero.mp hp with hz | hz
+    · exact absurd (sub_eq_zero.mp hz) hwy
+    · exact hz
+  have Mwz : -2 * c0 + (w + z) * (1 - 2 * c1 + w ^ 2 + z ^ 2) = 0 := by
+    have hp : (w - z) * (-2 * c0 + (w + z) * (1 - 2 * c1 + w ^ 2 + z ^ 2)) = 0 := by
+      linear_combination Hw - Hz
+    rcases mul_eq_zero.mp hp with hz | hz
+    · exact absurd (sub_eq_zero.mp hz) hwz
+    · exact hz
+  -- `N(u,v) := 1 - 2c₁ + w² + wu + wv + u² + uv + v²`: cancelling `(u-v)` from `M`-differences.
+  have Nxy : 1 - 2 * c1 + w ^ 2 + w * x + w * y + x ^ 2 + x * y + y ^ 2 = 0 := by
+    have hp : (x - y) * (1 - 2 * c1 + w ^ 2 + w * x + w * y + x ^ 2 + x * y + y ^ 2) = 0 := by
+      linear_combination Mwx - Mwy
+    rcases mul_eq_zero.mp hp with hz | hz
+    · exact absurd (sub_eq_zero.mp hz) hxy
+    · exact hz
+  have Nxz : 1 - 2 * c1 + w ^ 2 + w * x + w * z + x ^ 2 + x * z + z ^ 2 = 0 := by
+    have hp : (x - z) * (1 - 2 * c1 + w ^ 2 + w * x + w * z + x ^ 2 + x * z + z ^ 2) = 0 := by
+      linear_combination Mwx - Mwz
+    rcases mul_eq_zero.mp hp with hz | hz
+    · exact absurd (sub_eq_zero.mp hz) hxz
+    · exact hz
+  -- Final cancel of `(y-z)` yields the abscissa sum.
+  have hp : (y - z) * (w + x + y + z) = 0 := by linear_combination Nxy - Nxz
+  rcases mul_eq_zero.mp hp with hz | hz
+  · exact absurd (sub_eq_zero.mp hz) hyz
+  · exact hz
+
+/-- **The uniform witness.** `parabolaConfig n i = (i+1, (i+1)²)`: `n` points on the parabola
+`y = x²` with strictly positive, pairwise-distinct abscissae `1, 2, …, n`. -/
+noncomputable def parabolaConfig (n : ℕ) : PointConfig n :=
+  fun i => !₂[((i : ℕ) : ℝ) + 1, (((i : ℕ) : ℝ) + 1) ^ 2]
+
+@[simp] theorem parabolaConfig_zero (i : Fin n) :
+    parabolaConfig n i 0 = ((i : ℕ) : ℝ) + 1 := by simp [parabolaConfig]
+
+@[simp] theorem parabolaConfig_one (i : Fin n) :
+    parabolaConfig n i 1 = (((i : ℕ) : ℝ) + 1) ^ 2 := by simp [parabolaConfig]
+
+/-- The `parabolaConfig` points are distinct (distinct abscissae). -/
+theorem parabolaConfig_injective : Function.Injective (parabolaConfig n) := by
+  intro i j hij
+  have h0 : parabolaConfig n i 0 = parabolaConfig n j 0 := by rw [hij]
+  simp only [parabolaConfig_zero] at h0
+  have : ((i : ℕ) : ℝ) = ((j : ℕ) : ℝ) := by linarith
+  exact Fin.ext (by exact_mod_cast this)
+
+/-- **No three parabola points are collinear** — for any distinct-abscissa parabola configuration
+the only line through three of the points is the degenerate `(a,b,c) = 0`. -/
+theorem noThreeCollinear_parabolaConfig : NoThreeCollinear (parabolaConfig n) := by
+  intro i j k hcard
+  obtain ⟨hij, hik, hjk⟩ := card_triple_pairwise_ne hcard
+  rintro ⟨a, b, c, hne, hi, hj, hk⟩
+  apply hne
+  simp only [parabolaConfig_zero, parabolaConfig_one] at hi hj hk
+  obtain ⟨ha, hb, hc⟩ :=
+    parabola_collinear_trivial _ _ _ a b c
+      (parabola_x_ne hij) (parabola_x_ne hik) (parabola_x_ne hjk) hi hj hk
+  rw [ha, hb, hc]
+
+/-- **No four parabola points are concyclic** — the four positive abscissae would have to sum to
+`0` (`parabola_concyclic_sum_zero`), impossible since each is `≥ 1`. -/
+theorem noFourConcyclic_parabolaConfig : NoFourConcyclic (parabolaConfig n) := by
+  intro a b c d hcard
+  obtain ⟨hab, hac, had, hbc, hbd, hcd⟩ := card_quad_pairwise_ne hcard
+  rintro ⟨center, r, ha, hb, hc, hd⟩
+  -- Turn each `dist = r` into the squared-coordinate identity `(c₀-xₜ)² + (c₁-xₜ²)² = r²`.
+  have sq : ∀ t : Fin n, dist center (parabolaConfig n t) = r →
+      (center 0 - (((t : ℕ) : ℝ) + 1)) ^ 2 + (center 1 - ((((t : ℕ) : ℝ) + 1) ^ 2)) ^ 2 = r ^ 2 := by
+    intro t ht
+    have h2 : dist center (parabolaConfig n t) ^ 2 = r ^ 2 := by rw [ht]
+    simp only [EuclideanSpace.dist_sq_eq, Fin.sum_univ_two, parabolaConfig_zero,
+      parabolaConfig_one, Real.dist_eq, sq_abs] at h2
+    linear_combination h2
+  have hsum := parabola_concyclic_sum_zero
+    (((a : ℕ) : ℝ) + 1) (((b : ℕ) : ℝ) + 1) (((c : ℕ) : ℝ) + 1) (((d : ℕ) : ℝ) + 1)
+    (center 0) (center 1) (r ^ 2)
+    (parabola_x_ne hab) (parabola_x_ne hbc) (parabola_x_ne hcd)
+    (parabola_x_ne hac) (parabola_x_ne had) (parabola_x_ne hbd)
+    (sq a ha) (sq b hb) (sq c hc) (sq d hd)
+  have hpos : (0 : ℝ) <
+      (((a : ℕ) : ℝ) + 1) + (((b : ℕ) : ℝ) + 1) + (((c : ℕ) : ℝ) + 1) + (((d : ℕ) : ℝ) + 1) := by
+    positivity
+  linarith
+
+/-- **General-position configurations exist for every `n`.** The parabola configuration
+`i ↦ (i+1, (i+1)²)` is injective, has no three collinear (strict convexity), and no four
+concyclic (positive abscissae cannot sum to `0`). This resolves the constructive existence
+question for all `n`, superseding the concrete `n ≤ 4` witnesses above. -/
+theorem exists_inGeneralPosition (n : ℕ) : ∃ P : PointConfig n, InGeneralPosition P :=
+  ⟨parabolaConfig n, parabolaConfig_injective, noThreeCollinear_parabolaConfig,
+    noFourConcyclic_parabolaConfig⟩
+
+/-- **`h n` is a genuinely attained minimum for every `n`.** Because a general-position
+configuration exists (`exists_inGeneralPosition`), the defining set of `h n` is nonempty, so
+`Nat.sInf_mem` gives a witness `P` in general position with `numDistinctDistances P = h n` — the
+minimum is realized, never the `sInf ∅ = 0` junk value. -/
+theorem h_attained (n : ℕ) :
+    ∃ P : PointConfig n, InGeneralPosition P ∧ numDistinctDistances P = h n := by
+  have hne : {numDistinctDistances P | (P : PointConfig n) (_ : InGeneralPosition P)}.Nonempty :=
+    ⟨numDistinctDistances (parabolaConfig n), parabolaConfig n,
+      ⟨parabolaConfig_injective, noThreeCollinear_parabolaConfig, noFourConcyclic_parabolaConfig⟩,
+      rfl⟩
+  obtain ⟨P, hgp, hval⟩ := Nat.sInf_mem hne
+  exact ⟨P, hgp, hval⟩
 
 end Erdos98WIP01

--- a/research/problems/erdos-98-wip-01/knowledge.md
+++ b/research/problems/erdos-98-wip-01/knowledge.md
@@ -1,5 +1,53 @@
 # Knowledge Base: erdos-98-wip-01
 
+## Session 2026-07-21 (researcher-1) — general-position existence for ALL n (parabola, positive abscissae)
+
+**Mode**: FRESH build on the n≤4 tower. **Outcome**: progress — **resolved the "deep
+constructive piece"** that every prior session flagged as open. Docker-built
+`Proofs.Erdos98WIP01` (Build succeeded, 8577 jobs); 0 sorry / 0 axiom / no native_decide.
+
+**The key realization that unblocked it.** Prior sessions dismissed the parabola construction
+`(t, t²)` because "any 4 parabola points with abscissae summing to 0 are concyclic". True, but
+the fix is trivial: **make all abscissae positive**. Four parabola points are concyclic *iff*
+their abscissae sum to `0` (Vieta: the 4 abscissae are the roots of the monic quartic
+`x⁴ + (1−2c₁)x² − 2c₀x + s` cut by a circle, whose `x³`-coeff is `0`). Positive abscissae ⟹
+every 4-subset sum `≥ 4 > 0` ⟹ no four concyclic. And on `y = x²` **no three points are ever
+collinear** (strict convexity). So the config `parabolaConfig n : i ↦ (i+1, (i+1)²)` — abscissae
+`1,…,n` — is in general position for **every** `n`. The genericity/perturbation argument the
+earlier notes proposed is NOT needed; this is fully elementary.
+
+**Added declarations** (all in `Erdos98WIP01.lean`):
+- `parabolaConfig n` (def) + `parabolaConfig_zero/one` (coordinate simp lemmas via `simp [parabolaConfig]`).
+- `parabolaConfig_injective`, `noThreeCollinear_parabolaConfig`, `noFourConcyclic_parabolaConfig`.
+- `exists_inGeneralPosition (n) : ∃ P, InGeneralPosition P` — **for all n** (supersedes `_of_le_four`).
+- `h_attained (n) : ∃ P, InGeneralPosition P ∧ numDistinctDistances P = h n` — via `Nat.sInf_mem`,
+  so `h n` is a genuine attained minimum for EVERY n, never the `sInf ∅ = 0` junk value. This
+  removes the honesty caveat on `h_le_choose_two` (its nonempty branch is now unconditional).
+
+**Reusable Lean recipe (elementary algebraic general-position, no measure theory):**
+- Distinctness helpers `card_triple_pairwise_ne` / `card_quad_pairwise_ne`: from `card = k` derive
+  pairwise `≠` via `Finset.insert_eq_self.mpr` (collapse a duplicate) + `Finset.card_insert_of_notMem`
+  (NB: `notMem`, not `not_mem` — renamed in v4.31) + `card_insert_le`, closed by `omega`.
+- No-3-collinear as abstract real lemma `parabola_collinear_trivial`: from `a·xₜ+b·xₜ²+c=0` at 3
+  distinct abscissae, cancel `(xᵢ-xⱼ)` via `mul_eq_zero` + `sub_eq_zero.mp` to get `a+b(xᵢ+xⱼ)=0`,
+  hence `b=0,a=0,c=0`. Each cancellation step is `linear_combination hi - hj` producing the factored
+  product, then `rcases mul_eq_zero`.
+- No-4-concyclic as abstract real lemma `parabola_concyclic_sum_zero`: THREE rounds of
+  difference-and-cancel (`M(t,u)` linear-in-centre → `N(u,v)` symmetric-quadratic → abscissa sum),
+  each round `linear_combination (prev diff)` + `mul_eq_zero`/`sub_eq_zero`. Gives `w+x+y+z=0`;
+  `positivity` on the (all-≥1) sum + `linarith` closes.
+- Bridge metric→squared: `dist center (P t) = r` ⟹ `(c₀-xₜ)²+(c₁-xₜ²)² = r²` via
+  `simp only [EuclideanSpace.dist_sq_eq, Fin.sum_univ_two, <coord lemmas>, Real.dist_eq, sq_abs]`
+  then `linear_combination`.
+
+### Next (genuinely remaining — the parent is OPEN)
+- The constructive existence question is now CLOSED. What remains is purely the parent Erdős #98
+  quantitative content: `h(n)/n → ∞` (strong) and even `h(n) ≥ n` (weak) — both OPEN in mathematics,
+  not attackable by construction. A tractable formal increment would be a concrete lower bound like
+  `2 ≤ h n` for `n ≥ 3` (distinct-distance counting on a general-position witness), or monotonicity
+  `h n ≤ h (n+1)` (subconfiguration of general position is general position). No further "existence"
+  work is needed.
+
 ## Session 2026-07-20 (researcher-1) — n=4 general-position existence (first non-vacuous concyclic case)
 
 **Mode**: build on the n=3 triangle. **Outcome**: progress — 6 axiom-free declarations

--- a/src/data/research/problems/erdos-98-wip-01.json
+++ b/src/data/research/problems/erdos-98-wip-01.json
@@ -31,7 +31,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (2026-07-20, researcher-1, VERIFIED 0-axiom host, #print axioms=[propext,Classical.choice,Quot.sound]): n=3 general-position existence discharged via explicit right triangle (first non-vacuous no-3-collinear case) — exists_inGeneralPosition_three + exists_inGeneralPosition_of_le_three, so h n is an attained minimum for all n≤3 (was n≤2). Parent Erdős #98 (h(n)/n→∞) OPEN; full GP existence for all n (parabola fails no-4-concyclic) remains the deep constructive piece.",
+    "progressSummary": "PROGRESS (2026-07-21, researcher-1, docker-built Proofs.Erdos98WIP01 OK, 0 sorry/0 axiom/no native_decide): RESOLVED general-position existence for EVERY n via parabolaConfig i↦(i+1,(i+1)²) — positive abscissae avoid concyclicity (4 parabola points concyclic iff abscissae sum to 0), strict convexity avoids collinearity. exists_inGeneralPosition (all n) supersedes the n≤4 tower; h_attained makes h n a genuine attained minimum for all n. The constructive piece flagged open by every prior session is now closed. Parent Erdős #98 (h(n)/n→∞) remains OPEN.",
     "builtItems": [
       "InGeneralPosition.injective in Erdos98WIP01.lean",
       "numDistinctDistances_le_offDiag (≤ n·(n−1)) in Erdos98WIP01.lean",
@@ -47,7 +47,13 @@
       "triangleConfig — explicit right triangle (0,0),(1,0),(0,1) via EuclideanSpace.single (Erdos98WIP01.lean)",
       "triangleConfig_injective, noThreeCollinear_triangleConfig (first non-vacuous no-3-collinear case), noFourConcyclic_triangleConfig",
       "exists_inGeneralPosition_three — GP configs exist for n=3",
-      "exists_inGeneralPosition_of_le_three — GP configs exist for all n≤3, so h n is an attained minimum through n=3"
+      "exists_inGeneralPosition_of_le_three — GP configs exist for all n≤3, so h n is an attained minimum through n=3",
+      "parabolaConfig n : i↦(i+1,(i+1)²) + parabolaConfig_zero/one coord lemmas (Erdos98WIP01.lean)",
+      "parabolaConfig_injective, noThreeCollinear_parabolaConfig, noFourConcyclic_parabolaConfig",
+      "exists_inGeneralPosition (n) : ∃P, InGeneralPosition P — for ALL n (supersedes _of_le_four)",
+      "h_attained (n) : ∃P, InGeneralPosition P ∧ numDistinctDistances P = h n (via Nat.sInf_mem)",
+      "Abstract real lemmas parabola_collinear_trivial + parabola_concyclic_sum_zero (difference-and-cancel, linear_combination + mul_eq_zero)",
+      "Distinctness helpers card_triple_pairwise_ne / card_quad_pairwise_ne (Finset.card_insert_of_notMem)"
     ],
     "insights": [
       "Every positive pairwise distance comes from an off-diagonal ordered pair (dist>0 ⟹ points distinct ⟹ indices distinct), giving the clean upper bound numDistinctDistances P ≤ n·(n−1) via Finset.offDiag_card — the trivial ceiling of the h(n) envelope.",
@@ -62,13 +68,13 @@
       "OBSTRUCTION to full GP existence: the natural parabola construction (t,t²) gives no-3-collinear (a line meets a parabola in ≤2 pts) but FAILS no-4-concyclic — a circle meets y=x² in a quartic with zero cubic term, so any 4 parabola points whose x-coordinates SUM TO 0 are concyclic (e.g. x=-3,-1,1,3). Full GP existence needs a genericity/perturbation argument (config space minus finitely many proper algebraic subvarieties), not a single explicit curve.",
       "EuclideanSpace.single_apply deprecated → PiLp.single_apply (v4.31); coordinate extraction via congrArg (·0) then simpa [PiLp.single_apply].",
       "n=3 GP existence discharged with the right triangle (0,0),(1,0),(0,1): a line a·x+b·y+c=0 through all three forces c=0 (from origin), a=0 (from (1,0)), b=0 (from (0,1)). Proof by fin_cases over the 27 index triples: degenerate (repeat) triples killed by absurd hcard (by decide) on card{i,j,k}=3; the 6 permutations reduced by simp[cons_val_*, EuclideanSpace.single_apply]+norm_num then linarith.",
-      "Coordinate technique: build points with EuclideanSpace.single for uniform single_apply coordinate access; ![...] index reduction needs Matrix.cons_val_zero/one/two + head_cons/tail_cons; full simp (not simp only) closes false coordinate equalities in injectivity."
+      "Coordinate technique: build points with EuclideanSpace.single for uniform single_apply coordinate access; ![...] index reduction needs Matrix.cons_val_zero/one/two + head_cons/tail_cons; full simp (not simp only) closes false coordinate equalities in injectivity.",
+      "RESOLVED the general-n GP existence obstruction: four parabola points (t,t²) are concyclic IFF abscissae sum to 0 (Vieta, x³-coeff of the circle-cut quartic is 0). Choosing POSITIVE abscissae 1..n makes every 4-subset sum ≥4>0, so no four concyclic; strict convexity gives no three collinear. Earlier sessions wrongly deemed the parabola construction dead — the fix (positive x) is elementary, no genericity/perturbation argument needed."
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "General-position existence for n=4 (first non-vacuous no-4-concyclic case): needs the four-points-concyclic determinant/circle computation over EuclideanSpace — the analog of the n=3 triangle step for concyclicity.",
-      "Full GP existence for all n via genericity: failure locus is a finite union of proper algebraic subvarieties of (ℝ²)ⁿ, complement nonempty (measure/dimension argument) — deep constructive piece.",
-      "Parent Erdős #98 conjecture h(n)/n→∞ remains OPEN (Erdős could not even prove h(n)≥n)."
+      "Constructive existence is now CLOSED for all n. Remaining tractable increment: concrete lower bound 2 ≤ h n for n≥3, or monotonicity h n ≤ h(n+1) (subconfiguration of general position is general position).",
+      "Parent Erdős #98 quantitative content — h(n)/n→∞ (strong) and h(n)≥n (weak) — remains OPEN in mathematics; not attackable by construction."
     ],
     "markdown": "# Knowledge Base: erdos-98-wip-01\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },


### PR DESCRIPTION
## erdos-98-wip-01 — general-position distinct distances (Erdős #98)

Follow-up to #40110 (n=4 witness, merged). Adds **general-position existence for every `n`** to
`proofs/Proofs/Erdos98WIP01.lean`, closing the constructive-existence question the `n ≤ 4` work
flagged as "the deep constructive piece."

### The result
`exists_inGeneralPosition (n : ℕ) : ∃ P : PointConfig n, InGeneralPosition P` — no three
collinear, no four concyclic, for **all** `n`.

### The construction
`parabolaConfig n : i ↦ (i+1, (i+1)²)` — `n` points on `y = x²` with abscissae `1, 2, …, n`.
- **No three collinear:** strict convexity — three points `(xᵢ, xᵢ²)` force `a + b(xᵢ+xⱼ) = 0`
  for each pair, hence `(a,b,c) = 0` (abstract lemma `parabola_collinear_trivial`).
- **No four concyclic:** four parabola points are concyclic **iff** their abscissae sum to `0`
  (Vieta: the abscissae are the roots of the monic quartic `x⁴ + (1−2c₁)x² − 2c₀x + s` cut by a
  circle, whose `x³`-coefficient vanishes; lemma `parabola_concyclic_sum_zero`). Positive abscissae
  ⟹ every 4-subset sum `≥ 4 > 0`.

The earlier notes dismissed the parabola because unrestricted abscissae *can* sum to 0; the fix —
take them positive — is elementary and needs no genericity/perturbation argument.

### Downstream
`h_attained (n) : ∃ P, InGeneralPosition P ∧ numDistinctDistances P = h n` (via `Nat.sInf_mem`):
`h n` is a genuine attained minimum for **every** `n`, never the `sInf ∅ = 0` junk value. This
removes the honesty caveat on the existing `h_le_choose_two`.

### Verification
- Docker-built `Proofs.Erdos98WIP01` — **Build succeeded** (8577 jobs).
- **0 sorries, 0 `axiom` declarations, no `native_decide`.** Foundational axioms only
  (`propext` / `Classical.choice` / `Quot.sound`).

Parent **Erdős #98** (`h(n)/n → ∞`, and even the weak `h(n) ≥ n`) remains **OPEN** in mathematics —
the imported Pach / EFP / Guth–Katz bounds are stated as assumptions; nothing here resolves the
conjecture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
