### PR TITLE
audit: 11 gallery entries clean (arsinh/ballot/basel/automorphic/bernoulli)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -30256,14 +30256,68 @@
       "issues": []
     },
     "antitone-integral-sum-comparison-oq002": {
-      "auditCount": 2,
-      "lastAudited": "2026-07-21T06:55:43Z",
+      "auditCount": 3,
+      "lastAudited": "2026-07-21T07:02:59Z",
       "result": "clean",
       "issues": []
     },
     "arsinh-log-formula-oq001": {
+      "auditCount": 2,
+      "lastAudited": "2026-07-21T07:02:59Z",
+      "result": "clean",
+      "issues": []
+    },
+    "arsinh-log-formula-oq002": {
       "auditCount": 1,
-      "lastAudited": "2026-07-21T06:55:11Z",
+      "lastAudited": "2026-07-21T07:02:59Z",
+      "result": "clean",
+      "issues": []
+    },
+    "automorphic-number-oq001": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T07:02:59Z",
+      "result": "clean",
+      "issues": []
+    },
+    "ballot-problem-oq001": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T07:02:59Z",
+      "result": "clean",
+      "issues": []
+    },
+    "ballot-problem-oq002": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T07:02:59Z",
+      "result": "clean",
+      "issues": []
+    },
+    "ballot-problem-oq003": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T07:02:59Z",
+      "result": "clean",
+      "issues": []
+    },
+    "ballot-problem-oq004": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T07:02:59Z",
+      "result": "clean",
+      "issues": []
+    },
+    "basel-problem-oq001": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T07:02:59Z",
+      "result": "clean",
+      "issues": []
+    },
+    "basel-problem-oq002": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T07:02:59Z",
+      "result": "clean",
+      "issues": []
+    },
+    "bernoulli-inequality-oq001": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T07:02:59Z",
       "result": "clean",
       "issues": []
     }


### PR DESCRIPTION
Gallery integrity audit — **all clean**. Tracker append only.

| entry | thm/def | ax | sorry | badge | verdict |
|---|---|---|---|---|---|
| antitone-integral-sum-comparison-oq002 | 5/0 | 0 | 0 | mathlib | clean |
| arsinh-log-formula-oq001 | 8/0 | 0 | 0 | original | clean |
| arsinh-log-formula-oq002 | 11/0 | 0 | 0 | original | clean |
| automorphic-number-oq001 | 1/3 | 0 | 0 | original | clean |
| ballot-problem-oq001 | 24/1 | 0 | 0 | original | clean |
| ballot-problem-oq002 | 5/0 | 0 | 0 | original | clean |
| ballot-problem-oq003 | 8/0 | 0 | 0 | original | clean |
| ballot-problem-oq004 | 65/13 | 0 | 2 | wip | clean (2 disclosed sorries) |
| basel-problem-oq001 | 11/1 | 0 | 0 | original | clean |
| basel-problem-oq002 | 7/0 | 0 | 0 | original | clean |
| bernoulli-inequality-oq001 | 9/1 | 0 | 0 | original | clean |

Checks per entry: theoremCount ≥ actual (comment-stripped counts verified for ballot-oq004: exactly 65 thm/13 def/2 sorry), all originalContributions decls exist, no True-stubs, no undisclosed native_decide (automorphic uses plain kernel `decide`), badge/status consistent with tier. Supersedes #40184.

🤖 Generated with [Claude Code](https://claude.com/claude-code)