### PR TITLE
audit: binomial-theorem-oq006 (Disjoint-block PGF factorization) clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -30530,6 +30530,12 @@
       "lastAudited": "2026-07-21T08:44:54Z",
       "result": "clean",
       "issues": []
+    },
+    "binomial-theorem-oq006": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T08:46:17Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Gallery integrity audit — CLEAN

**Proof**: binomial-theorem-oq006 — *Joint Independence of Disjoint Blocks in the Binomial Model (PGF Factorization)*

Verified meta.json against `proofs/Proofs/BinomialTheoremOQ02OQ01OQ02OQ01.lean`:

- **theoremCount 5** ✓ (bernoulliPGF_one, jointPGF_one, jointPGF_union, jointPGF_const, disjoint_blocks_pgf) · **definitionCount 2** ✓ (bernoulliPGF, jointPGF)
- **sorries 0** ✓ · **axiomCount 0** ✓ · no `native_decide`
- Genuine PGF-factorization results over Mathlib's `Finset.prod` API — real theorems, no stubs
- Title "Joint Independence" is honestly qualified with "(PGF Factorization)" and an explicit **Scope** section disclaiming re-derivation of the measure-theoretic PGF⇒independence equivalence — no inequality/certificate-as-theorem inflation
- `verified`/`original` labeling correct; `#print axioms` disclosure accurate

No changes needed to meta.json. Tracker updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)