### PR TITLE
audit: bezout-identity-oq017 (constructive computable divisibility) clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -30452,6 +30452,12 @@
       "lastAudited": "2026-07-21T08:08:27Z",
       "result": "clean",
       "issues": []
+    },
+    "bezout-identity-oq017": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T08:17:02Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Gallery integrity audit — CLEAN

**Proof**: bezout-identity-oq017 — Constructive Divisibility: Removing the Noncomputable Annotation

### Verification
- **6 theorems, 2 defs, 0 axioms, 0 sorries, 182 lines** — all match.
- Build `lake env lean` **EXIT 0**.
- `native_decide` appears **only in 4 anonymous `example`s** (lines 143-152, "DEMONSTRATING COMPUTABILITY") — not in any named theorem/def.
- `#print axioms` on all 4 named theorems (`constructive_div_computable_correct`, `euclids_lemma_computable`, `extGcd_bezout`, `div_witness_correct`) → only `propext, Classical.choice, Quot.sound` (one just `propext`) — **no `ofReduceBool`**. The example-level native_decide taints no exported result, so `axiomCount: 0` is correct.

### Tier / narrative
Badge `original` **justified**: genuinely provides a computable `constructive_div_computable` (integer division witness `(b*c)/a` replacing classical `hdvd.choose`), with `constructive_div_computable_correct` proving `a * q = c`. Title accurately describes removing the noncomputable annotation. No overclaim.

Note: prior PR #40219 for this slug was an empty-diff PR closed unmerged; re-recorded with a verified non-empty diff.

---
Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)