### PR TITLE
audit: bezout-identity-oq009 (Fermat two-square via Gaussian integers) clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -30386,6 +30386,12 @@
       "lastAudited": "2026-07-21T07:08:47Z",
       "result": "clean",
       "issues": []
+    },
+    "bezout-identity-oq009": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T07:11:39Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Gallery Integrity Audit

**Proof**: bezout-identity-oq009 — Fermat's Two-Square Theorem via Gaussian Integers
**Result**: CLEAN

### Verification
- theoremCount 7 ✓ (2 lemmas + 5 theorems), definitionCount 0 ✓, lineCount 176 ✓
- sorries 0 ✓, axiomCount 0 ✓ (no `axiom` decls)
- Uses kernel `decide`/`fin_cases` for the ZMod 4 exhaustive checks — **no** `native_decide`, so no hidden `ofReduceBool` dependency ✓
- Tier B: backward/existence direction relies on Mathlib's `Nat.Prime.sq_add_sq`. This is **fully and honestly disclosed** in `description`, `assumptions`, `overview.proofStrategy`, `keyInsights`, and `mathlibDependencies`.
- `originalContributions` honestly scoped to the genuinely original parts: the mod-4 obstruction (`not_sum_sq_of_mod4_eq_three`) and the Gaussian-integer connection theorems (`inert_prime_not_sum_sq`, `split_prime_sum_sq`).

`original` badge with thorough Mathlib disclosure + genuine original components is consistent with fleet precedent (amgm-oq017). No overclaim.

---
Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)