### PR TITLE
audit: binomial-theorem-oq003 (degree-one multinomial support = index set) clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -30512,6 +30512,12 @@
       "lastAudited": "2026-07-21T08:40:18Z",
       "result": "clean",
       "issues": []
+    },
+    "binomial-theorem-oq003": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T08:41:46Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Gallery integrity audit — CLEAN

**Proof**: binomial-theorem-oq003 — *the degree-one multinomial support is the index set*

Verified meta.json against `proofs/Proofs/BinomialTheoremOQ02OQ01OQ01OQ02OQ01.lean`:

- **theoremCount 4**, **definitionCount 1**: all present (single_mem_piAntidiag_one, piAntidiag_one_eq_image, single_one_injective, card_piAntidiag_one; def piAntidiagOneEquiv)
- **Sorries**: 0 ✓ · **Axioms**: 0 ✓ · no `native_decide`
- `#print axioms` disclosure (propext/Classical.choice/Quot.sound only, no sorryAx/ofReduceBool) accurate
- **Labeling**: `verified`/`original` correct — original structural lemmas (e.g. `piAntidiag_one_eq_image`, not in Mathlib) built on Mathlib's `Finset.piAntidiag` API; no Mathlib-wrapper masking. All 5 originalContributions map to real decls.

No changes needed to meta.json. Tracker updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)