### PR TITLE
audit: bezout-identity-oq024 (unit-group cardinality under k-fold CRT) clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -30434,6 +30434,12 @@
       "lastAudited": "2026-07-21T07:42:26Z",
       "result": "clean",
       "issues": []
+    },
+    "bezout-identity-oq024": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T07:51:14Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Gallery Integrity Audit — CLEAN

**Proof**: bezout-identity-oq024 — |(ℤ/(∏nᵢ)ℤ)ˣ| = ∏ᵢ|(ℤ/nᵢℤ)ˣ| = ∏ᵢφ(nᵢ)
**Result**: clean (no integrity issues)

## Verified
- **theoremCount 8** ✓ (card_units_CRTProd, card_units_preservation, natCard_units_zmod, card_units_eq_totient_prod, coprime_2_3_5', card_units_2_3_5, card_units_30_eq_totient_prod, card_units_30_eq_8)
- **definitionCount 0** ✓ (crtKFold/CRTProd reused from parent)
- **axiomCount 0** ✓ — `#print axioms` on card_units_preservation / card_units_eq_totient_prod shows only `propext, Classical.choice, Quot.sound`
- **sorries 0** ✓; builds clean (`lake build`, 30s)
- `decide` uses are kernel `decide` on small numeric facts, not native_decide

## Claims match reality — badge `original` is defensible
The new content, `card_units_preservation`, is genuinely assembled: it applies the units functor (`Units.mapEquiv`) to the **parent's** CRT ring isomorphism `crtKFold` (a lean-genius original, not a Mathlib theorem), then factors the count with an induction over `MulEquiv.prodUnits` + `Nat.card_prod`. No single deep Mathlib theorem *is* the result. Under the fleet's established precedent (amgm-oq017, bezout-oq018), `original` is acceptable for assembled/bridged results when disclosure is thorough — and here it is exemplary: the overview discloses the parent reuse, names every Mathlib lemma used, and explicitly states that φ-multiplicativity (φ(∏nᵢ)=∏φ(nᵢ)) is Mathlib's `Nat.totient_mul` (already in the parent) and is **not** re-derived. `originalContributions` are scoped accordingly.

Note: the sibling element-count entry oq023 carries badge `mathlib` for structurally the same transport; the difference is a defensible judgment call, not an overclaim.

---
Discovered during gallery integrity audit.