### PR TITLE
audit: bezout-identity-oq012 (ℤ[√d] PID/UFD + prime-norm irreducibility) clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -30446,6 +30446,12 @@
       "lastAudited": "2026-07-21T07:56:34Z",
       "result": "clean",
       "issues": []
+    },
+    "bezout-identity-oq012": {
+      "auditCount": 2,
+      "lastAudited": "2026-07-21T08:08:27Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Gallery integrity audit — CLEAN

**Proof**: bezout-identity-oq012 — ℤ[√d] is a PID and UFD for d ∈ {−1,−2}, and Prime-Norm Irreducibility

### Verification
- **8 theorems**, all genuine statements (IsPrincipalIdealRing, UniqueFactorizationMonoid, Irreducible, Prime) — no True stubs.
- **0 axioms, 0 sorries, no `native_decide`** — matches meta exactly.
- Build `lake env lean` **EXIT 0**.
- `#print axioms` on `prime_of_prime_norm` / `irreducible_of_prime_norm` / `negTwo_uniqueFactorizationMonoid` → only `propext, Classical.choice, Quot.sound` (no `sorryAx`, no `ofReduceBool`).
- Parent `NormEuclideanZsqrtdFamilyOQ03` provides a genuine `EuclideanDomain` def (0 sorries/axioms).

### Tier / narrative
Honest **Tier B**: the file discloses the PID/UFD step as "pure Mathlib plumbing" (`EuclideanDomain.to_principal_ideal_domain`, `PrincipalIdealRing.to_uniqueFactorizationMonoid`). The genuinely new content — `irreducible_of_prime_norm` (unconditional in d) and its UFD upgrade — is correctly scoped in `originalContributions`. No delegation opacity, no axiom masking, counts all match.

Note: prior PR #40204 for this slug was closed without merging; re-audited and confirmed clean.

---
Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)