### PR TITLE
Research: erdos-98-wip-01 — h 5 ≤ 3 (explicit 3-distance general-position 5-config)

### DIFF
--- a/proofs/Proofs/Erdos98WIP01.lean
+++ b/proofs/Proofs/Erdos98WIP01.lean
@@ -120,6 +120,14 @@ conjectures are *open* in mathematics; nothing below claims to resolve them.
     result to use the *dimension* of the ambient plane rather than only metric/combinatorial
     facts.
 
+18. `h5Config` / `numDistinctDistances_h5Config_le` / `h_five_le_three` / `h_five_bounds`
+    — **`h 5 ≤ 3`**, hence `2 ≤ h 5 ≤ 3`. The explicit five points `(0,0), (1,0),
+    (−√3⁄2,−½), (½,√3⁄2), (½,−(2+√3)⁄2)` are in general position (no three collinear, no
+    four concyclic — the five circumscribed-circle determinants are all nonzero) and realize
+    *exactly three* distinct distances `1, √(2+√3), 1+√3`, giving `numDistinctDistances ≤ 3`.
+    The regular pentagon (the only planar 2-distance 5-set) is concyclic, so `h 5 = 3` is
+    expected; the matching lower bound `h 5 ≥ 3` needs that classification and is left open.
+
 ## Summary: 0 sorries, 0 axioms, no `native_decide`. Built over the gallery defs.
 -/
 
@@ -1382,5 +1390,250 @@ first to use both nondegeneracy hypotheses non-vacuously together with the plana
 dimension bound. -/
 theorem h_four : h 4 = 2 :=
   le_antisymm h_four_le_two h_four_ge_two
+
+/-! ## The upper bound `h 5 ≤ 3` via an explicit three-distance five-point witness
+
+For five points the pinning of `h` runs into genuine difficulty: the linear lower bound
+`three_mul_h_ge 5` gives only `h 5 ≥ 2`, and monotonicity (`h_four`, `h_mono`) gives the
+same `h 5 ≥ 2`, while the natural 2-distance candidate — the **regular pentagon** — is
+*disqualified* (its five vertices are concyclic).  Indeed the only planar 2-distance set
+of five points is the regular pentagon, so no general-position 5-set has two distances and
+in fact `h 5 = 3`; the matching lower bound `h 5 ≥ 3` requires that classification and is
+left open here.
+
+What *is* elementary is the **upper bound** `h 5 ≤ 3`.  The five points
+
+  `A = (0,0)`, `B = (1,0)`, `C = (−√3⁄2, −½)`, `D = (½, √3⁄2)`, `E = (½, −(2+√3)⁄2)`
+
+realize **exactly three** distinct distances — `1`, `√(2+√3)`, and `1+√3` — with the
+multiplicities
+
+  `1`         : `AB, AC, AD, BD`            (four pairs, squared distance `1`),
+  `√(2+√3)`   : `AE, BC, BE, CD, CE`        (five pairs, squared distance `2+√3`),
+  `1+√3`      : `DE`                        (one pair, squared distance `(1+√3)² = 4+2√3`).
+
+The configuration is in general position: no three of the five are collinear (all ten
+triangle areas are nonzero), and no four are concyclic (each of the five quadruples has a
+nonzero circumscribed-circle determinant — `1+√3⁄2`, `2+√3`, `5⁄2+3√3⁄2`).  Hence it
+witnesses `h 5 ≤ numDistinctDistances ≤ 3`, trapping `2 ≤ h 5 ≤ 3`. -/
+
+/-- The explicit five-point configuration `A=(0,0)`, `B=(1,0)`, `C=(−√3⁄2,−½)`,
+`D=(½,√3⁄2)`, `E=(½,−(2+√3)⁄2)` in `ℝ²`.  A three-distance set (`1`, `√(2+√3)`, `1+√3`)
+in general position — the first configuration in the file whose distinct-distance count is
+exactly three. -/
+noncomputable def h5Config : PointConfig 5 :=
+  ![!₂[0, 0], !₂[1, 0], !₂[-(Real.sqrt 3 / 2), -(1 / 2)],
+    !₂[1 / 2, Real.sqrt 3 / 2], !₂[1 / 2, -((2 + Real.sqrt 3) / 2)]]
+
+set_option maxHeartbeats 1600000 in
+/-- **Every pairwise squared distance of `h5Config` is `1`, `2+√3`, or `(1+√3)²`.** A direct
+coordinate computation over all off-diagonal pairs, using `√3² = 3`. -/
+theorem h5Config_dist_sq {i j : Fin 5} (hij : i ≠ j) :
+    dist (h5Config i) (h5Config j) ^ 2 = 1 ∨
+    dist (h5Config i) (h5Config j) ^ 2 = 2 + Real.sqrt 3 ∨
+    dist (h5Config i) (h5Config j) ^ 2 = (1 + Real.sqrt 3) ^ 2 := by
+  have hs2 : Real.sqrt 3 ^ 2 = 3 := Real.sq_sqrt (by norm_num)
+  fin_cases i <;> fin_cases j <;>
+    first
+    | exact absurd rfl hij
+    | (simp only [h5Config, EuclideanSpace.dist_sq_eq, Fin.sum_univ_two, Real.dist_eq, sq_abs,
+         Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.cons_val_two, Matrix.cons_val_three,
+         Matrix.cons_val_four, Matrix.head_cons, Matrix.tail_cons]
+       first
+       | (left; nlinarith [hs2])
+       | (right; left; nlinarith [hs2])
+       | (right; right; nlinarith [hs2]))
+
+/-- **Every pairwise distance of `h5Config` lies in `{1, √(2+√3), 1+√3}`.** The nonnegative
+square root of `h5Config_dist_sq`; `(1+√3)² ↦ 1+√3` since `1+√3 ≥ 0`. -/
+theorem h5Config_dist_mem {i j : Fin 5} (hij : i ≠ j) :
+    dist (h5Config i) (h5Config j) ∈
+      ({1, Real.sqrt (2 + Real.sqrt 3), 1 + Real.sqrt 3} : Finset ℝ) := by
+  have hd0 : 0 ≤ dist (h5Config i) (h5Config j) := dist_nonneg
+  have h3nn : (0 : ℝ) ≤ 1 + Real.sqrt 3 := by positivity
+  rcases h5Config_dist_sq hij with h | h | h
+  · have he : dist (h5Config i) (h5Config j) = 1 := by
+      rw [← Real.sqrt_sq hd0, h, Real.sqrt_one]
+    simp [he]
+  · have he : dist (h5Config i) (h5Config j) = Real.sqrt (2 + Real.sqrt 3) := by
+      rw [← Real.sqrt_sq hd0, h]
+    simp [he]
+  · have he : dist (h5Config i) (h5Config j) = 1 + Real.sqrt 3 := by
+      rw [← Real.sqrt_sq hd0, h, Real.sqrt_sq h3nn]
+    simp [he]
+
+/-- The five points are distinct: every pairwise distance lies in `{1, √(2+√3), 1+√3}`, all
+of whose elements are positive, so equal indices are forced. -/
+theorem h5Config_injective : Function.Injective h5Config := by
+  intro i j hij
+  by_contra hne
+  have hmem := h5Config_dist_mem hne
+  rw [hij, dist_self] at hmem
+  simp only [Finset.mem_insert, Finset.mem_singleton] at hmem
+  have hs : (0 : ℝ) < Real.sqrt 3 := Real.sqrt_pos.mpr (by norm_num)
+  have hs2 : (0 : ℝ) < Real.sqrt (2 + Real.sqrt 3) := Real.sqrt_pos.mpr (by positivity)
+  rcases hmem with h | h | h
+  · norm_num at h
+  · linarith [hs2]
+  · linarith [hs]
+
+set_option maxHeartbeats 1600000 in
+/-- **No three of the five points are collinear.** A line through any three forces
+`(a,b,c) = 0`; the cases involving the `√3`-abscissa points need `√3 > 0`. -/
+theorem noThreeCollinear_h5Config : NoThreeCollinear h5Config := by
+  have hs : (0 : ℝ) < Real.sqrt 3 := Real.sqrt_pos.mpr (by norm_num)
+  have hs2 : Real.sqrt 3 ^ 2 = 3 := Real.sq_sqrt (by norm_num)
+  intro i j k hcard
+  rintro ⟨a, b, c, hne, hi, hj, hk⟩
+  apply hne
+  fin_cases i <;> fin_cases j <;> fin_cases k <;>
+    first
+    | exact absurd hcard (by decide)
+    | (simp only [h5Config] at hi hj hk
+       norm_num at hi hj hk
+       simp only [Prod.mk.injEq]
+       refine ⟨?_, ?_, ?_⟩ <;> nlinarith [hs, hs2, hi, hj, hk])
+
+/-- No centre is equidistant from `A, B, C, D` (`h5Config 0,1,2,3`). The three
+squared-distance equalities relative to `A` are linear in the centre and inconsistent. -/
+theorem h5_not_equidistant_0123 (center : EuclideanSpace ℝ (Fin 2)) (r : ℝ)
+    (h0 : dist center (h5Config 0) = r) (h1 : dist center (h5Config 1) = r)
+    (h2 : dist center (h5Config 2) = r) (h3 : dist center (h5Config 3) = r) : False := by
+  have hs2 : Real.sqrt 3 ^ 2 = 3 := Real.sq_sqrt (by norm_num)
+  have e01 : dist center (h5Config 0) ^ 2 = dist center (h5Config 1) ^ 2 := by rw [h0, h1]
+  have e02 : dist center (h5Config 0) ^ 2 = dist center (h5Config 2) ^ 2 := by rw [h0, h2]
+  have e03 : dist center (h5Config 0) ^ 2 = dist center (h5Config 3) ^ 2 := by rw [h0, h3]
+  simp only [h5Config, EuclideanSpace.dist_sq_eq, Fin.sum_univ_two, Real.dist_eq, sq_abs,
+    Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.cons_val_two, Matrix.cons_val_three,
+    Matrix.cons_val_four, Matrix.head_cons, Matrix.tail_cons] at e01 e02 e03
+  nlinarith [e01, e02, e03, hs2]
+
+/-- No centre is equidistant from `A, B, C, E` (`h5Config 0,1,2,4`). -/
+theorem h5_not_equidistant_0124 (center : EuclideanSpace ℝ (Fin 2)) (r : ℝ)
+    (h0 : dist center (h5Config 0) = r) (h1 : dist center (h5Config 1) = r)
+    (h2 : dist center (h5Config 2) = r) (h4 : dist center (h5Config 4) = r) : False := by
+  have hs2 : Real.sqrt 3 ^ 2 = 3 := Real.sq_sqrt (by norm_num)
+  have e01 : dist center (h5Config 0) ^ 2 = dist center (h5Config 1) ^ 2 := by rw [h0, h1]
+  have e02 : dist center (h5Config 0) ^ 2 = dist center (h5Config 2) ^ 2 := by rw [h0, h2]
+  have e04 : dist center (h5Config 0) ^ 2 = dist center (h5Config 4) ^ 2 := by rw [h0, h4]
+  simp only [h5Config, EuclideanSpace.dist_sq_eq, Fin.sum_univ_two, Real.dist_eq, sq_abs,
+    Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.cons_val_two, Matrix.cons_val_three,
+    Matrix.cons_val_four, Matrix.head_cons, Matrix.tail_cons] at e01 e02 e04
+  nlinarith [e01, e02, e04, hs2]
+
+/-- No centre is equidistant from `A, B, D, E` (`h5Config 0,1,3,4`). -/
+theorem h5_not_equidistant_0134 (center : EuclideanSpace ℝ (Fin 2)) (r : ℝ)
+    (h0 : dist center (h5Config 0) = r) (h1 : dist center (h5Config 1) = r)
+    (h3 : dist center (h5Config 3) = r) (h4 : dist center (h5Config 4) = r) : False := by
+  have hs2 : Real.sqrt 3 ^ 2 = 3 := Real.sq_sqrt (by norm_num)
+  have e01 : dist center (h5Config 0) ^ 2 = dist center (h5Config 1) ^ 2 := by rw [h0, h1]
+  have e03 : dist center (h5Config 0) ^ 2 = dist center (h5Config 3) ^ 2 := by rw [h0, h3]
+  have e04 : dist center (h5Config 0) ^ 2 = dist center (h5Config 4) ^ 2 := by rw [h0, h4]
+  simp only [h5Config, EuclideanSpace.dist_sq_eq, Fin.sum_univ_two, Real.dist_eq, sq_abs,
+    Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.cons_val_two, Matrix.cons_val_three,
+    Matrix.cons_val_four, Matrix.head_cons, Matrix.tail_cons] at e01 e03 e04
+  nlinarith [e01, e03, e04, hs2]
+
+/-- No centre is equidistant from `A, C, D, E` (`h5Config 0,2,3,4`). -/
+theorem h5_not_equidistant_0234 (center : EuclideanSpace ℝ (Fin 2)) (r : ℝ)
+    (h0 : dist center (h5Config 0) = r) (h2 : dist center (h5Config 2) = r)
+    (h3 : dist center (h5Config 3) = r) (h4 : dist center (h5Config 4) = r) : False := by
+  have hs2 : Real.sqrt 3 ^ 2 = 3 := Real.sq_sqrt (by norm_num)
+  have e02 : dist center (h5Config 0) ^ 2 = dist center (h5Config 2) ^ 2 := by rw [h0, h2]
+  have e03 : dist center (h5Config 0) ^ 2 = dist center (h5Config 3) ^ 2 := by rw [h0, h3]
+  have e04 : dist center (h5Config 0) ^ 2 = dist center (h5Config 4) ^ 2 := by rw [h0, h4]
+  simp only [h5Config, EuclideanSpace.dist_sq_eq, Fin.sum_univ_two, Real.dist_eq, sq_abs,
+    Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.cons_val_two, Matrix.cons_val_three,
+    Matrix.cons_val_four, Matrix.head_cons, Matrix.tail_cons] at e02 e03 e04
+  nlinarith [e02, e03, e04, hs2]
+
+/-- No centre is equidistant from `B, C, D, E` (`h5Config 1,2,3,4`). -/
+theorem h5_not_equidistant_1234 (center : EuclideanSpace ℝ (Fin 2)) (r : ℝ)
+    (h1 : dist center (h5Config 1) = r) (h2 : dist center (h5Config 2) = r)
+    (h3 : dist center (h5Config 3) = r) (h4 : dist center (h5Config 4) = r) : False := by
+  have hs2 : Real.sqrt 3 ^ 2 = 3 := Real.sq_sqrt (by norm_num)
+  have e12 : dist center (h5Config 1) ^ 2 = dist center (h5Config 2) ^ 2 := by rw [h1, h2]
+  have e13 : dist center (h5Config 1) ^ 2 = dist center (h5Config 3) ^ 2 := by rw [h1, h3]
+  have e14 : dist center (h5Config 1) ^ 2 = dist center (h5Config 4) ^ 2 := by rw [h1, h4]
+  simp only [h5Config, EuclideanSpace.dist_sq_eq, Fin.sum_univ_two, Real.dist_eq, sq_abs,
+    Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.cons_val_two, Matrix.cons_val_three,
+    Matrix.cons_val_four, Matrix.head_cons, Matrix.tail_cons] at e12 e13 e14
+  nlinarith [e12, e13, e14, hs2]
+
+set_option maxHeartbeats 1600000 in
+/-- **No four of the five points are concyclic.** Every 4-subset is one of the five
+quadruples, and for each no centre is equidistant from its members
+(`h5_not_equidistant_*`), so no common circle exists. -/
+theorem noFourConcyclic_h5Config : NoFourConcyclic h5Config := by
+  intro a b c d hcard
+  rintro ⟨center, r, ha, hb, hc, hd⟩
+  fin_cases a <;> fin_cases b <;> fin_cases c <;> fin_cases d <;>
+    first
+    | exact absurd hcard (by decide)
+    | exact h5_not_equidistant_0123 center r (by assumption) (by assumption) (by assumption)
+        (by assumption)
+    | exact h5_not_equidistant_0124 center r (by assumption) (by assumption) (by assumption)
+        (by assumption)
+    | exact h5_not_equidistant_0134 center r (by assumption) (by assumption) (by assumption)
+        (by assumption)
+    | exact h5_not_equidistant_0234 center r (by assumption) (by assumption) (by assumption)
+        (by assumption)
+    | exact h5_not_equidistant_1234 center r (by assumption) (by assumption) (by assumption)
+        (by assumption)
+
+/-- **`h5Config` is in general position.** -/
+theorem inGeneralPosition_h5Config : InGeneralPosition h5Config :=
+  ⟨h5Config_injective, noThreeCollinear_h5Config, noFourConcyclic_h5Config⟩
+
+/-- **`h5Config` realizes at most three distinct distances.** Every positive pairwise
+distance lies in the three-element set `{1, √(2+√3), 1+√3}` (`h5Config_dist_mem`), so the
+distinct-distance count is at most `3`. -/
+theorem numDistinctDistances_h5Config_le :
+    numDistinctDistances h5Config ≤ 3 := by
+  unfold numDistinctDistances
+  have hsub :
+      ((univ.product univ).image
+          (fun p : Fin 5 × Fin 5 =>
+            dist (h5Config p.1) (h5Config p.2))).filter (· > 0)
+        ⊆ ({1, Real.sqrt (2 + Real.sqrt 3), 1 + Real.sqrt 3} : Finset ℝ) := by
+    intro d hd
+    rw [mem_filter, mem_image] at hd
+    obtain ⟨⟨p, -, hpd⟩, hpos⟩ := hd
+    have hne : p.1 ≠ p.2 := by
+      intro he
+      rw [he, dist_self] at hpd
+      rw [← hpd] at hpos
+      exact lt_irrefl 0 hpos
+    rw [← hpd]
+    exact h5Config_dist_mem hne
+  calc (((univ.product univ).image
+          (fun p : Fin 5 × Fin 5 =>
+            dist (h5Config p.1) (h5Config p.2))).filter (· > 0)).card
+      ≤ ({1, Real.sqrt (2 + Real.sqrt 3), 1 + Real.sqrt 3} : Finset ℝ).card := card_le_card hsub
+    _ ≤ 3 := by
+        refine (Finset.card_insert_le _ _).trans ?_
+        have h2 : ({Real.sqrt (2 + Real.sqrt 3), 1 + Real.sqrt 3} : Finset ℝ).card ≤ 2 := by
+          refine (Finset.card_insert_le _ _).trans ?_
+          simp
+        omega
+
+/-- **`h 5 ≤ 3`, an exact upper bound.** The three-distance witness `h5Config` is in general
+position and realizes at most three distinct distances, so it bounds the minimum:
+`h 5 ≤ numDistinctDistances ≤ 3`. -/
+theorem h_five_le_three : h 5 ≤ 3 :=
+  le_trans (h_le_of_inGeneralPosition inGeneralPosition_h5Config)
+    numDistinctDistances_h5Config_le
+
+/-- **`h 5 ≥ 2`.** From `h 4 = 2` (`h_four_ge_two`) and monotonicity (`h_mono`, `4 ≤ 5`). -/
+theorem h_five_ge_two : 2 ≤ h 5 :=
+  le_trans h_four_ge_two (h_mono (by norm_num))
+
+/-- **`2 ≤ h 5 ≤ 3`.** The three-distance witness gives the upper bound; monotonicity from
+`h 4 = 2` gives the lower bound.  Pinning `h 5 = 3` additionally requires `h 5 ≥ 3` — no
+general-position five-set has only two distinct distances — which reduces to the
+classification of planar 2-distance sets (the regular pentagon, which is concyclic) and is
+left as the next step. -/
+theorem h_five_bounds : 2 ≤ h 5 ∧ h 5 ≤ 3 :=
+  ⟨h_five_ge_two, h_five_le_three⟩
 
 end Erdos98WIP01

--- a/proofs/Proofs/Erdos98WIP01.lean
+++ b/proofs/Proofs/Erdos98WIP01.lean
@@ -1433,16 +1433,15 @@ theorem h5Config_dist_sq {i j : Fin 5} (hij : i ≠ j) :
     dist (h5Config i) (h5Config j) ^ 2 = 2 + Real.sqrt 3 ∨
     dist (h5Config i) (h5Config j) ^ 2 = (1 + Real.sqrt 3) ^ 2 := by
   have hs2 : Real.sqrt 3 ^ 2 = 3 := Real.sq_sqrt (by norm_num)
+  rw [EuclideanSpace.dist_sq_eq]
   fin_cases i <;> fin_cases j <;>
     first
     | exact absurd rfl hij
-    | (simp only [h5Config, EuclideanSpace.dist_sq_eq, Fin.sum_univ_two, Real.dist_eq, sq_abs,
-         Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.cons_val_two, Matrix.cons_val_three,
-         Matrix.cons_val_four, Matrix.head_cons, Matrix.tail_cons]
+    | (simp only [h5Config, Fin.sum_univ_two, Real.dist_eq, sq_abs]
        first
-       | (left; nlinarith [hs2])
-       | (right; left; nlinarith [hs2])
-       | (right; right; nlinarith [hs2]))
+       | (left; norm_num [hs2] <;> nlinarith [hs2])
+       | (right; left; norm_num [hs2] <;> nlinarith [hs2])
+       | (right; right; norm_num [hs2] <;> nlinarith [hs2]))
 
 /-- **Every pairwise distance of `h5Config` lies in `{1, √(2+√3), 1+√3}`.** The nonnegative
 square root of `h5Config_dist_sq`; `(1+√3)² ↦ 1+√3` since `1+√3 ≥ 0`. -/

--- a/research/problems/erdos-98-wip-01/knowledge.md
+++ b/research/problems/erdos-98-wip-01/knowledge.md
@@ -1,5 +1,55 @@
 # Knowledge Base: erdos-98-wip-01
 
+## Session 2026-07-21 (researcher-1) — h 5 ≤ 3 via explicit 3-distance general-position 5-witness
+
+**Mode**: FRESH (continue). **Outcome**: progress — `h 5 ≤ 3`, so `2 ≤ h 5 ≤ 3`.
+**docker-built** `Proofs.Erdos98WIP01` OK (0 sorry / 0 axiom / no `native_decide`;
+`#print axioms Erdos98WIP01.h_five_le_three` = `[propext, Classical.choice, Quot.sound]` only).
+
+Continued the pinned-values line past `h 4 = 2`. The lower-bound side of `h 5` is hard, so
+this session establishes the **upper bound** with a fully machine-checked explicit witness.
+
+**The witness `h5Config : PointConfig 5`.** Found by continuous optimization (minimize
+within-cluster spread of the 10 pairwise distances subject to general-position penalties,
+including a no-4-concyclic determinant penalty — omitting it first produced the degenerate
+"centre + 4 on a circle"), then rationalized and **sympy-verified exactly**:
+
+    A=(0,0), B=(1,0), C=(−√3⁄2,−½), D=(½,√3⁄2), E=(½,−(2+√3)⁄2)
+
+- **Exactly three distinct distances** `1`, `√(2+√3)`, `1+√3` (squared: `1`, `2+√3`,
+  `(1+√3)²=4+2√3`). Multiplicities `1`: AB,AC,AD,BD; `√(2+√3)`: AE,BC,BE,CD,CE; `1+√3`: DE.
+- **No 3 collinear**: all 10 triangle areas ≠ 0. **No 4 concyclic**: the 5 circumscribed-
+  circle determinants are `1+√3⁄2`, `2+√3`, `5⁄2+3√3⁄2` (all ≠ 0).
+
+**Lean results added** (`proofs/Proofs/Erdos98WIP01.lean`, item 18):
+`h5Config`, `h5Config_dist_sq`, `h5Config_dist_mem` (dist ∈ {1,√(2+√3),1+√3}),
+`h5Config_injective`, `noThreeCollinear_h5Config`, `noFourConcyclic_h5Config` (dispatched
+to five per-quadruple `h5_not_equidistant_*` helpers), `inGeneralPosition_h5Config`,
+`numDistinctDistances_h5Config_le` (≤ 3), `h_five_le_three` (`h 5 ≤ 3`),
+`h_five_ge_two` (`2 ≤ h 5`, from `h_four_ge_two` + `h_mono`), `h_five_bounds`.
+
+**Why not `h 5 = 3`.** Both natural lower-bound routes give only `h 5 ≥ 2`
+(`three_mul_h_ge 5` = `⌈4/3⌉ = 2`; `h_mono` from `h 4 = 2`). Pinning `h 5 = 3` needs
+`h 5 ≥ 3`: no general-position 5-set has ≤ 2 distances. The regular pentagon (the only
+planar 2-distance 5-set) is concyclic, so this reduces to the **classification of planar
+2-distance sets** (max 5, the pentagon) or the **Larman–Rogers–Seidel** linear-algebra
+bound (a 2-distance set in ℝ² has ≤ 6 points) refined by no-4-concyclic to ≤ 4. Left open.
+
+**Reusable tactic notes.** `!₂[·]` coordinate accessors reduce under `norm_num`, not by
+`simp only [Matrix.cons_val_*]` alone — the distance-value lemma needs
+`rw [EuclideanSpace.dist_sq_eq]; … simp only […]; norm_num [hs2] <;> nlinarith [hs2]`
+(bare `nlinarith` after `simp` fails on the value-1 √3 pairs). The no-4-concyclic proof
+for 5 points is cheap when factored as one `not_equidistant` helper per unordered quadruple
+(5 total `nlinarith` calls) with `noFourConcyclic` doing `fin_cases … <;> first | … | exact
+h5_not_equidistant_XYZW center r (by assumption) …`.
+
+**Files modified**: `proofs/Proofs/Erdos98WIP01.lean` (+~180 lines),
+`src/data/research/problems/erdos-98-wip-01.json`, this file.
+
+**Next**: prove `h 5 ≥ 3` (2-distance-set classification); abstract "1-distance set in ℝ^d
+has ≤ d+1 points"; sharpen the general `(n−1)/3` lower bound.
+
+
 ## Session 2026-07-21 (researcher-1) — pinned value h 4 = 2 (first value of h exceeding 1)
 
 **Mode**: FRESH (continue). **Outcome**: progress — `h 4 = 2` pinned exactly.

--- a/src/data/research/problems/erdos-98-wip-01.json
+++ b/src/data/research/problems/erdos-98-wip-01.json
@@ -31,7 +31,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: h 2 = h 3 = 1 and now h 4 = 2 all pinned exactly. h 4 = 2 uses the equilateral+centroid witness (h 4 ≤ 2, square disqualified as concyclic) and the impossibility of 4 equidistant points in the plane (h 4 ≥ 2, Gram/dimension). First value of h exceeding 1. Parent rate h(n)/n → ∞ (Erdős #98) OPEN.",
+    "progressSummary": "PROGRESS: h 2 = h 3 = 1, h 4 = 2 pinned exactly; now h 5 ≤ 3 via an explicit 3-distance general-position 5-point witness (2 ≤ h 5 ≤ 3). Pinning h 5 = 3 awaits the lower bound h 5 ≥ 3 (planar 2-distance-set classification). Parent rate h(n)/n → ∞ (Erdős #98) OPEN.",
     "builtItems": [
       "InGeneralPosition.injective in Erdos98WIP01.lean",
       "numDistinctDistances_le_offDiag (≤ n·(n−1)) in Erdos98WIP01.lean",
@@ -72,7 +72,11 @@
       "centeredTriangleConfig + centeredTriangleConfig_dist_mem/injective + noThreeCollinear/noFourConcyclic/inGeneralPosition_centeredTriangleConfig (Erdos98WIP01.lean): explicit equilateral+centroid general-position 4-config",
       "numDistinctDistances_centeredTriangleConfig_le + h_four_le_two: h 4 ≤ 2 (Erdos98WIP01.lean)",
       "not_four_equidistant + two_le_numDistinctDistances_four + h_four_ge_two: h 4 ≥ 2 via Gram/linear-independence + planar dimension (Erdos98WIP01.lean)",
-      "h_four : h 4 = 2 — pinned exactly, #print axioms = [propext, Classical.choice, Quot.sound]"
+      "h_four : h 4 = 2 — pinned exactly, #print axioms = [propext, Classical.choice, Quot.sound]",
+      "h5Config (PointConfig 5) + h5Config_dist_sq/h5Config_dist_mem: all pairwise dist ∈ {1,√(2+√3),1+√3} — Proofs/Erdos98WIP01.lean",
+      "h5Config_injective, noThreeCollinear_h5Config, noFourConcyclic_h5Config (via 5 per-quadruple h5_not_equidistant_* helpers), inGeneralPosition_h5Config",
+      "numDistinctDistances_h5Config_le : numDistinctDistances h5Config ≤ 3",
+      "h_five_le_three : h 5 ≤ 3 ; h_five_ge_two : 2 ≤ h 5 ; h_five_bounds : 2 ≤ h 5 ∧ h 5 ≤ 3 (all axiom-clean: [propext, Classical.choice, Quot.sound])"
     ],
     "insights": [
       "Every positive pairwise distance comes from an off-diagonal ordered pair (dist>0 ⟹ points distinct ⟹ indices distinct), giving the clean upper bound numDistinctDistances P ≤ n·(n−1) via Finset.offDiag_card — the trivial ceiling of the h(n) envelope.",
@@ -97,13 +101,19 @@
       "EuclideanSpace.dist_sq_eq introduces an .ofLp coordinate wrapper that Matrix.cons_val lemmas do NOT reduce; use EuclideanSpace.dist_eq (direct application) + norm_num to reduce !₂[..] k coordinate accesses, then nlinarith with (√3)^2=3 for the diagonal side",
       "h 4 = 2 pinned exactly. Upper bound h 4 ≤ 2 via the equilateral-triangle-plus-centroid config (0,0),(1,0),(−1/2,√3/2),(−1/2,−√3/2): a 2-distance set (circumradius 1, side √3). The classical minimal witness — the square — is DISQUALIFIED because its 4 vertices are concyclic (general position forbids 4 concyclic).",
       "Lower bound h 4 ≥ 2: four pairwise-equidistant points are impossible in ℝ². Proof: the 3 difference vectors p_{k+1}−p_0 have Gram matrix r²·½(I+J) (self inner product r², cross r²/2), which is nonsingular, so they are linearly independent; but dim(ℝ²)=2, contradicting LinearIndependent.fintype_card_le_finrank (3 ≤ 2). First use of the ambient DIMENSION rather than only metric/combinatorial facts.",
-      "Reusable idiom: to rule out a 1-distance n-set, take difference vectors from a base point, compute the Gram matrix from equidistance (real_inner_self_eq_norm_sq, norm_sub_sq_real), prove linear independence via Fintype.linearIndependent_iff + inner products (sum_inner, real_inner_smul_left), then LinearIndependent.fintype_card_le_finrank vs finrank_euclideanSpace_fin."
+      "Reusable idiom: to rule out a 1-distance n-set, take difference vectors from a base point, compute the Gram matrix from equidistance (real_inner_self_eq_norm_sq, norm_sub_sq_real), prove linear independence via Fintype.linearIndependent_iff + inner products (sum_inner, real_inner_smul_left), then LinearIndependent.fintype_card_le_finrank vs finrank_euclideanSpace_fin.",
+      "h 5 ≤ 3: explicit general-position 5-point witness with exactly 3 distinct distances. Points (0,0),(1,0),(−√3/2,−1/2),(1/2,√3/2),(1/2,−(2+√3)/2); distances 1 (×4), √(2+√3) (×5), 1+√3 (×1). Sympy-verified: 10 triple areas ≠0 (no 3 collinear), 5 circumcircle dets ≠0 (no 4 concyclic: 1+√3/2, 2+√3, 5/2+3√3/2).",
+      "Both natural lower-bound routes give only h 5 ≥ 2: three_mul_h_ge 5 (⌈4/3⌉=2) and monotonicity from h 4 = 2. So 2 ≤ h 5 ≤ 3, expected h 5 = 3.",
+      "The regular pentagon (only planar 2-distance 5-set) is concyclic, so no general-position 5-set has 2 distances; proving h 5 ≥ 3 reduces to the classification of planar 2-distance sets (or the Larman–Rogers–Seidel linear-algebra bound + concyclic refinement).",
+      "Empirical: no triangular-lattice 5-cap (origin-fixed radius ≤4) has ≤3 distinct distances in general position; the 3-distance witness needs the off-lattice point E=(1/2,−(2+√3)/2). Bowtie/centered-triangle + 1 point always lands the 5th on a lattice line (3 collinear) or on the shared circle (4 concyclic)."
     ],
-    "mathlibGaps": [],
+    "mathlibGaps": [
+      "Classification of planar 2-distance sets (max 5 points = regular pentagon, unique up to similarity) is absent from Mathlib — needed for h 5 ≥ 3."
+    ],
     "nextSteps": [
-      "Pin h 5: lower bound likely still 2 (a 2-distance general-position 5-set may exist? regular pentagon is concyclic — disqualified; need a non-concyclic 5-point 2- or 3-distance set) — determine h 5 exactly.",
-      "General lower bound sharper than (n−1)/3: does no-four-concyclic + no-three-collinear force h n ≥ cn for some explicit c, or at least h n ≥ 2 for all n ≥ 4 (already have) and monotone growth of the pinned values.",
-      "Abstract the Gram/dimension argument into a reusable lemma: a 1-distance set in ℝ^d has ≤ d+1 points (equidistant ⟹ affine/linear independent)."
+      "Prove h 5 ≥ 3: no general-position 5-set has ≤2 distinct distances. Route A: classify planar 2-distance 5-sets (regular pentagon, concyclic). Route B: Larman–Rogers–Seidel bound (a 2-distance set in ℝ² has ≤ 6 points) + refine with no-4-concyclic to ≤4.",
+      "Abstract the Gram/dimension argument into a reusable lemma: a 1-distance set in ℝ^d has ≤ d+1 points.",
+      "General lower bound sharper than (n−1)/3 using both nondegeneracy hypotheses."
     ],
     "markdown": "# Knowledge Base: erdos-98-wip-01\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },


### PR DESCRIPTION
## Summary

Extends the pinned distinct-distance minima for **Erdős #98** (general-position distinct
distances, `erdos-98-wip-01`) past `h 4 = 2`. This PR proves the **upper bound `h 5 ≤ 3`**
via an explicit general-position five-point configuration realizing exactly three distinct
distances, giving `2 ≤ h 5 ≤ 3`.

`h(n)` = minimum number of distinct distances among `n` points in ℝ² in general position
(no three collinear, no four concyclic). Prior merged work pins `h 2 = h 3 = 1` and
`h 4 = 2`.

## The witness `h5Config`

    A=(0,0), B=(1,0), C=(−√3⁄2,−½), D=(½,√3⁄2), E=(½,−(2+√3)⁄2)

- **Exactly three distinct distances** `1`, `√(2+√3)`, `1+√3` (squared distances `1`,
  `2+√3`, `(1+√3)² = 4+2√3`). Multiplicities: `1` on AB,AC,AD,BD; `√(2+√3)` on
  AE,BC,BE,CD,CE; `1+√3` on DE.
- **General position** — no three of the five are collinear (all ten triangle areas
  nonzero), and no four are concyclic (the five circumscribed-circle determinants are
  `1+√3⁄2`, `2+√3`, `5⁄2+3√3⁄2`, all nonzero). Both facts were verified exactly in `sympy`
  before formalization.

## New declarations (`proofs/Proofs/Erdos98WIP01.lean`, item 18)

`h5Config`, `h5Config_dist_sq`, `h5Config_dist_mem`, `h5Config_injective`,
`noThreeCollinear_h5Config`, `noFourConcyclic_h5Config` (via five per-quadruple
`h5_not_equidistant_*` helpers), `inGeneralPosition_h5Config`,
`numDistinctDistances_h5Config_le` (`≤ 3`), `h_five_le_three` (`h 5 ≤ 3`),
`h_five_ge_two` (`2 ≤ h 5`), `h_five_bounds` (`2 ≤ h 5 ∧ h 5 ≤ 3`).

## Verification

- `docker-build.sh Proofs.Erdos98WIP01` succeeds.
- **0 sorries, 0 `axiom` declarations, no `native_decide`.**
- `#print axioms Erdos98WIP01.h_five_le_three` = `[propext, Classical.choice, Quot.sound]`
  (standard foundational axioms only).

## Honest scope

Parent **Erdős #98** (`h(n)/n → ∞`) remains **OPEN**. This PR pins one more value from
above, not the conjectured rate. Pinning `h 5 = 3` exactly additionally requires the lower
bound `h 5 ≥ 3` — no general-position five-set has only two distinct distances — which
reduces to the classification of planar 2-distance sets (the regular pentagon, which is
concyclic) and is left as the next step. Both elementary lower-bound routes currently give
only `h 5 ≥ 2` (`three_mul_h_ge 5` and monotonicity from `h 4 = 2`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
