### PR TITLE
Enrich binomial-theorem-oq-02-oq-02-oq-01: cover head + Summary tail (7→9, 1..297/EOF)

### DIFF
--- a/src/data/proofs/binomial-theorem-oq-02-oq-02-oq-01/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-02-oq-02-oq-01/meta.json
@@ -68,6 +68,14 @@
   },
   "sections": [
     {
+      "id": "overview",
+      "title": "Overview: Gaussian q-Binomial Coefficients",
+      "startLine": 1,
+      "endLine": 53,
+      "summary": "Header docstring, design notes, key-results index, and imports. Builds the Gaussian (q-)binomial coefficient $\\binom{n}{k}_q$ from first principles (Mathlib v4.26.0 has no `GaussianBinomial` API) via the q-Pascal recurrence over any `CommSemiring R`, avoiding division/quotient machinery. Targets the q-Vandermonde identity $\\binom{m+n}{r}_q = \\sum_{k} q^{(m-k)(r-k)}\\binom{m}{k}_q\\binom{n}{r-k}_q$.",
+      "mathContext": "The recurrence $\\binom{n+1}{k+1}_q = q^{k+1}\\binom{n}{k+1}_q + \\binom{n}{k}_q$ with $\\binom{n}{0}_q = 1$, $\\binom{0}{k+1}_q = 0$ makes the coefficient computable. References: Andrews (1976) Ch. 3, Kac–Cheung (2002) §6, Stanley EC1 §1.7."
+    },
+    {
       "id": "definition",
       "title": "qBinomial Definition",
       "summary": "Recursive definition of qBinomial via the q-Pascal recurrence over any CommSemiring.",
@@ -115,6 +123,14 @@
       "summary": "qBinomial_one_eq_geom_sum (\\binom{n}{1}_q = ∑_{i<n} q^i), qBinomial_succ_pred_eq_geom_sum (\\binom{n+1}{n}_q = ∑_{i≤n} q^i), and the simplest reflection case qBinomial_reflection_at_one (\\binom{n+1}{1}_q = \\binom{n+1}{n}_q).",
       "startLine": 194,
       "endLine": 247
+    },
+    {
+      "id": "summary",
+      "title": "Summary, Open Future Work, and Mathlib Potential",
+      "startLine": 248,
+      "endLine": 297,
+      "summary": "Concluding `## Summary` block: recaps the established API (q-Pascal definition, boundary/vanishing/diagonal lemmas, the $q=1 \\to$ `Nat.choose` specialization, q-Vandermonde base cases) and records `Theorems Proved: 10, Axioms: 0, Sorries: 0`. Lists open future work — full q-Vandermonde induction, dual q-Pascal, reflection symmetry $\\binom{n}{k}_q = \\binom{n}{n-k}_q$, the Cauchy q-binomial theorem, and $\\mathbb{F}_q^n$ subspace counting — plus a proposed Mathlib upstream location. Ends with `#check` sanity commands.",
+      "mathContext": "The self-contained `CommSemiring` API is a candidate for `Mathlib/Combinatorics/Enumerative/QBinomial.lean`. The base cases proved here are the foundation for the (still-open) inductive q-Vandermonde proof."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Enrichment pass: binomial-theorem-oq-02-oq-02-oq-01

Driven by the grown-file section-undercoverage scan against fresh `origin/main` (sections covered 54–247; file is 297 lines).

### Head + tail coverage (7 → 9 sections, 1..297/EOF)
The seven existing sections are correctly anchored to the theorem clusters, but **both ends** were uncovered:
- **Head (1–53)**: the module docstring, "Design" and "Key Results" indices, and imports had no section. Added an **Overview: Gaussian q-Binomial Coefficients** section.
- **Tail (248–297)**: the concluding `## Summary` block (established-results recap, the `Theorems Proved: 10, Axioms: 0, Sorries: 0` tally, the itemized open future work — full q-Vandermonde induction, dual q-Pascal, reflection symmetry, Cauchy q-binomial theorem, subspace counting — the Mathlib upstream proposal, and `#check` commands) had no section. Added a **Summary, Open Future Work, and Mathlib Potential** section.

`maxEnd === wc-l` (297) asserted. Status/badge/axiomCount unchanged (verified/original, 0 axioms, 0 sorries — grep-confirmed and matches the file's own tally). No `pnpm build` (regenerates ~2135 unrelated files); JSON validated via parse + byte-identical round-trip.
