### PR TITLE
Enrich inclusion-exclusion-oq-01-oq-01-oq-02: re-anchor drifted Part IV/V–VI sections to cover 1..369/EOF

### DIFF
--- a/src/data/proofs/inclusion-exclusion-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/inclusion-exclusion-oq-01-oq-01-oq-02/meta.json
@@ -116,15 +116,15 @@
       "id": "sec-2bonf-inequality",
       "title": "Part IV: Inequality and Sharp Tightness",
       "startLine": 204,
-      "endLine": 284,
-      "summary": "Reads off second_bonferroni (S₁ - S₂ ≤ |U|), the sharp tightness criterion second_bonferroni_eq_iff (∀ x, deg x ≤ 2), and the equivalent geometric (all triple intersections empty) and algebraic (S₃ = 0) forms."
+      "endLine": 323,
+      "summary": "Reads off second_bonferroni (S₁ - S₂ ≤ |U|), the sharp tightness criterion second_bonferroni_eq_iff (∀ x, deg x ≤ 2), and its equivalent geometric form deg_le_two_iff_no_triple (all triple intersections A i ∩ A j ∩ A k empty) and algebraic form deg_le_two_iff_sieveLayer_three (S₃ = 0, the third sieve layer vanishes)."
     },
     {
       "id": "sec-2bonf-disjoint",
       "title": "Parts V–VI: Disjointness Sufficient, Not Necessary",
-      "startLine": 285,
-      "endLine": 328,
-      "summary": "Proves disjoint_imp_tight (pairwise-disjoint families are tight) and exhibits exFam over Fin 3 — sets {0,1} and {1,2} overlapping in 1 — which is tight despite the non-empty pairwise intersection, all verified by decide."
+      "startLine": 324,
+      "endLine": 369,
+      "summary": "Proves disjoint_imp_tight (pairwise-disjoint families are tight, since S₂ = 0 forces |U| = S₁) and exhibits the overlapping witness exFam over Fin 3 — sets {0,1} and {1,2} sharing the point 1 — which is tight despite the non-empty pairwise intersection (every point has degree ≤ 2), all verified by decide. Closes with #check declarations for the module's public API."
     }
   ],
   "sorries": 0


### PR DESCRIPTION
Enrichment pass for **inclusion-exclusion-oq-01-oq-01-oq-02** (the second Bonferroni inequality and its sharp tightness criterion).

**Problem:** the last two sections drifted, leaving lines 324..369 uncovered and mislabeling Part IV content:

- `sec-2bonf-inequality [204-284]` — its summary already describes the geometric form `deg_le_two_iff_no_triple` and algebraic form `deg_le_two_iff_sieveLayer_three`, but those theorems live at lines 277..323, past the section's `endLine: 284`.
- `sec-2bonf-disjoint [285-328]` — titled "Parts V–VI" but `startLine: 285` sits inside Part IV's degree-criterion theorems, and `endLine: 328` stopped before `disjoint_imp_tight` (Part V) and the entire Part VI overlapping witness (`exFam`) — ~41 lines of the file uncovered.

**Fix (banner-aligned, covers 1..369/EOF):**
- Extend `sec-2bonf-inequality` to `[204-323]` so it actually contains the two criterion theorems its summary already names.
- Re-anchor `sec-2bonf-disjoint` to `[324-369]` (Part V banner at 325 through EOF), so "Parts V–VI" now genuinely covers `disjoint_imp_tight`, the `exFam` witness, and the closing `#check` API block.

Summaries tightened to name the specific lemmas. No status/badge/axiom changes; content preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
