### PR TITLE
Enrich erdos-1216: re-anchor stale placeholder sections to real formalization (5→7, 1..62/EOF)

### DIFF
--- a/src/data/proofs/erdos-1216/annotations.json
+++ b/src/data/proofs/erdos-1216/annotations.json
@@ -81,7 +81,7 @@
     },
     "type": "insight",
     "title": "Reid-Parker (1970): The Answer is NO for n ≥ 14",
-    "content": "Reid and Parker (1970) proved that f(n) > ⌊log₂ n⌋ + 1 for n ≥ 14, answering Erdős's question in the negative. They showed f(n) ≥ ⌊log₂ n + 4 - log₂ 7⌋ for n ≥ 14. Since log₂ n + 4 - log₂ 7 = log₂(n/7) + 4 > ⌊log₂ n⌋ + 1 when n is large enough, the Stearns bound ⌊log₂ n⌋ + 1 is not tight. This was improved further by Sanchez-Flores (1994), giving f(n) ≥ ⌊log₂ n - log₂ 55⌋ + 7 for n ≥ 55. The constants reflect specific tournament constructions that beat the greedy bound.',",
+    "content": "Reid and Parker (1970) proved that f(n) > ⌊log₂ n⌋ + 1 for n ≥ 14, answering Erdős's question in the negative. They showed f(n) ≥ ⌊log₂ n + 4 - log₂ 7⌋ for n ≥ 14. Since log₂ n + 4 - log₂ 7 = log₂(n/7) + 4 > ⌊log₂ n⌋ + 1 when n is large enough, the Stearns bound ⌊log₂ n⌋ + 1 is not tight. This was improved further by Sanchez-Flores (1994), giving f(n) ≥ ⌊log₂ n - log₂ 55⌋ + 7 for n ≥ 55. The constants reflect specific tournament constructions that beat the greedy bound.",
     "mathContext": "Reid-Parker (1970): $f(n) \\geq \\lfloor \\log_2 n + 4 - \\log_2 7 \\rfloor$ for $n \\geq 14$. Since $4 - \\log_2 7 \\approx 1.193$, this exceeds $\\lfloor \\log_2 n \\rfloor + 1$ by roughly $0.193$, meaning for $n = 2^k \\cdot 7$, $f(n) \\geq k + 5 > \\lfloor \\log_2 n \\rfloor + 1 = k + 2 + 1 = k + 3$.",
     "significance": "key",
     "relatedConcepts": [
@@ -100,26 +100,27 @@
     "id": "ann-1216-lean-formalization",
     "proofId": "erdos-1216",
     "range": {
-      "startLine": 18,
-      "endLine": 23
+      "startLine": 24,
+      "endLine": 62
     },
     "type": "concept",
-    "title": "Lean Formalization: Tournament Theory in Mathlib",
-    "content": "The Stearns lower bound is the most accessible part of Problem #1216 for formalization. Mathlib has `SimpleGraph` but tournament-specific types (complete directed graphs) may need to be defined. Key components: (1) `Tournament V` as a type where for all u ≠ v, exactly one of `adj u v` or `adj v u` holds; (2) `outDegree T v = (T.neighborFinset v).card` for out-degree; (3) the greedy algorithm implemented as a recursive function picking vertices with maximum out-degree; (4) `Nat.log 2 n` for ⌊log₂ n⌋. The halving argument (out-neighborhood has size ≥ n/2) can be proved by averaging: ∑_v outDegree(v) = n(n-1)/2, so some vertex has out-degree ≥ (n-1)/2.",
-    "mathContext": "Lean sketch: `structure Tournament (V : Type*) where adj : V → V → Prop; complete : ∀ u v, u ≠ v → adj u v ∨ adj v u; antisymm : ∀ u v, ¬(adj u v ∧ adj v u)`. Then `f : ℕ → ℕ` with `f n = Nat.log 2 n + 1` (Stearns lower bound, conjectured equality). The greedy proof: `∃ v, T.outDegree v ≥ (n-1)/2` by `Finset.exists_le_of_sum_le`.",
+    "title": "Lean Formalization: Tournament Structure, Def, and Axiomatized Bound",
+    "content": "The file formalizes tournaments from scratch rather than via `SimpleGraph`. It defines `structure Tournament (V : Type*)` carrying `beats : V → V → Prop` together with the tournament law `∀ x y, x ≠ y → (beats x y ↔ ¬ beats y x)` and irreflexivity `∀ x, ¬ beats x x`; the biconditional encodes completeness and antisymmetry simultaneously (exactly one directed edge per pair). `IsTransitiveTournament T S` then requires `beats x y → beats y z → beats x z` for all x, y, z in a `Finset` subset S. The Stearns lower bound itself is introduced as `axiom stearns_lower_bound`, asserting a transitive S with `S.card ≥ Nat.log 2 n + 1`, and the headline `theorem erdos_1216` is proved by directly applying that axiom. The greedy construction underlying Stearns's bound is NOT proved here — it is assumed, which is why the entry is axiomatized (axiomCount = 1, badge \"axiom\") and asserts only the lower bound.",
+    "mathContext": "Actual Lean: `structure Tournament (V : Type*) where beats : V → V → Prop; tournament : ∀ x y, x ≠ y → (beats x y ↔ ¬ beats y x); irrefl : ∀ x, ¬ beats x x`, and `def IsTransitiveTournament (T : Tournament V) (S : Finset V) : Prop := ∀ x y z, x ∈ S → y ∈ S → z ∈ S → T.beats x y → T.beats y z → T.beats x z`. The unformalized greedy step would establish `∃ v, |N⁺(v)| ≥ (n-1)/2` via averaging ($\\sum_v \\deg^+(v) = \\binom{n}{2}$); packaging it as an `axiom` records the mathematical assumption instead of the (omitted) proof.",
     "significance": "supporting",
     "relatedConcepts": [
-      "SimpleGraph in Mathlib",
+      "structure vs SimpleGraph modelling",
+      "Prop-valued relation",
       "Finset.card",
       "Nat.log 2",
-      "greedy algorithm in Lean",
-      "averaging argument formalization"
+      "axiomatized lower bound",
+      "greedy averaging argument"
     ],
     "prerequisites": [
-      "Lean 4 Finset",
-      "SimpleGraph.neighborFinset",
+      "Lean 4 structures",
+      "Finset",
       "Nat.log",
-      "Finset.sum averaging"
+      "axiom vs theorem in Lean"
     ]
   }
 ]

--- a/src/data/proofs/erdos-1216/meta.json
+++ b/src/data/proofs/erdos-1216/meta.json
@@ -44,41 +44,57 @@
       "id": "problem-header",
       "title": "Problem Header: Directed Ramsey Numbers",
       "startLine": 1,
-      "endLine": 7,
-      "summary": "Module comment header identifying Erdős Problem #1216, source URL, and status (SOLVED — Erdős's question of whether f(n) = ⌊log₂ n⌋+1 answered NO by Reid-Parker 1970).",
+      "endLine": 9,
+      "summary": "Module docstring identifying Erdős Problem #1216, source URL, and status: the Stearns (1959) lower bound is formalized, and Erdős's question of whether f(n) = ⌊log₂ n⌋+1 exactly is stated. It defines f(n) as the largest k such that every n-vertex tournament contains a transitive tournament on k vertices.",
       "mathContext": "A tournament $T$ on $n$ vertices is a complete directed graph: for every pair $\\{u,v\\}$, exactly one of $u \\to v$ or $v \\to u$ holds. The function $f(n) = \\min_{|T|=n} \\max\\{k : T \\supseteq T_k^\\mathrm{trans}\\}$ measures the guaranteed transitive subtournament size. The directed Ramsey number $R_{\\rm dir}(k) = \\min\\{n : f(n) \\ge k\\}$ is the inverse function."
     },
     {
-      "id": "problem-statement",
-      "title": "Mathematical Statement: f(n) vs ⌊log₂ n⌋+1",
-      "startLine": 8,
-      "endLine": 14,
-      "summary": "Documents the full problem: is f(n) = ⌊log₂ n⌋+1? Records Stearns's greedy lower bound (f(n) ≥ ⌊log₂ n⌋+1) and that the directed Ramsey number is the inverse of f(n). The question was answered NO for large n.",
+      "id": "answer-and-definitions",
+      "title": "Answer (NO) and Prose Definitions",
+      "startLine": 10,
+      "endLine": 20,
+      "summary": "The docstring records the resolution: Stearns (1959) proved f(n) ≥ ⌊log₂ n⌋+1 by a greedy construction, but Reid–Parker (1970) proved f(n) grows strictly faster for n ≥ 14, so Erdős's conjectured equality FAILS; the exact growth rate (between log₂ n and 2·log₂ n) is open. It then gives the prose definitions of a tournament (complete directed graph, one direction per edge) and a transitive tournament (i → j → k implies i → k).",
       "mathContext": "Stearns's greedy proof: start with any vertex $v_1$; its out-neighborhood $N^+(v_1)$ has size $\\ge \\lceil(n-1)/2\\rceil$. Pick $v_2 \\in N^+(v_1)$; the out-neighborhood of $v_2$ within $N^+(v_1)$ has size $\\ge \\lfloor(|N^+(v_1)|-1)/2\\rfloor \\ge (n-3)/4$. After $k$ steps, the remaining set has size $\\ge n/2^k - C$, giving a transitive chain $v_1 \\to v_2 \\to \\cdots \\to v_k$ of length $k = \\lfloor \\log_2 n\\rfloor + 1$."
     },
     {
       "id": "imports",
       "title": "Mathlib Import",
-      "startLine": 16,
-      "endLine": 16,
-      "summary": "Full Mathlib import providing `SimpleGraph`, `Finset`, `Nat.log`, and tournament infrastructure for the eventual formalization.",
-      "mathContext": "Key Mathlib tools for formalization: `SimpleGraph.Tournament` (tournament predicate on `SimpleGraph V`); `SimpleGraph.neighborFinset` (out-neighborhood as `Finset V`); `Finset.exists_max_image` (greedy maximum selection); `Nat.log` (for the ⌊log₂ n⌋ bound). The greedy induction would use `Finset.card_pos` to ensure the neighborhood is nonempty at each step."
-    },
-    {
-      "id": "placeholder-theorem",
-      "title": "Placeholder Theorem: erdos_1216",
-      "startLine": 18,
-      "endLine": 20,
-      "summary": "Placeholder `erdos_1216 : True := by sorry`. The Stearns lower bound would be: ∀ n : ℕ, ∀ T : SimpleGraph (Fin n), T.IsTournament → ∃ S : Finset (Fin n), S.card ≥ Nat.log 2 n + 1 ∧ T.IsTransitiveOn S.",
-      "mathContext": "The Lean formalization of 'transitive subtournament on $S$': $\\forall u \\in S, \\forall v \\in S, \\forall w \\in S$, $T.Adj u v \\to T.Adj v w \\to T.Adj u w$. The greedy step requires showing that the out-neighborhood of any vertex in a tournament has size $\\ge (n-1)/2$, formalized as `SimpleGraph.Tournament.exists_large_outNeighborhood`."
-    },
-    {
-      "id": "check-statement",
-      "title": "Type Check",
       "startLine": 22,
-      "endLine": 23,
-      "summary": "`#check erdos_1216` verifies the theorem is well-typed. The sorry marker comment documents that this is a placeholder for future formalization.",
-      "mathContext": "The current placeholder type `True` is a sentinel: any proof of `True` is trivial (`trivial`), but using `sorry` marks it for tracking. When the actual formalization is complete, the type will be replaced with the Stearns bound and the proof by the greedy algorithm."
+      "endLine": 22,
+      "summary": "Full `import Mathlib`, providing `Finset`, `Nat.log`, and the `Prop`/relation infrastructure used by the self-contained tournament definitions below.",
+      "mathContext": "The file defines tournaments directly as a structure carrying a `Prop`-valued relation rather than reusing `SimpleGraph`, so it needs only `Finset` (for the subset $S$ and its cardinality) and `Nat.log 2 n` (for the $\\lfloor \\log_2 n\\rfloor$ bound) from Mathlib."
+    },
+    {
+      "id": "tournament-structure",
+      "title": "Tournament Structure",
+      "startLine": 24,
+      "endLine": 30,
+      "summary": "Opens `namespace Erdos1216` and defines `structure Tournament (V : Type*)`: a relation `beats : V → V → Prop` with the tournament axiom `∀ x y, x ≠ y → (beats x y ↔ ¬ beats y x)` (exactly one direction on every non-loop edge) and irreflexivity `∀ x, ¬ beats x x`.",
+      "mathContext": "This encodes a complete directed graph with no self-loops. For distinct $x,y$ the biconditional $\\text{beats}\\,x\\,y \\iff \\lnot\\,\\text{beats}\\,y\\,x$ forces exactly one directed edge per pair (completeness + antisymmetry combined), and `irrefl` rules out loops. Using a bare relation instead of `SimpleGraph` keeps the statement classical and self-contained."
+    },
+    {
+      "id": "transitive-subtournament",
+      "title": "Transitive Subtournament Predicate",
+      "startLine": 32,
+      "endLine": 35,
+      "summary": "Defines `IsTransitiveTournament T S` for a `Finset V` subset S: for all x, y, z ∈ S, `beats x y → beats y z → beats x z`. A transitive subtournament is one whose induced relation is genuinely transitive — a directed chain / total order.",
+      "mathContext": "On a tournament, a transitive subset $S$ carries a strict total order: transitivity plus the tournament trichotomy makes $(S,\\to)$ isomorphic to a linear order $v_1 \\to v_2 \\to \\cdots \\to v_k$. The quantity $f(n)$ is the largest such $|S|$ guaranteed to exist in every $n$-vertex tournament."
+    },
+    {
+      "id": "stearns-axiom",
+      "title": "Stearns Lower Bound (Axiom)",
+      "startLine": 37,
+      "endLine": 47,
+      "summary": "`axiom stearns_lower_bound (n : ℕ) (hn : n ≥ 1) (T : Tournament (Fin n))`: there exists a Finset S with `S.card ≥ Nat.log 2 n + 1` that is a transitive subtournament. This is Stearns's 1959 result, taken as an assumption; the docstring stresses that no upper-bound/equality companion is asserted since Erdős's equality is false (Reid–Parker 1970).",
+      "mathContext": "The assumed greedy proof repeatedly restricts to the out-neighborhood of a chosen vertex, roughly halving the vertex count each step, and after $\\le \\lfloor \\log_2 n\\rfloor + 1$ steps yields a transitive chain. It is encoded as an `axiom` because the greedy induction itself is not formalized here — hence the entry is `axiomatized` with `axiomCount = 1`."
+    },
+    {
+      "id": "main-theorem",
+      "title": "Main Theorem: erdos_1216",
+      "startLine": 49,
+      "endLine": 62,
+      "summary": "`theorem erdos_1216` restates the lower-bound direction — for all n ≥ 1 and every tournament T on `Fin n`, there is a transitive subtournament S with `S.card ≥ Nat.log 2 n + 1` — and is proved directly by `stearns_lower_bound`. `end Erdos1216` closes the namespace.",
+      "mathContext": "The theorem's statement is definitionally the axiom's, so the proof term is just `stearns_lower_bound`, packaging the assumed Stearns bound as the file's headline result. It deliberately omits any upper bound, since Erdős's conjectured equality $f(n)=\\lfloor\\log_2 n\\rfloor+1$ fails for $n\\ge 14$ (Reid–Parker 1970)."
     }
   ],
   "crossReferences": [


### PR DESCRIPTION
## Enrichment: erdos-1216 (Largest Transitive Subtournament / Directed Ramsey Numbers)

**Problem found:** the `sections[]` array in `meta.json` described an obsolete *placeholder* version of the Lean file — sections titled "Placeholder Theorem: erdos_1216" and "Type Check" referenced `erdos_1216 : True := by sorry` and a `#check` that no longer exist. Meanwhile the file has since grown into a real formalization whose actual content (lines 24–62) was entirely uncovered.

**What the file actually contains now** (`Proofs/Erdos1216Problem.lean`, 62 lines):
- `structure Tournament (V)` — `beats` relation + tournament law + irreflexivity
- `def IsTransitiveTournament`
- `axiom stearns_lower_bound` (Stearns 1959 greedy lower bound, assumed)
- `theorem erdos_1216 := stearns_lower_bound`

**Changes**
- Re-anchored `sections` from 5 → 7, now covering **1..62/EOF** with accurate summaries + `mathContext` for the `Tournament` structure, the transitive-subtournament def, the Stearns axiom, and the main theorem. Removed the two false placeholder/type-check sections.
- Re-anchored the stale `[18-23] Lean Formalization` annotation to `[24-62]` and rewrote it to describe the **actual** structure/def/axiom (was a hypothetical sketch with different field names `adj/complete/antisymm`).
- Fixed a stray `',` artifact in the Reid-Parker annotation prose.

**Integrity:** counts unchanged and verified against source — 1 axiom, 2 defs, 1 theorem, 0 sorries; `status: axiomatized`, `badge: axiom`, `axiomCount: 1` all accurate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
