### PR TITLE
Enrich 6 gallery entries: re-anchor drifted/undercovered sections (1..EOF)

### DIFF
--- a/src/data/proofs/cauchy-schwarz-oq-02-oq-04/meta.json
+++ b/src/data/proofs/cauchy-schwarz-oq-02-oq-04/meta.json
@@ -156,6 +156,14 @@
       "startLine": 143,
       "endLine": 201,
       "summary": "For a positive symmetric T on a real inner product space: positive_operator_diagonal_nonneg (restated positivity), positive_operator_cauchy_schwarz (⟪T x, y⟫² ≤ ⟪T x, x⟫·⟪T y, y⟫ via discrim_le_zero on the quadratic t ↦ ⟪T(x+t·y), x+t·y⟫ ≥ 0), and positive_operator_cs_abs (the √ form)."
+    },
+    {
+      "id": "sec-06-induced-seminorm",
+      "title": "Induced Seminorm from a Positive Operator",
+      "startLine": 202,
+      "endLine": 246,
+      "summary": "positive_operator_seminorm_smul: the functional p(x) = √⟪T x, x⟫ is absolutely homogeneous, p(c • x) = |c|·p(x), needing neither symmetry nor positivity of T. positive_operator_seminorm_triangle: for a positive symmetric T, p is subadditive — √⟪T(x+y),x+y⟫ ≤ √⟪T x,x⟫ + √⟪T y,y⟫ — proved by expanding the diagonal ⟪T(x+y),x+y⟫ = ⟪T x,x⟫ + 2⟪T x,y⟫ + ⟪T y,y⟫ and bounding the cross term with the Kadison–Schwarz inequality. Homogeneity, subadditivity and nonnegativity together show the form induces a genuine seminorm on F.",
+      "mathContext": "The Kadison–Schwarz inequality upgrades a positive symmetric operator $T$ to a seminorm $p(x)=\\sqrt{\\langle Tx,x\\rangle}$ satisfying $p(cx)=|c|\\,p(x)$ and $p(x+y)\\le p(x)+p(y)$."
     }
   ],
   "sorries": 0,

--- a/src/data/proofs/erdos-622-oq-04/meta.json
+++ b/src/data/proofs/erdos-622-oq-04/meta.json
@@ -104,15 +104,15 @@
       "title": "Absorbing Pair Existence and Density",
       "summary": "Proves absorbing_pair_exists (triangle existence in dense regular graphs) and erdos_faudree_absorbing_pairs_ge (≥ n absorbing pairs per vertex in EF graphs).",
       "startLine": 111,
-      "endLine": 165,
+      "endLine": 199,
       "mathContext": "For $|V| \\leq 2d - 2$: $|N(u) \\cap N(w)| \\geq 2 > 0$, giving a common neighbor $v$ forming a triangle. For EF: injecting $N(w) \\setminus \\{u_0\\}$ into absorbingPairs via $u \\mapsto (u, v(u))$ gives $\\geq n$ pairs."
     },
     {
       "id": "absorbing-lemma",
       "title": "Absorbing Lemma (Statement Only)",
       "summary": "Defines HasAbsorbingStructure: the existence of a short cycle that can absorb any small subset. This is the main DKM 2025 technical contribution.",
-      "startLine": 166,
-      "endLine": 180,
+      "startLine": 201,
+      "endLine": 222,
       "mathContext": "$\\exists$ cycle $C$ with $|C| \\leq \\lceil \\varepsilon |V| \\rceil$ such that $\\forall T \\subseteq V \\setminus V(C)$ with $|T| \\leq \\delta |V|$, $C$ can be extended to also span $T$."
     }
   ],

--- a/src/data/proofs/fair-games-theorem-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/fair-games-theorem-oq-02-oq-01-oq-01/meta.json
@@ -142,10 +142,18 @@
     },
     {
       "id": "sec-wald",
-      "title": "Wald's Identity and Corollaries",
+      "title": "Wald's Identity",
       "startLine": 286,
-      "endLine": 361,
-      "summary": "Assembles Wald's Identity from the four fully proved pieces. Provides two corollaries: bounded stopping times and zero-mean processes (Gambler's Ruin connection)."
+      "endLine": 356,
+      "summary": "integral_sum_range_eq_tsum rewrites the stopped-sum integral as a tsum over the tail probabilities; wald_identity assembles the full identity E[Σ_{k<τ} X_{k+1}] = E[X₀]·E[τ] from the four fully proved pieces (independence computation, tail-sum formula, and the Fubini interchange)."
+    },
+    {
+      "id": "sec-wald-corollaries",
+      "title": "Corollaries: Bounded Stopping Times and the Gambler’s Ruin",
+      "startLine": 357,
+      "endLine": 405,
+      "summary": "wald_identity_bounded specialises Wald’s identity to a deterministically bounded stopping time τ ≤ N, where the Fubini step reduces to a finite sum and integrability of τ is automatic. wald_zero_mean_gives_zero_drift applies the identity to the Gambler’s Ruin: for i.i.d. fair steps (mean 0), the total drift E[Σ_{k<τ} X_{k+1}] = 0·E[τ] = 0, complementing the optional-stopping computation of the terminal fortune.",
+      "mathContext": "For $\\tau\\le N$ a.s., $\\mathbb E\\big[\\sum_{k<\\tau}X_{k+1}\\big]=\\mathbb E[X_0]\\,\\mathbb E[\\tau]$; when $\\mathbb E[X_0]=0$ the expected total drift vanishes."
     }
   ],
   "conclusion": {

--- a/src/data/proofs/hilbert-17-oq-03-oq-06/meta.json
+++ b/src/data/proofs/hilbert-17-oq-03-oq-06/meta.json
@@ -218,10 +218,18 @@
       "summary": "multiplier_mul_robinson_eq is the integer-coefficient identity (4x²+4y²+4z²)·R = Q1² + 3Q2² + Ga² + Gb² + Gc², closed by ring; robinson_mul_isSumOfSquares packages it as IsSumOfSquaresMv, and multiplier_isSumOfSquares shows the multiplier is (2x)²+(2y)²+(2z)²."
     },
     {
+      "id": "positivstellensatz",
+      "title": "The certificate proves nonnegativity (Positivstellensatz payoff)",
+      "startLine": 139,
+      "endLine": 180,
+      "summary": "The SOS certificate is cashed out as pointwise nonnegativity: multiplier_eval_nonneg (the multiplier 4x²+4y²+4z², a sum of squares, evaluates ≥ 0 everywhere) and robinson_eval_nonneg (since multiplier·Robinson is a sum of squares and the multiplier is positive off the origin, Robinson itself is nonnegative on ℝ³). This is the Positivstellensatz payoff — an explicit certificate forcing the sign of a form that is not itself a polynomial sum of squares.",
+      "mathContext": "$0\\le\\operatorname{eval}_v(\\text{multiplier}\\cdot R)$ and $\\text{multiplier}\\ge 0$ give $\\operatorname{eval}_v R\\ge 0$ for all $v\\in\\mathbb R^3$."
+    },
+    {
       "id": "rational-corollary",
       "title": "Artin for Robinson, constructively",
-      "startLine": 139,
-      "endLine": 191,
+      "startLine": 181,
+      "endLine": 235,
       "summary": "multiplier_ne_zero / toRF_multiplier_ne_zero validate division by the multiplier in ℝ(x,y,z); product_identity is the 21-term polynomial identity Σ(qᵢdⱼ)² = (multiplier·R)·multiplier; robinson_isSOS_ratFunc divides through and reindexes Fin 7 × Fin 3 ≃ Fin 21 to conclude R = Σ (qᵢdⱼ/multiplier)², a sum of squares of rational functions."
     }
   ]

--- a/src/data/proofs/ptolemys-theorem-oq-01-incomplete-01/meta.json
+++ b/src/data/proofs/ptolemys-theorem-oq-01-incomplete-01/meta.json
@@ -101,15 +101,15 @@
       "id": "converse-theorem",
       "title": "Main Converse Theorem",
       "startLine": 215,
-      "endLine": 419,
+      "endLine": 455,
       "summary": "Ptolemy equality → IsCCWOrder z₁ z₂ z₃ z₄ ∨ IsCCWOrder z₁ z₄ z₃ z₂, via 8-case sign analysis on sine products.",
       "description": "ptolemy_equality_implies_ccw_or_cw: Ptolemy equality → IsCCWOrder z₁ z₂ z₃ z₄ ∨ IsCCWOrder z₁ z₄ z₃ z₂, via 8-case sign analysis"
     },
     {
       "id": "biconditional",
       "title": "The Full Biconditional",
-      "startLine": 420,
-      "endLine": 465,
+      "startLine": 456,
+      "endLine": 508,
       "summary": "Complete equivalence — Ptolemy equality ↔ CCW or CW order for unit-circle points.",
       "description": "ptolemy_equality_iff_ccw_or_cw: Complete equivalence — Ptolemy equality ↔ CCW or CW order for unit-circle points"
     }

--- a/src/data/proofs/solution-of-cubic-oq-03-oq-03/meta.json
+++ b/src/data/proofs/solution-of-cubic-oq-03-oq-03/meta.json
@@ -130,6 +130,14 @@
       "mathContext": "$m = t - 5p/6$ is a valid resolvent root."
     },
     {
+      "id": "cube-roots-of-unity",
+      "title": "Cube Roots of Unity",
+      "startLine": 146,
+      "endLine": 172,
+      "summary": "Defines the primitive cube root ω = exp(2πi/3) and proves the two facts Cardano’s three-root formula needs: omega_cubed (ω³ = 1) and omega_sum (1 + ω + ω² = 0). These let the resolvent root u + v be rotated to the other two roots ωu + ω²v and ω²u + ωv.",
+      "mathContext": "$\\omega=e^{2\\pi i/3}$ satisfies $\\omega^3=1$ and $1+\\omega+\\omega^2=0$, generating the three Cardano roots $\\omega^k u+\\omega^{2k}v$."
+    },
+    {
       "id": "verification",
       "title": "Root Correctness",
       "startLine": 173,
@@ -141,9 +149,17 @@
       "id": "chain",
       "title": "Complete Solution Chain",
       "startLine": 195,
-      "endLine": 220,
+      "endLine": 229,
       "summary": "Assembles the full quartic-to-Cardano chain in a single theorem.",
       "mathContext": "Quartic $\\to$ resolvent cubic $\\to$ depressed cubic $\\to$ Cardano $\\to$ radicals."
+    },
+    {
+      "id": "summary",
+      "title": "Summary: Complete Radical Solution Chain",
+      "startLine": 230,
+      "endLine": 262,
+      "summary": "A documentation block enumerating the eight theorems and five definitions (0 sorries, 0 axioms): the resolvent cubic (monic form, depression), the Cardano connection (recoverM_is_resolvent_root, resolvent_root_zero_correct), the cube-root-of-unity facts (omega_cubed, omega_sum), and the solution chain (quartic_to_cardano, isResolventRoot). It answers OQ-03-OQ-03 affirmatively: the resolvent cubic depresses to t³ + At + B with A = −p²/12 − r and B = −p³/108 + pr/3 − q²/8, exactly Cardano’s solvable form, completing Quartic → Ferrari → Resolvent → Depression → Cardano → Radicals.",
+      "mathContext": "The depressed resolvent $t^3+At+B=0$ with $A=-p^2/12-r$, $B=-p^3/108+pr/3-q^2/8$ is solved by $t=u+v$ with $u^3+v^3=-B$, $uv=-A/3$."
     }
   ],
   "crossReferences": [


### PR DESCRIPTION
Section-coverage enrichment pass driven by the fresh-origin/main grown-file
undercoverage scan (`gap>=40`, `maxEnd>0`). Each entry's top-level
`meta.sections` either stopped before EOF or drifted off the file's own banners;
all six are now contiguous with `maxEnd == wc`. Diffs are minimal (only the
touched section objects), unicode preserved.

**No status/badge/axiomCount changes.** All six lean files verified 0 `axiom`
declarations / 0 real `sorry` tactics (ptolemy's `sorry` tokens are all inside
comments; meta already `sorries: 0`).

| entry | change | coverage |
|-------|--------|----------|
| `cauchy-schwarz-oq-02-oq-04` | +Induced-Seminorm section (`positive_operator_seminorm_smul`/`_triangle`) | 201→246 |
| `fair-games-theorem-oq-02-oq-01-oq-01` | split Wald's Identity vs. its corollaries (bounded case / Gambler's Ruin drift) | 361→405 |
| `solution-of-cubic-oq-03-oq-03` | fill interior Cube-Roots-of-Unity hole (`omega_cubed`/`omega_sum`) + Summary tail | 220→262 |
| `hilbert-17-oq-03-oq-06` | split a mislabeled section into Positivstellensatz payoff + rational-function corollary | 191→235 |
| `ptolemys-theorem-oq-01-incomplete-01` | extend converse theorem, re-anchor Section V "Full Biconditional" to its true range | 465→508 |
| `erdos-622-oq-04` | extend density section, re-anchor Part V "Absorbing Lemma" banner | 180→222 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
