### PR TITLE
Enrich central-limit-theorem-oq-02-oq-03: anchor Part VII bounds-mono section (212-256)

### DIFF
--- a/src/data/proofs/central-limit-theorem-oq-02-oq-03/meta.json
+++ b/src/data/proofs/central-limit-theorem-oq-02-oq-03/meta.json
@@ -204,7 +204,9 @@
     },
     {
       "id": "bounds-mono",
-      "title": "Coefficient Bound and m-Monotonicity",
+      "title": "Part VII: Coefficient Bound and m-Monotonicity",
+      "startLine": 212,
+      "endLine": 256,
       "summary": "alphaMixingCoeff_le_one: on a probability space the α-mixing coefficient is ≤ 1 (every term |x−yz| with x,y,z∈[0,1]; proved via Real.iSup_le whose 0≤a side-condition absorbs the empty-index sup) — the upper bound the parent omits. mDependent_mono: m-dependence is monotone in m, nesting the finite-range classes upward."
     }
   ],


### PR DESCRIPTION
## Enrichment: central-limit-theorem-oq-02-oq-03 (m-Dependence & Ibragimov Mixing)

**Vein:** missing section anchors. The final `sections` entry (`bounds-mono`, "Coefficient Bound and m-Monotonicity") had **no `startLine`/`endLine` at all** — so it rendered with `undefined` anchors and lines 209–256 of the 256-line file (Part VII: `alphaMixingCoeff_le_one` and `mDependent_mono`) were effectively uncovered.

### Change (`meta.json` only)
- Added `"startLine": 212, "endLine": 256` to the `bounds-mono` section, anchoring it to the "Part VII" banner (line 212) through EOF. Renamed its title to "Part VII: Coefficient Bound and m-Monotonicity" to match the file's own part numbering. The summary was already accurate and is unchanged.

Sections now cover `1..256` (EOF).

### Verification
- `theoremCount` 7, `axiomCount` 0, `sorries` 0 — confirmed against source. Status `verified` unchanged.
- JSON validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
