### PR TITLE
audit: binomial-theorem-oq008 (Poisson Limit Theorem) clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -30542,6 +30542,12 @@
       "lastAudited": "2026-07-21T08:47:22Z",
       "result": "clean",
       "issues": []
+    },
+    "binomial-theorem-oq008": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T08:48:30Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Gallery integrity audit — CLEAN

**Proof**: binomial-theorem-oq008 — *The Poisson Limit Theorem: Multinomial Converges to Independent Poissons* (HIGH-risk title: names famous limit theorem)

Verified meta.json against `proofs/Proofs/BinomialTheoremOQ02OQ01OQ02OQ03.lean`:

- **theoremCount 7** ✓ (tendsto_zero_of_tendsto_nat_mul, tendsto_one_sub_pow_exp, tendsto_one_sub_pow_sub_exp, binomial_tendsto_poisson, binomial_tendsto_poissonPMFReal, tendsto_descFactorial_mul_prod, multinomial_tendsto_prod_poisson) · **definitionCount 1** ✓ (multinomialPMF)
- **sorries 0** ✓ · **axiomCount 0** ✓ · no `native_decide`
- All headline results are genuine `Tendsto` convergence theorems with proper hypotheses (`n·pₙ → λ`): binomial pmf → Poisson pmf (real form + restated against Mathlib's `poissonPMFReal`), and joint multinomial pmf → product of Poisson pmfs (asymptotic independence). Not vacuous — title fully supported.
- `verified`/`original` correct: genuinely fills a documented Mathlib gap (no binomial↔Poisson convergence result exists in Mathlib); `#print axioms` disclosure accurate

No changes needed to meta.json. Tracker updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)