### PR TITLE
Enrich borsuk-ulam-oq-02-oq-01-oq-01: re-anchor degenerate sections to 9 banners (5→9)

### DIFF
--- a/src/data/proofs/borsuk-ulam-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/borsuk-ulam-oq-02-oq-01-oq-01/meta.json
@@ -56,34 +56,66 @@
     {
       "id": "formula",
       "title": "The Dimension Formula Definition",
-      "startLine": 34,
-      "endLine": 35,
+      "startLine": 26,
+      "endLine": 36,
       "summary": "Defines buDimFormula(n,d) = Nat.primeFactors(n).sup (fun p => buDim p d), the maximum BU dimension over all prime divisors of n.",
       "mathContext": "Uses Finset.sup on the prime factorization: the supremum over {buDim p d | p prime, p | n}. Empty for n=1 giving 0."
     },
     {
       "id": "lower-bound",
       "title": "Lower Bound (Proved)",
-      "startLine": 42,
-      "endLine": 46,
+      "startLine": 37,
+      "endLine": 47,
       "summary": "Proves buDimFormula(n,d) ≤ buDim(n,d) via Finset.sup_le + Nat.mem_primeFactors + buDim_mono.",
       "mathContext": "For each p ∈ primeFactors(n): buDim(p,d) ≤ buDim(n,d) by restriction. Finset.sup_le packages this into the formula bound."
     },
     {
-      "id": "conjecture",
-      "title": "The Open Conjecture",
-      "startLine": 60,
-      "endLine": 60,
-      "summary": "AXIOM: buDim(n,d) ≤ buDimFormula(n,d) for n ≥ 2. The hard direction: no composite group exceeds its prime factor bounds.",
+      "id": "upper-bound",
+      "title": "Upper Bound: Prime Case and the Open Conjecture",
+      "startLine": 48,
+      "endLine": 83,
+      "summary": "buDimFormula_prime (proved): for prime n the upper bound buDim(n,d) ≤ buDimFormula(n,d) is immediate. buDim_le_formula_composite (AXIOM): the composite case buDim(n,d) ≤ max_{p|n} buDim(p,d) is the open conjecture. buDim_le_formula dispatches n ≥ 2 into the proved prime case and the axiomatized composite case.",
       "mathContext": "Equivalent to: the Fadell-Husseini index of a Z/n-space is bounded by the maximum FH index over prime subgroups."
     },
     {
-      "id": "consequences",
-      "title": "Concrete Cases and Applications",
-      "startLine": 66,
-      "endLine": 136,
-      "summary": "Derives: buDim(4,d) = buDim(2,d), buDim(6,d) = max(buDim(2,d), buDim(3,d)), buDim(9,d) = buDim(3,d), buDim(4,n+1) = n, buDim(6,2n) = 2n-1.",
-      "mathContext": "Uses native_decide to compute Nat.primeFactors for concrete n, then applies the formula theorem. buDim(6,2n)=2n-1 follows because both prime factor bounds equal 2n-1."
+      "id": "formula-theorem",
+      "title": "The Formula Theorem",
+      "startLine": 84,
+      "endLine": 91,
+      "summary": "buDim_eq_formula: for n ≥ 2, buDim(n,d) = buDimFormula(n,d), combining the proved lower bound with the (partly axiomatized) upper bound into the two-sided identity.",
+      "mathContext": "$\\text{buDim}(n,d)=\\max_{p\\mid n}\\text{buDim}(p,d)$ for $n\\ge2$ — the conjectured formula, two-sided."
+    },
+    {
+      "id": "formula-at-primes",
+      "title": "Formula at Primes",
+      "startLine": 92,
+      "endLine": 111,
+      "summary": "buDimFormula_prime and buDim_prime_eq_formula: for a prime p the formula recovers buDim(p,d) directly (primeFactors p = {p}), so the conjecture holds trivially at primes — the base case of the reduction.",
+      "mathContext": "$\\text{primeFactors}(p)=\\{p\\}$, hence $\\text{buDimFormula}(p,d)=\\text{buDim}(p,d)$."
+    },
+    {
+      "id": "concrete-cases",
+      "title": "Concrete Cases",
+      "startLine": 112,
+      "endLine": 141,
+      "summary": "Discharges small composite cases via native_decide on Nat.primeFactors: buDim(4,d)=buDim(2,d), buDim(6,d)=max(buDim(2,d),buDim(3,d)), buDim(9,d)=buDim(3,d). These evaluate primeFactors 4={2}, 6={2,3}, 9={3}, then apply the formula theorem — depending on Lean.ofReduceBool.",
+      "mathContext": "$\\mathbb{Z}/4$ and $\\mathbb{Z}/2$ share BU dimension; $\\mathbb{Z}/9=\\mathbb{Z}/3^2$ collapses to $\\mathbb{Z}/3$; $\\mathbb{Z}/6$ takes the max over its prime factors $2,3$."
+    },
+    {
+      "id": "prime-powers",
+      "title": "Prime Powers (General)",
+      "startLine": 142,
+      "endLine": 168,
+      "summary": "buDimFormula_prime_pow and buDim_prime_pow_eq: the formula collapses at any prime power p^k (k ≥ 1) to the single prime p, so prime powers do not increase the BU dimension — the general form of the n=4,9 concrete collapses.",
+      "mathContext": "$\\text{primeFactors}(p^k)=\\{p\\}$ for $k\\ge1$, hence $\\text{buDim}(p^k,d)=\\text{buDim}(p,d)$."
+    },
+    {
+      "id": "specific-bu-dims",
+      "title": "Specific BU Dimensions",
+      "startLine": 169,
+      "endLine": 187,
+      "summary": "Closed-form BU dimensions: buDim(4,n+1)=n (Z/4-equivariant odd maps S^n → R^{n+1} must vanish) and buDim(6,2n)=2n-1 for n ≥ 1 (both prime-factor bounds of 6 coincide at 2n-1).",
+      "mathContext": "$\\text{buDim}(4,n+1)=n$ and $\\text{buDim}(6,2n)=2n-1$ — explicit values from the formula."
     }
   ],
   "conclusion": {

--- a/src/data/proofs/pascals-hexagon-incomplete-01-oq-03-oq-01/meta.json
+++ b/src/data/proofs/pascals-hexagon-incomplete-01-oq-03-oq-01/meta.json
@@ -68,6 +68,14 @@
   },
   "sections": [
     {
+      "id": "overview",
+      "title": "Overview: the conic dichotomy and Sylvester reduction",
+      "startLine": 1,
+      "endLine": 48,
+      "summary": "Module docstring framing the goal — completing the diagonal half of the projective conic dichotomy: a diagonal real conic diag(a,b,c) is stdConic-equivalent iff its signature is indefinite (2,1). Outlines the three movements: the diagonal API and rescaling, the off-diagonal congruence engine (projEquiv_of_congr, projEquiv_trans), and the spectral closure discharging the last open Sylvester statement via Mathlib’s spectral theorem. Conic definitions are reproduced locally because PascalsHexagon.lean is bit-rotted under toolchain 4.26.0.",
+      "mathContext": "A real conic is a symmetric $3\\times3$ matrix $C$; projective equivalence $\\mathrm{projEquiv}\\,C_1\\,C_2$ holds when a congruence $M^{\\mathsf T} C_2 M = C_1$ with $\\det M\\ne0$ intertwines their quadratic forms."
+    },
+    {
       "id": "api",
       "title": "Minimal Conic API and the Rescaling",
       "startLine": 49,
@@ -106,6 +114,14 @@
       "endLine": 314,
       "summary": "Discharges the remaining spectral statement via Mathlib's spectral theorem. diagConic_eq_diagonal bridges the bespoke diagConic to Matrix.diagonal of the eigenvalue vector; symm_congr_diagEigenvalues congruence-diagonalises any Hermitian conic C as Mᵀ·diag(λ₀,λ₁,λ₂)·M = C with M = Uᵀ invertible (the eigenvector matrix U is unitary, so det Uᵀ = det U ≠ 0). Chaining through the congruence engine, symm_eigen_indefinite_projEquiv_stdConic shows a symmetric conic with eigenvalue signs (+,+,−) in index order is projectively equivalent to stdConic — the hard Sylvester half, closed modulo the elementary permutation reordering an arbitrary (2,1) signature.",
       "mathContext": "Spectral theorem C = U·diag(λ)·Uᵀ (U unitary) recast with M := Uᵀ; eigenvalue signs (+,+,−) supply the signature (2,1) hypothesis consumed by the congruence engine."
+    },
+    {
+      "id": "summary",
+      "title": "Summary",
+      "startLine": 315,
+      "endLine": 364,
+      "summary": "Closing docstring recapping the completed chain: qform_stdConic_rescale + det_rescale_ne_zero give diagConic_indefinite_projEquiv_stdConic (indefinite diagonals ≡ stdConic); the congruence pull-back law conicQuadraticForm_projTransform with projEquiv_of_congr/projEquiv_trans lifts this to the full congruence orbit (congrDiag_indefinite_projEquiv_stdConic); and symm_congr_diagEigenvalues + symm_eigen_indefinite_projEquiv_stdConic discharge the remaining spectral statement via Mathlib’s spectral theorem, closing the hard Sylvester half for the ordered signature (+,+,−). Status: 0 sorries, 0 axiom declarations, no native_decide.",
+      "mathContext": "The boundary is the $\\emph{signature}$: a diagonal conic is $\\mathrm{stdConic}$-equivalent iff indefinite of type $(2,1)$; the spectral theorem congruence-diagonalises any symmetric $C$ as $M^{\\mathsf T}\\mathrm{diag}(\\lambda_0,\\lambda_1,\\lambda_2)M=C$."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
Enrichment pass for `borsuk-ulam-oq-02-oq-01-oq-01`.

The `sections` array was degenerate/drifted — 1-line ranges (`[34-35]`, `[60-60]`),
a stale `[66-136]` that stopped 51 lines short, and no coverage of the tail.

Re-anchored all sections to the file's nine `-- ##` banners (Dimension Formula,
Lower Bound, **Upper Bound** — now capturing the prime case + `buDim_le_formula_composite`
axiom, Formula Theorem, Formula at Primes, Concrete Cases, **Prime Powers (general)**,
**Specific BU Dimensions**), covering 1..187/EOF (5→9). Head summaries reused; wrote
accurate summaries for the four previously-unsectioned theorem groups.

Axiom status verified accurate and unchanged: `axiomCount: 2` = the literal
`buDim_le_formula_composite` axiom + `Lean.ofReduceBool` from `native_decide` (used
only in the concrete n=4,6,9 cases @119/128/138; the general prime-power lemmas
@149/160 are `native_decide`-free, per the source comments — reflected in the section
summaries).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
