### PR TITLE
audit: binomial-theorem-oq012 (Sharp bound (1+1/n)^n < e) clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -30566,6 +30566,12 @@
       "lastAudited": "2026-07-21T08:52:27Z",
       "result": "clean",
       "issues": []
+    },
+    "binomial-theorem-oq012": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T08:53:37Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Gallery integrity audit — CLEAN

**Proof**: binomial-theorem-oq012 — *Sharp Bound: (1 + 1/n)^n < e for All n ≥ 1*

Verified meta.json against `proofs/Proofs/BinomialTheoremOQ03OQ02OQ03OQ01.lean`:

- **theoremCount 4** ✓ (add_div_pow_lt_exp, add_inv_pow_lt_e, two_le_add_inv_pow, add_inv_pow_bounds) · **definitionCount 0** ✓
- **sorries 0** ✓ · **axiomCount 0** ✓ · no `native_decide`
- Genuine strict inequalities: general (1+x/n)ⁿ < exp x via the strict tangent bound `Real.add_one_lt_exp`, headline (1+1/n)ⁿ < e, Bernoulli lower companion 2 ≤ (1+1/n)ⁿ, and the two-sided bound — real results, not vacuous
- Title matches headline exactly; `verified`/`original` correct

No changes needed to meta.json. Tracker updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)