### PR TITLE
Enrich erdos-1002-oq-03: split mislabeled Part V into gcd-general + Part VI corollaries (cover 1..259/EOF)

### DIFF
--- a/src/data/proofs/erdos-1002-oq-03/meta.json
+++ b/src/data/proofs/erdos-1002-oq-03/meta.json
@@ -94,12 +94,20 @@
       "mathContext": "Since deviation(p/q·(k+1)) is q-periodic in k, summing over n full periods adds the per-period constant 1/2 each time: S(p/q, n·q) = n·(1/2) = n/2. The growth is exactly linear with per-step rate 1/(2q), determined solely by the denominator q."
     },
     {
-      "id": "corollaries",
-      "title": "Part V: Sanity-Check Corollaries",
-      "summary": "Two example corollaries: after two periods the sum is exactly 1 (S(p/q, 2q) = 1, instantiating linear growth at n = 2), and concretely for α = 1/2 one period sums to 1/2 (S(1/2, 2) = 1/2).",
+      "id": "gcd-general",
+      "title": "Part V: The gcd Governs the Per-Period Sum",
+      "summary": "innerSum_period_sum_general drops the coprimality hypothesis: for any p, q with q ≥ 1, S(p/q, q) = gcd(p,q)/2. Reducing p/q to lowest terms p'/q' makes the length-q block consist of exactly gcd(p,q) full periods of p'/q', so innerSum_linear (applied to p', q', with n = gcd) yields gcd(p,q)/2. This strengthens innerSum_period_sum, which is the special case gcd(p,q) = 1.",
       "startLine": 200,
-      "endLine": 212,
-      "mathContext": "These instantiate the general theorems at small parameters, confirming the universal-constant and linear-growth claims numerically and demonstrating that the growth is genuinely unbounded (n/2 → ∞ as n → ∞)."
+      "endLine": 238,
+      "mathContext": "Writing p/q = p'/q' in lowest terms with q = gcd(p,q)·q', the block of length q is gcd(p,q) periods of p'/q', so S(p/q, q) = gcd(p,q)·(1/2) = gcd(p,q)/2. The per-period sum thus reads off the gcd rather than assuming coprimality."
+    },
+    {
+      "id": "corollaries",
+      "title": "Part VI: Sanity-Check Corollaries",
+      "summary": "Three example corollaries: after two periods the sum is exactly 1 (S(p/q, 2q) = 1 for coprime p, q, instantiating linear growth at n = 2), concretely S(1/2, 2) = 1/2 (one period for α = 1/2), and a non-reduced check S(2/4, 4) = gcd(2,4)/2 = 1 (two full periods of 1/2, not 1/2), which exercises the general gcd formula.",
+      "startLine": 239,
+      "endLine": 259,
+      "mathContext": "These instantiate the general theorems at small parameters, confirming the linear-growth and gcd claims numerically. The non-reduced 2/4 check demonstrates why coprimality matters for innerSum_period_sum and that the gcd version is the correct generalization; unbounded growth follows since n/2 → ∞."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
Enrichment pass for **inner-sum linear growth** (erdos-1002-oq-03, a `verified` entry — 0 axioms, 0 sorries).

**Problem:** the final section `Part V: Sanity-Check Corollaries [200-212]` was mislabeled and undercovered the file (259 lines):
- Its `startLine: 200` and title claim "Sanity-Check Corollaries", but the Lean Part V banner at line 204 is actually **"The gcd governs the per-period sum (coprimality dropped)"**, home to the theorem `innerSum_period_sum_general` (`S(p/q, q) = gcd(p,q)/2`) at line 217.
- The real sanity-check corollaries live under the **Part VI** banner at line 239 (three `example`s), and the section's `endLine: 212` left lines 213..259 entirely uncovered.

**Fix (banner-aligned, covers 1..259/EOF):**
- New `Part V: The gcd Governs the Per-Period Sum` → `[200-238]` — `innerSum_period_sum_general`, the coprimality-free generalization S(p/q, q) = gcd(p,q)/2.
- Re-anchored `Part VI: Sanity-Check Corollaries` → `[239-259]` — the three examples (2-period sum = 1, S(1/2, 2) = 1/2, and the non-reduced S(2/4, 4) = 1 check exercising the gcd formula). Summary corrected from "Two example corollaries" to the actual three.

No status/badge/axiom changes; content preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
