### PR TITLE
audit: binomial-theorem-oq007 (Multinomial Covariance = -n*pi*pj) clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -30536,6 +30536,12 @@
       "lastAudited": "2026-07-21T08:46:17Z",
       "result": "clean",
       "issues": []
+    },
+    "binomial-theorem-oq007": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T08:47:22Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Gallery integrity audit — CLEAN

**Proof**: binomial-theorem-oq007 — *Multinomial Covariance: Cov(Xᵢ, Xⱼ) = −n·pᵢ·pⱼ*

Verified meta.json against `proofs/Proofs/BinomialTheoremOQ02OQ01OQ02OQ02.lean`:

- **theoremCount 4** ✓ (multinomial_pair_pgf, multinomial_mean, multinomial_mixed_moment, multinomial_covariance) · **definitionCount 0** ✓
- **sorries 0** ✓ · **axiomCount 0** ✓ · no `native_decide` · no True-stubs
- Headline `multinomial_covariance` genuinely proves Cov = E[XᵢXⱼ] − E[Xᵢ]E[Xⱼ] = −n·pᵢ·pⱼ as an actual sum over the multinomial distribution, via honest PGF differentiation (`HasDerivAt`) — matches title exactly, no vacuous stub
- `verified`/`original` correct; `#print axioms` disclosure (propext/Classical.choice/Quot.sound only) accurate

No changes needed to meta.json. Tracker updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)