### PR TITLE
audit: bezout-identity-oq025 (Pi-type k-fold CRT ring iso) clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -30464,6 +30464,12 @@
       "lastAudited": "2026-07-21T08:19:56Z",
       "result": "clean",
       "issues": []
+    },
+    "bezout-identity-oq025": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T08:23:30Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
Gallery integrity audit — CLEAN. 9 theorems + 5 defs, 0 ax, 0 sorries, 217 lines — all match. Build EXIT 0. 'native_decide' grep hit is docstring line 30 ('no native_decide'); file uses only kernel `decide` (line 194). #print axioms crtPi_bijective/crtPi_card = only propext/Classical.choice/Quot.sound. Badge `mathlib` Tier B: crtPi built by induction on k from Mathlib ZMod.chineseRemainder + local finSplitRingEquiv(Fin.cons)/ringEquivOfSubsingleton. Re-record after empty-diff PR #40236 closed unmerged. 🤖 Generated with [Claude Code](https://claude.com/claude-code)