### PR TITLE
Enrich erdos-1098: drop 2 phantom originalContributions claims (bfc_center_connection axiom, symmetric-group example)

### DIFF
--- a/src/data/proofs/erdos-1098/meta.json
+++ b/src/data/proofs/erdos-1098/meta.json
@@ -59,8 +59,8 @@
       "erdos_question_answered: main theorem via rewrite with neumann_theorem",
       "same_coset_commute and clique_different_cosets (coset argument, fully proved)",
       "abelian_no_edges: proved using Subgroup.mem_center_iff",
-      "isBFCGroup definition and bfc_center_connection axiom",
-      "Examples: symmetric group and dihedral group clique bounds",
+      "isBFCGroup definition (bounded finite conjugacy classes) with the BFC–centre connection discussed in source comments",
+      "Examples: abelian_no_edges (abelian groups give an edgeless graph) and finite_group_finite_index; dihedral-group clique bounds discussed in comments",
       "erdos_1098_summary combining equivalence and implication"
     ],
     "dateAdded": "2026-01-19",


### PR DESCRIPTION
Follow-up to #40195 (which merged before this final commit landed). Two `originalContributions` items on **erdos-1098** still claim declarations that do not exist in the Lean file:

- *"isBFCGroup definition and **bfc_center_connection axiom**"* — the file's only axiom is `neumann_theorem` (`meta.axiomCount: 1`); there is no `bfc_center_connection` axiom.
- *"Examples: **symmetric group** and dihedral group clique bounds"* — there are no symmetric-group declarations; dihedral groups appear only in a source comment. The actual example theorems are `abelian_no_edges` and `finite_group_finite_index`.

Corrected both to match the file. Pure accuracy fix; no status/badge/axiomCount change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
