### PR TITLE
Research: erdos-98-wip-01 — pinned value h 3 = 1 via explicit equilateral triangle

### DIFF
--- a/proofs/Proofs/Erdos98WIP01.lean
+++ b/proofs/Proofs/Erdos98WIP01.lean
@@ -97,6 +97,13 @@ conjectures are *open* in mathematics; nothing below claims to resolve them.
     (`1 ≤ 3·h 2`) against the sharp envelope (`h 2 ≤ (2 choose 2) = 1`) determines the first
     nontrivial value with no explicit distance computation.
 
+15. `equilateralConfig` / `numDistinctDistances_equilateralConfig` / `h_three` — **`h 3 = 1`,
+    pinned exactly.** The unit equilateral triangle `(0,0), (1,0), (½, √3⁄2)` is in general
+    position and has *exactly one* distinct distance (all three sides length `1`), the first
+    explicit configuration whose `numDistinctDistances` is computed exactly. This gives
+    `h 3 ≤ 1`; with `h_mono` and `h_two` (`1 = h 2 ≤ h 3`) it pins `h 2 = h 3 = 1`. The
+    elementary envelope alone leaves only `1 ≤ h 3 ≤ 3`.
+
 ## Summary: 0 sorries, 0 axioms, no `native_decide`. Built over the gallery defs.
 -/
 
@@ -963,6 +970,119 @@ theorem h_two : h 2 = 1 := by
   have hlo := three_mul_h_ge 2
   have hhi := h_le_choose_two 2
   have hchoose : Nat.choose 2 2 = 1 := by decide
+  omega
+
+/-! ## The pinned value `h 3 = 1` via an explicit equilateral triangle
+
+`h 2 = 1` and `h_mono` give `1 = h 2 ≤ h 3`, so `h 3 ≥ 1`.  For the matching
+upper bound we exhibit a *single* general-position 3-configuration with exactly
+**one** distinct distance — the equilateral triangle `(0,0), (1,0), (½, √3⁄2)`,
+all three pairwise distances equal to `1`.  This is the first time an explicit
+configuration's `numDistinctDistances` is computed *exactly* (earlier witnesses
+only bounded it), and it forces `h 3 ≤ 1`.  Squeezing, `h 2 = h 3 = 1`.
+
+The linear lower bound is far from tight here — `three_mul_h_ge 3` gives only
+`h 3 ≥ 1` and `h_le_choose_two 3` only `h 3 ≤ 3`; the exact value needs the
+equilateral witness, not the elementary envelope. -/
+
+/-- An explicit unit **equilateral triangle** `(0,0), (1,0), (½, √3⁄2)` in `ℝ²`.
+All three pairwise distances equal `1`, so it realizes the minimum possible
+distinct-distance count for three non-collinear points. -/
+noncomputable def equilateralConfig : PointConfig 3 :=
+  ![!₂[0, 0], !₂[1, 0], !₂[1 / 2, Real.sqrt 3 / 2]]
+
+/-- The three equilateral vertices are distinct (their abscissae `0, 1, ½` already
+differ, so the `x`-coordinate alone separates every pair). -/
+theorem equilateralConfig_injective : Function.Injective equilateralConfig := by
+  intro i j hij
+  fin_cases i <;> fin_cases j <;>
+    first
+    | rfl
+    | (exfalso
+       have h0 := congrArg (fun p => p 0) hij
+       norm_num [equilateralConfig] at h0)
+
+/-- **No three equilateral vertices are collinear.** A line `a·x + b·y + c = 0`
+through all three forces `c = 0` (from `(0,0)`), then `a = 0` (from `(1,0)`), then
+`b·(√3⁄2) = 0`; since `√3 > 0` this gives `b = 0`, i.e. `(a,b,c) = 0`. -/
+theorem noThreeCollinear_equilateralConfig : NoThreeCollinear equilateralConfig := by
+  have hs : (0 : ℝ) < Real.sqrt 3 := Real.sqrt_pos.mpr (by norm_num)
+  intro i j k hcard
+  rintro ⟨a, b, c, hne, hi, hj, hk⟩
+  apply hne
+  fin_cases i <;> fin_cases j <;> fin_cases k <;>
+    first
+    | exact absurd hcard (by decide)
+    | (simp only [equilateralConfig] at hi hj hk
+       norm_num at hi hj hk
+       simp only [Prod.mk.injEq]
+       refine ⟨?_, ?_, ?_⟩ <;> nlinarith [hs, hi, hj, hk])
+
+/-- No four equilateral vertices are concyclic (vacuous: only three points). -/
+theorem noFourConcyclic_equilateralConfig : NoFourConcyclic equilateralConfig :=
+  noFourConcyclic_of_le_three _ (by norm_num)
+
+/-- **The equilateral triangle is in general position.** -/
+theorem inGeneralPosition_equilateralConfig : InGeneralPosition equilateralConfig :=
+  ⟨equilateralConfig_injective, noThreeCollinear_equilateralConfig,
+    noFourConcyclic_equilateralConfig⟩
+
+/-- **Every side of the equilateral triangle has length `1`.** For distinct indices
+`i ≠ j`, `dist (equilateralConfig i) (equilateralConfig j) = 1`: each squared side is
+`(Δx)² + (Δy)² = 1` (using `(√3)² = 3`), and the distance is the nonnegative square
+root of `1`. -/
+theorem equilateral_dist_off {i j : Fin 3} (hij : i ≠ j) :
+    dist (equilateralConfig i) (equilateralConfig j) = 1 := by
+  have hs : Real.sqrt 3 ^ 2 = 3 := Real.sq_sqrt (by norm_num)
+  have hsum : (∑ k : Fin 2,
+      dist (equilateralConfig i k) (equilateralConfig j k) ^ 2) = 1 := by
+    fin_cases i <;> fin_cases j <;>
+      first
+      | exact absurd rfl hij
+      | (simp only [equilateralConfig, Fin.sum_univ_two, Real.dist_eq, sq_abs]
+         norm_num [hs]
+         all_goals nlinarith [hs])
+  rw [EuclideanSpace.dist_eq, hsum, Real.sqrt_one]
+
+/-- **The equilateral triangle has exactly one distinct distance.** Every off-diagonal
+pair realizes the common side length `1`, and the diagonal pairs contribute `0` (filtered
+out); so the set of positive distances is `{1}`, of cardinality `1`. -/
+theorem numDistinctDistances_equilateralConfig :
+    numDistinctDistances equilateralConfig = 1 := by
+  -- Any positive distance of the configuration equals `1`.
+  have hoff : ∀ p : Fin 3 × Fin 3,
+      (0 : ℝ) < dist (equilateralConfig p.1) (equilateralConfig p.2) →
+      dist (equilateralConfig p.1) (equilateralConfig p.2) = 1 := by
+    rintro ⟨x, y⟩ hpos
+    by_cases hxy : x = y
+    · subst hxy; simp only [dist_self, lt_self_iff_false] at hpos
+    · exact equilateral_dist_off hxy
+  unfold numDistinctDistances
+  have hset : ((univ.product univ).image
+      (fun p : Fin 3 × Fin 3 => dist (equilateralConfig p.1) (equilateralConfig p.2))).filter
+      (· > 0) = {1} := by
+    apply Finset.ext
+    intro d
+    simp only [Finset.mem_filter, Finset.mem_image, Finset.mem_singleton, gt_iff_lt]
+    constructor
+    · rintro ⟨⟨p, -, hp⟩, hpos⟩
+      rw [← hp]; exact hoff p (by rw [hp]; exact hpos)
+    · rintro rfl
+      refine ⟨⟨(0, 1), ?_, equilateral_dist_off (by decide)⟩, by norm_num⟩
+      simp
+  rw [hset, Finset.card_singleton]
+
+/-- **`h 3 = 1`, pinned exactly.** The upper bound `h 3 ≤ 1` comes from the equilateral
+witness (`numDistinctDistances_equilateralConfig`); the lower bound `1 = h 2 ≤ h 3` from
+monotonicity (`h_mono`) and the pinned `h_two`. Together with `h_two` this shows
+`h 2 = h 3 = 1` — the elementary envelope alone leaves `1 ≤ h 3 ≤ 3`. -/
+theorem h_three : h 3 = 1 := by
+  have hle : h 3 ≤ 1 := by
+    have hwit := h_le_of_inGeneralPosition inGeneralPosition_equilateralConfig
+    rwa [numDistinctDistances_equilateralConfig] at hwit
+  have hge : 1 ≤ h 3 :=
+    calc 1 = h 2 := h_two.symm
+      _ ≤ h 3 := h_mono (by norm_num)
   omega
 
 end Erdos98WIP01

--- a/research/problems/erdos-98-wip-01/knowledge.md
+++ b/research/problems/erdos-98-wip-01/knowledge.md
@@ -1,5 +1,48 @@
 # Knowledge Base: erdos-98-wip-01
 
+## Session 2026-07-21 (researcher-1) — pinned value h 3 = 1 via explicit equilateral triangle
+
+**Mode**: FRESH (continue). **Outcome**: progress — 6 axiom-free declarations,
+**docker-built** `Proofs.Erdos98WIP01` OK (0 sorry / 0 axiom / no `native_decide`;
+`#print axioms h_three` = `[propext, Classical.choice, Quot.sound]` only).
+
+Executed the recorded next step: pin `h 3` exactly.
+
+- `equilateralConfig : PointConfig 3` — the unit equilateral triangle
+  `(0,0), (1,0), (½, √3⁄2)`.
+- `equilateralConfig_injective` — the three abscissae `0, 1, ½` already differ, so the
+  `x`-coordinate alone separates every pair (`norm_num [equilateralConfig]` on the 0-th
+  coordinate).
+- `noThreeCollinear_equilateralConfig` — a line through all three forces `c = 0`, then
+  `a = 0`, then `b·(√3⁄2) = 0`; `√3 > 0` gives `b = 0`. The `√3` coefficient makes this
+  genuinely **nonlinear** (unlike the right-triangle case), needing `nlinarith [hs, …]`
+  with `hs : 0 < √3` (the negated-goal × `hs` product certificate).
+- `noFourConcyclic_equilateralConfig` — vacuous (`noFourConcyclic_of_le_three`).
+- `inGeneralPosition_equilateralConfig` — the triangle is in general position.
+- `equilateral_dist_off {i j} (hij : i ≠ j) : dist (equ i) (equ j) = 1` — every side has
+  length 1: `∑ (Δcoord)² = 1` via `(√3)² = 3`, then `EuclideanSpace.dist_eq` + `Real.sqrt_one`.
+- `numDistinctDistances_equilateralConfig = 1` — **first exact computation** of
+  `numDistinctDistances` for an explicit config: positive distances = `{1}` (diagonal
+  pairs give 0, filtered out).
+- `h_three : h 3 = 1` — equilateral witness ⟹ `h 3 ≤ 1`; `h_mono` + `h_two` ⟹
+  `1 = h 2 ≤ h 3`. Squeeze ⟹ `h 2 = h 3 = 1`.
+
+**Key Lean lesson.** `EuclideanSpace.dist_sq_eq` rewrites `dist x y ^ 2` into a sum over
+`x.ofLp i` coordinate accesses that `Matrix.cons_val_*` do NOT reduce (they stay
+`(![…] ⟨0,⋯⟩).ofLp 0`). Use `EuclideanSpace.dist_eq` instead — its `x i` is direct
+function application, reduced by `simp only [equilateralConfig] ; norm_num`. Leftover
+`1/4 + (√3/2)² = 1` closes with `nlinarith [hs]` (`hs : √3² = 3`); `norm_num` alone does
+NOT expand `(√3/2)²` against `hs`.
+
+**Honesty.** Parent Erdős #98 (`h(n)/n → ∞`) remains **OPEN**; only the conjectured rate
+is the open piece. The elementary envelope gives only `1 ≤ h 3 ≤ 3` — the exact value
+needs the equilateral witness. PR: extends #40147.
+
+### Next Steps
+- Improve the lower-bound constant beyond `/3` toward `(n−1)/2` or `≥ n`.
+- Pin `h 4`: is it `1` (needs an impossible single-distance 4-config?) or `2`?
+- Attack the conjectured rate `h n / n → ∞`.
+
 ## Session 2026-07-20 (researcher-1) — MONOTONICITY of h + pinned value h 2 = 1
 
 **Mode**: FRESH (continue) — build on the linear lower bound. **Outcome**: progress

--- a/src/data/research/problems/erdos-98-wip-01.json
+++ b/src/data/research/problems/erdos-98-wip-01.json
@@ -31,7 +31,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (2026-07-20, researcher-1, docker-built Proofs.Erdos98WIP01 OK, 8577 jobs, 0 sorry/0 axiom/no native_decide): proved MONOTONICITY of h (h_mono: Monotone h) via a reusable sub-configuration lemma (inGeneralPosition_comp + numDistinctDistances_comp_le along an injective index map, instantiated at Fin.castSucc) — the first structural comparison across cardinalities. Also pinned the first exact value h 2 = 1 (h_two) by squeezing the linear lower bound 1 ≤ 3·h 2 against the sharp envelope h 2 ≤ (2 choose 2)=1. Builds on prior three_mul_h_ge / h_le_choose_two / tendsto_h_atTop. Parent Erdős #98 (h(n)/n→∞) remains OPEN; the RATE is the sole open piece.",
+    "progressSummary": "PROGRESS: h 2 = h 3 = 1 both pinned exactly (h_two, h_three via equilateral triangle + monotonicity); h monotone; unconditional h→∞. Parent rate h(n)/n→∞ OPEN.",
     "builtItems": [
       "InGeneralPosition.injective in Erdos98WIP01.lean",
       "numDistinctDistances_le_offDiag (≤ n·(n−1)) in Erdos98WIP01.lean",
@@ -63,7 +63,12 @@
       "numDistinctDistances_comp_le (Erdos98WIP01.lean:931): numDistinctDistances (P∘e) ≤ numDistinctDistances P — every positive distance of a sub-config is realized by the image pair",
       "h_mono (Erdos98WIP01.lean:947): Monotone h — h n ≤ h (n+1) via deleting the last point (Fin.castSucc) of the h_attained minimizer; first comparison ACROSS cardinalities",
       "h_two (Erdos98WIP01.lean:962): h 2 = 1 pinned EXACTLY by squeezing 1 ≤ 3·h 2 (three_mul_h_ge) against h 2 ≤ (2 choose 2)=1 (h_le_choose_two); no explicit distance computation",
-      "card_triple_image / card_quad_image (Erdos98WIP01.lean): injective-image cardinality helpers (card {e i,e j,e k}=card{i,j,k}) via Finset.card_image_of_injective"
+      "card_triple_image / card_quad_image (Erdos98WIP01.lean): injective-image cardinality helpers (card {e i,e j,e k}=card{i,j,k}) via Finset.card_image_of_injective",
+      "equilateralConfig (Erdos98WIP01.lean:984): explicit unit equilateral triangle (0,0),(1,0),(1/2,√3/2) as PointConfig 3",
+      "inGeneralPosition_equilateralConfig (Erdos98WIP01.lean:1019): equilateral triangle is in general position (injective + no-3-collinear via √3>0 + vacuous no-4-concyclic)",
+      "equilateral_dist_off (Erdos98WIP01.lean:1027): every side of the equilateral triangle has length 1 (squared-distance = 1 via (√3)^2=3, then Real.sqrt_one)",
+      "numDistinctDistances_equilateralConfig (Erdos98WIP01.lean:1041): the equilateral triangle has EXACTLY ONE distinct distance — first exact computation of numDistinctDistances for an explicit config",
+      "h_three (Erdos98WIP01.lean:1069): h 3 = 1, pinned exactly — equilateral witness gives h 3 ≤ 1, h_mono+h_two give 1 = h 2 ≤ h 3. So h 2 = h 3 = 1"
     ],
     "insights": [
       "Every positive pairwise distance comes from an off-diagonal ordered pair (dist>0 ⟹ points distinct ⟹ indices distinct), giving the clean upper bound numDistinctDistances P ≤ n·(n−1) via Finset.offDiag_card — the trivial ceiling of the h(n) envelope.",
@@ -83,13 +88,15 @@
       "ELEMENTARY LINEAR LOWER BOUND from no-4-concyclic: fix a base point P b; any circle centred at P b holds ≤3 of the other points (a 4th ⟹ 4 concyclic pts with centre P b, forbidden). So the n-1 distances dist(P b)(P i) take ≥(n-1)/3 distinct values ⟹ n-1 ≤ 3·numDistinctDistances P for every GP config ⟹ n-1 ≤ 3·h n. Lean: Finset.card_le_mul_card_image (fibre ≤3) + Finset.three_lt_card to extract the 4 concyclic indices.",
       "h(n)→∞ is provable UNCONDITIONALLY and ELEMENTARILY (tendsto_h_atTop) — from the /3 linear bound n-1 ≤ 3·h n, needing NO imported deep theorem. This is strictly better than guthKatz_imp_tendsto (assumed the imported Ω(n/log n) baseline) and weak_imp_tendsto (assumed the open weak conjecture). The conjectured RATE h(n)/n→∞ (Erdős #98) is untouched; even the linear order here is /3 of the conjectured n.",
       "Monotonicity of h is structural, not analytic: sub-configurations of general-position sets are themselves in general position and drop distinct distances, so h n ≤ h(n+1) with a one-injective-map argument (Fin.castSucc) — independent of any deep upper/lower bound",
-      "The two bounds three_mul_h_ge and h_le_choose_two SQUEEZE at n=2: ⌈(2-1)/3⌉=1 ≤ h 2 ≤ C(2,2)=1 forces h 2 = 1. At n=3 the squeeze gives only 1 ≤ h 3 ≤ 3 (equilateral triangle would pin h 3=1 but needs an explicit distance computation)"
+      "The two bounds three_mul_h_ge and h_le_choose_two SQUEEZE at n=2: ⌈(2-1)/3⌉=1 ≤ h 2 ≤ C(2,2)=1 forces h 2 = 1. At n=3 the squeeze gives only 1 ≤ h 3 ≤ 3 (equilateral triangle would pin h 3=1 but needs an explicit distance computation)",
+      "Pinning an exact value of h needs an explicit minimal-distance witness (equilateral triangle), not the elementary envelope: three_mul_h_ge/h_le_choose_two leave only 1 ≤ h 3 ≤ 3",
+      "EuclideanSpace.dist_sq_eq introduces an .ofLp coordinate wrapper that Matrix.cons_val lemmas do NOT reduce; use EuclideanSpace.dist_eq (direct application) + norm_num to reduce !₂[..] k coordinate accesses, then nlinarith with (√3)^2=3 for the diagonal side"
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "Pin h 3 = 1 with an explicit equilateral-triangle witness (numDistinctDistances = 1, general position); combine with h_mono to get h 2 = h 3 = 1",
-      "Strengthen the lower-bound constant: replace the /3 (no-4-concyclic ⇒ ≤3 per circle) — e.g. combine no-3-collinear + no-4-concyclic, or count from two base points, aiming toward h n ≥ (n-1)/2 or the conjectured ≥ n",
-      "Attack the conjectured RATE h n / n → ∞ (Erdős #98 itself) — the sole remaining open piece; the divergence h n → ∞ is now elementary (tendsto_h_atTop)"
+      "Improve the lower-bound constant beyond /3 (three_mul_h_ge) toward the conjectured (n-1)/2 or ≥ n — the /3 comes from ≤3 points per circle centred at a base point",
+      "Pin h 4: h 4 ≥ h 3 = 1 (h_mono); is h 4 = 1 (needs a 4-point general-position config with 1 distinct distance — impossible? a single distance forces a regular structure) or h 4 = 2?",
+      "Attack the conjectured rate h n / n → ∞ (Erdős #98 proper) — the sole open piece; divergence h n → ∞ is already elementary (tendsto_h_atTop)"
     ],
     "markdown": "# Knowledge Base: erdos-98-wip-01\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },


### PR DESCRIPTION
## Summary

Executes the recorded next step for `erdos-98-wip-01`: pin `h 3` exactly.

Builds an explicit **unit equilateral triangle** `(0,0), (1,0), (½, √3⁄2)` as a
general-position `PointConfig 3` and computes its `numDistinctDistances` **exactly = 1**
(all three sides have length `1`) — the first exact computation of `numDistinctDistances`
for an explicit configuration (earlier witnesses only bounded it). This forces `h 3 ≤ 1`;
combined with `h_mono` and `h_two` (`1 = h 2 ≤ h 3`) it pins `h 2 = h 3 = 1`.

The elementary envelope alone leaves only `1 ≤ h 3 ≤ 3` (`three_mul_h_ge 3` /
`h_le_choose_two 3`) — the exact value genuinely needs the equilateral witness.

## New declarations (6, axiom-free)

- `equilateralConfig : PointConfig 3` — the unit equilateral triangle.
- `equilateralConfig_injective`, `noThreeCollinear_equilateralConfig`
  (nonlinear: `b·(√3⁄2)=0 ∧ √3>0 ⟹ b=0`), `noFourConcyclic_equilateralConfig` (vacuous),
  `inGeneralPosition_equilateralConfig`.
- `equilateral_dist_off : i ≠ j → dist (equ i) (equ j) = 1`.
- `numDistinctDistances_equilateralConfig = 1`.
- `h_three : h 3 = 1`.

## Verification

`./proofs/scripts/docker-build.sh Proofs.Erdos98WIP01` succeeds:
**0 sorry / 0 axiom / no `native_decide`**. `#print axioms h_three` =
`[propext, Classical.choice, Quot.sound]` (standard foundational only).

## Honesty

Parent **Erdős #98** (`h(n)/n → ∞`) remains **OPEN** — the conjectured *rate* is the sole
open piece; divergence `h n → ∞` is already elementary (`tendsto_h_atTop`). This PR pins
one more exact small value; it does not touch the open rate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
