### PR TITLE
Enrich 4 gallery entries: re-anchor drifted/undercovered sections (1..EOF)

### DIFF
--- a/src/data/proofs/abel-ruffini-oq-04-oq-02/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-02/meta.json
@@ -84,7 +84,7 @@
       "id": "docstring-imports",
       "title": "Documentation and Imports",
       "startLine": 1,
-      "endLine": 43,
+      "endLine": 50,
       "summary": "Module docstring documenting the open question, the answer (S₂, S₃, S₄ are all solvable), the proof techniques (CommGroup, decide, native_decide), and references. Imports Mathlib's Solvable, Alternating, and Tactic modules.",
       "mathContext": "Imports: `GroupTheory.Solvable` supplies `IsSolvable`, `isSolvable_def` ($G$ is solvable $\\iff \\exists n,\\, D^n(G) = \\{e\\}$), and `derivedSeries`; `SpecificGroups.Alternating` provides the $A_5$ simplicity used contrapositively in the forward direction of `solvable_iff_le_four`. The `maxHeartbeats 1600000` increase (4× the default 400000) is required for `native_decide` in `s4_solvable`: computing that `derivedSeries(S_4, 3) = ⊥` requires exhaustive evaluation over $|S_4|^3 = 13824$ permutation triples.",
       "relatedConcepts": [
@@ -99,8 +99,8 @@
     {
       "id": "s2-solvable",
       "title": "S₂ Is Solvable",
-      "startLine": 45,
-      "endLine": 55,
+      "startLine": 51,
+      "endLine": 62,
       "summary": "S₂ is commutative (CommGroup instance via decide), hence solvable.",
       "mathContext": "$S_2 \\cong \\mathbb{Z}/2\\mathbb{Z}$ is abelian. $[S_2, S_2] = \\{e\\}$.",
       "relatedConcepts": [
@@ -115,8 +115,8 @@
     {
       "id": "s3-solvable",
       "title": "S₃ Is Solvable",
-      "startLine": 57,
-      "endLine": 69,
+      "startLine": 63,
+      "endLine": 94,
       "summary": "S₃ solvable via derivedSeries(2) = ⊥, verified by decide.",
       "mathContext": "$S_3 \\rhd A_3 \\cong \\mathbb{Z}/3\\mathbb{Z} \\rhd \\{e\\}$. Both quotients abelian.",
       "relatedConcepts": [
@@ -131,8 +131,8 @@
     {
       "id": "s4-solvable",
       "title": "S₄ Is Solvable",
-      "startLine": 71,
-      "endLine": 82,
+      "startLine": 95,
+      "endLine": 130,
       "summary": "S₄ solvable via derivedSeries(3) = ⊥, verified by native_decide.",
       "mathContext": "$S_4 \\rhd A_4 \\rhd V_4 \\rhd \\{e\\}$. $V_4$ is the Klein four-group.",
       "relatedConcepts": [
@@ -147,8 +147,8 @@
     {
       "id": "classification",
       "title": "Complete Classification",
-      "startLine": 84,
-      "endLine": 110,
+      "startLine": 131,
+      "endLine": 158,
       "summary": "solvable_iff_le_four: Sₙ is solvable iff n ≤ 4. Forward: contrapositive of not_solvable. Backward: interval_cases on n ∈ {0,1,2,3,4}.",
       "mathContext": "$S_n$ is solvable $\\iff n \\leq 4$.",
       "relatedConcepts": [
@@ -162,8 +162,8 @@
     {
       "id": "degree-picture",
       "title": "Degree-by-Degree Picture and Summary",
-      "startLine": 112,
-      "endLine": 154,
+      "startLine": 159,
+      "endLine": 202,
       "summary": "Convenience corollaries: small_symmetric_solvable (n ≤ 4 → solvable) and large_symmetric_not_solvable (n ≥ 5 → not solvable). Closing summary table showing all symmetric group solvability with proof techniques and derived series lengths.",
       "mathContext": "The two directional corollaries present the classification as implications: $n \\leq 4 \\Rightarrow \\text{IsSolvable}(S_n)$ (`small_symmetric_solvable`) and $n \\geq 5 \\Rightarrow \\neg\\text{IsSolvable}(S_n)$ (`large_symmetric_not_solvable`). Together with Galois's theorem ($\\text{IsSolvableByRad}(F, \\alpha) \\Rightarrow \\text{IsSolvable}(q.\\text{Gal})$, where $q = \\text{minpoly}_F(\\alpha)$), these give: if $q$ is a polynomial with $\\text{Gal}(q) \\cong S_n$ for $n \\leq 4$, then its roots are solvable by radicals; if $\\text{Gal}(q) \\cong S_n$ for $n \\geq 5$, they are not.",
       "relatedConcepts": [

--- a/src/data/proofs/ballot-problem-oq-01-oq-02-oq-04/meta.json
+++ b/src/data/proofs/ballot-problem-oq-01-oq-02-oq-04/meta.json
@@ -100,11 +100,19 @@
     },
     {
       "id": "scaled-case",
-      "title": "Scaled Ballot Expression and Open Directions",
+      "title": "Scaled Ballot Expression",
       "startLine": 247,
-      "endLine": 311,
-      "summary": "Defines scaledBallotFormula (ap-bq)/(ap+bq), proves degeneration to classical, positivity, and ≤1 bound. Notes this is NOT the actual probability for the scaled case. Concludes with open directions.",
+      "endLine": 329,
+      "summary": "Defines scaledBallotFormula (ap−bq)/(ap+bq) and proves its basic algebra: scaled_degenerates (recovers the classical (a−b)/(a+b) at p = q = 1), scaled_formula_pos (positive when ap > bq), and scaled_formula_le_one (bounded by 1). Emphasises that this closed form is NOT the actual probability for the weighted/scaled ballot process.",
       "mathContext": "$(ap-bq)/(ap+bq)$ degenerates to $(a-b)/(a+b)$ when $p = q = 1$. But it does not equal the actual ballot probability in general."
+    },
+    {
+      "id": "open-directions",
+      "title": "Part VI: Open Directions",
+      "startLine": 330,
+      "endLine": 352,
+      "summary": "A closing discussion of what a genuine weighted ballot theorem would require — a recurrence or reflection argument for biased steps — and how the scaled formula relates to the classical Bertrand ballot problem, framing the remaining open directions.",
+      "mathContext": "The weighted analogue of $P=(a-b)/(a+b)$ for step-biases $p,q$ is not $(ap-bq)/(ap+bq)$ in general; the true probability needs a biased reflection principle."
     }
   ],
   "conclusion": {

--- a/src/data/proofs/erdos-1033/meta.json
+++ b/src/data/proofs/erdos-1033/meta.json
@@ -198,14 +198,14 @@
       "title": "Small Cases",
       "summary": "h_three, h_four",
       "startLine": 795,
-      "endLine": 986
+      "endLine": 1027
     },
     {
       "id": "summary",
       "title": "Summary",
       "summary": "Status, conjecture, known bounds, and the open gap",
-      "startLine": 987,
-      "endLine": 1018,
+      "startLine": 1028,
+      "endLine": 1059,
       "mathContext": "Recap: OPEN problem. Conjecture $h(n) \\geq (2(\\sqrt{3}-1)-o(1))n$. Known $(21/16)n \\leq h(n) \\leq 2(\\sqrt{3}-1)n$ with a $\\approx 0.15n$ gap."
     }
   ],

--- a/src/data/proofs/prime-reciprocal-divergence-oq-03/meta.json
+++ b/src/data/proofs/prime-reciprocal-divergence-oq-03/meta.json
@@ -117,6 +117,14 @@
       "startLine": 288,
       "endLine": 353,
       "summary": "Proves infinitely_many_primes_erdos by contradiction and derives prime_reciprocals_unbounded."
+    },
+    {
+      "id": "reciprocal-corollary-notes",
+      "title": "Reciprocal Divergence Corollary and Proof-Path Notes",
+      "startLine": 354,
+      "endLine": 396,
+      "summary": "prime_reciprocals_unbounded packages infinitely_many_primes_erdos as the statement that primes are unbounded (∀ N, ∃ p > N prime), the finite-form corollary underlying Σ 1/p = ∞. A closing PART V \"Notes\" block honestly separates what is proved (Euclid-style infinitude via the rough-number counting argument) from what is not (the full quantitative divergence Σ_{p≤x} 1/p ~ log log x), and compares this Erdős-style smooth-number path with the classical proofs.",
+      "mathContext": "The rough-number count gives infinitude of primes; the reciprocal sum $\\sum_{p}1/p=\\infty$ follows from the same argument under $\\sum_{p>N}1/p<1/2$, but the sharp $\\sum_{p\\le x}1/p\\sim\\log\\log x$ is not formalised here."
     }
   ],
   "crossReferences": [


### PR DESCRIPTION
Second section-coverage enrichment batch driven by the fresh-origin/main
grown-file undercoverage scan (`gap>=40`, `maxEnd>0`). Each entry's top-level
`meta.sections` drifted off the file's own `-- PART` banners or stopped before
EOF; all four now reach `maxEnd == wc` with minimal, unicode-preserving diffs.

**No status/badge/axiomCount changes.** `erdos-1033` stays axiomatized (its 3
axioms and native_decide small-case checks are untouched); `abel-ruffini`'s only
`native_decide` tokens are inside comments/ASCII tables, not proof terms.

| entry | change | coverage |
|-------|--------|----------|
| `abel-ruffini-oq-04-oq-02` | full re-anchor of all 6 sections to the `-- PART N` decorator blocks (were ~20–50 lines early) | 154→202 |
| `prime-reciprocal-divergence-oq-03` | +Reciprocal-Divergence corollary & PART V Notes section (`prime_reciprocals_unbounded`) | 353→396 |
| `ballot-problem-oq-01-oq-02-oq-04` | split scaled-expression theorems from Part VI "Open Directions" | 311→352 |
| `erdos-1033` | extend Small Cases over the `h(4)=8` proof, re-anchor Summary to the real `## Summary` block | 1018→1059 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
