### PR TITLE
Enrich puiseux-theorem-oq-01 (Artin–Schreier obstruction): add non-vacuousness witness section (136..194/EOF)

### DIFF
--- a/src/data/proofs/puiseux-theorem-oq-01/meta.json
+++ b/src/data/proofs/puiseux-theorem-oq-01/meta.json
@@ -112,9 +112,17 @@
       "id": "sec-obstruction",
       "title": "The Artin–Schreier Obstruction",
       "startLine": 123,
-      "endLine": 131,
+      "endLine": 135,
       "summary": "artinSchreier_support_not_puiseux: any Hahn series whose support contains all artinSchreierExp p k is not a Puiseux series — an immediate consequence of the unbounded-denominator core applied through the support.",
       "mathContext": "Applied to the Artin–Schreier root y (support = {−1/pᵏ}), this is the formal statement that an algebraic element over the Laurent series fails to be Puiseux — Puiseux's theorem fails in characteristic p."
+    },
+    {
+      "id": "sec-witness",
+      "title": "The Obstruction Is Non-Vacuous: an Explicit Hahn-Series Witness",
+      "startLine": 136,
+      "endLine": 194,
+      "summary": "Shows the obstruction is realised by a genuine element of the Hahn field, not merely a hypothetical one. artinSchreierExp_range_isPWO: the exponent set {−1/p^{k+1}} is partially well-ordered — as the strictly monotone image of ℕ (well-ordered) it inherits IsPWO — hence a legitimate Hahn-series support. artinSchreierSeries: an explicit (noncomputable) Hahn series over any field K with coeff = the indicator of that exponent set (all coefficients 1), well-defined via the IsPWO support. artinSchreierSeries_carries: the witness carries every artinSchreierExp p k in its support (indicator_of_mem + one_ne_zero). artinSchreierSeries_not_puiseux and the capstone exists_hahnSeries_not_puiseux: over every field K and every p ≥ 2 there genuinely exists a Hahn series carrying the Artin–Schreier exponents that is not a Puiseux series, so the hypothesis of artinSchreier_support_not_puiseux is satisfiable. Closes namespace PuiseuxTheoremOQ01.",
+      "mathContext": "A Hahn series is well-defined only on a partially well-ordered support, so exhibiting the witness requires first certifying $\\{-1/p^{k+1}\\}$ is IsPWO. The coefficients are taken to be $1$ rather than the true characteristic-$p$ root values of $y^p - y = x^{-1}$ — only *a* series with this support is needed for non-vacuousness, not one satisfying the Artin–Schreier equation (which would need $\\operatorname{char} K = p$)."
     }
   ],
   "crossReferences": [


### PR DESCRIPTION
## Enrichment: `puiseux-theorem-oq-01` (Artin–Schreier obstruction to Puiseux in char p)

**Tail-undercoverage vein.** The `sections` list stopped at line 131, leaving the file's **entire second half uncovered** (136–194): the non-vacuousness argument — `artinSchreierExp_range_isPWO` (the exponent set is partially well-ordered), the explicit witness `artinSchreierSeries`, `artinSchreierSeries_carries`, `artinSchreierSeries_not_puiseux`, and the capstone `exists_hahnSeries_not_puiseux`. The `assumptions` field and `originalContributions` already described these theorems, but no section anchored them.

### Changes (surgical, meta.json only)
- Extended `sec-obstruction` endLine `131 → 135` so it covers the full body of `artinSchreier_support_not_puiseux` (the theorem runs to line 135).
- Added a new `sec-witness` section covering `136..194`: the `IsPWO` support certificate, the explicit Hahn-series witness (coefficients `1`), and the non-vacuousness capstone. Its `mathContext` explains why an `IsPWO` support is required and why coefficients `1` (rather than the true char-p root values) suffice.

Sections now cover **1..194 (EOF)**. No prose/status/badge changes; the entry remains `verified` / `original`, 0 axioms, 0 sorries (counts unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
