### PR TITLE
Enrich erdos-1017 family + erdos-1026: re-anchor drifted Part sections (1..EOF)

### DIFF
--- a/src/data/proofs/erdos-1017-oq-01/meta.json
+++ b/src/data/proofs/erdos-1017-oq-01/meta.json
@@ -102,82 +102,90 @@
   },
   "sections": [
     {
+      "id": "overview",
+      "title": "Module Header and Overview",
+      "startLine": 1,
+      "endLine": 60,
+      "summary": "Module docstring and imports: Erdős Problem #1017 (OQ-01) on clique partitions of dense graphs — background, the open question, what the file proves (reducing 9 axioms to 2), remaining axioms, and proof techniques.",
+      "mathContext": "Setup: clique-partition number of dense graphs; imports and the axiom-reduction summary (9 → 2 axioms)."
+    },
+    {
       "id": "framework",
       "title": "Part I: Edge Clique Partition Framework",
-      "startLine": 38,
-      "endLine": 90,
+      "startLine": 61,
+      "endLine": 88,
       "summary": "Defines `EdgeCliquePartition` (structure with cliques, isClique, covers), `cliquePartitionNum` (sInf of partition sizes), and `usesOnlyEdgesAndTriangles`.",
       "mathContext": "An edge clique partition decomposes $E(G)$ into complete subgraphs. The clique partition number $\\text{cp}(G)$ is the minimum size."
     },
     {
       "id": "turan-bound",
       "title": "Part II: Turán Number ⌊n²/4⌋",
-      "startLine": 91,
-      "endLine": 139,
+      "startLine": 89,
+      "endLine": 155,
       "summary": "Defines `turanBound n = n²/4` with concrete values (0-4) and monotonicity proof.",
       "mathContext": "$\\text{ex}(n, K_3) = \\lfloor n^2/4 \\rfloor$ by Turán's theorem."
     },
     {
       "id": "egp",
       "title": "Part III: Erdős-Goodman-Pósa Theorem (1966)",
-      "startLine": 140,
-      "endLine": 164,
+      "startLine": 156,
+      "endLine": 180,
       "summary": "Axiomatizes EGP: every graph partitions into ≤ ⌊n²/4⌋ cliques using only edges and triangles. Proves corollary `cliquePartitionNum_le_turan`.",
       "mathContext": "$f(n,k) \\leq \\lfloor n^2/4 \\rfloor$ for all $n, k$ (Erdős-Goodman-Pósa 1966)."
     },
     {
       "id": "extremal",
       "title": "Part IV: Extremal Example — Complete Bipartite Graph",
-      "startLine": 165,
-      "endLine": 459,
+      "startLine": 181,
+      "endLine": 469,
       "summary": "Constructs `completeBipartite` with `DecidableRel` instance. Proves `egp_tight_example: cp(K_{k,k}) = k²` and `egp_tight_matches_turan: k² = turanBound(2k)`.",
       "mathContext": "$K_{k,k}$ is triangle-free with $k^2$ edges. Since each edge must be its own clique, $\\text{cp}(K_{k,k}) = k^2 = \\lfloor (2k)^2/4 \\rfloor$."
     },
     {
       "id": "open-question",
       "title": "Part V: The Open Question — Dense Graphs with Large Cliques",
-      "startLine": 460,
-      "endLine": 515,
+      "startLine": 470,
+      "endLine": 550,
       "summary": "Defines `isDense` (more edges than Turán bound), states `erdos1017_question` formally, and proves savings from K₃, K₄, K₅.",
       "mathContext": "**Open**: Can dense graphs with $K_4$ improve on $\\lfloor n^2/4 \\rfloor$?"
     },
     {
       "id": "k4free",
       "title": "Part VI: K₄-Free Case — Győri-Keszegh (2017)",
-      "startLine": 516,
-      "endLine": 565,
+      "startLine": 551,
+      "endLine": 604,
       "summary": "Axiomatizes Győri-Keszegh as the full partition formula `cp(G) = ⌊n²/4⌋ - m`. Proves `k4free_improves`: dense K₄-free graphs have cp < ⌊n²/4⌋. The previously separate `gyori_keszegh_triangles` axiom (m distinct 3-cliques) was eliminated as redundant.",
       "mathContext": "For $K_4$-free graphs: $\\text{cp}(G) = \\lfloor n^2/4 \\rfloor - m$ where $m$ is the excess over $\\lfloor n^2/4 \\rfloor$ (Győri-Keszegh 2017)."
     },
     {
       "id": "connections",
       "title": "Part VII: Lovász Covering Bound (1968)",
-      "startLine": 566,
-      "endLine": 581,
+      "startLine": 605,
+      "endLine": 620,
       "summary": "Axiomatizes the Lovász (1968) covering bound and the clique-partition ≤ n(n−1)/2 edge bound, the classical covering input to the dense-graph estimates.",
       "mathContext": "Related bounds: Lovász covering, edge-coloring duality ($\\text{cp}(G) = \\chi'(\\bar{G})$), and Razborov supersaturation."
     },
     {
       "id": "connections-consequences",
       "title": "Part VIII: Connections and Consequences",
-      "startLine": 582,
-      "endLine": 611,
+      "startLine": 621,
+      "endLine": 650,
       "summary": "Derived consequences tying the framework together: the clique partition is bounded by the edge count, and triangle supersaturation (Razborov 2010) connects density to the number of triangles available for savings.",
       "mathContext": "$\\mathrm{cp}(G) \\le |E(G)|$, and dense graphs contain $\\gg n^3$ triangles (supersaturation), bounding the achievable clique-partition savings."
     },
     {
       "id": "additional-results",
       "title": "Part IX: Additional Proved Results",
-      "startLine": 612,
-      "endLine": 649,
+      "startLine": 651,
+      "endLine": 700,
       "summary": "Further proved corollaries, notably that dense graphs under the K₄-free constraint improve strictly more than the general dense case, sharpening the savings comparison.",
       "mathContext": "Under the $K_4$-free constraint, dense graphs achieve strictly larger clique-partition savings than the general dense bound."
     },
     {
       "id": "verification",
       "title": "Part X: Verification",
-      "startLine": 650,
-      "endLine": 696,
+      "startLine": 701,
+      "endLine": 750,
       "summary": "#check verification block confirming the core framework (EdgeCliquePartition, cliquePartitionNum) and the main results type-check as stated.",
       "mathContext": "Static `#check` confirmation that the declared framework and theorems elaborate correctly."
     }

--- a/src/data/proofs/erdos-1017/meta.json
+++ b/src/data/proofs/erdos-1017/meta.json
@@ -73,71 +73,71 @@
       "id": "part2-turan-bound",
       "title": "Part II: Turán Number and ⌊n²/4⌋",
       "startLine": 89,
-      "endLine": 137,
+      "endLine": 155,
       "summary": "Defines `turanBound n = ⌊n²/4⌋` and proves its basic arithmetic: explicit small values (0,0,1,2,4 for n=0..4), monotonicity (`turanBound_mono`), the product form `turanBound_eq_product` (⌊n²/4⌋ = (n/2)(n − n/2)), and positivity `turanBound_pos` for n ≥ 2.",
       "mathContext": "Turán bound: $\\lfloor n^2/4 \\rfloor = (n/2)(n - n/2)$, the EGP upper bound on cp(G)."
     },
     {
       "id": "part3-egp",
       "title": "Part III: Erdős-Goodman-Pósa Theorem (1966)",
-      "startLine": 138,
-      "endLine": 162,
+      "startLine": 156,
+      "endLine": 180,
       "summary": "Axiomatizes `egp_theorem` (every graph satisfies cp(G) ≤ ⌊n²/4⌋) and derives the corollary `cliquePartitionNum_le_turan`.",
       "mathContext": "EGP (1966): $cp(G) \\leq \\lfloor n^2/4 \\rfloor$ for every graph G on n vertices."
     },
     {
       "id": "part4-extremal-bipartite",
       "title": "Part IV: Extremal Example — Complete Bipartite Graph",
-      "startLine": 163,
-      "endLine": 457,
+      "startLine": 181,
+      "endLine": 469,
       "summary": "Constructs the extremal complete bipartite graph K_{a,b} (`completeBipartite` with its decidable adjacency instance), proves it is triangle-free (`completeBipartite_cliqueFree`) with exactly a·b edges (`completeBipartite_edgeCount`), establishes `triangleFree_cliquePartition_eq_edges` (cp(G) = |E| for triangle-free G, via one 2-vertex clique per edge for the upper bound and clique counting for the lower bound), and concludes `egp_tight_example`/`egp_tight_matches_turan`: K_{k,k} attains cp = k² = ⌊(2k)²/4⌋, so the EGP bound is tight.",
       "mathContext": "Extremal: $K_{k,k}$ achieves equality $cp(K_{k,k}) = k^2 = \\lfloor (2k)^2/4 \\rfloor$. For triangle-free G, $cp(G) = |E(G)|$."
     },
     {
       "id": "part5-open-question",
       "title": "Part V: The Open Question — Dense Graphs with Large Cliques",
-      "startLine": 458,
-      "endLine": 513,
+      "startLine": 470,
+      "endLine": 550,
       "summary": "Defines `isDense` and proves `dense_contains_triangle`; formalizes the open question `erdos1017_question` (is there c ∈ (0,1) with cp(G) ≤ c·⌊n²/4⌋ for all sufficiently dense graphs?) and proves the clique-savings arithmetic (`triangle_saves` = 2, `k4_saves` = 5, `k5_saves` = 9, `k4_saves_more_than_triangle`, `clique_savings`, `savings_growth`), quantifying how a K_r saves ⌊r(r−1)/2⌋ − 1 over using individual edges.",
       "mathContext": "Open question: can $\\lfloor n^2/4\\rfloor$ be improved to $c\\lfloor n^2/4\\rfloor$, $c<1$, for dense graphs? A $K_r$ saves $\\binom{r}{2}-1$ cliques."
     },
     {
       "id": "part6-k4free",
       "title": "Part VI: K₄-Free Case — Győri-Keszegh (2017)",
-      "startLine": 514,
-      "endLine": 563,
+      "startLine": 551,
+      "endLine": 604,
       "summary": "Axiomatizes `k4free_partition_number` (Győri-Keszegh 2017: a K₄-free graph with ⌊n²/4⌋ + m edges has m edge-disjoint triangles, so cp(G) = ⌊n²/4⌋ − m) and derives `k4free_improves` and `k4free_savings_linear` — the resolved K₄-free instance of the open question.",
       "mathContext": "Győri-Keszegh (2017): for K₄-free G with $\\lfloor n^2/4\\rfloor + m$ edges, $cp(G) = \\lfloor n^2/4\\rfloor - m$."
     },
     {
       "id": "part7-lovasz",
       "title": "Part VII: Lovász Covering Bound (1968)",
-      "startLine": 564,
-      "endLine": 579,
+      "startLine": 605,
+      "endLine": 620,
       "summary": "Proves `lovasz_covering`, the Lovász (1968) edge-covering bound for clique partitions.",
       "mathContext": "Lovász (1968) covering bound for edge clique partitions."
     },
     {
       "id": "part8-connections",
       "title": "Part VIII: Connections and Consequences",
-      "startLine": 580,
-      "endLine": 609,
+      "startLine": 621,
+      "endLine": 650,
       "summary": "Proves `cliquePartition_le_vertices` (cp(G) ≤ |V|) and `supersaturation_triangles`, linking edge surplus over the Turán threshold to forced triangles.",
       "mathContext": "cp(G) $\\leq$ |V|; supersaturation forces triangles past the Turán edge count."
     },
     {
       "id": "part9-additional",
       "title": "Part IX: Additional Proved Results",
-      "startLine": 610,
-      "endLine": 647,
+      "startLine": 651,
+      "endLine": 700,
       "summary": "Further lemmas: `k4free_double_savings`, `turanBound_succ_diff` (the increment ⌊(n+1)²/4⌋ − ⌊n²/4⌋), `turanBound_le_choose_two` (⌊n²/4⌋ ≤ C(n,2)), and `triangle_free_not_dense`.",
       "mathContext": "Auxiliary bounds: Turán increments, $\\lfloor n^2/4\\rfloor \\leq \\binom{n}{2}$, triangle-free graphs are not dense."
     },
     {
       "id": "part10-verification",
       "title": "Part X: Verification",
-      "startLine": 648,
-      "endLine": 696,
+      "startLine": 701,
+      "endLine": 750,
       "summary": "`#check` commands confirming all main definitions, theorems, and the two remaining axioms (`egp_theorem`, `k4free_partition_number`) type-check; closes the namespace.",
       "mathContext": "Type-check verification of all definitions, theorems, and the 2 remaining axioms."
     }

--- a/src/data/proofs/erdos-1026/meta.json
+++ b/src/data/proofs/erdos-1026/meta.json
@@ -92,7 +92,7 @@
       "id": "header",
       "title": "Module Header and Imports",
       "startLine": 1,
-      "endLine": 48,
+      "endLine": 44,
       "summary": "Module docstring documenting the problem statement, background, and references; 6 Mathlib imports covering required modules; `open` declarations (Finset BigOperators); namespace `Erdos1026`",
       "mathContext": "Module docstring documenting the problem statement, background, and references; 6 Mathlib imports covering required modules; `open` declarations (Finset BigOperators); namespace `Erdos1026`"
     },
@@ -100,64 +100,64 @@
       "id": "sequences",
       "title": "Sequences and Monotonicity",
       "summary": "RealSeq, Subsequence, IsIncreasing, IsDecreasing, IsMonotonic, subsequenceSum",
-      "startLine": 49,
-      "endLine": 82,
+      "startLine": 45,
+      "endLine": 78,
       "mathContext": "Definitions: $\\text{RealSeq}(n) = \\text{Fin}\\,n \\to \\mathbb{R}$, $\\text{Subsequence}(n,m)$ with StrictMono indices. Increasing: $\\text{StrictMono}(\\text{seq} \\circ \\sigma)$. Decreasing: pointwise $i < j \\implies x_{\\sigma(j)} < x_{\\sigma(i)}$. Sum: $\\sum_{i} x_{\\sigma(i)}$."
     },
     {
       "id": "erdos-szekeres",
       "title": "The Erdős-Szekeres Theorem",
       "summary": "Classical (r-1)(s-1)+1 bound and n²+1 corollary",
-      "startLine": 83,
-      "endLine": 107,
+      "startLine": 79,
+      "endLine": 137,
       "mathContext": "Axiomatized: any injective $x: \\text{Fin}((r-1)(s-1)+1) \\to \\mathbb{R}$ has an increasing subsequence of length $r$ or decreasing of length $s$. Corollary: $k^2+1$ elements yield monotonic length $\\geq k+1$."
     },
     {
       "id": "hanani",
       "title": "Hanani's Decomposition",
       "summary": "MonotonicDecomposition structure and √(2n) bound",
-      "startLine": 108,
-      "endLine": 140,
+      "startLine": 138,
+      "endLine": 160,
       "mathContext": "Structure with `numParts`, `parts : Fin p → Σ m, Subsequence n m`, monotonicity, disjointness, covering. Hanani: $\\exists$ decomposition with $p \\leq \\sqrt{2n} + 1$. Dilworth variant: $p \\leq 2\\sqrt{n}$."
     },
     {
       "id": "max-sum",
       "title": "The Maximum Monotonic Sum Problem",
       "summary": "maxMonotonicSumLength, maxMonotonicSum, normalizedRatio",
-      "startLine": 141,
-      "endLine": 159,
+      "startLine": 161,
+      "endLine": 179,
       "mathContext": "$\\text{maxMonotonicSum} = \\sup\\{\\sum x_{\\sigma(i)} : \\sigma \\text{ monotonic}\\}$ via `sSup`. Normalized ratio: $c_n(\\text{seq}) = \\text{maxMonotonicSum} \\cdot \\sqrt{n} / \\text{totalSum}$."
     },
     {
       "id": "bounds",
       "title": "The Main Conjecture",
       "summary": "Hanani lower bound (c ≥ 1/√2), Cambie upper bound (c ≤ 1)",
-      "startLine": 160,
-      "endLine": 186,
+      "startLine": 180,
+      "endLine": 196,
       "mathContext": "Lower: $\\text{maxMonotonicSum} \\geq S/(\\sqrt{2n}+1)$, so $c \\geq 1/\\sqrt{2}$. Upper: $\\forall \\varepsilon > 0,\\; \\exists$ seq with $\\text{maxMonotonicSum} \\leq (1+\\varepsilon) \\cdot S/\\sqrt{n}$, so $c \\leq 1$."
     },
     {
       "id": "weighted",
       "title": "The Weighted Erdős-Szekeres Theorem",
       "summary": "weighted_erdos_szekeres, tidor_wang_yang, optimal_constant_is_one",
-      "startLine": 187,
-      "endLine": 226,
+      "startLine": 197,
+      "endLine": 227,
       "mathContext": "Weighted ES: for $n = k^2$ distinct positive reals with $\\sum x_i = 1$, $\\text{maxMonotonicSum} \\geq 1/k$. Tidor-Wang-Yang proved this in 2016. Optimal constant: $\\forall \\varepsilon > 0,\\; \\text{maxMonotonicSum} \\geq (1-\\varepsilon) \\cdot S/\\sqrt{n}$."
     },
     {
       "id": "related",
       "title": "Related Results",
       "summary": "LIS, LDS definitions and bounds",
-      "startLine": 227,
-      "endLine": 250,
+      "startLine": 228,
+      "endLine": 293,
       "mathContext": "$\\text{LIS} = \\sup\\{m : \\exists \\text{ increasing subseq of length } m\\}$. $\\text{LIS} \\cdot \\text{LDS} \\geq n$ (Erdős-Szekeres). $\\max(\\text{LIS}, \\text{LDS}) \\geq \\sqrt{n}$."
     },
     {
       "id": "main",
       "title": "Main Results Summary",
       "summary": "erdos_1026 theorem, tightness, tournament connection",
-      "startLine": 251,
-      "endLine": 283,
+      "startLine": 294,
+      "endLine": 324,
       "mathContext": "`erdos_1026` is a direct application of `tidor_wang_yang`. Tightness: Cambie's construction achieves $1/k + \\varepsilon$. Tournament: directed path of length $\\geq \\sqrt{n}$ in any tournament gives an alternative proof route."
     }
   ],


### PR DESCRIPTION
## Enrichment: section re-anchor batch 2 (erdos-1017 family + erdos-1026)

More drift re-anchors from the fresh-`origin/main` undercoverage scan. Section arrays lagged the source `Part N` banner blocks and left tails (and one head) uncovered. Re-anchored contiguously to `1..EOF` (gap ∈ [0,2], `maxEnd === EOF`), preserving existing summaries/`mathContext` via object spread.

| Entry | Change | Fix |
|-------|--------|-----|
| `erdos-1017` | 11 (re-anchor) | Parts III–X drifted (Part III claimed @138 vs banner @156, Part IV @163 vs @181, …); tail 697–749 (Part X Verification) now covered |
| `erdos-1017-oq-01` | 10→11 | sibling meta over the **same** `Erdos1017OQ01.lean` — same drift + head 1–60 was uncovered; added Overview head |
| `erdos-1026` | 9 (re-anchor) | Parts drifted ~5–12 lines behind `## Part N` banners; Part VIII (@294) tail 284–323 was uncovered |

**Integrity:** no `status`/`badge`/`axiomCount` changes — verified against source (`erdos-1017` genuinely 2 axioms as its header states; `erdos-1026` 1 axiom; both `axiomatized`). `lineCount` refreshed. Surgical diffs (`startLine`/`endLine` + one new head section), no re-serialization noise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
