### PR TITLE
audit: antitone-integral-sum-comparison-oq002 clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -30254,6 +30254,12 @@
       "lastAudited": "2026-07-21T06:42:20Z",
       "result": "clean",
       "issues": []
+    },
+    "antitone-integral-sum-comparison-oq002": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T06:50:07Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
Gallery integrity audit — **clean**.

- Counts match: 5 theorems, 0 axioms, 0 sorries, no True-stubs, no native_decide.
- Badge `mathlib` correct (Tier B): parent `tendsto_defect` and Mathlib `Real.tendsto_harmonic_sub_log_add_one` properly credited.
- Main result `generalizedEuler (1/·) = γ` via termwise identity + uniqueness of limits; honestly scoped, no overclaim.
- `#print axioms` disclosed as propext/Classical only.

Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)