### PR TITLE
audit: binomial-theorem-oq002 (Multinomial Entropy) clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -30476,6 +30476,12 @@
       "lastAudited": "2026-07-21T08:24:40Z",
       "result": "clean",
       "issues": []
+    },
+    "binomial-theorem-oq002": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T08:27:52Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
Gallery integrity audit — CLEAN. 8 theorems (5 named + 3 private lemmas) + 1 def, 0 ax, 0 sorries, 377 lines — all match. Build EXIT 0. No native_decide/sorry/axiom. #print axioms multinomialEntropy_nonneg/n1_eq_source/upper_bound = only propext/Classical.choice/Quot.sound. Genuine Mathlib real-analysis proofs (Gibbs inequality via Real.add_one_le_exp; source-recovery bijection s≃piAntidiag s 1 via Finset.sum_nbij). Badge `verified` justified.

**Public meta is honest** — originalContributions scopes the binomial case to 'nonneg (proved)' and the upper bound to 'H(X) ≤ log|Comp(s,n)| (proved)', matching the kernel exactly.

**NIT (not reportable — public meta is accurate):** two *file-internal* docstrings over-describe relative to the theorems: `multinomialEntropy_binomial` docstring (line 341) says 'equals the binary entropy h(p)' but the theorem proves only `≥ 0`; `multinomialEntropy_upper_bound` docstring (line 252) says 'Equality holds iff p is uniform' but only the `≤` direction is proved. A future enricher should tighten these comments; no gallery-facing claim is affected. 🤖 Generated with [Claude Code](https://claude.com/claude-code)