### PR TITLE
Enrich erdos-1213: replace wholesale-stale placeholder-stub sections with accurate sections for the real file (1..73/EOF)

### DIFF
--- a/src/data/proofs/erdos-1213/meta.json
+++ b/src/data/proofs/erdos-1213/meta.json
@@ -44,45 +44,45 @@
       "id": "problem-header",
       "title": "Problem Identification and Status",
       "startLine": 1,
-      "endLine": 7,
-      "summary": "Module comment header identifying Erdős Problem #1213, its source (erdosproblems.com/1213), and its status as SOLVED (existence of f(a,K) confirmed by Hegyvári 1986, though the optimal growth rate in K remains open).",
-      "mathContext": "The problem concerns sequences $a_1 < a_2 < \\cdots < a_n$ with $a_1 = a \\ge 1$ and bounded gaps $a_{i+1} - a_i \\le K$. These are discrete analogs of Lipschitz functions on $\\{1, \\ldots, n\\}$. The 'solved' status means the existence of $f(a,K)$ is established, but the optimal $f(a,K) \\ll a \\cdot e^{O(K)}$ bound from Hegyvári (1986) is not believed tight."
+      "endLine": 17,
+      "summary": "Module docstring identifying Erdős Problem #1213, its source (erdosproblems.com/1213), and its status as SOLVED by Hegyvári (1986): for a ≥ 1, K ≥ 1 there exists f(a,K) so that any bounded-gap sequence a = a₁ < ⋯ < aₙ with gaps ≤ K and n > f(a,K) has two distinct intervals I, J with equal sums, and f(a,K) ≪ a·e^{O(K)}.",
+      "mathContext": "The problem concerns sequences $a_1 < a_2 < \\cdots < a_n$ with $a_1 = a \\ge 1$ and bounded gaps $a_{i+1} - a_i \\le K$ — discrete analogs of Lipschitz functions on $\\{1, \\ldots, n\\}$. 'Solved' means existence of $f(a,K)$ is established (Hegyvári 1986), but the optimal $f(a,K) \\ll a \\cdot e^{O(K)}$ bound is not believed tight in $K$."
     },
     {
-      "id": "problem-statement",
-      "title": "Mathematical Statement: Equal-Sum Interval Pairs",
-      "startLine": 8,
-      "endLine": 14,
-      "summary": "Documents the full problem: for n > f(a,K) with a₁=a, gaps ≤ K, there exist two distinct index-intervals I and J with ∑_{i∈I} aᵢ = ∑_{j∈J} aⱼ. Records Hegyvári's explicit bound f(a,K) ≪ a·e^{O(K)} and the open question of improving the exponential.",
-      "mathContext": "The equal-sum condition $\\sum_{i \\in I} a_i = \\sum_{j \\in J} a_j$ for disjoint index intervals $I = [l_1, r_1]$ and $J = [l_2, r_2]$ can be rephrased as: the function $S(l,r) = \\sum_{i=l}^{r} a_i$ is not injective on pairs $(l,r)$ with $l \\le r \\le n$. There are $\\binom{n}{2}$ such pairs; the range of $S$ lies in $[a, n \\cdot (a + Kn)]$. By pigeonhole, if $\\binom{n}{2} > n(a + Kn)$, a collision is guaranteed — giving a bound of order $\\sqrt{aKn}$, looser than Hegyvári's."
-    },
-    {
-      "id": "imports",
-      "title": "Mathlib Import",
-      "startLine": 16,
-      "endLine": 16,
-      "summary": "Imports the full Mathlib library, giving access to `StrictMono`, `Finset.Ico`, `Finset.sum`, and `Finset.exists_ne_map_eq_of_card_lt_of_maps_to` (the finitary pigeonhole lemma) — the key tools for a full formalization.",
-      "mathContext": "Key Mathlib lemmas for the eventual proof: `Finset.exists_ne_map_eq_of_card_lt_of_maps_to` (if f maps a finite set of size > |T| into T, some two map to the same value); `Finset.sum_Ico` (sum over a contiguous range); `StrictMono` (the sequence monotonicity condition); `Nat.lt_of_sub_eq_succ` (for bounded gap conditions)."
-    },
-    {
-      "id": "placeholder-theorem",
-      "title": "Placeholder Theorem: erdos_1213",
+      "id": "imports-setup",
+      "title": "Imports and Namespace",
       "startLine": 18,
-      "endLine": 20,
-      "summary": "Placeholder `erdos_1213 : True := by sorry`. The actual theorem type should be: ∀ a K : ℕ, ∃ N : ℕ, ∀ f : ℕ → ℕ, StrictMono f → f 0 = a → (∀ i, f (i+1) - f i ≤ K) → N < n → ∃ l₁ r₁ l₂ r₂, (l₁,r₁) ≠ (l₂,r₂) ∧ ∑ i ∈ Ico l₁ r₁, f i = ∑ j ∈ Ico l₂ r₂, f j.",
-      "mathContext": "The formalization challenge: (1) encoding bounded gaps as $\\forall i, f(i+1) - f(i) \\le K$ in `ℕ` (where subtraction is saturating — requires casting to `ℤ` or using `f(i) + K ≥ f(i+1)`); (2) the pigeonhole step needs a bound on the range of `Finset.Ico`-sums, requiring careful `Nat.cast` management; (3) the 'two distinct intervals' condition needs a careful definition of interval equality."
+      "endLine": 24,
+      "summary": "`import Mathlib` (plus `Mathlib.Data.Finset.Basic`), `open Finset BigOperators`, and `namespace Erdos1213`, giving access to `StrictMono`, `Finset.Ico`, `Finset.sum`, and the finitary pigeonhole lemma `Finset.exists_ne_map_eq_of_card_lt_of_maps_to`.",
+      "mathContext": "Key Mathlib tools for this problem: `Finset.exists_ne_map_eq_of_card_lt_of_maps_to` (if $f$ maps a finite set of size $> |T|$ into $T$, two elements collide); `Finset.sum_Ico` (sum over a contiguous range); `StrictMono` (the sequence monotonicity condition)."
     },
     {
-      "id": "check-statement",
-      "title": "Type Check: Theorem Accessibility",
-      "startLine": 22,
-      "endLine": 23,
-      "summary": "`#check erdos_1213` confirms the theorem is well-typed and accessible in the current namespace. Along with the sorry marker comment, it serves as a tracing point for future proof development.",
-      "mathContext": "The `#check` command in Lean 4 elaborates the term and prints its type without executing it. For a `sorry`-carrying theorem, the type is inferred from the stated return type (`True`). When the formalization is complete, replacing `True` with the actual statement will be validated here."
+      "id": "definitions",
+      "title": "Bounded-Gap Sequences and Repeated Interval Sums",
+      "startLine": 25,
+      "endLine": 39,
+      "summary": "Defines `IsBoundedGapSeq a K` as `StrictMono a ∧ ∀ i, a (i+1) - a i ≤ K`, and `HasRepeatedIntervalSum a n` as the existence of two distinct index sets I ≠ J (with all indices < n, I nonempty) whose sequence sums ∑_{i∈I} a i and ∑_{j∈J} a j are equal.",
+      "mathContext": "$\\text{IsBoundedGapSeq}$ encodes the hypothesis $a_1 < a_2 < \\cdots$ with $a_{i+1} - a_i \\le K$ (saturating $\\mathbb{N}$ subtraction). $\\text{HasRepeatedIntervalSum}$ captures the conclusion: the interval-sum map is not injective, i.e. two distinct index sets share a common sum."
+    },
+    {
+      "id": "hegyvari-axioms",
+      "title": "Hegyvári's Theorem and Exponential Bound (Axiomatized)",
+      "startLine": 40,
+      "endLine": 63,
+      "summary": "Axiomatizes Hegyvári's 1986 resolution as two axioms: `hegyv_ari_1986` (for a₀ ≥ 1, K ≥ 1 there is a threshold f beyond which every bounded-gap sequence has a repeated interval sum) and `hegyv_ari_bound` (the explicit bound f ≤ C·a₀·exp(c·K) for constants C, c > 0). These are the two assumptions counted in axiomCount.",
+      "mathContext": "Hegyvári (1986): for $a_0, K \\ge 1$ there exists $f(a_0,K)$ such that any bounded-gap sequence starting at $a_0$ with $n > f$ terms contains two distinct intervals of equal sum, with $f(a_0,K) \\le C \\cdot a_0 \\cdot e^{cK}$. The elementary pigeonhole argument gives only $f \\ll \\sqrt{a_0 K n}$-type bounds; the sharp exponential dependence is what is axiomatized here (beyond current Mathlib)."
+    },
+    {
+      "id": "main-theorem",
+      "title": "Main Statement: erdos_1213",
+      "startLine": 64,
+      "endLine": 73,
+      "summary": "Proves `erdos_1213` — the existence of the threshold f(a₀,K) for every a₀ ≥ 1, K ≥ 1 — directly from the `hegyv_ari_1986` axiom, then closes the namespace. This is the formal statement that Erdős Problem #1213 has a positive answer.",
+      "mathContext": "The main theorem $\\forall a_0\\, K \\ge 1,\\ \\exists f,\\ \\forall a\\, n,\\ a(0)=a_0 \\land \\text{IsBoundedGapSeq}\\,a\\,K \\land n > f \\to \\text{HasRepeatedIntervalSum}\\,a\\,n$ is discharged by `hegyv_ari_1986`; the remaining open direction is only the quantitative improvement of the $e^{O(K)}$ factor."
     }
   ],
   "conclusion": {
-    "summary": "Erdős Problem #1213 asks for the minimum length threshold f(a,K) guaranteeing two index-intervals with equal sums in a sequence starting at a with gaps ≤ K. Hegyvári (1986) proved f(a,K) ≪ a·e^{O(K)} exists; the open question is whether the exponential in K can be reduced to polynomial. The Lean formalization is a stub.",
+    "summary": "Erdős Problem #1213 asks for the minimum length threshold f(a,K) guaranteeing two index-intervals with equal sums in a sequence starting at a with gaps ≤ K. Hegyvári (1986) proved f(a,K) ≪ a·e^{O(K)} exists; the open question is whether the exponential in K can be reduced to polynomial. The Lean formalization gives clean definitions (IsBoundedGapSeq, HasRepeatedIntervalSum), axiomatizes Hegyvári's theorem and its exponential bound, and derives the main erdos_1213 statement from them.",
     "implications": "A formalization of the Hegyvári bound would add a clean combinatorial theorem to Lean's library, with a proof that is primarily finitary (pigeonhole over a finite set of interval sums) and potentially accessible without heavy analytic machinery. The sequence type (strictly increasing with bounded gaps) has clean Lean definitions via `StrictMono` and `Finset.Ico`.",
     "openQuestions": [
       "Can the bound $f(a,K) \\ll a \\cdot e^{O(K)}$ be improved to $f(a,K) \\ll a \\cdot K^c$ for some constant $c$? Hegyvári himself believed the exponential is not optimal.",


### PR DESCRIPTION
Enrichment pass for `erdos-1213` (Repeated Interval Sums in Bounded-Gap Sequences).

## Problem found
The `meta.json` sections were **wholesale stale** — they described a placeholder-stub version of the Lean file that no longer exists:
- `placeholder-theorem` section claimed `erdos_1213 : True := by sorry`
- `check-statement` section described a `#check erdos_1213` line
- `imports` anchored at line 16
- `conclusion.summary` ended with "The Lean formalization is a stub."

The actual 73-line file now contains real content: two definitions (`IsBoundedGapSeq`, `HasRepeatedIntervalSum`), two axioms (`hegyv_ari_1986`, `hegyv_ari_bound`), and a genuinely-proved `erdos_1213` (discharged from `hegyv_ari_1986`).

## Fix
Rewrote all sections to accurately describe the current file, giving contiguous coverage of lines **1..73 (EOF)**:
| section | lines | content |
|---|---|---|
| problem-header | 1–17 | docstring, source, SOLVED status |
| imports-setup | 18–24 | imports, `open`, namespace |
| definitions | 25–39 | `IsBoundedGapSeq`, `HasRepeatedIntervalSum` |
| hegyvari-axioms | 40–63 | `hegyv_ari_1986`, `hegyv_ari_bound` |
| main-theorem | 64–73 | proved `erdos_1213` |

Also de-stubbed `conclusion.summary` to describe the real formalization.

## Axiom integrity
`badge: axiom`, `axiomCount: 2` — accurate: two real `axiom` declarations (`hegyv_ari_1986`, `hegyv_ari_bound`), 0 sorries. `assumptions` field already correct.

Only `meta.json` touched.
