### PR TITLE
Enrich roth-theorem-k3-oq-03: re-anchor 11 drifted Part sections (1..472/EOF)

### DIFF
--- a/src/data/proofs/roth-theorem-k3-oq-03/meta.json
+++ b/src/data/proofs/roth-theorem-k3-oq-03/meta.json
@@ -51,87 +51,87 @@
       "title": "Module Header and Namespace",
       "summary": "File header and `RothTheoremOQ03` namespace for the OQ-03 study of how Roth's $k=3$ theorem extends to $k$-term progressions (Szemerédi) via the Gowers-norm / density-increment framework.",
       "startLine": 1,
-      "endLine": 32,
+      "endLine": 33,
       "mathContext": "Roth ($k=3$) vs Szemerédi ($k\\ge3$): both via density increment, but $k=3$ uses Fourier ($U^2$) while $k\\ge4$ needs Gowers $U^{k-1}$ norms."
     },
     {
       "id": "part1-kap-free",
       "title": "Part I: k-AP-Free Sets in ZMod N",
       "summary": "Defines `IsKAPFreeZMod A k` (no $k$-term arithmetic progression in $A\\subseteq\\mathbb{Z}/N$) and proves it agrees with the existing `APFree` predicate at $k=3$ (`apFree_of_isKAPFreeZMod_three`, `isKAPFreeZMod_three_of_apFree`).",
-      "startLine": 33,
-      "endLine": 64,
+      "startLine": 34,
+      "endLine": 62,
       "mathContext": "`IsKAPFreeZMod A k`: $A$ contains no nontrivial $k$-AP; equivalent to `APFree` for $k=3$."
     },
     {
       "id": "part1_5-structural-lemmas",
       "title": "Part I.5: Structural Lemmas for IsKAPFreeZMod",
       "summary": "Basic closure properties: `isKAPFreeZMod_empty`, `isKAPFreeZMod_subset`, `isKAPFreeZMod_succ` (monotone in $k$), `isKAPFreeZMod_singleton`, and `isKAPFreeZMod_three_iff_apFree`.",
-      "startLine": 65,
-      "endLine": 122,
+      "startLine": 63,
+      "endLine": 125,
       "mathContext": "$k$-AP-freeness is hereditary (subsets) and monotone in $k$; singletons are $k$-AP-free for $k\\ge2$."
     },
     {
       "id": "part2-gowers-norms",
       "title": "Part II: Gowers Uniformity Norms",
       "summary": "Defines the Gowers $U^s$ norm machinery: `hypercubeShift`, `conjugateByWeight`, and `gowersNorm N s f` — the analytic measure of (non-)uniformity used to count progressions.",
-      "startLine": 123,
-      "endLine": 161,
+      "startLine": 126,
+      "endLine": 164,
       "mathContext": "$\\|f\\|_{U^s}$ measures correlation with degree-$(s-1)$ structure; $U^2$ reduces to the Fourier $L^4$ norm."
     },
     {
       "id": "part3-kap-counting",
       "title": "Part III: k-AP Counting Operator",
       "summary": "Defines `kAPCount`, the multilinear operator $\\Lambda_k(f_1,\\dots,f_k)$ counting $k$-term progressions, whose deviation from the expected value is controlled by Gowers norms.",
-      "startLine": 162,
-      "endLine": 181,
+      "startLine": 165,
+      "endLine": 235,
       "mathContext": "$\\Lambda_k(f_1,\\dots,f_k)=\\mathbb{E}\\,f_1(x)f_2(x+d)\\cdots f_k(x+(k-1)d)$."
     },
     {
       "id": "part4-von-neumann",
       "title": "Part IV: Generalized von Neumann Theorem",
       "summary": "Commentary on the generalized von Neumann theorem ($|\\Lambda_k(f_1,\\dots,f_k)-\\prod\\mathbb{E}f_i|\\le\\min_i\\|f_i\\|_{U^{k-1}}$), whose proof needs the Gowers–Cauchy–Schwarz inequality — described but not axiomatized (beyond current Mathlib scope).",
-      "startLine": 182,
-      "endLine": 200,
+      "startLine": 236,
+      "endLine": 254,
       "mathContext": "Generalized von Neumann: the $k$-AP count is controlled by the $U^{k-1}$ norm of any factor."
     },
     {
       "id": "part5-inverse-theorem",
       "title": "Part V: The Inverse Theorem",
       "summary": "Commentary on the inverse theorem for Gowers norms (large $\\|f\\|_{U^s}$ implies correlation with a degree-$(s-1)$ nilsequence): the $s=2$ Fourier case underlies Roth, while $s\\ge3$ (Gowers 1998, Green–Tao–Ziegler 2012) needs nilmanifold infrastructure not yet in Mathlib — explicitly not axiomatized.",
-      "startLine": 201,
-      "endLine": 225,
+      "startLine": 255,
+      "endLine": 279,
       "mathContext": "Inverse theorem: $\\|f\\|_{U^2}\\ge\\delta\\Rightarrow$ large Fourier coefficient ($k=3$); $U^3\\Rightarrow$ quadratic phase ($k=4$)."
     },
     {
       "id": "part6-density-increment",
       "title": "Part VI: Density Increment for k-APs",
       "summary": "The single axiom `density_increment_kAP`: a $k$-AP-free set of density $\\delta$ has a subprogression where the (still $k$-AP-free) restriction has density $>\\delta$. The AP-free condition on the restriction is essential for iteration.",
-      "startLine": 226,
-      "endLine": 259,
+      "startLine": 280,
+      "endLine": 313,
       "mathContext": "Density increment: $k$-AP-free density $\\delta$ on $[N]$ $\\Rightarrow$ density $>\\delta$ on a subprogression — the engine of the Szemerédi proof."
     },
     {
       "id": "part7-szemeredi-connection",
       "title": "Part VII: Connection to Szemerédi's Theorem",
       "summary": "`szemeredi_from_density_increment`: iterating the density increment (density bounded by 1) forces a $k$-AP, yielding Szemerédi's theorem. Notes the remaining quantitative blocker — a lower bound $\\delta'\\ge\\delta+g(\\delta,k)$ with $g>0$.",
-      "startLine": 260,
-      "endLine": 365,
+      "startLine": 314,
+      "endLine": 419,
       "mathContext": "Iterate density increment until density $>1$ is forced — a contradiction unless a $k$-AP appears."
     },
     {
       "id": "part8-k3-case",
       "title": "Part VIII: k=3 Case (Proved from RothTheorem.lean)",
       "summary": "`density_increment_k3_explicit`: for $k=3$ the increment is explicit, $\\delta'\\ge\\delta+\\delta^2/100$, proved via the Fourier-analytic density increment in the sibling `RothTheorem.lean` (`Szemeredi.Roth.density_increment_lemma`).",
-      "startLine": 366,
-      "endLine": 392,
+      "startLine": 420,
+      "endLine": 446,
       "mathContext": "$k=3$: explicit Fourier increment $\\delta'\\ge\\delta+\\delta^2/100$ (Roth's quantitative bound)."
     },
     {
       "id": "part9-comparison",
       "title": "Part IX: Comparison: k=3 (Fourier) vs k≥4 (Gowers)",
       "summary": "A comparison table and discussion of why $k=3$ is special ($U^2=$ Fourier $L^4$, so direct Fourier analysis suffices) whereas $k\\ge4$ requires the deep inverse theorem for $U^{k-1}$ (nilsequences, hypergraph regularity, Gowers 2001).",
-      "startLine": 393,
-      "endLine": 419,
+      "startLine": 447,
+      "endLine": 472,
       "mathContext": "$k=3$: Fourier (large coefficient). $k\\ge4$: Gowers $U^{k-1}$ inverse theorem (nilsequence correlation) — qualitatively harder."
     }
   ],


### PR DESCRIPTION
Enrichment pass for `roth-theorem-k3-oq-03`.

**Drift re-anchor.** The `sections` array drifted increasingly toward the tail:
Part IV claimed lines 182-200 but its `-- PART IV` banner is at 236; Part VIII
claimed 366-392 vs actual banner @420; Part IX claimed 393-419 vs @447. The
uncovered tail (420-472) held the entire Part VIII `density_increment_k3_explicit`
theorem and the Part IX comparison table.

Re-anchored all 11 sections contiguously to their `-- PART` banners, covering
1..472/EOF (was maxEnd 419). Section summaries and `mathContext` preserved verbatim
— only `startLine`/`endLine` changed.

`axiomCount: 2` (`density_increment_kAP` in-file + `szemeredi_k_ge_4` inherited via
`Proofs.SzemerediTheorem`) verified accurate; `status: axiomatized`, `badge: axiom`
unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
