### PR TITLE
audit: beta-integral + bezout-identity cluster clean (10 entries)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -30326,6 +30326,66 @@
       "lastAudited": "2026-07-21T07:05:37Z",
       "result": "clean",
       "issues": []
+    },
+    "beta-integral-recurrence-oq001": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T07:08:47Z",
+      "result": "clean",
+      "issues": []
+    },
+    "beta-integral-recurrence-oq002": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T07:08:47Z",
+      "result": "clean",
+      "issues": []
+    },
+    "bezout-identity-oq001": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T07:08:47Z",
+      "result": "clean",
+      "issues": []
+    },
+    "bezout-identity-oq002": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T07:08:47Z",
+      "result": "clean",
+      "issues": []
+    },
+    "bezout-identity-oq003": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T07:08:47Z",
+      "result": "clean",
+      "issues": []
+    },
+    "bezout-identity-oq004": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T07:08:47Z",
+      "result": "clean",
+      "issues": []
+    },
+    "bezout-identity-oq005": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T07:08:47Z",
+      "result": "clean",
+      "issues": []
+    },
+    "bezout-identity-oq006": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T07:08:47Z",
+      "result": "clean",
+      "issues": []
+    },
+    "bezout-identity-oq007": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T07:08:47Z",
+      "result": "clean",
+      "issues": []
+    },
+    "bezout-identity-oq008": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T07:08:47Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
Gallery integrity audit — **all clean**. Tracker append only.

| entry | thm/def | ax | sorry | badge | notes |
|---|---|---|---|---|---|
| beta-integral-recurrence-oq001 | 4/1 | 0 | 0 | original | Beta diag asymptotic |
| beta-integral-recurrence-oq002 | 4/0 | 0 | 0 | original | Beta moments |
| bezout-identity-oq001 | 6/3 | 0 | 0 | verified | HGCD matrix invariant |
| bezout-identity-oq002 | 9/0 | 0 | 0 | original | binary-GCD constant=1 tight |
| bezout-identity-oq003 | 5/2 | 0 | 0 | original | extended binary GCD |
| bezout-identity-oq004 | 12/0 | 0 | 0 | mathlib | ℤ[X,Y] UFD (honest Tier B) |
| bezout-identity-oq005 | 10/4 | 0 | 0 | original | ℤ[X,Y] not PIR |
| bezout-identity-oq006 | 8/2 | 0 | 0 | original | Nullstellensatz fails over ℤ |
| bezout-identity-oq007 | 6/0 | 0 | 0 | original | 𝔽_p/ℚ explicit factorization |
| bezout-identity-oq008 | 14/0 | 0(ofReduceBool) | 0 | axiom | Gaussian primes; 3 native_decide disclosed |

Per-entry: comment-stripped decl counts match meta, all originalContributions decls exist, no True-stubs, native_decide only where disclosed (oq008: 3 prime certs lines 159/163/167). oq004 badge `mathlib` correctly credits Mathlib UFD typeclasses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)