### PR TITLE
Enrich combinations-formula-oq-03-oq-06: cover Part VII summary tail (6→7, 1..242/EOF)

### DIFF
--- a/src/data/proofs/combinations-formula-oq-03-oq-06/meta.json
+++ b/src/data/proofs/combinations-formula-oq-03-oq-06/meta.json
@@ -94,6 +94,14 @@
       "startLine": 155,
       "endLine": 193,
       "summary": "Explicit values: [2]_q = 1+q, [3]_q = 1+q+q², [2]_q! = 1+q. Applied: F²·v₀ = (1+q)·v₂, F³·v₀ = (1+q+q²)(1+q)·v₃ by rewriting with verma_Fpower_eq_qFactorial and the q-number values."
+    },
+    {
+      "id": "summary",
+      "title": "Part VII: What Is Formalized and Conclusion",
+      "startLine": 194,
+      "endLine": 242,
+      "summary": "Concluding documentation block: itemizes what is formalized (the abstract Verma-module divided-power identity $F^n \\cdot v_0 = [n]_q!\\, v_n$, the $q$-number/$q$-factorial scaling factors, the classical $q \\to 1$ limit, and concrete low-order computations), records the tally `Axioms: 0 | Sorries: 0 | Theorems: 12`, lists what remains for a full formalization, and states the conclusion that the OQ-03-OQ-06 question is answered YES.",
+      "mathContext": "The affirmative answer rests on the fully-proved abstract identity rather than a construction of a specific quantum group; the 'what remains' note scopes the gap between this abstract formalization and a concrete $U_q(\\mathfrak{sl}_2)$ realization."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Enrichment pass: combinations-formula-oq-03-oq-06

Driven by the grown-file section-undercoverage scan against fresh `origin/main` (sections stopped at line 193; file is 242 lines).

### Tail coverage (6 → 7 sections, 1..242/EOF)
The six existing sections are correctly anchored to the file's `Part I..VI` banners, but the concluding **Part VII** documentation block (lines 194–242) — "What Is Formalized", the `Axioms: 0 | Sorries: 0 | Theorems: 12` tally, "What Remains for Full Formalization", and the "Conclusion" answering the question YES — had no section. Appended a **Part VII: What Is Formalized and Conclusion** section covering 194–242. `maxEnd === wc-l` (242) asserted.

Status/badge/axiomCount unchanged (verified, 0 axioms, 0 sorries — grep-confirmed and matches the file's own tally). No `pnpm build` (regenerates ~2135 unrelated files); JSON validated via parse + byte-identical round-trip.
