### PR TITLE
audit: binomial-theorem-oq001 (Composition Fintype via piAntidiag) clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -30506,6 +30506,12 @@
       "lastAudited": "2026-07-21T08:35:45Z",
       "result": "clean",
       "issues": []
+    },
+    "binomial-theorem-oq001": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T08:40:18Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Gallery integrity audit — CLEAN

**Proof**: binomial-theorem-oq001 — *Fintype Instance for Composition via piAntidiag*

Verified meta.json against `proofs/Proofs/BinomialTheoremOQ02OQ01OQ01.lean`:

- **Sorries**: 0 (meta: 0 ✓) — no line-anchored `sorry` decls
- **Axioms**: 0 literal `axiom` decls. `axiomCount: 1` is the honest `Lean.ofReduceBool` disclosure for 3 `native_decide` computational checks (two `piAntidiag.card` examples + `dice_six_rolls_all_different`), documented in `assumptions`
- **theoremCount 5**: all present (ext_counts, card_composition, card_composition_zero, dice_six_rolls_all_different, sum_composition_eq_piAntidiag_sum)
- **originalContributions**: all 7 map to real declarations — no phantoms
- **Labeling**: `status: axiomatized`/`badge: axiom` is conservative (core Fintype/bijection/cardinality fully proved); title names no famous theorem. Safe direction — not an overclaim.

No changes needed to meta.json. Tracker updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)