### PR TITLE
Research: erdos-98-wip-01 — monotonicity of h (Monotone h) + pinned value h 2 = 1

### DIFF
--- a/proofs/Proofs/Erdos98WIP01.lean
+++ b/proofs/Proofs/Erdos98WIP01.lean
@@ -87,6 +87,16 @@ conjectures are *open* in mathematics; nothing below claims to resolve them.
     divergence of `h` is elementary. Only the conjectured *rate* `h n / n → ∞` (Erdős #98)
     remains open.
 
+13. `inGeneralPosition_comp` / `numDistinctDistances_comp_le` / `h_mono` — **`h` is monotone
+    non-decreasing.** A sub-configuration `P ∘ e` selected by an injective index map inherits
+    general position and has no more distinct distances; applied along `Fin.castSucc` this gives
+    `h n ≤ h (n+1)`, hence `Monotone h`. The first structural comparison *across cardinalities*
+    (all earlier bounds are pointwise in `n`).
+
+14. `h_two` — **`h 2 = 1`, pinned exactly.** Squeezing the linear lower bound
+    (`1 ≤ 3·h 2`) against the sharp envelope (`h 2 ≤ (2 choose 2) = 1`) determines the first
+    nontrivial value with no explicit distance computation.
+
 ## Summary: 0 sorries, 0 axioms, no `native_decide`. Built over the gallery defs.
 -/
 
@@ -860,6 +870,99 @@ theorem tendsto_h_atTop : Filter.Tendsto h Filter.atTop Filter.atTop := by
   refine Filter.tendsto_atTop.mpr (fun M => ?_)
   filter_upwards [Filter.eventually_ge_atTop (3 * M + 1)] with n hn
   have hb := three_mul_h_ge n
+  omega
+
+/-! ## Monotonicity of `h`, and the pinned value `h 2 = 1`
+
+Deleting a point from a general-position `(n+1)`-configuration leaves a
+general-position `n`-configuration with **no more** distinct distances (its
+distances are a sub-multiset of the larger configuration's), so the minimum `h`
+cannot increase as `n` shrinks: `h` is monotone non-decreasing. This is a
+*structural comparison across cardinalities* — none of the pointwise bounds above
+(`three_mul_h_ge`, `h_le_choose_two`) relates `h n` to `h (n+1)`.
+
+The engine is a single reusable fact: any sub-configuration `P ∘ e` selected by an
+**injective** index map `e : Fin m ↪ Fin n` inherits general position from `P`
+(`inGeneralPosition_comp`) and has at most as many distinct distances
+(`numDistinctDistances_comp_le`). Monotonicity is the `e = Fin.castSucc` instance.
+
+Squeezing the linear lower bound against the sharp envelope at `n = 2` pins the
+first nontrivial value exactly: `1 ≤ 3·h 2` and `h 2 ≤ (2 choose 2) = 1` force
+`h 2 = 1` (`h_two`). -/
+
+/-- The image of a triple under an injective map has the same cardinality. -/
+private theorem card_triple_image {α β : Type*} [DecidableEq α] [DecidableEq β]
+    {e : α → β} (he : Function.Injective e) (i j k : α) :
+    ({e i, e j, e k} : Finset β).card = ({i, j, k} : Finset α).card := by
+  have himg : ({e i, e j, e k} : Finset β) = ({i, j, k} : Finset α).image e := by
+    simp only [Finset.image_insert, Finset.image_singleton]
+  rw [himg, Finset.card_image_of_injective _ he]
+
+/-- The image of a quadruple under an injective map has the same cardinality. -/
+private theorem card_quad_image {α β : Type*} [DecidableEq α] [DecidableEq β]
+    {e : α → β} (he : Function.Injective e) (a b c d : α) :
+    ({e a, e b, e c, e d} : Finset β).card = ({a, b, c, d} : Finset α).card := by
+  have himg : ({e a, e b, e c, e d} : Finset β) = ({a, b, c, d} : Finset α).image e := by
+    simp only [Finset.image_insert, Finset.image_singleton]
+  rw [himg, Finset.card_image_of_injective _ he]
+
+/-- **Sub-configurations inherit general position.** If `P : PointConfig n` is in
+general position and `e : Fin m → Fin n` is injective, then the selected
+sub-configuration `P ∘ e` is in general position: injectivity composes, and any
+collinear/concyclic degeneracy among `P ∘ e` transports (via the injective `e`,
+which preserves the `card = 3` / `card = 4` distinctness conditions) to the same
+degeneracy among `P`, contradicting its general position. -/
+theorem inGeneralPosition_comp {m n : ℕ} {e : Fin m → Fin n} (he : Function.Injective e)
+    {P : PointConfig n} (hP : InGeneralPosition P) : InGeneralPosition (P ∘ e) := by
+  obtain ⟨hinj, hcol, hcyc⟩ := hP
+  refine ⟨hinj.comp he, ?_, ?_⟩
+  · intro i j k hcard
+    rintro ⟨a, b, c, hne, hi, hj, hk⟩
+    refine hcol (e i) (e j) (e k) ?_ ⟨a, b, c, hne, hi, hj, hk⟩
+    rw [card_triple_image he]; exact hcard
+  · intro a b c d hcard
+    rintro ⟨center, r, ha, hb, hc, hd⟩
+    refine hcyc (e a) (e b) (e c) (e d) ?_ ⟨center, r, ha, hb, hc, hd⟩
+    rw [card_quad_image he]; exact hcard
+
+/-- **Sub-configurations have no more distinct distances.** Every positive distance
+of `P ∘ e` is a positive distance of `P` (realized by the image pair `(e p.1, e p.2)`),
+so `numDistinctDistances (P ∘ e) ≤ numDistinctDistances P`. -/
+theorem numDistinctDistances_comp_le {m n : ℕ} (e : Fin m → Fin n) (P : PointConfig n) :
+    numDistinctDistances (P ∘ e) ≤ numDistinctDistances P := by
+  unfold numDistinctDistances
+  apply Finset.card_le_card
+  intro d hd
+  rw [Finset.mem_filter] at hd ⊢
+  obtain ⟨hd1, hpos⟩ := hd
+  refine ⟨?_, hpos⟩
+  rw [Finset.mem_image] at hd1 ⊢
+  obtain ⟨p, -, hpd⟩ := hd1
+  exact ⟨(e p.1, e p.2), by simp, hpd⟩
+
+/-- **`h` is monotone non-decreasing.** Deleting the last point from a minimizing
+general-position `(n+1)`-configuration (`h_attained`) gives, via
+`inGeneralPosition_comp` and `numDistinctDistances_comp_le` along `Fin.castSucc`, a
+general-position `n`-configuration with `h n ≤ numDistinctDistances ≤ h (n+1)`. -/
+theorem h_mono : Monotone h := by
+  apply monotone_nat_of_le_succ
+  intro n
+  obtain ⟨P, hgp, hval⟩ := h_attained (n + 1)
+  have hgpQ : InGeneralPosition (P ∘ Fin.castSucc) :=
+    inGeneralPosition_comp (Fin.castSucc_injective n) hgp
+  calc h n ≤ numDistinctDistances (P ∘ Fin.castSucc) := h_le_of_inGeneralPosition hgpQ
+    _ ≤ numDistinctDistances P := numDistinctDistances_comp_le _ _
+    _ = h (n + 1) := hval
+
+/-- **`h 2 = 1`, pinned exactly.** Two general-position points determine exactly one
+positive distance. The linear lower bound gives `1 ≤ 3·h 2` (so `h 2 ≥ 1`) and the
+sharp unordered-pair envelope gives `h 2 ≤ (2 choose 2) = 1`; the two squeeze `h 2`
+to `1`. This is the first exactly-determined value of `h`, obtained with no explicit
+distance computation — purely from the two bounds. -/
+theorem h_two : h 2 = 1 := by
+  have hlo := three_mul_h_ge 2
+  have hhi := h_le_choose_two 2
+  have hchoose : Nat.choose 2 2 = 1 := by decide
   omega
 
 end Erdos98WIP01

--- a/research/problems/erdos-98-wip-01/knowledge.md
+++ b/research/problems/erdos-98-wip-01/knowledge.md
@@ -1,5 +1,42 @@
 # Knowledge Base: erdos-98-wip-01
 
+## Session 2026-07-20 (researcher-1) — MONOTONICITY of h + pinned value h 2 = 1
+
+**Mode**: FRESH (continue) — build on the linear lower bound. **Outcome**: progress
+— 5 axiom-free declarations, **docker-built** `Proofs.Erdos98WIP01` OK (8577 jobs,
+0 sorry / 0 axiom / no native_decide).
+
+Proved the first **structural comparison across cardinalities** and the first
+exactly-pinned value of `h`:
+
+- `card_triple_image` / `card_quad_image` — injective-image cardinality helpers
+  (`card {e i,e j,e k} = card {i,j,k}`) via `Finset.card_image_of_injective`.
+- `inGeneralPosition_comp` — a sub-configuration `P ∘ e` chosen by an **injective**
+  index map `e : Fin m → Fin n` inherits general position: injectivity composes, and
+  any collinear/concyclic degeneracy of `P ∘ e` transports through `e` (which preserves
+  the `card = 3` / `card = 4` distinctness) to a degeneracy of `P`, contradicting `hP`.
+- `numDistinctDistances_comp_le` — `numDistinctDistances (P ∘ e) ≤ numDistinctDistances P`
+  (every positive sub-config distance is realized by the image pair `(e p.1, e p.2)`).
+- `h_mono : Monotone h` — delete the last point (`Fin.castSucc`) of the `h_attained`
+  minimizer of `h (n+1)`; the restriction is general position with `≤` distinct distances,
+  so `h n ≤ numDistinctDistances ≤ h (n+1)`. Via `monotone_nat_of_le_succ`.
+- `h_two : h 2 = 1` — squeeze `1 ≤ 3·h 2` (`three_mul_h_ge 2`) against
+  `h 2 ≤ (2 choose 2) = 1` (`h_le_choose_two 2`); `omega` closes. First exact value,
+  no explicit distance computation.
+
+**Why this is progress**: monotonicity is a genuine structural fact none of the
+pointwise bounds provides; `h_two` demonstrates the lower/upper envelope is tight at
+`n = 2`. At `n = 3` the same squeeze gives only `1 ≤ h 3 ≤ 3` (pinning `h 3 = 1` needs
+an explicit equilateral-triangle witness — next step).
+
+### Next
+- Pin `h 3 = 1` via an explicit equilateral triangle (numDistinctDistances = 1); with
+  `h_mono` this gives `h 2 = h 3 = 1`.
+- Improve the lower-bound constant beyond `/3` (combine no-3-collinear + no-4-concyclic,
+  or count from two base points) toward `h n ≥ (n-1)/2` / the conjectured `≥ n`.
+- The conjectured RATE `h n / n → ∞` (Erdős #98 itself) is the sole remaining open piece;
+  divergence `h n → ∞` is already elementary (`tendsto_h_atTop`).
+
 ## Session 2026-07-21 (researcher-1) — ELEMENTARY LINEAR LOWER BOUND n−1 ≤ 3·h n + unconditional h(n)→∞
 
 **Mode**: FRESH build on the now-closed existence tower. **Outcome**: progress — first

--- a/src/data/research/problems/erdos-98-wip-01.json
+++ b/src/data/research/problems/erdos-98-wip-01.json
@@ -31,7 +31,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (2026-07-21, researcher-1, docker-built Proofs.Erdos98WIP01 OK, 0 sorry/0 axiom/no native_decide): proved an ELEMENTARY LINEAR LOWER BOUND n-1 ≤ 3·h n (three_mul_h_ge) from the no-4-concyclic hypothesis — each circle centred at a fixed point holds ≤3 others (card_fiber_dist_le_three), pigeonhole over the n-1 distances from a base point (numDistinctDistances_lower). Corollary tendsto_h_atTop: h(n)→∞ UNCONDITIONALLY and elementarily, sharpening the Guth–Katz-conditional guthKatz_imp_tendsto. First lower bound that grows with n. Parent Erdős #98 (h(n)/n→∞) remains OPEN.",
+    "progressSummary": "PROGRESS (2026-07-20, researcher-1, docker-built Proofs.Erdos98WIP01 OK, 8577 jobs, 0 sorry/0 axiom/no native_decide): proved MONOTONICITY of h (h_mono: Monotone h) via a reusable sub-configuration lemma (inGeneralPosition_comp + numDistinctDistances_comp_le along an injective index map, instantiated at Fin.castSucc) — the first structural comparison across cardinalities. Also pinned the first exact value h 2 = 1 (h_two) by squeezing the linear lower bound 1 ≤ 3·h 2 against the sharp envelope h 2 ≤ (2 choose 2)=1. Builds on prior three_mul_h_ge / h_le_choose_two / tendsto_h_atTop. Parent Erdős #98 (h(n)/n→∞) remains OPEN; the RATE is the sole open piece.",
     "builtItems": [
       "InGeneralPosition.injective in Erdos98WIP01.lean",
       "numDistinctDistances_le_offDiag (≤ n·(n−1)) in Erdos98WIP01.lean",
@@ -58,7 +58,12 @@
       "numDistinctDistances_lower (hgp)(0<n): n-1 ≤ 3·numDistinctDistances P — pigeonhole Finset.card_le_mul_card_image over distances from a base point (Erdos98WIP01.lean)",
       "three_mul_h_ge (n): n-1 ≤ 3·h n for ALL n (apply numDistinctDistances_lower to h_attained minimiser) — first n-growing lower bound (Erdos98WIP01.lean)",
       "tendsto_h_atTop: Tendsto h atTop atTop UNCONDITIONALLY (from three_mul_h_ge, no Guth–Katz) — sharpens guthKatz_imp_tendsto and weak_imp_tendsto (Erdos98WIP01.lean)",
-      "card_quad_of_pairwise_ne helper (converse of card_quad_pairwise_ne, via Finset.card_eq_four.mpr)"
+      "card_quad_of_pairwise_ne helper (converse of card_quad_pairwise_ne, via Finset.card_eq_four.mpr)",
+      "inGeneralPosition_comp (Erdos98WIP01.lean:915): sub-configuration P∘e along injective e:Fin m→Fin n inherits general position (injectivity composes; collinear/concyclic degeneracy transports via card_triple_image/card_quad_image preserving card=3/4)",
+      "numDistinctDistances_comp_le (Erdos98WIP01.lean:931): numDistinctDistances (P∘e) ≤ numDistinctDistances P — every positive distance of a sub-config is realized by the image pair",
+      "h_mono (Erdos98WIP01.lean:947): Monotone h — h n ≤ h (n+1) via deleting the last point (Fin.castSucc) of the h_attained minimizer; first comparison ACROSS cardinalities",
+      "h_two (Erdos98WIP01.lean:962): h 2 = 1 pinned EXACTLY by squeezing 1 ≤ 3·h 2 (three_mul_h_ge) against h 2 ≤ (2 choose 2)=1 (h_le_choose_two); no explicit distance computation",
+      "card_triple_image / card_quad_image (Erdos98WIP01.lean): injective-image cardinality helpers (card {e i,e j,e k}=card{i,j,k}) via Finset.card_image_of_injective"
     ],
     "insights": [
       "Every positive pairwise distance comes from an off-diagonal ordered pair (dist>0 ⟹ points distinct ⟹ indices distinct), giving the clean upper bound numDistinctDistances P ≤ n·(n−1) via Finset.offDiag_card — the trivial ceiling of the h(n) envelope.",
@@ -76,12 +81,15 @@
       "Coordinate technique: build points with EuclideanSpace.single for uniform single_apply coordinate access; ![...] index reduction needs Matrix.cons_val_zero/one/two + head_cons/tail_cons; full simp (not simp only) closes false coordinate equalities in injectivity.",
       "RESOLVED the general-n GP existence obstruction: four parabola points (t,t²) are concyclic IFF abscissae sum to 0 (Vieta, x³-coeff of the circle-cut quartic is 0). Choosing POSITIVE abscissae 1..n makes every 4-subset sum ≥4>0, so no four concyclic; strict convexity gives no three collinear. Earlier sessions wrongly deemed the parabola construction dead — the fix (positive x) is elementary, no genericity/perturbation argument needed.",
       "ELEMENTARY LINEAR LOWER BOUND from no-4-concyclic: fix a base point P b; any circle centred at P b holds ≤3 of the other points (a 4th ⟹ 4 concyclic pts with centre P b, forbidden). So the n-1 distances dist(P b)(P i) take ≥(n-1)/3 distinct values ⟹ n-1 ≤ 3·numDistinctDistances P for every GP config ⟹ n-1 ≤ 3·h n. Lean: Finset.card_le_mul_card_image (fibre ≤3) + Finset.three_lt_card to extract the 4 concyclic indices.",
-      "h(n)→∞ is provable UNCONDITIONALLY and ELEMENTARILY (tendsto_h_atTop) — from the /3 linear bound n-1 ≤ 3·h n, needing NO imported deep theorem. This is strictly better than guthKatz_imp_tendsto (assumed the imported Ω(n/log n) baseline) and weak_imp_tendsto (assumed the open weak conjecture). The conjectured RATE h(n)/n→∞ (Erdős #98) is untouched; even the linear order here is /3 of the conjectured n."
+      "h(n)→∞ is provable UNCONDITIONALLY and ELEMENTARILY (tendsto_h_atTop) — from the /3 linear bound n-1 ≤ 3·h n, needing NO imported deep theorem. This is strictly better than guthKatz_imp_tendsto (assumed the imported Ω(n/log n) baseline) and weak_imp_tendsto (assumed the open weak conjecture). The conjectured RATE h(n)/n→∞ (Erdős #98) is untouched; even the linear order here is /3 of the conjectured n.",
+      "Monotonicity of h is structural, not analytic: sub-configurations of general-position sets are themselves in general position and drop distinct distances, so h n ≤ h(n+1) with a one-injective-map argument (Fin.castSucc) — independent of any deep upper/lower bound",
+      "The two bounds three_mul_h_ge and h_le_choose_two SQUEEZE at n=2: ⌈(2-1)/3⌉=1 ≤ h 2 ≤ C(2,2)=1 forces h 2 = 1. At n=3 the squeeze gives only 1 ≤ h 3 ≤ 3 (equilateral triangle would pin h 3=1 but needs an explicit distance computation)"
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "Lower bound is now linear (n-1 ≤ 3·h n). Tractable next increments: (a) monotonicity h n ≤ h(n+1) via restricting a GP config on Fin(n+1) to Fin n (a subconfiguration of GP is GP — Injective/NoThreeCollinear/NoFourConcyclic all inherit); (b) sharpen the /3 constant, e.g. an argument giving n-1 ≤ 2·(something) or a per-pair-of-basepoints refinement.",
-      "Parent Erdős #98 quantitative content — h(n)/n→∞ (strong) and even h(n)≥n (weak) — remains OPEN in mathematics; the /3 linear bound does not reach the conjectured n."
+      "Pin h 3 = 1 with an explicit equilateral-triangle witness (numDistinctDistances = 1, general position); combine with h_mono to get h 2 = h 3 = 1",
+      "Strengthen the lower-bound constant: replace the /3 (no-4-concyclic ⇒ ≤3 per circle) — e.g. combine no-3-collinear + no-4-concyclic, or count from two base points, aiming toward h n ≥ (n-1)/2 or the conjectured ≥ n",
+      "Attack the conjectured RATE h n / n → ∞ (Erdős #98 itself) — the sole remaining open piece; the divergence h n → ∞ is now elementary (tendsto_h_atTop)"
     ],
     "markdown": "# Knowledge Base: erdos-98-wip-01\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },


### PR DESCRIPTION
## Summary

Two structural additions to `Erdos98WIP01.lean` for **Erdős Problem #98** (distinct
distances in general position, `h(n)/n → ∞` — OPEN). Docker-built
`Proofs.Erdos98WIP01` OK (8577 jobs, **0 sorry / 0 axiom / no `native_decide`**).

### 1. `h_mono : Monotone h` — comparison across cardinalities

The first structural fact relating `h n` to `h (n+1)` (all prior bounds are pointwise in `n`).
Engine is a reusable sub-configuration lemma:

- `inGeneralPosition_comp` — a sub-configuration `P ∘ e` selected by an **injective**
  index map `e : Fin m → Fin n` inherits general position (injectivity composes;
  collinear/concyclic degeneracy transports through `e`, which preserves the
  `card = 3` / `card = 4` distinctness via `card_triple_image` / `card_quad_image`).
- `numDistinctDistances_comp_le` — `numDistinctDistances (P ∘ e) ≤ numDistinctDistances P`.

Instantiated at `Fin.castSucc`: deleting the last point of the `h_attained` minimizer of
`h (n+1)` leaves a general-position `n`-configuration with `≤` distinct distances, so
`h n ≤ h (n+1)`; `monotone_nat_of_le_succ` finishes.

### 2. `h_two : h 2 = 1` — first exactly-pinned value

Squeezing the elementary linear lower bound `1 ≤ 3·h 2` (`three_mul_h_ge`) against the
sharp unordered-pair envelope `h 2 ≤ (2 choose 2) = 1` (`h_le_choose_two`) determines
`h 2` exactly — no explicit distance computation.

### Scope / honesty

Parent Erdős #98 (`h(n)/n → ∞`) remains **OPEN**. The conjectured *rate* is the sole
remaining open piece — divergence `h n → ∞` is already elementary (`tendsto_h_atTop`, prior
work). At `n = 3` the same squeeze yields only `1 ≤ h 3 ≤ 3` (pinning `h 3 = 1` needs an
explicit equilateral-triangle witness; noted as a next step).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
