### PR TITLE
Enrich pythagorean-triples-oq-06-oq-01-oq-01 (60 ∣ xyz package): fix mislabeled 'instances' anchor + add locating-factor-3/sharpness sections (…175/EOF)

### DIFF
--- a/src/data/proofs/pythagorean-triples-oq-06-oq-01-oq-01/meta.json
+++ b/src/data/proofs/pythagorean-triples-oq-06-oq-01-oq-01/meta.json
@@ -73,10 +73,26 @@
       "mathContext": "$3 \\perp 4 \\Rightarrow 12 \\mid xyz$; $\\ 12 \\perp 5 \\Rightarrow 60 \\mid xyz$."
     },
     {
+      "id": "locating-factor-3",
+      "title": "Locating the factor 3 in a primitive triple",
+      "startLine": 100,
+      "endLine": 138,
+      "summary": "For a primitive triple (coprime legs), `three_not_dvd_hyp_of_coprime` shows 3 never divides the hypotenuse z; hence `three_dvd_leg_of_coprime` locates the guaranteed factor of 3 on one of the two legs x or y rather than on z.",
+      "mathContext": "If 3 ∣ z with x,y coprime then x²+y² ≡ 0 (mod 3) forces 3 ∣ x and 3 ∣ y, contradicting coprimality; so 3 divides a leg."
+    },
+    {
+      "id": "sharpness",
+      "title": "Sharpness: 60 is exactly the universal divisor",
+      "startLine": 139,
+      "endLine": 159,
+      "summary": "`sixty_greatest_universal_divisor`: any d dividing xyz for every triple must divide 60 (tested against the primitive witnesses (3,4,5) and (20,21,29)); combined with `sixty_dvd_prod` this gives the characterization `dvd_all_prod_iff_dvd_sixty : (∀ triple, d ∣ xyz) ↔ d ∣ 60`.",
+      "mathContext": "60 = lcm of the forced factors 3, 4, 5 and is the greatest integer dividing xyz for all Pythagorean triples: d ∣ (∀ xyz) ↔ d ∣ 60."
+    },
+    {
       "id": "instances",
       "title": "Concrete instances",
-      "startLine": 100,
-      "endLine": 115,
+      "startLine": 160,
+      "endLine": 175,
       "summary": "Four worked instances exercise the general theorem: (3,4,5) with xyz = 60, (5,12,13) with 780, (8,15,17) with 2040, and (20,21,29) — each discharged by `sixty_dvd_prod (by norm_num)`.",
       "mathContext": "$60 \\mid 3{\\cdot}4{\\cdot}5,\\ 5{\\cdot}12{\\cdot}13,\\ 8{\\cdot}15{\\cdot}17,\\ 20{\\cdot}21{\\cdot}29$."
     }


### PR DESCRIPTION
## Enrichment: pythagorean-triples-oq-06-oq-01-oq-01 (the full 60 ∣ xyz divisibility package)

Mislabeled-section repair + tail undercoverage. Surgical `meta.json`-only edits.

### Findings
The last section `instances` was **anchored at lines 100–115** but its summary describes the *concrete numeric instances* (`example_3_4_5`, …, `example_20_21_29`) which actually live at **lines 160–175**. Lines 100–115 are instead the start of the *"Locating the factor 3"* block. As a result, three theorem groups were mis-covered or uncovered:

- `three_not_dvd_hyp_of_coprime` / `three_dvd_leg_of_coprime` (100–137) — the primitive-triple analysis
- `sixty_greatest_universal_divisor` / `dvd_all_prod_iff_dvd_sixty` (139–158) — the sharpness/characterization block
- the four concrete instances (160–173)

### Changes
- Re-anchored `instances` to its true range **160–175** (summary unchanged, already accurate).
- Added `locating-factor-3` (100–138) and `sharpness` (139–159) sections describing the previously-uncovered primitive-triple and sharpness theorems.
- `sections` now reach **175 (EOF)**; no overlaps introduced.

No changes to `status` / `badge` / `axiomCount` / counts / prose / annotations. The file remains `status: verified`, `badge: original`, 0 axioms. Diff is 18 insertions / 2 deletions.
