### PR TITLE
Research: erdos-98-wip-01 — no 4 coplanar points are mutually equidistant (toward h 5 ≥ 3)

### DIFF
--- a/proofs/Proofs/Erdos98WIP01.lean
+++ b/proofs/Proofs/Erdos98WIP01.lean
@@ -1635,4 +1635,135 @@ left as the next step. -/
 theorem h_five_bounds : 2 ≤ h 5 ∧ h 5 ≤ 3 :=
   ⟨h_five_ge_two, h_five_le_three⟩
 
+/-! ## Toward `h 5 ≥ 3`: no four coplanar points are mutually equidistant
+
+Pinning `h 5 = 3` requires the lower bound `h 5 ≥ 3` — that **no** general-position
+five-point set determines only two distinct distances.  This is *not* the one-line
+"regular pentagon is concyclic" argument: the pentagon is only one of several planar
+2-distance 5-sets, so the lower bound genuinely needs the structure of 2-distance sets.
+
+A concrete first step toward that structure is recorded here.  Suppose a five-set uses
+only distances `a < b`.  By `card_fiber_dist_le_three`, from any point at most three
+others share a distance, so each point has `a`-degree and `b`-degree in `{1, 2, 3}`.
+A point `p` with `a`-degree `3` sees three points `X, Y, Z` at distance `a`; if those
+three were also pairwise at distance `a`, then `p, X, Y, Z` would be **four mutually
+equidistant points** — the densest local pattern, and one that cannot occur in the
+plane.  The following lemma rules it out unconditionally, killing that sub-case of the
+`h 5 ≥ 3` classification.
+
+The reason is dimensional: four mutually equidistant points are the vertices of a
+regular tetrahedron, which needs three dimensions.  Concretely, the three edge vectors
+`u = b - a`, `v = c - a`, `w = d - a` from one vertex have norms `r` and pairwise inner
+product `r²/2` (from `‖u - v‖ = r`, etc.), so their Gram matrix is
+`r²·[[1, ½, ½], [½, 1, ½], [½, ½, 1]]`, of determinant `r⁶/2 ≠ 0`.  A nonzero Gram
+determinant forces `u, v, w` linearly independent — impossible for three vectors in the
+`2`-dimensional space `EuclideanSpace ℝ (Fin 2)`. -/
+open scoped InnerProductSpace in
+/-- **No four points in the plane are mutually equidistant.** In `EuclideanSpace ℝ (Fin 2)`
+there is no quadruple of points with all six pairwise distances equal to a common positive
+value `r`: the three edge vectors from one vertex would be linearly independent (their
+Gram matrix has determinant `r⁶/2 ≠ 0`), contradicting `finrank = 2`.  This is the planar
+case of "a regular `k`-simplex needs dimension `k`". -/
+theorem no_four_mutually_equidistant
+    {a b c d : EuclideanSpace ℝ (Fin 2)} {r : ℝ} (hr : 0 < r)
+    (hab : dist a b = r) (hac : dist a c = r) (had : dist a d = r)
+    (hbc : dist b c = r) (hbd : dist b d = r) (hcd : dist c d = r) : False := by
+  set u : EuclideanSpace ℝ (Fin 2) := b - a with hu
+  set v : EuclideanSpace ℝ (Fin 2) := c - a with hv
+  set w : EuclideanSpace ℝ (Fin 2) := d - a with hw
+  -- Edge-vector norms are all `r`.
+  have hnu : ‖u‖ = r := by rw [hu, ← dist_eq_norm, dist_comm]; exact hab
+  have hnv : ‖v‖ = r := by rw [hv, ← dist_eq_norm, dist_comm]; exact hac
+  have hnw : ‖w‖ = r := by rw [hw, ← dist_eq_norm, dist_comm]; exact had
+  -- Self inner products.
+  have euu : inner ℝ u u = r ^ 2 := by rw [real_inner_self_eq_norm_sq, hnu]
+  have evv : inner ℝ v v = r ^ 2 := by rw [real_inner_self_eq_norm_sq, hnv]
+  have eww : inner ℝ w w = r ^ 2 := by rw [real_inner_self_eq_norm_sq, hnw]
+  -- Cross inner products are `r²/2`, from the equal opposite-edge lengths.
+  have huv : inner ℝ u v = r ^ 2 / 2 := by
+    have hnorm : ‖u - v‖ = r := by
+      have : u - v = b - c := by rw [hu, hv]; abel
+      rw [this, ← dist_eq_norm]; exact hbc
+    have h := norm_sub_sq_real u v
+    rw [hnorm, hnu, hnv] at h; linarith
+  have huw : inner ℝ u w = r ^ 2 / 2 := by
+    have hnorm : ‖u - w‖ = r := by
+      have : u - w = b - d := by rw [hu, hw]; abel
+      rw [this, ← dist_eq_norm]; exact hbd
+    have h := norm_sub_sq_real u w
+    rw [hnorm, hnu, hnw] at h; linarith
+  have hvw : inner ℝ v w = r ^ 2 / 2 := by
+    have hnorm : ‖v - w‖ = r := by
+      have : v - w = c - d := by rw [hv, hw]; abel
+      rw [this, ← dist_eq_norm]; exact hcd
+    have h := norm_sub_sq_real v w
+    rw [hnorm, hnv, hnw] at h; linarith
+  -- Reversed cross products (inner product is symmetric over `ℝ`).
+  have evu : inner ℝ v u = r ^ 2 / 2 := by rw [real_inner_comm]; exact huv
+  have ewu : inner ℝ w u = r ^ 2 / 2 := by rw [real_inner_comm]; exact huw
+  have ewv : inner ℝ w v = r ^ 2 / 2 := by rw [real_inner_comm]; exact hvw
+  -- The three edge vectors are linearly independent.
+  have hli : LinearIndependent ℝ ![u, v, w] := by
+    rw [Fintype.linearIndependent_iff]
+    intro g hg
+    rw [Fin.sum_univ_three] at hg
+    simp only [Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.head_cons,
+      Matrix.cons_val_two, Matrix.tail_cons] at hg
+    -- `hg : g 0 • u + g 1 • v + g 2 • w = 0`; test against `u`, `v`, `w`.
+    have e1 : g 0 * r ^ 2 + g 1 * (r ^ 2 / 2) + g 2 * (r ^ 2 / 2) = 0 := by
+      have h := congrArg (fun x => (inner ℝ x u : ℝ)) hg
+      simp only [inner_add_left, real_inner_smul_left, inner_zero_left] at h
+      rw [euu, evu, ewu] at h; linarith
+    have e2 : g 0 * (r ^ 2 / 2) + g 1 * r ^ 2 + g 2 * (r ^ 2 / 2) = 0 := by
+      have h := congrArg (fun x => (inner ℝ x v : ℝ)) hg
+      simp only [inner_add_left, real_inner_smul_left, inner_zero_left] at h
+      rw [huv, evv, ewv] at h; linarith
+    have e3 : g 0 * (r ^ 2 / 2) + g 1 * (r ^ 2 / 2) + g 2 * r ^ 2 = 0 := by
+      have h := congrArg (fun x => (inner ℝ x w : ℝ)) hg
+      simp only [inner_add_left, real_inner_smul_left, inner_zero_left] at h
+      rw [huw, hvw, eww] at h; linarith
+    -- Divide out `r²/2 ≠ 0` to reach the integer Gram system, then solve.
+    have hne : (r ^ 2 / 2 : ℝ) ≠ 0 := by positivity
+    have c1 : 2 * g 0 + g 1 + g 2 = 0 :=
+      (mul_eq_zero.mp (by linear_combination e1 : (2 * g 0 + g 1 + g 2) * (r ^ 2 / 2) = 0)).resolve_right hne
+    have c2 : g 0 + 2 * g 1 + g 2 = 0 :=
+      (mul_eq_zero.mp (by linear_combination e2 : (g 0 + 2 * g 1 + g 2) * (r ^ 2 / 2) = 0)).resolve_right hne
+    have c3 : g 0 + g 1 + 2 * g 2 = 0 :=
+      (mul_eq_zero.mp (by linear_combination e3 : (g 0 + g 1 + 2 * g 2) * (r ^ 2 / 2) = 0)).resolve_right hne
+    intro i; fin_cases i <;> linarith
+  -- Three linearly independent vectors cannot exist in a `2`-dimensional space.
+  have hcard := hli.fintype_card_le_finrank
+  rw [finrank_euclideanSpace_fin] at hcard
+  simp only [Fintype.card_fin] at hcard
+  omega
+
+/-- **No four configuration points are mutually equidistant.** Specialization of
+`no_four_mutually_equidistant` to the points of a `PointConfig`: no four indices
+`i, j, k, l` can have all six pairwise distances equal to a common positive value. This
+excludes the "regular-tetrahedron" sub-pattern from any five-point 2-distance analysis
+of `h 5 ≥ 3` (a degree-`3` vertex whose three neighbours are mutually at the short
+distance would produce exactly such a quadruple). -/
+theorem no_four_equidistant_indices {P : PointConfig n} {i j k l : Fin n} {r : ℝ}
+    (hr : 0 < r)
+    (hij : dist (P i) (P j) = r) (hik : dist (P i) (P k) = r) (hil : dist (P i) (P l) = r)
+    (hjk : dist (P j) (P k) = r) (hjl : dist (P j) (P l) = r) (hkl : dist (P k) (P l) = r) :
+    False :=
+  no_four_mutually_equidistant hr hij hik hil hjk hjl hkl
+
+/-! ## Concrete unconditional lower-bound values of `h`
+
+The linear bound `n - 1 ≤ 3 · h n` (`three_mul_h_ge`) already pins several exact
+threshold values of `h` from below, with no imported theorem and no open conjecture. -/
+
+/-- **`h n ≥ 3` for `n ≥ 8`.** From `n - 1 ≤ 3 · h n`: at `n = 8` this reads `7 ≤ 3 · h 8`,
+forcing `h 8 ≥ 3` (since `3 · 2 = 6 < 7`); monotonicity carries it to all `n ≥ 8`.  The
+first place the elementary bound alone certifies three distinct distances. -/
+theorem three_le_h_of_eight_le (hn : 8 ≤ n) : 3 ≤ h n := by
+  have := three_mul_h_ge n; omega
+
+/-- **`h n ≥ 4` for `n ≥ 11`.** From `n - 1 ≤ 3 · h n`: at `n = 11` this reads `10 ≤ 3 · h 11`,
+forcing `h 11 ≥ 4` (since `3 · 3 = 9 < 10`); monotonicity carries it to all `n ≥ 11`. -/
+theorem four_le_h_of_eleven_le (hn : 11 ≤ n) : 4 ≤ h n := by
+  have := three_mul_h_ge n; omega
+
 end Erdos98WIP01

--- a/proofs/Proofs/Erdos98WIP01.lean
+++ b/proofs/Proofs/Erdos98WIP01.lean
@@ -1730,7 +1730,11 @@ theorem no_four_mutually_equidistant
       (mul_eq_zero.mp (by linear_combination e2 : (g 0 + 2 * g 1 + g 2) * (r ^ 2 / 2) = 0)).resolve_right hne
     have c3 : g 0 + g 1 + 2 * g 2 = 0 :=
       (mul_eq_zero.mp (by linear_combination e3 : (g 0 + g 1 + 2 * g 2) * (r ^ 2 / 2) = 0)).resolve_right hne
-    intro i; fin_cases i <;> linarith
+    intro i
+    fin_cases i
+    · show g 0 = 0; linarith
+    · show g 1 = 0; linarith
+    · show g 2 = 0; linarith
   -- Three linearly independent vectors cannot exist in a `2`-dimensional space.
   have hcard := hli.fintype_card_le_finrank
   rw [finrank_euclideanSpace_fin] at hcard

--- a/research/problems/erdos-98-wip-01/knowledge.md
+++ b/research/problems/erdos-98-wip-01/knowledge.md
@@ -1,5 +1,53 @@
 # Knowledge Base: erdos-98-wip-01
 
+## Session 2026-07-21 (researcher-1) — toward h 5 ≥ 3: no 4 coplanar points are mutually equidistant
+
+**Mode**: REVISIT (continue). **Outcome**: progress — a reusable geometric lemma toward
+`h 5 ≥ 3`, plus concrete unconditional lower-bound thresholds.
+**docker-built** `Proofs.Erdos98WIP01` OK (0 sorry / 0 axiom / no `native_decide`;
+build "succeeded, 8577 jobs"). All new lemmas use only Mathlib + `linarith`/`omega`/
+`linear_combination`, so foundational axioms only (`propext`/`Classical.choice`/`Quot.sound`).
+
+### Why `h 5 ≥ 3` is not one line (correcting the prior docstring)
+The `h_five_bounds` docstring claimed "the regular pentagon, the only planar 2-distance
+5-set". That is **false**: the plane has several 5-point 2-distance sets (the pentagon is
+only the concyclic one). So `h 5 ≥ 3` genuinely needs the structure of 2-distance sets,
+not just "pentagon ⇒ concyclic ⇒ excluded". The new toward-`h 5 ≥ 3` section documents the
+real reduction.
+
+### The reduction (rigorous, and what remains)
+Suppose a general-position 5-set uses only two distances `a < b`. By
+`card_fiber_dist_le_three` (already in file), each point has `a`-degree and `b`-degree in
+`{1,2,3}` (a 4th point at a common distance would be 4 concyclic). Case split on whether
+some vertex has `a`-degree 3:
+- **Degree-3 vertex `p`** with neighbours `X,Y,Z` at distance `a`. Sub-case "`X,Y,Z`
+  pairwise `a`" makes `p,X,Y,Z` **four mutually equidistant** → **now excluded** by the new
+  `no_four_mutually_equidistant`. Remaining degree-3 sub-cases (some `XY` or `XZ` = `b`)
+  reduce to intersecting-circle distance equations (`|YZ| = a√3`, etc.) — **still open**,
+  coordinate-heavy.
+- **All degrees 2** (a-graph 2-regular on 5 vertices ⇒ `C₅`) is the pentagon-type case;
+  metric realizability forces the concyclic regular pentagon — **still open** (needs
+  "equilateral + equidiagonal convex pentagon ⇒ concyclic").
+
+### Lean results added (`proofs/Proofs/Erdos98WIP01.lean`)
+- **`no_four_mutually_equidistant`** (axiom-free): in `EuclideanSpace ℝ (Fin 2)` no four
+  points have all six pairwise distances equal to a common `r > 0`. Proof: edge vectors
+  `u=b-a, v=c-a, w=d-a` have `‖·‖²=r²`, pairwise inner product `r²/2` (from `‖u-v‖=r` via
+  `norm_sub_sq_real`); the Gram system forces `LinearIndependent ℝ ![u,v,w]`, contradicting
+  `finrank (EuclideanSpace ℝ (Fin 2)) = 2` (`LinearIndependent.fintype_card_le_finrank` +
+  `finrank_euclideanSpace_fin`). This is the planar "regular `k`-simplex needs dim `k`".
+- **`no_four_equidistant_indices`**: config-level specialization (no 4 indices mutually
+  equidistant).
+- **`three_le_h_of_eight_le`** (`n ≥ 8 → 3 ≤ h n`) and **`four_le_h_of_eleven_le`**
+  (`n ≥ 11 → 4 ≤ h n`): immediate from `three_mul_h_ge` (`n-1 ≤ 3·h n`) — the first exact
+  thresholds where the elementary bound alone certifies 3, resp. 4, distinct distances.
+
+### Next steps
+- Degree-3 remaining sub-cases: formalize "two circles of radius `a` at centre-distance `a`
+  meet at points `a√3` apart" as reusable `EuclideanSpace ℝ (Fin 2)` algebra.
+- All-degree-2 (`C₅`) case: "equilateral + equidiagonal convex pentagon is concyclic".
+- Both are coordinate-geometry heavy; each is a standalone multi-session sub-target.
+
 ## Session 2026-07-21 (researcher-1) — h 5 ≤ 3 via explicit 3-distance general-position 5-witness
 
 **Mode**: FRESH (continue). **Outcome**: progress — `h 5 ≤ 3`, so `2 ≤ h 5 ≤ 3`.

--- a/src/data/research/problems/erdos-98-wip-01.json
+++ b/src/data/research/problems/erdos-98-wip-01.json
@@ -31,7 +31,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: h 2 = h 3 = 1, h 4 = 2 pinned exactly; now h 5 ≤ 3 via an explicit 3-distance general-position 5-point witness (2 ≤ h 5 ≤ 3). Pinning h 5 = 3 awaits the lower bound h 5 ≥ 3 (planar 2-distance-set classification). Parent rate h(n)/n → ∞ (Erdős #98) OPEN.",
+    "progressSummary": "PROGRESS: h 2=h 3=1, h 4=2 pinned; 2 ≤ h 5 ≤ 3. Toward h 5 ≥ 3: no_four_mutually_equidistant (axiom-free, no 4 coplanar points mutually equidistant) kills the regular-tetrahedron sub-case of the 5-point 2-distance classification; remaining cases (mixed degree-3, and C5/pentagon) are coordinate-geometry heavy and open. Unconditional thresholds h n ≥ 3 (n≥8), h n ≥ 4 (n≥11) from n-1 ≤ 3·h n.",
     "builtItems": [
       "InGeneralPosition.injective in Erdos98WIP01.lean",
       "numDistinctDistances_le_offDiag (≤ n·(n−1)) in Erdos98WIP01.lean",
@@ -76,7 +76,11 @@
       "h5Config (PointConfig 5) + h5Config_dist_sq/h5Config_dist_mem: all pairwise dist ∈ {1,√(2+√3),1+√3} — Proofs/Erdos98WIP01.lean",
       "h5Config_injective, noThreeCollinear_h5Config, noFourConcyclic_h5Config (via 5 per-quadruple h5_not_equidistant_* helpers), inGeneralPosition_h5Config",
       "numDistinctDistances_h5Config_le : numDistinctDistances h5Config ≤ 3",
-      "h_five_le_three : h 5 ≤ 3 ; h_five_ge_two : 2 ≤ h 5 ; h_five_bounds : 2 ≤ h 5 ∧ h 5 ≤ 3 (all axiom-clean: [propext, Classical.choice, Quot.sound])"
+      "h_five_le_three : h 5 ≤ 3 ; h_five_ge_two : 2 ≤ h 5 ; h_five_bounds : 2 ≤ h 5 ∧ h 5 ≤ 3 (all axiom-clean: [propext, Classical.choice, Quot.sound])",
+      "no_four_mutually_equidistant (Erdos98WIP01.lean): axiom-free — no 4 points in EuclideanSpace ℝ (Fin 2) are mutually equidistant at r>0, via Gram linear independence + finrank_euclideanSpace_fin.",
+      "no_four_equidistant_indices (Erdos98WIP01.lean): config-level specialization to PointConfig indices.",
+      "three_le_h_of_eight_le (Erdos98WIP01.lean): n ≥ 8 → 3 ≤ h n, from three_mul_h_ge.",
+      "four_le_h_of_eleven_le (Erdos98WIP01.lean): n ≥ 11 → 4 ≤ h n, from three_mul_h_ge."
     ],
     "insights": [
       "Every positive pairwise distance comes from an off-diagonal ordered pair (dist>0 ⟹ points distinct ⟹ indices distinct), giving the clean upper bound numDistinctDistances P ≤ n·(n−1) via Finset.offDiag_card — the trivial ceiling of the h(n) envelope.",
@@ -105,15 +109,18 @@
       "h 5 ≤ 3: explicit general-position 5-point witness with exactly 3 distinct distances. Points (0,0),(1,0),(−√3/2,−1/2),(1/2,√3/2),(1/2,−(2+√3)/2); distances 1 (×4), √(2+√3) (×5), 1+√3 (×1). Sympy-verified: 10 triple areas ≠0 (no 3 collinear), 5 circumcircle dets ≠0 (no 4 concyclic: 1+√3/2, 2+√3, 5/2+3√3/2).",
       "Both natural lower-bound routes give only h 5 ≥ 2: three_mul_h_ge 5 (⌈4/3⌉=2) and monotonicity from h 4 = 2. So 2 ≤ h 5 ≤ 3, expected h 5 = 3.",
       "The regular pentagon (only planar 2-distance 5-set) is concyclic, so no general-position 5-set has 2 distances; proving h 5 ≥ 3 reduces to the classification of planar 2-distance sets (or the Larman–Rogers–Seidel linear-algebra bound + concyclic refinement).",
-      "Empirical: no triangular-lattice 5-cap (origin-fixed radius ≤4) has ≤3 distinct distances in general position; the 3-distance witness needs the off-lattice point E=(1/2,−(2+√3)/2). Bowtie/centered-triangle + 1 point always lands the 5th on a lattice line (3 collinear) or on the shared circle (4 concyclic)."
+      "Empirical: no triangular-lattice 5-cap (origin-fixed radius ≤4) has ≤3 distinct distances in general position; the 3-distance witness needs the off-lattice point E=(1/2,−(2+√3)/2). Bowtie/centered-triangle + 1 point always lands the 5th on a lattice line (3 collinear) or on the shared circle (4 concyclic).",
+      "h 5 ≥ 3 is NOT the one-line \"regular pentagon is concyclic\" argument: the plane has several 5-point 2-distance sets, so the lower bound needs 2-distance-set structure. The h_five_bounds docstring claiming the pentagon is the only planar 2-distance 5-set is mathematically false.",
+      "Degree structure of a general-position 5-point 2-distance set (distances a<b): by card_fiber_dist_le_three each point has a-degree and b-degree in {1,2,3}; the a-graph is either 2-regular (C5, pentagon-type) or has a degree-3 vertex.",
+      "Four mutually equidistant points cannot lie in the plane (regular tetrahedron needs dim 3): the 3 edge vectors from one vertex have Gram matrix r²·[[1,½,½],[½,1,½],[½,½,1]] (det r⁶/2 ≠ 0), hence linearly independent, contradicting finrank(EuclideanSpace ℝ (Fin 2))=2."
     ],
     "mathlibGaps": [
       "Classification of planar 2-distance sets (max 5 points = regular pentagon, unique up to similarity) is absent from Mathlib — needed for h 5 ≥ 3."
     ],
     "nextSteps": [
-      "Prove h 5 ≥ 3: no general-position 5-set has ≤2 distinct distances. Route A: classify planar 2-distance 5-sets (regular pentagon, concyclic). Route B: Larman–Rogers–Seidel bound (a 2-distance set in ℝ² has ≤ 6 points) + refine with no-4-concyclic to ≤4.",
-      "Abstract the Gram/dimension argument into a reusable lemma: a 1-distance set in ℝ^d has ≤ d+1 points.",
-      "General lower bound sharper than (n−1)/3 using both nondegeneracy hypotheses."
+      "h 5 ≥ 3 degree-3 remaining sub-cases: formalize \"two radius-a circles at centre-distance a meet at points a√3 apart\" as reusable EuclideanSpace ℝ (Fin 2) algebra, killing the mixed a/b sub-cases around a degree-3 vertex.",
+      "h 5 ≥ 3 all-degree-2 (C5) case: prove \"equilateral + equidiagonal convex pentagon is concyclic\", excluded by no-4-concyclic.",
+      "Parent Erdős #98 open: rate h(n)/n → ∞ still requires imported incidence geometry."
     ],
     "markdown": "# Knowledge Base: erdos-98-wip-01\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },


### PR DESCRIPTION
## erdos-98-wip-01 — toward `h 5 ≥ 3`

Continues the distinct-distances-in-general-position line (Erdős #98). The frontier after
`h_five_le_three` (PR #40244, merged) is the matching lower bound `h 5 ≥ 3`. This PR lands
a reusable geometric lemma that kills the worst sub-case of that classification, plus two
concrete unconditional lower-bound thresholds.

### Main result (axiom-free)
`no_four_mutually_equidistant`: in `EuclideanSpace ℝ (Fin 2)` **no four points have all six
pairwise distances equal** to a common `r > 0`. Proof: the edge vectors `u=b-a, v=c-a,
w=d-a` from one vertex satisfy `‖·‖² = r²` and pairwise inner product `r²/2` (from
`‖u-v‖ = r` via `norm_sub_sq_real`); the resulting Gram system forces
`LinearIndependent ℝ ![u,v,w]`, contradicting `finrank (EuclideanSpace ℝ (Fin 2)) = 2`.
This is the planar case of "a regular `k`-simplex needs dimension `k`".

`no_four_equidistant_indices`: config-level specialization to `PointConfig` indices.

### Why this matters for `h 5 ≥ 3`
In a general-position 5-point 2-distance set (distances `a<b`), `card_fiber_dist_le_three`
gives each point `a`/`b`-degree in `{1,2,3}`. A degree-3 vertex `p` with neighbours
`X,Y,Z` at distance `a`, all pairwise `a`, would make `p,X,Y,Z` four mutually equidistant —
**now excluded**. Remaining sub-cases (mixed `a/b` around a degree-3 vertex; the all-degree-2
`C₅`/pentagon case) reduce to intersecting-circle distance equations and are documented as
open, coordinate-geometry-heavy sub-targets.

Also corrects the `h_five_bounds` framing: the plane has several 5-point 2-distance sets,
not just the (concyclic) regular pentagon, so `h 5 ≥ 3` genuinely needs 2-distance-set
structure.

### Unconditional lower-bound thresholds
From `three_mul_h_ge` (`n-1 ≤ 3·h n`):
- `three_le_h_of_eight_le`: `n ≥ 8 → 3 ≤ h n`
- `four_le_h_of_eleven_le`: `n ≥ 11 → 4 ≤ h n`

### Verification
`./proofs/scripts/docker-build.sh Proofs.Erdos98WIP01` — build succeeded (8577 jobs).
0 sorry, 0 axiom, no `native_decide`; new lemmas use only Mathlib + `linarith`/`omega`/
`linear_combination` (foundational axioms only).

Files: `proofs/Proofs/Erdos98WIP01.lean`,
`research/problems/erdos-98-wip-01/knowledge.md`,
`src/data/research/problems/erdos-98-wip-01.json`.
