### PR TITLE
audit: binomial-theorem-oq009 (All Factorial Moments of Binomial Marginal) clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -30548,6 +30548,12 @@
       "lastAudited": "2026-07-21T08:48:30Z",
       "result": "clean",
       "issues": []
+    },
+    "binomial-theorem-oq009": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T08:49:54Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Gallery integrity audit — CLEAN

**Proof**: binomial-theorem-oq009 — *All Factorial Moments of the Binomial Marginal: E[(X)ᵣ] = (n)ᵣ·pʳ*

Verified meta.json against `proofs/Proofs/BinomialTheoremOQ02OQ01OQ04OQ03.lean`:

- **theoremCount 7** ✓ (descFactorial_mul_choose, descFactorial_mul_binomPMF [private], binomial_factorial_moment, + zeroth/mean'/second'/third factorial moments) · **definitionCount 0** ✓
- **sorries 0** ✓ · **axiomCount 0** ✓ · no `native_decide` · no True-stubs
- Headline `binomial_factorial_moment` genuinely proves E[(X)ᵣ] = ∑ₖ(k)ᵣ·binomPMF n p k = (n)ᵣ·pʳ for all n,r (both r≤n and r>n cases); specializations are real corollaries (E[X]=np, E[X(X-1)]=n(n-1)p², E[X(X-1)(X-2)]=n(n-1)(n-2)p³), dropping the lower-bound hypotheses of the parent term-peeling proofs
- `verified`/`original` correct; `#print axioms` disclosure accurate

No changes needed to meta.json. Tracker updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)