### PR TITLE
audit: bezout-identity-oq011 (norm-Euclidean ℤ[√d] uniform family) clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -30476,6 +30476,12 @@
       "lastAudited": "2026-07-21T08:24:40Z",
       "result": "clean",
       "issues": []
+    },
+    "bezout-identity-oq011": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T08:31:17Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Gallery integrity audit — CLEAN

**Proof**: bezout-identity-oq011 — "Norm-Euclidean ℤ[√d] for d ∈ {−1,−2}: A Uniform Family with One Bound"

Re-served target (prior audit PR #40203 closed without merging, so the tracker entry never landed).

### Verified
- **Counts**: 11 theorems, 5 defs, 229 lines — all match meta.json exactly.
- **0 sorries, 0 axioms**: no `sorry`, no `axiom` decl, no `native_decide` (the only `native_decide` string is in the header docstring).
- **Build**: `lake env lean` compiles (only cosmetic `@[reducible]`-on-class warnings).
- **`#print axioms`**: `four_mul_norm_rem_le`, `euclideanDomain`, `nearest_point_factor_ge_one_of_le_neg_three` depend only on `propext, Classical.choice, Quot.sound`. No `sorryAx`, no `Lean.ofReduceBool`.
- **Badge `original` justified**: genuine from-scratch norm-Euclidean division argument over Mathlib's `Zsqrtd`/`round`/`abs_sub_round` infrastructure; description honestly discloses the Mathlib dependency.
- **No overclaim**: `euclideanDomain` is scoped to `-2 ≤ d < 0` (= {−1,−2}), matching the description; the `d ≤ −3` obstruction is a real theorem and honest scope-limiting, not axiom masking.
- All `originalContributions` map to real declarations.

Tracker updated to record the clean result.

---
Discovered during gallery integrity audit.