### PR TITLE
audit: binomial-theorem-oq010 (q-Binomial Reflection + Dual q-Pascal) clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -30554,6 +30554,12 @@
       "lastAudited": "2026-07-21T08:49:54Z",
       "result": "clean",
       "issues": []
+    },
+    "binomial-theorem-oq010": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T08:51:00Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Gallery integrity audit — CLEAN

**Proof**: binomial-theorem-oq010 — *q-Binomial Reflection Symmetry and the Dual q-Pascal Rule*

Verified meta.json against `proofs/Proofs/BinomialTheoremOQ02OQ02OQ01OQ03.lean`:

- **theoremCount 4** ✓ (qBinomial_ratio, qBinomial_dual_pascal, qBinomial_reflection, qBinomial_choose_symm) · **definitionCount 0** ✓
- **sorries 0** ✓ · **axiomCount 0** ✓ · no `native_decide` · no True-stubs
- Genuine Gaussian-binomial identities over an arbitrary CommRing: ratio invariant, dual q-Pascal (splits smallest element), reflection symmetry `\binom{n}{k}_q = \binom{n}{n-k}_q` (proved by induction), and the q=1 specialization to `Nat.choose` symmetry — real theorems, not vacuous
- `verified`/`original` correct; `#print axioms` disclosure accurate

No changes needed to meta.json. Tracker updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)