### PR TITLE
Enrich erdos-531: re-anchor drifted back-half sections, cover 1..220/EOF

### DIFF
--- a/src/data/proofs/erdos-531/meta.json
+++ b/src/data/proofs/erdos-531/meta.json
@@ -94,63 +94,63 @@
       "title": "Imports and Setup",
       "summary": "Imports `Finset.Powerset` (for enumerating subsets), `BigOperators` (for summing over sets), `BoundedOrder` (for $\\inf$ definition of $F(k)$), and `SalemSpencer` (sum-free set infrastructure).",
       "startLine": 14,
-      "endLine": 22,
+      "endLine": 21,
       "mathContext": "Key Mathlib dependencies: `Finset.powerset` gives $\\mathcal{P}(A)$ for finite $A$, `Finset.sum` computes $\\sum_{a \\in S} a$, and `sInf` defines $F(k) = \\inf\\{N : \\text{any 2-coloring of } [N] \\text{ has a monochromatic } k\\text{-set}\\}$."
     },
     {
       "id": "core-definitions",
       "title": "Core Definitions",
       "summary": "Defines `Coloring` ($\\chi : \\mathbb{N} \\to \\text{Bool}$), `SubsetSums A` ($\\{\\sum_{a \\in S} a : \\emptyset \\neq S \\subseteq A\\}$), `MonochromaticSubsetSums` (all subset sums get the same color), `ExistsMonochromaticSet`, and $F(k)$ via `sInf`.",
-      "startLine": 23,
-      "endLine": 63,
+      "startLine": 22,
+      "endLine": 64,
       "mathContext": "For $A = \\{a_1, \\ldots, a_k\\}$, the subset sums are $\\{\\sum_{i \\in S} a_i : \\emptyset \\neq S \\subseteq [k]\\}$, giving $2^k - 1$ sums. Monochromaticity: $\\exists c,\\, \\forall \\emptyset \\neq S \\subseteq A,\\, \\chi(\\sum S) = c$. $F(k) = \\inf\\{N : \\forall \\chi,\\, \\exists |A| = k$ with monochromatic sums$\\}$."
     },
     {
       "id": "folkman-theorem",
       "title": "Folkman's Theorem",
       "summary": "Axiomatizes `folkman_theorem`: $F(k)$ is finite for all $k \\geq 1$. Also documents in source comments `folkman_well_defined` (no Lean declaration exists): any coloring of $\\{1,\\ldots,F(k)\\}$ contains a monochromatic $k$-set.",
-      "startLine": 64,
-      "endLine": 79,
+      "startLine": 65,
+      "endLine": 80,
       "mathContext": "Folkman's theorem (1960s): $\\forall k \\geq 1,\\, F(k) < \\infty$. Equivalently: the system of equations $\\{\\sum_{i \\in S} x_i = y_S : \\emptyset \\neq S \\subseteq [k]\\}$ is partition regular. This follows from Rado's theorem since the coefficient matrix has columns summing to a column of the identity."
     },
     {
       "id": "lower-bounds",
       "title": "Lower Bounds",
       "summary": "Axiomatizes `balogh_2017` ($F(k) \\geq 2^{2^{k-1}/k}$, the current best lower bound). Documents `erdos_spencer_1989` ($F(k) \\geq 2^{ck^2/\\log k}$) in a source comment only (no Lean declaration exists).",
-      "startLine": 80,
-      "endLine": 97,
+      "startLine": 81,
+      "endLine": 95,
       "mathContext": "Erdős-Spencer (1989): $F(k) \\geq 2^{ck^2/\\log k}$ for some $c > 0$. Balogh-Eberhard-Narayanan-Treglown-Wagner (2017): $F(k) \\geq 2^{2^{k-1}/k}$, showing doubly-exponential growth. For large $k$, $2^{k-1}/k \\gg k^2/\\log k$, so the 2017 bound is strictly stronger."
     },
     {
       "id": "small-cases",
       "title": "Small Cases",
       "summary": "Proves `F_1` ($F(1) = 1$) in full. Declares `F_2` ($F(2) = 8$) as a sorry-stubbed theorem pending a finite-coloring reduction; an earlier draft's $F(2) = 3$ was false for the distinct-pair Folkman number defined here. $F(3) \\geq 11$ is documented in a source comment only (no Lean declaration exists).",
-      "startLine": 98,
-      "endLine": 114,
+      "startLine": 96,
+      "endLine": 159,
       "mathContext": "$F(1) = 1$: any single element has its (unique) subset sum trivially monochromatic (fully proven). $F(2) = 8$: for the distinct-pair number defined here ($\\{a,b\\}$ with $a,b,a+b$ mono), $N = 7$ admits a defeating 2-coloring while every 2-coloring of $\\{1,\\ldots,8\\}$ forces such a pair — so $F(2) = 8$, not $3$ (established by exhaustive check; the Lean proof needs a finite-coloring reduction). $F(3) \\geq 11$: verified by exhaustive search."
     },
     {
       "id": "upper-bounds",
       "title": "Upper Bounds",
       "summary": "Documents the tower-type upper bound from Folkman's original existence proof and the Hales-Jewett/Rado approach, which gives $F(k) \\leq \\text{tower}(k)$ for an iterated exponential.",
-      "startLine": 115,
-      "endLine": 126,
+      "startLine": 160,
+      "endLine": 167,
       "mathContext": "Upper bounds come from the Rado/Hales-Jewett proof, giving $F(k) \\leq \\text{tower}(O(k))$ (iterated exponential). The gap between lower ($2^{2^{k-1}/k}$) and upper ($\\text{tower}(O(k))$) is enormous — closing it is the core of Problem #531."
     },
     {
       "id": "rado-connection",
       "title": "Connection to Rado's Theorem",
       "summary": "documents in source comments `folkman_from_rado` (no Lean declaration exists): Folkman's theorem follows from Rado's theorem on partition regularity. The subset sum equations form a partition-regular system because the coefficient matrix satisfies Rado's columns condition.",
-      "startLine": 127,
-      "endLine": 147,
+      "startLine": 168,
+      "endLine": 181,
       "mathContext": "Rado's theorem (1933): a system $Ax = 0$ over $\\mathbb{Z}$ is partition regular iff $A$ satisfies the columns condition. For Folkman: the variables are $x_1, \\ldots, x_k$ and $y_S$ for each $\\emptyset \\neq S \\subseteq [k]$, with equations $\\sum_{i \\in S} x_i = y_S$. The coefficient matrix satisfies Rado's condition."
     },
     {
       "id": "main-results",
       "title": "Main Results",
       "summary": "Combines all results into `erdos_531`: Folkman's theorem holds, $F(k) \\geq 2^{2^{k-1}/k}$, and exact values for $k \\leq 2$. Asserts the exact growth rate remains open.",
-      "startLine": 148,
-      "endLine": 171,
+      "startLine": 182,
+      "endLine": 220,
       "mathContext": "Summary: $F(k) < \\infty$ (Folkman), $F(k) \\geq 2^{2^{k-1}/k}$ (Balogh et al.), $F(1) = 1$ (proven), $F(2) = 8$ (value corrected from a false $F(2) = 3$; Lean proof sorry'd). The exact growth rate of $F(k)$ — somewhere between doubly exponential and tower-type — remains open."
     }
   ],


### PR DESCRIPTION
Enrichment pass for `erdos-531` (Folkman's Theorem — Monochromatic Subset Sums).

**Problem:** the back-half `sections` had drifted ~45 lines behind their `## ` banners — "Small Cases" claimed 98–114 but `## Small Cases` is at line 96 with its theorems running to 159; "Upper Bounds" claimed 115–126 but `## Upper Bounds` is at 160; "Connection to Rado's Theorem" claimed 127–147 but is at 168; and "Main Results" stopped at 171 while the `F_growth_doubly_exponential`, `erdos_531_summary`, and capstone `erdos_531` theorems (194–216) were left uncovered. `max(endLine)=171` vs `wc -l=220`.

**Changes (single JSON file, pure line re-anchor):**
- Re-anchored all 9 sections to their actual `## ` banners and declarations; now cover **1..220/EOF** contiguously.
- The existing summaries were already accurate (they correctly flag the `F_2` `sorry`, the comment-only `erdos_spencer_1989`/`folkman_from_rado` non-declarations, and the corrected $F(2)=8$) — only the line ranges changed.

No status/badge/axiomCount change — badge `axiom` is correct (`axiom folkman_theorem` @73, `axiom balogh_2017` @92, plus the `F_2` sorry @156), preserved as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
