### PR TITLE
audit: bezout-identity oq011/oq014/oq016/oq023 clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -30482,6 +30482,30 @@
       "lastAudited": "2026-07-21T08:27:52Z",
       "result": "clean",
       "issues": []
+    },
+    "bezout-identity-oq011": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T08:35:44Z",
+      "result": "clean",
+      "issues": []
+    },
+    "bezout-identity-oq014": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T08:35:45Z",
+      "result": "clean",
+      "issues": []
+    },
+    "bezout-identity-oq016": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T08:35:45Z",
+      "result": "clean",
+      "issues": []
+    },
+    "bezout-identity-oq023": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T08:35:45Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Gallery Integrity Audit — Bézout cluster (4 entries)

Batch audit of four Bézout-cluster entries that were unrecorded in the tracker (oq016 lost to a prior merge-race; oq011 was stuck behind CONFLICTING PR #40282, now closed). All four verify **clean** — meta claims match the Lean sources.

| id | file | thm/def | sorry/axiom | badge | verdict |
|----|------|---------|-------------|-------|---------|
| oq011 | NormEuclideanZsqrtdFamilyOQ03 | 11/5 | 0/0 | original | clean |
| oq014 | BezoutIdentityOQ02OQ01OQ02OQ03 | 24/1 | 0/0 | original | clean |
| oq016 | BezoutIdentityOQ02OQ01OQ03OQ01 | 12/0 | 0/0 | original | clean |
| oq023 | BezoutIdentityOQ03OQ01OQ01OQ02 | 9/0 | 0/0 | mathlib | clean |

### Findings
- **oq011** — Uniform norm-Euclidean bound `4·N(r)·N(y) ≤ (1−d)·N(y)²` proved from first principles over Mathlib `Zsqrtd`; single `EuclideanDomain` recovers ℤ[i] and ℤ[√-2]; honest `d ≤ −3` obstruction. The only `native_decide` grep hit is the docstring line *"no native_decide"* — no real use. Counts exact.
- **oq014** — ℤ[√-5]-not-a-UFD proved genuinely (`two_irreducible`, `two_not_prime`, `zsqrtneg5_not_ufd`); ideal-FTA honestly credited to Mathlib. Uses kernel `decide` only (assumptions text mentions "native_decide" but none is used — safe over-disclosure, not an overclaim). 24 thm exact.
- **oq016** — General non-coprime linear-Diophantine classification; meta documents a verified `#print axioms` (only propext/Classical.choice/Quot.sound). Counts exact.
- **oq023** — k-fold CRT cardinality preservation; badge `mathlib` correct, and the meta honestly notes the headline is "also immediate from `Nat.card_zmod` alone." Counts exact.

Supersedes stale CONFLICTING PR #40282 (oq011).

---
Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)