### PR TITLE
Research: erdos-98-wip-01 — elementary linear lower bound n−1 ≤ 3·h n + unconditional h(n)→∞

### DIFF
--- a/proofs/Proofs/Erdos98WIP01.lean
+++ b/proofs/Proofs/Erdos98WIP01.lean
@@ -71,6 +71,22 @@ conjectures are *open* in mathematics; nothing below claims to resolve them.
    rules out collinearity. Consequently `h_attained` upgrades the attained-minimum guarantee
    from `n ≤ 4` to all `n` — `h n` is never the `sInf ∅` junk value.
 
+10. `numDistinctDistances_lower` — **an elementary linear lower bound**
+    `n − 1 ≤ 3·numDistinctDistances P` for every general-position `P`: a circle centred at
+    any fixed point of the configuration holds at most three others (a fourth is four
+    concyclic points), so the `n−1` distances from a fixed point take `≥ (n−1)/3` distinct
+    values. This is the first lower bound that uses the *no-four-concyclic* hypothesis.
+
+11. `three_mul_h_ge` — the same bound for the extremal quantity: `n − 1 ≤ 3·h n` for all `n`,
+    obtained by applying (10) to the attained minimiser `h_attained`. Equivalently
+    `h n ≥ (n−1)/3`.
+
+12. `tendsto_h_atTop` — **`h n → ∞`, unconditionally.** A direct consequence of (11), needing
+    *no* imported deep theorem. This sharpens `guthKatz_imp_tendsto` (which assumed the
+    Guth–Katz baseline) and `weak_imp_tendsto` (which assumed the open weak conjecture): the
+    divergence of `h` is elementary. Only the conjectured *rate* `h n / n → ∞` (Erdős #98)
+    remains open.
+
 ## Summary: 0 sorries, 0 axioms, no `native_decide`. Built over the gallery defs.
 -/
 
@@ -746,5 +762,104 @@ theorem h_attained (n : ℕ) :
       rfl⟩
   obtain ⟨P, hgp, hval⟩ := Nat.sInf_mem hne
   exact ⟨P, hgp, hval⟩
+
+/-! ## An elementary linear lower bound `n - 1 ≤ 3 · h n`, and unconditional `h n → ∞`
+
+The upper bounds (Pach, EFP) and `guthKatz_imp_tendsto` all rest on imported deep
+theorems.  The **no-four-concyclic** hypothesis, by contrast, already forces a
+*linear* lower bound by a one-line pigeonhole, straight from the gallery
+definitions.  Fix a base point `P b`.  Any circle centred at `P b` meets the other
+`n - 1` points in **at most three** of them — a fourth would put four points at a
+common distance from `P b`, i.e. four concyclic points (centre `P b`), forbidden.
+So the `n - 1` distances `dist (P b) (P i)` (`i ≠ b`) take at least `(n-1)/3`
+distinct values, and each is a genuine distinct distance of the configuration.
+Hence `n - 1 ≤ 3 · numDistinctDistances P` for every general-position `P`, so
+`n - 1 ≤ 3 · h n`.
+
+In particular `h n → ∞` **unconditionally** (`tendsto_h_atTop`) — no Guth–Katz
+input, sharpening `guthKatz_imp_tendsto` which needed the imported `Ω(n/log n)`
+baseline.  Only the *divergence* is elementary; the conjectured *rate*
+`h n / n → ∞` (Erdős #98 itself) remains open, and even the linear order here is
+`/3` of the conjectured `n`. -/
+
+/-- Converse of `card_quad_pairwise_ne`: four pairwise-distinct elements form a
+four-element finset. -/
+private theorem card_quad_of_pairwise_ne {α : Type*} [DecidableEq α] {a b c d : α}
+    (hab : a ≠ b) (hac : a ≠ c) (had : a ≠ d) (hbc : b ≠ c) (hbd : b ≠ d) (hcd : c ≠ d) :
+    ({a, b, c, d} : Finset α).card = 4 :=
+  Finset.card_eq_four.mpr ⟨a, b, c, d, hab, hac, had, hbc, hbd, hcd, rfl⟩
+
+/-- **At most three points share a distance to a fixed point.** For general-position
+`P` and base index `b`, the fibre of `i ↦ dist (P b) (P i)` over any value `v`,
+restricted to `i ≠ b`, has at most three elements: a fourth would give four points
+equidistant from `P b` — four concyclic points (centre `P b`, radius `v`) —
+contradicting `NoFourConcyclic`. -/
+theorem card_fiber_dist_le_three {P : PointConfig n} (hgp : InGeneralPosition P)
+    (b : Fin n) (v : ℝ) :
+    ((univ.erase b).filter (fun i => dist (P b) (P i) = v)).card ≤ 3 := by
+  by_contra hlt
+  -- `3 < card` extracts four distinct fibre elements `i, j, k, l`.
+  obtain ⟨i, hi, j, hj, k, hk, l, hl, hij, hik, hil, hjk, hjl, hkl⟩ :=
+    Finset.three_lt_card.mp (not_le.mp hlt)
+  rw [mem_filter] at hi hj hk hl
+  -- Their common distance to `P b` makes them concyclic (centre `P b`, radius `v`).
+  exact hgp.2.2 i j k l (card_quad_of_pairwise_ne hij hik hil hjk hjl hkl)
+    ⟨P b, v, hi.2, hj.2, hk.2, hl.2⟩
+
+/-- **Linear lower bound (per configuration).** Any general-position configuration of
+`n ≥ 1` points has `n - 1 ≤ 3 · numDistinctDistances P`: the `n - 1` distances from a
+fixed point take at least `(n-1)/3` distinct values (each circle holds `≤ 3` points),
+all of which are genuine positive distinct distances. -/
+theorem numDistinctDistances_lower {P : PointConfig n} (hgp : InGeneralPosition P)
+    (hn : 0 < n) :
+    n - 1 ≤ 3 * numDistinctDistances P := by
+  let b : Fin n := ⟨0, hn⟩
+  -- Pigeonhole over distances from `P b`: each fibre `≤ 3`.
+  have hpig := Finset.card_le_mul_card_image (f := fun i => dist (P b) (P i))
+    (univ.erase b) 3 (fun v _ => card_fiber_dist_le_three hgp b v)
+  have hscard : (univ.erase b).card = n - 1 := by
+    rw [Finset.card_erase_of_mem (mem_univ _), Finset.card_univ, Fintype.card_fin]
+  -- The distances from `P b` are genuine positive distinct distances of `P`.
+  have hsub : (univ.erase b).image (fun i => dist (P b) (P i)) ⊆
+      ((univ.product univ).image
+        (fun p : Fin n × Fin n => dist (P p.1) (P p.2))).filter (· > 0) := by
+    intro v hv
+    rw [mem_image] at hv
+    obtain ⟨i, hi, hiv⟩ := hv
+    rw [mem_erase] at hi
+    obtain ⟨hib, _⟩ := hi
+    have hpos : (0 : ℝ) < v := by
+      rw [← hiv]; exact dist_pos.mpr (fun heq => hib (hgp.1 heq.symm))
+    rw [mem_filter]
+    exact ⟨mem_image.mpr ⟨(b, i), by simp, hiv⟩, hpos⟩
+  have hle : ((univ.erase b).image (fun i => dist (P b) (P i))).card ≤
+      numDistinctDistances P := by
+    unfold numDistinctDistances
+    exact card_le_card hsub
+  calc n - 1 = (univ.erase b).card := hscard.symm
+    _ ≤ 3 * ((univ.erase b).image (fun i => dist (P b) (P i))).card := hpig
+    _ ≤ 3 * numDistinctDistances P := by omega
+
+/-- **Unconditional linear lower bound on the minimum.** `n - 1 ≤ 3 · h n` for every `n`:
+apply the per-configuration bound `numDistinctDistances_lower` to the attained minimiser
+`h_attained`. Equivalently `h n ≥ (n-1)/3` — the first lower bound that grows with `n`,
+using only the no-four-concyclic hypothesis. -/
+theorem three_mul_h_ge (n : ℕ) : n - 1 ≤ 3 * h n := by
+  obtain ⟨P, hgp, hval⟩ := h_attained n
+  rcases Nat.eq_zero_or_pos n with hn | hn
+  · subst hn; simp
+  · rw [← hval]; exact numDistinctDistances_lower hgp hn
+
+open scoped Filter Topology in
+/-- **`h n → ∞`, unconditionally.** The elementary bound `n - 1 ≤ 3 · h n`
+(`three_mul_h_ge`) already forces divergence — with **no** imported deep theorem, in
+contrast to `guthKatz_imp_tendsto` (which assumes the Guth–Katz `Ω(n/log n)` baseline)
+and `weak_imp_tendsto` (which assumes the *open* weak conjecture). Only the divergence is
+elementary; the conjectured rate `h n / n → ∞` (Erdős #98) stays open. -/
+theorem tendsto_h_atTop : Filter.Tendsto h Filter.atTop Filter.atTop := by
+  refine Filter.tendsto_atTop.mpr (fun M => ?_)
+  filter_upwards [Filter.eventually_ge_atTop (3 * M + 1)] with n hn
+  have hb := three_mul_h_ge n
+  omega
 
 end Erdos98WIP01

--- a/research/problems/erdos-98-wip-01/knowledge.md
+++ b/research/problems/erdos-98-wip-01/knowledge.md
@@ -1,5 +1,55 @@
 # Knowledge Base: erdos-98-wip-01
 
+## Session 2026-07-21 (researcher-1) — ELEMENTARY LINEAR LOWER BOUND n−1 ≤ 3·h n + unconditional h(n)→∞
+
+**Mode**: FRESH build on the now-closed existence tower. **Outcome**: progress — first
+lower bound on `h n` that **grows with n**, and an **unconditional** proof of `h(n)→∞`.
+Docker-built `Proofs.Erdos98WIP01` (Build succeeded, 8577 jobs); 0 sorry / 0 axiom / no
+native_decide.
+
+**The idea (elementary, uses no-4-concyclic).** Fix a base point `P b`. Any circle centred
+at `P b` meets the other `n−1` points in **at most three** of them — a fourth would be four
+points equidistant from `P b`, i.e. four concyclic points (centre `P b`), which
+`NoFourConcyclic` forbids. So the `n−1` distances `dist (P b) (P i)` (`i ≠ b`) take at least
+`(n−1)/3` distinct values, each a genuine distinct distance. Hence
+`n−1 ≤ 3·numDistinctDistances P` for **every** general-position `P`, so `n−1 ≤ 3·h n`.
+
+**Added declarations** (all in `Erdos98WIP01.lean`, results #10–12 in the header):
+- `card_fiber_dist_le_three (hgp)(b)(v)` — the fibre of `i ↦ dist (P b)(P i)` over `v`,
+  restricted to `i ≠ b`, has `card ≤ 3`. Crux.
+- `numDistinctDistances_lower (hgp)(0<n) : n−1 ≤ 3·numDistinctDistances P` — the per-config
+  pigeonhole bound.
+- `three_mul_h_ge (n) : n−1 ≤ 3·h n` — same bound for the extremal quantity, via `h_attained`.
+- `tendsto_h_atTop : Tendsto h atTop atTop` — **h(n)→∞ UNCONDITIONALLY**, no imported theorem.
+- helper `card_quad_of_pairwise_ne` (converse of `card_quad_pairwise_ne`, via `Finset.card_eq_four`).
+
+**Why this matters.** `tendsto_h_atTop` strictly sharpens the earlier `guthKatz_imp_tendsto`
+(which assumed the imported Guth–Katz `Ω(n/log n)` baseline) and `weak_imp_tendsto` (which
+assumed the *open* weak conjecture): the divergence of `h` is now an **elementary theorem**.
+Only the conjectured *rate* `h(n)/n→∞` (Erdős #98) stays open — and even the linear order here
+is `/3` of the conjectured `n`, so this is honestly a weak-but-real lower bound, not the target.
+
+**Reusable Lean recipe (pigeonhole distinct-distance lower bound):**
+- `Finset.card_le_mul_card_image (f := …) s k hfib : s.card ≤ k · (s.image f).card` — supply
+  `hfib : ∀ v ∈ s.image f, (s.filter (f · = v)).card ≤ k`. Here `s = univ.erase b`, `k = 3`.
+- Extract the `k+1` colliding elements from `¬(card ≤ k)` via `Finset.three_lt_card.mp
+  (not_le.mp hlt)` (gives `∃ a∈s ∃ b∈s ∃ c∈s ∃ d∈s, pairwise ≠`); rebuild the 4-set cardinality
+  with `Finset.card_eq_four.mpr`.
+- `s.card = n−1` via `Finset.card_erase_of_mem (mem_univ _)` + `card_univ`/`Fintype.card_fin`.
+- Positivity/subset: distances from `P b` land in the `numDistinctDistances` filtered image
+  (each `>0` by injectivity `hib` since `i ≠ b`); `card_le_card` on the subset.
+- Descent to `h`: `three_mul_h_ge` applies `numDistinctDistances_lower` to the `h_attained`
+  minimiser; the `n = 0` case is `simp`. `tendsto_h_atTop` = `Filter.tendsto_atTop.mpr` +
+  `filter_upwards [eventually_ge_atTop (3M+1)]` + `omega` on `n−1 ≤ 3·h n`.
+
+### Next (genuinely remaining — the parent is OPEN)
+- Monotonicity `h n ≤ h (n+1)`: a subconfiguration of a general-position config is general
+  position (Injective / NoThreeCollinear / NoFourConcyclic all inherit under restriction
+  `Fin n ↪ Fin (n+1)`); pair with the extremal witness.
+- Sharpen the `/3` constant, or a per-basepoint-pair refinement.
+- Parent Erdős #98 `h(n)/n→∞` (and even weak `h(n)≥n`) remains OPEN; not reachable by the /3
+  bound.
+
 ## Session 2026-07-21 (researcher-1) — general-position existence for ALL n (parabola, positive abscissae)
 
 **Mode**: FRESH build on the n≤4 tower. **Outcome**: progress — **resolved the "deep

--- a/src/data/research/problems/erdos-98-wip-01.json
+++ b/src/data/research/problems/erdos-98-wip-01.json
@@ -31,7 +31,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (2026-07-21, researcher-1, docker-built Proofs.Erdos98WIP01 OK, 0 sorry/0 axiom/no native_decide): RESOLVED general-position existence for EVERY n via parabolaConfig i↦(i+1,(i+1)²) — positive abscissae avoid concyclicity (4 parabola points concyclic iff abscissae sum to 0), strict convexity avoids collinearity. exists_inGeneralPosition (all n) supersedes the n≤4 tower; h_attained makes h n a genuine attained minimum for all n. The constructive piece flagged open by every prior session is now closed. Parent Erdős #98 (h(n)/n→∞) remains OPEN.",
+    "progressSummary": "PROGRESS (2026-07-21, researcher-1, docker-built Proofs.Erdos98WIP01 OK, 0 sorry/0 axiom/no native_decide): proved an ELEMENTARY LINEAR LOWER BOUND n-1 ≤ 3·h n (three_mul_h_ge) from the no-4-concyclic hypothesis — each circle centred at a fixed point holds ≤3 others (card_fiber_dist_le_three), pigeonhole over the n-1 distances from a base point (numDistinctDistances_lower). Corollary tendsto_h_atTop: h(n)→∞ UNCONDITIONALLY and elementarily, sharpening the Guth–Katz-conditional guthKatz_imp_tendsto. First lower bound that grows with n. Parent Erdős #98 (h(n)/n→∞) remains OPEN.",
     "builtItems": [
       "InGeneralPosition.injective in Erdos98WIP01.lean",
       "numDistinctDistances_le_offDiag (≤ n·(n−1)) in Erdos98WIP01.lean",
@@ -53,7 +53,12 @@
       "exists_inGeneralPosition (n) : ∃P, InGeneralPosition P — for ALL n (supersedes _of_le_four)",
       "h_attained (n) : ∃P, InGeneralPosition P ∧ numDistinctDistances P = h n (via Nat.sInf_mem)",
       "Abstract real lemmas parabola_collinear_trivial + parabola_concyclic_sum_zero (difference-and-cancel, linear_combination + mul_eq_zero)",
-      "Distinctness helpers card_triple_pairwise_ne / card_quad_pairwise_ne (Finset.card_insert_of_notMem)"
+      "Distinctness helpers card_triple_pairwise_ne / card_quad_pairwise_ne (Finset.card_insert_of_notMem)",
+      "card_fiber_dist_le_three (hgp)(b)(v): fibre of i↦dist(P b)(P i) over v (i≠b) has card ≤3 — a 4th gives 4 concyclic pts (centre P b); via Finset.three_lt_card + card_quad_of_pairwise_ne + NoFourConcyclic (Erdos98WIP01.lean)",
+      "numDistinctDistances_lower (hgp)(0<n): n-1 ≤ 3·numDistinctDistances P — pigeonhole Finset.card_le_mul_card_image over distances from a base point (Erdos98WIP01.lean)",
+      "three_mul_h_ge (n): n-1 ≤ 3·h n for ALL n (apply numDistinctDistances_lower to h_attained minimiser) — first n-growing lower bound (Erdos98WIP01.lean)",
+      "tendsto_h_atTop: Tendsto h atTop atTop UNCONDITIONALLY (from three_mul_h_ge, no Guth–Katz) — sharpens guthKatz_imp_tendsto and weak_imp_tendsto (Erdos98WIP01.lean)",
+      "card_quad_of_pairwise_ne helper (converse of card_quad_pairwise_ne, via Finset.card_eq_four.mpr)"
     ],
     "insights": [
       "Every positive pairwise distance comes from an off-diagonal ordered pair (dist>0 ⟹ points distinct ⟹ indices distinct), giving the clean upper bound numDistinctDistances P ≤ n·(n−1) via Finset.offDiag_card — the trivial ceiling of the h(n) envelope.",
@@ -69,12 +74,14 @@
       "EuclideanSpace.single_apply deprecated → PiLp.single_apply (v4.31); coordinate extraction via congrArg (·0) then simpa [PiLp.single_apply].",
       "n=3 GP existence discharged with the right triangle (0,0),(1,0),(0,1): a line a·x+b·y+c=0 through all three forces c=0 (from origin), a=0 (from (1,0)), b=0 (from (0,1)). Proof by fin_cases over the 27 index triples: degenerate (repeat) triples killed by absurd hcard (by decide) on card{i,j,k}=3; the 6 permutations reduced by simp[cons_val_*, EuclideanSpace.single_apply]+norm_num then linarith.",
       "Coordinate technique: build points with EuclideanSpace.single for uniform single_apply coordinate access; ![...] index reduction needs Matrix.cons_val_zero/one/two + head_cons/tail_cons; full simp (not simp only) closes false coordinate equalities in injectivity.",
-      "RESOLVED the general-n GP existence obstruction: four parabola points (t,t²) are concyclic IFF abscissae sum to 0 (Vieta, x³-coeff of the circle-cut quartic is 0). Choosing POSITIVE abscissae 1..n makes every 4-subset sum ≥4>0, so no four concyclic; strict convexity gives no three collinear. Earlier sessions wrongly deemed the parabola construction dead — the fix (positive x) is elementary, no genericity/perturbation argument needed."
+      "RESOLVED the general-n GP existence obstruction: four parabola points (t,t²) are concyclic IFF abscissae sum to 0 (Vieta, x³-coeff of the circle-cut quartic is 0). Choosing POSITIVE abscissae 1..n makes every 4-subset sum ≥4>0, so no four concyclic; strict convexity gives no three collinear. Earlier sessions wrongly deemed the parabola construction dead — the fix (positive x) is elementary, no genericity/perturbation argument needed.",
+      "ELEMENTARY LINEAR LOWER BOUND from no-4-concyclic: fix a base point P b; any circle centred at P b holds ≤3 of the other points (a 4th ⟹ 4 concyclic pts with centre P b, forbidden). So the n-1 distances dist(P b)(P i) take ≥(n-1)/3 distinct values ⟹ n-1 ≤ 3·numDistinctDistances P for every GP config ⟹ n-1 ≤ 3·h n. Lean: Finset.card_le_mul_card_image (fibre ≤3) + Finset.three_lt_card to extract the 4 concyclic indices.",
+      "h(n)→∞ is provable UNCONDITIONALLY and ELEMENTARILY (tendsto_h_atTop) — from the /3 linear bound n-1 ≤ 3·h n, needing NO imported deep theorem. This is strictly better than guthKatz_imp_tendsto (assumed the imported Ω(n/log n) baseline) and weak_imp_tendsto (assumed the open weak conjecture). The conjectured RATE h(n)/n→∞ (Erdős #98) is untouched; even the linear order here is /3 of the conjectured n."
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "Constructive existence is now CLOSED for all n. Remaining tractable increment: concrete lower bound 2 ≤ h n for n≥3, or monotonicity h n ≤ h(n+1) (subconfiguration of general position is general position).",
-      "Parent Erdős #98 quantitative content — h(n)/n→∞ (strong) and h(n)≥n (weak) — remains OPEN in mathematics; not attackable by construction."
+      "Lower bound is now linear (n-1 ≤ 3·h n). Tractable next increments: (a) monotonicity h n ≤ h(n+1) via restricting a GP config on Fin(n+1) to Fin n (a subconfiguration of GP is GP — Injective/NoThreeCollinear/NoFourConcyclic all inherit); (b) sharpen the /3 constant, e.g. an argument giving n-1 ≤ 2·(something) or a per-pair-of-basepoints refinement.",
+      "Parent Erdős #98 quantitative content — h(n)/n→∞ (strong) and even h(n)≥n (weak) — remains OPEN in mathematics; the /3 linear bound does not reach the conjectured n."
     ],
     "markdown": "# Knowledge Base: erdos-98-wip-01\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },


### PR DESCRIPTION
## Erdős #98 (erdos-98-wip-01) — elementary linear lower bound on `h n`

Follow-up to the merged existence work (#40130). Builds on the gallery scaffold
`Erdos98Problem.lean`; all results **0 sorry / 0 axiom / no `native_decide`**,
docker-built `Proofs.Erdos98WIP01` (Build succeeded, 8577 jobs).

### The idea (uses the no-four-concyclic hypothesis)

Fix a base point `P b`. Any circle centred at `P b` meets the other `n − 1`
points in **at most three** of them — a fourth would be four points equidistant
from `P b`, i.e. four concyclic points (centre `P b`), which `NoFourConcyclic`
forbids. So the `n − 1` distances `dist (P b) (P i)` (`i ≠ b`) take at least
`(n−1)/3` distinct values, each a genuine distinct distance. Hence
`n − 1 ≤ 3·numDistinctDistances P` for every general-position `P`, so
`n − 1 ≤ 3·h n`.

### New declarations

- `card_fiber_dist_le_three` — the fibre of `i ↦ dist (P b)(P i)` over any value,
  restricted to `i ≠ b`, has `card ≤ 3` (crux; via `Finset.three_lt_card` +
  `NoFourConcyclic`).
- `numDistinctDistances_lower` — `n − 1 ≤ 3·numDistinctDistances P` for every
  general-position `P` (pigeonhole `Finset.card_le_mul_card_image`).
- `three_mul_h_ge` — `n − 1 ≤ 3·h n` for **all** `n` (apply to the `h_attained`
  minimiser). The first lower bound on `h` that grows with `n`.
- `tendsto_h_atTop` — **`h(n) → ∞`, unconditionally and elementarily**, with no
  imported deep theorem. Strictly sharpens `guthKatz_imp_tendsto` (which assumed
  the imported Guth–Katz `Ω(n/log n)` baseline) and `weak_imp_tendsto` (which
  assumed the *open* weak conjecture).

### Honesty

Only the *divergence* is elementary. The conjectured **rate** `h(n)/n → ∞`
(Erdős #98 itself) and even the weak `h(n) ≥ n` remain **open** in mathematics;
the linear order proved here is `/3` of the conjectured `n`, i.e. an honest
weak-but-real lower bound, not the target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
