### PR TITLE
audit: binomial-theorem-oq004 (Multinomial Marginal CLT) clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -30518,6 +30518,12 @@
       "lastAudited": "2026-07-21T08:41:46Z",
       "result": "clean",
       "issues": []
+    },
+    "binomial-theorem-oq004": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T08:43:36Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Gallery integrity audit — CLEAN

**Proof**: binomial-theorem-oq004 — *Multinomial Marginal Central Limit Theorem* (HIGH-risk: names CLT, axiomatized core)

Verified meta.json against `proofs/Proofs/BinomialTheoremOQ02OQ01OQ01OQ03.lean` (712 lines):

- **axiomCount 1** ✓ — single `binomial_clt_pointwise` = de Moivre–Laplace with correct hypotheses `0 < p < 1`; a TRUE classical theorem (not inconsistent/over-general), openly disclosed in `assumptions` and `badge: axiom`. **No axiom masking** — title's CLT claim is fully qualified by status/badge/description.
- **sorries 0** ✓ · **theoremCount 18** ✓ (16 + 2 private) · **definitionCount 3** ✓ · no `native_decide`
- `standardNormalCDF` is a genuine concrete Lebesgue-integral def (`∫ Iic x, gaussianPDFReal 0 1`) — the claimed axiomCount 2→1 reduction is real, not an opaque stub
- Main theorem `multinomial_marginal_clt` is genuinely **derived** (reduction lemma `multinomialMarginalCDF_eq_binomialCDF` + axiom via `Filter.Tendsto.congr`), not itself axiomatized or sorry'd
- All `originalContributions` map to real declarations

Exemplary honest conditional/axiomatized entry (Tier C). No changes needed. Tracker updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)