### PR TITLE
audit: antitone-integral-sum-comparison-oq001 clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -30242,6 +30242,12 @@
       "lastAudited": "2026-07-21T06:26:11Z",
       "result": "clean",
       "issues": []
+    },
+    "antitone-integral-sum-comparison-oq001": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T06:34:21Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Gallery Integrity Audit — clean

**Proof**: antitone-integral-sum-comparison-oq001 (Two-Sided Sandwich for the p-Series Tail)

Verified against the Lean source `Proofs/AntitoneIntegralSumComparisonOQ01OQ01OQ02OQ01.lean`:

- **Counts match**: 4 theorems + 2 worked witnesses, 194 lines, 0 definitions
- **0 sorries** (none in source), **0 axioms** (no `axiom` decls), no `native_decide`
- **Build verified**: `lake env lean` compiles EXIT 0; `#print axioms pseries_tail_sandwich` / `pseries_tail_tsum_ge` depend only on `propext, Classical.choice, Quot.sound` — matching the meta `assumptions` field
- **Statements faithful**: `pseries_tail_sandwich` genuinely proves both flanks `(N+1)^{1−p}/(p−1) ≤ tail ≤ N^{1−p}/(p−1)`; witnesses correctly specialize to `1/(N+1) ≤ ∑_{n>N} 1/n² ≤ 1/N` and `1/11 ≤ ∑_{n>10} 1/n²`
- **Disclosure honest**: description/overview fully credit `AntitoneOn.integral_le_sum` (Mathlib) and the parent's `pseries_tail_tsum_le` for the upper bound; `original` badge appropriate for the new lower-bound assembly

No integrity issues found.

---
Discovered during gallery integrity audit.