### PR TITLE
Enrich ballot-problem-oq004 + binary-gcd-oq-03-oq-02: cover uncovered tails (1..EOF)

### DIFF
--- a/src/data/proofs/ballot-problem-oq004/meta.json
+++ b/src/data/proofs/ballot-problem-oq004/meta.json
@@ -256,7 +256,7 @@
       "id": "sec-part-xi",
       "title": "Part XI: Main Theorems — ssytSchurFin_two_row & jacobi_trudi_ssyt_eq",
       "startLine": 2483,
-      "endLine": 2557,
+      "endLine": 2611,
       "summary": "Proves ssytSchurFin_two_row (k=2 Jacobi-Trudi identity) by combining the Part X partition and weight-sum lemmas — conditional on the L1907 cycle-lemma sorry it transitively invokes — then states the general jacobi_trudi_ssyt_eq: assembled for k=0,1,2 and left open (sorry, L2555) for k≥3 pending algebraic LGV + RSK.",
       "mathContext": "ssytSchurFin_two_row: rewrites schurPolynomial via schurPolynomial_two_row into h_a h_b − h_{a+1}(if 1≤b then h_{b-1} else 0), rewrites ssytSchurFin via ssytFin_two_row_eq_sum_colstrict, then closes with eq_sub_of_add_eq on jdt_weight_sum ▸ sym_pair_sum_partition — no sorry. jacobi_trudi_ssyt_eq dispatches k=0 (empty), k=1 (one-row), k=2 (via ssytSchurFin_two_row); k≥3 is the file's second open sorry (needs algebraic LGV ~150 lines + RSK bijection ~150 lines)."
     }

--- a/src/data/proofs/binary-gcd-oq-03-oq-02/meta.json
+++ b/src/data/proofs/binary-gcd-oq-03-oq-02/meta.json
@@ -353,7 +353,7 @@
       "id": "summary-status",
       "title": "Summary: Proved Results and Status of the Row-Output Bound",
       "startLine": 1958,
-      "endLine": 2225,
+      "endLine": 2278,
       "summary": "Closing Summary docstring enumerating the proved result-groups (0 axioms): composition, determinant, gcd preservation, Lehmer row-vector invariant + monotonicity, Cramer + sign pattern + entry bounds, perturbation/row-decomposition/row-output infrastructure, shift bounds, sign-pattern and pattern-det invariants for all fuel, and the Part XIV counterexample. Documents that the unconditional recursive hgcdMatrix_row_output_le is FALSE (Part IX now proves only the true non-recursive regime; paths A/B/C forward) and the out-of-scope O(M(n)·log n) bit-complexity bound (needs Mathlib fast-multiplication infrastructure).",
       "mathContext": "Status snapshot: the matrix-algebra layer (determinant, gcd preservation, patterns, entry bounds) is fully proved; the one unmet goal is the recursive row-output size-reduction bound, refuted as stated, requiring an algorithm or statement refinement."
     }


### PR DESCRIPTION
Two tail-coverage fixes where each entry's final `sections` entry already *described* content past its `endLine`. Pure `endLine` extensions — no summary/`mathContext`/`status`/`badge`/`axiomCount` changes.

- **ballot-problem-oq004** (wip): the "Part XI: Main Theorems — ssytSchurFin_two_row & jacobi_trudi_ssyt_eq" section names `jacobi_trudi_ssyt_eq` but ended at line 2557, while the theorem itself is @2574 (proved for k = 0,1,2; open `sorry` for k ≥ 3). Extended 2557 → 2611 (EOF), so the named headline theorem is actually covered.
- **binary-gcd-oq-03-oq-02** (axiomatized via `native_decide`): the "Summary: Proved Results and Status" section ended at 2225, mid-docstring; extended 2225 → 2278 (EOF) to include the rest of the status summary and the namespace close. (`endLine` bump only — no meta size increase; also normalizes a missing trailing newline.)

`maxEnd === wc` asserted for both; no section overlaps.
