### PR TITLE
Enrich 5 entries: re-section stale placeholders + cover uncovered tails (1..EOF)

### DIFF
--- a/src/data/proofs/de-moivre-oq-06/meta.json
+++ b/src/data/proofs/de-moivre-oq-06/meta.json
@@ -118,6 +118,20 @@
       "startLine": 117,
       "endLine": 142,
       "mathContext": "Dividing the telescoped identities by $2\\sin(\\theta/2)\\ne 0$ yields the Dirichlet kernel and its conjugate."
+    },
+    {
+      "id": "dirichlet-bounds",
+      "title": "Part V: Dirichlet Kernel Bounds",
+      "startLine": 143,
+      "endLine": 180,
+      "significance": "key",
+      "summary": "dirichlet_kernel_bound and dirichlet_conjugate_bound: absolute-value bounds on the Dirichlet kernel ∑cos(kθ) and its conjugate ∑sin(kθ) by 1/(2|sin(θ/2)|), the standard consequence of the Lagrange closed forms used in Fourier partial-sum estimates.",
+      "mathContext": "From $\\sum_{k=1}^{n}\\cos k\\theta=\\tfrac{\\sin((n+\\frac12)\\theta)}{2\\sin(\\theta/2)}-\\tfrac12$ one gets $\\bigl|\\sum\\cos k\\theta\\bigr|\\le \\tfrac{1}{2|\\sin(\\theta/2)|}+\\tfrac12$, and likewise for the conjugate sum — the kernel bounds underlying Dirichlet's convergence test.",
+      "relatedConcepts": [
+        "Dirichlet kernel",
+        "Fourier partial sums",
+        "Lagrange identity"
+      ]
     }
   ],
   "conclusion": {

--- a/src/data/proofs/erdos-1212/meta.json
+++ b/src/data/proofs/erdos-1212/meta.json
@@ -30,7 +30,7 @@
     "definitionCount": 4
   },
   "overview": {
-    "historicalContext": "This problem lives at the intersection of combinatorial graph theory and the distribution of prime and composite numbers. The vertex set—coprime pairs $(x,y) \\in \\mathbb{N}^2$ with $\\gcd(x,y)=1$—is the set of 'visible lattice points' from the origin, a classical object with density $6/\\pi^2 \\approx 60.8\\%$ in $\\mathbb{N}^2$ by Euler product methods. The adjacency rule (differ in one coordinate by $\\pm 1$) mirrors the Farey graph and Stern-Brocot tree, where neighboring fractions $p/q$ and $r/s$ satisfy $|ps - qr| = 1$ (equivalent to coprimality of the numerators and denominators in adjacent steps).\n\nErdős's question asks whether one can thread an infinite path through this graph while (a) staying away from the 'boundary' $\\min(x,y) = 1$ (i.e., avoiding the axes), and (b) ensuring that every visited pair has at least one composite coordinate. The boundary condition excludes the spines $(1, n)$ and $(n, 1)$ where $\\gcd = 1$ trivially. The composite condition is a Ramsey-type requirement: can we avoid visiting 'all-prime' pairs $(p, q)$ indefinitely? Since the density of composites grows to $1$ and Dirichlet's theorem guarantees infinitely many primes in any arithmetic progression, the answer is YES: arithmetic progressions can be used to construct explicit infinite paths where each step stays in coprime territory and hits at least one composite coordinate.\n\nThe problem is classified as solved (prize $\\$50$), with the positive resolution relying on the density of composites and explicit path constructions via arithmetic progressions or CRT arguments. The Lean formalization is a placeholder stub pending number-theoretic infrastructure.",
+    "historicalContext": "This problem lives at the intersection of combinatorial graph theory and the distribution of prime and composite numbers. The vertex set—coprime pairs $(x,y) \\in \\mathbb{N}^2$ with $\\gcd(x,y)=1$—is the set of 'visible lattice points' from the origin, a classical object with density $6/\\pi^2 \\approx 60.8\\%$ in $\\mathbb{N}^2$ by Euler product methods. The adjacency rule (differ in one coordinate by $\\pm 1$) mirrors the Farey graph and Stern-Brocot tree, where neighboring fractions $p/q$ and $r/s$ satisfy $|ps - qr| = 1$ (equivalent to coprimality of the numerators and denominators in adjacent steps).\n\nErdős's question asks whether one can thread an infinite path through this graph while (a) staying away from the 'boundary' $\\min(x,y) = 1$ (i.e., avoiding the axes), and (b) ensuring that every visited pair has at least one composite coordinate. The boundary condition excludes the spines $(1, n)$ and $(n, 1)$ where $\\gcd = 1$ trivially. The composite condition is a Ramsey-type requirement: can we avoid visiting 'all-prime' pairs $(p, q)$ indefinitely? Since the density of composites grows to $1$ and Dirichlet's theorem guarantees infinitely many primes in any arithmetic progression, the answer is YES: arithmetic progressions can be used to construct explicit infinite paths where each step stays in coprime territory and hits at least one composite coordinate.\n\nThe problem is classified as solved (prize $\\$50$), with the positive resolution relying on the density of composites and explicit path constructions via arithmetic progressions or CRT arguments. The Lean formalization defines the coprime graph, its adjacency relation, and the good-vertex predicate in full, and encodes the solved existence result as a single axiom (erdos_1212_solved), from which the main theorem erdos_1212 is derived.",
     "problemStatement": "Let $G$ be the graph with vertex set $V = \\{(x,y) \\in \\mathbb{N}^2 : \\gcd(x,y) = 1\\}$, where two vertices $(x,y)$ and $(x',y')$ are adjacent if and only if they differ in exactly one coordinate, and that difference is $\\pm 1$ (i.e., $(x',y') \\in \\{(x\\pm 1, y), (x, y\\pm 1)\\}$ and $\\gcd(x',y')=1$). Is there an infinite path $P$ in $G$ such that for every $(x,y) \\in P$:\n1. $\\min(x,y) > 1$ (both coordinates exceed 1), and\n2. At least one of $x$, $y$ is composite (not prime)?",
     "proofStrategy": "The positive answer uses two key facts: (1) composites have density 1 in $\\mathbb{N}$ (the prime counting function $\\pi(n)/n \\to 0$), and (2) Dirichlet's theorem ensures infinitely many primes in every arithmetic progression $a + nd$ with $\\gcd(a,d)=1$, which symmetrically implies infinitely many composites in every such progression. A concrete path construction: start at $(2, 3)$ (composite 2, prime 3—at least one composite coordinate); the neighbors in $G$ include $(3,3)$ (but $\\gcd(3,3)=3\\neq 1$, not in $V$), $(2,2)$ ($\\gcd=2$, not in $V$), $(1,3)$ (violates $\\min > 1$), and $(2,4)$ ($\\gcd(2,4)=2$, not in $V$)—so one must navigate carefully. A systematic construction uses arithmetic progressions: along any row $y = c$ (with $c$ composite), consecutive $x$ values with $\\gcd(x,c)=1$ include infinitely many $x$ values (by CRT/Euler $\\phi$), and one can step along them via $\\pm 1$ moves to adjacent $x$ values that also satisfy $\\gcd(x\\pm 1, c) = 1$, creating a path segment with $y = c$ composite. Combining horizontal and vertical segments via composite 'runways' yields an infinite path satisfying both conditions. The Lean formalization requires number theory (Nat.Coprime, Nat.Prime) and graph theory (SimpleGraph, path types).",
     "keyInsights": [
@@ -45,43 +45,51 @@
   "sections": [
     {
       "id": "problem-statement",
-      "title": "Problem Statement: Coprime Lattice Graph and Composite Path",
+      "title": "Problem Statement",
       "startLine": 1,
-      "endLine": 9,
-      "summary": "File header states Erdős Problem #1212: define G as the graph on coprime pairs (x,y) ∈ ℕ² with ±1 adjacency. The question: does there exist an infinite path P in G such that min(x,y) > 1 and at least one of x,y is composite for every (x,y) ∈ P? Cites erdosproblems.com/1212.",
-      "mathContext": "$G = (V, E)$ with $V = \\{(x,y) \\in \\mathbb{N}^2 : \\gcd(x,y) = 1\\}$ and $(x,y) \\sim (x',y')$ iff they differ in one coordinate by $\\pm 1$ and $\\gcd(x',y')=1$. The conditions $\\min > 1$ and at-least-one-composite are two independent requirements on path vertices."
+      "endLine": 15,
+      "significance": "context",
+      "summary": "Header for Erdős #1212 (SOLVED, $50 prize): is there an infinite path in the coprime lattice graph on which every vertex is 'good' — its smaller coordinate exceeds 1 and at least one coordinate is composite? Answer: yes.",
+      "mathContext": "$G$ has vertex set $\\{(x,y)\\in\\mathbb{N}^2 : \\gcd(x,y)=1\\}$; two vertices are adjacent iff they differ by $\\pm1$ in exactly one coordinate."
     },
     {
-      "id": "proof-status",
-      "title": "Proof Status: Solved, Prize $50, TODO",
-      "startLine": 10,
-      "endLine": 14,
-      "summary": "Header documents: Status SOLVED, Prize $50. TODO: implement the proof in Lean. Tags field is empty — the actual tags are in meta.json. The solved status reflects the mathematical resolution via density/Dirichlet arguments, not a Lean formalization.",
-      "mathContext": "The $50 prize reflects Erdős's assessment of the problem's difficulty. 'Solved' here means the mathematical answer is known (YES, such paths exist), not that the Lean proof is complete. The Lean stub awaits number-theoretic formalization infrastructure."
-    },
-    {
-      "id": "imports",
-      "title": "Mathlib Import and Namespace",
+      "id": "imports-namespace",
+      "title": "Imports and Namespace",
       "startLine": 16,
-      "endLine": 16,
-      "summary": "Full Mathlib import, giving access to Nat.Coprime, Nat.Prime, SimpleGraph, SimpleGraph.Walk, and related APIs needed for formalizing the coprime lattice graph and infinite path existence.",
-      "mathContext": "`import Mathlib` provides `Nat.Coprime x y` (= `Nat.gcd x y = 1`), `Nat.Prime`, `SimpleGraph α` (irreflexive symmetric binary relation), and `SimpleGraph.Walk`/`Path` for path structures."
+      "endLine": 19,
+      "significance": "technical",
+      "summary": "Imports Mathlib and opens the Erdos1212 namespace."
     },
     {
-      "id": "placeholder-theorem",
-      "title": "Placeholder Theorem: True with Sorry",
-      "startLine": 17,
-      "endLine": 21,
-      "summary": "Placeholder theorem `erdos_1212 : True := by sorry`. A full Lean formalization would: (1) define coprimePairGraph : SimpleGraph (ℕ × ℕ); (2) state existence of a stream f : ℕ → ℕ × ℕ satisfying adjacency, min > 1, and at-least-one-composite at every step; (3) prove via Dirichlet + König's lemma.",
-      "mathContext": "Target type: `∃ f : ℕ → ℕ × ℕ, ∀ n, Adj (f n) (f (n+1)) ∧ 1 < min (f n).1 (f n).2 ∧ (¬Nat.Prime (f n).1 ∨ ¬Nat.Prime (f n).2)`. The sorry tracks that this theorem body is not yet proved."
+      "id": "graph-definitions",
+      "title": "Coprime Graph Definitions",
+      "startLine": 20,
+      "endLine": 40,
+      "significance": "key",
+      "summary": "Defines CoprimeVertex (coprime pairs as a subtype), coprimeAdj (the ±1-in-one-coordinate adjacency relation), the SimpleGraph coprimeGraph (with symm/loopless discharged), and IsGoodVertex (min coordinate > 1 and at least one coordinate not prime).",
+      "mathContext": "A vertex $v=(x,y)$ is *good* iff $\\min(x,y)>1$ and ($x$ or $y$ is composite), i.e. $\\lnot\\mathrm{Prime}(x)\\lor\\lnot\\mathrm{Prime}(y)$.",
+      "relatedConcepts": [
+        "SimpleGraph",
+        "Nat.Coprime",
+        "infinite path"
+      ]
     },
     {
-      "id": "sorry-tracking",
-      "title": "Sorry Check for Aristotle Tracking",
-      "startLine": 22,
-      "endLine": 23,
-      "summary": "`#check erdos_1212` line used for sorry tracking by the Aristotle automated proof search system. This line verifies the theorem declaration is well-typed and makes the sorry visible to tooling.",
-      "mathContext": "The `#check` command in Lean 4 elaborates the term and reports its type, allowing automated tools to detect the sorry dependency via `#check_axioms` or similar introspection."
+      "id": "axiomatized-solution",
+      "title": "Axiomatized Solution",
+      "startLine": 41,
+      "endLine": 51,
+      "significance": "key",
+      "summary": "axiom erdos_1212_solved encodes the solved result: an injective infinite path exists whose consecutive vertices are adjacent and all of whose vertices are good.",
+      "mathContext": "The construction (a specific infinite good path) is assumed rather than reconstructed in Lean; this is the file's single axiom, so the entry is axiomatized."
+    },
+    {
+      "id": "main-theorem",
+      "title": "Main Theorem: Erdős #1212",
+      "startLine": 52,
+      "endLine": 60,
+      "significance": "key",
+      "summary": "theorem erdos_1212 extracts, from the axiom, the adjacency and goodness of an infinite path (dropping injectivity) — the affirmative answer to the problem."
     }
   ],
   "conclusion": {

--- a/src/data/proofs/erdos-1217/meta.json
+++ b/src/data/proofs/erdos-1217/meta.json
@@ -41,48 +41,56 @@
   },
   "sections": [
     {
-      "id": "metadata-header",
-      "title": "Problem Metadata: Title, Source, Status",
+      "id": "problem-statement",
+      "title": "Problem Statement",
       "startLine": 1,
-      "endLine": 7,
-      "summary": "Opening of the Lean block comment identifying this as Erdős Problem #1217, with source URL (erdosproblems.com/1217) and status SOLVED. The problem is attributed to Erdős-Sárközy-Sós 1966 [ESS66].",
-      "mathContext": "The **upper log-log density** of a sequence $A = \\{a_1 < a_2 < \\cdots\\}$ is $\\overline{d}_{\\text{ll}}(A) = \\limsup_{x \\to \\infty} \\frac{1}{\\log\\log x} \\sum_{a_n \\leq x} \\frac{1}{a_n}$. By Mertens' second theorem ($\\sum_{p \\leq x} 1/p \\sim \\log\\log x$), the primes have $\\overline{d}_{\\text{ll}} = 1$. Problem #1217 (ESS66, 1966) asks: if $\\overline{d}_{\\text{ll}}(A) > 0$, must $A$ contain a structurally constrained subsequence with the same property?"
+      "endLine": 18,
+      "significance": "context",
+      "summary": "Header for Erdős #1217 (SOLVED by Erdős–Sárközy–Sós 1966): a sequence with positive iterated-log (log-log) density admits a subsequence that is itself positive-density and satisfies additional convergence structure.",
+      "mathContext": "Iterated-log density of $A$: $\\limsup_{x\\to\\infty}\\tfrac{1}{\\log\\log x}\\sum_{a_n\\le x}\\tfrac1{a_n}$."
     },
     {
-      "id": "corrupted-statement",
-      "title": "Problem Statement (Corrupted Source)",
-      "startLine": 8,
-      "endLine": 14,
-      "summary": "The problem statement block is severely corrupted — LaTeX encoding issues stripped mathematical content. Legible fragments: a sequence A = {a₁, ...}, a reference to [ESS66], and a limsup over 1/(log log x) · ∑_{aₙ < x} 1/aₙ being positive implying the existence of a subsequence with the same limsup positive. The full statement requires consulting the original ESS66 paper.",
-      "mathContext": "From legible fragments: the hypothesis is $\\overline{d}_{\\text{ll}}(A) > 0$; the conclusion is $\\exists B \\subseteq A,\\, \\overline{d}_{\\text{ll}}(B) > 0$ and $B$ satisfies property $P$. Candidate properties from ESS66 context: (a) **primitive** ($a \\nmid b$ for $a, b \\in B$, $a \\neq b$); (b) **sum-free** ($B + B \\cap B = \\emptyset$); (c) **Sidon** (all pairwise sums distinct). Erdős's primitive set theorem (1935) gives $\\sum_{a \\in P} 1/(a \\log a) \\leq C$ for any primitive $P$, the key bound used in density-preservation arguments."
+      "id": "imports-namespace",
+      "title": "Imports, Opens, and Namespace",
+      "startLine": 19,
+      "endLine": 27,
+      "significance": "technical",
+      "summary": "Imports Real.Log and Topology.Filter, opens Classical / Filter / Real, and enters the Erdos1217 namespace."
     },
     {
-      "id": "imports",
-      "title": "Mathlib Import",
-      "startLine": 16,
-      "endLine": 16,
-      "summary": "Full Mathlib import, providing `Filter.limsup`, `Finset.sum`, `Real.log`, and prime-counting infrastructure for formalizing the log-log density and Mertens-type results.",
-      "mathContext": "The Mathlib tools needed for a full formalization: `Filter.limsup` (for the $\\limsup_{x \\to \\infty}$ in the log-log density definition), `Real.log` (for $\\log\\log x$), `Finset.sum` / `Finset.filter` (for $\\sum_{a_n \\leq x} 1/a_n$ as a sum over a filtered index set), and `Nat.Primes.sum_reciprocals_atTop` (Mertens' second theorem, if available). Importing all of Mathlib provides these but at compile cost; a production formalization would import only `Mathlib.NumberTheory.PrimeCounting` and `Mathlib.Topology.Filter`."
+      "id": "density-definitions",
+      "title": "Iterated-Log Density Definitions",
+      "startLine": 28,
+      "endLine": 37,
+      "significance": "key",
+      "summary": "Defines iterLogDensity (the log-log-normalized reciprocal-sum limsup of a set) and HasPositiveIterLogDensity (a strictly monotone sequence whose range has positive such density).",
+      "mathContext": "$\\mathrm{iterLogDensity}(A)=\\limsup_x \\tfrac{1}{\\log\\log x}\\sum_{n\\in A,\\,n\\le x}\\tfrac1n$; the predicate asks this to be $>0$ for $\\mathrm{range}(a)$.",
+      "relatedConcepts": [
+        "limsup",
+        "logarithmic density",
+        "StrictMono"
+      ]
     },
     {
-      "id": "theorem-scaffold",
-      "title": "Theorem Scaffold Comments",
-      "startLine": 18,
-      "endLine": 19,
-      "summary": "Two-line comment block marking this as a placeholder to be replaced with the actual statement and proof of the ESS66 result once the problem statement is recovered and Mathlib's analytic number theory is ready.",
-      "mathContext": "The scaffold comment marks where the actual formalization would go. The eventual theorem statement would take the form: `theorem erdos_1217 (A : Set ℕ) (hA : upperLogLogDensity A > 0) : ∃ B ⊆ A, upperLogLogDensity B > 0 ∧ P B` where `upperLogLogDensity A = Filter.limsup (fun x => (Real.log (Real.log x))⁻¹ * ∑ n ∈ A ∩ Icc 1 ⌊x⌋, (n : ℝ)⁻¹) Filter.atTop` and $P$ is the recovered structural property from ESS66."
+      "id": "axiomatized-ess",
+      "title": "Axiomatized Erdős–Sárközy–Sós Theorem (1966)",
+      "startLine": 38,
+      "endLine": 49,
+      "significance": "key",
+      "summary": "axiom erdos_sarkozy_sos_1966: any positive-iterated-log-density strictly monotone sequence has a strictly monotone reindexing whose image keeps positive density and whose consecutive ratios a(f n)/a(f(n+1)) → 1.",
+      "mathContext": "The extracted subsequence satisfies $a_{f(n)}/a_{f(n+1)}\\to 1$, the 'converges in an appropriate sense' clause. Assumed as the file's single axiom."
     },
     {
-      "id": "placeholder-theorem",
-      "title": "Placeholder: Log-Log Density Subsequence Theorem",
-      "startLine": 20,
-      "endLine": 23,
-      "summary": "Placeholder `erdos_1217 : True := by sorry` and type-check `#check erdos_1217`. A Lean formalization would define upper log-log density via `Filter.limsup` of `(Real.log (Real.log x))⁻¹ * ∑_{aₙ ≤ x} aₙ⁻¹` and prove that positive density forces a structurally constrained (primitive / sum-free / Sidon) subsequence with the same property.",
-      "mathContext": "`erdos_1217 : True := trivial` — a placeholder with `True` as the statement. This is the standard Lean stub for a theorem whose statement is not yet formalized: `True` is trivially provable, making the file compile, while flagging that the mathematical content is missing. The actual theorem would be non-trivially proved via a greedy construction (primitive case: keep $a \\in A$ not divisible by any already-kept element; density argument shows the kept subset satisfies $\\sum_{b \\leq x} 1/b \\geq c \\cdot \\sum_{a \\leq x} 1/a$ for some fixed $c > 0$)."
+      "id": "main-theorem",
+      "title": "Main Theorem: Erdős #1217",
+      "startLine": 50,
+      "endLine": 59,
+      "significance": "key",
+      "summary": "theorem erdos_1217 restates the affirmative answer, extracting the positive-density subsequence from the axiom (dropping the ratio-convergence refinement)."
     }
   ],
   "conclusion": {
-    "summary": "Erdős Problem #1217 (solved via [ESS66]) concerns sequences A with positive upper log-log density—the limsup of (1/log log x) * ∑_{aₙ ≤ x} 1/aₙ being positive—and the existence of structurally constrained subsequences (primitive, sum-free, or Sidon) with the same density property. The problem statement is corrupted in the current source, preventing an exact reconstruction. The Lean formalization is a placeholder stub requiring analytic number theory infrastructure.",
+    "summary": "Erdős Problem #1217 (solved via [ESS66]) concerns sequences A with positive upper log-log density—the limsup of (1/log log x) * ∑_{aₙ ≤ x} 1/aₙ being positive—and the existence of structurally constrained subsequences (primitive, sum-free, or Sidon) with the same density property. The problem statement is corrupted in the current source, preventing an exact reconstruction. The Lean formalization defines the iterated-log density and the positive-density predicate, and encodes the Erdős–Sárközy–Sós resolution as a single axiom (erdos_sarkozy_sos_1966), from which the main theorem erdos_1217 is derived.",
     "implications": "Log-log density is the 'canonical' density scale for sets like the primes, semiprimes, and related multiplicatively structured sets. Results about density-preserving subsequence extraction are fundamental in additive combinatorics and connect to the Erdős-Turán conjecture on arithmetic progressions, the Sidon problem, and sieve theory. A Lean formalization of even the density definition (Filter.limsup of a Finset.sum over ℕ) would be a useful addition to Mathlib.",
     "openQuestions": [
       "What is the exact statement of Problem #1217? The source is corrupted; consulting erdosproblems.com directly or the original [ESS66] paper would clarify whether the problem is about primitive sets, Sidon sets, or another structural property.",

--- a/src/data/proofs/erdos-690/meta.json
+++ b/src/data/proofs/erdos-690/meta.json
@@ -92,6 +92,15 @@
       "endLine": 134,
       "summary": "Combines all results: $d_k$ unimodal for $k = 1, 2, 3$ and not unimodal for $k = 4$. The threshold is exactly $k = 3/4$: the transition from regular to irregular shape of prime factor densities.",
       "mathContext": "Mathematical content: Combines all results: $d_k$ unimodal for $k = 1, 2, 3$ and not unimodal for $k = 4$. The threshold is exactly $k = 3/4$: the transition from regular to irregular shape of prime factor densities."
+    },
+    {
+      "id": "non-unimodal-witnesses",
+      "title": "Non-Unimodality Witnesses and Final Summary",
+      "startLine": 135,
+      "endLine": 173,
+      "significance": "key",
+      "summary": "Covers the concrete non-unimodality witnesses not_unimodal_k4, not_unimodal_k10, not_unimodal_k20 (each exhibiting a k for which d_k fails unimodality via Cambie's data), the partial sum d1_sum_2_3_5, and erdos_690_summary — the capstone theorem assembling unimodal (k=1,2,3) vs non-unimodal (k≥4) into the answer to the problem.",
+      "mathContext": "The witnesses instantiate cambie_not_unimodal at $k=4,10,20$, and erdos_690_summary packages the full dichotomy: $d_k$ is unimodal for $k\\le 3$ and non-unimodal for $k\\ge4$."
     }
   ],
   "overview": {

--- a/src/data/proofs/euler-identity-oq-01/meta.json
+++ b/src/data/proofs/euler-identity-oq-01/meta.json
@@ -54,15 +54,15 @@
     "definitionCount": 3
   },
   "overview": {
-    "historicalContext": "Euler published $e^{ix} = \\cos(x) + i\\sin(x)$ in 1748 in *Introductio in analysin infinitorum* (Chapter 8), using precisely this Taylor series splitting argument: he expanded $e^{ix}$ as a power series, separated even and odd terms, and identified them as the cosine and sine series. Euler was working in an era before rigorous convergence theory (Cauchy's work came ~80 years later), treating the manipulation of infinite series as formal algebra. The result was so striking that it connected the five most important constants in mathematics \u2014 $e$, $i$, $\\pi$, $1$, and $0$ \u2014 in a single equation $e^{i\\pi} + 1 = 0$, which physicist Richard Feynman called 'the most remarkable formula in mathematics.' The formula is foundational to complex analysis, appearing in Fourier analysis, quantum mechanics (where wave functions $e^{ikx}$ encode momentum states), signal processing, and the theory of Lie groups. The modern Lean formalization faces an extra challenge: Mathlib defines $\\cos$ and $\\sin$ via the complex exponential (not via Taylor series), creating a circularity that requires careful handling.",
+    "historicalContext": "Euler published $e^{ix} = \\cos(x) + i\\sin(x)$ in 1748 in *Introductio in analysin infinitorum* (Chapter 8), using precisely this Taylor series splitting argument: he expanded $e^{ix}$ as a power series, separated even and odd terms, and identified them as the cosine and sine series. Euler was working in an era before rigorous convergence theory (Cauchy's work came ~80 years later), treating the manipulation of infinite series as formal algebra. The result was so striking that it connected the five most important constants in mathematics — $e$, $i$, $\\pi$, $1$, and $0$ — in a single equation $e^{i\\pi} + 1 = 0$, which physicist Richard Feynman called 'the most remarkable formula in mathematics.' The formula is foundational to complex analysis, appearing in Fourier analysis, quantum mechanics (where wave functions $e^{ikx}$ encode momentum states), signal processing, and the theory of Lie groups. The modern Lean formalization faces an extra challenge: Mathlib defines $\\cos$ and $\\sin$ via the complex exponential (not via Taylor series), creating a circularity that requires careful handling.",
     "problemStatement": "**Question**: Can the full Taylor series proof of Euler's formula be formalized independently of Complex.exp_mul_I?\n\n**Answer**: Yes, with 0 axioms. The even/odd `tsum` splitting and the cos/sin Taylor series identifications are all proved from Mathlib (`tsum_even_add_odd`, `Complex.cos_eq_tsum`, `Complex.sin_eq_tsum`). The algebraic core (powers of i) is also fully proved.",
     "text": "Derives e^{ix} = cos(x) + i*sin(x) by: (1) expanding exp(ix) as sum of (ix)^n/n!, (2) splitting into even/odd indices using tsum_even_add_odd, (3) simplifying (ix)^{2k} = (-1)^k x^{2k} and (ix)^{2k+1} = i*(-1)^k x^{2k+1} using the proved identities I^{2k} = (-1)^k, (4) identifying the even subseries as cos and odd as i*sin.",
-    "proofStrategy": "Split the exponential Taylor series \u2211 (ix)^n/n! into even-indexed terms (giving the cosine series) and odd-indexed terms (giving i times the sine series). The key algebraic identities i^{2k} = (-1)^k and i^{2k+1} = i*(-1)^k are proved by induction from i^2 = -1.",
+    "proofStrategy": "Split the exponential Taylor series ∑ (ix)^n/n! into even-indexed terms (giving the cosine series) and odd-indexed terms (giving i times the sine series). The key algebraic identities i^{2k} = (-1)^k and i^{2k+1} = i*(-1)^k are proved by induction from i^2 = -1.",
     "keyInsights": [
       "The powers-of-i identities $i^{2k} = (-1)^k$ and $i^{2k+1} = i \\cdot (-1)^k$ are the algebraic heart of the proof, proved by induction from $i^2 = -1$ using just `pow_succ` and `I_sq`",
-      "The `tsum` even/odd splitting is the analytic bottleneck: while mathematically obvious, formalizing `\u2211_n a_n = \u2211_k a_{2k} + \u2211_k a_{2k+1}` requires the bijection `\u2115 \u2243 \u2115 \u2295 \u2115` and careful use of Mathlib's `HasSum` API",
+      "The `tsum` even/odd splitting is the analytic bottleneck: while mathematically obvious, formalizing `∑_n a_n = ∑_k a_{2k} + ∑_k a_{2k+1}` requires the bijection `ℕ ≃ ℕ ⊕ ℕ` and careful use of Mathlib's `HasSum` API",
       "The three definitions `expTerm`, `evenTerm`, `oddTerm` are designed so that `expTerm_even` and `expTerm_odd` hold definitionally after `rw [I_pow_even/odd]`, making the main proof a clean sequence of rewrites",
-      "Mathlib's circular definition \u2014 cos and sin are defined via exp, not via Taylor series \u2014 once made the Taylor series identification feel axiomatic, but Mathlib's `Complex.cos_eq_tsum` and `Complex.sin_eq_tsum` close the gap, so the proof now stands at 0 axioms",
+      "Mathlib's circular definition — cos and sin are defined via exp, not via Taylor series — once made the Taylor series identification feel axiomatic, but Mathlib's `Complex.cos_eq_tsum` and `Complex.sin_eq_tsum` close the gap, so the proof now stands at 0 axioms",
       "This proof follows Euler's original 1748 argument step-by-step, while Mathlib's `Complex.exp_mul_I` uses a different (more modern) approach; having both gives a cross-check of the formula's derivation"
     ]
   },
@@ -102,9 +102,18 @@
       "id": "main-theorem",
       "title": "Euler's Formula and Euler's Identity",
       "startLine": 137,
-      "endLine": 174,
+      "endLine": 191,
       "summary": "Main theorem euler_formula_taylor: exp(ix) = cos(x) + i*sin(x) via four-step Taylor series proof. Then euler_identity_taylor: exp(i*pi) + 1 = 0 by substituting x=pi and using cos(pi)=-1, sin(pi)=0.",
       "mathContext": "$e^{ix} = \\cos x + i\\sin x$ (Euler's formula, 1748). Proof: expand exp as power series, split by even/odd index, match to cos/sin series. Special case $x = \\pi$: $e^{i\\pi} = -1 + 0 = -1$, so $e^{i\\pi} + 1 = 0$ (Euler's identity). These are the most celebrated equations in mathematics."
+    },
+    {
+      "id": "axiom-status",
+      "title": "Axiom Status and Independence Notes",
+      "startLine": 192,
+      "endLine": 212,
+      "significance": "context",
+      "summary": "Closing documentation: confirms the Taylor-series route to Euler's formula and identity uses zero axioms beyond Mathlib, and notes the logical independence of this power-series derivation from Mathlib's own Complex.exp definition.",
+      "mathContext": "The entry derives $e^{ix}=\\cos x+i\\sin x$ from the exp power series rather than importing it, so the identity $e^{i\\pi}+1=0$ is obtained with an axiom budget of $0$."
     }
   ],
   "conclusion": {
@@ -128,7 +137,7 @@
     {
       "targetId": "euler-identity",
       "relationship": "alternative-proof",
-      "description": "Alternative derivation using Taylor series splitting vs Mathlib's Complex.exp_mul_I \u2014 the parent entry uses the Mathlib definition while this entry follows Euler's original 1748 argument"
+      "description": "Alternative derivation using Taylor series splitting vs Mathlib's Complex.exp_mul_I — the parent entry uses the Mathlib definition while this entry follows Euler's original 1748 argument"
     },
     {
       "targetId": "fourier-series",
@@ -138,7 +147,7 @@
     {
       "targetId": "ptolemys-complex-proof",
       "relationship": "related",
-      "description": "Ptolemy's theorem has an elegant proof via complex exponentials that uses Euler's formula \u2014 the product formula for e^{ix} gives the distance product identity"
+      "description": "Ptolemy's theorem has an elegant proof via complex exponentials that uses Euler's formula — the product formula for e^{ix} gives the distance product identity"
     }
   ],
   "leanFile": {


### PR DESCRIPTION
Five single-file `meta.json` enrichments; existing summaries/`mathContext` preserved where extended. No `status`/`badge`/`axiomCount` changes.

**Stale-placeholder re-sections** (files evolved past their meta):
- **erdos-1212** & **erdos-1217**: the `sections` were leftover scaffolding ("Placeholder Theorem: True with Sorry", "Sorry Check for Aristotle Tracking") from when each file was a `True`-stub. Both files now contain full definitions, a single axiom encoding the solved result, and the derived main theorem — no `sorry`. Re-anchored each to its real structure (Problem Statement → Imports → Definitions → Axiomatized Result → Main Theorem, 5 sections, 1..EOF) and fixed the "The Lean formalization is a placeholder stub" sentence in `historicalContext`/`conclusion.summary` to describe the actual axiomatized formalization.

**Uncovered-tail coverage:**
- **euler-identity-oq-01** (5→6): the "Euler's Formula and Euler's Identity" section ended at line 174, but the headline `euler_identity_taylor` ($e^{i\pi}+1=0$) is @186. Extended to 191 and added an "Axiom Status and Independence Notes" section (192–212).
- **erdos-690** (8→9): the non-unimodality witnesses `not_unimodal_k4/k10/k20` and the capstone `erdos_690_summary` (135–173) were uncovered; added a tail section.
- **de-moivre-oq-06** (4→5): Part V's Dirichlet-kernel bounds `dirichlet_kernel_bound` / `dirichlet_conjugate_bound` (143–180) were uncovered; added a tail section.

`maxEnd === wc` asserted for all five; no section overlaps.
