### PR TITLE
Enrich pythagorean-triples-oq-01: extend final section to EOF (2220..2566), cover parity-axiom-from-columns + Part XXIII summary

### DIFF
--- a/src/data/proofs/pythagorean-triples-oq-01/meta.json
+++ b/src/data/proofs/pythagorean-triples-oq-01/meta.json
@@ -299,9 +299,9 @@
     {
       "id": "algebraic-identities-composition",
       "title": "Part XXIII: Algebraic Identities, Composition and Straddling Pairs",
-      "summary": "Brahmagupta–Fibonacci identities (brahmagupta_fibonacci, triple_composition, compose examples, hypotenuse_65_two_triples) and the straddling-pair analysis (circleNorm, straddlingOE, circle_norm_gap, discrepancy_from_straddling, parity_from_straddling_vanishes) closing the boundary discrepancy argument.",
+      "summary": "Brahmagupta–Fibonacci identities (brahmagupta_fibonacci, triple_composition, compose examples, hypotenuse_65_two_triples) and the straddling-pair analysis (circleNorm, straddlingOE, circle_norm_gap, discrepancy_from_straddling, parity_from_straddling_vanishes) closing the boundary discrepancy argument. Finishes by deriving the column-boundary form of the parity axiom (`parity_axiom_from_columns` fed the vanishing OE−OO discrepancy), then a summary block documenting the file's final axiom decomposition: the parity axiom reduces to (a) column density → 2/3 and (b) straddling density → 0, leaving exactly the 3 irreducible core axioms (sector lattice density → π/8, coprime fraction → 6/π², both-odd fraction → 1/3).",
       "startLine": 2220,
-      "endLine": 2485,
+      "endLine": 2566,
       "mathContext": "Brahmagupta–Fibonacci identities (brahmagupta_fibonacci, triple_composition, compose examples, hypotenuse_65_two_triples) and the straddling-pair analysis (circleNorm, straddlingOE, circle_norm_gap, discrepancy_from_straddling, parity_from_straddling_vanishes) closing the boundary discrepancy argument."
     }
   ],


### PR DESCRIPTION
## Enrichment: pythagorean-triples-oq-01 (density of primitive Pythagorean triples)

**Tail undercoverage fix.** The final section `Part XXIII: Algebraic Identities,
Composition and Straddling Pairs` ended at line 2485 while the Lean file
(`Proofs/PythagoreanTriplesOQ01.lean`) runs to 2566. The uncovered tail (2486–2566)
contains two substantive pieces: the completion of the column-boundary derivation
of the parity axiom (`parity_axiom_from_columns` applied to the vanishing OE−OO
discrepancy) and the **Part XXIII Summary** block, which documents the file's final
axiom decomposition.

Change (single section, no re-serialization):
- Extended the last section's `endLine` 2485 → 2566 so `sections` covers 1..2566/EOF.
- Enriched its `summary` to record that the tail derives the column-form parity
  axiom and reduces the parity axiom to (a) column density → 2/3 and
  (b) straddling density → 0, leaving exactly the 3 irreducible core axioms
  (sector lattice density → π/8, coprime fraction → 6/π², both-odd fraction → 1/3).

All other 23 section anchors were verified against the actual `## Part` banners and
are correctly aligned. Axiom/status claims unchanged (3 axioms, axiomatized, 0 sorries).
meta.json is 40 KB, under the size cap.
