### PR TITLE
Enrich 8 entries: re-anchor drifted/undercovered sections (1..EOF)

### DIFF
--- a/src/data/proofs/erdos-1182/meta.json
+++ b/src/data/proofs/erdos-1182/meta.json
@@ -71,11 +71,19 @@
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Problem Statement and Background",
+      "startLine": 1,
+      "endLine": 39,
+      "summary": "Module docstring for Erd\u0151s #1182 (Burr\u2013Erd\u0151s\u2013Faudree\u2013Rousseau\u2013Schelp): the edge thresholds f(n) and F(n) for connected n-vertex graphs G with R(K\u2083,G)=2n\u22121, the known bounds, and computed small values; followed by imports and the namespace.",
+      "mathContext": "$F(n)\\ge(17n+1)/15$; does $F(n)/n\\to\\infty$?"
+    },
+    {
       "id": "ramsey-numbers",
       "title": "Ramsey Number Definition",
       "summary": "ramseyNumber(s, t) via sInf over 2-colorings of complete graphs",
       "startLine": 40,
-      "endLine": 46,
+      "endLine": 47,
       "mathContext": "R(s,t) = min r such that any 2-coloring of K_r has a red K_s or blue K_t"
     },
     {
@@ -83,7 +91,7 @@
       "title": "Graph Infrastructure",
       "summary": "Graph structure, edgeCount, connectivity, and graphRamseyK3 definitions",
       "startLine": 48,
-      "endLine": 75,
+      "endLine": 76,
       "mathContext": "Custom Graph type on Fin n with adj/symm/irrefl, edge counting via filtered Finset, connectivity via ReflTransGen"
     },
     {
@@ -91,7 +99,7 @@
       "title": "Threshold Functions f(n) and F(n)",
       "summary": "f_threshold and bigF_threshold definitions via sSup",
       "startLine": 77,
-      "endLine": 97,
+      "endLine": 98,
       "mathContext": "f(n) = sSup{edges | exists G with edgeCount = e and R(K_3,G) = 2n-1}; F(n) = sSup{e | all connected G with <= e edges satisfy R(K_3,G) = 2n-1}"
     },
     {
@@ -99,7 +107,7 @@
       "title": "Axiomatized Known Results",
       "summary": "Chvatal's tree theorem, connected_min_edges, and BEFRS lower bound",
       "startLine": 99,
-      "endLine": 111,
+      "endLine": 112,
       "mathContext": "Chvatal (1977), connected graph minimum edges, and BEFRS (1980) linear lower bound"
     },
     {
@@ -107,7 +115,7 @@
       "title": "Small Case Infrastructure (K_2)",
       "summary": "completeGraph2 construction with edge count and connectivity proofs",
       "startLine": 113,
-      "endLine": 155,
+      "endLine": 156,
       "mathContext": "K_2 has exactly 1 edge, is connected, and serves as the base case for f(2) and F(2)"
     },
     {
@@ -115,7 +123,7 @@
       "title": "Proved Bounds",
       "summary": "F(n) >= n-1, f(2) = 1, F(2) = 1 -- all proved from axioms",
       "startLine": 157,
-      "endLine": 230,
+      "endLine": 231,
       "mathContext": "bigF_lower_bound_tree from Chvatal + connectivity; f_val_2 and bigF_val_2 via K_2 construction"
     },
     {
@@ -123,8 +131,16 @@
       "title": "The Main Open Question",
       "summary": "erdos_1182_conjecture: does F(n)/n -> infinity?",
       "startLine": 232,
-      "endLine": 242,
+      "endLine": 246,
       "mathContext": "For all C, exists N_0 such that F(n) >= C*n for n >= N_0"
+    },
+    {
+      "id": "summary",
+      "title": "Summary",
+      "startLine": 247,
+      "endLine": 280,
+      "summary": "Closing summary: problem status (OPEN), the 3 axioms (`chvatal_tree_ramsey`, `bigF_lower_linear`, `connected_min_edges`), the 3 proved bounds (`bigF_lower_bound_tree` F(n)\u2265n\u22121, `f_val_2`, `bigF_val_2`), the 6 definitions, and the note that `bigF_threshold` restricts to connected graphs per the original BEFRS (1980) definition.",
+      "mathContext": "3 axioms; $F(n)\\ge n-1$ and $f(2)=F(2)=1$ proved."
     }
   ],
   "conclusion": {

--- a/src/data/proofs/erdos-565/meta.json
+++ b/src/data/proofs/erdos-565/meta.json
@@ -78,83 +78,91 @@
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Problem Statement and Setup",
+      "startLine": 1,
+      "endLine": 61,
+      "summary": "Module docstring for Erdős #565 on induced Ramsey numbers R*(G) and their resolution by Aragão, Chang, Ferber, Krueger, Kwan, Sah, Sawhney et al. (2025), followed by imports and the namespace/basic setup.",
+      "mathContext": "Induced Ramsey number $R^*(G)$."
+    },
+    {
       "id": "graph-basics",
       "title": "Part I: Graph Basics",
       "summary": "Abbreviates `Graph V` for `SimpleGraph V` and defines `numVertices` via `Fintype.card V`. Establishes the finitary setting with `Fintype` and `DecidableEq` constraints needed for computable cardinality and decidable adjacency.",
-      "startLine": 51,
-      "endLine": 66,
+      "startLine": 62,
+      "endLine": 76,
       "mathContext": "Abbreviates `Graph V` for `SimpleGraph V` and defines `numVertices` via `Fintype.card V`. Establishes the finitary setting with `Fintype` and `DecidableEq` constraints needed for computable cardinality and decidable adjacency."
     },
     {
       "id": "induced-subgraphs",
       "title": "Part II: Induced Subgraphs",
       "summary": "Defines `IsInducedSubgraph G S G'` via the biconditional $G'.\\text{Adj}(u,v) \\iff G.\\text{Adj}(u,v)$ for $u, v \\in S$, and `ContainsInducedCopy H G` via a `Function.Embedding` preserving AND reflecting adjacency. The biconditional is the key distinction from ordinary subgraph containment.",
-      "startLine": 67,
-      "endLine": 90,
+      "startLine": 77,
+      "endLine": 99,
       "mathContext": "Defines `IsInducedSubgraph G S G'` via the biconditional $G'.\\text{Adj}(u,v) \\iff G.\\text{Adj}(u,v)$ for $u, v \\in S$, and `ContainsInducedCopy H G` via a `Function.Embedding` preserving AND reflecting adjacency."
     },
     {
       "id": "edge-colorings",
       "title": "Part III: Edge Colorings",
       "summary": "Defines the `EdgeColor` inductive type (`Red | Blue`), `EdgeColoring G` as a function from `Sym2`-based edge witnesses to colors, and `HasMonochromaticInducedCopy` requiring an embedding with both the induced property and uniform coloring across all embedded edges.",
-      "startLine": 91,
-      "endLine": 122,
+      "startLine": 100,
+      "endLine": 130,
       "mathContext": "Defines the `EdgeColor` inductive type (`Red | Blue`), `EdgeColoring G` as a function from `Sym2`-based edge witnesses to colors, and `HasMonochromaticInducedCopy` requiring an embedding with both the induced property and uniform coloring across all embedded edges."
     },
     {
       "id": "induced-ramsey",
       "title": "Part IV: Induced Ramsey Numbers",
       "summary": "Defines `HasInducedRamseyProperty H G` as a universal statement over all 2-colorings, and `inducedRamseyNumber n G` as `sInf` over valid host sizes. The infimum optimizes over both the number of vertices $m$ and the choice of host graph $H$.",
-      "startLine": 123,
-      "endLine": 144,
+      "startLine": 131,
+      "endLine": 151,
       "mathContext": "Defines `HasInducedRamseyProperty H G` as a universal statement over all 2-colorings, and `inducedRamseyNumber n G` as `sInf` over valid host sizes. The infimum optimizes over both the number of vertices $m$ and the choice of host graph $H$."
     },
     {
       "id": "existence",
       "title": "Part V: Existence of R*(G)",
       "summary": "Axiomatizes `induced_ramsey_exists` (finiteness for all graphs, due to Deuber, EHP, and Rödl) and derives `induced_ramsey_number_finite` showing the defining set is nonempty by destructuring the existence axiom.",
-      "startLine": 145,
-      "endLine": 165,
+      "startLine": 152,
+      "endLine": 171,
       "mathContext": "Axiomatizes `induced_ramsey_exists` (finiteness for all graphs, due to Deuber, EHP, and Rödl) and derives `induced_ramsey_number_finite` showing the defining set is nonempty by destructuring the existence axiom."
     },
     {
       "id": "historical-bounds",
       "title": "Part VI: Historical Bounds",
       "summary": "Docstrings only (informational, not formalized) recording progressive improvements: Rödl's bipartite $2^{O(n)}$ (1973), KPR's $2^{O(n(\\log n)^2)}$ (1998, sparse regularity), and CFS's $2^{O(n \\log n)}$ (2012, dependent random choice + Lovász Local Lemma). No axioms or theorems are declared for these bounds.",
-      "startLine": 166,
-      "endLine": 198,
+      "startLine": 172,
+      "endLine": 186,
       "mathContext": "Docstrings only (informational, not formalized) recording progressive improvements: Rödl's bipartite $2^{O(n)}$ (1973), KPR's $2^{O(n(\\log n)^2)}$ (1998, sparse regularity), and CFS's $2^{O(n \\log n)}$ (2012, dependent random choice + Lovász Local Lemma). No axioms or theorems are declared for these bounds."
     },
     {
       "id": "solution",
       "title": "Part VII: The Solution - Aragão et al. (2025)",
       "summary": "Axiomatizes `aragao_et_al_theorem`: $\\exists C > 0$ with $R^*(G) \\le 2^{Cn}$ for all $n$-vertex $G$. The theorem `erdos_565_solution` follows by `exact aragao_et_al_theorem`, resolving the 50-year problem.",
-      "startLine": 199,
-      "endLine": 225,
+      "startLine": 187,
+      "endLine": 212,
       "mathContext": "Axiomatizes `aragao_et_al_theorem`: $\\exists C > 0$ with $R^*(G) \\le 2^{Cn}$ for all $n$-vertex $G$. The theorem `erdos_565_solution` follows by `exact aragao_et_al_theorem`, resolving the 50-year problem."
     },
     {
       "id": "comparison",
       "title": "Part VIII: Comparison with Ordinary Ramsey",
       "summary": "Defines `ordinaryRamseyNumber` using `completeGraph (Fin m)` as host (unlike induced Ramsey, which optimizes over all hosts). States `induced_ramsey_ge_ordinary` ($R^* \\ge R$, with sorry). A \"Gap can be large\" docstring records informally that some graphs exhibit large multiplicative gaps — no axiom is declared for it.",
-      "startLine": 226,
-      "endLine": 256,
+      "startLine": 213,
+      "endLine": 268,
       "mathContext": "Defines `ordinaryRamseyNumber` using `completeGraph (Fin m)` as host (unlike induced Ramsey, which optimizes over all hosts). States `induced_ramsey_ge_ordinary` ($R^* \\ge R$, with sorry). A \"Gap can be large\" docstring records informally that some graphs exhibit large multiplicative gaps — no axiom is declared for it."
     },
     {
       "id": "lower-bounds",
       "title": "Part IX: Lower Bounds",
       "summary": "Axiomatizes `exponential_lower_bound`: $\\exists c > 0$ with $\\exists G_n$ on $n$ vertices satisfying $R^*(G_n) \\ge 2^{cn}$. Proves `bound_essentially_tight` combining this with `aragao_et_al_theorem` via pair construction, establishing $R^* = 2^{\\Theta(n)}$ in worst case.",
-      "startLine": 257,
-      "endLine": 280,
+      "startLine": 269,
+      "endLine": 291,
       "mathContext": "Axiomatizes `exponential_lower_bound`: $\\exists c > 0$ with $\\exists G_n$ on $n$ vertices satisfying $R^*(G_n) \\ge 2^{cn}$. Proves `bound_essentially_tight` combining this with `aragao_et_al_theorem` via pair construction, establishing $R^* = 2^{\\Theta(n)}$ in worst case."
     },
     {
       "id": "summary",
       "title": "Part X: Summary",
       "summary": "Proves `erdos_565_summary` bundling the upper bound ($2^{O(n)}$, Aragão et al.) and lower bound ($2^{\\Omega(n)}$, random graphs) into a single conjunction via `⟨aragao_et_al_theorem, exponential_lower_bound⟩`, completely resolving Erdős Problem #565.",
-      "startLine": 281,
-      "endLine": 286,
+      "startLine": 292,
+      "endLine": 325,
       "mathContext": "Proves `erdos_565_summary` bundling the upper bound ($2^{O(n)}$, Aragão et al.) and lower bound ($2^{\\Omega(n)}$, random graphs) into a single conjunction via `⟨aragao_et_al_theorem, exponential_lower_bound⟩`, completely resolving Erdős Problem #565."
     }
   ],

--- a/src/data/proofs/erdos-690/meta.json
+++ b/src/data/proofs/erdos-690/meta.json
@@ -41,55 +41,47 @@
       "id": "imports",
       "title": "Library Imports",
       "startLine": 21,
-      "endLine": 22,
+      "endLine": 24,
       "summary": "Imports Mathlib's prime number API ($\\text{Nat.Prime}$, $\\text{Nat.factors}$) and tactics for defining the $k$-th smallest prime factor via sorted factor lists.",
       "mathContext": "Mathematical content: Imports Mathlib's prime number API ($\\text{Nat.Prime}$, $\\text{Nat.factors}$) and tactics for defining the $k$-th smallest prime factor via sorted factor lists."
     },
     {
       "id": "core-definitions",
       "title": "Core Definitions",
-      "startLine": 28,
-      "endLine": 47,
+      "startLine": 25,
+      "endLine": 49,
       "summary": "Defines the $k$-th smallest prime factor via sorted factorization, the level set $A_k(p) = \\{n : p_k(n) = p\\}$, the axiomatized density $d_k(p)$, and unimodality on primes (existence of a peak prime $p^*$).",
       "mathContext": "Defines the $k$-th smallest prime factor via sorted factorization, the level set $A_k(p) = \\{n : p_k(n) = p\\}$, the axiomatized density $d_k(p)$, and unimodality on primes (existence of a peak prime $p^*$)."
     },
     {
-      "id": "cambie-unimodal",
-      "title": "Cambie's Unimodality Results (k ≤ 3)",
-      "startLine": 53,
-      "endLine": 64,
-      "summary": "Cambie (2025) proved $d_k(p)$ is unimodal for $k = 1, 2, 3$. The $k = 1$ case is classical ($d_1$ is strictly decreasing); $k = 2, 3$ require delicate inclusion-exclusion analysis.",
-      "mathContext": "Mathematical content: Cambie (2025) proved $d_k(p)$ is unimodal for $k = 1, 2, 3$. The $k = 1$ case is classical ($d_1$ is strictly decreasing); $k = 2, 3$ require delicate inclusion-exclusion analysis."
+      "id": "axiomatized-results",
+      "title": "Axiomatized Results: Densities and Cambie (2025)",
+      "startLine": 50,
+      "endLine": 82,
+      "summary": "The classical density values d₁(2)=1/2, d₁(3)=1/6, d₁(5)=1/15 and the strict-decrease law for d₁, together with Cambie (2025): d_k is unimodal for k=2,3 and NOT unimodal for 4≤k≤20. Stated as axioms (`d1_at_2/3/5`, `d1_strictly_decreasing`, `cambie_unimodal_k2/k3`, `cambie_not_unimodal`).",
+      "mathContext": "$d_1(p)=\\tfrac1p\\prod_{q<p}(1-\\tfrac1q)$; Cambie: $d_k$ unimodal $\\iff k\\le 3$."
     },
     {
-      "id": "cambie-non-unimodal",
-      "title": "Cambie's Non-Unimodality (k ≥ 4) and Answer",
-      "startLine": 65,
-      "endLine": 75,
-      "summary": "Cambie proved $d_k(p)$ is NOT unimodal for $4 \\le k \\le 20$, confirming Erdős's expectation. The answer to Problem #690 is **NO**: unimodality fails for $k = 4$, giving a concrete counterexample.",
-      "mathContext": "Mathematical content: Cambie proved $d_k(p)$ is NOT unimodal for $4 \\le k \\le 20$, confirming Erdős's expectation. The answer to Problem #690 is **NO**: unimodality fails for $k = 4$, giving a concrete counterexample."
+      "id": "proved-k1-answer",
+      "title": "Proved Theorems: k = 1 Unimodality and the Answer",
+      "startLine": 83,
+      "endLine": 116,
+      "summary": "`d1_unimodal` proves d₁ is unimodal with peak at p=2, derived from strict decrease so no separate k=1 axiom is needed; `erdos_690_answer_no` resolves Erdős’s question in the negative (unimodality fails for k≥4, via Cambie k=4); `d1_2_gt_d1_3` compares the first two density values.",
+      "mathContext": "$d_1$ peaks at $p=2$; unimodality fails for $k\\ge4$."
     },
     {
-      "id": "erdos-observations",
-      "title": "Erdős's Observations",
-      "startLine": 81,
-      "endLine": 99,
-      "summary": "The typical $k$-th prime factor is $\\sim e^{e^k}$ (doubly exponential) while the mode of $d_k$ is $\\sim e^{(1+o(1))k}$ (singly exponential). The divisor analogue (non-unimodal) provided heuristic evidence.",
-      "mathContext": "The typical $k$-th prime factor is $\\sim e^{e^k}$ (doubly exponential) while the mode of $d_k$ is $\\sim e^{(1+o(1))k}$ (singly exponential)."
-    },
-    {
-      "id": "special-k1",
-      "title": "Special Case: k = 1",
-      "startLine": 105,
-      "endLine": 120,
-      "summary": "Explicit formula $d_1(p) = (1/p)\\prod_{q < p}(1 - 1/q)$: $d_1(2) = 1/2$, $d_1(3) = 1/6$. The function $d_1$ is strictly decreasing in $p$, hence trivially unimodal with peak at $p = 2$.",
-      "mathContext": "Mathematical content: Explicit formula $d_1(p) = (1/p)\\prod_{q < p}(1 - 1/q)$: $d_1(2) = 1/2$, $d_1(3) = 1/6$. The function $d_1$ is strictly decreasing in $p$, hence trivially unimodal with peak at $p = 2$."
+      "id": "density-values-nonunimodal",
+      "title": "Density Values and Non-Unimodality Witnesses",
+      "startLine": 117,
+      "endLine": 162,
+      "summary": "Exact density sums d₁(2)+d₁(3)=2/3 and d₁(2)+d₁(3)+d₁(5)=11/15, the peak-at-2 theorem `d1_peak_at_2`, and the explicit non-unimodality witnesses `not_unimodal_k4/k10/k20` obtained from `cambie_not_unimodal`.",
+      "mathContext": "$d_1(2)+d_1(3)=\\tfrac23$, $+\\,d_1(5)=\\tfrac{11}{15}$."
     },
     {
       "id": "summary-theorem",
       "title": "Complete Summary",
-      "startLine": 121,
-      "endLine": 134,
+      "startLine": 163,
+      "endLine": 173,
       "summary": "Combines all results: $d_k$ unimodal for $k = 1, 2, 3$ and not unimodal for $k = 4$. The threshold is exactly $k = 3/4$: the transition from regular to irregular shape of prime factor densities.",
       "mathContext": "Mathematical content: Combines all results: $d_k$ unimodal for $k = 1, 2, 3$ and not unimodal for $k = 4$. The threshold is exactly $k = 3/4$: the transition from regular to irregular shape of prime factor densities."
     },

--- a/src/data/proofs/erdos-877/meta.json
+++ b/src/data/proofs/erdos-877/meta.json
@@ -96,50 +96,50 @@
   ],
   "sections": [
     {
-      "id": "imports",
-      "title": "Imports and Setup",
-      "startLine": 26,
-      "endLine": 29,
-      "summary": "Imports all of `Mathlib` and opens `Nat`, `Finset`, and `scoped Classical` (the powerset filters defining f and f_m need classical decidability). Asymptotic bounds are stated over the reals via `rpow`.",
-      "mathContext": "Imports all of `Mathlib` and opens `Nat`, `Finset`, and `scoped Classical` (the powerset filters defining f and f_m need classical decidability). Asymptotic bounds are stated over the reals via `rpow`."
+      "id": "header",
+      "title": "Problem Statement and Imports",
+      "startLine": 1,
+      "endLine": 33,
+      "summary": "Module docstring for Erdős #877 on sum-free subsets of {1,…,n} and the count of maximal sum-free sets, tracing the resolution history — Cameron–Erdős lower bound, Łuczak–Schoen (2001) upper bound, and Balogh–Liu–Sharifzadeh–Treglown sharp asymptotics (2015/2018) — followed by imports and setup.",
+      "mathContext": "Number of (maximal) sum-free subsets of $\\{1,\\dots,n\\}$."
     },
     {
       "id": "sum-free-sets",
       "title": "Sum-Free Sets",
-      "startLine": 42,
-      "endLine": 76,
+      "startLine": 34,
+      "endLine": 77,
       "summary": "Defines `isSumFree` ($\\forall a,b,c \\in A,\\ a \\neq b+c$), `sumset` ($A+A$), and `isSumFree'` ($A \\cap (A+A) = \\emptyset$). Proves odd numbers and upper half are sum-free.",
       "mathContext": "Formal definition: Defines `isSumFree` ($\\forall a,b,c \\in A,\\ a \\neq b+c$), `sumset` ($A+A$), and `isSumFree'` ($A \\cap (A+A) = \\emptyset$). Proves odd numbers and upper half are sum-free."
     },
     {
       "id": "maximal-sum-free",
       "title": "Maximal Sum-Free Sets",
-      "startLine": 86,
-      "endLine": 147,
+      "startLine": 78,
+      "endLine": 148,
       "summary": "Defines `isMaximalSumFree` (sum-free and no proper extension) and PROVES the maximality criterion: every excluded positive $x$ satisfies $x = a+b$, $a = x+b$, or $2x \\in A$ (the hypothesis $x>0$ is necessary — the criterion fails at $x=0$ via the trivial sum $0=0+0$).",
       "mathContext": "Defines `isMaximalSumFree` (sum-free and no proper extension) and PROVES the maximality criterion: every excluded positive $x$ satisfies $x = a+b$, $a = x+b$, or $2x \\in A$ (the hypothesis $x>0$ is necessary — the criterion fails at $x=0$ via the trivial sum $0=0+0$)."
     },
     {
       "id": "counting-functions",
       "title": "Counting Functions f(n) and f_m(n)",
-      "startLine": 156,
-      "endLine": 176,
+      "startLine": 149,
+      "endLine": 177,
       "summary": "Defines $f(n)$ (all sum-free subsets) and $f_m(n)$ (maximal sum-free subsets) via `Finset.powerset.filter`. Proves $f_m(n) \\leq f(n)$.",
       "mathContext": "Formal definition: Defines $f(n)$ (all sum-free subsets) and $f_m(n)$ (maximal sum-free subsets) via `Finset.powerset.filter`. Proves $f_m(n) \\leq f(n)$."
     },
     {
       "id": "cameron-erdos-bound",
       "title": "Cameron-Erdős Lower Bound",
-      "startLine": 186,
-      "endLine": 212,
+      "startLine": 178,
+      "endLine": 213,
       "summary": "$f_m(n) > 2^{n/4}$ for $n \\geq 4$ (axiomatized Cameron-Erdős bound). `odds_construction` is PROVED: the upper half $\\{n/2+1,\\dots,n\\}$ is a sum-free set of cardinality $\\geq n/2$.",
       "mathContext": "$f_m(n) > 2^{n/4}$ for $n \\geq 4$ (axiomatized Cameron-Erdős bound). `odds_construction` is PROVED: the upper half $\\{n/2+1,\\dots,n\\}$ is a sum-free set of cardinality $\\geq n/2$."
     },
     {
       "id": "luczak-schoen",
       "title": "Łuczak-Schoen (2001): Main Question Resolved",
-      "startLine": 222,
-      "endLine": 239,
+      "startLine": 214,
+      "endLine": 240,
       "summary": "$\\exists c < 1/2,\\ f_m(n) < 2^{cn}$ (over $\\mathbb{R}$, via `rpow`). Resolves the main question: $f_m(n) = o(2^{n/2})$ is **YES**.",
       "mathContext": "$\\exists c < 1/2,\\ f_m(n) < 2^{cn}$ (over $\\mathbb{R}$, via `rpow`). Resolves the main question: $f_m(n) = o(2^{n/2})$ is **YES**."
     },
@@ -147,31 +147,31 @@
       "id": "blst-sharp",
       "title": "BLST Sharp Asymptotics (2015, 2018)",
       "startLine": 241,
-      "endLine": 257,
+      "endLine": 278,
       "summary": "BLST 2015: $f_m(n) = 2^{(1/4+o(1))n}$ via the container method. BLST 2018: $f_m(n) = (C_n + o(1)) \\cdot 2^{n/4}$ with $C_n$ depending on $n \\bmod 4$.",
       "mathContext": "BLST 2015: $f_m(n) = $$2^{{(1/4+o(1))n}$}$$ via the container method. BLST 2018: $f_m(n) = (C_n + o(1)) \\cdot $$2^{{n/4}$}$$ with $C_n$ depending on $n \\bmod 4$."
     },
     {
       "id": "structure",
       "title": "Structure and the Container Method",
-      "startLine": 259,
-      "endLine": 283,
+      "startLine": 279,
+      "endLine": 304,
       "summary": "Explains the $1/4$ exponent (only $n/4$ free choices in typical maximal sets) and the hypergraph container method underlying the BLST proof.",
       "mathContext": "Verified: Explains the $1/4$ exponent (only $n/4$ free choices in typical maximal sets) and the hypergraph container method underlying the BLST proof."
     },
     {
       "id": "erdos-748",
       "title": "Comparison with Erdős #748",
-      "startLine": 285,
-      "endLine": 304,
+      "startLine": 305,
+      "endLine": 335,
       "summary": "$f(n) = \\Theta(2^{n/2})$ vs $f_m(n) = \\Theta(2^{n/4})$: maximality reduces the count exponentially. The ratio $f_m(n)/f(n) = \\Theta(2^{-n/4}) \\to 0$.",
       "mathContext": "$f(n) = \\Theta($$2^{{n/2}$}$)$ vs $f_m(n) = \\Theta($$2^{{n/4}$}$)$: maximality reduces the count exponentially. The ratio $f_m(n)/f(n) = \\Theta($$2^{{-n/4}$}$) \\to 0$."
     },
     {
       "id": "summary",
       "title": "Summary and Resolution",
-      "startLine": 306,
-      "endLine": 341,
+      "startLine": 336,
+      "endLine": 380,
       "summary": "Combined `erdos_877_solved`: Łuczak-Schoen resolves the question, Cameron-Erdős gives the tight lower bound. Final `erdos_877` states $f_m(n) = \\Theta(2^{n/4})$.",
       "mathContext": "Combined `erdos_877_solved`: Łuczak-Schoen resolves the question, Cameron-Erdős gives the tight lower bound. Final `erdos_877` states $f_m(n) = \\Theta($$2^{{n/4}$}$)$."
     }

--- a/src/data/proofs/minkowski-fundamental-theorem-oq-01-oq-02/meta.json
+++ b/src/data/proofs/minkowski-fundamental-theorem-oq-01-oq-02/meta.json
@@ -84,6 +84,14 @@
       "endLine": 204,
       "summary": "prod_successiveMinimum_scale (∏ᵢ λᵢ(L, cS) = (∏ᵢ λᵢ(L, S))/cⁿ) and secondTheorem_product_scale_invariant (granting vol(cS)=cⁿ·vol(S), the quantity ∏ᵢ λᵢ·vol is unchanged under rescaling).",
       "mathContext": "The product of n minima scales by c⁻ⁿ; pairing it with the cⁿ scaling of the volume shows the Minkowski second-theorem quantity is a scaling invariant."
+    },
+    {
+      "id": "summary",
+      "title": "Summary: Scaling Homogeneity of the Successive Minima",
+      "startLine": 205,
+      "endLine": 243,
+      "summary": "Closing summary block (0 sorries, 0 axioms): the homogeneity law λᵢ(L,cS)=λᵢ(L,S)/c with its c=2 and c≥1 specialisations, the product law ∏λᵢ(L,cS)=(∏λᵢ)/cⁿ, and the scaling-invariance of the Minkowski second-theorem quantity ∏λᵢ·vol — with an honest note that the second theorem’s product bound itself remains the open analytic core. Ends with `#check` exports of the public API.",
+      "mathContext": "$\\prod_i\\lambda_i(L,cS)=c^{-n}\\prod_i\\lambda_i(L,S)$; $\\prod_i\\lambda_i\\cdot\\mathrm{vol}$ is scale-invariant."
     }
   ],
   "conclusion": {

--- a/src/data/proofs/taylor-sincos-convergence-oq-03/meta.json
+++ b/src/data/proofs/taylor-sincos-convergence-oq-03/meta.json
@@ -99,33 +99,41 @@
       "id": "sec-ase-abstract",
       "title": "Part I: Alternating Series Estimation (Abstract)",
       "startLine": 36,
-      "endLine": 91,
+      "endLine": 129,
       "summary": "Proves pair_nonneg (building block) and alternating_partial_sum_even_bounds by induction on paired terms. Proves alternating_tail_bound connecting partial sums to the infinite tail.",
       "mathContext": "$0 \\leq \\sum_{k=0}^{2m} (-1)^k a_k \\leq a_0$ for antitone $a_k \\geq 0$. Induction: $S_{2(n+1)} = S_{2n} - a_{2n+1} + a_{2n+2}$, with $a_{2n+1} \\geq a_{2n+2}$ maintaining both bounds."
     },
     {
       "id": "sec-term-decreasing",
       "title": "Part II: sin/cos Terms Are Decreasing",
-      "startLine": 93,
-      "endLine": 153,
+      "startLine": 130,
+      "endLine": 187,
       "summary": "Defines sinTermAbs and cosTermAbs. Proves both are antitone for |x| ≤ 1 and tend to 0. Uses pow_le_pow_of_le_one and subsequence convergence from summable_pow_div_factorial.",
       "mathContext": "$a_k = |x|^{2k+1}/(2k+1)!$ is antitone: $a_{k+1}/a_k = |x|^2 / (2k+2)(2k+3) \\leq 1$ for $|x| \\leq 1$. Tends to 0 as a subsequence of $|x|^n/n! \\to 0$."
     },
     {
       "id": "sec-remainders",
       "title": "Part III: sin/cos Alternating Remainder Bounds",
-      "startLine": 155,
-      "endLine": 181,
+      "startLine": 188,
+      "endLine": 215,
       "summary": "States sin_alternating_remainder and cos_alternating_remainder (both sorry) bounding Taylor remainder by sinTermAbs/cosTermAbs via the alternating tail bound.",
       "mathContext": "$|\\sin x - \\sum_{k=0}^{n-1} \\frac{(-1)^k x^{2k+1}}{(2k+1)!}| \\leq \\frac{|x|^{2n+1}}{(2n+1)!}$. Sorry: requires connecting Mathlib's Real.sin to its Taylor series."
     },
     {
       "id": "sec-comparison",
       "title": "Part IV: Comparison with Lagrange Bound",
-      "startLine": 183,
-      "endLine": 224,
+      "startLine": 216,
+      "endLine": 242,
       "summary": "Proves alternating_tighter_than_lagrange_sin (alternating ≤ Lagrange), verifies concrete x=1,n=3 example, and proves sin_lagrange_from_alternating (chain: remainder ≤ alternating ≤ Lagrange).",
       "mathContext": "$\\frac{|x|^{2n+1}}{(2n+1)!} \\leq \\frac{|x|^{2n+1}}{(2n)!}$ since $(2n)! \\leq (2n+1)!$. Ratio $= 1/(2n+1)$."
+    },
+    {
+      "id": "sec-recover-lagrange",
+      "title": "Part V: Recovering the Lagrange Bound",
+      "startLine": 243,
+      "endLine": 262,
+      "summary": "`sin_lagrange_from_alternating` derives the standard Lagrange remainder bound |x|^{2n+1}/(2n)! for sin from the alternating-series structure — recovering a weaker form of the axiom in `TaylorSinCosConvergence.lean` — by chaining `sin_alternating_remainder` with `alternating_tighter_than_lagrange_sin`.",
+      "mathContext": "$\\bigl\\|\\sin x-\\sum_{k<n}\\tfrac{(-1)^k x^{2k+1}}{(2k+1)!}\\bigr\\|\\le \\tfrac{|x|^{2n+1}}{(2n)!}$."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
Re-anchors drifted and tail-undercovered `sections` arrays across 8 gallery entries so the rendered sections cover their Lean files 1..EOF, aligned to the authors' own banners. Pure section metadata (no status/badge/axiomCount/lineCount changes — those were already accurate).

Found via the fresh-`origin/main` undercoverage scan at the gap 25-40 tier (the gap≥40 tier is drained down to giant-hub false positives and a few near-cap monsters).

| entry | sections | fix |
|-------|----------|-----|
| erdos-690 | 8→7 | restructured mis-anchored middle sections to the file's actual `##`-banner structure; covered non-unimodality witnesses + summary tail |
| euler-identity-oq-01 | 5→6 | +§6 Notes tail (192-212) |
| erdos-1182 | 7→9 | +head docstring (1-39) + `## Summary` tail (247-280) |
| taylor-sincos-convergence-oq-03 | 5→6 | +Part V (243-262); Parts I-IV re-anchored to `═══` banners |
| de-moivre-oq-06 | 5→6 | +Part V Dirichlet kernel bounds (143-180) |
| minkowski-fundamental-theorem-oq-01-oq-02 | 5→6 | +Summary block (205-243) |
| erdos-877 | 10→10 | +head (1-33), Parts I-IX re-anchored to `## Part N`, summary tail (336-380) |
| erdos-565 | 10→11 | +head (1-61), Parts I-X re-anchored to `/- ## Part N`, Part X tail (292-325) |

Each file validated: sections contiguous (no overlap), `max(endLine) === wc`, JSON parses, and diffs confined to the `sections` array (encoding preserved per-file — ASCII-escaped for euler/erdos-1182, literal for the rest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
