### PR TITLE
Enrich general-quartic (Ferrari's method, Wiedijk #46): re-anchor 8 drifted sections to Part I-VII banners (cover 1..816/EOF)

### DIFF
--- a/src/data/proofs/general-quartic/meta.json
+++ b/src/data/proofs/general-quartic/meta.json
@@ -79,63 +79,63 @@
       "id": "definitions",
       "title": "Part I: Basic Definitions",
       "startLine": 1,
-      "endLine": 79,
+      "endLine": 88,
       "summary": "Module docstring on Ferrari's method (1540) and its mathematical background, then the core definitions: `quarticPoly` (x⁴+ax³+bx²+cx+d), `depressedQuartic` (y⁴+py²+qy+r), and `resolventCubic` (8m³+20pm²+(16p²−8r)m+(4p³−4pr−q²))."
     },
     {
       "id": "depression",
       "title": "Part II: Depressed Form Reduction",
-      "startLine": 80,
-      "endLine": 92,
+      "startLine": 89,
+      "endLine": 116,
       "summary": "`depressionCoeffs`: the (p,q,r) of the depressed form obtained from the substitution y = x + a/4."
     },
     {
       "id": "proved-results-and-axioms",
       "title": "Proved Results (formerly Remaining Axioms)",
-      "startLine": 93,
-      "endLine": 306,
+      "startLine": 117,
+      "endLine": 364,
       "summary": "The depressed-quartic forward/backward transforms (proved via `linear_combination`), the sound Ferrari-factorization substrate `ferrari_factorization_id` and `ferrari_hβ2_of_resolvent`, the α≠0 (non-degenerate) factorization directions `ferrari_factorization_forward_ne`/`backward_ne`, `resolvent_cubic_has_root` (FTA), `quartic_to_depressed`, and the three formerly-axiomatic results now proved as theorems: `quartic_has_four_roots` (from Mathlib FTA: `IsAlgClosed.splits`, `splits_iff_card_roots`, `Multiset.card_eq_three`), `biquadratic_forward`, `biquadratic_backward` (complex quadratic formula via `Complex.cpow_nat_inv_pow` and `linear_combination`)."
     },
     {
       "id": "ferrari-method",
       "title": "Part III: Ferrari's Method",
-      "startLine": 307,
-      "endLine": 340,
+      "startLine": 365,
+      "endLine": 398,
       "summary": "`ferrari_factorization`: the depressed quartic factors into two quadratics at any non-degenerate resolvent root (iff form, delegating to the `_ne` lemmas), and `resolvent_has_root`."
     },
     {
       "id": "roots",
       "title": "Part IV: The Four Roots",
-      "startLine": 341,
-      "endLine": 443,
+      "startLine": 399,
+      "endLine": 501,
       "summary": "`quartic_four_roots` (FTA), the explicit `ferrariRoots` formula (α=√(2m+p), β=q/(2α), two discriminants), and `ferrari_roots_verify_ne` — the four roots satisfy the depressed quartic when 2m+p≠0, with the documented latent-false-axiom counterexample at α=0 (e.g. (p,q,r,m)=(0,0,1,0))."
     },
     {
       "id": "verification",
       "title": "Part V: Verification",
-      "startLine": 444,
-      "endLine": 460,
+      "startLine": 502,
+      "endLine": 518,
       "summary": "`ferrari_roots_are_roots`: packages `ferrari_roots_verify_ne` as the statement that all four Ferrari roots solve the depressed quartic (non-degenerate resolvent root)."
     },
     {
       "id": "special-cases",
       "title": "Part VI: Special Cases",
-      "startLine": 461,
-      "endLine": 477,
+      "startLine": 519,
+      "endLine": 535,
       "summary": "`biquadratic_simple`: the q=0 biquadratic case y⁴+py²+r=0 characterized as a quadratic in y²."
     },
     {
       "id": "biquadratic-limit-oq02c",
       "title": "Part VI.5: Biquadratic-Limit Removable Singularity (OQ-02.c)",
-      "startLine": 478,
-      "endLine": 709,
+      "startLine": 536,
+      "endLine": 767,
       "summary": "Discharges the α=0 boundary of `ferrariRoots`: `resolvent_cubic_q_zero`, `resolvent_root_neg_p_half_at_q_zero` (the trivial degenerate root m=−p/2), the Newton-polygon-cleaned `resolvent_cubic_eval_s_form` (s=2m+p), the Pan-witness scaffolding (`pan_witness_cleaned_resolvent`, `pan_witness_t_zero_factorisation` s²(s−2), `pan_witness_t_zero_nondegenerate_root` m=3/2), and `ferrari_biquad_limit`: for (p,r)≠(0,0) a non-degenerate resolvent root exists and each Ferrari root squared lands in the biquadratic pair {(−p±√(p²−4r))/2}."
     },
     {
       "id": "history",
       "title": "Part VII: Historical Context and Significance",
-      "startLine": 710,
-      "endLine": 758,
+      "startLine": 768,
+      "endLine": 816,
       "summary": "Ferrari's discovery (1540), why solvability by radicals stops at degree 4, and the connection to Abel-Ruffini and the solvable Galois group S₄ ▷ A₄ ▷ V₄ ▷ {e}."
     }
   ],


### PR DESCRIPTION
## Enrichment: general-quartic (Ferrari's method for the quartic, Wiedijk #46)

**Undercoverage / section drift fix.** The `sections` map had drifted out of sync
with the Lean file: from `ferrari-method` onward every section was anchored ~58
lines too early (the Part II "proved results" region had grown), so the
`verification` section sat at 444-460 — *before* the actual `Part V: Verification`
banner at line 502 — and the `history` section sat at 710-758 *inside* the
`ferrari_biquad_limit` proof, leaving the real `Part VII: Historical Context and
Significance` banner + commentary (768-816) completely uncovered.

**Changes (anchors only — no summary text altered):**
- Re-anchored all 8 drifted sections to their `Part I … VII` banners.
- Split the Part II `depressionCoeffs` definition (89-116) from the
  proved-results theorem block (117-364).
- Sections now cover the file contiguously **1..816 (EOF)** with no gaps/overlaps.

**Integrity:** unchanged — `status: verified`, `badge: verified`, `axiomCount: 0`;
Lean file has 0 axioms, 0 `native_decide`, 0 sorries (confirmed).

Summaries were already accurate to their Part titles; only the line anchors moved.
