### PR TITLE
Enrich erdos-116: re-anchor drifted tail + cover Foundational Lemmas/Conjecture (7→9), 1..124/EOF

### DIFF
--- a/src/data/proofs/erdos-116/meta.json
+++ b/src/data/proofs/erdos-116/meta.json
@@ -80,25 +80,41 @@
       "id": "pommerenke",
       "title": "Pommerenke's Bound",
       "startLine": 49,
-      "endLine": 56,
-      "summary": "States the first polynomial lower bound: $\\mu(S_P) \\geq c/n^4$ for all unit disk polynomials. Proved using logarithmic potential theory.",
-      "mathContext": "States the first polynomial lower bound: $\\mu(S_P) \\geq c/$n^{4}$$ for all unit disk polynomials. Proved using logarithmic potential theory."
+      "endLine": 52,
+      "summary": "States (in header prose) Pommerenke's first polynomial lower bound $\\mu(S_P) \\geq c/n^4$ for all unit disk polynomials. Proved via logarithmic potential theory; not formalized here (the potential-theoretic machinery is not in Mathlib).",
+      "mathContext": "Pommerenke's lower bound: $\\mu(\\{|p(z)| < 1\\}) \\geq c/n^4$."
     },
     {
       "id": "klr",
-      "title": "KLR Bounds",
-      "startLine": 57,
-      "endLine": 73,
-      "summary": "States the optimal KLR lower bound $c/\\log n$ (resolving the conjecture) and the near-tight upper bound $C/\\log\\log n$ from extremal polynomial constructions.",
-      "mathContext": "States the optimal KLR lower bound $c/\\$\\log n$$ (resolving the conjecture) and the near-tight upper bound $C/\\log\\$\\log n$$ from extremal polynomial constructions."
+      "title": "Krishnapur–Lundberg–Ramachandran Bounds",
+      "startLine": 53,
+      "endLine": 60,
+      "summary": "States (in header prose) the optimal KLR lower bound $c/\\log n$ — which resolves the Erdős–Herzog–Piranian conjecture — together with the near-tight upper bound $C/\\log\\log n$ from extremal polynomial constructions. Stated in prose only.",
+      "mathContext": "KLR bounds: $c/\\log n \\leq \\mu(\\{|p(z)| < 1\\}) \\leq C/\\log\\log n$, optimal up to $\\log\\log$."
     },
     {
       "id": "polya",
       "title": "Pólya's Upper Bound",
-      "startLine": 74,
-      "endLine": 74,
-      "summary": "States $\\mu(S_P) \\leq \\pi$ for all unit disk polynomials, with equality iff all roots coincide.",
-      "mathContext": "States $\\mu(S_P) \\leq \\$\\pi$$ for all unit disk polynomials, with equality iff all roots coincide."
+      "startLine": 61,
+      "endLine": 65,
+      "summary": "States (in header prose) Pólya's upper bound $\\mu(S_P) \\leq \\pi$ for all unit disk polynomials, with equality iff all roots coincide ($p(z) = (z-z_0)^n$).",
+      "mathContext": "Pólya's upper bound: $\\mu(\\{|p(z)| < 1\\}) \\leq \\pi$, attained by $p(z) = (z - z_0)^n$."
+    },
+    {
+      "id": "foundational-lemmas",
+      "title": "Foundational Structure Lemmas (axiom-free)",
+      "startLine": 66,
+      "endLine": 114,
+      "summary": "The machine-checked core: the deep quantitative bounds rest on measure/potential machinery absent from Mathlib, but the basic geometry of the lemniscate is proved with no axioms and no sorry. `eval_root_eq_zero` ($p(z_i)=0$, a factor vanishes); `root_mem_sublevelSet` (every root lies in the sublevel set, $|p(z_i)|=0<1$); `sublevelSet_nonempty` (positive degree ⟹ the set contains a root); `eval_of_degree_zero`/`sublevelSet_of_degree_zero` (the degree-0 boundary case $p\\equiv 1$, empty sublevel set); `sublevelMeasure_nonneg` (the measure is nonnegative via `ENNReal.toReal_nonneg`).",
+      "mathContext": "From the root factorization $p(z) = \\prod_i (z - z_i)$: each root is a zero, hence lies in $\\{|p| < 1\\}$, which is therefore nonempty for $n \\geq 1$ and empty for $n = 0$."
+    },
+    {
+      "id": "conjecture-proved",
+      "title": "The Erdős–Herzog–Piranian Conjecture (PROVED)",
+      "startLine": 116,
+      "endLine": 124,
+      "summary": "Records that Erdős Problem 116 is resolved: the sublevel measure is at least $(\\log n)^{-O(1)}$, proved by Krishnapur, Lundberg, and Ramachandran with the optimal $c/\\log n$. Notes the remaining open question — determining which polynomials minimize the sublevel measure.",
+      "mathContext": "Conjecture (proved by KLR): $\\mu(\\{|p(z)| < 1\\}) \\geq (\\log n)^{-O(1)}$. Open refinement: characterize the minimizers."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
Enrichment pass for `erdos-116` (Measure of Polynomial Sublevel Sets; status axiomatized/wip, 0 sorries, 0 `^axiom`).

**Gap:** top-level `meta.sections` stopped at line 74 (`maxEnd=74` vs `wc=124`). The tail was both drifted and undercovered:
- `KLR Bounds` claimed [57–73] but the KLR prose banner is at line 53 and the range swallowed the Pólya banner (61) and the start of the Foundational Lemmas doc (66).
- `Pólya's Upper Bound` was a **degenerate single-line** section [74–74] anchored to a blank line.
- The **entire axiom-free `Foundational Structure Lemmas` block [66–114]** (6 proved theorems: `eval_root_eq_zero`, `root_mem_sublevelSet`, `sublevelSet_nonempty`, `eval_of_degree_zero`, `sublevelSet_of_degree_zero`, `sublevelMeasure_nonneg`) had **no section**.
- The closing `Conjecture (PROVED)` block [116–124] had no section.

**Fix (7→9 sections, contiguous 1..EOF):**
- Re-anchored `Pommerenke` [49→52], `KLR` [53–60] (full name), `Pólya` [61–65] to their real prose banners.
- Added `Foundational Structure Lemmas (axiom-free)` [66–114] — the machine-checked core, with accurate per-theorem summary.
- Added `The Erdős–Herzog–Piranian Conjecture (PROVED)` [116–124].
- Cleaned pre-existing corrupted mathContext LaTeX (`$c/$n^{4}$$`, `$c/\$\log n$$`, `$\$\pi$$`).

Single-file `meta.json` change. No status/badge/axiomCount change (file has 0 `^axiom` and 0 real `sorry`; the deep bounds are stated only as header prose, consistent with the `axiomatized`/`wip` framing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
