### PR TITLE
Enrich erdos-678: re-anchor drifted §7/§8/§9 sections (~40-line drift) to cover 1..276/EOF

### DIFF
--- a/src/data/proofs/erdos-678/meta.json
+++ b/src/data/proofs/erdos-678/meta.json
@@ -147,23 +147,23 @@
       "id": "bounds",
       "title": "§7: Correct Bounds on Interval LCM",
       "startLine": 177,
-      "endLine": 214,
+      "endLine": 224,
       "summary": "Proves upper bounds on the interval lcm: a helper `Nat.lcm a b ≤ a*b`, `intervalLcm_le_prod` (M(n,k) is at most the product of the k consecutive elements), and the polynomial bound `intervalLcm_poly_upper` : intervalLcm n k ≤ (n+k)^k.",
       "mathContext": "$M(n,k) \\le \\prod_{i=1}^{k}(n+i) \\le (n+k)^k$."
     },
     {
       "id": "observations",
       "title": "§8: Erdős's Observations on Growth Rate",
-      "startLine": 215,
-      "endLine": 225,
-      "summary": "Defines `minimalN k`, the least n at which a comparison holds for k-element intervals, and states `erdos_growth_rate` (n_k / k → ∞, i.e. minimalN k > C·k eventually for every C). Stated as a `sorry`-backed theorem capturing Erdős's superlinear-growth observation.",
+      "startLine": 225,
+      "endLine": 264,
+      "summary": "Defines `minimalN k`, the least n at which a comparison holds for k-element intervals (guarded by `Nat.find` on the existence hypothesis, `0` otherwise), with its totality/characterization lemmas `minimalN_spec` (realized by an actual comparison), `minimalN_le` (lower bound), and `minimalN_eq_zero_of_not_exists`. Then states `erdos_growth_rate` (n_k / k → ∞, i.e. minimalN k > C·k eventually for every C), a `sorry`-backed theorem capturing Erdős's superlinear-growth observation.",
       "mathContext": "$n_k = \\text{minimalN}(k)$; Erdős showed $n_k/k \\to \\infty$, formalized as $\\forall C,\\ \\exists K,\\ \\forall k \\ge K,\\ n_k > Ck$ (stated with `sorry`)."
     },
     {
       "id": "summary",
       "title": "§9: Main Result Summary",
-      "startLine": 226,
-      "endLine": 236,
+      "startLine": 265,
+      "endLine": 276,
       "summary": "Closes with `erdos_678` : ∃ n m k, erdosLcmComparison n m k, proved unconditionally from `selfridge_example_1` — the existence statement of the problem, settled by an explicit Selfridge witness while the full infinitude (cambie_2024) remains `sorry`.",
       "mathContext": "$\\exists n,m,k,\\ M(n,k) > M(m,k+1)$, discharged by the explicit witness $(96,104,7)$."
     }


### PR DESCRIPTION
Enrichment pass for **erdos-678** (Erdős's interval-LCM comparison problem, solved by Cambie 2024). WIP entry — `status: formalized`, `badge: wip`, 3 disclosed sorries; no integrity change.

**Problem:** the last three sections were drifted ~40 lines against the Lean file, so their line ranges pointed at the wrong declarations (the summaries were already accurate — only the anchors were stale) and lines 237..276 were uncovered:

- `§7 bounds [177-214]` cut off `intervalLcm_poly_upper` (lines 213-224).
- `§8 observations [215-225]` claimed to define `minimalN` and state `erdos_growth_rate`, but those live at lines 236 and 262 — the section ended at 225, essentially just the banner line.
- `§9 summary [226-236]` claimed to close with `erdos_678`, but that theorem is at line 270.

**Fix (banner-aligned, covers 1..276/EOF):**
- `§7 bounds` → `[177-224]` (through `intervalLcm_poly_upper`, up to the Erdős's Observations banner at 225)
- `§8 observations` → `[225-264]` (the `minimalN` machinery + `erdos_growth_rate`)
- `§9 summary` → `[265-276]` (Main Result Summary banner through EOF)

Also completed the §8 summary to name the `minimalN` totality lemmas (`minimalN_spec`, `minimalN_le`, `minimalN_eq_zero_of_not_exists`) it now covers. No status/badge/axiom/sorry changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
