### PR TITLE
audit: binomial-theorem-oq011 (Figurate r-Simplex Numbers + Hockey-Stick Tower) clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -30560,6 +30560,12 @@
       "lastAudited": "2026-07-21T08:51:00Z",
       "result": "clean",
       "issues": []
+    },
+    "binomial-theorem-oq011": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T08:52:27Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Gallery integrity audit — CLEAN

**Proof**: binomial-theorem-oq011 — *Figurate (r-Simplex) Numbers and the General Hockey-Stick Tower*

Verified meta.json against `proofs/Proofs/BinomialTheoremOQ02OQ02OQ02OQ03.lean`:

- **theoremCount 8** ✓ (figurate_zero, figurate_one [both `@[simp]`], figurate_two, figurate_three, figurate_succ_eq_sum, figurate_pascal, factorial_mul_figurate, figurate_eq_multichoose) · **definitionCount 1** ✓ (figurate)
- **sorries 0** ✓ · **axiomCount 0** ✓ · no `native_decide`
- Genuine figurate-number identities (hockey-stick sum, Pascal recurrence, rising-factorial closed form, multichoose/stars-and-bars interpretation) — real theorems, not stubs
- `badge: mathlib` correctly reflects Tier-B reliance on Mathlib's `Nat.choose`/`multichoose`/`ascFactorial` API; `verified`/`#print axioms` disclosure accurate

Note: count of 8 correctly includes the two `@[simp] theorem` declarations (an `^theorem`-anchored grep would undercount to 6).

No changes needed to meta.json. Tracker updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)