### PR TITLE
audit: bezout-identity-oq013 (irreducible norm = p or p²) clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -30392,6 +30392,12 @@
       "lastAudited": "2026-07-21T07:11:39Z",
       "result": "clean",
       "issues": []
+    },
+    "bezout-identity-oq013": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T07:24:17Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Gallery integrity audit — bezout-identity-oq013

**Result: CLEAN.** All public claims match the Lean kernel.

**Entry**: *Irreducibles of ℤ[√d] Have Prime or Prime-Squared Norm (−2 ≤ d < 0)* — status `verified`, badge `verified`.

### Verification
- `lake build Proofs.NormEuclideanZsqrtdFamilyOQ03OQ02OQ01` succeeds (0 errors; only pre-existing `@[reducible]`-style warnings from the parent).
- File declares exactly **2 theorems** (`exists_prime_dvd_natCast`, `irreducible_norm_eq_prime_or_sq`), **0 sorries**, **0 axioms** — matches `theoremCount`/`sorries`/`axiomCount`.
- `#print axioms` on both theorems: only `propext, Classical.choice, Quot.sound`. No `native_decide`, no `Lean.ofReduceBool`, no custom axioms — matches the `assumptions` disclosure.
- Both theorems have genuine existential/dichotomy conclusions (no `True` stubs).
- Title, description, and `originalContributions` accurately scope the contribution to the *necessary* direction of the norm criterion, built on the parent's sufficiency + EuclideanDomain instance and Mathlib's UFD machinery (all disclosed in `assumptions`).

No changes to meta required. Tracker updated to record the clean audit.

---
Discovered during gallery integrity audit.