### PR TITLE
Enrich knights-tour-oblique-oq-01: cover module header + extend Main Theorem to EOF (7→8)

### DIFF
--- a/src/data/proofs/knights-tour-oblique-oq-01/meta.json
+++ b/src/data/proofs/knights-tour-oblique-oq-01/meta.json
@@ -51,6 +51,14 @@
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Module Header and Imports",
+      "startLine": 1,
+      "endLine": 29,
+      "summary": "Module docstring stating the oblique knight’s-tour question — whether every closed knight’s tour on an n×n board (n ≥ 5) must make an oblique (non-straight) turn at each of the four corners — with a checklist of the proved components (corner degree-2, corner-forces-oblique), followed by the Mathlib graph/list/tactic imports.",
+      "mathContext": "A closed knight’s tour is a Hamiltonian cycle in the knight graph on $[n]\\times[n]$; at a corner the two incident tour edges are forced to be non-collinear (an *oblique* turn)."
+    },
+    {
       "id": "sec1-board",
       "title": "Section 1: Parameterized Board and Knight Graph",
       "startLine": 30,
@@ -96,7 +104,7 @@
       "id": "sec7-main-theorem",
       "title": "Section 7: Main Theorem",
       "startLine": 366,
-      "endLine": 512,
+      "endLine": 564,
       "summary": "The main theorem: every closed oblique knight's tour on an n×n board has oblique turns at all four corners (TL, TR, BL, BR), proved by applying corner_forces_oblique at each corner via the cyclic adjacency structure."
     }
   ],


### PR DESCRIPTION
Enrichment pass for `knights-tour-oblique-oq-01`.

The `sections` array started at line 30 (missing the module docstring + imports)
and Section 7: Main Theorem stopped at 512, leaving its own proof tail (513-563 —
the four corner cases TL/TR/BL/BR of `corner_forces_oblique`, closing at
`end KnightsTourObliqueGeneral` @563) uncovered.

Added a **Module Header and Imports** section and extended Section 7 to line 564,
covering 1..EOF (7→8). `status: verified`, `badge: mathlib`, `axiomCount: 0`
unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
