### PR TITLE
Enrich erdos-1012-oq-03 (directed Hamiltonian arc threshold): cover capstone theorem + Proof Roadmap tail (1..1848/EOF)

### DIFF
--- a/src/data/proofs/erdos-1012-oq-03/meta.json
+++ b/src/data/proofs/erdos-1012-oq-03/meta.json
@@ -137,8 +137,8 @@
       "id": "part-v-threshold",
       "title": "Part V: Arc Threshold + Verification",
       "startLine": 1539,
-      "endLine": 1781,
-      "summary": "Defines arcCount. Proves directed_hamiltonian_threshold: (n-1)² < arcCount ∧ strongly connected → Hamiltonian cycle via probabilistic counting (hamiltonian_of_few_missing_arcs, perm_arc_bad_card_le, missing_arcs_le). Closes with #check commands verifying all four main theorems.",
+      "endLine": 1848,
+      "summary": "Defines arcCount. Proves directed_hamiltonian_threshold (the directed analogue of the Erdős #1012 edge threshold): (n-1)² < arcCount ∧ strongly connected → Hamiltonian cycle via probabilistic counting (hamiltonian_of_few_missing_arcs, perm_arc_bad_card_le, missing_arcs_le, counting_factorial_lt). A closing Proof Roadmap comment block documents the proof decomposition of all four main theorems and records the single remaining axiom gh_longest_cycle_is_hamiltonian (the Ghouila-Houri no-cross path-surgery case, ~150-200 lines of Menger's theorem left as future work). Ends with #check commands verifying ghouila_houri, moon_moser, redei, and directed_hamiltonian_threshold.",
       "mathContext": "`arcCount G = (Finset.univ.filter (fun p : Fin n × Fin n => G.arc p.1 p.2)).card`. `directed_hamiltonian_threshold`: if $(n-1)^2 < \\text{arcCount}(G)$ and $G$ is strongly connected, then $G$ is Hamiltonian. Proof via **probabilistic counting**: a random permutation $\\sigma$ is 'bad' (not a Hamiltonian cycle) only if some arc $(\\sigma(i), \\sigma(i+1))$ is missing. By union bound over $n$ arc positions and $n!$ total permutations: $\\Pr[\\text{bad}] \\leq n \\cdot (n!/n) \\cdot (\\text{missingArcs}/n(n-1)) < 1$ when missingArcs $< (n-1)^2/n$. Key lemma: `perm_arc_bad_card_le` bounds the number of bad permutations. This gives a polynomial-time Hamiltonicity certificate: check if $|E| > (n-1)^2$ and SC, and we're done."
     }
   ],


### PR DESCRIPTION
Enriches the gallery entry for **erdos-1012-oq-03** (directed Hamiltonian arc threshold — the directed analogue of Erdős #1012's edge threshold; Ghouila-Houri / Moon-Moser / Rédei package).

**Undercoverage found (fresh `origin/main` scan):** `wc -l = 1848`, but `max(section.endLine) = 1781` — a 67-line uncovered tail.

Part V (`part-v-threshold`) was anchored `1539..1781`, yet its own summary already described the `#check` commands (at `1843–1846`) and `directed_hamiltonian_threshold` — both beyond the anchor. The uncovered tail `1782..1848` contains:
- the capstone theorem `directed_hamiltonian_threshold` (`1783`), stated as the directed analogue of the Erdős #1012 edge threshold;
- a **Proof Roadmap** doc block (`1794–1841`) documenting the decomposition of all four main theorems and recording the single remaining axiom `gh_longest_cycle_is_hamiltonian` (the Ghouila-Houri no-cross path-surgery case, ~150–200 lines of Menger's theorem left as future work);
- the closing `#check`s for `ghouila_houri`, `moon_moser`, `redei`, `directed_hamiltonian_threshold`.

**Changes (meta.json only):**
- `part-v-threshold` `1539..1781 → 1539..1848`.
- Summary refreshed to name the capstone theorem, the Proof Roadmap block, and the recorded axiom.

Now covers `1..1848/EOF`. No `status`/`badge`/`axiomCount`/count changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
