### PR TITLE
audit: bezout-identity-oq027 (iterated CRT over CommRing) clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -30440,6 +30440,12 @@
       "lastAudited": "2026-07-21T07:51:14Z",
       "result": "clean",
       "issues": []
+    },
+    "bezout-identity-oq027": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T07:56:34Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Gallery Integrity Audit — CLEAN

**Proof**: bezout-identity-oq027 — Iterated CRT for multiple coprime moduli over commutative rings
**Result**: clean (no integrity issues)

## Verified
- **theoremCount 8** ✓ / **definitionCount 1** ✓ (def: crtRing; thms: crtRing_mod_m, crtRing_mod_n, crtRing_exists, isCoprime_list_prod, crtRing_list_exists, prod_dvd_of_pairwise_coprime, crtRing_list_unique, crtRing_three)
- **axiomCount 0** ✓ — `#print axioms` on crtRing_list_exists / crtRing_list_unique shows only `propext, Quot.sound` (not even Classical.choice)
- **sorries 0** ✓; builds clean (`lake build`, 2969 jobs)
- **No native_decide** — crtRing_three uses `fin_cases`

## Claims match reality — badge `original` (Tier A) justified
The two-modulus Bézout CRT formula `crtRing a b s t m n = b·s·m + a·t·n` is reproduced inline (self-contained, Mathlib-only imports), and the iterated existence (`crtRing_list_exists`) and uniqueness (`crtRing_list_unique`) are genuinely proved by folding over the list via `isCoprime_list_prod` (iterated IsCoprime.mul_right — the exact lemma the open question flagged) and `prod_dvd_of_pairwise_coprime` (iterated IsCoprime.mul_dvd). Mathlib supplies only elementary `IsCoprime` lemmas; no deep CRT theorem does the core work. The result is correctly stated over an arbitrary `CommRing R`. `originalContributions` accurately scoped.

---
Discovered during gallery integrity audit.