### PR TITLE
Enrich elementary-quadratic-reciprocity-oq-01: cover Summary/verification tail (12→13)

### DIFF
--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-01/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-01/meta.json
@@ -175,9 +175,17 @@
       "id": "character-uniqueness",
       "title": "Part X: Character Uniqueness",
       "startLine": 511,
-      "endLine": 577,
+      "endLine": 573,
       "summary": "The key algebraic reduction: on a cyclic group $G = \\langle g \\rangle$, any surjective homomorphism $\\varphi: G \\to \\{\\pm 1\\}$ satisfies $\\varphi(g) = -1$ (otherwise $\\varphi$ is trivial). Two such homomorphisms must agree. This forces `signMulHom = legendreCharOnUnits`, proving Zolotarev's Lemma.",
       "mathContext": "The key algebraic reduction: on a cyclic group $G = \\langle g \\rangle$, any surjective homomorphism $\\varphi: G \\to \\{\\pm 1\\}$ satisfies $\\varphi(g) = -1$ (otherwise $\\varphi$ is trivial). This forces `signMulHom = legendreCharOnUnits`, proving Zolotarev's Lemma."
+    },
+    {
+      "id": "summary-verification",
+      "title": "Summary and Verification",
+      "startLine": 574,
+      "endLine": 624,
+      "summary": "Closing docstring recapping what is proved (0 sorries, 0 axioms): mulPerm / mulPermHom / signMulHom, multiplicativity of the sign, squares have sign +1, the QR statement and both supplements (from Mathlib), five computational examples, the cyclic-group infrastructure (Parts VIII–X), and Zolotarev’s Lemma legendreSym p a = sign(mulPerm a) (Part XI). Followed by a #check verification block over the headline declarations.",
+      "mathContext": "Key insight: Eisenstein counts lattice points, Zolotarev counts transpositions; both give $(-1)^{\\frac{p-1}{2}\\cdot\\frac{q-1}{2}}$. The permutation route is algebraic and generalizes to higher reciprocity via Artin symbols."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
Enrichment pass for `elementary-quadratic-reciprocity-oq-01`.

The `sections` array ended at Part X (@577), leaving the closing `## Zolotarev's
Approach` Summary docstring plus its `#check` verification block (574-624)
uncovered. Shrank Part X to end at 573 (its last theorem
`quadratic_reciprocity_one_mod_four` @572) and added a **Summary and Verification**
section (12→13) covering 1..624/EOF.

`status: verified`, `badge: mathlib`, `axiomCount: 0` verified accurate (0 sorries,
0 axioms in the file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
