### PR TITLE
audit: binomial-theorem-oq005 (Multinomial Covariance Matrix) clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -30524,6 +30524,12 @@
       "lastAudited": "2026-07-21T08:43:36Z",
       "result": "clean",
       "issues": []
+    },
+    "binomial-theorem-oq005": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T08:44:54Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Gallery integrity audit — CLEAN

**Proof**: binomial-theorem-oq005 — *The Full Multinomial Covariance Matrix (Variance and Diagonal)*

Verified meta.json against `proofs/Proofs/BinomialTheoremOQ02OQ01OQ01OQ04.lean`:

- **theoremCount 6** ✓ (4 public: second_factorial_moment, second_moment, variance, covariance_matrix; + 2 private: absorb, absorb_weighted) · **definitionCount 0** ✓
- **sorries 0** ✓ · **axiomCount 0** ✓ · no `native_decide` · no True-stubs
- Theorems are genuine real-formula results (E[Xᵢ²]=n(n-1)pᵢ²+npᵢ, Var(Xᵢ)=n·pᵢ(1-pᵢ), full covariance matrix Cov(Xᵢ,Xⱼ)=n·pᵢ(δᵢⱼ-pⱼ)) proved as expectation sums over the actual multinomial distribution — not vacuous
- `verified`/`verified` labeling correct; `#print axioms` disclosure (propext/Classical.choice/Quot.sound only) accurate; probabilistic ∑p=1, 0≤pᵢ are ordinary hypotheses not axioms

No changes needed to meta.json. Tracker updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)